### PR TITLE
Clean up markdown preview messaging

### DIFF
--- a/extensions/markdown-language-features/preview-src/index.ts
+++ b/extensions/markdown-language-features/preview-src/index.ts
@@ -22,14 +22,14 @@ let documentResource = settings.settings.source;
 
 const vscode = acquireVsCodeApi();
 
-const originalState = vscode.getState();
+const originalState = vscode.getState() ?? {} as any;
 
 const state = {
-	...(typeof originalState === 'object' ? originalState : {}),
+	originalState,
 	...getData<any>('data-state')
 };
 
-if (originalState.resource !== state.resource) {
+if (originalState?.resource !== state.resource) {
 	state.scrollProgress = undefined;
 }
 

--- a/extensions/markdown-language-features/preview-src/messaging.ts
+++ b/extensions/markdown-language-features/preview-src/messaging.ts
@@ -25,7 +25,7 @@ export const createPosterForVsCode = (vscode: any, settingsManager: SettingsMana
 			vscode.postMessage({
 				type,
 				source: settingsManager.settings!.source,
-				body
+				...body
 			});
 		}
 	};

--- a/extensions/markdown-language-features/types/previewMessaging.d.ts
+++ b/extensions/markdown-language-features/types/previewMessaging.d.ts
@@ -11,28 +11,22 @@ export namespace FromWebviewMessage {
 
 	export interface CacheImageSizes extends BaseMessage {
 		readonly type: 'cacheImageSizes';
-		readonly body: { id: string; width: number; height: number }[];
+		readonly imageData: ReadonlyArray<{ id: string; width: number; height: number }>;
 	}
 
 	export interface RevealLine extends BaseMessage {
 		readonly type: 'revealLine';
-		readonly body: {
-			readonly line: number;
-		};
+		readonly line: number;
 	}
 
 	export interface DidClick extends BaseMessage {
 		readonly type: 'didClick';
-		readonly body: {
-			readonly line: number;
-		};
+		readonly line: number;
 	}
 
 	export interface ClickLink extends BaseMessage {
 		readonly type: 'openLink';
-		readonly body: {
-			readonly href: string;
-		};
+		readonly href: string;
 	}
 
 	export interface ShowPreviewSecuritySelector extends BaseMessage {
@@ -41,9 +35,7 @@ export namespace FromWebviewMessage {
 
 	export interface PreviewStyleLoadError extends BaseMessage {
 		readonly type: 'previewStyleLoadError';
-		readonly body: {
-			readonly unloadedStyles: string[];
-		};
+		readonly unloadedStyles: readonly string[];
 	}
 
 	export type Type =


### PR DESCRIPTION
- Add properties directly to message
- Add `ImageInfo` type
- Don't use state to pass around imageInfo
