### PR TITLE
Don't throw when chat viewpane's saveState is called before render

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatViewPane.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatViewPane.ts
@@ -134,13 +134,15 @@ export class ChatViewPane extends ViewPane implements IChatViewPane {
 	}
 
 	override saveState(): void {
-		// Since input history is per-provider, this is handled by a separate service and not the memento here.
-		// TODO multiple chat views will overwrite each other
-		this._widget.saveState();
+		if (this._widget) {
+			// Since input history is per-provider, this is handled by a separate service and not the memento here.
+			// TODO multiple chat views will overwrite each other
+			this._widget.saveState();
 
-		const widgetViewState = this._widget.getViewState();
-		this.viewState.inputValue = widgetViewState.inputValue;
-		this.memento.saveMemento();
+			const widgetViewState = this._widget.getViewState();
+			this.viewState.inputValue = widgetViewState.inputValue;
+			this.memento.saveMemento();
+		}
 
 		super.saveState();
 	}


### PR DESCRIPTION
Fix #182767

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
