### PR TITLE
Normalize folder/file URI paths with slash

### DIFF
--- a/src/vs/platform/windows/electron-main/windowsMainService.ts
+++ b/src/vs/platform/windows/electron-main/windowsMainService.ts
@@ -869,6 +869,9 @@ export class WindowsMainService extends Disposable implements IWindowsMainServic
 
 				return undefined;
 			}
+			if (!uri.path) {
+				return uri.with({ path: '/' });
+			}
 
 			return uri;
 		} catch (e) {


### PR DESCRIPTION
- code --folder-uri vscode-remote://test+test results in many errors thrown `cannot call joinPath on URI without path` all over the place
- found in https://github.com/microsoft/vscode/issues/182627

-> normalize the URI with a slash and continue.

fyi @bpasero