### PR TITLE
Align common text button heights + SCM buttons

### DIFF
--- a/src/vs/base/browser/ui/button/button.css
+++ b/src/vs/base/browser/ui/button/button.css
@@ -7,7 +7,7 @@
 	box-sizing: border-box;
 	display: flex;
 	width: 100%;
-	padding: 3px 4px;
+	padding: 4px;
 	border-radius: 2px;
 	text-align: center;
 	cursor: pointer;

--- a/src/vs/base/browser/ui/button/button.css
+++ b/src/vs/base/browser/ui/button/button.css
@@ -14,6 +14,7 @@
 	justify-content: center;
 	align-items: center;
 	border: 1px solid var(--vscode-button-border, transparent);
+	line-height: 18px;
 }
 
 .monaco-text-button:focus {
@@ -28,10 +29,6 @@
 .monaco-button.disabled {
 	opacity: 0.4 !important;
 	cursor: default;
-}
-
-.monaco-text-button span {
-	line-height: 18px;
 }
 
 .monaco-text-button > .codicon {

--- a/src/vs/base/browser/ui/button/button.css
+++ b/src/vs/base/browser/ui/button/button.css
@@ -7,7 +7,7 @@
 	box-sizing: border-box;
 	display: flex;
 	width: 100%;
-	padding: 4px;
+	padding: 3px 4px;
 	border-radius: 2px;
 	text-align: center;
 	cursor: pointer;
@@ -28,6 +28,10 @@
 .monaco-button.disabled {
 	opacity: 0.4 !important;
 	cursor: default;
+}
+
+.monaco-text-button span {
+	line-height: 18px;
 }
 
 .monaco-text-button > .codicon {

--- a/src/vs/workbench/browser/parts/notifications/media/notificationsList.css
+++ b/src/vs/workbench/browser/parts/notifications/media/notificationsList.css
@@ -128,7 +128,7 @@
 
 .monaco-workbench .notifications-list-container .notification-list-item .notification-list-item-buttons-container .monaco-text-button {
 	width: fit-content;
-	padding: 5px 10px;
+	padding: 4px 10px;
 	display: inline-block;	/* to enable ellipsis in text overflow */
 	font-size: 12px;
 	overflow: hidden;

--- a/src/vs/workbench/contrib/scm/browser/media/scm.css
+++ b/src/vs/workbench/contrib/scm/browser/media/scm.css
@@ -229,9 +229,6 @@
 	flex-wrap: wrap;
 	padding: 0 4px;
 	overflow: hidden;
-	height: 30px;
-	line-height: 20px;
-	border: 1px solid var(--vscode-button-background);
 }
 
 .scm-view .button-container .monaco-description-button:hover {
@@ -257,15 +254,13 @@
 
 .scm-view .button-container .codicon.codicon-cloud-upload,
 .scm-view .button-container .codicon.codicon-sync {
-	line-height: 20px;
-	margin: 0 0.4em 0 0;
+	margin: 0 4px 0 0;
 }
 
 .scm-view .button-container .codicon.codicon-arrow-up,
 .scm-view .button-container .codicon.codicon-arrow-down {
-	line-height: 20px;
 	font-size: small !important;
-	margin: 0 0.2em 0 0;
+	margin: 0 4px 0 0;
 }
 
 .scm-view .button-container > .monaco-button-dropdown {


### PR DESCRIPTION
- Updates line height of common text buttons
- Align SCM buttons (commit, sync, publish) to common text button
- Remove duplicated border on SCM button

<img width="292" alt="CleanShot 2022-12-15 at 14 47 48@2x" src="https://user-images.githubusercontent.com/25163139/207983410-c5f50765-3dd0-4a91-a656-384bf08415de.png">

<img width="301" alt="CleanShot 2022-12-15 at 14 48 00@2x" src="https://user-images.githubusercontent.com/25163139/207983429-f8614382-70b4-4ac1-8e5a-51730012ab19.png">

<img width="296" alt="CleanShot 2022-12-15 at 14 48 06@2x" src="https://user-images.githubusercontent.com/25163139/207983438-a05614a4-b8dc-4fa7-9af2-a943831fb832.png">

<img width="270" alt="CleanShot 2022-12-15 at 14 47 44@2x" src="https://user-images.githubusercontent.com/25163139/207983441-fb1af8de-7708-41b4-8f49-b3a5f866572c.png">

