### PR TITLE
create base `TerminalAccessibleWidget`, use it for terminal accessibility help menu

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/media/terminal.css
+++ b/src/vs/workbench/contrib/terminal/browser/media/terminal.css
@@ -551,8 +551,7 @@
 	background-color: var(--vscode-scrollbarSlider-activeBackground);
 }
 
-.monaco-workbench .terminal-accessibility-help,
-.monaco-workbench .accessible-buffer {
+.monaco-workbench .terminal-accessible-widget {
 	position: absolute;
 	left: 10px;
 	top: 0;
@@ -568,14 +567,12 @@
 	z-index: 0;
 }
 
-.monaco-workbench .accessible-buffer div {
+.monaco-workbench .terminal-accessible-widget div {
 	white-space: pre-wrap;
 }
 
-.monaco-workbench .terminal-accessibility-help.focus-within,
-.monaco-workbench .terminal-accessibility-help.active,
-.monaco-workbench .accessible-buffer.focus-within,
-.monaco-workbench .accessible-buffer.active {
+.monaco-workbench .terminal-accessible-widget.focus-within,
+.monaco-workbench .terminal-accessible-widget.active {
 	pointer-events: all;
 	opacity: 1;
 	z-index: 33;

--- a/src/vs/workbench/contrib/terminal/browser/media/terminal.css
+++ b/src/vs/workbench/contrib/terminal/browser/media/terminal.css
@@ -550,50 +550,11 @@
 .monaco-workbench .pane-body.integrated-terminal .xterm .xterm-viewport::-webkit-scrollbar-thumb:active {
 	background-color: var(--vscode-scrollbarSlider-activeBackground);
 }
-.monaco-workbench .terminal-accessibility-help {
-	z-index: 35;
-	position: absolute;
-	left: 0;
-	bottom: 0;
-	right: 0;
-	top: 0;
-	margin: auto;
-	text-align: left;
-	background-color: var(--vscode-menu-background);
-	min-width: 10%;
-	width: fit-content;
-	max-width: 70%;
-	min-height: fit-content;
-	height: fit-content !important;
-	vertical-align: middle;
-	border: 2px solid var(--vscode-contrastBorder);
-	box-shadow: 0 2px 8px var(--vscode-widget-shadow);
-}
 
-.terminal-accessibility-help a {
-	color: var(--vscode-textLink-foreground);
-}
-
-.terminal-accessibility-help a:hover {
-	cursor: pointer;
-	text-decoration: underline;
-	color: var(--vscode-textLink-activeForeground);
-}
-
-.terminal-accessibility-help a:active {
-	color: var(--vscode-textLink-activeForeground);
-}
-
-.terminal-accessibility-help a:focus {
-	outline: 1px solid -webkit-focus-ring-color;
-	outline-offset: -1px;
-	text-decoration: underline;
-	outline-color: var(--vscode-focusBorder);
-}
-
+.monaco-workbench .terminal-accessibility-help,
 .monaco-workbench .accessible-buffer {
 	position: absolute;
-	left: 0;
+	left: 10px;
 	top: 0;
 	bottom: 0;
 	right: 0;
@@ -603,21 +564,20 @@
 	padding: 0;
 	overflow: initial;
 	overflow-x: initial;
+	pointer-events: none;
+	z-index: 0;
 }
 
 .monaco-workbench .accessible-buffer div {
 	white-space: pre-wrap;
 }
 
+.monaco-workbench .terminal-accessibility-help.focus-within,
+.monaco-workbench .terminal-accessibility-help.active,
 .monaco-workbench .accessible-buffer.focus-within,
 .monaco-workbench .accessible-buffer.active {
 	pointer-events: all;
 	opacity: 1;
 	z-index: 33;
 	background-color: var(--vscode-terminal-background, --vscode-panel-background);
-}
-
-.monaco-workbench .accessible-buffer {
-	pointer-events: none;
-	z-index: 0;
 }

--- a/src/vs/workbench/contrib/terminalContrib/accessibility/browser/terminal.accessibility.contribution.ts
+++ b/src/vs/workbench/contrib/terminalContrib/accessibility/browser/terminal.accessibility.contribution.ts
@@ -72,11 +72,11 @@ registerTerminalAction({
 		const instantiationService = accessor.get(IInstantiationService);
 		const instance = await c.service.getActiveOrCreateInstance();
 		await revealActiveTerminal(instance, c);
-		const widget = instantiationService.createInstance(AccessibilityHelpWidget, instance);
-		instance.registerChildElement({
-			element: widget.element
-		});
-		widget.show();
+		const terminal = instance?.xterm;
+		if (!terminal) {
+			return;
+		}
+		await instantiationService.createInstance(AccessibilityHelpWidget, instance, terminal).show();
 	}
 });
 

--- a/src/vs/workbench/contrib/terminalContrib/accessibility/browser/terminalAccessibilityHelp.ts
+++ b/src/vs/workbench/contrib/terminalContrib/accessibility/browser/terminalAccessibilityHelp.ts
@@ -70,51 +70,29 @@ export class AccessibilityHelpWidget extends TerminalAccessibleWidget {
 	}
 
 	async updateEditor(): Promise<void> {
-		const introMessage = localize('introMsg', "Welcome to Terminal Accessibility Help");
-		const focusAccessibleBufferNls = localize('focusAccessibleBuffer', 'The Focus Accessible Buffer ({0}) command enables screen readers to read terminal contents.');
-		const focusAccessibleBufferNoKb = localize('focusAccessibleBufferNoKb', 'The Focus Accessible Buffer command enables screen readers to read terminal contents and is currently not triggerable by a keybinding.');
-		const shellIntegration = localize('shellIntegration', "The terminal has a feature called shell integration that offers an enhanced experience and provides useful commands for screen readers such as:");
-		const goToNextCommand = this._descriptionForCommand(TerminalCommandId.AccessibleBufferGoToNextCommand, localize('goToNextCommand', 'Go to Next Command ({0})'), localize('goToNextCommandNoKb', 'Go to Next Command is currently not triggerable by a keybinding.'));
-		const goToPreviousCommand = this._descriptionForCommand(TerminalCommandId.AccessibleBufferGoToPreviousCommand, localize('goToPreviousCommand', 'Go to Previous Command ({0})'), localize('goToPreviousCommandNoKb', 'Go to Previous Command is currently not triggerable by a keybinding.'));
-		const navigateAccessibleBuffer = localize('navigateAccessibleBuffer', 'Navigate Accessible Buffer ({0})');
-		const navigateAccessibleBufferNoKb = localize('navigateAccessibleBufferNoKb', 'Navigate Accessible Buffer is currently not triggerable by a keybinding.');
-		const runRecentCommand = localize('runRecentCommand', 'Run Recent Command ({0})');
-		const runRecentCommandNoKb = localize('runRecentCommandNoKb', 'Run Recent Command is currently not triggerable by a keybinding.');
-		const goToRecentNoShellIntegration = localize('goToRecentDirectoryNoShellIntegration', 'The Go to Recent Directory command ({0}) enables screen readers to easily navigate to a directory that has been used in the terminal.');
-		const goToRecentNoKbNoShellIntegration = localize('goToRecentDirectoryNoKbNoShellIntegration', 'The Go to Recent Directory command enables screen readers to easily navigate to a directory that has been used in the terminal and is currently not triggerable by a keybinding.');
-		const goToRecent = localize('goToRecentDirectory', 'Go to Recent Directory ({0})');
-		const goToRecentNoKb = localize('goToRecentDirectoryNoKb', 'Go to Recent Directory is currently not triggerable by a keybinding.');
-		const readMoreLink = localize('readMore', '[Read more about terminal accessibility](https://code.visualstudio.com/docs/editor/accessibility#_terminal-accessibility)');
-		const dismiss = localize('dismiss', "You can dismiss this dialog by pressing Escape, tab, or focusing elsewhere.");
-		const openDetectedLink = localize('openDetectedLink', 'The Open Detected Link ({0}) command enables screen readers to easily open links found in the terminal.');
-		const openDetectedLinkNoKb = localize('openDetectedLinkNoKb', 'The Open Detected Link command enables screen readers to easily open links found in the terminal and is currently not triggerable by a keybinding.');
-		const newWithProfile = localize('newWithProfile', 'The Create New Terminal (With Profile) ({0}) command allows for easy terminal creation using a specific profile.');
-		const newWithProfileNoKb = localize('newWithProfileNoKb', 'The Create New Terminal (With Profile) command allows for easy terminal creation using a specific profile and is currently not triggerable by a keybinding.');
-		const accessibilitySettings = localize('accessibilitySettings', 'Access accessibility settings such as `terminal.integrated.tabFocusMode` via the Preferences: Open Accessibility Settings command.');
-		const commandPrompt = localize('commandPromptMigration', "Consider using powershell instead of command prompt for an improved experience");
-
 		const content = [];
-		content.push(this._descriptionForCommand(TerminalCommandId.FocusAccessibleBuffer, focusAccessibleBufferNls, focusAccessibleBufferNoKb));
+		content.push(this._descriptionForCommand(TerminalCommandId.FocusAccessibleBuffer, localize('focusAccessibleBuffer', 'The Focus Accessible Buffer ({0}) command enables screen readers to read terminal contents.'), localize('focusAccessibleBufferNoKb', 'The Focus Accessible Buffer command enables screen readers to read terminal contents and is currently not triggerable by a keybinding.')));
 		if (this._instance.shellType === WindowsShellType.CommandPrompt) {
-			content.push(commandPrompt);
+			content.push(localize('commandPromptMigration', "Consider using powershell instead of command prompt for an improved experience"));
 		}
 		if (this._hasShellIntegration) {
-			content.push(shellIntegration);
-			content.push('- ' + goToNextCommand);
-			content.push('- ' + goToPreviousCommand);
-			content.push('- ' + this._descriptionForCommand(TerminalCommandId.NavigateAccessibleBuffer, navigateAccessibleBuffer, navigateAccessibleBufferNoKb));
-			content.push('- ' + this._descriptionForCommand(TerminalCommandId.RunRecentCommand, runRecentCommand, runRecentCommandNoKb));
-			content.push('- ' + this._descriptionForCommand(TerminalCommandId.GoToRecentDirectory, goToRecent, goToRecentNoKb));
+			content.push(localize('shellIntegration', "The terminal has a feature called shell integration that offers an enhanced experience and provides useful commands for screen readers such as:"));
+			content.push('- ' + this._descriptionForCommand(TerminalCommandId.AccessibleBufferGoToNextCommand, localize('goToNextCommand', 'Go to Next Command ({0})'), localize('goToNextCommandNoKb', 'Go to Next Command is currently not triggerable by a keybinding.')));
+			content.push('- ' + this._descriptionForCommand(TerminalCommandId.AccessibleBufferGoToPreviousCommand, localize('goToPreviousCommand', 'Go to Previous Command ({0})'), localize('goToPreviousCommandNoKb', 'Go to Previous Command is currently not triggerable by a keybinding.')));
+			content.push('- ' + this._descriptionForCommand(TerminalCommandId.NavigateAccessibleBuffer, localize('navigateAccessibleBuffer', 'Navigate Accessible Buffer ({0})'), localize('navigateAccessibleBufferNoKb', 'Navigate Accessible Buffer is currently not triggerable by a keybinding.')));
+			content.push('- ' + this._descriptionForCommand(TerminalCommandId.RunRecentCommand, localize('runRecentCommand', 'Run Recent Command ({0})'), localize('runRecentCommandNoKb', 'Run Recent Command is currently not triggerable by a keybinding.')));
+			content.push('- ' + this._descriptionForCommand(TerminalCommandId.GoToRecentDirectory, localize('goToRecentDirectory', 'Go to Recent Directory ({0})'), localize('goToRecentDirectoryNoKb', 'Go to Recent Directory is currently not triggerable by a keybinding.')));
 		} else {
-			content.push(this._descriptionForCommand(TerminalCommandId.GoToRecentDirectory, goToRecentNoShellIntegration, goToRecentNoKbNoShellIntegration));
+			content.push(this._descriptionForCommand(TerminalCommandId.RunRecentCommand, localize('goToRecentDirectoryNoShellIntegration', 'The Go to Recent Directory command ({0}) enables screen readers to easily navigate to a directory that has been used in the terminal.'), localize('goToRecentDirectoryNoKbNoShellIntegration', 'The Go to Recent Directory command enables screen readers to easily navigate to a directory that has been used in the terminal and is currently not triggerable by a keybinding.')));
 		}
-		content.push(this._descriptionForCommand(TerminalCommandId.OpenDetectedLink, openDetectedLink, openDetectedLinkNoKb));
-		content.push(this._descriptionForCommand(TerminalCommandId.NewWithProfile, newWithProfile, newWithProfileNoKb));
-		content.push(accessibilitySettings);
-		content.push(readMoreLink, dismiss);
+		content.push(this._descriptionForCommand(TerminalCommandId.OpenDetectedLink, localize('openDetectedLink', 'The Open Detected Link ({0}) command enables screen readers to easily open links found in the terminal.'), localize('openDetectedLinkNoKb', 'The Open Detected Link command enables screen readers to easily open links found in the terminal and is currently not triggerable by a keybinding.')));
+		content.push(this._descriptionForCommand(TerminalCommandId.NewWithProfile, localize('newWithProfile', 'The Create New Terminal (With Profile) ({0}) command allows for easy terminal creation using a specific profile.'), localize('newWithProfileNoKb', 'The Create New Terminal (With Profile) command allows for easy terminal creation using a specific profile and is currently not triggerable by a keybinding.')));
+		content.push(localize('accessibilitySettings', 'Access accessibility settings such as `terminal.integrated.tabFocusMode` via the Preferences: Open Accessibility Settings command.'));
+		content.push(localize('readMore', '[Read more about terminal accessibility](https://code.visualstudio.com/docs/editor/accessibility#_terminal-accessibility)'));
+		content.push(localize('dismiss', "You can dismiss this dialog by pressing Escape, tab, or focusing elsewhere."));
 		const model = this.editorWidget.getModel() || await this.getTextModel(this._instance.resource);
 		model?.setValue(content.join('\n'));
 		this.editorWidget.setModel(model);
-		this.element.setAttribute('aria-label', introMessage);
+		this.element.setAttribute('aria-label', localize('introMsg', "Welcome to Terminal Accessibility Help"));
 	}
 }

--- a/src/vs/workbench/contrib/terminalContrib/accessibility/browser/terminalAccessibilityHelp.ts
+++ b/src/vs/workbench/contrib/terminalContrib/accessibility/browser/terminalAccessibilityHelp.ts
@@ -77,6 +77,8 @@ export class AccessibilityHelpWidget extends TerminalAccessibleWidget {
 		const focusAccessibleBufferNls = localize('focusAccessibleBuffer', 'The Focus Accessible Buffer ({0}) command enables screen readers to read terminal contents.');
 		const focusAccessibleBufferNoKb = localize('focusAccessibleBufferNoKb', 'The Focus Accessible Buffer command enables screen readers to read terminal contents and is currently not triggerable by a keybinding.');
 		const shellIntegration = localize('shellIntegration', "The terminal has a feature called shell integration that offers an enhanced experience and provides useful commands for screen readers such as:");
+		const goToNextCommand = this._descriptionForCommand(TerminalCommandId.AccessibleBufferGoToNextCommand, localize('goToNextCommand', 'Go to Next Command ({0})'), localize('goToNextCommandNoKb', 'Go to Next Command is currently not triggerable by a keybinding.'));
+		const goToPreviousCommand = this._descriptionForCommand(TerminalCommandId.AccessibleBufferGoToPreviousCommand, localize('goToPreviousCommand', 'Go to Previous Command ({0})'), localize('goToPreviousCommandNoKb', 'Go to Previous Command is currently not triggerable by a keybinding.'));
 		const navigateAccessibleBuffer = localize('navigateAccessibleBuffer', 'Navigate Accessible Buffer ({0})');
 		const navigateAccessibleBufferNoKb = localize('navigateAccessibleBufferNoKb', 'Navigate Accessible Buffer is currently not triggerable by a keybinding.');
 		const runRecentCommand = localize('runRecentCommand', 'Run Recent Command ({0})');
@@ -101,6 +103,8 @@ export class AccessibilityHelpWidget extends TerminalAccessibleWidget {
 		}
 		if (this._hasShellIntegration) {
 			content.push(shellIntegration);
+			content.push('- ' + goToNextCommand);
+			content.push('- ' + goToPreviousCommand);
 			content.push('- ' + this._descriptionForCommand(TerminalCommandId.NavigateAccessibleBuffer, navigateAccessibleBuffer, navigateAccessibleBufferNoKb));
 			content.push('- ' + this._descriptionForCommand(TerminalCommandId.RunRecentCommand, runRecentCommand, runRecentCommandNoKb));
 			content.push('- ' + this._descriptionForCommand(TerminalCommandId.GoToRecentDirectory, goToRecent, goToRecentNoKb));

--- a/src/vs/workbench/contrib/terminalContrib/accessibility/browser/terminalAccessibilityHelp.ts
+++ b/src/vs/workbench/contrib/terminalContrib/accessibility/browser/terminalAccessibilityHelp.ts
@@ -47,10 +47,6 @@ export class AccessibilityHelpWidget extends TerminalAccessibleWidget {
 		return format(noKbMsg, commandId);
 	}
 
-	registerListeners(): void {
-		this._listeners.push(this._instance.onDidRequestFocus(() => this.editorWidget.focus()));
-	}
-
 	async updateEditor(): Promise<void> {
 		if (this.editorWidget.getModel()?.getValue().length) {
 			return;

--- a/src/vs/workbench/contrib/terminalContrib/accessibility/browser/terminalAccessibilityHelp.ts
+++ b/src/vs/workbench/contrib/terminalContrib/accessibility/browser/terminalAccessibilityHelp.ts
@@ -42,6 +42,10 @@ export class AccessibilityHelpWidget extends TerminalAccessibleWidget {
 		super(ClassName.AccessibleBuffer, _instance, _xterm, undefined, _instantiationService, _modelService, _configurationService, _contextKeyService, _terminalService);
 		this._hasShellIntegration = _xterm.shellIntegration.status === ShellIntegrationStatus.VSCode;
 		this.element.ariaRoleDescription = localize('terminal.integrated.accessiblityHelp', 'Terminal accessibility help');
+	}
+
+	override registerListeners(): void {
+		super.registerListeners();
 		this.add(once(this.editorWidget.onDidFocusEditorText)(() => {
 			// prevents tabbing into the editor
 			const editorTextArea = this.element.querySelector(ClassName.EditorTextArea) as HTMLElement;
@@ -49,14 +53,14 @@ export class AccessibilityHelpWidget extends TerminalAccessibleWidget {
 				editorTextArea.tabIndex = -1;
 			}
 		}));
+		this.add(this.editorWidget.onDidBlurEditorText(() => this.hide()));
 	}
 
 	private _descriptionForCommand(commandId: string, msg: string, noKbMsg: string): string {
 		const kb = this._keybindingService.lookupKeybindings(commandId);
 		switch (kb.length) {
 			case 0:
-				format(noKbMsg, commandId);
-				break;
+				return format(noKbMsg, commandId);
 			case 1:
 				return format(msg, kb[0].getAriaLabel());
 		}
@@ -82,7 +86,7 @@ export class AccessibilityHelpWidget extends TerminalAccessibleWidget {
 		const goToRecent = localize('goToRecentDirectory', 'Go to Recent Directory ({0})');
 		const goToRecentNoKb = localize('goToRecentDirectoryNoKb', 'Go to Recent Directory is currently not triggerable by a keybinding.');
 		const readMoreLink = localize('readMore', '[Read more about terminal accessibility](https://code.visualstudio.com/docs/editor/accessibility#_terminal-accessibility)');
-		const dismiss = localize('dismiss', "You can dismiss this dialog by pressing Escape or focusing elsewhere.");
+		const dismiss = localize('dismiss', "You can dismiss this dialog by pressing Escape, tab, or focusing elsewhere.");
 		const openDetectedLink = localize('openDetectedLink', 'The Open Detected Link ({0}) command enables screen readers to easily open links found in the terminal.');
 		const openDetectedLinkNoKb = localize('openDetectedLinkNoKb', 'The Open Detected Link command enables screen readers to easily open links found in the terminal and is currently not triggerable by a keybinding.');
 		const newWithProfile = localize('newWithProfile', 'The Create New Terminal (With Profile) ({0}) command allows for easy terminal creation using a specific profile.');
@@ -108,7 +112,7 @@ export class AccessibilityHelpWidget extends TerminalAccessibleWidget {
 		content.push(accessibilitySettings);
 		content.push(readMoreLink, dismiss);
 		const model = this.editorWidget.getModel() || await this.getTextModel(this._instance.resource);
-		model?.setValue(content.join('\n\n'));
+		model?.setValue(content.join('\n'));
 		this.editorWidget.setModel(model);
 		this.element.setAttribute('aria-label', introMessage);
 	}

--- a/src/vs/workbench/contrib/terminalContrib/accessibility/browser/terminalAccessibilityHelp.ts
+++ b/src/vs/workbench/contrib/terminalContrib/accessibility/browser/terminalAccessibilityHelp.ts
@@ -70,9 +70,6 @@ export class AccessibilityHelpWidget extends TerminalAccessibleWidget {
 	}
 
 	async updateEditor(): Promise<void> {
-		if (this.editorWidget.getModel()?.getValue().length) {
-			return;
-		}
 		const introMessage = localize('introMsg', "Welcome to Terminal Accessibility Help");
 		const focusAccessibleBufferNls = localize('focusAccessibleBuffer', 'The Focus Accessible Buffer ({0}) command enables screen readers to read terminal contents.');
 		const focusAccessibleBufferNoKb = localize('focusAccessibleBufferNoKb', 'The Focus Accessible Buffer command enables screen readers to read terminal contents and is currently not triggerable by a keybinding.');

--- a/src/vs/workbench/contrib/terminalContrib/accessibility/browser/terminalAccessibilityHelp.ts
+++ b/src/vs/workbench/contrib/terminalContrib/accessibility/browser/terminalAccessibilityHelp.ts
@@ -3,9 +3,11 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { once } from 'vs/base/common/functional';
 import { format } from 'vs/base/common/strings';
 import { IModelService } from 'vs/editor/common/services/model';
 import { localize } from 'vs/nls';
+import { IAccessibilityService } from 'vs/platform/accessibility/common/accessibility';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
@@ -17,7 +19,9 @@ import { TerminalAccessibleWidget } from 'vs/workbench/contrib/terminalContrib/a
 import type { Terminal } from 'xterm';
 
 export const enum ClassName {
-	AccessibleBuffer = 'terminal-accessibility-help'
+	AccessibleBuffer = 'terminal-accessibility-help',
+	Active = 'active',
+	EditorTextArea = 'textarea'
 }
 
 export class AccessibilityHelpWidget extends TerminalAccessibleWidget {
@@ -31,20 +35,34 @@ export class AccessibilityHelpWidget extends TerminalAccessibleWidget {
 		@IInstantiationService _instantiationService: IInstantiationService,
 		@IModelService _modelService: IModelService,
 		@IConfigurationService _configurationService: IConfigurationService,
+		@IAccessibilityService private readonly _accessibilityService: IAccessibilityService,
 		@IContextKeyService _contextKeyService: IContextKeyService,
 		@ITerminalService _terminalService: ITerminalService,
 	) {
 		super(ClassName.AccessibleBuffer, _instance, _xterm, undefined, _instantiationService, _modelService, _configurationService, _contextKeyService, _terminalService);
-		this._hasShellIntegration = _xterm?.shellIntegration.status === ShellIntegrationStatus.VSCode;
+		this._hasShellIntegration = _xterm.shellIntegration.status === ShellIntegrationStatus.VSCode;
 		this.element.ariaRoleDescription = localize('terminal.integrated.accessiblityHelp', 'Terminal accessibility help');
+		this.add(once(this.editorWidget.onDidFocusEditorText)(() => {
+			// prevents tabbing into the editor
+			const editorTextArea = this.element.querySelector(ClassName.EditorTextArea) as HTMLElement;
+			if (editorTextArea) {
+				editorTextArea.tabIndex = -1;
+			}
+		}));
 	}
 
 	private _descriptionForCommand(commandId: string, msg: string, noKbMsg: string): string {
-		const kb = this._keybindingService.lookupKeybinding(commandId, this._contextKeyService);
-		if (kb) {
-			return format(msg, kb.getAriaLabel());
+		const kb = this._keybindingService.lookupKeybindings(commandId);
+		switch (kb.length) {
+			case 0:
+				format(noKbMsg, commandId);
+				break;
+			case 1:
+				return format(msg, kb[0].getAriaLabel());
 		}
-		return format(noKbMsg, commandId);
+		// Run recent command has multiple keybindings. lookupKeybinding just returns the first one regardless of the when context.
+		// Thus, we have to check if accessibility mode is enabled to determine which keybinding to use.
+		return this._accessibilityService.isScreenReaderOptimized() ? format(msg, kb[1].getAriaLabel()) : format(msg, kb[0].getAriaLabel());
 	}
 
 	async updateEditor(): Promise<void> {

--- a/src/vs/workbench/contrib/terminalContrib/accessibility/browser/terminalAccessibleBuffer.ts
+++ b/src/vs/workbench/contrib/terminalContrib/accessibility/browser/terminalAccessibleBuffer.ts
@@ -20,6 +20,7 @@ import { BufferContentTracker } from 'vs/workbench/contrib/terminalContrib/acces
 import { ILogService } from 'vs/platform/log/common/log';
 import { IEditorViewState } from 'vs/editor/common/editorCommon';
 import { TerminalAccessibleWidget } from 'vs/workbench/contrib/terminalContrib/accessibility/browser/terminalAccessibleWidget';
+import { TerminalContextKeys } from 'vs/workbench/contrib/terminal/common/terminalContextKey';
 
 interface IAccessibleBufferQuickPickItem extends IQuickPickItem {
 	lineNumber: number;
@@ -39,8 +40,8 @@ export class AccessibleBufferWidget extends TerminalAccessibleWidget {
 	private _cursorPosition: { lineNumber: number; column: number } | undefined;
 
 	constructor(
-		_instance: Pick<ITerminalInstance, 'capabilities' | 'onDidRequestFocus' | 'resource'>,
-		_xterm: Pick<IXtermTerminal, 'getFont'> & { raw: Terminal },
+		_instance: Pick<ITerminalInstance, 'shellType' | 'capabilities' | 'onDidRequestFocus' | 'resource'>,
+		_xterm: Pick<IXtermTerminal, 'shellIntegration' | 'getFont'> & { raw: Terminal },
 		@IInstantiationService _instantiationService: IInstantiationService,
 		@IModelService _modelService: IModelService,
 		@IConfigurationService _configurationService: IConfigurationService,
@@ -48,9 +49,9 @@ export class AccessibleBufferWidget extends TerminalAccessibleWidget {
 		@IAudioCueService private readonly _audioCueService: IAudioCueService,
 		@IContextKeyService _contextKeyService: IContextKeyService,
 		@ILogService private readonly _logService: ILogService,
-		@ITerminalService _terminalService: ITerminalService,
+		@ITerminalService _terminalService: ITerminalService
 	) {
-		super(ClassName.AccessibleBuffer, _instance, _xterm, _instantiationService, _modelService, _configurationService, _contextKeyService, _terminalService);
+		super(ClassName.AccessibleBuffer, _instance, _xterm, TerminalContextKeys.accessibleBufferFocus, _instantiationService, _modelService, _configurationService, _contextKeyService, _terminalService);
 		this._bufferTracker = _instantiationService.createInstance(BufferContentTracker, _xterm);
 		this.element.ariaRoleDescription = localize('terminal.integrated.accessibleBuffer', 'Terminal buffer');
 		this.updateEditor();

--- a/src/vs/workbench/contrib/terminalContrib/accessibility/browser/terminalAccessibleBuffer.ts
+++ b/src/vs/workbench/contrib/terminalContrib/accessibility/browser/terminalAccessibleBuffer.ts
@@ -26,6 +26,10 @@ interface IAccessibleBufferQuickPickItem extends IQuickPickItem {
 	exitCode?: number;
 }
 
+export const enum ClassName {
+	AccessibleBuffer = 'accessible-buffer'
+}
+
 export class AccessibleBufferWidget extends TerminalAccessibleWidget {
 	private _isUpdating: boolean = false;
 	private _pendingUpdates = 0;
@@ -46,7 +50,7 @@ export class AccessibleBufferWidget extends TerminalAccessibleWidget {
 		@ILogService private readonly _logService: ILogService,
 		@ITerminalService _terminalService: ITerminalService,
 	) {
-		super('accessible-buffer', _instance, _xterm, _instantiationService, _modelService, _configurationService, _contextKeyService, _terminalService);
+		super(ClassName.AccessibleBuffer, _instance, _xterm, _instantiationService, _modelService, _configurationService, _contextKeyService, _terminalService);
 		this._bufferTracker = _instantiationService.createInstance(BufferContentTracker, _xterm);
 		this.element.ariaRoleDescription = localize('terminal.integrated.accessibleBuffer', 'Terminal buffer');
 		this.updateEditor();
@@ -173,7 +177,7 @@ export class AccessibleBufferWidget extends TerminalAccessibleWidget {
 		if (model) {
 			model.setValue(text);
 		} else {
-			model = await this.getTextModel(this._instance.resource.with({ fragment: text }));
+			model = await this.getTextModel(this._instance.resource.with({ fragment: `${ClassName.AccessibleBuffer}-${text}` }));
 		}
 		this.editorWidget.setModel(model);
 

--- a/src/vs/workbench/contrib/terminalContrib/accessibility/browser/terminalAccessibleBuffer.ts
+++ b/src/vs/workbench/contrib/terminalContrib/accessibility/browser/terminalAccessibleBuffer.ts
@@ -3,56 +3,30 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { KeyCode } from 'vs/base/common/keyCodes';
-import { DisposableStore, IDisposable } from 'vs/base/common/lifecycle';
-import { URI } from 'vs/base/common/uri';
-import * as dom from 'vs/base/browser/dom';
 import { Event } from 'vs/base/common/event';
-import { IEditorConstructionOptions } from 'vs/editor/browser/config/editorConfiguration';
-import { EditorExtensionsRegistry } from 'vs/editor/browser/editorExtensions';
-import { CodeEditorWidget, ICodeEditorWidgetOptions } from 'vs/editor/browser/widget/codeEditorWidget';
 import { ITextModel } from 'vs/editor/common/model';
 import { IModelService } from 'vs/editor/common/services/model';
-import { LinkDetector } from 'vs/editor/contrib/links/browser/links';
 import { localize } from 'vs/nls';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
-import { TerminalSettingId } from 'vs/platform/terminal/common/terminal';
-import { SelectionClipboardContributionID } from 'vs/workbench/contrib/codeEditor/browser/selectionClipboard';
-import { getSimpleEditorOptions } from 'vs/workbench/contrib/codeEditor/browser/simpleEditorOptions';
 import { ITerminalInstance, ITerminalService, IXtermTerminal } from 'vs/workbench/contrib/terminal/browser/terminal';
 import type { Terminal } from 'xterm';
 import { TerminalCapability } from 'vs/platform/terminal/common/capabilities/capabilities';
 import { IQuickInputService, IQuickPick, IQuickPickItem } from 'vs/platform/quickinput/common/quickInput';
 import { AudioCue, IAudioCueService } from 'vs/platform/audioCues/browser/audioCueService';
-import { IContextKey, IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
-import { TerminalContextKeys } from 'vs/workbench/contrib/terminal/common/terminalContextKey';
+import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 import { withNullAsUndefined } from 'vs/base/common/types';
 import { BufferContentTracker } from 'vs/workbench/contrib/terminalContrib/accessibility/browser/bufferContentTracker';
 import { ILogService } from 'vs/platform/log/common/log';
 import { IEditorViewState } from 'vs/editor/common/editorCommon';
-
-const enum CssClass {
-	Active = 'active',
-	Hide = 'hide'
-}
+import { TerminalAccessibleWidget } from 'vs/workbench/contrib/terminalContrib/accessibility/browser/terminalAccessibleWidget';
 
 interface IAccessibleBufferQuickPickItem extends IQuickPickItem {
 	lineNumber: number;
 	exitCode?: number;
 }
 
-export class AccessibleBufferWidget extends DisposableStore {
-
-	private _accessibleBuffer: HTMLElement;
-	private _editorWidget: CodeEditorWidget;
-	private _editorContainer: HTMLElement;
-	private _xtermElement: HTMLElement;
-
-	private readonly _focusedContextKey: IContextKey<boolean>;
-	private readonly _focusTracker: dom.IFocusTracker;
-
-	private _listeners: IDisposable[] = [];
+export class AccessibleBufferWidget extends TerminalAccessibleWidget {
 	private _isUpdating: boolean = false;
 	private _pendingUpdates = 0;
 
@@ -61,113 +35,25 @@ export class AccessibleBufferWidget extends DisposableStore {
 	private _cursorPosition: { lineNumber: number; column: number } | undefined;
 
 	constructor(
-		private readonly _instance: Pick<ITerminalInstance, 'capabilities' | 'onDidRequestFocus' | 'resource'>,
-		private readonly _xterm: Pick<IXtermTerminal, 'getFont'> & { raw: Terminal },
-		@IInstantiationService private readonly _instantiationService: IInstantiationService,
-		@IModelService private readonly _modelService: IModelService,
-		@IConfigurationService private readonly _configurationService: IConfigurationService,
+		_instance: Pick<ITerminalInstance, 'capabilities' | 'onDidRequestFocus' | 'resource'>,
+		_xterm: Pick<IXtermTerminal, 'getFont'> & { raw: Terminal },
+		@IInstantiationService _instantiationService: IInstantiationService,
+		@IModelService _modelService: IModelService,
+		@IConfigurationService _configurationService: IConfigurationService,
 		@IQuickInputService private readonly _quickInputService: IQuickInputService,
 		@IAudioCueService private readonly _audioCueService: IAudioCueService,
-		@IContextKeyService private readonly _contextKeyService: IContextKeyService,
+		@IContextKeyService _contextKeyService: IContextKeyService,
 		@ILogService private readonly _logService: ILogService,
-		@ITerminalService private readonly _terminalService: ITerminalService
+		@ITerminalService _terminalService: ITerminalService,
 	) {
-		super();
-		this._xtermElement = _xterm.raw.element!;
-		this._bufferTracker = this._instantiationService.createInstance(BufferContentTracker, _xterm);
-		this._accessibleBuffer = document.createElement('div');
-		this._accessibleBuffer.setAttribute('role', 'document');
-		this._accessibleBuffer.ariaRoleDescription = localize('terminal.integrated.accessibleBuffer', 'Terminal buffer');
-		this._accessibleBuffer.classList.add('accessible-buffer');
-		this._editorContainer = document.createElement('div');
-		const codeEditorWidgetOptions: ICodeEditorWidgetOptions = {
-			contributions: EditorExtensionsRegistry.getSomeEditorContributions([LinkDetector.ID, SelectionClipboardContributionID, 'editor.contrib.selectionAnchorController'])
-		};
-		const font = _xterm.getFont();
-		const editorOptions: IEditorConstructionOptions = {
-			...getSimpleEditorOptions(),
-			lineDecorationsWidth: 6,
-			dragAndDrop: true,
-			cursorWidth: 1,
-			fontSize: font.fontSize,
-			lineHeight: font.charHeight ? font.charHeight * font.lineHeight : 1,
-			letterSpacing: font.letterSpacing,
-			fontFamily: font.fontFamily,
-			wrappingStrategy: 'advanced',
-			wrappingIndent: 'none',
-			padding: { top: 2, bottom: 2 },
-			quickSuggestions: false,
-			renderWhitespace: 'none',
-			dropIntoEditor: { enabled: true },
-			accessibilitySupport: this._configurationService.getValue<'auto' | 'off' | 'on'>('editor.accessibilitySupport'),
-			cursorBlinking: this._configurationService.getValue('terminal.integrated.cursorBlinking'),
-			readOnly: true
-		};
-		this._editorWidget = this.add(this._instantiationService.createInstance(CodeEditorWidget, this._editorContainer, editorOptions, codeEditorWidgetOptions));
-		this._accessibleBuffer.replaceChildren(this._editorContainer);
-		this._xtermElement.insertAdjacentElement('beforebegin', this._accessibleBuffer);
-
-		this._focusTracker = this.add(dom.trackFocus(this._editorContainer));
-		this._focusedContextKey = TerminalContextKeys.accessibleBufferFocus.bindTo(this._contextKeyService);
-		this.add(this._focusTracker.onDidFocus(() => this._focusedContextKey.set(true)));
-		this.add(this._focusTracker.onDidBlur(() => this._focusedContextKey.reset()));
-
-		this.add(Event.runAndSubscribe(this._xterm.raw.onResize, () => this._layout()));
-		this.add(this._configurationService.onDidChangeConfiguration(e => {
-			if (e.affectedKeys.has(TerminalSettingId.FontFamily) || e.affectedKeys.has(TerminalSettingId.FontSize) || e.affectedKeys.has(TerminalSettingId.LineHeight) || e.affectedKeys.has(TerminalSettingId.LetterSpacing)) {
-				const font = this._xterm.getFont();
-				this._editorWidget.updateOptions({ fontFamily: font.fontFamily, fontSize: font.fontSize, lineHeight: font.charHeight ? font.charHeight * font.lineHeight : 1, letterSpacing: font.letterSpacing });
-			}
-		}));
-		this.add(this._editorWidget.onKeyDown((e) => {
-			switch (e.keyCode) {
-				case KeyCode.Tab:
-					// On tab or shift+tab, hide the accessible buffer and perform the default tab
-					// behavior
-					this._hide();
-					break;
-				case KeyCode.Escape:
-					// On escape, hide the accessible buffer and force focus onto the terminal
-					this._hide();
-					this._xterm.raw.focus();
-					break;
-			}
-		}));
-		this.add(this._editorWidget.onDidFocusEditorText(async () => {
-			this._terminalService.setActiveInstance(this._instance as ITerminalInstance);
-			if (this._accessibleBuffer.classList.contains(CssClass.Active)) {
-				// the user has focused the editor via mouse or
-				// Go to Command was run so we've already updated the editor
-				return;
-			}
-			// if the editor is focused via tab, we need to update the model
-			// and show it
-			this._registerListeners();
-			await this._updateEditor();
-			this._accessibleBuffer.classList.add(CssClass.Active);
-			this._xtermElement.classList.add(CssClass.Hide);
-		}));
-
-		this._updateEditor();
-	}
-
-	override dispose(): void {
-		this._disposeListeners();
-		super.dispose();
-	}
-
-	async show(): Promise<void> {
-		this._registerListeners();
-		await this._updateEditor();
-		this._accessibleBuffer.tabIndex = -1;
-		this._layout();
-		this._accessibleBuffer.classList.add(CssClass.Active);
-		this._xtermElement.classList.add(CssClass.Hide);
-		this._editorWidget.focus();
+		super('accessible-buffer', _instance, _xterm, _instantiationService, _modelService, _configurationService, _contextKeyService, _terminalService);
+		this._bufferTracker = _instantiationService.createInstance(BufferContentTracker, _xterm);
+		this.element.ariaRoleDescription = localize('terminal.integrated.accessibleBuffer', 'Terminal buffer');
+		this.updateEditor();
 	}
 
 	async createQuickPick(): Promise<IQuickPick<IAccessibleBufferQuickPickItem> | undefined> {
-		this._cursorPosition = withNullAsUndefined(this._editorWidget.getPosition());
+		this._cursorPosition = withNullAsUndefined(this.editorWidget.getPosition());
 		const commands = this._instance.capabilities.get(TerminalCapability.CommandDetection)?.commands;
 		if (!commands?.length) {
 			return;
@@ -196,7 +82,7 @@ export class AccessibleBufferWidget extends DisposableStore {
 			if (activeItem.exitCode) {
 				this._audioCueService.playAudioCue(AudioCue.error, true);
 			}
-			this._editorWidget.revealLine(activeItem.lineNumber, 0);
+			this.editorWidget.revealLine(activeItem.lineNumber, 0);
 		});
 		quickPick.onDidHide(() => {
 			this._resetPosition();
@@ -204,7 +90,7 @@ export class AccessibleBufferWidget extends DisposableStore {
 		});
 		quickPick.onDidAccept(() => {
 			const item = quickPick.activeItems[0];
-			const model = this._editorWidget.getModel();
+			const model = this.editorWidget.getModel();
 			if (!model) {
 				return;
 			}
@@ -213,7 +99,7 @@ export class AccessibleBufferWidget extends DisposableStore {
 			} else {
 				this._cursorPosition = { lineNumber: item.lineNumber, column: 1 };
 			}
-			this._editorWidget.focus();
+			this.editorWidget.focus();
 			return;
 		});
 		quickPick.items = quickPickItems.reverse();
@@ -225,17 +111,18 @@ export class AccessibleBufferWidget extends DisposableStore {
 		if (!this._cursorPosition) {
 			return;
 		}
-		this._editorWidget.setPosition(this._cursorPosition);
-		this._editorWidget.setScrollPosition({ scrollTop: this._editorWidget.getTopForLineNumber(this._cursorPosition.lineNumber) });
+		this.editorWidget.setPosition(this._cursorPosition);
+		this.editorWidget.setScrollPosition({ scrollTop: this.editorWidget.getTopForLineNumber(this._cursorPosition.lineNumber) });
 	}
 
-	private _hide(): void {
-		this._disposeListeners();
-		this._accessibleBuffer.classList.remove(CssClass.Active);
-		this._xtermElement.classList.remove(CssClass.Hide);
+	override layout(): void {
+		if (this._bufferTracker) {
+			this._bufferTracker.reset();
+		}
+		super.layout();
 	}
 
-	private async _updateEditor(dataChanged?: boolean): Promise<void> {
+	async updateEditor(dataChanged?: boolean): Promise<void> {
 		if (this._isUpdating) {
 			this._pendingUpdates++;
 			return;
@@ -249,42 +136,23 @@ export class AccessibleBufferWidget extends DisposableStore {
 		if (this._pendingUpdates) {
 			this._logService.debug('TerminalAccessibleBuffer._updateEditor: pending updates', this._pendingUpdates);
 			this._pendingUpdates--;
-			await this._updateEditor(dataChanged);
+			await this.updateEditor(dataChanged);
 		}
 	}
 
-	private _layout(): void {
-		this._bufferTracker.reset();
-		this._editorWidget.layout({ width: this._xtermElement.clientWidth, height: this._xtermElement.clientHeight });
-	}
-
-	private _registerListeners(): void {
+	registerListeners(): void {
 		this._xterm.raw.onWriteParsed(async () => {
 			if (this._xterm.raw.buffer.active.baseY === 0) {
-				await this._updateEditor(true);
+				await this.updateEditor(true);
 			}
 		});
 		const onRequestUpdateEditor = Event.latch(this._xterm.raw.onScroll);
-		this._listeners.push(onRequestUpdateEditor(async () => await this._updateEditor(true)));
-		this._listeners.push(this._instance.onDidRequestFocus(() => this._editorWidget.focus()));
-	}
-
-	private _disposeListeners(): void {
-		for (const listener of this._listeners) {
-			listener.dispose();
-		}
-	}
-
-	async getTextModel(resource: URI): Promise<ITextModel | null> {
-		const existing = this._modelService.getModel(resource);
-		if (existing && !existing.isDisposed()) {
-			return existing;
-		}
-		return this._modelService.createModel(resource.fragment, null, resource, false);
+		this._listeners.push(onRequestUpdateEditor(async () => await this.updateEditor(true)));
+		this._listeners.push(this._instance.onDidRequestFocus(() => this.editorWidget.focus()));
 	}
 
 	private _getDefaultCursorPosition(): { lineNumber: number; column: number } | undefined {
-		const modelLineCount = this._editorWidget.getModel()?.getLineCount();
+		const modelLineCount = this.editorWidget.getModel()?.getLineCount();
 		return modelLineCount ? { lineNumber: modelLineCount, column: 1 } : undefined;
 	}
 
@@ -297,29 +165,29 @@ export class AccessibleBufferWidget extends DisposableStore {
 		// Save the view state before the update if it was set by the user
 		let savedViewState: IEditorViewState | undefined;
 		if (dataChanged) {
-			savedViewState = withNullAsUndefined(this._editorWidget.saveViewState());
+			savedViewState = withNullAsUndefined(this.editorWidget.saveViewState());
 		}
 
-		let model = this._editorWidget.getModel();
+		let model = this.editorWidget.getModel();
 		const text = this._bufferTracker.lines.join('\n');
 		if (model) {
 			model.setValue(text);
 		} else {
 			model = await this.getTextModel(this._instance.resource.with({ fragment: text }));
 		}
-		this._editorWidget.setModel(model);
+		this.editorWidget.setModel(model);
 
 		// If the model changed due to new data, restore the view state
 		// If the model changed due to a refresh or the cursor is a the top, set to the bottom of the buffer
 		// Otherwise, don't change the position
-		const positionTopOfBuffer = this._editorWidget.getPosition()?.lineNumber === 1 && this._editorWidget.getPosition()?.column === 1;
+		const positionTopOfBuffer = this.editorWidget.getPosition()?.lineNumber === 1 && this.editorWidget.getPosition()?.column === 1;
 		if (savedViewState) {
-			this._editorWidget.restoreViewState(savedViewState);
+			this.editorWidget.restoreViewState(savedViewState);
 		} else if (modelChanged || positionTopOfBuffer) {
 			const defaultPosition = this._getDefaultCursorPosition();
 			if (defaultPosition) {
-				this._editorWidget.setPosition(defaultPosition);
-				this._editorWidget.setScrollPosition({ scrollTop: this._editorWidget.getTopForLineNumber(defaultPosition.lineNumber) });
+				this.editorWidget.setPosition(defaultPosition);
+				this.editorWidget.setScrollPosition({ scrollTop: this.editorWidget.getTopForLineNumber(defaultPosition.lineNumber) });
 			}
 		}
 		return model!;

--- a/src/vs/workbench/contrib/terminalContrib/accessibility/browser/terminalAccessibleBuffer.ts
+++ b/src/vs/workbench/contrib/terminalContrib/accessibility/browser/terminalAccessibleBuffer.ts
@@ -145,7 +145,8 @@ export class AccessibleBufferWidget extends TerminalAccessibleWidget {
 		}
 	}
 
-	registerListeners(): void {
+	override registerListeners(): void {
+		super.registerListeners();
 		this._xterm.raw.onWriteParsed(async () => {
 			if (this._xterm.raw.buffer.active.baseY === 0) {
 				await this.updateEditor(true);
@@ -153,7 +154,6 @@ export class AccessibleBufferWidget extends TerminalAccessibleWidget {
 		});
 		const onRequestUpdateEditor = Event.latch(this._xterm.raw.onScroll);
 		this._listeners.push(onRequestUpdateEditor(async () => await this.updateEditor(true)));
-		this._listeners.push(this._instance.onDidRequestFocus(() => this.editorWidget.focus()));
 	}
 
 	private _getDefaultCursorPosition(): { lineNumber: number; column: number } | undefined {

--- a/src/vs/workbench/contrib/terminalContrib/accessibility/browser/terminalAccessibleBuffer.ts
+++ b/src/vs/workbench/contrib/terminalContrib/accessibility/browser/terminalAccessibleBuffer.ts
@@ -28,7 +28,8 @@ interface IAccessibleBufferQuickPickItem extends IQuickPickItem {
 }
 
 export const enum ClassName {
-	AccessibleBuffer = 'accessible-buffer'
+	AccessibleBuffer = 'accessible-buffer',
+	Active = 'active'
 }
 
 export class AccessibleBufferWidget extends TerminalAccessibleWidget {
@@ -55,6 +56,18 @@ export class AccessibleBufferWidget extends TerminalAccessibleWidget {
 		this._bufferTracker = _instantiationService.createInstance(BufferContentTracker, _xterm);
 		this.element.ariaRoleDescription = localize('terminal.integrated.accessibleBuffer', 'Terminal buffer');
 		this.updateEditor();
+		this.add(this.editorWidget.onDidFocusEditorText(async () => {
+			if (this.element.classList.contains(ClassName.Active)) {
+				// the user has focused the editor via mouse or
+				// Go to Command was run so we've already updated the editor
+				return;
+			}
+			// if the editor is focused via tab, we need to update the model
+			// and show it
+			this.registerListeners();
+			await this.updateEditor();
+			this.element.classList.add(ClassName.Active);
+		}));
 	}
 
 	async createQuickPick(): Promise<IQuickPick<IAccessibleBufferQuickPickItem> | undefined> {

--- a/src/vs/workbench/contrib/terminalContrib/accessibility/browser/terminalAccessibleWidget.ts
+++ b/src/vs/workbench/contrib/terminalContrib/accessibility/browser/terminalAccessibleWidget.ts
@@ -23,9 +23,10 @@ import { ITerminalInstance, ITerminalService, IXtermTerminal } from 'vs/workbenc
 import type { Terminal } from 'xterm';
 import { IContextKey, IContextKeyService, RawContextKey } from 'vs/platform/contextkey/common/contextkey';
 
-const enum CssClass {
+const enum ClassName {
 	Active = 'active',
-	Hide = 'hide'
+	Hide = 'hide',
+	Widget = 'terminal-accessible-widget'
 }
 
 export abstract class TerminalAccessibleWidget extends DisposableStore {
@@ -58,6 +59,7 @@ export abstract class TerminalAccessibleWidget extends DisposableStore {
 		this._element = document.createElement('div');
 		this._element.setAttribute('role', 'document');
 		this._element.classList.add(_className);
+		this._element.classList.add(ClassName.Widget);
 		this._editorContainer = document.createElement('div');
 		const codeEditorWidgetOptions: ICodeEditorWidgetOptions = {
 			contributions: EditorExtensionsRegistry.getSomeEditorContributions([LinkDetector.ID, SelectionClipboardContributionID, 'editor.contrib.selectionAnchorController'])
@@ -116,7 +118,7 @@ export abstract class TerminalAccessibleWidget extends DisposableStore {
 		}));
 		this.add(this._editorWidget.onDidFocusEditorText(async () => {
 			this._terminalService.setActiveInstance(this._instance as ITerminalInstance);
-			if (this.element.classList.contains(CssClass.Active)) {
+			if (this.element.classList.contains(ClassName.Active)) {
 				// the user has focused the editor via mouse or
 				// Go to Command was run so we've already updated the editor
 				return;
@@ -125,7 +127,7 @@ export abstract class TerminalAccessibleWidget extends DisposableStore {
 			// and show it
 			this.registerListeners();
 			await this.updateEditor();
-			this.element.classList.add(CssClass.Active);
+			this.element.classList.add(ClassName.Active);
 		}));
 	}
 
@@ -144,8 +146,8 @@ export abstract class TerminalAccessibleWidget extends DisposableStore {
 		await this.updateEditor();
 		this.element.tabIndex = -1;
 		this.layout();
-		this.element.classList.add(CssClass.Active);
-		this._xtermElement.classList.add(CssClass.Hide);
+		this.element.classList.add(ClassName.Active);
+		this._xtermElement.classList.add(ClassName.Hide);
 		this.editorWidget.focus();
 	}
 
@@ -162,8 +164,8 @@ export abstract class TerminalAccessibleWidget extends DisposableStore {
 
 	private _hide(): void {
 		this._disposeListeners();
-		this.element.classList.remove(CssClass.Active);
-		this._xtermElement.classList.remove(CssClass.Hide);
+		this.element.classList.remove(ClassName.Active);
+		this._xtermElement.classList.remove(ClassName.Hide);
 	}
 
 	async getTextModel(resource: URI): Promise<ITextModel | null> {

--- a/src/vs/workbench/contrib/terminalContrib/accessibility/browser/terminalAccessibleWidget.ts
+++ b/src/vs/workbench/contrib/terminalContrib/accessibility/browser/terminalAccessibleWidget.ts
@@ -129,7 +129,9 @@ export abstract class TerminalAccessibleWidget extends DisposableStore {
 		}));
 	}
 
-	abstract registerListeners(): void;
+	registerListeners(): void {
+		this._listeners.push(this._instance.onDidRequestFocus(() => this.editorWidget.focus()));
+	}
 
 	layout(): void {
 		this._editorWidget.layout({ width: this._xtermElement.clientWidth, height: this._xtermElement.clientHeight });

--- a/src/vs/workbench/contrib/terminalContrib/accessibility/browser/terminalAccessibleWidget.ts
+++ b/src/vs/workbench/contrib/terminalContrib/accessibility/browser/terminalAccessibleWidget.ts
@@ -118,16 +118,6 @@ export abstract class TerminalAccessibleWidget extends DisposableStore {
 		this.add(this._editorWidget.onDidFocusEditorText(async () => {
 			this._terminalService.setActiveInstance(this._instance as ITerminalInstance);
 			this._xtermElement.classList.add(ClassName.Hide);
-			if (this.element.classList.contains(ClassName.Active)) {
-				// the user has focused the editor via mouse or
-				// Go to Command was run so we've already updated the editor
-				return;
-			}
-			// if the editor is focused via tab, we need to update the model
-			// and show it
-			this.registerListeners();
-			await this.updateEditor();
-			this.element.classList.add(ClassName.Active);
 		}));
 	}
 

--- a/src/vs/workbench/contrib/terminalContrib/accessibility/browser/terminalAccessibleWidget.ts
+++ b/src/vs/workbench/contrib/terminalContrib/accessibility/browser/terminalAccessibleWidget.ts
@@ -95,7 +95,6 @@ export abstract class TerminalAccessibleWidget extends DisposableStore {
 			this.add(this._focusTracker.onDidBlur(() => this._focusedContextKey?.reset()));
 		}
 
-
 		this.add(Event.runAndSubscribe(this._xterm.raw.onResize, () => this.layout()));
 		this.add(this._configurationService.onDidChangeConfiguration(e => {
 			if (e.affectedKeys.has(TerminalSettingId.FontFamily) || e.affectedKeys.has(TerminalSettingId.FontSize) || e.affectedKeys.has(TerminalSettingId.LineHeight) || e.affectedKeys.has(TerminalSettingId.LetterSpacing)) {
@@ -118,6 +117,7 @@ export abstract class TerminalAccessibleWidget extends DisposableStore {
 		}));
 		this.add(this._editorWidget.onDidFocusEditorText(async () => {
 			this._terminalService.setActiveInstance(this._instance as ITerminalInstance);
+			this._xtermElement.classList.add(ClassName.Hide);
 			if (this.element.classList.contains(ClassName.Active)) {
 				// the user has focused the editor via mouse or
 				// Go to Command was run so we've already updated the editor

--- a/src/vs/workbench/contrib/terminalContrib/accessibility/browser/terminalAccessibleWidget.ts
+++ b/src/vs/workbench/contrib/terminalContrib/accessibility/browser/terminalAccessibleWidget.ts
@@ -106,12 +106,13 @@ export abstract class TerminalAccessibleWidget extends DisposableStore {
 			switch (e.keyCode) {
 				case KeyCode.Escape:
 					// On escape, hide the accessible buffer and force focus onto the terminal
+					this.hide();
 					this._xterm.raw.focus();
 					break;
 				case KeyCode.Tab:
 					// On tab or shift+tab, hide the accessible buffer and perform the default tab
 					// behavior
-					this._hide();
+					this.hide();
 					break;
 			}
 		}));
@@ -152,7 +153,7 @@ export abstract class TerminalAccessibleWidget extends DisposableStore {
 		}
 	}
 
-	private _hide(): void {
+	hide(): void {
 		this._disposeListeners();
 		this.element.classList.remove(ClassName.Active);
 		this._xtermElement.classList.remove(ClassName.Hide);

--- a/src/vs/workbench/contrib/terminalContrib/accessibility/browser/terminalAccessibleWidget.ts
+++ b/src/vs/workbench/contrib/terminalContrib/accessibility/browser/terminalAccessibleWidget.ts
@@ -44,7 +44,7 @@ export abstract class TerminalAccessibleWidget extends DisposableStore {
 	private readonly _focusTracker: dom.IFocusTracker;
 
 	constructor(
-		className: string,
+		private readonly _className: string,
 		protected readonly _instance: Pick<ITerminalInstance, 'capabilities' | 'onDidRequestFocus' | 'resource'>,
 		protected readonly _xterm: Pick<IXtermTerminal, 'getFont'> & { raw: Terminal },
 		@IInstantiationService private readonly _instantiationService: IInstantiationService,
@@ -57,7 +57,7 @@ export abstract class TerminalAccessibleWidget extends DisposableStore {
 		this._xtermElement = _xterm.raw.element!;
 		this._element = document.createElement('div');
 		this._element.setAttribute('role', 'document');
-		this._element.classList.add(className);
+		this._element.classList.add(_className);
 		this._editorContainer = document.createElement('div');
 		const codeEditorWidgetOptions: ICodeEditorWidgetOptions = {
 			contributions: EditorExtensionsRegistry.getSomeEditorContributions([LinkDetector.ID, SelectionClipboardContributionID, 'editor.contrib.selectionAnchorController'])
@@ -166,6 +166,6 @@ export abstract class TerminalAccessibleWidget extends DisposableStore {
 		if (existing && !existing.isDisposed()) {
 			return existing;
 		}
-		return this._modelService.createModel(resource.fragment, null, resource, false);
+		return this._modelService.createModel(`${this._className}-${resource.fragment}`, null, resource, false);
 	}
 }

--- a/src/vs/workbench/contrib/terminalContrib/accessibility/browser/terminalAccessibleWidget.ts
+++ b/src/vs/workbench/contrib/terminalContrib/accessibility/browser/terminalAccessibleWidget.ts
@@ -1,0 +1,171 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { KeyCode } from 'vs/base/common/keyCodes';
+import { DisposableStore, IDisposable } from 'vs/base/common/lifecycle';
+import { URI } from 'vs/base/common/uri';
+import * as dom from 'vs/base/browser/dom';
+import { Event } from 'vs/base/common/event';
+import { IEditorConstructionOptions } from 'vs/editor/browser/config/editorConfiguration';
+import { EditorExtensionsRegistry } from 'vs/editor/browser/editorExtensions';
+import { CodeEditorWidget, ICodeEditorWidgetOptions } from 'vs/editor/browser/widget/codeEditorWidget';
+import { ITextModel } from 'vs/editor/common/model';
+import { IModelService } from 'vs/editor/common/services/model';
+import { LinkDetector } from 'vs/editor/contrib/links/browser/links';
+import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
+import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
+import { TerminalSettingId } from 'vs/platform/terminal/common/terminal';
+import { SelectionClipboardContributionID } from 'vs/workbench/contrib/codeEditor/browser/selectionClipboard';
+import { getSimpleEditorOptions } from 'vs/workbench/contrib/codeEditor/browser/simpleEditorOptions';
+import { ITerminalInstance, ITerminalService, IXtermTerminal } from 'vs/workbench/contrib/terminal/browser/terminal';
+import type { Terminal } from 'xterm';
+import { IContextKey, IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
+import { TerminalContextKeys } from 'vs/workbench/contrib/terminal/common/terminalContextKey';
+
+const enum CssClass {
+	Active = 'active',
+	Hide = 'hide'
+}
+
+export abstract class TerminalAccessibleWidget extends DisposableStore {
+
+	private _element: HTMLElement;
+	get element(): HTMLElement { return this._element; }
+	private _editorWidget: CodeEditorWidget;
+	protected get editorWidget(): CodeEditorWidget { return this._editorWidget; }
+	private _editorContainer: HTMLElement;
+	private _xtermElement: HTMLElement;
+
+	protected _listeners: IDisposable[] = [];
+
+	private readonly _focusedContextKey: IContextKey<boolean>;
+	private readonly _focusTracker: dom.IFocusTracker;
+
+	constructor(
+		className: string,
+		protected readonly _instance: Pick<ITerminalInstance, 'capabilities' | 'onDidRequestFocus' | 'resource'>,
+		protected readonly _xterm: Pick<IXtermTerminal, 'getFont'> & { raw: Terminal },
+		@IInstantiationService private readonly _instantiationService: IInstantiationService,
+		@IModelService private readonly _modelService: IModelService,
+		@IConfigurationService private readonly _configurationService: IConfigurationService,
+		@IContextKeyService private readonly _contextKeyService: IContextKeyService,
+		@ITerminalService private readonly _terminalService: ITerminalService
+	) {
+		super();
+		this._xtermElement = _xterm.raw.element!;
+		this._element = document.createElement('div');
+		this._element.setAttribute('role', 'document');
+		this._element.classList.add(className);
+		this._editorContainer = document.createElement('div');
+		const codeEditorWidgetOptions: ICodeEditorWidgetOptions = {
+			contributions: EditorExtensionsRegistry.getSomeEditorContributions([LinkDetector.ID, SelectionClipboardContributionID, 'editor.contrib.selectionAnchorController'])
+		};
+		const font = _xterm.getFont();
+		const editorOptions: IEditorConstructionOptions = {
+			...getSimpleEditorOptions(),
+			lineDecorationsWidth: 6,
+			dragAndDrop: true,
+			cursorWidth: 1,
+			fontSize: font.fontSize,
+			lineHeight: font.charHeight ? font.charHeight * font.lineHeight : 1,
+			letterSpacing: font.letterSpacing,
+			fontFamily: font.fontFamily,
+			wrappingStrategy: 'advanced',
+			wrappingIndent: 'none',
+			padding: { top: 2, bottom: 2 },
+			quickSuggestions: false,
+			renderWhitespace: 'none',
+			dropIntoEditor: { enabled: true },
+			accessibilitySupport: this._configurationService.getValue<'auto' | 'off' | 'on'>('editor.accessibilitySupport'),
+			cursorBlinking: this._configurationService.getValue('terminal.integrated.cursorBlinking'),
+			readOnly: true
+		};
+		this._editorWidget = this.add(this._instantiationService.createInstance(CodeEditorWidget, this._editorContainer, editorOptions, codeEditorWidgetOptions));
+		this._element.replaceChildren(this._editorContainer);
+		this._xtermElement.insertAdjacentElement('beforebegin', this._element);
+
+		this._focusTracker = this.add(dom.trackFocus(this._editorContainer));
+		this._focusedContextKey = TerminalContextKeys.accessibleBufferFocus.bindTo(this._contextKeyService);
+		this.add(this._focusTracker.onDidFocus(() => this._focusedContextKey.set(true)));
+		this.add(this._focusTracker.onDidBlur(() => this._focusedContextKey.reset()));
+
+		this.add(Event.runAndSubscribe(this._xterm.raw.onResize, () => this.layout()));
+		this.add(this._configurationService.onDidChangeConfiguration(e => {
+			if (e.affectedKeys.has(TerminalSettingId.FontFamily) || e.affectedKeys.has(TerminalSettingId.FontSize) || e.affectedKeys.has(TerminalSettingId.LineHeight) || e.affectedKeys.has(TerminalSettingId.LetterSpacing)) {
+				const font = this._xterm.getFont();
+				this._editorWidget.updateOptions({ fontFamily: font.fontFamily, fontSize: font.fontSize, lineHeight: font.charHeight ? font.charHeight * font.lineHeight : 1, letterSpacing: font.letterSpacing });
+			}
+		}));
+		this.add(this._editorWidget.onKeyDown((e) => {
+			switch (e.keyCode) {
+				case KeyCode.Escape:
+					// On escape, hide the accessible buffer and force focus onto the terminal
+					this._xterm.raw.focus();
+					break;
+				case KeyCode.Tab:
+					// On tab or shift+tab, hide the accessible buffer and perform the default tab
+					// behavior
+					this._hide();
+					break;
+			}
+		}));
+		this.add(this._editorWidget.onDidFocusEditorText(async () => {
+			this._terminalService.setActiveInstance(this._instance as ITerminalInstance);
+			if (this.element.classList.contains(CssClass.Active)) {
+				// the user has focused the editor via mouse or
+				// Go to Command was run so we've already updated the editor
+				return;
+			}
+			// if the editor is focused via tab, we need to update the model
+			// and show it
+			this.registerListeners?.();
+			await this.updateEditor();
+			this.element.classList.add(CssClass.Active);
+		}));
+	}
+
+	abstract registerListeners?(): void;
+
+	layout(): void {
+		this._editorWidget.layout({ width: this._xtermElement.clientWidth, height: this._xtermElement.clientHeight });
+	}
+
+	abstract updateEditor(): Promise<void>;
+
+	async show(): Promise<void> {
+		this.registerListeners?.();
+		await this.updateEditor();
+		this.element.tabIndex = -1;
+		this.layout();
+		this.element.classList.add(CssClass.Active);
+		this._xtermElement.classList.add(CssClass.Hide);
+		this.editorWidget.focus();
+	}
+
+	override dispose(): void {
+		this._disposeListeners();
+		super.dispose();
+	}
+
+	private _disposeListeners(): void {
+		for (const listener of this._listeners) {
+			listener.dispose();
+		}
+	}
+
+	private _hide(): void {
+		this._disposeListeners();
+		this.element.classList.remove(CssClass.Active);
+		this._xtermElement.classList.remove(CssClass.Hide);
+	}
+
+	async getTextModel(resource: URI): Promise<ITextModel | null> {
+		const existing = this._modelService.getModel(resource);
+		if (existing && !existing.isDisposed()) {
+			return existing;
+		}
+		return this._modelService.createModel(resource.fragment, null, resource, false);
+	}
+}


### PR DESCRIPTION
fixes #177899
fixes https://github.com/microsoft/vscode/issues/173911
fixes https://github.com/microsoft/vscode/issues/175130
fixes #179470

cc @isidorn revamping the terminal accessibility help menu and we can probably do the same for the editor one

https://user-images.githubusercontent.com/29464607/230525372-d129ca52-20a8-4334-aa5e-c1a510fc8c30.mov


