### PR TITLE
AddConditionalToSurroundingPairs

### DIFF
--- a/build/monaco/package.json
+++ b/build/monaco/package.json
@@ -1,7 +1,7 @@
 {
   "name": "monaco-editor-core",
   "private": true,
-  "version": "0.0.0",
+  "version": "0.0.0-os2-cnh-1",
   "description": "A browser based code editor",
   "author": "Microsoft Corporation",
   "license": "MIT",

--- a/src/vs/editor/common/languages/languageConfiguration.ts
+++ b/src/vs/editor/common/languages/languageConfiguration.ts
@@ -61,7 +61,7 @@ export interface LanguageConfiguration {
 	 * selected string is surrounded by the open and close characters. If not set, the autoclosing pairs
 	 * settings will be used.
 	 */
-	surroundingPairs?: IAutoClosingPair[];
+	surroundingPairs?: IAutoClosingPairConditional[];
 	/**
 	 * Defines a list of bracket pairs that are colorized depending on their nesting level.
 	 * If not set, the configured brackets will be used.

--- a/src/vs/editor/common/languages/languageConfigurationRegistry.ts
+++ b/src/vs/editor/common/languages/languageConfigurationRegistry.ts
@@ -8,7 +8,16 @@ import { Disposable, IDisposable, toDisposable } from 'vs/base/common/lifecycle'
 import * as strings from 'vs/base/common/strings';
 import { ITextModel } from 'vs/editor/common/model';
 import { DEFAULT_WORD_REGEXP, ensureValidWordDefinition } from 'vs/editor/common/core/wordHelper';
-import { EnterAction, FoldingRules, IAutoClosingPair, IndentationRule, LanguageConfiguration, AutoClosingPairs, CharacterPair, ExplicitLanguageConfiguration } from 'vs/editor/common/languages/languageConfiguration';
+import {
+	EnterAction,
+	FoldingRules,
+	IndentationRule,
+	LanguageConfiguration,
+	AutoClosingPairs,
+	CharacterPair,
+	ExplicitLanguageConfiguration,
+	IAutoClosingPairConditional
+} from 'vs/editor/common/languages/languageConfiguration';
 import { createScopedLineTokens, ScopedLineTokens } from 'vs/editor/common/languages/supports';
 import { CharacterPairSupport } from 'vs/editor/common/languages/supports/characterPair';
 import { BracketElectricCharacterSupport } from 'vs/editor/common/languages/supports/electricCharacter';
@@ -446,7 +455,7 @@ export class ResolvedLanguageConfiguration {
 		return this.characterPair.getAutoCloseBeforeSet();
 	}
 
-	public getSurroundingPairs(): IAutoClosingPair[] {
+	public getSurroundingPairs(): IAutoClosingPairConditional[] {
 		return this.characterPair.getSurroundingPairs();
 	}
 

--- a/src/vs/editor/common/languages/supports/characterPair.ts
+++ b/src/vs/editor/common/languages/supports/characterPair.ts
@@ -3,7 +3,11 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { IAutoClosingPair, StandardAutoClosingPairConditional, LanguageConfiguration } from 'vs/editor/common/languages/languageConfiguration';
+import {
+	StandardAutoClosingPairConditional,
+	LanguageConfiguration,
+	IAutoClosingPairConditional
+} from 'vs/editor/common/languages/languageConfiguration';
 
 export class CharacterPairSupport {
 
@@ -11,7 +15,7 @@ export class CharacterPairSupport {
 	static readonly DEFAULT_AUTOCLOSE_BEFORE_WHITESPACE = ' \n\t';
 
 	private readonly _autoClosingPairs: StandardAutoClosingPairConditional[];
-	private readonly _surroundingPairs: IAutoClosingPair[];
+	private readonly _surroundingPairs: IAutoClosingPairConditional[];
 	private readonly _autoCloseBefore: string;
 
 	constructor(config: LanguageConfiguration) {
@@ -42,7 +46,7 @@ export class CharacterPairSupport {
 		return this._autoCloseBefore;
 	}
 
-	public getSurroundingPairs(): IAutoClosingPair[] {
+	public getSurroundingPairs(): IAutoClosingPairConditional[] {
 		return this._surroundingPairs;
 	}
 }


### PR DESCRIPTION
That's is needed so that we are no able to select a part of a string (which is already surrounded by quotes) and surround it by other chars, like sharp for example. We want the selected string to be replaced and not surrounded.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
