### PR TITLE
cli: fix static import of openssl

### DIFF
--- a/build/azure-pipelines/darwin/cli-build-darwin.yml
+++ b/build/azure-pipelines/darwin/cli-build-darwin.yml
@@ -53,8 +53,9 @@ steps:
         VSCODE_CLI_TARGET: x86_64-apple-darwin
         VSCODE_CLI_ARTIFACT: unsigned_vscode_cli_darwin_x64_cli
         VSCODE_CLI_ENV:
-          OPENSSL_LIB_DIR: $(Build.ArtifactStagingDirectory)/openssl/arm64-osx/lib
-          OPENSSL_INCLUDE_DIR: $(Build.ArtifactStagingDirectory)/openssl/arm64-osx/include
+          OPENSSL_LIB_DIR: $(Build.ArtifactStagingDirectory)/openssl/x64-osx/lib
+          OPENSSL_INCLUDE_DIR: $(Build.ArtifactStagingDirectory)/openssl/x64-osx/include
+          OPENSSL_STATIC: '1'
 
   - ${{ if eq(parameters.VSCODE_BUILD_MACOS_ARM64, true) }}:
     - template: ../cli/cli-compile-and-publish.yml
@@ -62,5 +63,6 @@ steps:
         VSCODE_CLI_TARGET: aarch64-apple-darwin
         VSCODE_CLI_ARTIFACT: unsigned_vscode_cli_darwin_arm64_cli
         VSCODE_CLI_ENV:
-          OPENSSL_LIB_DIR: $(Build.ArtifactStagingDirectory)/openssl/x64-osx/lib
-          OPENSSL_INCLUDE_DIR: $(Build.ArtifactStagingDirectory)/openssl/x64-osx/include
+          OPENSSL_LIB_DIR: $(Build.ArtifactStagingDirectory)/openssl/arm64-osx/lib
+          OPENSSL_INCLUDE_DIR: $(Build.ArtifactStagingDirectory)/openssl/arm64-osx/include
+          OPENSSL_STATIC: '1'

--- a/build/azure-pipelines/linux/cli-build-linux.yml
+++ b/build/azure-pipelines/linux/cli-build-linux.yml
@@ -93,6 +93,7 @@ steps:
           CC_aarch64-unknown-linux-musl: musl-gcc
           OPENSSL_LIB_DIR: $(Build.ArtifactStagingDirectory)/openssl/arm64-linux/lib
           OPENSSL_INCLUDE_DIR: $(Build.ArtifactStagingDirectory)/openssl/arm64-linux/include
+          OPENSSL_STATIC: '1'
 
   - ${{ if eq(parameters.VSCODE_BUILD_ALPINE, true) }}:
     - template: ../cli/cli-compile-and-publish.yml
@@ -104,6 +105,7 @@ steps:
           CC_aarch64-unknown-linux-musl: musl-gcc
           OPENSSL_LIB_DIR: $(Build.ArtifactStagingDirectory)/openssl/x64-linux/lib
           OPENSSL_INCLUDE_DIR: $(Build.ArtifactStagingDirectory)/openssl/x64-linux/include
+          OPENSSL_STATIC: '1'
 
   - ${{ if eq(parameters.VSCODE_BUILD_LINUX_ARM64, true) }}:
     - template: ../cli/cli-compile-and-publish.yml
@@ -114,6 +116,7 @@ steps:
           CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
           OPENSSL_LIB_DIR: $(Build.ArtifactStagingDirectory)/openssl/arm64-linux/lib
           OPENSSL_INCLUDE_DIR: $(Build.ArtifactStagingDirectory)/openssl/arm64-linux/include
+          OPENSSL_STATIC: '1'
 
   - ${{ if eq(parameters.VSCODE_BUILD_LINUX, true) }}:
     - template: ../cli/cli-compile-and-publish.yml
@@ -123,6 +126,7 @@ steps:
         VSCODE_CLI_ENV:
           OPENSSL_LIB_DIR: $(Build.ArtifactStagingDirectory)/openssl/x64-linux/lib
           OPENSSL_INCLUDE_DIR: $(Build.ArtifactStagingDirectory)/openssl/x64-linux/include
