### PR TITLE
Alternate solutions for nested list events

### DIFF
--- a/src/vs/base/browser/ui/list/list.ts
+++ b/src/vs/base/browser/ui/list/list.ts
@@ -29,12 +29,8 @@ export interface IListEvent<T> {
 	browserEvent?: UIEvent;
 }
 
-export interface IListBrowserMouseEvent extends MouseEvent {
-	isHandledByList?: boolean;
-}
-
 export interface IListMouseEvent<T> {
-	browserEvent: IListBrowserMouseEvent;
+	browserEvent: MouseEvent;
 	element: T | undefined;
 	index: number | undefined;
 }

--- a/src/vs/base/browser/ui/list/list.ts
+++ b/src/vs/base/browser/ui/list/list.ts
@@ -29,8 +29,12 @@ export interface IListEvent<T> {
 	browserEvent?: UIEvent;
 }
 
+export interface IListBrowserMouseEvent extends MouseEvent {
+	isHandledByList?: boolean;
+}
+
 export interface IListMouseEvent<T> {
-	browserEvent: MouseEvent;
+	browserEvent: IListBrowserMouseEvent;
 	element: T | undefined;
 	index: number | undefined;
 }

--- a/src/vs/base/browser/ui/list/listWidget.ts
+++ b/src/vs/base/browser/ui/list/listWidget.ts
@@ -624,7 +624,7 @@ export class MouseController<T> implements IDisposable {
 			this.disposables.add(Gesture.addTarget(list.getHTMLElement()));
 		}
 
-		Event.any<IListMouseEvent<any> | IListGestureEvent<any>>(list.onMouseClick, list.onMouseMiddleClick, list.onTap)(this.onViewPointer, this, this.disposables);
+		Event.any(list.onMouseClick, list.onMouseMiddleClick, list.onTap)(this.onViewPointer, this, this.disposables);
 	}
 
 	updateOptions(optionsUpdate: IListOptionsUpdate): void {
@@ -677,15 +677,12 @@ export class MouseController<T> implements IDisposable {
 	}
 
 	protected onViewPointer(e: IListMouseEvent<T>): void {
+		e.browserEvent.stopPropagation();
 		if (!this.mouseSupport) {
 			return;
 		}
 
 		if (isInputElement(e.browserEvent.target as HTMLElement) || isMonacoEditor(e.browserEvent.target as HTMLElement)) {
-			return;
-		}
-
-		if (e.browserEvent.isHandledByList) {
 			return;
 		}
 
@@ -713,11 +710,11 @@ export class MouseController<T> implements IDisposable {
 			this.list.setSelection([focus], e.browserEvent);
 		}
 
-		e.browserEvent.isHandledByList = true;
 		this._onPointer.fire(e);
 	}
 
 	protected onDoubleClick(e: IListMouseEvent<T>): void {
+		e.browserEvent.stopPropagation();
 		if (isInputElement(e.browserEvent.target as HTMLElement) || isMonacoEditor(e.browserEvent.target as HTMLElement)) {
 			return;
 		}
@@ -726,13 +723,8 @@ export class MouseController<T> implements IDisposable {
 			return;
 		}
 
-		if (e.browserEvent.isHandledByList) {
-			return;
-		}
-
 		const focus = this.list.getFocus();
 		this.list.setSelection(focus, e.browserEvent);
-		e.browserEvent.isHandledByList = true;
 	}
 
 	private changeSelection(e: IListMouseEvent<T> | IListTouchEvent<T>): void {

--- a/src/vs/base/browser/ui/list/listWidget.ts
+++ b/src/vs/base/browser/ui/list/listWidget.ts
@@ -624,7 +624,7 @@ export class MouseController<T> implements IDisposable {
 			this.disposables.add(Gesture.addTarget(list.getHTMLElement()));
 		}
 
-		Event.any(list.onMouseClick, list.onMouseMiddleClick, list.onTap)(this.onViewPointer, this, this.disposables);
+		Event.any<IListMouseEvent<any> | IListGestureEvent<any>>(list.onMouseClick, list.onMouseMiddleClick, list.onTap)(this.onViewPointer, this, this.disposables);
 	}
 
 	updateOptions(optionsUpdate: IListOptionsUpdate): void {
@@ -685,6 +685,10 @@ export class MouseController<T> implements IDisposable {
 			return;
 		}
 
+		if (e.browserEvent.isHandledByList) {
+			return;
+		}
+
 		const focus = e.index;
 
 		if (typeof focus === 'undefined') {
@@ -709,6 +713,7 @@ export class MouseController<T> implements IDisposable {
 			this.list.setSelection([focus], e.browserEvent);
 		}
 
+		e.browserEvent.isHandledByList = true;
 		this._onPointer.fire(e);
 	}
 
@@ -721,8 +726,13 @@ export class MouseController<T> implements IDisposable {
 			return;
 		}
 
+		if (e.browserEvent.isHandledByList) {
+			return;
+		}
+
 		const focus = this.list.getFocus();
 		this.list.setSelection(focus, e.browserEvent);
+		e.browserEvent.isHandledByList = true;
 	}
 
 	private changeSelection(e: IListMouseEvent<T> | IListTouchEvent<T>): void {

--- a/src/vs/base/browser/ui/tree/abstractTree.ts
+++ b/src/vs/base/browser/ui/tree/abstractTree.ts
@@ -1358,6 +1358,10 @@ class TreeNodeListMouseController<T, TFilterData, TRef> extends MouseController<
 			return;
 		}
 
+		if (e.browserEvent.isHandledByList) {
+			return;
+		}
+
 		const node = e.element;
 
 		if (!node) {
@@ -1406,6 +1410,10 @@ class TreeNodeListMouseController<T, TFilterData, TRef> extends MouseController<
 		const onTwistie = (e.browserEvent.target as HTMLElement).classList.contains('monaco-tl-twistie');
 
 		if (onTwistie || !this.tree.expandOnDoubleClick) {
+			return;
+		}
+
+		if (e.browserEvent.isHandledByList) {
 			return;
 		}
 

--- a/src/vs/base/browser/ui/tree/abstractTree.ts
+++ b/src/vs/base/browser/ui/tree/abstractTree.ts
@@ -1358,9 +1358,7 @@ class TreeNodeListMouseController<T, TFilterData, TRef> extends MouseController<
 			return;
 		}
 
-		if (e.browserEvent.isHandledByList) {
-			return;
-		}
+		e.browserEvent.stopPropagation();
 
 		const node = e.element;
 
@@ -1413,9 +1411,7 @@ class TreeNodeListMouseController<T, TFilterData, TRef> extends MouseController<
 			return;
 		}
 
-		if (e.browserEvent.isHandledByList) {
-			return;
-		}
+		e.browserEvent.stopPropagation();
 
 		super.onDoubleClick(e);
 	}


### PR DESCRIPTION
For #97820

Here are two other possible solutions that I had in mind, each in its own commit

1. 5a43a3d8af18b39d18fb351f6900f6c474019406 Write a flag to the browser event that says it was handled by a list. Same logic as the preventDefault solution, without messing with native browser behavior.
1. d53a11f75a94ad0eeb1143af1a572b0eae03233f Just make the event stop propagating when it is handled by the list. This one I am not sure what weird consequences it might have somewhere that we are paying attention to events outside of a List