### PR TITLE
Use outline instead of border for filterMatchBorder in explorer

### DIFF
--- a/src/vs/workbench/browser/parts/views/media/views.css
+++ b/src/vs/workbench/browser/parts/views/media/views.css
@@ -21,8 +21,8 @@
 .monaco-tl-contents .monaco-highlighted-label .highlight {
 	color: unset !important;
 	background-color: var(--vscode-list-filterMatchBackground);
-	border: 1px dotted var(--vscode-list-filterMatchBorder);
-	box-sizing: border-box;
+	outline: 1px dotted var(--vscode-list-filterMatchBorder);
+	outline-offset: -1px;
 }
 
 .monaco-workbench .tree-explorer-viewlet-tree-view {


### PR DESCRIPTION
Fixes #175947

This makes sure we don't shift around content when adding the border/outline