### PR TITLE
Avoid `extensionService.getExtension` and use `ActivationKind.Immediate` to allow that URI handling works while resolving

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadUrls.ts
+++ b/src/vs/workbench/api/browser/mainThreadUrls.ts
@@ -5,18 +5,19 @@
 
 import { ExtHostContext, MainContext, MainThreadUrlsShape, ExtHostUrlsShape } from 'vs/workbench/api/common/extHost.protocol';
 import { extHostNamedCustomer, IExtHostContext } from '../../services/extensions/common/extHostCustomers';
-import { IURLService, IURLHandler, IOpenURLOptions } from 'vs/platform/url/common/url';
+import { IURLService, IOpenURLOptions } from 'vs/platform/url/common/url';
 import { URI, UriComponents } from 'vs/base/common/uri';
 import { IDisposable } from 'vs/base/common/lifecycle';
-import { IExtensionUrlHandler } from 'vs/workbench/services/extensions/browser/extensionUrlHandler';
+import { IExtensionContributedURLHandler, IExtensionUrlHandler } from 'vs/workbench/services/extensions/browser/extensionUrlHandler';
 import { ExtensionIdentifier } from 'vs/platform/extensions/common/extensions';
 
-class ExtensionUrlHandler implements IURLHandler {
+class ExtensionUrlHandler implements IExtensionContributedURLHandler {
 
 	constructor(
 		private readonly proxy: ExtHostUrlsShape,
 		private readonly handle: number,
-		readonly extensionId: ExtensionIdentifier
+		readonly extensionId: ExtensionIdentifier,
+		readonly extensionDisplayName: string
 	) { }
 
 	handleURL(uri: URI, options?: IOpenURLOptions): Promise<boolean> {
@@ -42,8 +43,8 @@ export class MainThreadUrls implements MainThreadUrlsShape {
 		this.proxy = context.getProxy(ExtHostContext.ExtHostUrls);
 	}
 
-	$registerUriHandler(handle: number, extensionId: ExtensionIdentifier): Promise<void> {
-		const handler = new ExtensionUrlHandler(this.proxy, handle, extensionId);
+	$registerUriHandler(handle: number, extensionId: ExtensionIdentifier, extensionDisplayName: string): Promise<void> {
+		const handler = new ExtensionUrlHandler(this.proxy, handle, extensionId, extensionDisplayName);
 		const disposable = this.urlService.registerHandler(handler);
 
 		this.handlers.set(handle, { extensionId, disposable });

--- a/src/vs/workbench/api/common/extHost.api.impl.ts
+++ b/src/vs/workbench/api/common/extHost.api.impl.ts
@@ -788,7 +788,7 @@ export function createApiFactoryAndRegisterActors(accessor: ServicesAccessor): I
 				return extHostDecorations.registerFileDecorationProvider(provider, extension);
 			},
 			registerUriHandler(handler: vscode.UriHandler) {
-				return extHostUrls.registerUriHandler(extension.identifier, handler);
+				return extHostUrls.registerUriHandler(extension, handler);
 			},
 			createQuickPick<T extends vscode.QuickPickItem>(): vscode.QuickPick<T> {
 				return extHostQuickOpen.createQuickPick(extension);

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -1130,7 +1130,7 @@ export interface ExtHostInteractiveEditorShape {
 }
 
 export interface MainThreadUrlsShape extends IDisposable {
-	$registerUriHandler(handle: number, extensionId: ExtensionIdentifier): Promise<void>;
+	$registerUriHandler(handle: number, extensionId: ExtensionIdentifier, extensionDisplayName: string): Promise<void>;
 	$unregisterUriHandler(handle: number): Promise<void>;
 	$createAppUri(uri: UriComponents): Promise<UriComponents>;
 }

--- a/src/vs/workbench/api/common/extHostUrls.ts
+++ b/src/vs/workbench/api/common/extHostUrls.ts
@@ -8,7 +8,7 @@ import { MainContext, IMainContext, ExtHostUrlsShape, MainThreadUrlsShape } from
 import { URI, UriComponents } from 'vs/base/common/uri';
 import { toDisposable } from 'vs/base/common/lifecycle';
 import { onUnexpectedError } from 'vs/base/common/errors';
-import { ExtensionIdentifier, ExtensionIdentifierSet } from 'vs/platform/extensions/common/extensions';
+import { ExtensionIdentifierSet, IExtensionDescription } from 'vs/platform/extensions/common/extensions';
 
 export class ExtHostUrls implements ExtHostUrlsShape {
 
@@ -24,7 +24,8 @@ export class ExtHostUrls implements ExtHostUrlsShape {
 		this._proxy = mainContext.getProxy(MainContext.MainThreadUrls);
 	}
 
-	registerUriHandler(extensionId: ExtensionIdentifier, handler: vscode.UriHandler): vscode.Disposable {
+	registerUriHandler(extension: IExtensionDescription, handler: vscode.UriHandler): vscode.Disposable {
+		const extensionId = extension.identifier;
 		if (this.handles.has(extensionId)) {
 			throw new Error(`Protocol handler already registered for extension ${extensionId}`);
 		}
@@ -32,7 +33,7 @@ export class ExtHostUrls implements ExtHostUrlsShape {
 		const handle = ExtHostUrls.HandlePool++;
 		this.handles.add(extensionId);
 		this.handlers.set(handle, handler);
-		this._proxy.$registerUriHandler(handle, extensionId);
+		this._proxy.$registerUriHandler(handle, extensionId, extension.displayName || extension.name);
 
 		return toDisposable(() => {
 			this.handles.delete(extensionId);


### PR DESCRIPTION
Fixes #182217