### PR TITLE
Only rebuild walkthrough markdown media on unload

### DIFF
--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts
@@ -658,8 +658,8 @@ export class GettingStartedPage extends EditorPane {
 			const layoutDelayer = new Delayer(50);
 
 			this.layoutMarkdown = () => {
-				layoutDelayer.trigger(async () => {
-					this.buildMediaComponent(stepId);
+				layoutDelayer.trigger(() => {
+					webview.postMessage({ layoutMeNow: true });
 				});
 			};
 
@@ -674,7 +674,10 @@ export class GettingStartedPage extends EditorPane {
 					this.openerService.open(message, { allowCommands: true });
 				} else if (message.startsWith('setTheme:')) {
 					this.configurationService.updateValue(ThemeSettings.COLOR_THEME, message.slice('setTheme:'.length), ConfigurationTarget.USER);
-				} else {
+				} else if (message === 'unloaded') {
+					this.buildMediaComponent(stepId);
+				}
+				else {
 					console.error('Unexpected message', message);
 				}
 			}));

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStartedDetailsRenderer.ts
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStartedDetailsRenderer.ts
@@ -125,6 +125,11 @@ export class GettingStartedDetailsRenderer {
 			</body>
 			<script nonce="${nonce}">
 				const vscode = acquireVsCodeApi();
+
+				window.addEventListener('unload', event => {
+					vscode.postMessage('unloaded');
+				});
+
 				document.querySelectorAll('[when-checked]').forEach(el => {
 					el.addEventListener('click', () => {
 						vscode.postMessage(el.getAttribute('when-checked'));


### PR DESCRIPTION
Fixes: 
https://github.com/microsoft/vscode/issues/176539 
https://github.com/microsoft/vscode/issues/175386

Introduced a bug where we try to rebuild the walkthrough media every time we detect a layout change as a part of https://github.com/microsoft/vscode/pull/175993.

Changed it by only rebuild when we detect the markdown content has been reparented.