### PR TITLE
Keep notebook kernel bindings for non-untitled notebooks after they close

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
@@ -88,6 +88,7 @@ import { FloatingClickMenu } from 'vs/workbench/browser/codeeditor';
 import { IDimension } from 'vs/editor/common/core/dimension';
 import { CellFindMatchModel } from 'vs/workbench/contrib/notebook/browser/contrib/find/findModel';
 import { INotebookLoggingService } from 'vs/workbench/contrib/notebook/common/notebookLoggingService';
+import { Schemas } from 'vs/base/common/network';
 
 const $ = DOM.$;
 
@@ -1693,7 +1694,9 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditorD
 			}
 		}
 		state.contributionsState = contributionsState;
-		state.selectedKernelId = this.activeKernel?.id;
+		if (this.textModel?.uri.scheme === Schemas.untitled) {
+			state.selectedKernelId = this.activeKernel?.id;
+		}
 
 		return state;
 	}

--- a/src/vs/workbench/contrib/notebook/browser/services/notebookKernelServiceImpl.ts
+++ b/src/vs/workbench/contrib/notebook/browser/services/notebookKernelServiceImpl.ts
@@ -16,6 +16,7 @@ import { IMenu, IMenuService, MenuId } from 'vs/platform/actions/common/actions'
 import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 import { IAction } from 'vs/base/common/actions';
 import { MarshalledId } from 'vs/base/common/marshallingIds';
+import { Schemas } from 'vs/base/common/network';
 
 class KernelInfo {
 
@@ -134,7 +135,7 @@ export class NotebookKernelService extends Disposable implements INotebookKernel
 		this._register(_notebookService.onWillRemoveNotebookDocument(notebook => {
 			const id = NotebookTextModelLikeId.str(notebook);
 			const kernelId = this._notebookBindings.get(id);
-			if (kernelId) {
+			if (kernelId && notebook.uri.scheme === Schemas.untitled) {
 				this.selectKernelForNotebook(undefined, notebook);
 			}
 			this._kernelSourceActionsUpdates.get(id)?.dispose();


### PR DESCRIPTION
And also only persist the selected kernel in the editor view state for untitled notebook editors.
This basically moves things back to the kernel service being the real source of truth in general, and the editor viewstate  being an explicit fix just for the untitled editor case.
Fix #171385
