### PR TITLE
Configuration perf tweaks

### DIFF
--- a/src/vs/platform/configuration/common/configurationModels.ts
+++ b/src/vs/platform/configuration/common/configurationModels.ts
@@ -1098,7 +1098,7 @@ export class ConfigurationChangeEvent implements IConfigurationChangeEvent {
 		// Example: '\nfoo.bar\nabc.def\n'
 		this._affectsConfigStr = this._marker;
 		for (const key of this.affectedKeys) {
-			this._affectsConfigStr = key + this._marker;
+			this._affectsConfigStr += key + this._marker;
 		}
 	}
 

--- a/src/vs/platform/configuration/common/configurationModels.ts
+++ b/src/vs/platform/configuration/common/configurationModels.ts
@@ -1094,9 +1094,11 @@ export class ConfigurationChangeEvent implements IConfigurationChangeEvent {
 				this.affectedKeys.add(key);
 			}
 		}
-		this._affectsConfigStr = '\n';
+
+		// Example: '\nfoo.bar\nabc.def\n'
+		this._affectsConfigStr = this._marker;
 		for (const key of this.affectedKeys) {
-			this._affectsConfigStr = key + '\n';
+			this._affectsConfigStr = key + this._marker;
 		}
 	}
 

--- a/src/vs/platform/configuration/common/configurationRegistry.ts
+++ b/src/vs/platform/configuration/common/configurationRegistry.ts
@@ -23,6 +23,13 @@ export const Extensions = {
 	Configuration: 'base.contributions.configuration'
 };
 
