### PR TITLE
fix action2 category in search

### DIFF
--- a/src/vs/workbench/contrib/search/browser/searchActionsCopy.ts
+++ b/src/vs/workbench/contrib/search/browser/searchActionsCopy.ts
@@ -26,7 +26,7 @@ registerAction2(class CopyMatchCommandAction extends Action2 {
 				value: nls.localize('copyMatchLabel', "Copy"),
 				original: 'Copy'
 			},
-			category: category.value,
+			category,
 			keybinding: {
 				weight: KeybindingWeight.WorkbenchContrib,
 				when: Constants.FileMatchOrMatchFocusKey,
@@ -57,7 +57,7 @@ registerAction2(class CopyPathCommandAction extends Action2 {
 				value: nls.localize('copyPathLabel', "Copy Path"),
 				original: 'Copy Path'
 			},
-			category: category.value,
+			category,
 			keybinding: {
 				weight: KeybindingWeight.WorkbenchContrib,
 				when: Constants.FileMatchOrFolderMatchWithResourceFocusKey,
@@ -91,7 +91,7 @@ registerAction2(class CopyAllCommandAction extends Action2 {
 				value: nls.localize('copyAllLabel', "Copy All"),
 				original: 'Copy All'
 			},
-			category: category.value,
+			category,
 			menu: [{
 				id: MenuId.SearchContext,
 				when: Constants.HasSearchResults,

--- a/src/vs/workbench/contrib/search/browser/searchActionsFind.ts
+++ b/src/vs/workbench/contrib/search/browser/searchActionsFind.ts
@@ -110,7 +110,7 @@ registerAction2(class RevealInSideBarForSearchResultsAction extends Action2 {
 				value: nls.localize('revealInSideBar', "Reveal in Explorer View"),
 				original: 'Reveal in Explorer View'
 			},
-			category: category,
+			category,
 			menu: [{
 				id: MenuId.SearchContext,
 				when: ContextKeyExpr.and(Constants.FileFocusKey, Constants.HasSearchResults),
@@ -193,7 +193,7 @@ registerAction2(class FindInFilesAction extends Action2 {
 					},
 				]
 			},
-			category: category,
+			category,
 			keybinding: {
 				weight: KeybindingWeight.WorkbenchContrib,
 				primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KeyF,

--- a/src/vs/workbench/contrib/search/browser/searchActionsNav.ts
+++ b/src/vs/workbench/contrib/search/browser/searchActionsNav.ts
@@ -90,7 +90,7 @@ registerAction2(class ToggleCaseSensitiveCommandAction extends Action2 {
 				value: nls.localize('ToggleCaseSensitiveCommandId.label', "Toggle Case Sensitive"),
 				original: 'Toggle Case Sensitive'
 			},
-			category: category,
+			category,
 			keybinding: Object.assign({
 				weight: KeybindingWeight.WorkbenchContrib,
 				when: isMacintosh ? ContextKeyExpr.and(Constants.SearchViewFocusedKey, Constants.FileMatchOrFolderMatchFocusKey.toNegated()) : Constants.SearchViewFocusedKey,
@@ -117,7 +117,7 @@ registerAction2(class ToggleWholeWordCommandAction extends Action2 {
 				weight: KeybindingWeight.WorkbenchContrib,
 				when: Constants.SearchViewFocusedKey,
 			}, ToggleWholeWordKeybinding),
-			category: category.value,
+			category,
 		});
 	}
 
@@ -138,7 +138,7 @@ registerAction2(class ToggleRegexCommandAction extends Action2 {
 				weight: KeybindingWeight.WorkbenchContrib,
 				when: Constants.SearchViewFocusedKey,
 			}, ToggleRegexKeybinding),
-			category: category.value,
+			category,
 		});
 	}
 
@@ -159,7 +159,7 @@ registerAction2(class TogglePreserveCaseAction extends Action2 {
 				weight: KeybindingWeight.WorkbenchContrib,
 				when: Constants.SearchViewFocusedKey,
 			}, TogglePreserveCaseKeybinding),
-			category: category.value,
+			category,
 		});
 	}
 
@@ -247,7 +247,7 @@ registerAction2(class AddCursorsAtSearchResultsAction extends Action2 {
 				when: ContextKeyExpr.and(Constants.SearchViewVisibleKey, Constants.FileMatchOrMatchFocusKey),
 				primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KeyL,
 			},
-			category: category.value,
+			category,
 		});
 	}
 
@@ -359,7 +359,7 @@ registerAction2(class ToggleSearchOnTypeAction extends Action2 {
 				value: nls.localize('toggleTabs', 'Toggle Search on Type'),
 				original: 'Toggle Search on Type'
 			},
-			category: category.value,
+			category,
 		});
 
 	}
@@ -381,7 +381,7 @@ registerAction2(class FocusSearchListCommandAction extends Action2 {
 				value: nls.localize('focusSearchListCommandLabel', "Focus List"),
 				original: 'Focus List'
 			},
-			category: category,
+			category,
 			f1: true
 		});
 	}
@@ -403,7 +403,7 @@ registerAction2(class FocusNextSearchResultAction extends Action2 {
 				primary: KeyCode.F4,
 				weight: KeybindingWeight.WorkbenchContrib,
 			}],
-			category: category,
+			category,
 			f1: true,
 			precondition: ContextKeyExpr.or(Constants.HasSearchResults, SearchEditorConstants.InSearchEditor),
 		});
@@ -426,7 +426,7 @@ registerAction2(class FocusPreviousSearchResultAction extends Action2 {
 				primary: KeyMod.Shift | KeyCode.F4,
 				weight: KeybindingWeight.WorkbenchContrib,
 			}],
-			category: category,
+			category,
 			f1: true,
 			precondition: ContextKeyExpr.or(Constants.HasSearchResults, SearchEditorConstants.InSearchEditor),
 		});
@@ -449,7 +449,7 @@ registerAction2(class ReplaceInFilesAction extends Action2 {
 				primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KeyH,
 				weight: KeybindingWeight.WorkbenchContrib,
 			}],
-			category: category,
+			category,
 			f1: true,
 			menu: [{
 				id: MenuId.MenubarEditMenu,

--- a/src/vs/workbench/contrib/search/browser/searchActionsTopBar.ts
+++ b/src/vs/workbench/contrib/search/browser/searchActionsTopBar.ts
@@ -31,7 +31,7 @@ registerAction2(class ClearSearchHistoryCommandAction extends Action2 {
 				value: nls.localize('clearSearchHistoryLabel', "Clear Search History"),
 				original: 'Clear Search History'
 			},
-			category: category,
+			category,
 			f1: true
 		});
 


### PR DESCRIPTION
Small fix: some action2 areas in search were assigned `category.value` instead of `category`.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
