### PR TITLE
Disable lightbulb in scm input

### DIFF
--- a/src/vs/editor/contrib/codeAction/browser/codeActionContributions.ts
+++ b/src/vs/editor/contrib/codeAction/browser/codeActionContributions.ts
@@ -7,11 +7,13 @@ import { EditorContributionInstantiation, registerEditorAction, registerEditorCo
 import { editorConfigurationBaseNode } from 'vs/editor/common/config/editorConfigurationSchema';
 import { AutoFixAction, CodeActionCommand, FixAllAction, OrganizeImportsAction, QuickFixAction, RefactorAction, SourceAction } from 'vs/editor/contrib/codeAction/browser/codeActionCommands';
 import { CodeActionController } from 'vs/editor/contrib/codeAction/browser/codeActionController';
+import { LightBulbWidget } from 'vs/editor/contrib/codeAction/browser/lightBulbWidget';
 import * as nls from 'vs/nls';
 import { ConfigurationScope, Extensions, IConfigurationRegistry } from 'vs/platform/configuration/common/configurationRegistry';
 import { Registry } from 'vs/platform/registry/common/platform';
 
 registerEditorContribution(CodeActionController.ID, CodeActionController, EditorContributionInstantiation.Eventually);
+registerEditorContribution(LightBulbWidget.ID, LightBulbWidget, EditorContributionInstantiation.Lazy);
 registerEditorAction(QuickFixAction);
 registerEditorAction(RefactorAction);
 registerEditorAction(SourceAction);

--- a/src/vs/editor/contrib/codeAction/browser/codeActionUi.ts
+++ b/src/vs/editor/contrib/codeAction/browser/codeActionUi.ts
@@ -17,6 +17,7 @@ import { CodeActionKeybindingResolver } from 'vs/editor/contrib/codeAction/brows
 import { toMenuItems } from 'vs/editor/contrib/codeAction/browser/codeActionMenu';
 import { MessageController } from 'vs/editor/contrib/message/browser/messageController';
 import { localize } from 'vs/nls';
+import { IActionListDelegate } from 'vs/platform/actionWidget/browser/actionList';
 import { IActionWidgetService } from 'vs/platform/actionWidget/browser/actionWidget';
 import { ICommandService } from 'vs/platform/commands/common/commands';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
@@ -24,7 +25,6 @@ import { IInstantiationService } from 'vs/platform/instantiation/common/instanti
 import { CodeActionAutoApply, CodeActionItem, CodeActionSet, CodeActionTrigger } from '../common/types';
 import { CodeActionsState } from './codeActionModel';
 import { LightBulbWidget } from './lightBulbWidget';
-import { IActionListDelegate } from 'vs/platform/actionWidget/browser/actionList';
 
 export interface IActionShowOptions {
 	readonly includeDisabledActions?: boolean;
@@ -33,7 +33,7 @@ export interface IActionShowOptions {
 
 export class CodeActionUi extends Disposable {
 
-	private readonly _lightBulbWidget: Lazy<LightBulbWidget>;
+	private readonly _lightBulbWidget: Lazy<LightBulbWidget | null>;
 	private readonly _activeCodeActions = this._register(new MutableDisposable<CodeActionSet>());
 
 	private readonly _resolver: CodeActionKeybindingResolver;
@@ -55,8 +55,10 @@ export class CodeActionUi extends Disposable {
 		super();
 
 		this._lightBulbWidget = new Lazy(() => {
-			const widget = this._register(instantiationService.createInstance(LightBulbWidget, this._editor));
-			this._register(widget.onClick(e => this.showCodeActionList(e.actions, e, { includeDisabledActions: false, fromLightbulb: true })));
+			const widget = this._editor.getContribution<LightBulbWidget>(LightBulbWidget.ID);
+			if (widget) {
+				this._register(widget.onClick(e => this.showCodeActionList(e.actions, e, { includeDisabledActions: false, fromLightbulb: true })));
+			}
 			return widget;
 		});
 
@@ -88,7 +90,7 @@ export class CodeActionUi extends Disposable {
 			return;
 		}
 
-		this._lightBulbWidget.value.update(actions, newState.trigger, newState.position);
+		this._lightBulbWidget.value?.update(actions, newState.trigger, newState.position);
 
 		if (newState.trigger.type === CodeActionTriggerType.Invoke) {
 			if (newState.trigger.filter?.include) { // Triggered for specific scope
@@ -97,7 +99,7 @@ export class CodeActionUi extends Disposable {
 				const validActionToApply = this.tryGetValidActionToApply(newState.trigger, actions);
 				if (validActionToApply) {
 					try {
-						this._lightBulbWidget.value.hide();
+						this._lightBulbWidget.value?.hide();
 						await this.delegate.applyCodeAction(validActionToApply, false, false);
 					} finally {
 						actions.dispose();

--- a/src/vs/editor/contrib/codeAction/browser/lightBulbWidget.ts
+++ b/src/vs/editor/contrib/codeAction/browser/lightBulbWidget.ts
@@ -60,7 +60,6 @@ export class LightBulbWidget extends Disposable implements IContentWidget {
 
 	constructor(
 		private readonly _editor: ICodeEditor,
-
 		@IKeybindingService keybindingService: IKeybindingService
 	) {
 		super();
@@ -157,7 +156,7 @@ export class LightBulbWidget extends Disposable implements IContentWidget {
 		}
 
 		const model = this._editor.getModel();
-		if (!model) {
+		if (!model || model.getLanguageId() === 'scminput') {
 			return this.hide();
 		}
 

--- a/src/vs/editor/contrib/codeAction/browser/lightBulbWidget.ts
+++ b/src/vs/editor/contrib/codeAction/browser/lightBulbWidget.ts
@@ -14,6 +14,7 @@ import 'vs/css!./lightBulbWidget';
 import { ContentWidgetPositionPreference, ICodeEditor, IContentWidget, IContentWidgetPosition } from 'vs/editor/browser/editorBrowser';
 import { EditorOption } from 'vs/editor/common/config/editorOptions';
 import { IPosition } from 'vs/editor/common/core/position';
+import { IEditorContribution } from 'vs/editor/common/editorCommon';
 import { computeIndentLevel } from 'vs/editor/common/model/utils';
 import { autoFixCommandId, quickFixCommandId } from 'vs/editor/contrib/codeAction/browser/codeAction';
 import type { CodeActionSet, CodeActionTrigger } from 'vs/editor/contrib/codeAction/common/types';
@@ -43,8 +44,9 @@ namespace LightBulbState {
 	export type State = typeof Hidden | Showing;
 }
 
+export class LightBulbWidget extends Disposable implements IEditorContribution, IContentWidget {
 
-export class LightBulbWidget extends Disposable implements IContentWidget {
+	public static readonly ID = 'editor.contrib.lightbulbWidget';
 
 	private static readonly _posPref = [ContentWidgetPositionPreference.EXACT];
 
@@ -156,7 +158,7 @@ export class LightBulbWidget extends Disposable implements IContentWidget {
 		}
 
 		const model = this._editor.getModel();
-		if (!model || model.getLanguageId() === 'scminput') {
+		if (!model) {
 			return this.hide();
 		}
 


### PR DESCRIPTION
The lightbulb decoration looks out of place in scm input. With this, we still allow code actions using the shortcut or problems UI

