### PR TITLE
when-clause parser improvements/fixes

### DIFF
--- a/src/vs/platform/contextkey/common/contextkey.ts
+++ b/src/vs/platform/contextkey/common/contextkey.ts
@@ -328,7 +328,7 @@ export class Parser {
 	// ContextKeyExpression's that we use as AST nodes do not expose constructors that do not normalize
 
 	// lifetime note: `_scanner` lives as long as the parser does, i.e., is not reset between calls to `parse`
-	private _scanner = new Scanner();
+	private readonly _scanner = new Scanner();
 
 	// lifetime note: `_tokens`, `_current`, and `_parsingErrors` must be reset between calls to `parse`
 	private _tokens: Token[] = [];
@@ -343,7 +343,7 @@ export class Parser {
 		return this._parsingErrors;
 	}
 
-	constructor(private _config: ParserConfig = defaultConfig) {
+	constructor(private readonly _config: ParserConfig = defaultConfig) {
 	}
 
 	/**

--- a/src/vs/platform/contextkey/common/contextkey.ts
+++ b/src/vs/platform/contextkey/common/contextkey.ts
@@ -577,6 +577,9 @@ export class Parser {
 						this._advance();
 
 						const right = this._value();
+						if (this._previous().type === TokenType.QuotedStr) { // to preserve old parser behavior: "foo == 'true'" is preserved as "foo == 'true'", but "foo == true" is optimized as "foo"
+							return ContextKeyExpr.equals(key, right);
+						}
 						switch (right) {
 							case 'true':
 								return ContextKeyExpr.has(key);
@@ -591,6 +594,9 @@ export class Parser {
 						this._advance();
 
 						const right = this._value();
+						if (this._previous().type === TokenType.QuotedStr) { // same as above with "foo != 'true'"
+							return ContextKeyExpr.notEquals(key, right);
+						}
 						switch (right) {
 							case 'true':
 								return ContextKeyExpr.not(key);

--- a/src/vs/platform/contextkey/common/contextkey.ts
+++ b/src/vs/platform/contextkey/common/contextkey.ts
@@ -126,23 +126,6 @@ export abstract class ContextKeyExpr {
 		return ContextKeySmallerEqualsExpr.create(key, value);
 	}
 
-	/**
-	 * Warning: experimental; the API might change.
-	 */
-	public static deserializeOrErrorNew(serialized: string | null | undefined): { type: 'ok'; expr: ContextKeyExpression } | { type: 'error'; readonly lexingErrors: string[]; readonly parsingErrors: readonly string[] } {
-		if (!serialized) {
-			return { type: 'error', lexingErrors: [], parsingErrors: [] };
-		}
-
-		const parser = new Parser();
-		const expr = parser.parse(serialized);
-		if (expr === undefined) {
-			return { type: 'error', lexingErrors: parser.lexingErrors.map(token => Scanner.reportError(token)), parsingErrors: parser.parsingErrors };
-		} else {
-			return { type: 'ok', expr };
-		}
-	}
-
 	public static deserialize(serialized: string | null | undefined): ContextKeyExpression | undefined {
 		if (!serialized) {
 			return undefined;

--- a/src/vs/platform/contextkey/common/contextkey.ts
+++ b/src/vs/platform/contextkey/common/contextkey.ts
@@ -520,7 +520,12 @@ export class Parser {
 							const regexLexeme = lexemeReconstruction.join('');
 							const closingSlashIndex = regexLexeme.lastIndexOf('/');
 							const flags = closingSlashIndex === regexLexeme.length - 1 ? undefined : regexLexeme.substring(closingSlashIndex + 1);
-							const regexp = new RegExp(regexLexeme.substring(1, closingSlashIndex), flags);
+							let regexp: RegExp | null;
+							try {
+								regexp = new RegExp(regexLexeme.substring(1, closingSlashIndex), flags);
+							} catch (e) {
+								throw this._errExpectedButGot(`REGEX`, expr);
+							}
 							return ContextKeyExpr.regex(key, regexp);
 						}
 
@@ -541,7 +546,7 @@ export class Parser {
 									try {
 										regex = new RegExp(value, caseIgnoreFlag);
 									} catch (_e) {
-										// FIXME@ulugbekna - handle error
+										throw this._errExpectedButGot(`REGEX`, expr);
 									}
 								}
 							}

--- a/src/vs/platform/contextkey/common/contextkey.ts
+++ b/src/vs/platform/contextkey/common/contextkey.ts
@@ -7,8 +7,9 @@ import { CharCode } from 'vs/base/common/charCode';
 import { Event } from 'vs/base/common/event';
 import { isChrome, isEdge, isFirefox, isLinux, isMacintosh, isSafari, isWeb, isWindows } from 'vs/base/common/platform';
 import { isFalsyOrWhitespace } from 'vs/base/common/strings';
-import { Scanner, Token, TokenType } from 'vs/platform/contextkey/common/scanner';
+import { Scanner, LexingError, Token, TokenType } from 'vs/platform/contextkey/common/scanner';
 import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
+import { localize } from 'vs/nls';
 
 const CONSTANT_VALUES = new Map<string, boolean>();
 CONSTANT_VALUES.set('false', false);
@@ -254,21 +255,21 @@ or ::= and { '||' and }*
 and ::= term { '&&' term }*
 
 term ::=
-	| '!' (KEY | 'true' | 'false')
+	| '!' (CONTEXT | 'true' | 'false') // we do not yet support negation of arbitrary expressions
 	| primary
 
 primary ::=
 	| 'true'
 	| 'false'
 	| '(' expression ')'
-	| KEY '=~' REGEX
-	| KEY [ ('==' | '!=' | '<' | '<=' | '>' | '>=' | 'not' 'in' | 'in') value ]
+	| CONTEXT '=~' REGEX
+	| CONTEXT [ ('==' | '!=' | '<' | '<=' | '>' | '>=' | 'not' 'in' | 'in') value ]
 
 value ::=
 	| 'true'
 	| 'false'
-	| 'in'      	// we support `in` as a value because there's an extension that uses it, ie "when": "languageId = in"
-	| KEY
+	| 'in'      	// we support `in` as a value because there's an extension that uses it, ie "when": "languageId == in"
+	| VALUE 		// matched by the same regex as CONTEXT; consider putting the value in single quotes if it's a string (e.g., with spaces)
 	| SINGLE_QUOTED_STR
 	| EMPTY_STR  	// this allows "when": "foo == " which's used by existing extensions
 
@@ -276,14 +277,34 @@ value ::=
 */
 
 export type ParserConfig = {
+	/**
+	 * with this option enabled, the parser can recover from regex parsing errors, e.g., unescaped slashes: `/src//` is accepted as `/src\//` would be
+	 */
 	regexParsingWithErrorRecovery: boolean;
 };
 
 const defaultConfig: ParserConfig = {
-	regexParsingWithErrorRecovery: true // with this option enabled, the parser can recover from regex parsing errors, e.g., unescaped slashes
+	regexParsingWithErrorRecovery: true
 };
 
 class ParseError extends Error { }
+
+export type ParsingError = {
+	message: string;
+	offset: number;
+	lexeme: string;
+	additionalInfo?: string;
+};
+
+const errorEmptyString = localize('contextkey.parser.error.emptyString', "Empty context key expression");
+const hintEmptyString = localize('contextkey.parser.error.emptyString.hint', "Did you forget to write an expression? You can also put 'false' or 'true' to always evaluate to false or true, respectively.");
+const errorDontSupportArbitraryNegation = localize('contextkey.parser.error.dontSupportArbitraryNegation', "Negation of arbitrary expressions is not supported.");
+const errorNoInAfterNot = localize('contextkey.parser.error.noInAfterNot', "'in' after 'not'.");
+const errorClosingParenthesis = localize('contextkey.parser.error.closingParenthesis', "closing parenthesis ')'");
+const errorUnexpectedToken = localize('contextkey.parser.error.unexpectedToken', "Unexpected token");
+const hintUnexpectedToken = localize('contextkey.parser.error.unexpectedToken.hint', "Did you forget to put && or || before the token?");
+const errorUnexpectedEOF = localize('contextkey.parser.error.unexpectedEOF', "Unexpected end of expression");
+const hintUnexpectedEOF = localize('contextkey.parser.error.unexpectedEOF.hint', "Did you forget to put a context key?");
 
 /**
  * A parser for context key expressions.
@@ -312,13 +333,13 @@ export class Parser {
 	// lifetime note: `_tokens`, `_current`, and `_parsingErrors` must be reset between calls to `parse`
 	private _tokens: Token[] = [];
 	private _current = 0; 					// invariant: 0 <= this._current < this._tokens.length ; any incrementation of this value must first call `_isAtEnd`
-	private _parsingErrors: string[] = [];
+	private _parsingErrors: ParsingError[] = [];
 
-	get lexingErrors(): Readonly<Token[]> {
-		return this._scanner.errorTokens;
+	get lexingErrors(): Readonly<LexingError[]> {
+		return this._scanner.errors;
 	}
 
-	get parsingErrors(): Readonly<string[]> {
+	get parsingErrors(): Readonly<ParsingError[]> {
 		return this._parsingErrors;
 	}
 
@@ -334,12 +355,12 @@ export class Parser {
 	parse(input: string): ContextKeyExpression | undefined {
 
 		if (input === '') {
-			this._parsingErrors.push('Expected an expression but got an empty string');
+			this._parsingErrors.push({ message: errorEmptyString, offset: 0, lexeme: '', additionalInfo: hintEmptyString });
 			return undefined;
 		}
 
 		this._tokens = this._scanner.reset(input).scan();
-		// @ulugbekna: we do not stop parsing if there are lexing errors to be able to reconstruct regexes with unescaped slashes
+		// @ulugbekna: we do not stop parsing if there are lexing errors to be able to reconstruct regexes with unescaped slashes; TODO@ulugbekna: make this respect config option for recovery
 
 		this._current = 0;
 		this._parsingErrors = [];
@@ -347,13 +368,15 @@ export class Parser {
 		try {
 			const expr = this._expr();
 			if (!this._isAtEnd()) {
-				throw this._errUnexpected(this._peek());
+				const peek = this._peek();
+				const additionalInfo = peek.type === TokenType.Str ? hintUnexpectedToken : undefined;
+				this._parsingErrors.push({ message: errorUnexpectedToken, offset: peek.offset, lexeme: Scanner.getLexeme(peek), additionalInfo });
+				throw new ParseError();
 			}
 			return expr;
 		} catch (e) {
 			if (!(e instanceof ParseError)) {
-				const token = this._peek();
-				this._parsingErrors.push(`Unexpected error: ${e} for token ${Scanner.getLexeme(token)} at offset ${token.offset}.`);
+				throw e;
 			}
 			return undefined;
 		}
@@ -399,7 +422,7 @@ export class Parser {
 					this._advance();
 					return ContextKeyExpr.true();
 				default:
-					throw this._errExpectedButGot(`KEY, 'true', or 'false'`, expr);
+					throw this._errExpectedButGot('CONTEXT | true | false', expr, errorDontSupportArbitraryNegation);
 			}
 		}
 		return this._primary();
@@ -420,12 +443,12 @@ export class Parser {
 			case TokenType.LParen: {
 				this._advance();
 				const expr = this._expr();
-				this._consume(TokenType.RParen, `')'`);
+				this._consume(TokenType.RParen, errorClosingParenthesis);
 				return expr;
 			}
 
 			case TokenType.Str: {
-				// KEY
+				// CONTEXT
 				const key = peek.lexeme;
 				this._advance();
 
@@ -443,8 +466,13 @@ export class Parser {
 						const regexLexeme = expr.lexeme;
 						const closingSlashIndex = regexLexeme.lastIndexOf('/');
 						const flags = closingSlashIndex === regexLexeme.length - 1 ? undefined : regexLexeme.substring(closingSlashIndex + 1);
-						const regexp = new RegExp(regexLexeme.substring(1, closingSlashIndex), flags);
-						return ContextKeyExpr.regex(key, regexp);
+						let regexp: RegExp | null;
+						try {
+							regexp = new RegExp(regexLexeme.substring(1, closingSlashIndex), flags);
+						} catch (e) {
+							throw this._errExpectedButGot(`REGEX`, expr);
+						}
+						return ContextKeyRegexExpr.create(key, regexp);
 					}
 
 					switch (expr.type) {
@@ -512,7 +540,9 @@ export class Parser {
 									const caseIgnoreFlag = serializedValue[end + 1] === 'i' ? 'i' : '';
 									try {
 										regex = new RegExp(value, caseIgnoreFlag);
-									} catch (_e) { }
+									} catch (_e) {
+										// FIXME@ulugbekna - handle error
+									}
 								}
 							}
 
@@ -530,7 +560,7 @@ export class Parser {
 
 				// [ 'not' 'in' value ]
 				if (this._matchOne(TokenType.Not)) {
-					this._consume(TokenType.In, `'in' after 'not'`);
+					this._consume(TokenType.In, errorNoInAfterNot);
 					const right = this._value();
 					return ContextKeyExpr.notIn(key, right);
 				}
@@ -592,8 +622,12 @@ export class Parser {
 				}
 			}
 
+			case TokenType.EOF:
+				this._parsingErrors.push({ message: errorUnexpectedEOF, offset: peek.offset, lexeme: '', additionalInfo: hintUnexpectedEOF });
+				throw new ParseError();
+
 			default:
-				throw this._errExpectedButGot(`'true', 'false', '(', KEY, KEY '=~' regex, KEY [ ('==' | '!=' | '<' | '<=' | '>' | '>=' | 'in' | 'not' 'in') value ]`, this._peek());
+				throw this._errExpectedButGot(`true | false | CONTEXT \n\t| CONTEXT '=~' REGEX \n\t| CONTEXT ('==' | '!=' | '<' | '<=' | '>' | '>=' | 'in' | 'not' 'in') value`, this._peek());
 
 		}
 	}
@@ -650,17 +684,11 @@ export class Parser {
 		throw this._errExpectedButGot(message, this._peek());
 	}
 
-	private _errExpectedButGot(expected: string, got: Token) {
-		return this._error(`Expected ${expected} but got '${Scanner.getLexeme(got)}' at offset ${got.offset}.`);
-	}
-
-	private _errUnexpected(token: Token) {
-		return this._error(`Unexpected '${Scanner.getLexeme(token)}' at offset ${token.offset}.`);
-	}
-
-	// TODO@ulugbekna: the whole error reporting needs reworking - especially, when we introduce it to package.json linting
-	private _error(errMsg: string) {
-		this._parsingErrors.push(errMsg);
+	private _errExpectedButGot(expected: string, got: Token, additionalInfo?: string) {
+		const message = localize('contextkey.parser.error.expectedButGot', "Expected: {0}\nReceived: '{1}'.", expected, Scanner.getLexeme(got));
+		const offset = got.offset;
+		const lexeme = Scanner.getLexeme(got);
+		this._parsingErrors.push({ message, offset, lexeme, additionalInfo });
 		return new ParseError();
 	}
 

--- a/src/vs/platform/contextkey/common/contextkey.ts
+++ b/src/vs/platform/contextkey/common/contextkey.ts
@@ -275,6 +275,14 @@ value ::=
 ```
 */
 
+export type ParserConfig = {
+	regexParsingWithErrorRecovery: boolean;
+};
+
+const defaultConfig: ParserConfig = {
+	regexParsingWithErrorRecovery: true // with this option enabled, the parser can recover from regex parsing errors, e.g., unescaped slashes
+};
+
 class ParseError extends Error { }
 
 /**
@@ -312,6 +320,9 @@ export class Parser {
 
 	get parsingErrors(): Readonly<string[]> {
 		return this._parsingErrors;
+	}
+
+	constructor(private _config: ParserConfig = defaultConfig) {
 	}
 
 	/**
@@ -423,6 +434,19 @@ export class Parser {
 
 					// @ulugbekna: we need to reconstruct the regex from the tokens because some extensions use unescaped slashes in regexes
 					const expr = this._peek();
+
+					if (!this._config.regexParsingWithErrorRecovery) {
+						this._advance();
+						if (expr.type !== TokenType.RegexStr) {
+							throw this._errExpectedButGot(`REGEX`, expr);
+						}
+						const regexLexeme = expr.lexeme;
+						const closingSlashIndex = regexLexeme.lastIndexOf('/');
+						const flags = closingSlashIndex === regexLexeme.length - 1 ? undefined : regexLexeme.substring(closingSlashIndex + 1);
+						const regexp = new RegExp(regexLexeme.substring(1, closingSlashIndex), flags);
+						return ContextKeyExpr.regex(key, regexp);
+					}
+
 					switch (expr.type) {
 						case TokenType.RegexStr:
 						case TokenType.Error: { // also handle an ErrorToken in case of smth such as /(/file)/

--- a/src/vs/platform/contextkey/common/scanner.ts
+++ b/src/vs/platform/contextkey/common/scanner.ts
@@ -4,7 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { CharCode } from 'vs/base/common/charCode';
-import { illegalArgument, illegalState } from 'vs/base/common/errors';
+import { illegalState } from 'vs/base/common/errors';
+import { localize } from 'vs/nls';
 
 export const enum TokenType {
 	LParen,
@@ -73,6 +74,33 @@ type TokenTypeWithoutLexeme =
 	TokenType.Or |
 	TokenType.EOF;
 
+/**
+ * Example:
+ * `foo == bar'` - note how single quote doesn't have a corresponding closing quote,
+ * so it's reported as unexpected
+ */
+export type LexingError = {
+	offset: number; /** note that this doesn't take into account escape characters from the original encoding of the string, e.g., within an extension manifest file's JSON encoding  */
+	lexeme: string;
+	additionalInfo?: string;
+};
+
+function hintDidYouMean(...meant: string[]) {
+	switch (meant.length) {
+		case 1:
+			return localize('contextkey.scanner.hint.didYouMean1', "Did you mean {0}?", meant[0]);
+		case 2:
+			return localize('contextkey.scanner.hint.didYouMean2', "Did you mean {0} or {1}?", meant[0], meant[1]);
+		case 3:
+			return localize('contextkey.scanner.hint.didYouMean3', "Did you mean {0}, {1} or {2}?", meant[0], meant[1], meant[2]);
+		default: // we just don't expect that many
+			return undefined;
+	}
+}
+
+const hintDontSupportTripleEq = localize('contextkey.scanner.hint.dontSupportTripleEq', "The '===' operator is not supported. Use '==' instead.");
+const hintDidYouForgetToOpenOrCloseQuote = localize('contextkey.scanner.hint.didYouForgetToOpenOrCloseQuote', "Did you forget to open or close the quote?");
+const hintDidYouForgetToEscapeSlash = localize('contextkey.scanner.hint.didYouForgetToEscapeSlash', "Did you forget to escape the '/' (slash) character? Put two backslashes before it to escape, e.g., '\\\\/\'.");
 
 /**
  * A simple scanner for context keys.
@@ -83,41 +111,13 @@ type TokenTypeWithoutLexeme =
  * const scanner = new Scanner().reset('resourceFileName =~ /docker/ && !config.docker.enabled');
  * const tokens = [...scanner];
  * if (scanner.errorTokens.length > 0) {
- *     scanner.errorTokens.forEach(token => console.error(Scanner.reportError(token)));
+ *     scanner.errorTokens.forEach(err => console.error(`Unexpected token at ${err.offset}: ${err.lexeme}\nHint: ${err.additional}`));
  * } else {
  *     // process tokens
  * }
  * ```
  */
 export class Scanner {
-
-	/**
-	 * Provides an error message for the given error token.
-	 *
-	 * @throws Error if the token is not an error token
-	 */
-	static reportError(token: Token): string {
-		if (token.type !== TokenType.Error) { throw illegalArgument(`expected an error token but got ${JSON.stringify(token)}`); }
-
-		switch (token.lexeme) {
-			case '=': return `Unexpected token '${token.lexeme}' at offset ${token.offset}. Did you mean '==' or '=~'?`;
-			case '&': return `Unexpected token '${token.lexeme}' at offset ${token.offset}. Did you mean '&&'?`;
-			case '|': return `Unexpected token '${token.lexeme}' at offset ${token.offset}. Did you mean '||'?`;
-			default: {
-				const lexeme = token.lexeme;
-
-				if (lexeme && lexeme.length > 1 && lexeme.startsWith(`'`)) {
-					return `Unexpected token '${token.lexeme}' at offset ${token.offset}. Did you forget to close the string?`;
-				}
-
-				if (lexeme && lexeme.length > 1 && lexeme.endsWith(`'`)) {
-					return `Unexpected token '${token.lexeme}' at offset ${token.offset}. Did you forget to open the string?`;
-				}
-
-				return `Unexpected token '${token.lexeme}' at offset ${token.offset}`;
-			}
-		}
-	}
 
 	static getLexeme(token: Token): string {
 		switch (token.type) {
@@ -181,10 +181,10 @@ export class Scanner {
 	private _start: number = 0;
 	private _current: number = 0;
 	private _tokens: Token[] = [];
-	private _errorTokens: Token[] = [];
+	private _errors: LexingError[] = [];
 
-	get errorTokens(): Readonly<Token[]> {
-		return this._errorTokens;
+	get errors(): Readonly<LexingError[]> {
+		return this._errors;
 	}
 
 	reset(value: string) {
@@ -193,7 +193,7 @@ export class Scanner {
 		this._start = 0;
 		this._current = 0;
 		this._tokens = [];
-		this._errorTokens = [];
+		this._errors = [];
 
 		return this;
 	}
@@ -221,7 +221,11 @@ export class Scanner {
 					} else if (this._match(CharCode.Tilde)) {
 						this._addToken(TokenType.RegexOp);
 					} else {
-						this._error();
+						if (this._tokens.length === 0 || this._tokens[this._tokens.length - 1].type !== TokenType.Eq) {
+							this._error(hintDidYouMean('==', '=~'));
+						} else {
+							this._error(hintDontSupportTripleEq);
+						}
 					}
 					break;
 
@@ -233,7 +237,7 @@ export class Scanner {
 					if (this._match(CharCode.Ampersand)) {
 						this._addToken(TokenType.And);
 					} else {
-						this._error();
+						this._error(hintDidYouMean('&&'));
 					}
 					break;
 
@@ -241,11 +245,11 @@ export class Scanner {
 					if (this._match(CharCode.Pipe)) {
 						this._addToken(TokenType.Or);
 					} else {
-						this._error();
+						this._error(hintDidYouMean('||'));
 					}
 					break;
 
-				// TODO@ulugbekna: 1) I don't think we need to handle whitespace here, 2) if we do, we should reconsider what characters we consider whitespace, including unicode, nbsp, etc.
+				// TODO@ulugbekna: 1) rewrite using a regex 2) reconsider what characters are considered whitespace, including unicode, nbsp, etc.
 				case CharCode.Space:
 				case CharCode.CarriageReturn:
 				case CharCode.Tab:
@@ -287,13 +291,15 @@ export class Scanner {
 		this._tokens.push({ type, offset: this._start });
 	}
 
-	private _error() {
-		const errToken = { type: TokenType.Error, offset: this._start, lexeme: this._input.substring(this._start, this._current) };
-		this._errorTokens.push(errToken);
+	private _error(additional?: string) {
+		const offset = this._start;
+		const lexeme = this._input.substring(this._start, this._current);
+		const errToken = { type: TokenType.Error, offset: this._start, lexeme };
+		this._errors.push({ offset, lexeme, additionalInfo: additional });
 		this._tokens.push(errToken);
 	}
 
-	// u - unicode, y - sticky
+	// u - unicode, y - sticky // TODO@ulugbekna: we accept double quotes as part of the string rather than as a delimiter (to preserve old parser's behavior)
 	private stringRe = /[a-zA-Z0-9_<>\-\./\\:\*\?\+\[\]\^,#@;"%\$\p{L}-]+/uy;
 	private _string() {
 		this.stringRe.lastIndex = this._start;
@@ -317,7 +323,7 @@ export class Scanner {
 		}
 
 		if (this._isAtEnd()) {
-			this._error();
+			this._error(hintDidYouForgetToOpenOrCloseQuote);
 			return;
 		}
 
@@ -341,7 +347,7 @@ export class Scanner {
 		while (true) {
 			if (p >= this._input.length) {
 				this._current = p;
-				this._error();
+				this._error(hintDidYouForgetToEscapeSlash);
 				return;
 			}
 
@@ -362,7 +368,7 @@ export class Scanner {
 			p++;
 		}
 
-		// Consume flags
+		// Consume flags // TODO@ulugbekna: use regex instead
 		while (p < this._input.length && Scanner._regexFlags.has(this._input.charCodeAt(p))) {
 			p++;
 		}

--- a/src/vs/platform/contextkey/test/common/parser.test.ts
+++ b/src/vs/platform/contextkey/test/common/parser.test.ts
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 import * as assert from 'assert';
 import { Parser } from 'vs/platform/contextkey/common/contextkey';
-import { Scanner } from 'vs/platform/contextkey/common/scanner';
 
 function parseToStr(input: string): string {
 	const parser = new Parser();
@@ -17,13 +16,13 @@ function parseToStr(input: string): string {
 	if (expr === undefined) {
 		if (parser.lexingErrors.length > 0) {
 			print('Lexing errors:', '\n\n');
-			parser.lexingErrors.forEach(token => print(Scanner.reportError(token), '\n'));
+			parser.lexingErrors.forEach(lexingError => print(`Unexpected token '${lexingError.lexeme}' at offset ${lexingError.offset}. ${lexingError.additionalInfo}`, '\n'));
 		}
 
 		if (parser.parsingErrors.length > 0) {
 			if (parser.lexingErrors.length > 0) { print('\n --- \n'); }
 			print('Parsing errors:', '\n\n');
-			parser.parsingErrors.forEach(message => print(`${message}`, '\n'));
+			parser.parsingErrors.forEach(parsingError => print(`Unexpected '${parsingError.lexeme}' at offset ${parsingError.offset}.`, '\n'));
 		}
 
 	} else {
@@ -173,7 +172,7 @@ suite('Context Key Parser', () => {
 
 		test(`/foo`, () => {
 			const input = `/foo`;
-			assert.deepStrictEqual(parseToStr(input), "Lexing errors:\n\nUnexpected token '/foo' at offset 0\n\n --- \nParsing errors:\n\nExpected 'true', 'false', '(', KEY, KEY '=~' regex, KEY [ ('==' | '!=' | '<' | '<=' | '>' | '>=' | 'in' | 'not' 'in') value ] but got '/foo' at offset 0.\n");
+			assert.deepStrictEqual(parseToStr(input), "Lexing errors:\n\nUnexpected token '/foo' at offset 0. Did you forget to escape the '/' (slash) character? Put two backslashes before it to escape, e.g., '\\\\/'.\n\n --- \nParsing errors:\n\nUnexpected '/foo' at offset 0.\n");
 		});
 
 		test(`!b == 'true'`, () => {
@@ -183,17 +182,17 @@ suite('Context Key Parser', () => {
 
 		test('!foo &&  in bar', () => {
 			const input = '!foo &&  in bar';
-			assert.deepStrictEqual(parseToStr(input), "Parsing errors:\n\nExpected 'true', 'false', '(', KEY, KEY '=~' regex, KEY [ ('==' | '!=' | '<' | '<=' | '>' | '>=' | 'in' | 'not' 'in') value ] but got 'in' at offset 9.\n");
+			assert.deepStrictEqual(parseToStr(input), "Parsing errors:\n\nUnexpected 'in' at offset 9.\n");
 		});
 
 		test('vim<c-r> == 1 && vim<2<=3', () => {
 			const input = 'vim<c-r> == 1 && vim<2<=3';
-			assert.deepStrictEqual(parseToStr(input), "Lexing errors:\n\nUnexpected token '=' at offset 23. Did you mean '==' or '=~'?\n\n --- \nParsing errors:\n\nUnexpected '=' at offset 23.\n"); // FIXME
+			assert.deepStrictEqual(parseToStr(input), "Lexing errors:\n\nUnexpected token '=' at offset 23. Did you mean == or =~?\n\n --- \nParsing errors:\n\nUnexpected '=' at offset 23.\n"); // FIXME
 		});
 
 		test(`foo && 'bar`, () => {
 			const input = `foo && 'bar`;
-			assert.deepStrictEqual(parseToStr(input), "Lexing errors:\n\nUnexpected token ''bar' at offset 7. Did you forget to close the string?\n\n --- \nParsing errors:\n\nExpected 'true', 'false', '(', KEY, KEY '=~' regex, KEY [ ('==' | '!=' | '<' | '<=' | '>' | '>=' | 'in' | 'not' 'in') value ] but got ''bar' at offset 7.\n");
+			assert.deepStrictEqual(parseToStr(input), "Lexing errors:\n\nUnexpected token ''bar' at offset 7. Did you forget to open or close the quote?\n\n --- \nParsing errors:\n\nUnexpected ''bar' at offset 7.\n");
 		});
 
 		/*
@@ -203,12 +202,12 @@ suite('Context Key Parser', () => {
 		*/
 		test('!(foo && bar)', () => {
 			const input = '!(foo && bar)';
-			assert.deepStrictEqual(parseToStr(input), "Parsing errors:\n\nExpected KEY, 'true', or 'false' but got '(' at offset 1.\n");
+			assert.deepStrictEqual(parseToStr(input), "Parsing errors:\n\nUnexpected '(' at offset 1.\n");
 		});
 
 		test(`config.foo &&  &&bar =~ /^foo$|^bar-foo$|^joo$|^jar$/ && !foo`, () => {
 			const input = `config.foo &&  &&bar =~ /^foo$|^bar-foo$|^joo$|^jar$/ && !foo`;
-			assert.deepStrictEqual(parseToStr(input), "Parsing errors:\n\nExpected 'true', 'false', '(', KEY, KEY '=~' regex, KEY [ ('==' | '!=' | '<' | '<=' | '>' | '>=' | 'in' | 'not' 'in') value ] but got '&&' at offset 15.\n");
+			assert.deepStrictEqual(parseToStr(input), "Parsing errors:\n\nUnexpected '&&' at offset 15.\n");
 		});
 
 	});

--- a/src/vs/platform/contextkey/test/common/scanner.test.ts
+++ b/src/vs/platform/contextkey/test/common/scanner.test.ts
@@ -185,7 +185,7 @@ suite('Context Key Scanner', () => {
 
 		test(`foo === '`, () => {
 			const input = `foo === '`;
-			assert.deepStrictEqual(scan(input), ([{ type: "Str", lexeme: "foo", offset: 0 }, { type: "==", offset: 4 }, { type: "ErrorToken", offset: 6, lexeme: "=" }, { type: "ErrorToken", offset: 8, lexeme: "'" }, { type: "EOF", offset: 9 }]));
+			assert.deepStrictEqual(scan(input), ([{ type: "Str", offset: 0, lexeme: "foo" }, { type: "==", offset: 4 }, { type: "ErrorToken", offset: 6, lexeme: "=" }, { type: "ErrorToken", offset: 8, lexeme: "'" }, { type: "EOF", offset: 9 }]));
 		});
 
 		test(`foo && 'bar - unterminated single quote`, () => {
@@ -195,9 +195,7 @@ suite('Context Key Scanner', () => {
 
 		test(`foo === bar'`, () => {
 			const input = `foo === bar'`;
-			const tokens = new Scanner().reset(input).scan();
-			const r = tokens.filter(t => t.type === TokenType.Error).map(Scanner.reportError);
-			assert.deepStrictEqual(r, (["Unexpected token '=' at offset 6. Did you mean '==' or '=~'?", "Unexpected token ''' at offset 11"]));
+			assert.deepStrictEqual(scan(input), ([{ type: "Str", offset: 0, lexeme: "foo" }, { type: "==", offset: 4 }, { type: "ErrorToken", offset: 6, lexeme: "=" }, { type: "Str", offset: 8, lexeme: "bar" }, { type: "ErrorToken", offset: 11, lexeme: "'" }, { type: "EOF", offset: 12 }]));
 		});
 
 		test('vim<c-r> == 1 && vim<2 <= 3', () => {
@@ -228,6 +226,11 @@ suite('Context Key Scanner', () => {
 		test(`resourcePath =~ //foo/barr// || resourcePath =~ //view/(jarrr|doooor|bees)/(web|templates)// && resourceExtname in foo.Bar`, () => {
 			const input = `resourcePath =~ //foo/barr// || resourcePath =~ //view/(jarrr|doooor|bees)/(web|templates)// && resourceExtname in foo.Bar`;
 			assert.deepStrictEqual(scan(input), ([{ type: "Str", offset: 0, lexeme: "resourcePath" }, { type: "=~", offset: 13 }, { type: "RegexStr", offset: 16, lexeme: "//" }, { type: "Str", offset: 18, lexeme: "foo/barr//" }, { type: "||", offset: 29 }, { type: "Str", offset: 32, lexeme: "resourcePath" }, { type: "=~", offset: 45 }, { type: "RegexStr", offset: 48, lexeme: "//" }, { type: "Str", offset: 50, lexeme: "view/" }, { type: "(", offset: 55 }, { type: "Str", offset: 56, lexeme: "jarrr" }, { type: "ErrorToken", offset: 61, lexeme: "|" }, { type: "Str", offset: 62, lexeme: "doooor" }, { type: "ErrorToken", offset: 68, lexeme: "|" }, { type: "Str", offset: 69, lexeme: "bees" }, { type: ")", offset: 73 }, { type: "RegexStr", offset: 74, lexeme: "/(web|templates)/" }, { type: "ErrorToken", offset: 91, lexeme: "/ && resourceExtname in foo.Bar" }, { type: "EOF", offset: 122 }]));
+		});
+
+		test(`foo =~ /file:\// || bar`, () => {
+			const input = JSON.parse('"foo =~ /file:\// || bar"');
+			assert.deepStrictEqual(scan(input), ([{ type: "Str", offset: 0, lexeme: "foo" }, { type: "=~", offset: 4 }, { type: "RegexStr", offset: 7, lexeme: "/file:/" }, { type: "ErrorToken", offset: 14, lexeme: "/ || bar" }, { type: "EOF", offset: 22 }]));
 		});
 	});
 });


### PR DESCRIPTION
- context keys: remove unused new parser caller (we don't really need it right now, especially given the parser API keeps changing)
- context keys: parser: support for running without regex parsing error recovery
- context keys: parsing: rewrite scanner and parser error reporting
- context keys: parsing: raise parsing error on regexp object creation
- context keys: parser: preserve old parsers behavior with "foo == 'true'" remaining same, but "foo == true" being optimized to "foo"

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
