### PR TITLE
Have account menu be snappier by caching accounts

### DIFF
--- a/src/vs/workbench/services/authentication/common/authentication.ts
+++ b/src/vs/workbench/services/authentication/common/authentication.ts
@@ -5,13 +5,15 @@
 import { Event } from 'vs/base/common/event';
 import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
 
+export interface AuthenticationSessionAccount {
+	label: string;
+	id: string;
+}
+
 export interface AuthenticationSession {
 	id: string;
 	accessToken: string;
-	account: {
-		label: string;
-		id: string;
-	};
+	account: AuthenticationSessionAccount;
 	scopes: ReadonlyArray<string>;
 	idToken?: string;
 }


### PR DESCRIPTION
Before, we were calling out to the auth providers (thus going all the way to the extension host per provider)

Now, we cache the accounts and handle events for when accounts change.

This makes the account menu way snappier!

Fixes #111398

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
