### PR TITLE
Fix Run menu not appearing

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/debug.contribution.ts
+++ b/src/vs/workbench/contrib/debug/browser/debug.contribution.ts
@@ -355,7 +355,6 @@ MenuRegistry.appendMenuItem(MenuId.MenubarDebugMenu, {
 		id: 'debug.installAdditionalDebuggers',
 		title: nls.localize({ key: 'miInstallAdditionalDebuggers', comment: ['&& denotes a mnemonic'] }, "&&Install Additional Debuggers...")
 	},
-	when: CONTEXT_DEBUGGERS_AVAILABLE,
 	order: 1
 });
 


### PR DESCRIPTION
Seems that if a menu item doesn't have any enabled items at launch, it won't show up later when items become enabled. Keep one item enabled all the time, which we had planned to do anyway.
Fix #166623

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
