### PR TITLE
Allow QuickAccessProviders to asynchronously initialize

### DIFF
--- a/src/vs/editor/standalone/browser/quickAccess/standaloneCommandsQuickAccess.ts
+++ b/src/vs/editor/standalone/browser/quickAccess/standaloneCommandsQuickAccess.ts
@@ -68,8 +68,8 @@ export class GotoLineAction extends EditorAction {
 		});
 	}
 
-	run(accessor: ServicesAccessor): void {
-		accessor.get(IQuickInputService).quickAccess.show(StandaloneCommandsQuickAccessProvider.PREFIX);
+	run(accessor: ServicesAccessor): Promise<void> {
+		return accessor.get(IQuickInputService).quickAccess.show(StandaloneCommandsQuickAccessProvider.PREFIX);
 	}
 }
 

--- a/src/vs/editor/standalone/browser/quickAccess/standaloneGotoLineQuickAccess.ts
+++ b/src/vs/editor/standalone/browser/quickAccess/standaloneGotoLineQuickAccess.ts
@@ -48,8 +48,8 @@ export class GotoLineAction extends EditorAction {
 		});
 	}
 
-	run(accessor: ServicesAccessor): void {
-		accessor.get(IQuickInputService).quickAccess.show(StandaloneGotoLineQuickAccessProvider.PREFIX);
+	run(accessor: ServicesAccessor): Promise<void> {
+		return accessor.get(IQuickInputService).quickAccess.show(StandaloneGotoLineQuickAccessProvider.PREFIX);
 	}
 }
 

--- a/src/vs/editor/standalone/browser/quickAccess/standaloneGotoSymbolQuickAccess.ts
+++ b/src/vs/editor/standalone/browser/quickAccess/standaloneGotoSymbolQuickAccess.ts
@@ -60,8 +60,8 @@ export class GotoSymbolAction extends EditorAction {
 		});
 	}
 
-	run(accessor: ServicesAccessor): void {
-		accessor.get(IQuickInputService).quickAccess.show(AbstractGotoSymbolQuickAccessProvider.PREFIX, { itemActivation: ItemActivation.NONE });
+	run(accessor: ServicesAccessor): Promise<void> {
+		return accessor.get(IQuickInputService).quickAccess.show(AbstractGotoSymbolQuickAccessProvider.PREFIX, { itemActivation: ItemActivation.NONE });
 	}
 }
 

--- a/src/vs/platform/quickinput/common/quickAccess.ts
+++ b/src/vs/platform/quickinput/common/quickAccess.ts
@@ -55,7 +55,7 @@ export interface IQuickAccessController {
 	/**
 	 * Open the quick access picker with the optional value prefilled.
 	 */
-	show(value?: string, options?: IQuickAccessOptions): void;
+	show(value?: string, options?: IQuickAccessOptions): Promise<void>;
 
 	/**
 	 * Same as `show()` but instead of executing the selected pick item,
@@ -106,6 +106,11 @@ export interface IQuickAccessProvider {
 	 * closes or is replaced by another picker.
 	 */
 	provide(picker: IQuickPick<IQuickPickItem>, token: CancellationToken, options?: IQuickAccessProviderRunOptions): IDisposable;
+
+	/**
+	 * An optional method that is called to asynchronously initialize the provider.
+	 */
+	initialize?(): Promise<void>;
 }
 
 export interface IQuickAccessProviderHelp {

--- a/src/vs/workbench/browser/actions/quickAccessActions.ts
+++ b/src/vs/workbench/browser/actions/quickAccessActions.ts
@@ -144,9 +144,8 @@ registerAction2(class QuickAccessAction extends Action2 {
 		});
 	}
 
