### PR TITLE
Remove usage of A11yService & go back to aria-activedescendant

### DIFF
--- a/src/vs/editor/standalone/browser/quickInput/standaloneQuickInputService.ts
+++ b/src/vs/editor/standalone/browser/quickInput/standaloneQuickInputService.ts
@@ -12,7 +12,6 @@ import { IQuickInputService, IQuickInputButton, IQuickPickItem, IQuickPick, IInp
 import { CancellationToken } from 'vs/base/common/cancellation';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
-import { IAccessibilityService } from 'vs/platform/accessibility/common/accessibility';
 import { EditorScopedLayoutService } from 'vs/editor/standalone/browser/standaloneLayoutService';
 import { ICodeEditorService } from 'vs/editor/browser/services/codeEditorService';
 import { IQuickInputControllerHost, QuickInputController } from 'vs/platform/quickinput/browser/quickInput';
@@ -29,10 +28,9 @@ class EditorScopedQuickInputService extends QuickInputService {
 		@IInstantiationService instantiationService: IInstantiationService,
 		@IContextKeyService contextKeyService: IContextKeyService,
 		@IThemeService themeService: IThemeService,
-		@IAccessibilityService accessibilityService: IAccessibilityService,
 		@ICodeEditorService codeEditorService: ICodeEditorService
 	) {
-		super(instantiationService, contextKeyService, themeService, accessibilityService, new EditorScopedLayoutService(editor.getContainerDomNode(), codeEditorService));
+		super(instantiationService, contextKeyService, themeService, new EditorScopedLayoutService(editor.getContainerDomNode(), codeEditorService));
 
 		// Use the passed in code editor as host for the quick input widget
 		const contribution = QuickInputEditorContribution.get(editor);

--- a/src/vs/platform/quickinput/browser/quickInput.ts
+++ b/src/vs/platform/quickinput/browser/quickInput.ts
@@ -1036,8 +1036,8 @@ class QuickPick<T extends IQuickPickItem> extends QuickInput implements IQuickPi
 				ariaLabel += ` - ${this.title}`;
 			}
 		}
