### PR TITLE
Fix locale and language handling

### DIFF
--- a/src/vs/base/node/languagePacks.js
+++ b/src/vs/base/node/languagePacks.js
@@ -119,10 +119,14 @@
 			// We have a built version so we have extracted nls file. Try to find
 			// the right file to use.
 
-			// Check if we have an English or English US locale. If so fall to default since that is our
-			// English translation (we don't ship *.nls.en.json files)
-			if (locale && (locale === 'en' || locale === 'en-us')) {
+			// If we didn't specify a language, use the default
+			if (!language) {
 				return Promise.resolve({ locale, availableLanguages: {} });
+			}
+
+			// If we specified English or English US, return that as the available language.
+			if (language === 'en' || language === 'en-us') {
+				return Promise.resolve({ locale, availableLanguages: { '*': 'en' } });
 			}
 
 			perf.mark('code/willGenerateNls');
@@ -152,7 +156,7 @@
 						if (!fileExists) {
 							return defaultResult(locale);
 						}
-						const _languagePackId = packConfig.hash + '.' + locale;
+						const _languagePackId = packConfig.hash + '.' + language;
 						const cacheRoot = path.join(userDataPath, 'clp', _languagePackId);
 						const coreLocation = path.join(cacheRoot, commit);
 						const _translationsConfigFile = path.join(cacheRoot, 'tcf.json');

--- a/src/vs/base/node/languagePacks.js
+++ b/src/vs/base/node/languagePacks.js
@@ -81,6 +81,30 @@
 		}
 
 		/**
+		 * @param {object} config
+		 * @param {string | undefined} locale
+		 */
+		function resolveLanguagePackLocale(config, locale) {
+			try {
+				while (locale) {
+					if (config[locale]) {
+						return locale;
+					} else {
+						const index = locale.lastIndexOf('-');
+						if (index > 0) {
+							locale = locale.substring(0, index);
+						} else {
+							return undefined;
+						}
+					}
+				}
+			} catch (err) {
+				console.error('Resolving language pack configuration failed.', err);
+			}
+			return undefined;
+		}
+
+		/**
 		 * @param {string | undefined} commit
 		 * @param {string} userDataPath
 		 * @param {string} metaDataFile
@@ -115,7 +139,11 @@
 					if (!configs) {
 						return defaultResult(locale);
 					}
-					const packConfig = configs[locale];
+					language = resolveLanguagePackLocale(configs, language);
+					if (!language) {
+						return defaultResult(locale);
+					}
+					const packConfig = configs[language];
 					let mainPack;
 					if (!packConfig || typeof packConfig.hash !== 'string' || !packConfig.translations || typeof (mainPack = packConfig.translations['vscode']) !== 'string') {
 						return defaultResult(locale);

--- a/test/smoke/src/areas/workbench/localization.test.ts
+++ b/test/smoke/src/areas/workbench/localization.test.ts
@@ -8,7 +8,9 @@ import { installAllHandlers } from '../../utils';
 
 export function setup(logger: Logger) {
 
-	describe('Localization', () => {
+	// BUG: app.getPreferredSystemLanguages() doesn't seem to return anything here on Linux: https://github.com/microsoft/vscode/blob/3ba29f37d6b9f3f2257b48f2b90f0699ea581be4/src/main.js#L100-L113
+	// but it should when we move to Electron 22 so we can re-enable this test then.
+	(process.platform === 'linux' ? describe.skip : describe)('Localization', () => {
 		// Shared before/after handling
 		installAllHandlers(logger);
 

--- a/test/smoke/src/areas/workbench/localization.test.ts
+++ b/test/smoke/src/areas/workbench/localization.test.ts
@@ -25,7 +25,7 @@ export function setup(logger: Logger) {
 			// The smoke tests will only work on a machine that uses English as the OS language.
 			// The build machine is configured to use English as the OS language so that is why
 			// we can hardcode the expected values here.
-			if (localeInfo.locale === undefined || localeInfo.locale.toLowerCase().startsWith('en')) {
+			if (localeInfo.locale === undefined || !localeInfo.locale.toLowerCase().startsWith('en')) {
 				throw new Error(`The requested locale for VS Code was not English. The received value is: ${localeInfo.locale === undefined ? 'not set' : localeInfo.locale}`);
 			}
 

--- a/test/smoke/src/areas/workbench/localization.test.ts
+++ b/test/smoke/src/areas/workbench/localization.test.ts
@@ -22,7 +22,10 @@ export function setup(logger: Logger) {
 			const result = await app.workbench.localization.getLocalizedStrings();
 			const localeInfo = await app.workbench.localization.getLocaleInfo();
 
-			if (localeInfo.locale === undefined || localeInfo.locale.toLowerCase() !== 'de') {
+			// The smoke tests will only work on a machine that uses English as the OS language.
+			// The build machine is configured to use English as the OS language so that is why
+			// we can hardcode the expected values here.
+			if (localeInfo.locale === undefined || localeInfo.locale.toLowerCase() !== 'en-us') {
 				throw new Error(`The requested locale for VS Code was not German. The received value is: ${localeInfo.locale === undefined ? 'not set' : localeInfo.locale}`);
 			}
 

--- a/test/smoke/src/areas/workbench/localization.test.ts
+++ b/test/smoke/src/areas/workbench/localization.test.ts
@@ -25,8 +25,8 @@ export function setup(logger: Logger) {
 			// The smoke tests will only work on a machine that uses English as the OS language.
 			// The build machine is configured to use English as the OS language so that is why
 			// we can hardcode the expected values here.
-			if (localeInfo.locale === undefined || localeInfo.locale.toLowerCase() !== 'en-us') {
-				throw new Error(`The requested locale for VS Code was not German. The received value is: ${localeInfo.locale === undefined ? 'not set' : localeInfo.locale}`);
+			if (localeInfo.locale === undefined || localeInfo.locale.toLowerCase().startsWith('en')) {
+				throw new Error(`The requested locale for VS Code was not English. The received value is: ${localeInfo.locale === undefined ? 'not set' : localeInfo.locale}`);
 			}
 
 			if (localeInfo.language.toLowerCase() !== 'de') {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This should align locale and language to the follow definitions:
* locale: if we have the `app.getPreferredSystemLanguages()` Electron API then this variable will be the OS locale, otherwise it's the app locale.
* language: we grab the language specied by argv or argv.json and then resolve it to an installed language pack. If we don't have the language pack, then we fall back to English.

This fixes the build, and skips this smoke test on linux as `app.getPreferredSystemLanguages()` doesn't seem to work as expected there.

cc @rzhao271 

Fixes #174734