### PR TITLE
Fix sticky scroll background within peek views in v2 themes

### DIFF
--- a/extensions/theme-defaults/themes/dark_plus_experimental.json
+++ b/extensions/theme-defaults/themes/dark_plus_experimental.json
@@ -74,7 +74,7 @@
 		"panelTitle.activeBorder": "#2488d8",
 		"panelTitle.activeForeground": "#ffffffc5",
 		"panelTitle.inactiveForeground": "#8b949e",
-		"peekViewEditor.background": "#6e76811a",
+		"peekViewEditor.background": "#1f1f1f",
 		"peekViewEditor.matchHighlightBackground": "#bb800966",
 		"peekViewResult.background": "#1f1f1f",
 		"peekViewResult.matchHighlightBackground": "#bb800966",

--- a/extensions/theme-defaults/themes/light_plus_experimental.json
+++ b/extensions/theme-defaults/themes/light_plus_experimental.json
@@ -81,7 +81,6 @@
 		"panelTitle.activeBorder": "#005FB8",
 		"panelTitle.activeForeground": "#000000e4",
 		"panelTitle.inactiveForeground": "#000000e4",
-		"peekViewEditor.background": "#6e76811a",
 		"peekViewEditor.matchHighlightBackground": "#bb800966",
 		"peekViewResult.background": "#ffffff",
 		"peekViewResult.matchHighlightBackground": "#bb800966",


### PR DESCRIPTION
Fix #168372

<img width="603" alt="CleanShot 2022-12-13 at 11 59 38@2x" src="https://user-images.githubusercontent.com/25163139/207432308-ef25411a-8993-4b07-b54a-fef9a31117df.png">

<img width="606" alt="CleanShot 2022-12-13 at 11 59 44@2x" src="https://user-images.githubusercontent.com/25163139/207432312-6d1a6774-6e58-4e36-b403-1738dcfa27a4.png">
