### PR TITLE
rearrange search result aria label

### DIFF
--- a/src/vs/workbench/contrib/search/browser/searchResultsView.ts
+++ b/src/vs/workbench/contrib/search/browser/searchResultsView.ts
@@ -401,10 +401,10 @@ export class SearchAccessibilityProvider implements IListAccessibilityProvider<R
 			const range = match.range();
 			const matchText = match.text().substr(0, range.endColumn + 150);
 			if (replace) {
-				return nls.localize('replacePreviewResultAria', "Replace '{0}' with '{1}' in line '{2}' at column {3}", matchString, match.replaceString, matchText, range.startColumn + 1);
+				return nls.localize('replacePreviewResultAria', "'{0}' at column {1} replace with {2}", matchText, range.startColumn + 1, matchString);
 			}
 
-			return nls.localize('searchResultAria', "Found '{0}' in line '{1}' at column {2}", matchString, matchText, range.startColumn + 1);
+			return nls.localize('searchResultAria', "'{0}' at column {1} found {2}", matchText, range.startColumn + 1, matchString);
 		}
 		return null;
 	}

--- a/src/vs/workbench/contrib/search/browser/searchResultsView.ts
+++ b/src/vs/workbench/contrib/search/browser/searchResultsView.ts
@@ -401,7 +401,7 @@ export class SearchAccessibilityProvider implements IListAccessibilityProvider<R
 			const range = match.range();
 			const matchText = match.text().substr(0, range.endColumn + 150);
 			if (replace) {
-				return nls.localize('replacePreviewResultAria', "'{0}' at column {1} replace with {2}", matchText, range.startColumn + 1, matchString);
+				return nls.localize('replacePreviewResultAria', "'{0}' at column {1} replace {2} with {3}", matchText, range.startColumn + 1, matchString, match.replaceString);
 			}
 
 			return nls.localize('searchResultAria', "'{0}' at column {1} found {2}", matchText, range.startColumn + 1, matchString);


### PR DESCRIPTION
This rearranges the aria label content so the most important info is presented first such that a screen reader user can easily traverse the results without listening to redundant content
fixes #179718