### PR TITLE
Await xterm.load addon in lineDataEventAddong test

### DIFF
--- a/src/vs/workbench/contrib/terminal/test/browser/xterm/lineDataEventAddon.test.ts
+++ b/src/vs/workbench/contrib/terminal/test/browser/xterm/lineDataEventAddon.test.ts
@@ -27,10 +27,10 @@ suite('LineDataEventAddon', () => {
 	suite('onLineData', () => {
 		let events: string[];
 
-		setup(() => {
+		setup(async () => {
 			xterm = new Terminal({ allowProposedApi: true, cols: 4 });
 			lineDataEventAddon = new LineDataEventAddon();
-			xterm.loadAddon(lineDataEventAddon);
+			await xterm.loadAddon(lineDataEventAddon);
 
 			events = [];
 			lineDataEventAddon.onLineData(e => events.push(e));


### PR DESCRIPTION
When we are running these tests, they are failing for us because our test suite is running the tests before the loadAddon promise is resolved. (Our test system tries to be clever with async.)

It seems to work fine with the standard VS Code suite, but I believe the change that fixes the issue for us would also make sense here anyway since it adds another layer of guarantee against any chance of race conditions and potentially flake tests.