### PR TITLE
Add embedder API for creating simple readonly terminals

### DIFF
--- a/src/vs/platform/instantiation/common/extensions.ts
+++ b/src/vs/platform/instantiation/common/extensions.ts
@@ -10,7 +10,7 @@ const _registry: [ServiceIdentifier<any>, SyncDescriptor<any>][] = [];
 
 export const enum InstantiationType {
 	/**
-	 * Instantiate this service as soon as a consumer depdends on it. _Note_ that this
+	 * Instantiate this service as soon as a consumer depends on it. _Note_ that this
 	 * is more costly as some upfront work is done that is likely not needed
 	 */
 	Eager = 0,

--- a/src/vs/workbench/browser/web.api.ts
+++ b/src/vs/workbench/browser/web.api.ts
@@ -17,6 +17,7 @@ import type { TunnelProviderFeatures } from 'vs/platform/tunnel/common/tunnel';
 import type { IProgress, IProgressCompositeOptions, IProgressDialogOptions, IProgressNotificationOptions, IProgressOptions, IProgressStep, IProgressWindowOptions } from 'vs/platform/progress/common/progress';
 import type { ITextEditorOptions } from 'vs/platform/editor/common/editor';
 import type { EditorGroupLayout } from 'vs/workbench/services/editor/common/editorGroupsService';
+import { IEmbedderTerminalOptions } from 'vs/workbench/services/terminal/common/embedderTerminalService';
 
 /**
  * The `IWorkbench` interface is the API facade for web embedders
@@ -90,6 +91,17 @@ export interface IWorkbench {
 			options: IProgressOptions | IProgressDialogOptions | IProgressNotificationOptions | IProgressWindowOptions | IProgressCompositeOptions,
 			task: (progress: IProgress<IProgressStep>) => Promise<R>
 		): Promise<R>;
+
+		/**
+		 * Creates a terminal with limited capabilities that is intended for
+		 * writing output from the embedder before the workbench has finished
+		 * loading. When an embedder terminal is created it will automatically
+		 * show to the user.
+		 *
+		 * @param options The definition of the terminal, this is similar to
+		 * `ExtensionTerminalOptions` in the extension API.
+		 */
+		createTerminal(options: IEmbedderTerminalOptions): void;
 	};
 
 	workspace: {

--- a/src/vs/workbench/browser/web.api.ts
+++ b/src/vs/workbench/browser/web.api.ts
@@ -17,7 +17,7 @@ import type { TunnelProviderFeatures } from 'vs/platform/tunnel/common/tunnel';
 import type { IProgress, IProgressCompositeOptions, IProgressDialogOptions, IProgressNotificationOptions, IProgressOptions, IProgressStep, IProgressWindowOptions } from 'vs/platform/progress/common/progress';
 import type { ITextEditorOptions } from 'vs/platform/editor/common/editor';
 import type { EditorGroupLayout } from 'vs/workbench/services/editor/common/editorGroupsService';
-import { IEmbedderTerminalOptions } from 'vs/workbench/services/terminal/common/embedderTerminalService';
+import type { IEmbedderTerminalOptions } from 'vs/workbench/services/terminal/common/embedderTerminalService';
 
 /**
  * The `IWorkbench` interface is the API facade for web embedders

--- a/src/vs/workbench/browser/web.main.ts
+++ b/src/vs/workbench/browser/web.main.ts
@@ -91,6 +91,7 @@ import { UserDataSyncInitializer } from 'vs/workbench/services/userDataSync/brow
 import { BrowserRemoteResourceLoader } from 'vs/workbench/services/remote/browser/browserRemoteResourceHandler';
 import { BufferLogger } from 'vs/platform/log/common/bufferLog';
 import { FileLoggerService } from 'vs/platform/log/common/fileLog';
+import { IEmbedderTerminalService } from 'vs/workbench/services/terminal/common/embedderTerminalService';
 
 export class BrowserMain extends Disposable {
 
@@ -151,6 +152,7 @@ export class BrowserMain extends Disposable {
 			const instantiationService = accessor.get(IInstantiationService);
 			const remoteExplorerService = accessor.get(IRemoteExplorerService);
 			const labelService = accessor.get(ILabelService);
+			const embedderTerminalService = accessor.get(IEmbedderTerminalService);
 
 			let logger: DelayedLogChannel | undefined = undefined;
 
@@ -181,7 +183,8 @@ export class BrowserMain extends Disposable {
 					}
 				},
 				window: {
-					withProgress: (options, task) => progressService.withProgress(options, task)
+					withProgress: (options, task) => progressService.withProgress(options, task),
+					createTerminal: (options) => embedderTerminalService.createTerminal(options),
 				},
 				workspace: {
 					openTunnel: async tunnelOptions => {

--- a/src/vs/workbench/contrib/terminal/browser/terminalMainContribution.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalMainContribution.ts
@@ -91,9 +91,7 @@ export class TerminalMainContribution extends Disposable implements IWorkbenchCo
 			}
 		});
 
-		console.log('Main contribution init', embedderTerminalService);
 		embedderTerminalService.onDidCreateTerminal(async embedderTerminal => {
-			console.log('Main contribution', embedderTerminal);
 			const terminal = await terminalService.createTerminal({
 				config: embedderTerminal,
 				location: TerminalLocation.Panel

--- a/src/vs/workbench/contrib/terminal/browser/terminalMainContribution.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalMainContribution.ts
@@ -12,6 +12,7 @@ import { ITerminalEditorService, ITerminalGroupService, ITerminalInstanceService
 import { parseTerminalUri } from 'vs/workbench/contrib/terminal/browser/terminalUri';
 import { terminalStrings } from 'vs/workbench/contrib/terminal/common/terminalStrings';
 import { IEditorResolverService, RegisteredEditorPriority } from 'vs/workbench/services/editor/common/editorResolverService';
+import { IEmbedderTerminalService } from 'vs/workbench/services/terminal/common/embedderTerminalService';
 
 /**
  * The main contribution for the terminal contrib. This contains calls to other components necessary
@@ -21,6 +22,7 @@ import { IEditorResolverService, RegisteredEditorPriority } from 'vs/workbench/s
 export class TerminalMainContribution extends Disposable implements IWorkbenchContribution {
 	constructor(
 		@IEditorResolverService editorResolverService: IEditorResolverService,
+		@IEmbedderTerminalService embedderTerminalService: IEmbedderTerminalService,
 		@ILabelService labelService: ILabelService,
 		@ITerminalService terminalService: ITerminalService,
 		@ITerminalEditorService terminalEditorService: ITerminalEditorService,
@@ -87,6 +89,17 @@ export class TerminalMainContribution extends Disposable implements IWorkbenchCo
 				label: '${path}',
 				separator: ''
 			}
+		});
+
+		console.log('Main contribution init', embedderTerminalService);
+		embedderTerminalService.onDidCreateTerminal(async embedderTerminal => {
+			console.log('Main contribution', embedderTerminal);
+			const terminal = await terminalService.createTerminal({
+				config: embedderTerminal,
+				location: TerminalLocation.Panel
+			});
+			terminalService.setActiveInstance(terminal);
+			await terminalService.revealActiveTerminal();
 		});
 	}
 }

--- a/src/vs/workbench/services/terminal/common/embedderTerminalService.ts
+++ b/src/vs/workbench/services/terminal/common/embedderTerminalService.ts
@@ -1,0 +1,152 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { InstantiationType, registerSingleton } from 'vs/platform/instantiation/common/extensions';
+import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
+import { Emitter, Event } from 'vs/base/common/event';
+import { IProcessDataEvent, IProcessProperty, IProcessPropertyMap, IShellLaunchConfig, ITerminalChildProcess, ITerminalLaunchError, ProcessPropertyType } from 'vs/platform/terminal/common/terminal';
+import { Disposable } from 'vs/base/common/lifecycle';
+
+export const IEmbedderTerminalService = createDecorator<IEmbedderTerminalService>('embedderTerminalService');
+
+/**
+ * Manages terminals that the embedder can create before the terminal contrib is available.
+ */
+export interface IEmbedderTerminalService {
+	readonly _serviceBrand: undefined;
+
+	readonly onDidCreateTerminal: Event<IShellLaunchConfig>;
+
+	createTerminal(options: IEmbedderTerminalOptions): void;
+}
+
+export type EmbedderTerminal = IShellLaunchConfig & Required<Pick<IShellLaunchConfig, 'customPtyImplementation'>>;
+
+export interface IEmbedderTerminalOptions {
+	name: string;
+	pty: IEmbedderTerminalPty;
+
+	// Extension APIs that have not been implemented for embedders:
+	//   iconPath?: URI | { light: URI; dark: URI } | ThemeIcon;
+	//   color?: ThemeColor;
+	//   location?: TerminalLocation | TerminalEditorLocationOptions | TerminalSplitLocationOptions;
+	//   isTransient?: boolean;
+}
+
+/**
+ * See Pseudoterminal on the vscode API for usage.
+ */
+export interface IEmbedderTerminalPty {
+	onDidWrite: Event<string>;
+	onDidClose?: Event<void | number>;
+	onDidChangeName?: Event<string>;
+
+	open(): void;
+	close(): void;
+
+	// Extension APIs that have not been implemented for embedders:
+	//   onDidOverrideDimensions?: Event<TerminalDimensions | undefined>;
+	//   handleInput?(data: string): void;
+	//   setDimensions?(dimensions: TerminalDimensions): void;
+}
+
+class EmbedderTerminalService implements IEmbedderTerminalService {
+	declare _serviceBrand: undefined;
+
+	private readonly _onDidCreateTerminal = new Emitter<IShellLaunchConfig>();
+	readonly onDidCreateTerminal = Event.buffer(this._onDidCreateTerminal.event);
+
+	createTerminal(options: IEmbedderTerminalOptions): void {
+		console.log('createTerminal!', options);
+		const slc: EmbedderTerminal = {
+			name: options.name,
+			isFeatureTerminal: true,
+			customPtyImplementation(terminalId, cols, rows) {
+				return new EmbedderTerminalProcess(terminalId, options.pty);
+			},
+		};
+		this._onDidCreateTerminal.fire(slc);
+	}
+}
+
+
+class EmbedderTerminalProcess extends Disposable implements ITerminalChildProcess {
+	readonly #pty: IEmbedderTerminalPty;
+
+	readonly shouldPersist = false;
+
+	readonly onProcessData: Event<IProcessDataEvent | string>;
+	readonly #onProcessReady = this._register(new Emitter<{ pid: number; cwd: string }>());
+	readonly onProcessReady = this.#onProcessReady.event;
+	readonly #onDidChangeProperty = this._register(new Emitter<IProcessProperty<any>>());
+	readonly onDidChangeProperty = this.#onDidChangeProperty.event;
+	readonly #onProcessExit = this._register(new Emitter<number | undefined>());
+	readonly onProcessExit = this.#onProcessExit.event;
+
+	constructor(
+		readonly id: number,
+		pty: IEmbedderTerminalPty
+	) {
+		super();
+
+		this.#pty = pty;
+		this.onProcessData = this.#pty.onDidWrite;
+		if (this.#pty.onDidClose) {
+			this._register(this.#pty.onDidClose(e => this.#onProcessExit.fire(e || undefined)));
+		}
+		if (this.#pty.onDidChangeName) {
+			this._register(this.#pty.onDidChangeName(e => this.#onDidChangeProperty.fire({
+				type: ProcessPropertyType.Title,
+				value: e
+			})));
+		}
+	}
+
+	async start(): Promise<ITerminalLaunchError | undefined> {
+		this.#onProcessReady.fire({ pid: -1, cwd: '' });
+		this.#pty.open();
+		return undefined;
+	}
+	shutdown(): void {
+		this.#pty.close();
+	}
+
+	// TODO: A lot of these aren't useful for some implementations of ITerminalChildProcess, should
+	// they be optional? Should there be a base class for "external" consumers to implement?
+
+	input(): void {
+		// not supported
+	}
+	async processBinary(): Promise<void> {
+		// not supported
+	}
+	resize(): void {
+		// no-op
+	}
+	acknowledgeDataEvent(): void {
+		// no-op, flow control not currently implemented
+	}
+	async setUnicodeVersion(): Promise<void> {
+		// no-op
+	}
+	async getInitialCwd(): Promise<string> {
+		return '';
+	}
+	async getCwd(): Promise<string> {
+		return '';
+	}
+	async getLatency(): Promise<number> {
+		return 0;
+	}
+	refreshProperty<T extends ProcessPropertyType>(property: ProcessPropertyType): Promise<IProcessPropertyMap[T]> {
+		throw new Error(`refreshProperty is not suppported in EmbedderTerminalProcess. property: ${property}`);
+	}
+
+	updateProperty(property: ProcessPropertyType, value: any): Promise<void> {
+		throw new Error(`updateProperty is not suppported in EmbedderTerminalProcess. property: ${property}, value: ${value}`);
+	}
+}
+
+registerSingleton(IEmbedderTerminalService, EmbedderTerminalService, InstantiationType.Delayed);

