### PR TITLE
Update: add command to give back the current state

### DIFF
--- a/src/vs/workbench/contrib/update/browser/update.ts
+++ b/src/vs/workbench/contrib/update/browser/update.ts
@@ -437,6 +437,10 @@ export class UpdateContribution extends Disposable implements IWorkbenchContribu
 			},
 			when: CONTEXT_UPDATE_STATE.isEqualTo(StateType.Ready)
 		});
+
+		CommandsRegistry.registerCommand('_update.state', () => {
+			return this.state;
+		});
 	}
 }
 


### PR DESCRIPTION
For https://github.com/microsoft/vscode-remote-release/issues/3839

Gives the WSL extension the information which build the update service is/has downloaded.