### PR TITLE
Visually show empty linked editing ranges

### DIFF
--- a/src/vs/editor/contrib/linkedEditing/browser/linkedEditing.css
+++ b/src/vs/editor/contrib/linkedEditing/browser/linkedEditing.css
@@ -5,5 +5,7 @@
 
 .monaco-editor .linked-editing-decoration {
 	background-color: var(--vscode-editor-linkedEditingBackground);
-	border-left-color: var(--vscode-editor-linkedEditingBackground);
+
+	/* Ensure decoration is visible even if range is empty */
+	min-width: 1px;
 }


### PR DESCRIPTION
Fixes #179319

Setting a min-width seems better than adding a border since borders shift the size of the element