### PR TITLE
Remove extra file check in documentHighlights

### DIFF
--- a/extensions/typescript-language-features/src/languageFeatures/documentHighlight.ts
+++ b/extensions/typescript-language-features/src/languageFeatures/documentHighlight.ts
@@ -33,10 +33,7 @@ class TypeScriptDocumentHighlightProvider implements vscode.DocumentHighlightPro
 			return [];
 		}
 
-		return response.body
-			.filter(highlight => highlight.file === file)
-			.map(convertDocumentHighlight)
-			.flat();
+		return response.body.flatMap(convertDocumentHighlight);
 	}
 }
 


### PR DESCRIPTION
Fixes #177823

For document hightlights, it seems TS returns windows paths that use forward slashes. This seems wrong, but we also likely don't need the extra check for the file on our side either since we already pass in `filesToSearch`

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
