### PR TITLE
Fix copy providers incorrectly overwriting data transfer values

### DIFF
--- a/src/vs/base/common/dataTransfer.ts
+++ b/src/vs/base/common/dataTransfer.ts
@@ -8,14 +8,14 @@ import { Iterable } from 'vs/base/common/iterator';
 import { URI } from 'vs/base/common/uri';
 import { generateUuid } from 'vs/base/common/uuid';
 
-interface IDataTransferFile {
+export interface IDataTransferFile {
+	readonly id: string;
 	readonly name: string;
 	readonly uri?: URI;
 	data(): Promise<Uint8Array>;
 }
 
 export interface IDataTransferItem {
-	readonly id: string;
 	asString(): Thenable<string>;
 	asFile(): IDataTransferFile | undefined;
 	value: any;
@@ -23,7 +23,6 @@ export interface IDataTransferItem {
 
 export function createStringDataTransferItem(stringOrPromise: string | Promise<string>): IDataTransferItem {
 	return {
-		id: generateUuid(),
 		asString: async () => stringOrPromise,
 		asFile: () => undefined,
 		value: typeof stringOrPromise === 'string' ? stringOrPromise : undefined,
@@ -31,36 +30,26 @@ export function createStringDataTransferItem(stringOrPromise: string | Promise<s
 }
 
 export function createFileDataTransferItem(fileName: string, uri: URI | undefined, data: () => Promise<Uint8Array>): IDataTransferItem {
+	const file = { id: generateUuid(), name: fileName, uri, data };
 	return {
-		id: generateUuid(),
 		asString: async () => '',
-		asFile: () => ({ name: fileName, uri, data }),
+		asFile: () => file,
 		value: undefined,
 	};
 }
 
-export class VSDataTransfer {
-
-	private readonly _entries = new Map<string, IDataTransferItem[]>();
-
+export interface IReadonlyVSDataTransfer extends Iterable<readonly [string, IDataTransferItem]> {
 	/**
 	 * Get the total number of entries in this data transfer.
 	 */
-	public get size(): number {
-		let size = 0;
-		this.forEach(() => size++);
-		return size;
-	}
+	get size(): number;
 
 	/**
 	 * Check if this data transfer contains data for `mimeType`.
 	 *
 	 * This uses exact matching and does not support wildcards.
 	 */
-	public has(mimeType: string): boolean {
-		return this._entries.has(this.toKey(mimeType));
-	}
-
+	has(mimeType: string): boolean;
 	/**
 	 * Check if this data transfer contains data matching `pattern`.
 	 *
@@ -68,20 +57,41 @@ export class VSDataTransfer {
 	 *
 	 * Use the special `files` mime type to match any file in the data transfer.
 	 */
+	matches(pattern: string): boolean;
+
+	/**
+	 * Retrieve the first entry for `mimeType`.
+	 *
+	 * Note that if you want to find all entries for a given mime type, use {@link IReadonlyVSDataTransfer.entries} instead.
+	 */
+	get(mimeType: string): IDataTransferItem | undefined;
+}
+
+export class VSDataTransfer implements IReadonlyVSDataTransfer {
+
+	private readonly _entries = new Map<string, IDataTransferItem[]>();
+
+	public get size(): number {
+		let size = 0;
+		for (const _ of this._entries) {
+			size++;
+		}
+		return size;
+	}
+
+	public has(mimeType: string): boolean {
+		return this._entries.has(this.toKey(mimeType));
+	}
+
 	public matches(pattern: string): boolean {
 		const mimes = [...this._entries.keys()];
-		if (Iterable.some(this.values(), item => item.asFile())) {
+		if (Iterable.some(this, ([_, item]) => item.asFile())) {
 			mimes.push('files');
 		}
 
 		return matchesMimeType_normalized(normalizeMimeType(pattern), mimes);
 	}
 
-	/**
-	 * Retrieve the first entry for `mimeType`.
-	 *
-	 * Note that if want to find all entries for a given mime type, use {@link VSDataTransfer.entries} instead.
-	 */
 	public get(mimeType: string): IDataTransferItem | undefined {
 		return this._entries.get(this.toKey(mimeType))?.[0];
 	}
@@ -121,31 +131,11 @@ export class VSDataTransfer {
 	 *
 	 * There may be multiple entries for each mime type.
 	 */
-	public *entries(): Iterable<[string, IDataTransferItem]> {
-		for (const [mine, items] of this._entries.entries()) {
+	public *[Symbol.iterator](): IterableIterator<readonly [string, IDataTransferItem]> {
+		for (const [mine, items] of this._entries) {
 			for (const item of items) {
 				yield [mine, item];
 			}
-		}
-	}
-
-	/**
-	 * Iterate over all items in this data transfer.
-	 *
-	 * There may be multiple entries for each mime type.
-	 */
-	public values(): Iterable<IDataTransferItem> {
-		return Array.from(this._entries.values()).flat();
-	}
-
-	/**
-	 * Call `f` for each item and mime in the data transfer.
-	 *
-	 * There may be multiple entries for each mime type.
-	 */
-	public forEach(f: (value: IDataTransferItem, mime: string) => void) {
-		for (const [mime, item] of this.entries()) {
-			f(item, mime);
 		}
 	}
 

--- a/src/vs/editor/common/languages.ts
+++ b/src/vs/editor/common/languages.ts
@@ -7,7 +7,7 @@ import { VSBuffer } from 'vs/base/common/buffer';
 import { CancellationToken } from 'vs/base/common/cancellation';
 import { Codicon } from 'vs/base/common/codicons';
 import { Color } from 'vs/base/common/color';
-import { VSDataTransfer } from 'vs/base/common/dataTransfer';
+import { IReadonlyVSDataTransfer } from 'vs/base/common/dataTransfer';
 import { Event } from 'vs/base/common/event';
 import { IMarkdownString } from 'vs/base/common/htmlContent';
 import { IDisposable } from 'vs/base/common/lifecycle';
@@ -801,9 +801,9 @@ export interface DocumentPasteEditProvider {
 	readonly copyMimeTypes?: readonly string[];
 	readonly pasteMimeTypes: readonly string[];
 
-	prepareDocumentPaste?(model: model.ITextModel, ranges: readonly IRange[], dataTransfer: VSDataTransfer, token: CancellationToken): Promise<undefined | VSDataTransfer>;
+	prepareDocumentPaste?(model: model.ITextModel, ranges: readonly IRange[], dataTransfer: IReadonlyVSDataTransfer, token: CancellationToken): Promise<undefined | IReadonlyVSDataTransfer>;
 
-	provideDocumentPasteEdits(model: model.ITextModel, ranges: readonly IRange[], dataTransfer: VSDataTransfer, token: CancellationToken): Promise<DocumentPasteEdit | undefined>;
+	provideDocumentPasteEdits(model: model.ITextModel, ranges: readonly IRange[], dataTransfer: IReadonlyVSDataTransfer, token: CancellationToken): Promise<DocumentPasteEdit | undefined>;
 }
 
 /**
@@ -1960,5 +1960,5 @@ export interface DocumentOnDropEdit {
 export interface DocumentOnDropEditProvider {
 	readonly dropMimeTypes?: readonly string[];
 
-	provideDocumentOnDropEdits(model: model.ITextModel, position: IPosition, dataTransfer: VSDataTransfer, token: CancellationToken): ProviderResult<DocumentOnDropEdit>;
+	provideDocumentOnDropEdits(model: model.ITextModel, position: IPosition, dataTransfer: IReadonlyVSDataTransfer, token: CancellationToken): ProviderResult<DocumentOnDropEdit>;
 }

--- a/src/vs/editor/contrib/dropOrPasteInto/browser/defaultProviders.ts
+++ b/src/vs/editor/contrib/dropOrPasteInto/browser/defaultProviders.ts
@@ -5,7 +5,7 @@
 
 import { coalesce } from 'vs/base/common/arrays';
 import { CancellationToken } from 'vs/base/common/cancellation';
-import { UriList, VSDataTransfer } from 'vs/base/common/dataTransfer';
+import { IReadonlyVSDataTransfer, UriList } from 'vs/base/common/dataTransfer';
 import { Disposable } from 'vs/base/common/lifecycle';
 import { Mimes } from 'vs/base/common/mime';
 import { Schemas } from 'vs/base/common/network';
@@ -27,17 +27,17 @@ abstract class SimplePasteAndDropProvider implements DocumentOnDropEditProvider,
 	abstract readonly dropMimeTypes: readonly string[] | undefined;
 	abstract readonly pasteMimeTypes: readonly string[];
 
-	async provideDocumentPasteEdits(_model: ITextModel, _ranges: readonly IRange[], dataTransfer: VSDataTransfer, token: CancellationToken): Promise<DocumentPasteEdit | undefined> {
+	async provideDocumentPasteEdits(_model: ITextModel, _ranges: readonly IRange[], dataTransfer: IReadonlyVSDataTransfer, token: CancellationToken): Promise<DocumentPasteEdit | undefined> {
 		const edit = await this.getEdit(dataTransfer, token);
 		return edit ? { id: this.id, insertText: edit.insertText, label: edit.label, detail: edit.detail, priority: edit.priority } : undefined;
 	}
 
-	async provideDocumentOnDropEdits(_model: ITextModel, _position: IPosition, dataTransfer: VSDataTransfer, token: CancellationToken): Promise<DocumentOnDropEdit | undefined> {
+	async provideDocumentOnDropEdits(_model: ITextModel, _position: IPosition, dataTransfer: IReadonlyVSDataTransfer, token: CancellationToken): Promise<DocumentOnDropEdit | undefined> {
 		const edit = await this.getEdit(dataTransfer, token);
 		return edit ? { id: this.id, insertText: edit.insertText, label: edit.label, priority: edit.priority } : undefined;
 	}
 
-	protected abstract getEdit(dataTransfer: VSDataTransfer, token: CancellationToken): Promise<DocumentPasteEdit | undefined>;
+	protected abstract getEdit(dataTransfer: IReadonlyVSDataTransfer, token: CancellationToken): Promise<DocumentPasteEdit | undefined>;
 }
 
 class DefaultTextProvider extends SimplePasteAndDropProvider {
@@ -46,7 +46,7 @@ class DefaultTextProvider extends SimplePasteAndDropProvider {
 	readonly dropMimeTypes = [Mimes.text];
 	readonly pasteMimeTypes = [Mimes.text];
 
-	protected async getEdit(dataTransfer: VSDataTransfer, _token: CancellationToken) {
+	protected async getEdit(dataTransfer: IReadonlyVSDataTransfer, _token: CancellationToken) {
 		const textEntry = dataTransfer.get(Mimes.text);
 		if (!textEntry) {
 			return;
@@ -75,7 +75,7 @@ class PathProvider extends SimplePasteAndDropProvider {
 	readonly dropMimeTypes = [Mimes.uriList];
 	readonly pasteMimeTypes = [Mimes.uriList];
 
-	protected async getEdit(dataTransfer: VSDataTransfer, token: CancellationToken) {
+	protected async getEdit(dataTransfer: IReadonlyVSDataTransfer, token: CancellationToken) {
 		const entries = await extractUriList(dataTransfer);
 		if (!entries.length || token.isCancellationRequested) {
 			return;
@@ -128,7 +128,7 @@ class RelativePathProvider extends SimplePasteAndDropProvider {
 		super();
 	}
 
-	protected async getEdit(dataTransfer: VSDataTransfer, token: CancellationToken) {
+	protected async getEdit(dataTransfer: IReadonlyVSDataTransfer, token: CancellationToken) {
 		const entries = await extractUriList(dataTransfer);
 		if (!entries.length || token.isCancellationRequested) {
 			return;
@@ -155,7 +155,7 @@ class RelativePathProvider extends SimplePasteAndDropProvider {
 	}
 }
 
-async function extractUriList(dataTransfer: VSDataTransfer): Promise<{ readonly uri: URI; readonly originalText: string }[]> {
+async function extractUriList(dataTransfer: IReadonlyVSDataTransfer): Promise<{ readonly uri: URI; readonly originalText: string }[]> {
 	const urlListEntry = dataTransfer.get(Mimes.uriList);
 	if (!urlListEntry) {
 		return [];

--- a/src/vs/editor/contrib/dropOrPasteInto/browser/dropIntoEditorController.ts
+++ b/src/vs/editor/contrib/dropOrPasteInto/browser/dropIntoEditorController.ts
@@ -145,7 +145,7 @@ export class DropIntoEditorController extends Disposable implements IEditorContr
 				for (const id of data) {
 					const treeDataTransfer = await this._treeViewsDragAndDropService.removeDragOperationTransfer(id.identifier);
 					if (treeDataTransfer) {
-						for (const [type, value] of treeDataTransfer.entries()) {
+						for (const [type, value] of treeDataTransfer) {
 							dataTransfer.replace(type, value);
 						}
 					}

--- a/src/vs/workbench/api/browser/mainThreadLanguageFeatures.ts
+++ b/src/vs/workbench/api/browser/mainThreadLanguageFeatures.ts
@@ -5,7 +5,7 @@
 
 import { VSBuffer } from 'vs/base/common/buffer';
 import { CancellationToken } from 'vs/base/common/cancellation';
-import { createStringDataTransferItem, VSDataTransfer } from 'vs/base/common/dataTransfer';
+import { createStringDataTransferItem, IReadonlyVSDataTransfer, VSDataTransfer } from 'vs/base/common/dataTransfer';
 import { CancellationError } from 'vs/base/common/errors';
 import { Emitter, Event } from 'vs/base/common/event';
 import { combinedDisposable, Disposable, DisposableMap, toDisposable } from 'vs/base/common/lifecycle';
@@ -27,7 +27,7 @@ import { ExtensionIdentifier } from 'vs/platform/extensions/common/extensions';
 import { IUriIdentityService } from 'vs/platform/uriIdentity/common/uriIdentity';
 import { reviveWorkspaceEditDto } from 'vs/workbench/api/browser/mainThreadBulkEdits';
 import * as typeConvert from 'vs/workbench/api/common/extHostTypeConverters';
-import { DataTransferCache } from 'vs/workbench/api/common/shared/dataTransferCache';
+import { DataTransferFileCache } from 'vs/workbench/api/common/shared/dataTransferCache';
 import * as callh from 'vs/workbench/contrib/callHierarchy/common/callHierarchy';
 import * as search from 'vs/workbench/contrib/search/common/search';
 import * as typeh from 'vs/workbench/contrib/typeHierarchy/common/typeHierarchy';
@@ -927,12 +927,12 @@ export class MainThreadLanguageFeatures extends Disposable implements MainThread
 
 class MainThreadPasteEditProvider implements languages.DocumentPasteEditProvider {
 
-	private readonly dataTransfers = new DataTransferCache();
+	private readonly dataTransfers = new DataTransferFileCache();
 
 	public readonly copyMimeTypes?: readonly string[];
 	public readonly pasteMimeTypes: readonly string[];
 
-	readonly prepareDocumentPaste?: (model: ITextModel, ranges: readonly IRange[], dataTransfer: VSDataTransfer, token: CancellationToken) => Promise<undefined | VSDataTransfer>;
+	readonly prepareDocumentPaste?: languages.DocumentPasteEditProvider['prepareDocumentPaste'];
 
 	constructor(
 		private readonly handle: number,
@@ -944,33 +944,37 @@ class MainThreadPasteEditProvider implements languages.DocumentPasteEditProvider
 		this.pasteMimeTypes = metadata.pasteMimeTypes;
 
 		if (metadata.supportsCopy) {
-			this.prepareDocumentPaste = async (model: ITextModel, selections: readonly IRange[], dataTransfer: VSDataTransfer, token: CancellationToken): Promise<VSDataTransfer | undefined> => {
-				const dataTransferDto = await typeConvert.DataTransfer.toDataTransferDTO(dataTransfer);
+			this.prepareDocumentPaste = async (model: ITextModel, selections: readonly IRange[], dataTransfer: IReadonlyVSDataTransfer, token: CancellationToken): Promise<IReadonlyVSDataTransfer | undefined> => {
+				const dataTransferDto = await typeConvert.DataTransfer.from(dataTransfer);
 				if (token.isCancellationRequested) {
 					return undefined;
 				}
 
-				const result = await this._proxy.$prepareDocumentPaste(handle, model.uri, selections, dataTransferDto, token);
-				if (!result) {
+				const newDataTransfer = await this._proxy.$prepareDocumentPaste(handle, model.uri, selections, dataTransferDto, token);
+				if (!newDataTransfer) {
 					return undefined;
 				}
 
 				const dataTransferOut = new VSDataTransfer();
-				result.items.forEach(([type, item]) => {
+				for (const [type, item] of newDataTransfer.items) {
 					dataTransferOut.replace(type, createStringDataTransferItem(item.asString));
-				});
+				}
 				return dataTransferOut;
 			};
 		}
 	}
 
-	async provideDocumentPasteEdits(model: ITextModel, selections: Selection[], dataTransfer: VSDataTransfer, token: CancellationToken) {
+	async provideDocumentPasteEdits(model: ITextModel, selections: Selection[], dataTransfer: IReadonlyVSDataTransfer, token: CancellationToken) {
 		const request = this.dataTransfers.add(dataTransfer);
 		try {
-			const d = await typeConvert.DataTransfer.toDataTransferDTO(dataTransfer);
-			const result = await this._proxy.$providePasteEdits(this.handle, request.id, model.uri, selections, d, token);
+			const dataTransferDto = await typeConvert.DataTransfer.from(dataTransfer);
+			if (token.isCancellationRequested) {
+				return;
+			}
+
+			const result = await this._proxy.$providePasteEdits(this.handle, request.id, model.uri, selections, dataTransferDto, token);
 			if (!result) {
-				return undefined;
+				return;
 			}
 
 			return {
@@ -989,7 +993,7 @@ class MainThreadPasteEditProvider implements languages.DocumentPasteEditProvider
 
 class MainThreadDocumentOnDropEditProvider implements languages.DocumentOnDropEditProvider {
 
-	private readonly dataTransfers = new DataTransferCache();
+	private readonly dataTransfers = new DataTransferFileCache();
 
 	readonly dropMimeTypes?: readonly string[];
 
@@ -1002,14 +1006,19 @@ class MainThreadDocumentOnDropEditProvider implements languages.DocumentOnDropEd
 		this.dropMimeTypes = metadata?.dropMimeTypes ?? ['*/*'];
 	}
 
-	async provideDocumentOnDropEdits(model: ITextModel, position: IPosition, dataTransfer: VSDataTransfer, token: CancellationToken): Promise<languages.DocumentOnDropEdit | null | undefined> {
+	async provideDocumentOnDropEdits(model: ITextModel, position: IPosition, dataTransfer: IReadonlyVSDataTransfer, token: CancellationToken): Promise<languages.DocumentOnDropEdit | null | undefined> {
 		const request = this.dataTransfers.add(dataTransfer);
 		try {
-			const dataTransferDto = await typeConvert.DataTransfer.toDataTransferDTO(dataTransfer);
+			const dataTransferDto = await typeConvert.DataTransfer.from(dataTransfer);
+			if (token.isCancellationRequested) {
+				return;
+			}
+
 			const edit = await this._proxy.$provideDocumentOnDropEdits(this.handle, request.id, model.uri, position, dataTransferDto, token);
 			if (!edit) {
-				return undefined;
+				return;
 			}
+
 			return {
 				...edit,
 				additionalEdit: reviveWorkspaceEditDto(edit.additionalEdit, this._uriIdentService, dataId => this.resolveDocumentOnDropFileData(request.id, dataId)),

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -1493,12 +1493,12 @@ export interface ExtHostDocumentsAndEditorsShape {
 }
 
 export interface IDataTransferFileDTO {
+	readonly id: string;
 	readonly name: string;
 	readonly uri?: UriComponents;
 }
 
 export interface DataTransferItemDTO {
-	readonly id: string;
 	readonly asString: string;
 	readonly fileData: IDataTransferFileDTO | undefined;
 	readonly uriListData?: ReadonlyArray<string | UriComponents>;

--- a/src/vs/workbench/api/common/extHostLanguageFeatures.ts
+++ b/src/vs/workbench/api/common/extHostLanguageFeatures.ts
@@ -7,7 +7,7 @@ import { URI, UriComponents } from 'vs/base/common/uri';
 import { mixin } from 'vs/base/common/objects';
 import type * as vscode from 'vscode';
 import * as typeConvert from 'vs/workbench/api/common/extHostTypeConverters';
-import { Range, Disposable, CompletionList, SnippetString, CodeActionKind, SymbolInformation, DocumentSymbol, SemanticTokensEdits, SemanticTokens, SemanticTokensEdit, Location, InlineCompletionTriggerKind } from 'vs/workbench/api/common/extHostTypes';
+import { Range, Disposable, CompletionList, SnippetString, CodeActionKind, SymbolInformation, DocumentSymbol, SemanticTokensEdits, SemanticTokens, SemanticTokensEdit, Location, InlineCompletionTriggerKind, InternalDataTransferItem } from 'vs/workbench/api/common/extHostTypes';
 import { ISingleEditOperation } from 'vs/editor/common/core/editOperation';
 import * as languages from 'vs/editor/common/languages';
 import { ExtHostDocuments } from 'vs/workbench/api/common/extHostDocuments';
@@ -510,7 +510,7 @@ class DocumentPasteEditProvider {
 
 	async prepareDocumentPaste(resource: URI, ranges: IRange[], dataTransferDto: extHostProtocol.DataTransferDTO, token: CancellationToken): Promise<extHostProtocol.DataTransferDTO | undefined> {
 		if (!this._provider.prepareDocumentPaste) {
-			return undefined;
+			return;
 		}
 
 		const doc = this._documents.getDocument(resource);
@@ -520,8 +520,13 @@ class DocumentPasteEditProvider {
 			throw new NotImplementedError();
 		});
 		await this._provider.prepareDocumentPaste(doc, vscodeRanges, dataTransfer, token);
+		if (token.isCancellationRequested) {
+			return;
+		}
 
-		return typeConvert.DataTransfer.toDataTransferDTO(dataTransfer);
+		// Only send back values that have been added to the data transfer
+		const entries = Array.from(dataTransfer).filter(([, value]) => !(value instanceof InternalDataTransferItem));
+		return typeConvert.DataTransfer.from(entries);
 	}
 
 	async providePasteEdits(requestId: number, resource: URI, ranges: IRange[], dataTransferDto: extHostProtocol.DataTransferDTO, token: CancellationToken): Promise<undefined | extHostProtocol.IPasteEditDto> {

--- a/src/vs/workbench/api/common/extHostTreeViews.ts
+++ b/src/vs/workbench/api/common/extHostTreeViews.ts
@@ -191,11 +191,11 @@ export class ExtHostTreeViews implements ExtHostTreeViewsShape {
 		}
 
 		const treeDataTransfer = await this.addAdditionalTransferItems(new types.DataTransfer(), treeView, sourceTreeItemHandles, token, operationUuid);
-		if (!treeDataTransfer) {
+		if (!treeDataTransfer || token.isCancellationRequested) {
 			return;
 		}
 
-		return DataTransfer.toDataTransferDTO(treeDataTransfer);
+		return DataTransfer.from(treeDataTransfer);
 	}
 
 	async $hasResolve(treeViewId: string): Promise<boolean> {

--- a/src/vs/workbench/api/common/extHostTypes.ts
+++ b/src/vs/workbench/api/common/extHostTypes.ts
@@ -2594,13 +2594,34 @@ export class DataTransferItem implements vscode.DataTransferItem {
 		return undefined;
 	}
 
-	public readonly id: string;
-
 	constructor(
 		public readonly value: any,
-		id?: string,
-	) {
-		this.id = id ?? generateUuid();
+	) { }
+}
+
+/**
+ * A data transfer item that has been created by VS Code instead of by a extension.
+ *
+ * Intentionally not exported to extensions.
+ */
+export class InternalDataTransferItem extends DataTransferItem { }
+
+/**
+ * A data transfer item for a file.
+ *
+ * Intentionally not exported to extensions as only we can create these.
+ */
+export class InternalFileDataTransferItem extends InternalDataTransferItem {
+
+	readonly #file: vscode.DataTransferFile;
+
+	constructor(file: vscode.DataTransferFile) {
+		super('');
+		this.#file = file;
+	}
+
+	override asFile() {
+		return this.#file;
 	}
 }
 

--- a/src/vs/workbench/api/common/shared/dataTransferCache.ts
+++ b/src/vs/workbench/api/common/shared/dataTransferCache.ts
@@ -3,45 +3,41 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { coalesce } from 'vs/base/common/arrays';
 import { VSBuffer } from 'vs/base/common/buffer';
-import { VSDataTransfer, IDataTransferItem } from 'vs/base/common/dataTransfer';
+import { IDataTransferFile, IReadonlyVSDataTransfer } from 'vs/base/common/dataTransfer';
 
-export class DataTransferCache {
+export class DataTransferFileCache {
 
 	private requestIdPool = 0;
-	private readonly dataTransfers = new Map</* requestId */ number, ReadonlyArray<IDataTransferItem>>();
+	private readonly dataTransferFiles = new Map</* requestId */ number, ReadonlyArray<IDataTransferFile>>();
 
-	public add(dataTransfer: VSDataTransfer): { id: number; dispose: () => void } {
+	public add(dataTransfer: IReadonlyVSDataTransfer): { id: number; dispose: () => void } {
 		const requestId = this.requestIdPool++;
-		this.dataTransfers.set(requestId, [...dataTransfer.values()]);
+		this.dataTransferFiles.set(requestId, coalesce(Array.from(dataTransfer, ([, item]) => item.asFile())));
 		return {
 			id: requestId,
 			dispose: () => {
-				this.dataTransfers.delete(requestId);
+				this.dataTransferFiles.delete(requestId);
 			}
 		};
 	}
 
 	async resolveFileData(requestId: number, dataItemId: string): Promise<VSBuffer> {
-		const entry = this.dataTransfers.get(requestId);
-		if (!entry) {
+		const files = this.dataTransferFiles.get(requestId);
+		if (!files) {
 			throw new Error('No data transfer found');
 		}
 
-		const item = entry.find(x => x.id === dataItemId);
-		if (!item) {
-			throw new Error('No item found in data transfer');
-		}
-
-		const file = item.asFile();
+		const file = files.find(file => file.id === dataItemId);
 		if (!file) {
-			throw new Error('Found data transfer item is not a file');
+			throw new Error('No matching file found in data transfer');
 		}
 
 		return VSBuffer.wrap(await file.data());
 	}
 
 	dispose() {
-		this.dataTransfers.clear();
+		this.dataTransferFiles.clear();
 	}
 }

--- a/src/vs/workbench/browser/parts/views/treeView.ts
+++ b/src/vs/workbench/browser/parts/views/treeView.ts
@@ -1547,7 +1547,7 @@ export class CustomTreeViewDragAndDrop implements ITreeDragAndDrop<ITreeItem> {
 		return dndController.handleDrag(itemHandles, uuid, dragCancellationToken).then(additionalDataTransfer => {
 			if (additionalDataTransfer) {
 				const unlistedTypes: string[] = [];
-				for (const item of additionalDataTransfer.entries()) {
+				for (const item of additionalDataTransfer) {
 					if ((item[0] !== this.treeMimeType) && (dndController.dragMimeTypes.findIndex(value => value === item[0]) < 0)) {
 						unlistedTypes.push(item[0]);
 					}
@@ -1625,7 +1625,7 @@ export class CustomTreeViewDragAndDrop implements ITreeDragAndDrop<ITreeItem> {
 	onDragOver(data: IDragAndDropData, targetElement: ITreeItem, targetIndex: number, originalEvent: DragEvent): boolean | ITreeDragOverReaction {
 		const dataTransfer = toExternalVSDataTransfer(originalEvent.dataTransfer!);
 
-		const types = new Set<string>(Array.from(dataTransfer.entries()).map(x => x[0]));
+		const types = new Set<string>(Array.from(dataTransfer, x => x[0]));
 
 		if (originalEvent.dataTransfer) {
 			// Also add uri-list if we have any files. At this stage we can't actually access the file itself though.
@@ -1689,7 +1689,7 @@ export class CustomTreeViewDragAndDrop implements ITreeDragAndDrop<ITreeItem> {
 		const originalDataTransfer = toExternalVSDataTransfer(originalEvent.dataTransfer, true);
 
 		const outDataTransfer = new VSDataTransfer();
-		for (const [type, item] of originalDataTransfer.entries()) {
+		for (const [type, item] of originalDataTransfer) {
 			if (type === this.treeMimeType || dndController.dropMimeTypes.includes(type) || (item.asFile() && dndController.dropMimeTypes.includes(DataTransfers.FILES.toLowerCase()))) {
 				outDataTransfer.append(type, item);
 				if (type === this.treeMimeType) {
@@ -1704,7 +1704,7 @@ export class CustomTreeViewDragAndDrop implements ITreeDragAndDrop<ITreeItem> {
 
 		const additionalDataTransfer = await this.treeViewsDragAndDropService.removeDragOperationTransfer(willDropUuid);
 		if (additionalDataTransfer) {
-			for (const [type, item] of additionalDataTransfer.entries()) {
+			for (const [type, item] of additionalDataTransfer) {
 				outDataTransfer.append(type, item);
 			}
 		}


### PR DESCRIPTION
At present, copy providers on the ext host side return the full data transfer object passed to them (which includes both the original data and any additions they make to it). We then use this to construct a new data transfer that is passed on to paste providers

There are a few issues with this approach:

- If there are multiple copy providers, they can incorrectly end up overwriting each other. For example if the initial data transfer contains `text/plain` and there are two providers, the first of which tries writing a new `text/plain`, the second provider will overwrite this with the initial `text/plain` value

- If the original data transfer contains multiple entries for a mime, these always end up being overwritten with a single value for that mime

- We shouldn't waste time transferring values back to the main thread when the main thread already has them

This PR tries to fix this by skipping ext host to main thread transfer of non-modified data transfer items. As part of this work, I reworked a few internal structures and introduced a new `IReadonlyVSDataTransfer` interface to make it more clear when a internal data transfer is or is not expected to be modified

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
