### PR TITLE
add profile name to window title

### DIFF
--- a/src/vs/workbench/browser/parts/titlebar/windowTitle.ts
+++ b/src/vs/workbench/browser/parts/titlebar/windowTitle.ts
@@ -24,6 +24,7 @@ import { IProductService } from 'vs/platform/product/common/productService';
 import { Schemas } from 'vs/base/common/network';
 import { withNullAsUndefined } from 'vs/base/common/types';
 import { getVirtualWorkspaceLocation } from 'vs/platform/workspace/common/virtualWorkspace';
+import { IUserDataProfileService } from 'vs/workbench/services/userDataProfile/common/userDataProfile';
 
 const enum WindowSettingNames {
 	titleSeparator = 'window.titleSeparator',
@@ -52,6 +53,7 @@ export class WindowTitle extends Disposable {
 		@IWorkspaceContextService private readonly contextService: IWorkspaceContextService,
 		@IInstantiationService protected readonly instantiationService: IInstantiationService,
 		@ILabelService private readonly labelService: ILabelService,
+		@IUserDataProfileService private readonly userDataProfileService: IUserDataProfileService,
 		@IProductService private readonly productService: IProductService
 	) {
 		super();
@@ -73,6 +75,7 @@ export class WindowTitle extends Disposable {
 		this._register(this.contextService.onDidChangeWorkbenchState(() => this.titleUpdater.schedule()));
 		this._register(this.contextService.onDidChangeWorkspaceName(() => this.titleUpdater.schedule()));
 		this._register(this.labelService.onDidChangeFormatters(() => this.titleUpdater.schedule()));
+		this._register(this.userDataProfileService.onDidChangeCurrentProfile(() => this.titleUpdater.schedule()));
 	}
 
 	private onConfigurationChanged(event: IConfigurationChangeEvent): void {
@@ -232,6 +235,7 @@ export class WindowTitle extends Disposable {
 		const folderPath = folder ? this.labelService.getUriLabel(folder.uri) : '';
 		const dirty = editor?.isDirty() && !editor.isSaving() ? WindowTitle.TITLE_DIRTY : '';
 		const appName = this.productService.nameLong;
+		const profileName = this.userDataProfileService.currentProfile.isDefault ? '' : `${this.userDataProfileService.currentProfile.name} (${localize('profile', "Profile")})`;
 		const separator = this.configurationService.getValue<string>(WindowSettingNames.titleSeparator);
 		const titleTemplate = this.configurationService.getValue<string>(WindowSettingNames.title);
 
@@ -250,6 +254,7 @@ export class WindowTitle extends Disposable {
 			dirty,
 			appName,
 			remoteName,
+			profileName,
 			separator: { label: separator }
 		});
 	}

--- a/src/vs/workbench/browser/workbench.contribution.ts
+++ b/src/vs/workbench/browser/workbench.contribution.ts
@@ -512,7 +512,7 @@ const registry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Con
 						return '${activeEditorShort}${separator}${rootName}${separator}${profileName}'; // macOS has native dirty indicator
 					}
 
-					const base = '${dirty}${activeEditorShort}${separator}${rootName}${separator}${appName}${separator}${profileName}';
+					const base = '${dirty}${activeEditorShort}${separator}${rootName}${separator}${profileName}${separator}${appName}';
 					if (isWeb) {
 						return base + '${separator}${remoteName}'; // Web: always show remote name
 					}

--- a/src/vs/workbench/browser/workbench.contribution.ts
+++ b/src/vs/workbench/browser/workbench.contribution.ts
@@ -492,6 +492,7 @@ const registry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Con
 		localize('rootName', "`${rootName}`: name of the workspace with optional remote name and workspace indicator if applicable (e.g. myFolder, myRemoteFolder [SSH] or myWorkspace (Workspace))."),
 		localize('rootNameShort', "`${rootNameShort}`: shortened name of the workspace without suffixes (e.g. myFolder, myRemoteFolder or myWorkspace)."),
 		localize('rootPath', "`${rootPath}`: file path of the opened workspace or folder (e.g. /Users/Development/myWorkspace)."),
+		localize('profileName', "`${profileName}`: name of the profile in which the workspace is opened (e.g. Data Science (Profile)). Ignored if default profile is used."),
 		localize('appName', "`${appName}`: e.g. VS Code."),
 		localize('remoteName', "`${remoteName}`: e.g. SSH"),
 		localize('dirty', "`${dirty}`: an indicator for when the active editor has unsaved changes."),
@@ -508,10 +509,10 @@ const registry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Con
 				'type': 'string',
 				'default': (() => {
 					if (isMacintosh && isNative) {
-						return '${activeEditorShort}${separator}${rootName}'; // macOS has native dirty indicator
+						return '${activeEditorShort}${separator}${rootName}${separator}${profileName}'; // macOS has native dirty indicator
 					}
 
-					const base = '${dirty}${activeEditorShort}${separator}${rootName}${separator}${appName}';
+					const base = '${dirty}${activeEditorShort}${separator}${rootName}${separator}${appName}${separator}${profileName}';
 					if (isWeb) {
 						return base + '${separator}${remoteName}'; // Web: always show remote name
 					}


### PR DESCRIPTION
#168864

Adds non-default profile name to the window title by default and can be configurable.

- Single Folder Workspace
![image](https://user-images.githubusercontent.com/10746682/210399537-7bfb556a-3a0f-4e5d-89fc-8d6bc1565da9.png)

- Multi-folder Workspace
![image](https://user-images.githubusercontent.com/10746682/210399628-d92b3274-02ab-40a9-8f63-7b7ba1819be0.png)

- Empty Window 
![image](https://user-images.githubusercontent.com/10746682/210400255-820250be-16fc-4898-9fd6-eef473c5ce2e.png)

- Remote folder
![image](https://user-images.githubusercontent.com/10746682/210401546-a645f3c3-2fc7-4584-934e-4a885bf7aaea.png)

- Remote Workspace
![image](https://user-images.githubusercontent.com/10746682/210401728-63bbfc2f-1cc5-43a8-8444-555535bc6fb8.png)


Profile name is shown for windows by default with non default profiles. One can configure the profile name in the window title using `${profileName}` parameter. 

CC @isidorn 
