### PR TITLE
Fix shell integration for PowerShell 5.1 

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/media/shellIntegration.ps1
+++ b/src/vs/workbench/contrib/terminal/browser/media/shellIntegration.ps1
@@ -29,6 +29,9 @@ function Global:__VSCode-Escape-Value([string]$value) {
 }
 
 function Global:Prompt() {
+	# NOTE: We disable strict mode for the scope of this function because it unhelpfully throws an
+	# error when $LastHistoryEntry is null, and is not otherwise useful.
+	Set-StrictMode -Off
 	$FakeCode = [int]!$global:?
 	$LastHistoryEntry = Get-History -Count 1
 	# Skip finishing the command if the first command has not yet started

--- a/src/vs/workbench/contrib/terminal/browser/media/shellIntegration.ps1
+++ b/src/vs/workbench/contrib/terminal/browser/media/shellIntegration.ps1
@@ -23,8 +23,7 @@ function Global:__VSCode-Escape-Value([string]$value) {
 	[regex]::Replace($value, '[\\\n;]', { param($match)
 		# Encode the (ascii) matches as `\x<hex>`
 		-Join (
-			[System.Text.Encoding]::UTF8.GetBytes($match.Value)
-			| ForEach-Object { '\x{0:x2}' -f $_ }
+			[System.Text.Encoding]::UTF8.GetBytes($match.Value) | ForEach-Object { '\x{0:x2}' -f $_ }
 		)
 	})
 }


### PR DESCRIPTION
The pipeline operator cannot be used on a new line, which caused https://github.com/microsoft/vscode/issues/167068.

Also sets the dubious runtime ["strict mode"](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/set-strictmode) PowerShell feature off in the `prompt` function. Note that this is off by default, but can be turned on by users, leading to cryptic issues as this code expects `$LastHistoryEntry.Id` to just be return `$Null` when `$LastHistoryEntry` is `$Null` (a reasonable expectation and valid PowerShell code, just against "strict" mode's guidelines). This caused https://github.com/PowerShell/vscode-powershell/issues/4343.

Image of it working again:

<img width="465" alt="Screenshot 2023-01-03 at 12 23 25 PM" src="https://user-images.githubusercontent.com/2226434/210435430-a2e64fbd-bc22-4a4d-a024-9ddcc15d7b5d.png">
