### PR TITLE
Set disableLineTextInReferences=true in TS user preferences

### DIFF
--- a/extensions/typescript-language-features/src/languageFeatures/fileConfigurationManager.ts
+++ b/extensions/typescript-language-features/src/languageFeatures/fileConfigurationManager.ts
@@ -193,6 +193,7 @@ export default class FileConfigurationManager extends Disposable {
 			useLabelDetailsInCompletionEntries: true,
 			allowIncompleteCompletions: true,
 			displayPartsForJSDoc: true,
+			disableLineTextInReferences: true,
 			...getInlayHintsPreferences(config),
 		};
 


### PR DESCRIPTION
In https://github.com/microsoft/TypeScript/issues/51017 and https://github.com/microsoft/TypeScript/pull/51081 we introduced this option to speed up references, but then never set it in VS Code. Oops!