### PR TITLE
fix(keybindings): fix hashcode for scan codes & simple keys

### DIFF
--- a/src/vs/base/common/keybindings.ts
+++ b/src/vs/base/common/keybindings.ts
@@ -28,6 +28,11 @@ const enum BinaryKeybindingsMask {
 	KeyCode = 0x000000FF
 }
 
+const enum HashCodeBinding {
+	SimpleKey,
+	ScanCode
+}
+
 export function decodeKeybinding(keybinding: number, OS: OperatingSystem): Keybinding | null {
 	if (keybinding === 0) {
 		return null;
@@ -94,7 +99,7 @@ export class KeyCodeChord implements Modifiers {
 		const shift = this.shiftKey ? '1' : '0';
 		const alt = this.altKey ? '1' : '0';
 		const meta = this.metaKey ? '1' : '0';
-		return `${ctrl}${shift}${alt}${meta}${this.keyCode}`;
+		return `${HashCodeBinding.SimpleKey}${ctrl}${shift}${alt}${meta}${this.keyCode}`;
 	}
 
 	public isModifierKey(): boolean {
@@ -154,7 +159,7 @@ export class ScanCodeChord implements Modifiers {
 		const shift = this.shiftKey ? '1' : '0';
 		const alt = this.altKey ? '1' : '0';
 		const meta = this.metaKey ? '1' : '0';
-		return `${ctrl}${shift}${alt}${meta}${this.scanCode}`;
+		return `${HashCodeBinding.SimpleKey}${ctrl}${shift}${alt}${meta}${this.scanCode}`;
 	}
 
 	/**

--- a/src/vs/base/common/keybindings.ts
+++ b/src/vs/base/common/keybindings.ts
@@ -28,11 +28,6 @@ const enum BinaryKeybindingsMask {
 	KeyCode = 0x000000FF
 }
 
-const enum HashCodeBinding {
-	SimpleKey,
-	ScanCode
-}
-
 export function decodeKeybinding(keybinding: number, OS: OperatingSystem): Keybinding | null {
 	if (keybinding === 0) {
 		return null;
@@ -99,7 +94,7 @@ export class KeyCodeChord implements Modifiers {
 		const shift = this.shiftKey ? '1' : '0';
 		const alt = this.altKey ? '1' : '0';
 		const meta = this.metaKey ? '1' : '0';
-		return `${HashCodeBinding.SimpleKey}${ctrl}${shift}${alt}${meta}${this.keyCode}`;
+		return `K${ctrl}${shift}${alt}${meta}${this.keyCode}`;
 	}
 
 	public isModifierKey(): boolean {
@@ -159,7 +154,7 @@ export class ScanCodeChord implements Modifiers {
 		const shift = this.shiftKey ? '1' : '0';
 		const alt = this.altKey ? '1' : '0';
 		const meta = this.metaKey ? '1' : '0';
-		return `${HashCodeBinding.SimpleKey}${ctrl}${shift}${alt}${meta}${this.scanCode}`;
+		return `S${ctrl}${shift}${alt}${meta}${this.scanCode}`;
 	}
 
 	/**

--- a/src/vs/base/test/common/keybindings.test.ts
+++ b/src/vs/base/test/common/keybindings.test.ts
@@ -1,0 +1,18 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { KeyCode, ScanCode } from 'vs/base/common/keyCodes';
+import { KeyCodeChord, ScanCodeChord } from 'vs/base/common/keybindings';
+
+suite('keyCodes', () => {
+
+	test('issue #173325: wrong interpretations of special keys (e.g. [Equal] is mistaken for V)', () => {
+		const a = new KeyCodeChord(true, false, false, false, KeyCode.KeyV);
+		const b = new ScanCodeChord(true, false, false, false, ScanCode.Equal);
+		assert.strictEqual(a.getHashCode() === b.getHashCode(), false);
+	});
+
+});


### PR DESCRIPTION
The issue was introduced in this PR https://github.com/microsoft/vscode/pull/169842 
The hashcode for scan codes and simple keys was not updated to distinguish between them.

fix #173325
fix #173283

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
