### PR TITLE
Pass custom options for `input` dialogs

### DIFF
--- a/src/vs/workbench/browser/parts/dialogs/dialogHandler.ts
+++ b/src/vs/workbench/browser/parts/dialogs/dialogHandler.ts
@@ -70,7 +70,7 @@ export class BrowserDialogHandler extends AbstractDialogHandler {
 
 		const buttons = this.getInputButtons(input);
 
-		const { button, checkboxChecked, values } = await this.doShow(input.type ?? 'question', input.message, buttons, input.detail, buttons.length - 1, input?.checkbox, input.inputs, typeof input.custom !== 'boolean' ? input.custom : undefined);
+		const { button, checkboxChecked, values } = await this.doShow(input.type ?? 'question', input.message, buttons, input.detail, buttons.length - 1, input?.checkbox, input.inputs, typeof input.custom === 'object' ? input.custom : undefined);
 
 		return { confirmed: button === 0, checkboxChecked, values };
 	}

--- a/src/vs/workbench/browser/parts/dialogs/dialogHandler.ts
+++ b/src/vs/workbench/browser/parts/dialogs/dialogHandler.ts
@@ -70,7 +70,7 @@ export class BrowserDialogHandler extends AbstractDialogHandler {
 
 		const buttons = this.getInputButtons(input);
 
-		const { button, checkboxChecked, values } = await this.doShow(input.type ?? 'question', input.message, buttons, input.detail, buttons.length - 1, input?.checkbox, input.inputs);
+		const { button, checkboxChecked, values } = await this.doShow(input.type ?? 'question', input.message, buttons, input.detail, buttons.length - 1, input?.checkbox, input.inputs, typeof input.custom !== 'boolean' ? input.custom : undefined);
 
 		return { confirmed: button === 0, checkboxChecked, values };
 	}


### PR DESCRIPTION
Currently custom options are dropped for `input` dialogs, this ensures they're passed through to the created `Dialog` instance.