### PR TITLE
Fix: Changed bash-syntax to fish-syntax in shellIntegration

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/media/shellIntegration.fish
+++ b/src/vs/workbench/contrib/terminal/browser/media/shellIntegration.fish
@@ -30,25 +30,25 @@ set -e VSCODE_PATH_PREFIX
 
 # Apply EnvironmentVariableCollections if needed
 if test -n "$VSCODE_ENV_REPLACE"
-	set ITEMS $(string split : $VSCODE_ENV_REPLACE)
+	set ITEMS (string split : $VSCODE_ENV_REPLACE)
 	for B in $ITEMS
-		set split $(string split = $B)
+		set split (string split = $B)
 		set -gx "$split[1]" "$split[2]"
 	end
 	set -e VSCODE_ENV_REPLACE
 end
 if test -n "$VSCODE_ENV_PREPEND"
-	set ITEMS $(string split : $VSCODE_ENV_PREPEND)
+	set ITEMS (string split : $VSCODE_ENV_PREPEND)
 	for B in $ITEMS
-		set split $(string split = $B)
+		set split (string split = $B)
 		set -gx "$split[1]" "$split[2]$$split[1]" # avoid -p as it adds a space
 	end
 	set -e VSCODE_ENV_PREPEND
 end
 if test -n "$VSCODE_ENV_APPEND"
-	set ITEMS $(string split : $VSCODE_ENV_APPEND)
+	set ITEMS (string split : $VSCODE_ENV_APPEND)
 	for B in $ITEMS
-		set split $(string split = $B)
+		set split (string split = $B)
 		set -gx "$split[1]" "$$split[1]$split[2]" # avoid -a as it adds a space
 	end
 	set -e VSCODE_ENV_APPEND


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes the regression in the `shellIntegration.fish`-script. 
The used bash-syntax for a command substitution (`$(...)`) doesn't work in fish (expects `(...)` without `$`).
Closes #181634

I wasn't able to find tests for this script. I tested it manually in my insiders instance and I can now see exit status markings again. I'd need further instructions if that's not enough.