### PR TITLE
joh/universal pig

### DIFF
--- a/src/vs/workbench/contrib/interactiveEditor/browser/interactiveEditorController.ts
+++ b/src/vs/workbench/contrib/interactiveEditor/browser/interactiveEditorController.ts
@@ -613,7 +613,7 @@ export class InteractiveEditorController implements IEditorContribution {
 			} else {
 				// make edits more minimal
 
-				const moreMinimalEdits = (await this._editorWorkerService.computeMoreMinimalEdits(textModel.uri, editResponse.localEdits));
+				const moreMinimalEdits = (await this._editorWorkerService.computeHumanReadableDiff(textModel.uri, editResponse.localEdits));
 				const editOperations = (moreMinimalEdits ?? editResponse.localEdits).map(edit => EditOperation.replace(Range.lift(edit.range), edit.text));
 				this._logService.trace('[IE] edits from PROVIDER and after making them MORE MINIMAL', provider.debugName, editResponse.localEdits, moreMinimalEdits);
 

--- a/src/vs/workbench/contrib/interactiveEditor/browser/interactiveEditorDiffWidget.ts
+++ b/src/vs/workbench/contrib/interactiveEditor/browser/interactiveEditorDiffWidget.ts
@@ -116,7 +116,15 @@ export class InteractiveEditorDiffWidget extends ZoneWidget {
 
 		this._sessionStore.add(this._diffEditor.onDidUpdateDiff(() => {
 			const result = this._diffEditor.getDiffComputationResult();
+			const hasFocus = this._diffEditor.hasTextFocus();
 			this._doShowForChanges(range(), result?.changes2 ?? []);
+			// TODO@jrieken find a better fix for this. this is the challenge:
+			// the _doShowForChanges method invokes show of the zone widget which removes and adds the
+			// zone and overlay parts. this dettaches and reattaches the dom nodes which means they lose
+			// focus
+			if (hasFocus) {
+				this._diffEditor.focus();
+			}
 		}));
 		this._doShowForChanges(range(), changes);
 	}

--- a/src/vs/workbench/contrib/interactiveEditor/browser/interactiveEditorWidget.ts
+++ b/src/vs/workbench/contrib/interactiveEditor/browser/interactiveEditorWidget.ts
@@ -66,6 +66,8 @@ const _inputEditorOptions: IEditorConstructionOptions = {
 	guides: { indentation: false },
 	rulers: [],
 	cursorWidth: 1,
+	cursorStyle: 'line',
+	cursorBlinking: 'blink',
 	wrappingStrategy: 'advanced',
 	wrappingIndent: 'none',
 	renderWhitespace: 'none',


### PR DESCRIPTION
- more cursor overrides: style and blinking
- make sure to restore diff editor focus after repositioning the zone widget
- back to `computeHumanReadableDiff` diff
