### PR TITLE
Bump TS versions

### DIFF
--- a/extensions/package.json
+++ b/extensions/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "description": "Dependencies shared by all extensions",
   "dependencies": {
-    "typescript": "^5.1.0-dev.20230509"
+    "typescript": "^5.1.0-dev.20230515"
   },
   "scripts": {
     "postinstall": "node ./postinstall.mjs"

--- a/extensions/yarn.lock
+++ b/extensions/yarn.lock
@@ -228,10 +228,10 @@ to-regex-range@^5.0.1:
   dependencies:
     is-number "^7.0.0"
 
-typescript@^5.1.0-dev.20230509:
-  version "5.1.0-dev.20230509"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.1.0-dev.20230509.tgz#20024bfeb6d0c7bfa4026d614d35fea53a40de94"
-  integrity sha512-ZOIqXGpzmqUPr0Mgi5dP1NMTH6AcbKqojL7ChJk1AyE3I0zfce04xH5vpjtNOl4UcGWyZoz1xI7HOvmJhy/yng==
+typescript@^5.1.0-dev.20230515:
+  version "5.1.0-dev.20230515"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.1.0-dev.20230515.tgz#cf1c5b9542d7bb6f5eeb7878f041705ee6f963be"
+  integrity sha512-yn0MGsy6U0QAVF+lXW6LPupQmuRsyA0xUJetqw2tDqa+49231BpkhTuY6oEwLsc98tiEzCfIw7hzbLsiwVGFaA==
 
 vscode-grammar-updater@^1.1.0:
   version "1.1.0"

--- a/package.json
+++ b/package.json
@@ -204,7 +204,7 @@
     "ts-loader": "^9.4.2",
     "ts-node": "^10.9.1",
     "tsec": "0.1.4",
-    "typescript": "^5.1.0-dev.20230509",
+    "typescript": "^5.2.0-dev.20230516",
     "typescript-formatter": "7.1.0",
     "underscore": "^1.12.1",
     "util": "^0.12.4",

--- a/src/vs/base/test/browser/ui/splitview/splitview.test.ts
+++ b/src/vs/base/test/browser/ui/splitview/splitview.test.ts
@@ -336,7 +336,7 @@ suite('Splitview', () => {
 		const viewContainers = container.querySelectorAll('.split-view-view');
 		assert.strictEqual(viewContainers.length, 2, 'there are two view containers');
 		assert.strictEqual((viewContainers.item(0) as HTMLElement).style.height, '66px', 'second view container is 66px');
-		assert.strictEqual((viewContainers.item(1) as HTMLElement).style.height, `${986 - 66}px`, 'first view container is 66px');
+		assert.strictEqual<string>((viewContainers.item(1) as HTMLElement).style.height, `${986 - 66}px`, 'first view container is 66px');
 
 		splitview.dispose();
 		view2.dispose();

--- a/yarn.lock
+++ b/yarn.lock
@@ -9782,10 +9782,10 @@ typescript@^4.7.4:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.4.tgz#c464abca159669597be5f96b8943500b238e60e6"
   integrity sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==
 
-typescript@^5.1.0-dev.20230509:
-  version "5.1.0-dev.20230509"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.1.0-dev.20230509.tgz#20024bfeb6d0c7bfa4026d614d35fea53a40de94"
-  integrity sha512-ZOIqXGpzmqUPr0Mgi5dP1NMTH6AcbKqojL7ChJk1AyE3I0zfce04xH5vpjtNOl4UcGWyZoz1xI7HOvmJhy/yng==
+typescript@^5.2.0-dev.20230516:
+  version "5.2.0-dev.20230516"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.2.0-dev.20230516.tgz#9dc4d02c031cdf311ddb6ee646be09d5f13de4c9"
+  integrity sha512-DGK8md4PQgA6QG9JnvC6LecNnBstc1h6zrg71isrlZTsRFVl3EsID6D2Exrh4ULbxynA61PE13M+uOmLFWOu4w==
 
 typical@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
Picks up new TS for building VS code: nightly, 5.2

Picks up new bundled TS version: last 5.1 release

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
