### PR TITLE
The startDebugging request should use the new config's name if available

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/debugSession.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugSession.ts
@@ -325,6 +325,7 @@ export class DebugSession implements IDebugSession {
 				supportsMemoryReferences: true, //#129684
 				supportsArgsCanBeInterpretedByShell: true, // #149910
 				supportsMemoryEvent: true, // #133643
+				supportsStartDebuggingRequest: true
 			});
 
 			this.initialized = true;

--- a/src/vs/workbench/contrib/debug/browser/rawDebugSession.ts
+++ b/src/vs/workbench/contrib/debug/browser/rawDebugSession.ts
@@ -669,7 +669,7 @@ export class RawDebugSession implements IDisposable {
 					...{
 						request: args.request,
 						type: this.dbgr.type,
-						name: this.name
+						name: args.configuration.name || this.name
 					}
 				};
 				const success = await this.dbgr.startDebugging(config, this.sessionId);


### PR DESCRIPTION
Fix #173655
and VS Code already supports startDebuggingRequest, fix #173654