### PR TITLE
Always show Copy vscode.dev link in notebook gutter

### DIFF
--- a/extensions/github/package.json
+++ b/extensions/github/package.json
@@ -115,7 +115,7 @@
         },
         {
           "command": "github.copyVscodeDevLink",
-          "when": "github.hasGitHubRepo && resourceScheme != untitled && activeEditor == workbench.editor.notebook && notebookCellLineNumbers == on && remoteName != 'codespaces'",
+          "when": "github.hasGitHubRepo && resourceScheme != untitled && activeEditor == workbench.editor.notebook && remoteName != 'codespaces'",
           "group": "1_cutcopypaste@2"
         }
       ],


### PR DESCRIPTION
From talking with @rebornix we should show this the in notebook gutter context menu by default because otherwise discoverability is very low given that line numbers are disabled in notebooks by default. We'll correctly generate a deeplink to the cell and range even with line numbers turned off, so enabling this functionality won't cause breakage, the only wrinkle is that the user just can't see which line the link was originally generated for.