### PR TITLE
debug: bump js-debug to 1.76.1

### DIFF
--- a/product.json
+++ b/product.json
@@ -47,7 +47,7 @@
 		},
 		{
 			"name": "ms-vscode.js-debug",
-			"version": "1.76.0",
+			"version": "1.76.1",
 			"repo": "https://github.com/microsoft/vscode-js-debug",
 			"metadata": {
 				"id": "25629058-ddac-4e17-abba-74678e126c5d",


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-js-debug/issues/1604

Contains these changes: https://github.com/microsoft/vscode-js-debug/compare/v1.76.0...v1.76.1