### PR TITLE
Add command/keybinding to change drop type

### DIFF
--- a/src/vs/editor/contrib/dropIntoEditor/browser/dropIntoEditorContribution.ts
+++ b/src/vs/editor/contrib/dropIntoEditor/browser/dropIntoEditorContribution.ts
@@ -22,7 +22,7 @@ import { TrackedRangeStickiness } from 'vs/editor/common/model';
 import { ILanguageFeaturesService } from 'vs/editor/common/services/languageFeatures';
 import { DraggedTreeItemsIdentifier } from 'vs/editor/common/services/treeViewsDnd';
 import { ITreeViewsDnDService } from 'vs/editor/common/services/treeViewsDndService';
-import { PostDropWidgetManager, dropWidgetVisibleCtx } from 'vs/editor/contrib/dropIntoEditor/browser/postDropWidget';
+import { PostDropWidgetManager, changeDropTypeCommandId, dropWidgetVisibleCtx } from 'vs/editor/contrib/dropIntoEditor/browser/postDropWidget';
 import { CodeEditorStateFlag, EditorStateCancellationTokenSource } from 'vs/editor/contrib/editorState/browser/editorState';
 import { InlineProgressManager } from 'vs/editor/contrib/inlineProgress/browser/inlineProgress';
 import { SnippetParser } from 'vs/editor/contrib/snippet/browser/snippetParser';
