### PR TITLE
Remove `textPreformat-foreground` override in experimental dark theme

### DIFF
--- a/extensions/theme-defaults/themes/dark_plus_experimental.json
+++ b/extensions/theme-defaults/themes/dark_plus_experimental.json
@@ -126,7 +126,6 @@
 		"textCodeBlock.background": "#6e768166",
 		"textLink.activeForeground": "#40A6FF",
 		"textLink.foreground": "#40A6FF",
-		"textPreformat.foreground": "#f85149",
 		"textSeparator.foreground": "#21262d",
 		"titleBar.activeBackground": "#181818",
 		"titleBar.activeForeground": "#cccccc",


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/175596