### PR TITLE
chore: disable portals for snap

### DIFF
--- a/resources/linux/snap/snapcraft.yaml
+++ b/resources/linux/snap/snapcraft.yaml
@@ -76,10 +76,6 @@ apps:
   @@NAME@@:
     command: electron-launch $SNAP/usr/share/@@NAME@@/bin/@@NAME@@ --no-sandbox
     common-id: @@NAME@@.desktop
-    environment:
-      GTK_USE_PORTAL: 1
 
   url-handler:
     command: electron-launch $SNAP/usr/share/@@NAME@@/bin/@@NAME@@ --open-url --no-sandbox
-    environment:
-      GTK_USE_PORTAL: 1


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/180004

Portals on Ubuntu <= 21.04 are old and does not check the [file access permissions](https://github.com/flatpak/xdg-desktop-portal/commit/48a981ee3cc3fbfbb2474629ab6c2e8a81ba67a4) for snaps correctly and end up creating symlinks in sandboxed paths.