### PR TITLE
remote: make managed web resolvers work

### DIFF
--- a/src/vs/workbench/browser/web.main.ts
+++ b/src/vs/workbench/browser/web.main.ts
@@ -255,8 +255,7 @@ export class BrowserMain extends Disposable {
 
 		// Remote
 		const connectionToken = environmentService.options.connectionToken || getCookieValue(connectionTokenCookieName);
-		const expectResolverExtension = !!environmentService.remoteAuthority?.includes('+') && !environmentService.options.webSocketFactory;
-		const remoteAuthorityResolverService = new RemoteAuthorityResolverService(!expectResolverExtension, connectionToken, this.configuration.resourceUriProvider, productService, logService);
+		const remoteAuthorityResolverService = new RemoteAuthorityResolverService(!environmentService.expectsResolverExtension, connectionToken, this.configuration.resourceUriProvider, productService, logService);
 		serviceCollection.set(IRemoteAuthorityResolverService, remoteAuthorityResolverService);
 
 		// Signing

--- a/src/vs/workbench/services/environment/browser/environmentService.ts
+++ b/src/vs/workbench/services/environment/browser/environmentService.ts
@@ -32,6 +32,11 @@ export interface IBrowserWorkbenchEnvironmentService extends IWorkbenchEnvironme
 	 * Options used to configure the workbench.
 	 */
 	readonly options?: IWorkbenchConstructionOptions;
+
+	/**
+	 * Gets whether a resolver extension is expected for the environment.
+	 */
+	readonly expectsResolverExtension: boolean;
 }
 
 export class BrowserWorkbenchEnvironmentService implements IBrowserWorkbenchEnvironmentService {
@@ -40,6 +45,11 @@ export class BrowserWorkbenchEnvironmentService implements IBrowserWorkbenchEnvi
 
 	@memoize
 	get remoteAuthority(): string | undefined { return this.options.remoteAuthority; }
+
+	@memoize
+	get expectsResolverExtension(): boolean {
+		return !!this.options.remoteAuthority?.includes('+') && !this.options.webSocketFactory;
+	}
 
 	@memoize
 	get isBuilt(): boolean { return !!this.productService.commit; }

--- a/src/vs/workbench/services/environment/electron-sandbox/environmentService.ts
+++ b/src/vs/workbench/services/environment/electron-sandbox/environmentService.ts
@@ -63,6 +63,9 @@ export class NativeWorkbenchEnvironmentService extends AbstractNativeEnvironment
 	get remoteAuthority() { return this.configuration.remoteAuthority; }
 
 	@memoize
+	get expectsResolverExtension() { return !!this.configuration.remoteAuthority; }
+
+	@memoize
 	get execPath() { return this.configuration.execPath; }
 
 	@memoize


### PR DESCRIPTION
Builds on https://github.com/microsoft/vscode/pull/180263. With these changes, I now got the tunnel resolver working in web. Mostly this was copying logic from the `nativeExtensionService`. We could probably pull up a good bit of that into the AbstractExtensionService if we opt to take this route; I (or perhaps someone with more knowledge 😛 ) can clean it up if so.