### PR TITLE
"tab.activeBorderTop" color hidden under "editorGroup.border" (fix #174134)

### DIFF
--- a/src/vs/base/browser/ui/splitview/splitview.css
+++ b/src/vs/base/browser/ui/splitview/splitview.css
@@ -54,7 +54,7 @@
 	position: absolute;
 	top: 0;
 	left: 0;
-	z-index: 20;
+	z-index: 5;
 	pointer-events: none;
 	background-color: var(--separator-border);
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
