### PR TITLE
fix terminal toolbar reset menu visibility

### DIFF
--- a/src/vs/platform/actions/browser/toolbar.ts
+++ b/src/vs/platform/actions/browser/toolbar.ts
@@ -114,7 +114,6 @@ export class WorkbenchToolBar extends ToolBar {
 
 		const extraSecondary: IAction[] = [];
 
-		let someAreHidden = false;
 		// unless disabled, move all hidden items to secondary group or ignore them
 		if (this._options?.hiddenItemStrategy !== HiddenItemStrategy.NoHide) {
 			for (let i = 0; i < primary.length; i++) {
@@ -132,7 +131,6 @@ export class WorkbenchToolBar extends ToolBar {
 
 				// hidden items move into overflow or ignore
 				if (action.hideActions.isHidden) {
-					someAreHidden = true;
 					primary[i] = undefined!;
 					if (this._options?.hiddenItemStrategy !== HiddenItemStrategy.Ignore) {
 						extraSecondary[i] = action;
@@ -197,7 +195,7 @@ export class WorkbenchToolBar extends ToolBar {
 				if (this._options?.resetMenu && !menuIds) {
 					menuIds = [this._options.resetMenu];
 				}
-				if (someAreHidden && menuIds) {
+				if (menuIds) {
 					actions.push(new Separator());
 					actions.push(toAction({
 						id: 'resetThisMenu',


### PR DESCRIPTION
Fixes #171187 

I'm solving this issue as a good-first-issue.
I think the ideal case would be considering the default hiddenness of menu items and then not showing the "reset menu" option in that default state. But currently, it doesn't show up the reset menu option when all items are visible (which is not the default state anymore after adding options like "Run active file" which are hidden by default).
Unfortunately, I couldn't find a way to access the `isHiddenByDefault` property in toolbar.ts (where showing or hiding the reset menu option is handled). I think It would be nice if we also have that property in the `IAction` interface so that we can easily detect the default state and then decide whether to show or not show the reset menu option.
For now, the only change in this pr is always showing the reset menu option which I think is at least better than the current state.