### PR TITLE
Mimic status bar hover delay in explorer

### DIFF
--- a/src/vs/workbench/contrib/files/browser/views/explorerViewer.ts
+++ b/src/vs/workbench/contrib/files/browser/views/explorerViewer.ts
@@ -280,9 +280,15 @@ export class FilesRenderer implements ICompressibleTreeRenderer<ExplorerItem, Fu
 
 	private readonly hoverDelegate = new class implements IHoverDelegate {
 
+		private lastHoverHideTime = 0;
 		readonly placement = 'element';
 
 		get delay() {
+			// Delay implementation borrowed froms src/vs/workbench/browser/parts/statusbar/statusbarPart.ts
+			if (Date.now() - this.lastHoverHideTime < 200) {
+				return 0; // show instantly when a hover was recently shown
+			}
+
 			return this.configurationService.getValue<number>('workbench.hover.delay');
 		}
 
@@ -333,6 +339,10 @@ export class FilesRenderer implements ICompressibleTreeRenderer<ExplorerItem, Fu
 				},
 				hoverPosition: HoverPosition.RIGHT,
 			}, focus) : undefined;
+		}
+
+		onDidHideHover(): void {
+			this.lastHoverHideTime = Date.now();
 		}
 	}(this.configurationService, this.hoverService);
 


### PR DESCRIPTION
Feedback from the UX sync to show hovers instantly if one was shown in the last 200ms