### PR TITLE
Change default terminal cursor blinking setting to true

### DIFF
--- a/src/vs/workbench/contrib/terminal/common/terminalConfiguration.ts
+++ b/src/vs/workbench/contrib/terminal/common/terminalConfiguration.ts
@@ -256,7 +256,7 @@ const terminalConfiguration: IConfigurationNode = {
 		[TerminalSettingId.CursorBlinking]: {
 			description: localize('terminal.integrated.cursorBlinking', "Controls whether the terminal cursor blinks."),
 			type: 'boolean',
-			default: false
+			default: true
 		},
 		[TerminalSettingId.CursorStyle]: {
 			description: localize('terminal.integrated.cursorStyle', "Controls the style of terminal cursor."),


### PR DESCRIPTION
This pull request aims to unlock the inspiring power of a blinking cursor in VSCode terminal windows by changing the default cursor blinking setting to "true".