### PR TITLE
Redesigns inline suggestion hover menu.

### DIFF
--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -3785,8 +3785,7 @@ export interface IInlineSuggestOptions {
 	*/
 	mode?: 'prefix' | 'subword' | 'subwordSmart';
 
-	useExperimentalHints?: boolean;
-	hideHints?: boolean;
+	showToolbar?: 'always' | 'onHover';
 }
 
 /**
@@ -3802,8 +3801,7 @@ class InlineEditorSuggest extends BaseEditorOption<EditorOption.inlineSuggest, I
 		const defaults: InternalInlineSuggestOptions = {
 			enabled: true,
 			mode: 'subwordSmart',
-			useExperimentalHints: false,
-			hideHints: false,
+			showToolbar: 'onHover',
 		};
 
 		super(
@@ -3814,15 +3812,15 @@ class InlineEditorSuggest extends BaseEditorOption<EditorOption.inlineSuggest, I
 					default: defaults.enabled,
 					description: nls.localize('inlineSuggest.enabled', "Controls whether to automatically show inline suggestions in the editor.")
 				},
-				'editor.inlineSuggest.useExperimentalHints': {
-					type: 'boolean',
-					default: defaults.useExperimentalHints,
-					description: nls.localize('inlineSuggest.useExperimentalHints', "Controls whether to use experimental hints in the editor."),
-				},
-				'editor.inlineSuggest.hideHints': {
-					type: 'boolean',
-					default: defaults.hideHints,
-					description: nls.localize('inlineSuggest.hideHints', "Controls whether to hide hints in the editor."),
+				'editor.inlineSuggest.showToolbar': {
+					type: 'string',
+					default: defaults.showToolbar,
+					enum: ['always', 'onHover'],
+					enumDescriptions: [
+						nls.localize('inlineSuggest.showToolbar.always', "Always show the inline suggestion toolbar."),
+						nls.localize('inlineSuggest.showToolbar.onHover', "Show the inline suggestion toolbar when hovering over the inline suggestion."),
+					],
+					description: nls.localize('inlineSuggest.showToolbar', "Controls when to show the inline suggestion toolbar."),
 				},
 			}
 		);
@@ -3836,8 +3834,7 @@ class InlineEditorSuggest extends BaseEditorOption<EditorOption.inlineSuggest, I
 		return {
 			enabled: boolean(input.enabled, this.defaultValue.enabled),
 			mode: stringSet(input.mode, this.defaultValue.mode, ['prefix', 'subword', 'subwordSmart']),
-			useExperimentalHints: boolean(input.useExperimentalHints, this.defaultValue.useExperimentalHints),
-			hideHints: boolean(input.hideHints, this.defaultValue.hideHints),
+			showToolbar: stringSet(input.showToolbar, this.defaultValue.showToolbar, ['always', 'onHover']),
 		};
 	}
 }

--- a/src/vs/editor/contrib/inlineCompletions/browser/ghostText.contribution.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/ghostText.contribution.ts
@@ -5,8 +5,9 @@
 
 import { EditorContributionInstantiation, registerEditorAction, registerEditorContribution } from 'vs/editor/browser/editorExtensions';
 import { HoverParticipantRegistry } from 'vs/editor/contrib/hover/browser/hoverTypes';
-import { AcceptInlineCompletion, AcceptNextWordOfInlineCompletion, DisableSuggestionHints, GhostTextController, HideInlineCompletion, ShowNextInlineSuggestionAction, ShowPreviousInlineSuggestionAction, TriggerInlineSuggestionAction, UndoAcceptPart } from 'vs/editor/contrib/inlineCompletions/browser/ghostTextController';
+import { AcceptInlineCompletion, AcceptNextWordOfInlineCompletion, ToggleAlwaysShowInlineSuggestionToolbar, GhostTextController, HideInlineCompletion, ShowNextInlineSuggestionAction, ShowPreviousInlineSuggestionAction, TriggerInlineSuggestionAction, UndoAcceptPart } from 'vs/editor/contrib/inlineCompletions/browser/ghostTextController';
 import { InlineCompletionsHoverParticipant } from 'vs/editor/contrib/inlineCompletions/browser/ghostTextHoverParticipant';
+import { registerAction2 } from 'vs/platform/actions/common/actions';
 
 registerEditorContribution(GhostTextController.ID, GhostTextController, EditorContributionInstantiation.Eventually);
 registerEditorAction(TriggerInlineSuggestionAction);
@@ -16,6 +17,6 @@ registerEditorAction(AcceptNextWordOfInlineCompletion);
 registerEditorAction(AcceptInlineCompletion);
 registerEditorAction(HideInlineCompletion);
 registerEditorAction(UndoAcceptPart);
-registerEditorAction(DisableSuggestionHints);
+registerAction2(ToggleAlwaysShowInlineSuggestionToolbar);
 
 HoverParticipantRegistry.register(InlineCompletionsHoverParticipant);

--- a/src/vs/editor/contrib/inlineCompletions/browser/ghostTextController.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/ghostTextController.ts
@@ -19,7 +19,7 @@ import { GhostTextModel } from 'vs/editor/contrib/inlineCompletions/browser/ghos
 import { GhostTextWidget } from 'vs/editor/contrib/inlineCompletions/browser/ghostTextWidget';
 import { InlineSuggestionHintsWidget } from 'vs/editor/contrib/inlineCompletions/browser/inlineSuggestionHintsWidget';
 import * as nls from 'vs/nls';
-import { MenuId } from 'vs/platform/actions/common/actions';
+import { Action2, MenuId } from 'vs/platform/actions/common/actions';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { ContextKeyExpr, IContextKeyService, RawContextKey } from 'vs/platform/contextkey/common/contextkey';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
@@ -33,6 +33,8 @@ export class GhostTextController extends Disposable {
 	 * Enables to use Ctrl+Left to undo partially accepted inline completions.
 	 */
 	public static readonly canUndoInlineSuggestion = new RawContextKey<boolean>('canUndoInlineSuggestion', false, nls.localize('canUndoInlineSuggestion', "Whether undo would undo an inline suggestion"));
