### PR TITLE
Escape command used when sticky scroll focused, not just enabled

### DIFF
--- a/src/vs/editor/contrib/stickyScroll/browser/stickyScrollActions.ts
+++ b/src/vs/editor/contrib/stickyScroll/browser/stickyScrollActions.ts
@@ -142,7 +142,7 @@ export class SelectEditor extends EditorAction2 {
 				value: localize('selectEditor.title', "Select Editor"),
 				original: 'Select Editor'
 			},
-			precondition: ContextKeyExpr.has('config.editor.stickyScroll.enabled'),
+			precondition: EditorContextKeys.stickyScrollFocused.isEqualTo(true),
 			keybinding: {
 				weight,
 				primary: KeyCode.Escape


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/178127
