### PR TITLE
remove mac specific styling for WCO (#169549)

### DIFF
--- a/src/vs/workbench/browser/parts/titlebar/media/titlebarpart.css
+++ b/src/vs/workbench/browser/parts/titlebar/media/titlebarpart.css
@@ -238,7 +238,6 @@
 
 .monaco-workbench.mac .part.titlebar>.window-controls-container {
 	width: 70px;
-	height: env(titlebar-area-height, 28px);
 }
 
 .monaco-workbench.web .part.titlebar>.window-controls-container {


### PR DESCRIPTION
* remove mac specific styling for WCO

esp remove usage of the `env()` function because that shows terrible performance

Refs https://github.com/microsoft/vscode/issues/165441
Fixes https://github.com/microsoft/vscode/issues/169142

* keep width property

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
