### PR TITLE
Fix runInTerminal when exec basename is 'wt'

### DIFF
--- a/src/vs/platform/externalTerminal/node/externalTerminalService.ts
+++ b/src/vs/platform/externalTerminal/node/externalTerminalService.ts
@@ -46,8 +46,8 @@ export class WindowsExternalTerminalService extends ExternalTerminalService impl
 
 		// cmder ignores the environment cwd and instead opts to always open in %USERPROFILE%
 		// unless otherwise specified
-		const basename = path.basename(exec).toLowerCase();
-		if (basename === 'cmder' || basename === 'cmder.exe') {
+		const basename = path.basename(exec, '.exe').toLowerCase();
+		if (basename === 'cmder') {
 			spawner.spawn(exec, cwd ? [cwd] : undefined);
 			return Promise.resolve(undefined);
 		}
@@ -60,7 +60,7 @@ export class WindowsExternalTerminalService extends ExternalTerminalService impl
 		}
 		cmdArgs.push(exec);
 		// Add starting directory parameter for Windows Terminal (see #90734)
-		if (basename === 'wt' || basename === 'wt.exe') {
+		if (basename === 'wt') {
 			cmdArgs.push('-d .');
 		}
 
@@ -96,7 +96,7 @@ export class WindowsExternalTerminalService extends ExternalTerminalService impl
 			let spawnExec: string;
 			let cmdArgs: string[];
 
-			if (path.basename(exec) === 'wt') {
+			if (path.basename(exec, '.exe') === 'wt') {
 				// Handle Windows Terminal specially; -d to set the cwd and run a cmd.exe instance
 				// inside it
 				spawnExec = exec;


### PR DESCRIPTION
Part of #167865

Testing debugging a single line `console.log` node app when windowsExec is the default and when it's set to `wt`.