### PR TITLE
fix: disable AutoDisableAccessibility feature

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -239,11 +239,6 @@ function configureCommandlineSwitchesSync(cliArgs) {
 	 */
 	app.commandLine.appendSwitch('disable-features', 'CalculateNativeWinOcclusion');
 
-	/* Following features are enabled from the runtime.
-	 * `AutoDisableAccessibility` - https://github.com/microsoft/vscode/issues/162331#issue-1390744354
-	 */
-	app.commandLine.appendSwitch('enable-features', 'AutoDisableAccessibility');
-
 	// Support JS Flags
 	const jsFlags = getJSFlags(cliArgs);
 	if (jsFlags) {


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/169000

The feature disables a11y support in the runtime if there is no a11y api usage for 30s since receiving a user input, most scenarios described in the above issue indicate that the runtime is not sending a11y events to us when it detects usage after gaining focus from a different application indicating a bug in the runtime. Created https://github.com/microsoft/vscode/issues/169200 to track re-enabling this feature.

/cc @isidorn @meganrogge 
