### PR TITLE
Add `JSON Lines` language definition

### DIFF
--- a/extensions/json/build/update-grammars.js
+++ b/extensions/json/build/update-grammars.js
@@ -6,8 +6,8 @@
 
 var updateGrammar = require('vscode-grammar-updater');
 
-function adaptJSON(grammar, replacementScope) {
-	grammar.name = 'JSON with comments';
+function adaptJSON(grammar, name, replacementScope) {
+	grammar.name = name;
 	grammar.scopeName = `source${replacementScope}`;
 
 	var fixScopeNames = function (rule) {
@@ -33,9 +33,5 @@ function adaptJSON(grammar, replacementScope) {
 
 var tsGrammarRepo = 'microsoft/vscode-JSON.tmLanguage';
 updateGrammar.update(tsGrammarRepo, 'JSON.tmLanguage', './syntaxes/JSON.tmLanguage.json');
-updateGrammar.update(tsGrammarRepo, 'JSON.tmLanguage', './syntaxes/JSONC.tmLanguage.json', grammar => adaptJSON(grammar, '.json.comments'));
-
-
-
-
-
+updateGrammar.update(tsGrammarRepo, 'JSON.tmLanguage', './syntaxes/JSONC.tmLanguage.json', grammar => adaptJSON(grammar, 'JSON with Comments', '.json.comments'));
+updateGrammar.update(tsGrammarRepo, 'JSON.tmLanguage', './syntaxes/JSONL.tmLanguage.json', grammar => adaptJSON(grammar, 'JSON Lines', '.json.lines'));

--- a/extensions/json/package.json
+++ b/extensions/json/package.json
@@ -31,7 +31,7 @@
           ".jslintrc",
           ".jsonld",
           ".geojson",
-		      ".ipynb"
+          ".ipynb"
         ],
         "filenames": [
           "composer.lock",

--- a/extensions/json/package.json
+++ b/extensions/json/package.json
@@ -31,7 +31,7 @@
           ".jslintrc",
           ".jsonld",
           ".geojson",
-		  ".ipynb"
+		      ".ipynb"
         ],
         "filenames": [
           "composer.lock",
@@ -65,6 +65,17 @@
           "typedoc.json"
         ],
         "configuration": "./language-configuration.json"
+      },
+      {
+        "id": "jsonl",
+        "aliases": [
+          "JSON Lines"
+        ],
+        "extensions": [
+          ".jsonl"
+        ],
+        "filenames": [],
+        "configuration": "./language-configuration.json"
       }
     ],
     "grammars": [
@@ -77,6 +88,11 @@
         "language": "jsonc",
         "scopeName": "source.json.comments",
         "path": "./syntaxes/JSONC.tmLanguage.json"
+      },
+      {
+        "language": "jsonl",
+        "scopeName": "source.json.lines",
+        "path": "./syntaxes/JSONL.tmLanguage.json"
       }
     ]
   },

--- a/extensions/json/syntaxes/JSONL.tmLanguage.json
+++ b/extensions/json/syntaxes/JSONL.tmLanguage.json
@@ -5,8 +5,8 @@
 		"Once accepted there, we are happy to receive an update request."
 	],
 	"version": "https://github.com/microsoft/vscode-JSON.tmLanguage/commit/9bd83f1c252b375e957203f21793316203f61f70",
