### PR TITLE
Allow storing arrays in StorageService

### DIFF
--- a/src/vs/base/parts/storage/common/storage.ts
+++ b/src/vs/base/parts/storage/common/storage.ts
@@ -7,7 +7,7 @@ import { ThrottledDelayer } from 'vs/base/common/async';
 import { Emitter, Event } from 'vs/base/common/event';
 import { Disposable, IDisposable } from 'vs/base/common/lifecycle';
 import { parse, stringify } from 'vs/base/common/marshalling';
-import { isUndefinedOrNull, isObject } from 'vs/base/common/types';
+import { isObject, isUndefinedOrNull } from 'vs/base/common/types';
 
 export enum StorageHint {
 
@@ -240,7 +240,7 @@ export class Storage extends Disposable implements IStorage {
 		}
 
 		// Otherwise, convert to String and store
-		const valueStr = isObject(value) ? stringify(value) : String(value);
+		const valueStr = isObject(value) || Array.isArray(value) ? stringify(value) : String(value);
 
 		// Return early if value already set
 		const currentValue = this.cache.get(key);

--- a/src/vs/platform/storage/test/common/storageService.test.ts
+++ b/src/vs/platform/storage/test/common/storageService.test.ts
@@ -42,6 +42,7 @@ export function createSuite<T extends IStorageService>(params: { setup: () => Pr
 		strictEqual(storageService.getBoolean('test.getBoolean', scope, false), false);
 		deepStrictEqual(storageService.getObject('test.getObject', scope, { 'foo': 'bar' }), { 'foo': 'bar' });
 		deepStrictEqual(storageService.getObject('test.getObject', scope, {}), {});
+		deepStrictEqual(storageService.getObject('test.getObject', scope, []), []);
 
 		storageService.store('test.get', 'foobar', scope, StorageTarget.MACHINE);
 		strictEqual(storageService.get('test.get', scope, (undefined)!), 'foobar');
@@ -70,6 +71,9 @@ export function createSuite<T extends IStorageService>(params: { setup: () => Pr
 
 		storageService.store('test.getObject', {}, scope, StorageTarget.MACHINE);
 		deepStrictEqual(storageService.getObject('test.getObject', scope, (undefined)!), {});
+
+		storageService.store('test.getObject', [42], scope, StorageTarget.MACHINE);
+		deepStrictEqual(storageService.getObject('test.getObject', scope, (undefined)!), [42]);
 
 		storageService.store('test.getObject', { 'foo': {} }, scope, StorageTarget.MACHINE);
 		deepStrictEqual(storageService.getObject('test.getObject', scope, (undefined)!), { 'foo': {} });


### PR DESCRIPTION
Breakpoints stores JSON-stringified arrays in the storage service today, we should handle those correctly if they are stored in object form: https://github.com/microsoft/vscode/blob/b168fe514578b58db9d6be38201b897c4794414a/src/vs/workbench/contrib/debug/common/debugStorage.ts#L110-L112C52