### PR TITLE
Option to change the location of the ellipsis of quickopen

### DIFF
--- a/src/vs/base/browser/ui/iconLabel/iconLabel.ts
+++ b/src/vs/base/browser/ui/iconLabel/iconLabel.ts
@@ -18,6 +18,7 @@ export interface IIconLabelCreationOptions {
 	readonly supportDescriptionHighlights?: boolean;
 	readonly supportIcons?: boolean;
 	readonly hoverDelegate?: IHoverDelegate;
+	readonly ellipsisLocation?: 'left' | 'right';
 }
 
 export interface IIconLabelValueOptions {
@@ -104,6 +105,11 @@ export class IconLabel extends Disposable {
 
 		const nameContainer = dom.append(this.labelContainer, dom.$('span.monaco-icon-name-container'));
 
+		if (options?.ellipsisLocation === 'left') {
+			nameContainer.classList.add('left-ellipsis');
+			this.labelContainer.classList.add('left-ellipsis');
+		}
+
 		if (options?.supportHighlights || options?.supportIcons) {
 			this.nameNode = new LabelWithHighlights(nameContainer, !!options.supportIcons);
 		} else {
@@ -137,6 +143,7 @@ export class IconLabel extends Disposable {
 				containerClasses.push('disabled');
 			}
 		}
+
 
 		this.domNode.className = labelClasses.join(' ');
 		this.labelContainer.className = containerClasses.join(' ');
@@ -190,13 +197,15 @@ export class IconLabel extends Disposable {
 	private getOrCreateDescriptionNode() {
 		if (!this.descriptionNode) {
 			const descriptionContainer = this._register(new FastLabelNode(dom.append(this.labelContainer, dom.$('span.monaco-icon-description-container'))));
+			if (this.creationOptions?.ellipsisLocation === 'left') {
+				descriptionContainer.element.classList.add('left-ellipsis');
+			}
 			if (this.creationOptions?.supportDescriptionHighlights) {
 				this.descriptionNode = new HighlightedLabel(dom.append(descriptionContainer.element, dom.$('span.label-description')), { supportIcons: !!this.creationOptions.supportIcons });
 			} else {
 				this.descriptionNode = this._register(new FastLabelNode(dom.append(descriptionContainer.element, dom.$('span.label-description'))));
 			}
 		}
-
 		return this.descriptionNode;
 	}
 }

--- a/src/vs/platform/quickinput/browser/media/quickInput.css
+++ b/src/vs/platform/quickinput/browser/media/quickInput.css
@@ -190,7 +190,9 @@
 	border-radius: 3px;
 }
 
-.quick-input-list .monaco-list-row[data-index="0"] .quick-input-list-entry.quick-input-list-separator-border {
+.quick-input-list
+	.monaco-list-row[data-index="0"]
+	.quick-input-list-entry.quick-input-list-separator-border {
 	border-top-style: none;
 }
 
@@ -223,7 +225,9 @@
 .quick-input-widget .quick-input-list .quick-input-list-checkbox {
 	display: none;
 }
-.quick-input-widget.show-checkboxes .quick-input-list .quick-input-list-checkbox {
+.quick-input-widget.show-checkboxes
+	.quick-input-list
+	.quick-input-list-checkbox {
 	display: inline;
 }
 
@@ -232,12 +236,43 @@
 	align-items: center;
 }
 
-.quick-input-list .quick-input-list-rows > .quick-input-list-row .monaco-icon-label,
-.quick-input-list .quick-input-list-rows > .quick-input-list-row .monaco-icon-label .monaco-icon-label-container > .monaco-icon-name-container {
+.quick-input-list .monaco-icon-label-container .left-ellipsis {
+	display: flex;
+	align-items: center;
+}
+
+.quick-input-list .monaco-icon-name-container.left-ellipsis {
+	display: inline-block;
+	block-size: 1.5rem;
+}
+
+.quick-input-list .monaco-icon-description-container .left-ellipsis {
+	display: inline-block;
+	block-size: 1.5rem;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	width: 100%;
+	direction: rtl;
+	text-align: left;
+}
+
+.quick-input-list
+	.quick-input-list-rows
+	> .quick-input-list-row
+	.monaco-icon-label,
+.quick-input-list
+	.quick-input-list-rows
+	> .quick-input-list-row
+	.monaco-icon-label
+	.monaco-icon-label-container
+	> .monaco-icon-name-container {
 	flex: 1; /* make sure the icon label grows within the row */
 }
 
-.quick-input-list .quick-input-list-rows > .quick-input-list-row .codicon[class*='codicon-'] {
+.quick-input-list
+	.quick-input-list-rows
+	> .quick-input-list-row
+	.codicon[class*="codicon-"] {
 	vertical-align: text-bottom;
 }
 
@@ -291,16 +326,28 @@
 	margin-right: 4px; /* separate from scrollbar */
 }
 
-.quick-input-list .quick-input-list-entry .quick-input-list-entry-action-bar .action-label.always-visible,
-.quick-input-list .quick-input-list-entry:hover .quick-input-list-entry-action-bar .action-label,
-.quick-input-list .monaco-list-row.focused .quick-input-list-entry-action-bar .action-label {
+.quick-input-list
+	.quick-input-list-entry
+	.quick-input-list-entry-action-bar
+	.action-label.always-visible,
+.quick-input-list
+	.quick-input-list-entry:hover
+	.quick-input-list-entry-action-bar
+	.action-label,
+.quick-input-list
+	.monaco-list-row.focused
+	.quick-input-list-entry-action-bar
+	.action-label {
 	display: flex;
 }
 
 /* focused items in quick pick */
 .quick-input-list .monaco-list-row.focused .monaco-keybinding-key,
-.quick-input-list .monaco-list-row.focused .quick-input-list-entry .quick-input-list-separator {
-	color: inherit
+.quick-input-list
+	.monaco-list-row.focused
+	.quick-input-list-entry
+	.quick-input-list-separator {
+	color: inherit;
 }
 .quick-input-list .monaco-list-row.focused .monaco-keybinding-key {
 	background: none;

--- a/src/vs/platform/quickinput/browser/quickInputList.ts
+++ b/src/vs/platform/quickinput/browser/quickInputList.ts
@@ -144,7 +144,7 @@ class ListElementRenderer implements IListRenderer<ListElement, IListElementTemp
 		const row2 = dom.append(rows, $('.quick-input-list-row'));
 
 		// Label
-		data.label = new IconLabel(row1, { supportHighlights: true, supportDescriptionHighlights: true, supportIcons: true });
+		data.label = new IconLabel(row1, { supportHighlights: true, supportDescriptionHighlights: true, supportIcons: true, ellipsisLocation: 'left' });
 
 		// Keybinding
 		const keybindingContainer = dom.append(row1, $('.quick-input-list-entry-keybinding'));

--- a/src/vs/workbench/contrib/search/browser/anythingQuickAccess.ts
+++ b/src/vs/workbench/contrib/search/browser/anythingQuickAccess.ts
@@ -205,6 +205,7 @@ export class AnythingQuickAccessProvider extends PickerQuickAccessProvider<IAnyt
 			openSideBySideDirection: editorConfig?.openSideBySideDirection,
 			includeSymbols: searchConfig?.quickOpen.includeSymbols,
 			includeHistory: searchConfig?.quickOpen.includeHistory,
+			ellipsisLocation: searchConfig?.quickOpen.ellipsisLocation,
 			historyFilterSortOrder: searchConfig?.quickOpen.history.filterSortOrder,
 			shortAutoSaveDelay: this.filesConfigurationService.getAutoSaveMode() === AutoSaveMode.AFTER_SHORT_DELAY,
 			preserveInput: quickAccessConfig.preserveInput

--- a/src/vs/workbench/contrib/search/browser/search.contribution.ts
+++ b/src/vs/workbench/contrib/search/browser/search.contribution.ts
@@ -215,10 +215,10 @@ configurationRegistry.registerConfiguration({
 			'type': 'string',
 			'enum': ['left', 'right'],
 			'default': 'right',
-			'description': nls.localize('search.quickOpen.ellipsisLocation', "Controls the location of the ellipsis in the quick open widget."),
+			'description': nls.localize('search.quickOpen.ellipsisLocation', "Controls the location of the ellipsis in truncated quick-open results."),
 			'enumDescriptions': [
-				nls.localize('search.quickOpen.ellipsisLocation.left', 'Ellipsis is located at the left of the label.'),
-				nls.localize('search.quickOpen.ellipsisLocation.right', 'Ellipsis is located at the right of the label.')
+				nls.localize('search.quickOpen.ellipsisLocation.left', 'Ellipsis is located at the left of the text.'),
+				nls.localize('search.quickOpen.ellipsisLocation.right', 'Ellipsis is located at the right of the text.')
 			]
 		},
 		'search.followSymlinks': {

--- a/src/vs/workbench/contrib/search/browser/search.contribution.ts
+++ b/src/vs/workbench/contrib/search/browser/search.contribution.ts
@@ -211,6 +211,16 @@ configurationRegistry.registerConfiguration({
 			],
 			'description': nls.localize('filterSortOrder', "Controls sorting order of editor history in quick open when filtering.")
 		},
+		'search.quickOpen.ellipsisLocation': {
+			'type': 'string',
+			'enum': ['left', 'right'],
+			'default': 'right',
+			'description': nls.localize('search.quickOpen.ellipsisLocation', "Controls the location of the ellipsis in the quick open widget."),
+			'enumDescriptions': [
+				nls.localize('search.quickOpen.ellipsisLocation.left', 'Ellipsis is located at the left of the label.'),
+				nls.localize('search.quickOpen.ellipsisLocation.right', 'Ellipsis is located at the right of the label.')
+			]
+		},
 		'search.followSymlinks': {
 			type: 'boolean',
 			description: nls.localize('search.followSymlinks', "Controls whether to follow symlinks while searching."),

--- a/src/vs/workbench/contrib/search/common/search.ts
+++ b/src/vs/workbench/contrib/search/common/search.ts
@@ -123,6 +123,7 @@ export interface IWorkbenchSearchConfigurationProperties extends ISearchConfigur
 	quickOpen: {
 		includeSymbols: boolean;
 		includeHistory: boolean;
+		ellipsisLocation: 'left' | 'right';
 		history: {
 			filterSortOrder: 'default' | 'recency';
 		};


### PR DESCRIPTION
Fixes #143956.

I saw #145450 and wanted to proceed with its implementation. The discussion there served as my guide.

Right now I'm stuck. Adding the `left-ellipsis` class to the `monaco-icon-description-container` element causes its `monaco-highlighted-label` child to not be drawn. I *think* this is because, at some point in the pipeline, the parent class of the `monaco-highlighted-label` is referenced, and my addition of `left-ellipsis` causes that reference to break. However, I'm very new to this codebase and I don't know where to find this breakpoint. I'll keep looking for it on my own, but I thought it'd be lucrative to open this up to anyone who'd be willing to help.

I also haven't yet made it so the position of the ellipsis is affected by the `search.quickOpen.ellipsisLocation` option. I'm still figuring out how to do that, but I imagine it'll be simple enough.