### PR TITLE
Partial fix for task reconnection on reload (#180243)

### DIFF
--- a/src/vs/workbench/contrib/tasks/browser/terminalTaskSystem.ts
+++ b/src/vs/workbench/contrib/tasks/browser/terminalTaskSystem.ts
@@ -264,6 +264,7 @@ export class TerminalTaskSystem extends Disposable implements ITaskSystem {
 		this._onDidStateChange = new Emitter();
 		this._taskSystemInfoResolver = taskSystemInfoResolver;
 		this._register(this._terminalStatusManager = instantiationService.createInstance(TaskTerminalStatus));
+		this._reconnectToTerminals();
 	}
 
 	public get onDidStateChange(): Event<ITaskEvent> {


### PR DESCRIPTION
When the window is reloaded, and there are long running, non-background tasks the tasks are left running, but aren't added to the `TerminalTaskSystem`'s `_instances` or `_activeTasks` maps after the reload.

As a result, various commands, such as `workbench.action.tasks.terminate`, `workbench.action.tasks.restartTask`, `workbench.action.tasks.showTasks` all report that there are no running tasks - even though the tasks are in fact running.

In addition, trying to start the tasks starts a new copy - even if the task's `runOptions.instanceLimit` is set to 1 (the default). Note that prior to the reload, trying to start one of the already running tasks would pop up a prompt asking if you want to stop or restart the task.

Finally, if you have a task configured as `runOn: folderOpen` that is still running when the window is reloaded, the original task will still be running after the reload, and a new copy will be started in addition.

This commit partially fixes these issues.

By running `this._reconnectToTerminals()` from `TerminalTaskSystm`'s constructor, it ensures that any future attempt to run one of the already running tasks will simply select its terminal, while also adding the task to `_instances` or `_activeTasks`, so that further attempts to run it will present the prompt as expected.

This completely fixes the issue of allowing multiple copies of a task to run when its configured with an `instanceLimit` of 1. It also completely fixes all the issues for any `runOn: folderOpen` tasks.

It doesn't address the issue where various commands report that there are no running tasks; but that's no worse than before, and it can now be fixed by simply launching the tasks manually (which doesn't actually start new copies)

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
