### PR TITLE
Render keybindings nicely in markdown

### DIFF
--- a/src/vs/editor/contrib/markdownRenderer/browser/markdownRenderer.ts
+++ b/src/vs/editor/contrib/markdownRenderer/browser/markdownRenderer.ts
@@ -8,6 +8,7 @@ import { onUnexpectedError } from 'vs/base/common/errors';
 import { Emitter } from 'vs/base/common/event';
 import { IMarkdownString, MarkdownStringTrustedOptions } from 'vs/base/common/htmlContent';
 import { DisposableStore, IDisposable } from 'vs/base/common/lifecycle';
+import 'vs/css!./renderedMarkdown';
 import { applyFontInfo } from 'vs/editor/browser/config/domFontInfo';
 import { ICodeEditor } from 'vs/editor/browser/editorBrowser';
 import { EditorOption } from 'vs/editor/common/config/editorOptions';
@@ -59,6 +60,7 @@ export class MarkdownRenderer {
 
 		const disposables = new DisposableStore();
 		const rendered = disposables.add(renderMarkdown(markdown, { ...this._getRenderOptions(markdown, disposables), ...options }, markedOptions));
+		rendered.element.classList.add('rendered-markdown');
 		return {
 			element: rendered.element,
 			dispose: () => disposables.dispose()

--- a/src/vs/editor/contrib/markdownRenderer/browser/renderedMarkdown.css
+++ b/src/vs/editor/contrib/markdownRenderer/browser/renderedMarkdown.css
@@ -1,0 +1,17 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+.monaco-editor .rendered-markdown kbd {
+	background-color: var(--vscode-keybindingLabel-background);
+	color: var(--vscode-keybindingLabel-foreground);
+	border-style: solid;
+	border-width: 1px;
+	border-radius: 3px;
+	border-color: var(--vscode-keybindingLabel-border);
+	border-bottom-color: var(--vscode-keybindingLabel-bottomBorder);
+	box-shadow: inset 0 -1px 0 var(--vscode-widget-shadow);
+	vertical-align: middle;
+	padding: 1px 3px;
+}

--- a/src/vs/workbench/contrib/webview/browser/pre/index-no-csp.html
+++ b/src/vs/workbench/contrib/webview/browser/pre/index-no-csp.html
@@ -130,21 +130,16 @@
 			}
 
 			kbd {
-				color: var(--vscode-editor-foreground);
+				background-color: var(--vscode-keybindingLabel-background);
+				color: var(--vscode-keybindingLabel-foreground);
+				border-style: solid;
+				border-width: 1px;
 				border-radius: 3px;
+				border-color: var(--vscode-keybindingLabel-border);
+				border-bottom-color: var(--vscode-keybindingLabel-bottomBorder);
+				box-shadow: inset 0 -1px 0 var(--vscode-widget-shadow);
 				vertical-align: middle;
 				padding: 1px 3px;
-
-				background-color: hsla(0,0%,50%,.17);
-				border: 1px solid rgba(71,71,71,.4);
-				border-bottom-color: rgba(88,88,88,.4);
-				box-shadow: inset 0 -1px 0 rgba(88,88,88,.4);
-			}
-			.vscode-light kbd {
-				background-color: hsla(0,0%,87%,.5);
-				border: 1px solid hsla(0,0%,80%,.7);
-				border-bottom-color: hsla(0,0%,73%,.7);
-				box-shadow: inset 0 -1px 0 hsla(0,0%,73%,.7);
 			}
 
 			::-webkit-scrollbar {

--- a/src/vs/workbench/contrib/webview/browser/pre/index.html
+++ b/src/vs/workbench/contrib/webview/browser/pre/index.html
@@ -5,7 +5,7 @@
 	<meta charset="UTF-8">
 
 	<meta http-equiv="Content-Security-Policy"
-		content="default-src 'none'; script-src 'sha256-RaCvj6SRgHm+2C3LKzSAamDwa3Bp4u4iQ1Y2Sm+97tE=' 'self'; frame-src 'self'; style-src 'unsafe-inline';">
+		content="default-src 'none'; script-src 'sha256-f/XuzcTyXb1X6po1otWlqfEUBjHOsprrTOZknXfbS9I=' 'self'; frame-src 'self'; style-src 'unsafe-inline';">
 
 	<!-- Disable pinch zooming -->
 	<meta name="viewport"
@@ -131,21 +131,16 @@
 			}
 
 			kbd {
-				color: var(--vscode-editor-foreground);
+				background-color: var(--vscode-keybindingLabel-background);
+				color: var(--vscode-keybindingLabel-foreground);
+				border-style: solid;
+				border-width: 1px;
 				border-radius: 3px;
+				border-color: var(--vscode-keybindingLabel-border);
+				border-bottom-color: var(--vscode-keybindingLabel-bottomBorder);
+				box-shadow: inset 0 -1px 0 var(--vscode-widget-shadow);
 				vertical-align: middle;
 				padding: 1px 3px;
-
-				background-color: hsla(0,0%,50%,.17);
-				border: 1px solid rgba(71,71,71,.4);
-				border-bottom-color: rgba(88,88,88,.4);
-				box-shadow: inset 0 -1px 0 rgba(88,88,88,.4);
-			}
-			.vscode-light kbd {
-				background-color: hsla(0,0%,87%,.5);
-				border: 1px solid hsla(0,0%,80%,.7);
-				border-bottom-color: hsla(0,0%,73%,.7);
-				box-shadow: inset 0 -1px 0 hsla(0,0%,73%,.7);
 			}
 
 			::-webkit-scrollbar {


### PR DESCRIPTION
Fixes #173722

Adds a new `renderedMarkdown.css` file that is used for styling that should be shared among places that show markdown strings: hovers, param hints, suggest, ...

Also aligns the styling of keybindings in webviews to use the VS Code theme variables instead of hardcoding colors

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
