### PR TITLE
Allow IExternalUriResolver to return URI or URL

### DIFF
--- a/src/vs/editor/browser/services/openerService.ts
+++ b/src/vs/editor/browser/services/openerService.ts
@@ -103,7 +103,7 @@ export class OpenerService implements IOpenerService {
 	private readonly _openers = new LinkedList<IOpener>();
 	private readonly _validators = new LinkedList<IValidator>();
 	private readonly _resolvers = new LinkedList<IExternalUriResolver>();
-	private readonly _resolvedUriTargets = new ResourceMap<URI>(uri => uri.with({ path: null, fragment: null, query: null }).toString());
+	private readonly _resolvedUriTargets = new ResourceMap<URI | URL>(uri => uri.with({ path: null, fragment: null, query: null }).toString());
 
 	private _defaultExternalOpener: IExternalOpener;
 	private readonly _externalOpeners = new LinkedList<IExternalOpener>();
@@ -171,7 +171,8 @@ export class OpenerService implements IOpenerService {
 		// check with contributed validators
 		const targetURI = typeof target === 'string' ? URI.parse(target) : target;
 		// validate against the original URI that this URI resolves to, if one exists
-		const validationTarget = this._resolvedUriTargets.get(targetURI) ?? target;
+		const resolvedTarget = this._resolvedUriTargets.get(targetURI);
+		const validationTarget = (resolvedTarget instanceof URL ? resolvedTarget.toString() : resolvedTarget) ?? target;
 		for (const validator of this._validators) {
 			if (!(await validator.shouldOpen(validationTarget, options))) {
 				return false;
@@ -194,8 +195,9 @@ export class OpenerService implements IOpenerService {
 			try {
 				const result = await resolver.resolveExternalUri(resource, options);
 				if (result) {
-					if (!this._resolvedUriTargets.has(result.resolved)) {
-						this._resolvedUriTargets.set(result.resolved, resource);
+					const resolved = result.resolved instanceof URL ? URI.parse(result.resolved.toString()) : result.resolved;
+					if (!this._resolvedUriTargets.has(resolved)) {
+						this._resolvedUriTargets.set(resolved, result.resolved);
 					}
 					return result;
 				}
@@ -211,7 +213,7 @@ export class OpenerService implements IOpenerService {
 
 		//todo@jrieken IExternalUriResolver should support `uri: URI | string`
 		const uri = typeof resource === 'string' ? URI.parse(resource) : resource;
-		let externalUri: URI;
+		let externalUri: URI | URL;
 
 		try {
 			externalUri = (await this.resolveExternalUri(uri, options)).resolved;
@@ -223,9 +225,11 @@ export class OpenerService implements IOpenerService {
 		if (typeof resource === 'string' && uri.toString() === externalUri.toString()) {
 			// open the url-string AS IS
 			href = resource;
-		} else {
+		} else if (externalUri instanceof URI) {
 			// open URI using the toString(noEncode)+encodeURI-trick
 			href = encodeURI(externalUri.toString(true));
+		} else {
+			href = externalUri.toString();
 		}
 
 		if (options?.allowContributedOpeners) {

--- a/src/vs/platform/opener/common/opener.ts
+++ b/src/vs/platform/opener/common/opener.ts
@@ -51,7 +51,7 @@ export type OpenOptions = OpenInternalOptions & OpenExternalOptions;
 export type ResolveExternalUriOptions = { readonly allowTunneling?: boolean };
 
 export interface IResolvedExternalUri extends IDisposable {
-	resolved: URI;
+	resolved: URI | URL;
 }
 
 export interface IOpener {
@@ -68,7 +68,7 @@ export interface IValidator {
 }
 
 export interface IExternalUriResolver {
-	resolveExternalUri(resource: URI, options?: OpenOptions): Promise<{ resolved: URI; dispose(): void } | undefined>;
+	resolveExternalUri(resource: URI, options?: OpenOptions): Promise<{ resolved: URI | URL; dispose(): void } | undefined>;
 }
 
 export interface IOpenerService {

--- a/src/vs/workbench/api/browser/mainThreadWindow.ts
+++ b/src/vs/workbench/api/browser/mainThreadWindow.ts
@@ -55,6 +55,6 @@ export class MainThreadWindow implements MainThreadWindowShape {
 
 	async $asExternalUri(uriComponents: UriComponents, options: IOpenUriOptions): Promise<UriComponents> {
 		const result = await this.openerService.resolveExternalUri(URI.revive(uriComponents), options);
-		return result.resolved;
+		return result.resolved instanceof URL ? URI.parse(result.resolved.toString()) : result.resolved;
 	}
 }

--- a/src/vs/workbench/browser/web.api.ts
+++ b/src/vs/workbench/browser/web.api.ts
@@ -348,7 +348,7 @@ export interface ICommonTelemetryPropertiesResolver {
 }
 
 export interface IExternalUriResolver {
-	(uri: URI): Promise<URI>;
+	(uri: URI): Promise<URI | URL>;
 }
 
 export interface IExternalURLOpener {


### PR DESCRIPTION
Fixes #175164

Allow IExternalUriResolver to return URI or URL, this is backwards compatible for current web embedders and will allow to properly open a resolved uri that currently fails if we return a URI

cc @jrieken 