### PR TITLE
Unfreeze Git Commit Message grammar II

### DIFF
--- a/extensions/git-base/build/update-grammars.js
+++ b/extensions/git-base/build/update-grammars.js
@@ -6,5 +6,5 @@
 
 var updateGrammar = require('vscode-grammar-updater');
 
-updateGrammar.update('textmate/git.tmbundle', 'Syntaxes/Git%20Commit%20Message.tmLanguage', './syntaxes/git-commit.tmLanguage.json');
+updateGrammar.update('walles/git-commit-message-plus', 'syntaxes/git-commit.tmLanguage.json', './syntaxes/git-commit.tmLanguage.json', undefined, 'main');
 updateGrammar.update('textmate/git.tmbundle', 'Syntaxes/Git%20Rebase%20Message.tmLanguage', './syntaxes/git-rebase.tmLanguage.json');

--- a/extensions/git-base/cgmanifest.json
+++ b/extensions/git-base/cgmanifest.json
@@ -33,6 +33,41 @@
 			],
 			"license": "MIT",
 			"version": "0.0.0"
+		},
+		{
+			"component": {
+				"type": "git",
+				"git": {
+					"name": "walles/git-commit-message-plus",
+					"repositoryUrl": "https://github.com/walles/git-commit-message-plus",
+					"commitHash": "35a079dea5a91b087021b40c01a6bb4eb0337a87"
+				}
+			},
+			"licenseDetail": [
+				"Copyright (c) 2023 Johan Walles <johan.walles@gmail.com>",
+				"",
+				"Permission is hereby granted, free of charge, to any person obtaining",
+				"a copy of this software and associated documentation files (the\"",
+				"Software\"), to deal in the Software without restriction, including",
+				"without limitation the rights to use, copy, modify, merge, publish,",
+				"distribute, sublicense, and/or sell copies of the Software, and to",
+				"permit persons to whom the Software is furnished to do so, subject to",
+				"the following conditions:",
+				"",
+				"The above copyright notice and this permission notice shall be",
+				"included in all copies or substantial portions of the Software.",
+				"",
+				"THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND,",
+				"EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF",
+				"MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND",
+				"NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE",
+				"LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION",
+				"OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION",
+				"WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE."
+			],
+			"license": "MIT",
+			"version": "1.0.0",
+			"description": "The original JSON grammars were derived from https://github.com/microsoft/vscode/blob/e95c74c4c7af876e79ec58df262464467c06df28/extensions/git-base/syntaxes/git-commit.tmLanguage.json. That file was originally copied from https://github.com/textmate/git.tmbundle."
 		}
 	],
 	"version": 1

