### PR TITLE
notebook render output update

### DIFF
--- a/extensions/notebook-renderers/src/index.ts
+++ b/extensions/notebook-renderers/src/index.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import type { ActivationFunction, OutputItem, RendererContext } from 'vscode-notebook-renderer';
-import { insertOutput as createOutputContent, scrollableClass } from './textHelper';
+import { createOutputContent, scrollableClass } from './textHelper';
 
 interface IDisposable {
 	dispose(): void;

--- a/extensions/notebook-renderers/src/index.ts
+++ b/extensions/notebook-renderers/src/index.ts
@@ -215,7 +215,7 @@ function getPreviousMatchingContentGroup(outputElement: HTMLElement) {
 		}
 
 		match = outputElement.firstChild as HTMLElement;
-		previous = outputContainer?.previousSibling;
+		previous = previous?.previousSibling;
 	}
 
 	return match;
@@ -326,7 +326,7 @@ export const activate: ActivationFunction<void> = (ctx) => {
 
 	const style = document.createElement('style');
 	style.textContent = `
-	#container > div > div > div.output.remove-padding {
+	#container div.output.remove-padding {
 		padding-left: 0;
 		padding-right: 0;
 	}
@@ -347,12 +347,10 @@ export const activate: ActivationFunction<void> = (ctx) => {
 		white-space: pre;
 	}
 	/* When wordwrap turned on, force it to pre-wrap */
-	.output-plaintext.wordWrap span,
-	.output-stream.wordWrap span,
-	.traceback.wordWrap span {
+	#container div.output_container .wordWrap span {
 		white-space: pre-wrap;
 	}
-	.output .scrollable {
+	#container div.output .scrollable {
 		padding-left: var(--notebook-output-node-left-padding);
 		padding-right: var(--notebook-output-node-padding);
 		overflow-y: scroll;
@@ -362,10 +360,10 @@ export const activate: ActivationFunction<void> = (ctx) => {
 		border-width: 1px;
 		border-color: transparent;
 	}
-	.output .scrollable.more-above {
+	#container div.output .scrollable.more-above {
 		box-shadow: var(--vscode-scrollbar-shadow) 0 6px 6px -6px inset
 	}
-	.output .scrollable.scrollbar-visible {
+	#container div.output .scrollable.scrollbar-visible {
 		border-color: var(--vscode-editorWidget-border);
 	}
 	.output-plaintext .code-bold,

--- a/extensions/notebook-renderers/src/index.ts
+++ b/extensions/notebook-renderers/src/index.ts
@@ -203,14 +203,14 @@ function renderError(
 	return disposableStore;
 }
 
-function getPreviousMatchingContentGroup(outputElement: HTMLElement, mimeType: string) {
+function getPreviousMatchingContentGroup(outputElement: HTMLElement) {
 	const outputContainer = outputElement.parentElement;
 	let match: HTMLElement | undefined = undefined;
 
 	let previous = outputContainer?.previousSibling;
 	while (previous) {
 		const outputElement = (previous.firstChild as HTMLElement | null);
-		if (!outputElement || outputElement.getAttribute('output-mime-type') !== mimeType) {
+		if (!outputElement || !outputElement.classList.contains('output-stream')) {
 			break;
 		}
 
@@ -253,7 +253,6 @@ function renderStream(outputInfo: OutputItem, outputElement: HTMLElement, error:
 	const disposableStore = createDisposableStore();
 	const outputScrolling = ctx.settings.outputScrolling;
 
-	outputElement.setAttribute('output-mime-type', outputInfo.mime);
 	outputElement.classList.add('output-stream');
 	outputElement.classList.toggle('remove-padding', outputScrolling);
 
@@ -267,7 +266,7 @@ function renderStream(outputInfo: OutputItem, outputElement: HTMLElement, error:
 	const scrollTop = outputScrolling ? findScrolledHeight(outputElement) : undefined;
 
 	// If the previous output item for the same cell was also a stream, append this output to the previous
-	const existingContentParent = getPreviousMatchingContentGroup(outputElement, outputInfo.mime);
+	const existingContentParent = getPreviousMatchingContentGroup(outputElement);
 	if (existingContentParent) {
 		const existing = existingContentParent.querySelector(`[output-item-id="${outputInfo.id}"]`) as HTMLElement | null;
 		if (existing) {
@@ -298,9 +297,9 @@ function renderStream(outputInfo: OutputItem, outputElement: HTMLElement, error:
 	return disposableStore;
 }
 
-function renderText(outputInfo: OutputItem, container: HTMLElement, ctx: IRichRenderContext): IDisposable {
+function renderText(outputInfo: OutputItem, outputElement: HTMLElement, ctx: IRichRenderContext): IDisposable {
 	const disposableStore = createDisposableStore();
-	clearContainer(container);
+	clearContainer(outputElement);
 
 	const text = outputInfo.text();
 	const content = createOutputContent(outputInfo.id, [text], ctx.settings.lineLimit, ctx.settings.outputScrolling, false);
@@ -309,7 +308,12 @@ function renderText(outputInfo: OutputItem, container: HTMLElement, ctx: IRichRe
 		content.classList.add('wordWrap');
 	}
 
+	const outputScrolling = ctx.settings.outputScrolling;
+	content.classList.toggle('scrollable', outputScrolling);
+	outputElement.classList.toggle('remove-padding', outputScrolling);
+	outputElement.appendChild(content);
 	initializeScroll(content, disposableStore);
+
 	return disposableStore;
 }
 

--- a/extensions/notebook-renderers/src/textHelper.ts
+++ b/extensions/notebook-renderers/src/textHelper.ts
@@ -77,7 +77,7 @@ function scrollableArrayOfString(id: string, buffer: string[], trustHtml: boolea
 	return element;
 }
 
-export function insertOutput(id: string, outputs: string[], linesLimit: number, scrollable: boolean, trustHtml: boolean): HTMLElement {
+export function createOutputContent(id: string, outputs: string[], linesLimit: number, scrollable: boolean, trustHtml: boolean): HTMLElement {
 
 	const buffer = outputs.join('\n').split(/\r\n|\r|\n/g);
 

--- a/extensions/notebook-renderers/src/textHelper.ts
+++ b/extensions/notebook-renderers/src/textHelper.ts
@@ -35,46 +35,43 @@ function generateViewMoreElement(outputId: string, adjustableSize: boolean) {
 
 function truncatedArrayOfString(id: string, buffer: string[], linesLimit: number, container: HTMLElement, trustHtml: boolean) {
 	const lineCount = buffer.length;
-	container.appendChild(generateViewMoreElement(id, true));
+	container.parentNode!.append(generateViewMoreElement(id, true));
 
-	const div = document.createElement('div');
-	container.appendChild(div);
-	div.appendChild(handleANSIOutput(buffer.slice(0, linesLimit - 5).join('\n'), trustHtml));
+	container.appendChild(handleANSIOutput(buffer.slice(0, linesLimit - 5).join('\n'), trustHtml));
 
 	// view more ...
 	const viewMoreSpan = document.createElement('span');
 	viewMoreSpan.innerText = '...';
 	container.appendChild(viewMoreSpan);
 
-	const div2 = document.createElement('div');
-	container.appendChild(div2);
-	div2.appendChild(handleANSIOutput(buffer.slice(lineCount - 5).join('\n'), trustHtml));
+	container.appendChild(handleANSIOutput(buffer.slice(lineCount - 5).join('\n'), trustHtml));
 }
 
 function scrollableArrayOfString(id: string, buffer: string[], container: HTMLElement, trustHtml: boolean) {
-	const scrollableDiv = document.createElement('div');
-	scrollableDiv.classList.add(scrollableClass);
+	container.classList.add(scrollableClass);
 
 	if (buffer.length > 5000) {
-		container.appendChild(generateViewMoreElement(id, false));
+		container.parentNode!.append(generateViewMoreElement(id, false));
 	}
-	container.appendChild(scrollableDiv);
-	scrollableDiv.appendChild(handleANSIOutput(buffer.slice(0, 5000).join('\n'), trustHtml));
+
+	container.appendChild(handleANSIOutput(buffer.slice(0, 5000).join('\n'), trustHtml));
 }
 
-export function insertOutput(id: string, outputs: string[], linesLimit: number, scrollable: boolean, container: HTMLElement, trustHtml: boolean) {
+export function insertOutput(id: string, outputs: string[], linesLimit: number, scrollable: boolean, trustHtml: boolean) {
+	const element = document.createElement('div');
 	const buffer = outputs.join('\n').split(/\r\n|\r|\n/g);
 	const lineCount = buffer.length;
 
 	if (lineCount < linesLimit) {
 		const spanElement = handleANSIOutput(buffer.join('\n'), trustHtml);
-		container.appendChild(spanElement);
-		return;
+		element.appendChild(spanElement);
+	} else {
+		if (scrollable) {
+			scrollableArrayOfString(id, buffer, element, trustHtml);
+		} else {
+			truncatedArrayOfString(id, buffer, linesLimit, element, trustHtml);
+		}
 	}
 
-	if (scrollable) {
-		scrollableArrayOfString(id, buffer, container, trustHtml);
-	} else {
-		truncatedArrayOfString(id, buffer, linesLimit, container, trustHtml);
-	}
+	return element;
 }

--- a/extensions/notebook-renderers/src/textHelper.ts
+++ b/extensions/notebook-renderers/src/textHelper.ts
@@ -7,35 +7,50 @@ import { handleANSIOutput } from './ansi';
 
 export const scrollableClass = 'scrollable';
 
-function generateViewMoreElement(outputId: string, adjustableSize: boolean) {
+function generateViewMoreElement(outputId: string) {
 	const container = document.createElement('span');
 	const first = document.createElement('span');
+	first.textContent = 'Output exceeds the ';
 
-	if (adjustableSize) {
-		first.textContent = 'Output exceeds the ';
-		const second = document.createElement('a');
-		second.textContent = 'size limit';
-		second.href = `command:workbench.action.openSettings?%5B%22notebook.output.textLineLimit%22%5D`;
-		container.appendChild(first);
-		container.appendChild(second);
-	} else {
-		first.textContent = 'Output exceeds the maximium size limit';
-		container.appendChild(first);
-	}
+	const second = document.createElement('a');
+	second.textContent = 'size limit';
+	second.href = `command:workbench.action.openSettings?%5B%22notebook.output.textLineLimit%22%5D`;
+	container.appendChild(first);
+	container.appendChild(second);
 
 	const third = document.createElement('span');
 	third.textContent = '. Open the full output data ';
+
 	const forth = document.createElement('a');
 	forth.textContent = 'in a text editor';
 	forth.href = `command:workbench.action.openLargeOutput?${outputId}`;
 	container.appendChild(third);
 	container.appendChild(forth);
+
+	return container;
+}
+
+function generateNestedViewAllElement(outputId: string) {
+	const container = document.createElement('span');
+	const prefix = document.createElement('span');
+	prefix.innerText = '... (View full content in a ';
+	container.append(prefix);
+
+	const link = document.createElement('a');
+	link.textContent = 'text editor';
+	link.href = `command:workbench.action.openLargeOutput?${outputId}`;
+	container.append(link);
+
+	const postfix = document.createElement('span');
+	prefix.innerText = ')\n';
+	container.append(postfix);
+
 	return container;
 }
 
 function truncatedArrayOfString(id: string, buffer: string[], linesLimit: number, container: HTMLElement, trustHtml: boolean) {
 	const lineCount = buffer.length;
-	container.parentNode!.append(generateViewMoreElement(id, true));
+	container.appendChild(generateViewMoreElement(id));
 
 	container.appendChild(handleANSIOutput(buffer.slice(0, linesLimit - 5).join('\n'), trustHtml));
 
@@ -48,29 +63,28 @@ function truncatedArrayOfString(id: string, buffer: string[], linesLimit: number
 }
 
 function scrollableArrayOfString(id: string, buffer: string[], container: HTMLElement, trustHtml: boolean) {
-	container.classList.add(scrollableClass);
-
 	if (buffer.length > 5000) {
-		container.parentNode!.append(generateViewMoreElement(id, false));
+		container.parentNode!.append(generateNestedViewAllElement(id));
 	}
 
-	container.appendChild(handleANSIOutput(buffer.slice(0, 5000).join('\n'), trustHtml));
+	container.appendChild(handleANSIOutput(buffer.slice(-5000).join('\n'), trustHtml));
 }
 
 export function insertOutput(id: string, outputs: string[], linesLimit: number, scrollable: boolean, trustHtml: boolean) {
 	const element = document.createElement('div');
 	const buffer = outputs.join('\n').split(/\r\n|\r|\n/g);
+
+	if (scrollable) {
+		scrollableArrayOfString(id, buffer, element, trustHtml);
+	}
+
 	const lineCount = buffer.length;
 
-	if (lineCount < linesLimit) {
+	if (lineCount <= linesLimit) {
 		const spanElement = handleANSIOutput(buffer.join('\n'), trustHtml);
 		element.appendChild(spanElement);
 	} else {
-		if (scrollable) {
-			scrollableArrayOfString(id, buffer, element, trustHtml);
-		} else {
-			truncatedArrayOfString(id, buffer, linesLimit, element, trustHtml);
-		}
+		truncatedArrayOfString(id, buffer, linesLimit, element, trustHtml);
 	}
 
 	return element;

--- a/extensions/notebook-renderers/src/textHelper.ts
+++ b/extensions/notebook-renderers/src/textHelper.ts
@@ -8,7 +8,7 @@ import { handleANSIOutput } from './ansi';
 export const scrollableClass = 'scrollable';
 
 function generateViewMoreElement(outputId: string) {
-	const container = document.createElement('span');
+	const container = document.createElement('div');
 	const first = document.createElement('span');
 	first.textContent = 'Output exceeds the ';
 
@@ -57,7 +57,7 @@ function truncatedArrayOfString(id: string, buffer: string[], linesLimit: number
 	container.appendChild(handleANSIOutput(buffer.slice(0, linesLimit - 5).join('\n'), trustHtml));
 
 	// truncated piece
-	const elipses = document.createElement('span');
+	const elipses = document.createElement('div');
 	elipses.innerText = '...';
 	container.appendChild(elipses);
 

--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView.ts
@@ -323,14 +323,11 @@ export class BackLayerWebView<T extends ICommonCellInfo> extends Themable {
 						width: 100%;
 					}
 
-					#container > div > div > div.output:not(.scrollable) {
+					#container > div > div > div.output {
 						font-size: var(--notebook-cell-output-font-size);
 						width: var(--notebook-output-width);
 						margin-left: var(--notebook-output-left-margin);
 						background-color: var(--theme-notebook-output-background);
-					}
-
-					#container > div > div > div.output:not(.scrollable) {
 						padding-top: var(--notebook-output-node-padding);
 						padding-right: var(--notebook-output-node-padding);
 						padding-bottom: var(--notebook-output-node-padding);

--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView.ts
@@ -323,18 +323,21 @@ export class BackLayerWebView<T extends ICommonCellInfo> extends Themable {
 						width: 100%;
 					}
 
-					#container > div > div > div.output {
+					#container > div > div > div.output:not(.scrollable) {
 						font-size: var(--notebook-cell-output-font-size);
 						width: var(--notebook-output-width);
 						margin-left: var(--notebook-output-left-margin);
+						background-color: var(--theme-notebook-output-background);
+					}
+
+					#container > div > div > div.output:not(.scrollable) {
 						padding-top: var(--notebook-output-node-padding);
 						padding-right: var(--notebook-output-node-padding);
 						padding-bottom: var(--notebook-output-node-padding);
 						padding-left: var(--notebook-output-node-left-padding);
 						box-sizing: border-box;
-						border-top: none !important;
+						border-top: none;
 						border: 1px solid var(--theme-notebook-output-border);
-						background-color: var(--theme-notebook-output-background);
 					}
 
 					/* markdown */


### PR DESCRIPTION
- All neighboring streaming output is now consolidated into a single output.
- reduced the nesting of some of the html
- removed the padding from the output container when adding a scrollable element
- truncation for scrollable elements is now just signified with a '...' link at the top of the output. I think this is a rare enough case that we don't need UI beyond that.