### PR TITLE
fix: adding escape command in order to focus out of the sticky scroll

### DIFF
--- a/src/vs/editor/contrib/stickyScroll/browser/stickyScrollActions.ts
+++ b/src/vs/editor/contrib/stickyScroll/browser/stickyScrollActions.ts
@@ -46,7 +46,7 @@ export class ToggleStickyScroll extends Action2 {
 	}
 }
 
-const weight = KeybindingWeight.EditorContrib + 10000;
+const weight = KeybindingWeight.EditorContrib;
 
 export class FocusStickyScroll extends EditorAction2 {
 
@@ -145,13 +145,14 @@ export class GoToStickyScrollLine extends EditorAction2 {
 	}
 }
 
-export class EscapeStickyScroll extends EditorAction2 {
+export class SelectEditor extends EditorAction2 {
+
 	constructor() {
 		super({
-			id: 'editor.action.escapeStickyScroll',
+			id: 'editor.action.selectEditor',
 			title: {
-				value: localize('escapeStickyScroll.title', "Escape Sticky Scroll"),
-				original: 'Escape Sticky Scroll'
+				value: localize('selectEditor.title', "Select Editor"),
+				original: 'Select Editor'
 			},
 			precondition: ContextKeyExpr.has('config.editor.stickyScroll.enabled'),
 			keybinding: {

--- a/src/vs/editor/contrib/stickyScroll/browser/stickyScrollActions.ts
+++ b/src/vs/editor/contrib/stickyScroll/browser/stickyScrollActions.ts
@@ -66,10 +66,7 @@ export class FocusStickyScroll extends EditorAction2 {
 	}
 
 	runEditorCommand(_accessor: ServicesAccessor, editor: ICodeEditor) {
-		const stickyScrollController = StickyScrollController.get(editor);
-		if (stickyScrollController) {
-			stickyScrollController.focus();
-		}
+		StickyScrollController.get(editor)?.focus();
 	}
 }
 
@@ -90,10 +87,7 @@ export class SelectNextStickyScrollLine extends EditorAction2 {
 	}
 
 	runEditorCommand(_accessor: ServicesAccessor, editor: ICodeEditor) {
-		const stickyScrollController = StickyScrollController.get(editor);
-		if (stickyScrollController) {
-			stickyScrollController.focusNext();
-		}
+		StickyScrollController.get(editor)?.focusNext();
 	}
 }
 
@@ -114,10 +108,7 @@ export class SelectPreviousStickyScrollLine extends EditorAction2 {
 	}
 
 	runEditorCommand(_accessor: ServicesAccessor, editor: ICodeEditor) {
-		const stickyScrollController = StickyScrollController.get(editor);
-		if (stickyScrollController) {
-			stickyScrollController.focusPrevious();
-		}
+		StickyScrollController.get(editor)?.focusPrevious();
 	}
 }
 
@@ -138,10 +129,7 @@ export class GoToStickyScrollLine extends EditorAction2 {
 	}
 
 	runEditorCommand(_accessor: ServicesAccessor, editor: ICodeEditor) {
-		const stickyScrollController = StickyScrollController.get(editor);
-		if (stickyScrollController) {
-			stickyScrollController.goToFocused();
-		}
+		StickyScrollController.get(editor)?.goToFocused();
 	}
 }
 
@@ -163,9 +151,6 @@ export class SelectEditor extends EditorAction2 {
 	}
 
 	runEditorCommand(_accessor: ServicesAccessor, editor: ICodeEditor) {
-		const stickyScrollController = StickyScrollController.get(editor);
-		if (stickyScrollController) {
-			stickyScrollController.escape();
-		}
+		StickyScrollController.get(editor)?.escape();
 	}
 }

--- a/src/vs/editor/contrib/stickyScroll/browser/stickyScrollActions.ts
+++ b/src/vs/editor/contrib/stickyScroll/browser/stickyScrollActions.ts
@@ -151,6 +151,6 @@ export class SelectEditor extends EditorAction2 {
 	}
 
 	runEditorCommand(_accessor: ServicesAccessor, editor: ICodeEditor) {
-		StickyScrollController.get(editor)?.escape();
+		StickyScrollController.get(editor)?.selectEditor();
 	}
 }

--- a/src/vs/editor/contrib/stickyScroll/browser/stickyScrollActions.ts
+++ b/src/vs/editor/contrib/stickyScroll/browser/stickyScrollActions.ts
@@ -144,3 +144,27 @@ export class GoToStickyScrollLine extends EditorAction2 {
 		}
 	}
 }
+
+export class EscapeStickyScroll extends EditorAction2 {
+	constructor() {
+		super({
+			id: 'editor.action.escapeStickyScroll',
+			title: {
+				value: localize('escapeStickyScroll.title', "Escape sticky scroll"),
+				original: 'Escape sticky scroll'
+			},
+			precondition: ContextKeyExpr.has('config.editor.stickyScroll.enabled'),
+			keybinding: {
+				weight,
+				primary: KeyCode.Escape
+			}
+		});
+	}
+
+	runEditorCommand(_accessor: ServicesAccessor, editor: ICodeEditor) {
+		const stickyScrollController = StickyScrollController.get(editor);
+		if (stickyScrollController) {
+			stickyScrollController.escape();
+		}
+	}
+}

