### PR TITLE
don't override link open keybinding

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/accessibility/browser/terminal.accessibility.contribution.ts
+++ b/src/vs/workbench/contrib/terminalContrib/accessibility/browser/terminal.accessibility.contribution.ts
@@ -136,7 +136,7 @@ registerAction2(class extends Action2 {
 				{
 					primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KeyO,
 					weight: KeybindingWeight.WorkbenchContrib + 2,
-					when: ContextKeyExpr.or(TerminalContextKeys.accessibleBufferFocus, ContextKeyExpr.and(CONTEXT_ACCESSIBILITY_MODE_ENABLED, TerminalContextKeys.focus))
+					when: TerminalContextKeys.accessibleBufferFocus
 				}
 			],
 		});


### PR DESCRIPTION
also allow non-screen reader users to navigate the accessible buffer when it's focused
fix #178059