### PR TITLE
Don't add extra right margin to layout controls

### DIFF
--- a/src/vs/workbench/browser/parts/titlebar/media/titlebarpart.css
+++ b/src/vs/workbench/browser/parts/titlebar/media/titlebarpart.css
@@ -120,8 +120,8 @@
 	/* see #55435 */
 }
 
-.monaco-workbench .part.titlebar > .titlebar-container .monaco-toolbar .action-item {
-	margin-right: 4px;
+.monaco-workbench .part.titlebar > .titlebar-container .monaco-toolbar .actions-container {
+	gap: 4px;
 }
 
 /* Window Title Menu */


### PR DESCRIPTION
#168910 added a right margin between layout control elements. However this also added a right margin to the last element, which means that the layout controls are now all shifted left by 4px

This change switch to use `gap` instead so that there's a 4px margin between elements but no extra margin for the entire set of layout control buttons

Current is top, new is bottom:

![Screenshot 2023-01-24 at 2 43 43 PM](https://user-images.githubusercontent.com/12821956/214438220-75c07c85-2ef8-4798-bd8b-7c0b99adca4a.png)
