### PR TITLE
Consistently expand or collapse all comments on a line

### DIFF
--- a/src/vs/workbench/contrib/comments/browser/commentThreadZoneWidget.ts
+++ b/src/vs/workbench/contrib/comments/browser/commentThreadZoneWidget.ts
@@ -111,6 +111,10 @@ export class ReviewZoneWidget extends ZoneWidget implements ICommentThreadWidget
 		return this._commentThread;
 	}
 
+	public get expanded(): boolean | undefined {
+		return this._isExpanded;
+	}
+
 	private _commentOptions: languages.CommentOptions | undefined;
 
 	constructor(

--- a/src/vs/workbench/contrib/comments/browser/commentThreadZoneWidget.ts
+++ b/src/vs/workbench/contrib/comments/browser/commentThreadZoneWidget.ts
@@ -257,22 +257,12 @@ export class ReviewZoneWidget extends ZoneWidget implements ICommentThreadWidget
 		this.commentService.disposeCommentThread(this.owner, this._commentThread.threadId);
 	}
 
-	public collapse(): Promise<void> {
+	public collapse() {
 		this._commentThread.collapsibleState = languages.CommentThreadCollapsibleState.Collapsed;
-		if (this._commentThread.comments && this._commentThread.comments.length === 0) {
-			this.deleteCommentThread();
-			return Promise.resolve();
-		}
-
-		this.hide();
-		return Promise.resolve();
 	}
 
-	public expand(): Promise<void> {
+	public expand() {
 		this._commentThread.collapsibleState = languages.CommentThreadCollapsibleState.Expanded;
-
-		this.show(this.arrowPosition(this._commentThread.range), 2);
-		return Promise.resolve();
 	}
 
 	public getGlyphPosition(): number {

--- a/src/vs/workbench/contrib/comments/browser/commentsController.ts
+++ b/src/vs/workbench/contrib/comments/browser/commentsController.ts
@@ -766,7 +766,8 @@ export class CommentController implements IEditorContribution {
 			// The widget's position is undefined until the widget has been displayed, so rely on the glyph position instead
 			const existingCommentsAtLine = this._commentWidgets.filter(widget => widget.getGlyphPosition() === commentRange.endLineNumber);
 			if (existingCommentsAtLine.length) {
-				existingCommentsAtLine.forEach(widget => widget.toggleExpand());
+				const allExpanded = existingCommentsAtLine.every(widget => widget.expanded);
+				existingCommentsAtLine.forEach(allExpanded ? widget => widget.collapse() : widget => widget.expand());
 				this.processNextThreadToAdd();
 				return;
 			} else {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fixes #77155.

I verified this locally with a test extension that populates some comments, but have not covered the scenario of collapsing a newly created comment thread, where collapsing apparently is meant to delete the thread again in `hide()`: https://github.com/microsoft/vscode/blob/711cd94734e015e48de00d1380b14e9626463b86/src/vs/workbench/contrib/comments/browser/commentThreadZoneWidget.ts#L469