-	run(accessor: ServicesAccessor, prefix: undefined): void {
-		const quickInputService = accessor.get(IQuickInputService);
-		quickInputService.quickAccess.show(typeof prefix === 'string' ? prefix : undefined, { preserveValue: typeof prefix === 'string' /* preserve as is if provided */ });
+	run(accessor: ServicesAccessor, prefix: undefined): Promise<void> {
+		return accessor.get(IQuickInputService).quickAccess.show(typeof prefix === 'string' ? prefix : undefined, { preserveValue: typeof prefix === 'string' /* preserve as is if provided */ });
 	}
 });
 
@@ -162,9 +161,8 @@ registerAction2(class QuickAccessAction extends Action2 {
 		});
 	}
 
-	run(accessor: ServicesAccessor): void {
-		const quickInputService = accessor.get(IQuickInputService);
-		quickInputService.quickAccess.show(undefined, {
+	run(accessor: ServicesAccessor): Promise<void> {
+		return accessor.get(IQuickInputService).quickAccess.show(undefined, {
 			preserveValue: true,
 			providerOptions: {
 				includeHelp: true,
@@ -174,10 +172,8 @@ registerAction2(class QuickAccessAction extends Action2 {
 	}
 });
 
-CommandsRegistry.registerCommand('workbench.action.quickOpenPreviousEditor', async accessor => {
-	const quickInputService = accessor.get(IQuickInputService);
-
-	quickInputService.quickAccess.show('', { itemActivation: ItemActivation.SECOND });
+CommandsRegistry.registerCommand('workbench.action.quickOpenPreviousEditor', accessor => {
+	return accessor.get(IQuickInputService).quickAccess.show('', { itemActivation: ItemActivation.SECOND });
 });
 
 //#endregion

--- a/src/vs/workbench/browser/parts/editor/editorActions.ts
+++ b/src/vs/workbench/browser/parts/editor/editorActions.ts
@@ -1603,10 +1603,8 @@ export class ShowEditorsInActiveGroupByMostRecentlyUsedAction extends Action2 {
 		});
 	}
 
-	override async run(accessor: ServicesAccessor): Promise<void> {
-		const quickInputService = accessor.get(IQuickInputService);
-
-		quickInputService.quickAccess.show(ActiveGroupEditorsByMostRecentlyUsedQuickAccess.PREFIX);
+	override run(accessor: ServicesAccessor): Promise<void> {
+		return accessor.get(IQuickInputService).quickAccess.show(ActiveGroupEditorsByMostRecentlyUsedQuickAccess.PREFIX);
 	}
 }
 
@@ -1631,9 +1629,7 @@ export class ShowAllEditorsByAppearanceAction extends Action2 {
 	}
 
 	override async run(accessor: ServicesAccessor): Promise<void> {
-		const quickInputService = accessor.get(IQuickInputService);
-
-		quickInputService.quickAccess.show(AllEditorsByAppearanceQuickAccess.PREFIX);
+		return accessor.get(IQuickInputService).quickAccess.show(AllEditorsByAppearanceQuickAccess.PREFIX);
 	}
 }
 
@@ -1651,9 +1647,7 @@ export class ShowAllEditorsByMostRecentlyUsedAction extends Action2 {
 	}
 
 	override async run(accessor: ServicesAccessor): Promise<void> {
-		const quickInputService = accessor.get(IQuickInputService);
-
-		quickInputService.quickAccess.show(AllEditorsByMostRecentlyUsedQuickAccess.PREFIX);
+		return accessor.get(IQuickInputService).quickAccess.show(AllEditorsByMostRecentlyUsedQuickAccess.PREFIX);
 	}
 }
 
@@ -1673,7 +1667,7 @@ abstract class AbstractQuickAccessEditorAction extends Action2 {
 
 		const keybindings = keybindingService.lookupKeybindings(this.desc.id);
 
-		quickInputService.quickAccess.show(this.prefix, {
+		return quickInputService.quickAccess.show(this.prefix, {
 			quickNavigateConfiguration: { keybindings },
 			itemActivation: this.itemActivation
 		});
@@ -1770,7 +1764,7 @@ export class QuickAccessPreviousEditorFromHistoryAction extends Action2 {
 			itemActivation = ItemActivation.FIRST;
 		}
 
-		quickInputService.quickAccess.show('', { quickNavigateConfiguration: { keybindings }, itemActivation });
+		return quickInputService.quickAccess.show('', { quickNavigateConfiguration: { keybindings }, itemActivation });
 	}
 }
 

--- a/src/vs/workbench/contrib/codeEditor/browser/quickaccess/gotoLineQuickAccess.ts
+++ b/src/vs/workbench/contrib/codeEditor/browser/quickaccess/gotoLineQuickAccess.ts
@@ -84,8 +84,8 @@ class GotoLineAction extends Action2 {
 		});
 	}
 
-	async run(accessor: ServicesAccessor): Promise<void> {
-		accessor.get(IQuickInputService).quickAccess.show(GotoLineQuickAccessProvider.PREFIX);
+	run(accessor: ServicesAccessor): Promise<void> {
+		return accessor.get(IQuickInputService).quickAccess.show(GotoLineQuickAccessProvider.PREFIX);
 	}
 }
 

--- a/src/vs/workbench/contrib/codeEditor/browser/quickaccess/gotoSymbolQuickAccess.ts
+++ b/src/vs/workbench/contrib/codeEditor/browser/quickaccess/gotoSymbolQuickAccess.ts
@@ -260,8 +260,8 @@ class GotoSymbolAction extends Action2 {
 		});
 	}
 
-	run(accessor: ServicesAccessor) {
-		accessor.get(IQuickInputService).quickAccess.show(GotoSymbolQuickAccessProvider.PREFIX, { itemActivation: ItemActivation.NONE });
+	run(accessor: ServicesAccessor): Promise<void> {
+		return accessor.get(IQuickInputService).quickAccess.show(GotoSymbolQuickAccessProvider.PREFIX, { itemActivation: ItemActivation.NONE });
 	}
 }
 

--- a/src/vs/workbench/contrib/debug/browser/debugCommands.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugCommands.ts
@@ -704,17 +704,15 @@ CommandsRegistry.registerCommand({
 
 CommandsRegistry.registerCommand({
 	id: SELECT_AND_START_ID,
-	handler: async (accessor: ServicesAccessor) => {
-		const quickInputService = accessor.get(IQuickInputService);
-		quickInputService.quickAccess.show(DEBUG_QUICK_ACCESS_PREFIX);
+	handler: (accessor: ServicesAccessor) => {
+		return accessor.get(IQuickInputService).quickAccess.show(DEBUG_QUICK_ACCESS_PREFIX);
 	}
 });
 
 CommandsRegistry.registerCommand({
 	id: SELECT_DEBUG_CONSOLE_ID,
-	handler: async (accessor: ServicesAccessor) => {
-		const quickInputService = accessor.get(IQuickInputService);
-		quickInputService.quickAccess.show(DEBUG_CONSOLE_QUICK_ACCESS_PREFIX);
+	handler: (accessor: ServicesAccessor) => {
+		return accessor.get(IQuickInputService).quickAccess.show(DEBUG_CONSOLE_QUICK_ACCESS_PREFIX);
 	}
 });
 

--- a/src/vs/workbench/contrib/quickaccess/browser/viewQuickAccess.ts
+++ b/src/vs/workbench/contrib/quickaccess/browser/viewQuickAccess.ts
@@ -239,8 +239,8 @@ export class OpenViewPickerAction extends Action2 {
 		});
 	}
 
-	async run(accessor: ServicesAccessor): Promise<void> {
-		accessor.get(IQuickInputService).quickAccess.show(ViewQuickAccessProvider.PREFIX);
+	run(accessor: ServicesAccessor): Promise<void> {
+		return accessor.get(IQuickInputService).quickAccess.show(ViewQuickAccessProvider.PREFIX);
 	}
 }
 
@@ -273,7 +273,7 @@ export class QuickAccessViewPickerAction extends Action2 {
 
 		const keys = keybindingService.lookupKeybindings(QuickAccessViewPickerAction.ID);
 
-		quickInputService.quickAccess.show(ViewQuickAccessProvider.PREFIX, { quickNavigateConfiguration: { keybindings: keys }, itemActivation: ItemActivation.FIRST });
+		return quickInputService.quickAccess.show(ViewQuickAccessProvider.PREFIX, { quickNavigateConfiguration: { keybindings: keys }, itemActivation: ItemActivation.FIRST });
 	}
 }
 

--- a/src/vs/workbench/contrib/search/browser/searchActionsSymbol.ts
+++ b/src/vs/workbench/contrib/search/browser/searchActionsSymbol.ts
@@ -40,8 +40,8 @@ registerAction2(class ShowAllSymbolsAction extends Action2 {
 		});
 	}
 
-	override async run(accessor: ServicesAccessor): Promise<void> {
-		accessor.get(IQuickInputService).quickAccess.show(ShowAllSymbolsAction.ALL_SYMBOLS_PREFIX);
+	override run(accessor: ServicesAccessor): Promise<void> {
+		return accessor.get(IQuickInputService).quickAccess.show(ShowAllSymbolsAction.ALL_SYMBOLS_PREFIX);
 	}
 });
 

