### PR TITLE
Add widget to change how content is pasted

### DIFF
--- a/extensions/ipynb/src/notebookImagePaste.ts
+++ b/extensions/ipynb/src/notebookImagePaste.ts
@@ -53,7 +53,7 @@ class CopyPasteEditProvider implements vscode.DocumentPasteEditProvider {
 			return;
 		}
 
-		const pasteEdit = new vscode.DocumentPasteEdit(insert.insertText);
+		const pasteEdit = new vscode.DocumentPasteEdit(insert.insertText, vscode.l10n.t('Insert image as attachment'));
 		pasteEdit.additionalEdit = insert.additionalEdit;
 		return pasteEdit;
 	}

--- a/extensions/markdown-language-features/src/languageFeatures/copyFiles/copyPaste.ts
+++ b/extensions/markdown-language-features/src/languageFeatures/copyFiles/copyPaste.ts
@@ -46,7 +46,7 @@ class PasteEditProvider implements vscode.DocumentPasteEditProvider {
 		}
 
 		const snippet = await tryGetUriListSnippet(document, dataTransfer, token);
-		return snippet ? new vscode.DocumentPasteEdit(snippet.snippet) : undefined;
+		return snippet ? new vscode.DocumentPasteEdit(snippet.snippet, snippet.label) : undefined;
 	}
 
 	private async _makeCreateImagePasteEdit(document: vscode.TextDocument, file: vscode.DataTransferFile, token: vscode.CancellationToken): Promise<vscode.DocumentPasteEdit | undefined> {
@@ -55,7 +55,7 @@ class PasteEditProvider implements vscode.DocumentPasteEditProvider {
 			const workspaceFolder = vscode.workspace.getWorkspaceFolder(file.uri);
 			if (workspaceFolder) {
 				const snippet = createUriListSnippet(document, [file.uri]);
-				return snippet ? new vscode.DocumentPasteEdit(snippet.snippet) : undefined;
+				return snippet ? new vscode.DocumentPasteEdit(snippet.snippet, snippet.label) : undefined;
 			}
 		}
 
@@ -73,7 +73,7 @@ class PasteEditProvider implements vscode.DocumentPasteEditProvider {
 		const workspaceEdit = new vscode.WorkspaceEdit();
 		workspaceEdit.createFile(uri, { contents: file });
 
-		const pasteEdit = new vscode.DocumentPasteEdit(snippet.snippet);
+		const pasteEdit = new vscode.DocumentPasteEdit(snippet.snippet, snippet.label);
 		pasteEdit.additionalEdit = workspaceEdit;
 		return pasteEdit;
 	}

--- a/src/vs/editor/common/languages.ts
+++ b/src/vs/editor/common/languages.ts
@@ -783,6 +783,7 @@ export interface CodeActionProvider {
  * @internal
  */
 export interface DocumentPasteEdit {
+	label: string;
 	insertText: string | { snippet: string };
 	additionalEdit?: WorkspaceEdit;
 }

--- a/src/vs/editor/common/languages.ts
+++ b/src/vs/editor/common/languages.ts
@@ -784,7 +784,7 @@ export interface CodeActionProvider {
  */
 export interface DocumentPasteEdit {
 	readonly label: string;
-	insertText: string | { snippet: string };
+	insertText: string | { readonly snippet: string };
 	additionalEdit?: WorkspaceEdit;
 }
 

--- a/src/vs/editor/common/languages.ts
+++ b/src/vs/editor/common/languages.ts
@@ -783,7 +783,7 @@ export interface CodeActionProvider {
  * @internal
  */
 export interface DocumentPasteEdit {
-	label: string;
+	readonly label: string;
 	insertText: string | { snippet: string };
 	additionalEdit?: WorkspaceEdit;
 }

--- a/src/vs/editor/contrib/copyPaste/browser/copyPasteContribution.ts
+++ b/src/vs/editor/contrib/copyPaste/browser/copyPasteContribution.ts
@@ -3,11 +3,14 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { EditorContributionInstantiation, registerEditorContribution } from 'vs/editor/browser/editorExtensions';
+import { KeyCode, KeyMod } from 'vs/base/common/keyCodes';
+import { ICodeEditor } from 'vs/editor/browser/editorBrowser';
+import { EditorCommand, EditorContributionInstantiation, ServicesAccessor, registerEditorCommand, registerEditorContribution } from 'vs/editor/browser/editorExtensions';
 import { editorConfigurationBaseNode } from 'vs/editor/common/config/editorConfigurationSchema';
-import { CopyPasteController } from 'vs/editor/contrib/copyPaste/browser/copyPasteController';
+import { CopyPasteController, changePasteTypeCommandId, pasteWidgetVisibleCtx } from 'vs/editor/contrib/copyPaste/browser/copyPasteController';
 import * as nls from 'vs/nls';
 import { ConfigurationScope, Extensions, IConfigurationRegistry } from 'vs/platform/configuration/common/configurationRegistry';
+import { KeybindingWeight } from 'vs/platform/keybinding/common/keybindingsRegistry';
 import { Registry } from 'vs/platform/registry/common/platform';
 
 registerEditorContribution(CopyPasteController.ID, CopyPasteController, EditorContributionInstantiation.Eager); // eager because it listens to events on the container dom node of the editor
@@ -21,5 +24,22 @@ Registry.as<IConfigurationRegistry>(Extensions.Configuration).registerConfigurat
 			description: nls.localize('pasteActions', "Enable/disable running edits from extensions on paste."),
 			default: false,
 		},
+	}
+});
+
+registerEditorCommand(new class extends EditorCommand {
+	constructor() {
+		super({
+			id: changePasteTypeCommandId,
+			precondition: pasteWidgetVisibleCtx,
+			kbOpts: {
+				weight: KeybindingWeight.EditorContrib,
+				primary: KeyMod.CtrlCmd | KeyCode.Period,
+			}
+		});
+	}
+
+	public override runEditorCommand(_accessor: ServicesAccessor | null, editor: ICodeEditor, _args: any) {
+		CopyPasteController.get(editor)?.changePasteType();
 	}
 });

