### PR TITLE
Revert "Ignore pointer events from nested ListViews (#169680)"

### DIFF
--- a/src/vs/base/browser/ui/list/listWidget.ts
+++ b/src/vs/base/browser/ui/list/listWidget.ts
@@ -685,10 +685,6 @@ export class MouseController<T> implements IDisposable {
 			return;
 		}
 
-		if (e.browserEvent.defaultPrevented) {
-			return;
-		}
-
 		const focus = e.index;
 
 		if (typeof focus === 'undefined') {
@@ -713,7 +709,6 @@ export class MouseController<T> implements IDisposable {
 			this.list.setSelection([focus], e.browserEvent);
 		}
 
-		e.browserEvent.preventDefault();
 		this._onPointer.fire(e);
 	}
 
@@ -726,13 +721,8 @@ export class MouseController<T> implements IDisposable {
 			return;
 		}
 
-		if (e.browserEvent.defaultPrevented) {
-			return;
-		}
-
 		const focus = this.list.getFocus();
 		this.list.setSelection(focus, e.browserEvent);
-		e.browserEvent.preventDefault();
 	}
 
 	private changeSelection(e: IListMouseEvent<T> | IListTouchEvent<T>): void {

--- a/src/vs/base/browser/ui/tree/abstractTree.ts
+++ b/src/vs/base/browser/ui/tree/abstractTree.ts
@@ -1358,10 +1358,6 @@ class TreeNodeListMouseController<T, TFilterData, TRef> extends MouseController<
 			return;
 		}
 
-		if (e.browserEvent.defaultPrevented) {
-			return;
-		}
-
 		const node = e.element;
 
 		if (!node) {
@@ -1410,10 +1406,6 @@ class TreeNodeListMouseController<T, TFilterData, TRef> extends MouseController<
 		const onTwistie = (e.browserEvent.target as HTMLElement).classList.contains('monaco-tl-twistie');
 
 		if (onTwistie || !this.tree.expandOnDoubleClick) {
-			return;
-		}
-
-		if (e.browserEvent.defaultPrevented) {
 			return;
 		}
 


### PR DESCRIPTION
Revert f078e6db483250957314c56c3b12e23dae03d351 from https://github.com/microsoft/vscode/pull/169680. This approach just won't work, because it prevents clicks on a div linked to a checkbox `<input>` via a `<label>` from toggling the input. I think this is sort of abusing `preventDefault` anyway, so I'll find a different solution.

I don't think there is any need to revert https://github.com/microsoft/vscode/pull/170567.

Fix #170880

fyi @joaomoreno 