### PR TITLE
computeStickyModel: check token cancellation because it signals that the model is disposed

### DIFF
--- a/src/vs/editor/contrib/stickyScroll/browser/stickyScrollModelProvider.ts
+++ b/src/vs/editor/contrib/stickyScroll/browser/stickyScrollModelProvider.ts
@@ -157,7 +157,7 @@ abstract class StickyModelCandidateProvider<T> implements IStickyModelCandidateP
 	public abstract get provider(): LanguageFeatureRegistry<object> | null;
 
 	public computeStickyModel(textModel: ITextModel, modelVersionId: number, token: CancellationToken): { statusPromise: Promise<Status> | Status; modelPromise: CancelablePromise<T | null> | null } {
-		if (!this.isProviderValid(textModel)) {
+		if (token.isCancellationRequested || !this.isProviderValid(textModel)) {
 			return { statusPromise: this._invalid(), modelPromise: null };
 		}
 		const providerModelPromise = createCancelablePromise(token => this.createModelFromProvider(textModel, modelVersionId, token));


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/180702