### PR TITLE
Show breakpoint hint even if there are other line decorations

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/breakpointEditorContribution.ts
+++ b/src/vs/workbench/contrib/debug/browser/breakpointEditorContribution.ts
@@ -468,7 +468,8 @@ export class BreakpointEditorContribution implements IBreakpointEditorContributi
 		if (decorations) {
 			for (const { options } of decorations) {
 				const clz = options.glyphMarginClassName;
-				if (clz && (!clz.includes('codicon-') || clz.includes('codicon-testing-') || clz.includes('codicon-merge-') || clz.includes('codicon-arrow-'))) {
+				const lane = options.glyphMargin?.position;
+				if (clz && lane === GlyphMarginLane.Right && (!clz.includes('codicon-') || clz.includes('codicon-testing-') || clz.includes('codicon-merge-') || clz.includes('codicon-arrow-'))) {
 					return false;
 				}
 			}


### PR DESCRIPTION
For https://github.com/microsoft/vscode/issues/179725

This allows easy setting of breakpoints even if the current line already has a non-breakpoint decoration. 


https://user-images.githubusercontent.com/30305945/233258731-edd2c300-4c05-490e-a84a-56c16024fa4f.mp4



One potential issue with this change is that it will cause the margin to resize if hovering on a line which already has a non-breakpoint decoration, which would cause a lot of visual flickering. We could address this by rendering a sentinel breakpoint to reserve the second lane for debug, which avoids the flickering at the expense of extra margin space even when the decoration has yet to be rendered. Another approach could be to debounce the margin resizing, which would reduce flickering at the expense of potential degraded performance.