### PR TITLE
Add border to sticky scroll widget when using the high contrast light or the high contrast dark theme

### DIFF
--- a/src/vs/editor/contrib/stickyScroll/browser/stickyScroll.css
+++ b/src/vs/editor/contrib/stickyScroll/browser/stickyScroll.css
@@ -22,6 +22,14 @@
 	width : 100%;
 }
 
+.monaco-editor .sticky-line-root-high-contrast-dark {
+	border-bottom: 1px solid white;
+}
+
+.monaco-editor .sticky-line-root-high-contrast-light {
+	border-bottom: 1px solid black;
+}
+
 .monaco-editor .sticky-line-root:hover {
 	background-color: var(--vscode-editorStickyScrollHover-background);
 	cursor : pointer;

--- a/src/vs/editor/contrib/stickyScroll/browser/stickyScroll.css
+++ b/src/vs/editor/contrib/stickyScroll/browser/stickyScroll.css
@@ -22,12 +22,8 @@
 	width : 100%;
 }
 
-.monaco-editor .sticky-line-root-high-contrast-dark {
-	border-bottom: 1px solid white;
-}
-
-.monaco-editor .sticky-line-root-high-contrast-light {
-	border-bottom: 1px solid black;
+.monaco-editor .sticky-widget.high-contrast{
+	border-bottom: 1px solid var(--vscode-contrastBorder);
 }
 
 .monaco-editor .sticky-line-root:hover {

--- a/src/vs/editor/contrib/stickyScroll/browser/stickyScroll.css
+++ b/src/vs/editor/contrib/stickyScroll/browser/stickyScroll.css
@@ -4,40 +4,41 @@
  *--------------------------------------------------------------------------------------------*/
 
 .monaco-editor .sticky-line {
-	color : var(--vscode-editorLineNumber-foreground);
-	overflow : hidden;
-	white-space : nowrap;
-	display : inline-block;
+	color: var(--vscode-editorLineNumber-foreground);
+	overflow: hidden;
+	white-space: nowrap;
+	display: inline-block;
 }
 
 .monaco-editor .sticky-line-number {
-	text-align : right;
-	float : left;
+	text-align: right;
+	float: left;
 }
 
 .monaco-editor .sticky-line-root {
-	background-color : inherit;
-	overflow : hidden;
-	white-space : nowrap;
-	width : 100%;
+	background-color: inherit;
+	overflow: hidden;
+	white-space: nowrap;
+	width: 100%;
 }
 
-.monaco-editor .sticky-widget.high-contrast{
+.monaco-editor.hc-black .sticky-widget,
+.monaco-editor.hc-white .sticky-widget {
 	border-bottom: 1px solid var(--vscode-contrastBorder);
 }
 
 .monaco-editor .sticky-line-root:hover {
 	background-color: var(--vscode-editorStickyScrollHover-background);
-	cursor : pointer;
+	cursor: pointer;
 }
 
 .monaco-editor .sticky-widget {
-	width : 100%;
-	box-shadow : var(--vscode-scrollbar-shadow) 0 3px 2px -2px;
-	z-index : 11;
-	background-color : var(--vscode-editorStickyScroll-background);
+	width: 100%;
+	box-shadow: var(--vscode-scrollbar-shadow) 0 3px 2px -2px;
+	z-index: 11;
+	background-color: var(--vscode-editorStickyScroll-background);
 }
 
 .monaco-editor .sticky-widget.peek {
-	background-color : var(--vscode-peekViewEditorStickyScroll-background);
+	background-color: var(--vscode-peekViewEditorStickyScroll-background);
 }

--- a/src/vs/editor/contrib/stickyScroll/browser/stickyScrollController.ts
+++ b/src/vs/editor/contrib/stickyScroll/browser/stickyScrollController.ts
@@ -15,7 +15,6 @@ import { IInstantiationService } from 'vs/platform/instantiation/common/instanti
 import * as dom from 'vs/base/browser/dom';
 import { IContextMenuService } from 'vs/platform/contextview/browser/contextView';
 import { MenuId } from 'vs/platform/actions/common/actions';
-import { IThemeService } from 'vs/platform/theme/common/themeService';
 
 export class StickyScrollController extends Disposable implements IEditorContribution {
 
@@ -33,10 +32,10 @@ export class StickyScrollController extends Disposable implements IEditorContrib
 		@IContextMenuService private readonly _contextMenuService: IContextMenuService,
 		@ILanguageFeaturesService languageFeaturesService: ILanguageFeaturesService,
 		@IInstantiationService instaService: IInstantiationService,
-		@IThemeService themeService: IThemeService
 	) {
 		super();
-		this._stickyScrollWidget = new StickyScrollWidget(this._editor, languageFeaturesService, instaService, themeService);
+
+		this._stickyScrollWidget = new StickyScrollWidget(this._editor, languageFeaturesService, instaService);
 		this._stickyLineCandidateProvider = new StickyLineCandidateProvider(this._editor, languageFeaturesService);
 		this._widgetState = new StickyScrollWidgetState([], 0);
 

--- a/src/vs/editor/contrib/stickyScroll/browser/stickyScrollController.ts
+++ b/src/vs/editor/contrib/stickyScroll/browser/stickyScrollController.ts
@@ -15,6 +15,7 @@ import { IInstantiationService } from 'vs/platform/instantiation/common/instanti
 import * as dom from 'vs/base/browser/dom';
 import { IContextMenuService } from 'vs/platform/contextview/browser/contextView';
 import { MenuId } from 'vs/platform/actions/common/actions';
+// import { IThemeService } from 'vs/platform/theme/common/themeService';
 
 export class StickyScrollController extends Disposable implements IEditorContribution {
 
@@ -32,10 +33,11 @@ export class StickyScrollController extends Disposable implements IEditorContrib
 		@IContextMenuService private readonly _contextMenuService: IContextMenuService,
 		@ILanguageFeaturesService languageFeaturesService: ILanguageFeaturesService,
 		@IInstantiationService instaService: IInstantiationService,
+		// @IThemeService themeService: IThemeService
 	) {
 		super();
 
-		this._stickyScrollWidget = new StickyScrollWidget(this._editor, languageFeaturesService, instaService);
+		this._stickyScrollWidget = new StickyScrollWidget(this._editor, languageFeaturesService, instaService); // themeService);
 		this._stickyLineCandidateProvider = new StickyLineCandidateProvider(this._editor, languageFeaturesService);
 		this._widgetState = new StickyScrollWidgetState([], 0);
 

--- a/src/vs/editor/contrib/stickyScroll/browser/stickyScrollController.ts
+++ b/src/vs/editor/contrib/stickyScroll/browser/stickyScrollController.ts
@@ -15,7 +15,7 @@ import { IInstantiationService } from 'vs/platform/instantiation/common/instanti
 import * as dom from 'vs/base/browser/dom';
 import { IContextMenuService } from 'vs/platform/contextview/browser/contextView';
 import { MenuId } from 'vs/platform/actions/common/actions';
-// import { IThemeService } from 'vs/platform/theme/common/themeService';
+import { IThemeService } from 'vs/platform/theme/common/themeService';
 
 export class StickyScrollController extends Disposable implements IEditorContribution {
 
@@ -33,11 +33,10 @@ export class StickyScrollController extends Disposable implements IEditorContrib
 		@IContextMenuService private readonly _contextMenuService: IContextMenuService,
 		@ILanguageFeaturesService languageFeaturesService: ILanguageFeaturesService,
 		@IInstantiationService instaService: IInstantiationService,
-		// @IThemeService themeService: IThemeService
+		@IThemeService themeService: IThemeService
 	) {
 		super();
-
-		this._stickyScrollWidget = new StickyScrollWidget(this._editor, languageFeaturesService, instaService); // themeService);
+		this._stickyScrollWidget = new StickyScrollWidget(this._editor, languageFeaturesService, instaService, themeService);
 		this._stickyLineCandidateProvider = new StickyLineCandidateProvider(this._editor, languageFeaturesService);
 		this._widgetState = new StickyScrollWidgetState([], 0);
 

--- a/src/vs/editor/contrib/stickyScroll/browser/stickyScrollWidget.ts
+++ b/src/vs/editor/contrib/stickyScroll/browser/stickyScrollWidget.ts
@@ -56,6 +56,7 @@ export class StickyScrollWidget extends Disposable implements IOverlayWidget {
 	private _stickyRangeProjectedOnEditor: IRange | undefined;
 	private _candidateDefinitionsLength: number = -1;
 	private _colorSchemeType: ColorScheme | undefined;
+	private _widgetHeight: number = 0;
 
 	constructor(
 		private readonly _editor: ICodeEditor,
@@ -75,7 +76,9 @@ export class StickyScrollWidget extends Disposable implements IOverlayWidget {
 		this._themeService.onDidColorThemeChange((colorTheme) => {
 			this._colorSchemeType = colorTheme.type;
 			// classList.toggle() is not used because if we move from HIGH_CONTRAST_DARK to HIGH_CONTRAST_LIGHT we want to keep the class name 'high-contrast'
-			if (this._colorSchemeType === ColorScheme.HIGH_CONTRAST_DARK || this._colorSchemeType === ColorScheme.HIGH_CONTRAST_LIGHT) {
+			if ((this._colorSchemeType === ColorScheme.HIGH_CONTRAST_DARK
+				|| this._colorSchemeType === ColorScheme.HIGH_CONTRAST_LIGHT)
+				&& this._widgetHeight > 0) {
 				this._rootDomNode.classList.add('high-contrast');
 			} else {
 				this._rootDomNode.classList.remove('high-contrast');
@@ -303,11 +306,11 @@ export class StickyScrollWidget extends Disposable implements IOverlayWidget {
 			this._rootDomNode.appendChild(this._renderChildNode(index, line));
 		}
 		const editorLineHeight = this._editor.getOption(EditorOption.lineHeight);
-		const widgetHeight: number = this._lineNumbers.length * editorLineHeight + this._lastLineRelativePosition;
-		this._rootDomNode.style.height = widgetHeight.toString() + 'px';
+		this._widgetHeight = this._lineNumbers.length * editorLineHeight + this._lastLineRelativePosition;
+		this._rootDomNode.style.height = this._widgetHeight.toString() + 'px';
 		if (this._colorSchemeType === ColorScheme.HIGH_CONTRAST_DARK || this._colorSchemeType === ColorScheme.HIGH_CONTRAST_LIGHT) {
 			// When the widget height is zero remove the bottom border, else there will be a double border below the breadcrumbs bar
-			if (widgetHeight === 0) {
+			if (this._widgetHeight === 0) {
 				this._rootDomNode.classList.remove('high-contrast');
 			}
 			// Otherwise if the widget height is bigger than 0 and previously the class name 'high-contrast' was removed, set it again

--- a/src/vs/editor/contrib/stickyScroll/browser/stickyScrollWidget.ts
+++ b/src/vs/editor/contrib/stickyScroll/browser/stickyScrollWidget.ts
@@ -20,6 +20,7 @@ import { IRange, Range } from 'vs/editor/common/core/range';
 import { StandardMouseEvent } from 'vs/base/browser/mouseEvent';
 import 'vs/css!./stickyScroll';
 import { EmbeddedCodeEditorWidget } from 'vs/editor/browser/widget/embeddedCodeEditorWidget';
+// import { IThemeService } from 'vs/platform/theme/common/themeService';
 
 interface CustomMouseEvent {
 	detail: string;
@@ -51,7 +52,8 @@ export class StickyScrollWidget extends Disposable implements IOverlayWidget {
 	constructor(
 		private readonly _editor: ICodeEditor,
 		@ILanguageFeaturesService private readonly _languageFeatureService: ILanguageFeaturesService,
-		@IInstantiationService private readonly _instaService: IInstantiationService
+		@IInstantiationService private readonly _instaService: IInstantiationService,
+		// @IThemeService private readonly _themeService: IThemeService
 	) {
 		super();
 		this._layoutInfo = this._editor.getLayoutInfo();
@@ -249,6 +251,7 @@ export class StickyScrollWidget extends Disposable implements IOverlayWidget {
 		child.appendChild(lineHTMLNode);
 
 		child.className = 'sticky-line-root';
+		// console.log('this._themeService.getColorTheme() : ', this._themeService.getColorTheme());
 		child.style.lineHeight = `${lineHeight}px`;
 		child.style.width = `${width}px`;
 		child.style.height = `${lineHeight}px`;

--- a/src/vs/editor/contrib/stickyScroll/browser/stickyScrollWidget.ts
+++ b/src/vs/editor/contrib/stickyScroll/browser/stickyScrollWidget.ts
@@ -20,14 +20,6 @@ import { IRange, Range } from 'vs/editor/common/core/range';
 import { StandardMouseEvent } from 'vs/base/browser/mouseEvent';
 import 'vs/css!./stickyScroll';
 import { EmbeddedCodeEditorWidget } from 'vs/editor/browser/widget/embeddedCodeEditorWidget';
-import { IThemeService } from 'vs/platform/theme/common/themeService';
-
-export enum ColorScheme {
-	DARK = 'dark',
-	LIGHT = 'light',
-	HIGH_CONTRAST_LIGHT = 'hcLight',
-	HIGH_CONTRAST_DARK = 'hcDark'
-}
 
 interface CustomMouseEvent {
 	detail: string;
@@ -55,14 +47,11 @@ export class StickyScrollWidget extends Disposable implements IOverlayWidget {
 	private _hoverOnColumn: number = -1;
 	private _stickyRangeProjectedOnEditor: IRange | undefined;
 	private _candidateDefinitionsLength: number = -1;
-	private _colorSchemeType: ColorScheme | undefined;
-	private _widgetHeight: number = 0;
 
 	constructor(
 		private readonly _editor: ICodeEditor,
 		@ILanguageFeaturesService private readonly _languageFeatureService: ILanguageFeaturesService,
-		@IInstantiationService private readonly _instaService: IInstantiationService,
-		@IThemeService private readonly _themeService: IThemeService
+		@IInstantiationService private readonly _instaService: IInstantiationService
 	) {
 		super();
 		this._layoutInfo = this._editor.getLayoutInfo();
@@ -70,20 +59,7 @@ export class StickyScrollWidget extends Disposable implements IOverlayWidget {
 		this._rootDomNode.className = 'sticky-widget';
 		this._rootDomNode.classList.toggle('peek', _editor instanceof EmbeddedCodeEditorWidget);
 		this._rootDomNode.style.width = `${this._layoutInfo.width - this._layoutInfo.minimap.minimapCanvasOuterWidth - this._layoutInfo.verticalScrollbarWidth}px`;
-		this._colorSchemeType = this._themeService.getColorTheme().type;
 
-		// Listener on the color theme is used in order to keep track of whether a border on the sticky widget is needed
-		this._themeService.onDidColorThemeChange((colorTheme) => {
-			this._colorSchemeType = colorTheme.type;
-			// classList.toggle() is not used because if we move from HIGH_CONTRAST_DARK to HIGH_CONTRAST_LIGHT we want to keep the class name 'high-contrast'
-			if ((this._colorSchemeType === ColorScheme.HIGH_CONTRAST_DARK
-				|| this._colorSchemeType === ColorScheme.HIGH_CONTRAST_LIGHT)
-				&& this._widgetHeight > 0) {
-				this._rootDomNode.classList.add('high-contrast');
-			} else {
-				this._rootDomNode.classList.remove('high-contrast');
-			}
-		});
 		this._register(this._updateLinkGesture());
 	}
 
@@ -306,18 +282,9 @@ export class StickyScrollWidget extends Disposable implements IOverlayWidget {
 			this._rootDomNode.appendChild(this._renderChildNode(index, line));
 		}
 		const editorLineHeight = this._editor.getOption(EditorOption.lineHeight);
-		this._widgetHeight = this._lineNumbers.length * editorLineHeight + this._lastLineRelativePosition;
-		this._rootDomNode.style.height = this._widgetHeight.toString() + 'px';
-		if (this._colorSchemeType === ColorScheme.HIGH_CONTRAST_DARK || this._colorSchemeType === ColorScheme.HIGH_CONTRAST_LIGHT) {
-			// When the widget height is zero remove the bottom border, else there will be a double border below the breadcrumbs bar
-			if (this._widgetHeight === 0) {
-				this._rootDomNode.classList.remove('high-contrast');
-			}
-			// Otherwise if the widget height is bigger than 0 and previously the class name 'high-contrast' was removed, set it again
-			else if (!this._rootDomNode.classList.contains('high-contrast')) {
-				this._rootDomNode.classList.add('high-contrast');
-			}
-		}
+		const widgetHeight: number = this._lineNumbers.length * editorLineHeight + this._lastLineRelativePosition;
+		this._rootDomNode.style.display = widgetHeight > 0 ? 'block' : 'none';
+		this._rootDomNode.style.height = widgetHeight.toString() + 'px';
 		const minimapSide = this._editor.getOption(EditorOption.minimap).side;
 		if (minimapSide === 'left') {
 			this._rootDomNode.style.marginLeft = this._editor.getLayoutInfo().minimap.minimapCanvasOuterWidth + 'px';


### PR DESCRIPTION
Fixes #172570.

Adding border for the sticky scroll when in high contrast light or high contrast dark theme.

https://user-images.githubusercontent.com/61460952/219064278-98774fe5-9423-4a12-8708-4b90f725bf66.mov

