### PR TITLE
Confusion tweaks for the standalone CLI

### DIFF
--- a/build/azure-pipelines/cli/cli-compile-and-publish.yml
+++ b/build/azure-pipelines/cli/cli-compile-and-publish.yml
@@ -16,13 +16,15 @@ steps:
       ${{ each pair in parameters.VSCODE_CLI_ENV }}:
         ${{ pair.key }}: ${{ pair.value }}
 
-  - ${{ if or(contains(parameters.VSCODE_CLI_TARGET, '-windows-'), contains(parameters.VSCODE_CLI_TARGET, '-darwin')) }}:
+  - ${{ if contains(parameters.VSCODE_CLI_TARGET, '-windows-') }}:
+    - powershell: |
+        . build/azure-pipelines/win32/exec.ps1
+        $ErrorActionPreference = "Stop"
+        Move-Item -Path $(Build.SourcesDirectory)/cli/target/${{ parameters.VSCODE_CLI_TARGET }}/release/code.exe -Destination "$(Build.ArtifactStagingDirectory)/${env:VSCODE_CLI_APPLICATION_NAME}.exe"
+
     - task: ArchiveFiles@2
       inputs:
-        ${{ if contains(parameters.VSCODE_CLI_TARGET, '-windows-') }}:
-          rootFolderOrFile: $(Build.SourcesDirectory)/cli/target/${{ parameters.VSCODE_CLI_TARGET }}/release/code.exe
-        ${{ if contains(parameters.VSCODE_CLI_TARGET, '-darwin') }}:
-          rootFolderOrFile: $(Build.SourcesDirectory)/cli/target/${{ parameters.VSCODE_CLI_TARGET }}/release/code
+        rootFolderOrFile: $(Build.ArtifactStagingDirectory)/$(VSCODE_CLI_APPLICATION_NAME).exe
         includeRootFolder: false
         archiveType: zip
         archiveFile: $(Build.ArtifactStagingDirectory)/${{ parameters.VSCODE_CLI_ARTIFACT }}.zip
@@ -32,14 +34,31 @@ steps:
       displayName: Publish ${{ parameters.VSCODE_CLI_ARTIFACT }} artifact
 
   - ${{ else }}:
-    - task: ArchiveFiles@2
-      inputs:
-        rootFolderOrFile: $(Build.SourcesDirectory)/cli/target/${{ parameters.VSCODE_CLI_TARGET }}/release/code
-        includeRootFolder: false
-        archiveType: tar
-        tarCompression: gz
-        archiveFile: $(Build.ArtifactStagingDirectory)/${{ parameters.VSCODE_CLI_ARTIFACT }}.tar.gz
+    - script: |
+        set -e
+        mv $(Build.SourcesDirectory)/cli/target/${{ parameters.VSCODE_CLI_TARGET }}/release/code $(Build.ArtifactStagingDirectory)/$(VSCODE_CLI_APPLICATION_NAME)
 
-    - publish: $(Build.ArtifactStagingDirectory)/${{ parameters.VSCODE_CLI_ARTIFACT }}.tar.gz
-      artifact: ${{ parameters.VSCODE_CLI_ARTIFACT }}
-      displayName: Publish ${{ parameters.VSCODE_CLI_ARTIFACT }} artifact
+    - ${{ if contains(parameters.VSCODE_CLI_TARGET, '-darwin') }}:
+      - task: ArchiveFiles@2
+        inputs:
+          rootFolderOrFile: $(Build.ArtifactStagingDirectory)/$(VSCODE_CLI_APPLICATION_NAME)
+          includeRootFolder: false
+          archiveType: zip
+          archiveFile: $(Build.ArtifactStagingDirectory)/${{ parameters.VSCODE_CLI_ARTIFACT }}.zip
+
+      - publish: $(Build.ArtifactStagingDirectory)/${{ parameters.VSCODE_CLI_ARTIFACT }}.zip
+        artifact: ${{ parameters.VSCODE_CLI_ARTIFACT }}
+        displayName: Publish ${{ parameters.VSCODE_CLI_ARTIFACT }} artifact
+
+    - ${{ else }}:
+      - task: ArchiveFiles@2
+        inputs:
+          rootFolderOrFile: $(Build.ArtifactStagingDirectory)/$(VSCODE_CLI_APPLICATION_NAME)
+          includeRootFolder: false
+          archiveType: tar
+          tarCompression: gz
+          archiveFile: $(Build.ArtifactStagingDirectory)/${{ parameters.VSCODE_CLI_ARTIFACT }}.tar.gz
+
+      - publish: $(Build.ArtifactStagingDirectory)/${{ parameters.VSCODE_CLI_ARTIFACT }}.tar.gz
+        artifact: ${{ parameters.VSCODE_CLI_ARTIFACT }}
+        displayName: Publish ${{ parameters.VSCODE_CLI_ARTIFACT }} artifact

--- a/build/azure-pipelines/darwin/product-build-darwin.yml
+++ b/build/azure-pipelines/darwin/product-build-darwin.yml
@@ -214,7 +214,8 @@ steps:
           ARCHIVE_NAME=$(ls "$(Build.ArtifactStagingDirectory)/cli" | head -n 1)
           unzip "$(Build.ArtifactStagingDirectory)/cli/$ARCHIVE_NAME" -d "$(Build.ArtifactStagingDirectory)/cli"
           CLI_APP_NAME=$(node -p "require(\"$(APP_PATH)/Contents/Resources/app/product.json\").tunnelApplicationName")
