### PR TITLE
fix: exclude .test and .spec from default rename selection

### DIFF
--- a/src/vs/workbench/contrib/files/browser/views/explorerViewer.ts
+++ b/src/vs/workbench/contrib/files/browser/views/explorerViewer.ts
@@ -550,12 +550,19 @@ export class FilesRenderer implements ICompressibleTreeRenderer<ExplorerItem, Fu
 			inputBoxStyles: defaultInputBoxStyles
 		});
 
-		const lastDot = value.lastIndexOf('.');
+		let indexOfLastDot = value.lastIndexOf('.');
+		if (indexOfLastDot > 5) {
+			const possiblySpecOrTest = value.substring(indexOfLastDot - 5, indexOfLastDot);
+			if (possiblySpecOrTest === '.test' || possiblySpecOrTest === '.spec') {
+				indexOfLastDot -= 5;
+			}
+		}
+
 		let currentSelectionState = 'prefix';
 
 		inputBox.value = value;
 		inputBox.focus();
-		inputBox.select({ start: 0, end: lastDot > 0 && !stat.isDirectory ? lastDot : value.length });
+		inputBox.select({ start: 0, end: indexOfLastDot > 0 && !stat.isDirectory ? indexOfLastDot : value.length });
 
 		const done = once((success: boolean, finishEditing: boolean) => {
 			label.element.style.display = 'none';


### PR DESCRIPTION
Fixes #180053.  When renaming, the `.test` or `.spec` portion of the file name is now excluded from the selection in addition to the file extension.  For example:

![image](https://user-images.githubusercontent.com/46951987/235396524-92ff446b-2d4d-4a70-a5a6-d620f5aacca1.png)

The behavior of selection cycling with F2 is unchanged.

It's not clear if the PR will be accepted.  The docs state that the community is encouraged to contribute to `help-wanted` issues, and that this label will be applied to `Backlog`.  However, the docs also state that PRs aren't accepted for `Backlog Candidates`.  This issue is both `Backlog Candidate` with the `help-wanted` label.  🤷‍♀️




