### PR TITLE
Full support for local files and folders containing [ and ] chars

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/links/terminalLocalLinkDetector.ts
+++ b/src/vs/workbench/contrib/terminal/browser/links/terminalLocalLinkDetector.ts
@@ -45,7 +45,7 @@ const enum RegexPathConstants {
 }
 
 /** A regex that matches paths in the form /foo, ~/foo, ./foo, ../foo, foo/bar */
-export const unixLocalLinkClause = '((' + RegexPathConstants.PathPrefix + '|(' + RegexPathConstants.ExcludedPathCharactersClause + RegexPathConstants.ExcludedStartPathCharactersClause + '*))?(' + RegexPathConstants.PathSeparatorClause + '(' + RegexPathConstants.ExcludedPathCharactersClause + ')+)+)';
+export const unixLocalLinkClause = '((' + RegexPathConstants.PathPrefix + '|(' + RegexPathConstants.ExcludedStartPathCharactersClause + RegexPathConstants.ExcludedPathCharactersClause + '*))?(' + RegexPathConstants.PathSeparatorClause + '(' + RegexPathConstants.ExcludedPathCharactersClause + ')+)+)';
 
 export const winDrivePrefix = '(?:\\\\\\\\\\?\\\\)?[a-zA-Z]:';
 /** A regex that matches paths in the form \\?\c:\foo c:\foo, ~\foo, .\foo, ..\foo, foo\bar */
