### PR TITLE
Don't init chat editors to js

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatListRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatListRenderer.ts
@@ -643,8 +643,7 @@ class CodeBlockPart extends Disposable implements IInteractiveResultCodeBlockPar
 			WordHighlighterContribution.get(this.editor)?.restoreViewState(true);
 		}));
 
-		const vscodeLanguageId = this.languageService.getLanguageIdByLanguageName('javascript');
-		this.textModel = this._register(this.modelService.createModel('', this.languageService.createById(vscodeLanguageId), undefined));
+		this.textModel = this._register(this.modelService.createModel('', null, undefined));
 		this.editor.setModel(this.textModel);
 	}
 


### PR DESCRIPTION
Also for #182526

It seems like chat editors are initially set to be treated as JS. When the document language is then changed, we trigger: #182526

Instead I think we should not include a language initially

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
