### PR TITLE
testing: avoid including individual children in run at cursor if their parent is already included

### DIFF
--- a/src/vs/workbench/contrib/testing/browser/testExplorerActions.ts
+++ b/src/vs/workbench/contrib/testing/browser/testExplorerActions.ts
@@ -34,6 +34,7 @@ import { TestingExplorerView } from 'vs/workbench/contrib/testing/browser/testin
 import { ITestingOutputTerminalService } from 'vs/workbench/contrib/testing/browser/testingOutputTerminalService';
 import { TestingConfigKeys, getTestingConfiguration } from 'vs/workbench/contrib/testing/common/configuration';
 import { TestCommandId, TestExplorerViewMode, TestExplorerViewSorting, Testing, testConfigurationGroupNames } from 'vs/workbench/contrib/testing/common/constants';
+import { TestId } from 'vs/workbench/contrib/testing/common/testId';
 import { ITestProfileService, canUseProfileWithTest } from 'vs/workbench/contrib/testing/common/testProfileService';
 import { ITestResult } from 'vs/workbench/contrib/testing/common/testResult';
 import { ITestResultService } from 'vs/workbench/contrib/testing/common/testResultService';
@@ -1018,7 +1019,10 @@ abstract class ExecuteTestAtCursor extends Action2 {
 				const irange = Range.lift(test.item.range);
 				if (irange.containsPosition(position)) {
 					if (bestRange && Range.equalsRange(test.item.range, bestRange)) {
-						bestNodes.push(test);
+						// check that a parent isn't already included (#180760)
+						if (!bestNodes.some(b => TestId.isChild(b.item.extId, test.item.extId))) {
+							bestNodes.push(test);
+						}
 					} else {
 						bestRange = irange;
 						bestNodes = [test];
@@ -1027,7 +1031,7 @@ abstract class ExecuteTestAtCursor extends Action2 {
 					if (!bestRangeBefore || bestRangeBefore.getStartPosition().isBefore(irange.getStartPosition())) {
 						bestRangeBefore = irange;
 						bestNodesBefore = [test];
-					} else if (irange.equalsRange(bestRangeBefore)) {
+					} else if (irange.equalsRange(bestRangeBefore) && !bestNodesBefore.some(b => TestId.isChild(b.item.extId, test.item.extId))) {
 						bestNodesBefore.push(test);
 					}
 				}

--- a/src/vs/workbench/contrib/testing/common/testId.ts
+++ b/src/vs/workbench/contrib/testing/common/testId.ts
@@ -101,6 +101,13 @@ export class TestId {
 	}
 
 	/**
+	 * Gets whether maybeChild is a child of maybeParent.
+	 */
+	public static isChild(maybeParent: string, maybeChild: string) {
+		return maybeChild.startsWith(maybeParent) && maybeChild[maybeParent.length] === TestIdPathParts.Delimiter;
+	}
+
+	/**
 	 * Compares the position of the two ID strings.
 	 */
 	public static compare(a: string, b: string) {
@@ -108,11 +115,11 @@ export class TestId {
 			return TestPosition.IsSame;
 		}
 
-		if (b.startsWith(a + TestIdPathParts.Delimiter)) {
+		if (TestId.isChild(a, b)) {
 			return TestPosition.IsChild;
 		}
 
-		if (a.startsWith(b + TestIdPathParts.Delimiter)) {
+		if (TestId.isChild(b, a)) {
 			return TestPosition.IsParent;
 		}
 


### PR DESCRIPTION
For microsoft/vscode-python#21151

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
