### PR TITLE
context keys: implement a new parser (and a scanner/lexer) for 'when' clauses

### DIFF
--- a/src/vs/base/common/charCode.ts
+++ b/src/vs/base/common/charCode.ts
@@ -225,6 +225,12 @@ export const enum CharCode {
 	 */
 	Tilde = 126,
 
+	/**
+	 * The &nbsp; (no-break space) character.
+	 * Unicode Character 'NO-BREAK SPACE' (U+00A0)
+	 */
+	NoBreakSpace = 160,
+
 	U_Combining_Grave_Accent = 0x0300,								//	U+0300	Combining Grave Accent
 	U_Combining_Acute_Accent = 0x0301,								//	U+0301	Combining Acute Accent
 	U_Combining_Circumflex_Accent = 0x0302,							//	U+0302	Combining Circumflex Accent

--- a/src/vs/platform/contextkey/common/contextkey.ts
+++ b/src/vs/platform/contextkey/common/contextkey.ts
@@ -356,7 +356,7 @@ export class Parser {
 		} catch (e) {
 			if (!(e instanceof ParseError)) {
 				const token = this._peek();
-				this._parsingErrors.push(`Unexpected error: ${e} for token ${this._nameToken(token)} at offset ${token.offset}.`);
+				this._parsingErrors.push(`Unexpected error: ${e} for token ${Scanner.getLexeme(token)} at offset ${token.offset}.`);
 			}
 			return undefined;
 		}
@@ -564,60 +564,17 @@ export class Parser {
 	}
 
 	private _errExpectedButGot(expected: string, got: Token) {
-		return this._error(`Expected ${expected} but got '${this._nameToken(got)}' at offset ${got.offset}.`);
+		return this._error(`Expected ${expected} but got '${Scanner.getLexeme(got)}' at offset ${got.offset}.`);
 	}
 
 	private _errUnexpected(token: Token) {
-		return this._error(`Unexpected '${this._nameToken(token)}' at offset ${token.offset}.`);
+		return this._error(`Unexpected '${Scanner.getLexeme(token)}' at offset ${token.offset}.`);
 	}
 
 	// TODO@ulugbekna: the whole error reporting needs reworking - especially, when we introduce it to package.json linting
 	private _error(errMsg: string) {
 		this._parsingErrors.push(errMsg);
 		return new ParseError();
-	}
-
-	private _nameToken(token: Token): string {
-		if (token.lexeme !== undefined) { return token.lexeme!; }
-
-		switch (token.type) {
-			case TokenType.LParen:
-				return '(';
-			case TokenType.RParen:
-				return ')';
-			case TokenType.Neg:
-				return '!';
-			case TokenType.Eq:
-				return '==';
-			case TokenType.NotEq:
-				return '!=';
-			case TokenType.Lt:
-				return '<';
-			case TokenType.LtEq:
-				return '<=';
-			case TokenType.Gt:
-				return '>=';
-			case TokenType.GtEq:
-				return '>=';
-			case TokenType.RegexOp:
-				return '=~';
-			case TokenType.True:
-				return 'true';
-			case TokenType.False:
-				return 'false';
-			case TokenType.In:
-				return 'in';
-			case TokenType.Not:
-				return 'not';
-			case TokenType.And:
-				return '&&';
-			case TokenType.Or:
-				return '||';
-			case TokenType.EOF:
-				return 'EOF';
-			default:
-				throw illegalState(`all other tokens must have a lexeme : ${JSON.stringify(token)}`);
-		}
 	}
 
 	private _check(type: TokenType) {

--- a/src/vs/platform/contextkey/common/contextkey.ts
+++ b/src/vs/platform/contextkey/common/contextkey.ts
@@ -1451,7 +1451,7 @@ export class ContextKeyRegexExpr implements IContextKeyExpression {
 
 	public serialize(): string {
 		const value = this.regexp
-			? `/${this.regexp.source}/${this.regexp.ignoreCase ? 'i' : ''}`
+			? `/${this.regexp.source}/${this.regexp.flags}`
 			: '/invalid/';
 		return `${this.key} =~ ${value}`;
 	}

--- a/src/vs/platform/contextkey/common/contextkey.ts
+++ b/src/vs/platform/contextkey/common/contextkey.ts
@@ -336,10 +336,7 @@ export class Parser {
 			return undefined;
 		}
 
-		this._scanner.reset(input);
-
-		this._tokens = this._scanner.scan();
-
+		this._tokens = this._scanner.reset(input).scan();
 		if (this._scanner.errorTokens.length > 0) {
 			return undefined;
 		}

--- a/src/vs/platform/contextkey/common/contextkey.ts
+++ b/src/vs/platform/contextkey/common/contextkey.ts
@@ -319,7 +319,7 @@ export class Parser {
 		return this._scanner.errorTokens;
 	}
 
-	get parsingErrors(): string[] {
+	get parsingErrors(): Readonly<string[]> {
 		return this._parsingErrors;
 	}
 

--- a/src/vs/platform/contextkey/common/contextkey.ts
+++ b/src/vs/platform/contextkey/common/contextkey.ts
@@ -338,7 +338,7 @@ export class Parser {
 
 		this._scanner.reset(input);
 
-		this._tokens = [...this._scanner];
+		this._tokens = this._scanner.scan();
 
 		if (this._scanner.errorTokens.length > 0) {
 			return undefined;

--- a/src/vs/platform/contextkey/common/contextkey.ts
+++ b/src/vs/platform/contextkey/common/contextkey.ts
@@ -129,7 +129,7 @@ export abstract class ContextKeyExpr {
 	/**
 	 * Warning: experimental; the API might change.
 	 */
-	public static deserializeOrErrorNew(serialized: string | null | undefined): { type: 'ok'; expr: ContextKeyExpr } | { type: 'error'; readonly lexingErrors: string[]; readonly parsingErrors: readonly string[] } {
+	public static deserializeOrErrorNew(serialized: string | null | undefined): { type: 'ok'; expr: ContextKeyExpression } | { type: 'error'; readonly lexingErrors: string[]; readonly parsingErrors: readonly string[] } {
 		if (!serialized) {
 			return { type: 'error', lexingErrors: [], parsingErrors: [] };
 		}

--- a/src/vs/platform/contextkey/common/contextkey.ts
+++ b/src/vs/platform/contextkey/common/contextkey.ts
@@ -126,7 +126,7 @@ export abstract class ContextKeyExpr {
 		return ContextKeySmallerEqualsExpr.create(key, value);
 	}
 
-	public static deserialize(serialized: string | null | undefined): ContextKeyExpression | undefined {
+	public static deserializeNew(serialized: string | null | undefined): ContextKeyExpression | undefined {
 		if (!serialized) {
 			return undefined;
 		}
@@ -152,7 +152,7 @@ export abstract class ContextKeyExpr {
 		return expr;
 	}
 
-	public static deserializeOld(serialized: string | null | undefined): ContextKeyExpression | undefined {
+	public static deserialize(serialized: string | null | undefined): ContextKeyExpression | undefined {
 		if (!serialized) {
 			return undefined;
 		}
@@ -1488,7 +1488,8 @@ export class ContextKeyRegexExpr implements IContextKeyExpression {
 
 	public serialize(): string {
 		const value = this.regexp
-			? `/${this.regexp.source}/${this.regexp.flags}`
+			// ? `/${this.regexp.source}/${this.regexp.flags}`
+			? `/${this.regexp.source}/`
 			: '/invalid/';
 		return `${this.key} =~ ${value}`;
 	}

--- a/src/vs/platform/contextkey/common/contextkey.ts
+++ b/src/vs/platform/contextkey/common/contextkey.ts
@@ -578,7 +578,7 @@ export class Parser {
 	}
 
 	private _nameToken(token: Token): string {
-		if (token.lexeme) { return token.lexeme!; }
+		if (token.lexeme !== undefined) { return token.lexeme!; }
 
 		switch (token.type) {
 			case TokenType.LParen:

--- a/src/vs/platform/contextkey/common/contextkey.ts
+++ b/src/vs/platform/contextkey/common/contextkey.ts
@@ -311,7 +311,7 @@ class ParseError extends Error { }
 export class Parser {
 
 	private _tokens: Token[] = [];
-	private _current = 0;
+	private _current = 0; 					// invariant: 0 <= this._current < this._tokens.length ; any incrementation of this value must first call `_isAtEnd`
 	private _parsingErrors: string[] = [];
 	private _scanner = new Scanner();
 
@@ -575,9 +575,12 @@ export class Parser {
 	}
 
 	private _check(type: TokenType) {
-		return !this._isAtEnd() && this._peek().type === type;
+		return this._peek().type === type;
 	}
 
+	/*
+		Careful: the function doesn't check array bounds.
+	*/
 	private _peek() {
 		return this._tokens[this._current];
 	}

--- a/src/vs/platform/contextkey/common/contextkey.ts
+++ b/src/vs/platform/contextkey/common/contextkey.ts
@@ -319,7 +319,6 @@ export class Parser {
 		return this._scanner.errorTokens;
 	}
 
-	// TODO: this could use a prettier return
 	get parsingErrors(): string[] {
 		return this._parsingErrors;
 	}

--- a/src/vs/platform/contextkey/common/contextkey.ts
+++ b/src/vs/platform/contextkey/common/contextkey.ts
@@ -332,6 +332,7 @@ export class Parser {
 	parse(input: string): ContextKeyExpression | undefined {
 
 		if (input === '') {
+			this._parsingErrors.push('Expected an expression but got an empty string');
 			return undefined;
 		}
 

--- a/src/vs/platform/contextkey/common/contextkey.ts
+++ b/src/vs/platform/contextkey/common/contextkey.ts
@@ -362,11 +362,11 @@ export class Parser {
 		}
 	}
 
-	private _expr(): ContextKeyExpression {
+	private _expr(): ContextKeyExpression | undefined {
 		return this._or();
 	}
 
-	private _or(): ContextKeyExpression {
+	private _or(): ContextKeyExpression | undefined {
 		const expr = [this._and()];
 
 		while (this._match(TokenType.Or)) {
@@ -374,10 +374,10 @@ export class Parser {
 			expr.push(right);
 		}
 
-		return expr.length === 1 ? expr[0] : ContextKeyExpr.or(...expr)!; // FIXME: bang
+		return expr.length === 1 ? expr[0] : ContextKeyExpr.or(...expr);
 	}
 
-	private _and(): ContextKeyExpression {
+	private _and(): ContextKeyExpression | undefined {
 		const expr = [this._term()];
 
 		while (this._match(TokenType.And)) {
@@ -385,10 +385,10 @@ export class Parser {
 			expr.push(right);
 		}
 
-		return expr.length === 1 ? expr[0] : ContextKeyExpr.and(...expr)!; // FIXME: bang
+		return expr.length === 1 ? expr[0] : ContextKeyExpr.and(...expr);
 	}
 
-	private _term(): ContextKeyExpression {
+	private _term(): ContextKeyExpression | undefined {
 		if (this._match(TokenType.Neg)) {
 			if (this._match(TokenType.Str, TokenType.True, TokenType.False)) {
 				const expr = this._previous();
@@ -408,7 +408,7 @@ export class Parser {
 		return this._primary();
 	}
 
-	private _primary(): ContextKeyExpression {
+	private _primary(): ContextKeyExpression | undefined {
 
 		if (this._match(TokenType.True)) {
 			return ContextKeyExpr.true();

--- a/src/vs/platform/contextkey/common/scanner.ts
+++ b/src/vs/platform/contextkey/common/scanner.ts
@@ -6,40 +6,28 @@
 import { CharCode } from 'vs/base/common/charCode';
 import { illegalArgument, illegalState } from 'vs/base/common/errors';
 
-export enum TokenType {
-	LParen = '(',
-	RParen = ')',
-
-	Neg = '!',
-
-	Eq = '==',
-	NotEq = '!=',
-
-	Lt = '<',
-	LtEq = '<=',
-	Gt = '>',
-	GtEq = '>=',
-
-	RegexOp = '=~',
-
-	RegexStr = 'RegexStr',
-
-	True = 'true',
-	False = 'false',
-
-	In = 'in',
-	Not = 'not',
-
-	And = '&&',
-	Or = '||',
-
-	Str = 'Str',
-
-	QuotedStr = 'QuotedStr',
-
-	Error = 'ErrorToken',
-
-	EOF = 'EOF'
+export const enum TokenType {
+	LParen,
+	RParen,
+	Neg,
+	Eq,
+	NotEq,
+	Lt,
+	LtEq,
+	Gt,
+	GtEq,
+	RegexOp,
+	RegexStr,
+	True,
+	False,
+	In,
+	Not,
+	And,
+	Or,
+	Str,
+	QuotedStr,
+	Error,
+	EOF,
 }
 
 export type Token = {

--- a/src/vs/platform/contextkey/common/scanner.ts
+++ b/src/vs/platform/contextkey/common/scanner.ts
@@ -1,0 +1,387 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { CharCode } from 'vs/base/common/charCode';
+import { illegalArgument } from 'vs/base/common/errors';
+
+export enum TokenType {
+	LParen = '(',
+	RParen = ')',
+
+	Neg = '!',
+
+	Eq = '==',
+	NotEq = '!=',
+
+	Lt = '<',
+	LtEq = '<=',
+	Gt = '>',
+	GtEq = '>=',
+
+	RegexOp = '=~',
+
+	RegexStr = 'RegexStr',
+
+	True = 'true',
+	False = 'false',
+
+	In = 'in',
+	Not = 'not',
+
+	And = '&&',
+	Or = '||',
+
+	Str = 'Str',
+
+	QuotedStr = 'QuotedStr',
+
+	Error = 'ErrorToken',
+
+	EOF = 'EOF'
+}
+
+export type Token = {
+	type: TokenType;
+	offset: number;
+	lexeme?: string;
+};
+
+/**
+ * A simple scanner for context keys.
+ *
+ * Example:
+ *
+ * ```ts
+ * const scanner = new Scanner().reset('resourceFileName =~ /docker/ && !config.docker.enabled');
+ * const tokens = [...scanner];
+ * if (scanner.errorTokens.length > 0) {
+ *     scanner.errorTokens.forEach(token => console.error(Scanner.reportError(token)));
+ * } else {
+ *     // process tokens
+ * }
+ * ```
+ */
+export class Scanner {
+
+	/**
+	 * Provides an error message for the given error token.
+	 *
+	 * @throws Error if the token is not an error token
+	 */
+	static reportError(token: Token): string {
+		if (token.type !== TokenType.Error) { throw illegalArgument(`expected an error token but got ${JSON.stringify(token)}`); }
+
+		switch (token.lexeme) {
+			case '=': return `Unexpected token '${token.lexeme}' at offset ${token.offset}. Did you mean '==' or '=~'?`;
+			case '&': return `Unexpected token '${token.lexeme}' at offset ${token.offset}. Did you mean '&&'?`;
+			case '|': return `Unexpected token '${token.lexeme}' at offset ${token.offset}. Did you mean '||'?`;
+			default: {
+				const lexeme = token.lexeme;
+
+				if (lexeme && lexeme.length > 1 && lexeme.startsWith(`'`)) {
+					return `Unexpected token '${token.lexeme}' at offset ${token.offset}. Did you forget to close the string?`;
+				}
+
+				if (lexeme && lexeme.length > 1 && lexeme.endsWith(`'`)) {
+					return `Unexpected token '${token.lexeme}' at offset ${token.offset}. Did you forget to open the string?`;
+				}
+
+				return `Unexpected token '${token.lexeme}' at offset ${token.offset}`;
+			}
+		}
+	}
+
+	private static _whitespace = /^\s*/;
+
+	private static _regexFlags = new Set(['i', 'g', 's', 'm', 'y', 'u'].map(ch => ch.charCodeAt(0)));
+
+	private static _keywords = new Map<string, TokenType>([
+		['not', TokenType.Not],
+		['in', TokenType.In],
+		['false', TokenType.False],
+		['true', TokenType.True],
+	]);
+
+	private _input: string = '';
+	private _start: number = 0;
+	private _current: number = 0;
+	private _errorTokens: Token[] = [];
+
+	get errorTokens(): Readonly<Token[]> {
+		return this._errorTokens;
+	}
+
+	reset(value: string) {
+		this._input = value;
+
+		this._start = 0;
+		this._current = 0;
+		this._errorTokens = [];
+
+		return this;
+	}
+
+	next(): Token {
+		this._eatWhitespace();
+
+		if (this._isAtEnd()) {
+			return { type: TokenType.EOF, offset: this._current };
+		}
+
+		this._start = this._current;
+
+		const ch = this._advance();
+		switch (ch) {
+			case '(': return this._token(TokenType.LParen);
+			case ')': return this._token(TokenType.RParen);
+
+			case '!': {
+				if (this._match('=')) { // support `!=`
+					return this._token(TokenType.NotEq);
+				}
+				return this._token(TokenType.Neg);
+			}
+
+			case '\'': return this._quotedString();
+			case '/': return this._regex();
+
+			case '=':
+				if (this._match('=')) { // support `==`
+					return this._token(TokenType.Eq);
+				} else if (this._match('~')) {
+					return this._token(TokenType.RegexOp);
+				} else {
+					return this._error();
+				}
+
+			case '<': return this._token(this._match('=') ? TokenType.LtEq : TokenType.Lt);
+
+			case '>': return this._token(this._match('=') ? TokenType.GtEq : TokenType.Gt);
+
+			case '&':
+				if (this._match('&')) {
+					return this._token(TokenType.And);
+				} else {
+					return this._error();
+				}
+
+			case '|':
+				if (this._match('|')) {
+					return this._token(TokenType.Or);
+				} else {
+					return this._error();
+				}
+
+			// handle whitespace
+			case ' ':
+			case '\r':
+			case '\t':
+			case '\n': // TODO@ulugbekna: if we're allowing newlines, we should keep track of line # as well ?
+				return this.next();
+
+			case '\u00A0': // &nbsp
+				return this.next();
+
+			default:
+				return this._string();
+		}
+	}
+
+	private _match(expected: string): boolean {
+		if (this._isAtEnd()) {
+			return false;
+		}
+		if (this._input[this._current] !== expected) {
+			return false;
+		}
+		this._current++;
+		return true;
+	}
+
+	private _advance(): string {
+		return this._input[this._current++];
+	}
+
+	private _peek(): string {
+		return this._isAtEnd() ? '\0' : this._input[this._current];
+	}
+
+	private _peekNext(): string {
+		if (this._current + 1 >= this._input.length) {
+			return '\0';
+		} else {
+			return this._input[this._current + 1];
+		}
+	}
+
+	private _token(type: TokenType, captureLexeme: boolean = false): Token {
+		if (captureLexeme) {
+			const lexeme = this._input.substring(this._start, this._current);
+			return { type, lexeme, offset: this._start };
+		} else {
+			return { type, offset: this._start };
+		}
+	}
+
+	private _error(): Token {
+		const errToken = { type: TokenType.Error, offset: this._start, lexeme: this._input.substring(this._start, this._current) };
+		this._errorTokens.push(errToken);
+		if (!this._isAtEnd()) {
+			++this._current;
+		}
+		return errToken;
+	}
+
+	private _string() {
+		let peek = this._peek();
+
+		while (this._isStringChar(peek) && !this._isAtEnd()) {
+			this._advance();
+			peek = this._peek();
+		}
+
+		const lexeme = this._input.substring(this._start, this._current);
+
+		const keyword = Scanner._keywords.get(lexeme);
+
+		if (keyword) {
+			return this._token(keyword);
+		} else {
+			return this._token(TokenType.Str, true);
+		}
+	}
+
+	private _isStringChar(peek: string) {
+		if (this._isAlphaNumeric(peek)) { return true; }
+		if (this._isWhitespace(peek)) { return false; }
+
+		switch (peek) {
+			case ')':
+			case '=':
+			case '!':
+			case '&':
+			case '|':
+			case '~':
+				return false;
+			case '<':
+			case '>':
+				return (this._peekNext() === '=') ? false : true; // so that we support `foo<=1` as `foo <= 1`, but also support `vim.use<C-r>` as a single KEY
+			case '_':
+			case '-':
+			case '.':
+			case '/':
+			case '\\':
+			case ':':
+			case '*':
+			case '?': // do we have to?
+			case '%':
+			case '+':
+			case '[':
+			case ']':
+			case '^':
+			case ',':
+			case '#':
+			case '@':
+			case ';':
+			case '"':
+				return true;
+			default:
+				if (peek.charCodeAt(0) > 127) { // handle unicode, eg Chinese hieroglyphs used in extensions
+					return true;
+				}
+				return false;
+		}
+	}
+
+	private _isAlphaNumeric(ch: string) {
+		return (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || (ch >= '0' && ch <= '9');
+	}
+
+	private _isWhitespace(ch: string) {
+		return ch === ' ' || ch === '\t' || ch === '\n' || ch === '\r' || ch === /* &nbsp */ '\u00A0';
+	}
+
+	// captures the lexeme without the leading and trailing '
+	private _quotedString(): Token {
+		while (this._peek() !== `'` && !this._isAtEnd()) { // TODO@ulugbekna: add support for escaping ' ?
+			this._advance();
+		}
+
+		if (this._isAtEnd()) {
+			return this._error();
+		}
+
+		// consume the closing '
+		this._advance();
+
+		return { type: TokenType.QuotedStr, lexeme: this._input.substring(this._start + 1, this._current - 1), offset: this._start + 1 };
+	}
+
+	/*
+	 * Lexing a regex expression: /.../[igsmyu]*
+	 * Based on https://github.com/microsoft/TypeScript/blob/9247ef115e617805983740ba795d7a8164babf89/src/compiler/scanner.ts#L2129-L2181
+	 *
+	 * Note that we want slashes within a regex to be escaped, e.g., /file:\\/\\/\\// should match `file:///`
+	 */
+	private _regex(): Token {
+		let p = this._current;
+
+		let inEscape = false;
+		let inCharacterClass = false;
+		while (true) {
+			if (p >= this._input.length) {
+				return this._error();
+			}
+
+			const ch = this._input.charCodeAt(p);
+
+			if (inEscape) { // parsing an escape character
+				inEscape = false;
+			} else if (ch === CharCode.Slash && !inCharacterClass) { // end of regex
+				p++;
+				break;
+			} else if (ch === CharCode.OpenSquareBracket) {
+				inCharacterClass = true;
+			} else if (ch === CharCode.Backslash) {
+				inEscape = true;
+			} else if (ch === CharCode.CloseSquareBracket) {
+				inCharacterClass = false;
+			}
+			p++;
+		}
+
+		// Consume flags
+		while (p < this._input.length && Scanner._regexFlags.has(this._input.charCodeAt(p))) {
+			p++;
+		}
+
+		this._current = p;
+
+		return this._token(TokenType.RegexStr, true);
+	}
+
+	// invariant: this must not fail if at end of `this._value`
+	private _eatWhitespace() {
+		Scanner._whitespace.lastIndex = this._current;
+		const match = Scanner._whitespace.exec(this._input);
+		if (match) {
+			this._current += match[0].length;
+		}
+	}
+
+	private _isAtEnd() {
+		return this._current >= this._input.length;
+	}
+
+	*[Symbol.iterator](): Iterator<Token> {
+		while (true) {
+			const token = this.next();
+			yield token;
+			if (token?.type === TokenType.EOF) {
+				break;
+			}
+		}
+	}
+}

--- a/src/vs/platform/contextkey/common/scanner.ts
+++ b/src/vs/platform/contextkey/common/scanner.ts
@@ -332,6 +332,7 @@ export class Scanner {
 		let inCharacterClass = false;
 		while (true) {
 			if (p >= this._input.length) {
+				this._current = p;
 				return this._error();
 			}
 

--- a/src/vs/platform/contextkey/common/scanner.ts
+++ b/src/vs/platform/contextkey/common/scanner.ts
@@ -290,9 +290,6 @@ export class Scanner {
 	private _error() {
 		const errToken = { type: TokenType.Error, offset: this._start, lexeme: this._input.substring(this._start, this._current) };
 		this._errorTokens.push(errToken);
-		if (!this._isAtEnd()) {
-			++this._current;
-		}
 		this._tokens.push(errToken);
 	}
 

--- a/src/vs/platform/contextkey/common/scanner.ts
+++ b/src/vs/platform/contextkey/common/scanner.ts
@@ -93,8 +93,6 @@ export class Scanner {
 		}
 	}
 
-	private static _whitespace = /^\s*/;
-
 	private static _regexFlags = new Set(['i', 'g', 's', 'm', 'y', 'u'].map(ch => ch.charCodeAt(0)));
 
 	private static _keywords = new Map<string, TokenType>([
@@ -127,7 +125,6 @@ export class Scanner {
 
 	scan() {
 		while (!this._isAtEnd()) {
-			this._eatWhitespace();
 
 			this._start = this._current;
 
@@ -368,15 +365,6 @@ export class Scanner {
 		this._current = p;
 
 		this._addToken(TokenType.RegexStr, true);
-	}
-
-	// invariant: this must not fail if at end of `this._value`
-	private _eatWhitespace() {
-		Scanner._whitespace.lastIndex = this._current;
-		const match = Scanner._whitespace.exec(this._input);
-		if (match) {
-			this._current += match[0].length;
-		}
 	}
 
 	private _isAtEnd() {

--- a/src/vs/platform/contextkey/common/scanner.ts
+++ b/src/vs/platform/contextkey/common/scanner.ts
@@ -205,40 +205,40 @@ export class Scanner {
 
 			const ch = this._advance();
 			switch (ch) {
-				case '(': this._addToken(TokenType.LParen); break;
-				case ')': this._addToken(TokenType.RParen); break;
+				case CharCode.OpenParen: this._addToken(TokenType.LParen); break;
+				case CharCode.CloseParen: this._addToken(TokenType.RParen); break;
 
-				case '!':
-					this._addToken(this._match('=') ? TokenType.NotEq : TokenType.Neg);
+				case CharCode.ExclamationMark:
+					this._addToken(this._match(CharCode.Equals) ? TokenType.NotEq : TokenType.Neg);
 					break;
 
-				case '\'': this._quotedString(); break;
-				case '/': this._regex(); break;
+				case CharCode.SingleQuote: this._quotedString(); break;
+				case CharCode.Slash: this._regex(); break;
 
-				case '=':
-					if (this._match('=')) { // support `==`
+				case CharCode.Equals:
+					if (this._match(CharCode.Equals)) { // support `==`
 						this._addToken(TokenType.Eq);
-					} else if (this._match('~')) {
+					} else if (this._match(CharCode.Tilde)) {
 						this._addToken(TokenType.RegexOp);
 					} else {
 						this._error();
 					}
 					break;
 
-				case '<': this._addToken(this._match('=') ? TokenType.LtEq : TokenType.Lt); break;
+				case CharCode.LessThan: this._addToken(this._match(CharCode.Equals) ? TokenType.LtEq : TokenType.Lt); break;
 
-				case '>': this._addToken(this._match('=') ? TokenType.GtEq : TokenType.Gt); break;
+				case CharCode.GreaterThan: this._addToken(this._match(CharCode.Equals) ? TokenType.GtEq : TokenType.Gt); break;
 
-				case '&':
-					if (this._match('&')) {
+				case CharCode.Ampersand:
+					if (this._match(CharCode.Ampersand)) {
 						this._addToken(TokenType.And);
 					} else {
 						this._error();
 					}
 					break;
 
-				case '|':
-					if (this._match('|')) {
+				case CharCode.Pipe:
+					if (this._match(CharCode.Pipe)) {
 						this._addToken(TokenType.Or);
 					} else {
 						this._error();
@@ -246,11 +246,11 @@ export class Scanner {
 					break;
 
 				// TODO@ulugbekna: 1) I don't think we need to handle whitespace here, 2) if we do, we should reconsider what characters we consider whitespace, including unicode, nbsp, etc.
-				case ' ':
-				case '\r':
-				case '\t':
-				case '\n':
-				case '\u00A0': // &nbsp
+				case CharCode.Space:
+				case CharCode.CarriageReturn:
+				case CharCode.Tab:
+				case CharCode.LineFeed:
+				case CharCode.NoBreakSpace: // &nbsp
 					break;
 
 				default:
@@ -264,23 +264,23 @@ export class Scanner {
 		return Array.from(this._tokens);
 	}
 
-	private _match(expected: string): boolean {
+	private _match(expected: number): boolean {
 		if (this._isAtEnd()) {
 			return false;
 		}
-		if (this._input[this._current] !== expected) {
+		if (this._input.charCodeAt(this._current) !== expected) {
 			return false;
 		}
 		this._current++;
 		return true;
 	}
 
-	private _advance(): string {
-		return this._input[this._current++];
+	private _advance(): number {
+		return this._input.charCodeAt(this._current++);
 	}
 
-	private _peek(): string {
-		return this._isAtEnd() ? '\0' : this._input[this._current];
+	private _peek(): number {
+		return this._isAtEnd() ? CharCode.Null : this._input.charCodeAt(this._current);
 	}
 
 	private _addToken(type: TokenTypeWithoutLexeme) {
@@ -312,7 +312,7 @@ export class Scanner {
 
 	// captures the lexeme without the leading and trailing '
 	private _quotedString() {
-		while (this._peek() !== `'` && !this._isAtEnd()) { // TODO@ulugbekna: add support for escaping ' ?
+		while (this._peek() !== CharCode.SingleQuote && !this._isAtEnd()) { // TODO@ulugbekna: add support for escaping ' ?
 			this._advance();
 		}
 

--- a/src/vs/platform/contextkey/common/scanner.ts
+++ b/src/vs/platform/contextkey/common/scanner.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { CharCode } from 'vs/base/common/charCode';
-import { illegalArgument } from 'vs/base/common/errors';
+import { illegalArgument, illegalState } from 'vs/base/common/errors';
 
 export enum TokenType {
 	LParen = '(',
@@ -90,6 +90,49 @@ export class Scanner {
 
 				return `Unexpected token '${token.lexeme}' at offset ${token.offset}`;
 			}
+		}
+	}
+
+	static getLexeme(token: Token): string {
+		if (token.lexeme !== undefined) { return token.lexeme!; }
+
+		switch (token.type) {
+			case TokenType.LParen:
+				return '(';
+			case TokenType.RParen:
+				return ')';
+			case TokenType.Neg:
+				return '!';
+			case TokenType.Eq:
+				return '==';
+			case TokenType.NotEq:
+				return '!=';
+			case TokenType.Lt:
+				return '<';
+			case TokenType.LtEq:
+				return '<=';
+			case TokenType.Gt:
+				return '>=';
+			case TokenType.GtEq:
+				return '>=';
+			case TokenType.RegexOp:
+				return '=~';
+			case TokenType.True:
+				return 'true';
+			case TokenType.False:
+				return 'false';
+			case TokenType.In:
+				return 'in';
+			case TokenType.Not:
+				return 'not';
+			case TokenType.And:
+				return '&&';
+			case TokenType.Or:
+				return '||';
+			case TokenType.EOF:
+				return 'EOF';
+			default:
+				throw illegalState(`all other tokens must have a lexeme : ${JSON.stringify(token)}`);
 		}
 	}
 

--- a/src/vs/platform/contextkey/test/common/contextkey.test.ts
+++ b/src/vs/platform/contextkey/test/common/contextkey.test.ts
@@ -299,31 +299,31 @@ suite('ContextKeyExpr', () => {
 			assert.strictEqual(_expr.evaluate(createContext(ctx)), expected);
 		}
 
-		checkEvaluate('a>1', {}, false);
-		checkEvaluate('a>1', { a: 0 }, false);
-		checkEvaluate('a>1', { a: 1 }, false);
-		checkEvaluate('a>1', { a: 2 }, true);
-		checkEvaluate('a>1', { a: '0' }, false);
-		checkEvaluate('a>1', { a: '1' }, false);
-		checkEvaluate('a>1', { a: '2' }, true);
-		checkEvaluate('a>1', { a: 'a' }, false);
+		checkEvaluate('a > 1', {}, false);
+		checkEvaluate('a > 1', { a: 0 }, false);
+		checkEvaluate('a > 1', { a: 1 }, false);
+		checkEvaluate('a > 1', { a: 2 }, true);
+		checkEvaluate('a > 1', { a: '0' }, false);
+		checkEvaluate('a > 1', { a: '1' }, false);
+		checkEvaluate('a > 1', { a: '2' }, true);
+		checkEvaluate('a > 1', { a: 'a' }, false);
 
-		checkEvaluate('a>10', { a: 2 }, false);
-		checkEvaluate('a>10', { a: 11 }, true);
-		checkEvaluate('a>10', { a: '11' }, true);
-		checkEvaluate('a>10', { a: '2' }, false);
-		checkEvaluate('a>10', { a: '11' }, true);
+		checkEvaluate('a > 10', { a: 2 }, false);
+		checkEvaluate('a > 10', { a: 11 }, true);
+		checkEvaluate('a > 10', { a: '11' }, true);
+		checkEvaluate('a > 10', { a: '2' }, false);
+		checkEvaluate('a > 10', { a: '11' }, true);
 
-		checkEvaluate('a>1.1', { a: 1 }, false);
-		checkEvaluate('a>1.1', { a: 2 }, true);
-		checkEvaluate('a>1.1', { a: 11 }, true);
-		checkEvaluate('a>1.1', { a: '1.1' }, false);
-		checkEvaluate('a>1.1', { a: '2' }, true);
-		checkEvaluate('a>1.1', { a: '11' }, true);
+		checkEvaluate('a > 1.1', { a: 1 }, false);
+		checkEvaluate('a > 1.1', { a: 2 }, true);
+		checkEvaluate('a > 1.1', { a: 11 }, true);
+		checkEvaluate('a > 1.1', { a: '1.1' }, false);
+		checkEvaluate('a > 1.1', { a: '2' }, true);
+		checkEvaluate('a > 1.1', { a: '11' }, true);
 
-		checkEvaluate('a>b', { a: 'b' }, false);
-		checkEvaluate('a>b', { a: 'c' }, false);
-		checkEvaluate('a>b', { a: 1000 }, false);
+		checkEvaluate('a > b', { a: 'b' }, false);
+		checkEvaluate('a > b', { a: 'c' }, false);
+		checkEvaluate('a > b', { a: 1000 }, false);
 
 		checkEvaluate('a >= 2', { a: '1' }, false);
 		checkEvaluate('a >= 2', { a: '2' }, true);
@@ -345,21 +345,21 @@ suite('ContextKeyExpr', () => {
 			assert.strictEqual(b.serialize(), expected);
 		}
 
-		checkNegate('a>1', 'a <= 1');
-		checkNegate('a>1.1', 'a <= 1.1');
-		checkNegate('a>b', 'a <= b');
+		checkNegate('a > 1', 'a <= 1');
+		checkNegate('a > 1.1', 'a <= 1.1');
+		checkNegate('a > b', 'a <= b');
 
-		checkNegate('a>=1', 'a < 1');
-		checkNegate('a>=1.1', 'a < 1.1');
-		checkNegate('a>=b', 'a < b');
+		checkNegate('a >= 1', 'a < 1');
+		checkNegate('a >= 1.1', 'a < 1.1');
+		checkNegate('a >= b', 'a < b');
 
-		checkNegate('a<1', 'a >= 1');
-		checkNegate('a<1.1', 'a >= 1.1');
-		checkNegate('a<b', 'a >= b');
+		checkNegate('a < 1', 'a >= 1');
+		checkNegate('a < 1.1', 'a >= 1.1');
+		checkNegate('a < b', 'a >= b');
 
-		checkNegate('a<=1', 'a > 1');
-		checkNegate('a<=1.1', 'a > 1.1');
-		checkNegate('a<=b', 'a > b');
+		checkNegate('a <= 1', 'a > 1');
+		checkNegate('a <= 1.1', 'a > 1.1');
+		checkNegate('a <= b', 'a > b');
 	});
 
 	test('issue #111899: context keys can use `<` or `>` ', () => {

--- a/src/vs/platform/contextkey/test/common/parser.test.ts
+++ b/src/vs/platform/contextkey/test/common/parser.test.ts
@@ -150,7 +150,36 @@ suite('Context Key Scanner', () => {
 
 	});
 
+	suite('regex', () => {
+
+		test(`resource =~ //foo/(barr|door/(Foo-Bar%20Templates|Soo%20Looo)|Web%20Site%Jjj%20Llll)(/.*)*$/`, () => {
+			const input = `resource =~ //foo/(barr|door/(Foo-Bar%20Templates|Soo%20Looo)|Web%20Site%Jjj%20Llll)(/.*)*$/`;
+			assert.deepStrictEqual(parseToStr(input), "resource =~ /\\/FileCabinet\\/(SuiteScripts|Templates\\/(E-mail%20Templates|Marketing%20Templates)|Web%20Site%20Hosting%20Files)(\\/.*)*$/");
+		});
+
+		test(`resource =~ /((/scratch/(?!update)(.*)/)|((/src/).*/)).*$/`, () => {
+			const input = `resource =~ /((/scratch/(?!update)(.*)/)|((/src/).*/)).*$/`;
+			assert.deepStrictEqual(parseToStr(input), "resource =~ /((\\/scratch\\/(?!update)(.*)\\/)|((\\/src\\/).*\\/)).*$/");
+		});
+
+		test(`FIXME resourcePath =~ //foo/barr// || resourcePath =~ //view/(foo|frontend|base)/(foo|barr)// && resourceExtname in fooBar`, () => {
+			const input = `resourcePath =~ //foo/barr// || resourcePath =~ //view/(foo|frontend|base)/(foo|barr)// && resourceExtname in fooBar`;
+			assert.deepStrictEqual(parseToStr(input), "Lexing errors:\n\nUnexpected token '|' at offset 59. Did you mean '||'?\nUnexpected token '|' at offset 68. Did you mean '||'?\nUnexpected token '/ && resourceExtname in fooBar' at offset 86\n\n --- \nParsing errors:\n\nUnexpected error: SyntaxError: Invalid flags supplied to RegExp constructor ' && resourceExtname in fooBar' for token EOF at offset 116.\n");
+		});
+
+		test(`resourcePath =~ /\.md(\.yml|\.txt)*$/gim`, () => {
+			const input = `resourcePath =~ /\.md(\.yml|\.txt)*$/gim`;
+			assert.deepStrictEqual(parseToStr(input), "resourcePath =~ /.md(.yml|.txt)*$/gim");
+		});
+
+	});
+
 	suite('error handling', () => {
+
+		test(`/foo`, () => {
+			const input = `/foo`;
+			assert.deepStrictEqual(parseToStr(input), "Lexing errors:\n\nUnexpected token '/foo' at offset 0\n\n --- \nParsing errors:\n\nExpected 'true', 'false', '(', KEY, KEY '=~' regex, KEY [ ('==' | '!=' | '<' | '<=' | '>' | '>=' | 'in' | 'not' 'in') value ] but got '/foo' at offset 0.\n");
+		});
 
 		test(`!b == 'true'`, () => {
 			const input = `!b == 'true'`;
@@ -164,17 +193,17 @@ suite('Context Key Scanner', () => {
 
 		test(`view =~ '/(servers)/' && viewItem =~ /^(Starting|Started|Debugging|Stopping|Stopped|Unknown)/'`, () => {
 			const input = `view =~ '/(servers)/' && viewItem =~ /^(Starting|Started|Debugging|Stopping|Stopped|Unknown)/'`;
-			assert.deepStrictEqual(parseToStr(input), "Lexing errors:\n\nUnexpected token ''' at offset 93\n");
+			assert.deepStrictEqual(parseToStr(input), "Lexing errors:\n\nUnexpected token ''' at offset 93\n\n --- \nParsing errors:\n\nUnexpected error: SyntaxError: Invalid flags supplied to RegExp constructor ''' for token EOF at offset 94.\n");
 		});
 
 		test('vim<c-r> == 1 && vim<2<=3', () => {
 			const input = 'vim<c-r> == 1 && vim<2<=3';
-			assert.deepStrictEqual(parseToStr(input), "Lexing errors:\n\nUnexpected token '=' at offset 23. Did you mean '==' or '=~'?\n"); // FIXME
+			assert.deepStrictEqual(parseToStr(input), "Lexing errors:\n\nUnexpected token '=' at offset 23. Did you mean '==' or '=~'?\n\n --- \nParsing errors:\n\nUnexpected '=' at offset 23.\n"); // FIXME
 		});
 
 		test(`foo && 'bar`, () => {
 			const input = `foo && 'bar`;
-			assert.deepStrictEqual(parseToStr(input), "Lexing errors:\n\nUnexpected token ''bar' at offset 7. Did you forget to close the string?\n");
+			assert.deepStrictEqual(parseToStr(input), "Lexing errors:\n\nUnexpected token ''bar' at offset 7. Did you forget to close the string?\n\n --- \nParsing errors:\n\nExpected 'true', 'false', '(', KEY, KEY '=~' regex, KEY [ ('==' | '!=' | '<' | '<=' | '>' | '>=' | 'in' | 'not' 'in') value ] but got ''bar' at offset 7.\n");
 		});
 
 		/*

--- a/src/vs/platform/contextkey/test/common/parser.test.ts
+++ b/src/vs/platform/contextkey/test/common/parser.test.ts
@@ -169,7 +169,7 @@ suite('Context Key Scanner', () => {
 
 		test('vim<c-r> == 1 && vim<2<=3', () => {
 			const input = 'vim<c-r> == 1 && vim<2<=3';
-			assert.deepStrictEqual(parseToStr(input), "vim<c-r> == '1' && vim<2 <= 3"); // FIXME
+			assert.deepStrictEqual(parseToStr(input), "Lexing errors:\n\nUnexpected token '=' at offset 23. Did you mean '==' or '=~'?\n"); // FIXME
 		});
 
 		test(`foo && 'bar`, () => {

--- a/src/vs/platform/contextkey/test/common/parser.test.ts
+++ b/src/vs/platform/contextkey/test/common/parser.test.ts
@@ -154,7 +154,7 @@ suite('Context Key Scanner', () => {
 
 		test(`resource =~ //foo/(barr|door/(Foo-Bar%20Templates|Soo%20Looo)|Web%20Site%Jjj%20Llll)(/.*)*$/`, () => {
 			const input = `resource =~ //foo/(barr|door/(Foo-Bar%20Templates|Soo%20Looo)|Web%20Site%Jjj%20Llll)(/.*)*$/`;
-			assert.deepStrictEqual(parseToStr(input), "resource =~ /\\/FileCabinet\\/(SuiteScripts|Templates\\/(E-mail%20Templates|Marketing%20Templates)|Web%20Site%20Hosting%20Files)(\\/.*)*$/");
+			assert.deepStrictEqual(parseToStr(input), "resource =~ /\\/foo\\/(barr|door\\/(Foo-Bar%20Templates|Soo%20Looo)|Web%20Site%Jjj%20Llll)(\\/.*)*$/");
 		});
 
 		test(`resource =~ /((/scratch/(?!update)(.*)/)|((/src/).*/)).*$/`, () => {

--- a/src/vs/platform/contextkey/test/common/parser.test.ts
+++ b/src/vs/platform/contextkey/test/common/parser.test.ts
@@ -1,0 +1,192 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import * as assert from 'assert';
+import { Parser } from 'vs/platform/contextkey/common/contextkey';
+import { Scanner } from 'vs/platform/contextkey/common/scanner';
+
+function parseToStr(input: string): string {
+	const parser = new Parser();
+
+	const prints: string[] = [];
+
+	const print = (...ss: string[]) => { ss.forEach(s => prints.push(s)); };
+
+	const expr = parser.parse(input);
+	if (expr === undefined) {
+		if (parser.lexingErrors.length > 0) {
+			print('Lexing errors:', '\n\n');
+			parser.lexingErrors.forEach(token => print(Scanner.reportError(token), '\n'));
+		}
+
+		if (parser.parsingErrors.length > 0) {
+			if (parser.lexingErrors.length > 0) { print('\n --- \n'); }
+			print('Parsing errors:', '\n\n');
+			parser.parsingErrors.forEach(message => print(`${message}`, '\n'));
+		}
+
+	} else {
+		print(expr.serialize());
+	}
+
+	return prints.join('');
+}
+
+suite('Context Key Scanner', () => {
+
+	test(' foo', () => {
+		const input = ' foo';
+		assert.deepStrictEqual(parseToStr(input), "foo");
+	});
+
+	test('!foo', () => {
+		const input = '!foo';
+		assert.deepStrictEqual(parseToStr(input), "!foo");
+	});
+
+	test('foo =~ /bar/', () => {
+		const input = 'foo =~ /bar/';
+		assert.deepStrictEqual(parseToStr(input), "foo =~ /bar/");
+	});
+
+	test(`foo || (foo =~ /bar/ && baz)`, () => {
+		const input = `foo || (foo =~ /bar/ && baz)`;
+		assert.deepStrictEqual(parseToStr(input), "foo || baz && foo =~ /bar/");
+	});
+
+	test('foo || (foo =~ /bar/ || baz)', () => {
+		const input = 'foo || (foo =~ /bar/ || baz)';
+		assert.deepStrictEqual(parseToStr(input), "baz || foo || foo =~ /bar/");
+	});
+
+	test(`(foo || bar) && (jee || jar)`, () => {
+		const input = `(foo || bar) && (jee || jar)`;
+		assert.deepStrictEqual(parseToStr(input), "bar && jar || bar && jee || foo && jar || foo && jee");
+	});
+
+	test('foo && foo =~ /zee/i', () => {
+		const input = 'foo && foo =~ /zee/i';
+		assert.deepStrictEqual(parseToStr(input), "foo && foo =~ /zee/i");
+	});
+
+	test('foo.bar==enabled', () => {
+		const input = 'foo.bar==enabled';
+		assert.deepStrictEqual(parseToStr(input), "foo.bar == 'enabled'");
+	});
+
+	test(`foo.bar == 'enabled'`, () => {
+		const input = `foo.bar == 'enabled'`;
+		assert.deepStrictEqual(parseToStr(input), `foo.bar == 'enabled'`);
+	});
+
+	test('foo.bar:zed==completed - equality with no space', () => {
+		const input = 'foo.bar:zed==completed';
+		assert.deepStrictEqual(parseToStr(input), "foo.bar:zed == 'completed'");
+	});
+
+	test('a && b || c', () => {
+		const input = 'a && b || c';
+		assert.deepStrictEqual(parseToStr(input), "c || a && b");
+	});
+
+	test('fooBar && baz.jar && fee.bee<K-loo+1>', () => {
+		const input = 'fooBar && baz.jar && fee.bee<K-loo+1>';
+		assert.deepStrictEqual(parseToStr(input), "baz.jar && fee.bee<K-loo+1> && fooBar");
+	});
+
+	test('foo.barBaz<C-r> < 2', () => {
+		const input = 'foo.barBaz<C-r> < 2';
+		assert.deepStrictEqual(parseToStr(input), `foo.barBaz<C-r> < 2`);
+	});
+
+	test('foo.bar >= -1', () => {
+		const input = 'foo.bar >= -1';
+		assert.deepStrictEqual(parseToStr(input), "foo.bar >= -1");
+	});
+
+	test(`key contains &nbsp: view == vsc-packages-activitybar-folders && vsc-packages-folders-loaded`, () => {
+		const input = `view == vsc-packages-activitybar-folders && vsc-packages-folders-loaded`;
+		assert.deepStrictEqual(parseToStr(input), "vsc-packages-folders-loaded && view == 'vsc-packages-activitybar-folders'");
+	});
+
+	test('foo.bar <= -1', () => {
+		const input = 'foo.bar <= -1';
+		assert.deepStrictEqual(parseToStr(input), `foo.bar <= -1`);
+	});
+
+	test('!cmake:hideBuildCommand \u0026\u0026 cmake:enableFullFeatureSet', () => {
+		const input = '!cmake:hideBuildCommand \u0026\u0026 cmake:enableFullFeatureSet';
+		assert.deepStrictEqual(parseToStr(input), "cmake:enableFullFeatureSet && !cmake:hideBuildCommand");
+	});
+
+	suite('controversial', () => {
+		/*
+			new parser KEEPS old one's behavior:
+
+			old parser output: { key: 'debugState', op: '==', value: '"stopped"' }
+			new parser output: { key: 'debugState', op: '==', value: '"stopped"' }
+
+			TODO@ulugbekna: we should consider breaking old parser's behavior, and not take double quotes as part of the `value` because that's not what user expects.
+		*/
+		test(`debugState == "stopped"`, () => {
+			const input = `debugState == "stopped"`;
+			assert.deepStrictEqual(parseToStr(input), "debugState == '\"stopped\"'");
+		});
+
+		/*
+			new parser BREAKS old one's behavior:
+
+			old parser output: { key: 'viewItem', op: '==', value: 'VSCode WorkSpace' }
+			new parser output: { key: 'viewItem', op: '==', value: 'VSCode' }
+
+			TODO@ulugbekna: since this's breaking, we can have hacky code that tries detecting such cases and replicate old parser's behavior.
+		*/
+		test(` viewItem == VSCode WorkSpace`, () => {
+			const input = ` viewItem == VSCode WorkSpace`;
+			assert.deepStrictEqual(parseToStr(input), "Parsing errors:\n\nUnexpected 'WorkSpace' at offset 20.\n");
+		});
+
+
+	});
+
+	suite('error handling', () => {
+
+		test(`!b == 'true'`, () => {
+			const input = `!b == 'true'`;
+			assert.deepStrictEqual(parseToStr(input), "Parsing errors:\n\nUnexpected '==' at offset 3.\n");
+		});
+
+		test('!foo &&  in bar', () => {
+			const input = '!foo &&  in bar';
+			assert.deepStrictEqual(parseToStr(input), "Parsing errors:\n\nExpected 'true', 'false', '(', KEY, KEY '=~' regex, KEY [ ('==' | '!=' | '<' | '<=' | '>' | '>=' | 'in' | 'not' 'in') value ] but got 'in' at offset 9.\n");
+		});
+
+		test(`view =~ '/(servers)/' && viewItem =~ /^(Starting|Started|Debugging|Stopping|Stopped|Unknown)/'`, () => {
+			const input = `view =~ '/(servers)/' && viewItem =~ /^(Starting|Started|Debugging|Stopping|Stopped|Unknown)/'`;
+			assert.deepStrictEqual(parseToStr(input), "Lexing errors:\n\nUnexpected token ''' at offset 93\n");
+		});
+
+		test('vim<c-r> == 1 && vim<2<=3', () => {
+			const input = 'vim<c-r> == 1 && vim<2<=3';
+			assert.deepStrictEqual(parseToStr(input), "vim<c-r> == '1' && vim<2 <= 3"); // FIXME
+		});
+
+		test(`foo && 'bar`, () => {
+			const input = `foo && 'bar`;
+			assert.deepStrictEqual(parseToStr(input), "Lexing errors:\n\nUnexpected token ''bar' at offset 7. Did you forget to close the string?\n");
+		});
+
+		/*
+			We do not support negation of arbitrary expressions, only of keys.
+
+			TODO@ulugbekna: move after adding support for negation of arbitrary expressions
+		*/
+		test('!(foo && bar)', () => {
+			const input = '!(foo && bar)';
+			assert.deepStrictEqual(parseToStr(input), "Parsing errors:\n\nExpected KEY, 'true', or 'false' but got '(' at offset 1.\n");
+		});
+
+	});
+
+});

--- a/src/vs/platform/contextkey/test/common/parser.test.ts
+++ b/src/vs/platform/contextkey/test/common/parser.test.ts
@@ -216,6 +216,11 @@ suite('Context Key Scanner', () => {
 			assert.deepStrictEqual(parseToStr(input), "Parsing errors:\n\nExpected KEY, 'true', or 'false' but got '(' at offset 1.\n");
 		});
 
+		test(`config.foo &&  &&bar =~ /^foo$|^bar-foo$|^joo$|^jar$/ && !foo`, () => {
+			const input = `config.foo &&  &&bar =~ /^foo$|^bar-foo$|^joo$|^jar$/ && !foo`;
+			assert.deepStrictEqual(parseToStr(input), "Parsing errors:\n\nExpected 'true', 'false', '(', KEY, KEY '=~' regex, KEY [ ('==' | '!=' | '<' | '<=' | '>' | '>=' | 'in' | 'not' 'in') value ] but got '&&' at offset 15.\n");
+		});
+
 	});
 
 });

--- a/src/vs/platform/contextkey/test/common/scanner.test.ts
+++ b/src/vs/platform/contextkey/test/common/scanner.test.ts
@@ -197,7 +197,12 @@ suite('Context Key Scanner', () => {
 
 		test('vim<c-r>==1 && vim<2<=3', () => {
 			const input = 'vim<c-r>==1 && vim<2<=3';
-			assert.deepStrictEqual(scan(input), ([{ type: "Str", lexeme: "vim<c-r>", offset: 0 }, { type: "==", offset: 8 }, { type: "Str", lexeme: "1", offset: 10 }, { type: "&&", offset: 12 }, { type: "Str", lexeme: "vim<2<", offset: 15 }, { type: "ErrorToken", offset: 21, lexeme: "=" }, { type: "EOF", offset: 23 }]));
+			assert.deepStrictEqual(scan(input), ([{ type: "Str", offset: 0, lexeme: "vim<c-r>" }, { type: "==", offset: 8 }, { type: "Str", offset: 10, lexeme: "1" }, { type: "&&", offset: 12 }, { type: "Str", offset: 15, lexeme: "vim<2<" }, { type: "ErrorToken", offset: 21, lexeme: "=" }, { type: "Str", offset: 22, lexeme: "3" }, { type: "EOF", offset: 23 }]));
+		});
+
+		test(`foo|bar`, () => {
+			const input = `foo|bar`;
+			assert.deepStrictEqual(scan(input), ([{ type: "Str", offset: 0, lexeme: "foo" }, { type: "ErrorToken", offset: 3, lexeme: "|" }, { type: "Str", offset: 4, lexeme: "bar" }, { type: "EOF", offset: 7 }]));
 		});
 	});
 });

--- a/src/vs/platform/contextkey/test/common/scanner.test.ts
+++ b/src/vs/platform/contextkey/test/common/scanner.test.ts
@@ -7,7 +7,7 @@ import { Scanner, TokenType } from 'vs/platform/contextkey/common/scanner';
 
 suite('Context Key Scanner', () => {
 	function scan(input: string) {
-		return [...((new Scanner()).reset(input))];
+		return (new Scanner()).reset(input).scan();
 	}
 
 	suite('scanning a single token', () => {
@@ -181,8 +181,8 @@ suite('Context Key Scanner', () => {
 
 		test(`foo === bar'`, () => {
 			const input = `foo === bar'`;
-			const scanner = new Scanner().reset(input);
-			const r = [...scanner].filter(t => t.type === TokenType.Error).map(Scanner.reportError);
+			const tokens = new Scanner().reset(input).scan();
+			const r = tokens.filter(t => t.type === TokenType.Error).map(Scanner.reportError);
 			assert.deepStrictEqual(r, (["Unexpected token '=' at offset 6. Did you mean '==' or '=~'?", "Unexpected token ''' at offset 11"]));
 		});
 

--- a/src/vs/platform/contextkey/test/common/scanner.test.ts
+++ b/src/vs/platform/contextkey/test/common/scanner.test.ts
@@ -106,6 +106,11 @@ suite('Context Key Scanner', () => {
 			assert.deepStrictEqual(scan(input), ([{ type: "Str", lexeme: "foo", offset: 0 }, { type: "=~", offset: 4 }, { type: "RegexStr", lexeme: "/zee/gm", offset: 7 }, { type: "EOF", offset: 14 }]));
 		});
 
+		test('foo in barrr  ', () => {
+			const input = 'foo in barrr  ';
+			assert.deepStrictEqual(scan(input), ([{ type: "Str", lexeme: "foo", offset: 0 }, { type: "in", offset: 4 }, { type: "Str", lexeme: "barrr", offset: 7 }, { type: "EOF", offset: 14 }]));
+		});
+
 		test('editorLangId in testely.supportedLangIds && resourceFilename =~ /^.+(.test.(\w+))$/gm', () => {
 			const input = 'editorLangId in testely.supportedLangIds && resourceFilename =~ /^.+(.test.(\w+))$/gm';
 			assert.deepStrictEqual(scan(input), ([{ type: "Str", lexeme: "editorLangId", offset: 0 }, { type: "in", offset: 13 }, { type: "Str", lexeme: "testely.supportedLangIds", offset: 16 }, { type: "&&", offset: 41 }, { type: "Str", lexeme: "resourceFilename", offset: 44 }, { type: "=~", offset: 61 }, { type: "RegexStr", lexeme: "/^.+(.test.(w+))$/gm", offset: 64 }, { type: "EOF", offset: 84 }]));
@@ -193,7 +198,7 @@ suite('Context Key Scanner', () => {
 
 		test('vim<c-r>==1 && vim<2<=3', () => {
 			const input = 'vim<c-r>==1 && vim<2<=3';
-			assert.deepStrictEqual(scan(input), ([{ type: "Str", lexeme: "vim<c-r", offset: 0 }, { type: ">=", offset: 7 }, { type: "ErrorToken", offset: 9, lexeme: "=" }, { type: "&&", offset: 12 }, { type: "Str", lexeme: "vim<2", offset: 15 }, { type: "<=", offset: 20 }, { type: "Str", lexeme: "3", offset: 22 }, { type: "EOF", offset: 23 }]));
+			assert.deepStrictEqual(scan(input), ([{ type: "Str", lexeme: "vim<c-r>", offset: 0 }, { type: "==", offset: 8 }, { type: "Str", lexeme: "1", offset: 10 }, { type: "&&", offset: 12 }, { type: "Str", lexeme: "vim<2<", offset: 15 }, { type: "ErrorToken", offset: 21, lexeme: "=" }, { type: "EOF", offset: 23 }]));
 		});
 	});
 });

--- a/src/vs/platform/contextkey/test/common/scanner.test.ts
+++ b/src/vs/platform/contextkey/test/common/scanner.test.ts
@@ -1,0 +1,199 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import * as assert from 'assert';
+import { Scanner, TokenType } from 'vs/platform/contextkey/common/scanner';
+
+suite('Context Key Scanner', () => {
+	function scan(input: string) {
+		return [...((new Scanner()).reset(input))];
+	}
+
+	suite('scanning a single token', () => {
+		function assertTokenTypes(str: string, ...expected: TokenType[]) {
+			const tokens = scan(str);
+			expected.push(TokenType.EOF);
+			assert.deepStrictEqual(tokens.length, expected.length, 'len: ' + str);
+			tokens.forEach((token, i) => {
+				assert.deepStrictEqual(token.type, expected[i], token.lexeme ? token.lexeme : token.type);
+			});
+		}
+
+		test('single', () => {
+			assertTokenTypes('(', TokenType.LParen);
+			assertTokenTypes(')', TokenType.RParen);
+
+			assertTokenTypes('!', TokenType.Neg);
+
+			assertTokenTypes('==', TokenType.Eq);
+			assertTokenTypes('!=', TokenType.NotEq);
+
+			assertTokenTypes('<', TokenType.Lt);
+			assertTokenTypes('<=', TokenType.LtEq);
+			assertTokenTypes('>', TokenType.Gt);
+			assertTokenTypes('>=', TokenType.GtEq);
+
+			assertTokenTypes('=~', TokenType.RegexOp);
+
+			assertTokenTypes('=~', TokenType.RegexOp);
+
+			assertTokenTypes('/foo/', TokenType.RegexStr);
+			assertTokenTypes('/foo/i', TokenType.RegexStr);
+			assertTokenTypes('/foo/gm', TokenType.RegexStr);
+
+			assertTokenTypes('true', TokenType.True);
+			assertTokenTypes('false', TokenType.False);
+
+			assertTokenTypes('in', TokenType.In);
+			assertTokenTypes('not', TokenType.Not);
+			assertTokenTypes('not in', TokenType.Not, TokenType.In);
+
+			assertTokenTypes('&&', TokenType.And);
+			assertTokenTypes('||', TokenType.Or);
+
+			assertTokenTypes('a', TokenType.Str);
+			assertTokenTypes('a.b', TokenType.Str);
+			assertTokenTypes('.b.c', TokenType.Str);
+			assertTokenTypes('Foo<C-r>', TokenType.Str);
+			assertTokenTypes('foo.bar<C-shift+2>', TokenType.Str);
+			assertTokenTypes('foo.bar:zee', TokenType.Str);
+
+			assertTokenTypes('\'hello world\'', TokenType.QuotedStr);
+
+			assertTokenTypes(' ');
+			assertTokenTypes('\n');
+			assertTokenTypes('  ');
+			assertTokenTypes(' \n ');
+		});
+	});
+
+	suite('scanning various cases of context keys', () => {
+
+		test('foo.bar<C-shift+2>', () => {
+			const input = 'foo.bar<C-shift+2>';
+			assert.deepStrictEqual(scan(input), ([{ type: "Str", lexeme: "foo.bar<C-shift+2>", offset: 0 }, { type: "EOF", offset: 18 }]));
+		});
+
+		test('!foo', () => {
+			const input = '!foo';
+			assert.deepStrictEqual(scan(input), ([{ type: "!", offset: 0 }, { type: "Str", lexeme: "foo", offset: 1 }, { type: "EOF", offset: 4 }]));
+		});
+
+		test('!(foo && bar)', () => {
+			const input = '!(foo && bar)';
+			assert.deepStrictEqual(scan(input), ([{ type: "!", offset: 0 }, { type: "(", offset: 1 }, { type: "Str", lexeme: "foo", offset: 2 }, { type: "&&", offset: 6 }, { type: "Str", lexeme: "bar", offset: 9 }, { type: ")", offset: 12 }, { type: "EOF", offset: 13 }]));
+		});
+
+		test('=~ ', () => {
+			const input = '=~ ';
+			assert.deepStrictEqual(scan(input), ([{ type: "=~", offset: 0 }, { type: "EOF", offset: 3 }]));
+		});
+
+		test('foo =~ /bar/', () => {
+			const input = 'foo =~ /bar/';
+			assert.deepStrictEqual(scan(input), ([{ type: "Str", lexeme: "foo", offset: 0 }, { type: "=~", offset: 4 }, { type: "RegexStr", lexeme: "/bar/", offset: 7 }, { type: "EOF", offset: 12 }]));
+		});
+
+		test('foo =~ /zee/i', () => {
+			const input = 'foo =~ /zee/i';
+			assert.deepStrictEqual(scan(input), ([{ type: "Str", lexeme: "foo", offset: 0 }, { type: "=~", offset: 4 }, { type: "RegexStr", lexeme: "/zee/i", offset: 7 }, { type: "EOF", offset: 13 }]));
+		});
+
+
+		test('foo =~ /zee/gm', () => {
+			const input = 'foo =~ /zee/gm';
+			assert.deepStrictEqual(scan(input), ([{ type: "Str", lexeme: "foo", offset: 0 }, { type: "=~", offset: 4 }, { type: "RegexStr", lexeme: "/zee/gm", offset: 7 }, { type: "EOF", offset: 14 }]));
+		});
+
+		test('editorLangId in testely.supportedLangIds && resourceFilename =~ /^.+(.test.(\w+))$/gm', () => {
+			const input = 'editorLangId in testely.supportedLangIds && resourceFilename =~ /^.+(.test.(\w+))$/gm';
+			assert.deepStrictEqual(scan(input), ([{ type: "Str", lexeme: "editorLangId", offset: 0 }, { type: "in", offset: 13 }, { type: "Str", lexeme: "testely.supportedLangIds", offset: 16 }, { type: "&&", offset: 41 }, { type: "Str", lexeme: "resourceFilename", offset: 44 }, { type: "=~", offset: 61 }, { type: "RegexStr", lexeme: "/^.+(.test.(w+))$/gm", offset: 64 }, { type: "EOF", offset: 84 }]));
+		});
+
+		test('!(foo && bar) && baz', () => {
+			const input = '!(foo && bar) && baz';
+			assert.deepStrictEqual(scan(input), ([{ type: "!", offset: 0 }, { type: "(", offset: 1 }, { type: "Str", lexeme: "foo", offset: 2 }, { type: "&&", offset: 6 }, { type: "Str", lexeme: "bar", offset: 9 }, { type: ")", offset: 12 }, { type: "&&", offset: 14 }, { type: "Str", lexeme: "baz", offset: 17 }, { type: "EOF", offset: 20 }]));
+		});
+
+		test('foo.bar:zed==completed - equality with no space', () => {
+			const input = 'foo.bar:zed==completed';
+			assert.deepStrictEqual(scan(input), ([{ type: "Str", lexeme: "foo.bar:zed", offset: 0 }, { type: "==", offset: 11 }, { type: "Str", lexeme: "completed", offset: 13 }, { type: "EOF", offset: 22 }]));
+		});
+
+		test('a && b || c', () => {
+			const input = 'a && b || c';
+			assert.deepStrictEqual(scan(input), ([{ type: "Str", lexeme: "a", offset: 0 }, { type: "&&", offset: 2 }, { type: "Str", lexeme: "b", offset: 5 }, { type: "||", offset: 7 }, { type: "Str", lexeme: "c", offset: 10 }, { type: "EOF", offset: 11 }]));
+		});
+
+		test('fooBar && baz.jar && fee.bee<K-loo+1>', () => {
+			const input = 'fooBar && baz.jar && fee.bee<K-loo+1>';
+			assert.deepStrictEqual(scan(input), ([{ type: "Str", lexeme: "fooBar", offset: 0 }, { type: "&&", offset: 7 }, { type: "Str", lexeme: "baz.jar", offset: 10 }, { type: "&&", offset: 18 }, { type: "Str", lexeme: "fee.bee<K-loo+1>", offset: 21 }, { type: "EOF", offset: 37 }]));
+		});
+
+		test('foo.barBaz<C-r> < 2', () => {
+			const input = 'foo.barBaz<C-r> < 2';
+			assert.deepStrictEqual(scan(input), ([{ type: "Str", lexeme: "foo.barBaz<C-r>", offset: 0 }, { type: "<", offset: 16 }, { type: "Str", lexeme: "2", offset: 18 }, { type: "EOF", offset: 19 }]));
+		});
+
+		test('foo.bar >= -1', () => {
+			const input = 'foo.bar >= -1';
+			assert.deepStrictEqual(scan(input), ([{ type: "Str", lexeme: "foo.bar", offset: 0 }, { type: ">=", offset: 8 }, { type: "Str", lexeme: "-1", offset: 11 }, { type: "EOF", offset: 13 }]));
+		});
+
+		test('foo.bar <= -1', () => {
+			const input = 'foo.bar <= -1';
+			assert.deepStrictEqual(scan(input), ([{ type: "Str", lexeme: "foo.bar", offset: 0 }, { type: "<=", offset: 8 }, { type: "Str", lexeme: "-1", offset: 11 }, { type: "EOF", offset: 13 }]));
+		});
+
+		test(`resource =~ /\\/Objects\\/.+\\.xml$/`, () => {
+			const input = `resource =~ /\\/Objects\\/.+\\.xml$/`;
+			assert.deepStrictEqual(scan(input), ([{ type: "Str", lexeme: "resource", offset: 0 }, { type: "=~", offset: 9 }, { type: "RegexStr", lexeme: "/\\/Objects\\/.+\\.xml$/", offset: 12 }, { type: "EOF", offset: 33 }]));
+		});
+
+		test('view == vsc-packages-activitybar-folders && vsc-packages-folders-loaded', () => {
+			const input = `view == vsc-packages-activitybar-folders && vsc-packages-folders-loaded`;
+			assert.deepStrictEqual(scan(input), ([{ type: "Str", lexeme: "view", offset: 0 }, { type: "==", offset: 5 }, { type: "Str", lexeme: "vsc-packages-activitybar-folders", offset: 8 }, { type: "&&", offset: 41 }, { type: "Str", lexeme: "vsc-packages-folders-loaded", offset: 44 }, { type: "EOF", offset: 71 }]));
+		});
+
+		test(`sfdx:project_opened && resource =~ /.*\\/functions\\/.*\\/[^\\/]+(\\/[^\\/]+\.(ts|js|java|json|toml))?$/ && resourceFilename != package.json && resourceFilename != package-lock.json && resourceFilename != tsconfig.json`, () => {
+			const input = `sfdx:project_opened && resource =~ /.*\\/functions\\/.*\\/[^\\/]+(\\/[^\\/]+\.(ts|js|java|json|toml))?$/ && resourceFilename != package.json && resourceFilename != package-lock.json && resourceFilename != tsconfig.json`;
+			assert.deepStrictEqual(scan(input), ([{ type: "Str", lexeme: "sfdx:project_opened", offset: 0 }, { type: "&&", offset: 20 }, { type: "Str", lexeme: "resource", offset: 23 }, { type: "=~", offset: 32 }, { type: "RegexStr", lexeme: "/.*\\/functions\\/.*\\/[^\\/]+(\\/[^\\/]+.(ts|js|java|json|toml))?$/", offset: 35 }, { type: "&&", offset: 98 }, { type: "Str", lexeme: "resourceFilename", offset: 101 }, { type: "!=", offset: 118 }, { type: "Str", lexeme: "package.json", offset: 121 }, { type: "&&", offset: 134 }, { type: "Str", lexeme: "resourceFilename", offset: 137 }, { type: "!=", offset: 154 }, { type: "Str", lexeme: "package-lock.json", offset: 157 }, { type: "&&", offset: 175 }, { type: "Str", lexeme: "resourceFilename", offset: 178 }, { type: "!=", offset: 195 }, { type: "Str", lexeme: "tsconfig.json", offset: 198 }, { type: "EOF", offset: 211 }]));
+		});
+
+		test(`view =~ '/(servers)/' && viewItem =~ '/^(Starting|Started|Debugging|Stopping|Stopped)/'`, () => {
+			const input = `view =~ '/(servers)/' && viewItem =~ '/^(Starting|Started|Debugging|Stopping|Stopped)/'`;
+			assert.deepStrictEqual(scan(input), ([{ type: "Str", lexeme: "view", offset: 0 }, { type: "=~", offset: 5 }, { type: "QuotedStr", lexeme: "/(servers)/", offset: 9 }, { type: "&&", offset: 22 }, { type: "Str", lexeme: "viewItem", offset: 25 }, { type: "=~", offset: 34 }, { type: "QuotedStr", lexeme: "/^(Starting|Started|Debugging|Stopping|Stopped)/", offset: 38 }, { type: "EOF", offset: 87 }]));
+		});
+	});
+
+	suite('handling lexical errors', () => {
+
+		test(`foo === '`, () => {
+			const input = `foo === '`;
+			assert.deepStrictEqual(scan(input), ([{ type: "Str", lexeme: "foo", offset: 0 }, { type: "==", offset: 4 }, { type: "ErrorToken", offset: 6, lexeme: "=" }, { type: "ErrorToken", offset: 8, lexeme: "'" }, { type: "EOF", offset: 9 }]));
+		});
+
+		test(`foo && 'bar - unterminated single quote`, () => {
+			const input = `foo && 'bar`;
+			assert.deepStrictEqual(scan(input), ([{ type: "Str", lexeme: "foo", offset: 0 }, { type: "&&", offset: 4 }, { type: "ErrorToken", offset: 7, lexeme: "'bar" }, { type: "EOF", offset: 11 }]));
+		});
+
+		test(`foo === bar'`, () => {
+			const input = `foo === bar'`;
+			const scanner = new Scanner().reset(input);
+			const r = [...scanner].filter(t => t.type === TokenType.Error).map(Scanner.reportError);
+			assert.deepStrictEqual(r, (["Unexpected token '=' at offset 6. Did you mean '==' or '=~'?", "Unexpected token ''' at offset 11"]));
+		});
+
+		test('vim<c-r> == 1 && vim<2 <= 3', () => {
+			const input = 'vim<c-r> == 1 && vim<2 <= 3';
+			assert.deepStrictEqual(scan(input), ([{ type: "Str", lexeme: "vim<c-r>", offset: 0 }, { type: "==", offset: 9 }, { type: "Str", lexeme: "1", offset: 12 }, { type: "&&", offset: 14 }, { type: "Str", lexeme: "vim<2", offset: 17 }, { type: "<=", offset: 23 }, { type: "Str", lexeme: "3", offset: 26 }, { type: "EOF", offset: 27 }]));
+		});
+
+		test('vim<c-r>==1 && vim<2<=3', () => {
+			const input = 'vim<c-r>==1 && vim<2<=3';
+			assert.deepStrictEqual(scan(input), ([{ type: "Str", lexeme: "vim<c-r", offset: 0 }, { type: ">=", offset: 7 }, { type: "ErrorToken", offset: 9, lexeme: "=" }, { type: "&&", offset: 12 }, { type: "Str", lexeme: "vim<2", offset: 15 }, { type: "<=", offset: 20 }, { type: "Str", lexeme: "3", offset: 22 }, { type: "EOF", offset: 23 }]));
+		});
+	});
+});

--- a/src/vs/platform/contextkey/test/common/scanner.test.ts
+++ b/src/vs/platform/contextkey/test/common/scanner.test.ts
@@ -3,70 +3,69 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 import * as assert from 'assert';
-import { Scanner, TokenType } from 'vs/platform/contextkey/common/scanner';
+import { Scanner, Token, TokenType } from 'vs/platform/contextkey/common/scanner';
 
 suite('Context Key Scanner', () => {
-	function scan(input: string) {
-		return (new Scanner()).reset(input).scan();
-	}
-
-	suite('scanning a single token', () => {
-		function assertTokenTypes(str: string, ...expected: TokenType[]) {
-			const tokens = scan(str);
-			expected.push(TokenType.EOF);
-			assert.deepStrictEqual(tokens.length, expected.length, 'len: ' + str);
-			tokens.forEach((token, i) => {
-				assert.deepStrictEqual(token.type, expected[i], token.lexeme ? token.lexeme : token.type);
-			});
+	function tokenTypeToStr(token: Token) {
+		switch (token.type) {
+			case TokenType.LParen:
+				return '(';
+			case TokenType.RParen:
+				return ')';
+			case TokenType.Neg:
+				return '!';
+			case TokenType.Eq:
+				return '==';
+			case TokenType.NotEq:
+				return '!=';
+			case TokenType.Lt:
+				return '<';
+			case TokenType.LtEq:
+				return '<=';
+			case TokenType.Gt:
+				return '>';
+			case TokenType.GtEq:
+				return '>=';
+			case TokenType.RegexOp:
+				return '=~';
+			case TokenType.RegexStr:
+				return 'RegexStr';
+			case TokenType.True:
+				return 'true';
+			case TokenType.False:
+				return 'false';
+			case TokenType.In:
+				return 'in';
+			case TokenType.Not:
+				return 'not';
+			case TokenType.And:
+				return '&&';
+			case TokenType.Or:
+				return '||';
+			case TokenType.Str:
+				return 'Str';
+			case TokenType.QuotedStr:
+				return 'QuotedStr';
+			case TokenType.Error:
+				return 'ErrorToken';
+			case TokenType.EOF:
+				return 'EOF';
 		}
 
-		test('single', () => {
-			assertTokenTypes('(', TokenType.LParen);
-			assertTokenTypes(')', TokenType.RParen);
-
-			assertTokenTypes('!', TokenType.Neg);
-
-			assertTokenTypes('==', TokenType.Eq);
-			assertTokenTypes('!=', TokenType.NotEq);
-
-			assertTokenTypes('<', TokenType.Lt);
-			assertTokenTypes('<=', TokenType.LtEq);
-			assertTokenTypes('>', TokenType.Gt);
-			assertTokenTypes('>=', TokenType.GtEq);
-
-			assertTokenTypes('=~', TokenType.RegexOp);
-
-			assertTokenTypes('=~', TokenType.RegexOp);
-
-			assertTokenTypes('/foo/', TokenType.RegexStr);
-			assertTokenTypes('/foo/i', TokenType.RegexStr);
-			assertTokenTypes('/foo/gm', TokenType.RegexStr);
-
-			assertTokenTypes('true', TokenType.True);
-			assertTokenTypes('false', TokenType.False);
-
-			assertTokenTypes('in', TokenType.In);
-			assertTokenTypes('not', TokenType.Not);
-			assertTokenTypes('not in', TokenType.Not, TokenType.In);
-
-			assertTokenTypes('&&', TokenType.And);
-			assertTokenTypes('||', TokenType.Or);
-
-			assertTokenTypes('a', TokenType.Str);
-			assertTokenTypes('a.b', TokenType.Str);
-			assertTokenTypes('.b.c', TokenType.Str);
-			assertTokenTypes('Foo<C-r>', TokenType.Str);
-			assertTokenTypes('foo.bar<C-shift+2>', TokenType.Str);
-			assertTokenTypes('foo.bar:zee', TokenType.Str);
-
-			assertTokenTypes('\'hello world\'', TokenType.QuotedStr);
-
-			assertTokenTypes(' ');
-			assertTokenTypes('\n');
-			assertTokenTypes('  ');
-			assertTokenTypes(' \n ');
+	}
+	function scan(input: string) {
+		return (new Scanner()).reset(input).scan().map((token: Token) => {
+			return 'lexeme' in token
+				? {
+					type: tokenTypeToStr(token),
+					offset: token.offset,
+					lexeme: token.lexeme
+				} : {
+					type: tokenTypeToStr(token),
+					offset: token.offset
+				};
 		});
-	});
+	}
 
 	suite('scanning various cases of context keys', () => {
 

--- a/src/vs/platform/contextkey/test/common/scanner.test.ts
+++ b/src/vs/platform/contextkey/test/common/scanner.test.ts
@@ -110,6 +110,11 @@ suite('Context Key Scanner', () => {
 			assert.deepStrictEqual(scan(input), ([{ type: "Str", lexeme: "foo", offset: 0 }, { type: "in", offset: 4 }, { type: "Str", lexeme: "barrr", offset: 7 }, { type: "EOF", offset: 14 }]));
 		});
 
+		test(`resource =~ //FileCabinet/(SuiteScripts|Templates/(E-mail%20Templates|Marketing%20Templates)|Web%20Site%20Hosting%20Files)(/.*)*$/`, () => {
+			const input = `resource =~ //FileCabinet/(SuiteScripts|Templates/(E-mail%20Templates|Marketing%20Templates)|Web%20Site%20Hosting%20Files)(/.*)*$/`;
+			assert.deepStrictEqual(scan(input), ([{ type: "Str", offset: 0, lexeme: "resource" }, { type: "=~", offset: 9 }, { type: "RegexStr", offset: 12, lexeme: "//" }, { type: "Str", offset: 14, lexeme: "FileCabinet/" }, { type: "(", offset: 26 }, { type: "Str", offset: 27, lexeme: "SuiteScripts" }, { type: "ErrorToken", offset: 39, lexeme: "|" }, { type: "Str", offset: 40, lexeme: "Templates/" }, { type: "(", offset: 50 }, { type: "Str", offset: 51, lexeme: "E-mail%20Templates" }, { type: "ErrorToken", offset: 69, lexeme: "|" }, { type: "Str", offset: 70, lexeme: "Marketing%20Templates" }, { type: ")", offset: 91 }, { type: "ErrorToken", offset: 92, lexeme: "|" }, { type: "Str", offset: 93, lexeme: "Web%20Site%20Hosting%20Files" }, { type: ")", offset: 121 }, { type: "(", offset: 122 }, { type: "RegexStr", offset: 123, lexeme: "/.*)*$/" }, { type: "EOF", offset: 130 }]));
+		});
+
 		test('editorLangId in testely.supportedLangIds && resourceFilename =~ /^.+(.test.(\w+))$/gm', () => {
 			const input = 'editorLangId in testely.supportedLangIds && resourceFilename =~ /^.+(.test.(\w+))$/gm';
 			assert.deepStrictEqual(scan(input), ([{ type: "Str", lexeme: "editorLangId", offset: 0 }, { type: "in", offset: 13 }, { type: "Str", lexeme: "testely.supportedLangIds", offset: 16 }, { type: "&&", offset: 41 }, { type: "Str", lexeme: "resourceFilename", offset: 44 }, { type: "=~", offset: 61 }, { type: "RegexStr", lexeme: "/^.+(.test.(w+))$/gm", offset: 64 }, { type: "EOF", offset: 84 }]));
@@ -169,6 +174,11 @@ suite('Context Key Scanner', () => {
 			const input = `view =~ '/(servers)/' && viewItem =~ '/^(Starting|Started|Debugging|Stopping|Stopped)/'`;
 			assert.deepStrictEqual(scan(input), ([{ type: "Str", lexeme: "view", offset: 0 }, { type: "=~", offset: 5 }, { type: "QuotedStr", lexeme: "/(servers)/", offset: 9 }, { type: "&&", offset: 22 }, { type: "Str", lexeme: "viewItem", offset: 25 }, { type: "=~", offset: 34 }, { type: "QuotedStr", lexeme: "/^(Starting|Started|Debugging|Stopping|Stopped)/", offset: 38 }, { type: "EOF", offset: 87 }]));
 		});
+
+		test(`resourcePath =~ /\.md(\.yml|\.txt)*$/gim`, () => {
+			const input = `resourcePath =~ /\.md(\.yml|\.txt)*$/gim`;
+			assert.deepStrictEqual(scan(input), ([{ type: "Str", offset: 0, lexeme: "resourcePath" }, { type: "=~", offset: 13 }, { type: "RegexStr", offset: 16, lexeme: "/.md(.yml|.txt)*$/gim" }, { type: "EOF", offset: 37 }]));
+		});
 	});
 
 	suite('handling lexical errors', () => {
@@ -203,6 +213,21 @@ suite('Context Key Scanner', () => {
 		test(`foo|bar`, () => {
 			const input = `foo|bar`;
 			assert.deepStrictEqual(scan(input), ([{ type: "Str", offset: 0, lexeme: "foo" }, { type: "ErrorToken", offset: 3, lexeme: "|" }, { type: "Str", offset: 4, lexeme: "bar" }, { type: "EOF", offset: 7 }]));
+		});
+
+		test(`resource =~ //foo/(barr|door/(Foo-Bar%20Templates|Soo%20Looo)|Web%20Site%Jjj%20Llll)(/.*)*$/`, () => {
+			const input = `resource =~ //foo/(barr|door/(Foo-Bar%20Templates|Soo%20Looo)|Web%20Site%Jjj%20Llll)(/.*)*$/`;
+			assert.deepStrictEqual(scan(input), ([{ type: "Str", offset: 0, lexeme: "resource" }, { type: "=~", offset: 9 }, { type: "RegexStr", offset: 12, lexeme: "//" }, { type: "Str", offset: 14, lexeme: "foo/" }, { type: "(", offset: 18 }, { type: "Str", offset: 19, lexeme: "barr" }, { type: "ErrorToken", offset: 23, lexeme: "|" }, { type: "Str", offset: 24, lexeme: "door/" }, { type: "(", offset: 29 }, { type: "Str", offset: 30, lexeme: "Foo-Bar%20Templates" }, { type: "ErrorToken", offset: 49, lexeme: "|" }, { type: "Str", offset: 50, lexeme: "Soo%20Looo" }, { type: ")", offset: 60 }, { type: "ErrorToken", offset: 61, lexeme: "|" }, { type: "Str", offset: 62, lexeme: "Web%20Site%Jjj%20Llll" }, { type: ")", offset: 83 }, { type: "(", offset: 84 }, { type: "RegexStr", offset: 85, lexeme: "/.*)*$/" }, { type: "EOF", offset: 92 }]));
+		});
+
+		test(`/((/foo/(?!bar)(.*)/)|((/src/).*/)).*$/`, () => {
+			const input = `/((/foo/(?!bar)(.*)/)|((/src/).*/)).*$/`;
+			assert.deepStrictEqual(scan(input), ([{ type: "RegexStr", offset: 0, lexeme: "/((/" }, { type: "Str", offset: 4, lexeme: "foo/" }, { type: "(", offset: 8 }, { type: "Str", offset: 9, lexeme: "?" }, { type: "!", offset: 10 }, { type: "Str", offset: 11, lexeme: "bar" }, { type: ")", offset: 14 }, { type: "(", offset: 15 }, { type: "Str", offset: 16, lexeme: ".*" }, { type: ")", offset: 18 }, { type: "RegexStr", offset: 19, lexeme: "/)|((/s" }, { type: "Str", offset: 26, lexeme: "rc/" }, { type: ")", offset: 29 }, { type: "Str", offset: 30, lexeme: ".*/" }, { type: ")", offset: 33 }, { type: ")", offset: 34 }, { type: "Str", offset: 35, lexeme: ".*$/" }, { type: "EOF", offset: 39 }]));
+		});
+
+		test(`resourcePath =~ //foo/barr// || resourcePath =~ //view/(jarrr|doooor|bees)/(web|templates)// && resourceExtname in foo.Bar`, () => {
+			const input = `resourcePath =~ //foo/barr// || resourcePath =~ //view/(jarrr|doooor|bees)/(web|templates)// && resourceExtname in foo.Bar`;
+			assert.deepStrictEqual(scan(input), ([{ type: "Str", offset: 0, lexeme: "resourcePath" }, { type: "=~", offset: 13 }, { type: "RegexStr", offset: 16, lexeme: "//" }, { type: "Str", offset: 18, lexeme: "foo/barr//" }, { type: "||", offset: 29 }, { type: "Str", offset: 32, lexeme: "resourcePath" }, { type: "=~", offset: 45 }, { type: "RegexStr", offset: 48, lexeme: "//" }, { type: "Str", offset: 50, lexeme: "view/" }, { type: "(", offset: 55 }, { type: "Str", offset: 56, lexeme: "jarrr" }, { type: "ErrorToken", offset: 61, lexeme: "|" }, { type: "Str", offset: 62, lexeme: "doooor" }, { type: "ErrorToken", offset: 68, lexeme: "|" }, { type: "Str", offset: 69, lexeme: "bees" }, { type: ")", offset: 73 }, { type: "RegexStr", offset: 74, lexeme: "/(web|templates)/" }, { type: "ErrorToken", offset: 91, lexeme: "/ && resourceExtname in foo.Bar" }, { type: "EOF", offset: 122 }]));
 		});
 	});
 });


### PR DESCRIPTION
This PR introduces a new parser for "when" [clause](https://code.visualstudio.com/api/references/when-clause-contexts) contexts. 

The new parser has a (semi-)formal syntax grammar provided at the end of this description. As a result it has more strict parsing rules that we did before. 

When I say "key" or "key name" below, I mean the identifier that is looked up from the when-clause's context.

## New features introduced

- support for parenthesis (fixes https://github.com/microsoft/vscode/issues/91473) 

   Data (based on ~16040 when-clauses from ~18100 most popular extensions): at least 35 when-clauses in the wild already use parentheses already (ie people generally just assume parentheses support)

- support for all regex flags, the old parser supported only `i`; the new one supports all: i g s m y u
   
   Data: there're at least 21 when-clauses in the wild that use regex flags besides `i`. 

- syntax grammar that users can address to write when-clauses correctly

For example, if a user wrote a when-clause: 

```
!isEditor == 'true'
``` 

the old parser would recognize `!isEditor` as a key rather than a negation because there was no clear specification of how a when-clause was allowed to look like. The new parser shows a parsing error because we support only negation of a key (we can change this behavior, but it is still better than old parser's behavior). 

- lexical and syntax error reporting

## Breakages

### Regexes 

- we stop supporting regex that do not escape slashes, e.g., writing `foo =~ /file:////` was supported in the old parser, while the new parser requires `foo =~ /file:\\/\\/\\/`. This looks uglier but it's very hard to lex a regex with unescaped slashes, e.g., javascript also can't parse `const foo = /foo//`. 

   Data: around 50 when-clauses that use unescaped slashes in their regexes. 

Note: the old parser had its own problems parsing such expressions, where `foo =~ /&&/` would be parsed as `(foo =~ /invalid/) && /`, i.e., an AND expression with `/` as a key. 

### Comparison operators

The old parser allowed comparison operators `>` and `<` in key names, e.g., `vim.use<C-r>`, but only if it's not within a comparison -- `vim.usesOf<C-r> < 1` would all be parsed as a single key name, ie `{ "key" : "vim.usesOf<C-r> < 1"}`. 

The new parser allows `<` and `>` in key names to not break existing key names such as `vim.use<C-r>`, but then we don't allow non-space-separated comparison expressions such as `foo<1`. We still support `foo<=1` as normal comparison (though at some time cost). 

- [ ] From 16K when-clauses I've observed, not a single use non-space separated comparison currently. I propose that we disallow comparison without spaces around. 

### Space-separated strings

The old parser allowed `foo == Bar Jar` as `foo == 'Bar Jar'`, 
the new parser reports an error in such a case. One can wrap the space-separated string in single-quotes. 

Data: I found ~9 when-clauses with space-separated but unquoted strings. 

## Syntax grammar

(Uses [EBNF](https://en.wikipedia.org/wiki/Extended_Backus%E2%80%93Naur_form))

```ebnf

expression ::= or

or ::= and { '||' and }*

and ::= term { '&&' term }*

term ::=
	| '!' (KEY | 'true' | 'false')
	| primary

primary ::=
	| 'true'
	| 'false'
	| '(' expression ')'
	| KEY '=~' REGEX
	| KEY [ ('==' | '!=' | '<' | '<=' | '>' | '>=' | 'not' 'in' | 'in') value ]

value ::=
	| 'true'
	| 'false'
	| 'in'     
	| KEY
	| SINGLE_QUOTED_STR
	| EMPTY_STR
```

