### PR TITLE
Snippets in bulk edits should not create extra undo stops

### DIFF
--- a/src/vs/workbench/contrib/bulkEdit/browser/bulkTextEdits.ts
+++ b/src/vs/workbench/contrib/bulkEdit/browser/bulkTextEdits.ts
@@ -156,7 +156,7 @@ class EditorEditTask extends ModelEditTask {
 						});
 					}
 				}
-				snippetCtrl.apply(snippetEdits);
+				snippetCtrl.apply(snippetEdits, { undoStopBefore: false, undoStopAfter: false });
 
 			} else {
 				// normal edit


### PR DESCRIPTION
Fixes #181962

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
