### PR TITLE
Fix `console` not being a known symbol in media-preview

### DIFF
--- a/extensions/media-preview/tsconfig.json
+++ b/extensions/media-preview/tsconfig.json
@@ -1,8 +1,7 @@
 {
 	"extends": "../tsconfig.base.json",
 	"compilerOptions": {
-		"outDir": "./out",
-		"types": []
+		"outDir": "./out"
 	},
 	"include": [
 		"src/**/*",


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
