### PR TITLE
perf improvements in config land

### DIFF
--- a/src/vs/editor/standalone/browser/standaloneServices.ts
+++ b/src/vs/editor/standalone/browser/standaloneServices.ts
@@ -87,7 +87,7 @@ import { IQuickInputService } from 'vs/platform/quickinput/common/quickInput';
 import { IStorageService, InMemoryStorageService } from 'vs/platform/storage/common/storage';
 
 import 'vs/editor/common/services/languageFeaturesService';
-import { DefaultConfigurationModel } from 'vs/platform/configuration/common/configurations';
+import { DefaultConfiguration } from 'vs/platform/configuration/common/configurations';
 import { WorkspaceEdit } from 'vs/editor/common/languages';
 import { AudioCue, IAudioCueService, Sound } from 'vs/platform/audioCues/browser/audioCueService';
 
@@ -549,7 +549,9 @@ export class StandaloneConfigurationService implements IConfigurationService {
 	private readonly _configuration: Configuration;
 
 	constructor() {
-		this._configuration = new Configuration(new DefaultConfigurationModel(), new ConfigurationModel(), new ConfigurationModel(), new ConfigurationModel());
+		const defaultConfiguration = new DefaultConfiguration();
+		this._configuration = new Configuration(defaultConfiguration.reload(), new ConfigurationModel(), new ConfigurationModel(), new ConfigurationModel());
+		defaultConfiguration.dispose();
 	}
 
 	getValue<T>(): T;

--- a/src/vs/platform/configuration/test/common/configurationModels.test.ts
+++ b/src/vs/platform/configuration/test/common/configurationModels.test.ts
@@ -6,9 +6,6 @@ import * as assert from 'assert';
 import { join } from 'vs/base/common/path';
 import { URI } from 'vs/base/common/uri';
 import { Configuration, ConfigurationChangeEvent, ConfigurationModel, ConfigurationModelParser, mergeChanges } from 'vs/platform/configuration/common/configurationModels';
-import { Extensions, IConfigurationRegistry } from 'vs/platform/configuration/common/configurationRegistry';
-import { DefaultConfigurationModel } from 'vs/platform/configuration/common/configurations';
-import { Registry } from 'vs/platform/registry/common/platform';
 import { WorkspaceFolder } from 'vs/platform/workspace/common/workspace';
 import { Workspace } from 'vs/platform/workspace/test/common/testWorkspace';
 
@@ -108,7 +105,7 @@ suite('ConfigurationModel', () => {
 		testObject.setValue('a.b.c', 1);
 
 		assert.deepStrictEqual(testObject.contents, { 'a': { 'b': { 'c': 1 } }, 'f': 1 });
-		assert.deepStrictEqual(testObject.keys, ['a.b.c', 'f']);
+		assert.deepStrictEqual(testObject.keys, ['a.b', 'f', 'a.b.c']);
 	});
 
 	test('removeValue: remove a non existing key', () => {
@@ -228,17 +225,6 @@ suite('ConfigurationModel', () => {
 		const base = new ConfigurationModel({ 'a': { 'b': 1 }, 'f': 1 }, ['a.b', 'f'], [{ identifiers: ['c'], contents: { 'a': { 'd': 1 } }, keys: ['a'] }]);
 		const add = new ConfigurationModel({ 'a': { 'b': 2 } }, ['a.b'], [{ identifiers: ['c'], contents: { 'a': { 'e': 2 } }, keys: ['a'] }]);
 		const result = base.merge(add);
-
-		assert.deepStrictEqual(result.contents, { 'a': { 'b': 2 }, 'f': 1 });
-		assert.deepStrictEqual(result.overrides, [{ identifiers: ['c'], contents: { 'a': { 'd': 1, 'e': 2 } }, keys: ['a'] }]);
-		assert.deepStrictEqual(result.override('c').contents, { 'a': { 'b': 2, 'd': 1, 'e': 2 }, 'f': 1 });
-		assert.deepStrictEqual(result.keys, ['a.b', 'f']);
-	});
-
-	test('merge overrides when frozen', () => {
-		const model1 = new ConfigurationModel({ 'a': { 'b': 1 }, 'f': 1 }, ['a.b', 'f'], [{ identifiers: ['c'], contents: { 'a': { 'd': 1 } }, keys: ['a'] }]).freeze();
-		const model2 = new ConfigurationModel({ 'a': { 'b': 2 } }, ['a.b'], [{ identifiers: ['c'], contents: { 'a': { 'e': 2 } }, keys: ['a'] }]).freeze();
-		const result = new ConfigurationModel().merge(model1, model2);
 
 		assert.deepStrictEqual(result.contents, { 'a': { 'b': 2 }, 'f': 1 });
 		assert.deepStrictEqual(result.overrides, [{ identifiers: ['c'], contents: { 'a': { 'd': 1, 'e': 2 } }, keys: ['a'] }]);
@@ -473,72 +459,6 @@ suite('CustomConfigurationModel', () => {
 		assert.deepStrictEqual(testObject.configurationModel.keys, ['']);
 	});
 
-	test('Test registering the same property again', () => {
-		Registry.as<IConfigurationRegistry>(Extensions.Configuration).registerConfiguration({
-			'id': 'a',
-			'order': 1,
-			'title': 'a',
-			'type': 'object',
-			'properties': {
-				'a': {
-					'description': 'a',
-					'type': 'boolean',
-					'default': true,
-				}
-			}
-		});
-		Registry.as<IConfigurationRegistry>(Extensions.Configuration).registerConfiguration({
-			'id': 'a',
-			'order': 1,
-			'title': 'a',
-			'type': 'object',
-			'properties': {
-				'a': {
-					'description': 'a',
-					'type': 'boolean',
-					'default': false,
-				}
-			}
-		});
-		assert.strictEqual(true, new DefaultConfigurationModel().getValue('a'));
-	});
-});
-
-suite('CustomConfigurationModel (2)', () => {
-
-	test('Default configuration model uses overrides (1/2)', () => {
-		Registry.as<IConfigurationRegistry>(Extensions.Configuration).registerConfiguration({
-			'id': 'a',
-			'order': 1,
-			'title': 'a',
-			'type': 'object',
-			'properties': {
-				'a': {
-					'description': 'a',
-					'type': 'boolean',
-					'default': false,
-				}
-			}
-		});
-		assert.strictEqual(true, new DefaultConfigurationModel().getValue('a'));
-	});
-
-	test('Default configuration model uses overrides (2/2)', () => {
-		Registry.as<IConfigurationRegistry>(Extensions.Configuration).registerConfiguration({
-			'id': 'a',
-			'order': 1,
-			'title': 'a',
-			'type': 'object',
-			'properties': {
-				'a': {
-					'description': 'a',
-					'type': 'boolean',
-					'default': false,
-				}
-			}
-		});
-		assert.strictEqual(false, new DefaultConfigurationModel({ a: false }).getValue('a'));
-	});
 });
 
 suite('Configuration', () => {

--- a/src/vs/platform/configuration/test/common/configurationService.test.ts
+++ b/src/vs/platform/configuration/test/common/configurationService.test.ts
@@ -165,6 +165,7 @@ suite('ConfigurationService', () => {
 
 		await fileService.writeFile(settingsResource, VSBuffer.fromString('{ "testworkbench.editor.tabs": true }'));
 		testObject = disposables.add(new ConfigurationService(settingsResource, fileService, new NullPolicyService(), new NullLogService()));
+		await testObject.initialize();
 
 		setting = testObject.getValue<ITestSetting>();
 
@@ -193,7 +194,7 @@ suite('ConfigurationService', () => {
 		});
 
 		const testObject = disposables.add(new ConfigurationService(settingsResource, fileService, new NullPolicyService(), new NullLogService()));
-		testObject.initialize();
+		await testObject.initialize();
 
 		let res = testObject.inspect('something.missing');
 		assert.strictEqual(res.value, undefined);
@@ -228,7 +229,7 @@ suite('ConfigurationService', () => {
 		});
 
 		const testObject = disposables.add(new ConfigurationService(settingsResource, fileService, new NullPolicyService(), new NullLogService()));
-		testObject.initialize();
+		await testObject.initialize();
 
 		let res = testObject.inspect('lookup.service.testNullSetting');
 		assert.strictEqual(res.defaultValue, null);

--- a/src/vs/platform/configuration/test/common/configurations.test.ts
+++ b/src/vs/platform/configuration/test/common/configurations.test.ts
@@ -1,0 +1,361 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { Event } from 'vs/base/common/event';
+import { equals } from 'vs/base/common/objects';
+import { Extensions, IConfigurationNode, IConfigurationRegistry } from 'vs/platform/configuration/common/configurationRegistry';
+import { DefaultConfiguration } from 'vs/platform/configuration/common/configurations';
+import { Registry } from 'vs/platform/registry/common/platform';
+
+suite('DefaultConfiguration', () => {
+
+	const configurationRegistry = Registry.as<IConfigurationRegistry>(Extensions.Configuration);
+
+	setup(() => reset());
+	teardown(() => reset());
+
+	function reset() {
+		configurationRegistry.deregisterConfigurations(configurationRegistry.getConfigurations());
+		const configurationDefaultsOverrides = configurationRegistry.getConfigurationDefaultsOverrides();
+		configurationRegistry.deregisterDefaultConfigurations([...configurationDefaultsOverrides.keys()].map(key => ({ extensionId: configurationDefaultsOverrides.get(key)?.source, overrides: { [key]: configurationDefaultsOverrides.get(key)?.value } })));
+	}
+
+	test('Test registering a property before initialize', async () => {
+		const testObject = new DefaultConfiguration();
+		configurationRegistry.registerConfiguration({
+			'id': 'a',
+			'order': 1,
+			'title': 'a',
+			'type': 'object',
+			'properties': {
+				'a': {
+					'description': 'a',
+					'type': 'boolean',
+					'default': false,
+				}
+			}
+		});
+		const actual = await testObject.initialize();
+		assert.strictEqual(actual.getValue('a'), false);
+	});
+
+	test('Test registering a property and do not initialize', async () => {
+		const testObject = new DefaultConfiguration();
+		configurationRegistry.registerConfiguration({
+			'id': 'a',
+			'order': 1,
+			'title': 'a',
+			'type': 'object',
+			'properties': {
+				'a': {
+					'description': 'a',
+					'type': 'boolean',
+					'default': false,
+				}
+			}
+		});
+		assert.strictEqual(testObject.configurationModel.getValue('a'), undefined);
+	});
+
+	test('Test registering a property after initialize', async () => {
+		const testObject = new DefaultConfiguration();
+		const promise = Event.toPromise(testObject.onDidChangeConfiguration);
+		await testObject.initialize();
+		configurationRegistry.registerConfiguration({
+			'id': 'a',
+			'order': 1,
+			'title': 'a',
+			'type': 'object',
+			'properties': {
+				'a': {
+					'description': 'a',
+					'type': 'boolean',
+					'default': false,
+				}
+			}
+		});
+		const { defaults: actual, properties } = await promise;
+		assert.strictEqual(actual.getValue('a'), false);
+		assert.deepStrictEqual(properties, ['a']);
+	});
+
+	test('Test registering nested properties', async () => {
+		const testObject = new DefaultConfiguration();
+		configurationRegistry.registerConfiguration({
+			'id': 'a',
+			'order': 1,
+			'title': 'a',
+			'type': 'object',
+			'properties': {
+				'a.b': {
+					'description': '1',
+					'type': 'object',
+					'default': {},
+				},
+				'a.b.c': {
+					'description': '2',
+					'type': 'object',
+					'default': '2',
+				}
+			}
+		});
+
+		const actual = await testObject.initialize();
+
+		assert.ok(equals(actual.getValue('a'), { b: { c: '2' } }));
+		assert.ok(equals(actual.contents, { 'a': { b: { c: '2' } } }));
+		assert.deepStrictEqual(actual.keys, ['a.b', 'a.b.c']);
+	});
+
+	test('Test registering the same property again', async () => {
+		const testObject = new DefaultConfiguration();
+		configurationRegistry.registerConfiguration({
+			'id': 'a',
+			'order': 1,
+			'title': 'a',
+			'type': 'object',
+			'properties': {
+				'a': {
+					'description': 'a',
+					'type': 'boolean',
+					'default': true,
+				}
+			}
+		});
+		configurationRegistry.registerConfiguration({
+			'id': 'a',
+			'order': 1,
+			'title': 'a',
+			'type': 'object',
+			'properties': {
+				'a': {
+					'description': 'a',
+					'type': 'boolean',
+					'default': false,
+				}
+			}
+		});
+		const actual = await testObject.initialize();
+		assert.strictEqual(true, actual.getValue('a'));
+	});
+
+	test('Test registering an override identifier', async () => {
+		const testObject = new DefaultConfiguration();
+		configurationRegistry.registerDefaultConfigurations([{
+			overrides: {
+				'[a]': {
+					'b': true
+				}
+			}
+		}]);
+		const actual = await testObject.initialize();
+		assert.ok(equals(actual.getValue('[a]'), { 'b': true }));
+		assert.ok(equals(actual.contents, { '[a]': { 'b': true } }));
+		assert.ok(equals(actual.overrides, [{ contents: { 'b': true }, identifiers: ['a'], keys: ['b'] }]));
+		assert.deepStrictEqual(actual.keys, ['[a]']);
+		assert.strictEqual(actual.getOverrideValue('b', 'a'), true);
+	});
+
+	test('Test registering a normal property and override identifier', async () => {
+		const testObject = new DefaultConfiguration();
+		configurationRegistry.registerConfiguration({
+			'id': 'a',
+			'order': 1,
+			'title': 'a',
+			'type': 'object',
+			'properties': {
+				'b': {
+					'description': 'b',
+					'type': 'boolean',
+					'default': false,
+				}
+			}
+		});
+
+		configurationRegistry.registerDefaultConfigurations([{
+			overrides: {
+				'[a]': {
+					'b': true
+				}
+			}
+		}]);
+
+		const actual = await testObject.initialize();
+		assert.deepStrictEqual(actual.getValue('b'), false);
+		assert.ok(equals(actual.getValue('[a]'), { 'b': true }));
+		assert.ok(equals(actual.contents, { 'b': false, '[a]': { 'b': true } }));
+		assert.ok(equals(actual.overrides, [{ contents: { 'b': true }, identifiers: ['a'], keys: ['b'] }]));
+		assert.deepStrictEqual(actual.keys, ['b', '[a]']);
+		assert.strictEqual(actual.getOverrideValue('b', 'a'), true);
+	});
+
+	test('Test normal property is registered after override identifier', async () => {
+		const testObject = new DefaultConfiguration();
+		const promise = Event.toPromise(testObject.onDidChangeConfiguration);
+		configurationRegistry.registerDefaultConfigurations([{
+			overrides: {
+				'[a]': {
+					'b': true
+				}
+			}
+		}]);
+
+		await testObject.initialize();
+
+		configurationRegistry.registerConfiguration({
+			'id': 'a',
+			'order': 1,
+			'title': 'a',
+			'type': 'object',
+			'properties': {
+				'b': {
+					'description': 'b',
+					'type': 'boolean',
+					'default': false,
+				}
+			}
+		});
+
+		const { defaults: actual, properties } = await promise;
+		assert.deepStrictEqual(actual.getValue('b'), false);
+		assert.ok(equals(actual.getValue('[a]'), { 'b': true }));
+		assert.ok(equals(actual.contents, { 'b': false, '[a]': { 'b': true } }));
+		assert.ok(equals(actual.overrides, [{ contents: { 'b': true }, identifiers: ['a'], keys: ['b'] }]));
+		assert.deepStrictEqual(actual.keys, ['[a]', 'b']);
+		assert.strictEqual(actual.getOverrideValue('b', 'a'), true);
+		assert.deepStrictEqual(properties, ['b']);
+	});
+
+	test('Test override identifier is registered after property', async () => {
+		const testObject = new DefaultConfiguration();
+		const promise = Event.toPromise(testObject.onDidChangeConfiguration);
+		configurationRegistry.registerConfiguration({
+			'id': 'a',
+			'order': 1,
+			'title': 'a',
+			'type': 'object',
+			'properties': {
+				'b': {
+					'description': 'b',
+					'type': 'boolean',
+					'default': false,
+				}
+			}
+		});
+		await testObject.initialize();
+
+		configurationRegistry.registerDefaultConfigurations([{
+			overrides: {
+				'[a]': {
+					'b': true
+				}
+			}
+		}]);
+
+		const { defaults: actual, properties } = await promise;
+		assert.deepStrictEqual(actual.getValue('b'), false);
+		assert.ok(equals(actual.getValue('[a]'), { 'b': true }));
+		assert.ok(equals(actual.contents, { 'b': false, '[a]': { 'b': true } }));
+		assert.ok(equals(actual.overrides, [{ contents: { 'b': true }, identifiers: ['a'], keys: ['b'] }]));
+		assert.deepStrictEqual(actual.keys, ['b', '[a]']);
+		assert.strictEqual(actual.getOverrideValue('b', 'a'), true);
+		assert.deepStrictEqual(properties, ['[a]']);
+	});
+
+	test('Test register override identifier and property after initialize', async () => {
+		const testObject = new DefaultConfiguration();
+
+		await testObject.initialize();
+
+		configurationRegistry.registerConfiguration({
+			'id': 'a',
+			'order': 1,
+			'title': 'a',
+			'type': 'object',
+			'properties': {
+				'b': {
+					'description': 'b',
+					'type': 'boolean',
+					'default': false,
+				}
+			}
+		});
+		configurationRegistry.registerDefaultConfigurations([{
+			overrides: {
+				'[a]': {
+					'b': true
+				}
+			}
+		}]);
+
+		const actual = testObject.configurationModel;
+		assert.deepStrictEqual(actual.getValue('b'), false);
+		assert.ok(equals(actual.getValue('[a]'), { 'b': true }));
+		assert.ok(equals(actual.contents, { 'b': false, '[a]': { 'b': true } }));
+		assert.ok(equals(actual.overrides, [{ contents: { 'b': true }, identifiers: ['a'], keys: ['b'] }]));
+		assert.deepStrictEqual(actual.keys, ['b', '[a]']);
+		assert.strictEqual(actual.getOverrideValue('b', 'a'), true);
+	});
+
+	test('Test deregistering a property', async () => {
+		const testObject = new DefaultConfiguration();
+		const promise = Event.toPromise(testObject.onDidChangeConfiguration);
+		const node: IConfigurationNode = {
+			'id': 'a',
+			'order': 1,
+			'title': 'a',
+			'type': 'object',
+			'properties': {
+				'a': {
+					'description': 'a',
+					'type': 'boolean',
+					'default': false,
+				}
+			}
+		};
+		configurationRegistry.registerConfiguration(node);
+		await testObject.initialize();
+		configurationRegistry.deregisterConfigurations([node]);
+
+		const { defaults: actual, properties } = await promise;
+		assert.strictEqual(actual.getValue('a'), undefined);
+		assert.ok(equals(actual.contents, {}));
+		assert.deepStrictEqual(actual.keys, []);
+		assert.deepStrictEqual(properties, ['a']);
+	});
+
+	test('Test deregistering an override identifier', async () => {
+		const testObject = new DefaultConfiguration();
+		configurationRegistry.registerConfiguration({
+			'id': 'a',
+			'order': 1,
+			'title': 'a',
+			'type': 'object',
+			'properties': {
+				'b': {
+					'description': 'b',
+					'type': 'boolean',
+					'default': false,
+				}
+			}
+		});
+		const node = {
+			overrides: {
+				'[a]': {
+					'b': true
+				}
+			}
+		};
+		configurationRegistry.registerDefaultConfigurations([node]);
+		await testObject.initialize();
+		configurationRegistry.deregisterDefaultConfigurations([node]);
+		assert.deepStrictEqual(testObject.configurationModel.getValue('[a]'), undefined);
+		assert.ok(equals(testObject.configurationModel.contents, { 'b': false }));
+		assert.ok(equals(testObject.configurationModel.overrides, []));
+		assert.deepStrictEqual(testObject.configurationModel.keys, ['b']);
+		assert.strictEqual(testObject.configurationModel.getOverrideValue('b', 'a'), undefined);
+	});
+});

--- a/src/vs/platform/userDataSync/test/common/settingsSync.test.ts
+++ b/src/vs/platform/userDataSync/test/common/settingsSync.test.ts
@@ -17,21 +17,6 @@ import { ISettingsSyncContent, parseSettingsSyncContent, SettingsSynchroniser } 
 import { ISyncData, IUserDataSyncStoreService, SyncResource, SyncStatus, UserDataSyncError, UserDataSyncErrorCode } from 'vs/platform/userDataSync/common/userDataSync';
 import { UserDataSyncClient, UserDataSyncTestServer } from 'vs/platform/userDataSync/test/common/userDataSyncClient';
 
-Registry.as<IConfigurationRegistry>(Extensions.Configuration).registerConfiguration({
-	'id': 'settingsSync',
-	'type': 'object',
-	'properties': {
-		'settingsSync.machine': {
-			'type': 'string',
-			'scope': ConfigurationScope.MACHINE
-		},
-		'settingsSync.machineOverridable': {
-			'type': 'string',
-			'scope': ConfigurationScope.MACHINE_OVERRIDABLE
-		}
-	}
-});
-
 suite('SettingsSync - Auto', () => {
 
 	const disposableStore = new DisposableStore();
@@ -40,6 +25,20 @@ suite('SettingsSync - Auto', () => {
 	let testObject: SettingsSynchroniser;
 
 	setup(async () => {
+		Registry.as<IConfigurationRegistry>(Extensions.Configuration).registerConfiguration({
+			'id': 'settingsSync',
+			'type': 'object',
+			'properties': {
+				'settingsSync.machine': {
+					'type': 'string',
+					'scope': ConfigurationScope.MACHINE
+				},
+				'settingsSync.machineOverridable': {
+					'type': 'string',
+					'scope': ConfigurationScope.MACHINE_OVERRIDABLE
+				}
+			}
+		});
 		client = disposableStore.add(new UserDataSyncClient(server));
 		await client.setUp(true);
 		testObject = client.getSynchronizer(SyncResource.Settings) as SettingsSynchroniser;

--- a/src/vs/workbench/services/configuration/browser/configuration.ts
+++ b/src/vs/workbench/services/configuration/browser/configuration.ts
@@ -24,7 +24,7 @@ import { IStringDictionary } from 'vs/base/common/collections';
 import { joinPath } from 'vs/base/common/resources';
 import { Registry } from 'vs/platform/registry/common/platform';
 import { IBrowserWorkbenchEnvironmentService } from 'vs/workbench/services/environment/browser/environmentService';
-import { isObject } from 'vs/base/common/types';
+import { isEmptyObject, isObject } from 'vs/base/common/types';
 import { DefaultConfiguration as BaseDefaultConfiguration } from 'vs/platform/configuration/common/configurations';
 import { IJSONEditingService } from 'vs/workbench/services/configuration/common/jsonEditing';
 
@@ -62,6 +62,10 @@ export class DefaultConfiguration extends BaseDefaultConfiguration {
 		this.cachedConfigurationDefaultsOverrides = {};
 		this.updateCachedConfigurationDefaultsOverrides();
 		return super.reload();
+	}
+
+	hasCachedConfigurationDefaultsOverrides(): boolean {
+		return !isEmptyObject(this.cachedConfigurationDefaultsOverrides);
 	}
 
 	private initiaizeCachedConfigurationDefaultsOverridesPromise: Promise<void> | undefined;

--- a/src/vs/workbench/services/configuration/browser/configurationService.ts
+++ b/src/vs/workbench/services/configuration/browser/configurationService.ts
@@ -398,6 +398,10 @@ export class WorkspaceService extends Disposable implements IWorkbenchConfigurat
 		}
 	}
 
+	hasCachedConfigurationDefaultsOverrides(): boolean {
+		return this.defaultConfiguration.hasCachedConfigurationDefaultsOverrides();
+	}
+
 	inspect<T>(key: string, overrides?: IConfigurationOverrides): IConfigurationValue<T> {
 		return this._configuration.inspect<T>(key, overrides);
 	}
@@ -1256,11 +1260,13 @@ class RegisterConfigurationSchemasContribution extends Disposable implements IWo
 
 class ResetConfigurationDefaultsOverridesCache extends Disposable implements IWorkbenchContribution {
 	constructor(
-		@IConfigurationService configurationService: IConfigurationService,
+		@IConfigurationService configurationService: WorkspaceService,
 		@IExtensionService extensionService: IExtensionService,
 	) {
 		super();
-		extensionService.whenInstalledExtensionsRegistered().then(() => configurationService.reloadConfiguration(ConfigurationTarget.DEFAULT));
+		if (configurationService.hasCachedConfigurationDefaultsOverrides()) {
+			extensionService.whenInstalledExtensionsRegistered().then(() => configurationService.reloadConfiguration(ConfigurationTarget.DEFAULT));
+		}
 	}
 }
 

--- a/src/vs/workbench/services/configuration/test/browser/configuration.test.ts
+++ b/src/vs/workbench/services/configuration/test/browser/configuration.test.ts
@@ -52,6 +52,7 @@ suite('DefaultConfiguration', () => {
 	test('configuration default overrides are read from environment', async () => {
 		const environmentService = new BrowserWorkbenchEnvironmentService('', joinPath(URI.file('tests').with({ scheme: 'vscode-tests' }), 'logs'), { configurationDefaults: { 'test.configurationDefaultsOverride': 'envOverrideValue' } }, TestProductService);
 		const testObject = new DefaultConfiguration(configurationCache, environmentService);
+		await testObject.initialize();
 		assert.deepStrictEqual(testObject.configurationModel.getValue('test.configurationDefaultsOverride'), 'envOverrideValue');
 	});
 
@@ -63,29 +64,14 @@ suite('DefaultConfiguration', () => {
 		const actual = await testObject.initialize();
 
 		assert.deepStrictEqual(actual.getValue('test.configurationDefaultsOverride'), 'overrideValue');
-	});
-
-	test('configuration default overrides are read from cache when model is read before initialize', async () => {
-		window.localStorage.setItem(DefaultConfiguration.DEFAULT_OVERRIDES_CACHE_EXISTS_KEY, 'yes');
-		await configurationCache.write(cacheKey, JSON.stringify({ 'test.configurationDefaultsOverride': 'overrideValue' }));
-		const testObject = new DefaultConfiguration(configurationCache, TestEnvironmentService);
-
-		assert.deepStrictEqual(testObject.configurationModel.getValue('test.configurationDefaultsOverride'), 'defaultValue');
-
-		const actual = await testObject.initialize();
-
-		assert.deepStrictEqual(actual.getValue('test.configurationDefaultsOverride'), 'overrideValue');
 		assert.deepStrictEqual(testObject.configurationModel.getValue('test.configurationDefaultsOverride'), 'overrideValue');
 	});
 
-	test('configuration default overrides are read from cache', async () => {
+	test('configuration default overrides are not read from cache when model is read before initialize', async () => {
 		window.localStorage.setItem(DefaultConfiguration.DEFAULT_OVERRIDES_CACHE_EXISTS_KEY, 'yes');
 		await configurationCache.write(cacheKey, JSON.stringify({ 'test.configurationDefaultsOverride': 'overrideValue' }));
 		const testObject = new DefaultConfiguration(configurationCache, TestEnvironmentService);
-
-		const actual = await testObject.initialize();
-
-		assert.deepStrictEqual(actual.getValue('test.configurationDefaultsOverride'), 'overrideValue');
+		assert.deepStrictEqual(testObject.configurationModel.getValue('test.configurationDefaultsOverride'), undefined);
 	});
 
 	test('configuration default overrides read from cache override environment', async () => {


### PR DESCRIPTION
- improve parsing default config
- remove freezing the model
- improve setValue method
- add/fix unit tests
- reset default config only if cached default overrides exist