### PR TITLE
Make interactive session input a simple widget

### DIFF
--- a/src/vs/workbench/contrib/interactiveSession/browser/interactiveSessionWidget.ts
+++ b/src/vs/workbench/contrib/interactiveSession/browser/interactiveSessionWidget.ts
@@ -448,7 +448,7 @@ export class InteractiveSessionWidget extends Disposable implements IInteractive
 		options.scrollbar = { ...(options.scrollbar ?? {}), vertical: 'hidden' };
 
 		const inputEditorElement = dom.append(inputContainer, $('.interactive-input-editor'));
-		this._inputEditor = this._register(scopedInstantiationService.createInstance(CodeEditorWidget, inputEditorElement, options, { ...getSimpleCodeEditorWidgetOptions(), isSimpleWidget: false }));
+		this._inputEditor = this._register(scopedInstantiationService.createInstance(CodeEditorWidget, inputEditorElement, options, getSimpleCodeEditorWidgetOptions()));
 
 		this._register(this._inputEditor.onDidChangeModelContent(() => {
 			const currentHeight = Math.min(this._inputEditor.getContentHeight(), INPUT_EDITOR_MAX_HEIGHT);


### PR DESCRIPTION
I disabled this when I added the suggest widget, but I'm pretty sure that isn't necessary, and this causes the vim extension to run in this editor

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
