### PR TITLE
Noop when moving a symbol into the file it is already in

### DIFF
--- a/extensions/typescript-language-features/src/languageFeatures/refactor.ts
+++ b/extensions/typescript-language-features/src/languageFeatures/refactor.ts
@@ -145,7 +145,7 @@ class MoveToFileRefactorCommand implements Command {
 		}
 
 		const targetFile = await this.getTargetFile(args.document, file, args.range);
-		if (!targetFile) {
+		if (!targetFile || targetFile.toString() === file.toString()) {
 			return;
 		}
 


### PR DESCRIPTION
Fixes #183793

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
