### PR TITLE
Fix undesired button reordering.

### DIFF
--- a/src/vs/workbench/services/dialogs/browser/fileDialogService.ts
+++ b/src/vs/workbench/services/dialogs/browser/fileDialogService.ts
@@ -232,7 +232,7 @@ export class FileDialogService extends AbstractFileDialogService implements IFil
 			buttons,
 			{
 				detail: localize('unsupportedBrowserDetail', "Your browser doesn't support opening local folders.\nYou can either open single files or open a remote repository."),
-				cancelId: -1 // no "Cancel" button offered
+				cancelId: undefined // no "Cancel" button offered
 			}
 		);
 


### PR DESCRIPTION
A `cancelId` that is `!== undefined` and `< buttons.length` will cause the buttons to be reordered. Specifically, `-1` is interprecated as "the last element" by `Array.prototype.splice`, causing the last button ("Open files" or "Learn more") to be moved to the second last position (see also #170492). Passing `undefined` is the correct way to indicate "no cancel button offered", which according to the comment was the authors intent.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
