### PR TITLE
testing: preserve the collapse state better

### DIFF
--- a/src/vs/workbench/contrib/testing/browser/explorerProjections/hierarchalByName.ts
+++ b/src/vs/workbench/contrib/testing/browser/explorerProjections/hierarchalByName.ts
@@ -3,16 +3,16 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { AbstractTreeViewState } from 'vs/base/browser/ui/tree/abstractTree';
-import { TestExplorerTreeElement } from 'vs/workbench/contrib/testing/browser/explorerProjections/index';
 import { flatTestItemDelimiter } from 'vs/workbench/contrib/testing/browser/explorerProjections/display';
-import { HierarchicalByLocationProjection as HierarchicalByLocationProjection } from 'vs/workbench/contrib/testing/browser/explorerProjections/hierarchalByLocation';
+import { HierarchicalByLocationProjection } from 'vs/workbench/contrib/testing/browser/explorerProjections/hierarchalByLocation';
 import { ByLocationTestItemElement } from 'vs/workbench/contrib/testing/browser/explorerProjections/hierarchalNodes';
+import { TestExplorerTreeElement } from 'vs/workbench/contrib/testing/browser/explorerProjections/index';
 import { NodeRenderDirective } from 'vs/workbench/contrib/testing/browser/explorerProjections/nodeHelper';
-import { InternalTestItem } from 'vs/workbench/contrib/testing/common/testTypes';
+import { ISerializedTestTreeCollapseState } from 'vs/workbench/contrib/testing/browser/explorerProjections/testingViewState';
+import { TestId } from 'vs/workbench/contrib/testing/common/testId';
 import { ITestResultService } from 'vs/workbench/contrib/testing/common/testResultService';
 import { ITestService } from 'vs/workbench/contrib/testing/common/testService';
