### PR TITLE
Move opening default built-in walkthrough to after built-in walkthrough initialization

### DIFF
--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts
@@ -242,7 +242,28 @@ export class GettingStartedPage extends EditorPane {
 			}
 		}));
 
-		this._register(this.gettingStartedService.onDidAddBuiltInWalkthrough(rerender));
+		this._register(this.gettingStartedService.onDidAddBuiltInWalkthrough(() => {
+			rerender();
+			const someStepsComplete = this.gettingStartedCategories.some(category => category.steps.find(s => s.done));
+			if (!this.productService.openToWelcomeMainPage && !someStepsComplete && !this.hasScrolledToFirstCategory) {
+				const firstSessionDateString = this.storageService.get(firstSessionDateStorageKey, StorageScope.APPLICATION) || new Date().toUTCString();
+				const daysSinceFirstSession = ((+new Date()) - (+new Date(firstSessionDateString))) / 1000 / 60 / 60 / 24;
+				const fistContentBehaviour = daysSinceFirstSession < 1 ? 'openToFirstCategory' : 'index';
+
+				if (fistContentBehaviour === 'openToFirstCategory') {
+					const first = this.gettingStartedCategories.filter(c => !c.when || this.contextService.contextMatchesRules(c.when))[0];
+					this.hasScrolledToFirstCategory = true;
+					if (first) {
+						this.currentWalkthrough = first;
+						this.editorInput.selectedCategory = this.currentWalkthrough?.id;
+						this.buildCategorySlide(this.editorInput.selectedCategory, undefined);
+						this.setSlide('details');
+						return;
+					}
+				}
+			}
+		}));
+
 		this._register(this.gettingStartedService.onDidAddWalkthrough(rerender));
 		this._register(this.gettingStartedService.onDidRemoveWalkthrough(rerender));
 
@@ -872,29 +893,11 @@ export class GettingStartedPage extends EditorPane {
 			}
 		}
 
-		const someStepsComplete = this.gettingStartedCategories.some(category => category.steps.find(s => s.done));
 		if (this.editorInput.showTelemetryNotice && this.productService.openToWelcomeMainPage) {
 			const telemetryNotice = $('p.telemetry-notice');
 			this.buildTelemetryFooter(telemetryNotice);
 			footer.appendChild(telemetryNotice);
-		} else if (!this.productService.openToWelcomeMainPage && !someStepsComplete && !this.hasScrolledToFirstCategory) {
-			const firstSessionDateString = this.storageService.get(firstSessionDateStorageKey, StorageScope.APPLICATION) || new Date().toUTCString();
-			const daysSinceFirstSession = ((+new Date()) - (+new Date(firstSessionDateString))) / 1000 / 60 / 60 / 24;
-			const fistContentBehaviour = daysSinceFirstSession < 1 ? 'openToFirstCategory' : 'index';
-
-			if (fistContentBehaviour === 'openToFirstCategory') {
-				const first = this.gettingStartedCategories.filter(c => !c.when || this.contextService.contextMatchesRules(c.when))[0];
-				this.hasScrolledToFirstCategory = true;
-				if (first) {
-					this.currentWalkthrough = first;
-					this.editorInput.selectedCategory = this.currentWalkthrough?.id;
-					this.buildCategorySlide(this.editorInput.selectedCategory, undefined);
-					this.setSlide('details');
-					return;
-				}
-			}
 		}
-
 		this.setSlide('categories');
 	}
 


### PR DESCRIPTION
Fixes: https://github.com/microsoft/vscode/issues/181063

**The issue affects new user experience**

**Issue:**

The built-in walkthrough registration was recently changed to be asynchronous with https://github.com/microsoft/vscode/commit/06dbbfa9355666d4c36a19bfb3f88a20ec99d40b#diff-ef0653ae93121f64b9d756dff8460099cba11fc175134d2ff193b671fe3f9003
This causes a timing issue with the check for opening the Setup walkthrough occurring before the built-in walkthroughs have finished resolving.

**Fix :**
Moved up the code to check/open the Setup walkthrough into the event handler `onDidAddBuiltInWalkthrough`. (Ideally, we would change up the [gettingStartedService ](https://github.com/microsoft/vscode/blob/15cb6b36f8c29df77133b422d46b64e4d508488f/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStartedService.ts#LL94C1-L112C42)to be async but that is a larger fix I do not wish to make currently).