### PR TITLE
Set glyph margin decoration width appropriately

### DIFF
--- a/src/vs/editor/browser/viewParts/glyphMargin/glyphMargin.ts
+++ b/src/vs/editor/browser/viewParts/glyphMargin/glyphMargin.ts
@@ -212,7 +212,7 @@ export class GlyphMarginOverlay extends DedupOverlay {
 		const toRender = this._render(visibleStartLineNumber, visibleEndLineNumber, decorationsToRender, this._glyphMarginDecorationLaneCount);
 
 		const lineHeight = this._lineHeight.toString();
-		const width = this._glyphMarginWidth.toString();
+		const width = (Math.round(this._glyphMarginWidth / this._glyphMarginDecorationLaneCount)).toString();
 		const common = '" style="width:' + width + 'px' + ';height:' + lineHeight + 'px;';
 
 		const output: string[] = [];


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/180834

Before: 
![image](https://user-images.githubusercontent.com/30305945/234995138-5031513e-5e9c-490b-b29d-a6085b6f9106.png)
After: 
![image](https://user-images.githubusercontent.com/30305945/234995150-9e10185d-be48-4f66-b40d-e2d7fdadce30.png)
