### PR TITLE
Fix 415 during telemetry health check

### DIFF
--- a/src/vs/platform/telemetry/browser/1dsAppender.ts
+++ b/src/vs/platform/telemetry/browser/1dsAppender.ts
@@ -17,7 +17,7 @@ export class OneDataSystemWebAppender extends AbstractOneDataSystemAppender {
 
 		// If we cannot fetch the endpoint it means it is down and we should not send any telemetry.
 		// This is most likely due to ad blockers
-		fetch(this.endPointUrl, { method: 'POST' }).catch(err => {
+		fetch(this.endPointHealthUrl, { method: 'GET' }).catch(err => {
 			this._aiCoreOrKey = undefined;
 		});
 	}

--- a/src/vs/platform/telemetry/common/1dsAppender.ts
+++ b/src/vs/platform/telemetry/common/1dsAppender.ts
@@ -18,6 +18,7 @@ export interface IAppInsightsCore {
 }
 
 const endpointUrl = 'https://mobile.events.data.microsoft.com/OneCollector/1.0';
+const endpointHealthUrl = 'https://mobile.events.data.microsoft.com/ping';
 
 async function getClient(instrumentationKey: string, addInternalFlag?: boolean, xhrOverride?: IXHROverride): Promise<IAppInsightsCore> {
 	const oneDs = await import('@microsoft/1ds-core-js');
@@ -68,6 +69,7 @@ export abstract class AbstractOneDataSystemAppender implements ITelemetryAppende
 	protected _aiCoreOrKey: IAppInsightsCore | string | undefined;
 	private _asyncAiCore: Promise<IAppInsightsCore> | null;
 	protected readonly endPointUrl = endpointUrl;
+	protected readonly endPointHealthUrl = endpointHealthUrl;
 
 	constructor(
 		private readonly _isInternalTelemetry: boolean,


### PR DESCRIPTION
Uses a different `ping` endpoint to verify that the telemtry endpoint is alive instead of an empty post to prevent the annoying 415 console error