### PR TITLE
Adding source !== 'api' caused regression

### DIFF
--- a/src/vs/editor/browser/viewParts/lines/viewLines.ts
+++ b/src/vs/editor/browser/viewParts/lines/viewLines.ts
@@ -710,7 +710,7 @@ export class ViewLines extends ViewPart implements IVisibleLinesHost<ViewLine>, 
 
 		if (!shouldIgnoreScrollOff) {
 			const context = Math.min((viewportHeight / this._lineHeight) / 2, this._cursorSurroundingLines);
-			if (this._stickyScrollEnabled && source === 'api') {
+			if (this._stickyScrollEnabled) {
 				paddingTop = Math.max(context, this._maxNumberStickyLines) * this._lineHeight;
 			} else {
 				paddingTop = context * this._lineHeight;

--- a/src/vs/editor/browser/viewParts/lines/viewLines.ts
+++ b/src/vs/editor/browser/viewParts/lines/viewLines.ts
@@ -710,11 +710,13 @@ export class ViewLines extends ViewPart implements IVisibleLinesHost<ViewLine>, 
 
 		if (!shouldIgnoreScrollOff) {
 			const context = Math.min((viewportHeight / this._lineHeight) / 2, this._cursorSurroundingLines);
-			if (this._stickyScrollEnabled && source !== 'api') {
+			console.log('context : ', context);
+			if (this._stickyScrollEnabled) {
 				paddingTop = Math.max(context, this._maxNumberStickyLines) * this._lineHeight;
 			} else {
 				paddingTop = context * this._lineHeight;
 			}
+			console.log('paddingTop : ', paddingTop);
 			paddingBottom = Math.max(0, (context - 1)) * this._lineHeight;
 		} else {
 			if (!minimalReveal) {

--- a/src/vs/editor/browser/viewParts/lines/viewLines.ts
+++ b/src/vs/editor/browser/viewParts/lines/viewLines.ts
@@ -710,13 +710,11 @@ export class ViewLines extends ViewPart implements IVisibleLinesHost<ViewLine>, 
 
 		if (!shouldIgnoreScrollOff) {
 			const context = Math.min((viewportHeight / this._lineHeight) / 2, this._cursorSurroundingLines);
-			console.log('context : ', context);
-			if (this._stickyScrollEnabled) {
+			if (this._stickyScrollEnabled && source === 'api') {
 				paddingTop = Math.max(context, this._maxNumberStickyLines) * this._lineHeight;
 			} else {
 				paddingTop = context * this._lineHeight;
 			}
-			console.log('paddingTop : ', paddingTop);
 			paddingBottom = Math.max(0, (context - 1)) * this._lineHeight;
 		} else {
 			if (!minimalReveal) {


### PR DESCRIPTION
Previous fix caused regression. Need to find a better fix for issue #159265 which is reopened. 
