### PR TITLE
Cache auto port properties

### DIFF
--- a/src/vs/platform/tunnel/common/tunnel.ts
+++ b/src/vs/platform/tunnel/common/tunnel.ts
@@ -349,6 +349,9 @@ export abstract class AbstractTunnelService implements ITunnelService {
 			if (tunnel.tunnelRemoteHost !== remoteHost || tunnel.tunnelRemotePort !== remotePort) {
 				this.logService.warn('ForwardedPorts: (TunnelService) Created tunnel does not match requirements of requested tunnel. Host or port mismatch.');
 			}
+			if (privacy && tunnel.privacy !== privacy) {
+				this.logService.warn('ForwardedPorts: (TunnelService) Created tunnel does not match requirements of requested tunnel. Privacy mismatch.');
+			}
 			this._onTunnelOpened.fire(newTunnel);
 			return newTunnel;
 		});

--- a/src/vs/workbench/api/browser/mainThreadTunnelService.ts
+++ b/src/vs/workbench/api/browser/mainThreadTunnelService.ts
@@ -7,7 +7,7 @@ import * as nls from 'vs/nls';
 import { MainThreadTunnelServiceShape, MainContext, ExtHostContext, ExtHostTunnelServiceShape, CandidatePortSource, PortAttributesProviderSelector, TunnelDto } from 'vs/workbench/api/common/extHost.protocol';
 import { TunnelDtoConverter } from 'vs/workbench/api/common/extHostTunnelService';
 import { extHostNamedCustomer, IExtHostContext } from 'vs/workbench/services/extensions/common/extHostCustomers';
-import { CandidatePort, IRemoteExplorerService, makeAddress, PORT_AUTO_FORWARD_SETTING, PORT_AUTO_SOURCE_SETTING, PORT_AUTO_SOURCE_SETTING_OUTPUT, TunnelSource } from 'vs/workbench/services/remote/common/remoteExplorerService';
+import { CandidatePort, IRemoteExplorerService, makeAddress, PORT_AUTO_FORWARD_SETTING, PORT_AUTO_SOURCE_SETTING, PORT_AUTO_SOURCE_SETTING_OUTPUT, TunnelCloseReason, TunnelSource } from 'vs/workbench/services/remote/common/remoteExplorerService';
 import { ITunnelProvider, ITunnelService, TunnelCreationOptions, TunnelProviderFeatures, TunnelOptions, RemoteTunnel, ProvidedPortAttributes, PortAttributesProvider, TunnelProtocol } from 'vs/platform/tunnel/common/tunnel';
 import { Disposable } from 'vs/base/common/lifecycle';
 import type { TunnelDescription } from 'vs/platform/remote/common/remoteAuthorityResolver';
