### PR TITLE
Use custom node-gyp in product build

### DIFF
--- a/build/azure-pipelines/win32/product-build-win32.yml
+++ b/build/azure-pipelines/win32/product-build-win32.yml
@@ -83,11 +83,10 @@ steps:
     displayName: Setup NPM Authentication
 
   - powershell: |
-      . build/azure-pipelines/win32/exec.ps1
-      $ErrorActionPreference = "Stop"
-      exec { cd .build }
-      exec { git clone -b "rzhao271/msvs-spectre" https://github.com/rzhao271/node-gyp.git }
-      exec { cd .. }
+      mkdir "node-gyp-custom"
+      cd "node-gyp-custom"
+      git clone -b "rzhao271/msvs-spectre" https://github.com/rzhao271/node-gyp.git
+      cd ..
     displayName: Install custom node-gyp
     condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'))
 
@@ -95,7 +94,7 @@ steps:
       . build/azure-pipelines/win32/exec.ps1
       . build/azure-pipelines/win32/retry.ps1
       $ErrorActionPreference = "Stop"
-      $env:npm_config_node_gyp=".build/node-gyp/bin/node-gyp.js"
+      $env:npm_config_node_gyp="node-gyp-custom/node-gyp/bin/node-gyp.js"
       $env:npm_config_arch="$(VSCODE_ARCH)"
       $env:CHILD_CONCURRENCY="1"
       retry { exec { yarn --frozen-lockfile --check-files } }

--- a/build/azure-pipelines/win32/product-build-win32.yml
+++ b/build/azure-pipelines/win32/product-build-win32.yml
@@ -85,9 +85,9 @@ steps:
   - powershell: |
       . build/azure-pipelines/win32/exec.ps1
       $ErrorActionPreference = "Stop"
-      exec { cd .build } "Got code $lastexitcode while trying to cd into builds"
-      exec { git clone -b rzhao271/msvs-spectre https://github.com/rzhao271/node-gyp.git } "Got code $lastexitcode while trying to clone"
-      exec { cd .. } "Got code $lastexitcode while trying to cd out of builds"
+      cd .build
+      exec { git clone -b rzhao271/msvs-spectre https://github.com/rzhao271/node-gyp.git } "Cloning rzhao271/node-gyp failed"
+      cd ..
     displayName: Install custom node-gyp
     condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'))
 

--- a/build/azure-pipelines/win32/product-build-win32.yml
+++ b/build/azure-pipelines/win32/product-build-win32.yml
@@ -83,10 +83,11 @@ steps:
     displayName: Setup NPM Authentication
 
   - powershell: |
-      mkdir "node-gyp-custom"
-      cd "node-gyp-custom"
-      git clone -b "rzhao271/msvs-spectre" https://github.com/rzhao271/node-gyp.git
-      cd ..
+      . build/azure-pipelines/win32/exec.ps1
+      $ErrorActionPreference = "Stop"
+      exec { cd .build }
+      exec { git clone -b rzhao271/msvs-spectre https://github.com/rzhao271/node-gyp.git }
+      exec { cd .. }
     displayName: Install custom node-gyp
     condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'))
 
@@ -94,7 +95,7 @@ steps:
       . build/azure-pipelines/win32/exec.ps1
       . build/azure-pipelines/win32/retry.ps1
       $ErrorActionPreference = "Stop"
-      $env:npm_config_node_gyp="node-gyp-custom/node-gyp/bin/node-gyp.js"
+      $env:npm_config_node_gyp="$(Join-Path $pwd.Path '.build/node-gyp/bin/node-gyp.js')"
       $env:npm_config_arch="$(VSCODE_ARCH)"
       $env:CHILD_CONCURRENCY="1"
       retry { exec { yarn --frozen-lockfile --check-files } }

--- a/build/azure-pipelines/win32/product-build-win32.yml
+++ b/build/azure-pipelines/win32/product-build-win32.yml
@@ -84,8 +84,18 @@ steps:
 
   - powershell: |
       . build/azure-pipelines/win32/exec.ps1
+      $ErrorActionPreference = "Stop"
+      exec { cd .build }
+      exec { git clone -b "rzhao271/msvs-spectre" https://github.com/rzhao271/node-gyp.git }
+      exec { cd .. }
+    displayName: Install custom node-gyp
+    condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'))
+
+  - powershell: |
+      . build/azure-pipelines/win32/exec.ps1
       . build/azure-pipelines/win32/retry.ps1
       $ErrorActionPreference = "Stop"
+      $env:npm_config_node_gyp=".build/node-gyp/bin/node-gyp.js"
       $env:npm_config_arch="$(VSCODE_ARCH)"
       $env:CHILD_CONCURRENCY="1"
       retry { exec { yarn --frozen-lockfile --check-files } }

--- a/build/azure-pipelines/win32/product-build-win32.yml
+++ b/build/azure-pipelines/win32/product-build-win32.yml
@@ -85,9 +85,9 @@ steps:
   - powershell: |
       . build/azure-pipelines/win32/exec.ps1
       $ErrorActionPreference = "Stop"
-      exec { cd .build }
-      exec { git clone -b rzhao271/msvs-spectre https://github.com/rzhao271/node-gyp.git }
-      exec { cd .. }
+      exec { cd .build } "Got code $lastexitcode while trying to cd into builds"
+      exec { git clone -b rzhao271/msvs-spectre https://github.com/rzhao271/node-gyp.git } "Got code $lastexitcode while trying to clone"
+      exec { cd .. } "Got code $lastexitcode while trying to cd out of builds"
     displayName: Install custom node-gyp
     condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'))
 

--- a/build/azure-pipelines/win32/product-build-win32.yml
+++ b/build/azure-pipelines/win32/product-build-win32.yml
@@ -87,6 +87,7 @@ steps:
       $ErrorActionPreference = "Stop"
       cd .build
       exec { git clone -b rzhao271/msvs-spectre https://github.com/rzhao271/node-gyp.git } "Cloning rzhao271/node-gyp failed"
+      npm install
       cd ..
     displayName: Install custom node-gyp
     condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'))

--- a/build/azure-pipelines/win32/product-build-win32.yml
+++ b/build/azure-pipelines/win32/product-build-win32.yml
@@ -85,10 +85,12 @@ steps:
   - powershell: |
       . build/azure-pipelines/win32/exec.ps1
       $ErrorActionPreference = "Stop"
+      $curPath = $pwd.Path
       cd .build
       exec { git clone -b rzhao271/msvs-spectre https://github.com/rzhao271/node-gyp.git } "Cloning rzhao271/node-gyp failed"
+      cd node-gyp
       npm install
-      cd ..
+      cd "$curPath"
     displayName: Install custom node-gyp
     condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'))
 

--- a/build/azure-pipelines/win32/product-build-win32.yml
+++ b/build/azure-pipelines/win32/product-build-win32.yml
@@ -85,7 +85,7 @@ steps:
   - powershell: |
       . build/azure-pipelines/win32/exec.ps1
       $ErrorActionPreference = "Stop"
-      exec { git clone https://github.com/rzhao271/node-gyp.git .build/node-gyp && git checkout 102b347 } "Cloning rzhao271/node-gyp failed"
+      exec { git clone https://github.com/rzhao271/node-gyp.git .build/node-gyp && git checkout 102b347da0c92c29f9c67df22e864e70249cf086 } "Cloning rzhao271/node-gyp failed"
       exec { npm install -C .build/node-gyp } "Building rzhao271/node-gyp failed"
     displayName: Install custom node-gyp
     condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'))

--- a/build/azure-pipelines/win32/product-build-win32.yml
+++ b/build/azure-pipelines/win32/product-build-win32.yml
@@ -85,12 +85,8 @@ steps:
   - powershell: |
       . build/azure-pipelines/win32/exec.ps1
       $ErrorActionPreference = "Stop"
-      $curPath = $pwd.Path
-      cd .build
-      exec { git clone -b rzhao271/msvs-spectre https://github.com/rzhao271/node-gyp.git } "Cloning rzhao271/node-gyp failed"
-      cd node-gyp
-      npm install
-      cd "$curPath"
+      exec { git clone https://github.com/rzhao271/node-gyp.git .build/node-gyp && git checkout 102b347 } "Cloning rzhao271/node-gyp failed"
+      exec { npm install -C .build/node-gyp } "Building rzhao271/node-gyp failed"
     displayName: Install custom node-gyp
     condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'))
 

--- a/build/azure-pipelines/win32/product-build-win32.yml
+++ b/build/azure-pipelines/win32/product-build-win32.yml
@@ -85,8 +85,11 @@ steps:
   - powershell: |
       . build/azure-pipelines/win32/exec.ps1
       $ErrorActionPreference = "Stop"
-      exec { git clone https://github.com/rzhao271/node-gyp.git .build/node-gyp && git checkout 102b347da0c92c29f9c67df22e864e70249cf086 } "Cloning rzhao271/node-gyp failed"
-      exec { npm install -C .build/node-gyp } "Building rzhao271/node-gyp failed"
+      exec { git clone https://github.com/rzhao271/node-gyp.git .build/node-gyp } "Cloning rzhao271/node-gyp failed"
+      cd .build/node-gyp
+      exec { git checkout 102b347da0c92c29f9c67df22e864e70249cf086 } "Checking out 102b347 failed"
+      exec { npm install } "Building rzhao271/node-gyp failed"
+      cd ../..
     displayName: Install custom node-gyp
     condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'))
 

--- a/build/azure-pipelines/win32/product-build-win32.yml
+++ b/build/azure-pipelines/win32/product-build-win32.yml
@@ -82,15 +82,24 @@ steps:
     condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'), ne(variables['NPM_REGISTRY'], 'none'))
     displayName: Setup NPM Authentication
 
+
   - powershell: |
       . build/azure-pipelines/win32/exec.ps1
       $ErrorActionPreference = "Stop"
-      exec { git clone https://github.com/rzhao271/node-gyp.git .build/node-gyp } "Cloning rzhao271/node-gyp failed"
-      cd .build/node-gyp
+      exec { mkdir -Force .build/node-gyp }
+    displayName: Create custom node-gyp directory
+    condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'))
+  
+  - powershell: |
+      . build/azure-pipelines/win32/exec.ps1
+      $ErrorActionPreference = "Stop"
+      # TODO: Should be replaced with upstream URL once https://github.com/nodejs/node-gyp/pull/2825
+      # gets merged.
+      exec { git clone https://github.com/rzhao271/node-gyp.git . } "Cloning rzhao271/node-gyp failed"
       exec { git checkout 102b347da0c92c29f9c67df22e864e70249cf086 } "Checking out 102b347 failed"
       exec { npm install } "Building rzhao271/node-gyp failed"
-      cd ../..
     displayName: Install custom node-gyp
+    workingDirectory: .build/node-gyp
     condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'))
 
   - powershell: |

--- a/build/azure-pipelines/win32/product-build-win32.yml
+++ b/build/azure-pipelines/win32/product-build-win32.yml
@@ -83,9 +83,7 @@ steps:
     displayName: Setup NPM Authentication
 
   - powershell: |
-      . build/azure-pipelines/win32/exec.ps1
-      $ErrorActionPreference = "Stop"
-      exec { mkdir -Force .build/node-gyp }
+      mkdir -Force .build/node-gyp
     displayName: Create custom node-gyp directory
     condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'))
 

--- a/build/azure-pipelines/win32/product-build-win32.yml
+++ b/build/azure-pipelines/win32/product-build-win32.yml
@@ -82,16 +82,15 @@ steps:
     condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'), ne(variables['NPM_REGISTRY'], 'none'))
     displayName: Setup NPM Authentication
 
-
   - powershell: |
       . build/azure-pipelines/win32/exec.ps1
       $ErrorActionPreference = "Stop"
       exec { mkdir -Force .build/node-gyp }
     displayName: Create custom node-gyp directory
     condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'))
-  
+
   - powershell: |
-      . build/azure-pipelines/win32/exec.ps1
+      . ../../build/azure-pipelines/win32/exec.ps1
       $ErrorActionPreference = "Stop"
       # TODO: Should be replaced with upstream URL once https://github.com/nodejs/node-gyp/pull/2825
       # gets merged.


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
This PR has to do with Binskim.

Upstream is blocked on a CI failure for https://github.com/nodejs/node-gyp/pull/2825, which is blocked on [nodejs/gyp-next](https://github.com/nodejs/gyp-next) requiring another release. Even after upstream merges the PR, we would need to wait for a new version of node-gyp to come out.