### PR TITLE
Fix focus trapping issues

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/accessibility/browser/terminal.accessibility.contribution.ts
+++ b/src/vs/workbench/contrib/terminalContrib/accessibility/browser/terminal.accessibility.contribution.ts
@@ -105,7 +105,7 @@ registerAction2(class extends Action2 {
 				{
 					primary: KeyMod.Shift | KeyCode.Tab,
 					weight: KeybindingWeight.WorkbenchContrib,
-					when: ContextKeyExpr.and(CONTEXT_ACCESSIBILITY_MODE_ENABLED, terminalTabFocusContextKey)
+					when: ContextKeyExpr.and(CONTEXT_ACCESSIBILITY_MODE_ENABLED, terminalTabFocusContextKey, TerminalContextKeys.accessibleBufferFocus.negate())
 				}
 			],
 		});


### PR DESCRIPTION
Focus could be trapped in the accessible buffer when the user attempts to shift+tab to use backwards tab navigation. This was caused by a few things:

- A buffer editor tab key listeners which always prevented default and always focused the xterm instance.
- The workbench.action.terminal.focusAccessibleBuffer command keybinding would run regardless of whether the accessible buffer was focused or not.

Fixes #177886
Fixes #177755

![Recording 2023-03-22 at 07 53 13](https://user-images.githubusercontent.com/2193314/226943731-5d65dc19-b2a3-461e-86fd-d2713d929342.gif)

