### PR TITLE
Return instead of throwing when the markers can't be found

### DIFF
--- a/src/vs/platform/terminal/common/capabilities/commandDetectionCapability.ts
+++ b/src/vs/platform/terminal/common/capabilities/commandDetectionCapability.ts
@@ -703,7 +703,7 @@ export function getLinesForCommand(buffer: IBuffer, command: ITerminalCommand, c
 	const executedMarker = command.executedMarker;
 	const endMarker = command.endMarker;
 	if (!executedMarker || !endMarker) {
-		throw new Error('No marker for command');
+		return undefined;
 	}
 	const startLine = executedMarker.line;
 	const endLine = endMarker.line;


### PR DESCRIPTION
Fixes #170463
