### PR TITLE
prevent task / extension activation deadlock

### DIFF
--- a/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
+++ b/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
@@ -82,6 +82,7 @@ import { IPreferencesService } from 'vs/workbench/services/preferences/common/pr
 import { TerminalExitReason } from 'vs/platform/terminal/common/terminal';
 import { IRemoteAgentService } from 'vs/workbench/services/remote/common/remoteAgentService';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
+import { timeout } from 'vs/base/common/async';
 
 const QUICKOPEN_HISTORY_LIMIT_CONFIG = 'task.quickOpen.history';
 const PROBLEM_MATCHER_NEVER_CONFIG = 'task.problemMatchers.neverPrompt';
@@ -574,10 +575,7 @@ export abstract class AbstractTaskService extends Disposable implements ITaskSer
 		// We need to first wait for extensions to be registered because we might read
 		// the `TaskDefinitionRegistry` in case `type` is `undefined`
 		await this._extensionService.whenInstalledExtensionsRegistered();
-
-		await Promise.all(
-			this._getActivationEvents(type).map(activationEvent => this._extensionService.activateByEvent(activationEvent))
-		);
+		this._getActivationEvents(type).map(activationEvent => Promise.race([this._extensionService.activateByEvent(activationEvent), timeout(2000).then(() => { return undefined; })]));
 	}
 
 	private _updateSetup(setup?: [IWorkspaceFolder[], IWorkspaceFolder[], ExecutionEngine, JsonSchemaVersion, IWorkspace | undefined]): void {

--- a/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
+++ b/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
@@ -575,7 +575,15 @@ export abstract class AbstractTaskService extends Disposable implements ITaskSer
 		// We need to first wait for extensions to be registered because we might read
 		// the `TaskDefinitionRegistry` in case `type` is `undefined`
 		await this._extensionService.whenInstalledExtensionsRegistered();
-		this._getActivationEvents(type).map(activationEvent => Promise.race([this._extensionService.activateByEvent(activationEvent), timeout(2000).then(() => { return undefined; })]));
+		console.log(this._getActivationEvents(type));
+		// Wait for the first of either to resolve
+		await Promise.race([
+			// Create a promise that resolves when all activation promises resolve
+			Promise.all(
+				this._getActivationEvents(type).map(activationEvent => this._extensionService.activateByEvent(activationEvent))
+			),
+			timeout(5000).then(() => console.warn('Timed out activating extensions for task providers'))
+		]);
 	}
 
 	private _updateSetup(setup?: [IWorkspaceFolder[], IWorkspaceFolder[], ExecutionEngine, JsonSchemaVersion, IWorkspace | undefined]): void {

--- a/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
+++ b/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
@@ -575,7 +575,6 @@ export abstract class AbstractTaskService extends Disposable implements ITaskSer
 		// We need to first wait for extensions to be registered because we might read
 		// the `TaskDefinitionRegistry` in case `type` is `undefined`
 		await this._extensionService.whenInstalledExtensionsRegistered();
-		console.log(this._getActivationEvents(type));
 		// Wait for the first of either to resolve
 		await Promise.race([
 			// Create a promise that resolves when all activation promises resolve


### PR DESCRIPTION
Repro was an extension contributes tasks or uses `onTaskType:X` as an `activationEvent` and has `await vscode.fetchTasks()` in its `activate` method  and try to run a task of that type, it just spins. 

Confirmed the theory from @alexdima that what happens is:
the extension `activate()` waits on `vscode.tasks.fetchTasks()`
`vscode.tasks.fetchTasks()` waits on `activateByEvent(onTaskType:X)`
`activateByEvent(onTaskType:X)` waits on the extension `activate()`

To avoid this, we only wait 5 seconds for extensions to activate.

fix #176006