+          OPENSSL_STATIC: '1'
 
   - ${{ if eq(parameters.VSCODE_BUILD_LINUX_ARMHF, true) }}:
     - template: ../cli/cli-compile-and-publish.yml
@@ -133,3 +137,4 @@ steps:
           CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_LINKER: arm-linux-gnueabihf-gcc
           OPENSSL_LIB_DIR: $(Build.ArtifactStagingDirectory)/openssl/arm-linux/lib
           OPENSSL_INCLUDE_DIR: $(Build.ArtifactStagingDirectory)/openssl/arm-linux/include
+          OPENSSL_STATIC: '1'

--- a/build/azure-pipelines/win32/cli-build-win32.yml
+++ b/build/azure-pipelines/win32/cli-build-win32.yml
@@ -60,6 +60,7 @@ steps:
         VSCODE_CLI_ENV:
           OPENSSL_LIB_DIR: $(Build.ArtifactStagingDirectory)/openssl/x64-windows-static-md/lib
           OPENSSL_INCLUDE_DIR: $(Build.ArtifactStagingDirectory)/openssl/x64-windows-static-md/include
+          OPENSSL_STATIC: '1'
 
   - ${{ if eq(parameters.VSCODE_BUILD_WIN32_ARM64, true) }}:
     - template: ../cli/cli-compile-and-publish.yml
@@ -69,6 +70,7 @@ steps:
         VSCODE_CLI_ENV:
           OPENSSL_LIB_DIR: $(Build.ArtifactStagingDirectory)/openssl/arm64-windows-static-md/lib
           OPENSSL_INCLUDE_DIR: $(Build.ArtifactStagingDirectory)/openssl/arm64-windows-static-md/include
+          OPENSSL_STATIC: '1'
 
   - ${{ if eq(parameters.VSCODE_BUILD_WIN32_32BIT, true) }}:
     - template: ../cli/cli-compile-and-publish.yml
@@ -78,3 +80,4 @@ steps:
         VSCODE_CLI_ENV:
           OPENSSL_LIB_DIR: $(Build.ArtifactStagingDirectory)/openssl/x86-windows-static-md/lib
           OPENSSL_INCLUDE_DIR: $(Build.ArtifactStagingDirectory)/openssl/x86-windows-static-md/include
+          OPENSSL_STATIC: '1'

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -1334,15 +1334,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
-name = "openssl-src"
-version = "111.22.0+1.1.1q"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f31f0d509d1c1ae9cada2f9539ff8f37933831fd5098879e482aa687d659853"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "openssl-sys"
 version = "0.9.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1351,7 +1342,6 @@ dependencies = [
  "autocfg",
  "cc",
  "libc",
- "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
@@ -1908,7 +1898,7 @@ checksum = "9c8132065adcfd6e02db789d9285a0deb2f3fcb04002865ab67d5fb103533898"
 [[package]]
 name = "secret-service"
 version = "2.0.2"
