### PR TITLE
Add priority to paste / drop apis

### DIFF
--- a/extensions/ipynb/src/notebookImagePaste.ts
+++ b/extensions/ipynb/src/notebookImagePaste.ts
@@ -45,8 +45,10 @@ function getImageMimeType(uri: vscode.Uri): string | undefined {
 	return imageExtToMime.get(extname(uri.fsPath).toLowerCase());
 }
 
-const id = 'insertAttachment';
-class CopyPasteEditProvider implements vscode.DocumentPasteEditProvider {
+class DropOrPasteEditProvider implements vscode.DocumentPasteEditProvider, vscode.DocumentDropEditProvider {
+
+	private readonly id = 'insertAttachment';
+	private readonly priority = -1;
 
 	async provideDocumentPasteEdits(
 		document: vscode.TextDocument,
@@ -59,18 +61,16 @@ class CopyPasteEditProvider implements vscode.DocumentPasteEditProvider {
 			return;
 		}
 
-		const insert = await createInsertImageAttachmentEdit(document, dataTransfer, token);
+		const insert = await this.createInsertImageAttachmentEdit(document, dataTransfer, token);
 		if (!insert) {
 			return;
 		}
 
-		const pasteEdit = new vscode.DocumentPasteEdit(insert.insertText, id, vscode.l10n.t('Insert Image as Attachment'));
+		const pasteEdit = new vscode.DocumentPasteEdit(insert.insertText, this.id, vscode.l10n.t('Insert Image as Attachment'));
+		pasteEdit.priority = this.priority;
 		pasteEdit.additionalEdit = insert.additionalEdit;
 		return pasteEdit;
 	}
-}
-
-class DropEditProvider implements vscode.DocumentDropEditProvider {
 
 	async provideDocumentDropEdits(
 		document: vscode.TextDocument,
@@ -78,58 +78,59 @@ class DropEditProvider implements vscode.DocumentDropEditProvider {
 		dataTransfer: vscode.DataTransfer,
 		token: vscode.CancellationToken,
 	): Promise<vscode.DocumentDropEdit | undefined> {
-		const insert = await createInsertImageAttachmentEdit(document, dataTransfer, token);
+		const insert = await this.createInsertImageAttachmentEdit(document, dataTransfer, token);
 		if (!insert) {
 			return;
 		}
 
 		const dropEdit = new vscode.DocumentDropEdit(insert.insertText);
-		dropEdit.id = id;
+		dropEdit.id = this.id;
+		dropEdit.priority = this.priority;
 		dropEdit.additionalEdit = insert.additionalEdit;
 		dropEdit.label = vscode.l10n.t('Insert Image as Attachment');
 		return dropEdit;
 	}
-}
 
-async function createInsertImageAttachmentEdit(
-	document: vscode.TextDocument,
-	dataTransfer: vscode.DataTransfer,
-	token: vscode.CancellationToken,
-): Promise<{ insertText: vscode.SnippetString; additionalEdit: vscode.WorkspaceEdit } | undefined> {
-	const imageData = await getDroppedImageData(dataTransfer, token);
-	if (!imageData.length || token.isCancellationRequested) {
-		return;
-	}
-
-	const currentCell = getCellFromCellDocument(document);
-	if (!currentCell) {
-		return undefined;
-	}
-
-	// create updated metadata for cell (prep for WorkspaceEdit)
-	const newAttachment = buildAttachment(currentCell, imageData);
-	if (!newAttachment) {
-		return;
-	}
-
-	// build edits
-	const additionalEdit = new vscode.WorkspaceEdit();
-	const nbEdit = vscode.NotebookEdit.updateCellMetadata(currentCell.index, newAttachment.metadata);
-	const notebookUri = currentCell.notebook.uri;
-	additionalEdit.set(notebookUri, [nbEdit]);
-
-	// create a snippet for paste
-	const insertText = new vscode.SnippetString();
-	newAttachment.filenames.forEach((filename, i) => {
-		insertText.appendText('![');
-		insertText.appendPlaceholder(`${filename}`);
-		insertText.appendText(`](${/\s/.test(filename) ? `<attachment:${filename}>` : `attachment:${filename}`})`);
-		if (i !== newAttachment.filenames.length - 1) {
-			insertText.appendText(' ');
+	private async createInsertImageAttachmentEdit(
+		document: vscode.TextDocument,
+		dataTransfer: vscode.DataTransfer,
+		token: vscode.CancellationToken,
+	): Promise<{ insertText: vscode.SnippetString; additionalEdit: vscode.WorkspaceEdit } | undefined> {
+		const imageData = await getDroppedImageData(dataTransfer, token);
+		if (!imageData.length || token.isCancellationRequested) {
+			return;
 		}
-	});
 
-	return { insertText, additionalEdit };
+		const currentCell = getCellFromCellDocument(document);
+		if (!currentCell) {
+			return undefined;
+		}
+
+		// create updated metadata for cell (prep for WorkspaceEdit)
+		const newAttachment = buildAttachment(currentCell, imageData);
+		if (!newAttachment) {
+			return;
+		}
+
+		// build edits
+		const additionalEdit = new vscode.WorkspaceEdit();
+		const nbEdit = vscode.NotebookEdit.updateCellMetadata(currentCell.index, newAttachment.metadata);
+		const notebookUri = currentCell.notebook.uri;
+		additionalEdit.set(notebookUri, [nbEdit]);
+
+		// create a snippet for paste
+		const insertText = new vscode.SnippetString();
+		newAttachment.filenames.forEach((filename, i) => {
+			insertText.appendText('![');
+			insertText.appendPlaceholder(`${filename}`);
+			insertText.appendText(`](${/\s/.test(filename) ? `<attachment:${filename}>` : `attachment:${filename}`})`);
+			if (i !== newAttachment.filenames.length - 1) {
+				insertText.appendText(' ');
+			}
+		});
+
+		return { insertText, additionalEdit };
+	}
 }
 
 async function getDroppedImageData(
@@ -296,14 +297,15 @@ function buildAttachment(
 }
 
 export function notebookImagePasteSetup(): vscode.Disposable {
+	const provider = new DropOrPasteEditProvider();
 	return vscode.Disposable.from(
-		vscode.languages.registerDocumentPasteEditProvider(JUPYTER_NOTEBOOK_MARKDOWN_SELECTOR, new CopyPasteEditProvider(), {
+		vscode.languages.registerDocumentPasteEditProvider(JUPYTER_NOTEBOOK_MARKDOWN_SELECTOR, provider, {
 			pasteMimeTypes: [
 				MimeType.png,
 				MimeType.uriList,
 			],
 		}),
-		vscode.languages.registerDocumentDropEditProvider(JUPYTER_NOTEBOOK_MARKDOWN_SELECTOR, new DropEditProvider(), {
+		vscode.languages.registerDocumentDropEditProvider(JUPYTER_NOTEBOOK_MARKDOWN_SELECTOR, provider, {
 			dropMimeTypes: [
 				...Object.values(imageExtToMime),
 				MimeType.uriList,

--- a/extensions/markdown-language-features/src/languageFeatures/copyFiles/copyPaste.ts
+++ b/extensions/markdown-language-features/src/languageFeatures/copyFiles/copyPaste.ts
@@ -21,8 +21,6 @@ class PasteEditProvider implements vscode.DocumentPasteEditProvider {
 
 	private readonly _id = 'insertLink';
 
-	private readonly _priority = -10;
-
 	async provideDocumentPasteEdits(
 		document: vscode.TextDocument,
 		_ranges: readonly vscode.Range[],
@@ -45,7 +43,7 @@ class PasteEditProvider implements vscode.DocumentPasteEditProvider {
 		}
 
 		const uriEdit = new vscode.DocumentPasteEdit(snippet.snippet, this._id, snippet.label);
-		uriEdit.priority = this._priority;
+		uriEdit.priority = this._getPriority(dataTransfer);
 		return uriEdit;
 	}
 
@@ -99,8 +97,16 @@ class PasteEditProvider implements vscode.DocumentPasteEditProvider {
 
 		const pasteEdit = new vscode.DocumentPasteEdit(snippet.snippet, this._id, snippet.label);
 		pasteEdit.additionalEdit = workspaceEdit;
-		pasteEdit.priority = this._priority;
+		pasteEdit.priority = this._getPriority(dataTransfer);
 		return pasteEdit;
+	}
+
+	private _getPriority(dataTransfer: vscode.DataTransfer): number {
+		if (dataTransfer.get('text/plain')) {
+			// Deprioritize in favor of normal text content
+			return -10;
+		}
+		return 0;
 	}
 }
 

--- a/extensions/markdown-language-features/src/languageFeatures/copyFiles/copyPaste.ts
+++ b/extensions/markdown-language-features/src/languageFeatures/copyFiles/copyPaste.ts
@@ -32,13 +32,19 @@ class PasteEditProvider implements vscode.DocumentPasteEditProvider {
 			return;
 		}
 
-		const edit = await this._makeCreateImagePasteEdit(document, dataTransfer, token);
-		if (edit) {
-			return edit;
+		const createEdit = await this._makeCreateImagePasteEdit(document, dataTransfer, token);
+		if (createEdit) {
+			return createEdit;
 		}
 
 		const snippet = await tryGetUriListSnippet(document, dataTransfer, token);
-		return snippet ? new vscode.DocumentPasteEdit(snippet.snippet, this._id, snippet.label) : undefined;
+		if (!snippet) {
+			return;
+		}
+
+		const uriEdit = new vscode.DocumentPasteEdit(snippet.snippet, this._id, snippet.label);
+		uriEdit.priority = -1;
+		return uriEdit;
 	}
 
 	private async _makeCreateImagePasteEdit(document: vscode.TextDocument, dataTransfer: vscode.DataTransfer, token: vscode.CancellationToken): Promise<vscode.DocumentPasteEdit | undefined> {
@@ -89,8 +95,9 @@ class PasteEditProvider implements vscode.DocumentPasteEditProvider {
 			return;
 		}
 
-		const pasteEdit = new vscode.DocumentPasteEdit(snippet.snippet, '', snippet.label);
+		const pasteEdit = new vscode.DocumentPasteEdit(snippet.snippet, this._id, snippet.label);
 		pasteEdit.additionalEdit = workspaceEdit;
+		pasteEdit.priority = -1;
 		return pasteEdit;
 	}
 }

--- a/extensions/markdown-language-features/src/languageFeatures/copyFiles/copyPaste.ts
+++ b/extensions/markdown-language-features/src/languageFeatures/copyFiles/copyPaste.ts
@@ -21,6 +21,8 @@ class PasteEditProvider implements vscode.DocumentPasteEditProvider {
 
 	private readonly _id = 'insertLink';
 
+	private readonly _priority = -10;
+
 	async provideDocumentPasteEdits(
 		document: vscode.TextDocument,
 		_ranges: readonly vscode.Range[],
@@ -43,7 +45,7 @@ class PasteEditProvider implements vscode.DocumentPasteEditProvider {
 		}
 
 		const uriEdit = new vscode.DocumentPasteEdit(snippet.snippet, this._id, snippet.label);
-		uriEdit.priority = -1;
+		uriEdit.priority = this._priority;
 		return uriEdit;
 	}
 
@@ -97,7 +99,7 @@ class PasteEditProvider implements vscode.DocumentPasteEditProvider {
 
 		const pasteEdit = new vscode.DocumentPasteEdit(snippet.snippet, this._id, snippet.label);
 		pasteEdit.additionalEdit = workspaceEdit;
-		pasteEdit.priority = -1;
+		pasteEdit.priority = this._priority;
 		return pasteEdit;
 	}
 }

--- a/src/vs/editor/common/languages.ts
+++ b/src/vs/editor/common/languages.ts
@@ -786,6 +786,7 @@ export interface DocumentPasteEdit {
 	readonly id: string;
 	readonly label: string;
 	readonly detail: string;
+	readonly priority: number;
 	insertText: string | { readonly snippet: string };
 	additionalEdit?: WorkspaceEdit;
 }
@@ -1948,6 +1949,7 @@ export enum ExternalUriOpenerPriority {
 export interface DocumentOnDropEdit {
 	readonly id: string;
 	readonly label: string;
+	readonly priority: number;
 	insertText: string | { readonly snippet: string };
 	additionalEdit?: WorkspaceEdit;
 }

--- a/src/vs/editor/contrib/dropOrPasteInto/browser/copyPasteController.ts
+++ b/src/vs/editor/contrib/dropOrPasteInto/browser/copyPasteController.ts
@@ -391,6 +391,7 @@ export class CopyPasteController extends Disposable implements IEditorContributi
 				providers.map(provider => provider.provideDocumentPasteEdits(model, selections, dataTransfer, token))
 			).then(coalesce),
 			token);
+		result?.sort((a, b) => b.priority - a.priority);
 		return result ?? [];
 	}
 

--- a/src/vs/editor/contrib/dropOrPasteInto/browser/defaultProviders.ts
+++ b/src/vs/editor/contrib/dropOrPasteInto/browser/defaultProviders.ts
@@ -29,12 +29,12 @@ abstract class SimplePasteAndDropProvider implements DocumentOnDropEditProvider,
 
 	async provideDocumentPasteEdits(_model: ITextModel, _ranges: readonly IRange[], dataTransfer: VSDataTransfer, token: CancellationToken): Promise<DocumentPasteEdit | undefined> {
 		const edit = await this.getEdit(dataTransfer, token);
-		return edit ? { id: this.id, insertText: edit.insertText, label: edit.label, detail: edit.detail } : undefined;
+		return edit ? { id: this.id, insertText: edit.insertText, label: edit.label, detail: edit.detail, priority: edit.priority } : undefined;
 	}
 
 	async provideDocumentOnDropEdits(_model: ITextModel, _position: IPosition, dataTransfer: VSDataTransfer, token: CancellationToken): Promise<DocumentOnDropEdit | undefined> {
 		const edit = await this.getEdit(dataTransfer, token);
-		return edit ? { id: this.id, insertText: edit.insertText, label: edit.label } : undefined;
+		return edit ? { id: this.id, insertText: edit.insertText, label: edit.label, priority: edit.priority } : undefined;
 	}
 
 	protected abstract getEdit(dataTransfer: VSDataTransfer, token: CancellationToken): Promise<DocumentPasteEdit | undefined>;
@@ -61,6 +61,7 @@ class DefaultTextProvider extends SimplePasteAndDropProvider {
 		const insertText = await textEntry.asString();
 		return {
 			id: this.id,
+			priority: 0,
 			label: localize('text.label', "Insert Plain Text"),
 			detail: builtInLabel,
 			insertText
@@ -107,6 +108,7 @@ class PathProvider extends SimplePasteAndDropProvider {
 
 		return {
 			id: this.id,
+			priority: 0,
 			insertText,
 			label,
 			detail: builtInLabel,
@@ -143,6 +145,7 @@ class RelativePathProvider extends SimplePasteAndDropProvider {
 
 		return {
 			id: this.id,
+			priority: 0,
 			insertText: relativeUris.join(' '),
 			label: entries.length > 1
 				? localize('defaultDropProvider.uriList.relativePaths', "Insert Relative Paths")

--- a/src/vs/workbench/api/browser/mainThreadLanguageFeatures.ts
+++ b/src/vs/workbench/api/browser/mainThreadLanguageFeatures.ts
@@ -974,10 +974,7 @@ class MainThreadPasteEditProvider implements languages.DocumentPasteEditProvider
 			}
 
 			return {
-				id: result.id,
-				label: result.label,
-				detail: result.detail,
-				insertText: result.insertText,
+				...result,
 				additionalEdit: result.additionalEdit ? reviveWorkspaceEditDto(result.additionalEdit, this._uriIdentService, dataId => this.resolveFileData(request.id, dataId)) : undefined,
 			};
 		} finally {
@@ -1014,9 +1011,7 @@ class MainThreadDocumentOnDropEditProvider implements languages.DocumentOnDropEd
 				return undefined;
 			}
 			return {
-				id: edit.id,
-				label: edit.label,
-				insertText: edit.insertText,
+				...edit,
 				additionalEdit: reviveWorkspaceEditDto(edit.additionalEdit, this._uriIdentService, dataId => this.resolveDocumentOnDropFileData(request.id, dataId)),
 			};
 		} finally {

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -1838,6 +1838,7 @@ export interface IPasteEditDto {
 	id: string;
 	label: string;
 	detail: string;
+	priority: number;
 	insertText: string | { snippet: string };
 	additionalEdit?: IWorkspaceEditDto;
 }
@@ -1849,6 +1850,7 @@ export interface IDocumentDropEditProviderMetadata {
 export interface IDocumentOnDropEditDto {
 	id: string;
 	label: string;
+	priority: number;
 	insertText: string | { snippet: string };
 	additionalEdit?: IWorkspaceEditDto;
 }

--- a/src/vs/workbench/api/common/extHostLanguageFeatures.ts
+++ b/src/vs/workbench/api/common/extHostLanguageFeatures.ts
@@ -541,6 +541,7 @@ class DocumentPasteEditProvider {
 			id: edit.id ? this._extension.identifier.value + '.' + edit.id : this._extension.identifier.value,
 			label: edit.label ?? localize('defaultPasteLabel', "Paste using '{0}' extension", this._extension.displayName || this._extension.name),
 			detail: this._extension.displayName || this._extension.name,
+			priority: edit.priority ?? 0,
 			insertText: typeof edit.insertText === 'string' ? edit.insertText : { snippet: edit.insertText.value },
 			additionalEdit: edit.additionalEdit ? typeConvert.WorkspaceEdit.from(edit.additionalEdit, undefined) : undefined,
 		};
@@ -1754,6 +1755,7 @@ class DocumentOnDropEditAdapter {
 		return {
 			id: edit.id ? this._extension.identifier.value + '.' + edit.id : this._extension.identifier.value,
 			label: edit.label ?? localize('defaultDropLabel', "Drop using '{0}' extension", this._extension.displayName || this._extension.name),
+			priority: edit.priority ?? 0,
 			insertText: typeof edit.insertText === 'string' ? edit.insertText : { snippet: edit.insertText.value },
 			additionalEdit: edit.additionalEdit ? typeConvert.WorkspaceEdit.from(edit.additionalEdit, undefined) : undefined,
 		};

--- a/src/vscode-dts/vscode.proposed.documentPaste.d.ts
+++ b/src/vscode-dts/vscode.proposed.documentPaste.d.ts
@@ -57,6 +57,13 @@ declare module 'vscode' {
 		label: string;
 
 		/**
+		 * The relative priority of this edit. Higher priority items are shown first in the UI.
+		 *
+		 * Defaults to `0`.
+		 */
+		priority?: number;
+
+		/**
 		 * The text or snippet to insert at the pasted locations.
 		 */
 		insertText: string | SnippetString;

--- a/src/vscode-dts/vscode.proposed.dropMetadata.d.ts
+++ b/src/vscode-dts/vscode.proposed.dropMetadata.d.ts
@@ -13,7 +13,14 @@ declare module 'vscode' {
 		 *
 		 * This id should be unique within the extension but does not need to be unique across extensions.
 		 */
-		id: string;
+		id?: string;
+
+		/**
+		 * The relative priority of this edit. Higher priority items are shown first in the UI.
+		 *
+		 * Defaults to `0`.
+		 */
+		priority?: number;
 
 		/**
 		 * Human readable label that describes the edit.


### PR DESCRIPTION
Fixes #181886

Replacement for #181453

This lets paste/drops have a relative order. We then use this to prefer pasting as text instead of as an image when both text and images are available in the clipboard 