### PR TITLE
only cache audio cues, do not try to preload

### DIFF
--- a/src/vs/platform/audioCues/browser/audioCueService.ts
+++ b/src/vs/platform/audioCues/browser/audioCueService.ts
@@ -37,12 +37,6 @@ export class AudioCueService extends Disposable implements IAudioCueService {
 		@IAccessibilityService private readonly accessibilityService: IAccessibilityService
 	) {
 		super();
-		// preload all sounds so there's no delay
-		for (const audioCue of AudioCue.allAudioCues) {
-			playAudio(FileAccess.asBrowserUri(
-				`vs/platform/audioCues/browser/media/${audioCue.sound.fileName}`
-			).toString(true), 0).then(sound => { { this.sounds.set(sound.src, sound); } });
-		}
 	}
 
 	public async playAudioCue(cue: AudioCue, allowManyInParallel = false): Promise<void> {
@@ -79,11 +73,9 @@ export class AudioCueService extends Disposable implements IAudioCueService {
 		try {
 			const sound = this.sounds.get(url);
 			if (sound) {
-				// preloaded
 				sound.volume = this.getVolumeInPercent() / 100;
 				await sound.play();
 			} else {
-				// not yet preloaded
 				const playedSound = await playAudio(url, this.getVolumeInPercent() / 100);
 				this.sounds.set(url, playedSound);
 			}


### PR DESCRIPTION
We cannot preload the sounds because chrome requires a user gesture to play them. 

fix #180670