### PR TITLE
Try to optimize ContextKeyService.updateParent

### DIFF
--- a/src/vs/base/common/ternarySearchTree.ts
+++ b/src/vs/base/common/ternarySearchTree.ts
@@ -700,8 +700,8 @@ export class TernarySearchTree<K, V> {
 		}
 	}
 
-	*[Symbol.iterator](): IterableIterator<[K, V]> {
-		yield* this._entries(this._root);
+	[Symbol.iterator](): IterableIterator<[K, V]> {
+		return this._entries(this._root);
 	}
 
 	private _entries(node: TernarySearchTreeNode<K, V> | undefined): IterableIterator<[K, V]> {

--- a/src/vs/platform/contextkey/browser/contextKeyService.ts
+++ b/src/vs/platform/contextkey/browser/contextKeyService.ts
@@ -67,8 +67,10 @@ export class Context implements IContext {
 	}
 
 	public collectAllValues(): Record<string, any> {
-		let result = this._parent ? this._parent.collectAllValues() : Object.create(null);
-		result = { ...result, ...this._value };
+		const result = {
+			...this._parent?.collectAllValues(),
+			...this._value
+		};
 		delete result['_contextId'];
 		return result;
 	}
@@ -175,18 +177,10 @@ class ConfigAwareContextValuesContainer extends Context {
 		return value;
 	}
 
-	override setValue(key: string, value: any): boolean {
-		return super.setValue(key, value);
-	}
-
-	override removeValue(key: string): boolean {
-		return super.removeValue(key);
-	}
-
 	override collectAllValues(): { [key: string]: any } {
-		const result: { [key: string]: any } = Object.create(null);
+		const result = super.collectAllValues();
 		this._values.forEach((value, index) => result[index] = value);
-		return { ...result, ...super.collectAllValues() };
+		return result;
 	}
 }
 
@@ -498,6 +492,10 @@ class ScopedContextKeyService extends AbstractContextKeyService {
 	}
 
 	public updateParent(parentContextKeyService: AbstractContextKeyService): void {
+		if (this._parent === parentContextKeyService) {
+			return;
+		}
+
 		const thisContainer = this._parent.getContextValuesContainer(this._myContextId);
 		const oldAllValues = thisContainer.collectAllValues();
 		this._parent = parentContextKeyService;


### PR DESCRIPTION
I noticed that `ContextKeyService.updateParent` was taking ~5ms, which causes jitter if it happens during scrolling in the interactive view

This PR reduces it's cost by doing the following:

- Skip the call entirely if we already have the correct parent

- Don't re-spread objects in `collectAllValues`

- Return iterator directly instead of yield*ing it

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