--- a/src/vs/editor/contrib/copyPaste/browser/copyPasteController.ts
+++ b/src/vs/editor/contrib/copyPaste/browser/copyPasteController.ts
@@ -315,7 +315,8 @@ export class CopyPasteController extends Disposable implements IEditorContributi
 			]
 		};
 
-		await this._postPasteWidgetManager.applyEditAndShowIfNeeded(selection, combinedWorkspaceEdit, { activeEditIndex, allEdits }, async (newEditIndex) => {
+		const editSet = { activeEditIndex, allEdits: allEdits.map(edit => ({ label: edit.label })) };
+		await this._postPasteWidgetManager.applyEditAndShowIfNeeded(selection, combinedWorkspaceEdit, editSet, async (newEditIndex) => {
 			await model.undo();
 			this.applyPasteEdit(editor, selection, newEditIndex, allEdits, token);
 		}, token);

--- a/src/vs/editor/contrib/copyPaste/browser/defaultPasteProviders.ts
+++ b/src/vs/editor/contrib/copyPaste/browser/defaultPasteProviders.ts
@@ -7,7 +7,7 @@ import { CancellationToken } from 'vs/base/common/cancellation';
 import { VSDataTransfer } from 'vs/base/common/dataTransfer';
 import { Mimes } from 'vs/base/common/mime';
 import { IRange } from 'vs/editor/common/core/range';
-import { DocumentOnDropEdit, DocumentPasteEditProvider } from 'vs/editor/common/languages';
+import { DocumentPasteEdit, DocumentPasteEditProvider } from 'vs/editor/common/languages';
 import { ITextModel } from 'vs/editor/common/model';
 import { ILanguageFeaturesService } from 'vs/editor/common/services/languageFeatures';
 import { localize } from 'vs/nls';
@@ -17,7 +17,7 @@ class DefaultTextDropProvider implements DocumentPasteEditProvider {
 	readonly id = 'text';
 	readonly pasteMimeTypes = [Mimes.text, 'text'];
 
-	async provideDocumentPasteEdits(_model: ITextModel, _ranges: readonly IRange[], dataTransfer: VSDataTransfer, _token: CancellationToken): Promise<DocumentOnDropEdit | undefined> {
+	async provideDocumentPasteEdits(_model: ITextModel, _ranges: readonly IRange[], dataTransfer: VSDataTransfer, _token: CancellationToken): Promise<DocumentPasteEdit | undefined> {
 		const textEntry = dataTransfer.get('text') ?? dataTransfer.get(Mimes.text);
 		if (!textEntry) {
 			return;

--- a/src/vs/editor/contrib/copyPaste/browser/defaultPasteProviders.ts
+++ b/src/vs/editor/contrib/copyPaste/browser/defaultPasteProviders.ts
@@ -1,0 +1,45 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { CancellationToken } from 'vs/base/common/cancellation';
+import { VSDataTransfer } from 'vs/base/common/dataTransfer';
+import { Mimes } from 'vs/base/common/mime';
+import { IRange } from 'vs/editor/common/core/range';
+import { DocumentOnDropEdit, DocumentPasteEditProvider } from 'vs/editor/common/languages';
+import { ITextModel } from 'vs/editor/common/model';
+import { ILanguageFeaturesService } from 'vs/editor/common/services/languageFeatures';
+import { localize } from 'vs/nls';
+
+class DefaultTextDropProvider implements DocumentPasteEditProvider {
+
+	readonly id = 'text';
+	readonly pasteMimeTypes = [Mimes.text, 'text'];
+
+	async provideDocumentPasteEdits(_model: ITextModel, _ranges: readonly IRange[], dataTransfer: VSDataTransfer, _token: CancellationToken): Promise<DocumentOnDropEdit | undefined> {
+		const textEntry = dataTransfer.get('text') ?? dataTransfer.get(Mimes.text);
+		if (!textEntry) {
+			return;
+		}
+
+		const text = await textEntry.asString();
+		return {
+			label: localize('defaultPasteProvider.text.label', "Insert Plain Text"),
+			insertText: text
+		};
+	}
+}
+
+
+let registeredDefaultProviders = false;
+
+export function registerDefaultPasteProviders(
+	languageFeaturesService: ILanguageFeaturesService
+) {
+	if (!registeredDefaultProviders) {
+		registeredDefaultProviders = true;
+
+		languageFeaturesService.documentPasteEditProvider.register('*', new DefaultTextDropProvider());
+	}
+}

--- a/src/vs/editor/contrib/copyPaste/browser/defaultPasteProviders.ts
+++ b/src/vs/editor/contrib/copyPaste/browser/defaultPasteProviders.ts
@@ -12,7 +12,7 @@ import { ITextModel } from 'vs/editor/common/model';
 import { ILanguageFeaturesService } from 'vs/editor/common/services/languageFeatures';
 import { localize } from 'vs/nls';
 
-class DefaultTextDropProvider implements DocumentPasteEditProvider {
+class DefaultTextPasteProvider implements DocumentPasteEditProvider {
 
 	readonly id = 'text';
 	readonly pasteMimeTypes = [Mimes.text, 'text'];
@@ -40,6 +40,6 @@ export function registerDefaultPasteProviders(
 	if (!registeredDefaultProviders) {
 		registeredDefaultProviders = true;
 
-		languageFeaturesService.documentPasteEditProvider.register('*', new DefaultTextDropProvider());
+		languageFeaturesService.documentPasteEditProvider.register('*', new DefaultTextPasteProvider());
 	}
 }

--- a/src/vs/editor/contrib/postEditWidget/browser/postEditWidget.css
+++ b/src/vs/editor/contrib/postEditWidget/browser/postEditWidget.css
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-.post-drop-widget {
+.post-edit-widget {
 	box-shadow: 0 0 8px 2px var(--vscode-widget-shadow);
 	border: 1px solid var(--vscode-widget-border, transparent);
 	border-radius: 4px;
@@ -11,16 +11,16 @@
 	overflow: hidden;
 }
 
-.post-drop-widget .monaco-button {
+.post-edit-widget .monaco-button {
 	padding: 2px;
 	border: none;
 	border-radius: 0;
 }
 
-.post-drop-widget .monaco-button:hover {
+.post-edit-widget .monaco-button:hover {
 	background-color: var(--vscode-button-secondaryHoverBackground) !important;
 }
 
-.post-drop-widget .monaco-button .codicon {
+.post-edit-widget .monaco-button .codicon {
 	margin: 0;
 }

--- a/src/vs/workbench/api/browser/mainThreadLanguageFeatures.ts
+++ b/src/vs/workbench/api/browser/mainThreadLanguageFeatures.ts
@@ -973,6 +973,7 @@ class MainThreadPasteEditProvider implements languages.DocumentPasteEditProvider
 			}
 
 			return {
+				label: result.label,
 				insertText: result.insertText,
 				additionalEdit: result.additionalEdit ? reviveWorkspaceEditDto(result.additionalEdit, this._uriIdentService, dataId => this.resolveFileData(request.id, dataId)) : undefined,
 			};

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -1817,6 +1817,7 @@ export interface IInlineValueContextDto {
 export type ITypeHierarchyItemDto = Dto<TypeHierarchyItem>;
 
 export interface IPasteEditDto {
+	label: string;
 	insertText: string | { snippet: string };
 	additionalEdit?: IWorkspaceEditDto;
 }

--- a/src/vs/workbench/api/common/extHostLanguageFeatures.ts
+++ b/src/vs/workbench/api/common/extHostLanguageFeatures.ts
@@ -505,6 +505,7 @@ class DocumentPasteEditProvider {
 		private readonly _documents: ExtHostDocuments,
 		private readonly _provider: vscode.DocumentPasteEditProvider,
 		private readonly _handle: number,
+		private readonly _extension: IExtensionDescription,
 	) { }
 
 	async prepareDocumentPaste(resource: URI, ranges: IRange[], dataTransferDto: extHostProtocol.DataTransferDTO, token: CancellationToken): Promise<extHostProtocol.DataTransferDTO | undefined> {
@@ -537,6 +538,7 @@ class DocumentPasteEditProvider {
 		}
 
 		return {
+			label: edit.label ?? localize('defaultPasteLabel', "Paste using '{0}' extension", this._extension.displayName || this._extension.name),
 			insertText: typeof edit.insertText === 'string' ? edit.insertText : { snippet: edit.insertText.value },
 			additionalEdit: edit.additionalEdit ? typeConvert.WorkspaceEdit.from(edit.additionalEdit, undefined) : undefined,
 		};
@@ -2405,7 +2407,7 @@ export class ExtHostLanguageFeatures implements extHostProtocol.ExtHostLanguageF
 
 	registerDocumentPasteEditProvider(extension: IExtensionDescription, selector: vscode.DocumentSelector, provider: vscode.DocumentPasteEditProvider, metadata: vscode.DocumentPasteProviderMetadata): vscode.Disposable {
 		const handle = this._nextHandle();
-		this._adapter.set(handle, new AdapterData(new DocumentPasteEditProvider(this._proxy, this._documents, provider, handle), extension));
+		this._adapter.set(handle, new AdapterData(new DocumentPasteEditProvider(this._proxy, this._documents, provider, handle, extension), extension));
 		this._proxy.$registerPasteEditProvider(handle, this._transformDocumentSelector(selector, extension), !!provider.prepareDocumentPaste, metadata.pasteMimeTypes);
 		return this._createDisposable(handle);
 	}

--- a/src/vs/workbench/api/common/extHostTypes.ts
+++ b/src/vs/workbench/api/common/extHostTypes.ts
@@ -2686,11 +2686,14 @@ export class DocumentDropEdit {
 
 @es5ClassCompat
 export class DocumentPasteEdit {
+	label: string;
+
 	insertText: string | SnippetString;
 
 	additionalEdit?: WorkspaceEdit;
 
-	constructor(insertText: string | SnippetString) {
+	constructor(insertText: string | SnippetString, label: string) {
+		this.label = label;
 		this.insertText = insertText;
 	}
 }

--- a/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
@@ -90,6 +90,7 @@ import { CellFindMatchModel } from 'vs/workbench/contrib/notebook/browser/contri
 import { INotebookLoggingService } from 'vs/workbench/contrib/notebook/common/notebookLoggingService';
 import { Schemas } from 'vs/base/common/network';
 import { DropIntoEditorController } from 'vs/editor/contrib/dropIntoEditor/browser/dropIntoEditorContribution';
+import { CopyPasteController } from 'vs/editor/contrib/copyPaste/browser/copyPasteController';
 
 const $ = DOM.$;
 
@@ -1900,6 +1901,7 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditorD
 			if (this.getActiveCell() === cell && editor) {
 				SuggestController.get(editor)?.cancelSuggestWidget();
 				DropIntoEditorController.get(editor)?.clearWidgets();
+				CopyPasteController.get(editor)?.clearWidgets();
 			}
 		});
 	}

--- a/src/vscode-dts/vscode.proposed.documentPaste.d.ts
+++ b/src/vscode-dts/vscode.proposed.documentPaste.d.ts
@@ -45,6 +45,11 @@ declare module 'vscode' {
 	 */
 	class DocumentPasteEdit {
 		/**
+		 * Human readable label that describes the edit.
+		 */
+		label: string;
+
+		/**
 		 * The text or snippet to insert at the pasted locations.
 		 */
 		insertText: string | SnippetString;
@@ -56,8 +61,10 @@ declare module 'vscode' {
 
 		/**
 		 * @param insertText The text or snippet to insert at the pasted locations.
+		 *
+		 * TODO: Reverse args, but this will break existing consumers :(
 		 */
-		constructor(insertText: string | SnippetString);
+		constructor(insertText: string | SnippetString, label: string);
 	}
 
 	interface DocumentPasteProviderMetadata {


### PR DESCRIPTION
For #30066

This adds a widget that lets you change how content is pasted if there are multiple ways it could be pasted

To do this, I've made the post drop widget generic and reused it for pasting too
