### PR TITLE
When `tabSize` is set via API, also set `indentSize` to the same value

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadEditor.ts
+++ b/src/vs/workbench/api/browser/mainThreadEditor.ts
@@ -377,6 +377,7 @@ export class MainThreadTextEditor {
 		}
 		if (typeof newConfiguration.tabSize !== 'undefined') {
 			newOpts.tabSize = newConfiguration.tabSize;
+			newOpts.indentSize = newConfiguration.tabSize;
 		}
 		if (typeof newConfiguration.indentSize !== 'undefined') {
 			if (newConfiguration.indentSize === 'tabSize') {


### PR DESCRIPTION
Fixes #168836 for stable. The better fix (for `main`) is at https://github.com/microsoft/vscode/pull/168984