### PR TITLE
monaco-editor-3626: Ensure brackets are highlighted in languages like 'json'

### DIFF
--- a/src/vs/editor/standalone/browser/standaloneLanguages.ts
+++ b/src/vs/editor/standalone/browser/standaloneLanguages.ts
@@ -24,6 +24,7 @@ import { IMarkerData, IMarkerService } from 'vs/platform/markers/common/markers'
 import { ILanguageFeaturesService } from 'vs/editor/common/services/languageFeatures';
 import { LanguageSelector } from 'vs/editor/common/languageSelector';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
+import { MetadataConsts } from 'vs/editor/common/encodedTokenAttributes';
 
 /**
  * Register information about a new language.
@@ -193,7 +194,7 @@ export class TokenizationSupportAdapter implements languages.ITokenizationSuppor
 		let previousStartIndex: number = 0;
 		for (let i = 0, len = tokens.length; i < len; i++) {
 			const t = tokens[i];
-			const metadata = tokenTheme.match(languageId, t.scopes);
+			const metadata = tokenTheme.match(languageId, t.scopes) | MetadataConsts.BALANCED_BRACKETS_MASK;
 			if (resultLen > 0 && result[resultLen - 1] === metadata) {
 				// same metadata
 				continue;

--- a/src/vs/editor/standalone/test/browser/standaloneLanguages.test.ts
+++ b/src/vs/editor/standalone/test/browser/standaloneLanguages.test.ts
@@ -160,8 +160,8 @@ suite('TokenizationSupport2Adapter', () => {
 				new Token(0, 'bar', languageId),
 			],
 			[
-				0, (0 << MetadataConsts.FOREGROUND_OFFSET),
-				0, (1 << MetadataConsts.FOREGROUND_OFFSET)
+				0, (0 << MetadataConsts.FOREGROUND_OFFSET) | MetadataConsts.BALANCED_BRACKETS_MASK,
+				0, (1 << MetadataConsts.FOREGROUND_OFFSET) | MetadataConsts.BALANCED_BRACKETS_MASK
 			]
 		);
 	});
@@ -179,9 +179,9 @@ suite('TokenizationSupport2Adapter', () => {
 				new Token(5, 'foo', languageId),
 			],
 			[
-				0, (0 << MetadataConsts.FOREGROUND_OFFSET),
-				5, (1 << MetadataConsts.FOREGROUND_OFFSET),
-				5, (2 << MetadataConsts.FOREGROUND_OFFSET)
+				0, (0 << MetadataConsts.FOREGROUND_OFFSET) | MetadataConsts.BALANCED_BRACKETS_MASK,
+				5, (1 << MetadataConsts.FOREGROUND_OFFSET) | MetadataConsts.BALANCED_BRACKETS_MASK,
+				5, (2 << MetadataConsts.FOREGROUND_OFFSET) | MetadataConsts.BALANCED_BRACKETS_MASK
 			]
 		);
 	});


### PR DESCRIPTION
This PR relates to the Bug [monaco-editor 3626](https://github.com/microsoft/monaco-editor/issues/3626) reported to the monaco-editor project.

The fix makes sure that languages like `json` tokenized in the browser via the TokenizationSupportAdapter in `standaloneLanguages.ts` will support highlighting matching brackets.

The MetadataConsts.BALANCED_BRACKETS_MASK flag is added to the bitmask of the language metadata, like in [monarchLexer.ts](https://github.com/microsoft/vscode/blob/1ab647fd443d606e7d6b07e24512ce6de3be3e70/src/vs/editor/standalone/common/monarch/monarchLexer.ts#L318).