### PR TITLE
When snippet mode is active, make `Tab` not accept suggestion but advance placeholder

### DIFF
--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -4118,10 +4118,6 @@ export interface ISuggestOptions {
 	 */
 	filterGraceful?: boolean;
 	/**
-	 * Prevent quick suggestions when a snippet is active. Defaults to true.
-	 */
-	snippetsPreventQuickSuggestions?: boolean;
-	/**
 	 * Favors words that appear close to the cursor.
 	 */
 	localityBonus?: boolean;
@@ -4282,7 +4278,6 @@ class EditorSuggest extends BaseEditorOption<EditorOption.suggest, ISuggestOptio
 		const defaults: InternalSuggestOptions = {
 			insertMode: 'insert',
 			filterGraceful: true,
-			snippetsPreventQuickSuggestions: true,
 			localityBonus: false,
 			shareSuggestSelections: false,
 			selectionMode: 'always',
@@ -4360,11 +4355,6 @@ class EditorSuggest extends BaseEditorOption<EditorOption.suggest, ISuggestOptio
 					],
 					default: defaults.selectionMode,
 					markdownDescription: nls.localize('suggest.selectionMode', "Controls whether a suggestion is selected when the widget shows. Note that this only applies to automatically triggered suggestions (`#editor.quickSuggestions#` and `#editor.suggestOnTriggerCharacters#`) and that a suggestion is always selected when explicitly invoked, e.g via `Ctrl+Space`.")
-				},
-				'editor.suggest.snippetsPreventQuickSuggestions': {
-					type: 'boolean',
-					default: defaults.snippetsPreventQuickSuggestions,
-					description: nls.localize('suggest.snippetsPreventQuickSuggestions', "Controls whether an active snippet prevents quick suggestions.")
 				},
 				'editor.suggest.showIcons': {
 					type: 'boolean',
@@ -4556,7 +4546,6 @@ class EditorSuggest extends BaseEditorOption<EditorOption.suggest, ISuggestOptio
 		return {
 			insertMode: stringSet(input.insertMode, this.defaultValue.insertMode, ['insert', 'replace']),
 			filterGraceful: boolean(input.filterGraceful, this.defaultValue.filterGraceful),
-			snippetsPreventQuickSuggestions: boolean(input.snippetsPreventQuickSuggestions, this.defaultValue.filterGraceful),
 			localityBonus: boolean(input.localityBonus, this.defaultValue.localityBonus),
 			shareSuggestSelections: boolean(input.shareSuggestSelections, this.defaultValue.shareSuggestSelections),
 			selectionMode: stringSet(input.selectionMode, this.defaultValue.selectionMode, ['always', 'never', 'whenQuickSuggestion', 'whenTriggerCharacter']),

--- a/src/vs/editor/contrib/suggest/browser/suggestController.ts
+++ b/src/vs/editor/contrib/suggest/browser/suggestController.ts
@@ -249,11 +249,7 @@ export class SuggestController implements IEditorContribution {
 				// don't "focus" item when configured to do so or when in snippet mode (and configured to do so)
 				const options = this.editor.getOption(EditorOption.suggest);
 
-				if (options.snippetsPreventQuickSuggestions && SnippetController2.get(this.editor)?.isInSnippet()) {
-					// SPECIAL: in snippet mode, we never focus unless the user wants to
-					noFocus = true;
-
-				} else if (options.selectionMode === 'never' || options.selectionMode === 'always') {
+				if (options.selectionMode === 'never' || options.selectionMode === 'always') {
 					// simple: always or never
 					noFocus = options.selectionMode === 'never';
 
@@ -775,7 +771,7 @@ registerEditorCommand(new SuggestCommand({
 	kbOpts: [{
 		// normal tab
 		primary: KeyCode.Tab,
-		kbExpr: ContextKeyExpr.and(SuggestContext.Visible, EditorContextKeys.textInputFocus),
+		kbExpr: ContextKeyExpr.and(SuggestContext.Visible, EditorContextKeys.textInputFocus, SnippetController2.InSnippetMode.toNegated()),
 		weight,
 	}, {
 		// accept on enter has special rules
@@ -809,7 +805,7 @@ registerEditorCommand(new SuggestCommand({
 	precondition: ContextKeyExpr.and(SuggestContext.Visible, EditorContextKeys.textInputFocus, SuggestContext.HasFocusedSuggestion),
 	kbOpts: {
 		weight: weight,
-		kbExpr: EditorContextKeys.textInputFocus,
+		kbExpr: ContextKeyExpr.and(EditorContextKeys.textInputFocus, SnippetController2.InSnippetMode.toNegated()),
 		primary: KeyMod.Shift | KeyCode.Enter,
 		secondary: [KeyMod.Shift | KeyCode.Tab],
 	},

--- a/src/vs/editor/contrib/suggest/test/browser/completionModel.test.ts
+++ b/src/vs/editor/contrib/suggest/test/browser/completionModel.test.ts
@@ -35,7 +35,6 @@ suite('CompletionModel', function () {
 
 	const defaultOptions = <InternalSuggestOptions>{
 		insertMode: 'insert',
-		snippetsPreventQuickSuggestions: true,
 		filterGraceful: true,
 		localityBonus: false,
 		shareSuggestSelections: false,

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -4511,10 +4511,6 @@ declare namespace monaco.editor {
 		 */
 		filterGraceful?: boolean;
 		/**
-		 * Prevent quick suggestions when a snippet is active. Defaults to true.
-		 */
-		snippetsPreventQuickSuggestions?: boolean;
-		/**
 		 * Favors words that appear close to the cursor.
 		 */
 		localityBonus?: boolean;


### PR DESCRIPTION
Also remove the dreaded `snippetsPreventQuickSuggestions`which prevents suggestions inside snippets. Clear up the confusion about showing but not focusing suggest (#17338) when inside a snippet.

resolves/avoids https://github.com/microsoft/vscode/issues/173387
