### PR TITLE
increase search area of quick fixes

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminalQuickFixBuiltinActions.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalQuickFixBuiltinActions.ts
@@ -129,7 +129,7 @@ export function gitPushSetUpstream(): IInternalOptions {
 			lineMatcher: GitPushOutputRegex,
 			anchor: 'bottom',
 			offset: 0,
-			length: 5
+			length: 15
 		},
 		commandExitResult: 'error',
 		getQuickFixes: (matchResult: ITerminalCommandMatchResult) => {
@@ -175,7 +175,7 @@ export function gitCreatePr(): IInternalOptions {
 			lineMatcher: GitCreatePrOutputRegex,
 			anchor: 'bottom',
 			offset: 0,
-			length: 5
+			length: 15
 		},
 		commandExitResult: 'success',
 		getQuickFixes: (matchResult: ITerminalCommandMatchResult) => {


### PR DESCRIPTION
fix #172068

below you see oss then insider's - always reproes if you have 3 splits that are pretty narrow in insider's, but not oss

this is because we check only `length` lines where `length` is the number `\n` in a possibly wrapped string. it often exceeds the length of 5, so we don't find a match. 15 is arbitrary, but seems to work in my testing without being too many

https://user-images.githubusercontent.com/29464607/214704753-8e07c84c-a804-4023-b70e-776f4d3a30cf.mov

