### PR TITLE
Fixes #175393

### DIFF
--- a/src/vs/editor/common/model/textModelTokens.ts
+++ b/src/vs/editor/common/model/textModelTokens.ts
@@ -120,14 +120,12 @@ export class TokenizationStateStore {
 		return this._lineBeginState.get(lineIndex);
 	}
 
+	/**
+	 * Returns `false` if the end state equals the previous end state.
+	 */
 	public setEndState(linesLength: number, lineIndex: number, endState: IState): boolean {
 		this._lineNeedsTokenization.set(lineIndex, false);
 		this._firstLineNeedsTokenization = lineIndex + 1;
-
-		// Check if this was the last line
-		if (lineIndex === linesLength - 1) {
-			return false;
-		}
 
 		// Check if the end state has changed
 		const previousEndState = this._lineBeginState.get(lineIndex + 1);

--- a/src/vs/workbench/services/textMate/browser/worker/textMateWorkerModel.ts
+++ b/src/vs/workbench/services/textMate/browser/worker/textMateWorkerModel.ts
@@ -177,6 +177,8 @@ export class TextMateWorkerModel extends MirrorTextModel {
 						tokenizeResult.endState as StateStack
 					);
 					stateDeltaBuilder.setState(lineIndex + 1, delta);
+				} else {
+					stateDeltaBuilder.setState(lineIndex + 1, null);
 				}
 
 				LineTokens.convertToEndOffset(tokenizeResult.tokens, text.length);
@@ -215,7 +217,7 @@ class StateDeltaBuilder {
 	private _lastStartLineNumber: number = -1;
 	private _stateDeltas: StateDeltas[] = [];
 
-	public setState(lineNumber: number, stackDiff: StackDiff): void {
+	public setState(lineNumber: number, stackDiff: StackDiff | null): void {
 		if (lineNumber === this._lastStartLineNumber + 1) {
 			this._stateDeltas[this._stateDeltas.length - 1].stateDeltas.push(stackDiff);
 		} else {

--- a/src/vs/workbench/services/textMate/browser/workerHost/textMateWorkerHost.ts
+++ b/src/vs/workbench/services/textMate/browser/workerHost/textMateWorkerHost.ts
@@ -189,7 +189,8 @@ export class TextMateWorkerHost implements IDisposable {
 
 export interface StateDeltas {
 	startLineNumber: number;
-	stateDeltas: StackDiff[];
+	// null means the state for that line did not change
+	stateDeltas: (StackDiff | null)[];
 }
 
 function keepAliveWhenAttached(textModel: ITextModel, factory: () => IDisposable): IDisposable {

--- a/src/vs/workbench/services/textMate/browser/workerHost/textMateWorkerTokenizerController.ts
+++ b/src/vs/workbench/services/textMate/browser/workerHost/textMateWorkerTokenizerController.ts
@@ -183,8 +183,13 @@ export class TextMateWorkerTokenizerController extends Disposable {
 			let prevState = d.startLineNumber <= 1 ? this._initialState : this._states.get(d.startLineNumber - 1 - 1);
 			for (let i = 0; i < d.stateDeltas.length; i++) {
 				const delta = d.stateDeltas[i];
-				const state = applyStateStackDiff(prevState, delta)!;
-				this._states.set(d.startLineNumber + i - 1, state);
+				let state: StateStack;
+				if (delta) {
+					state = applyStateStackDiff(prevState, delta)!;
+					this._states.set(d.startLineNumber + i - 1, state);
+				} else {
+					state = this._states.get(d.startLineNumber + i - 1)!;
+				}
 
 				const offset = curToFutureTransformerStates.transform(d.startLineNumber + i - 1);
 				if (offset !== undefined) {


### PR DESCRIPTION
Fixes #175393

This sends a `null` state diff to indicate that the state did not change over time. This effectively resets the "needs tokenization" flag for that line.

Previously, that flag would not be reset when the state didn't change.
The render would then heuristically tokenize everything after that line, which would cause visible flickering if the heuristic is off.