### PR TITLE
keybindings-json: require 'command' field before linting code action args

### DIFF
--- a/src/vs/workbench/contrib/codeActions/browser/codeActionsContribution.ts
+++ b/src/vs/workbench/contrib/codeActions/browser/codeActionsContribution.ts
@@ -108,6 +108,7 @@ export class CodeActionsContribution extends Disposable implements IWorkbenchCon
 		const conditionalSchema = (command: string, actions: readonly ContributedCodeAction[]): IJSONSchema => {
 			return {
 				if: {
+					required: ['command'],
 					properties: {
 						'command': { const: command }
 					}


### PR DESCRIPTION
fixes #176629 (2nd part of the fix)
