### PR TITLE
add context key for tab focus mode

### DIFF
--- a/src/vs/platform/terminal/common/terminal.ts
+++ b/src/vs/platform/terminal/common/terminal.ts
@@ -11,6 +11,9 @@ import { IPtyHostProcessReplayEvent, ISerializedCommandDetectionCapability, ITer
 import { IGetTerminalLayoutInfoArgs, IProcessDetails, ISetTerminalLayoutInfoArgs } from 'vs/platform/terminal/common/terminalProcess';
 import { ThemeIcon } from 'vs/base/common/themables';
 import { ISerializableEnvironmentVariableCollections } from 'vs/platform/terminal/common/environmentVariable';
+import { RawContextKey } from 'vs/platform/contextkey/common/contextkey';
+
+export const terminalTabFocusContextKey = new RawContextKey<boolean>('terminalTabFocusMode', false, true);
 
 export const enum TerminalSettingPrefix {
 	Shell = 'terminal.integrated.shell.',

--- a/src/vs/workbench/browser/parts/editor/tabFocus.ts
+++ b/src/vs/workbench/browser/parts/editor/tabFocus.ts
@@ -1,0 +1,71 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Emitter } from 'vs/base/common/event';
+import { Disposable } from 'vs/base/common/lifecycle';
+import { TabFocusContext, TabFocus } from 'vs/editor/browser/config/tabFocus';
+import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
+import { RawContextKey, IContextKey, IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
+import { TerminalSettingId } from 'vs/platform/terminal/common/terminal';
+
+export const terminalTabFocusContextKey = new RawContextKey<boolean>('terminalTabFocusMode', false, true);
+export const editorTabFocusContextKey = new RawContextKey<boolean>('editorTabFocusMode', false, true);
+
+export class TabFocusMode extends Disposable {
+	private _previousViewContext?: TabFocusContext;
+	private readonly _onDidChange = this._register(new Emitter<void>());
+	readonly onDidChange = this._onDidChange.event;
+	private _editorContext: IContextKey<boolean>;
+	private _terminalContext: IContextKey<boolean>;
+
+	constructor(
+		@IContextKeyService contextKeyService: IContextKeyService,
+		@IConfigurationService configurationService: IConfigurationService
+	) {
+		super();
+
+		this._editorContext = editorTabFocusContextKey.bindTo(contextKeyService);
+		this._editorContext.set(configurationService.getValue('editor.tabFocusMode'));
+		this._terminalContext = terminalTabFocusContextKey.bindTo(contextKeyService);
+		this._terminalContext.set(configurationService.getValue(TerminalSettingId.TabFocusMode));
+		const viewKey = new Set<string>();
+		viewKey.add('focusedView');
+		this._register(contextKeyService.onDidChangeContext((c) => {
+			if (c.affectsSome(viewKey)) {
+				const terminalFocus = contextKeyService.getContextKeyValue('focusedView') === 'terminal';
+				const context = terminalFocus ? TabFocusContext.Terminal : TabFocusContext.Editor;
+				if (this._previousViewContext === context) {
+					return;
+				}
+				if (terminalFocus) {
+					this._editorContext.reset();
+				} else {
+					this._terminalContext.reset();
+				}
+				this._previousViewContext = context;
+				this._onDidChange.fire();
+			}
+		}));
+		this._register(configurationService.onDidChangeConfiguration(e => {
+			if (e.affectsConfiguration('editor.tabFocusMode')) {
+				TabFocus.setTabFocusMode(configurationService.getValue('editor.tabFocusMode'), TabFocusContext.Editor);
+				this._editorContext.set(configurationService.getValue('editor.tabFocusMode'));
+				this._onDidChange.fire();
+			} else if (e.affectsConfiguration(TerminalSettingId.TabFocusMode)) {
+				TabFocus.setTabFocusMode(configurationService.getValue(TerminalSettingId.TabFocusMode), TabFocusContext.Terminal);
+				this._terminalContext.set(configurationService.getValue(TerminalSettingId.TabFocusMode));
+				this._onDidChange.fire();
+			}
+		}));
+		TabFocus.onDidChangeTabFocus(() => {
+			const focusedView = contextKeyService.getContextKeyValue('focusedView') === 'terminal' ? TabFocusContext.Terminal : TabFocusContext.Editor;
+			if (focusedView === TabFocusContext.Terminal) {
+				this._terminalContext.set(TabFocus.getTabFocusMode(focusedView));
+			} else {
+				this._editorContext.set(TabFocus.getTabFocusMode(focusedView));
+			}
+		});
+	}
+}

--- a/src/vs/workbench/browser/parts/editor/tabFocus.ts
+++ b/src/vs/workbench/browser/parts/editor/tabFocus.ts
@@ -8,9 +8,8 @@ import { Disposable } from 'vs/base/common/lifecycle';
 import { TabFocusContext, TabFocus } from 'vs/editor/browser/config/tabFocus';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { RawContextKey, IContextKey, IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
-import { TerminalSettingId } from 'vs/platform/terminal/common/terminal';
+import { TerminalSettingId, terminalTabFocusContextKey } from 'vs/platform/terminal/common/terminal';
 
-export const terminalTabFocusContextKey = new RawContextKey<boolean>('terminalTabFocusMode', false, true);
 export const editorTabFocusContextKey = new RawContextKey<boolean>('editorTabFocusMode', false, true);
 
 export class TabFocusMode extends Disposable {

--- a/src/vs/workbench/contrib/terminal/browser/terminalActions.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalActions.ts
@@ -63,6 +63,7 @@ import { IClipboardService } from 'vs/platform/clipboard/common/clipboardService
 import { TerminalCapability } from 'vs/platform/terminal/common/capabilities/capabilities';
 import { VSBuffer } from 'vs/base/common/buffer';
 import { killTerminalIcon, newTerminalIcon } from 'vs/workbench/contrib/terminal/browser/terminalIcons';
+import { editorTabFocusContextKey, terminalTabFocusContextKey } from 'vs/workbench/browser/parts/editor/tabFocus';
 
 export const switchTerminalActionViewItemSeparator = '\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500';
 export const switchTerminalShowTabsTitle = localize('showTerminalTabs', "Show Tabs");
@@ -417,7 +418,7 @@ export function registerTerminalActions() {
 					{
 						primary: KeyMod.Shift | KeyCode.Tab,
 						weight: KeybindingWeight.WorkbenchContrib,
-						when: ContextKeyExpr.and(CONTEXT_ACCESSIBILITY_MODE_ENABLED, TerminalContextKeys.focus)
+						when: ContextKeyExpr.and(CONTEXT_ACCESSIBILITY_MODE_ENABLED, TerminalContextKeys.focus, ContextKeyExpr.or(terminalTabFocusContextKey, editorTabFocusContextKey))
 					}
 				],
 			});

--- a/src/vs/workbench/contrib/terminal/browser/terminalActions.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalActions.ts
@@ -418,7 +418,7 @@ export function registerTerminalActions() {
 					{
 						primary: KeyMod.Shift | KeyCode.Tab,
 						weight: KeybindingWeight.WorkbenchContrib,
-						when: ContextKeyExpr.or(terminalTabFocusContextKey, editorTabFocusContextKey)
+						when: ContextKeyExpr.or(terminalTabFocusContextKey, ContextKeyExpr.and(CONTEXT_ACCESSIBILITY_MODE_ENABLED, editorTabFocusContextKey))
 					}
 				],
 			});

