### PR TITLE
Fix marked es module Parcel compatibility issue

### DIFF
--- a/src/vs/base/common/marked/marked.js
+++ b/src/vs/base/common/marked/marked.js
@@ -19,8 +19,8 @@
 // ESM-uncomment-end
 
  (function (global, factory) {
-  typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
   typeof define === 'function' && define.amd ? define(['exports'], factory) :
+  typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
   (global = typeof globalThis !== 'undefined' ? globalThis : global || self, factory(global.marked = {}));
 })(this, (function (exports) { 'use strict';
 


### PR DESCRIPTION
Reverse order of marked.js module type conditions to ensure esm output doesn't run the commonjs branch.

Right now if an `exports` variable is defined, and the esm output has been bundled and run in a non-esm context, the commonjs code paths will be run. By reversing the order of the conditions, we can ensure this doesn't happen.

Should fix the monaco-kusto Parcel example: https://github.com/microsoft/monaco-editor/issues/2966
