### PR TITLE
Don't allow debug console message badge to wrap

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/media/repl.css
+++ b/src/vs/workbench/contrib/debug/browser/media/repl.css
@@ -60,9 +60,10 @@
 	margin-right: 4px;
 }
 
-/* Allow the badge to be a bit shorter so it does not look cut off */
 .monaco-workbench .repl .repl-tree .output.expression.value-and-source .count-badge-wrapper .monaco-count-badge {
+	/* Allow the badge to be a bit shorter so it does not look cut off */
 	min-height: 16px;
+	word-break: keep-all;
 }
 
 .monaco-workbench .repl .repl-tree .monaco-tl-contents .arrow {


### PR DESCRIPTION
Fix #169829