### PR TITLE
Support sovereign/custom clouds in `microsoft` authentication provider

### DIFF
--- a/extensions/microsoft-authentication/README.md
+++ b/extensions/microsoft-authentication/README.md
@@ -6,4 +6,4 @@
 
 This extension provides support for authenticating to Microsoft. It registers the `microsoft` Authentication Provider that can be leveraged by other extensions. This also provides the Microsoft authentication used by Settings Sync.
 
-Additionally, it provides the `azure-cloud` Authentication Provider that can be used to sign in to other Azure clouds like Azure for US Government or Azure China. Use the setting `azure-cloud.endpoint` to select the authentication endpoint the provider should use. Please note that different scopes may also be required in different environments.
+Additionally, it provides the `microsoft-sovereign-cloud` Authentication Provider that can be used to sign in to other Azure clouds like Azure for US Government or Azure China. Use the setting `microsoft-sovereign-cloud.endpoint` to select the authentication endpoint the provider should use. Please note that different scopes may also be required in different environments.

--- a/extensions/microsoft-authentication/README.md
+++ b/extensions/microsoft-authentication/README.md
@@ -5,3 +5,5 @@
 ## Features
 
 This extension provides support for authenticating to Microsoft. It registers the `microsoft` Authentication Provider that can be leveraged by other extensions. This also provides the Microsoft authentication used by Settings Sync.
+
+Additionally, it provides the `azure-cloud` Authentication Provider that can be used to sign in to other Azure clouds like Azure for US Government or Azure China. Use the setting `azure-cloud.endpoint` to select the authentication endpoint the provider should use. Please note that different scopes may also be required in different environments.

--- a/extensions/microsoft-authentication/package.json
+++ b/extensions/microsoft-authentication/package.json
@@ -41,7 +41,7 @@
       {
         "title": "Azure Cloud",
         "properties": {
-          "azureCloud.endpoint": {
+          "azure-cloud.endpoint": {
             "anyOf": [
               {
                 "type": "string"
@@ -49,19 +49,16 @@
               {
                 "type": "string",
                 "enum": [
-                  "https://login.microsoftonline.com",
                   "https://login.chinacloudapi.cn",
                   "https://login.microsoftonline.us"
                 ],
                 "enumDescriptions": [
-                  "Azure Public",
                   "Azure China",
                   "Azure US Government"
                 ]
               }
             ],
-            "default": "https://login.microsoftonline.com",
-            "description": "%azureCloud.endpoint.description%"
+            "description": "%azure-cloud.endpoint.description%"
           }
         }
       }

--- a/extensions/microsoft-authentication/package.json
+++ b/extensions/microsoft-authentication/package.json
@@ -54,7 +54,6 @@
                 ]
               }
             ],
-            "default": "",
             "description": "%microsoft-sovereign-cloud.endpoint.description%"
           }
         }

--- a/extensions/microsoft-authentication/package.json
+++ b/extensions/microsoft-authentication/package.json
@@ -49,8 +49,8 @@
               {
                 "type": "string",
                 "enum": [
-                  "https://login.chinacloudapi.cn",
-                  "https://login.microsoftonline.us"
+                  "https://login.chinacloudapi.cn/",
+                  "https://login.microsoftonline.us/"
                 ],
                 "enumDescriptions": [
                   "Azure China",

--- a/extensions/microsoft-authentication/package.json
+++ b/extensions/microsoft-authentication/package.json
@@ -32,6 +32,35 @@
         "label": "Microsoft",
         "id": "microsoft"
       }
+    ],
+    "configuration": [
+      {
+        "title": "Microsoft Authentication",
+        "properties": {
+          "microsoftAuthentication.enterprise.endpoint": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "string",
+                "enum": [
+                  "https://login.microsoftonline.com",
+                  "https://login.chinacloudapi.cn",
+                  "https://login.microsoftonline.us"
+                ],
+                "enumDescriptions": [
+                  "Azure Public",
+                  "Azure China",
+                  "Azure US Government"
+                ]
+              }
+            ],
+            "default": "https://login.microsoftonline.com",
+            "description": "%microsoftAuthentication.enterprise.endpoint.description%"
+          }
+        }
+      }
     ]
   },
   "aiKey": "0c6ae279ed8443289764825290e4f9e2-1a736e7c-1324-4338-be46-fc2a58ae4d14-7255",

