### PR TITLE
Settings should not show indent guides. Simple fix

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
@@ -2281,23 +2281,27 @@ export class SettingsTree extends WorkbenchObjectTree<SettingsTreeElement> {
 
 		this.getHTMLElement().classList.add('settings-editor-tree');
 
-		this.style(getListStyles({
-			listBackground: editorBackground,
-			listActiveSelectionBackground: editorBackground,
-			listActiveSelectionForeground: foreground,
-			listFocusAndSelectionBackground: editorBackground,
-			listFocusAndSelectionForeground: foreground,
-			listFocusBackground: editorBackground,
-			listFocusForeground: foreground,
-			listHoverForeground: foreground,
-			listHoverBackground: editorBackground,
-			listHoverOutline: editorBackground,
-			listFocusOutline: editorBackground,
-			listInactiveSelectionBackground: editorBackground,
-			listInactiveSelectionForeground: foreground,
-			listInactiveFocusBackground: editorBackground,
-			listInactiveFocusOutline: editorBackground
-		}));
+		this.style({
+			...getListStyles({
+				listBackground: editorBackground,
+				listActiveSelectionBackground: editorBackground,
+				listActiveSelectionForeground: foreground,
+				listFocusAndSelectionBackground: editorBackground,
+				listFocusAndSelectionForeground: foreground,
+				listFocusBackground: editorBackground,
+				listFocusForeground: foreground,
+				listHoverForeground: foreground,
+				listHoverBackground: editorBackground,
+				listHoverOutline: editorBackground,
+				listFocusOutline: editorBackground,
+				listInactiveSelectionBackground: editorBackground,
+				listInactiveSelectionForeground: foreground,
+				listInactiveFocusBackground: editorBackground,
+				listInactiveFocusOutline: editorBackground,
+			}),
+			treeIndentGuidesStroke: undefined,
+			treeInactiveIndentGuidesStroke: undefined,
+		});
 
 		this.disposables.add(configurationService.onDidChangeConfiguration(e => {
 			if (e.affectsConfiguration('workbench.list.smoothScrolling')) {

--- a/src/vs/workbench/contrib/preferences/browser/tocTree.ts
+++ b/src/vs/workbench/contrib/preferences/browser/tocTree.ts
@@ -231,21 +231,27 @@ export class TOCTree extends WorkbenchObjectTree<SettingsTreeGroupElement> {
 			configurationService,
 		);
 
-		this.style(getListStyles({
-			listBackground: editorBackground,
-			listFocusOutline: focusBorder,
-			listActiveSelectionBackground: editorBackground,
-			listActiveSelectionForeground: settingsHeaderForeground,
-			listFocusAndSelectionBackground: editorBackground,
-			listFocusAndSelectionForeground: settingsHeaderForeground,
-			listFocusBackground: editorBackground,
-			listFocusForeground: settingsHeaderHoverForeground,
-			listHoverForeground: settingsHeaderHoverForeground,
-			listHoverBackground: editorBackground,
-			listInactiveSelectionBackground: editorBackground,
-			listInactiveSelectionForeground: settingsHeaderForeground,
-			listInactiveFocusBackground: editorBackground,
-			listInactiveFocusOutline: editorBackground
-		}));
+		this.style({
+			...getListStyles({
+				listBackground: editorBackground,
+				listFocusOutline: focusBorder,
+				listActiveSelectionBackground: editorBackground,
+				listActiveSelectionForeground: settingsHeaderForeground,
+				listFocusAndSelectionBackground: editorBackground,
+				listFocusAndSelectionForeground: settingsHeaderForeground,
+				listFocusBackground: editorBackground,
+				listFocusForeground: settingsHeaderHoverForeground,
+				listHoverForeground: settingsHeaderHoverForeground,
+				listHoverBackground: editorBackground,
+				listInactiveSelectionBackground: editorBackground,
+				listInactiveSelectionForeground: settingsHeaderForeground,
+				listInactiveFocusBackground: editorBackground,
+				listInactiveFocusOutline: editorBackground,
+				treeIndentGuidesStroke: undefined,
+				treeInactiveIndentGuidesStroke: undefined
+			}),
+			treeIndentGuidesStroke: undefined,
+			treeInactiveIndentGuidesStroke: undefined,
+		});
 	}
 }


### PR DESCRIPTION
Fixes #171754

Turns off indent guides by not providing colors, but IMO this should be done with the already existing option.

Better fix is following up, but needs more discussion.