### PR TITLE
Avoid hash collisions between `KeyCodeChord` and `ScanCodeChord`

### DIFF
--- a/src/vs/base/common/keybindings.ts
+++ b/src/vs/base/common/keybindings.ts
@@ -94,7 +94,7 @@ export class KeyCodeChord implements Modifiers {
 		const shift = this.shiftKey ? '1' : '0';
 		const alt = this.altKey ? '1' : '0';
 		const meta = this.metaKey ? '1' : '0';
-		return `${ctrl}${shift}${alt}${meta}${this.keyCode}`;
+		return `K${ctrl}${shift}${alt}${meta}${this.keyCode}`;
 	}
 
 	public isModifierKey(): boolean {
@@ -154,7 +154,7 @@ export class ScanCodeChord implements Modifiers {
 		const shift = this.shiftKey ? '1' : '0';
 		const alt = this.altKey ? '1' : '0';
 		const meta = this.metaKey ? '1' : '0';
-		return `${ctrl}${shift}${alt}${meta}${this.scanCode}`;
+		return `S${ctrl}${shift}${alt}${meta}${this.scanCode}`;
 	}
 
 	/**

--- a/src/vs/base/test/common/keybindings.test.ts
+++ b/src/vs/base/test/common/keybindings.test.ts
@@ -1,0 +1,18 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { KeyCode, ScanCode } from 'vs/base/common/keyCodes';
+import { KeyCodeChord, ScanCodeChord } from 'vs/base/common/keybindings';
+
+suite('keyCodes', () => {
+
+	test('issue #173325: wrong interpretations of special keys (e.g. [Equal] is mistaken for V)', () => {
+		const a = new KeyCodeChord(true, false, false, false, KeyCode.KeyV);
+		const b = new ScanCodeChord(true, false, false, false, ScanCode.Equal);
+		assert.strictEqual(a.getHashCode() === b.getHashCode(), false);
+	});
+
+});


### PR DESCRIPTION
Fixes #173325 for stable. The problem was that scan code bindings and key code bindings had hash collisions.