### PR TITLE
Adding the server and client code to the JSON language features extensions to enable JSONC sorting in VS Code

### DIFF
--- a/extensions/json-language-features/client/src/jsonClient.ts
+++ b/extensions/json-language-features/client/src/jsonClient.ts
@@ -175,15 +175,16 @@ export async function startClient(context: ExtensionContext, newLanguageClient: 
 					uri: document.uri.toString(),
 					options: options
 				};
-				const textEdits = await client.sendRequest(DocumentSortingRequest.type, params);
-				textEditor.edit(mutator => {
-					for (const edit of textEdits) {
-						mutator.replace(client.protocol2CodeConverter.asRange(edit.range), edit.newText);
-					}
-				}).then(success => {
-					if (!success) {
-						window.showErrorMessage(l10n.t('Failed to sort the JSONC document, please consider opening an issue.'));
-					}
+				client.sendRequest(DocumentSortingRequest.type, params).then((textEdits) => {
+					textEditor.edit(mutator => {
+						for (const edit of textEdits) {
+							mutator.replace(client.protocol2CodeConverter.asRange(edit.range), edit.newText);
+						}
+					}).then(success => {
+						if (!success) {
+							window.showErrorMessage(l10n.t('Failed to sort the JSONC document, please consider opening an issue.'));
+						}
+					});
 				});
 			}
 		}

--- a/extensions/json-language-features/client/src/jsonClient.ts
+++ b/extensions/json-language-features/client/src/jsonClient.ts
@@ -36,6 +36,9 @@ namespace LanguageStatusRequest {
 	export const type: RequestType<string, JSONLanguageStatus, any> = new RequestType('json/languageStatus');
 }
 
+namespace DocumentSortingRequest {
+	export const type: RequestType<string, TextEdit[], any> = new RequestType('json/sort');
+}
 
 export interface ISchemaAssociations {
 	[pattern: string]: string[];
@@ -144,6 +147,32 @@ export async function startClient(context: ExtensionContext, newLanguageClient: 
 			await client.sendNotification(SchemaContentChangeNotification.type, cachedSchemas);
 		}
 		window.showInformationMessage(l10n.t('JSON schema cache cleared.'));
+	}));
+
+	toDispose.push(commands.registerCommand('json.sort', async () => {
+
+		// const params: DocumentSortingParams = {
+		//	textDocument: client.code2ProtocolConverter.asTextDocumentIdentifier(document),
+		//	range: client.code2ProtocolConverter.asRange(range),
+		//	options: client.code2ProtocolConverter.asFormattingOptions(options, fileFormattingOptions)
+		//};
+
+		if (isClientReady) {
+			console.log('Before send request');
+			// const params = undefined;
+			// const activeDocUri = window.activeTextEditor.document.uri.toString();
+			const document = window.activeTextEditor?.document;
+			if (document) {
+				await client.sendRequest(DocumentSortingRequest.type, document.uri.toString()).then((textEdits) => {
+					const convertedTextEdits = client.protocol2CodeConverter.asTextEdits(textEdits);
+					console.log('convertedTextEdits : ', convertedTextEdits);
+					// (error) => {
+					//	client.handleFailedRequest(DocumentSortingRequest.type, undefined, error, []);
+					//	return Promise.resolve([]);
+					// }
+				});
+			}
+		}
 	}));
 
 	// Options to control the language client

