### PR TITLE
Support OCaml-style links

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/links/browser/terminalLinkParsing.ts
+++ b/src/vs/workbench/contrib/terminalContrib/links/browser/terminalLinkParsing.ts
@@ -74,7 +74,7 @@ const linkSuffixRegexEol = new Lazy<RegExp>(() => {
 		// "foo", line 339, character 12     [#171880]
 		// "foo", line 339, characters 12-13 [#171880]
 		// "foo", lines 339-340              [#171880]
-		`['"]?(?:,? |: ?| on )lines? ${l()}(:?-\\d+)?(,? (col(?:umn)?|characters?) ${c()}(:?-\\d+)?)?$`,
+		`['"]?(?:,? |: ?| on )lines? ${l()}(?:-\\d+)?(?:,? (?:col(?:umn)?|characters?) ${c()}(?:-\\d+)?)?$`,
 		// foo(339)
 		// foo(339,12)
 		// foo(339, 12)
@@ -107,7 +107,7 @@ const linkSuffixRegex = new Lazy<RegExp>(() => {
 	// These duplicate the regex's above, just without the trailing `$`
 	const lineAndColumnRegexClauses = [
 		`(?::| |['"],)${l()}(:${c()})?`,
-		`['"]?(?:,? |: ?| on )lines? ${l()}(:?-\\d+)?(,? (col(?:umn)?|characters?) ${c()}(:?-\\d+)?)?`,
+		`['"]?(?:,? |: ?| on )lines? ${l()}(?:-\\d+)?(?:,? (?:col(?:umn)?|characters?) ${c()}(?:-\\d+)?)?`,
 		`:? ?[\\[\\(]${l()}(?:, ?${c()})?[\\]\\)]`,
 	];
 

--- a/src/vs/workbench/contrib/terminalContrib/links/browser/terminalLinkParsing.ts
+++ b/src/vs/workbench/contrib/terminalContrib/links/browser/terminalLinkParsing.ts
@@ -53,12 +53,12 @@ const linkSuffixRegexEol = new Lazy<RegExp>(() => {
 		// foo:339
 		// foo:339:12
 		// foo 339
-		// foo 339:12                    [#140780]
+		// foo 339:12                        [#140780]
 		// "foo",339
 		// "foo",339:12
 		`(?::| |['"],)${l()}(:${c()})?$`,
-		// The quotes below are optional [#171652]
-		// "foo", line 339                [#40468]
+		// The quotes below are optional     [#171652]
+		// "foo", line 339                   [#40468]
 		// "foo", line 339, col 12
 		// "foo", line 339, column 12
 		// "foo":line 339
@@ -71,7 +71,10 @@ const linkSuffixRegexEol = new Lazy<RegExp>(() => {
 		// "foo" on line 339, col 12
 		// "foo" on line 339, column 12
 		// "foo" line 339 column 12
-		`['"]?(?:,? |: ?| on )line ${l()}(,? col(?:umn)? ${c()})?$`,
+		// "foo", line 339, character 12     [#171880]
+		// "foo", line 339, characters 12-13 [#171880]
+		// "foo", lines 339-340              [#171880]
+		`['"]?(?:,? |: ?| on )lines? ${l()}(:?-\\d+)?(,? (col(?:umn)?|characters?) ${c()}(:?-\\d+)?)?$`,
 		// foo(339)
 		// foo(339,12)
 		// foo(339, 12)
@@ -101,36 +104,10 @@ const linkSuffixRegex = new Lazy<RegExp>(() => {
 		return `(?<col${ci++}>\\d+)`;
 	}
 
+	// These duplicate the regex's above, just without the trailing `$`
 	const lineAndColumnRegexClauses = [
-		// foo:339
-		// foo:339:12
-		// foo 339
-		// foo 339:12                    [#140780]
-		// "foo",339
-		// "foo",339:12
 		`(?::| |['"],)${l()}(:${c()})?`,
-		// The quotes below are optional [#171652]
-		// foo, line 339                [#40468]
-		// foo, line 339, col 12
-		// foo, line 339, column 12
-		// "foo":line 339
-		// "foo":line 339, col 12
-		// "foo":line 339, column 12
-		// "foo": line 339
-		// "foo": line 339, col 12
-		// "foo": line 339, column 12
-		// "foo" on line 339
-		// "foo" on line 339, col 12
-		// "foo" on line 339, column 12
-		// "foo" line 339 column 12
-		`['"]?(?:,? |: ?| on )line ${l()}(,? col(?:umn)? ${c()})?`,
-		// foo(339)
-		// foo(339,12)
-		// foo(339, 12)
-		// foo (339)
-		//   ...
-		// foo: (339)
-		//   ...
+		`['"]?(?:,? |: ?| on )lines? ${l()}(:?-\\d+)?(,? (col(?:umn)?|characters?) ${c()}(:?-\\d+)?)?`,
 		`:? ?[\\[\\(]${l()}(?:, ?${c()})?[\\]\\)]`,
 	];
 

--- a/src/vs/workbench/contrib/terminalContrib/links/test/browser/terminalLinkParsing.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/links/test/browser/terminalLinkParsing.test.ts
@@ -99,6 +99,11 @@ const testLinks: ITestLink[] = [
 	{ link: 'foo: [339,12]', prefix: undefined, suffix: ': [339,12]', hasRow: true, hasCol: true },
 	{ link: 'foo: [339, 12]', prefix: undefined, suffix: ': [339, 12]', hasRow: true, hasCol: true },
 
+	// OCaml-style
+	{ link: '"foo", line 339, character 12', prefix: '"', suffix: '", line 339, character 12', hasRow: true, hasCol: true },
+	{ link: '"foo", line 339, characters 12-13', prefix: '"', suffix: '", line 339, characters 12-13', hasRow: true, hasCol: true },
+	{ link: '"foo", lines 339-340', prefix: '"', suffix: '", lines 339-340', hasRow: true, hasCol: false },
+
 	// Non-breaking space
 	{ link: 'foo\u00A0339:12', prefix: undefined, suffix: '\u00A0339:12', hasRow: true, hasCol: true },
 	{ link: '"foo" on line 339,\u00A0column 12', prefix: '"', suffix: '" on line 339,\u00A0column 12', hasRow: true, hasCol: true },


### PR DESCRIPTION
Fixes #171880

Currently the end row/col is just ignored, that's tracked in https://github.com/microsoft/vscode/issues/178287

![image](https://user-images.githubusercontent.com/2193314/227662635-b601c487-57af-49b0-94ed-9ff51f8e00df.png)

![image](https://user-images.githubusercontent.com/2193314/227662316-0a069b3f-33a8-47c9-b6f9-dc78f0d57d31.png)

![image](https://user-images.githubusercontent.com/2193314/227662157-c1fbcbae-ca33-4c5e-866d-2ce400773798.png)
