### PR TITLE
Initial draft of the workbench state logger

### DIFF
--- a/build/lib/i18n.resources.json
+++ b/build/lib/i18n.resources.json
@@ -203,6 +203,10 @@
 			"project": "vscode-workbench"
 		},
 		{
+			"name": "vs/workbench/contrib/stateLogger",
+			"project": "vscode-workbench"
+		},
+		{
 			"name": "vs/workbench/contrib/format",
 			"project": "vscode-workbench"
 		},

--- a/src/vs/workbench/browser/actions/developerActions.ts
+++ b/src/vs/workbench/browser/actions/developerActions.ts
@@ -5,31 +5,31 @@
 
 import 'vs/css!./media/actions';
 
-import { localize } from 'vs/nls';
-import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
+import { $, append, createCSSRule, createStyleSheet, getDomNodePagePosition } from 'vs/base/browser/dom';
 import { DomEmitter } from 'vs/base/browser/event';
-import { Color } from 'vs/base/common/color';
-import { Event } from 'vs/base/common/event';
-import { IDisposable, toDisposable, dispose, DisposableStore } from 'vs/base/common/lifecycle';
-import { getDomNodePagePosition, createStyleSheet, createCSSRule, append, $ } from 'vs/base/browser/dom';
-import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
-import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
-import { Context } from 'vs/platform/contextkey/browser/contextKeyService';
 import { StandardKeyboardEvent } from 'vs/base/browser/keyboardEvent';
 import { RunOnceScheduler } from 'vs/base/common/async';
-import { ILayoutService } from 'vs/platform/layout/browser/layoutService';
-import { Registry } from 'vs/platform/registry/common/platform';
-import { registerAction2, Action2, MenuRegistry } from 'vs/platform/actions/common/actions';
-import { IStorageService } from 'vs/platform/storage/common/storage';
-import { clamp } from 'vs/base/common/numbers';
+import { Color } from 'vs/base/common/color';
+import { Event } from 'vs/base/common/event';
 import { KeyCode } from 'vs/base/common/keyCodes';
