### PR TITLE
Enable `search.experimental.notebookSearch` flag for insiders

### DIFF
--- a/src/vs/workbench/contrib/search/browser/search.contribution.ts
+++ b/src/vs/workbench/contrib/search/browser/search.contribution.ts
@@ -354,7 +354,7 @@ configurationRegistry.registerConfiguration({
 		'search.experimental.notebookSearch': {
 			type: 'boolean',
 			description: nls.localize('search.experimental.notebookSearch', "Controls whether to use the experimental notebook search in the global search. Please reload your VS Code instance for changes to this setting to take effect."),
-			default: typeof product.quality !== 'string' ? product.quality !== 'stable' : false, // only enable as default in insiders
+			default: typeof product.quality === 'string' && product.quality !== 'stable', // only enable as default in insiders
 		},
 	}
 });


### PR DESCRIPTION
Fixes #177306

Previous conditional had a bug.
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
