### PR TITLE
🐛 Fix wrong toggling of `show-checkboxes` style

### DIFF
--- a/src/vs/base/parts/quickinput/browser/quickInput.ts
+++ b/src/vs/base/parts/quickinput/browser/quickInput.ts
@@ -1677,7 +1677,7 @@ export class QuickInputController extends Disposable {
 		ui.message.style.display = visibilities.message ? '' : 'none';
 		ui.progressBar.getContainer().style.display = visibilities.progressBar ? '' : 'none';
 		ui.list.display(!!visibilities.list);
-		ui.container.classList.toggle('show-checkboxes', visibilities.checkBox);
+		ui.container.classList.toggle('show-checkboxes', !!visibilities.checkBox);
 		this.updateLayout(); // TODO
 	}
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fixes #168439

The issue was because of an unwanted toggling of the `show-checkboxes` style class (when the `visibilities.checkBox` is `undefined`).

## Cause

This was due to a recent change that improved the code by changing the dynamic call below into a simple call to the `toggle` method:

```ts
// Old
ui.container.classList[visibilities.checkBox ? 'add' : 'remove']('show-checkboxes');
// New
ui.container.classList.toggle('show-checkboxes', visibilities.checkBox);
```

This PR makes sure that `visibilities.checkBox` is never `undefined`:

```ts
ui.container.classList.toggle('show-checkboxes', !!visibilities.checkBox);
```