### PR TITLE
Fix #180797. Fine tune edit mode switch.

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/contrib/find/findModel.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/find/findModel.ts
@@ -155,9 +155,6 @@ export class FindModel extends Disposable {
 			}
 		};
 
-		if (this._state.replaceString.length === 0) {
-			return;
-		}
 
 		if (e.isReplaceRevealed) {
 			updateEditingState();


### PR DESCRIPTION
Switch editing state on type turned out to be a surprise. Let's use the replace button toggle as the hint.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
