### PR TITLE
debug: show `output` test when present with variablesReference

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadDebugService.ts
+++ b/src/vs/workbench/api/browser/mainThreadDebugService.ts
@@ -286,7 +286,7 @@ export class MainThreadDebugService implements MainThreadDebugServiceShape, IDeb
 	public $appendDebugConsole(value: string): void {
 		// Use warning as severity to get the orange color for messages coming from the debug extension
 		const session = this.debugService.getViewModel().focusedSession;
-		session?.appendToRepl(value, severity.Warning);
+		session?.appendToRepl({ output: value, sev: severity.Warning });
 	}
 
 	public $acceptDAMessage(handle: number, message: DebugProtocol.ProtocolMessage) {

--- a/src/vs/workbench/contrib/debug/browser/baseDebugView.ts
+++ b/src/vs/workbench/contrib/debug/browser/baseDebugView.ts
@@ -145,7 +145,7 @@ export interface IExpressionTemplateData {
 	currentElement: IExpression | undefined;
 }
 
-export abstract class AbstractExpressionsRenderer implements ITreeRenderer<IExpression, FuzzyScore, IExpressionTemplateData> {
+export abstract class AbstractExpressionsRenderer<T = IExpression> implements ITreeRenderer<T, FuzzyScore, IExpressionTemplateData> {
 
 	constructor(
 		@IDebugService protected debugService: IDebugService,
@@ -185,10 +185,11 @@ export abstract class AbstractExpressionsRenderer implements ITreeRenderer<IExpr
 		return template;
 	}
 
-	renderElement(node: ITreeNode<IExpression, FuzzyScore>, index: number, data: IExpressionTemplateData): void {
-		const { element } = node;
+	public abstract renderElement(node: ITreeNode<T, FuzzyScore>, index: number, data: IExpressionTemplateData): void;
+
+	protected renderExpressionElement(element: IExpression, node: ITreeNode<T, FuzzyScore>, data: IExpressionTemplateData): void {
 		data.currentElement = element;
-		this.renderExpression(element, data, createMatches(node.filterData));
+		this.renderExpression(node.element, data, createMatches(node.filterData));
 		if (data.actionBar) {
 			this.renderActionBar!(data.actionBar, element, data);
 		}
@@ -252,12 +253,12 @@ export abstract class AbstractExpressionsRenderer implements ITreeRenderer<IExpr
 		});
 	}
 
-	protected abstract renderExpression(expression: IExpression, data: IExpressionTemplateData, highlights: IHighlight[]): void;
+	protected abstract renderExpression(expression: T, data: IExpressionTemplateData, highlights: IHighlight[]): void;
 	protected abstract getInputBoxOptions(expression: IExpression, settingValue: boolean): IInputBoxOptions | undefined;
 
 	protected renderActionBar?(actionBar: ActionBar, expression: IExpression, data: IExpressionTemplateData): void;
 
-	disposeElement(node: ITreeNode<IExpression, FuzzyScore>, index: number, templateData: IExpressionTemplateData): void {
+	disposeElement(node: ITreeNode<T, FuzzyScore>, index: number, templateData: IExpressionTemplateData): void {
 		dispose(templateData.elementDisposable);
 		templateData.elementDisposable = [];
 	}

--- a/src/vs/workbench/contrib/debug/browser/repl.ts
+++ b/src/vs/workbench/contrib/debug/browser/repl.ts
@@ -63,7 +63,7 @@ import { FocusSessionActionViewItem } from 'vs/workbench/contrib/debug/browser/d
 import { debugConsoleClearAll, debugConsoleEvaluationPrompt } from 'vs/workbench/contrib/debug/browser/debugIcons';
 import { LinkDetector } from 'vs/workbench/contrib/debug/browser/linkDetector';
 import { ReplFilter } from 'vs/workbench/contrib/debug/browser/replFilter';
-import { ReplAccessibilityProvider, ReplDataSource, ReplDelegate, ReplEvaluationInputsRenderer, ReplEvaluationResultsRenderer, ReplGroupRenderer, ReplRawObjectsRenderer, ReplSimpleElementsRenderer, ReplVariablesRenderer } from 'vs/workbench/contrib/debug/browser/replViewer';
+import { ReplAccessibilityProvider, ReplDataSource, ReplDelegate, ReplEvaluationInputsRenderer, ReplEvaluationResultsRenderer, ReplGroupRenderer, ReplRawObjectsRenderer, ReplOutputElementRenderer, ReplVariablesRenderer } from 'vs/workbench/contrib/debug/browser/replViewer';
 import { CONTEXT_DEBUG_STATE, CONTEXT_IN_DEBUG_REPL, CONTEXT_MULTI_SESSION_REPL, DEBUG_SCHEME, getStateLabel, IDebugConfiguration, IDebugService, IDebugSession, IReplConfiguration, IReplElement, IReplOptions, REPL_VIEW_ID, State } from 'vs/workbench/contrib/debug/common/debug';
 import { Variable } from 'vs/workbench/contrib/debug/common/debugModel';
 import { ReplGroup } from 'vs/workbench/contrib/debug/common/replModel';
@@ -576,7 +576,7 @@ export class Repl extends FilterViewPane implements IHistoryNavigationWidget {
 			this.replDelegate,
 			[
 				this.instantiationService.createInstance(ReplVariablesRenderer, linkDetector),
-				this.instantiationService.createInstance(ReplSimpleElementsRenderer, linkDetector),
+				this.instantiationService.createInstance(ReplOutputElementRenderer, linkDetector),
 				new ReplEvaluationInputsRenderer(),
 				this.instantiationService.createInstance(ReplGroupRenderer, linkDetector),
 				new ReplEvaluationResultsRenderer(linkDetector),

--- a/src/vs/workbench/contrib/debug/browser/replViewer.ts
+++ b/src/vs/workbench/contrib/debug/browser/replViewer.ts
@@ -24,9 +24,9 @@ import { AbstractExpressionsRenderer, IExpressionTemplateData, IInputBoxOptions,
 import { handleANSIOutput } from 'vs/workbench/contrib/debug/browser/debugANSIHandling';
 import { debugConsoleEvaluationInput } from 'vs/workbench/contrib/debug/browser/debugIcons';
 import { LinkDetector } from 'vs/workbench/contrib/debug/browser/linkDetector';
-import { IDebugConfiguration, IDebugService, IDebugSession, IExpression, IExpressionContainer, IReplElement, IReplElementSource, IReplOptions } from 'vs/workbench/contrib/debug/common/debug';
+import { IDebugConfiguration, IDebugService, IDebugSession, IExpression, IExpressionContainer, INestingReplElement, IReplElement, IReplElementSource, IReplOptions } from 'vs/workbench/contrib/debug/common/debug';
 import { Variable } from 'vs/workbench/contrib/debug/common/debugModel';
-import { RawObjectReplElement, ReplEvaluationInput, ReplEvaluationResult, ReplGroup, SimpleReplElement } from 'vs/workbench/contrib/debug/common/replModel';
+import { RawObjectReplElement, ReplEvaluationInput, ReplEvaluationResult, ReplGroup, ReplOutputElement, ReplVariableElement } from 'vs/workbench/contrib/debug/common/replModel';
 import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
 
 const $ = dom.$;
@@ -43,7 +43,7 @@ interface IReplEvaluationResultTemplateData {
 	value: HTMLElement;
 }
 
-interface ISimpleReplElementTemplateData {
+interface IOutputReplElementTemplateData {
 	container: HTMLElement;
 	count: CountBadge;
 	countContainer: HTMLElement;
@@ -145,8 +145,8 @@ export class ReplEvaluationResultsRenderer implements ITreeRenderer<ReplEvaluati
 	}
 }
 
-export class ReplSimpleElementsRenderer implements ITreeRenderer<SimpleReplElement, FuzzyScore, ISimpleReplElementTemplateData> {
-	static readonly ID = 'simpleReplElement';
+export class ReplOutputElementRenderer implements ITreeRenderer<ReplOutputElement, FuzzyScore, IOutputReplElementTemplateData> {
+	static readonly ID = 'outputReplElement';
 
 	constructor(
 		private readonly linkDetector: LinkDetector,
@@ -156,11 +156,11 @@ export class ReplSimpleElementsRenderer implements ITreeRenderer<SimpleReplEleme
 	) { }
 
 	get templateId(): string {
-		return ReplSimpleElementsRenderer.ID;
+		return ReplOutputElementRenderer.ID;
 	}
 
-	renderTemplate(container: HTMLElement): ISimpleReplElementTemplateData {
-		const data: ISimpleReplElementTemplateData = Object.create(null);
+	renderTemplate(container: HTMLElement): IOutputReplElementTemplateData {
+		const data: IOutputReplElementTemplateData = Object.create(null);
 		container.classList.add('output');
 		const expression = dom.append(container, $('.output.expression.value-and-source'));
 
@@ -187,15 +187,15 @@ export class ReplSimpleElementsRenderer implements ITreeRenderer<SimpleReplEleme
 		return data;
 	}
 
-	renderElement({ element }: ITreeNode<SimpleReplElement, FuzzyScore>, index: number, templateData: ISimpleReplElementTemplateData): void {
+	renderElement({ element }: ITreeNode<ReplOutputElement, FuzzyScore>, index: number, templateData: IOutputReplElementTemplateData): void {
 		this.setElementCount(element, templateData);
 		templateData.elementListener = element.onDidChangeCount(() => this.setElementCount(element, templateData));
 		// value
 		dom.clearNode(templateData.value);
 		// Reset classes to clear ansi decorations since templates are reused
 		templateData.value.className = 'value';
-		const result = handleANSIOutput(element.value, this.linkDetector, this.themeService, element.session.root);
-		templateData.value.appendChild(result);
+
+		templateData.value.appendChild(handleANSIOutput(element.value, this.linkDetector, this.themeService, element.session.root));
 
 		templateData.value.classList.add((element.severity === severity.Warning) ? 'warn' : (element.severity === severity.Error) ? 'error' : (element.severity === severity.Ignore) ? 'ignore' : 'info');
 		templateData.source.textContent = element.sourceData ? `${basename(element.sourceData.source.name)}:${element.sourceData.lineNumber}` : '';
@@ -203,7 +203,7 @@ export class ReplSimpleElementsRenderer implements ITreeRenderer<SimpleReplEleme
 		templateData.getReplElementSource = () => element.sourceData;
 	}
 
-	private setElementCount(element: SimpleReplElement, templateData: ISimpleReplElementTemplateData): void {
+	private setElementCount(element: ReplOutputElement, templateData: IOutputReplElementTemplateData): void {
 		if (element.count >= 2) {
 			templateData.count.setCount(element.count);
 			templateData.countContainer.hidden = false;
@@ -212,16 +212,16 @@ export class ReplSimpleElementsRenderer implements ITreeRenderer<SimpleReplEleme
 		}
 	}
 
-	disposeTemplate(templateData: ISimpleReplElementTemplateData): void {
+	disposeTemplate(templateData: IOutputReplElementTemplateData): void {
 		dispose(templateData.toDispose);
 	}
 
-	disposeElement(_element: ITreeNode<SimpleReplElement, FuzzyScore>, _index: number, templateData: ISimpleReplElementTemplateData): void {
+	disposeElement(_element: ITreeNode<ReplOutputElement, FuzzyScore>, _index: number, templateData: IOutputReplElementTemplateData): void {
 		templateData.elementListener.dispose();
 	}
 }
 
-export class ReplVariablesRenderer extends AbstractExpressionsRenderer {
+export class ReplVariablesRenderer extends AbstractExpressionsRenderer<IExpression | ReplVariableElement> {
 
 	static readonly ID = 'replVariable';
 
@@ -237,9 +237,20 @@ export class ReplVariablesRenderer extends AbstractExpressionsRenderer {
 		super(debugService, contextViewService);
 	}
 
-	protected renderExpression(expression: IExpression, data: IExpressionTemplateData, highlights: IHighlight[]): void {
-		renderVariable(expression as Variable, data, true, highlights, this.linkDetector);
-		data.expression.classList.toggle('nested-variable', isNestedVariable(expression));
+	public renderElement(node: ITreeNode<IExpression | ReplVariableElement, FuzzyScore>, _index: number, data: IExpressionTemplateData): void {
+		const element = node.element;
+		super.renderExpressionElement(element instanceof ReplVariableElement ? element.expr : element, node, data);
+	}
+
+	protected renderExpression(expression: IExpression | ReplVariableElement, data: IExpressionTemplateData, highlights: IHighlight[]): void {
+		const isReplVariable = expression instanceof ReplVariableElement;
+		if (isReplVariable || !expression.name) {
+			renderExpressionValue(isReplVariable ? expression.expr : expression, data.value, { showHover: false, colorize: true, linkDetector: this.linkDetector });
+			data.expression.classList.remove('nested-variable');
+		} else {
+			renderVariable(expression as Variable, data, true, highlights, this.linkDetector);
+			data.expression.classList.toggle('nested-variable', isNestedVariable(expression));
+		}
 	}
 
 	protected getInputBoxOptions(expression: IExpression): IInputBoxOptions | undefined {
@@ -324,7 +335,7 @@ export class ReplDelegate extends CachedListVirtualDelegate<IReplElement> {
 			const value = element.value;
 			const valueRows = countNumberOfLines(value)
 				+ (ignoreValueLength ? 0 : Math.floor(value.length / 70)) // Make an estimate for wrapping
-				+ (element instanceof SimpleReplElement ? 0 : 1); // A SimpleReplElement ends in \n if it's a complete line
+				+ (element instanceof ReplOutputElement ? 0 : 1); // A SimpleReplElement ends in \n if it's a complete line
 
 			return Math.max(valueRows, 1) * lineHeight;
 		}
@@ -333,18 +344,17 @@ export class ReplDelegate extends CachedListVirtualDelegate<IReplElement> {
 	}
 
 	getTemplateId(element: IReplElement): string {
-		if (element instanceof Variable && element.name) {
+		if (element instanceof Variable || element instanceof ReplVariableElement) {
 			return ReplVariablesRenderer.ID;
 		}
-		if (element instanceof ReplEvaluationResult || (element instanceof Variable && !element.name)) {
-			// Variable with no name is a top level variable which should be rendered like a repl element #17404
+		if (element instanceof ReplEvaluationResult) {
 			return ReplEvaluationResultsRenderer.ID;
 		}
 		if (element instanceof ReplEvaluationInput) {
 			return ReplEvaluationInputsRenderer.ID;
 		}
-		if (element instanceof SimpleReplElement) {
-			return ReplSimpleElementsRenderer.ID;
+		if (element instanceof ReplOutputElement) {
+			return ReplOutputElementRenderer.ID;
 		}
 		if (element instanceof ReplGroup) {
 			return ReplGroupRenderer.ID;
@@ -374,21 +384,15 @@ export class ReplDataSource implements IAsyncDataSource<IDebugSession, IReplElem
 			return true;
 		}
 
-		return !!(<IExpressionContainer | ReplGroup>element).hasChildren;
+		return !!(<IExpressionContainer | INestingReplElement>element).hasChildren;
 	}
 
 	getChildren(element: IReplElement | IDebugSession): Promise<IReplElement[]> {
 		if (isDebugSession(element)) {
 			return Promise.resolve(element.getReplElements());
 		}
-		if (element instanceof RawObjectReplElement) {
-			return element.getChildren();
-		}
-		if (element instanceof ReplGroup) {
-			return Promise.resolve(element.getChildren());
-		}
 
-		return (<IExpression>element).getChildren();
+		return Promise.resolve((<IExpression | INestingReplElement>element).getChildren());
 	}
 }
 
@@ -402,8 +406,8 @@ export class ReplAccessibilityProvider implements IListAccessibilityProvider<IRe
 		if (element instanceof Variable) {
 			return localize('replVariableAriaLabel', "Variable {0}, value {1}", element.name, element.value);
 		}
-		if (element instanceof SimpleReplElement || element instanceof ReplEvaluationInput || element instanceof ReplEvaluationResult) {
-			return element.value + (element instanceof SimpleReplElement && element.count > 1 ? localize({ key: 'occurred', comment: ['Front will the value of the debug console element. Placeholder will be replaced by a number which represents occurrance count.'] },
+		if (element instanceof ReplOutputElement || element instanceof ReplEvaluationInput || element instanceof ReplEvaluationResult) {
+			return element.value + (element instanceof ReplOutputElement && element.count > 1 ? localize({ key: 'occurred', comment: ['Front will the value of the debug console element. Placeholder will be replaced by a number which represents occurrance count.'] },
 				", occurred {0} times", element.count) : '');
 		}
 		if (element instanceof RawObjectReplElement) {

--- a/src/vs/workbench/contrib/debug/browser/variablesView.ts
+++ b/src/vs/workbench/contrib/debug/browser/variablesView.ts
@@ -414,6 +414,10 @@ export class VariablesRenderer extends AbstractExpressionsRenderer {
 		renderVariable(expression as Variable, data, true, highlights, this.linkDetector);
 	}
 
+	public override renderElement(node: ITreeNode<IExpression, FuzzyScore>, index: number, data: IExpressionTemplateData): void {
+		super.renderExpressionElement(node.element, node, data);
+	}
+
 	protected getInputBoxOptions(expression: IExpression): IInputBoxOptions {
 		const variable = <Variable>expression;
 		return {

--- a/src/vs/workbench/contrib/debug/browser/watchExpressionsView.ts
+++ b/src/vs/workbench/contrib/debug/browser/watchExpressionsView.ts
@@ -18,7 +18,7 @@ import { ActionBar } from 'vs/base/browser/ui/actionbar/actionbar';
 import { IListVirtualDelegate } from 'vs/base/browser/ui/list/list';
 import { IListAccessibilityProvider } from 'vs/base/browser/ui/list/listWidget';
 import { WorkbenchAsyncDataTree } from 'vs/platform/list/browser/listService';
-import { IAsyncDataSource, ITreeMouseEvent, ITreeContextMenuEvent, ITreeDragAndDrop, ITreeDragOverReaction } from 'vs/base/browser/ui/tree/tree';
+import { IAsyncDataSource, ITreeMouseEvent, ITreeContextMenuEvent, ITreeDragAndDrop, ITreeDragOverReaction, ITreeNode } from 'vs/base/browser/ui/tree/tree';
 import { IDragAndDropData } from 'vs/base/browser/dnd';
 import { ElementsDragAndDropData } from 'vs/base/browser/ui/list/listView';
 import { FuzzyScore } from 'vs/base/common/filters';
@@ -278,6 +278,10 @@ class WatchExpressionsRenderer extends AbstractExpressionsRenderer {
 
 	get templateId() {
 		return WatchExpressionsRenderer.ID;
+	}
+
+	public override renderElement(node: ITreeNode<IExpression, FuzzyScore>, index: number, data: IExpressionTemplateData): void {
+		super.renderExpressionElement(node.element, node, data);
 	}
 
 	protected renderExpression(expression: IExpression, data: IExpressionTemplateData, highlights: IHighlight[]): void {

--- a/src/vs/workbench/contrib/debug/common/debug.ts
+++ b/src/vs/workbench/contrib/debug/common/debug.ts
@@ -132,6 +132,11 @@ export interface IReplElement extends ITreeElement {
 	readonly sourceData?: IReplElementSource;
 }
 
+export interface INestingReplElement extends IReplElement {
+	readonly hasChildren: boolean;
+	getChildren(): Promise<IReplElement[]> | IReplElement[];
+}
+
 export interface IReplElementSource {
 	readonly source: Source;
 	readonly lineNumber: number;
@@ -291,6 +296,31 @@ export interface IMemoryRegion extends IDisposable {
 	write(offset: number, data: VSBuffer): Promise<number>;
 }
 
+/** Data that can be inserted in {@link IDebugSession.appendToRepl} */
+export interface INewReplElementData {
+	/**
+	 * Output string to display
+	 */
+	output: string;
+
+	/**
+	 * Expression data to display. Will result in the item being expandable in
+	 * the REPL. Its value will be used if {@link output} is not provided.
+	 */
+	expression?: IExpression;
+
+	/**
+	 * Output severity.
+	 */
+	sev: severity;
+
+	/**
+	 * Originating location.
+	 */
+	source?: IReplElementSource;
+}
+
+
 export interface IDebugSession extends ITreeElement {
 
 	readonly configuration: IConfig;
@@ -332,7 +362,7 @@ export interface IDebugSession extends ITreeElement {
 	hasSeparateRepl(): boolean;
 	removeReplExpressions(): void;
 	addReplExpression(stackFrame: IStackFrame | undefined, name: string): Promise<void>;
-	appendToRepl(data: string | IExpression, severity: severity, isImportant?: boolean, source?: IReplElementSource): void;
+	appendToRepl(data: INewReplElementData): void;
 
 	// session events
 	readonly onDidEndAdapter: Event<AdapterEndEvent | undefined>;

--- a/src/vs/workbench/contrib/debug/common/replModel.ts
+++ b/src/vs/workbench/contrib/debug/common/replModel.ts
@@ -9,14 +9,18 @@ import { isObject, isString } from 'vs/base/common/types';
 import { generateUuid } from 'vs/base/common/uuid';
 import * as nls from 'vs/nls';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
-import { IDebugConfiguration, IDebugSession, IExpression, IReplElement, IReplElementSource, IStackFrame } from 'vs/workbench/contrib/debug/common/debug';
+import { IDebugConfiguration, IDebugSession, IExpression, INestingReplElement, IReplElement, IReplElementSource, IStackFrame } from 'vs/workbench/contrib/debug/common/debug';
 import { ExpressionContainer } from 'vs/workbench/contrib/debug/common/debugModel';
 
 const MAX_REPL_LENGTH = 10000;
 let topReplElementCounter = 0;
 const getUniqueId = () => `topReplElement:${topReplElementCounter++}`;
 
-export class SimpleReplElement implements IReplElement {
+/**
+ * General case of data from DAP the `output` event. {@link ReplVariableElement}
+ * is used instead only if there is a `variablesReference` with no `output` text.
+ */
+export class ReplOutputElement implements INestingReplElement {
 
 	private _count = 1;
 	private _onDidChangeCount = new Emitter<void>();
@@ -27,7 +31,9 @@ export class SimpleReplElement implements IReplElement {
 		public value: string,
 		public severity: severity,
 		public sourceData?: IReplElementSource,
-	) { }
+		public readonly expression?: IExpression,
+	) {
+	}
 
 	toString(includeSource = false): string {
 		let valueRespectCount = this.value;
@@ -42,6 +48,10 @@ export class SimpleReplElement implements IReplElement {
 		return this.id;
 	}
 
+	getChildren(): Promise<IReplElement[]> {
+		return this.expression?.getChildren() || Promise.resolve([]);
+	}
+
 	set count(value: number) {
 		this._count = value;
 		this._onDidChangeCount.fire();
@@ -54,9 +64,39 @@ export class SimpleReplElement implements IReplElement {
 	get onDidChangeCount(): Event<void> {
 		return this._onDidChangeCount.event;
 	}
+
+	get hasChildren() {
+		return !!this.expression?.hasChildren;
+	}
 }
 
-export class RawObjectReplElement implements IExpression {
+/** Top-level variable logged via DAP output when there's no `output` string */
+export class ReplVariableElement implements INestingReplElement {
+	public readonly hasChildren: boolean;
+	private readonly id = generateUuid();
+
+	constructor(
+		public readonly expr: IExpression,
+		public readonly severity: severity,
+		public readonly sourceData?: IReplElementSource,
+	) {
+		this.hasChildren = expr.hasChildren;
+	}
+
+	getChildren(): IReplElement[] | Promise<IReplElement[]> {
+		return this.expr.getChildren();
+	}
+
+	toString(): string {
+		return this.expr.toString();
+	}
+
+	getId(): string {
+		return this.id;
+	}
+}
+
+export class RawObjectReplElement implements IExpression, INestingReplElement {
 
 	private static readonly MAX_CHILDREN = 1000; // upper bound of children per value
 
@@ -145,7 +185,7 @@ export class ReplEvaluationResult extends ExpressionContainer implements IReplEl
 	}
 }
 
-export class ReplGroup implements IReplElement {
+export class ReplGroup implements INestingReplElement {
 
 	private children: IReplElement[] = [];
 	private id: string;
@@ -211,6 +251,13 @@ function areSourcesEqual(first: IReplElementSource | undefined, second: IReplEle
 	return false;
 }
 
+export interface INewReplElementData {
+	output: string;
+	expression?: IExpression;
+	sev: severity;
+	source?: IReplElementSource;
+}
+
 export class ReplModel {
 	private replElements: IReplElement[] = [];
 	private readonly _onDidChangeElements = new Emitter<void>();
@@ -229,40 +276,43 @@ export class ReplModel {
 		this.addReplElement(result);
 	}
 
-	appendToRepl(session: IDebugSession, data: string | IExpression, sev: severity, source?: IReplElementSource): void {
+	appendToRepl(session: IDebugSession, { output, expression, sev, source }: INewReplElementData): void {
 		const clearAnsiSequence = '\u001b[2J';
-		if (typeof data === 'string' && data.indexOf(clearAnsiSequence) >= 0) {
+		const clearAnsiIndex = output.lastIndexOf(clearAnsiSequence);
+		if (clearAnsiIndex !== -1) {
 			// [2J is the ansi escape sequence for clearing the display http://ascii-table.com/ansi-escape-sequences.php
 			this.removeReplExpressions();
-			this.appendToRepl(session, nls.localize('consoleCleared', "Console was cleared"), severity.Ignore);
-			data = data.substring(data.lastIndexOf(clearAnsiSequence) + clearAnsiSequence.length);
+			this.appendToRepl(session, { output: nls.localize('consoleCleared', "Console was cleared"), sev: severity.Ignore });
+			output = output.substring(clearAnsiIndex + clearAnsiSequence.length);
 		}
 
-		if (typeof data === 'string') {
-			const previousElement = this.replElements.length ? this.replElements[this.replElements.length - 1] : undefined;
-			if (previousElement instanceof SimpleReplElement && previousElement.severity === sev) {
-				const config = this.configurationService.getValue<IDebugConfiguration>('debug');
-				if (previousElement.value === data && areSourcesEqual(previousElement.sourceData, source) && config.console.collapseIdenticalLines) {
-					previousElement.count++;
-					// No need to fire an event, just the count updates and badge will adjust automatically
-					return;
-				}
-				if (!previousElement.value.endsWith('\n') && !previousElement.value.endsWith('\r\n') && previousElement.count === 1) {
-					this.replElements[this.replElements.length - 1] = new SimpleReplElement(
-						session, getUniqueId(), previousElement.value + data, sev, source);
-					this._onDidChangeElements.fire();
-					return;
-				}
+		if (expression) {
+			// if there is an output string, prefer to show that, since the DA could
+			// have formatted it nicely e.g. with ANSI color codes.
+			this.addReplElement(output
+				? new ReplOutputElement(session, getUniqueId(), output, sev, source, expression)
+				: new ReplVariableElement(expression, sev, source));
+			return;
+		}
+
+		const previousElement = this.replElements.length ? this.replElements[this.replElements.length - 1] : undefined;
+		if (previousElement instanceof ReplOutputElement && previousElement.severity === sev) {
+			const config = this.configurationService.getValue<IDebugConfiguration>('debug');
+			if (previousElement.value === output && areSourcesEqual(previousElement.sourceData, source) && config.console.collapseIdenticalLines) {
+				previousElement.count++;
+				// No need to fire an event, just the count updates and badge will adjust automatically
+				return;
 			}
-
-			const element = new SimpleReplElement(session, getUniqueId(), data, sev, source);
-			this.addReplElement(element);
-		} else {
-			// TODO@Isidor hack, we should introduce a new type which is an output that can fetch children like an expression
-			(<any>data).severity = sev;
-			(<any>data).sourceData = source;
-			this.addReplElement(data);
+			if (!previousElement.value.endsWith('\n') && !previousElement.value.endsWith('\r\n') && previousElement.count === 1) {
+				this.replElements[this.replElements.length - 1] = new ReplOutputElement(
+					session, getUniqueId(), previousElement.value + output, sev, source);
+				this._onDidChangeElements.fire();
+				return;
+			}
 		}
+
+		const element = new ReplOutputElement(session, getUniqueId(), output, sev, source);
+		this.addReplElement(element);
 	}
 
 	startGroup(name: string, autoExpand: boolean, sourceData?: IReplElementSource): void {

--- a/src/vs/workbench/contrib/debug/test/common/mockDebug.ts
+++ b/src/vs/workbench/contrib/debug/test/common/mockDebug.ts
@@ -6,13 +6,12 @@
 import { DeferredPromise } from 'vs/base/common/async';
 import { CancellationToken } from 'vs/base/common/cancellation';
 import { Event } from 'vs/base/common/event';
-import Severity from 'vs/base/common/severity';
 import { URI as uri } from 'vs/base/common/uri';
 import { IPosition, Position } from 'vs/editor/common/core/position';
 import { ITextModel } from 'vs/editor/common/model';
 import { IWorkspaceFolder } from 'vs/platform/workspace/common/workspace';
 import { AbstractDebugAdapter } from 'vs/workbench/contrib/debug/common/abstractDebugAdapter';
-import { AdapterEndEvent, IAdapterManager, IBreakpoint, IBreakpointData, IBreakpointUpdateData, IConfig, IConfigurationManager, IDataBreakpoint, IDebugger, IDebugModel, IDebugService, IDebugSession, IDebugSessionOptions, IEvaluate, IExceptionBreakpoint, IExceptionInfo, IExpression, IFunctionBreakpoint, IInstructionBreakpoint, ILaunch, IMemoryRegion, IRawModelUpdate, IRawStoppedDetails, IReplElement, IReplElementSource, IStackFrame, IThread, IViewModel, LoadedSourceEvent, State } from 'vs/workbench/contrib/debug/common/debug';
+import { AdapterEndEvent, IAdapterManager, IBreakpoint, IBreakpointData, IBreakpointUpdateData, IConfig, IConfigurationManager, IDataBreakpoint, IDebugger, IDebugModel, IDebugService, IDebugSession, IDebugSessionOptions, IEvaluate, IExceptionBreakpoint, IExceptionInfo, IExpression, IFunctionBreakpoint, IInstructionBreakpoint, ILaunch, IMemoryRegion, INewReplElementData, IRawModelUpdate, IRawStoppedDetails, IReplElement, IStackFrame, IThread, IViewModel, LoadedSourceEvent, State } from 'vs/workbench/contrib/debug/common/debug';
 import { DebugCompoundRoot } from 'vs/workbench/contrib/debug/common/debugCompoundRoot';
 import { Breakpoint, DataBreakpoint, ExceptionBreakpoint, Expression, FunctionBreakpoint } from 'vs/workbench/contrib/debug/common/debugModel';
 import { Source } from 'vs/workbench/contrib/debug/common/debugSource';
@@ -252,7 +251,7 @@ export class MockSession implements IDebugSession {
 		return Promise.resolve(undefined);
 	}
 
-	appendToRepl(data: string | IExpression, severity: Severity, isImportant?: boolean, source?: IReplElementSource): void { }
+	appendToRepl(data: INewReplElementData): void { }
 
 	configuration: IConfig = { type: 'mock', name: 'mock', request: 'launch' };
 	unresolvedConfiguration: IConfig = { type: 'mock', name: 'mock', request: 'launch' };


### PR DESCRIPTION
Previously, if a DAP output event contained a variablesReference, we
would entirely ignore the `output` text in favor of shows its variables.
However, output can be richer than variable data: namely, it can show
ANSI sequences which would be inappropriate to format in
a variable `value`.

In this PR, if an output event has a single variable in its
`variablesReference` and output text, we show the output text instead
of the variable value. (Maybe we should also log output as plain text,
though this could be a confusing experience. I don't know of any DA's
that actually emit >1 variable in their output.)

For #172868
For #171732

(will need adoption in js-debug to actually fix those)

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
