### PR TITLE
Fix terminal locale handling

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -580,11 +580,11 @@ async function resolveNlsConfiguration() {
 		// VS Code moves to Electron 22.
 		// Ref https://github.com/microsoft/vscode/issues/159813
 		// and https://github.com/electron/electron/pull/36035
-		if ('getPreferredSystemLanguages' in app
-			&& typeof app.getPreferredSystemLanguages === 'function'
-			&& app.getPreferredSystemLanguages().length) {
-			appLocale = app.getPreferredSystemLanguages()[0];
-		}
+		// if ('getPreferredSystemLanguages' in app
+		// 	&& typeof app.getPreferredSystemLanguages === 'function'
+		// 	&& app.getPreferredSystemLanguages().length) {
+		// 	appLocale = app.getPreferredSystemLanguages()[0];
+		// }
 		if (!appLocale) {
 			nlsConfiguration = { locale: 'en', availableLanguages: {} };
 		} else {


### PR DESCRIPTION
Fixes #166936

**New description**:
This PR is the main branch version of the candidate PR #169072.
The PR breaks language pack recommendation in favour of restoring terminal functionality.

The PR switches from `app.getPreferredSystemLanguages()` back to `app.getLocale()`, because the former method was returning locales that were not on the user's system, leading to invalid character rendering in the terminal.

**Old description**:
Previously, the value of `locale` was obtained using `app.getLocale()`. `app.getLocale()` would almost always return just the language, such as `en` or `fr`. The terminal code would handle that situation fine. Now that `locale` is returned using `app.getPreferredSystemLanguages()`, the terminal code doesn't do any processing on the locale, and as a result, though the value is a valid system language, it results in an invaild terminal locale.

This PR takes out an if case and adds special cases for `zh-cn` and `zh-tw`.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
