### PR TITLE
joh/central rooster

### DIFF
--- a/src/vs/workbench/contrib/interactiveEditor/browser/interactiveEditorLivePreviewWidget.ts
+++ b/src/vs/workbench/contrib/interactiveEditor/browser/interactiveEditorLivePreviewWidget.ts
@@ -136,7 +136,7 @@ export class InteractiveEditorLivePreviewWidget extends ZoneWidget {
 		this._sessionStore.add(this._diffEditor.onDidUpdateDiff(() => {
 			const result = this._diffEditor.getDiffComputationResult();
 			const hasFocus = this._diffEditor.hasTextFocus();
-			this._updateFromChanges(this._session.wholeRange, result?.changes2 ?? []);
+			this._updateFromChanges(this._session.wholeRange.value, result?.changes2 ?? []);
 			// TODO@jrieken find a better fix for this. this is the challenge:
 			// the _doShowForChanges method invokes show of the zone widget which removes and adds the
 			// zone and overlay parts. this dettaches and reattaches the dom nodes which means they lose
@@ -145,7 +145,7 @@ export class InteractiveEditorLivePreviewWidget extends ZoneWidget {
 				this._diffEditor.focus();
 			}
 		}));
-		this._updateFromChanges(this._session.wholeRange, this._session.lastTextModelChanges);
+		this._updateFromChanges(this._session.wholeRange.value, this._session.lastTextModelChanges);
 		this._isVisible = true;
 	}
 

--- a/src/vs/workbench/contrib/interactiveEditor/browser/interactiveEditorSession.ts
+++ b/src/vs/workbench/contrib/interactiveEditor/browser/interactiveEditorSession.ts
@@ -371,9 +371,9 @@ export class InteractiveEditorSessionService implements IInteractiveEditorSessio
 		if (!wholeRange) {
 			wholeRange = raw.wholeRange ? Range.lift(raw.wholeRange) : editor.getSelection();
 		}
-		if (Range.isEmpty(wholeRange)) {
-			wholeRange = new Range(wholeRange.startLineNumber, 1, wholeRange.endLineNumber, textModel.getLineMaxColumn(wholeRange.endLineNumber));
-		}
+
+		// expand to whole lines
+		wholeRange = new Range(wholeRange.startLineNumber, 1, wholeRange.endLineNumber, textModel.getLineMaxColumn(wholeRange.endLineNumber));
 
 		// install a marker for the decoration range
 		const [wholeRangeDecorationId] = textModel.deltaDecorations([], [{ range: wholeRange, options: { description: 'interactiveEditor/session/wholeRange' } }]);

--- a/src/vs/workbench/contrib/interactiveEditor/browser/interactiveEditorSession.ts
+++ b/src/vs/workbench/contrib/interactiveEditor/browser/interactiveEditorSession.ts
@@ -8,7 +8,7 @@ import { URI } from 'vs/base/common/uri';
 import { Event } from 'vs/base/common/event';
 import { ResourceEdit, ResourceFileEdit, ResourceTextEdit } from 'vs/editor/browser/services/bulkEditService';
 import { TextEdit } from 'vs/editor/common/languages';
-import { ITextModel } from 'vs/editor/common/model';
+import { IModelDeltaDecoration, ITextModel } from 'vs/editor/common/model';
 import { EditMode, IInteractiveEditorSessionProvider, IInteractiveEditorSession, IInteractiveEditorBulkEditResponse, IInteractiveEditorEditResponse, IInteractiveEditorMessageResponse, IInteractiveEditorResponse, IInteractiveEditorService } from 'vs/workbench/contrib/interactiveEditor/common/interactiveEditor';
 import { IRange, Range } from 'vs/editor/common/core/range';
 import { IActiveCodeEditor, ICodeEditor } from 'vs/editor/browser/editorBrowser';
@@ -24,6 +24,7 @@ import { Iterable } from 'vs/base/common/iterator';
 import { toErrorMessage } from 'vs/base/common/errorMessage';
 import { isCancellationError } from 'vs/base/common/errors';
 import { LineRangeMapping } from 'vs/editor/common/diff/linesDiffComputer';
