### PR TITLE
fix: Default Formatter invalid setting type error (#172552)

### DIFF
--- a/src/vs/workbench/contrib/format/browser/formatActionsMultiple.ts
+++ b/src/vs/workbench/contrib/format/browser/formatActionsMultiple.ts
@@ -90,7 +90,7 @@ class DefaultFormatter extends Disposable implements IWorkbenchContribution {
 		DefaultFormatter.extensionItemLabels.length = 0;
 		DefaultFormatter.extensionDescriptions.length = 0;
 
-		DefaultFormatter.extensionIds.push(null);
+		DefaultFormatter.extensionIds.push('null');
 		DefaultFormatter.extensionItemLabels.push(nls.localize('null', 'None'));
 		DefaultFormatter.extensionDescriptions.push(nls.localize('nullFormatterDescription', "None"));
 
@@ -249,7 +249,7 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).regis
 		[DefaultFormatter.configName]: {
 			description: nls.localize('formatter.default', "Defines a default formatter which takes precedence over all other formatter settings. Must be the identifier of an extension contributing a formatter."),
 			type: ['string', 'null'],
-			default: null,
+			default: 'null',
 			enum: DefaultFormatter.extensionIds,
 			enumItemLabels: DefaultFormatter.extensionItemLabels,
 			markdownEnumDescriptions: DefaultFormatter.extensionDescriptions


### PR DESCRIPTION
Fixes this error from #172552:

![image](https://user-images.githubusercontent.com/46951987/235333175-82948c93-89e1-462f-9389-cb12eaa7416f.png)

I put a writeup in the issue explaining the problem and the fix.