### PR TITLE
Use defined variable instead of internal property

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminalProfileService.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalProfileService.ts
@@ -114,7 +114,7 @@ export class TerminalProfileService implements ITerminalProfileService {
 
 		// IMPORTANT: Only allow the default profile name to find non-auto detected profiles as
 		// to avoid unsafe path profiles being picked up.
-		return this.availableProfiles.find(e => e.profileName === this._defaultProfileName && !e.isAutoDetected);
+		return this.availableProfiles.find(e => e.profileName === defaultProfileName && !e.isAutoDetected);
 	}
 
 	private _getOsKey(os: OperatingSystem): string {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
Fixes https://github.com/microsoft/vscode/issues/173277.

The function being fixed defines a variable for finding the default profile, but doesn't use it in the actual search. This works fine if the `_defaultProfileName` is set properly, but if it is different from the config value, this loads the incorrect profile, causing the above issue.
