### PR TITLE
Setting `NODE_UNC_HOST_ALLOWLIST` does not work (fix #182019)

### DIFF
--- a/src/vs/base/node/unc.ts
+++ b/src/vs/base/node/unc.ts
@@ -23,9 +23,7 @@ export function setUNCHostAllowlist(allowedHosts: string[]): void {
 	const allowlist = processUNCHostAllowlist();
 	if (allowlist) {
 		for (const allowedHost of allowedHosts) {
-			if (!allowlist.has(allowedHost)) {
-				allowlist.add(allowedHost);
-			}
+			allowlist.add(allowedHost);
 		}
 	}
 }

--- a/src/vs/base/node/unc.ts
+++ b/src/vs/base/node/unc.ts
@@ -22,10 +22,10 @@ export function setUNCHostAllowlist(allowedHosts: string[]): void {
 
 	const allowlist = processUNCHostAllowlist();
 	if (allowlist) {
-		allowlist.clear();
-
 		for (const allowedHost of allowedHosts) {
-			allowlist.add(allowedHost);
+			if (!allowlist.has(allowedHost)) {
+				allowlist.add(allowedHost);
+			}
 		}
 	}
 }


### PR DESCRIPTION
We offer `NODE_UNC_HOST_ALLOWLIST` as a way to configure the allow list from the system and this works fine up until we have anyone calling `setUNCHostAllowlist()`: we used to `clear` any previously configured hosts and this will actually clear any host configured by `NODE_UNC_HOST_ALLOWLIST`. 

The fix is to not `clear` but `add` to the `Set`. Since we only do this once on startup and never react to settings changes, this will be fine.

A variant of this fix is already live in todays insider 👍 