### PR TITLE
allow non-api command instead

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView.ts
@@ -675,7 +675,7 @@ export class BackLayerWebView<T extends ICommonCellInfo> extends Themable {
 								'github-issues.authNow',
 								'workbench.extensions.search',
 								'workbench.action.openSettings',
-								'notebook.selectKernel',
+								'_notebook.selectKernel',
 							],
 						});
 						return;


### PR DESCRIPTION
the linked command from the web view needs to call the _ prefixed command, since it exists in the renderer
