### PR TITLE
[folding] if a FoldingRangeProvider always returns undefined for a file, it should never override the default provider

### DIFF
--- a/src/vs/editor/contrib/folding/browser/folding.ts
+++ b/src/vs/editor/contrib/folding/browser/folding.ts
@@ -63,7 +63,7 @@ export interface FoldingLimitInfo {
 	limited: number | false;
 }
 
-export type FoldingRangeProviderSelector = (formatter: FoldingRangeProvider[], document: ITextModel) => FoldingRangeProvider[] | undefined;
+export type FoldingRangeProviderSelector = (provider: FoldingRangeProvider[], document: ITextModel) => FoldingRangeProvider[] | undefined;
 
 export class FoldingController extends Disposable implements IEditorContribution {
 
@@ -286,12 +286,13 @@ export class FoldingController extends Disposable implements IEditorContribution
 		if (this.rangeProvider) {
 			return this.rangeProvider;
 		}
-		this.rangeProvider = new IndentRangeProvider(editorModel, this.languageConfigurationService, this._foldingLimitReporter); // fallback
+		const indentRangeProvider = new IndentRangeProvider(editorModel, this.languageConfigurationService, this._foldingLimitReporter);
+		this.rangeProvider = indentRangeProvider; // fallback
 		if (this._useFoldingProviders && this.foldingModel) {
 			const foldingProviders = this.languageFeaturesService.foldingRangeProvider.ordered(this.foldingModel.textModel);
 			const selectedProviders = (FoldingController._foldingRangeSelector?.(foldingProviders, editorModel)) ?? foldingProviders;
 			if (selectedProviders.length > 0) {
-				this.rangeProvider = new SyntaxRangeProvider(editorModel, selectedProviders, () => this.triggerFoldingModelChanged(), this._foldingLimitReporter);
+				this.rangeProvider = new SyntaxRangeProvider(editorModel, selectedProviders, () => this.triggerFoldingModelChanged(), this._foldingLimitReporter, indentRangeProvider);
 			}
 		}
 		return this.rangeProvider;

--- a/src/vs/editor/contrib/folding/test/browser/syntaxFold.test.ts
+++ b/src/vs/editor/contrib/folding/test/browser/syntaxFold.test.ts
@@ -77,7 +77,7 @@ suite('Syntax folding', () => {
 		async function assertLimit(maxEntries: number, expectedRanges: IndentRange[], message: string) {
 			let reported: number | false = false;
 			const foldingRangesLimit: FoldingLimitReporter = { limit: maxEntries, report: r => reported = r.limited };
-			const indentRanges = await new SyntaxRangeProvider(model, providers, () => { }, foldingRangesLimit).compute(CancellationToken.None);
+			const indentRanges = await new SyntaxRangeProvider(model, providers, () => { }, foldingRangesLimit, undefined).compute(CancellationToken.None);
 			const actual: IndentRange[] = [];
 			if (indentRanges) {
 				for (let i = 0; i < indentRanges.length; i++) {

--- a/src/vs/workbench/contrib/folding/browser/folding.contribution.ts
+++ b/src/vs/workbench/contrib/folding/browser/folding.contribution.ts
@@ -158,12 +158,12 @@ class DefaultFoldingRangeProvider extends Disposable implements IWorkbenchContri
 		}
 	}
 
-	private _selectFoldingRangeProvider(providers: FoldingRangeProvider[], document: ITextModel): FoldingRangeProvider[] {
+	private _selectFoldingRangeProvider(providers: FoldingRangeProvider[], document: ITextModel): FoldingRangeProvider[] | undefined {
 		const value = this._configurationService.getValue<string>(DefaultFoldingRangeProvider.configName, { overrideIdentifier: document.getLanguageId() });
 		if (value) {
 			return providers.filter(p => p.id === value);
 		}
-		return providers;
+		return undefined;
 	}
 }
 


### PR DESCRIPTION
Fixes #171012