### PR TITLE
remove mac specific styling for WCO

### DIFF
--- a/src/vs/workbench/browser/parts/titlebar/media/titlebarpart.css
+++ b/src/vs/workbench/browser/parts/titlebar/media/titlebarpart.css
@@ -240,11 +240,6 @@
 	zoom: calc(1 / var(--zoom-factor));
 }
 
-.monaco-workbench.mac .part.titlebar>.window-controls-container {
-	width: 70px;
-	height: env(titlebar-area-height, 28px);
-}
-
 .monaco-workbench.web .part.titlebar>.window-controls-container {
 	width: calc(100% - env(titlebar-area-width, 100%));
 	height: env(titlebar-area-height, 35px);

--- a/src/vs/workbench/browser/parts/titlebar/media/titlebarpart.css
+++ b/src/vs/workbench/browser/parts/titlebar/media/titlebarpart.css
@@ -240,6 +240,10 @@
 	zoom: calc(1 / var(--zoom-factor));
 }
 
+.monaco-workbench.mac .part.titlebar>.window-controls-container {
+	width: 70px;
+}
+
 .monaco-workbench.web .part.titlebar>.window-controls-container {
 	width: calc(100% - env(titlebar-area-width, 100%));
 	height: env(titlebar-area-height, 35px);


### PR DESCRIPTION
esp remove usage of the `env()` function because that shows terrible performance

https://github.com/microsoft/vscode/issues/165441
