### PR TITLE
new context key for input elements focused within the notebook output webview

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/controller/editActions.ts
+++ b/src/vs/workbench/contrib/notebook/browser/controller/editActions.ts
@@ -126,61 +126,6 @@ registerAction2(class QuitEditCellAction extends NotebookCellAction {
 	}
 });
 
-registerAction2(class UnfocusCellOutput extends NotebookCellAction {
-	constructor() {
-		super(
-			{
-				id: 'notebook.cell.unfocusOutput',
-				title: localize('notebookActions.unfocusOutput', "Stop Editing Cell"),
-				menu: {
-					id: MenuId.NotebookCellTitle,
-					when: ContextKeyExpr.and(
-						NOTEBOOK_CELL_TYPE.isEqualTo('markup'),
-						NOTEBOOK_CELL_MARKDOWN_EDIT_MODE,
-						NOTEBOOK_CELL_EDITABLE),
-					order: CellToolbarOrder.SaveCell,
-					group: CELL_TITLE_CELL_GROUP_ID
-				},
-				icon: icons.stopEditIcon,
-				keybinding: [
-					{
-						when: ContextKeyExpr.and(quitEditCondition,
-							EditorContextKeys.hoverVisible.toNegated(),
-							EditorContextKeys.hasNonEmptySelection.toNegated(),
-							EditorContextKeys.hasMultipleSelections.toNegated()),
-						primary: KeyCode.Escape,
-						weight: NOTEBOOK_EDITOR_WIDGET_ACTION_WEIGHT - 5
-					},
-					{
-						when: ContextKeyExpr.and(NOTEBOOK_EDITOR_FOCUSED,
-							NOTEBOOK_OUTPUT_FOCUSED,
-							NOTEBOOK_OUPTUT_INPUT_FOCUSED.toNegated()),
-						primary: KeyCode.Escape,
-						weight: KeybindingWeight.WorkbenchContrib + 1
-					},
-					{
-						when: ContextKeyExpr.and(
-							quitEditCondition,
-							NOTEBOOK_CELL_TYPE.isEqualTo('markup')),
-						primary: KeyMod.WinCtrl | KeyCode.Enter,
-						win: {
-							primary: KeyMod.CtrlCmd | KeyMod.Alt | KeyCode.Enter
-						},
-						weight: NOTEBOOK_EDITOR_WIDGET_ACTION_WEIGHT - 5
-					},
-				]
-			});
-	}
-
-	async runWithContext(accessor: ServicesAccessor, context: INotebookCellActionContext) {
-		if (context.cell.cellKind === CellKind.Markup) {
-			context.cell.updateEditState(CellEditState.Preview, QUIT_EDIT_CELL_COMMAND_ID);
-		}
-
-		await context.notebookEditor.focusNotebookCell(context.cell, 'container', { skipReveal: true });
-	}
-});
-
 registerAction2(class DeleteCellAction extends NotebookCellAction {
 	constructor() {
 		super(

--- a/src/vs/workbench/contrib/notebook/browser/controller/editActions.ts
+++ b/src/vs/workbench/contrib/notebook/browser/controller/editActions.ts
@@ -126,6 +126,61 @@ registerAction2(class QuitEditCellAction extends NotebookCellAction {
 	}
 });
 
+registerAction2(class UnfocusCellOutput extends NotebookCellAction {
+	constructor() {
+		super(
+			{
+				id: 'notebook.cell.unfocusOutput',
+				title: localize('notebookActions.unfocusOutput', "Stop Editing Cell"),
+				menu: {
+					id: MenuId.NotebookCellTitle,
+					when: ContextKeyExpr.and(
+						NOTEBOOK_CELL_TYPE.isEqualTo('markup'),
+						NOTEBOOK_CELL_MARKDOWN_EDIT_MODE,
+						NOTEBOOK_CELL_EDITABLE),
+					order: CellToolbarOrder.SaveCell,
+					group: CELL_TITLE_CELL_GROUP_ID
+				},
+				icon: icons.stopEditIcon,
+				keybinding: [
+					{
+						when: ContextKeyExpr.and(quitEditCondition,
+							EditorContextKeys.hoverVisible.toNegated(),
+							EditorContextKeys.hasNonEmptySelection.toNegated(),
+							EditorContextKeys.hasMultipleSelections.toNegated()),
+						primary: KeyCode.Escape,
+						weight: NOTEBOOK_EDITOR_WIDGET_ACTION_WEIGHT - 5
+					},
+					{
+						when: ContextKeyExpr.and(NOTEBOOK_EDITOR_FOCUSED,
+							NOTEBOOK_OUTPUT_FOCUSED,
+							NOTEBOOK_OUPTUT_INPUT_FOCUSED.toNegated()),
+						primary: KeyCode.Escape,
+						weight: KeybindingWeight.WorkbenchContrib + 1
+					},
+					{
+						when: ContextKeyExpr.and(
+							quitEditCondition,
+							NOTEBOOK_CELL_TYPE.isEqualTo('markup')),
+						primary: KeyMod.WinCtrl | KeyCode.Enter,
+						win: {
+							primary: KeyMod.CtrlCmd | KeyMod.Alt | KeyCode.Enter
+						},
+						weight: NOTEBOOK_EDITOR_WIDGET_ACTION_WEIGHT - 5
+					},
+				]
+			});
+	}
+
+	async runWithContext(accessor: ServicesAccessor, context: INotebookCellActionContext) {
+		if (context.cell.cellKind === CellKind.Markup) {
+			context.cell.updateEditState(CellEditState.Preview, QUIT_EDIT_CELL_COMMAND_ID);
+		}
+
+		await context.notebookEditor.focusNotebookCell(context.cell, 'container', { skipReveal: true });
+	}
+});
+
 registerAction2(class DeleteCellAction extends NotebookCellAction {
 	constructor() {
 		super(

--- a/src/vs/workbench/contrib/notebook/browser/diff/notebookDiffEditor.ts
+++ b/src/vs/workbench/contrib/notebook/browser/diff/notebookDiffEditor.ts
@@ -183,6 +183,10 @@ export class NotebookTextDiffEditor extends EditorPane implements INotebookTextD
 		// throw new Error('Method not implemented.');
 	}
 
+	didFocusOutputInputChange(focus: boolean): void {
+		// noop
+	}
+
 	getScrollTop() {
 		return this._list?.scrollTop ?? 0;
 	}

--- a/src/vs/workbench/contrib/notebook/browser/diff/notebookDiffEditor.ts
+++ b/src/vs/workbench/contrib/notebook/browser/diff/notebookDiffEditor.ts
@@ -183,7 +183,7 @@ export class NotebookTextDiffEditor extends EditorPane implements INotebookTextD
 		// throw new Error('Method not implemented.');
 	}
 
-	didFocusOutputInputChange(focus: boolean): void {
+	didFocusOutputInputChange(inputFocused: boolean): void {
 		// noop
 	}
 

--- a/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
@@ -71,7 +71,7 @@ import { NotebookOverviewRuler } from 'vs/workbench/contrib/notebook/browser/vie
 import { ListTopCellToolbar } from 'vs/workbench/contrib/notebook/browser/viewParts/notebookTopCellToolbar';
 import { NotebookTextModel } from 'vs/workbench/contrib/notebook/common/model/notebookTextModel';
 import { CellEditType, CellKind, INotebookSearchOptions, RENDERER_NOT_AVAILABLE, SelectionStateType } from 'vs/workbench/contrib/notebook/common/notebookCommon';
-import { NOTEBOOK_CURSOR_NAVIGATION_MODE, NOTEBOOK_EDITOR_EDITABLE, NOTEBOOK_EDITOR_FOCUSED, NOTEBOOK_OUTPUT_FOCUSED } from 'vs/workbench/contrib/notebook/common/notebookContextKeys';
+import { NOTEBOOK_CURSOR_NAVIGATION_MODE, NOTEBOOK_EDITOR_EDITABLE, NOTEBOOK_EDITOR_FOCUSED, NOTEBOOK_OUTPUT_FOCUSED, NOTEBOOK_OUPTUT_INPUT_FOCUSED } from 'vs/workbench/contrib/notebook/common/notebookContextKeys';
 import { INotebookExecutionService } from 'vs/workbench/contrib/notebook/common/notebookExecutionService';
 import { INotebookExecutionStateService } from 'vs/workbench/contrib/notebook/common/notebookExecutionStateService';
 import { INotebookKernelService } from 'vs/workbench/contrib/notebook/common/notebookKernelService';
@@ -198,6 +198,7 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditorD
 	private readonly _outputFocus: IContextKey<boolean>;
 	private readonly _editorEditable: IContextKey<boolean>;
 	private readonly _cursorNavMode: IContextKey<boolean>;
+	private readonly _outputInputFocus: IContextKey<boolean>;
 	protected readonly _contributions = new Map<string, INotebookEditorContribution>();
 	private _scrollBeyondLastLine: boolean;
 	private readonly _insetModifyQueueByOutputId = new SequencerByKey<string>();
@@ -390,6 +391,7 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditorD
 		this._isVisible = true;
 		this._editorFocus = NOTEBOOK_EDITOR_FOCUSED.bindTo(this.scopedContextKeyService);
 		this._outputFocus = NOTEBOOK_OUTPUT_FOCUSED.bindTo(this.scopedContextKeyService);
+		this._outputInputFocus = NOTEBOOK_OUPTUT_INPUT_FOCUSED.bindTo(this.scopedContextKeyService);
 		this._editorEditable = NOTEBOOK_EDITOR_EDITABLE.bindTo(this.scopedContextKeyService);
 		this._cursorNavMode = NOTEBOOK_CURSOR_NAVIGATION_MODE.bindTo(this.scopedContextKeyService);
 
@@ -1349,6 +1351,7 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditorD
 			didEndDragMarkupCell: that._didEndDragMarkupCell.bind(that),
 			didResizeOutput: that._didResizeOutput.bind(that),
 			updatePerformanceMetadata: that._updatePerformanceMetadata.bind(that),
+			didFocusOutputInputChange: that._didFocusOutputInputChange.bind(that),
 		}, id, viewType, resource, {
 			...this._notebookOptions.computeWebviewOptions(),
 			fontFamily: this._generateFontFamily()
@@ -1973,6 +1976,10 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditorD
 		}
 
 		return false;
+	}
+
+	_didFocusOutputInputChange(hasFocus: boolean) {
+		this._outputInputFocus.set(hasFocus);
 	}
 
 	//#endregion

--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView.ts
@@ -94,6 +94,7 @@ export interface INotebookDelegateForWebview {
 	setScrollTop(scrollTop: number): void;
 	triggerScroll(event: IMouseWheelEvent): void;
 	updatePerformanceMetadata(cellId: string, executionId: string, duration: number, rendererId: string): void;
+	didFocusOutputInputChange(focus: boolean): void;
 }
 
 interface BacklayerWebviewOptions {
@@ -876,6 +877,9 @@ export class BackLayerWebView<T extends ICommonCellInfo> extends Themable {
 				case 'notebookPerformanceMessage': {
 					this.notebookEditor.updatePerformanceMetadata(data.cellId, data.executionId, data.duration, data.rendererId);
 					break;
+				}
+				case 'outputInputFocus': {
+					this.notebookEditor.didFocusOutputInputChange(data.hasFocus);
 				}
 			}
 		}));

--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView.ts
@@ -94,7 +94,7 @@ export interface INotebookDelegateForWebview {
 	setScrollTop(scrollTop: number): void;
 	triggerScroll(event: IMouseWheelEvent): void;
 	updatePerformanceMetadata(cellId: string, executionId: string, duration: number, rendererId: string): void;
-	didFocusOutputInputChange(focus: boolean): void;
+	didFocusOutputInputChange(inputFocused: boolean): void;
 }
 
 interface BacklayerWebviewOptions {
@@ -879,7 +879,7 @@ export class BackLayerWebView<T extends ICommonCellInfo> extends Themable {
 					break;
 				}
 				case 'outputInputFocus': {
-					this.notebookEditor.didFocusOutputInputChange(data.hasFocus);
+					this.notebookEditor.didFocusOutputInputChange(data.inputFocused);
 				}
 			}
 		}));

