### PR TITLE
testing: fix incorrect offsets showing escape codes in output

### DIFF
--- a/src/vs/workbench/contrib/testing/test/common/testResultService.test.ts
+++ b/src/vs/workbench/contrib/testing/test/common/testResultService.test.ts
@@ -367,6 +367,16 @@ suite('Workbench - Test Results Service', () => {
 			assert.deepStrictEqual(await ctrl.getRange(15, 10), VSBuffer.fromString('67890'));
 		});
 
+		test('corrects offsets for marked ranges', async () => {
+			const ctrl = storage.getOutputController('a');
+
+			const a1 = ctrl.append(VSBuffer.fromString('12345'), 1);
+			const a2 = ctrl.append(VSBuffer.fromString('67890'), 1234);
+
+			assert.deepStrictEqual(await ctrl.getRange(a1.offset, 5), VSBuffer.fromString('12345'));
+			assert.deepStrictEqual(await ctrl.getRange(a2.offset, 5), VSBuffer.fromString('67890'));
+		});
+
 		test('reads stored output ranges', async () => {
 			const ctrl = storage.getOutputController('a');
 


### PR DESCRIPTION
Fixes #166270

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
