### PR TITLE
Fix encoding of pwsh shell integration cwd

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/media/shellIntegration.ps1
+++ b/src/vs/workbench/contrib/terminal/browser/media/shellIntegration.ps1
@@ -20,17 +20,12 @@ $Global:__LastHistoryId = -1
 function Global:__VSCode-Escape-Value([string]$value) {
 	# NOTE: In PowerShell v6.1+, this can be written `$value -replace '…', { … }` instead of `[regex]::Replace`.
 	# Replace any non-alphanumeric characters.
-	[regex]::Replace($value, '[^a-zA-Z0-9]', { param($match)
-		# Backslashes must be doubled.
-		if ($match.Value -eq '\') {
-			'\\'
-		} else {
-			# Any other characters are encoded as their UTF-8 hex values.
-			-Join (
-				[System.Text.Encoding]::UTF8.GetBytes($match.Value)
-				| ForEach-Object { '\x{0:x2}' -f $_ }
-			)
-		}
+	[regex]::Replace($value, '[\\\n;]', { param($match)
+		# Encode the (ascii) matches as `\x<hex>`
+		-Join (
+			[System.Text.Encoding]::UTF8.GetBytes($match.Value)
+			| ForEach-Object { '\x{0:x2}' -f $_ }
+		)
 	})
 }
 


### PR DESCRIPTION
Fixes #170140

FYI @rwe I needed to invert the regex here in order to properly support unicode to avoid the more complicated decoding of UTF8 on the TS side.

![image](https://user-images.githubusercontent.com/2193314/209839241-d45b7d57-0f85-4c8d-8605-bb14db246d65.png)
