### PR TITLE
precedence for isReadonly() for #181708

### DIFF
--- a/src/vs/workbench/services/textfile/common/textFileEditorModel.ts
+++ b/src/vs/workbench/services/textfile/common/textFileEditorModel.ts
@@ -1160,8 +1160,7 @@ export class TextFileEditorModel extends BaseTextEditorModel implements ITextFil
 	}
 
 	override isReadonly(): boolean {
-		return this.lastResolvedFileStat?.readonly ||
-			this.fileService.hasCapability(this.resource, FileSystemProviderCapabilities.Readonly) ||
+		return this.fileService.hasCapability(this.resource, FileSystemProviderCapabilities.Readonly) ||
 			this.filesConfigurationService.isReadonly(this.resource, this.lastResolvedFileStat);
 	}
 

--- a/src/vs/workbench/services/workingCopy/common/storedFileWorkingCopy.ts
+++ b/src/vs/workbench/services/workingCopy/common/storedFileWorkingCopy.ts
@@ -1245,8 +1245,7 @@ export class StoredFileWorkingCopy<M extends IStoredFileWorkingCopyModel> extend
 	//#region Utilities
 
 	isReadonly(): boolean {
-		return this.lastResolvedFileStat?.readonly ||
-			this.fileService.hasCapability(this.resource, FileSystemProviderCapabilities.Readonly) ||
+		return this.fileService.hasCapability(this.resource, FileSystemProviderCapabilities.Readonly) ||
 			this.filesConfigurationService.isReadonly(this.resource, this.lastResolvedFileStat);
 	}
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
https://github.com/microsoft/vscode/pull/181708

isReadonly precedence:
* inSession/Command
* readonlyInclude/Exclude Globs
* configuredReadonlyFromPermissions && stat?.locked
* false

see: https://github.com/microsoft/vscode/pull/161716#issuecomment-1540663206