--- a/src/vs/editor/contrib/stickyScroll/browser/stickyScrollActions.ts
+++ b/src/vs/editor/contrib/stickyScroll/browser/stickyScrollActions.ts
@@ -150,8 +150,8 @@ export class EscapeStickyScroll extends EditorAction2 {
 		super({
 			id: 'editor.action.escapeStickyScroll',
 			title: {
-				value: localize('escapeStickyScroll.title', "Escape sticky scroll"),
-				original: 'Escape sticky scroll'
+				value: localize('escapeStickyScroll.title', "Escape Sticky Scroll"),
+				original: 'Escape Sticky Scroll'
 			},
 			precondition: ContextKeyExpr.has('config.editor.stickyScroll.enabled'),
 			keybinding: {

--- a/src/vs/editor/contrib/stickyScroll/browser/stickyScrollContribution.ts
+++ b/src/vs/editor/contrib/stickyScroll/browser/stickyScrollContribution.ts
@@ -4,13 +4,14 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { EditorContributionInstantiation, registerEditorContribution } from 'vs/editor/browser/editorExtensions';
-import { ToggleStickyScroll, FocusStickyScroll, SelectPreviousStickyScrollLine, SelectNextStickyScrollLine, GoToStickyScrollLine } from 'vs/editor/contrib/stickyScroll/browser/stickyScrollActions';
+import { ToggleStickyScroll, FocusStickyScroll, EscapeStickyScroll, SelectPreviousStickyScrollLine, SelectNextStickyScrollLine, GoToStickyScrollLine } from 'vs/editor/contrib/stickyScroll/browser/stickyScrollActions';
 import { StickyScrollController } from 'vs/editor/contrib/stickyScroll/browser/stickyScrollController';
 import { registerAction2 } from 'vs/platform/actions/common/actions';
 
 registerEditorContribution(StickyScrollController.ID, StickyScrollController, EditorContributionInstantiation.AfterFirstRender);
 registerAction2(ToggleStickyScroll);
 registerAction2(FocusStickyScroll);
+registerAction2(EscapeStickyScroll);
 registerAction2(SelectPreviousStickyScrollLine);
 registerAction2(SelectNextStickyScrollLine);
 registerAction2(GoToStickyScrollLine);

--- a/src/vs/editor/contrib/stickyScroll/browser/stickyScrollContribution.ts
+++ b/src/vs/editor/contrib/stickyScroll/browser/stickyScrollContribution.ts
@@ -4,14 +4,14 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { EditorContributionInstantiation, registerEditorContribution } from 'vs/editor/browser/editorExtensions';
-import { ToggleStickyScroll, FocusStickyScroll, EscapeStickyScroll, SelectPreviousStickyScrollLine, SelectNextStickyScrollLine, GoToStickyScrollLine } from 'vs/editor/contrib/stickyScroll/browser/stickyScrollActions';
+import { ToggleStickyScroll, FocusStickyScroll, SelectEditor, SelectPreviousStickyScrollLine, SelectNextStickyScrollLine, GoToStickyScrollLine } from 'vs/editor/contrib/stickyScroll/browser/stickyScrollActions';
 import { StickyScrollController } from 'vs/editor/contrib/stickyScroll/browser/stickyScrollController';
 import { registerAction2 } from 'vs/platform/actions/common/actions';
 
 registerEditorContribution(StickyScrollController.ID, StickyScrollController, EditorContributionInstantiation.AfterFirstRender);
 registerAction2(ToggleStickyScroll);
 registerAction2(FocusStickyScroll);
-registerAction2(EscapeStickyScroll);
 registerAction2(SelectPreviousStickyScrollLine);
 registerAction2(SelectNextStickyScrollLine);
 registerAction2(GoToStickyScrollLine);
+registerAction2(SelectEditor);

--- a/src/vs/editor/contrib/stickyScroll/browser/stickyScrollController.ts
+++ b/src/vs/editor/contrib/stickyScroll/browser/stickyScrollController.ts
@@ -41,6 +41,7 @@ export interface IStickyScrollController {
 	goToFocused(): void;
 	findScrollWidgetState(): StickyScrollWidgetState;
 	dispose(): void;
+	escape(): void;
 }
 
 export class StickyScrollController extends Disposable implements IEditorContribution, IStickyScrollController {

--- a/src/vs/editor/contrib/stickyScroll/browser/stickyScrollController.ts
+++ b/src/vs/editor/contrib/stickyScroll/browser/stickyScrollController.ts
@@ -41,7 +41,7 @@ export interface IStickyScrollController {
 	goToFocused(): void;
 	findScrollWidgetState(): StickyScrollWidgetState;
 	dispose(): void;
-	escape(): void;
+	selectEditor(): void;
 }
 
 export class StickyScrollController extends Disposable implements IEditorContribution, IStickyScrollController {
@@ -173,7 +173,7 @@ export class StickyScrollController extends Disposable implements IEditorContrib
 		}
 	}
 
-	public escape(): void {
+	public selectEditor(): void {
 		this._editor.focus();
 	}
 

--- a/src/vs/editor/contrib/stickyScroll/browser/stickyScrollController.ts
+++ b/src/vs/editor/contrib/stickyScroll/browser/stickyScrollController.ts
@@ -172,6 +172,10 @@ export class StickyScrollController extends Disposable implements IEditorContrib
 		}
 	}
 
+	public escape(): void {
+		this._editor.focus();
+	}
+
 	// True is next, false is previous
 	private _focusNav(direction: boolean): void {
 		this._focusedStickyElementIndex = direction ? this._focusedStickyElementIndex + 1 : this._focusedStickyElementIndex - 1;


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/177871

Simple fix to add escape command to focus out of the sticky scroll
