### PR TITLE
HTML files default to save as .txt, but only if line 1 is not blank (fix #174048)

### DIFF
--- a/src/vs/workbench/services/textfile/browser/textFileService.ts
+++ b/src/vs/workbench/services/textfile/browser/textFileService.ts
@@ -591,13 +591,18 @@ export abstract class AbstractTextFileService extends Disposable implements ITex
 				// of untitled model if it is a valid path name and
 				// figure out the file extension from the mode if any.
 
+				let nameCandidate: string;
 				if (await this.pathService.hasValidBasename(joinPath(defaultFilePath, model.name), model.name)) {
-					const languageId = model.getLanguageId();
-					if (languageId && languageId !== PLAINTEXT_LANGUAGE_ID) {
-						suggestedFilename = this.suggestFilename(languageId, model.name);
-					} else {
-						suggestedFilename = model.name;
-					}
+					nameCandidate = model.name;
+				} else {
+					nameCandidate = basename(resource);
+				}
+
+				const languageId = model.getLanguageId();
+				if (languageId && languageId !== PLAINTEXT_LANGUAGE_ID) {
+					suggestedFilename = this.suggestFilename(languageId, nameCandidate);
+				} else {
+					suggestedFilename = nameCandidate;
 				}
 			}
 		}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
