### PR TITLE
Remove items from vscode-known-variables

### DIFF
--- a/build/lib/stylelint/vscode-known-variables.json
+++ b/build/lib/stylelint/vscode-known-variables.json
@@ -309,8 +309,6 @@
 		"--vscode-interactiveEditor-border",
 		"--vscode-interactiveEditor-regionHighlight",
 		"--vscode-interactiveEditor-shadow",
-		"--vscode-interactiveEditorDiff-inserted",
-		"--vscode-interactiveEditorDiff-removed",
 		"--vscode-interactiveEditorInput-background",
 		"--vscode-interactiveEditorInput-border",
 		"--vscode-interactiveEditorInput-focusBorder",


### PR DESCRIPTION
These were added in https://github.com/microsoft/vscode/pull/181543/files on accident- maybe they are supposed to be here but I don't want to add colors that I don't own