### PR TITLE
Support for `Notebook` CodeAction Kind

### DIFF
--- a/src/vs/editor/contrib/codeAction/common/types.ts
+++ b/src/vs/editor/contrib/codeAction/common/types.ts
@@ -24,7 +24,6 @@ export class CodeActionKind {
 	public static readonly SourceOrganizeImports = CodeActionKind.Source.append('organizeImports');
 	public static readonly SourceFixAll = CodeActionKind.Source.append('fixAll');
 	public static readonly SurroundWith = CodeActionKind.Refactor.append('surround');
-	public static readonly Notebook = new CodeActionKind('notebook');
 
 	constructor(
 		public readonly value: string

--- a/src/vs/editor/contrib/codeAction/common/types.ts
+++ b/src/vs/editor/contrib/codeAction/common/types.ts
@@ -24,6 +24,7 @@ export class CodeActionKind {
 	public static readonly SourceOrganizeImports = CodeActionKind.Source.append('organizeImports');
 	public static readonly SourceFixAll = CodeActionKind.Source.append('fixAll');
 	public static readonly SurroundWith = CodeActionKind.Refactor.append('surround');
+	public static readonly Notebook = new CodeActionKind('notebook');
 
 	constructor(
 		public readonly value: string

--- a/src/vs/workbench/api/common/extHost.api.impl.ts
+++ b/src/vs/workbench/api/common/extHost.api.impl.ts
@@ -1526,7 +1526,8 @@ export function createApiFactoryAndRegisterActors(accessor: ServicesAccessor): I
 			InteractiveSessionCopyKind: extHostTypes.InteractiveSessionCopyKind,
 			InteractiveEditorResponseFeedbackKind: extHostTypes.InteractiveEditorResponseFeedbackKind,
 			StackFrameFocus: extHostTypes.StackFrameFocus,
-			ThreadFocus: extHostTypes.ThreadFocus
+			ThreadFocus: extHostTypes.ThreadFocus,
+			NotebookCodeActionKind: extHostTypes.NotebookCodeActionKind
 		};
 	};
 }

--- a/src/vs/workbench/api/common/extHostTypes.ts
+++ b/src/vs/workbench/api/common/extHostTypes.ts
@@ -1358,7 +1358,6 @@ export class CodeAction {
 	}
 }
 
