### PR TITLE
Custom File Explorer Order

### DIFF
--- a/src/vs/workbench/contrib/files/browser/explorerService.ts
+++ b/src/vs/workbench/contrib/files/browser/explorerService.ts
@@ -146,6 +146,10 @@ export class ExplorerService implements IExplorerService {
 		return this.model.roots;
 	}
 
+	get customOrder(): String[] {
+		return this.config.customOrder;
+	}
+
 	get sortOrderConfiguration(): ISortOrderConfiguration {
 		return {
 			sortOrder: this.config.sortOrder,

--- a/src/vs/workbench/contrib/files/browser/files.contribution.ts
+++ b/src/vs/workbench/contrib/files/browser/files.contribution.ts
@@ -477,6 +477,14 @@ configurationRegistry.registerConfiguration({
 			],
 			'markdownDescription': nls.localize('sortOrder', "Controls the property-based sorting of files and folders in the Explorer. When `#explorer.fileNesting.enabled#` is enabled, also controls sorting of nested files.")
 		},
+		'explorer.customOrder': {
+			'type': 'array',
+			'items': {
+				'type': 'string'
+			},
+			'default': [],
+			'markdownDescription': nls.localize('customOrder', "Files and folders matching the list will be displayed first, while the rest will be sorted by `#explorer.sortOrder#`.")
+		},
 		'explorer.sortOrderLexicographicOptions': {
 			'type': 'string',
 			'enum': [LexicographicOptions.Default, LexicographicOptions.Upper, LexicographicOptions.Lower, LexicographicOptions.Unicode],

--- a/src/vs/workbench/contrib/files/browser/files.ts
+++ b/src/vs/workbench/contrib/files/browser/files.ts
@@ -22,6 +22,7 @@ export interface IExplorerService {
 	readonly _serviceBrand: undefined;
 	readonly roots: ExplorerItem[];
 	readonly sortOrderConfiguration: ISortOrderConfiguration;
+	readonly customOrder: String[];
 
 	getContext(respectMultiSelection: boolean, ignoreNestedChildren?: boolean): ExplorerItem[];
 	hasViewFocus(): boolean;

--- a/src/vs/workbench/contrib/files/browser/views/explorerViewer.ts
+++ b/src/vs/workbench/contrib/files/browser/views/explorerViewer.ts
@@ -930,7 +930,25 @@ export class FileSorter implements ITreeSorter<ExplorerItem> {
 		}
 
 		const sortOrder = this.explorerService.sortOrderConfiguration.sortOrder;
+		const customOrder = this.explorerService.customOrder;
 		const lexicographicOptions = this.explorerService.sortOrderConfiguration.lexicographicOptions;
+
+		// Override sort if a custom order is defined
+		const isStatACustom = customOrder.includes(statA.name);
+		const isStatBCustom = customOrder.includes(statB.name);
+
+		if (isStatACustom && !isStatBCustom) {
+			return -1;
+		}
+
+		if (isStatBCustom && !isStatACustom) {
+			return 1;
+		}
+
+		if (isStatACustom && isStatBCustom) {
+			return customOrder.indexOf(statA.name) < customOrder.indexOf(statB.name) ? -1 : 1;
+		}
+
 
 		let compareFileNames;
 		let compareFileExtensions;

--- a/src/vs/workbench/contrib/files/common/files.ts
+++ b/src/vs/workbench/contrib/files/common/files.ts
@@ -96,6 +96,7 @@ export interface IFilesConfiguration extends PlatformIFilesConfiguration, IWorkb
 		confirmUndo: UndoConfirmLevel;
 		expandSingleFolderWorkspaces: boolean;
 		sortOrder: SortOrder;
+		customOrder: String[];
 		sortOrderLexicographicOptions: LexicographicOptions;
 		decorations: {
 			colors: boolean;


### PR DESCRIPTION
This PR addresses one of the issues from #27286 and fixes #25724.

This new configuration provides users with enhanced control over their coding environment. By utilizing this feature, developers can customize the organization of their file explorer based on their preferences. Files and folders matching the specified list will be displayed with priority, following the specified order.

This functionality enables developers to navigate their codebase more efficiently by tailoring the file explorer to suit their individual workflows. Whether it's prioritizing specific files, focusing on particular folders, or grouping related elements together, users have the flexibility to optimize their coding experience.

To test it, just go to Settings (File → Preferences → Settings) and search for: explorer.customOrder. Add file or folders names to the list and see them go to the top of their directory.