### PR TITLE
fix: peek / treeFind escape event clash

### DIFF
--- a/src/vs/workbench/browser/actions/listCommands.ts
+++ b/src/vs/workbench/browser/actions/listCommands.ts
@@ -676,7 +676,7 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 
 KeybindingsRegistry.registerCommandAndKeybindingRule({
 	id: 'list.closeFind',
-	weight: KeybindingWeight.WorkbenchContrib,
+	weight: KeybindingWeight.WorkbenchContrib + 60,
 	when: ContextKeyExpr.and(RawWorkbenchListFocusContextKey, WorkbenchTreeFindOpen),
 	primary: KeyCode.Escape,
 	handler: (accessor) => {


### PR DESCRIPTION
Fixes #160621 via 1-line change in key priority.

![image](https://user-images.githubusercontent.com/46951987/235339716-0c7d5740-2ead-4711-891e-ffa097da9376.png)

There is another PR (#171215) for this same issue, but it appears to have been abandoned.