### PR TITLE
clear stale outputs when previously appended

### DIFF
--- a/extensions/notebook-renderers/src/index.ts
+++ b/extensions/notebook-renderers/src/index.ts
@@ -292,6 +292,7 @@ function renderStream(outputInfo: OutputItem, outputElement: HTMLElement, error:
 		if (existing) {
 			existing.replaceWith(content);
 			while (content.nextSibling) {
+				// clear out any stale content if we had previously combined streaming outputs into this one
 				content.nextSibling.remove();
 			}
 		} else {

--- a/extensions/notebook-renderers/src/index.ts
+++ b/extensions/notebook-renderers/src/index.ts
@@ -291,6 +291,9 @@ function renderStream(outputInfo: OutputItem, outputElement: HTMLElement, error:
 		const existing = existingContentParent.querySelector(`[output-item-id="${outputInfo.id}"]`) as HTMLElement | null;
 		if (existing) {
 			existing.replaceWith(content);
+			while (content.nextSibling) {
+				content.nextSibling.remove();
+			}
 		} else {
 			existingContentParent.appendChild(content);
 		}

--- a/scripts/test-integration.bat
+++ b/scripts/test-integration.bat
@@ -24,82 +24,17 @@ if "%INTEGRATION_TEST_ELECTRON_PATH%"=="" (
 echo Storing crash reports into '%VSCODECRASHDIR%'.
 echo Storing log files into '%VSCODELOGSDIR%'.
 
-
-:: Tests standalone (AMD)
-
-echo.
-echo ### node.js integration tests
-call .\scripts\test.bat --runGlob **\*.integrationTest.js %*
-if %errorlevel% neq 0 exit /b %errorlevel%
-
-
 :: Tests in the extension host
 
 set API_TESTS_EXTRA_ARGS=--disable-telemetry --skip-welcome --skip-release-notes --crash-reporter-directory=%VSCODECRASHDIR% --logsPath=%VSCODELOGSDIR% --no-cached-data --disable-updates --disable-keytar --disable-extensions --disable-workspace-trust --user-data-dir=%VSCODEUSERDATADIR%
 
 echo.
-echo ### API tests (folder)
-call "%INTEGRATION_TEST_ELECTRON_PATH%" %~dp0\..\extensions\vscode-api-tests\testWorkspace --enable-proposed-api=vscode.vscode-api-tests --extensionDevelopmentPath=%~dp0\..\extensions\vscode-api-tests --extensionTestsPath=%~dp0\..\extensions\vscode-api-tests\out\singlefolder-tests %API_TESTS_EXTRA_ARGS%
+echo ### Notebook Output tests
+set NBOUTWORKSPACE=%TEMPDIR%\nbout-%RANDOM%
+mkdir %NBOUTWORKSPACE%
+call "%INTEGRATION_TEST_ELECTRON_PATH%" %NBOUTWORKSPACE% --extensionDevelopmentPath=%~dp0\..\extensions\notebook-renderers --extensionTestsPath=%~dp0\..\extensions\notebook-renderers\out\test %API_TESTS_EXTRA_ARGS%
 if %errorlevel% neq 0 exit /b %errorlevel%
 
-echo.
-echo ### API tests (workspace)
-call "%INTEGRATION_TEST_ELECTRON_PATH%" %~dp0\..\extensions\vscode-api-tests\testworkspace.code-workspace --enable-proposed-api=vscode.vscode-api-tests --extensionDevelopmentPath=%~dp0\..\extensions\vscode-api-tests --extensionTestsPath=%~dp0\..\extensions\vscode-api-tests\out\workspace-tests %API_TESTS_EXTRA_ARGS%
-if %errorlevel% neq 0 exit /b %errorlevel%
-
-echo.
-echo ### Colorize tests
-call "%INTEGRATION_TEST_ELECTRON_PATH%" %~dp0\..\extensions\vscode-colorize-tests\test --extensionDevelopmentPath=%~dp0\..\extensions\vscode-colorize-tests --extensionTestsPath=%~dp0\..\extensions\vscode-colorize-tests\out %API_TESTS_EXTRA_ARGS%
-if %errorlevel% neq 0 exit /b %errorlevel%
-
-echo.
-echo ### TypeScript tests
-call "%INTEGRATION_TEST_ELECTRON_PATH%" %~dp0\..\extensions\typescript-language-features\test-workspace --extensionDevelopmentPath=%~dp0\..\extensions\typescript-language-features --extensionTestsPath=%~dp0\..\extensions\typescript-language-features\out\test\unit %API_TESTS_EXTRA_ARGS%
-if %errorlevel% neq 0 exit /b %errorlevel%
-
-echo.
-echo ### Markdown tests
-call "%INTEGRATION_TEST_ELECTRON_PATH%" %~dp0\..\extensions\markdown-language-features\test-workspace --extensionDevelopmentPath=%~dp0\..\extensions\markdown-language-features --extensionTestsPath=%~dp0\..\extensions\markdown-language-features\out\test %API_TESTS_EXTRA_ARGS%
-if %errorlevel% neq 0 exit /b %errorlevel%
-
-echo.
-echo ### Emmet tests
-call "%INTEGRATION_TEST_ELECTRON_PATH%" %~dp0\..\extensions\emmet\test-workspace --extensionDevelopmentPath=%~dp0\..\extensions\emmet --extensionTestsPath=%~dp0\..\extensions\emmet\out\test %API_TESTS_EXTRA_ARGS%
-if %errorlevel% neq 0 exit /b %errorlevel%
-
-echo.
-echo ### Git tests
-for /f "delims=" %%i in ('node -p "require('fs').realpathSync.native(require('os').tmpdir())"') do set TEMPDIR=%%i
-set GITWORKSPACE=%TEMPDIR%\git-%RANDOM%
-mkdir %GITWORKSPACE%
-call "%INTEGRATION_TEST_ELECTRON_PATH%" %GITWORKSPACE% --extensionDevelopmentPath=%~dp0\..\extensions\git --extensionTestsPath=%~dp0\..\extensions\git\out\test %API_TESTS_EXTRA_ARGS%
-if %errorlevel% neq 0 exit /b %errorlevel%
-
-echo.
-echo ### Ipynb tests
-set IPYNBWORKSPACE=%TEMPDIR%\ipynb-%RANDOM%
-mkdir %IPYNBWORKSPACE%
-call "%INTEGRATION_TEST_ELECTRON_PATH%" %IPYNBWORKSPACE% --extensionDevelopmentPath=%~dp0\..\extensions\ipynb --extensionTestsPath=%~dp0\..\extensions\ipynb\out\test %API_TESTS_EXTRA_ARGS%
-if %errorlevel% neq 0 exit /b %errorlevel%
-
-echo.
-echo ### Configuration editing tests
-set CFWORKSPACE=%TEMPDIR%\cf-%RANDOM%
-mkdir %CFWORKSPACE%
-call "%INTEGRATION_TEST_ELECTRON_PATH%" %CFWORKSPACE% --extensionDevelopmentPath=%~dp0\..\extensions\configuration-editing --extensionTestsPath=%~dp0\..\extensions\configuration-editing\out\test %API_TESTS_EXTRA_ARGS%
-if %errorlevel% neq 0 exit /b %errorlevel%
-
-:: Tests standalone (CommonJS)
-
-echo.
-echo ### CSS tests
-call %~dp0\node-electron.bat %~dp0\..\extensions\css-language-features/server/test/index.js
-if %errorlevel% neq 0 exit /b %errorlevel%
-
-echo.
-echo ### HTML tests
-call %~dp0\node-electron.bat %~dp0\..\extensions\html-language-features/server/test/index.js
-if %errorlevel% neq 0 exit /b %errorlevel%
 
 
 :: Cleanup

--- a/scripts/test-integration.bat
+++ b/scripts/test-integration.bat
@@ -24,17 +24,82 @@ if "%INTEGRATION_TEST_ELECTRON_PATH%"=="" (
 echo Storing crash reports into '%VSCODECRASHDIR%'.
 echo Storing log files into '%VSCODELOGSDIR%'.
 
+
+:: Tests standalone (AMD)
+
+echo.
+echo ### node.js integration tests
+call .\scripts\test.bat --runGlob **\*.integrationTest.js %*
+if %errorlevel% neq 0 exit /b %errorlevel%
+
+
 :: Tests in the extension host
 
 set API_TESTS_EXTRA_ARGS=--disable-telemetry --skip-welcome --skip-release-notes --crash-reporter-directory=%VSCODECRASHDIR% --logsPath=%VSCODELOGSDIR% --no-cached-data --disable-updates --disable-keytar --disable-extensions --disable-workspace-trust --user-data-dir=%VSCODEUSERDATADIR%
 
 echo.
-echo ### Notebook Output tests
-set NBOUTWORKSPACE=%TEMPDIR%\nbout-%RANDOM%
-mkdir %NBOUTWORKSPACE%
-call "%INTEGRATION_TEST_ELECTRON_PATH%" %NBOUTWORKSPACE% --extensionDevelopmentPath=%~dp0\..\extensions\notebook-renderers --extensionTestsPath=%~dp0\..\extensions\notebook-renderers\out\test %API_TESTS_EXTRA_ARGS%
+echo ### API tests (folder)
+call "%INTEGRATION_TEST_ELECTRON_PATH%" %~dp0\..\extensions\vscode-api-tests\testWorkspace --enable-proposed-api=vscode.vscode-api-tests --extensionDevelopmentPath=%~dp0\..\extensions\vscode-api-tests --extensionTestsPath=%~dp0\..\extensions\vscode-api-tests\out\singlefolder-tests %API_TESTS_EXTRA_ARGS%
 if %errorlevel% neq 0 exit /b %errorlevel%
 
+echo.
+echo ### API tests (workspace)
+call "%INTEGRATION_TEST_ELECTRON_PATH%" %~dp0\..\extensions\vscode-api-tests\testworkspace.code-workspace --enable-proposed-api=vscode.vscode-api-tests --extensionDevelopmentPath=%~dp0\..\extensions\vscode-api-tests --extensionTestsPath=%~dp0\..\extensions\vscode-api-tests\out\workspace-tests %API_TESTS_EXTRA_ARGS%
+if %errorlevel% neq 0 exit /b %errorlevel%
+
+echo.
+echo ### Colorize tests
+call "%INTEGRATION_TEST_ELECTRON_PATH%" %~dp0\..\extensions\vscode-colorize-tests\test --extensionDevelopmentPath=%~dp0\..\extensions\vscode-colorize-tests --extensionTestsPath=%~dp0\..\extensions\vscode-colorize-tests\out %API_TESTS_EXTRA_ARGS%
+if %errorlevel% neq 0 exit /b %errorlevel%
+
+echo.
+echo ### TypeScript tests
+call "%INTEGRATION_TEST_ELECTRON_PATH%" %~dp0\..\extensions\typescript-language-features\test-workspace --extensionDevelopmentPath=%~dp0\..\extensions\typescript-language-features --extensionTestsPath=%~dp0\..\extensions\typescript-language-features\out\test\unit %API_TESTS_EXTRA_ARGS%
+if %errorlevel% neq 0 exit /b %errorlevel%
+
+echo.
+echo ### Markdown tests
+call "%INTEGRATION_TEST_ELECTRON_PATH%" %~dp0\..\extensions\markdown-language-features\test-workspace --extensionDevelopmentPath=%~dp0\..\extensions\markdown-language-features --extensionTestsPath=%~dp0\..\extensions\markdown-language-features\out\test %API_TESTS_EXTRA_ARGS%
+if %errorlevel% neq 0 exit /b %errorlevel%
+
+echo.
+echo ### Emmet tests
+call "%INTEGRATION_TEST_ELECTRON_PATH%" %~dp0\..\extensions\emmet\test-workspace --extensionDevelopmentPath=%~dp0\..\extensions\emmet --extensionTestsPath=%~dp0\..\extensions\emmet\out\test %API_TESTS_EXTRA_ARGS%
+if %errorlevel% neq 0 exit /b %errorlevel%
+
+echo.
+echo ### Git tests
+for /f "delims=" %%i in ('node -p "require('fs').realpathSync.native(require('os').tmpdir())"') do set TEMPDIR=%%i
+set GITWORKSPACE=%TEMPDIR%\git-%RANDOM%
+mkdir %GITWORKSPACE%
+call "%INTEGRATION_TEST_ELECTRON_PATH%" %GITWORKSPACE% --extensionDevelopmentPath=%~dp0\..\extensions\git --extensionTestsPath=%~dp0\..\extensions\git\out\test %API_TESTS_EXTRA_ARGS%
+if %errorlevel% neq 0 exit /b %errorlevel%
+
+echo.
+echo ### Ipynb tests
+set IPYNBWORKSPACE=%TEMPDIR%\ipynb-%RANDOM%
+mkdir %IPYNBWORKSPACE%
+call "%INTEGRATION_TEST_ELECTRON_PATH%" %IPYNBWORKSPACE% --extensionDevelopmentPath=%~dp0\..\extensions\ipynb --extensionTestsPath=%~dp0\..\extensions\ipynb\out\test %API_TESTS_EXTRA_ARGS%
+if %errorlevel% neq 0 exit /b %errorlevel%
+
+echo.
+echo ### Configuration editing tests
+set CFWORKSPACE=%TEMPDIR%\cf-%RANDOM%
+mkdir %CFWORKSPACE%
+call "%INTEGRATION_TEST_ELECTRON_PATH%" %CFWORKSPACE% --extensionDevelopmentPath=%~dp0\..\extensions\configuration-editing --extensionTestsPath=%~dp0\..\extensions\configuration-editing\out\test %API_TESTS_EXTRA_ARGS%
+if %errorlevel% neq 0 exit /b %errorlevel%
+
+:: Tests standalone (CommonJS)
+
+echo.
+echo ### CSS tests
+call %~dp0\node-electron.bat %~dp0\..\extensions\css-language-features/server/test/index.js
+if %errorlevel% neq 0 exit /b %errorlevel%
+
+echo.
+echo ### HTML tests
+call %~dp0\node-electron.bat %~dp0\..\extensions\html-language-features/server/test/index.js
+if %errorlevel% neq 0 exit /b %errorlevel%
 
 
 :: Cleanup


### PR DESCRIPTION
when a cell has multiple adjacent streaming outputs, we combine them into a single output element, so if that cell is run again, it needs to clear out the extra outputs that were appended. This change will do that by removing the subsequent siblings of the rendered output content since the first output will be rendered again on a new cell run.