### PR TITLE
for cached audio cues, reset `currentTime` to 0

### DIFF
--- a/src/vs/platform/audioCues/browser/audioCueService.ts
+++ b/src/vs/platform/audioCues/browser/audioCueService.ts
@@ -74,6 +74,7 @@ export class AudioCueService extends Disposable implements IAudioCueService {
 			const sound = this.sounds.get(url);
 			if (sound) {
 				sound.volume = this.getVolumeInPercent() / 100;
+				sound.currentTime = 0;
 				await sound.play();
 			} else {
 				const playedSound = await playAudio(url, this.getVolumeInPercent() / 100);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
fix #175014

Before:

https://user-images.githubusercontent.com/29464607/234974424-997ad526-7976-46cd-8f88-ceef4f2ab31c.mov

After:

https://user-images.githubusercontent.com/29464607/234974887-bd2140a2-9f09-453e-a1ba-db47ccdb6658.mov



