### PR TITLE
Demonstrate how notebook localization can work

### DIFF
--- a/extensions/markdown-math/esbuild.js
+++ b/extensions/markdown-math/esbuild.js
@@ -33,6 +33,7 @@ async function build() {
 		outdir: outDir,
 		platform: 'browser',
 		target: ['es2020'],
+		external: ['vscode']
 	});
 
 	fse.copySync(

--- a/extensions/markdown-math/notebook/katex.ts
+++ b/extensions/markdown-math/notebook/katex.ts
@@ -4,6 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 import type * as markdownIt from 'markdown-it';
 import type { RendererContext } from 'vscode-notebook-renderer';
+import * as vscode from 'vscode';
+
+console.log(vscode);
 
 const styleHref = import.meta.url.replace(/katex.js$/, 'katex.min.css');
 

--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView.ts
@@ -271,7 +271,7 @@ export class BackLayerWebView<T extends ICommonCellInfo> extends Themable {
 			lineLimit: this.options.outputLineLimit,
 			outputScrolling: this.options.outputScrolling
 		};
-		const preloadScript = preloadsScriptStr(
+		const preloadScripts = preloadsScriptStr(
 			this.options,
 			{ dragAndDropEnabled: this.options.dragAndDropEnabled },
 			renderOptions,
@@ -445,7 +445,9 @@ export class BackLayerWebView<T extends ICommonCellInfo> extends Themable {
 				<div id='findStart' tabIndex=-1></div>
 				<div id='container' class="widgetarea" style="position: absolute;width:100%;top: 0px"></div>
 				<div id="_defaultColorPalatte"></div>
-				<script type="module">${preloadScript}</script>
+				${Array.from(preloadScripts, script => {
+					return `<script type="${script.module ? 'module' : ''}">${script.source}</script>`;
+				}).join('\n')}
 			</body>
 		</html>`;
 	}

--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewPreloads.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewPreloads.ts
@@ -2440,14 +2440,15 @@ async function webviewImportMap(rendererData: readonly webviewMessages.RendererM
 	const scopes: Record<string, Record<string, string>> = {};
 
 	for (const renderer of rendererData) {
-		const script = ` export const abc = 'hello ' + '${renderer.id}';`;
+		const script = `export const l10n = Object.freeze({
+			t(message) { return message; }
+		});`;
 
 		const blob = new Blob([script], { type: 'application/javascript' });
 		const scriptUrl = URL.createObjectURL(blob);
 
-		// TODO: the entrypoint should likely be broader so the the import maps also works
-		// in files that the main script imports
-		scopes[renderer.entrypoint.path] = {
+		const scope = renderer.entrypoint.path.replace(/\/[^\/]+\.js$/i, '/');
+		scopes[scope] = {
 			'vscode': scriptUrl
 		};
 	}


### PR DESCRIPTION
For #170919

This shows how we can use an [importmap](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script/type/importmap) to create an api that is specific to each renderer in a notebook. This lets a renderer write:

```ts
import * as vscode from 'vscode'
```

and get back a version of that api that is specific to that renderer, even though multiple different renderers may be running in the same notebook webview

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
