### PR TITLE
Ignore pointer events from nested ListViews

### DIFF
--- a/src/vs/base/browser/ui/list/listWidget.ts
+++ b/src/vs/base/browser/ui/list/listWidget.ts
@@ -685,6 +685,10 @@ export class MouseController<T> implements IDisposable {
 			return;
 		}
 
+		if (e.browserEvent.defaultPrevented) {
+			return;
+		}
+
 		const focus = e.index;
 
 		if (typeof focus === 'undefined') {
@@ -709,6 +713,7 @@ export class MouseController<T> implements IDisposable {
 			this.list.setSelection([focus], e.browserEvent);
 		}
 
+		e.browserEvent.preventDefault();
 		this._onPointer.fire(e);
 	}
 
@@ -721,8 +726,13 @@ export class MouseController<T> implements IDisposable {
 			return;
 		}
 
+		if (e.browserEvent.defaultPrevented) {
+			return;
+		}
+
 		const focus = this.list.getFocus();
 		this.list.setSelection(focus, e.browserEvent);
+		e.browserEvent.preventDefault();
 	}
 
 	private changeSelection(e: IListMouseEvent<T> | IListTouchEvent<T>): void {

--- a/src/vs/base/browser/ui/tree/abstractTree.ts
+++ b/src/vs/base/browser/ui/tree/abstractTree.ts
@@ -1244,6 +1244,10 @@ class TreeNodeListMouseController<T, TFilterData, TRef> extends MouseController<
 			return;
 		}
 
+		if (e.browserEvent.defaultPrevented) {
+			return;
+		}
+
 		const node = e.element;
 
 		if (!node) {
@@ -1292,6 +1296,10 @@ class TreeNodeListMouseController<T, TFilterData, TRef> extends MouseController<
 		const onTwistie = (e.browserEvent.target as HTMLElement).classList.contains('monaco-tl-twistie');
 
 		if (onTwistie || !this.tree.expandOnDoubleClick) {
+			return;
+		}
+
+		if (e.browserEvent.defaultPrevented) {
 			return;
 		}
 


### PR DESCRIPTION
Fix #97820

This is one option, the inner ListView uses preventDefault to mark the event as "handled". I don't think we should lose any events that we are intending to handle, but that's a risk.

Another option would be to mark each event with the ListView that it came from, in a similar way to how we find the element https://github.com/microsoft/vscode/blob/1456f4671c3d74d31008d86e9ba4f640defdb4dc/src/vs/base/browser/ui/list/listView.ts#L1246 and somewhere filter out events that came from a different ListView.