### PR TITLE
Fix issues with inconsistent line wrap application

### DIFF
--- a/src/vs/editor/browser/services/abstractCodeEditorService.ts
+++ b/src/vs/editor/browser/services/abstractCodeEditorService.ts
@@ -225,8 +225,11 @@ export abstract class AbstractCodeEditorService extends Disposable implements IC
 			this._transientWatchers[uri] = w;
 		}
 
-		w.set(key, value);
-		this._onDidChangeTransientModelProperty.fire(model);
+		const previousValue = w.get(key);
+		if (previousValue !== value) {
+			w.set(key, value);
+			this._onDidChangeTransientModelProperty.fire(model);
+		}
 	}
 
 	public getTransientModelProperty(model: ITextModel, key: string): any {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes #173969 by modifying the `mirrorWordWrapTransientState` to apply to all Merge Editor windows  


Co-author: @hediet 