### PR TITLE
Allow for custom dialog options to also include custom renderer for the body

### DIFF
--- a/src/vs/platform/dialogs/common/dialogs.ts
+++ b/src/vs/platform/dialogs/common/dialogs.ts
@@ -263,6 +263,7 @@ export const IDialogService = createDecorator<IDialogService>('dialogService');
 export interface ICustomDialogOptions {
 	readonly buttonDetails?: string[];
 	readonly markdownDetails?: ICustomDialogMarkdown[];
+	readonly renderBody?: (container: HTMLElement) => void;
 	readonly classes?: string[];
 	readonly icon?: ThemeIcon;
 	readonly disableCloseAction?: boolean;

--- a/src/vs/workbench/browser/parts/dialogs/dialogHandler.ts
+++ b/src/vs/workbench/browser/parts/dialogs/dialogHandler.ts
@@ -107,7 +107,7 @@ export class BrowserDialogHandler extends AbstractDialogHandler {
 	private async doShow(type: Severity | DialogType | undefined, message: string, buttons?: string[], detail?: string, cancelId?: number, checkbox?: ICheckbox, inputs?: IInputElement[], customOptions?: ICustomDialogOptions): Promise<IDialogResult> {
 		const dialogDisposables = new DisposableStore();
 
-		const renderBody = customOptions ? (parent: HTMLElement) => {
+		const renderBody = customOptions ? (customOptions.renderBody ? customOptions.renderBody : (parent: HTMLElement) => {
 			parent.classList.add(...(customOptions.classes || []));
 			customOptions.markdownDetails?.forEach(markdownDetail => {
 				const result = this.markdownRenderer.render(markdownDetail.markdown);
@@ -115,7 +115,7 @@ export class BrowserDialogHandler extends AbstractDialogHandler {
 				result.element.classList.add(...(markdownDetail.classes || []));
 				dialogDisposables.add(result);
 			});
-		} : undefined;
+		}) : undefined;
 
 		const dialog = new Dialog(
 			this.layoutService.container,

--- a/src/vs/workbench/contrib/welcomeDialog/browser/welcomeDialogService.ts
+++ b/src/vs/workbench/contrib/welcomeDialog/browser/welcomeDialogService.ts
@@ -7,13 +7,11 @@ import 'vs/css!./media/welcomeDialog';
 import { IInstantiationService, createDecorator } from 'vs/platform/instantiation/common/instantiation';
 import { ThemeIcon } from 'vs/base/common/themables';
 import { InstantiationType, registerSingleton } from 'vs/platform/instantiation/common/extensions';
-import { ILayoutService } from 'vs/platform/layout/browser/layoutService';
 import { DisposableStore } from 'vs/base/common/lifecycle';
-import { Dialog } from 'vs/base/browser/ui/dialog/dialog';
-import { defaultButtonStyles, defaultCheckboxStyles, defaultDialogStyles, defaultInputBoxStyles } from 'vs/platform/theme/browser/defaultStyles';
 import { $ } from 'vs/base/browser/dom';
 import { renderLabelWithIcons } from 'vs/base/browser/ui/iconLabel/iconLabels';
 import { ILinkDescriptor, Link } from 'vs/platform/opener/browser/link';
+import { IDialogService } from 'vs/platform/dialogs/common/dialogs';
 
 interface IWelcomeDialogItem {
 	readonly title: string;
@@ -34,12 +32,11 @@ export interface IWelcomeDialogService {
 export class WelcomeDialogService implements IWelcomeDialogService {
 	declare readonly _serviceBrand: undefined;
 
-	private dialog: Dialog | undefined;
 	private disposableStore: DisposableStore = new DisposableStore();
 
 	constructor(
-		@ILayoutService private readonly layoutService: ILayoutService,
-		@IInstantiationService private readonly instantiationService: IInstantiationService) {
+		@IInstantiationService private readonly instantiationService: IInstantiationService,
+		@IDialogService private readonly dialogService: IDialogService) {
 	}
 
 	private static iconWidgetFor(icon: string) {
@@ -78,23 +75,16 @@ export class WelcomeDialogService implements IWelcomeDialogService {
 			}
 		};
 
-		this.dialog = new Dialog(
-			this.layoutService.container,
-			welcomeDialogItem.title,
-			[welcomeDialogItem.buttonText],
-			{
-				detail: '',
-				type: 'none',
-				renderBody: renderBody,
+		await this.dialogService.prompt({
+			type: 'none',
+			message: welcomeDialogItem.title,
+			cancelButton: welcomeDialogItem.buttonText,
+			custom: {
 				disableCloseAction: true,
-				buttonStyles: defaultButtonStyles,
-				checkboxStyles: defaultCheckboxStyles,
-				inputBoxStyles: defaultInputBoxStyles,
-				dialogStyles: defaultDialogStyles
-			});
+				renderBody: renderBody
+			}
+		});
 
-		this.disposableStore.add(this.dialog);
-		await this.dialog.show();
 		welcomeDialogItem.onClose?.();
 		this.disposableStore.dispose();
 	}


### PR DESCRIPTION
Fixes:
https://github.com/microsoft/vscode/issues/176972

Fix Description:
Previously, the `welcomeDialogService` was rendering its own `Dialog` which prevented it from being able to block future modal dialogs from the `dialogService` from showing.

I would like to request allowing ICustomDialogOptions to also include a function for rendering custom body so that we can hook into the existing `dialogService` for showing dialogs sequentially.

cc: @joyceerhl 