### PR TITLE
revert change to terminal process kill signal

### DIFF
--- a/src/vs/platform/terminal/node/terminalProcess.ts
+++ b/src/vs/platform/terminal/node/terminalProcess.ts
@@ -375,7 +375,7 @@ export class TerminalProcess extends Disposable implements ITerminalChildProcess
 			if (this._ptyProcess) {
 				await this._throttleKillSpawn();
 				this._logService.trace('IPty#kill');
-				this._ptyProcess.kill(!isWindows ? 'SIGKILL' : undefined);
+				this._ptyProcess.kill();
 			}
 		} catch (ex) {
 			// Swallow, the pty has already been killed


### PR DESCRIPTION
We thought that this fixed an issue where processes were hanging around, but the real fix for that was https://github.com/microsoft/node-pty/pull/589

When `SIGKILL` is used, history isn't saved which has caused some issues 

fixes https://github.com/microsoft/vscode/issues/181508