### PR TITLE
Support VSCODE_ENV_* variables to adjust environment in shell integration scripts

### DIFF
--- a/src/vs/base/common/processes.ts
+++ b/src/vs/base/common/processes.ts
@@ -108,7 +108,7 @@ export function sanitizeProcessEnvironment(env: IProcessEnvironment, ...preserve
 	}, {} as Record<string, boolean>);
 	const keysToRemove = [
 		/^ELECTRON_.+$/,
-		/^VSCODE_(?!(PORTABLE|SHELL_LOGIN)).+$/,
+		/^VSCODE_(?!(PORTABLE|SHELL_LOGIN|ENV_REPLACE|ENV_APPEND|ENV_PREPEND)).+$/,
 		/^SNAP(|_.*)$/,
 		/^GDK_PIXBUF_.+$/,
 	];

--- a/src/vs/platform/terminal/common/environmentVariable.ts
+++ b/src/vs/platform/terminal/common/environmentVariable.ts
@@ -10,9 +10,15 @@ export enum EnvironmentVariableMutatorType {
 	Append = 2,
 	Prepend = 3
 }
+export enum EnvironmentVariableMutatorTiming {
+	AtSpawn = 1,
+	AfterShellIntegration = 2
+	// TODO: Do we need a both?
+}
 export interface IEnvironmentVariableMutator {
 	readonly value: string;
 	readonly type: EnvironmentVariableMutatorType;
+	readonly timing?: EnvironmentVariableMutatorTiming;
 }
 
 export interface IEnvironmentVariableCollection {

--- a/src/vs/platform/terminal/common/environmentVariable.ts
+++ b/src/vs/platform/terminal/common/environmentVariable.ts
@@ -10,15 +10,15 @@ export enum EnvironmentVariableMutatorType {
 	Append = 2,
 	Prepend = 3
 }
-export enum EnvironmentVariableMutatorTiming {
-	AtSpawn = 1,
-	AfterShellIntegration = 2
-	// TODO: Do we need a both?
-}
+// export enum EnvironmentVariableMutatorTiming {
+// 	AtSpawn = 1,
+// 	AfterShellIntegration = 2
+// 	// TODO: Do we need a both?
+// }
 export interface IEnvironmentVariableMutator {
 	readonly value: string;
 	readonly type: EnvironmentVariableMutatorType;
-	readonly timing?: EnvironmentVariableMutatorTiming;
+	// readonly timing?: EnvironmentVariableMutatorTiming;
 }
 
 export interface IEnvironmentVariableCollection {

--- a/src/vs/platform/terminal/common/environmentVariableCollection.ts
+++ b/src/vs/platform/terminal/common/environmentVariableCollection.ts
@@ -4,15 +4,15 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { IProcessEnvironment, isWindows } from 'vs/base/common/platform';
-import { EnvironmentVariableMutatorTiming, EnvironmentVariableMutatorType, IEnvironmentVariableCollection, IExtensionOwnedEnvironmentVariableMutator, IMergedEnvironmentVariableCollection, IMergedEnvironmentVariableCollectionDiff } from 'vs/platform/terminal/common/environmentVariable';
+import { EnvironmentVariableMutatorType, IEnvironmentVariableCollection, IExtensionOwnedEnvironmentVariableMutator, IMergedEnvironmentVariableCollection, IMergedEnvironmentVariableCollectionDiff } from 'vs/platform/terminal/common/environmentVariable';
 
 type VariableResolver = (str: string) => Promise<string>;
 
-const mutatorTypeToLabelMap: Map<EnvironmentVariableMutatorType, string> = new Map([
-	[EnvironmentVariableMutatorType.Append, 'APPEND'],
-	[EnvironmentVariableMutatorType.Prepend, 'PREPEND'],
-	[EnvironmentVariableMutatorType.Replace, 'REPLACE']
-]);
+// const mutatorTypeToLabelMap: Map<EnvironmentVariableMutatorType, string> = new Map([
+// 	[EnvironmentVariableMutatorType.Append, 'APPEND'],
+// 	[EnvironmentVariableMutatorType.Prepend, 'PREPEND'],
+// 	[EnvironmentVariableMutatorType.Replace, 'REPLACE']
+// ]);
 
 export class MergedEnvironmentVariableCollection implements IMergedEnvironmentVariableCollection {
 	readonly map: Map<string, IExtensionOwnedEnvironmentVariableMutator[]> = new Map();
@@ -61,11 +61,11 @@ export class MergedEnvironmentVariableCollection implements IMergedEnvironmentVa
 			const actualVariable = isWindows ? lowerToActualVariableNames![variable.toLowerCase()] || variable : variable;
 			for (const mutator of mutators) {
 				const value = variableResolver ? await variableResolver(mutator.value) : mutator.value;
-				if (mutator.timing === EnvironmentVariableMutatorTiming.AfterShellIntegration) {
-					const key = `VSCODE_ENV_${mutatorTypeToLabelMap.get(mutator.type)!}`;
-					env[key] = (env[key] ? env[key] + ':' : '') + variable + '=' + value;
-					continue;
-				}
+				// if (mutator.timing === EnvironmentVariableMutatorTiming.AfterShellIntegration) {
+				// 	const key = `VSCODE_ENV_${mutatorTypeToLabelMap.get(mutator.type)!}`;
+				// 	env[key] = (env[key] ? env[key] + ':' : '') + variable + '=' + value;
+				// 	continue;
+				// }
 				switch (mutator.type) {
 					case EnvironmentVariableMutatorType.Append:
 						env[actualVariable] = (env[actualVariable] || '') + value;

--- a/src/vs/platform/terminal/common/environmentVariableCollection.ts
+++ b/src/vs/platform/terminal/common/environmentVariableCollection.ts
@@ -61,10 +61,6 @@ export class MergedEnvironmentVariableCollection implements IMergedEnvironmentVa
 			const actualVariable = isWindows ? lowerToActualVariableNames![variable.toLowerCase()] || variable : variable;
 			for (const mutator of mutators) {
 				const value = variableResolver ? await variableResolver(mutator.value) : mutator.value;
-
-				// TODO: Remove me
-				(mutator as any).timing = EnvironmentVariableMutatorTiming.AfterShellIntegration;
-
 				if (mutator.timing === EnvironmentVariableMutatorTiming.AfterShellIntegration) {
 					const key = `VSCODE_ENV_${mutatorTypeToLabelMap.get(mutator.type)!}`;
 					env[key] = (env[key] ? env[key] + ':' : '') + variable + '=' + value;

--- a/src/vs/workbench/contrib/terminal/browser/media/shellIntegration-bash.sh
+++ b/src/vs/workbench/contrib/terminal/browser/media/shellIntegration-bash.sh
@@ -47,31 +47,31 @@ fi
 
 # Apply EnvironmentVariableCollections if needed
 if [ -n "$VSCODE_ENV_REPLACE" ]; then
-	echo "VSCODE_ENV_REPLACE: $VSCODE_ENV_REPLACE"
 	IFS=':' read -ra ADDR <<< "$VSCODE_ENV_REPLACE"
 	for ITEM in "${ADDR[@]}"; do
 		VARNAME="$(echo $ITEM | cut -d "=" -f 1)"
 		VALUE="$(echo $ITEM | cut -d "=" -f 2)"
 		export $VARNAME="$VALUE"
 	done
+	builtin unset VSCODE_ENV_REPLACE
 fi
 if [ -n "$VSCODE_ENV_PREPEND" ]; then
-	echo "VSCODE_ENV_PREPEND: $VSCODE_ENV_PREPEND"
 	IFS=':' read -ra ADDR <<< "$VSCODE_ENV_PREPEND"
 	for ITEM in "${ADDR[@]}"; do
 		VARNAME="$(echo $ITEM | cut -d "=" -f 1)"
 		VALUE="$(echo $ITEM | cut -d "=" -f 2)"
 		export $VARNAME="$VALUE${!VARNAME}"
 	done
+	builtin unset VSCODE_ENV_REPLACE
 fi
 if [ -n "$VSCODE_ENV_APPEND" ]; then
-	echo "VSCODE_ENV_APPEND: $VSCODE_ENV_APPEND"
 	IFS=':' read -ra ADDR <<< "$VSCODE_ENV_APPEND"
 	for ITEM in "${ADDR[@]}"; do
 		VARNAME="$(echo $ITEM | cut -d "=" -f 1)"
 		VALUE="$(echo $ITEM | cut -d "=" -f 2)"
 		export $VARNAME="${!VARNAME}$VALUE"
 	done
+	builtin unset VSCODE_ENV_REPLACE
 fi
 
 __vsc_get_trap() {

--- a/src/vs/workbench/contrib/terminal/browser/media/shellIntegration-bash.sh
+++ b/src/vs/workbench/contrib/terminal/browser/media/shellIntegration-bash.sh
@@ -45,6 +45,35 @@ if [ -z "$VSCODE_SHELL_INTEGRATION" ]; then
 	builtin return
 fi
 
+# Apply EnvironmentVariableCollections if needed
+if [ -n "$VSCODE_ENV_REPLACE" ]; then
+	echo "VSCODE_ENV_REPLACE: $VSCODE_ENV_REPLACE"
+	IFS=':' read -ra ADDR <<< "$VSCODE_ENV_REPLACE"
+	for ITEM in "${ADDR[@]}"; do
+		VARNAME="$(echo $ITEM | cut -d "=" -f 1)"
+		VALUE="$(echo $ITEM | cut -d "=" -f 2)"
+		export $VARNAME="$VALUE"
+	done
+fi
+if [ -n "$VSCODE_ENV_PREPEND" ]; then
+	echo "VSCODE_ENV_PREPEND: $VSCODE_ENV_PREPEND"
+	IFS=':' read -ra ADDR <<< "$VSCODE_ENV_REPLACE"
+	for ITEM in "${ADDR[@]}"; do
+		VARNAME="$(echo $ITEM | cut -d "=" -f 1)"
+		VALUE="$(echo $ITEM | cut -d "=" -f 2)"
+		export $VARNAME="$VALUE${!VARNAME}"
+	done
+fi
+if [ -n "$VSCODE_ENV_APPEND" ]; then
+	echo "VSCODE_ENV_APPEND: $VSCODE_ENV_APPEND"
+	IFS=':' read -ra ADDR <<< "$VSCODE_ENV_APPEND"
+	for ITEM in "${ADDR[@]}"; do
+		VARNAME="$(echo $ITEM | cut -d "=" -f 1)"
+		VALUE="$(echo $ITEM | cut -d "=" -f 2)"
+		export $VARNAME="${!VARNAME}$VALUE"
+	done
+fi
+
 __vsc_get_trap() {
 	# 'trap -p DEBUG' outputs a shell command like `trap -- '…shellcode…' DEBUG`.
 	# The terms are quoted literals, but are not guaranteed to be on a single line.

--- a/src/vs/workbench/contrib/terminal/browser/media/shellIntegration-bash.sh
+++ b/src/vs/workbench/contrib/terminal/browser/media/shellIntegration-bash.sh
@@ -57,7 +57,7 @@ if [ -n "$VSCODE_ENV_REPLACE" ]; then
 fi
 if [ -n "$VSCODE_ENV_PREPEND" ]; then
 	echo "VSCODE_ENV_PREPEND: $VSCODE_ENV_PREPEND"
-	IFS=':' read -ra ADDR <<< "$VSCODE_ENV_REPLACE"
+	IFS=':' read -ra ADDR <<< "$VSCODE_ENV_PREPEND"
 	for ITEM in "${ADDR[@]}"; do
 		VARNAME="$(echo $ITEM | cut -d "=" -f 1)"
 		VALUE="$(echo $ITEM | cut -d "=" -f 2)"

--- a/src/vs/workbench/contrib/terminal/browser/media/shellIntegration-rc.zsh
+++ b/src/vs/workbench/contrib/terminal/browser/media/shellIntegration-rc.zsh
@@ -38,6 +38,35 @@ if [ -z "$VSCODE_SHELL_INTEGRATION" ]; then
 	builtin return
 fi
 
+# Apply EnvironmentVariableCollections if needed
+if [ -n "$VSCODE_ENV_REPLACE" ]; then
+	echo "VSCODE_ENV_REPLACE: $VSCODE_ENV_REPLACE"
+	IFS=':' read -rA ADDR <<< "$VSCODE_ENV_REPLACE"
+	for ITEM in "${ADDR[@]}"; do
+		VARNAME="$(echo ${ITEM%%=*})"
+		export $VARNAME="${ITEM#*=}"
+	done
+	unset VSCODE_ENV_REPLACE
+fi
+if [ -n "$VSCODE_ENV_PREPEND" ]; then
+	echo "VSCODE_ENV_PREPEND: $VSCODE_ENV_PREPEND"
+	IFS=':' read -rA ADDR <<< "$VSCODE_ENV_PREPEND"
+	for ITEM in "${ADDR[@]}"; do
+		VARNAME="$(echo ${ITEM%%=*})"
+		export $VARNAME="${ITEM#*=}${(P)VARNAME}"
+	done
+	unset VSCODE_ENV_PREPEND
+fi
+if [ -n "$VSCODE_ENV_APPEND" ]; then
+	echo "VSCODE_ENV_APPEND: $VSCODE_ENV_APPEND"
+	IFS=':' read -rA ADDR <<< "$VSCODE_ENV_APPEND"
+	for ITEM in "${ADDR[@]}"; do
+		VARNAME="$(echo ${ITEM%%=*})"
+		export $VARNAME="${(P)VARNAME}${ITEM#*=}"
+	done
+	unset VSCODE_ENV_APPEND
+fi
+
 # The property (P) and command (E) codes embed values which require escaping.
 # Backslashes are doubled. Non-alphanumeric characters are converted to escaped hex.
 __vsc_escape_value() {

--- a/src/vs/workbench/contrib/terminal/browser/media/shellIntegration.fish
+++ b/src/vs/workbench/contrib/terminal/browser/media/shellIntegration.fish
@@ -28,6 +28,29 @@ if status --is-login; and set -q VSCODE_PATH_PREFIX
 end
 set -e VSCODE_PATH_PREFIX
 
+# Apply EnvironmentVariableCollections if needed
+if test -n "$VSCODE_ENV_REPLACE"
+	set ITEMS $(string split : $VSCODE_ENV_REPLACE)
+	for B in $ITEMS
+		set split $(string split = $B)
+		set -gx "$split[1]" "$split[2]"
+	end
+end
+if test -n "$VSCODE_ENV_PREPEND"
+	set ITEMS $(string split : $VSCODE_ENV_PREPEND)
+	for B in $ITEMS
+		set split $(string split = $B)
+		set -gx "$split[1]" "$split[2]$$split[1]" # avoid -p as it adds a space
+	end
+end
+if test -n "$VSCODE_ENV_APPEND"
+	set ITEMS $(string split : $VSCODE_ENV_APPEND)
+	for B in $ITEMS
+		set split $(string split = $B)
+		set -gx "$split[1]" "$$split[1]$split[2]" # avoid -a as it adds a space
+	end
+end
+
 # Helper function
 function __vsc_esc -d "Emit escape sequences for VS Code shell integration"
 	builtin printf "\e]633;%s\a" (string join ";" $argv)

--- a/src/vs/workbench/contrib/terminal/browser/media/shellIntegration.fish
+++ b/src/vs/workbench/contrib/terminal/browser/media/shellIntegration.fish
@@ -35,6 +35,7 @@ if test -n "$VSCODE_ENV_REPLACE"
 		set split $(string split = $B)
 		set -gx "$split[1]" "$split[2]"
 	end
+	set -e VSCODE_ENV_REPLACE
 end
 if test -n "$VSCODE_ENV_PREPEND"
 	set ITEMS $(string split : $VSCODE_ENV_PREPEND)
@@ -42,6 +43,7 @@ if test -n "$VSCODE_ENV_PREPEND"
 		set split $(string split = $B)
 		set -gx "$split[1]" "$split[2]$$split[1]" # avoid -p as it adds a space
 	end
+	set -e VSCODE_ENV_PREPEND
 end
 if test -n "$VSCODE_ENV_APPEND"
 	set ITEMS $(string split : $VSCODE_ENV_APPEND)
@@ -49,6 +51,7 @@ if test -n "$VSCODE_ENV_APPEND"
 		set split $(string split = $B)
 		set -gx "$split[1]" "$$split[1]$split[2]" # avoid -a as it adds a space
 	end
+	set -e VSCODE_ENV_APPEND
 end
 
 # Helper function

--- a/src/vs/workbench/contrib/terminal/browser/media/shellIntegration.ps1
+++ b/src/vs/workbench/contrib/terminal/browser/media/shellIntegration.ps1
@@ -25,7 +25,6 @@ if ($env:VSCODE_ENV_REPLACE) {
 	}
 	$env:VSCODE_ENV_REPLACE = $null
 }
-$env:VSCODE_ENV_PREPEND = "PATH=/a/"
 if ($env:VSCODE_ENV_PREPEND) {
 	$Split = $env:VSCODE_ENV_PREPEND.Split(":")
 	foreach ($Item in $Split) {

--- a/src/vs/workbench/contrib/terminal/browser/media/shellIntegration.ps1
+++ b/src/vs/workbench/contrib/terminal/browser/media/shellIntegration.ps1
@@ -17,6 +17,32 @@ $Global:__VSCodeOriginalPrompt = $function:Prompt
 
 $Global:__LastHistoryId = -1
 
+if ($env:VSCODE_ENV_REPLACE) {
+	$Split = $env:VSCODE_ENV_REPLACE.Split(":")
+	foreach ($Item in $Split) {
+		$Inner = $Item.Split('=')
+		[Environment]::SetEnvironmentVariable($Inner[0], $Inner[1])
+	}
+	$env:VSCODE_ENV_REPLACE = $null
+}
+$env:VSCODE_ENV_PREPEND = "PATH=/a/"
+if ($env:VSCODE_ENV_PREPEND) {
+	$Split = $env:VSCODE_ENV_PREPEND.Split(":")
+	foreach ($Item in $Split) {
+		$Inner = $Item.Split('=')
+		[Environment]::SetEnvironmentVariable($Inner[0], $Inner[1] + [Environment]::GetEnvironmentVariable($Inner[0]))
+	}
+	$env:VSCODE_ENV_PREPEND = $null
+}
+if ($env:VSCODE_ENV_APPEND) {
+	$Split = $env:VSCODE_ENV_APPEND.Split(":")
+	foreach ($Item in $Split) {
+		$Inner = $Item.Split('=')
+		[Environment]::SetEnvironmentVariable($Inner[0], [Environment]::GetEnvironmentVariable($Inner[0]) + $Inner[1])
+	}
+	$env:VSCODE_ENV_APPEND = $null
+}
+
 function Global:__VSCode-Escape-Value([string]$value) {
 	# NOTE: In PowerShell v6.1+, this can be written `$value -replace '…', { … }` instead of `[regex]::Replace`.
 	# Replace any non-alphanumeric characters.


### PR DESCRIPTION
Part of #179476

This implements the shell script part of #179476. With this, an extension can temporarily set the following variables via the `EnvironmentVariableCollection` to get this behavior, all of which have the format `var1=value1:var2=value2`

- `VSCODE_ENV_REPLACE`: Replace the variable
- `VSCODE_ENV_PREPEND`: Add the value to the start of the variable
- `VSCODE_ENV_APPEND`: Add the value to the end of the variable

I'll be out for a few weeks so this is an MVP for the Python extension to use it. Eventually, when the API is added, we'll prevent it from working like this be sanitizing out any `VSCODE_ENV_*` variables when applying the environment variable collection to the process as we want VS Code core to have full control over them.