### PR TITLE
Expose comment editor to extension API and add new menu

### DIFF
--- a/src/vs/platform/actions/common/actions.ts
+++ b/src/vs/platform/actions/common/actions.ts
@@ -126,6 +126,7 @@ export class MenuId {
 	static readonly ViewContainerTitleContext = new MenuId('ViewContainerTitleContext');
 	static readonly ViewTitle = new MenuId('ViewTitle');
 	static readonly ViewTitleContext = new MenuId('ViewTitleContext');
+	static readonly CommentEditorActions = new MenuId('CommentEditorActions');
 	static readonly CommentThreadTitle = new MenuId('CommentThreadTitle');
 	static readonly CommentThreadActions = new MenuId('CommentThreadActions');
 	static readonly CommentThreadAdditionalActions = new MenuId('CommentThreadAdditionalActions');

--- a/src/vs/workbench/contrib/comments/browser/commentMenus.ts
+++ b/src/vs/workbench/contrib/comments/browser/commentMenus.ts
@@ -23,6 +23,10 @@ export class CommentMenus implements IDisposable {
 		return this.getMenu(MenuId.CommentThreadActions, contextKeyService);
 	}
 
+	getCommentEditorActions(contextKeyService: IContextKeyService): IMenu {
+		return this.getMenu(MenuId.CommentEditorActions, contextKeyService);
+	}
+
 	getCommentThreadAdditionalActions(contextKeyService: IContextKeyService): IMenu {
 		return this.getMenu(MenuId.CommentThreadAdditionalActions, contextKeyService);
 	}

--- a/src/vs/workbench/contrib/comments/browser/commentNode.ts
+++ b/src/vs/workbench/contrib/comments/browser/commentNode.ts
@@ -67,6 +67,7 @@ export class CommentNode<T extends IRange | ICellRange> extends Disposable {
 	protected actionRunner?: IActionRunner;
 	protected toolbar: ToolBar | undefined;
 	private _commentFormActions: CommentFormActions | null = null;
+	private _commentEditorActions: CommentFormActions | null = null;
 
 	private readonly _onDidClick = new Emitter<CommentNode<T>>();
 
@@ -469,8 +470,16 @@ export class CommentNode<T extends IRange | ICellRange> extends Disposable {
 		this._body.classList.add('hidden');
 		this._commentEditContainer = dom.append(this._commentDetailsContainer, dom.$('.edit-container'));
 		this.createCommentEditor(this._commentEditContainer);
-		const formActions = dom.append(this._commentEditContainer, dom.$('.form-actions'));
 
+		const formActions = dom.append(this._commentEditContainer, dom.$('.form-actions'));
+		const otherActions = dom.append(formActions, dom.$('.other-actions'));
+		this.createCommentWidgetFormActions(otherActions);
+		const editorActions = dom.append(formActions, dom.$('.editor-actions'));
+		this.createCommentWidgetEditorActions(editorActions);
+
+	}
+
+	private createCommentWidgetFormActions(container: HTMLElement) {
 		const menus = this.commentService.getCommentMenus(this.owner);
 		const menu = menus.getCommentActions(this.comment, this._contextKeyService);
 
@@ -479,7 +488,7 @@ export class CommentNode<T extends IRange | ICellRange> extends Disposable {
 			this._commentFormActions?.setActions(menu);
 		}));
 
-		this._commentFormActions = new CommentFormActions(formActions, (action: IAction): void => {
+		this._commentFormActions = new CommentFormActions(container, (action: IAction): void => {
 			const text = this._commentEditor!.getValue();
 
 			action.run({
@@ -494,6 +503,32 @@ export class CommentNode<T extends IRange | ICellRange> extends Disposable {
 
 		this._register(this._commentFormActions);
 		this._commentFormActions.setActions(menu);
+	}
+
+	private createCommentWidgetEditorActions(container: HTMLElement) {
+		const menus = this.commentService.getCommentMenus(this.owner);
+		const menu = menus.getCommentEditorActions(this._contextKeyService);
+
+		this._register(menu);
+		this._register(menu.onDidChange(() => {
+			this._commentEditorActions?.setActions(menu);
+		}));
+
+		this._commentEditorActions = new CommentFormActions(container, (action: IAction): void => {
+			const text = this._commentEditor!.getValue();
+
+			action.run({
+				thread: this.commentThread,
+				commentUniqueId: this.comment.uniqueIdInThread,
+				text: text,
+				$mid: MarshalledId.CommentThreadNode
+			});
+
+			this._commentEditor?.focus();
+		});
+
+		this._register(this._commentEditorActions);
+		this._commentEditorActions.setActions(menu, true);
 	}
 
 	setFocus(focused: boolean, visible: boolean = false) {

--- a/src/vs/workbench/contrib/comments/browser/simpleCommentEditor.ts
+++ b/src/vs/workbench/contrib/comments/browser/simpleCommentEditor.ts
@@ -49,7 +49,6 @@ export class SimpleCommentEditor extends CodeEditorWidget {
 		@ILanguageFeaturesService languageFeaturesService: ILanguageFeaturesService,
 	) {
 		const codeEditorWidgetOptions: ICodeEditorWidgetOptions = {
-			isSimpleWidget: true,
 			contributions: <IEditorContributionDescription[]>[
 				{ id: MenuPreventer.ID, ctor: MenuPreventer, instantiation: EditorContributionInstantiation.BeforeFirstInteraction },
 				{ id: ContextMenuController.ID, ctor: ContextMenuController, instantiation: EditorContributionInstantiation.BeforeFirstInteraction },

--- a/src/vs/workbench/services/actions/common/menusExtensionPoint.ts
+++ b/src/vs/workbench/services/actions/common/menusExtensionPoint.ts
@@ -149,6 +149,12 @@ const apiMenus: IAPIMenu[] = [
 		description: localize('view.itemContext', "The contributed view item context menu")
 	},
 	{
+		key: 'comments/comment/editorActions',
+		id: MenuId.CommentEditorActions,
+		description: localize('commentThread.editorActions', "The contributed comment editor actions"),
+		proposed: 'contribCommentEditorActionsMenu'
+	},
+	{
 		key: 'comments/commentThread/title',
 		id: MenuId.CommentThreadTitle,
 		description: localize('commentThread.title', "The contributed comment thread title menu")

--- a/src/vs/workbench/services/extensions/common/extensionsApiProposals.ts
+++ b/src/vs/workbench/services/extensions/common/extensionsApiProposals.ts
@@ -9,6 +9,7 @@ export const allApiProposals = Object.freeze({
 	authSession: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.authSession.d.ts',
 	codiconDecoration: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.codiconDecoration.d.ts',
 	commentsResolvedState: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.commentsResolvedState.d.ts',
+	contribCommentEditorActionsMenu: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.contribCommentEditorActionsMenu.d.ts',
 	contribCommentPeekContext: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.contribCommentPeekContext.d.ts',
 	contribCommentThreadAdditionalMenu: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.contribCommentThreadAdditionalMenu.d.ts',
 	contribEditSessions: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.contribEditSessions.d.ts',

--- a/src/vscode-dts/vscode.proposed.contribCommentEditorActionsMenu.d.ts
+++ b/src/vscode-dts/vscode.proposed.contribCommentEditorActionsMenu.d.ts
@@ -1,0 +1,6 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// empty placeholder declaration for the `comments/comment/editorActions` menu


### PR DESCRIPTION
Fixes #169737 and adds a new menu for the comments widget that doesn't close the comment editor when run.