### PR TITLE
cli: use x64 server for windows arm64

### DIFF
--- a/cli/src/update_service.rs
+++ b/cli/src/update_service.rs
@@ -247,7 +247,7 @@ impl Platform {
 			Platform::DarwinARM64 => "server-darwin-arm64",
 			Platform::WindowsX64 => "server-win32-x64",
 			Platform::WindowsX86 => "server-win32",
-			Platform::WindowsARM64 => "server-win32-arm64",
+			Platform::WindowsARM64 => "server-win32-x64", // we don't publish an arm64 server build yet
 		}
 		.to_owned()
 	}


### PR DESCRIPTION
We don't publish an arm64 server yet. Same thing as ssh does.

Fixes https://github.com/microsoft/vscode/issues/171832
