### PR TITLE
Add ` as an autoClosingPair in markdown

### DIFF
--- a/extensions/markdown-basics/language-configuration.json
+++ b/extensions/markdown-basics/language-configuration.json
@@ -8,12 +8,20 @@
 	},
 	// symbols used as brackets
 	"brackets": [
-		["{", "}"],
-		["[", "]"],
-		["(", ")"]
+		[
+			"{",
+			"}"
+		],
+		[
+			"[",
+			"]"
+		],
+		[
+			"(",
+			")"
+		]
 	],
-	"colorizedBracketPairs": [
-	],
+	"colorizedBracketPairs": [],
 	"autoClosingPairs": [
 		{
 			"open": "{",
@@ -33,17 +41,49 @@
 			"notIn": [
 				"string"
 			]
-		}
+		},
+		{
+			"open": "`",
+			"close": "`"
+		},
+		{
+			"open": "```",
+			"close": "```"
+		},
 	],
 	"surroundingPairs": [
-		["(", ")"],
-		["[", "]"],
-		["`", "`"],
-		["_", "_"],
-		["*", "*"],
-		["{", "}"],
-		["'", "'"],
-		["\"", "\""]
+		[
+			"(",
+			")"
+		],
+		[
+			"[",
+			"]"
+		],
+		[
+			"`",
+			"`"
+		],
+		[
+			"_",
+			"_"
+		],
+		[
+			"*",
+			"*"
+		],
+		[
+			"{",
+			"}"
+		],
+		[
+			"'",
+			"'"
+		],
+		[
+			"\"",
+			"\""
+		]
 	],
 	"folding": {
 		"offSide": true,
@@ -52,5 +92,8 @@
 			"end": "^\\s*<!--\\s*#?endregion\\b.*-->"
 		}
 	},
-	"wordPattern": { "pattern": "(\\p{Alphabetic}|\\p{Number}|\\p{Nonspacing_Mark})(((\\p{Alphabetic}|\\p{Number}|\\p{Nonspacing_Mark})|[_])?(\\p{Alphabetic}|\\p{Number}|\\p{Nonspacing_Mark}))*", "flags": "ug" },
+	"wordPattern": {
+		"pattern": "(\\p{Alphabetic}|\\p{Number}|\\p{Nonspacing_Mark})(((\\p{Alphabetic}|\\p{Number}|\\p{Nonspacing_Mark})|[_])?(\\p{Alphabetic}|\\p{Number}|\\p{Nonspacing_Mark}))*",
+		"flags": "ug"
+	},
 }


### PR DESCRIPTION
Fixes #183489

Will test this out to see if it's helpful or too annoying
