### PR TITLE
Icons in problems view show black when not focused

### DIFF
--- a/src/vs/platform/severityIcon/browser/media/severityIcon.css
+++ b/src/vs/platform/severityIcon/browser/media/severityIcon.css
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 .monaco-editor .zone-widget .codicon.codicon-error,
-.markers-panel .marker-icon.codicon.codicon-error,
+.markers-panel .marker-icon.error, .markers-panel .marker-icon .codicon.codicon-error,
 .text-search-provider-messages .providerMessage .codicon.codicon-error,
 .extensions-viewlet > .extensions .codicon.codicon-error,
 .extension-editor .codicon.codicon-error,
@@ -13,7 +13,7 @@
 }
 
 .monaco-editor .zone-widget .codicon.codicon-warning,
-.markers-panel .marker-icon.codicon.codicon-warning,
+.markers-panel .marker-icon.warning, .markers-panel .marker-icon .codicon.codicon-warning,
 .text-search-provider-messages .providerMessage .codicon.codicon-warning,
 .extensions-viewlet > .extensions .codicon.codicon-warning,
 .extension-editor .codicon.codicon-warning,
@@ -22,7 +22,7 @@
 }
 
 .monaco-editor .zone-widget .codicon.codicon-info,
-.markers-panel .marker-icon.codicon.codicon-info,
+.markers-panel .marker-icon.info, .markers-panel .marker-icon .codicon.codicon-info,
 .text-search-provider-messages .providerMessage .codicon.codicon-info,
 .extensions-viewlet > .extensions .codicon.codicon-info,
 .extension-editor .codicon.codicon-info,

--- a/src/vs/workbench/contrib/markers/browser/markersTreeViewer.ts
+++ b/src/vs/workbench/contrib/markers/browser/markersTreeViewer.ts
@@ -50,6 +50,7 @@ import { IContextKey, IContextKeyService } from 'vs/platform/contextkey/common/c
 import { MarkersContextKeys, MarkersViewMode } from 'vs/workbench/contrib/markers/common/markers';
 import { unsupportedSchemas } from 'vs/platform/markers/common/markerService';
 import { defaultCountBadgeStyles } from 'vs/platform/theme/browser/defaultStyles';
+import Severity from 'vs/base/common/severity';
 
 interface IResourceMarkersTemplateData {
 	readonly resourceLabel: IResourceLabel;
@@ -270,6 +271,7 @@ class MarkerWidget extends Disposable {
 
 	private readonly actionBar: ActionBar;
 	private readonly icon: HTMLElement;
+	private readonly iconContainer: HTMLElement;
 	private readonly messageAndDetailsContainer: HTMLElement;
 	private readonly disposables = this._register(new DisposableStore());
 
@@ -283,7 +285,12 @@ class MarkerWidget extends Disposable {
 		this.actionBar = this._register(new ActionBar(dom.append(parent, dom.$('.actions')), {
 			actionViewItemProvider: (action: IAction) => action.id === QuickFixAction.ID ? _instantiationService.createInstance(QuickFixActionViewItem, <QuickFixAction>action) : undefined
 		}));
-		this.icon = dom.append(parent, dom.$(''));
+
+		// wrap the icon in a container that get the icon color as foreground color. That way, if the
+		// list view does not have a specific color for the icon (=the color variable is invalid) it
+		// falls back to the foreground color of container (inherit)
+		this.iconContainer = dom.append(parent, dom.$(''));
+		this.icon = dom.append(this.iconContainer, dom.$(''));
 		this.messageAndDetailsContainer = dom.append(parent, dom.$('.marker-message-details-container'));
 	}
 
@@ -292,7 +299,8 @@ class MarkerWidget extends Disposable {
 		this.disposables.clear();
 		dom.clearNode(this.messageAndDetailsContainer);
 
-		this.icon.className = `marker-icon codicon ${SeverityIcon.className(MarkerSeverity.toSeverity(element.marker.severity))}`;
+		this.iconContainer.className = `marker-icon ${Severity.toString(MarkerSeverity.toSeverity(element.marker.severity))}`;
+		this.icon.className = `codicon ${SeverityIcon.className(MarkerSeverity.toSeverity(element.marker.severity))}`;
 		this.renderQuickfixActionbar(element);
 
 		this.renderMessageAndDetails(element, filterData);

--- a/src/vs/workbench/contrib/markers/browser/markersView.ts
+++ b/src/vs/workbench/contrib/markers/browser/markersView.ts
@@ -478,8 +478,7 @@ export class MarkersView extends FilterViewPane implements IMarkersView {
 				}),
 				expandOnlyOnTwistieClick: (e: MarkerElement) => e instanceof Marker && e.relatedInformation.length > 0,
 				overrideStyles: {
-					listBackground: this.getBackgroundColor(),
-					listInactiveSelectionIconForeground: undefined // we don't want to override the severity icon color
+					listBackground: this.getBackgroundColor()
 				},
 				selectionNavigation: true,
 				multipleSelectionSupport: true,

--- a/test/automation/src/problems.ts
+++ b/test/automation/src/problems.ts
@@ -33,7 +33,7 @@ export class Problems {
 
 	static getSelectorInProblemsView(problemType: ProblemSeverity): string {
 		const selector = problemType === ProblemSeverity.WARNING ? 'codicon-warning' : 'codicon-error';
-		return `div[id="workbench.panel.markers"] .monaco-tl-contents .marker-icon.${selector}`;
+		return `div[id="workbench.panel.markers"] .monaco-tl-contents .marker-icon .${selector}`;
 	}
 
 	static getSelectorInEditor(problemType: ProblemSeverity): string {


### PR DESCRIPTION
Wraps the severity icon in markers view in a container node that gets the severity icon color as foreground color. 
That way, if the icon color of the list view entry is not set, the color of container is used. 
That also works also with colors set as css variable. If a color is not set, the variable in invalid and `inherit` is used as color.
`inherit` means using the container color.

FYI @joaomoreno 

Fixes https://github.com/microsoft/vscode/issues/173148
