### PR TITLE
don't recovery notebook editors from IW notebooks.

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/notebook.contribution.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebook.contribution.ts
@@ -613,7 +613,7 @@ class SimpleNotebookWorkingCopyEditorHandler extends Disposable implements IWork
 		await this._extensionService.whenInstalledExtensionsRegistered();
 
 		this._register(this._workingCopyEditorService.registerHandler({
-			handles: workingCopy => typeof this._getViewType(workingCopy) === 'string',
+			handles: workingCopy => typeof this._getViewType(workingCopy) && workingCopy.resource.scheme !== Schemas.vscodeInteractive,
 			isOpen: (workingCopy, editor) => editor instanceof NotebookEditorInput && editor.viewType === this._getViewType(workingCopy) && isEqual(workingCopy.resource, editor.resource),
 			createEditor: workingCopy => NotebookEditorInput.create(this._instantiationService, workingCopy.resource, this._getViewType(workingCopy)!)
 		}));

--- a/src/vs/workbench/contrib/notebook/browser/notebook.contribution.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebook.contribution.ts
@@ -613,7 +613,10 @@ class SimpleNotebookWorkingCopyEditorHandler extends Disposable implements IWork
 		await this._extensionService.whenInstalledExtensionsRegistered();
 
 		this._register(this._workingCopyEditorService.registerHandler({
-			handles: workingCopy => typeof this._getViewType(workingCopy) && workingCopy.resource.scheme !== Schemas.vscodeInteractive,
+			handles: workingCopy => {
+				const viewType = this._getViewType(workingCopy);
+				return typeof viewType === 'string' && viewType !== 'interactive';
+			},
 			isOpen: (workingCopy, editor) => editor instanceof NotebookEditorInput && editor.viewType === this._getViewType(workingCopy) && isEqual(workingCopy.resource, editor.resource),
 			createEditor: workingCopy => NotebookEditorInput.create(this._instantiationService, workingCopy.resource, this._getViewType(workingCopy)!)
 		}));

--- a/src/vs/workbench/contrib/notebook/common/notebookEditorModel.ts
+++ b/src/vs/workbench/contrib/notebook/common/notebookEditorModel.ts
@@ -252,8 +252,14 @@ export class NotebookFileWorkingCopyModelFactory implements IStoredFileWorkingCo
 			throw new Error('CANNOT open file notebook with this provider');
 		}
 
-		const bytes = await streamToBuffer(stream);
-		const data = await info.serializer.dataToNotebook(bytes);
+		let data: NotebookData = {
+			metadata: {},
+			cells: []
+		};
+		if (resource.scheme !== Schemas.vscodeInteractive) {
+			const bytes = await streamToBuffer(stream);
+			data = await info.serializer.dataToNotebook(bytes);
+		}
 
 		if (token.isCancellationRequested) {
 			throw new CancellationError();


### PR DESCRIPTION
for https://github.com/microsoft/vscode-jupyter/issues/12638

There is a backed-up notebook editor model within an IW, and it should not be recovered as its own notebook editor.
Also just create an empty notebook when creating the notebook model for an IW to avoid any back-ups that may exist.


<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
