### PR TITLE
Fix range when copying empty selection

### DIFF
--- a/extensions/vscode-api-tests/package.json
+++ b/extensions/vscode-api-tests/package.json
@@ -10,6 +10,7 @@
     "customEditorMove",
     "diffCommand",
     "documentFiltersExclusive",
+    "documentPaste",
     "editorInsets",
     "extensionRuntime",
     "extensionsAny",

--- a/extensions/vscode-api-tests/src/singlefolder-tests/documentPaste.test.ts
+++ b/extensions/vscode-api-tests/src/singlefolder-tests/documentPaste.test.ts
@@ -38,7 +38,7 @@ suite('vscode API - Copy Paste', () => {
 	}));
 
 	test('Copy with empty selection should copy entire line', usingDisposables(async (disposables) => {
-		const file = await createRandomFile('abc');
+		const file = await createRandomFile('abc\ndef');
 		const doc = await vscode.workspace.openTextDocument(file);
 		await vscode.window.showTextDocument(doc);
 
@@ -58,7 +58,7 @@ suite('vscode API - Copy Paste', () => {
 		await vscode.commands.executeCommand('editor.action.clipboardCopyAction');
 		const newDocContent = getNextDocumentText(disposables, doc);
 		await vscode.commands.executeCommand('editor.action.clipboardPasteAction');
-		assert.strictEqual(await newDocContent, `cba${doc.eol}abc`);
+		assert.strictEqual(await newDocContent, `cba\nabc\ndef`);
 	}));
 
 	test('Copy with multiple selections should get all selections', usingDisposables(async (disposables) => {
@@ -86,11 +86,11 @@ suite('vscode API - Copy Paste', () => {
 		const newDocContent = getNextDocumentText(disposables, doc);
 		await vscode.commands.executeCommand('editor.action.clipboardPasteAction');
 
-		assert.strictEqual(await newDocContent, `(2)111 333111${doc.eol}222${doc.eol}333`);
+		assert.strictEqual(await newDocContent, `(2)111 333111\n222\n333`);
 	}));
 
 	test('Earlier invoked copy providers should win when writing values', usingDisposables(async (disposables) => {
-		const file = await createRandomFile('abc');
+		const file = await createRandomFile('abc\ndef');
 		const doc = await vscode.workspace.openTextDocument(file);
 
 		const editor = await vscode.window.showTextDocument(doc);
@@ -128,7 +128,7 @@ suite('vscode API - Copy Paste', () => {
 		await vscode.commands.executeCommand('editor.action.clipboardCopyAction');
 		const newDocContent = getNextDocumentText(disposables, doc);
 		await vscode.commands.executeCommand('editor.action.clipboardPasteAction');
-		assert.strictEqual(await newDocContent, 'b');
+		assert.strictEqual(await newDocContent, 'b\ndef');
 
 		// Confirm provider call order is what we expected
 		assert.deepStrictEqual(callOrder, [b_id, a_id]);

--- a/extensions/vscode-api-tests/src/singlefolder-tests/documentPaste.test.ts
+++ b/extensions/vscode-api-tests/src/singlefolder-tests/documentPaste.test.ts
@@ -1,0 +1,112 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import { assertNoRpc, createRandomFile, usingDisposables } from '../utils';
+
+const textPlain = 'text/plain';
+
+suite('vscode API - Copy Paste', () => {
+
+	teardown(assertNoRpc);
+
+	test('Copy should be able to overwrite text/plain', usingDisposables(async (disposables) => {
+		const file = await createRandomFile('$abcde@');
+		const doc = await vscode.workspace.openTextDocument(file);
+
+		const editor = await vscode.window.showTextDocument(doc);
+		editor.selections = [new vscode.Selection(0, 1, 0, 6)];
+
+		disposables.push(vscode.languages.registerDocumentPasteEditProvider({ language: 'plaintext' }, new class implements vscode.DocumentPasteEditProvider {
+			async prepareDocumentPaste?(_document: vscode.TextDocument, _ranges: readonly vscode.Range[], dataTransfer: vscode.DataTransfer, _token: vscode.CancellationToken): Promise<void> {
+				const existing = dataTransfer.get(textPlain);
+				if (existing) {
+					const str = await existing.asString();
+					const reversed = reverseString(str);
+					dataTransfer.set(textPlain, new vscode.DataTransferItem(reversed));
+				}
+			}
+		}, {
+			copyMimeTypes: [textPlain],
+		}));
+
+		await vscode.commands.executeCommand('editor.action.clipboardCopyAction');
+		const newDocContent = getNextDocumentText(disposables, doc);
+		await vscode.commands.executeCommand('editor.action.clipboardPasteAction');
+		assert.strictEqual(await newDocContent, '$edcba@');
+	}));
+
+	test('Copy with empty selection should copy entire line', usingDisposables(async (disposables) => {
+		const file = await createRandomFile('abc');
+		const doc = await vscode.workspace.openTextDocument(file);
+		await vscode.window.showTextDocument(doc);
+
+		disposables.push(vscode.languages.registerDocumentPasteEditProvider({ language: 'plaintext' }, new class implements vscode.DocumentPasteEditProvider {
+			async prepareDocumentPaste?(_document: vscode.TextDocument, _ranges: readonly vscode.Range[], dataTransfer: vscode.DataTransfer, _token: vscode.CancellationToken): Promise<void> {
+				const existing = dataTransfer.get(textPlain);
+				if (existing) {
+					const str = await existing.asString();
+					// Don't include the trailing new line when reversing
+					const eol = str.match(/\r?\n$/);
+					const reversed = reverseString(str.slice(0, -eol!.length));
+					dataTransfer.set(textPlain, new vscode.DataTransferItem(reversed + eol));
+				}
+			}
+		}, {
+			copyMimeTypes: [textPlain],
+		}));
+
+		await vscode.commands.executeCommand('editor.action.clipboardCopyAction');
+		const newDocContent = getNextDocumentText(disposables, doc);
+		await vscode.commands.executeCommand('editor.action.clipboardPasteAction');
+		assert.strictEqual(await newDocContent, 'cba\nabc');
+	}));
+
+	test('Copy with multiple selections should get all selections', usingDisposables(async (disposables) => {
+		const file = await createRandomFile('111\n222\n333');
+		const doc = await vscode.workspace.openTextDocument(file);
+		const editor = await vscode.window.showTextDocument(doc);
+
+		editor.selections = [
+			new vscode.Selection(0, 0, 0, 3),
+			new vscode.Selection(2, 0, 2, 3),
+		];
+
+		disposables.push(vscode.languages.registerDocumentPasteEditProvider({ language: 'plaintext' }, new class implements vscode.DocumentPasteEditProvider {
+			async prepareDocumentPaste?(document: vscode.TextDocument, ranges: readonly vscode.Range[], dataTransfer: vscode.DataTransfer, _token: vscode.CancellationToken): Promise<void> {
+				const existing = dataTransfer.get(textPlain);
+				if (existing) {
+					const selections = ranges.map(range => document.getText(range));
+					dataTransfer.set(textPlain, new vscode.DataTransferItem(`(${ranges.length})${selections.join(' ')}`));
+				}
+			}
+		}, {
+			copyMimeTypes: [textPlain],
+		}));
+
+		await vscode.commands.executeCommand('editor.action.clipboardCopyAction');
+		editor.selections = [new vscode.Selection(0, 0, 0, 0)];
+		const newDocContent = getNextDocumentText(disposables, doc);
+		await vscode.commands.executeCommand('editor.action.clipboardPasteAction');
+
+		assert.strictEqual(await newDocContent, '(2)111 333111\n222\n333');
+	}));
+});
+
+function reverseString(str: string) {
+	return str.split("").reverse().join("");
+}
+
+function getNextDocumentText(disposables: vscode.Disposable[], doc: vscode.TextDocument): Promise<string> {
+	return new Promise<string>(resolve => {
+		disposables.push(vscode.workspace.onDidChangeTextDocument(e => {
+			if (e.document === doc) {
+				resolve(doc.getText());
+			}
+		}));
+	});
+}
+

--- a/extensions/vscode-api-tests/src/singlefolder-tests/documentPaste.test.ts
+++ b/extensions/vscode-api-tests/src/singlefolder-tests/documentPaste.test.ts
@@ -9,7 +9,7 @@ import { assertNoRpc, createRandomFile, usingDisposables } from '../utils';
 
 const textPlain = 'text/plain';
 
-suite('vscode API - Copy Paste', () => {
+(vscode.env.uiKind === vscode.UIKind.Web ? suite.skip : suite)('vscode API - Copy Paste', () => {
 
 	teardown(assertNoRpc);
 

--- a/extensions/vscode-api-tests/src/singlefolder-tests/documentPaste.test.ts
+++ b/extensions/vscode-api-tests/src/singlefolder-tests/documentPaste.test.ts
@@ -50,7 +50,7 @@ const textPlain = 'text/plain';
 					// text/plain includes the trailing new line in this case
 					// On windows, this will always be `\r\n` even if the document uses `\n`
 					const eol = str.match(/\r?\n$/);
-					const reversed = reverseString(str.slice(0, -eol!.length));
+					const reversed = reverseString(str.slice(0, -eol![0].length));
 					dataTransfer.set(textPlain, new vscode.DataTransferItem(reversed + '\n'));
 				}
 			}

--- a/extensions/vscode-api-tests/src/singlefolder-tests/documentPaste.test.ts
+++ b/extensions/vscode-api-tests/src/singlefolder-tests/documentPaste.test.ts
@@ -47,8 +47,10 @@ suite('vscode API - Copy Paste', () => {
 				const existing = dataTransfer.get(textPlain);
 				if (existing) {
 					const str = await existing.asString();
-					// Don't include the trailing new line when reversing
-					const reversed = reverseString(str.slice(0, -1));
+					// text/plain includes the trailing new line in this case
+					// On windows, this will always be `\r\n` even if the document uses `\n`
+					const eol = str.match(/\r?\n$/);
+					const reversed = reverseString(str.slice(0, eol!.length));
 					dataTransfer.set(textPlain, new vscode.DataTransferItem(reversed + '\n'));
 				}
 			}

--- a/extensions/vscode-api-tests/src/singlefolder-tests/documentPaste.test.ts
+++ b/extensions/vscode-api-tests/src/singlefolder-tests/documentPaste.test.ts
@@ -50,7 +50,7 @@ const textPlain = 'text/plain';
 					// text/plain includes the trailing new line in this case
 					// On windows, this will always be `\r\n` even if the document uses `\n`
 					const eol = str.match(/\r?\n$/);
-					const reversed = reverseString(str.slice(0, eol!.length));
+					const reversed = reverseString(str.slice(0, -eol!.length));
 					dataTransfer.set(textPlain, new vscode.DataTransferItem(reversed + '\n'));
 				}
 			}

--- a/extensions/vscode-api-tests/src/utils.ts
+++ b/extensions/vscode-api-tests/src/utils.ts
@@ -62,6 +62,17 @@ export function disposeAll(disposables: vscode.Disposable[]) {
 	vscode.Disposable.from(...disposables).dispose();
 }
 
+export function usingDisposables<R>(fn: (this: Mocha.Context, store: vscode.Disposable[]) => Promise<R>) {
+	return async function (this: Mocha.Context): Promise<R> {
+		const disposables: vscode.Disposable[] = [];
+		try {
+			return await fn.call(this, disposables);
+		} finally {
+			disposeAll(disposables);
+		}
+	};
+}
+
 export function delay(ms: number) {
 	return new Promise(resolve => setTimeout(resolve, ms));
 }

--- a/src/vs/editor/common/languages.ts
+++ b/src/vs/editor/common/languages.ts
@@ -799,11 +799,11 @@ export interface DocumentPasteEditProvider {
 	readonly id?: string;
 
 	readonly copyMimeTypes?: readonly string[];
-	readonly pasteMimeTypes: readonly string[];
+	readonly pasteMimeTypes?: readonly string[];
 
 	prepareDocumentPaste?(model: model.ITextModel, ranges: readonly IRange[], dataTransfer: IReadonlyVSDataTransfer, token: CancellationToken): Promise<undefined | IReadonlyVSDataTransfer>;
 
-	provideDocumentPasteEdits(model: model.ITextModel, ranges: readonly IRange[], dataTransfer: IReadonlyVSDataTransfer, token: CancellationToken): Promise<DocumentPasteEdit | undefined>;
+	provideDocumentPasteEdits?(model: model.ITextModel, ranges: readonly IRange[], dataTransfer: IReadonlyVSDataTransfer, token: CancellationToken): Promise<DocumentPasteEdit | undefined>;
 }
 
 /**

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -1830,8 +1830,9 @@ export type ITypeHierarchyItemDto = Dto<TypeHierarchyItem>;
 
 export interface IPasteEditProviderMetadataDto {
 	readonly supportsCopy: boolean;
+	readonly supportsPaste: boolean;
 	readonly copyMimeTypes?: readonly string[];
-	readonly pasteMimeTypes: readonly string[];
+	readonly pasteMimeTypes?: readonly string[];
 }
 
 export interface IPasteEditDto {

--- a/src/vs/workbench/api/common/extHostLanguageFeatures.ts
+++ b/src/vs/workbench/api/common/extHostLanguageFeatures.ts
@@ -530,6 +530,10 @@ class DocumentPasteEditProvider {
 	}
 
 	async providePasteEdits(requestId: number, resource: URI, ranges: IRange[], dataTransferDto: extHostProtocol.DataTransferDTO, token: CancellationToken): Promise<undefined | extHostProtocol.IPasteEditDto> {
+		if (!this._provider.provideDocumentPasteEdits) {
+			return;
+		}
+
 		const doc = this._documents.getDocument(resource);
 		const vscodeRanges = ranges.map(range => typeConvert.Range.to(range));
 
@@ -2420,6 +2424,7 @@ export class ExtHostLanguageFeatures implements extHostProtocol.ExtHostLanguageF
 		this._adapter.set(handle, new AdapterData(new DocumentPasteEditProvider(this._proxy, this._documents, provider, handle, extension), extension));
 		this._proxy.$registerPasteEditProvider(handle, this._transformDocumentSelector(selector, extension), {
 			supportsCopy: !!provider.prepareDocumentPaste,
+			supportsPaste: !!provider.provideDocumentPasteEdits,
 			copyMimeTypes: metadata.copyMimeTypes,
 			pasteMimeTypes: metadata.pasteMimeTypes,
 		});

--- a/src/vscode-dts/vscode.proposed.documentPaste.d.ts
+++ b/src/vscode-dts/vscode.proposed.documentPaste.d.ts
@@ -37,7 +37,7 @@ declare module 'vscode' {
 		 *
 		 * @return Optional workspace edit that applies the paste. Return undefined to use standard pasting.
 		 */
-		provideDocumentPasteEdits(document: TextDocument, ranges: readonly Range[], dataTransfer: DataTransfer, token: CancellationToken): ProviderResult<DocumentPasteEdit>;
+		provideDocumentPasteEdits?(document: TextDocument, ranges: readonly Range[], dataTransfer: DataTransfer, token: CancellationToken): ProviderResult<DocumentPasteEdit>;
 	}
 
 	/**
@@ -98,7 +98,7 @@ declare module 'vscode' {
 		 * Note that {@link DataTransferFile} entries are only created when dropping content from outside the editor, such as
 		 * from the operating system.
 		 */
-		readonly pasteMimeTypes: readonly string[];
+		readonly pasteMimeTypes?: readonly string[];
 	}
 
 	namespace languages {


### PR DESCRIPTION
This fixes the range extensions get when copying an empty selection. As part of this, I've also:

- Added tests for this change
- Made the paste parts of the api optional. This is useful when a test provider only wants to add data on copy

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
