### PR TITLE
Revert "Hide kernel picker if nothing is returned (#182919)"

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/viewParts/notebookKernelQuickPickStrategy.ts
+++ b/src/vs/workbench/contrib/notebook/browser/viewParts/notebookKernelQuickPickStrategy.ts
@@ -568,7 +568,7 @@ export class KernelPickerMRUStrategy extends KernelPickerStrategyBase {
 						}
 						return true;
 					} else {
-						return false;
+						return this.displaySelectAnotherQuickPick(editor, false);
 					}
 				} catch (ex) {
 					return false;


### PR DESCRIPTION
This reverts commit 5015de8fb2980ec6d4d38ffe5cc02128610141c4.
Handling the error is required to re-display the kernel picker.