### PR TITLE
Git - Add the capability to "attach" state to operations

### DIFF
--- a/extensions/git/src/actionButton.ts
+++ b/extensions/git/src/actionButton.ts
@@ -6,7 +6,7 @@
 import { Command, Disposable, Event, EventEmitter, SourceControlActionButton, Uri, workspace, l10n } from 'vscode';
 import { Branch, Status } from './api/git';
 import { CommitCommandsCenter } from './postCommitCommands';
-import { Repository, Operation } from './repository';
+import { Repository, OperationKind } from './repository';
 import { dispose } from './util';
 
 interface ActionButtonState {
@@ -181,14 +181,14 @@ export class ActionButtonCommand {
 
 	private onDidChangeOperations(): void {
 		const isCommitInProgress =
-			this.repository.operations.isRunning(Operation.Commit) ||
-			this.repository.operations.isRunning(Operation.PostCommitCommand) ||
-			this.repository.operations.isRunning(Operation.RebaseContinue);
+			this.repository.operations.isRunning(OperationKind.Commit) ||
+			this.repository.operations.isRunning(OperationKind.PostCommitCommand) ||
+			this.repository.operations.isRunning(OperationKind.RebaseContinue);
 
 		const isSyncInProgress =
-			this.repository.operations.isRunning(Operation.Sync) ||
-			this.repository.operations.isRunning(Operation.Push) ||
-			this.repository.operations.isRunning(Operation.Pull);
+			this.repository.operations.isRunning(OperationKind.Sync) ||
+			this.repository.operations.isRunning(OperationKind.Push) ||
+			this.repository.operations.isRunning(OperationKind.Pull);
 
 		this.state = { ...this.state, isCommitInProgress, isSyncInProgress };
 	}

--- a/extensions/git/src/autofetch.ts
+++ b/extensions/git/src/autofetch.ts
@@ -4,12 +4,12 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { workspace, Disposable, EventEmitter, Memento, window, MessageItem, ConfigurationTarget, Uri, ConfigurationChangeEvent, l10n } from 'vscode';
-import { Repository, Operation } from './repository';
+import { Repository, OperationKind } from './repository';
 import { eventToPromise, filterEvent, onceEvent } from './util';
 import { GitErrorCodes } from './api/git';
 
-function isRemoteOperation(operation: Operation): boolean {
-	return operation === Operation.Pull || operation === Operation.Push || operation === Operation.Sync || operation === Operation.Fetch;
+function isRemoteOperation(operation: OperationKind): boolean {
+	return operation === OperationKind.Pull || operation === OperationKind.Push || operation === OperationKind.Sync || operation === OperationKind.Fetch;
 }
 
 export class AutoFetcher {

--- a/extensions/git/src/model.ts
+++ b/extensions/git/src/model.ts
@@ -5,7 +5,7 @@
 
 import { workspace, WorkspaceFoldersChangeEvent, Uri, window, Event, EventEmitter, QuickPickItem, Disposable, SourceControl, SourceControlResourceGroup, TextEditor, Memento, commands, LogOutputChannel, l10n, ProgressLocation } from 'vscode';
 import TelemetryReporter from '@vscode/extension-telemetry';
-import { Operation, Repository, RepositoryState } from './repository';
+import { OperationKind, Repository, RepositoryState } from './repository';
 import { memoize, sequentialize, debounce } from './decorators';
 import { dispose, anyEvent, filterEvent, isDescendant, pathEquals, toDisposable, eventToPromise } from './util';
 import { Git } from './git';
@@ -533,19 +533,19 @@ export class Model implements IRemoteSourcePublisherRegistry, IPostCommitCommand
 			let commitInProgress = false;
 			let operationInProgress = false;
 			for (const { repository } of this.openRepositories.values()) {
-				if (repository.operations.isRunning(Operation.Commit)) {
+				if (repository.operations.isRunning(OperationKind.Commit)) {
 					commitInProgress = true;
 				}
 
 				// When one of the following operations is running, we want to
 				// disable most commands in order to avoid multiple commands
 				// running at the same time.
-				if (repository.operations.isRunning(Operation.Checkout) ||
-					repository.operations.isRunning(Operation.CheckoutTracking) ||
-					repository.operations.isRunning(Operation.Commit) ||
-					repository.operations.isRunning(Operation.Pull) ||
-					repository.operations.isRunning(Operation.Push) ||
-					repository.operations.isRunning(Operation.Sync)) {
+				if (repository.operations.isRunning(OperationKind.Checkout) ||
+					repository.operations.isRunning(OperationKind.CheckoutTracking) ||
+					repository.operations.isRunning(OperationKind.Commit) ||
+					repository.operations.isRunning(OperationKind.Pull) ||
+					repository.operations.isRunning(OperationKind.Push) ||
+					repository.operations.isRunning(OperationKind.Sync)) {
 					operationInProgress = true;
 				}
 			}

--- a/extensions/git/src/postCommitCommands.ts
+++ b/extensions/git/src/postCommitCommands.ts
@@ -5,7 +5,7 @@
 
 import { Command, commands, Disposable, Event, EventEmitter, Memento, Uri, workspace, l10n } from 'vscode';
 import { PostCommitCommandsProvider } from './api/git';
-import { Operation, Repository } from './repository';
+import { OperationKind, Repository } from './repository';
 import { ApiRepository } from './api/api1';
 import { dispose } from './util';
 
@@ -28,7 +28,7 @@ export class GitPostCommitCommandsProvider implements PostCommitCommandsProvider
 
 		// Icon
 		const repository = apiRepository.repository;
-		const isCommitInProgress = repository.operations.isRunning(Operation.Commit) || repository.operations.isRunning(Operation.PostCommitCommand);
+		const isCommitInProgress = repository.operations.isRunning(OperationKind.Commit) || repository.operations.isRunning(OperationKind.PostCommitCommand);
 		const icon = isCommitInProgress ? '$(sync~spin)' : alwaysPrompt ? '$(lock)' : alwaysCommitToNewBranch ? '$(git-branch)' : undefined;
 
 		// Tooltip (default)
@@ -178,7 +178,7 @@ export class CommitCommandsCenter {
 			l10n.t('Commit Changes to New Branch');
 
 		// Tooltip (in progress)
-		if (this.repository.operations.isRunning(Operation.Commit)) {
+		if (this.repository.operations.isRunning(OperationKind.Commit)) {
 			tooltip = !alwaysCommitToNewBranch ?
 				l10n.t('Committing Changes...') :
 				l10n.t('Committing Changes to New Branch...');

--- a/extensions/git/src/statusbar.ts
+++ b/extensions/git/src/statusbar.ts
@@ -40,9 +40,9 @@ class CheckoutStatusBar {
 	}
 
 	get command(): Command | undefined {
-		const operationData: CheckoutOperation[] = [
-			...this.repository.operations.getData<CheckoutOperation>(OperationKind.Checkout),
-			...this.repository.operations.getData<CheckoutOperation>(OperationKind.CheckoutTracking)
+		const operationData = [
+			...this.repository.operations.getOperations(OperationKind.Checkout) as CheckoutOperation[],
+			...this.repository.operations.getOperations(OperationKind.CheckoutTracking) as CheckoutOperation[]
 		];
 
 		const rebasing = !!this.repository.rebaseCommit;

--- a/extensions/git/src/statusbar.ts
+++ b/extensions/git/src/statusbar.ts
@@ -46,7 +46,7 @@ class CheckoutStatusBar {
 		];
 
 		const rebasing = !!this.repository.rebaseCommit;
-		const label = operationData[0]?.state.ref ?? `${this.repository.headLabel}${rebasing ? ` (${l10n.t('Rebasing')})` : ''}`;
+		const label = operationData[0]?.state?.ref ?? `${this.repository.headLabel}${rebasing ? ` (${l10n.t('Rebasing')})` : ''}`;
 		const command = (this.state.isCheckoutRunning || this.state.isCommitRunning || this.state.isSyncRunning) ? '' : 'git.checkout';
 
 		return {

--- a/extensions/git/src/statusbar.ts
+++ b/extensions/git/src/statusbar.ts
@@ -46,7 +46,7 @@ class CheckoutStatusBar {
 		];
 
 		const rebasing = !!this.repository.rebaseCommit;
-		const label = operationData[0]?.state?.ref ?? `${this.repository.headLabel}${rebasing ? ` (${l10n.t('Rebasing')})` : ''}`;
+		const label = operationData[0]?.state?.refLabel ?? `${this.repository.headLabel}${rebasing ? ` (${l10n.t('Rebasing')})` : ''}`;
 		const command = (this.state.isCheckoutRunning || this.state.isCommitRunning || this.state.isSyncRunning) ? '' : 'git.checkout';
 
 		return {

--- a/extensions/git/src/statusbar.ts
+++ b/extensions/git/src/statusbar.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Disposable, Command, EventEmitter, Event, workspace, Uri, l10n } from 'vscode';
-import { Repository, Operation } from './repository';
+import { Repository, Operation, OperationData, CheckoutOperationData } from './repository';
 import { anyEvent, dispose, filterEvent } from './util';
 import { Branch, RefType, RemoteSourcePublisher } from './api/git';
 import { IRemoteSourcePublisherRegistry } from './remotePublisher';
@@ -40,8 +40,13 @@ class CheckoutStatusBar {
 	}
 
 	get command(): Command | undefined {
+		const operationData: OperationData<CheckoutOperationData>[] = [
+			...this.repository.operations.getData<CheckoutOperationData>(Operation.Checkout),
+			...this.repository.operations.getData<CheckoutOperationData>(Operation.CheckoutTracking)
+		];
+
 		const rebasing = !!this.repository.rebaseCommit;
-		const label = this.repository.checkoutRef ?? `${this.repository.headLabel}${rebasing ? ` (${l10n.t('Rebasing')})` : ''}`;
+		const label = operationData[0]?.state.ref ?? `${this.repository.headLabel}${rebasing ? ` (${l10n.t('Rebasing')})` : ''}`;
 		const command = (this.state.isCheckoutRunning || this.state.isCommitRunning || this.state.isSyncRunning) ? '' : 'git.checkout';
 
 		return {

--- a/extensions/git/src/statusbar.ts
+++ b/extensions/git/src/statusbar.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Disposable, Command, EventEmitter, Event, workspace, Uri, l10n } from 'vscode';
-import { Repository, Operation, OperationData, CheckoutOperationData } from './repository';
+import { Repository, OperationKind, CheckoutOperation } from './repository';
 import { anyEvent, dispose, filterEvent } from './util';
 import { Branch, RefType, RemoteSourcePublisher } from './api/git';
 import { IRemoteSourcePublisherRegistry } from './remotePublisher';
@@ -40,13 +40,13 @@ class CheckoutStatusBar {
 	}
 
 	get command(): Command | undefined {
-		const operationData: OperationData<CheckoutOperationData>[] = [
-			...this.repository.operations.getData<CheckoutOperationData>(Operation.Checkout),
-			...this.repository.operations.getData<CheckoutOperationData>(Operation.CheckoutTracking)
+		const operationData: CheckoutOperation[] = [
+			...this.repository.operations.getData<CheckoutOperation>(OperationKind.Checkout),
+			...this.repository.operations.getData<CheckoutOperation>(OperationKind.CheckoutTracking)
 		];
 
 		const rebasing = !!this.repository.rebaseCommit;
-		const label = operationData[0]?.state?.refLabel ?? `${this.repository.headLabel}${rebasing ? ` (${l10n.t('Rebasing')})` : ''}`;
+		const label = operationData[0]?.refLabel ?? `${this.repository.headLabel}${rebasing ? ` (${l10n.t('Rebasing')})` : ''}`;
 		const command = (this.state.isCheckoutRunning || this.state.isCommitRunning || this.state.isSyncRunning) ? '' : 'git.checkout';
 
 		return {
@@ -99,12 +99,12 @@ class CheckoutStatusBar {
 	}
 
 	private onDidChangeOperations(): void {
-		const isCommitRunning = this.repository.operations.isRunning(Operation.Commit);
-		const isCheckoutRunning = this.repository.operations.isRunning(Operation.Checkout) ||
-			this.repository.operations.isRunning(Operation.CheckoutTracking);
-		const isSyncRunning = this.repository.operations.isRunning(Operation.Sync) ||
-			this.repository.operations.isRunning(Operation.Push) ||
-			this.repository.operations.isRunning(Operation.Pull);
+		const isCommitRunning = this.repository.operations.isRunning(OperationKind.Commit);
+		const isCheckoutRunning = this.repository.operations.isRunning(OperationKind.Checkout) ||
+			this.repository.operations.isRunning(OperationKind.CheckoutTracking);
+		const isSyncRunning = this.repository.operations.isRunning(OperationKind.Sync) ||
+			this.repository.operations.isRunning(OperationKind.Push) ||
+			this.repository.operations.isRunning(OperationKind.Pull);
 
 		this.state = { ...this.state, isCheckoutRunning, isCommitRunning, isSyncRunning };
 	}
@@ -167,12 +167,12 @@ class SyncStatusBar {
 	}
 
 	private onDidChangeOperations(): void {
-		const isCommitRunning = this.repository.operations.isRunning(Operation.Commit);
-		const isCheckoutRunning = this.repository.operations.isRunning(Operation.Checkout) ||
-			this.repository.operations.isRunning(Operation.CheckoutTracking);
-		const isSyncRunning = this.repository.operations.isRunning(Operation.Sync) ||
-			this.repository.operations.isRunning(Operation.Push) ||
-			this.repository.operations.isRunning(Operation.Pull);
+		const isCommitRunning = this.repository.operations.isRunning(OperationKind.Commit);
+		const isCheckoutRunning = this.repository.operations.isRunning(OperationKind.Checkout) ||
+			this.repository.operations.isRunning(OperationKind.CheckoutTracking);
+		const isSyncRunning = this.repository.operations.isRunning(OperationKind.Sync) ||
+			this.repository.operations.isRunning(OperationKind.Push) ||
+			this.repository.operations.isRunning(OperationKind.Pull);
 
 		this.state = { ...this.state, isCheckoutRunning, isCommitRunning, isSyncRunning };
 	}


### PR DESCRIPTION
Introduce `OperationData` that enables us to attach and retrieve state for a git operation. At the moment we are using this new capability to specify the label of the ref that is being checked out. This label is then retrieved by the checkout status bar item to display the label while the checkout is executing.