### PR TITLE
Ignore pointer events from nested ListViews and handle Labels in items

### DIFF
--- a/src/vs/base/browser/ui/list/listWidget.ts
+++ b/src/vs/base/browser/ui/list/listWidget.ts
@@ -685,6 +685,10 @@ export class MouseController<T> implements IDisposable {
 			return;
 		}
 
+		if (e.browserEvent.defaultPrevented) {
+			return;
+		}
+
 		const focus = e.index;
 
 		if (typeof focus === 'undefined') {
@@ -709,6 +713,7 @@ export class MouseController<T> implements IDisposable {
 			this.list.setSelection([focus], e.browserEvent);
 		}
 
+		e.browserEvent.preventDefault();
 		this._onPointer.fire(e);
 	}
 
@@ -721,8 +726,13 @@ export class MouseController<T> implements IDisposable {
 			return;
 		}
 
+		if (e.browserEvent.defaultPrevented) {
+			return;
+		}
+
 		const focus = this.list.getFocus();
 		this.list.setSelection(focus, e.browserEvent);
+		e.browserEvent.preventDefault();
 	}
 
 	private changeSelection(e: IListMouseEvent<T> | IListTouchEvent<T>): void {

--- a/src/vs/base/browser/ui/list/listWidget.ts
+++ b/src/vs/base/browser/ui/list/listWidget.ts
@@ -258,6 +258,22 @@ export function isMonacoEditor(e: HTMLElement): boolean {
 	return isMonacoEditor(e.parentElement);
 }
 
+export function isWithinLabel(e: HTMLElement): boolean {
+	if (e.tagName === 'LABEL') {
+		return true;
+	}
+
+	if (e.classList.contains('monaco-list-row')) {
+		return false;
+	}
+
+	if (!e.parentElement) {
+		return false;
+	}
+
+	return isWithinLabel(e.parentElement);
+}
+
 export function isButton(e: HTMLElement): boolean {
 	if ((e.tagName === 'A' && e.classList.contains('monaco-button')) ||
 		(e.tagName === 'DIV' && e.classList.contains('monaco-button-dropdown'))) {
@@ -668,7 +684,9 @@ export class MouseController<T> implements IDisposable {
 	}
 
 	private onContextMenu(e: IListContextMenuEvent<T>): void {
-		if (isInputElement(e.browserEvent.target as HTMLElement) || isMonacoEditor(e.browserEvent.target as HTMLElement)) {
+		if (isInputElement(e.browserEvent.target as HTMLElement) ||
+			isMonacoEditor(e.browserEvent.target as HTMLElement) ||
+			isWithinLabel(e.browserEvent.target as HTMLElement)) {
 			return;
 		}
 
@@ -681,7 +699,10 @@ export class MouseController<T> implements IDisposable {
 			return;
 		}
 
-		if (isInputElement(e.browserEvent.target as HTMLElement) || isMonacoEditor(e.browserEvent.target as HTMLElement)) {
+		if (isInputElement(e.browserEvent.target as HTMLElement)
+			|| isMonacoEditor(e.browserEvent.target as HTMLElement)
+			|| isWithinLabel(e.browserEvent.target as HTMLElement)
+		) {
 			return;
 		}
 
@@ -718,7 +739,9 @@ export class MouseController<T> implements IDisposable {
 	}
 
 	protected onDoubleClick(e: IListMouseEvent<T>): void {
-		if (isInputElement(e.browserEvent.target as HTMLElement) || isMonacoEditor(e.browserEvent.target as HTMLElement)) {
+		if (isInputElement(e.browserEvent.target as HTMLElement) ||
+			isMonacoEditor(e.browserEvent.target as HTMLElement) ||
+			isWithinLabel(e.browserEvent.target as HTMLElement)) {
 			return;
 		}
 

--- a/src/vs/base/browser/ui/list/listWidget.ts
+++ b/src/vs/base/browser/ui/list/listWidget.ts
@@ -674,7 +674,8 @@ export class MouseController<T> implements IDisposable {
 	}
 
 	private onMouseDown(e: IListMouseEvent<T> | IListTouchEvent<T>): void {
-		if (isMonacoEditor(e.browserEvent.target as HTMLElement)) {
+		if (isMonacoEditor(e.browserEvent.target as HTMLElement) ||
+			isWithinLabel(e.browserEvent.target as HTMLElement)) {
 			return;
 		}
 

--- a/src/vs/base/browser/ui/tree/abstractTree.ts
+++ b/src/vs/base/browser/ui/tree/abstractTree.ts
@@ -13,7 +13,7 @@ import { FindInput } from 'vs/base/browser/ui/findinput/findInput';
 import { IInputBoxStyles, IMessage, MessageType, unthemedInboxStyles } from 'vs/base/browser/ui/inputbox/inputBox';
 import { IIdentityProvider, IKeyboardNavigationLabelProvider, IListContextMenuEvent, IListDragAndDrop, IListDragOverReaction, IListMouseEvent, IListRenderer, IListVirtualDelegate } from 'vs/base/browser/ui/list/list';
 import { ElementsDragAndDropData } from 'vs/base/browser/ui/list/listView';
-import { IListOptions, IListStyles, isButton, isInputElement, isMonacoEditor, List, MouseController, TypeNavigationMode } from 'vs/base/browser/ui/list/listWidget';
+import { IListOptions, IListStyles, isButton, isInputElement, isMonacoEditor, isWithinLabel, List, MouseController, TypeNavigationMode } from 'vs/base/browser/ui/list/listWidget';
 import { IToggleStyles, Toggle, unthemedToggleStyles } from 'vs/base/browser/ui/toggle/toggle';
 import { getVisibleState, isFilterResult } from 'vs/base/browser/ui/tree/indexTreeModel';
 import { ICollapseStateChangeEvent, ITreeContextMenuEvent, ITreeDragAndDrop, ITreeEvent, ITreeFilter, ITreeModel, ITreeModelSpliceEvent, ITreeMouseEvent, ITreeNavigator, ITreeNode, ITreeRenderer, TreeDragOverBubble, TreeError, TreeFilterResult, TreeMouseEventTarget, TreeVisibility } from 'vs/base/browser/ui/tree/tree';
@@ -1354,7 +1354,8 @@ class TreeNodeListMouseController<T, TFilterData, TRef> extends MouseController<
 	protected override onViewPointer(e: IListMouseEvent<ITreeNode<T, TFilterData>>): void {
 		if (isButton(e.browserEvent.target as HTMLElement) ||
 			isInputElement(e.browserEvent.target as HTMLElement) ||
-			isMonacoEditor(e.browserEvent.target as HTMLElement)) {
+			isMonacoEditor(e.browserEvent.target as HTMLElement) ||
+			isWithinLabel(e.browserEvent.target as HTMLElement)) {
 			return;
 		}
 

--- a/src/vs/base/browser/ui/tree/abstractTree.ts
+++ b/src/vs/base/browser/ui/tree/abstractTree.ts
@@ -1358,6 +1358,10 @@ class TreeNodeListMouseController<T, TFilterData, TRef> extends MouseController<
 			return;
 		}
 
+		if (e.browserEvent.defaultPrevented) {
+			return;
+		}
+
 		const node = e.element;
 
 		if (!node) {
@@ -1406,6 +1410,10 @@ class TreeNodeListMouseController<T, TFilterData, TRef> extends MouseController<
 		const onTwistie = (e.browserEvent.target as HTMLElement).classList.contains('monaco-tl-twistie');
 
 		if (onTwistie || !this.tree.expandOnDoubleClick) {
+			return;
+		}
+
+		if (e.browserEvent.defaultPrevented) {
 			return;
 		}
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Labels are weird. They capture events when clicked and toggle checkboxes inside of them. @roblourens's initial change prevented the labels from doing this intended dom behavior. So we extend that change to say "listen if we're in a label, let it do its thing"

So this is really close to the solution, I feel. Couple of concerns...

@joaomoreno said we can probably use `isWithinLabel` everywhere `isMonacoEditor` is used. Here are the references I skipped:

https://github.com/microsoft/vscode/blob/2ebbb1632cabe4a6d0a5074620992ecf3cc3391e/src/vs/workbench/contrib/notebook/browser/diff/notebookDiffList.ts#L293

because... I really don't know. Seems odd to add it there.

Also, some interesting behavior change... after this PR, right clicking on an item or a checkbox in an item causes the checkbox to toggle.

Stable VS Code doesn't show this behavior so this PR doesn't seem 100% correct to me.

Any thoughts @joaomoreno?

Fixes https://github.com/microsoft/vscode/issues/97820

cc @roblourens