### PR TITLE
fix `UriComponents` typings, add `isUriComponents`, add doc to `revive` and `from`. Prevent double validation with `from` and support strict-mode for from.

### DIFF
--- a/src/vs/base/common/uri.ts
+++ b/src/vs/base/common/uri.ts
@@ -327,15 +327,22 @@ export class URI implements UriComponents {
 		return new Uri('file', authority, path, _empty, _empty);
 	}
 
-	static from(components: { scheme: string; authority?: string; path?: string; query?: string; fragment?: string }): URI {
+	/**
+	 * Creates new URI from uri components.
+	 *
+	 * Unless `strict` is `true` the scheme is defaults to be `file`. This function performs
+	 * validation and should be used for untrusted uri components retrieved from storage,
+	 * user input, command arguments etc
+	 */
+	static from(components: { scheme: string; authority?: string; path?: string; query?: string; fragment?: string }, strict?: boolean): URI {
 		const result = new Uri(
 			components.scheme,
 			components.authority,
 			components.path,
 			components.query,
 			components.fragment,
+			strict
 		);
-		_validateUri(result, true);
 		return result;
 	}
 
@@ -380,6 +387,16 @@ export class URI implements UriComponents {
 		return this;
 	}
 
+	/**
+	 * A helper function to revive URIs.
+	 *
+	 * **Note** that this function should only be used when receiving URI#toJSON generated data
+	 * and that it doesn't do any validation. Use {@link URI.from} when received "untrusted"
+	 * uri components such as command arguments or data from storage.
+	 *
+	 * @param data The URI components or URI to revive.
+	 * @returns The revived URI or undefined or null.
+	 */
 	static revive(data: UriComponents | URI): URI;
 	static revive(data: UriComponents | URI | undefined): URI | undefined;
 	static revive(data: UriComponents | URI | null): URI | null;
@@ -391,8 +408,8 @@ export class URI implements UriComponents {
 			return data;
 		} else {
 			const result = new Uri(data);
-			result._formatted = (<UriState>data).external;
-			result._fsPath = (<UriState>data)._sep === _pathSepMarker ? (<UriState>data).fsPath : null;
+			result._formatted = (<UriState>data).external ?? null;
+			result._fsPath = (<UriState>data)._sep === _pathSepMarker ? (<UriState>data).fsPath ?? null : null;
 			return result;
 		}
 	}
