### PR TITLE
Deduce parent element from compressed node instead of stored info

### DIFF
--- a/src/vs/workbench/contrib/search/browser/searchActionsTopBar.ts
+++ b/src/vs/workbench/contrib/search/browser/searchActionsTopBar.ts
@@ -290,7 +290,9 @@ function collapseDeepestExpandedLevel(accessor: ServicesAccessor) {
 					let nodeToTest = node;
 
 					if (node instanceof FolderMatch) {
-						nodeToTest = node.compressionStartParent ?? node;
+						const compressionStartNode = viewer.getCompressedTreeNode(node).element?.elements[0];
+						// Match elements should never be compressed, so !(compressionStartNode instanceof Match) should always be true here
+						nodeToTest = (compressionStartNode && !(compressionStartNode instanceof Match)) ? compressionStartNode : node;
 					}
 
 					const immediateParent = nodeToTest.parent();
@@ -317,7 +319,9 @@ function collapseDeepestExpandedLevel(accessor: ServicesAccessor) {
 					let nodeToTest = node;
 
 					if (node instanceof FolderMatch) {
-						nodeToTest = node.compressionStartParent ?? node;
+						const compressionStartNode = viewer.getCompressedTreeNode(node).element?.elements[0];
+						// Match elements should never be compressed, so !(compressionStartNode instanceof Match) should always be true here
+						nodeToTest = (compressionStartNode && !(compressionStartNode instanceof Match)) ? compressionStartNode : node;
 					}
 					const immediateParent = nodeToTest.parent();
 

--- a/src/vs/workbench/contrib/search/browser/searchResultsView.ts
+++ b/src/vs/workbench/contrib/search/browser/searchResultsView.ts
@@ -98,7 +98,6 @@ export class FolderMatchRenderer extends Disposable implements ICompressibleTree
 	renderCompressedElements(node: ITreeNode<ICompressedTreeNode<FolderMatch>, any>, index: number, templateData: IFolderMatchTemplate, height: number | undefined): void {
 		const compressed = node.element;
 		const folder = compressed.elements[compressed.elements.length - 1];
-		folder.compressionStartParent = compressed.elements[0];
 		const label = compressed.elements.map(e => e.name());
 
 		if (folder.resource) {
@@ -149,7 +148,6 @@ export class FolderMatchRenderer extends Disposable implements ICompressibleTree
 
 	renderElement(node: ITreeNode<FolderMatch, any>, index: number, templateData: IFolderMatchTemplate): void {
 		const folderMatch = node.element;
-		folderMatch.compressionStartParent = undefined;
 		if (folderMatch.resource) {
 			const workspaceFolder = this.contextService.getWorkspaceFolder(folderMatch.resource);
 			if (workspaceFolder && isEqual(workspaceFolder.uri, folderMatch.resource)) {

--- a/src/vs/workbench/contrib/search/common/searchModel.ts
+++ b/src/vs/workbench/contrib/search/common/searchModel.ts
@@ -511,9 +511,6 @@ export class FolderMatch extends Disposable {
 	private _replacingAll: boolean = false;
 	private _name: Lazy<string>;
 
-	// if this is compressed in a node with other FolderMatches, then this is set to the parent where compression starts
-	public compressionStartParent: FolderMatch | undefined;
-
 	constructor(
 		protected _resource: URI | null,
 		private _id: string,


### PR DESCRIPTION
Fixes #163599

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
