### PR TITLE
Debounce storing forwarded ports

### DIFF
--- a/src/vs/workbench/services/remote/common/remoteExplorerService.ts
+++ b/src/vs/workbench/services/remote/common/remoteExplorerService.ts
@@ -25,6 +25,7 @@ import Severity from 'vs/base/common/severity';
 import { IDialogService } from 'vs/platform/dialogs/common/dialogs';
 import { URI } from 'vs/base/common/uri';
 import { deepClone } from 'vs/base/common/objects';
+import { debounce } from 'vs/base/common/decorators';
 
 export const IRemoteExplorerService = createDecorator<IRemoteExplorerService>('remoteExplorerService');
 export const REMOTE_EXPLORER_TYPE_KEY: string = 'remote.explorerType';
@@ -568,6 +569,7 @@ export class TunnelModel extends Disposable {
 		}
 	}
 
+	@debounce(1000)
 	private async storeForwarded() {
 		if (this.configurationService.getValue('remote.restoreForwardedPorts')) {
 			const valueToStore = JSON.stringify(Array.from(this.forwarded.values()).filter(value => value.source.source === TunnelSource.User));


### PR DESCRIPTION
This prevents over-agressive syncing of ports, which can cause deleted ports to be re-added.