### PR TITLE
suggest: trigger when one starts typing before a word, e.g.,

### DIFF
--- a/src/vs/editor/contrib/suggest/browser/suggestModel.ts
+++ b/src/vs/editor/contrib/suggest/browser/suggestModel.ts
@@ -72,7 +72,8 @@ export class LineContext {
 		if (!word) {
 			return false;
 		}
-		if (word.endColumn !== pos.column) {
+		if (word.endColumn !== pos.column &&
+			word.startColumn + 1 !== pos.column /* after typing a single character before a word */) {
 			return false;
 		}
 		if (!isNaN(Number(word.word))) {

--- a/src/vs/editor/contrib/suggest/test/browser/suggestModel.test.ts
+++ b/src/vs/editor/contrib/suggest/test/browser/suggestModel.test.ts
@@ -142,7 +142,7 @@ suite('SuggestModel - Context', function () {
 
 		assertAutoTrigger(model, 3, true, 'end of word, Das|');
 		assertAutoTrigger(model, 4, false, 'no word Das |');
-		assertAutoTrigger(model, 1, false, 'middle of word D|as');
+		assertAutoTrigger(model, 1, true, 'typing a single character before a word: D|as');
 		assertAutoTrigger(model, 55, false, 'number, 1861|');
 		model.dispose();
 	});
@@ -157,7 +157,7 @@ suite('SuggestModel - Context', function () {
 
 		assertAutoTrigger(model, 1, true, 'a|<x — should trigger at end of word');
 		assertAutoTrigger(model, 2, false, 'a<|x — should NOT trigger at start of word');
-		assertAutoTrigger(model, 3, false, 'a<x|x —  should NOT trigger in middle of word');
+		assertAutoTrigger(model, 3, true, 'a<x|x —  should trigger after typing a single character before a word');
 		assertAutoTrigger(model, 4, true, 'a<xx|> — should trigger at boundary between languages');
 		assertAutoTrigger(model, 5, false, 'a<xx>|a — should NOT trigger at start of word');
 		assertAutoTrigger(model, 6, true, 'a<xx>a|< — should trigger at end of word');


### PR DESCRIPTION
| - cursor

```typescript
const foo = new Foo()
|foo
```

typing in `c` when the current cursor is should trigger suggest, e.g., with suggestion `console`, etc.

### Before

https://github.com/microsoft/vscode/assets/16353531/8c2dbd24-9592-4ed8-b01a-949de91d8406


### After

https://github.com/microsoft/vscode/assets/16353531/3ce9f253-9d1c-4569-8cea-2f1f2452656e

