### PR TITLE
Join with empty string to mirror what l10n-dev does

### DIFF
--- a/src/vs/workbench/api/common/extHostLocalizationService.ts
+++ b/src/vs/workbench/api/common/extHostLocalizationService.ts
@@ -40,7 +40,7 @@ export class ExtHostLocalizationService implements ExtHostLocalizationShape {
 
 		let key = message;
 		if (comment && comment.length > 0) {
-			key += `/${Array.isArray(comment) ? comment.join() : comment}`;
+			key += `/${Array.isArray(comment) ? comment.join('') : comment}`;
 		}
 		const str = this.bundleCache.get(extensionId)?.contents[key];
 		if (!str) {


### PR DESCRIPTION
This should have been the case all along, but I missed it and probably thought not passing anything joins with empty string.

fixes https://github.com/microsoft/vscode-l10n/issues/77

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
