### PR TITLE
Change welcome dialog contribution to Eventually

### DIFF
--- a/src/vs/workbench/contrib/welcomeDialog/browser/welcomeDialog.contribution.ts
+++ b/src/vs/workbench/contrib/welcomeDialog/browser/welcomeDialog.contribution.ts
@@ -59,8 +59,8 @@ class WelcomeDialogContribution extends Disposable implements IWorkbenchContribu
 			return; // do not show if this is not the first session
 		}
 
-		const setting = configurationService.inspect<boolean>(configurationKey);
-		if (!setting.value) {
+		const setting = configurationService.getValue<boolean>(configurationKey);
+		if (!setting) {
 			return;
 		}
 
@@ -108,18 +108,18 @@ class WelcomeDialogContribution extends Disposable implements IWorkbenchContribu
 }
 
 Registry.as<IWorkbenchContributionsRegistry>(WorkbenchExtensions.Workbench)
-	.registerWorkbenchContribution(WelcomeDialogContribution, LifecyclePhase.Restored);
+	.registerWorkbenchContribution(WelcomeDialogContribution, LifecyclePhase.Eventually);
 
 const configurationRegistry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration);
 configurationRegistry.registerConfiguration({
 	...applicationConfigurationNodeBase,
 	properties: {
-		'workbench.welcome.experimental.dialog': {
+		'config.welcome.experimental.dialog': {
 			scope: ConfigurationScope.APPLICATION,
 			type: 'boolean',
 			default: false,
 			tags: ['experimental'],
-			description: localize('workbench.welcome.dialog', "When enabled, a welcome widget is shown in the editor")
+			description: localize('config.welcome.dialog', "When enabled, a welcome widget is shown in the editor")
 		}
 	}
 });


### PR DESCRIPTION
Fixes issue with Welcome Dialog not being rendered.


We control the dialogs visibility through an experimental setting. https://github.com/microsoft/vscode/blob/822eaefbabf1f8f387b56b37cc95453ee5eec14f/src/vs/workbench/contrib/welcomeDialog/browser/welcomeDialog.contribution.ts#L62

This experimental setting is set after the check above happens. https://github.com/microsoft/vscode/blob/822eaefbabf1f8f387b56b37cc95453ee5eec14f/src/vs/workbench/services/configuration/browser/configurationService.ts#L1305-L1306

Delaying this contribution initialization to Eventually as a fix. 