### PR TITLE
Support links with spaces in cmd prompt paths

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/links/browser/terminalLocalLinkDetector.ts
+++ b/src/vs/workbench/contrib/terminalContrib/links/browser/terminalLocalLinkDetector.ts
@@ -49,6 +49,8 @@ const fallbackMatchers: RegExp[] = [
 	// C:\foo/bar baz:339: error ...
 	// C:\foo/bar baz:339:12: error ...     [#178584, Clang]
 	/^(?<link>(?<path>.+):(?<line>\d+)(?::(?<col>\d+))?) ?:/,
+	// Cmd prompt
+	/^(?<link>(?<path>.+))>/,
 	// The whole line is the path
 	/^ *(?<link>(?<path>.+))/
 ];

--- a/src/vs/workbench/contrib/terminalContrib/links/test/browser/terminalLocalLinkDetector.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/links/test/browser/terminalLocalLinkDetector.test.ts
@@ -135,6 +135,8 @@ const supportedFallbackLinkFormats: LinkFormatInfo[] = [
 	{ urlFormat: '{0}:{1}:{2} :', line: '5', column: '3', linkCellEndOffset: -2 },
 	{ urlFormat: '{0}:{1}:', line: '5', linkCellEndOffset: -1 },
 	{ urlFormat: '{0}:{1}:{2}:', line: '5', column: '3', linkCellEndOffset: -1 },
+	// Cmd prompt
+	{ urlFormat: '{0}>', linkCellEndOffset: -1 },
 	// The whole line is the path
 	{ urlFormat: '{0}' },
 ];


### PR DESCRIPTION
Fixes #180398
