### PR TITLE
joh/overwhelming tuna

### DIFF
--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -4135,6 +4135,10 @@ export interface ISuggestOptions {
 	 */
 	filterGraceful?: boolean;
 	/**
+	 * Prevent quick suggestions when a snippet is active. Defaults to true.
+	 */
+	snippetsPreventQuickSuggestions?: boolean;
+	/**
 	 * Favors words that appear close to the cursor.
 	 */
 	localityBonus?: boolean;
@@ -4295,6 +4299,7 @@ class EditorSuggest extends BaseEditorOption<EditorOption.suggest, ISuggestOptio
 		const defaults: InternalSuggestOptions = {
 			insertMode: 'insert',
 			filterGraceful: true,
+			snippetsPreventQuickSuggestions: true,
 			localityBonus: false,
 			shareSuggestSelections: false,
 			selectionMode: 'always',
@@ -4372,6 +4377,11 @@ class EditorSuggest extends BaseEditorOption<EditorOption.suggest, ISuggestOptio
 					],
 					default: defaults.selectionMode,
 					markdownDescription: nls.localize('suggest.selectionMode', "Controls whether a suggestion is selected when the widget shows. Note that this only applies to automatically triggered suggestions (`#editor.quickSuggestions#` and `#editor.suggestOnTriggerCharacters#`) and that a suggestion is always selected when explicitly invoked, e.g via `Ctrl+Space`.")
+				},
+				'editor.suggest.snippetsPreventQuickSuggestions': {
+					type: 'boolean',
+					default: defaults.snippetsPreventQuickSuggestions,
+					description: nls.localize('suggest.snippetsPreventQuickSuggestions', "Controls whether an active snippet prevents quick suggestions.")
 				},
 				'editor.suggest.showIcons': {
 					type: 'boolean',
@@ -4563,6 +4573,7 @@ class EditorSuggest extends BaseEditorOption<EditorOption.suggest, ISuggestOptio
 		return {
 			insertMode: stringSet(input.insertMode, this.defaultValue.insertMode, ['insert', 'replace']),
 			filterGraceful: boolean(input.filterGraceful, this.defaultValue.filterGraceful),
+			snippetsPreventQuickSuggestions: boolean(input.snippetsPreventQuickSuggestions, this.defaultValue.filterGraceful),
 			localityBonus: boolean(input.localityBonus, this.defaultValue.localityBonus),
 			shareSuggestSelections: boolean(input.shareSuggestSelections, this.defaultValue.shareSuggestSelections),
 			selectionMode: stringSet(input.selectionMode, this.defaultValue.selectionMode, ['always', 'never', 'whenQuickSuggestion', 'whenTriggerCharacter']),

--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -4299,7 +4299,7 @@ class EditorSuggest extends BaseEditorOption<EditorOption.suggest, ISuggestOptio
 		const defaults: InternalSuggestOptions = {
 			insertMode: 'insert',
 			filterGraceful: true,
-			snippetsPreventQuickSuggestions: true,
+			snippetsPreventQuickSuggestions: false,
 			localityBonus: false,
 			shareSuggestSelections: false,
 			selectionMode: 'always',

--- a/src/vs/editor/contrib/suggest/browser/suggestController.ts
+++ b/src/vs/editor/contrib/suggest/browser/suggestController.ts
@@ -249,7 +249,11 @@ export class SuggestController implements IEditorContribution {
 				// don't "focus" item when configured to do so or when in snippet mode (and configured to do so)
 				const options = this.editor.getOption(EditorOption.suggest);
 
-				if (options.selectionMode === 'never' || options.selectionMode === 'always') {
+				if (options.snippetsPreventQuickSuggestions && SnippetController2.get(this.editor)?.isInSnippet()) {
+					// SPECIAL: in snippet mode, we never focus unless the user wants to
+					noFocus = true;
+
+				} else if (options.selectionMode === 'never' || options.selectionMode === 'always') {
 					// simple: always or never
 					noFocus = options.selectionMode === 'never';
 
@@ -777,7 +781,7 @@ registerEditorCommand(new SuggestCommand({
 	kbOpts: [{
 		// normal tab
 		primary: KeyCode.Tab,
-		kbExpr: ContextKeyExpr.and(SuggestContext.Visible, EditorContextKeys.textInputFocus, SnippetController2.InSnippetMode.toNegated()),
+		kbExpr: ContextKeyExpr.and(SuggestContext.Visible, EditorContextKeys.textInputFocus),
 		weight,
 	}, {
 		// accept on enter has special rules
@@ -811,7 +815,7 @@ registerEditorCommand(new SuggestCommand({
 	precondition: ContextKeyExpr.and(SuggestContext.Visible, EditorContextKeys.textInputFocus, SuggestContext.HasFocusedSuggestion),
 	kbOpts: {
 		weight: weight,
-		kbExpr: ContextKeyExpr.and(EditorContextKeys.textInputFocus, SnippetController2.InSnippetMode.toNegated()),
+		kbExpr: EditorContextKeys.textInputFocus,
 		primary: KeyMod.Shift | KeyCode.Enter,
 		secondary: [KeyMod.Shift | KeyCode.Tab],
 	},

--- a/src/vs/editor/contrib/suggest/browser/suggestController.ts
+++ b/src/vs/editor/contrib/suggest/browser/suggestController.ts
@@ -246,14 +246,9 @@ export class SuggestController implements IEditorContribution {
 
 			let noFocus = false;
 			if (e.triggerOptions.auto) {
-				// don't "focus" item when configured to do so or when in snippet mode (and configured to do so)
+				// don't "focus" item when configured to do
 				const options = this.editor.getOption(EditorOption.suggest);
-
-				if (options.snippetsPreventQuickSuggestions && SnippetController2.get(this.editor)?.isInSnippet()) {
-					// SPECIAL: in snippet mode, we never focus unless the user wants to
-					noFocus = true;
-
-				} else if (options.selectionMode === 'never' || options.selectionMode === 'always') {
+				if (options.selectionMode === 'never' || options.selectionMode === 'always') {
 					// simple: always or never
 					noFocus = options.selectionMode === 'never';
 

--- a/src/vs/editor/contrib/suggest/test/browser/completionModel.test.ts
+++ b/src/vs/editor/contrib/suggest/test/browser/completionModel.test.ts
@@ -35,6 +35,7 @@ suite('CompletionModel', function () {
 
 	const defaultOptions = <InternalSuggestOptions>{
 		insertMode: 'insert',
+		snippetsPreventQuickSuggestions: true,
 		filterGraceful: true,
 		localityBonus: false,
 		shareSuggestSelections: false,

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -4544,6 +4544,10 @@ declare namespace monaco.editor {
 		 */
 		filterGraceful?: boolean;
 		/**
+		 * Prevent quick suggestions when a snippet is active. Defaults to true.
+		 */
+		snippetsPreventQuickSuggestions?: boolean;
+		/**
 		 * Favors words that appear close to the cursor.
 		 */
 		localityBonus?: boolean;


### PR DESCRIPTION
re https://github.com/microsoft/vscode/issues/173387

- Revert "When snippet mode is active, make `Tab` not accept suggestion but advance placeholder"
- revert not focusing completion list when quick suggest happens during snippet
- change `snippetsPreventQuickSuggestions` default to false
