### PR TITLE
Git gutter not shown in workspace with multiple folders

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadSCM.ts
+++ b/src/vs/workbench/api/browser/mainThreadSCM.ts
@@ -286,7 +286,7 @@ class MainThreadSCMProvider implements ISCMProvider, QuickDiffProvider {
 	}
 
 	dispose(): void {
-
+		this._quickDiff?.dispose();
 	}
 }
 

--- a/src/vs/workbench/api/common/extHostSCM.ts
+++ b/src/vs/workbench/api/common/extHostSCM.ts
@@ -22,6 +22,9 @@ import { ThemeIcon } from 'vs/base/common/themables';
 import { IMarkdownString } from 'vs/base/common/htmlContent';
 import { MarkdownString } from 'vs/workbench/api/common/extHostTypeConverters';
 import { checkProposedApiEnabled, isProposedApiEnabled } from 'vs/workbench/services/extensions/common/extensions';
+import { normalizeDriveLetter } from 'vs/base/common/labels';
+import { toPosixPath } from 'vs/base/common/extpath';
+import { normalizePath } from 'vs/base/common/resources';
 
 type ProviderHandle = number;
 type GroupHandle = number;
@@ -757,7 +760,7 @@ export class ExtHostSCM implements ExtHostSCMShape {
 		});
 
 		const handle = ExtHostSCM._handlePool++;
-		const sourceControl = new ExtHostSourceControl(extension, this._proxy, this._commands, id, label, rootUri);
+		const sourceControl = new ExtHostSourceControl(extension, this._proxy, this._commands, id, label, rootUri ? normalizePath(rootUri.with({ path: toPosixPath(normalizeDriveLetter(rootUri.fsPath)) })) : undefined);
 		this._sourceControls.set(handle, sourceControl);
 
 		const sourceControls = this._sourceControlsByExtension.get(extension.identifier) || [];

--- a/src/vs/workbench/api/common/extHostSCM.ts
+++ b/src/vs/workbench/api/common/extHostSCM.ts
@@ -22,9 +22,6 @@ import { ThemeIcon } from 'vs/base/common/themables';
 import { IMarkdownString } from 'vs/base/common/htmlContent';
 import { MarkdownString } from 'vs/workbench/api/common/extHostTypeConverters';
 import { checkProposedApiEnabled, isProposedApiEnabled } from 'vs/workbench/services/extensions/common/extensions';
-import { normalizeDriveLetter } from 'vs/base/common/labels';
-import { toPosixPath } from 'vs/base/common/extpath';
-import { normalizePath } from 'vs/base/common/resources';
 
 type ProviderHandle = number;
 type GroupHandle = number;
@@ -760,7 +757,7 @@ export class ExtHostSCM implements ExtHostSCMShape {
 		});
 
 		const handle = ExtHostSCM._handlePool++;
-		const sourceControl = new ExtHostSourceControl(extension, this._proxy, this._commands, id, label, rootUri ? normalizePath(rootUri.with({ path: toPosixPath(normalizeDriveLetter(rootUri.fsPath)) })) : undefined);
+		const sourceControl = new ExtHostSourceControl(extension, this._proxy, this._commands, id, label, rootUri);
 		this._sourceControls.set(handle, sourceControl);
 
 		const sourceControls = this._sourceControlsByExtension.get(extension.identifier) || [];

--- a/src/vs/workbench/contrib/scm/common/quickDiffService.ts
+++ b/src/vs/workbench/contrib/scm/common/quickDiffService.ts
@@ -10,6 +10,9 @@ import { isEqualOrParent } from 'vs/base/common/resources';
 import { score } from 'vs/editor/common/languageSelector';
 import { Emitter } from 'vs/base/common/event';
 import { withNullAsUndefined } from 'vs/base/common/types';
+import { normalizeDriveLetter } from 'vs/base/common/labels';
+import { toPosixPath } from 'vs/base/common/extpath';
+import { IUriIdentityService } from 'vs/platform/uriIdentity/common/uriIdentity';
 
 function createProviderComparer(uri: URI): (a: QuickDiffProvider, b: QuickDiffProvider) => number {
 	return (a, b) => {
@@ -43,6 +46,10 @@ export class QuickDiffService extends Disposable implements IQuickDiffService {
 	private readonly _onDidChangeQuickDiffProviders = this._register(new Emitter<void>());
 	readonly onDidChangeQuickDiffProviders = this._onDidChangeQuickDiffProviders.event;
 
+	constructor(@IUriIdentityService private readonly uriIdentityService: IUriIdentityService) {
+		super();
+	}
+
 	addQuickDiffProvider(quickDiff: QuickDiffProvider): IDisposable {
 		this.quickDiffProviders.add(quickDiff);
 		this._onDidChangeQuickDiffProviders.fire();
@@ -59,6 +66,7 @@ export class QuickDiffService extends Disposable implements IQuickDiffService {
 	}
 
 	async getQuickDiffs(uri: URI, language: string = '', isSynchronized: boolean = false): Promise<QuickDiff[]> {
+		uri = this.uriIdentityService.extUri.normalizePath(uri.with({ path: toPosixPath(normalizeDriveLetter(uri.fsPath)) }));
 		const providers = Array.from(this.quickDiffProviders)
 			.filter(provider => !provider.rootUri || isEqualOrParent(uri, provider.rootUri))
 			.sort(createProviderComparer(uri));

--- a/src/vs/workbench/contrib/scm/common/quickDiffService.ts
+++ b/src/vs/workbench/contrib/scm/common/quickDiffService.ts
@@ -10,8 +10,6 @@ import { isEqualOrParent } from 'vs/base/common/resources';
 import { score } from 'vs/editor/common/languageSelector';
 import { Emitter } from 'vs/base/common/event';
 import { withNullAsUndefined } from 'vs/base/common/types';
-import { normalizeDriveLetter } from 'vs/base/common/labels';
-import { toPosixPath } from 'vs/base/common/extpath';
 import { IUriIdentityService } from 'vs/platform/uriIdentity/common/uriIdentity';
 
 function createProviderComparer(uri: URI): (a: QuickDiffProvider, b: QuickDiffProvider) => number {
@@ -66,9 +64,8 @@ export class QuickDiffService extends Disposable implements IQuickDiffService {
 	}
 
 	async getQuickDiffs(uri: URI, language: string = '', isSynchronized: boolean = false): Promise<QuickDiff[]> {
-		uri = this.uriIdentityService.extUri.normalizePath(uri.with({ path: toPosixPath(normalizeDriveLetter(uri.fsPath)) }));
 		const providers = Array.from(this.quickDiffProviders)
-			.filter(provider => !provider.rootUri || isEqualOrParent(uri, provider.rootUri))
+			.filter(provider => !provider.rootUri || this.uriIdentityService.extUri.isEqualOrParent(uri, provider.rootUri))
 			.sort(createProviderComparer(uri));
 
 		const diffs = await Promise.all(providers.map(async provider => {


### PR DESCRIPTION
Fixes #176738

When adding a folder to a workspace extension re-contribute their SCM. In this case, the old quick diff wasn't getting disposed.

This wasn't fixed by simply reloading becasue there was still a URI mismatch: the git extension gave the root URI with a lower case drive letter and the VS Code core often (depends on how the file was opened) give the file URI with an upper case drive letter.