### PR TITLE
onEnterRules add prefix on newline inside Javadoc

### DIFF
--- a/extensions/java/language-configuration.json
+++ b/extensions/java/language-configuration.json
@@ -29,5 +29,74 @@
 			"start": "^\\s*//\\s*(?:(?:#?region\\b)|(?:<editor-fold\\b))",
 			"end": "^\\s*//\\s*(?:(?:#?endregion\\b)|(?:</editor-fold>))"
 		}
-	}
+	},
+	"onEnterRules": [
+		{
+			// e.g. /** | */
+			"beforeText": {
+				"pattern": "^\\s*/\\*\\*(?!/)([^\\*]|\\*(?!/))*$"
+			},
+			"afterText": {
+				"pattern": "^\\s*\\*/$"
+			},
+			"action": {
+				"indent": "indentOutdent",
+				"appendText": " * "
+			}
+		},
+		{
+			// e.g. /** ...|
+			"beforeText": {
+				"pattern": "^\\s*/\\*\\*(?!/)([^\\*]|\\*(?!/))*$"
+			},
+			"action": {
+				"indent": "none",
+				"appendText": " * "
+			}
+		},
+		{
+			// e.g.  * ...|
+			"beforeText": {
+				"pattern": "^(\\t|[ ])*[ ]\\*([ ]([^\\*]|\\*(?!/))*)?$"
+			},
+			"previousLineText": {
+				"pattern": "(?=^(\\s*(/\\*\\*|\\*)).*)(?=(?!(\\s*\\*/)))"
+			},
+			"action": {
+				"indent": "none",
+				"appendText": "* "
+			}
+		},
+		{
+			// e.g.  */|
+			"beforeText": {
+				"pattern": "^(\\t|[ ])*[ ]\\*/\\s*$"
+			},
+			"action": {
+				"indent": "none",
+				"removeText": 1
+			}
+		},
+		{
+			// e.g.  *-----*/|
+			"beforeText": {
+				"pattern": "^(\\t|[ ])*[ ]\\*[^/]*\\*/\\s*$"
+			},
+			"action": {
+				"indent": "none",
+				"removeText": 1
+			}
+		},
+		{
+			"beforeText": {
+				"pattern": "^\\s*(\\bcase\\s.+:|\\bdefault:)$"
+			},
+			"afterText": {
+				"pattern": "^(?!\\s*(\\bcase\\b|\\bdefault\\b))"
+			},
+			"action": {
+				"indent": "indent"
+			}
+		}
+	]
 }


### PR DESCRIPTION
Add some onEnterRules to Java language configuration to add the usual prefix (` * `) when inserting a new line in Javadoc.
Those were actually copied from typescript language configuration which shares the same syntax for comments.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
