### PR TITLE
use publisher in extension name for telemetry api

### DIFF
--- a/src/vs/workbench/api/common/extHostTelemetry.ts
+++ b/src/vs/workbench/api/common/extHostTelemetry.ts
@@ -77,7 +77,7 @@ export class ExtHostTelemetry implements ExtHostTelemetryShape {
 		const commonProperties: Record<string, string | boolean | number | undefined> = {};
 		// TODO @lramos15, does os info like node arch, platform version, etc exist here.
 		// Or will first party extensions just mix this in
-		commonProperties['common.extname'] = extension.name;
+		commonProperties['common.extname'] = `${extension.publisher}.${extension.name}`;
 		commonProperties['common.extversion'] = extension.version;
 		commonProperties['common.vscodemachineid'] = this.initData.telemetryInfo.machineId;
 		commonProperties['common.vscodesessionid'] = this.initData.telemetryInfo.sessionId;


### PR DESCRIPTION
Historically extensions specify publisher.name for their extname in the telemetry module. now that we take this over, we should do the same as just the name is not very unique

It is worth noting that extensions had control over this before and now they do not, we are just striving to match an existing standard.