### PR TITLE
Add close event on debug adapter inline impl

### DIFF
--- a/src/vs/workbench/api/common/extHostDebugService.ts
+++ b/src/vs/workbench/api/common/extHostDebugService.ts
@@ -979,6 +979,10 @@ class DirectDebugAdapter extends AbstractDebugAdapter {
 		implementation.onDidSendMessage((message: vscode.DebugProtocolMessage) => {
 			this.acceptMessage(message as DebugProtocol.ProtocolMessage);
 		});
+
+		implementation.onDidClose?.((status: number | null) => {
+			this._onExit.fire(status);
+		});
 	}
 
 	startSession(): Promise<void> {

--- a/src/vscode-dts/vscode.d.ts
+++ b/src/vscode-dts/vscode.d.ts
@@ -14764,6 +14764,11 @@ declare module 'vscode' {
 		 * @param message A Debug Adapter Protocol message
 		 */
 		handleMessage(message: DebugProtocolMessage): void;
+
+		/**
+		 * An event which fires when the debug adapter was closed
+		 */
+		readonly onDidClose?: Event<number | null>;
 	}
 
 	/**


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

fixes https://github.com/microsoft/vscode/issues/178046

It adds an optional `onDidClose` field on the `DebugAdapter` class to allow notifying vscode when the debug adapter inline implementation was closed prematurely
