### PR TITLE
Fix TS Server logging on windows

### DIFF
--- a/extensions/typescript-language-features/src/tsServer/spawner.ts
+++ b/extensions/typescript-language-features/src/tsServer/spawner.ts
@@ -232,7 +232,7 @@ export class TypeScriptServerSpawner {
 					tsServerLog = { type: 'file', uri: logFilePath };
 
 					args.push('--logVerbosity', TsServerLogLevel.toString(configuration.tsServerLogLevel));
-					args.push('--logFile', logFilePath.path);
+					args.push('--logFile', logFilePath.fsPath);
 				}
 			}
 		}


### PR DESCRIPTION
For #175172
Ports #175600 to the 1.76 branch

We need to pass TS the windows style path here instead of the unix style path
