### PR TITLE
perf - avoid `window.document.body.clientWidth` on window resize

### DIFF
--- a/src/vs/workbench/electron-sandbox/window.ts
+++ b/src/vs/workbench/electron-sandbox/window.ts
@@ -7,7 +7,7 @@ import { localize } from 'vs/nls';
 import { URI } from 'vs/base/common/uri';
 import { onUnexpectedError } from 'vs/base/common/errors';
 import { equals } from 'vs/base/common/objects';
-import { EventType, EventHelper, addDisposableListener, scheduleAtNextAnimationFrame, ModifierKeyEmitter } from 'vs/base/browser/dom';
+import { EventType, EventHelper, addDisposableListener, ModifierKeyEmitter } from 'vs/base/browser/dom';
 import { Separator, WorkbenchActionExecutedClassification, WorkbenchActionExecutedEvent } from 'vs/base/common/actions';
 import { IFileService } from 'vs/platform/files/common/files';
 import { EditorResourceAccessor, IUntitledTextResourceEditorInput, SideBySideEditor, pathsToEditors, IResourceDiffEditorInput, IUntypedEditorInput, IEditorPane, isResourceEditorInput, IResourceMergeEditorInput } from 'vs/workbench/common/editor';
@@ -131,7 +131,7 @@ export class NativeWindow extends Disposable {
 	private registerListeners(): void {
 
 		// Layout
-		this._register(addDisposableListener(window, EventType.RESIZE, e => this.onWindowResize(e, true)));
+		this._register(addDisposableListener(window, EventType.RESIZE, e => this.onWindowResize(e)));
 
 		// React to editor input changes
 		this._register(this.editorService.onDidActiveEditorChange(() => this.updateTouchbarMenu()));
@@ -497,20 +497,8 @@ export class NativeWindow extends Disposable {
 		}
 	}
 
-	private onWindowResize(e: UIEvent, retry: boolean): void {
+	private onWindowResize(e: UIEvent): void {
 		if (e.target === window) {
-			if (window.document && window.document.body && window.document.body.clientWidth === 0) {
-				// TODO@electron this is an electron issue on macOS when simple fullscreen is enabled
-				// where for some reason the window clientWidth is reported as 0 when switching
-				// between simple fullscreen and normal screen. In that case we schedule the layout
-				// call at the next animation frame once, in the hope that the dimensions are
-				// proper then.
-				if (retry) {
-					scheduleAtNextAnimationFrame(() => this.onWindowResize(e, false));
-				}
-				return;
-			}
-
 			this.layoutService.layout();
 		}
 	}


### PR DESCRIPTION
The code was introduced a while ago in https://github.com/microsoft/vscode/commit/9667519b858db6076f800590f3d433fb51ba6149#diff-51ff76548a002b9a54ddc2f1e9bcb99f6470bea70da4c2a433c5f89a6aad8a38 but I cannot reproduce the original issue anymore:
* enable simple fullscreen (`window.nativeFullScreen: false`)
* transition between fullscreen and non-fullscreen (via command palette)
* I see no exception in dev tools, it seems back then we sometimes got `0` width or height which would then throw an error in [`DOM.getClientArea`](https://github.com/microsoft/vscode/blob/9d064dd667cca8fa095f50e45dfeaada65ce3cd3/src/vs/base/browser/dom.ts#L289)

Btw I am not 100% convinced that this would fully get rid of the perf issue, because in the end we still need the client area to perform a layout here:

https://github.com/microsoft/vscode/blob/9d064dd667cca8fa095f50e45dfeaada65ce3cd3/src/vs/workbench/browser/layout.ts#L1375