### PR TITLE
Add border radius to monaco-hover

### DIFF
--- a/src/vs/editor/contrib/hover/browser/hover.css
+++ b/src/vs/editor/contrib/hover/browser/hover.css
@@ -11,6 +11,7 @@
 	color: var(--vscode-editorHoverWidget-foreground);
 	background-color: var(--vscode-editorHoverWidget-background);
 	border: 1px solid var(--vscode-editorHoverWidget-border);
+	border-radius: 3px;
 }
 
 .monaco-editor .monaco-hover a {

--- a/src/vs/workbench/services/hover/browser/media/hover.css
+++ b/src/vs/workbench/services/hover/browser/media/hover.css
@@ -13,6 +13,7 @@
 	max-width: 700px;
 	background: var(--vscode-editorHoverWidget-background);
 	border: 1px solid var(--vscode-editorHoverWidget-border);
+	border-radius: 3px;
 	color: var(--vscode-editorHoverWidget-foreground);
 	box-shadow: 0 2px 8px var(--vscode-widget-shadow);
 }


### PR DESCRIPTION
To match other widgets that have all adopted border radius (editor widgets, notifications, quick pick, etc.)

<img width="500" alt="CleanShot 2023-05-23 at 11 48 31@2x" src="https://github.com/microsoft/vscode/assets/25163139/20fff91e-cfde-419e-a821-d6c417757ce3">

<img width="506" alt="CleanShot 2023-05-23 at 11 48 35@2x" src="https://github.com/microsoft/vscode/assets/25163139/87d7d5de-c8eb-43aa-b3f5-4cf0369d805c">

<img width="212" alt="CleanShot 2023-05-23 at 11 49 07@2x" src="https://github.com/microsoft/vscode/assets/25163139/5032604c-e0d0-4479-b73d-2781921ca369">
