### PR TITLE
Update update-icon-theme.js

### DIFF
--- a/extensions/theme-seti/build/update-icon-theme.js
+++ b/extensions/theme-seti/build/update-icon-theme.js
@@ -38,7 +38,8 @@ const nonBuiltInLanguages = { // { fileNames, extensions  }
 	"terraform": { extensions: ['tf', 'tfvars', 'hcl'] },
 	"todo": { fileNames: ['todo'] },
 	"vala": { extensions: ['vala'] },
-	"vue": { extensions: ['vue'] }
+	"vue": { extensions: ['vue'] },
+	"wick": { extensions: ['wick'] }
 };
 
 // list of languagesId that inherit the icon from another language


### PR DESCRIPTION
https://github.com/candlecorp/wick

The wick files are yaml based but I would like for the Wick extension (CandleCorp.wick-development-framework) which includes a file icon to use its icon instead of the default icon for the .wick files.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