@@ -129,7 +129,7 @@ export class MainThreadTunnelService extends Disposable implements MainThreadTun
 				label: nls.localize('remote.tunnelsView.elevationButton', "Use Port {0} as Sudo...", tunnel.tunnelRemotePort),
 				run: async () => {
 					this.elevateionRetry = true;
-					await this.remoteExplorerService.close({ host: tunnel.tunnelRemoteHost, port: tunnel.tunnelRemotePort });
+					await this.remoteExplorerService.close({ host: tunnel.tunnelRemoteHost, port: tunnel.tunnelRemotePort }, TunnelCloseReason.Other);
 					await this.remoteExplorerService.forward({
 						remote: tunnelOptions.remoteAddress,
 						local: tunnelOptions.localAddressPort,
@@ -146,7 +146,7 @@ export class MainThreadTunnelService extends Disposable implements MainThreadTun
 	}
 
 	async $closeTunnel(remote: { host: string; port: number }): Promise<void> {
-		return this.remoteExplorerService.close(remote);
+		return this.remoteExplorerService.close(remote, TunnelCloseReason.Other);
 	}
 
 	async $getTunnels(): Promise<TunnelDescription[]> {

--- a/src/vs/workbench/contrib/remote/browser/remoteExplorer.ts
+++ b/src/vs/workbench/contrib/remote/browser/remoteExplorer.ts
@@ -6,7 +6,7 @@ import * as nls from 'vs/nls';
 import { Disposable, IDisposable } from 'vs/base/common/lifecycle';
 import { IWorkbenchContribution } from 'vs/workbench/common/contributions';
 import { Extensions, IViewContainersRegistry, IViewsRegistry, ViewContainer, ViewContainerLocation } from 'vs/workbench/common/views';
-import { Attributes, AutoTunnelSource, IRemoteExplorerService, makeAddress, mapHasAddressLocalhostOrAllInterfaces, OnPortForward, PORT_AUTO_FORWARD_SETTING, PORT_AUTO_SOURCE_SETTING, PORT_AUTO_SOURCE_SETTING_HYBRID, PORT_AUTO_SOURCE_SETTING_OUTPUT, PORT_AUTO_SOURCE_SETTING_PROCESS, Tunnel, TUNNEL_VIEW_CONTAINER_ID, TUNNEL_VIEW_ID, TunnelSource } from 'vs/workbench/services/remote/common/remoteExplorerService';
+import { Attributes, AutoTunnelSource, IRemoteExplorerService, makeAddress, mapHasAddressLocalhostOrAllInterfaces, OnPortForward, PORT_AUTO_FORWARD_SETTING, PORT_AUTO_SOURCE_SETTING, PORT_AUTO_SOURCE_SETTING_HYBRID, PORT_AUTO_SOURCE_SETTING_OUTPUT, PORT_AUTO_SOURCE_SETTING_PROCESS, Tunnel, TUNNEL_VIEW_CONTAINER_ID, TUNNEL_VIEW_ID, TunnelCloseReason, TunnelSource } from 'vs/workbench/services/remote/common/remoteExplorerService';
 import { forwardedPortsViewEnabled, ForwardPortAction, OpenPortInBrowserAction, TunnelPanel, TunnelPanelDescriptor, TunnelViewModel, OpenPortInPreviewAction, openPreviewEnabledContext } from 'vs/workbench/contrib/remote/browser/tunnelView';
 import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 import { IWorkbenchEnvironmentService } from 'vs/workbench/services/environment/common/environmentService';
@@ -380,7 +380,7 @@ class OnAutoForwardedAction extends Disposable {
 			// Privileged ports are not on Windows, so it's ok to stick to just "sudo".
 			label: nls.localize('remote.tunnelsView.elevationButton', "Use Port {0} as Sudo...", tunnel.tunnelRemotePort),
 			run: async () => {
-				await this.remoteExplorerService.close({ host: tunnel.tunnelRemoteHost, port: tunnel.tunnelRemotePort });
+				await this.remoteExplorerService.close({ host: tunnel.tunnelRemoteHost, port: tunnel.tunnelRemotePort }, TunnelCloseReason.Other);
 				const newTunnel = await this.remoteExplorerService.forward({
 					remote: { host: tunnel.tunnelRemoteHost, port: tunnel.tunnelRemotePort },
 					local: tunnel.tunnelRemotePort,
@@ -643,7 +643,7 @@ class ProcAutomaticPortForwarding extends Disposable {
 				} else {
 					value = { host: forwardedValue.remoteHost, port: forwardedValue.remotePort };
 				}
-				await this.remoteExplorerService.close(value);
+				await this.remoteExplorerService.close(value, TunnelCloseReason.AutoForwardEnd);
 				removedPorts.push(value.port);
 			} else if (this.notifiedOnly.has(key)) {
 				this.notifiedOnly.delete(key);

--- a/src/vs/workbench/services/remote/common/remoteExplorerService.ts
+++ b/src/vs/workbench/services/remote/common/remoteExplorerService.ts
@@ -514,14 +514,6 @@ export class TunnelModel extends Disposable {
 	private async onTunnelClosed(address: { host: string; port: number }, reason: TunnelCloseReason) {
 		const key = makeAddress(address.host, address.port);
 		if (this.forwarded.has(key)) {
-			const oldTunnel = this.forwarded.get(key)!;
-			if (reason === TunnelCloseReason.AutoForwardEnd) {
-				this.sessionCachedProperties.set(key, {
-					local: oldTunnel.localPort,
-					name: oldTunnel.name,
-					privacy: oldTunnel.privacy,
-				});
-			}
 			this.forwarded.delete(key);
 			await this.storeForwarded();
 			this._onClosePort.fire(address);
@@ -749,6 +741,15 @@ export class TunnelModel extends Disposable {
 	}
 
 	async close(host: string, port: number, reason: TunnelCloseReason): Promise<void> {
+		const key = makeAddress(host, port);
+		const oldTunnel = this.forwarded.get(key)!;
+		if (reason === TunnelCloseReason.AutoForwardEnd) {
+			this.sessionCachedProperties.set(key, {
+				local: oldTunnel.localPort,
+				name: oldTunnel.name,
+				privacy: oldTunnel.privacy,
+			});
+		}
 		await this.tunnelService.closeTunnel(host, port);
 		return this.onTunnelClosed({ host, port }, reason);
 	}

--- a/src/vs/workbench/services/remote/common/remoteExplorerService.ts
+++ b/src/vs/workbench/services/remote/common/remoteExplorerService.ts
@@ -426,6 +426,7 @@ export class TunnelModel extends Disposable {
 	private restoreListener: IDisposable | undefined;
 	private knownPortsRestoreValue: string | undefined;
 	private unrestoredExtensionTunnels: Map<string, Tunnel> = new Map();
+	private sessionCachedProperties: Map<string, Partial<TunnelProperties>> = new Map();
 
 	private portAttributesProviders: PortAttributesProvider[] = [];
 
@@ -507,6 +508,12 @@ export class TunnelModel extends Disposable {
 	private async onTunnelClosed(address: { host: string; port: number }) {
 		const key = makeAddress(address.host, address.port);
 		if (this.forwarded.has(key)) {
+			const oldTunnel = this.forwarded.get(key)!;
+			this.sessionCachedProperties.set(key, {
+				local: oldTunnel.localPort,
+				name: oldTunnel.name,
+				privacy: oldTunnel.privacy,
+			});
 			this.forwarded.delete(key);
 			await this.storeForwarded();
 			this._onClosePort.fire(address);
@@ -631,7 +638,9 @@ export class TunnelModel extends Disposable {
 
 			const key = makeAddress(tunnelProperties.remote.host, tunnelProperties.remote.port);
 			this.inProgress.set(key, true);
-			let tunnel = await this.tunnelService.openTunnel(addressProvider, tunnelProperties.remote.host, tunnelProperties.remote.port, undefined, localPort, (!tunnelProperties.elevateIfNeeded) ? attributes?.elevateIfNeeded : tunnelProperties.elevateIfNeeded, tunnelProperties.privacy, attributes?.protocol);
+			tunnelProperties = this.mergeCachedAndUnrestoredProperties(key, tunnelProperties);
+
+			const tunnel = await this.tunnelService.openTunnel(addressProvider, tunnelProperties.remote.host, tunnelProperties.remote.port, undefined, localPort, (!tunnelProperties.elevateIfNeeded) ? attributes?.elevateIfNeeded : tunnelProperties.elevateIfNeeded, tunnelProperties.privacy, attributes?.protocol);
 			if (tunnel && tunnel.localAddress) {
 				const matchingCandidate = mapHasAddressLocalhostOrAllInterfaces<CandidatePort>(this._candidates ?? new Map(), tunnelProperties.remote.host, tunnelProperties.remote.port);
 				const protocol = (tunnel.protocol ?
@@ -658,37 +667,63 @@ export class TunnelModel extends Disposable {
 				await this.storeForwarded();
 				await this.showPortMismatchModalIfNeeded(tunnel, localPort, attributes);
 				this._onForwardPort.fire(newForward);
-				if (this.unrestoredExtensionTunnels.has(key)) {
-					const updateProps = this.unrestoredExtensionTunnels.get(key);
-					this.unrestoredExtensionTunnels.delete(key);
-					if (updateProps) {
-						tunnel = await this.forward({
-							remote: { host: newForward.remoteHost, port: newForward.remotePort },
-							local: newForward.localPort,
-							name: newForward.name,
-							privacy: updateProps.privacy,
-							elevateIfNeeded: true,
-						});
-					}
-				}
 				return tunnel;
 			}
 			this.inProgress.delete(key);
 		} else {
-			const newName = attributes?.label ?? tunnelProperties.name;
-			if (newName !== existingTunnel.name) {
-				existingTunnel.name = newName;
-				this._onForwardPort.fire();
-			}
-			if ((attributes?.protocol || (existingTunnel.protocol !== TunnelProtocol.Http)) && (attributes?.protocol !== existingTunnel.protocol)) {
-				await this.close(existingTunnel.remoteHost, existingTunnel.remotePort);
-				tunnelProperties.source = existingTunnel.source;
-				await this.forward(tunnelProperties, attributes);
-			}
-			return mapHasAddressLocalhostOrAllInterfaces(this.remoteTunnels, tunnelProperties.remote.host, tunnelProperties.remote.port);
+			return this.mergeAttributesIntoExistingTunnel(existingTunnel, tunnelProperties, attributes);
 		}
 
 		return undefined;
+	}
+
+	private mergeCachedAndUnrestoredProperties(key: string, tunnelProperties: TunnelProperties): TunnelProperties {
+		const map = this.unrestoredExtensionTunnels.has(key) ? this.unrestoredExtensionTunnels : (this.sessionCachedProperties.has(key) ? this.sessionCachedProperties : undefined);
+		if (map) {
+			const updateProps = map.get(key)!;
+			map.delete(key);
+			if (updateProps) {
+				tunnelProperties.name = updateProps.name ?? tunnelProperties.name;
+				tunnelProperties.local = (('local' in updateProps) ? updateProps.local : (('localPort' in updateProps) ? updateProps.localPort : undefined)) ?? tunnelProperties.local;
+				tunnelProperties.privacy = updateProps.privacy ?? tunnelProperties.privacy;
+			}
+		}
+		return tunnelProperties;
+	}
+
+	private async mergeAttributesIntoExistingTunnel(existingTunnel: Tunnel, tunnelProperties: TunnelProperties, attributes: Attributes | undefined) {
+		const newName = attributes?.label ?? tunnelProperties.name;
+		enum MergedAttributeAction {
+			None = 0,
+			Fire = 1,
+			Reopen = 2
+		}
+		let mergedAction = MergedAttributeAction.None;
+		if (newName !== existingTunnel.name) {
+			existingTunnel.name = newName;
+			mergedAction = MergedAttributeAction.Fire;
+		}
+		// Source of existing tunnel wins so that original source is maintained
+		if ((attributes?.protocol || (existingTunnel.protocol !== TunnelProtocol.Http)) && (attributes?.protocol !== existingTunnel.protocol)) {
+			tunnelProperties.source = existingTunnel.source;
+			mergedAction = MergedAttributeAction.Reopen;
+		}
+		// New privacy value wins
+		if (tunnelProperties.privacy && (existingTunnel.privacy !== tunnelProperties.privacy)) {
+			mergedAction = MergedAttributeAction.Reopen;
+		}
+		switch (mergedAction) {
+			case MergedAttributeAction.Fire: {
+				this._onForwardPort.fire();
+				break;
+			}
+			case MergedAttributeAction.Reopen: {
+				await this.close(existingTunnel.remoteHost, existingTunnel.remotePort);
+				await this.forward(tunnelProperties, attributes);
+			}
+		}
+
+		return mapHasAddressLocalhostOrAllInterfaces(this.remoteTunnels, tunnelProperties.remote.host, tunnelProperties.remote.port);
 	}
 
 	async name(host: string, port: number, name: string) {


### PR DESCRIPTION
Cache user configured properties of auto forwarded ports so that they get re-applied when the prot gets automatically unforwarded and re-forwarded.