### PR TITLE
Fix #173869 marking active line for code elements too in markdown pre…

### DIFF
--- a/extensions/markdown-language-features/preview-src/activeLineMarker.ts
+++ b/extensions/markdown-language-features/preview-src/activeLineMarker.ts
@@ -9,7 +9,7 @@ export class ActiveLineMarker {
 
 	onDidChangeTextEditorSelection(line: number, documentVersion: number) {
 		const { previous } = getElementsForSourceLine(line, documentVersion);
-		this._update(previous && previous.element);
+		this._update(previous && (previous.codeElement || previous.element));
 	}
 
 	_update(before: HTMLElement | undefined) {
@@ -22,13 +22,14 @@ export class ActiveLineMarker {
 		if (!element) {
 			return;
 		}
-		element.className = element.className.replace(/\bcode-active-line\b/g, '');
+		element.classList.toggle('code-active-line', false);
 	}
 
 	_markActiveElement(element: HTMLElement | undefined) {
 		if (!element) {
 			return;
 		}
-		element.className += ' code-active-line';
+
+		element.classList.toggle('code-active-line', true);
 	}
 }

--- a/extensions/markdown-language-features/preview-src/scroll-sync.ts
+++ b/extensions/markdown-language-features/preview-src/scroll-sync.ts
@@ -11,6 +11,7 @@ const codeLineClass = 'code-line';
 export interface CodeLineElement {
 	element: HTMLElement;
 	line: number;
+	codeElement?: HTMLElement;
 }
 
 const getCodeLineElements = (() => {
@@ -27,9 +28,9 @@ const getCodeLineElements = (() => {
 				}
 
 				if (element.tagName === 'CODE' && element.parentElement && element.parentElement.tagName === 'PRE') {
-					// Fenched code blocks are a special case since the `code-line` can only be marked on
+					// Fenced code blocks are a special case since the `code-line` can only be marked on
 					// the `<code>` element and not the parent `<pre>` element.
-					cachedElements.push({ element: element.parentElement as HTMLElement, line });
+					cachedElements.push({ element: element.parentElement as HTMLElement, line: line, codeElement: element as HTMLElement });
 				} else if (element.tagName === 'UL' || element.tagName === 'OL') {
 					// Skip adding list elements since the first child has the same code line (and should be preferred)
 				} else {


### PR DESCRIPTION
Fix #173869

activating code line on code blocks too

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
