### PR TITLE
Fix indentation issues when pasting with trailing newline

### DIFF
--- a/src/vs/editor/contrib/indentation/test/browser/indentation.test.ts
+++ b/src/vs/editor/contrib/indentation/test/browser/indentation.test.ts
@@ -264,6 +264,48 @@ suite('Editor Contrib - Auto Indent On Paste', () => {
 			assert.strictEqual(model.getValue(), pasteText);
 		});
 	});
+
+	test('issue #85781: Do not indent the final line if the selection ends at the start of it', () => {
+		const languageId = 'indentFinalLine';
+		const lines = [
+			'if (true) {',
+			'    console.log("end");',
+			'}',
+		];
+		const model = createTextModel(lines.join('\n'), languageId, {});
+		disposables.add(model);
+		withTestCodeEditor(model, { autoIndent: 'full' }, (editor, viewModel, instantiationService) => {
+			const languageService = instantiationService.get(ILanguageService);
+			const languageConfigurationService = instantiationService.get(ILanguageConfigurationService);
+			disposables.add(languageService.registerLanguage({ id: languageId }));
+			disposables.add(languageConfigurationService.register(languageId, {
+				brackets: [
+					['{', '}'],
+					['[', ']'],
+					['(', ')']
+				],
+				indentationRules: javascriptIndentationRules,
+				onEnterRules: javascriptOnEnterRules
+			}));
+
+			const autoIndentOnPasteController = editor.registerAndInstantiateContribution(AutoIndentOnPaste.ID, AutoIndentOnPaste);
+			// The bug only happened when pasting 2 or more lines
+			const pasteLines = [
+				'console.log(1);',
+				'console.log(2);',
+			];
+
+			viewModel.setSelections('test', [new Selection(2, 1, 2, 1)]);
+			viewModel.paste(pasteLines.join('\n') + '\n', false, undefined, 'keyboard');
+			autoIndentOnPasteController.trigger(new Range(2, 1, 4, 1));
+			const expectText = [
+				lines[0],
+				...pasteLines.map(line => '    ' + line),
+				...lines.slice(1),
+			].join('\n');
+			assert.strictEqual(model.getValue(), expectText);
+		});
+	});
 });
 
 suite('Editor Contrib - Keep Indent On Paste', () => {


### PR DESCRIPTION
Fixes #85781
Fixes #147223
Fixes #33760
Fixes #65614
Fixes #86301

(Some of the issues above were closed as being limitations of the regex based indentation rules, but this change is able to fix them.)

Note that ReindentSelectedLinesAction already does the same thing as this fix (which is what inspired it -- I noticed that running Reindent Selected Lines in the same scenarios didn't have the same issues): see https://github.com/microsoft/vscode/blob/6cbd9e8f3c5a59c5b1170aac8f2b5e9b0b4edfee/src/vs/editor/contrib/indentation/browser/indentation.ts#L390-L392