--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewMessages.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewMessages.ts
@@ -47,6 +47,11 @@ export interface IOutputBlurMessage extends BaseToWebviewMessage {
 	readonly id: string;
 }
 
+export interface IOutputInputFocusMessage extends BaseToWebviewMessage {
+	readonly type: 'outputInputFocus';
+	readonly hasFocus: boolean;
+}
+
 export interface IScrollToRevealMessage extends BaseToWebviewMessage {
 	readonly type: 'scroll-to-reveal';
 	readonly scrollTop: number;
@@ -475,6 +480,7 @@ export type FromWebviewMessage = WebviewInitialized |
 	IMouseLeaveMessage |
 	IOutputFocusMessage |
 	IOutputBlurMessage |
+	IOutputInputFocusMessage |
 	IScrollToRevealMessage |
 	IWheelMessage |
 	IScrollAckMessage |

--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewMessages.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewMessages.ts
@@ -49,7 +49,7 @@ export interface IOutputBlurMessage extends BaseToWebviewMessage {
 
 export interface IOutputInputFocusMessage extends BaseToWebviewMessage {
 	readonly type: 'outputInputFocus';
-	readonly hasFocus: boolean;
+	readonly inputFocused: boolean;
 }
 
 export interface IScrollToRevealMessage extends BaseToWebviewMessage {

--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewPreloads.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewPreloads.ts
@@ -146,10 +146,10 @@ async function webviewPreloads(ctx: PreloadContext) {
 		}
 
 		if (activeElement.tagName === 'INPUT' || activeElement.tagName === 'TEXTAREA') {
-			postNotebookMessage<webviewMessages.IOutputInputFocusMessage>('outputInputFocus', { hasFocus: true });
+			postNotebookMessage<webviewMessages.IOutputInputFocusMessage>('outputInputFocus', { inputFocused: true });
 
-			activeElement.addEventListener('onblur', () => {
-				postNotebookMessage<webviewMessages.IOutputInputFocusMessage>('outputInputFocus', { hasFocus: false });
+			activeElement.addEventListener('blur', () => {
+				postNotebookMessage<webviewMessages.IOutputInputFocusMessage>('outputInputFocus', { inputFocused: false });
 			}, { once: true });
 		}
 	};
@@ -158,8 +158,6 @@ async function webviewPreloads(ctx: PreloadContext) {
 		if (!event || !event.view || !event.view.document) {
 			return;
 		}
-
-		checkOutputInputFocus();
 
 		for (const node of event.composedPath()) {
 			if (node instanceof HTMLElement && node.classList.contains('output')) {
@@ -241,6 +239,7 @@ async function webviewPreloads(ctx: PreloadContext) {
 	};
 
 	document.body.addEventListener('click', handleInnerClick);
+	document.body.addEventListener('focusin', checkOutputInputFocus);
 
 	interface RendererContext extends rendererApi.RendererContext<unknown> {
 		readonly onDidChangeSettings: Event<RenderOptions>;

--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewPreloads.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewPreloads.ts
@@ -94,8 +94,6 @@ async function webviewPreloads(ctx: PreloadContext) {
 	let currentRenderOptions = ctx.renderOptions;
 	const settingChange: EmitterLike<RenderOptions> = createEmitter<RenderOptions>();
 
-	let isInputElementFocused: boolean | undefined = undefined;
-
 	const acquireVsCodeApi = globalThis.acquireVsCodeApi;
 	const vscode = acquireVsCodeApi();
 	delete (globalThis as any).acquireVsCodeApi;
@@ -147,9 +145,7 @@ async function webviewPreloads(ctx: PreloadContext) {
 			return;
 		}
 
-		isInputElementFocused = !!activeElement && (activeElement.tagName === 'INPUT' || activeElement.tagName === 'TEXTAREA');
-
-		if (isInputElementFocused) {
+		if (activeElement.tagName === 'INPUT' || activeElement.tagName === 'TEXTAREA') {
 			postNotebookMessage<webviewMessages.IOutputInputFocusMessage>('outputInputFocus', { hasFocus: true });
 
 			activeElement.addEventListener('onblur', () => {

--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewPreloads.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewPreloads.ts
@@ -5,7 +5,7 @@
 
 import type { Event } from 'vs/base/common/event';
 import type { IDisposable } from 'vs/base/common/lifecycle';
-import * as webviewMessages from 'vs/workbench/contrib/notebook/browser/view/renderers/webviewMessages';
+import type * as webviewMessages from 'vs/workbench/contrib/notebook/browser/view/renderers/webviewMessages';
 import type { NotebookCellMetadata } from 'vs/workbench/contrib/notebook/common/notebookCommon';
 import type * as rendererApi from 'vscode-notebook-renderer';
 
@@ -94,6 +94,8 @@ async function webviewPreloads(ctx: PreloadContext) {
 	let currentRenderOptions = ctx.renderOptions;
 	const settingChange: EmitterLike<RenderOptions> = createEmitter<RenderOptions>();
 
+	let isInputElementFocused: boolean | undefined = undefined;
+
 	const acquireVsCodeApi = globalThis.acquireVsCodeApi;
 	const vscode = acquireVsCodeApi();
 	delete (globalThis as any).acquireVsCodeApi;
@@ -138,16 +140,19 @@ async function webviewPreloads(ctx: PreloadContext) {
 		};
 
 	// check if an input element is focused within the output element
-	const handleOutputFocus = () => {
+	const checkOutputInputFocus = () => {
+
 		const activeElement = document.activeElement;
 		if (!activeElement) {
 			return;
 		}
 
-		if (activeElement.tagName === 'INPUT' || activeElement.tagName === 'TEXTAREA') {
+		isInputElementFocused = !!activeElement && (activeElement.tagName === 'INPUT' || activeElement.tagName === 'TEXTAREA');
+
+		if (isInputElementFocused) {
 			postNotebookMessage<webviewMessages.IOutputInputFocusMessage>('outputInputFocus', { hasFocus: true });
 
-			activeElement.addEventListener('blur', () => {
+			activeElement.addEventListener('onblur', () => {
 				postNotebookMessage<webviewMessages.IOutputInputFocusMessage>('outputInputFocus', { hasFocus: false });
 			}, { once: true });
 		}
@@ -158,7 +163,7 @@ async function webviewPreloads(ctx: PreloadContext) {
 			return;
 		}
 
-		handleOutputFocus();
+		checkOutputInputFocus();
 
 		for (const node of event.composedPath()) {
 			if (node instanceof HTMLElement && node.classList.contains('output')) {
@@ -240,7 +245,6 @@ async function webviewPreloads(ctx: PreloadContext) {
 	};
 
 	document.body.addEventListener('click', handleInnerClick);
-	document.body.addEventListener('focusin', handleOutputFocus);
 
 	interface RendererContext extends rendererApi.RendererContext<unknown> {
 		readonly onDidChangeSettings: Event<RenderOptions>;

--- a/src/vs/workbench/contrib/notebook/common/notebookContextKeys.ts
+++ b/src/vs/workbench/contrib/notebook/common/notebookContextKeys.ts
@@ -20,6 +20,7 @@ export const INTERACTIVE_WINDOW_IS_ACTIVE_EDITOR = ContextKeyExpr.equals('active
 export const NOTEBOOK_EDITOR_FOCUSED = new RawContextKey<boolean>('notebookEditorFocused', false);
 export const NOTEBOOK_CELL_LIST_FOCUSED = new RawContextKey<boolean>('notebookCellListFocused', false);
 export const NOTEBOOK_OUTPUT_FOCUSED = new RawContextKey<boolean>('notebookOutputFocused', false);
+export const NOTEBOOK_OUPTUT_INPUT_FOCUSED = new RawContextKey<boolean>('notebookOutputInputFocused', false);
 export const NOTEBOOK_EDITOR_EDITABLE = new RawContextKey<boolean>('notebookEditable', true);
 export const NOTEBOOK_HAS_RUNNING_CELL = new RawContextKey<boolean>('notebookHasRunningCell', false);
 export const NOTEBOOK_HAS_SOMETHING_RUNNING = new RawContextKey<boolean>('notebookHasSomethingRunning', false);


### PR DESCRIPTION
required for https://github.com/microsoft/vscode-jupyter/issues/13026

the hotkeys for notebook commands a,b,j,k come from (or are modified by) the jupyter extension which can make use of this new context key