### PR TITLE
🐛 Fix incorrect JSON schema for `fileLocation` property

### DIFF
--- a/src/vs/workbench/contrib/tasks/common/problemMatcher.ts
+++ b/src/vs/workbench/contrib/tasks/common/problemMatcher.ts
@@ -1695,9 +1695,25 @@ export namespace Schemas {
 					},
 					{
 						type: 'array',
-						items: {
-							type: 'string'
-						},
+						prefixItems: [
+							{
+								type: 'string',
+								enum: ['absolute', 'relative', 'autoDetect', 'search']
+							},
+						],
+						minItems: 1,
+						maxItems: 1,
+						additionalItems: false
+					},
+					{
+						type: 'array',
+						prefixItems: [
+							{ type: 'string', enum: ['relative', 'autoDetect'] },
+							{ type: 'string' },
+						],
+						minItems: 2,
+						maxItems: 2,
+						additionalItems: false,
 						examples: [
 							['relative', '${workspaceFolder}'],
 							['autoDetect', '${workspaceFolder}'],
@@ -1705,7 +1721,7 @@ export namespace Schemas {
 					},
 					{
 						type: 'array',
-						items: [
+						prefixItems: [
 							{ type: 'string', enum: ['search'] },
 							{
 								type: 'object',
@@ -1726,6 +1742,8 @@ export namespace Schemas {
 								required: ['include']
 							}
 						],
+						minItems: 2,
+						maxItems: 2,
 						additionalItems: false,
 						examples: [
 							['search', { 'include': ['${workspaceFolder}'] }],


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fixes #168581

I should've used `prefixItems` (instead of `items`) for the tuples. This PR has fixed that.

Also, since use cases like `["absolute"]` are still in place (we have one in the current repository's `task.json`, [here](https://github.com/microsoft/vscode/blob/edd764b6dc4592449b988ef9779b99ffdc50dade/.vscode/tasks.json#L17)), I've included them, as well as `[ "relative" | "autoDetect" | "search" ]` in the schema, too.
