### PR TITLE
Adds an option to populate  from snippet to a blank file prompt

### DIFF
--- a/src/vs/workbench/contrib/codeEditor/browser/untitledTextEditorHint/untitledTextEditorHint.ts
+++ b/src/vs/workbench/contrib/codeEditor/browser/untitledTextEditorHint/untitledTextEditorHint.ts
@@ -113,7 +113,7 @@ class UntitledTextEditorHintContentWidget implements IContentWidget {
 					'Preserve double-square brackets and their order',
 					'language refers to a programming language'
 				]
-			}, '[[Select a language]], [[fill with template]], or [[open a different editor]] to get started.\nStart typing to dismiss or [[don\'t show]] this again.');
+			}, '[[Select a language]], or [[fill with template]], or [[open a different editor]] to get started.\nStart typing to dismiss or [[don\'t show]] this again.');
 			const hintHandler: IContentActionHandler = {
 				disposables: this.toDispose,
 				callback: (index, event) => {

--- a/src/vs/workbench/contrib/codeEditor/browser/untitledTextEditorHint/untitledTextEditorHint.ts
+++ b/src/vs/workbench/contrib/codeEditor/browser/untitledTextEditorHint/untitledTextEditorHint.ts
@@ -113,7 +113,7 @@ class UntitledTextEditorHintContentWidget implements IContentWidget {
 					'Preserve double-square brackets and their order',
 					'language refers to a programming language'
 				]
-			}, '[[Select a language]], or [[open a different editor]] to get started.\nStart typing to dismiss or [[don\'t show]] this again.');
+			}, '[[Select a language]], [[fill with template]], or [[open a different editor]] to get started.\nStart typing to dismiss or [[don\'t show]] this again.');
 			const hintHandler: IContentActionHandler = {
 				disposables: this.toDispose,
 				callback: (index, event) => {
@@ -122,9 +122,12 @@ class UntitledTextEditorHintContentWidget implements IContentWidget {
 							languageOnClickOrTap(event.browserEvent);
 							break;
 						case '1':
-							chooseEditorOnClickOrTap(event.browserEvent);
+							snippetOnClickOrTap(event.browserEvent);
 							break;
 						case '2':
+							chooseEditorOnClickOrTap(event.browserEvent);
+							break;
+						case '3':
 							dontShowOnClickOrTap();
 							break;
 					}
@@ -153,6 +156,12 @@ class UntitledTextEditorHintContentWidget implements IContentWidget {
 				this.editor.focus();
 				await this.commandService.executeCommand(ChangeLanguageAction.ID, { from: 'hint' });
 				this.editor.focus();
+			};
+
+			const snippetOnClickOrTap = async (e: UIEvent) => {
+				e.stopPropagation();
+
+				await this.commandService.executeCommand(ApplyFileSnippetAction.Id);
 			};
 
 			const chooseEditorOnClickOrTap = async (e: UIEvent) => {

--- a/src/vs/workbench/contrib/snippets/browser/commands/fileTemplateSnippets.ts
+++ b/src/vs/workbench/contrib/snippets/browser/commands/fileTemplateSnippets.ts
@@ -25,8 +25,8 @@ export class ApplyFileSnippetAction extends SnippetsAction {
 		super({
 			id: ApplyFileSnippetAction.Id,
 			title: {
-				value: localize('label', 'Populate File from Snippet'),
-				original: 'Populate File from Snippet'
+				value: localize('label', 'Fill File with Snippet'),
+				original: 'Fill File with Snippet'
 			},
 			f1: true,
 		});

--- a/src/vs/workbench/contrib/snippets/browser/commands/fileTemplateSnippets.ts
+++ b/src/vs/workbench/contrib/snippets/browser/commands/fileTemplateSnippets.ts
@@ -63,6 +63,8 @@ export class ApplyFileSnippetAction extends SnippetsAction {
 
 			// set language if possible
 			modelService.setMode(editor.getModel(), langService.createById(selection.langId), ApplyFileSnippetAction.Id);
+
+			editor.focus();
 		}
 	}
 


### PR DESCRIPTION
Before: 
<img width="845" alt="Screenshot 2023-02-02 at 09 41 49" src="https://user-images.githubusercontent.com/16353531/216274124-a83f1c73-e500-407c-b3fb-f02011498c25.png">

After: 
<img width="845" alt="Screenshot 2023-02-01 at 18 00 16" src="https://user-images.githubusercontent.com/16353531/216274177-87feefb7-5bf7-45fc-8a27-f282fff82e6b.png">

I am a bit worried, however, that the new text is hard on eyes (difficult to read, "select language" and "create from template" are not well separated). Would something like this read better? Note how this prompt now indicates the "why" (to get started) first and has well separated buttons

<img width="845" alt="Screenshot 2023-02-01 at 18 04 20" src="https://user-images.githubusercontent.com/16353531/216274457-09bfdeb3-68db-4a1b-b35b-d66c524adc99.png">

other options: 

```
Blank page. Start typing to dismiss... 
You can also select a language | fill with template | open a different editor 
Don't show this again.
```

cc @jrieken @isidorn
