### PR TITLE
bring back `onTaskType` implicit activation, set timeout for extension activation

### DIFF
--- a/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
+++ b/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
@@ -577,7 +577,10 @@ export abstract class AbstractTaskService extends Disposable implements ITaskSer
 		await this._extensionService.whenInstalledExtensionsRegistered();
 
 		await Promise.all(
-			this._getActivationEvents(type).map(activationEvent => Promise.race([this._extensionService.activateByEvent(activationEvent), timeout(2000)]))
+			this._getActivationEvents(type).map(activationEvent => Promise.race([this._extensionService.activateByEvent(activationEvent), timeout(2000).then(() => {
+				return undefined;
+			}
+			)]))
 		);
 	}
 

--- a/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
+++ b/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
@@ -82,6 +82,7 @@ import { IPreferencesService } from 'vs/workbench/services/preferences/common/pr
 import { TerminalExitReason } from 'vs/platform/terminal/common/terminal';
 import { IRemoteAgentService } from 'vs/workbench/services/remote/common/remoteAgentService';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
+import { timeout } from 'vs/base/common/async';
 
 const QUICKOPEN_HISTORY_LIMIT_CONFIG = 'task.quickOpen.history';
 const PROBLEM_MATCHER_NEVER_CONFIG = 'task.problemMatchers.neverPrompt';
@@ -576,7 +577,7 @@ export abstract class AbstractTaskService extends Disposable implements ITaskSer
 		await this._extensionService.whenInstalledExtensionsRegistered();
 
 		await Promise.all(
-			this._getActivationEvents(type).map(activationEvent => this._extensionService.activateByEvent(activationEvent))
+			this._getActivationEvents(type).map(activationEvent => Promise.race([this._extensionService.activateByEvent(activationEvent), timeout(2000)]))
 		);
 	}
 

--- a/src/vs/workbench/contrib/tasks/common/taskDefinitionRegistry.ts
+++ b/src/vs/workbench/contrib/tasks/common/taskDefinitionRegistry.ts
@@ -83,6 +83,13 @@ namespace Configuration {
 
 const taskDefinitionsExtPoint = ExtensionsRegistry.registerExtensionPoint<Configuration.ITaskDefinition[]>({
 	extensionPoint: 'taskDefinitions',
+	activationEventsGenerator: (contributions: Configuration.ITaskDefinition[], result: { push(item: string): void }) => {
+		for (const task of contributions) {
+			if (task.type) {
+				result.push(`onTaskType:${task.type}`);
+			}
+		}
+	},
 	jsonSchema: {
 		description: nls.localize('TaskDefinitionExtPoint', 'Contributes task kinds'),
 		type: 'array',


### PR DESCRIPTION
Repro was an extension contributes tasks or uses `onTaskType:X` as an `activationEvent` and has `await vscode.fetchTasks()` in its `activate` method  and try to run a task of that type, it just spins. 

Confirmed the theory from @alexdima that what happens is:
the extension `activate()` waits on `vscode.tasks.fetchTasks()`
`vscode.tasks.fetchTasks()` waits on `activateByEvent(onTaskType:X)`
`activateByEvent(onTaskType:X)` waits on the extension `activate()`

