### PR TITLE
Reduce min split pane size in terminal

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminalGroup.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalGroup.ts
@@ -19,7 +19,7 @@ const enum Constants {
 	/**
 	 * The minimum size in pixels of a split pane.
 	 */
-	SplitPaneMinSize = 180,
+	SplitPaneMinSize = 80,
 	/**
 	 * The number of cells the terminal gets added or removed when asked to increase or decrease
 	 * the view size.


### PR DESCRIPTION
This was done without terminal tabs in mind. It's just a sanity check to avoid very small terminals. This width should never be hit in practice now.

Fixes #145404
