### PR TITLE
Support detecting terminal profile with potentially unsafe paths and add an opt-in

### DIFF
--- a/src/vs/platform/terminal/common/terminal.ts
+++ b/src/vs/platform/terminal/common/terminal.ts
@@ -755,6 +755,13 @@ export interface ITerminalProfile {
 	profileName: string;
 	path: string;
 	isDefault: boolean;
+	/**
+	 * Whether the terminal profile contains a potentially unsafe path. For example, the path
+	 *  `C:\Cygwin` is the default install for Cygwin on Windows, but it could be created by any
+	 * user in a multi-user environment. As such, we don't want to blindly present it as a profile
+	 * without a warning.
+	 */
+	isUnsafePath?: boolean;
 	isAutoDetected?: boolean;
 	/**
 	 * Whether the profile path was found on the `$PATH` environment variable, if so it will be
@@ -789,8 +796,15 @@ export interface IBaseUnresolvedTerminalProfile {
 	env?: ITerminalEnvironment;
 }
 
+type OneOrN<T> = T | T[];
+
+export interface ITerminalUnsafePath {
+	path: string;
+	isUnsafe: true;
+}
+
 export interface ITerminalExecutable extends IBaseUnresolvedTerminalProfile {
-	path: string | string[];
+	path: OneOrN<string | ITerminalUnsafePath>;
 }
 
 export interface ITerminalProfileSource extends IBaseUnresolvedTerminalProfile {

--- a/src/vs/platform/terminal/node/terminalProfiles.ts
+++ b/src/vs/platform/terminal/node/terminalProfiles.ts
@@ -12,7 +12,7 @@ import * as pfs from 'vs/base/node/pfs';
 import { enumeratePowerShellInstallations } from 'vs/base/node/powershell';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { ILogService } from 'vs/platform/log/common/log';
-import { ITerminalEnvironment, ITerminalExecutable, ITerminalProfile, ITerminalProfileSource, ProfileSource, TerminalIcon, TerminalSettingId } from 'vs/platform/terminal/common/terminal';
+import { ITerminalEnvironment, ITerminalExecutable, ITerminalProfile, ITerminalProfileSource, ITerminalUnsafePath, ProfileSource, TerminalIcon, TerminalSettingId } from 'vs/platform/terminal/common/terminal';
 import { findExecutable, getWindowsBuildNumber } from 'vs/platform/terminal/node/terminalEnvironment';
 import { ThemeIcon } from 'vs/platform/theme/common/themeService';
 
@@ -108,6 +108,15 @@ async function detectAvailableWindowsProfiles(
 			icon: Codicon.terminalCmd,
 			isAutoDetected: true
 		});
+		detectedProfiles.set('Cygwin', {
+			path: [
+				{ path: `${process.env['HOMEDRIVE']}\\cygwin64\\bin\\bash.exe`, isUnsafe: true },
+				{ path: `${process.env['HOMEDRIVE']}\\cygwin\\bin\\bash.exe`, isUnsafe: true }
+			],
+			args: ['--login'],
+			isAutoDetected: true
+		});
+		// isUnsafePath
 	}
 
 	applyConfigProfilesToMap(configProfiles, detectedProfiles);
@@ -144,7 +153,7 @@ async function transformToTerminalProfiles(
 	const resultProfiles: ITerminalProfile[] = [];
 	for (const [profileName, profile] of entries) {
 		if (profile === null) { continue; }
-		let originalPaths: string[];
+		let originalPaths: (string | ITerminalUnsafePath)[];
 		let args: string[] | string | undefined;
 		let icon: ThemeIcon | URI | { light: URI; dark: URI } | undefined = undefined;
 		if ('source' in profile) {
@@ -167,7 +176,26 @@ async function transformToTerminalProfiles(
 			icon = validateIcon(profile.icon);
 		}
 
-		const paths = (await variableResolver?.(originalPaths)) || originalPaths.slice();
+		let paths: (string | ITerminalUnsafePath)[];
+		if (variableResolver) {
+			// Convert to string[] for resolve
+			const mapped = originalPaths.map(e => typeof e === 'string' ? e : e.path);
+			const resolved = await variableResolver(mapped);
+			// Convert resolved back to (T | string)[]
+			paths = new Array(originalPaths.length);
+			for (let i = 0; i < originalPaths.length; i++) {
+				if (typeof originalPaths[i] === 'string') {
+					paths[i] = originalPaths[i];
+				} else {
+					paths[i] = {
+						path: resolved[i],
+						isUnsafe: true
+					};
+				}
+			}
+		} else {
+			paths = originalPaths.slice();
+		}
 		const validatedProfile = await validateProfilePaths(profileName, defaultProfileName, paths, fsProvider, shellEnv, args, profile.env, profile.overrideName, profile.isAutoDetected, logService);
 		if (validatedProfile) {
 			validatedProfile.isAutoDetected = profile.isAutoDetected;
@@ -328,7 +356,7 @@ function applyConfigProfilesToMap(configProfiles: { [key: string]: IUnresolvedTe
 	}
 }
 
-async function validateProfilePaths(profileName: string, defaultProfileName: string | undefined, potentialPaths: string[], fsProvider: IFsProvider, shellEnv: typeof process.env, args?: string[] | string, env?: ITerminalEnvironment, overrideName?: boolean, isAutoDetected?: boolean, logService?: ILogService): Promise<ITerminalProfile | undefined> {
+async function validateProfilePaths(profileName: string, defaultProfileName: string | undefined, potentialPaths: (string | ITerminalUnsafePath)[], fsProvider: IFsProvider, shellEnv: typeof process.env, args?: string[] | string, env?: ITerminalEnvironment, overrideName?: boolean, isAutoDetected?: boolean, logService?: ILogService): Promise<ITerminalProfile | undefined> {
 	if (potentialPaths.length === 0) {
 		return Promise.resolve(undefined);
 	}
@@ -336,14 +364,25 @@ async function validateProfilePaths(profileName: string, defaultProfileName: str
 	if (path === '') {
 		return validateProfilePaths(profileName, defaultProfileName, potentialPaths, fsProvider, shellEnv, args, env, overrideName, isAutoDetected);
 	}
+	const isUnsafePath = typeof path !== 'string' && path.isUnsafe;
+	const actualPath = typeof path === 'string' ? path : path.path;
 
-	const profile: ITerminalProfile = { profileName, path, args, env, overrideName, isAutoDetected, isDefault: profileName === defaultProfileName };
+	const profile: ITerminalProfile = {
+		profileName,
+		path: actualPath,
+		args,
+		env,
+		overrideName,
+		isAutoDetected,
+		isDefault: profileName === defaultProfileName,
+		isUnsafePath
+	};
 
 	// For non-absolute paths, check if it's available on $PATH
-	if (basename(path) === path) {
+	if (basename(actualPath) === actualPath) {
 		// The executable isn't an absolute path, try find it on the PATH
 		const envPaths: string[] | undefined = shellEnv.PATH ? shellEnv.PATH.split(delimiter) : undefined;
-		const executable = await findExecutable(path, undefined, envPaths, undefined, fsProvider.existsFile);
+		const executable = await findExecutable(actualPath, undefined, envPaths, undefined, fsProvider.existsFile);
 		if (!executable) {
 			return validateProfilePaths(profileName, defaultProfileName, potentialPaths, fsProvider, shellEnv, args);
 		}
@@ -352,7 +391,7 @@ async function validateProfilePaths(profileName: string, defaultProfileName: str
 		return profile;
 	}
 
-	const result = await fsProvider.existsFile(normalize(path));
+	const result = await fsProvider.existsFile(normalize(actualPath));
 	if (result) {
 		return profile;
 	}

--- a/src/vs/platform/terminal/node/terminalProfiles.ts
+++ b/src/vs/platform/terminal/node/terminalProfiles.ts
@@ -116,7 +116,14 @@ async function detectAvailableWindowsProfiles(
 			args: ['--login'],
 			isAutoDetected: true
 		});
-		// isUnsafePath
+		detectedProfiles.set('bash (MSYS2)', {
+			path: [
+				{ path: `${process.env['HOMEDRIVE']}\\msys64\\usr\\bin\\bash.exe`, isUnsafe: true },
+			],
+			args: ['--login', '-i'],
+			icon: Codicon.terminalBash,
+			isAutoDetected: true
+		});
 	}
 
 	applyConfigProfilesToMap(configProfiles, detectedProfiles);

--- a/src/vs/workbench/contrib/terminal/browser/terminalProfileQuickpick.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalProfileQuickpick.ts
@@ -241,7 +241,7 @@ export class TerminalProfileQuickpick {
 		}];
 		const icon = (profile.icon && ThemeIcon.isThemeIcon(profile.icon)) ? profile.icon : Codicon.terminal;
 		const label = `$(${icon.id}) ${profile.profileName}`;
-		const friendlyPath = (profile.isFromPath ? basename(profile.path) : profile.path) + (profile.isUnsafePath ? ` $(${Codicon.warning.id})` : '');
+		const friendlyPath = profile.isFromPath ? basename(profile.path) : profile.path;
 		const colorClass = getColorClass(profile);
 		const iconClasses = [];
 		if (colorClass) {

--- a/src/vs/workbench/contrib/terminal/browser/terminalProfileQuickpick.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalProfileQuickpick.ts
@@ -213,7 +213,7 @@ export class TerminalProfileQuickpick {
 	}
 
 	private async _isProfileSafe(profile: ITerminalProfile | IExtensionTerminalProfile): Promise<boolean> {
-		if (!('isUnsafePath' in profile)) {
+		if (!('isUnsafePath' in profile) || profile.isUnsafePath === false) {
 			return true;
 		}
 

--- a/src/vs/workbench/contrib/terminal/browser/terminalProfileQuickpick.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalProfileQuickpick.ts
@@ -221,7 +221,7 @@ export class TerminalProfileQuickpick {
 		return await new Promise<boolean>(r => {
 			const handle = this._notificationService.prompt(
 				Severity.Warning,
-				nls.localize('unsafePathWarning', 'This profile uses the potentially unsafe path {0} that another user can write to. Are you sure you want to use it?', `"${profile.path}"`),
+				nls.localize('unsafePathWarning', 'This profile uses a potentially unsafe path that can be modified by another user: {0}. Are you use you want to use it?', `"${profile.path}"`),
 				[{
 					label: nls.localize('yes', 'Yes'),
 					run: () => r(true)

--- a/src/vs/workbench/contrib/terminal/browser/terminalProfileQuickpick.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalProfileQuickpick.ts
@@ -223,11 +223,11 @@ export class TerminalProfileQuickpick {
 				Severity.Warning,
 				nls.localize('unsafePathWarning', 'This profile uses the potentially unsafe path {0} that another user can write to. Are you sure you want to use it?', `"${profile.path}"`),
 				[{
-					label: nls.localize('cancel', 'Cancel'),
-					run: () => r(false)
-				}, {
 					label: nls.localize('yes', 'Yes'),
 					run: () => r(true)
+				}, {
+					label: nls.localize('cancel', 'Cancel'),
+					run: () => r(false)
 				}]
 			);
 			handle.onDidClose(() => r(false));

--- a/src/vs/workbench/contrib/terminal/browser/terminalProfileResolverService.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalProfileResolverService.ts
@@ -243,12 +243,7 @@ export abstract class BaseTerminalProfileResolverService implements ITerminalPro
 	}
 
 	private _getUnresolvedRealDefaultProfile(os: OperatingSystem): ITerminalProfile | undefined {
-		const defaultProfileName = this._configurationService.getValue(`${TerminalSettingPrefix.DefaultProfile}${this._getOsKey(os)}`);
-		if (defaultProfileName && typeof defaultProfileName === 'string') {
-			return this._terminalProfileService.availableProfiles.find(e => e.profileName === defaultProfileName);
-		}
-
-		return undefined;
+		return this._terminalProfileService.getDefaultProfile(os);
 	}
 
 	private async _getUnresolvedShellSettingDefaultProfile(options: IShellLaunchConfigResolveOptions): Promise<ITerminalProfile | undefined> {

--- a/src/vs/workbench/contrib/terminal/browser/terminalProfileService.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalProfileService.ts
@@ -101,7 +101,6 @@ export class TerminalProfileService implements ITerminalProfileService {
 	getDefaultProfile(os?: OperatingSystem): ITerminalProfile | undefined {
 		let defaultProfileName: string | undefined;
 		if (os) {
-			// TODO: Verify new local works
 			const defaultProfileName = this._configurationService.getValue(`${TerminalSettingPrefix.DefaultProfile}${this._getOsKey(os)}`);
 			if (!defaultProfileName || typeof defaultProfileName !== 'string') {
 				return undefined;

--- a/src/vs/workbench/contrib/terminal/browser/terminalProfileService.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalProfileService.ts
@@ -28,6 +28,8 @@ import { IRemoteAgentService } from 'vs/workbench/services/remote/common/remoteA
  * and keeps the available terminal profiles updated
  */
 export class TerminalProfileService implements ITerminalProfileService {
+	declare _serviceBrand: undefined;
+
 	private _webExtensionContributedProfileContextKey: IContextKey<boolean>;
 	private _profilesReadyBarrier: AutoOpenBarrier;
 	private _availableProfiles: ITerminalProfile[] | undefined;
@@ -91,8 +93,6 @@ export class TerminalProfileService implements ITerminalProfileService {
 			}
 		});
 	}