-	"name": "JSON with Comments",
-	"scopeName": "source.json.comments",
+	"name": "JSON Lines",
+	"scopeName": "source.json.lines",
 	"patterns": [
 		{
 			"include": "#value"
@@ -17,27 +17,27 @@
 			"begin": "\\[",
 			"beginCaptures": {
 				"0": {
-					"name": "punctuation.definition.array.begin.json.comments"
+					"name": "punctuation.definition.array.begin.json.lines"
 				}
 			},
 			"end": "\\]",
 			"endCaptures": {
 				"0": {
-					"name": "punctuation.definition.array.end.json.comments"
+					"name": "punctuation.definition.array.end.json.lines"
 				}
 			},
-			"name": "meta.structure.array.json.comments",
+			"name": "meta.structure.array.json.lines",
 			"patterns": [
 				{
 					"include": "#value"
 				},
 				{
 					"match": ",",
-					"name": "punctuation.separator.array.json.comments"
+					"name": "punctuation.separator.array.json.lines"
 				},
 				{
 					"match": "[^\\s\\]]",
-					"name": "invalid.illegal.expected-array-separator.json.comments"
+					"name": "invalid.illegal.expected-array-separator.json.lines"
 				}
 			]
 		},
@@ -47,26 +47,26 @@
 					"begin": "/\\*\\*(?!/)",
 					"captures": {
 						"0": {
-							"name": "punctuation.definition.comment.json.comments"
+							"name": "punctuation.definition.comment.json.lines"
 						}
 					},
 					"end": "\\*/",
-					"name": "comment.block.documentation.json.comments"
+					"name": "comment.block.documentation.json.lines"
 				},
 				{
 					"begin": "/\\*",
 					"captures": {
 						"0": {
-							"name": "punctuation.definition.comment.json.comments"
+							"name": "punctuation.definition.comment.json.lines"
 						}
 					},
 					"end": "\\*/",
-					"name": "comment.block.json.comments"
+					"name": "comment.block.json.lines"
 				},
 				{
 					"captures": {
 						"1": {
-							"name": "punctuation.definition.comment.json.comments"
+							"name": "punctuation.definition.comment.json.lines"
 						}
 					},
 					"match": "(//).*$\\n?",
@@ -76,26 +76,26 @@
 		},
 		"constant": {
 			"match": "\\b(?:true|false|null)\\b",
-			"name": "constant.language.json.comments"
+			"name": "constant.language.json.lines"
 		},
 		"number": {
 			"match": "(?x)        # turn on extended mode\n  -?        # an optional minus\n  (?:\n    0       # a zero\n    |       # ...or...\n    [1-9]   # a 1-9 character\n    \\d*     # followed by zero or more digits\n  )\n  (?:\n    (?:\n      \\.    # a period\n      \\d+   # followed by one or more digits\n    )?\n    (?:\n      [eE]  # an e character\n      [+-]? # followed by an option +/-\n      \\d+   # followed by one or more digits\n    )?      # make exponent optional\n  )?        # make decimal portion optional",
-			"name": "constant.numeric.json.comments"
+			"name": "constant.numeric.json.lines"
 		},
 		"object": {
 			"begin": "\\{",
 			"beginCaptures": {
 				"0": {
-					"name": "punctuation.definition.dictionary.begin.json.comments"
+					"name": "punctuation.definition.dictionary.begin.json.lines"
 				}
 			},
 			"end": "\\}",
 			"endCaptures": {
 				"0": {
-					"name": "punctuation.definition.dictionary.end.json.comments"
+					"name": "punctuation.definition.dictionary.end.json.lines"
 				}
 			},
-			"name": "meta.structure.dictionary.json.comments",
+			"name": "meta.structure.dictionary.json.lines",
 			"patterns": [
 				{
 					"comment": "the JSON object key",
@@ -108,16 +108,16 @@
 					"begin": ":",
 					"beginCaptures": {
 						"0": {
-							"name": "punctuation.separator.dictionary.key-value.json.comments"
+							"name": "punctuation.separator.dictionary.key-value.json.lines"
 						}
 					},
 					"end": "(,)|(?=\\})",
 					"endCaptures": {
 						"1": {
-							"name": "punctuation.separator.dictionary.pair.json.comments"
+							"name": "punctuation.separator.dictionary.pair.json.lines"
 						}
 					},
-					"name": "meta.structure.dictionary.value.json.comments",
+					"name": "meta.structure.dictionary.value.json.lines",
 					"patterns": [
 						{
 							"comment": "the JSON object value",
@@ -125,13 +125,13 @@
 						},
 						{
 							"match": "[^\\s,]",
-							"name": "invalid.illegal.expected-dictionary-separator.json.comments"
+							"name": "invalid.illegal.expected-dictionary-separator.json.lines"
 						}
 					]
 				},
 				{
 					"match": "[^\\s\\}]",
-					"name": "invalid.illegal.expected-dictionary-separator.json.comments"
+					"name": "invalid.illegal.expected-dictionary-separator.json.lines"
 				}
 			]
 		},
