### PR TITLE
Update Razor repo

### DIFF
--- a/extensions/razor/build/update-grammar.mjs
+++ b/extensions/razor/build/update-grammar.mjs
@@ -11,7 +11,7 @@ function patchGrammar(grammar) {
 	return grammar;
 }
 
-const razorGrammarRepo = 'dotnet/razor-tooling';
+const razorGrammarRepo = 'dotnet/razor';
 const grammarPath = 'src/Razor/src/Microsoft.AspNetCore.Razor.VSCode.Extension/syntaxes/aspnetcorerazor.tmLanguage.json';
 vscodeGrammarUpdater.update(razorGrammarRepo, grammarPath, './syntaxes/cshtml.tmLanguage.json', grammar => patchGrammar(grammar), 'main');
 

--- a/extensions/razor/cgmanifest.json
+++ b/extensions/razor/cgmanifest.json
@@ -4,8 +4,8 @@
 			"component": {
 				"type": "git",
 				"git": {
-					"name": "dotnet/razor-tooling",
-					"repositoryUrl": "https://github.com/dotnet/razor-tooling",
+					"name": "dotnet/razor",
+					"repositoryUrl": "https://github.com/dotnet/razor",
 					"commitHash": "8d0ae9664cb27276eab36d83e48e88356468ca67"
 				}
 			},


### PR DESCRIPTION
We recently renamed our repo, and forgot to tell you. Sorry :)

I assume you would have found this out whenever this script next ran, or maybe GitHub's URL redirection is good enough that you never would have known, but either way this seems better.