### PR TITLE
Update Markdown preview styles to prevent `sub` and `sup` from affecting line height

### DIFF
--- a/extensions/markdown-language-features/media/markdown.css
+++ b/extensions/markdown-language-features/media/markdown.css
@@ -98,6 +98,11 @@ body.showEditorSelection li.code-line:hover:before {
 	border-left: 3px solid rgba(255, 160, 0, 1);
 }
 
+/* Prevent `sub` and `sup` elements from affecting line height */
+sub,
+sup {
+	line-height: 0;
+}
 
 ul ul,
 ul ol,


### PR DESCRIPTION
This PR adds a style to the Markdown previews CSS to prevent `sub` and `sup` elements from affecting line height, which currently affects the flow of text lines.

For example:

<img width="1440" alt="Screenshot 2023-03-30 at 12 50 13 AM" src="https://user-images.githubusercontent.com/3684553/228733817-a7d76c88-0588-4abb-98c4-25ea49ced950.png">

(Note the extra vertical space marked in red.)

And then with the proposed CSS applied:

<img width="1440" alt="Screenshot 2023-03-30 at 12 50 41 AM" src="https://user-images.githubusercontent.com/3684553/228733933-1a38277f-5219-4585-9477-4f4b75e8e5e6.png">

---

For reference, [Normalize.css](https://necolas.github.io/normalize.css/8.0.1/normalize.css) (a common CSS reset) does this as well.