### PR TITLE
Fix cannot hide terminal find widget when pressing `esc`

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminal.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminal.ts
@@ -2,7 +2,7 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import { Dimension } from 'vs/base/browser/dom';
+import { IDimension } from 'vs/base/browser/dom';
 import { Orientation } from 'vs/base/browser/ui/splitview/splitview';
 import { Color } from 'vs/base/common/color';
 import { Event } from 'vs/base/common/event';
@@ -37,7 +37,7 @@ export const ITerminalInstanceService = createDecorator<ITerminalInstanceService
  * been initialized.
  */
 export interface ITerminalContribution extends IDisposable {
-	layout?(xterm: IXtermTerminal & { raw: RawXtermTerminal }): void;
+	layout?(xterm: IXtermTerminal & { raw: RawXtermTerminal }, dimension: IDimension): void;
 	xtermReady?(xterm: IXtermTerminal & { raw: RawXtermTerminal }): void;
 }
 
@@ -434,7 +434,7 @@ export interface ITerminalInstance {
 	readonly maxRows: number;
 	readonly fixedCols?: number;
 	readonly fixedRows?: number;
-	readonly container?: HTMLElement;
+	readonly domElement: HTMLElement;
 	readonly icon?: TerminalIcon;
 	readonly color?: string;
 	readonly reconnectionProperties?: IReconnectionProperties;
@@ -937,22 +937,9 @@ export interface ITerminalInstance {
 	resetScrollbarVisibility(): void;
 
 	/**
-	 * Register a child element to the terminal instance's container.
-	 */
-	registerChildElement(element: ITerminalChildElement): IDisposable;
-
-	/**
 	 * Gets a terminal contribution by its ID.
 	 */
 	getContribution<T extends ITerminalContribution>(id: string): T | null;
-}
-
-// NOTE: This interface is very similar to the widget manager internal to TerminalInstance, in the
-// future these should probably be consolidated.
-export interface ITerminalChildElement {
-	element: HTMLElement;
-	layout?(dimension: Dimension): void;
-	xtermReady?(xterm: IXtermTerminal): void;
 }
 
 export const enum XtermTerminalConstants {

--- a/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
@@ -17,7 +17,7 @@ import { ErrorNoTelemetry, onUnexpectedError } from 'vs/base/common/errors';
 import { Emitter, Event } from 'vs/base/common/event';
 import { KeyCode } from 'vs/base/common/keyCodes';
 import { ISeparator, template } from 'vs/base/common/labels';
-import { Disposable, DisposableStore, dispose, IDisposable, toDisposable } from 'vs/base/common/lifecycle';
+import { Disposable, dispose, IDisposable, toDisposable } from 'vs/base/common/lifecycle';
 import { Schemas } from 'vs/base/common/network';
 import * as path from 'vs/base/common/path';
 import { isMacintosh, isWindows, OperatingSystem, OS } from 'vs/base/common/platform';
@@ -53,7 +53,7 @@ import { IWorkspaceContextService, IWorkspaceFolder } from 'vs/platform/workspac
 import { IWorkspaceTrustRequestService } from 'vs/platform/workspace/common/workspaceTrust';
 import { IViewDescriptorService, IViewsService, ViewContainerLocation } from 'vs/workbench/common/views';
 import { TaskSettingId } from 'vs/workbench/contrib/tasks/common/tasks';
-import { IRequestAddInstanceToGroupEvent, ITerminalChildElement, ITerminalContribution, ITerminalInstance, TerminalDataTransfers } from 'vs/workbench/contrib/terminal/browser/terminal';
+import { IRequestAddInstanceToGroupEvent, ITerminalContribution, ITerminalInstance, TerminalDataTransfers } from 'vs/workbench/contrib/terminal/browser/terminal';
 import { TerminalLaunchHelpAction } from 'vs/workbench/contrib/terminal/browser/terminalActions';
 import { TerminalConfigHelper } from 'vs/workbench/contrib/terminal/browser/terminalConfigHelper';
 import { TerminalEditorInput } from 'vs/workbench/contrib/terminal/browser/terminalEditorInput';
@@ -163,8 +163,8 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 	private _title: string = '';
 	private _titleSource: TitleEventSource = TitleEventSource.Process;
 	private _container: HTMLElement | undefined;
-	get container(): HTMLElement | undefined { return this._container; }
 	private _wrapperElement: (HTMLElement & { xterm?: XTermTerminal });
+	get domElement(): HTMLElement { return this._wrapperElement; }
 	private _horizontalScrollbar: DomScrollableElement | undefined;
 	private _terminalFocusContextKey: IContextKey<boolean>;
 	private _terminalHasFixedWidth: IContextKey<boolean>;
@@ -334,12 +334,6 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 	readonly onRequestAddInstanceToGroup = this._onRequestAddInstanceToGroup.event;
 	private readonly _onDidChangeHasChildProcesses = this._register(new Emitter<boolean>());
 	readonly onDidChangeHasChildProcesses = this._onDidChangeHasChildProcesses.event;
-
-	// Internal events
-	private readonly _onDidAttachToElement = new Emitter<HTMLElement>();
-	private readonly _onDidAttachToElementEvent = this._onDidAttachToElement.event;
-	private readonly _onDidLayout = new Emitter<dom.Dimension>();
-	private readonly _onDidLayoutEvent = this._onDidLayout.event;
 
 	constructor(
 		private readonly _terminalShellTypeContextKey: IContextKey<string>,
@@ -871,7 +865,6 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 		// The container changed, reattach
 		this._container = container;
 		this._container.appendChild(this._wrapperElement);
-		this._onDidAttachToElement.fire(this._container);
 		this.xterm?.refresh();
 
 		setTimeout(() => this._initDragAndDrop(container));
@@ -1832,7 +1825,6 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 		}
 
 		this._resize();
-		this._onDidLayout.fire(dimension);
 
 		// Signal the container is ready
 		this._containerReadyBarrier.open();
@@ -1840,9 +1832,9 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 		// Layout all contributions
 		for (const contribution of this._contributions.values()) {
 			if (!this.xterm) {
-				this._xtermReadyPromise.then(xterm => contribution.layout?.(xterm));
+				this._xtermReadyPromise.then(xterm => contribution.layout?.(xterm, dimension));
 			} else {
-				contribution.layout?.(this.xterm);
+				contribution.layout?.(this.xterm, dimension);
 			}
 		}
 	}
@@ -2279,28 +2271,11 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 	}
 
 	forceScrollbarVisibility(): void {
-		this._container?.classList.add('force-scrollbar');
+		this._wrapperElement.classList.add('force-scrollbar');
 	}
 
 	resetScrollbarVisibility(): void {
-		this._container?.classList.remove('force-scrollbar');
-	}
-
-	registerChildElement(child: ITerminalChildElement): IDisposable {
-		const store = new DisposableStore();
-		if (this._container) {
-			this._container.appendChild(child.element);
-		} else {
-			store.add(this._onDidAttachToElementEvent(container => container.appendChild(child.element)));
-		}
-		if (this._lastLayoutDimensions) {
-			child.layout?.(this._lastLayoutDimensions);
-		}
-		store.add(this._onDidLayoutEvent(e => child.layout?.(e)));
-		if (child.xtermReady) {
-			this._xtermReadyPromise.then(xterm => child.xtermReady!(xterm));
-		}
-		return store;
+		this._wrapperElement.classList.remove('force-scrollbar');
 	}
 }
 

