### PR TITLE
Avoid infinite undo loop in notebook.

### DIFF
--- a/src/vs/workbench/contrib/interactiveEditor/browser/interactiveEditorController.ts
+++ b/src/vs/workbench/contrib/interactiveEditor/browser/interactiveEditorController.ts
@@ -832,7 +832,7 @@ class LiveStrategy extends EditModeStrategy {
 	}
 
 	cancel(): void {
-		while (this._model.getAlternativeVersionId() !== this._versionId) {
+		while (this._model.getAlternativeVersionId() !== this._versionId && this._model.canUndo()) {
 			this._model.undo();
 		}
 	}


### PR DESCRIPTION
In notebook, when a cell is scrolled out of view, its text model is diposed, which will

* undo/redo stack for the cell text model set to invalid
* and then it will trigger live strategy to cancel but since `undo` is a no op (as the undo stack is invalid), the while loop never quits, which freezes the UI

The fix is ensuring that the model `canUndo` before we perform `undo`. 
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
