### PR TITLE
Draft fix to issue #159265

### DIFF
--- a/src/vs/editor/browser/viewParts/lines/viewLines.ts
+++ b/src/vs/editor/browser/viewParts/lines/viewLines.ts
@@ -269,7 +269,7 @@ export class ViewLines extends ViewPart implements IVisibleLinesHost<ViewLine>, 
 	public override onRevealRangeRequest(e: viewEvents.ViewRevealRangeRequestEvent): boolean {
 		// Using the future viewport here in order to handle multiple
 		// incoming reveal range requests that might all desire to be animated
-		const desiredScrollTop = this._computeScrollTopToRevealRange(this._context.viewLayout.getFutureViewport(), e.source, e.minimalReveal, e.range, e.selections, e.verticalType);
+		const desiredScrollTop = this._computeScrollTopToRevealRange(this._context.viewLayout.getFutureViewport(), e.source, e.minimalReveal, e.range, e.selections, e.verticalType, e.emitter);
 
 		if (desiredScrollTop === -1) {
 			// marker to abort the reveal range request
@@ -676,7 +676,7 @@ export class ViewLines extends ViewPart implements IVisibleLinesHost<ViewLine>, 
 		}
 	}
 
-	private _computeScrollTopToRevealRange(viewport: Viewport, source: string | null | undefined, minimalReveal: boolean, range: Range | null, selections: Selection[] | null, verticalType: viewEvents.VerticalRevealType): number {
+	private _computeScrollTopToRevealRange(viewport: Viewport, source: string | null | undefined, minimalReveal: boolean, range: Range | null, selections: Selection[] | null, verticalType: viewEvents.VerticalRevealType, emitter?: string): number {
 		const viewportStartY = viewport.top;
 		const viewportHeight = viewport.height;
 		const viewportEndY = viewportStartY + viewportHeight;
@@ -710,7 +710,8 @@ export class ViewLines extends ViewPart implements IVisibleLinesHost<ViewLine>, 
 
 		if (!shouldIgnoreScrollOff) {
 			const context = Math.min((viewportHeight / this._lineHeight) / 2, this._cursorSurroundingLines);
-			if (this._stickyScrollEnabled && source !== 'api') {
+			console.log('emitter : ', emitter);
+			if (this._stickyScrollEnabled && emitter !== 'foldingController') {
 				paddingTop = Math.max(context, this._maxNumberStickyLines) * this._lineHeight;
 			} else {
 				paddingTop = context * this._lineHeight;

--- a/src/vs/editor/browser/widget/codeEditorWidget.ts
+++ b/src/vs/editor/browser/widget/codeEditorWidget.ts
@@ -642,7 +642,7 @@ export class CodeEditorWidget extends Disposable implements editorBrowser.ICodeE
 		}]);
 	}
 
-	private _sendRevealRange(modelRange: Range, verticalType: VerticalRevealType, revealHorizontal: boolean, scrollType: editorCommon.ScrollType): void {
+	private _sendRevealRange(modelRange: Range, verticalType: VerticalRevealType, revealHorizontal: boolean, scrollType: editorCommon.ScrollType, emitter?: string): void {
 		if (!this._modelData) {
 			return;
 		}
@@ -652,7 +652,7 @@ export class CodeEditorWidget extends Disposable implements editorBrowser.ICodeE
 		const validatedModelRange = this._modelData.model.validateRange(modelRange);
 		const viewRange = this._modelData.viewModel.coordinatesConverter.convertModelRangeToViewRange(validatedModelRange);
 
-		this._modelData.viewModel.revealRange('api', revealHorizontal, viewRange, verticalType, scrollType);
+		this._modelData.viewModel.revealRange('api', revealHorizontal, viewRange, verticalType, scrollType, emitter);
 	}
 
 	public revealLine(lineNumber: number, scrollType: editorCommon.ScrollType = editorCommon.ScrollType.Smooth): void {
@@ -702,12 +702,13 @@ export class CodeEditorWidget extends Disposable implements editorBrowser.ICodeE
 		);
 	}
 
-	public revealPositionInCenterIfOutsideViewport(position: IPosition, scrollType: editorCommon.ScrollType = editorCommon.ScrollType.Smooth): void {
+	public revealPositionInCenterIfOutsideViewport(position: IPosition, scrollType: editorCommon.ScrollType = editorCommon.ScrollType.Smooth, emitter?: string): void {
 		this._revealPosition(
 			position,
 			VerticalRevealType.CenterIfOutsideViewport,
 			true,
-			scrollType
+			scrollType,
+			emitter
 		);
 	}
 
@@ -720,7 +721,7 @@ export class CodeEditorWidget extends Disposable implements editorBrowser.ICodeE
 		);
 	}
 
