### PR TITLE
Can't do regex search after opening notebook

### DIFF
--- a/src/vs/workbench/contrib/search/browser/searchFindInput.ts
+++ b/src/vs/workbench/contrib/search/browser/searchFindInput.ts
@@ -67,20 +67,8 @@ export class SearchFindInput extends ContextScopedFindInput {
 			!this.filters.codeInput ||
 			!this.filters.codeOutput;
 
-		// for now, allow the default state to enable regex, since it would be strange for regex to suddenly
-		// be disabled when a notebook is opened. However, since regex isn't supported for outputs, this should
-		// be revisted.
-		if (this.regex) {
-			if ((this.filters.markupPreview || this.filters.codeOutput) && this._filterChecked && this._visible) {
-				this.regex.disable();
-				this.regex.domNode.tabIndex = -1;
-				this.regex.domNode.classList.toggle('disabled', true);
-			} else {
-				this.regex.enable();
-				this.regex.domNode.tabIndex = 0;
-				this.regex.domNode.classList.toggle('disabled', false);
-			}
-		}
+		// TODO: find a way to express that searching notebook output and markdown preview don't support regex.
+
 		this._findFilter.applyStyles(this._filterChecked);
 	}
 }

--- a/src/vs/workbench/contrib/search/browser/searchModel.ts
+++ b/src/vs/workbench/contrib/search/browser/searchModel.ts
@@ -792,7 +792,11 @@ export class FileMatch extends Disposable implements IFileMatch {
 				webviewMatches: webviewMatches
 			};
 		});
-		this._findMatchDecorationModel.setAllFindMatchesDecorations(cellFindMatch);
+		try {
+			this._findMatchDecorationModel.setAllFindMatchesDecorations(cellFindMatch);
+		} catch (e) {
+			// no op, might happen due to bugs related to cell output regex search
+		}
 	}
 	async updateMatchesForEditorWidget(): Promise<void> {
 		if (!this._notebookEditorWidget) {


### PR DESCRIPTION
Deletes the code that changes the regex state depending on the toggle. I suspect it wasn't working properly anyways, and we need a better solution for telling the user that outputs can't be regex-searched.  Follow-up work will be done in https://github.com/microsoft/vscode/issues/183882.

Fixes #183858

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
