### PR TITLE
Remove a false test

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/view/cellParts/cellOutput.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/cellParts/cellOutput.ts
@@ -688,7 +688,7 @@ export class CellOutputContainer extends CellContentPart {
 		// if it's clearing all outputs, or outputs are all rendered synchronously
 		// shrink immediately as the final output height will be zero.
 		// if it's rerun, then the output clearing might be temporary, so we don't shrink immediately
-		this._validateFinalOutputHeight(false || (context === CellOutputUpdateContext.Other && this.viewCell.outputsViewModels.length === 0));
+		this._validateFinalOutputHeight(context === CellOutputUpdateContext.Other && this.viewCell.outputsViewModels.length === 0);
 	}
 
 	private _generateShowMoreElement(disposables: DisposableStore): HTMLElement {


### PR DESCRIPTION
This was introduced some time ago without justification replacing

`false || xxx` is equivalent to `xxx` if `xxx` is boolean (which it is here).

Please let me know if there is an actual reason for it and I can adapt the PR to comment on this false statement.

Closes #173786