### PR TITLE
rename `selectQuickSuggestions` to `editor.suggest.selectionMode`, allow to differentiate between auto suggestions trigger by typing (aka quick suggest) and by trigger characters

### DIFF
--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -4046,7 +4046,7 @@ export interface ISuggestOptions {
 	/**
 	 * Select suggestions when triggered via quick suggest or trigger characters
 	 */
-	selectQuickSuggestions?: boolean;
+	selectionMode?: 'always' | 'never' | 'whenTriggerCharacter' | 'whenQuickSuggestion';
 	/**
 	 * Enable or disable icons in suggestions. Defaults to true.
 	 */
@@ -4199,7 +4199,7 @@ class EditorSuggest extends BaseEditorOption<EditorOption.suggest, ISuggestOptio
 			snippetsPreventQuickSuggestions: true,
 			localityBonus: false,
 			shareSuggestSelections: false,
-			selectQuickSuggestions: true,
+			selectionMode: 'always',
 			showIcons: true,
 			showStatusBar: false,
 			preview: false,
@@ -4263,10 +4263,17 @@ class EditorSuggest extends BaseEditorOption<EditorOption.suggest, ISuggestOptio
 					default: defaults.shareSuggestSelections,
 					markdownDescription: nls.localize('suggest.shareSuggestSelections', "Controls whether remembered suggestion selections are shared between multiple workspaces and windows (needs `#editor.suggestSelection#`).")
 				},
