### PR TITLE
Add more processing for ZH locales

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -553,6 +553,15 @@ async function mkdirpIgnoreError(dir) {
 function processZhLocale(appLocale) {
 	if (appLocale.startsWith('zh')) {
 		const region = appLocale.split('-')[1];
+		// On Windows and macOS, Chinese languages returned by
+		// app.getPreferredSystemLanguages() start with zh-hans
+		// for Simplified Chinese or zh-hant for Traditional Chinese,
+		// so we can easily determine whether to use Simplified or Traditional.
+		// However, on Linux, Chinese languages returned by that same API
+		// are of the form zh-XY, where XY is a country code.
+		// For China (CN), Singapore (SG), and Malaysia (MY)
+		// country codes, assume they use Simplified Chinese.
+		// For other cases, assume they use Traditional.
 		if (['hans', 'cn', 'sg', 'my'].includes(region)) {
 			return 'zh-cn';
 		}

--- a/src/main.js
+++ b/src/main.js
@@ -550,6 +550,17 @@ async function mkdirpIgnoreError(dir) {
 
 //#region NLS Support
 
+function processZhLocale(appLocale) {
+	if (appLocale.startsWith('zh')) {
+		const region = appLocale.split('-')[1];
+		if (['hans', 'cn', 'sg', 'my'].includes(region)) {
+			return 'zh-cn';
+		}
+		return 'zh-tw';
+	}
+	return appLocale;
+}
+
 /**
  * Resolve the NLS configuration
  *
@@ -586,15 +597,8 @@ async function resolveNlsConfiguration() {
 		if (!appLocale) {
 			nlsConfiguration = { locale: 'en', availableLanguages: {} };
 		} else {
-
 			// See above the comment about the loader and case sensitiveness
-			appLocale = appLocale.toLowerCase();
-
-			if (appLocale.startsWith('zh-hans')) {
-				appLocale = 'zh-cn';
-			} else if (appLocale.startsWith('zh-hant')) {
-				appLocale = 'zh-tw';
-			}
+			appLocale = processZhLocale(appLocale.toLowerCase());
 
 			const { getNLSConfiguration } = require('./vs/base/node/languagePacks');
 			nlsConfiguration = await getNLSConfiguration(product.commit, userDataPath, metaDataFile, appLocale);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
Ref #172240

On Windows and macOS, Chinese languages returned by `app.getPreferredSystemLanguages()` start with `zh-hans` for Simplified Chinese or `zh-hant` for Traditional Chinese, so we can easily determine whether to use Simplified or Traditional.

However, on Linux, Chinese languages returned by that same API are of the form `zh-XY`, where `XY` is a country code. This PR adds more processing for those codes as follows:

For anyone using a ZH locale with China, Singapore, and Malaysia as the country, assume they use Simplified Chinese. For anyone using another ZH locale, assume they use Traditional.
