### PR TITLE
testing: tie test output correctly to runs, rework ui accordingly

### DIFF
--- a/src/vs/base/common/strings.ts
+++ b/src/vs/base/common/strings.ts
@@ -730,9 +730,12 @@ export function lcut(text: string, n: number) {
 // Escape codes, compiled from https://invisible-island.net/xterm/ctlseqs/ctlseqs.html#h3-Functions-using-CSI-_-ordered-by-the-final-character_s_
 const CSI_SEQUENCE = /(:?\x1b\[|\x9B)[=?>!]?[\d;:]*["$#'* ]?[a-zA-Z@^`{}|~]/g;
 
+// Plus additional markers for custom `\x1b]...\x07` instructions.
+const CSI_CUSTOM_SEQUENCE = /\x1b\].*?\x07/g;
+
 export function removeAnsiEscapeCodes(str: string): string {
 	if (str) {
-		str = str.replace(CSI_SEQUENCE, '');
+		str = str.replace(CSI_SEQUENCE, '').replace(CSI_CUSTOM_SEQUENCE, '');
 	}
 
 	return str;

--- a/src/vs/base/test/common/strings.test.ts
+++ b/src/vs/base/test/common/strings.test.ts
@@ -511,6 +511,10 @@ suite('Strings', () => {
 			`${CSI}48;5;128m`, // 256 indexed color alt
 			`${CSI}38:2:0:255:255:255m`, // truecolor
 			`${CSI}38;2;255;255;255m`, // truecolor alt
+
+			// Custom sequences:
+			'\x1b]633;SetMark;\x07',
+			'\x1b]633;P;Cwd=/foo\x07',
 		];
 
 		for (const sequence of sequences) {

--- a/src/vs/workbench/contrib/testing/browser/testExplorerActions.ts
+++ b/src/vs/workbench/contrib/testing/browser/testExplorerActions.ts
@@ -838,9 +838,31 @@ export class ShowMostRecentOutputAction extends Action2 {
 		});
 	}
 
-	public run(accessor: ServicesAccessor) {
+	public async run(accessor: ServicesAccessor) {
+		const quickInputService = accessor.get(IQuickInputService);
+		const terminalOutputService = accessor.get(ITestingOutputTerminalService);
 		const result = accessor.get(ITestResultService).results[0];
-		accessor.get(ITestingOutputTerminalService).open(result);
+
+		if (!result.tasks.length) {
+			return;
+		}
+
+		let index = 0;
+		if (result.tasks.length > 1) {
+			const picked = await quickInputService.pick(
+				result.tasks.map((t, i) => ({ label: t.name || localize('testing.pickTaskUnnamed', "Run #{0}", i), index: i })),
+				{ placeHolder: localize('testing.pickTask', "Pick a run to show output for") }
+			);
+
+			if (!picked) {
+				return;
+			}
+
+			index = picked.index;
+		}
+
+
+		terminalOutputService.open(result, index);
 	}
 }
 

--- a/src/vs/workbench/contrib/testing/common/testResult.ts
+++ b/src/vs/workbench/contrib/testing/common/testResult.ts
@@ -382,12 +382,10 @@ export class LiveTestResult implements ITestResult {
 	 * Adds a new run task to the results.
 	 */
 	public addTask(task: ITestRunTask) {
-		const index = this.tasks.length;
 		this.tasks.push({ ...task, coverage: new MutableObservableValue(undefined), otherMessages: [] });
 
 		for (const test of this.tests) {
 			test.tasks.push({ duration: undefined, messages: [], state: TestResultState.Unset });
-			this.fireUpdateAndRefresh(test, index, TestResultState.Queued);
 		}
 	}
 
@@ -570,7 +568,7 @@ export class LiveTestResult implements ITestResult {
 
 		if (this.tasks.length) {
 			for (let i = 0; i < this.tasks.length; i++) {
-				node.tasks.push({ duration: undefined, messages: [], state: TestResultState.Queued });
+				node.tasks.push({ duration: undefined, messages: [], state: TestResultState.Unset });
 			}
 		}
 

--- a/src/vs/workbench/contrib/testing/common/testResult.ts
+++ b/src/vs/workbench/contrib/testing/common/testResult.ts
@@ -3,19 +3,19 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { newWriteableBufferStream, VSBuffer, VSBufferReadableStream, VSBufferWriteableStream } from 'vs/base/common/buffer';
-import { Emitter } from 'vs/base/common/event';
+import { DeferredPromise } from 'vs/base/common/async';
+import { VSBuffer } from 'vs/base/common/buffer';
+import { Emitter, Event } from 'vs/base/common/event';
 import { Lazy } from 'vs/base/common/lazy';
-import { DisposableStore } from 'vs/base/common/lifecycle';
+import { language } from 'vs/base/common/platform';
+import { removeAnsiEscapeCodes } from 'vs/base/common/strings';
 import { localize } from 'vs/nls';
 import { IComputedStateAccessor, refreshComputedState } from 'vs/workbench/contrib/testing/common/getComputedState';
 import { IObservableValue, MutableObservableValue, staticObservableValue } from 'vs/workbench/contrib/testing/common/observableValue';
-import { getMarkId, IRichLocation, ISerializedTestResults, ITestItem, ITestMessage, ITestOutputMessage, ITestRunTask, ITestTaskState, ResolvedTestRunRequest, TestItemExpandState, TestMessageType, TestResultItem, TestResultState } from 'vs/workbench/contrib/testing/common/testTypes';
 import { TestCoverage } from 'vs/workbench/contrib/testing/common/testCoverage';
-import { maxPriority, statesInOrder, terminalStatePriorities } from 'vs/workbench/contrib/testing/common/testingStates';
-import { removeAnsiEscapeCodes } from 'vs/base/common/strings';
 import { TestId } from 'vs/workbench/contrib/testing/common/testId';
-import { language } from 'vs/base/common/platform';
+import { maxPriority, statesInOrder, terminalStatePriorities } from 'vs/workbench/contrib/testing/common/testingStates';
+import { getMarkId, IRichLocation, ISerializedTestResults, ITestItem, ITestMessage, ITestOutputMessage, ITestRunTask, ITestTaskState, ResolvedTestRunRequest, TestItemExpandState, TestMessageType, TestResultItem, TestResultState } from 'vs/workbench/contrib/testing/common/testTypes';
 
 export interface ITestRunTaskResults extends ITestRunTask {
 	/**
@@ -27,6 +27,11 @@ export interface ITestRunTaskResults extends ITestRunTask {
 	 * Messages from the task not associated with any specific test.
 	 */
 	readonly otherMessages: ITestOutputMessage[];
+
+	/**
+	 * Test results output for the task.
+	 */
+	readonly output: ITaskRawOutput;
 }
 
 export interface ITestResult {
@@ -72,16 +77,6 @@ export interface ITestResult {
 	getStateById(testExtId: string): TestResultItem | undefined;
 
 	/**
-	 * Loads the output of the result as a stream.
-	 */
-	getOutput(): Promise<VSBufferReadableStream>;
-
-	/**
-	 * Loads an output of the result.
-	 */
-	getOutputRange(offset: number, length: number): Promise<VSBuffer>;
-
-	/**
 	 * Serializes the test result. Used to save and restore results
 	 * in the workspace.
 	 */
@@ -91,6 +86,97 @@ export interface ITestResult {
 	 * Serializes the test result, includes messages. Used to send the test states to the extension host.
 	 */
 	toJSONWithMessages(): ISerializedTestResults | undefined;
+}
+
+/**
+ * Output type exposed from live test results.
+ */
+export interface ITaskRawOutput {
+	readonly onDidWriteData: Event<VSBuffer>;
+	readonly endPromise: Promise<void>;
+	readonly buffers: VSBuffer[];
+	readonly length: number;
+
+	getRange(start: number, end: number): VSBuffer;
+}
+
+const emptyRawOutput: ITaskRawOutput = {
+	buffers: [],
+	length: 0,
+	onDidWriteData: Event.None,
+	endPromise: Promise.resolve(),
+	getRange: () => VSBuffer.alloc(0),
+};
+
+export class TaskRawOutput implements ITaskRawOutput {
+	private readonly writeDataEmitter = new Emitter<VSBuffer>();
+	private readonly endDeferred = new DeferredPromise<void>();
+	private offset = 0;
+
+	/** @inheritdoc */
+	public readonly onDidWriteData = this.writeDataEmitter.event;
+
+	/** @inheritdoc */
+	public readonly endPromise = this.endDeferred.p;
+
+	/** @inheritdoc */
+	public readonly buffers: VSBuffer[] = [];
+
+	/** @inheritdoc */
+	public get length() {
+		return this.offset;
+	}
+
+	/** @inheritdoc */
+	getRange(start: number, length: number): VSBuffer {
+		const buf = VSBuffer.alloc(length);
+
+		let bufLastWrite = 0;
+		let internalLastRead = 0;
+		for (const b of this.buffers) {
+			if (internalLastRead + b.byteLength <= start) {
+				internalLastRead += b.byteLength;
+				continue;
+			}
+
+			const bstart = Math.max(0, start - internalLastRead);
+			const bend = Math.min(b.byteLength, bstart + length - bufLastWrite);
+
+			buf.buffer.set(b.buffer.subarray(bstart, bend), bufLastWrite);
+			bufLastWrite += bend - bstart;
+			internalLastRead += b.byteLength;
+
+			if (bufLastWrite === buf.byteLength) {
+				break;
+			}
+		}
+
+		return bufLastWrite < length ? buf.slice(0, bufLastWrite) : buf;
+	}
+
+	/**
+	 * Appends data to the output, returning the byte index where data starts.
+	 */
+	public append(data: VSBuffer, marker?: number): number {
+		let startOffset = this.offset;
+		if (marker !== undefined) {
+			const start = VSBuffer.fromString(getMarkCode(marker, true));
+			const end = VSBuffer.fromString(getMarkCode(marker, false));
+			startOffset += start.byteLength;
+			data = VSBuffer.concat([start, data, end]);
+		}
+
+		this.buffers.push(data);
+		this.writeDataEmitter.fire(data);
+		this.offset += data.byteLength;
+
+		return startOffset;
+	}
+
+	/** Signals the output has ended. */
+	public end() {
+		this.endDeferred.complete();
+	}
 }
 
 export const resultItemParents = function* (results: ITestResult, item: TestResultItem) {
@@ -125,134 +211,6 @@ export const maxCountPriority = (counts: Readonly<TestStateCount>) => {
 
 const getMarkCode = (marker: number, start: boolean) => `\x1b]633;SetMark;Id=${getMarkId(marker, start)};Hidden\x07`;
 
-/**
- * Deals with output of a {@link LiveTestResult}. By default we pass-through
- * data into the underlying write stream, but if a client requests to read it
- * we splice in the written data and then continue streaming incoming data.
- */
-export class LiveOutputController {
-	/** Set on close() to a promise that is resolved once closing is complete */
-	private closed?: Promise<void>;
-	/** Data written so far. This is available until the file closes. */
-	private previouslyWritten: VSBuffer[] | undefined = [];
-
-	private readonly dataEmitter = new Emitter<VSBuffer>();
-	private readonly endEmitter = new Emitter<void>();
-	private _offset = 0;
-
-	/**
-	 * Gets the number of written bytes.
-	 */
-	public get offset() {
-		return this._offset;
-	}
-
-	constructor(
-		private readonly writer: Lazy<[VSBufferWriteableStream, Promise<void>]>,
-		private readonly reader: () => Promise<VSBufferReadableStream>,
-		private readonly rangeReader: (offset: number, length: number) => Promise<VSBuffer>,
-	) { }
-
-	/**
-	 * Appends data to the output.
-	 */
-	public append(data: VSBuffer, marker?: number): { offset: number; done: Promise<void> | void } {
-		if (this.closed) {
-			return { offset: this._offset, done: this.closed };
-		}
-
-		let startOffset = this._offset;
-		if (marker !== undefined) {
-			const start = VSBuffer.fromString(getMarkCode(marker, true));
-			const end = VSBuffer.fromString(getMarkCode(marker, false));
-			startOffset += start.byteLength;
-			data = VSBuffer.concat([start, data, end]);
-		}
-
-		this.previouslyWritten?.push(data);
-		this.dataEmitter.fire(data);
-		this._offset += data.byteLength;
-
-		return { offset: startOffset, done: this.writer.value[0].write(data) };
-	}
-
-	/**
-	 * Reads a range of data from the output.
-	 */
-	public getRange(offset: number, length: number) {
-		if (!this.previouslyWritten) {
-			return this.rangeReader(offset, length);
-		}
-
-		const buffer = VSBuffer.alloc(length);
-		let pos = 0;
-		for (const chunk of this.previouslyWritten) {
-			if (pos + chunk.byteLength < offset) {
-				// no-op
-			} else if (pos > offset + length) {
-				break;
-			} else {
-				const cs = Math.max(0, offset - pos);
-				const bs = Math.max(0, pos - offset);
-				buffer.set(chunk.slice(cs, cs + Math.min(length - bs, chunk.byteLength - cs)), bs);
-			}
-
-			pos += chunk.byteLength;
-		}
-
-		const trailing = (offset + length) - pos;
-		return Promise.resolve(trailing > 0 ? buffer.slice(0, -trailing) : buffer);
-	}
-
-	/**
-	 * Reads the value of the stream.
-	 */
-	public read() {
-		if (!this.previouslyWritten) {
-			return this.reader();
-		}
-
-		const stream = newWriteableBufferStream();
-		for (const chunk of this.previouslyWritten) {
-			stream.write(chunk);
-		}
-
-		const disposable = new DisposableStore();
-		disposable.add(this.dataEmitter.event(d => stream.write(d)));
-		disposable.add(this.endEmitter.event(() => stream.end()));
-		stream.on('end', () => disposable.dispose());
-
-		return Promise.resolve(stream);
-	}
-
-	/**
-	 * Closes the output, signalling no more writes will be made.
-	 * @returns a promise that resolves when the output is written
-	 */
-	public close(): Promise<void> {
-		if (this.closed) {
-			return this.closed;
-		}
-
-		if (!this.writer.hasValue) {
-			this.closed = Promise.resolve();
-		} else {
-			const [stream, ended] = this.writer.value;
-			stream.end();
-			this.closed = ended;
-		}
-
-		this.endEmitter.fire();
-		this.closed.then(() => {
-			this.previouslyWritten = undefined;
-			this.dataEmitter.dispose();
-			this.endEmitter.dispose();
-		});
-
-		return this.closed;
-	}
-}
-
 interface TestResultItemWithChildren extends TestResultItem {
 	/** Children in the run */
 	children: TestResultItemWithChildren[];
@@ -284,6 +242,8 @@ export type TestResultItemChange = { item: TestResultItem; result: ITestResult }
  */
 export class LiveTestResult implements ITestResult {
 	private readonly completeEmitter = new Emitter<void>();
+	private readonly newTaskEmitter = new Emitter<number>();
+	private readonly endTaskEmitter = new Emitter<number>();
 	private readonly changeEmitter = new Emitter<TestResultItemChange>();
 	private readonly testById = new Map<string, TestResultItemWithChildren>();
 	private testMarkerCounter = 0;
@@ -291,7 +251,9 @@ export class LiveTestResult implements ITestResult {
 
 	public readonly onChange = this.changeEmitter.event;
 	public readonly onComplete = this.completeEmitter.event;
-	public readonly tasks: ITestRunTaskResults[] = [];
+	public readonly onNewTask = this.newTaskEmitter.event;
+	public readonly onEndTask = this.endTaskEmitter.event;
+	public readonly tasks: (ITestRunTaskResults & { output: TaskRawOutput })[] = [];
 	public readonly name = localize('runFinished', 'Test run at {0}', new Date().toLocaleString(language));
 
 	/**
@@ -333,7 +295,6 @@ export class LiveTestResult implements ITestResult {
 
 	constructor(
 		public readonly id: string,
-		public readonly output: LiveOutputController,
 		public readonly persist: boolean,
 		public readonly request: ResolvedTestRunRequest,
 	) {
@@ -359,7 +320,10 @@ export class LiveTestResult implements ITestResult {
 			marker = this.testMarkerCounter++;
 		}
 
-		const { offset } = this.output.append(output, marker);
+		const index = this.mustGetTaskIndex(taskId);
+		const task = this.tasks[index];
+
+		const offset = task.output.append(output, marker);
 		const message: ITestOutputMessage = {
 			location,
 			message: removeAnsiEscapeCodes(preview),
@@ -369,12 +333,10 @@ export class LiveTestResult implements ITestResult {
 			type: TestMessageType.Output,
 		};
 
-
-		const index = this.mustGetTaskIndex(taskId);
 		if (testId) {
 			this.testById.get(testId)?.tasks[index].messages.push(message);
 		} else {
-			this.tasks[index].otherMessages.push(message);
+			task.otherMessages.push(message);
 		}
 	}
 
@@ -382,11 +344,13 @@ export class LiveTestResult implements ITestResult {
 	 * Adds a new run task to the results.
 	 */
 	public addTask(task: ITestRunTask) {
-		this.tasks.push({ ...task, coverage: new MutableObservableValue(undefined), otherMessages: [] });
+		this.tasks.push({ ...task, coverage: new MutableObservableValue(undefined), otherMessages: [], output: new TaskRawOutput() });
 
 		for (const test of this.tests) {
 			test.tasks.push({ duration: undefined, messages: [], state: TestResultState.Unset });
 		}
+
+		this.newTaskEmitter.fire(this.tasks.length - 1);
 	}
 
 	/**
@@ -454,29 +418,21 @@ export class LiveTestResult implements ITestResult {
 	}
 
 	/**
-	 * @inheritdoc
-	 */
-	public getOutput() {
-		return this.output.read();
-	}
-
-	/**
-	 * @inheritdoc
-	 */
-	public getOutputRange(offset: number, bytes: number) {
-		return this.output.getRange(offset, bytes);
-	}
-
-	/**
 	 * Marks the task in the test run complete.
 	 */
 	public markTaskComplete(taskId: string) {
-		this.tasks[this.mustGetTaskIndex(taskId)].running = false;
+		const index = this.mustGetTaskIndex(taskId);
+		const task = this.tasks[index];
+		task.running = false;
+		task.output.end();
+
 		this.setAllToState(
 			TestResultState.Unset,
 			taskId,
 			t => t.state === TestResultState.Queued || t.state === TestResultState.Running,
 		);
+
+		this.endTaskEmitter.fire(index);
 	}
 
 	/**
@@ -648,8 +604,6 @@ export class HydratedTestResult implements ITestResult {
 
 	constructor(
 		private readonly serialized: ISerializedTestResults,
-		private readonly outputLoader: () => Promise<VSBufferReadableStream>,
-		private readonly outputRangeLoader: (offset: number, length: number) => Promise<VSBuffer>,
 		private readonly persist = true,
 	) {
 		this.id = serialized.id;
@@ -659,6 +613,7 @@ export class HydratedTestResult implements ITestResult {
 			name: task.name,
 			running: false,
 			coverage: staticObservableValue(undefined),
+			output: emptyRawOutput,
 			otherMessages: []
 		}));
 		this.name = serialized.name;
@@ -674,22 +629,8 @@ export class HydratedTestResult implements ITestResult {
 	/**
 	 * @inheritdoc
 	 */
-	public getOutputRange(offset: number, bytes: number) {
-		return this.outputRangeLoader(offset, bytes);
-	}
-
-	/**
-	 * @inheritdoc
-	 */
 	public getStateById(extTestId: string) {
 		return this.testById.get(extTestId);
-	}
-
-	/**
-	 * @inheritdoc
-	 */
-	public getOutput() {
-		return this.outputLoader();
 	}
 
 	/**

--- a/src/vs/workbench/contrib/testing/common/testResultService.ts
+++ b/src/vs/workbench/contrib/testing/common/testResultService.ts
@@ -133,7 +133,7 @@ export class TestResultService implements ITestResultService {
 	public createLiveResult(req: ResolvedTestRunRequest | ExtensionRunTestsRequest) {
 		if ('targets' in req) {
 			const id = generateUuid();
-			return this.push(new LiveTestResult(id, this.storage.getOutputController(id), true, req));
+			return this.push(new LiveTestResult(id, true, req));
 		}
 
 		let profile: ITestRunProfile | undefined;
@@ -158,7 +158,7 @@ export class TestResultService implements ITestResultService {
 			});
 		}
 
-		return this.push(new LiveTestResult(req.id, this.storage.getOutputController(req.id), req.persist, resolved));
+		return this.push(new LiveTestResult(req.id, req.persist, resolved));
 	}
 
 	/**

--- a/src/vs/workbench/contrib/testing/common/testResultStorage.ts
+++ b/src/vs/workbench/contrib/testing/common/testResultStorage.ts
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { bufferToStream, newWriteableBufferStream, VSBuffer, VSBufferReadableStream, VSBufferWriteableStream } from 'vs/base/common/buffer';
-import { Lazy } from 'vs/base/common/lazy';
 import { isDefined } from 'vs/base/common/types';
 import { URI } from 'vs/base/common/uri';
 import { IEnvironmentService } from 'vs/platform/environment/common/environment';
@@ -14,8 +13,8 @@ import { ILogService } from 'vs/platform/log/common/log';
 import { IStorageService, StorageScope, StorageTarget } from 'vs/platform/storage/common/storage';
 import { IWorkspaceContextService } from 'vs/platform/workspace/common/workspace';
 import { StoredValue } from 'vs/workbench/contrib/testing/common/storedValue';
+import { HydratedTestResult, ITestResult } from 'vs/workbench/contrib/testing/common/testResult';
 import { ISerializedTestResults } from 'vs/workbench/contrib/testing/common/testTypes';
-import { HydratedTestResult, ITestResult, LiveOutputController, LiveTestResult } from 'vs/workbench/contrib/testing/common/testResult';
 
 export const RETAIN_MAX_RESULTS = 128;
 const RETAIN_MIN_RESULTS = 16;
@@ -34,11 +33,6 @@ export interface ITestResultStorage {
 	 * Persists the list of test results.
 	 */
 	persist(results: ReadonlyArray<ITestResult>): Promise<void>;
-
-	/**
-	 * Gets the output controller for a new or existing test result.
-	 */
-	getOutputController(resultId: string): LiveOutputController;
 }
 
 export const ITestResultStorage = createDecorator('ITestResultStorage');
@@ -80,7 +74,7 @@ export abstract class BaseTestResultStorage implements ITestResultStorage {
 					return undefined;
 				}
 
-				return new HydratedTestResult(contents, () => this.readOutputForResultId(id), (o, l) => this.readOutputRangeForResultId(id, o, l));
+				return new HydratedTestResult(contents);
 			} catch (e) {
 				this.logService.warn(`Error deserializing stored test result ${id}`, e);
 				return undefined;
@@ -88,21 +82,6 @@ export abstract class BaseTestResultStorage implements ITestResultStorage {
 		}));
 
 		return results.filter(isDefined);
-	}
-
-	/**
-	 * @override
-	 */
-	public getOutputController(resultId: string) {
-		return new LiveOutputController(
-			new Lazy(() => {
-				const stream = newWriteableBufferStream();
-				const promise = this.storeOutputForResultId(resultId, stream);
-				return [stream, promise];
-			}),
-			() => this.readOutputForResultId(resultId),
-			(o, l) => this.readOutputRangeForResultId(resultId, o, l)
-		);
 	}
 
 	/**
@@ -150,10 +129,6 @@ export abstract class BaseTestResultStorage implements ITestResultStorage {
 			todo.push(this.storeForResultId(result.id, obj));
 			toStore.push({ id: result.id, rev: currentRevision, bytes: contents.byteLength });
 			budget -= contents.byteLength;
-
-			if (result instanceof LiveTestResult && result.completedAt !== undefined) {
-				todo.push(result.output.close());
-			}
 		}
 
 		for (const id of toDelete.keys()) {

--- a/src/vs/workbench/contrib/testing/common/testingStates.ts
+++ b/src/vs/workbench/contrib/testing/common/testingStates.ts
@@ -18,8 +18,8 @@ export const statePriority: { [K in TestResultState]: number } = {
 	[TestResultState.Failed]: 4,
 	[TestResultState.Queued]: 3,
 	[TestResultState.Passed]: 2,
-	[TestResultState.Unset]: 1,
-	[TestResultState.Skipped]: 0,
+	[TestResultState.Unset]: 0,
+	[TestResultState.Skipped]: 1,
 };
 
 export const isFailedState = (s: TestResultState) => s === TestResultState.Errored || s === TestResultState.Failed;

--- a/src/vs/workbench/contrib/testing/common/testingUri.ts
+++ b/src/vs/workbench/contrib/testing/common/testingUri.ts
@@ -9,15 +9,16 @@ import { URI } from 'vs/base/common/uri';
 export const TEST_DATA_SCHEME = 'vscode-test-data';
 
 export const enum TestUriType {
-	AllOutput,
+	TaskOutput,
 	ResultMessage,
 	ResultActualOutput,
 	ResultExpectedOutput,
 }
 
 interface IAllOutputReference {
-	type: TestUriType.AllOutput;
+	type: TestUriType.TaskOutput;
 	resultId: string;
+	taskIndex: number;
 }
 
 interface IResultTestUri {
@@ -73,18 +74,18 @@ export const parseTestUri = (uri: URI): ParsedTestUri | undefined => {
 	}
 
 	if (request[0] === TestUriParts.AllOutput) {
-		return { resultId: locationId, type: TestUriType.AllOutput };
+		return { resultId: locationId, taskIndex: Number(request[1]), type: TestUriType.TaskOutput };
 	}
 
 	return undefined;
 };
 
 export const buildTestUri = (parsed: ParsedTestUri): URI => {
-	if (parsed.type === TestUriType.AllOutput) {
+	if (parsed.type === TestUriType.TaskOutput) {
 		return URI.from({
 			scheme: TEST_DATA_SCHEME,
 			authority: TestUriParts.Results,
-			path: ['', parsed.resultId, TestUriParts.AllOutput].join('/'),
+			path: ['', parsed.resultId, TestUriParts.AllOutput, parsed.taskIndex].join('/'),
 		});
 	}
 

--- a/src/vs/workbench/contrib/testing/test/common/testResultStorage.test.ts
+++ b/src/vs/workbench/contrib/testing/test/common/testResultStorage.test.ts
@@ -8,7 +8,6 @@ import { range } from 'vs/base/common/arrays';
 import { NullLogService } from 'vs/platform/log/common/log';
 import { ITestResult, LiveTestResult } from 'vs/workbench/contrib/testing/common/testResult';
 import { InMemoryResultStorage, RETAIN_MAX_RESULTS } from 'vs/workbench/contrib/testing/common/testResultStorage';
-import { emptyOutputController } from 'vs/workbench/contrib/testing/test/common/testResultService.test';
 import { testStubs } from 'vs/workbench/contrib/testing/test/common/testStubs';
 import { TestStorageService } from 'vs/workbench/test/common/workbenchTestServices';
 
@@ -18,7 +17,6 @@ suite('Workbench - Test Result Storage', () => {
 	const makeResult = (taskName = 't') => {
 		const t = new LiveTestResult(
 			'',
-			emptyOutputController(),
 			true,
 			{ targets: [] }
 		);


### PR DESCRIPTION
Previously, test output was handled for an entire TestRunRequest into
a single stream. This didn't match what the public API implied, nor what
the real intentions were.

This makes output be stored correctly on a per-test run (called "tasks"
internally). It changes the order of the Test Results view so that tests
nested under their task, and also improves some of the tree handling
there to update nodes more specifically.

Clicking on the "terminal" button in the test view continues to show
output from the last test run request, but if there were multiple tasks,
the user is asked to choose which they want to view output for.

Finally I removed some old unused code that dealt with storing test
results on disk, which we no longer do, and moved to a simpler interface
instead.

Fixes #180041

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
