### PR TITLE
div outputs scrollable, register scroll setting

### DIFF
--- a/extensions/notebook-renderers/src/index.ts
+++ b/extensions/notebook-renderers/src/index.ts
@@ -252,7 +252,7 @@ export const activate: ActivationFunction<void> = (ctx) => {
 	.traceback {
 		word-wrap: break-word;
 	}
-	.output > span.scrollable {
+	.output > .scrollable {
 		overflow-y: scroll;
 		max-height: var(--notebook-cell-output-max-height);
 		border: var(--vscode-editorWidget-border);

--- a/src/vs/workbench/contrib/notebook/browser/notebook.contribution.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebook.contribution.ts
@@ -923,6 +923,13 @@ configurationRegistry.registerConfiguration({
 			],
 			tags: ['notebookLayout'],
 			default: 'all'
+		},
+		[NotebookSetting.outputScrolling]: {
+			markdownDescription: nls.localize('notebook.outputScrolling', "Use a scrollable region for notebook output when longer than the limit"),
+			type: 'boolean',
+			default: false
 		}
 	}
 });
+
+


### PR DESCRIPTION
fixes https://github.com/microsoft/vscode-jupyter/issues/12558

plaintext output mime types are rendered inside of divs, not spans, so just remove that specificity.
Also register the output scrolling setting so that it can be found in the UI
