### PR TITLE
Better fix for previous candidate debug issue

### DIFF
--- a/src/vs/workbench/contrib/debug/common/debugModel.ts
+++ b/src/vs/workbench/contrib/debug/common/debugModel.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { distinct, lastIndex } from 'vs/base/common/arrays';
-import { RunOnceScheduler } from 'vs/base/common/async';
+import { DeferredPromise, RunOnceScheduler } from 'vs/base/common/async';
 import { decodeBase64, encodeBase64, VSBuffer } from 'vs/base/common/buffer';
 import { CancellationTokenSource } from 'vs/base/common/cancellation';
 import { stringHash } from 'vs/base/common/hash';
@@ -1176,7 +1176,7 @@ export class ThreadAndSessionIds implements ITreeElement {
 export class DebugModel implements IDebugModel {
 
 	private sessions: IDebugSession[];
-	private schedulers = new Map<string, RunOnceScheduler>();
+	private schedulers = new Map<string, { scheduler: RunOnceScheduler; completeDeferred: DeferredPromise<void> }>();
 	private breakpointsActivated = true;
 	private readonly _onDidChangeBreakpoints = new Emitter<IBreakpointsChangeEvent | undefined>();
 	private readonly _onDidChangeCallStack = new Emitter<void>();
@@ -1274,7 +1274,10 @@ export class DebugModel implements IDebugModel {
 
 	clearThreads(id: string, removeThreads: boolean, reference: number | undefined = undefined): void {
 		const session = this.sessions.find(p => p.getId() === id);
-		this.schedulers.forEach(scheduler => scheduler.dispose());
+		this.schedulers.forEach(entry => {
+			entry.scheduler.dispose();
+			entry.completeDeferred.complete();
+		});
 		this.schedulers.clear();
 
 		if (session) {
@@ -1314,24 +1317,32 @@ export class DebugModel implements IDebugModel {
 			const wholeCallStack = new Promise<void>((c, e) => {
 				topCallStack = thread.fetchCallStack(1).then(() => {
 					if (!this.schedulers.has(thread.getId())) {
-						this.schedulers.set(thread.getId(), new RunOnceScheduler(() => {
-							thread.fetchCallStack(19).then(() => {
-								const stale = thread.getStaleCallStack();
-								const current = thread.getCallStack();
-								let bottomOfCallStackChanged = stale.length !== current.length;
-								for (let i = 1; i < stale.length && !bottomOfCallStackChanged; i++) {
-									bottomOfCallStackChanged = !stale[i].equals(current[i]);
-								}
+						const deferred = new DeferredPromise<void>();
+						this.schedulers.set(thread.getId(), {
+							completeDeferred: deferred,
+							scheduler: new RunOnceScheduler(() => {
+								thread.fetchCallStack(19).then(() => {
+									const stale = thread.getStaleCallStack();
+									const current = thread.getCallStack();
+									let bottomOfCallStackChanged = stale.length !== current.length;
+									for (let i = 1; i < stale.length && !bottomOfCallStackChanged; i++) {
+										bottomOfCallStackChanged = !stale[i].equals(current[i]);
+									}
 
-								if (bottomOfCallStackChanged) {
-									this._onDidChangeCallStack.fire();
-								}
-								c();
-							});
-						}, 420));
+									if (bottomOfCallStackChanged) {
+										this._onDidChangeCallStack.fire();
+									}
+								}).finally(() => {
+									deferred.complete();
+									this.schedulers.delete(thread.getId());
+								});
+							}, 420)
+						});
 					}
 
-					this.schedulers.get(thread.getId())!.schedule();
+					const entry = this.schedulers.get(thread.getId())!;
+					entry.scheduler.schedule();
+					entry.completeDeferred.p.then(c, e);
 					this._onDidChangeCallStack.fire();
 				});
 			});

--- a/src/vs/workbench/contrib/debug/test/common/debugModel.test.ts
+++ b/src/vs/workbench/contrib/debug/test/common/debugModel.test.ts
@@ -4,7 +4,11 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as assert from 'assert';
-import { ExceptionBreakpoint, FunctionBreakpoint } from 'vs/workbench/contrib/debug/common/debugModel';
+import { DeferredPromise } from 'vs/base/common/async';
+import { mockObject } from 'vs/base/test/common/mock';
+import { NullLogService } from 'vs/platform/log/common/log';
+import { DebugModel, ExceptionBreakpoint, FunctionBreakpoint, Thread } from 'vs/workbench/contrib/debug/common/debugModel';
+import { MockDebugStorage } from 'vs/workbench/contrib/debug/test/common/mockDebug';
 
 suite('DebugModel', () => {
 	suite('FunctionBreakpoint', () => {
@@ -15,6 +19,7 @@ suite('DebugModel', () => {
 			assert.equal(parsed.id, fbp.getId());
 		});
 	});
+
 	suite('ExceptionBreakpoint', () => {
 		test('Restored matches new', () => {
 			const ebp = new ExceptionBreakpoint('id', 'label', true, true, 'condition', 'description', 'condition description', false);
@@ -22,6 +27,49 @@ suite('DebugModel', () => {
 			const parsed = JSON.parse(strigified);
 			const newEbp = new ExceptionBreakpoint(parsed.filter, parsed.label, parsed.enabled, parsed.supportsCondition, parsed.condition, parsed.description, parsed.conditionDescription, !!parsed.fallback);
 			assert.ok(ebp.matches(newEbp));
+		});
+	});
+
+	suite('DebugModel', () => {
+		test('refreshTopOfCallstack resolves all returned promises when called multiple times', async () => {
+			const topFrameDeferred = new DeferredPromise<void>();
+			const wholeStackDeferred = new DeferredPromise<void>();
+			const fakeThread = mockObject<Thread>()({
+				session: { capabilities: { supportsDelayedStackTraceLoading: true } } as any,
+			});
+			fakeThread.fetchCallStack.callsFake((levels: number) => {
+				return levels === 1 ? topFrameDeferred.p : wholeStackDeferred.p;
+			});
+			fakeThread.getId.returns(1);
+
+			const model = new DebugModel(new MockDebugStorage(), <any>{ isDirty: (e: any) => false }, undefined!, new NullLogService());
+
+			let top1Resolved = false;
+			let whole1Resolved = false;
+			let top2Resolved = false;
+			let whole2Resolved = false;
+			const result1 = model.refreshTopOfCallstack(fakeThread as any);
+			result1.topCallStack.then(() => top1Resolved = true);
+			result1.wholeCallStack.then(() => whole1Resolved = true);
+
+			const result2 = model.refreshTopOfCallstack(fakeThread as any);
+			result2.topCallStack.then(() => top2Resolved = true);
+			result2.wholeCallStack.then(() => whole2Resolved = true);
+
+			assert.ok(!top1Resolved);
+			assert.ok(!whole1Resolved);
+			assert.ok(!top2Resolved);
+			assert.ok(!whole2Resolved);
+
+			await topFrameDeferred.complete();
+			await result1.topCallStack;
+			await result2.topCallStack;
+			assert.ok(!whole1Resolved);
+			assert.ok(!whole2Resolved);
+
+			await wholeStackDeferred.complete();
+			await result1.wholeCallStack;
+			await result2.wholeCallStack;
 		});
 	});
 });


### PR DESCRIPTION
Only merge after Friday
Bring back the async queue for handling debug messages, but be sure that refreshTopOfCallstack will always resolve its promises and won't make the queue stuck
Fix #181966
