### PR TITLE
Fix conditionals for visibility for input box and progress

### DIFF
--- a/src/vs/base/parts/quickinput/browser/quickInput.ts
+++ b/src/vs/base/parts/quickinput/browser/quickInput.ts
@@ -992,15 +992,14 @@ class QuickPick<T extends IQuickPickItem> extends QuickInput implements IQuickPi
 		}
 		// store the scrollTop before it is reset
 		const scrollTopBefore = this.keepScrollPosition ? this.scrollTop : 0;
-		const hideInput = !!this._hideInput && this._items.length > 0;
-		this.ui.container.classList.toggle('hidden-input', hideInput && !this.description);
+		const hasDescription = !!this.description;
 		const visibilities: Visibilities = {
 			title: !!this.title || !!this.step || !!this.buttons.length,
-			description: !!this.description,
+			description: hasDescription,
 			checkAll: this.canSelectMany && !this._hideCheckAll,
 			checkBox: this.canSelectMany,
-			inputBox: !hideInput,
-			progressBar: !hideInput,
+			inputBox: !this._hideInput,
+			progressBar: !this._hideInput || hasDescription,
 			visibleCount: true,
 			count: this.canSelectMany,
 			ok: this.ok === 'default' ? this.canSelectMany : this.ok,
@@ -1696,6 +1695,7 @@ export class QuickInputController extends Disposable {
 		ui.progressBar.getContainer().style.display = visibilities.progressBar ? '' : 'none';
 		ui.list.display(!!visibilities.list);
 		ui.container.classList.toggle('show-checkboxes', !!visibilities.checkBox);
+		ui.container.classList.toggle('hidden-input', !visibilities.inputBox && !visibilities.description);
 		this.updateLayout(); // TODO
 	}
 


### PR DESCRIPTION
I think this is left over from a previous PR of mine https://github.com/microsoft/vscode/pull/122054/files

Previously if there were no items in the quick pick, the input box would be forced. Additionally, if there was no input box, no progress would be shown.

Both of this don't make a ton of sense from the user's perspective so I've updated that to:

* hide the input if it's been asked to be hidden
* show the progress bar regardless of whether the input is shown

The only exception to the second rule is if there is no input and no description which means we're in a `Ctrl`+`Tab` quick behavior.

Fixes #167554

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
