### PR TITLE
Remove some completions logic specific to old TS versions

### DIFF
--- a/extensions/typescript-language-features/src/languageFeatures/completions.ts
+++ b/extensions/typescript-language-features/src/languageFeatures/completions.ts
@@ -31,7 +31,6 @@ interface DotAccessorContext {
 interface CompletionContext {
 	readonly isNewIdentifierLocation: boolean;
 	readonly isMemberCompletion: boolean;
-	readonly isInValidCommitCharacterContext: boolean;
 
 	readonly dotAccessorContext?: DotAccessorContext;
 
@@ -40,8 +39,6 @@ interface CompletionContext {
 
 	readonly wordRange: vscode.Range | undefined;
 	readonly line: string;
-
-	readonly useFuzzyWordRangeLogic: boolean;
 }
 
 type ResolvedCompletionItem = {
@@ -102,7 +99,7 @@ class MyCompletionItem extends vscode.CompletionItem {
 		if (completionContext.isMemberCompletion && completionContext.dotAccessorContext && !(this.insertText instanceof vscode.SnippetString)) {
 			this.filterText = completionContext.dotAccessorContext.text + (this.insertText || this.textLabel);
 			if (!this.range) {
-				const replacementRange = this.getFuzzyWordRange();
+				const replacementRange = this.completionContext.wordRange;
 				if (replacementRange) {
 					this.range = {
 						inserting: completionContext.dotAccessorContext.range,
@@ -423,30 +420,13 @@ class MyCompletionItem extends vscode.CompletionItem {
 			return;
 		}
 
-		const replaceRange = this.getFuzzyWordRange();
+		const replaceRange = this.completionContext.wordRange;
 		if (replaceRange) {
 			this.range = {
 				inserting: new vscode.Range(replaceRange.start, this.position),
 				replacing: replaceRange
 			};
 		}
-	}
-
-	private getFuzzyWordRange() {
-		if (this.completionContext.useFuzzyWordRangeLogic) {
-			// Try getting longer, prefix based range for completions that span words
-			const text = this.completionContext.line.slice(Math.max(0, this.position.character - this.textLabel.length), this.position.character).toLowerCase();
-			const entryName = this.textLabel.toLowerCase();
-			for (let i = entryName.length; i >= 0; --i) {
-				if (text.endsWith(entryName.substr(0, i)) && (!this.completionContext.wordRange || this.completionContext.wordRange.start.character > this.position.character - i)) {
-					return new vscode.Range(
-						new vscode.Position(this.position.line, Math.max(0, this.position.character - i)),
-						this.position);
-				}
-			}
-		}
-
-		return this.completionContext.wordRange;
 	}
 
 	private static convertKind(kind: string): vscode.CompletionItemKind {
@@ -517,7 +497,7 @@ class MyCompletionItem extends vscode.CompletionItem {
 			return undefined;
 		}
 
-		if (context.isNewIdentifierLocation || !context.isInValidCommitCharacterContext) {
+		if (context.isNewIdentifierLocation) {
 			return undefined;
 		}
 
@@ -790,16 +770,14 @@ class TypeScriptCompletionItemProvider implements vscode.CompletionItemProvider<
 			metadata = response.metadata;
 		}
 
-		const completionContext = {
+		const completionContext: CompletionContext = {
 			isNewIdentifierLocation,
 			isMemberCompletion,
 			dotAccessorContext,
-			isInValidCommitCharacterContext: this.isInValidCommitCharacterContext(document, position),
 			enableCallCompletions: !completionConfiguration.completeFunctionCalls,
 			wordRange,
 			line: line.text,
 			completeFunctionCalls: completionConfiguration.completeFunctionCalls,
-			useFuzzyWordRangeLogic: this.client.apiVersion.lt(API.v390),
 		};
 
 		let includesPackageJsonImport = false;
@@ -864,26 +842,27 @@ class TypeScriptCompletionItemProvider implements vscode.CompletionItemProvider<
 
 	private getTsTriggerCharacter(context: vscode.CompletionContext): Proto.CompletionsTriggerCharacter | undefined {
 		switch (context.triggerCharacter) {
-			case '@': // Workaround for https://github.com/microsoft/TypeScript/issues/27321
+			case '@': { // Workaround for https://github.com/microsoft/TypeScript/issues/27321
 				return this.client.apiVersion.gte(API.v310) && this.client.apiVersion.lt(API.v320) ? undefined : '@';
-
-			case '#': // Workaround for https://github.com/microsoft/TypeScript/issues/36367
+			}
+			case '#': { // Workaround for https://github.com/microsoft/TypeScript/issues/36367
 				return this.client.apiVersion.lt(API.v381) ? undefined : '#';
-
+			}
 			case ' ': {
-				const space: Proto.CompletionsTriggerCharacter = ' ';
-				return this.client.apiVersion.gte(API.v430) ? space : undefined;
+				return this.client.apiVersion.gte(API.v430) ? ' ' : undefined;
 			}
 			case '.':
 			case '"':
 			case '\'':
 			case '`':
 			case '/':
-			case '<':
+			case '<': {
 				return context.triggerCharacter;
+			}
+			default: {
+				return undefined;
+			}
 		}
-
-		return undefined;
 	}
 
 	public async resolveCompletionItem(
@@ -892,25 +871,6 @@ class TypeScriptCompletionItemProvider implements vscode.CompletionItemProvider<
 	): Promise<MyCompletionItem | undefined> {
 		await item.resolveCompletionItem(this.client, token);
 		return item;
-	}
-
-	private isInValidCommitCharacterContext(
-		document: vscode.TextDocument,
-		position: vscode.Position
-	): boolean {
-		if (this.client.apiVersion.lt(API.v320)) {
-			// Workaround for https://github.com/microsoft/TypeScript/issues/27742
-			// Only enable dot completions when previous character not a dot preceded by whitespace.
-			// Prevents incorrectly completing while typing spread operators.
-			if (position.character > 1) {
-				const preText = document.getText(new vscode.Range(
-					position.line, 0,
-					position.line, position.character));
-				return preText.match(/(\s|^)\.$/ig) === null;
-			}
-		}
-
-		return true;
 	}
 
 	private shouldTrigger(


### PR DESCRIPTION
Removes workarounds added for TS versions that are many years old at this point

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
