### PR TITLE
Git - fix git status regression for git versions older than 2.18

### DIFF
--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -2021,7 +2021,7 @@ export class Repository {
 		}
 
 		// --find-renames option is only available starting with git 2.18.0
-		if (opts?.similarityThreshold && this._git.compareGitVersionTo('2.18') !== -1) {
+		if (opts?.similarityThreshold && this._git.compareGitVersionTo('2.18.0') !== -1) {
 			args.push(`--find-renames=${opts.similarityThreshold}%`);
 		}
 

--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -2020,7 +2020,8 @@ export class Repository {
 			args.push('--ignore-submodules');
 		}
 
-		if (opts?.similarityThreshold) {
+		// --find-renames option is only available starting with git 2.18.0
+		if (opts?.similarityThreshold && this._git.compareGitVersionTo('2.18') !== -1) {
 			args.push(`--find-renames=${opts.similarityThreshold}%`);
 		}
 


### PR DESCRIPTION
Fixes #182645