### PR TITLE
Check if there is an edit before applying it to the buffer

### DIFF
--- a/src/vs/workbench/services/configuration/common/jsonEditingService.ts
+++ b/src/vs/workbench/services/configuration/common/jsonEditingService.ts
@@ -51,7 +51,7 @@ export class JSONEditingService implements IJSONEditingService {
 		let hasEdits: boolean = false;
 		for (const value of values) {
 			const edit = this.getEdits(model, value)[0];
-			hasEdits = this.applyEditsToBuffer(edit, model);
+			hasEdits = !!edit && this.applyEditsToBuffer(edit, model);
 		}
 		if (hasEdits) {
 			return this.textFileService.save(model.uri);


### PR DESCRIPTION
This was throwing an error before if you were writing `undefined` to a property that didn't exist.

Fixes #168092

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
