### PR TITLE
fix [object Object] in invalid decorator warning

### DIFF
--- a/src/vs/workbench/api/common/extHostDecorations.ts
+++ b/src/vs/workbench/api/common/extHostDecorations.ts
@@ -106,7 +106,7 @@ export class ExtHostDecorations implements ExtHostDecorationsShape {
 					}
 					result[id] = <DecorationData>[data.propagate, data.tooltip, data.badge, data.color];
 				} catch (e) {
-					this._logService.warn(`INVALID decoration from extension '${extensionId}': ${e}`);
+					this._logService.warn(`INVALID decoration from extension '${extensionId.identifier.value}': ${e}`);
 				}
 			} catch (err) {
 				this._logService.error(err);


### PR DESCRIPTION
when there's an invalid decorator, you get a warning like this:

```
[warning] INVALID decoration from extension '[object Object]': Error: The decoration is empty
```

as is done elsewhere in this file, should use `extensionId.identifier.value` to get a string

Fixes #183839

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