--- a/extensions/git-base/syntaxes/git-commit.tmLanguage.json
+++ b/extensions/git-base/syntaxes/git-commit.tmLanguage.json
@@ -1,141 +1,59 @@
 {
 	"information_for_contributors": [
-		"This file has been converted from https://github.com/textmate/git.tmbundle/blob/master/Syntaxes/Git%20Commit%20Message.tmLanguage",
+		"This file has been copied from https://github.com/walles/git-commit-message-plus/blob/main/syntaxes/git-commit.tmLanguage.json",
 		"If you want to provide a fix or improvement, please create a pull request against the original repository.",
 		"Once accepted there, we are happy to receive an update request."
 	],
-	"version": "https://github.com/textmate/git.tmbundle/commit/93897a78c6e52bef13dadc0d4091d203c5facb40",
+	"metadata": [
+		"This file is maintained here:",
+		"https://github.com/walles/git-commit-message-plus/blob/main/syntaxes/git-commit.tmLanguage.json",
+		"",
+		"It was originally based on this file, but has been heavily modified:",
+		"https://github.com/microsoft/vscode/blob/e95c74c4c7af876e79ec58df262464467c06df28/extensions/git-base/syntaxes/git-commit.tmLanguage.json"
+	],
 	"name": "Git Commit Message",
 	"scopeName": "text.git-commit",
 	"patterns": [
 		{
-			"begin": "\\A(?!# Please enter the commit message)",
-			"end": "^(?=# Please enter the commit message)",
+			"comment": "diff presented at the end of the commit message when using commit -v.",
+			"name": "meta.embedded.diff.git-commit",
+			"contentName": "source.diff",
+			"begin": "(?=^diff\\ \\-\\-git)",
+			"end": "\\z",
+			"patterns": [ { "include": "source.diff" } ]
+		},
+		{
+			"comment": "User supplied message",
 			"name": "meta.scope.message.git-commit",
+			"begin": "^(?!#)",
+			"end": "^(?=#)",
 			"patterns": [
 				{
-					"begin": "\\A(?=#)",
-					"end": "^(?!#)",
-					"patterns": [
-						{
-							"include": "#comment"
-						}
-					]
-				},
-				{
-					"begin": "^(?!# Please enter the commit message)",
-					"end": "^(?=# Please enter the commit message)",
-					"patterns": [
-						{
-							"begin": "\\G",
-							"end": "^(?!\\G)",
-							"name": "meta.scope.subject.git-commit",
-							"patterns": [
-								{
-									"captures": {
-										"1": {
-											"name": "keyword.other.$2.git-commit"
-										}
-									},
-									"match": "\\G((fixup|squash)!)\\s*"
-								},
-								{
-									"match": ".{73,}$",
-									"name": "invalid.illegal.line-too-long.git-commit"
-								},
-								{
-									"match": ".{51,}$",
-									"name": "invalid.deprecated.line-too-long.git-commit"
-								}
-							]
-						},
-						{
-							"begin": "^(?!# Please enter the commit message)",
-							"end": "^(?=# Please enter the commit message)",
-							"patterns": [
-								{
-									"include": "#comment"
-								}
-							]
-						}
-					]
+					"name": "meta.scope.subject.git-commit",
+					"match": "\\G.*$"
 				}
 			]
 		},
 		{
-			"begin": "^(?=# Please enter the commit message)",
-			"end": "\\z",
+			"comment": "Git supplied metadata in a number of lines starting with #",
 			"name": "meta.scope.metadata.git-commit",
+			"begin": "^(?=#)",
+			"end": "(?!^#)",
 			"patterns": [
 				{
-					"include": "#metadata"
+					"comment": "What is happening with which files",
+					"match": "^#\\t([^:]+): *(.*)$",
+					"name": "comment.line.number-sign.git-commit",
+					"captures": {
+						"1": { "name": "keyword.other.file-type.git-commit" },
+						"2": { "name": "string.unquoted.filename.git-commit" }
+					}
+				},
+				{
+					"name": "comment.line.number-sign.git-commit",
+					"match": "^#.*$"
 				}
 			]
 		}
-	],
-	"repository": {
-		"comment": {
-			"begin": "^(#)",
-			"captures": {
-				"1": {
-					"name": "punctuation.definition.comment.git-commit"
-				}
-			},
-			"end": "\\n",
-			"name": "comment.line.number-sign.git-commit"
-		},
-		"metadata": {
-			"patterns": [
-				{
-					"begin": "(?=^# Changes to be committed:)",
-					"end": "(?!\\G)((?=^# \\w)|(?!^#))",
-					"patterns": [
-						{
-							"begin": "(^[ \\t]+)?(?=#)",
-							"beginCaptures": {
-								"1": {
-									"name": "punctuation.whitespace.comment.leading.git-commit"
-								}
-							},
-							"contentName": "comment.line.number-sign.git-commit",
-							"end": "(?!\\G)^",
-							"patterns": [
-								{
-									"match": "\\G#",
-									"name": "punctuation.definition.comment.git-commit"
-								},
-								{
-									"match": "((modified|renamed):.*)$\\n?",
-									"name": "markup.changed.git-commit"
-								},
-								{
-									"match": "(new file:.*)$\\n?",
-									"name": "markup.inserted.git-commit"
-								},
-								{
-									"match": "(deleted:.*)$\\n?",
-									"name": "markup.deleted.git-commit"
-								}
-							]
-						}
-					]
-				},
-				{
-					"include": "#comment"
-				},
-				{
-					"begin": "(?=diff\\ \\-\\-git)",
-					"comment": "diff presented at the end of the commit message when using commit -v.",
-					"contentName": "source.diff",
-					"end": "\\z",
-					"name": "meta.embedded.diff.git-commit",
-					"patterns": [
-						{
-							"include": "source.diff"
-						}
-					]
-				}
-			]
-		}
-	}
+	]
 }

