### PR TITLE
Use native path for trace directory

### DIFF
--- a/extensions/typescript-language-features/src/tsServer/spawner.ts
+++ b/extensions/typescript-language-features/src/tsServer/spawner.ts
@@ -153,7 +153,7 @@ export class TypeScriptServerSpawner {
 
 		if (configuration.enableTsServerTracing) {
 			if (tsServerTraceDirectory) {
-				this._logger.info(`<${kind}> Trace directory: ${tsServerTraceDirectory}`);
+				this._logger.info(`<${kind}> Trace directory: ${tsServerTraceDirectory.fsPath}`);
 			} else {
 				this._logger.error(`<${kind}> Could not create trace directory`);
 			}
@@ -240,7 +240,7 @@ export class TypeScriptServerSpawner {
 		if (configuration.enableTsServerTracing && !isWeb()) {
 			tsServerTraceDirectory = this._logDirectoryProvider.getNewLogDirectory();
 			if (tsServerTraceDirectory) {
-				args.push('--traceDirectory', tsServerTraceDirectory.path);
+				args.push('--traceDirectory', tsServerTraceDirectory.fsPath);
 			}
 		}
 


### PR DESCRIPTION
Fixes #173854

On windows, we need to pass in the `c:\` style path as the trace directory. The normal `/` path causes TS Server to crash

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
