### PR TITLE
Apply token style also to the text content of a wide cursor

### DIFF
--- a/src/vs/editor/browser/viewParts/viewCursors/viewCursor.ts
+++ b/src/vs/editor/browser/viewParts/viewCursors/viewCursor.ts
@@ -136,6 +136,7 @@ export class ViewCursor {
 
 	private _prepareRender(ctx: RenderingContext): ViewCursorRenderData | null {
 		let textContent = '';
+		let textContentClassName = '';
 		const [position, nextGrapheme] = this._getGraphemeAwarePosition();
 
 		if (this._cursorStyle === TextEditorCursorStyle.Line || this._cursorStyle === TextEditorCursorStyle.LineThin) {
@@ -150,6 +151,7 @@ export class ViewCursor {
 				width = dom.computeScreenAwareSize(this._lineCursorWidth > 0 ? this._lineCursorWidth : 2);
 				if (width > 2) {
 					textContent = nextGrapheme;
+					textContentClassName = this._getTokenClassName(position);
 				}
 			} else {
 				width = dom.computeScreenAwareSize(1);
@@ -164,7 +166,7 @@ export class ViewCursor {
 			}
 
 			const top = ctx.getVerticalOffsetForLineNumber(position.lineNumber) - ctx.bigNumbersDelta;
-			return new ViewCursorRenderData(top, left, paddingLeft, width, this._lineHeight, textContent, '');
+			return new ViewCursorRenderData(top, left, paddingLeft, width, this._lineHeight, textContent, textContentClassName);
 		}
 
 		const visibleRangeForCharacter = ctx.linesVisibleRangesForRange(new Range(position.lineNumber, position.column, position.lineNumber, position.column + nextGrapheme.length), false);
@@ -188,12 +190,9 @@ export class ViewCursor {
 					: range.width)
 		);
 
-		let textContentClassName = '';
 		if (this._cursorStyle === TextEditorCursorStyle.Block) {
-			const lineData = this._context.viewModel.getViewLineData(position.lineNumber);
 			textContent = nextGrapheme;
-			const tokenIndex = lineData.tokens.findTokenIndexAtOffset(position.column - 1);
-			textContentClassName = lineData.tokens.getClassName(tokenIndex);
+			textContentClassName = this._getTokenClassName(position);
 		}
 
 		let top = ctx.getVerticalOffsetForLineNumber(position.lineNumber) - ctx.bigNumbersDelta;
@@ -206,6 +205,12 @@ export class ViewCursor {
 		}
 
 		return new ViewCursorRenderData(top, range.left, 0, width, height, textContent, textContentClassName);
+	}
+
+	private _getTokenClassName(position: Position): string {
+		const lineData = this._context.viewModel.getViewLineData(position.lineNumber);
+		const tokenIndex = lineData.tokens.findTokenIndexAtOffset(position.column - 1);
+		return lineData.tokens.getClassName(tokenIndex);
 	}
 
 	public prepareRender(ctx: RenderingContext): void {


### PR DESCRIPTION
Fixes #129696