### PR TITLE
Add a11y help to commands to skip shell, make alt+f1

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminalActions.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalActions.ts
@@ -188,12 +188,8 @@ export function registerTerminalActions() {
 					primary: KeyMod.Alt | KeyCode.F1,
 					weight: KeybindingWeight.WorkbenchContrib,
 					linux: {
-						primary: KeyMod.Shift | KeyCode.F1,
-						secondary: [KeyMod.Shift | KeyCode.F1]
-					},
-					win: {
-						primary: KeyMod.Shift | KeyCode.F1,
-						secondary: [KeyMod.Shift | KeyCode.F1]
+						primary: KeyMod.Alt | KeyMod.Shift | KeyCode.F1,
+						secondary: [KeyMod.Alt | KeyCode.F1]
 					},
 					when: TerminalContextKeys.focus
 				}

--- a/src/vs/workbench/contrib/terminal/common/terminal.ts
+++ b/src/vs/workbench/contrib/terminal/common/terminal.ts
@@ -672,6 +672,7 @@ export const DEFAULT_COMMANDS_TO_SKIP_SHELL: string[] = [
 	TerminalCommandId.SelectNextPageSuggestion,
 	TerminalCommandId.AcceptSelectedSuggestion,
 	TerminalCommandId.HideSuggestWidget,
+	TerminalCommandId.ShowTerminalAccessibilityHelp,
 	'editor.action.toggleTabFocusMode',
 	'notifications.hideList',
 	'notifications.hideToasts',


### PR DESCRIPTION
Aligns keybindings with the editor command

Fixes #172196
