### PR TITLE
web - cleanup embedder API impl

### DIFF
--- a/src/vs/workbench/browser/web.main.ts
+++ b/src/vs/workbench/browser/web.main.ts
@@ -5,6 +5,7 @@
 
 import { mark } from 'vs/base/common/performance';
 import { domContentLoaded, detectFullscreen, getCookieValue } from 'vs/base/browser/dom';
+import { assertIsDefined } from 'vs/base/common/types';
 import { ServiceCollection } from 'vs/platform/instantiation/common/serviceCollection';
 import { ILogService, ConsoleLogger, MultiplexLogService, getLogLevel, ILoggerService } from 'vs/platform/log/common/log';
 import { ConsoleLogInAutomationLogger } from 'vs/platform/log/browser/log';
@@ -144,7 +145,7 @@ export class BrowserMain extends Disposable {
 			const remoteExplorerService = accessor.get(IRemoteExplorerService);
 			const labelService = accessor.get(ILabelService);
 
-			const embedderLogger = instantiationService.createInstance(DelayedLogChannel, 'webEmbedder', productService.embedderIdentifier || localize('vscode.dev', "vscode.dev"), joinPath(dirname(environmentService.logFile), `webEmbedder.log`));
+			let logger: DelayedLogChannel | undefined = undefined;
 
 			return {
 				commands: {
@@ -165,15 +166,19 @@ export class BrowserMain extends Disposable {
 				},
 				logger: {
 					log: (level, message) => {
-						embedderLogger.log(level, message);
+						if (!logger) {
+							logger = instantiationService.createInstance(DelayedLogChannel, 'webEmbedder', productService.embedderIdentifier || productService.nameShort, joinPath(dirname(environmentService.logFile), 'webEmbedder.log'));
+						}
+
+						logger.log(level, message);
 					}
 				},
 				window: {
 					withProgress: (options, task) => progressService.withProgress(options, task)
 				},
 				workspace: {
-					openTunnel: async (tunnelOptions) => {
-						const tunnel = await remoteExplorerService.forward({
+					openTunnel: async tunnelOptions => {
+						const tunnel = assertIsDefined(await remoteExplorerService.forward({
 							remote: tunnelOptions.remoteAddress,
 							local: tunnelOptions.localAddressPort,
 							name: tunnelOptions.label,
@@ -188,16 +193,15 @@ export class BrowserMain extends Disposable {
 							elevateIfNeeded: undefined,
 							onAutoForward: undefined,
 							requireLocalPort: undefined,
-							protocol: tunnelOptions.protocol === TunnelProtocol.Https ? tunnelOptions.protocol : TunnelProtocol.Http,
-
-						});
-						if (!tunnel) {
-							throw new Error('cannot open tunnel');
-						}
+							protocol: tunnelOptions.protocol === TunnelProtocol.Https ? tunnelOptions.protocol : TunnelProtocol.Http
+						}));
 
 						return new class extends DisposableTunnel implements ITunnel {
 							declare localAddress: string;
-						}({ port: tunnel.tunnelRemotePort, host: tunnel.tunnelRemoteHost }, tunnel.localAddress, () => tunnel.dispose());
+						}({
+							port: tunnel.tunnelRemotePort,
+							host: tunnel.tunnelRemoteHost
+						}, tunnel.localAddress, () => tunnel.dispose());
 					}
 				},
 				shutdown: () => lifecycleService.shutdown()

--- a/src/vs/workbench/contrib/remote/browser/tunnelView.ts
+++ b/src/vs/workbench/contrib/remote/browser/tunnelView.ts
@@ -1504,6 +1504,8 @@ namespace ChangeTunnelPrivacyAction {
 					source: arg.source
 				});
 			}
+
+			return undefined;
 		};
 	}
 }

--- a/src/vs/workbench/services/remote/common/remoteExplorerService.ts
+++ b/src/vs/workbench/services/remote/common/remoteExplorerService.ts
@@ -597,7 +597,7 @@ export class TunnelModel extends Disposable {
 		return this.dialogService.show(Severity.Info, mismatchString);
 	}
 
-	async forward(tunnelProperties: TunnelProperties, attributes?: Attributes | null): Promise<RemoteTunnel | void> {
+	async forward(tunnelProperties: TunnelProperties, attributes?: Attributes | null): Promise<RemoteTunnel | undefined> {
 		const existingTunnel = mapHasAddressLocalhostOrAllInterfaces(this.forwarded, tunnelProperties.remote.host, tunnelProperties.remote.port);
 		attributes = attributes ??
 			((attributes !== null)
@@ -655,6 +655,8 @@ export class TunnelModel extends Disposable {
 			}
 			return mapHasAddressLocalhostOrAllInterfaces(this.remoteTunnels, tunnelProperties.remote.host, tunnelProperties.remote.port);
 		}
+
+		return undefined;
 	}
 
 	async name(host: string, port: number, name: string) {
@@ -894,7 +896,7 @@ export interface IRemoteExplorerService {
 	onDidChangeEditable: Event<{ tunnel: ITunnelItem; editId: TunnelEditId } | undefined>;
 	setEditable(tunnelItem: ITunnelItem | undefined, editId: TunnelEditId, data: IEditableData | null): void;
 	getEditableData(tunnelItem: ITunnelItem | undefined, editId?: TunnelEditId): IEditableData | undefined;
-	forward(tunnelProperties: TunnelProperties, attributes?: Attributes | null): Promise<RemoteTunnel | void>;
+	forward(tunnelProperties: TunnelProperties, attributes?: Attributes | null): Promise<RemoteTunnel | undefined>;
 	close(remote: { host: string; port: number }): Promise<void>;
 	setTunnelInformation(tunnelInformation: TunnelInformation | undefined): void;
 	setCandidateFilter(filter: ((candidates: CandidatePort[]) => Promise<CandidatePort[]>) | undefined): IDisposable;
@@ -953,7 +955,7 @@ class RemoteExplorerService implements IRemoteExplorerService {
 		return this._tunnelModel;
 	}
 
-	forward(tunnelProperties: TunnelProperties, attributes?: Attributes | null): Promise<RemoteTunnel | void> {
+	forward(tunnelProperties: TunnelProperties, attributes?: Attributes | null): Promise<RemoteTunnel | undefined> {
 		return this.tunnelModel.forward(tunnelProperties, attributes);
 	}
 


### PR DESCRIPTION
Still not super happy that we have to build the API facade from the web core, we should find a way to build the facade from different components where the code should belong to.