### PR TITLE
Quick Diff selection dropdown is not keyboard accessible

### DIFF
--- a/src/vs/workbench/contrib/scm/browser/dirtyDiffSwitcher.ts
+++ b/src/vs/workbench/contrib/scm/browser/dirtyDiffSwitcher.ts
@@ -47,6 +47,11 @@ export class SwitchQuickDiffViewItem extends SelectActionViewItem<IQuickDiffSele
 	protected override getActionContext(_: string, index: number): IQuickDiffSelectItem {
 		return this.optionsItems[index];
 	}
+
+	override render(container: HTMLElement): void {
+		super.render(container);
+		this.setFocusable(true);
+	}
 }
 
 export class SwitchQuickDiffBaseAction extends Action {


### PR DESCRIPTION
Fixes #174926