### PR TITLE
Introduce share links in more places via a contrib

### DIFF
--- a/build/lib/i18n.resources.json
+++ b/build/lib/i18n.resources.json
@@ -195,6 +195,10 @@
 			"project": "vscode-workbench"
 		},
 		{
+			"name": "vs/workbench/contrib/share",
+			"project": "vscode-workbench"
+		},
+		{
 			"name": "vs/workbench/contrib/snippets",
 			"project": "vscode-workbench"
 		},

--- a/extensions/github/package.json
+++ b/extensions/github/package.json
@@ -38,14 +38,11 @@
       },
       {
         "command": "github.copyVscodeDevLink",
+        "enablement": "github.hasGitHubRepo && resourceScheme != untitled && remoteName != 'codespaces'",
         "title": "Copy vscode.dev Link"
       },
       {
         "command": "github.copyVscodeDevLinkFile",
-        "title": "Copy vscode.dev Link"
-      },
-      {
-        "command": "github.copyVscodeDevLinkWithoutRange",
         "title": "Copy vscode.dev Link"
       },
       {
@@ -78,12 +75,14 @@
           "when": "false"
         },
         {
-          "command": "github.copyVscodeDevLinkWithoutRange",
-          "when": "false"
-        },
-        {
           "command": "github.openOnVscodeDev",
           "when": "false"
+        }
+      ],
+      "share": [
+        {
+          "command": "github.copyVscodeDevLink",
+          "title": "Copy vscode.dev Link"
         }
       ],
       "file/share": [
@@ -92,41 +91,7 @@
           "when": "github.hasGitHubRepo && remoteName != 'codespaces'",
           "group": "0_vscode@0"
         }
-      ],
-      "editor/context/share": [
-        {
-          "command": "github.copyVscodeDevLink",
-          "when": "github.hasGitHubRepo && resourceScheme != untitled && remoteName != 'codespaces'",
-          "group": "0_vscode@0"
-        }
-      ],
-      "explorer/context/share": [
-        {
-          "command": "github.copyVscodeDevLinkWithoutRange",
-          "when": "github.hasGitHubRepo && resourceScheme != untitled && remoteName != 'codespaces'",
-          "group": "0_vscode@0"
-        }
-      ],
-      "editor/lineNumber/context": [
-        {
-          "command": "github.copyVscodeDevLink",
-          "when": "github.hasGitHubRepo && resourceScheme != untitled && activeEditor == workbench.editors.files.textFileEditor && config.editor.lineNumbers == on && remoteName != 'codespaces'",
-          "group": "1_cutcopypaste@2"
-        },
-        {
-          "command": "github.copyVscodeDevLink",
-          "when": "github.hasGitHubRepo && resourceScheme != untitled && activeEditor == workbench.editor.notebook && remoteName != 'codespaces'",
-          "group": "1_cutcopypaste@2"
-        }
-      ],
-      "editor/title/context/share": [
-        {
-          "command": "github.copyVscodeDevLinkWithoutRange",
-          "when": "github.hasGitHubRepo && resourceScheme != untitled && remoteName != 'codespaces'",
-          "group": "0_vscode@0"
-        }
       ]
-
     },
     "configuration": [
       {

--- a/extensions/github/src/commands.ts
+++ b/extensions/github/src/commands.ts
@@ -45,16 +45,15 @@ export function registerCommands(gitAPI: GitAPI): vscode.Disposable {
 		}
 	}));
 
