### PR TITLE
Make symbol link icon to be refreshed correctly

### DIFF
--- a/src/vs/workbench/browser/labels.ts
+++ b/src/vs/workbench/browser/labels.ts
@@ -57,6 +57,11 @@ export interface IResourceLabelOptions extends IIconLabelValueOptions {
 	 * Will take the provided label as is and e.g. not override it for untitled files.
 	 */
 	readonly forceLabel?: boolean;
+
+	/**
+	 * Whether this resource is a symbolic link.
+	 */
+	readonly isSymbolicLink?: boolean;
 }
 
 export interface IFileLabelOptions extends IResourceLabelOptions {
@@ -456,6 +461,7 @@ class ResourceLabelWidget extends IconLabel {
 			}
 		}
 
+		const hasIsSymbolicLinkChanged = this.hasIsSymbolicLinkChanged(options);
 		const hasResourceChanged = this.hasResourceChanged(label);
 		const hasPathLabelChanged = hasResourceChanged || this.hasPathLabelChanged(label);
 		const hasFileKindChanged = this.hasFileKindChanged(options);
@@ -472,9 +478,16 @@ class ResourceLabelWidget extends IconLabel {
 		}
 
 		this.render({
-			updateIcon: hasResourceChanged || hasFileKindChanged,
-			updateDecoration: hasResourceChanged || hasFileKindChanged
+			updateIcon: hasResourceChanged || hasFileKindChanged || hasIsSymbolicLinkChanged,
+			updateDecoration: hasResourceChanged || hasFileKindChanged || hasIsSymbolicLinkChanged
 		});
+	}
+
+	private hasIsSymbolicLinkChanged(newOptions?: IResourceLabelOptions): boolean {
+		const isNewSymbolicLink = newOptions?.isSymbolicLink;
+		const isOldSymbolicLink = this.options?.isSymbolicLink;
+
+		return isNewSymbolicLink !== isOldSymbolicLink;
 	}
 
 	private hasFileKindChanged(newOptions?: IResourceLabelOptions): boolean {

--- a/src/vs/workbench/contrib/files/browser/views/explorerDecorationsProvider.ts
+++ b/src/vs/workbench/contrib/files/browser/views/explorerDecorationsProvider.ts
@@ -13,6 +13,7 @@ import { DisposableStore } from 'vs/base/common/lifecycle';
 import { explorerRootErrorEmitter } from 'vs/workbench/contrib/files/browser/views/explorerViewer';
 import { ExplorerItem } from 'vs/workbench/contrib/files/common/explorerModel';
 import { IExplorerService } from 'vs/workbench/contrib/files/browser/files';
+import { IFileService } from 'vs/platform/files/common/files';
 
 export function provideDecorations(fileStat: ExplorerItem): IDecorationData | undefined {
 	if (fileStat.isRoot && fileStat.isError) {
@@ -50,7 +51,8 @@ export class ExplorerDecorationsProvider implements IDecorationsProvider {
 
 	constructor(
 		@IExplorerService private explorerService: IExplorerService,
-		@IWorkspaceContextService contextService: IWorkspaceContextService
+		@IWorkspaceContextService contextService: IWorkspaceContextService,
+		@IFileService fileService: IFileService,
 	) {
 		this.toDispose.add(this._onDidChange);
 		this.toDispose.add(contextService.onDidChangeWorkspaceFolders(e => {
@@ -59,6 +61,9 @@ export class ExplorerDecorationsProvider implements IDecorationsProvider {
 		this.toDispose.add(explorerRootErrorEmitter.event((resource => {
 			this._onDidChange.fire([resource]);
 		})));
+		this.toDispose.add(fileService.onDidFilesChange(e => {
+			this._onDidChange.fire([...e.rawAdded, ...e.rawUpdated]);
+		}));
 	}
 
 	get onDidChange(): Event<URI[]> {

--- a/src/vs/workbench/contrib/files/browser/views/explorerView.ts
+++ b/src/vs/workbench/contrib/files/browser/views/explorerView.ts
@@ -719,7 +719,7 @@ export class ExplorerView extends ViewPane implements IExplorerView {
 
 		await promise;
 		if (!this.decorationsProvider) {
-			this.decorationsProvider = new ExplorerDecorationsProvider(this.explorerService, this.contextService);
+			this.decorationsProvider = new ExplorerDecorationsProvider(this.explorerService, this.contextService, this.fileService);
 			this._register(this.decorationService.registerDecorationsProvider(this.decorationsProvider));
 		}
 	}

--- a/src/vs/workbench/contrib/files/browser/views/explorerViewer.ts
+++ b/src/vs/workbench/contrib/files/browser/views/explorerViewer.ts
@@ -418,6 +418,7 @@ export class FilesRenderer implements ICompressibleTreeRenderer<ExplorerItem, Fu
 			fileKind: stat.isRoot ? FileKind.ROOT_FOLDER : stat.isDirectory ? FileKind.FOLDER : FileKind.FILE,
 			extraClasses: realignNestedChildren ? [...extraClasses, 'align-nest-icon-with-parent-icon'] : extraClasses,
 			fileDecorations: this.config.explorer.decorations,
+			isSymbolicLink: stat.isSymbolicLink,
 			matches: createMatches(filterData),
 			separator: this.labelService.getSeparator(stat.resource.scheme, stat.resource.authority),
 			domId


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

#167146

Another try to fix #167146 by reference https://github.com/microsoft/vscode/pull/167828#issuecomment-1339197955

This PR makes the following changes:
- `IDecorationsProvider` is able to fire another event `onForceRefresh`, to tell which URI need to be refreshed.
- `DecorationsService` will listen to the event, record the `URI`s that need to be refreshed. And when getting values, it will get the fresh value rather than cache from the `IDecorationsProvider` if the `IDecorationsProvider` and `URI` are both same.

However, this PR is kind of noisy, because it adds `onForceRefresh` to all `IDecorationsProvider`s. Should this method be optional?