### PR TITLE
Pass TS Server the original fs path

### DIFF
--- a/extensions/typescript-language-features/src/typescriptServiceClient.ts
+++ b/extensions/typescript-language-features/src/typescriptServiceClient.ts
@@ -697,12 +697,7 @@ export default class TypeScriptServiceClient extends Disposable implements IType
 		}
 
 		if (resource.scheme === fileSchemes.file && !isWeb()) {
-			if (!resource.fsPath) {
-				return undefined;
-			}
-
-			// Convert to posix style path
-			return path.posix.normalize(resource.fsPath.split(path.sep).join(path.posix.sep));
+			return resource.fsPath;
 		}
 
 		return (this.isProjectWideIntellisenseOnWebEnabled() ? '' : this.inMemoryResourcePrefix)


### PR DESCRIPTION
For #177083

We've had code to normalize the file path for a long time but I don't think it's needed. In the case of samba paths, it also appears to break things

Let's try dropping it and passing along the original `fsPath` instead


