### PR TITLE
Add support for help link and allow customization of command and labels used in remote start entry

### DIFF
--- a/src/vs/base/common/product.ts
+++ b/src/vs/base/common/product.ts
@@ -252,14 +252,24 @@ export interface IRemoteExtensionTip {
 	friendlyName: string;
 	extensionId: string;
 	supportedPlatforms?: PlatformName[];
-	showInStartEntry?: boolean;
+	startEntry?: {
+		helpLink: string;
+		startConnectLabel: string;
+		startCommand: string;
+		priority: number;
+	};
 }
 
 export interface IVirtualWorkspaceExtensionTip {
 	friendlyName: string;
 	extensionId: string;
 	supportedPlatforms?: PlatformName[];
-	showInStartEntry?: boolean;
+	startEntry: {
+		helpLink: string;
+		startConnectLabel: string;
+		startCommand: string;
+		priority: number;
+	};
 }
 
 export interface ISurveyData {


### PR DESCRIPTION
Fixes:
https://github.com/microsoft/vscode/issues/178205 
https://github.com/microsoft/vscode/issues/177940
https://github.com/microsoft/vscode/issues/177936
https://github.com/microsoft/vscode/issues/178203

Added support in remoteExtensionTips to allow remote extensions to specify
1. The remote command to be after extension install (previously we would pick the first command from `statusbar/remoteEndicator` contribution
2. The command label to be shown in the quick pick for extension install
3. Help link icon in the quick pick.
<img width="449" alt="image" src="https://github.com/microsoft/vscode/assets/25044782/b371797a-be6b-421b-9705-5367ad4bb171">
