### PR TITLE
Removing the sorting options type that was added into vscode.d.ts

### DIFF
--- a/src/vscode-dts/vscode.d.ts
+++ b/src/vscode-dts/vscode.d.ts
@@ -4077,27 +4077,6 @@ declare module 'vscode' {
 	/**
 	 * Value-object describing what options formatting should use.
 	 */
-	export interface SortingOptions {
-
-		/**
-		 * Size of a tab in spaces.
-		 */
-		tabSize: number;
-
-		/**
-		 * Prefer spaces over tabs.
-		 */
-		insertSpaces: boolean;
-
-		/**
-		 * Signature for further properties.
-		 */
-		[key: string]: boolean | number | string;
-	}
-
-	/**
-	 * Value-object describing what options formatting should use.
-	 */
 	export interface FormattingOptions {
 
 		/**


### PR DESCRIPTION
Fixes #175243.

Removing the useless type
