### PR TITLE
Git gutter not shown in workspace with multiple folders (#176754)

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadSCM.ts
+++ b/src/vs/workbench/api/browser/mainThreadSCM.ts
@@ -286,7 +286,7 @@ class MainThreadSCMProvider implements ISCMProvider, QuickDiffProvider {
 	}
 
 	dispose(): void {
-
+		this._quickDiff?.dispose();
 	}
 }
 


### PR DESCRIPTION
Fixes #176738

When adding a folder to a workspace extension re-contribute their SCM. In this case, the old quick diff wasn't getting disposed.

This wasn't fixed by simply reloading becasue there was still a URI mismatch: the git extension gave the root URI with a lower case drive letter and the VS Code core often (depends on how the file was opened) give the file URI with an upper case drive letter.