### PR TITLE
fix Settings editor search result count

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
@@ -1591,7 +1591,7 @@ export class SettingsEditor2 extends EditorPane {
 		}
 
 		if (this.tocTreeModel && this.tocTreeModel.settingsTreeRoot) {
-			const count = this.tocTreeModel.settingsTreeRoot.count;
+			const count = this.searchResultModel.getUniqueResultsCount();
 			let resultString: string;
 			switch (count) {
 				case 0: resultString = localize('noResults', "No Settings Found"); break;

--- a/src/vs/workbench/contrib/preferences/browser/settingsTreeModels.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsTreeModels.ts
@@ -853,6 +853,13 @@ export class SearchResultModel extends SettingsTreeModel {
 		return this.rawSearchResults || [];
 	}
 
+	getUniqueResultsCount(): number {
+		const uniqueResults = this.getUniqueResults();
+		const localResultsCount = uniqueResults[0]?.filterMatches.length ?? 0;
+		const remoteResultsCount = uniqueResults[1]?.filterMatches.length ?? 0;
+		return localResultsCount + remoteResultsCount;
+	}
+
 	setResult(order: SearchResultIdx, result: ISearchResult | null): void {
 		this.cachedUniqueSearchResults = null;
 		this.newExtensionSearchResults = null;


### PR DESCRIPTION
Ref #158531

When searching for settings, the same setting sometimes shows up in two ToC (table of contents) groups. The search result label and aria status then uses that count instead of the deduplicated count. The deduplicated count makes more sense, considering that the search results are shown deduplicated.