### PR TITLE
Add option for smartSelect to ignore subwords

### DIFF
--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -4603,6 +4603,7 @@ class EditorSuggest extends BaseEditorOption<EditorOption.suggest, ISuggestOptio
 
 export interface ISmartSelectOptions {
 	selectLeadingAndTrailingWhitespace?: boolean;
+	selectSubwords?: boolean;
 }
 
 /**
@@ -4616,11 +4617,17 @@ class SmartSelect extends BaseEditorOption<EditorOption.smartSelect, ISmartSelec
 		super(
 			EditorOption.smartSelect, 'smartSelect',
 			{
-				selectLeadingAndTrailingWhitespace: true
+				selectLeadingAndTrailingWhitespace: true,
+				selectSubwords: true,
 			},
 			{
 				'editor.smartSelect.selectLeadingAndTrailingWhitespace': {
 					description: nls.localize('selectLeadingAndTrailingWhitespace', "Whether leading and trailing whitespace should always be selected."),
+					default: true,
+					type: 'boolean'
+				},
+				'editor.smartSelect.selectSubwords': {
+					description: nls.localize('selectSubwords', "Whether subwords (like 'foo' in 'fooBar' or 'foo_bar') should be selected."),
 					default: true,
 					type: 'boolean'
 				}
@@ -4633,7 +4640,8 @@ class SmartSelect extends BaseEditorOption<EditorOption.smartSelect, ISmartSelec
 			return this.defaultValue;
 		}
 		return {
-			selectLeadingAndTrailingWhitespace: boolean((input as ISmartSelectOptions).selectLeadingAndTrailingWhitespace, this.defaultValue.selectLeadingAndTrailingWhitespace)
+			selectLeadingAndTrailingWhitespace: boolean((input as ISmartSelectOptions).selectLeadingAndTrailingWhitespace, this.defaultValue.selectLeadingAndTrailingWhitespace),
+			selectSubwords: boolean((input as ISmartSelectOptions).selectSubwords, this.defaultValue.selectSubwords),
 		};
 	}
 }

--- a/src/vs/editor/contrib/smartSelect/browser/smartSelect.ts
+++ b/src/vs/editor/contrib/smartSelect/browser/smartSelect.ts
@@ -208,12 +208,13 @@ registerEditorAction(ShrinkSelectionAction);
 
 export interface SelectionRangesOptions {
 	selectLeadingAndTrailingWhitespace: boolean;
+	selectSubwords: boolean;
 }
 
 export async function provideSelectionRanges(registry: LanguageFeatureRegistry<languages.SelectionRangeProvider>, model: ITextModel, positions: Position[], options: SelectionRangesOptions, token: CancellationToken): Promise<Range[][]> {
 
 	const providers = registry.all(model)
-		.concat(new WordSelectionRangeProvider()); // ALWAYS have word based selection range
+		.concat(new WordSelectionRangeProvider(options.selectSubwords)); // ALWAYS have word based selection range
 
 	if (providers.length === 1) {
 		// add word selection and bracket selection when no provider exists
@@ -313,7 +314,7 @@ CommandsRegistry.registerCommand('_executeSelectionRangeProvider', async functio
 	const reference = await accessor.get(ITextModelService).createModelReference(resource);
 
 	try {
-		return provideSelectionRanges(registry, reference.object.textEditorModel, positions, { selectLeadingAndTrailingWhitespace: true }, CancellationToken.None);
+		return provideSelectionRanges(registry, reference.object.textEditorModel, positions, { selectLeadingAndTrailingWhitespace: true, selectSubwords: true }, CancellationToken.None);
 	} finally {
 		reference.dispose();
 	}

--- a/src/vs/editor/contrib/smartSelect/browser/wordSelections.ts
+++ b/src/vs/editor/contrib/smartSelect/browser/wordSelections.ts
@@ -12,12 +12,16 @@ import { SelectionRange, SelectionRangeProvider } from 'vs/editor/common/languag
 
 export class WordSelectionRangeProvider implements SelectionRangeProvider {
 
+	constructor(private readonly selectSubwords = true) { }
+
 	provideSelectionRanges(model: ITextModel, positions: Position[]): SelectionRange[][] {
 		const result: SelectionRange[][] = [];
 		for (const position of positions) {
 			const bucket: SelectionRange[] = [];
 			result.push(bucket);
-			this._addInWordRanges(bucket, model, position);
+			if (this.selectSubwords) {
+				this._addInWordRanges(bucket, model, position);
+			}
 			this._addWordRanges(bucket, model, position);
 			this._addWhitespaceLine(bucket, model, position);
 			bucket.push({ range: model.getFullModelRange() });

--- a/src/vs/editor/contrib/smartSelect/test/browser/smartSelect.test.ts
+++ b/src/vs/editor/contrib/smartSelect/test/browser/smartSelect.test.ts
@@ -67,7 +67,7 @@ suite('SmartSelect', () => {
 	async function assertGetRangesToPosition(text: string[], lineNumber: number, column: number, ranges: Range[], selectLeadingAndTrailingWhitespace = true): Promise<void> {
 		const uri = URI.file('test.js');
 		const model = modelService.createModel(text.join('\n'), new StaticLanguageSelector(languageId), uri);
-		const [actual] = await provideSelectionRanges(providers, model, [new Position(lineNumber, column)], { selectLeadingAndTrailingWhitespace }, CancellationToken.None);
+		const [actual] = await provideSelectionRanges(providers, model, [new Position(lineNumber, column)], { selectLeadingAndTrailingWhitespace, selectSubwords: true }, CancellationToken.None);
 		const actualStr = actual!.map(r => new Range(r.startLineNumber, r.startColumn, r.endLineNumber, r.endColumn).toString());
 		const desiredStr = ranges.reverse().map(r => String(r));
 
@@ -289,6 +289,24 @@ suite('SmartSelect', () => {
 
 		await assertRanges(new WordSelectionRangeProvider(), 'f|oo-Ba',
 			new Range(1, 1, 1, 4),
+			new Range(1, 1, 1, 7),
+			new Range(1, 1, 1, 7),
+		);
+	});
+
+	test('in-word ranges with selectSubwords=false', async () => {
+
+		await assertRanges(new WordSelectionRangeProvider(false), 'f|ooBar',
+			new Range(1, 1, 1, 7),
+			new Range(1, 1, 1, 7),
+		);
+
+		await assertRanges(new WordSelectionRangeProvider(false), 'f|oo_Ba',
+			new Range(1, 1, 1, 7),
+			new Range(1, 1, 1, 7),
+		);
+
+		await assertRanges(new WordSelectionRangeProvider(false), 'f|oo-Ba',
 			new Range(1, 1, 1, 7),
 			new Range(1, 1, 1, 7),
 		);

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -4682,6 +4682,7 @@ declare namespace monaco.editor {
 
 	export interface ISmartSelectOptions {
 		selectLeadingAndTrailingWhitespace?: boolean;
+		selectSubwords?: boolean;
 	}
 
 	/**

--- a/src/vs/workbench/api/test/browser/extHostLanguageFeatures.test.ts
+++ b/src/vs/workbench/api/test/browser/extHostLanguageFeatures.test.ts
@@ -1252,7 +1252,7 @@ suite('ExtHostLanguageFeatures', function () {
 
 		await rpcProtocol.sync();
 
-		provideSelectionRanges(languageFeaturesService.selectionRangeProvider, model, [new Position(1, 17)], { selectLeadingAndTrailingWhitespace: true }, CancellationToken.None).then(ranges => {
+		provideSelectionRanges(languageFeaturesService.selectionRangeProvider, model, [new Position(1, 17)], { selectLeadingAndTrailingWhitespace: true, selectSubwords: true }, CancellationToken.None).then(ranges => {
 			assert.strictEqual(ranges.length, 1);
 			assert.ok(ranges[0].length >= 2);
 		});


### PR DESCRIPTION
Fixes #97257

This brings VS Code to parity with other major editors/IDEs (e.g., JetBrains IDEs have the `Use "CamelHumps" words` option).
