### PR TITLE
Ensure language packs are installed on the server side

### DIFF
--- a/build/lib/i18n.resources.json
+++ b/build/lib/i18n.resources.json
@@ -493,6 +493,10 @@
 		{
 			"name": "vs/workbench/services/userDataProfile",
 			"project": "vscode-profiles"
+		},
+		{
+			"name": "vs/workbench/services/localization",
+			"project": "vscode-workbench"
 		}
 	]
 }

--- a/src/vs/platform/languagePacks/browser/languagePacks.ts
+++ b/src/vs/platform/languagePacks/browser/languagePacks.ts
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { CancellationTokenSource } from 'vs/base/common/cancellation';
-import { withNullAsUndefined } from 'vs/base/common/types';
 import { URI } from 'vs/base/common/uri';
 import { IExtensionGalleryService } from 'vs/platform/extensionManagement/common/extensionManagement';
 import { IExtensionResourceLoaderService } from 'vs/platform/extensionResourceLoader/common/extensionResourceLoader';
@@ -74,15 +73,5 @@ export class WebLanguagePacksService extends LanguagePackBaseService {
 	// Web doesn't have a concept of language packs, so we just return an empty array
 	getInstalledLanguages(): Promise<ILanguagePackItem[]> {
 		return Promise.resolve([]);
-	}
-
-	/**
-	 *
-	 * @returns The current language pack extension
-	 */
-	getCurrentLanguagePackExtensionId(): Promise<string | undefined> {
-		// HACK: Since the locale service in workbench is responsible for setting the language pack extension id
-		// we just read it from the local storage. Ideally we get it from a wellknown service instead.
-		return Promise.resolve(withNullAsUndefined(window.localStorage.getItem('vscode.nls.languagePackExtensionId')));
 	}
 }

--- a/src/vs/platform/languagePacks/common/languagePacks.ts
+++ b/src/vs/platform/languagePacks/common/languagePacks.ts
@@ -27,7 +27,6 @@ export interface ILanguagePackService {
 	readonly _serviceBrand: undefined;
 	getAvailableLanguages(): Promise<Array<ILanguagePackItem>>;
 	getInstalledLanguages(): Promise<Array<ILanguagePackItem>>;
-	getCurrentLanguagePackExtensionId(): Promise<string | undefined>;
 	getBuiltInExtensionTranslationsUri(id: string, language: string): Promise<URI | undefined>;
 }
 
@@ -41,7 +40,6 @@ export abstract class LanguagePackBaseService extends Disposable implements ILan
 	abstract getBuiltInExtensionTranslationsUri(id: string, language: string): Promise<URI | undefined>;
 
 	abstract getInstalledLanguages(): Promise<Array<ILanguagePackItem>>;
