### PR TITLE
Make language servers use webworker typings

### DIFF
--- a/extensions/css-language-features/server/src/browser/cssServerMain.ts
+++ b/extensions/css-language-features/server/src/browser/cssServerMain.ts
@@ -6,8 +6,6 @@
 import { createConnection, BrowserMessageReader, BrowserMessageWriter, Disposable } from 'vscode-languageserver/browser';
 import { RuntimeEnvironment, startServer } from '../cssServer';
 
-declare let self: any;
-
 const messageReader = new BrowserMessageReader(self);
 const messageWriter = new BrowserMessageWriter(self);
 

--- a/extensions/css-language-features/server/src/browser/cssServerWorkerMain.ts
+++ b/extensions/css-language-features/server/src/browser/cssServerWorkerMain.ts
@@ -2,7 +2,6 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-declare let self: any;
 
 import * as l10n from '@vscode/l10n';
 
@@ -25,7 +24,7 @@ const messageHandler = async (e: any) => {
 		}
 		await import('./cssServerMain');
 		if (self.onmessage !== messageHandler) {
-			pendingMessages.forEach(self.onmessage);
+			pendingMessages.forEach(msg => self.onmessage?.(msg));
 			pendingMessages.length = 0;
 		}
 		l10nLog.forEach(console.log);

--- a/extensions/css-language-features/server/tsconfig.json
+++ b/extensions/css-language-features/server/tsconfig.json
@@ -1,7 +1,11 @@
 {
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
-		"outDir": "./out"
+		"outDir": "./out",
+		"lib": [
+			"ES2020",
+			"WebWorker"
+		]
 	},
 	"include": [
 		"src/**/*"

--- a/extensions/html-language-features/server/src/browser/htmlServerMain.ts
+++ b/extensions/html-language-features/server/src/browser/htmlServerMain.ts
@@ -6,8 +6,6 @@
 import { createConnection, BrowserMessageReader, BrowserMessageWriter, Disposable } from 'vscode-languageserver/browser';
 import { RuntimeEnvironment, startServer } from '../htmlServer';
 
-declare let self: any;
-
 const messageReader = new BrowserMessageReader(self);
 const messageWriter = new BrowserMessageWriter(self);
 

--- a/extensions/html-language-features/server/src/browser/htmlServerWorkerMain.ts
+++ b/extensions/html-language-features/server/src/browser/htmlServerWorkerMain.ts
@@ -2,7 +2,6 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-declare let self: any;
 
 import * as l10n from '@vscode/l10n';
 
@@ -25,7 +24,7 @@ const messageHandler = async (e: any) => {
 		}
 		await import('./htmlServerMain');
 		if (self.onmessage !== messageHandler) {
-			pendingMessages.forEach(self.onmessage);
+			pendingMessages.forEach(msg => self.onmessage?.(msg));
 			pendingMessages.length = 0;
 		}
 		l10nLog.forEach(console.log);

--- a/extensions/html-language-features/server/tsconfig.json
+++ b/extensions/html-language-features/server/tsconfig.json
@@ -1,7 +1,11 @@
 {
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
-		"outDir": "./out"
+		"outDir": "./out",
+		"lib": [
+			"ES2020",
+			"WebWorker"
+		]
 	},
 	"include": [
 		"src/**/*"

--- a/extensions/json-language-features/server/src/browser/jsonServerMain.ts
+++ b/extensions/json-language-features/server/src/browser/jsonServerMain.ts
@@ -6,7 +6,6 @@
 import { createConnection, BrowserMessageReader, BrowserMessageWriter, Disposable } from 'vscode-languageserver/browser';
 import { RuntimeEnvironment, startServer } from '../jsonServer';
 
-declare let self: any;
 
 const messageReader = new BrowserMessageReader(self);
 const messageWriter = new BrowserMessageWriter(self);

--- a/extensions/json-language-features/server/src/browser/jsonServerWorkerMain.ts
+++ b/extensions/json-language-features/server/src/browser/jsonServerWorkerMain.ts
@@ -2,7 +2,6 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-declare let self: any;
 
 import * as l10n from '@vscode/l10n';
 
@@ -25,7 +24,7 @@ const messageHandler = async (e: any) => {
 		}
 		await import('./jsonServerMain');
 		if (self.onmessage !== messageHandler) {
-			pendingMessages.forEach(self.onmessage);
+			pendingMessages.forEach(msg => self.onmessage?.(msg));
 			pendingMessages.length = 0;
 		}
 		l10nLog.forEach(console.log);

--- a/extensions/json-language-features/server/tsconfig.json
+++ b/extensions/json-language-features/server/tsconfig.json
@@ -3,7 +3,11 @@
 	"compilerOptions": {
 		"outDir": "./out",
 		"sourceMap": true,
-		"sourceRoot": "../src"
+		"sourceRoot": "../src",
+		"lib": [
+			"ES2020",
+			"WebWorker"
+		]
 	},
 	"include": [
 		"src/**/*"


### PR DESCRIPTION
This makes the css, html, and json language  servers to use the `webworker` typings. This lets us avoid having to redeclare `self`

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
