### PR TITLE
Reset simple browser `localResourceRoots` on reload

### DIFF
--- a/extensions/simple-browser/src/simpleBrowserView.ts
+++ b/extensions/simple-browser/src/simpleBrowserView.ts
@@ -17,6 +17,20 @@ export class SimpleBrowserView extends Disposable {
 	public static readonly viewType = 'simpleBrowser.view';
 	private static readonly title = vscode.l10n.t("Simple Browser");
 
+	private static getWebviewLocalResourceRoots(extensionUri: vscode.Uri): readonly vscode.Uri[] {
+		return [
+			vscode.Uri.joinPath(extensionUri, 'media')
+		];
+	}
+
+	private static getWebviewOptions(extensionUri: vscode.Uri): vscode.WebviewOptions {
+		return {
+			enableScripts: true,
+			enableForms: true,
+			localResourceRoots: SimpleBrowserView.getWebviewLocalResourceRoots(extensionUri),
+		};
+	}
+
 	private readonly _webviewPanel: vscode.WebviewPanel;
 
 	private readonly _onDidDispose = this._register(new vscode.EventEmitter<void>());
@@ -31,12 +45,8 @@ export class SimpleBrowserView extends Disposable {
 			viewColumn: showOptions?.viewColumn ?? vscode.ViewColumn.Active,
 			preserveFocus: showOptions?.preserveFocus
 		}, {
-			enableScripts: true,
-			enableForms: true,
 			retainContextWhenHidden: true,
-			localResourceRoots: [
-				vscode.Uri.joinPath(extensionUri, 'media')
-			]
+			...SimpleBrowserView.getWebviewOptions(extensionUri)
 		});
 		return new SimpleBrowserView(extensionUri, url, webview);
 	}
@@ -44,9 +54,9 @@ export class SimpleBrowserView extends Disposable {
 	public static restore(
 		extensionUri: vscode.Uri,
 		url: string,
-		webview: vscode.WebviewPanel,
+		webviewPanel: vscode.WebviewPanel,
 	): SimpleBrowserView {
-		return new SimpleBrowserView(extensionUri, url, webview);
+		return new SimpleBrowserView(extensionUri, url, webviewPanel);
 	}
 
 	private constructor(
@@ -57,6 +67,7 @@ export class SimpleBrowserView extends Disposable {
 		super();
 
 		this._webviewPanel = this._register(webviewPanel);
+		this._webviewPanel.webview.options = SimpleBrowserView.getWebviewOptions(extensionUri);
 
 		this._register(this._webviewPanel.webview.onDidReceiveMessage(e => {
 			switch (e.type) {
@@ -170,7 +181,6 @@ export class SimpleBrowserView extends Disposable {
 function escapeAttribute(value: string | vscode.Uri): string {
 	return value.toString().replace(/"/g, '&quot;');
 }
-
 
 function getNonce() {
 	let text = '';


### PR DESCRIPTION
This makes us set the `localResourceRoots` when the simple browser is reloaded. In codespaces when switching from stable to insiders, this reload can change the extensionUrl, so we can't use the old local resource roots

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
