### PR TITLE
Enable navigating past the end of history, to get an empty input box

### DIFF
--- a/src/vs/base/browser/ui/inputbox/inputBox.ts
+++ b/src/vs/base/browser/ui/inputbox/inputBox.ts
@@ -711,10 +711,8 @@ export class HistoryInputBox extends InputBox implements IHistoryNavigationWidge
 			next = next === this.value ? this.getNextValue() : next;
 		}
 
-		if (next) {
-			this.value = next;
-			aria.status(this.value);
-		}
+		this.value = next ?? '';
+		aria.status(this.value ? this.value : nls.localize('clearedInput', "Cleared Input"));
 	}
 
 	public showPreviousValue(): void {
@@ -761,6 +759,6 @@ export class HistoryInputBox extends InputBox implements IHistoryNavigationWidge
 	}
 
 	private getNextValue(): string | null {
-		return this.history.next() || this.history.last();
+		return this.history.next();
 	}
 }

--- a/src/vs/base/common/history.ts
+++ b/src/vs/base/common/history.ts
@@ -28,17 +28,15 @@ export class HistoryNavigator<T> implements INavigator<T> {
 	}
 
 	public next(): T | null {
-		if (this._currentPosition() !== this._elements.length - 1) {
-			return this._navigator.next();
-		}
-		return null;
+		// This will navigate past the end of the last element, and in that case the input should be cleared
+		return this._navigator.next();
 	}
 
 	public previous(): T | null {
 		if (this._currentPosition() !== 0) {
 			return this._navigator.previous();
 		}
-		return null;
+		return this.first();
 	}
 
 	public current(): T | null {

--- a/src/vs/base/common/history.ts
+++ b/src/vs/base/common/history.ts
@@ -36,7 +36,7 @@ export class HistoryNavigator<T> implements INavigator<T> {
 		if (this._currentPosition() !== 0) {
 			return this._navigator.previous();
 		}
-		return this.first();
+		return null;
 	}
 
 	public current(): T | null {
@@ -56,7 +56,7 @@ export class HistoryNavigator<T> implements INavigator<T> {
 	}
 
 	public isLast(): boolean {
-		return this._currentPosition() === this._elements.length - 1;
+		return this._currentPosition() >= this._elements.length - 1;
 	}
 
 	public isNowhere(): boolean {

--- a/src/vs/base/test/common/history.test.ts
+++ b/src/vs/base/test/common/history.test.ts
@@ -72,7 +72,7 @@ suite('History Navigator', () => {
 		assert.strictEqual(testObject.isLast(), true);
 		assert.strictEqual(testObject.current(), '4');
 		assert.strictEqual(testObject.next(), null);
-		assert.strictEqual(testObject.isLast(), true);
+		assert.strictEqual(testObject.isLast(), false); // Stepping past the last element, is no longer "last"
 	});
 
 	test('previous on first element returns null and remains on first', () => {
@@ -109,8 +109,9 @@ suite('History Navigator', () => {
 		testObject.add('5');
 
 		assert.strictEqual(testObject.previous(), '5');
-		assert.strictEqual(testObject.next(), null);
 		assert.strictEqual(testObject.isLast(), true);
+		assert.strictEqual(testObject.next(), null);
+		assert.strictEqual(testObject.isLast(), false);
 	});
 
 	test('adding an existing item changes the order', () => {
@@ -144,8 +145,9 @@ suite('History Navigator', () => {
 
 		testObject.last();
 
-		assert.deepStrictEqual(testObject.next(), null);
 		assert.strictEqual(testObject.isLast(), true);
+		assert.deepStrictEqual(testObject.next(), null);
+		assert.strictEqual(testObject.isLast(), false);
 	});
 
 	test('next returns object if the current position is not the last one', () => {

--- a/src/vs/workbench/contrib/codeEditor/browser/suggestEnabledInput/suggestEnabledInput.ts
+++ b/src/vs/workbench/contrib/codeEditor/browser/suggestEnabledInput/suggestEnabledInput.ts
@@ -388,9 +388,7 @@ export class SuggestEnabledInputWithHistory extends SuggestEnabledInput implemen
 			next = next === this.getValue() ? this.getNextValue() : next;
 		}
 
-		if (next) {
-			this.setValue(next);
-		}
+		this.setValue(next ?? '');
 	}
 
 	public showPreviousValue(): void {
@@ -427,7 +425,7 @@ export class SuggestEnabledInputWithHistory extends SuggestEnabledInput implemen
 	}
 
 	private getNextValue(): string | null {
-		return this.history.next() || this.history.last();
+		return this.history.next();
 	}
 }
 

--- a/src/vs/workbench/contrib/debug/browser/repl.ts
+++ b/src/vs/workbench/contrib/debug/browser/repl.ts
@@ -384,7 +384,9 @@ export class Repl extends FilterViewPane implements IHistoryNavigationWidget {
 	}
 
 	private navigateHistory(previous: boolean): void {
-		const historyInput = (previous ? this.history.previous() : this.history.next()) ?? '';
+		const historyInput = (previous ?
+			(this.history.previous() ?? this.history.first()) : this.history.next())
+			?? '';
 		this.replInput.setValue(historyInput);
 		aria.status(historyInput);
 		// always leave cursor at the end.

--- a/src/vs/workbench/contrib/debug/browser/repl.ts
+++ b/src/vs/workbench/contrib/debug/browser/repl.ts
@@ -384,14 +384,12 @@ export class Repl extends FilterViewPane implements IHistoryNavigationWidget {
 	}
 
 	private navigateHistory(previous: boolean): void {
-		const historyInput = previous ? this.history.previous() : this.history.next();
-		if (historyInput) {
-			this.replInput.setValue(historyInput);
-			aria.status(historyInput);
-			// always leave cursor at the end.
-			this.replInput.setPosition({ lineNumber: 1, column: historyInput.length + 1 });
-			this.setHistoryNavigationEnablement(true);
-		}
+		const historyInput = (previous ? this.history.previous() : this.history.next()) ?? '';
+		this.replInput.setValue(historyInput);
+		aria.status(historyInput);
+		// always leave cursor at the end.
+		this.replInput.setPosition({ lineNumber: 1, column: historyInput.length + 1 });
+		this.setHistoryNavigationEnablement(true);
 	}
 
 	async selectSession(session?: IDebugSession): Promise<void> {

--- a/src/vs/workbench/contrib/interactiveSession/browser/interactiveSessionInputPart.ts
+++ b/src/vs/workbench/contrib/interactiveSession/browser/interactiveSessionInputPart.ts
@@ -98,7 +98,9 @@ export class InteractiveSessionInputPart extends Disposable implements IHistoryN
 	}
 
 	private navigateHistory(previous: boolean): void {
-		const historyInput = (previous ? this.history.previous() : this.history.next()) ?? '';
+		const historyInput = (previous ?
+			(this.history.previous() ?? this.history.first()) : this.history.next())
+			?? '';
 
 		this.inputEditor.setValue(historyInput);
 		aria.status(historyInput);

--- a/src/vs/workbench/contrib/interactiveSession/browser/interactiveSessionInputPart.ts
+++ b/src/vs/workbench/contrib/interactiveSession/browser/interactiveSessionInputPart.ts
@@ -98,17 +98,15 @@ export class InteractiveSessionInputPart extends Disposable implements IHistoryN
 	}
 
 	private navigateHistory(previous: boolean): void {
-		const historyInput = previous ? this.history.previous() : this.history.next();
+		const historyInput = (previous ? this.history.previous() : this.history.next()) ?? '';
 
+		this.inputEditor.setValue(historyInput);
+		aria.status(historyInput);
 		if (historyInput) {
-			this.inputEditor.setValue(historyInput);
-			aria.status(historyInput);
-			if (historyInput) {
-				// always leave cursor at the end.
-				this.inputEditor.setPosition({ lineNumber: 1, column: historyInput.length + 1 });
-			}
-			this.setHistoryNavigationEnablement(true);
+			// always leave cursor at the end.
+			this.inputEditor.setPosition({ lineNumber: 1, column: historyInput.length + 1 });
 		}
+		this.setHistoryNavigationEnablement(true);
 	}
 
 	focus() {


### PR DESCRIPTION
Fix #179488

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