-
-	_serviceBrand: undefined;
 
 	getDefaultProfileName(): string | undefined {
 		return this._defaultProfileName;

--- a/src/vs/workbench/contrib/terminal/browser/terminalService.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalService.ts
@@ -934,7 +934,7 @@ export class TerminalService implements ITerminalService {
 			}
 		}
 
-		const config = options?.config || this._terminalProfileService.availableProfiles?.find(p => p.profileName === this._terminalProfileService.getDefaultProfileName());
+		const config = options?.config || this._terminalProfileService.getDefaultProfile();
 		const shellLaunchConfig = config && 'extensionIdentifier' in config ? {} : this._terminalInstanceService.convertProfileToShellLaunchConfig(config || {});
 
 		// Get the contributed profile if it was provided

--- a/src/vs/workbench/contrib/terminal/common/terminal.ts
+++ b/src/vs/workbench/contrib/terminal/common/terminal.ts
@@ -80,6 +80,7 @@ export interface ITerminalProfileService {
 	getPlatformKey(): Promise<string>;
 	refreshAvailableProfiles(): void;
 	getDefaultProfileName(): string | undefined;
+	getDefaultProfile(os?: OperatingSystem): ITerminalProfile | undefined;
 	onDidChangeAvailableProfiles: Event<ITerminalProfile[]>;
 	getContributedDefaultProfile(shellLaunchConfig: IShellLaunchConfig): Promise<IExtensionTerminalProfile | undefined>;
 	registerContributedProfile(args: IRegisterContributedProfileArgs): Promise<void>;

--- a/src/vs/workbench/test/browser/workbenchTestServices.ts
+++ b/src/vs/workbench/test/browser/workbenchTestServices.ts
@@ -1846,6 +1846,7 @@ export class TestTerminalProfileService implements ITerminalProfileService {
 	getPlatformKey(): Promise<string> { throw new Error('Method not implemented.'); }
 	refreshAvailableProfiles(): void { throw new Error('Method not implemented.'); }
 	getDefaultProfileName(): string | undefined { throw new Error('Method not implemented.'); }
+	getDefaultProfile(): ITerminalProfile | undefined { throw new Error('Method not implemented.'); }
 	getContributedDefaultProfile(shellLaunchConfig: IShellLaunchConfig): Promise<IExtensionTerminalProfile | undefined> { throw new Error('Method not implemented.'); }
 	registerContributedProfile(args: IRegisterContributedProfileArgs): Promise<void> { throw new Error('Method not implemented.'); }
 	getContributedProfileProvider(extensionIdentifier: string, id: string): ITerminalProfileProvider | undefined { throw new Error('Method not implemented.'); }


### PR DESCRIPTION
Fixes #167721

Some background on this, there was a CVE recently about picking up shells with paths that could be written to by other users on Windows in a shared user environment. The cygwin profile was removed and the git bash profile lost a single path it used to pick up:

- `C:\Cygwin64\bin\bash.exe`
- `C:\Cygwin\bin\bash.exe`
- `C:\ProgramData\scoop\apps\git-with-openssh\current\bin\bash.exe`

The PR for reference is https://github.com/microsoft/vscode/issues/160827.

---

This change adds the ability to pick unsafe paths up as a "detected profile", similar to Windows PowerShell when PowerShell is not installed, it will not show up in new terminal with profile list by default:

![image](https://user-images.githubusercontent.com/2193314/209881424-eb51a6d5-50f4-4d52-b168-b49c1a15e67c.png)

But we do make it more convenient to set up:
![image](https://user-images.githubusercontent.com/2193314/209881440-34c64b8a-b78f-4141-bf29-806d929c3a63.png)
![image](https://user-images.githubusercontent.com/2193314/209881451-4b779ddd-e3b2-4ace-bfa7-5d4d4e4dcc5e.png)

From there the user can select the item to make it the default or click the gear to just add it to settings.

This is what that looks like now if you have Cygwin or MSYS2 (new) installed:

![image](https://user-images.githubusercontent.com/2193314/209881528-6ab3bad6-b3c4-45e5-b65d-dcebee912600.png)
![image](https://user-images.githubusercontent.com/2193314/209881547-c67381d9-4123-437a-906f-9814c69e5041.png)

Notice the warning icon next to the exe as an extra indicator that this one is special. When you click on either the profile or the gear, it will present this notification:

![image](https://user-images.githubusercontent.com/2193314/209882438-9a664bd2-19e2-4070-926b-3ace8fa06ade.png)

Notice that Cancel is the default which is atypical, not sure whether we should swap it?

When accepting:

![image](https://user-images.githubusercontent.com/2193314/209882468-a16d9dfa-7f36-4801-9860-1b535394c151.png)

This change will also let us support cmder https://github.com/microsoft/vscode/issues/125387, but that needs some more functionality added to profiles and I didn't want to make this PR more complex than it needed to be.