### PR TITLE
Remove uses of `X-UA-Compatible` meta tag

### DIFF
--- a/build/builtin/index.html
+++ b/build/builtin/index.html
@@ -5,7 +5,6 @@
 
 <head>
 	<meta charset="utf-8" />
-	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<title>Manage Built-in Extensions</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<script src="browser-main.js"></script>

--- a/src/vs/base/test/node/pfs/fixtures/index.html
+++ b/src/vs/base/test/node/pfs/fixtures/index.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html>
 <head id='headID'>
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <title>Strada </title>
     <link href="site.css" rel="stylesheet" type="text/css" />
     <script src="jquery-1.4.1.js"></script>

--- a/src/vs/platform/files/test/node/fixtures/resolver/index.html
+++ b/src/vs/platform/files/test/node/fixtures/resolver/index.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html>
 <head id='headID'>
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <title>Strada </title>
     <link href="site.css" rel="stylesheet" type="text/css" />
     <script src="jquery-1.4.1.js"></script>

--- a/src/vs/platform/files/test/node/fixtures/service/index.html
+++ b/src/vs/platform/files/test/node/fixtures/service/index.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html>
 <head id='headID'>
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <title>Strada </title>
     <link href="site.css" rel="stylesheet" type="text/css" />
     <script src="jquery-1.4.1.js"></script>

--- a/src/vs/workbench/contrib/webview/browser/pre/fake.html
+++ b/src/vs/workbench/contrib/webview/browser/pre/fake.html
@@ -3,7 +3,6 @@
 <head>
 	<meta charset="UTF-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<meta http-equiv="X-UA-Compatible" content="ie=edge">
 	<title>Fake</title>
 </head>
 <body>

--- a/src/vs/workbench/contrib/webview/browser/pre/index-no-csp.html
+++ b/src/vs/workbench/contrib/webview/browser/pre/index-no-csp.html
@@ -7,8 +7,6 @@
 	<!-- Disable pinch zooming -->
 	<meta name="viewport"
 		content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no">
-
-	<meta http-equiv="X-UA-Compatible" content="ie=edge">
 </head>
 
 <body style="margin: 0; overflow: hidden; width: 100%; height: 100%" role="document">

--- a/src/vs/workbench/contrib/webview/browser/pre/index.html
+++ b/src/vs/workbench/contrib/webview/browser/pre/index.html
@@ -10,8 +10,6 @@
 	<!-- Disable pinch zooming -->
 	<meta name="viewport"
 		content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no">
-
-	<meta http-equiv="X-UA-Compatible" content="ie=edge">
 </head>
 
 <body style="margin: 0; overflow: hidden; width: 100%; height: 100%" role="document">

--- a/src/vs/workbench/services/search/test/node/fixtures/index.html
+++ b/src/vs/workbench/services/search/test/node/fixtures/index.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html>
 <head id='headID'>
-    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <title>Strada </title>
     <link href="site.css" rel="stylesheet" type="text/css" />
     <script src="jquery-1.4.1.js"></script>

--- a/src/vs/workbench/services/search/test/node/textSearch.integrationTest.ts
+++ b/src/vs/workbench/services/search/test/node/textSearch.integrationTest.ts
@@ -347,7 +347,7 @@ flakySuite('TextSearch-integration', function () {
 			assert.strictEqual((<ITextSearchContext>results[0].results![0]).lineNumber, 24);
 			assert.strictEqual((<ITextSearchContext>results[0].results![0]).text, '        compiler.addUnit(prog,"input.ts");');
 			// assert.strictEqual((<ITextSearchMatch>results[1].results[0]).preview.text, '        compiler.typeCheck();\n'); // See https://github.com/BurntSushi/ripgrep/issues/1095
-			assert.strictEqual((<ITextSearchContext>results[2].results![0]).lineNumber, 27);
+			assert.strictEqual((<ITextSearchContext>results[2].results![0]).lineNumber, 26);
 			assert.strictEqual((<ITextSearchContext>results[2].results![0]).text, '        compiler.emit();');
 			assert.strictEqual((<ITextSearchContext>results[3].results![0]).lineNumber, 28);
 			assert.strictEqual((<ITextSearchContext>results[3].results![0]).text, '');

--- a/src/vs/workbench/services/search/test/node/textSearch.integrationTest.ts
+++ b/src/vs/workbench/services/search/test/node/textSearch.integrationTest.ts
@@ -349,7 +349,7 @@ flakySuite('TextSearch-integration', function () {
 			// assert.strictEqual((<ITextSearchMatch>results[1].results[0]).preview.text, '        compiler.typeCheck();\n'); // See https://github.com/BurntSushi/ripgrep/issues/1095
 			assert.strictEqual((<ITextSearchContext>results[2].results![0]).lineNumber, 26);
 			assert.strictEqual((<ITextSearchContext>results[2].results![0]).text, '        compiler.emit();');
-			assert.strictEqual((<ITextSearchContext>results[3].results![0]).lineNumber, 28);
+			assert.strictEqual((<ITextSearchContext>results[3].results![0]).lineNumber, 27);
 			assert.strictEqual((<ITextSearchContext>results[3].results![0]).text, '');
 		});
 	});

--- a/src/vs/workbench/services/search/test/node/textSearch.integrationTest.ts
+++ b/src/vs/workbench/services/search/test/node/textSearch.integrationTest.ts
@@ -157,7 +157,7 @@ flakySuite('TextSearch-integration', function () {
 			contentPattern: { pattern: 'e' }
 		};
 
-		return doSearchTest(config, 788);
+		return doSearchTest(config, 781);
 	});
 
 	test('Text: e (with excludes)', () => {
@@ -167,7 +167,7 @@ flakySuite('TextSearch-integration', function () {
 			excludePattern: { '**/examples': true }
 		};
 
-		return doSearchTest(config, 394);
+		return doSearchTest(config, 387);
 	});
 
 	test('Text: e (with includes)', () => {
@@ -344,7 +344,7 @@ flakySuite('TextSearch-integration', function () {
 
 		return doSearchTest(config, 4).then(results => {
 			assert.strictEqual(results.length, 4);
-			assert.strictEqual((<ITextSearchContext>results[0].results![0]).lineNumber, 25);
+			assert.strictEqual((<ITextSearchContext>results[0].results![0]).lineNumber, 24);
 			assert.strictEqual((<ITextSearchContext>results[0].results![0]).text, '        compiler.addUnit(prog,"input.ts");');
 			// assert.strictEqual((<ITextSearchMatch>results[1].results[0]).preview.text, '        compiler.typeCheck();\n'); // See https://github.com/BurntSushi/ripgrep/issues/1095
 			assert.strictEqual((<ITextSearchContext>results[2].results![0]).lineNumber, 27);


### PR DESCRIPTION
We no longer support IE

Mainly removing this from the webview html but I figured we should remove the other references to it as well
