### PR TITLE
fix keycodes on firefox

### DIFF
--- a/src/vs/base/browser/keyboardEvent.ts
+++ b/src/vs/base/browser/keyboardEvent.ts
@@ -25,8 +25,11 @@ function extractKeyCode(e: KeyboardEvent): KeyCode {
 	} else if (browser.isFirefox) {
 		switch (keyCode) {
 			case 59: return KeyCode.Semicolon;
-			case 107: return KeyCode.Equal;
-			case 109: return KeyCode.Minus;
+
+			// based on: https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode#numpad_keys
+			case 107: return KeyCode.NumpadAdd;
+			case 109: return KeyCode.NumpadSubtract;
+
 			case 224:
 				if (platform.isMacintosh) { return KeyCode.Meta; }
 		}

--- a/src/vs/base/browser/keyboardEvent.ts
+++ b/src/vs/base/browser/keyboardEvent.ts
@@ -23,14 +23,12 @@ function extractKeyCode(e: KeyboardEvent): KeyCode {
 	if (keyCode === 3) {
 		return KeyCode.PauseBreak;
 	} else if (browser.isFirefox) {
-		if (keyCode === 59) {
-			return KeyCode.Semicolon;
-		} else if (keyCode === 107) {
-			return KeyCode.Equal;
-		} else if (keyCode === 109) {
-			return KeyCode.Minus;
-		} else if (platform.isMacintosh && keyCode === 224) {
-			return KeyCode.Meta;
+		switch (keyCode) {
+			case 59: return KeyCode.Semicolon;
+			case 107: return KeyCode.Equal;
+			case 109: return KeyCode.Minus;
+			case 224:
+				if (platform.isMacintosh) { return KeyCode.Meta; }
 		}
 	} else if (browser.isWebKit) {
 		if (keyCode === 91) {


### PR DESCRIPTION
- keyboardEvent: refactor: use a switch instead of if-else for clarity
- keyboardEvent: fix translation of a e.keyCode to a virtual keycode

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
