### PR TITLE
Revert "Prevent dragging of links in rendered markdown (#168232)"

### DIFF
--- a/src/vs/base/browser/markdownRenderer.ts
+++ b/src/vs/base/browser/markdownRenderer.ts
@@ -257,7 +257,7 @@ export function renderMarkdown(markdown: IMarkdownString, options: MarkdownRende
 	markdownHtmlDoc.body.querySelectorAll('a')
 		.forEach(a => {
 			const href = a.getAttribute('href'); // Get the raw 'href' attribute value as text, not the resolved 'href'
-			a.removeAttribute('href'); // Clear out href. We use the `data-href` for handling clicks instead
+			a.setAttribute('href', ''); // Clear out href. We use the `data-href` for handling clicks instead
 			if (
 				!href
 				|| /^data:|javascript:/i.test(href)

--- a/src/vs/base/test/browser/markdownRenderer.test.ts
+++ b/src/vs/base/test/browser/markdownRenderer.test.ts
@@ -161,7 +161,7 @@ suite('MarkdownRenderer', () => {
 			mds.appendMarkdown(`[$(zap)-link](#link)`);
 
 			const result: HTMLElement = renderMarkdown(mds).element;
-			assert.strictEqual(result.innerHTML, `<p><a data-href="#link" title="#link"><span class="codicon codicon-zap"></span>-link</a></p>`);
+			assert.strictEqual(result.innerHTML, `<p><a data-href="#link" href="" title="#link"><span class="codicon codicon-zap"></span>-link</a></p>`);
 		});
 
 		test('render icon in table', () => {
@@ -181,7 +181,7 @@ suite('MarkdownRenderer', () => {
 </thead>
 <tbody><tr>
 <td><span class="codicon codicon-zap"></span></td>
-<td><a data-href="#link" title="#link"><span class="codicon codicon-zap"></span>-link</a></td>
+<td><a data-href="#link" href="" title="#link"><span class="codicon codicon-zap"></span>-link</a></td>
 </tr>
 </tbody></table>
 `);
@@ -248,7 +248,7 @@ suite('MarkdownRenderer', () => {
 		});
 
 		const result: HTMLElement = renderMarkdown(md).element;
-		assert.strictEqual(result.innerHTML, `<p><a data-href="command:doFoo" title="command:doFoo">command1</a> <a data-href="command:doFoo">command2</a></p>`);
+		assert.strictEqual(result.innerHTML, `<p><a data-href="command:doFoo" href="" title="command:doFoo">command1</a> <a data-href="command:doFoo" href="">command2</a></p>`);
 	});
 
 	suite('PlaintextMarkdownRender', () => {


### PR DESCRIPTION
This reverts commit 7981d7f1430f40ce0abe9b71f0d1cc5979367fc5.

This causes a regression in which you cannot tab through custom hovers with links.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
