### PR TITLE
feat: enable domReadOnly for mobile

### DIFF
--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -149,7 +149,7 @@ export interface IEditorOptions {
 	readOnly?: boolean;
 	/**
 	 * Should the textarea used for input use the DOM `readonly` attribute.
-	 * Defaults to false.
+	 * Defaults to true for mobile and false for others.
 	 */
 	domReadOnly?: boolean;
 	/**
@@ -5104,7 +5104,7 @@ export const EditorOptions = {
 		EditorOption.disableMonospaceOptimizations, 'disableMonospaceOptimizations', false
 	)),
 	domReadOnly: register(new EditorBooleanOption(
-		EditorOption.domReadOnly, 'domReadOnly', false,
+		EditorOption.domReadOnly, 'domReadOnly', platform.isMobile,
 	)),
 	dragAndDrop: register(new EditorBooleanOption(
 		EditorOption.dragAndDrop, 'dragAndDrop', true,

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -3122,7 +3122,7 @@ declare namespace monaco.editor {
 		readOnly?: boolean;
 		/**
 		 * Should the textarea used for input use the DOM `readonly` attribute.
-		 * Defaults to false.
+		 * Defaults to true for mobile and false for others.
 		 */
 		domReadOnly?: boolean;
 		/**


### PR DESCRIPTION
Enable `domReadOnly` option for mobile devices default to avoid to always popping up the keyboard when viewing read-only document.
