### PR TITLE
Revert "only renderBody when view is visible/expanded (#165187)"

### DIFF
--- a/src/vs/base/browser/ui/splitview/paneview.ts
+++ b/src/vs/base/browser/ui/splitview/paneview.ts
@@ -58,7 +58,6 @@ export abstract class Pane extends Disposable implements IView {
 
 	private expandedSize: number | undefined = undefined;
 	private _headerVisible = true;
-	private _bodyRendered = false;
 	private _minimumBodySize: number;
 	private _maximumBodySize: number;
 	private _ariaHeaderLabel: string;
@@ -159,11 +158,6 @@ export abstract class Pane extends Disposable implements IView {
 		this.updateHeader();
 
 		if (expanded) {
-			if (!this._bodyRendered) {
-				this.renderBody(this.body);
-				this._bodyRendered = true;
-			}
-
 			if (typeof this.animationTimer === 'number') {
 				clearTimeout(this.animationTimer);
 			}
@@ -255,13 +249,7 @@ export abstract class Pane extends Disposable implements IView {
 		});
 
 		this.body = append(this.element, $('.pane-body'));
-
-		// Only render the body if it will be visible
-		// Otherwise, render it when the pane is expanded
-		if (!this._bodyRendered && this.isExpanded()) {
-			this.renderBody(this.body);
-			this._bodyRendered = true;
-		}
+		this.renderBody(this.body);
 
 		if (!this.isExpanded()) {
 			this.body.remove();


### PR DESCRIPTION
This reverts commit 8f06fd3722cc621bdeba2209780de9fc3725fd58.

Fixes #168703