### PR TITLE
make sure rename disposes it `EditorStateCancellationTokenSource` so that its down-level context key is correctly updated

### DIFF
--- a/src/vs/base/test/common/cancellation.test.ts
+++ b/src/vs/base/test/common/cancellation.test.ts
@@ -108,6 +108,12 @@ suite('CancellationToken', function () {
 		assert.strictEqual(count, 1);
 	});
 
+	test('dispose does not cancel', function () {
+		const source = new CancellationTokenSource();
+		source.dispose();
+		assert.strictEqual(source.token.isCancellationRequested, false);
+	});
+
 	test('parent cancels child', function () {
 
 		const parent = new CancellationTokenSource();


### PR DESCRIPTION
this is part two of https://github.com/microsoft/vscode-internalbacklog/issues/3928
