### PR TITLE
restore editor scroll state after applying edits

### DIFF
--- a/src/vs/editor/contrib/format/browser/formattingEdit.ts
+++ b/src/vs/editor/contrib/format/browser/formattingEdit.ts
@@ -8,6 +8,7 @@ import { EditOperation, ISingleEditOperation } from 'vs/editor/common/core/editO
 import { Range } from 'vs/editor/common/core/range';
 import { EndOfLineSequence } from 'vs/editor/common/model';
 import { TextEdit } from 'vs/editor/common/languages';
+import { StableEditorScrollState } from 'vs/editor/browser/stableEditorScroll';
 
 export class FormattingEdit {
 
@@ -47,6 +48,7 @@ export class FormattingEdit {
 		if (addUndoStops) {
 			editor.pushUndoStop();
 		}
+		const scrollState = StableEditorScrollState.capture(editor);
 		const edits = FormattingEdit._handleEolEdits(editor, _edits);
 		if (edits.length === 1 && FormattingEdit._isFullModelReplaceEdit(editor, edits[0])) {
 			// We use replace semantics and hope that markers stay put...
@@ -57,5 +59,6 @@ export class FormattingEdit {
 		if (addUndoStops) {
 			editor.pushUndoStop();
 		}
+		scrollState.restoreRelativeVerticalPositionOfCursor(editor);
 	}
 }


### PR DESCRIPTION
fixes https://github.com/microsoft/vscode/issues/160934
