### PR TITLE
Fixes `PieceTreeBase.equal`

### DIFF
--- a/src/vs/editor/common/model/pieceTreeTextBuffer/pieceTreeBase.ts
+++ b/src/vs/editor/common/model/pieceTreeTextBuffer/pieceTreeBase.ts
@@ -374,7 +374,7 @@ export class PieceTreeBase {
 			return false;
 		}
 
-		const offset = 0;
+		let offset = 0;
 		const ret = this.iterate(this.root, node => {
 			if (node === SENTINEL) {
 				return true;
@@ -385,6 +385,7 @@ export class PieceTreeBase {
 			const endPosition = other.nodeAt(offset + len);
 			const val = other.getValueInRange2(startPosition, endPosition);
 
+			offset += len;
 			return str === val;
 		});
 

--- a/src/vs/editor/test/common/model/pieceTreeTextBuffer/pieceTreeTextBuffer.test.ts
+++ b/src/vs/editor/test/common/model/pieceTreeTextBuffer/pieceTreeTextBuffer.test.ts
@@ -1595,6 +1595,12 @@ suite('buffer api', () => {
 		assert(!a.equal(d));
 	});
 
+	test('equal with more chunks', () => {
+		const a = createTextBuffer(['ab', 'cd', 'e']);
+		const b = createTextBuffer(['ab', 'c', 'de']);
+		assert(a.equal(b));
+	});
+
 	test('equal 2, empty buffer', () => {
 		const a = createTextBuffer(['']);
 		const b = createTextBuffer(['']);


### PR DESCRIPTION
Fixes microsoft/vscode-internalbacklog#4025