--- a/src/vs/workbench/contrib/terminalContrib/find/browser/terminal.find.contribution.ts
+++ b/src/vs/workbench/contrib/terminalContrib/find/browser/terminal.find.contribution.ts
@@ -38,26 +38,26 @@ class TerminalFindContribution extends Disposable implements ITerminalContributi
 		private readonly _instance: ITerminalInstance,
 		processManager: ITerminalProcessManager,
 		widgetManager: TerminalWidgetManager,
-		@IInstantiationService readonly _instantiationService: IInstantiationService,
-		@ITerminalService readonly _terminalService: ITerminalService
+		@IInstantiationService instantiationService: IInstantiationService,
+		@ITerminalService terminalService: ITerminalService
 	) {
 		super();
 
 		this._findWidget = new Lazy(() => {
-			const findWidget = this._instantiationService.createInstance(TerminalFindWidget, _instance);
+			const findWidget = instantiationService.createInstance(TerminalFindWidget, this._instance);
 
 			// Track focus and set state so we can force the scroll bar to be visible
 			findWidget.focusTracker.onDidFocus(() => {
 				this._focusState = true;
-				_instance.forceScrollbarVisibility();
-				_terminalService.setActiveInstance(_instance);
+				this._instance.forceScrollbarVisibility();
+				terminalService.setActiveInstance(this._instance);
 			});
 			findWidget.focusTracker.onDidBlur(() => {
 				this._focusState = false;
-				_instance.resetScrollbarVisibility();
+				this._instance.resetScrollbarVisibility();
 			});
 
-			_instance.domElement.appendChild(findWidget.getDomNode());
+			this._instance.domElement.appendChild(findWidget.getDomNode());
 			if (this._lastLayoutDimensions) {
 				findWidget.layout(this._lastLayoutDimensions.width);
 			}
@@ -98,7 +98,7 @@ registerActiveInstanceAction({
 	},
 	precondition: ContextKeyExpr.or(TerminalContextKeys.processSupported, TerminalContextKeys.terminalHasBeenCreated),
 	run: (activeInstance) => {
-		TerminalFindContribution.get(activeInstance)?.findWidget?.reveal();
+		TerminalFindContribution.get(activeInstance)?.findWidget.reveal();
 	}
 });
 
@@ -113,7 +113,7 @@ registerActiveInstanceAction({
 	},
 	precondition: ContextKeyExpr.or(TerminalContextKeys.processSupported, TerminalContextKeys.terminalHasBeenCreated),
 	run: (activeInstance) => {
-		TerminalFindContribution.get(activeInstance)?.findWidget?.hide();
+		TerminalFindContribution.get(activeInstance)?.findWidget.hide();
 	}
 });
 
@@ -128,10 +128,8 @@ registerActiveInstanceAction({
 	},
 	precondition: ContextKeyExpr.or(TerminalContextKeys.processSupported, TerminalContextKeys.terminalHasBeenCreated),
 	run: (activeInstance) => {
-		const state = TerminalFindContribution.get(activeInstance)?.findWidget?.state;
-		if (state) {
-			state.change({ matchCase: !state.isRegex }, false);
-		}
+		const state = TerminalFindContribution.get(activeInstance)?.findWidget.state;
+		state?.change({ matchCase: !state.isRegex }, false);
 	}
 });
 
