### PR TITLE
Support cmder profile detection

### DIFF
--- a/src/vs/platform/terminal/common/terminal.ts
+++ b/src/vs/platform/terminal/common/terminal.ts
@@ -794,6 +794,7 @@ export interface IBaseUnresolvedTerminalProfile {
 	icon?: string | ThemeIcon | URI | { light: URI; dark: URI };
 	color?: string;
 	env?: ITerminalEnvironment;
+	requiresPath?: string | ITerminalUnsafePath;
 }
 
 type OneOrN<T> = T | T[];

--- a/src/vs/platform/terminal/common/terminal.ts
+++ b/src/vs/platform/terminal/common/terminal.ts
@@ -756,12 +756,16 @@ export interface ITerminalProfile {
 	path: string;
 	isDefault: boolean;
 	/**
-	 * Whether the terminal profile contains a potentially unsafe path. For example, the path
-	 *  `C:\Cygwin` is the default install for Cygwin on Windows, but it could be created by any
+	 * Whether the terminal profile contains a potentially unsafe {@link path}. For example, the path
+	 * `C:\Cygwin` is the default install for Cygwin on Windows, but it could be created by any
 	 * user in a multi-user environment. As such, we don't want to blindly present it as a profile
 	 * without a warning.
 	 */
 	isUnsafePath?: boolean;
+	/**
+	 * An additional unsafe path that must exist, for example a script that appears in {@link args}.
+	 */
+	requiresUnsafePath?: string;
 	isAutoDetected?: boolean;
 	/**
 	 * Whether the profile path was found on the `$PATH` environment variable, if so it will be

--- a/src/vs/platform/terminal/node/terminalProfiles.ts
+++ b/src/vs/platform/terminal/node/terminalProfiles.ts
@@ -124,6 +124,14 @@ async function detectAvailableWindowsProfiles(
 			icon: Codicon.terminalBash,
 			isAutoDetected: true
 		});
+		const cmderPath = `${process.env['CMDER_ROOT'] || `${process.env['HOMEDRIVE']}\\cmder`}\\vendor\\bin\\vscode_init.cmd`;
+		detectedProfiles.set('Cmder', {
+			path: `${system32Path}\\cmd.exe`,
+			args: ['/K', cmderPath],
+			// The path is safe if it was derived from CMDER_ROOT
+			requiresPath: process.env['CMDER_ROOT'] ? cmderPath : { path: cmderPath, isUnsafe: true },
+			isAutoDetected: true
+		});
 	}
 
 	applyConfigProfilesToMap(configProfiles, detectedProfiles);


### PR DESCRIPTION
Includes https://github.com/microsoft/vscode/pull/170193 so that should get merged before review

If `%CMDER_ROOT%` exists, the profile will be detected if `%CMDER_ROOT%\vendor\bin\vscode_init.cmd`, otherwise we'll do a best effort guess and check `C:\cmder\vendor\bin\vscode_init.cmd`. If `%CMDER_ROOT%` was used, the path is safe as the control over the environment is restricted.

![image](https://user-images.githubusercontent.com/2193314/210007092-84fd4810-7601-4d49-b582-65d3e88a397e.png)

If `%CMDER_ROOT%` was not used:

![image](https://user-images.githubusercontent.com/2193314/210007101-86a1e9ad-70ba-48f5-81a5-cd833b78506f.png)

Resulting profile:

![image](https://user-images.githubusercontent.com/2193314/210007142-6e606121-8aff-4b2a-bb65-711aaf974b41.png)

Fixes #125387