### PR TITLE
fix `ERR TypeError`

### DIFF
--- a/src/vs/platform/profiling/electron-sandbox/profileAnalysisWorker.ts
+++ b/src/vs/platform/profiling/electron-sandbox/profileAnalysisWorker.ts
@@ -29,7 +29,7 @@ class ProfileAnalysisWorker implements IRequestHandler, IProfileAnalysisWorker {
 		const samples = bottomUp(model, 5, false)
 			.filter(s => !s.isSpecial);
 
-		if (samples.length === 0 || samples[1].percentage < 10) {
+		if (samples.length === 0 || samples[0].percentage < 10) {
 			// ignore this profile because 90% of the time is spent inside "special" frames
 			// like idle, GC, or program
 			return { kind: ProfilingOutput.Irrelevant, samples: [] };


### PR DESCRIPTION
```
ERR TypeError: Cannot read properties of undefined (reading 'percentage')
    at u.analyseBottomUp (vscode-file://vscode-app/Applications/Visual%20Studio%20Code%20-%20Insiders.app/Contents/Resources/app/out/vs/vs/platform/profiling/electron-sandbox/profileAnalysisWorker.js:3:12186)
    at l.d (vscode-file://vscode-app/Applications/Visual%20Studio%20Code%20-%20Insiders.app/Contents/Resources/app/out/vs/base/worker/workerMain.js#CpuProfileAnalysis:17:76770)
    at Object.handleMessage (vscode-file://vscode-app/Applications/Visual%20Studio%20Code%20-%20Insiders.app/Contents/Resources/app/out/vs/base/worker/workerMain.js#CpuProfileAnalysis:17:76491)
    at C.k (vscode-file://vscode-app/Applications/Visual%20Studio%20Code%20-%20Insiders.app/Contents/Resources/app/out/vs/base/worker/workerMain.js#CpuProfileAnalysis:17:73744)
    at C.h (vscode-file://vscode-app/Applications/Visual%20Studio%20Code%20-%20Insiders.app/Contents/Resources/app/out/vs/base/worker/workerMain.js#CpuProfileAnalysis:17:73375)
    at C.handleMessage (vscode-file://vscode-app/Applications/Visual%20Studio%20Code%20-%20Insiders.app/Contents/Resources/app/out/vs/base/worker/workerMain.js#CpuProfileAnalysis:17:73307)
    at l.onmessage (vscode-file://vscode-app/Applications/Visual%20Studio%20Code%20-%20Insiders.app/Contents/Resources/app/out/vs/base/worker/workerMain.js#CpuProfileAnalysis:17:76551)
    at self.onmessage (vscode-file://vscode-app/Applications/Visual%20Studio%20Code%20-%20Insiders.app/Contents/Resources/app/out/vs/base/worker/workerMain.js#CpuProfileAnalysis:8:431)
```
