### PR TITLE
Revert "only terminate session when content change moves all cursors outside of whole range, don't use change range for this"

### DIFF
--- a/src/vs/workbench/contrib/interactiveEditor/browser/interactiveEditorController.ts
+++ b/src/vs/workbench/contrib/interactiveEditor/browser/interactiveEditorController.ts
@@ -267,12 +267,14 @@ export class InteractiveEditorController implements IEditorContribution {
 			}
 
 			const wholeRange = this._activeSession!.wholeRange;
-			const someSelectionInsideOfWholeRange = this._editor.getSelections()!
-				.some(sel => Range.areIntersectingOrTouching(sel, wholeRange));
+			let editIsOutsideOfWholeRange = false;
+			for (const { range } of e.changes) {
+				editIsOutsideOfWholeRange = !Range.areIntersectingOrTouching(range, wholeRange);
+			}
 
-			this._activeSession!.recordExternalEditOccurred(someSelectionInsideOfWholeRange);
+			this._activeSession!.recordExternalEditOccurred(editIsOutsideOfWholeRange);
 
-			if (!someSelectionInsideOfWholeRange) {
+			if (editIsOutsideOfWholeRange) {
 				this._logService.trace('[IE] text changed outside of whole range, FINISH session');
 				this._finishExistingSession();
 			}


### PR DESCRIPTION
Reverts microsoft/vscode#182786

This PR causes the inline chat to hide when any character is pressed in the diff view