### PR TITLE
Hide chevron element when it's empty to unblock dragging in the markdown cell gutter

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/view/cellParts/markupCell.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/cellParts/markupCell.ts
@@ -445,12 +445,15 @@ export class MarkupCell extends Disposable {
 	private layoutFoldingIndicator() {
 		switch (this.foldingState) {
 			case CellFoldingState.None:
+				this.templateData.foldingIndicator.style.display = 'none';
 				this.templateData.foldingIndicator.innerText = '';
 				break;
 			case CellFoldingState.Collapsed:
+				this.templateData.foldingIndicator.style.display = '';
 				DOM.reset(this.templateData.foldingIndicator, renderIcon(collapsedIcon));
 				break;
 			case CellFoldingState.Expanded:
+				this.templateData.foldingIndicator.style.display = '';
 				DOM.reset(this.templateData.foldingIndicator, renderIcon(expandedIcon));
 				break;
 


### PR DESCRIPTION
Fix #125169
