### PR TITLE
Enable project wide JS/TS intellisense on web by default

### DIFF
--- a/extensions/typescript-language-features/extension-browser.webpack.config.js
+++ b/extensions/typescript-language-features/extension-browser.webpack.config.js
@@ -41,7 +41,7 @@ module.exports = [withBrowserDefaults({
 			patterns: [
 				{
 					from: '../node_modules/typescript/lib/*.d.ts',
-					to: 'typescript/',
+					to: 'typescript/[name][ext]',
 				},
 				{
 					from: '../node_modules/typescript/lib/typesMap.json',

--- a/extensions/typescript-language-features/package.json
+++ b/extensions/typescript-language-features/package.json
@@ -1241,14 +1241,17 @@
           "description": "%configuration.suggest.objectLiteralMethodSnippets.enabled%",
           "scope": "resource"
         },
-        "typescript.experimental.tsserver.web.enableProjectWideIntellisense": {
+        "typescript.tsserver.web.projectWideIntellisense.enabled": {
           "type": "boolean",
-          "default": false,
-          "description": "%typescript.experimental.tsserver.web.enableProjectWideIntellisense%",
-          "scope": "window",
-          "tags": [
-            "experimental"
-          ]
+          "default": true,
+          "description": "%configuration.tsserver.web.projectWideIntellisense.enabled%",
+          "scope": "window"
+        },
+        "typescript.tsserver.web.projectWideIntellisense.suppressSemanticErrors": {
+          "type": "boolean",
+          "default": true,
+          "description": "%configuration.tsserver.web.projectWideIntellisense.suppressSemanticErrors%",
+          "scope": "window"
         },
         "typescript.preferGoToSourceDefinition": {
           "type": "boolean",

--- a/extensions/typescript-language-features/package.nls.json
+++ b/extensions/typescript-language-features/package.nls.json
@@ -87,29 +87,41 @@
 	"inlayHints.parameterNames.all": "Enable parameter name hints for literal and non-literal arguments.",
 	"configuration.inlayHints.parameterNames.enabled": {
 		"message": "Enable/disable inlay hints for parameter names:\n```typescript\n\nparseInt(/* str: */ '123', /* radix: */ 8)\n \n```",
-		"comment": ["The text inside the ``` block is code and should not be localized."]
+		"comment": [
+			"The text inside the ``` block is code and should not be localized."
+		]
 	},
 	"configuration.inlayHints.parameterNames.suppressWhenArgumentMatchesName": "Suppress parameter name hints on arguments whose text is identical to the parameter name.",
 	"configuration.inlayHints.parameterTypes.enabled": {
 		"message": "Enable/disable inlay hints for implicit parameter types:\n```typescript\n\nel.addEventListener('click', e /* :MouseEvent */ => ...)\n \n```",
-		"comment": ["The text inside the ``` block is code and should not be localized."]
+		"comment": [
+			"The text inside the ``` block is code and should not be localized."
+		]
 	},
 	"configuration.inlayHints.variableTypes.enabled": {
 		"message": "Enable/disable inlay hints for implicit variable types:\n```typescript\n\nconst foo /* :number */ = Date.now();\n \n```",
-		"comment": ["The text inside the ``` block is code and should not be localized."]
+		"comment": [
+			"The text inside the ``` block is code and should not be localized."
+		]
 	},
 	"configuration.inlayHints.variableTypes.suppressWhenTypeMatchesName": "Suppress type hints on variables whose name is identical to the type name. Requires using TypeScript 4.8+ in the workspace.",
 	"configuration.inlayHints.propertyDeclarationTypes.enabled": {
 		"message": "Enable/disable inlay hints for implicit types on property declarations:\n```typescript\n\nclass Foo {\n\tprop /* :number */ = Date.now();\n}\n \n```",
-		"comment": ["The text inside the ``` block is code and should not be localized."]
+		"comment": [
+			"The text inside the ``` block is code and should not be localized."
+		]
 	},
 	"configuration.inlayHints.functionLikeReturnTypes.enabled": {
 		"message": "Enable/disable inlay hints for implicit return types on function signatures:\n```typescript\n\nfunction foo() /* :number */ {\n\treturn Date.now();\n} \n \n```",
-		"comment": ["The text inside the ``` block is code and should not be localized."]
+		"comment": [
+			"The text inside the ``` block is code and should not be localized."
+		]
 	},
 	"configuration.inlayHints.enumMemberValues.enabled": {
 		"message": "Enable/disable inlay hints for member values in enum declarations:\n```typescript\n\nenum MyValue {\n\tA /* = 0 */;\n\tB /* = 1 */;\n}\n \n```",
-		"comment": ["The text inside the ``` block is code and should not be localized."]
+		"comment": [
+			"The text inside the ``` block is code and should not be localized."
+		]
 	},
 	"taskDefinition.tsconfig.description": "The tsconfig file that defines the TS build.",
 	"javascript.suggestionActions.enabled": "Enable/disable suggestion diagnostics for JavaScript files in the editor.",
@@ -197,25 +209,19 @@
 	"typescript.goToSourceDefinition": "Go to Source Definition",
 	"configuration.suggest.classMemberSnippets.enabled": "Enable/disable snippet completions for class members.",
 	"configuration.suggest.objectLiteralMethodSnippets.enabled": "Enable/disable snippet completions for methods in object literals. Requires using TypeScript 4.7+ in the workspace.",
-
-	"typescript.experimental.tsserver.web.enableProjectWideIntellisense": "Enable/disable project-wide IntelliSense on web. Requires that VS Code is running in a trusted context.",
-
+	"configuration.tsserver.web.projectWideIntellisense.enabled": "Enable/disable project-wide IntelliSense on web. Requires that VS Code is running in a trusted context.",
+	"configuration.tsserver.web.projectWideIntellisense.suppressSemanticErrors": "Suppresses semantic errors. This is needed when using external packages as these can't be included analyzed on web.",
 	"walkthroughs.nodejsWelcome.title": "Get started with JavaScript and Node.js",
 	"walkthroughs.nodejsWelcome.description": "Make the most of Visual Studio Code's first-class JavaScript experience.",
-
 	"walkthroughs.nodejsWelcome.downloadNode.forMacOrWindows.title": "Install Node.js",
 	"walkthroughs.nodejsWelcome.downloadNode.forMacOrWindows.description": "Node.js is an easy way to run JavaScript code. You can use it to quickly build command-line apps and servers. It also comes with npm, a package manager which makes reusing and sharing JavaScript code easy.\n[Install Node.js](https://nodejs.org/en/download/)",
-
 	"walkthroughs.nodejsWelcome.downloadNode.forLinux.title": "Install Node.js",
 	"walkthroughs.nodejsWelcome.downloadNode.forLinux.description": "Node.js is an easy way to run JavaScript code. You can use it to quickly build command-line apps and servers. It also comes with npm, a package manager which makes reusing and sharing JavaScript code easy.\n[Install Node.js](https://nodejs.org/en/download/package-manager/)",
-
 	"walkthroughs.nodejsWelcome.makeJsFile.title": "Create a JavaScript File",
 	"walkthroughs.nodejsWelcome.makeJsFile.description": "Let's write our first JavaScript file. We'll have to create a new file and save it with the ``.js`` extension at the end of the file name.\n[Create a JavaScript File](command:javascript-walkthrough.commands.createJsFile)",
-
 	"walkthroughs.nodejsWelcome.debugJsFile.title": "Run and Debug your JavaScript",
 	"walkthroughs.nodejsWelcome.debugJsFile.description": "Once you've installed Node.js, you can run JavaScript programs at a terminal by entering ``node your-file-name.js``\nAnother easy way to run Node.js programs is by using VS Code's debugger which lets you run your code, pause at different points, and help you understand what's going on step-by-step.\n[Start Debugging](command:javascript-walkthrough.commands.debugJsFile)",
 	"walkthroughs.nodejsWelcome.debugJsFile.altText": "Debug and run your JavaScript code in Node.js with Visual Studio Code.",
-
 	"walkthroughs.nodejsWelcome.learnMoreAboutJs.title": "Explore More",
 	"walkthroughs.nodejsWelcome.learnMoreAboutJs.description": "Want to get more comfortable with JavaScript, Node.js, and VS Code? Be sure to check out our docs!\nWe've got lots of resources for learning [JavaScript](https://code.visualstudio.com/docs/nodejs/working-with-javascript) and [Node.js](https://code.visualstudio.com/docs/nodejs/nodejs-tutorial).\n\n[Learn More](https://code.visualstudio.com/docs/nodejs/nodejs-tutorial)",
 	"walkthroughs.nodejsWelcome.learnMoreAboutJs.altText": "Learn more about JavaScript and Node.js in Visual Studio Code."

--- a/extensions/typescript-language-features/src/configuration/configuration.ts
+++ b/extensions/typescript-language-features/src/configuration/configuration.ts
@@ -110,7 +110,8 @@ export interface TypeScriptServiceConfiguration {
 	readonly implicitProjectConfiguration: ImplicitProjectConfiguration;
 	readonly disableAutomaticTypeAcquisition: boolean;
 	readonly useSyntaxServer: SyntaxServerConfiguration;
-	readonly enableProjectWideIntellisenseOnWeb: boolean;
+	readonly webProjectWideIntellisenseEnabled: boolean;
+	readonly webProjectWideIntellisenseSuppressSemanticErrors: boolean;
 	readonly enableProjectDiagnostics: boolean;
 	readonly maxTsServerMemory: number;
 	readonly enablePromptUseWorkspaceTsdk: boolean;
@@ -141,7 +142,8 @@ export abstract class BaseServiceConfigurationProvider implements ServiceConfigu
 			implicitProjectConfiguration: new ImplicitProjectConfiguration(configuration),
 			disableAutomaticTypeAcquisition: this.readDisableAutomaticTypeAcquisition(configuration),
 			useSyntaxServer: this.readUseSyntaxServer(configuration),
-			enableProjectWideIntellisenseOnWeb: this.readEnableProjectWideIntellisenseOnWeb(configuration),
+			webProjectWideIntellisenseEnabled: this.readWebProjectWideIntellisenseEnable(configuration),
+			webProjectWideIntellisenseSuppressSemanticErrors: this.readWebProjectWideIntellisenseSuppressSemanticErrors(configuration),
 			enableProjectDiagnostics: this.readEnableProjectDiagnostics(configuration),
 			maxTsServerMemory: this.readMaxTsServerMemory(configuration),
 			enablePromptUseWorkspaceTsdk: this.readEnablePromptUseWorkspaceTsdk(configuration),
@@ -227,7 +229,11 @@ export abstract class BaseServiceConfigurationProvider implements ServiceConfigu
 		return configuration.get<boolean>('typescript.tsserver.enableTracing', false);
 	}
 
-	private readEnableProjectWideIntellisenseOnWeb(configuration: vscode.WorkspaceConfiguration): boolean {
-		return configuration.get<boolean>('typescript.experimental.tsserver.web.enableProjectWideIntellisense', false);
+	private readWebProjectWideIntellisenseEnable(configuration: vscode.WorkspaceConfiguration): boolean {
+		return configuration.get<boolean>('typescript.tsserver.web.projectWideIntellisense.enabled', true);
+	}
+
+	private readWebProjectWideIntellisenseSuppressSemanticErrors(configuration: vscode.WorkspaceConfiguration): boolean {
+		return configuration.get<boolean>('typescript.tsserver.web.projectWideIntellisense.suppressSemanticErrors', true);
 	}
 }

--- a/extensions/typescript-language-features/src/languageProvider.ts
+++ b/extensions/typescript-language-features/src/languageProvider.ts
@@ -6,17 +6,18 @@
 import { basename, extname } from 'path';
 import * as vscode from 'vscode';
 import { CommandManager } from './commands/commandManager';
+import { DocumentSelector } from './configuration/documentSelector';
+import * as fileSchemes from './configuration/fileSchemes';
+import { LanguageDescription } from './configuration/languageDescription';
 import { DiagnosticKind } from './languageFeatures/diagnostics';
 import FileConfigurationManager from './languageFeatures/fileConfigurationManager';
+import { TelemetryReporter } from './logging/telemetry';
 import { CachedResponse } from './tsServer/cachedResponse';
 import { ClientCapability } from './typescriptService';
 import TypeScriptServiceClient from './typescriptServiceClient';
 import TypingsStatus from './ui/typingsStatus';
 import { Disposable } from './utils/dispose';
-import { DocumentSelector } from './configuration/documentSelector';
-import * as fileSchemes from './configuration/fileSchemes';
-import { LanguageDescription } from './configuration/languageDescription';
-import { TelemetryReporter } from './logging/telemetry';
+import { isWeb } from './utils/platform';
 
 
 const validateSetting = 'validate.enable';
@@ -136,6 +137,10 @@ export default class LanguageProvider extends Disposable {
 
 	public diagnosticsReceived(diagnosticsKind: DiagnosticKind, file: vscode.Uri, diagnostics: (vscode.Diagnostic & { reportUnnecessary: any; reportDeprecated: any })[]): void {
 		if (diagnosticsKind !== DiagnosticKind.Syntax && !this.client.hasCapabilityForResource(file, ClientCapability.Semantic)) {
+			return;
+		}
+
+		if (diagnosticsKind === DiagnosticKind.Semantic && isWeb() && this.client.configuration.webProjectWideIntellisenseSuppressSemanticErrors) {
 			return;
 		}
 

--- a/extensions/typescript-language-features/src/typescriptServiceClient.ts
+++ b/extensions/typescript-language-features/src/typescriptServiceClient.ts
@@ -258,7 +258,7 @@ export default class TypeScriptServiceClient extends Disposable implements IType
 	readonly onDidChangeCapabilities = this._onDidChangeCapabilities.event;
 
 	private isProjectWideIntellisenseOnWebEnabled(): boolean {
-		return isWebAndHasSharedArrayBuffers() && this._configuration.enableProjectWideIntellisenseOnWeb;
+		return isWebAndHasSharedArrayBuffers() && this._configuration.webProjectWideIntellisenseEnabled;
 	}
 
 	private cancelInflightRequestsForResource(resource: vscode.Uri): void {
@@ -902,7 +902,7 @@ export default class TypeScriptServiceClient extends Disposable implements IType
 				const diagnosticEvent = event as Proto.DiagnosticEvent;
 				if (diagnosticEvent.body?.diagnostics) {
 					this._onDiagnosticsReceived.fire({
-						kind: getDignosticsKind(event),
+						kind: getDiagnosticsKind(event),
 						resource: this.toResource(diagnosticEvent.body.file),
 						diagnostics: diagnosticEvent.body.diagnostics
 					});
@@ -1089,7 +1089,7 @@ ${error.serverStack}
 	};
 }
 
-function getDignosticsKind(event: Proto.Event) {
+function getDiagnosticsKind(event: Proto.Event) {
 	switch (event.event) {
 		case 'syntaxDiag': return DiagnosticKind.Syntax;
 		case 'semanticDiag': return DiagnosticKind.Semantic;


### PR DESCRIPTION
Fixes #170920

Enables this feature by default but also disables semantic errors. This is needed to avoid lots of annoying false positive errors for external modules. We plan to remove this limitation once type downloading support is enabled

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
