### PR TITLE
Fix CodeActionItem with no edits showing preview option on tooltip

### DIFF
--- a/src/vs/editor/contrib/codeAction/browser/codeActionMenu.ts
+++ b/src/vs/editor/contrib/codeAction/browser/codeActionMenu.ts
@@ -44,7 +44,8 @@ export function toMenuItems(
 				item: action,
 				group: uncategorizedCodeActionGroup,
 				disabled: !!action.action.disabled,
-				label: action.action.disabled || action.action.title
+				label: action.action.disabled || action.action.title,
+				hasEdits: action.action.edit?.edits.length ? true : false
 			};
 		});
 	}
@@ -74,6 +75,7 @@ export function toMenuItems(
 					label: action.action.title,
 					disabled: !!action.action.disabled,
 					keybinding: keybindingResolver(action.action),
+					hasEdits: action.action.edit?.edits.length ? true : false
 				});
 			}
 		}

--- a/src/vs/editor/contrib/codeAction/browser/codeActionUi.ts
+++ b/src/vs/editor/contrib/codeAction/browser/codeActionUi.ts
@@ -25,6 +25,7 @@ import { CodeActionAutoApply, CodeActionItem, CodeActionSet, CodeActionTrigger }
 import { CodeActionsState } from './codeActionModel';
 import { LightBulbWidget } from './lightBulbWidget';
 import { IActionListDelegate } from 'vs/platform/actionWidget/browser/actionList';
+import { CancellationToken } from 'vs/base/common/cancellation';
 
 export interface IActionShowOptions {
 	readonly includeDisabledActions?: boolean;
@@ -189,6 +190,8 @@ export class CodeActionUi extends Disposable {
 				this._editor?.focus();
 			}
 		};
+
+		await Promise.all(actionsToShow.map(async (action) => action.resolve(CancellationToken.None)));
 
 		this._actionWidgetService.show(
 			'codeActionWidget',

--- a/src/vs/platform/actionWidget/browser/actionList.ts
+++ b/src/vs/platform/actionWidget/browser/actionList.ts
@@ -32,6 +32,7 @@ export interface IActionListItem<T> {
 	readonly group?: { kind?: any; icon?: ThemeIcon; title: string };
 	readonly disabled?: boolean;
 	readonly label?: string;
+	readonly hasEdits?: boolean;
 
 	readonly keybinding?: ResolvedKeybinding;
 }
@@ -126,7 +127,7 @@ class ActionItemRenderer<T> implements IListRenderer<IActionListItem<T>, IAction
 		if (element.disabled) {
 			data.container.title = element.label;
 		} else if (actionTitle && previewTitle) {
-			if (this._supportsPreview) {
+			if (this._supportsPreview && element.hasEdits) {
 				data.container.title = localize({ key: 'label-preview', comment: ['placeholders are keybindings, e.g "F2 to apply, Shift+F2 to preview"'] }, "{0} to apply, {1} to preview", actionTitle, previewTitle);
 			} else {
 				data.container.title = localize({ key: 'label', comment: ['placeholder is a keybinding, e.g "F2 to apply"'] }, "{0} to apply", actionTitle);


### PR DESCRIPTION
Fixes  #175008

Tested with [vscode-cpptools v1.14.4](https://github.com/microsoft/vscode-cpptools) same as it was described in the issue linked above.