### PR TITLE
Default to current dir for `move to file` select

### DIFF
--- a/extensions/typescript-language-features/src/languageFeatures/refactor.ts
+++ b/extensions/typescript-language-features/src/languageFeatures/refactor.ts
@@ -175,7 +175,6 @@ class MoveToFileRefactorCommand implements Command {
 		if (response.type !== 'response' || !response.body) {
 			return;
 		}
-		const defaultUri = this.client.toResource(response.body.newFileName);
 
 		const selectExistingFileItem: vscode.QuickPickItem = {
 			label: vscode.l10n.t("Select existing file..."),
@@ -226,14 +225,14 @@ class MoveToFileRefactorCommand implements Command {
 			const picked = await vscode.window.showOpenDialog({
 				title: vscode.l10n.t("Select move destination"),
 				openLabel: vscode.l10n.t("Move to File"),
-				defaultUri
+				defaultUri: Utils.dirname(document.uri),
 			});
 			return picked?.length ? this.client.toTsFilePath(picked[0]) : undefined;
 		} else if (picked === selectNewFileItem) {
 			const picked = await vscode.window.showSaveDialog({
 				title: vscode.l10n.t("Select move destination"),
 				saveLabel: vscode.l10n.t("Move to File"),
-				defaultUri,
+				defaultUri: this.client.toResource(response.body.newFileName),
 			});
 			return picked ? this.client.toTsFilePath(picked) : undefined;
 		} else {


### PR DESCRIPTION
Fixes #183870

`showOpenDialog` seems to ignore `defaultUri` if the file doesn't exist

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
