### PR TITLE
re-enable default zone widget revealing when showing

### DIFF
--- a/src/vs/workbench/contrib/interactiveEditor/browser/interactiveEditorWidget.ts
+++ b/src/vs/workbench/contrib/interactiveEditor/browser/interactiveEditorWidget.ts
@@ -748,10 +748,6 @@ export class InteractiveEditorZoneWidget extends ZoneWidget {
 		this._ctxVisible.set(true);
 	}
 
-	protected override revealRange(_range: Range, _isLastLine: boolean) {
-		// disabled
-	}
-
 	override hide(): void {
 		this._ctxVisible.reset();
 		this._ctxCursorPosition.reset();


### PR DESCRIPTION
fixes https://github.com/microsoft/vscode-internalbacklog/issues/4332, also fixes https://github.com/microsoft/vscode-internalbacklog/issues/3784
