### PR TITLE
Changing hc-white to hc-light, wrong classname is used for light contrast theme 

### DIFF
--- a/src/vs/editor/contrib/stickyScroll/browser/stickyScroll.css
+++ b/src/vs/editor/contrib/stickyScroll/browser/stickyScroll.css
@@ -23,7 +23,7 @@
 }
 
 .monaco-editor.hc-black .sticky-widget,
-.monaco-editor.hc-white .sticky-widget {
+.monaco-editor.hc-light .sticky-widget {
 	border-bottom: 1px solid var(--vscode-contrastBorder);
 }
 


### PR DESCRIPTION
Fixes: #172570

Change hc-white to hc-light