### PR TITLE
Prep for list view custom impl.

### DIFF
--- a/src/vs/base/browser/ui/list/listView.ts
+++ b/src/vs/base/browser/ui/list/listView.ts
@@ -212,6 +212,52 @@ class ListViewAccessibilityProvider<T> implements Required<IListViewAccessibilit
 	}
 }
 
+export interface IListView<T> extends ISpliceable<T>, IDisposable {
+	readonly domId: string;
+	readonly domNode: HTMLElement;
+	readonly containerDomNode: HTMLElement;
+	readonly scrollableElementDomNode: HTMLElement;
+	readonly length: number;
+	readonly contentHeight: number;
+	readonly onDidChangeContentHeight: Event<number>;
+	readonly renderHeight: number;
+	readonly scrollHeight: number;
+	readonly firstVisibleIndex: number;
+	readonly lastVisibleIndex: number;
+	onDidScroll: Event<ScrollEvent>;
+	onWillScroll: Event<ScrollEvent>;
+	onMouseClick: Event<IListMouseEvent<T>>;
+	onMouseDblClick: Event<IListMouseEvent<T>>;
+	onMouseMiddleClick: Event<IListMouseEvent<T>>;
+	onMouseUp: Event<IListMouseEvent<T>>;
+	onMouseDown: Event<IListMouseEvent<T>>;
+	onMouseOver: Event<IListMouseEvent<T>>;
+	onMouseMove: Event<IListMouseEvent<T>>;
+	onMouseOut: Event<IListMouseEvent<T>>;
+	onContextMenu: Event<IListMouseEvent<T>>;
+	onTouchStart: Event<IListTouchEvent<T>>;
+	onTap: Event<IListGestureEvent<T>>;
+	element(index: number): T;
+	domElement(index: number): HTMLElement | null;
+	getElementDomId(index: number): string;
+	elementHeight(index: number): number;
+	elementTop(index: number): number;
+	indexOf(element: T): number;
+	indexAt(position: number): number;
+	indexAfter(position: number): number;
+	updateOptions(options: IListViewOptionsUpdate): void;
+	getScrollTop(): number;
+	setScrollTop(scrollTop: number, reuseAnimation?: boolean): void;
+	getScrollLeft(): number;
+	setScrollLeft(scrollLeft: number): void;
+	delegateScrollFromMouseWheelEvent(browserEvent: IMouseWheelEvent): void;
+	delegateVerticalScrollbarPointerDown(browserEvent: PointerEvent): void;
+	updateWidth(index: number): void;
+	updateElementHeight(index: number, size: number | undefined, anchorIndex: number | null): void;
+	rerender(): void;
+	layout(height?: number, width?: number): void;
+}
+
 /**
  * The {@link ListView} is a virtual scrolling engine.
  *
@@ -222,7 +268,7 @@ class ListViewAccessibilityProvider<T> implements Required<IListViewAccessibilit
  * @remarks It is a low-level widget, not meant to be used directly. Refer to the
  * List widget instead.
  */
