### PR TITLE
Fix remote servers that never had a connection not shutting down

### DIFF
--- a/src/vs/server/node/remoteExtensionHostAgentServer.ts
+++ b/src/vs/server/node/remoteExtensionHostAgentServer.ts
@@ -89,6 +89,8 @@ class RemoteExtensionHostAgentServer extends Disposable implements IServerAPI {
 				: null
 		);
 		this._logService.info(`Extension host agent started.`);
+
+		this._waitThenShutdown(true);
 	}
 
 	public async handleRequest(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
@@ -587,12 +589,12 @@ class RemoteExtensionHostAgentServer extends Disposable implements IServerAPI {
 		}
 	}
 
-	private _waitThenShutdown(): void {
+	private _waitThenShutdown(initial = false): void {
 		if (!this._environmentService.args['enable-remote-auto-shutdown']) {
 			return;
 		}
 
-		if (this._environmentService.args['remote-auto-shutdown-without-delay']) {
+		if (this._environmentService.args['remote-auto-shutdown-without-delay'] && !initial) {
 			this._shutdown();
 		} else {
 			this.shutdownTimer = setTimeout(() => {


### PR DESCRIPTION
Fixes microsoft/vscode-remote-release#4390

@alexdima, my only question is, this would change the behavior for anyone who wants to start a remote server early and connect to it more than 5 minutes later. Do you think that's a scenario for codespaces or anyone else? Should this be a new flag for Remote-SSH?