### PR TITLE
Fix webview editor position on groups changes

### DIFF
--- a/src/vs/workbench/contrib/webviewPanel/browser/webviewEditor.ts
+++ b/src/vs/workbench/contrib/webviewPanel/browser/webviewEditor.ts
@@ -65,7 +65,12 @@ export class WebviewEditor extends EditorPane {
 	) {
 		super(WebviewEditor.ID, telemetryService, themeService, storageService);
 
-		this._register(editorGroupsService.onDidScroll(() => {
+		this._register(Event.any(
+			editorGroupsService.onDidScroll,
+			editorGroupsService.onDidAddGroup,
+			editorGroupsService.onDidRemoveGroup,
+			editorGroupsService.onDidMoveGroup,
+		)(() => {
 			if (this.webview && this._visible) {
 				this.synchronizeWebviewContainerDimensions(this.webview);
 			}
@@ -192,7 +197,7 @@ export class WebviewEditor extends EditorPane {
 	}
 
 	private synchronizeWebviewContainerDimensions(webview: IOverlayWebview, dimension?: DOM.Dimension) {
-		if (!this._element) {
+		if (!this._element?.isConnected) {
 			return;
 		}
 		const rootContainer = this._workbenchLayoutService.getContainer(Parts.EDITOR_PART);


### PR DESCRIPTION
Part of #173874

Makes sure we re-layout the webview after an editor group is added/removed

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
