### PR TITLE
cli: allow client process to control singleton process

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -234,6 +234,7 @@ dependencies = [
  "chrono",
  "clap",
  "clap_lex",
+ "console",
  "const_format",
  "core-foundation",
  "dialoguer",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -53,6 +53,7 @@ shell-escape = "0.1.5"
 thiserror = "1.0"
 cfg-if = "1.0.0"
 pin-project = "1.0"
+console = "0.15"
 
 [build-dependencies]
 serde = { version = "1.0" }

--- a/cli/src/log.rs
+++ b/cli/src/log.rs
@@ -303,11 +303,11 @@ pub fn format(level: Level, prefix: &str, message: &str) -> String {
 
 	if let Some(c) = level.color_code() {
 		format!(
-			"\x1b[2m[{}]\x1b[0m {}{}\x1b[0m {}{}\n",
+			"\x1b[2m[{}]\x1b[0m {}{}\x1b[0m {}{}\r\n",
 			timestamp, c, name, prefix, message
 		)
 	} else {
-		format!("[{}] {} {}{}\n", timestamp, name, prefix, message)
+		format!("[{}] {} {}{}\r\n", timestamp, name, prefix, message)
 	}
 }
 

--- a/cli/src/tunnels.rs
+++ b/cli/src/tunnels.rs
@@ -33,7 +33,7 @@ mod service_windows;
 mod socket_signal;
 mod wsl_server;
 
-pub use control_server::serve;
+pub use control_server::{serve, Next};
 pub use nosleep::SleepInhibitor;
 pub use service::{
 	create_service_manager, ServiceContainer, ServiceManager, SERVICE_LOG_FILE_NAME,

--- a/cli/src/tunnels/dev_tunnels.rs
+++ b/cli/src/tunnels/dev_tunnels.rs
@@ -378,14 +378,14 @@ impl DevTunnels {
 	/// this attempts to reuse or create a tunnel of a preferred name or of a generated friendly tunnel name.
 	pub async fn start_new_launcher_tunnel(
 		&mut self,
-		preferred_name: Option<String>,
+		preferred_name: Option<&str>,
 		use_random_name: bool,
 	) -> Result<ActiveTunnel, AnyError> {
 		let (mut tunnel, persisted) = match self.launcher_tunnel.load() {
 			Some(mut persisted) => {
 				if let Some(name) = preferred_name {
 					if persisted.name.ne(&name) {
-						(_, persisted) = self.update_tunnel_name(persisted, &name).await?;
+						(_, persisted) = self.update_tunnel_name(persisted, name).await?;
 					}
 				}
 
@@ -631,7 +631,7 @@ impl DevTunnels {
 
 	async fn get_name_for_tunnel(
 		&mut self,
-		preferred_name: Option<String>,
+		preferred_name: Option<&str>,
 		mut use_random_name: bool,
 	) -> Result<String, AnyError> {
 		let existing_tunnels = self.list_all_server_tunnels().await?;
@@ -646,12 +646,12 @@ impl DevTunnels {
 
 		if let Some(machine_name) = preferred_name {
 			let name = machine_name;
-			if let Err(e) = is_valid_name(&name) {
+			if let Err(e) = is_valid_name(name) {
 				info!(self.log, "{} is an invalid name", e);
 				return Err(AnyError::from(wrap(e, "invalid name")));
 			}
-			if is_name_free(&name) {
-				return Ok(name);
+			if is_name_free(name) {
+				return Ok(name.to_owned());
 			}
 			info!(
 				self.log,

--- a/cli/src/tunnels/protocol.rs
+++ b/cli/src/tunnels/protocol.rs
@@ -164,14 +164,14 @@ pub mod singleton {
 
 	#[derive(Serialize)]
 	pub struct LogMessage<'a> {
-		pub level: log::Level,
+		pub level: Option<log::Level>,
 		pub prefix: &'a str,
 		pub message: &'a str,
 	}
 
 	#[derive(Deserialize)]
 	pub struct LogMessageOwned {
-		pub level: log::Level,
+		pub level: Option<log::Level>,
 		pub prefix: String,
 		pub message: String,
 	}

--- a/cli/src/tunnels/singleton_client.rs
+++ b/cli/src/tunnels/singleton_client.rs
@@ -3,10 +3,21 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+use std::{
+	sync::{
+		atomic::{AtomicBool, Ordering},
+		Arc,
+	},
+	thread,
+};
+
+use tokio::sync::mpsc;
+
 use crate::{
 	async_pipe::{socket_stream_split, AsyncPipe},
 	json_rpc::{new_json_rpc, start_json_rpc},
 	log,
+	tunnels::protocol::EmptyObject,
 	util::sync::Barrier,
 };
 
@@ -20,26 +31,58 @@ pub struct SingletonClientArgs {
 
 struct SingletonServerContext {
 	log: log::Logger,
+	exit_entirely: Arc<AtomicBool>,
 }
 
-pub async fn start_singleton_client(args: SingletonClientArgs) {
-	let rpc = new_json_rpc();
+/// Serves a client singleton. Returns true if the process should exit after
+/// this returns, instead of trying to start a tunnel.
+pub async fn start_singleton_client(args: SingletonClientArgs) -> bool {
+	let mut rpc = new_json_rpc();
+	let (msg_tx, msg_rx) = mpsc::unbounded_channel();
+	let exit_entirely = Arc::new(AtomicBool::new(false));
 
 	debug!(
 		args.log,
 		"An existing tunnel is running on this machine, connecting to it..."
 	);
 
+	let stdin_handle = rpc.get_caller(msg_tx);
+	thread::spawn(move || {
+		let term = console::Term::stderr();
+		loop {
+			match term.read_key() {
+				Ok(console::Key::Char('x')) => {
+					stdin_handle.notify("shutdown", EmptyObject {});
+				}
+				Ok(console::Key::Char('r')) => {
+					stdin_handle.notify("restart", EmptyObject {});
+				}
+				Err(_) => return, // EOF or not a tty
+				_ => {}
+			}
+		}
+	});
+
 	let mut rpc = rpc.methods(SingletonServerContext {
 		log: args.log.clone(),
+		exit_entirely: exit_entirely.clone(),
+	});
+
+	rpc.register_sync("shutdown", |_: EmptyObject, c| {
+		c.exit_entirely.store(true, Ordering::SeqCst);
+		Ok(())
 	});
 
 	rpc.register_sync("log", |log: protocol::singleton::LogMessageOwned, c| {
-		c.log
-			.emit(log.level, &format!("{}: {}", log.prefix, log.message));
+		match log.level {
+			Some(level) => c.log.emit(level, &format!("{}{}", log.prefix, log.message)),
+			None => c.log.result(format!("{}{}", log.prefix, log.message)),
+		}
 		Ok(())
 	});
 
 	let (read, write) = socket_stream_split(args.stream);
-	let _ = start_json_rpc(rpc.build(args.log), read, write, (), args.shutdown.clone()).await;
+	let _ = start_json_rpc(rpc.build(args.log), read, write, msg_rx, args.shutdown).await;
+
+	exit_entirely.load(Ordering::SeqCst)
 }

--- a/cli/src/util/sync.rs
+++ b/cli/src/util/sync.rs
@@ -35,6 +35,13 @@ where
 	}
 }
 
+#[async_trait]
+impl<T: Clone + Send + Sync> Receivable<T> for Barrier<T> {
+	async fn recv_msg(&mut self) -> Option<T> {
+		self.wait().await.ok()
+	}
+}
+
 #[derive(Clone)]
 pub struct BarrierOpener<T: Clone>(Arc<watch::Sender<Option<T>>>);
 


### PR DESCRIPTION
Other connected clients will now print:

```
Connected to an existing tunnel process running on this machine. You can press:

- Ctrl+C to detach
- "x" to stop the tunnel and exit
- "r" to restart the tunnel
```

These are then sent to the server to have that take effect. This is mostly some refactors in the singleton_server to make the lifecycle work.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
