### PR TITLE
chore: remove library entitlements from main helper executable

### DIFF
--- a/build/azure-pipelines/darwin/app-entitlements.plist
+++ b/build/azure-pipelines/darwin/app-entitlements.plist
@@ -4,12 +4,6 @@
 <dict>
     <key>com.apple.security.cs.allow-jit</key>
     <true/>
-    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
-    <true/>
-    <key>com.apple.security.cs.allow-dyld-environment-variables</key>
-    <true/>
-    <key>com.apple.security.cs.disable-library-validation</key>
-    <true/>
     <key>com.apple.security.device.audio-input</key>
     <true/>
     <key>com.apple.security.device.camera</key>


### PR DESCRIPTION
Follow-up to https://github.com/microsoft/vscode/pull/161102#issuecomment-1249543794

Now that we no longer support a setting to use non-utility extension host, these entitlements are safe to be removed from the main helper executable.