### PR TITLE
Dark+ V2: match panel color to rest of the workbench

### DIFF
--- a/extensions/theme-defaults/themes/dark_plus_experimental.json
+++ b/extensions/theme-defaults/themes/dark_plus_experimental.json
@@ -68,7 +68,7 @@
 		"notifications.background": "#1f1f1f",
 		"notifications.border": "#ffffff15",
 		"notifications.foreground": "#ffffffc5",
-		"panel.background": "#1f1f1f",
+		"panel.background": "#181818",
 		"panel.border": "#ffffff15",
 		"panelInput.border": "#ffffff15",
 		"panelTitle.activeBorder": "#2488d8",


### PR DESCRIPTION
Fix https://github.com/microsoft/vscode/issues/168904

![CleanShot 2022-12-12 at 12 27 17@2x](https://user-images.githubusercontent.com/25163139/207147771-656af1ed-0769-4c57-ac8b-9385896d1998.png)

cc @Tyriar 