### PR TITLE
Git - Add `getRefs()` extension API

### DIFF
--- a/extensions/git/src/api/api1.ts
+++ b/extensions/git/src/api/api1.ts
@@ -5,8 +5,8 @@
 
 import { Model } from '../model';
 import { Repository as BaseRepository, Resource } from '../repository';
-import { InputBox, Git, API, Repository, Remote, RepositoryState, Branch, ForcePushMode, Ref, Submodule, Commit, Change, RepositoryUIState, Status, LogOptions, APIState, CommitOptions, RefType, CredentialsProvider, BranchQuery, PushErrorHandler, PublishEvent, FetchOptions, RemoteSourceProvider, RemoteSourcePublisher, PostCommitCommandsProvider } from './git';
-import { Event, SourceControlInputBox, Uri, SourceControl, Disposable, commands } from 'vscode';
+import { InputBox, Git, API, Repository, Remote, RepositoryState, Branch, ForcePushMode, Ref, Submodule, Commit, Change, RepositoryUIState, Status, LogOptions, APIState, CommitOptions, RefType, CredentialsProvider, BranchQuery, PushErrorHandler, PublishEvent, FetchOptions, RemoteSourceProvider, RemoteSourcePublisher, PostCommitCommandsProvider, RefQuery } from './git';
+import { Event, SourceControlInputBox, Uri, SourceControl, Disposable, commands, CancellationToken } from 'vscode';
 import { combinedDisposable, mapEvent } from '../util';
 import { toGitUri } from '../uri';
 import { GitExtensionImpl } from './extension';
@@ -170,12 +170,16 @@ export class ApiRepository implements Repository {
 		return this.repository.getBranch(name);
 	}
 
