### PR TITLE
Fix disappearing chat response

### DIFF
--- a/src/vs/workbench/contrib/interactiveSession/browser/interactiveSessionWidget.ts
+++ b/src/vs/workbench/contrib/interactiveSession/browser/interactiveSessionWidget.ts
@@ -206,8 +206,13 @@ export class InteractiveSessionWidget extends Disposable implements IInteractive
 		this.renderer.setVisible(visible);
 
 		if (visible) {
-			// Progressive rendering paused while hidden, so start it up again
-			this.onDidChangeItems();
+			setTimeout(() => {
+				// Progressive rendering paused while hidden, so start it up again.
+				// Do it after a timeout because the container is not visible yet (it should be but offsetHeight returns 0 here)
+				if (this.visible) {
+					this.onDidChangeItems();
+				}
+			}, 0);
 		}
 	}
 
@@ -340,6 +345,7 @@ export class InteractiveSessionWidget extends Disposable implements IInteractive
 			throw new Error('Call render() before setModel()');
 		}
 
+		this.container.setAttribute('data-session-id', model.sessionId);
 		this.viewModel = this.instantiationService.createInstance(InteractiveSessionViewModel, model);
 		this.viewModelDisposables.add(this.viewModel.onDidChange(() => {
 			this.slashCommandsPromise = undefined;


### PR DESCRIPTION
Weird issue, maybe a browser bug, but the dynamic height calculation in the list sometimes sets the height of an item to 0 when rendering it right after toggling the sidebar to visible.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
