### PR TITLE
fix terminal help menu keybinding for windows/linux

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminalActions.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalActions.ts
@@ -188,8 +188,12 @@ export function registerTerminalActions() {
 					primary: KeyMod.Alt | KeyCode.F1,
 					weight: KeybindingWeight.WorkbenchContrib,
 					linux: {
-						primary: KeyMod.Alt | KeyMod.Shift | KeyCode.F1,
-						secondary: [KeyMod.Alt | KeyCode.F1]
+						primary: KeyMod.Shift | KeyCode.F1,
+						secondary: [KeyMod.Shift | KeyCode.F1]
+					},
+					win: {
+						primary: KeyMod.Shift | KeyCode.F1,
+						secondary: [KeyMod.Shift | KeyCode.F1]
 					},
 					when: TerminalContextKeys.focus
 				}

--- a/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
@@ -1996,7 +1996,12 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 			} else {
 				label = nls.localize('terminalTextBoxAriaLabel', "Terminal {0}", terminalId);
 			}
-			label += this._accessibilityService.isScreenReaderOptimized() ? nls.localize('terminalTextBoxAriaLabelNumberAndTitleAccessibility', "Press alt+f1 for terminal accessibility help") : '';
+			const screenReaderOptimized = this._accessibilityService.isScreenReaderOptimized();
+			if (screenReaderOptimized && isMacintosh) {
+				label += nls.localize('terminalTextBoxAriaLabelMacKeybinding', 'Press alt+f1 for terminal accessibility help');
+			} else if (screenReaderOptimized) {
+				label += nls.localize('terminalTextBoxAriaLabelLinuxWinKeybinding', 'Press shift+f1 for terminal accessibility help');
+			}
 			const navigateUpKeybinding = this._keybindingService.lookupKeybinding(TerminalCommandId.NavigationModeFocusPrevious)?.getLabel();
 			const navigateDownKeybinding = this._keybindingService.lookupKeybinding(TerminalCommandId.NavigationModeFocusNext)?.getLabel();
 			if (navigateUpKeybinding && navigateDownKeybinding) {


### PR DESCRIPTION
alt moves the cursor and that can't be disabled AFAIK for windows/linux, so went with shift+f1 instead

part of #169853