### PR TITLE
Various tweaks to a11y buffer input/layout

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/media/terminal.css
+++ b/src/vs/workbench/contrib/terminal/browser/media/terminal.css
@@ -586,3 +586,19 @@
 	text-decoration: underline;
 	outline-color: var(--vscode-focusBorder);
 }
+
+/* Overrides for the a11y buffer as we're hosting monaco within it */
+.xterm .xterm-accessible-buffer {
+	padding: 0 !important;
+	overflow: initial !important;
+	overflow-x: initial !important;
+}
+.xterm .xterm-accessible-buffer:focus-within {
+	top: 0 !important;
+	left: 0 !important;
+	pointer-events: all !important;
+}
+.xterm > .xterm-accessible-buffer {
+	/* Reset cursor style as monaco controls it here */
+	cursor: default;
+}


### PR DESCRIPTION
- Avoid all padding, this was pushing the scrollbar off screen
- Allow pointer events in the a11y buffer, we want the user to be able to interact via mouse (selection + scrolling). Getting out of it is now done by focusing another element or tab/shift+tab
- Remove overflow styles, these were obscuring the vscode-style scrollable element

Fixes #175041

@meganrogge could you verify these changes?