### PR TITLE
Fix find highlight background in Light+ V2

### DIFF
--- a/extensions/theme-defaults/themes/light_plus_experimental.json
+++ b/extensions/theme-defaults/themes/light_plus_experimental.json
@@ -31,7 +31,6 @@
 		"dropdown.foreground": "#3b3b3b",
 		"dropdown.listBackground": "#ffffff",
 		"editor.background": "#ffffff",
-		"editor.findMatchBackground": "#9e6a03",
 		"editor.foreground": "#3b3b3b",
 		"editor.inactiveSelectionBackground": "#E5EBF1",
 		"editor.selectionHighlightBackground": "#ADD6FF80",


### PR DESCRIPTION
Fix #173663

## Before

<img width="180" alt="CleanShot 2023-02-24 at 10 25 47@2x" src="https://user-images.githubusercontent.com/25163139/221260020-ff7fd401-7f86-4e07-a903-59ee86697b74.png">

## After

<img width="205" alt="CleanShot 2023-02-24 at 10 24 36@2x" src="https://user-images.githubusercontent.com/25163139/221259956-22646f15-8cd9-48d7-81dc-1dd6a518d3aa.png">
