### PR TITLE
Make JS/TS `go to configuration` commands work on non-`file:` file systems

### DIFF
--- a/extensions/typescript-language-features/src/languageFeatures/updatePathsOnRename.ts
+++ b/extensions/typescript-language-features/src/languageFeatures/updatePathsOnRename.ts
@@ -239,7 +239,7 @@ class UpdateImportsOnFileRenameHandler extends Disposable {
 
 		for (const rename of renames) {
 			// Group renames by type (js/ts) and by workspace.
-			const key = `${this.client.getWorkspaceRootForResource(rename.jsTsFileThatIsBeingMoved)}@@@${doesResourceLookLikeATypeScriptFile(rename.jsTsFileThatIsBeingMoved)}`;
+			const key = `${this.client.getWorkspaceRootForResource(rename.jsTsFileThatIsBeingMoved)?.fsPath}@@@${doesResourceLookLikeATypeScriptFile(rename.jsTsFileThatIsBeingMoved)}`;
 			if (!groups.has(key)) {
 				groups.set(key, new Set());
 			}

--- a/extensions/typescript-language-features/src/tsconfig.ts
+++ b/extensions/typescript-language-features/src/tsconfig.ts
@@ -3,7 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as path from 'path';
 import * as vscode from 'vscode';
 import type * as Proto from './tsServer/protocol/protocol';
 import { ITypeScriptServiceClient, ServerResponse } from './typescriptService';
@@ -87,10 +86,10 @@ function inferredProjectConfigSnippet(
 
 export async function openOrCreateConfig(
 	projectType: ProjectType,
-	rootPath: string,
+	rootPath: vscode.Uri,
 	configuration: TypeScriptServiceConfiguration,
 ): Promise<vscode.TextEditor | null> {
-	const configFile = vscode.Uri.file(path.join(rootPath, projectType === ProjectType.TypeScript ? 'tsconfig.json' : 'jsconfig.json'));
+	const configFile = vscode.Uri.joinPath(rootPath, projectType === ProjectType.TypeScript ? 'tsconfig.json' : 'jsconfig.json');
 	const col = vscode.window.activeTextEditor?.viewColumn;
 	try {
 		const doc = await vscode.workspace.openTextDocument(configFile);
@@ -108,11 +107,11 @@ export async function openOrCreateConfig(
 export async function openProjectConfigOrPromptToCreate(
 	projectType: ProjectType,
 	client: ITypeScriptServiceClient,
-	rootPath: string,
-	configFileName: string,
+	rootPath: vscode.Uri,
+	configFilePath: string,
 ): Promise<void> {
-	if (!isImplicitProjectConfigFile(configFileName)) {
-		const doc = await vscode.workspace.openTextDocument(configFileName);
+	if (!isImplicitProjectConfigFile(configFilePath)) {
+		const doc = await vscode.workspace.openTextDocument(client.toResource(configFilePath));
 		vscode.window.showTextDocument(doc, vscode.window.activeTextEditor?.viewColumn);
 		return;
 	}

--- a/extensions/typescript-language-features/src/typescriptService.ts
+++ b/extensions/typescript-language-features/src/typescriptService.ts
@@ -156,7 +156,7 @@ export interface ITypeScriptServiceClient {
 	 */
 	hasCapabilityForResource(resource: vscode.Uri, capability: ClientCapability): boolean;
 
-	getWorkspaceRootForResource(resource: vscode.Uri): string | undefined;
+	getWorkspaceRootForResource(resource: vscode.Uri): vscode.Uri | undefined;
 
 	readonly onTsServerStarted: vscode.Event<{ version: TypeScriptVersion; usedApiVersion: API }>;
 	readonly onProjectLanguageServiceStateChanged: vscode.Event<Proto.ProjectLanguageServiceStateEventBody>;

--- a/extensions/typescript-language-features/src/ui/intellisenseStatus.ts
+++ b/extensions/typescript-language-features/src/ui/intellisenseStatus.ts
@@ -62,9 +62,9 @@ export class IntellisenseStatus extends Disposable {
 
 		commandManager.register({
 			id: this.openOpenConfigCommandId,
-			execute: async (rootPath: string, projectType: ProjectType) => {
+			execute: async (root: vscode.Uri, projectType: ProjectType) => {
 				if (this._state.type === IntellisenseState.Type.Resolved) {
-					await openProjectConfigOrPromptToCreate(projectType, this._client, rootPath, this._state.configFile);
+					await openProjectConfigOrPromptToCreate(projectType, this._client, root, this._state.configFile);
 				} else if (this._state.type === IntellisenseState.Type.Pending) {
 					await openProjectConfigForFile(projectType, this._client, this._state.resource);
 				}
@@ -72,8 +72,8 @@ export class IntellisenseStatus extends Disposable {
 		});
 		commandManager.register({
 			id: this.createOrOpenConfigCommandId,
-			execute: async (rootPath: string, projectType: ProjectType) => {
-				await openOrCreateConfig(projectType, rootPath, this._client.configuration);
+			execute: async (root: vscode.Uri, projectType: ProjectType) => {
+				await openOrCreateConfig(projectType, root, this._client.configuration);
 			},
 		});
 


### PR DESCRIPTION
Fixes #183685

