### PR TITLE
Prevent ligatures between inlay hints and editor contents (Fix #170449)

### DIFF
--- a/src/vs/editor/browser/editorDom.ts
+++ b/src/vs/editor/browser/editorDom.ts
@@ -342,6 +342,7 @@ export interface CssProperties {
 	fontWeight?: string;
 	fontSize?: string;
 	fontFamily?: string;
+	unicodeBidi?: string;
 	textDecoration?: string;
 	color?: string | ThemeColor;
 	backgroundColor?: string | ThemeColor;

--- a/src/vs/editor/contrib/inlayHints/browser/inlayHintsController.ts
+++ b/src/vs/editor/contrib/inlayHints/browser/inlayHintsController.ts
@@ -495,6 +495,7 @@ export class InlayHintsController implements IEditorContribution {
 					fontSize: `${fontSize}px`,
 					fontFamily: `var(${fontFamilyVar}), ${EDITOR_FONT_DEFAULTS.fontFamily}`,
 					verticalAlign: isUniform ? 'baseline' : 'middle',
+					unicodeBidi: 'isolate'
 				};
 
 				if (isNonEmptyArray(item.hint.textEdits)) {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fixes #170449

Setting:

```json
    "editor.fontLigatures": "'liga', 'calt', 'cv16'", // *
"editor.fontFamily": "'Fira Code'",
```

Extension:

```typescript
vscode.languages.registerInlayHintsProvider({pattern: "**"}, {
		provideInlayHints(document, range, token) {
			const ret:vscode.InlayHint[] = [];
			for (let i = range.start.line; i <= range.end.line; i++) {
				const lineText = document.lineAt(i).text;
				for (const j of lineText.matchAll(/&/g)) {
					ret.push({label: "&", position: new vscode.Position(i, j.index!)});
				}
				for (const j of lineText.matchAll(/==/g)) {
					ret.push({label: "=", position: new vscode.Position(i, j.index!)});
				}
				if (token.isCancellationRequested) throw new vscode.CancellationError();
			}
			return ret;
		},
	});
```

Expected result:

![image](https://github.com/microsoft/vscode/assets/1485998/17db350d-92c4-4b25-bbe1-620c07344439)

vs VS Code:

![image](https://github.com/microsoft/vscode/assets/1485998/a9dec075-0544-4d5a-815b-b757c9a61efd)

See https://www.w3.org/TR/2023/CRD-css-text-3-20230213/#boundary-shaping