### PR TITLE
keybinding widgets: press escape to clear, press again to hide

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/keybindingWidgets.ts
+++ b/src/vs/workbench/contrib/preferences/browser/keybindingWidgets.ts
@@ -103,6 +103,10 @@ export class KeybindingsSearchWidget extends SearchWidget {
 			return;
 		}
 		if (keyboardEvent.equals(KeyCode.Escape)) {
+			if (this._chords !== null) {
+				this.clear();
+			}
+
 			this._onEscape.fire();
 			return;
 		}
@@ -181,8 +185,8 @@ export class DefineKeybindingWidget extends Widget {
 		this._keybindingInputWidget.startRecordingKeys();
 		this._register(this._keybindingInputWidget.onKeybinding(keybinding => this.onKeybinding(keybinding)));
 		this._register(this._keybindingInputWidget.onEnter(() => this.hide()));
-		this._register(this._keybindingInputWidget.onEscape(() => this.onCancel()));
-		this._register(this._keybindingInputWidget.onBlur(() => this.onCancel()));
+		this._register(this._keybindingInputWidget.onEscape(() => this.onEscape()));
+		this._register(this._keybindingInputWidget.onBlur(() => this.onBlur()));
 
 		this._outputNode = dom.append(this._domNode.domNode, dom.$('.output'));
 		this._showExistingKeybindingsNode = dom.append(this._domNode.domNode, dom.$('.existing'));
@@ -276,8 +280,18 @@ export class DefineKeybindingWidget extends Widget {
 		return label;
 	}
 
-	private onCancel(): void {
+	private onBlur(): void {
 		this._chords = null;
+		this.hide();
+	}
+
+	private onEscape(): void {
+		if (this._chords !== null) {
+			this._chords = null;
+			dom.clearNode(this._outputNode);
+			dom.clearNode(this._showExistingKeybindingsNode);
+			return;
+		}
 		this.hide();
 	}
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Currently, pressing Escape simply closes the "Define Keybinding" widget, but with this PR, the first ESCAPE press clears the input (and related info such as conflicting keybindings), pressing ESCAPE again hides the widget. See: 

https://user-images.githubusercontent.com/16353531/228234095-94db26da-c9e0-494b-8d26-05eff5809aab.mov


