### PR TITLE
Set Opacity to MatchHighlight in QuietLight

### DIFF
--- a/extensions/theme-quietlight/themes/quietlight-color-theme.json
+++ b/extensions/theme-quietlight/themes/quietlight-color-theme.json
@@ -500,7 +500,7 @@
 		"inputOption.activeBorder": "#adafb7",
 		"dropdown.background": "#F5F5F5",
 		"editor.findMatchBackground": "#BF9CAC",
-		"editor.findMatchHighlightBackground": "#edc9d8",
+		"editor.findMatchHighlightBackground": "#edc9d899",
 		"peekViewEditor.matchHighlightBackground": "#C2DFE3",
 		"peekViewTitle.background": "#F2F8FC",
 		"peekViewEditor.background": "#F2F8FC",


### PR DESCRIPTION
As stated in the docs for `editor.findMatchHighlightBackground`: 

> The color must not be opaque so as not to hide underlying decorations.

I've simply added a `0.6` opacity to the color so that it doesn't obscure the selection background.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
