### PR TITLE
Enable getPreferredSystemLanguages on Linux

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -107,7 +107,7 @@ if (locale) {
 // Pseudo Language Language Pack is being used.
 // In that case, use `en` as the Electron locale.
 
-if (process.platform === 'win32') {
+if (process.platform === 'win32' || process.platform === 'linux') {
 	const electronLocale = (!locale || locale === 'qps-ploc') ? 'en' : locale;
 	app.commandLine.appendSwitch('lang', electronLocale);
 }
@@ -575,7 +575,7 @@ async function resolveNlsConfiguration() {
 		// VS Code moves to Electron 22.
 		// Ref https://github.com/microsoft/vscode/issues/159813
 		// and https://github.com/electron/electron/pull/36035
-		if (process.platform === 'win32'
+		if ((process.platform === 'win32' || process.platform === 'linux')
 			&& 'getPreferredSystemLanguages' in app
 			&& typeof app.getPreferredSystemLanguages === 'function'
 			&& app.getPreferredSystemLanguages().length) {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Ref #169114

This PR passes the locale to Electron on Linux, and then uses the new `app.getPreferredSystemLanguages()` API to fetch the correct system language to use for the language recommender.

I first tested the API in Electron Fiddle on Ubuntu 22.04, and noticed the API returns values such as `en-US` or `zh-HK`. Since the value `C` is filtered out, it is possible for the returned array to be empty, but there is already a check for that in `main.js`. A potential issue is that VS Code has language packs for the `zh-CN` and `zh-TW` locales specifically, and not for other `zh` locales. Therefore, more code might be needed to handle other `zh` locales. 

I have tested this change on Ubuntu 22.04 with a custom Insiders and noticed that when the preferred language is Arabic, the window controls are on the left side. However, the window controls are still on the left side even in Stable. I also confirmed the controls are also on the left side for other programs such as Firefox.

I also set the preferred language to French (France) and confirmed that the language recommender works.