### PR TITLE
Remove redundant cell layout updates

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
@@ -980,7 +980,7 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditorD
 
 	private _registerNotebookActionsToolbar() {
 		this._notebookTopToolbar = this._register(this.instantiationService.createInstance(NotebookEditorToolbar, this, this.scopedContextKeyService, this._notebookOptions, this._notebookTopToolbarContainer));
-		this._register(this._notebookTopToolbar.onDidChangeState(() => {
+		this._register(this._notebookTopToolbar.onDidChangeVisibility(() => {
 			if (this._dimension && this._isVisible) {
 				this.layout(this._dimension);
 			}
@@ -1457,7 +1457,8 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditorD
 		const store = new DisposableStore();
 
 		store.add(cell.onDidChangeLayout(e => {
-			if (e.totalHeight !== undefined || e.outerWidth) {
+			// e.totalHeight will be false it's not changed
+			if (e.totalHeight || e.outerWidth) {
 				this.layoutNotebookCell(cell, cell.layoutInfo.totalHeight, e.context);
 			}
 		}));

--- a/src/vs/workbench/contrib/notebook/browser/view/cellParts/codeCell.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/cellParts/codeCell.ts
@@ -239,10 +239,6 @@ export class CodeCell extends Disposable {
 					this.onCellWidthChange();
 				}
 			}
-
-			if (e.totalHeight) {
-				this.relayoutCell();
-			}
 		}));
 	}
 

--- a/src/vs/workbench/contrib/notebook/browser/view/cellParts/markupCell.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/cellParts/markupCell.ts
@@ -170,8 +170,6 @@ export class MarkupCell extends Disposable {
 			const layoutInfo = this.editor?.getLayoutInfo();
 			if (e.outerWidth && this.viewCell.getEditState() === CellEditState.Editing && layoutInfo && layoutInfo.width !== this.viewCell.layoutInfo.editorWidth) {
 				this.onCellEditorWidthChange();
-			} else if (e.totalHeight || e.outerWidth) {
-				this.relayoutCell();
 			}
 		}));
 

--- a/src/vs/workbench/contrib/notebook/browser/viewModel/codeCellViewModel.ts
+++ b/src/vs/workbench/contrib/notebook/browser/viewModel/codeCellViewModel.ts
@@ -50,8 +50,11 @@ export class CodeCellViewModel extends BaseCellViewModel implements ICellViewMod
 
 	private _editorHeight = 0;
 	set editorHeight(height: number) {
-		this._editorHeight = height;
+		if (this._editorHeight === height) {
+			return;
+		}
 
+		this._editorHeight = height;
 		this.layoutChange({ editorHeight: true }, 'CodeCellViewModel#editorHeight');
 	}
 

--- a/src/vs/workbench/contrib/notebook/browser/viewParts/notebookEditorToolbar.ts
+++ b/src/vs/workbench/contrib/notebook/browser/viewParts/notebookEditorToolbar.ts
@@ -274,8 +274,15 @@ export class NotebookEditorToolbar extends Disposable {
 	private _strategy!: IActionLayoutStrategy;
 	private _renderLabel: RenderLabel = RenderLabel.Always;
 
-	private readonly _onDidChangeState = this._register(new Emitter<void>());
-	onDidChangeState: Event<void> = this._onDidChangeState.event;
+	private _visible: boolean = false;
+	set visible(visible: boolean) {
+		if (this._visible !== visible) {
+			this._visible = visible;
+			this._onDidChangeVisibility.fire(visible);
+		}
+	}
+	private readonly _onDidChangeVisibility = this._register(new Emitter<boolean>());
+	onDidChangeVisibility: Event<boolean> = this._onDidChangeVisibility.event;
 
 	get useGlobalToolbar(): boolean {
 		return this._useGlobalToolbar;
@@ -492,6 +499,7 @@ export class NotebookEditorToolbar extends Disposable {
 		if (!this.notebookEditor.hasModel()) {
 			this._deferredActionUpdate?.dispose();
 			this._deferredActionUpdate = undefined;
+			this.visible = false;
 			return;
 		}
 
@@ -502,12 +510,12 @@ export class NotebookEditorToolbar extends Disposable {
 		if (!this._useGlobalToolbar) {
 			this.domNode.style.display = 'none';
 			this._deferredActionUpdate = undefined;
-			this._onDidChangeState.fire();
+			this.visible = false;
 		} else {
 			this._deferredActionUpdate = disposableTimeout(async () => {
 				await this._setNotebookActions();
+				this.visible = true;
 				this._deferredActionUpdate = undefined;
-				this._onDidChangeState.fire();
 			}, 50);
 		}
 	}


### PR DESCRIPTION
Though redundant layout updates are removed, it's making it hard for us to understand when resize happens and why.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
