### PR TITLE
fix notebook search focus shifting and fix bad column number

### DIFF
--- a/src/vs/workbench/contrib/search/browser/searchResultsView.ts
+++ b/src/vs/workbench/contrib/search/browser/searchResultsView.ts
@@ -431,10 +431,10 @@ export class SearchAccessibilityProvider implements IListAccessibilityProvider<R
 			const range = match.range();
 			const matchText = match.text().substr(0, range.endColumn + 150);
 			if (replace) {
-				return nls.localize('replacePreviewResultAria', "'{0}' at column {1} replace {2} with {3}", matchText, range.startColumn + 1, matchString, match.replaceString);
+				return nls.localize('replacePreviewResultAria', "'{0}' at column {1} replace {2} with {3}", matchText, range.startColumn, matchString, match.replaceString);
 			}
 
-			return nls.localize('searchResultAria', "'{0}' at column {1} found {2}", matchText, range.startColumn + 1, matchString);
+			return nls.localize('searchResultAria', "'{0}' at column {1} found {2}", matchText, range.startColumn, matchString);
 		}
 		return null;
 	}

--- a/src/vs/workbench/contrib/search/browser/searchView.ts
+++ b/src/vs/workbench/contrib/search/browser/searchView.ts
@@ -1874,7 +1874,7 @@ export class SearchView extends ViewPane {
 						if (editorWidget) {
 							// Ensure that the editor widget is binded. If if is, then this should return immediately.
 							// Otherwise, it will bind the widget.
-							await elemParent.bindNotebookEditorWidget(editorWidget);
+							elemParent.bindNotebookEditorWidget(editorWidget);
 							await elemParent.updateMatchesForEditorWidget();
 
 							const matchIndex = oldParentMatches.findIndex(e => e.id() === element.id());
@@ -1887,6 +1887,7 @@ export class SearchView extends ViewPane {
 
 							if (!this.tree.getFocus().includes(match) || !this.tree.getSelection().includes(match)) {
 								this.tree.setSelection([match], getSelectionKeyboardEvent());
+								this.tree.setFocus([match]);
 							}
 						}
 


### PR DESCRIPTION
Fixes #180982
Fixes #177512

For the search output moving, it seems to be less severe after the fix in https://github.com/microsoft/vscode/commit/9ff83d41a3268ec578c032ae54102285b447e947. This is because there are more consistent results from the notebook widget's find API.