### PR TITLE
Show remote indicator in web when remoteAuthority is set

### DIFF
--- a/src/vs/workbench/contrib/remote/browser/remoteIndicator.ts
+++ b/src/vs/workbench/contrib/remote/browser/remoteIndicator.ts
@@ -374,7 +374,7 @@ export class RemoteStatusIndicator extends Disposable implements IWorkbenchContr
 		}
 
 		// Show for remote windows on the desktop, but not when in code server web
-		if (this.remoteAuthority && (!isWeb || this.environmentService.options?.webSocketFactory)) {
+		if (this.remoteAuthority) {
 			const hostLabel = this.labelService.getHostLabel(Schemas.vscodeRemote, this.remoteAuthority) || this.remoteAuthority;
 			switch (this.connectionState) {
 				case 'initializing':


### PR DESCRIPTION
Fixes #183729

Now that the web uses resolvers too, I think we want to remove the special handling for the remote indicator label.
When a remoteAuthority is set, use the label formatter for the host name.

As always, web embedders can control the remote indicator by defining the `windowIndicator` property in the embedder API.
If they don't set it, they get the host label defined by our resource label providers.

I checked that this does not impact Codespaces (uses windowIndicator) and github.dev (serverless, no remoteAuthority)

FYI @bpasero @connor4312 