### PR TITLE
fix: restore old behavior of not preventing default and not executing keybindings with empty command ID bound (#181920)

### DIFF
--- a/src/vs/platform/keybinding/common/abstractKeybindingService.ts
+++ b/src/vs/platform/keybinding/common/abstractKeybindingService.ts
@@ -342,16 +342,15 @@ export abstract class AbstractKeybindingService extends Disposable implements IK
 
 				this._logService.trace('KeybindingService#dispatch', keypressLabel, `[ Will dispatch command ${resolveResult.commandId} ]`);
 
-				if (resolveResult.commandId === null) {
+				if (resolveResult.commandId === null || resolveResult.commandId === '') {
 
 					if (this.inChordMode) {
 						const currentChordsLabel = this._currentChords.map(({ label }) => label).join(', ');
 						this._log(`+ Leaving chord mode: Nothing bound to "${currentChordsLabel}, ${keypressLabel}".`);
 						this._notificationService.status(nls.localize('missing.chord', "The key combination ({0}, {1}) is not a command.", currentChordsLabel, keypressLabel), { hideAfter: 10 * 1000 /* 10s */ });
 						this._leaveChordMode();
+						shouldPreventDefault = true;
 					}
-
-					shouldPreventDefault = true;
 
 				} else {
 					if (this.inChordMode) {


### PR DESCRIPTION
* abstractKeybindingService: fix: don't try executing keybindings with empty command IDs

* abstractKeybindingService: fix: restore old behavior that wouldn't prevent default if the keybinding has an empty command ID (unless the keybinding consists of more than one chord)


Fixes #181654

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
