### PR TITLE
Flush debounced events when disposing of a listener

### DIFF
--- a/src/vs/base/browser/ui/list/listWidget.ts
+++ b/src/vs/base/browser/ui/list/listWidget.ts
@@ -458,7 +458,7 @@ class TypeNavigationController<T> implements IDisposable {
 			.map(event => event.browserEvent.key)
 			.event;
 
-		const onClear = Event.debounce<string, null>(onChar, () => null, 800, undefined, undefined, this.enabledDisposables);
+		const onClear = Event.debounce<string, null>(onChar, () => null, 800, undefined, undefined, undefined, this.enabledDisposables);
 		const onInput = Event.reduce<string | null, string | null>(Event.any(onChar, onClear), (r, i) => i === null ? null : ((r || '') + i), undefined, this.enabledDisposables);
 
 		onInput(this.onInput, this, this.enabledDisposables);

--- a/src/vs/base/test/common/event.test.ts
+++ b/src/vs/base/test/common/event.test.ts
@@ -1202,7 +1202,7 @@ suite('Event utils', () => {
 			assert.deepStrictEqual(calls, [1, 1]);
 		});
 
-		test('should flush events when a listener is disposed', async () => {
+		test('should not flush events when a listener is disposed', async () => {
 			const emitter = new Emitter<number>();
 			const debounced = Event.debounce(emitter.event, (l, e) => l ? l + 1 : 1, 0);
 
@@ -1215,8 +1215,25 @@ suite('Event utils', () => {
 			emitter.fire(1);
 
 			await timeout(1);
+			assert.deepStrictEqual(calls, []);
+		});
+
+		test('flushOnListenerRemove - should flush events when a listener is disposed', async () => {
+			const emitter = new Emitter<number>();
+			const debounced = Event.debounce(emitter.event, (l, e) => l ? l + 1 : 1, 0, undefined, true);
+
+			const calls: number[] = [];
+			const listener = debounced((e) => calls.push(e));
+
+			emitter.fire(1);
+			listener.dispose();
+
+			emitter.fire(1);
+
+			await timeout(1);
 			assert.deepStrictEqual(calls, [1], 'should fire with the first event, not the second (after listener dispose)');
 		});
+
 
 		test('should flush events when the emitter is disposed', async () => {
 			const emitter = new Emitter<number>();

--- a/src/vs/base/test/common/event.test.ts
+++ b/src/vs/base/test/common/event.test.ts
@@ -195,6 +195,24 @@ suite('Event', function () {
 		assert.strictEqual(lastCount, 1);
 	});
 
+	test('onWillRemoveListener', () => {
+		let count = 0;
+		const a = new Emitter({
+			onWillRemoveListener() { count += 1; }
+		});
+
+		assert.strictEqual(count, 0);
+
+		let subscription = a.event(function () { });
+		assert.strictEqual(count, 0);
+
+		subscription.dispose();
+		assert.strictEqual(count, 1);
+
+		subscription = a.event(function () { });
+		assert.strictEqual(count, 1);
+	});
+
 	test('throwingListener', () => {
 		const origErrorHandler = errorHandler.getUnexpectedErrorHandler();
 		setUnexpectedErrorHandler(() => null);

--- a/src/vs/base/test/common/event.test.ts
+++ b/src/vs/base/test/common/event.test.ts
@@ -91,7 +91,7 @@ suite('Event utils dispose', function () {
 	test('no leak with debounce-util', function () {
 		const store = new DisposableStore();
 		const emitter = new Emitter<number>();
-		const debounced = Event.debounce(emitter.event, (l) => 0, undefined, undefined, undefined, store);
+		const debounced = Event.debounce(emitter.event, (l) => 0, undefined, undefined, undefined, undefined, store);
 		assertDisposablesCount(1); // debounce only listens when `debounce` is being listened on
 
 		let all = 0;

--- a/src/vs/workbench/contrib/extensions/browser/extensionsViewlet.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsViewlet.ts
@@ -802,7 +802,7 @@ export class StatusUpdater extends Disposable implements IWorkbenchContribution 
 	) {
 		super();
 		this.onServiceChange();
-		this._register(Event.debounce(extensionsWorkbenchService.onChange, () => undefined, 100, undefined, undefined, this._store)(this.onServiceChange, this));
+		this._register(Event.debounce(extensionsWorkbenchService.onChange, () => undefined, 100, undefined, undefined, undefined, this._store)(this.onServiceChange, this));
 	}
 
 	private onServiceChange(): void {

--- a/src/vs/workbench/contrib/scm/browser/scmViewService.ts
+++ b/src/vs/workbench/contrib/scm/browser/scmViewService.ts
@@ -143,7 +143,7 @@ export class SCMViewService implements ISCMViewService {
 				}
 
 				return { added, removed };
-			}, 0, undefined, undefined, this.disposables)
+			}, 0, undefined, undefined, undefined, this.disposables)
 	);
 
 	get focusedRepository(): ISCMRepository | undefined {


### PR DESCRIPTION
This is a behavior change and could introduce regressions, it seems like a reasonable assumption to make though.

Part of #173111

Should we add an option?