### PR TITLE
Preserve the `undefined` value and don't overwrite it

### DIFF
--- a/src/vs/workbench/browser/actions/quickAccessActions.ts
+++ b/src/vs/workbench/browser/actions/quickAccessActions.ts
@@ -165,6 +165,7 @@ registerAction2(class QuickAccessAction extends Action2 {
 	run(accessor: ServicesAccessor): void {
 		const quickInputService = accessor.get(IQuickInputService);
 		quickInputService.quickAccess.show(undefined, {
+			preserveValue: true,
 			providerOptions: {
 				includeHelp: true,
 			} as AnythingQuickAccessProviderRunOptions


### PR DESCRIPTION
This is kinda confusing... because the property doesn't really match the `"workbench.quickOpen.preserveInput": true` setting behavior.

But I _think_ `preserveValue` here means... ensure that whatever I pass in as the first parameter of this `show(...)` function gets to be the value at the end of the day and _don't_ overwrite it with any previous value. In the original issue, the overwriting was happening here:
https://github.com/microsoft/vscode/blob/d305f229ca124d1c137abea4e25e67125ccda32e/src/vs/platform/quickinput/browser/quickAccess.ts#L84

cc @bpasero for context.

Fixes #169058

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
