### PR TITLE
keybindings refactor

### DIFF
--- a/src/vs/platform/keybinding/common/keybinding.ts
+++ b/src/vs/platform/keybinding/common/keybinding.ts
@@ -19,6 +19,22 @@ export interface IUserFriendlyKeybinding {
 	when?: string;
 }
 
+/**
+ * Type for values read from `keybindings.json` -- the file is simply JSON-parsed,
+ * so the parsed value can be of type `any`. But it's better to have this type
+ * than `any`.
+ *
+ * Keep in mind that the parsed value still needs to be validated for being an array
+ * of objects (excluding `null`)
+ */
+export type KeybindingFromJSON = {
+	key?: string;
+	command?: string;
+	args?: any;
+	when?: string;
+	[index: string]: any;
+};
+
 export interface IKeyboardEvent {
 	readonly _standardKeyboardEventBrand: true;
 

--- a/src/vs/platform/keybinding/common/keybinding.ts
+++ b/src/vs/platform/keybinding/common/keybinding.ts
@@ -19,22 +19,6 @@ export interface IUserFriendlyKeybinding {
 	when?: string;
 }
 
-/**
- * Type for values read from `keybindings.json` -- the file is simply JSON-parsed,
- * so the parsed value can be of type `any`. But it's better to have this type
- * than `any`.
- *
- * Keep in mind that the parsed value still needs to be validated for being an array
- * of objects (excluding `null`)
- */
-export type KeybindingFromJSON = {
-	key?: string;
-	command?: string;
-	args?: any;
-	when?: string;
-	[index: string]: any;
-};
-
 export interface IKeyboardEvent {
 	readonly _standardKeyboardEventBrand: true;
 

--- a/src/vs/platform/keybinding/common/keybindingResolver.ts
+++ b/src/vs/platform/keybinding/common/keybindingResolver.ts
@@ -20,12 +20,14 @@ export class KeybindingResolver {
 	private readonly _log: (str: string) => void;
 	private readonly _defaultKeybindings: ResolvedKeybindingItem[];
 	private readonly _keybindings: ResolvedKeybindingItem[];
-	private readonly _defaultBoundCommands: Map<string, boolean>;
-	private readonly _map: Map<string, ResolvedKeybindingItem[]>;
-	private readonly _lookupMap: Map<string, ResolvedKeybindingItem[]>;
+	private readonly _defaultBoundCommands: Map</* commandId */ string, boolean>;
+	private readonly _map: Map</* 1st chord's keypress */ string, ResolvedKeybindingItem[]>;
+	private readonly _lookupMap: Map</* commandId */ string, ResolvedKeybindingItem[]>;
 
 	constructor(
+		/** built-in and extension-provided keybindings */
 		defaultKeybindings: ResolvedKeybindingItem[],
+		/** user's keybindings */
 		overrides: ResolvedKeybindingItem[],
 		log: (str: string) => void
 	) {
@@ -90,7 +92,7 @@ export class KeybindingResolver {
 	 */
 	public static handleRemovals(rules: ResolvedKeybindingItem[]): ResolvedKeybindingItem[] {
 		// Do a first pass and construct a hash-map for removals
-		const removals = new Map<string, ResolvedKeybindingItem[]>();
+		const removals = new Map</* commandId */ string, ResolvedKeybindingItem[]>();
 		for (let i = 0, len = rules.length; i < len; i++) {
 			const rule = rules[i];
 			if (rule.command && rule.command.charAt(0) === '-') {

--- a/src/vs/platform/keybinding/common/keybindingsRegistry.ts
+++ b/src/vs/platform/keybinding/common/keybindingsRegistry.ts
@@ -76,6 +76,9 @@ export interface IKeybindingsRegistry {
 	getDefaultKeybindings(): IKeybindingItem[];
 }
 
+/**
+ * Stores all built-in and extension-provided keybindings (but not ones that user defines themselves)
+ */
 class KeybindingsRegistryImpl implements IKeybindingsRegistry {
 
 	private _coreKeybindings: LinkedList<IKeybindingItem>;

--- a/src/vs/workbench/services/keybinding/browser/keybindingService.ts
+++ b/src/vs/workbench/services/keybinding/browser/keybindingService.ts
@@ -17,7 +17,7 @@ import { ICommandService, CommandsRegistry } from 'vs/platform/commands/common/c
 import { ContextKeyExpr, IContextKeyService, ContextKeyExpression, IContextKey } from 'vs/platform/contextkey/common/contextkey';
 import { Extensions, IJSONContributionRegistry } from 'vs/platform/jsonschemas/common/jsonContributionRegistry';
 import { AbstractKeybindingService } from 'vs/platform/keybinding/common/abstractKeybindingService';
-import { IKeyboardEvent, IKeybindingService, KeybindingsSchemaContribution, KeybindingFromJSON } from 'vs/platform/keybinding/common/keybinding';
+import { IKeyboardEvent, IKeybindingService, KeybindingsSchemaContribution } from 'vs/platform/keybinding/common/keybinding';
 import { KeybindingResolver } from 'vs/platform/keybinding/common/keybindingResolver';
 import { IKeybindingItem, IExtensionKeybindingRule, KeybindingWeight, KeybindingsRegistry } from 'vs/platform/keybinding/common/keybindingsRegistry';
 import { ResolvedKeybindingItem } from 'vs/platform/keybinding/common/resolvedKeybindingItem';
@@ -682,7 +682,7 @@ export class WorkbenchKeybindingService extends AbstractKeybindingService {
 
 class UserKeybindings extends Disposable {
 
-	private _rawKeybindings: KeybindingFromJSON[] = [];
+	private _rawKeybindings: Object[] = [];
 	private _keybindings: IUserKeybindingItem[] = [];
 	get keybindings(): IUserKeybindingItem[] { return this._keybindings; }
 
@@ -756,7 +756,7 @@ class UserKeybindings extends Disposable {
 		return true;
 	}
 
-	private async readUserKeybindings(): Promise<KeybindingFromJSON[]> {
+	private async readUserKeybindings(): Promise<Object[]> {
 		try {
 			const content = await this.fileService.readFile(this.userDataProfileService.currentProfile.keybindingsResource);
 			const value = parse(content.value.toString());

--- a/src/vs/workbench/services/keybinding/browser/keybindingService.ts
+++ b/src/vs/workbench/services/keybinding/browser/keybindingService.ts
@@ -343,7 +343,7 @@ export class WorkbenchKeybindingService extends AbstractKeybindingService {
 			if (!item.keybinding) {
 				continue;
 			}
-			const input = item._source.key;
+			const input = item._sourceKey ?? 'Impossible: missing source key, but has keybinding';
 			if (seenBindings.has(input)) {
 				continue;
 			}

--- a/src/vs/workbench/services/keybinding/browser/keybindingService.ts
+++ b/src/vs/workbench/services/keybinding/browser/keybindingService.ts
@@ -17,7 +17,7 @@ import { ICommandService, CommandsRegistry } from 'vs/platform/commands/common/c
 import { ContextKeyExpr, IContextKeyService, ContextKeyExpression, IContextKey } from 'vs/platform/contextkey/common/contextkey';
 import { Extensions, IJSONContributionRegistry } from 'vs/platform/jsonschemas/common/jsonContributionRegistry';
 import { AbstractKeybindingService } from 'vs/platform/keybinding/common/abstractKeybindingService';
-import { IKeyboardEvent, IUserFriendlyKeybinding, IKeybindingService, KeybindingsSchemaContribution } from 'vs/platform/keybinding/common/keybinding';
+import { IKeyboardEvent, IKeybindingService, KeybindingsSchemaContribution, KeybindingFromJSON } from 'vs/platform/keybinding/common/keybinding';
 import { KeybindingResolver } from 'vs/platform/keybinding/common/keybindingResolver';
 import { IKeybindingItem, IExtensionKeybindingRule, KeybindingWeight, KeybindingsRegistry } from 'vs/platform/keybinding/common/keybindingsRegistry';
 import { ResolvedKeybindingItem } from 'vs/platform/keybinding/common/resolvedKeybindingItem';
@@ -682,7 +682,7 @@ export class WorkbenchKeybindingService extends AbstractKeybindingService {
 
 class UserKeybindings extends Disposable {
 
-	private _rawKeybindings: IUserFriendlyKeybinding[] = [];
+	private _rawKeybindings: KeybindingFromJSON[] = [];
 	private _keybindings: IUserKeybindingItem[] = [];
 	get keybindings(): IUserKeybindingItem[] { return this._keybindings; }
 
@@ -756,11 +756,13 @@ class UserKeybindings extends Disposable {
 		return true;
 	}
 
-	private async readUserKeybindings(): Promise<IUserFriendlyKeybinding[]> {
+	private async readUserKeybindings(): Promise<KeybindingFromJSON[]> {
 		try {
 			const content = await this.fileService.readFile(this.userDataProfileService.currentProfile.keybindingsResource);
 			const value = parse(content.value.toString());
-			return Array.isArray(value) ? value : [];
+			return Array.isArray(value)
+				? value.filter(v => v && typeof v === 'object' /* just typeof === object doesn't catch `null` */)
+				: [];
 		} catch (e) {
 			return [];
 		}

--- a/src/vs/workbench/services/keybinding/browser/keybindingService.ts
+++ b/src/vs/workbench/services/keybinding/browser/keybindingService.ts
@@ -406,7 +406,7 @@ export class WorkbenchKeybindingService extends AbstractKeybindingService {
 				// This might be a removal keybinding item in user settings => accept it
 				result[resultLen++] = new ResolvedKeybindingItem(undefined, item.command, item.commandArgs, when, isDefault, item.extensionId, item.isBuiltinExtension);
 			} else {
-				if (this._assertBrowserConflicts(keybinding, item.command)) {
+				if (this._assertBrowserConflicts(keybinding)) {
 					continue;
 				}
 
@@ -440,7 +440,7 @@ export class WorkbenchKeybindingService extends AbstractKeybindingService {
 		return result;
 	}
 
-	private _assertBrowserConflicts(keybinding: Keybinding, commandId: string | null): boolean {
+	private _assertBrowserConflicts(keybinding: Keybinding): boolean {
 		if (BrowserFeatures.keyboard === KeyboardSupport.Always) {
 			return false;
 		}

--- a/src/vs/workbench/services/keybinding/common/keybindingIO.ts
+++ b/src/vs/workbench/services/keybinding/common/keybindingIO.ts
@@ -3,10 +3,10 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Keybinding } from 'vs/base/common/keybindings';
 import { KeybindingParser } from 'vs/base/common/keybindingParser';
+import { Keybinding } from 'vs/base/common/keybindings';
 import { ContextKeyExpr, ContextKeyExpression } from 'vs/platform/contextkey/common/contextkey';
-import { IUserFriendlyKeybinding, KeybindingFromJSON } from 'vs/platform/keybinding/common/keybinding';
+import { KeybindingFromJSON } from 'vs/platform/keybinding/common/keybinding';
 import { ResolvedKeybindingItem } from 'vs/platform/keybinding/common/resolvedKeybindingItem';
 
 export interface IUserKeybindingItem {
@@ -14,7 +14,7 @@ export interface IUserKeybindingItem {
 	command: string | null;
 	commandArgs?: any;
 	when: ContextKeyExpression | undefined;
-	_source: IUserFriendlyKeybinding;
+	_sourceKey: string | undefined; /** captures `key` field from `keybindings.json`; `this.keybinding !== null` implies `_sourceKey !== null` */
 }
 
 export class KeybindingIO {
@@ -53,7 +53,7 @@ export class KeybindingIO {
 			command,
 			commandArgs,
 			when,
-			_source: { key: input.key ?? 'KEYBINDING_MISSING_KEY', command: input.command ?? 'KEYBINDING_MISSING_COMMAND', when: input.when, args: input.args }
+			_sourceKey: input.key,
 		};
 	}
 }

--- a/src/vs/workbench/services/keybinding/common/keybindingIO.ts
+++ b/src/vs/workbench/services/keybinding/common/keybindingIO.ts
@@ -6,7 +6,7 @@
 import { Keybinding } from 'vs/base/common/keybindings';
 import { KeybindingParser } from 'vs/base/common/keybindingParser';
 import { ContextKeyExpr, ContextKeyExpression } from 'vs/platform/contextkey/common/contextkey';
-import { IUserFriendlyKeybinding } from 'vs/platform/keybinding/common/keybinding';
+import { IUserFriendlyKeybinding, KeybindingFromJSON } from 'vs/platform/keybinding/common/keybinding';
 import { ResolvedKeybindingItem } from 'vs/platform/keybinding/common/resolvedKeybindingItem';
 
 export interface IUserKeybindingItem {
@@ -43,7 +43,7 @@ export class KeybindingIO {
 		out.write(' }');
 	}
 
-	public static readUserKeybindingItem(input: IUserFriendlyKeybinding): IUserKeybindingItem {
+	public static readUserKeybindingItem(input: KeybindingFromJSON): IUserKeybindingItem {
 		const keybinding = (typeof input.key === 'string' ? KeybindingParser.parseKeybinding(input.key) : null);
 		const when = (typeof input.when === 'string' ? ContextKeyExpr.deserialize(input.when) : undefined);
 		const command = (typeof input.command === 'string' ? input.command : null);
@@ -53,7 +53,7 @@ export class KeybindingIO {
 			command,
 			commandArgs,
 			when,
-			_source: input
+			_source: { key: input.key ?? 'KEYBINDING_MISSING_KEY', command: input.command ?? 'KEYBINDING_MISSING_COMMAND', when: input.when, args: input.args }
 		};
 	}
 }

--- a/src/vs/workbench/services/keybinding/common/keybindingIO.ts
+++ b/src/vs/workbench/services/keybinding/common/keybindingIO.ts
@@ -6,7 +6,6 @@
 import { KeybindingParser } from 'vs/base/common/keybindingParser';
 import { Keybinding } from 'vs/base/common/keybindings';
 import { ContextKeyExpr, ContextKeyExpression } from 'vs/platform/contextkey/common/contextkey';
-import { KeybindingFromJSON } from 'vs/platform/keybinding/common/keybinding';
 import { ResolvedKeybindingItem } from 'vs/platform/keybinding/common/resolvedKeybindingItem';
 
 export interface IUserKeybindingItem {
@@ -43,17 +42,25 @@ export class KeybindingIO {
 		out.write(' }');
 	}
 
-	public static readUserKeybindingItem(input: KeybindingFromJSON): IUserKeybindingItem {
-		const keybinding = (typeof input.key === 'string' ? KeybindingParser.parseKeybinding(input.key) : null);
-		const when = (typeof input.when === 'string' ? ContextKeyExpr.deserialize(input.when) : undefined);
-		const command = (typeof input.command === 'string' ? input.command : null);
-		const commandArgs = (typeof input.args !== 'undefined' ? input.args : undefined);
+	public static readUserKeybindingItem(input: Object): IUserKeybindingItem {
+		const keybinding = 'key' in input && typeof input.key === 'string'
+			? KeybindingParser.parseKeybinding(input.key)
+			: null;
+		const when = 'when' in input && typeof input.when === 'string'
+			? ContextKeyExpr.deserialize(input.when)
+			: undefined;
+		const command = 'command' in input && typeof input.command === 'string'
+			? input.command
+			: null;
+		const commandArgs = 'args' in input && typeof input.args !== 'undefined'
+			? input.args
+			: undefined;
 		return {
 			keybinding,
 			command,
 			commandArgs,
 			when,
-			_sourceKey: input.key,
+			_sourceKey: 'key' in input && typeof input.key === 'string' ? input.key : undefined,
 		};
 	}
 }

--- a/src/vs/workbench/services/keybinding/test/browser/keybindingIO.test.ts
+++ b/src/vs/workbench/services/keybinding/test/browser/keybindingIO.test.ts
@@ -7,7 +7,6 @@ import { KeyChord, KeyCode, KeyMod, ScanCode } from 'vs/base/common/keyCodes';
 import { KeyCodeChord, decodeKeybinding, ScanCodeChord, Keybinding } from 'vs/base/common/keybindings';
 import { KeybindingParser } from 'vs/base/common/keybindingParser';
 import { OperatingSystem } from 'vs/base/common/platform';
-import { IUserFriendlyKeybinding } from 'vs/platform/keybinding/common/keybinding';
 import { KeybindingIO } from 'vs/workbench/services/keybinding/common/keybindingIO';
 import { createUSLayoutResolvedKeybinding } from 'vs/platform/keybinding/test/common/keybindingsTestUtils';
 
@@ -125,35 +124,35 @@ suite('keybindingIO', () => {
 
 	test('issue #10452 - invalid command', () => {
 		const strJSON = `[{ "key": "ctrl+k ctrl+f", "command": ["firstcommand", "seccondcommand"] }]`;
-		const userKeybinding = <IUserFriendlyKeybinding>JSON.parse(strJSON)[0];
+		const userKeybinding = <Object>JSON.parse(strJSON)[0];
 		const keybindingItem = KeybindingIO.readUserKeybindingItem(userKeybinding);
 		assert.strictEqual(keybindingItem.command, null);
 	});
 
 	test('issue #10452 - invalid when', () => {
 		const strJSON = `[{ "key": "ctrl+k ctrl+f", "command": "firstcommand", "when": [] }]`;
-		const userKeybinding = <IUserFriendlyKeybinding>JSON.parse(strJSON)[0];
+		const userKeybinding = <Object>JSON.parse(strJSON)[0];
 		const keybindingItem = KeybindingIO.readUserKeybindingItem(userKeybinding);
 		assert.strictEqual(keybindingItem.when, undefined);
 	});
 
 	test('issue #10452 - invalid key', () => {
 		const strJSON = `[{ "key": [], "command": "firstcommand" }]`;
-		const userKeybinding = <IUserFriendlyKeybinding>JSON.parse(strJSON)[0];
+		const userKeybinding = <Object>JSON.parse(strJSON)[0];
 		const keybindingItem = KeybindingIO.readUserKeybindingItem(userKeybinding);
 		assert.deepStrictEqual(keybindingItem.keybinding, null);
 	});
 
 	test('issue #10452 - invalid key 2', () => {
 		const strJSON = `[{ "key": "", "command": "firstcommand" }]`;
-		const userKeybinding = <IUserFriendlyKeybinding>JSON.parse(strJSON)[0];
+		const userKeybinding = <Object>JSON.parse(strJSON)[0];
 		const keybindingItem = KeybindingIO.readUserKeybindingItem(userKeybinding);
 		assert.deepStrictEqual(keybindingItem.keybinding, null);
 	});
 
 	test('test commands args', () => {
 		const strJSON = `[{ "key": "ctrl+k ctrl+f", "command": "firstcommand", "when": [], "args": { "text": "theText" } }]`;
-		const userKeybinding = <IUserFriendlyKeybinding>JSON.parse(strJSON)[0];
+		const userKeybinding = <Object>JSON.parse(strJSON)[0];
 		const keybindingItem = KeybindingIO.readUserKeybindingItem(userKeybinding);
 		assert.strictEqual(keybindingItem.commandArgs.text, 'theText');
 	});


### PR DESCRIPTION
- keybindings: de/serialization: refactor: use more correct return type for user keybindings parsing function
- keybindings: de/serialization: refactor: don't keep whole object for its single field
- keybindings: de/serialization: now fix the return type of parsed json object for real to be the 'real' type of the object
- keybindings: WorkbenchKeybindingService: remove unused param
- keybindings: platform: add some comments

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
