### PR TITLE
Prevent duplicate text in workspace folder picker when path has no parent (fix #183418)

### DIFF
--- a/src/vs/workbench/browser/actions/workspaceCommands.ts
+++ b/src/vs/workbench/browser/actions/workspaceCommands.ts
@@ -118,13 +118,11 @@ CommandsRegistry.registerCommand(PICK_WORKSPACE_FOLDER_COMMAND_ID, async functio
 
 	const folderPicks: IQuickPickItem[] = folders.map(folder => {
 		const label = folder.name;
-		let description = labelService.getUriLabel(dirname(folder.uri), { relative: true });
-		if (description === label) {
-			description = '';
-		}
+		const description = labelService.getUriLabel(dirname(folder.uri), { relative: true });
+
 		return {
 			label,
-			description,
+			description: description !== label ? description : undefined, // https://github.com/microsoft/vscode/issues/183418
 			folder,
 			iconClasses: getIconClasses(modelService, languageService, folder.uri, FileKind.ROOT_FOLDER)
 		};

--- a/src/vs/workbench/browser/actions/workspaceCommands.ts
+++ b/src/vs/workbench/browser/actions/workspaceCommands.ts
@@ -117,9 +117,14 @@ CommandsRegistry.registerCommand(PICK_WORKSPACE_FOLDER_COMMAND_ID, async functio
 	}
 
 	const folderPicks: IQuickPickItem[] = folders.map(folder => {
+		const label = folder.name;
+		let description = labelService.getUriLabel(dirname(folder.uri), { relative: true });
+		if (description === label) {
+			description = '';
+		}
 		return {
-			label: folder.name,
-			description: labelService.getUriLabel(dirname(folder.uri), { relative: folder.uri.path !== '/' }),
+			label,
+			description,
 			folder,
 			iconClasses: getIconClasses(modelService, languageService, folder.uri, FileKind.ROOT_FOLDER)
 		};

--- a/src/vs/workbench/browser/actions/workspaceCommands.ts
+++ b/src/vs/workbench/browser/actions/workspaceCommands.ts
@@ -119,7 +119,7 @@ CommandsRegistry.registerCommand(PICK_WORKSPACE_FOLDER_COMMAND_ID, async functio
 	const folderPicks: IQuickPickItem[] = folders.map(folder => {
 		return {
 			label: folder.name,
-			description: labelService.getUriLabel(dirname(folder.uri), { relative: true }),
+			description: labelService.getUriLabel(dirname(folder.uri), { relative: folder.uri.path !== '/' }),
 			folder,
 			iconClasses: getIconClasses(modelService, languageService, folder.uri, FileKind.ROOT_FOLDER)
 		};


### PR DESCRIPTION
This PR fixes #183418, which contains repro steps suitable for testing.