### PR TITLE
Decreasing the z-index to 4

### DIFF
--- a/src/vs/editor/contrib/peekView/browser/peekView.ts
+++ b/src/vs/editor/contrib/peekView/browser/peekView.ts
@@ -26,7 +26,7 @@ import { createActionViewItem } from 'vs/platform/actions/browser/menuEntryActio
 import { IContextKeyService, RawContextKey } from 'vs/platform/contextkey/common/contextkey';
 import { InstantiationType, registerSingleton } from 'vs/platform/instantiation/common/extensions';
 import { createDecorator, IInstantiationService, ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
-import { activeContrastBorder, contrastBorder, editorForeground, editorInfoForeground, registerColor, transparent } from 'vs/platform/theme/common/colorRegistry';
+import { activeContrastBorder, contrastBorder, editorForeground, editorInfoForeground, registerColor } from 'vs/platform/theme/common/colorRegistry';
 
 export const IPeekViewService = createDecorator<IPeekViewService>('IPeekViewService');
 export interface IPeekViewService {

--- a/src/vs/editor/contrib/peekView/browser/peekView.ts
+++ b/src/vs/editor/contrib/peekView/browser/peekView.ts
@@ -278,7 +278,7 @@ export abstract class PeekViewWidget extends ZoneWidget {
 }
 
 
-export const peekViewTitleBackground = registerColor('peekViewTitle.background', { dark: transparent(editorInfoForeground, .1), light: transparent(editorInfoForeground, .1), hcDark: null, hcLight: null }, nls.localize('peekViewTitleBackground', 'Background color of the peek view title area.'));
+export const peekViewTitleBackground = registerColor('peekViewTitle.background', { dark: '#252526', light: '#F3F3F3', hcDark: Color.black, hcLight: Color.white }, nls.localize('peekViewTitleBackground', 'Background color of the peek view title area.'));
 export const peekViewTitleForeground = registerColor('peekViewTitleLabel.foreground', { dark: Color.white, light: Color.black, hcDark: Color.white, hcLight: editorForeground }, nls.localize('peekViewTitleForeground', 'Color of the peek view title.'));
 export const peekViewTitleInfoForeground = registerColor('peekViewTitleDescription.foreground', { dark: '#ccccccb3', light: '#616161', hcDark: '#FFFFFF99', hcLight: '#292929' }, nls.localize('peekViewTitleInfoForeground', 'Color of the peek view title info.'));
 export const peekViewBorder = registerColor('peekView.border', { dark: editorInfoForeground, light: editorInfoForeground, hcDark: contrastBorder, hcLight: contrastBorder }, nls.localize('peekViewBorder', 'Color of the peek view borders and arrow.'));

--- a/src/vs/editor/contrib/stickyScroll/browser/stickyScroll.css
+++ b/src/vs/editor/contrib/stickyScroll/browser/stickyScroll.css
@@ -35,7 +35,7 @@
 .monaco-editor .sticky-widget {
 	width: 100%;
 	box-shadow: var(--vscode-scrollbar-shadow) 0 3px 2px -2px;
-	z-index: 11;
+	z-index: 4;
 	background-color: var(--vscode-editorStickyScroll-background);
 }
 


### PR DESCRIPTION
Decreasing the z-index to 4 and setting the background color of the peekview header to a solid color

The background color chosen for the peek view header is the same color as the for peek view results (where the file names are located).

In relation to issue: https://github.com/microsoft/vscode/issues/174134

https://user-images.githubusercontent.com/61460952/222395043-a998036d-ab66-40d8-b413-2af3eb8a6cda.mov

