### PR TITLE
support negation of arbitrary expressions in when-clauses

### DIFF
--- a/src/vs/platform/contextkey/common/contextkey.ts
+++ b/src/vs/platform/contextkey/common/contextkey.ts
@@ -255,15 +255,15 @@ or ::= and { '||' and }*
 and ::= term { '&&' term }*
 
 term ::=
-	| '!' (CONTEXT | 'true' | 'false') // we do not yet support negation of arbitrary expressions
+	| '!' (KEY | 'true' | 'false') // we do not yet support negation of arbitrary expressions
 	| primary
 
 primary ::=
 	| 'true'
 	| 'false'
 	| '(' expression ')'
-	| CONTEXT '=~' REGEX
-	| CONTEXT [ ('==' | '!=' | '<' | '<=' | '>' | '>=' | 'not' 'in' | 'in') value ]
+	| KEY '=~' REGEX
+	| KEY [ ('==' | '!=' | '<' | '<=' | '>' | '>=' | 'not' 'in' | 'in') value ]
 
 value ::=
 	| 'true'

--- a/src/vs/platform/contextkey/common/contextkey.ts
+++ b/src/vs/platform/contextkey/common/contextkey.ts
@@ -255,21 +255,24 @@ or ::= and { '||' and }*
 and ::= term { '&&' term }*
 
 term ::=
-	| '!' (KEY | 'true' | 'false') // we do not yet support negation of arbitrary expressions
+	| '!' (KEY | true | false | parenthesized)
 	| primary
 
 primary ::=
 	| 'true'
 	| 'false'
-	| '(' expression ')'
+	| parenthesized
 	| KEY '=~' REGEX
 	| KEY [ ('==' | '!=' | '<' | '<=' | '>' | '>=' | 'not' 'in' | 'in') value ]
+
+parenthesized ::=
+	| '(' expression ')'
 
 value ::=
 	| 'true'
 	| 'false'
 	| 'in'      	// we support `in` as a value because there's an extension that uses it, ie "when": "languageId == in"
-	| VALUE 		// matched by the same regex as CONTEXT; consider putting the value in single quotes if it's a string (e.g., with spaces)
+	| VALUE 		// matched by the same regex as KEY; consider putting the value in single quotes if it's a string (e.g., with spaces)
 	| SINGLE_QUOTED_STR
 	| EMPTY_STR  	// this allows "when": "foo == " which's used by existing extensions
 
