### PR TITLE
Revert "Sends test result messages over to extension host. Fixes regression. (#173028)

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadTesting.ts
+++ b/src/vs/workbench/api/browser/mainThreadTesting.ts
@@ -45,7 +45,7 @@ export class MainThreadTesting extends Disposable implements MainThreadTestingSh
 
 		this._register(resultService.onResultsChanged(evt => {
 			const results = 'completed' in evt ? evt.completed : ('inserted' in evt ? evt.inserted : undefined);
-			const serialized = results?.toJSONWithMessages();
+			const serialized = results?.toJSON();
 			if (serialized) {
 				this.proxy.$publishTestResults([serialized]);
 			}

--- a/src/vs/workbench/contrib/testing/common/testResult.ts
+++ b/src/vs/workbench/contrib/testing/common/testResult.ts
@@ -86,11 +86,6 @@ export interface ITestResult {
 	 * in the workspace.
 	 */
 	toJSON(): ISerializedTestResults | undefined;
-
-	/**
-	 * Serializes the test result, includes messages. Used to send the test states to the extension host.
-	 */
-	toJSONWithMessages(): ISerializedTestResults | undefined;
 }
 
 export const resultItemParents = function* (results: ITestResult, item: TestResultItem) {
@@ -506,10 +501,6 @@ export class LiveTestResult implements ITestResult {
 		return this.completedAt && this.persist ? this.doSerialize.value : undefined;
 	}
 
-	public toJSONWithMessages(): ISerializedTestResults | undefined {
-		return this.completedAt && this.persist ? this.doSerializeWithMessages.value : undefined;
-	}
-
 	/**
 	 * Updates all tests in the collection to the given state.
 	 */
@@ -593,15 +584,6 @@ export class LiveTestResult implements ITestResult {
 		name: this.name,
 		request: this.request,
 		items: [...this.testById.values()].map(TestResultItem.serializeWithoutMessages),
-	}));
-
-	private readonly doSerializeWithMessages = new Lazy((): ISerializedTestResults => ({
-		id: this.id,
-		completedAt: this.completedAt!,
-		tasks: this.tasks.map(t => ({ id: t.id, name: t.name })),
-		name: this.name,
-		request: this.request,
-		items: [...this.testById.values()].map(TestResultItem.serialize),
 	}));
 }
 
@@ -699,12 +681,5 @@ export class HydratedTestResult implements ITestResult {
 	 */
 	public toJSON(): ISerializedTestResults | undefined {
 		return this.persist ? this.serialized : undefined;
-	}
-
-	/**
-	 * @inheritdoc
-	 */
-	public toJSONWithMessages(): ISerializedTestResults | undefined {
-		return this.toJSON();
 	}
 }


### PR DESCRIPTION
This reverts commit 4e01d21e4a9e4972249469bf1d1daa052604636c.

Reverting, because I wanted @connor4312 to review the PR and I accidentally enabled auto-merge.