### PR TITLE
Remove the `Refactor with Preview` command

### DIFF
--- a/src/vs/editor/contrib/codeAction/browser/codeActionContributions.ts
+++ b/src/vs/editor/contrib/codeAction/browser/codeActionContributions.ts
@@ -5,7 +5,7 @@
 
 import { EditorContributionInstantiation, registerEditorAction, registerEditorCommand, registerEditorContribution } from 'vs/editor/browser/editorExtensions';
 import { editorConfigurationBaseNode } from 'vs/editor/common/config/editorConfigurationSchema';
-import { AutoFixAction, CodeActionCommand, CodeActionController, FixAllAction, OrganizeImportsAction, QuickFixAction, RefactorAction, RefactorPreview, SourceAction } from 'vs/editor/contrib/codeAction/browser/codeActionCommands';
+import { AutoFixAction, CodeActionCommand, CodeActionController, FixAllAction, OrganizeImportsAction, QuickFixAction, RefactorAction, SourceAction } from 'vs/editor/contrib/codeAction/browser/codeActionCommands';
 import * as nls from 'vs/nls';
 import { ConfigurationScope, Extensions, IConfigurationRegistry } from 'vs/platform/configuration/common/configurationRegistry';
 import { Registry } from 'vs/platform/registry/common/platform';
@@ -13,7 +13,6 @@ import { Registry } from 'vs/platform/registry/common/platform';
 registerEditorContribution(CodeActionController.ID, CodeActionController, EditorContributionInstantiation.Eventually);
 registerEditorAction(QuickFixAction);
 registerEditorAction(RefactorAction);
-registerEditorAction(RefactorPreview);
 registerEditorAction(SourceAction);
 registerEditorAction(OrganizeImportsAction);
 registerEditorAction(AutoFixAction);

--- a/src/vs/editor/contrib/codeAction/common/types.ts
+++ b/src/vs/editor/contrib/codeAction/common/types.ts
@@ -146,7 +146,6 @@ export interface CodeActionTrigger {
 		readonly notAvailableMessage: string;
 		readonly position: Position;
 	};
-	readonly preview?: boolean;
 }
 
 export class CodeActionCommandArgs {


### PR DESCRIPTION
The new code action UI now supports previewing code actions directly so we don't need this command anymore (it was also broken and no one seems to have noticed this)