### PR TITLE
Fix variable resolver on safe profile paths

### DIFF
--- a/src/vs/platform/terminal/node/terminalProfiles.ts
+++ b/src/vs/platform/terminal/node/terminalProfiles.ts
@@ -201,7 +201,7 @@ async function transformToTerminalProfiles(
 			paths = new Array(originalPaths.length);
 			for (let i = 0; i < originalPaths.length; i++) {
 				if (typeof originalPaths[i] === 'string') {
-					paths[i] = originalPaths[i];
+					paths[i] = resolved[i];
 				} else {
 					paths[i] = {
 						path: resolved[i],


### PR DESCRIPTION
Command Prompt was not being detected properly because of this regression.

Fixes #170563
