### PR TITLE
Telemetry: include commands from builtin extensions

### DIFF
--- a/src/vs/workbench/api/common/extHostCommands.ts
+++ b/src/vs/workbench/api/common/extHostCommands.ts
@@ -268,7 +268,7 @@ export class ExtHostCommands implements ExtHostCommandsShape {
 	}
 
 	private _reportTelemetry(command: CommandHandler, id: string, duration: number) {
-		if (!command.extension || command.extension.isBuiltin) {
+		if (!command.extension) {
 			return;
 		}
 		type ExtensionActionTelemetry = {


### PR DESCRIPTION
With this change, the `Extension:ActionExecuted` event is now logged for extensions marked as builtin.

In my setup, some of the extensions are care about are marked as builtin.
I didn't find any information in the blame about this check, or why they should be filtered.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
