### PR TITLE
Fix some errors for project wide JS/TS IntelliSense

### DIFF
--- a/extensions/typescript-language-features/src/configuration/fileSchemes.ts
+++ b/extensions/typescript-language-features/src/configuration/fileSchemes.ts
@@ -19,13 +19,18 @@ export const memFs = 'memfs';
 export const vscodeVfs = 'vscode-vfs';
 export const officeScript = 'office-script';
 
-export const semanticSupportedSchemes = isWeb() && vscode.workspace.workspaceFolders ?
-	vscode.workspace.workspaceFolders.map(folder => folder.uri.scheme) : [
+export function getSemanticSupportedSchemes() {
+	if (isWeb() && vscode.workspace.workspaceFolders) {
+		return vscode.workspace.workspaceFolders.map(folder => folder.uri.scheme);
+	}
+
+	return [
 		file,
 		untitled,
 		walkThroughSnippet,
 		vscodeNotebookCell,
 	];
+}
 
 /**
  * File scheme for which JS/TS language feature should be disabled

--- a/extensions/typescript-language-features/src/languageProvider.ts
+++ b/extensions/typescript-language-features/src/languageProvider.ts
@@ -46,7 +46,7 @@ export default class LanguageProvider extends Disposable {
 		const syntax: vscode.DocumentFilter[] = [];
 		for (const language of this.description.languageIds) {
 			syntax.push({ language });
-			for (const scheme of fileSchemes.semanticSupportedSchemes) {
+			for (const scheme of fileSchemes.getSemanticSupportedSchemes()) {
 				semantic.push({ language, scheme });
 			}
 		}

--- a/extensions/typescript-language-features/src/typescriptServiceClient.ts
+++ b/extensions/typescript-language-features/src/typescriptServiceClient.ts
@@ -719,15 +719,13 @@ export default class TypeScriptServiceClient extends Disposable implements IType
 		}
 
 		switch (capability) {
-			case ClientCapability.Semantic:
-				{
-					return fileSchemes.semanticSupportedSchemes.includes(resource.scheme);
-				}
+			case ClientCapability.Semantic: {
+				return fileSchemes.getSemanticSupportedSchemes().includes(resource.scheme);
+			}
 			case ClientCapability.Syntax:
-			case ClientCapability.EnhancedSyntax:
-				{
-					return true;
-				}
+			case ClientCapability.EnhancedSyntax: {
+				return true;
+			}
 		}
 	}
 


### PR DESCRIPTION
- Don't compute `semanticSupportedSchemes` early, as this may be incorrect if the script is loaded before there are workspace folders or if the workspace folders change

- Handle exceptions when watching files by logging them but not crashing the server
