### PR TITLE
GitHub - use GitHub default branch name when publishing to GitHub

### DIFF
--- a/extensions/git/src/api/api1.ts
+++ b/extensions/git/src/api/api1.ts
@@ -5,7 +5,7 @@
 
 import { Model } from '../model';
 import { Repository as BaseRepository, Resource } from '../repository';
-import { InputBox, Git, API, Repository, Remote, RepositoryState, Branch, ForcePushMode, Ref, Submodule, Commit, Change, RepositoryUIState, Status, LogOptions, APIState, CommitOptions, RefType, CredentialsProvider, BranchQuery, PushErrorHandler, PublishEvent, FetchOptions, RemoteSourceProvider, RemoteSourcePublisher, PostCommitCommandsProvider, RefQuery, BranchProtectionProvider } from './git';
+import { InputBox, Git, API, Repository, Remote, RepositoryState, Branch, ForcePushMode, Ref, Submodule, Commit, Change, RepositoryUIState, Status, LogOptions, APIState, CommitOptions, RefType, CredentialsProvider, BranchQuery, PushErrorHandler, PublishEvent, FetchOptions, RemoteSourceProvider, RemoteSourcePublisher, PostCommitCommandsProvider, RefQuery, BranchProtectionProvider, InitOptions } from './git';
 import { Event, SourceControlInputBox, Uri, SourceControl, Disposable, commands, CancellationToken } from 'vscode';
 import { combinedDisposable, mapEvent } from '../util';
 import { toGitUri } from '../uri';
@@ -294,9 +294,9 @@ export class ApiImpl implements API {
 		return result ? new ApiRepository(result) : null;
 	}
 
-	async init(root: Uri): Promise<Repository | null> {
+	async init(root: Uri, options?: InitOptions): Promise<Repository | null> {
 		const path = root.fsPath;
-		await this._model.git.init(path);
+		await this._model.git.init(path, options);
 		await this._model.openRepository(path);
 		return this.getRepository(root) || null;
 	}

--- a/extensions/git/src/api/git.d.ts
+++ b/extensions/git/src/api/git.d.ts
@@ -156,6 +156,10 @@ export interface FetchOptions {
 	depth?: number;
 }
 
+export interface InitOptions {
+	defaultBranch?: string;
+}
+
 export interface RefQuery {
 	readonly contains?: string;
 	readonly count?: number;
@@ -307,7 +311,7 @@ export interface API {
 
 	toGitUri(uri: Uri, ref: string): Uri;
 	getRepository(uri: Uri): Repository | null;
-	init(root: Uri): Promise<Repository | null>;
+	init(root: Uri, options?: InitOptions): Promise<Repository | null>;
 	openRepository(root: Uri): Promise<Repository | null>
 
 	registerRemoteSourcePublisher(publisher: RemoteSourcePublisher): Disposable;

--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -15,7 +15,7 @@ import * as filetype from 'file-type';
 import { assign, groupBy, IDisposable, toDisposable, dispose, mkdirp, readBytes, detectUnicodeEncoding, Encoding, onceEvent, splitInChunks, Limiter, Versions, isWindows, pathEquals } from './util';
 import { CancellationError, CancellationToken, ConfigurationChangeEvent, LogOutputChannel, Progress, Uri, workspace } from 'vscode';
 import { detectEncoding } from './encoding';
-import { Ref, RefType, Branch, Remote, ForcePushMode, GitErrorCodes, LogOptions, Change, Status, CommitOptions, RefQuery } from './api/git';
+import { Ref, RefType, Branch, Remote, ForcePushMode, GitErrorCodes, LogOptions, Change, Status, CommitOptions, RefQuery, InitOptions } from './api/git';
 import * as byline from 'byline';
 import { StringDecoder } from 'string_decoder';
 
@@ -401,7 +401,7 @@ export class Git {
 		return new Repository(this, repository, dotGit, logger);
 	}
 
-	async init(repository: string, options: { defaultBranch?: string } = {}): Promise<void> {
+	async init(repository: string, options: InitOptions = {}): Promise<void> {
 		const args = ['init'];
 
 		if (options.defaultBranch && options.defaultBranch !== '') {

--- a/extensions/github/src/publish.ts
+++ b/extensions/github/src/publish.ts
@@ -190,7 +190,7 @@ export async function publishRepository(gitAPI: GitAPI, repository?: Repository)
 			progress.report({ message: vscode.l10n.t('Creating first commit'), increment: 25 });
 
 			if (!repository) {
-				repository = await gitAPI.init(folder) || undefined;
+				repository = await gitAPI.init(folder, { defaultBranch: createdGithubRepository.default_branch }) || undefined;
 
 				if (!repository) {
 					return;

--- a/extensions/github/src/typings/git.d.ts
+++ b/extensions/github/src/typings/git.d.ts
@@ -156,6 +156,10 @@ export interface FetchOptions {
 	depth?: number;
 }
 
+export interface InitOptions {
+	defaultBranch?: string;
+}
+
 export interface BranchQuery {
 	readonly remote?: boolean;
 	readonly pattern?: string;
@@ -301,7 +305,7 @@ export interface API {
 
 	toGitUri(uri: Uri, ref: string): Uri;
 	getRepository(uri: Uri): Repository | null;
-	init(root: Uri): Promise<Repository | null>;
+	init(root: Uri, options?: InitOptions): Promise<Repository | null>;
 	openRepository(root: Uri): Promise<Repository | null>
 
 	registerRemoteSourcePublisher(publisher: RemoteSourcePublisher): Disposable;


### PR DESCRIPTION
Fixes #183158