### PR TITLE
build: fix win32 signed cli archive

### DIFF
--- a/build/azure-pipelines/cli/cli-win32-sign.yml
+++ b/build/azure-pipelines/cli/cli-win32-sign.yml
@@ -56,7 +56,7 @@ steps:
 
       - task: ArchiveFiles@2
         inputs:
-          rootFolderOrFile: $(Build.ArtifactStagingDirectory)/sign/${{ target }}/code.exe
+          rootFolderOrFile: $(Build.ArtifactStagingDirectory)/sign/${{ target }}
           includeRootFolder: false
           archiveType: zip
           archiveFile: $(Build.ArtifactStagingDirectory)/$(ASSET_ID).zip


### PR DESCRIPTION
includeRootFolder is false anyway, so this should result in the same output