### PR TITLE
Fix search result count again

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
@@ -1555,6 +1555,8 @@ export class SettingsEditor2 extends EditorPane {
 
 			if (!this.searchResultModel) {
 				this.searchResultModel = this.instantiationService.createInstance(SearchResultModel, this.viewState, this.workspaceTrustManagementService.isWorkspaceTrusted());
+				// Must be called before this.renderTree()
+				// to make sure the search results count is set.
 				this.searchResultModel.setResult(type, result);
 				this.tocTreeModel.currentSearchModel = this.searchResultModel;
 				this.onSearchModeToggled();
@@ -1596,9 +1598,7 @@ export class SettingsEditor2 extends EditorPane {
 			this.rootElement.classList.remove('no-results');
 			this.splitView.el.style.visibility = 'visible';
 			return;
-		}
-
-		if (this.tocTreeModel && this.tocTreeModel.settingsTreeRoot) {
+		} else {
 			const count = this.searchResultModel.getUniqueResultsCount();
 			let resultString: string;
 			switch (count) {

--- a/src/vs/workbench/contrib/preferences/browser/settingsTreeModels.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsTreeModels.ts
@@ -808,6 +808,7 @@ export class SearchResultModel extends SettingsTreeModel {
 	private rawSearchResults: ISearchResult[] | null = null;
 	private cachedUniqueSearchResults: ISearchResult[] | null = null;
 	private newExtensionSearchResults: ISearchResult | null = null;
+	private searchResultCount: number | null = null;
 
 	readonly id = 'searchResultModel';
 
@@ -853,13 +854,6 @@ export class SearchResultModel extends SettingsTreeModel {
 		return this.rawSearchResults || [];
 	}
 
-	getUniqueResultsCount(): number {
-		const uniqueResults = this.getUniqueResults();
-		const localResultsCount = uniqueResults[0]?.filterMatches.length ?? 0;
-		const remoteResultsCount = uniqueResults[1]?.filterMatches.length ?? 0;
-		return localResultsCount + remoteResultsCount;
-	}
-
 	setResult(order: SearchResultIdx, result: ISearchResult | null): void {
 		this.cachedUniqueSearchResults = null;
 		this.newExtensionSearchResults = null;
@@ -890,6 +884,7 @@ export class SearchResultModel extends SettingsTreeModel {
 
 		this.root.children = this.root.children
 			.filter(child => child instanceof SettingsTreeSettingElement && child.matchesAllTags(this._viewState.tagFilters) && child.matchesScope(this._viewState.settingsTarget, isRemote) && child.matchesAnyExtension(this._viewState.extensionFilters) && child.matchesAnyId(this._viewState.idFilters) && child.matchesAnyFeature(this._viewState.featureFilters) && child.matchesAllLanguages(this._viewState.languageFilter));
+		this.searchResultCount = this.root.children.length;
 
 		if (this.newExtensionSearchResults?.filterMatches.length) {
 			let resultExtensionIds = this.newExtensionSearchResults.filterMatches
@@ -904,6 +899,10 @@ export class SearchResultModel extends SettingsTreeModel {
 				this._root.children.push(newExtElement);
 			}
 		}
+	}
+
+	getUniqueResultsCount(): number {
+		return this.searchResultCount ?? 0;
 	}
 
 	private getFlatSettings(): ISetting[] {


### PR DESCRIPTION
Ref #158531

This PR fixes a bug introduced by #178842 where searching for `@id:editor.tabSize` results in the search result counter saying that over 1000 settings were found.

This PR also loosens an if condition. The if condition was previously there, because the toc tree was responsible for providing the count, but we now get the count from the search results model itself, so we don't check for the status of the toc tree.