### PR TITLE
Don't remove VSCODE_PORTABLE from process env

### DIFF
--- a/src/vs/base/common/processes.ts
+++ b/src/vs/base/common/processes.ts
@@ -108,7 +108,7 @@ export function sanitizeProcessEnvironment(env: IProcessEnvironment, ...preserve
 	}, {} as Record<string, boolean>);
 	const keysToRemove = [
 		/^ELECTRON_.+$/,
-		/^VSCODE_(?!SHELL_LOGIN).+$/,
+		/^VSCODE_(?!(PORTABLE|SHELL_LOGIN)).+$/,
 		/^SNAP(|_.*)$/,
 		/^GDK_PIXBUF_.+$/,
 	];

--- a/src/vs/base/test/common/processes.test.ts
+++ b/src/vs/base/test/common/processes.test.ts
@@ -19,7 +19,7 @@ suite('Processes', () => {
 			VSCODE_DEV: 'x',
 			VSCODE_IPC_HOOK: 'x',
 			VSCODE_NLS_CONFIG: 'x',
-			VSCODE_PORTABLE: 'x',
+			VSCODE_PORTABLE: '3',
 			VSCODE_PID: 'x',
 			VSCODE_SHELL_LOGIN: '1',
 			VSCODE_CODE_CACHE_PATH: 'x',
@@ -30,6 +30,7 @@ suite('Processes', () => {
 		processes.sanitizeProcessEnvironment(env);
 		assert.strictEqual(env['FOO'], 'bar');
 		assert.strictEqual(env['VSCODE_SHELL_LOGIN'], '1');
+		assert.strictEqual(env['VSCODE_PORTABLE'], '3');
 		assert.strictEqual(Object.keys(env).length, 2);
 	});
 });

--- a/src/vs/base/test/common/processes.test.ts
+++ b/src/vs/base/test/common/processes.test.ts
@@ -31,6 +31,6 @@ suite('Processes', () => {
 		assert.strictEqual(env['FOO'], 'bar');
 		assert.strictEqual(env['VSCODE_SHELL_LOGIN'], '1');
 		assert.strictEqual(env['VSCODE_PORTABLE'], '3');
-		assert.strictEqual(Object.keys(env).length, 2);
+		assert.strictEqual(Object.keys(env).length, 3);
 	});
 });


### PR DESCRIPTION
Fixes #171230