-import { TestId } from 'vs/workbench/contrib/testing/common/testId';
+import { InternalTestItem } from 'vs/workbench/contrib/testing/common/testTypes';
 
 /**
  * Type of test element in the list.
@@ -76,7 +76,7 @@ export class ByNameTestItemElement extends ByLocationTestItemElement {
  * test root rather than the heirarchal parent.
  */
 export class HierarchicalByNameProjection extends HierarchicalByLocationProjection {
-	constructor(lastState: AbstractTreeViewState, @ITestService testService: ITestService, @ITestResultService results: ITestResultService) {
+	constructor(lastState: ISerializedTestTreeCollapseState, @ITestService testService: ITestService, @ITestResultService results: ITestResultService) {
 		super(lastState, testService, results);
 
 		const originalRenderNode = this.renderNode.bind(this);

--- a/src/vs/workbench/contrib/testing/browser/explorerProjections/index.ts
+++ b/src/vs/workbench/contrib/testing/browser/explorerProjections/index.ts
@@ -10,6 +10,7 @@ import { IMarkdownString } from 'vs/base/common/htmlContent';
 import { Iterable } from 'vs/base/common/iterator';
 import { IDisposable } from 'vs/base/common/lifecycle';
 import { MarshalledId } from 'vs/base/common/marshallingIds';
+import { ISerializedTestTreeCollapseState } from 'vs/workbench/contrib/testing/browser/explorerProjections/testingViewState';
 import { InternalTestItem, ITestItemContext, TestResultState } from 'vs/workbench/contrib/testing/common/testTypes';
 
 /**
@@ -24,6 +25,11 @@ export interface ITestTreeProjection extends IDisposable {
 	 * Event that fires when the projection changes.
 	 */
 	onUpdate: Event<void>;
+
+	/**
+	 * State to use for applying default collapse state of items.
+	 */
+	lastState: ISerializedTestTreeCollapseState;
 
 	/**
 	 * Fired when an element in the tree is expanded.

--- a/src/vs/workbench/contrib/testing/browser/explorerProjections/testingObjectTree.ts
+++ b/src/vs/workbench/contrib/testing/browser/explorerProjections/testingObjectTree.ts
@@ -1,0 +1,73 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { ITreeNode } from 'vs/base/browser/ui/tree/tree';
+import { WorkbenchObjectTree } from 'vs/platform/list/browser/listService';
+import { TestExplorerTreeElement, TestItemTreeElement } from 'vs/workbench/contrib/testing/browser/explorerProjections/index';
+import { ISerializedTestTreeCollapseState } from 'vs/workbench/contrib/testing/browser/explorerProjections/testingViewState';
+import { TestId } from 'vs/workbench/contrib/testing/common/testId';
+
+
+export class TestingObjectTree<TFilterData = void> extends WorkbenchObjectTree<TestExplorerTreeElement, TFilterData> {
+
+	/**
+	 * Gets a serialized view state for the tree, optimized for storage.
+	 *
+	 * @param updatePreviousState Optional previous state to mutate and update
+	 * instead of creating a new one.
+	 */
+	public getOptimizedViewState(updatePreviousState?: ISerializedTestTreeCollapseState): ISerializedTestTreeCollapseState {
+		const root: ISerializedTestTreeCollapseState = updatePreviousState || {};
+
+		/**
+		 * Recursive builder function. Returns whether the subtree has any non-default
+		 * value. Adds itself to the parent children if it does.
+		 */
+		const build = (node: ITreeNode<TestExplorerTreeElement | null, unknown>, parent: ISerializedTestTreeCollapseState): boolean => {
+			if (!(node.element instanceof TestItemTreeElement)) {
+				return false;
+			}
+
+			const localId = TestId.localId(node.element.test.item.extId);
+			const inTree = parent.children?.[localId] || {};
+			// only saved collapsed state if it's not the default (not collapsed, or a root depth)
+			inTree.collapsed = node.depth === 0 || !node.collapsed ? node.collapsed : undefined;
+
+			let hasAnyNonDefaultValue = inTree.collapsed !== undefined;
+			if (node.children.length) {
+				for (const child of node.children) {
+					hasAnyNonDefaultValue = build(child, inTree) || hasAnyNonDefaultValue;
+				}
+			}
+
+			if (hasAnyNonDefaultValue) {
+				parent.children ??= {};
+				parent.children[localId] = inTree;
+			} else if (parent.children?.hasOwnProperty(localId)) {
+				delete parent.children[localId];
+			}
+
+			return hasAnyNonDefaultValue;
+		};
+
+		root.children ??= {};
+
+		// Controller IDs are hidden if there's only a single test controller, but
+		// make sure they're added when the tree is built if this is the case, so
+		// that the later ID lookup works.
+		for (const node of this.getNode().children) {
+			if (node.element instanceof TestItemTreeElement) {
+				if (node.element.test.controllerId === node.element.test.item.extId) {
+					build(node, root);
+				} else {
+					const ctrlNode = root.children[node.element.test.controllerId] ??= { children: {} };
+					build(node, ctrlNode);
+				}
+			}
+		}
+
+		return root;
+	}
+}

--- a/src/vs/workbench/contrib/testing/browser/explorerProjections/testingViewState.ts
+++ b/src/vs/workbench/contrib/testing/browser/explorerProjections/testingViewState.ts
@@ -1,0 +1,31 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { TestId } from 'vs/workbench/contrib/testing/common/testId';
+
+export interface ISerializedTestTreeCollapseState {
+	collapsed?: boolean;
+	children?: { [localId: string]: ISerializedTestTreeCollapseState };
+}
+
+/**
+ * Gets whether the given test ID is collapsed.
+ */
+export function isCollapsedInSerializedTestTree(serialized: ISerializedTestTreeCollapseState, id: TestId | string): boolean | undefined {
+	if (!(id instanceof TestId)) {
+		id = TestId.fromString(id);
+	}
+
+	let node = serialized;
+	for (const part of id.path) {
+		if (!node.children?.hasOwnProperty(part)) {
+			return undefined;
+		}
+
+		node = node.children[part];
+	}
+
+	return node.collapsed;
+}

--- a/src/vs/workbench/contrib/testing/browser/testingExplorerView.ts
+++ b/src/vs/workbench/contrib/testing/browser/testingExplorerView.ts
@@ -10,16 +10,14 @@ import { Button } from 'vs/base/browser/ui/button/button';
 import { renderLabelWithIcons } from 'vs/base/browser/ui/iconLabel/iconLabels';
 import { IIdentityProvider, IKeyboardNavigationLabelProvider, IListVirtualDelegate } from 'vs/base/browser/ui/list/list';
 import { DefaultKeyboardNavigationDelegate, IListAccessibilityProvider } from 'vs/base/browser/ui/list/listWidget';
-import { AbstractTreeViewState, IAbstractTreeViewState } from 'vs/base/browser/ui/tree/abstractTree';
-import { ObjectTree } from 'vs/base/browser/ui/tree/objectTree';
 import { ITreeContextMenuEvent, ITreeFilter, ITreeNode, ITreeRenderer, ITreeSorter, TreeFilterResult, TreeVisibility } from 'vs/base/browser/ui/tree/tree';
 import { Action, ActionRunner, IAction, Separator } from 'vs/base/common/actions';
-import { disposableTimeout, RunOnceScheduler } from 'vs/base/common/async';
+import { RunOnceScheduler, disposableTimeout } from 'vs/base/common/async';
 import { Color, RGBA } from 'vs/base/common/color';
 import { Emitter, Event } from 'vs/base/common/event';
 import { FuzzyScore } from 'vs/base/common/filters';
 import { KeyCode } from 'vs/base/common/keyCodes';
-import { Disposable, dispose, IDisposable, MutableDisposable } from 'vs/base/common/lifecycle';
+import { Disposable, IDisposable, MutableDisposable, dispose } from 'vs/base/common/lifecycle';
 import { fuzzyContains } from 'vs/base/common/strings';
 import { isDefined } from 'vs/base/common/types';
 import { URI } from 'vs/base/common/uri';
@@ -27,7 +25,7 @@ import 'vs/css!./media/testing';
 import { MarkdownRenderer } from 'vs/editor/contrib/markdownRenderer/browser/markdownRenderer';
 import { localize } from 'vs/nls';
 import { DropdownWithPrimaryActionViewItem } from 'vs/platform/actions/browser/dropdownWithPrimaryActionViewItem';
-import { createAndFillInActionBarActions, MenuEntryActionViewItem } from 'vs/platform/actions/browser/menuEntryActionViewItem';
+import { MenuEntryActionViewItem, createAndFillInActionBarActions } from 'vs/platform/actions/browser/menuEntryActionViewItem';
 import { IMenuService, MenuId, MenuItemAction } from 'vs/platform/actions/common/actions';
 import { ICommandService } from 'vs/platform/commands/common/commands';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
@@ -35,14 +33,13 @@ import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 import { IContextMenuService } from 'vs/platform/contextview/browser/contextView';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
-import { WorkbenchObjectTree } from 'vs/platform/list/browser/listService';
 import { IOpenerService } from 'vs/platform/opener/common/opener';
 import { UnmanagedProgress } from 'vs/platform/progress/common/progress';
 import { IStorageService, StorageScope, StorageTarget, WillSaveStateReason } from 'vs/platform/storage/common/storage';
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 import { defaultButtonStyles } from 'vs/platform/theme/browser/defaultStyles';
 import { foreground } from 'vs/platform/theme/common/colorRegistry';
-import { IThemeService, registerThemingParticipant, ThemeIcon } from 'vs/platform/theme/common/themeService';
+import { IThemeService, ThemeIcon, registerThemingParticipant } from 'vs/platform/theme/common/themeService';
 import { IUriIdentityService } from 'vs/platform/uriIdentity/common/uriIdentity';
 import { ViewPane } from 'vs/workbench/browser/parts/views/viewPane';
 import { IViewletViewOptions } from 'vs/workbench/browser/parts/views/viewsViewlet';
@@ -52,22 +49,24 @@ import { HierarchicalByLocationProjection } from 'vs/workbench/contrib/testing/b
 import { ByNameTestItemElement, HierarchicalByNameProjection } from 'vs/workbench/contrib/testing/browser/explorerProjections/hierarchalByName';
 import { ITestTreeProjection, TestExplorerTreeElement, TestItemTreeElement, TestTreeErrorMessage } from 'vs/workbench/contrib/testing/browser/explorerProjections/index';
 import { getTestItemContextOverlay } from 'vs/workbench/contrib/testing/browser/explorerProjections/testItemContextOverlay';
+import { TestingObjectTree } from 'vs/workbench/contrib/testing/browser/explorerProjections/testingObjectTree';
+import { ISerializedTestTreeCollapseState } from 'vs/workbench/contrib/testing/browser/explorerProjections/testingViewState';
 import * as icons from 'vs/workbench/contrib/testing/browser/icons';
 import { TestingExplorerFilter } from 'vs/workbench/contrib/testing/browser/testingExplorerFilter';
 import { ITestingProgressUiService } from 'vs/workbench/contrib/testing/browser/testingProgressUiService';
-import { getTestingConfiguration, TestingConfigKeys } from 'vs/workbench/contrib/testing/common/configuration';
-import { labelForTestInState, TestCommandId, TestExplorerViewMode, TestExplorerViewSorting, Testing } from 'vs/workbench/contrib/testing/common/constants';
+import { TestingConfigKeys, getTestingConfiguration } from 'vs/workbench/contrib/testing/common/configuration';
+import { TestCommandId, TestExplorerViewMode, TestExplorerViewSorting, Testing, labelForTestInState } from 'vs/workbench/contrib/testing/common/constants';
 import { StoredValue } from 'vs/workbench/contrib/testing/common/storedValue';
 import { ITestExplorerFilterState, TestExplorerFilterState, TestFilterTerm } from 'vs/workbench/contrib/testing/common/testExplorerFilterState';
 import { TestId } from 'vs/workbench/contrib/testing/common/testId';
-import { TestingContextKeys } from 'vs/workbench/contrib/testing/common/testingContextKeys';
-import { ITestingPeekOpener } from 'vs/workbench/contrib/testing/common/testingPeekOpener';
-import { cmpPriority, isFailedState, isStateWithResult } from 'vs/workbench/contrib/testing/common/testingStates';
-import { canUseProfileWithTest, ITestProfileService } from 'vs/workbench/contrib/testing/common/testProfileService';
+import { ITestProfileService, canUseProfileWithTest } from 'vs/workbench/contrib/testing/common/testProfileService';
 import { TestResultItemChangeReason } from 'vs/workbench/contrib/testing/common/testResult';
 import { ITestResultService } from 'vs/workbench/contrib/testing/common/testResultService';
 import { IMainThreadTestCollection, ITestService, testCollectionIsEmpty } from 'vs/workbench/contrib/testing/common/testService';
-import { InternalTestItem, ITestRunProfile, TestItemExpandState, TestResultState, TestRunProfileBitset } from 'vs/workbench/contrib/testing/common/testTypes';
+import { ITestRunProfile, InternalTestItem, TestItemExpandState, TestResultState, TestRunProfileBitset } from 'vs/workbench/contrib/testing/common/testTypes';
+import { TestingContextKeys } from 'vs/workbench/contrib/testing/common/testingContextKeys';
+import { ITestingPeekOpener } from 'vs/workbench/contrib/testing/common/testingPeekOpener';
+import { cmpPriority, isFailedState, isStateWithResult } from 'vs/workbench/contrib/testing/common/testingStates';
 import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
 
 const enum LastFocusState {
@@ -405,7 +404,7 @@ const enum WelcomeExperience {
 }
 
 export class TestingExplorerViewModel extends Disposable {
-	public tree: ObjectTree<TestExplorerTreeElement, FuzzyScore>;
+	public tree: TestingObjectTree<FuzzyScore>;
 	private filter: TestsFilter;
 	public projection = this._register(new MutableDisposable<ITestTreeProjection>());
 
@@ -414,7 +413,7 @@ export class TestingExplorerViewModel extends Disposable {
 	private readonly _viewSorting = TestingContextKeys.viewSorting.bindTo(this.contextKeyService);
 	private readonly welcomeVisibilityEmitter = new Emitter<WelcomeExperience>();
 	private readonly actionRunner = new TestExplorerActionRunner(() => this.tree.getSelection().filter(isDefined));
-	private readonly lastViewState = new StoredValue<IAbstractTreeViewState>({
+	private readonly lastViewState = new StoredValue<ISerializedTestTreeCollapseState>({
 		key: 'testing.treeState',
 		scope: StorageScope.WORKSPACE,
 		target: StorageTarget.MACHINE,
@@ -493,7 +492,7 @@ export class TestingExplorerViewModel extends Disposable {
 		this.reevaluateWelcomeState();
 		this.filter = this.instantiationService.createInstance(TestsFilter, testService.collection);
 		this.tree = instantiationService.createInstance(
-			WorkbenchObjectTree,
+			TestingObjectTree,
 			'Test Explorer List',
 			listContainer,
 			new ListDelegate(),
@@ -509,11 +508,24 @@ export class TestingExplorerViewModel extends Disposable {
 				accessibilityProvider: instantiationService.createInstance(ListAccessibilityProvider),
 				filter: this.filter,
 				findWidgetEnabled: false
-			}) as WorkbenchObjectTree<TestExplorerTreeElement, FuzzyScore>;
+			}) as TestingObjectTree<FuzzyScore>;
+
+
+		// saves the collapse state so that if items are removed or refreshed, they
+		// retain the same state (#170169)
+		const collapseStateSaver = this._register(new RunOnceScheduler(() => {
+			// reuse the last view state to avoid making a bunch of object garbage:
+			const state = this.tree.getOptimizedViewState(this.lastViewState.get({}));
+			const projection = this.projection.value;
+			if (projection) {
+				projection.lastState = state;
+			}
+		}, 3000));
 
 		this._register(this.tree.onDidChangeCollapseState(evt => {
 			if (evt.node.element instanceof TestItemTreeElement) {
 				this.projection.value?.expandElement(evt.node.element, evt.deep ? Infinity : 0);
+				collapseStateSaver.schedule();
 			}
 		}));
 
@@ -620,11 +632,9 @@ export class TestingExplorerViewModel extends Disposable {
 
 		this._register(editorService.onDidActiveEditorChange(onEditorChange));
 
-		this._register(this.storageService.onWillSaveState(({ reason }) => {
+		this._register(this.storageService.onWillSaveState(({ reason, }) => {
 			if (reason === WillSaveStateReason.SHUTDOWN) {
-				this.lastViewState.store(this.tree.getViewState({
-					getId: e => e instanceof TestItemTreeElement ? e.test.item.extId : '',
-				}));
+				this.lastViewState.store(this.tree.getOptimizedViewState());
 			}
 		}));
 
@@ -787,7 +797,7 @@ export class TestingExplorerViewModel extends Disposable {
 	private updatePreferredProjection() {
 		this.projection.clear();
 
-		const lastState = AbstractTreeViewState.lift(this.lastViewState.get() ?? AbstractTreeViewState.empty());
+		const lastState = this.lastViewState.get({});
 		if (this._viewMode.get() === TestExplorerViewMode.List) {
 			this.projection.value = this.instantiationService.createInstance(HierarchicalByNameProjection, lastState);
 		} else {

--- a/src/vs/workbench/contrib/testing/common/storedValue.ts
+++ b/src/vs/workbench/contrib/testing/common/storedValue.ts
@@ -31,6 +31,7 @@ export class StoredValue<T> {
 	private readonly key: string;
 	private readonly scope: StorageScope;
 	private readonly target: StorageTarget;
+	private value?: T;
 
 	/**
 	 * Emitted whenever the value is updated or deleted.
@@ -58,8 +59,12 @@ export class StoredValue<T> {
 	public get(defaultValue: T): T;
 
 	public get(defaultValue?: T): T | undefined {
-		const value = this.storage.get(this.key, this.scope);
-		return value === undefined ? defaultValue : this.serialization.deserialize(value);
+		if (this.value === undefined) {
+			const value = this.storage.get(this.key, this.scope);
+			this.value = value === undefined ? defaultValue : this.serialization.deserialize(value);
+		}
+
+		return this.value;
 	}
 
 	/**
@@ -67,6 +72,7 @@ export class StoredValue<T> {
 	 * @param value
 	 */
 	public store(value: T) {
+		this.value = value;
 		this.storage.store(this.key, this.serialization.serialize(value), this.scope, this.target);
 	}
 

--- a/src/vs/workbench/contrib/testing/common/testId.ts
+++ b/src/vs/workbench/contrib/testing/common/testId.ts
@@ -93,6 +93,14 @@ export class TestId {
 	}
 
 	/**
+	 * Cheaply gets the local ID of a test identified with the string.
+	 */
+	public static localId(idString: string) {
+		const idx = idString.lastIndexOf(TestIdPathParts.Delimiter);
+		return idx === -1 ? idString : idString.slice(idx + TestIdPathParts.Delimiter.length);
+	}
+
+	/**
 	 * Compares the position of the two ID strings.
 	 */
 	public static compare(a: string, b: string) {

--- a/src/vs/workbench/contrib/testing/test/browser/explorerProjections/hierarchalByLocation.test.ts
+++ b/src/vs/workbench/contrib/testing/test/browser/explorerProjections/hierarchalByLocation.test.ts
@@ -4,12 +4,11 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as assert from 'assert';
-import { AbstractTreeViewState } from 'vs/base/browser/ui/tree/abstractTree';
 import { Emitter } from 'vs/base/common/event';
 import { HierarchicalByLocationProjection } from 'vs/workbench/contrib/testing/browser/explorerProjections/hierarchalByLocation';
-import { TestDiffOpType, TestItemExpandState, TestResultItem, TestResultState } from 'vs/workbench/contrib/testing/common/testTypes';
 import { TestId } from 'vs/workbench/contrib/testing/common/testId';
 import { TestResultItemChange, TestResultItemChangeReason } from 'vs/workbench/contrib/testing/common/testResult';
+import { TestDiffOpType, TestItemExpandState, TestResultItem, TestResultState } from 'vs/workbench/contrib/testing/common/testTypes';
 import { TestTreeTestHarness } from 'vs/workbench/contrib/testing/test/browser/testObjectTree';
 import { TestTestItem } from 'vs/workbench/contrib/testing/test/common/testStubs';
 
@@ -29,7 +28,7 @@ suite('Workbench - Testing Explorer Hierarchal by Location Projection', () => {
 			getStateById: () => ({ state: { state: 0 }, computedState: 0 }),
 		};
 
-		harness = new TestTreeTestHarness(l => new TestHierarchicalByLocationProjection(AbstractTreeViewState.empty(), l, resultsService as any));
+		harness = new TestTreeTestHarness(l => new TestHierarchicalByLocationProjection({}, l, resultsService as any));
 	});
 
 	teardown(() => {

--- a/src/vs/workbench/contrib/testing/test/browser/explorerProjections/hierarchalByName.test.ts
+++ b/src/vs/workbench/contrib/testing/test/browser/explorerProjections/hierarchalByName.test.ts
@@ -4,14 +4,13 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as assert from 'assert';
-import { AbstractTreeViewState } from 'vs/base/browser/ui/tree/abstractTree';
 import { Emitter } from 'vs/base/common/event';
 import { HierarchicalByNameProjection } from 'vs/workbench/contrib/testing/browser/explorerProjections/hierarchalByName';
-import { TestDiffOpType, TestItemExpandState } from 'vs/workbench/contrib/testing/common/testTypes';
+import { TestId } from 'vs/workbench/contrib/testing/common/testId';
 import { TestResultItemChange } from 'vs/workbench/contrib/testing/common/testResult';
+import { TestDiffOpType, TestItemExpandState } from 'vs/workbench/contrib/testing/common/testTypes';
 import { TestTreeTestHarness } from 'vs/workbench/contrib/testing/test/browser/testObjectTree';
 import { TestTestItem } from 'vs/workbench/contrib/testing/test/common/testStubs';
-import { TestId } from 'vs/workbench/contrib/testing/common/testId';
 
 suite('Workbench - Testing Explorer Hierarchal by Name Projection', () => {
 	let harness: TestTreeTestHarness<HierarchicalByNameProjection>;
@@ -26,7 +25,7 @@ suite('Workbench - Testing Explorer Hierarchal by Name Projection', () => {
 			getStateById: () => ({ state: { state: 0 }, computedState: 0 }),
 		};
 
-		harness = new TestTreeTestHarness(l => new HierarchicalByNameProjection(AbstractTreeViewState.empty(), l, resultsService as any));
+		harness = new TestTreeTestHarness(l => new HierarchicalByNameProjection({}, l, resultsService as any));
 	});
 
 	teardown(() => {


### PR DESCRIPTION
Previously, to preserve collapse state, we were serializing the tree collapses in a generic way provided by the AbstractTree. This was fairly slow, and as a result I didn't want to do it at runtime, except during shutdown.

First, this makes that a lot faster by extending the tree and making speciale serialization logic. It generates a serialized state that reflects the tree, and stores keeps collapse states that aren't the default. Test IDs are heirarchal, like `\0`-delimited paths, and it also only stores the 'local' ID of each test.

With this, serialization of the big VS Code test tree takes ~2ms, which is done on a debounce if the user changes the collapse state of any items. This logic now lets us preserve the collapse state of items at runtime as requested in the original issue.

Fixes #140332 (for real this time)
