### PR TITLE
Add default keybindings for shell integration

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminal.contribution.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminal.contribution.ts
@@ -211,6 +211,20 @@ registerSendSequenceKeybinding('\x1b[1;2H', { // Shift+home
 	mac: { primary: KeyMod.Shift | KeyMod.CtrlCmd | KeyCode.LeftArrow }
 });
 
+// Map ctrl+alt+r -> ctrl+r when in accessibility mode due to default run recent command keybinding
+registerSendSequenceKeybinding('\x12', {
+	when: ContextKeyExpr.and(TerminalContextKeys.focus, CONTEXT_ACCESSIBILITY_MODE_ENABLED),
+	primary: KeyMod.CtrlCmd | KeyMod.Alt | KeyCode.KeyR,
+	mac: { primary: KeyMod.WinCtrl | KeyMod.Alt | KeyCode.KeyR }
+});
+
+// Map ctrl+alt+g -> ctrl+g due to default go to recent directory keybinding
+registerSendSequenceKeybinding('\x07', {
+	when: TerminalContextKeys.focus,
+	primary: KeyMod.CtrlCmd | KeyMod.Alt | KeyCode.KeyG,
+	mac: { primary: KeyMod.WinCtrl | KeyMod.Alt | KeyCode.KeyG }
+});
+
 // send ctrl+c to the iPad when the terminal is focused and ctrl+c is pressed to kill the process (work around for #114009)
 if (isIOS) {
 	registerSendSequenceKeybinding(String.fromCharCode('C'.charCodeAt(0) - Constants.CtrlLetterOffset), { // ctrl+c

--- a/src/vs/workbench/contrib/terminal/browser/terminalActions.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalActions.ts
@@ -325,7 +325,21 @@ export function registerTerminalActions() {
 				title: { value: localize('workbench.action.terminal.runRecentCommand', "Run Recent Command..."), original: 'Run Recent Command...' },
 				f1: true,
 				category,
-				precondition: ContextKeyExpr.or(TerminalContextKeys.processSupported, TerminalContextKeys.terminalHasBeenCreated)
+				precondition: ContextKeyExpr.or(TerminalContextKeys.processSupported, TerminalContextKeys.terminalHasBeenCreated),
+				keybinding: [
+					{
+						primary: KeyMod.CtrlCmd | KeyCode.KeyR,
+						mac: { primary: KeyMod.WinCtrl | KeyCode.KeyR },
+						when: ContextKeyExpr.and(TerminalContextKeys.focus, CONTEXT_ACCESSIBILITY_MODE_ENABLED),
+						weight: KeybindingWeight.WorkbenchContrib
+					},
+					{
+						primary: KeyMod.CtrlCmd | KeyMod.Alt | KeyCode.KeyR,
+						mac: { primary: KeyMod.WinCtrl | KeyMod.Alt | KeyCode.KeyR },
+						when: ContextKeyExpr.and(TerminalContextKeys.focus, CONTEXT_ACCESSIBILITY_MODE_ENABLED.negate()),
+						weight: KeybindingWeight.WorkbenchContrib
+					}
+				]
 			});
 		}
 		async run(accessor: ServicesAccessor): Promise<void> {
@@ -375,7 +389,12 @@ export function registerTerminalActions() {
 				title: { value: localize('workbench.action.terminal.goToRecentDirectory', "Go to Recent Directory..."), original: 'Go to Recent Directory...' },
 				f1: true,
 				category,
-				precondition: ContextKeyExpr.or(TerminalContextKeys.processSupported, TerminalContextKeys.terminalHasBeenCreated)
+				precondition: ContextKeyExpr.or(TerminalContextKeys.processSupported, TerminalContextKeys.terminalHasBeenCreated),
+				keybinding: {
+					primary: KeyMod.CtrlCmd | KeyCode.KeyG,
+					when: TerminalContextKeys.focus,
+					weight: KeybindingWeight.WorkbenchContrib
+				}
 			});
 		}
 		async run(accessor: ServicesAccessor): Promise<void> {


### PR DESCRIPTION
These new keybindings will help with the discoverability of shell integration features, especially run recent command when accessibility mode is enabled. The alt+f1 menu in #170977 will help with discoverability further and also help with the discovery of ctrl+alt+r.

When in accessibility mode:
- ctrl+r: run recent command
- ctrl+alt+r: send ctrl+r

When not in accessibility mode:
- ctrl+r: send ctrl+r
- ctrl+alt+r: run recent command

Regardless of accessibility mode:
- ctrl+g: go to recent directory
- ctrl+alt+g: send ctrl+g

Fixes #170976
