### PR TITLE
Revert "Adopt `activationEventsGenerator` for `onTaskType` (#173192)"

### DIFF
--- a/src/vs/workbench/contrib/tasks/common/taskDefinitionRegistry.ts
+++ b/src/vs/workbench/contrib/tasks/common/taskDefinitionRegistry.ts
@@ -83,13 +83,6 @@ namespace Configuration {
 
 const taskDefinitionsExtPoint = ExtensionsRegistry.registerExtensionPoint<Configuration.ITaskDefinition[]>({
 	extensionPoint: 'taskDefinitions',
-	activationEventsGenerator: (contributions: Configuration.ITaskDefinition[], result: { push(item: string): void }) => {
-		for (const task of contributions) {
-			if (task.type) {
-				result.push(`onTaskType:${task.type}`);
-			}
-		}
-	},
 	jsonSchema: {
 		description: nls.localize('TaskDefinitionExtPoint', 'Contributes task kinds'),
 		type: 'array',


### PR DESCRIPTION
This reverts commit 1108c31f0d0b4852786db42904a135acb56209a5 that caused issues like https://github.com/microsoft/vscode/issues/176006

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
