### PR TITLE
support Event.debounce with MicrotaskDelay, extract MicrotaskDelay into (new) symbols.ts, update bulk edit preview models only once per task

### DIFF
--- a/src/vs/base/browser/ui/tree/indexTreeModel.ts
+++ b/src/vs/base/browser/ui/tree/indexTreeModel.ts
@@ -6,7 +6,8 @@
 import { IIdentityProvider } from 'vs/base/browser/ui/list/list';
 import { ICollapseStateChangeEvent, ITreeElement, ITreeFilter, ITreeFilterDataResult, ITreeModel, ITreeModelSpliceEvent, ITreeNode, TreeError, TreeVisibility } from 'vs/base/browser/ui/tree/tree';
 import { splice, tail2 } from 'vs/base/common/arrays';
-import { Delayer, MicrotaskDelay } from 'vs/base/common/async';
+import { Delayer } from 'vs/base/common/async';
+import { MicrotaskDelay } from 'vs/base/common/symbols';
 import { LcsDiff } from 'vs/base/common/diff/diff';
 import { Emitter, Event, EventBufferer } from 'vs/base/common/event';
 import { Iterable } from 'vs/base/common/iterator';

--- a/src/vs/base/common/async.ts
+++ b/src/vs/base/common/async.ts
@@ -10,6 +10,7 @@ import { Disposable, IDisposable, MutableDisposable, toDisposable } from 'vs/bas
 import { extUri as defaultExtUri, IExtUri } from 'vs/base/common/resources';
 import { URI } from 'vs/base/common/uri';
 import { setTimeout0 } from 'vs/base/common/platform';
+import { MicrotaskDelay } from './symbols';
 
 export function isThenable<T>(obj: unknown): obj is Promise<T> {
 	return !!obj && typeof (obj as unknown as Promise<T>).then === 'function';
@@ -273,9 +274,6 @@ const microtaskDeferred = (fn: () => void): IScheduledLater => {
 		dispose: () => { scheduled = false; },
 	};
 };
-
-/** Can be passed into the Delayed to defer using a microtask */
-export const MicrotaskDelay = Symbol('MicrotaskDelay');
 
 /**
  * A helper to delay (debounce) execution of a task that is being requested often.

--- a/src/vs/base/common/symbols.ts
+++ b/src/vs/base/common/symbols.ts
@@ -1,0 +1,9 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * Can be passed into the Delayed to defer using a microtask
+ * */
+export const MicrotaskDelay = Symbol('MicrotaskDelay');

--- a/src/vs/base/test/common/async.test.ts
+++ b/src/vs/base/test/common/async.test.ts
@@ -5,6 +5,7 @@
 
 import * as assert from 'assert';
 import * as async from 'vs/base/common/async';
+import * as MicrotaskDelay from "vs/base/common/symbols";
 import { CancellationToken, CancellationTokenSource } from 'vs/base/common/cancellation';
 import { isCancellationError } from 'vs/base/common/errors';
 import { Event } from 'vs/base/common/event';
@@ -188,7 +189,7 @@ suite('Async', () => {
 				return Promise.resolve(++count);
 			};
 
-			const delayer = new async.Delayer(async.MicrotaskDelay);
+			const delayer = new async.Delayer(MicrotaskDelay.MicrotaskDelay);
 			const promises: Promise<any>[] = [];
 
 			assert(!delayer.isTriggered());
@@ -251,7 +252,7 @@ suite('Async', () => {
 				return Promise.resolve(++count);
 			};
 
-			const delayer = new async.Delayer(async.MicrotaskDelay);
+			const delayer = new async.Delayer(MicrotaskDelay.MicrotaskDelay);
 
 			assert(!delayer.isTriggered());
 

--- a/src/vs/workbench/contrib/bulkEdit/browser/preview/bulkEditPreview.ts
+++ b/src/vs/workbench/contrib/bulkEdit/browser/preview/bulkEditPreview.ts
@@ -24,6 +24,7 @@ import { ResourceEdit, ResourceFileEdit, ResourceTextEdit } from 'vs/editor/brow
 import { Codicon } from 'vs/base/common/codicons';
 import { generateUuid } from 'vs/base/common/uuid';
 import { SnippetParser } from 'vs/editor/contrib/snippet/browser/snippetParser';
+import { MicrotaskDelay } from 'vs/base/common/symbols';
 
 export class CheckedStates<T extends object> {
 
@@ -386,7 +387,7 @@ export class BulkEditPreviewProvider implements ITextModelContentProvider {
 		for (const operation of this._operations.fileOperations) {
 			await this._applyTextEditsToPreviewModel(operation.uri);
 		}
-		this._disposables.add(this._operations.checked.onDidChange(e => {
+		this._disposables.add(Event.debounce(this._operations.checked.onDidChange, (_last, e) => e, MicrotaskDelay)(e => {
 			const uri = this._operations.getUriOfEdit(e);
 			this._applyTextEditsToPreviewModel(uri);
 		}));


### PR DESCRIPTION
(likely) fixes https://github.com/microsoft/vscode/issues/168858