@@ -139,16 +139,16 @@
 			"begin": "\"",
 			"beginCaptures": {
 				"0": {
-					"name": "punctuation.definition.string.begin.json.comments"
+					"name": "punctuation.definition.string.begin.json.lines"
 				}
 			},
 			"end": "\"",
 			"endCaptures": {
 				"0": {
-					"name": "punctuation.definition.string.end.json.comments"
+					"name": "punctuation.definition.string.end.json.lines"
 				}
 			},
-			"name": "string.quoted.double.json.comments",
+			"name": "string.quoted.double.json.lines",
 			"patterns": [
 				{
 					"include": "#stringcontent"
@@ -159,16 +159,16 @@
 			"begin": "\"",
 			"beginCaptures": {
 				"0": {
-					"name": "punctuation.support.type.property-name.begin.json.comments"
+					"name": "punctuation.support.type.property-name.begin.json.lines"
 				}
 			},
 			"end": "\"",
 			"endCaptures": {
 				"0": {
-					"name": "punctuation.support.type.property-name.end.json.comments"
+					"name": "punctuation.support.type.property-name.end.json.lines"
 				}
 			},
-			"name": "string.json.comments support.type.property-name.json.comments",
+			"name": "string.json.lines support.type.property-name.json.lines",
 			"patterns": [
 				{
 					"include": "#stringcontent"
@@ -179,11 +179,11 @@
 			"patterns": [
 				{
 					"match": "(?x)                # turn on extended mode\n  \\\\                # a literal backslash\n  (?:               # ...followed by...\n    [\"\\\\/bfnrt]     # one of these characters\n    |               # ...or...\n    u               # a u\n    [0-9a-fA-F]{4}) # and four hex digits",
-					"name": "constant.character.escape.json.comments"
+					"name": "constant.character.escape.json.lines"
 				},
 				{
 					"match": "\\\\.",
-					"name": "invalid.illegal.unrecognized-string-escape.json.comments"
+					"name": "invalid.illegal.unrecognized-string-escape.json.lines"
 				}
 			]
 		},

--- a/extensions/theme-seti/build/update-icon-theme.js
+++ b/extensions/theme-seti/build/update-icon-theme.js
@@ -44,6 +44,7 @@ const nonBuiltInLanguages = { // { fileNames, extensions  }
 // list of languagesId that inherit the icon from another language
 const inheritIconFromLanguage = {
 	"jsonc": 'json',
+	"jsonl": 'json',
 	"postcss": 'css',
 	"django-html": 'html',
 	"blade": 'php'

--- a/extensions/theme-seti/icons/vs-seti-icon-theme.json
+++ b/extensions/theme-seti/icons/vs-seti-icon-theme.json
@@ -1943,6 +1943,7 @@
 		"todo": "_todo",
 		"vala": "_vala",
 		"vue": "_vue",
+		"jsonl": "_json",
 		"postcss": "_css",
 		"django-html": "_html_3",
 		"blade": "_php"
@@ -2257,6 +2258,7 @@
 			"terraform": "_terraform_light",
 			"vala": "_vala_light",
 			"vue": "_vue_light",
+			"jsonl": "_json_light",
 			"postcss": "_css_light",
 			"django-html": "_html_3_light",
 			"blade": "_php_light"


### PR DESCRIPTION
Part of https://github.com/microsoft/vscode/issues/182402

This PR adds `JSON Lines` language definition with id `jsonl`. It doesn't add fancy language features, just basic colorization. But even this makes a great difference when viewing  `.jsonl` files.

Looks like this:
![Code_-_OSS_NcXK3eUR8q](https://github.com/microsoft/vscode/assets/70431552/a1b2c4d0-7023-40e0-a685-28980b80c3da)

![Code_-_OSS_EPJlBdN13F](https://github.com/microsoft/vscode/assets/70431552/024083af-361f-472f-9f81-f5683a901ebe)