### PR TITLE
Cannot toggle shared process when `window.experimental.sharedProcessUseUtilityProcess: true` (fix #174960)

### DIFF
--- a/src/vs/workbench/electron-sandbox/actions/developerActions.ts
+++ b/src/vs/workbench/electron-sandbox/actions/developerActions.ts
@@ -16,6 +16,7 @@ import { KeyCode, KeyMod } from 'vs/base/common/keyCodes';
 import { IFileService } from 'vs/platform/files/common/files';
 import { INativeWorkbenchEnvironmentService } from 'vs/workbench/services/environment/electron-sandbox/environmentService';
 import { URI } from 'vs/base/common/uri';
+import { ContextKeyExpr } from 'vs/platform/contextkey/common/contextkey';
 
 export class ToggleDevToolsAction extends Action2 {
 
@@ -75,6 +76,7 @@ export class ToggleSharedProcessAction extends Action2 {
 			id: 'workbench.action.toggleSharedProcess',
 			title: { value: localize('toggleSharedProcess', "Toggle Shared Process"), original: 'Toggle Shared Process' },
 			category: Categories.Developer,
+			precondition: ContextKeyExpr.has('config.window.experimental.sharedProcessUseUtilityProcess').negate(),
 			f1: true
 		});
 	}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
