### PR TITLE
refactor keybinding resolver

### DIFF
--- a/src/vs/editor/contrib/hover/browser/hover.ts
+++ b/src/vs/editor/contrib/hover/browser/hover.ts
@@ -30,6 +30,7 @@ import { MarkerHoverParticipant } from 'vs/editor/contrib/hover/browser/markerHo
 import 'vs/css!./hover';
 import { InlineSuggestionHintsContentWidget } from 'vs/editor/contrib/inlineCompletions/browser/inlineSuggestionHintsWidget';
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
+import { ResultKind } from 'vs/platform/keybinding/common/keybindingResolver';
 
 export class ModesHoverController implements IEditorContribution {
 
@@ -205,7 +206,7 @@ export class ModesHoverController implements IEditorContribution {
 
 		const resolvedKeyboardEvent = this._keybindingService.softDispatch(e, this._editor.getDomNode());
 		// If the beginning of a multi-chord keybinding is pressed, or the command aims to focus the hover, set the variable to true, otherwise false
-		const mightTriggerFocus = (resolvedKeyboardEvent?.enterMultiChord || (resolvedKeyboardEvent?.commandId === 'editor.action.showHover' && this._contentWidget?.isVisible()));
+		const mightTriggerFocus = (resolvedKeyboardEvent?.kind === ResultKind.MoreChordsNeeded || (resolvedKeyboardEvent && resolvedKeyboardEvent.kind === ResultKind.KbFound && resolvedKeyboardEvent.commandId === 'editor.action.showHover' && this._contentWidget?.isVisible()));
 
 		if (e.keyCode !== KeyCode.Ctrl && e.keyCode !== KeyCode.Alt && e.keyCode !== KeyCode.Meta && e.keyCode !== KeyCode.Shift
 			&& !mightTriggerFocus) {

--- a/src/vs/platform/keybinding/common/abstractKeybindingService.ts
+++ b/src/vs/platform/keybinding/common/abstractKeybindingService.ts
@@ -153,7 +153,7 @@ export abstract class AbstractKeybindingService extends Disposable implements IK
 		}
 
 		const contextValue = this._contextKeyService.getContext(target);
-		const currentChords = this._currentChords.length > 0 ? this._currentChords.map((({ keypress }) => keypress)) : null; // TODO@ulugbekna: adapt `resolve` to accept []
+		const currentChords = this._currentChords.map((({ keypress }) => keypress));
 		return this._getResolver().resolve(contextValue, currentChords, firstChord);
 	}
 
@@ -297,7 +297,7 @@ export abstract class AbstractKeybindingService extends Disposable implements IK
 			currentChords = dispatchKeyname ? [dispatchKeyname] : []; // TODO@ulugbekna: in the `else` case we assign an empty array - make sure `resolve` can handle an empty array well
 		} else {
 			[userPressedChord,] = userKeypress.getDispatchChords();
-			currentChords = this._currentChords.length > 0 ? this._currentChords.map(({ keypress }) => keypress) : null;
+			currentChords = this._currentChords.map(({ keypress }) => keypress);
 		}
 
 		if (userPressedChord === null) {

--- a/src/vs/platform/keybinding/common/keybinding.ts
+++ b/src/vs/platform/keybinding/common/keybinding.ts
@@ -9,7 +9,7 @@ import { KeyCode } from 'vs/base/common/keyCodes';
 import { ResolvedKeybinding, Keybinding } from 'vs/base/common/keybindings';
 import { IContextKeyService, IContextKeyServiceTarget } from 'vs/platform/contextkey/common/contextkey';
 import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
-import { IResolveResult } from 'vs/platform/keybinding/common/keybindingResolver';
+import { ResolutionResult } from 'vs/platform/keybinding/common/keybindingResolver';
 import { ResolvedKeybindingItem } from 'vs/platform/keybinding/common/resolvedKeybindingItem';
 
 export interface IUserFriendlyKeybinding {
@@ -63,7 +63,7 @@ export interface IKeybindingService {
 	/**
 	 * Resolve and dispatch `keyboardEvent`, but do not invoke the command or change inner state.
 	 */
-	softDispatch(keyboardEvent: IKeyboardEvent, target: IContextKeyServiceTarget): IResolveResult | null;
+	softDispatch(keyboardEvent: IKeyboardEvent, target: IContextKeyServiceTarget): ResolutionResult | null;
 
 	dispatchByUserSettingsLabel(userSettingsLabel: string, target: IContextKeyServiceTarget): void;
 

--- a/src/vs/platform/keybinding/common/keybindingResolver.ts
+++ b/src/vs/platform/keybinding/common/keybindingResolver.ts
@@ -300,12 +300,13 @@ export class KeybindingResolver {
 		return items[items.length - 1];
 	}
 
-	public resolve(context: IContext, currentChords: string[] | null, keypress: string): ResolutionResult {
+	public resolve(context: IContext, currentChords: string[], keypress: string): ResolutionResult {
+
 		this._log(`| Resolving ${keypress}${currentChords ? ` chorded from ${currentChords}` : ``}`);
 
 		let lookupMap: ResolvedKeybindingItem[] | null = null;
 
-		if (currentChords === null) {
+		if (currentChords.length === 0) {
 			const candidates = this._map.get(keypress);
 			if (candidates === undefined) {
 				// No bindings with `keypress`
@@ -349,10 +350,10 @@ export class KeybindingResolver {
 			return NoMatchingKb;
 		}
 
-		if (currentChords === null && result.chords.length > 1 && result.chords[1] !== null) { // first chord of a multi-chord KB matched
+		if (currentChords.length === 0 && result.chords.length > 1 && result.chords[1] !== null) { // first chord of a multi-chord KB matched
 			this._log(`\\ From ${lookupMap.length} keybinding entries, matched chord, when: ${printWhenExplanation(result.when)}, source: ${printSourceExplanation(result)}.`);
 			return MoreChordsNeeded;
-		} else if (currentChords !== null && currentChords.length + 1 < result.chords.length) { // prefix (ie, a sequence of chords) of a multi-chord KB matched, eg 2 out of 3 matched - still need one more to dispatch the KB
+		} else if (currentChords.length !== 0 && currentChords.length + 1 < result.chords.length) { // prefix (ie, a sequence of chords) of a multi-chord KB matched, eg 2 out of 3 matched - still need one more to dispatch the KB
 			this._log(`\\ From ${lookupMap.length} keybinding entries, continued chord, when: ${printWhenExplanation(result.when)}, source: ${printSourceExplanation(result)}.`);
 			return MoreChordsNeeded;
 		}

--- a/src/vs/platform/keybinding/common/keybindingResolver.ts
+++ b/src/vs/platform/keybinding/common/keybindingResolver.ts
@@ -283,12 +283,22 @@ export class KeybindingResolver {
 
 	public resolve(context: IContext, currentChords: string[] | null, keypress: string): IResolveResult | null {
 		this._log(`| Resolving ${keypress}${currentChords ? ` chorded from ${currentChords}` : ``}`);
+
 		let lookupMap: ResolvedKeybindingItem[] | null = null;
 
-		if (currentChords !== null) {
+		if (currentChords === null) {
+			const candidates = this._map.get(keypress);
+			if (candidates === undefined) {
+				// No bindings with `keypress`
+				this._log(`\\ No keybinding entries.`);
+				return null;
+			}
+
+			lookupMap = candidates;
+		} else {
 			// Fetch all chord bindings for `currentChords`
 			const candidates = this._map.get(currentChords[0]);
-			if (typeof candidates === 'undefined') {
+			if (candidates === undefined) {
 				// No chords starting with `currentChords`
 				this._log(`\\ No keybinding entries.`);
 				return null;
@@ -312,15 +322,6 @@ export class KeybindingResolver {
 					lookupMap.push(candidate);
 				}
 			}
-		} else {
-			const candidates = this._map.get(keypress);
-			if (typeof candidates === 'undefined') {
-				// No bindings with `keypress`
-				this._log(`\\ No keybinding entries.`);
-				return null;
-			}
-
-			lookupMap = candidates;
 		}
 
 		const result = this._findCommand(context, lookupMap);

--- a/src/vs/platform/keybinding/common/keybindingResolver.ts
+++ b/src/vs/platform/keybinding/common/keybindingResolver.ts
@@ -350,15 +350,14 @@ export class KeybindingResolver {
 			return NoMatchingKb;
 		}
 
-		if (currentChords.length === 0 && result.chords.length > 1 && result.chords[1] !== null) { // first chord of a multi-chord KB matched
-			this._log(`\\ From ${lookupMap.length} keybinding entries, matched chord, when: ${printWhenExplanation(result.when)}, source: ${printSourceExplanation(result)}.`);
-			return MoreChordsNeeded;
-		} else if (currentChords.length !== 0 && currentChords.length + 1 < result.chords.length) { // prefix (ie, a sequence of chords) of a multi-chord KB matched, eg 2 out of 3 matched - still need one more to dispatch the KB
-			this._log(`\\ From ${lookupMap.length} keybinding entries, continued chord, when: ${printWhenExplanation(result.when)}, source: ${printSourceExplanation(result)}.`);
+		if (currentChords.length + 1 /* keypress */ < result.chords.length) {
+			// The chord sequence is not complete
+			this._log(`\\ From ${lookupMap.length} keybinding entries, awaiting ${result.chords.length - currentChords.length - 1} more chord(s), when: ${printWhenExplanation(result.when)}, source: ${printSourceExplanation(result)}.`);
 			return MoreChordsNeeded;
 		}
 
 		this._log(`\\ From ${lookupMap.length} keybinding entries, matched ${result.command}, when: ${printWhenExplanation(result.when)}, source: ${printSourceExplanation(result)}.`);
+
 		return KbFound(result.command, result.commandArgs, result.bubble);
 	}
 

--- a/src/vs/platform/keybinding/test/common/keybindingResolver.test.ts
+++ b/src/vs/platform/keybinding/test/common/keybindingResolver.test.ts
@@ -51,11 +51,11 @@ suite('KeybindingResolver', () => {
 
 		const resolver = new KeybindingResolver([keybindingItem], [], () => { });
 
-		const r1 = resolver.resolve(createContext({ bar: 'baz' }), null, getDispatchStr(runtimeKeybinding));
+		const r1 = resolver.resolve(createContext({ bar: 'baz' }), [], getDispatchStr(runtimeKeybinding));
 		assert.ok(r1.kind === ResultKind.KbFound);
 		assert.strictEqual(r1.commandId, 'yes');
 
-		const r2 = resolver.resolve(createContext({ bar: 'bz' }), null, getDispatchStr(runtimeKeybinding));
+		const r2 = resolver.resolve(createContext({ bar: 'bz' }), [], getDispatchStr(runtimeKeybinding));
 		assert.strictEqual(r2.kind, ResultKind.NoMatchingKb);
 	});
 
@@ -68,7 +68,7 @@ suite('KeybindingResolver', () => {
 
 		const resolver = new KeybindingResolver([keybindingItem], [], () => { });
 
-		const r = resolver.resolve(createContext({ bar: 'baz' }), null, getDispatchStr(runtimeKeybinding));
+		const r = resolver.resolve(createContext({ bar: 'baz' }), [], getDispatchStr(runtimeKeybinding));
 		assert.ok(r.kind === ResultKind.KbFound);
 		assert.strictEqual(r.commandArgs, commandArgs);
 	});
@@ -415,7 +415,7 @@ suite('KeybindingResolver', () => {
 		const testResolve = (ctx: IContext, _expectedKey: number | number[], commandId: string) => {
 			const expectedKeybinding = decodeKeybinding(_expectedKey, OS)!;
 
-			let previousChord: string[] | null = null;
+			const previousChord: string[] = [];
 
 			for (let i = 0, len = expectedKeybinding.chords.length; i < len; i++) {
 
@@ -436,9 +436,6 @@ suite('KeybindingResolver', () => {
 					// if it's not the final chord and not an intermediate, then we should not
 					// find a valid command, and we should enter a chord.
 					assert.ok(result.kind === ResultKind.MoreChordsNeeded, `Enters multi chord for ${commandId} at chord ${i}`);
-				}
-				if (previousChord === null) {
-					previousChord = [];
 				}
 				previousChord.push(chord);
 			}

--- a/src/vs/platform/keybinding/test/common/keybindingResolver.test.ts
+++ b/src/vs/platform/keybinding/test/common/keybindingResolver.test.ts
@@ -73,241 +73,244 @@ suite('KeybindingResolver', () => {
 		assert.strictEqual(r.commandArgs, commandArgs);
 	});
 
-	test('KeybindingResolver.handleRemovals simple 1', () => {
-		const defaults = [
-			kbItem(KeyCode.KeyA, 'yes1', null, ContextKeyExpr.equals('1', 'a'), true)
-		];
-		const overrides = [
-			kbItem(KeyCode.KeyB, 'yes2', null, ContextKeyExpr.equals('2', 'b'), false)
-		];
-		const actual = KeybindingResolver.handleRemovals([...defaults, ...overrides]);
-		assert.deepStrictEqual(actual, [
-			kbItem(KeyCode.KeyA, 'yes1', null, ContextKeyExpr.equals('1', 'a'), true),
-			kbItem(KeyCode.KeyB, 'yes2', null, ContextKeyExpr.equals('2', 'b'), false),
-		]);
-	});
+	suite('handle keybinding removals', () => {
 
-	test('KeybindingResolver.handleRemovals simple 2', () => {
-		const defaults = [
-			kbItem(KeyCode.KeyA, 'yes1', null, ContextKeyExpr.equals('1', 'a'), true),
-			kbItem(KeyCode.KeyB, 'yes2', null, ContextKeyExpr.equals('2', 'b'), true)
-		];
-		const overrides = [
-			kbItem(KeyCode.KeyC, 'yes3', null, ContextKeyExpr.equals('3', 'c'), false)
-		];
-		const actual = KeybindingResolver.handleRemovals([...defaults, ...overrides]);
-		assert.deepStrictEqual(actual, [
-			kbItem(KeyCode.KeyA, 'yes1', null, ContextKeyExpr.equals('1', 'a'), true),
-			kbItem(KeyCode.KeyB, 'yes2', null, ContextKeyExpr.equals('2', 'b'), true),
-			kbItem(KeyCode.KeyC, 'yes3', null, ContextKeyExpr.equals('3', 'c'), false),
-		]);
-	});
+		test('simple 1', () => {
+			const defaults = [
+				kbItem(KeyCode.KeyA, 'yes1', null, ContextKeyExpr.equals('1', 'a'), true)
+			];
+			const overrides = [
+				kbItem(KeyCode.KeyB, 'yes2', null, ContextKeyExpr.equals('2', 'b'), false)
+			];
+			const actual = KeybindingResolver.handleRemovals([...defaults, ...overrides]);
+			assert.deepStrictEqual(actual, [
+				kbItem(KeyCode.KeyA, 'yes1', null, ContextKeyExpr.equals('1', 'a'), true),
+				kbItem(KeyCode.KeyB, 'yes2', null, ContextKeyExpr.equals('2', 'b'), false),
+			]);
+		});
 
-	test('KeybindingResolver.handleRemovals removal with not matching when', () => {
-		const defaults = [
-			kbItem(KeyCode.KeyA, 'yes1', null, ContextKeyExpr.equals('1', 'a'), true),
-			kbItem(KeyCode.KeyB, 'yes2', null, ContextKeyExpr.equals('2', 'b'), true)
-		];
-		const overrides = [
-			kbItem(KeyCode.KeyA, '-yes1', null, ContextKeyExpr.equals('1', 'b'), false)
-		];
-		const actual = KeybindingResolver.handleRemovals([...defaults, ...overrides]);
-		assert.deepStrictEqual(actual, [
-			kbItem(KeyCode.KeyA, 'yes1', null, ContextKeyExpr.equals('1', 'a'), true),
-			kbItem(KeyCode.KeyB, 'yes2', null, ContextKeyExpr.equals('2', 'b'), true)
-		]);
-	});
+		test('simple 2', () => {
+			const defaults = [
+				kbItem(KeyCode.KeyA, 'yes1', null, ContextKeyExpr.equals('1', 'a'), true),
+				kbItem(KeyCode.KeyB, 'yes2', null, ContextKeyExpr.equals('2', 'b'), true)
+			];
+			const overrides = [
+				kbItem(KeyCode.KeyC, 'yes3', null, ContextKeyExpr.equals('3', 'c'), false)
+			];
+			const actual = KeybindingResolver.handleRemovals([...defaults, ...overrides]);
+			assert.deepStrictEqual(actual, [
+				kbItem(KeyCode.KeyA, 'yes1', null, ContextKeyExpr.equals('1', 'a'), true),
+				kbItem(KeyCode.KeyB, 'yes2', null, ContextKeyExpr.equals('2', 'b'), true),
+				kbItem(KeyCode.KeyC, 'yes3', null, ContextKeyExpr.equals('3', 'c'), false),
+			]);
+		});
 
-	test('KeybindingResolver.handleRemovals removal with not matching keybinding', () => {
-		const defaults = [
-			kbItem(KeyCode.KeyA, 'yes1', null, ContextKeyExpr.equals('1', 'a'), true),
-			kbItem(KeyCode.KeyB, 'yes2', null, ContextKeyExpr.equals('2', 'b'), true)
-		];
-		const overrides = [
-			kbItem(KeyCode.KeyB, '-yes1', null, ContextKeyExpr.equals('1', 'a'), false)
-		];
-		const actual = KeybindingResolver.handleRemovals([...defaults, ...overrides]);
-		assert.deepStrictEqual(actual, [
-			kbItem(KeyCode.KeyA, 'yes1', null, ContextKeyExpr.equals('1', 'a'), true),
-			kbItem(KeyCode.KeyB, 'yes2', null, ContextKeyExpr.equals('2', 'b'), true)
-		]);
-	});
+		test('removal with not matching when', () => {
+			const defaults = [
+				kbItem(KeyCode.KeyA, 'yes1', null, ContextKeyExpr.equals('1', 'a'), true),
+				kbItem(KeyCode.KeyB, 'yes2', null, ContextKeyExpr.equals('2', 'b'), true)
+			];
+			const overrides = [
+				kbItem(KeyCode.KeyA, '-yes1', null, ContextKeyExpr.equals('1', 'b'), false)
+			];
+			const actual = KeybindingResolver.handleRemovals([...defaults, ...overrides]);
+			assert.deepStrictEqual(actual, [
+				kbItem(KeyCode.KeyA, 'yes1', null, ContextKeyExpr.equals('1', 'a'), true),
+				kbItem(KeyCode.KeyB, 'yes2', null, ContextKeyExpr.equals('2', 'b'), true)
+			]);
+		});
 
-	test('KeybindingResolver.handleRemovals removal with matching keybinding and when', () => {
-		const defaults = [
-			kbItem(KeyCode.KeyA, 'yes1', null, ContextKeyExpr.equals('1', 'a'), true),
-			kbItem(KeyCode.KeyB, 'yes2', null, ContextKeyExpr.equals('2', 'b'), true)
-		];
-		const overrides = [
-			kbItem(KeyCode.KeyA, '-yes1', null, ContextKeyExpr.equals('1', 'a'), false)
-		];
-		const actual = KeybindingResolver.handleRemovals([...defaults, ...overrides]);
-		assert.deepStrictEqual(actual, [
-			kbItem(KeyCode.KeyB, 'yes2', null, ContextKeyExpr.equals('2', 'b'), true)
-		]);
-	});
+		test('removal with not matching keybinding', () => {
+			const defaults = [
+				kbItem(KeyCode.KeyA, 'yes1', null, ContextKeyExpr.equals('1', 'a'), true),
+				kbItem(KeyCode.KeyB, 'yes2', null, ContextKeyExpr.equals('2', 'b'), true)
+			];
+			const overrides = [
+				kbItem(KeyCode.KeyB, '-yes1', null, ContextKeyExpr.equals('1', 'a'), false)
+			];
+			const actual = KeybindingResolver.handleRemovals([...defaults, ...overrides]);
+			assert.deepStrictEqual(actual, [
+				kbItem(KeyCode.KeyA, 'yes1', null, ContextKeyExpr.equals('1', 'a'), true),
+				kbItem(KeyCode.KeyB, 'yes2', null, ContextKeyExpr.equals('2', 'b'), true)
+			]);
+		});
 
-	test('KeybindingResolver.handleRemovals removal with unspecified keybinding', () => {
-		const defaults = [
-			kbItem(KeyCode.KeyA, 'yes1', null, ContextKeyExpr.equals('1', 'a'), true),
-			kbItem(KeyCode.KeyB, 'yes2', null, ContextKeyExpr.equals('2', 'b'), true)
-		];
-		const overrides = [
-			kbItem(0, '-yes1', null, ContextKeyExpr.equals('1', 'a'), false)
-		];
-		const actual = KeybindingResolver.handleRemovals([...defaults, ...overrides]);
-		assert.deepStrictEqual(actual, [
-			kbItem(KeyCode.KeyB, 'yes2', null, ContextKeyExpr.equals('2', 'b'), true)
-		]);
-	});
+		test('removal with matching keybinding and when', () => {
+			const defaults = [
+				kbItem(KeyCode.KeyA, 'yes1', null, ContextKeyExpr.equals('1', 'a'), true),
+				kbItem(KeyCode.KeyB, 'yes2', null, ContextKeyExpr.equals('2', 'b'), true)
+			];
+			const overrides = [
+				kbItem(KeyCode.KeyA, '-yes1', null, ContextKeyExpr.equals('1', 'a'), false)
+			];
+			const actual = KeybindingResolver.handleRemovals([...defaults, ...overrides]);
+			assert.deepStrictEqual(actual, [
+				kbItem(KeyCode.KeyB, 'yes2', null, ContextKeyExpr.equals('2', 'b'), true)
+			]);
+		});
 
-	test('KeybindingResolver.handleRemovals removal with unspecified when', () => {
-		const defaults = [
-			kbItem(KeyCode.KeyA, 'yes1', null, ContextKeyExpr.equals('1', 'a'), true),
-			kbItem(KeyCode.KeyB, 'yes2', null, ContextKeyExpr.equals('2', 'b'), true)
-		];
-		const overrides = [
-			kbItem(KeyCode.KeyA, '-yes1', null, undefined, false)
-		];
-		const actual = KeybindingResolver.handleRemovals([...defaults, ...overrides]);
-		assert.deepStrictEqual(actual, [
-			kbItem(KeyCode.KeyB, 'yes2', null, ContextKeyExpr.equals('2', 'b'), true)
-		]);
-	});
+		test('removal with unspecified keybinding', () => {
+			const defaults = [
+				kbItem(KeyCode.KeyA, 'yes1', null, ContextKeyExpr.equals('1', 'a'), true),
+				kbItem(KeyCode.KeyB, 'yes2', null, ContextKeyExpr.equals('2', 'b'), true)
+			];
+			const overrides = [
+				kbItem(0, '-yes1', null, ContextKeyExpr.equals('1', 'a'), false)
+			];
+			const actual = KeybindingResolver.handleRemovals([...defaults, ...overrides]);
+			assert.deepStrictEqual(actual, [
+				kbItem(KeyCode.KeyB, 'yes2', null, ContextKeyExpr.equals('2', 'b'), true)
+			]);
+		});
 
-	test('KeybindingResolver.handleRemovals removal with unspecified when and unspecified keybinding', () => {
-		const defaults = [
-			kbItem(KeyCode.KeyA, 'yes1', null, ContextKeyExpr.equals('1', 'a'), true),
-			kbItem(KeyCode.KeyB, 'yes2', null, ContextKeyExpr.equals('2', 'b'), true)
-		];
-		const overrides = [
-			kbItem(0, '-yes1', null, undefined, false)
-		];
-		const actual = KeybindingResolver.handleRemovals([...defaults, ...overrides]);
-		assert.deepStrictEqual(actual, [
-			kbItem(KeyCode.KeyB, 'yes2', null, ContextKeyExpr.equals('2', 'b'), true)
-		]);
-	});
+		test('removal with unspecified when', () => {
+			const defaults = [
+				kbItem(KeyCode.KeyA, 'yes1', null, ContextKeyExpr.equals('1', 'a'), true),
+				kbItem(KeyCode.KeyB, 'yes2', null, ContextKeyExpr.equals('2', 'b'), true)
+			];
+			const overrides = [
+				kbItem(KeyCode.KeyA, '-yes1', null, undefined, false)
+			];
+			const actual = KeybindingResolver.handleRemovals([...defaults, ...overrides]);
+			assert.deepStrictEqual(actual, [
+				kbItem(KeyCode.KeyB, 'yes2', null, ContextKeyExpr.equals('2', 'b'), true)
+			]);
+		});
 
-	test('issue #138997 KeybindingResolver.handleRemovals removal in default list', () => {
-		const defaults = [
-			kbItem(KeyCode.KeyA, 'yes1', null, undefined, true),
-			kbItem(KeyCode.KeyB, 'yes2', null, undefined, true),
-			kbItem(0, '-yes1', null, undefined, false)
-		];
-		const overrides: ResolvedKeybindingItem[] = [];
-		const actual = KeybindingResolver.handleRemovals([...defaults, ...overrides]);
-		assert.deepStrictEqual(actual, [
-			kbItem(KeyCode.KeyB, 'yes2', null, undefined, true)
-		]);
-	});
+		test('removal with unspecified when and unspecified keybinding', () => {
+			const defaults = [
+				kbItem(KeyCode.KeyA, 'yes1', null, ContextKeyExpr.equals('1', 'a'), true),
+				kbItem(KeyCode.KeyB, 'yes2', null, ContextKeyExpr.equals('2', 'b'), true)
+			];
+			const overrides = [
+				kbItem(0, '-yes1', null, undefined, false)
+			];
+			const actual = KeybindingResolver.handleRemovals([...defaults, ...overrides]);
+			assert.deepStrictEqual(actual, [
+				kbItem(KeyCode.KeyB, 'yes2', null, ContextKeyExpr.equals('2', 'b'), true)
+			]);
+		});
 
-	test('issue #612#issuecomment-222109084 cannot remove keybindings for commands with ^', () => {
-		const defaults = [
-			kbItem(KeyCode.KeyA, '^yes1', null, ContextKeyExpr.equals('1', 'a'), true),
-			kbItem(KeyCode.KeyB, 'yes2', null, ContextKeyExpr.equals('2', 'b'), true)
-		];
-		const overrides = [
-			kbItem(KeyCode.KeyA, '-yes1', null, undefined, false)
-		];
-		const actual = KeybindingResolver.handleRemovals([...defaults, ...overrides]);
-		assert.deepStrictEqual(actual, [
-			kbItem(KeyCode.KeyB, 'yes2', null, ContextKeyExpr.equals('2', 'b'), true)
-		]);
-	});
+		test('issue #138997 - removal in default list', () => {
+			const defaults = [
+				kbItem(KeyCode.KeyA, 'yes1', null, undefined, true),
+				kbItem(KeyCode.KeyB, 'yes2', null, undefined, true),
+				kbItem(0, '-yes1', null, undefined, false)
+			];
+			const overrides: ResolvedKeybindingItem[] = [];
+			const actual = KeybindingResolver.handleRemovals([...defaults, ...overrides]);
+			assert.deepStrictEqual(actual, [
+				kbItem(KeyCode.KeyB, 'yes2', null, undefined, true)
+			]);
+		});
 
-	test('issue #140884 Unable to reassign F1 as keybinding for Show All Commands', () => {
-		const defaults = [
-			kbItem(KeyCode.KeyA, 'command1', null, undefined, true),
-		];
-		const overrides = [
-			kbItem(KeyCode.KeyA, '-command1', null, undefined, false),
-			kbItem(KeyCode.KeyA, 'command1', null, undefined, false),
-		];
-		const actual = KeybindingResolver.handleRemovals([...defaults, ...overrides]);
-		assert.deepStrictEqual(actual, [
-			kbItem(KeyCode.KeyA, 'command1', null, undefined, false)
-		]);
-	});
+		test('issue #612#issuecomment-222109084 cannot remove keybindings for commands with ^', () => {
+			const defaults = [
+				kbItem(KeyCode.KeyA, '^yes1', null, ContextKeyExpr.equals('1', 'a'), true),
+				kbItem(KeyCode.KeyB, 'yes2', null, ContextKeyExpr.equals('2', 'b'), true)
+			];
+			const overrides = [
+				kbItem(KeyCode.KeyA, '-yes1', null, undefined, false)
+			];
+			const actual = KeybindingResolver.handleRemovals([...defaults, ...overrides]);
+			assert.deepStrictEqual(actual, [
+				kbItem(KeyCode.KeyB, 'yes2', null, ContextKeyExpr.equals('2', 'b'), true)
+			]);
+		});
 
-	test('issue #141638: Keyboard Shortcuts: Change When Expression might actually remove keybinding in Insiders', () => {
-		const defaults = [
-			kbItem(KeyCode.KeyA, 'command1', null, undefined, true),
-		];
-		const overrides = [
-			kbItem(KeyCode.KeyA, 'command1', null, ContextKeyExpr.equals('a', '1'), false),
-			kbItem(KeyCode.KeyA, '-command1', null, undefined, false),
-		];
-		const actual = KeybindingResolver.handleRemovals([...defaults, ...overrides]);
-		assert.deepStrictEqual(actual, [
-			kbItem(KeyCode.KeyA, 'command1', null, ContextKeyExpr.equals('a', '1'), false)
-		]);
-	});
+		test('issue #140884 Unable to reassign F1 as keybinding for Show All Commands', () => {
+			const defaults = [
+				kbItem(KeyCode.KeyA, 'command1', null, undefined, true),
+			];
+			const overrides = [
+				kbItem(KeyCode.KeyA, '-command1', null, undefined, false),
+				kbItem(KeyCode.KeyA, 'command1', null, undefined, false),
+			];
+			const actual = KeybindingResolver.handleRemovals([...defaults, ...overrides]);
+			assert.deepStrictEqual(actual, [
+				kbItem(KeyCode.KeyA, 'command1', null, undefined, false)
+			]);
+		});
 
-	test('issue #157751: Auto-quoting of context keys prevents removal of keybindings via UI', () => {
-		const defaults = [
-			kbItem(KeyCode.KeyA, 'command1', null, ContextKeyExpr.deserialize(`editorTextFocus && activeEditor != workbench.editor.notebook && editorLangId in julia.supportedLanguageIds`), true),
-		];
-		const overrides = [
-			kbItem(KeyCode.KeyA, '-command1', null, ContextKeyExpr.deserialize(`editorTextFocus && activeEditor != 'workbench.editor.notebook' && editorLangId in 'julia.supportedLanguageIds'`), false),
-		];
-		const actual = KeybindingResolver.handleRemovals([...defaults, ...overrides]);
-		assert.deepStrictEqual(actual, []);
-	});
+		test('issue #141638: Keyboard Shortcuts: Change When Expression might actually remove keybinding in Insiders', () => {
+			const defaults = [
+				kbItem(KeyCode.KeyA, 'command1', null, undefined, true),
+			];
+			const overrides = [
+				kbItem(KeyCode.KeyA, 'command1', null, ContextKeyExpr.equals('a', '1'), false),
+				kbItem(KeyCode.KeyA, '-command1', null, undefined, false),
+			];
+			const actual = KeybindingResolver.handleRemovals([...defaults, ...overrides]);
+			assert.deepStrictEqual(actual, [
+				kbItem(KeyCode.KeyA, 'command1', null, ContextKeyExpr.equals('a', '1'), false)
+			]);
+		});
 
-	test('issue #160604: Remove keybindings with when clause does not work', () => {
-		const defaults = [
-			kbItem(KeyCode.KeyA, 'command1', null, undefined, true),
-		];
-		const overrides = [
-			kbItem(KeyCode.KeyA, '-command1', null, ContextKeyExpr.true(), false),
-		];
-		const actual = KeybindingResolver.handleRemovals([...defaults, ...overrides]);
-		assert.deepStrictEqual(actual, []);
-	});
+		test('issue #157751: Auto-quoting of context keys prevents removal of keybindings via UI', () => {
+			const defaults = [
+				kbItem(KeyCode.KeyA, 'command1', null, ContextKeyExpr.deserialize(`editorTextFocus && activeEditor != workbench.editor.notebook && editorLangId in julia.supportedLanguageIds`), true),
+			];
+			const overrides = [
+				kbItem(KeyCode.KeyA, '-command1', null, ContextKeyExpr.deserialize(`editorTextFocus && activeEditor != 'workbench.editor.notebook' && editorLangId in 'julia.supportedLanguageIds'`), false),
+			];
+			const actual = KeybindingResolver.handleRemovals([...defaults, ...overrides]);
+			assert.deepStrictEqual(actual, []);
+		});
 
-	test('contextIsEntirelyIncluded', () => {
-		const toContextKeyExpression = (expr: ContextKeyExpression | string | null) => {
-			if (typeof expr === 'string' || !expr) {
-				return ContextKeyExpr.deserialize(expr);
-			}
-			return expr;
-		};
-		const assertIsIncluded = (a: ContextKeyExpression | string | null, b: ContextKeyExpression | string | null) => {
-			assert.strictEqual(KeybindingResolver.whenIsEntirelyIncluded(toContextKeyExpression(a), toContextKeyExpression(b)), true);
-		};
-		const assertIsNotIncluded = (a: ContextKeyExpression | string | null, b: ContextKeyExpression | string | null) => {
-			assert.strictEqual(KeybindingResolver.whenIsEntirelyIncluded(toContextKeyExpression(a), toContextKeyExpression(b)), false);
-		};
+		test('issue #160604: Remove keybindings with when clause does not work', () => {
+			const defaults = [
+				kbItem(KeyCode.KeyA, 'command1', null, undefined, true),
+			];
+			const overrides = [
+				kbItem(KeyCode.KeyA, '-command1', null, ContextKeyExpr.true(), false),
+			];
+			const actual = KeybindingResolver.handleRemovals([...defaults, ...overrides]);
+			assert.deepStrictEqual(actual, []);
+		});
 
-		assertIsIncluded(null, null);
-		assertIsIncluded(null, ContextKeyExpr.true());
-		assertIsIncluded(ContextKeyExpr.true(), null);
-		assertIsIncluded(ContextKeyExpr.true(), ContextKeyExpr.true());
-		assertIsIncluded('key1', null);
-		assertIsIncluded('key1', '');
-		assertIsIncluded('key1', 'key1');
-		assertIsIncluded('key1', ContextKeyExpr.true());
-		assertIsIncluded('!key1', '');
-		assertIsIncluded('!key1', '!key1');
-		assertIsIncluded('key2', '');
-		assertIsIncluded('key2', 'key2');
-		assertIsIncluded('key1 && key1 && key2 && key2', 'key2');
-		assertIsIncluded('key1 && key2', 'key2');
-		assertIsIncluded('key1 && key2', 'key1');
-		assertIsIncluded('key1 && key2', '');
-		assertIsIncluded('key1', 'key1 || key2');
-		assertIsIncluded('key1 || !key1', 'key2 || !key2');
-		assertIsIncluded('key1', 'key1 || key2 && key3');
+		test('contextIsEntirelyIncluded', () => {
+			const toContextKeyExpression = (expr: ContextKeyExpression | string | null) => {
+				if (typeof expr === 'string' || !expr) {
+					return ContextKeyExpr.deserialize(expr);
+				}
+				return expr;
+			};
+			const assertIsIncluded = (a: ContextKeyExpression | string | null, b: ContextKeyExpression | string | null) => {
+				assert.strictEqual(KeybindingResolver.whenIsEntirelyIncluded(toContextKeyExpression(a), toContextKeyExpression(b)), true);
+			};
+			const assertIsNotIncluded = (a: ContextKeyExpression | string | null, b: ContextKeyExpression | string | null) => {
+				assert.strictEqual(KeybindingResolver.whenIsEntirelyIncluded(toContextKeyExpression(a), toContextKeyExpression(b)), false);
+			};
 
-		assertIsNotIncluded('key1', '!key1');
-		assertIsNotIncluded('!key1', 'key1');
-		assertIsNotIncluded('key1 && key2', 'key3');
-		assertIsNotIncluded('key1 && key2', 'key4');
-		assertIsNotIncluded('key1', 'key2');
-		assertIsNotIncluded('key1 || key2', 'key2');
-		assertIsNotIncluded('', 'key2');
-		assertIsNotIncluded(null, 'key2');
+			assertIsIncluded(null, null);
+			assertIsIncluded(null, ContextKeyExpr.true());
+			assertIsIncluded(ContextKeyExpr.true(), null);
+			assertIsIncluded(ContextKeyExpr.true(), ContextKeyExpr.true());
+			assertIsIncluded('key1', null);
+			assertIsIncluded('key1', '');
+			assertIsIncluded('key1', 'key1');
+			assertIsIncluded('key1', ContextKeyExpr.true());
+			assertIsIncluded('!key1', '');
+			assertIsIncluded('!key1', '!key1');
+			assertIsIncluded('key2', '');
+			assertIsIncluded('key2', 'key2');
+			assertIsIncluded('key1 && key1 && key2 && key2', 'key2');
+			assertIsIncluded('key1 && key2', 'key2');
+			assertIsIncluded('key1 && key2', 'key1');
+			assertIsIncluded('key1 && key2', '');
+			assertIsIncluded('key1', 'key1 || key2');
+			assertIsIncluded('key1 || !key1', 'key2 || !key2');
+			assertIsIncluded('key1', 'key1 || key2 && key3');
+
+			assertIsNotIncluded('key1', '!key1');
+			assertIsNotIncluded('!key1', 'key1');
+			assertIsNotIncluded('key1 && key2', 'key3');
+			assertIsNotIncluded('key1 && key2', 'key4');
+			assertIsNotIncluded('key1', 'key2');
+			assertIsNotIncluded('key1 || key2', 'key2');
+			assertIsNotIncluded('', 'key2');
+			assertIsNotIncluded(null, 'key2');
+		});
 	});
 
 	test('resolve command', () => {

--- a/src/vs/platform/keybinding/test/common/keybindingResolver.test.ts
+++ b/src/vs/platform/keybinding/test/common/keybindingResolver.test.ts
@@ -381,25 +381,35 @@ suite('KeybindingResolver', () => {
 				undefined
 			),
 			_kbItem(
-				KeyChord(KeyMod.CtrlCmd | KeyCode.KeyK, KeyMod.CtrlCmd | KeyCode.KeyC),
+				KeyChord(KeyMod.CtrlCmd | KeyCode.KeyK, KeyMod.CtrlCmd | KeyCode.KeyC), // cmd+k cmd+c
 				'comment lines',
 				undefined
 			),
 			_kbItem(
-				KeyChord(KeyMod.CtrlCmd | KeyCode.KeyG, KeyMod.CtrlCmd | KeyCode.KeyC),
+				KeyChord(KeyMod.CtrlCmd | KeyCode.KeyG, KeyMod.CtrlCmd | KeyCode.KeyC), // cmd+g cmd+c
 				'unreachablechord',
 				undefined
 			),
 			_kbItem(
-				KeyMod.CtrlCmd | KeyCode.KeyG,
+				KeyMod.CtrlCmd | KeyCode.KeyG, // cmd+g
 				'eleven',
 				undefined
 			),
 			_kbItem(
-				[KeyMod.CtrlCmd | KeyCode.KeyK, KeyCode.KeyA, KeyCode.KeyB],
+				[KeyMod.CtrlCmd | KeyCode.KeyK, KeyCode.KeyA, KeyCode.KeyB], // cmd+k a b
 				'long multi chord',
 				undefined
 			),
+			_kbItem(
+				[KeyMod.CtrlCmd | KeyCode.KeyB, KeyMod.CtrlCmd | KeyCode.KeyC], // cmd+b cmd+c
+				'shadowed by long-multi-chord-2',
+				undefined
+			),
+			_kbItem(
+				[KeyMod.CtrlCmd | KeyCode.KeyB, KeyMod.CtrlCmd | KeyCode.KeyC, KeyCode.KeyI], // cmd+b cmd+c i
+				'long-multi-chord-2',
+				undefined
+			)
 		];
 
 		const resolver = new KeybindingResolver(items, [], () => { });
@@ -444,40 +454,67 @@ suite('KeybindingResolver', () => {
 			}
 		};
 
-		test('resolve command - several', () => {
-
+		test('resolve command - 1', () => {
 			testKbLookupByCommand('first', []);
+		});
 
+		test('resolve command - 2', () => {
 			testKbLookupByCommand('second', [KeyCode.KeyZ, KeyCode.KeyX]);
 			testResolve(createContext({ key2: true }), KeyCode.KeyX, 'second');
 			testResolve(createContext({}), KeyCode.KeyZ, 'second');
+		});
 
+		test('resolve command - 3', () => {
 			testKbLookupByCommand('third', [KeyCode.KeyX]);
 			testResolve(createContext({ key3: true }), KeyCode.KeyX, 'third');
+		});
 
+		test('resolve command - 4', () => {
 			testKbLookupByCommand('fourth', []);
+		});
 
+		test('resolve command - 5', () => {
 			testKbLookupByCommand('fifth', [KeyChord(KeyMod.CtrlCmd | KeyCode.KeyY, KeyCode.KeyZ)]);
 			testResolve(createContext({}), KeyChord(KeyMod.CtrlCmd | KeyCode.KeyY, KeyCode.KeyZ), 'fifth');
+		});
 
+		test('resolve command - 6', () => {
 			testKbLookupByCommand('seventh', [KeyChord(KeyMod.CtrlCmd | KeyCode.KeyK, KeyMod.CtrlCmd | KeyCode.KeyK)]);
 			testResolve(createContext({}), KeyChord(KeyMod.CtrlCmd | KeyCode.KeyK, KeyMod.CtrlCmd | KeyCode.KeyK), 'seventh');
+		});
 
+		test('resolve command - 7', () => {
 			testKbLookupByCommand('uncomment lines', [KeyChord(KeyMod.CtrlCmd | KeyCode.KeyK, KeyMod.CtrlCmd | KeyCode.KeyU)]);
 			testResolve(createContext({}), KeyChord(KeyMod.CtrlCmd | KeyCode.KeyK, KeyMod.CtrlCmd | KeyCode.KeyU), 'uncomment lines');
+		});
 
+		test('resolve command - 8', () => {
 			testKbLookupByCommand('comment lines', [KeyChord(KeyMod.CtrlCmd | KeyCode.KeyK, KeyMod.CtrlCmd | KeyCode.KeyC)]);
 			testResolve(createContext({}), KeyChord(KeyMod.CtrlCmd | KeyCode.KeyK, KeyMod.CtrlCmd | KeyCode.KeyC), 'comment lines');
+		});
 
+		test('resolve command - 9', () => {
 			testKbLookupByCommand('unreachablechord', []);
+		});
 
+		test('resolve command - 10', () => {
 			testKbLookupByCommand('eleven', [KeyMod.CtrlCmd | KeyCode.KeyG]);
 			testResolve(createContext({}), KeyMod.CtrlCmd | KeyCode.KeyG, 'eleven');
+		});
 
+		test('resolve command - 11', () => {
 			testKbLookupByCommand('sixth', []);
+		});
 
+		test('resolve command - 12', () => {
 			testKbLookupByCommand('long multi chord', [[KeyMod.CtrlCmd | KeyCode.KeyK, KeyCode.KeyA, KeyCode.KeyB]]);
 			testResolve(createContext({}), [KeyMod.CtrlCmd | KeyCode.KeyK, KeyCode.KeyA, KeyCode.KeyB], 'long multi chord');
+		});
+
+		const emptyContext = createContext({});
+
+		test('KBs having common prefix - the one defined later is returned', () => {
+			testResolve(emptyContext, [KeyMod.CtrlCmd | KeyCode.KeyB, KeyMod.CtrlCmd | KeyCode.KeyC, KeyCode.KeyI], 'long-multi-chord-2');
 		});
 	});
 });

--- a/src/vs/platform/keybinding/test/common/keybindingResolver.test.ts
+++ b/src/vs/platform/keybinding/test/common/keybindingResolver.test.ts
@@ -313,7 +313,7 @@ suite('KeybindingResolver', () => {
 		});
 	});
 
-	test('resolve command', () => {
+	suite('resolve command', () => {
 
 		function _kbItem(keybinding: number | number[], command: string, when: ContextKeyExpression | undefined): ResolvedKeybindingItem {
 			return kbItem(keybinding, command, null, when, true);
@@ -404,7 +404,7 @@ suite('KeybindingResolver', () => {
 
 		const resolver = new KeybindingResolver(items, [], () => { });
 
-		const testKey = (commandId: string, expectedKeys: number[] | number[][]) => {
+		const testKbLookupByCommand = (commandId: string, expectedKeys: number[] | number[][]) => {
 			// Test lookup
 			const lookupResult = resolver.lookupKeybindings(commandId);
 			assert.strictEqual(lookupResult.length, expectedKeys.length, 'Length mismatch @ commandId ' + commandId);
@@ -444,37 +444,40 @@ suite('KeybindingResolver', () => {
 			}
 		};
 
-		testKey('first', []);
+		test('resolve command - several', () => {
 
-		testKey('second', [KeyCode.KeyZ, KeyCode.KeyX]);
-		testResolve(createContext({ key2: true }), KeyCode.KeyX, 'second');
-		testResolve(createContext({}), KeyCode.KeyZ, 'second');
+			testKbLookupByCommand('first', []);
 
-		testKey('third', [KeyCode.KeyX]);
-		testResolve(createContext({ key3: true }), KeyCode.KeyX, 'third');
+			testKbLookupByCommand('second', [KeyCode.KeyZ, KeyCode.KeyX]);
+			testResolve(createContext({ key2: true }), KeyCode.KeyX, 'second');
+			testResolve(createContext({}), KeyCode.KeyZ, 'second');
 
-		testKey('fourth', []);
+			testKbLookupByCommand('third', [KeyCode.KeyX]);
+			testResolve(createContext({ key3: true }), KeyCode.KeyX, 'third');
 
-		testKey('fifth', [KeyChord(KeyMod.CtrlCmd | KeyCode.KeyY, KeyCode.KeyZ)]);
-		testResolve(createContext({}), KeyChord(KeyMod.CtrlCmd | KeyCode.KeyY, KeyCode.KeyZ), 'fifth');
+			testKbLookupByCommand('fourth', []);
 
-		testKey('seventh', [KeyChord(KeyMod.CtrlCmd | KeyCode.KeyK, KeyMod.CtrlCmd | KeyCode.KeyK)]);
-		testResolve(createContext({}), KeyChord(KeyMod.CtrlCmd | KeyCode.KeyK, KeyMod.CtrlCmd | KeyCode.KeyK), 'seventh');
+			testKbLookupByCommand('fifth', [KeyChord(KeyMod.CtrlCmd | KeyCode.KeyY, KeyCode.KeyZ)]);
+			testResolve(createContext({}), KeyChord(KeyMod.CtrlCmd | KeyCode.KeyY, KeyCode.KeyZ), 'fifth');
 
-		testKey('uncomment lines', [KeyChord(KeyMod.CtrlCmd | KeyCode.KeyK, KeyMod.CtrlCmd | KeyCode.KeyU)]);
-		testResolve(createContext({}), KeyChord(KeyMod.CtrlCmd | KeyCode.KeyK, KeyMod.CtrlCmd | KeyCode.KeyU), 'uncomment lines');
+			testKbLookupByCommand('seventh', [KeyChord(KeyMod.CtrlCmd | KeyCode.KeyK, KeyMod.CtrlCmd | KeyCode.KeyK)]);
+			testResolve(createContext({}), KeyChord(KeyMod.CtrlCmd | KeyCode.KeyK, KeyMod.CtrlCmd | KeyCode.KeyK), 'seventh');
 
-		testKey('comment lines', [KeyChord(KeyMod.CtrlCmd | KeyCode.KeyK, KeyMod.CtrlCmd | KeyCode.KeyC)]);
-		testResolve(createContext({}), KeyChord(KeyMod.CtrlCmd | KeyCode.KeyK, KeyMod.CtrlCmd | KeyCode.KeyC), 'comment lines');
+			testKbLookupByCommand('uncomment lines', [KeyChord(KeyMod.CtrlCmd | KeyCode.KeyK, KeyMod.CtrlCmd | KeyCode.KeyU)]);
+			testResolve(createContext({}), KeyChord(KeyMod.CtrlCmd | KeyCode.KeyK, KeyMod.CtrlCmd | KeyCode.KeyU), 'uncomment lines');
 
-		testKey('unreachablechord', []);
+			testKbLookupByCommand('comment lines', [KeyChord(KeyMod.CtrlCmd | KeyCode.KeyK, KeyMod.CtrlCmd | KeyCode.KeyC)]);
+			testResolve(createContext({}), KeyChord(KeyMod.CtrlCmd | KeyCode.KeyK, KeyMod.CtrlCmd | KeyCode.KeyC), 'comment lines');
 
-		testKey('eleven', [KeyMod.CtrlCmd | KeyCode.KeyG]);
-		testResolve(createContext({}), KeyMod.CtrlCmd | KeyCode.KeyG, 'eleven');
+			testKbLookupByCommand('unreachablechord', []);
 
-		testKey('sixth', []);
+			testKbLookupByCommand('eleven', [KeyMod.CtrlCmd | KeyCode.KeyG]);
+			testResolve(createContext({}), KeyMod.CtrlCmd | KeyCode.KeyG, 'eleven');
 
-		testKey('long multi chord', [[KeyMod.CtrlCmd | KeyCode.KeyK, KeyCode.KeyA, KeyCode.KeyB]]);
-		testResolve(createContext({}), [KeyMod.CtrlCmd | KeyCode.KeyK, KeyCode.KeyA, KeyCode.KeyB], 'long multi chord');
+			testKbLookupByCommand('sixth', []);
+
+			testKbLookupByCommand('long multi chord', [[KeyMod.CtrlCmd | KeyCode.KeyK, KeyCode.KeyA, KeyCode.KeyB]]);
+			testResolve(createContext({}), [KeyMod.CtrlCmd | KeyCode.KeyK, KeyCode.KeyA, KeyCode.KeyB], 'long multi chord');
+		});
 	});
 });

--- a/src/vs/platform/keybinding/test/common/mockKeybindingService.ts
+++ b/src/vs/platform/keybinding/test/common/mockKeybindingService.ts
@@ -8,7 +8,7 @@ import { ResolvedKeybinding, KeyCodeChord, Keybinding } from 'vs/base/common/key
 import { OS } from 'vs/base/common/platform';
 import { ContextKeyExpression, ContextKeyValue, IContextKey, IContextKeyChangeEvent, IContextKeyService, IContextKeyServiceTarget, IScopedContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 import { IKeybindingService, IKeyboardEvent } from 'vs/platform/keybinding/common/keybinding';
-import { IResolveResult } from 'vs/platform/keybinding/common/keybindingResolver';
+import { ResolutionResult } from 'vs/platform/keybinding/common/keybindingResolver';
 import { ResolvedKeybindingItem } from 'vs/platform/keybinding/common/resolvedKeybindingItem';
 import { USLayoutResolvedKeybinding } from 'vs/platform/keybinding/common/usLayoutResolvedKeybinding';
 
@@ -135,7 +135,7 @@ export class MockKeybindingService implements IKeybindingService {
 		return 0;
 	}
 
-	public softDispatch(keybinding: IKeyboardEvent, target: IContextKeyServiceTarget): IResolveResult | null {
+	public softDispatch(keybinding: IKeyboardEvent, target: IContextKeyServiceTarget): ResolutionResult | null {
 		return null;
 	}
 

--- a/src/vs/platform/list/browser/listService.ts
+++ b/src/vs/platform/list/browser/listService.ts
@@ -26,6 +26,7 @@ import { IContextViewService } from 'vs/platform/contextview/browser/contextView
 import { IEditorOptions } from 'vs/platform/editor/common/editor';
 import { createDecorator, IInstantiationService, ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
+import { ResultKind } from 'vs/platform/keybinding/common/keybindingResolver';
 import { Registry } from 'vs/platform/registry/common/platform';
 import { IStyleOverride, defaultFindWidgetStyles, defaultListStyles, getListStyles } from 'vs/platform/theme/browser/defaultStyles';
 
@@ -809,7 +810,7 @@ function createKeyboardNavigationEventFilter(keybindingService: IKeybindingServi
 
 		const result = keybindingService.softDispatch(event, event.target);
 
-		if (result?.enterMultiChord) {
+		if (result?.kind === ResultKind.MoreChordsNeeded) {
 			inMultiChord = true;
 			return false;
 		}

--- a/src/vs/workbench/browser/actions/developerActions.ts
+++ b/src/vs/workbench/browser/actions/developerActions.ts
@@ -29,6 +29,7 @@ import { IWorkingCopyService } from 'vs/workbench/services/workingCopy/common/wo
 import { ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
 import { Categories } from 'vs/platform/action/common/actionCommonCategories';
 import { IWorkingCopyBackupService } from 'vs/workbench/services/workingCopy/common/workingCopyBackup';
+import { ResolutionResult, ResultKind } from 'vs/platform/keybinding/common/keybindingResolver';
 
 class InspectContextKeysAction extends Action2 {
 
@@ -259,7 +260,7 @@ class ToggleScreencastModeAction extends Action2 {
 			const shortcut = keybindingService.softDispatch(event, event.target);
 
 			// Hide the single arrow key pressed
-			if (shortcut?.commandId && configurationService.getValue('screencastMode.hideSingleEditorCursorMoves') && (
+			if (shortcut && shortcut.kind === ResultKind.KbFound && shortcut.commandId && configurationService.getValue('screencastMode.hideSingleEditorCursorMoves') && (
 				['cursorLeft', 'cursorRight', 'cursorUp', 'cursorDown'].includes(shortcut.commandId))
 			) {
 				return;
@@ -278,7 +279,7 @@ class ToggleScreencastModeAction extends Action2 {
 
 			const format = configurationService.getValue<'keys' | 'command' | 'commandWithGroup' | 'commandAndKeys' | 'commandWithGroupAndKeys'>('screencastMode.keyboardShortcutsFormat');
 			const keybinding = keybindingService.resolveKeyboardEvent(event);
-			const command = shortcut?.commandId ? MenuRegistry.getCommand(shortcut.commandId) : null;
+			const command = (this._isKbFound(shortcut) && shortcut.commandId) ? MenuRegistry.getCommand(shortcut.commandId) : null;
 
 			let titleLabel = '';
 			let keyLabel: string | undefined | null = keybinding.getLabel();
@@ -290,7 +291,7 @@ class ToggleScreencastModeAction extends Action2 {
 					titleLabel = `${typeof command.category === 'string' ? command.category : command.category.value}: ${titleLabel} `;
 				}
 
-				if (shortcut?.commandId) {
+				if (this._isKbFound(shortcut) && shortcut.commandId) {
 					const keybindings = keybindingService.lookupKeybindings(shortcut.commandId)
 						.filter(k => k.getLabel()?.endsWith(keyLabel ?? ''));
 
@@ -306,7 +307,7 @@ class ToggleScreencastModeAction extends Action2 {
 				append(keyboardMarker, $('span.title', {}, `${titleLabel} `));
 			}
 
-			if (onlyKeyboardShortcuts || !titleLabel || shortcut?.commandId && (format === 'keys' || format === 'commandAndKeys' || format === 'commandWithGroupAndKeys')) {
+			if (onlyKeyboardShortcuts || !titleLabel || (this._isKbFound(shortcut) && shortcut.commandId) && (format === 'keys' || format === 'commandAndKeys' || format === 'commandWithGroupAndKeys')) {
 				// Fix label for arrow keys
 				keyLabel = keyLabel?.replace('UpArrow', '↑')
 					?.replace('DownArrow', '↓')
@@ -321,6 +322,10 @@ class ToggleScreencastModeAction extends Action2 {
 		}));
 
 		ToggleScreencastModeAction.disposable = disposables;
+	}
+
+	private _isKbFound(resolutionResult: ResolutionResult | null): resolutionResult is { kind: ResultKind.KbFound; commandId: string | null; commandArgs: any; isBubble: boolean } {
+		return resolutionResult !== null && resolutionResult.kind === ResultKind.KbFound;
 	}
 }
 

--- a/src/vs/workbench/browser/parts/dialogs/dialogHandler.ts
+++ b/src/vs/workbench/browser/parts/dialogs/dialogHandler.ts
@@ -19,6 +19,7 @@ import { fromNow } from 'vs/base/common/date';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { MarkdownRenderer } from 'vs/editor/contrib/markdownRenderer/browser/markdownRenderer';
 import { defaultButtonStyles, defaultCheckboxStyles, defaultDialogStyles, defaultInputBoxStyles } from 'vs/platform/theme/browser/defaultStyles';
+import { ResultKind } from 'vs/platform/keybinding/common/keybindingResolver';
 
 export class BrowserDialogHandler extends AbstractDialogHandler {
 
@@ -127,7 +128,7 @@ export class BrowserDialogHandler extends AbstractDialogHandler {
 				type: this.getDialogType(type),
 				keyEventProcessor: (event: StandardKeyboardEvent) => {
 					const resolved = this.keybindingService.softDispatch(event, this.layoutService.container);
-					if (resolved?.commandId) {
+					if (resolved && resolved.kind === ResultKind.KbFound && resolved.commandId) {
 						if (BrowserDialogHandler.ALLOWABLE_COMMANDS.indexOf(resolved.commandId) === -1) {
 							EventHelper.stop(event, true);
 						}

--- a/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
@@ -88,6 +88,7 @@ import { editorBackground } from 'vs/platform/theme/common/colorRegistry';
 import { PANEL_BACKGROUND, SIDE_BAR_BACKGROUND } from 'vs/workbench/common/theme';
 import { TerminalExtensionsRegistry } from 'vs/workbench/contrib/terminal/browser/terminalExtensions';
 import { ResolvedKeybinding } from 'vs/base/common/keybindings';
+import { ResultKind } from 'vs/platform/keybinding/common/keybindingResolver';
 
 const enum Constants {
 	/**
@@ -941,7 +942,7 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 			// Respect chords if the allowChords setting is set and it's not Escape. Escape is
 			// handled specially for Zen Mode's Escape, Escape chord, plus it's important in
 			// terminals generally
-			const isValidChord = resolveResult?.enterMultiChord && this._configHelper.config.allowChords && event.key !== 'Escape';
+			const isValidChord = resolveResult?.kind === ResultKind.MoreChordsNeeded && this._configHelper.config.allowChords && event.key !== 'Escape';
 			if (this._keybindingService.inChordMode || isValidChord) {
 				event.preventDefault();
 				return false;
@@ -961,7 +962,7 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 
 			// for keyboard events that resolve to commands described
 			// within commandsToSkipShell, either alert or skip processing by xterm.js
-			if (resolveResult && resolveResult.commandId && this._skipTerminalCommands.some(k => k === resolveResult.commandId) && !this._configHelper.config.sendKeybindingsToShell) {
+			if (resolveResult && resolveResult.kind === ResultKind.KbFound && resolveResult.commandId && this._skipTerminalCommands.some(k => k === resolveResult.commandId) && !this._configHelper.config.sendKeybindingsToShell) {
 				// don't alert when terminal is opened or closed
 				if (this._storageService.getBoolean(SHOW_TERMINAL_CONFIG_PROMPT_KEY, StorageScope.APPLICATION, true) &&
 					this._hasHadInput &&

--- a/src/vs/workbench/services/progress/browser/progressService.ts
+++ b/src/vs/workbench/services/progress/browser/progressService.ts
@@ -25,6 +25,7 @@ import { IViewsService, IViewDescriptorService, ViewContainerLocation } from 'vs
 import { IPaneCompositePartService } from 'vs/workbench/services/panecomposite/browser/panecomposite';
 import { stripIcons } from 'vs/base/common/iconLabels';
 import { defaultButtonStyles, defaultCheckboxStyles, defaultDialogStyles, defaultInputBoxStyles } from 'vs/platform/theme/browser/defaultStyles';
+import { ResultKind } from 'vs/platform/keybinding/common/keybindingResolver';
 
 export class ProgressService extends Disposable implements IProgressService {
 
@@ -556,7 +557,7 @@ export class ProgressService extends Disposable implements IProgressService {
 					disableDefaultAction: options.sticky,
 					keyEventProcessor: (event: StandardKeyboardEvent) => {
 						const resolved = this.keybindingService.softDispatch(event, this.layoutService.container);
-						if (resolved?.commandId) {
+						if (resolved && resolved.kind === ResultKind.KbFound && resolved.commandId) {
 							if (!allowableCommands.includes(resolved.commandId)) {
 								EventHelper.stop(event, true);
 							}


### PR DESCRIPTION
## What this PR does

Cleans up `KeybindingResolver` & `AbstractKeybindingService`

- by mostly making impossible state unrepresentable ([more](https://fsharpforfunandprofit.com/posts/designing-with-types-making-illegal-states-unrepresentable/))
- grouping test cases into suites or splitting up multi-purpose tests into smaller test cases

## How to review

Best reviewed commit by commit because some of commits are simply reordering code (for good reasons, IMHO)

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