+
+	public static readonly alwaysShowInlineSuggestionToolbar = new RawContextKey<boolean>('alwaysShowInlineSuggestionToolbar', false, nls.localize('alwaysShowInlineSuggestionToolbar', "Whether the inline suggestion toolbar should always be visible"));
 
 	static ID = 'editor.contrib.ghostTextController';
 
@@ -56,9 +58,12 @@ export class GhostTextController extends Disposable {
 	 */
 	private firstUndoableVersionId: number | undefined = undefined;
 
+	public readonly alwaysShowInlineSuggestionToolbar = GhostTextController.alwaysShowInlineSuggestionToolbar.bindTo(this.contextKeyService);
+
 	constructor(
 		public readonly editor: ICodeEditor,
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
+		@IContextKeyService private readonly contextKeyService: IContextKeyService,
 	) {
 		super();
 
@@ -77,31 +82,36 @@ export class GhostTextController extends Disposable {
 		}));
 
 		this._register(this.editor.onDidChangeModel(() => {
-			this.updateModelController();
+			this.update();
 		}));
 		this._register(this.editor.onDidChangeConfiguration((e) => {
 			if (e.hasChanged(EditorOption.suggest) || e.hasChanged(EditorOption.inlineSuggest)) {
-				this.updateModelController();
+				this.update();
 			}
 		}));
-		this.updateModelController();
+		this.update();
 	}
 
 	// Don't call this method when not necessary. It will recreate the activeController.
