### PR TITLE
Fix webview disappearing when extension is slow to start (#168516)

### DIFF
--- a/src/vs/workbench/contrib/webviewView/browser/webviewViewPane.ts
+++ b/src/vs/workbench/contrib/webviewView/browser/webviewViewPane.ts
@@ -185,7 +185,7 @@ export class WebviewViewPane extends ViewPane {
 		this._webview.value = webview;
 
 		if (this._container) {
-			this._webview.value?.layoutWebviewOverElement(this._container);
+			this.layoutWebview();
 		}
 
 		this._webviewDisposables.add(toDisposable(() => {
@@ -278,7 +278,7 @@ export class WebviewViewPane extends ViewPane {
 		this.layoutWebview();
 	}
 
-	private layoutWebview(dimension?: Dimension) {
+	private doLayoutWebview(dimension?: Dimension) {
 		const webviewEntry = this._webview.value;
 		if (!this._container || !webviewEntry) {
 			return;
@@ -289,11 +289,14 @@ export class WebviewViewPane extends ViewPane {
 		}
 
 		webviewEntry.layoutWebviewOverElement(this._container, dimension, this._rootContainer);
+	}
 
+	private layoutWebview(dimension?: Dimension) {
+		this.doLayoutWebview(dimension);
 		// Temporary fix for https://github.com/microsoft/vscode/issues/110450
 		// There is an animation that lasts about 200ms, update the webview positioning once this animation is complete.
 		clearTimeout(this._repositionTimeout);
-		this._repositionTimeout = setTimeout(() => this.layoutWebview(), 200);
+		this._repositionTimeout = setTimeout(() => this.doLayoutWebview(dimension), 200);
 	}
 
 	private findRootContainer(container: HTMLElement): HTMLElement | undefined {


### PR DESCRIPTION
Fixes #168516

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

To test:

Build the extension in webview-view-sample folder at https://github.com/r3m0t/vscode-extension-samples/tree/webview-samples-slow and install it into VS Code/Code - OSS Dev

Close Workspace (if any is open)

Choose Foo on the activity bar, it loads eventually:

![image](https://user-images.githubusercontent.com/1485998/206670936-56931d15-a202-4ac8-9587-4694158e3f1a.png)

From Command Palette, run "Add folder to Workspace" and choose a trusted folder.

Correct behaviour: the Foo reloads.

Incorrect behaviour (seen in VS Code Insiders and probably VS Code): see screenshot - the webviews are empty

![image](https://user-images.githubusercontent.com/1485998/206671495-fec51a1f-edb6-4730-b187-bbb79a804806.png)
