### PR TITLE
Adding the provider info in the interactive editor

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadChat.ts
+++ b/src/vs/workbench/api/browser/mainThreadChat.ts
@@ -76,7 +76,7 @@ export class MainThreadChat extends Disposable implements MainThreadChatShape {
 		const unreg = this._chatService.registerProvider({
 			id,
 			displayName: registration.label,
-			iconUrl: registration.extensionIcon,
+			iconUri: registration.extensionIcon,
 			prepareSession: async (initialState, token) => {
 				const session = await this._proxy.$prepareChat(handle, initialState, token);
 				if (!session) {

--- a/src/vs/workbench/api/browser/mainThreadChat.ts
+++ b/src/vs/workbench/api/browser/mainThreadChat.ts
@@ -76,6 +76,7 @@ export class MainThreadChat extends Disposable implements MainThreadChatShape {
 		const unreg = this._chatService.registerProvider({
 			id,
 			displayName: registration.label,
+			iconUrl: registration.extensionIcon,
 			prepareSession: async (initialState, token) => {
 				const session = await this._proxy.$prepareChat(handle, initialState, token);
 				if (!session) {

--- a/src/vs/workbench/contrib/chat/common/chatService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService.ts
@@ -49,7 +49,7 @@ export interface IPersistedChatState { }
 export interface IChatProvider {
 	readonly id: string;
 	readonly displayName: string;
-	readonly iconUrl?: URI | undefined;
+	readonly iconUri?: URI | undefined;
 	prepareSession(initialState: IPersistedChatState | undefined, token: CancellationToken): ProviderResult<IChat | undefined>;
 	resolveRequest?(session: IChat, context: any, token: CancellationToken): ProviderResult<IChatRequest>;
 	provideWelcomeMessage?(token: CancellationToken): ProviderResult<(string | IChatReplyFollowup[])[] | undefined>;
@@ -169,7 +169,7 @@ export interface IChatDetail {
 export interface IChatProviderInfo {
 	id: string;
 	displayName: string;
-	iconUrl?: URI | undefined;
+	iconUri?: URI | undefined;
 }
 
 export const IChatService = createDecorator<IChatService>('IChatService');

--- a/src/vs/workbench/contrib/chat/common/chatService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService.ts
@@ -49,7 +49,7 @@ export interface IPersistedChatState { }
 export interface IChatProvider {
 	readonly id: string;
 	readonly displayName: string;
-	readonly iconUrl?: string;
+	readonly iconUrl?: URI | undefined;
 	prepareSession(initialState: IPersistedChatState | undefined, token: CancellationToken): ProviderResult<IChat | undefined>;
 	resolveRequest?(session: IChat, context: any, token: CancellationToken): ProviderResult<IChatRequest>;
 	provideWelcomeMessage?(token: CancellationToken): ProviderResult<(string | IChatReplyFollowup[])[] | undefined>;
@@ -169,6 +169,7 @@ export interface IChatDetail {
 export interface IChatProviderInfo {
 	id: string;
 	displayName: string;
+	iconUrl?: URI | undefined;
 }
 
 export const IChatService = createDecorator<IChatService>('IChatService');

--- a/src/vs/workbench/contrib/chat/common/chatServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/chatServiceImpl.ts
@@ -588,7 +588,7 @@ export class ChatService extends Disposable implements IChatService {
 			return {
 				id: provider.id,
 				displayName: provider.displayName,
-				iconUrl: provider.iconUrl
+				iconUri: provider.iconUri
 			};
 		});
 	}

--- a/src/vs/workbench/contrib/chat/common/chatServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/chatServiceImpl.ts
@@ -587,7 +587,8 @@ export class ChatService extends Disposable implements IChatService {
 		return Array.from(this._providers.values()).map(provider => {
 			return {
 				id: provider.id,
-				displayName: provider.displayName
+				displayName: provider.displayName,
+				iconUrl: provider.iconUrl
 			};
 		});
 	}

--- a/src/vs/workbench/contrib/chat/common/chatViewModel.ts
+++ b/src/vs/workbench/contrib/chat/common/chatViewModel.ts
@@ -180,6 +180,7 @@ export class ChatViewModel extends Disposable implements IChatViewModel {
 			.forEach((item: ChatResponseViewModel) => item.dispose());
 	}
 }
+
 export class ChatRequestViewModel implements IChatRequestViewModel {
 	get id() {
 		return this._model.id;

--- a/src/vs/workbench/contrib/chat/common/chatViewModel.ts
+++ b/src/vs/workbench/contrib/chat/common/chatViewModel.ts
@@ -180,7 +180,6 @@ export class ChatViewModel extends Disposable implements IChatViewModel {
 			.forEach((item: ChatResponseViewModel) => item.dispose());
 	}
 }
-
 export class ChatRequestViewModel implements IChatRequestViewModel {
 	get id() {
 		return this._model.id;

--- a/src/vs/workbench/contrib/interactiveEditor/browser/interactiveEditor.css
+++ b/src/vs/workbench/contrib/interactiveEditor/browser/interactiveEditor.css
@@ -141,6 +141,15 @@
 	font-weight: bold;
 }
 
+.monaco-editor .interactive-editor .markdownMessage .providerAvatar {
+	display: inline-block;
+}
+
+.monaco-editor .interactive-editor .markdownMessage .providerName {
+	display: inline-block;
+	margin-left: 5px;
+}
+
 .monaco-editor .interactive-editor .markdownMessage .message * {
 	margin: unset;
 }

--- a/src/vs/workbench/contrib/interactiveEditor/browser/interactiveEditor.css
+++ b/src/vs/workbench/contrib/interactiveEditor/browser/interactiveEditor.css
@@ -139,10 +139,13 @@
 	margin-left: 5px;
 	margin-bottom: 5px;
 	font-weight: bold;
+	display: flex;
 }
 
 .monaco-editor .interactive-editor .markdownMessage .providerAvatar {
 	display: inline-block;
+	height: 20px;
+	width: 20px;
 }
 
 .monaco-editor .interactive-editor .markdownMessage .providerName {

--- a/src/vs/workbench/contrib/interactiveEditor/browser/interactiveEditor.css
+++ b/src/vs/workbench/contrib/interactiveEditor/browser/interactiveEditor.css
@@ -135,6 +135,12 @@
 	display: none;
 }
 
+.monaco-editor .interactive-editor .markdownMessage .providerInfo {
+	margin-left: 5px;
+	margin-bottom: 5px;
+	font-weight: bold;
+}
+
 .monaco-editor .interactive-editor .markdownMessage .message * {
 	margin: unset;
 }

--- a/src/vs/workbench/contrib/interactiveEditor/browser/interactiveEditorWidget.ts
+++ b/src/vs/workbench/contrib/interactiveEditor/browser/interactiveEditorWidget.ts
@@ -439,33 +439,25 @@ export class InteractiveEditorWidget {
 	}
 
 	updateMarkdownMessage(message: Node | undefined) {
-		this._elements.markdownMessage.classList.toggle('hidden', !message);
-
-		// --- potentially place elsewhere
 		const providerInfo = this._chatService.getProviderInfos()[0];
 		if (!providerInfo) {
 			return;
 		}
-		console.log('providerInfo : ', providerInfo);
-
 		const providerName = providerInfo.displayName;
 		reset(this._elements.providerName, providerName);
-		const providerIconUrl = providerInfo.iconUri;
-		console.log('providerIconUrl : ', providerIconUrl);
-
-		if (providerIconUrl) {
+		const providerIconUri = providerInfo.iconUri;
+		if (providerIconUri) {
 			const avatarIcon = $<HTMLImageElement>('img.icon');
 			avatarIcon.style.height = 20 + 'px';
 			avatarIcon.style.width = 20 + 'px';
-			avatarIcon.src = FileAccess.uriToBrowserUri(providerIconUrl).toString(true);
+			avatarIcon.src = FileAccess.uriToBrowserUri(providerIconUri).toString(true);
 			reset(this._elements.providerAvatar, avatarIcon);
 		} else {
 			const defaultIcon = Codicon.account;
 			const avatarIcon = $(ThemeIcon.asCSSSelector(defaultIcon));
 			reset(this._elements.providerAvatar, avatarIcon);
 		}
-		// ---
-
+		this._elements.markdownMessage.classList.toggle('hidden', !message);
 		if (!message) {
 			this._ctxMessageCropState.reset();
 			reset(this._elements.message);

--- a/src/vs/workbench/contrib/interactiveEditor/browser/interactiveEditorWidget.ts
+++ b/src/vs/workbench/contrib/interactiveEditor/browser/interactiveEditorWidget.ts
@@ -450,7 +450,7 @@ export class InteractiveEditorWidget {
 
 		const providerName = providerInfo.displayName;
 		reset(this._elements.providerName, providerName);
-		const providerIconUrl = providerInfo.iconUrl;
+		const providerIconUrl = providerInfo.iconUri;
 		console.log('providerIconUrl : ', providerIconUrl);
 
 		if (providerIconUrl) {

--- a/src/vs/workbench/contrib/interactiveEditor/browser/interactiveEditorWidget.ts
+++ b/src/vs/workbench/contrib/interactiveEditor/browser/interactiveEditorWidget.ts
@@ -14,6 +14,7 @@ import { IInstantiationService } from 'vs/platform/instantiation/common/instanti
 import { ZoneWidget } from 'vs/editor/contrib/zoneWidget/browser/zoneWidget';
 import { CTX_INTERACTIVE_EDITOR_FOCUSED, CTX_INTERACTIVE_EDITOR_INNER_CURSOR_FIRST, CTX_INTERACTIVE_EDITOR_INNER_CURSOR_LAST, CTX_INTERACTIVE_EDITOR_EMPTY, CTX_INTERACTIVE_EDITOR_OUTER_CURSOR_POSITION, CTX_INTERACTIVE_EDITOR_VISIBLE, MENU_INTERACTIVE_EDITOR_WIDGET, MENU_INTERACTIVE_EDITOR_WIDGET_STATUS, MENU_INTERACTIVE_EDITOR_WIDGET_MARKDOWN_MESSAGE, CTX_INTERACTIVE_EDITOR_MESSAGE_CROP_STATE, IInteractiveEditorSlashCommand, MENU_INTERACTIVE_EDITOR_WIDGET_FEEDBACK, ACTION_ACCEPT_CHANGES } from 'vs/workbench/contrib/interactiveEditor/common/interactiveEditor';
 import { IModelDeltaDecoration, ITextModel } from 'vs/editor/common/model';
+import { Dimension, addDisposableListener, getTotalHeight, getTotalWidth, h, reset, $ } from 'vs/base/browser/dom';
 import { Emitter, Event, MicrotaskEmitter } from 'vs/base/common/event';
 import { IEditorConstructionOptions } from 'vs/editor/browser/config/editorConfiguration';
 import { ICodeEditorWidgetOptions } from 'vs/editor/browser/widget/codeEditorWidget';
@@ -51,7 +52,6 @@ import { assertType } from 'vs/base/common/types';
 import { renderLabelWithIcons } from 'vs/base/browser/ui/iconLabel/iconLabels';
 import { IdleValue } from 'vs/base/common/async';
 import { IChatService } from 'vs/workbench/contrib/chat/common/chatService';
-import * as dom from 'vs/base/browser/dom';
 import { ThemeIcon } from 'vs/base/common/themables';
 import { Codicon } from 'vs/base/common/codicons';
 import { FileAccess } from 'vs/base/common/network';
@@ -454,14 +454,14 @@ export class InteractiveEditorWidget {
 		console.log('providerIconUrl : ', providerIconUrl);
 
 		if (providerIconUrl) {
-			const avatarIcon = dom.$<HTMLImageElement>('img.icon');
+			const avatarIcon = $<HTMLImageElement>('img.icon');
 			avatarIcon.style.height = 20 + 'px';
 			avatarIcon.style.width = 20 + 'px';
 			avatarIcon.src = FileAccess.uriToBrowserUri(providerIconUrl).toString(true);
 			reset(this._elements.providerAvatar, avatarIcon);
 		} else {
 			const defaultIcon = Codicon.account;
-			const avatarIcon = dom.$(ThemeIcon.asCSSSelector(defaultIcon));
+			const avatarIcon = $(ThemeIcon.asCSSSelector(defaultIcon));
 			reset(this._elements.providerAvatar, avatarIcon);
 		}
 		// ---

--- a/src/vs/workbench/contrib/interactiveEditor/test/browser/interactiveEditorController.test.ts
+++ b/src/vs/workbench/contrib/interactiveEditor/test/browser/interactiveEditorController.test.ts
@@ -23,6 +23,17 @@ import { ITextModel } from 'vs/editor/common/model';
 import { IEditorProgressService, IProgressRunner } from 'vs/platform/progress/common/progress';
 import { mock } from 'vs/base/test/common/mock';
 import { Emitter, Event } from 'vs/base/common/event';
+import { IChatProviderInfo, IChatService } from 'vs/workbench/contrib/chat/common/chatService';
+
+class TestChatService {
+	constructor() { }
+	getProviderInfos(): IChatProviderInfo[] {
+		return [{
+			id: 'test',
+			displayName: 'Test'
+		}];
+	}
+}
 
 suite('InteractiveEditorController', function () {
 
@@ -56,6 +67,7 @@ suite('InteractiveEditorController', function () {
 	setup(function () {
 
 		const contextKeyService = new MockContextKeyService();
+		const chatService = new TestChatService();
 		interactiveEditorService = new InteractiveEditorServiceImpl(contextKeyService);
 
 		const serviceCollection = new ServiceCollection(
@@ -70,7 +82,8 @@ suite('InteractiveEditorController', function () {
 						done() { },
 					};
 				}
-			}]
+			}],
+			[IChatService, chatService]
 		);
 
 		instaService = workbenchInstantiationService(undefined, store).createChild(serviceCollection);


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-internalbacklog/issues/4316

The extension icon and the display name are shown in the interactive editor when a message is returned in order to make it clear that one is conversing with the specific provider