### PR TITLE
build: don't apply cli 'patches' for merge check

### DIFF
--- a/build/azure-pipelines/cli/cli-apply-patches.yml
+++ b/build/azure-pipelines/cli/cli-apply-patches.yml
@@ -1,0 +1,17 @@
+steps:
+  - template: ../distro/download-distro.yml
+
+  - task: Cache@2
+    inputs:
+      key: '"build_node_modules" | build/yarn.lock'
+      path: build/node_modules
+      cacheHitVar: BUILD_NODE_MODULES_RESTORED
+    displayName: Restore node_modules cache
+
+  - script: yarn --frozen-lockfile --ignore-optional --check-files
+    workingDirectory: build
+    condition: and(succeeded(), ne(variables.BUILD_NODE_MODULES_RESTORED, 'true'))
+    displayName: Install pipeline build
+
+  - script: node build/azure-pipelines/distro/apply-cli-patches
+    displayName: Apply distro patches

--- a/build/azure-pipelines/darwin/cli-build-darwin.yml
+++ b/build/azure-pipelines/darwin/cli-build-darwin.yml
@@ -14,16 +14,7 @@ steps:
       versionSpec: "16.x"
 
   - ${{ if ne(parameters.VSCODE_QUALITY, 'oss') }}:
-    - template: ../distro/download-distro.yml
-
-    - script: |
-        set -e
-        yarn --frozen-lockfile --ignore-optional
-      workingDirectory: build
-      displayName: Install pipeline build
-
-    - script: node build/azure-pipelines/distro/apply-cli-patches
-      displayName: Apply distro patches
+    - template: ../cli/cli-apply-patches.yml
 
   - task: Npm@1
     displayName: Download openssl prebuilt

--- a/build/azure-pipelines/distro-build.yml
+++ b/build/azure-pipelines/distro-build.yml
@@ -11,5 +11,3 @@ steps:
     inputs:
       versionSpec: "16.x"
   - template: ./distro/download-distro.yml
-  - script: node build/azure-pipelines/distro/apply-cli-patches
-    displayName: Apply distro patches

--- a/build/azure-pipelines/linux/cli-build-linux.yml
+++ b/build/azure-pipelines/linux/cli-build-linux.yml
@@ -17,16 +17,7 @@ steps:
       versionSpec: "16.x"
 
   - ${{ if ne(parameters.VSCODE_QUALITY, 'oss') }}:
-    - template: ../distro/download-distro.yml
-
-    - script: |
-        set -e
-        yarn --frozen-lockfile --ignore-optional
-      workingDirectory: build
-      displayName: Install pipeline build
-
-    - script: node build/azure-pipelines/distro/apply-cli-patches
-      displayName: Apply distro patches
+    - template: ../cli/cli-apply-patches.yml
 
   - task: Npm@1
     displayName: Download openssl prebuilt

--- a/build/azure-pipelines/win32/cli-build-win32.yml
+++ b/build/azure-pipelines/win32/cli-build-win32.yml
@@ -17,14 +17,7 @@ steps:
       versionSpec: "16.x"
 
   - ${{ if ne(parameters.VSCODE_QUALITY, 'oss') }}:
-    - template: ../distro/download-distro.yml
-
-    - pwsh: yarn --frozen-lockfile --ignore-optional
-      workingDirectory: build
-      displayName: Install pipeline build
-
-    - pwsh: node build/azure-pipelines/distro/apply-cli-patches
-      displayName: Apply distro patches
+    - template: ../cli/cli-apply-patches.yml
 
   - task: Npm@1
     displayName: Download openssl prebuilt


### PR DESCRIPTION
This also needed modules installed. But with the new toml patches, the 'merge' will never fail outright, so there's no need to do a separate merge check for it imo

Also, reduce duplication in the cli pipelines and cache build dependencies