### PR TITLE
fix: restore old behavior of not preventing default and not executing keybindings with empty command ID bound

### DIFF
--- a/src/vs/platform/keybinding/common/abstractKeybindingService.ts
+++ b/src/vs/platform/keybinding/common/abstractKeybindingService.ts
@@ -349,9 +349,8 @@ export abstract class AbstractKeybindingService extends Disposable implements IK
 						this._log(`+ Leaving chord mode: Nothing bound to "${currentChordsLabel}, ${keypressLabel}".`);
 						this._notificationService.status(nls.localize('missing.chord', "The key combination ({0}, {1}) is not a command.", currentChordsLabel, keypressLabel), { hideAfter: 10 * 1000 /* 10s */ });
 						this._leaveChordMode();
+						shouldPreventDefault = true;
 					}
-
-					shouldPreventDefault = true;
 
 				} else {
 					if (this.inChordMode) {

--- a/src/vs/platform/keybinding/common/abstractKeybindingService.ts
+++ b/src/vs/platform/keybinding/common/abstractKeybindingService.ts
@@ -342,7 +342,7 @@ export abstract class AbstractKeybindingService extends Disposable implements IK
 
 				this._logService.trace('KeybindingService#dispatch', keypressLabel, `[ Will dispatch command ${resolveResult.commandId} ]`);
 
-				if (resolveResult.commandId === null) {
+				if (resolveResult.commandId === null || resolveResult.commandId === '') {
 
 					if (this.inChordMode) {
 						const currentChordsLabel = this._currentChords.map(({ label }) => label).join(', ');


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/181654

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