@@ -146,10 +144,8 @@ registerActiveInstanceAction({
 	},
 	precondition: ContextKeyExpr.or(TerminalContextKeys.processSupported, TerminalContextKeys.terminalHasBeenCreated),
 	run: (activeInstance) => {
-		const state = TerminalFindContribution.get(activeInstance)?.findWidget?.state;
-		if (state) {
-			state.change({ matchCase: !state.wholeWord }, false);
-		}
+		const state = TerminalFindContribution.get(activeInstance)?.findWidget.state;
+		state?.change({ matchCase: !state.wholeWord }, false);
 	}
 });
 
@@ -164,10 +160,8 @@ registerActiveInstanceAction({
 	},
 	precondition: ContextKeyExpr.or(TerminalContextKeys.processSupported, TerminalContextKeys.terminalHasBeenCreated),
 	run: (activeInstance) => {
-		const state = TerminalFindContribution.get(activeInstance)?.findWidget?.state;
-		if (state) {
-			state.change({ matchCase: !state.matchCase }, false);
-		}
+		const state = TerminalFindContribution.get(activeInstance)?.findWidget.state;
+		state?.change({ matchCase: !state.matchCase }, false);
 	}
 });
 

--- a/src/vs/workbench/contrib/terminalContrib/find/browser/terminal.find.contribution.ts
+++ b/src/vs/workbench/contrib/terminalContrib/find/browser/terminal.find.contribution.ts
@@ -30,7 +30,6 @@ class TerminalFindContribution extends Disposable implements ITerminalContributi
 
 	private _findWidget: Lazy<TerminalFindWidget>;
 	private _lastLayoutDimensions: IDimension | undefined;
-	private _focusState: boolean = false;
 
 	get findWidget(): TerminalFindWidget { return this._findWidget.value; }
 
@@ -48,12 +47,10 @@ class TerminalFindContribution extends Disposable implements ITerminalContributi
 
 			// Track focus and set state so we can force the scroll bar to be visible
 			findWidget.focusTracker.onDidFocus(() => {
-				this._focusState = true;
 				this._instance.forceScrollbarVisibility();
 				terminalService.setActiveInstance(this._instance);
 			});
 			findWidget.focusTracker.onDidBlur(() => {
-				this._focusState = false;
 				this._instance.resetScrollbarVisibility();
 			});
 
@@ -77,12 +74,7 @@ class TerminalFindContribution extends Disposable implements ITerminalContributi
 
 	override dispose() {
 		super.dispose();
-
-		const focusTerminal = this._focusState;
 		this._findWidget.rawValue?.dispose();
-		if (focusTerminal) {
-			this._instance.focus();
-		}
 	}
 
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
Fixes #183087

Before, find contribution was using the global contextService so context keys values were incorrect, convert to a proper terminal contribution so the terminal instance scoped contextService is used instead.

cc @Tyriar 