### PR TITLE
Use platform.language more

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -575,17 +575,26 @@ async function resolveNlsConfiguration() {
 		// VS Code moves to Electron 22.
 		// Ref https://github.com/microsoft/vscode/issues/159813
 		// and https://github.com/electron/electron/pull/36035
-		// if ('getPreferredSystemLanguages' in app
-		// 	&& typeof app.getPreferredSystemLanguages === 'function'
-		// 	&& app.getPreferredSystemLanguages().length) {
-		// 	appLocale = app.getPreferredSystemLanguages()[0];
-		// }
+		if (process.platform === 'win32'
+			&& 'getPreferredSystemLanguages' in app
+			&& typeof app.getPreferredSystemLanguages === 'function'
+			&& app.getPreferredSystemLanguages().length) {
+			// Use the most preferred OS language for language recommendation.
+			appLocale = app.getPreferredSystemLanguages()[0];
+		}
+
 		if (!appLocale) {
 			nlsConfiguration = { locale: 'en', availableLanguages: {} };
 		} else {
 
 			// See above the comment about the loader and case sensitiveness
 			appLocale = appLocale.toLowerCase();
+
+			if (appLocale.startsWith('zh-hans')) {
+				appLocale = 'zh-cn';
+			} else if (appLocale.startsWith('zh-hant')) {
+				appLocale = 'zh-tw';
+			}
 
 			const { getNLSConfiguration } = require('./vs/base/node/languagePacks');
 			nlsConfiguration = await getNLSConfiguration(product.commit, userDataPath, metaDataFile, appLocale);

--- a/src/vs/workbench/contrib/comments/browser/timestamp.ts
+++ b/src/vs/workbench/contrib/comments/browser/timestamp.ts
@@ -6,6 +6,7 @@
 import * as dom from 'vs/base/browser/dom';
 import { fromNow } from 'vs/base/common/date';
 import { Disposable } from 'vs/base/common/lifecycle';
+import { language } from 'vs/base/common/platform';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { COMMENTS_SECTION, ICommentsConfiguration } from 'vs/workbench/contrib/comments/common/commentsConfiguration';
 
@@ -62,6 +63,6 @@ export class TimestampWidget extends Disposable {
 	}
 
 	private getDateString(date: Date): string {
-		return date.toLocaleString();
+		return date.toLocaleString(language);
 	}
 }

--- a/src/vs/workbench/contrib/localization/electron-sandbox/localization.contribution.ts
+++ b/src/vs/workbench/contrib/localization/electron-sandbox/localization.contribution.ts
@@ -87,12 +87,7 @@ export class LocalizationWorkbenchContribution extends Disposable implements IWo
 
 	private checkAndInstall(): void {
 		const language = platform.language;
-		let locale = platform.locale ?? '';
-		if (locale.startsWith('zh-hans')) {
-			locale = 'zh-cn';
-		} else if (locale.startsWith('zh-hant')) {
-			locale = 'zh-tw';
-		}
+		const locale = platform.locale ?? '';
 		const languagePackSuggestionIgnoreList = <string[]>JSON.parse(this.storageService.get(LANGUAGEPACK_SUGGESTION_IGNORE_STORAGE_KEY, StorageScope.APPLICATION, '[]'));
 
 		if (!this.galleryService.isEnabled()) {

--- a/src/vs/workbench/contrib/notebook/browser/contrib/cellStatusBar/executionStatusBarItemController.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/cellStatusBar/executionStatusBarItemController.ts
@@ -5,6 +5,7 @@
 
 import { disposableTimeout, RunOnceScheduler } from 'vs/base/common/async';
 import { Disposable, dispose, IDisposable, MutableDisposable } from 'vs/base/common/lifecycle';
+import { language } from 'vs/base/common/platform';
 import { localize } from 'vs/nls';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { themeColorFromId, ThemeIcon } from 'vs/platform/theme/common/themeService';
@@ -272,7 +273,7 @@ class TimerCellStatusBarItem extends Disposable {
 			text: formatCellDuration(duration),
 			alignment: CellStatusbarAlignment.Left,
 			priority: Number.MAX_SAFE_INTEGER - 1,
-			tooltip: isDone ? new Date(endTime).toLocaleString() : undefined
+			tooltip: isDone ? new Date(endTime).toLocaleString(language) : undefined
 		};
 	}
 

--- a/src/vs/workbench/contrib/terminal/common/terminalEnvironment.ts
+++ b/src/vs/workbench/contrib/terminal/common/terminalEnvironment.ts
@@ -14,7 +14,7 @@ import { IConfigurationResolverService } from 'vs/workbench/services/configurati
 import { sanitizeProcessEnvironment } from 'vs/base/common/processes';
 import { ILogService } from 'vs/platform/log/common/log';
 import { IShellLaunchConfig, ITerminalEnvironment, TerminalSettingId, TerminalSettingPrefix, TerminalShellType, WindowsShellType } from 'vs/platform/terminal/common/terminal';
-import { IProcessEnvironment, isWindows, locale, OperatingSystem, platform, Platform } from 'vs/base/common/platform';
+import { IProcessEnvironment, isWindows, language, OperatingSystem, platform, Platform } from 'vs/base/common/platform';
 import { escapeNonWindowsPath, sanitizeCwd } from 'vs/platform/terminal/common/terminalEnvironment';
 import { isString } from 'vs/base/common/types';
 import { ITerminalBackend } from 'vs/workbench/contrib/terminal/common/terminal';
@@ -390,7 +390,7 @@ export async function createTerminalEnvironment(
 		mergeEnvironments(env, shellLaunchConfig.env);
 
 		// Adding other env keys necessary to create the process
-		addTerminalEnvironmentKeys(env, version, locale, detectLocale);
+		addTerminalEnvironmentKeys(env, version, language, detectLocale);
 	}
 	return env;
 }

--- a/src/vs/workbench/contrib/testing/browser/testingOutputTerminalService.ts
+++ b/src/vs/workbench/contrib/testing/browser/testingOutputTerminalService.ts
@@ -6,6 +6,7 @@
 import { DeferredPromise } from 'vs/base/common/async';
 import { Emitter, Event } from 'vs/base/common/event';
 import { Disposable } from 'vs/base/common/lifecycle';
+import { language } from 'vs/base/common/platform';
 import { listenStream } from 'vs/base/common/stream';
 import { isDefined } from 'vs/base/common/types';
 import { localize } from 'vs/nls';
@@ -152,7 +153,7 @@ export class TestingOutputTerminalService implements ITestingOutputTerminalServi
 				}
 
 				const completedAt = result.completedAt ? new Date(result.completedAt) : new Date();
