### PR TITLE
Disable move to file in TS versions < 5.2

### DIFF
--- a/extensions/typescript-language-features/src/languageFeatures/refactor.ts
+++ b/extensions/typescript-language-features/src/languageFeatures/refactor.ts
@@ -480,7 +480,7 @@ class TypeScriptRefactorProvider implements vscode.CodeActionProvider<TsCodeActi
 				...typeConverters.Range.toFileRangeRequestArgs(file, rangeOrSelection),
 				triggerReason: this.toTsTriggerReason(context),
 				kind: context.only?.value,
-				includeInteractiveActions: true,
+				includeInteractiveActions: this.client.apiVersion.gte(API.v520),
 			};
 			return this.client.execute('getApplicableRefactors', args, token);
 		});

--- a/extensions/typescript-language-features/src/tsServer/api.ts
+++ b/extensions/typescript-language-features/src/tsServer/api.ts
@@ -35,6 +35,7 @@ export class API {
 	public static readonly v480 = API.fromSimpleString('4.8.0');
 	public static readonly v490 = API.fromSimpleString('4.9.0');
 	public static readonly v510 = API.fromSimpleString('5.1.0');
+	public static readonly v520 = API.fromSimpleString('5.2.0');
 
 	public static fromVersionString(versionString: string): API {
 		let version = semver.valid(versionString);


### PR DESCRIPTION
There are still a few key bugs with this refactoring. We will  ship this as a preview for TS 5.2+ instead of for 5.1