@@ -298,7 +301,6 @@ export type ParsingError = {
 
 const errorEmptyString = localize('contextkey.parser.error.emptyString', "Empty context key expression");
 const hintEmptyString = localize('contextkey.parser.error.emptyString.hint', "Did you forget to write an expression? You can also put 'false' or 'true' to always evaluate to false or true, respectively.");
-const errorDontSupportArbitraryNegation = localize('contextkey.parser.error.dontSupportArbitraryNegation', "Negation of arbitrary expressions is not supported.");
 const errorNoInAfterNot = localize('contextkey.parser.error.noInAfterNot', "'in' after 'not'.");
 const errorClosingParenthesis = localize('contextkey.parser.error.closingParenthesis', "closing parenthesis ')'");
 const errorUnexpectedToken = localize('contextkey.parser.error.unexpectedToken', "Unexpected token");
@@ -410,19 +412,25 @@ export class Parser {
 
 	private _term(): ContextKeyExpression | undefined {
 		if (this._matchOne(TokenType.Neg)) {
-			const expr = this._peek();
-			switch (expr.type) {
-				case TokenType.Str:
-					this._advance();
-					return ContextKeyExpr.not(expr.lexeme!);
+			const peek = this._peek();
+			switch (peek.type) {
 				case TokenType.True:
 					this._advance();
-					return ContextKeyExpr.false();
+					return ContextKeyFalseExpr.INSTANCE;
 				case TokenType.False:
 					this._advance();
-					return ContextKeyExpr.true();
+					return ContextKeyTrueExpr.INSTANCE;
+				case TokenType.LParen: {
+					this._advance();
+					const expr = this._expr();
+					this._consume(TokenType.RParen, errorClosingParenthesis);
+					return expr?.negate();
+				}
+				case TokenType.Str:
+					this._advance();
+					return ContextKeyNotExpr.create(peek.lexeme);
 				default:
-					throw this._errExpectedButGot('CONTEXT | true | false', expr, errorDontSupportArbitraryNegation);
+					throw this._errExpectedButGot(`KEY | true | false | '(' expression ')'`, peek);
 			}
 		}
 		return this._primary();
@@ -448,7 +456,7 @@ export class Parser {
 			}
 
 			case TokenType.Str: {
-				// CONTEXT
+				// KEY
 				const key = peek.lexeme;
 				this._advance();
 
@@ -638,7 +646,7 @@ export class Parser {
 				throw new ParseError();
 
 			default:
-				throw this._errExpectedButGot(`true | false | CONTEXT \n\t| CONTEXT '=~' REGEX \n\t| CONTEXT ('==' | '!=' | '<' | '<=' | '>' | '>=' | 'in' | 'not' 'in') value`, this._peek());
+				throw this._errExpectedButGot(`true | false | KEY \n\t| KEY '=~' REGEX \n\t| KEY ('==' | '!=' | '<' | '<=' | '>' | '>=' | 'in' | 'not' 'in') value`, this._peek());
 
 		}
 	}

--- a/src/vs/platform/contextkey/test/common/parser.test.ts
+++ b/src/vs/platform/contextkey/test/common/parser.test.ts
@@ -119,6 +119,21 @@ suite('Context Key Parser', () => {
 		assert.deepStrictEqual(parseToStr(input), "cmake:enableFullFeatureSet && !cmake:hideBuildCommand");
 	});
 
+	test('!(foo && bar)', () => {
+		const input = '!(foo && bar)';
+		assert.deepStrictEqual(parseToStr(input), "!bar || !foo");
+	});
+
+	test('!(foo && bar || boar) || deer', () => {
+		const input = '!(foo && bar || boar) || deer';
+		assert.deepStrictEqual(parseToStr(input), "deer || !bar && !boar || !boar && !foo");
+	});
+
+	test(`!(!foo)`, () => {
+		const input = `!(!foo)`;
+		assert.deepStrictEqual(parseToStr(input), "foo");
+	});
+
 	suite('controversial', () => {
 		/*
 			new parser KEEPS old one's behavior:
@@ -195,19 +210,19 @@ suite('Context Key Parser', () => {
 			assert.deepStrictEqual(parseToStr(input), "Lexing errors:\n\nUnexpected token ''bar' at offset 7. Did you forget to open or close the quote?\n\n --- \nParsing errors:\n\nUnexpected ''bar' at offset 7.\n");
 		});
 
-		/*
-			We do not support negation of arbitrary expressions, only of keys.
-
-			TODO@ulugbekna: move after adding support for negation of arbitrary expressions
-		*/
-		test('!(foo && bar)', () => {
-			const input = '!(foo && bar)';
-			assert.deepStrictEqual(parseToStr(input), "Parsing errors:\n\nUnexpected '(' at offset 1.\n");
-		});
-
 		test(`config.foo &&  &&bar =~ /^foo$|^bar-foo$|^joo$|^jar$/ && !foo`, () => {
 			const input = `config.foo &&  &&bar =~ /^foo$|^bar-foo$|^joo$|^jar$/ && !foo`;
 			assert.deepStrictEqual(parseToStr(input), "Parsing errors:\n\nUnexpected '&&' at offset 15.\n");
+		});
+
+		test(`!foo == 'test'`, () => {
+			const input = `!foo == 'test'`;
+			assert.deepStrictEqual(parseToStr(input), "Parsing errors:\n\nUnexpected '==' at offset 5.\n");
+		});
+
+		test(`!!foo`, function () {
+			const input = `!!foo`;
+			assert.deepStrictEqual(parseToStr(input), "Parsing errors:\n\nUnexpected '!' at offset 1.\n");
 		});
 
 	});


### PR DESCRIPTION
- context keys: parser: rename CONTEXT to KEY because it makes more sense
- context keys: add support for negating arbitrary expressions (as long as they're parenthesized)

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
