### PR TITLE
[typescript-language-features] Support replacing Go to Definition with Go to Source Definition by preference

### DIFF
--- a/extensions/typescript-language-features/package.json
+++ b/extensions/typescript-language-features/package.json
@@ -1221,6 +1221,18 @@
           "tags": [
             "experimental"
           ]
+        },
+        "typescript.preferGoToSourceDefinition": {
+          "type": "boolean",
+          "default": false,
+          "description": "%configuration.preferGoToSourceDefinition%",
+          "scope": "window"
+        },
+				"javascript.preferGoToSourceDefinition": {
+          "type": "boolean",
+          "default": false,
+          "description": "%configuration.preferGoToSourceDefinition%",
+          "scope": "window"
         }
       }
     },

--- a/extensions/typescript-language-features/package.nls.json
+++ b/extensions/typescript-language-features/package.nls.json
@@ -80,6 +80,7 @@
 	"configuration.implicitProjectConfig.strictFunctionTypes": "Enable/disable [strict function types](https://www.typescriptlang.org/tsconfig#strictFunctionTypes) in JavaScript and TypeScript files that are not part of a project. Existing `jsconfig.json` or `tsconfig.json` files override this setting.",
 	"configuration.suggest.jsdoc.generateReturns": "Enable/disable generating `@returns` annotations for JSDoc templates.",
 	"configuration.suggest.autoImports": "Enable/disable auto import suggestions.",
+	"configuration.preferGoToSourceDefinition": "Makes Go to Definition avoid type declaration files when possible by triggering Go to Source Definition instead. This allows Go to Source Definition to be triggered with the mouse gesture. Requires using TypeScript 4.7+ in the workspace.",
 	"inlayHints.parameterNames.none": "Disable parameter name hints.",
 	"inlayHints.parameterNames.literals": "Enable parameter name hints only for literal arguments.",
 	"inlayHints.parameterNames.all": "Enable parameter name hints for literal and non-literal arguments.",

--- a/extensions/typescript-language-features/src/languageFeatures/definitions.ts
+++ b/extensions/typescript-language-features/src/languageFeatures/definitions.ts
@@ -5,6 +5,7 @@
 
 import * as vscode from 'vscode';
 import { DocumentSelector } from '../configuration/documentSelector';
+import { API } from '../tsServer/api';
 import * as typeConverters from '../typeConverters';
 import { ClientCapability, ITypeScriptServiceClient } from '../typescriptService';
 import DefinitionProviderBase from './definitionProviderBase';
@@ -31,7 +32,7 @@ export default class TypeScriptDefinitionProvider extends DefinitionProviderBase
 		const span = response.body.textSpan ? typeConverters.Range.fromTextSpan(response.body.textSpan) : undefined;
 		let definitions = response.body.definitions;
 
-		if (vscode.workspace.getConfiguration(document.languageId).get('preferGoToSourceDefinition', false)) {
+		if (vscode.workspace.getConfiguration(document.languageId).get('preferGoToSourceDefinition', false) && this.client.apiVersion.gte(API.v470)) {
 			const sourceDefinitionsResponse = await this.client.execute('findSourceDefinition', args, token);
 			if (sourceDefinitionsResponse.type === 'response' && sourceDefinitionsResponse.body?.length) {
 				definitions = sourceDefinitionsResponse.body;

--- a/extensions/typescript-language-features/src/languageFeatures/definitions.ts
+++ b/extensions/typescript-language-features/src/languageFeatures/definitions.ts
@@ -33,7 +33,7 @@ export default class TypeScriptDefinitionProvider extends DefinitionProviderBase
 
 		if (vscode.workspace.getConfiguration(document.languageId).get('preferGoToSourceDefinition', false)) {
 			const sourceDefinitionsResponse = await this.client.execute('findSourceDefinition', args, token);
-			if (sourceDefinitionsResponse.type === 'response' && sourceDefinitionsResponse.body) {
+			if (sourceDefinitionsResponse.type === 'response' && sourceDefinitionsResponse.body?.length) {
 				definitions = sourceDefinitionsResponse.body;
 			}
 		}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

When a new preference is enabled, Go To Definition shows definitions from Go To Source Definition when available, instead of its typical results.

This is achievable without TS Server changes, allowing it to work on TypeScript versions as old as 4.7, but perhaps not optimally so. As it is now, `definitionAndBoundSpan` is still called first, because `findSourceDefinition` does not return the text span used to draw the underline, and it also does not return fallback results to type declarations, which I think we would want if Go To Definition is fully replaced. `findSourceDefinition` is called subsequently, and the definitions it returns replace the ones returned by `definitionAndBoundSpan`. If `findSourceDefinition` returns no results, the response from `definitionAndBoundSpan` is used as a fallback.

`definitionAndBoundSpan` is typically very cheap, so this might be acceptable. But there are two ways we could improve performance:

1. Make a new TS Server command that returns source definitions, along with the text span, and falls back to type declarations when no other definitions are found. This would allow VS Code to trigger only one request, provided the TS version is new enough to have this capability.
2. A bigger change to VS Code, but the best thing for perceived performance would be to support separate requests for drawing the underline and showing the definitions. `findSourceDefinition` can be considerably more expensive than `definitionAndBoundSpan`, so it would be nice to trigger the latter when hovering with ctrl/cmd, and then trigger the former once the user clicks.