### PR TITLE
Improve view title of references-view (fixes #172619)

### DIFF
--- a/extensions/references-view/package.nls.json
+++ b/extensions/references-view/package.nls.json
@@ -5,7 +5,7 @@
 	"config.references.preferredLocation.peek": "Show references in peek editor.",
 	"config.references.preferredLocation.view": "Show references in separate view.",
 	"container.title": "References",
-	"view.title": "Results",
+	"view.title": "Reference Search Results",
 	"cmd.category.references": "References",
 	"cmd.references-view.findReferences": "Find All References",
 	"cmd.references-view.findImplementations": "Find All Implementations",


### PR DESCRIPTION
This PR fixes #172619 by giving the view a more descriptive title property.

![image](https://user-images.githubusercontent.com/6726799/222715336-99104e49-8245-4783-bab8-2e015b0e401c.png)