-	getBranches(query: BranchQuery): Promise<Ref[]> {
-		return this.repository.getBranches(query);
+	getBranches(query: BranchQuery, cancellationToken?: CancellationToken): Promise<Ref[]> {
+		return this.repository.getBranches(query, cancellationToken);
 	}
 
 	setBranchUpstream(name: string, upstream: string): Promise<void> {
 		return this.repository.setBranchUpstream(name, upstream);
+	}
+
+	getRefs(query: RefQuery, cancellationToken?: CancellationToken): Promise<Ref[]> {
+		return this.repository.getRefs(query, cancellationToken);
 	}
 
 	getMergeBase(ref1: string, ref2: string): Promise<string> {

--- a/extensions/git/src/api/git.d.ts
+++ b/extensions/git/src/api/git.d.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Uri, Event, Disposable, ProviderResult, Command } from 'vscode';
+import { Uri, Event, Disposable, ProviderResult, Command, CancellationToken } from 'vscode';
 export { ProviderResult } from 'vscode';
 
 export interface Git {
@@ -156,11 +156,15 @@ export interface FetchOptions {
 	depth?: number;
 }
 
-export interface BranchQuery {
-	readonly remote?: boolean;
-	readonly pattern?: string;
-	readonly count?: number;
+export interface RefQuery {
 	readonly contains?: string;
+	readonly count?: number;
+	readonly pattern?: string;
+	readonly sort?: 'alphabetically' | 'committerdate';
+}
+
+export interface BranchQuery extends RefQuery {
+	readonly remote?: boolean;
 }
 
 export interface Repository {
@@ -204,8 +208,10 @@ export interface Repository {
 	createBranch(name: string, checkout: boolean, ref?: string): Promise<void>;
 	deleteBranch(name: string, force?: boolean): Promise<void>;
 	getBranch(name: string): Promise<Branch>;
-	getBranches(query: BranchQuery): Promise<Ref[]>;
+	getBranches(query: BranchQuery, cancellationToken?: CancellationToken): Promise<Ref[]>;
 	setBranchUpstream(name: string, upstream: string): Promise<void>;
+
+	getRefs(query: RefQuery, cancellationToken?: CancellationToken): Promise<Ref[]>;
 
 	getMergeBase(ref1: string, ref2: string): Promise<string>;
 

--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -2126,7 +2126,7 @@ export class CommandCenter {
 			});
 
 			// Check for local ref conflict
-			const refs = await repository.getRefs({ pattern: `refs/heads/${randomName}` });
+			const refs = await repository.getRefs({ pattern: `heads/${randomName}` });
 			if (refs.length === 0) {
 				return randomName;
 			}
@@ -2224,7 +2224,7 @@ export class CommandCenter {
 			run = force => repository.deleteBranch(name, force);
 		} else {
 			const getBranchPicks = async () => {
-				const refs = await repository.getRefs({ pattern: 'refs/heads/*' });
+				const refs = await repository.getRefs({ pattern: 'heads/*' });
 				const currentHead = repository.HEAD && repository.HEAD.name;
 
 				return refs.filter(ref => ref.type === RefType.Head && ref.name !== currentHead)
@@ -2386,7 +2386,7 @@ export class CommandCenter {
 	@command('git.deleteTag', { repository: true })
 	async deleteTag(repository: Repository): Promise<void> {
 		const tagPicks = async (): Promise<TagItem[] | QuickPickItem[]> => {
-			const remoteTags = await repository.getRefs({ pattern: 'refs/tags/*' });
+			const remoteTags = await repository.getRefs({ pattern: 'tags/*' });
 			return remoteTags.length === 0 ? [{ label: l10n.t('$(info) This repository has no tags.') }] : remoteTags.map(ref => new TagItem(ref));
 		};
 

--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -2126,7 +2126,7 @@ export class CommandCenter {
 			});
 
 			// Check for local ref conflict
-			const refs = await repository.getRefs({ pattern: `heads/${randomName}` });
+			const refs = await repository.getRefs({ pattern: `refs/heads/${randomName}` });
 			if (refs.length === 0) {
 				return randomName;
 			}
@@ -2224,7 +2224,7 @@ export class CommandCenter {
 			run = force => repository.deleteBranch(name, force);
 		} else {
 			const getBranchPicks = async () => {
-				const refs = await repository.getRefs({ pattern: 'heads/*' });
+				const refs = await repository.getRefs({ pattern: 'refs/heads/*' });
 				const currentHead = repository.HEAD && repository.HEAD.name;
 
 				return refs.filter(ref => ref.type === RefType.Head && ref.name !== currentHead)
@@ -2386,7 +2386,7 @@ export class CommandCenter {
 	@command('git.deleteTag', { repository: true })
 	async deleteTag(repository: Repository): Promise<void> {
 		const tagPicks = async (): Promise<TagItem[] | QuickPickItem[]> => {
-			const remoteTags = await repository.getRefs({ pattern: 'tags/*' });
+			const remoteTags = await repository.getRefs({ pattern: 'refs/tags/*' });
 			return remoteTags.length === 0 ? [{ label: l10n.t('$(info) This repository has no tags.') }] : remoteTags.map(ref => new TagItem(ref));
 		};
 

--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -2093,7 +2093,7 @@ export class Repository {
 				HEAD = await this.getBranch(HEAD.name);
 			} else if (HEAD.commit) {
 				// Tag || Commit
-				const tags = await this.getRefs({ pattern: 'tags/*' });
+				const tags = await this.getRefs({ pattern: 'refs/tags/*' });
 				const tag = tags.find(tag => tag.commit === HEAD!.commit);
 
 				if (tag) {
@@ -2183,7 +2183,7 @@ export class Repository {
 		args.push('--format', '%(refname) %(objectname) %(*objectname)');
 
 		if (query.pattern) {
-			args.push(query.pattern);
+			args.push(query.pattern.startsWith('refs/') ? query.pattern : `refs/${query.pattern}`);
 		}
 
 		if (query.contains) {

--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -15,7 +15,7 @@ import * as filetype from 'file-type';
 import { assign, groupBy, IDisposable, toDisposable, dispose, mkdirp, readBytes, detectUnicodeEncoding, Encoding, onceEvent, splitInChunks, Limiter, Versions, isWindows } from './util';
 import { CancellationError, CancellationToken, ConfigurationChangeEvent, LogOutputChannel, Progress, Uri, workspace } from 'vscode';
 import { detectEncoding } from './encoding';
-import { Ref, RefType, Branch, Remote, ForcePushMode, GitErrorCodes, LogOptions, Change, Status, CommitOptions, BranchQuery } from './api/git';
+import { Ref, RefType, Branch, Remote, ForcePushMode, GitErrorCodes, LogOptions, Change, Status, CommitOptions, RefQuery } from './api/git';
 import * as byline from 'byline';
 import { StringDecoder } from 'string_decoder';
 
@@ -2093,7 +2093,7 @@ export class Repository {
 				HEAD = await this.getBranch(HEAD.name);
 			} else if (HEAD.commit) {
 				// Tag || Commit
-				const tags = await this.getRefs({ pattern: 'refs/tags/*' });
+				const tags = await this.getRefs({ pattern: 'tags/*' });
 				const tag = tags.find(tag => tag.commit === HEAD!.commit);
 
 				if (tag) {
@@ -2165,32 +2165,32 @@ export class Repository {
 			.map(([ref]) => ({ name: ref, type: RefType.Head } as Branch));
 	}
 
-	async getRefs(opts?: { sort?: 'alphabetically' | 'committerdate'; contains?: string; pattern?: string; count?: number; cancellationToken?: CancellationToken }): Promise<Ref[]> {
-		if (opts?.cancellationToken && opts?.cancellationToken.isCancellationRequested) {
+	async getRefs(query: RefQuery, cancellationToken?: CancellationToken): Promise<Ref[]> {
+		if (cancellationToken && cancellationToken.isCancellationRequested) {
 			throw new CancellationError();
 		}
 
 		const args = ['for-each-ref'];
 
-		if (opts?.count) {
-			args.push(`--count=${opts.count}`);
+		if (query.count) {
+			args.push(`--count=${query.count}`);
 		}
 
-		if (opts && opts.sort && opts.sort !== 'alphabetically') {
-			args.push('--sort', `-${opts.sort}`);
+		if (query.sort && query.sort !== 'alphabetically') {
+			args.push('--sort', `-${query.sort}`);
 		}
 
 		args.push('--format', '%(refname) %(objectname) %(*objectname)');
 
-		if (opts?.pattern) {
-			args.push(opts.pattern);
+		if (query.pattern) {
+			args.push(query.pattern);
 		}
 
-		if (opts?.contains) {
-			args.push('--contains', opts.contains);
+		if (query.contains) {
+			args.push('--contains', query.contains);
 		}
 
-		const result = await this.exec(args, { cancellationToken: opts?.cancellationToken });
+		const result = await this.exec(args, { cancellationToken });
 
 		const fn = (line: string): Ref | null => {
 			let match: RegExpExecArray | null;
@@ -2393,11 +2393,6 @@ export class Repository {
 		}
 
 		return Promise.reject<Branch>(new Error('No such branch'));
-	}
-
-	async getBranches(query: BranchQuery): Promise<Ref[]> {
-		const refs = await this.getRefs({ contains: query.contains, pattern: query.pattern ? `refs/${query.pattern}` : undefined, count: query.count });
-		return refs.filter(value => (value.type !== RefType.Tag) && (query.remote || !value.remote));
 	}
 
 	// TODO: Support core.commentChar

--- a/extensions/git/src/repository.ts
+++ b/extensions/git/src/repository.ts
@@ -1376,16 +1376,14 @@ export class Repository implements Disposable {
 
 	async getBranches(query: BranchQuery = {}, cancellationToken?: CancellationToken): Promise<Ref[]> {
 		return await this.run(Operation.GetBranches, async () => {
-			const pattern = query.pattern ? `refs/${query.pattern}` : undefined;
-			const refs = await this.getRefs({ ...query, pattern }, cancellationToken);
+			const refs = await this.getRefs(query, cancellationToken);
 			return refs.filter(value => (value.type === RefType.Head || value.type === RefType.RemoteHead) && (query.remote || !value.remote));
 		});
 	}
 
 	async getRefs(query: RefQuery = {}, cancellationToken?: CancellationToken): Promise<Ref[]> {
 		return await this.run(Operation.GetRefs, () => {
-			const pattern = query.pattern ? `refs/${query.pattern}` : undefined;
-			return this.repository.getRefs({ ...query, pattern }, cancellationToken);
+			return this.repository.getRefs(query, cancellationToken);
 		});
 	}
 


### PR DESCRIPTION
Add a new `getRefs()` method to the git extension API in an effort to deprecate the `RepositoryState.refs` property.

//cc @alexr00

Related #170838