### PR TITLE
fixed tab sizing: restore tab widths when the last tab is closed

### DIFF
--- a/src/vs/workbench/browser/parts/editor/editorGroupView.ts
+++ b/src/vs/workbench/browser/parts/editor/editorGroupView.ts
@@ -1335,30 +1335,29 @@ export class EditorGroupView extends Themable implements IEditorGroupView {
 	}
 
 	private doCloseEditor(editor: EditorInput, focusNext = (this.accessor.activeGroup === this), internalOptions?: IInternalEditorCloseOptions): void {
-		let index: number | undefined;
 
 		// Forward to title control unless skipped via internal options
 		if (!internalOptions?.skipTitleUpdate) {
-			this.titleAreaControl.beforeCloseEditor(editor, index);
+			this.titleAreaControl.beforeCloseEditor(editor);
 		}
 
 		// Closing the active editor of the group is a bit more work
 		if (this.model.isActive(editor)) {
-			index = this.doCloseActiveEditor(focusNext, internalOptions);
+			this.doCloseActiveEditor(focusNext, internalOptions);
 		}
 
 		// Closing inactive editor is just a model update
 		else {
-			index = this.doCloseInactiveEditor(editor, internalOptions);
+			this.doCloseInactiveEditor(editor, internalOptions);
 		}
 
 		// Forward to title control unless skipped via internal options
 		if (!internalOptions?.skipTitleUpdate) {
-			this.titleAreaControl.closeEditor(editor, index);
+			this.titleAreaControl.closeEditor(editor);
 		}
 	}
 
