### PR TITLE
Rebuild markdown media in case of layouting

### DIFF
--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts
@@ -667,8 +667,8 @@ export class GettingStartedPage extends EditorPane {
 			const layoutDelayer = new Delayer(50);
 
 			this.layoutMarkdown = () => {
-				layoutDelayer.trigger(() => {
-					webview.postMessage({ layoutMeNow: true });
+				layoutDelayer.trigger(async () => {
+					this.buildMediaComponent(stepId);
 				});
 			};
 


### PR DESCRIPTION
Fixes: https://github.com/microsoft/vscode/issues/175386

I couldn't switch to using IOverlayWebview since we do need interactivity. ex: [`Choose the look you want`](https://github.com/microsoft/vscode/blob/58e3dd3f033a53972103053a95182f887d11f37f/src/vs/workbench/contrib/welcomeGettingStarted/common/gettingStartedContent.ts#LL201C37-L201C37) step uses https://github.com/microsoft/vscode/blob/58e3dd3f033a53972103053a95182f887d11f37f/src/vs/workbench/contrib/welcomeGettingStarted/common/media/theme_picker.ts#L11

I instead chose to rebuild the container in-case of layouting.