### PR TITLE
Add temporary nodeJS walkthrough

### DIFF
--- a/extensions/typescript-language-features/package.json
+++ b/extensions/typescript-language-features/package.json
@@ -68,6 +68,15 @@
   "main": "./out/extension",
   "browser": "./dist/browser/extension",
   "contributes": {
+    "walkthroughs": [
+      {
+        "id": "tempNodejsWelcome",
+        "title": "tempNodejsTitle",
+        "description": "tempNodejsDescription",
+        "steps": [],
+        "when": "false"
+      }
+    ],
     "jsonValidation": [
       {
         "fileMatch": "package.json",


### PR DESCRIPTION
Fixes: https://github.com/microsoft/vscode/issues/181400
This is a temp fix.

Commit https://github.com/microsoft/vscode/commit/93026118c5c68f54220d5a39993a5e29a8df0029 removes a walkthrough from a builtin extension.
The place where we are stuck https://github.com/microsoft/vscode/blob/6812cf9a3b4aaa5b1738dbb63b467ace423856ae/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts#L887 is waiting on a promise that only resolves when an extension’s contributed walkthroughs are processed, and with that commit, we no longer have any builtin extensions contributing a walkthrough.

Temporary fix is to add in a placeholder walkthrough that is disabled with a when clause and that gets everything working the way it did before.

PR in main: https://github.com/microsoft/vscode/pull/181441