### PR TITLE
Prevent welcome page from stealing focus

### DIFF
--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts
@@ -1554,7 +1554,18 @@ export class GettingStartedPage extends EditorPane {
 	}
 
 	override focus() {
-		this.container.focus();
+		const active = document.activeElement;
+
+		let parent = this.container.parentElement;
+		while (parent && parent !== active) {
+			parent = parent.parentElement;
+		}
+
+		if (parent) {
+			// Only set focus if there is no other focued element outside this chain.
+			// This prevents us from stealing back focus from quick open due to delayed welcome page load.
+			this.container.focus();
+		}
 	}
 }
 

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts
@@ -1563,7 +1563,7 @@ export class GettingStartedPage extends EditorPane {
 
 		if (parent) {
 			// Only set focus if there is no other focued element outside this chain.
-			// This prevents us from stealing back focus from quick open due to delayed welcome page load.
+			// This prevents us from stealing back focus from other focused elements such as quick pick due to delayed load.
 			this.container.focus();
 		}
 	}


### PR DESCRIPTION
Fixes: https://github.com/microsoft/vscode/issues/181660#event-9202537341

Couldn't repro this myself but tested this by loading the welcome page with a delay. 