### PR TITLE
Allow dropping images into notebook cells to create attachments

### DIFF
--- a/extensions/ipynb/notebook-src/cellAttachmentRenderer.ts
+++ b/extensions/ipynb/notebook-src/cellAttachmentRenderer.ts
@@ -24,7 +24,7 @@ export async function activate(ctx: RendererContext<void>) {
 			const src = token.attrGet('src');
 			const attachments: Record<string, Record<string, string>> | undefined = env.outputItem.metadata?.attachments;
 			if (attachments && src) {
-				const imageAttachment = attachments[src.replace('attachment:', '')];
+				const imageAttachment = attachments[tryDecodeURIComponent(src.replace('attachment:', ''))];
 				if (imageAttachment) {
 					// objEntries will always be length 1, with objEntries[0] holding [0]=mime,[1]=b64
 					// if length = 0, something is wrong with the attachment, mime/b64 weren't copied over
@@ -44,4 +44,12 @@ export async function activate(ctx: RendererContext<void>) {
 			}
 		};
 	});
+}
+
+function tryDecodeURIComponent(uri: string) {
+	try {
+		return decodeURIComponent(uri);
+	} catch {
+		return uri;
+	}
 }

--- a/extensions/ipynb/package.json
+++ b/extensions/ipynb/package.json
@@ -10,7 +10,8 @@
 	},
 	"enabledApiProposals": [
 		"documentPaste",
-		"diffContentOptions"
+		"diffContentOptions",
+    "dropMetadata"
 	],
 	"activationEvents": [
 		"onNotebook:jupyter-notebook"

--- a/extensions/ipynb/package.json
+++ b/extensions/ipynb/package.json
@@ -11,7 +11,7 @@
 	"enabledApiProposals": [
 		"documentPaste",
 		"diffContentOptions",
-    "dropMetadata"
+		"dropMetadata"
 	],
 	"activationEvents": [
 		"onNotebook:jupyter-notebook"

--- a/extensions/ipynb/src/notebookAttachmentCleaner.ts
+++ b/extensions/ipynb/src/notebookAttachmentCleaner.ts
@@ -365,7 +365,7 @@ export class AttachmentCleaner implements vscode.CodeActionProvider {
 	private getAttachmentNames(document: vscode.TextDocument) {
 		const source = document.getText();
 		const filenames: Map<string, { valid: boolean; ranges: vscode.Range[] }> = new Map();
-		const re = /!\[.*?\]\(attachment:(?<filename>.*?)\)/gm;
+		const re = /!\[.*?\]\(<?attachment:(?<filename>.*?)>?\)/gm;
 
 		let match;
 		while ((match = re.exec(source))) {

--- a/extensions/ipynb/src/notebookImagePaste.ts
+++ b/extensions/ipynb/src/notebookImagePaste.ts
@@ -5,6 +5,34 @@
 
 import * as vscode from 'vscode';
 import { JUPYTER_NOTEBOOK_MARKDOWN_SELECTOR } from './constants';
+import { basename, extname } from 'path';
+
+enum MimeType {
+	bmp = 'image/bmp',
+	gif = 'image/gif',
+	ico = 'image/ico',
+	jpeg = 'image/jpeg',
+	png = 'image/png',
+	tiff = 'image/tiff',
+	webp = 'image/webp',
+}
+
+const imageExtToMime: ReadonlyMap<string, string> = new Map<string, string>([
+	['.bmp', MimeType.bmp],
+	['.gif', MimeType.gif],
+	['.ico', MimeType.ico],
+	['.jpe', MimeType.jpeg],
+	['.jpeg', MimeType.jpeg],
+	['.jpg', MimeType.jpeg],
+	['.png', MimeType.png],
+	['.tif', MimeType.tiff],
+	['.tiff', MimeType.tiff],
+	['.webp', MimeType.webp],
+]);
+
+function getImageMimeType(uri: vscode.Uri): string | undefined {
+	return imageExtToMime.get(extname(uri.fsPath).toLowerCase());
+}
 
 class CopyPasteEditProvider implements vscode.DocumentPasteEditProvider {
 
@@ -12,74 +40,150 @@ class CopyPasteEditProvider implements vscode.DocumentPasteEditProvider {
 		document: vscode.TextDocument,
 		_ranges: readonly vscode.Range[],
 		dataTransfer: vscode.DataTransfer,
-		_token: vscode.CancellationToken
+		token: vscode.CancellationToken,
 	): Promise<vscode.DocumentPasteEdit | undefined> {
-
 		const enabled = vscode.workspace.getConfiguration('ipynb', document).get('pasteImagesAsAttachments.enabled', false);
 		if (!enabled) {
-			return undefined;
+			return;
 		}
 
-		// get b64 data from paste
-		// TODO: dataTransfer.get() limits to one image pasted
-		const dataItem = dataTransfer.get('image/png');
-		if (!dataItem) {
-			return undefined;
-		}
-		const fileDataAsUint8 = await dataItem.asFile()?.data();
-		if (!fileDataAsUint8) {
-			return undefined;
+		const insert = await createInsertImageAttachmentEdit(document, dataTransfer, token);
+		if (!insert) {
+			return;
 		}
 
-		// get filename data from paste
-		const clipboardFilename = dataItem.asFile()?.name;
-		if (!clipboardFilename) {
-			return undefined;
+		const pasteEdit = new vscode.DocumentPasteEdit(insert.insertText);
+		pasteEdit.additionalEdit = insert.additionalEdit;
+		return pasteEdit;
+	}
+}
+
+class DropEditProvider implements vscode.DocumentDropEditProvider {
+
+	async provideDocumentDropEdits(
+		document: vscode.TextDocument,
+		_position: vscode.Position,
+		dataTransfer: vscode.DataTransfer,
+		token: vscode.CancellationToken,
+	): Promise<vscode.DocumentDropEdit | undefined> {
+		const insert = await createInsertImageAttachmentEdit(document, dataTransfer, token);
+		if (!insert) {
+			return;
 		}
-		const separatorIndex = clipboardFilename?.lastIndexOf('.');
-		const filename = clipboardFilename?.slice(0, separatorIndex);
-		const filetype = clipboardFilename?.slice(separatorIndex);
-		if (!filename || !filetype) {
-			return undefined;
-		}
 
-		const currentCell = this.getCellFromCellDocument(document);
-		if (!currentCell) {
-			return undefined;
-		}
-		const notebookUri = currentCell.notebook.uri;
+		const dropEdit = new vscode.DocumentDropEdit(insert.insertText);
+		dropEdit.additionalEdit = insert.additionalEdit;
+		dropEdit.label = vscode.l10n.t('Insert image as attachment');
+		return dropEdit;
+	}
+}
 
-		// create updated metadata for cell (prep for WorkspaceEdit)
-		const b64string = encodeBase64(fileDataAsUint8);
-		const startingAttachments = currentCell.metadata.attachments;
-		const newAttachment = buildAttachment(b64string, currentCell, filename, filetype, startingAttachments);
-
-		// build edits
-		const nbEdit = vscode.NotebookEdit.updateCellMetadata(currentCell.index, newAttachment.metadata);
-		const workspaceEdit = new vscode.WorkspaceEdit();
-		workspaceEdit.set(notebookUri, [nbEdit]);
-
-		// create a snippet for paste
-		const pasteSnippet = new vscode.SnippetString();
-		pasteSnippet.appendText('![');
-		pasteSnippet.appendPlaceholder(`${clipboardFilename}`);
-		pasteSnippet.appendText(`](attachment:${newAttachment.filename})`);
-
-		return { insertText: pasteSnippet, additionalEdit: workspaceEdit };
+async function createInsertImageAttachmentEdit(
+	document: vscode.TextDocument,
+	dataTransfer: vscode.DataTransfer,
+	token: vscode.CancellationToken,
+): Promise<{ insertText: vscode.SnippetString; additionalEdit: vscode.WorkspaceEdit } | undefined> {
+	const imageData = await getDroppedImageData(dataTransfer, token);
+	if (!imageData.length || token.isCancellationRequested) {
+		return;
 	}
 
-	private getCellFromCellDocument(cellDocument: vscode.TextDocument): vscode.NotebookCell | undefined {
-		for (const notebook of vscode.workspace.notebookDocuments) {
-			if (notebook.uri.path === cellDocument.uri.path) {
-				for (const cell of notebook.getCells()) {
-					if (cell.document === cellDocument) {
-						return cell;
-					}
+	const currentCell = getCellFromCellDocument(document);
+	if (!currentCell) {
+		return undefined;
+	}
+
+	// create updated metadata for cell (prep for WorkspaceEdit)
+	const newAttachment = buildAttachment(currentCell, imageData);
+	if (!newAttachment) {
+		return;
+	}
+
+	// build edits
+	const additionalEdit = new vscode.WorkspaceEdit();
+	const nbEdit = vscode.NotebookEdit.updateCellMetadata(currentCell.index, newAttachment.metadata);
+	const notebookUri = currentCell.notebook.uri;
+	additionalEdit.set(notebookUri, [nbEdit]);
+
+	// create a snippet for paste
+	const insertText = new vscode.SnippetString();
+	newAttachment.filenames.forEach((filename, i) => {
+		insertText.appendText('![');
+		insertText.appendPlaceholder(`${filename}`);
+		insertText.appendText(`](${/\s/.test(filename) ? `<attachment:${filename}>` : `attachment:${filename}`})`);
+		if (i !== newAttachment.filenames.length - 1) {
+			insertText.appendText(' ');
+		}
+	});
+
+	return { insertText, additionalEdit };
+}
+
+async function getDroppedImageData(
+	dataTransfer: vscode.DataTransfer,
+	token: vscode.CancellationToken,
+): Promise<readonly ImageAttachmentData[]> {
+
+	// Prefer using image data in the clipboard
+	// TODO: dataTransfer.get() limits to one image pasted. Should we support multiple?
+	const pngDataItem = dataTransfer.get(MimeType.png);
+	if (pngDataItem) {
+		const fileItem = pngDataItem.asFile();
+		if (!fileItem) {
+			return [];
+		}
+
+		const data = await fileItem.data();
+		return [{ fileName: fileItem.name, mimeType: MimeType.png, data }];
+	}
+
+	// Then fallback to image files in the uri-list
+	const urlList = await dataTransfer.get('text/uri-list')?.asString();
+	if (token.isCancellationRequested) {
+		return [];
+	}
+
+	if (urlList) {
+		const uris: vscode.Uri[] = [];
+		for (const resource of urlList.split(/\r?\n/g)) {
+			try {
+				uris.push(vscode.Uri.parse(resource));
+			} catch {
+				// noop
+			}
+		}
+
+		const entries = await Promise.all(uris.map(async (uri) => {
+			const mimeType = getImageMimeType(uri);
+			if (!mimeType) {
+				return;
+			}
+
+			const data = await vscode.workspace.fs.readFile(uri);
+			return { fileName: basename(uri.fsPath), mimeType, data };
+		}));
+
+		return coalesce(entries);
+	}
+
+	return [];
+}
+
+function coalesce<T>(array: ReadonlyArray<T | undefined | null>): T[] {
+	return <T[]>array.filter(e => !!e);
+}
+
+function getCellFromCellDocument(cellDocument: vscode.TextDocument): vscode.NotebookCell | undefined {
+	for (const notebook of vscode.workspace.notebookDocuments) {
+		if (notebook.uri.path === cellDocument.uri.path) {
+			for (const cell of notebook.getCells()) {
+				if (cell.document === cellDocument) {
+					return cell;
 				}
 			}
 		}
-		return undefined;
 	}
+	return undefined;
 }
 
 /**
@@ -123,35 +227,69 @@ function encodeBase64(buffer: Uint8Array, padded = true, urlSafe = false) {
 	return output;
 }
 
-function buildAttachment(b64: string, cell: vscode.NotebookCell, filename: string, filetype: string, startingAttachments: any): { metadata: { [key: string]: any }; filename: string } {
+
+interface ImageAttachmentData {
+	readonly fileName: string;
+	readonly data: Uint8Array;
+	readonly mimeType: string;
+}
+
+function buildAttachment(
+	cell: vscode.NotebookCell,
+	attachments: readonly ImageAttachmentData[],
+): { metadata: { [key: string]: any }; filenames: string[] } | undefined {
 	const cellMetadata = { ...cell.metadata };
-	let tempFilename = filename + filetype;
+	const tempFilenames: string[] = [];
+	if (!attachments.length) {
+		return undefined;
+	}
 
 	if (!cellMetadata.attachments) {
-		cellMetadata['attachments'] = { [tempFilename]: { 'image/png': b64 } };
-	} else {
-		for (let appendValue = 2; tempFilename in startingAttachments; appendValue++) {
-			const objEntries = Object.entries(startingAttachments[tempFilename]);
+		cellMetadata.attachments = {};
+	}
+
+	for (const attachment of attachments) {
+		const b64 = encodeBase64(attachment.data);
+
+		const fileExt = extname(attachment.fileName);
+		const filenameWithoutExt = basename(attachment.fileName, fileExt);
+
+		let tempFilename = filenameWithoutExt + fileExt;
+		for (let appendValue = 2; tempFilename in cellMetadata.attachments; appendValue++) {
+			const objEntries = Object.entries(cellMetadata.attachments[tempFilename]);
 			if (objEntries.length) { // check that mime:b64 are present
-				const [, attachmentb64] = objEntries[0];
-				if (attachmentb64 === b64) { // checking if filename can be reused, based on camparison of image data
+				const [mime, attachmentb64] = objEntries[0];
+				if (mime === attachment.mimeType && attachmentb64 === b64) { // checking if filename can be reused, based on comparison of image data
 					break;
 				} else {
-					tempFilename = filename.concat(`-${appendValue}`) + filetype;
+					tempFilename = filenameWithoutExt.concat(`-${appendValue}`) + fileExt;
 				}
 			}
 		}
-		cellMetadata.attachments[tempFilename] = { 'image/png': b64 };
+
+		tempFilenames.push(tempFilename);
+		cellMetadata.attachments[tempFilename] = { [attachment.mimeType]: b64 };
 	}
 
 	return {
 		metadata: cellMetadata,
-		filename: tempFilename
+		filenames: tempFilenames,
 	};
 }
 
-export function notebookImagePasteSetup() {
-	return vscode.languages.registerDocumentPasteEditProvider(JUPYTER_NOTEBOOK_MARKDOWN_SELECTOR, new CopyPasteEditProvider(), {
-		pasteMimeTypes: ['image/png'],
-	});
+export function notebookImagePasteSetup(): vscode.Disposable {
+	return vscode.Disposable.from(
+		vscode.languages.registerDocumentPasteEditProvider(JUPYTER_NOTEBOOK_MARKDOWN_SELECTOR, new CopyPasteEditProvider(), {
+			pasteMimeTypes: [
+				MimeType.png,
+			],
+		}),
+		vscode.languages.registerDocumentDropEditProvider(JUPYTER_NOTEBOOK_MARKDOWN_SELECTOR, new DropEditProvider(), {
+			id: '',
+			dropMimeTypes: [
+				...Object.values(imageExtToMime),
+				'text/uri-list',
+			],
+		})
+	);
 }

--- a/extensions/ipynb/src/notebookImagePaste.ts
+++ b/extensions/ipynb/src/notebookImagePaste.ts
@@ -283,14 +283,14 @@ export function notebookImagePasteSetup(): vscode.Disposable {
 		vscode.languages.registerDocumentPasteEditProvider(JUPYTER_NOTEBOOK_MARKDOWN_SELECTOR, new CopyPasteEditProvider(), {
 			pasteMimeTypes: [
 				MimeType.png,
-				MimeType.uriList
+				MimeType.uriList,
 			],
 		}),
 		vscode.languages.registerDocumentDropEditProvider(JUPYTER_NOTEBOOK_MARKDOWN_SELECTOR, new DropEditProvider(), {
-			id: '',
+			id: 'imageAttachment',
 			dropMimeTypes: [
 				...Object.values(imageExtToMime),
-				MimeType.uriList
+				MimeType.uriList,
 			],
 		})
 	);

--- a/extensions/ipynb/src/notebookImagePaste.ts
+++ b/extensions/ipynb/src/notebookImagePaste.ts
@@ -15,6 +15,7 @@ enum MimeType {
 	png = 'image/png',
 	tiff = 'image/tiff',
 	webp = 'image/webp',
+	uriList = 'text/uri-list',
 }
 
 const imageExtToMime: ReadonlyMap<string, string> = new Map<string, string>([
@@ -282,13 +283,14 @@ export function notebookImagePasteSetup(): vscode.Disposable {
 		vscode.languages.registerDocumentPasteEditProvider(JUPYTER_NOTEBOOK_MARKDOWN_SELECTOR, new CopyPasteEditProvider(), {
 			pasteMimeTypes: [
 				MimeType.png,
+				MimeType.uriList
 			],
 		}),
 		vscode.languages.registerDocumentDropEditProvider(JUPYTER_NOTEBOOK_MARKDOWN_SELECTOR, new DropEditProvider(), {
 			id: '',
 			dropMimeTypes: [
 				...Object.values(imageExtToMime),
-				'text/uri-list',
+				MimeType.uriList
 			],
 		})
 	);

--- a/extensions/ipynb/tsconfig.json
+++ b/extensions/ipynb/tsconfig.json
@@ -7,6 +7,8 @@
 	"include": [
 		"src/**/*",
 		"../../src/vscode-dts/vscode.d.ts",
-		"../../src/vscode-dts/vscode.proposed.documentPaste.d.ts"
+		"../../src/vscode-dts/vscode.proposed.documentPaste.d.ts",
+		"../../src/vscode-dts/vscode.proposed.dropMetadata.d.ts"
+
 	]
 }


### PR DESCRIPTION
Fixes #157577

This PR enables drag and drop of image files or image data into a notebook cell to create an attachment

As part of this change, I updated the copy/paste attachment logic so it can:

- Create attachments from image files in uri-lists instead of being restricted to image data
- Create multiple attachments in a single operation
- Create attachments of other mime types besides `image/png`
- Create attachments for images that have spaces in the filename (in these cases, we insert `![...](<attachment:...>)` into the markdown)
