### PR TITLE
Initial getSessions API

### DIFF
--- a/src/vs/workbench/api/common/extHost.api.impl.ts
+++ b/src/vs/workbench/api/common/extHost.api.impl.ts
@@ -247,6 +247,10 @@ export function createApiFactoryAndRegisterActors(accessor: ServicesAccessor): I
 			getSession(providerId: string, scopes: readonly string[], options?: vscode.AuthenticationGetSessionOptions) {
 				return extHostAuthentication.getSession(extension, providerId, scopes, options as any);
 			},
+			getSessions(providerId: string, scopes: readonly string[]) {
+				checkProposedApiEnabled(extension, 'getSessions');
+				return extHostAuthentication.getSessions(extension, providerId, scopes);
+			},
 			// TODO: remove this after GHPR and Codespaces move off of it
 			async hasSession(providerId: string, scopes: readonly string[]) {
 				checkProposedApiEnabled(extension, 'authSession');

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -150,6 +150,7 @@ export interface MainThreadAuthenticationShape extends IDisposable {
 	$ensureProvider(id: string): Promise<void>;
 	$sendDidChangeSessions(providerId: string, event: AuthenticationSessionsChangeEvent): void;
 	$getSession(providerId: string, scopes: readonly string[], extensionId: string, extensionName: string, options: { createIfNone?: boolean; forceNewSession?: boolean | { detail: string }; clearSessionPreference?: boolean }): Promise<AuthenticationSession | undefined>;
+	$getSessions(providerId: string, scopes: readonly string[], extensionId: string, extensionName: string): Promise<AuthenticationSession[]>;
 	$removeSession(providerId: string, sessionId: string): Promise<void>;
 }
 

--- a/src/vs/workbench/api/common/extHostAuthentication.ts
+++ b/src/vs/workbench/api/common/extHostAuthentication.ts
@@ -43,7 +43,7 @@ export class ExtHostAuthentication implements ExtHostAuthenticationShape {
 	async getSession(requestingExtension: IExtensionDescription, providerId: string, scopes: readonly string[], options: vscode.AuthenticationGetSessionOptions = {}): Promise<vscode.AuthenticationSession | undefined> {
 		const extensionId = ExtensionIdentifier.toKey(requestingExtension.identifier);
 		const sortedScopes = [...scopes].sort().join(' ');
-		return await this._getSessionTaskSingler.getOrCreate(`${extensionId} ${sortedScopes}`, async () => {
+		return await this._getSessionTaskSingler.getOrCreate(`${extensionId} ${providerId} ${sortedScopes}`, async () => {
 			await this._proxy.$ensureProvider(providerId);
 			const extensionName = requestingExtension.displayName || requestingExtension.name;
 			return this._proxy.$getSession(providerId, scopes, extensionId, extensionName, options);

--- a/src/vs/workbench/api/common/extHostAuthentication.ts
+++ b/src/vs/workbench/api/common/extHostAuthentication.ts
@@ -9,12 +9,6 @@ import { IMainContext, MainContext, MainThreadAuthenticationShape, ExtHostAuthen
 import { Disposable } from 'vs/workbench/api/common/extHostTypes';
 import { IExtensionDescription, ExtensionIdentifier } from 'vs/platform/extensions/common/extensions';
 
-interface GetSessionsRequest {
-	scopes: string;
-	providerId: string;
-	result: Promise<vscode.AuthenticationSession | undefined>;
-}
-
 interface ProviderWithMetadata {
 	label: string;
 	provider: vscode.AuthenticationProvider;
@@ -30,7 +24,8 @@ export class ExtHostAuthentication implements ExtHostAuthenticationShape {
 	private _onDidChangeSessions = new Emitter<vscode.AuthenticationSessionsChangeEvent>();
 	readonly onDidChangeSessions: Event<vscode.AuthenticationSessionsChangeEvent> = this._onDidChangeSessions.event;
 
-	private _inFlightRequests = new Map<string, GetSessionsRequest[]>();
+	private _getSessionTaskSingler = new TaskSingler<vscode.AuthenticationSession | undefined>();
+	private _getSessionsTaskSingler = new TaskSingler<ReadonlyArray<vscode.AuthenticationSession>>();
 
 	constructor(mainContext: IMainContext) {
 		this._proxy = mainContext.getProxy(MainContext.MainThreadAuthentication);
@@ -47,41 +42,22 @@ export class ExtHostAuthentication implements ExtHostAuthenticationShape {
 	async getSession(requestingExtension: IExtensionDescription, providerId: string, scopes: readonly string[], options: vscode.AuthenticationGetSessionOptions): Promise<vscode.AuthenticationSession | undefined>;
 	async getSession(requestingExtension: IExtensionDescription, providerId: string, scopes: readonly string[], options: vscode.AuthenticationGetSessionOptions = {}): Promise<vscode.AuthenticationSession | undefined> {
 		const extensionId = ExtensionIdentifier.toKey(requestingExtension.identifier);
-		const inFlightRequests = this._inFlightRequests.get(extensionId) || [];
 		const sortedScopes = [...scopes].sort().join(' ');
-		let inFlightRequest: GetSessionsRequest | undefined = inFlightRequests.find(request => request.providerId === providerId && request.scopes === sortedScopes);
-
-		if (inFlightRequest) {
-			return inFlightRequest.result;
-		} else {
-			const session = this._getSession(requestingExtension, extensionId, providerId, scopes, options);
-			inFlightRequest = {
-				providerId,
-				scopes: sortedScopes,
-				result: session
-			};
-
-			inFlightRequests.push(inFlightRequest);
-			this._inFlightRequests.set(extensionId, inFlightRequests);
-
-			try {
-				await session;
-			} finally {
-				const requestIndex = inFlightRequests.findIndex(request => request.providerId === providerId && request.scopes === sortedScopes);
-				if (requestIndex > -1) {
-					inFlightRequests.splice(requestIndex);
-					this._inFlightRequests.set(extensionId, inFlightRequests);
-				}
-			}
-
-			return session;
-		}
+		return await this._getSessionTaskSingler.getOrCreate(`${extensionId} ${sortedScopes}`, async () => {
+			await this._proxy.$ensureProvider(providerId);
+			const extensionName = requestingExtension.displayName || requestingExtension.name;
+			return this._proxy.$getSession(providerId, scopes, extensionId, extensionName, options);
+		});
 	}
 
-	private async _getSession(requestingExtension: IExtensionDescription, extensionId: string, providerId: string, scopes: readonly string[], options: vscode.AuthenticationGetSessionOptions = {}): Promise<vscode.AuthenticationSession | undefined> {
-		await this._proxy.$ensureProvider(providerId);
-		const extensionName = requestingExtension.displayName || requestingExtension.name;
-		return this._proxy.$getSession(providerId, scopes, extensionId, extensionName, options);
+	async getSessions(requestingExtension: IExtensionDescription, providerId: string, scopes: readonly string[]): Promise<ReadonlyArray<vscode.AuthenticationSession>> {
+		const extensionId = ExtensionIdentifier.toKey(requestingExtension.identifier);
+		const sortedScopes = [...scopes].sort().join(' ');
+		return await this._getSessionsTaskSingler.getOrCreate(`${extensionId} ${sortedScopes}`, async () => {
+			await this._proxy.$ensureProvider(providerId);
+			const extensionName = requestingExtension.displayName || requestingExtension.name;
+			return this._proxy.$getSessions(providerId, scopes, extensionId, extensionName);
+		});
 	}
 
 	async removeSession(providerId: string, sessionId: string): Promise<void> {
@@ -160,5 +136,20 @@ export class ExtHostAuthentication implements ExtHostAuthenticationShape {
 	$onDidChangeAuthenticationSessions(id: string, label: string) {
 		this._onDidChangeSessions.fire({ provider: { id, label } });
 		return Promise.resolve();
+	}
+}
+
+class TaskSingler<T> {
+	private _inFlightPromises = new Map<string, Promise<T>>();
+	getOrCreate(key: string, promiseFactory: () => Promise<T>) {
+		const inFlight = this._inFlightPromises.get(key);
+		if (inFlight) {
+			return inFlight;
+		}
+
+		const promise = promiseFactory().finally(() => this._inFlightPromises.delete(key));
+		this._inFlightPromises.set(key, promise);
+
+		return promise;
 	}
 }

--- a/src/vs/workbench/services/extensions/common/extensionsApiProposals.ts
+++ b/src/vs/workbench/services/extensions/common/extensionsApiProposals.ts
@@ -36,6 +36,7 @@ export const allApiProposals = Object.freeze({
 	fileSearchProvider: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.fileSearchProvider.d.ts',
 	findTextInFiles: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.findTextInFiles.d.ts',
 	fsChunks: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.fsChunks.d.ts',
+	getSessions: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.getSessions.d.ts',
 	idToken: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.idToken.d.ts',
 	indentSize: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.indentSize.d.ts',
 	inlineCompletionsAdditions: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.inlineCompletionsAdditions.d.ts',

--- a/src/vscode-dts/vscode.proposed.getSessions.d.ts
+++ b/src/vscode-dts/vscode.proposed.getSessions.d.ts
@@ -1,0 +1,25 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+declare module 'vscode' {
+
+	// https://github.com/microsoft/vscode/issues/152399
+
+	export namespace authentication {
+		/**
+		 * Get all authentication sessions matching the desired scopes that this extension has access to. In order to request access,
+		 * use {@link getSession}. To request an additional account, specify {@link AuthenticationGetSessionOptions.clearSessionPreference}
+		 * and {@link AuthenticationGetSessionOptions.createIfNone} together.
+		 *
+		 * Currently, there are only two authentication providers that are contributed from built in extensions
+		 * to the editor that implement GitHub and Microsoft authentication: their providerId's are 'github' and 'microsoft'.
+		 *
+		 * @param providerId The id of the provider to use
+		 * @param scopes A list of scopes representing the permissions requested. These are dependent on the authentication provider
+		 * @returns A thenable that resolves to a readonly array of authentication sessions.
+		 */
+		export function getSessions(providerId: string, scopes: readonly string[]): Thenable<readonly AuthenticationSession[]>;
+	}
+}


### PR DESCRIPTION
ref https://github.com/microsoft/vscode/issues/152399

Usage:

```
const result = await vscode.authentication.getSessions('microsoft', ['Mail.ReadWrite']);
```

If an auth provider supports multi-account, then we will return all sessions that match the scopes requested.

This is done for Microsoft auth but also to prepare for a mult-github account auth provider.
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
