### PR TITLE
Add "Navigate locations in current file" commands

### DIFF
--- a/src/vs/workbench/browser/parts/editor/editor.contribution.ts
+++ b/src/vs/workbench/browser/parts/editor/editor.contribution.ts
@@ -42,7 +42,7 @@ import {
 	QuickAccessPreviousRecentlyUsedEditorAction, OpenPreviousRecentlyUsedEditorInGroupAction, OpenNextRecentlyUsedEditorInGroupAction, QuickAccessLeastRecentlyUsedEditorAction, QuickAccessLeastRecentlyUsedEditorInGroupAction,
 	ReOpenInTextEditorAction, DuplicateGroupDownAction, DuplicateGroupLeftAction, DuplicateGroupRightAction, DuplicateGroupUpAction, ToggleEditorTypeAction, SplitEditorToAboveGroupAction, SplitEditorToBelowGroupAction,
 	SplitEditorToFirstGroupAction, SplitEditorToLastGroupAction, SplitEditorToLeftGroupAction, SplitEditorToNextGroupAction, SplitEditorToPreviousGroupAction, SplitEditorToRightGroupAction, NavigateForwardInEditsAction,
-	NavigateBackwardsInEditsAction, NavigateForwardInNavigationsAction, NavigateBackwardsInNavigationsAction, NavigatePreviousInNavigationsAction, NavigatePreviousInEditsAction, NavigateToLastNavigationLocationAction
+	NavigateBackwardsInEditsAction, NavigateForwardInNavigationsAction, NavigateBackwardsInNavigationsAction, NavigatePreviousInNavigationsAction, NavigatePreviousInEditsAction, NavigateToLastNavigationLocationAction, NavigateForwardInEditsInCurrentEditorAction, NavigateBackwardsInEditsInCurrentEditorAction, NavigateBackwardsInNavigationsInCurrentEditorAction, NavigateForwardInNavigationsInCurrentEditorAction, NavigatePreviousInEditsInCurrentEditorAction, NavigatePreviousInNavigationsInCurrentEditorAction, NavigateToLastEditLocationInCurrentEditorAction, NavigateToLastNavigationLocationInCurrentEditorAction
 } from 'vs/workbench/browser/parts/editor/editorActions';
 import {
 	CLOSE_EDITORS_AND_GROUP_COMMAND_ID, CLOSE_EDITORS_IN_GROUP_COMMAND_ID, CLOSE_EDITORS_TO_THE_RIGHT_COMMAND_ID, CLOSE_EDITOR_COMMAND_ID, CLOSE_EDITOR_GROUP_COMMAND_ID, CLOSE_OTHER_EDITORS_IN_GROUP_COMMAND_ID,
@@ -255,6 +255,16 @@ registry.registerWorkbenchAction(SyncActionDescriptor.from(NavigateForwardInNavi
 registry.registerWorkbenchAction(SyncActionDescriptor.from(NavigateBackwardsInNavigationsAction), 'Go Back in Navigation Locations');
 registry.registerWorkbenchAction(SyncActionDescriptor.from(NavigatePreviousInNavigationsAction), 'Go Previous in Navigation Locations');
 registry.registerWorkbenchAction(SyncActionDescriptor.from(NavigateToLastNavigationLocationAction), 'Go to Last Navigation Location');
+
+registry.registerWorkbenchAction(SyncActionDescriptor.from(NavigateForwardInEditsInCurrentEditorAction), 'Go Forward in Edit Locations in Current Editor');
+registry.registerWorkbenchAction(SyncActionDescriptor.from(NavigateBackwardsInEditsInCurrentEditorAction), 'Go Back in Edit Locations in Current Editor');
+registry.registerWorkbenchAction(SyncActionDescriptor.from(NavigatePreviousInEditsInCurrentEditorAction), 'Go Previous in Edit Locations in Current Editor');
+registry.registerWorkbenchAction(SyncActionDescriptor.from(NavigateToLastEditLocationInCurrentEditorAction), 'Go to Last Edit Location in Current Editor');
+registry.registerWorkbenchAction(SyncActionDescriptor.from(NavigateForwardInNavigationsInCurrentEditorAction), 'Go Forward in Navigation Locations in Current Editor');
+registry.registerWorkbenchAction(SyncActionDescriptor.from(NavigateBackwardsInNavigationsInCurrentEditorAction), 'Go Back in Navigation Locations in Current Editor');
+registry.registerWorkbenchAction(SyncActionDescriptor.from(NavigatePreviousInNavigationsInCurrentEditorAction), 'Go Previous in Navigation Locations in Current Editor');
+registry.registerWorkbenchAction(SyncActionDescriptor.from(NavigateToLastNavigationLocationInCurrentEditorAction), 'Go to Last Navigation Location in Current Editor');
+
 registry.registerWorkbenchAction(SyncActionDescriptor.from(ClearEditorHistoryAction), 'Clear Editor History');
 registry.registerWorkbenchAction(SyncActionDescriptor.from(RevertAndCloseEditorAction), 'View: Revert and Close Editor', Categories.View.value);
 registry.registerWorkbenchAction(SyncActionDescriptor.from(EditorLayoutSingleAction), 'View: Single Column Editor Layout', Categories.View.value);

--- a/src/vs/workbench/browser/parts/editor/editorActions.ts
+++ b/src/vs/workbench/browser/parts/editor/editorActions.ts
@@ -10,7 +10,7 @@ import { IEditorIdentifier, IEditorCommandsContext, CloseDirection, SaveReason, 
 import { EditorInput } from 'vs/workbench/common/editor/editorInput';
 import { SideBySideEditorInput } from 'vs/workbench/common/editor/sideBySideEditorInput';
 import { IWorkbenchLayoutService, Parts } from 'vs/workbench/services/layout/browser/layoutService';
-import { GoFilter, IHistoryService } from 'vs/workbench/services/history/common/history';
+import { GoFilter, GoScope, IHistoryService } from 'vs/workbench/services/history/common/history';
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 import { ICommandService } from 'vs/platform/commands/common/commands';
 import { CLOSE_EDITOR_COMMAND_ID, MOVE_ACTIVE_EDITOR_COMMAND_ID, ActiveEditorMoveCopyArguments, SPLIT_EDITOR_LEFT, SPLIT_EDITOR_RIGHT, SPLIT_EDITOR_UP, SPLIT_EDITOR_DOWN, splitEditor, LAYOUT_EDITOR_GROUPS_COMMAND_ID, UNPIN_EDITOR_COMMAND_ID, COPY_ACTIVE_EDITOR_COMMAND_ID } from 'vs/workbench/browser/parts/editor/editorCommands';
@@ -1512,6 +1512,150 @@ export class NavigateToLastNavigationLocationAction extends Action {
 
 	override async run(): Promise<void> {
 		await this.historyService.goLast(GoFilter.NAVIGATION);
+	}
+}
+
+export class NavigateForwardInEditsInCurrentEditorAction extends Action {
+
+	static readonly ID = 'workbench.action.navigateForwardInEditLocationsInCurrentEditor';
+	static readonly LABEL = localize('navigateForwardInEditsInCurrentEditor', "Go Forward in Edit Locations in Current Editor");
+
+	constructor(
+		id: string,
+		label: string,
+		@IHistoryService private readonly historyService: IHistoryService
+	) {
+		super(id, label);
+	}
+
+	override async run(): Promise<void> {
+		await this.historyService.goForward(GoFilter.EDITS, GoScope.EDITOR);
+	}
+}
+
+export class NavigateBackwardsInEditsInCurrentEditorAction extends Action {
+
+	static readonly ID = 'workbench.action.navigateBackInEditLocationsInCurrentEditor';
+	static readonly LABEL = localize('navigateBackInEditsInCurrentEditor', "Go Back in Edit Locations in Current Editor");
+
+	constructor(
+		id: string,
+		label: string,
+		@IHistoryService private readonly historyService: IHistoryService
+	) {
+		super(id, label);
+	}
+
+	override async run(): Promise<void> {
+		await this.historyService.goBack(GoFilter.EDITS, GoScope.EDITOR);
+	}
+}
+
+export class NavigatePreviousInEditsInCurrentEditorAction extends Action {
+
+	static readonly ID = 'workbench.action.navigatePreviousInEditLocationsInCurrentEditor';
+	static readonly LABEL = localize('navigatePreviousInEditsInCurrentEditor', "Go Previous in Edit Locations in Current Editor");
+
+	constructor(
+		id: string,
+		label: string,
+		@IHistoryService private readonly historyService: IHistoryService
+	) {
+		super(id, label);
+	}
+
+	override async run(): Promise<void> {
+		await this.historyService.goPrevious(GoFilter.EDITS, GoScope.EDITOR);
+	}
+}
+
+export class NavigateToLastEditLocationInCurrentEditorAction extends Action {
+
+	static readonly ID = 'workbench.action.navigateToLastEditLocationInCurrentEditor';
+	static readonly LABEL = localize('navigateToLastEditLocationInCurrentEditor', "Go to Last Edit Location in Current Editor");
+
+	constructor(
+		id: string,
+		label: string,
+		@IHistoryService private readonly historyService: IHistoryService
+	) {
+		super(id, label);
+	}
+
+	override async run(): Promise<void> {
+		await this.historyService.goLast(GoFilter.EDITS, GoScope.EDITOR);
+	}
+}
+
+export class NavigateForwardInNavigationsInCurrentEditorAction extends Action {
+
+	static readonly ID = 'workbench.action.navigateForwardInNavigationLocationsInCurrentEditor';
+	static readonly LABEL = localize('navigateForwardInNavigationsInCurrentEditor', "Go Forward in Navigation Locations in Current Editor");
+
+	constructor(
+		id: string,
+		label: string,
+		@IHistoryService private readonly historyService: IHistoryService
+	) {
+		super(id, label);
+	}
+
+	override async run(): Promise<void> {
+		await this.historyService.goForward(GoFilter.NAVIGATION, GoScope.EDITOR);
+	}
+}
+
+export class NavigateBackwardsInNavigationsInCurrentEditorAction extends Action {
+
+	static readonly ID = 'workbench.action.navigateBackInNavigationLocationsInCurrentEditor';
+	static readonly LABEL = localize('navigateBackInNavigationsInCurrentEditor', "Go Back in Navigation Locations in Current Editor");
+
+	constructor(
+		id: string,
+		label: string,
+		@IHistoryService private readonly historyService: IHistoryService
+	) {
+		super(id, label);
+	}
+
+	override async run(): Promise<void> {
+		await this.historyService.goBack(GoFilter.NAVIGATION, GoScope.EDITOR);
+	}
+}
+
+export class NavigatePreviousInNavigationsInCurrentEditorAction extends Action {
+
+	static readonly ID = 'workbench.action.navigatePreviousInNavigationLocationsInCurrentEditor';
+	static readonly LABEL = localize('navigatePreviousInNavigationLocationsInCurrentEditor', "Go Previous in Navigation Locations in Current Editor");
+
+	constructor(
+		id: string,
+		label: string,
+		@IHistoryService private readonly historyService: IHistoryService
+	) {
+		super(id, label);
+	}
+
+	override async run(): Promise<void> {
+		await this.historyService.goPrevious(GoFilter.NAVIGATION, GoScope.EDITOR);
+	}
+}
+
+export class NavigateToLastNavigationLocationInCurrentEditorAction extends Action {
+
+	static readonly ID = 'workbench.action.navigateToLastNavigationLocationInCurrentEditor';
+	static readonly LABEL = localize('navigateToLastNavigationLocationInCurrentEditor', "Go to Last Navigation Location in Current Editor");
+
+	constructor(
+		id: string,
+		label: string,
+		@IHistoryService private readonly historyService: IHistoryService
+	) {
+		super(id, label);
+	}
+
+	override async run(): Promise<void> {
+		await this.historyService.goLast(GoFilter.NAVIGATION, GoScope.EDITOR);
 	}
 }
 

--- a/src/vs/workbench/services/history/browser/historyService.ts
+++ b/src/vs/workbench/services/history/browser/historyService.ts
@@ -269,7 +269,7 @@ export class HistoryService extends Disposable implements IHistoryService {
 
 	updateContextKeys(): void {
 		this.contextKeyService.bufferChangeEvents(() => {
-			const activeStack = this.getStack();
+			const activeStack = this.getStack({ scope: this.editorNavigationScope });
 
 			this.canNavigateBackContextKey.set(activeStack.canGoBack(GoFilter.NONE));
 			this.canNavigateForwardContextKey.set(activeStack.canGoForward(GoFilter.NONE));
@@ -325,8 +325,16 @@ export class HistoryService extends Disposable implements IHistoryService {
 		handleEditorNavigationScopeChange();
 	}
 
-	private getStack(group = this.editorGroupService.activeGroup, editor = group.activeEditor): IEditorNavigationStacks {
-		switch (this.editorNavigationScope) {
+	private getStack({
+		group = this.editorGroupService.activeGroup,
+		editor = group.activeEditor,
+		scope,
+	}: {
+		group?: IEditorGroup;
+		editor?: typeof group.activeEditor;
+		scope: GoScope;
+	}): IEditorNavigationStacks {
+		switch (scope) {
 
 			// Per Editor
 			case GoScope.EDITOR: {
@@ -381,28 +389,32 @@ export class HistoryService extends Disposable implements IHistoryService {
 		}
 	}
 
-	goForward(filter?: GoFilter): Promise<void> {
-		return this.getStack().goForward(filter);
+	goForward(filter?: GoFilter, scope: GoScope = this.editorNavigationScope): Promise<void> {
+		return this.getStack({ scope }).goForward(filter);
 	}
 
-	goBack(filter?: GoFilter): Promise<void> {
-		return this.getStack().goBack(filter);
+	goBack(filter?: GoFilter, scope: GoScope = this.editorNavigationScope): Promise<void> {
+		return this.getStack({ scope }).goBack(filter);
 	}
 
-	goPrevious(filter?: GoFilter): Promise<void> {
-		return this.getStack().goPrevious(filter);
+	goPrevious(filter?: GoFilter, scope: GoScope = this.editorNavigationScope): Promise<void> {
+		return this.getStack({ scope }).goPrevious(filter);
 	}
 
-	goLast(filter?: GoFilter): Promise<void> {
-		return this.getStack().goLast(filter);
+	goLast(filter?: GoFilter, scope: GoScope = this.editorNavigationScope): Promise<void> {
+		return this.getStack({ scope }).goLast(filter);
 	}
 
 	private handleActiveEditorChangeInNavigationStacks(group: IEditorGroup, editorPane?: IEditorPane): void {
-		this.getStack(group, editorPane?.input).handleActiveEditorChange(editorPane);
+		for (const scope of [GoScope.DEFAULT, GoScope.EDITOR, GoScope.EDITOR_GROUP]) {
+			this.getStack({ scope, group, editor: editorPane?.input }).handleActiveEditorChange(editorPane);
+		}
 	}
 
 	private handleActiveEditorSelectionChangeInNavigationStacks(group: IEditorGroup, editorPane: IEditorPaneWithSelection, event: IEditorPaneSelectionChangeEvent): void {
-		this.getStack(group, editorPane.input).handleActiveEditorSelectionChange(editorPane, event);
+		for (const scope of [GoScope.DEFAULT, GoScope.EDITOR, GoScope.EDITOR_GROUP]) {
+			this.getStack({ scope, group, editor: editorPane.input }).handleActiveEditorSelectionChange(editorPane, event);
+		}
 	}
 
 	private handleEditorCloseEventInHistory(e: IEditorCloseEvent): void {

--- a/src/vs/workbench/services/history/common/history.ts
+++ b/src/vs/workbench/services/history/common/history.ts
@@ -64,12 +64,12 @@ export interface IHistoryService {
 	/**
 	 * Navigate forwards in editor navigation history.
 	 */
-	goForward(filter?: GoFilter): Promise<void>;
+	goForward(filter?: GoFilter, scope?: GoScope): Promise<void>;
 
 	/**
 	 * Navigate backwards in editor navigation history.
 	 */
-	goBack(filter?: GoFilter): Promise<void>;
+	goBack(filter?: GoFilter, scope?: GoScope): Promise<void>;
 
 	/**
 	 * Navigate between the current editor navigtion history entry
@@ -77,12 +77,12 @@ export interface IHistoryService {
 	 * like a toggle for `forward` and `back` to jump between 2 points
 	 * in editor navigation history.
 	 */
-	goPrevious(filter?: GoFilter): Promise<void>;
+	goPrevious(filter?: GoFilter, scope?: GoScope): Promise<void>;
 
 	/**
 	 * Navigate to the last entry in editor navigation history.
 	 */
-	goLast(filter?: GoFilter): Promise<void>;
+	goLast(filter?: GoFilter, scope?: GoScope): Promise<void>;
 
 	/**
 	 * Re-opens the last closed editor if any.


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Resolves #166314

These changes are a proof-of-concept and are not complete, but my hope is that putting them up can start a discussion about how they might get reviewed and potentially accepted.

Current limitations:
- "current editor" and "default" history stacks are completely separate, which leads to some slightly sketchy behavior. If you have changes A, B and C in the current editor, and then run "go back in edit locations" twice your cursor will be at A. If you then run "go back in edit locations in current editor", your cursor will be at B.
- I have made no attempt to update the existing context keys scheme. I think there's a discussion to be had about which context keys might make sense.
- In the linked issue, I discussed unifying all the navigation commands into a single command that takes _scope_ and _filter_ arguments. I have made no attempt to make that change, since that's somewhat orthogonal to the underlying history service functionality. If that change is desired, I'm happy to add it to this or another pull request.
- I haven't added or updated any tests. I figured let's decide what the changes are first, then I can write tests that verify the behavior.