### PR TITLE
don't cache audio cues

### DIFF
--- a/src/vs/platform/audioCues/browser/audioCueService.ts
+++ b/src/vs/platform/audioCues/browser/audioCueService.ts
@@ -26,7 +26,6 @@ export interface IAudioCueService {
 
 export class AudioCueService extends Disposable implements IAudioCueService {
 	readonly _serviceBrand: undefined;
-	sounds: Map<string, HTMLAudioElement> = new Map();
 	private readonly screenReaderAttached = observableFromEvent(
 		this.accessibilityService.onDidChangeScreenReaderOptimized,
 		() => /** @description accessibilityService.onDidChangeScreenReaderOptimized */ this.accessibilityService.isScreenReaderOptimized()
@@ -71,14 +70,7 @@ export class AudioCueService extends Disposable implements IAudioCueService {
 		const url = FileAccess.asBrowserUri(`vs/platform/audioCues/browser/media/${sound.fileName}`).toString(true);
 
 		try {
-			const sound = this.sounds.get(url);
-			if (sound) {
-				sound.volume = this.getVolumeInPercent() / 100;
-				await sound.play();
-			} else {
-				const playedSound = await playAudio(url, this.getVolumeInPercent() / 100);
-				this.sounds.set(url, playedSound);
-			}
+			await playAudio(url, this.getVolumeInPercent() / 100);
 		} catch (e) {
 			console.error('Error while playing sound', e);
 		} finally {

--- a/src/vs/workbench/contrib/scm/browser/dirtydiffDecorator.ts
+++ b/src/vs/workbench/contrib/scm/browser/dirtydiffDecorator.ts
@@ -600,8 +600,13 @@ export class GotoPreviousChangeAction extends EditorAction {
 
 		const index = model.findPreviousClosestChange(lineNumber, false);
 		const change = model.changes[index];
-		await playAudioCueForChange(change.change, audioCueService);
-		setPositionAndSelection(change.change, outerEditor, accessibilityService, codeEditorService);
+		if (audioCueService.isEnabled(AudioCue.diffLineDeleted) || audioCueService.isEnabled(AudioCue.diffLineInserted) || audioCueService.isEnabled(AudioCue.diffLineModified)) {
+			await playAudioCueForChange(change.change, audioCueService);
+			// The audio cue can take up to a second to load. Give it a chance to play before we read the line content
+			await setTimeout(() => setPositionAndSelection(change.change, outerEditor, accessibilityService, codeEditorService), 500);
+		} else {
+			setPositionAndSelection(change.change, outerEditor, accessibilityService, codeEditorService);
+		}
 	}
 }
 registerEditorAction(GotoPreviousChangeAction);

--- a/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
+++ b/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
@@ -725,7 +725,7 @@ export abstract class AbstractTaskService extends Disposable implements ITaskSer
 		});
 	}
 
-	public async getTask(folder: IWorkspace | IWorkspaceFolder | string, identifier: string | ITaskIdentifier, compareId: boolean = false, type: string | undefined = undefined): Promise<Task | undefined> {
+	public async getTask(folder: IWorkspace | IWorkspaceFolder | string, identifier: string | ITaskIdentifier, compareId: boolean = false): Promise<Task | undefined> {
 		if (!(await this._trust())) {
 			return;
 		}
@@ -762,7 +762,7 @@ export abstract class AbstractTaskService extends Disposable implements ITaskSer
 		}
 
 		// We didn't find the task, so we need to ask all resolvers about it
-		const map = await this._getGroupedTasks({ type });
+		const map = await this._getGroupedTasks();
 		let values = map.get(folder);
 		values = values.concat(map.get(USER_TASKS_GROUP_KEY));
 
@@ -1842,12 +1842,11 @@ export abstract class AbstractTaskService extends Disposable implements ITaskSer
 			await this._updateWorkspaceTasks();
 			const taskFolder = task.getWorkspaceFolder();
 			const taskIdentifier = task.configurationProperties.identifier;
-			const taskType = CustomTask.is(task) ? task.customizes()?.type : (ContributedTask.is(task) ? task.type : undefined);
 			// Since we save before running tasks, the task may have changed as part of the save.
 			// However, if the TaskRunSource is not User, then we shouldn't try to fetch the task again
 			// since this can cause a new'd task to get overwritten with a provided task.
 			taskToRun = ((taskFolder && taskIdentifier && (runSource === TaskRunSource.User))
-				? await this.getTask(taskFolder, taskIdentifier, false, taskType) : task) ?? task;
+				? await this.getTask(taskFolder, taskIdentifier) : task) ?? task;
 		}
 		await ProblemMatcherRegistry.onReady();
 		const executeResult = runSource === TaskRunSource.Reconnect ? this._getTaskSystem().reconnect(taskToRun, resolver) : this._getTaskSystem().run(taskToRun, resolver);


### PR DESCRIPTION
caching prevents the audio cues from playing sometimes and it's not clear why / there are no errors. We know there's an issue with playing media that is not initiated via user gesture. Perhaps that's what's going on.

fixes #175014