### PR TITLE
fix: make sure `user-data-dir` command line parameter is customizable

### DIFF
--- a/src/vs/server/node/server.main.ts
+++ b/src/vs/server/node/server.main.ts
@@ -37,14 +37,14 @@ const errorReporter: ErrorReporter = {
 const args = parseArgs(process.argv.slice(2), serverOptions, errorReporter);
 
 const REMOTE_DATA_FOLDER = args['server-data-dir'] || process.env['VSCODE_AGENT_FOLDER'] || join(os.homedir(), product.serverDataFolderName || '.vscode-remote');
-const USER_DATA_PATH = join(REMOTE_DATA_FOLDER, 'data');
+const USER_DATA_PATH = args['user-data-dir'] || join(REMOTE_DATA_FOLDER, 'data');
 const APP_SETTINGS_HOME = join(USER_DATA_PATH, 'User');
 const GLOBAL_STORAGE_HOME = join(APP_SETTINGS_HOME, 'globalStorage');
 const LOCAL_HISTORY_HOME = join(APP_SETTINGS_HOME, 'History');
 const MACHINE_SETTINGS_HOME = join(USER_DATA_PATH, 'Machine');
-args['user-data-dir'] = USER_DATA_PATH;
 const APP_ROOT = dirname(FileAccess.asFileUri('').fsPath);
 const BUILTIN_EXTENSIONS_FOLDER_PATH = join(APP_ROOT, 'extensions');
+args['user-data-dir'] = USER_DATA_PATH;
 args['builtin-extensions-dir'] = BUILTIN_EXTENSIONS_FOLDER_PATH;
 args['extensions-dir'] = args['extensions-dir'] || join(REMOTE_DATA_FOLDER, 'extensions');
 


### PR DESCRIPTION
The `--user-data-dir` command-line parameter is currently unusable. Its functionality is hampered due to an automatically appended `/data` directory, rendering the parameter completely ineffective.

The proposed minor modification allows users to accurately customize this variable, enhancing its utility.

The change is already implemented in `coder/code-server` at https://github.com/coder/code-server/blob/main/patches/integration.diff#L55

This PR is linked to:

- https://github.com/gitpod-io/openvscode-server/issues/512
- https://github.com/gitpod-io/openvscode-server/pull/511

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
