### PR TITLE
Display terminal icon correctly in panel titlebar (fix #183679)

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminalView.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalView.ts
@@ -488,8 +488,8 @@ function getSingleTabLabel(accessor: ServicesAccessor, instance: ITerminalInstan
 	if (!instance || !instance.title) {
 		return '';
 	}
-	const iconClass = ThemeIcon.isThemeIcon(instance.icon) ? instance.icon.id : accessor.get(ITerminalProfileResolverService).getDefaultIcon();
-	const label = `$(${icon?.id || iconClass}) ${getSingleTabTitle(instance, separator)}`;
+	const iconId = ThemeIcon.isThemeIcon(instance.icon) ? instance.icon.id : accessor.get(ITerminalProfileResolverService).getDefaultIcon().id;
+	const label = `$(${icon?.id || iconId}) ${getSingleTabTitle(instance, separator)}`;
 
 	const primaryStatus = instance.statusList.primary;
 	if (!primaryStatus?.icon) {


### PR DESCRIPTION
This PR fixes #183679 