### PR TITLE
Git - Improve unsafe repository handling

### DIFF
--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -3200,7 +3200,7 @@ export class CommandCenter {
 
 		const allRepositoriesLabel = l10n.t('All Repositories');
 		const allRepositoriesQuickPickItem: QuickPickItem = { label: allRepositoriesLabel };
-		const repositoriesQuickPickItems: QuickPickItem[] = Array.from(this.model.unsafeRepositories.values()).sort().map(r => new UnsafeRepositoryItem(r));
+		const repositoriesQuickPickItems: QuickPickItem[] = Array.from(this.model.unsafeRepositories.keys()).sort().map(r => new UnsafeRepositoryItem(r));
 
 		quickpick.items = this.model.unsafeRepositories.size === 1 ? [...repositoriesQuickPickItems] :
 			[...repositoriesQuickPickItems, { label: '', kind: QuickPickItemKind.Separator }, allRepositoriesQuickPickItem];
@@ -3219,7 +3219,7 @@ export class CommandCenter {
 
 		if (repositoryItem.label === allRepositoriesLabel) {
 			// All Repositories
-			unsafeRepositories.push(...this.model.unsafeRepositories.values());
+			unsafeRepositories.push(...this.model.unsafeRepositories.keys());
 		} else {
 			// One Repository
 			unsafeRepositories.push((repositoryItem as UnsafeRepositoryItem).path);
@@ -3227,7 +3227,7 @@ export class CommandCenter {
 
 		for (const unsafeRepository of unsafeRepositories) {
 			// Mark as Safe
-			await this.git.addSafeDirectory(unsafeRepository);
+			await this.git.addSafeDirectory(this.model.unsafeRepositories.get(unsafeRepository)!);
 
 			// Open Repository
 			await this.model.openRepository(unsafeRepository);

--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -686,9 +686,6 @@ export class Git {
 	}
 
 	async addSafeDirectory(repositoryPath: string): Promise<void> {
-		// safe.directory only supports paths with `/` as separator
-		repositoryPath = repositoryPath.replaceAll('\\', '/');
-
 		await this.exec(repositoryPath, ['config', '--global', '--add', 'safe.directory', repositoryPath]);
 		return;
 	}

--- a/extensions/git/src/model.ts
+++ b/extensions/git/src/model.ts
@@ -33,21 +33,26 @@ class RepositoryPick implements QuickPickItem {
 	constructor(public readonly repository: Repository, public readonly index: number) { }
 }
 
-class UnsafeRepositorySet extends Set<string> {
+/**
+ * Key   - normalized path used in user interface
+ * Value - path extracted from the output of the `git status` command
+ *         used when calling `git config --global --add safe.directory`
+ */
+class UnsafeRepositoryMap extends Map<string, string> {
 	constructor() {
 		super();
 		this.updateContextKey();
 	}
 
-	override add(value: string): this {
-		const result = super.add(value);
+	override set(key: string, value: string): this {
+		const result = super.set(key, value);
 		this.updateContextKey();
 
 		return result;
 	}
 
-	override delete(value: string): boolean {
-		const result = super.delete(value);
+	override delete(key: string): boolean {
+		const result = super.delete(key);
 		this.updateContextKey();
 
 		return result;
@@ -135,8 +140,8 @@ export class Model implements IRemoteSourcePublisherRegistry, IPostCommitCommand
 	private showRepoOnHomeDriveRootWarning = true;
 	private pushErrorHandlers = new Set<PushErrorHandler>();
 
-	private _unsafeRepositories = new UnsafeRepositorySet();
-	get unsafeRepositories(): Set<string> {
+	private _unsafeRepositories = new UnsafeRepositoryMap();
+	get unsafeRepositories(): Map<string, string> {
 		return this._unsafeRepositories;
 	}
 
@@ -430,8 +435,8 @@ export class Model implements IRemoteSourcePublisherRegistry, IPostCommitCommand
 			repository.status(); // do not await this, we want SCM to know about the repo asap
 		} catch (ex) {
 			// Handle unsafe repository
-			const match = /^fatal: detected dubious ownership in repository at \'([^']+)\'$/m.exec(ex.stderr);
-			if (match && match.length === 2) {
+			const match = /^fatal: detected dubious ownership in repository at \'([^']+)\'[\s\S]*git config --global --add safe\.directory '?([^'\n]+)'?$/m.exec(ex.stderr);
+			if (match && match.length === 3) {
 				const unsafeRepositoryPath = path.normalize(match[1]);
 				this.logger.trace(`Unsafe repository: ${unsafeRepositoryPath}`);
 
@@ -440,7 +445,7 @@ export class Model implements IRemoteSourcePublisherRegistry, IPostCommitCommand
 					this.showUnsafeRepositoryNotification();
 				}
 
-				this._unsafeRepositories.add(unsafeRepositoryPath);
+				this._unsafeRepositories.set(unsafeRepositoryPath, match[2]);
 
 				return;
 			}


### PR DESCRIPTION
Fixes #168344 

Extract both paths from the git output:
1) Path to be used in various user interfaces (ex: quick pick)
2) Path to be used as an argument when calling `git config` 