### PR TITLE
#162727: 'Debug:Run to cursor' command is now available in inactive d…

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/debug.contribution.ts
+++ b/src/vs/workbench/contrib/debug/browser/debug.contribution.ts
@@ -121,7 +121,7 @@ registerDebugCommandPaletteItem(CONTINUE_ID, CONTINUE_LABEL, CONTEXT_IN_DEBUG_MO
 registerDebugCommandPaletteItem(FOCUS_REPL_ID, { value: nls.localize({ comment: ['Debug is a noun in this context, not a verb.'], key: 'debugFocusConsole' }, 'Focus on Debug Console View'), original: 'Focus on Debug Console View' });
 registerDebugCommandPaletteItem(JUMP_TO_CURSOR_ID, { value: nls.localize('jumpToCursor', "Jump to Cursor"), original: 'Jump to Cursor' }, CONTEXT_JUMP_TO_CURSOR_SUPPORTED);
 registerDebugCommandPaletteItem(JUMP_TO_CURSOR_ID, { value: nls.localize('SetNextStatement', "Set Next Statement"), original: 'Set Next Statement' }, CONTEXT_JUMP_TO_CURSOR_SUPPORTED);
-registerDebugCommandPaletteItem(RunToCursorAction.ID, { value: RunToCursorAction.LABEL, original: 'Run to Cursor' }, ContextKeyExpr.and(CONTEXT_IN_DEBUG_MODE, CONTEXT_DEBUG_STATE.isEqualTo('stopped')));
+registerDebugCommandPaletteItem(RunToCursorAction.ID, { value: RunToCursorAction.LABEL, original: 'Run to Cursor' }, CONTEXT_DEBUGGERS_AVAILABLE);
 registerDebugCommandPaletteItem(SelectionToReplAction.ID, { value: SelectionToReplAction.LABEL, original: 'Evaluate in Debug Console' }, CONTEXT_IN_DEBUG_MODE);
 registerDebugCommandPaletteItem(SelectionToWatchExpressionsAction.ID, { value: SelectionToWatchExpressionsAction.LABEL, original: 'Add to Watch' }, ContextKeyExpr.and(EditorContextKeys.hasNonEmptySelection, CONTEXT_IN_DEBUG_MODE));
 registerDebugCommandPaletteItem(TOGGLE_INLINE_BREAKPOINT_ID, { value: nls.localize('inlineBreakpoint', "Inline Breakpoint"), original: 'Inline Breakpoint' });

--- a/src/vs/workbench/contrib/debug/browser/debugEditorActions.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugEditorActions.ts
@@ -6,6 +6,7 @@
 import { getDomNodePagePosition } from 'vs/base/browser/dom';
 import { Action } from 'vs/base/common/actions';
 import { KeyChord, KeyCode, KeyMod } from 'vs/base/common/keyCodes';
+import { deepClone } from 'vs/base/common/objects';
 import { ICodeEditor } from 'vs/editor/browser/editorBrowser';
 import { EditorAction, EditorAction2, IActionOptions, registerEditorAction } from 'vs/editor/browser/editorExtensions';
 import { Position } from 'vs/editor/common/core/position';
@@ -22,7 +23,7 @@ import { IUriIdentityService } from 'vs/platform/uriIdentity/common/uriIdentity'
 import { PanelFocusContext } from 'vs/workbench/common/contextkeys';
 import { IViewsService } from 'vs/workbench/common/views';
 import { openBreakpointSource } from 'vs/workbench/contrib/debug/browser/breakpointsView';
-import { BreakpointWidgetContext, BREAKPOINT_EDITOR_CONTRIBUTION_ID, CONTEXT_CALLSTACK_ITEM_TYPE, CONTEXT_DEBUGGERS_AVAILABLE, CONTEXT_DEBUG_STATE, CONTEXT_DISASSEMBLE_REQUEST_SUPPORTED, CONTEXT_EXCEPTION_WIDGET_VISIBLE, CONTEXT_FOCUSED_STACK_FRAME_HAS_INSTRUCTION_POINTER_REFERENCE, CONTEXT_IN_DEBUG_MODE, CONTEXT_LANGUAGE_SUPPORTS_DISASSEMBLE_REQUEST, CONTEXT_STEP_INTO_TARGETS_SUPPORTED, EDITOR_CONTRIBUTION_ID, IBreakpointEditorContribution, IDebugConfiguration, IDebugEditorContribution, IDebugService, REPL_VIEW_ID, WATCH_VIEW_ID } from 'vs/workbench/contrib/debug/common/debug';
+import { BreakpointWidgetContext, BREAKPOINT_EDITOR_CONTRIBUTION_ID, CONTEXT_CALLSTACK_ITEM_TYPE, CONTEXT_DEBUGGERS_AVAILABLE, CONTEXT_DEBUG_STATE, CONTEXT_DISASSEMBLE_REQUEST_SUPPORTED, CONTEXT_EXCEPTION_WIDGET_VISIBLE, CONTEXT_FOCUSED_STACK_FRAME_HAS_INSTRUCTION_POINTER_REFERENCE, CONTEXT_IN_DEBUG_MODE, CONTEXT_LANGUAGE_SUPPORTS_DISASSEMBLE_REQUEST, CONTEXT_STEP_INTO_TARGETS_SUPPORTED, EDITOR_CONTRIBUTION_ID, IBreakpoint, IBreakpointEditorContribution, IDebugConfiguration, IDebugEditorContribution, IDebugService, REPL_VIEW_ID, State, WATCH_VIEW_ID } from 'vs/workbench/contrib/debug/common/debug';
 import { DisassemblyViewInput } from 'vs/workbench/contrib/debug/common/disassemblyViewInput';
 import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
 
@@ -249,7 +250,7 @@ export class RunToCursorAction extends EditorAction {
 			id: RunToCursorAction.ID,
 			label: RunToCursorAction.LABEL,
 			alias: 'Debug: Run to Cursor',
-			precondition: ContextKeyExpr.and(CONTEXT_IN_DEBUG_MODE, PanelFocusContext.toNegated(), CONTEXT_DEBUG_STATE.isEqualTo('stopped'), EditorContextKeys.editorTextFocus),
+			precondition: ContextKeyExpr.and(CONTEXT_DEBUGGERS_AVAILABLE, PanelFocusContext.toNegated(), EditorContextKeys.editorTextFocus),
 			contextMenuOpts: {
 				group: 'debug',
 				order: 2
@@ -275,7 +276,29 @@ export class RunToCursorAction extends EditorAction {
 			// otherwise set it at the precise column #102199
 			column = position.column;
 		}
-
+		if (debugService.state === State.Inactive) {
+			// add a break point to be removed later
+			const canSet = debugService.canSetBreakpointsIn(editor.getModel());
+			const modelUri = editor.getModel().uri;
+			let breakPointToRemove: IBreakpoint | undefined;
+			if (canSet) {
+				breakPointToRemove = (await debugService.addBreakpoints(modelUri, [{ lineNumber: position.lineNumber }], false))[0];
+			}
+			// start the debugger . Same as Debug: Start Debugging
+			const { launch, name, getConfig } = debugService.getConfigurationManager().selectedConfiguration;
+			const config = await getConfig();
+			const configOrName = config ? Object.assign(deepClone(config), {}) : name;
+			await debugService.startDebugging(launch, configOrName, undefined, true);
+			// Remove the break point in one time listener
+			// Why can't I invoke runTo and let it do the job ?
+			const listner = debugService.onDidChangeState((state) => {
+				if (state === State.Stopped) {
+					debugService.removeBreakpoints(breakPointToRemove?.getId());
+					listner.dispose();
+				}
+			});
+			return;
+		}
 		await debugService.runTo(uri, position.lineNumber, column);
 	}
 }

--- a/src/vs/workbench/contrib/debug/browser/debugEditorActions.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugEditorActions.ts
@@ -292,7 +292,7 @@ export class RunToCursorAction extends EditorAction {
 			// Remove the break point in one time listener
 			// Why can't I invoke runTo and let it do the job ?
 			const listner = debugService.onDidChangeState((state) => {
-				if (state === State.Stopped) {
+				if (state === State.Stopped || state === State.Inactive) {
 					debugService.removeBreakpoints(breakPointToRemove?.getId());
 					listner.dispose();
 				}

--- a/src/vs/workbench/contrib/debug/browser/debugService.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugService.ts
@@ -1183,7 +1183,7 @@ export class DebugService implements IDebugService {
 				}
 			}
 			return { threadToContinue, breakpointToRemove };
-		}
+		};
 		const removeTempBreakPoint = (state: State, oneTimeListener: IDisposable) => {
 			if (state === State.Stopped || state === State.Inactive) {
 				if (breakpointToRemove) {
@@ -1191,7 +1191,7 @@ export class DebugService implements IDebugService {
 				}
 				oneTimeListener.dispose();
 			}
-		}
+		};
 
 		await addTempBreakPoint();
 		if (this.state === State.Inactive) {
@@ -1200,15 +1200,15 @@ export class DebugService implements IDebugService {
 			const config = await getConfig();
 			const configOrName = config ? Object.assign(deepClone(config), {}) : name;
 			const oneTimeListner = this.onDidChangeState((state) => {
-				removeTempBreakPoint(state, oneTimeListner)
-			})
+				removeTempBreakPoint(state, oneTimeListner);
+			});
 			await this.startDebugging(launch, configOrName, undefined, true);
 			return;
 		}
 		if (this.state === State.Stopped) {
 			const focusedSession = this.getViewModel().focusedSession;
 			if (!focusedSession || !threadToContinue) { return; }
-			const oneTimeListner = threadToContinue.session.onDidChangeState(() => removeTempBreakPoint(focusedSession.state, oneTimeListner))
+			const oneTimeListner = threadToContinue.session.onDidChangeState(() => removeTempBreakPoint(focusedSession.state, oneTimeListner));
 			await threadToContinue.continue();
 			return;
 		}

--- a/src/vs/workbench/contrib/debug/browser/debugService.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugService.ts
@@ -1196,7 +1196,7 @@ export class DebugService implements IDebugService {
 
 		await addTempBreakPoint();
 		if (this.state === State.Inactive) {
-			// If no session exists start the degbugger;
+			// If no session exists start the debugger
 			const { launch, name, getConfig } = this.getConfigurationManager().selectedConfiguration;
 			const config = await getConfig();
 			const configOrName = config ? Object.assign(deepClone(config), {}) : name;
@@ -1206,18 +1206,19 @@ export class DebugService implements IDebugService {
 				}
 			});
 			await this.startDebugging(launch, configOrName, undefined, true);
-			return;
 		}
 		if (this.state === State.Stopped) {
 			const focusedSession = this.getViewModel().focusedSession;
-			if (!focusedSession || !threadToContinue) { return; }
+			if (!focusedSession || !threadToContinue) {
+				return;
+			}
+
 			const listener = threadToContinue.session.onDidChangeState(() => {
 				if (removeTempBreakPoint(focusedSession.state)) {
 					listener.dispose();
 				}
 			});
 			await threadToContinue.continue();
-			return;
 		}
 	}
 


### PR DESCRIPTION
Addresses the feature requested in https://github.com/microsoft/vscode/issues/162727

This PR took the strategy mentioned in this [comment](https://github.com/microsoft/vscode/issues/162727#issuecomment-1268634341) 

## Refactorings
1. The `debuggerService.runTo` is refactored to support inactive debugger state
2. Two closures have been added to handle add and remove temp breakpoints.
3. Remove breakpoints is attached to the listeners in the both the cases (Stopped and Inactive blocks)
