### PR TITLE
enable audio cues to be played in parallel when `playAudioCues` is called

### DIFF
--- a/src/vs/platform/audioCues/browser/audioCueService.ts
+++ b/src/vs/platform/audioCues/browser/audioCueService.ts
@@ -48,7 +48,7 @@ export class AudioCueService extends Disposable implements IAudioCueService {
 	public async playAudioCues(cues: AudioCue[]): Promise<void> {
 		// Some audio cues might reuse sounds. Don't play the same sound twice.
 		const sounds = new Set(cues.filter(cue => this.isEnabled(cue)).map(cue => cue.sound));
-		await Promise.all(Array.from(sounds).map(sound => this.playSound(sound)));
+		await Promise.all(Array.from(sounds).map(sound => this.playSound(sound, true)));
 	}
 
 	private getVolumeInPercent(): number {


### PR DESCRIPTION
fix #172523

Any consumer wishing to prevent sounds running in parallel can use `playAudioCue`