### PR TITLE
notebook search: text with ansi control codes (like for colors) causes wrong highlight in outputs

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewPreloads.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewPreloads.ts
@@ -1069,6 +1069,20 @@ async function webviewPreloads(ctx: PreloadContext) {
 		return range.commonAncestorContainer;
 	}
 
+	function getTextContentLength(node: Node): number {
+		let length = 0;
+
+		if (node.nodeType === Node.TEXT_NODE) {
+			length += node.textContent?.length || 0;
+		} else {
+			for (const childNode of node.childNodes) {
+				length += getTextContentLength(childNode);
+			}
+		}
+
+		return length;
+	}
+
 	// modified from https://stackoverflow.com/a/48812529/16253823
 	function getSelectionOffsetRelativeTo(parentElement: Node, currentNode: Node | null): number {
 		if (!currentNode) {
@@ -1084,8 +1098,7 @@ async function webviewPreloads(ctx: PreloadContext) {
 		// count the number of chars before the current dom elem and the start of the dom
 		let prevSibling = currentNode.previousSibling;
 		while (prevSibling) {
-			const nodeContent = prevSibling.nodeValue || '';
-			offset += nodeContent.length;
+			offset += getTextContentLength(prevSibling);
 			prevSibling = prevSibling.previousSibling;
 		}
 


### PR DESCRIPTION
Fixes #178286

Seems that this was a bug where the selection offsets were wrong if the preceeding sibling nodes of the highlight were non-text nodes.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
