### PR TITLE
cli: only show other interactive attach commands when in a terminal

### DIFF
--- a/cli/src/tunnels/singleton_client.rs
+++ b/cli/src/tunnels/singleton_client.rs
@@ -39,15 +39,15 @@ struct SingletonServerContext {
 }
 
 const CONTROL_INSTRUCTIONS_COMMON: &str =
-	"Connected to an existing tunnel process running on this machine. You can press:
-
-- \"x\" + Enter to stop the tunnel and exit
-- \"r\" + Enter to restart the tunnel
-";
+	"Connected to an existing tunnel process running on this machine.";
 
 const CONTROL_INSTRUCTIONS_INTERACTIVE: &str = concatcp!(
 	CONTROL_INSTRUCTIONS_COMMON,
-	"- Ctrl+C to detach
+	" You can press:
+
+- \"x\" + Enter to stop the tunnel and exit
+- \"r\" + Enter to restart the tunnel
+- Ctrl+C to detach
 "
 );
 

--- a/src/vs/workbench/contrib/testing/common/testResult.ts
+++ b/src/vs/workbench/contrib/testing/common/testResult.ts
@@ -367,10 +367,6 @@ export class LiveTestResult implements ITestResult {
 			parent = this.addTestToRun(controllerId, chain[i], parent.item.extId);
 		}
 
-		for (let i = 0; i < this.tasks.length; i++) {
-			this.fireUpdateAndRefresh(parent, i, TestResultState.Queued);
-		}
-
 		return undefined;
 	}
 


### PR DESCRIPTION
Fixes #178091

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
