### PR TITLE
Fix incorrect locale value in argv.json

### DIFF
--- a/src/vs/workbench/contrib/localization/electron-sandbox/localization.contribution.ts
+++ b/src/vs/workbench/contrib/localization/electron-sandbox/localization.contribution.ts
@@ -89,7 +89,7 @@ export class LocalizationWorkbenchContribution extends Disposable implements IWo
 
 	private checkAndInstall(): void {
 		const language = platform.language;
-		const locale = platform.locale ?? '';
+		let locale = platform.locale ?? '';
 		const languagePackSuggestionIgnoreList = <string[]>JSON.parse(this.storageService.get(LANGUAGEPACK_SUGGESTION_IGNORE_STORAGE_KEY, StorageScope.APPLICATION, '[]'));
 
 		if (!this.galleryService.isEnabled()) {
@@ -108,12 +108,11 @@ export class LocalizationWorkbenchContribution extends Disposable implements IWo
 					return;
 				}
 
-				let searchLocale = locale;
-				let tagResult = await this.galleryService.query({ text: `tag:lp-${searchLocale}` }, CancellationToken.None);
+				let tagResult = await this.galleryService.query({ text: `tag:lp-${locale}` }, CancellationToken.None);
 				if (tagResult.total === 0) {
 					// Trim the locale and try again.
-					searchLocale = locale.split('-')[0];
-					tagResult = await this.galleryService.query({ text: `tag:lp-${searchLocale}` }, CancellationToken.None);
+					locale = locale.split('-')[0];
+					tagResult = await this.galleryService.query({ text: `tag:lp-${locale}` }, CancellationToken.None);
 					if (tagResult.total === 0) {
 						return;
 					}
@@ -162,7 +161,7 @@ export class LocalizationWorkbenchContribution extends Disposable implements IWo
 								this.paneCompositeService.openPaneComposite(EXTENSIONS_VIEWLET_ID, ViewContainerLocation.Sidebar, true)
 									.then(viewlet => viewlet?.getViewPaneContainer() as IExtensionsViewPaneContainer)
 									.then(viewlet => {
-										viewlet.search(`tag:lp-${searchLocale}`);
+										viewlet.search(`tag:lp-${locale}`);
 										viewlet.focus();
 									});
 							}

--- a/src/vs/workbench/contrib/localization/electron-sandbox/localization.contribution.ts
+++ b/src/vs/workbench/contrib/localization/electron-sandbox/localization.contribution.ts
@@ -108,6 +108,7 @@ export class LocalizationWorkbenchContribution extends Disposable implements IWo
 					return;
 				}
 
+				const fullLocale = locale;
 				let tagResult = await this.galleryService.query({ text: `tag:lp-${locale}` }, CancellationToken.None);
 				if (tagResult.total === 0) {
 					// Trim the locale and try again.
@@ -125,9 +126,9 @@ export class LocalizationWorkbenchContribution extends Disposable implements IWo
 					return;
 				}
 
-				Promise.all([this.galleryService.getManifest(extensionToFetchTranslationsFrom, CancellationToken.None), this.galleryService.getCoreTranslation(extensionToFetchTranslationsFrom, searchLocale)])
+				Promise.all([this.galleryService.getManifest(extensionToFetchTranslationsFrom, CancellationToken.None), this.galleryService.getCoreTranslation(extensionToFetchTranslationsFrom, locale)])
 					.then(([manifest, translation]) => {
-						const loc = manifest && manifest.contributes && manifest.contributes.localizations && manifest.contributes.localizations.find(x => locale.startsWith(x.languageId.toLowerCase()));
+						const loc = manifest?.contributes?.localizations && manifest.contributes.localizations.find(x => locale.startsWith(x.languageId.toLowerCase()));
 						const languageName = loc ? (loc.languageName || locale) : locale;
 						const languageDisplayName = loc ? (loc.localizedLanguageName || loc.languageName || locale) : locale;
 						const translationsFromPack: { [key: string]: string } = translation?.contents?.['vs/workbench/contrib/localization/electron-sandbox/minimalTranslations'] ?? {};
@@ -187,7 +188,7 @@ export class LocalizationWorkbenchContribution extends Disposable implements IWo
 								label: localize('neverAgain', "Don't Show Again"),
 								isSecondary: true,
 								run: () => {
-									languagePackSuggestionIgnoreList.push(locale);
+									languagePackSuggestionIgnoreList.push(fullLocale);
 									this.storageService.store(
 										LANGUAGEPACK_SUGGESTION_IGNORE_STORAGE_KEY,
 										JSON.stringify(languagePackSuggestionIgnoreList),
@@ -210,9 +211,7 @@ export class LocalizationWorkbenchContribution extends Disposable implements IWo
 	private async isLocaleInstalled(locale: string): Promise<boolean> {
 		const installed = await this.extensionManagementService.getInstalled();
 		return installed.some(i => !!(i.manifest
-			&& i.manifest.contributes
-			&& i.manifest.contributes.localizations
-			&& i.manifest.contributes.localizations.length
+			&& i.manifest.contributes?.localizations?.length
 			&& i.manifest.contributes.localizations.some(l => locale.startsWith(l.languageId.toLowerCase()))));
 	}
 

--- a/src/vs/workbench/contrib/localization/electron-sandbox/localization.contribution.ts
+++ b/src/vs/workbench/contrib/localization/electron-sandbox/localization.contribution.ts
@@ -128,7 +128,7 @@ export class LocalizationWorkbenchContribution extends Disposable implements IWo
 
 				Promise.all([this.galleryService.getManifest(extensionToFetchTranslationsFrom, CancellationToken.None), this.galleryService.getCoreTranslation(extensionToFetchTranslationsFrom, locale)])
 					.then(([manifest, translation]) => {
-						const loc = manifest?.contributes?.localizations && manifest.contributes.localizations.find(x => locale.startsWith(x.languageId.toLowerCase()));
+						const loc = manifest?.contributes?.localizations?.find(x => locale.startsWith(x.languageId.toLowerCase()));
 						const languageName = loc ? (loc.languageName || locale) : locale;
 						const languageDisplayName = loc ? (loc.localizedLanguageName || loc.languageName || locale) : locale;
 						const translationsFromPack: { [key: string]: string } = translation?.contents?.['vs/workbench/contrib/localization/electron-sandbox/minimalTranslations'] ?? {};
@@ -210,9 +210,8 @@ export class LocalizationWorkbenchContribution extends Disposable implements IWo
 
 	private async isLocaleInstalled(locale: string): Promise<boolean> {
 		const installed = await this.extensionManagementService.getInstalled();
-		return installed.some(i => !!(i.manifest
-			&& i.manifest.contributes?.localizations?.length
-			&& i.manifest.contributes.localizations.some(l => locale.startsWith(l.languageId.toLowerCase()))));
+		return installed.some(i => !!i.manifest.contributes?.localizations?.length
+			&& i.manifest.contributes.localizations.some(l => locale.startsWith(l.languageId.toLowerCase())));
 	}
 
 	private installExtension(extension: IGalleryExtension): Promise<void> {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Ref https://github.com/microsoft/vscode/issues/169114

With this change, if the locale value needs to be trimmed, the trimmed locale value gets saved to argv.json instead of the untrimmed one.

For example, let's say platform.locale is "fr-ca", and that we are going through the flow of recommending a language pack. In this case, we first try to search for an extension with the query "tag:lp-fr-ca", which returns no results, so we trim the locale to "fr" and try again. Searching "tag:lp-fr" returns a result, and so we install and download that language pack if the user presses the accept button. However, previous to this commit, the value "fr-ca" gets saved in argv.json rather than "fr".
