### PR TITLE
remove nb.codeactiononsave setting, add `nb.experimental` to command ID

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/contrib/saveParticipants/saveParticipants.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/saveParticipants/saveParticipants.ts
@@ -104,7 +104,7 @@ class CodeActionOnSaveParticipant implements IStoredFileWorkingCopySaveParticipa
 			return undefined;
 		}
 
-		const setting = this.configurationService.getValue<{ [kind: string]: boolean } | string[]>('notebook.codeActionsOnSave');
+		const setting = this.configurationService.getValue<{ [kind: string]: boolean } | string[]>('notebook.experimental.codeActionsOnSave');
 		if (!setting) {
 			return undefined;
 		}

--- a/src/vs/workbench/contrib/notebook/browser/notebook.contribution.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebook.contribution.ts
@@ -920,15 +920,15 @@ configurationRegistry.registerConfiguration({
 			tags: ['notebookLayout'],
 			default: false
 		},
-		[NotebookSetting.codeActionsOnSave]: {
-			markdownDescription: nls.localize('notebook.codeActionsOnSave', "Experimental. Run a series of CodeActions for a notebook on save. CodeActions must be specified, the file must not be saved after delay, and the editor must not be shutting down. Example: `notebook.format: true`"),
-			type: 'object',
-			additionalProperties: {
-				type: 'boolean'
-			},
-			tags: ['notebookLayout'],
-			default: {}
-		},
+		// [NotebookSetting.codeActionsOnSave]: {
+		// 	markdownDescription: nls.localize('notebook.codeActionsOnSave', "Experimental. Run a series of CodeActions for a notebook on save. CodeActions must be specified, the file must not be saved after delay, and the editor must not be shutting down. Example: `notebook.format: true`"),
+		// 	type: 'object',
+		// 	additionalProperties: {
+		// 		type: 'boolean'
+		// 	},
+		// 	tags: ['notebookLayout'],
+		// 	default: {}
+		// },
 		[NotebookSetting.confirmDeleteRunningCell]: {
 			markdownDescription: nls.localize('notebook.confirmDeleteRunningCell', "Control whether a confirmation prompt is required to delete a running cell."),
 			type: 'boolean',

--- a/src/vs/workbench/contrib/notebook/common/notebookCommon.ts
+++ b/src/vs/workbench/contrib/notebook/common/notebookCommon.ts
@@ -937,7 +937,7 @@ export const NotebookSetting = {
 	outputScrolling: 'notebook.output.scrolling',
 	textOutputLineLimit: 'notebook.output.textLineLimit',
 	formatOnSave: 'notebook.formatOnSave.enabled',
-	codeActionsOnSave: 'notebook.codeActionsOnSave',
+	codeActionsOnSave: 'notebook.experimental.codeActionsOnSave',
 	outputWordWrap: 'notebook.output.wordWrap',
 	outputLineHeightDeprecated: 'notebook.outputLineHeight',
 	outputLineHeight: 'notebook.output.lineHeight',


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Re: #180839, #180846, #180765

Remove the setting until CodeActions are properly supported. 

Change setting from `notebook.codeActionsOnSave` --> `notebook.experimental.codeActionsOnSave`