### PR TITLE
Fix active icon color for selected list items in Light+ V2

### DIFF
--- a/extensions/theme-defaults/themes/light_plus_experimental.json
+++ b/extensions/theme-defaults/themes/light_plus_experimental.json
@@ -66,7 +66,6 @@
 		"keybindingLabel.foreground": "#000000e4",
 		"list.activeSelectionBackground": "#e8e8e8",
 		"list.activeSelectionForeground": "#000000",
-		"list.activeSelectionIconForeground": "#000000",
 		"list.hoverBackground": "#f2f2f2",
 		"menu.border": "#D4D4D4",
 		"notebook.cellBorderColor": "#E8E8E8",


### PR DESCRIPTION
Fix #169812