### PR TITLE
Not showing sticky widget on the left editor of inline diff

### DIFF
--- a/src/vs/editor/browser/widget/diffEditorWidget.ts
+++ b/src/vs/editor/browser/widget/diffEditorWidget.ts
@@ -1297,6 +1297,7 @@ export class DiffEditorWidget extends Disposable implements editorBrowser.IDiffE
 		result.readOnly = !this._options.originalEditable;
 		result.dropIntoEditor = { enabled: !result.readOnly };
 		result.extraEditorClassName = 'original-in-monaco-diff-editor';
+		result.stickyScroll = { enabled: false };
 		return {
 			...result,
 			dimension: {

--- a/src/vs/editor/browser/widget/diffEditorWidget.ts
+++ b/src/vs/editor/browser/widget/diffEditorWidget.ts
@@ -1287,6 +1287,7 @@ export class DiffEditorWidget extends Disposable implements editorBrowser.IDiffE
 			// never wrap hidden editor
 			result.wordWrapOverride1 = 'off';
 			result.wordWrapOverride2 = 'off';
+			result.stickyScroll = { enabled: false };
 		} else {
 			result.wordWrapOverride1 = this._options.diffWordWrap;
 		}
@@ -1297,7 +1298,6 @@ export class DiffEditorWidget extends Disposable implements editorBrowser.IDiffE
 		result.readOnly = !this._options.originalEditable;
 		result.dropIntoEditor = { enabled: !result.readOnly };
 		result.extraEditorClassName = 'original-in-monaco-diff-editor';
-		result.stickyScroll = { enabled: false };
 		return {
 			...result,
 			dimension: {

--- a/src/vs/editor/browser/widget/diffEditorWidget2/diffEditorWidget2.ts
+++ b/src/vs/editor/browser/widget/diffEditorWidget2/diffEditorWidget2.ts
@@ -281,6 +281,7 @@ export class DiffEditorWidget2 extends DelegatingEditor implements IDiffEditor {
 			// never wrap hidden editor
 			result.wordWrapOverride1 = 'off';
 			result.wordWrapOverride2 = 'off';
+			result.stickyScroll = { enabled: false };
 		} else {
 			result.wordWrapOverride1 = this._options.get().diffWordWrap;
 		}
@@ -291,7 +292,6 @@ export class DiffEditorWidget2 extends DelegatingEditor implements IDiffEditor {
 		result.readOnly = !options.originalEditable;
 		result.dropIntoEditor = { enabled: !result.readOnly };
 		result.extraEditorClassName = 'original-in-monaco-diff-editor';
-		result.stickyScroll = { enabled: false };
 		return result;
 	}
 

--- a/src/vs/editor/browser/widget/diffEditorWidget2/diffEditorWidget2.ts
+++ b/src/vs/editor/browser/widget/diffEditorWidget2/diffEditorWidget2.ts
@@ -291,6 +291,7 @@ export class DiffEditorWidget2 extends DelegatingEditor implements IDiffEditor {
 		result.readOnly = !options.originalEditable;
 		result.dropIntoEditor = { enabled: !result.readOnly };
 		result.extraEditorClassName = 'original-in-monaco-diff-editor';
+		result.stickyScroll = { enabled: false };
 		return result;
 	}
 

--- a/src/vs/editor/contrib/stickyScroll/browser/stickyScrollController.ts
+++ b/src/vs/editor/contrib/stickyScroll/browser/stickyScrollController.ts
@@ -26,7 +26,6 @@ import { ILanguageConfigurationService } from 'vs/editor/common/languages/langua
 import { ILanguageFeatureDebounceService } from 'vs/editor/common/services/languageFeatureDebounce';
 import * as dom from 'vs/base/browser/dom';
 import { StickyRange } from 'vs/editor/contrib/stickyScroll/browser/stickyScrollElement';
-import { ICodeEditorService } from 'vs/editor/browser/services/codeEditorService';
 
 interface CustomMouseEvent {
 	detail: string;
@@ -77,8 +76,7 @@ export class StickyScrollController extends Disposable implements IEditorContrib
 		@IInstantiationService private readonly _instaService: IInstantiationService,
 		@ILanguageConfigurationService _languageConfigurationService: ILanguageConfigurationService,
 		@ILanguageFeatureDebounceService _languageFeatureDebounceService: ILanguageFeatureDebounceService,
-		@IContextKeyService private readonly _contextKeyService: IContextKeyService,
-		@ICodeEditorService private readonly _codeEditorService: ICodeEditorService
+		@IContextKeyService private readonly _contextKeyService: IContextKeyService
 	) {
 		super();
 		this._stickyScrollWidget = new StickyScrollWidget(this._editor);
@@ -299,32 +297,15 @@ export class StickyScrollController extends Disposable implements IEditorContrib
 		});
 	}
 
-	private _removeStickyWidget(): void {
-		this._editor.removeOverlayWidget(this._stickyScrollWidget);
-		this._sessionStore.clear();
-		this._enabled = false;
-	}
-
 	private _readConfiguration() {
 		const options = this._editor.getOption(EditorOption.stickyScroll);
 
 		if (options.enabled === false) {
-			this._removeStickyWidget();
+			this._editor.removeOverlayWidget(this._stickyScrollWidget);
+			this._sessionStore.clear();
+			this._enabled = false;
 			return;
 		} else if (options.enabled && !this._enabled) {
-			// Do not render the sticky scroll if the editor is the left side of an inline diff editor
-			let isLeftSideOfInlineDiffEditor = false;
-			if (this._editor.getOption(EditorOption.inDiffEditor)) {
-				for (const diffEditor of this._codeEditorService.listDiffEditors()) {
-					if (diffEditor.getOriginalEditor() === this._editor && !diffEditor.renderSideBySide) {
-						isLeftSideOfInlineDiffEditor = true;
-					}
-				}
-			}
-			if (isLeftSideOfInlineDiffEditor) {
-				this._removeStickyWidget();
-				return;
-			}
 			// When sticky scroll was just enabled, add the listeners on the sticky scroll
 			this._editor.addOverlayWidget(this._stickyScrollWidget);
 			this._sessionStore.add(this._editor.onDidScrollChange(() => this._renderStickyScroll()));


### PR DESCRIPTION
Fixes #182276

Not showing the sticky widget in an editor when the editor is the left editor of an inline diff view