### PR TITLE
Align drop and paste providers handling of mimetypes

### DIFF
--- a/src/vs/base/common/dataTransfer.ts
+++ b/src/vs/base/common/dataTransfer.ts
@@ -50,7 +50,7 @@ export class VSDataTransfer {
 	/**
 	 * Check if this data transfer contains data for a given mime type.
 	 *
-	 * This uses exact matching and does support wildcards.
+	 * This uses exact matching and does not support wildcards.
 	 */
 	public has(mimeType: string): boolean {
 		return this._entries.has(this.toKey(mimeType));
@@ -60,11 +60,18 @@ export class VSDataTransfer {
 	 * Check if this data transfer contains data matching a given mime type glob.
 	 *
 	 * This allows matching for wildcards, such as `image/*`.
+	 *
+	 * Use the special `files` mime type to match any file in the data transfer.
 	 */
 	public matches(mimeTypeGlob: string): boolean {
 		// Exact match
 		if (this.has(mimeTypeGlob)) {
 			return true;
+		}
+
+		// Special `files` mime type matches any file
+		if (mimeTypeGlob.toLowerCase() === 'files') {
+			return Iterable.some(this.values(), item => item.asFile());
 		}
 
 		// Anything glob

--- a/src/vs/editor/contrib/copyPaste/browser/copyPasteController.ts
+++ b/src/vs/editor/contrib/copyPaste/browser/copyPasteController.ts
@@ -3,7 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { DataTransfers } from 'vs/base/browser/dnd';
 import { addDisposableListener } from 'vs/base/browser/dom';
 import { CancelablePromise, createCancelablePromise, raceCancellation } from 'vs/base/common/async';
 import { CancellationToken } from 'vs/base/common/cancellation';
@@ -294,10 +293,5 @@ export class CopyPasteController extends Disposable implements IEditorContributi
 }
 
 function isSupportedProvider(provider: DocumentPasteEditProvider, dataTransfer: VSDataTransfer): boolean {
-	return provider.pasteMimeTypes.some(type => {
-		if (type.toLowerCase() === DataTransfers.FILES.toLowerCase()) {
-			return [...dataTransfer.values()].some(item => item.asFile());
-		}
-		return dataTransfer.has(type);
-	});
+	return provider.pasteMimeTypes.some(type => dataTransfer.matches(type));
 }

--- a/src/vscode-dts/vscode.proposed.documentPaste.d.ts
+++ b/src/vscode-dts/vscode.proposed.documentPaste.d.ts
@@ -62,9 +62,11 @@ declare module 'vscode' {
 
 	interface DocumentPasteProviderMetadata {
 		/**
-		 * Mime types that `provideDocumentPasteEdits` should be invoked for.
+		 * Mime types that {@link DocumentPasteEditProvider.provideDocumentPasteEdits provideDocumentPasteEdits} should be invoked for.
 		 *
-		 * Use the special `files` mimetype to indicate the provider should be invoked if any files are present in the `DataTransfer`.
+		 * This can either be an exact mime type such as `image/png`, or a wildcard pattern such as `image/*`.
+		 *
+		 * Use `files` to indicate that the provider should be invoked if any {@link DataTransferFile files} are present in the {@link DataTransfer}..
 		 */
 		readonly pasteMimeTypes: readonly string[];
 	}

--- a/src/vscode-dts/vscode.proposed.dropMetadata.d.ts
+++ b/src/vscode-dts/vscode.proposed.dropMetadata.d.ts
@@ -26,6 +26,8 @@ declare module 'vscode' {
 		 * List of data transfer types that the provider supports.
 		 *
 		 * This can either be an exact mime type such as `image/png`, or a wildcard pattern such as `image/*`.
+		 *
+		 * Use `files` to indicate that the provider should be invoked if any {@link DataTransferFile files} are present in the {@link DataTransfer}.
 		 */
 		readonly dropMimeTypes: readonly string[];
 	}


### PR DESCRIPTION
Makes sure that both drop and paste providers support wildcard matching and can also use the special `files` type to indicate that they should be invoked if there are any files in the data transfer 

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
