### PR TITLE
Implement linting for when-clauses

### DIFF
--- a/extensions/extension-editing/src/extensionLinter.ts
+++ b/extensions/extension-editing/src/extensionLinter.ts
@@ -212,7 +212,7 @@ export class ExtensionLinter {
 			if (node) {
 				switch (node.type) {
 					case 'property':
-						if (node.children) {
+						if (node.children && node.children.length === 2) {
 							const key = node.children[0];
 							const value = node.children[1];
 							switch (value.type) {

--- a/extensions/extension-editing/src/extensionLinter.ts
+++ b/extensions/extension-editing/src/extensionLinter.ts
@@ -272,10 +272,10 @@ export class ExtensionLinter {
 	}
 
 	private async lintReadme() {
-		for (const document of Array.from(this.readmeQ)) {
+		for (const document of this.readmeQ) {
 			this.readmeQ.delete(document);
 			if (document.isClosed) {
-				return; // TODO@ulugbekna: are we sure we want to return here? it may be a copy-paste problem where it used to be written with forEach, so it `return`ed instead of `continue`ing
+				continue;
 			}
 
 			const folder = this.getUriFolder(document.uri);

--- a/extensions/extension-editing/src/extensionLinter.ts
+++ b/extensions/extension-editing/src/extensionLinter.ts
@@ -247,7 +247,7 @@ export class ExtensionLinter {
 
 		findWhens(findNodeAtLocation(contributesNode, ['commands']), 'enablement');
 
-		const parseResults = await commands.executeCommand<{ errorMessage: string; offset: number; length: number }[][]>('_parseWhenClausesForErrors', whenClauses.map(w => w.value as string /* we make sure to capture only if `w.value` is string above */));
+		const parseResults = await commands.executeCommand<{ errorMessage: string; offset: number; length: number }[][]>('_validateWhenClauses', whenClauses.map(w => w.value as string /* we make sure to capture only if `w.value` is string above */));
 
 		const diagnostics: Diagnostic[] = [];
 		for (let i = 0; i < parseResults.length; ++i) {

--- a/extensions/extension-editing/src/extensionLinter.ts
+++ b/extensions/extension-editing/src/extensionLinter.ts
@@ -38,7 +38,7 @@ const implicitActivationEvent = l10n.t("This activation event cannot be explicit
 const redundantImplicitActivationEvent = l10n.t("This activation event can be removed as VS Code generates these automatically from your package.json contribution declarations.");
 const bumpEngineForImplicitActivationEvents = l10n.t("This activation event can be removed for extensions targeting engine version ^1.75 as VS Code will generate these automatically from your package.json contribution declarations.");
 const starActivation = l10n.t("Using '*' activation is usually a bad idea as it impacts performance.");
-const parsingErrorHeader = l10n.t("Error when parsing when clause:");
+const parsingErrorHeader = l10n.t("Error parsing the when-clause:");
 
 enum Context {
 	ICON,

--- a/extensions/extension-editing/src/extensionLinter.ts
+++ b/extensions/extension-editing/src/extensionLinter.ts
@@ -12,7 +12,6 @@ import * as MarkdownItType from 'markdown-it';
 
 import { commands, languages, workspace, Disposable, TextDocument, Uri, Diagnostic, Range, DiagnosticSeverity, Position, env, l10n } from 'vscode';
 import { INormalizedVersion, normalizeVersion, parseVersion } from './extensionEngineValidation';
-import { TextDecoder } from 'util';
 import { JsonStringScanner } from './jsonReconstruct';
 
 const product = JSON.parse(fs.readFileSync(path.join(env.appRoot, 'product.json'), { encoding: 'utf-8' }));

--- a/extensions/extension-editing/src/extensionLinter.ts
+++ b/extensions/extension-editing/src/extensionLinter.ts
@@ -199,7 +199,7 @@ export class ExtensionLinter {
 		for (const document of Array.from(this.readmeQ)) {
 			this.readmeQ.delete(document);
 			if (document.isClosed) {
-				return;
+				return; // TODO@ulugbekna: are we sure we want to return here? it may be a copy-paste problem where it used to be written with forEach, so it `return`ed instead of `continue`ing
 			}
 
 			const folder = this.getUriFolder(document.uri);

--- a/extensions/extension-editing/src/extensionLinter.ts
+++ b/extensions/extension-editing/src/extensionLinter.ts
@@ -115,10 +115,10 @@ export class ExtensionLinter {
 	}
 
 	private lintPackageJson() {
-		this.packageJsonQ.forEach(document => {
+		for (const document of Array.from(this.packageJsonQ)) {
 			this.packageJsonQ.delete(document);
 			if (document.isClosed) {
-				return;
+				continue;
 			}
 
 			const diagnostics: Diagnostic[] = [];
@@ -192,7 +192,7 @@ export class ExtensionLinter {
 				}
 			}
 			this.diagnosticsCollection.set(document.uri, diagnostics);
-		});
+		}
 	}
 
 	private async lintReadme() {

--- a/extensions/extension-editing/src/extensionLinter.ts
+++ b/extensions/extension-editing/src/extensionLinter.ts
@@ -244,7 +244,7 @@ export class ExtensionLinter {
 
 		findWhens(findNodeAtLocation(contributesNode, ['commands']), 'enablement');
 
-		const parseResults = await commands.executeCommand<(string | undefined)[]>('_parseWhenExpressions', whens.map(w => w.value as string /* we make sure to capture only if `w.value` is string above */));
+		const parseResults = await commands.executeCommand<string[]>('_parseWhenExpressions', whens.map(w => w.value as string /* we make sure to capture only if `w.value` is string above */));
 
 		const diagnostics: Diagnostic[] = [];
 		for (let i = 0; i < parseResults.length; ++i) {
@@ -252,7 +252,8 @@ export class ExtensionLinter {
 			if (parseRes) {
 				const start = whens[i].offset;
 				const end = whens[i].offset + whens[i].length;
-				diagnostics.push(new Diagnostic(new Range(document.positionAt(start), document.positionAt(end)), parseRes, DiagnosticSeverity.Warning));
+				const range = new Range(document.positionAt(start), document.positionAt(end));
+				diagnostics.push(new Diagnostic(range, parseRes, DiagnosticSeverity.Warning));
 			}
 		}
 		return diagnostics;

--- a/extensions/extension-editing/src/jsonReconstruct.ts
+++ b/extensions/extension-editing/src/jsonReconstruct.ts
@@ -1,0 +1,183 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/**
+ * This class has a very specific purpose:
+ *
+ *	It can return convert offset within a decoded JSON string to offset within the encoded JSON string.
+ */
+export class JsonStringScanner {
+	private resultChars = 0;
+	private pos = 0;
+
+	/**
+	 *
+	 * @param text the encoded JSON string
+	 * @param pos must not include ", ie must be `stringJSONNode.offset + 1`
+	 */
+	constructor(private readonly text: string, initialPos: number /* offset within `text` */) {
+		this.pos = initialPos;
+	}
+
+	// note that we don't do bound checks here, because we know that the offset is within the string
+	getOffsetInEncoded(offsetDecoded: number) {
+
+		let start = this.pos;
+
+		while (true) {
+			if (this.resultChars > offsetDecoded) {
+				return start;
+			}
+
+			const ch = this.text.charCodeAt(this.pos);
+
+			if (ch === CharacterCodes.backslash) {
+				start = this.pos;
+				this.pos++;
+
+				const ch2 = this.text.charCodeAt(this.pos++);
+				switch (ch2) {
+					case CharacterCodes.doubleQuote:
+					case CharacterCodes.backslash:
+					case CharacterCodes.slash:
+					case CharacterCodes.b:
+					case CharacterCodes.f:
+					case CharacterCodes.n:
+					case CharacterCodes.r:
+					case CharacterCodes.t:
+						this.resultChars += 1;
+						break;
+					case CharacterCodes.u: {
+						const ch3 = this.scanHexDigits(4, true);
+						if (ch3 >= 0) {
+							this.resultChars += String.fromCharCode(ch3).length;
+						}
+						break;
+					}
+				}
+				continue;
+			}
+			start = this.pos;
+			this.pos++;
+			this.resultChars++;
+		}
+	}
+
+	scanHexDigits(count: number, exact?: boolean): number {
+		let digits = 0;
+		let value = 0;
+		while (digits < count || !exact) {
+			const ch = this.text.charCodeAt(this.pos);
+			if (ch >= CharacterCodes._0 && ch <= CharacterCodes._9) {
+				value = value * 16 + ch - CharacterCodes._0;
+			}
+			else if (ch >= CharacterCodes.A && ch <= CharacterCodes.F) {
+				value = value * 16 + ch - CharacterCodes.A + 10;
+			}
+			else if (ch >= CharacterCodes.a && ch <= CharacterCodes.f) {
+				value = value * 16 + ch - CharacterCodes.a + 10;
+			}
+			else {
+				break;
+			}
+			this.pos++;
+			digits++;
+		}
+		if (digits < count) {
+			value = -1;
+		}
+		return value;
+	}
+}
+
+
+const enum CharacterCodes {
+	lineFeed = 0x0A,              // \n
+	carriageReturn = 0x0D,        // \r
+
+	space = 0x0020,   // " "
+
+	_0 = 0x30,
+	_1 = 0x31,
+	_2 = 0x32,
+	_3 = 0x33,
+	_4 = 0x34,
+	_5 = 0x35,
+	_6 = 0x36,
+	_7 = 0x37,
+	_8 = 0x38,
+	_9 = 0x39,
+
+	a = 0x61,
+	b = 0x62,
+	c = 0x63,
+	d = 0x64,
+	e = 0x65,
+	f = 0x66,
+	g = 0x67,
+	h = 0x68,
+	i = 0x69,
+	j = 0x6A,
+	k = 0x6B,
+	l = 0x6C,
+	m = 0x6D,
+	n = 0x6E,
+	o = 0x6F,
+	p = 0x70,
+	q = 0x71,
+	r = 0x72,
+	s = 0x73,
+	t = 0x74,
+	u = 0x75,
+	v = 0x76,
+	w = 0x77,
+	x = 0x78,
+	y = 0x79,
+	z = 0x7A,
+
+	A = 0x41,
+	B = 0x42,
+	C = 0x43,
+	D = 0x44,
+	E = 0x45,
+	F = 0x46,
+	G = 0x47,
+	H = 0x48,
+	I = 0x49,
+	J = 0x4A,
+	K = 0x4B,
+	L = 0x4C,
+	M = 0x4D,
+	N = 0x4E,
+	O = 0x4F,
+	P = 0x50,
+	Q = 0x51,
+	R = 0x52,
+	S = 0x53,
+	T = 0x54,
+	U = 0x55,
+	V = 0x56,
+	W = 0x57,
+	X = 0x58,
+	Y = 0x59,
+	Z = 0x5a,
+
+	asterisk = 0x2A,              // *
+	backslash = 0x5C,             // \
+	closeBrace = 0x7D,            // }
+	closeBracket = 0x5D,          // ]
+	colon = 0x3A,                 // :
+	comma = 0x2C,                 // ,
+	dot = 0x2E,                   // .
+	doubleQuote = 0x22,           // "
+	minus = 0x2D,                 // -
+	openBrace = 0x7B,             // {
+	openBracket = 0x5B,           // [
+	plus = 0x2B,                  // +
+	slash = 0x2F,                 // /
+
+	formFeed = 0x0C,              // \f
+	tab = 0x09,                   // \t
+}

--- a/src/vs/platform/contextkey/browser/contextKeyService.ts
+++ b/src/vs/platform/contextkey/browser/contextKeyService.ts
@@ -14,8 +14,8 @@ import { URI } from 'vs/base/common/uri';
 import { localize } from 'vs/nls';
 import { CommandsRegistry } from 'vs/platform/commands/common/commands';
 import { ConfigurationTarget, IConfigurationService } from 'vs/platform/configuration/common/configuration';
-import { ContextKeyExpression, ContextKeyInfo, ContextKeyValue, IContext, IContextKey, IContextKeyChangeEvent, IContextKeyService, IContextKeyServiceTarget, IReadableSet, Parser, RawContextKey } from 'vs/platform/contextkey/common/contextkey';
-import { Scanner } from 'vs/platform/contextkey/common/scanner';
+import { ContextKeyExpression, ContextKeyInfo, ContextKeyValue, IContext, IContextKey, IContextKeyChangeEvent, IContextKeyService, IContextKeyServiceTarget, IReadableSet, Parser, ParsingError, RawContextKey } from 'vs/platform/contextkey/common/contextkey';
+import { LexingError } from 'vs/platform/contextkey/common/scanner';
 import { ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
 
 const KEYBINDING_CONTEXT_ATTR = 'data-keybinding-context';
@@ -646,17 +646,36 @@ CommandsRegistry.registerCommand('_generateContextKeyInfo', function () {
 	console.log(JSON.stringify(result, undefined, 2));
 });
 
-CommandsRegistry.registerCommand('_parseWhenExpressions', (_accessor: ServicesAccessor, whenClauses: string[]) => {
+CommandsRegistry.registerCommand('_parseWhenClausesForErrors', (_accessor: ServicesAccessor, whenClauses: string[]): { errorMessage: string; offset: number; length: number }[][] => {
+
 	const parser = new Parser({ regexParsingWithErrorRecovery: false });
+
 	return whenClauses.map(whenClause => {
 		parser.parse(whenClause);
 
 		if (parser.lexingErrors.length > 0) {
-			return parser.lexingErrors.map(errToken => Scanner.reportError(errToken)).join('\n');
+			return parser.lexingErrors.map((se: LexingError) => {
+				return {
+					errorMessage: se.additionalInfo ?
+						localize('contextkey.scanner.errorForLinterWithHint', "Unexpected token. Hint: {0}", se.additionalInfo) :
+						localize('contextkey.scanner.errorForLinter', "Unexpected token."),
+					offset: se.offset,
+					length: se.lexeme.length,
+				};
+			});
 		} else if (parser.parsingErrors.length > 0) {
-			return parser.parsingErrors.join('\n');
+			return parser.parsingErrors.map((pe: ParsingError) => {
+				return {
+					errorMessage:
+						pe.additionalInfo ?
+							localize('contextkey.parser.errorForLinterWithHint', "{0}. {1}", pe.message, pe.additionalInfo) :
+							pe.message,
+					offset: pe.offset,
+					length: pe.lexeme.length,
+				};
+			});
 		} else {
-			return '';
+			return [];
 		}
 	});
 });

--- a/src/vs/platform/contextkey/browser/contextKeyService.ts
+++ b/src/vs/platform/contextkey/browser/contextKeyService.ts
@@ -647,16 +647,16 @@ CommandsRegistry.registerCommand('_generateContextKeyInfo', function () {
 });
 
 CommandsRegistry.registerCommand('_parseWhenExpressions', (_accessor: ServicesAccessor, whenClauses: string[]) => {
-	const parser = new Parser();
+	const parser = new Parser({ regexParsingWithErrorRecovery: false });
 	return whenClauses.map(whenClause => {
 		parser.parse(whenClause);
 
 		if (parser.lexingErrors.length > 0) {
-			return parser.lexingErrors.map(errToken => Scanner.reportError(errToken));
+			return parser.lexingErrors.map(errToken => Scanner.reportError(errToken)).join('\n');
 		} else if (parser.parsingErrors.length > 0) {
-			return parser.parsingErrors;
+			return parser.parsingErrors.join('\n');
 		} else {
-			return undefined;
+			return '';
 		}
 	});
 });

--- a/src/vs/platform/contextkey/browser/contextKeyService.ts
+++ b/src/vs/platform/contextkey/browser/contextKeyService.ts
@@ -14,7 +14,7 @@ import { URI } from 'vs/base/common/uri';
 import { localize } from 'vs/nls';
 import { CommandsRegistry } from 'vs/platform/commands/common/commands';
 import { ConfigurationTarget, IConfigurationService } from 'vs/platform/configuration/common/configuration';
-import { ContextKeyExpression, ContextKeyInfo, ContextKeyValue, IContext, IContextKey, IContextKeyChangeEvent, IContextKeyService, IContextKeyServiceTarget, IReadableSet, RawContextKey } from 'vs/platform/contextkey/common/contextkey';
+import { ContextKeyExpr, ContextKeyExpression, ContextKeyInfo, ContextKeyValue, IContext, IContextKey, IContextKeyChangeEvent, IContextKeyService, IContextKeyServiceTarget, IReadableSet, RawContextKey } from 'vs/platform/contextkey/common/contextkey';
 import { ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
 
 const KEYBINDING_CONTEXT_ATTR = 'data-keybinding-context';
@@ -643,4 +643,25 @@ CommandsRegistry.registerCommand('_generateContextKeyInfo', function () {
 	}
 	result.sort((a, b) => a.key.localeCompare(b.key));
 	console.log(JSON.stringify(result, undefined, 2));
+});
+
+CommandsRegistry.registerCommand('_parseWhenExpressions', (_accessor: ServicesAccessor, whenClauses: string[]) => {
+	return whenClauses.map(whenClause => {
+		const r = ContextKeyExpr.deserializeOrErrorNew(whenClause);
+		switch (r.type) {
+			case 'ok':
+				return undefined;
+			case 'error': {
+				const errMsg = [localize('_parseWhenExpressions', "Error parsing when clause: \n")];
+				if (r.lexingErrors.length > 0) {
+					errMsg.push(...r.lexingErrors);
+				} else if (r.parsingErrors.length > 0) {
+					errMsg.push(...r.parsingErrors);
+				} else {
+					return undefined;
+				}
+				return errMsg.join('\n');
+			}
+		}
+	});
 });

--- a/src/vs/platform/contextkey/browser/contextKeyService.ts
+++ b/src/vs/platform/contextkey/browser/contextKeyService.ts
@@ -14,8 +14,7 @@ import { URI } from 'vs/base/common/uri';
 import { localize } from 'vs/nls';
 import { CommandsRegistry } from 'vs/platform/commands/common/commands';
 import { ConfigurationTarget, IConfigurationService } from 'vs/platform/configuration/common/configuration';
-import { ContextKeyExpression, ContextKeyInfo, ContextKeyValue, IContext, IContextKey, IContextKeyChangeEvent, IContextKeyService, IContextKeyServiceTarget, IReadableSet, Parser, ParsingError, RawContextKey } from 'vs/platform/contextkey/common/contextkey';
-import { LexingError } from 'vs/platform/contextkey/common/scanner';
+import { ContextKeyExpression, ContextKeyInfo, ContextKeyValue, IContext, IContextKey, IContextKeyChangeEvent, IContextKeyService, IContextKeyServiceTarget, IReadableSet, RawContextKey } from 'vs/platform/contextkey/common/contextkey';
 import { ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
 
 const KEYBINDING_CONTEXT_ATTR = 'data-keybinding-context';
@@ -644,38 +643,4 @@ CommandsRegistry.registerCommand('_generateContextKeyInfo', function () {
 	}
 	result.sort((a, b) => a.key.localeCompare(b.key));
 	console.log(JSON.stringify(result, undefined, 2));
-});
-
-CommandsRegistry.registerCommand('_parseWhenClausesForErrors', (_accessor: ServicesAccessor, whenClauses: string[]): { errorMessage: string; offset: number; length: number }[][] => {
-
-	const parser = new Parser({ regexParsingWithErrorRecovery: false });
-
-	return whenClauses.map(whenClause => {
-		parser.parse(whenClause);
-
-		if (parser.lexingErrors.length > 0) {
-			return parser.lexingErrors.map((se: LexingError) => {
-				return {
-					errorMessage: se.additionalInfo ?
-						localize('contextkey.scanner.errorForLinterWithHint', "Unexpected token. Hint: {0}", se.additionalInfo) :
-						localize('contextkey.scanner.errorForLinter', "Unexpected token."),
-					offset: se.offset,
-					length: se.lexeme.length,
-				};
-			});
-		} else if (parser.parsingErrors.length > 0) {
-			return parser.parsingErrors.map((pe: ParsingError) => {
-				return {
-					errorMessage:
-						pe.additionalInfo ?
-							localize('contextkey.parser.errorForLinterWithHint', "{0}. {1}", pe.message, pe.additionalInfo) :
-							pe.message,
-					offset: pe.offset,
-					length: pe.lexeme.length,
-				};
-			});
-		} else {
-			return [];
-		}
-	});
 });

--- a/src/vs/platform/contextkey/common/contextkey.ts
+++ b/src/vs/platform/contextkey/common/contextkey.ts
@@ -716,6 +716,33 @@ export class Parser {
 	}
 }
 
+export function validateWhenClauses(whenClauses: string[]): any {
+
+	const parser = new Parser({ regexParsingWithErrorRecovery: false }); // we run with no recovery to guide users to use correct regexes
+
+	return whenClauses.map(whenClause => {
+		parser.parse(whenClause);
+
+		if (parser.lexingErrors.length > 0) {
+			return parser.lexingErrors.map((se: LexingError) => ({
+				errorMessage: se.additionalInfo ?
+					localize('contextkey.scanner.errorForLinterWithHint', "Unexpected token. Hint: {0}", se.additionalInfo) :
+					localize('contextkey.scanner.errorForLinter', "Unexpected token."),
+				offset: se.offset,
+				length: se.lexeme.length,
+			}));
+		} else if (parser.parsingErrors.length > 0) {
+			return parser.parsingErrors.map((pe: ParsingError) => ({
+				errorMessage: pe.additionalInfo ? `${pe.message}. ${pe.additionalInfo}` : pe.message,
+				offset: pe.offset,
+				length: pe.lexeme.length,
+			}));
+		} else {
+			return [];
+		}
+	});
+}
+
 export function expressionsAreEqualWithConstantSubstitution(a: ContextKeyExpression | null | undefined, b: ContextKeyExpression | null | undefined): boolean {
 	const aExpr = a ? a.substituteConstants() : undefined;
 	const bExpr = b ? b.substituteConstants() : undefined;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This implements linting for when-clauses. 

<img width="1266" alt="image" src="https://user-images.githubusercontent.com/16353531/220191790-c79ed202-59dd-4375-af75-b181bf418060.png">

Depends on #175530

TODO:

- [x] `when` clauses in package.json's
- [x] `enablement` clauses in package.json's
- [x] errors specific to range of error (currently we report offset within the string rather than within the file)

- [x] `when` clauses in keybindings.json's (let's make it in another PR after discussions where it fits) 