-export class ListView<T> implements ISpliceable<T>, IDisposable {
+export class ListView<T> implements IListView<T> {
 
 	private static InstanceCount = 0;
 	readonly domId = `list_id_${++ListView.InstanceCount}`;

--- a/src/vs/base/browser/ui/list/listWidget.ts
+++ b/src/vs/base/browser/ui/list/listWidget.ts
@@ -28,7 +28,7 @@ import { IThemable } from 'vs/base/common/styler';
 import { isNumber } from 'vs/base/common/types';
 import 'vs/css!./list';
 import { IIdentityProvider, IKeyboardNavigationDelegate, IKeyboardNavigationLabelProvider, IListContextMenuEvent, IListDragAndDrop, IListDragOverReaction, IListEvent, IListGestureEvent, IListMouseEvent, IListRenderer, IListTouchEvent, IListVirtualDelegate, ListError } from './list';
-import { IListViewAccessibilityProvider, IListViewDragAndDrop, IListViewOptions, IListViewOptionsUpdate, ListView } from './listView';
+import { IListView, IListViewAccessibilityProvider, IListViewDragAndDrop, IListViewOptions, IListViewOptionsUpdate, ListView } from './listView';
 
 interface ITraitChangeEvent {
 	indexes: number[];
@@ -222,7 +222,7 @@ class TraitSpliceable<T> implements ISpliceable<T> {
 
 	constructor(
 		private trait: Trait<T>,
-		private view: ListView<T>,
+		private view: IListView<T>,
 		private identityProvider?: IIdentityProvider<T>
 	) { }
 
@@ -289,7 +289,7 @@ class KeyboardController<T> implements IDisposable {
 
 	constructor(
 		private list: List<T>,
-		private view: ListView<T>,
+		private view: IListView<T>,
 		options: IListOptions<T>
 	) {
 		this.onKeyDown.filter(e => e.keyCode === KeyCode.Enter).on(this.onEnter, this, this.disposables);
@@ -421,7 +421,7 @@ class TypeNavigationController<T> implements IDisposable {
 
 	constructor(
 		private list: List<T>,
-		private view: ListView<T>,
+		private view: IListView<T>,
 		private keyboardNavigationLabelProvider: IKeyboardNavigationLabelProvider<T>,
 		private keyboardNavigationEventFilter: IKeyboardNavigationEventFilter,
 		private delegate: IKeyboardNavigationDelegate
@@ -535,7 +535,7 @@ class DOMFocusController<T> implements IDisposable {
 
 	constructor(
 		private list: List<T>,
-		private view: ListView<T>
+		private view: IListView<T>
 	) {
 		const onKeyDown = this.disposables.add(Event.chain(this.disposables.add(new DomEmitter(view.domNode, 'keydown')).event))
 			.filter(e => !isInputElement(e.target as HTMLElement))
@@ -1247,7 +1247,7 @@ export class List<T> implements ISpliceable<T>, IThemable, IDisposable {
 	private selection: Trait<T>;
 	private anchor = new Trait<T>('anchor');
 	private eventBufferer = new EventBufferer();
-	protected view: ListView<T>;
+	protected view: IListView<T>;
 	private spliceable: ISpliceable<T>;
 	private styleController: IStyleController;
 	private typeNavigationController?: TypeNavigationController<T>;
@@ -1358,7 +1358,7 @@ export class List<T> implements ISpliceable<T>, IThemable, IDisposable {
 			dnd: _options.dnd && new ListViewDragAndDrop(this, _options.dnd)
 		};
 
-		this.view = new ListView(container, virtualDelegate, renderers, viewOptions);
+		this.view = this.createListView(container, virtualDelegate, renderers, viewOptions);
 		this.view.domNode.setAttribute('role', role);
 
 		if (_options.styleController) {
@@ -1407,6 +1407,10 @@ export class List<T> implements ISpliceable<T>, IThemable, IDisposable {
 		if (this._options.multipleSelectionSupport !== false) {
 			this.view.domNode.setAttribute('aria-multiselectable', 'true');
 		}
+	}
+
+	protected createListView(container: HTMLElement, virtualDelegate: IListVirtualDelegate<T>, renderers: IListRenderer<any, any>[], viewOptions: IListViewOptions<T>): IListView<T> {
+		return new ListView(container, virtualDelegate, renderers, viewOptions);
 	}
 
 	protected createMouseController(options: IListOptions<T>): MouseController<T> {

--- a/src/vs/workbench/contrib/notebook/browser/view/notebookCellList.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/notebookCellList.ts
@@ -1173,7 +1173,7 @@ export class NotebookCellList extends WorkbenchList<CellViewModel> implements ID
 		// the `element` is in the viewport, it's very often that the height update is triggerred by user interaction (collapse, run cell)
 		// then we should make sure that the `element`'s visual view position doesn't change.
 
-		if (this.view.elementTop(index) >= this.view.scrollTop) {
+		if (this.view.elementTop(index) >= this.view.getScrollTop()) {
 			return this.view.updateElementHeight(index, size, index);
 		}
 


### PR DESCRIPTION
Re #170881.

The motivation of building notebook specific list view is majorly allowing us to move quicker by tweaking the list view without worrying affecting other list view users or being restricted by the current design of the list view while we are still exploring ideas, including but not limited to

* Add sufficient logging to help us understand how cells are rendered/updated in different phases/scenarios (scroll, layout, element height change)
* Not limited by current dynamic height check logic (`_rerender`) and also find the right/best rendering logic for notebook cells
* Avoid expsoing more internals to public while exploring rendering optimizations
* Look into opportunities for aligning cell rendering phases (e.g., render monaco editors for all visible cells at the same time)

If possible, we want to keep a single version of `ListView` impl in VS Code. When we see an optimization that should be adopted in current `ListView` we would do so. At the end of the exploration, we should sit together with @joaomoreno and revisit our learnings and decide what's the best way forward: either we unify them, or the notebook list view `extends ListView`, or the notebook list view has its own very special impl.



<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
