### PR TITLE
Remote Start Entry Improvements

### DIFF
--- a/src/vs/workbench/contrib/remote/browser/remoteStartEntry.ts
+++ b/src/vs/workbench/contrib/remote/browser/remoteStartEntry.ts
@@ -10,35 +10,44 @@ import { ICommandService } from 'vs/platform/commands/common/commands';
 import { QuickPickItem, IQuickInputService } from 'vs/platform/quickinput/common/quickInput';
 import { once } from 'vs/base/common/functional';
 import { IProductService } from 'vs/platform/product/common/productService';
-import { Action2, registerAction2 } from 'vs/platform/actions/common/actions';
+import { Action2, MenuRegistry, registerAction2 } from 'vs/platform/actions/common/actions';
 import { IExtensionService } from 'vs/workbench/services/extensions/common/extensions';
-import { IExtensionManagementService } from 'vs/platform/extensionManagement/common/extensionManagement';
+import { IExtensionGalleryService, IExtensionManagementService } from 'vs/platform/extensionManagement/common/extensionManagement';
 import { timeout } from 'vs/base/common/async';
 import { Registry } from 'vs/platform/registry/common/platform';
 import { ConfigurationScope, Extensions as ConfigurationExtensions, IConfigurationRegistry } from 'vs/platform/configuration/common/configurationRegistry';
 import { workbenchConfigurationNodeBase } from 'vs/workbench/common/configuration';
-import { IExtensionContributions } from 'vs/platform/extensions/common/extensions';
+import { CancellationToken } from 'vs/base/common/cancellation';
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
+import { IRelaxedExtensionDescription } from 'vs/platform/extensions/common/extensions';
 
 const STATUSBAR_REMOTEINDICATOR_CONTRIBUTION = 'statusBar/remoteIndicator';
 
 type RemoteStartActionClassification = {
 	command: { classification: 'PublicNonPersonalData'; purpose: 'FeatureInsight'; comment: 'The command being executed by the remote start entry.' };
-	remoteExtensionId: { classification: 'PublicNonPersonalData'; purpose: 'FeatureInsight'; comment: 'The remote extension id being used.' };
+	remoteExtensionId?: { classification: 'PublicNonPersonalData'; purpose: 'FeatureInsight'; comment: 'The remote extension id being used.' };
 	owner: 'bhavyau';
 	comment: 'Help understand which remote extensions are most commonly used from the remote start entry';
 };
 
 type RemoteStartActionEvent = {
 	command: string;
-	remoteExtensionId: string;
+	remoteExtensionId?: string;
 };
