### PR TITLE
remote: allow _ in ext host resolvedauthority

### DIFF
--- a/src/vs/server/node/serverConnectionToken.ts
+++ b/src/vs/server/node/serverConnectionToken.ts
@@ -85,7 +85,7 @@ export async function parseServerConnectionToken(args: ServerParsedArgs, default
 		}
 
 		if (!connectionTokenRegex.test(rawConnectionToken)) {
-			return new ServerConnectionTokenParseError(`The connection token defined in '${connectionTokenFile} does not adhere to the characters 0-9, a-z, A-Z or -.`);
+			return new ServerConnectionTokenParseError(`The connection token defined in '${connectionTokenFile} does not adhere to the characters 0-9, a-z, A-Z, _, or -.`);
 		}
 
 		return new MandatoryServerConnectionToken(rawConnectionToken);

--- a/src/vs/workbench/api/common/extHostTypes.ts
+++ b/src/vs/workbench/api/common/extHostTypes.ts
@@ -492,7 +492,7 @@ export class ResolvedAuthority {
 			throw illegalArgument('port');
 		}
 		if (typeof connectionToken !== 'undefined') {
-			if (typeof connectionToken !== 'string' || connectionToken.length === 0 || !/^[0-9A-Za-z\-]+$/.test(connectionToken)) {
+			if (typeof connectionToken !== 'string' || connectionToken.length === 0 || !/^[0-9A-Za-z_\-]+$/.test(connectionToken)) {
 				throw illegalArgument('connectionToken');
 			}
 		}


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/168878

This character was allowed in https://github.com/microsoft/vscode/pull/167635,
but the extension host side did a separate check that I didn't update.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
