### PR TITLE
cli: fix build for x64 musl

### DIFF
--- a/build/azure-pipelines/linux/cli-build-linux.yml
+++ b/build/azure-pipelines/linux/cli-build-linux.yml
@@ -91,6 +91,7 @@ steps:
         VSCODE_CLI_ENV:
           CXX_aarch64-unknown-linux-musl: musl-g++
           CC_aarch64-unknown-linux-musl: musl-gcc
+          RUSTFLAGS: "-L $(Build.ArtifactStagingDirectory)/openssl/arm64-linux/lib"
           OPENSSL_LIB_DIR: $(Build.ArtifactStagingDirectory)/openssl/arm64-linux/lib
           OPENSSL_INCLUDE_DIR: $(Build.ArtifactStagingDirectory)/openssl/arm64-linux/include
           OPENSSL_STATIC: '1'


### PR DESCRIPTION
I have no idea why this is needed, it should be there automatically, and is for all other targets. But it fixes it, despite my doubts 🤷  https://dev.azure.com/monacotools/Monaco/_build/results?buildId=204833&view=results