### PR TITLE
Add shellscript `filenamePatterns` for `.env.*`

### DIFF
--- a/extensions/shellscript/package.json
+++ b/extensions/shellscript/package.json
@@ -67,6 +67,9 @@
           "bashrc_Apple_Terminal",
           "zshrc_Apple_Terminal"
         ],
+        "filenamePatterns": [
+          ".env*"
+        ],
         "firstLine": "^#!.*\\b(bash|fish|zsh|sh|ksh|dtksh|pdksh|mksh|ash|dash|yash|sh|csh|jcsh|tcsh|itcsh).*|^#\\s*-\\*-[^*]*mode:\\s*shell-script[^*]*-\\*-",
         "configuration": "./language-configuration.json",
         "mimetypes": [

--- a/extensions/shellscript/package.json
+++ b/extensions/shellscript/package.json
@@ -68,7 +68,7 @@
           "zshrc_Apple_Terminal"
         ],
         "filenamePatterns": [
-          ".env*"
+          ".env.*"
         ],
         "firstLine": "^#!.*\\b(bash|fish|zsh|sh|ksh|dtksh|pdksh|mksh|ash|dash|yash|sh|csh|jcsh|tcsh|itcsh).*|^#\\s*-\\*-[^*]*mode:\\s*shell-script[^*]*-\\*-",
         "configuration": "./language-configuration.json",


### PR DESCRIPTION
In some cases, projects use `.env` files such as `.env.development` or `.env.production` or similar things.

Adding this to extensions/shellscript/package.json as a `filenamePatterns` avoids developers having to add specific `"files.associations"` to their VS Code settings files.

Fixes #173425

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
