### PR TITLE
Fix bugs with drop widget in notebooks

### DIFF
--- a/src/vs/editor/contrib/dropIntoEditor/browser/dropIntoEditorContribution.ts
+++ b/src/vs/editor/contrib/dropIntoEditor/browser/dropIntoEditorContribution.ts
@@ -33,6 +33,10 @@ export class DropIntoEditorController extends Disposable implements IEditorContr
 
 	public static readonly ID = 'editor.contrib.dropIntoEditorController';
 
+	public static get(editor: ICodeEditor): DropIntoEditorController | null {
+		return editor.getContribution<DropIntoEditorController>(DropIntoEditorController.ID);
+	}
+
 	private operationIdPool = 0;
 	private _currentOperation?: { readonly id: number; readonly promise: CancelablePromise<void> };
 
@@ -54,6 +58,10 @@ export class DropIntoEditorController extends Disposable implements IEditorContr
 		this._register(editor.onDropIntoEditor(e => this.onDropIntoEditor(editor, e.position, e.event)));
 
 		registerDefaultDropProviders(this._languageFeaturesService, workspaceContextService);
+	}
+
+	public clearWidgets() {
+		this._postDropWidgetManager.clear();
 	}
 
 	private async onDropIntoEditor(editor: ICodeEditor, position: IPosition, dragEvent: DragEvent) {

--- a/src/vs/editor/contrib/dropIntoEditor/browser/postDropWidget.ts
+++ b/src/vs/editor/contrib/dropIntoEditor/browser/postDropWidget.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as dom from 'vs/base/browser/dom';
+import { Event } from 'vs/base/common/event';
 import { Button } from 'vs/base/browser/ui/button/button';
 import { toAction } from 'vs/base/common/actions';
 import { Disposable, MutableDisposable, toDisposable } from 'vs/base/common/lifecycle';
@@ -25,7 +26,7 @@ interface DropEditSet {
 class PostDropWidget extends Disposable implements IContentWidget {
 	private static readonly ID = 'editor.widget.postDropWidget';
 
-	readonly allowEditorOverflow = false;
+	readonly allowEditorOverflow = true;
 	readonly suppressMouseDown = true;
 
 	private domNode!: HTMLElement;
@@ -107,7 +108,10 @@ export class PostDropWidgetManager extends Disposable {
 	) {
 		super();
 
-		this._register(_editor.onDidChangeModelContent(() => this.clear()));
+		this._register(Event.any(
+			_editor.onDidChangeModel,
+			_editor.onDidChangeModelContent,
+		)(() => this.clear()));
 	}
 
 	public show(range: Range, edits: DropEditSet, onDidSelectEdit: (newIndex: number) => void) {
@@ -119,6 +123,6 @@ export class PostDropWidgetManager extends Disposable {
 	}
 
 	public clear() {
-		this._currentWidget?.clear();
+		this._currentWidget.clear();
 	}
 }

--- a/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
@@ -90,6 +90,7 @@ import { IDimension } from 'vs/editor/common/core/dimension';
 import { CellFindMatchModel } from 'vs/workbench/contrib/notebook/browser/contrib/find/findModel';
 import { INotebookLoggingService } from 'vs/workbench/contrib/notebook/common/notebookLoggingService';
 import { Schemas } from 'vs/base/common/network';
+import { DropIntoEditorController } from 'vs/editor/contrib/dropIntoEditor/browser/dropIntoEditorContribution';
 
 const $ = DOM.$;
 
@@ -966,11 +967,7 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditorD
 			this._onDidScroll.fire();
 
 			if (e.scrollTop !== e.oldScrollTop) {
-				this._renderedEditors.forEach((editor, cell) => {
-					if (this.getActiveCell() === cell && editor) {
-						SuggestController.get(editor)?.cancelSuggestWidget();
-					}
-				});
+				this.clearActiveCellWidgets();
 			}
 		}));
 
@@ -1892,6 +1889,16 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditorD
 		this._overlayContainer.style.visibility = 'hidden';
 		this._overlayContainer.style.left = '-50000px';
 		this._notebookTopToolbarContainer.style.display = 'none';
+		this.clearActiveCellWidgets();
+	}
+
+	private clearActiveCellWidgets() {
+		this._renderedEditors.forEach((editor, cell) => {
+			if (this.getActiveCell() === cell && editor) {
+				SuggestController.get(editor)?.cancelSuggestWidget();
+				DropIntoEditorController.get(editor)?.clearWidgets();
+			}
+		});
 	}
 
 	private editorHasDomFocus(): boolean {


### PR DESCRIPTION
- Correctly hide the widget when the notebook editor is not the active tab
- Hide the widget when the notebook editor scrolls (to prevent widget showing in wrong spot)
- Fix widget being clipped by notebook cell
- Hide the widget on change model too

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
