### PR TITLE
Fix #173590. Reset code editor container display on render.

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/view/cellParts/codeCell.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/cellParts/codeCell.ts
@@ -62,6 +62,7 @@ export class CodeCell extends Disposable {
 		const editorHeight = this.calculateInitEditorHeight();
 		this.initializeEditor(editorHeight);
 		this._renderedInputCollapseState = false; // editor is always expanded initially
+		DOM.show(this.templateData.editorPart); // however the editor part display might not be cleared on template
 
 		this.registerViewCellLayoutChange();
 		this.registerCellEditorEventListeners();


### PR DESCRIPTION
Otherwise it might inherit a wrong 'display:none' from other cells.



<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
