### PR TITLE
cli: add acquire_cli

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -55,6 +55,7 @@ cfg-if = "1.0.0"
 pin-project = "1.0"
 console = "0.15"
 bytes = "1.4"
+tar = { version = "0.4" }
 
 [build-dependencies]
 serde = { version = "1.0" }
@@ -68,7 +69,6 @@ winapi = "0.3.9"
 core-foundation = "0.9.3"
 
 [target.'cfg(target_os = "linux")'.dependencies]
-tar = { version = "0.4" }
 zbus = { version = "3.4", default-features = false, features = ["tokio"] }
 
 [patch.crates-io]

--- a/cli/src/download_cache.rs
+++ b/cli/src/download_cache.rs
@@ -86,12 +86,12 @@ impl DownloadCache {
 		let _ = remove_dir_all(&temp_dir).await; // cleanup any existing
 
 		create_dir_all(&temp_dir).map_err(|e| wrap(e, "error creating server directory"))?;
-		do_create(target_dir.clone()).await?;
+		do_create(temp_dir.clone()).await?;
 
 		let _ = self.touch(name.to_string());
 		std::fs::rename(&temp_dir, &target_dir)
 			.map_err(|e| wrap(e, "error renaming downloaded server"))?;
-		println!("done rename");
+
 		Ok(target_dir)
 	}
 

--- a/cli/src/download_cache.rs
+++ b/cli/src/download_cache.rs
@@ -1,0 +1,119 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+use std::{
+	fs::create_dir_all,
+	path::{Path, PathBuf},
+};
+
+use futures::Future;
+use tokio::fs::remove_dir_all;
+
+use crate::{
+	state::PersistedState,
+	util::errors::{wrap, AnyError, WrappedError},
+};
+
+const KEEP_LRU: usize = 5;
+const STAGING_SUFFIX: &str = ".staging";
+
+#[derive(Clone)]
+pub struct DownloadCache {
+	path: PathBuf,
+	state: PersistedState<Vec<String>>,
+}
+
+impl DownloadCache {
+	pub fn new(path: PathBuf) -> DownloadCache {
+		DownloadCache {
+			state: PersistedState::new(path.join("lru.json")),
+			path,
+		}
+	}
+
+	/// Gets the download cache path. Names of cache entries can be formed by
+	/// joining them to the path.
+	pub fn path(&self) -> &Path {
+		&self.path
+	}
+
+	/// Gets whether a cache exists with the name already. Marks it as recently
+	/// used if it does exist.
+	pub fn exists(&self, name: &str) -> Option<PathBuf> {
+		let p = self.path.join(name);
+		if !p.exists() {
+			return None;
+		}
+
+		let _ = self.touch(name.to_string());
+		Some(p)
+	}
+
+	/// Removes the item from the cache, if it exists
+	pub fn delete(&self, name: &str) -> Result<(), WrappedError> {
+		let f = self.path.join(name);
+		if f.exists() {
+			std::fs::remove_dir_all(f).map_err(|e| wrap(e, "error removing cached folder"))?;
+		}
+
+		self.state.update(|l| {
+			l.retain(|n| n != name);
+		})
+	}
+
+	/// Calls the function to create the cached folder if it doesn't exist,
+	/// returning the path where the folder is. Note that the path passed to
+	/// the `do_create` method is a staging path and will not be the same as the
+	/// final returned path.
+	pub async fn create<F, T>(
+		&self,
+		name: impl AsRef<str>,
+		do_create: F,
+	) -> Result<PathBuf, AnyError>
+	where
+		F: FnOnce(PathBuf) -> T,
+		T: Future<Output = Result<(), AnyError>> + Send,
+	{
+		let name = name.as_ref();
+		let target_dir = self.path.join(name);
+		if target_dir.exists() {
+			return Ok(target_dir);
+		}
+
+		let temp_dir = self.path.join(format!("{}{}", name, STAGING_SUFFIX));
+		let _ = remove_dir_all(&temp_dir).await; // cleanup any existing
+
+		create_dir_all(&temp_dir).map_err(|e| wrap(e, "error creating server directory"))?;
+		do_create(target_dir.clone()).await?;
+
+		let _ = self.touch(name.to_string());
+		std::fs::rename(&temp_dir, &target_dir)
+			.map_err(|e| wrap(e, "error renaming downloaded server"))?;
+		println!("done rename");
+		Ok(target_dir)
+	}
+
+	fn touch(&self, name: String) -> Result<(), AnyError> {
+		self.state.update(|l| {
+			if let Some(index) = l.iter().position(|s| s == &name) {
+				l.remove(index);
+			}
+			l.insert(0, name);
+
+			if l.len() <= KEEP_LRU {
+				return;
+			}
+
+			if let Some(f) = l.last() {
+				let f = self.path.join(f);
+				if !f.exists() || std::fs::remove_dir_all(f).is_ok() {
+					l.pop();
+				}
+			}
+		})?;
+
+		Ok(())
+	}
+}

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -18,6 +18,7 @@ pub mod tunnels;
 pub mod update_service;
 pub mod util;
 
