### PR TITLE
Remove explicit support for TS versions < 3.0

### DIFF
--- a/extensions/typescript-language-features/src/languageFeatures/completions.ts
+++ b/extensions/typescript-language-features/src/languageFeatures/completions.ts
@@ -904,35 +904,6 @@ class TypeScriptCompletionItemProvider implements vscode.CompletionItemProvider<
 		position: vscode.Position,
 		configuration: CompletionConfiguration,
 	): boolean {
-		if (context.triggerCharacter && this.client.apiVersion.lt(API.v290)) {
-			if ((context.triggerCharacter === '"' || context.triggerCharacter === '\'')) {
-				// make sure we are in something that looks like the start of an import
-				const pre = line.text.slice(0, position.character);
-				if (!/\b(from|import)\s*["']$/.test(pre) && !/\b(import|require)\(['"]$/.test(pre)) {
-					return false;
-				}
-			}
-
-			if (context.triggerCharacter === '/') {
-				// make sure we are in something that looks like an import path
-				const pre = line.text.slice(0, position.character);
-				if (!/\b(from|import)\s*["'][^'"]*$/.test(pre) && !/\b(import|require)\(['"][^'"]*$/.test(pre)) {
-					return false;
-				}
-			}
-
-			if (context.triggerCharacter === '@') {
-				// make sure we are in something that looks like the start of a jsdoc comment
-				const pre = line.text.slice(0, position.character);
-				if (!/^\s*\*[ ]?@/.test(pre) && !/\/\*\*+[ ]?@/.test(pre)) {
-					return false;
-				}
-			}
-
-			if (context.triggerCharacter === '<') {
-				return false;
-			}
-		}
 		if (context.triggerCharacter === ' ') {
 			if (!configuration.importStatementSuggestions || this.client.apiVersion.lt(API.v430)) {
 				return false;

--- a/extensions/typescript-language-features/src/languageFeatures/definitions.ts
+++ b/extensions/typescript-language-features/src/languageFeatures/definitions.ts
@@ -5,57 +5,47 @@
 
 import * as vscode from 'vscode';
 import { ClientCapability, ITypeScriptServiceClient } from '../typescriptService';
-import API from '../utils/api';
 import { conditionalRegistration, requireSomeCapability } from '../utils/dependentRegistration';
 import { DocumentSelector } from '../utils/documentSelector';
 import * as typeConverters from '../utils/typeConverters';
 import DefinitionProviderBase from './definitionProviderBase';
 
 export default class TypeScriptDefinitionProvider extends DefinitionProviderBase implements vscode.DefinitionProvider {
-	constructor(
-		client: ITypeScriptServiceClient
-	) {
-		super(client);
-	}
 
 	public async provideDefinition(
 		document: vscode.TextDocument,
 		position: vscode.Position,
 		token: vscode.CancellationToken
 	): Promise<vscode.DefinitionLink[] | vscode.Definition | undefined> {
-		if (this.client.apiVersion.gte(API.v270)) {
-			const filepath = this.client.toOpenedFilePath(document);
-			if (!filepath) {
-				return undefined;
-			}
-
-			const args = typeConverters.Position.toFileLocationRequestArgs(filepath, position);
-			const response = await this.client.execute('definitionAndBoundSpan', args, token);
-			if (response.type !== 'response' || !response.body) {
-				return undefined;
-			}
-
-			const span = response.body.textSpan ? typeConverters.Range.fromTextSpan(response.body.textSpan) : undefined;
-			return response.body.definitions
-				.map((location): vscode.DefinitionLink => {
-					const target = typeConverters.Location.fromTextSpan(this.client.toResource(location.file), location);
-					if (location.contextStart && location.contextEnd) {
-						return {
-							originSelectionRange: span,
-							targetRange: typeConverters.Range.fromLocations(location.contextStart, location.contextEnd),
-							targetUri: target.uri,
-							targetSelectionRange: target.range,
-						};
-					}
-					return {
-						originSelectionRange: span,
-						targetRange: target.range,
-						targetUri: target.uri
-					};
-				});
+		const filepath = this.client.toOpenedFilePath(document);
+		if (!filepath) {
+			return undefined;
 		}
 
-		return this.getSymbolLocations('definition', document, position, token);
+		const args = typeConverters.Position.toFileLocationRequestArgs(filepath, position);
+		const response = await this.client.execute('definitionAndBoundSpan', args, token);
+		if (response.type !== 'response' || !response.body) {
+			return undefined;
+		}
+
+		const span = response.body.textSpan ? typeConverters.Range.fromTextSpan(response.body.textSpan) : undefined;
+		return response.body.definitions
+			.map((location): vscode.DefinitionLink => {
+				const target = typeConverters.Location.fromTextSpan(this.client.toResource(location.file), location);
+				if (location.contextStart && location.contextEnd) {
+					return {
+						originSelectionRange: span,
+						targetRange: typeConverters.Range.fromLocations(location.contextStart, location.contextEnd),
+						targetUri: target.uri,
+						targetSelectionRange: target.range,
+					};
+				}
+				return {
+					originSelectionRange: span,
+					targetRange: target.range,
+					targetUri: target.uri
+				};
+			});
 	}
 }
 

--- a/extensions/typescript-language-features/src/languageFeatures/fileConfigurationManager.ts
+++ b/extensions/typescript-language-features/src/languageFeatures/fileConfigurationManager.ts
@@ -165,10 +165,6 @@ export default class FileConfigurationManager extends Disposable {
 	}
 
 	private getPreferences(document: vscode.TextDocument): Proto.UserPreferences {
-		if (this.client.apiVersion.lt(API.v290)) {
-			return {};
-		}
-
 		const config = vscode.workspace.getConfiguration(
 			isTypeScriptDocument(document) ? 'typescript' : 'javascript',
 			document);

--- a/extensions/typescript-language-features/src/languageFeatures/folding.ts
+++ b/extensions/typescript-language-features/src/languageFeatures/folding.ts
@@ -6,14 +6,11 @@
 import * as vscode from 'vscode';
 import type * as Proto from '../protocol';
 import { ITypeScriptServiceClient } from '../typescriptService';
-import API from '../utils/api';
 import { coalesce } from '../utils/arrays';
-import { conditionalRegistration, requireMinVersion } from '../utils/dependentRegistration';
 import { DocumentSelector } from '../utils/documentSelector';
 import * as typeConverters from '../utils/typeConverters';
 
 class TypeScriptFoldingProvider implements vscode.FoldingRangeProvider {
-	public static readonly minVersion = API.v280;
 
 	public constructor(
 		private readonly client: ITypeScriptServiceClient
@@ -87,10 +84,6 @@ export function register(
 	selector: DocumentSelector,
 	client: ITypeScriptServiceClient,
 ): vscode.Disposable {
-	return conditionalRegistration([
-		requireMinVersion(client, TypeScriptFoldingProvider.minVersion),
-	], () => {
-		return vscode.languages.registerFoldingRangeProvider(selector.syntax,
-			new TypeScriptFoldingProvider(client));
-	});
+	return vscode.languages.registerFoldingRangeProvider(selector.syntax,
+		new TypeScriptFoldingProvider(client));
 }

--- a/extensions/typescript-language-features/src/languageFeatures/organizeImports.ts
+++ b/extensions/typescript-language-features/src/languageFeatures/organizeImports.ts
@@ -20,14 +20,13 @@ import FileConfigurationManager from './fileConfigurationManager';
 interface OrganizeImportsCommandMetadata {
 	readonly ids: readonly string[];
 	readonly title: string;
-	readonly minVersion: API;
+	readonly minVersion?: API;
 	readonly kind: vscode.CodeActionKind;
 	readonly mode: OrganizeImportsMode;
 }
 
 const organizeImportsCommand: OrganizeImportsCommandMetadata = {
 	ids: ['typescript.organizeImports'],
-	minVersion: API.v280,
 	title: vscode.l10n.t("Organize Imports"),
 	kind: vscode.CodeActionKind.SourceOrganizeImports,
 	mode: OrganizeImportsMode.All,
@@ -157,7 +156,7 @@ export function register(
 
 	for (const command of [organizeImportsCommand, sortImportsCommand, removeUnusedImportsCommand]) {
 		disposables.push(conditionalRegistration([
-			requireMinVersion(client, command.minVersion),
+			requireMinVersion(client, command.minVersion ?? API.defaultVersion),
 			requireSomeCapability(client, ClientCapability.Semantic),
 		], () => {
 			const provider = new ImportsCodeActionProvider(client, command, commandManager, fileConfigurationManager, telemetryReporter);

--- a/extensions/typescript-language-features/src/languageFeatures/quickFix.ts
+++ b/extensions/typescript-language-features/src/languageFeatures/quickFix.ts
@@ -7,7 +7,6 @@ import * as vscode from 'vscode';
 import { Command, CommandManager } from '../commands/commandManager';
 import type * as Proto from '../protocol';
 import { ClientCapability, ITypeScriptServiceClient } from '../typescriptService';
-import API from '../utils/api';
 import { nulToken } from '../utils/cancellation';
 import { applyCodeActionCommands, getEditForCodeAction } from '../utils/codeAction';
 import { conditionalRegistration, requireSomeCapability } from '../utils/dependentRegistration';
@@ -342,7 +341,7 @@ class TypeScriptQuickFixProvider implements vscode.CodeActionProvider<VsCodeCode
 		diagnostic: vscode.Diagnostic,
 		tsAction: Proto.CodeFixAction,
 	): CodeActionSet {
-		if (!tsAction.fixId || this.client.apiVersion.lt(API.v270) || results.hasFixAllAction(tsAction.fixId)) {
+		if (!tsAction.fixId || results.hasFixAllAction(tsAction.fixId)) {
 			return results;
 		}
 

--- a/extensions/typescript-language-features/src/languageFeatures/refactor.ts
+++ b/extensions/typescript-language-features/src/languageFeatures/refactor.ts
@@ -10,7 +10,7 @@ import type * as Proto from '../protocol';
 import { ClientCapability, ITypeScriptServiceClient } from '../typescriptService';
 import API from '../utils/api';
 import { nulToken } from '../utils/cancellation';
-import { conditionalRegistration, requireMinVersion, requireSomeCapability } from '../utils/dependentRegistration';
+import { conditionalRegistration, requireSomeCapability } from '../utils/dependentRegistration';
 import { DocumentSelector } from '../utils/documentSelector';
 import * as fileSchemes from '../utils/fileSchemes';
 import { TelemetryReporter } from '../utils/telemetry';
@@ -249,7 +249,6 @@ class SelectCodeAction extends vscode.CodeAction {
 type TsCodeAction = InlinedCodeAction | SelectCodeAction;
 
 class TypeScriptRefactorProvider implements vscode.CodeActionProvider<TsCodeAction> {
-	public static readonly minVersion = API.v240;
 
 	constructor(
 		private readonly client: ITypeScriptServiceClient,
@@ -505,7 +504,6 @@ export function register(
 	telemetryReporter: TelemetryReporter,
 ) {
 	return conditionalRegistration([
-		requireMinVersion(client, TypeScriptRefactorProvider.minVersion),
 		requireSomeCapability(client, ClientCapability.Semantic),
 	], () => {
 		return vscode.languages.registerCodeActionsProvider(selector.semantic,

--- a/extensions/typescript-language-features/src/tsServer/bufferSyncSupport.ts
+++ b/extensions/typescript-language-features/src/tsServer/bufferSyncSupport.ts
@@ -211,13 +211,11 @@ class SyncedBuffer {
 			args.scriptKindName = scriptKind;
 		}
 
-		if (this.client.apiVersion.gte(API.v240)) {
-			const tsPluginsForDocument = this.client.pluginManager.plugins
-				.filter(x => x.languages.indexOf(this.document.languageId) >= 0);
+		const tsPluginsForDocument = this.client.pluginManager.plugins
+			.filter(x => x.languages.indexOf(this.document.languageId) >= 0);
 
-			if (tsPluginsForDocument.length) {
-				(args as any).plugins = tsPluginsForDocument.map(plugin => plugin.name);
-			}
+		if (tsPluginsForDocument.length) {
+			(args as any).plugins = tsPluginsForDocument.map(plugin => plugin.name);
 		}
 
 		this.synchronizer.open(this.resource, args);

--- a/extensions/typescript-language-features/src/tsServer/spawner.ts
+++ b/extensions/typescript-language-features/src/tsServer/spawner.ts
@@ -199,11 +199,7 @@ export class TypeScriptServerSpawner {
 			}
 		}
 
-		if (apiVersion.gte(API.v250)) {
-			args.push('--useInferredProjectPerProjectRoot');
-		} else {
-			args.push('--useSingleInferredProject');
-		}
+		args.push('--useInferredProjectPerProjectRoot');
 
 		if (configuration.disableAutomaticTypeAcquisition || kind === TsServerProcessKind.Syntax || kind === TsServerProcessKind.Diagnostics) {
 			args.push('--disableAutomaticTypingAcquisition');

--- a/extensions/typescript-language-features/src/utils/api.ts
+++ b/extensions/typescript-language-features/src/utils/api.ts
@@ -13,13 +13,6 @@ export default class API {
 	}
 
 	public static readonly defaultVersion = API.fromSimpleString('1.0.0');
-	public static readonly v240 = API.fromSimpleString('2.4.0');
-	public static readonly v250 = API.fromSimpleString('2.5.0');
-	public static readonly v260 = API.fromSimpleString('2.6.0');
-	public static readonly v270 = API.fromSimpleString('2.7.0');
-	public static readonly v280 = API.fromSimpleString('2.8.0');
-	public static readonly v290 = API.fromSimpleString('2.9.0');
-	public static readonly v291 = API.fromSimpleString('2.9.1');
 	public static readonly v300 = API.fromSimpleString('3.0.0');
 	public static readonly v310 = API.fromSimpleString('3.1.0');
 	public static readonly v314 = API.fromSimpleString('3.1.4');


### PR DESCRIPTION
This removes extra code we had to support TS versions that are 4+ years old. We do not test these versions and a very small number of users are actually using them
