### PR TITLE
fix workbench.action.findInFiles arguements usage

### DIFF
--- a/src/vs/workbench/contrib/search/browser/searchActionsFind.ts
+++ b/src/vs/workbench/contrib/search/browser/searchActionsFind.ts
@@ -381,9 +381,8 @@ export async function findInFilesCommand(accessor: ServicesAccessor, _args: IFin
 				const searchAndReplaceWidget = openedView.searchAndReplaceWidget;
 				searchAndReplaceWidget.toggleReplace(typeof args.replace === 'string');
 				let updatedText = false;
-				if (typeof args.query === 'string') {
-					openedView.setSearchParameters(args);
-				} else {
+				openedView.setSearchParameters(args);
+				if (typeof args.query !== 'string') {
 					updatedText = openedView.updateTextFromFindWidgetOrSelection({ allowUnselectedWord: typeof args.replace !== 'string' });
 				}
 				openedView.searchAndReplaceWidget.focus(undefined, updatedText, updatedText);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

When not using the `query` argument in `workbench.action.findInFiles`, the other arguments are not used. Fixing this issue will allow to create a keybinding to perform a search in the current directory like:

```json
{
    "key": "ctrl+shift+g",
    "command": "workbench.action.findInFiles",
    "args": {
        "filesToInclude": "./${relativeFileDirname}",
    }
},
```

which fixes #175546 too.
