### PR TITLE
Add tests to confirm MD code comments aren't foldable regions

### DIFF
--- a/src/vs/workbench/contrib/notebook/test/browser/notebookFolding.test.ts
+++ b/src/vs/workbench/contrib/notebook/test/browser/notebookFolding.test.ts
@@ -54,9 +54,10 @@ suite('Notebook Folding', () => {
 			[
 				['# header 1', 'markdown', CellKind.Markup, [], {}],
 				['body', 'markdown', CellKind.Markup, [], {}],
-				['# comment', 'python', CellKind.Code, [], {}],
+				['# comment 1', 'python', CellKind.Code, [], {}],
 				['body 2', 'markdown', CellKind.Markup, [], {}],
-				['body 3', 'markdown', CellKind.Markup, [], {}],
+				['body 3\n```\n## comment 2\n```', 'markdown', CellKind.Markup, [], {}],
+				['body 4', 'markdown', CellKind.Markup, [], {}],
 				['## header 2.1', 'markdown', CellKind.Markup, [], {}],
 				['var e = 7;', 'python', CellKind.Code, [], {}],
 			],
@@ -69,8 +70,9 @@ suite('Notebook Folding', () => {
 				assert.strictEqual(foldingController.regions.findRange(3), 0);
 				assert.strictEqual(foldingController.regions.findRange(4), 0);
 				assert.strictEqual(foldingController.regions.findRange(5), 0);
-				assert.strictEqual(foldingController.regions.findRange(6), 1);
+				assert.strictEqual(foldingController.regions.findRange(6), 0);
 				assert.strictEqual(foldingController.regions.findRange(7), 1);
+				assert.strictEqual(foldingController.regions.findRange(8), 1);
 			}
 		);
 	});

--- a/src/vs/workbench/contrib/notebook/test/browser/notebookFolding.test.ts
+++ b/src/vs/workbench/contrib/notebook/test/browser/notebookFolding.test.ts
@@ -49,6 +49,32 @@ suite('Notebook Folding', () => {
 		);
 	});
 
+	test('Folding not based on code cells', async function () {
+		await withTestNotebook(
+			[
+				['# header 1', 'markdown', CellKind.Markup, [], {}],
+				['body', 'markdown', CellKind.Markup, [], {}],
+				['# comment', 'python', CellKind.Code, [], {}],
+				['body 2', 'markdown', CellKind.Markup, [], {}],
+				['body 3', 'markdown', CellKind.Markup, [], {}],
+				['## header 2.1', 'markdown', CellKind.Markup, [], {}],
+				['var e = 7;', 'python', CellKind.Code, [], {}],
+			],
+			(editor, viewModel) => {
+				const foldingController = new FoldingModel();
+				foldingController.attachViewModel(viewModel);
+
+				assert.strictEqual(foldingController.regions.findRange(1), 0);
+				assert.strictEqual(foldingController.regions.findRange(2), 0);
+				assert.strictEqual(foldingController.regions.findRange(3), 0);
+				assert.strictEqual(foldingController.regions.findRange(4), 0);
+				assert.strictEqual(foldingController.regions.findRange(5), 0);
+				assert.strictEqual(foldingController.regions.findRange(6), 1);
+				assert.strictEqual(foldingController.regions.findRange(7), 1);
+			}
+		);
+	});
+
 	test('Top level header in a cell wins', async function () {
 		await withTestNotebook(
 			[


### PR DESCRIPTION
This PR adds tests to confirm https://github.com/microsoft/vscode/issues/158179 is fixed. Comments in code in markdown no longer make a fold-able region.

[Video of current release (unwanted behavior)](https://user-images.githubusercontent.com/89945219/213945335-8c8caf32-fe10-44bd-931d-e2e729b997de.mov)
[Video of development build (correct behavior)](https://user-images.githubusercontent.com/89945219/213945402-399aaebc-ab0e-4b71-ae41-7d59fd772402.mov)

