### PR TITLE
fix: extra repls added when debugging js

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/debugSession.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugSession.ts
@@ -139,12 +139,13 @@ export class DebugSession implements IDebugSession {
 		const parent = this._options.parentSession;
 		if (parent) {
 			toDispose.add(parent.onDidEndAdapter(() => {
-				// copy the parent repl and get a new detached repl for this child
-				if (!this.hasSeparateRepl()) {
+				// copy the parent repl and get a new detached repl for this child, and
+				// remove its parent, if it's still running
+				if (!this.hasSeparateRepl() && this.raw?.isInShutdown === false) {
 					this.repl = this.repl.clone();
 					replListener.value = this.repl.onDidChangeElements(() => this._onDidChangeREPLElements.fire());
+					this.parentSession = undefined;
 				}
-				this.parentSession = undefined;
 			}));
 		}
 	}

--- a/src/vs/workbench/contrib/debug/browser/rawDebugSession.ts
+++ b/src/vs/workbench/contrib/debug/browser/rawDebugSession.ts
@@ -172,6 +172,10 @@ export class RawDebugSession implements IDisposable {
 		this.debugAdapter.onRequest(request => this.dispatchRequest(request));
 	}
 
+	get isInShutdown() {
+		return this.inShutdown;
+	}
+
 	get onDidExitAdapter(): Event<AdapterEndEvent> {
 		return this._onDidExitAdapter.event;
 	}


### PR DESCRIPTION
If a child session is shut down or shutting down, don't detach it from its parent.

Fixes #173993

Requires https://github.com/microsoft/vscode-js-debug/pull/1619 to work reliably

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