-source = "git+https://github.com/microsoft/vscode-secret-service-rs?rev=30f0414108a122d6f2bfc28a5425d0dac9738518#30f0414108a122d6f2bfc28a5425d0dac9738518"
+source = "git+https://github.com/microsoft/vscode-secret-service-rs?rev=fbbaf222de10546609be26bb043e64356e855edb#fbbaf222de10546609be26bb043e64356e855edb"
 dependencies = [
  "lazy_static",
  "num",
@@ -2280,9 +2270,7 @@ checksum = "f714dd15bead90401d77e04243611caec13726c2408afd5b31901dfcdcb3b181"
 dependencies = [
  "futures-util",
  "log",
- "native-tls",
  "tokio",
- "tokio-native-tls",
  "tungstenite",
 ]
 
@@ -2366,7 +2354,6 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "native-tls",
  "rand 0.8.5",
  "sha-1",
  "thiserror",

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -2270,7 +2270,9 @@ checksum = "f714dd15bead90401d77e04243611caec13726c2408afd5b31901dfcdcb3b181"
 dependencies = [
  "futures-util",
  "log",
+ "native-tls",
  "tokio",
+ "tokio-native-tls",
  "tungstenite",
 ]
 
@@ -2354,6 +2356,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
+ "native-tls",
  "rand 0.8.5",
  "sha-1",
  "thiserror",
@@ -2364,11 +2367,12 @@ dependencies = [
 [[package]]
 name = "tunnels"
 version = "0.1.0"
-source = "git+https://github.com/microsoft/dev-tunnels?rev=3870e9133dfb9557774521bb447827f19b26e55d#3870e9133dfb9557774521bb447827f19b26e55d"
+source = "git+https://github.com/microsoft/dev-tunnels?rev=730aa86f8ccd9e2dd4541693fbce763357da93f4#730aa86f8ccd9e2dd4541693fbce763357da93f4"
 dependencies = [
  "async-trait",
  "chrono",
  "futures",
+ "hyper",
  "log",
  "reqwest",
  "russh",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -15,7 +15,7 @@ name = "code"
 futures = "0.3"
 clap = { version = "3.0", features = ["derive", "env"] }
 open = { version = "2.1.0" }
-reqwest = { version = "0.11.9", default-features = false, features = ["json", "stream", "native-tls-vendored"] }
+reqwest = { version = "0.11.9", default-features = false, features = ["json", "stream", "native-tls"] }
 tokio = { version = "1.24.2", features = ["full"] }
 tokio-util = { version = "0.7", features = ["compat"] }
 flate2 = { version = "1.0.22" }
@@ -31,12 +31,12 @@ dirs = "4.0.0"
 rand = "0.8.5"
 atty = "0.2.14"
 opentelemetry = { version = "0.18.0", features = ["rt-tokio"] }
-opentelemetry-application-insights = { version = "0.22.0", features = ["reqwest-client-vendored-tls"] }
+opentelemetry-application-insights = { version = "0.22.0", features = ["reqwest-client"] }
 serde_bytes = "0.11.5"
 chrono = { version = "0.4", features = ["serde"] }
 gethostname = "0.2.3"
 libc = "0.2"
-tunnels = { git = "https://github.com/microsoft/dev-tunnels", rev = "3870e9133dfb9557774521bb447827f19b26e55d", default-features = false, features = ["connections", "vendored-openssl"] }
+tunnels = { git = "https://github.com/microsoft/dev-tunnels", rev = "3870e9133dfb9557774521bb447827f19b26e55d", default-features = false, features = ["connections"] }
 keyring = "1.1"
 dialoguer = "0.10"
 hyper = "0.14"
@@ -70,7 +70,7 @@ zbus = { version = "3.4", default-features = false, features = ["tokio"] }
 russh = { git = "https://github.com/microsoft/vscode-russh", branch = "main" }
 russh-cryptovec = { git = "https://github.com/microsoft/vscode-russh", branch = "main" }
 russh-keys = { git = "https://github.com/microsoft/vscode-russh", branch = "main" }
-secret-service = { git = "https://github.com/microsoft/vscode-secret-service-rs", rev = "30f0414108a122d6f2bfc28a5425d0dac9738518" }
+secret-service = { git = "https://github.com/microsoft/vscode-secret-service-rs", rev = "fbbaf222de10546609be26bb043e64356e855edb" }
 
 [profile.release]
 strip = true

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -36,7 +36,7 @@ serde_bytes = "0.11.5"
 chrono = { version = "0.4", features = ["serde"] }
 gethostname = "0.2.3"
 libc = "0.2"
-tunnels = { git = "https://github.com/microsoft/dev-tunnels", rev = "3870e9133dfb9557774521bb447827f19b26e55d", default-features = false, features = ["connections"] }
+tunnels = { git = "https://github.com/microsoft/dev-tunnels", rev = "730aa86f8ccd9e2dd4541693fbce763357da93f4", default-features = false, features = ["connections"] }
 keyring = "1.1"
 dialoguer = "0.10"
 hyper = "0.14"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "code-oss-dev",
   "version": "1.77.0",
-  "distro": "52635c8055ef02ea8f780dcd04d1fb534b1b30db",
+  "distro": "b6ce387d48144f5c7d0d33843b76e545fe561af7",
   "author": {
     "name": "Microsoft Corporation"
   },


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/175620

The build was still compiling openssl-src, instead remove the "vendored" flag and pass `OPENSSL_STATIC: '1'`. As reflected in the Cargo.lock, this means we never pull openssl-src.

Edit: this also pulls in the dev-tunnels update that fixes https://github.com/microsoft/vscode/issues/169333
