### PR TITLE
fix build: account for mac not exiting app on window close

### DIFF
--- a/src/vs/workbench/services/workingCopy/test/electron-sandbox/workingCopyBackupTracker.test.ts
+++ b/src/vs/workbench/services/workingCopy/test/electron-sandbox/workingCopyBackupTracker.test.ts
@@ -570,7 +570,7 @@ suite('WorkingCopyBackupTracker (native)', function () {
 				return scratchpadHotExitTest.call(this, HotExitConfiguration.ON_EXIT, ShutdownReason.CLOSE, false, true, false);
 			});
 			test('should hot exit (reason: CLOSE, windows: single, empty workspace)', function () {
-				return scratchpadHotExitTest.call(this, HotExitConfiguration.ON_EXIT, ShutdownReason.CLOSE, false, false, false);
+				return scratchpadHotExitTest.call(this, HotExitConfiguration.ON_EXIT, ShutdownReason.CLOSE, false, false, !!isMacintosh);
 			});
 			test('should hot exit (reason: CLOSE, windows: multiple, workspace)', function () {
 				return scratchpadHotExitTest.call(this, HotExitConfiguration.ON_EXIT, ShutdownReason.CLOSE, true, true, false);


### PR DESCRIPTION
change to match with the corresponding `onExitAndWindowClose` test