### PR TITLE
[extensions/rust] add markdown syntax highlighting to doc comments

### DIFF
--- a/extensions/rust/package.json
+++ b/extensions/rust/package.json
@@ -32,8 +32,7 @@
         "scopeName": "source.rust",
         "embeddedLanguages": {
           "meta.embedded.block.markdown": "markdown"
-        },
-        "tokenTypes": {}
+        }
       }
     ]
   },

--- a/extensions/rust/package.json
+++ b/extensions/rust/package.json
@@ -29,7 +29,11 @@
       {
         "language": "rust",
         "path": "./syntaxes/rust.tmLanguage.json",
-        "scopeName": "source.rust"
+        "scopeName": "source.rust",
+        "embeddedLanguages": {
+          "meta.embedded.block.markdown": "markdown"
+        },
+        "tokenTypes": {}
       }
     ]
   },

--- a/extensions/rust/syntaxes/rust.tmLanguage.json
+++ b/extensions/rust/syntaxes/rust.tmLanguage.json
@@ -300,7 +300,17 @@
 				{
 					"comment": "documentation comments",
 					"name": "comment.line.documentation.rust",
-					"match": "^\\s*///.*"
+					"match": "///\\s?(.*)",
+					"captures": {
+						"0": {
+							"name": "meta.embedded.block.markdown",
+							"patterns": [
+								{
+									"include": "text.html.markdown"
+								}
+							]
+						}
+					}
 				},
 				{
 					"comment": "line comments",

--- a/extensions/rust/syntaxes/rust.tmLanguage.json
+++ b/extensions/rust/syntaxes/rust.tmLanguage.json
@@ -300,17 +300,14 @@
 				{
 					"comment": "documentation comments",
 					"name": "comment.line.documentation.rust",
-					"match": "///\\s?(.*)",
-					"captures": {
-						"0": {
-							"name": "meta.embedded.block.markdown",
-							"patterns": [
-								{
-									"include": "text.html.markdown"
-								}
-							]
+					"begin": "^\\s*///",
+					"while": "^\\s*///",
+					"contentName": "meta.embedded.block.markdown",
+					"patterns": [
+						{
+							"include": "text.html.markdown"
 						}
-					}
+					]
 				},
 				{
 					"comment": "line comments",


### PR DESCRIPTION
This is an attempt at implementing #169676. It's currently only doing it for `///` comments as I am testing the implementation.

Current state: 
![image](https://user-images.githubusercontent.com/1593486/209413055-8ab6679e-1b74-4db5-9c23-18fb1c8bfd6f.png)

Still making `/*` comment blocks work.

<details>
<summary>Original problem I faced, keeping it for context.</summary>

![image](https://user-images.githubusercontent.com/1593486/209411130-76a180d2-ba6f-4bcf-9785-a0f4e8f5be9d.png)

Markdown is highlighted, though because it's including `///`, it does not properly highlight the titles as `/// # Title` would also not be highlighted in Markdown:
![image](https://user-images.githubusercontent.com/1593486/209411184-a8ce327d-3a74-4d3f-b7a9-8c1653a46c01.png)

![image](https://user-images.githubusercontent.com/1593486/209411459-a3b1354c-6e7f-4068-9e39-ee8c654ce682.png)

It would be if those weren't there:

![image](https://user-images.githubusercontent.com/1593486/209411196-9ffe1603-c072-480a-aae3-5847dff86724.png)

So we have to tell it to only apply the markdown on the content of the comment, right? However when changing it to apply for the captured group and not the entire match, it's still recognised as Markdown, but there is no highlighting at all:

```diff
				{
					"comment": "documentation comments",
					"name": "comment.line.documentation.rust",
					"match": "^\\s*///(.*)",
					"captures": {
-						"0": {
+						"1": {
							"name": "meta.embedded.block.markdown",
							"patterns": [
								{
									"include": "text.html.markdown"
								}
							]
						}
					}
				},
```

Results in:

![image](https://user-images.githubusercontent.com/1593486/209411335-a8dee349-fcd1-4dbd-9fd7-d947fe3e3acb.png)

![image](https://user-images.githubusercontent.com/1593486/209411491-24a68314-085d-4c68-b6b3-5a36c760cd16.png)

So my thought was that it might be doing something wrong with applying it if it's a specific capture group. What if we change the capture group to include `///`?

```diff
				{
					"comment": "documentation comments",
					"name": "comment.line.documentation.rust",
-					"match": "^\\s*///(.*)",
+					"match": "^\\s*(///.*)",
					"captures": {
						"1": {
							"name": "meta.embedded.block.markdown",
							"patterns": [
								{
									"include": "text.html.markdown"
								}
							]
						}
					}
				},
```

That seems to make it give the same Markdown issue as before: 
![image](https://user-images.githubusercontent.com/1593486/209411862-e58e3dc6-c6ff-4bce-b1c8-bebff2616d2b.png)

I've tried juggling around with `contentName` instead of `name` and some other stuff. But I keep bumping my head against the same rock. Anyone got any idea on what the issue could be? 😅


</details>


This will be made into a PR as well on `dustypomerleau/rust-syntax`, but this keeps it concise for now in 1 PR.
