### PR TITLE
Handle `ParameterBindingException` for PowerShell 5.1

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/media/shellIntegration.ps1
+++ b/src/vs/workbench/contrib/terminal/browser/media/shellIntegration.ps1
@@ -95,7 +95,13 @@ if (Get-Module -Name PSReadLine) {
 # Set always on key handlers which map to default VS Code keybindings
 function Set-MappedKeyHandler {
 	param ([string[]] $Chord, [string[]]$Sequence)
-	$Handler = $(Get-PSReadLineKeyHandler -Chord $Chord | Select-Object -First 1)
+	try {
+		$Handler = Get-PSReadLineKeyHandler -Chord $Chord | Select-Object -First 1
+	} catch [System.Management.Automation.ParameterBindingException] {
+		# PowerShell 5.1 ships with PSReadLine 2.0.0 which does not have -Chord,
+		# so we check what's bound and filter it.
+		$Handler = Get-PSReadLineKeyHandler -Bound | Where-Object -FilterScript { $_.Key -eq $Chord } | Select-Object -First 1
+	}
 	if ($Handler) {
 		Set-PSReadLineKeyHandler -Chord $Sequence -Function $Handler.Function
 	}


### PR DESCRIPTION
Which ships with PSReadLine 2.0.0 whose `Get-PSReadLineKeyHandler` function does not support `-Chord`. Easiest fix is catching the exception in that rare case and using `-Bound` and a filter to do the same thing.

Note that most people do upgrade PSReadLine, but there are cases where an inbox PowerShell 5.1 is being used without an update (and it may not always be updateable).

Interestingly `Set-PSReadLineKeyHandler` does have `-Chord` in this older version, so it can be left alone.

Fixes https://github.com/PowerShell/vscode-powershell/issues/4409 (which should have been an upstream issue).