### PR TITLE
Temporarily skip extracting node-debug2

### DIFF
--- a/build/azure-pipelines/common/telemetry-config.json
+++ b/build/azure-pipelines/common/telemetry-config.json
@@ -50,16 +50,6 @@
 		"applyEndpoints": true
 	},
 	{
-		"eventPrefix": "ms-vscode.node2/",
-		"sourceDirs": [
-			"vscode-chrome-debug-core",
-			"vscode-node-debug2"
-		],
-		"excludedDirs": [],
-		"applyEndpoints": true,
-		"patchDebugEvents": true
-	},
-	{
 		"eventPrefix": "ms-vscode.node/",
 		"sourceDirs": [
 			"vscode-chrome-debug-core",


### PR DESCRIPTION
Seems the number event name errors are a bit overzealous towards node-debug2. Will skip for now as they're not actually even shipped, js-debug is.