### PR TITLE
Add better fall backs to standard pasting logic

### DIFF
--- a/src/vs/editor/common/languages.ts
+++ b/src/vs/editor/common/languages.ts
@@ -793,6 +793,9 @@ export interface DocumentPasteEdit {
  */
 export interface DocumentPasteEditProvider {
 
+	readonly id?: string;
+
+	readonly copyMimeTypes?: readonly string[];
 	readonly pasteMimeTypes: readonly string[];
 
 	prepareDocumentPaste?(model: model.ITextModel, ranges: readonly IRange[], dataTransfer: VSDataTransfer, token: CancellationToken): Promise<undefined | VSDataTransfer>;

--- a/src/vs/editor/contrib/dropOrPasteInto/browser/copyPasteController.ts
+++ b/src/vs/editor/contrib/dropOrPasteInto/browser/copyPasteController.ts
@@ -7,11 +7,12 @@ import { addDisposableListener } from 'vs/base/browser/dom';
 import { coalesce } from 'vs/base/common/arrays';
 import { CancelablePromise, createCancelablePromise, raceCancellation } from 'vs/base/common/async';
 import { CancellationToken } from 'vs/base/common/cancellation';
-import { UriList, VSDataTransfer, createStringDataTransferItem } from 'vs/base/common/dataTransfer';
+import { UriList, VSDataTransfer, createStringDataTransferItem, matchesMimeType } from 'vs/base/common/dataTransfer';
 import { Disposable } from 'vs/base/common/lifecycle';
 import { Mimes } from 'vs/base/common/mime';
+import * as platform from 'vs/base/common/platform';
 import { generateUuid } from 'vs/base/common/uuid';
-import { toVSDataTransfer } from 'vs/editor/browser/dnd';
+import { toExternalVSDataTransfer, toVSDataTransfer } from 'vs/editor/browser/dnd';
 import { ICodeEditor } from 'vs/editor/browser/editorBrowser';
 import { EditorOption } from 'vs/editor/common/config/editorOptions';
 import { IRange, Range } from 'vs/editor/common/core/range';
@@ -36,7 +37,9 @@ const vscodeClipboardMime = 'application/vnd.code.copyMetadata';
 
 interface CopyMetadata {
 	readonly id?: string;
-	readonly wasFromEmptySelection: boolean;
+	readonly providerCopyMimeTypes?: readonly string[];
+
+	readonly defaultPastePayload: Omit<PastePayload, 'text'>;
 }
 
 export class CopyPasteController extends Disposable implements IEditorContribution {
@@ -49,12 +52,12 @@ export class CopyPasteController extends Disposable implements IEditorContributi
 
 	private readonly _editor: ICodeEditor;
 
-	private _currentClipboardItem?: {
+	private _currentCopyOperation?: {
 		readonly handle: string;
 		readonly dataTransferPromise: CancelablePromise<VSDataTransfer>;
 	};
 
-	private _currentOperation?: CancelablePromise<void>;
+	private _currentPasteOperation?: CancelablePromise<void>;
 
 	private readonly _pasteProgressManager: InlineProgressManager;
 	private readonly _postPasteWidgetManager: PostEditWidgetManager;
@@ -92,7 +95,7 @@ export class CopyPasteController extends Disposable implements IEditorContributi
 	}
 
 	private handleCopy(e: ClipboardEvent) {
-		if (!e.clipboardData || !this._editor.hasTextFocus()) {
+		if (!e.clipboardData || !this._editor.hasTextFocus() || !this.isPasteAsEnabled()) {
 			return;
 		}
 
@@ -102,33 +105,44 @@ export class CopyPasteController extends Disposable implements IEditorContributi
 			return;
 		}
 
-		if (!this.isPasteAsEnabled()) {
-			return;
-		}
+		const enableEmptySelectionClipboard = this._editor.getOption(EditorOption.emptySelectionClipboard);
 
-		const ranges: IRange[] = [...selections];
-		const primarySelection = selections[0];
-		const wasFromEmptySelection = primarySelection.isEmpty();
+		let ranges: readonly IRange[] = selections;
+		const wasFromEmptySelection = selections.length === 1 && selections[0].isEmpty();
 		if (wasFromEmptySelection) {
-			if (!this._editor.getOption(EditorOption.emptySelectionClipboard)) {
+			if (!enableEmptySelectionClipboard) {
 				return;
 			}
-			ranges[0] = new Range(primarySelection.startLineNumber, 0, primarySelection.startLineNumber, model.getLineLength(primarySelection.startLineNumber));
+
+			ranges = ranges.map(range => new Range(range.startLineNumber, 0, range.startLineNumber, model.getLineLength(range.startLineNumber)));
 		}
 
-		const providers = this._languageFeaturesService.documentPasteEditProvider.ordered(model).filter(x => !!x.prepareDocumentPaste);
+		const toCopy = this._editor._getViewModel()?.getPlainTextToCopy(selections, enableEmptySelectionClipboard, platform.isWindows);
+		const multicursorText = Array.isArray(toCopy) ? toCopy : null;
+
+		const defaultPastePayload = {
+			multicursorText,
+			pasteOnNewLine: wasFromEmptySelection,
+			mode: null
+		};
+
+		const providers = this._languageFeaturesService.documentPasteEditProvider
+			.ordered(model)
+			.filter(x => !!x.prepareDocumentPaste);
 		if (!providers.length) {
-			this.setCopyMetadata(e.clipboardData, { wasFromEmptySelection });
+			this.setCopyMetadata(e.clipboardData, { defaultPastePayload });
 			return;
 		}
 
 		const dataTransfer = toVSDataTransfer(e.clipboardData);
+		const providerCopyMimeTypes = providers.flatMap(x => x.copyMimeTypes ?? []);
 
 		// Save off a handle pointing to data that VS Code maintains.
 		const handle = generateUuid();
 		this.setCopyMetadata(e.clipboardData, {
 			id: handle,
-			wasFromEmptySelection,
+			providerCopyMimeTypes,
+			defaultPastePayload
 		});
 
 		const promise = createCancelablePromise(async token => {
@@ -145,12 +159,8 @@ export class CopyPasteController extends Disposable implements IEditorContributi
 			return dataTransfer;
 		});
 
-		this._currentClipboardItem?.dataTransferPromise.cancel();
-		this._currentClipboardItem = { handle: handle, dataTransferPromise: promise };
-	}
-
-	private setCopyMetadata(dataTransfer: DataTransfer, metadata: CopyMetadata) {
-		dataTransfer.setData(vscodeClipboardMime, JSON.stringify(metadata));
+		this._currentCopyOperation?.dataTransferPromise.cancel();
+		this._currentCopyOperation = { handle: handle, dataTransferPromise: promise };
 	}
 
 	private async handlePaste(e: ClipboardEvent) {
@@ -158,7 +168,8 @@ export class CopyPasteController extends Disposable implements IEditorContributi
 			return;
 		}
 
-		this._currentOperation?.cancel();
+		this._currentPasteOperation?.cancel();
+		this._currentPasteOperation = undefined;
 
 		const selections = this._editor.getSelections();
 		if (!selections?.length || !this._editor.hasModel()) {
@@ -170,17 +181,29 @@ export class CopyPasteController extends Disposable implements IEditorContributi
 			return;
 		}
 
-		let metadata: CopyMetadata | undefined;
-		const rawMetadata = e.clipboardData?.getData(vscodeClipboardMime);
-		if (rawMetadata && typeof rawMetadata === 'string') {
-			metadata = JSON.parse(rawMetadata);
-		}
+		const metadata = this.fetchCopyMetadata(e.clipboardData);
+		const dataTransfer = toExternalVSDataTransfer(e.clipboardData);
+		dataTransfer.delete(vscodeClipboardMime);
 
-		const providers = this._languageFeaturesService.documentPasteEditProvider.ordered(model);
-		if (!providers.length) {
+		const allPotentialMimeTypes = [
+			...e.clipboardData.types,
+			...metadata?.providerCopyMimeTypes ?? [],
+			// TODO: always adds `uri-list` because this get set if there are resources in the system clipboard.
+			// However we can only check the system clipboard async. For this early check, just add it in.
+			// We filter providers again once we have the final dataTransfer we will use.
+			Mimes.uriList,
+		];
+
+		const allProviders = this._languageFeaturesService.documentPasteEditProvider
+			.ordered(model)
+			.filter(provider => provider.pasteMimeTypes.some(type => matchesMimeType(type, allPotentialMimeTypes)));
+		if (!allProviders.length) {
 			return;
 		}
 
+		// Prevent the editor's default paste handler from running.
+		// Note that after this point, we are fully responsible for handling paste.
+		// If we can't provider a paste for any reason, we need to explicitly delegate pasting back to the editor.
 		e.preventDefault();
 		e.stopImmediatePropagation();
 
@@ -192,33 +215,21 @@ export class CopyPasteController extends Disposable implements IEditorContributi
 
 			const tokenSource = new EditorStateCancellationTokenSource(editor, CodeEditorStateFlag.Value | CodeEditorStateFlag.Selection, undefined, token);
 			try {
-				const dataTransfer = toVSDataTransfer(e.clipboardData!);
-
-				if (metadata?.id && this._currentClipboardItem?.handle === metadata.id) {
-					const toMergeDataTransfer = await this._currentClipboardItem.dataTransferPromise;
-					if (tokenSource.token.isCancellationRequested) {
-						return;
-					}
-
-					toMergeDataTransfer.forEach((value, key) => {
-						dataTransfer.replace(key, value);
-					});
+				await this.mergeInDataFromCopy(dataTransfer, metadata, tokenSource.token);
+				if (tokenSource.token.isCancellationRequested) {
+					return;
 				}
 
-				if (!dataTransfer.has(Mimes.uriList)) {
-					const resources = await this._clipboardService.readResources();
-					if (tokenSource.token.isCancellationRequested) {
-						return;
-					}
-
-					if (resources.length) {
-						dataTransfer.append(Mimes.uriList, createStringDataTransferItem(UriList.create(resources)));
-					}
+				// Filter out any providers the don't match the full data transfer we will send them.
+				const supportedProviders = allProviders.filter(provider => isSupportedProvider(provider, dataTransfer));
+				if (!supportedProviders.length
+					|| (supportedProviders.length === 1 && supportedProviders[0].id === 'text') // Only our default text provider is active
+				) {
+					await this.applyDefaultPasteHandler(dataTransfer, metadata, tokenSource.token);
+					return;
 				}
 
-				dataTransfer.delete(vscodeClipboardMime);
-
-				const providerEdits = await this.getPasteEdits(providers, dataTransfer, model, selections, tokenSource.token);
+				const providerEdits = await this.getPasteEdits(supportedProviders, dataTransfer, model, selections, tokenSource.token);
 				if (tokenSource.token.isCancellationRequested) {
 					return;
 				}
@@ -231,22 +242,60 @@ export class CopyPasteController extends Disposable implements IEditorContributi
 				await this.applyDefaultPasteHandler(dataTransfer, metadata, tokenSource.token);
 			} finally {
 				tokenSource.dispose();
-				if (this._currentOperation === p) {
-					this._currentOperation = undefined;
+				if (this._currentPasteOperation === p) {
+					this._currentPasteOperation = undefined;
 				}
 			}
 		});
 
 		this._pasteProgressManager.showWhile(selections[0].getEndPosition(), localize('pasteIntoEditorProgress', "Running paste handlers. Click to cancel"), p);
-		this._currentOperation = p;
+		this._currentPasteOperation = p;
+	}
+
+	private setCopyMetadata(dataTransfer: DataTransfer, metadata: CopyMetadata) {
+		dataTransfer.setData(vscodeClipboardMime, JSON.stringify(metadata));
+	}
+
+	private fetchCopyMetadata(dataTransfer: DataTransfer): CopyMetadata | undefined {
+		const rawMetadata = dataTransfer.getData(vscodeClipboardMime);
+		if (rawMetadata) {
+			try {
+				return JSON.parse(rawMetadata);
+			} catch {
+				return undefined;
+			}
+		}
+		return undefined;
+	}
+
+	private async mergeInDataFromCopy(dataTransfer: VSDataTransfer, metadata: CopyMetadata | undefined, token: CancellationToken): Promise<void> {
+		if (metadata?.id && this._currentCopyOperation?.handle === metadata.id) {
+			const toMergeDataTransfer = await this._currentCopyOperation.dataTransferPromise;
+			if (token.isCancellationRequested) {
+				return;
+			}
+
+			toMergeDataTransfer.forEach((value, key) => {
+				dataTransfer.replace(key, value);
+			});
+		}
+
+		if (!dataTransfer.has(Mimes.uriList)) {
+			const resources = await this._clipboardService.readResources();
+			if (token.isCancellationRequested) {
+				return;
+			}
+
+			if (resources.length) {
+				dataTransfer.append(Mimes.uriList, createStringDataTransferItem(UriList.create(resources)));
+			}
+		}
 	}
 
 	private async getPasteEdits(providers: readonly DocumentPasteEditProvider[], dataTransfer: VSDataTransfer, model: ITextModel, selections: Selection[], token: CancellationToken): Promise<DocumentPasteEdit[]> {
 		const result = await raceCancellation(
 			Promise.all(
-				providers
-					.filter(provider => isSupportedProvider(provider, dataTransfer))
-					.map(provider => provider.provideDocumentPasteEdits(model, selections, dataTransfer, token))
+				providers.map(provider => provider.provideDocumentPasteEdits(model, selections, dataTransfer, token))
 			).then(coalesce),
 			token);
 		return result ?? [];
@@ -263,11 +312,13 @@ export class CopyPasteController extends Disposable implements IEditorContributi
 			return;
 		}
 
-		this._editor.trigger('keyboard', Handler.Paste, <PastePayload>{
-			text: text,
-			pasteOnNewLine: metadata?.wasFromEmptySelection,
-			multicursorText: null
-		});
+		const payload: PastePayload = {
+			text,
+			pasteOnNewLine: metadata?.defaultPastePayload.pasteOnNewLine ?? false,
+			multicursorText: metadata?.defaultPastePayload.multicursorText ?? null,
+			mode: null,
+		};
+		this._editor.trigger('keyboard', Handler.Paste, payload);
 	}
 }
 

--- a/src/vs/workbench/api/browser/mainThreadLanguageFeatures.ts
+++ b/src/vs/workbench/api/browser/mainThreadLanguageFeatures.ts
@@ -32,7 +32,7 @@ import * as callh from 'vs/workbench/contrib/callHierarchy/common/callHierarchy'
 import * as search from 'vs/workbench/contrib/search/common/search';
 import * as typeh from 'vs/workbench/contrib/typeHierarchy/common/typeHierarchy';
 import { extHostNamedCustomer, IExtHostContext } from 'vs/workbench/services/extensions/common/extHostCustomers';
-import { ExtHostContext, ExtHostLanguageFeaturesShape, ICallHierarchyItemDto, ICodeActionDto, ICodeActionProviderMetadataDto, IdentifiableInlineCompletion, IdentifiableInlineCompletions, IDocumentFilterDto, IIndentationRuleDto, IInlayHintDto, ILanguageConfigurationDto, ILanguageWordDefinitionDto, ILinkDto, ILocationDto, ILocationLinkDto, IOnEnterRuleDto, IRegExpDto, ISignatureHelpProviderMetadataDto, ISuggestDataDto, ISuggestDataDtoField, ISuggestResultDtoField, ITypeHierarchyItemDto, IWorkspaceSymbolDto, MainContext, MainThreadLanguageFeaturesShape } from '../common/extHost.protocol';
+import { ExtHostContext, ExtHostLanguageFeaturesShape, ICallHierarchyItemDto, ICodeActionDto, ICodeActionProviderMetadataDto, IdentifiableInlineCompletion, IdentifiableInlineCompletions, IDocumentFilterDto, IIndentationRuleDto, IInlayHintDto, ILanguageConfigurationDto, ILanguageWordDefinitionDto, ILinkDto, ILocationDto, ILocationLinkDto, IOnEnterRuleDto, IPasteEditProviderMetadataDto, IRegExpDto, ISignatureHelpProviderMetadataDto, ISuggestDataDto, ISuggestDataDtoField, ISuggestResultDtoField, ITypeHierarchyItemDto, IWorkspaceSymbolDto, MainContext, MainThreadLanguageFeaturesShape } from '../common/extHost.protocol';
 
 @extHostNamedCustomer(MainContext.MainThreadLanguageFeatures)
 export class MainThreadLanguageFeatures extends Disposable implements MainThreadLanguageFeaturesShape {
@@ -372,8 +372,8 @@ export class MainThreadLanguageFeatures extends Disposable implements MainThread
 
 	private readonly _pasteEditProviders = new Map<number, MainThreadPasteEditProvider>();
 
-	$registerPasteEditProvider(handle: number, selector: IDocumentFilterDto[], supportsCopy: boolean, pasteMimeTypes: readonly string[]): void {
-		const provider = new MainThreadPasteEditProvider(handle, this._proxy, supportsCopy, pasteMimeTypes, this._uriIdentService);
+	$registerPasteEditProvider(handle: number, selector: IDocumentFilterDto[], metadata: IPasteEditProviderMetadataDto): void {
+		const provider = new MainThreadPasteEditProvider(handle, this._proxy, metadata, this._uriIdentService);
 		this._pasteEditProviders.set(handle, provider);
 		this._registrations.set(handle, combinedDisposable(
 			this._languageFeaturesService.documentPasteEditProvider.register(selector, provider),
@@ -929,6 +929,7 @@ class MainThreadPasteEditProvider implements languages.DocumentPasteEditProvider
 
 	private readonly dataTransfers = new DataTransferCache();
 
+	public readonly copyMimeTypes?: readonly string[];
 	public readonly pasteMimeTypes: readonly string[];
 
 	readonly prepareDocumentPaste?: (model: ITextModel, ranges: readonly IRange[], dataTransfer: VSDataTransfer, token: CancellationToken) => Promise<undefined | VSDataTransfer>;
@@ -936,13 +937,13 @@ class MainThreadPasteEditProvider implements languages.DocumentPasteEditProvider
 	constructor(
 		private readonly handle: number,
 		private readonly _proxy: ExtHostLanguageFeaturesShape,
-		supportsCopy: boolean,
-		pasteMimeTypes: readonly string[],
+		metadata: IPasteEditProviderMetadataDto,
 		@IUriIdentityService private readonly _uriIdentService: IUriIdentityService
 	) {
-		this.pasteMimeTypes = pasteMimeTypes;
+		this.copyMimeTypes = metadata.copyMimeTypes;
+		this.pasteMimeTypes = metadata.pasteMimeTypes;
 
-		if (supportsCopy) {
+		if (metadata.supportsCopy) {
 			this.prepareDocumentPaste = async (model: ITextModel, selections: readonly IRange[], dataTransfer: VSDataTransfer, token: CancellationToken): Promise<VSDataTransfer | undefined> => {
 				const dataTransferDto = await typeConvert.DataTransfer.toDataTransferDTO(dataTransfer);
 				if (token.isCancellationRequested) {

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -387,7 +387,7 @@ export interface MainThreadLanguageFeaturesShape extends IDisposable {
 	$registerLinkedEditingRangeProvider(handle: number, selector: IDocumentFilterDto[]): void;
 	$registerReferenceSupport(handle: number, selector: IDocumentFilterDto[]): void;
 	$registerQuickFixSupport(handle: number, selector: IDocumentFilterDto[], metadata: ICodeActionProviderMetadataDto, displayName: string, supportsResolve: boolean): void;
-	$registerPasteEditProvider(handle: number, selector: IDocumentFilterDto[], supportsCopy: boolean, pasteMimeTypes: readonly string[]): void;
+	$registerPasteEditProvider(handle: number, selector: IDocumentFilterDto[], metadata: IPasteEditProviderMetadataDto): void;
 	$registerDocumentFormattingSupport(handle: number, selector: IDocumentFilterDto[], extensionId: ExtensionIdentifier, displayName: string): void;
 	$registerRangeFormattingSupport(handle: number, selector: IDocumentFilterDto[], extensionId: ExtensionIdentifier, displayName: string, supportRanges: boolean): void;
 	$registerOnTypeFormattingSupport(handle: number, selector: IDocumentFilterDto[], autoFormatTriggerCharacters: string[], extensionId: ExtensionIdentifier): void;
@@ -1816,6 +1816,12 @@ export interface IInlineValueContextDto {
 }
 
 export type ITypeHierarchyItemDto = Dto<TypeHierarchyItem>;
+
+export interface IPasteEditProviderMetadataDto {
+	readonly supportsCopy: boolean;
+	readonly copyMimeTypes?: readonly string[];
+	readonly pasteMimeTypes: readonly string[];
+}
 
 export interface IPasteEditDto {
 	label: string;

--- a/src/vs/workbench/api/common/extHostLanguageFeatures.ts
+++ b/src/vs/workbench/api/common/extHostLanguageFeatures.ts
@@ -2408,7 +2408,11 @@ export class ExtHostLanguageFeatures implements extHostProtocol.ExtHostLanguageF
 	registerDocumentPasteEditProvider(extension: IExtensionDescription, selector: vscode.DocumentSelector, provider: vscode.DocumentPasteEditProvider, metadata: vscode.DocumentPasteProviderMetadata): vscode.Disposable {
 		const handle = this._nextHandle();
 		this._adapter.set(handle, new AdapterData(new DocumentPasteEditProvider(this._proxy, this._documents, provider, handle, extension), extension));
-		this._proxy.$registerPasteEditProvider(handle, this._transformDocumentSelector(selector, extension), !!provider.prepareDocumentPaste, metadata.pasteMimeTypes);
+		this._proxy.$registerPasteEditProvider(handle, this._transformDocumentSelector(selector, extension), {
+			supportsCopy: !!provider.prepareDocumentPaste,
+			copyMimeTypes: metadata.copyMimeTypes,
+			pasteMimeTypes: metadata.pasteMimeTypes,
+		});
 		return this._createDisposable(handle);
 	}
 

--- a/src/vscode-dts/vscode.proposed.documentPaste.d.ts
+++ b/src/vscode-dts/vscode.proposed.documentPaste.d.ts
@@ -69,6 +69,11 @@ declare module 'vscode' {
 
 	interface DocumentPasteProviderMetadata {
 		/**
+		 * Mime types that {@link DocumentPasteEditProvider.prepareDocumentPaste provideDocumentPasteEdits} may add on copy.
+		 */
+		readonly copyMimeTypes?: readonly string[];
+
+		/**
 		 * Mime types that {@link DocumentPasteEditProvider.provideDocumentPasteEdits provideDocumentPasteEdits} should be invoked for.
 		 *
 		 * This can either be an exact mime type such as `image/png`, or a wildcard pattern such as `image/*`.


### PR DESCRIPTION
Fixes #181489

This tries to avoid having copy paste provider mess up normal text copy and paste by doing the following:

- When copy paste providers are used but none end up handling the paste,  compute the `PastePayload` we pass back to the editor more correctly

- If only a single provider is used and it's the default text provider, fall back to the editor's paste handler instead of using the provider. This is a workaround until we figure out how/if to make paste providers aware of empty selection copies and multi cursor copies

- Be more aggressive about avoiding invoking providers. Before deciding to override paste, we now check a list of possible mime types on the clipboard. We can then use this list to filter out providers which we know will not handle any of these types

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
