### PR TITLE
Git - mark a failed operation completed as soon as the error dialog is shown

### DIFF
--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -3448,7 +3448,7 @@ export class CommandCenter {
 			*/
 			this.telemetryReporter.sendTelemetryEvent('git.command', { command: id });
 
-			return result.catch(async err => {
+			return result.catch(err => {
 				const options: MessageOptions = {
 					modal: true
 				};
@@ -3546,26 +3546,10 @@ export class CommandCenter {
 					return;
 				}
 
-				let result: string | undefined;
-				const allChoices = Array.from(choices.keys());
-
-				switch (type) {
-					case 'error':
-						result = await window.showErrorMessage(message, options, ...allChoices);
-						break;
-					case 'warning':
-						result = await window.showWarningMessage(message, options, ...allChoices);
-						break;
-					case 'information':
-						result = await window.showInformationMessage(message, options, ...allChoices);
-						break;
-				}
-
-				if (result) {
-					const resultFn = choices.get(result);
-
-					resultFn?.();
-				}
+				// We explicitly do not await this promise, because we do not
+				// want the command execution to be stuck waiting for the user
+				// to take action on the notification.
+				this.showErrorNotification(type, message, options, choices);
 			});
 		};
 
@@ -3573,6 +3557,29 @@ export class CommandCenter {
 		(this as any)[key] = result;
 
 		return result;
+	}
+
+	private async showErrorNotification(type: 'error' | 'warning' | 'information', message: string, options: MessageOptions, choices: Map<string, () => void>): Promise<void> {
+		let result: string | undefined;
+		const allChoices = Array.from(choices.keys());
+
+		switch (type) {
+			case 'error':
+				result = await window.showErrorMessage(message, options, ...allChoices);
+				break;
+			case 'warning':
+				result = await window.showWarningMessage(message, options, ...allChoices);
+				break;
+			case 'information':
+				result = await window.showInformationMessage(message, options, ...allChoices);
+				break;
+		}
+
+		if (result) {
+			const resultFn = choices.get(result);
+
+			resultFn?.();
+		}
 	}
 
 	private getSCMResource(uri?: Uri): Resource | undefined {


### PR DESCRIPTION
Fixes #172048