### PR TITLE
Switch to standard imports

### DIFF
--- a/extensions/github/src/pushErrorHandler.ts
+++ b/extensions/github/src/pushErrorHandler.ts
@@ -7,7 +7,7 @@ import { TextDecoder } from 'util';
 import { commands, env, ProgressLocation, Uri, window, workspace, QuickPickOptions, FileType, l10n } from 'vscode';
 import { getOctokit } from './auth';
 import { GitErrorCodes, PushErrorHandler, Remote, Repository } from './typings/git';
-import path = require('path');
+import * as path from 'path';
 
 type Awaited<T> = T extends PromiseLike<infer U> ? Awaited<U> : T;
 

--- a/extensions/microsoft-authentication/src/AADHelper.ts
+++ b/extensions/microsoft-authentication/src/AADHelper.ts
@@ -5,7 +5,7 @@
 
 import * as vscode from 'vscode';
 import * as querystring from 'querystring';
-import path = require('path');
+import * as path from 'path';
 import Logger from './logger';
 import { isSupportedEnvironment } from './utils';
 import { generateCodeChallenge, generateCodeVerifier, randomUUID } from './cryptoUtils';

--- a/extensions/npm/src/preferred-pm.ts
+++ b/extensions/npm/src/preferred-pm.ts
@@ -4,9 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 
 import findWorkspaceRoot = require('../node_modules/find-yarn-workspace-root');
-import findUp = require('find-up');
+import * as findUp from 'find-up';
 import * as path from 'path';
-import whichPM = require('which-pm');
+import * as whichPM from 'which-pm';
 import { Uri, workspace } from 'vscode';
 
 interface PreferredProperties {


### PR DESCRIPTION
We shouldn't use `import x = require(...)` in most cases