-	private _revealPosition(position: IPosition, verticalType: VerticalRevealType, revealHorizontal: boolean, scrollType: editorCommon.ScrollType): void {
+	private _revealPosition(position: IPosition, verticalType: VerticalRevealType, revealHorizontal: boolean, scrollType: editorCommon.ScrollType, emitter?: string): void {
 		if (!Position.isIPosition(position)) {
 			throw new Error('Invalid arguments');
 		}
@@ -729,7 +730,8 @@ export class CodeEditorWidget extends Disposable implements editorBrowser.ICodeE
 			new Range(position.lineNumber, position.column, position.lineNumber, position.column),
 			verticalType,
 			revealHorizontal,
-			scrollType
+			scrollType,
+			emitter
 		);
 	}
 

--- a/src/vs/editor/common/editorCommon.ts
+++ b/src/vs/editor/common/editorCommon.ts
@@ -333,7 +333,7 @@ export interface IEditor {
 	/**
 	 * Scroll vertically or horizontally as necessary and reveal a position centered vertically only if it lies outside the viewport.
 	 */
-	revealPositionInCenterIfOutsideViewport(position: IPosition, scrollType?: ScrollType): void;
+	revealPositionInCenterIfOutsideViewport(position: IPosition, scrollType?: ScrollType, emitter?: string): void;
 
 	/**
 	 * Scroll vertically or horizontally as necessary and reveal a position close to the top of the viewport,

--- a/src/vs/editor/common/viewEvents.ts
+++ b/src/vs/editor/common/viewEvents.ts
@@ -219,7 +219,11 @@ export class ViewRevealRangeRequestEvent {
 		/**
 		 * The scroll type.
 		 */
-		public readonly scrollType: ScrollType
+		public readonly scrollType: ScrollType,
+		/**
+		 * Information on who sent the reveal range request
+		 */
+		public readonly emitter?: string
 	) { }
 }
 

--- a/src/vs/editor/common/viewModel/viewModelImpl.ts
+++ b/src/vs/editor/common/viewModel/viewModelImpl.ts
@@ -1062,8 +1062,8 @@ export class ViewModel extends Disposable implements IViewModel {
 		const viewRange = new Range(viewPosition.lineNumber, viewPosition.column, viewPosition.lineNumber, viewPosition.column);
 		this._withViewEventsCollector(eventsCollector => eventsCollector.emitViewEvent(new viewEvents.ViewRevealRangeRequestEvent(source, false, viewRange, null, viewEvents.VerticalRevealType.Simple, true, ScrollType.Smooth)));
 	}
-	public revealRange(source: string | null | undefined, revealHorizontal: boolean, viewRange: Range, verticalType: viewEvents.VerticalRevealType, scrollType: ScrollType): void {
-		this._withViewEventsCollector(eventsCollector => eventsCollector.emitViewEvent(new viewEvents.ViewRevealRangeRequestEvent(source, false, viewRange, null, verticalType, revealHorizontal, scrollType)));
+	public revealRange(source: string | null | undefined, revealHorizontal: boolean, viewRange: Range, verticalType: viewEvents.VerticalRevealType, scrollType: ScrollType, emitter?: string): void {
+		this._withViewEventsCollector(eventsCollector => eventsCollector.emitViewEvent(new viewEvents.ViewRevealRangeRequestEvent(source, false, viewRange, null, verticalType, revealHorizontal, scrollType, emitter)));
 	}
 
 	//#endregion

--- a/src/vs/editor/contrib/folding/browser/folding.ts
+++ b/src/vs/editor/contrib/folding/browser/folding.ts
@@ -509,7 +509,7 @@ export class FoldingController extends Disposable implements IEditorContribution
 	}
 
 	public reveal(position: IPosition): void {
-		this.editor.revealPositionInCenterIfOutsideViewport(position, ScrollType.Smooth);
+		this.editor.revealPositionInCenterIfOutsideViewport(position, ScrollType.Smooth, 'foldingController');
 	}
 }
 

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -2628,7 +2628,7 @@ declare namespace monaco.editor {
 		/**
 		 * Scroll vertically or horizontally as necessary and reveal a position centered vertically only if it lies outside the viewport.
 		 */
-		revealPositionInCenterIfOutsideViewport(position: IPosition, scrollType?: ScrollType): void;
+		revealPositionInCenterIfOutsideViewport(position: IPosition, scrollType?: ScrollType, emitter?: string): void;
 		/**
 		 * Scroll vertically or horizontally as necessary and reveal a position close to the top of the viewport,
 		 * optimized for viewing a code definition.


### PR DESCRIPTION
Concerns https://github.com/microsoft/vscode/issues/159265

The view lines function reveals at least `maxStickyScrollLines` above the cursor/point-of-focus when sticky scroll is enabled. This is not wanted when a folding range is folded, because it causes unexpected jumps. This PR is a draft fix for disabling this feature when the folding controller asks to reveal the ranges and sticky scroll is enabled. A better fix should be explored, since we do not want the view lines to be aware of the emitter of the request, ideally.