+
+interface RemoteExtensionMetadata {
+	id: string;
+	friendlyName: string;
+	remoteCommand?: string;
+	installed: boolean;
+	dependenciesStr?: string;
+}
 
 export class RemoteStartEntry extends Disposable implements IWorkbenchContribution {
 
 	private static readonly REMOTE_START_ENTRY_ACTIONS_COMMAND_ID = 'workbench.action.remote.showStartEntryActions';
-	private currentRemoteExtensionId: string = '';
-	private readonly remoteCommands: Map<string, string> = new Map<string, string>();
+	private readonly remoteExtensionMetadata: RemoteExtensionMetadata[];
+	private _isInitialized: boolean = false;
 
 	constructor(
 		@IQuickInputService private readonly quickInputService: IQuickInputService,
@@ -46,9 +55,16 @@ export class RemoteStartEntry extends Disposable implements IWorkbenchContributi
 		@IProductService private readonly productService: IProductService,
 		@IExtensionService private readonly extensionService: IExtensionService,
 		@IExtensionManagementService private readonly extensionManagementService: IExtensionManagementService,
+		@IExtensionGalleryService private readonly extensionGalleryService: IExtensionGalleryService,
 		@ITelemetryService private readonly telemetryService: ITelemetryService) {
 
 		super();
+
+		const remoteExtensionTips = { ...this.productService.remoteExtensionTips, ...this.productService.virtualWorkspaceExtensionTips };
+		this.remoteExtensionMetadata = Object.values(remoteExtensionTips).filter(value => value.showInStartEntry === true).map(value => {
+			return { id: value.extensionId, installed: false, friendlyName: value.friendlyName };
+		});
+
 		this.registerActions();
 		this.registerListeners();
 	}
@@ -75,63 +91,116 @@ export class RemoteStartEntry extends Disposable implements IWorkbenchContributi
 	}
 
 	private registerListeners(): void {
-		this._register(this.extensionManagementService.onDidInstallExtensions(result => {
+
+		this._register(this.extensionManagementService.onDidInstallExtensions(async (result) => {
 			for (const ext of result) {
-				if (ext.identifier.id === this.currentRemoteExtensionId) {
-					this.registerRemoteCommand(ext.local?.manifest?.contributes, this.currentRemoteExtensionId);
+				const index = this.remoteExtensionMetadata.findIndex(value => value.id === ext.identifier.id && !value.installed);
+				if (index > -1) {
+					const command = await this.getRemoteCommand(ext.identifier.id);
+					if (command) {
+						this.remoteExtensionMetadata[index].remoteCommand = command;
+						this.remoteExtensionMetadata[index].installed = true;
+					}
 				}
 			}
 		}));
 
-		this._register(this.extensionManagementService.onDidUninstallExtension(result => {
-			if (this.remoteCommands.has(result.identifier.id)) {
-				this.remoteCommands.delete(result.identifier.id);
+		this._register(this.extensionManagementService.onDidUninstallExtension(async (result) => {
+			const index = this.remoteExtensionMetadata.findIndex(value => value.id === result.identifier.id && value.installed);
+			if (index > -1) {
+				this.remoteExtensionMetadata[index].installed = false;
+				if (this.remoteExtensionMetadata[index].dependenciesStr === undefined) {
+					const dependenciesStr = await this.getDependenciesStr(this.remoteExtensionMetadata[index].id);
+					this.remoteExtensionMetadata[index].dependenciesStr = dependenciesStr;
+				}
 			}
 		}));
 	}
 
-	private registerRemoteCommand(extensionContributions: IExtensionContributions | undefined, remoteId: string) {
-		if (extensionContributions?.menus) {
-			for (const context in extensionContributions.menus) {
-				if (context === STATUSBAR_REMOTEINDICATOR_CONTRIBUTION) {
-					const command = extensionContributions.menus[context][0];
-					this.remoteCommands.set(remoteId, command.command);
+	private async _init(): Promise<void> {
+
+		if (this._isInitialized) {
+			return;
+		}
+
+		for (let i = 0; i < this.remoteExtensionMetadata.length; i++) {
+			const installed = this.extensionService.extensions.some((e) => e.id?.toLowerCase() === this.remoteExtensionMetadata[i].id);
+			if (installed) {
+				const command = await this.getRemoteCommand(this.remoteExtensionMetadata[i].id);
+				if (command) {
+					this.remoteExtensionMetadata[i].remoteCommand = command;
+					this.remoteExtensionMetadata[i].installed = true;
+				}
+			}
+			else {
+				const dependenciesStr = await this.getDependenciesStr(this.remoteExtensionMetadata[i].id);
+				this.remoteExtensionMetadata[i].dependenciesStr = dependenciesStr;
+			}
+		}
+
+		this._isInitialized = true;
+	}
+
+	private async getRemoteCommand(remoteExtensionId: string): Promise<string | undefined> {
+
+		// Remote extension is not registered immediately on install.
+		// Wait for it to appear before returning.
+		let extension: Readonly<IRelaxedExtensionDescription> | undefined;
+		while (!extension) {
+			extension = await this.extensionService.getExtension(remoteExtensionId);
+			await timeout(300);
+		}
+
+		const menus = extension?.contributes?.menus;
+		if (menus) {
+			for (const contextMenu in menus) {
+				// The remote start entry pulls the first command from the statusBar/remoteIndicator menu contribution
+				if (contextMenu === STATUSBAR_REMOTEINDICATOR_CONTRIBUTION) {
+					const command = menus[contextMenu][0];
+					return command.command;
 				}
 			}
 		}
+		return undefined;
 	}
 
 	private async showRemoteStartActions() {
 
-		const computeItems = () => {
-			const items: QuickPickItem[] = [];
-			const remoteExtensionTips = { ...this.productService.remoteExtensionTips, ...this.productService.virtualWorkspaceExtensionTips };
+		await this._init();
 
-			for (const extension of Object.values(remoteExtensionTips)) {
-				if (extension?.showInStartEntry === true) {
-					const label = nls.localize('remote.startActions.connectTo', 'Connect to {0}... ', extension.friendlyName);
-					const description = this.extensionService.extensions.some((e) => e.id?.toLowerCase() === extension.extensionId.toLowerCase()) ?
-						'' : nls.localize('remote.startActions.installExtension', 'Extension will be downloaded and installed.');
+		const computeItems = async () => {
+			const installedItems: QuickPickItem[] = [];
+			const notInstalledItems: QuickPickItem[] = [];
+			for (const metadata of this.remoteExtensionMetadata) {
 
-					items.push({
-						type: 'item',
-						id: extension.extensionId,
-						description: description,
-						label
-					});
-
-					items.push({
-						type: 'separator'
-					});
+				if (metadata.installed && metadata.remoteCommand) {
+					const commandAction = MenuRegistry.getCommand(metadata.remoteCommand);
+					const label = typeof commandAction?.title === 'string' ? commandAction.title : commandAction?.title?.value;
+					if (label) {
+						installedItems.push({ type: 'separator', label: metadata.friendlyName });
+						installedItems.push({
+							type: 'item',
+							label: label,
+							id: metadata.id
+						});
+					}
+				}
+				else if (!metadata.installed) {
+					const label = nls.localize('remote.startActions.connectTo', 'Connect to {0}... ', metadata.friendlyName);
+					const tooltip = metadata.dependenciesStr ? nls.localize('remote.startActions.tooltip', 'Also installs dependencies - {0} ', metadata.dependenciesStr) : '';
+					notInstalledItems.push({ type: 'item', id: metadata.id, label: label, tooltip: tooltip });
 				}
 			}
 
-			return items;
+			installedItems.push({
+				type: 'separator', label: nls.localize('remote.startActions.downloadAndInstall', 'Download and Install')
+			});
+			return installedItems.concat(notInstalledItems);
 		};
 
 		const quickPick = this.quickInputService.createQuickPick();
-		quickPick.placeholder = nls.localize('remoteActions', "Select an option to connect to a Remote Window");
-		quickPick.items = computeItems();
+		quickPick.placeholder = nls.localize('remote.startActions.quickPickPlaceholder', 'Select an option to connect to a Remote Window');
+		quickPick.items = await computeItems();
 		quickPick.sortByLabel = false;
 		quickPick.canSelectMany = false;
 		quickPick.ignoreFocusOut = false;
@@ -141,50 +210,59 @@ export class RemoteStartEntry extends Disposable implements IWorkbenchContributi
 			const selectedItems = quickPick.selectedItems;
 			if (selectedItems.length === 1) {
 
-				const selectedItem = selectedItems[0];
-				const remoteExtensionId = selectedItem.id!;
-				this.currentRemoteExtensionId = remoteExtensionId;
+				const selectedItem = selectedItems[0].id!;
 
-				let remoteCommand = this.remoteCommands.get(remoteExtensionId);
-
-				//Remote Extension is not installed
-				if (!remoteCommand && selectedItem.description !== '') {
-
-					this.commandService.executeCommand('workbench.extensions.installExtension', remoteExtensionId);
-					this.telemetryService.publicLog2<RemoteStartActionEvent, RemoteStartActionClassification>('remoteStartList.ActionExecuted', { command: 'workbench.extensions.installExtension', remoteExtensionId: remoteExtensionId });
+				const metadata = this.remoteExtensionMetadata.find(value => value.id === selectedItem)!;
+				if (!metadata.installed) {
+					this.executeCommand('workbench.extensions.installExtension', selectedItem);
 
 					quickPick.placeholder = nls.localize('remote.startActions.installingExtension', 'Installing extension... ');
 					quickPick.busy = true;
 
 					// Remote extension is not registered immediately on install.
 					// Wait for it to appear before returning.
-					while (!await this.extensionService.getExtension(remoteExtensionId)) {
-						await timeout(300);
-					}
-
 					while (!(await this.extensionService.whenInstalledExtensionsRegistered())) {
 						await timeout(300);
 					}
-				}
-				//Remote Extension is installed
-				else {
-					const extension = await this.extensionService.getExtension(remoteExtensionId);
-					this.registerRemoteCommand(extension?.contributes, this.currentRemoteExtensionId);
-				}
 
-				remoteCommand = this.remoteCommands.get(remoteExtensionId);
-				if (remoteCommand) {
-
-					this.telemetryService.publicLog2<RemoteStartActionEvent, RemoteStartActionClassification>('remoteStartList.ActionExecuted', { command: remoteCommand, remoteExtensionId: remoteExtensionId });
-					this.commandService.executeCommand(remoteCommand);
+					const command = await this.getRemoteCommand(selectedItem);
 					quickPick.busy = false;
+
+					if (command) {
+						this.executeCommand(command);
+					}
+					else {
+						throw Error('Could not find statusBar/remoteIndicator menu contributions for: ' + selectedItem);
+					}
+				}
+				else if (metadata.installed && metadata.remoteCommand) {
+					this.executeCommand(metadata.remoteCommand);
 				}
 				else {
-					throw Error('Could not find statusBar/remoteIndicator menu contributions for ' + remoteExtensionId);
+					throw Error('Could not find statusBar/remoteIndicator menu contributions for: ' + selectedItem);
 				}
 			}
 		});
 		quickPick.show();
+	}
+
+	private executeCommand(command: string, remoteExtensionId?: string) {
+		this.telemetryService.publicLog2<RemoteStartActionEvent, RemoteStartActionClassification>('remoteStartList.ActionExecuted', { command: command, remoteExtensionId: remoteExtensionId });
+		this.commandService.executeCommand(command, remoteExtensionId);
+	}
+
+	private async getDependenciesStr(extensionId: string): Promise<string> {
+
+		const galleryExtension = (await this.extensionGalleryService.getExtensions([{ id: extensionId }], CancellationToken.None))[0];
+		const friendlyNames: string[] = [];
+		if (galleryExtension.properties.extensionPack) {
+			for (const extensionPackItem of galleryExtension.properties.extensionPack) {
+				const extensionPack = (await this.extensionGalleryService.getExtensions([{ id: extensionPackItem }], CancellationToken.None))[0];
+				friendlyNames.push(extensionPack.displayName);
+			}
+		}
+
+		return friendlyNames.join(', ');
 	}
 }
 
@@ -195,7 +273,7 @@ configurationRegistry.registerConfiguration({
 		'workbench.remote.experimental.showStartListEntry': {
 			scope: ConfigurationScope.MACHINE,
 			type: 'boolean',
-			default: false,
+			default: true,
 			description: nls.localize('workbench.remote.showStartListEntry', "When enabled, a start list entry for getting started with remote experiences in shown on the welcome page.")
 		}
 	}


### PR DESCRIPTION
- Enabled the settings to show the remote start list entry by default.
- If remote extension is installed, we now show the remote command entry from that extension in the quick
- Else we display a "Connect to <Remote Extension>..."

<img width="636" alt="image" src="https://user-images.githubusercontent.com/25044782/225194546-097aa470-6d4a-4d9d-a685-9f9a9d1052bb.png">
