### PR TITLE
cli: fix mutex names contain extra characters

### DIFF
--- a/cli/src/util/app_lock.rs
+++ b/cli/src/util/app_lock.rs
@@ -30,7 +30,10 @@ impl AppMutex {
 
 	#[cfg(windows)]
 	pub fn new(name: &str) -> Result<Self, CodeError> {
-		let handle = unsafe { CreateMutexA(ptr::null_mut(), 0, name.as_ptr() as _) };
+		use std::ffi::CString;
+
+		let cname = CString::new(name).unwrap();
+		let handle = unsafe { CreateMutexA(ptr::null_mut(), 0, cname.as_ptr() as _) };
 
 		if !handle.is_null() {
 			return Ok(Self { handle });


### PR DESCRIPTION
Fixes #181334

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
