### PR TITLE
Skip waiting on service worker ready

### DIFF
--- a/src/vs/workbench/contrib/webview/browser/pre/index-no-csp.html
+++ b/src/vs/workbench/contrib/webview/browser/pre/index-no-csp.html
@@ -219,7 +219,6 @@
 
 			const swPath = `service-worker.js?v=${expectedWorkerVersion}&vscode-resource-base-authority=${searchParams.get('vscode-resource-base-authority')}&remoteAuthority=${searchParams.get('remoteAuthority') ?? ''}`;
 			navigator.serviceWorker.register(swPath)
-				.then(() => navigator.serviceWorker.ready)
 				.then(async registration => {
 					/**
 					 * @param {MessageEvent} event
@@ -241,7 +240,6 @@
 							// `unregister` and `register` here.
 							return registration.unregister()
 								.then(() => navigator.serviceWorker.register(swPath))
-								.then(() => navigator.serviceWorker.ready)
 								.finally(() => { resolve(); });
 						}
 					};
@@ -434,13 +432,13 @@
 		};
 
 		hostMessaging.onMessage('did-load-resource', (_event, data) => {
-			navigator.serviceWorker.ready.then(registration => {
+			navigator.serviceWorker.getRegistration().then(registration => {
 				assertIsDefined(registration.active).postMessage({ channel: 'did-load-resource', data }, data.data?.buffer ? [data.data.buffer] : []);
 			});
 		});
 
 		hostMessaging.onMessage('did-load-localhost', (_event, data) => {
-			navigator.serviceWorker.ready.then(registration => {
+			navigator.serviceWorker.getRegistration().then(registration => {
 				assertIsDefined(registration.active).postMessage({ channel: 'did-load-localhost', data });
 			});
 		});

--- a/src/vs/workbench/contrib/webview/browser/pre/index.html
+++ b/src/vs/workbench/contrib/webview/browser/pre/index.html
@@ -5,7 +5,7 @@
 	<meta charset="UTF-8">
 
 	<meta http-equiv="Content-Security-Policy"
-		content="default-src 'none'; script-src 'sha256-H4svLwQU3wxDoPkj+nPmtKUs0e266wn5f8Kb0LuxEHw=' 'self'; frame-src 'self'; style-src 'unsafe-inline';">
+		content="default-src 'none'; script-src 'sha256-PXLLbTxUqUn4p+KvvFj5cqYN1AHAoeOHkHWZwsmuGck=' 'self'; frame-src 'self'; style-src 'unsafe-inline';">
 
 	<!-- Disable pinch zooming -->
 	<meta name="viewport"
@@ -220,7 +220,6 @@
 
 			const swPath = `service-worker.js?v=${expectedWorkerVersion}&vscode-resource-base-authority=${searchParams.get('vscode-resource-base-authority')}&remoteAuthority=${searchParams.get('remoteAuthority') ?? ''}`;
 			navigator.serviceWorker.register(swPath)
-				.then(() => navigator.serviceWorker.ready)
 				.then(async registration => {
 					/**
 					 * @param {MessageEvent} event
@@ -242,7 +241,6 @@
 							// `unregister` and `register` here.
 							return registration.unregister()
 								.then(() => navigator.serviceWorker.register(swPath))
-								.then(() => navigator.serviceWorker.ready)
 								.finally(() => { resolve(); });
 						}
 					};
@@ -435,13 +433,13 @@
 		};
 
 		hostMessaging.onMessage('did-load-resource', (_event, data) => {
-			navigator.serviceWorker.ready.then(registration => {
+			navigator.serviceWorker.getRegistration().then(registration => {
 				assertIsDefined(registration.active).postMessage({ channel: 'did-load-resource', data }, data.data?.buffer ? [data.data.buffer] : []);
 			});
 		});
 
 		hostMessaging.onMessage('did-load-localhost', (_event, data) => {
-			navigator.serviceWorker.ready.then(registration => {
+			navigator.serviceWorker.getRegistration().then(registration => {
 				assertIsDefined(registration.active).postMessage({ channel: 'did-load-localhost', data });
 			});
 		});


### PR DESCRIPTION
For #160302

Sometimes the `ready` events never fired. It is not clear why this happens since the service worker actually is marked as `activated`

Waiting on `ready` may not actually be needed anyways. Tested removing it on web and desktop and everything looked fine

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
