### PR TITLE
fix tab order for hidden status element when a message shows

### DIFF
--- a/src/vs/workbench/contrib/interactiveEditor/browser/interactiveEditor.css
+++ b/src/vs/workbench/contrib/interactiveEditor/browser/interactiveEditor.css
@@ -106,6 +106,10 @@
 	margin-left: auto;
 }
 
+.monaco-editor .interactive-editor .status .label.hidden {
+	display: none;
+}
+
 .monaco-editor .interactive-editor .markdownMessage {
 	padding-top: 10px;
 }

--- a/src/vs/workbench/contrib/interactiveEditor/browser/interactiveEditorController.ts
+++ b/src/vs/workbench/contrib/interactiveEditor/browser/interactiveEditorController.ts
@@ -569,6 +569,7 @@ export class InteractiveEditorController implements IEditorContribution {
 				this._messageReply = reply.message.value;
 				this._requestPrompt = request.prompt;
 				const renderedMarkdown = renderMarkdown(reply.message, { inline: true });
+				this._zone.widget.updateStatus('');
 				this._zone.widget.updateMarkdownMessage(renderedMarkdown.element);
 				this._currentSession.addResponse(reply);
 				continue;

--- a/src/vs/workbench/contrib/interactiveEditor/browser/interactiveEditorWidget.ts
+++ b/src/vs/workbench/contrib/interactiveEditor/browser/interactiveEditorWidget.ts
@@ -120,7 +120,7 @@ class InteractiveEditorWidget {
 			h('div.previewCreate.hidden@previewCreate'),
 			h('div.status@status', [
 				h('div.actions.hidden@statusToolbar'),
-				h('div.label@statusLabel')
+				h('div.label.hidden@statusLabel')
 			]),
 			h('div.markdownMessage.hidden@markdownMessage', [
 				h('div.message@message'),
@@ -377,7 +377,6 @@ class InteractiveEditorWidget {
 
 	updateMarkdownMessage(message: Node) {
 		reset(this._elements.message, message);
-		this._elements.statusLabel.innerText = '';
 		this._elements.markdownMessage.classList.toggle('hidden', false);
 		this._onDidChangeHeight.fire();
 	}
@@ -393,9 +392,9 @@ class InteractiveEditorWidget {
 		} else if (!isTempMessage && !ops.keepMessage) {
 			this._elements.markdownMessage.classList.toggle('hidden', true);
 		}
-		this._elements.status.classList.toggle('hidden', false);
 		reset(this._elements.statusLabel, message);
 		this._elements.statusLabel.className = `label ${(ops.classes ?? []).join(' ')}`;
+		this._elements.statusLabel.classList.toggle('hidden', !message);
 		if (isTempMessage) {
 			this._elements.statusLabel.dataset['state'] = 'temp';
 		} else {
@@ -407,6 +406,7 @@ class InteractiveEditorWidget {
 	reset() {
 		this._ctxInputEmpty.reset();
 		reset(this._elements.statusLabel);
+		this._elements.statusLabel.classList.toggle('hidden', true);
 		this._elements.statusToolbar.classList.add('hidden');
 		this.hideCreatePreview();
 		this.hideEditsPreview();


### PR DESCRIPTION
fixes https://github.com/microsoft/vscode-internalbacklog/issues/4039

Edit by @meganrogge
Before:

https://user-images.githubusercontent.com/29464607/234972689-8442d652-a54e-41de-b3c4-b2045a42face.mov

After:

https://user-images.githubusercontent.com/29464607/234972881-98c14b1a-72f4-4c5b-92f1-5af6d50c1ab0.mov


