### PR TITLE
fix selection/focus separation on search

### DIFF
--- a/src/vs/workbench/contrib/search/browser/searchView.ts
+++ b/src/vs/workbench/contrib/search/browser/searchView.ts
@@ -1642,6 +1642,7 @@ export class SearchView extends ViewPane {
 		this.searchWidget.setReplaceAllActionState(false);
 
 		this.tree.setSelection([]);
+		this.tree.setFocus([]);
 		return this.viewModel.search(query)
 			.then(onComplete, onError);
 	}


### PR DESCRIPTION
Fixes #172894

Now, if you run `search.action.focusSearchList` while the search is loading, you should always see file previews.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
