### PR TITLE
extensions: Make ScrollToTop button less prominent

### DIFF
--- a/src/vs/workbench/contrib/extensions/browser/extensionEditor.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionEditor.ts
@@ -768,11 +768,11 @@ export class ExtensionEditor extends EditorPane {
 
 					#scroll-to-top {
 						position: fixed;
-						width: 40px;
-						height: 40px;
+						width: 32px;
+						height: 32px;
 						right: 25px;
 						bottom: 25px;
-						background-color: var(--vscode-button-background);
+						background-color: var(--vscode-button-secondaryBackground);
 						border-color: var(--vscode-button-border);
 						border-radius: 50%;
 						cursor: pointer;
@@ -784,7 +784,7 @@ export class ExtensionEditor extends EditorPane {
 					}
 
 					#scroll-to-top:hover {
-						background-color: var(--vscode-button-hoverBackground);
+						background-color: var(--vscode-button-secondaryHoverBackground);
 						box-shadow: 2px 2px 2px rgba(0,0,0,.25);
 					}
 


### PR DESCRIPTION
This styles the ScrollToTop button to be less prominent.

This button visually stands out more than the Install button, even when we're already at the top of the page. So I've reduced the size slightly and changed it to use the the secondary button colour instead of primary.

Left: before, right: after

<img width="1616" alt="image" src="https://user-images.githubusercontent.com/103326/226912983-9af4ac0e-b6c7-46a3-88be-2ea250530531.png">

Even better would be to hide this button when already at the top of the page, but I haven't figured that out yet.