### PR TITLE
extension host - allow to report issue when crash

### DIFF
--- a/src/vs/workbench/services/extensions/electron-sandbox/nativeExtensionService.ts
+++ b/src/vs/workbench/services/extensions/electron-sandbox/nativeExtensionService.ts
@@ -17,7 +17,7 @@ import { IRemoteAgentService } from 'vs/workbench/services/remote/common/remoteA
 import { IRemoteAuthorityResolverService, RemoteAuthorityResolverError, RemoteAuthorityResolverErrorCode, ResolverResult, getRemoteAuthorityPrefix } from 'vs/platform/remote/common/remoteAuthorityResolver';
 import { IInstantiationService, ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
 import { ILifecycleService, LifecyclePhase } from 'vs/workbench/services/lifecycle/common/lifecycle';
-import { INotificationService, Severity } from 'vs/platform/notification/common/notification';
+import { INotificationService, IPromptChoice, Severity } from 'vs/platform/notification/common/notification';
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 import { IHostService } from 'vs/workbench/services/host/browser/host';
 import { IExtensionService, toExtension, ExtensionHostKind, IExtensionHost, webWorkerExtHostConfig, ExtensionRunningLocation, WebWorkerExtHostConfigValue, extensionHostKindToString } from 'vs/workbench/services/extensions/common/extensions';
@@ -52,6 +52,7 @@ import { IUserDataProfileService } from 'vs/workbench/services/userDataProfile/c
 import { LegacyNativeLocalProcessExtensionHost } from 'vs/workbench/services/extensions/electron-sandbox/nativeLocalProcessExtensionHost';
 import { InstantiationType, registerSingleton } from 'vs/platform/instantiation/common/extensions';
 import { process } from 'vs/base/parts/sandbox/electron-sandbox/globals';
+import { IWorkbenchIssueService } from 'vs/workbench/services/issue/common/issue';
 
 export class NativeExtensionService extends AbstractExtensionService implements IExtensionService {
 
@@ -83,7 +84,7 @@ export class NativeExtensionService extends AbstractExtensionService implements 
 		@IRemoteExplorerService private readonly _remoteExplorerService: IRemoteExplorerService,
 		@IExtensionGalleryService private readonly _extensionGalleryService: IExtensionGalleryService,
 		@IWorkspaceTrustManagementService private readonly _workspaceTrustManagementService: IWorkspaceTrustManagementService,
-		@IUserDataProfileService userDataProfileService: IUserDataProfileService,
+		@IUserDataProfileService userDataProfileService: IUserDataProfileService
 	) {
 		super(
 			instantiationService,
@@ -294,16 +295,30 @@ export class NativeExtensionService extends AbstractExtensionService implements 
 				this._notificationService.status(nls.localize('extensionService.autoRestart', "The extension host terminated unexpectedly. Restarting..."), { hideAfter: 5000 });
 				this.startExtensionHosts();
 			} else {
-				this._notificationService.prompt(Severity.Error, nls.localize('extensionService.crash', "Extension host terminated unexpectedly 3 times within the last 5 minutes."),
-					[{
+				const choices: IPromptChoice[] = [];
+				if (this._environmentService.isBuilt) {
+					choices.push({
+						label: nls.localize('reportIssue', "Report Issue"),
+						run: () => {
+							this._instantiationService.invokeFunction(accessor => {
+								const issueService = accessor.get(IWorkbenchIssueService);
+								issueService.openReporter();
+							});
+						}
+					});
+				} else {
+					choices.push({
 						label: nls.localize('devTools', "Open Developer Tools"),
 						run: () => this._nativeHostService.openDevTools()
-					},
-					{
-						label: nls.localize('restart', "Restart Extension Host"),
-						run: () => this.startExtensionHosts()
-					}]
-				);
+					});
+				}
+
+				choices.push({
+					label: nls.localize('restart', "Restart Extension Host"),
+					run: () => this.startExtensionHosts()
+				});
+
+				this._notificationService.prompt(Severity.Error, nls.localize('extensionService.crash', "Extension host terminated unexpectedly 3 times within the last 5 minutes."), choices);
 			}
 		}
 	}


### PR DESCRIPTION
cc @deepak1556 @digitarald to get people to report issues from crashing extension hosts:

<img width="494" alt="image" src="https://user-images.githubusercontent.com/900690/218558321-87dbab4b-a612-49ee-9e83-286c9d645d18.png">

We still attempt to restart on crash up to 3 times, so a user would only see it then.