### PR TITLE
Expose `EditorZoom` in the monaco API

### DIFF
--- a/build/monaco/monaco.d.ts.recipe
+++ b/build/monaco/monaco.d.ts.recipe
@@ -85,6 +85,7 @@ export interface ICommandHandler {
 #include(vs/editor/browser/config/editorConfiguration): IEditorConstructionOptions
 #includeAll(vs/editor/browser/editorBrowser;editorCommon.=>):
 #include(vs/editor/common/config/fontInfo): FontInfo, BareFontInfo
+#include(vs/editor/common/config/editorZoom): EditorZoom, IEditorZoom
 
 //compatibility:
 export type IReadOnlyModel = ITextModel;

--- a/src/vs/editor/standalone/browser/standaloneEditor.ts
+++ b/src/vs/editor/standalone/browser/standaloneEditor.ts
@@ -36,6 +36,7 @@ import { ContextKeyExpr } from 'vs/platform/contextkey/common/contextkey';
 import { PLAINTEXT_LANGUAGE_ID } from 'vs/editor/common/languages/modesRegistry';
 import { LineRangeMapping, RangeMapping } from 'vs/editor/common/diff/linesDiffComputer';
 import { LineRange } from 'vs/editor/common/core/lineRange';
+import { EditorZoom } from 'vs/editor/common/config/editorZoom';
 
 /**
  * Create a new editor under `domElement`.
@@ -508,6 +509,7 @@ export function createMonacoEditorAPI(): typeof monaco.editor {
 		LineRange: <any>LineRange,
 		LineRangeMapping: <any>LineRangeMapping,
 		RangeMapping: <any>RangeMapping,
+		EditorZoom: <any>EditorZoom,
 
 		// vars
 		EditorType: EditorType,

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -5834,6 +5834,14 @@ declare namespace monaco.editor {
 		readonly letterSpacing: number;
 	}
 
+	export const EditorZoom: IEditorZoom;
+
+	export interface IEditorZoom {
+		onDidChangeZoomLevel: IEvent<number>;
+		getZoomLevel(): number;
+		setZoomLevel(zoomLevel: number): void;
+	}
+
 	//compatibility:
 	export type IReadOnlyModel = ITextModel;
 	export type IModel = ITextModel;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Addresses https://github.com/microsoft/monaco-editor/issues/2322#issuecomment-768540613 and https://github.com/microsoft/monaco-editor/issues/196

It was already possible to get this class in the ESM build. In the AMD build you could get this same API using `require` calls (see first link above) but they were untyped. This PR exposes the `EditorZoom` API in the (AMD) monaco API in a more type safe manner.

We use this (currently untyped) API when embedding Monaco to sync up editor zoom levels changed by keyboard actions (e.g. `editor.action.fontZoomIn`) with a dropdown control (simulated below by a simple `div` element), and to be able to set zoom levels through the dropdown control without doing font size calculations.

**Monaco Playground Code:**
```html
<div id="container" style="height: 90%"></div>
<div id="dropdown"></div>
```

```js
const text = `function hello() {
	alert('Hello world!');
}`;

// Hover on each property to see its docs!
monaco.editor.create(document.getElementById("container"), {
	value: text,
	language: "javascript",
	automaticLayout: true,
});

monaco.editor.addKeybindingRule({
	command: "editor.action.fontZoomIn", 
	keybinding: monaco.KeyMod.CtrlCmd | monaco.KeyCode.Equal,
});

monaco.editor.addKeybindingRule({
	command: "editor.action.fontZoomOut", 
	keybinding: monaco.KeyMod.CtrlCmd | monaco.KeyCode.Minus,
});

monaco.editor.addKeybindingRule({
	command: "editor.action.fontZoomReset", 
	keybinding: monaco.KeyMod.CtrlCmd | monaco.KeyCode.Digit0,
});

const dropdown = document.querySelector("#dropdown");
dropdown.addEventListener("click", () => monaco.editor.EditorZoom.setZoomLevel(3));
dropdown.textContent = String(monaco.editor.EditorZoom.getZoomLevel());
monaco.editor.EditorZoom.onDidChangeZoomLevel(level => dropdown.textContent = String(level));
```