### PR TITLE
Slightly more robust WebActiveLanguagePackService

### DIFF
--- a/src/vs/workbench/services/localization/browser/localeService.ts
+++ b/src/vs/workbench/services/localization/browser/localeService.ts
@@ -13,6 +13,7 @@ import { IProductService } from 'vs/platform/product/common/productService';
 import { InstantiationType, registerSingleton } from 'vs/platform/instantiation/common/extensions';
 import { CancellationToken } from 'vs/base/common/cancellation';
 import { IExtensionGalleryService } from 'vs/platform/extensionManagement/common/extensionManagement';
+import { ILogService } from 'vs/platform/log/common/log';
 
 export class WebLocaleService implements ILocaleService {
 	declare readonly _serviceBrand: undefined;
@@ -76,7 +77,10 @@ export class WebLocaleService implements ILocaleService {
 class WebActiveLanguagePackService implements IActiveLanguagePackService {
 	_serviceBrand: undefined;
 
-	constructor(@IExtensionGalleryService private readonly galleryService: IExtensionGalleryService) { }
+	constructor(
+		@IExtensionGalleryService private readonly galleryService: IExtensionGalleryService,
+		@ILogService private readonly logService: ILogService
+	) { }
 
 	async getExtensionIdProvidingCurrentLocale(): Promise<string | undefined> {
 		const language = Language.value();
@@ -88,17 +92,26 @@ class WebActiveLanguagePackService implements IActiveLanguagePackService {
 			return extensionId;
 		}
 
-		const tagResult = await this.galleryService.query({ text: `tag:lp-${language}` }, CancellationToken.None);
-
-		// Only install extensions that are published by Microsoft and start with vscode-language-pack for extra certainty
-		const extensionToInstall = tagResult.firstPage.find(e => e.publisher === 'MS-CEINTL' && e.name.startsWith('vscode-language-pack'));
-		if (extensionToInstall) {
-			window.localStorage.setItem(WebLocaleService._LOCAL_STORAGE_EXTENSION_ID_KEY, extensionToInstall.identifier.id);
-			return extensionToInstall.identifier.id;
+		if (!this.galleryService.isEnabled()) {
+			return undefined;
 		}
 
-		// TODO: If a non-Microsoft language pack is installed, we should prompt the user asking if they want to install that.
-		// Since no such language packs exist yet, we can wait until that happens to implement this.
+		try {
+			const tagResult = await this.galleryService.query({ text: `tag:lp-${language}` }, CancellationToken.None);
+
+			// Only install extensions that are published by Microsoft and start with vscode-language-pack for extra certainty
+			const extensionToInstall = tagResult.firstPage.find(e => e.publisher === 'MS-CEINTL' && e.name.startsWith('vscode-language-pack'));
+			if (extensionToInstall) {
+				window.localStorage.setItem(WebLocaleService._LOCAL_STORAGE_EXTENSION_ID_KEY, extensionToInstall.identifier.id);
+				return extensionToInstall.identifier.id;
+			}
+
+			// TODO: If a non-Microsoft language pack is installed, we should prompt the user asking if they want to install that.
+			// Since no such language packs exist yet, we can wait until that happens to implement this.
+		} catch (e) {
+			// Best effort
+			this.logService.error(e);
+		}
 
 		return undefined;
 	}


### PR DESCRIPTION
forgot to add this in my last PR... this makes sure we check if the galleryService is enabled and also try/catches all of those service calls just in case.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