+import { ISingleEditOperation } from 'vs/editor/common/core/editOperation';
 
 export type Recording = {
 	when: Date;
@@ -61,6 +62,50 @@ export enum ExpansionState {
 	NOT_CROPPED = 'not_cropped'
 }
 
+class SessionWholeRange {
+
+	private static readonly _options = { description: 'interactiveEditor/session/wholeRange' };
+
+	private readonly _store = new DisposableStore();
+	private readonly _decorationIds: string[] = [];
+
+	constructor(private readonly _textModel: ITextModel, wholeRange: IRange) {
+		this._decorationIds = _textModel.deltaDecorations([], [{ range: wholeRange, options: SessionWholeRange._options }]);
+		this._store.add(toDisposable(() => {
+			if (!_textModel.isDisposed()) {
+				_textModel.deltaDecorations(this._decorationIds, []);
+			}
+		}));
+	}
+
+	dispose() {
+		this._store.dispose();
+	}
+
+	trackEdits(edits: ISingleEditOperation[]): void {
+		const newDeco: IModelDeltaDecoration[] = [];
+		for (const edit of edits) {
+			newDeco.push({ range: edit.range, options: SessionWholeRange._options });
+		}
+		this._decorationIds.push(...this._textModel.deltaDecorations([], newDeco));
+	}
+
+	get value(): Range {
+		let result: Range | undefined;
+		for (const id of this._decorationIds) {
+			const range = this._textModel.getDecorationRange(id);
+			if (range) {
+				if (!result) {
+					result = range;
+				} else {
+					result = Range.plusRange(result, range);
+				}
+			}
+		}
+		return result!;
+	}
+}
+
 export class Session {
 
 	private _lastInput: string | undefined;
@@ -81,7 +126,7 @@ export class Session {
 		readonly textModelN: ITextModel,
 		readonly provider: IInteractiveEditorSessionProvider,
 		readonly session: IInteractiveEditorSession,
-		private readonly _wholeRangeMarkerId: string
+		readonly wholeRange: SessionWholeRange
 	) {
 		this.textModelNAltVersion = textModelN.getAlternativeVersionId();
 		this._teldata = {
@@ -120,11 +165,6 @@ export class Session {
 
 	get textModelNSnapshotAltVersion(): number | undefined {
 		return this._textModelNSnapshotAltVersion;
-	}
-
-	get wholeRange(): Range {
-		return this.textModelN.getDecorationRange(this._wholeRangeMarkerId)!;
-		// return new Range(1, 1, 1, 1);
 	}
 
 	createSnapshot(): void {
@@ -375,15 +415,11 @@ export class InteractiveEditorSessionService implements IInteractiveEditorSessio
 		// expand to whole lines
 		wholeRange = new Range(wholeRange.startLineNumber, 1, wholeRange.endLineNumber, textModel.getLineMaxColumn(wholeRange.endLineNumber));
 
-		// install a marker for the decoration range
-		const [wholeRangeDecorationId] = textModel.deltaDecorations([], [{ range: wholeRange, options: { description: 'interactiveEditor/session/wholeRange' } }]);
-		store.add(toDisposable(() => {
-			if (!textModel.isDisposed()) {
-				textModel.deltaDecorations([wholeRangeDecorationId], []);
-			}
-		}));
+		// install managed-marker for the decoration range
+		const wholeRangeMgr = new SessionWholeRange(textModel, wholeRange);
+		store.add(wholeRangeMgr);
 
-		const session = new Session(options.editMode, editor, textModel0, textModel, provider, raw, wholeRangeDecorationId);
+		const session = new Session(options.editMode, editor, textModel0, textModel, provider, raw, wholeRangeMgr);
 
 		// store: key -> session
 		const key = this._key(editor, textModel.uri);

--- a/src/vs/workbench/contrib/interactiveEditor/browser/interactiveEditorStrategies.ts
+++ b/src/vs/workbench/contrib/interactiveEditor/browser/interactiveEditorStrategies.ts
@@ -37,7 +37,7 @@ export abstract class EditModeStrategy {
 
 	abstract cancel(): Promise<void>;
 
-	abstract makeChanges(response: EditResponse, edits: ISingleEditOperation[]): Promise<void>;
+	abstract makeChanges(edits: ISingleEditOperation[]): Promise<void>;
 
 	abstract renderChanges(response: EditResponse): Promise<void>;
 
@@ -106,7 +106,7 @@ export class PreviewStrategy extends EditModeStrategy {
 		// nothing to do
 	}
 
-	override async makeChanges(_response: EditResponse, _edits: ISingleEditOperation[]): Promise<void> {
+	override async makeChanges(_edits: ISingleEditOperation[]): Promise<void> {
 		// nothing to do
 	}
 
@@ -287,7 +287,7 @@ export class LiveStrategy extends EditModeStrategy {
 		}
 	}
 
-	override async makeChanges(_response: EditResponse, edits: ISingleEditOperation[], ignoreInlineDiff?: boolean): Promise<void> {
+	override async makeChanges(edits: ISingleEditOperation[], ignoreInlineDiff?: boolean): Promise<void> {
 		const cursorStateComputerAndInlineDiffCollection: ICursorStateComputer = (undoEdits) => {
 			let last: Position | null = null;
 			for (const edit of undoEdits) {
@@ -362,10 +362,6 @@ export class LivePreviewStrategy extends LiveStrategy {
 		super.dispose();
 	}
 
-	override async makeChanges(_response: EditResponse, edits: ISingleEditOperation[]): Promise<void> {
-		super.makeChanges(_response, edits, true);
-	}
-
 	override async renderChanges(response: EditResponse) {
 
 		this._updateSummaryMessage();
@@ -374,7 +370,7 @@ export class LivePreviewStrategy extends LiveStrategy {
 		}
 
 		if (response.singleCreateFileEdit) {
-			this._previewZone.showCreation(this._session.wholeRange, response.singleCreateFileEdit.uri, await Promise.all(response.singleCreateFileEdit.edits));
+			this._previewZone.showCreation(this._session.wholeRange.value, response.singleCreateFileEdit.uri, await Promise.all(response.singleCreateFileEdit.edits));
 		} else {
 			this._previewZone.hide();
 		}

--- a/src/vs/workbench/contrib/interactiveEditor/common/interactiveEditorServiceImpl.ts
+++ b/src/vs/workbench/contrib/interactiveEditor/common/interactiveEditorServiceImpl.ts
@@ -32,6 +32,6 @@ export class InteractiveEditorServiceImpl implements IInteractiveEditorService {
 	}
 
 	getAllProvider() {
-		return [...this._entries];
+		return [...this._entries].reverse();
 	}
 }


### PR DESCRIPTION
- add unit testing for wholeRange
- assert finishing when typing outside of wholeRange
- track initial whole range and all subsequent edits as wholeRanges so that "outside" edits are treated properly
