### PR TITLE
joh/ridiculous herring

### DIFF
--- a/src/vs/workbench/contrib/interactiveEditor/browser/interactiveEditorController.ts
+++ b/src/vs/workbench/contrib/interactiveEditor/browser/interactiveEditorController.ts
@@ -183,6 +183,7 @@ export class InteractiveEditorController implements IEditorContribution {
 		delete options?.existingSession;
 
 		if (!session) {
+			this._dialogService.info(localize('create.fail', "Failed to start editor chat"), localize('create.fail.detail', "Please consult the error log and try again later."));
 			return State.DONE;
 		}
 

--- a/src/vs/workbench/contrib/interactiveEditor/browser/interactiveEditorLivePreviewWidget.ts
+++ b/src/vs/workbench/contrib/interactiveEditor/browser/interactiveEditorLivePreviewWidget.ts
@@ -148,8 +148,8 @@ export class InteractiveEditorLivePreviewWidget extends ZoneWidget {
 	private _updateFromChanges(range: Range, changes: LineRangeMapping[]): void {
 		assertType(this.editor.hasModel());
 
-		if (changes.length === 0) {
-			// no change
+		if (changes.length === 0 || this._textModelv0.getValueLength() === 0) {
+			// no change or changes to an empty file
 			this._logService.debug('[IE] livePreview-mode: no diff');
 			this.hide();
 

--- a/src/vs/workbench/contrib/interactiveEditor/browser/interactiveEditorSession.ts
+++ b/src/vs/workbench/contrib/interactiveEditor/browser/interactiveEditorSession.ts
@@ -282,7 +282,14 @@ export class InteractiveEditorSessionService implements IInteractiveEditorSessio
 
 		const textModel = editor.getModel();
 		const selection = editor.getSelection();
-		const raw = await provider.prepareInteractiveEditorSession(textModel, selection, token);
+		let raw: IInteractiveEditorSession | undefined | null;
+		try {
+			raw = await provider.prepareInteractiveEditorSession(textModel, selection, token);
+		} catch (error) {
+			this._logService.error('[IE] FAILED to prepare session', provider.debugName);
+			this._logService.error(error);
+			return undefined;
+		}
 		if (!raw) {
 			this._logService.trace('[IE] NO session', provider.debugName);
 			return undefined;

--- a/src/vs/workbench/contrib/interactiveEditor/browser/interactiveEditorStrategies.ts
+++ b/src/vs/workbench/contrib/interactiveEditor/browser/interactiveEditorStrategies.ts
@@ -40,8 +40,6 @@ export abstract class EditModeStrategy {
 
 	abstract renderChanges(response: EditResponse, changes: LineRangeMapping[]): Promise<void>;
 
-	abstract hide(): Promise<void>;
-
 	abstract toggleInlineDiff(): void;
 }
 
@@ -99,10 +97,6 @@ export class PreviewStrategy extends EditModeStrategy {
 				modelN.pushStackElement();
 			}
 		}
-	}
-
-	override async hide(): Promise<void> {
-		// nothing to do, input widget will be hidden by controller
 	}
 
 	async cancel(): Promise<void> {
@@ -264,10 +258,6 @@ export class LiveStrategy extends EditModeStrategy {
 		}
 	}
 
-	override async hide(): Promise<void> {
-		this._inlineDiffDecorations.clear();
-	}
-
 	async cancel() {
 		const { textModelN: modelN, textModel0: model0, lastSnapshot } = this._session;
 		if (modelN.isDisposed() || (model0.isDisposed() && !lastSnapshot)) {
@@ -360,11 +350,6 @@ export class LivePreviewStrategy extends LiveStrategy {
 		this._previewZone.hide();
 		this._previewZone.dispose();
 		super.dispose();
-	}
-
-	override async hide(): Promise<void> {
-		this._diffZone.hide();
-		super.hide();
 	}
 
 	override async makeChanges(_response: EditResponse, edits: ISingleEditOperation[]): Promise<void> {


### PR DESCRIPTION
- in live modes only push undo stops before first and after last edits, not on each edit
- handle strategies failing during apply/discard
- remove unused code
- livePreview - don't show diff when populating just an empty file
- state machine polish
- log session creation failure and show a modal to users
