### PR TITLE
Introduce `ctrl+alt+o` keybinding to open remote menu

### DIFF
--- a/src/vs/workbench/contrib/remote/browser/remoteIndicator.ts
+++ b/src/vs/workbench/contrib/remote/browser/remoteIndicator.ts
@@ -39,6 +39,8 @@ import { IPaneCompositePartService } from 'vs/workbench/services/panecomposite/b
 import { ViewContainerLocation } from 'vs/workbench/common/views';
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 import { WorkbenchActionExecutedClassification, WorkbenchActionExecutedEvent } from 'vs/base/common/actions';
+import { KeybindingWeight } from 'vs/platform/keybinding/common/keybindingsRegistry';
+import { KeyCode, KeyMod } from 'vs/base/common/keyCodes';
 
 type ActionGroup = [string, Array<MenuItemAction | SubmenuItemAction>];
 export class RemoteStatusIndicator extends Disposable implements IWorkbenchContribution {
@@ -112,6 +114,10 @@ export class RemoteStatusIndicator extends Disposable implements IWorkbenchContr
 					category,
 					title: { value: nls.localize('remote.showMenu', "Show Remote Menu"), original: 'Show Remote Menu' },
 					f1: true,
+					keybinding: {
+						weight: KeybindingWeight.WorkbenchContrib,
+						primary: KeyMod.Shift | KeyCode.KeyR,
+					}
 				});
 			}
 			run = () => that.showRemoteMenu();

--- a/src/vs/workbench/contrib/remote/browser/remoteIndicator.ts
+++ b/src/vs/workbench/contrib/remote/browser/remoteIndicator.ts
@@ -116,7 +116,7 @@ export class RemoteStatusIndicator extends Disposable implements IWorkbenchContr
 					f1: true,
 					keybinding: {
 						weight: KeybindingWeight.WorkbenchContrib,
-						primary: KeyMod.Shift | KeyCode.KeyR,
+						primary: KeyMod.CtrlCmd | KeyMod.Alt | KeyCode.KeyO,
 					}
 				});
 			}


### PR DESCRIPTION
To make it easier to open the remote indicator, we'd like to introduce a remote indicator keybinding.

`ctrl+alt+o` is not taken yet and mirrors `ctrl+o` to open a file/folder. My first choice would've been to include `r` but `ctrl+r`, `ctrl+shift+r`, `ctrl+alt+r`, `alt+r` and `alt+shift+r` are already taken.