### PR TITLE
Fix cannot specify custom path for built-in profiles on Windows

### DIFF
--- a/src/vs/platform/terminal/common/terminalPlatformConfiguration.ts
+++ b/src/vs/platform/terminal/common/terminalPlatformConfiguration.ts
@@ -287,7 +287,7 @@ const terminalPlatformConfiguration: IConfigurationNode = {
 						required: ['source'],
 						properties: {
 							source: {
-								description: localize('terminalProfile.windowsSource', 'A profile source that will auto detect the paths to the shell. Note that non-standard executable locations are not supported and must be created manually in a new profile.'),
+								description: localize('terminalProfile.windowsSource', 'A profile source that will auto detect the paths to the shell. Override built-in defaults by adding a profile with the same name and a path specified.'),
 								enum: ['PowerShell', 'Git Bash']
 							},
 							...terminalProfileBaseProperties

--- a/src/vs/platform/terminal/common/terminalPlatformConfiguration.ts
+++ b/src/vs/platform/terminal/common/terminalPlatformConfiguration.ts
@@ -287,7 +287,7 @@ const terminalPlatformConfiguration: IConfigurationNode = {
 						required: ['source'],
 						properties: {
 							source: {
-								description: localize('terminalProfile.windowsSource', 'A profile source that will auto detect the paths to the shell. Override built-in defaults by adding a profile with the same name and a path specified.'),
+								description: localize('terminalProfile.windowsSource', 'A profile source that will auto detect the paths to the shell. Note that non-standard executable locations are not supported and must be created manually in a new profile.'),
 								enum: ['PowerShell', 'Git Bash']
 							},
 							...terminalProfileBaseProperties

--- a/src/vs/platform/terminal/node/terminalProfiles.ts
+++ b/src/vs/platform/terminal/node/terminalProfiles.ts
@@ -172,16 +172,13 @@ async function transformToTerminalProfiles(
 		let originalPaths: (string | ITerminalUnsafePath)[];
 		let args: string[] | string | undefined;
 		let icon: ThemeIcon | URI | { light: URI; dark: URI } | undefined = undefined;
-		if ('source' in profile) {
+		// if there are configured args, override the default ones
+		if ('source' in profile && !('path' in profile)) {
 			const source = profileSources?.get(profile.source);
 			if (!source) {
 				continue;
 			}
-			if (profile.path) {
-				originalPaths = Array.isArray(profile.path) ? profile.path : [profile.path];
-			} else {
-				originalPaths = source.paths;
-			}
+			originalPaths = source.paths;
 			// if there are configured args, override the default ones
 			args = profile.args || source.args;
 			if (profile.icon) {

--- a/src/vs/platform/terminal/node/terminalProfiles.ts
+++ b/src/vs/platform/terminal/node/terminalProfiles.ts
@@ -172,7 +172,7 @@ async function transformToTerminalProfiles(
 		let originalPaths: (string | ITerminalUnsafePath)[];
 		let args: string[] | string | undefined;
 		let icon: ThemeIcon | URI | { light: URI; dark: URI } | undefined = undefined;
-		// if there are configured args, override the default ones
+		// use calculated values if path is not specified
 		if ('source' in profile && !('path' in profile)) {
 			const source = profileSources?.get(profile.source);
 			if (!source) {

--- a/src/vs/platform/terminal/node/terminalProfiles.ts
+++ b/src/vs/platform/terminal/node/terminalProfiles.ts
@@ -177,8 +177,11 @@ async function transformToTerminalProfiles(
 			if (!source) {
 				continue;
 			}
-			originalPaths = source.paths;
-
+			if (profile.path) {
+				originalPaths = Array.isArray(profile.path) ? profile.path : [profile.path];
+			} else {
+				originalPaths = source.paths;
+			}
 			// if there are configured args, override the default ones
 			args = profile.args || source.args;
 			if (profile.icon) {

--- a/src/vs/platform/terminal/node/terminalProfiles.ts
+++ b/src/vs/platform/terminal/node/terminalProfiles.ts
@@ -179,6 +179,7 @@ async function transformToTerminalProfiles(
 				continue;
 			}
 			originalPaths = source.paths;
+
 			// if there are configured args, override the default ones
 			args = profile.args || source.args;
 			if (profile.icon) {


### PR DESCRIPTION
Fix paths misconfigured if build-in profile with same name exists

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
