### PR TITLE
use correct `title` type so `Toggle Tab Moves Focus Mode` shows up in the command palette 

### DIFF
--- a/src/vs/editor/contrib/toggleTabFocusMode/browser/toggleTabFocusMode.ts
+++ b/src/vs/editor/contrib/toggleTabFocusMode/browser/toggleTabFocusMode.ts
@@ -18,13 +18,14 @@ export class ToggleTabFocusModeAction extends Action2 {
 	constructor() {
 		super({
 			id: ToggleTabFocusModeAction.ID,
-			title: nls.localize({ key: 'toggle.tabMovesFocus', comment: ['Turn on/off use of tab key for moving focus around VS Code'] }, "Toggle Tab Key Moves Focus"),
+			title: { value: nls.localize({ key: 'toggle.tabMovesFocus', comment: ['Turn on/off use of tab key for moving focus around VS Code'] }, 'Toggle Tab Key Moves Focus'), original: 'Toggle Tab Key Moves Focus' },
 			precondition: undefined,
 			keybinding: {
 				primary: KeyMod.CtrlCmd | KeyCode.KeyM,
 				mac: { primary: KeyMod.WinCtrl | KeyMod.Shift | KeyCode.KeyM },
 				weight: KeybindingWeight.EditorContrib
-			}
+			},
+			f1: true
 		});
 	}
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
fix #174450