### PR TITLE
Fix #184183. Multiple output height updates are skipped.

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView.ts
@@ -616,13 +616,13 @@ export class BackLayerWebView<T extends ICommonCellInfo> extends Themable {
 
 							{
 								if (!update.init) {
-									return;
+									continue;
 								}
 
 								const output = this.reversedInsetMapping.get(update.id);
 
 								if (!output) {
-									return;
+									continue;
 								}
 
 								const inset = this.insetMapping.get(output)!;


### PR DESCRIPTION
A `return` would skip all other output height updates in the loop

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
