### PR TITLE
[Monaco] Add `monaco.editor.registerLinkOpener` method to be able to intercept opening links from the editor

### DIFF
--- a/src/vs/editor/standalone/browser/standaloneEditor.ts
+++ b/src/vs/editor/standalone/browser/standaloneEditor.ts
@@ -37,6 +37,7 @@ import { PLAINTEXT_LANGUAGE_ID } from 'vs/editor/common/languages/modesRegistry'
 import { LineRangeMapping, RangeMapping } from 'vs/editor/common/diff/linesDiffComputer';
 import { LineRange } from 'vs/editor/common/core/lineRange';
 import { EditorZoom } from 'vs/editor/common/config/editorZoom';
+import { IOpenerService } from 'vs/platform/opener/common/opener';
 
 /**
  * Create a new editor under `domElement`.
@@ -433,6 +434,28 @@ export function registerCommand(id: string, handler: (accessor: any, ...args: an
 	return CommandsRegistry.registerCommand({ id, handler });
 }
 
+export interface ILinkOpener {
+	open(resource: URI): boolean | Promise<boolean>;
+}
+
+/**
+ * Registers a handler that is called when a link is opened in any editor. The handler callback should return `true` if the link was handled and `false` otherwise.
+ * The handler that was registered last will be called first when a link is opened.
+ *
+ * Returns a disposable that can unregister the opener again.
+ */
+export function registerLinkOpener(opener: ILinkOpener): IDisposable {
+	const openerService = StandaloneServices.get(IOpenerService);
+	return openerService.registerOpener({
+		async open(resource: string | URI) {
+			if (typeof resource === 'string') {
+				resource = URI.parse(resource);
+			}
+			return opener.open(resource);
+		}
+	});
+}
+
 /**
  * @internal
  */
@@ -474,6 +497,8 @@ export function createMonacoEditorAPI(): typeof monaco.editor {
 		setTheme: <any>setTheme,
 		remeasureFonts: remeasureFonts,
 		registerCommand: registerCommand,
+
+		registerLinkOpener: registerLinkOpener,
 
 		// enums
 		AccessibilitySupport: standaloneEnums.AccessibilitySupport,

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -1097,6 +1097,18 @@ declare namespace monaco.editor {
 	 */
 	export function registerCommand(id: string, handler: (accessor: any, ...args: any[]) => void): IDisposable;
 
+	export interface ILinkOpener {
+		open(resource: Uri): boolean | Promise<boolean>;
+	}
+
+	/**
+	 * Registers a handler that is called when a link is opened in any editor. The handler callback should return `true` if the link was handled and `false` otherwise.
+	 * The handler that was registered last will be called first when a link is opened.
+	 *
+	 * Returns a disposable that can unregister the opener again.
+	 */
+	export function registerLinkOpener(opener: ILinkOpener): IDisposable;
+
 	export type BuiltinTheme = 'vs' | 'vs-dark' | 'hc-black' | 'hc-light';
 
 	export interface IStandaloneThemeData {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fixes https://github.com/microsoft/monaco-editor/issues/3354

By default the Monaco editor opens links clicked in the editor in a new tab. As stated in my comment in the above issue this is a good thing! However, there are situations where you want to handle the links yourself. For example, we have types of links that should be opened in the same tab, and we have types of links that should use our own window open method that transfers some state to the new tab/window. Everything else should still use the default.

This PR addresses that need by providing a `monaco.editor.registerLinkOpener` function that can be used to intercept the openening of links from the embedded editor and handle them however the embedder wishes to. The function delegates to the `IOpenerService` and returns an `IDisposable` instance to unregister the handler again.

**Monaco Playground Code:**
```js
const text = `function hello() {
	alert('Hello world!');
	// https://www.example.com
}`;

// Hover on each property to see its docs!
monaco.editor.create(document.getElementById("container"), {
	value: text,
	language: "javascript",
	automaticLayout: true,
});

monaco.editor.registerLinkOpener({
	open(resource) {
		// do something with the link
		console.log(`handled ${resource}`);
		return true;
	}
});
```