### PR TITLE
Check for `attachment:` in markdown cell renderer

### DIFF
--- a/extensions/ipynb/notebook-src/cellAttachmentRenderer.ts
+++ b/extensions/ipynb/notebook-src/cellAttachmentRenderer.ts
@@ -23,7 +23,7 @@ export async function activate(ctx: RendererContext<void>) {
 			const token = tokens[idx];
 			const src = token.attrGet('src');
 			const attachments: Record<string, Record<string, string>> | undefined = env.outputItem.metadata?.attachments;
-			if (attachments && src) {
+			if (attachments && src && src.startsWith('attachment:')) {
 				const imageAttachment = attachments[tryDecodeURIComponent(src.replace('attachment:', ''))];
 				if (imageAttachment) {
 					// objEntries will always be length 1, with objEntries[0] holding [0]=mime,[1]=b64


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Previously all images were attempted to be rendered via the attachment renderer. Issues when json holds b64 for `image.png` but you're actually just trying to render `![alt](image.png)`. whoops.