### PR TITLE
Use const enum more in terminal and general clean up

### DIFF
--- a/src/vs/platform/externalTerminal/electron-main/externalTerminalService.test.ts
+++ b/src/vs/platform/externalTerminal/electron-main/externalTerminalService.test.ts
@@ -64,7 +64,7 @@ suite('ExternalTerminalService', () => {
 		);
 	});
 
-	test(`WinTerminalService - uses default terminal when configuration.terminal.external.windowsExec is undefined`, done => {
+	test(`WinTerminalService - cwd is correct regardless of case`, done => {
 		const testShell = 'cmd';
 		const testCwd = 'c:/foo';
 		const mockSpawner: any = {

--- a/src/vs/platform/terminal/common/terminalRecorder.ts
+++ b/src/vs/platform/terminal/common/terminalRecorder.ts
@@ -6,7 +6,9 @@
 import { IPtyHostProcessReplayEvent } from 'vs/platform/terminal/common/capabilities/capabilities';
 import { ReplayEntry } from 'vs/platform/terminal/common/terminalProcess';
 
-const MAX_RECORDER_DATA_SIZE = 1024 * 1024; // 1MB
+const enum Constants {
+	MaxRecorderDataSize = 1024 * 1024 // 1MB
+}
 
 interface RecorderEntry {
 	cols: number;
@@ -58,9 +60,9 @@ export class TerminalRecorder {
 		lastEntry.data.push(data);
 
 		this._totalDataLength += data.length;
-		while (this._totalDataLength > MAX_RECORDER_DATA_SIZE) {
+		while (this._totalDataLength > Constants.MaxRecorderDataSize) {
 			const firstEntry = this._entries[0];
-			const remainingToDelete = this._totalDataLength - MAX_RECORDER_DATA_SIZE;
+			const remainingToDelete = this._totalDataLength - Constants.MaxRecorderDataSize;
 			if (remainingToDelete >= firstEntry.data[0].length) {
 				// the first data piece must be deleted
 				this._totalDataLength -= firstEntry.data[0].length;

--- a/src/vs/workbench/contrib/terminal/browser/terminal.contribution.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminal.contribution.ts
@@ -165,15 +165,17 @@ function registerSendSequenceKeybinding(text: string, rule: { when?: ContextKeyE
 	});
 }
 
-// The text representation of `^<letter>` is `'A'.charCodeAt(0) + 1`.
-const CTRL_LETTER_OFFSET = 64;
+const enum Constants {
+	/** The text representation of `^<letter>` is `'A'.charCodeAt(0) + 1`. */
+	CtrlLetterOffset = 64
+}
 
 // An extra Windows-only ctrl+v keybinding is used for pwsh that sends ctrl+v directly to the
 // shell, this gets handled by PSReadLine which properly handles multi-line pastes. This is
 // disabled in accessibility mode as PowerShell does not run PSReadLine when it detects a screen
 // reader. This works even when clipboard.readText is not supported.
 if (isWindows) {
-	registerSendSequenceKeybinding(String.fromCharCode('V'.charCodeAt(0) - CTRL_LETTER_OFFSET), { // ctrl+v
+	registerSendSequenceKeybinding(String.fromCharCode('V'.charCodeAt(0) - Constants.CtrlLetterOffset), { // ctrl+v
 		when: ContextKeyExpr.and(TerminalContextKeys.focus, ContextKeyExpr.equals(TerminalContextKeyStrings.ShellType, WindowsShellType.PowerShell), CONTEXT_ACCESSIBILITY_MODE_ENABLED.negate()),
 		primary: KeyMod.CtrlCmd | KeyCode.KeyV
 	});
@@ -208,21 +210,21 @@ registerSendSequenceKeybinding('\x1b[1;2H', { // Shift+home
 
 // send ctrl+c to the iPad when the terminal is focused and ctrl+c is pressed to kill the process (work around for #114009)
 if (isIOS) {
-	registerSendSequenceKeybinding(String.fromCharCode('C'.charCodeAt(0) - CTRL_LETTER_OFFSET), { // ctrl+c
+	registerSendSequenceKeybinding(String.fromCharCode('C'.charCodeAt(0) - Constants.CtrlLetterOffset), { // ctrl+c
 		when: ContextKeyExpr.and(TerminalContextKeys.focus),
 		primary: KeyMod.WinCtrl | KeyCode.KeyC
 	});
 }
 
 // Delete word left: ctrl+w
-registerSendSequenceKeybinding(String.fromCharCode('W'.charCodeAt(0) - CTRL_LETTER_OFFSET), {
+registerSendSequenceKeybinding(String.fromCharCode('W'.charCodeAt(0) - Constants.CtrlLetterOffset), {
 	primary: KeyMod.CtrlCmd | KeyCode.Backspace,
 	mac: { primary: KeyMod.Alt | KeyCode.Backspace }
 });
 if (isWindows) {
 	// Delete word left: ctrl+h
 	// Windows cmd.exe requires ^H to delete full word left
-	registerSendSequenceKeybinding(String.fromCharCode('H'.charCodeAt(0) - CTRL_LETTER_OFFSET), {
+	registerSendSequenceKeybinding(String.fromCharCode('H'.charCodeAt(0) - Constants.CtrlLetterOffset), {
 		when: ContextKeyExpr.and(TerminalContextKeys.focus, ContextKeyExpr.equals(TerminalContextKeyStrings.ShellType, WindowsShellType.CommandPrompt)),
 		primary: KeyMod.CtrlCmd | KeyCode.Backspace,
 	});

--- a/src/vs/workbench/contrib/terminal/browser/terminalActions.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalActions.ts
@@ -116,8 +116,6 @@ export const terminalSendSequenceCommand = (accessor: ServicesAccessor, args: { 
 	});
 };
 
-const terminalIndexRe = /^([0-9]+): /;
-
 export class TerminalLaunchHelpAction extends Action {
 
 	constructor(
@@ -2435,6 +2433,8 @@ export function registerTerminalActions() {
 				accessor.get(IConfigurationService).updateValue(TerminalSettingId.TabsEnabled, true);
 				return;
 			}
+
+			const terminalIndexRe = /^([0-9]+): /;
 			const indexMatches = terminalIndexRe.exec(item);
 			if (indexMatches) {
 				terminalGroupService.setActiveGroupByIndex(Number(indexMatches[1]) - 1);

--- a/src/vs/workbench/contrib/terminal/browser/terminalConfigHelper.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalConfigHelper.ts
@@ -20,8 +20,10 @@ import { IXtermCore } from 'vs/workbench/contrib/terminal/browser/xterm-private'
 import { IShellLaunchConfig } from 'vs/platform/terminal/common/terminal';
 import { isLinux, isWindows } from 'vs/base/common/platform';
 
-const MINIMUM_FONT_SIZE = 6;
-const MAXIMUM_FONT_SIZE = 100;
+const enum FontConstants {
+	MinimumFontSize = 6,
+	MaximumFontSize = 100,
+}
 
 /**
  * Encapsulates terminal configuration logic, the primary purpose of this file is so that platform
@@ -156,7 +158,7 @@ export class TerminalConfigHelper implements IBrowserTerminalConfigHelper {
 		const editorConfig = this._configurationService.getValue<IEditorOptions>('editor');
 
 		let fontFamily = this.config.fontFamily || editorConfig.fontFamily || EDITOR_FONT_DEFAULTS.fontFamily;
-		let fontSize = this._clampInt(this.config.fontSize, MINIMUM_FONT_SIZE, MAXIMUM_FONT_SIZE, EDITOR_FONT_DEFAULTS.fontSize);
+		let fontSize = this._clampInt(this.config.fontSize, FontConstants.MinimumFontSize, FontConstants.MaximumFontSize, EDITOR_FONT_DEFAULTS.fontSize);
 
 		// Work around bad font on Fedora/Ubuntu
 		if (!this.config.fontFamily) {
@@ -167,7 +169,7 @@ export class TerminalConfigHelper implements IBrowserTerminalConfigHelper {
 				fontFamily = '\'Ubuntu Mono\'';
 
 				// Ubuntu mono is somehow smaller, so set fontSize a bit larger to get the same perceived size.
-				fontSize = this._clampInt(fontSize + 2, MINIMUM_FONT_SIZE, MAXIMUM_FONT_SIZE, EDITOR_FONT_DEFAULTS.fontSize);
+				fontSize = this._clampInt(fontSize + 2, FontConstants.MinimumFontSize, FontConstants.MaximumFontSize, EDITOR_FONT_DEFAULTS.fontSize);
 			}
 		}
 

--- a/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
@@ -131,9 +131,12 @@ interface IGridDimensions {
 	rows: number;
 }
 
-const shellIntegrationSupportedShellTypes = [PosixShellType.Bash, PosixShellType.Zsh, PosixShellType.PowerShell, WindowsShellType.PowerShell];
-
-const scrollbarHeight = 5;
+const shellIntegrationSupportedShellTypes = [
+	PosixShellType.Bash,
+	PosixShellType.Zsh,
+	PosixShellType.PowerShell,
+	WindowsShellType.PowerShell
+];
 
 export class TerminalInstance extends Disposable implements ITerminalInstance {
 	private static _lastKnownCanvasDimensions: ICanvasDimensions | undefined;
@@ -716,7 +719,7 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 		const verticalPadding = parseInt(computedStyle.paddingTop) + parseInt(computedStyle.paddingBottom);
 		TerminalInstance._lastKnownCanvasDimensions = new dom.Dimension(
 			Math.min(Constants.MaxCanvasWidth, width - horizontalPadding),
-			height + (this._hasScrollBar && !this._horizontalScrollbar ? -scrollbarHeight : 0) - 2/* bottom padding */ - verticalPadding);
+			height + (this._hasScrollBar && !this._horizontalScrollbar ? -5/* scroll bar height */ : 0) - 2/* bottom padding */ - verticalPadding);
 		return TerminalInstance._lastKnownCanvasDimensions;
 	}
 

--- a/src/vs/workbench/contrib/terminal/browser/terminalProcessManager.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalProcessManager.ts
@@ -39,15 +39,18 @@ import { TaskSettingId } from 'vs/workbench/contrib/tasks/common/tasks';
 import Severity from 'vs/base/common/severity';
 import { INotificationService } from 'vs/platform/notification/common/notification';
 
-/** The amount of time to consider terminal errors to be related to the launch */
-const LAUNCHING_DURATION = 500;
+const enum ProcessConstants {
+	/**
+	 * The amount of time to consider terminal errors to be related to the launch.
+	 */
+	ErrorLaunchThresholdDuration = 500,
+	/**
+	 * The minimum amount of time between latency requests.
+	 */
+	LatencyMeasuringInterval = 1000,
+}
 
-/**
- * The minimum amount of time between latency requests.
- */
-const LATENCY_MEASURING_INTERVAL = 1000;
-
-enum ProcessType {
+const enum ProcessType {
 	Process,
 	PsuedoTerminal
 }
@@ -377,7 +380,7 @@ export class TerminalProcessManager extends Disposable implements ITerminalProce
 			if (this.processState === ProcessState.Launching) {
 				this._setProcessState(ProcessState.Running);
 			}
-		}, LAUNCHING_DURATION);
+		}, ProcessConstants.ErrorLaunchThresholdDuration);
 
 		const result = await newProcess.start();
 		if (result) {
@@ -597,7 +600,7 @@ export class TerminalProcessManager extends Disposable implements ITerminalProce
 		if (!this._process) {
 			return Promise.resolve(0);
 		}
-		if (this._latencyLastMeasured === 0 || this._latencyLastMeasured + LATENCY_MEASURING_INTERVAL < Date.now()) {
+		if (this._latencyLastMeasured === 0 || this._latencyLastMeasured + ProcessConstants.LatencyMeasuringInterval < Date.now()) {
 			const latencyRequest = this._process.getLatency();
 			this._latency = await latencyRequest;
 			this._latencyLastMeasured = Date.now();

--- a/src/vs/workbench/contrib/terminal/browser/terminalProfileResolverService.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalProfileResolverService.ts
@@ -37,16 +37,16 @@ export interface IProfileContextProvider {
 
 const generatedProfileName = 'Generated';
 
-/*
-* Resolves terminal shell launch config and terminal
-* profiles for the given operating system,
-* environment, and user configuration
-*/
-
-const SHOULD_PROMPT_FOR_PROFILE_MIGRATION_KEY = 'terminals.integrated.profile-migration';
+const enum StorageKeys {
+	ShouldPromptForProfileMigration = 'terminals.integrated.profile-migration'
+}
 
 let migrationMessageShown = false;
 
+/*
+ * Resolves terminal shell launch config and terminal profiles for the given operating system,
+ * environment, and user configuration.
+ */
 export abstract class BaseTerminalProfileResolverService implements ITerminalProfileResolverService {
 	declare _serviceBrand: undefined;
 
@@ -482,7 +482,7 @@ export abstract class BaseTerminalProfileResolverService implements ITerminalPro
 		const shouldMigrateToProfile = (!!this._configurationService.getValue(TerminalSettingPrefix.Shell + this._primaryBackendOs) ||
 			!!this._configurationService.inspect(TerminalSettingPrefix.ShellArgs + this._primaryBackendOs).userValue) &&
 			!!this._configurationService.getValue(TerminalSettingPrefix.DefaultProfile + this._primaryBackendOs);
-		if (shouldMigrateToProfile && this._storageService.getBoolean(SHOULD_PROMPT_FOR_PROFILE_MIGRATION_KEY, StorageScope.WORKSPACE, true) && !migrationMessageShown) {
+		if (shouldMigrateToProfile && this._storageService.getBoolean(StorageKeys.ShouldPromptForProfileMigration, StorageScope.WORKSPACE, true) && !migrationMessageShown) {
 			this._notificationService.prompt(
 				Severity.Info,
 				localize('terminalProfileMigration', "The terminal is using deprecated shell/shellArgs settings, do you want to migrate it to a profile?"),
@@ -513,7 +513,7 @@ export abstract class BaseTerminalProfileResolverService implements ITerminalPro
 					} as IPromptChoice,
 				],
 				{
-					neverShowAgain: { id: SHOULD_PROMPT_FOR_PROFILE_MIGRATION_KEY, scope: NeverShowAgainScope.WORKSPACE }
+					neverShowAgain: { id: StorageKeys.ShouldPromptForProfileMigration, scope: NeverShowAgainScope.WORKSPACE }
 				}
 			);
 			migrationMessageShown = true;

--- a/src/vs/workbench/contrib/terminal/browser/terminalQuickFixBuiltinActions.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalQuickFixBuiltinActions.ts
@@ -11,7 +11,6 @@ import { ITerminalInstance } from 'vs/workbench/contrib/terminal/browser/termina
 export const GitCommandLineRegex = /git/;
 export const GitPushCommandLineRegex = /git\s+push/;
 export const GitTwoDashesRegex = /error: did you mean `--(.+)` \(with two dashes\)\?/;
-const AnyCommandLineRegex = /.+/;
 export const GitSimilarOutputRegex = /(?:(most similar (command|commands) (is|are)))((\n\s*(?<fixedCommand>[^\s]+))+)/m;
 export const FreePortOutputRegex = /address already in use (0\.0\.0\.0|127\.0\.0\.1|localhost|::):(?<portNumber>\d{4,5})|Unable to bind [^ ]*:(\d{4,5})|can't listen on port (\d{4,5})|listen EADDRINUSE [^ ]*:(\d{4,5})/;
 export const GitPushOutputRegex = /git push --set-upstream origin (?<branchName>[^\s]+)/;
@@ -89,7 +88,7 @@ export function freePort(terminalInstance?: Partial<ITerminalInstance>): IIntern
 	return {
 		id: 'Free Port',
 		type: 'internal',
-		commandLineMatcher: AnyCommandLineRegex,
+		commandLineMatcher: /.+/,
 		outputMatcher: {
 			lineMatcher: FreePortOutputRegex,
 			anchor: 'bottom',

--- a/src/vs/workbench/contrib/terminal/browser/xterm/quickFixAddon.ts
+++ b/src/vs/workbench/contrib/terminal/browser/xterm/quickFixAddon.ts
@@ -32,7 +32,13 @@ import { Schemas } from 'vs/base/common/network';
 import { URI } from 'vs/base/common/uri';
 import { ITerminalContributionService } from 'vs/workbench/contrib/terminal/common/terminalExtensionPoints';
 
-const quickFixSelectors = [DecorationSelector.QuickFix, DecorationSelector.LightBulb, DecorationSelector.Codicon, DecorationSelector.CommandDecoration, DecorationSelector.XtermDecoration];
+const quickFixSelectors = [
+	DecorationSelector.QuickFix,
+	DecorationSelector.LightBulb,
+	DecorationSelector.Codicon,
+	DecorationSelector.CommandDecoration,
+	DecorationSelector.XtermDecoration
+];
 
 export interface ITerminalQuickFixAddon {
 	showMenu(): void;

--- a/src/vs/workbench/contrib/terminal/browser/xterm/quickFixAddon.ts
+++ b/src/vs/workbench/contrib/terminal/browser/xterm/quickFixAddon.ts
@@ -17,7 +17,6 @@ import { IDecoration, Terminal } from 'xterm';
 // eslint-disable-next-line local/code-import-patterns
 import type { ITerminalAddon } from 'xterm-headless';
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
-import { ILogService } from 'vs/platform/log/common/log';
 import { CancellationTokenSource } from 'vs/base/common/cancellation';
 import { IExtensionService } from 'vs/workbench/services/extensions/common/extensions';
 import { AudioCue, IAudioCueService } from 'vs/platform/audioCues/browser/audioCueService';
@@ -61,7 +60,7 @@ export class TerminalQuickFixAddon extends Disposable implements ITerminalAddon,
 
 	private _lastQuickFixId: string | undefined;
 
-	private registeredSelectors: Set<string> = new Set();
+	private _registeredSelectors: Set<string> = new Set();
 
 	constructor(
 		private readonly _aliases: string[][] | undefined,
@@ -71,7 +70,6 @@ export class TerminalQuickFixAddon extends Disposable implements ITerminalAddon,
 		@IAudioCueService private readonly _audioCueService: IAudioCueService,
 		@IOpenerService private readonly _openerService: IOpenerService,
 		@ITelemetryService private readonly _telemetryService: ITelemetryService,
-		@ILogService private readonly _logService: ILogService,
 		@IExtensionService private readonly _extensionService: IExtensionService,
 		@IActionWidgetService private readonly _actionWidgetService: IActionWidgetService,
 		@ILabelService private readonly _labelService: ILabelService,
@@ -130,7 +128,7 @@ export class TerminalQuickFixAddon extends Disposable implements ITerminalAddon,
 	}
 
 	registerCommandSelector(selector: ITerminalCommandSelector): void {
-		if (this.registeredSelectors.has(selector.id)) {
+		if (this._registeredSelectors.has(selector.id)) {
 			return;
 		}
 		const matcherKey = selector.commandLineMatcher.toString();
@@ -142,7 +140,7 @@ export class TerminalQuickFixAddon extends Disposable implements ITerminalAddon,
 			outputMatcher: selector.outputMatcher,
 			commandExitResult: selector.commandExitResult
 		});
-		this.registeredSelectors.add(selector.id);
+		this._registeredSelectors.add(selector.id);
 		this._commandListeners.set(matcherKey, currentOptions);
 	}
 

--- a/src/vs/workbench/contrib/terminal/browser/xterm/quickFixAddon.ts
+++ b/src/vs/workbench/contrib/terminal/browser/xterm/quickFixAddon.ts
@@ -33,17 +33,6 @@ import { Schemas } from 'vs/base/common/network';
 import { URI } from 'vs/base/common/uri';
 import { ITerminalContributionService } from 'vs/workbench/contrib/terminal/common/terminalExtensionPoints';
 
-const quickFixTelemetryTitle = 'terminal/quick-fix';
-type QuickFixResultTelemetryEvent = {
-	quickFixId: string;
-	ranQuickFix: boolean;
-};
-type QuickFixClassification = {
-	owner: 'meganrogge';
-	quickFixId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The quick fix ID' };
-	ranQuickFix: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Whether the quick fix was run' };
-	comment: 'Terminal quick fixes';
-};
 const quickFixSelectors = [DecorationSelector.QuickFix, DecorationSelector.LightBulb, DecorationSelector.Codicon, DecorationSelector.CommandDecoration, DecorationSelector.XtermDecoration];
 
 export interface ITerminalQuickFixAddon {
@@ -209,11 +198,17 @@ export class TerminalQuickFixAddon extends Disposable implements ITerminalAddon,
 	}
 
 	private _disposeQuickFix(id: string, ranQuickFix: boolean): void {
-		this._logService.debug(quickFixTelemetryTitle, {
-			quickFixId: id,
-			ranQuickFix
-		});
-		this._telemetryService?.publicLog2<QuickFixResultTelemetryEvent, QuickFixClassification>(quickFixTelemetryTitle, {
+		type QuickFixResultTelemetryEvent = {
+			quickFixId: string;
+			ranQuickFix: boolean;
+		};
+		type QuickFixClassification = {
+			owner: 'meganrogge';
+			quickFixId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The quick fix ID' };
+			ranQuickFix: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Whether the quick fix was run' };
+			comment: 'Terminal quick fixes';
+		};
+		this._telemetryService?.publicLog2<QuickFixResultTelemetryEvent, QuickFixClassification>('terminal/quick-fix', {
 			quickFixId: id,
 			ranQuickFix
 		});

--- a/src/vs/workbench/contrib/terminal/browser/xterm/xtermTerminal.ts
+++ b/src/vs/workbench/contrib/terminal/browser/xterm/xtermTerminal.ts
@@ -37,12 +37,15 @@ import { ITerminalCapabilityStore, ITerminalCommand, TerminalCapability } from '
 import { Emitter } from 'vs/base/common/event';
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 
-
-// How long in milliseconds should an average frame take to render for a notification to appear
-// which suggests the fallback DOM-based renderer
-const SLOW_CANVAS_RENDER_THRESHOLD = 50;
-const NUMBER_OF_FRAMES_TO_MEASURE = 20;
-const SMOOTH_SCROLL_DURATION = 125;
+const enum RenderConstants {
+	/**
+	 * How long in milliseconds should an average frame take to render for a notification to appear
+	 * which suggests the fallback DOM-based renderer.
+	 */
+	SlowCanvasRenderThreshold = 50,
+	NumberOfFramestoMeasure = 20,
+	SmoothScrollDuration = 125
+}
 
 let CanvasAddon: typeof CanvasAddonType;
 let SearchAddon: typeof SearchAddonType;
@@ -216,7 +219,7 @@ export class XtermTerminal extends DisposableStore implements IXtermTerminal, II
 			scrollSensitivity: config.mouseWheelScrollSensitivity,
 			wordSeparator: config.wordSeparators,
 			overviewRulerWidth: 10,
-			smoothScrollDuration: config.smoothScrolling ? SMOOTH_SCROLL_DURATION : 0
+			smoothScrollDuration: config.smoothScrolling ? RenderConstants.SmoothScrollDuration : 0
 		}));
 		this._core = (this.raw as any)._core as IXtermCore;
 
@@ -310,7 +313,7 @@ export class XtermTerminal extends DisposableStore implements IXtermTerminal, II
 		this.raw.options.rightClickSelectsWord = config.rightClickBehavior === 'selectWord';
 		this.raw.options.wordSeparator = config.wordSeparators;
 		this.raw.options.customGlyphs = config.customGlyphs;
-		this.raw.options.smoothScrollDuration = config.smoothScrolling ? SMOOTH_SCROLL_DURATION : 0;
+		this.raw.options.smoothScrollDuration = config.smoothScrolling ? RenderConstants.SmoothScrollDuration : 0;
 		if (this._shouldLoadWebgl()) {
 			this._enableWebglRenderer();
 		} else {
@@ -620,7 +623,7 @@ export class XtermTerminal extends DisposableStore implements IXtermTerminal, II
 			frameTimes.shift();
 
 			const medianTime = frameTimes.sort((a, b) => a - b)[Math.floor(frameTimes.length / 2)];
-			if (medianTime > SLOW_CANVAS_RENDER_THRESHOLD) {
+			if (medianTime > RenderConstants.SlowCanvasRenderThreshold) {
 				if (this._configHelper.config.gpuAcceleration === 'auto') {
 					XtermTerminal._suggestedRendererType = 'dom';
 					this.updateConfig();
@@ -653,7 +656,7 @@ export class XtermTerminal extends DisposableStore implements IXtermTerminal, II
 			const startTime = performance.now();
 			originalOnGridChanged.call(textRenderLayer, terminal, firstRow, lastRow);
 			frameTimes.push(performance.now() - startTime);
-			if (frameTimes.length === NUMBER_OF_FRAMES_TO_MEASURE) {
+			if (frameTimes.length === RenderConstants.NumberOfFramestoMeasure) {
 				evaluateCanvasRenderer();
 				// Restore original function
 				textRenderLayer.onGridChanged = originalOnGridChanged;


### PR DESCRIPTION
This primarily changes most global constants in the terminal code to either be inline or move to const enums which get inlined at compile time.

Fixes #163554