### PR TITLE
bump to ripgrep 1.15.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "@vscode/iconv-lite-umd": "0.7.0",
     "@vscode/policy-watcher": "^1.1.4",
     "@vscode/proxy-agent": "^0.13.1",
-    "@vscode/ripgrep": "^1.15.0",
+    "@vscode/ripgrep": "^1.15.2",
     "@vscode/sqlite3": "5.1.3-vscode",
     "@vscode/sudo-prompt": "9.3.1",
     "@vscode/vscode-languagedetection": "1.0.21",

--- a/remote/package.json
+++ b/remote/package.json
@@ -8,7 +8,7 @@
     "@parcel/watcher": "2.1.0",
     "@vscode/iconv-lite-umd": "0.7.0",
     "@vscode/proxy-agent": "^0.13.1",
-    "@vscode/ripgrep": "^1.15.0",
+    "@vscode/ripgrep": "^1.15.2",
     "@vscode/vscode-languagedetection": "1.0.21",
     "cookie": "^0.4.0",
     "graceful-fs": "4.2.8",

--- a/remote/yarn.lock
+++ b/remote/yarn.lock
@@ -72,10 +72,10 @@
   optionalDependencies:
     "@vscode/windows-ca-certs" "^0.3.1"
 
-"@vscode/ripgrep@^1.15.0":
-  version "1.15.0"
-  resolved "https://registry.yarnpkg.com/@vscode/ripgrep/-/ripgrep-1.15.0.tgz#d6fec68d7c44d594967f21a6e6c97416cc7fb2bc"
-  integrity sha512-qbLYP3XPTfS5a80+WnGvDLhsD01LDrs03zjbbtWWnvwt8G9hP3j8mc3ckaIid7pj86MBSTyUb/ECaIWmJIGBYw==
+"@vscode/ripgrep@^1.15.2":
+  version "1.15.2"
+  resolved "https://registry.yarnpkg.com/@vscode/ripgrep/-/ripgrep-1.15.2.tgz#85b55181353d6d204210e64e03853c5e2ee6edd9"
+  integrity sha512-8zmyoxV6F+CY1Rinaq7LO/bGShaX2+B333X+Nqo984nC6jg2OvfZtQHzU+PKNQte2fjhm9h2ZlZTufnJxHaX9w==
   dependencies:
     https-proxy-agent "^5.0.0"
     proxy-from-env "^1.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1315,6 +1315,14 @@
     https-proxy-agent "^5.0.0"
     proxy-from-env "^1.1.0"
 
+"@vscode/ripgrep@^1.15.2":
+  version "1.15.2"
+  resolved "https://registry.yarnpkg.com/@vscode/ripgrep/-/ripgrep-1.15.2.tgz#85b55181353d6d204210e64e03853c5e2ee6edd9"
+  integrity sha512-8zmyoxV6F+CY1Rinaq7LO/bGShaX2+B333X+Nqo984nC6jg2OvfZtQHzU+PKNQte2fjhm9h2ZlZTufnJxHaX9w==
+  dependencies:
+    https-proxy-agent "^5.0.0"
+    proxy-from-env "^1.1.0"
+
 "@vscode/sqlite3@5.1.3-vscode":
   version "5.1.3-vscode"
   resolved "https://registry.yarnpkg.com/@vscode/sqlite3/-/sqlite3-5.1.3-vscode.tgz#4fe81eb2422edef7b13869fe9d66663f4d925e93"


### PR DESCRIPTION
Revert build for `arm-unknown-linux-gnueabihf` to use from `ripgrep-prebuilt 13.0.0-4`

related https://github.com/microsoft/vscode/issues/179121