### PR TITLE
code --status displays a lot of errors before actual status output (fix #183787)

### DIFF
--- a/src/vs/code/node/cli.ts
+++ b/src/vs/code/node/cli.ts
@@ -194,7 +194,7 @@ export async function main(argv: string[]): Promise<any> {
 
 		if (args.verbose || args.status) {
 			processCallbacks.push(async child => {
-				child.stdout!.on('data', (data: Buffer) => console.log(data.toString('utf8').trim()));
+				child.stdout?.on('data', (data: Buffer) => console.log(data.toString('utf8').trim()));
 				child.stderr?.on('data', (data: Buffer) => console.log(data.toString('utf8').trim()));
 
 				await Event.toPromise(Event.fromNodeEventEmitter(child, 'exit'));


### PR DESCRIPTION
This was discussed and approved in the Zurich standup but had 1 little issue that I did not catch in my review

fixes https://github.com/microsoft/vscode/issues/183787#issuecomment-1573973172