### PR TITLE
Always use vscode-textCodeBlock-background in rendered markdown

### DIFF
--- a/extensions/markdown-language-features/media/markdown.css
+++ b/extensions/markdown-language-features/media/markdown.css
@@ -205,15 +205,7 @@ pre code {
 
 /** Theming */
 
-.vscode-light pre {
-	background-color: rgba(220, 220, 220, 0.4);
-}
-
-.vscode-dark pre {
-	background-color: rgba(10, 10, 10, 0.4);
-}
-
-.vscode-high-contrast pre {
+pre {
 	background-color: var(--vscode-textCodeBlock-background);
 }
 

--- a/src/vs/workbench/contrib/markdown/browser/markdownDocumentRenderer.ts
+++ b/src/vs/workbench/contrib/markdown/browser/markdownDocumentRenderer.ts
@@ -115,15 +115,7 @@ pre code {
 
 /** Theming */
 
-.vscode-light pre {
-	background-color: rgba(220, 220, 220, 0.4);
-}
-
-.vscode-dark pre {
-	background-color: rgba(10, 10, 10, 0.4);
-}
-
-.vscode-high-contrast pre {
+.pre {
 	background-color: var(--vscode-textCodeBlock-background);
 }
 
@@ -150,7 +142,6 @@ pre code {
 .vscode-dark td {
 	border-color: rgba(255, 255, 255, 0.18);
 }
-
 `;
 
 const allowedProtocols = [Schemas.http, Schemas.https, Schemas.command];


### PR DESCRIPTION
Fixes #179219

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
