### PR TITLE
Fix bug with snippet choices escaping

### DIFF
--- a/src/vs/editor/contrib/snippet/browser/snippetParser.ts
+++ b/src/vs/editor/contrib/snippet/browser/snippetParser.ts
@@ -300,7 +300,7 @@ export class Choice extends Marker {
 
 	toTextmateString(): string {
 		return this.options
-			.map(option => option.value.replace(/\||,/g, '\\$&'))
+			.map(option => option.value.replace(/\||,|\\/g, '\\$&'))
 			.join(',');
 	}
 

--- a/src/vs/editor/contrib/snippet/test/browser/snippetParser.test.ts
+++ b/src/vs/editor/contrib/snippet/test/browser/snippetParser.test.ts
@@ -299,6 +299,7 @@ suite('SnippetParser', () => {
 		assertTextsnippetString('\\$1', '\\$1');
 		assertTextsnippetString('console.log(${1|not\\, not, five, 5, 1   23|});', 'console.log(${1|not\\, not, five, 5, 1   23|});');
 		assertTextsnippetString('console.log(${1|not\\, not, \\| five, 5, 1   23|});', 'console.log(${1|not\\, not, \\| five, 5, 1   23|});');
+		assertTextsnippetString('${1|cho\\,ices,wi\\|th,esc\\\\aping,chall\\\\\\,enges|}', '${1|cho\\,ices,wi\\|th,esc\\\\aping,chall\\\\\\,enges|}');
 		assertTextsnippetString('this is text', 'this is text');
 		assertTextsnippetString('this ${1:is ${2:nested with $var}}', 'this ${1:is ${2:nested with ${var}}}');
 		assertTextsnippetString('this ${1:is ${2:nested with $var}}}', 'this ${1:is ${2:nested with ${var}}}\\}');


### PR DESCRIPTION
The code that inserts `\` to escape text in choices in `toTextmateString` wasn't escaping `\` characters themselves.  Fwiw this bug could have been caught by [codeql](https://codeql.github.com/)