### PR TITLE
define our custom `prepareStackTrace` as getter/setter so that it survises subsequent reassignments

### DIFF
--- a/src/vs/workbench/api/common/extensionHostMain.ts
+++ b/src/vs/workbench/api/common/extensionHostMain.ts
@@ -67,9 +67,10 @@ abstract class ErrorHandler {
 		const map = await extensionService.getExtensionPathIndex();
 		const extensionErrors = new WeakMap<Error, ExtensionIdentifier | undefined>();
 
+		// PART 1
 		// set the prepareStackTrace-handle and use it as a side-effect to associate errors
 		// with extensions - this works by looking up callsites in the extension path index
-		(<any>Error).prepareStackTrace = (error: Error, stackTrace: errors.V8CallSite[]) => {
+		function prepareStackTraceAndFindExtension(error: Error, stackTrace: errors.V8CallSite[]) {
 			let stackTraceMessage = '';
 			let extension: IExtensionDescription | undefined;
 			let fileName: string | null;
@@ -82,8 +83,26 @@ abstract class ErrorHandler {
 			}
 			extensionErrors.set(error, extension?.identifier);
 			return `${error.name || 'Error'}: ${error.message || ''}${stackTraceMessage}`;
-		};
+		}
 
+		let _prepareStackTrace = prepareStackTraceAndFindExtension;
+		Object.defineProperty(Error, 'prepareStackTrace', {
+			configurable: false,
+			get() {
+				return _prepareStackTrace;
+			},
+			set(v) {
+				_prepareStackTrace = function (error, stackTrace) {
+					prepareStackTraceAndFindExtension(error, stackTrace);
+					return v.call(Error, error, stackTrace);
+				};
+			},
+		});
+
+		// PART 2
+		// set the unexpectedErrorHandler and check for extensions that have been identified as
+		// having caused the error. Note that the runtime order is actually reversed, the code
+		// below accesses the stack-property which triggers the code above
 		errors.setUnexpectedErrorHandler(err => {
 			logService.error(err);
 


### PR DESCRIPTION
fixes https://github.com/microsoft/vscode/issues/175288
