### PR TITLE
debug: allow orphans to outlive their parents

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/debugCommands.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugCommands.ts
@@ -458,7 +458,7 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 		} else {
 			const showSubSessions = configurationService.getValue<IDebugConfiguration>('debug').showSubSessionsInToolBar;
 			// Stop should be sent to the root parent session
-			while (!showSubSessions && session && session.parentSession) {
+			while (!showSubSessions && session.lifecycleManagedByParent && session.parentSession) {
 				session = session.parentSession;
 			}
 			session.removeReplExpressions();
@@ -605,7 +605,7 @@ async function stopHandler(accessor: ServicesAccessor, _: string, context: CallS
 	const configurationService = accessor.get(IConfigurationService);
 	const showSubSessions = configurationService.getValue<IDebugConfiguration>('debug').showSubSessionsInToolBar;
 	// Stop should be sent to the root parent session
-	while (!showSubSessions && session && session.parentSession) {
+	while (!showSubSessions && session && session.lifecycleManagedByParent && session.parentSession) {
 		session = session.parentSession;
 	}
 

--- a/src/vs/workbench/contrib/debug/browser/repl.ts
+++ b/src/vs/workbench/contrib/debug/browser/repl.ts
@@ -176,6 +176,11 @@ export class Repl extends FilterViewPane implements IHistoryNavigationWidget {
 			}
 			this.multiSessionRepl.set(this.isMultiSessionView);
 		}));
+		this._register(this.debugService.onDidEndSession(async session => {
+			// Update view, since orphaned sessions might now be separate
+			await Promise.resolve(); // allow other listeners to go first, so sessions can update parents
+			this.multiSessionRepl.set(this.isMultiSessionView);
+		}));
 		this._register(this.themeService.onDidColorThemeChange(() => {
 			this.refreshReplElements(false);
 			if (this.isVisible()) {

--- a/src/vs/workbench/contrib/debug/common/debug.ts
+++ b/src/vs/workbench/contrib/debug/common/debug.ts
@@ -304,6 +304,7 @@ export interface IDebugSession extends ITreeElement {
 	readonly suppressDebugToolbar: boolean;
 	readonly suppressDebugStatusbar: boolean;
 	readonly suppressDebugView: boolean;
+	readonly lifecycleManagedByParent: boolean;
 
 	setSubId(subId: string | undefined): void;
 

--- a/src/vs/workbench/contrib/debug/common/replModel.ts
+++ b/src/vs/workbench/contrib/debug/common/replModel.ts
@@ -297,4 +297,11 @@ export class ReplModel {
 			this._onDidChangeElements.fire();
 		}
 	}
+
+	/** Returns a new REPL model that's a copy of this one. */
+	clone() {
+		const newRepl = new ReplModel(this.configurationService);
+		newRepl.replElements = this.replElements.slice();
+		return newRepl;
+	}
 }

--- a/src/vs/workbench/contrib/debug/test/common/mockDebug.ts
+++ b/src/vs/workbench/contrib/debug/test/common/mockDebug.ts
@@ -197,6 +197,10 @@ export class MockSession implements IDebugSession {
 		return false;
 	}
 
+	get lifecycleManagedByParent(): boolean {
+		return false;
+	}
+
 	stepInTargets(frameId: number): Promise<{ id: number; label: string }[]> {
 		throw new Error('Method not implemented.');
 	}


### PR DESCRIPTION
Previously, if a parent session was terminated but its children lived on, the UI would get into a broken state. Talking with @roblourens, we should probably support this, and doing so was disturbingly easy...

This PR unsets `parentSession` on the children when their parent is terminated. Generally `session.parentSession` was only checked and used synchronously, for example in the debug console switcher command. The area where this wasn't the case was in the REPLs. If a child previously merged its repl with its parent, then we'll clone the parent's repl and detach it into each child; I think keeping them connected would likely be confusing.

The other change I tentatively put forward, is only bubbling restart and stop commands to the parent if `session.lifecycleManagedByParent` is true. I think this is more 'correct' but may result in surprising behavior for DA's who haven't yet adopted that property (like Python https://github.com/microsoft/vscode-python/issues/20376)

Fixes https://github.com/microsoft/vscode/issues/130941
Fixes https://github.com/microsoft/vscode/issues/164553
