### PR TITLE
chore: update spdlog@0.13.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "@vscode/policy-watcher": "^1.1.4",
     "@vscode/proxy-agent": "^0.13.1",
     "@vscode/ripgrep": "^1.15.0",
-    "@vscode/spdlog": "^0.13.8",
+    "@vscode/spdlog": "^0.13.9",
     "@vscode/sqlite3": "5.1.2-vscode",
     "@vscode/sudo-prompt": "9.3.1",
     "@vscode/vscode-languagedetection": "1.0.21",

--- a/remote/package.json
+++ b/remote/package.json
@@ -8,7 +8,7 @@
     "@parcel/watcher": "2.1.0",
     "@vscode/iconv-lite-umd": "0.7.0",
     "@vscode/proxy-agent": "^0.13.1",
-    "@vscode/spdlog": "^0.13.8",
+    "@vscode/spdlog": "^0.13.9",
     "@vscode/ripgrep": "^1.15.0",
     "@vscode/vscode-languagedetection": "1.0.21",
     "cookie": "^0.4.0",

--- a/remote/yarn.lock
+++ b/remote/yarn.lock
@@ -80,10 +80,10 @@
     https-proxy-agent "^5.0.0"
     proxy-from-env "^1.1.0"
 
-"@vscode/spdlog@^0.13.8":
-  version "0.13.8"
-  resolved "https://registry.yarnpkg.com/@vscode/spdlog/-/spdlog-0.13.8.tgz#6136438e149f90eeb9d493d7b396866a542e1229"
-  integrity sha512-yYgiAF2eOFJJRvDGdB3b7LNNS+CTdIkmHmAYUr8RaAu+aJlCsRkfCdMS/jisnyHzVLYlE4bZYn/gkAbROtEeYw==
+"@vscode/spdlog@^0.13.9":
+  version "0.13.9"
+  resolved "https://registry.yarnpkg.com/@vscode/spdlog/-/spdlog-0.13.9.tgz#bac062762bc48ae9a6e86dd2d59c96b5ab63170c"
+  integrity sha512-c5Kmkhq+FyI0tCr569Q9aqIex2CgfRsa41PirK/9zpGRYRJlPyLo5U3Vp3THvfJYiDDLpQFeyRh/Sy5UJFW2gA==
   dependencies:
     bindings "^1.5.0"
     mkdirp "^0.5.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1325,10 +1325,10 @@
     https-proxy-agent "^5.0.0"
     proxy-from-env "^1.1.0"
 
-"@vscode/spdlog@^0.13.8":
-  version "0.13.8"
-  resolved "https://registry.yarnpkg.com/@vscode/spdlog/-/spdlog-0.13.8.tgz#6136438e149f90eeb9d493d7b396866a542e1229"
-  integrity sha512-yYgiAF2eOFJJRvDGdB3b7LNNS+CTdIkmHmAYUr8RaAu+aJlCsRkfCdMS/jisnyHzVLYlE4bZYn/gkAbROtEeYw==
+"@vscode/spdlog@^0.13.9":
+  version "0.13.9"
+  resolved "https://registry.yarnpkg.com/@vscode/spdlog/-/spdlog-0.13.9.tgz#bac062762bc48ae9a6e86dd2d59c96b5ab63170c"
+  integrity sha512-c5Kmkhq+FyI0tCr569Q9aqIex2CgfRsa41PirK/9zpGRYRJlPyLo5U3Vp3THvfJYiDDLpQFeyRh/Sy5UJFW2gA==
   dependencies:
     bindings "^1.5.0"
     mkdirp "^0.5.5"


### PR DESCRIPTION
Addresses the build failure introduced with https://github.com/microsoft/vscode/pull/179035

/cc @rzhao271 