### PR TITLE
Use readonly for enable/disable of quick pick in order to preserve focus to the inputbox

### DIFF
--- a/src/vs/base/parts/quickinput/browser/quickInput.ts
+++ b/src/vs/base/parts/quickinput/browser/quickInput.ts
@@ -1730,9 +1730,6 @@ export class QuickInputController extends Disposable {
 			this.getUI().inputBox.enabled = enabled;
 			this.getUI().ok.enabled = enabled;
 			this.getUI().list.enabled = enabled;
-			if (!enabled) {
-				this.getUI().container.focus();
-			}
 		}
 	}
 

--- a/src/vs/base/parts/quickinput/browser/quickInputBox.ts
+++ b/src/vs/base/parts/quickinput/browser/quickInputBox.ts
@@ -91,7 +91,15 @@ export class QuickInputBox extends Disposable {
 	}
 
 	set enabled(enabled: boolean) {
-		this.findInput.setEnabled(enabled);
+		// We can't disable the input box because it is still used for
+		// navigating the list. Instead, we disable the list and the OK
+		// so that nothing can be selected.
+		// TODO: should this be what we do for all find inputs? Or maybe some _other_ API
+		// on findInput to change it to readonly?
+		this.findInput.inputBox.inputElement.toggleAttribute('readonly', !enabled);
+		// TODO: styles of the quick pick need to be moved to the CSS instead of being in line
+		// so things like this can be done in CSS
+		// this.findInput.inputBox.inputElement.classList.toggle('disabled', !enabled);
 	}
 
 	set toggles(toggles: Toggle[] | undefined) {


### PR DESCRIPTION
Fixes #163753

This is a tactical fix in order to give us a "disabled" input box but also not mess with focus and keybindings.

The look of a disabled quick input still needs to be done, but that can be done when quickpick applies style via CSS variables instead instead of inline.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