+mod download_cache;
 mod async_pipe;
 mod json_rpc;
 mod msgpack_rpc;

--- a/cli/src/self_update.rs
+++ b/cli/src/self_update.rs
@@ -65,8 +65,8 @@ impl<'a> SelfUpdate<'a> {
 	) -> Result<(), AnyError> {
 		// 1. Download the archive into a temporary directory
 		let tempdir = tempdir().map_err(|e| wrap(e, "Failed to create temp dir"))?;
-		let archive_path = tempdir.path().join("archive");
 		let stream = self.update_service.get_download_stream(release).await?;
+		let archive_path = tempdir.path().join(stream.url_path_basename().unwrap());
 		http::download_into_file(&archive_path, progress, stream).await?;
 
 		// 2. Unzip the archive and get the binary

--- a/cli/src/tunnels/paths.rs
+++ b/cli/src/tunnels/paths.rs
@@ -11,19 +11,15 @@ use std::{
 use serde::{Deserialize, Serialize};
 
 use crate::{
-	log, options,
-	state::{LauncherPaths, PersistedState},
+	options::{self, Quality},
+	state::LauncherPaths,
 	util::{
 		errors::{wrap, AnyError, WrappedError},
 		machine,
 	},
 };
 
-const INSIDERS_INSTALL_FOLDER: &str = "server-insiders";
-const STABLE_INSTALL_FOLDER: &str = "server-stable";
-const EXPLORATION_INSTALL_FOLDER: &str = "server-exploration";
-const PIDFILE_SUFFIX: &str = ".pid";
-const LOGFILE_SUFFIX: &str = ".log";
+pub const SERVER_FOLDER_NAME: &str = "server";
 
 pub struct ServerPaths {
 	// Directory into which the server is downloaded
@@ -93,73 +89,24 @@ pub struct InstalledServer {
 impl InstalledServer {
 	/// Gets path information about where a specific server should be stored.
 	pub fn server_paths(&self, p: &LauncherPaths) -> ServerPaths {
-		let base_folder = self.get_install_folder(p);
-		let server_dir = base_folder.join("bin").join(&self.commit);
+		let server_dir = self.get_install_folder(p);
 		ServerPaths {
 			executable: server_dir
+				.join(SERVER_FOLDER_NAME)
 				.join("bin")
 				.join(self.quality.server_entrypoint()),
+			logfile: server_dir.join("log.txt"),
+			pidfile: server_dir.join("pid.txt"),
 			server_dir,
-			logfile: base_folder.join(format!(".{}{}", self.commit, LOGFILE_SUFFIX)),
-			pidfile: base_folder.join(format!(".{}{}", self.commit, PIDFILE_SUFFIX)),
 		}
 	}
 
 	fn get_install_folder(&self, p: &LauncherPaths) -> PathBuf {
-		let name = match self.quality {
-			options::Quality::Insiders => INSIDERS_INSTALL_FOLDER,
-			options::Quality::Exploration => EXPLORATION_INSTALL_FOLDER,
-			options::Quality::Stable => STABLE_INSTALL_FOLDER,
-		};
-
-		p.root().join(if !self.headless {
-			format!("{}-web", name)
+		p.server_cache.path().join(if !self.headless {
+			format!("{}-web", get_server_folder_name(self.quality, &self.commit))
 		} else {
-			name.to_string()
+			get_server_folder_name(self.quality, &self.commit)
 		})
-	}
-}
-
-pub struct LastUsedServers<'a> {
-	state: PersistedState<Vec<InstalledServer>>,
-	paths: &'a LauncherPaths,
-}
-
-impl<'a> LastUsedServers<'a> {
-	pub fn new(paths: &'a LauncherPaths) -> LastUsedServers {
-		LastUsedServers {
-			state: PersistedState::new(paths.root().join("last-used-servers.json")),
-			paths,
-		}
-	}
-
-	/// Adds a server as having been used most recently. Returns the number of retained server.
-	pub fn add(&self, server: InstalledServer) -> Result<usize, WrappedError> {
-		self.state.update_with(server, |server, l| {
-			if let Some(index) = l.iter().position(|s| s == &server) {
-				l.remove(index);
-			}
-			l.insert(0, server);
-			l.len()
-		})
-	}
-
-	/// Trims so that at most `max_servers` are saved on disk.
-	pub fn trim(&self, log: &log::Logger, max_servers: usize) -> Result<(), WrappedError> {
-		let mut servers = self.state.load();
-		while servers.len() > max_servers {
-			let server = servers.pop().unwrap();
-			debug!(
-				log,
-				"Removing old server {}/{}",
-				server.quality.get_machine_name(),
-				server.commit
-			);
-			let server_paths = server.server_paths(self.paths);
-			server_paths.delete()?;
-		}
-		self.state.save(servers)?;
-		Ok(())
 	}
 }
 
@@ -177,40 +124,31 @@ pub fn prune_stopped_servers(launcher_paths: &LauncherPaths) -> Result<Vec<Serve
 // Gets a list of all servers which look like they might be running.
 pub fn get_all_servers(lp: &LauncherPaths) -> Vec<InstalledServer> {
 	let mut servers: Vec<InstalledServer> = vec![];
-	let mut server = InstalledServer {
-		commit: "".to_owned(),
-		headless: false,
-		quality: options::Quality::Stable,
-	};
+	if let Ok(children) = read_dir(lp.server_cache.path()) {
+		for child in children.flatten() {
+			let fname = child.file_name();
+			let fname = fname.to_string_lossy();
+			let (quality, commit) = match fname.split_once('-') {
+				Some(r) => r,
+				None => continue,
+			};
 
-	add_server_paths_in_folder(lp, &server, &mut servers);
+			let quality = match options::Quality::try_from(quality) {
+				Ok(q) => q,
+				Err(_) => continue,
+			};
 
-	server.headless = true;
-	add_server_paths_in_folder(lp, &server, &mut servers);
-
-	server.headless = false;
-	server.quality = options::Quality::Insiders;
-	add_server_paths_in_folder(lp, &server, &mut servers);
-
-	server.headless = true;
-	add_server_paths_in_folder(lp, &server, &mut servers);
+			servers.push(InstalledServer {
+				quality,
+				commit: commit.to_string(),
+				headless: true,
+			});
+		}
+	}
 
 	servers
 }
 
-fn add_server_paths_in_folder(
-	lp: &LauncherPaths,
-	server: &InstalledServer,
-	servers: &mut Vec<InstalledServer>,
-) {
-	let dir = server.get_install_folder(lp).join("bin");
-	if let Ok(children) = read_dir(dir) {
-		for bin in children.flatten() {
-			servers.push(InstalledServer {
-				quality: server.quality,
-				headless: server.headless,
-				commit: bin.file_name().to_string_lossy().into(),
-			});
-		}
-	}
+pub fn get_server_folder_name(quality: Quality, commit: &str) -> String {
+	format!("{}-{}", quality, commit)
 }

--- a/cli/src/tunnels/protocol.rs
+++ b/cli/src/tunnels/protocol.rs
@@ -7,6 +7,7 @@ use std::collections::HashMap;
 use crate::{
 	constants::{PROTOCOL_VERSION, VSCODE_CLI_VERSION},
 	options::Quality,
+	update_service::Platform,
 };
 use serde::{Deserialize, Serialize};
 
@@ -164,6 +165,15 @@ pub struct SpawnParams {
 	pub args: Vec<String>,
 	#[serde(default)]
 	pub env: HashMap<String, String>,
+}
+
+#[derive(Deserialize)]
+pub struct AcquireCliParams {
+	pub platform: Platform,
+	pub quality: Quality,
+	pub commit_id: Option<String>,
+	#[serde(flatten)]
+	pub spawn: SpawnParams,
 }
 
 #[derive(Serialize)]

--- a/cli/src/tunnels/wsl_server.rs
+++ b/cli/src/tunnels/wsl_server.rs
@@ -151,7 +151,7 @@ async fn handle_serve(
 		Some(AnyCodeServer::Socket(s)) => s,
 		Some(_) => return Err(MismatchedLaunchModeError().into()),
 		None => {
-			sb.setup(Some(params.archive_path.into())).await?;
+			sb.setup().await?;
 			sb.listen_on_default_socket().await?
 		}
 	};

--- a/cli/src/util.rs
+++ b/cli/src/util.rs
@@ -17,9 +17,5 @@ pub mod sync;
 pub use is_integrated::*;
 pub mod app_lock;
 pub mod file_lock;
-
-#[cfg(target_os = "linux")]
 pub mod tar;
-
-#[cfg(any(target_os = "windows", target_os = "macos"))]
 pub mod zipper;

--- a/cli/src/util/errors.rs
+++ b/cli/src/util/errors.rs
@@ -477,9 +477,11 @@ pub enum CodeError {
 	UnsupportedPlatform(String),
 	#[error("This machine not meet {name}'s prerequisites, expected either...: {bullets}")]
 	PrerequisitesFailed { name: &'static str, bullets: String },
-
 	#[error("failed to spawn process: {0:?}")]
-	ProcessSpawnFailed(std::io::Error)
+	ProcessSpawnFailed(std::io::Error),
+
+	#[error("download appears corrupted, please retry ({0})")]
+	CorruptDownload(&'static str),
 }
 
 makeAnyError!(

--- a/cli/src/util/http.rs
+++ b/cli/src/util/http.rs
@@ -59,14 +59,23 @@ pub struct SimpleResponse {
 	pub status_code: StatusCode,
 	pub headers: HeaderMap,
 	pub read: Pin<Box<dyn Send + AsyncRead + 'static>>,
-	pub url: String,
+	pub url: Option<url::Url>,
 }
 
 impl SimpleResponse {
-	pub fn generic_error(url: String) -> Self {
+	pub fn url_path_basename(&self) -> Option<String> {
+		self.url.as_ref().and_then(|u| {
+			u.path_segments()
+				.and_then(|s| s.last().map(|s| s.to_owned()))
+		})
+	}
+}
+
+impl SimpleResponse {
+	pub fn generic_error(url: &str) -> Self {
 		let (_, rx) = mpsc::unbounded_channel();
 		SimpleResponse {
-			url,
+			url: url::Url::parse(url).ok(),
 			status_code: StatusCode::INTERNAL_SERVER_ERROR,
 			headers: HeaderMap::new(),
 			read: Box::pin(DelegatedReader::new(rx)),
@@ -79,7 +88,10 @@ impl SimpleResponse {
 		self.read.read_to_string(&mut body).await.ok();
 
 		StatusError {
-			url: self.url,
+			url: self
+				.url
+				.map(|u| u.to_string())
+				.unwrap_or_else(|| "<invalid url>".to_owned()),
 			status_code: self.status_code.as_u16(),
 			body,
 		}
@@ -97,7 +109,7 @@ impl SimpleResponse {
 			.map_err(|e| wrap(e, "error reading response"))?;
 
 		let t = serde_json::from_slice(&buf)
-			.map_err(|e| wrap(e, format!("error decoding json from {}", self.url)))?;
+			.map_err(|e| wrap(e, format!("error decoding json from {:?}", self.url)))?;
 
 		Ok(t)
 	}
@@ -161,7 +173,7 @@ impl SimpleHttp for ReqwestSimpleHttp {
 		Ok(SimpleResponse {
 			status_code: res.status(),
 			headers: res.headers().clone(),
-			url,
+			url: Some(res.url().clone()),
 			read: Box::pin(
 				res.bytes_stream()
 					.map_err(|e| futures::io::Error::new(futures::io::ErrorKind::Other, e))
@@ -250,7 +262,7 @@ impl SimpleHttp for DelegatedSimpleHttp {
 			.await;
 
 		if sent.is_err() {
-			return Ok(SimpleResponse::generic_error(url)); // sender shut down
+			return Ok(SimpleResponse::generic_error(&url)); // sender shut down
 		}
 
 		match rx.recv().await {
@@ -275,16 +287,16 @@ impl SimpleHttp for DelegatedSimpleHttp {
 				}
 
 				Ok(SimpleResponse {
-					url,
+					url: url::Url::parse(&url).ok(),
 					status_code: StatusCode::from_u16(status_code)
 						.unwrap_or(StatusCode::INTERNAL_SERVER_ERROR),
 					headers: headers_map,
 					read: Box::pin(DelegatedReader::new(rx)),
 				})
 			}
-			Some(DelegatedHttpEvent::End) => Ok(SimpleResponse::generic_error(url)),
+			Some(DelegatedHttpEvent::End) => Ok(SimpleResponse::generic_error(&url)),
 			Some(_) => panic!("expected initresponse as first message from delegated http"),
-			None => Ok(SimpleResponse::generic_error(url)), // sender shut down
+			None => Ok(SimpleResponse::generic_error(&url)), // sender shut down
 		}
 	}
 }


### PR DESCRIPTION
As given in my draft document, pipes a CLI of the given platform to the
specified process, for example:

```js
const cmd = await rpc.call('acquire_cli', {
	command: 'node',
	args: [
		'-e',
		'process.stdin.pipe(fs.createWriteStream("c:/users/conno/downloads/hello-cli"))',
	],
	platform: Platform.LinuxX64,
	quality: 'insider',
});
```

It genericizes caching so that the CLI is also cached on the host, just
like servers.

Still one bug I need to fix, but this generally works.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
