### PR TITLE
Fix disappearing search results and improve handling of notebook output matches

### DIFF
--- a/src/vs/workbench/common/editor/editorInput.ts
+++ b/src/vs/workbench/common/editor/editorInput.ts
@@ -75,6 +75,7 @@ export abstract class EditorInput extends AbstractEditorInput {
 	 * custom confirmation on close behavior.
 	 */
 	readonly closeHandler?: IEditorCloseHandler;
+	shortTitle: string | undefined;
 
 	/**
 	 * Unique type identifier for this input. Every editor input of the

--- a/src/vs/workbench/contrib/search/browser/searchModel.ts
+++ b/src/vs/workbench/contrib/search/browser/searchModel.ts
@@ -584,7 +584,8 @@ export class FileMatch extends Disposable implements IFileMatch {
 
 	matches(): Match[] {
 		const cellMatches: MatchInNotebook[] = Array.from(this._cellMatches.values()).flatMap((e) => e.matches());
-		return [...this._textMatches.values(), ...cellMatches];
+		const cellOutputMatches: MatchInNotebook[] = this.getCellOutputMatches(); // TODO: implement
+		return [...this._textMatches.values(), ...cellMatches, ...cellOutputMatches];
 	}
 
 	textMatches(): Match[] {
@@ -709,6 +710,11 @@ export class FileMatch extends Disposable implements IFileMatch {
 	}
 
 	// #region strictly notebook methods
+	getCellOutputMatches(): MatchInNotebook[] {
+
+		return [];
+	}
+
 	bindNotebookEditorWidget(widget: NotebookEditorWidget) {
 		if (this._notebookEditorWidget === widget) {
 			return;
@@ -1176,7 +1182,7 @@ export class FolderMatch extends Disposable {
 			this.doAddFile(fileMatch);
 			added = true;
 		}
-		if (fileMatch.count() === 0) {
+		if (fileMatch.count() === 0 && this.matches().length === 0) {
 			this.doRemoveFile([fileMatch], false, false);
 			added = false;
 			removed = true;

--- a/src/vs/workbench/contrib/search/browser/searchView.ts
+++ b/src/vs/workbench/contrib/search/browser/searchView.ts
@@ -566,6 +566,9 @@ export class SearchView extends ViewPane {
 
 	private onSearchResultsChanged(event?: IChangeEvent): void {
 		if (this.isVisible()) {
+			if (this.editorService.activeEditor && this.editorService.activeEditor.shortTitle === event?.elements[0].name()) {
+				return;
+			}
 			return this.refreshAndUpdateCount(event);
 		} else {
 			this.changedWhileHidden = true;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

**Problem:** Search results disappearing when clicking on a search result.

**Solution:** Added a check in searchView.ts to not refresh the search results if the opened editor is the same file as the parent of the selected search result. This fixes the issue of the search results disappearing.

**Testing:**
1. Set `search.experimental.notebookSearch:` true in settings
2. Set notebook search filter to look at outputs
3. Close all editors 
4. Search for something that only appears in outputs
5. Click on the result
6. Confirm result does not disappear

**Remaining Issue:** The selected search result does not get highlighted in the editor.
See the following snippet from searchView.ts for context:
```ts
if (experimentalNotebooksEnabled) {
	if (element instanceof Match) {
		if (element instanceof MatchInNotebook) {
			// TODO: This branch is never reached because cell output Match is not a MatchInNotebook.
			element.parent().showMatch(element);
		} else {
		        const editorWidget = editor.getControl();
		        if (editorWidget) {
			        // Ensure that the editor widget is binded. If if is, then this should return immediately.
			        // Otherwise, it will bind the widget.
			        await elemParent.bindNotebookEditorWidget(editorWidget);
			        await elemParent.updateMatchesForEditorWidget();
        
			        const matchIndex = oldParentMatches.findIndex(e => e.id() === element.id());
			        const matches = element.parent().matches();
			        const match = matchIndex >= matches.length ? matches[matches.length - 1] : matches[matchIndex];

				// TODO: This branch is never reached because cell output Match is not a MatchInNotebook.
			        if (match instanceof MatchInNotebook) {
				        elemParent.showMatch(match);
			        }
        
			        if (!this.tree.getFocus().includes(match) || !this.tree.getSelection().includes(match)) {
				        this.tree.setSelection([match], getSelectionKeyboardEvent());
			        }
			}

		}
	}
}
```

**Potential Solutions for Highlighting Issue:**
1. Change matches from cellOutput to be of type `MatchInNotebook`:
- This would allow `element.parent().showMatch(element);` to be reached and highlight the selection in the editor.
- Currently, matches are not returned as a match from `element.parent().matches();` if they are from a cell output area because they are not of type `MatchInNotebook` or one of `_textMatches`.
2. Implement a getCellOutputMatches() function:
- This function would return cell output matches as a list of `MatchInNotebook` elements.
- It would allow const `match = matchIndex >= matches.length ? matches[matches.length - 1] : matches[matchIndex];` to find the match and highlight it in the following `if` block.


**Request for collaboration:** The highlighting issue could be fixed by implementing one or both of these changes. However, further collaboration and input from developers with more experience in the codebase would be helpful to determine the most effective solution.

**Additional Observations:**
There might be a bigger underlying problem since onSearchResultsChanged() shouldn't have been called by the selection of a search result in the first place. The exact cause of this issue is not clear and may require further investigation.