### PR TITLE
remove font-face from shadow dom css

### DIFF
--- a/src/vs/base/browser/ui/contextview/contextview.ts
+++ b/src/vs/base/browser/ui/contextview/contextview.ts
@@ -366,12 +366,6 @@ const SHADOW_ROOT_CSS = /* css */ `
 		all: initial; /* 1st rule so subsequent properties are reset. */
 	}
 
-	@font-face {
-		font-family: "codicon";
-		font-display: block;
-		src: url("./codicon.ttf?5d4d76ab2ce5108968ad644d591a16a6") format("truetype");
-	}
-
 	.codicon[class*='codicon-'] {
 		font: normal normal normal 16px/1 codicon;
 		display: inline-block;


### PR DESCRIPTION
fixes #159877

If I understand the issue correctly, I only need to avoid redefining font-face in the shadow dom. This did not seem to cause any issues, but I wasn't certain if it resolved the problem.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