+export interface IConfigurationDelta {
+	removedDefaults?: IConfigurationDefaults[];
+	removedConfigurations?: IConfigurationNode[];
+	addedDefaults?: IConfigurationDefaults[];
+	addedConfigurations?: IConfigurationNode[];
+}
+
 export interface IConfigurationRegistry {
 
 	/**
@@ -58,6 +65,12 @@ export interface IConfigurationRegistry {
 	deregisterDefaultConfigurations(defaultConfigurations: IConfigurationDefaults[]): void;
 
 	/**
+	 * Bulk update of the configuration registry (default and configurations, remove and add)
+	 * @param delta
+	 */
+	deltaConfiguration(delta: IConfigurationDelta): void;
+
+	/**
 	 * Return the registered configuration defaults overrides
 	 */
 	getConfigurationDefaultsOverrides(): Map<string, IConfigurationDefaultOverride>;
@@ -78,7 +91,7 @@ export interface IConfigurationRegistry {
 	 * Event that fires whenever a configuration has been
 	 * registered.
 	 */
-	readonly onDidUpdateConfiguration: Event<{ properties: string[]; defaultsOverrides?: boolean }>;
+	readonly onDidUpdateConfiguration: Event<{ properties: ReadonlySet<string>; defaultsOverrides?: boolean }>;
 
 	/**
 	 * Returns all configuration nodes contributed to this registry.
@@ -263,7 +276,7 @@ class ConfigurationRegistry implements IConfigurationRegistry {
 	private readonly _onDidSchemaChange = new Emitter<void>();
 	readonly onDidSchemaChange: Event<void> = this._onDidSchemaChange.event;
 
-	private readonly _onDidUpdateConfiguration = new Emitter<{ properties: string[]; defaultsOverrides?: boolean }>();
+	private readonly _onDidUpdateConfiguration = new Emitter<{ properties: ReadonlySet<string>; defaultsOverrides?: boolean }>();
 	readonly onDidUpdateConfiguration = this._onDidUpdateConfiguration.event;
 
 	constructor() {
@@ -294,7 +307,8 @@ class ConfigurationRegistry implements IConfigurationRegistry {
 	}
 
 	public registerConfigurations(configurations: IConfigurationNode[], validate: boolean = true): void {
-		const properties = this.doRegisterConfigurations(configurations, validate);
+		const properties = new Set<string>();
+		this.doRegisterConfigurations(configurations, validate, properties);
 
 		contributionRegistry.registerSchema(resourceLanguageSettingsSchemaId, this.resourceLanguageSettingsSchema);
 		this._onDidSchemaChange.fire();
@@ -302,7 +316,8 @@ class ConfigurationRegistry implements IConfigurationRegistry {
 	}
 
 	public deregisterConfigurations(configurations: IConfigurationNode[]): void {
-		const properties = this.doDeregisterConfigurations(configurations);
+		const properties = new Set<string>();
+		this.doDeregisterConfigurations(configurations, properties);
 
 		contributionRegistry.registerSchema(resourceLanguageSettingsSchemaId, this.resourceLanguageSettingsSchema);
 		this._onDidSchemaChange.fire();
@@ -310,22 +325,29 @@ class ConfigurationRegistry implements IConfigurationRegistry {
 	}
 
 	public updateConfigurations({ add, remove }: { add: IConfigurationNode[]; remove: IConfigurationNode[] }): void {
-		const properties = [];
-		properties.push(...this.doDeregisterConfigurations(remove));
-		properties.push(...this.doRegisterConfigurations(add, false));
+		const properties = new Set<string>();
+		this.doDeregisterConfigurations(remove, properties);
+		this.doRegisterConfigurations(add, false, properties);
 
 		contributionRegistry.registerSchema(resourceLanguageSettingsSchemaId, this.resourceLanguageSettingsSchema);
 		this._onDidSchemaChange.fire();
-		this._onDidUpdateConfiguration.fire({ properties: distinct(properties) });
+		this._onDidUpdateConfiguration.fire({ properties });
 	}
 
 	public registerDefaultConfigurations(configurationDefaults: IConfigurationDefaults[]): void {
-		const properties: string[] = [];
+		const properties = new Set<string>();
+		this.doRegisterDefaultConfigurations(configurationDefaults, properties);
+		this._onDidSchemaChange.fire();
+		this._onDidUpdateConfiguration.fire({ properties, defaultsOverrides: true });
+	}
+
+	private doRegisterDefaultConfigurations(configurationDefaults: IConfigurationDefaults[], bucket: Set<string>) {
+
 		const overrideIdentifiers: string[] = [];
 
 		for (const { overrides, source } of configurationDefaults) {
 			for (const key in overrides) {
-				properties.push(key);
+				bucket.add(key);
 
 				if (OVERRIDE_PROPERTY_REGEX.test(key)) {
 					const configurationDefaultOverride = this.configurationDefaultsOverrides.get(key);
@@ -362,12 +384,17 @@ class ConfigurationRegistry implements IConfigurationRegistry {
 		}
 
 		this.doRegisterOverrideIdentifiers(overrideIdentifiers);
+	}
+
+	public deregisterDefaultConfigurations(defaultConfigurations: IConfigurationDefaults[]): void {
+		const properties = new Set<string>();
+		this.doDeregisterDefaultConfigurations(defaultConfigurations, properties);
 		this._onDidSchemaChange.fire();
 		this._onDidUpdateConfiguration.fire({ properties, defaultsOverrides: true });
 	}
 
-	public deregisterDefaultConfigurations(defaultConfigurations: IConfigurationDefaults[]): void {
-		const properties: string[] = [];
+	private doDeregisterDefaultConfigurations(defaultConfigurations: IConfigurationDefaults[], bucket: Set<string>): void {
+
 		for (const { overrides, source } of defaultConfigurations) {
 			for (const key in overrides) {
 				const configurationDefaultsOverride = this.configurationDefaultsOverrides.get(key);
@@ -376,7 +403,7 @@ class ConfigurationRegistry implements IConfigurationRegistry {
 				if (id !== configurationDefaultsOverrideSourceId) {
 					continue;
 				}
-				properties.push(key);
+				bucket.add(key);
 				this.configurationDefaultsOverrides.delete(key);
 				if (OVERRIDE_PROPERTY_REGEX.test(key)) {
 					delete this.configurationProperties[key];
@@ -392,8 +419,31 @@ class ConfigurationRegistry implements IConfigurationRegistry {
 		}
 
 		this.updateOverridePropertyPatternKey();
+	}
+
+	public deltaConfiguration(delta: IConfigurationDelta): void {
+		// defaults: remove
+		let defaultsOverrides = false;
+		const properties = new Set<string>();
+		if (delta.removedDefaults) {
+			this.doDeregisterDefaultConfigurations(delta.removedDefaults, properties);
+			defaultsOverrides = true;
+		}
+		// defaults: add
+		if (delta.addedDefaults) {
+			this.doRegisterDefaultConfigurations(delta.addedDefaults, properties);
+			defaultsOverrides = true;
+		}
+		// configurations: remove
+		if (delta.removedConfigurations) {
+			this.doDeregisterConfigurations(delta.removedConfigurations, properties);
+		}
+		// configurations: add
+		if (delta.addedConfigurations) {
+			this.doRegisterConfigurations(delta.addedConfigurations, false, properties);
+		}
 		this._onDidSchemaChange.fire();
-		this._onDidUpdateConfiguration.fire({ properties, defaultsOverrides: true });
+		this._onDidUpdateConfiguration.fire({ properties, defaultsOverrides });
 	}
 
 	public notifyConfigurationSchemaUpdated(...configurations: IConfigurationNode[]) {
@@ -412,22 +462,23 @@ class ConfigurationRegistry implements IConfigurationRegistry {
 		this.updateOverridePropertyPatternKey();
 	}
 
-	private doRegisterConfigurations(configurations: IConfigurationNode[], validate: boolean): string[] {
-		const properties: string[] = [];
+	private doRegisterConfigurations(configurations: IConfigurationNode[], validate: boolean, bucket: Set<string>): void {
+
 		configurations.forEach(configuration => {
-			properties.push(...this.validateAndRegisterProperties(configuration, validate, configuration.extensionInfo, configuration.restrictedProperties)); // fills in defaults
+
+			this.validateAndRegisterProperties(configuration, validate, configuration.extensionInfo, configuration.restrictedProperties, undefined, bucket);
+
 			this.configurationContributors.push(configuration);
 			this.registerJSONConfiguration(configuration);
 		});
-		return properties;
 	}
 
-	private doDeregisterConfigurations(configurations: IConfigurationNode[]): string[] {
-		const properties: string[] = [];
+	private doDeregisterConfigurations(configurations: IConfigurationNode[], bucket: Set<string>): void {
+
 		const deregisterConfiguration = (configuration: IConfigurationNode) => {
 			if (configuration.properties) {
 				for (const key in configuration.properties) {
-					properties.push(key);
+					bucket.add(key);
 					const property = this.configurationProperties[key];
 					if (property?.policy?.name) {
 						this.policyConfigurations.delete(property.policy.name);
@@ -445,12 +496,10 @@ class ConfigurationRegistry implements IConfigurationRegistry {
 				this.configurationContributors.splice(index, 1);
 			}
 		}
-		return properties;
 	}
 
-	private validateAndRegisterProperties(configuration: IConfigurationNode, validate: boolean = true, extensionInfo: IExtensionInfo | undefined, restrictedProperties: string[] | undefined, scope: ConfigurationScope = ConfigurationScope.WINDOW): string[] {
+	private validateAndRegisterProperties(configuration: IConfigurationNode, validate: boolean = true, extensionInfo: IExtensionInfo | undefined, restrictedProperties: string[] | undefined, scope: ConfigurationScope = ConfigurationScope.WINDOW, bucket: Set<string>): void {
 		scope = types.isUndefinedOrNull(configuration.scope) ? scope : configuration.scope;
-		const propertyKeys: string[] = [];
 		const properties = configuration.properties;
 		if (properties) {
 			for (const key in properties) {
@@ -492,16 +541,15 @@ class ConfigurationRegistry implements IConfigurationRegistry {
 					properties[key].deprecationMessage = properties[key].markdownDeprecationMessage;
 				}
 
-				propertyKeys.push(key);
+				bucket.add(key);
 			}
 		}
 		const subNodes = configuration.allOf;
 		if (subNodes) {
 			for (const node of subNodes) {
-				propertyKeys.push(...this.validateAndRegisterProperties(node, validate, extensionInfo, restrictedProperties, scope));
+				this.validateAndRegisterProperties(node, validate, extensionInfo, restrictedProperties, scope, bucket);
 			}
 		}
-		return propertyKeys;
 	}
 
 	// TODO: @sandy081 - Remove this method and include required info in getConfigurationProperties

--- a/src/vs/platform/configuration/common/configurations.ts
+++ b/src/vs/platform/configuration/common/configurations.ts
@@ -31,7 +31,7 @@ export class DefaultConfiguration extends Disposable {
 
 	async initialize(): Promise<ConfigurationModel> {
 		this._configurationModel = undefined;
-		this._register(Registry.as<IConfigurationRegistry>(Extensions.Configuration).onDidUpdateConfiguration(({ properties, defaultsOverrides }) => this.onDidUpdateConfiguration(properties, defaultsOverrides)));
+		this._register(Registry.as<IConfigurationRegistry>(Extensions.Configuration).onDidUpdateConfiguration(({ properties, defaultsOverrides }) => this.onDidUpdateConfiguration(Array.from(properties), defaultsOverrides)));
 		return this.configurationModel;
 	}
 

--- a/src/vs/platform/configuration/test/common/configurationModels.test.ts
+++ b/src/vs/platform/configuration/test/common/configurationModels.test.ts
@@ -1072,6 +1072,14 @@ suite('ConfigurationChangeEvent', () => {
 		assert.ok(testObject.affectsConfiguration('tasks'));
 	});
 
+	test('affectsConfiguration returns false for empty string', () => {
+		const configuration = new Configuration(new ConfigurationModel(), new ConfigurationModel(), new ConfigurationModel(), new ConfigurationModel());
+		const change = configuration.compareAndUpdateLocalUserConfiguration(toConfigurationModel({ 'window.zoomLevel': 1 }));
+		const testObject = new ConfigurationChangeEvent(change, undefined, configuration);
+
+		assert.strictEqual(false, testObject.affectsConfiguration(''));
+	});
+
 });
 
 function toConfigurationModel(obj: any): ConfigurationModel {

--- a/src/vs/workbench/services/configuration/browser/configurationService.ts
+++ b/src/vs/workbench/services/configuration/browser/configurationService.ts
@@ -1269,7 +1269,7 @@ class UpdateExperimentalSettingsDefaults extends Disposable implements IWorkbenc
 		this._register(this.configurationRegistry.onDidUpdateConfiguration(({ properties }) => this.processExperimentalSettings(properties)));
 	}
 
-	private async processExperimentalSettings(properties: string[]): Promise<void> {
+	private async processExperimentalSettings(properties: Iterable<string>): Promise<void> {
 		const overrides: IStringDictionary<any> = {};
 		const allProperties = this.configurationRegistry.getConfigurationProperties();
 		for (const property of properties) {


### PR DESCRIPTION
- turns out that the TST isn't the best way to use for `affectsConfiguration`. A very simply string-indexOf approach is really fast
- add `deltaConfiguration` to configuration registry so that a single event is only use
