### PR TITLE
Restore code that removed separators on filter

### DIFF
--- a/src/vs/platform/quickinput/browser/quickInputList.ts
+++ b/src/vs/platform/quickinput/browser/quickInputList.ts
@@ -804,6 +804,13 @@ export class QuickInputList {
 					element.hidden = element.item ? !element.item.alwaysShow : true;
 				}
 
+				// Ensure separators are filtered out first before deciding if we need to bring them back
+				if (element.item) {
+					element.separator = undefined;
+				} else if (element.separator) {
+					element.hidden = true;
+				}
+
 				// we can show the separator unless the list gets sorted by match
 				if (!this.sortByLabel) {
 					const previous = element.index && this.inputElements[element.index - 1];


### PR DESCRIPTION
A version of this code was removed when I added quick pick item separator buttons... causing #180037

This restores that code.

Fixes #180037

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
