### PR TITLE
use error cue instead of task failed for terminal command failure

### DIFF
--- a/src/vs/platform/audioCues/browser/audioCueService.ts
+++ b/src/vs/platform/audioCues/browser/audioCueService.ts
@@ -296,7 +296,7 @@ export class AudioCue {
 
 	public static readonly terminalCommandFailed = AudioCue.register({
 		name: localize('audioCues.terminalCommandFailed', 'Terminal Command Failed'),
-		sound: Sound.taskFailed,
+		sound: Sound.error,
 		settingsKey: 'audioCues.terminalCommandFailed'
 	});
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
fix #175012