### PR TITLE
[remote tunnel] cannot start with a host name that starts with dash

### DIFF
--- a/src/vs/platform/remoteTunnel/electron-browser/remoteTunnelService.ts
+++ b/src/vs/platform/remoteTunnel/electron-browser/remoteTunnelService.ts
@@ -19,6 +19,7 @@ import { IConfigurationService } from 'vs/platform/configuration/common/configur
 import { localize } from 'vs/nls';
 import { hostname, homedir } from 'os';
 import { URI } from 'vs/base/common/uri';
+import { CharCode } from 'vs/base/common/charCode';
 
 type RemoteTunnelEnablementClassification = {
 	owner: 'aeschli';
@@ -285,8 +286,19 @@ export class RemoteTunnelService extends Disposable implements IRemoteTunnelServ
 
 	private _getHostName(): string | undefined {
 		let name = this.configurationService.getValue<string>(CONFIGURATION_KEY_HOST_NAME) || hostname();
-		name = name.replace(/[^\w-]/g, '').substring(0, 20);
+		name = _removeLeadingDashes(name).replace(/[^\w-]/g, '').substring(0, 20);
 		return name || undefined;
 	}
 
+}
+
+function _removeLeadingDashes(name: string): string {
+	let i = 0;
+	while (i < name.length && name.codePointAt(i) === CharCode.Dash) {
+		i++;
+	}
+	if (i > 0) {
+		return name.substring(i);
+	}
+	return name;
 }

--- a/src/vs/workbench/contrib/remoteTunnel/electron-sandbox/remoteTunnel.contribution.ts
+++ b/src/vs/workbench/contrib/remoteTunnel/electron-sandbox/remoteTunnel.contribution.ts
@@ -754,8 +754,8 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).regis
 			description: localize('remoteTunnelAccess.machineName', "The name under which the remote tunnel access is registered. If not set, the host name is used."),
 			type: 'string',
 			scope: ConfigurationScope.MACHINE,
-			pattern: '^[\\w-]*$',
-			patternErrorMessage: localize('remoteTunnelAccess.machineNameRegex', "The name can only consist of letters, numbers, underscore and minus."),
+			pattern: '^\\w[\\w-]*$',
+			patternErrorMessage: localize('remoteTunnelAccess.machineNameRegex', "The name must only consist of letters, numbers, underscore and dash. It must not start with a dash."),
 			maxLength: 20,
 			default: ''
 		}


### PR DESCRIPTION
Fixes #168736