### PR TITLE
more mangler output polishing

### DIFF
--- a/extensions/mangle-loader.js
+++ b/extensions/mangle-loader.js
@@ -6,6 +6,8 @@
 
 const fs = require('fs');
 const webpack = require('webpack');
+const fancyLog = require('fancy-log');
+const ansiColors = require('ansi-colors');
 const { Mangler } = require('../build/lib/mangleTypeScript');
 
 /**
@@ -21,8 +23,9 @@ const mangleMap = new Map();
 function getMangledFileContents(projectPath) {
 	let entry = mangleMap.get(projectPath);
 	if (!entry) {
-		console.log(`Mangling ${projectPath}`);
-		const ts2tsMangler = new Mangler(projectPath, console.log);
+		const log = (...data) => fancyLog(ansiColors.blue('[mangler]'), ...data);
+		log(`Mangling ${projectPath}`);
+		const ts2tsMangler = new Mangler(projectPath, log);
 		entry = ts2tsMangler.computeNewFileContents();
 		mangleMap.set(projectPath, entry);
 	}


### PR DESCRIPTION
related to #169388

Missed the fact that we run the same mangler for extensions

![image](https://user-images.githubusercontent.com/22350/208117147-e1ed2fa1-d66f-4891-a1fb-8d94d3daf8f0.png)
