### PR TITLE
Eager `getResolvedShellEnv` call (fix #183069)

### DIFF
--- a/src/vs/platform/terminal/node/ptyHostService.ts
+++ b/src/vs/platform/terminal/node/ptyHostService.ts
@@ -55,7 +55,6 @@ export class PtyHostService extends Disposable implements IPtyService {
 		}
 	}
 
-	private readonly _shellEnv: Promise<typeof process.env>;
 	private readonly _resolveVariablesRequestStore: RequestStore<string[], { workspaceId: string; originalText: string[] }>;
 	private _wasQuitRequested = false;
 	private _restartCount = 0;
@@ -101,8 +100,6 @@ export class PtyHostService extends Disposable implements IPtyService {
 		// Platform configuration is required on the process running the pty host (shared process or
 		// remote server).
 		registerTerminalPlatformConfiguration();
-
-		this._shellEnv = this._resolveShellEnv();
 
 		this._register(toDisposable(() => this._disposePtyHost()));
 
@@ -287,7 +284,7 @@ export class PtyHostService extends Disposable implements IPtyService {
 		return this._proxy.getDefaultSystemShell(osOverride);
 	}
 	async getProfiles(workspaceId: string, profiles: unknown, defaultProfile: unknown, includeDetectedProfiles: boolean = false): Promise<ITerminalProfile[]> {
-		const shellEnv = await this._shellEnv;
+		const shellEnv = await this._resolveShellEnv();
 		return detectAvailableProfiles(profiles, defaultProfile, includeDetectedProfiles, this._configurationService, shellEnv, undefined, this._logService, this._resolveVariables.bind(this, workspaceId));
 	}
 	getEnvironment(): Promise<IProcessEnvironment> {


### PR DESCRIPTION
The call is no longer cached but we already cache the expensive part here:

https://github.com/microsoft/vscode/blob/d780f60ac8923aafe1616ab2e9148fb75a23238d/src/vs/platform/shell/node/shellEnv.ts#L63-L67

So I think this is fine.