### PR TITLE
Showing the standalone color picker at the model state position, not view state

### DIFF
--- a/src/vs/editor/contrib/colorPicker/browser/standaloneColorPickerWidget.ts
+++ b/src/vs/editor/contrib/colorPicker/browser/standaloneColorPickerWidget.ts
@@ -109,7 +109,7 @@ export class StandaloneColorPickerWidget extends Disposable implements IContentW
 		super();
 		this._standaloneColorPickerVisible.set(true);
 		this._standaloneColorPickerParticipant = _instantiationService.createInstance(StandaloneColorPickerParticipant, this._editor);
-		this._position = this._editor._getViewModel()?.getPrimaryCursorState().viewState.position;
+		this._position = this._editor._getViewModel()?.getPrimaryCursorState().modelState.position;
 		const editorSelection = this._editor.getSelection();
 		const selection = editorSelection ?
 			{


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/181480