### PR TITLE
Add support for attachment cleaning on notebook save

### DIFF
--- a/extensions/ipynb/package.json
+++ b/extensions/ipynb/package.json
@@ -10,7 +10,8 @@
 	},
 	"enabledApiProposals": [
 		"documentPaste",
-		"diffContentOptions"
+		"diffContentOptions",
+    "notebookDocumentWillSave"
 	],
 	"activationEvents": [
 		"onNotebook:jupyter-notebook"

--- a/extensions/ipynb/src/notebookAttachmentCleaner.ts
+++ b/extensions/ipynb/src/notebookAttachmentCleaner.ts
@@ -5,7 +5,7 @@
 
 import * as vscode from 'vscode';
 import { ATTACHMENT_CLEANUP_COMMANDID, JUPYTER_NOTEBOOK_MARKDOWN_SELECTOR } from './constants';
-import { DebounceTrigger, deepClone, objectEquals } from './helper';
+import { deepClone, objectEquals, Delayer } from './helper';
 
 interface AttachmentCleanRequest {
 	notebook: vscode.NotebookDocument;
@@ -32,15 +32,10 @@ export class AttachmentCleaner implements vscode.CodeActionProvider {
 
 	private _disposables: vscode.Disposable[];
 	private _imageDiagnosticCollection: vscode.DiagnosticCollection;
+	private readonly _delayer = new Delayer(750);
+
 	constructor() {
 		this._disposables = [];
-		const debounceTrigger = new DebounceTrigger<AttachmentCleanRequest>({
-			callback: (change: AttachmentCleanRequest) => {
-				this.cleanNotebookAttachments(change);
-			},
-			delay: 500
-		});
-
 		this._imageDiagnosticCollection = vscode.languages.createDiagnosticCollection('Notebook Image Attachment');
 		this._disposables.push(this._imageDiagnosticCollection);
 
@@ -57,21 +52,64 @@ export class AttachmentCleaner implements vscode.CodeActionProvider {
 		}));
 
 		this._disposables.push(vscode.workspace.onDidChangeNotebookDocument(e => {
-			e.cellChanges.forEach(change => {
-				if (!change.document) {
-					return;
-				}
+			this._delayer.trigger(() => {
 
-				if (change.cell.kind !== vscode.NotebookCellKind.Markup) {
-					return;
-				}
+				e.cellChanges.forEach(change => {
+					if (!change.document) {
+						return;
+					}
 
-				debounceTrigger.trigger({
-					notebook: e.notebook,
-					cell: change.cell,
-					document: change.document
+					if (change.cell.kind !== vscode.NotebookCellKind.Markup) {
+						return;
+					}
+
+					const metadataEdit = this.cleanNotebookAttachments({
+						notebook: e.notebook,
+						cell: change.cell,
+						document: change.document
+					});
+					if (metadataEdit) {
+						const workspaceEdit = new vscode.WorkspaceEdit();
+						workspaceEdit.set(e.notebook.uri, [metadataEdit]);
+						vscode.workspace.applyEdit(workspaceEdit);
+					}
 				});
 			});
+		}));
+
+
+		this._disposables.push(vscode.workspace.onWillSaveNotebookDocument(e => {
+			if (e.reason === vscode.TextDocumentSaveReason.Manual) {
+				this._delayer.dispose();
+
+				e.waitUntil(new Promise((resolve) => {
+					if (e.document.getCells().length === 0) {
+						return;
+					}
+
+					const notebookEdits: vscode.NotebookEdit[] = [];
+					for (const cell of e.document.getCells()) {
+						if (cell.kind !== vscode.NotebookCellKind.Markup) {
+							continue;
+						}
+
+						const metadataEdit = this.cleanNotebookAttachments({
+							notebook: e.document,
+							cell: cell,
+							document: cell.document
+						});
+
+						if (metadataEdit) {
+							notebookEdits.push(metadataEdit);
+						}
+					}
+
+					const workspaceEdit = new vscode.WorkspaceEdit();
+					workspaceEdit.set(e.document.uri, notebookEdits);
+
+					resolve(workspaceEdit);
+				}));
+			}
 		}));
 
 		this._disposables.push(vscode.workspace.onDidCloseNotebookDocument(e => {
@@ -134,8 +172,10 @@ export class AttachmentCleaner implements vscode.CodeActionProvider {
 	/**
 	 * take in a NotebookDocumentChangeEvent, and clean the attachment data for the cell(s) that have had their markdown source code changed
 	 * @param e NotebookDocumentChangeEvent from the onDidChangeNotebookDocument listener
+	 * @returns vscode.NotebookEdit, the metadata alteration performed on the json behind the ipynb
 	 */
-	private cleanNotebookAttachments(e: AttachmentCleanRequest) {
+	private cleanNotebookAttachments(e: AttachmentCleanRequest): vscode.NotebookEdit | undefined {
+
 		if (e.notebook.isClosed) {
 			return;
 		}
@@ -187,16 +227,16 @@ export class AttachmentCleaner implements vscode.CodeActionProvider {
 			}
 		}
 
+		this.updateDiagnostics(cell.document.uri, diagnostics);
+
 		if (cell.index > -1 && !objectEquals(markdownAttachmentsInUse, cell.metadata.attachments)) {
 			const updateMetadata: { [key: string]: any } = deepClone(cell.metadata);
 			updateMetadata.attachments = markdownAttachmentsInUse;
 			const metadataEdit = vscode.NotebookEdit.updateCellMetadata(cell.index, updateMetadata);
-			const workspaceEdit = new vscode.WorkspaceEdit();
-			workspaceEdit.set(e.notebook.uri, [metadataEdit]);
-			vscode.workspace.applyEdit(workspaceEdit);
-		}
 
-		this.updateDiagnostics(cell.document.uri, diagnostics);
+			return metadataEdit;
+		}
+		return;
 	}
 
 	private analyzeMissingAttachments(document: vscode.TextDocument): void {

--- a/extensions/ipynb/tsconfig.json
+++ b/extensions/ipynb/tsconfig.json
@@ -2,13 +2,12 @@
 	"extends": "../tsconfig.base.json",
 	"compilerOptions": {
 		"outDir": "./out",
-		"lib": [
-			"dom"
-		]
+		"lib": ["dom"]
 	},
 	"include": [
 		"src/**/*",
 		"../../src/vscode-dts/vscode.d.ts",
-		"../../src/vscode-dts/vscode.proposed.documentPaste.d.ts"
+		"../../src/vscode-dts/vscode.proposed.documentPaste.d.ts",
+		"../../src/vscode-dts/vscode.proposed.notebookDocumentWillSave.d.ts"
 	]
 }

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "@vscode/policy-watcher": "^1.1.4",
     "@vscode/proxy-agent": "^0.13.1",
     "@vscode/ripgrep": "^1.15.0",
-    "@vscode/sqlite3": "5.1.2-vscode",
+    "@vscode/sqlite3": "5.1.3-vscode",
     "@vscode/sudo-prompt": "9.3.1",
     "@vscode/vscode-languagedetection": "1.0.21",
     "graceful-fs": "4.2.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1325,10 +1325,10 @@
     https-proxy-agent "^5.0.0"
     proxy-from-env "^1.1.0"
 
-"@vscode/sqlite3@5.1.2-vscode":
-  version "5.1.2-vscode"
-  resolved "https://registry.yarnpkg.com/@vscode/sqlite3/-/sqlite3-5.1.2-vscode.tgz#ba15962d23ad784a43ecbaaa22c93f17f93b2400"
-  integrity sha512-CIH0BWzQJA97teb1f3aAoyylztPdg1WqThHEvVPWXr8UO0+VtIa+ha20Q2PGYV4AGfPtkPnhUrSYpJDxnVhW/g==
+"@vscode/sqlite3@5.1.3-vscode":
+  version "5.1.3-vscode"
+  resolved "https://registry.yarnpkg.com/@vscode/sqlite3/-/sqlite3-5.1.3-vscode.tgz#4fe81eb2422edef7b13869fe9d66663f4d925e93"
+  integrity sha512-B5PNGHzfdnLiAQiC4YjOt0YETtxVfRcyIJya39RdNNFW63ApCznsu4m+jrW6r1sDFCPSSTNurAwx1Bl25FCQFw==
   dependencies:
     node-addon-api "^4.2.0"
     tar "^6.1.11"


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Adopted `onWillSaveNotebookDocument` into `notebookAttachmentCleaner.ts`. Replaced the debouncer with a Delayer class that allowed for the disposal of the timeout. 

This is a fix for the corner case where a user edits an attachment link quickly, then saves immediately, resulting in the metadata being altered *after* the notebook is saved. The user would see a dirty notebook state right after saving. 

