### PR TITLE
ui: reduce transition of status bar background color

### DIFF
--- a/src/vs/workbench/browser/parts/statusbar/media/statusbarpart.css
+++ b/src/vs/workbench/browser/parts/statusbar/media/statusbarpart.css
@@ -11,7 +11,7 @@
 	font-size: 12px;
 	display: flex;
 	overflow: hidden;
-	transition: background-color 0.35s ease-out;
+	transition: background-color 0.15s ease-out;
 }
 
 .monaco-workbench .part.statusbar.status-border-top::after {


### PR DESCRIPTION
When testing a new feature to disable debug treatment of the status bar, I found that debugging felt _much_ more snappy when there wasn't a big slow color fade on the status bar. Rob agreed it was a bit "dramatic."

A 150ms fade instead of a 350ms fade feels much nicer, I think we should try this out for next month's Insiders.

[Do not merge until after endgame]