### PR TITLE
LinkParsing: Support "foo line 123"

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/links/browser/terminalLinkParsing.ts
+++ b/src/vs/workbench/contrib/terminalContrib/links/browser/terminalLinkParsing.ts
@@ -70,7 +70,8 @@ const linkSuffixRegexEol = new Lazy<RegExp>(() => {
 		// "foo" on line 339
 		// "foo" on line 339, col 12
 		// "foo" on line 339, column 12
-		`['"]?(?:, |: ?| on )line ${l()}(, col(?:umn)? ${c()})?$`,
+		// "foo" line 339 column 12
+		`['"]?(?:,? |: ?| on )line ${l()}(,? col(?:umn)? ${c()})?$`,
 		// foo(339)
 		// foo(339,12)
 		// foo(339, 12)
@@ -121,7 +122,8 @@ const linkSuffixRegex = new Lazy<RegExp>(() => {
 		// "foo" on line 339
 		// "foo" on line 339, col 12
 		// "foo" on line 339, column 12
-		`['"]?(?:, |: ?| on )line ${l()}(, col(?:umn)? ${c()})?`,
+		// "foo" line 339 column 12
+		`['"]?(?:,? |: ?| on )line ${l()}(,? col(?:umn)? ${c()})?`,
 		// foo(339)
 		// foo(339,12)
 		// foo(339, 12)

--- a/src/vs/workbench/contrib/terminalContrib/links/test/browser/terminalLinkParsing.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/links/test/browser/terminalLinkParsing.test.ts
@@ -40,6 +40,8 @@ const testLinks: ITestLink[] = [
 	{ link: '"foo" on line 339', prefix: '"', suffix: '" on line 339', hasRow: true, hasCol: false },
 	{ link: '"foo" on line 339, col 12', prefix: '"', suffix: '" on line 339, col 12', hasRow: true, hasCol: true },
 	{ link: '"foo" on line 339, column 12', prefix: '"', suffix: '" on line 339, column 12', hasRow: true, hasCol: true },
+	{ link: '"foo" line 339', prefix: '"', suffix: '" line 339', hasRow: true, hasCol: false },
+	{ link: '"foo" line 339 column 12', prefix: '"', suffix: '" line 339 column 12', hasRow: true, hasCol: true },
 
 	// Single quotes
 	{ link: '\'foo\',339', prefix: '\'', suffix: '\',339', hasRow: true, hasCol: false },
@@ -56,6 +58,8 @@ const testLinks: ITestLink[] = [
 	{ link: '\'foo\' on line 339', prefix: '\'', suffix: '\' on line 339', hasRow: true, hasCol: false },
 	{ link: '\'foo\' on line 339, col 12', prefix: '\'', suffix: '\' on line 339, col 12', hasRow: true, hasCol: true },
 	{ link: '\'foo\' on line 339, column 12', prefix: '\'', suffix: '\' on line 339, column 12', hasRow: true, hasCol: true },
+	{ link: '\'foo\' line 339', prefix: '\'', suffix: '\' line 339', hasRow: true, hasCol: false },
+	{ link: '\'foo\' line 339 column 12', prefix: '\'', suffix: '\' line 339 column 12', hasRow: true, hasCol: true },
 
 	// No quotes
 	{ link: 'foo, line 339', prefix: undefined, suffix: ', line 339', hasRow: true, hasCol: false },
@@ -70,6 +74,8 @@ const testLinks: ITestLink[] = [
 	{ link: 'foo on line 339', prefix: undefined, suffix: ' on line 339', hasRow: true, hasCol: false },
 	{ link: 'foo on line 339, col 12', prefix: undefined, suffix: ' on line 339, col 12', hasRow: true, hasCol: true },
 	{ link: 'foo on line 339, column 12', prefix: undefined, suffix: ' on line 339, column 12', hasRow: true, hasCol: true },
+	{ link: 'foo line 339', prefix: undefined, suffix: ' line 339', hasRow: true, hasCol: false },
+	{ link: 'foo line 339 column 12', prefix: undefined, suffix: ' line 339 column 12', hasRow: true, hasCol: true },
 
 	// Parentheses
 	{ link: 'foo(339)', prefix: undefined, suffix: '(339)', hasRow: true, hasCol: false },


### PR DESCRIPTION
Terraform output.

Example:
```
│ Error: Invalid reference
│
│   on main.tf line 2, in locals:
│    2:   foo = abcd
```

Fixes #175896
