### PR TITLE
Adding the possibility to scroll up and down the editor hover widget

### DIFF
--- a/src/vs/editor/common/editorContextKeys.ts
+++ b/src/vs/editor/common/editorContextKeys.ts
@@ -39,9 +39,11 @@ export namespace EditorContextKeys {
 	export const canRedo = new RawContextKey<boolean>('canRedo', false, true);
 
 	export const hoverVisible = new RawContextKey<boolean>('editorHoverVisible', false, nls.localize('editorHoverVisible', "Whether the editor hover is visible"));
+	export const hoverFocused = new RawContextKey<boolean>('editorHoverFocused', false, nls.localize('editorHoverFocused', "Whether the editor hover is focused"));
 
 	export const stickyScrollFocused = new RawContextKey<boolean>('stickyScrollFocused', false, nls.localize('stickyScrollFocused', "Whether the sticky scroll is focused"));
 	export const stickyScrollVisible = new RawContextKey<boolean>('stickyScrollVisible', false, nls.localize('stickyScrollVisible', "Whether the sticky scroll is visible"));
+
 	/**
 	 * A context key that is set when an editor is part of a larger editor, like notebooks or
 	 * (future) a diff editor

--- a/src/vs/editor/contrib/hover/browser/contentHover.ts
+++ b/src/vs/editor/contrib/hover/browser/contentHover.ts
@@ -340,6 +340,10 @@ export class ContentHoverController extends Disposable {
 			highlightRange
 		};
 	}
+
+	public focus(): void {
+		this._widget.focus();
+	}
 }
 
 class HoverResult {
@@ -579,6 +583,10 @@ export class ContentHoverWidget extends Disposable implements IContentWidget {
 
 	public clear(): void {
 		this._hover.contentsDomNode.textContent = '';
+	}
+
+	public focus(): void {
+		this._hover.containerDomNode.focus();
 	}
 }
 

--- a/src/vs/editor/contrib/hover/browser/contentHover.ts
+++ b/src/vs/editor/contrib/hover/browser/contentHover.ts
@@ -344,6 +344,14 @@ export class ContentHoverController extends Disposable {
 	public focus(): void {
 		this._widget.focus();
 	}
+
+	public scrollUp(): void {
+		this._widget.scrollUp();
+	}
+
+	public scrollDown(): void {
+		this._widget.scrollDown();
+	}
 }
 
 class HoverResult {
@@ -404,7 +412,9 @@ export class ContentHoverWidget extends Disposable implements IContentWidget {
 	public readonly allowEditorOverflow = true;
 
 	private readonly _hoverVisibleKey = EditorContextKeys.hoverVisible.bindTo(this._contextKeyService);
+	private readonly _hoverFocusedKey = EditorContextKeys.hoverFocused.bindTo(this._contextKeyService);
 	private readonly _hover: HoverWidget = this._register(new HoverWidget());
+	private readonly _focusTracker = this._register(dom.trackFocus(this.getDomNode()));
 
 	private _visibleData: ContentHoverVisibleData | null = null;
 
@@ -439,6 +449,13 @@ export class ContentHoverWidget extends Disposable implements IContentWidget {
 		this._setVisibleData(null);
 		this._layout();
 		this._editor.addContentWidget(this);
+
+		this._register(this._focusTracker.onDidFocus(() => {
+			this._hoverFocusedKey.set(true);
+		}));
+		this._register(this._focusTracker.onDidBlur(() => {
+			this._hoverFocusedKey.set(false);
+		}));
 	}
 
 	public override dispose(): void {
@@ -587,6 +604,18 @@ export class ContentHoverWidget extends Disposable implements IContentWidget {
 
 	public focus(): void {
 		this._hover.containerDomNode.focus();
+	}
+
+	public scrollUp(): void {
+		const scrollTop = this._hover.scrollbar.getScrollPosition().scrollTop;
+		const fontInfo = this._editor.getOption(EditorOption.fontInfo);
+		this._hover.scrollbar.setScrollPosition({ scrollTop: scrollTop - fontInfo.lineHeight });
+	}
+
+	public scrollDown(): void {
+		const scrollTop = this._hover.scrollbar.getScrollPosition().scrollTop;
+		const fontInfo = this._editor.getOption(EditorOption.fontInfo);
+		this._hover.scrollbar.setScrollPosition({ scrollTop: scrollTop + fontInfo.lineHeight });
 	}
 }
 

--- a/src/vs/editor/contrib/hover/browser/contentHover.ts
+++ b/src/vs/editor/contrib/hover/browser/contentHover.ts
@@ -352,6 +352,14 @@ export class ContentHoverController extends Disposable {
 	public scrollDown(): void {
 		this._widget.scrollDown();
 	}
+
+	public pageUp(): void {
+		this._widget.pageUp();
+	}
+
+	public pageDown(): void {
+		this._widget.pageDown();
+	}
 }
 
 class HoverResult {
@@ -616,6 +624,18 @@ export class ContentHoverWidget extends Disposable implements IContentWidget {
 		const scrollTop = this._hover.scrollbar.getScrollPosition().scrollTop;
 		const fontInfo = this._editor.getOption(EditorOption.fontInfo);
 		this._hover.scrollbar.setScrollPosition({ scrollTop: scrollTop + fontInfo.lineHeight });
+	}
+
+	public pageUp(): void {
+		const scrollTop = this._hover.scrollbar.getScrollPosition().scrollTop;
+		const scrollHeight = this._hover.scrollbar.getScrollDimensions().height;
+		this._hover.scrollbar.setScrollPosition({ scrollTop: scrollTop - scrollHeight });
+	}
+
+	public pageDown(): void {
+		const scrollTop = this._hover.scrollbar.getScrollPosition().scrollTop;
+		const scrollHeight = this._hover.scrollbar.getScrollDimensions().height;
+		this._hover.scrollbar.setScrollPosition({ scrollTop: scrollTop + scrollHeight });
 	}
 }
 

--- a/src/vs/editor/contrib/hover/browser/contentHover.ts
+++ b/src/vs/editor/contrib/hover/browser/contentHover.ts
@@ -208,6 +208,10 @@ export class ContentHoverController extends Disposable {
 		return this._widget.isVisibleFromKeyboard;
 	}
 
+	public isVisible(): boolean {
+		return this._widget.isVisible;
+	}
+
 	public containsNode(node: Node): boolean {
 		return this._widget.getDomNode().contains(node);
 	}
@@ -439,6 +443,10 @@ export class ContentHoverWidget extends Disposable implements IContentWidget {
 
 	public get isVisibleFromKeyboard(): boolean {
 		return (this._visibleData?.source === HoverStartSource.Keyboard);
+	}
+
+	public get isVisible(): boolean {
+		return this._hoverVisibleKey.get() ?? false;
 	}
 
 	constructor(

--- a/src/vs/editor/contrib/hover/browser/hover.ts
+++ b/src/vs/editor/contrib/hover/browser/hover.ts
@@ -238,8 +238,7 @@ export class ModesHoverController implements IEditorContribution {
 	}
 
 	public showContentHover(range: Range, mode: HoverStartMode, source: HoverStartSource, focus: boolean): void {
-		const hoverContentWidget = this._getOrCreateContentWidget();
-		hoverContentWidget.startShowingAtRange(range, mode, source, focus);
+		this._getOrCreateContentWidget().startShowingAtRange(range, mode, source, focus);
 	}
 
 	public focus(): void {
@@ -283,7 +282,8 @@ class ShowOrFocusHoverAction extends EditorAction {
 			label: nls.localize({
 				key: 'showOrFocusHover',
 				comment: [
-					'Label for action that will trigger the showing of a hover in the editor.',
+					'Label for action that will trigger the showing/focusing of a hover in the editor.',
+					'If the hover is not visible, it will show the hover.',
 					'This allows for users to show the hover without using the mouse.',
 					'If the hover is already visible, it will take focus.'
 				]
@@ -329,7 +329,7 @@ class ShowOrFocusHoverAction extends EditorAction {
 		if (controller.isHoverVisible()) {
 			controller.focus();
 		} else {
-			controller.showHover(range, HoverStartMode.Immediate, HoverStartSource.Keyboard, focus);
+			controller.showContentHover(range, HoverStartMode.Immediate, HoverStartSource.Keyboard, focus);
 		}
 	}
 }
@@ -369,7 +369,7 @@ class ShowDefinitionPreviewHoverAction extends EditorAction {
 		}
 		const promise = goto.startFindDefinitionFromCursor(position);
 		promise.then(() => {
-			controller.showHover(range, HoverStartMode.Immediate, HoverStartSource.Keyboard, true);
+			controller.showContentHover(range, HoverStartMode.Immediate, HoverStartSource.Keyboard, true);
 		});
 	}
 }

--- a/src/vs/editor/contrib/hover/browser/hover.ts
+++ b/src/vs/editor/contrib/hover/browser/hover.ts
@@ -237,6 +237,14 @@ export class ModesHoverController implements IEditorContribution {
 		this._contentWidget?.focus();
 	}
 
+	public scrollUp(): void {
+		this._contentWidget?.scrollUp();
+	}
+
+	public scrollDown(): void {
+		this._contentWidget?.scrollDown();
+	}
+
 	public dispose(): void {
 		this._unhookEvents();
 		this._toUnhook.dispose();
@@ -353,10 +361,74 @@ class FocusHoverAction extends EditorAction {
 	}
 }
 
+class ScrollUpHoverAction extends EditorAction {
+
+	constructor() {
+		super({
+			id: 'editor.action.scrollUpHover',
+			label: nls.localize({
+				key: 'scrollUpHover',
+				comment: [
+					'Action that allows to scroll up in the hover widget with the up arrow when the hover widget is focused.'
+				]
+			}, "Scroll Up Hover"),
+			alias: 'Scroll Up Hover',
+			precondition: EditorContextKeys.hoverFocused,
+			kbOpts: {
+				kbExpr: EditorContextKeys.hoverFocused,
+				primary: KeyCode.UpArrow,
+				weight: KeybindingWeight.EditorContrib + 10000
+			}
+		});
+	}
+
+	public run(accessor: ServicesAccessor, editor: ICodeEditor): void {
+		console.log('Inside of scroll up');
+		const controller = ModesHoverController.get(editor);
+		if (!controller) {
+			return;
+		}
+		controller.scrollUp();
+	}
+}
+
+class ScrollDownHoverAction extends EditorAction {
+
+	constructor() {
+		super({
+			id: 'editor.action.scrollDownHover',
+			label: nls.localize({
+				key: 'scrollDownHover',
+				comment: [
+					'Action that allows to scroll down in the hover widget with the up arrow when the hover widget is focused.'
+				]
+			}, "Scroll Down Hover"),
+			alias: 'Scroll Down Hover',
+			precondition: EditorContextKeys.hoverFocused,
+			kbOpts: {
+				kbExpr: EditorContextKeys.hoverFocused,
+				primary: KeyCode.DownArrow,
+				weight: KeybindingWeight.EditorContrib + 10000
+			}
+		});
+	}
+
+	public run(accessor: ServicesAccessor, editor: ICodeEditor): void {
+		console.log('Inside of scroll down');
+		const controller = ModesHoverController.get(editor);
+		if (!controller) {
+			return;
+		}
+		controller.scrollDown();
+	}
+}
+
 registerEditorContribution(ModesHoverController.ID, ModesHoverController, EditorContributionInstantiation.BeforeFirstInteraction);
 registerEditorAction(ShowHoverAction);
 registerEditorAction(ShowDefinitionPreviewHoverAction);
 registerEditorAction(FocusHoverAction);
+registerEditorAction(ScrollUpHoverAction);
+registerEditorAction(ScrollDownHoverAction);
 HoverParticipantRegistry.register(MarkdownHoverParticipant);
 HoverParticipantRegistry.register(MarkerHoverParticipant);
 

--- a/src/vs/editor/contrib/hover/browser/hover.ts
+++ b/src/vs/editor/contrib/hover/browser/hover.ts
@@ -377,7 +377,7 @@ class ScrollUpHoverAction extends EditorAction {
 			kbOpts: {
 				kbExpr: EditorContextKeys.hoverFocused,
 				primary: KeyCode.UpArrow,
-				weight: KeybindingWeight.EditorContrib + 10000
+				weight: KeybindingWeight.EditorContrib
 			}
 		});
 	}
@@ -408,7 +408,7 @@ class ScrollDownHoverAction extends EditorAction {
 			kbOpts: {
 				kbExpr: EditorContextKeys.hoverFocused,
 				primary: KeyCode.DownArrow,
-				weight: KeybindingWeight.EditorContrib + 10000
+				weight: KeybindingWeight.EditorContrib
 			}
 		});
 	}

--- a/src/vs/editor/contrib/hover/browser/hover.ts
+++ b/src/vs/editor/contrib/hover/browser/hover.ts
@@ -198,7 +198,11 @@ export class ModesHoverController implements IEditorContribution {
 	}
 
 	private _onKeyDown(e: IKeyboardEvent): void {
-		if (e.keyCode !== KeyCode.Ctrl && e.keyCode !== KeyCode.Alt && e.keyCode !== KeyCode.Meta && e.keyCode !== KeyCode.Shift) {
+		console.log('e : ', e);
+
+		// Since the hover disappears as soon as a key code is pressed, the keybindings chosen only has on keycode and several key mods
+		if (e.keyCode !== KeyCode.Ctrl && e.keyCode !== KeyCode.Alt && e.keyCode !== KeyCode.Meta && e.keyCode !== KeyCode.Shift
+			&& !(e.keyCode === KeyCode.KeyK && e.altKey === true && e.metaKey === true && e.shiftKey === true)) {
 			// Do not hide hover when a modifier key is pressed
 			this._hideWidgets();
 		}
@@ -334,7 +338,7 @@ class FocusHoverAction extends EditorAction {
 			precondition: EditorContextKeys.hoverVisible,
 			kbOpts: {
 				kbExpr: EditorContextKeys.hoverVisible,
-				primary: KeyMod.CtrlCmd | KeyCode.KeyK | KeyCode.KeyF, // Change the keybindings later
+				primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyMod.Alt | KeyCode.KeyK, // Change the keybindings later
 				weight: KeybindingWeight.EditorContrib
 			}
 		});

--- a/src/vs/editor/contrib/hover/browser/hover.ts
+++ b/src/vs/editor/contrib/hover/browser/hover.ts
@@ -55,7 +55,6 @@ export class ModesHoverController implements IEditorContribution {
 		@IInstantiationService private readonly _instantiationService: IInstantiationService,
 		@IOpenerService private readonly _openerService: IOpenerService,
 		@ILanguageService private readonly _languageService: ILanguageService,
-		@IContextKeyService _contextKeyService: IContextKeyService,
 		@IKeybindingService private readonly _keybindingService: IKeybindingService
 	) {
 		this._isMouseDown = false;

--- a/src/vs/editor/contrib/hover/browser/hover.ts
+++ b/src/vs/editor/contrib/hover/browser/hover.ts
@@ -296,7 +296,7 @@ class ShowOrFocusHoverAction extends EditorAction {
 						type: 'object',
 						properties: {
 							'focus': {
-								description: 'Controls if when shown, the hover should take focus immediately.',
+								description: 'Controls if when triggered with the keyboard, the hover should take focus immediately.',
 								type: 'boolean',
 								default: false
 							}

--- a/src/vs/editor/contrib/hover/browser/hover.ts
+++ b/src/vs/editor/contrib/hover/browser/hover.ts
@@ -19,7 +19,6 @@ import { ContentHoverWidget, ContentHoverController } from 'vs/editor/contrib/ho
 import { MarginHoverWidget } from 'vs/editor/contrib/hover/browser/marginHover';
 import * as nls from 'vs/nls';
 import { AccessibilitySupport } from 'vs/platform/accessibility/common/accessibility';
-import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { KeybindingWeight } from 'vs/platform/keybinding/common/keybindingsRegistry';
 import { IOpenerService } from 'vs/platform/opener/common/opener';

--- a/src/vs/editor/contrib/hover/browser/hover.ts
+++ b/src/vs/editor/contrib/hover/browser/hover.ts
@@ -30,7 +30,6 @@ import { MarkdownHoverParticipant } from 'vs/editor/contrib/hover/browser/markdo
 import { MarkerHoverParticipant } from 'vs/editor/contrib/hover/browser/markerHoverParticipant';
 import 'vs/css!./hover';
 import { InlineSuggestionHintsContentWidget } from 'vs/editor/contrib/inlineCompletions/browser/inlineSuggestionHintsWidget';
-
 export class ModesHoverController implements IEditorContribution {
 
 	public static readonly ID = 'editor.contrib.hover';
@@ -230,6 +229,10 @@ export class ModesHoverController implements IEditorContribution {
 		this._getOrCreateContentWidget().startShowingAtRange(range, mode, source, focus);
 	}
 
+	public focus(): void {
+		this._contentWidget?.focus();
+	}
+
 	public dispose(): void {
 		this._unhookEvents();
 		this._toUnhook.dispose();
@@ -316,9 +319,40 @@ class ShowDefinitionPreviewHoverAction extends EditorAction {
 	}
 }
 
+class FocusHoverAction extends EditorAction {
+
+	constructor() {
+		super({
+			id: 'editor.action.focusHover',
+			label: nls.localize({
+				key: 'focusHover',
+				comment: [
+					'Action that allows to focus on the hover widget, when there is a hover widget visible.'
+				]
+			}, "Focus Hover"),
+			alias: 'Focus Hover',
+			precondition: EditorContextKeys.hoverVisible,
+			kbOpts: {
+				kbExpr: EditorContextKeys.hoverVisible,
+				primary: KeyMod.CtrlCmd | KeyCode.KeyK | KeyCode.KeyF, // Change the keybindings later
+				weight: KeybindingWeight.EditorContrib
+			}
+		});
+	}
+
+	public run(accessor: ServicesAccessor, editor: ICodeEditor): void {
+		const controller = ModesHoverController.get(editor);
+		if (!controller) {
+			return;
+		}
+		controller.focus();
+	}
+}
+
 registerEditorContribution(ModesHoverController.ID, ModesHoverController, EditorContributionInstantiation.BeforeFirstInteraction);
 registerEditorAction(ShowHoverAction);
 registerEditorAction(ShowDefinitionPreviewHoverAction);
+registerEditorAction(FocusHoverAction);
 HoverParticipantRegistry.register(MarkdownHoverParticipant);
 HoverParticipantRegistry.register(MarkerHoverParticipant);
 

--- a/src/vs/editor/contrib/hover/browser/hover.ts
+++ b/src/vs/editor/contrib/hover/browser/hover.ts
@@ -208,7 +208,7 @@ export class ModesHoverController implements IEditorContribution {
 		// If there a mapping to the key names, how they are returned inside of the keyboard events
 		// The keybindings associated with focusing the hover widget should not be pressed
 		if (e.keyCode !== KeyCode.Ctrl && e.keyCode !== KeyCode.Alt && e.keyCode !== KeyCode.Meta && e.keyCode !== KeyCode.Shift
-			&& !(keys && e.keyCode === KeyCode.KeyK && e.ctrlKey === keys.ctrlKey && e.altKey === keys.altKey && e.metaKey === keys.metaKey && e.shiftKey === keys.shiftKey)) {
+			&& !(keys && e.code === ('Key' + keys.keyLabel) && e.ctrlKey === keys.ctrlKey && e.altKey === keys.altKey && e.metaKey === keys.metaKey && e.shiftKey === keys.shiftKey)) {
 			// Do not hide hover when a modifier key is pressed
 			this._hideWidgets();
 		}


### PR DESCRIPTION
Fixes: https://github.com/microsoft/vscode/issues/69836

This PR adds code in order to allow the user to scroll the hover widget using the keyboard. If the content hover is visible, it is possible to focus the hover and then use the arrow up, arrow down, page up and page down keys to navigate in the hover. Provided the hover is visible, the default keybindings for focusing the hover are `cmd+k cmd+i`, the same as the keybindings to toggle the hover. It is also possible to define settings in the `keybindings.json` file to specify if the hover should automatically be focused when triggered by the keyboard. By default, this is false.

https://user-images.githubusercontent.com/61460952/223463391-559ad991-6257-4983-9ff5-5f9aa12bfbeb.mov