@@ -123,7 +123,7 @@ export class TerminalLocalLinkDetector implements ITerminalLinkDetector {
 			// up the link here as before that will be matched as a regular file path.
 			if (link.match(/\[\d+,$/)) {
 				const partialText = text.slice(rex.lastIndex);
-				const suffixMatch = partialText.match(/ \d+\]/);
+				const suffixMatch = partialText.match(/^ \d+\]/);
 				if (suffixMatch) {
 					link += suffixMatch[0];
 				}

--- a/src/vs/workbench/contrib/terminal/browser/links/terminalLocalLinkDetector.ts
+++ b/src/vs/workbench/contrib/terminal/browser/links/terminalLocalLinkDetector.ts
@@ -37,17 +37,19 @@ const enum RegexPathConstants {
 	// '":; are allowed in paths but they are often separators so ignore them
 	// Also disallow \\ to prevent a catastropic backtracking case #24795
 	ExcludedPathCharactersClause = '[^\\0\\s!`&*()\'":;\\\\]',
+	ExcludedStartPathCharactersClause = '[^\\0\\s!`&*()\\[\\]\'":;\\\\]',
 	WinOtherPathPrefix = '\\.\\.?|\\~',
 	WinPathSeparatorClause = '(\\\\|\\/)',
 	WinExcludedPathCharactersClause = '[^\\0<>\\?\\|\\/\\s!`&*()\'":;]',
+	WinExcludedStartPathCharactersClause = '[^\\0<>\\?\\|\\/\\s!`&*()\\[\\]\'":;]',
 }
 
 /** A regex that matches paths in the form /foo, ~/foo, ./foo, ../foo, foo/bar */
-export const unixLocalLinkClause = '((' + RegexPathConstants.PathPrefix + '|(' + RegexPathConstants.ExcludedPathCharactersClause + ')+)?(' + RegexPathConstants.PathSeparatorClause + '(' + RegexPathConstants.ExcludedPathCharactersClause + ')+)+)';
+export const unixLocalLinkClause = '((' + RegexPathConstants.PathPrefix + '|(' + RegexPathConstants.ExcludedPathCharactersClause + RegexPathConstants.ExcludedStartPathCharactersClause + '*))?(' + RegexPathConstants.PathSeparatorClause + '(' + RegexPathConstants.ExcludedPathCharactersClause + ')+)+)';
 
 export const winDrivePrefix = '(?:\\\\\\\\\\?\\\\)?[a-zA-Z]:';
 /** A regex that matches paths in the form \\?\c:\foo c:\foo, ~\foo, .\foo, ..\foo, foo\bar */
-export const winLocalLinkClause = '((' + `(${winDrivePrefix}|${RegexPathConstants.WinOtherPathPrefix})` + '|(' + RegexPathConstants.WinExcludedPathCharactersClause + ')+)?(' + RegexPathConstants.WinPathSeparatorClause + '(' + RegexPathConstants.WinExcludedPathCharactersClause + ')+)+)';
+export const winLocalLinkClause = '((' + `(${winDrivePrefix}|${RegexPathConstants.WinOtherPathPrefix})` + '|(' + RegexPathConstants.WinExcludedStartPathCharactersClause + RegexPathConstants.WinExcludedPathCharactersClause + '*))?(' + RegexPathConstants.WinPathSeparatorClause + '(' + RegexPathConstants.WinExcludedPathCharactersClause + ')+)+)';
 
 // TODO: This should eventually move to the more structured terminalLinkParsing
 /** As xterm reads from DOM, space in that case is nonbreaking char ASCII code - 160,
@@ -114,6 +116,17 @@ export class TerminalLocalLinkDetector implements ITerminalLinkDetector {
 			if (stringIndex < 0) {
 				// invalid stringIndex (should not have happened)
 				break;
+			}
+
+			// HACK: In order to support both links containing [ and ] characters as well as the
+			// `<file>[<line>, <col>]` pattern, we need to detect the part after the comma and fix
+			// up the link here as before that will be matched as a regular file path.
+			if (link.match(/\[\d+,$/)) {
+				const partialText = text.slice(rex.lastIndex);
+				const suffixMatch = partialText.match(/ \d+\]/);
+				if (suffixMatch) {
+					link += suffixMatch[0];
+				}
 			}
 
 			// Adjust the link range to exclude a/ and b/ if it looks like a git diff

--- a/src/vs/workbench/contrib/terminal/test/browser/links/linkTestUtils.ts
+++ b/src/vs/workbench/contrib/terminal/test/browser/links/linkTestUtils.ts
@@ -46,7 +46,22 @@ export async function assertLinkHelper(
 	deepStrictEqual(actualLinks, expectedLinks);
 }
 
+function countOccurrences(source: string, pattern: string): number {
+	return source.length - (source.replaceAll(pattern, '').length / pattern.length);
+}
+
 export async function resolveLinkForTest(link: string, uri?: URI): Promise<ResolvedLink> {
+	// A set of conditions to help with square brackets in testing, this is only needed because the
+	// resolve path function must be injected
+	if (link.startsWith('[')) {
+		return null;
+	}
+	if (countOccurrences(link, '[') !== countOccurrences(link, ']')) {
+		return null;
+	}
+	if (link.includes('[') !== link.includes(']')) {
+		return null;
+	}
 	return {
 		link,
 		uri: URI.from({ scheme: Schemas.file, path: link }),

--- a/src/vs/workbench/contrib/terminal/test/browser/links/terminalLocalLinkDetector.test.ts
+++ b/src/vs/workbench/contrib/terminal/test/browser/links/terminalLocalLinkDetector.test.ts
@@ -23,6 +23,9 @@ const unixLinks = [
 	'./$foo',
 	'../foo',
 	'/foo/bar',
+	'/foo/[bar]',
+	'/foo/[bar].baz',
+	'/foo/[bar]/baz',
 	'/foo/bar+more',
 	'foo/bar',
 	'foo/bar+more',
@@ -44,7 +47,12 @@ const windowsLinks = [
 	'c:\\foo/bar\\baz',
 	'foo/bar',
 	'foo/bar',
+	'foo/[bar]',
+	'foo/[bar].baz',
+	'foo/[bar]/baz',
 	'foo\\bar',
+	'foo\\[bar].baz',
+	'foo\\[bar]\\baz',
 	'foo\\bar+more',
 ];
 


### PR DESCRIPTION
Fixes #161543

Examples now supported:

![image](https://user-images.githubusercontent.com/2193314/208985682-2e8baee6-a911-4491-a9dd-2e0a365c26be.png)
![image](https://user-images.githubusercontent.com/2193314/208985723-d08668c5-5b83-484d-83a8-7970303a4fc0.png)
![image](https://user-images.githubusercontent.com/2193314/208985750-371980a2-5940-4afb-925f-3f78a5e5d789.png)
![image](https://user-images.githubusercontent.com/2193314/208985786-a26591d0-f29f-4936-95ea-1880cb6980eb.png)
![image](https://user-images.githubusercontent.com/2193314/208985813-38473147-f04b-4290-9c7e-7f9a6ed228c9.png)
![image](https://user-images.githubusercontent.com/2193314/208985869-107fafde-1494-4e60-9fb9-bab77af2421d.png)
![image](https://user-images.githubusercontent.com/2193314/208985923-7156b5cb-822a-4e7f-9319-16490c94a8be.png)