-	private doCloseActiveEditor(focusNext = (this.accessor.activeGroup === this), internalOptions?: IInternalEditorCloseOptions): number | undefined {
+	private doCloseActiveEditor(focusNext = (this.accessor.activeGroup === this), internalOptions?: IInternalEditorCloseOptions): void {
 		const editorToClose = this.activeEditor;
 		const restoreFocus = this.shouldRestoreFocus(this.element);
 
@@ -1383,9 +1382,8 @@ export class EditorGroupView extends Themable implements IEditorGroupView {
 		}
 
 		// Update model
-		let index: number | undefined = undefined;
 		if (editorToClose) {
-			index = this.model.closeEditor(editorToClose, internalOptions?.context)?.editorIndex;
+			this.model.closeEditor(editorToClose, internalOptions?.context);
 		}
 
 		// Open next active if there are more to show
@@ -1437,8 +1435,6 @@ export class EditorGroupView extends Themable implements IEditorGroupView {
 				this.accessor.removeGroup(this);
 			}
 		}
-
-		return index;
 	}
 
 	private shouldRestoreFocus(target: Element): boolean {
@@ -1452,10 +1448,10 @@ export class EditorGroupView extends Themable implements IEditorGroupView {
 		return isAncestor(activeElement, target);
 	}
 
-	private doCloseInactiveEditor(editor: EditorInput, internalOptions?: IInternalEditorCloseOptions): number | undefined {
+	private doCloseInactiveEditor(editor: EditorInput, internalOptions?: IInternalEditorCloseOptions): void {
 
 		// Update model
-		return this.model.closeEditor(editor, internalOptions?.context)?.editorIndex;
+		this.model.closeEditor(editor, internalOptions?.context);
 	}
 
 	private async handleCloseConfirmation(editors: EditorInput[]): Promise<boolean /* veto */> {

--- a/src/vs/workbench/browser/parts/editor/noTabsTitleControl.ts
+++ b/src/vs/workbench/browser/parts/editor/noTabsTitleControl.ts
@@ -143,11 +143,11 @@ export class NoTabsTitleControl extends TitleControl {
 		}
 	}
 
-	beforeCloseEditor(): void {
+	beforeCloseEditor(editor: EditorInput): void {
 		// Nothing to do before closing an editor
 	}
 
-	closeEditor(editor: EditorInput, index: number | undefined): void {
+	closeEditor(editor: EditorInput): void {
 		this.ifActiveEditorChanged(() => this.redraw());
 	}
 

--- a/src/vs/workbench/browser/parts/editor/tabsTitleControl.ts
+++ b/src/vs/workbench/browser/parts/editor/tabsTitleControl.ts
@@ -557,15 +557,16 @@ export class TabsTitleControl extends TitleControl {
 			labelA.ariaLabel === labelB.ariaLabel;
 	}
 
-	beforeCloseEditor(): void {
+	beforeCloseEditor(editor: EditorInput): void {
 
-		// Fix tabs width if the mouse is over tabs and
-		// before closing a tab when tab sizing is 'fixed'.
+		// Fix tabs width if the mouse is over tabs and before closing
+		// a tab (except the last tab) when tab sizing is 'fixed'.
 		// This helps keeping the close button stable under
 		// the mouse and allows for rapid closing of tabs.
 
 		if (this.isMouseOverTabs && this.accessor.partOptions.tabSizing === 'fixed') {
-			this.updateTabsFixedWidth(true);
+			const closingLastTab = this.group.editors.at(-1) === editor;
+			this.updateTabsFixedWidth(!closingLastTab);
 		}
 	}
 

--- a/src/vs/workbench/browser/parts/editor/tabsTitleControl.ts
+++ b/src/vs/workbench/browser/parts/editor/tabsTitleControl.ts
@@ -565,7 +565,7 @@ export class TabsTitleControl extends TitleControl {
 		// the mouse and allows for rapid closing of tabs.
 
 		if (this.isMouseOverTabs && this.accessor.partOptions.tabSizing === 'fixed') {
-			const closingLastTab = this.group.editors.at(-1) === editor;
+			const closingLastTab = this.group.isLast(editor);
 			this.updateTabsFixedWidth(!closingLastTab);
 		}
 	}

--- a/src/vs/workbench/browser/parts/editor/tabsTitleControl.ts
+++ b/src/vs/workbench/browser/parts/editor/tabsTitleControl.ts
@@ -570,15 +570,15 @@ export class TabsTitleControl extends TitleControl {
 		}
 	}
 
-	closeEditor(editor: EditorInput, index: number | undefined): void {
-		this.handleClosedEditors(index);
+	closeEditor(editor: EditorInput): void {
+		this.handleClosedEditors();
 	}
 
 	closeEditors(editors: EditorInput[]): void {
 		this.handleClosedEditors();
 	}
 
-	private handleClosedEditors(index?: number): void {
+	private handleClosedEditors(): void {
 
 		// There are tabs to show
 		if (this.group.activeEditor) {

--- a/src/vs/workbench/browser/parts/editor/titleControl.ts
+++ b/src/vs/workbench/browser/parts/editor/titleControl.ts
@@ -418,9 +418,9 @@ export abstract class TitleControl extends Themable {
 
 	abstract openEditors(editors: EditorInput[]): void;
 
-	abstract beforeCloseEditor(editor: EditorInput, index: number | undefined): void;
+	abstract beforeCloseEditor(editor: EditorInput): void;
 
-	abstract closeEditor(editor: EditorInput, index: number | undefined): void;
+	abstract closeEditor(editor: EditorInput): void;
 
 	abstract closeEditors(editors: EditorInput[]): void;
 


### PR DESCRIPTION
This is meant to address a forgotten case in #40290 that wasn't addressed in #181729: when the last tab is closed, there is no more reason to hold the tabs at fixed length. This behaviour is consistent with Chrome and Safari.

For illustration, here's a before and after:

![2023-05-22 23 05 49](https://github.com/microsoft/vscode/assets/807315/7fdfcf71-4e51-4beb-8437-8c6ea82125a2)

![2023-05-22 23 05 18](https://github.com/microsoft/vscode/assets/807315/77fae313-e3be-4b0d-88af-94fcb327d07d)

(my cursor is huge and the recording software misplaced it, but it was right over the close icons)

cc @bpasero 