### PR TITLE
fix: update debug logic in process explorer

### DIFF
--- a/src/vs/base/node/ps.ts
+++ b/src/vs/base/node/ps.ts
@@ -98,6 +98,8 @@ export function listProcesses(rootPid: number): Promise<ProcessItem> {
 					if (UTILITY_EXTENSION_HOST_HINT.exec(cmd)) {
 						return 'extension-host';
 					}
+				} else if (matches[1] === 'extensionHost') {
+					return 'extension-host'; // normalize remote extension host type
 				}
 				return matches[1];
 			}

--- a/src/vs/code/electron-sandbox/processExplorer/processExplorerMain.ts
+++ b/src/vs/code/electron-sandbox/processExplorer/processExplorerMain.ts
@@ -26,8 +26,8 @@ import { applyZoom, zoomIn, zoomOut } from 'vs/platform/window/electron-sandbox/
 import { StandardKeyboardEvent } from 'vs/base/browser/keyboardEvent';
 import { KeyCode } from 'vs/base/common/keyCodes';
 
-const DEBUG_FLAGS_PATTERN = /\s--(inspect|debug)(-brk|port)?=(\d+)?/;
-const DEBUG_PORT_PATTERN = /\s--(inspect|debug)-port=(\d+)/;
+const DEBUG_FLAGS_PATTERN = /\s--inspect(?:-brk|port)?=(\d+)?/;
+const DEBUG_PORT_PATTERN = /\s--inspect-port=(\d+)/;
 
 class ProcessListDelegate implements IListVirtualDelegate<MachineProcessInformation | ProcessItem | IRemoteDiagnosticError> {
 	getHeight(element: MachineProcessInformation | ProcessItem | IRemoteDiagnosticError) {
@@ -363,7 +363,7 @@ class ProcessExplorer {
 
 	private isDebuggable(cmd: string): boolean {
 		const matches = DEBUG_FLAGS_PATTERN.exec(cmd);
-		return (matches && matches.length >= 2) || cmd.indexOf('node ') >= 0 || cmd.indexOf('node.exe') >= 0;
+		return (matches && matches[1] !== '0') || cmd.indexOf('node ') >= 0 || cmd.indexOf('node.exe') >= 0;
 	}
 
 	private attachTo(item: ProcessItem) {
@@ -374,12 +374,8 @@ class ProcessExplorer {
 		};
 
 		let matches = DEBUG_FLAGS_PATTERN.exec(item.cmd);
-		if (matches && matches.length >= 2) {
-			// attach via port
-			if (matches.length === 4 && matches[3]) {
-				config.port = parseInt(matches[3]);
-			}
-			config.protocol = matches[1] === 'debug' ? 'legacy' : 'inspector';
+		if (matches) {
+			config.port = parseInt(matches[1]);
 		} else {
 			// no port -> try to attach via pid (send SIGUSR1)
 			config.processId = String(item.pid);
@@ -387,9 +383,9 @@ class ProcessExplorer {
 
 		// a debug-port=n or inspect-port=n overrides the port
 		matches = DEBUG_PORT_PATTERN.exec(item.cmd);
-		if (matches && matches.length === 3) {
+		if (matches) {
 			// override port
-			config.port = parseInt(matches[2]);
+			config.port = Number(matches[1]);
 		}
 
 		ipcRenderer.send('vscode:workbenchCommand', { id: 'debug.startFromConfig', from: 'processExplorer', args: [config] });

--- a/src/vs/code/electron-sandbox/processExplorer/processExplorerMain.ts
+++ b/src/vs/code/electron-sandbox/processExplorer/processExplorerMain.ts
@@ -26,8 +26,8 @@ import { applyZoom, zoomIn, zoomOut } from 'vs/platform/window/electron-sandbox/
 import { StandardKeyboardEvent } from 'vs/base/browser/keyboardEvent';
 import { KeyCode } from 'vs/base/common/keyCodes';
 
-const DEBUG_FLAGS_PATTERN = /\s--inspect(?:-brk|port)?=(\d+)?/;
-const DEBUG_PORT_PATTERN = /\s--inspect-port=(\d+)/;
+const DEBUG_FLAGS_PATTERN = /\s--inspect(?:-brk|port)?=(?<port>\d+)?/;
+const DEBUG_PORT_PATTERN = /\s--inspect-port=(?<port>\d+)/;
 
 class ProcessListDelegate implements IListVirtualDelegate<MachineProcessInformation | ProcessItem | IRemoteDiagnosticError> {
 	getHeight(element: MachineProcessInformation | ProcessItem | IRemoteDiagnosticError) {
@@ -363,7 +363,7 @@ class ProcessExplorer {
 
 	private isDebuggable(cmd: string): boolean {
 		const matches = DEBUG_FLAGS_PATTERN.exec(cmd);
-		return (matches && matches[1] !== '0') || cmd.indexOf('node ') >= 0 || cmd.indexOf('node.exe') >= 0;
+		return (matches && matches.groups!.port !== '0') || cmd.indexOf('node ') >= 0 || cmd.indexOf('node.exe') >= 0;
 	}
 
 	private attachTo(item: ProcessItem) {
@@ -375,7 +375,7 @@ class ProcessExplorer {
 
 		let matches = DEBUG_FLAGS_PATTERN.exec(item.cmd);
 		if (matches) {
-			config.port = parseInt(matches[1]);
+			config.port = Number(matches.groups!.port);
 		} else {
 			// no port -> try to attach via pid (send SIGUSR1)
 			config.processId = String(item.pid);
@@ -385,7 +385,7 @@ class ProcessExplorer {
 		matches = DEBUG_PORT_PATTERN.exec(item.cmd);
 		if (matches) {
 			// override port
-			config.port = Number(matches[1]);
+			config.port = Number(matches.groups!.port);
 		}
 
 		ipcRenderer.send('vscode:workbenchCommand', { id: 'debug.startFromConfig', from: 'processExplorer', args: [config] });


### PR DESCRIPTION
- Remove support for the `legacy` debug protocol, which js-debug does
  not support (and was removed in Node 8)
- Don't try to connect to port 0 (fixes #168343)
- Add extra logic to ps.ts to classify `extension-host` consistently

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
