### PR TITLE
prioritize images over text in accessiblity mode

### DIFF
--- a/src/vs/workbench/contrib/notebook/common/notebookCommon.ts
+++ b/src/vs/workbench/contrib/notebook/common/notebookCommon.ts
@@ -57,11 +57,11 @@ export const ACCESSIBLE_NOTEBOOK_DISPLAY_ORDER: readonly string[] = [
 	Mimes.latex,
 	Mimes.markdown,
 	'application/json',
-	Mimes.text,
 	'text/html',
 	'image/svg+xml',
 	'image/png',
 	'image/jpeg',
+	Mimes.text,
 ];
 
 /**


### PR DESCRIPTION
for https://github.com/microsoft/vscode/issues/176293
users in accessibility mode still expect to have an image displayed for visual outputs, especially useful when sharing the screen with someone else.