-	disposables.add(vscode.commands.registerCommand('github.copyVscodeDevLink', async (context: LinkContext) => {
+	disposables.add(vscode.commands.registerCommand('github.copyVscodeDevLink', async (context: LinkContext, ranges?: vscode.Range[]) => {
+		if (Array.isArray(ranges) && ranges.every((range) => 'start' in range && 'end' in range) && context instanceof vscode.Uri) {
+			context = { uri: context, ranges };
+		}
 		return copyVscodeDevLink(gitAPI, true, context);
 	}));
 
 	disposables.add(vscode.commands.registerCommand('github.copyVscodeDevLinkFile', async (context: LinkContext) => {
 		return copyVscodeDevLink(gitAPI, false, context);
-	}));
-
-	disposables.add(vscode.commands.registerCommand('github.copyVscodeDevLinkWithoutRange', async (context: LinkContext) => {
-		return copyVscodeDevLink(gitAPI, true, context, false);
 	}));
 
 	disposables.add(vscode.commands.registerCommand('github.openOnVscodeDev', async () => {

--- a/src/vs/editor/contrib/clipboard/browser/clipboard.ts
+++ b/src/vs/editor/contrib/clipboard/browser/clipboard.ts
@@ -16,7 +16,6 @@ import { EditorContextKeys } from 'vs/editor/common/editorContextKeys';
 import * as nls from 'vs/nls';
 import { MenuId, MenuRegistry } from 'vs/platform/actions/common/actions';
 import { IClipboardService } from 'vs/platform/clipboard/common/clipboardService';
-import { ContextKeyExpr } from 'vs/platform/contextkey/common/contextkey';
 import { ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
 import { KeybindingWeight } from 'vs/platform/keybinding/common/keybindingsRegistry';
 
@@ -108,9 +107,6 @@ export const CopyAction = supportsCopy ? registerCommand(new MultiCommand({
 
 MenuRegistry.appendMenuItem(MenuId.MenubarEditMenu, { submenu: MenuId.MenubarCopy, title: { value: nls.localize('copy as', "Copy As"), original: 'Copy As', }, group: '2_ccp', order: 3 });
 MenuRegistry.appendMenuItem(MenuId.EditorContext, { submenu: MenuId.EditorContextCopy, title: { value: nls.localize('copy as', "Copy As"), original: 'Copy As', }, group: CLIPBOARD_CONTEXT_MENU_GROUP, order: 3 });
-MenuRegistry.appendMenuItem(MenuId.EditorContext, { submenu: MenuId.EditorContextShare, title: { value: nls.localize('share', "Share"), original: 'Share', }, group: '11_share', order: -1, when: ContextKeyExpr.and(ContextKeyExpr.notEquals('resourceScheme', 'output'), EditorContextKeys.editorTextFocus) });
-MenuRegistry.appendMenuItem(MenuId.EditorTitleContext, { submenu: MenuId.EditorTitleContextShare, title: { value: nls.localize('share', "Share"), original: 'Share', }, group: '11_share', order: -1 });
-MenuRegistry.appendMenuItem(MenuId.ExplorerContext, { submenu: MenuId.ExplorerContextShare, title: { value: nls.localize('share', "Share"), original: 'Share', }, group: '11_share', order: -1 });
 
 export const PasteAction = supportsPaste ? registerCommand(new MultiCommand({
 	id: 'editor.action.clipboardPasteAction',

--- a/src/vs/editor/contrib/contextmenu/browser/contextmenu.ts
+++ b/src/vs/editor/contrib/contextmenu/browser/contextmenu.ts
@@ -161,7 +161,18 @@ export class ContextMenuController implements IEditorContribution {
 
 		// get menu groups
 		const menu = this._menuService.createMenu(menuId, this._contextKeyService);
-		const groups = menu.getActions({ arg: model.uri });
+		const groups = menu.getActions({
+			arg: [model.uri, this._editor.getSelections()?.map((selection) => ({
+				start: {
+					line: selection.getStartPosition().lineNumber - 1,
+					character: selection.getStartPosition().column
+				},
+				end: {
+					line: selection.getEndPosition().lineNumber - 1,
+					character: selection.getEndPosition().column
+				}
+			}))]
+		});
 		menu.dispose();
 
 		// translate them into other actions

--- a/src/vs/platform/actions/common/actions.ts
+++ b/src/vs/platform/actions/common/actions.ts
@@ -98,15 +98,18 @@ export class MenuId {
 	static readonly MenubarViewMenu = new MenuId('MenubarViewMenu');
 	static readonly MenubarHomeMenu = new MenuId('MenubarHomeMenu');
 	static readonly OpenEditorsContext = new MenuId('OpenEditorsContext');
+	static readonly OpenEditorsContextShare = new MenuId('OpenEditorsContextShare');
 	static readonly ProblemsPanelContext = new MenuId('ProblemsPanelContext');
 	static readonly SCMChangeContext = new MenuId('SCMChangeContext');
 	static readonly SCMResourceContext = new MenuId('SCMResourceContext');
+	static readonly SCMResourceContextShare = new MenuId('SCMResourceContextShare');
 	static readonly SCMResourceFolderContext = new MenuId('SCMResourceFolderContext');
 	static readonly SCMResourceGroupContext = new MenuId('SCMResourceGroupContext');
 	static readonly SCMSourceControl = new MenuId('SCMSourceControl');
 	static readonly SCMTitle = new MenuId('SCMTitle');
 	static readonly SearchContext = new MenuId('SearchContext');
 	static readonly SearchActionMenu = new MenuId('SearchActionContext');
+	static readonly Share = new MenuId('Share');
 	static readonly StatusBarWindowIndicatorMenu = new MenuId('StatusBarWindowIndicatorMenu');
 	static readonly StatusBarRemoteIndicatorMenu = new MenuId('StatusBarRemoteIndicatorMenu');
 	static readonly StickyScrollContext = new MenuId('StickyScrollContext');
@@ -477,7 +480,9 @@ export class MenuItemAction implements IAction {
 	run(...args: any[]): Promise<void> {
 		let runArgs: any[] = [];
 
-		if (this._options?.arg) {
+		if (this._options?.arg && Array.isArray(this._options.arg)) {
+			runArgs = [...runArgs, ...this._options.arg];
+		} else if (this._options?.arg) {
 			runArgs = [...runArgs, this._options.arg];
 		}
 

--- a/src/vs/workbench/contrib/codeEditor/browser/editorLineNumberMenu.ts
+++ b/src/vs/workbench/contrib/codeEditor/browser/editorLineNumberMenu.ts
@@ -88,9 +88,6 @@ export class EditorLineNumberContextMenu extends Disposable implements IEditorCo
 				actions.push(collectedActions);
 			}
 
-			const menuActions = menu.getActions({ arg: { lineNumber, uri: model.uri }, shouldForwardArgs: true });
-			actions.push(...menuActions.map(a => a[1]));
-
 			// if the current editor selections do not contain the target line number,
 			// set the selection to the clicked line number
 			if (e.target.type === MouseTargetType.GUTTER_LINE_NUMBERS) {
@@ -107,11 +104,24 @@ export class EditorLineNumberContextMenu extends Disposable implements IEditorCo
 				}
 			}
 
+			const ranges = this.editor.getSelections()?.map((selection) => ({
+				start: {
+					line: selection.getStartPosition().lineNumber - 1,
+					character: selection.getStartPosition().column
+				},
+				end: {
+					line: selection.getEndPosition().lineNumber - 1,
+					character: selection.getEndPosition().column
+				}
+			}));
+			const menuActions = menu.getActions({ arg: { lineNumber, uri: model.uri, ranges } });
+			actions.push(...menuActions.map(a => a[1]));
+
 			this.contextMenuService.showContextMenu({
 				getAnchor: () => anchor,
 				getActions: () => Separator.join(...actions),
 				menuActionOptions: { shouldForwardArgs: true },
-				getActionsContext: () => ({ lineNumber, uri: model.uri }),
+				getActionsContext: () => ({ lineNumber, uri: model.uri, ranges }),
 				onHide: () => menu.dispose(),
 			});
 		});

--- a/src/vs/workbench/contrib/share/browser/share.contribution.ts
+++ b/src/vs/workbench/contrib/share/browser/share.contribution.ts
@@ -1,0 +1,64 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { DisposableStore } from 'vs/base/common/lifecycle';
+import { IMenuService, MenuId, MenuRegistry, SubmenuItemAction } from 'vs/platform/actions/common/actions';
+import { ContextKeyExpr, ContextKeyExpression, IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
+import { Registry } from 'vs/platform/registry/common/platform';
+import { Extensions, IWorkbenchContributionsRegistry } from 'vs/workbench/common/contributions';
+import { LifecyclePhase } from 'vs/workbench/services/lifecycle/common/lifecycle';
+import * as nls from 'vs/nls';
+import { EditorContextKeys } from 'vs/editor/common/editorContextKeys';
+
+const menuIds: [MenuId, MenuId | undefined, ContextKeyExpression | undefined][] = [
+	[MenuId.EditorContext, MenuId.EditorContextShare, ContextKeyExpr.and(ContextKeyExpr.notEquals('resourceScheme', 'output'), EditorContextKeys.editorTextFocus)],
+	[MenuId.EditorTitleContext, MenuId.EditorTitleContextShare, undefined],
+	[MenuId.ExplorerContext, MenuId.ExplorerContextShare, undefined],
+	[MenuId.OpenEditorsContext, MenuId.OpenEditorsContextShare, undefined],
+	[MenuId.SCMResourceContext, MenuId.SCMResourceContextShare, undefined],
+	[MenuId.EditorLineNumberContext, undefined, undefined],
+];
+
+for (const [menuId, submenuId, when] of menuIds) {
+	if (submenuId !== undefined) {
+		MenuRegistry.appendMenuItem(menuId, { submenu: submenuId, title: { value: nls.localize('share', "Share"), original: 'Share', }, group: '11_share', order: -1, when });
+	}
+}
+
+class ShareContribution {
+
+	private readonly disposableStore = new DisposableStore();
+	private readonly menu = this.menuService.createMenu(MenuId.Share, this.contextKeyService);
+
+	constructor(
+		@IMenuService private readonly menuService: IMenuService,
+		@IContextKeyService private readonly contextKeyService: IContextKeyService,
+	) {
+		this.ensureActions();
+		this.menu.onDidChange(() => this.ensureActions());
+	}
+
+	private ensureActions(): void {
+		this.disposableStore.clear();
+
+		const allActions = this.menu.getActions();
+
+		for (const [_, actions] of allActions) {
+			for (const action of actions) {
+				if (action instanceof SubmenuItemAction || !action.enabled) {
+					continue;
+				}
+				for (const [menuId, submenuId] of menuIds) {
+					this.disposableStore.add(MenuRegistry.appendMenuItem(
+						submenuId ?? menuId,
+						{ command: action.item }
+					));
+				}
+			}
+		}
+	}
+}
+
+Registry.as<IWorkbenchContributionsRegistry>(Extensions.Workbench).registerWorkbenchContribution(ShareContribution, LifecyclePhase.Eventually);

--- a/src/vs/workbench/services/actions/common/menusExtensionPoint.ts
+++ b/src/vs/workbench/services/actions/common/menusExtensionPoint.ts
@@ -130,6 +130,11 @@ const apiMenus: IAPIMenu[] = [
 		description: localize('menus.resourceStateContext', "The Source Control resource state context menu")
 	},
 	{
+		key: 'scm/resourceState/context/share',
+		id: MenuId.SCMResourceContextShare,
+		description: localize('menus.resourceStateContextShare', "The Share submenu in the Source Control resource state context menu")
+	},
+	{
 		key: 'scm/resourceFolder/context',
 		id: MenuId.SCMResourceFolderContext,
 		description: localize('menus.resourceFolderContext', "The Source Control resource folder context menu")
@@ -293,6 +298,13 @@ const apiMenus: IAPIMenu[] = [
 		key: 'file/share',
 		id: MenuId.MenubarShare,
 		description: localize('menus.share', "Share submenu shown in the top level File menu."),
+		proposed: 'contribShareMenu'
+	},
+	{
+		key: 'share',
+		id: MenuId.Share,
+		description: localize('share', "Share submenus in all relevant context menus."),
+		supportsSubmenus: false,
 		proposed: 'contribShareMenu'
 	},
 	{

--- a/src/vs/workbench/workbench.common.main.ts
+++ b/src/vs/workbench/workbench.common.main.ts
@@ -358,4 +358,6 @@ import 'vs/workbench/contrib/deprecatedExtensionMigrator/browser/deprecatedExten
 // Bracket Pair Colorizer 2 Telemetry
 import 'vs/workbench/contrib/bracketPairColorizer2Telemetry/browser/bracketPairColorizer2Telemetry.contribution';
 
+import 'vs/workbench/contrib/share/browser/share.contribution';
+
 //#endregion


### PR DESCRIPTION
Re: https://github.com/microsoft/vscode/issues/176316, https://github.com/microsoft/vscode/issues/175676

I received feedback in https://github.com/microsoft/vscode/issues/176316#issuecomment-1468498140 that introducing multiple share menus, each with their own expected behavior (copying a range, copying a path without a range, and copying neither a path nor a range) is onerous for extensions. 

This PR reduces the burden on extensions by passing a more predictable context object to extension-contributed share commands and allowing extensions to register commands in all relevant share submenus with one contrib declaration in package.json. In brief:
- no args: use active editor (this is the behavior for command palette)
- uri in args: link to file or folder without range (this is the behavior for SCM, editor title context, explorer context, open editors context)
- uri and range in args: link to file with range (this is the behavior for editor context share and editor line number context)

It's adopted here for the builtin GitHub extension but also requires adoption in GHPRI and GitHub Repositories.