### PR TITLE
debug: log progress in NamedPipeDebugAdapter tests

### DIFF
--- a/src/vs/workbench/contrib/debug/test/node/streamDebugAdapter.test.ts
+++ b/src/vs/workbench/contrib/debug/test/node/streamDebugAdapter.test.ts
@@ -46,15 +46,23 @@ function serverConnection(socket: net.Socket) {
 suite('Debug - StreamDebugAdapter', () => {
 
 	test(`StreamDebugAdapter (NamedPipeDebugAdapter) can initialize a connection`, async () => {
+		// todo@connor4312: debug test failure that seems to only happen in CI.
+		// Even running this test on a loop on my machine for an hour doesn't hit failures :(
+		const progress: string[] = [];
+		const timeout = setTimeout(() => {
+			console.log('NamedPipeDebugAdapter test might fail. Progress:', progress.join(','));
+		}, 1000); // should usually finish is <10ms
 
 		const pipeName = crypto.randomBytes(10).toString('hex');
 		const pipePath = platform.isWindows ? join('\\\\.\\pipe\\', pipeName) : join(tmpdir(), pipeName);
+		progress.push(`listen on ${pipePath}`);
 		const server = await new Promise<net.Server>((resolve, reject) => {
 			const server = net.createServer(serverConnection);
 			server.once('listening', () => resolve(server));
 			server.once('error', reject);
 			server.listen(pipePath);
 		});
+		progress.push('server up');
 
 		const debugAdapter = new NamedPipeDebugAdapter({
 			type: 'pipeServer',
@@ -62,12 +70,16 @@ suite('Debug - StreamDebugAdapter', () => {
 		});
 		try {
 			await debugAdapter.startSession();
+			progress.push('started session');
 			const response: DebugProtocol.Response = await sendInitializeRequest(debugAdapter);
+			progress.push('got response');
 			assert.strictEqual(response.command, 'initialize');
 			assert.strictEqual(response.request_seq, 1);
 			assert.strictEqual(response.success, true, response.message);
 		} finally {
 			await debugAdapter.stopSession();
+			progress.push('stopped session');
+			clearTimeout(timeout);
 			server.close();
 			debugAdapter.dispose();
 		}


### PR DESCRIPTION
This test has timed out rarely, but several times in CI. I have tried to review the code and hit the failure locally, but without success. This PR adds a progress log that might contain a hint....
