### PR TITLE
Fix race when registering extension quick fix providers 

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminalQuickFixService.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalQuickFixService.ts
@@ -10,16 +10,19 @@ import { ITerminalQuickFixProviderSelector, ITerminalQuickFixService } from 'vs/
 import { ITerminalContributionService } from 'vs/workbench/contrib/terminal/common/terminalExtensionPoints';
 
 export class TerminalQuickFixService implements ITerminalQuickFixService {
+	declare _serviceBrand: undefined;
+
+	private _selectors: Map<string, ITerminalCommandSelector> = new Map();
+
+	private _providers: Map<string, ITerminalQuickFixProvider> = new Map();
+	get providers(): Map<string, ITerminalQuickFixProvider> { return this._providers; }
+
 	private readonly _onDidRegisterProvider = new Emitter<ITerminalQuickFixProviderSelector>();
 	readonly onDidRegisterProvider = this._onDidRegisterProvider.event;
 	private readonly _onDidRegisterCommandSelector = new Emitter<ITerminalCommandSelector>();
 	readonly onDidRegisterCommandSelector = this._onDidRegisterCommandSelector.event;
 	private readonly _onDidUnregisterProvider = new Emitter<string>();
 	readonly onDidUnregisterProvider = this._onDidUnregisterProvider.event;
-	_serviceBrand: undefined;
-	_providers: Map<string, ITerminalQuickFixProvider> = new Map();
-	_selectors: Map<string, ITerminalCommandSelector> = new Map();
-	get providers(): Map<string, ITerminalQuickFixProvider> { return this._providers; }
 
 	constructor(@ITerminalContributionService private readonly _terminalContributionService: ITerminalContributionService) {
 		this._terminalContributionService.quickFixes.then(selectors => {


### PR DESCRIPTION
Fixes #168154

I tested this by adding an `await timeout(3000)` to before the resolve below in order to artificially simulate the race condition:

https://github.com/microsoft/vscode/blob/81fbd20c41652eba0a33b417d12ab940cdf5f051/src/vs/workbench/contrib/terminal/common/terminalExtensionPoints.ts#L35-L43

@meganrogge I see the quick fix provider is providing the correct `npm init` when running `npm initt`, I don't see the quick fix lightbulb come up though on main or this branch 🤷, Insiders seems fine