### PR TITLE
Unfreeze Git grammars

### DIFF
--- a/extensions/git-base/syntaxes/git-commit.tmLanguage.json
+++ b/extensions/git-base/syntaxes/git-commit.tmLanguage.json
@@ -1,8 +1,7 @@
 {
 	"information_for_contributors": [
-		"This file has been converted from https://github.com/textmate/git.tmbundle/blob/master/Syntaxes/Git%20Commit%20Message.tmLanguage",
-		"If you want to provide a fix or improvement, please create a pull request against the original repository.",
-		"Once accepted there, we are happy to receive an update request."
+		"This file was originally converted from https://github.com/textmate/git.tmbundle/blob/master/Syntaxes/Git%20Commit%20Message.tmLanguage",
+		"However, since that project is dead, changes are now welcome directly in here."
 	],
 	"version": "https://github.com/textmate/git.tmbundle/commit/93897a78c6e52bef13dadc0d4091d203c5facb40",
 	"name": "Git Commit Message",

--- a/extensions/git-base/syntaxes/git-rebase.tmLanguage.json
+++ b/extensions/git-base/syntaxes/git-rebase.tmLanguage.json
@@ -1,8 +1,7 @@
 {
 	"information_for_contributors": [
-		"This file has been converted from https://github.com/textmate/git.tmbundle/blob/master/Syntaxes/Git%20Rebase%20Message.tmLanguage",
-		"If you want to provide a fix or improvement, please create a pull request against the original repository.",
-		"Once accepted there, we are happy to receive an update request."
+		"This file was originally converted from https://github.com/textmate/git.tmbundle/blob/master/Syntaxes/Git%20Rebase%20Message.tmLanguage",
+		"However, since that project is dead, changes are now welcome directly in here."
 	],
 	"version": "https://github.com/textmate/git.tmbundle/commit/5870cf3f8abad3a6637bdf69250b5d2ded427dc4",
 	"name": "Git Rebase Message",


### PR DESCRIPTION
Before this change, editing the Git grammars required making PRs to https://github.com/textmate/git.tmbundle and then importing the new grammars in here.

However, that **upstream repo is dead**:
* No changes since 2019: https://github.com/textmate/git.tmbundle/commits/master
* Upstream test suite requires ruby 1.8.7, which is EOL since 2014:
  https://github.com/textmate/git.tmbundle/issues/59

With this change in place, it is now possible to make PRs to improve Git grammars, to solve problems like this one for example: https://github.com/microsoft/vscode/issues/133888

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
