### PR TITLE
vscode perf cli

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,8 @@
     "hygiene": "node --max_old_space_size=4095 ./node_modules/gulp/bin/gulp.js hygiene",
     "core-ci": "node --max_old_space_size=8095 ./node_modules/gulp/bin/gulp.js core-ci",
     "extensions-ci": "node --max_old_space_size=4095 ./node_modules/gulp/bin/gulp.js extensions-ci",
-    "webview-generate-csp-hash": "npx github:apaatsio/csp-hash-from-html csp-hash ./src/vs/workbench/contrib/webview/browser/pre/index.html"
+    "webview-generate-csp-hash": "npx github:apaatsio/csp-hash-from-html csp-hash ./src/vs/workbench/contrib/webview/browser/pre/index.html",
+    "perf": "node scripts/code-perf.js"
   },
   "dependencies": {
     "@microsoft/1ds-core-js": "^3.2.2",
@@ -131,6 +132,7 @@
     "@vscode/l10n-dev": "0.0.21",
     "@vscode/telemetry-extractor": "^1.9.8",
     "@vscode/test-web": "^0.0.32",
+    "@vscode/vscode-perf": "^0.0.1",
     "ansi-colors": "^3.2.3",
     "asar": "^3.0.3",
     "chromium-pickle-js": "^0.2.0",

--- a/scripts/code-perf.js
+++ b/scripts/code-perf.js
@@ -1,0 +1,73 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// @ts-check
+
+const path = require('path');
+const perf = require('@vscode/vscode-perf');
+
+const VSCODE_FOLDER = path.join(__dirname, '..');
+
+async function main() {
+
+	const args = [...process.argv];
+
+	// get build arg from args
+	let buildArgIndex = args.indexOf('--build');
+	buildArgIndex = buildArgIndex === -1 ? args.indexOf('-b') : buildArgIndex;
+	if (buildArgIndex === -1) {
+		args.push('--build');
+		args.push(getLocalCLIPath());
+	} else {
+		const exePath = args[buildArgIndex + 1];
+		args.splice(buildArgIndex + 1, 1, getExePath(exePath));
+	}
+
+	args.push('--folder');
+	args.push(VSCODE_FOLDER);
+	args.push('--file');
+	args.push(path.join(VSCODE_FOLDER, 'package.json'));
+
+	await perf(args);
+}
+
+/**
+ * @param {string} buildPath
+ * @returns {string}
+ */
+function getExePath(buildPath) {
+	buildPath = path.normalize(path.resolve(buildPath));
+	if (buildPath === path.normalize(getLocalCLIPath())) {
+		return buildPath;
+	}
+	let relativeExePath;
+	switch (process.platform) {
+		case 'darwin':
+			relativeExePath = path.join('Contents', 'MacOS', 'Electron');
+			break;
+		case 'linux': {
+			const product = require(path.join(buildPath, 'resources', 'app', 'product.json'));
+			relativeExePath = product.applicationName;
+			break;
+		}
+		case 'win32': {
+			const product = require(path.join(buildPath, 'resources', 'app', 'product.json'));
+			relativeExePath = `${product.nameShort}.exe`;
+			break;
+		}
+		default:
+			throw new Error('Unsupported platform.');
+	}
+	return buildPath.endsWith(relativeExePath) ? buildPath : path.join(buildPath, relativeExePath);
+}
+
+/**
+ * @returns {string}
+ */
+function getLocalCLIPath() {
+	return process.platform === 'win32' ? path.join(VSCODE_FOLDER, 'scripts', 'code-cli.bat') : path.join(VSCODE_FOLDER, 'scripts', 'code-cli.sh');
+}
+
+main();

--- a/yarn.lock
+++ b/yarn.lock
@@ -1321,6 +1321,14 @@
   resolved "https://registry.yarnpkg.com/@vscode/vscode-languagedetection/-/vscode-languagedetection-1.0.21.tgz#89b48f293f6aa3341bb888c1118d16ff13b032d3"
   integrity sha512-zSUH9HYCw5qsCtd7b31yqkpaCU6jhtkKLkvOOA8yTrIRfBSOFb8PPhgmMicD7B/m+t4PwOJXzU1XDtrM9Fd3/g==
 
+"@vscode/vscode-perf@^0.0.1":
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/@vscode/vscode-perf/-/vscode-perf-0.0.1.tgz#8378057d86003d8823d7404734adc64cfae80780"
+  integrity sha512-7xzVgkWAqFAFMTbHNGY6WiIKHEn0X0ARvIJmDEv2fDKjIB9W76R67Ft25jn3rf2/Gi0HfTPeJwjPTXm6ih5juw==
+  dependencies:
+    chalk "^4.x"
+    commander "^9.4.0"
+
 "@vscode/windows-registry@1.0.6":
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/@vscode/windows-registry/-/windows-registry-1.0.6.tgz#8b9fb9a55bf5a0be4ea11849c45ae94c6910e3e4"
@@ -2630,6 +2638,14 @@ chalk@^4.0.0, chalk@^4.1.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
+chalk@^4.x:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
+  integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
+
 chardet@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
@@ -2993,6 +3009,11 @@ commander@^7.0.0, commander@^7.1.0, commander@^7.2.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-7.2.0.tgz#a36cb57d0b501ce108e4d20559a150a391d97ab7"
   integrity sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==
+
+commander@^9.4.0:
+  version "9.5.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-9.5.0.tgz#bc08d1eb5cedf7ccb797a96199d41c7bc3e60d30"
+  integrity sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==
 
 commandpost@^1.0.0:
   version "1.2.1"


### PR DESCRIPTION
- add vscode-perf module
- add script to run perfs

Usage:

```sh
yarn perf
yarn perf -m marker1-marker2
yarn perf -b <build-path>

```