### PR TITLE
keybindings.json linter showing spurious warnings

### DIFF
--- a/src/vs/workbench/services/keybinding/browser/keybindingService.ts
+++ b/src/vs/workbench/services/keybinding/browser/keybindingService.ts
@@ -873,6 +873,7 @@ function updateSchema(additionalContributions: readonly IJSONSchema[]) {
 		);
 		const addition = {
 			'if': {
+				'required': ['command'],
 				'properties': {
 					'command': { 'const': commandId }
 				}


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/176629