### PR TITLE
Remove width and height defn for svg.

### DIFF
--- a/src/vs/workbench/contrib/welcomeGettingStarted/common/media/learn.svg
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/common/media/learn.svg
@@ -1,4 +1,4 @@
-<svg width="351" height="225" viewBox="0 0 351 225" fill="none" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg viewBox="0 0 351 225" fill="none" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
 	<g clip-path="url(#clip0_1103_9950)">
 		<rect width="350.625" height="225" fill="#1E1E1E" />
 		<rect width="350.625" height="225" fill="url(#paint0_radial_1103_9950)" />


### PR DESCRIPTION
Fixes: https://github.com/microsoft/vscode/issues/143763 

Hoping the viewBox does not get stripped out. without width/height defns (seems to be the case for the rest of the svgs used).
