### PR TITLE
remove task from in progress when it terminates

### DIFF
--- a/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
+++ b/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
@@ -1913,6 +1913,7 @@ export abstract class AbstractTaskService extends Disposable implements ITaskSer
 		if (!this._taskSystem) {
 			return { success: true, task: undefined };
 		}
+		this._inProgressTasks.delete(task._label);
 		return this._taskSystem.terminate(task);
 	}
 


### PR DESCRIPTION
`_inProgressTasks` were added to fix the race condition where multiple build tasks would stack up. #159640

When a background task is `run`, it is added to `_inProgressTasks`. When the execution result is returned, it's removed. 

If `rerun` is called, it gets terminated but not removed from `_inProgressTasks` so when `run` is called again, it doesn't start because it returns here 

https://github.com/microsoft/vscode/blob/56156dafe88b9fc708736d81054bc82dba5ae7fc/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts#L1208-L1211

The fix is to remove a task from `_inProgressTasks` when it terminates


fix #168378