### PR TITLE
Label name with `undefined` when the workspace is not named (fix #171402)

### DIFF
--- a/src/vs/workbench/services/label/common/labelService.ts
+++ b/src/vs/workbench/services/label/common/labelService.ts
@@ -6,7 +6,7 @@
 import { localize } from 'vs/nls';
 import { URI } from 'vs/base/common/uri';
 import { IDisposable, Disposable } from 'vs/base/common/lifecycle';
-import { posix, win32 } from 'vs/base/common/path';
+import { posix, sep, win32 } from 'vs/base/common/path';
 import { Emitter } from 'vs/base/common/event';
 import { Extensions as WorkbenchExtensions, IWorkbenchContributionsRegistry, IWorkbenchContribution } from 'vs/workbench/common/contributions';
 import { Registry } from 'vs/platform/registry/common/platform';
@@ -89,7 +89,20 @@ class ResourceLabelFormattersHandler implements IWorkbenchContribution {
 
 	constructor(@ILabelService labelService: ILabelService) {
 		resourceLabelFormattersExtPoint.setHandler((extensions, delta) => {
-			delta.added.forEach(added => added.value.forEach(formatter => {
+			delta.added.forEach(added => added.value.forEach(untrustedFormatter => {
+
+				// We cannot trust that the formatter as it comes from an extension
+				// adheres to our interface, so for the required properties we fill
+				// in some defaults if missing.
+
+				const formatter = { ...untrustedFormatter };
+				if (typeof formatter.formatting.label !== 'string') {
+					formatter.formatting.label = '${authority}${path}';
+				}
+				if (typeof formatter.formatting.separator !== `string`) {
+					formatter.formatting.separator = sep;
+				}
+
 				if (!isProposedApiEnabled(added.description, 'contribLabelFormatterWorkspaceTooltip') && formatter.formatting.workspaceTooltip) {
 					formatter.formatting.workspaceTooltip = undefined; // workspaceTooltip is only proposed
 				}


### PR DESCRIPTION
@isidorn @aeschli fyi, an extension is not enforced to provide the `separator` option and the vscode test web extension does not:

https://github.com/microsoft/vscode-test-web/blob/main/fs-provider/package.json#L23

I think we cannot trust the values from the extension and thus need to fill in defaults for the required types we have.