--- a/extensions/git-base/syntaxes/git-commit.tmLanguage.json
+++ b/extensions/git-base/syntaxes/git-commit.tmLanguage.json
@@ -29,8 +29,13 @@
 			"end": "^(?=#)",
 			"patterns": [
 				{
+					"comment": "Mark > 50 lines as deprecated, > 72 as illegal",
 					"name": "meta.scope.subject.git-commit",
-					"match": "\\G.*$"
+					"match": "\\G.{0,50}(.{0,22}(.*))$",
+					"captures": {
+						"1": { "name": "invalid.deprecated.line-too-long.git-commit" },
+						"2": { "name": "invalid.illegal.line-too-long.git-commit" }
+					}
 				}
 			]
 		},
@@ -38,20 +43,28 @@
 			"comment": "Git supplied metadata in a number of lines starting with #",
 			"name": "meta.scope.metadata.git-commit",
 			"begin": "^(?=#)",
-			"end": "(?!^#)",
+			"contentName": "comment.line.number-sign.git-commit",
+			"end": "^(?!#)",
 			"patterns": [
 				{
-					"comment": "What is happening with which files",
+					"match": "^#\\t((modified|renamed):.*)$",
+					"captures": { "1": { "name": "markup.changed.git-commit" } }
+				},
+				{
+					"match": "^#\\t(new file:.*)$",
+					"captures": { "1": { "name": "markup.inserted.git-commit" } }
+				},
+				{
+					"match": "^#\\t(deleted.*)$",
+					"captures": { "1": { "name": "markup.deleted.git-commit" } }
+				},
+				{
+					"comment": "Fallback for non-English git commit template",
 					"match": "^#\\t([^:]+): *(.*)$",
-					"name": "comment.line.number-sign.git-commit",
 					"captures": {
 						"1": { "name": "keyword.other.file-type.git-commit" },
 						"2": { "name": "string.unquoted.filename.git-commit" }
 					}
-				},
-				{
-					"name": "comment.line.number-sign.git-commit",
-					"match": "^#.*$"
 				}
 			]
 		}

--- a/extensions/git-base/syntaxes/git-commit.tmLanguage.json
+++ b/extensions/git-base/syntaxes/git-commit.tmLanguage.json
@@ -1,16 +1,10 @@
 {
 	"information_for_contributors": [
-		"This file has been copied from https://github.com/walles/git-commit-message-plus/blob/main/syntaxes/git-commit.tmLanguage.json",
+		"This file has been converted from https://github.com/walles/git-commit-message-plus/blob/master/syntaxes/git-commit.tmLanguage.json",
 		"If you want to provide a fix or improvement, please create a pull request against the original repository.",
 		"Once accepted there, we are happy to receive an update request."
 	],
-	"metadata": [
-		"This file is maintained here:",
-		"https://github.com/walles/git-commit-message-plus/blob/main/syntaxes/git-commit.tmLanguage.json",
-		"",
-		"It was originally based on this file, but has been heavily modified:",
-		"https://github.com/microsoft/vscode/blob/e95c74c4c7af876e79ec58df262464467c06df28/extensions/git-base/syntaxes/git-commit.tmLanguage.json"
-	],
+	"version": "https://github.com/walles/git-commit-message-plus/commit/35a079dea5a91b087021b40c01a6bb4eb0337a87",
 	"name": "Git Commit Message",
 	"scopeName": "text.git-commit",
 	"patterns": [
@@ -20,7 +14,11 @@
 			"contentName": "source.diff",
 			"begin": "(?=^diff\\ \\-\\-git)",
 			"end": "\\z",
-			"patterns": [ { "include": "source.diff" } ]
+			"patterns": [
+				{
+					"include": "source.diff"
+				}
+			]
 		},
 		{
 			"comment": "User supplied message",
@@ -33,8 +31,12 @@
 					"name": "meta.scope.subject.git-commit",
 					"match": "\\G.{0,50}(.{0,22}(.*))$",
 					"captures": {
-						"1": { "name": "invalid.deprecated.line-too-long.git-commit" },
-						"2": { "name": "invalid.illegal.line-too-long.git-commit" }
+						"1": {
+							"name": "invalid.deprecated.line-too-long.git-commit"
+						},
+						"2": {
+							"name": "invalid.illegal.line-too-long.git-commit"
+						}
 					}
 				}
 			]
