### PR TITLE
Add missing border radius to suggest widget

### DIFF
--- a/src/vs/editor/contrib/suggest/browser/media/suggest.css
+++ b/src/vs/editor/contrib/suggest/browser/media/suggest.css
@@ -10,6 +10,7 @@
 	z-index: 40;
 	display: flex;
 	flex-direction: column;
+	border-radius: 3px;
 }
 
 .monaco-editor .suggest-widget.message {


### PR DESCRIPTION
Adds subtle border radius to suggest widget to match other editor widgets

## Before

<img width="558" alt="CleanShot 2023-05-15 at 13 20 08@2x" src="https://github.com/microsoft/vscode/assets/25163139/13e294cd-96c9-438c-8fc8-67a501f3d1be">

## After

<img width="503" alt="CleanShot 2023-05-15 at 13 19 53@2x" src="https://github.com/microsoft/vscode/assets/25163139/6e0e978d-7c15-412a-9ac4-fb91a9c32acf">