--- a/extensions/microsoft-authentication/package.json
+++ b/extensions/microsoft-authentication/package.json
@@ -33,15 +33,15 @@
         "id": "microsoft"
       },
       {
-        "label": "Azure Cloud",
-        "id": "azure-cloud"
+        "label": "Microsoft Sovereign Cloud",
+        "id": "microsoft-sovereign-cloud"
       }
     ],
     "configuration": [
       {
-        "title": "Azure Cloud",
+        "title": "Microsoft Sovereign Cloud",
         "properties": {
-          "azure-cloud.endpoint": {
+          "microsoft-sovereign-cloud.endpoint": {
             "anyOf": [
               {
                 "type": "string"
@@ -54,7 +54,7 @@
                 ]
               }
             ],
-            "description": "%azure-cloud.endpoint.description%"
+            "description": "%microsoft-sovereign-cloud.endpoint.description%"
           }
         }
       }

--- a/extensions/microsoft-authentication/package.json
+++ b/extensions/microsoft-authentication/package.json
@@ -54,6 +54,7 @@
                 ]
               }
             ],
+            "default": "",
             "description": "%microsoft-sovereign-cloud.endpoint.description%"
           }
         }

--- a/extensions/microsoft-authentication/package.json
+++ b/extensions/microsoft-authentication/package.json
@@ -49,10 +49,6 @@
               {
                 "type": "string",
                 "enum": [
-                  "https://login.chinacloudapi.cn/",
-                  "https://login.microsoftonline.us/"
-                ],
-                "enumDescriptions": [
                   "Azure China",
                   "Azure US Government"
                 ]

--- a/extensions/microsoft-authentication/package.json
+++ b/extensions/microsoft-authentication/package.json
@@ -31,13 +31,17 @@
       {
         "label": "Microsoft",
         "id": "microsoft"
+      },
+      {
+        "label": "Azure Cloud",
+        "id": "azure-cloud"
       }
     ],
     "configuration": [
       {
-        "title": "Microsoft Authentication",
+        "title": "Azure Cloud",
         "properties": {
-          "microsoftAuthentication.enterprise.endpoint": {
+          "azureCloud.endpoint": {
             "anyOf": [
               {
                 "type": "string"
@@ -57,7 +61,7 @@
               }
             ],
             "default": "https://login.microsoftonline.com",
-            "description": "%microsoftAuthentication.enterprise.endpoint.description%"
+            "description": "%azureCloud.endpoint.description%"
           }
         }
       }

--- a/extensions/microsoft-authentication/package.nls.json
+++ b/extensions/microsoft-authentication/package.nls.json
@@ -2,5 +2,6 @@
 	"displayName": "Microsoft Account",
 	"description": "Microsoft authentication provider",
 	"signIn": "Sign In",
-	"signOut": "Sign Out"
+	"signOut": "Sign Out",
+	"microsoftAuthentication.enterprise.endpoint.description": "Login endpoint for enterprise authentication"
 }

--- a/extensions/microsoft-authentication/package.nls.json
+++ b/extensions/microsoft-authentication/package.nls.json
@@ -3,5 +3,5 @@
 	"description": "Microsoft authentication provider",
 	"signIn": "Sign In",
 	"signOut": "Sign Out",
-	"azureCloud.endpoint.description": "Login endpoint for Azure authentication"
+	"azure-cloud.endpoint.description": "Login endpoint for Azure authentication"
 }

--- a/extensions/microsoft-authentication/package.nls.json
+++ b/extensions/microsoft-authentication/package.nls.json
@@ -3,5 +3,5 @@
 	"description": "Microsoft authentication provider",
 	"signIn": "Sign In",
 	"signOut": "Sign Out",
