### PR TITLE
fix: remove extraneous incorrect context keys

### DIFF
--- a/src/vs/workbench/contrib/testing/browser/testingExplorerView.ts
+++ b/src/vs/workbench/contrib/testing/browser/testingExplorerView.ts
@@ -1394,12 +1394,6 @@ const getActionableElementActions = (
 		], [
 			TestingContextKeys.supportsContinuousRun.key,
 			supportsCr,
-		], [
-			TestingContextKeys.controllerId.key,
-			test.controllerId,
-		], [
-			TestingContextKeys.testItemExtId.key,
-			test.item.extId,
 		]);
 	}
 


### PR DESCRIPTION
These were actually getting added in getTestItemContextOverlay, and the test ID was using the extended ID which extensions do not know about.

Fixes #183612

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
