### PR TITLE
do not auto finish session when inline chat widgets have focus

### DIFF
--- a/src/vs/editor/contrib/zoneWidget/browser/zoneWidget.ts
+++ b/src/vs/editor/contrib/zoneWidget/browser/zoneWidget.ts
@@ -307,6 +307,10 @@ export abstract class ZoneWidget implements IHorizontalSashLayoutProvider {
 		return range.getStartPosition();
 	}
 
+	hasFocus() {
+		return this.domNode.contains(dom.getActiveElement());
+	}
+
 	protected _isShowing: boolean = false;
 
 	show(rangeOrPos: IRange | IPosition, heightInLines: number): void {

--- a/src/vs/workbench/contrib/debug/browser/exceptionWidget.ts
+++ b/src/vs/workbench/contrib/debug/browser/exceptionWidget.ts
@@ -122,7 +122,7 @@ export class ExceptionWidget extends ZoneWidget {
 		this.container?.focus();
 	}
 
-	hasFocus(): boolean {
+	override hasFocus(): boolean {
 		return dom.isAncestor(document.activeElement, this.container);
 	}
 }

--- a/src/vs/workbench/contrib/interactiveEditor/browser/interactiveEditorController.ts
+++ b/src/vs/workbench/contrib/interactiveEditor/browser/interactiveEditorController.ts
@@ -281,7 +281,7 @@ export class InteractiveEditorController implements IEditorContribution {
 		}));
 
 		this._sessionStore.add(this._editor.onDidChangeModelContent(e => {
-			if (this._ignoreModelContentChanged) {
+			if (this._ignoreModelContentChanged || this._strategy?.hasFocus()) {
 				return;
 			}
 

--- a/src/vs/workbench/contrib/interactiveEditor/browser/interactiveEditorStrategies.ts
+++ b/src/vs/workbench/contrib/interactiveEditor/browser/interactiveEditorStrategies.ts
@@ -42,6 +42,8 @@ export abstract class EditModeStrategy {
 	abstract renderChanges(response: EditResponse): Promise<void>;
 
 	abstract toggleDiff(): void;
+
+	abstract hasFocus(): boolean;
 }
 
 export class PreviewStrategy extends EditModeStrategy {
@@ -127,6 +129,10 @@ export class PreviewStrategy extends EditModeStrategy {
 
 	toggleDiff(): void {
 		// nothing to do
+	}
+
+	hasFocus(): boolean {
+		return this._widget.hasFocus();
 	}
 }
 
@@ -331,6 +337,10 @@ export class LiveStrategy extends EditModeStrategy {
 		}
 		this._widget.updateStatus(message);
 	}
+
+	hasFocus(): boolean {
+		return this._widget.hasFocus();
+	}
 }
 
 export class LivePreviewStrategy extends LiveStrategy {
@@ -388,6 +398,10 @@ export class LivePreviewStrategy extends LiveStrategy {
 			this._diffZone.hide();
 		}
 		scrollState.restore(this._editor);
+	}
+
+	override hasFocus(): boolean {
+		return super.hasFocus() || this._diffZone.hasFocus() || this._previewZone.hasFocus();
 	}
 }
 

--- a/src/vs/workbench/contrib/interactiveEditor/browser/interactiveEditorWidget.ts
+++ b/src/vs/workbench/contrib/interactiveEditor/browser/interactiveEditorWidget.ts
@@ -14,7 +14,7 @@ import { IInstantiationService } from 'vs/platform/instantiation/common/instanti
 import { ZoneWidget } from 'vs/editor/contrib/zoneWidget/browser/zoneWidget';
 import { CTX_INTERACTIVE_EDITOR_FOCUSED, CTX_INTERACTIVE_EDITOR_INNER_CURSOR_FIRST, CTX_INTERACTIVE_EDITOR_INNER_CURSOR_LAST, CTX_INTERACTIVE_EDITOR_EMPTY, CTX_INTERACTIVE_EDITOR_OUTER_CURSOR_POSITION, CTX_INTERACTIVE_EDITOR_VISIBLE, MENU_INTERACTIVE_EDITOR_WIDGET, MENU_INTERACTIVE_EDITOR_WIDGET_STATUS, MENU_INTERACTIVE_EDITOR_WIDGET_MARKDOWN_MESSAGE, CTX_INTERACTIVE_EDITOR_MESSAGE_CROP_STATE, IInteractiveEditorSlashCommand, MENU_INTERACTIVE_EDITOR_WIDGET_FEEDBACK, ACTION_ACCEPT_CHANGES } from 'vs/workbench/contrib/interactiveEditor/common/interactiveEditor';
 import { IModelDeltaDecoration, ITextModel } from 'vs/editor/common/model';
-import { Dimension, addDisposableListener, getTotalHeight, getTotalWidth, h, reset } from 'vs/base/browser/dom';
+import { Dimension, addDisposableListener, getActiveElement, getTotalHeight, getTotalWidth, h, reset } from 'vs/base/browser/dom';
 import { Emitter, Event, MicrotaskEmitter } from 'vs/base/common/event';
 import { IEditorConstructionOptions } from 'vs/editor/browser/config/editorConfiguration';
 import { ICodeEditorWidgetOptions } from 'vs/editor/browser/widget/codeEditorWidget';
@@ -500,6 +500,10 @@ export class InteractiveEditorWidget {
 
 	focus() {
 		this._inputEditor.focus();
+	}
+
+	hasFocus() {
+		return this.domNode.contains(getActiveElement());
 	}
 
 	updateMarkdownMessageExpansionState(expand: boolean) {

--- a/src/vs/workbench/contrib/scm/browser/dirtydiffDecorator.ts
+++ b/src/vs/workbench/contrib/scm/browser/dirtydiffDecorator.ts
@@ -467,7 +467,7 @@ class DirtyDiffWidget extends PeekViewWidget {
 		this.editor.revealLineInCenterIfOutsideViewport(range.endLineNumber, ScrollType.Smooth);
 	}
 
-	hasFocus(): boolean {
+	override hasFocus(): boolean {
 		return this.diffEditor.hasTextFocus();
 	}
 


### PR DESCRIPTION
re https://github.com/microsoft/vscode-internalbacklog/issues/4354

Adds ways to know if a widget is focused, never auto-finish when having focus