### PR TITLE
use `StableEditorScrollState` to ensure inlay hints don't move lines vertically

### DIFF
--- a/src/vs/editor/contrib/inlayHints/browser/inlayHintsController.ts
+++ b/src/vs/editor/contrib/inlayHints/browser/inlayHintsController.ts
@@ -15,6 +15,7 @@ import { assertType } from 'vs/base/common/types';
 import { URI } from 'vs/base/common/uri';
 import { IActiveCodeEditor, ICodeEditor, IEditorMouseEvent, MouseTargetType } from 'vs/editor/browser/editorBrowser';
 import { ClassNameReference, CssProperties, DynamicCssRules } from 'vs/editor/browser/editorDom';
+import { StableEditorScrollState } from 'vs/editor/browser/stableEditorScroll';
 import { EditorOption, EDITOR_FONT_DEFAULTS } from 'vs/editor/common/config/editorOptions';
 import { EditOperation } from 'vs/editor/common/core/editOperation';
 import { Range } from 'vs/editor/common/core/range';
@@ -563,6 +564,8 @@ export class InlayHintsController implements IEditorContribution {
 			}
 		}
 
+		const scrollState = StableEditorScrollState.capture(this._editor);
+
 		this._editor.changeDecorations(accessor => {
 			const newDecorationIds = accessor.deltaDecorations(decorationIdsToReplace, newDecorationsData.map(d => d.decoration));
 			for (let i = 0; i < newDecorationIds.length; i++) {
@@ -570,6 +573,8 @@ export class InlayHintsController implements IEditorContribution {
 				this._decorationsMetadata.set(newDecorationIds[i], data);
 			}
 		});
+
+		scrollState.restore(this._editor);
 	}
 
 	private _fillInColors(props: CssProperties, hint: languages.InlayHint): void {


### PR DESCRIPTION
fixes https://github.com/microsoft/vscode/issues/165312
