### PR TITLE
Set offSide to sql lang configuration to true

### DIFF
--- a/extensions/sql/language-configuration.json
+++ b/extensions/sql/language-configuration.json
@@ -25,6 +25,7 @@
 		["`", "`"]
 	],
 	"folding": {
+		"offSide": true,
 		"markers": {
 			"start": "^\\s*--\\s*#region\\b",
 			"end": "^\\s*--\\s*#endregion\\b"


### PR DESCRIPTION
Got some user feedback about trailing lines being included in folding regions not being desirable (https://github.com/microsoft/azuredatastudio/issues/23167) which seems reasonable. 

@alexr00 - Is there a way to have changes to our config file in the vscode-mssql extension be picked up here automatically? The update grammar stuff only seems to pick up actual grammar changes, but it seems to me like language config changes should come along with that too, right?