### PR TITLE
perf - use `Lazy` for comparers and 💄 `Lazy` to align with `IdleValue`

### DIFF
--- a/src/vs/base/browser/markdownRenderer.ts
+++ b/src/vs/base/browser/markdownRenderer.ts
@@ -438,7 +438,7 @@ export function renderMarkdownAsPlaintext(markdown: IMarkdownString) {
 		value = `${value.substr(0, 100_000)}…`;
 	}
 
-	const html = marked.parse(value, { renderer: plainTextRenderer.getValue() }).replace(/&(#\d+|[a-zA-Z]+);/g, m => unescapeInfo.get(m) ?? m);
+	const html = marked.parse(value, { renderer: plainTextRenderer.value }).replace(/&(#\d+|[a-zA-Z]+);/g, m => unescapeInfo.get(m) ?? m);
 
 	return sanitizeRenderedMarkdown({ isTrusted: false }, html).toString();
 }

--- a/src/vs/base/common/comparers.ts
+++ b/src/vs/base/common/comparers.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { IdleValue } from 'vs/base/common/async';
+import { Lazy } from 'vs/base/common/lazy';
 import { sep } from 'vs/base/common/path';
 
 // When comparing large numbers of strings it's better for performance to create an
@@ -11,27 +11,27 @@ import { sep } from 'vs/base/common/path';
 // than it is to use String.prototype.localeCompare()
 
 // A collator with numeric sorting enabled, and no sensitivity to case, accents or diacritics.
-const intlFileNameCollatorBaseNumeric: IdleValue<{ collator: Intl.Collator; collatorIsNumeric: boolean }> = new IdleValue(() => {
+const intlFileNameCollatorBaseNumeric: Lazy<{ collator: Intl.Collator; collatorIsNumeric: boolean }> = new Lazy(() => {
 	const collator = new Intl.Collator(undefined, { numeric: true, sensitivity: 'base' });
 	return {
-		collator: collator,
+		collator,
 		collatorIsNumeric: collator.resolvedOptions().numeric
 	};
 });
 
 // A collator with numeric sorting enabled.
-const intlFileNameCollatorNumeric: IdleValue<{ collator: Intl.Collator }> = new IdleValue(() => {
+const intlFileNameCollatorNumeric: Lazy<{ collator: Intl.Collator }> = new Lazy(() => {
 	const collator = new Intl.Collator(undefined, { numeric: true });
 	return {
-		collator: collator
+		collator
 	};
 });
 
 // A collator with numeric sorting enabled, and sensitivity to accents and diacritics but not case.
-const intlFileNameCollatorNumericCaseInsensitive: IdleValue<{ collator: Intl.Collator }> = new IdleValue(() => {
+const intlFileNameCollatorNumericCaseInsensitive: Lazy<{ collator: Intl.Collator }> = new Lazy(() => {
 	const collator = new Intl.Collator(undefined, { numeric: true, sensitivity: 'accent' });
 	return {
-		collator: collator
+		collator
 	};
 });
 

--- a/src/vs/base/common/lazy.ts
+++ b/src/vs/base/common/lazy.ts
@@ -3,20 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-/**
- * A value that is resolved synchronously when it is first needed.
- */
-export interface Lazy<T> {
-
-	hasValue(): boolean;
-
-
-	getValue(): T;
-
-
-	map<R>(f: (x: T) => R): Lazy<R>;
-}
-
 export class Lazy<T> {
 
 	private _didRun: boolean = false;
@@ -30,7 +16,7 @@ export class Lazy<T> {
 	/**
 	 * True if the lazy value has been resolved.
 	 */
-	hasValue() { return this._didRun; }
+	get hasValue() { return this._didRun; }
 
 	/**
 	 * Get the wrapped value.
@@ -38,7 +24,7 @@ export class Lazy<T> {
 	 * This will force evaluation of the lazy value if it has not been resolved yet. Lazy values are only
 	 * resolved once. `getValue` will re-throw exceptions that are hit while resolving the value
 	 */
-	getValue(): T {
+	get value(): T {
 		if (!this._didRun) {
 			try {
 				this._value = this.executor();
@@ -58,13 +44,4 @@ export class Lazy<T> {
 	 * Get the wrapped value without forcing evaluation.
 	 */
 	get rawValue(): T | undefined { return this._value; }
-
-	/**
-	 * Create a new lazy value that is the result of applying `f` to the wrapped value.
-	 *
-	 * This does not force the evaluation of the current lazy value.
-	 */
-	map<R>(f: (x: T) => R): Lazy<R> {
-		return new Lazy<R>(() => f(this.getValue()));
-	}
 }

--- a/src/vs/base/common/strings.ts
+++ b/src/vs/base/common/strings.ts
@@ -1134,7 +1134,7 @@ export class AmbiguousCharacters {
 			return result;
 		}
 
-		const data = this.ambiguousCharacterData.getValue();
+		const data = this.ambiguousCharacterData.value;
 
 		let filteredLocales = locales.filter(
 			(l) => !l.startsWith('_') && l in data
@@ -1160,12 +1160,12 @@ export class AmbiguousCharacters {
 	}
 
 	private static _locales = new Lazy<string[]>(() =>
-		Object.keys(AmbiguousCharacters.ambiguousCharacterData.getValue()).filter(
+		Object.keys(AmbiguousCharacters.ambiguousCharacterData.value).filter(
 			(k) => !k.startsWith('_')
 		)
 	);
 	public static getLocales(): string[] {
-		return AmbiguousCharacters._locales.getValue();
+		return AmbiguousCharacters._locales.value;
 	}
 
 	private constructor(

--- a/src/vs/base/test/common/lazy.test.ts
+++ b/src/vs/base/test/common/lazy.test.ts
@@ -12,53 +12,19 @@ suite('Lazy', () => {
 		let counter = 0;
 		const value = new Lazy(() => ++counter);
 
-		assert.strictEqual(value.hasValue(), false);
-		assert.strictEqual(value.getValue(), 1);
-		assert.strictEqual(value.hasValue(), true);
-		assert.strictEqual(value.getValue(), 1); // make sure we did not evaluate again
+		assert.strictEqual(value.hasValue, false);
+		assert.strictEqual(value.value, 1);
+		assert.strictEqual(value.hasValue, true);
+		assert.strictEqual(value.value, 1); // make sure we did not evaluate again
 	});
 
 	test('lazy values handle error case', () => {
 		let counter = 0;
 		const value = new Lazy(() => { throw new Error(`${++counter}`); });
 
-		assert.strictEqual(value.hasValue(), false);
-		assert.throws(() => value.getValue(), /\b1\b/);
-		assert.strictEqual(value.hasValue(), true);
-		assert.throws(() => value.getValue(), /\b1\b/);
-	});
-
-	test('map should not cause lazy values to be re-resolved', () => {
-		let outer = 0;
-		let inner = 10;
-		const outerLazy = new Lazy(() => ++outer);
-		const innerLazy = outerLazy.map(x => [x, ++inner]);
-
-		assert.strictEqual(outerLazy.hasValue(), false);
-		assert.strictEqual(innerLazy.hasValue(), false);
-
-		assert.deepStrictEqual(innerLazy.getValue(), [1, 11]);
-		assert.strictEqual(outerLazy.hasValue(), true);
-		assert.strictEqual(innerLazy.hasValue(), true);
-		assert.strictEqual(outerLazy.getValue(), 1);
-
-		// make sure we did not evaluate again
-		assert.strictEqual(outerLazy.getValue(), 1);
-		assert.deepStrictEqual(innerLazy.getValue(), [1, 11]);
-	});
-
-	test('map should handle error values', () => {
-		let outer = 0;
-		let inner = 10;
-		const outerLazy = new Lazy(() => { throw new Error(`${++outer}`); });
-		const innerLazy = outerLazy.map(x => { throw new Error(`${++inner}`); });
-
-		assert.strictEqual(outerLazy.hasValue(), false);
-		assert.strictEqual(innerLazy.hasValue(), false);
-
-		assert.throws(() => innerLazy.getValue(), /\b1\b/); // we should get result from outer
-		assert.strictEqual(outerLazy.hasValue(), true);
-		assert.strictEqual(innerLazy.hasValue(), true);
-		assert.throws(() => outerLazy.getValue(), /\b1\b/);
+		assert.strictEqual(value.hasValue, false);
+		assert.throws(() => value.value, /\b1\b/);
+		assert.strictEqual(value.hasValue, true);
+		assert.throws(() => value.value, /\b1\b/);
 	});
 });

--- a/src/vs/editor/contrib/codeAction/browser/codeActionCommands.ts
+++ b/src/vs/editor/contrib/codeAction/browser/codeActionCommands.ts
@@ -125,11 +125,11 @@ export class CodeActionController extends Disposable implements IEditorContribut
 	}
 
 	private update(newState: CodeActionsState.State): void {
-		this._ui.getValue().update(newState);
+		this._ui.value.update(newState);
 	}
 
 	public showCodeActions(_trigger: CodeActionTrigger, actions: CodeActionSet, at: IAnchor | IPosition) {
-		return this._ui.getValue().showCodeActionList(actions, at, { includeDisabledActions: false, fromLightbulb: false });
+		return this._ui.value.showCodeActionList(actions, at, { includeDisabledActions: false, fromLightbulb: false });
 	}
 
 	public manualTriggerAtCurrentPosition(

--- a/src/vs/editor/contrib/codeAction/browser/codeActionKeybindingResolver.ts
+++ b/src/vs/editor/contrib/codeAction/browser/codeActionKeybindingResolver.ts
@@ -54,7 +54,7 @@ export class CodeActionKeybindingResolver {
 
 		return (action) => {
 			if (action.kind) {
-				const binding = this.bestKeybindingForCodeAction(action, allCodeActionBindings.getValue());
+				const binding = this.bestKeybindingForCodeAction(action, allCodeActionBindings.value);
 				return binding?.resolvedKeybinding;
 			}
 			return undefined;

--- a/src/vs/editor/contrib/codeAction/browser/codeActionUi.ts
+++ b/src/vs/editor/contrib/codeAction/browser/codeActionUi.ts
@@ -89,7 +89,7 @@ export class CodeActionUi extends Disposable {
 			return;
 		}
 
-		this._lightBulbWidget.getValue().update(actions, newState.trigger, newState.position);
+		this._lightBulbWidget.value.update(actions, newState.trigger, newState.position);
 
 		if (newState.trigger.type === CodeActionTriggerType.Invoke) {
 			if (newState.trigger.filter?.include) { // Triggered for specific scope
@@ -98,7 +98,7 @@ export class CodeActionUi extends Disposable {
 				const validActionToApply = this.tryGetValidActionToApply(newState.trigger, actions);
 				if (validActionToApply) {
 					try {
-						this._lightBulbWidget.getValue().hide();
+						this._lightBulbWidget.value.hide();
 						await this.delegate.applyCodeAction(validActionToApply, false, false);
 					} finally {
 						actions.dispose();

--- a/src/vs/editor/contrib/parameterHints/browser/parameterHints.ts
+++ b/src/vs/editor/contrib/parameterHints/browser/parameterHints.ts
@@ -45,8 +45,8 @@ class ParameterHintsController extends Disposable implements IEditorContribution
 
 		this._register(this.model.onChangedHints(newParameterHints => {
 			if (newParameterHints) {
-				this.widget.getValue().show();
-				this.widget.getValue().render(newParameterHints);
+				this.widget.value.show();
+				this.widget.value.render(newParameterHints);
 			} else {
 				this.widget.rawValue?.hide();
 			}

--- a/src/vs/workbench/api/common/extHostTextEditor.ts
+++ b/src/vs/workbench/api/common/extHostTextEditor.ts
@@ -428,7 +428,7 @@ export class ExtHostTextEditor {
 
 		this.value = Object.freeze({
 			get document(): vscode.TextDocument {
-				return document.getValue();
+				return document.value;
 			},
 			set document(_value) {
 				throw readonly('document');
@@ -482,7 +482,7 @@ export class ExtHostTextEditor {
 				if (that._disposed) {
 					return Promise.reject(new Error('TextEditor#edit not possible on closed editors'));
 				}
-				const edit = new TextEditorEdit(document.getValue(), options);
+				const edit = new TextEditorEdit(document.value, options);
 				callback(edit);
 				return that._applyEdit(edit);
 			},
@@ -513,7 +513,7 @@ export class ExtHostTextEditor {
 						}
 					}
 				}
-				return _proxy.$tryInsertSnippet(id, document.getValue().version, snippet.value, ranges, options);
+				return _proxy.$tryInsertSnippet(id, document.value.version, snippet.value, ranges, options);
 			},
 			setDecorations(decorationType: vscode.TextEditorDecorationType, ranges: Range[] | vscode.DecorationOptions[]): void {
 				const willBeEmpty = (ranges.length === 0);

--- a/src/vs/workbench/api/common/extHostVariableResolverService.ts
+++ b/src/vs/workbench/api/common/extHostVariableResolverService.ts
@@ -158,7 +158,7 @@ export class ExtHostVariableResolverProviderService extends Disposable implement
 	}
 
 	public getResolver(): Promise<IConfigurationResolverService> {
-		return this._resolver.getValue();
+		return this._resolver.value;
 	}
 
 	protected homeDir(): string | undefined {

--- a/src/vs/workbench/contrib/notebook/browser/contrib/find/notebookFindWidget.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/find/notebookFindWidget.ts
@@ -57,7 +57,7 @@ export class NotebookFindContrib extends Disposable implements INotebookEditorCo
 	}
 
 	show(initialInput?: string, options?: IShowNotebookFindWidgetOptions): Promise<void> {
-		return this.widget.getValue().show(initialInput, options);
+		return this.widget.value.show(initialInput, options);
 	}
 
 	hide() {
@@ -65,7 +65,7 @@ export class NotebookFindContrib extends Disposable implements INotebookEditorCo
 	}
 
 	replace(searchString: string | undefined) {
-		return this.widget.getValue().replace(searchString);
+		return this.widget.value.replace(searchString);
 	}
 }
 

--- a/src/vs/workbench/contrib/notebook/browser/services/notebookServiceImpl.ts
+++ b/src/vs/workbench/contrib/notebook/browser/services/notebookServiceImpl.ts
@@ -338,7 +338,7 @@ export class NotebookOutputRendererInfoStore {
 
 	/** Update and remember the preferred renderer for the given mimetype in this workspace */
 	setPreferred(notebookProviderInfo: NotebookProviderInfo, mimeType: string, rendererId: string) {
-		const mementoObj = this.preferredMimetype.getValue();
+		const mementoObj = this.preferredMimetype.value;
 		const forNotebook = mementoObj[notebookProviderInfo.id];
 		if (forNotebook) {
 			forNotebook[mimeType] = rendererId;
@@ -358,7 +358,7 @@ export class NotebookOutputRendererInfoStore {
 			BuiltIn = 4 << 8,
 		}
 
-		const preferred = notebookProviderInfo && this.preferredMimetype.getValue()[notebookProviderInfo.id]?.[mimeType];
+		const preferred = notebookProviderInfo && this.preferredMimetype.value[notebookProviderInfo.id]?.[mimeType];
 		const notebookExtId = notebookProviderInfo?.extension?.value;
 		const notebookId = notebookProviderInfo?.id;
 		const renderers: { ordered: IOrderedMimeType; score: number }[] = Array.from(this.contributedRenderers.values())

--- a/src/vs/workbench/contrib/search/browser/anythingQuickAccess.ts
+++ b/src/vs/workbench/contrib/search/browser/anythingQuickAccess.ts
@@ -1005,8 +1005,8 @@ export class AnythingQuickAccessProvider extends PickerQuickAccessProvider<IAnyt
 			label,
 			ariaLabel: isDirty ? localize('filePickAriaLabelDirty', "{0} unsaved changes", labelAndDescription) : labelAndDescription,
 			description,
-			get iconClasses() { return iconClassesValue.getValue(); },
-			get buttons() { return buttonsValue.getValue(); },
+			get iconClasses() { return iconClassesValue.value; },
+			get buttons() { return buttonsValue.value; },
 			trigger: (buttonIndex, keyMods) => {
 				switch (buttonIndex) {
 

--- a/src/vs/workbench/contrib/search/common/searchModel.ts
+++ b/src/vs/workbench/contrib/search/common/searchModel.ts
@@ -440,7 +440,7 @@ export class FileMatch extends Disposable implements IFileMatch {
 	}
 
 	name(): string {
-		return this._name.getValue();
+		return this._name.value;
 	}
 
 	addContext(results: ITextSearchResult[] | undefined) {
@@ -564,7 +564,7 @@ export class FolderMatch extends Disposable {
 	}
 
 	name(): string {
-		return this._name.getValue();
+		return this._name.value;
 	}
 
 	parent(): SearchResult | FolderMatch {

--- a/src/vs/workbench/contrib/terminal/browser/links/terminalLinkParsing.ts
+++ b/src/vs/workbench/contrib/terminal/browser/links/terminalLinkParsing.ts
@@ -81,7 +81,7 @@ export function removeLinkSuffix(link: string): string {
  * @param link The link to parse.
  */
 export function getLinkSuffix(link: string): { row: number | undefined; col: number | undefined; suffix: { index: number; text: string } } | null {
-	const matches = linkSuffixRegex.getValue().exec(link);
+	const matches = linkSuffixRegex.value.exec(link);
 	const groups = matches?.groups;
 	if (!groups || matches.length < 1) {
 		return null;

--- a/src/vs/workbench/contrib/terminal/browser/terminalActions.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalActions.ts
@@ -1091,7 +1091,7 @@ export function registerTerminalActions() {
 			});
 		}
 		run(accessor: ServicesAccessor) {
-			accessor.get(ITerminalService).activeInstance?.findWidget.getValue().reveal();
+			accessor.get(ITerminalService).activeInstance?.findWidget.value.reveal();
 		}
 	});
 	registerAction2(class extends Action2 {
@@ -1111,7 +1111,7 @@ export function registerTerminalActions() {
 			});
 		}
 		run(accessor: ServicesAccessor) {
-			accessor.get(ITerminalService).activeInstance?.findWidget.getValue().hide();
+			accessor.get(ITerminalService).activeInstance?.findWidget.value.hide();
 		}
 	});
 
@@ -1457,7 +1457,7 @@ export function registerTerminalActions() {
 		}
 		run(accessor: ServicesAccessor) {
 			const terminalService = accessor.get(ITerminalService);
-			const state = terminalService.activeInstance?.findWidget.getValue().findState;
+			const state = terminalService.activeInstance?.findWidget.value.findState;
 			state?.change({ isRegex: !state.isRegex }, false);
 		}
 	});
@@ -1479,7 +1479,7 @@ export function registerTerminalActions() {
 		}
 		run(accessor: ServicesAccessor) {
 			const terminalService = accessor.get(ITerminalService);
-			const state = terminalService.activeInstance?.findWidget.getValue().findState;
+			const state = terminalService.activeInstance?.findWidget.value.findState;
 			state?.change({ wholeWord: !state.wholeWord }, false);
 		}
 	});
@@ -1501,7 +1501,7 @@ export function registerTerminalActions() {
 		}
 		run(accessor: ServicesAccessor) {
 			const terminalService = accessor.get(ITerminalService);
-			const state = terminalService.activeInstance?.findWidget.getValue().findState;
+			const state = terminalService.activeInstance?.findWidget.value.findState;
 			state?.change({ matchCase: !state.matchCase }, false);
 		}
 	});
@@ -1530,7 +1530,7 @@ export function registerTerminalActions() {
 		}
 		run(accessor: ServicesAccessor) {
 			const terminalService = accessor.get(ITerminalService);
-			const findWidget = terminalService.activeInstance?.findWidget.getValue();
+			const findWidget = terminalService.activeInstance?.findWidget.value;
 			if (findWidget) {
 				findWidget.show();
 				findWidget.find(false);
@@ -1562,7 +1562,7 @@ export function registerTerminalActions() {
 		}
 		run(accessor: ServicesAccessor) {
 			const terminalService = accessor.get(ITerminalService);
-			const findWidget = terminalService.activeInstance?.findWidget.getValue();
+			const findWidget = terminalService.activeInstance?.findWidget.value;
 			if (findWidget) {
 				findWidget.show();
 				findWidget.find(true);

--- a/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
@@ -909,8 +909,8 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 		// The container changed, reattach
 		this._container = container;
 		this._container.appendChild(this._wrapperElement);
-		if (this.findWidget.hasValue()) {
-			this._container.appendChild(this.findWidget.getValue().getDomNode());
+		if (this.findWidget.hasValue) {
+			this._container.appendChild(this.findWidget.value.getDomNode());
 		}
 		setTimeout(() => this._initDragAndDrop(container));
 	}
@@ -933,8 +933,8 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 		this._wrapperElement.appendChild(xtermElement);
 
 		this._container.appendChild(this._wrapperElement);
-		if (this.findWidget.hasValue()) {
-			this._container.appendChild(this.findWidget.getValue().getDomNode());
+		if (this.findWidget.hasValue) {
+			this._container.appendChild(this.findWidget.value.getDomNode());
 		}
 
 		const xterm = this.xterm;
@@ -944,7 +944,7 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 
 		const screenElement = xterm.attachToElement(xtermElement);
 
-		this._register(xterm.onDidChangeFindResults(() => this.findWidget.getValue().updateResultCount()));
+		this._register(xterm.onDidChangeFindResults(() => this.findWidget.value.updateResultCount()));
 		this._register(xterm.shellIntegration.onDidChangeStatus(() => {
 			if (this.hasFocus) {
 				this._setShellIntegrationContextKey();

--- a/src/vs/workbench/contrib/testing/browser/testingOutputPeek.ts
+++ b/src/vs/workbench/contrib/testing/browser/testingOutputPeek.ts
@@ -957,7 +957,7 @@ class MarkdownTestMessagePeek extends Disposable implements IPeekOutputRenderer 
 
 		this.textPreview.value = new ScrollableMarkdownMessage(
 			this.container,
-			this.markdown.getValue(),
+			this.markdown.value,
 			message.message as IMarkdownString,
 		);
 	}

--- a/src/vs/workbench/contrib/testing/common/testResult.ts
+++ b/src/vs/workbench/contrib/testing/common/testResult.ts
@@ -167,7 +167,7 @@ export class LiveOutputController {
 		this.dataEmitter.fire(data);
 		this._offset += data.byteLength;
 
-		return this.writer.getValue()[0].write(data);
+		return this.writer.value[0].write(data);
 	}
 
 	/**
@@ -228,10 +228,10 @@ export class LiveOutputController {
 			return this.closed;
 		}
 
-		if (!this.writer.hasValue()) {
+		if (!this.writer.hasValue) {
 			this.closed = Promise.resolve();
 		} else {
-			const [stream, ended] = this.writer.getValue();
+			const [stream, ended] = this.writer.value;
 			stream.end();
 			this.closed = ended;
 		}
@@ -497,7 +497,7 @@ export class LiveTestResult implements ITestResult {
 	 * @inheritdoc
 	 */
 	public toJSON(): ISerializedTestResults | undefined {
-		return this.completedAt && this.persist ? this.doSerialize.getValue() : undefined;
+		return this.completedAt && this.persist ? this.doSerialize.value : undefined;
 	}
 
 	/**


### PR DESCRIPTION
Not using `IdleValue` anymore because it means the comparers will be created even in contexts where not used (such as the extension host). `Lazy` is better fit here to avoid that, even though that will move instantiation closer to where it is needed (in my testing: the explorer).