### PR TITLE
:notebook: find scope

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -125,9 +125,5 @@
 	],
 	"application.experimental.rendererProfiling": true,
 	"editor.experimental.asyncTokenization": true,
-	"editor.experimental.asyncTokenizationVerification": true,
-	"notebook.experimental.findInMarkdownMode": {
-        "source": true,
-        "preview": true
-    }
+	"editor.experimental.asyncTokenizationVerification": true
 }

--- a/src/vs/workbench/contrib/notebook/browser/contrib/find/findModel.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/find/findModel.ts
@@ -124,54 +124,41 @@ export class FindModel extends Disposable {
 		}
 
 		// we only update cell state if users are using the hybrid mode (both input and preview are enabled)
-		const updateEditingState = (editing: boolean) => {
+		const updateEditingState = () => {
 			const viewModel = this._notebookEditor._getViewModel() as NotebookViewModel | undefined;
 			if (!viewModel) {
 				return;
 			}
+			// search markup sources first to decide if a markup cell should be in editing mode
+			const wordSeparators = this._configurationService.inspect<string>('editor.wordSeparators').value;
+			const options: INotebookSearchOptions = {
+				regex: this._state.isRegex,
+				wholeWord: this._state.wholeWord,
+				caseSensitive: this._state.matchCase,
+				wordSeparators: wordSeparators,
+				includeMarkupInput: true,
+				includeCodeInput: false,
+				includeMarkupPreview: false,
+				includeOutput: false
+			};
 
-			if (!editing) {
-				for (let i = 0; i < viewModel.length; i++) {
-					const cell = viewModel.cellAt(i);
-					if (cell && cell.cellKind === CellKind.Markup) {
-						cell.updateEditState(CellEditState.Preview, 'Find');
-					}
-				}
-			} else {
-				// search markup sources first to decide if a markup cell should be in editing mode
-				const wordSeparators = this._configurationService.inspect<string>('editor.wordSeparators').value;
-				const options: INotebookSearchOptions = {
-					regex: this._state.isRegex,
-					wholeWord: this._state.wholeWord,
-					caseSensitive: this._state.matchCase,
-					wordSeparators: wordSeparators,
-					includeMarkupInput: true,
-					includeCodeInput: false,
-					includeMarkupPreview: false,
-					includeOutput: false
-				};
-
-				const contentMatches = viewModel.find(this._state.searchString, options);
-				for (let i = 0; i < viewModel.length; i++) {
-					const cell = viewModel.cellAt(i);
-					if (cell && cell.cellKind === CellKind.Markup) {
-						const foundContentMatch = contentMatches.find(m => m.cell.handle === cell.handle && m.contentMatches.length > 0);
-						cell.updateEditState(foundContentMatch ? CellEditState.Editing : CellEditState.Preview, 'Find');
+			const contentMatches = viewModel.find(this._state.searchString, options);
+			for (let i = 0; i < viewModel.length; i++) {
+				const cell = viewModel.cellAt(i);
+				if (cell && cell.cellKind === CellKind.Markup) {
+					const foundContentMatch = contentMatches.find(m => m.cell.handle === cell.handle && m.contentMatches.length > 0);
+					const targetState = foundContentMatch ? CellEditState.Editing : CellEditState.Preview;
+					if (cell.getEditState() !== targetState) {
+						cell.updateEditState(targetState, 'find');
 					}
 				}
 			}
 		};
 
-		if (e.isReplaceRevealed) {
-			updateEditingState(this._state.replaceString.length > 0);
-		}
-
-		if (e.isRevealed && !this._state.isRevealed && this._state.isReplaceRevealed) {
-			updateEditingState(false);
-		}
-
-		if ((e.searchString || e.replaceString) && this._state.isRevealed && this._state.isReplaceRevealed && this._state.replaceString.length > 0) {
-			updateEditingState(true);
+		if (e.isReplaceRevealed && this._state.replaceString.length > 0) {
+			updateEditingState();
+		} else if ((e.filters || e.isRevealed || e.searchString || e.replaceString) && this._state.isRevealed && this._state.isReplaceRevealed && this._state.replaceString.length > 0) {
+			updateEditingState();
 		}
 	}
 
@@ -272,7 +259,9 @@ export class FindModel extends Disposable {
 			}
 		} else {
 			const match = findMatch.getMatch(matchIndex) as FindMatch;
-			findMatch.cell.updateEditState(CellEditState.Editing, 'find');
+			if (findMatch.cell.getEditState() !== CellEditState.Editing) {
+				findMatch.cell.updateEditState(CellEditState.Editing, 'find');
+			}
 			findMatch.cell.isInputCollapsed = false;
 			this._notebookEditor.focusElement(findMatch.cell);
 			this._notebookEditor.setCellEditorSelection(findMatch.cell, match.range);

--- a/src/vs/workbench/contrib/notebook/browser/contrib/find/findModel.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/find/findModel.ts
@@ -155,9 +155,13 @@ export class FindModel extends Disposable {
 			}
 		};
 
-		if (e.isReplaceRevealed && this._state.replaceString.length > 0) {
+		if (this._state.replaceString.length === 0) {
+			return;
+		}
+
+		if (e.isReplaceRevealed) {
 			updateEditingState();
-		} else if ((e.filters || e.isRevealed || e.searchString || e.replaceString) && this._state.isRevealed && this._state.isReplaceRevealed && this._state.replaceString.length > 0) {
+		} else if ((e.filters || e.isRevealed || e.searchString || e.replaceString) && this._state.isRevealed && this._state.isReplaceRevealed) {
 			updateEditingState();
 		}
 	}

--- a/src/vs/workbench/contrib/notebook/browser/contrib/find/notebookFindReplaceWidget.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/find/notebookFindReplaceWidget.ts
@@ -306,9 +306,14 @@ export abstract class SimpleFindReplaceWidget extends Widget {
 	) {
 		super();
 
-		const findInMarkdownMode = this._configurationService.getValue<{ source: boolean; preview: boolean }>(NotebookSetting.experimentalFindInMarkdownMode) ?? { source: true, preview: false };
+		const findScope = this._configurationService.getValue<{
+			markupSource: boolean;
+			markupPreview: boolean;
+			codeSource: boolean;
+			codeOutput: boolean;
+		}>(NotebookSetting.findScope) ?? { markupSource: true, markupPreview: true, codeSource: true, codeOutput: true };
 
-		this._filters = new NotebookFindFilters(findInMarkdownMode.source, findInMarkdownMode.preview, true, true);
+		this._filters = new NotebookFindFilters(findScope.markupSource, findScope.markupPreview, findScope.codeSource, findScope.codeOutput);
 		this._state.change({ filters: this._filters }, false);
 
 		this._filters.onDidChange(() => {

--- a/src/vs/workbench/contrib/notebook/browser/contrib/find/notebookFindWidget.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/find/notebookFindWidget.ts
@@ -321,7 +321,7 @@ class NotebookFindWidget extends SimpleFindReplaceWidget implements INotebookEdi
 				const cell = this._notebookEditor.cellAt(i);
 
 				if (cell.getEditState() === CellEditState.Editing && cell.editStateSource === 'find') {
-					cell.updateEditState(CellEditState.Preview, 'find');
+					cell.updateEditState(CellEditState.Preview, 'closeFind');
 				}
 			}
 		}

--- a/src/vs/workbench/contrib/notebook/browser/notebook.contribution.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebook.contribution.ts
@@ -917,22 +917,32 @@ configurationRegistry.registerConfiguration({
 			type: 'boolean',
 			default: true
 		},
-		[NotebookSetting.experimentalFindInMarkdownMode]: {
-			markdownDescription: nls.localize('notebook.experimental.findInMarkdownMode', "Customize the Find Widget behavior for searching within markdown cells. When both are enabled, the Find Widget will search either the content or preview based on the current state of the markdown cell. Toggle the boolean values to control the Find Widget's scope for each mode as needed."),
+		[NotebookSetting.findScope]: {
+			markdownDescription: nls.localize('notebook.findScope', "Customize the Find Widget behavior for searching within notebook cells. When both markup source and markup preview are enabled, the Find Widget will search either the source code or preview based on the current state of the cell."),
 			type: 'object',
 			properties: {
-				source: {
+				markupSource: {
 					type: 'boolean',
 					default: true
 				},
-				preview: {
+				markupPreview: {
 					type: 'boolean',
-					default: false
+					default: true
+				},
+				codeSource: {
+					type: 'boolean',
+					default: true
+				},
+				codeOutput: {
+					type: 'boolean',
+					default: true
 				}
 			},
 			default: {
-				source: true,
-				preview: false
+				markupSource: true,
+				markupPreview: true,
+				codeSource: true,
+				codeOutput: true
 			},
 			tags: ['notebookLayout']
 		}

--- a/src/vs/workbench/contrib/notebook/common/notebookCommon.ts
+++ b/src/vs/workbench/contrib/notebook/common/notebookCommon.ts
@@ -944,7 +944,7 @@ export const NotebookSetting = {
 	outputFontSize: 'notebook.output.fontSize',
 	outputFontFamilyDeprecated: 'notebook.outputFontFamily',
 	outputFontFamily: 'notebook.output.fontFamily',
-	experimentalFindInMarkdownMode: 'notebook.experimental.findInMarkdownMode',
+	findScope: 'notebook.find.scope',
 	logging: 'notebook.logging',
 	confirmDeleteRunningCell: 'notebook.confirmDeleteRunningCell',
 } as const;


### PR DESCRIPTION
This PR added

* Settings to control notebook find scope
* Restore cell editing state if it's modifed by find widget during a find session

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
