### PR TITLE
Clear linked editing range on recompute

### DIFF
--- a/src/vs/editor/contrib/linkedEditing/browser/linkedEditing.ts
+++ b/src/vs/editor/contrib/linkedEditing/browser/linkedEditing.ts
@@ -91,7 +91,7 @@ export class LinkedEditingContribution extends Disposable implements IEditorCont
 		this._providers = languageFeaturesService.linkedEditingRangeProvider;
 		this._enabled = false;
 		this._visibleContextKey = CONTEXT_ONTYPE_RENAME_INPUT_VISIBLE.bindTo(contextKeyService);
-		this._debounceInformation = languageFeatureDebounceService.for(this._providers, 'Linked Editing', { min: 200 });
+		this._debounceInformation = languageFeatureDebounceService.for(this._providers, 'Linked Editing', { max: 200 });
 
 		this._currentDecorations = this._editor.createDecorationsCollection();
 		this._languageWordPattern = null;
@@ -177,7 +177,7 @@ export class LinkedEditingContribution extends Disposable implements IEditorCont
 	}
 
 	private _syncRanges(token: number): void {
-		// dalayed invocation, make sure we're still on
+		// delayed invocation, make sure we're still on
 		if (!this._editor.hasModel() || token !== this._syncRangesToken || this._currentDecorations.length === 0) {
 			// nothing to do
 			return;
@@ -299,6 +299,9 @@ export class LinkedEditingContribution extends Disposable implements IEditorCont
 				}
 			}
 		}
+
+		// Clear existing decorations while we compute new ones
+		this.clearRanges();
 
 		this._currentRequestPosition = position;
 		this._currentRequestModelVersion = modelVersionId;


### PR DESCRIPTION
Fixes #179328

Makes linked editing appear more responsive by:

- Clear the existing ranges when we start recomputing new ones
- Cap recompute delay at 200ms instead of making 200ms the min. IMO this could be lowered further

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
