### PR TITLE
Fixes #181207 - Add padding to extension viewer bottom

### DIFF
--- a/src/vs/workbench/contrib/extensions/browser/extensionEditor.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionEditor.ts
@@ -767,6 +767,11 @@ export class ExtensionEditor extends EditorPane {
 				<style nonce="${nonce}">
 					${DEFAULT_MARKDOWN_STYLES}
 
+					/* prevent scroll-to-top button from blocking the body text */
+					body {
+						padding-bottom: 75px;
+					}
+
 					#scroll-to-top {
 						position: fixed;
 						width: 32px;


### PR DESCRIPTION
I added some padding to the bottom of the extension viewer body in order to prevent the scroll-to-top button from blocking the text, which should resolve issue #181207.