### PR TITLE
perf - allow to log duration of 2 perf markers in web

### DIFF
--- a/src/vs/workbench/contrib/performance/browser/performance.web.contribution.ts
+++ b/src/vs/workbench/contrib/performance/browser/performance.web.contribution.ts
@@ -53,19 +53,22 @@ class ResourcePerformanceMarks {
 
 class StartupTimings {
 	constructor(
-		@ITimerService timerService: ITimerService,
-		@ILogService logService: ILogService,
-		@IBrowserWorkbenchEnvironmentService environmentService: IBrowserWorkbenchEnvironmentService
+		@ITimerService private readonly timerService: ITimerService,
+		@ILogService private readonly logService: ILogService,
+		@IBrowserWorkbenchEnvironmentService private readonly environmentService: IBrowserWorkbenchEnvironmentService
 	) {
-		if (!environmentService.profDurationMarkers) {
+		this.logPerfMarks();
+	}
+
+	private async logPerfMarks(): Promise<void> {
+		if (!this.environmentService.profDurationMarkers) {
 			return;
 		}
 
-		const [from, to] = environmentService.profDurationMarkers;
+		await this.timerService.whenReady();
 
-		timerService.whenReady().then(() => {
-			logService.info(`[perf] from '${from}' to '${to}': ${timerService.getDuration(from, to)}ms`);
-		});
+		const [from, to] = this.environmentService.profDurationMarkers;
+		this.logService.info(`[perf] from '${from}' to '${to}': ${this.timerService.getDuration(from, to)}ms`);
 	}
 }
 

--- a/src/vs/workbench/services/environment/browser/environmentService.ts
+++ b/src/vs/workbench/services/environment/browser/environmentService.ts
@@ -53,6 +53,7 @@ export class BrowserWorkbenchEnvironmentService implements IBrowserWorkbenchEnvi
 		if (logLevelFromPayload) {
 			return logLevelFromPayload.split(',').find(entry => !EXTENSION_IDENTIFIER_WITH_LOG_REGEX.test(entry));
 		}
+
 		return this.options.developmentOptions?.logLevel !== undefined ? LogLevelToString(this.options.developmentOptions?.logLevel) : undefined;
 	}
 
@@ -66,9 +67,25 @@ export class BrowserWorkbenchEnvironmentService implements IBrowserWorkbenchEnvi
 					result.push([matches[1], matches[2]]);
 				}
 			}
+
 			return result.length ? result : undefined;
 		}
+
 		return this.options.developmentOptions?.extensionLogLevel !== undefined ? this.options.developmentOptions?.extensionLogLevel.map(([extension, logLevel]) => ([extension, LogLevelToString(logLevel)])) : undefined;
+	}
+
+	get profDurationMarkers(): string[] | undefined {
+		const profDurationMarkersFromPayload = this.payload?.get('profDurationMarkers');
+		if (profDurationMarkersFromPayload) {
+			const result: string[] = [];
+			for (const entry of profDurationMarkersFromPayload.split(',')) {
+				result.push(entry);
+			}
+
+			return result.length === 2 ? result : undefined;
+		}
+
+		return undefined;
 	}
 
 	@memoize

--- a/src/vs/workbench/services/environment/common/environmentService.ts
+++ b/src/vs/workbench/services/environment/common/environmentService.ts
@@ -42,6 +42,7 @@ export interface IWorkbenchEnvironmentService extends IEnvironmentService {
 	readonly debugRenderer: boolean;
 	readonly logExtensionHostCommunication?: boolean;
 	readonly enableSmokeTestDriver?: boolean;
+	readonly profDurationMarkers?: string[];
 
 	// --- Editors to open
 	readonly filesToOpenOrCreate?: IPath[] | undefined;

--- a/src/vs/workbench/services/timer/browser/timerService.ts
+++ b/src/vs/workbench/services/timer/browser/timerService.ts
@@ -622,7 +622,7 @@ export abstract class AbstractTimerService implements ITimerService {
 		const initialStartup = this._isInitialStartup();
 		let startMark: string;
 		if (isWeb) {
-			startMark = 'code/didStartRenderer';
+			startMark = 'code/timeOrigin';
 		} else {
 			startMark = initialStartup ? 'code/didStartMain' : 'code/willOpenNewWindow';
 		}

--- a/src/vs/workbench/services/timer/browser/timerService.ts
+++ b/src/vs/workbench/services/timer/browser/timerService.ts
@@ -18,6 +18,7 @@ import { IPaneCompositePartService } from 'vs/workbench/services/panecomposite/b
 import { ViewContainerLocation } from 'vs/workbench/common/views';
 import { StopWatch } from 'vs/base/common/stopwatch';
 import { TelemetryTrustedValue } from 'vs/platform/telemetry/common/telemetryUtils';
+import { isWeb } from 'vs/base/common/platform';
 
 /* __GDPR__FRAGMENT__
 	"IMemoryInfo" : {
@@ -619,7 +620,12 @@ export abstract class AbstractTimerService implements ITimerService {
 
 	private async _computeStartupMetrics(): Promise<IStartupMetrics> {
 		const initialStartup = this._isInitialStartup();
-		const startMark = initialStartup ? 'code/didStartMain' : 'code/willOpenNewWindow';
+		let startMark: string;
+		if (isWeb) {
+			startMark = 'code/didStartRenderer';
+		} else {
+			startMark = initialStartup ? 'code/didStartMain' : 'code/willOpenNewWindow';
+		}
 
 		const activeViewlet = this._paneCompositeService.getActivePaneComposite(ViewContainerLocation.Sidebar);
 		const activePanel = this._paneCompositeService.getActivePaneComposite(ViewContainerLocation.Panel);


### PR DESCRIPTION
This allows printing 2 perf markers to console via URL param such as: `?payload=[[%22profDurationMarkers%22,%22code/didStartRenderer,code/didStartWorkbench%22]]`