### PR TITLE
Remove extra decode while loading webview resources

### DIFF
--- a/src/vs/platform/webview/electron-main/webviewProtocolProvider.ts
+++ b/src/vs/platform/webview/electron-main/webviewProtocolProvider.ts
@@ -36,7 +36,7 @@ export class WebviewProtocolProvider extends Disposable {
 				const relativeResourcePath: AppResourcePath = `vs/workbench/contrib/webview/browser/pre/${entry}`;
 				const url = FileAccess.asFileUri(relativeResourcePath);
 				return callback({
-					path: decodeURIComponent(url.fsPath),
+					path: url.fsPath,
 					headers: {
 						...COI.getHeadersFromQuery(request.url),
 						'Cross-Origin-Resource-Policy': 'cross-origin'


### PR DESCRIPTION
Fixes #154860

The extra decode call messes up installs that have `%` in the path. Tested this change with paths that include spaces, multi-byte characters, and `%`
