### PR TITLE
fix editor ID for IW editor input

### DIFF
--- a/src/vs/workbench/contrib/interactive/browser/interactiveEditorInput.ts
+++ b/src/vs/workbench/contrib/interactive/browser/interactiveEditorInput.ts
@@ -28,7 +28,7 @@ export class InteractiveEditorInput extends EditorInput implements ICompositeNot
 	static readonly ID: string = 'workbench.input.interactive';
 
 	public override get editorId(): string {
-		return InteractiveEditorInput.ID;
+		return 'interactive';
 	}
 
 	override get typeId(): string {


### PR DESCRIPTION
fix a warning that we were getting because the editor ID for the editor input did not match ID of the registered editor
