### PR TITLE
Fixing some project wide intellisense issues in safari

### DIFF
--- a/extensions/typescript-language-features/src/utils/configuration.ts
+++ b/extensions/typescript-language-features/src/utils/configuration.ts
@@ -200,7 +200,9 @@ export abstract class BaseServiceConfigurationProvider implements ServiceConfigu
 	}
 
 	protected readWatchOptions(configuration: vscode.WorkspaceConfiguration): Proto.WatchOptions | undefined {
-		return configuration.get<Proto.WatchOptions>('typescript.tsserver.watchOptions');
+		const watchOptions = configuration.get<Proto.WatchOptions>('typescript.tsserver.watchOptions');
+		// Returned value may be a proxy. Clone it into a normal object
+		return { ...(watchOptions ?? {}) };
 	}
 
 	protected readIncludePackageJsonAutoImports(configuration: vscode.WorkspaceConfiguration): 'auto' | 'on' | 'off' | undefined {

--- a/src/vs/workbench/services/extensions/worker/polyfillNestedWorker.ts
+++ b/src/vs/workbench/services/extensions/worker/polyfillNestedWorker.ts
@@ -38,7 +38,7 @@ const _bootstrapFnSource = (function _bootstrapFn(workerUrl: string) {
 		});
 
 		port.addEventListener('message', msg => {
-			globalThis.dispatchEvent(new MessageEvent('message', { data: msg.data }));
+			globalThis.dispatchEvent(new MessageEvent('message', { data: msg.data, ports: msg.ports ? [...msg.ports] : undefined }));
 		});
 
 		port.start();


### PR DESCRIPTION
For #175229

- Safari can't transfer `Proxy` objects
- Safari's nested worker polyfill wasn't forwarding along the `ports` field on message events

/cc @alexdima @jrieken 