### PR TITLE
fix quickpick alignment

### DIFF
--- a/src/vs/base/parts/quickinput/browser/media/quickInput.css
+++ b/src/vs/base/parts/quickinput/browser/media/quickInput.css
@@ -7,9 +7,8 @@
 	position: absolute;
 	width: 600px;
 	z-index: 2550;
-	left: 0;
-	right: 0;
-	margin: 0 auto;
+	left: 50%;
+	margin-left: -300px;
 	-webkit-app-region: no-drag;
 	border-radius: 6px;
 }

--- a/src/vs/base/parts/quickinput/browser/quickInput.ts
+++ b/src/vs/base/parts/quickinput/browser/quickInput.ts
@@ -1815,6 +1815,7 @@ export class QuickInputController extends Disposable {
 			const style = this.ui.container.style;
 			const width = Math.min(this.dimension!.width * 0.62 /* golden cut */, QuickInputController.MAX_WIDTH);
 			style.width = width + 'px';
+			style.marginLeft = '-' + (width / 2) + 'px';
 
 			this.ui.inputBox.layout();
 			this.ui.list.layout(this.dimension && this.dimension.height * 0.4);


### PR DESCRIPTION
This fix is only for the monaco editor, thus not in the release branch!

This reverts commit 40e7185033da52a465918bef7f7ac3bf43ae024e, which broke the monaco editor.

FYI @mjbvz

Before:
![image](https://user-images.githubusercontent.com/2931520/217214705-673d799e-ec02-411f-9143-3db16002f213.png)


After:
![image](https://user-images.githubusercontent.com/2931520/217214672-82bd6a8d-fd84-4f92-b229-5726bf2004e9.png)

