### PR TITLE
fix `HISTFILE` issue

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/media/shellIntegration-rc.zsh
+++ b/src/vs/workbench/contrib/terminal/browser/media/shellIntegration-rc.zsh
@@ -24,7 +24,6 @@ if [[ "$VSCODE_INJECTION" == "1" ]]; then
 	fi
 
 	if [[ -f $USER_ZDOTDIR/.zsh_history && -f $HISTFILE ]]; then
-		ZDOTDIR=$USER_ZDOTDIR
 		HISTFILE=$USER_ZDOTDIR/.zsh_history
 	fi
 fi

--- a/src/vs/workbench/contrib/terminal/browser/media/shellIntegration-rc.zsh
+++ b/src/vs/workbench/contrib/terminal/browser/media/shellIntegration-rc.zsh
@@ -4,6 +4,10 @@
 # ---------------------------------------------------------------------------------------------
 builtin autoload -Uz add-zsh-hook
 
+if [[  "$VSCODE_INJECTION" == "1"  && -f $USER_ZDOTDIR/.zsh_history && -f $HISTFILE ]]; then
+	HISTFILE=$USER_ZDOTDIR/.zsh_history
+fi
+
 # Prevent the script recursing when setting up
 if [ -n "$VSCODE_SHELL_INTEGRATION" ]; then
 	ZDOTDIR=$USER_ZDOTDIR
@@ -20,11 +24,6 @@ if [[ "$VSCODE_INJECTION" == "1" ]]; then
 		VSCODE_ZDOTDIR=$ZDOTDIR
 		ZDOTDIR=$USER_ZDOTDIR
 		. $USER_ZDOTDIR/.zshrc
-		ZDOTDIR=$VSCODE_ZDOTDIR
-	fi
-
-	if [[ -f $USER_ZDOTDIR/.zsh_history && -f $HISTFILE ]]; then
-		HISTFILE=$USER_ZDOTDIR/.zsh_history
 	fi
 fi
 

--- a/src/vs/workbench/contrib/terminal/browser/media/shellIntegration-rc.zsh
+++ b/src/vs/workbench/contrib/terminal/browser/media/shellIntegration-rc.zsh
@@ -16,7 +16,7 @@ VSCODE_SHELL_INTEGRATION=1
 
 # Set HISTFILE to the default location before the user's .zshrc is sourced
 # to prevent the value of HISTFILE from defaulting to VSCODE_ZDOTDIR/.zsh_history
-if [[  "$VSCODE_INJECTION" == "1"  && -f $USER_ZDOTDIR/.zsh_history && -f $HISTFILE ]]; then
+if [[  "$VSCODE_INJECTION" == "1" ]]; then
 	HISTFILE=$USER_ZDOTDIR/.zsh_history
 fi
 

--- a/src/vs/workbench/contrib/terminal/browser/media/shellIntegration-rc.zsh
+++ b/src/vs/workbench/contrib/terminal/browser/media/shellIntegration-rc.zsh
@@ -23,7 +23,8 @@ if [[ "$VSCODE_INJECTION" == "1" ]]; then
 		ZDOTDIR=$VSCODE_ZDOTDIR
 	fi
 
-	if [[ -f $USER_ZDOTDIR/.zsh_history && -z $HISTFILE ]]; then
+	if [[ -f $USER_ZDOTDIR/.zsh_history && -f $HISTFILE ]]; then
+		ZDOTDIR=$USER_ZDOTDIR
 		HISTFILE=$USER_ZDOTDIR/.zsh_history
 	fi
 fi

--- a/src/vs/workbench/contrib/terminal/browser/media/shellIntegration-rc.zsh
+++ b/src/vs/workbench/contrib/terminal/browser/media/shellIntegration-rc.zsh
@@ -14,8 +14,10 @@ fi
 # as disable it by unsetting the variable.
 VSCODE_SHELL_INTEGRATION=1
 
-# Set HISTFILE to the default location before the user's .zshrc is sourced
-# to prevent the value of HISTFILE from defaulting to VSCODE_ZDOTDIR/.zsh_history
+# By default, zsh will set the $HISTFILE to the $ZDOTDIR location automatically. In the case of the
+# shell integration being injected, this means that the terminal will use a different history file
+# to other terminals. To fix this issue, set $HISTFILE back to the default location before ~/.zshrc
+# is called as that may depend upon the value.
 if [[  "$VSCODE_INJECTION" == "1" ]]; then
 	HISTFILE=$USER_ZDOTDIR/.zsh_history
 fi

--- a/src/vs/workbench/contrib/terminal/browser/media/shellIntegration-rc.zsh
+++ b/src/vs/workbench/contrib/terminal/browser/media/shellIntegration-rc.zsh
@@ -4,10 +4,6 @@
 # ---------------------------------------------------------------------------------------------
 builtin autoload -Uz add-zsh-hook
 
-if [[  "$VSCODE_INJECTION" == "1"  && -f $USER_ZDOTDIR/.zsh_history && -f $HISTFILE ]]; then
-	HISTFILE=$USER_ZDOTDIR/.zsh_history
-fi
-
 # Prevent the script recursing when setting up
 if [ -n "$VSCODE_SHELL_INTEGRATION" ]; then
 	ZDOTDIR=$USER_ZDOTDIR
@@ -18,11 +14,18 @@ fi
 # as disable it by unsetting the variable.
 VSCODE_SHELL_INTEGRATION=1
 
+# Set HISTFILE to the default location before the user's .zshrc is sourced
+# to prevent the value of HISTFILE from defaulting to VSCODE_ZDOTDIR/.zsh_history
+if [[  "$VSCODE_INJECTION" == "1"  && -f $USER_ZDOTDIR/.zsh_history && -f $HISTFILE ]]; then
+	HISTFILE=$USER_ZDOTDIR/.zsh_history
+fi
+
 # Only fix up ZDOTDIR if shell integration was injected (not manually installed) and has not been called yet
 if [[ "$VSCODE_INJECTION" == "1" ]]; then
 	if [[ $options[norcs] = off  && -f $USER_ZDOTDIR/.zshrc ]]; then
 		VSCODE_ZDOTDIR=$ZDOTDIR
 		ZDOTDIR=$USER_ZDOTDIR
+		# A user's custom HISTFILE location might be set when their .zshrc file is sourced below
 		. $USER_ZDOTDIR/.zshrc
 	fi
 fi


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

The issue occurs when a user has not set a custom `$HISTFILE`. I was not able to repro the reports at first because was setting `HISTFILE` in my `.zshrc` file. We want to preserve the behavior for a custom `$HISTFILE`.

Verified that:
- `HISTFILE` will always be set by the end of the `.zshrc` file
- It can be customized in the user's `.zshrc` file or left unset, in which case it will default to `$ZDOTDIR/.zsh_history`

For the unset case:
- When our `$VSCODE_ZDOTDIR/.zshrc` file ran, `$HISTFILE` was set to `$VSCODE_ZDOTDIR/.zsh_history` because we were not setting that before the user's `.zshrc` file was sourced

For the set case:
- We shouldn't have to do anything here as now we don't set the `$HISTFILE` after running their `.zshrc`, which was the original problem that was solved by https://github.com/microsoft/vscode/pull/166813
