### PR TITLE
only reconnect to `isBackground` task terminals

### DIFF
--- a/src/vs/workbench/contrib/tasks/browser/terminalTaskSystem.ts
+++ b/src/vs/workbench/contrib/tasks/browser/terminalTaskSystem.ts
@@ -1453,7 +1453,9 @@ export class TerminalTaskSystem extends Disposable implements ITaskSystem {
 			}
 
 			terminalToReuse.terminal.scrollToBottom();
-			launchConfigs.reconnectionProperties = { ownerId: ReconnectionType, data: { lastTask: task.getCommonTaskId(), group, label: task._label, id: task._id } };
+			if (task.configurationProperties.isBackground) {
+				launchConfigs.reconnectionProperties = { ownerId: ReconnectionType, data: { lastTask: task.getCommonTaskId(), group, label: task._label, id: task._id } };
+			}
 			await terminalToReuse.terminal.reuseTerminal(launchConfigs);
 
 			if (task.command.presentation && task.command.presentation.clear) {
@@ -1465,7 +1467,9 @@ export class TerminalTaskSystem extends Disposable implements ITaskSystem {
 
 		this._terminalCreationQueue = this._terminalCreationQueue.then(() => this._doCreateTerminal(task, group, launchConfigs!));
 		const terminal: ITerminalInstance = (await this._terminalCreationQueue)!;
-		terminal.shellLaunchConfig.reconnectionProperties = { ownerId: ReconnectionType, data: { lastTask: task.getCommonTaskId(), group, label: task._label, id: task._id } };
+		if (task.configurationProperties.isBackground) {
+			terminal.shellLaunchConfig.reconnectionProperties = { ownerId: ReconnectionType, data: { lastTask: task.getCommonTaskId(), group, label: task._label, id: task._id } };
+		}
 		const terminalKey = terminal.instanceId.toString();
 		const terminalData = { terminal: terminal, lastTask: taskKey, group };
 		terminal.onDisposed(() => this._deleteTaskAndTerminal(terminal, terminalData));


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

To test:

Using `xterm.js`, modify the `Start demo` task so none of its dependencies have `isBackground:true`. Start that task and reload the window. 🐛 , without these changes, the tasks are still running but the task system doesn't know that. With these changes, the task terminals should no longer be there.

Context:
We wanted to keep terminals around that had tasks run in them regardless of whether or not those tasks persisted. In doing that, the tasks were never terminated. We could keep the terminals around after reload, but I think that's confusing and we should just kill them.

Also see https://github.com/microsoft/vscode/pull/180374#issuecomment-1529845738

An exploration into a different approach - where we would reconnect to non background tasks as well:
https://github.com/microsoft/vscode/issues/180243#issuecomment-1515621144

fixes https://github.com/microsoft/vscode/issues/180243