### PR TITLE
Allow telemetry action to run again

### DIFF
--- a/.github/workflows/telemetry.yml
+++ b/.github/workflows/telemetry.yml
@@ -15,5 +15,5 @@ jobs:
 
       - name: 'Run vscode-telemetry-extractor'
         run: 'npx --package=@vscode/telemetry-extractor --yes vscode-telemetry-extractor -s .'
-        with:
+        env:
           GITHUB_TOKEN: ${{secrets.VSCODE_ISSUE_TRIAGE_BOT_PAT}}


### PR DESCRIPTION
Fixes the telemetry job which has been failing for quite some time. Looks like `env` is what we want here and not `with`