### PR TITLE
copy stdin to clipboard from integrated terminal

### DIFF
--- a/src/vs/platform/environment/common/argv.ts
+++ b/src/vs/platform/environment/common/argv.ts
@@ -111,6 +111,7 @@ export interface NativeParsedArgs {
 	'profile-temp'?: boolean;
 
 	'enable-coi'?: boolean;
+	'clipboard'?: boolean;
 
 	// chromium command line args: https://electronjs.org/docs/all#supported-chrome-command-line-switches
 	'no-proxy-server'?: boolean;

--- a/src/vs/platform/environment/node/argv.ts
+++ b/src/vs/platform/environment/node/argv.ts
@@ -79,6 +79,7 @@ export const OPTIONS: OptionDescriptions<Required<NativeParsedArgs>> = {
 	'user-data-dir': { type: 'string', cat: 'o', args: 'dir', description: localize('userDataDir', "Specifies the directory that user data is kept in. Can be used to open multiple distinct instances of Code.") },
 	'profile': { type: 'string', 'cat': 'o', args: 'profileName', description: localize('profileName', "Opens the provided folder or workspace with the given profile and associates the profile with the workspace. If the profile does not exist, a new empty one is created. A folder or workspace must be provided for the profile to take effect.") },
 	'help': { type: 'boolean', cat: 'o', alias: 'h', description: localize('help', "Print usage.") },
+	'clipboard': { type: 'boolean', cat: 'o', alias: 'c', description: localize('clipboard', "copies the STDIN to the clipboard") },
 
 	'extensions-dir': { type: 'string', deprecates: ['extensionHomePath'], cat: 'e', args: 'dir', description: localize('extensionHomePath', "Set the root path for extensions.") },
 	'extensions-download-dir': { type: 'string' },

--- a/src/vs/workbench/api/browser/mainThreadCLICommands.ts
+++ b/src/vs/workbench/api/browser/mainThreadCLICommands.ts
@@ -8,6 +8,7 @@ import { isWeb } from 'vs/base/common/platform';
 import { isString } from 'vs/base/common/types';
 import { URI, UriComponents } from 'vs/base/common/uri';
 import { localize } from 'vs/nls';
+import { IClipboardService } from 'vs/platform/clipboard/common/clipboardService';
 import { CommandsRegistry, ICommandService } from 'vs/platform/commands/common/commands';
 import { IExtensionGalleryService, IExtensionManagementService } from 'vs/platform/extensionManagement/common/extensionManagement';
 import { ExtensionManagementCLI } from 'vs/platform/extensionManagement/common/extensionManagementCLI';
@@ -88,6 +89,11 @@ CommandsRegistry.registerCommand('_remoteCLI.manageExtensions', async function (
 		}
 	}
 	return lines.join('\n');
+});
+
+CommandsRegistry.registerCommand('_remoteCLI.setClipboard', function (accessor: ServicesAccessor, content: string) {
+	const clipboardService = accessor.get(IClipboardService);
+	clipboardService.writeText(content);
 });
 
 class RemoteExtensionManagementCLI extends ExtensionManagementCLI {

--- a/src/vs/workbench/api/node/extHostCLIServer.ts
+++ b/src/vs/workbench/api/node/extHostCLIServer.ts
@@ -43,7 +43,12 @@ export interface ExtensionManagementPipeArgs {
 	force?: boolean;
 }
 
-export type PipeCommand = OpenCommandPipeArgs | StatusPipeArgs | OpenExternalCommandPipeArgs | ExtensionManagementPipeArgs;
+export interface ClipboardPipeArgs {
+	type: 'clipboard';
+	content: string;
+}
+
+export type PipeCommand = OpenCommandPipeArgs | StatusPipeArgs | OpenExternalCommandPipeArgs | ExtensionManagementPipeArgs | ClipboardPipeArgs;
 
 export interface ICommandsExecuter {
 	executeCommand<T>(id: string, ...args: any[]): Promise<T>;
@@ -104,6 +109,9 @@ export class CLIServerBase {
 						break;
 					case 'extensionManagement':
 						returnObj = await this.manageExtensions(data);
+						break;
+					case 'clipboard':
+						returnObj = await this.clipboard(data);
 						break;
 					default:
 						sendResponse(404, `Unknown message type: ${data.type}`);
@@ -172,6 +180,10 @@ export class CLIServerBase {
 
 	private async getStatus(data: StatusPipeArgs) {
 		return await this._commands.executeCommand('_remoteCLI.getSystemStatus');
+	}
+
+	private async clipboard(data: ClipboardPipeArgs) {
+		return await this._commands.executeCommand('_remoteCLI.setClipboard', data.content);
 	}
 
 	dispose(): void {

--- a/src/vs/workbench/contrib/terminal/browser/remoteTerminalBackend.ts
+++ b/src/vs/workbench/contrib/terminal/browser/remoteTerminalBackend.ts
@@ -88,7 +88,7 @@ class RemoteTerminalBackend extends BaseTerminalBackend implements ITerminalBack
 			}
 		});
 
-		const allowedCommands = ['_remoteCLI.openExternal', '_remoteCLI.windowOpen', '_remoteCLI.getSystemStatus', '_remoteCLI.manageExtensions'];
+		const allowedCommands = ['_remoteCLI.openExternal', '_remoteCLI.windowOpen', '_remoteCLI.getSystemStatus', '_remoteCLI.manageExtensions', '_remoteCLI.setClipboard'];
 		this._remoteTerminalChannel.onExecuteCommand(async e => {
 			// Ensure this request for for this window
 			const pty = this._ptys.get(e.persistentProcessId);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fixes #181724

to test use a remote-cli.sh script pointing to the dev environment and run it from an integrated terminal.

e.g.:

```bash
#!/usr/bin/env sh
#
# Copyright (c) Microsoft Corporation. All rights reserved.
#
VSROOT=/home/coder/dev/vscode
ROOT="$(dirname "$(dirname "$VSROOT")")"


APP_NAME="code"
VERSION="1.0.0"
COMMIT="..."
EXEC_NAME="code"
CLI_SCRIPT="$VSROOT/out/server-cli.js"
"${NODE_EXEC_PATH:-$ROOT/lib/node}" "$CLI_SCRIPT" "$APP_NAME" "$VERSION" "$COMMIT" "$EXEC_NAME" "$@"
```

usage in terminal:

```bash
echo -n my clipboard text | code --clipboard
```
