### PR TITLE
chore: update code signing certificate identity

### DIFF
--- a/build/darwin/sign.js
+++ b/build/darwin/sign.js
@@ -38,7 +38,7 @@ async function main() {
         'pre-embed-provisioning-profile': false,
         keychain: path.join(tempDir, 'buildagent.keychain'),
         version: util.getElectronVersion(),
-        identity: '99FM488X57',
+        identity: 'U8XXGZG5HC',
         'gatekeeper-assess': false
     };
     const appOpts = {

--- a/build/darwin/sign.ts
+++ b/build/darwin/sign.ts
@@ -42,7 +42,7 @@ async function main(): Promise<void> {
 		'pre-embed-provisioning-profile': false,
 		keychain: path.join(tempDir, 'buildagent.keychain'),
 		version: util.getElectronVersion(),
-		identity: '99FM488X57',
+		identity: 'U8XXGZG5HC',
 		'gatekeeper-assess': false
 	};
 


### PR DESCRIPTION
Refs https://monacotools.visualstudio.com/Monaco/_build/results?buildId=199169

Ideally we wouldn't have to pass an identity since this is the only certificate installed in the temporary keychain we create for code signing and the `electron-osx-sign` module can query for `Mac Developer: ` via `security find-identity` https://github.com/electron/osx-sign/blob/14a578b8097f138162030ec219ca9df4be53fdde/src/sign.ts#L336 but that is only used when the signing for app store distributions. So it is requirement in our case to explicitly specify the identity.
