### PR TITLE
Fix enumItem labels

### DIFF
--- a/extensions/typescript-language-features/package.json
+++ b/extensions/typescript-language-features/package.json
@@ -920,9 +920,9 @@
             "js"
           ],
           "enumItemLabels": [
-            "%typescript.preferences.importModuleSpecifierEnding.label.auto%",
-            "%typescript.preferences.importModuleSpecifierEnding.label.minimal%",
-            "%typescript.preferences.importModuleSpecifierEnding.label.index%",
+            null,
+            null,
+            null,
             "%typescript.preferences.importModuleSpecifierEnding.label.js%"
           ],
           "markdownEnumDescriptions": [


### PR DESCRIPTION
`javascript.preferences.importModuleSpecifierEnding` and `typescript.preferences.importModuleSpecifierEnding` got out of sync here

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
