### PR TITLE
Try to position code action widget from markers view better

### DIFF
--- a/src/vs/editor/contrib/hover/browser/markerHoverParticipant.ts
+++ b/src/vs/editor/contrib/hover/browser/markerHoverParticipant.ts
@@ -228,8 +228,8 @@ export class MarkerHoverParticipant implements IEditorHoverParticipant<MarkerHov
 						// context menu as well when using keyboard navigation
 						context.hide();
 						controller?.showCodeActions(markerCodeActionTrigger, actions, {
-							x: elementPosition.left + 6,
-							y: elementPosition.top + elementPosition.height + 6,
+							x: elementPosition.left,
+							y: elementPosition.top,
 							width: elementPosition.width,
 							height: elementPosition.height
 						});


### PR DESCRIPTION
#141958 added a `height` parameter to the anchor. I believe this is causing the code action widget to be pushed too far down the screen since we were also manually adding the`height` to compute the `y` value

By removing this, the code action widget should show closer to the mouse position

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
