### PR TITLE
Extensions:  warn not fail on UnknownError during signature verification

### DIFF
--- a/src/vs/platform/extensionManagement/common/abstractExtensionManagementService.ts
+++ b/src/vs/platform/extensionManagement/common/abstractExtensionManagementService.ts
@@ -25,7 +25,7 @@ import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 import { IUserDataProfilesService } from 'vs/platform/userDataProfile/common/userDataProfile';
 
 export const enum ExtensionVerificationStatus {
-	'Verified' = 'verified',
+	'Verified' = 'Verified',
 	'Unverified' = 'Unverified',
 	'UnknownError' = 'UnknownError',
 }
@@ -686,7 +686,7 @@ function toExtensionManagementError(error: Error): ExtensionManagementError {
 	return e;
 }
 
-export function reportTelemetry(telemetryService: ITelemetryService, eventName: string, { extensionData, verificationStatus, hadUnknownError, duration, error, durationSinceUpdate }: { extensionData: any; verificationStatus?: ExtensionVerificationStatus; hadUnknownError?: boolean; duration?: number; durationSinceUpdate?: number; error?: Error }): void {
+export function reportTelemetry(telemetryService: ITelemetryService, eventName: string, { extensionData, verificationStatus, duration, error, durationSinceUpdate }: { extensionData: any; verificationStatus?: ExtensionVerificationStatus; duration?: number; durationSinceUpdate?: number; error?: Error }): void {
 	let errorcode: ExtensionManagementErrorCode | undefined;
 	let errorcodeDetail: string | undefined;
 
@@ -736,13 +736,12 @@ export function reportTelemetry(telemetryService: ITelemetryService, eventName: 
 			"errorcode": { "classification": "CallstackOrException", "purpose": "PerformanceAndHealth" },
 			"errorcodeDetail": { "classification": "CallstackOrException", "purpose": "PerformanceAndHealth" },
 			"verificationStatus" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
-			"hadUnknownError" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
 			"${include}": [
 				"${GalleryExtensionTelemetryData}"
 			]
 		}
 	*/
-	telemetryService.publicLog(eventName, { ...extensionData, verificationStatus, hadUnknownError, success: !error, duration, errorcode, errorcodeDetail, durationSinceUpdate });
+	telemetryService.publicLog(eventName, { ...extensionData, verificationStatus, success: !error, duration, errorcode, errorcodeDetail, durationSinceUpdate });
 }
 
 export abstract class AbstractExtensionTask<T> {

--- a/src/vs/platform/extensionManagement/node/extensionDownloader.ts
+++ b/src/vs/platform/extensionManagement/node/extensionDownloader.ts
@@ -19,7 +19,6 @@ import { INativeEnvironmentService } from 'vs/platform/environment/common/enviro
 import { ExtensionManagementError, ExtensionManagementErrorCode, IExtensionGalleryService, IGalleryExtension, InstallOperation } from 'vs/platform/extensionManagement/common/extensionManagement';
 import { ExtensionKey, groupByExtension } from 'vs/platform/extensionManagement/common/extensionManagementUtil';
 import { ExtensionSignatureVerificationError, IExtensionSignatureVerificationService } from 'vs/platform/extensionManagement/node/extensionSignatureVerificationService';
-import { TargetPlatform } from 'vs/platform/extensions/common/extensions';
 import { IFileService, IFileStatWithMetadata } from 'vs/platform/files/common/files';
 import { ILogService } from 'vs/platform/log/common/log';
 import { IProductService } from 'vs/platform/product/common/productService';
@@ -33,7 +32,6 @@ export class ExtensionsDownloader extends Disposable {
 	private readonly cleanUpPromise: Promise<void>;
 
 	constructor(
-		private readonly targetPlatform: Promise<TargetPlatform>,
 		@INativeEnvironmentService environmentService: INativeEnvironmentService,
 		@IFileService private readonly fileService: IFileService,
 		@IExtensionGalleryService private readonly extensionGalleryService: IExtensionGalleryService,
@@ -48,7 +46,7 @@ export class ExtensionsDownloader extends Disposable {
 		this.cleanUpPromise = this.cleanUp();
 	}
 
-	async download(extension: IGalleryExtension, operation: InstallOperation): Promise<{ readonly location: URI; verified: boolean }> {
+	async download(extension: IGalleryExtension, operation: InstallOperation): Promise<{ readonly location: URI; readonly wasVerified: boolean; readonly hadUnknownError: boolean }> {
 		await this.cleanUpPromise;
 
 		const location = joinPath(this.extensionsDownloadDir, this.getName(extension));
@@ -58,31 +56,37 @@ export class ExtensionsDownloader extends Disposable {
 			throw new ExtensionManagementError(error.message, ExtensionManagementErrorCode.Download);
 		}
 
-		let verified: boolean = false;
-		if (await this.checkForVerification(extension)) {
+		let wasVerified: boolean = false;
+		let hadUnknownError: boolean = false;
+
+		if (await this.shouldVerifySignature(extension)) {
 			const signatureArchiveLocation = await this.downloadSignatureArchive(extension);
 			try {
-				verified = await this.extensionSignatureVerificationService.verify(location.fsPath, signatureArchiveLocation.fsPath);
-				this.logService.info(`Verified extension: ${extension.identifier.id}`, verified);
+				wasVerified = await this.extensionSignatureVerificationService.verify(location.fsPath, signatureArchiveLocation.fsPath);
+				this.logService.info(`Extension signature verification: ${extension.identifier.id} (was verified: ${wasVerified})`);
 			} catch (error) {
-				await this.delete(signatureArchiveLocation);
-				await this.delete(location);
-				throw new ExtensionManagementError((error as ExtensionSignatureVerificationError).code, ExtensionManagementErrorCode.Signature);
+				const code: string = (error as ExtensionSignatureVerificationError).code;
+
+				if (code === 'UnknownError') {
+					hadUnknownError = true;
+					this.logService.warn(`Extension signature verification: ${extension.identifier.id} (was verified: ${wasVerified} with UnknownError)`);
+				} else {
+					await this.delete(signatureArchiveLocation);
+					await this.delete(location);
+
+					throw new ExtensionManagementError(code, ExtensionManagementErrorCode.Signature);
+				}
 			}
 		}
 
-		return { location, verified };
+		return { location, wasVerified, hadUnknownError };
 	}
 
-	private async checkForVerification(extension: IGalleryExtension): Promise<boolean> {
+	private async shouldVerifySignature(extension: IGalleryExtension): Promise<boolean> {
 		if (!extension.isSigned) {
 			return false;
 		}
-		const targetPlatform = await this.targetPlatform;
-		// Signing module has issue in this platform - https://github.com/microsoft/vscode/issues/164726
-		if (targetPlatform === TargetPlatform.LINUX_ARMHF) {
-			return false;
-		}
+
 		const value = this.configurationService.getValue('extensions.verifySignature');
 		if (isBoolean(value)) {
 			return value;

--- a/src/vs/platform/extensionManagement/node/extensionDownloader.ts
+++ b/src/vs/platform/extensionManagement/node/extensionDownloader.ts
@@ -66,13 +66,13 @@ export class ExtensionsDownloader extends Disposable {
 				if (verified) {
 					verificationStatus = ExtensionVerificationStatus.Verified;
 				}
-				this.logService.info(`Extension signature verification: ${extension.identifier.id}. Verification Status: ${verificationStatus})`);
+				this.logService.info(`Extension signature verification: ${extension.identifier.id}. Verification status: ${verificationStatus}.`);
 			} catch (error) {
 				const code: string = (error as ExtensionSignatureVerificationError).code;
 
 				if (code === 'UnknownError') {
 					verificationStatus = ExtensionVerificationStatus.UnknownError;
-					this.logService.warn(`Extension signature verification: ${extension.identifier.id} (was verified: ${verificationStatus} with UnknownError)`);
+					this.logService.warn(`Extension signature verification: ${extension.identifier.id}. Verification status: ${verificationStatus}.`);
 				} else {
 					await this.delete(signatureArchiveLocation);
 					await this.delete(location);

--- a/src/vs/platform/extensionManagement/node/extensionSignatureVerificationService.ts
+++ b/src/vs/platform/extensionManagement/node/extensionSignatureVerificationService.ts
@@ -19,7 +19,7 @@ export interface IExtensionSignatureVerificationService {
 	 * @param { string } signatureArchiveFilePath The signature archive file path.
 	 * @returns { Promise<boolean> } A promise with `true` if the extension is validly signed and trusted;
 	 * otherwise, `false` because verification is not enabled (e.g.:  in the OSS version of VS Code).
-	 * @throws { ExtensionVerificationError } An error with a code indicating the validity, integrity, or trust issue
+	 * @throws { ExtensionSignatureVerificationError } An error with a code indicating the validity, integrity, or trust issue
 	 * found during verification or a more fundamental issue (e.g.:  a required dependency was not found).
 	 */
 	verify(vsixFilePath: string, signatureArchiveFilePath: string): Promise<boolean>;

--- a/src/vs/platform/extensionManagement/test/node/installGalleryExtensionTask.test.ts
+++ b/src/vs/platform/extensionManagement/test/node/installGalleryExtensionTask.test.ts
@@ -16,6 +16,7 @@ import { mock } from 'vs/base/test/common/mock';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { TestConfigurationService } from 'vs/platform/configuration/test/common/testConfigurationService';
 import { INativeEnvironmentService } from 'vs/platform/environment/common/environment';
+import { ExtensionVerificationStatus } from 'vs/platform/extensionManagement/common/abstractExtensionManagementService';
 import { ExtensionManagementError, ExtensionManagementErrorCode, getTargetPlatform, IExtensionGalleryService, IGalleryExtension, IGalleryExtensionAssets, ILocalExtension } from 'vs/platform/extensionManagement/common/extensionManagement';
 import { getGalleryExtensionId } from 'vs/platform/extensionManagement/common/extensionManagementUtil';
 import { ExtensionsDownloader } from 'vs/platform/extensionManagement/node/extensionDownloader';
@@ -92,7 +93,7 @@ suite('InstallGalleryExtensionTask Tests', () => {
 
 		await testObject.run();
 
-		assert.strictEqual(testObject.wasVerified, true);
+		assert.strictEqual(testObject.verificationStatus, ExtensionVerificationStatus.Verified);
 		assert.strictEqual(testObject.installed, true);
 	});
 
@@ -101,7 +102,7 @@ suite('InstallGalleryExtensionTask Tests', () => {
 
 		await testObject.run();
 
-		assert.strictEqual(testObject.wasVerified, false);
+		assert.strictEqual(testObject.verificationStatus, ExtensionVerificationStatus.Unverified);
 		assert.strictEqual(testObject.installed, true);
 	});
 
@@ -110,7 +111,7 @@ suite('InstallGalleryExtensionTask Tests', () => {
 
 		await testObject.run();
 
-		assert.strictEqual(testObject.wasVerified, false);
+		assert.strictEqual(testObject.verificationStatus, ExtensionVerificationStatus.Unverified);
 		assert.strictEqual(testObject.installed, true);
 	});
 
@@ -119,7 +120,7 @@ suite('InstallGalleryExtensionTask Tests', () => {
 
 		await testObject.run();
 
-		assert.strictEqual(testObject.wasVerified, false);
+		assert.strictEqual(testObject.verificationStatus, ExtensionVerificationStatus.Unverified);
 		assert.strictEqual(testObject.installed, true);
 	});
 
@@ -134,7 +135,7 @@ suite('InstallGalleryExtensionTask Tests', () => {
 			assert.ok(e instanceof ExtensionManagementError);
 			assert.strictEqual(e.code, ExtensionManagementErrorCode.Signature);
 			assert.strictEqual(e.message, errorCode);
-			assert.strictEqual(testObject.wasVerified, false);
+			assert.strictEqual(testObject.verificationStatus, ExtensionVerificationStatus.Unverified);
 			assert.strictEqual(testObject.installed, false);
 			return;
 		}
@@ -148,7 +149,7 @@ suite('InstallGalleryExtensionTask Tests', () => {
 
 		await testObject.run();
 
-		assert.strictEqual(testObject.wasVerified, true);
+		assert.strictEqual(testObject.verificationStatus, ExtensionVerificationStatus.Verified);
 		assert.strictEqual(testObject.installed, true);
 	});
 
@@ -157,7 +158,7 @@ suite('InstallGalleryExtensionTask Tests', () => {
 
 		await testObject.run();
 
-		assert.strictEqual(testObject.wasVerified, false);
+		assert.strictEqual(testObject.verificationStatus, ExtensionVerificationStatus.Unverified);
 		assert.strictEqual(testObject.installed, true);
 	});
 
@@ -166,7 +167,7 @@ suite('InstallGalleryExtensionTask Tests', () => {
 
 		await testObject.run();
 
-		assert.strictEqual(testObject.wasVerified, false);
+		assert.strictEqual(testObject.verificationStatus, ExtensionVerificationStatus.Unverified);
 		assert.strictEqual(testObject.installed, true);
 	});
 

--- a/src/vs/platform/extensionManagement/test/node/installGalleryExtensionTask.test.ts
+++ b/src/vs/platform/extensionManagement/test/node/installGalleryExtensionTask.test.ts
@@ -21,7 +21,6 @@ import { getGalleryExtensionId } from 'vs/platform/extensionManagement/common/ex
 import { ExtensionsDownloader } from 'vs/platform/extensionManagement/node/extensionDownloader';
 import { ExtensionsScanner, InstallGalleryExtensionTask } from 'vs/platform/extensionManagement/node/extensionManagementService';
 import { IExtensionSignatureVerificationService } from 'vs/platform/extensionManagement/node/extensionSignatureVerificationService';
-import { TargetPlatform } from 'vs/platform/extensions/common/extensions';
 import { IFileService } from 'vs/platform/files/common/files';
 import { FileService } from 'vs/platform/files/common/fileService';
 import { InMemoryFileSystemProvider } from 'vs/platform/files/common/inMemoryFilesystemProvider';
@@ -192,7 +191,7 @@ suite('InstallGalleryExtensionTask Tests', () => {
 		});
 		instantiationService.stub(IConfigurationService, new TestConfigurationService(isBoolean(isSignatureVerificationEnabled) ? { extensions: { verifySignature: isSignatureVerificationEnabled } } : undefined));
 		instantiationService.stub(IExtensionSignatureVerificationService, new TestExtensionSignatureVerificationService(verificationResult));
-		return instantiationService.createInstance(ExtensionsDownloader, Promise.resolve(TargetPlatform.LINUX_X64));
+		return instantiationService.createInstance(ExtensionsDownloader);
 	}
 
 	function aGalleryExtension(name: string, properties: Partial<IGalleryExtension> = {}, galleryExtensionProperties: any = {}, assets: Partial<IGalleryExtensionAssets> = {}): IGalleryExtension {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
Resolve https://github.com/microsoft/vscode/issues/164726.

This change does a few things:

1.  Re-enables extension signature verification on Linux armhf.
2.  Logs a warning (not an error) if extension signature verification fails with `UnknownError`.

    Example of verification success:
    ```
    2022-12-21 11:13:55.387 [info] Extension signature verification: ms-vscode.cpptools. Verification status: Verified.
    ```
    Example of verification failure with `UnknownError`:
    ```
    2022-12-21 11:10:57.744 [warning] Extension signature verification: ms-vscode.cpptools. Verification status: UnknownError.
    ```

3.  Allows an extension install/update to proceed if extension signature verification failed with `UnknownError`.
4.  Reports via telemetry if extension signature verification failed with `UnknownError`.

Note that this PR does not fix the underlying problem (TBD) causing `UnknownError`.

CC @isidorn, @sandy081, @joaomoreno