### PR TITLE
fix: #169151 fallback to editor hover if no breakpoint

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/debugEditorContribution.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugEditorContribution.ts
@@ -379,6 +379,8 @@ export class DebugEditorContribution implements IDebugEditorContribution {
 				// When no expression available fallback to editor hover
 				this.showEditorHover(position, focus);
 			}
+		} else {
+			this.showEditorHover(position, focus);
 		}
 	}
 


### PR DESCRIPTION
Closes #169151.

This PR fixes the issue mentioned in this comment 
https://github.com/microsoft/vscode/issues/169151#issuecomment-1527805907

Now when no focused stack frame is available , editor hover is shown 
