### PR TITLE
feature: add a default keybinding for toggling secondary side bar visibility

### DIFF
--- a/src/vs/workbench/browser/parts/auxiliarybar/auxiliaryBarActions.ts
+++ b/src/vs/workbench/browser/parts/auxiliarybar/auxiliaryBarActions.ts
@@ -14,6 +14,8 @@ import { ViewContainerLocation, ViewContainerLocationToString } from 'vs/workben
 import { IWorkbenchLayoutService, Parts } from 'vs/workbench/services/layout/browser/layoutService';
 import { IPaneCompositePartService } from 'vs/workbench/services/panecomposite/browser/panecomposite';
 import { ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
+import { KeybindingWeight } from 'vs/platform/keybinding/common/keybindingsRegistry';
+import { KeyCode, KeyMod } from 'vs/base/common/keyCodes';
 
 
 const auxiliaryBarRightIcon = registerIcon('auxiliarybar-right-layout-icon', Codicon.layoutSidebarRight, localize('toggleAuxiliaryIconRight', 'Icon to toggle the auxiliary bar off in its right position.'));
@@ -38,6 +40,10 @@ export class ToggleAuxiliaryBarAction extends Action2 {
 
 			category: Categories.View,
 			f1: true,
+			keybinding: {
+				weight: KeybindingWeight.WorkbenchContrib,
+				primary: KeyMod.CtrlCmd | KeyMod.Alt | KeyCode.KeyB
+			},
 			menu: [
 				{
 					id: MenuId.LayoutControlMenuSubmenu,


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Adds a default keybinding for toggling secondary side bar visibility - `cmd + option + b`

The PR follows how the keybinding is added for "toggle primary side bar visibility" command

