### PR TITLE
joh/remarkable egret

### DIFF
--- a/src/vs/platform/actions/browser/menuEntryActionViewItem.ts
+++ b/src/vs/platform/actions/browser/menuEntryActionViewItem.ts
@@ -320,14 +320,15 @@ export class SubmenuEntryActionViewItem extends DropdownMenuActionViewItem {
 
 export interface IDropdownWithDefaultActionViewItemOptions extends IDropdownMenuActionViewItemOptions {
 	renderKeybindingWithDefaultActionLabel?: boolean;
+	persistLastActionId?: boolean;
 }
 
 export class DropdownWithDefaultActionViewItem extends BaseActionViewItem {
 	private readonly _options: IDropdownWithDefaultActionViewItemOptions | undefined;
 	private _defaultAction: ActionViewItem;
-	private _dropdown: DropdownMenuActionViewItem;
+	private readonly _dropdown: DropdownMenuActionViewItem;
 	private _container: HTMLElement | null = null;
-	private _storageKey: string;
+	private readonly _storageKey: string;
 
 	get onDidChangeDropdownVisibility(): Event<boolean> {
 		return this._dropdown.onDidChangeVisibility;
@@ -349,7 +350,7 @@ export class DropdownWithDefaultActionViewItem extends BaseActionViewItem {
 
 		// determine default action
 		let defaultAction: IAction | undefined;
-		const defaultActionId = _storageService.get(this._storageKey, StorageScope.WORKSPACE);
+		const defaultActionId = options?.persistLastActionId ? _storageService.get(this._storageKey, StorageScope.WORKSPACE) : undefined;
 		if (defaultActionId) {
 			defaultAction = submenuAction.actions.find(a => defaultActionId === a.id);
 		}
@@ -359,11 +360,13 @@ export class DropdownWithDefaultActionViewItem extends BaseActionViewItem {
 
 		this._defaultAction = this._instaService.createInstance(MenuEntryActionViewItem, <MenuItemAction>defaultAction, { keybinding: this._getDefaultActionKeybindingLabel(defaultAction) });
 
-		const dropdownOptions = Object.assign({}, options ?? Object.create(null), {
+		const dropdownOptions: IDropdownMenuActionViewItemOptions = {
+			keybindingProvider: action => this._keybindingService.lookupKeybinding(action.id),
+			...options,
 			menuAsChild: options?.menuAsChild ?? true,
 			classNames: options?.classNames ?? ['codicon', 'codicon-chevron-down'],
-			actionRunner: options?.actionRunner ?? new ActionRunner()
-		});
+			actionRunner: options?.actionRunner ?? new ActionRunner(),
+		};
 
 		this._dropdown = new DropdownMenuActionViewItem(submenuAction, submenuAction.actions, this._contextMenuService, dropdownOptions);
 		this._dropdown.actionRunner.onDidRun((e: IRunEvent) => {
@@ -374,7 +377,9 @@ export class DropdownWithDefaultActionViewItem extends BaseActionViewItem {
 	}
 
 	private update(lastAction: MenuItemAction): void {
-		this._storageService.store(this._storageKey, lastAction.id, StorageScope.WORKSPACE, StorageTarget.MACHINE);
+		if (this._options?.persistLastActionId) {
+			this._storageService.store(this._storageKey, lastAction.id, StorageScope.WORKSPACE, StorageTarget.MACHINE);
+		}
 
 		this._defaultAction.dispose();
 		this._defaultAction = this._instaService.createInstance(MenuEntryActionViewItem, lastAction, { keybinding: this._getDefaultActionKeybindingLabel(lastAction) });
@@ -505,7 +510,7 @@ export function createActionViewItem(instaService: IInstantiationService, action
 			return instaService.createInstance(SubmenuEntrySelectActionViewItem, action);
 		} else {
 			if (action.item.rememberDefaultAction) {
-				return instaService.createInstance(DropdownWithDefaultActionViewItem, action, options);
+				return instaService.createInstance(DropdownWithDefaultActionViewItem, action, { ...options, persistLastActionId: true });
 			} else {
 				return instaService.createInstance(SubmenuEntryActionViewItem, action, options);
 			}

--- a/src/vs/workbench/contrib/interactiveEditor/browser/interactiveEditor.contribution.ts
+++ b/src/vs/workbench/contrib/interactiveEditor/browser/interactiveEditor.contribution.ts
@@ -20,7 +20,11 @@ registerEditorContribution(INTERACTIVE_EDITOR_ID, InteractiveEditorController, E
 registerAction2(interactiveEditorActions.StartSessionAction);
 registerAction2(interactiveEditorActions.MakeRequestAction);
 registerAction2(interactiveEditorActions.StopRequestAction);
+registerAction2(interactiveEditorActions.DicardAction);
+registerAction2(interactiveEditorActions.DiscardToClipboardAction);
+registerAction2(interactiveEditorActions.DiscardUndoToNewFileAction);
 registerAction2(interactiveEditorActions.CancelSessionAction);
+
 registerAction2(interactiveEditorActions.ArrowOutUpAction);
 registerAction2(interactiveEditorActions.ArrowOutDownAction);
 registerAction2(interactiveEditorActions.FocusInteractiveEditor);
@@ -30,9 +34,6 @@ registerAction2(interactiveEditorActions.ViewInChatAction);
 registerAction2(interactiveEditorActions.ExpandMessageAction);
 registerAction2(interactiveEditorActions.ContractMessageAction);
 
-registerAction2(interactiveEditorActions.UndoToClipboard);
-registerAction2(interactiveEditorActions.UndoToNewFile);
-registerAction2(interactiveEditorActions.UndoCommand);
 registerAction2(interactiveEditorActions.ToggleInlineDiff);
 registerAction2(interactiveEditorActions.FeebackHelpfulCommand);
 registerAction2(interactiveEditorActions.FeebackUnhelpfulCommand);

--- a/src/vs/workbench/contrib/interactiveEditor/browser/interactiveEditorActions.ts
+++ b/src/vs/workbench/contrib/interactiveEditor/browser/interactiveEditorActions.ts
@@ -404,7 +404,6 @@ export class ApplyPreviewEdits extends AbstractInteractiveEditorAction {
 			keybinding: [{
 				weight: KeybindingWeight.EditorContrib + 10,
 				primary: KeyMod.CtrlCmd | KeyCode.Enter,
-				when: CTX_INTERACTIVE_EDITOR_EDIT_MODE.isEqualTo(EditMode.Preview)
 			}, {
 				weight: KeybindingWeight.EditorContrib + 10,
 				primary: KeyCode.Escape,
@@ -412,6 +411,7 @@ export class ApplyPreviewEdits extends AbstractInteractiveEditorAction {
 			}],
 			menu: {
 				id: MENU_INTERACTIVE_EDITOR_WIDGET_STATUS,
+				when: CTX_INTERACTIVE_EDITOR_EDIT_MODE.isEqualTo(EditMode.Preview),
 				group: '0_main',
 				order: 0
 			}

--- a/src/vs/workbench/contrib/interactiveEditor/browser/interactiveEditorActions.ts
+++ b/src/vs/workbench/contrib/interactiveEditor/browser/interactiveEditorActions.ts
@@ -10,7 +10,7 @@ import { EditorAction2 } from 'vs/editor/browser/editorExtensions';
 import { EmbeddedCodeEditorWidget, EmbeddedDiffEditorWidget } from 'vs/editor/browser/widget/embeddedCodeEditorWidget';
 import { EditorContextKeys } from 'vs/editor/common/editorContextKeys';
 import { InteractiveEditorController, InteractiveEditorRunOptions } from 'vs/workbench/contrib/interactiveEditor/browser/interactiveEditorController';
-import { CTX_INTERACTIVE_EDITOR_FOCUSED, CTX_INTERACTIVE_EDITOR_HAS_ACTIVE_REQUEST, CTX_INTERACTIVE_EDITOR_HAS_PROVIDER, CTX_INTERACTIVE_EDITOR_INNER_CURSOR_FIRST, CTX_INTERACTIVE_EDITOR_INNER_CURSOR_LAST, CTX_INTERACTIVE_EDITOR_EMPTY, CTX_INTERACTIVE_EDITOR_OUTER_CURSOR_POSITION, CTX_INTERACTIVE_EDITOR_VISIBLE, MENU_INTERACTIVE_EDITOR_WIDGET, CTX_INTERACTIVE_EDITOR_LAST_EDIT_TYPE, MENU_INTERACTIVE_EDITOR_WIDGET_UNDO, MENU_INTERACTIVE_EDITOR_WIDGET_STATUS, CTX_INTERACTIVE_EDITOR_LAST_FEEDBACK, CTX_INTERACTIVE_EDITOR_INLNE_DIFF, CTX_INTERACTIVE_EDITOR_EDIT_MODE, EditMode, CTX_INTERACTIVE_EDITOR_LAST_RESPONSE_TYPE, MENU_INTERACTIVE_EDITOR_WIDGET_MARKDOWN_MESSAGE, CTX_INTERACTIVE_EDITOR_MESSAGE_CROP_STATE, CTX_INTERACTIVE_EDITOR_DOCUMENT_CHANGED } from 'vs/workbench/contrib/interactiveEditor/common/interactiveEditor';
+import { CTX_INTERACTIVE_EDITOR_FOCUSED, CTX_INTERACTIVE_EDITOR_HAS_ACTIVE_REQUEST, CTX_INTERACTIVE_EDITOR_HAS_PROVIDER, CTX_INTERACTIVE_EDITOR_INNER_CURSOR_FIRST, CTX_INTERACTIVE_EDITOR_INNER_CURSOR_LAST, CTX_INTERACTIVE_EDITOR_EMPTY, CTX_INTERACTIVE_EDITOR_OUTER_CURSOR_POSITION, CTX_INTERACTIVE_EDITOR_VISIBLE, MENU_INTERACTIVE_EDITOR_WIDGET, MENU_INTERACTIVE_EDITOR_WIDGET_DISCARD, MENU_INTERACTIVE_EDITOR_WIDGET_STATUS, CTX_INTERACTIVE_EDITOR_LAST_FEEDBACK, CTX_INTERACTIVE_EDITOR_INLNE_DIFF, CTX_INTERACTIVE_EDITOR_EDIT_MODE, EditMode, CTX_INTERACTIVE_EDITOR_LAST_RESPONSE_TYPE, MENU_INTERACTIVE_EDITOR_WIDGET_MARKDOWN_MESSAGE, CTX_INTERACTIVE_EDITOR_MESSAGE_CROP_STATE, CTX_INTERACTIVE_EDITOR_DOCUMENT_CHANGED, CTX_INTERACTIVE_EDITOR_DID_EDIT } from 'vs/workbench/contrib/interactiveEditor/common/interactiveEditor';
 import { localize } from 'vs/nls';
 import { IAction2Options } from 'vs/platform/actions/common/actions';
 import { IClipboardService } from 'vs/platform/clipboard/common/clipboardService';
@@ -20,7 +20,6 @@ import { KeybindingWeight } from 'vs/platform/keybinding/common/keybindingsRegis
 import { IQuickInputService, IQuickPickItem } from 'vs/platform/quickinput/common/quickInput';
 import { IEditorService, SIDE_GROUP } from 'vs/workbench/services/editor/common/editorService';
 import { IUntitledTextResourceEditorInput } from 'vs/workbench/common/editor';
-import { ILogService } from 'vs/platform/log/common/log';
 import { ICodeEditorService } from 'vs/editor/browser/services/codeEditorService';
 import { Range } from 'vs/editor/common/core/range';
 import { fromNow } from 'vs/base/common/date';
@@ -251,86 +250,79 @@ export class NextFromHistory extends AbstractInteractiveEditorAction {
 	}
 }
 
-
-export class UndoToClipboard extends AbstractInteractiveEditorAction {
+export class DicardAction extends AbstractInteractiveEditorAction {
 
 	constructor() {
 		super({
-			id: 'interactiveEditor.undoToClipboard',
-			title: localize('undo.clipboard', 'Undo to Clipboard'),
-			precondition: ContextKeyExpr.and(CTX_INTERACTIVE_EDITOR_VISIBLE, CTX_INTERACTIVE_EDITOR_LAST_EDIT_TYPE.isEqualTo('simple')),
-			keybinding: {
-				weight: KeybindingWeight.EditorContrib + 10,
-				primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KeyZ,
-				mac: { primary: KeyMod.CtrlCmd | KeyMod.Alt | KeyCode.KeyZ },
-			},
+			id: 'interactiveEditor.discard',
+			title: localize('discard', 'Discard'),
+			icon: Codicon.discard,
+			precondition: CTX_INTERACTIVE_EDITOR_VISIBLE,
+			// keybinding: {
+			// 	weight: KeybindingWeight.EditorContrib - 1,
+			// 	primary: KeyCode.Escape
+			// },
 			menu: {
-				when: CTX_INTERACTIVE_EDITOR_LAST_EDIT_TYPE.isEqualTo('simple'),
-				id: MENU_INTERACTIVE_EDITOR_WIDGET_UNDO,
-				group: '1_undo',
+				id: MENU_INTERACTIVE_EDITOR_WIDGET_DISCARD,
+				order: 0
+			}
+		});
+	}
+
+	async runInteractiveEditorCommand(_accessor: ServicesAccessor, ctrl: InteractiveEditorController, _editor: ICodeEditor, ..._args: any[]): Promise<void> {
+		await ctrl.cancelSession();
+	}
+}
+
+export class DiscardToClipboardAction extends AbstractInteractiveEditorAction {
+
+	constructor() {
+		super({
+			id: 'interactiveEditor.discardToClipboard',
+			title: localize('undo.clipboard', 'Discard to Clipboard'),
+			precondition: ContextKeyExpr.and(CTX_INTERACTIVE_EDITOR_VISIBLE, CTX_INTERACTIVE_EDITOR_DID_EDIT),
+			// keybinding: {
+			// 	weight: KeybindingWeight.EditorContrib + 10,
+			// 	primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KeyZ,
+			// 	mac: { primary: KeyMod.CtrlCmd | KeyMod.Alt | KeyCode.KeyZ },
+			// },
+			menu: {
+				id: MENU_INTERACTIVE_EDITOR_WIDGET_DISCARD,
 				order: 1
 			}
 		});
 	}
 
-	override runInteractiveEditorCommand(accessor: ServicesAccessor, ctrl: InteractiveEditorController): void {
+	override async runInteractiveEditorCommand(accessor: ServicesAccessor, ctrl: InteractiveEditorController): Promise<void> {
 		const clipboardService = accessor.get(IClipboardService);
-		const lastText = ctrl.undoLast();
-		if (lastText !== undefined) {
-			clipboardService.writeText(lastText);
+		const changedText = await ctrl.cancelSession();
+		if (changedText !== undefined) {
+			clipboardService.writeText(changedText);
 		}
 	}
 }
 
-export class UndoToNewFile extends AbstractInteractiveEditorAction {
+export class DiscardUndoToNewFileAction extends AbstractInteractiveEditorAction {
 
 	constructor() {
 		super({
-			id: 'interactiveEditor.undoToFile',
-			title: localize('undo.newfile', 'Undo to New File'),
-			precondition: ContextKeyExpr.and(CTX_INTERACTIVE_EDITOR_VISIBLE, CTX_INTERACTIVE_EDITOR_LAST_EDIT_TYPE.isEqualTo('simple')),
+			id: 'interactiveEditor.discardToFile',
+			title: localize('undo.newfile', 'Discard to New File'),
+			precondition: ContextKeyExpr.and(CTX_INTERACTIVE_EDITOR_VISIBLE, CTX_INTERACTIVE_EDITOR_DID_EDIT),
 			menu: {
-				when: CTX_INTERACTIVE_EDITOR_LAST_EDIT_TYPE.isEqualTo('simple'),
-				id: MENU_INTERACTIVE_EDITOR_WIDGET_UNDO,
-				group: '1_undo',
+				id: MENU_INTERACTIVE_EDITOR_WIDGET_DISCARD,
 				order: 2
 			}
 		});
 	}
 
-	override runInteractiveEditorCommand(accessor: ServicesAccessor, ctrl: InteractiveEditorController, editor: ICodeEditor, ..._args: any[]): void {
+	override async runInteractiveEditorCommand(accessor: ServicesAccessor, ctrl: InteractiveEditorController, editor: ICodeEditor, ..._args: any[]): Promise<void> {
 		const editorService = accessor.get(IEditorService);
-		const lastText = ctrl.undoLast();
-		if (lastText !== undefined) {
-			const input: IUntitledTextResourceEditorInput = { forceUntitled: true, resource: undefined, contents: lastText, languageId: editor.getModel()?.getLanguageId() };
+		const changedText = await ctrl.cancelSession();
+		if (changedText !== undefined) {
+			const input: IUntitledTextResourceEditorInput = { forceUntitled: true, resource: undefined, contents: changedText, languageId: editor.getModel()?.getLanguageId() };
 			editorService.openEditor(input, SIDE_GROUP);
 		}
-	}
-}
-
-export class UndoCommand extends AbstractInteractiveEditorAction {
-
-	constructor() {
-		super({
-			id: 'interactiveEditor.undo',
-			title: localize('undo', 'Undo'),
-			icon: Codicon.commentDiscussion,
-			precondition: ContextKeyExpr.and(CTX_INTERACTIVE_EDITOR_VISIBLE, CTX_INTERACTIVE_EDITOR_LAST_EDIT_TYPE.isEqualTo('simple')),
-			// keybinding: {
-			// 	weight: KeybindingWeight.EditorContrib + 10,
-			// 	primary: KeyMod.CtrlCmd | KeyCode.KeyZ,
-			// },
-			menu: {
-				when: CTX_INTERACTIVE_EDITOR_LAST_EDIT_TYPE.isEqualTo('simple'),
-				id: MENU_INTERACTIVE_EDITOR_WIDGET_UNDO,
-				group: '1_undo',
-				order: 3
-			}
-		});
-	}
-
-	override runInteractiveEditorCommand(_accessor: ServicesAccessor, ctrl: InteractiveEditorController): void {
-		ctrl.undoLast();
 	}
 }
 
@@ -409,10 +401,15 @@ export class ApplyPreviewEdits extends AbstractInteractiveEditorAction {
 			title: localize('applyEdits', 'Apply Changes'),
 			icon: Codicon.check,
 			precondition: ContextKeyExpr.and(CTX_INTERACTIVE_EDITOR_VISIBLE, ContextKeyExpr.or(CTX_INTERACTIVE_EDITOR_DOCUMENT_CHANGED.toNegated(), CTX_INTERACTIVE_EDITOR_EDIT_MODE.notEqualsTo(EditMode.Preview))),
-			keybinding: {
+			keybinding: [{
 				weight: KeybindingWeight.EditorContrib + 10,
-				primary: KeyMod.CtrlCmd | KeyCode.Enter
-			},
+				primary: KeyMod.CtrlCmd | KeyCode.Enter,
+				when: CTX_INTERACTIVE_EDITOR_EDIT_MODE.isEqualTo(EditMode.Preview)
+			}, {
+				weight: KeybindingWeight.EditorContrib + 10,
+				primary: KeyCode.Escape,
+				when: CTX_INTERACTIVE_EDITOR_EDIT_MODE.notEqualsTo(EditMode.Preview)
+			}],
 			menu: {
 				id: MENU_INTERACTIVE_EDITOR_WIDGET_STATUS,
 				group: '0_main',
@@ -421,18 +418,8 @@ export class ApplyPreviewEdits extends AbstractInteractiveEditorAction {
 		});
 	}
 
-	override async runInteractiveEditorCommand(accessor: ServicesAccessor, ctrl: InteractiveEditorController): Promise<void> {
-		const logService = accessor.get(ILogService);
-		const editorService = accessor.get(IEditorService);
-		const edit = await ctrl.applyChanges();
-		if (!edit) {
-			logService.warn('FAILED to apply changes, no edit response');
-			return;
-		}
-		if (edit.singleCreateFileEdit) {
-			editorService.openEditor({ resource: edit.singleCreateFileEdit.uri }, SIDE_GROUP);
-		}
-
+	override async runInteractiveEditorCommand(_accessor: ServicesAccessor, ctrl: InteractiveEditorController): Promise<void> {
+		await ctrl.applyChanges();
 	}
 }
 
@@ -441,15 +428,16 @@ export class CancelSessionAction extends AbstractInteractiveEditorAction {
 	constructor() {
 		super({
 			id: 'interactiveEditor.cancel',
-			title: localize('discard', 'Discard Changes'),
+			title: localize('cancel', 'Cancel'),
 			icon: Codicon.clearAll,
-			precondition: CTX_INTERACTIVE_EDITOR_VISIBLE,
+			precondition: ContextKeyExpr.and(CTX_INTERACTIVE_EDITOR_VISIBLE, CTX_INTERACTIVE_EDITOR_EDIT_MODE.isEqualTo(EditMode.Preview)),
 			keybinding: {
 				weight: KeybindingWeight.EditorContrib - 1,
 				primary: KeyCode.Escape
 			},
 			menu: {
 				id: MENU_INTERACTIVE_EDITOR_WIDGET_STATUS,
+				when: CTX_INTERACTIVE_EDITOR_EDIT_MODE.isEqualTo(EditMode.Preview),
 				group: '0_main',
 				order: 1
 			}
@@ -468,7 +456,8 @@ export class CopyRecordings extends AbstractInteractiveEditorAction {
 			id: 'interactiveEditor.copyRecordings',
 			f1: true,
 			title: {
-				value: localize('copyRecordings', '(Developer) Write Exchange to Clipboard'), original: '(Developer) Write Exchange to Clipboard'
+				value: localize('copyRecordings', '(Developer) Write Exchange to Clipboard'),
+				original: '(Developer) Write Exchange to Clipboard'
 			}
 		});
 	}

--- a/src/vs/workbench/contrib/interactiveEditor/browser/interactiveEditorSession.ts
+++ b/src/vs/workbench/contrib/interactiveEditor/browser/interactiveEditorSession.ts
@@ -120,6 +120,25 @@ export class Session {
 		this._lastTextModelChanges = changes;
 	}
 
+	get hasChangedText(): boolean {
+		return !this.textModel0.equalsTextBuffer(this.textModelN.getTextBuffer());
+	}
+
+	asChangedText(): string | undefined {
+		if (!this._lastTextModelChanges || this._lastTextModelChanges.length === 0) {
+			return undefined;
+		}
+
+		let startLine = Number.MAX_VALUE;
+		let endLine = Number.MIN_VALUE;
+		for (const change of this._lastTextModelChanges) {
+			startLine = Math.min(startLine, change.modifiedRange.startLineNumber);
+			endLine = Math.max(endLine, change.modifiedRange.endLineNumberExclusive);
+		}
+
+		return this.textModelN.getValueInRange(new Range(startLine, 1, endLine, Number.MAX_VALUE));
+	}
+
 	recordExternalEditOccurred() {
 		this._teldata.edits = true;
 	}

--- a/src/vs/workbench/contrib/interactiveEditor/browser/interactiveEditorWidget.ts
+++ b/src/vs/workbench/contrib/interactiveEditor/browser/interactiveEditorWidget.ts
@@ -28,7 +28,7 @@ import { ProgressBar } from 'vs/base/browser/ui/progressbar/progressbar';
 import { SuggestController } from 'vs/editor/contrib/suggest/browser/suggestController';
 import { IPosition, Position } from 'vs/editor/common/core/position';
 import { DEFAULT_FONT_FAMILY } from 'vs/workbench/browser/style';
-import { createActionViewItem } from 'vs/platform/actions/browser/menuEntryActionViewItem';
+import { DropdownWithDefaultActionViewItem, createActionViewItem } from 'vs/platform/actions/browser/menuEntryActionViewItem';
 import { CompletionItem, CompletionItemInsertTextRule, CompletionItemKind, CompletionItemProvider, CompletionList, ProviderResult, TextEdit } from 'vs/editor/common/languages';
 import { EditOperation, ISingleEditOperation } from 'vs/editor/common/core/editOperation';
 import { ILanguageSelection, ILanguageService } from 'vs/editor/common/languages/language';
@@ -43,6 +43,7 @@ import { LineRangeMapping } from 'vs/editor/common/diff/linesDiffComputer';
 import { invertLineRange, lineRangeAsRange } from 'vs/workbench/contrib/interactiveEditor/browser/utils';
 import { ICodeEditorViewState, ScrollType } from 'vs/editor/common/editorCommon';
 import { LineRange } from 'vs/editor/common/core/lineRange';
+import { SubmenuItemAction } from 'vs/platform/actions/common/actions';
 
 const _inputEditorOptions: IEditorConstructionOptions = {
 	padding: { top: 3, bottom: 2 },
@@ -264,7 +265,14 @@ export class InteractiveEditorWidget {
 				primaryGroup: () => true,
 				useSeparatorsInPrimaryActions: true
 			},
-			actionViewItemProvider: (action: IAction, options: IActionViewItemOptions) => createActionViewItem(this._instantiationService, action, options)
+			actionViewItemProvider: (action: IAction, options: IActionViewItemOptions) => {
+
+				if (action instanceof SubmenuItemAction) {
+					return this._instantiationService.createInstance(DropdownWithDefaultActionViewItem, action, { ...options, renderKeybindingWithDefaultActionLabel: true, persistLastActionId: false });
+				}
+
+				return createActionViewItem(this._instantiationService, action, options);
+			}
 		};
 		const statusToolbar = this._instantiationService.createInstance(MenuWorkbenchToolBar, this._elements.statusToolbar, MENU_INTERACTIVE_EDITOR_WIDGET_STATUS, workbenchToolbarOptions);
 		this._store.add(statusToolbar);

--- a/src/vs/workbench/contrib/interactiveEditor/common/interactiveEditor.ts
+++ b/src/vs/workbench/contrib/interactiveEditor/common/interactiveEditor.ts
@@ -112,7 +112,7 @@ export const CTX_INTERACTIVE_EDITOR_OUTER_CURSOR_POSITION = new RawContextKey<'a
 export const CTX_INTERACTIVE_EDITOR_HAS_ACTIVE_REQUEST = new RawContextKey<boolean>('interactiveEditorHasActiveRequest', false, localize('interactiveEditorHasActiveRequest', "Whether interactive editor has an active request"));
 export const CTX_INTERACTIVE_EDITOR_INLNE_DIFF = new RawContextKey<boolean>('interactiveEditorInlineDiff', false, localize('interactiveEditorInlineDiff', "Whether interactive editor show inline diffs for changes"));
 export const CTX_INTERACTIVE_EDITOR_LAST_RESPONSE_TYPE = new RawContextKey<InteractiveEditorResponseType | undefined>('interactiveEditorLastResponseType', undefined, localize('interactiveEditorResponseType', "What type was the last response of the current interactive editor session"));
-export const CTX_INTERACTIVE_EDITOR_LAST_EDIT_TYPE = new RawContextKey<'simple' | ''>('interactiveEditorLastEditKind', '', localize('interactiveEditorLastEditKind', "The last kind of edit that was performed"));
+export const CTX_INTERACTIVE_EDITOR_DID_EDIT = new RawContextKey<boolean>('interactiveEditorDidEdit', false, localize('interactiveEditorDidEdit', "Whether interactive editor did change any code"));
 export const CTX_INTERACTIVE_EDITOR_LAST_FEEDBACK = new RawContextKey<'unhelpful' | 'helpful' | ''>('interactiveEditorLastFeedbackKind', '', localize('interactiveEditorLastFeedbackKind', "The last kind of feedback that was provided"));
 export const CTX_INTERACTIVE_EDITOR_DOCUMENT_CHANGED = new RawContextKey<boolean>('interactiveEditorDocumentChanged', false, localize('interactiveEditorDocumentChanged', "Whether the document has changed concurrently"));
 export const CTX_INTERACTIVE_EDITOR_EDIT_MODE = new RawContextKey<EditMode>('config.interactiveEditor.editMode', EditMode.Live);
@@ -122,14 +122,15 @@ export const CTX_INTERACTIVE_EDITOR_EDIT_MODE = new RawContextKey<EditMode>('con
 export const MENU_INTERACTIVE_EDITOR_WIDGET = MenuId.for('interactiveEditorWidget');
 export const MENU_INTERACTIVE_EDITOR_WIDGET_MARKDOWN_MESSAGE = MenuId.for('interactiveEditorWidget.markdownMessage');
 export const MENU_INTERACTIVE_EDITOR_WIDGET_STATUS = MenuId.for('interactiveEditorWidget.status');
-export const MENU_INTERACTIVE_EDITOR_WIDGET_UNDO = MenuId.for('interactiveEditorWidget.undo');
+export const MENU_INTERACTIVE_EDITOR_WIDGET_DISCARD = MenuId.for('interactiveEditorWidget.undo');
 MenuRegistry.appendMenuItem(MENU_INTERACTIVE_EDITOR_WIDGET_STATUS, {
-	submenu: MENU_INTERACTIVE_EDITOR_WIDGET_UNDO,
-	title: localize('undo', "Undo..."),
+	submenu: MENU_INTERACTIVE_EDITOR_WIDGET_DISCARD,
+	title: localize('discard', "Discard..."),
 	icon: Codicon.discard,
 	group: '0_main',
 	order: 2,
-	when: CTX_INTERACTIVE_EDITOR_EDIT_MODE.isEqualTo('direct')
+	when: CTX_INTERACTIVE_EDITOR_EDIT_MODE.notEqualsTo(EditMode.Preview),
+	rememberDefaultAction: true
 });
 
 // --- colors


### PR DESCRIPTION
- For preview modes bring back actions to discard but keep changes in clipboard or new file, in live modes ESC accepts, in preview is cancels, DropDownWithDefault tweaks so that the first option can always be the default
- handle reentrant editor chat with cancel or accept (depending on mode)
