### PR TITLE
Don't skip JS/TS diagnostic updates on equals

### DIFF
--- a/extensions/typescript-language-features/src/languageFeatures/diagnostics.ts
+++ b/extensions/typescript-language-features/src/languageFeatures/diagnostics.ts
@@ -53,7 +53,7 @@ class FileDiagnostics {
 		}
 
 		const existing = this._diagnostics.get(kind);
-		if (arrays.equals(existing || arrays.empty, diagnostics, diagnosticsEquals)) {
+		if (existing?.length === 0 && diagnostics.length === 0) {
 			// No need to update
 			return false;
 		}


### PR DESCRIPTION
Even though the diagnostics on the ext host side may be equal, the displayed diagnostic may be at a different spot as we shift around markers on edit. We need to make sure the UI is also updated in these cases by setting the diagnostics again

Fixes #169443