### PR TITLE
Fix annoying arrows in screencast mode

### DIFF
--- a/src/vs/workbench/browser/actions/developerActions.ts
+++ b/src/vs/workbench/browser/actions/developerActions.ts
@@ -242,6 +242,8 @@ class ToggleScreencastModeAction extends Action2 {
 					event.ctrlKey || event.altKey || event.metaKey || event.shiftKey
 					|| length > 20
 					|| event.keyCode === KeyCode.Backspace || event.keyCode === KeyCode.Escape
+					|| event.keyCode === KeyCode.ArrowUp || event.keyCode === KeyCode.ArrowDown
+					|| event.keyCode === KeyCode.ArrowLeft || event.keyCode === KeyCode.ArrowRight
 				) {
 					keyboardMarker.innerText = '';
 					length = 0;


### PR DESCRIPTION
Remove the arrows from screencast mode when screencastMode.onlyKeyboardShortcuts is true
