### PR TITLE
hidesExplorerArrows for search tree should keep arrows for files

### DIFF
--- a/src/vs/workbench/contrib/search/browser/searchResultsView.ts
+++ b/src/vs/workbench/contrib/search/browser/searchResultsView.ts
@@ -244,6 +244,11 @@ export class FileMatchRenderer extends Disposable implements ICompressibleTreeRe
 		templateData.badge.setTitleFormat(count > 1 ? nls.localize('searchMatches', "{0} matches found", count) : nls.localize('searchMatch', "{0} match found", count));
 
 		templateData.actions.context = <ISearchActionContext>{ viewer: this.searchView.getControl(), element: fileMatch };
+
+		// when hidesExplorerArrows: true, then the file nodes should still have a twistie because it would otherwise
+		// be hard to tell whether the node is collapsed or expanded.
+		const twistieContainer = templateData.el.parentElement?.parentElement?.querySelector('.monaco-tl-twistie');
+		twistieContainer?.classList.add('force-twistie');
 	}
 
 	disposeElement(element: ITreeNode<RenderableMatch, any>, index: number, templateData: IFileMatchTemplate): void {


### PR DESCRIPTION
Fixes #169685

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
