### PR TITLE
Fix typos: “extenion host” to “extension host”

### DIFF
--- a/src/vs/workbench/services/extensions/common/remoteExtensionHost.ts
+++ b/src/vs/workbench/services/extensions/common/remoteExtensionHost.ts
@@ -145,7 +145,7 @@ export class RemoteExtensionHost extends Disposable implements IExtensionHost {
 				return new Promise<IMessagePassingProtocol>((resolve, reject) => {
 
 					const handle = setTimeout(() => {
-						reject('The remote extenion host took longer than 60s to send its ready message.');
+						reject('The remote extension host took longer than 60s to send its ready message.');
 					}, 60 * 1000);
 
 					const disposable = protocol.onMessage(msg => {

--- a/src/vs/workbench/services/extensions/electron-sandbox/localProcessExtensionHost.ts
+++ b/src/vs/workbench/services/extensions/electron-sandbox/localProcessExtensionHost.ts
@@ -376,7 +376,7 @@ export class NativeLocalProcessExtensionHost implements IExtensionHost {
 			let timeoutHandle: any;
 			const installTimeoutCheck = () => {
 				timeoutHandle = setTimeout(() => {
-					reject('The local extenion host took longer than 60s to send its ready message.');
+					reject('The local extension host took longer than 60s to send its ready message.');
 				}, 60 * 1000);
 			};
 			const uninstallTimeoutCheck = () => {


### PR DESCRIPTION
This fixes a couple of typos where the “s” is omitted from “extension host” in two specific log lines.