### PR TITLE
fix & improve  runCommands

### DIFF
--- a/src/vs/workbench/contrib/commands/common/commands.contribution.ts
+++ b/src/vs/workbench/contrib/commands/common/commands.contribution.ts
@@ -41,6 +41,9 @@ class RunCommands extends Action2 {
 												$ref: 'vscode://schemas/keybindings#commandNames'
 											},
 											{
+												type: 'string', // we support "arbitrary" strings because extension-contributed command names aren't in 'vscode://schemas/keybindings#commandNames'
+											},
+											{
 												type: 'object',
 												required: ['command'],
 												$ref: 'vscode://schemas/keybindings#/definitions/commandsSchemas'

--- a/src/vs/workbench/contrib/commands/common/commands.contribution.ts
+++ b/src/vs/workbench/contrib/commands/common/commands.contribution.ts
@@ -9,7 +9,7 @@ import { ICommandService } from 'vs/platform/commands/common/commands';
 import { ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
 import { INotificationService } from 'vs/platform/notification/common/notification';
 
-type RunnableCommand = string | { id: string; args: any[] };
+type RunnableCommand = string | { command: string; args: any[] };
 
 type CommandArgs = {
 	commands: RunnableCommand[];
@@ -85,7 +85,7 @@ class RunCommands extends Action2 {
 			if (typeof cmd === 'string') {
 				continue;
 			}
-			if (typeof cmd === 'object' && typeof cmd.id === 'string') {
+			if (typeof cmd === 'object' && typeof cmd.command === 'string') {
 				continue;
 			}
 			return false;
@@ -99,7 +99,7 @@ class RunCommands extends Action2 {
 		if (typeof cmd === 'string') {
 			commandID = cmd;
 		} else {
-			commandID = cmd.id;
+			commandID = cmd.command;
 			commandArgs = cmd.args;
 		}
 

--- a/src/vs/workbench/contrib/commands/common/commands.contribution.ts
+++ b/src/vs/workbench/contrib/commands/common/commands.contribution.ts
@@ -32,19 +32,19 @@ class RunCommands extends Action2 {
 									type: 'array',
 									description: nls.localize('runCommands.commands', "Commands to run"),
 									items: {
-										type: ['string', 'object'],
-										required: ['command'],
-										properties: {
-											command: {
-												type: 'string'
+										anyOf: [  // Note: we don't allow arbitrary strings as command names as does `keybindingService.ts` - such behavior would be useful if the commands registry doesn't know about all existing commands - needs investigation
+											{
+												$ref: 'vscode://schemas/keybindings#/definitions/commandNameSchema'
 											},
-											args: { // type: any
+											{
+												type: 'object',
+												required: ['command'],
+												$ref: 'vscode://schemas/keybindings#/definitions/commandsSchemas'
 											}
-										}
+										]
 									}
 								}
 							}
-
 						}
 					}
 				]

--- a/src/vs/workbench/contrib/commands/common/commands.contribution.ts
+++ b/src/vs/workbench/contrib/commands/common/commands.contribution.ts
@@ -65,12 +65,13 @@ class RunCommands extends Action2 {
 			throw new Error('runCommands: invalid arguments');
 		}
 		const commandService = accessor.get(ICommandService);
+		const notificationService = accessor.get(INotificationService);
 		try {
 			for (const cmd of args.commands) {
 				await this._runCommand(commandService, cmd);
 			}
 		} catch (err) {
-			accessor.get(INotificationService).warn(err);
+			notificationService.warn(err);
 		}
 	}
 

--- a/src/vs/workbench/contrib/commands/common/commands.contribution.ts
+++ b/src/vs/workbench/contrib/commands/common/commands.contribution.ts
@@ -11,6 +11,10 @@ import { INotificationService } from 'vs/platform/notification/common/notificati
 
 type RunnableCommand = string | { id: string; args: any[] };
 
+type CommandArgs = {
+	commands: RunnableCommand[];
+};
+
 /** Runs several commands passed to it as an argument */
 class RunCommands extends Action2 {
 
@@ -56,8 +60,8 @@ class RunCommands extends Action2 {
 	// - this command takes a single argument-object because
 	//	- keybinding definitions don't allow running commands with several arguments
 	//  - and we want to be able to take on different other arguments in future, e.g., `runMode : 'serial' | 'concurrent'`
-	async run(accessor: ServicesAccessor, args: any) {
-		if (!this._validateInput(args)) {
+	async run(accessor: ServicesAccessor, args: unknown) {
+		if (!this._isCommandArgs(args)) {
 			throw new Error('runCommands: invalid arguments');
 		}
 		const commandService = accessor.get(ICommandService);
@@ -70,11 +74,11 @@ class RunCommands extends Action2 {
 		}
 	}
 
-	private _validateInput(args: any): args is { commands: RunnableCommand[] } {
+	private _isCommandArgs(args: unknown): args is CommandArgs {
 		if (!args || typeof args !== 'object') {
 			return false;
 		}
-		if (!Array.isArray(args.commands)) {
+		if (!('commands' in args) || !Array.isArray(args.commands)) {
 			return false;
 		}
 		for (const cmd of args.commands) {

--- a/src/vs/workbench/contrib/commands/common/commands.contribution.ts
+++ b/src/vs/workbench/contrib/commands/common/commands.contribution.ts
@@ -38,7 +38,7 @@ class RunCommands extends Action2 {
 									items: {
 										anyOf: [  // Note: we don't allow arbitrary strings as command names as does `keybindingService.ts` - such behavior would be useful if the commands registry doesn't know about all existing commands - needs investigation
 											{
-												$ref: 'vscode://schemas/keybindings#commandNames'
+												$ref: 'vscode://schemas/keybindings#/definitions/commandNames'
 											},
 											{
 												type: 'string', // we support "arbitrary" strings because extension-contributed command names aren't in 'vscode://schemas/keybindings#commandNames'
@@ -46,6 +46,18 @@ class RunCommands extends Action2 {
 											{
 												type: 'object',
 												required: ['command'],
+												properties: {
+													command: {
+														'anyOf': [
+															{
+																$ref: 'vscode://schemas/keybindings#/definitions/commandNames'
+															},
+															{
+																type: 'string'
+															},
+														]
+													}
+												},
 												$ref: 'vscode://schemas/keybindings#/definitions/commandsSchemas'
 											}
 										]

--- a/src/vs/workbench/contrib/commands/common/commands.contribution.ts
+++ b/src/vs/workbench/contrib/commands/common/commands.contribution.ts
@@ -34,7 +34,7 @@ class RunCommands extends Action2 {
 									items: {
 										anyOf: [  // Note: we don't allow arbitrary strings as command names as does `keybindingService.ts` - such behavior would be useful if the commands registry doesn't know about all existing commands - needs investigation
 											{
-												$ref: 'vscode://schemas/keybindings#/definitions/commandNameSchema'
+												$ref: 'vscode://schemas/keybindings#commandNames'
 											},
 											{
 												type: 'object',

--- a/src/vs/workbench/contrib/commands/common/commands.contribution.ts
+++ b/src/vs/workbench/contrib/commands/common/commands.contribution.ts
@@ -107,7 +107,11 @@ class RunCommands extends Action2 {
 		if (commandArgs === undefined) {
 			return commandService.executeCommand(commandID);
 		} else {
-			return commandService.executeCommand(commandID, ...commandArgs);
+			if (Array.isArray(commandArgs)) { // TODO@ulugbekna: this needs discussion - do we allow passing several arguments to command run, which isn't by the regular `keybindings.json`
+				return commandService.executeCommand(commandID, ...commandArgs);
+			} else {
+				return commandService.executeCommand(commandID, commandArgs);
+			}
 		}
 	}
 }

--- a/src/vs/workbench/services/keybinding/browser/keybindingService.ts
+++ b/src/vs/workbench/services/keybinding/browser/keybindingService.ts
@@ -797,6 +797,12 @@ const schema: IJSONSchema = {
 				}
 			}
 		},
+		'commandNames': {
+			'type': 'string',
+			'enum': commandsEnum,
+			'enumDescriptions': <any>commandsEnumDescriptions,
+			'description': nls.localize('keybindings.json.command', "Name of the command to execute"),
+		},
 		'commandsSchemas': {
 			'allOf': commandsSchemas
 		}
@@ -811,35 +817,20 @@ const schema: IJSONSchema = {
 				'description': nls.localize('keybindings.json.key', "Key or key sequence (separated by space)"),
 			},
 			'command': {
-				'if': {
-					'type': 'array'
-				},
-				'then': {
-					'not': {
-						'type': 'array',
+				'anyOf': [
+					{
+						$ref: '#/definitions/commandNames'
 					},
-					'errorMessage': nls.localize('keybindings.commandsIsArray', "Incorrect type. Expected \"{0}\". The field 'command' does not support running multiple commands. Use command 'runCommands' to pass it multiple commands to run.", 'string')
-				},
-				'else': {
-					'anyOf': [
-						{
-							'$anchor': 'commandNames', // https://json-schema.org/understanding-json-schema/structuring.html#anchor
-							'type': 'string',
-							'enum': commandsEnum,
-							'enumDescriptions': <any>commandsEnumDescriptions,
-							'description': nls.localize('keybindings.json.command', "Name of the command to execute"),
-						},
-						{
-							'type': 'string',
-							'enum': removalCommandsEnum,
-							'enumDescriptions': <any>commandsEnumDescriptions,
-							'description': nls.localize('keybindings.json.removalCommand', "Name of the command to remove keyboard shortcut for"),
-						},
-						{
-							'type': 'string'
-						}
-					],
-				}
+					{
+						'type': 'string',
+						'enum': removalCommandsEnum,
+						'enumDescriptions': <any>commandsEnumDescriptions,
+						'description': nls.localize('keybindings.json.removalCommand', "Name of the command to remove keyboard shortcut for"),
+					},
+					{
+						'type': 'string'
+					},
+				],
 			},
 			'when': {
 				'type': 'string',

--- a/src/vs/workbench/services/keybinding/browser/keybindingService.ts
+++ b/src/vs/workbench/services/keybinding/browser/keybindingService.ts
@@ -796,6 +796,15 @@ const schema: IJSONSchema = {
 					}
 				}
 			}
+		},
+		'commandNameSchema': {
+			'type': 'string',
+			'enum': commandsEnum,
+			'enumDescriptions': <any>commandsEnumDescriptions,
+			'description': nls.localize('keybindings.json.command', "Name of the command to execute"),
+		},
+		'commandsSchemas': {
+			'allOf': commandsSchemas
 		}
 	},
 	items: {
@@ -810,10 +819,7 @@ const schema: IJSONSchema = {
 			'command': {
 				'anyOf': [
 					{
-						'type': 'string',
-						'enum': commandsEnum,
-						'enumDescriptions': <any>commandsEnumDescriptions,
-						'description': nls.localize('keybindings.json.command', "Name of the command to execute"),
+						'$ref': '#/definitions/commandNameSchema'
 					},
 					{
 						'type': 'string',
@@ -834,7 +840,7 @@ const schema: IJSONSchema = {
 				'description': nls.localize('keybindings.json.args', "Arguments to pass to the command to execute.")
 			}
 		},
-		'allOf': commandsSchemas
+		'$ref': '#/definitions/commandsSchemas'
 	}
 };
 

--- a/src/vs/workbench/services/keybinding/browser/keybindingService.ts
+++ b/src/vs/workbench/services/keybinding/browser/keybindingService.ts
@@ -811,24 +811,35 @@ const schema: IJSONSchema = {
 				'description': nls.localize('keybindings.json.key', "Key or key sequence (separated by space)"),
 			},
 			'command': {
-				'anyOf': [
-					{
-						'$anchor': 'commandNames', // https://json-schema.org/understanding-json-schema/structuring.html#anchor
-						'type': 'string',
-						'enum': commandsEnum,
-						'enumDescriptions': <any>commandsEnumDescriptions,
-						'description': nls.localize('keybindings.json.command', "Name of the command to execute"),
+				'if': {
+					'type': 'array'
+				},
+				'then': {
+					'not': {
+						'type': 'array',
 					},
-					{
-						'type': 'string',
-						'enum': removalCommandsEnum,
-						'enumDescriptions': <any>commandsEnumDescriptions,
-						'description': nls.localize('keybindings.json.removalCommand', "Name of the command to remove keyboard shortcut for"),
-					},
-					{
-						'type': 'string'
-					}
-				]
+					'errorMessage': nls.localize('keybindings.commandsIsArray', "Incorrect type. Expected \"{0}\". The field 'command' does not support running multiple commands. Use command 'runCommands' to pass it multiple commands to run.", 'string')
+				},
+				'else': {
+					'anyOf': [
+						{
+							'$anchor': 'commandNames', // https://json-schema.org/understanding-json-schema/structuring.html#anchor
+							'type': 'string',
+							'enum': commandsEnum,
+							'enumDescriptions': <any>commandsEnumDescriptions,
+							'description': nls.localize('keybindings.json.command', "Name of the command to execute"),
+						},
+						{
+							'type': 'string',
+							'enum': removalCommandsEnum,
+							'enumDescriptions': <any>commandsEnumDescriptions,
+							'description': nls.localize('keybindings.json.removalCommand', "Name of the command to remove keyboard shortcut for"),
+						},
+						{
+							'type': 'string'
+						}
+					],
+				}
 			},
 			'when': {
 				'type': 'string',

--- a/src/vs/workbench/services/keybinding/browser/keybindingService.ts
+++ b/src/vs/workbench/services/keybinding/browser/keybindingService.ts
@@ -797,12 +797,6 @@ const schema: IJSONSchema = {
 				}
 			}
 		},
-		'commandNameSchema': {
-			'type': 'string',
-			'enum': commandsEnum,
-			'enumDescriptions': <any>commandsEnumDescriptions,
-			'description': nls.localize('keybindings.json.command', "Name of the command to execute"),
-		},
 		'commandsSchemas': {
 			'allOf': commandsSchemas
 		}
@@ -819,7 +813,11 @@ const schema: IJSONSchema = {
 			'command': {
 				'anyOf': [
 					{
-						'$ref': '#/definitions/commandNameSchema'
+						'$anchor': 'commandNames', // https://json-schema.org/understanding-json-schema/structuring.html#anchor
+						'type': 'string',
+						'enum': commandsEnum,
+						'enumDescriptions': <any>commandsEnumDescriptions,
+						'description': nls.localize('keybindings.json.command', "Name of the command to execute"),
 					},
 					{
 						'type': 'string',

--- a/src/vs/workbench/services/keybinding/browser/keybindingService.ts
+++ b/src/vs/workbench/services/keybinding/browser/keybindingService.ts
@@ -772,6 +772,7 @@ class UserKeybindings extends Disposable {
 const schemaId = 'vscode://schemas/keybindings';
 const commandsSchemas: IJSONSchema[] = [];
 const commandsEnum: string[] = [];
+const removalCommandsEnum: string[] = [];
 const commandsEnumDescriptions: (string | undefined)[] = [];
 const schema: IJSONSchema = {
 	id: schemaId,
@@ -815,6 +816,12 @@ const schema: IJSONSchema = {
 						'description': nls.localize('keybindings.json.command', "Name of the command to execute"),
 					},
 					{
+						'type': 'string',
+						'enum': removalCommandsEnum,
+						'enumDescriptions': <any>commandsEnumDescriptions,
+						'description': nls.localize('keybindings.json.removalCommand', "Name of the command to remove keyboard shortcut for"),
+					},
+					{
 						'type': 'string'
 					}
 				]
@@ -837,6 +844,7 @@ schemaRegistry.registerSchema(schemaId, schema);
 function updateSchema(additionalContributions: readonly IJSONSchema[]) {
 	commandsSchemas.length = 0;
 	commandsEnum.length = 0;
+	removalCommandsEnum.length = 0;
 	commandsEnumDescriptions.length = 0;
 
 	const knownCommands = new Set<string>();
@@ -849,8 +857,7 @@ function updateSchema(additionalContributions: readonly IJSONSchema[]) {
 				commandsEnumDescriptions.push(description);
 
 				// Also add the negative form for keybinding removal
-				commandsEnum.push(`-${commandId}`);
-				commandsEnumDescriptions.push(description);
+				removalCommandsEnum.push(`-${commandId}`);
 			}
 		}
 	};

--- a/src/vs/workbench/services/keybinding/browser/keybindingService.ts
+++ b/src/vs/workbench/services/keybinding/browser/keybindingService.ts
@@ -817,20 +817,36 @@ const schema: IJSONSchema = {
 				'description': nls.localize('keybindings.json.key', "Key or key sequence (separated by space)"),
 			},
 			'command': {
-				'anyOf': [
+				'allOf': [
 					{
-						$ref: '#/definitions/commandNames'
+						'if': {
+							'type': 'array'
+						},
+						'then': {
+							'not': {
+								'type': 'array'
+							},
+							'errorMessage': nls.localize('keybindings.commandsIsArray', "Incorrect type. Expected \"{0}\". The field 'command' does not support running multiple commands. Use command 'runCommands' to pass it multiple commands to run.", 'string')
+						}
 					},
 					{
-						'type': 'string',
-						'enum': removalCommandsEnum,
-						'enumDescriptions': <any>commandsEnumDescriptions,
-						'description': nls.localize('keybindings.json.removalCommand', "Name of the command to remove keyboard shortcut for"),
+						'anyOf': [
+							{
+								$ref: '#/definitions/commandNames'
+							},
+							{
+								'type': 'string',
+								'enum': removalCommandsEnum,
+								'enumDescriptions': <any>commandsEnumDescriptions,
+								'description': nls.localize('keybindings.json.removalCommand', "Name of the command to remove keyboard shortcut for"),
+							},
+							{
+								'type': 'string'
+							},
+						]
 					},
-					{
-						'type': 'string'
-					},
-				],
+
+				]
 			},
 			'when': {
 				'type': 'string',

--- a/src/vs/workbench/services/keybinding/browser/keybindingService.ts
+++ b/src/vs/workbench/services/keybinding/browser/keybindingService.ts
@@ -803,6 +803,22 @@ const schema: IJSONSchema = {
 			'enumDescriptions': <any>commandsEnumDescriptions,
 			'description': nls.localize('keybindings.json.command', "Name of the command to execute"),
 		},
+		'commandType': {
+			'anyOf': [ // repetition of this clause here and below is intentional: one is for nice diagnostics & one is for code completion
+				{
+					$ref: '#/definitions/commandNames'
+				},
+				{
+					'type': 'string',
+					'enum': removalCommandsEnum,
+					'enumDescriptions': <any>commandsEnumDescriptions,
+					'description': nls.localize('keybindings.json.removalCommand', "Name of the command to remove keyboard shortcut for"),
+				},
+				{
+					'type': 'string'
+				},
+			]
+		},
 		'commandsSchemas': {
 			'allOf': commandsSchemas
 		}
@@ -829,34 +845,12 @@ const schema: IJSONSchema = {
 							'errorMessage': nls.localize('keybindings.commandsIsArray', "Incorrect type. Expected \"{0}\". The field 'command' does not support running multiple commands. Use command 'runCommands' to pass it multiple commands to run.", 'string')
 						},
 						'else': {
-							'anyOf': [ // repetition of this clause here and below is intentional: one is for nice diagnostics & one is for code completion
-								{
-									$ref: '#/definitions/commandNames'
-								},
-								{
-									'type': 'string',
-									'enum': removalCommandsEnum,
-									'enumDescriptions': <any>commandsEnumDescriptions,
-									'description': nls.localize('keybindings.json.removalCommand', "Name of the command to remove keyboard shortcut for"),
-								},
-								{
-									'type': 'string'
-								},
-							]
+							'$ref': '#/definitions/commandType'
 						}
 					},
 					{
-						$ref: '#/definitions/commandNames'
-					},
-					{
-						'type': 'string',
-						'enum': removalCommandsEnum,
-						'enumDescriptions': <any>commandsEnumDescriptions,
-						'description': nls.localize('keybindings.json.removalCommand', "Name of the command to remove keyboard shortcut for"),
-					},
-					{
-						'type': 'string'
-					},
+						'$ref': '#/definitions/commandType'
+					}
 				]
 			},
 			'when': {

--- a/src/vs/workbench/services/keybinding/browser/keybindingService.ts
+++ b/src/vs/workbench/services/keybinding/browser/keybindingService.ts
@@ -817,7 +817,7 @@ const schema: IJSONSchema = {
 				'description': nls.localize('keybindings.json.key', "Key or key sequence (separated by space)"),
 			},
 			'command': {
-				'allOf': [
+				'anyOf': [
 					{
 						'if': {
 							'type': 'array'
@@ -827,25 +827,36 @@ const schema: IJSONSchema = {
 								'type': 'array'
 							},
 							'errorMessage': nls.localize('keybindings.commandsIsArray', "Incorrect type. Expected \"{0}\". The field 'command' does not support running multiple commands. Use command 'runCommands' to pass it multiple commands to run.", 'string')
+						},
+						'else': {
+							'anyOf': [ // repetition of this clause here and below is intentional: one is for nice diagnostics & one is for code completion
+								{
+									$ref: '#/definitions/commandNames'
+								},
+								{
+									'type': 'string',
+									'enum': removalCommandsEnum,
+									'enumDescriptions': <any>commandsEnumDescriptions,
+									'description': nls.localize('keybindings.json.removalCommand', "Name of the command to remove keyboard shortcut for"),
+								},
+								{
+									'type': 'string'
+								},
+							]
 						}
 					},
 					{
-						'anyOf': [
-							{
-								$ref: '#/definitions/commandNames'
-							},
-							{
-								'type': 'string',
-								'enum': removalCommandsEnum,
-								'enumDescriptions': <any>commandsEnumDescriptions,
-								'description': nls.localize('keybindings.json.removalCommand', "Name of the command to remove keyboard shortcut for"),
-							},
-							{
-								'type': 'string'
-							},
-						]
+						$ref: '#/definitions/commandNames'
 					},
-
+					{
+						'type': 'string',
+						'enum': removalCommandsEnum,
+						'enumDescriptions': <any>commandsEnumDescriptions,
+						'description': nls.localize('keybindings.json.removalCommand', "Name of the command to remove keyboard shortcut for"),
+					},
+					{
+						'type': 'string'
+					},
 				]
 			},
 			'when': {


### PR DESCRIPTION
# What this PR includes

## Fixes: 
- using the notification service incorrectly
- mismatch between linting rule & real expected arg name

## Features

- completion & linting for runCommands arguments

# Commits: 

- keybindings-json: split command names and removal command names into separate variables
- runCommands: linting for arguments
- runCommands: simplify linting rules
- runCommands: cleanup arg validation - don't use `any`; better names
- runCommands: fix naming of RunnableCommand field
- runCommands: fix use of notif service
- runCommands: support passing several arguments to commands (unlike ordinary `keybindings.json` entry)

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
