### PR TITLE
cli: fix reading of client tunnel commands

### DIFF
--- a/cli/src/tunnels/singleton_client.rs
+++ b/cli/src/tunnels/singleton_client.rs
@@ -50,6 +50,8 @@ pub async fn start_singleton_client(args: SingletonClientArgs) -> bool {
 	thread::spawn(move || {
 		let mut input = String::new();
 		loop {
+			input.truncate(0);
+
 			match std::io::stdin().read_line(&mut input) {
 				Err(_) | Ok(0) => return, // EOF or not a tty
 				_ => {}


### PR DESCRIPTION
.read_line() appends to the string, so this caused the first command entered to always be read again

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