-				const text = localize('runFinished', 'Test run finished at {0}', completedAt.toLocaleString());
+				const text = localize('runFinished', 'Test run finished at {0}', completedAt.toLocaleString(language));
 				output.pushData(`\r\n\r\n\x1b[1m> ${text} <\x1b[0m\r\n\r\n`);
 				output.ended = true;
 				this.revealMarker(terminal, thenSelectMarker);

--- a/src/vs/workbench/contrib/testing/common/testResult.ts
+++ b/src/vs/workbench/contrib/testing/common/testResult.ts
@@ -15,6 +15,7 @@ import { TestCoverage } from 'vs/workbench/contrib/testing/common/testCoverage';
 import { maxPriority, statesInOrder, terminalStatePriorities } from 'vs/workbench/contrib/testing/common/testingStates';
 import { removeAnsiEscapeCodes } from 'vs/base/common/strings';
 import { TestId } from 'vs/workbench/contrib/testing/common/testId';
+import { language } from 'vs/base/common/platform';
 
 export interface ITestRunTaskResults extends ITestRunTask {
 	/**
@@ -286,7 +287,7 @@ export class LiveTestResult implements ITestResult {
 	public readonly onChange = this.changeEmitter.event;
 	public readonly onComplete = this.completeEmitter.event;
 	public readonly tasks: ITestRunTaskResults[] = [];
-	public readonly name = localize('runFinished', 'Test run at {0}', new Date().toLocaleString());
+	public readonly name = localize('runFinished', 'Test run at {0}', new Date().toLocaleString(language));
 
 	/**
 	 * @inheritdoc


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
Ref #169114

I added the `platform.language` variable in more parts of the code. That variable allows functions such as `.toLocaleString()` to use the application language instead of the system language. The PR also changes the terminal to use the `platform.language` variable, because in older versions, it was using the application language rather than the system language to create a valid locale to use.

Some examples of `toLocaleString` for reference:
```
> const n = 5;
'5'
> n.toLocaleString('en-US')
'5'
> n.toLocaleString('en-US.UTF8')
Uncaught RangeError: Incorrect locale information provided
    at Number.toLocaleString (<anonymous>)
> n.toLocaleString('en_US.UTF8')
Uncaught RangeError: Incorrect locale information provided
    at Number.toLocaleString (<anonymous>)
> n.toLocaleString('qps-ploc')
'5'
> n.toLocaleString('qps-ploc')
'5'
> n.toLocaleString('zh-hans')
'5'
> n.toLocaleString('zh-hans-cn')
'5'
> n.toLocaleString('zh-cn')
'5'
```
`platform.language` has the form `zh-cn`, `qps-ploc`, `en`, etc., so we should be good for the `.toLocaleString()` calls.