### PR TITLE
testing: keep the selection in test explorer after running multiple tests

### DIFF
--- a/src/vs/base/browser/ui/tree/abstractTree.ts
+++ b/src/vs/base/browser/ui/tree/abstractTree.ts
@@ -1749,6 +1749,10 @@ export abstract class AbstractTree<T, TFilterData, TRef> implements IDisposable 
 		this.view.ariaLabel = value;
 	}
 
+	get selectionSize() {
+		return this.selection.getNodes().length;
+	}
+
 	domFocus(): void {
 		this.view.domFocus();
 	}

--- a/src/vs/workbench/contrib/testing/browser/testingExplorerView.ts
+++ b/src/vs/workbench/contrib/testing/browser/testingExplorerView.ts
@@ -645,6 +645,10 @@ class TestingExplorerViewModel extends Disposable {
 				return;
 			}
 
+			if (this.tree.selectionSize > 1) {
+				return; // don't change a multi-selection #180950
+			}
+
 			// follow running tests, or tests whose state changed. Tests that
 			// complete very fast may not enter the running state at all.
 			if (evt.item.ownComputedState !== TestResultState.Running && !(evt.previousState === TestResultState.Queued && isStateWithResult(evt.item.ownComputedState))) {


### PR DESCRIPTION
Adds a `selectionSize` getter to the abstractTree, since calling getSelection clones an array which is unnecessary and inefficient here.

Fixes #180950

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
