### PR TITLE
Fix restoration of problems (from watch task) when closing a file

### DIFF
--- a/src/vs/workbench/contrib/tasks/common/problemCollectors.ts
+++ b/src/vs/workbench/contrib/tasks/common/problemCollectors.ts
@@ -446,6 +446,7 @@ export class WatchingProblemCollector extends AbstractProblemCollector implement
 					for (const line of oldLines) {
 						await this.processLineInternal(line);
 					}
+					this.forceDelivery();
 				});
 			setTimeout(async () => {
 				markerChanged?.dispose();


### PR DESCRIPTION
Fixes #47386

Logic was added in https://github.com/microsoft/vscode/commit/df97bc32ada631730715bf97163cf981a3ec6ec0 to add a watcher's problems back to the problems view after closing a file.

~~It doesn't work quite right though because of how `processLineInternal` batches up changes, only sending them to `markerService` when it gets called on subsequent lines with a different owner or resource.~~

Because of that, the current behavior is that when you close a file with errors, the errors will disappear and only end up getting restored the next time a different file being watched gets saved.

This PR fixes that (restoring the errors right after the file is closed) by calling `forceDelivery()`.

cc @alexr00 