### PR TITLE
fix:Extension keybindings in the context menu

### DIFF
--- a/src/vs/editor/contrib/contextmenu/browser/contextmenu.ts
+++ b/src/vs/editor/contrib/contextmenu/browser/contextmenu.ts
@@ -375,7 +375,7 @@ export class ContextMenuController implements IEditorContribution {
 	}
 
 	private _keybindingFor(action: IAction): ResolvedKeybinding | undefined {
-		return this._keybindingService.lookupKeybinding(action.id);
+		return this._keybindingService.lookupKeybinding(action.id, this._contextKeyService);
 	}
 
 	public dispose(): void {


### PR DESCRIPTION
before fix:
Keybindings registered by the extension cannot be displayed correctly in the context menu,the keybinding label in contextmenu only display the last registered key by default;
![image](https://github.com/Jeehunter/vscodebug/blob/main/bug1.png?raw=true)

after fix:
The contextmenu can dynamically retrieve the context of 'editorTextFocus' or other contexts on the when statement,to display the correct keybindings.
![image](https://github.com/Jeehunter/vscodebug/blob/main/bug2.png?raw=true)