### PR TITLE
fix #176154

### DIFF
--- a/src/vs/editor/contrib/suggest/browser/suggestAlternatives.ts
+++ b/src/vs/editor/contrib/suggest/browser/suggestAlternatives.ts
@@ -68,7 +68,7 @@ export class SuggestAlternatives {
 
 	private static _moveIndex(fwd: boolean, model: CompletionModel, index: number): number {
 		let newIndex = index;
-		while (true) {
+		for (let rounds = model.items.length; rounds > 0; rounds--) {
 			newIndex = (newIndex + model.items.length + (fwd ? +1 : -1)) % model.items.length;
 			if (newIndex === index) {
 				break;

--- a/src/vs/editor/contrib/suggest/browser/suggestController.ts
+++ b/src/vs/editor/contrib/suggest/browser/suggestController.ts
@@ -339,6 +339,10 @@ export class SuggestController implements IEditorContribution {
 
 
 		if (Array.isArray(item.completion.additionalTextEdits)) {
+
+			// cancel -> stops all listening and closes widget
+			this.model.cancel();
+
 			// sync additional edits
 			const scrollState = StableEditorScrollState.capture(this.editor);
 			this.editor.executeEdits(


### PR DESCRIPTION
- add extra check when computing next index for completion model
- cancel suggestion also/even before applying additional edits. this ensure alternative edits actually work properly
