### PR TITLE
Make script blocks respect js/ts.implicitProjectConfig.strictNullChecks

### DIFF
--- a/extensions/html-language-features/client/src/htmlClient.ts
+++ b/extensions/html-language-features/client/src/htmlClient.ts
@@ -155,7 +155,7 @@ async function startClientWithParticipants(languageParticipants: LanguagePartici
 	const clientOptions: LanguageClientOptions = {
 		documentSelector,
 		synchronize: {
-			configurationSection: ['html', 'css', 'javascript'], // the settings to synchronize
+			configurationSection: ['html', 'css', 'javascript', 'js/ts'], // the settings to synchronize
 		},
 		initializationOptions: {
 			embeddedLanguages,

--- a/extensions/html-language-features/server/src/htmlServer.ts
+++ b/extensions/html-language-features/server/src/htmlServer.ts
@@ -120,8 +120,9 @@ export function startServer(connection: Connection, runtime: RuntimeEnvironment)
 			let promise = documentSettings[textDocument.uri];
 			if (!promise) {
 				const scopeUri = textDocument.uri;
-				const configRequestParam: ConfigurationParams = { items: [{ scopeUri, section: 'css' }, { scopeUri, section: 'html' }, { scopeUri, section: 'javascript' }] };
-				promise = connection.sendRequest(ConfigurationRequest.type, configRequestParam).then(s => ({ css: s[0], html: s[1], javascript: s[2] }));
+				const sections = ['css', 'html', 'javascript', 'js/ts'];
+				const configRequestParam: ConfigurationParams = { items: sections.map(section => ({ scopeUri, section })) };
+				promise = connection.sendRequest(ConfigurationRequest.type, configRequestParam).then(s => ({ css: s[0], html: s[1], javascript: s[2], 'js/ts': s[3] }));
 				documentSettings[textDocument.uri] = promise;
 			}
 			return promise;

--- a/extensions/html-language-features/server/src/modes/javascriptMode.ts
+++ b/extensions/html-language-features/server/src/modes/javascriptMode.ts
@@ -103,12 +103,20 @@ export function getJavaScriptMode(documentRegions: LanguageModelCache<HTMLDocume
 
 	const host = getLanguageServiceHost(languageId === 'javascript' ? ts.ScriptKind.JS : ts.ScriptKind.TS);
 	const globalSettings: Settings = {};
+
+	function updateHostSettings(settings: Settings) {
+		const hostSettings = host.getCompilationSettings();
+		hostSettings.experimentalDecorators = settings?.['js/ts']?.implicitProjectConfig?.experimentalDecorators;
+		hostSettings.strictNullChecks = settings?.['js/ts']?.implicitProjectConfig.strictNullChecks;
+	}
+
 	return {
 		getId() {
 			return languageId;
 		},
 		async doValidation(document: TextDocument, settings = workspace.settings): Promise<Diagnostic[]> {
-			host.getCompilationSettings()['experimentalDecorators'] = settings && settings.javascript && settings.javascript.implicitProjectConfig.experimentalDecorators;
+			updateHostSettings(settings);
+
 			const jsDocument = jsDocuments.get(document);
 			const languageService = await host.getLanguageService(jsDocument);
 			const syntaxDiagnostics: ts.Diagnostic[] = languageService.getSyntacticDiagnostics(jsDocument.uri);

--- a/extensions/html-language-features/server/src/modes/languageModes.ts
+++ b/extensions/html-language-features/server/src/modes/languageModes.ts
@@ -37,9 +37,10 @@ export { ClientCapabilities, DocumentContext, LanguageService, HTMLDocument, HTM
 export { TextDocument } from 'vscode-languageserver-textdocument';
 
 export interface Settings {
-	css?: any;
-	html?: any;
-	javascript?: any;
+	readonly css?: any;
+	readonly html?: any;
+	readonly javascript?: any;
+	readonly 'js/ts'?: any;
 }
 
 export interface Workspace {


### PR DESCRIPTION
Fixes #179331

These settings now live under `js/ts`. Make sure we send these over to the html server 

Also fixes experimental decorators for script blocks
