### PR TITLE
joh/inquisitive meerkat

### DIFF
--- a/src/vs/workbench/contrib/interactiveEditor/browser/interactiveEditorController.ts
+++ b/src/vs/workbench/contrib/interactiveEditor/browser/interactiveEditorController.ts
@@ -613,7 +613,7 @@ export class InteractiveEditorController implements IEditorContribution {
 		this[State.PAUSE]();
 
 		this._stashedSession.clear();
-		if (!mySession.isUnstashed && mySession.lastExchange?.response instanceof EditResponse) {
+		if (!mySession.isUnstashed && mySession.lastExchange) {
 			// only stash sessions that had edits
 			this._stashedSession.value = this._instaService.createInstance(StashedSession, this._editor, mySession);
 		} else {

--- a/src/vs/workbench/contrib/interactiveEditor/browser/interactiveEditorController.ts
+++ b/src/vs/workbench/contrib/interactiveEditor/browser/interactiveEditorController.ts
@@ -613,7 +613,7 @@ export class InteractiveEditorController implements IEditorContribution {
 		this[State.PAUSE]();
 
 		this._stashedSession.clear();
-		if (mySession.lastExchange?.response instanceof EditResponse) {
+		if (!mySession.isUnstashed && mySession.lastExchange?.response instanceof EditResponse) {
 			// only stash sessions that had edits
 			this._stashedSession.value = this._instaService.createInstance(StashedSession, this._editor, mySession);
 		} else {
@@ -771,6 +771,7 @@ class StashedSession {
 		}
 		this._listener.dispose();
 		const result = this._session;
+		result.markUnstashed();
 		this._session = undefined;
 		this._logService.debug('[IE] Unstashed session');
 		return result;

--- a/src/vs/workbench/contrib/interactiveEditor/browser/interactiveEditorController.ts
+++ b/src/vs/workbench/contrib/interactiveEditor/browser/interactiveEditorController.ts
@@ -612,8 +612,13 @@ export class InteractiveEditorController implements IEditorContribution {
 
 		this[State.PAUSE]();
 
-		this._stashedSession.clear(); // !important that this isn't done with `value = ...`
-		this._stashedSession.value = this._instaService.createInstance(StashedSession, this._editor, mySession);
+		this._stashedSession.clear();
+		if (mySession.lastExchange?.response instanceof EditResponse) {
+			// only stash sessions that had edits
+			this._stashedSession.value = this._instaService.createInstance(StashedSession, this._editor, mySession);
+		} else {
+			this._interactiveEditorSessionService.releaseSession(mySession);
+		}
 	}
 
 	// ---- controller API

--- a/src/vs/workbench/contrib/interactiveEditor/browser/interactiveEditorSession.ts
+++ b/src/vs/workbench/contrib/interactiveEditor/browser/interactiveEditorSession.ts
@@ -61,6 +61,7 @@ export class Session {
 	private _lastExpansionState: boolean | undefined;
 	private _lastTextModelChanges: LineRangeMapping[] | undefined;
 	private _lastSnapshot: ITextSnapshot | undefined;
+	private _isUnstashed: boolean = false;
 	private readonly _exchange: SessionExchange[] = [];
 	private readonly _startTime = new Date();
 	private readonly _teldata: Partial<TelemetryData>;
@@ -86,6 +87,14 @@ export class Session {
 
 	addInput(input: string): void {
 		this._lastInput = input;
+	}
+
+	get isUnstashed(): boolean {
+		return this._isUnstashed;
+	}
+
+	markUnstashed() {
+		this._isUnstashed = true;
 	}
 
 	get lastInput() {
@@ -114,6 +123,7 @@ export class Session {
 	}
 
 	addExchange(exchange: SessionExchange): void {
+		this._isUnstashed = false;
 		const newLen = this._exchange.push(exchange);
 		this._teldata.rounds += `${newLen}|`;
 	}


### PR DESCRIPTION
fixes https://github.com/microsoft/vscode-internalbacklog/issues/4281

- only stash sessions that are none empty
- only unstash a session once - unless new exchanges are made,
- account for all exchange types