@@ -48,22 +50,38 @@
 			"patterns": [
 				{
 					"match": "^#\\t((modified|renamed):.*)$",
-					"captures": { "1": { "name": "markup.changed.git-commit" } }
+					"captures": {
+						"1": {
+							"name": "markup.changed.git-commit"
+						}
+					}
 				},
 				{
 					"match": "^#\\t(new file:.*)$",
-					"captures": { "1": { "name": "markup.inserted.git-commit" } }
+					"captures": {
+						"1": {
+							"name": "markup.inserted.git-commit"
+						}
+					}
 				},
 				{
 					"match": "^#\\t(deleted.*)$",
-					"captures": { "1": { "name": "markup.deleted.git-commit" } }
+					"captures": {
+						"1": {
+							"name": "markup.deleted.git-commit"
+						}
+					}
 				},
 				{
 					"comment": "Fallback for non-English git commit template",
 					"match": "^#\\t([^:]+): *(.*)$",
 					"captures": {
-						"1": { "name": "keyword.other.file-type.git-commit" },
-						"2": { "name": "string.unquoted.filename.git-commit" }
+						"1": {
+							"name": "keyword.other.file-type.git-commit"
+						},
+						"2": {
+							"name": "string.unquoted.filename.git-commit"
+						}
 					}
 				}
 			]

