### PR TITLE
Hide find widget controls for small widget

### DIFF
--- a/src/vs/base/browser/ui/findinput/findInput.ts
+++ b/src/vs/base/browser/ui/findinput/findInput.ts
@@ -191,7 +191,7 @@ export class FindInput extends Widget {
 
 		this.controls = document.createElement('div');
 		this.controls.className = 'controls';
-		this.controls.style.display = this.showCommonFindToggles ? 'block' : 'none';
+		this.controls.style.display = this.showCommonFindToggles ? '' : 'none';
 		if (this.caseSensitive) {
 			this.controls.append(this.caseSensitive.domNode);
 		}
@@ -230,6 +230,11 @@ export class FindInput extends Widget {
 
 	public get onDidChange(): Event<string> {
 		return this.inputBox.onDidChange;
+	}
+
+	public layout(style: { collapsedFindWidget: boolean; narrowFindWidget: boolean; reducedFindWidget: boolean }) {
+		this.inputBox.layout();
+		this.updateInputBoxPadding(style.collapsedFindWidget);
 	}
 
 	public enable(): void {
@@ -291,12 +296,20 @@ export class FindInput extends Widget {
 		}
 
 		if (this.additionalToggles.length > 0) {
-			this.controls.style.display = 'block';
+			this.controls.style.display = '';
 		}
 
-		this.inputBox.paddingRight =
-			((this.caseSensitive?.width() ?? 0) + (this.wholeWords?.width() ?? 0) + (this.regex?.width() ?? 0))
-			+ this.additionalToggles.reduce((r, t) => r + t.width(), 0);
+		this.updateInputBoxPadding();
+	}
+
+	private updateInputBoxPadding(controlsHidden = false) {
+		if (controlsHidden) {
+			this.inputBox.paddingRight = 0;
+		} else {
+			this.inputBox.paddingRight =
+				((this.caseSensitive?.width() ?? 0) + (this.wholeWords?.width() ?? 0) + (this.regex?.width() ?? 0))
+				+ this.additionalToggles.reduce((r, t) => r + t.width(), 0);
+		}
 	}
 
 	public clear(): void {

--- a/src/vs/editor/contrib/find/browser/findWidget.ts
+++ b/src/vs/editor/contrib/find/browser/findWidget.ts
@@ -731,8 +731,8 @@ export class FindWidget extends Widget implements IOverlayWidget, IVerticalSashL
 			this._domNode.style.maxWidth = `${editorWidth - 28 - minimapWidth - 15}px`;
 		}
 
+		this._findInput.layout({ collapsedFindWidget, narrowFindWidget, reducedFindWidget });
 		if (this._resized) {
-			this._findInput.inputBox.layout();
 			const findInputWidth = this._findInput.inputBox.element.clientWidth;
 			if (findInputWidth > 0) {
 				this._replaceInput.width = findInputWidth;


### PR DESCRIPTION
Fixes #175954

Fixes the controls not being hidden and also makes sure we remove the right padding on the find input for small find widgets when the controls are hidden
