### PR TITLE
Log correct tsserver path

### DIFF
--- a/extensions/typescript-language-features/src/tsServer/spawner.ts
+++ b/extensions/typescript-language-features/src/tsServer/spawner.ts
@@ -142,12 +142,12 @@ export class TypeScriptServerSpawner {
 		const { args, tsServerLog, tsServerTraceDirectory } = this.getTsServerArgs(kind, configuration, version, apiVersion, pluginManager, canceller.cancellationPipeName);
 
 		if (TypeScriptServerSpawner.isLoggingEnabled(configuration)) {
-			if (!isWeb()) {
-				if (tsServerLog) {
-					this._logger.info(`<${kind}> Log file: ${tsServerLog}`);
-				} else {
-					this._logger.error(`<${kind}> Could not create log directory`);
-				}
+			if (tsServerLog?.type === 'file') {
+				this._logger.info(`<${kind}> Log file: ${tsServerLog.uri.fsPath}`);
+			} else if (tsServerLog?.type === 'output') {
+				this._logger.info(`<${kind}> Logging to output`);
+			} else {
+				this._logger.error(`<${kind}> Could not create TS Server log`);
 			}
 		}
 
@@ -275,7 +275,7 @@ export class TypeScriptServerSpawner {
 			args.push('--enableProjectWideIntelliSenseOnWeb');
 		}
 
-		return { args, tsServerLog: tsServerLog, tsServerTraceDirectory };
+		return { args, tsServerLog, tsServerTraceDirectory };
 	}
 
 	private static isLoggingEnabled(configuration: TypeScriptServiceConfiguration) {

--- a/extensions/typescript-language-features/src/typescriptServiceClient.ts
+++ b/extensions/typescript-language-features/src/typescriptServiceClient.ts
@@ -422,8 +422,8 @@ export default class TypeScriptServiceClient extends Disposable implements IType
 
 			this.serverState = new ServerState.Errored(err, handle.tsServerLog);
 			this.error('TSServer errored with error.', err);
-			if (handle.tsServerLog) {
-				this.error(`TSServer log file: ${handle.tsServerLog}`);
+			if (handle.tsServerLog && handle.tsServerLog.type === 'file') {
+				this.error(`TSServer log file: ${handle.tsServerLog.uri.fsPath}`);
 			}
 
 			/* __GDPR__
@@ -462,8 +462,8 @@ export default class TypeScriptServiceClient extends Disposable implements IType
 				return;
 			}
 
-			if (handle.tsServerLog) {
-				this.info(`TSServer log file: ${handle.tsServerLog}`);
+			if (handle.tsServerLog && handle.tsServerLog.type === 'file') {
+				this.info(`TSServer log file: ${handle.tsServerLog.uri.fsPath}`);
 			}
 			this.serviceExited(!this.isRestarting);
 			this.isRestarting = false;

--- a/extensions/typescript-language-features/src/typescriptServiceClient.ts
+++ b/extensions/typescript-language-features/src/typescriptServiceClient.ts
@@ -422,7 +422,7 @@ export default class TypeScriptServiceClient extends Disposable implements IType
 
 			this.serverState = new ServerState.Errored(err, handle.tsServerLog);
 			this.error('TSServer errored with error.', err);
-			if (handle.tsServerLog && handle.tsServerLog.type === 'file') {
+			if (handle.tsServerLog?.type === 'file') {
 				this.error(`TSServer log file: ${handle.tsServerLog.uri.fsPath}`);
 			}
 
@@ -462,7 +462,7 @@ export default class TypeScriptServiceClient extends Disposable implements IType
 				return;
 			}
 
-			if (handle.tsServerLog && handle.tsServerLog.type === 'file') {
+			if (handle.tsServerLog?.type === 'file') {
 				this.info(`TSServer log file: ${handle.tsServerLog.uri.fsPath}`);
 			}
 			this.serviceExited(!this.isRestarting);


### PR DESCRIPTION
Fixes #173707

We previously converted the TS Server log from a simple string to an object. However there were a few cases where this object was incorrectly being converted into a UI string, resulting in `[Object object]`

