### PR TITLE
add querystring fallback

### DIFF
--- a/extensions/microsoft-authentication/extension-browser.webpack.config.js
+++ b/extensions/microsoft-authentication/extension-browser.webpack.config.js
@@ -21,9 +21,12 @@ module.exports = withBrowserDefaults({
 		extension: './src/extension.ts',
 	},
 	externals: {
-		'keytar': 'commonjs keytar'
+		'keytar': 'commonjs keytar',
 	},
 	resolve: {
+		fallback: {
+			'querystring': require.resolve('querystring-es3')
+		},
 		alias: {
 			'./node/crypto': path.resolve(__dirname, 'src/browser/crypto'),
 			'./node/authServer': path.resolve(__dirname, 'src/browser/authServer'),

--- a/extensions/microsoft-authentication/package.json
+++ b/extensions/microsoft-authentication/package.json
@@ -49,7 +49,8 @@
     "@types/node-fetch": "^2.5.7",
     "@types/randombytes": "^2.0.0",
     "@types/sha.js": "^2.4.0",
-    "@types/uuid": "8.0.0"
+    "@types/uuid": "8.0.0",
+    "querystring-es3": "^0.2.1"
   },
   "dependencies": {
     "node-fetch": "2.6.7",

--- a/extensions/microsoft-authentication/yarn.lock
+++ b/extensions/microsoft-authentication/yarn.lock
@@ -370,6 +370,11 @@ node-fetch@2.6.7:
   dependencies:
     whatwg-url "^5.0.0"
 
+querystring-es3@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/querystring-es3/-/querystring-es3-0.2.1.tgz#9ec61f79049875707d69414596fd907a4d711e73"
+  integrity sha512-773xhDQnZBMFobEiztv8LIl70ch5MSF/jUQVlhwFyBILqq96anmoctVIYz+ZRp0qbCKATTn6ev02M3r7Ga5vqA==
+
 semver@^5.3.0, semver@^5.4.1:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"


### PR DESCRIPTION
`yarn watch-web` fails with
```
  moduleIdentifier: '/home/martin/workspaces/vscode/node_modules/ts-loader/index.js??ruleSet[1].rules[0].use[0]!/home/martin/workspaces/vscode/extensions/mangle-loader.js??ruleSet[1].rules[0].use[1]!/home/martin/workspaces/vscode/extensions/microsoft-authentication/src/AADHelper.ts',
  moduleName: './src/AADHelper.ts',
  loc: '9:20-42',
  message: "Module not found: Error: Can't resolve 'querystring' in '/home/martin/workspaces/vscode/extensions/microsoft-authentication/src'\n" +
    '\n' +
    'BREAKING CHANGE: webpack < 5 used to include polyfills for node.js core modules by default.\n' +
    'This is no longer the case. Verify if you need this module and configure a polyfill for it.\n' +
    '\n' +
    'If you want to include a polyfill, you need to:\n' +
    `\t- add a fallback 'resolve.fallback: { "querystring": require.resolve("querystring-es3") }'\n` +
    "\t- install 'querystring-es3'\n" +
    "If you don't want to include a polyfill, you can use an empty module like this:\n" +
    '\tresolve.fallback: { "querystring": false }',
  moduleId: 2,
  moduleTrace: [
    {
...
```