-	"microsoftAuthentication.enterprise.endpoint.description": "Login endpoint for enterprise authentication"
+	"azureCloud.endpoint.description": "Login endpoint for Azure authentication"
 }

--- a/extensions/microsoft-authentication/package.nls.json
+++ b/extensions/microsoft-authentication/package.nls.json
@@ -3,5 +3,5 @@
 	"description": "Microsoft authentication provider",
 	"signIn": "Sign In",
 	"signOut": "Sign Out",
-	"azure-cloud.endpoint.description": "Login endpoint for Azure authentication"
+	"azure-cloud.endpoint.description": "Login endpoint for Azure authentication. Select a national cloud or enter the login URL for a custom Azure cloud."
 }

--- a/extensions/microsoft-authentication/package.nls.json
+++ b/extensions/microsoft-authentication/package.nls.json
@@ -3,5 +3,5 @@
 	"description": "Microsoft authentication provider",
 	"signIn": "Sign In",
 	"signOut": "Sign Out",
-	"azure-cloud.endpoint.description": "Login endpoint for Azure authentication. Select a national cloud or enter the login URL for a custom Azure cloud."
+	"microsoft-sovereign-cloud.endpoint.description": "Login endpoint for Azure authentication. Select a national cloud or enter the login URL for a custom Azure cloud."
 }

--- a/extensions/microsoft-authentication/src/AADHelper.ts
+++ b/extensions/microsoft-authentication/src/AADHelper.ts
@@ -13,6 +13,7 @@ import { BetterTokenStorage, IDidChangeInOtherWindowEvent } from './betterSecret
 import { LoopbackAuthServer } from './node/authServer';
 import { base64Decode } from './node/buffer';
 import { fetching } from './node/fetch';
+import { UriEventHandler } from './UriEventHandler';
 
 const redirectUrl = 'https://vscode.dev/redirect';
 const loginEndpointUrl = 'https://login.microsoftonline.com/';
