### PR TITLE
Split uri-lists on \r\n for markdown drop

### DIFF
--- a/extensions/markdown-language-features/src/languageFeatures/copyFiles/dropIntoEditor.ts
+++ b/extensions/markdown-language-features/src/languageFeatures/copyFiles/dropIntoEditor.ts
@@ -45,7 +45,7 @@ export async function tryGetUriListSnippet(document: vscode.TextDocument, dataTr
 	}
 
 	const uris: vscode.Uri[] = [];
-	for (const resource of urlList.split('\n')) {
+	for (const resource of urlList.split(/\r?\n/g)) {
 		try {
 			uris.push(vscode.Uri.parse(resource));
 		} catch {


### PR DESCRIPTION
Fixes #175547


