### PR TITLE
Add missing await

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/rawDebugSession.ts
+++ b/src/vs/workbench/contrib/debug/browser/rawDebugSession.ts
@@ -573,7 +573,7 @@ export class RawDebugSession implements IDisposable {
 				} catch (e) {
 					// Catch the potential 'disconnect' error - no need to show it to the user since the adapter is shutting down
 				} finally {
-					this.stopAdapter(error);
+					await this.stopAdapter(error);
 				}
 			} else {
 				return this.stopAdapter(error);


### PR DESCRIPTION
So that the debug stop command properly waits on stopping the adapter
Fix #132446