### PR TITLE
Reduce unused exports

### DIFF
--- a/src/vs/workbench/contrib/search/browser/searchWidget.ts
+++ b/src/vs/workbench/contrib/search/browser/searchWidget.ts
@@ -38,7 +38,7 @@ import { showHistoryKeybindingHint } from 'vs/platform/history/browser/historyWi
 import { defaultInputBoxStyles, defaultToggleStyles } from 'vs/platform/theme/browser/defaultStyles';
 
 /** Specified in searchview.css */
-export const SingleLineInputHeight = 24;
+const SingleLineInputHeight = 24;
 
 export interface ISearchWidgetOptions {
 	value?: string;

--- a/src/vs/workbench/services/search/common/fileSearchManager.ts
+++ b/src/vs/workbench/services/search/common/fileSearchManager.ts
@@ -13,7 +13,7 @@ import { URI } from 'vs/base/common/uri';
 import { IFileMatch, IFileSearchProviderStats, IFolderQuery, ISearchCompleteStats, IFileQuery, QueryGlobTester, resolvePatternsForProvider, hasSiblingFn } from 'vs/workbench/services/search/common/search';
 import { FileSearchProvider, FileSearchOptions } from 'vs/workbench/services/search/common/searchExtTypes';
 
-export interface IInternalFileMatch {
+interface IInternalFileMatch {
 	base: URI;
 	original?: URI;
 	relativePath?: string; // Not present for extraFiles or absolute path matches
@@ -21,13 +21,13 @@ export interface IInternalFileMatch {
 	size?: number;
 }
 
-export interface IDirectoryEntry {
+interface IDirectoryEntry {
 	base: URI;
 	relativePath: string;
 	basename: string;
 }
 
-export interface IDirectoryTree {
+interface IDirectoryTree {
 	rootEntries: IDirectoryEntry[];
 	pathToEntries: { [relativePath: string]: IDirectoryEntry[] };
 }

--- a/src/vs/workbench/services/search/common/queryBuilder.ts
+++ b/src/vs/workbench/services/search/common/queryBuilder.ts
@@ -26,7 +26,7 @@ import { getExcludes, ICommonQueryProps, IFileQuery, IFolderQuery, IPatternInfo,
 /**
  * One folder to search and a glob expression that should be applied.
  */
-export interface IOneSearchPathPattern {
+interface IOneSearchPathPattern {
 	searchPath: uri;
 	pattern?: string;
 }
@@ -47,7 +47,7 @@ export interface ISearchPathsInfo {
 	pattern?: glob.IExpression;
 }
 
-export interface ICommonQueryBuilderOptions {
+interface ICommonQueryBuilderOptions {
 	_reason?: string;
 	excludePattern?: string | string[];
 	includePattern?: string | string[];

--- a/src/vs/workbench/services/search/node/fileSearch.ts
+++ b/src/vs/workbench/services/search/node/fileSearch.ts
@@ -716,7 +716,7 @@ class AbsoluteAndRelativeParsedExpression {
 	}
 }
 
-export function rgErrorMsgForDisplay(msg: string): string | undefined {
+function rgErrorMsgForDisplay(msg: string): string | undefined {
 	const lines = msg.trim().split('\n');
 	const firstLine = lines[0].trim();
 

--- a/src/vs/workbench/services/search/node/rawSearchService.ts
+++ b/src/vs/workbench/services/search/node/rawSearchService.ts
@@ -18,7 +18,7 @@ import { Engine as FileSearchEngine } from 'vs/workbench/services/search/node/fi
 import { TextSearchEngineAdapter } from 'vs/workbench/services/search/node/textSearchAdapter';
 
 export type IProgressCallback = (p: ISerializedSearchProgressItem) => void;
-export type IFileProgressCallback = (p: IFileSearchProgressItem) => void;
+type IFileProgressCallback = (p: IFileSearchProgressItem) => void;
 
 export class SearchService implements IRawSearchService {
 

--- a/src/vs/workbench/services/search/node/ripgrepFileSearch.ts
+++ b/src/vs/workbench/services/search/node/ripgrepFileSearch.ts
@@ -82,12 +82,12 @@ function getRgArgs(config: IFileQuery, folderQuery: IFolderQuery, includePattern
 	};
 }
 
-export interface IRgGlobResult {
+interface IRgGlobResult {
 	globArgs: string[];
 	siblingClauses: glob.IExpression;
 }
 
-export function foldersToRgExcludeGlobs(folderQueries: IFolderQuery[], globalExclude?: glob.IExpression, excludesToSkip?: Set<string>, absoluteGlobs = true): IRgGlobResult {
+function foldersToRgExcludeGlobs(folderQueries: IFolderQuery[], globalExclude?: glob.IExpression, excludesToSkip?: Set<string>, absoluteGlobs = true): IRgGlobResult {
 	const globArgs: string[] = [];
 	let siblingClauses: glob.IExpression = {};
 	folderQueries.forEach(folderQuery => {
@@ -102,7 +102,7 @@ export function foldersToRgExcludeGlobs(folderQueries: IFolderQuery[], globalExc
 	return { globArgs, siblingClauses };
 }
 
-export function foldersToIncludeGlobs(folderQueries: IFolderQuery[], globalInclude?: glob.IExpression, absoluteGlobs = true): string[] {
+function foldersToIncludeGlobs(folderQueries: IFolderQuery[], globalInclude?: glob.IExpression, absoluteGlobs = true): string[] {
 	const globArgs: string[] = [];
 	folderQueries.forEach(folderQuery => {
 		const totalIncludePattern = Object.assign({}, globalInclude || {}, folderQuery.includePattern || {});

--- a/src/vs/workbench/services/search/node/ripgrepTextSearchEngine.ts
+++ b/src/vs/workbench/services/search/node/ripgrepTextSearchEngine.ts
@@ -131,7 +131,7 @@ export class RipgrepTextSearchEngine {
  * Ripgrep produces stderr output which is not from a fatal error, and we only want the search to be
  * "failed" when a fatal error was produced.
  */
-export function rgErrorMsgForDisplay(msg: string): Maybe<SearchError> {
+function rgErrorMsgForDisplay(msg: string): Maybe<SearchError> {
 	const lines = msg.split('\n');
 	const firstLine = lines[0].trim();
 
@@ -161,7 +161,7 @@ export function rgErrorMsgForDisplay(msg: string): Maybe<SearchError> {
 	return undefined;
 }
 
-export function buildRegexParseError(lines: string[]): string {
+function buildRegexParseError(lines: string[]): string {
 	const errorMessage: string[] = ['Regex parse error'];
 	const pcre2ErrorLine = lines.filter(l => (l.startsWith('PCRE2:')));
 	if (pcre2ErrorLine.length >= 1) {
@@ -495,7 +495,7 @@ function getRgArgs(query: TextSearchQuery, options: TextSearchOptions): string[]
 /**
  * `"foo/*bar/something"` -> `["foo", "foo/*bar", "foo/*bar/something", "foo/*bar/something/**"]`
  */
-export function spreadGlobComponents(globArg: string): string[] {
+function spreadGlobComponents(globArg: string): string[] {
 	const components = splitGlobAware(globArg, '/');
 	return components.map((_, i) => components.slice(0, i + 1).join('/'));
 }


### PR DESCRIPTION
Fixes #164939

Addresses all search unused exports except for the following:
- ISearchPathPattern (used in ISearchPathsInfo)
- IRgSubmatch (used in IRgMatch)
- IRgBytesOrText (used in IRgSubmatch)

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
