### PR TITLE
Send cwd shell integration sequence for tasks

### DIFF
--- a/src/vs/workbench/contrib/tasks/browser/terminalTaskSystem.ts
+++ b/src/vs/workbench/contrib/tasks/browser/terminalTaskSystem.ts
@@ -214,11 +214,25 @@ export class TerminalTaskSystem extends Disposable implements ITaskSystem {
 	private readonly _onDidStateChange: Emitter<ITaskEvent>;
 	private _reconnectedTerminals: ITerminalInstance[] | undefined;
 
-	get taskShellIntegrationStartSequence(): string {
-		return this._configurationService.getValue(TaskSettingId.ShowDecorations) ? VSCodeSequence(VSCodeOscPt.PromptStart) + VSCodeSequence(VSCodeOscPt.Property, `${VSCodeOscProperty.Task}=True`) + VSCodeSequence(VSCodeOscPt.CommandStart) : '';
+	taskShellIntegrationStartSequence(cwd: string | URI | undefined): string {
+		if (!this._configurationService.getValue(TaskSettingId.ShowDecorations)) {
+			return '';
+		}
+		return (
+			VSCodeSequence(VSCodeOscPt.PromptStart) +
+			VSCodeSequence(VSCodeOscPt.Property, `${VSCodeOscProperty.Task}=True`) +
+			(cwd
+				? VSCodeSequence(VSCodeOscPt.Property, `${VSCodeOscProperty.Cwd}=${typeof cwd === 'string' ? cwd : cwd.fsPath}`)
+				: ''
+			) +
+			VSCodeSequence(VSCodeOscPt.CommandStart)
+		);
 	}
 	get taskShellIntegrationOutputSequence(): string {
-		return this._configurationService.getValue(TaskSettingId.ShowDecorations) ? VSCodeSequence(VSCodeOscPt.CommandExecuted) : '';
+		if (!this._configurationService.getValue(TaskSettingId.ShowDecorations)) {
+			return '';
+		}
+		return VSCodeSequence(VSCodeOscPt.CommandExecuted);
 	}
 
 	constructor(
@@ -1071,6 +1085,17 @@ export class TerminalTaskSystem extends Disposable implements ITaskSystem {
 		const terminalName = this._createTerminalName(task);
 		const type = ReconnectionType;
 		const originalCommand = task.command.name;
+		let cwd: string | URI | undefined;
+		if (options.cwd) {
+			cwd = options.cwd;
+			if (!path.isAbsolute(cwd)) {
+				if (workspaceFolder && (workspaceFolder.uri.scheme === Schemas.file)) {
+					cwd = path.join(workspaceFolder.uri.fsPath, cwd);
+				}
+			}
+			// This must be normalized to the OS
+			cwd = isUNC(cwd) ? cwd : resources.toLocalResource(URI.from({ scheme: Schemas.file, path: cwd }), this._environmentService.remoteAuthority, this._pathService.defaultUriScheme);
+		}
 		if (isShellCommand) {
 			let os: Platform.OperatingSystem;
 			switch (platform) {
@@ -1175,19 +1200,19 @@ export class TerminalTaskSystem extends Disposable implements ITaskSystem {
 			shellLaunchConfig.args = windowsShellArgs ? combinedShellArgs.join(' ') : combinedShellArgs;
 			if (task.command.presentation && task.command.presentation.echo) {
 				if (needsFolderQualification && workspaceFolder) {
-					shellLaunchConfig.initialText = this.taskShellIntegrationStartSequence + formatMessageForTerminal(nls.localize({
+					shellLaunchConfig.initialText = this.taskShellIntegrationStartSequence(cwd) + formatMessageForTerminal(nls.localize({
 						key: 'task.executingInFolder',
 						comment: ['The workspace folder the task is running in', 'The task command line or label']
 					}, 'Executing task in folder {0}: {1}', workspaceFolder.name, commandLine), { excludeLeadingNewLine: true }) + this.taskShellIntegrationOutputSequence;
 				} else {
-					shellLaunchConfig.initialText = this.taskShellIntegrationStartSequence + formatMessageForTerminal(nls.localize({
+					shellLaunchConfig.initialText = this.taskShellIntegrationStartSequence(cwd) + formatMessageForTerminal(nls.localize({
 						key: 'task.executing.shellIntegration',
 						comment: ['The task command line or label']
 					}, 'Executing task: {0}', commandLine), { excludeLeadingNewLine: true }) + this.taskShellIntegrationOutputSequence;
 				}
 			} else {
 				shellLaunchConfig.initialText = {
-					text: this.taskShellIntegrationStartSequence + this.taskShellIntegrationOutputSequence,
+					text: this.taskShellIntegrationStartSequence(cwd) + this.taskShellIntegrationOutputSequence,
 					trailingNewLine: false
 				};
 			}
@@ -1218,33 +1243,26 @@ export class TerminalTaskSystem extends Disposable implements ITaskSystem {
 					return args.join(' ');
 				};
 				if (needsFolderQualification && workspaceFolder) {
-					shellLaunchConfig.initialText = this.taskShellIntegrationStartSequence + formatMessageForTerminal(nls.localize({
+					shellLaunchConfig.initialText = this.taskShellIntegrationStartSequence(cwd) + formatMessageForTerminal(nls.localize({
 						key: 'task.executingInFolder',
 						comment: ['The workspace folder the task is running in', 'The task command line or label']
 					}, 'Executing task in folder {0}: {1}', workspaceFolder.name, `${shellLaunchConfig.executable} ${getArgsToEcho(shellLaunchConfig.args)}`), { excludeLeadingNewLine: true }) + this.taskShellIntegrationOutputSequence;
 				} else {
-					shellLaunchConfig.initialText = this.taskShellIntegrationStartSequence + formatMessageForTerminal(nls.localize({
+					shellLaunchConfig.initialText = this.taskShellIntegrationStartSequence(cwd) + formatMessageForTerminal(nls.localize({
 						key: 'task.executing.shell-integration',
 						comment: ['The task command line or label']
 					}, 'Executing task: {0}', `${shellLaunchConfig.executable} ${getArgsToEcho(shellLaunchConfig.args)}`), { excludeLeadingNewLine: true }) + this.taskShellIntegrationOutputSequence;
 				}
 			} else {
 				shellLaunchConfig.initialText = {
-					text: this.taskShellIntegrationStartSequence + this.taskShellIntegrationOutputSequence,
+					text: this.taskShellIntegrationStartSequence(cwd) + this.taskShellIntegrationOutputSequence,
 					trailingNewLine: false
 				};
 			}
 		}
 
-		if (options.cwd) {
-			let cwd = options.cwd;
-			if (!path.isAbsolute(cwd)) {
-				if (workspaceFolder && (workspaceFolder.uri.scheme === Schemas.file)) {
-					cwd = path.join(workspaceFolder.uri.fsPath, cwd);
-				}
-			}
-			// This must be normalized to the OS
-			shellLaunchConfig.cwd = isUNC(cwd) ? cwd : resources.toLocalResource(URI.from({ scheme: Schemas.file, path: cwd }), this._environmentService.remoteAuthority, this._pathService.defaultUriScheme);
+		if (cwd) {
+			shellLaunchConfig.cwd = cwd;
 		}
 		if (options.env) {
 			if (shellLaunchConfig.env) {

--- a/src/vs/workbench/contrib/terminal/browser/links/terminalLinkHelpers.ts
+++ b/src/vs/workbench/contrib/terminal/browser/links/terminalLinkHelpers.ts
@@ -161,25 +161,26 @@ export function getXtermLineContent(buffer: IBuffer, lineStart: number, lineEnd:
  * For shells with the CommandDetection capability, the cwd for a command relative to the line of
  * the particular link can be used to narrow down the result for an exact file match.
  */
-export function updateLinkWithRelativeCwd(capabilities: ITerminalCapabilityStore, y: number, text: string, pathSeparator: string): string[] | undefined {
+export function updateLinkWithRelativeCwd(capabilities: ITerminalCapabilityStore, y: number, text: string, osPath: IPath): string[] | undefined {
 	const cwd = capabilities.get(TerminalCapability.CommandDetection)?.getCwdForLine(y);
 	if (!cwd) {
 		return undefined;
 	}
 	const result: string[] = [];
-	if (!text.includes(pathSeparator)) {
-		result.push(cwd + pathSeparator + text);
+	const sep = osPath.sep;
+	if (!text.includes(sep)) {
+		result.push(osPath.resolve(cwd + sep + text));
 	} else {
 		let commonDirs = 0;
 		let i = 0;
-		const cwdPath = cwd.split(pathSeparator).reverse();
-		const linkPath = text.split(pathSeparator);
+		const cwdPath = cwd.split(sep).reverse();
+		const linkPath = text.split(sep);
 		// Get all results as candidates, prioritizing the link with the most common directories.
 		// For example if in the directory /home/common and the link is common/file, the result
 		// should be: `['/home/common/common/file', '/home/common/file']`. The first is the most
 		// likely as cwd detection is active.
 		while (i < cwdPath.length) {
-			result.push(cwd + pathSeparator + linkPath.slice(commonDirs).join(pathSeparator));
+			result.push(osPath.resolve(cwd + sep + linkPath.slice(commonDirs).join(sep)));
 			if (cwdPath[i] === linkPath[i]) {
 				commonDirs++;
 			}

--- a/src/vs/workbench/contrib/terminal/browser/links/terminalLinkOpeners.ts
+++ b/src/vs/workbench/contrib/terminal/browser/links/terminalLinkOpeners.ts
@@ -156,10 +156,11 @@ export class TerminalSearchLinkOpener implements ITerminalLinkOpener {
 	}
 
 	async open(link: ITerminalSimpleLink): Promise<void> {
-		const pathSeparator = osPathModule(this._os).sep;
+		const osPath = osPathModule(this._os);
+		const pathSeparator = osPath.sep;
 		// Remove file:/// and any leading ./ or ../ since quick access doesn't understand that format
 		let text = link.text.replace(/^file:\/\/\/?/, '');
-		text = osPathModule(this._os).normalize(text).replace(/^(\.+[\\/])+/, '');
+		text = osPath.normalize(text).replace(/^(\.+[\\/])+/, '');
 
 		// Remove `:<one or more non number characters>` from the end of the link.
 		// Examples:
@@ -177,7 +178,7 @@ export class TerminalSearchLinkOpener implements ITerminalLinkOpener {
 		});
 		let cwdResolvedText = text;
 		if (this._capabilities.has(TerminalCapability.CommandDetection)) {
-			cwdResolvedText = updateLinkWithRelativeCwd(this._capabilities, link.bufferRange.start.y, text, pathSeparator)?.[0] || text;
+			cwdResolvedText = updateLinkWithRelativeCwd(this._capabilities, link.bufferRange.start.y, text, osPath)?.[0] || text;
 		}
 
 		// Try open the cwd resolved link first

--- a/src/vs/workbench/contrib/terminal/browser/links/terminalLocalLinkDetector.ts
+++ b/src/vs/workbench/contrib/terminal/browser/links/terminalLocalLinkDetector.ts
@@ -151,7 +151,8 @@ export class TerminalLocalLinkDetector implements ITerminalLinkDetector {
 				linkCandidates.push(link);
 			} else {
 				if (this._capabilities.has(TerminalCapability.CommandDetection)) {
-					const absolutePath = updateLinkWithRelativeCwd(this._capabilities, bufferRange.start.y, link, osPathModule(this._os).sep);
+					const osModule = osPathModule(this._os);
+					const absolutePath = updateLinkWithRelativeCwd(this._capabilities, bufferRange.start.y, link, osModule);
 					// Only add a single exact link candidate if the cwd is available, this may cause
 					// the link to not be resolved but that should only occur when the actual file does
 					// not exist. Doing otherwise could cause unexpected results where handling via the

--- a/src/vs/workbench/contrib/terminal/browser/terminalEscapeSequences.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalEscapeSequences.ts
@@ -89,7 +89,8 @@ export const enum VSCodeOscPt {
 }
 
 export const enum VSCodeOscProperty {
-	Task = 'Task'
+	Task = 'Task',
+	Cwd = 'Cwd'
 }
 
 /**


### PR DESCRIPTION
This enables links to be resolved with knowledge of the cwd, the downside here is if the task changes the directory via cd it will no longer be accurate unless shell integration is manually installed and activated.

Fixes #159255

![Recording 2022-12-09 at 08 55 53](https://user-images.githubusercontent.com/2193314/206752469-a5f4c337-6d4e-4961-9f99-5d98edf068d4.gif)
