### PR TITLE
fix: Update default behavior to make sure keybinding listener runs first #174877

### DIFF
--- a/src/vs/workbench/services/keybinding/browser/keybindingService.ts
+++ b/src/vs/workbench/services/keybinding/browser/keybindingService.ts
@@ -238,12 +238,14 @@ export class WorkbenchKeybindingService extends AbstractKeybindingService {
 			const keyEvent = new StandardKeyboardEvent(e);
 			this._log(`/ Received  keydown event - ${printKeyboardEvent(e)}`);
 			this._log(`| Converted keydown event - ${printStandardKeyboardEvent(keyEvent)}`);
-			const shouldPreventDefault = this._dispatch(keyEvent, keyEvent.target);
-			if (shouldPreventDefault) {
+			const shouldPreventDefaultAndStopPropagation = this._dispatch(keyEvent, keyEvent.target);
+
+			if (shouldPreventDefaultAndStopPropagation) {
 				keyEvent.preventDefault();
+				keyEvent.stopPropagation();
 			}
 			this.isComposingGlobalContextKey.set(false);
-		}));
+		}, true));
 
 		// for single modifier chord keybindings (e.g. shift shift)
 		this._register(dom.addDisposableListener(window, dom.EventType.KEY_UP, (e: KeyboardEvent) => {

--- a/src/vs/workbench/services/keybinding/browser/keybindingService.ts
+++ b/src/vs/workbench/services/keybinding/browser/keybindingService.ts
@@ -239,7 +239,6 @@ export class WorkbenchKeybindingService extends AbstractKeybindingService {
 			this._log(`/ Received  keydown event - ${printKeyboardEvent(e)}`);
 			this._log(`| Converted keydown event - ${printStandardKeyboardEvent(keyEvent)}`);
 			const shouldPreventDefaultAndStopPropagation = this._dispatch(keyEvent, keyEvent.target);
-
 			if (shouldPreventDefaultAndStopPropagation) {
 				keyEvent.preventDefault();
 				keyEvent.stopPropagation();


### PR DESCRIPTION
fix #174877

The keybinding listener is essentially a window listener for key-down events. However, the input file name listener in the explorer view runs first due to default browser behavior, where the event starts at the target and propagates upwards. The bug was when the input file name listener ran first and the keybinding rule wasn't matched due to the input file name listener logic in this example but this can happen with every key down event on any element. Our goal was to have the window key down listener for keybinding run first, and if a certain condition is met (keybind rule match), stop the propagation downwards. To accomplish this, I'm using the optional argument useCapture. By default, this argument is set to false, but when set to true, the registered listener will run at the top level before being dispatched to any EventTarget below it in the DOM tree.