-	private updateModelController(): void {
+	private update(): void {
 		const suggestOptions = this.editor.getOption(EditorOption.suggest);
 		const inlineSuggestOptions = this.editor.getOption(EditorOption.inlineSuggest);
 
-		this.activeController.value = undefined;
-		// ActiveGhostTextController is only created if one of those settings is set or if the inline completions are triggered explicitly.
-		this.activeController.value =
-			this.editor.hasModel() && (suggestOptions.preview || inlineSuggestOptions.enabled || this.triggeredExplicitly)
-				? this.instantiationService.createInstance(
+		this.alwaysShowInlineSuggestionToolbar.set(inlineSuggestOptions.showToolbar === 'always');
+
+		const shouldCreate = this.editor.hasModel() && (suggestOptions.preview || inlineSuggestOptions.enabled || this.triggeredExplicitly);
+
+		if (shouldCreate !== !!this.activeController.value) {
+			this.activeController.value = undefined;
+			// ActiveGhostTextController is only created if one of those settings is set or if the inline completions are triggered explicitly.
+			this.activeController.value =
+				shouldCreate ? this.instantiationService.createInstance(
 					ActiveGhostTextController,
-					this.editor
+					this.editor as IActiveCodeEditor
 				)
-				: undefined;
-		this.activeModelDidChangeEmitter.fire();
+					: undefined;
+			this.activeModelDidChangeEmitter.fire();
+		}
 	}
 
 	public shouldShowHoverAt(hoverRange: Range): boolean {
@@ -115,7 +125,7 @@ export class GhostTextController extends Disposable {
 	public trigger(): void {
 		this.triggeredExplicitly = true;
 		if (!this.activeController.value) {
-			this.updateModelController();
+			this.update();
 		}
 		this.activeModel?.triggerInlineCompletion();
 	}
@@ -376,27 +386,29 @@ export class HideInlineCompletion extends EditorAction {
 	}
 }
 
-export class DisableSuggestionHints extends EditorAction {
-	public static ID = 'editor.action.inlineSuggest.disableHints';
+export class ToggleAlwaysShowInlineSuggestionToolbar extends Action2 {
+	public static ID = 'editor.action.inlineSuggest.toggleAlwaysShowToolbar';
 
 	constructor() {
 		super({
-			id: DisableSuggestionHints.ID,
-			label: nls.localize('action.inlineSuggest.disableHints', "Disable suggestion hints"),
-			alias: 'Disable suggestion hints',
+			id: ToggleAlwaysShowInlineSuggestionToolbar.ID,
+			title: nls.localize('action.inlineSuggest.alwaysShowToolbar', "Always Show Toolbar"),
+			f1: false,
 			precondition: undefined,
-			menuOpts: [{
-				menuId: MenuId.InlineSuggestionToolbar,
-				title: nls.localize('action.inlineSuggest.disableHints', "Disable suggestion hints"),
+			menu: [{
+				id: MenuId.InlineSuggestionToolbar,
 				group: 'secondary',
 				order: 10,
 			}],
+			toggled: GhostTextController.alwaysShowInlineSuggestionToolbar,
 		});
 	}
 
 	public async run(accessor: ServicesAccessor, editor: ICodeEditor): Promise<void> {
 		const configService = accessor.get(IConfigurationService);
-		configService.updateValue('editor.inlineSuggest.hideHints', true);
+		const currentValue = configService.getValue<'always' | 'onHover'>('editor.inlineSuggest.showToolbar');
+		const newValue = currentValue === 'always' ? 'onHover' : 'always';
+		configService.updateValue('editor.inlineSuggest.showToolbar', newValue);
 	}
 }
 

--- a/src/vs/editor/contrib/inlineCompletions/browser/ghostTextHoverParticipant.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/ghostTextHoverParticipant.ts
@@ -5,23 +5,21 @@
 
 import * as dom from 'vs/base/browser/dom';
 import { MarkdownString } from 'vs/base/common/htmlContent';
-import { DisposableStore, IDisposable } from 'vs/base/common/lifecycle';
-import { MarkdownRenderer } from 'vs/editor/contrib/markdownRenderer/browser/markdownRenderer';
+import { Disposable, DisposableStore, IDisposable } from 'vs/base/common/lifecycle';
 import { ICodeEditor, IEditorMouseEvent, MouseTargetType } from 'vs/editor/browser/editorBrowser';
+import { EditorOption } from 'vs/editor/common/config/editorOptions';
 import { Range } from 'vs/editor/common/core/range';
-import { IModelDecoration } from 'vs/editor/common/model';
+import { Command } from 'vs/editor/common/languages';
 import { ILanguageService } from 'vs/editor/common/languages/language';
+import { IModelDecoration } from 'vs/editor/common/model';
 import { HoverAnchor, HoverAnchorType, HoverForeignElementAnchor, IEditorHoverParticipant, IEditorHoverRenderContext, IHoverPart } from 'vs/editor/contrib/hover/browser/hoverTypes';
-import { GhostTextController, ShowNextInlineSuggestionAction, ShowPreviousInlineSuggestionAction } from 'vs/editor/contrib/inlineCompletions/browser/ghostTextController';
+import { GhostTextController } from 'vs/editor/contrib/inlineCompletions/browser/ghostTextController';
+import { InlineSuggestionHintsContentWidget } from 'vs/editor/contrib/inlineCompletions/browser/inlineSuggestionHintsWidget';
+import { MarkdownRenderer } from 'vs/editor/contrib/markdownRenderer/browser/markdownRenderer';
 import * as nls from 'vs/nls';
 import { IAccessibilityService } from 'vs/platform/accessibility/common/accessibility';
-import { IMenuService, MenuId, MenuItemAction } from 'vs/platform/actions/common/actions';
-import { ICommandService } from 'vs/platform/commands/common/commands';
-import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
+import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { IOpenerService } from 'vs/platform/opener/common/opener';
-import { inlineSuggestCommitId } from 'vs/editor/contrib/inlineCompletions/browser/consts';
-import { Command } from 'vs/editor/common/languages';
-import { EditorOption } from 'vs/editor/common/config/editorOptions';
 
 export class InlineCompletionsHover implements IHoverPart {
 	constructor(
@@ -38,8 +36,25 @@ export class InlineCompletionsHover implements IHoverPart {
 		);
 	}
 
-	public getInlineCompletionsCount(): Promise<number> {
-		return this.controller.getInlineCompletionsCount();
+	public requestExplicitContext(): void {
+		this.controller.activeModel?.activeInlineCompletionsModel?.completionSession.value?.ensureUpdateWithExplicitContext();
+	}
+
+	public getInlineCompletionsCount(): number | undefined {
+		const session = this.controller.activeModel?.activeInlineCompletionsModel?.completionSession.value;
+		if (!session?.hasBeenTriggeredExplicitly) {
+			return undefined;
+		}
+		return session?.getInlineCompletionsCountSync();
+	}
+
+	public getInlineCompletionIndex(): number | undefined {
+		return this.controller.activeModel?.activeInlineCompletionsModel?.completionSession.value?.currentlySelectedIndex;
+	}
+
+	public onDidChange(handler: () => void): IDisposable {
+		const d = this.controller.activeModel?.activeInlineCompletionsModel?.onDidChange(handler);
+		return d || Disposable.None;
 	}
 
 	public get commands(): Command[] {
@@ -53,21 +68,16 @@ export class InlineCompletionsHoverParticipant implements IEditorHoverParticipan
 
 	constructor(
 		private readonly _editor: ICodeEditor,
-		@ICommandService private readonly _commandService: ICommandService,
-		@IMenuService private readonly _menuService: IMenuService,
-		@IContextKeyService private readonly _contextKeyService: IContextKeyService,
 		@ILanguageService private readonly _languageService: ILanguageService,
 		@IOpenerService private readonly _openerService: IOpenerService,
 		@IAccessibilityService private readonly accessibilityService: IAccessibilityService,
+		@IInstantiationService private readonly _instantiationService: IInstantiationService
 	) {
 	}
 
 	suggestHoverAnchor(mouseEvent: IEditorMouseEvent): HoverAnchor | null {
 		const controller = GhostTextController.get(this._editor);
 		if (!controller) {
-			return null;
-		}
-		if (this._editor.getOption(EditorOption.inlineSuggest).useExperimentalHints) {
 			return null;
 		}
 
@@ -96,6 +106,10 @@ export class InlineCompletionsHoverParticipant implements IEditorHoverParticipan
 	}
 
 	computeSync(anchor: HoverAnchor, lineDecorations: IModelDecoration[]): InlineCompletionsHover[] {
+		if (this._editor.getOption(EditorOption.inlineSuggest).showToolbar === 'always') {
+			return [];
+		}
+
 		const controller = GhostTextController.get(this._editor);
 		if (controller && controller.shouldShowHoverAt(anchor.range)) {
 			return [new InlineCompletionsHover(this, anchor.range, controller)];
@@ -111,57 +125,15 @@ export class InlineCompletionsHoverParticipant implements IEditorHoverParticipan
 			this.renderScreenReaderText(context, part, disposableStore);
 		}
 
-		// TODO@hediet: deprecate MenuId.InlineCompletionsActions
-		const menu = disposableStore.add(this._menuService.createMenu(
-			MenuId.InlineCompletionsActions,
-			this._contextKeyService
-		));
+		const w = this._instantiationService.createInstance(InlineSuggestionHintsContentWidget, this._editor);
+		context.fragment.appendChild(w.getDomNode());
 
-		const previousAction = context.statusBar.addAction({
-			label: nls.localize('showNextInlineSuggestion', "Next"),
-			commandId: ShowNextInlineSuggestionAction.ID,
-			run: () => this._commandService.executeCommand(ShowNextInlineSuggestionAction.ID)
-		});
-		const nextAction = context.statusBar.addAction({
-			label: nls.localize('showPreviousInlineSuggestion', "Previous"),
-			commandId: ShowPreviousInlineSuggestionAction.ID,
-			run: () => this._commandService.executeCommand(ShowPreviousInlineSuggestionAction.ID)
-		});
-		context.statusBar.addAction({
-			label: nls.localize('acceptInlineSuggestion', "Accept"),
-			commandId: inlineSuggestCommitId,
-			run: () => this._commandService.executeCommand(inlineSuggestCommitId)
-		});
+		w.update(null, part.getInlineCompletionIndex() || 0, part.getInlineCompletionsCount(), part.commands);
+		part.requestExplicitContext();
 
-		const actions = [previousAction, nextAction];
-		for (const action of actions) {
-			action.setEnabled(false);
-		}
-		part.getInlineCompletionsCount().then(count => {
-			for (const action of actions) {
-				action.setEnabled(count > 1);
-			}
-		});
-
-		for (const command of part.commands) {
-			context.statusBar.addAction({
-				label: command.title,
-				commandId: command.id,
-				run: () => this._commandService.executeCommand(command.id, ...(command.arguments || []))
-			});
-		}
-
-		for (const [_, group] of menu.getActions()) {
-			for (const action of group) {
-				if (action instanceof MenuItemAction) {
-					context.statusBar.addAction({
-						label: action.label,
-						commandId: action.item.id,
-						run: () => this._commandService.executeCommand(action.item.id)
-					});
-				}
-			}
-		}
+		disposableStore.add(part.onDidChange(() => {
+			w.update(null, part.getInlineCompletionIndex() || 0, part.getInlineCompletionsCount(), part.commands);
+		}));
 
 		return disposableStore;
 	}

--- a/src/vs/editor/contrib/inlineCompletions/browser/inlineSuggestionHintsWidget.css
+++ b/src/vs/editor/contrib/inlineCompletions/browser/inlineSuggestionHintsWidget.css
@@ -9,3 +9,28 @@
 	background-color: var(--vscode-editorHoverWidget-background);
 	border: 1px solid var(--vscode-editorHoverWidget-border);
 }
+
+.monaco-editor .inlineSuggestionsHints a {
+	color: var(--vscode-foreground);
+}
+
+.monaco-editor .inlineSuggestionsHints a:hover {
+	color: var(--vscode-foreground);
+}
+
+.monaco-editor .inlineSuggestionsHints .keybinding {
+	display: flex;
+	margin-left: 4px;
+	opacity: 0.5;
+}
+
+.monaco-editor .inlineSuggestionsHints .keybinding .monaco-keybinding-key {
+	font-size: 8px;
+	padding: 2px 3px;
+}
+
+.monaco-editor .inlineSuggestionsHints .custom-actions .action-item:nth-child(2) a {
+	display: flex;
+	min-width: 19px;
+	justify-content: center;
+}

--- a/src/vs/editor/contrib/inlineCompletions/browser/inlineSuggestionHintsWidget.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/inlineSuggestionHintsWidget.ts
@@ -5,25 +5,30 @@
 
 import { h } from 'vs/base/browser/dom';
 import { ActionBar } from 'vs/base/browser/ui/actionbar/actionbar';
-import { Action } from 'vs/base/common/actions';
+import { KeybindingLabel } from 'vs/base/browser/ui/keybindingLabel/keybindingLabel';
+import { Action, IAction, Separator } from 'vs/base/common/actions';
 import { Codicon } from 'vs/base/common/codicons';
 import { Disposable, toDisposable } from 'vs/base/common/lifecycle';
+import { OperatingSystem } from 'vs/base/common/platform';
 import { ThemeIcon } from 'vs/base/common/themables';
 import 'vs/css!./inlineSuggestionHintsWidget';
 import { ContentWidgetPositionPreference, ICodeEditor, IContentWidget, IContentWidgetPosition } from 'vs/editor/browser/editorBrowser';
 import { EditorOption } from 'vs/editor/common/config/editorOptions';
 import { Position } from 'vs/editor/common/core/position';
+import { Command } from 'vs/editor/common/languages';
 import { PositionAffinity } from 'vs/editor/common/model';
 import { showNextInlineSuggestionActionId, showPreviousInlineSuggestionActionId } from 'vs/editor/contrib/inlineCompletions/browser/consts';
 import { InlineCompletionsModel } from 'vs/editor/contrib/inlineCompletions/browser/inlineCompletionsModel';
 import { localize } from 'vs/nls';
-import { MenuEntryActionViewItem } from 'vs/platform/actions/browser/menuEntryActionViewItem';
-import { MenuWorkbenchToolBar } from 'vs/platform/actions/browser/toolbar';
-import { MenuId, MenuItemAction } from 'vs/platform/actions/common/actions';
+import { createAndFillInActionBarActions, MenuEntryActionViewItem } from 'vs/platform/actions/browser/menuEntryActionViewItem';
+import { IMenuWorkbenchToolBarOptions, WorkbenchToolBar } from 'vs/platform/actions/browser/toolbar';
+import { IMenuService, MenuId, MenuItemAction } from 'vs/platform/actions/common/actions';
 import { ICommandService } from 'vs/platform/commands/common/commands';
 import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
+import { IContextMenuService } from 'vs/platform/contextview/browser/contextView';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
+import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 import { registerIcon } from 'vs/platform/theme/common/iconRegistry';
 
 export class InlineSuggestionHintsWidget extends Disposable {
@@ -47,8 +52,8 @@ export class InlineSuggestionHintsWidget extends Disposable {
 
 	private update(): void {
 		const options = this.editor.getOption(EditorOption.inlineSuggest);
-		if (!options.useExperimentalHints || options.hideHints || !this.model.ghostText) {
-			this.widget.update(null, 0, undefined);
+		if (options.showToolbar !== 'always' || !this.model.ghostText) {
+			this.widget.update(null, 0, undefined, []);
 			this.sessionPosition = undefined;
 			return;
 		}
@@ -75,6 +80,7 @@ export class InlineSuggestionHintsWidget extends Disposable {
 			this.sessionPosition,
 			this.model.completionSession.value.currentlySelectedIndex,
 			this.model.completionSession.value.hasBeenTriggeredExplicitly ? this.model.completionSession.value.getInlineCompletionsCountSync() : undefined,
+			this.model.completionSession.value.commands,
 		);
 	}
 }
@@ -82,7 +88,7 @@ export class InlineSuggestionHintsWidget extends Disposable {
 const inlineSuggestionHintsNextIcon = registerIcon('inline-suggestion-hints-next', Codicon.chevronRight, localize('parameterHintsNextIcon', 'Icon for show next parameter hint.'));
 const inlineSuggestionHintsPreviousIcon = registerIcon('inline-suggestion-hints-previous', Codicon.chevronLeft, localize('parameterHintsPreviousIcon', 'Icon for show previous parameter hint.'));
 
-class InlineSuggestionHintsContentWidget extends Disposable implements IContentWidget {
+export class InlineSuggestionHintsContentWidget extends Disposable implements IContentWidget {
 	private static id = 0;
 
 	private readonly id = `InlineSuggestionHintsContentWidget${InlineSuggestionHintsContentWidget.id++}`;
@@ -91,7 +97,7 @@ class InlineSuggestionHintsContentWidget extends Disposable implements IContentW
 
 	private readonly nodes = h('div.inlineSuggestionsHints', [
 		h('div', { style: { display: 'flex' } }, [
-			h('div@actionBar'),
+			h('div@actionBar', { className: 'custom-actions' }),
 			h('div@toolBar'),
 		])
 	]);
@@ -103,7 +109,7 @@ class InlineSuggestionHintsContentWidget extends Disposable implements IContentW
 			label,
 			iconClassName,
 			true,
-			() => this.commandService.executeCommand(commandId),
+			() => this._commandService.executeCommand(commandId),
 		);
 		const kb = this.keybindingService.lookupKeybinding(commandId, this._contextKeyService);
 		let tooltip = label;
@@ -118,12 +124,21 @@ class InlineSuggestionHintsContentWidget extends Disposable implements IContentW
 	private readonly availableSuggestionCountAction = new Action('inlineSuggestionHints.availableSuggestionCount', '', undefined, false);
 	private readonly nextAction = this.createCommandAction(showNextInlineSuggestionActionId, localize('next', 'Next'), ThemeIcon.asClassName(inlineSuggestionHintsNextIcon));
 
+	private readonly toolBar: CustomizedMenuWorkbenchToolBar;
+
+	// TODO@hediet: deprecate MenuId.InlineCompletionsActions
+	private readonly inlineCompletionsActionsMenus = this._register(this._menuService.createMenu(
+		MenuId.InlineCompletionsActions,
+		this._contextKeyService
+	));
+
 	constructor(
 		private readonly editor: ICodeEditor,
-		@ICommandService private readonly commandService: ICommandService,
+		@ICommandService private readonly _commandService: ICommandService,
 		@IInstantiationService instantiationService: IInstantiationService,
 		@IKeybindingService private readonly keybindingService: IKeybindingService,
 		@IContextKeyService private readonly _contextKeyService: IContextKeyService,
+		@IMenuService private readonly _menuService: IMenuService,
 	) {
 		super();
 
@@ -133,22 +148,47 @@ class InlineSuggestionHintsContentWidget extends Disposable implements IContentW
 		actionBar.push(this.availableSuggestionCountAction);
 		actionBar.push(this.nextAction, { icon: true, label: false });
 
-		this._register(instantiationService.createInstance(MenuWorkbenchToolBar, this.nodes.toolBar, MenuId.InlineSuggestionToolbar, {
+		this.toolBar = this._register(instantiationService.createInstance(CustomizedMenuWorkbenchToolBar, this.nodes.toolBar, MenuId.InlineSuggestionToolbar, {
 			menuOptions: { renderShortTitle: true },
-			toolbarOptions: { primaryGroup: 'primary' },
+			toolbarOptions: { primaryGroup: g => g.startsWith('primary') },
 			actionViewItemProvider: (action, options) => {
 				return action instanceof MenuItemAction ? instantiationService.createInstance(StatusBarViewItem, action, undefined) : undefined;
 			},
 		}));
 	}
 
-	public update(position: Position | null, currentSuggestionIdx: number, suggestionCount: number | undefined): void {
+	public update(position: Position | null, currentSuggestionIdx: number, suggestionCount: number | undefined, extraCommands: Command[]): void {
 		this.position = position;
 
 		this.previousAction.enabled = this.nextAction.enabled = suggestionCount !== undefined && suggestionCount > 1;
 		this.availableSuggestionCountAction.label = suggestionCount !== undefined ? `${currentSuggestionIdx + 1}/${suggestionCount}` : '1/?';
 
 		this.editor.layoutContentWidget(this);
+
+		const extraActions = extraCommands.map<IAction>(c => ({
+			class: undefined,
+			id: c.id,
+			enabled: true,
+			tooltip: c.tooltip || '',
+			label: c.title,
+			run: (event) => {
+				return this._commandService.executeCommand(c.id);
+			},
+		}));
+
+		for (const [_, group] of this.inlineCompletionsActionsMenus.getActions()) {
+			for (const action of group) {
+				if (action instanceof MenuItemAction) {
+					extraActions.push(action);
+				}
+			}
+		}
+
+		if (extraActions.length > 0) {
+			extraActions.unshift(new Separator());
+		}
+
+		this.toolBar.setAdditionalSecondaryActions(extraActions);
 	}
 
 	getId(): string { return this.id; }
@@ -173,7 +213,51 @@ class StatusBarViewItem extends MenuEntryActionViewItem {
 			return super.updateLabel();
 		}
 		if (this.label) {
-			this.label.textContent = localize({ key: 'content', comment: ['A label', 'A keybinding'] }, '{0} ({1})', this._action.label, kb.getLabel());
+			const div = h('div.keybinding').root;
+			const k = new KeybindingLabel(div, OperatingSystem.Linux);
+			k.set(kb);
+			this.label.textContent = this._action.label;
+			this.label.appendChild(div);
 		}
+	}
+}
+
+export class CustomizedMenuWorkbenchToolBar extends WorkbenchToolBar {
+	private readonly menu = this._store.add(this.menuService.createMenu(this.menuId, this.contextKeyService, { emitEventsForSubmenuChanges: true }));
+	private additionalActions: IAction[] = [];
+
+	constructor(
+		container: HTMLElement,
+		private readonly menuId: MenuId,
+		private readonly options2: IMenuWorkbenchToolBarOptions | undefined,
+		@IMenuService private readonly menuService: IMenuService,
+		@IContextKeyService private readonly contextKeyService: IContextKeyService,
+		@IContextMenuService contextMenuService: IContextMenuService,
+		@IKeybindingService keybindingService: IKeybindingService,
+		@ITelemetryService telemetryService: ITelemetryService,
+	) {
+		super(container, { resetMenu: menuId, ...options2 }, menuService, contextKeyService, contextMenuService, keybindingService, telemetryService);
+
+		this._store.add(this.menu.onDidChange(() => this.updateToolbar()));
+		this.updateToolbar();
+	}
+
+	private updateToolbar(): void {
+		const primary: IAction[] = [];
+		const secondary: IAction[] = [];
+		createAndFillInActionBarActions(
+			this.menu,
+			this.options2?.menuOptions,
+			{ primary, secondary },
+			this.options2?.toolbarOptions?.primaryGroup, this.options2?.toolbarOptions?.shouldInlineSubmenu, this.options2?.toolbarOptions?.useSeparatorsInPrimaryActions
+		);
+
+		secondary.push(...this.additionalActions);
+		this.setActions(primary, secondary);
+	}
+
+	setAdditionalSecondaryActions(actions: IAction[]): void {
+		this.additionalActions = actions;
+		this.updateToolbar();
 	}
 }

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -4325,8 +4325,7 @@ declare namespace monaco.editor {
 		 * Defaults to `prefix`.
 		*/
 		mode?: 'prefix' | 'subword' | 'subwordSmart';
-		useExperimentalHints?: boolean;
-		hideHints?: boolean;
+		showToolbar?: 'always' | 'onHover';
 	}
 
 	export interface IBracketPairColorizationOptions {


### PR DESCRIPTION
Fixes #130550, fixes #167042
Introduces setting `editor.inlineSuggest.showToolbar` (onHover/always) to control behavior of the new inline suggestion toolbar (default onHover).

![gif](https://user-images.githubusercontent.com/2931520/214107173-faa3f02c-7b74-4ee4-8bc1-7baf73ae9943.gif)
