### PR TITLE
Only raise OfflineError when actually offline

### DIFF
--- a/src/vs/base/parts/request/browser/request.ts
+++ b/src/vs/base/parts/request/browser/request.ts
@@ -9,10 +9,6 @@ import { canceled } from 'vs/base/common/errors';
 import { IRequestContext, IRequestOptions, OfflineError } from 'vs/base/parts/request/common/request';
 
 export function request(options: IRequestOptions, token: CancellationToken): Promise<IRequestContext> {
-	if (!navigator.onLine) {
-		throw new OfflineError();
-	}
-
 	if (options.proxyAuthorization) {
 		options.headers = {
 			...(options.headers || {}),
@@ -27,7 +23,9 @@ export function request(options: IRequestOptions, token: CancellationToken): Pro
 		setRequestHeaders(xhr, options);
 
 		xhr.responseType = 'arraybuffer';
-		xhr.onerror = e => reject(new Error(xhr.statusText && ('XHR failed: ' + xhr.statusText) || 'XHR failed'));
+		xhr.onerror = e => reject(
+			navigator.onLine ? new Error(xhr.statusText && ('XHR failed: ' + xhr.statusText) || 'XHR failed') : new OfflineError()
+		);
 		xhr.onload = (e) => {
 			resolve({
 				res: {


### PR DESCRIPTION
Fixes #147510
Fixes https://github.com/microsoft/vscode/issues/171130

At least on macOS, `navigator.onLine` seems to be based on the status of the "connectivity icon":
https://support.apple.com/en-gb/guide/mac-help/mchlcedc581e/mac

It's possible to have macOS think it's not connected while there's actually a proxy configured that allows HTTP(S) connectivity:
- The main interface (Wi-Fi/Ethernet) is configured with TCP/IP -> IPv4 set to "Disabled"
- A virtual interface (e.g. `vmnet2`, the host interface for VMware Fusion) is connected to a virtual machine with a bridged network interface to W-Fi/Ethernet
- A HTTP(S) proxy is configured so that network traffic is routed over `vmnet2` to a proxy virtual machine and out to the internet

This configuration will make the Wi-Fi icon look like "No internet", even though there's a proxy available through which applications (e.g. VS Code) can talk to the internet.

However, since #141762, I have to "spoof" macOS into thinking it has network connectivity (change the icon from "No internet" to a "connected" state). Even though VS Code can access the marketplace fine through the configure proxy, `navigator.onLine` will always return `false` if the Wi-Fi icon is not in a "connected" state. If I configure the main interface with a bogus, non-routable IP address, the Wi-Fi icon will change to a "connected" state (even though it can't actually reach anything). Now `navigator.onLine` will return `true`, and VS Code stops throwing errors.

This change moves the throwing of the `OfflineError` to when the request actually fails. The original intent of #141762 is maintained, but it's more accurate as it works around weird `navigator.onLine` quirks.