### PR TITLE
SemanticOccurenceAtPositionRequest should also check for empty selection

### DIFF
--- a/src/vs/editor/contrib/wordHighlighter/browser/wordHighlighter.ts
+++ b/src/vs/editor/contrib/wordHighlighter/browser/wordHighlighter.ts
@@ -117,6 +117,9 @@ class SemanticOccurenceAtPositionRequest extends OccurenceAtPositionRequest {
 	}
 
 	protected _compute(model: ITextModel, selection: Selection, wordSeparators: string, token: CancellationToken): Promise<DocumentHighlight[]> {
+		if (!selection.isEmpty()) {
+			return [];
+		}
 		return getOccurrencesAtPosition(this._providers, model, selection.getPosition(), token).then(value => value || []);
 	}
 }

--- a/src/vs/editor/contrib/wordHighlighter/browser/wordHighlighter.ts
+++ b/src/vs/editor/contrib/wordHighlighter/browser/wordHighlighter.ts
@@ -118,7 +118,7 @@ class SemanticOccurenceAtPositionRequest extends OccurenceAtPositionRequest {
 
 	protected _compute(model: ITextModel, selection: Selection, wordSeparators: string, token: CancellationToken): Promise<DocumentHighlight[]> {
 		if (!selection.isEmpty()) {
-			return [];
+			return Promise.resolve([]);
 		}
 		return getOccurrencesAtPosition(this._providers, model, selection.getPosition(), token).then(value => value || []);
 	}


### PR DESCRIPTION
… same as TextualOccurenceAtPositionRequest

Fixes #179803

This check is performed with `TextualOccurenceAtPositionRequest`, but not with `SemanticOccurenceAtPositionRequest`.