### PR TITLE
Git - Remove double quotation mark from the property value

### DIFF
--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -711,7 +711,7 @@ interface GitConfigSection {
 class GitConfigParser {
 	private static readonly _lineSeparator = /\r?\n/;
 
-	private static readonly _propertyRegex = /^\s*(\w+)\s*=\s*(.*)$/;
+	private static readonly _propertyRegex = /^\s*(\w+)\s*=\s*"?([^"]+)"?$/;
 	private static readonly _sectionRegex = /^\s*\[\s*([^\]]+?)\s*(\"[^"]+\")*\]\s*$/;
 
 	static parse(raw: string): GitConfigSection[] {


### PR DESCRIPTION
Fixes #157872