### PR TITLE
Align extension detail tabs to panel tabs + fix focus chopped off focus border

### DIFF
--- a/src/vs/workbench/contrib/extensions/browser/media/extensionEditor.css
+++ b/src/vs/workbench/contrib/extensions/browser/media/extensionEditor.css
@@ -355,31 +355,34 @@
 	font-size: 14px;
 	line-height: 36px;
 	padding-left: 20px;
-	border-bottom: 1px solid rgba(136, 136, 136, 0.45);
-	box-sizing: border-box;
+	border-bottom: 1px solid var(--vscode-panelSection-border);
 }
 
 .extension-editor > .body > .navbar > .monaco-action-bar > .actions-container {
 	justify-content: initial;
 }
 
-.extension-editor > .body > .navbar > .monaco-action-bar > .actions-container > .action-item > .action-label {
-	margin-right: 16px;
-	font-size: inherit;
-	opacity: 0.7;
+.extension-editor > .body > .navbar > .monaco-action-bar > .actions-container > .action-item {
+	height: 100%;
 }
 
 .extension-editor > .body > .navbar > .monaco-action-bar > .actions-container > .action-item > .action-label {
+	padding: 0 10px;
+	font-size: 11px;
+	font-weight: normal;
+	color: var(--vscode-panelTitle-inactiveForeground);
+	text-transform: uppercase;
 	background: none !important;
+	border-radius: 0px !important;
 }
 
 .extension-editor > .body > .navbar > .monaco-action-bar > .actions-container > .action-item > .action-label.checked {
-	opacity: 1;
-	text-decoration: underline;
+	border-bottom: 1px solid var(--vscode-panelTitle-activeBorder);
+	color: var(--vscode-panelTitle-activeForeground);
 }
 
 .extension-editor > .body > .navbar > .monaco-action-bar > .actions-container > .action-item > .action-label:hover {
-	text-decoration: underline;
+	color: var(--vscode-panelTitle-activeForeground);
 }
 
 .extension-editor > .body > .content {


### PR DESCRIPTION
Fix #166476 while snapping the look and feel to the tab bar found in panels, among other places:

## Before

![CleanShot 2022-12-14 at 16 50 12](https://user-images.githubusercontent.com/25163139/207746760-a27850a2-ec3a-4e26-bf7b-35e3cf28f449.gif)

<img width="317" alt="CleanShot 2022-12-14 at 16 52 46@2x" src="https://user-images.githubusercontent.com/25163139/207746845-7f986a0b-baf5-4535-9e34-5eda91400d0e.png">

## After

![CleanShot 2022-12-14 at 16 48 23](https://user-images.githubusercontent.com/25163139/207746780-e9dfbd31-4e92-4571-a613-f737725cb1e0.gif)

<img width="525" alt="CleanShot 2022-12-14 at 16 49 41@2x" src="https://user-images.githubusercontent.com/25163139/207746806-ec962415-e461-4a11-a130-a2170aeb28b3.png">


## Prior art

<img width="511" alt="CleanShot 2022-12-14 at 16 53 03@2x" src="https://user-images.githubusercontent.com/25163139/207746875-0a6e4f19-25dc-4bdc-9ad5-be65811c0cd5.png">

cc @rzhao271 @esonnino 