### PR TITLE
Use a colon instead of quotes to handle long queries better

### DIFF
--- a/src/vs/workbench/contrib/quickaccess/browser/commandsQuickAccess.ts
+++ b/src/vs/workbench/contrib/quickaccess/browser/commandsQuickAccess.ts
@@ -84,7 +84,7 @@ export class CommandsQuickAccessProvider extends AbstractEditorCommandsQuickAcce
 				const info = this.interactiveSessionService.getProviderInfos()[0];
 				return info
 					? {
-						label: localize('askXInInteractiveSession', "Ask {0} '{1}'", info.displayName, filter),
+						label: localize('askXInInteractiveSession', "Ask {0}: {1}", info.displayName, filter),
 						commandId: AskInInteractiveAction.ID,
 						accept: () => commandService.executeCommand(AskInInteractiveAction.ID, filter)
 					}


### PR DESCRIPTION
Fixes this:
![image](https://user-images.githubusercontent.com/2644648/234707568-f1c6fd26-eb15-4a16-801c-e8a1375bdb98.png)


Fixes https://github.com/microsoft/vscode-internalbacklog/issues/4021

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
