### PR TITLE
Fix AccessibleBufferContribution.ID typo

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/accessibility/browser/terminal.accessibility.contribution.ts
+++ b/src/vs/workbench/contrib/terminalContrib/accessibility/browser/terminal.accessibility.contribution.ts
@@ -24,7 +24,7 @@ import { AccessibleBufferWidget, NavigationType } from 'vs/workbench/contrib/ter
 import { Terminal } from 'xterm';
 
 class AccessibleBufferContribution extends DisposableStore implements ITerminalContribution {
-	static readonly ID: 'terminal.accessible-buffer';
+	static readonly ID = 'terminal.accessible-buffer';
 	static get(instance: ITerminalInstance): AccessibleBufferContribution | null {
 		return instance.getContribution<AccessibleBufferContribution>(AccessibleBufferContribution.ID);
 	}


### PR DESCRIPTION
It was registering the contribution with `undefined` as id

cc @meganrogge 
