### PR TITLE
Adding settings to control color decorator behavior

### DIFF
--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -352,7 +352,7 @@ export interface IEditorOptions {
 	/**
 	 * Controls what is the condition to spawn a color picker from a color dectorator
 	 */
-	colorDecoratorsActivatedOn?: 'click' | 'hover';
+	colorDecoratorsActivatedOn?: 'click and hover' | 'click' | 'hover';
 	/**
 	 * Controls the max number of color decorators that can be rendered in an editor at once.
 	 */
@@ -5216,8 +5216,9 @@ export const EditorOptions = {
 		EditorOption.colorDecorators, 'colorDecorators', true,
 		{ description: nls.localize('colorDecorators', "Controls whether the editor should render the inline color decorators and color picker.") }
 	)),
-	colorDecoratorActivatedOn: register(new EditorStringEnumOption(EditorOption.colorDecoratorsActivatedOn, 'colorDecoratorsActivatedOn', 'hover' as 'hover' | 'click', ['hover', 'click'] as const, {
+	colorDecoratorActivatedOn: register(new EditorStringEnumOption(EditorOption.colorDecoratorsActivatedOn, 'colorDecoratorsActivatedOn', 'click and hover' as 'click and hover' | 'hover' | 'click', ['click and hover', 'hover', 'click'] as const, {
 		enumDescriptions: [
+			nls.localize('editor.colorDecoratorActivatedOn.clickAndHover', "Make the color picker appear both on click and hover of the color decorator"),
 			nls.localize('editor.colorDecoratorActivatedOn.hover', "Make the color picker appear on hover of the color decorator"),
 			nls.localize('editor.colorDecoratorActivatedOn.click', "Make the color picker appear on click of the color decorator")
 		],

--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -352,7 +352,7 @@ export interface IEditorOptions {
 	/**
 	 * Controls what is the condition to spawn a color picker from a color dectorator
 	 */
-	colorDecoratorsActivatedOn?: 'click and hover' | 'click' | 'hover';
+	colorDecoratorsActivatedOn?: 'clickAndHover' | 'click' | 'hover';
 	/**
 	 * Controls the max number of color decorators that can be rendered in an editor at once.
 	 */
@@ -5216,7 +5216,7 @@ export const EditorOptions = {
 		EditorOption.colorDecorators, 'colorDecorators', true,
 		{ description: nls.localize('colorDecorators', "Controls whether the editor should render the inline color decorators and color picker.") }
 	)),
-	colorDecoratorActivatedOn: register(new EditorStringEnumOption(EditorOption.colorDecoratorsActivatedOn, 'colorDecoratorsActivatedOn', 'click and hover' as 'click and hover' | 'hover' | 'click', ['click and hover', 'hover', 'click'] as const, {
+	colorDecoratorActivatedOn: register(new EditorStringEnumOption(EditorOption.colorDecoratorsActivatedOn, 'colorDecoratorsActivatedOn', 'clickAndHover' as 'clickAndHover' | 'hover' | 'click', ['clickAndHover', 'hover', 'click'] as const, {
 		enumDescriptions: [
 			nls.localize('editor.colorDecoratorActivatedOn.clickAndHover', "Make the color picker appear both on click and hover of the color decorator"),
 			nls.localize('editor.colorDecoratorActivatedOn.hover', "Make the color picker appear on hover of the color decorator"),

--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -350,6 +350,10 @@ export interface IEditorOptions {
 	 */
 	colorDecorators?: boolean;
 	/**
+	 * Controls what is the condition to spawn a color picker from a color dectorator
+	 */
+	colorDecoratorsActivatedOn?: 'click' | 'hover';
+	/**
 	 * Controls the max number of color decorators that can be rendered in an editor at once.
 	 */
 	colorDecoratorsLimit?: number;
@@ -5062,7 +5066,8 @@ export const enum EditorOption {
 	tabFocusMode,
 	layoutInfo,
 	wrappingInfo,
-	defaultColorDecorators
+	defaultColorDecorators,
+	colorDecoratorsActivatedOn
 }
 
 export const EditorOptions = {
@@ -5211,6 +5216,13 @@ export const EditorOptions = {
 		EditorOption.colorDecorators, 'colorDecorators', true,
 		{ description: nls.localize('colorDecorators', "Controls whether the editor should render the inline color decorators and color picker.") }
 	)),
+	colorDecoratorActivatedOn: register(new EditorStringEnumOption(EditorOption.colorDecoratorsActivatedOn, 'colorDecoratorsActivatedOn', 'hover' as 'hover' | 'click', ['hover', 'click'] as const, {
+		enumDescriptions: [
+			nls.localize('editor.colorDecoratorActivatedOn.hover', "Make the color picker appear on hover of the color decorator"),
+			nls.localize('editor.colorDecoratorActivatedOn.click', "Make the color picker appear on click of the color decorator")
+		],
+		description: nls.localize('colorDecoratorActivatedOn', "Controls the condition to make a color picker appear from a color decorator")
+	})),
 	colorDecoratorsLimit: register(new EditorIntOption(
 		EditorOption.colorDecoratorsLimit, 'colorDecoratorsLimit', 500, 1, 1000000,
 		{

--- a/src/vs/editor/common/standalone/standaloneEnums.ts
+++ b/src/vs/editor/common/standalone/standaloneEnums.ts
@@ -315,7 +315,8 @@ export enum EditorOption {
 	tabFocusMode = 139,
 	layoutInfo = 140,
 	wrappingInfo = 141,
-	defaultColorDecorators = 142
+	defaultColorDecorators = 142,
+	colorDecoratorsActivatedOn = 143
 }
 
 /**

--- a/src/vs/editor/contrib/colorPicker/browser/colorContributions.ts
+++ b/src/vs/editor/contrib/colorPicker/browser/colorContributions.ts
@@ -34,7 +34,7 @@ export class ColorContribution extends Disposable implements IEditorContribution
 	private onMouseDown(mouseEvent: IEditorMouseEvent) {
 
 		const colorDecoratorsActivatedOn = this._editor.getOption(EditorOption.colorDecoratorsActivatedOn);
-		if (colorDecoratorsActivatedOn !== 'click' && colorDecoratorsActivatedOn !== 'click and hover') {
+		if (colorDecoratorsActivatedOn !== 'click' && colorDecoratorsActivatedOn !== 'clickAndHover') {
 			return;
 		}
 

--- a/src/vs/editor/contrib/colorPicker/browser/colorContributions.ts
+++ b/src/vs/editor/contrib/colorPicker/browser/colorContributions.ts
@@ -34,7 +34,7 @@ export class ColorContribution extends Disposable implements IEditorContribution
 	private onMouseDown(mouseEvent: IEditorMouseEvent) {
 
 		const colorDecoratorsActivatedOn = this._editor.getOption(EditorOption.colorDecoratorsActivatedOn);
-		if (colorDecoratorsActivatedOn !== 'click') {
+		if (colorDecoratorsActivatedOn !== 'click' && colorDecoratorsActivatedOn !== 'click and hover') {
 			return;
 		}
 

--- a/src/vs/editor/contrib/colorPicker/browser/colorContributions.ts
+++ b/src/vs/editor/contrib/colorPicker/browser/colorContributions.ts
@@ -6,6 +6,7 @@
 import { Disposable } from 'vs/base/common/lifecycle';
 import { ICodeEditor, IEditorMouseEvent, MouseTargetType } from 'vs/editor/browser/editorBrowser';
 import { EditorContributionInstantiation, registerEditorContribution } from 'vs/editor/browser/editorExtensions';
+import { EditorOption } from 'vs/editor/common/config/editorOptions';
 import { Range } from 'vs/editor/common/core/range';
 import { IEditorContribution } from 'vs/editor/common/editorCommon';
 import { ColorDecorationInjectedTextMarker } from 'vs/editor/contrib/colorPicker/browser/colorDetector';
@@ -31,6 +32,12 @@ export class ColorContribution extends Disposable implements IEditorContribution
 	}
 
 	private onMouseDown(mouseEvent: IEditorMouseEvent) {
+
+		const colorDecoratorsActivatedOn = this._editor.getOption(EditorOption.colorDecoratorsActivatedOn);
+		if (colorDecoratorsActivatedOn !== 'click') {
+			return;
+		}
+
 		const target = mouseEvent.target;
 
 		if (target.type !== MouseTargetType.CONTENT_TEXT) {
@@ -55,7 +62,7 @@ export class ColorContribution extends Disposable implements IEditorContribution
 		}
 		if (!hoverController.isColorPickerVisible()) {
 			const range = new Range(target.range.startLineNumber, target.range.startColumn + 1, target.range.endLineNumber, target.range.endColumn + 1);
-			hoverController.showContentHover(range, HoverStartMode.Immediate, HoverStartSource.Mouse, false);
+			hoverController.showContentHover(range, HoverStartMode.Immediate, HoverStartSource.Mouse, false, true);
 		}
 	}
 }

--- a/src/vs/editor/contrib/hover/browser/hover.ts
+++ b/src/vs/editor/contrib/hover/browser/hover.ts
@@ -182,7 +182,7 @@ export class ModesHoverController implements IEditorContribution {
 		if ((mouseOnDecorator && (
 			(decoratorActivatedOn === 'click' && !this._hoverActivatedByColorDecoratorClick) ||
 			(decoratorActivatedOn === 'hover' && !this._isHoverEnabled) ||
-			(decoratorActivatedOn === 'click and hover' && !this._isHoverEnabled && !this._hoverActivatedByColorDecoratorClick)))
+			(decoratorActivatedOn === 'clickAndHover' && !this._isHoverEnabled && !this._hoverActivatedByColorDecoratorClick)))
 			|| !mouseOnDecorator && !this._isHoverEnabled && !this._hoverActivatedByColorDecoratorClick
 		) {
 			this._hideWidgets();

--- a/src/vs/editor/contrib/hover/browser/hover.ts
+++ b/src/vs/editor/contrib/hover/browser/hover.ts
@@ -199,6 +199,14 @@ export class ModesHoverController implements IEditorContribution {
 						return;
 					}
 				}
+			} else if (decoratorActivatedOn === 'click and hover') {
+				console.log('entered into the third case');
+				if (!this._activatedByColorDecoratorClick) {
+					if (!this._isHoverEnabled) {
+						this._hideWidgets();
+						return;
+					}
+				}
 			} else {
 				throw new Error('Invalid value for EditorOption.colorDecoratorsActivatedOn');
 			}

--- a/src/vs/editor/contrib/hover/browser/hover.ts
+++ b/src/vs/editor/contrib/hover/browser/hover.ts
@@ -179,6 +179,11 @@ export class ModesHoverController implements IEditorContribution {
 		const onDecorator = target.element?.classList.contains('colorpicker-color-decoration');
 		const decoratorActivatedOn = this._editor.getOption(EditorOption.colorDecoratorsActivatedOn);
 
+		console.log('onDecorator : ', onDecorator);
+		console.log('decoratorActivatedOn : ', decoratorActivatedOn);
+
+		// TODO: finish the following code whith the option 'click and hover''
+		// TODO: find out why the color hover seems to disappear when clicking on th box
 		if (onDecorator) {
 			if (decoratorActivatedOn === 'click') {
 				if (!this._activatedByColorDecoratorClick) {

--- a/src/vs/editor/contrib/hover/browser/hover.ts
+++ b/src/vs/editor/contrib/hover/browser/hover.ts
@@ -46,7 +46,7 @@ export class ModesHoverController implements IEditorContribution {
 	private _hoverClicked: boolean;
 	private _isHoverEnabled!: boolean;
 	private _isHoverSticky!: boolean;
-	private _activatedByColorDecoratorClick: boolean = false;
+	private _hoverActivatedByColorDecoratorClick: boolean = false;
 
 	static get(editor: ICodeEditor): ModesHoverController | null {
 		return editor.getContribution<ModesHoverController>(ModesHoverController.ID);
@@ -176,45 +176,17 @@ export class ModesHoverController implements IEditorContribution {
 			return;
 		}
 
-		const onDecorator = target.element?.classList.contains('colorpicker-color-decoration');
+		const mouseOnDecorator = target.element?.classList.contains('colorpicker-color-decoration');
 		const decoratorActivatedOn = this._editor.getOption(EditorOption.colorDecoratorsActivatedOn);
 
-		console.log('onDecorator : ', onDecorator);
-		console.log('decoratorActivatedOn : ', decoratorActivatedOn);
-
-		// TODO: finish the following code whith the option 'click and hover''
-		// TODO: find out why the color hover seems to disappear when clicking on th box
-		if (onDecorator) {
-			if (decoratorActivatedOn === 'click') {
-				if (!this._activatedByColorDecoratorClick) {
-					this._hideWidgets();
-					return;
-				}
-			} else if (decoratorActivatedOn === 'hover') {
-				if (this._activatedByColorDecoratorClick) {
-					throw new Error('Invalid state');
-				} else {
-					if (!this._isHoverEnabled) {
-						this._hideWidgets();
-						return;
-					}
-				}
-			} else if (decoratorActivatedOn === 'click and hover') {
-				console.log('entered into the third case');
-				if (!this._activatedByColorDecoratorClick) {
-					if (!this._isHoverEnabled) {
-						this._hideWidgets();
-						return;
-					}
-				}
-			} else {
-				throw new Error('Invalid value for EditorOption.colorDecoratorsActivatedOn');
-			}
-		} else {
-			if (!this._isHoverEnabled && !this._activatedByColorDecoratorClick) {
-				this._hideWidgets();
-				return;
-			}
+		if ((mouseOnDecorator && (
+			(decoratorActivatedOn === 'click' && !this._hoverActivatedByColorDecoratorClick) ||
+			(decoratorActivatedOn === 'hover' && !this._isHoverEnabled) ||
+			(decoratorActivatedOn === 'click and hover' && !this._isHoverEnabled && !this._hoverActivatedByColorDecoratorClick)))
+			|| !mouseOnDecorator && !this._isHoverEnabled && !this._hoverActivatedByColorDecoratorClick
+		) {
+			this._hideWidgets();
+			return;
 		}
 
 		const contentWidget = this._getOrCreateContentWidget();
@@ -256,7 +228,7 @@ export class ModesHoverController implements IEditorContribution {
 		if ((this._isMouseDown && this._hoverClicked && this._contentWidget?.isColorPickerVisible()) || InlineSuggestionHintsContentWidget.dropDownVisible) {
 			return;
 		}
-		this._activatedByColorDecoratorClick = false;
+		this._hoverActivatedByColorDecoratorClick = false;
 		this._hoverClicked = false;
 		this._glyphWidget?.hide();
 		this._contentWidget?.hide();
@@ -274,7 +246,7 @@ export class ModesHoverController implements IEditorContribution {
 	}
 
 	public showContentHover(range: Range, mode: HoverStartMode, source: HoverStartSource, focus: boolean, activatedByColorDecoratorClick: boolean = false): void {
-		this._activatedByColorDecoratorClick = activatedByColorDecoratorClick;
+		this._hoverActivatedByColorDecoratorClick = activatedByColorDecoratorClick;
 		this._getOrCreateContentWidget().startShowingAtRange(range, mode, source, focus);
 	}
 

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -3437,7 +3437,7 @@ declare namespace monaco.editor {
 		/**
 		 * Controls what is the condition to spawn a color picker from a color dectorator
 		 */
-		colorDecoratorsActivatedOn?: 'click' | 'hover';
+		colorDecoratorsActivatedOn?: 'click and hover' | 'click' | 'hover';
 		/**
 		 * Controls the max number of color decorators that can be rendered in an editor at once.
 		 */
@@ -4934,7 +4934,7 @@ declare namespace monaco.editor {
 		codeLensFontFamily: IEditorOption<EditorOption.codeLensFontFamily, string>;
 		codeLensFontSize: IEditorOption<EditorOption.codeLensFontSize, number>;
 		colorDecorators: IEditorOption<EditorOption.colorDecorators, boolean>;
-		colorDecoratorActivatedOn: IEditorOption<EditorOption.colorDecoratorsActivatedOn, 'click' | 'hover'>;
+		colorDecoratorActivatedOn: IEditorOption<EditorOption.colorDecoratorsActivatedOn, 'click and hover' | 'click' | 'hover'>;
 		colorDecoratorsLimit: IEditorOption<EditorOption.colorDecoratorsLimit, number>;
 		columnSelection: IEditorOption<EditorOption.columnSelection, boolean>;
 		comments: IEditorOption<EditorOption.comments, Readonly<Required<IEditorCommentsOptions>>>;

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -3435,6 +3435,10 @@ declare namespace monaco.editor {
 		 */
 		colorDecorators?: boolean;
 		/**
+		 * Controls what is the condition to spawn a color picker from a color dectorator
+		 */
+		colorDecoratorsActivatedOn?: 'click' | 'hover';
+		/**
 		 * Controls the max number of color decorators that can be rendered in an editor at once.
 		 */
 		colorDecoratorsLimit?: number;
@@ -4905,7 +4909,8 @@ declare namespace monaco.editor {
 		tabFocusMode = 139,
 		layoutInfo = 140,
 		wrappingInfo = 141,
-		defaultColorDecorators = 142
+		defaultColorDecorators = 142,
+		colorDecoratorsActivatedOn = 143
 	}
 
 	export const EditorOptions: {
@@ -4929,6 +4934,7 @@ declare namespace monaco.editor {
 		codeLensFontFamily: IEditorOption<EditorOption.codeLensFontFamily, string>;
 		codeLensFontSize: IEditorOption<EditorOption.codeLensFontSize, number>;
 		colorDecorators: IEditorOption<EditorOption.colorDecorators, boolean>;
+		colorDecoratorActivatedOn: IEditorOption<EditorOption.colorDecoratorsActivatedOn, 'click' | 'hover'>;
 		colorDecoratorsLimit: IEditorOption<EditorOption.colorDecoratorsLimit, number>;
 		columnSelection: IEditorOption<EditorOption.columnSelection, boolean>;
 		comments: IEditorOption<EditorOption.comments, Readonly<Required<IEditorCommentsOptions>>>;

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -3437,7 +3437,7 @@ declare namespace monaco.editor {
 		/**
 		 * Controls what is the condition to spawn a color picker from a color dectorator
 		 */
-		colorDecoratorsActivatedOn?: 'click and hover' | 'click' | 'hover';
+		colorDecoratorsActivatedOn?: 'clickAndHover' | 'click' | 'hover';
 		/**
 		 * Controls the max number of color decorators that can be rendered in an editor at once.
 		 */
@@ -4934,7 +4934,7 @@ declare namespace monaco.editor {
 		codeLensFontFamily: IEditorOption<EditorOption.codeLensFontFamily, string>;
 		codeLensFontSize: IEditorOption<EditorOption.codeLensFontSize, number>;
 		colorDecorators: IEditorOption<EditorOption.colorDecorators, boolean>;
-		colorDecoratorActivatedOn: IEditorOption<EditorOption.colorDecoratorsActivatedOn, 'click and hover' | 'click' | 'hover'>;
+		colorDecoratorActivatedOn: IEditorOption<EditorOption.colorDecoratorsActivatedOn, 'clickAndHover' | 'click' | 'hover'>;
 		colorDecoratorsLimit: IEditorOption<EditorOption.colorDecoratorsLimit, number>;
 		columnSelection: IEditorOption<EditorOption.columnSelection, boolean>;
 		comments: IEditorOption<EditorOption.comments, Readonly<Required<IEditorCommentsOptions>>>;


### PR DESCRIPTION
Fixes #179575
Fixes #182697


These two fixes are placed into one PR as they are intimately linked. Somes notes about the PR:

- From now on, when one clicks on the color decorators, then no matter if the hovers are enabled or disabled, the color picker hover appears. This is the fix for https://github.com/microsoft/vscode/issues/179575
- This PR also introduces a new setting which is called `editor.colorDecoratorsActivatedOn`. It can take three values, `click`, `hover` and `click and hover`. The `click` option signifies that the color picker appears when one clicks on the color decorator, the `hover` option signifies that the color picker appears when one hovers on the color decorator and the `click and hover` does both. This is the fix for: https://github.com/microsoft/vscode/issues/182697
- In all cases for the color picker to appear on hover of the color decorator, the hover needs to be enabled.