### PR TITLE
Nicely format logged objects

### DIFF
--- a/extensions/typescript-language-features/src/logging/tracer.ts
+++ b/extensions/typescript-language-features/src/logging/tracer.ts
@@ -45,6 +45,6 @@ export default class Tracer extends Disposable {
 	}
 
 	public trace(serverId: string, message: string, data?: unknown): void {
-		this.logger.trace(`<${serverId}> ${message}`, ...(data ? [JSON.stringify(data, null, 4)] : []));
+		this.logger.trace(`<${serverId}> ${message}`, data);
 	}
 }

--- a/src/vs/platform/log/common/log.ts
+++ b/src/vs/platform/log/common/log.ts
@@ -79,7 +79,7 @@ function format(args: any, verbose: boolean = false): string {
 
 		if (typeof a === 'object') {
 			try {
-				a = JSON.stringify(a);
+				a = JSON.stringify(a, null, 2);
 			} catch (e) { }
 		}
 


### PR DESCRIPTION
Follow up oin https://github.com/microsoft/vscode/issues/176479#issuecomment-1498597499

This uses JSON.stringify to format objects that are logged. Currently they are all printed as a single line without any whitespace

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
