### PR TITLE
Restore slice call for decoding file contents

### DIFF
--- a/extensions/typescript-language-features/web/webServer.ts
+++ b/extensions/typescript-language-features/web/webServer.ts
@@ -184,7 +184,9 @@ function createServerHost(extensionUri: URI, logger: ts.server.Logger, apiClient
 			}
 
 			try {
-				return textDecoder.decode(fs.readFile(toResource(path)));
+				// We need to slice the bytes since we can't pass a shared array to text decoder
+				const contents = fs.readFile(toResource(path)).slice();
+				return textDecoder.decode(contents);
 			} catch (error) {
 				logNormal('Error fs.readFile', { path, error });
 				return undefined;


### PR DESCRIPTION
We need to slice the bytes since we can't pass a shared array to text decoder

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