--- a/extensions/json-language-features/client/src/jsonClient.ts
+++ b/extensions/json-language-features/client/src/jsonClient.ts
@@ -164,12 +164,12 @@ export async function startClient(context: ExtensionContext, newLanguageClient: 
 
 		if (isClientReady) {
 			const textEditor = window.activeTextEditor;
-			const document = window.activeTextEditor?.document;
+			const document = textEditor?.document;
 
 			if (textEditor && document) {
 				const options: FormattingOptions = {
-					tabSize: window.activeTextEditor?.options.tabSize ? Number(window.activeTextEditor?.options.tabSize) : 4,
-					insertSpaces: window.activeTextEditor?.options.insertSpaces ? Boolean(window.activeTextEditor?.options.insertSpaces) : true
+					tabSize: textEditor?.options.tabSize ? Number(textEditor?.options.tabSize) : 4,
+					insertSpaces: textEditor?.options.insertSpaces ? Boolean(textEditor?.options.insertSpaces) : true
 				};
 				const params: DocumentSortingParams = {
 					uri: document.uri.toString(),

--- a/extensions/json-language-features/client/src/jsonClient.ts
+++ b/extensions/json-language-features/client/src/jsonClient.ts
@@ -159,18 +159,11 @@ export async function startClient(context: ExtensionContext, newLanguageClient: 
 
 		if (isClientReady) {
 			console.log('Before send request');
-			// const params = undefined;
-			// const activeDocUri = window.activeTextEditor.document.uri.toString();
 			const document = window.activeTextEditor?.document;
 			if (document) {
-				await client.sendRequest(DocumentSortingRequest.type, document.uri.toString()).then((textEdits) => {
-					const convertedTextEdits = client.protocol2CodeConverter.asTextEdits(textEdits);
-					console.log('convertedTextEdits : ', convertedTextEdits);
-					// (error) => {
-					//	client.handleFailedRequest(DocumentSortingRequest.type, undefined, error, []);
-					//	return Promise.resolve([]);
-					// }
-				});
+				const textEdits = await client.sendRequest(DocumentSortingRequest.type, document.uri.toString());
+				console.log('textEdits : ', textEdits);
+				// How to use the text-edits? Implement a sorting provider?
 			}
 		}
 	}));

--- a/extensions/json-language-features/package.json
+++ b/extensions/json-language-features/package.json
@@ -149,6 +149,11 @@
         "command": "json.clearCache",
         "title": "%json.command.clearCache%",
         "category": "JSON"
+      },
+      {
+        "command": "json.sort",
+        "title": "%json.command.sort%",
+        "category": "JSON"
       }
     ]
   },

--- a/extensions/json-language-features/package.nls.json
+++ b/extensions/json-language-features/package.nls.json
@@ -17,5 +17,6 @@
 	"json.maxItemsComputed.desc": "The maximum number of outline symbols and folding regions computed (limited for performance reasons).",
 	"json.maxItemsExceededInformation.desc": "Show notification when exceeding the maximum number of outline symbols and folding regions.",
 	"json.enableSchemaDownload.desc": "When enabled, JSON schemas can be fetched from http and https locations.",
-	"json.command.clearCache": "Clear schema cache"
+	"json.command.clearCache": "Clear schema cache",
+	"json.command.sort": "Sort document"
 }

--- a/extensions/json-language-features/server/package.json
+++ b/extensions/json-language-features/server/package.json
@@ -15,7 +15,7 @@
     "@vscode/l10n": "^0.0.11",
     "jsonc-parser": "^3.2.0",
     "request-light": "^0.7.0",
-    "vscode-json-languageservice": "^5.2.0",
+    "vscode-json-languageservice": "^5.3.0",
     "vscode-languageserver": "^8.1.0-next.6",
     "vscode-uri": "^3.0.7"
   },

--- a/extensions/json-language-features/server/src/jsonServer.ts
+++ b/extensions/json-language-features/server/src/jsonServer.ts
@@ -39,8 +39,19 @@ namespace LanguageStatusRequest {
 	export const type: RequestType<string, JSONLanguageStatus, any> = new RequestType('json/languageStatus');
 }
 
+export interface DocumentSortingParams {
+	/**
+	 * The uri of the document to sort.
+	 */
+	uri: string;
+	/**
+	 * The format options
+	 */
+	options: FormattingOptions;
+}
+
 namespace DocumentSortingRequest {
-	export const type: RequestType<string, TextEdit[], any> = new RequestType('json/sort');
+	export const type: RequestType<DocumentSortingParams, TextEdit[], any> = new RequestType('json/sort');
 }
 
 const workspaceContext = {
@@ -296,19 +307,12 @@ export function startServer(connection: Connection, runtime: RuntimeEnvironment)
 		}
 	});
 
