### PR TITLE
Respect gitignore file even when not in a git repository

### DIFF
--- a/src/vs/workbench/services/search/node/ripgrepFileSearch.ts
+++ b/src/vs/workbench/services/search/node/ripgrepFileSearch.ts
@@ -30,7 +30,7 @@ export function spawnRipgrepCmd(config: IFileQuery, folderQuery: IFolderQuery, i
 }
 
 function getRgArgs(config: IFileQuery, folderQuery: IFolderQuery, includePattern?: glob.IExpression, excludePattern?: glob.IExpression) {
-	const args = ['--files', '--hidden', '--case-sensitive'];
+	const args = ['--files', '--hidden', '--case-sensitive', '--no-require-git'];
 
 	// includePattern can't have siblingClauses
 	foldersToIncludeGlobs([folderQuery], includePattern, false).forEach(globArg => {

--- a/src/vs/workbench/services/search/node/ripgrepTextSearchEngine.ts
+++ b/src/vs/workbench/services/search/node/ripgrepTextSearchEngine.ts
@@ -370,7 +370,7 @@ function getNumLinesAndLastNewlineLength(text: string): { numLines: number; last
 
 // exported for testing
 export function getRgArgs(query: TextSearchQuery, options: TextSearchOptions): string[] {
-	const args = ['--hidden'];
+	const args = ['--hidden', '--no-require-git'];
 	args.push(query.isCaseSensitive ? '--case-sensitive' : '--ignore-case');
 
 	const { doubleStarIncludes, otherIncludes } = groupBy(

--- a/src/vs/workbench/services/search/test/node/ripgrepTextSearchEngineUtils.test.ts
+++ b/src/vs/workbench/services/search/test/node/ripgrepTextSearchEngineUtils.test.ts
@@ -317,6 +317,7 @@ suite('RipgrepTextSearchEngine', () => {
 				};
 				const expected = [
 					'--hidden',
+					'--no-require-git',
 					'--ignore-case',
 					...expectedFromIncludes,
 					'--no-ignore',


### PR DESCRIPTION
If a .gitignore file exists in a workspace, we currently only respect it
if we're also in a git repository. This is because of ripgrep's default
behavior. Pass an extra flag to ripgrep so that it always respects the
.gitignore file if it exists.

Fixes #182958