-				'editor.suggest.selectQuickSuggestions': {
-					type: 'boolean',
-					default: defaults.selectQuickSuggestions,
-					markdownDescription: nls.localize('suggest.selectQuickSuggestions', "Controls whether the suggest widget becomes active when triggered via quick suggest or trigger characters.")
+				'editor.suggest.selectionMode': {
+					type: 'string',
+					enum: ['always', 'never', 'whenTriggerCharacter', 'whenQuickSuggestion'],
+					enumDescriptions: [
+						nls.localize('suggest.insertMode.always', "Always activate the suggest widget when triggering IntelliSense automatically."),
+						nls.localize('suggest.insertMode.never', "Never activate the suggest when when triggering IntelliSense automatically."),
+						nls.localize('suggest.insertMode.whenTriggerCharacter', "Activate the suggest widget only when triggering IntelliSense from a trigger character."),
+						nls.localize('suggest.insertMode.whenQuickSuggestion', "Activate the suggest widget only when triggering IntelliSense as you type."),
+					],
+					default: defaults.selectionMode,
+					markdownDescription: nls.localize('suggest.selectionMode', "Controls whether the suggest widget becomes active when triggered via quick suggest or trigger characters. Note that the widget is always active when explicitly invoked, e.g via `Ctrl+Space`.")
 				},
 				'editor.suggest.snippetsPreventQuickSuggestions': {
 					type: 'boolean',
@@ -4466,7 +4473,7 @@ class EditorSuggest extends BaseEditorOption<EditorOption.suggest, ISuggestOptio
 			snippetsPreventQuickSuggestions: boolean(input.snippetsPreventQuickSuggestions, this.defaultValue.filterGraceful),
 			localityBonus: boolean(input.localityBonus, this.defaultValue.localityBonus),
 			shareSuggestSelections: boolean(input.shareSuggestSelections, this.defaultValue.shareSuggestSelections),
-			selectQuickSuggestions: boolean(input.selectQuickSuggestions, this.defaultValue.selectQuickSuggestions),
+			selectionMode: stringSet(input.selectionMode, this.defaultValue.selectionMode, ['always', 'never', 'whenQuickSuggestion', 'whenTriggerCharacter']),
 			showIcons: boolean(input.showIcons, this.defaultValue.showIcons),
 			showStatusBar: boolean(input.showStatusBar, this.defaultValue.showStatusBar),
 			preview: boolean(input.preview, this.defaultValue.preview),

--- a/src/vs/editor/contrib/suggest/browser/suggestWidget.ts
+++ b/src/vs/editor/contrib/suggest/browser/suggestWidget.ts
@@ -555,9 +555,7 @@ export class SuggestWidget implements IDisposable {
 			this._list.splice(0, this._list.length, this._completionModel.items);
 			this._setState(isFrozen ? State.Frozen : State.Open);
 			this._list.reveal(selectionIndex, 0);
-			if (!noFocus) {
-				this._list.setFocus([selectionIndex]);
-			}
+			this._list.setFocus(noFocus ? [] : [selectionIndex]);
 		} finally {
 			this._onDidFocus.resume();
 			this._onDidSelect.resume();

--- a/src/vs/editor/contrib/suggest/test/browser/suggestModel.test.ts
+++ b/src/vs/editor/contrib/suggest/test/browser/suggestModel.test.ts
@@ -294,7 +294,7 @@ suite('SuggestModel - TriggerAndCancelOracle', function () {
 				assertEvent(model.onDidSuggest, function () {
 					model.trigger({ auto: false });
 				}, function (event) {
-					assert.strictEqual(event.auto, false);
+					assert.strictEqual(event.triggerOptions.auto, false);
 					assert.strictEqual(event.isFrozen, false);
 					assert.strictEqual(event.completionModel.items.length, 0);
 				})
@@ -312,7 +312,7 @@ suite('SuggestModel - TriggerAndCancelOracle', function () {
 				editor.trigger('keyboard', Handler.Type, { text: 'd' });
 
 			}, event => {
-				assert.strictEqual(event.auto, true);
+				assert.strictEqual(event.triggerOptions.auto, true);
 				assert.strictEqual(event.completionModel.items.length, 1);
 				const [first] = event.completionModel.items;
 
@@ -351,7 +351,7 @@ suite('SuggestModel - TriggerAndCancelOracle', function () {
 					editor.trigger('keyboard', Handler.Type, { text: 'My' });
 
 				}, event => {
-					assert.strictEqual(event.auto, true);
+					assert.strictEqual(event.triggerOptions.auto, true);
 					assert.strictEqual(event.completionModel.items.length, 1);
 					const [first] = event.completionModel.items;
 					assert.strictEqual(first.completion.label, 'My Table');
@@ -361,7 +361,7 @@ suite('SuggestModel - TriggerAndCancelOracle', function () {
 						editor.trigger('keyboard', Handler.Type, { text: ' ' });
 
 					}, event => {
-						assert.strictEqual(event.auto, true);
+						assert.strictEqual(event.triggerOptions.auto, true);
 						assert.strictEqual(event.completionModel.items.length, 1);
 						const [first] = event.completionModel.items;
 						assert.strictEqual(first.completion.label, 'My Table');
@@ -414,7 +414,7 @@ suite('SuggestModel - TriggerAndCancelOracle', function () {
 				editor.trigger('keyboard', Handler.Type, { text: 'foo' });
 
 			}, event => {
-				assert.strictEqual(event.auto, true);
+				assert.strictEqual(event.triggerOptions.auto, true);
 				assert.strictEqual(event.completionModel.items.length, 1);
 				const [first] = event.completionModel.items;
 				assert.strictEqual(first.completion.label, 'foo.bar');
@@ -426,7 +426,7 @@ suite('SuggestModel - TriggerAndCancelOracle', function () {
 
 			}, event => {
 				// SYNC
-				assert.strictEqual(event.auto, true);
+				assert.strictEqual(event.triggerOptions.auto, true);
 				assert.strictEqual(event.completionModel.items.length, 1);
 				const [first] = event.completionModel.items;
 				assert.strictEqual(first.completion.label, 'foo.bar');
@@ -437,7 +437,7 @@ suite('SuggestModel - TriggerAndCancelOracle', function () {
 
 			}, event => {
 				// ASYNC
-				assert.strictEqual(event.auto, true);
+				assert.strictEqual(event.triggerOptions.auto, true);
 				assert.strictEqual(event.completionModel.items.length, 2);
 				const [first, second] = event.completionModel.items;
 				assert.strictEqual(first.completion.label, 'foo.bar');
@@ -458,7 +458,7 @@ suite('SuggestModel - TriggerAndCancelOracle', function () {
 			return assertEvent(model.onDidSuggest, () => {
 				model.trigger({ auto: false });
 			}, event => {
-				assert.strictEqual(event.auto, false);
+				assert.strictEqual(event.triggerOptions.auto, false);
 				assert.strictEqual(event.isFrozen, false);
 				assert.strictEqual(event.completionModel.items.length, 1);
 
@@ -483,7 +483,7 @@ suite('SuggestModel - TriggerAndCancelOracle', function () {
 			return assertEvent(model.onDidSuggest, () => {
 				model.trigger({ auto: false });
 			}, event => {
-				assert.strictEqual(event.auto, false);
+				assert.strictEqual(event.triggerOptions.auto, false);
 				assert.strictEqual(event.isFrozen, false);
 				assert.strictEqual(event.completionModel.items.length, 1);
 
@@ -520,7 +520,7 @@ suite('SuggestModel - TriggerAndCancelOracle', function () {
 			return assertEvent(model.onDidSuggest, () => {
 				model.trigger({ auto: false });
 			}, event => {
-				assert.strictEqual(event.auto, false);
+				assert.strictEqual(event.triggerOptions.auto, false);
 				assert.strictEqual(event.completionModel.getIncompleteProvider().size, 1);
 				assert.strictEqual(event.completionModel.items.length, 1);
 
@@ -557,7 +557,7 @@ suite('SuggestModel - TriggerAndCancelOracle', function () {
 			return assertEvent(model.onDidSuggest, () => {
 				model.trigger({ auto: false });
 			}, event => {
-				assert.strictEqual(event.auto, false);
+				assert.strictEqual(event.triggerOptions.auto, false);
 				assert.strictEqual(event.completionModel.getIncompleteProvider().size, 1);
 				assert.strictEqual(event.completionModel.items.length, 1);
 
@@ -567,7 +567,7 @@ suite('SuggestModel - TriggerAndCancelOracle', function () {
 					// until now
 					editor.trigger('keyboard', Handler.Type, { text: ';' });
 				}, event => {
-					assert.strictEqual(event.auto, false);
+					assert.strictEqual(event.triggerOptions.auto, false);
 					assert.strictEqual(event.completionModel.getIncompleteProvider().size, 1);
 					assert.strictEqual(event.completionModel.items.length, 1);
 
@@ -662,7 +662,7 @@ suite('SuggestModel - TriggerAndCancelOracle', function () {
 				editor.trigger('keyboard', Handler.Type, { text: 'd' });
 
 			}, event => {
-				assert.strictEqual(event.auto, true);
+				assert.strictEqual(event.triggerOptions.auto, true);
 				assert.strictEqual(event.completionModel.items.length, 1);
 				const [first] = event.completionModel.items;
 
@@ -673,7 +673,7 @@ suite('SuggestModel - TriggerAndCancelOracle', function () {
 				CoreEditingCommands.DeleteLeft.runEditorCommand(null, editor, null);
 
 			}, event => {
-				assert.strictEqual(event.auto, true);
+				assert.strictEqual(event.triggerOptions.auto, true);
 				assert.strictEqual(event.completionModel.items.length, 1);
 				const [first] = event.completionModel.items;
 
@@ -742,7 +742,7 @@ suite('SuggestModel - TriggerAndCancelOracle', function () {
 				editor.trigger('keyboard', Handler.Type, { text: 'e' });
 
 			}, event => {
-				assert.strictEqual(event.auto, true);
+				assert.strictEqual(event.triggerOptions.auto, true);
 				assert.strictEqual(event.completionModel.items.length, 1);
 				const [first] = event.completionModel.items;
 
@@ -799,7 +799,7 @@ suite('SuggestModel - TriggerAndCancelOracle', function () {
 				editor.trigger('keyboard', Handler.Type, { text: 'c' });
 
 			}, event => {
-				assert.strictEqual(event.auto, true);
+				assert.strictEqual(event.triggerOptions.auto, true);
 				assert.strictEqual(event.completionModel.items.length, 2);
 				assert.strictEqual(disposeA, 0);
 				assert.strictEqual(disposeB, 0);
@@ -808,7 +808,7 @@ suite('SuggestModel - TriggerAndCancelOracle', function () {
 			await assertEvent(model.onDidSuggest, () => {
 				editor.trigger('keyboard', Handler.Type, { text: 'o' });
 			}, event => {
-				assert.strictEqual(event.auto, true);
+				assert.strictEqual(event.triggerOptions.auto, true);
 				assert.strictEqual(event.completionModel.items.length, 2);
 
 				// clean up
@@ -866,7 +866,7 @@ suite('SuggestModel - TriggerAndCancelOracle', function () {
 				editor.trigger('keyboard', Handler.Type, { text: 'Z' });
 
 			}, event => {
-				assert.strictEqual(event.auto, true);
+				assert.strictEqual(event.triggerOptions.auto, true);
 				assert.strictEqual(event.completionModel.items.length, 1);
 				assert.strictEqual(event.completionModel.items[0].textLabel, 'Z aaa');
 			});
@@ -876,7 +876,7 @@ suite('SuggestModel - TriggerAndCancelOracle', function () {
 				// item should be: Z aaa, aaa
 				editor.trigger('keyboard', Handler.Type, { text: ' a' });
 			}, event => {
-				assert.strictEqual(event.auto, true);
+				assert.strictEqual(event.triggerOptions.auto, true);
 				assert.strictEqual(event.completionModel.items.length, 2);
 				assert.strictEqual(event.completionModel.items[0].textLabel, 'Z aaa');
 				assert.strictEqual(event.completionModel.items[1].textLabel, 'aaa');
@@ -923,7 +923,7 @@ suite('SuggestModel - TriggerAndCancelOracle', function () {
 				editor.trigger('keyboard', Handler.Type, { text: '.' });
 
 			}, event => {
-				assert.strictEqual(event.auto, true);
+				assert.strictEqual(event.triggerOptions.auto, true);
 				assert.strictEqual(event.completionModel.items.length, 1);
 			});
 
@@ -936,7 +936,7 @@ suite('SuggestModel - TriggerAndCancelOracle', function () {
 				editor.trigger('keyboard', Handler.Type, { text: 'a' });
 
 			}, event => {
-				assert.strictEqual(event.auto, true);
+				assert.strictEqual(event.triggerOptions.auto, true);
 				assert.strictEqual(event.completionModel.items.length, 2);
 			});
 		});
@@ -979,7 +979,7 @@ suite('SuggestModel - TriggerAndCancelOracle', function () {
 				editor.trigger('keyboard', Handler.Type, { text: 't' });
 
 			}, event => {
-				assert.strictEqual(event.auto, true);
+				assert.strictEqual(event.triggerOptions.auto, true);
 				assert.strictEqual(event.completionModel.items.length, 1);
 				assert.strictEqual(event.completionModel.items[0].textLabel, 'git.pull');
 			});
@@ -990,7 +990,7 @@ suite('SuggestModel - TriggerAndCancelOracle', function () {
 				editor.trigger('keyboard', Handler.Type, { text: 'p' });
 
 			}, event => {
-				assert.strictEqual(event.auto, true);
+				assert.strictEqual(event.triggerOptions.auto, true);
 				assert.strictEqual(event.completionModel.items.length, 1);
 				assert.strictEqual(event.completionModel.items[0].textLabel, 'git.pull');
 			});
@@ -1046,7 +1046,7 @@ suite('SuggestModel - TriggerAndCancelOracle', function () {
 				model.trigger({ auto: false });
 
 			}, event => {
-				assert.strictEqual(event.auto, false);
+				assert.strictEqual(event.triggerOptions.auto, false);
 				assert.strictEqual(event.completionModel.items.length, 2);
 				assert.strictEqual(event.completionModel.items[0].textLabel, 'foo-20');
 				assert.strictEqual(event.completionModel.items[1].textLabel, 'foo-hello');
@@ -1059,11 +1059,68 @@ suite('SuggestModel - TriggerAndCancelOracle', function () {
 				editor.trigger('keyboard', Handler.Type, { text: '2' });
 
 			}, event => {
-				assert.strictEqual(event.auto, true);
+				assert.strictEqual(event.triggerOptions.auto, true);
 				assert.strictEqual(event.completionModel.items.length, 2);
 				assert.strictEqual(event.completionModel.items[0].textLabel, 'foo-20');
 				assert.strictEqual(event.completionModel.items[1].textLabel, 'foo-210');
 				assert.deepStrictEqual(requestCounts, [1, 2]);
+			});
+		});
+	});
+
+	test('Set refilter-flag, keep triggerKind', function () {
+
+		disposables.add(registry.register({ scheme: 'test' }, {
+			triggerCharacters: ['.'],
+			provideCompletionItems(doc, pos, ctx) {
+				return {
+					suggestions: [{
+						label: doc.getWordUntilPosition(pos).word || 'hello',
+						kind: CompletionItemKind.Property,
+						insertText: 'foofoo',
+						range: getDefaultSuggestRange(doc, pos)
+					}]
+				};
+			},
+		}));
+
+		return withOracle(async function (model, editor) {
+
+			// editor.updateOptions({ suggest: { selectQuickSuggestions: 'whenQuickSuggestion' } });
+
+			await assertEvent(model.onDidSuggest, () => {
+				editor.setValue('foo');
+				editor.setSelection(new Selection(1, 4, 1, 4));
+				editor.trigger('keyboard', Handler.Type, { text: 'o' });
+
+
+			}, event => {
+				assert.strictEqual(event.triggerOptions.auto, true);
+				assert.strictEqual(event.triggerOptions.triggerCharacter, undefined);
+				assert.strictEqual(event.triggerOptions.triggerKind, undefined);
+				assert.strictEqual(event.completionModel.items.length, 1);
+			});
+
+			await assertEvent(model.onDidSuggest, () => {
+				editor.trigger('keyboard', Handler.Type, { text: '.' });
+
+			}, event => {
+				assert.strictEqual(event.triggerOptions.auto, true);
+				assert.strictEqual(event.triggerOptions.refilter, undefined);
+				assert.strictEqual(event.triggerOptions.triggerCharacter, '.');
+				assert.strictEqual(event.triggerOptions.triggerKind, CompletionTriggerKind.TriggerCharacter);
+				assert.strictEqual(event.completionModel.items.length, 1);
+			});
+
+			await assertEvent(model.onDidSuggest, () => {
+				editor.trigger('keyboard', Handler.Type, { text: 'h' });
+
+			}, event => {
+				assert.strictEqual(event.triggerOptions.auto, true);
+				assert.strictEqual(event.triggerOptions.refilter, true);
+				assert.strictEqual(event.triggerOptions.triggerCharacter, '.');
+				assert.strictEqual(event.triggerOptions.triggerKind, CompletionTriggerKind.TriggerCharacter);
+				assert.strictEqual(event.completionModel.items.length, 1);
 			});
 		});
 	});

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -4393,7 +4393,7 @@ declare namespace monaco.editor {
 		/**
 		 * Select suggestions when triggered via quick suggest or trigger characters
 		 */
-		selectQuickSuggestions?: boolean;
+		selectionMode?: 'always' | 'never' | 'whenTriggerCharacter' | 'whenQuickSuggestion';
 		/**
 		 * Enable or disable icons in suggestions. Defaults to true.
 		 */


### PR DESCRIPTION
re https://github.com/microsoft/vscode/issues/139825 and https://github.com/microsoft/vscode/issues/169830
