### PR TITLE
Support hiding navigation menu items by default

### DIFF
--- a/src/vs/platform/action/common/action.ts
+++ b/src/vs/platform/action/common/action.ts
@@ -77,6 +77,8 @@ export interface ICommandAction {
 	 * or define toggle-info including an icon and a title that goes well with a checkmark.
 	 */
 	toggled?: ContextKeyExpression | ICommandActionToggleInfo;
+
+	isHiddenByDefault?: boolean;
 }
 
 export type ISerializableCommandAction = UriDto<ICommandAction>;

--- a/src/vs/platform/actions/common/menuService.ts
+++ b/src/vs/platform/actions/common/menuService.ts
@@ -77,8 +77,9 @@ class PersistedMenuHideState {
 		this._disposables.dispose();
 	}
 
-	isHidden(menu: MenuId, commandId: string): boolean {
-		return this._data[menu.id]?.includes(commandId) ?? false;
+	isHidden(menu: MenuId, commandId: string, defaultState: boolean): boolean {
+		const state = this._data[menu.id]?.includes(commandId) ?? false;
+		return defaultState ? state : !state;
 	}
 
 	updateHidden(menu: MenuId, commandId: string, hidden: boolean): void {
@@ -400,7 +401,7 @@ function createMenuHide(menu: MenuId, command: ICommandAction | ISubmenuItem, st
 
 	const id = isISubmenuItem(command) ? command.submenu.id : command.id;
 	const title = typeof command.title === 'string' ? command.title : command.title.value;
-	const isHiddenByDefault = isISubmenuItem(command) ? true : !!command.isHiddenByDefault;
+	const defaultState = isISubmenuItem(command) ? true : !command.isHiddenByDefault;
 
 	const hide = toAction({
 		id: `hide/${menu.id}/${id}`,
@@ -411,17 +412,8 @@ function createMenuHide(menu: MenuId, command: ICommandAction | ISubmenuItem, st
 	const toggle = toAction({
 		id: `toggle/${menu.id}/${id}`,
 		label: title,
-		get checked() {
-			// Invert the meaning of the isHidden state when the default is hidden
-			if (isHiddenByDefault) {
-				return states.isHidden(menu, id);
-			}
-			return !states.isHidden(menu, id);
-		},
-		run() {
-			const newValue = !states.isHidden(menu, id);
-			states.updateHidden(menu, id, newValue);
-		}
+		get checked() { return !states.isHidden(menu, id, defaultState); },
+		run() { states.updateHidden(menu, id, !this.checked); }
 	});
 
 	return {

--- a/src/vs/platform/actions/common/menuService.ts
+++ b/src/vs/platform/actions/common/menuService.ts
@@ -400,6 +400,7 @@ function createMenuHide(menu: MenuId, command: ICommandAction | ISubmenuItem, st
 
 	const id = isISubmenuItem(command) ? command.submenu.id : command.id;
 	const title = typeof command.title === 'string' ? command.title : command.title.value;
+	const isHiddenByDefault = isISubmenuItem(command) ? true : !!command.isHiddenByDefault;
 
 	const hide = toAction({
 		id: `hide/${menu.id}/${id}`,
@@ -410,7 +411,13 @@ function createMenuHide(menu: MenuId, command: ICommandAction | ISubmenuItem, st
 	const toggle = toAction({
 		id: `toggle/${menu.id}/${id}`,
 		label: title,
-		get checked() { return !states.isHidden(menu, id); },
+		get checked() {
+			// Invert the meaning of the isHidden state when the default is hidden
+			if (isHiddenByDefault) {
+				return states.isHidden(menu, id);
+			}
+			return !states.isHidden(menu, id);
+		},
 		run() {
 			const newValue = !states.isHidden(menu, id);
 			states.updateHidden(menu, id, newValue);


### PR DESCRIPTION
This will let us expose many terminal actions in an overflow `...` menu in the view title which can be toggled to show, such as Clear (often requested), Run Recent Command, etc.