### PR TITLE
use parent's `getOverflowWidgetsDomNode` for live preview diff editors

### DIFF
--- a/src/vs/workbench/contrib/interactiveEditor/browser/interactiveEditorLivePreviewWidget.ts
+++ b/src/vs/workbench/contrib/interactiveEditor/browser/interactiveEditorLivePreviewWidget.ts
@@ -76,7 +76,8 @@ export class InteractiveEditorLivePreviewWidget extends ZoneWidget {
 			diffCodeLens: false,
 			stickyScroll: { enabled: false },
 			minimap: { enabled: false },
-			isInEmbeddedEditor: true
+			isInEmbeddedEditor: true,
+			overflowWidgetsDomNode: editor.getOverflowWidgetsDomNode()
 		}, {
 			originalEditor: { contributions: diffContributions },
 			modifiedEditor: { contributions: diffContributions }


### PR DESCRIPTION
https://github.com/microsoft/vscode-internalbacklog/issues/4152#issuecomment-1575963055