@@ -220,7 +220,7 @@ registerEditorContribution(DropIntoEditorController.ID, DropIntoEditorController
 registerEditorCommand(new class extends EditorCommand {
 	constructor() {
 		super({
-			id: 'editor.changeDropType',
+			id: changeDropTypeCommandId,
 			precondition: dropWidgetVisibleCtx,
 			kbOpts: {
 				weight: KeybindingWeight.EditorContrib,
@@ -229,8 +229,7 @@ registerEditorCommand(new class extends EditorCommand {
 		});
 	}
 
-	public override runEditorCommand(accessor: ServicesAccessor | null, editor: ICodeEditor, args: any): void | Promise<void> {
-		const controller = DropIntoEditorController.get(editor);
-		controller?.changeDropType();
+	public override runEditorCommand(_accessor: ServicesAccessor | null, editor: ICodeEditor, _args: any) {
+		DropIntoEditorController.get(editor)?.changeDropType();
 	}
 });

--- a/src/vs/editor/contrib/dropIntoEditor/browser/dropIntoEditorContribution.ts
+++ b/src/vs/editor/contrib/dropIntoEditor/browser/dropIntoEditorContribution.ts
@@ -7,10 +7,11 @@ import { coalesce } from 'vs/base/common/arrays';
 import { CancelablePromise, createCancelablePromise, raceCancellation } from 'vs/base/common/async';
 import { CancellationToken } from 'vs/base/common/cancellation';
 import { VSDataTransfer } from 'vs/base/common/dataTransfer';
+import { KeyCode, KeyMod } from 'vs/base/common/keyCodes';
 import { Disposable } from 'vs/base/common/lifecycle';
 import { addExternalEditorsDropData, toVSDataTransfer } from 'vs/editor/browser/dnd';
 import { ICodeEditor } from 'vs/editor/browser/editorBrowser';
-import { EditorContributionInstantiation, registerEditorContribution } from 'vs/editor/browser/editorExtensions';
+import { EditorCommand, EditorContributionInstantiation, ServicesAccessor, registerEditorCommand, registerEditorContribution } from 'vs/editor/browser/editorExtensions';
 import { IBulkEditService, ResourceTextEdit } from 'vs/editor/browser/services/bulkEditService';
 import { EditorOption } from 'vs/editor/common/config/editorOptions';
 import { IPosition } from 'vs/editor/common/core/position';
@@ -21,13 +22,14 @@ import { TrackedRangeStickiness } from 'vs/editor/common/model';
 import { ILanguageFeaturesService } from 'vs/editor/common/services/languageFeatures';
 import { DraggedTreeItemsIdentifier } from 'vs/editor/common/services/treeViewsDnd';
 import { ITreeViewsDnDService } from 'vs/editor/common/services/treeViewsDndService';
-import { PostDropWidgetManager } from 'vs/editor/contrib/dropIntoEditor/browser/postDropWidget';
+import { PostDropWidgetManager, dropWidgetVisibleCtx } from 'vs/editor/contrib/dropIntoEditor/browser/postDropWidget';
 import { CodeEditorStateFlag, EditorStateCancellationTokenSource } from 'vs/editor/contrib/editorState/browser/editorState';
 import { InlineProgressManager } from 'vs/editor/contrib/inlineProgress/browser/inlineProgress';
 import { SnippetParser } from 'vs/editor/contrib/snippet/browser/snippetParser';
 import { localize } from 'vs/nls';
 import { LocalSelectionTransfer } from 'vs/platform/dnd/browser/dnd';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
+import { KeybindingWeight } from 'vs/platform/keybinding/common/keybindingsRegistry';
 import { IWorkspaceContextService } from 'vs/platform/workspace/common/workspace';
 import { registerDefaultDropProviders } from './defaultOnDropProviders';
 
@@ -58,8 +60,8 @@ export class DropIntoEditorController extends Disposable implements IEditorContr
 	) {
 		super();
 
-		this._dropProgressManager = this._register(new InlineProgressManager('dropIntoEditor', editor, instantiationService));
-		this._postDropWidgetManager = this._register(new PostDropWidgetManager(editor, instantiationService));
+		this._dropProgressManager = this._register(instantiationService.createInstance(InlineProgressManager, 'dropIntoEditor', editor));
+		this._postDropWidgetManager = this._register(instantiationService.createInstance(PostDropWidgetManager, editor));
 
 		this._register(editor.onDropIntoEditor(e => this.onDropIntoEditor(editor, e.position, e.event)));
 
@@ -68,6 +70,10 @@ export class DropIntoEditorController extends Disposable implements IEditorContr
 
 	public clearWidgets() {
 		this._postDropWidgetManager.clear();
+	}
+
+	public changeDropType() {
+		this._postDropWidgetManager.changeExistingDropType();
 	}
 
 	private async onDropIntoEditor(editor: ICodeEditor, position: IPosition, dragEvent: DragEvent) {
@@ -210,3 +216,21 @@ export class DropIntoEditorController extends Disposable implements IEditorContr
 }
 
 registerEditorContribution(DropIntoEditorController.ID, DropIntoEditorController, EditorContributionInstantiation.BeforeFirstInteraction);
+
+registerEditorCommand(new class extends EditorCommand {
+	constructor() {
+		super({
+			id: 'editor.changeDropType',
+			precondition: dropWidgetVisibleCtx,
+			kbOpts: {
+				weight: KeybindingWeight.EditorContrib,
+				primary: KeyMod.CtrlCmd | KeyCode.Period,
+			}
+		});
+	}
+
+	public override runEditorCommand(accessor: ServicesAccessor | null, editor: ICodeEditor, args: any): void | Promise<void> {
+		const controller = DropIntoEditorController.get(editor);
+		controller?.changeDropType();
+	}
+});

--- a/src/vs/editor/contrib/dropIntoEditor/browser/postDropWidget.ts
+++ b/src/vs/editor/contrib/dropIntoEditor/browser/postDropWidget.ts
@@ -13,9 +13,11 @@ import { ContentWidgetPositionPreference, ICodeEditor, IContentWidget, IContentW
 import { Range } from 'vs/editor/common/core/range';
 import { DocumentOnDropEdit } from 'vs/editor/common/languages';
 import { localize } from 'vs/nls';
+import { IContextKey, IContextKeyService, RawContextKey } from 'vs/platform/contextkey/common/contextkey';
 import { IContextMenuService } from 'vs/platform/contextview/browser/contextView';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 
+export const dropWidgetVisibleCtx = new RawContextKey<boolean>('dropWidgetVisible', false, localize('dropWidgetVisible', "Whether the drop widget is showing"));
 
 interface DropEditSet {
 	readonly activeEditIndex: number;
@@ -31,16 +33,23 @@ class PostDropWidget extends Disposable implements IContentWidget {
 	private domNode!: HTMLElement;
 	private button!: Button;
 
+	private readonly dropWidgetVisible: IContextKey<boolean>;
+
 	constructor(
 		private readonly editor: ICodeEditor,
 		private readonly range: Range,
 		private readonly edits: DropEditSet,
 		private readonly onSelectNewEdit: (editIndex: number) => void,
 		@IContextMenuService private readonly _contextMenuService: IContextMenuService,
+		@IContextKeyService contextKeyService: IContextKeyService,
 	) {
 		super();
 
 		this.create();
+
+		this.dropWidgetVisible = dropWidgetVisibleCtx.bindTo(contextKeyService);
+		this.dropWidgetVisible.set(true);
+		this._register(toDisposable(() => this.dropWidgetVisible.reset()));
 
 		this.editor.addContentWidget(this);
 		this.editor.layoutContentWidget(this);
@@ -63,26 +72,7 @@ class PostDropWidget extends Disposable implements IContentWidget {
 		}));
 		this.button.label = '$(insert)';
 
-		this._register(dom.addDisposableListener(this.domNode, dom.EventType.CLICK, e => {
-			this._contextMenuService.showContextMenu({
-				getAnchor: () => {
-					const pos = dom.getDomNodePagePosition(this.button.element);
-					return { x: pos.left + pos.width, y: pos.top + pos.height };
-				},
-				getActions: () => {
-					return this.edits.allEdits.map((edit, i) => toAction({
-						id: '',
-						label: edit.label,
-						checked: i === this.edits.activeEditIndex,
-						run: () => {
-							if (i !== this.edits.activeEditIndex) {
-								return this.onSelectNewEdit(i);
-							}
-						},
-					}));
-				}
-			});
-		}));
+		this._register(dom.addDisposableListener(this.domNode, dom.EventType.CLICK, () => this.showDropSelector()));
 	}
 
 	getId(): string {
@@ -98,6 +88,27 @@ class PostDropWidget extends Disposable implements IContentWidget {
 			position: this.range.getEndPosition(),
 			preference: [ContentWidgetPositionPreference.BELOW]
 		};
+	}
+
+	showDropSelector() {
+		this._contextMenuService.showContextMenu({
+			getAnchor: () => {
+				const pos = dom.getDomNodePagePosition(this.button.element);
+				return { x: pos.left + pos.width, y: pos.top + pos.height };
+			},
+			getActions: () => {
+				return this.edits.allEdits.map((edit, i) => toAction({
+					id: '',
+					label: edit.label,
+					checked: i === this.edits.activeEditIndex,
+					run: () => {
+						if (i !== this.edits.activeEditIndex) {
+							return this.onSelectNewEdit(i);
+						}
+					},
+				}));
+			}
+		});
 	}
 }
 
@@ -127,5 +138,9 @@ export class PostDropWidgetManager extends Disposable {
 
 	public clear() {
 		this._currentWidget.clear();
+	}
+
+	public changeExistingDropType() {
+		this._currentWidget.value?.showDropSelector();
 	}
 }


### PR DESCRIPTION
Adds a command/keybinding to toggle the post drop widget

Currently using the same keybinding as the code action widget