### PR TITLE
Avoid double-encoding icon path

### DIFF
--- a/src/vs/workbench/contrib/interactiveSession/browser/interactiveSessionListRenderer.ts
+++ b/src/vs/workbench/contrib/interactiveSession/browser/interactiveSessionListRenderer.ts
@@ -192,7 +192,7 @@ export class InteractiveListItemRenderer extends Disposable implements ITreeRend
 
 		if (element.avatarIconUri) {
 			const avatarIcon = dom.$<HTMLImageElement>('img.icon');
-			avatarIcon.src = element.avatarIconUri.toString();
+			avatarIcon.src = element.avatarIconUri.toString(true);
 			templateData.avatar.replaceChildren(avatarIcon);
 		} else {
 			const defaultIcon = isRequestVM(element) ? Codicon.account : Codicon.hubot;


### PR DESCRIPTION
Fixes this icon missing in remote windows