--- a/src/vs/workbench/contrib/terminalContrib/links/browser/terminalLinkOpeners.ts
+++ b/src/vs/workbench/contrib/terminalContrib/links/browser/terminalLinkOpeners.ts
@@ -130,7 +130,7 @@ export class TerminalSearchLinkOpener implements ITerminalLinkOpener {
 		}
 
 		// Fallback to searching quick access
-		return this._quickInputService.quickAccess.show(text);
+		return await this._quickInputService.quickAccess.show(text);
 	}
 
 	private async _getExactMatch(sanitizedLink: string): Promise<IResourceMatch | undefined> {

--- a/src/vs/workbench/contrib/terminalContrib/links/test/browser/terminalLinkOpeners.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/links/test/browser/terminalLinkOpeners.test.ts
@@ -92,6 +92,7 @@ suite('Workbench - TerminalLinkOpeners', () => {
 			quickAccess: {
 				show(link: string) {
 					activationResult = { link, source: 'search' };
+					return Promise.resolve();
 				}
 			}
 		} as Partial<IQuickInputService>);

--- a/src/vs/workbench/test/browser/quickAccess.test.ts
+++ b/src/vs/workbench/test/browser/quickAccess.test.ts
@@ -138,7 +138,7 @@ suite('QuickAccess', () => {
 		disposables.add(registry.registerQuickAccessProvider(providerDescriptor2));
 		disposables.add(registry.registerQuickAccessProvider(providerDescriptor3));
 
-		accessor.quickInputService.quickAccess.show('test');
+		await accessor.quickInputService.quickAccess.show('test');
 		assert.strictEqual(providerDefaultCalled, false);
 		assert.strictEqual(provider1Called, true);
 		assert.strictEqual(provider2Called, false);
@@ -153,7 +153,7 @@ suite('QuickAccess', () => {
 		assert.strictEqual(provider3Disposed, false);
 		provider1Called = false;
 
-		accessor.quickInputService.quickAccess.show('test something');
+		await accessor.quickInputService.quickAccess.show('test something');
 		assert.strictEqual(providerDefaultCalled, false);
 		assert.strictEqual(provider1Called, false);
 		assert.strictEqual(provider2Called, true);
@@ -170,7 +170,7 @@ suite('QuickAccess', () => {
 		provider1Canceled = false;
 		provider1Disposed = false;
 
-		accessor.quickInputService.quickAccess.show('usedefault');
+		await accessor.quickInputService.quickAccess.show('usedefault');
 		assert.strictEqual(providerDefaultCalled, true);
 		assert.strictEqual(provider1Called, false);
 		assert.strictEqual(provider2Called, false);
@@ -277,13 +277,13 @@ suite('QuickAccess', () => {
 		disposables.add(registry.registerQuickAccessProvider(slowProviderDescriptor));
 		disposables.add(registry.registerQuickAccessProvider(fastAndSlowProviderDescriptor));
 
-		accessor.quickInputService.quickAccess.show('fast');
+		await accessor.quickInputService.quickAccess.show('fast');
 		assert.strictEqual(fastProviderCalled, true);
 		assert.strictEqual(slowProviderCalled, false);
 		assert.strictEqual(fastAndSlowProviderCalled, false);
 		fastProviderCalled = false;
 
-		accessor.quickInputService.quickAccess.show('slow');
+		await accessor.quickInputService.quickAccess.show('slow');
 		await timeout(2);
 
 		assert.strictEqual(fastProviderCalled, false);
@@ -292,7 +292,7 @@ suite('QuickAccess', () => {
 		assert.strictEqual(fastAndSlowProviderCalled, false);
 		slowProviderCalled = false;
 
-		accessor.quickInputService.quickAccess.show('bothFastAndSlow');
+		await accessor.quickInputService.quickAccess.show('bothFastAndSlow');
 		await timeout(2);
 
 		assert.strictEqual(fastProviderCalled, false);
@@ -301,9 +301,9 @@ suite('QuickAccess', () => {
 		assert.strictEqual(fastAndSlowProviderCanceled, false);
 		fastAndSlowProviderCalled = false;
 
-		accessor.quickInputService.quickAccess.show('slow');
-		accessor.quickInputService.quickAccess.show('bothFastAndSlow');
-		accessor.quickInputService.quickAccess.show('fast');
+		await accessor.quickInputService.quickAccess.show('slow');
+		await accessor.quickInputService.quickAccess.show('bothFastAndSlow');
+		await accessor.quickInputService.quickAccess.show('fast');
 
 		assert.strictEqual(fastProviderCalled, true);
 		assert.strictEqual(slowProviderCalled, true);


### PR DESCRIPTION
This allows a provider to do something async when initialized. This is used in CommandQuickAccess to asynchronously wait for Extension Activation before showing commands.

As a result, `show(): void` needed to be updated to be async and references of show needed updating to... I've updated as many as I think makes sense.

Here is a list of others that I didn't update that I didn't think needed it:
* https://github.com/microsoft/vscode/blob/e71aaf717957fdee9be79f16b0fdac2fd35ba70b/src/vs/platform/quickinput/browser/helpQuickAccess.ts#L35
* https://github.com/microsoft/vscode/blob/e71aaf717957fdee9be79f16b0fdac2fd35ba70b/src/vs/platform/quickinput/browser/helpQuickAccess.ts#L44
* https://github.com/microsoft/vscode/blob/e71aaf717957fdee9be79f16b0fdac2fd35ba70b/src/vs/workbench/browser/parts/editor/breadcrumbsControl.ts#L385
* https://github.com/microsoft/vscode/blob/e71aaf717957fdee9be79f16b0fdac2fd35ba70b/src/vs/workbench/browser/parts/editor/editorCommands.ts#L1417
* https://github.com/microsoft/vscode/blob/e71aaf717957fdee9be79f16b0fdac2fd35ba70b/src/vs/workbench/browser/parts/editor/noTabsTitleControl.ts#L95
* https://github.com/microsoft/vscode/blob/e71aaf717957fdee9be79f16b0fdac2fd35ba70b/src/vs/workbench/browser/parts/editor/noTabsTitleControl.ts#L128
* https://github.com/microsoft/vscode/blob/e71aaf717957fdee9be79f16b0fdac2fd35ba70b/src/vs/workbench/contrib/search/browser/anythingQuickAccess.ts#L792

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
