### PR TITLE
Check for existing walkthroughs open before opening walkthroughs

### DIFF
--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.contribution.ts
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.contribution.ts
@@ -63,12 +63,16 @@ registerAction2(class extends Action2 {
 		if (walkthroughID) {
 			const selectedCategory = typeof walkthroughID === 'string' ? walkthroughID : walkthroughID.category;
 			const selectedStep = typeof walkthroughID === 'string' ? undefined : walkthroughID.step;
+
+			let openedWalkthroughExists = false;
 			// Try first to select the walkthrough on an active welcome page with no selected walkthrough
 			for (const group of editorGroupsService.groups) {
 				if (group.activeEditor instanceof GettingStartedInput) {
 					if (!group.activeEditor.selectedCategory) {
 						(group.activeEditorPane as GettingStartedPage).makeCategoryVisibleWhenAvailable(selectedCategory, selectedStep);
 						return;
+					} else {
+						openedWalkthroughExists = true;
 					}
 				}
 			}
@@ -83,6 +87,8 @@ registerAction2(class extends Action2 {
 						editor.selectedStep = selectedStep;
 						group.openEditor(editor, { revealIfOpened: true });
 						return;
+					} else {
+						openedWalkthroughExists = true;
 					}
 				}
 			}
@@ -102,7 +108,7 @@ registerAction2(class extends Action2 {
 					editor: activeEditor,
 					replacement: gettingStartedInput
 				}]);
-			} else {
+			} else if (!openedWalkthroughExists) {
 				// else open respecting toSide
 				editorService.openEditor(gettingStartedInput, { preserveFocus: toSide ?? false }, toSide ? SIDE_GROUP : undefined);
 			}


### PR DESCRIPTION
Guard against multiple walkthroughs being opened.
This is an additional guard against opening walkthroughs in cases where https://github.com/microsoft/vscode/blob/0ba17fc87c4c48888fc9e6fb3a1968d89b3c93ba/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStartedService.ts#L286

is missing. 