--- a/extensions/vscode-colorize-tests/test/colorize-results/COMMIT_EDITMSG.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/COMMIT_EDITMSG.json
@@ -28,8 +28,8 @@
 		}
 	},
 	{
-		"c": "#",
-		"t": "text.git-commit meta.scope.metadata.git-commit comment.line.number-sign.git-commit punctuation.definition.comment.git-commit",
+		"c": "# Please enter the commit message for your changes. Lines starting",
+		"t": "text.git-commit meta.scope.metadata.git-commit comment.line.number-sign.git-commit",
 		"r": {
 			"dark_plus": "comment: #6A9955",
 			"light_plus": "comment: #008000",
@@ -42,7 +42,35 @@
 		}
 	},
 	{
-		"c": " Please enter the commit message for your changes. Lines starting",
+		"c": "# with '#' will be ignored, and an empty message aborts the commit.",
+		"t": "text.git-commit meta.scope.metadata.git-commit comment.line.number-sign.git-commit",
+		"r": {
+			"dark_plus": "comment: #6A9955",
+			"light_plus": "comment: #008000",
+			"dark_vs": "comment: #6A9955",
+			"light_vs": "comment: #008000",
+			"hc_black": "comment: #7CA668",
+			"dark_plus_experimental": "comment: #6A9955",
+			"hc_light": "comment: #515151",
+			"light_plus_experimental": "comment: #008000"
+		}
+	},
+	{
+		"c": "# On branch master",
+		"t": "text.git-commit meta.scope.metadata.git-commit comment.line.number-sign.git-commit",
+		"r": {
+			"dark_plus": "comment: #6A9955",
+			"light_plus": "comment: #008000",
+			"dark_vs": "comment: #6A9955",
+			"light_vs": "comment: #008000",
+			"hc_black": "comment: #7CA668",
+			"dark_plus_experimental": "comment: #6A9955",
+			"hc_light": "comment: #515151",
+			"light_plus_experimental": "comment: #008000"
+		}
+	},
+	{
+		"c": "# Your branch is up-to-date with 'origin/master'.",
 		"t": "text.git-commit meta.scope.metadata.git-commit comment.line.number-sign.git-commit",
 		"r": {
 			"dark_plus": "comment: #6A9955",
@@ -57,20 +85,6 @@
 	},
 	{
 		"c": "#",
-		"t": "text.git-commit meta.scope.metadata.git-commit comment.line.number-sign.git-commit punctuation.definition.comment.git-commit",
-		"r": {
-			"dark_plus": "comment: #6A9955",
-			"light_plus": "comment: #008000",
-			"dark_vs": "comment: #6A9955",
-			"light_vs": "comment: #008000",
-			"hc_black": "comment: #7CA668",
-			"dark_plus_experimental": "comment: #6A9955",
-			"hc_light": "comment: #515151",
-			"light_plus_experimental": "comment: #008000"
-		}
-	},
-	{
-		"c": " with '#' will be ignored, and an empty message aborts the commit.",
 		"t": "text.git-commit meta.scope.metadata.git-commit comment.line.number-sign.git-commit",
 		"r": {
 			"dark_plus": "comment: #6A9955",
@@ -84,21 +98,7 @@
 		}
 	},
 	{
-		"c": "#",
-		"t": "text.git-commit meta.scope.metadata.git-commit comment.line.number-sign.git-commit punctuation.definition.comment.git-commit",
-		"r": {
-			"dark_plus": "comment: #6A9955",
-			"light_plus": "comment: #008000",
-			"dark_vs": "comment: #6A9955",
-			"light_vs": "comment: #008000",
-			"hc_black": "comment: #7CA668",
-			"dark_plus_experimental": "comment: #6A9955",
-			"hc_light": "comment: #515151",
-			"light_plus_experimental": "comment: #008000"
-		}
-	},
-	{
-		"c": " On branch master",
+		"c": "# Changes to be committed:",
 		"t": "text.git-commit meta.scope.metadata.git-commit comment.line.number-sign.git-commit",
 		"r": {
 			"dark_plus": "comment: #6A9955",
@@ -112,91 +112,7 @@
 		}
 	},
 	{
-		"c": "#",
-		"t": "text.git-commit meta.scope.metadata.git-commit comment.line.number-sign.git-commit punctuation.definition.comment.git-commit",
-		"r": {
-			"dark_plus": "comment: #6A9955",
-			"light_plus": "comment: #008000",
-			"dark_vs": "comment: #6A9955",
-			"light_vs": "comment: #008000",
-			"hc_black": "comment: #7CA668",
-			"dark_plus_experimental": "comment: #6A9955",
-			"hc_light": "comment: #515151",
-			"light_plus_experimental": "comment: #008000"
-		}
-	},
-	{
-		"c": " Your branch is up-to-date with 'origin/master'.",
-		"t": "text.git-commit meta.scope.metadata.git-commit comment.line.number-sign.git-commit",
-		"r": {
-			"dark_plus": "comment: #6A9955",
-			"light_plus": "comment: #008000",
-			"dark_vs": "comment: #6A9955",
-			"light_vs": "comment: #008000",
-			"hc_black": "comment: #7CA668",
-			"dark_plus_experimental": "comment: #6A9955",
-			"hc_light": "comment: #515151",
-			"light_plus_experimental": "comment: #008000"
-		}
-	},
-	{
-		"c": "#",
-		"t": "text.git-commit meta.scope.metadata.git-commit comment.line.number-sign.git-commit punctuation.definition.comment.git-commit",
-		"r": {
-			"dark_plus": "comment: #6A9955",
-			"light_plus": "comment: #008000",
-			"dark_vs": "comment: #6A9955",
-			"light_vs": "comment: #008000",
-			"hc_black": "comment: #7CA668",
-			"dark_plus_experimental": "comment: #6A9955",
-			"hc_light": "comment: #515151",
-			"light_plus_experimental": "comment: #008000"
-		}
-	},
-	{
-		"c": "#",
-		"t": "text.git-commit meta.scope.metadata.git-commit comment.line.number-sign.git-commit punctuation.definition.comment.git-commit",
-		"r": {
-			"dark_plus": "comment: #6A9955",
-			"light_plus": "comment: #008000",
-			"dark_vs": "comment: #6A9955",
-			"light_vs": "comment: #008000",
-			"hc_black": "comment: #7CA668",
-			"dark_plus_experimental": "comment: #6A9955",
-			"hc_light": "comment: #515151",
-			"light_plus_experimental": "comment: #008000"
-		}
-	},
-	{
-		"c": " Changes to be committed:",
-		"t": "text.git-commit meta.scope.metadata.git-commit comment.line.number-sign.git-commit",
-		"r": {
-			"dark_plus": "comment: #6A9955",
-			"light_plus": "comment: #008000",
-			"dark_vs": "comment: #6A9955",
-			"light_vs": "comment: #008000",
-			"hc_black": "comment: #7CA668",
-			"dark_plus_experimental": "comment: #6A9955",
-			"hc_light": "comment: #515151",
-			"light_plus_experimental": "comment: #008000"
-		}
-	},
-	{
-		"c": "#",
-		"t": "text.git-commit meta.scope.metadata.git-commit comment.line.number-sign.git-commit punctuation.definition.comment.git-commit",
-		"r": {
-			"dark_plus": "comment: #6A9955",
-			"light_plus": "comment: #008000",
-			"dark_vs": "comment: #6A9955",
-			"light_vs": "comment: #008000",
-			"hc_black": "comment: #7CA668",
-			"dark_plus_experimental": "comment: #6A9955",
-			"hc_light": "comment: #515151",
-			"light_plus_experimental": "comment: #008000"
-		}
-	},
-	{
-		"c": "\t",
+		"c": "#\t",
 		"t": "text.git-commit meta.scope.metadata.git-commit comment.line.number-sign.git-commit",
 		"r": {
 			"dark_plus": "comment: #6A9955",
@@ -224,21 +140,7 @@
 		}
 	},
 	{
-		"c": "#",
-		"t": "text.git-commit meta.scope.metadata.git-commit comment.line.number-sign.git-commit punctuation.definition.comment.git-commit",
-		"r": {
-			"dark_plus": "comment: #6A9955",
-			"light_plus": "comment: #008000",
-			"dark_vs": "comment: #6A9955",
-			"light_vs": "comment: #008000",
-			"hc_black": "comment: #7CA668",
-			"dark_plus_experimental": "comment: #6A9955",
-			"hc_light": "comment: #515151",
-			"light_plus_experimental": "comment: #008000"
-		}
-	},
-	{
-		"c": "\t",
+		"c": "#\t",
 		"t": "text.git-commit meta.scope.metadata.git-commit comment.line.number-sign.git-commit",
 		"r": {
 			"dark_plus": "comment: #6A9955",
@@ -266,21 +168,7 @@
 		}
 	},
 	{
-		"c": "#",
-		"t": "text.git-commit meta.scope.metadata.git-commit comment.line.number-sign.git-commit punctuation.definition.comment.git-commit",
-		"r": {
-			"dark_plus": "comment: #6A9955",
-			"light_plus": "comment: #008000",
-			"dark_vs": "comment: #6A9955",
-			"light_vs": "comment: #008000",
-			"hc_black": "comment: #7CA668",
-			"dark_plus_experimental": "comment: #6A9955",
-			"hc_light": "comment: #515151",
-			"light_plus_experimental": "comment: #008000"
-		}
-	},
-	{
-		"c": "\t",
+		"c": "#\t",
 		"t": "text.git-commit meta.scope.metadata.git-commit comment.line.number-sign.git-commit",
 		"r": {
 			"dark_plus": "comment: #6A9955",
@@ -309,7 +197,7 @@
 	},
 	{
 		"c": "#",
-		"t": "text.git-commit meta.scope.metadata.git-commit comment.line.number-sign.git-commit punctuation.definition.comment.git-commit",
+		"t": "text.git-commit meta.scope.metadata.git-commit comment.line.number-sign.git-commit",
 		"r": {
 			"dark_plus": "comment: #6A9955",
 			"light_plus": "comment: #008000",


### PR DESCRIPTION
Before this change, the upstream for the VSCode Git grammar was dead.
Also, the test setup for that project has been EOL since 2014, so even
just running their tests was difficult.

The replacement grammar, unlike the current grammar:
* Has [a vscode-tmgrammar-test test suite](https://github.com/walles/git-commit-message-plus/tree/main/tests/unit) that is runnable and [passing](https://github.com/walles/git-commit-message-plus/actions)
  and that will run in CI for any PRs (in the upstream project)
* Has diff highlighting for Swedish as well as English (#133888)
* Highlights touched files both in Swedish and in English

Fixes #133888
Fixes #168847

Ref: <https://github.com/walles/git-commit-message-plus>

For the record, I was the one setting up the new Git Commit Message project. And it was fun!

# After

<img width="803" alt="after" src="https://user-images.githubusercontent.com/158201/216440049-a5b59570-ca9f-4428-8a36-f39c1c9a484f.png">

Sample message to test this yourselves:

```

# Ange incheckningsmeddelandet för dina ändringar. Rader som inleds
# med "#" kommer ignoreras, och ett tomt meddelande avbryter incheckningen.
#
# På grenen main
# Ändringar att checka in:
#	ändrad:        hej
#
# ------------------------ >8 ------------------------
# Raden ovan får inte ändras eller tas bort.
# Allt under den kommer tas bort.
diff --git hej hej
index 257cc56..5716ca5 100644
--- hej
+++ hej
@@ -1 +1 @@
-foo
+bar
```

## Before

Note lack of file names highlighting and diff highlighting.

<img width="794" alt="before" src="https://user-images.githubusercontent.com/158201/216440085-d5eced6c-099a-41cc-aae1-6f0e9e7131e1.png">
