### PR TITLE
Change chat view container name to "Chat", mainly so that the word Chat ends up in the autogenerated "focus" command name

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatContributionServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContributionServiceImpl.ts
@@ -116,7 +116,7 @@ export class ChatContributionService implements IChatContributionService {
 		const viewContainerId = CHAT_SIDEBAR_PANEL_ID + '.' + providerDescriptor.id;
 		const viewContainer: ViewContainer = Registry.as<IViewContainersRegistry>(ViewExtensions.ViewContainersRegistry).registerViewContainer({
 			id: viewContainerId,
-			title: providerDescriptor.label,
+			title: localize('chat.viewContainer.label', "Chat"),
 			icon: providerDescriptor.icon ? resources.joinPath(extension.extensionLocation, providerDescriptor.icon) : Codicon.commentDiscussion,
 			ctorDescriptor: new SyncDescriptor(ViewPaneContainer, [viewContainerId, { mergeViewWithContainerWhenSingleView: true }]),
 			storageId: viewContainerId,


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
