### PR TITLE
fix typo in Errors and Warnings section

### DIFF
--- a/src/vs/workbench/contrib/welcomeWalkthrough/browser/editor/vs_code_editor_walkthrough.ts
+++ b/src/vs/workbench/contrib/welcomeWalkthrough/browser/editor/vs_code_editor_walkthrough.ts
@@ -19,7 +19,7 @@ The core editor in VS Code is packed with features.  This page highlights a numb
 * [Rename Refactoring](#rename-refactoring) - quickly rename symbols across your code base.` : ''}
 * [Formatting](#formatting) - keep your code looking great with inbuilt document & selection formatting.
 * [Code Folding](#code-folding) - focus on the most relevant parts of your code by folding other areas.
-* [Errors and Warnings](#errors-and-warnings) - see errors and warning as you type.
+* [Errors and Warnings](#errors-and-warnings) - see errors and warnings as you type.
 * [Snippets](#snippets) - spend less time typing with snippets.
 * [Emmet](#emmet) - integrated Emmet support takes HTML and CSS editing to the next level.
 * [JavaScript Type Checking](#javascript-type-checking) - perform type checking on your JavaScript file using TypeScript with zero configuration.


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
#172675 
This fixes a single-character typo in the "Errors and Warnings" section of the Editor Playground walkthrough.