### PR TITLE
[Backport] Fix built-in walkthroughs rendering

### DIFF
--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts
@@ -242,6 +242,7 @@ export class GettingStartedPage extends EditorPane {
 			}
 		}));
 
+		this._register(this.gettingStartedService.onDidAddBuiltInWalkthrough(rerender));
 		this._register(this.gettingStartedService.onDidAddWalkthrough(rerender));
 		this._register(this.gettingStartedService.onDidRemoveWalkthrough(rerender));
 

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStartedService.ts
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStartedService.ts
@@ -97,6 +97,7 @@ export interface IWalkthroughsService {
 	readonly onDidRemoveWalkthrough: Event<string>;
 	readonly onDidChangeWalkthrough: Event<IResolvedWalkthrough>;
 	readonly onDidProgressStep: Event<IResolvedWalkthroughStep>;
+	readonly onDidAddBuiltInWalkthrough: Event<void>;
 
 	readonly installedExtensionsRegistered: Promise<void>;
 
@@ -133,6 +134,9 @@ export class WalkthroughsService extends Disposable implements IWalkthroughsServ
 	readonly onDidChangeWalkthrough: Event<IResolvedWalkthrough> = this._onDidChangeWalkthrough.event;
 	private readonly _onDidProgressStep = new Emitter<IResolvedWalkthroughStep>();
 	readonly onDidProgressStep: Event<IResolvedWalkthroughStep> = this._onDidProgressStep.event;
+
+	private readonly _onDidAddBuiltInWalkthrough = new Emitter<void>();
+	readonly onDidAddBuiltInWalkthrough: Event<void> = this._onDidAddBuiltInWalkthrough.event;
 
 	private memento: Memento;
 	private stepProgress: Record<string, StepProgress | undefined>;
@@ -255,6 +259,8 @@ export class WalkthroughsService extends Disposable implements IWalkthroughsServ
 					})
 			});
 		});
+
+		this._onDidAddBuiltInWalkthrough.fire();
 	}
 
 	private updateWalkthroughContent(walkthrough: BuiltinGettingStartedCategory, experimentTreatment: WalkthroughTreatment): BuiltinGettingStartedCategory {


### PR DESCRIPTION
Fixes: https://github.com/microsoft/vscode/issues/178831
PR in main: https://github.com/microsoft/vscode/pull/179304
**The issue affects new user experience**

**Issue:**
- The built-in walkthrough registration was recently changed to be asynchronous with https://github.com/microsoft/vscode/commit/06dbbfa9355666d4c36a19bfb3f88a20ec99d40b#diff-ef0653ae93121f64b9d756dff8460099cba11fc175134d2ff193b671fe3f9003
- This causes a timing issue with the walkthrough rendering occurring before the built-in walkthroughs have finished resolving. 

**Fix :** 
Added a new event to watch for built-in walkthrough registration completion. We now retrigger walkthrough rendering on this event. (Ideally, we would change up the [gettingStartedService ](https://github.com/microsoft/vscode/blob/15cb6b36f8c29df77133b422d46b64e4d508488f/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStartedService.ts#LL94C1-L112C42)to be async  but that is a larger fix I do not wish to make currently).

