### PR TITLE
Support copying non-pngs and wait for focus to avoid race conditions

### DIFF
--- a/extensions/media-preview/media/imagePreview.js
+++ b/extensions/media-preview/media/imagePreview.js
@@ -370,7 +370,8 @@
 			canvas.getContext('2d').drawImage(image, 0, 0);
 			canvas.toBlob(async (blob) => {
 				try {
-					await navigator.clipboard.write([new ClipboardItem({'image/png': blob})]);
+					await navigator.clipboard.write([new ClipboardItem({ 'image/png': blob })]);
+					canvas.remove();
 				} catch (e) {
 					console.error(e);
 				}

--- a/extensions/media-preview/media/imagePreview.js
+++ b/extensions/media-preview/media/imagePreview.js
@@ -354,28 +354,28 @@
 		copyImage();
 	});
 
-	async function copyImage() {
-		try {
-			if (!document.hasFocus()) {
-				// copyImage is called at the same time as webview.reveal, which means this function is running whilst the webview is gaining focus.
-				// Since navigator.clipboard.write requires the document to be focused, we need to wait for focus.
-				// We cannot use a listener, as there is a high chance the focus is gained during the setup of the listener resulting in us missing it.
-				setTimeout(copyImage, 10);
-				return;
-			}
+	async function copyImage(retries = 3) {
+		if (!document.hasFocus() && retries > 0) {
+			// copyImage is called at the same time as webview.reveal, which means this function is running whilst the webview is gaining focus.
+			// Since navigator.clipboard.write requires the document to be focused, we need to wait for focus.
+			// We cannot use a listener, as there is a high chance the focus is gained during the setup of the listener resulting in us missing it.
+			setTimeout(() => { copyImage(retries - 1); }, 10);
+			return;
+		}
 
-			const canvas = document.createElement('canvas');
-			canvas.width = image.naturalWidth;
-			canvas.height = image.naturalHeight;
-			canvas.getContext('2d').drawImage(image, 0, 0);
-			canvas.toBlob(async (blob) => {
-				try {
-					await navigator.clipboard.write([new ClipboardItem({ 'image/png': blob })]);
-					canvas.remove();
-				} catch (e) {
-					console.error(e);
-				}
-			}, 'image/png');
+		try {
+			await navigator.clipboard.write([new ClipboardItem({
+				'image/png': new Promise((resolve, reject) => {
+					const canvas = document.createElement('canvas');
+					canvas.width = image.naturalWidth;
+					canvas.height = image.naturalHeight;
+					canvas.getContext('2d').drawImage(image, 0, 0);
+					canvas.toBlob((blob) => {
+						resolve(blob);
+						canvas.remove();
+					}, 'image/png');
+				})
+			})]);
 		} catch (e) {
 			console.error(e);
 		}

--- a/extensions/media-preview/media/imagePreview.js
+++ b/extensions/media-preview/media/imagePreview.js
@@ -354,12 +354,12 @@
 		copyImage();
 	});
 
-	async function copyImage(retries = 3) {
+	async function copyImage(retries = 5) {
 		if (!document.hasFocus() && retries > 0) {
 			// copyImage is called at the same time as webview.reveal, which means this function is running whilst the webview is gaining focus.
 			// Since navigator.clipboard.write requires the document to be focused, we need to wait for focus.
 			// We cannot use a listener, as there is a high chance the focus is gained during the setup of the listener resulting in us missing it.
-			setTimeout(() => { copyImage(retries - 1); }, 10);
+			setTimeout(() => { copyImage(retries - 1); }, 20);
 			return;
 		}
 


### PR DESCRIPTION
This is a follow up to #180269 which fixes #171616

I patched the first PR to test it out and notices a couple of problems.

Firstly, when right clicking, it would often fail with the error message:

```
DOMException: Document is not focused.
```

This was because it was called by doing:

```
this.webviewEditor.reveal();
this.webviewEditor.webview.postMessage({ type: 'copyImage' });
```

Since `.reveal()` runs async, there was a race condition where the object was receiving focus and trying to copy at the same time, and for me, the copying was often winning.

I tried to fix this by adding an event listener on document to wait for it to gain focus, but this would also usually fail as it would usually gain focus whilst the listener was being setup, causing it to miss the focus gain event. Instead, I have a slightly less optimal solution which just waits 10ms and then checks again for focus. In testing this was never called more than once so I think that it is acceptable. Another solution would be to have a message sent back from the webview when it has focus, and wait for that in the copy command on the extension side, but I think this would be a lot more expensive.

---

The other issue I came across was that the copy only works for png images, other types it complains about the mime type not matching. I tried setting the mimetype based on the content type returned in the fetch, but it turns out the clipboard only supports png.

What I have done here is created a temporary canvas, which we can write the image into, avoiding the fetch() entirely. This allows us to get a png from any image type - when testing with gifs, this only keeps a single frame of the gif, so there is room for improvement there.

I think there is room for improvement here, but this resolves some of the issues I was seeing when copying images.