### PR TITLE
Move quick input progress bar below text input

### DIFF
--- a/src/vs/base/parts/quickinput/browser/media/quickInput.css
+++ b/src/vs/base/parts/quickinput/browser/media/quickInput.css
@@ -17,6 +17,8 @@
 .quick-input-titlebar {
 	display: flex;
 	align-items: center;
+	border-top-left-radius: 5px; /* match border radius of quick input widget */
+	border-top-right-radius: 5px;
 }
 
 .quick-input-left-action-bar {
@@ -58,8 +60,7 @@
 
 .quick-input-header {
 	display: flex;
-	padding: 8px 6px 0px 6px;
-	margin-bottom: -2px;
+	padding: 8px 6px 6px 6px;
 }
 
 .quick-input-widget.hidden-input .quick-input-header {
@@ -151,8 +152,6 @@
 
 .quick-input-list {
 	line-height: 22px;
-	margin-top: 6px;
-	padding: 1px;
 }
 
 .quick-input-widget.hidden-input .quick-input-list {

--- a/src/vs/base/parts/quickinput/browser/quickInput.ts
+++ b/src/vs/base/parts/quickinput/browser/quickInput.ts
@@ -1311,6 +1311,9 @@ export class QuickInputController extends Disposable {
 
 		const message = dom.append(extraContainer, $(`#${this.idPrefix}message.quick-input-message`));
 
+		const progressBar = new ProgressBar(container, this.styles.progressBar);
+		progressBar.getContainer().classList.add('quick-input-progress');
+
 		const list = this._register(new QuickInputList(container, this.idPrefix + 'list', this.options));
 		this._register(list.onChangedAllVisibleChecked(checked => {
 			checkAll.checked = checked;
@@ -1335,9 +1338,6 @@ export class QuickInputController extends Disposable {
 				this.getUI().inputBox.setAttribute('aria-activedescendant', this.getUI().list.getActiveDescendant() || '');
 			}
 		}));
-
-		const progressBar = new ProgressBar(container, this.styles.progressBar);
-		progressBar.getContainer().classList.add('quick-input-progress');
 
 		const focusTracker = dom.trackFocus(container);
 		this._register(focusTracker);


### PR DESCRIPTION
- Fix #167507 moving progress bar below the input box. This also fixes an issue where there was 2px of empty space at the bottom of the list even if the bar wasn't visible. This is now instead factored in when calculating the space underneath the text input (6px instead of 8px). Note that the scrollbar now longer appears floating in space when scrolled all the way to the bottom.
- Minor padding/border radius fixes

<img width="620" alt="CleanShot 2022-12-13 at 11 43 37@2x" src="https://user-images.githubusercontent.com/25163139/207429786-6cb91ff8-843a-4782-a5ec-451d2809805a.png">

<img width="609" alt="CleanShot 2022-12-13 at 11 45 15@2x" src="https://user-images.githubusercontent.com/25163139/207429797-09a64dc8-5fda-4121-a868-958bf24805bd.png">
