### PR TITLE
Revert "chore: update electron@22.4.6 (#179947)"

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,4 +1,4 @@
 disturl "https://electronjs.org/headers"
-target "22.3.6"
+target "22.3.5"
 runtime "electron"
 build_from_source "true"

--- a/build/lib/electron.js
+++ b/build/lib/electron.js
@@ -76,7 +76,7 @@ function darwinBundleDocumentTypes(types, icon) {
     });
 }
 exports.config = {
-    version: product.electronRepository ? '22.4.6' : util.getElectronVersion(),
+    version: product.electronRepository ? '22.4.5' : util.getElectronVersion(),
     productAppName: product.nameLong,
     companyName: 'Microsoft Corporation',
     copyright: 'Copyright (C) 2023 Microsoft. All rights reserved',
@@ -193,7 +193,7 @@ function getElectron(arch) {
     };
 }
 async function main(arch = process.arch) {
-    const version = product.electronRepository ? '22.4.6' : util.getElectronVersion();
+    const version = product.electronRepository ? '22.4.5' : util.getElectronVersion();
     const electronPath = path.join(root, '.build', 'electron');
     const versionFile = path.join(electronPath, 'version');
     const isUpToDate = fs.existsSync(versionFile) && fs.readFileSync(versionFile, 'utf8') === `${version}`;

--- a/build/lib/electron.ts
+++ b/build/lib/electron.ts
@@ -91,7 +91,7 @@ function darwinBundleDocumentTypes(types: { [name: string]: string | string[] },
 }
 
 export const config = {
-	version: product.electronRepository ? '22.4.6' : util.getElectronVersion(),
+	version: product.electronRepository ? '22.4.5' : util.getElectronVersion(),
 	productAppName: product.nameLong,
 	companyName: 'Microsoft Corporation',
 	copyright: 'Copyright (C) 2023 Microsoft. All rights reserved',
@@ -212,7 +212,7 @@ function getElectron(arch: string): () => NodeJS.ReadWriteStream {
 }
 
 async function main(arch = process.arch): Promise<void> {
-	const version = product.electronRepository ? '22.4.6' : util.getElectronVersion();
+	const version = product.electronRepository ? '22.4.5' : util.getElectronVersion();
 	const electronPath = path.join(root, '.build', 'electron');
 	const versionFile = path.join(electronPath, 'version');
 	const isUpToDate = fs.existsSync(versionFile) && fs.readFileSync(versionFile, 'utf8') === `${version}`;

--- a/cgmanifest.json
+++ b/cgmanifest.json
@@ -528,12 +528,12 @@
 				"git": {
 					"name": "electron",
 					"repositoryUrl": "https://github.com/electron/electron",
-					"commitHash": "fcbd88f8aa27b1b603d267e5ebe0b7d748375c43"
+					"commitHash": "0b17a201195ae6445e11cee50e436a3511717600"
 				}
 			},
 			"isOnlyProductionDependency": true,
 			"license": "MIT",
-			"version": "22.3.6"
+			"version": "22.3.5"
 		},
 		{
 			"component": {

--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
     "cssnano": "^4.1.11",
     "debounce": "^1.0.0",
     "deemon": "^1.8.0",
-    "electron": "22.3.6",
+    "electron": "22.3.5",
     "eslint": "8.36.0",
     "eslint-plugin-header": "3.1.1",
     "eslint-plugin-jsdoc": "^39.3.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3572,10 +3572,10 @@ electron-to-chromium@^1.4.202:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.207.tgz#9c3310ebace2952903d05dcaba8abe3a4ed44c01"
   integrity sha512-piH7MJDJp4rJCduWbVvmUd59AUne1AFBJ8JaRQvk0KzNTSUnZrVXHCZc+eg+CGE4OujkcLJznhGKD6tuAshj5Q==
 
-electron@22.3.6:
-  version "22.3.6"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-22.3.6.tgz#ab79a2da20e83b02ec9cbb22a4069468e6949b4f"
-  integrity sha512-/1/DivFHH5AWa/uOuqpkeg12/jjicjkBU8kYv70oeqRFwXzoyuJhgwlzER4jZXnbGjF5Nxz9900oXq/QzAViAw==
+electron@22.3.5:
+  version "22.3.5"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-22.3.5.tgz#a53a318cbb25a44914dfedd30a9ad6120632197f"
+  integrity sha512-CTdnoTbO3sDiMv47TX3ZO640Ca57v1qpiqGChFF8oZbtfHuQjTPPaE4hsoynf22wwnBiyJNL41DpB/pfp9USnA==
   dependencies:
     "@electron/get" "^2.0.0"
     "@types/node" "^16.11.26"


### PR DESCRIPTION
Causes crash in extension host when using v8.serializer API, regressed with https://github.com/electron/electron/commit/62dddd12edb54b2fe73fd810b7a739f869f0b271