--- a/src/vs/workbench/services/terminal/common/embedderTerminalService.ts
+++ b/src/vs/workbench/services/terminal/common/embedderTerminalService.ts
@@ -59,7 +59,6 @@ class EmbedderTerminalService implements IEmbedderTerminalService {
 	readonly onDidCreateTerminal = Event.buffer(this._onDidCreateTerminal.event);
 
 	createTerminal(options: IEmbedderTerminalOptions): void {
-		console.log('createTerminal!', options);
 		const slc: EmbedderTerminal = {
 			name: options.name,
 			isFeatureTerminal: true,

--- a/src/vs/workbench/workbench.common.main.ts
+++ b/src/vs/workbench/workbench.common.main.ts
@@ -90,6 +90,7 @@ import 'vs/workbench/services/userDataProfile/browser/userDataProfileManagement'
 import 'vs/workbench/services/userDataProfile/common/remoteUserDataProfiles';
 import 'vs/workbench/services/remote/common/remoteExplorerService';
 import 'vs/workbench/services/remote/common/remoteExtensionsScanner';
+import 'vs/workbench/services/terminal/common/embedderTerminalService';
 import 'vs/workbench/services/workingCopy/common/workingCopyService';
 import 'vs/workbench/services/workingCopy/common/workingCopyFileService';
 import 'vs/workbench/services/workingCopy/common/workingCopyEditorService';


### PR DESCRIPTION
cc @osortega

I tested by adding this into `BrowserMain`:

```ts
const onDidWriteEmitter = new Emitter<string>();
embedderTerminalService.createTerminal({
	name: 'Building Codespace',
	pty: {
		onDidWrite: onDidWriteEmitter.event,
		open() {
			onDidWriteEmitter.fire('Hello world!\r\n');
			setInterval(() => onDidWriteEmitter.fire('\r\nwork...'), 1000);
		},
		close() { },
	}
});
```

![Recording 2023-05-23 at 06 09 50](https://github.com/microsoft/vscode/assets/2193314/1531960f-a854-4b69-b643-37393c8079a4)