-		if (this.ui.inputBox.ariaLabel !== ariaLabel) {
-			this.ui.inputBox.ariaLabel = ariaLabel;
+		if (this.ui.list.ariaLabel !== ariaLabel) {
+			this.ui.list.ariaLabel = ariaLabel;
 		}
 		this.ui.list.matchOnDescription = this.matchOnDescription;
 		this.ui.list.matchOnDetail = this.matchOnDetail;
@@ -1339,6 +1339,9 @@ export class QuickInputController extends Disposable {
 		const listId = this.idPrefix + 'list';
 		const list = this._register(new QuickInputList(container, listId, this.options));
 		inputBox.setAttribute('aria-controls', listId);
+		this._register(list.onDidChangeFocus(() => {
+			inputBox.setAttribute('aria-activedescendant', list.getActiveDescendant() ?? '');
+		}));
 		this._register(list.onChangedAllVisibleChecked(checked => {
 			checkAll.checked = checked;
 		}));
@@ -1680,7 +1683,6 @@ export class QuickInputController extends Disposable {
 		ui.list.matchOnLabel = true;
 		ui.list.sortByLabel = true;
 		ui.ignoreFocusOut = false;
-		ui.inputBox.ariaLabel = '';
 		ui.inputBox.toggles = undefined;
 
 		const backKeybindingLabel = this.options.backKeybindingLabel();

--- a/src/vs/platform/quickinput/browser/quickInputBox.ts
+++ b/src/vs/platform/quickinput/browser/quickInputBox.ts
@@ -28,6 +28,11 @@ export class QuickInputBox extends Disposable {
 		super();
 		this.container = dom.append(this.parent, $('.quick-input-box'));
 		this.findInput = this._register(new FindInput(this.container, undefined, { label: '', inputBoxStyles, toggleStyles }));
+		const input = this.findInput.inputBox.inputElement;
+		input.role = 'combobox';
+		input.ariaHasPopup = 'menu';
+		input.ariaAutoComplete = 'list';
+		input.ariaExpanded = 'true';
 	}
 
 	onKeyDown = (handler: (event: StandardKeyboardEvent) => void): IDisposable => {

--- a/src/vs/platform/quickinput/browser/quickInputBox.ts
+++ b/src/vs/platform/quickinput/browser/quickInputBox.ts
@@ -79,14 +79,6 @@ export class QuickInputBox extends Disposable {
 		this.findInput.inputBox.setPlaceHolder(placeholder);
 	}
 
-	get ariaLabel() {
-		return this.findInput.inputBox.getAriaLabel();
-	}
-
-	set ariaLabel(ariaLabel: string) {
-		this.findInput.inputBox.setAriaLabel(ariaLabel);
-	}
-
 	get password() {
 		return this.findInput.inputBox.inputElement.type === 'password';
 	}

--- a/src/vs/platform/quickinput/browser/quickInputList.ts
+++ b/src/vs/platform/quickinput/browser/quickInputList.ts
@@ -6,7 +6,7 @@
 import * as dom from 'vs/base/browser/dom';
 import { StandardKeyboardEvent } from 'vs/base/browser/keyboardEvent';
 import { ActionBar } from 'vs/base/browser/ui/actionbar/actionbar';
-import { AriaRole } from 'vs/base/browser/ui/aria/aria';
+import { alert, AriaRole } from 'vs/base/browser/ui/aria/aria';
 import { HoverPosition } from 'vs/base/browser/ui/hover/hoverWidget';
 import { IHoverWidget } from 'vs/base/browser/ui/iconLabel/iconHoverDelegate';
 import { IconLabel, IIconLabelValueOptions } from 'vs/base/browser/ui/iconLabel/iconLabel';
@@ -286,7 +286,6 @@ export class QuickInputList {
 
 	readonly id: string;
 	private container: HTMLElement;
-	private liveElement: HTMLElement;
 	private list: List<ListElement>;
 	private inputElements: Array<QuickPickItem> = [];
 	private elements: ListElement[] = [];
@@ -326,11 +325,6 @@ export class QuickInputList {
 	) {
 		this.id = id;
 		this.container = dom.append(this.parent, $('.quick-input-list'));
-		this.liveElement = dom.append(this.container, $('div', {
-			'aria-live': 'polite',
-			'aria-relevant': 'additions'
-		}));
-
 		const delegate = new ListElementDelegate();
 		const accessibilityProvider = new QuickInputAccessibilityProvider();
 		this.list = options.createList('QuickInput', this.container, delegate, [new ListElementRenderer()], {
@@ -343,16 +337,8 @@ export class QuickInputList {
 		this.list.getHTMLElement().id = id;
 		this.disposables.push(this.list);
 		this.disposables.push(this.list.onDidChangeFocus(e => {
-			const item = $('div', {
-				'aria-labelledby': this.getActiveDescendant() ?? ''
-			});
-			if (this.liveElement.hasChildNodes()) {
-				dom.reset(this.liveElement, item);
-			} else {
-				// give NVDA time to register that the newly created live region - ref https://github.com/nvaccess/nvda/issues/8873
-				setTimeout(() => {
-					dom.reset(this.liveElement, item);
-				}, 500);
+			if (e.elements.length) {
+				alert(e.elements.map(el => el.saneAriaLabel).join(', '));
 			}
 		}));
 		this.disposables.push(this.list.onKeyDown(e => {

--- a/src/vs/platform/quickinput/browser/quickInputList.ts
+++ b/src/vs/platform/quickinput/browser/quickInputList.ts
@@ -6,7 +6,7 @@
 import * as dom from 'vs/base/browser/dom';
 import { StandardKeyboardEvent } from 'vs/base/browser/keyboardEvent';
 import { ActionBar } from 'vs/base/browser/ui/actionbar/actionbar';
-import { alert, AriaRole } from 'vs/base/browser/ui/aria/aria';
+import { AriaRole } from 'vs/base/browser/ui/aria/aria';
 import { HoverPosition } from 'vs/base/browser/ui/hover/hoverWidget';
 import { IHoverWidget } from 'vs/base/browser/ui/iconLabel/iconHoverDelegate';
 import { IconLabel, IIconLabelValueOptions } from 'vs/base/browser/ui/iconLabel/iconLabel';
@@ -336,11 +336,6 @@ export class QuickInputList {
 		} as IListOptions<ListElement>);
 		this.list.getHTMLElement().id = id;
 		this.disposables.push(this.list);
-		this.disposables.push(this.list.onDidChangeFocus(e => {
-			if (e.elements.length) {
-				alert(e.elements.map(el => el.saneAriaLabel).join(', '));
-			}
-		}));
 		this.disposables.push(this.list.onKeyDown(e => {
 			const event = new StandardKeyboardEvent(e);
 			switch (event.keyCode) {
@@ -466,6 +461,14 @@ export class QuickInputList {
 
 	set scrollTop(scrollTop: number) {
 		this.list.scrollTop = scrollTop;
+	}
+
+	get ariaLabel() {
+		return this.list.getHTMLElement().ariaLabel;
+	}
+
+	set ariaLabel(label: string | null) {
+		this.list.getHTMLElement().ariaLabel = label;
 	}
 
 	getAllVisibleChecked() {

--- a/src/vs/platform/quickinput/browser/quickInputService.ts
+++ b/src/vs/platform/quickinput/browser/quickInputService.ts
@@ -7,7 +7,6 @@ import { IListRenderer, IListVirtualDelegate } from 'vs/base/browser/ui/list/lis
 import { List } from 'vs/base/browser/ui/list/listWidget';
 import { CancellationToken } from 'vs/base/common/cancellation';
 import { Emitter } from 'vs/base/common/event';
-import { IAccessibilityService } from 'vs/platform/accessibility/common/accessibility';
 import { IContextKey, IContextKeyService, RawContextKey } from 'vs/platform/contextkey/common/contextkey';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { ILayoutService } from 'vs/platform/layout/browser/layoutService';
@@ -60,7 +59,6 @@ export class QuickInputService extends Themable implements IQuickInputService {
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
 		@IContextKeyService protected readonly contextKeyService: IContextKeyService,
 		@IThemeService themeService: IThemeService,
-		@IAccessibilityService private readonly accessibilityService: IAccessibilityService,
 		@ILayoutService protected readonly layoutService: ILayoutService
 	) {
 		super(themeService);
@@ -71,7 +69,6 @@ export class QuickInputService extends Themable implements IQuickInputService {
 			idPrefix: 'quickInput_',
 			container: host.container,
 			ignoreFocusOut: () => false,
-			isScreenReaderOptimized: () => this.accessibilityService.isScreenReaderOptimized(),
 			backKeybindingLabel: () => undefined,
 			setContextKey: (id?: string) => this.setContextKey(id),
 			linkOpenerDelegate: (content) => {

--- a/src/vs/platform/quickinput/test/browser/quickinput.test.ts
+++ b/src/vs/platform/quickinput/test/browser/quickinput.test.ts
@@ -46,7 +46,6 @@ suite('QuickInput', () => { // https://github.com/microsoft/vscode/issues/147543
 			container: fixture,
 			idPrefix: 'testQuickInput',
 			ignoreFocusOut() { return true; },
-			isScreenReaderOptimized() { return false; },
 			returnFocus() { },
 			backKeybindingLabel() { return undefined; },
 			setContextKey() { return undefined; },

--- a/src/vs/workbench/services/quickinput/browser/quickInputService.ts
+++ b/src/vs/workbench/services/quickinput/browser/quickInputService.ts
@@ -9,7 +9,6 @@ import { IThemeService } from 'vs/platform/theme/common/themeService';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
-import { IAccessibilityService } from 'vs/platform/accessibility/common/accessibility';
 import { QuickInputController } from 'vs/platform/quickinput/browser/quickInput';
 import { QuickInputService as BaseQuickInputService } from 'vs/platform/quickinput/browser/quickInputService';
 import { InstantiationType, registerSingleton } from 'vs/platform/instantiation/common/extensions';
@@ -29,11 +28,10 @@ export class QuickInputService extends BaseQuickInputService {
 		@IKeybindingService private readonly keybindingService: IKeybindingService,
 		@IContextKeyService contextKeyService: IContextKeyService,
 		@IThemeService themeService: IThemeService,
-		@IAccessibilityService accessibilityService: IAccessibilityService,
 		@ILayoutService layoutService: ILayoutService,
 		@IHoverService private readonly hoverService: IHoverService
 	) {
-		super(instantiationService, contextKeyService, themeService, accessibilityService, layoutService);
+		super(instantiationService, contextKeyService, themeService, layoutService);
 
 		this.registerListeners();
 	}

--- a/src/vs/workbench/test/browser/workbenchTestServices.ts
+++ b/src/vs/workbench/test/browser/workbenchTestServices.ts
@@ -320,7 +320,7 @@ export function workbenchInstantiationService(
 	instantiationService.stub(IPaneCompositePartService, new TestPaneCompositeService());
 	instantiationService.stub(IListService, new TestListService());
 	const hoverService = instantiationService.stub(IHoverService, instantiationService.createInstance(TestHoverService));
-	instantiationService.stub(IQuickInputService, disposables.add(new QuickInputService(configService, instantiationService, keybindingService, contextKeyService, themeService, accessibilityService, layoutService, hoverService)));
+	instantiationService.stub(IQuickInputService, disposables.add(new QuickInputService(configService, instantiationService, keybindingService, contextKeyService, themeService, layoutService, hoverService)));
 	instantiationService.stub(IWorkspacesService, new TestWorkspacesService());
 	instantiationService.stub(IWorkspaceTrustManagementService, new TestWorkspaceTrustManagementService());
 	instantiationService.stub(ITerminalInstanceService, new TestTerminalInstanceService());


### PR DESCRIPTION
Follow up of https://github.com/microsoft/vscode/pull/179193

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Sorry for the confusion... but where this ends up is:
* we still use `aria-activedescendant`
* we set the aria-label of the _list_ to be the placeholder/saneAriaLabel value

This is based on the idea from https://github.com/microsoft/vscode/issues/176081#issuecomment-1496723789