### PR TITLE
speed up `parseLabelWithIcons`

### DIFF
--- a/src/vs/base/common/iconLabels.ts
+++ b/src/vs/base/common/iconLabels.ts
@@ -10,7 +10,6 @@ import { ltrim } from 'vs/base/common/strings';
 const iconStartMarker = '$(';
 
 const iconsRegex = new RegExp(`\\$\\(${CSSIcon.iconNameExpression}(?:${CSSIcon.iconModifierExpression})?\\)`, 'g'); // no capturing groups
-const iconNameCharacterRegexp = new RegExp(CSSIcon.iconNameCharacter);
 
 const escapeIconsRegex = new RegExp(`(\\\\)?${iconsRegex.source}`, 'g');
 export function escapeIcons(text: string): string {
@@ -38,98 +37,36 @@ export interface IParsedLabelWithIcons {
 	readonly iconOffsets?: readonly number[];
 }
 
-export function parseLabelWithIcons(text: string): IParsedLabelWithIcons {
-	const firstIconIndex = text.indexOf(iconStartMarker);
-	if (firstIconIndex === -1) {
-		return { text }; // return early if the word does not include an icon
-	}
+const _parseIconsRegex = new RegExp(`\\$\\(${CSSIcon.iconNameCharacter}+\\)`, 'g');
 
-	return doParseLabelWithIcons(text, firstIconIndex);
-}
+export function parseLabelWithIcons(input: string): IParsedLabelWithIcons {
 
-function doParseLabelWithIcons(text: string, firstIconIndex: number): IParsedLabelWithIcons {
+	_parseIconsRegex.lastIndex = 0;
+
+	let text = '';
 	const iconOffsets: number[] = [];
-	let textWithoutIcons: string = '';
-
-	function appendChars(chars: string) {
-		if (chars) {
-			textWithoutIcons += chars;
-
-			for (const _ of chars) {
-				iconOffsets.push(iconsOffset); // make sure to fill in icon offsets
-			}
-		}
-	}
-
-	let currentIconStart = -1;
-	let currentIconValue: string = '';
 	let iconsOffset = 0;
 
-	let char: string;
-	let nextChar: string;
+	while (true) {
+		const pos = _parseIconsRegex.lastIndex;
+		const match = _parseIconsRegex.exec(input);
 
-	let offset = firstIconIndex;
-	const length = text.length;
-
-	// Append all characters until the first icon
-	appendChars(text.substr(0, firstIconIndex));
-
-	// example: $(file-symlink-file) my cool $(other-icon) entry
-	while (offset < length) {
-		char = text[offset];
-		nextChar = text[offset + 1];
-
-		// beginning of icon: some value $( <--
-		if (char === iconStartMarker[0] && nextChar === iconStartMarker[1]) {
-			currentIconStart = offset;
-
-			// if we had a previous potential icon value without
-			// the closing ')', it was actually not an icon and
-			// so we have to add it to the actual value
-			appendChars(currentIconValue);
-
-			currentIconValue = iconStartMarker;
-
-			offset++; // jump over '('
-		}
-
-		// end of icon: some value $(some-icon) <--
-		else if (char === ')' && currentIconStart !== -1) {
-			const currentIconLength = offset - currentIconStart + 1; // +1 to include the closing ')'
-			iconsOffset += currentIconLength;
-			currentIconStart = -1;
-			currentIconValue = '';
-		}
-
-		// within icon
-		else if (currentIconStart !== -1) {
-			// Make sure this is a real icon name
-			if (iconNameCharacterRegexp.test(char)) {
-				currentIconValue += char;
-			} else {
-				// This is not a real icon, treat it as text
-				appendChars(currentIconValue);
-
-				currentIconStart = -1;
-				currentIconValue = '';
+		const chars = input.substring(pos, match?.index);
+		if (chars.length > 0) {
+			text += chars;
+			for (let i = 0; i < chars.length; i++) {
+				iconOffsets.push(iconsOffset);
 			}
 		}
-
-		// any value outside of icon
-		else {
-			appendChars(char);
+		if (!match) {
+			break;
 		}
-
-		offset++;
+		iconsOffset += match[0].length;
 	}
 
-	// if we had a previous potential icon value without
-	// the closing ')', it was actually not an icon and
-	// so we have to add it to the actual value
-	appendChars(currentIconValue);
-
-	return { text: textWithoutIcons, iconOffsets };
+	return { text, iconOffsets };
 }
+
 
 export function matchesFuzzyIconAware(query: string, target: IParsedLabelWithIcons, enableSeparateSubstringMatching = false): IMatch[] | null {
 	const { text, iconOffsets } = target;


### PR DESCRIPTION
Use a regex instead of traversing the string character by character. This is faster, surprisingly it's also faster than using String.replace with the same regex and a replacer function.

Using `big.js` from https://github.com/microsoft/vscode/issues/140661 and running quick open shows a 5-7X speed improvement. However, a few more things seem wrong and too slow
