### PR TITLE
Fixes #172384

### DIFF
--- a/src/vs/editor/common/languages.ts
+++ b/src/vs/editor/common/languages.ts
@@ -656,6 +656,11 @@ export interface InlineCompletionsProvider<T extends InlineCompletions = InlineC
 	handleItemDidShow?(completions: T, item: T['items'][number]): void;
 
 	/**
+	 * Will be called when an item is partially accepted.
+	 */
+	handlePartialAccept?(completions: T, item: T['items'][number], acceptedCharacters: number): void;
+
+	/**
 	 * Will be called when a completions list is no longer in use and can be garbage-collected.
 	*/
 	freeInlineCompletions(completions: T): void;

--- a/src/vs/editor/contrib/inlineCompletions/browser/inlineCompletionsModel.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/inlineCompletionsModel.ts
@@ -562,6 +562,20 @@ export class InlineCompletionsSession extends BaseGhostTextWidgetModel {
 			]
 		);
 		this.editor.setPosition(position.delta(0, partialText.length));
+
+		if (completion.sourceProvider.handlePartialAccept) {
+			const acceptedRange = Range.fromPositions(completion.range.getStartPosition(), position.delta(0, acceptUntilIndexExclusive));
+
+			// This assumes that the inline completion and the model use the same EOL style.
+			// This is not a problem at the moment, because partial acceptance only works for the first line of an
+			// inline completion.
+			const text = this.editor.getModel()!.getValueInRange(acceptedRange);
+			completion.sourceProvider.handlePartialAccept(
+				completion.sourceInlineCompletions,
+				completion.sourceInlineCompletion,
+				text.length,
+			);
+		}
 	}
 
 	public commitCurrentCompletion(): void {

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -6734,6 +6734,10 @@ declare namespace monaco.languages {
 		*/
 		handleItemDidShow?(completions: T, item: T['items'][number]): void;
 		/**
+		 * Will be called when an item is partially accepted.
+		 */
+		handlePartialAccept?(completions: T, item: T['items'][number], acceptedCharacters: number): void;
+		/**
 		 * Will be called when a completions list is no longer in use and can be garbage-collected.
 		*/
 		freeInlineCompletions(completions: T): void;

--- a/src/vs/workbench/api/browser/mainThreadLanguageFeatures.ts
+++ b/src/vs/workbench/api/browser/mainThreadLanguageFeatures.ts
@@ -537,14 +537,19 @@ export class MainThreadLanguageFeatures extends Disposable implements MainThread
 		this._registrations.set(handle, this._languageFeaturesService.completionProvider.register(selector, provider));
 	}
 
-	$registerInlineCompletionsSupport(handle: number, selector: IDocumentFilterDto[], supportsHandleDidShowCompletionItem: boolean): void {
+	$registerInlineCompletionsSupport(handle: number, selector: IDocumentFilterDto[], supportsHandleEvents: boolean): void {
 		const provider: languages.InlineCompletionsProvider<IdentifiableInlineCompletions> = {
 			provideInlineCompletions: async (model: ITextModel, position: EditorPosition, context: languages.InlineCompletionContext, token: CancellationToken): Promise<IdentifiableInlineCompletions | undefined> => {
 				return this._proxy.$provideInlineCompletions(handle, model.uri, position, context, token);
 			},
 			handleItemDidShow: async (completions: IdentifiableInlineCompletions, item: IdentifiableInlineCompletion): Promise<void> => {
-				if (supportsHandleDidShowCompletionItem) {
+				if (supportsHandleEvents) {
 					await this._proxy.$handleInlineCompletionDidShow(handle, completions.pid, item.idx);
+				}
+			},
+			handlePartialAccept: async (completions, item, acceptedCharacters): Promise<void> => {
+				if (supportsHandleEvents) {
+					await this._proxy.$handleInlineCompletionPartialAccept(handle, completions.pid, item.idx, acceptedCharacters);
 				}
 			},
 			freeInlineCompletions: (completions: IdentifiableInlineCompletions): void => {

--- a/src/vs/workbench/api/common/extHost.api.impl.ts
+++ b/src/vs/workbench/api/common/extHost.api.impl.ts
@@ -551,6 +551,9 @@ export function createApiFactoryAndRegisterActors(accessor: ServicesAccessor): I
 				if (provider.handleDidShowCompletionItem) {
 					checkProposedApiEnabled(extension, 'inlineCompletionsAdditions');
 				}
+				if (provider.handleDidPartiallyAcceptCompletionItem) {
+					checkProposedApiEnabled(extension, 'inlineCompletionsAdditions');
+				}
 				return extHostLanguageFeatures.registerInlineCompletionsProvider(extension, checkSelector(selector), provider);
 			},
 			registerDocumentLinkProvider(selector: vscode.DocumentSelector, provider: vscode.DocumentLinkProvider): vscode.Disposable {

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -1784,6 +1784,7 @@ export interface ExtHostLanguageFeaturesShape {
 	$releaseCompletionItems(handle: number, id: number): void;
 	$provideInlineCompletions(handle: number, resource: UriComponents, position: IPosition, context: languages.InlineCompletionContext, token: CancellationToken): Promise<IdentifiableInlineCompletions | undefined>;
 	$handleInlineCompletionDidShow(handle: number, pid: number, idx: number): void;
+	$handleInlineCompletionPartialAccept(handle: number, pid: number, idx: number, acceptedCharacters: number): void;
 	$freeInlineCompletionsList(handle: number, pid: number): void;
 	$provideSignatureHelp(handle: number, resource: UriComponents, position: IPosition, context: languages.SignatureHelpContext, token: CancellationToken): Promise<ISignatureHelpDto | undefined>;
 	$releaseSignatureHelp(handle: number, id: number): void;

--- a/src/vs/workbench/api/common/extHostLanguageFeatures.ts
+++ b/src/vs/workbench/api/common/extHostLanguageFeatures.ts
@@ -1074,6 +1074,8 @@ class InlineCompletionAdapterBase {
 	disposeCompletions(pid: number): void { }
 
 	handleDidShowCompletionItem(pid: number, idx: number): void { }
+
+	handlePartialAccept(pid: number, idx: number, acceptedCharacters: number): void { }
 }
 
 class InlineCompletionAdapter extends InlineCompletionAdapterBase {
@@ -1093,8 +1095,10 @@ class InlineCompletionAdapter extends InlineCompletionAdapterBase {
 		super();
 	}
 
-	public get supportsHandleDidShowCompletionItem(): boolean {
-		return isProposedApiEnabled(this._extension, 'inlineCompletionsAdditions') && typeof this._provider.handleDidShowCompletionItem === 'function';
+	public get supportsHandleEvents(): boolean {
+		return isProposedApiEnabled(this._extension, 'inlineCompletionsAdditions')
+			&& (typeof this._provider.handleDidShowCompletionItem === 'function'
+				|| typeof this._provider.handleDidPartiallyAcceptCompletionItem === 'function');
 	}
 
 	private readonly languageTriggerKindToVSCodeTriggerKind: Record<languages.InlineCompletionTriggerKind, InlineCompletionTriggerKind> = {
@@ -1179,6 +1183,15 @@ class InlineCompletionAdapter extends InlineCompletionAdapterBase {
 		if (completionItem) {
 			if (this._provider.handleDidShowCompletionItem && this._isAdditionsProposedApiEnabled) {
 				this._provider.handleDidShowCompletionItem(completionItem);
+			}
+		}
+	}
+
+	override handlePartialAccept(pid: number, idx: number, acceptedCharacters: number): void {
+		const completionItem = this._references.get(pid)?.items[idx];
+		if (completionItem) {
+			if (this._provider.handleDidPartiallyAcceptCompletionItem && this._isAdditionsProposedApiEnabled) {
+				this._provider.handleDidPartiallyAcceptCompletionItem(completionItem, acceptedCharacters);
 			}
 		}
 	}
@@ -2145,7 +2158,7 @@ export class ExtHostLanguageFeatures implements extHostProtocol.ExtHostLanguageF
 	registerInlineCompletionsProvider(extension: IExtensionDescription, selector: vscode.DocumentSelector, provider: vscode.InlineCompletionItemProvider): vscode.Disposable {
 		const adapter = new InlineCompletionAdapter(extension, this._documents, provider, this._commands.converter);
 		const handle = this._addNewAdapter(adapter, extension);
-		this._proxy.$registerInlineCompletionsSupport(handle, this._transformDocumentSelector(selector), adapter.supportsHandleDidShowCompletionItem);
+		this._proxy.$registerInlineCompletionsSupport(handle, this._transformDocumentSelector(selector), adapter.supportsHandleEvents);
 		return this._createDisposable(handle);
 	}
 
@@ -2156,6 +2169,12 @@ export class ExtHostLanguageFeatures implements extHostProtocol.ExtHostLanguageF
 	$handleInlineCompletionDidShow(handle: number, pid: number, idx: number): void {
 		this._withAdapter(handle, InlineCompletionAdapterBase, async adapter => {
 			adapter.handleDidShowCompletionItem(pid, idx);
+		}, undefined, undefined);
+	}
+
+	$handleInlineCompletionPartialAccept(handle: number, pid: number, idx: number, acceptedCharacters: number): void {
+		this._withAdapter(handle, InlineCompletionAdapterBase, async adapter => {
+			adapter.handlePartialAccept(pid, idx, acceptedCharacters);
 		}, undefined, undefined);
 	}
 

--- a/src/vscode-dts/vscode.proposed.inlineCompletionsAdditions.d.ts
+++ b/src/vscode-dts/vscode.proposed.inlineCompletionsAdditions.d.ts
@@ -18,6 +18,13 @@ declare module 'vscode' {
 	export interface InlineCompletionItemProvider {
 		// eslint-disable-next-line local/vscode-dts-provider-naming
 		handleDidShowCompletionItem?(completionItem: InlineCompletionItem): void;
+
+		/**
+		 * Is called when an inline completion item was accepted partially.
+		 * @param acceptedLength The length of the substring of the inline completion that was accepted already.
+		 */
+		// eslint-disable-next-line local/vscode-dts-provider-naming
+		handleDidPartiallyAcceptCompletionItem?(completionItem: InlineCompletionItem, acceptedLength: number): void;
 	}
 
 	// When finalizing `commands`, make sure to add a corresponding constructor parameter.


### PR DESCRIPTION
Fixes #172384

Inline completion providers can now implement the following method:
```
handleDidPartiallyAcceptCompletionItem: async (completionItem, acceptedLength) => {
	console.log('partially accepted', acceptedLength, completionItem.insertText.substr(0, acceptedLength));
},
 ```

 `acceptedLength` refers to the number of actual characters that have been accepted from `completionItem` (after the snippet is resolved and brackets are auto-completed).