-          mv "$(Build.ArtifactStagingDirectory)/cli/code" "$(APP_PATH)/Contents/Resources/app/bin/$CLI_APP_NAME"
+          APP_NAME=$(node -p "require(\"$(APP_PATH)/Contents/Resources/app/product.json\").applicationName")
+          mv "$(Build.ArtifactStagingDirectory)/cli/$APP_NAME" "$(APP_PATH)/Contents/Resources/app/bin/$CLI_APP_NAME"
           chmod +x "$(APP_PATH)/Contents/Resources/app/bin/$CLI_APP_NAME"
         displayName: Make CLI executable
 

--- a/build/azure-pipelines/linux/product-build-linux-client.yml
+++ b/build/azure-pipelines/linux/product-build-linux-client.yml
@@ -293,7 +293,8 @@ steps:
           set -e
           tar -xzvf $(Build.ArtifactStagingDirectory)/cli/*.tar.gz -C $(Build.ArtifactStagingDirectory)/cli
           CLI_APP_NAME=$(node -p "require(\"$(agent.builddirectory)/VSCode-linux-$(VSCODE_ARCH)/resources/app/product.json\").tunnelApplicationName")
-          mv $(Build.ArtifactStagingDirectory)/cli/code $(agent.builddirectory)/VSCode-linux-$(VSCODE_ARCH)/bin/$CLI_APP_NAME
+          APP_NAME=$(node -p "require(\"$(agent.builddirectory)/VSCode-linux-$(VSCODE_ARCH)/resources/app/product.json\").applicationName")
+          mv $(Build.ArtifactStagingDirectory)/cli/$APP_NAME $(agent.builddirectory)/VSCode-linux-$(VSCODE_ARCH)/bin/$CLI_APP_NAME
         displayName: Make CLI executable
 
   - ${{ if or(eq(parameters.VSCODE_RUN_UNIT_TESTS, true), eq(parameters.VSCODE_RUN_INTEGRATION_TESTS, true), eq(parameters.VSCODE_RUN_SMOKE_TESTS, true)) }}:

--- a/build/azure-pipelines/win32/product-build-win32.yml
+++ b/build/azure-pipelines/win32/product-build-win32.yml
@@ -240,7 +240,8 @@ steps:
           Expand-Archive -Path $ArtifactName -DestinationPath "$(Build.ArtifactStagingDirectory)/cli"
           $AppProductJson = Get-Content -Raw -Path "$(agent.builddirectory)\VSCode-win32-$(VSCODE_ARCH)\resources\app\product.json" | ConvertFrom-Json
           $CliAppName = $AppProductJson.tunnelApplicationName
-          Move-Item -Path "$(Build.ArtifactStagingDirectory)/cli/code.exe" -Destination "$(agent.builddirectory)/VSCode-win32-$(VSCODE_ARCH)/bin/$CliAppName.exe"
+          $AppName = $AppProductJson.applicationName
+          Move-Item -Path "$(Build.ArtifactStagingDirectory)/cli/$AppName.exe" -Destination "$(agent.builddirectory)/VSCode-win32-$(VSCODE_ARCH)/bin/$CliAppName.exe"
         displayName: Move VS Code CLI
 
   - ${{ if eq(parameters.VSCODE_PUBLISH, true) }}:

--- a/cli/src/commands/args.rs
+++ b/cli/src/commands/args.rs
@@ -10,17 +10,30 @@ use clap::{ArgEnum, Args, Parser, Subcommand};
 use const_format::concatcp;
 
 const CLI_NAME: &str = concatcp!(constants::PRODUCT_NAME_LONG, " CLI");
-const TEMPLATE: &str = concatcp!(
+const HELP_COMMANDS: &str = "Usage: {name} [options][paths...]
+
+To read output from another program, append '-' (e.g. 'echo Hello World | {name} -')";
+
+const STANDALONE_TEMPLATE: &str = concatcp!(
+	CLI_NAME,
+	" Standalone - {version}
+
+",
+	HELP_COMMANDS,
+	"
+Running editor commands requires installing ",
+	constants::QUALITYLESS_PRODUCT_NAME,
+	", and may differ slightly.
+
+{all-args}"
+);
+const INTEGRATED_TEMPLATE: &str = concatcp!(
 	CLI_NAME,
 	" - {version}
 
-Usage: ",
-	constants::APPLICATION_NAME,
-	" [options][paths...]
-
-To read output from another program, append '-' (e.g. 'echo Hello World | ",
-	constants::APPLICATION_NAME,
-	" -')
+",
+	HELP_COMMANDS,
+	"
 
 {all-args}"
 );
@@ -37,9 +50,8 @@ const VERSION: &str = concatcp!(NUMBER_IN_VERSION, " (commit ", COMMIT_IN_VERSIO
 
 #[derive(Parser, Debug, Default)]
 #[clap(
-   help_template = TEMPLATE,
+   help_template = INTEGRATED_TEMPLATE,
    long_about = None,
-   name = CLI_NAME,
    version = VERSION,
  )]
 pub struct IntegratedCli {
@@ -69,9 +81,8 @@ pub struct CliCore {
 
 #[derive(Parser, Debug, Default)]
 #[clap(
-   help_template = TEMPLATE,
+   help_template = STANDALONE_TEMPLATE,
    long_about = None,
-   name = CLI_NAME,
    version = VERSION,
  )]
 pub struct StandaloneCli {


### PR DESCRIPTION
- Makes the help text distinct between standalone and integrated modes
- Make the name of the standalone CLI match the quality-specific application name (Fixes https://github.com/microsoft/vscode-remote-tunnels/issues/571)

note the 'failed build' from CI is just because I ran a partial build to sanity check things - seems macOS universal doesn't build if artifacts don't get published 😛 