### PR TITLE
resolvers: add appQuality and appCommit

### DIFF
--- a/src/vs/workbench/api/common/extHost.api.impl.ts
+++ b/src/vs/workbench/api/common/extHost.api.impl.ts
@@ -397,7 +397,15 @@ export function createApiFactoryAndRegisterActors(accessor: ServicesAccessor): I
 			registerIssueUriRequestHandler(handler: vscode.IssueUriRequestHandler) {
 				checkProposedApiEnabled(extension, 'handleIssueUri');
 				return extHostIssueReporter.registerIssueUriRequestHandler(extension, handler);
-			}
+			},
+			get appQuality(): string | undefined {
+				checkProposedApiEnabled(extension, 'resolvers');
+				return initData.quality;
+			},
+			get appCommit(): string | undefined {
+				checkProposedApiEnabled(extension, 'resolvers');
+				return initData.commit;
+			},
 		};
 		if (!initData.environment.extensionTestsLocationURI) {
 			// allow to patch env-function when running tests

--- a/src/vs/workbench/services/extensions/browser/webWorkerExtensionHost.ts
+++ b/src/vs/workbench/services/extensions/browser/webWorkerExtensionHost.ts
@@ -278,6 +278,7 @@ export class WebWorkerExtensionHost extends Disposable implements IExtensionHost
 		return {
 			commit: this._productService.commit,
 			version: this._productService.version,
+			quality: this._productService.quality,
 			parentPid: 0,
 			environment: {
 				isExtensionDevelopmentDebug: this._environmentService.debugRenderer,

--- a/src/vs/workbench/services/extensions/common/extensionHostProtocol.ts
+++ b/src/vs/workbench/services/extensions/common/extensionHostProtocol.ts
@@ -19,6 +19,7 @@ export interface IExtensionDescriptionDelta {
 
 export interface IExtensionHostInitData {
 	version: string;
+	quality: string | undefined;
 	commit?: string;
 	/**
 	 * When set to `0`, no polling for the parent process still running will happen.

--- a/src/vs/workbench/services/extensions/common/remoteExtensionHost.ts
+++ b/src/vs/workbench/services/extensions/common/remoteExtensionHost.ts
@@ -208,6 +208,7 @@ export class RemoteExtensionHost extends Disposable implements IExtensionHost {
 		return {
 			commit: this._productService.commit,
 			version: this._productService.version,
+			quality: this._productService.quality,
 			parentPid: remoteInitData.pid,
 			environment: {
 				isExtensionDevelopmentDebug,

--- a/src/vs/workbench/services/extensions/electron-sandbox/localProcessExtensionHost.ts
+++ b/src/vs/workbench/services/extensions/electron-sandbox/localProcessExtensionHost.ts
@@ -419,6 +419,7 @@ export class NativeLocalProcessExtensionHost implements IExtensionHost {
 		return {
 			commit: this._productService.commit,
 			version: this._productService.version,
+			quality: this._productService.quality,
 			parentPid: 0,
 			environment: {
 				isExtensionDevelopmentDebug: this._isExtensionDevDebug,

--- a/src/vscode-dts/vscode.proposed.resolvers.d.ts
+++ b/src/vscode-dts/vscode.proposed.resolvers.d.ts
@@ -60,6 +60,13 @@ declare module 'vscode' {
 		label: string;
 	}
 
+	export namespace env {
+		/** Quality of the application. May be undefined if running from sources. */
+		export const appQuality: string | undefined;
+		/** Commit of the application. May be undefined if running from sources. */
+		export const appCommit: string | undefined;
+	}
+
 	interface TunnelOptions {
 		remoteAddress: { port: number; host: string };
 		// The desired local port. If this port can't be used, then another will be chosen.


### PR DESCRIPTION
Currently remote extensions use a hack to read the product.json, but
this can't be done on web. Instead expose proper API to get the
appQuality and appCommit.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
