### PR TITLE
Ctrl/cmd+shift+o to open detected link in the terminal

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminalActions.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalActions.ts
@@ -2059,6 +2059,11 @@ export function registerTerminalActions() {
 				f1: true,
 				category,
 				precondition: TerminalContextKeys.terminalHasBeenCreated,
+				keybinding: {
+					primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KeyO,
+					weight: KeybindingWeight.WorkbenchContrib + 1,
+					when: TerminalContextKeys.focus,
+				}
 			});
 		}
 		run(accessor: ServicesAccessor) {


### PR DESCRIPTION
This is similar functionality to go to symbol in the editor.

Fixes #170643