--- a/src/vs/workbench/contrib/terminal/browser/terminalActions.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalActions.ts
@@ -418,7 +418,7 @@ export function registerTerminalActions() {
 					{
 						primary: KeyMod.Shift | KeyCode.Tab,
 						weight: KeybindingWeight.WorkbenchContrib,
-						when: ContextKeyExpr.and(CONTEXT_ACCESSIBILITY_MODE_ENABLED, TerminalContextKeys.focus, ContextKeyExpr.or(terminalTabFocusContextKey, editorTabFocusContextKey))
+						when: ContextKeyExpr.or(terminalTabFocusContextKey, editorTabFocusContextKey)
 					}
 				],
 			});

--- a/src/vs/workbench/contrib/terminal/browser/terminalActions.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalActions.ts
@@ -28,7 +28,7 @@ import { IListService } from 'vs/platform/list/browser/listService';
 import { INotificationService, Severity } from 'vs/platform/notification/common/notification';
 import { IOpenerService } from 'vs/platform/opener/common/opener';
 import { IPickOptions, IQuickInputService, IQuickPickItem } from 'vs/platform/quickinput/common/quickInput';
-import { ITerminalProfile, TerminalExitReason, TerminalLocation, TerminalSettingId } from 'vs/platform/terminal/common/terminal';
+import { ITerminalProfile, TerminalExitReason, TerminalLocation, TerminalSettingId, terminalTabFocusContextKey } from 'vs/platform/terminal/common/terminal';
 import { IWorkspaceContextService, IWorkspaceFolder } from 'vs/platform/workspace/common/workspace';
 import { PICK_WORKSPACE_FOLDER_COMMAND_ID } from 'vs/workbench/browser/actions/workspaceCommands';
 import { CLOSE_EDITOR_COMMAND_ID } from 'vs/workbench/browser/parts/editor/editorCommands';
