### PR TITLE
Fixing an issue in debug output prompts to not show up as '[object Object]'

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/debugSession.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugSession.ts
@@ -1345,7 +1345,7 @@ export class DebugSession implements IDebugSession {
 	appendToRepl(data: INewReplElementData, isImportant?: boolean): void {
 		this.repl.appendToRepl(this, data);
 		if (isImportant) {
-			this.notificationService.notify({ message: data.toString(), severity: data.sev, source: this.name });
+			this.notificationService.notify({ message: data.output.toString(), severity: data.sev, source: this.name });
 		}
 	}
 }


### PR DESCRIPTION
When this method is called from [debugSession.ts:1154](https://github.com/ashgti/vscode/blob/6a462308a4f5222b6738db9cd3265dceb808fc1f/src/vs/workbench/contrib/debug/browser/debugSession.ts#L1152) the value passed to `data` is an object, the actual output is in the `output` field on the object so the `.toString()` call results in a message like `[object Object]`.

