### PR TITLE
Introduce VSCODE_RESOLVING_ENVIRONMENT env var.

### DIFF
--- a/src/vs/platform/shell/node/shellEnv.ts
+++ b/src/vs/platform/shell/node/shellEnv.ts
@@ -111,7 +111,8 @@ async function doResolveUnixShellEnv(logService: ILogService, token: Cancellatio
 	const env = {
 		...process.env,
 		ELECTRON_RUN_AS_NODE: '1',
-		ELECTRON_NO_ATTACH_CONSOLE: '1'
+		ELECTRON_NO_ATTACH_CONSOLE: '1',
+		VSCODE_RESOLVING_ENVIRONMENT: '1'
 	};
 
 	logService.trace('getUnixShellEnvironment#env', env);
@@ -197,6 +198,8 @@ async function doResolveUnixShellEnv(logService: ILogService, token: Cancellatio
 				} else {
 					delete env['ELECTRON_NO_ATTACH_CONSOLE'];
 				}
+
+				delete env['VSCODE_RESOLVING_ENVIRONMENT'];
 
 				// https://github.com/microsoft/vscode/issues/22593#issuecomment-336050758
 				delete env['XDG_RUNTIME_DIR'];


### PR DESCRIPTION
This environment variable is set while VS Code attempts to resolve your environment (i.e. tries to pick up on all the environment variables that you set in your shell startup scripts, such as .bashrc).

The purpose of this environment variable is to let users opt out of certain actions while VS Code does this, e.g. to avoid slow processes running or exec lines being executed.

Fixes #163186

This is kind of a tough one to test, TBH. But it's small enough that I figure it's probably not worth worrying about too hard.

Only thing I'm not sure about is where to document this? Any pointers would be grand.
