### PR TITLE
Revert "tweak command name (#168214)"

### DIFF
--- a/src/vs/workbench/contrib/quickaccess/browser/commandsQuickAccess.ts
+++ b/src/vs/workbench/contrib/quickaccess/browser/commandsQuickAccess.ts
@@ -196,8 +196,8 @@ export class ClearCommandHistoryAction extends Action2 {
 
 	constructor() {
 		super({
-			id: 'workbench.action.clearPreviousSessionCommandHistory',
-			title: { value: localize('clearPreviousSessionCommandHistory', "Clear Previous Session Command History"), original: 'Clear Previous Session Command History' },
+			id: 'workbench.action.clearCommandHistory',
+			title: { value: localize('clearCommandHistory', "Clear Command History"), original: 'Clear Command History' },
 			f1: true
 		});
 	}
@@ -212,7 +212,7 @@ export class ClearCommandHistoryAction extends Action2 {
 
 			// Ask for confirmation
 			const { confirmed } = await dialogService.confirm({
-				message: localize('confirmClearMessage', "Do you want to clear the previous session command history?"),
+				message: localize('confirmClearMessage', "Do you want to clear the history of recently used commands?"),
 				detail: localize('confirmClearDetail', "This action is irreversible!"),
 				primaryButton: localize({ key: 'clearButtonLabel', comment: ['&& denotes a mnemonic'] }, "&&Clear"),
 				type: 'warning'


### PR DESCRIPTION
This reverts commit 3c84e0d7637df08ffe1e88b63a02d5a684eaab3a.

This name change was applied to the wrong command

See https://github.com/microsoft/vscode/issues/143701