### PR TITLE
Implements experimental inline suggestion hints.

### DIFF
--- a/src/vs/base/browser/dom.ts
+++ b/src/vs/base/browser/dom.ts
@@ -1818,8 +1818,23 @@ export function h(tag: string, ...args: [] | [attributes: { $: string } & Partia
 		el.id = match.groups['id'];
 	}
 
+	const classNames = [];
 	if (match.groups['class']) {
-		el.className = match.groups['class'].replace(/\./g, ' ').trim();
+		for (const className of match.groups['class'].split('.')) {
+			if (className !== '') {
+				classNames.push(className);
+			}
+		}
+	}
+	if (attributes.className !== undefined) {
+		for (const className of attributes.className.split('.')) {
+			if (className !== '') {
+				classNames.push(className);
+			}
+		}
+	}
+	if (classNames.length > 0) {
+		el.className = classNames.join(' ');
 	}
 
 	const result: Record<string, HTMLElement> = {};
@@ -1842,7 +1857,9 @@ export function h(tag: string, ...args: [] | [attributes: { $: string } & Partia
 	}
 
 	for (const [key, value] of Object.entries(attributes)) {
-		if (key === 'style') {
+		if (key === 'className') {
+			continue;
+		} else if (key === 'style') {
 			for (const [cssKey, cssValue] of Object.entries(value)) {
 				el.style.setProperty(
 					camelCaseToHyphenCase(cssKey),

--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -3784,6 +3784,9 @@ export interface IInlineSuggestOptions {
 	 * Defaults to `prefix`.
 	*/
 	mode?: 'prefix' | 'subword' | 'subwordSmart';
+
+	useExperimentalHints?: boolean;
+	hideHints?: boolean;
 }
 
 /**
@@ -3798,7 +3801,9 @@ class InlineEditorSuggest extends BaseEditorOption<EditorOption.inlineSuggest, I
 	constructor() {
 		const defaults: InternalInlineSuggestOptions = {
 			enabled: true,
-			mode: 'subwordSmart'
+			mode: 'subwordSmart',
+			useExperimentalHints: false,
+			hideHints: false,
 		};
 
 		super(
@@ -3808,7 +3813,17 @@ class InlineEditorSuggest extends BaseEditorOption<EditorOption.inlineSuggest, I
 					type: 'boolean',
 					default: defaults.enabled,
 					description: nls.localize('inlineSuggest.enabled', "Controls whether to automatically show inline suggestions in the editor.")
-				}
+				},
+				'editor.inlineSuggest.useExperimentalHints': {
+					type: 'boolean',
+					default: defaults.useExperimentalHints,
+					description: nls.localize('inlineSuggest.useExperimentalHints', "Controls whether to use experimental hints in the editor."),
+				},
+				'editor.inlineSuggest.hideHints': {
+					type: 'boolean',
+					default: defaults.hideHints,
+					description: nls.localize('inlineSuggest.hideHints', "Controls whether to hide hints in the editor."),
+				},
 			}
 		);
 	}
@@ -3821,6 +3836,8 @@ class InlineEditorSuggest extends BaseEditorOption<EditorOption.inlineSuggest, I
 		return {
 			enabled: boolean(input.enabled, this.defaultValue.enabled),
 			mode: stringSet(input.mode, this.defaultValue.mode, ['prefix', 'subword', 'subwordSmart']),
+			useExperimentalHints: boolean(input.useExperimentalHints, this.defaultValue.useExperimentalHints),
+			hideHints: boolean(input.hideHints, this.defaultValue.hideHints),
 		};
 	}
 }

--- a/src/vs/editor/contrib/inlineCompletions/browser/ghostText.contribution.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/ghostText.contribution.ts
@@ -3,55 +3,19 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { KeyCode } from 'vs/base/common/keyCodes';
-import { EditorCommand, EditorContributionInstantiation, registerEditorAction, registerEditorCommand, registerEditorContribution } from 'vs/editor/browser/editorExtensions';
-import { EditorContextKeys } from 'vs/editor/common/editorContextKeys';
+import { EditorContributionInstantiation, registerEditorAction, registerEditorContribution } from 'vs/editor/browser/editorExtensions';
 import { HoverParticipantRegistry } from 'vs/editor/contrib/hover/browser/hoverTypes';
-import { inlineSuggestCommitId } from 'vs/editor/contrib/inlineCompletions/browser/consts';
-import { GhostTextController, AcceptNextWordOfInlineCompletion, ShowNextInlineSuggestionAction, ShowPreviousInlineSuggestionAction, TriggerInlineSuggestionAction } from 'vs/editor/contrib/inlineCompletions/browser/ghostTextController';
+import { AcceptInlineCompletion, AcceptNextWordOfInlineCompletion, DisableSuggestionHints, GhostTextController, HideInlineCompletion, ShowNextInlineSuggestionAction, ShowPreviousInlineSuggestionAction, TriggerInlineSuggestionAction, UndoAcceptPart } from 'vs/editor/contrib/inlineCompletions/browser/ghostTextController';
 import { InlineCompletionsHoverParticipant } from 'vs/editor/contrib/inlineCompletions/browser/ghostTextHoverParticipant';
-import { ContextKeyExpr } from 'vs/platform/contextkey/common/contextkey';
-import { KeybindingsRegistry } from 'vs/platform/keybinding/common/keybindingsRegistry';
 
 registerEditorContribution(GhostTextController.ID, GhostTextController, EditorContributionInstantiation.Eventually);
 registerEditorAction(TriggerInlineSuggestionAction);
 registerEditorAction(ShowNextInlineSuggestionAction);
 registerEditorAction(ShowPreviousInlineSuggestionAction);
 registerEditorAction(AcceptNextWordOfInlineCompletion);
+registerEditorAction(AcceptInlineCompletion);
+registerEditorAction(HideInlineCompletion);
+registerEditorAction(UndoAcceptPart);
+registerEditorAction(DisableSuggestionHints);
 
 HoverParticipantRegistry.register(InlineCompletionsHoverParticipant);
-
-const GhostTextCommand = EditorCommand.bindToContribution(GhostTextController.get);
-
-export const commitInlineSuggestionAction = new GhostTextCommand({
-	id: inlineSuggestCommitId,
-	precondition: GhostTextController.inlineSuggestionVisible,
-	handler(x) {
-		x.commit();
-		x.editor.focus();
-	}
-});
-registerEditorCommand(commitInlineSuggestionAction);
-
-KeybindingsRegistry.registerKeybindingRule({
-	primary: KeyCode.Tab,
-	weight: 200,
-	id: commitInlineSuggestionAction.id,
-	when: ContextKeyExpr.and(
-		commitInlineSuggestionAction.precondition,
-		EditorContextKeys.tabMovesFocus.toNegated(),
-		GhostTextController.inlineSuggestionHasIndentationLessThanTabSize
-	),
-});
-
-registerEditorCommand(new GhostTextCommand({
-	id: 'editor.action.inlineSuggest.hide',
-	precondition: GhostTextController.inlineSuggestionVisible,
-	kbOpts: {
-		weight: 100,
-		primary: KeyCode.Escape,
-	},
-	handler(x) {
-		x.hide();
-	}
-}));

--- a/src/vs/editor/contrib/inlineCompletions/browser/ghostTextHoverParticipant.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/ghostTextHoverParticipant.ts
@@ -21,6 +21,7 @@ import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 import { IOpenerService } from 'vs/platform/opener/common/opener';
 import { inlineSuggestCommitId } from 'vs/editor/contrib/inlineCompletions/browser/consts';
 import { Command } from 'vs/editor/common/languages';
+import { EditorOption } from 'vs/editor/common/config/editorOptions';
 
 export class InlineCompletionsHover implements IHoverPart {
 	constructor(
@@ -37,8 +38,8 @@ export class InlineCompletionsHover implements IHoverPart {
 		);
 	}
 
-	public hasMultipleSuggestions(): Promise<boolean> {
-		return this.controller.hasMultipleInlineCompletions();
+	public getInlineCompletionsCount(): Promise<number> {
+		return this.controller.getInlineCompletionsCount();
 	}
 
 	public get commands(): Command[] {
@@ -58,13 +59,18 @@ export class InlineCompletionsHoverParticipant implements IEditorHoverParticipan
 		@ILanguageService private readonly _languageService: ILanguageService,
 		@IOpenerService private readonly _openerService: IOpenerService,
 		@IAccessibilityService private readonly accessibilityService: IAccessibilityService,
-	) { }
+	) {
+	}
 
 	suggestHoverAnchor(mouseEvent: IEditorMouseEvent): HoverAnchor | null {
 		const controller = GhostTextController.get(this._editor);
 		if (!controller) {
 			return null;
 		}
+		if (this._editor.getOption(EditorOption.inlineSuggest).useExperimentalHints) {
+			return null;
+		}
+
 		const target = mouseEvent.target;
 		if (target.type === MouseTargetType.CONTENT_VIEW_ZONE) {
 			// handle the case where the mouse is over the view zone
@@ -131,9 +137,9 @@ export class InlineCompletionsHoverParticipant implements IEditorHoverParticipan
 		for (const action of actions) {
 			action.setEnabled(false);
 		}
-		part.hasMultipleSuggestions().then(hasMore => {
+		part.getInlineCompletionsCount().then(count => {
 			for (const action of actions) {
-				action.setEnabled(hasMore);
+				action.setEnabled(count > 1);
 			}
 		});
 

--- a/src/vs/editor/contrib/inlineCompletions/browser/ghostTextModel.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/ghostTextModel.ts
@@ -130,9 +130,9 @@ export class GhostTextModel extends DelegatingModel implements GhostTextWidgetMo
 		this.activeInlineCompletionsModel?.showPrevious();
 	}
 
-	public async hasMultipleInlineCompletions(): Promise<boolean> {
-		const result = await this.activeInlineCompletionsModel?.hasMultipleInlineCompletions();
-		return result !== undefined ? result : false;
+	public async getInlineCompletionsCount(): Promise<number> {
+		const result = await this.activeInlineCompletionsModel?.getInlineCompletionsCount();
+		return result ?? 0;
 	}
 }
 

--- a/src/vs/editor/contrib/inlineCompletions/browser/inlineSuggestionHintsWidget.css
+++ b/src/vs/editor/contrib/inlineCompletions/browser/inlineSuggestionHintsWidget.css
@@ -3,8 +3,9 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-export const inlineSuggestCommitId = 'editor.action.inlineSuggest.commit';
-
-export const showPreviousInlineSuggestionActionId = 'editor.action.inlineSuggest.showPrevious';
-
-export const showNextInlineSuggestionActionId = 'editor.action.inlineSuggest.showNext';
+.monaco-editor .inlineSuggestionsHints {
+	z-index: 39;
+	color: var(--vscode-editor-hoverForeground);
+	background-color: var(--vscode-editorHoverWidget-background);
+	border: 1px solid var(--vscode-editorHoverWidget-border);
+}

--- a/src/vs/editor/contrib/inlineCompletions/browser/inlineSuggestionHintsWidget.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/inlineSuggestionHintsWidget.ts
@@ -7,7 +7,7 @@ import { h } from 'vs/base/browser/dom';
 import { ActionBar } from 'vs/base/browser/ui/actionbar/actionbar';
 import { Action } from 'vs/base/common/actions';
 import { Codicon } from 'vs/base/common/codicons';
-import { Disposable } from 'vs/base/common/lifecycle';
+import { Disposable, toDisposable } from 'vs/base/common/lifecycle';
 import { ThemeIcon } from 'vs/base/common/themables';
 import 'vs/css!./inlineSuggestionHintsWidget';
 import { ContentWidgetPositionPreference, ICodeEditor, IContentWidget, IContentWidgetPosition } from 'vs/editor/browser/editorBrowser';
@@ -39,6 +39,7 @@ export class InlineSuggestionHintsWidget extends Disposable {
 		super();
 
 		editor.addContentWidget(this.widget);
+		this._register(toDisposable(() => editor.removeContentWidget(this.widget)));
 		this._register(model.onDidChange(() => this.update()));
 		this._register(editor.onDidChangeConfiguration(() => this.update()));
 		this.update();

--- a/src/vs/editor/contrib/inlineCompletions/browser/inlineSuggestionHintsWidget.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/inlineSuggestionHintsWidget.ts
@@ -12,7 +12,6 @@ import { ThemeIcon } from 'vs/base/common/themables';
 import 'vs/css!./inlineSuggestionHintsWidget';
 import { ContentWidgetPositionPreference, ICodeEditor, IContentWidget, IContentWidgetPosition } from 'vs/editor/browser/editorBrowser';
 import { EditorOption } from 'vs/editor/common/config/editorOptions';
-import { IDimension } from 'vs/editor/common/core/dimension';
 import { Position } from 'vs/editor/common/core/position';
 import { PositionAffinity } from 'vs/editor/common/model';
 import { showNextInlineSuggestionActionId, showPreviousInlineSuggestionActionId } from 'vs/editor/contrib/inlineCompletions/browser/consts';

--- a/src/vs/editor/contrib/inlineCompletions/browser/inlineSuggestionHintsWidget.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/inlineSuggestionHintsWidget.ts
@@ -1,0 +1,179 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { h } from 'vs/base/browser/dom';
+import { ActionBar } from 'vs/base/browser/ui/actionbar/actionbar';
+import { Action } from 'vs/base/common/actions';
+import { Codicon } from 'vs/base/common/codicons';
+import { Disposable } from 'vs/base/common/lifecycle';
+import { ThemeIcon } from 'vs/base/common/themables';
+import 'vs/css!./inlineSuggestionHintsWidget';
+import { ContentWidgetPositionPreference, ICodeEditor, IContentWidget, IContentWidgetPosition } from 'vs/editor/browser/editorBrowser';
+import { EditorOption } from 'vs/editor/common/config/editorOptions';
+import { IDimension } from 'vs/editor/common/core/dimension';
+import { Position } from 'vs/editor/common/core/position';
+import { PositionAffinity } from 'vs/editor/common/model';
+import { showNextInlineSuggestionActionId, showPreviousInlineSuggestionActionId } from 'vs/editor/contrib/inlineCompletions/browser/consts';
+import { InlineCompletionsModel } from 'vs/editor/contrib/inlineCompletions/browser/inlineCompletionsModel';
+import { localize } from 'vs/nls';
+import { MenuEntryActionViewItem } from 'vs/platform/actions/browser/menuEntryActionViewItem';
+import { MenuWorkbenchToolBar } from 'vs/platform/actions/browser/toolbar';
+import { MenuId, MenuItemAction } from 'vs/platform/actions/common/actions';
+import { ICommandService } from 'vs/platform/commands/common/commands';
+import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
+import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
+import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
+import { registerIcon } from 'vs/platform/theme/common/iconRegistry';
+
+export class InlineSuggestionHintsWidget extends Disposable {
+	private readonly widget = this._register(this.instantiationService.createInstance(InlineSuggestionHintsContentWidget, this.editor));
+
+	private sessionPosition: Position | undefined = undefined;
+
+	constructor(
+		private readonly editor: ICodeEditor,
+		private readonly model: InlineCompletionsModel,
+		@IInstantiationService private readonly instantiationService: IInstantiationService,
+	) {
+		super();
+
+		editor.addContentWidget(this.widget);
+		this._register(model.onDidChange(() => this.update()));
+		this._register(editor.onDidChangeConfiguration(() => this.update()));
+		this.update();
+	}
+
+	private update(): void {
+		const options = this.editor.getOption(EditorOption.inlineSuggest);
+		if (!options.useExperimentalHints || options.hideHints || !this.model.ghostText) {
+			this.widget.update(null, 0, undefined);
+			this.sessionPosition = undefined;
+			return;
+		}
+
+		if (!this.model.completionSession.value) {
+			return;
+		}
+
+		if (!this.model.completionSession.value.hasBeenTriggeredExplicitly) {
+			this.model.completionSession.value.ensureUpdateWithExplicitContext();
+		}
+
+		const ghostText = this.model.ghostText;
+
+		const firstColumn = ghostText.parts[0].column;
+		if (this.sessionPosition && this.sessionPosition.lineNumber !== ghostText.lineNumber) {
+			this.sessionPosition = undefined;
+		}
+
+		const position = new Position(ghostText.lineNumber, Math.min(firstColumn, this.sessionPosition?.column ?? Number.MAX_SAFE_INTEGER));
+		this.sessionPosition = position;
+
+		this.widget.update(
+			this.sessionPosition,
+			this.model.completionSession.value.currentlySelectedIndex,
+			this.model.completionSession.value.hasBeenTriggeredExplicitly ? this.model.completionSession.value.getInlineCompletionsCountSync() : undefined,
+		);
+	}
+}
+
+const inlineSuggestionHintsNextIcon = registerIcon('inline-suggestion-hints-next', Codicon.chevronRight, localize('parameterHintsNextIcon', 'Icon for show next parameter hint.'));
+const inlineSuggestionHintsPreviousIcon = registerIcon('inline-suggestion-hints-previous', Codicon.chevronLeft, localize('parameterHintsPreviousIcon', 'Icon for show previous parameter hint.'));
+
+class InlineSuggestionHintsContentWidget extends Disposable implements IContentWidget {
+	private static id = 0;
+
+	private readonly id = `InlineSuggestionHintsContentWidget${InlineSuggestionHintsContentWidget.id++}`;
+	public readonly allowEditorOverflow = true;
+	public readonly suppressMouseDown = false;
+
+	private readonly nodes = h('div.inlineSuggestionsHints', [
+		h('div', { style: { display: 'flex' } }, [
+			h('div@actionBar'),
+			h('div@toolBar'),
+		])
+	]);
+	private position: Position | null = null;
+
+	private createCommandAction(commandId: string, label: string, iconClassName: string): Action {
+		const action = new Action(
+			commandId,
+			label,
+			iconClassName,
+			true,
+			() => this.commandService.executeCommand(commandId),
+		);
+		const kb = this.keybindingService.lookupKeybinding(commandId, this._contextKeyService);
+		let tooltip = label;
+		if (kb) {
+			tooltip = localize({ key: 'content', comment: ['A label', 'A keybinding'] }, '{0} ({1})', label, kb.getLabel());
+		}
+		action.tooltip = tooltip;
+		return action;
+	}
+
+	private readonly previousAction = this.createCommandAction(showPreviousInlineSuggestionActionId, localize('previous', 'Previous'), ThemeIcon.asClassName(inlineSuggestionHintsPreviousIcon));
+	private readonly availableSuggestionCountAction = new Action('inlineSuggestionHints.availableSuggestionCount', '', undefined, false);
+	private readonly nextAction = this.createCommandAction(showNextInlineSuggestionActionId, localize('next', 'Next'), ThemeIcon.asClassName(inlineSuggestionHintsNextIcon));
+
+	constructor(
+		private readonly editor: ICodeEditor,
+		@ICommandService private readonly commandService: ICommandService,
+		@IInstantiationService instantiationService: IInstantiationService,
+		@IKeybindingService private readonly keybindingService: IKeybindingService,
+		@IContextKeyService private readonly _contextKeyService: IContextKeyService,
+	) {
+		super();
+
+		const actionBar = this._register(new ActionBar(this.nodes.actionBar));
+
+		actionBar.push(this.previousAction, { icon: true, label: false });
+		actionBar.push(this.availableSuggestionCountAction);
+		actionBar.push(this.nextAction, { icon: true, label: false });
+
+		this._register(instantiationService.createInstance(MenuWorkbenchToolBar, this.nodes.toolBar, MenuId.InlineSuggestionToolbar, {
+			menuOptions: { renderShortTitle: true },
+			toolbarOptions: { primaryGroup: 'primary' },
+			actionViewItemProvider: (action, options) => {
+				return action instanceof MenuItemAction ? instantiationService.createInstance(StatusBarViewItem, action, undefined) : undefined;
+			},
+		}));
+	}
+
+	public update(position: Position | null, currentSuggestionIdx: number, suggestionCount: number | undefined): void {
+		this.position = position;
+
+		this.previousAction.enabled = this.nextAction.enabled = suggestionCount !== undefined && suggestionCount > 1;
+		this.availableSuggestionCountAction.label = suggestionCount !== undefined ? `${currentSuggestionIdx + 1}/${suggestionCount}` : '1/?';
+
+		this.editor.layoutContentWidget(this);
+	}
+
+	getId(): string { return this.id; }
+
+	getDomNode(): HTMLElement {
+		return this.nodes.root;
+	}
+
+	getPosition(): IContentWidgetPosition | null {
+		return {
+			position: this.position,
+			preference: [ContentWidgetPositionPreference.ABOVE, ContentWidgetPositionPreference.BELOW],
+			positionAffinity: PositionAffinity.LeftOfInjectedText,
+		};
+	}
+}
+
+class StatusBarViewItem extends MenuEntryActionViewItem {
+	protected override updateLabel() {
+		const kb = this._keybindingService.lookupKeybinding(this._action.id, this._contextKeyService);
+		if (!kb) {
+			return super.updateLabel();
+		}
+		if (this.label) {
+			this.label.textContent = localize({ key: 'content', comment: ['A label', 'A keybinding'] }, '{0} ({1})', this._action.label, kb.getLabel());
+		}
+	}
+}

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -4325,6 +4325,8 @@ declare namespace monaco.editor {
 		 * Defaults to `prefix`.
 		*/
 		mode?: 'prefix' | 'subword' | 'subwordSmart';
+		useExperimentalHints?: boolean;
+		hideHints?: boolean;
 	}
 
 	export interface IBracketPairColorizationOptions {

--- a/src/vs/platform/actions/common/actions.ts
+++ b/src/vs/platform/actions/common/actions.ts
@@ -175,6 +175,7 @@ export class MenuId {
 	static readonly MergeInput2Toolbar = new MenuId('MergeToolbar2Toolbar');
 	static readonly MergeBaseToolbar = new MenuId('MergeBaseToolbar');
 	static readonly MergeInputResultToolbar = new MenuId('MergeToolbarResultToolbar');
+	static readonly InlineSuggestionToolbar = new MenuId('InlineSuggestionToolbar');
 
 	/**
 	 * Create or reuse a `MenuId` with the given identifier


### PR DESCRIPTION
Use `"editor.inlineSuggest.useExperimentalHints": true` to enable this feature.

![gif](https://user-images.githubusercontent.com/2931520/213763734-6764c2bf-33f8-4737-92c4-2afcdf8d0028.gif)

