### PR TITLE
Pass session down so we can avoid a network call

### DIFF
--- a/extensions/github-authentication/src/github.ts
+++ b/extensions/github-authentication/src/github.ts
@@ -110,7 +110,7 @@ export class GitHubAuthenticationProvider implements vscode.AuthenticationProvid
 		// We only want to fire a telemetry if we haven't seen this account yet in this session.
 		if (!this._accountsSeen.has(session.account.id)) {
 			this._accountsSeen.add(session.account.id);
-			this._githubServer.sendAdditionalTelemetryInfo(session.accessToken);
+			this._githubServer.sendAdditionalTelemetryInfo(session);
 		}
 	}
 


### PR DESCRIPTION
We don't need to fetch the user details when the Auth Session already has the info we need. This PR removes that extraneous web request.

I've also changed the `User-Agent` that we pass to be more specific so we can narrow down any future issues with spamming web requests.

Fixes #173645

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
