### PR TITLE
Fix #182075. Make standalone color picker overflow.

### DIFF
--- a/src/vs/editor/contrib/colorPicker/browser/standaloneColorPickerWidget.ts
+++ b/src/vs/editor/contrib/colorPicker/browser/standaloneColorPickerWidget.ts
@@ -85,6 +85,8 @@ const CLOSE_BUTTON_WIDTH = 22;
 export class StandaloneColorPickerWidget extends Disposable implements IContentWidget {
 
 	static readonly ID = 'editor.contrib.standaloneColorPickerWidget';
+	readonly allowEditorOverflow = true;
+
 	private body: HTMLElement = document.createElement('div');
 
 	private readonly _position: Position | undefined = undefined;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

We may want to make the standalone color picker overflow as same as suggest widget, so it won't be cut off if the Monaco editor container is absolutely positioned with transformation.