### PR TITLE
Fixed Styling for Profile badge

### DIFF
--- a/src/vs/workbench/browser/parts/activitybar/activitybarActions.ts
+++ b/src/vs/workbench/browser/parts/activitybar/activitybarActions.ts
@@ -375,7 +375,7 @@ export class GlobalActivityActionViewItem extends MenuActivityActionViewItem {
 		this.updateProfileBadge();
 	}
 
-	protected updateProfileBadge(): void {
+	private updateProfileBadge(): void {
 		if (!this.profileBadge || !this.profileBadgeContent) {
 			return;
 		}
@@ -387,8 +387,17 @@ export class GlobalActivityActionViewItem extends MenuActivityActionViewItem {
 			return;
 		}
 
+		if ((this.action as ActivityAction).getBadge()) {
+			return;
+		}
+
 		this.profileBadgeContent.textContent = this.userDataProfileService.currentProfile.name.substring(0, 2).toUpperCase();
 		show(this.profileBadge);
+	}
+
+	protected override updateBadge(): void {
+		super.updateBadge();
+		this.updateProfileBadge();
 	}
 
 	protected override computeTitle(): string {

--- a/src/vs/workbench/browser/parts/activitybar/media/activityaction.css
+++ b/src/vs/workbench/browser/parts/activitybar/media/activityaction.css
@@ -175,12 +175,12 @@
 .monaco-workbench .activitybar > .content :not(.monaco-menu) > .monaco-action-bar .profile-badge .profile-badge-content {
 	position: absolute;
 	font-weight: 600;
-	font-size: 11px;
+	font-size: 9px;
 	line-height: 10px;
-	top: 28px;
-	right: 24px;
-	padding: 1px;
-	border-radius: 3px;
+	top: 24px;
+	right: 6px;
+	padding: 2px;
+	border-radius: 4px;
 	background-color: var(--vscode-activityBar-background);
 	color: var(--vscode-activityBar-inactiveForeground);
 	border: 1px solid;


### PR DESCRIPTION
Idea for #166983
![image](https://user-images.githubusercontent.com/113370447/219520962-6fe70cca-8265-462c-9611-ca5020fdde26.png)

@sandy081, if you feel strongly about having the badge and the profile indicator, we can experiment with the profile indicator shift to the left when there's a badge active:

![image](https://user-images.githubusercontent.com/113370447/219521297-73268ab5-a61f-465c-a397-b196b834efe1.png)

IMO the badge can stay always on the right side and temporarily vanish while there's a badge on the settings gear :) 