### PR TITLE
Fix #183076. Restore editor focus only if the DOM focus is inside the editor widget.

### DIFF
--- a/src/vs/workbench/contrib/interactiveEditor/browser/interactiveEditorController.ts
+++ b/src/vs/workbench/contrib/interactiveEditor/browser/interactiveEditorController.ts
@@ -555,7 +555,11 @@ export class InteractiveEditorController implements IEditorContribution {
 		this._ctxLastFeedbackKind.reset();
 
 		this._zone.hide();
-		this._editor.focus();
+
+		// Return focus to the editor only if the current focus is within the editor widget
+		if (this._editor.hasWidgetFocus()) {
+			this._editor.focus();
+		}
 
 		this._sessionStore?.dispose();
 		this._sessionStore = undefined;


### PR DESCRIPTION
Only restore the focus back to the editor if the DOM focus is still inside the same editor, otherwise wrong editor gets focused when its internal inline chat widget gets disposed/hidden.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
