### PR TITLE
Don't throw on main thread when messaging disposed webviews

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadWebviewPanels.ts
+++ b/src/vs/workbench/api/browser/mainThreadWebviewPanels.ts
@@ -199,19 +199,14 @@ export class MainThreadWebviewPanels extends Disposable implements extHostProtoc
 	}
 
 	public $setTitle(handle: extHostProtocol.WebviewHandle, value: string): void {
-		const webview = this.tryGetWebviewInput(handle);
-		if (!webview) {
-			return;
-		}
-		webview.setName(value);
+		this.tryGetWebviewInput(handle)?.setName(value);
 	}
 
 	public $setIconPath(handle: extHostProtocol.WebviewHandle, value: extHostProtocol.IWebviewIconPath | undefined): void {
 		const webview = this.tryGetWebviewInput(handle);
-		if (!webview) {
-			return;
+		if (webview) {
+			webview.iconPath = reviveWebviewIcon(value);
 		}
-		webview.iconPath = reviveWebviewIcon(value);
 	}
 
 	public $reveal(handle: extHostProtocol.WebviewHandle, showOptions: extHostProtocol.WebviewPanelShowOptions): void {

--- a/src/vs/workbench/api/browser/mainThreadWebviewPanels.ts
+++ b/src/vs/workbench/api/browser/mainThreadWebviewPanels.ts
@@ -191,23 +191,32 @@ export class MainThreadWebviewPanels extends Disposable implements extHostProtoc
 	}
 
 	public $disposeWebview(handle: extHostProtocol.WebviewHandle): void {
-		const webview = this.getWebviewInput(handle);
+		const webview = this.tryGetWebviewInput(handle);
+		if (!webview) {
+			return;
+		}
 		webview.dispose();
 	}
 
 	public $setTitle(handle: extHostProtocol.WebviewHandle, value: string): void {
-		const webview = this.getWebviewInput(handle);
+		const webview = this.tryGetWebviewInput(handle);
+		if (!webview) {
+			return;
+		}
 		webview.setName(value);
 	}
 
 	public $setIconPath(handle: extHostProtocol.WebviewHandle, value: extHostProtocol.IWebviewIconPath | undefined): void {
-		const webview = this.getWebviewInput(handle);
+		const webview = this.tryGetWebviewInput(handle);
+		if (!webview) {
+			return;
+		}
 		webview.iconPath = reviveWebviewIcon(value);
 	}
 
 	public $reveal(handle: extHostProtocol.WebviewHandle, showOptions: extHostProtocol.WebviewPanelShowOptions): void {
-		const webview = this.getWebviewInput(handle);
-		if (webview.isDisposed()) {
+		const webview = this.tryGetWebviewInput(handle);
+		if (!webview || webview.isDisposed()) {
 			return;
 		}
 
@@ -340,14 +349,6 @@ export class MainThreadWebviewPanels extends Disposable implements extHostProtoc
 		if (Object.keys(viewStates).length) {
 			this._proxy.$onDidChangeWebviewPanelViewStates(viewStates);
 		}
-	}
-
-	private getWebviewInput(handle: extHostProtocol.WebviewHandle): WebviewInput {
-		const webview = this.tryGetWebviewInput(handle);
-		if (!webview) {
-			throw new Error(`Unknown webview handle:${handle}`);
-		}
-		return webview;
 	}
 
 	private tryGetWebviewInput(handle: extHostProtocol.WebviewHandle): WebviewInput | undefined {

--- a/src/vs/workbench/api/browser/mainThreadWebviews.ts
+++ b/src/vs/workbench/api/browser/mainThreadWebviews.ts
@@ -53,17 +53,26 @@ export class MainThreadWebviews extends Disposable implements extHostProtocol.Ma
 	}
 
 	public $setHtml(handle: extHostProtocol.WebviewHandle, value: string): void {
-		const webview = this.getWebview(handle);
+		const webview = this.tryGetWebview(handle);
+		if (!webview) {
+			return;
+		}
 		webview.setHtml(value);
 	}
 
 	public $setOptions(handle: extHostProtocol.WebviewHandle, options: extHostProtocol.IWebviewContentOptions): void {
-		const webview = this.getWebview(handle);
+		const webview = this.tryGetWebview(handle);
+		if (!webview) {
+			return;
+		}
 		webview.contentOptions = reviveWebviewContentOptions(options);
 	}
 
 	public async $postMessage(handle: extHostProtocol.WebviewHandle, jsonMessage: string, ...buffers: VSBuffer[]): Promise<boolean> {
-		const webview = this.getWebview(handle);
+		const webview = this.tryGetWebview(handle);
+		if (!webview) {
+			return false;
+		}
 		const { message, arrayBuffers } = deserializeWebviewMessage(jsonMessage, buffers);
 		return webview.postMessage(message, arrayBuffers);
 	}
@@ -113,8 +122,12 @@ export class MainThreadWebviews extends Disposable implements extHostProtocol.Ma
 		return false;
 	}
 
+	private tryGetWebview(handle: extHostProtocol.WebviewHandle): IWebview | undefined {
+		return this._webviews.get(handle);
+	}
+
 	private getWebview(handle: extHostProtocol.WebviewHandle): IWebview {
-		const webview = this._webviews.get(handle);
+		const webview = this.tryGetWebview(handle);
 		if (!webview) {
 			throw new Error(`Unknown webview handle:${handle}`);
 		}

--- a/src/vs/workbench/api/browser/mainThreadWebviews.ts
+++ b/src/vs/workbench/api/browser/mainThreadWebviews.ts
@@ -53,19 +53,14 @@ export class MainThreadWebviews extends Disposable implements extHostProtocol.Ma
 	}
 
 	public $setHtml(handle: extHostProtocol.WebviewHandle, value: string): void {
-		const webview = this.tryGetWebview(handle);
-		if (!webview) {
-			return;
-		}
-		webview.setHtml(value);
+		this.tryGetWebview(handle)?.setHtml(value);
 	}
 
 	public $setOptions(handle: extHostProtocol.WebviewHandle, options: extHostProtocol.IWebviewContentOptions): void {
 		const webview = this.tryGetWebview(handle);
-		if (!webview) {
-			return;
+		if (webview) {
+			webview.contentOptions = reviveWebviewContentOptions(options);
 		}
-		webview.contentOptions = reviveWebviewContentOptions(options);
 	}
 
 	public async $postMessage(handle: extHostProtocol.WebviewHandle, jsonMessage: string, ...buffers: VSBuffer[]): Promise<boolean> {


### PR DESCRIPTION
Fixes #173291

It's possible for the ext host to try performing an action on a webview that has been disposed but where the dispose message hasn't yet reached the ext host.  We currently throw in these cases but there's nothing an extension could do to prevent this error

With this change, I've removed the exception logic so these types of messages to the main thread will just noop. On the ext host side, we still throw an error if you try posting to a webview that the ext host knows for sure is disposed of. This is usually a real bug in extension code. Extensions can prevent it by checking if the webview they are holding has been disposed of before making a request to it

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
