### PR TITLE
Use standard list height for settings dropdown options

### DIFF
--- a/src/vs/base/browser/ui/selectBox/selectBoxCustom.ts
+++ b/src/vs/base/browser/ui/selectBox/selectBoxCustom.ts
@@ -147,7 +147,7 @@ export class SelectBoxList extends Disposable implements ISelectBoxDelegate, ILi
 	// IDelegate - List renderer
 
 	getHeight(): number {
-		return 18;
+		return 22;
 	}
 
 	getTemplateId(): string {


### PR DESCRIPTION
These options lists are quite cramped today. This change matches them to the height used in lists like the Explorer.

## Before
<img width="410" alt="CleanShot 2022-12-15 at 16 23 24@2x" src="https://user-images.githubusercontent.com/25163139/207994233-a2716baa-b8ed-4064-a3f4-14b9c61f4fa9.png">

## After
<img width="401" alt="CleanShot 2022-12-15 at 16 23 09@2x" src="https://user-images.githubusercontent.com/25163139/207994243-114d0bdd-3464-40bd-b746-952759a587c8.png">