@@ -63,7 +63,7 @@ import { IClipboardService } from 'vs/platform/clipboard/common/clipboardService
 import { TerminalCapability } from 'vs/platform/terminal/common/capabilities/capabilities';
 import { VSBuffer } from 'vs/base/common/buffer';
 import { killTerminalIcon, newTerminalIcon } from 'vs/workbench/contrib/terminal/browser/terminalIcons';
-import { editorTabFocusContextKey, terminalTabFocusContextKey } from 'vs/workbench/browser/parts/editor/tabFocus';
+import { editorTabFocusContextKey } from 'vs/workbench/browser/parts/editor/tabFocus';
 
 export const switchTerminalActionViewItemSeparator = '\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u2500';
 export const switchTerminalShowTabsTitle = localize('showTerminalTabs', "Show Tabs");

--- a/src/vs/workbench/contrib/terminal/browser/xterm/xtermTerminal.ts
+++ b/src/vs/workbench/contrib/terminal/browser/xterm/xtermTerminal.ts
@@ -37,7 +37,7 @@ import { ITerminalCapabilityStore, ITerminalCommand, TerminalCapability } from '
 import { Emitter } from 'vs/base/common/event';
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 import { SuggestAddon } from 'vs/workbench/contrib/terminal/browser/xterm/suggestAddon';
-import { IContextKey, IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
+import { IContextKey } from 'vs/platform/contextkey/common/contextkey';
 import { URI } from 'vs/base/common/uri';
 import { ITextModel } from 'vs/editor/common/model';
 import { IModelService } from 'vs/editor/common/services/model';
@@ -48,7 +48,6 @@ import { getSimpleEditorOptions } from 'vs/workbench/contrib/codeEditor/browser/
 import { IEditorConstructionOptions } from 'vs/editor/browser/config/editorConfiguration';
 import { LinkDetector } from 'vs/editor/contrib/links/browser/links';
 import { SelectionClipboardContributionID } from 'vs/workbench/contrib/codeEditor/browser/selectionClipboard';
-import { TabFocus, TabFocusContext } from 'vs/editor/browser/config/tabFocus';
 
 const enum RenderConstants {
 	/**
@@ -208,8 +207,7 @@ export class XtermTerminal extends DisposableStore implements IXtermTerminal, II
 		@IStorageService private readonly _storageService: IStorageService,
 		@IThemeService private readonly _themeService: IThemeService,
 		@IViewDescriptorService private readonly _viewDescriptorService: IViewDescriptorService,
-		@ITelemetryService private readonly _telemetryService: ITelemetryService,
-		@IContextKeyService private readonly _contextKeyService: IContextKeyService
+		@ITelemetryService private readonly _telemetryService: ITelemetryService
 	) {
 		super();
 		this.target = location;
@@ -292,10 +290,7 @@ export class XtermTerminal extends DisposableStore implements IXtermTerminal, II
 	}
 
 	async focusAccessibleBuffer(): Promise<void> {
-		const tabFocusMode = TabFocus.getTabFocusMode(this._contextKeyService.getContextKeyValue('focusedView') === 'terminal' ? TabFocusContext.Terminal : TabFocusContext.Editor);
-		if (tabFocusMode) {
-			this._accessibileBuffer?.focus();
-		}
+		this._accessibileBuffer?.focus();
 	}
 
 	async getSelectionAsHtml(command?: ITerminalCommand): Promise<string> {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

fix #174800
Also:
- move tab focus components out of `EditorStatus`
- show all content when there are no commands instead of no content message