-	abstract getCurrentLanguagePackExtensionId(): Promise<string | undefined>;
 
 	async getAvailableLanguages(): Promise<ILanguagePackItem[]> {
 		const timeout = new CancellationTokenSource();

--- a/src/vs/platform/languagePacks/common/languagePacks.ts
+++ b/src/vs/platform/languagePacks/common/languagePacks.ts
@@ -27,7 +27,8 @@ export interface ILanguagePackService {
 	readonly _serviceBrand: undefined;
 	getAvailableLanguages(): Promise<Array<ILanguagePackItem>>;
 	getInstalledLanguages(): Promise<Array<ILanguagePackItem>>;
-	getBuiltInExtensionTranslationsUri(id: string): Promise<URI | undefined>;
+	getCurrentLanguagePackExtensionId(): Promise<string | undefined>;
+	getBuiltInExtensionTranslationsUri(id: string, language: string): Promise<URI | undefined>;
 }
 
 export abstract class LanguagePackBaseService extends Disposable implements ILanguagePackService {
@@ -37,9 +38,10 @@ export abstract class LanguagePackBaseService extends Disposable implements ILan
 		super();
 	}
 
-	abstract getBuiltInExtensionTranslationsUri(id: string): Promise<URI | undefined>;
+	abstract getBuiltInExtensionTranslationsUri(id: string, language: string): Promise<URI | undefined>;
 
 	abstract getInstalledLanguages(): Promise<Array<ILanguagePackItem>>;
+	abstract getCurrentLanguagePackExtensionId(): Promise<string | undefined>;
 
 	async getAvailableLanguages(): Promise<ILanguagePackItem[]> {
 		const timeout = new CancellationTokenSource();

--- a/src/vs/platform/languagePacks/node/languagePacks.ts
+++ b/src/vs/platform/languagePacks/node/languagePacks.ts
@@ -16,7 +16,6 @@ import { areSameExtensions } from 'vs/platform/extensionManagement/common/extens
 import { ILogService } from 'vs/platform/log/common/log';
 import { ILocalizationContribution } from 'vs/platform/extensions/common/extensions';
 import { ILanguagePackItem, LanguagePackBaseService } from 'vs/platform/languagePacks/common/languagePacks';
-import { Language, LANGUAGE_DEFAULT } from 'vs/base/common/platform';
 import { URI } from 'vs/base/common/uri';
 
 interface ILanguagePack {
@@ -75,25 +74,6 @@ export class NativeLanguagePackService extends LanguagePackBaseService {
 		languages.push(this.createQuickPickItem('en', 'English'));
 		languages.sort((a, b) => a.label.localeCompare(b.label));
 		return languages;
-	}
-
-	/**
-	 * Gets the current language pack being used by the client or undefined if we are using the default language.
-	 * Note, since we use {@link Language.value()} here, this API can't be used in remote because a remote manages language per-connection.
-	 * @returns The current language pack or undefined if we are using the default language.
-	 */
-	async getCurrentLanguagePackExtensionId(): Promise<string | undefined> {
-		const currentLangage = Language.value();
-		if (currentLangage === LANGUAGE_DEFAULT) {
-			return;
-		}
-		const languagePacks = await this.cache.getLanguagePacks();
-		const currentLanguagePack = languagePacks[currentLangage];
-		if (currentLanguagePack) {
-			return currentLanguagePack.extensions[0].extensionIdentifier.id;
-		}
-		// No language pack found for the current language. Should be impossible.
-		return undefined;
 	}
 
 	private async postInstallExtension(extension: ILocalExtension): Promise<void> {

--- a/src/vs/server/node/serverServices.ts
+++ b/src/vs/server/node/serverServices.ts
@@ -209,6 +209,8 @@ export async function setupServerServices(connectionToken: ServerConnectionToken
 	instantiationService.invokeFunction(accessor => {
 		const extensionManagementService = accessor.get(INativeServerExtensionManagementService);
 		const extensionsScannerService = accessor.get(IExtensionsScannerService);
+		const extensionGalleryService = accessor.get(IExtensionGalleryService);
+		const languagePackService = accessor.get(ILanguagePackService);
 		const remoteExtensionEnvironmentChannel = new RemoteAgentEnvironmentChannel(connectionToken, environmentService, userDataProfilesService, extensionHostStatusService);
 		socketServer.registerChannel('remoteextensionsenvironment', remoteExtensionEnvironmentChannel);
 
@@ -217,7 +219,7 @@ export async function setupServerServices(connectionToken: ServerConnectionToken
 
 		socketServer.registerChannel(REMOTE_TERMINAL_CHANNEL_NAME, new RemoteTerminalChannel(environmentService, logService, ptyService, productService, extensionManagementService, configurationService));
 
-		const remoteExtensionsScanner = new RemoteExtensionsScannerService(instantiationService.createInstance(ExtensionManagementCLI), environmentService, userDataProfilesService, extensionsScannerService, logService);
+		const remoteExtensionsScanner = new RemoteExtensionsScannerService(instantiationService.createInstance(ExtensionManagementCLI), environmentService, userDataProfilesService, extensionsScannerService, logService, extensionGalleryService, languagePackService);
 		socketServer.registerChannel(RemoteExtensionsScannerChannelName, new RemoteExtensionsScannerChannel(remoteExtensionsScanner, (ctx: RemoteAgentConnectionContext) => getUriTransformer(ctx.remoteAuthority)));
 
 		const remoteFileSystemChannel = new RemoteAgentFileSystemProviderChannel(logService, environmentService);

--- a/src/vs/workbench/api/browser/mainThreadLocalization.ts
+++ b/src/vs/workbench/api/browser/mainThreadLocalization.ts
@@ -21,9 +21,9 @@ export class MainThreadLocalization extends Disposable implements MainThreadLoca
 		super();
 	}
 
-	async $fetchBuiltInBundleUri(id: string): Promise<URI | undefined> {
+	async $fetchBuiltInBundleUri(id: string, language: string): Promise<URI | undefined> {
 		try {
-			const uri = await this.languagePackService.getBuiltInExtensionTranslationsUri(id);
+			const uri = await this.languagePackService.getBuiltInExtensionTranslationsUri(id, language);
 			return uri;
 		} catch (e) {
 			return undefined;

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -2194,7 +2194,7 @@ export interface MainThreadThemingShape extends IDisposable {
 }
 
 export interface MainThreadLocalizationShape extends IDisposable {
-	$fetchBuiltInBundleUri(id: string): Promise<UriComponents | undefined>;
+	$fetchBuiltInBundleUri(id: string, language: string): Promise<UriComponents | undefined>;
 	$fetchBundleContents(uriComponents: UriComponents): Promise<string>;
 }
 

--- a/src/vs/workbench/api/common/extHostLocalizationService.ts
+++ b/src/vs/workbench/api/common/extHostLocalizationService.ts
@@ -95,7 +95,7 @@ export class ExtHostLocalizationService implements ExtHostLocalizationShape {
 
 	private async getBundleLocation(extension: IExtensionDescription): Promise<URI | undefined> {
 		if (extension.isBuiltin) {
-			const uri = await this._proxy.$fetchBuiltInBundleUri(extension.identifier.value);
+			const uri = await this._proxy.$fetchBuiltInBundleUri(extension.identifier.value, this.currentLanguage);
 			return URI.revive(uri);
 		}
 

--- a/src/vs/workbench/contrib/extensions/browser/extensionsActions.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsActions.ts
@@ -67,7 +67,7 @@ import { flatten } from 'vs/base/common/arrays';
 import { fromNow } from 'vs/base/common/date';
 import { IPreferencesService } from 'vs/workbench/services/preferences/common/preferences';
 import { getLocale } from 'vs/platform/languagePacks/common/languagePacks';
-import { ILocaleService } from 'vs/workbench/contrib/localization/common/locale';
+import { ILocaleService } from 'vs/workbench/services/localization/common/locale';
 import { isString } from 'vs/base/common/types';
 import { showWindowLogActionId } from 'vs/workbench/common/logConstants';
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';

--- a/src/vs/workbench/contrib/extensions/browser/extensionsWorkbenchService.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsWorkbenchService.ts
@@ -47,7 +47,7 @@ import { IExtensionService, IExtensionsStatus, toExtension, toExtensionDescripti
 import { ExtensionEditor } from 'vs/workbench/contrib/extensions/browser/extensionEditor';
 import { isWeb, language } from 'vs/base/common/platform';
 import { getLocale } from 'vs/platform/languagePacks/common/languagePacks';
-import { ILocaleService } from 'vs/workbench/contrib/localization/common/locale';
+import { ILocaleService } from 'vs/workbench/services/localization/common/locale';
 import { TelemetryTrustedValue } from 'vs/platform/telemetry/common/telemetryUtils';
 import { ILifecycleService, LifecyclePhase } from 'vs/workbench/services/lifecycle/common/lifecycle';
 

--- a/src/vs/workbench/contrib/localization/browser/localeService.ts
+++ b/src/vs/workbench/contrib/localization/browser/localeService.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { localize } from 'vs/nls';
-import { Language } from 'vs/base/common/platform';
+import { Language, LANGUAGE_DEFAULT } from 'vs/base/common/platform';
 import { IDialogService } from 'vs/platform/dialogs/common/dialogs';
 import { ILanguagePackItem } from 'vs/platform/languagePacks/common/languagePacks';
 import { ILocaleService } from 'vs/workbench/contrib/localization/common/locale';
@@ -27,8 +27,12 @@ export class WebLocaleService implements ILocaleService {
 		}
 		if (locale) {
 			window.localStorage.setItem('vscode.nls.locale', locale);
+			if (languagePackItem.extensionId) {
+				window.localStorage.setItem('vscode.nls.languagePackExtensionId', languagePackItem.extensionId);
+			}
 		} else {
 			window.localStorage.removeItem('vscode.nls.locale');
+			window.localStorage.removeItem('vscode.nls.languagePackExtensionId');
 		}
 
 		const restartDialog = await this.dialogService.confirm({
@@ -45,6 +49,7 @@ export class WebLocaleService implements ILocaleService {
 
 	async clearLocalePreference(): Promise<void> {
 		window.localStorage.removeItem('vscode.nls.locale');
+		window.localStorage.removeItem('vscode.nls.languagePackExtensionId');
 
 		if (Language.value() === navigator.language) {
 			return;
@@ -60,5 +65,21 @@ export class WebLocaleService implements ILocaleService {
 		if (restartDialog.confirmed) {
 			this.hostService.restart();
 		}
+	}
+
+	private async _ensureExtensionIdIsSet(): Promise<void> {
+		const language = Language.value();
+		const extensionId = window.localStorage.getItem('vscode.nls.languagePackExtensionId');
+		if (language === LANGUAGE_DEFAULT) {
+			if (extensionId) {
+				window.localStorage.removeItem('vscode.nls.languagePackExtensionId');
+			}
+			return;
+		}
+		if (extensionId) {
+			return;
+		}
+
+
 	}
 }

--- a/src/vs/workbench/contrib/localization/browser/localization.contribution.ts
+++ b/src/vs/workbench/contrib/localization/browser/localization.contribution.ts
@@ -4,12 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { registerAction2 } from 'vs/platform/actions/common/actions';
-import { InstantiationType, registerSingleton } from 'vs/platform/instantiation/common/extensions';
-import { WebLocaleService } from 'vs/workbench/contrib/localization/browser/localeService';
 import { ClearDisplayLanguageAction, ConfigureDisplayLanguageAction } from 'vs/workbench/contrib/localization/browser/localizationsActions';
-import { ILocaleService } from 'vs/workbench/contrib/localization/common/locale';
-
-registerSingleton(ILocaleService, WebLocaleService, InstantiationType.Delayed);
 
 // Register action to configure locale and related settings
 registerAction2(ConfigureDisplayLanguageAction);

--- a/src/vs/workbench/contrib/localization/browser/localizationsActions.ts
+++ b/src/vs/workbench/contrib/localization/browser/localizationsActions.ts
@@ -10,7 +10,7 @@ import { DisposableStore } from 'vs/base/common/lifecycle';
 import { Action2, MenuId } from 'vs/platform/actions/common/actions';
 import { ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
 import { ILanguagePackItem, ILanguagePackService } from 'vs/platform/languagePacks/common/languagePacks';
-import { ILocaleService } from 'vs/workbench/contrib/localization/common/locale';
+import { ILocaleService } from 'vs/workbench/services/localization/common/locale';
 import { IExtensionsWorkbenchService } from 'vs/workbench/contrib/extensions/common/extensions';
 
 export class ConfigureDisplayLanguageAction extends Action2 {

--- a/src/vs/workbench/contrib/localization/electron-sandbox/localization.contribution.ts
+++ b/src/vs/workbench/contrib/localization/electron-sandbox/localization.contribution.ts
@@ -22,12 +22,8 @@ import { IPaneCompositePartService } from 'vs/workbench/services/panecomposite/b
 import { ViewContainerLocation } from 'vs/workbench/common/views';
 import { registerAction2 } from 'vs/platform/actions/common/actions';
 import { ClearDisplayLanguageAction, ConfigureDisplayLanguageAction } from 'vs/workbench/contrib/localization/browser/localizationsActions';
-import { InstantiationType, registerSingleton } from 'vs/platform/instantiation/common/extensions';
-import { ILocaleService } from 'vs/workbench/contrib/localization/common/locale';
-import { NativeLocaleService } from 'vs/workbench/contrib/localization/electron-sandbox/localeService';
+import { ILocaleService } from 'vs/workbench/services/localization/common/locale';
 import { IProductService } from 'vs/platform/product/common/productService';
-
-registerSingleton(ILocaleService, NativeLocaleService, InstantiationType.Delayed);
 
 // Register action to configure locale and related settings
 registerAction2(ConfigureDisplayLanguageAction);

--- a/src/vs/workbench/services/localization/browser/localeService.ts
+++ b/src/vs/workbench/services/localization/browser/localeService.ts
@@ -7,12 +7,16 @@ import { localize } from 'vs/nls';
 import { Language, LANGUAGE_DEFAULT } from 'vs/base/common/platform';
 import { IDialogService } from 'vs/platform/dialogs/common/dialogs';
 import { ILanguagePackItem } from 'vs/platform/languagePacks/common/languagePacks';
-import { ILocaleService } from 'vs/workbench/contrib/localization/common/locale';
+import { IActiveLanguagePackService, ILocaleService } from 'vs/workbench/services/localization/common/locale';
 import { IHostService } from 'vs/workbench/services/host/browser/host';
 import { IProductService } from 'vs/platform/product/common/productService';
+import { withNullAsUndefined } from 'vs/base/common/types';
+import { InstantiationType, registerSingleton } from 'vs/platform/instantiation/common/extensions';
 
 export class WebLocaleService implements ILocaleService {
 	declare readonly _serviceBrand: undefined;
+	static readonly _LOCAL_STORAGE_EXTENSION_ID_KEY = 'vscode.nls.languagePackExtensionId';
+	static readonly _LOCAL_STORAGE_LOCALE_KEY = 'vscode.nls.locale';
 
 	constructor(
 		@IDialogService private readonly dialogService: IDialogService,
@@ -26,13 +30,13 @@ export class WebLocaleService implements ILocaleService {
 			return;
 		}
 		if (locale) {
-			window.localStorage.setItem('vscode.nls.locale', locale);
+			window.localStorage.setItem(WebLocaleService._LOCAL_STORAGE_LOCALE_KEY, locale);
 			if (languagePackItem.extensionId) {
-				window.localStorage.setItem('vscode.nls.languagePackExtensionId', languagePackItem.extensionId);
+				window.localStorage.setItem(WebLocaleService._LOCAL_STORAGE_EXTENSION_ID_KEY, languagePackItem.extensionId);
 			}
 		} else {
-			window.localStorage.removeItem('vscode.nls.locale');
-			window.localStorage.removeItem('vscode.nls.languagePackExtensionId');
+			window.localStorage.removeItem(WebLocaleService._LOCAL_STORAGE_LOCALE_KEY);
+			window.localStorage.removeItem(WebLocaleService._LOCAL_STORAGE_EXTENSION_ID_KEY);
 		}
 
 		const restartDialog = await this.dialogService.confirm({
@@ -48,8 +52,8 @@ export class WebLocaleService implements ILocaleService {
 	}
 
 	async clearLocalePreference(): Promise<void> {
-		window.localStorage.removeItem('vscode.nls.locale');
-		window.localStorage.removeItem('vscode.nls.languagePackExtensionId');
+		window.localStorage.removeItem(WebLocaleService._LOCAL_STORAGE_LOCALE_KEY);
+		window.localStorage.removeItem(WebLocaleService._LOCAL_STORAGE_EXTENSION_ID_KEY);
 
 		if (Language.value() === navigator.language) {
 			return;
@@ -66,20 +70,20 @@ export class WebLocaleService implements ILocaleService {
 			this.hostService.restart();
 		}
 	}
+}
 
-	private async _ensureExtensionIdIsSet(): Promise<void> {
+class WebActiveLanguagePackService implements IActiveLanguagePackService {
+	_serviceBrand: undefined;
+
+	async getExtensionIdProvidingCurrentLocale(): Promise<string | undefined> {
 		const language = Language.value();
-		const extensionId = window.localStorage.getItem('vscode.nls.languagePackExtensionId');
 		if (language === LANGUAGE_DEFAULT) {
-			if (extensionId) {
-				window.localStorage.removeItem('vscode.nls.languagePackExtensionId');
-			}
-			return;
+			return undefined;
 		}
-		if (extensionId) {
-			return;
-		}
-
-
+		const extensionId = window.localStorage.getItem(WebLocaleService._LOCAL_STORAGE_EXTENSION_ID_KEY);
+		return withNullAsUndefined(extensionId);
 	}
 }
+
+registerSingleton(ILocaleService, WebLocaleService, InstantiationType.Delayed);
+registerSingleton(IActiveLanguagePackService, WebActiveLanguagePackService, InstantiationType.Delayed);

--- a/src/vs/workbench/services/localization/common/locale.ts
+++ b/src/vs/workbench/services/localization/common/locale.ts
@@ -13,3 +13,10 @@ export interface ILocaleService {
 	setLocale(languagePackItem: ILanguagePackItem, skipDialog?: boolean): Promise<void>;
 	clearLocalePreference(): Promise<void>;
 }
+
+export const IActiveLanguagePackService = createDecorator<IActiveLanguagePackService>('activeLanguageService');
+
+export interface IActiveLanguagePackService {
+	readonly _serviceBrand: undefined;
+	getExtensionIdProvidingCurrentLocale(): Promise<string | undefined>;
+}

--- a/src/vs/workbench/services/remote/common/remoteExtensionsScanner.ts
+++ b/src/vs/workbench/services/remote/common/remoteExtensionsScanner.ts
@@ -15,6 +15,7 @@ import { IRemoteUserDataProfilesService } from 'vs/workbench/services/userDataPr
 import { IWorkbenchEnvironmentService } from 'vs/workbench/services/environment/common/environmentService';
 import { ILogService } from 'vs/platform/log/common/log';
 import { InstantiationType, registerSingleton } from 'vs/platform/instantiation/common/extensions';
+import { ILanguagePackService } from 'vs/platform/languagePacks/common/languagePacks';
 
 class RemoteExtensionsScannerService implements IRemoteExtensionsScannerService {
 
@@ -26,6 +27,7 @@ class RemoteExtensionsScannerService implements IRemoteExtensionsScannerService 
 		@IUserDataProfileService private readonly userDataProfileService: IUserDataProfileService,
 		@IRemoteUserDataProfilesService private readonly remoteUserDataProfilesService: IRemoteUserDataProfilesService,
 		@ILogService private readonly logService: ILogService,
+		@ILanguagePackService private readonly languagePackService: ILanguagePackService
 	) { }
 
 	whenExtensionsReady(): Promise<void> {
@@ -37,10 +39,11 @@ class RemoteExtensionsScannerService implements IRemoteExtensionsScannerService 
 
 	async scanExtensions(): Promise<IExtensionDescription[]> {
 		try {
+			const languagePack = await this.languagePackService.getCurrentLanguagePackExtensionId();
 			return await this.withChannel(
 				async (channel) => {
 					const profileLocation = this.userDataProfileService.currentProfile.isDefault ? undefined : (await this.remoteUserDataProfilesService.getRemoteProfile(this.userDataProfileService.currentProfile)).extensionsResource;
-					const scannedExtensions = await channel.call<IRelaxedExtensionDescription[]>('scanExtensions', [platform.language, profileLocation, this.environmentService.extensionDevelopmentLocationURI]);
+					const scannedExtensions = await channel.call<IRelaxedExtensionDescription[]>('scanExtensions', [platform.language, profileLocation, this.environmentService.extensionDevelopmentLocationURI, languagePack]);
 					scannedExtensions.forEach((extension) => {
 						extension.extensionLocation = URI.revive(extension.extensionLocation);
 						ImplicitActivationEvents.updateManifest(extension);

--- a/src/vs/workbench/services/remote/common/remoteExtensionsScanner.ts
+++ b/src/vs/workbench/services/remote/common/remoteExtensionsScanner.ts
@@ -15,7 +15,7 @@ import { IRemoteUserDataProfilesService } from 'vs/workbench/services/userDataPr
 import { IWorkbenchEnvironmentService } from 'vs/workbench/services/environment/common/environmentService';
 import { ILogService } from 'vs/platform/log/common/log';
 import { InstantiationType, registerSingleton } from 'vs/platform/instantiation/common/extensions';
-import { ILanguagePackService } from 'vs/platform/languagePacks/common/languagePacks';
+import { IActiveLanguagePackService } from 'vs/workbench/services/localization/common/locale';
 
 class RemoteExtensionsScannerService implements IRemoteExtensionsScannerService {
 
@@ -27,7 +27,7 @@ class RemoteExtensionsScannerService implements IRemoteExtensionsScannerService 
 		@IUserDataProfileService private readonly userDataProfileService: IUserDataProfileService,
 		@IRemoteUserDataProfilesService private readonly remoteUserDataProfilesService: IRemoteUserDataProfilesService,
 		@ILogService private readonly logService: ILogService,
-		@ILanguagePackService private readonly languagePackService: ILanguagePackService
+		@IActiveLanguagePackService private readonly activeLanguagePackService: IActiveLanguagePackService
 	) { }
 
 	whenExtensionsReady(): Promise<void> {
@@ -39,7 +39,7 @@ class RemoteExtensionsScannerService implements IRemoteExtensionsScannerService 
 
 	async scanExtensions(): Promise<IExtensionDescription[]> {
 		try {
-			const languagePack = await this.languagePackService.getCurrentLanguagePackExtensionId();
+			const languagePack = await this.activeLanguagePackService.getExtensionIdProvidingCurrentLocale();
 			return await this.withChannel(
 				async (channel) => {
 					const profileLocation = this.userDataProfileService.currentProfile.isDefault ? undefined : (await this.remoteUserDataProfilesService.getRemoteProfile(this.userDataProfileService.currentProfile)).extensionsResource;

--- a/src/vs/workbench/workbench.desktop.main.ts
+++ b/src/vs/workbench/workbench.desktop.main.ts
@@ -62,6 +62,7 @@ import 'vs/workbench/services/localization/electron-sandbox/languagePackService'
 import 'vs/workbench/services/telemetry/electron-sandbox/telemetryService';
 import 'vs/workbench/services/extensions/electron-sandbox/extensionHostStarter';
 import 'vs/platform/extensionResourceLoader/common/extensionResourceLoaderService';
+import 'vs/workbench/services/localization/electron-sandbox/localeService';
 import 'vs/platform/extensionManagement/electron-sandbox/extensionsScannerService';
 import 'vs/workbench/services/extensionManagement/electron-sandbox/extensionManagementServerService';
 import 'vs/workbench/services/extensionManagement/electron-sandbox/extensionTipsService';

--- a/src/vs/workbench/workbench.web.main.ts
+++ b/src/vs/workbench/workbench.web.main.ts
@@ -53,6 +53,7 @@ import 'vs/workbench/services/dialogs/browser/fileDialogService';
 import 'vs/workbench/services/host/browser/browserHostService';
 import 'vs/workbench/services/lifecycle/browser/lifecycleService';
 import 'vs/workbench/services/clipboard/browser/clipboardService';
+import 'vs/workbench/services/localization/browser/localeService';
 import 'vs/workbench/services/path/browser/pathService';
 import 'vs/workbench/services/themes/browser/browserHostColorSchemeService';
 import 'vs/workbench/services/encryption/browser/encryptionService';


### PR DESCRIPTION
We need the language pack to be on the server side so that extensions running over there are translated correctly.

This ensures the correct language pack is installed before the ExtensionScanner (which will translate the manifest of extensions) kicks in.

Fixes #166836

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
