### PR TITLE
files - add new option `atomic` for `writeFile` and adopt for state (fix #180695)

### DIFF
--- a/src/vs/platform/files/common/fileService.ts
+++ b/src/vs/platform/files/common/fileService.ts
@@ -370,7 +370,7 @@ export class FileService extends Disposable implements IFileService {
 		await this.doWriteFile(tempResource, bufferOrReadableOrStream, options, true /* skip events */);
 
 		// then rename to target
-		const stat = await this.move(tempResource, resource, true, true);
+		const stat = await this.move(tempResource, resource, true, true /* skip events */);
 
 		// events
 		this._onDidRunOperation.fire(new FileOperationEvent(resource, FileOperation.WRITE));

--- a/src/vs/platform/files/common/files.ts
+++ b/src/vs/platform/files/common/files.ts
@@ -1146,6 +1146,12 @@ export interface IWriteFileOptions {
 	 * Whether to attempt to unlock a file before writing.
 	 */
 	readonly unlock?: boolean;
+
+	/**
+	 * Whether to write in an atomic way by first writing to a different
+	 * file in the same folder and then renaming to the target file.
+	 */
+	readonly atomic?: boolean;
 }
 
 export interface IResolveFileOptions {

--- a/src/vs/platform/state/node/stateService.ts
+++ b/src/vs/platform/state/node/stateService.ts
@@ -139,7 +139,7 @@ export class FileStorage {
 
 		// Write to disk
 		try {
-			await this.fileService.writeFile(this.storagePath, VSBuffer.fromString(serializedDatabase));
+			await this.fileService.writeFile(this.storagePath, VSBuffer.fromString(serializedDatabase), { atomic: true });
 			this.lastSavedStorageContents = serializedDatabase;
 		} catch (error) {
 			this.logService.error(error);


### PR DESCRIPTION
@sandy081 would be happy if you could check if the implementation makes sense

//cc @alexdima this adds the most basic atomic write to the file service (behind an option) which is:
* write to a file `<resource path>.vsctmp` in the same folder
* `move` the file to `<resource path>`
* skip our internal events and only send a single event (as we would have it without atomic writes)

**Some notes:**
* this will actually work with any file system provider because it leverages existing capabilities [1]
* some external file watchers maybe confused (I think thats ok, our watcher should be fine)
* when process dies, we risk to keep `.vsctmp` files laying around (I think thats ok too, because its never acumulating, its always the same tmp file)

[1] we could consider making this a capability and move this into the provider itself to do the `write` and `move` one after the other without going over processes, but I think it does not change the aspects of it much.