### PR TITLE
Ensure language packs are installed on the server side

### DIFF
--- a/src/vs/platform/languagePacks/browser/languagePacks.ts
+++ b/src/vs/platform/languagePacks/browser/languagePacks.ts
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { CancellationTokenSource } from 'vs/base/common/cancellation';
-import { Language } from 'vs/base/common/platform';
 import { URI } from 'vs/base/common/uri';
 import { IExtensionGalleryService } from 'vs/platform/extensionManagement/common/extensionManagement';
 import { IExtensionResourceLoaderService } from 'vs/platform/extensionResourceLoader/common/extensionResourceLoader';
@@ -20,7 +19,7 @@ export class WebLanguagePacksService extends LanguagePackBaseService {
 		super(extensionGalleryService);
 	}
 
-	async getBuiltInExtensionTranslationsUri(id: string): Promise<URI | undefined> {
+	async getBuiltInExtensionTranslationsUri(id: string, language: string): Promise<URI | undefined> {
 
 		const queryTimeout = new CancellationTokenSource();
 		setTimeout(() => queryTimeout.cancel(), 1000);
@@ -29,7 +28,7 @@ export class WebLanguagePacksService extends LanguagePackBaseService {
 		let result;
 		try {
 			result = await this.extensionGalleryService.query({
-				text: `tag:"lp-${Language.value()}"`,
+				text: `tag:"lp-${language}"`,
 				pageSize: 5
 			}, queryTimeout.token);
 		} catch (err) {
@@ -39,7 +38,7 @@ export class WebLanguagePacksService extends LanguagePackBaseService {
 
 		const languagePackExtensions = result.firstPage.find(e => e.properties.localizedLanguages?.length);
 		if (!languagePackExtensions) {
-			this.logService.trace(`No language pack found for language ${Language.value()}`);
+			this.logService.trace(`No language pack found for language ${language}`);
 			return undefined;
 		}
 
@@ -49,7 +48,7 @@ export class WebLanguagePacksService extends LanguagePackBaseService {
 		const manifest = await this.extensionGalleryService.getManifest(languagePackExtensions, manifestTimeout.token);
 
 		// Find the translation from the language pack
-		const localization = manifest?.contributes?.localizations?.find(l => l.languageId === Language.value());
+		const localization = manifest?.contributes?.localizations?.find(l => l.languageId === language);
 		const translation = localization?.translations.find(t => t.id === id);
 		if (!translation) {
 			this.logService.trace(`No translation found for id '${id}, in ${manifest?.name}`);

--- a/src/vs/platform/languagePacks/common/languagePacks.ts
+++ b/src/vs/platform/languagePacks/common/languagePacks.ts
@@ -27,7 +27,7 @@ export interface ILanguagePackService {
 	readonly _serviceBrand: undefined;
 	getAvailableLanguages(): Promise<Array<ILanguagePackItem>>;
 	getInstalledLanguages(): Promise<Array<ILanguagePackItem>>;
-	getBuiltInExtensionTranslationsUri(id: string): Promise<URI | undefined>;
+	getBuiltInExtensionTranslationsUri(id: string, language: string): Promise<URI | undefined>;
 }
 
 export abstract class LanguagePackBaseService extends Disposable implements ILanguagePackService {
@@ -37,7 +37,7 @@ export abstract class LanguagePackBaseService extends Disposable implements ILan
 		super();
 	}
 
-	abstract getBuiltInExtensionTranslationsUri(id: string): Promise<URI | undefined>;
+	abstract getBuiltInExtensionTranslationsUri(id: string, language: string): Promise<URI | undefined>;
 
 	abstract getInstalledLanguages(): Promise<Array<ILanguagePackItem>>;
 

--- a/src/vs/platform/languagePacks/node/languagePacks.ts
+++ b/src/vs/platform/languagePacks/node/languagePacks.ts
@@ -16,7 +16,6 @@ import { areSameExtensions } from 'vs/platform/extensionManagement/common/extens
 import { ILogService } from 'vs/platform/log/common/log';
 import { ILocalizationContribution } from 'vs/platform/extensions/common/extensions';
 import { ILanguagePackItem, LanguagePackBaseService } from 'vs/platform/languagePacks/common/languagePacks';
-import { Language } from 'vs/base/common/platform';
 import { URI } from 'vs/base/common/uri';
 
 interface ILanguagePack {
@@ -50,11 +49,11 @@ export class NativeLanguagePackService extends LanguagePackBaseService {
 		});
 	}
 
-	async getBuiltInExtensionTranslationsUri(id: string): Promise<URI | undefined> {
+	async getBuiltInExtensionTranslationsUri(id: string, language: string): Promise<URI | undefined> {
 		const packs = await this.cache.getLanguagePacks();
-		const pack = packs[Language.value()];
+		const pack = packs[language];
 		if (!pack) {
-			this.logService.warn(`No language pack found for ${Language.value()}`);
+			this.logService.warn(`No language pack found for ${language}`);
 			return undefined;
 		}
 

--- a/src/vs/server/node/remoteAgentEnvironmentImpl.ts
+++ b/src/vs/server/node/remoteAgentEnvironmentImpl.ts
@@ -356,7 +356,7 @@ export class RemoteAgentEnvironmentChannel implements IServerChannel {
 	private async _ensureLanguagePackIsInstalled(language: string): Promise<void> {
 		if (
 			// No need to install language packs for the default language
-			language === platform.LANGUAGE_DEFAULT &&
+			language === platform.LANGUAGE_DEFAULT ||
 			// The extension gallery service needs to be available
 			!this._extensionGalleryService.isEnabled()
 		) {

--- a/src/vs/server/node/serverServices.ts
+++ b/src/vs/server/node/serverServices.ts
@@ -201,6 +201,7 @@ export async function setupServerServices(connectionToken: ServerConnectionToken
 		const extensionManagementService = accessor.get(INativeServerExtensionManagementService);
 		const extensionsScannerService = accessor.get(IExtensionsScannerService);
 		const extensionGalleryService = accessor.get(IExtensionGalleryService);
+		const languagePackService = accessor.get(ILanguagePackService);
 		const remoteExtensionEnvironmentChannel = new RemoteAgentEnvironmentChannel(
 			connectionToken,
 			environmentService,
@@ -209,7 +210,8 @@ export async function setupServerServices(connectionToken: ServerConnectionToken
 			extensionGalleryService,
 			logService,
 			extensionHostStatusService,
-			extensionsScannerService
+			extensionsScannerService,
+			languagePackService
 		);
 		socketServer.registerChannel('remoteextensionsenvironment', remoteExtensionEnvironmentChannel);
 

--- a/src/vs/server/node/serverServices.ts
+++ b/src/vs/server/node/serverServices.ts
@@ -200,7 +200,17 @@ export async function setupServerServices(connectionToken: ServerConnectionToken
 	instantiationService.invokeFunction(accessor => {
 		const extensionManagementService = accessor.get(INativeServerExtensionManagementService);
 		const extensionsScannerService = accessor.get(IExtensionsScannerService);
-		const remoteExtensionEnvironmentChannel = new RemoteAgentEnvironmentChannel(connectionToken, environmentService, userDataProfilesService, instantiationService.createInstance(ExtensionManagementCLI), logService, extensionHostStatusService, extensionsScannerService);
+		const extensionGalleryService = accessor.get(IExtensionGalleryService);
+		const remoteExtensionEnvironmentChannel = new RemoteAgentEnvironmentChannel(
+			connectionToken,
+			environmentService,
+			userDataProfilesService,
+			instantiationService.createInstance(ExtensionManagementCLI),
+			extensionGalleryService,
+			logService,
+			extensionHostStatusService,
+			extensionsScannerService
+		);
 		socketServer.registerChannel('remoteextensionsenvironment', remoteExtensionEnvironmentChannel);
 
 		const telemetryChannel = new ServerTelemetryChannel(accessor.get(IServerTelemetryService), oneDsAppender);

--- a/src/vs/workbench/api/browser/mainThreadLocalization.ts
+++ b/src/vs/workbench/api/browser/mainThreadLocalization.ts
@@ -21,9 +21,9 @@ export class MainThreadLocalization extends Disposable implements MainThreadLoca
 		super();
 	}
 
-	async $fetchBuiltInBundleUri(id: string): Promise<URI | undefined> {
+	async $fetchBuiltInBundleUri(id: string, language: string): Promise<URI | undefined> {
 		try {
-			const uri = await this.languagePackService.getBuiltInExtensionTranslationsUri(id);
+			const uri = await this.languagePackService.getBuiltInExtensionTranslationsUri(id, language);
 			return uri;
 		} catch (e) {
 			return undefined;

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -2192,7 +2192,7 @@ export interface MainThreadThemingShape extends IDisposable {
 }
 
 export interface MainThreadLocalizationShape extends IDisposable {
-	$fetchBuiltInBundleUri(id: string): Promise<UriComponents | undefined>;
+	$fetchBuiltInBundleUri(id: string, language: string): Promise<UriComponents | undefined>;
 	$fetchBundleContents(uriComponents: UriComponents): Promise<string>;
 }
 

--- a/src/vs/workbench/api/common/extHostLocalizationService.ts
+++ b/src/vs/workbench/api/common/extHostLocalizationService.ts
@@ -95,7 +95,7 @@ export class ExtHostLocalizationService implements ExtHostLocalizationShape {
 
 	private async getBundleLocation(extension: IExtensionDescription): Promise<URI | undefined> {
 		if (extension.isBuiltin) {
-			const uri = await this._proxy.$fetchBuiltInBundleUri(extension.identifier.value);
+			const uri = await this._proxy.$fetchBuiltInBundleUri(extension.identifier.value, this.currentLanguage);
 			return URI.revive(uri);
 		}
 


### PR DESCRIPTION
We need the language pack to be on the server side so that extensions running over there are translated correctly.

This ensures the correct language pack is installed before the ExtensionScanner (which will translate the manifest of extensions) kicks in.

Fixes #166836

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
