### PR TITLE
Shows "Accept Combination (Incoming first)" when combination is order-sensitive.

### DIFF
--- a/src/vs/workbench/contrib/mergeEditor/browser/view/conflictActions.ts
+++ b/src/vs/workbench/contrib/mergeEditor/browser/view/conflictActions.ts
@@ -136,8 +136,12 @@ export class ActionsSource {
 					);
 
 					if (modifiedBaseRange.canBeCombined) {
+						const commandName = modifiedBaseRange.isOrderRelevant
+							? localize('acceptBoth0First', "Accept Combination ({0} first)", inputData.title)
+							: localize('acceptBoth', "Accept Combination");
+
 						result.push(
-							command(localize('acceptBoth', "Accept Combination"), async () => {
+							command(commandName, async () => {
 								transaction((tx) => {
 									model.setState(
 										modifiedBaseRange,

--- a/src/vs/workbench/contrib/mergeEditor/browser/view/conflictActions.ts
+++ b/src/vs/workbench/contrib/mergeEditor/browser/view/conflictActions.ts
@@ -137,7 +137,7 @@ export class ActionsSource {
 
 					if (modifiedBaseRange.canBeCombined) {
 						const commandName = modifiedBaseRange.isOrderRelevant
-							? localize('acceptBoth0First', "Accept Combination ({0} first)", inputData.title)
+							? localize('acceptBoth0First', "Accept Combination ({0} First)", inputData.title)
 							: localize('acceptBoth', "Accept Combination");
 
 						result.push(


### PR DESCRIPTION
In some situations, "Accept Combination" can put Incoming or Current first (e.g. when both append a parameter to the same signature).

I think it is helpful to indicate that clicking "Accept Combination" in the left editor puts Incoming first, while clicking "Accept Combination" in the right editor puts Current first in such cases.
Personally, it makes it easier to decide which side to take when I know the combination is not order-sensitive (which is the common case).

In cases where the order does not matter, only "Accept Combination" should be shown.

![image](https://user-images.githubusercontent.com/2931520/216074321-91d16eb8-a99d-4ad0-b971-da7a087c3261.png)

The addition `Accept Combination (Incoming first)` looks a bit ugly at first, but since it is not the common case I would favor clarity over looks here. When `(Incoming first)` or `(Current first)` is missing, the user can learn that the order does not matter in such cases.