-import { IConfigurationRegistry, Extensions as ConfigurationExtensions } from 'vs/platform/configuration/common/configurationRegistry';
-import { ILogService } from 'vs/platform/log/common/log';
-import { IWorkingCopyService } from 'vs/workbench/services/workingCopy/common/workingCopyService';
-import { ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
+import { DisposableStore, IDisposable, dispose, toDisposable } from 'vs/base/common/lifecycle';
+import { clamp } from 'vs/base/common/numbers';
+import { localize } from 'vs/nls';
 import { Categories } from 'vs/platform/action/common/actionCommonCategories';
-import { IWorkingCopyBackupService } from 'vs/workbench/services/workingCopy/common/workingCopyBackup';
+import { Action2, MenuRegistry, registerAction2 } from 'vs/platform/actions/common/actions';
+import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
+import { Extensions as ConfigurationExtensions, IConfigurationRegistry } from 'vs/platform/configuration/common/configurationRegistry';
+import { Context } from 'vs/platform/contextkey/browser/contextKeyService';
+import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
+import { ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
+import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 import { ResolutionResult, ResultKind } from 'vs/platform/keybinding/common/keybindingResolver';
+import { ILayoutService } from 'vs/platform/layout/browser/layoutService';
+import { ILogService } from 'vs/platform/log/common/log';
+import { Registry } from 'vs/platform/registry/common/platform';
+import { IStorageService } from 'vs/platform/storage/common/storage';
+import { IWorkingCopyBackupService } from 'vs/workbench/services/workingCopy/common/workingCopyBackup';
+import { IWorkingCopyService } from 'vs/workbench/services/workingCopy/common/workingCopyService';
 
 class InspectContextKeysAction extends Action2 {
 

--- a/src/vs/workbench/contrib/stateLogger/browser/stateLoggerAction.ts
+++ b/src/vs/workbench/contrib/stateLogger/browser/stateLoggerAction.ts
@@ -1,0 +1,85 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { VSBuffer } from 'vs/base/common/buffer';
+import { URI } from 'vs/base/common/uri';
+import { ICodeEditorService } from 'vs/editor/browser/services/codeEditorService';
+import { Selection } from 'vs/editor/common/core/selection';
+import { localize } from 'vs/nls';
+import { Categories } from 'vs/platform/action/common/actionCommonCategories';
+import { Action2, registerAction2 } from 'vs/platform/actions/common/actions';
+import { IFileService } from 'vs/platform/files/common/files';
+import { ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
+import { IMarker, IMarkerService } from 'vs/platform/markers/common/markers';
+import { ITerminalService } from 'vs/workbench/contrib/terminal/browser/terminal';
+import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
+import { IHistoryService } from 'vs/workbench/services/history/common/history';
+
+
+
+interface ISavedWorkbenchState {
+	activeFile: string | undefined;
+	visibleEditors: string[];
+	activeEditorDiagnostics: IMarker[];
+	allDiagnostics: IMarker[];
+	currentSelections: Selection[];
+	terminalData: string[];
+}
+class LogWorkbenchStateAction extends Action2 {
+	constructor() {
+		super({
+			id: 'workbench.action.logWorkbenchStateAction',
+			title: { value: localize({ key: 'logWorkbenchState', comment: ['A developer only action to log the current state of the workbench.'] }, "Log Workbench State"), original: 'Log Workbench State' },
+			category: Categories.Developer,
+			f1: true
+		});
+	}
+
+	async run(accessor: ServicesAccessor): Promise<void> {
+		const editorService = accessor.get(IEditorService);
+		const markerService = accessor.get(IMarkerService);
+		const codeEditorService = accessor.get(ICodeEditorService);
+		const terminalService = accessor.get(ITerminalService);
+		const fileService = accessor.get(IFileService);
+		const historyService = accessor.get(IHistoryService);
+
+		const workspaceRoot = historyService.getLastActiveWorkspaceRoot();
+		if (!workspaceRoot) {
+			return;
+		}
+		const activeEditor = editorService.activeEditor;
+		const activeEditorDiagnostics = activeEditor ? markerService.read({ resource: activeEditor.resource }) : undefined;
+		const allDiagnostics = markerService.read();
+		const allEditors = editorService.editors;
+		const activeCodeEditor = codeEditorService.getActiveCodeEditor();
+		const selections = activeCodeEditor?.getSelections() ?? [];
+		const terminalContents = terminalService.activeInstance?.xterm?.getBufferReverseIterator();
+		// Collect the last 10 lines of the terminal
+		const terminalLines: string[] = [];
+		if (terminalContents) {
+			for (const line of terminalContents) {
+				terminalLines.push(line);
+				if (terminalLines.length === 10) {
+					break;
+				}
+			}
+			terminalLines.reverse();
+		}
+		const workbenchState: ISavedWorkbenchState = {
+			activeFile: activeEditor?.resource?.fsPath.replace(workspaceRoot.fsPath, '.'),
+			visibleEditors: allEditors.map(e => e.resource?.fsPath.replace(workspaceRoot.fsPath, '.') ?? e.getTitle()),
+			activeEditorDiagnostics: activeEditorDiagnostics ?? [],
+			allDiagnostics,
+			currentSelections: selections,
+			terminalData: terminalLines
+		};
+
+		const workbenchStateString = JSON.stringify(workbenchState, undefined, '\t');
+		const stateFileURI = URI.joinPath(workspaceRoot, 'workbenchState.json');
+		await fileService.createFile(stateFileURI, VSBuffer.fromString(workbenchStateString), { overwrite: true });
+	}
+}
+
+registerAction2(LogWorkbenchStateAction);

--- a/src/vs/workbench/workbench.common.main.ts
+++ b/src/vs/workbench/workbench.common.main.ts
@@ -365,4 +365,7 @@ import 'vs/workbench/contrib/bracketPairColorizer2Telemetry/browser/bracketPairC
 // Accessibility
 import 'vs/workbench/contrib/accessibility/browser/accessibility.contribution';
 
+// Workbench State Logger
+import 'vs/workbench/contrib/stateLogger/browser/stateLoggerAction';
+
 //#endregion


### PR DESCRIPTION
Initial draft of the workbench state logger which allows for logging specific information about the current state of the workbench. This is useful for setting up an environment, exporting the JSON, and then using that JSON for testing.