### PR TITLE
Use !important to prevent hover widget overriding hover size

### DIFF
--- a/src/vs/workbench/contrib/files/browser/media/explorerviewlet.css
+++ b/src/vs/workbench/contrib/files/browser/media/explorerviewlet.css
@@ -14,7 +14,7 @@
 	cursor: pointer !important;
 	padding-left: 6px;
 	height: 22px;
-	font-size: 13px;
+	font-size: 13px !important;
 }
 
 .explorer-folders-view .monaco-list-row {


### PR DESCRIPTION
Fixes #174498