### PR TITLE
Fix `textPreformat.foreground` in v2 themes

### DIFF
--- a/extensions/theme-defaults/themes/dark_plus_experimental.json
+++ b/extensions/theme-defaults/themes/dark_plus_experimental.json
@@ -126,7 +126,7 @@
 		"textCodeBlock.background": "#6e768166",
 		"textLink.activeForeground": "#40A6FF",
 		"textLink.foreground": "#40A6FF",
-		"textPreformat.foreground": "#8b949e",
+		"textPreformat.foreground": "#f85149",
 		"textSeparator.foreground": "#21262d",
 		"titleBar.activeBackground": "#181818",
 		"titleBar.activeForeground": "#ffffffc5",

--- a/extensions/theme-defaults/themes/light_plus_experimental.json
+++ b/extensions/theme-defaults/themes/light_plus_experimental.json
@@ -141,7 +141,6 @@
 		"textCodeBlock.background": "#6e768166",
 		"textLink.activeForeground": "#005FB8",
 		"textLink.foreground": "#005FB8",
-		"textPreformat.foreground": "#8b949e",
 		"textSeparator.foreground": "#21262d",
 		"titleBar.activeBackground": "#f8f8f8",
 		"titleBar.activeForeground": "#1e1e1e",


### PR DESCRIPTION
Fix #173255