### PR TITLE
Make sure only lib files go through `XMLHttpRequest` in TS Server

### DIFF
--- a/extensions/typescript-language-features/web/webServer.ts
+++ b/extensions/typescript-language-features/web/webServer.ts
@@ -152,7 +152,7 @@ function createServerHost(extensionUri: URI, logger: ts.server.Logger, apiClient
 			return true;
 		},
 		readFile(path) {
-			if (!fs || path.startsWith('/')) {
+			if (!fs || path.startsWith('/lib.')) {
 				const webPath = getWebPath(path);
 				if (webPath) {
 					const request = new XMLHttpRequest();


### PR DESCRIPTION
If project wide IntelliSense is enabled, we want to make sure only `lib` files go through the old `XMLHttpRequest` flow

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
