### PR TITLE
Enable inline suggestions in SCM input

### DIFF
--- a/src/vs/workbench/contrib/scm/browser/scmViewPane.ts
+++ b/src/vs/workbench/contrib/scm/browser/scmViewPane.ts
@@ -89,6 +89,7 @@ import { DropIntoEditorController } from 'vs/editor/contrib/dropIntoEditor/brows
 import { MessageController } from 'vs/editor/contrib/message/browser/messageController';
 import { contrastBorder, registerColor } from 'vs/platform/theme/common/colorRegistry';
 import { defaultButtonStyles, defaultCountBadgeStyles } from 'vs/platform/theme/browser/defaultStyles';
+import { GhostTextController } from 'vs/editor/contrib/inlineCompletions/browser/ghostTextController';
 
 type TreeElement = ISCMRepository | ISCMInput | ISCMActionButton | ISCMResourceGroup | IResourceNode<ISCMResource, ISCMResourceGroup> | ISCMResource;
 
@@ -1961,6 +1962,7 @@ class SCMInputWidget {
 				SelectionClipboardContributionID,
 				SnippetController2.ID,
 				SuggestController.ID,
+				GhostTextController.ID,
 			])
 		};
 


### PR DESCRIPTION
Fixes #176565

Tested with the inline suggest example extension:

<img width="751" alt="Screenshot 2023-03-08 at 2 20 14 PM" src="https://user-images.githubusercontent.com/12821956/223864398-3475c47a-736c-4c78-a8a2-089281d46e62.png">

Copilot does not seem to work yet, and it likely would need to be tweaked to provide suggestions tailored to scm input