-
 @es5ClassCompat
 export class CodeActionKind {
 	private static readonly sep = '.';
@@ -1373,6 +1372,7 @@ export class CodeActionKind {
 	public static Source: CodeActionKind;
 	public static SourceOrganizeImports: CodeActionKind;
 	public static SourceFixAll: CodeActionKind;
+	public static Notebook: CodeActionKind;
 
 	constructor(
 		public readonly value: string
@@ -1390,6 +1390,17 @@ export class CodeActionKind {
 		return this.value === other.value || other.value.startsWith(this.value + CodeActionKind.sep);
 	}
 }
+
+export class NotebookCodeActionKind extends CodeActionKind {
+	public static override Notebook: CodeActionKind;
+
+	constructor(
+		public override readonly value: string
+	) {
+		super(value);
+	}
+}
+
 CodeActionKind.Empty = new CodeActionKind('');
 CodeActionKind.QuickFix = CodeActionKind.Empty.append('quickfix');
 CodeActionKind.Refactor = CodeActionKind.Empty.append('refactor');
@@ -1400,6 +1411,7 @@ CodeActionKind.RefactorRewrite = CodeActionKind.Refactor.append('rewrite');
 CodeActionKind.Source = CodeActionKind.Empty.append('source');
 CodeActionKind.SourceOrganizeImports = CodeActionKind.Source.append('organizeImports');
 CodeActionKind.SourceFixAll = CodeActionKind.Source.append('fixAll');
+CodeActionKind.Notebook = CodeActionKind.Empty.append('notebook');
 
 @es5ClassCompat
 export class SelectionRange {

--- a/src/vs/workbench/contrib/notebook/browser/contrib/saveParticipants/saveParticipants.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/saveParticipants/saveParticipants.ts
@@ -30,6 +30,8 @@ import { CodeActionTriggerType, CodeActionProvider, IWorkspaceTextEdit } from 'v
 import { applyCodeAction, ApplyCodeActionReason, getCodeActions } from 'vs/editor/contrib/codeAction/browser/codeAction';
 import { isEqual } from 'vs/base/common/resources';
 
+const NotebookCodeAction = new CodeActionKind('notebook');
+
 
 class FormatOnSaveParticipant implements IStoredFileWorkingCopySaveParticipant {
 	constructor(
@@ -133,8 +135,8 @@ class CodeActionOnSaveParticipant implements IStoredFileWorkingCopySaveParticipa
 			return undefined;
 		}
 
-		const codeActionsOnSave = this.createCodeActionsOnSave(settingItems).filter(x => !CodeActionKind.Notebook.contains(x));
-		const notebookCodeActionsOnSave = this.createCodeActionsOnSave(settingItems).filter(x => CodeActionKind.Notebook.contains(x));
+		const codeActionsOnSave = this.createCodeActionsOnSave(settingItems).filter(x => !NotebookCodeAction.contains(x));
+		const notebookCodeActionsOnSave = this.createCodeActionsOnSave(settingItems).filter(x => NotebookCodeAction.contains(x));
 
 		// prioritize `source.fixAll` code actions
 		if (!Array.isArray(setting)) {

--- a/src/vs/workbench/contrib/notebook/browser/contrib/saveParticipants/saveParticipants.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/saveParticipants/saveParticipants.ts
@@ -246,14 +246,16 @@ class CodeActionOnSaveParticipant implements IStoredFileWorkingCopySaveParticipa
 				for (const action of actionsToRun.validActions) {
 					const codeActionEdits = action.action.edit?.edits;
 					let breakFlag = false;
-					for (const edit of codeActionEdits ?? []) {
-						const workspaceTextEdit = edit as IWorkspaceTextEdit;
-						if (workspaceTextEdit.resource && isEqual(workspaceTextEdit.resource, model.uri)) {
-							continue;
-						} else {
-							// error -> applied to multiple resources
-							breakFlag = true;
-							break;
+					if (!action.action.kind?.includes('notebook')) {
+						for (const edit of codeActionEdits ?? []) {
+							const workspaceTextEdit = edit as IWorkspaceTextEdit;
+							if (workspaceTextEdit.resource && isEqual(workspaceTextEdit.resource, model.uri)) {
+								continue;
+							} else {
+								// error -> applied to multiple resources
+								breakFlag = true;
+								break;
+							}
 						}
 					}
 					if (breakFlag) {

--- a/src/vs/workbench/services/extensions/common/extensionsApiProposals.ts
+++ b/src/vs/workbench/services/extensions/common/extensionsApiProposals.ts
@@ -55,6 +55,7 @@ export const allApiProposals = Object.freeze({
 	interactiveWindow: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.interactiveWindow.d.ts',
 	ipc: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.ipc.d.ts',
 	notebookCellExecutionState: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.notebookCellExecutionState.d.ts',
+	notebookCodeActions: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.notebookCodeActions.d.ts',
 	notebookControllerAffinityHidden: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.notebookControllerAffinityHidden.d.ts',
 	notebookDeprecated: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.notebookDeprecated.d.ts',
 	notebookExecution: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.notebookExecution.d.ts',

--- a/src/vscode-dts/vscode.proposed.notebookCodeActions.d.ts
+++ b/src/vscode-dts/vscode.proposed.notebookCodeActions.d.ts
@@ -1,0 +1,17 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+declare module 'vscode' {
+
+	// https://github.com/microsoft/vscode/issues/179213
+
+	export class NotebookCodeActionKind {
+		// can only return MULTI CELL workspaceEdits
+		// ex: notebook.organizeImprots
+		static readonly Notebook: CodeActionKind;
+
+		constructor(value: string);
+	}
+}


### PR DESCRIPTION
re: #179213 

Add in proposed api for the new CodeActionKind of `Notebook`

Formally support notebook codeactions on save for ipynb notebook files. Notebook Save Participants first call the providers for the first cell of the notebook, running all notebook specific actions across the entire notebook. Once they resolve, providers are called for all cells in the notebook, performing source level actions on each cell in parallel.

As stated in the proposed api, any CodeAction with the `Notebook` will only be called for the first cell of the notebook, and all CodeActions not with that kind must only apply edits to the single cell that they are passed.