@@ -400,17 +417,28 @@ export class URI implements UriComponents {
 
 export interface UriComponents {
 	scheme: string;
-	authority: string;
-	path: string;
-	query: string;
-	fragment: string;
+	authority?: string;
+	path?: string;
+	query?: string;
+	fragment?: string;
+}
+
+export function isUriComponents(thing: any): thing is UriComponents {
+	if (!thing || typeof thing !== 'object') {
+		return false;
+	}
+	return typeof (<UriComponents>thing).scheme === 'string'
+		&& (typeof (<UriComponents>thing).authority === 'string' || typeof (<UriComponents>thing).authority === 'undefined')
+		&& (typeof (<UriComponents>thing).path === 'string' || typeof (<UriComponents>thing).path === 'undefined')
+		&& (typeof (<UriComponents>thing).query === 'string' || typeof (<UriComponents>thing).query === 'undefined')
+		&& (typeof (<UriComponents>thing).fragment === 'string' || typeof (<UriComponents>thing).fragment === 'undefined');
 }
 
 interface UriState extends UriComponents {
 	$mid: MarshalledId.Uri;
-	external: string;
-	fsPath: string;
-	_sep: 1 | undefined;
+	external?: string;
+	fsPath?: string;
+	_sep?: 1;
 }
 
 const _pathSepMarker = isWindows ? 1 : undefined;
@@ -452,10 +480,14 @@ class Uri extends URI {
 		if (this._formatted) {
 			res.external = this._formatted;
 		}
-		// uri components
+		//--- uri components
 		if (this.path) {
 			res.path = this.path;
 		}
+		// TODO
+		// this isn't correct and can violate the UriComponents contract but
+		// this is part of the vscode.Uri API and we shouldn't change how that
+		// works anymore
 		if (this.scheme) {
 			res.scheme = this.scheme;
 		}

--- a/src/vs/base/test/common/uri.test.ts
+++ b/src/vs/base/test/common/uri.test.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 import * as assert from 'assert';
 import { isWindows } from 'vs/base/common/platform';
-import { URI, UriComponents } from 'vs/base/common/uri';
+import { URI, UriComponents, isUriComponents } from 'vs/base/common/uri';
 
 
 suite('URI', () => {
@@ -467,6 +467,30 @@ suite('URI', () => {
 			with() { return this; },
 			toString() { return ''; }
 		}), true);
+	});
+
+	test('isUriComponents', function () {
+
+		assert.ok(isUriComponents(URI.file('a')));
+		assert.ok(isUriComponents(URI.file('a').toJSON()));
+		assert.ok(isUriComponents(URI.file('')));
+		assert.ok(isUriComponents(URI.file('').toJSON()));
+
+		assert.strictEqual(isUriComponents(1), false);
+		assert.strictEqual(isUriComponents(true), false);
+		assert.strictEqual(isUriComponents("true"), false);
+		assert.strictEqual(isUriComponents({}), false);
+		assert.strictEqual(isUriComponents({ scheme: '' }), true); // valid components but INVALID uri
+		assert.strictEqual(isUriComponents({ scheme: 'fo' }), true);
+		assert.strictEqual(isUriComponents({ scheme: 'fo', path: '/p' }), true);
+		assert.strictEqual(isUriComponents({ path: '/p' }), false);
+	});
+
+	test('from, from(strict), revive', function () {
+
+		assert.throws(() => URI.from({ scheme: '' }, true));
+		assert.strictEqual(URI.from({ scheme: '' }).scheme, 'file');
+		assert.strictEqual(URI.revive({ scheme: '' }).scheme, '');
 	});
 
 	test('Unable to open \'%A0.txt\': URI malformed #76506, part 2', function () {

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -174,13 +174,20 @@ declare namespace monaco {
 		 * @param path A file system path (see `Uri#fsPath`)
 		 */
 		static file(path: string): Uri;
+		/**
+		 * Creates new Uri from uri components.
+		 *
+		 * Unless `strict` is `true` the scheme is defaults to be `file`. This function performs
+		 * validation and should be used for untrusted uri components retrieved from storage,
+		 * user input, command arguments etc
+		 */
 		static from(components: {
 			scheme: string;
 			authority?: string;
 			path?: string;
 			query?: string;
 			fragment?: string;
-		}): Uri;
+		}, strict?: boolean): Uri;
 		/**
 		 * Join a Uri path with path fragments and normalizes the resulting path.
 		 *
@@ -202,6 +209,16 @@ declare namespace monaco {
 		 */
 		toString(skipEncoding?: boolean): string;
 		toJSON(): UriComponents;
+		/**
+		 * A helper function to revive URIs.
+		 *
+		 * **Note** that this function should only be used when receiving Uri#toJSON generated data
+		 * and that it doesn't do any validation. Use {@link Uri.from} when received "untrusted"
+		 * uri components such as command arguments or data from storage.
+		 *
+		 * @param data The Uri components or Uri to revive.
+		 * @returns The revived Uri or undefined or null.
+		 */
 		static revive(data: UriComponents | Uri): Uri;
 		static revive(data: UriComponents | Uri | undefined): Uri | undefined;
 		static revive(data: UriComponents | Uri | null): Uri | null;
@@ -210,10 +227,10 @@ declare namespace monaco {
 
 	export interface UriComponents {
 		scheme: string;
-		authority: string;
-		path: string;
-		query: string;
-		fragment: string;
+		authority?: string;
+		path?: string;
+		query?: string;
+		fragment?: string;
 	}
 	/**
 	 * Virtual Key Codes, the value does not hold any inherent meaning.


### PR DESCRIPTION
re https://github.com/microsoft/vscode/issues/181385, https://github.com/microsoft/vscode/pull/181315/
