### PR TITLE
Fix local terminal launching when back and frontend OS differs

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminalProfileResolverService.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalProfileResolverService.ts
@@ -289,14 +289,18 @@ export abstract class BaseTerminalProfileResolverService implements ITerminalPro
 	private async _getUnresolvedFallbackDefaultProfile(options: IShellLaunchConfigResolveOptions): Promise<ITerminalProfile> {
 		const executable = await this._context.getDefaultSystemShell(options.remoteAuthority, options.os);
 
-		// Try select an existing profile to fallback to, based on the default system shell
-		let existingProfile = this._terminalProfileService.availableProfiles.find(e => path.parse(e.path).name === path.parse(executable).name);
-		if (existingProfile) {
-			if (options.allowAutomationShell) {
-				existingProfile = deepClone(existingProfile);
-				existingProfile.icon = Codicon.tools;
+		// Try select an existing profile to fallback to, based on the default system shell, only do
+		// this when it is NOT a local terminal in a remote window where the front and back end OS
+		// differs (eg. Windows -> WSL, Mac -> Linux)
+		if (options.os === OS) {
+			let existingProfile = this._terminalProfileService.availableProfiles.find(e => path.parse(e.path).name === path.parse(executable).name);
+			if (existingProfile) {
+				if (options.allowAutomationShell) {
+					existingProfile = deepClone(existingProfile);
+					existingProfile.icon = Codicon.tools;
+				}
+				return existingProfile;
 			}
-			return existingProfile;
 		}
 
 		// Finally fallback to a generated profile


### PR DESCRIPTION
Terminals launched with local cwds were matching their executable names against resolved (remote) profiles, causing the wrong executable to launch which could lead to the wrong executable being used or failing all together if it didn't exist or the path separators were switched.

Fixes #148572

---

This will need to be verified in the product build as this cannot be reproduced via the test resolver.