### PR TITLE
Fix uri transformer slowness over large buffers

### DIFF
--- a/src/vs/base/common/uriIpc.ts
+++ b/src/vs/base/common/uriIpc.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { VSBuffer } from 'vs/base/common/buffer';
 import { MarshalledObject } from 'vs/base/common/marshalling';
 import { MarshalledId } from 'vs/base/common/marshallingIds';
 import { URI, UriComponents } from 'vs/base/common/uri';
@@ -123,6 +124,10 @@ function _transformIncomingURIs(obj: any, transformer: IURITransformer, revive: 
 
 		if ((<MarshalledObject>obj).$mid === MarshalledId.Uri) {
 			return revive ? URI.revive(transformer.transformIncoming(obj)) : transformer.transformIncoming(obj);
+		}
+
+		if (obj instanceof VSBuffer) {
+			return null;
 		}
 
 		// walk object (or array)


### PR DESCRIPTION
Fix #138784

tl;dr of that issue

- I have a notebook with a really large output, like an image that is many MBs
- The notebook is dirty
- When I save, or autosave kicks in, we transfer the entire notebook model data to the EH to serialize
- This hangs up the EH process for a long time
- I try to execute a simple cell and it takes a long time, because the EH is stuck

Turns out that most of the CPU time is in `_transformIncomingURIs` because it is iterating the large output VSBuffer. There will never be a URI in there, so this changes skips them.

As a separate optimization, we could also avoid transferring the full notebook model to save, since the EH should already have this model which has been updated incrementally