-	// Document sorting
-	connection.onRequest(DocumentSortingRequest.type, async uri => {
-		console.log('Entered into the server side onRequest');
+	connection.onRequest(DocumentSortingRequest.type, async params => {
+		const uri = params.uri;
+		const options = params.options;
 		const document = documents.get(uri);
-		// How to to get the options ?
-		const options = {
-			tabSize: 2,
-			insertSpaces: true
-		};
-		// How to get the options?
 		if (document) {
 			const sortedDocument = languageService.sort(document, options);
-			console.log('Inside of onRequest inside of server : ', [TextEdit.replace(getFullRange(document), sortedDocument)]);
 			return [TextEdit.replace(getFullRange(document), sortedDocument)];
 		}
 		return [];

--- a/extensions/json-language-features/server/src/jsonServer.ts
+++ b/extensions/json-language-features/server/src/jsonServer.ts
@@ -11,7 +11,7 @@ import {
 
 import { runSafe, runSafeAsync } from './utils/runner';
 import { DiagnosticsSupport, registerDiagnosticsPullSupport, registerDiagnosticsPushSupport } from './utils/validation';
-import { TextDocument, JSONDocument, JSONSchema, getLanguageService, DocumentLanguageSettings, SchemaConfiguration, ClientCapabilities, Range, Position } from 'vscode-json-languageservice';
+import { TextDocument, JSONDocument, JSONSchema, getLanguageService, DocumentLanguageSettings, SchemaConfiguration, ClientCapabilities, Range, Position, SortOptions } from 'vscode-json-languageservice';
 import { getLanguageModelCache } from './languageModelCache';
 import { Utils, URI } from 'vscode-uri';
 
@@ -47,7 +47,7 @@ export interface DocumentSortingParams {
 	/**
 	 * The format options
 	 */
-	options: FormattingOptions;
+	options: SortOptions;
 }
 
 namespace DocumentSortingRequest {

--- a/extensions/json-language-features/server/src/jsonServer.ts
+++ b/extensions/json-language-features/server/src/jsonServer.ts
@@ -39,6 +39,9 @@ namespace LanguageStatusRequest {
 	export const type: RequestType<string, JSONLanguageStatus, any> = new RequestType('json/languageStatus');
 }
 
+namespace DocumentSortingRequest {
+	export const type: RequestType<string, TextEdit[], any> = new RequestType('json/sort');
+}
 
 const workspaceContext = {
 	resolveRelativePath: (relativePath: string, resource: string) => {
@@ -112,9 +115,7 @@ export function startServer(connection: Connection, runtime: RuntimeEnvironment)
 	let jsonColorDecoratorLimit = Number.MAX_VALUE;
 	let jsoncColorDecoratorLimit = Number.MAX_VALUE;
 
-
 	let formatterMaxNumberOfEdits = Number.MAX_VALUE;
-
 	let diagnosticsSupport: DiagnosticsSupport | undefined;
 
 
@@ -293,6 +294,24 @@ export function startServer(connection: Connection, runtime: RuntimeEnvironment)
 		} else {
 			return { schemas: [] };
 		}
+	});
+
+	// Document sorting
+	connection.onRequest(DocumentSortingRequest.type, async uri => {
+		console.log('Entered into the server side onRequest');
+		const document = documents.get(uri);
+		// How to to get the options ?
+		const options = {
+			tabSize: 2,
+			insertSpaces: true
+		};
+		// How to get the options?
+		if (document) {
+			const sortedDocument = languageService.sort(document, options);
+			console.log('Inside of onRequest inside of server : ', [TextEdit.replace(getFullRange(document), sortedDocument)]);
+			return [TextEdit.replace(getFullRange(document), sortedDocument)];
+		}
+		return [];
 	});
 
 	function updateConfiguration() {

--- a/extensions/json-language-features/server/src/jsonServer.ts
+++ b/extensions/json-language-features/server/src/jsonServer.ts
@@ -403,17 +403,27 @@ export function startServer(connection: Connection, runtime: RuntimeEnvironment)
 	});
 
 	function onFormat(textDocument: TextDocumentIdentifier, range: Range | undefined, options: FormattingOptions): TextEdit[] {
-		options.keepLines = keepLinesEnabled;
+
 		const document = documents.get(textDocument.uri);
 		if (document) {
-			const edits = languageService.format(document, range ?? getFullRange(document), options);
-			if (edits.length > formatterMaxNumberOfEdits) {
-				const newText = TextDocument.applyEdits(document, edits);
-				return [TextEdit.replace(getFullRange(document), newText)];
-			}
-			return edits;
+			const sortedDocument = languageService.sort(document, options);
+			return [TextEdit.replace(getFullRange(document), sortedDocument)];
 		}
+
 		return [];
+
+		// OLD CODE
+		// options.keepLines = keepLinesEnabled;
+		// const document = documents.get(textDocument.uri);
+		// if (document) {
+		//	const edits = languageService.format(document, range ?? getFullRange(document), options);
+		//	if (edits.length > formatterMaxNumberOfEdits) {
+		//		const newText = TextDocument.applyEdits(document, edits);
+		//		return [TextEdit.replace(getFullRange(document), newText)];
+		//	}
+		//	return edits;
+		// }
+		// return [];
 	}
 
 	connection.onDocumentRangeFormatting((formatParams, token) => {

--- a/extensions/json-language-features/server/src/jsonServer.ts
+++ b/extensions/json-language-features/server/src/jsonServer.ts
@@ -312,8 +312,7 @@ export function startServer(connection: Connection, runtime: RuntimeEnvironment)
 		const options = params.options;
 		const document = documents.get(uri);
 		if (document) {
-			const sortedDocument = languageService.sort(document, options);
-			return [TextEdit.replace(getFullRange(document), sortedDocument)];
+			return languageService.sort(document, options);
 		}
 		return [];
 	});
@@ -427,26 +426,17 @@ export function startServer(connection: Connection, runtime: RuntimeEnvironment)
 
 	function onFormat(textDocument: TextDocumentIdentifier, range: Range | undefined, options: FormattingOptions): TextEdit[] {
 
+		options.keepLines = keepLinesEnabled;
 		const document = documents.get(textDocument.uri);
 		if (document) {
-			const sortedDocument = languageService.sort(document, options);
-			return [TextEdit.replace(getFullRange(document), sortedDocument)];
+			const edits = languageService.format(document, range ?? getFullRange(document), options);
+			if (edits.length > formatterMaxNumberOfEdits) {
+				const newText = TextDocument.applyEdits(document, edits);
+				return [TextEdit.replace(getFullRange(document), newText)];
+			}
+			return edits;
 		}
-
 		return [];
-
-		// OLD CODE
-		// options.keepLines = keepLinesEnabled;
-		// const document = documents.get(textDocument.uri);
-		// if (document) {
-		//	const edits = languageService.format(document, range ?? getFullRange(document), options);
-		//	if (edits.length > formatterMaxNumberOfEdits) {
-		//		const newText = TextDocument.applyEdits(document, edits);
-		//		return [TextEdit.replace(getFullRange(document), newText)];
-		//	}
-		//	return edits;
-		// }
-		// return [];
 	}
 
 	connection.onDocumentRangeFormatting((formatParams, token) => {

--- a/extensions/json-language-features/server/yarn.lock
+++ b/extensions/json-language-features/server/yarn.lock
@@ -27,15 +27,15 @@ request-light@^0.7.0:
   resolved "https://registry.yarnpkg.com/request-light/-/request-light-0.7.0.tgz#885628bb2f8040c26401ebf258ec51c4ae98ac2a"
   integrity sha512-lMbBMrDoxgsyO+yB3sDcrDuX85yYt7sS8BfQd11jtbW/z5ZWgLZRcEGLsLoYw7I0WSUGQBs8CC8ScIxkTX1+6Q==
 
-vscode-json-languageservice@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/vscode-json-languageservice/-/vscode-json-languageservice-5.2.0.tgz#884b7f108be4310e3332167c3ea60ab17f03418c"
-  integrity sha512-q8Rdhu2HEddRxvlhVqwh0cWmKK+OtyMB2xRhtqXEQ7cjb0iZ14madb90iJe9fCHPjoj9CGBrq6QzuOp8OE6XWg==
+vscode-json-languageservice@^5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/vscode-json-languageservice/-/vscode-json-languageservice-5.3.0.tgz#b8e8f220f4030af33144182029ac13090d3ceb96"
+  integrity sha512-yVC2WpAaF1swkUBA7EqG3hmSORxI6EpTBGdGgo5DIfJpG5hrk8PzPODAhQd0gVFtTF5j4yFxFD6V1x2XBqagcg==
   dependencies:
     "@vscode/l10n" "^0.0.11"
     jsonc-parser "^3.2.0"
     vscode-languageserver-textdocument "^1.0.8"
-    vscode-languageserver-types "^3.17.2"
+    vscode-languageserver-types "^3.17.3"
     vscode-uri "^3.0.7"
 
 vscode-jsonrpc@8.1.0-next.7:
@@ -61,10 +61,10 @@ vscode-languageserver-types@3.17.3-next.3:
   resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.17.3-next.3.tgz#fc909d37d4200126d74583f2114e53ace27a3e04"
   integrity sha512-R36Wi5sHoVc/PsAva0QGoEgw+LRCXPDKcdjFfgoVwrRdrFOdYUkvp5G4NvrPUsVT2f2qS/bSs6QiRxyjNkcR9A==
 
-vscode-languageserver-types@^3.17.2:
-  version "3.17.2"
-  resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.17.2.tgz#b2c2e7de405ad3d73a883e91989b850170ffc4f2"
-  integrity sha512-zHhCWatviizPIq9B7Vh9uvrH6x3sK8itC84HkamnBWoDFJtzBf7SWlpLCZUit72b3os45h6RWQNC9xHRDF8dRA==
+vscode-languageserver-types@^3.17.3:
+  version "3.17.3"
+  resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.17.3.tgz#72d05e47b73be93acb84d6e311b5786390f13f64"
+  integrity sha512-SYU4z1dL0PyIMd4Vj8YOqFvHu7Hz/enbWtpfnVbJHU4Nd1YNYx8u0ennumc6h48GQNeOLxmwySmnADouT/AuZA==
 
 vscode-languageserver@^8.1.0-next.6:
   version "8.1.0-next.6"

--- a/src/vscode-dts/vscode.d.ts
+++ b/src/vscode-dts/vscode.d.ts
@@ -4064,6 +4064,27 @@ declare module 'vscode' {
 	/**
 	 * Value-object describing what options formatting should use.
 	 */
+	export interface SortingOptions {
+
+		/**
+		 * Size of a tab in spaces.
+		 */
+		tabSize: number;
+
+		/**
+		 * Prefer spaces over tabs.
+		 */
+		insertSpaces: boolean;
+
+		/**
+		 * Signature for further properties.
+		 */
+		[key: string]: boolean | number | string;
+	}
+
+	/**
+	 * Value-object describing what options formatting should use.
+	 */
 	export interface FormattingOptions {
 
 		/**


### PR DESCRIPTION
This pull-request adds the server and client code to enable the usage of the JSONC sorting API. 

⚠ Pull request to be merged once the new sort API from the JSON language features is merged. Currently throwing errors.