### PR TITLE
define-keybinding widget: escape clears if non-empty, otherwise hides the widget

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/keybindingWidgets.ts
+++ b/src/vs/workbench/contrib/preferences/browser/keybindingWidgets.ts
@@ -103,10 +103,6 @@ export class KeybindingsSearchWidget extends SearchWidget {
 			return;
 		}
 		if (keyboardEvent.equals(KeyCode.Escape)) {
-			if (this._chords !== null) {
-				this.clear();
-			}
-
 			this._onEscape.fire();
 			return;
 		}
@@ -185,8 +181,8 @@ export class DefineKeybindingWidget extends Widget {
 		this._keybindingInputWidget.startRecordingKeys();
 		this._register(this._keybindingInputWidget.onKeybinding(keybinding => this.onKeybinding(keybinding)));
 		this._register(this._keybindingInputWidget.onEnter(() => this.hide()));
-		this._register(this._keybindingInputWidget.onEscape(() => this.onEscape()));
-		this._register(this._keybindingInputWidget.onBlur(() => this.onBlur()));
+		this._register(this._keybindingInputWidget.onEscape(() => this.onCancel()));
+		this._register(this._keybindingInputWidget.onBlur(() => this.onCancel()));
 
 		this._outputNode = dom.append(this._domNode.domNode, dom.$('.output'));
 		this._showExistingKeybindingsNode = dom.append(this._domNode.domNode, dom.$('.existing'));
@@ -280,18 +276,8 @@ export class DefineKeybindingWidget extends Widget {
 		return label;
 	}
 
-	private onBlur(): void {
+	private onCancel(): void {
 		this._chords = null;
-		this.hide();
-	}
-
-	private onEscape(): void {
-		if (this._chords !== null) {
-			this._chords = null;
-			dom.clearNode(this._outputNode);
-			dom.clearNode(this._showExistingKeybindingsNode);
-			return;
-		}
 		this.hide();
 	}
 

--- a/src/vs/workbench/contrib/preferences/browser/keybindingWidgets.ts
+++ b/src/vs/workbench/contrib/preferences/browser/keybindingWidgets.ts
@@ -177,7 +177,7 @@ export class DefineKeybindingWidget extends Widget {
 		this._keybindingInputWidget.startRecordingKeys();
 		this._register(this._keybindingInputWidget.onKeybinding(keybinding => this.onKeybinding(keybinding)));
 		this._register(this._keybindingInputWidget.onEnter(() => this.hide()));
-		this._register(this._keybindingInputWidget.onEscape(() => this.onCancel()));
+		this._register(this._keybindingInputWidget.onEscape(() => this.clearOrHide()));
 		this._register(this._keybindingInputWidget.onBlur(() => this.onCancel()));
 
 		this._outputNode = dom.append(this._domNode.domNode, dom.$('.output'));
@@ -271,6 +271,17 @@ export class DefineKeybindingWidget extends Widget {
 	private onCancel(): void {
 		this._chords = null;
 		this.hide();
+	}
+
+	private clearOrHide(): void {
+		if (this._chords === null) {
+			this.hide();
+		} else {
+			this._chords = null;
+			this._keybindingInputWidget.clear();
+			dom.clearNode(this._outputNode);
+			dom.clearNode(this._showExistingKeybindingsNode);
+		}
 	}
 
 	private hide(): void {

--- a/src/vs/workbench/contrib/preferences/browser/keybindingWidgets.ts
+++ b/src/vs/workbench/contrib/preferences/browser/keybindingWidgets.ts
@@ -64,12 +64,10 @@ export class KeybindingsSearchWidget extends SearchWidget {
 
 		this._chords = null;
 		this._inputValue = '';
-
-		this._reset();
 	}
 
 	override clear(): void {
-		this._reset();
+		this._chords = null;
 		super.clear();
 	}
 
@@ -83,17 +81,13 @@ export class KeybindingsSearchWidget extends SearchWidget {
 	}
 
 	stopRecordingKeys(): void {
-		this._reset();
+		this._chords = null;
 		this.recordDisposables.clear();
 	}
 
 	setInputValue(value: string): void {
 		this._inputValue = value;
 		this.inputBox.value = this._inputValue;
-	}
-
-	private _reset() {
-		this._chords = null;
 	}
 
 	private _onKeyDown(keyboardEvent: IKeyboardEvent): void {

--- a/src/vs/workbench/contrib/preferences/browser/keybindingWidgets.ts
+++ b/src/vs/workbench/contrib/preferences/browser/keybindingWidgets.ts
@@ -59,7 +59,9 @@ export class KeybindingsSearchWidget extends SearchWidget {
 		@IKeybindingService keybindingService: IKeybindingService,
 	) {
 		super(parent, options, contextViewService, instantiationService, contextKeyService, keybindingService);
+
 		this._register(toDisposable(() => this.stopRecordingKeys()));
+
 		this._chords = null;
 		this._inputValue = '';
 
@@ -247,11 +249,8 @@ export class DefineKeybindingWidget extends Widget {
 		dom.clearNode(this._outputNode);
 		dom.clearNode(this._showExistingKeybindingsNode);
 
-
-
 		const firstLabel = new KeybindingLabel(this._outputNode, OS, defaultKeybindingLabelStyles);
 		firstLabel.set(withNullAsUndefined(this._chords?.[0]));
-
 
 		if (this._chords) {
 			for (let i = 1; i < this._chords.length; i++) {
@@ -259,7 +258,6 @@ export class DefineKeybindingWidget extends Widget {
 				const chordLabel = new KeybindingLabel(this._outputNode, OS, defaultKeybindingLabelStyles);
 				chordLabel.set(this._chords[i]);
 			}
-
 		}
 
 		const label = this.getUserSettingsLabel();


### PR DESCRIPTION
Re-implement how we clear non-empty define-keybinding widget, or hide otherwise.

Fixes https://github.com/microsoft/vscode/issues/181765