### PR TITLE
Remove unused classification

### DIFF
--- a/src/vs/workbench/services/search/common/search.ts
+++ b/src/vs/workbench/services/search/common/search.ts
@@ -129,7 +129,6 @@ export const enum QueryType {
 
 /* __GDPR__FRAGMENT__
 	"IPatternInfo" : {
-		"pattern" : { "classification": "CustomerContent", "purpose": "FeatureInsight" },
 		"isRegExp": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true },
 		"isWordMatch": { "classification": "SystemMetaData", "purpose": "FeatureInsight", "isMeasurement": true },
 		"wordSeparators": { "classification": "SystemMetaData", "purpose": "FeatureInsight" },


### PR DESCRIPTION
This was a hanging classification that is no longer used. Removing it to prevent confusion