### PR TITLE
SCM - Add onDidChangeValue event to SourceControlInputBox

### DIFF
--- a/src/vs/workbench/api/common/extHostSCM.ts
+++ b/src/vs/workbench/api/common/extHostSCM.ts
@@ -213,10 +213,10 @@ export class ExtHostSCMInputBox implements vscode.SourceControlInputBox {
 		this.updateValue(value);
 	}
 
-	private readonly _onDidChange = new Emitter<string>();
+	private readonly _onDidChangeValue = new Emitter<string>();
 
-	get onDidChange(): Event<string> {
-		return this._onDidChange.event;
+	get onDidChangeValue(): Event<string> {
+		return this._onDidChangeValue.event;
 	}
 
 	private _placeholder: string = '';
@@ -299,7 +299,7 @@ export class ExtHostSCMInputBox implements vscode.SourceControlInputBox {
 
 	private updateValue(value: string): void {
 		this._value = value;
-		this._onDidChange.fire(value);
+		this._onDidChangeValue.fire(value);
 	}
 }
 

--- a/src/vscode-dts/vscode.d.ts
+++ b/src/vscode-dts/vscode.d.ts
@@ -14232,6 +14232,11 @@ declare module 'vscode' {
 		 * Controls whether the input box is visible (default is `true`).
 		 */
 		visible: boolean;
+
+		/**
+		 * An event which fires when the input box value changes.
+		 */
+		readonly onDidChangeValue: Event<string>;
 	}
 
 	interface QuickDiffProvider {


### PR DESCRIPTION
Add onDidChangeValue event to SourceControlInputBox. The event was already in place, but it was not defined in the `vscode.d.ts`.


Related #166615