### PR TITLE
Fix notebook-renderers compile error

### DIFF
--- a/extensions/notebook-renderers/src/index.ts
+++ b/extensions/notebook-renderers/src/index.ts
@@ -218,8 +218,10 @@ function findScrolledHeight(scrollableElement: HTMLElement): number | undefined 
 }
 
 function scrollingEnabled(output: OutputItem, options: RenderOptions) {
-	const metadata: any = output.metadata;
-	return metadata?.scrollable !== undefined ? metadata?.scrollable : options.outputScrolling;
+	const metadata = output.metadata;
+	return (typeof metadata === 'object' && metadata
+		&& 'scrollable' in metadata && typeof metadata.scrollable === 'boolean') ?
+		metadata.scrollable : options.outputScrolling;
 }
 
 function renderStream(outputInfo: OutputItem, outputElement: HTMLElement, error: boolean, ctx: IRichRenderContext): IDisposable {

--- a/extensions/notebook-renderers/src/index.ts
+++ b/extensions/notebook-renderers/src/index.ts
@@ -218,7 +218,8 @@ function findScrolledHeight(scrollableElement: HTMLElement): number | undefined 
 }
 
 function scrollingEnabled(output: OutputItem, options: RenderOptions) {
-	return output.metadata?.scrollable !== undefined ? output.metadata?.scrollable : options.outputScrolling;
+	const metadata: any = output.metadata;
+	return metadata?.scrollable !== undefined ? metadata?.scrollable : options.outputScrolling;
 }
 
 function renderStream(outputInfo: OutputItem, outputElement: HTMLElement, error: boolean, ctx: IRichRenderContext): IDisposable {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
There's a compile error that shows up in notebook-renderers depending on what's run.

```
yarn gulp compile-extensions-build <- OK, and also used by CI/build pipelines
yarn gulp compile-extension:notebook-renderers <- fail, but used by yarn compile or yarn watch
yarn gulp compile-extensions-build-legacy <- fail
```

I noticed that notebook-renderers is using esbuild, but I'm not sure how that causes the difference in behaviour above.

CC @joaomoreno 