### PR TITLE
option to disable encryption of keys

### DIFF
--- a/cli/src/auth.rs
+++ b/cli/src/auth.rs
@@ -183,7 +183,7 @@ where
 	T: Serialize + ?Sized,
 {
 	let dec = serde_json::to_string(value).expect("expected to serialize");
-	if std::env::var("VSCODE_CLI_DISABLE_ENCRYPT").is_ok() {
+	if std::env::var("VSCODE_CLI_DISABLE_KEYCHAIN_ENCRYPT").is_ok() {
 		return dec;
 	}
 	encrypt(&dec)
@@ -194,7 +194,7 @@ fn unseal<T>(value: &str) -> Option<T>
 where
 	T: DeserializeOwned,
 {
-	// small back-compat for old unencrypted values, or if VSCODE_CLI_DISABLE_ENCRYPT set
+	// small back-compat for old unencrypted values, or if VSCODE_CLI_DISABLE_KEYCHAIN_ENCRYPT set
 	if let Ok(v) = serde_json::from_str::<T>(value) {
 		return Some(v);
 	}

--- a/cli/src/auth.rs
+++ b/cli/src/auth.rs
@@ -186,7 +186,7 @@ where
 	if std::env::var("VSCODE_CLI_DISABLE_ENCRYPT").is_ok() {
 		return dec;
 	}
-	encrypt(&dec);
+	encrypt(&dec)
 }
 
 // unseal decrypts and deserializes the value

--- a/cli/src/auth.rs
+++ b/cli/src/auth.rs
@@ -183,7 +183,10 @@ where
 	T: Serialize + ?Sized,
 {
 	let dec = serde_json::to_string(value).expect("expected to serialize");
-	encrypt(&dec)
+	if std::env::var("VSCODE_CLI_DISABLE_ENCRYPT").is_ok() {
+		return dec;
+	}
+	encrypt(&dec);
 }
 
 // unseal decrypts and deserializes the value
@@ -191,7 +194,7 @@ fn unseal<T>(value: &str) -> Option<T>
 where
 	T: DeserializeOwned,
 {
-	// small back-compat for old unencrypted values
+	// small back-compat for old unencrypted values, or if VSCODE_CLI_DISABLE_ENCRYPT set
 	if let Ok(v) = serde_json::from_str::<T>(value) {
 		return Some(v);
 	}


### PR DESCRIPTION
Avoids issue of token invalidation when switching machines with a shared home directory, as suggested by @connor4312 in https://github.com/microsoft/vscode-remote-release/issues/8110#issuecomment-1452270922

Fixes https://github.com/microsoft/vscode-remote-release/issues/8110

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
