### PR TITLE
testing: fix missing getter for resolveHandler

### DIFF
--- a/src/vs/workbench/contrib/testing/common/testItemCollection.ts
+++ b/src/vs/workbench/contrib/testing/common/testItemCollection.ts
@@ -191,6 +191,10 @@ export class TestItemCollection<T extends ITestItemLike> extends Disposable {
 		}
 	}
 
+	public get resolveHandler() {
+		return this._resolveHandler;
+	}
+
 	/**
 	 * Fires when an operation happens that should result in a diff.
 	 */


### PR DESCRIPTION
Found this writing my own test extension 🤦‍♂️ `TestController.resolveHandler`
was settable, but would always return undefined on access.

I'm surprised that property access with a missing getter compiled at all.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