@@ -72,12 +73,6 @@ interface IScopeData {
 
 export const REFRESH_NETWORK_FAILURE = 'Network failure';
 
-class UriEventHandler extends vscode.EventEmitter<vscode.Uri> implements vscode.UriHandler {
-	public handleUri(uri: vscode.Uri) {
-		this.fire(uri);
-	}
-}
-
 export class AzureActiveDirectoryService {
 	// For details on why this is set to 2/3... see https://github.com/microsoft/vscode/issues/133201#issuecomment-966668197
 	private static REFRESH_TIMEOUT_MODIFIER = 1000 * 2 / 3;
@@ -95,10 +90,9 @@ export class AzureActiveDirectoryService {
 
 	private readonly _tokenStorage: BetterTokenStorage<IStoredSession>;
 
-	constructor(private _context: vscode.ExtensionContext) {
+	constructor(private _context: vscode.ExtensionContext, uriHandler: UriEventHandler) {
 		this._tokenStorage = new BetterTokenStorage('microsoft.login.keylist', _context);
-		this._uriHandler = new UriEventHandler();
-		_context.subscriptions.push(vscode.window.registerUriHandler(this._uriHandler));
+		this._uriHandler = uriHandler;
 		_context.subscriptions.push(this._tokenStorage.onDidChangeInOtherWindow((e) => this.checkForUpdates(e)));
 	}
 

--- a/extensions/microsoft-authentication/src/AADHelper.ts
+++ b/extensions/microsoft-authentication/src/AADHelper.ts
@@ -875,6 +875,11 @@ export class AzureActiveDirectoryService {
 		}
 
 		for (const { value } of e.removed) {
+			if (!this.sessionMatchesEndpoint(value)) {
+				// If the session wasn't made for this login endpoint, ignore this update
+				continue;
+			}
+
 			Logger.info(`Session removed in another window with scopes: ${value.scope}`);
 			await this.removeSessionById(value.id, false);
 		}

--- a/extensions/microsoft-authentication/src/AADHelper.ts
+++ b/extensions/microsoft-authentication/src/AADHelper.ts
@@ -92,7 +92,8 @@ export class AzureActiveDirectoryService {
 	private readonly _tokenStorage: BetterTokenStorage<IStoredSession>;
 
 	constructor(private _context: vscode.ExtensionContext, uriHandler: UriEventHandler, loginEndpointUrl: string = defaultLoginEndpointUrl) {
-		this._tokenStorage = new BetterTokenStorage('microsoft.login.keylist', _context);
+		const keylistKey = loginEndpointUrl === defaultLoginEndpointUrl ? 'microsoft.login.keylist' : 'azure-cloud.login.keylist';
+		this._tokenStorage = new BetterTokenStorage(keylistKey, _context);
 		this._uriHandler = uriHandler;
 		this._loginEndpointUrl = loginEndpointUrl;
 		_context.subscriptions.push(this._tokenStorage.onDidChangeInOtherWindow((e) => this.checkForUpdates(e)));

--- a/extensions/microsoft-authentication/src/UriEventHandler.ts
+++ b/extensions/microsoft-authentication/src/UriEventHandler.ts
@@ -1,0 +1,12 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+
+export class UriEventHandler extends vscode.EventEmitter<vscode.Uri> implements vscode.UriHandler {
+	public handleUri(uri: vscode.Uri) {
+		this.fire(uri);
+	}
+}

--- a/extensions/microsoft-authentication/src/betterSecretStorage.ts
+++ b/extensions/microsoft-authentication/src/betterSecretStorage.ts
@@ -81,11 +81,13 @@ export class BetterTokenStorage<T> {
 		return tokens.get(key);
 	}
 
-	async getAll(): Promise<T[]> {
+	async getAll(predicate?: (item: T) => boolean): Promise<T[]> {
 		const tokens = await this.getTokens();
 		const values = new Array<T>();
 		for (const [_, value] of tokens) {
-			values.push(value);
+			if (!predicate || predicate(value)) {
+				values.push(value);
+			}
 		}
 		return values;
 	}
@@ -141,11 +143,13 @@ export class BetterTokenStorage<T> {
 		this._operationInProgress = false;
 	}
 
-	async deleteAll(): Promise<void> {
+	async deleteAll(predicate?: (item: T) => boolean): Promise<void> {
 		const tokens = await this.getTokens();
 		const promises = [];
-		for (const [key] of tokens) {
-			promises.push(this.delete(key));
+		for (const [key, value] of tokens) {
+			if (!predicate || predicate(value)) {
+				promises.push(this.delete(key));
+			}
 		}
 		await Promise.all(promises);
 	}

--- a/extensions/microsoft-authentication/src/betterSecretStorage.ts
+++ b/extensions/microsoft-authentication/src/betterSecretStorage.ts
@@ -196,7 +196,7 @@ export class BetterTokenStorage<T> {
 
 		// The KeyList is only a list of keys to aid initial start up of VS Code to know which
 		// Keys are associated with this handler.
-		if (key === 'microsoft.login.keylist' || key === 'azure-cloud.login.keylist') {
+		if (key === this.keylistKey) {
 			return;
 		}
 		const tokens = await this.getTokens();

--- a/extensions/microsoft-authentication/src/betterSecretStorage.ts
+++ b/extensions/microsoft-authentication/src/betterSecretStorage.ts
@@ -192,7 +192,7 @@ export class BetterTokenStorage<T> {
 
 		// The KeyList is only a list of keys to aid initial start up of VS Code to know which
 		// Keys are associated with this handler.
-		if (key === this.keylistKey) {
+		if (key === 'microsoft.login.keylist' || key === 'azure-cloud.login.keylist') {
 			return;
 		}
 		const tokens = await this.getTokens();

--- a/extensions/microsoft-authentication/src/extension.ts
+++ b/extensions/microsoft-authentication/src/extension.ts
@@ -5,9 +5,9 @@
 
 import * as vscode from 'vscode';
 import { AzureActiveDirectoryService, IStoredSession } from './AADHelper';
+import { BetterTokenStorage } from './betterSecretStorage';
 import { UriEventHandler } from './UriEventHandler';
 import TelemetryReporter from '@vscode/extension-telemetry';
-import { BetterTokenStorage } from 'src/betterSecretStorage';
 
 async function initAzureCloudAuthProvider(context: vscode.ExtensionContext, telemetryReporter: TelemetryReporter, uriHandler: UriEventHandler, tokenStorage: BetterTokenStorage<IStoredSession>): Promise<vscode.Disposable | undefined> {
 	const settingValue = vscode.workspace.getConfiguration('azure-cloud').get<string | undefined>('endpoint');

--- a/extensions/microsoft-authentication/src/extension.ts
+++ b/extensions/microsoft-authentication/src/extension.ts
@@ -132,7 +132,7 @@ export async function activate(context: vscode.ExtensionContext) {
 	let azureCloudAuthProviderDisposable = await initAzureCloudAuthProvider(context, telemetryReporter, uriHandler);
 
 	context.subscriptions.push(vscode.workspace.onDidChangeConfiguration(async e => {
-		if (e.affectsConfiguration('azureCloud.endpoint')) {
+		if (e.affectsConfiguration('azure-cloud.endpoint')) {
 			azureCloudAuthProviderDisposable?.dispose();
 			azureCloudAuthProviderDisposable = await initAzureCloudAuthProvider(context, telemetryReporter, uriHandler);
 		}

--- a/extensions/microsoft-authentication/src/extension.ts
+++ b/extensions/microsoft-authentication/src/extension.ts
@@ -9,7 +9,7 @@ import { UriEventHandler } from './UriEventHandler';
 import TelemetryReporter from '@vscode/extension-telemetry';
 
 async function initAzureCloudAuthProvider(context: vscode.ExtensionContext, telemetryReporter: TelemetryReporter, uriHandler: UriEventHandler): Promise<vscode.Disposable | undefined> {
-	const settingValue = vscode.workspace.getConfiguration().get<string>('azureCloud.endpoint');
+	const settingValue = vscode.workspace.getConfiguration('azure-cloud').get<string | undefined>('endpoint');
 	if (!settingValue) {
 		return undefined;
 	}

--- a/extensions/microsoft-authentication/src/extension.ts
+++ b/extensions/microsoft-authentication/src/extension.ts
@@ -5,13 +5,18 @@
 
 import * as vscode from 'vscode';
 import { AzureActiveDirectoryService } from './AADHelper';
+import { UriEventHandler } from './UriEventHandler';
 import TelemetryReporter from '@vscode/extension-telemetry';
 
 export async function activate(context: vscode.ExtensionContext) {
 	const { name, version, aiKey } = context.extension.packageJSON as { name: string; version: string; aiKey: string };
 	const telemetryReporter = new TelemetryReporter(aiKey);
 
-	const loginService = new AzureActiveDirectoryService(context);
+	const uriHandler = new UriEventHandler();
+	context.subscriptions.push(uriHandler);
+	context.subscriptions.push(vscode.window.registerUriHandler(uriHandler));
+
+	const loginService = new AzureActiveDirectoryService(context, uriHandler);
 	await loginService.initialize();
 
 	context.subscriptions.push(vscode.authentication.registerAuthenticationProvider('microsoft', 'Microsoft', {

--- a/extensions/microsoft-authentication/src/extension.ts
+++ b/extensions/microsoft-authentication/src/extension.ts
@@ -8,6 +8,72 @@ import { AzureActiveDirectoryService } from './AADHelper';
 import { UriEventHandler } from './UriEventHandler';
 import TelemetryReporter from '@vscode/extension-telemetry';
 
+async function initAzureCloudAuthProvider(context: vscode.ExtensionContext, telemetryReporter: TelemetryReporter, uriHandler: UriEventHandler): Promise<vscode.Disposable | undefined> {
+	const settingValue = vscode.workspace.getConfiguration().get<string>('azureCloud.endpoint');
+	if (!settingValue) {
+		return undefined;
+	}
+
+	// validate user value
+	let uri: vscode.Uri;
+	try {
+		uri = vscode.Uri.parse(settingValue, true);
+	} catch (e) {
+		vscode.window.showErrorMessage(vscode.l10n.t('Azure Cloud login URI is not a valid URI: {0}', e.message ?? e));
+		return;
+	}
+
+	const azureEnterpriseAuthProvider = new AzureActiveDirectoryService(context, uriHandler, settingValue);
+	await azureEnterpriseAuthProvider.initialize();
+
+	const disposable = vscode.authentication.registerAuthenticationProvider('azure-cloud', 'Azure Cloud', {
+		onDidChangeSessions: azureEnterpriseAuthProvider.onDidChangeSessions,
+		getSessions: (scopes: string[]) => azureEnterpriseAuthProvider.getSessions(scopes),
+		createSession: async (scopes: string[]) => {
+			try {
+				/* __GDPR__
+					"login" : {
+						"owner": "TylerLeonhardt",
+						"comment": "Used to determine the usage of the Azure Cloud Auth Provider.",
+						"scopes": { "classification": "PublicNonPersonalData", "purpose": "FeatureInsight", "comment": "Used to determine what scope combinations are being requested." }
+					}
+				*/
+				telemetryReporter.sendTelemetryEvent('loginAzureCloud', {
+					// Get rid of guids from telemetry.
+					scopes: JSON.stringify(scopes.map(s => s.replace(/[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}/i, '{guid}'))),
+				});
+
+				return await azureEnterpriseAuthProvider.createSession(scopes.sort());
+			} catch (e) {
+				/* __GDPR__
+					"loginFailed" : { "owner": "TylerLeonhardt", "comment": "Used to determine how often users run into issues with the login flow." }
+				*/
+				telemetryReporter.sendTelemetryEvent('loginAzureCloudFailed');
+
+				throw e;
+			}
+		},
+		removeSession: async (id: string) => {
+			try {
+				/* __GDPR__
+					"logout" : { "owner": "TylerLeonhardt", "comment": "Used to determine how often users log out." }
+				*/
+				telemetryReporter.sendTelemetryEvent('logoutAzureCloud');
+
+				await azureEnterpriseAuthProvider.removeSessionById(id);
+			} catch (e) {
+				/* __GDPR__
+					"logoutFailed" : { "owner": "TylerLeonhardt", "comment": "Used to determine how often fail to log out." }
+				*/
+				telemetryReporter.sendTelemetryEvent('logoutAzureCloudFailed');
+			}
+		}
+	}, { supportsMultipleAccounts: true });
+
+	context.subscriptions.push(disposable);
+	return disposable;
+}
+
 export async function activate(context: vscode.ExtensionContext) {
 	const { name, version, aiKey } = context.extension.packageJSON as { name: string; version: string; aiKey: string };
 	const telemetryReporter = new TelemetryReporter(aiKey);
@@ -62,6 +128,15 @@ export async function activate(context: vscode.ExtensionContext) {
 			}
 		}
 	}, { supportsMultipleAccounts: true }));
+
+	let azureCloudAuthProviderDisposable = await initAzureCloudAuthProvider(context, telemetryReporter, uriHandler);
+
+	context.subscriptions.push(vscode.workspace.onDidChangeConfiguration(async e => {
+		if (e.affectsConfiguration('azureCloud.endpoint')) {
+			azureCloudAuthProviderDisposable?.dispose();
+			azureCloudAuthProviderDisposable = await initAzureCloudAuthProvider(context, telemetryReporter, uriHandler);
+		}
+	}));
 
 	return;
 }

--- a/extensions/microsoft-authentication/src/extension.ts
+++ b/extensions/microsoft-authentication/src/extension.ts
@@ -13,6 +13,10 @@ async function initAzureCloudAuthProvider(context: vscode.ExtensionContext, tele
 	let settingValue = vscode.workspace.getConfiguration('azure-cloud').get<string | undefined>('endpoint');
 	if (!settingValue) {
 		return undefined;
+	} else if (settingValue === 'Azure China') {
+		settingValue = 'https://login.chinacloudapi.cn/';
+	} else if (settingValue === 'Azure US Government') {
+		settingValue = 'https://login.microsoftonline.us/';
 	}
 
 	// validate user value

--- a/extensions/microsoft-authentication/src/extension.ts
+++ b/extensions/microsoft-authentication/src/extension.ts
@@ -10,7 +10,7 @@ import { UriEventHandler } from './UriEventHandler';
 import TelemetryReporter from '@vscode/extension-telemetry';
 
 async function initAzureCloudAuthProvider(context: vscode.ExtensionContext, telemetryReporter: TelemetryReporter, uriHandler: UriEventHandler, tokenStorage: BetterTokenStorage<IStoredSession>): Promise<vscode.Disposable | undefined> {
-	let settingValue = vscode.workspace.getConfiguration('azure-cloud').get<string | undefined>('endpoint');
+	let settingValue = vscode.workspace.getConfiguration('microsoft-sovereign-cloud').get<string | undefined>('endpoint');
 	if (!settingValue) {
 		return undefined;
 	} else if (settingValue === 'Azure China') {
@@ -36,7 +36,7 @@ async function initAzureCloudAuthProvider(context: vscode.ExtensionContext, tele
 	const azureEnterpriseAuthProvider = new AzureActiveDirectoryService(context, uriHandler, tokenStorage, settingValue);
 	await azureEnterpriseAuthProvider.initialize();
 
-	const disposable = vscode.authentication.registerAuthenticationProvider('azure-cloud', settingValue, {
+	const disposable = vscode.authentication.registerAuthenticationProvider('microsoft-sovereign-cloud', settingValue, {
 		onDidChangeSessions: azureEnterpriseAuthProvider.onDidChangeSessions,
 		getSessions: (scopes: string[]) => azureEnterpriseAuthProvider.getSessions(scopes),
 		createSession: async (scopes: string[]) => {
@@ -144,7 +144,7 @@ export async function activate(context: vscode.ExtensionContext) {
 	let azureCloudAuthProviderDisposable = await initAzureCloudAuthProvider(context, telemetryReporter, uriHandler, betterSecretStorage);
 
 	context.subscriptions.push(vscode.workspace.onDidChangeConfiguration(async e => {
-		if (e.affectsConfiguration('azure-cloud.endpoint')) {
+		if (e.affectsConfiguration('microsoft-sovereign-cloud.endpoint')) {
 			azureCloudAuthProviderDisposable?.dispose();
 			azureCloudAuthProviderDisposable = await initAzureCloudAuthProvider(context, telemetryReporter, uriHandler, betterSecretStorage);
 		}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This fixes https://github.com/microsoft/vscode/issues/162539. A setting (`microsoft-sovereign-cloud.endpoint`) is added; if present then the `microsoft-sovereign-cloud` authentication provider will be registered. The endpoint needs to be the login URL of that cloud. For example, for Azure China, that is `https://login.chinacloudapi.cn/`.

Additionally, in some circumstances the caller of the auth provider will need to pass in different scopes. For example, for most resource management work on the Azure public cloud, the desired scope is `https://management.azure.com/.default`, but the equivalent for Azure China is `https://management.chinacloudapi.cn/.default`.

This provider _should_ also work on any custom Azure login endpoints that are network-accessible to VSCode (but may not work in VSCode.dev, where a redirect server also needs to have access to the endpoint).

One limitation is that it will not be possible to obtain tokens simultaneously from two sovereign clouds in the same VSCode window--the setting will be shared at least across the entire workspace. However, if the setting is changed, it should be able to obtain sessions from the newly-set cloud. It _is_ possible to simultaneously use the Azure public cloud and a sovereign cloud.