### PR TITLE
Improve protocol link handling around `windowId=_blank` support

### DIFF
--- a/src/vs/code/electron-main/app.ts
+++ b/src/vs/code/electron-main/app.ts
@@ -571,7 +571,7 @@ export class CodeApplication extends Disposable {
 	private setupProtocolUrlHandlers(accessor: ServicesAccessor, mainProcessElectronServer: ElectronIPCServer): IInitialProtocolUrls | undefined {
 		const windowsMainService = this.windowsMainService = accessor.get(IWindowsMainService);
 		const urlService = accessor.get(IURLService);
-		const nativeHostMainService = accessor.get(INativeHostMainService);
+		const nativeHostMainService = this.nativeHostMainService = accessor.get(INativeHostMainService);
 
 		// Install URL handlers that deal with protocl URLs either
 		// from this process by opening windows and/or by forwarding
@@ -603,20 +603,19 @@ export class CodeApplication extends Disposable {
 	private resolveInitialProtocolUrls(): IInitialProtocolUrls | undefined {
 
 		/**
-		 * Protocol URL handling on startup is complex,
-		 * refer to {@link IInitialProtocolUrls} for an
-		 * explainer.
+		 * Protocol URL handling on startup is complex, refer to
+		 * {@link IInitialProtocolUrls} for an explainer.
 		 */
 
 		// Windows/Linux: protocol handler invokes CLI with --open-url
 		const protocolUrlsFromCommandLine = this.environmentMainService.args['open-url'] ? this.environmentMainService.args._urls || [] : [];
-		if (protocolUrlsFromCommandLine.length) {
+		if (protocolUrlsFromCommandLine.length > 0) {
 			this.logService.trace('app#resolveInitialProtocolUrls() protocol urls from command line:', protocolUrlsFromCommandLine);
 		}
 
 		// macOS: open-url events that were received before the app is ready
 		const protocolUrlsFromEvent = ((<any>global).getOpenUrls() || []) as string[];
-		if (protocolUrlsFromEvent.length) {
+		if (protocolUrlsFromEvent.length > 0) {
 			this.logService.trace(`app#resolveInitialProtocolUrls() protocol urls from macOS 'open-url' event:`, protocolUrlsFromEvent);
 		}
 

--- a/src/vs/code/electron-main/app.ts
+++ b/src/vs/code/electron-main/app.ts
@@ -623,7 +623,7 @@ export class CodeApplication extends Disposable {
 			return undefined;
 		}
 
-		let openables: IWindowOpenable[] | undefined = undefined;
+		const openables: IWindowOpenable[] = [];
 		const urls = [
 			...protocolUrlsFromCommandLine,
 			...protocolUrlsFromEvent
@@ -650,9 +650,6 @@ export class CodeApplication extends Disposable {
 			if (windowOpenable) {
 				this.logService.trace('app#resolveInitialProtocolUrls() protocol url will be handled as window to open:', obj.uri.toString(true), windowOpenable);
 
-				if (!openables) {
-					openables = [];
-				}
 				openables.push(windowOpenable);
 
 				return false; // handled as window to open
@@ -1089,7 +1086,7 @@ export class CodeApplication extends Disposable {
 		if (initialProtocolUrls) {
 
 			// Openables can open as windows directly
-			if (Array.isArray(initialProtocolUrls.openables) && initialProtocolUrls.openables.length > 0) {
+			if (initialProtocolUrls.openables.length > 0) {
 				return windowsMainService.open({
 					context,
 					cli: args,

--- a/src/vs/platform/launch/electron-main/launchMainService.ts
+++ b/src/vs/platform/launch/electron-main/launchMainService.ts
@@ -17,6 +17,7 @@ import { IURLService } from 'vs/platform/url/common/url';
 import { ICodeWindow } from 'vs/platform/window/electron-main/window';
 import { IWindowSettings } from 'vs/platform/window/common/window';
 import { IOpenConfiguration, IWindowsMainService, OpenContext } from 'vs/platform/windows/electron-main/windows';
+import { IProtocolUrl } from 'vs/platform/url/electron-main/url';
 
 export const ID = 'launchMainService';
 export const ILaunchMainService = createDecorator<ILaunchMainService>(ID);
@@ -77,8 +78,8 @@ export class LaunchMainService implements ILaunchMainService {
 
 			// Make sure a window is open, ready to receive the url event
 			whenWindowReady.then(() => {
-				for (const { uri, url } of urlsToOpen) {
-					this.urlService.open(uri, { originalUrl: url });
+				for (const { uri, originalUrl } of urlsToOpen) {
+					this.urlService.open(uri, { originalUrl });
 				}
 			});
 		}
@@ -89,7 +90,7 @@ export class LaunchMainService implements ILaunchMainService {
 		}
 	}
 
-	private parseOpenUrl(args: NativeParsedArgs): { uri: URI; url: string }[] {
+	private parseOpenUrl(args: NativeParsedArgs): IProtocolUrl[] {
 		if (args['open-url'] && args._urls && args._urls.length > 0) {
 
 			// --open-url must contain -- followed by the url(s)
@@ -98,7 +99,7 @@ export class LaunchMainService implements ILaunchMainService {
 			return coalesce(args._urls
 				.map(url => {
 					try {
-						return { uri: URI.parse(url), url };
+						return { uri: URI.parse(url), originalUrl: url };
 					} catch (err) {
 						return null;
 					}

--- a/src/vs/platform/url/electron-main/electronUrlListener.ts
+++ b/src/vs/platform/url/electron-main/electronUrlListener.ts
@@ -34,17 +34,19 @@ export class ElectronURLListener {
 	private readonly disposables = new DisposableStore();
 
 	constructor(
-		initialProtocolUrls: IProtocolUrl[],
+		initialProtocolUrls: IProtocolUrl[] | undefined,
 		private readonly urlService: IURLService,
 		windowsMainService: IWindowsMainService,
 		environmentMainService: IEnvironmentMainService,
 		productService: IProductService,
 		private readonly logService: ILogService
 	) {
-		logService.trace('ElectronURLListener initialUrisToHandle:', initialProtocolUrls.map(url => url.originalUrl));
+		if (initialProtocolUrls) {
+			logService.trace('ElectronURLListener initialUrisToHandle:', initialProtocolUrls.map(url => url.originalUrl));
 
-		// the initial set of URIs we need to handle once the window is ready
-		this.uris = initialProtocolUrls;
+			// the initial set of URIs we need to handle once the window is ready
+			this.uris = initialProtocolUrls;
+		}
 
 		// Windows: install as protocol handler
 		if (isWindows) {

--- a/src/vs/platform/url/electron-main/electronUrlListener.ts
+++ b/src/vs/platform/url/electron-main/electronUrlListener.ts
@@ -13,7 +13,7 @@ import { IEnvironmentMainService } from 'vs/platform/environment/electron-main/e
 import { ILogService } from 'vs/platform/log/common/log';
 import { IProductService } from 'vs/platform/product/common/productService';
 import { IURLService } from 'vs/platform/url/common/url';
-import { IInitialProtocolUrls, IProtocolUrl } from 'vs/platform/url/electron-main/url';
+import { IProtocolUrl } from 'vs/platform/url/electron-main/url';
 import { IWindowsMainService } from 'vs/platform/windows/electron-main/windows';
 
 /**
@@ -34,17 +34,17 @@ export class ElectronURLListener {
 	private readonly disposables = new DisposableStore();
 
 	constructor(
-		initialProtocolUrls: IInitialProtocolUrls,
+		initialProtocolUrls: IProtocolUrl[],
 		private readonly urlService: IURLService,
 		windowsMainService: IWindowsMainService,
 		environmentMainService: IEnvironmentMainService,
 		productService: IProductService,
 		private readonly logService: ILogService
 	) {
-		logService.trace('ElectronURLListener initialUrisToHandle:', initialProtocolUrls.urls.map(url => url.originalUrl));
+		logService.trace('ElectronURLListener initialUrisToHandle:', initialProtocolUrls.map(url => url.originalUrl));
 
 		// the initial set of URIs we need to handle once the window is ready
-		this.uris = initialProtocolUrls.urls;
+		this.uris = initialProtocolUrls;
 
 		// Windows: install as protocol handler
 		if (isWindows) {

--- a/src/vs/platform/url/electron-main/electronUrlListener.ts
+++ b/src/vs/platform/url/electron-main/electronUrlListener.ts
@@ -13,7 +13,7 @@ import { IEnvironmentMainService } from 'vs/platform/environment/electron-main/e
 import { ILogService } from 'vs/platform/log/common/log';
 import { IProductService } from 'vs/platform/product/common/productService';
 import { IURLService } from 'vs/platform/url/common/url';
-import { IProtocolUrl } from 'vs/platform/url/electron-main/url';
+import { IInitialProtocolUrls, IProtocolUrl } from 'vs/platform/url/electron-main/url';
 import { IWindowsMainService } from 'vs/platform/windows/electron-main/windows';
 
 /**
@@ -34,17 +34,17 @@ export class ElectronURLListener {
 	private readonly disposables = new DisposableStore();
 
 	constructor(
-		initialUrisToHandle: IProtocolUrl[],
+		initialProtocolUrls: IInitialProtocolUrls,
 		private readonly urlService: IURLService,
 		windowsMainService: IWindowsMainService,
 		environmentMainService: IEnvironmentMainService,
 		productService: IProductService,
 		private readonly logService: ILogService
 	) {
-		logService.trace('ElectronURLListener initialUrisToHandle:', initialUrisToHandle.map(initialUri => initialUri.originalUrl));
+		logService.trace('ElectronURLListener initialUrisToHandle:', initialProtocolUrls.urls.map(url => url.originalUrl));
 
 		// the initial set of URIs we need to handle once the window is ready
-		this.uris = initialUrisToHandle;
+		this.uris = initialProtocolUrls.urls;
 
 		// Windows: install as protocol handler
 		if (isWindows) {

--- a/src/vs/platform/url/electron-main/electronUrlListener.ts
+++ b/src/vs/platform/url/electron-main/electronUrlListener.ts
@@ -13,6 +13,7 @@ import { IEnvironmentMainService } from 'vs/platform/environment/electron-main/e
 import { ILogService } from 'vs/platform/log/common/log';
 import { IProductService } from 'vs/platform/product/common/productService';
 import { IURLService } from 'vs/platform/url/common/url';
+import { IProtocolUrl } from 'vs/platform/url/electron-main/url';
 import { IWindowsMainService } from 'vs/platform/windows/electron-main/windows';
 
 /**
@@ -27,20 +28,20 @@ import { IWindowsMainService } from 'vs/platform/windows/electron-main/windows';
  */
 export class ElectronURLListener {
 
-	private uris: { uri: URI; url: string }[] = [];
+	private uris: IProtocolUrl[] = [];
 	private retryCount = 0;
 	private flushDisposable: IDisposable = Disposable.None;
 	private readonly disposables = new DisposableStore();
 
 	constructor(
-		initialUrisToHandle: { uri: URI; url: string }[],
+		initialUrisToHandle: IProtocolUrl[],
 		private readonly urlService: IURLService,
 		windowsMainService: IWindowsMainService,
 		environmentMainService: IEnvironmentMainService,
 		productService: IProductService,
 		private readonly logService: ILogService
 	) {
-		logService.trace('ElectronURLListener initialUrisToHandle:', initialUrisToHandle.map(initialUri => initialUri.url));
+		logService.trace('ElectronURLListener initialUrisToHandle:', initialUrisToHandle.map(initialUri => initialUri.originalUrl));
 
 		// the initial set of URIs we need to handle once the window is ready
 		this.uris = initialUrisToHandle;
@@ -103,14 +104,14 @@ export class ElectronURLListener {
 
 		this.logService.trace('ElectronURLListener#flush(): flushing URLs');
 
-		const uris: { uri: URI; url: string }[] = [];
+		const uris: IProtocolUrl[] = [];
 
 		for (const obj of this.uris) {
-			const handled = await this.urlService.open(obj.uri, { originalUrl: obj.url });
+			const handled = await this.urlService.open(obj.uri, { originalUrl: obj.originalUrl });
 			if (handled) {
-				this.logService.trace('ElectronURLListener#flush(): URL was handled', obj.url);
+				this.logService.trace('ElectronURLListener#flush(): URL was handled', obj.originalUrl);
 			} else {
-				this.logService.trace('ElectronURLListener#flush(): URL was not yet handled', obj.url);
+				this.logService.trace('ElectronURLListener#flush(): URL was not yet handled', obj.originalUrl);
 
 				uris.push(obj);
 			}

--- a/src/vs/platform/url/electron-main/url.ts
+++ b/src/vs/platform/url/electron-main/url.ts
@@ -4,8 +4,35 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { URI } from 'vs/base/common/uri';
+import { IWindowOpenable } from 'vs/platform/window/common/window';
 
 export interface IProtocolUrl {
+
+	/**
+	 * The parsed URI from the raw URL.
+	 */
 	readonly uri: URI;
+
+	/**
+	 * The raw URL that was passed in.
+	 */
 	readonly originalUrl: string;
+}
+
+/**
+ * Protocol URLs that are passed in on startup.
+ */
+export interface IInitialProtocolUrls {
+
+	/**
+	 * Initial protocol URLs to handle that are not
+	 * already converted to `IWindowOpenable` instances.
+	 */
+	readonly urls: IProtocolUrl[];
+
+	/**
+	 * Initial protocol URLs that result in direct
+	 * `IWindowOpenable` instances.
+	 */
+	readonly openables: IWindowOpenable[];
 }

--- a/src/vs/platform/url/electron-main/url.ts
+++ b/src/vs/platform/url/electron-main/url.ts
@@ -4,19 +4,19 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { URI } from 'vs/base/common/uri';
-import { IWindowOpenable, IOpenEmptyWindowOptions } from 'vs/platform/window/common/window';
+import { IWindowOpenable } from 'vs/platform/window/common/window';
 
 export interface IProtocolUrl {
 
 	/**
 	 * The parsed URI from the raw URL.
 	 */
-	readonly uri: URI;
+	uri: URI;
 
 	/**
 	 * The raw URL that was passed in.
 	 */
-	readonly originalUrl: string;
+	originalUrl: string;
 }
 
 /**
@@ -25,19 +25,26 @@ export interface IProtocolUrl {
  * form of the protocol URL:
  *
  * On the high level, there are 2 types of protocol URLs:
- * - those that need to be handled within a window because
- *   they need to be forwarded to an extension for handling
+ * - those that need to be handled within a window for
+ *   example because they need to be forwarded to an
+ *   extension
  * - those that can be handled directly as window to open
  *
- * The former are of the form <protocol>://<extension.id>/<path>
- * and the latter are of the form <protocol>:/<file>/<path> to
- * open local workspaces or files or <protocol>:/<vscode-remote>/<path>
- * for remote ones.
+ * The former are for example of the form:
+ * ```
+ * <protocol>://<extension.id>/<path>
+ * ```
+ * and the latter are of the form
+ *
+ * ```
+ * <protocol>:/<file | vscode-remote>/<path>
+ * ```
  *
  * On top of that, protocol URLs can indicate to be handled in
  * a new empty window or not via the `windowId` parameter. If that
  * parameter is set to `_blank`, the URL should be handled not in
- * the existing window but a new window.
+ * the existing window but a new window. This is only supported
+ * for protocol URLs that need to be handled within a window.
  *
  * This interface splits the protocol links up into the 2 groups:
  * - `urls` are the protocol URLs that need to be handled in a window
@@ -47,27 +54,23 @@ export interface IProtocolUrl {
  * - a URL with authority `file` or `vscode-remote` becomes an `IWindowOpenable`
  *   and will not be included in the `urls` array because it was fully handled
  * - a URL with any other authority will be added to the `urls` array
- * - a URL with `windowId` set to `_blank` will be added to the `openables` as
- *   an `IOpenEmptyWindowOptions` instance unless it is a `file` or `vscode-remote`
- *   authority.
  */
 export interface IInitialProtocolUrls {
 
 	/**
 	 * Initial protocol URLs to handle that are not
-	 * already converted to `IWindowOpenable` or empty
-	 * window instances.
+	 * already converted to `IWindowOpenable` window
+	 * instances.
 	 *
 	 * These URLs will be handled by the URL service
-	 * in the active window (i.e. forwarded to extensions).
+	 * in the active or a new empty window (if `windowId`
+	 * is set to `_blank`).
 	 */
 	readonly urls: IProtocolUrl[];
 
 	/**
 	 * Initial protocol URLs that result in direct
-	 * `IWindowOpenable` or empty instances. These
-	 * are either handled directly by the window
-	 * when opening or within the empty window.
+	 * windows to open.
 	 */
-	readonly openables: (IWindowOpenable | IOpenEmptyWindowOptions)[];
+	readonly openables: IWindowOpenable[] | undefined;
 }

--- a/src/vs/platform/url/electron-main/url.ts
+++ b/src/vs/platform/url/electron-main/url.ts
@@ -1,0 +1,11 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { URI } from 'vs/base/common/uri';
+
+export interface IProtocolUrl {
+	readonly uri: URI;
+	readonly originalUrl: string;
+}

--- a/src/vs/platform/url/electron-main/url.ts
+++ b/src/vs/platform/url/electron-main/url.ts
@@ -26,13 +26,27 @@ export interface IInitialProtocolUrls {
 
 	/**
 	 * Initial protocol URLs to handle that are not
-	 * already converted to `IWindowOpenable` instances.
+	 * already converted to `IWindowOpenable` or empty
+	 * window instances.
+	 *
+	 * These URLs will be handled by the URL service
+	 * in the active window (i.e. forwarded to extensions).
 	 */
 	readonly urls: IProtocolUrl[];
 
 	/**
 	 * Initial protocol URLs that result in direct
-	 * `IWindowOpenable` instances.
+	 * `IWindowOpenable` instances. These are not
+	 * handled within the URL service but directly
+	 * result in a window to open (currently only
+	 * `file` and `vscode-remote` URLs).
 	 */
 	readonly openables: IWindowOpenable[];
+
+	/**
+	 * Initial protocol URLs that result require
+	 * a new window to be handled within (having
+	 * a `windowId` property of `blank`).
+	 */
+	readonly emptyWindows: IProtocolUrl[];
 }

--- a/src/vs/platform/url/electron-main/url.ts
+++ b/src/vs/platform/url/electron-main/url.ts
@@ -20,7 +20,36 @@ export interface IProtocolUrl {
 }
 
 /**
- * Protocol URLs that are passed in on startup.
+ * A special set of protocol URLs that are to be handled
+ * right on startup. Handling is complex depending on the
+ * form of the protocol URL:
+ *
+ * On the high level, there are 2 types of protocol URLs:
+ * - those that need to be handled within a window because
+ *   they need to be forwarded to an extension for handling
+ * - those that can be handled directly as window to open
+ *
+ * The former are of the form <protocol>://<extension.id>/<path>
+ * and the latter are of the form <protocol>:/<file>/<path> to
+ * open local workspaces or files or <protocol>:/<vscode-remote>/<path>
+ * for remote ones.
+ *
+ * On top of that, protocol URLs can indicate to be handled in
+ * a new empty window or not via the `windowId` parameter. If that
+ * parameter is set to `_blank`, the URL should be handled not in
+ * the existing window but a new window.
+ *
+ * This interface splits the protocol links up into the 2 groups:
+ * - `urls` are the protocol URLs that need to be handled in a window
+ * - `openables` are windows that should open for the protocol URLs
+ *
+ * The decision is made as follows:
+ * - a URL with authority `file` or `vscode-remote` becomes an `IWindowOpenable`
+ *   and will not be included in the `urls` array because it was fully handled
+ * - a URL with any other authority will be added to the `urls` array
+ * - a URL with `windowId` set to `_blank` will be added to the `openables` as
+ *   an `IOpenEmptyWindowOptions` instance unless it is a `file` or `vscode-remote`
+ *   authority.
  */
 export interface IInitialProtocolUrls {
 

--- a/src/vs/platform/url/electron-main/url.ts
+++ b/src/vs/platform/url/electron-main/url.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { URI } from 'vs/base/common/uri';
-import { IWindowOpenable } from 'vs/platform/window/common/window';
+import { IWindowOpenable, IOpenEmptyWindowOptions } from 'vs/platform/window/common/window';
 
 export interface IProtocolUrl {
 
@@ -36,17 +36,9 @@ export interface IInitialProtocolUrls {
 
 	/**
 	 * Initial protocol URLs that result in direct
-	 * `IWindowOpenable` instances. These are not
-	 * handled within the URL service but directly
-	 * result in a window to open (currently only
-	 * `file` and `vscode-remote` URLs).
+	 * `IWindowOpenable` or empty instances. These
+	 * are either handled directly by the window
+	 * when opening or within the empty window.
 	 */
-	readonly openables: IWindowOpenable[];
-
-	/**
-	 * Initial protocol URLs that result require
-	 * a new window to be handled within (having
-	 * a `windowId` property of `blank`).
-	 */
-	readonly emptyWindows: IProtocolUrl[];
+	readonly openables: (IWindowOpenable | IOpenEmptyWindowOptions)[];
 }

--- a/src/vs/platform/url/electron-main/url.ts
+++ b/src/vs/platform/url/electron-main/url.ts
@@ -71,5 +71,5 @@ export interface IInitialProtocolUrls {
 	 * Initial protocol URLs that result in direct
 	 * windows to open.
 	 */
-	readonly openables: IWindowOpenable[] | undefined;
+	readonly openables: IWindowOpenable[];
 }

--- a/src/vs/platform/url/electron-main/url.ts
+++ b/src/vs/platform/url/electron-main/url.ts
@@ -25,12 +25,11 @@ export interface IProtocolUrl {
  * form of the protocol URL:
  *
  * On the high level, there are 2 types of protocol URLs:
- * - those that need to be handled within a window for
- *   example because they need to be forwarded to an
- *   extension
+ * - those that need to be handled within a window because
+ *   they need to be forwarded to an extension for example
  * - those that can be handled directly as window to open
  *
- * The former are for example of the form:
+ * The former can be of the form:
  * ```
  * <protocol>://<extension.id>/<path>
  * ```

--- a/src/vs/platform/window/common/window.ts
+++ b/src/vs/platform/window/common/window.ts
@@ -103,6 +103,15 @@ export function isFileToOpen(uriToOpen: IWindowOpenable): uriToOpen is IFileToOp
 	return !!(uriToOpen as IFileToOpen).fileUri;
 }
 
+export function isWindowOpenable(obj: unknown): obj is IWindowOpenable {
+	if (!obj) {
+		return false;
+	}
+
+	const candidate = obj as IWindowOpenable;
+	return isWorkspaceToOpen(candidate) || isFolderToOpen(candidate) || isFileToOpen(candidate);
+}
+
 export type MenuBarVisibility = 'classic' | 'visible' | 'toggle' | 'hidden' | 'compact';
 
 export function getMenuBarVisibility(configurationService: IConfigurationService): MenuBarVisibility {

--- a/src/vs/platform/window/common/window.ts
+++ b/src/vs/platform/window/common/window.ts
@@ -103,15 +103,6 @@ export function isFileToOpen(uriToOpen: IWindowOpenable): uriToOpen is IFileToOp
 	return !!(uriToOpen as IFileToOpen).fileUri;
 }
 
-export function isWindowOpenable(obj: unknown): obj is IWindowOpenable {
-	if (!obj) {
-		return false;
-	}
-
-	const candidate = obj as IWindowOpenable;
-	return isWorkspaceToOpen(candidate) || isFolderToOpen(candidate) || isFileToOpen(candidate);
-}
-
 export type MenuBarVisibility = 'classic' | 'visible' | 'toggle' | 'hidden' | 'compact';
 
 export function getMenuBarVisibility(configurationService: IConfigurationService): MenuBarVisibility {

--- a/src/vs/workbench/services/url/electron-sandbox/urlService.ts
+++ b/src/vs/workbench/services/url/electron-sandbox/urlService.ts
@@ -13,6 +13,7 @@ import { InstantiationType, registerSingleton } from 'vs/platform/instantiation/
 import { ProxyChannel } from 'vs/base/parts/ipc/common/ipc';
 import { INativeHostService } from 'vs/platform/native/electron-sandbox/native';
 import { NativeURLService } from 'vs/platform/url/common/urlService';
+import { ILogService } from 'vs/platform/log/common/log';
 
 export interface IRelayOpenURLOptions extends IOpenURLOptions {
 	openToSide?: boolean;
@@ -27,7 +28,8 @@ export class RelayURLService extends NativeURLService implements IURLHandler, IO
 		@IMainProcessService mainProcessService: IMainProcessService,
 		@IOpenerService openerService: IOpenerService,
 		@INativeHostService private readonly nativeHostService: INativeHostService,
-		@IProductService productService: IProductService
+		@IProductService productService: IProductService,
+		@ILogService private readonly logService: ILogService
 	) {
 		super(productService);
 
@@ -66,7 +68,11 @@ export class RelayURLService extends NativeURLService implements IURLHandler, IO
 		const result = await super.open(uri, options);
 
 		if (result) {
+			this.logService.trace('[URL #handleURL()] handled', uri.toString(true));
+
 			await this.nativeHostService.focusWindow({ force: true /* Application may not be active */ });
+		} else {
+			this.logService.trace('[URL #handleURL()] not handled', uri.toString(true));
 		}
 
 		return result;

--- a/src/vs/workbench/services/url/electron-sandbox/urlService.ts
+++ b/src/vs/workbench/services/url/electron-sandbox/urlService.ts
@@ -68,11 +68,11 @@ export class RelayURLService extends NativeURLService implements IURLHandler, IO
 		const result = await super.open(uri, options);
 
 		if (result) {
-			this.logService.trace('[URL #handleURL()] handled', uri.toString(true));
+			this.logService.trace('URLService#handleURL(): handled', uri.toString(true));
 
 			await this.nativeHostService.focusWindow({ force: true /* Application may not be active */ });
 		} else {
-			this.logService.trace('[URL #handleURL()] not handled', uri.toString(true));
+			this.logService.trace('URLService#handleURL(): not handled', uri.toString(true));
 		}
 
 		return result;


### PR DESCRIPTION
Protocol links can use `windowId=_blank` to indicate that they want a fresh window to be handled in. This works fine in most cases except when VS Code is not running. In that case, we first restore the previous session only then to open another empty window to handle the protocol link in. A better solution is to open an empty window right from the beginning and then handle the link in there.

The code that deals with protocol links is incredibly complex and spaghetti.  Will try to cleanup the existing implementation but will resort to explanatory comments in most cases where cleanup is not helping reduce complexity.

Refs: https://github.com/github/codespaces/issues/9792