### PR TITLE
Ctrl+Click should show context menu in the editor gutter on Mac

### DIFF
--- a/src/vs/workbench/contrib/codeEditor/browser/editorLineNumberMenu.ts
+++ b/src/vs/workbench/contrib/codeEditor/browser/editorLineNumberMenu.ts
@@ -5,6 +5,7 @@
 
 import { IAction, Separator } from 'vs/base/common/actions';
 import { Disposable, IDisposable } from 'vs/base/common/lifecycle';
+import { isMacintosh } from 'vs/base/common/platform';
 import { ICodeEditor, IEditorMouseEvent, MouseTargetType } from 'vs/editor/browser/editorBrowser';
 import { registerEditorContribution, EditorContributionInstantiation } from 'vs/editor/browser/editorExtensions';
 import { IEditorContribution } from 'vs/editor/common/editorCommon';
@@ -56,11 +57,16 @@ export class EditorLineNumberContextMenu extends Disposable implements IEditorCo
 	) {
 		super();
 
-		this._register(this.editor.onContextMenu((e: IEditorMouseEvent) => this.show(e)));
+		this._register(this.editor.onMouseDown((e: IEditorMouseEvent) => this.show(e)));
 
 	}
 
 	public show(e: IEditorMouseEvent) {
+		// on macOS ctrl+click is interpreted as right click
+		if (!e.event.rightButton && !(isMacintosh && e.event.leftButton && e.event.ctrlKey)) {
+			return;
+		}
+
 		const menu = this.menuService.createMenu(MenuId.EditorLineNumberContext, this.contextKeyService);
 
 		const model = this.editor.getModel();

--- a/src/vs/workbench/contrib/debug/browser/breakpointEditorContribution.ts
+++ b/src/vs/workbench/contrib/debug/browser/breakpointEditorContribution.ts
@@ -251,6 +251,7 @@ export class BreakpointEditorContribution implements IBreakpointEditorContributi
 			const uri = model.uri;
 
 			if (e.event.rightButton || (env.isMacintosh && e.event.leftButton && e.event.ctrlKey)) {
+				// handled by editor gutter context menu
 				return;
 			} else {
 				const breakpoints = this.debugService.getModel().getBreakpoints({ uri, lineNumber });

--- a/src/vs/workbench/contrib/testing/browser/testingDecorations.ts
+++ b/src/vs/workbench/contrib/testing/browser/testingDecorations.ts
@@ -51,6 +51,7 @@ import { ITestResultService } from 'vs/workbench/contrib/testing/common/testResu
 import { getContextForTestItem, ITestService, testsInFile } from 'vs/workbench/contrib/testing/common/testService';
 import { IncrementalTestCollectionItem, InternalTestItem, IRichLocation, ITestMessage, ITestRunProfile, TestDiffOpType, TestMessageType, TestResultItem, TestResultState, TestRunProfileBitset } from 'vs/workbench/contrib/testing/common/testTypes';
 import { EditorLineNumberContextMenu, GutterActionsRegistry } from 'vs/workbench/contrib/codeEditor/browser/editorLineNumberMenu';
+import { isMacintosh } from 'vs/base/common/platform';
 
 const MAX_INLINE_MESSAGE_LENGTH = 128;
 
@@ -727,7 +728,11 @@ abstract class RunTestDecoration {
 
 	/** @inheritdoc */
 	public click(e: IEditorMouseEvent): boolean {
-		if (e.target.type !== MouseTargetType.GUTTER_GLYPH_MARGIN || e.event.rightButton) {
+		if (e.target.type !== MouseTargetType.GUTTER_GLYPH_MARGIN
+			// handled by editor gutter context menu
+			|| e.event.rightButton
+			|| isMacintosh && e.event.leftButton && e.event.ctrlKey
+		) {
 			return false;
 		}
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/176492