### PR TITLE
Mark extension ids as exempt from cleaning

### DIFF
--- a/src/vs/platform/extensionManagement/common/extensionManagementUtil.ts
+++ b/src/vs/platform/extensionManagement/common/extensionManagementUtil.ts
@@ -12,6 +12,7 @@ import { URI } from 'vs/base/common/uri';
 import { getErrorMessage } from 'vs/base/common/errors';
 import { ILogService } from 'vs/platform/log/common/log';
 import { arch } from 'vs/base/common/process';
+import { TrustedTelemetryValue } from 'vs/platform/telemetry/common/telemetryUtils';
 
 export function areSameExtensions(a: IExtensionIdentifier, b: IExtensionIdentifier): boolean {
 	if (a.uuid && b.uuid) {
@@ -133,8 +134,8 @@ export function getLocalExtensionTelemetryData(extension: ILocalExtension): any 
 */
 export function getGalleryExtensionTelemetryData(extension: IGalleryExtension): any {
 	return {
-		id: extension.identifier.id,
-		name: extension.name,
+		id: new TrustedTelemetryValue(extension.identifier.id),
+		name: new TrustedTelemetryValue(extension.name),
 		galleryId: extension.identifier.uuid,
 		publisherId: extension.publisherId,
 		publisherName: extension.publisher,

--- a/src/vs/workbench/api/common/extHostCommands.ts
+++ b/src/vs/workbench/api/common/extHostCommands.ts
@@ -27,6 +27,7 @@ import { SerializableObjectWithBuffers } from 'vs/workbench/services/extensions/
 import { toErrorMessage } from 'vs/base/common/errorMessage';
 import { StopWatch } from 'vs/base/common/stopwatch';
 import { IExtensionDescription } from 'vs/platform/extensions/common/extensions';
+import { TrustedTelemetryValue } from 'vs/platform/telemetry/common/telemetryUtils';
 
 interface CommandHandler {
 	callback: Function;
@@ -273,7 +274,7 @@ export class ExtHostCommands implements ExtHostCommandsShape {
 		}
 		type ExtensionActionTelemetry = {
 			extensionId: string;
-			id: string;
+			id: TrustedTelemetryValue<string>;
 			duration: number;
 		};
 		type ExtensionActionTelemetryMeta = {
@@ -285,7 +286,7 @@ export class ExtHostCommands implements ExtHostCommandsShape {
 		};
 		this.#telemetry.$publicLog2<ExtensionActionTelemetry, ExtensionActionTelemetryMeta>('Extension:ActionExecuted', {
 			extensionId: command.extension.identifier.value,
-			id: id,
+			id: new TrustedTelemetryValue(id),
 			duration: duration,
 		});
 	}

--- a/src/vs/workbench/browser/parts/views/treeView.ts
+++ b/src/vs/workbench/browser/parts/views/treeView.ts
@@ -68,6 +68,7 @@ import { addExternalEditorsDropData, toVSDataTransfer } from 'vs/editor/browser/
 import { CheckboxStateHandler, TreeItemCheckbox } from 'vs/workbench/browser/parts/views/checkbox';
 import { setTimeout0 } from 'vs/base/common/platform';
 import { AriaRole } from 'vs/base/browser/ui/aria/aria';
+import { TrustedTelemetryValue } from 'vs/platform/telemetry/common/telemetryUtils';
 
 export class TreeViewPane extends ViewPane {
 
@@ -1463,7 +1464,7 @@ export class CustomTreeView extends AbstractTreeView {
 	protected activate() {
 		if (!this.activated) {
 			type ExtensionViewTelemetry = {
-				extensionId: string;
+				extensionId: TrustedTelemetryValue<string>;
 				id: string;
 			};
 			type ExtensionViewTelemetryMeta = {
@@ -1473,7 +1474,7 @@ export class CustomTreeView extends AbstractTreeView {
 				comment: 'Helps to gain insights on what extension contributed views are most popular';
 			};
 			this.telemetryService.publicLog2<ExtensionViewTelemetry, ExtensionViewTelemetryMeta>('Extension:ViewActivate', {
-				extensionId: this.extensionId,
+				extensionId: new TrustedTelemetryValue(this.extensionId),
 				id: this.id,
 			});
 			this.createTree();

--- a/src/vs/workbench/contrib/extensions/browser/extensionsWorkbenchService.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsWorkbenchService.ts
@@ -48,13 +48,14 @@ import { ExtensionEditor } from 'vs/workbench/contrib/extensions/browser/extensi
 import { isWeb, language } from 'vs/base/common/platform';
 import { getLocale } from 'vs/platform/languagePacks/common/languagePacks';
 import { ILocaleService } from 'vs/workbench/contrib/localization/common/locale';
+import { TrustedTelemetryValue } from 'vs/platform/telemetry/common/telemetryUtils';
 
 interface IExtensionStateProvider<T> {
 	(extension: Extension): T;
 }
 
 interface InstalledExtensionsEvent {
-	readonly extensionIds: string;
+	readonly extensionIds: TrustedTelemetryValue<string>;
 	readonly count: number;
 }
 type ExtensionsLoadClassification = {
@@ -800,7 +801,7 @@ export class ExtensionsWorkbenchService extends Disposable implements IExtension
 			(extension.enablementState === EnablementState.EnabledWorkspace ||
 				extension.enablementState === EnablementState.EnabledGlobally))
 			.map(extension => ExtensionIdentifier.toKey(extension.identifier.id));
-		this.telemetryService.publicLog2<InstalledExtensionsEvent, ExtensionsLoadClassification>('installedExtensions', { extensionIds: extensionIds.join(';'), count: extensionIds.length });
+		this.telemetryService.publicLog2<InstalledExtensionsEvent, ExtensionsLoadClassification>('installedExtensions', { extensionIds: new TrustedTelemetryValue(extensionIds.join(';')), count: extensionIds.length });
 	}
 
 	private async onDidChangeRunningExtensions(added: ReadonlyArray<IExtensionDescription>, removed: ReadonlyArray<IExtensionDescription>): Promise<void> {


### PR DESCRIPTION
Extension ids are public identifiers from the marketplace and therefore shouldn't contain PII so there is no need to clean them.