### PR TITLE
Update countBadge CSS to prevent numbers from being broken onto several lines

### DIFF
--- a/src/vs/base/browser/ui/countBadge/countBadge.css
+++ b/src/vs/base/browser/ui/countBadge/countBadge.css
@@ -14,6 +14,7 @@
 	text-align: center;
 	display: inline-block;
 	box-sizing: border-box;
+	white-space: nowrap;
 }
 
 .monaco-count-badge.long {


### PR DESCRIPTION
Fixes #169829
Fixes issue where count badges in the debug terminal are breaking numbers onto several lines.

<img width="650" alt="Screenshot 2022-12-22 at 11 58 56" src="https://user-images.githubusercontent.com/5485364/209132967-f0efd399-0882-478f-b5c7-473d5d2faaf7.png">

<!-- Thank you for submitting a Pull Request. Pleas

e:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
