### PR TITLE
update path version to node 16.14.2

### DIFF
--- a/src/vs/base/common/path.ts
+++ b/src/vs/base/common/path.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 // NOTE: VSCode's copy of nodejs path library to be usable in common (non-node) namespace
-// Copied from: https://github.com/nodejs/node/blob/v14.16.0/lib/path.js
+// Copied from: https://github.com/nodejs/node/blob/v16.14.2/lib/path.js
 
 /**
  * Copyright Joyent, Inc. and other Node contributors.
@@ -63,11 +63,19 @@ class ErrorInvalidArgType extends Error {
 	}
 }
 
+function validateObject(pathObject: object, name: string) {
+	if (pathObject === null || typeof pathObject !== 'object') {
+		throw new ErrorInvalidArgType(name, 'Object', pathObject);
+	}
+}
+
 function validateString(value: string, name: string) {
 	if (typeof value !== 'string') {
 		throw new ErrorInvalidArgType(name, 'string', value);
 	}
 }
+
+const platformIsWin32 = (process.platform === 'win32');
 
 function isPathSeparator(code: number | undefined) {
 	return code === CHAR_FORWARD_SLASH || code === CHAR_BACKWARD_SLASH;
@@ -152,9 +160,7 @@ function normalizeString(path: string, allowAboveRoot: boolean, separator: strin
 }
 
 function _format(sep: string, pathObject: ParsedPath) {
-	if (pathObject === null || typeof pathObject !== 'object') {
-		throw new ErrorInvalidArgType('pathObject', 'Object', pathObject);
-	}
+	validateObject(pathObject, 'pathObject');
 	const dir = pathObject.dir || pathObject.root;
 	const base = pathObject.base ||
 		`${pathObject.name || ''}${pathObject.ext || ''}`;
@@ -634,12 +640,8 @@ export const win32: IPath = {
 
 	toNamespacedPath(path: string): string {
 		// Note: this will *probably* throw somewhere.
-		if (typeof path !== 'string') {
+		if (typeof path !== 'string' || path.length === 0) {
 			return path;
-		}
-
-		if (path.length === 0) {
-			return '';
 		}
 
 		const resolvedPath = win32.resolve(path);
@@ -1069,6 +1071,21 @@ export const win32: IPath = {
 	posix: null
 };
 
+const posixCwd = (() => {
+	if (platformIsWin32) {
+		// Converts Windows' backslash path separators to POSIX forward slashes
+		// and truncates any drive indicator
+		const regexp = /\\/g;
+		return () => {
+			const cwd = process.cwd().replace(regexp, '/');
+			return cwd.slice(cwd.indexOf('/'));
+		};
+	}
+
+	// We're already on POSIX, no need for any transformations
+	return () => process.cwd();
+})();
+
 export const posix: IPath = {
 	// path.resolve([from ...], to)
 	resolve(...pathSegments: string[]): string {
@@ -1076,7 +1093,7 @@ export const posix: IPath = {
 		let resolvedAbsolute = false;
 
 		for (let i = pathSegments.length - 1; i >= -1 && !resolvedAbsolute; i--) {
-			const path = i >= 0 ? pathSegments[i] : process.cwd();
+			const path = i >= 0 ? pathSegments[i] : posixCwd();
 
 			validateString(path, 'path');
 
@@ -1491,16 +1508,16 @@ export const posix: IPath = {
 posix.win32 = win32.win32 = win32;
 posix.posix = win32.posix = posix;
 
-export const normalize = (process.platform === 'win32' ? win32.normalize : posix.normalize);
-export const isAbsolute = (process.platform === 'win32' ? win32.isAbsolute : posix.isAbsolute);
-export const join = (process.platform === 'win32' ? win32.join : posix.join);
-export const resolve = (process.platform === 'win32' ? win32.resolve : posix.resolve);
-export const relative = (process.platform === 'win32' ? win32.relative : posix.relative);
-export const dirname = (process.platform === 'win32' ? win32.dirname : posix.dirname);
-export const basename = (process.platform === 'win32' ? win32.basename : posix.basename);
-export const extname = (process.platform === 'win32' ? win32.extname : posix.extname);
-export const format = (process.platform === 'win32' ? win32.format : posix.format);
-export const parse = (process.platform === 'win32' ? win32.parse : posix.parse);
-export const toNamespacedPath = (process.platform === 'win32' ? win32.toNamespacedPath : posix.toNamespacedPath);
-export const sep = (process.platform === 'win32' ? win32.sep : posix.sep);
-export const delimiter = (process.platform === 'win32' ? win32.delimiter : posix.delimiter);
+export const normalize = (platformIsWin32 ? win32.normalize : posix.normalize);
+export const isAbsolute = (platformIsWin32 ? win32.isAbsolute : posix.isAbsolute);
+export const join = (platformIsWin32 ? win32.join : posix.join);
+export const resolve = (platformIsWin32 ? win32.resolve : posix.resolve);
+export const relative = (platformIsWin32 ? win32.relative : posix.relative);
+export const dirname = (platformIsWin32 ? win32.dirname : posix.dirname);
+export const basename = (platformIsWin32 ? win32.basename : posix.basename);
+export const extname = (platformIsWin32 ? win32.extname : posix.extname);
+export const format = (platformIsWin32 ? win32.format : posix.format);
+export const parse = (platformIsWin32 ? win32.parse : posix.parse);
+export const toNamespacedPath = (platformIsWin32 ? win32.toNamespacedPath : posix.toNamespacedPath);
+export const sep = (platformIsWin32 ? win32.sep : posix.sep);
+export const delimiter = (platformIsWin32 ? win32.delimiter : posix.delimiter);

--- a/src/vs/base/test/common/path.test.ts
+++ b/src/vs/base/test/common/path.test.ts
@@ -360,7 +360,7 @@ suite('Paths (Node Implementation)', () => {
 		assert.strictEqual(path.extname('far.boo/boo'), '');
 	});
 
-	(isWeb && isWindows ? test.skip : test)('resolve', () => { // TODO@sbatten fails on windows & browser only
+	test('resolve', () => {
 		const failures = [] as string[];
 		const slashRE = /\//g;
 		const backslashRE = /\\/g;
@@ -372,7 +372,6 @@ suite('Paths (Node Implementation)', () => {
 			[['c:/ignore', 'd:\\a/b\\c/d', '\\e.exe'], 'd:\\e.exe'],
 			[['c:/ignore', 'c:/some/file'], 'c:\\some\\file'],
 			[['d:/ignore', 'd:some/dir//'], 'd:\\ignore\\some\\dir'],
-			[['.'], process.cwd()],
 			[['//server/share', '..', 'relative\\'], '\\\\server\\share\\relative'],
 			[['c:/', '//'], 'c:\\'],
 			[['c:/', '//dir'], 'c:\\dir'],
@@ -387,12 +386,16 @@ suite('Paths (Node Implementation)', () => {
 			// arguments                    result
 			[[['/var/lib', '../', 'file/'], '/var/file'],
 			[['/var/lib', '/../', 'file/'], '/file'],
-			[['a/b/c/', '../../..'], process.cwd()],
-			[['.'], process.cwd()],
 			[['/some/dir', '.', '/absolute/'], '/absolute'],
 			[['/foo/tmp.3/', '../tmp.3/cycles/root.js'], '/foo/tmp.3/cycles/root.js']
 			]
+			],
+			[(isWeb ? path.posix.resolve : path.resolve),
+			// arguments						result
+			[[['.'], process.cwd()],
+			[['a/b/c', '../../..'], process.cwd()]
 			]
+			],
 		];
 		resolveTests.forEach((test) => {
 			const resolve = test[0];


### PR DESCRIPTION
+fix unit tests
fixes https://github.com/microsoft/vscode/issues/146317

I tested on macOS/Windows and test-browser for both.  I verified with the corresponding node version that the failing test was giving the same value. Since it was, I moved the relative path resolution to a platform dependent set. On web, this will always use posix.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
