### PR TITLE
Fix trusted telemetry serialization

### DIFF
--- a/src/vs/platform/telemetry/common/telemetryUtils.ts
+++ b/src/vs/platform/telemetry/common/telemetryUtils.ts
@@ -21,6 +21,8 @@ import { ICustomEndpointTelemetryService, ITelemetryData, ITelemetryEndpoint, IT
  * NOTE: This is used as an API type as well, and should not be changed.
  */
 export class TelemetryTrustedValue<T> {
+	// This is merely used as an identifier as the instance will be lost during serialization over the exthost
+	public readonly isTrustedTelemetryValue = true;
 	constructor(public readonly value: T) { }
 }
 
@@ -378,7 +380,7 @@ export function cleanData(data: Record<string, any>, cleanUpPatterns: RegExp[]):
 	return cloneAndChange(data, value => {
 
 		// If it's a trusted value it means it's okay to skip cleaning so we don't clean it
-		if (value instanceof TelemetryTrustedValue) {
+		if (value instanceof TelemetryTrustedValue || value.hasOwnProperty('isTrustedTelemetryValue')) {
 			return value.value;
 		}
 


### PR DESCRIPTION
Fixes an issue with using the new `TelemetryTrustedValue` concept on the ext host due to the instance getting lost to serialization.


cc @jrieken Is there an RPC feature that will automatically add an identifier to classes or is this something that we must do ourselves?