### PR TITLE
Call Stack View: Sort most relevant thread(s) first

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/debugSession.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugSession.ts
@@ -839,14 +839,19 @@ export class DebugSession implements IDebugSession {
 	}
 
 	getAllThreads(): IThread[] {
-		const result: IThread[] = [];
+		const result1: IThread[] = [];
+		const result2: IThread[] = [];
 		this.threadIds.forEach((threadId) => {
 			const thread = this.threads.get(threadId);
 			if (thread) {
-				result.push(thread);
+				if (thread.stoppedDetails && thread.stoppedDetails.reason) {
+					result1.push(thread);
+				} else {
+					result2.push(thread);
+				}
 			}
 		});
-		return result;
+		return result1.concat(result2);
 	}
 
 	clearThreads(removeThreads: boolean, reference: number | undefined = undefined): void {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

# After

Breakpoint just hit, note how all lines of the stack trace are visible.

<img width="325" alt="after" src="https://user-images.githubusercontent.com/158201/227721053-d271ee96-cda0-46f9-a05d-4fb2126d7ffc.png">

# Before

Breakpoint just hit, note how most lines of the stack trace have scrolled out of view.

<img width="325" alt="before" src="https://user-images.githubusercontent.com/158201/227721060-014fce92-5fa8-4415-b296-ebd82fa67b51.png">

# Repro

Repro instructions:
* Clone any repo containing debuggable code with multiple threads. I used <https://github.com/walles/moar>.
* Set a breakpoint you know you will hit, I set mine in some test.
* Start the code and hit the breakpoint.

Before this change, most of your call stack was scrolled out of view at the bottom.

With this change in place, your call stack is mostly visible.

Fixes #178308.