### PR TITLE
TreeView Checkbox State set to 0 fixed

### DIFF
--- a/src/vs/workbench/api/common/extHostTreeViews.ts
+++ b/src/vs/workbench/api/common/extHostTreeViews.ts
@@ -764,7 +764,7 @@ class ExtHostTreeView<T> extends Disposable {
 	}
 
 	private getCheckbox(extensionTreeItem: vscode.TreeItem2): ITreeItemCheckboxState | undefined {
-		if (!extensionTreeItem.checkboxState) {
+		if (extensionTreeItem.checkboxState === undefined) {
 			return undefined;
 		}
 		let checkboxState: TreeItemCheckboxState;


### PR DESCRIPTION
Fixes the bug mentioned in #183339 

I haven't tested it, but it's a very simple fix.
Reviewer: @alexr00