### PR TITLE
cli: enable code-tunnel systemd service to start when the machine booted

### DIFF
--- a/cli/src/tunnels/service_linux.rs
+++ b/cli/src/tunnels/service_linux.rs
@@ -197,7 +197,7 @@ fn write_systemd_service_file(
       ExecStart={} \"{}\"\n\
       \n\
       [Install]\n\
-      WantedBy=multi-user.target\n\
+      WantedBy=default.target\n\
     ",
 		PRODUCT_NAME_LONG,
 		exe.into_os_string().to_string_lossy(),


### PR DESCRIPTION
fixes #170014 

Since target "multi-user" doesn't exist on the user systemd, the old service file cannot be enabled.
I changed "WantedBy" from multi-user.target to default.target (exists on the user systemd) to fix it.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
