### PR TITLE
Use JSX in display names of the `TypeScript React` and `JavaScript React` languages

### DIFF
--- a/extensions/javascript/package.json
+++ b/extensions/javascript/package.json
@@ -18,6 +18,7 @@
       {
         "id": "javascriptreact",
         "aliases": [
+          "JavaScript JSX",
           "JavaScript React",
           "jsx"
         ],

--- a/extensions/typescript-basics/package.json
+++ b/extensions/typescript-basics/package.json
@@ -31,6 +31,7 @@
       {
         "id": "typescriptreact",
         "aliases": [
+          "TypeScript JSX",
           "TypeScript React",
           "tsx"
         ],


### PR DESCRIPTION
Fixes #138285

This changes the display name of the languages `JavaScript React` -> `JavaScript JSX` and `TypeScript React` -> `TypeScript JSX`

This only changes the display names and leaves the ids alone. Changing the ids would be a very breaking change for extensions with no real user benefits

