### PR TITLE
Support continue in local clone from remote window

### DIFF
--- a/extensions/git/package.json
+++ b/extensions/git/package.json
@@ -13,6 +13,7 @@
     "telemetryLogger",
     "diffCommand",
     "contribEditorContentMenu",
+    "contribEditSessions",
     "contribViewsWelcome",
     "editSessionIdentityProvider",
     "scmActionButton",
@@ -50,6 +51,13 @@
   },
   "contributes": {
     "commands": [
+      {
+        "command": "git.continueInLocalClone",
+        "title": "%command.continueInLocalClone%",
+        "category": "Git",
+        "icon": "$(repo-clone)",
+        "enablement": "config.git.enabled && !git.missing && gitOpenRepositoryCount != 0 && remoteName"
+      },
       {
         "command": "git.clone",
         "title": "%command.clone%",
@@ -706,6 +714,13 @@
         "category": "Git"
       }
     ],
+    "continueEditSession": [
+      {
+        "command": "git.continueInLocalClone",
+        "qualifiedName": "%command.continueInLocalClone.qualifiedName%",
+        "when": "config.git.enabled && !git.missing && gitOpenRepositoryCount != 0 && remoteName"
+      }
+    ],
     "keybindings": [
       {
         "command": "git.stageSelectedRanges",
@@ -728,6 +743,10 @@
     ],
     "menus": {
       "commandPalette": [
+        {
+          "command": "git.continueInLocalClone",
+          "when": "false"
+        },
         {
           "command": "git.clone",
           "when": "config.git.enabled && !git.missing"

--- a/extensions/git/package.nls.json
+++ b/extensions/git/package.nls.json
@@ -1,6 +1,8 @@
 {
 	"displayName": "Git",
 	"description": "Git SCM Integration",
+	"command.continueInLocalClone": "Clone Repository Locally and Open on Desktop...",
+	"command.continueInLocalClone.qualifiedName": "Continue Working in New Local Clone",
 	"command.clone": "Clone",
 	"command.cloneRecursive": "Clone (Recursive)",
 	"command.init": "Initialize Repository",

--- a/extensions/git/src/editSessionIdentityProvider.ts
+++ b/extensions/git/src/editSessionIdentityProvider.ts
@@ -31,7 +31,7 @@ export class GitEditSessionIdentityProvider implements vscode.EditSessionIdentit
 
 		return JSON.stringify({
 			remote: repository.remotes.find((remote) => remote.name === repository.HEAD?.upstream?.remote)?.pushUrl ?? null,
-			ref: repository.HEAD?.name ?? null,
+			ref: repository.HEAD?.upstream?.name ?? null,
 			sha: repository.HEAD?.commit ?? null,
 		});
 	}


### PR DESCRIPTION
For https://github.com/microsoft/vscode/issues/162118

This introduces the ability to continue working on a git repository from a remote window in a new local git clone, e.g. if you've exhausted your free GitHub Codespaces entitlement.

When in a web browser it uses a protocol URL to clone the repository in the desktop client. If already in the desktop client it does a direct `git.clone` command execution.

From codespaces in web browser to desktop git clone:

https://user-images.githubusercontent.com/30305945/211971275-3f22c603-bfb3-4ccd-a6c5-b1d7a728d7e2.mp4

