### PR TITLE
Align lifecycle of toggles to be similar to titlebar buttons

### DIFF
--- a/src/vs/base/browser/ui/findinput/findInput.ts
+++ b/src/vs/base/browser/ui/findinput/findInput.ts
@@ -269,6 +269,11 @@ export class FindInput extends Widget {
 	}
 
 	public setAdditionalToggles(toggles: Toggle[] | undefined): void {
+		// Short circuit if there are no toggles to update
+		if (!this.additionalToggles.length && !toggles?.length) {
+			return;
+		}
+
 		for (const currentToggle of this.additionalToggles) {
 			currentToggle.domNode.remove();
 		}


### PR DESCRIPTION
Fixes #168199

Also moves the toggles to the QuickInput class in case we ever want to use them for InputBoxes.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
