### PR TITLE
Show unresolved comment glyph in gutter when appropriate (#149162)

### DIFF
--- a/src/vs/workbench/contrib/comments/browser/commentGlyphWidget.ts
+++ b/src/vs/workbench/contrib/comments/browser/commentGlyphWidget.ts
@@ -50,21 +50,25 @@ export class CommentGlyphWidget {
 		if (this._threadState !== state) {
 			this._threadState = state;
 			this._commentsOptions = this.createDecorationOptions();
-			this.setLineNumber(this._lineNumber);
+			this._updateDecorations();
 		}
 	}
 
-	setLineNumber(lineNumber: number): void {
-		this._lineNumber = lineNumber;
+	private _updateDecorations(): void {
 		const commentsDecorations = [{
 			range: {
-				startLineNumber: lineNumber, startColumn: 1,
-				endLineNumber: lineNumber, endColumn: 1
+				startLineNumber: this._lineNumber, startColumn: 1,
+				endLineNumber: this._lineNumber, endColumn: 1
 			},
 			options: this._commentsOptions
 		}];
 
 		this._commentsDecorations.set(commentsDecorations);
+	}
+
+	setLineNumber(lineNumber: number): void {
+		this._lineNumber = lineNumber;
+		this._updateDecorations();
 	}
 
 	getPosition(): IContentWidgetPosition {

--- a/src/vs/workbench/contrib/comments/browser/commentGlyphWidget.ts
+++ b/src/vs/workbench/contrib/comments/browser/commentGlyphWidget.ts
@@ -11,6 +11,7 @@ import { ModelDecorationOptions } from 'vs/editor/common/model/textModel';
 import { darken, editorBackground, editorForeground, listInactiveSelectionBackground, opaque, registerColor } from 'vs/platform/theme/common/colorRegistry';
 import { themeColorFromId } from 'vs/platform/theme/common/themeService';
 import { IEditorDecorationsCollection } from 'vs/editor/common/editorCommon';
+import { CommentThreadState } from 'vs/editor/common/languages';
 
 export const overviewRulerCommentingRangeForeground = registerColor('editorGutter.commentRangeForeground', { dark: opaque(listInactiveSelectionBackground, editorBackground), light: darken(opaque(listInactiveSelectionBackground, editorBackground), .05), hcDark: Color.white, hcLight: Color.black }, nls.localize('editorGutterCommentRangeForeground', 'Editor gutter decoration color for commenting ranges. This color should be opaque.'));
 registerColor('editorGutter.commentGlyphForground', { dark: editorForeground, light: editorForeground, hcDark: Color.black, hcLight: Color.white }, nls.localize('editorGutterCommentGlyphForeground', 'Editor gutter decoration color for commenting glyphs.'));
@@ -19,6 +20,7 @@ export class CommentGlyphWidget {
 	public static description = 'comment-glyph-widget';
 	private _lineNumber!: number;
 	private _editor: ICodeEditor;
+	private _threadState: CommentThreadState | undefined;
 	private readonly _commentsDecorations: IEditorDecorationsCollection;
 	private _commentsOptions: ModelDecorationOptions;
 
@@ -38,10 +40,18 @@ export class CommentGlyphWidget {
 				position: OverviewRulerLane.Center
 			},
 			collapseOnReplaceEdit: true,
-			linesDecorationsClassName: `comment-range-glyph comment-thread`
+			linesDecorationsClassName: `comment-range-glyph comment-thread${this._threadState === CommentThreadState.Unresolved ? '-unresolved' : ''}`
 		};
 
 		return ModelDecorationOptions.createDynamic(decorationOptions);
+	}
+
+	setThreadState(state: CommentThreadState | undefined): void {
+		if (this._threadState !== state) {
+			this._threadState = state;
+			this._commentsOptions = this.createDecorationOptions();
+			this.setLineNumber(this._lineNumber);
+		}
 	}
 
 	setLineNumber(lineNumber: number): void {

--- a/src/vs/workbench/contrib/comments/browser/commentThreadZoneWidget.ts
+++ b/src/vs/workbench/contrib/comments/browser/commentThreadZoneWidget.ts
@@ -300,6 +300,7 @@ export class ReviewZoneWidget extends ZoneWidget implements ICommentThreadWidget
 		const lineNumber = this._commentThread.range.endLineNumber;
 		let shouldMoveWidget = false;
 		if (this._commentGlyph) {
+			this._commentGlyph.setThreadState(commentThread.state);
 			if (this._commentGlyph.getPosition().position!.lineNumber !== lineNumber) {
 				shouldMoveWidget = true;
 				this._commentGlyph.setLineNumber(lineNumber);
@@ -327,6 +328,7 @@ export class ReviewZoneWidget extends ZoneWidget implements ICommentThreadWidget
 
 	display(lineNumber: number) {
 		this._commentGlyph = new CommentGlyphWidget(this.editor, lineNumber);
+		this._commentGlyph.setThreadState(this._commentThread.state);
 
 		this._commentThreadWidget.display(this.editor.getOption(EditorOption.lineHeight));
 		this._disposables.add(this._commentThreadWidget.onDidResize(dimension => {

--- a/src/vs/workbench/contrib/comments/browser/media/review.css
+++ b/src/vs/workbench/contrib/comments/browser/media/review.css
@@ -467,7 +467,8 @@ div.preview.inline .monaco-editor .comment-range-glyph {
 	background: var(--vscode-editorGutter-commentRangeForeground);
 }
 
-.monaco-editor .comment-thread:before {
+.monaco-editor .comment-thread:before,
+.monaco-editor .comment-thread-unresolved:before {
 	background: var(--vscode-editorGutter-commentRangeForeground);
 }
 
@@ -489,28 +490,14 @@ div.preview.inline .monaco-editor .comment-range-glyph {
 }
 
 .monaco-editor .margin-view-overlays .comment-range-glyph.line-hover,
-.monaco-editor .margin-view-overlays .comment-range-glyph.comment-thread {
-	margin-left: 13px;
-}
+.monaco-editor .margin-view-overlays .comment-range-glyph.comment-thread,
 .monaco-editor .margin-view-overlays .comment-range-glyph.comment-thread-unresolved {
 	margin-left: 13px;
 }
 
 .monaco-editor .margin-view-overlays > div:hover > .comment-range-glyph.comment-diff-added:before,
 .monaco-editor .margin-view-overlays .comment-range-glyph.line-hover:before,
-.monaco-editor .comment-range-glyph.comment-thread:before {
-	position: absolute;
-	height: 100%;
-	width: 9px;
-	left: -6px;
-	z-index: 10;
-	color: var(--vscode-editorGutter-commentGlyphForground);
-	text-align: center;
-	display: flex;
-	flex-direction: row;
-	align-items: center;
-	justify-content: center;
-}
+.monaco-editor .comment-range-glyph.comment-thread:before,
 .monaco-editor .comment-range-glyph.comment-thread-unresolved:before {
 	position: absolute;
 	height: 100%;
@@ -542,15 +529,13 @@ div.preview.inline .monaco-editor .comment-range-glyph {
 	padding-left: 1px;
 }
 
-.monaco-editor .comment-range-glyph.comment-thread {
-	z-index: 20;
-}
+.monaco-editor .comment-range-glyph.comment-thread,
 .monaco-editor .comment-range-glyph.comment-thread-unresolved {
 	z-index: 20;
 }
 
-.monaco-editor .comment-range-glyph.comment-thread:before {
-	content: "\ea6b";
+.monaco-editor .comment-range-glyph.comment-thread:before,
+.monaco-editor .comment-range-glyph.comment-thread-unresolved:before {
 	font-family: "codicon";
 	font-size: 13px;
 	width: 18px !important;
@@ -561,17 +546,13 @@ div.preview.inline .monaco-editor .comment-range-glyph {
 	padding-top: 1px;
 	padding-left: 1px;
 }
+
+.monaco-editor .comment-range-glyph.comment-thread:before {
+	content: "\ea6b";
+
+}
 .monaco-editor .comment-range-glyph.comment-thread-unresolved:before {
 	content: "\ec0a";
-	font-family: "codicon";
-	font-size: 13px;
-	width: 18px !important;
-	line-height: 100%;
-	border-radius: 3px;
-	z-index: 20;
-	margin-left: -5px;
-	padding-top: 1px;
-	padding-left: 1px;
 }
 
 .monaco-editor.inline-comment .margin-view-overlays .codicon-folding-expanded,

--- a/src/vs/workbench/contrib/comments/browser/media/review.css
+++ b/src/vs/workbench/contrib/comments/browser/media/review.css
@@ -492,10 +492,26 @@ div.preview.inline .monaco-editor .comment-range-glyph {
 .monaco-editor .margin-view-overlays .comment-range-glyph.comment-thread {
 	margin-left: 13px;
 }
+.monaco-editor .margin-view-overlays .comment-range-glyph.comment-thread-unresolved {
+	margin-left: 13px;
+}
 
 .monaco-editor .margin-view-overlays > div:hover > .comment-range-glyph.comment-diff-added:before,
 .monaco-editor .margin-view-overlays .comment-range-glyph.line-hover:before,
 .monaco-editor .comment-range-glyph.comment-thread:before {
+	position: absolute;
+	height: 100%;
+	width: 9px;
+	left: -6px;
+	z-index: 10;
+	color: var(--vscode-editorGutter-commentGlyphForground);
+	text-align: center;
+	display: flex;
+	flex-direction: row;
+	align-items: center;
+	justify-content: center;
+}
+.monaco-editor .comment-range-glyph.comment-thread-unresolved:before {
 	position: absolute;
 	height: 100%;
 	width: 9px;
@@ -529,9 +545,24 @@ div.preview.inline .monaco-editor .comment-range-glyph {
 .monaco-editor .comment-range-glyph.comment-thread {
 	z-index: 20;
 }
+.monaco-editor .comment-range-glyph.comment-thread-unresolved {
+	z-index: 20;
+}
 
 .monaco-editor .comment-range-glyph.comment-thread:before {
 	content: "\ea6b";
+	font-family: "codicon";
+	font-size: 13px;
+	width: 18px !important;
+	line-height: 100%;
+	border-radius: 3px;
+	z-index: 20;
+	margin-left: -5px;
+	padding-top: 1px;
+	padding-left: 1px;
+}
+.monaco-editor .comment-range-glyph.comment-thread-unresolved:before {
+	content: "\ec0a";
 	font-family: "codicon";
 	font-size: 13px;
 	width: 18px !important;


### PR DESCRIPTION
This PR resolves #149162 by showing the `comment-unresolved` codicon in the glyph gutter if a comment on the line has a status of unresolved.