### PR TITLE
Add line height to chat list items

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/media/chat.css
@@ -167,6 +167,10 @@
 	line-height: 1.6em;
 }
 
+.interactive-item-container li {
+	line-height: 1.5rem;
+}
+
 .interactive-item-container .monaco-tokenized-source,
 .interactive-item-container code {
 	font-family: var(--monaco-monospace-font);


### PR DESCRIPTION
## Before

<img width="265" alt="CleanShot 2023-05-19 at 15 32 20@2x" src="https://github.com/microsoft/vscode/assets/25163139/5010c9c3-3f57-4a4f-b5aa-6bd3132bc755">
<img width="405" alt="CleanShot 2023-05-19 at 15 32 17@2x" src="https://github.com/microsoft/vscode/assets/25163139/d7577584-03e2-4956-ba0d-9de1d7245d6c">

## After

<img width="267" alt="CleanShot 2023-05-19 at 15 32 13@2x" src="https://github.com/microsoft/vscode/assets/25163139/1f8f3825-d379-4cac-992a-2a59af0ae030">
<img width="423" alt="CleanShot 2023-05-19 at 15 34 35@2x" src="https://github.com/microsoft/vscode/assets/25163139/39b6b907-624c-4316-8344-3296894326f4">



