### PR TITLE
outweigh normal editor accessibility help menu

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/chatAccessibilityHelp.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatAccessibilityHelp.ts
@@ -9,7 +9,6 @@ import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 
 export function getAccessibilityHelpText(keybindingService: IKeybindingService): string {
 	const content = [];
-	content.push(localize('chat.accessibilityHelp', "Chat Accessibility Help"));
 	content.push(localize('interactiveSession.helpMenuExit', "Exit this menu and return to the interactive editor input via the Escape key."));
 	content.push(descriptionForCommand('interactiveSession.action.focus', localize('interactiveSession.action.focus', 'The Focus Interactive Session ({0}) command focuses the chat request/response list, which can be navigated with UpArrow/DownArrow.',), localize('interactiveSession.action.focusNoKb', 'The Focus Interactive Session command focuses the chat request/response list, which can be navigated with UpArrow/DownArrow and is currently not triggerable by a keybinding.'), keybindingService));
 	content.push(descriptionForCommand('workbench.action.interactiveSession.focusInput', localize('workbench.action.interactiveSession.focusInput', 'The Focus Interactive Session Input ({0}) command focuses the input box for chat requests.'), localize('workbench.action.interactiveSession.focusInputNoKb', 'Focus Interactive Session Input command focuses the input box for chat requests and is currently not triggerable by a keybinding.'), keybindingService));

--- a/src/vs/workbench/contrib/chat/browser/actions/chatActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatActions.ts
@@ -137,7 +137,7 @@ export function registerChatActions() {
 				precondition: CONTEXT_IN_INTERACTIVE_INPUT,
 				kbOpts: {
 					primary: KeyMod.Alt | KeyCode.F1,
-					weight: KeybindingWeight.EditorContrib
+					weight: KeybindingWeight.EditorContrib + 10
 				}
 			});
 		}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

`Alt+f1` is also used in the editor to access the help menu, so need to have higher weight for the same action in the chat view

fyi @jooyoungseo this should be fixed in tomorrow's Insider's!