### PR TITLE
Support msys2 git (fix absolute paths)

### DIFF
--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -473,10 +473,11 @@ export class Git {
 	}
 
 	async getRepositoryRoot(repositoryPath: string): Promise<string> {
-		const result = await this.exec(repositoryPath, ['rev-parse', '--show-toplevel']);
+		// Use relative path due to discrepancies in how different Git distributions format absolute paths
+		const result = await this.exec(repositoryPath, ['rev-parse', '--path-format=relative', '--show-toplevel']);
 
 		// Keep trailing spaces which are part of the directory name
-		const repoPath = path.normalize(result.stdout.trimLeft().replace(/[\r\n]+$/, ''));
+		const repoPath = path.normalize(path.resolve(repositoryPath, result.stdout.trimLeft().replace(/[\r\n]+$/, '')));
 
 		if (isWindows) {
 			// On Git 2.25+ if you call `rev-parse --show-toplevel` on a mapped drive, instead of getting the mapped


### PR DESCRIPTION
msys2 git returns absolute paths like "/c/Users/johnv/...". Git for Windows returns absolute paths like C:\Users\johnv\...". To support both (and likely Cygwin git as well), relative paths are requested from git and then made absolute with path.resolve().

This fixes #143165

To test, install both Git for Windows & msys2 git

- Git for Windows: <https://gitforwindows.org>
- msys2: <https://www.msys2.org/#installation>

After installing msys2, install msys2 git with `pacman -S git`.

Once both `git`s are installed, vscode git integration should work with either of the following User `settings.json` configs (vscode restart required when switching):

```
{
    "git.path": "C:\\Program Files\\Git\\cmd\\git.exe"
    //"git.path": "C:\\msys64\\usr\\bin\\git.exe"
}
```

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
