### PR TITLE
Revert changes to render featured extensions when available. 

### DIFF
--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStartedService.ts
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStartedService.ts
@@ -18,7 +18,7 @@ import { joinPath } from 'vs/base/common/resources';
 import { FileAccess } from 'vs/base/common/network';
 import { EXTENSION_INSTALL_SKIP_WALKTHROUGH_CONTEXT, IExtensionManagementService } from 'vs/platform/extensionManagement/common/extensionManagement';
 import { ThemeIcon } from 'vs/base/common/themables';
-import { BuiltinGettingStartedCategory, BuiltinGettingStartedStep, walkthroughs } from 'vs/workbench/contrib/welcomeGettingStarted/common/gettingStartedContent';
+import { walkthroughs } from 'vs/workbench/contrib/welcomeGettingStarted/common/gettingStartedContent';
 import { IWorkbenchAssignmentService } from 'vs/workbench/services/assignment/common/assignmentService';
 import { IHostService } from 'vs/workbench/services/host/browser/host';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
@@ -34,8 +34,6 @@ import { checkGlobFileExists } from 'vs/workbench/services/extensions/common/wor
 import { IWorkspaceContextService } from 'vs/platform/workspace/common/workspace';
 import { CancellationTokenSource } from 'vs/base/common/cancellation';
 import { DefaultIconPath } from 'vs/workbench/services/extensionManagement/common/extensionManagement';
-import { IProductService } from 'vs/platform/product/common/productService';
-import { ILifecycleService, LifecyclePhase } from 'vs/workbench/services/lifecycle/common/lifecycle';
 
 export const HasMultipleNewFileEntries = new RawContextKey<boolean>('hasMultipleNewFileEntries', false);
 
@@ -98,8 +96,8 @@ export interface IWalkthroughsService {
 	readonly onDidChangeWalkthrough: Event<IResolvedWalkthrough>;
 	readonly onDidProgressStep: Event<IResolvedWalkthroughStep>;
 
-	getWalkthroughs(): Promise<IResolvedWalkthrough[]>;
-	getWalkthrough(id: string): Promise<IResolvedWalkthrough>;
+	getWalkthroughs(): IResolvedWalkthrough[];
+	getWalkthrough(id: string): IResolvedWalkthrough;
 
 	registerWalkthrough(descriptor: IWalkthroughLoose): void;
 
@@ -113,12 +111,6 @@ export interface IWalkthroughsService {
 // Show walkthrough as "new" for 7 days after first install
 const DAYS = 24 * 60 * 60 * 1000;
 const NEW_WALKTHROUGH_TIME = 7 * DAYS;
-
-type WalkthroughTreatment = {
-	walkthroughId: string;
-	walkthroughStepIds?: string[];
-	stepOrder: number[];
-};
 
 export class WalkthroughsService extends Disposable implements IWalkthroughsService {
 	declare readonly _serviceBrand: undefined;
@@ -149,7 +141,6 @@ export class WalkthroughsService extends Disposable implements IWalkthroughsServ
 
 	private metadata: WalkthroughMetaDataType;
 
-	private registeredWalkthroughs: boolean = false;
 	constructor(
 		@IStorageService private readonly storageService: IStorageService,
 		@ICommandService private readonly commandService: ICommandService,
@@ -162,9 +153,7 @@ export class WalkthroughsService extends Disposable implements IWalkthroughsServ
 		@IHostService private readonly hostService: IHostService,
 		@IViewsService private readonly viewsService: IViewsService,
 		@ITelemetryService private readonly telemetryService: ITelemetryService,
-		@IWorkbenchAssignmentService private readonly tasExperimentService: IWorkbenchAssignmentService,
-		@IProductService private readonly productService: IProductService,
-		@ILifecycleService private readonly lifecycleService: ILifecycleService,
+		@IWorkbenchAssignmentService private readonly tasExperimentService: IWorkbenchAssignmentService
 	) {
 		super();
 
@@ -178,28 +167,13 @@ export class WalkthroughsService extends Disposable implements IWalkthroughsServ
 		this.initCompletionEventListeners();
 
 		HasMultipleNewFileEntries.bindTo(this.contextService).set(false);
+		this.registerWalkthroughs();
+
 	}
 
-	private async registerWalkthroughs() {
-
-		const treatmentString = await Promise.race([
-			this.tasExperimentService?.getTreatment<string>('welcome.walkthrough.content'),
-			new Promise<string | undefined>(resolve => setTimeout(() => resolve(''), 50))
-		]);
-
-		const treatment: WalkthroughTreatment = treatmentString ? JSON.parse(treatmentString) : { walkthroughId: '' };
+	private registerWalkthroughs() {
 
 		walkthroughs.forEach(async (category, index) => {
-			let shouldReorder = false;
-			if (category.id === treatment?.walkthroughId) {
-				category = this.updateWalkthroughContent(category, treatment);
-
-				shouldReorder = (treatment?.stepOrder !== undefined && category.content.steps.length === treatment.stepOrder.length);
-				if (shouldReorder) {
-					category.content.steps = category.content.steps.filter((_step, index) => treatment.stepOrder[index] >= 0);
-					treatment.stepOrder = treatment.stepOrder.filter(value => value >= 0);
-				}
-			}
 
 			this._registerWalkthrough({
 				...category,
@@ -214,7 +188,7 @@ export class WalkthroughsService extends Disposable implements IWalkthroughsServ
 							completionEvents: step.completionEvents ?? [],
 							description: parseDescription(step.description),
 							category: category.id,
-							order: shouldReorder ? (treatment?.stepOrder ? treatment.stepOrder[index] : index) : index,
+							order: index,
 							when: ContextKeyExpr.deserialize(step.when) ?? ContextKeyExpr.true(),
 							media: step.media.type === 'image'
 								? {
@@ -239,36 +213,10 @@ export class WalkthroughsService extends Disposable implements IWalkthroughsServ
 			});
 		});
 
-		await this.lifecycleService.when(LifecyclePhase.Restored);
-
 		walkthroughsExtensionPoint.setHandler((_, { added, removed }) => {
 			added.map(e => this.registerExtensionWalkthroughContributions(e.description));
 			removed.map(e => this.unregisterExtensionWalkthroughContributions(e.description));
 		});
-	}
-
-	private updateWalkthroughContent(walkthrough: BuiltinGettingStartedCategory, experimentTreatment: WalkthroughTreatment): BuiltinGettingStartedCategory {
-
-		if (!experimentTreatment?.walkthroughStepIds) {
-			return walkthrough;
-		}
-
-		const walkthroughMetadata = this.productService.walkthroughMetadata?.find(value => value.id === walkthrough.id);
-		for (const step of experimentTreatment.walkthroughStepIds) {
-			const stepMetadata = walkthroughMetadata?.steps.find(value => value.id === step);
-			if (stepMetadata) {
-
-				const newStep: BuiltinGettingStartedStep = {
-					id: step,
-					title: stepMetadata.title,
-					description: stepMetadata.description,
-					when: stepMetadata.when,
-					media: stepMetadata.media
-				};
-				walkthrough.content.steps.push(newStep);
-			}
-		}
-		return walkthrough;
 	}
 
 	private initCompletionEventListeners() {
@@ -493,22 +441,14 @@ export class WalkthroughsService extends Disposable implements IWalkthroughsServ
 		});
 	}
 
-	async getWalkthrough(id: string): Promise<IResolvedWalkthrough> {
-		if (!this.registeredWalkthroughs) {
-			await this.registerWalkthroughs();
-			this.registeredWalkthroughs = true;
-		}
+	getWalkthrough(id: string): IResolvedWalkthrough {
 
 		const walkthrough = this.gettingStartedContributions.get(id);
 		if (!walkthrough) { throw Error('Trying to get unknown walkthrough: ' + id); }
 		return this.resolveWalkthrough(walkthrough);
 	}
 
-	async getWalkthroughs(): Promise<IResolvedWalkthrough[]> {
-		if (!this.registeredWalkthroughs) {
-			await this.registerWalkthroughs();
-			this.registeredWalkthroughs = true;
-		}
+	getWalkthroughs(): IResolvedWalkthrough[] {
 
 		const registeredCategories = [...this.gettingStartedContributions.values()];
 		const categoriesWithCompletion = registeredCategories

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStartedService.ts
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStartedService.ts
@@ -184,7 +184,7 @@ export class WalkthroughsService extends Disposable implements IWalkthroughsServ
 
 		const treatmentString = await Promise.race([
 			this.tasExperimentService?.getTreatment<string>('welcome.walkthrough.content'),
-			new Promise<string | undefined>(resolve => setTimeout(() => resolve(''), 2000))
+			new Promise<string | undefined>(resolve => setTimeout(() => resolve(''), 50))
 		]);
 
 		const treatment: WalkthroughTreatment = treatmentString ? JSON.parse(treatmentString) : { walkthroughId: '' };


### PR DESCRIPTION
Addresses: 
https://github.com/microsoft/vscode/issues/184562

**Cause:**

The getting started infrastructure depends on the experimentation service and gallery service. On first launch, this causes the contents of the getting started infrastructure to move around after rendering:
![Recording 2023-06-08 at 08 46 57](https://github.com/microsoft/vscode/assets/25044782/55f714bf-d396-4c19-9949-507f11c164a9)

To prevent this issue, I introduced this fix to wait on all services to be ready before rendering the welcome page. 
https://github.com/microsoft/vscode/pull/182947

The paths spending the most time waiting are:
https://github.com/microsoft/vscode/blob/main/src/vs/workbench/contrib/welcomeGettingStarted/browser/featuredExtensionService.ts#L87

and

https://github.com/microsoft/vscode/blob/main/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStartedService.ts#L185

**Fix:**

**featuredExtensionService.ts:**
-  Changed it to check for experiment contents in parallel. Used `raceTimeout` 

**gettingStartedService.ts:** 
- Removed all code dealing with walkthrough experimentation. 
- Confirmed with @digitarald that we will no longer run the walkthrough experiments since we have the data.

**gettingStarted.ts:**
- Reverted changes so that we first render the welcome page first and then render the featured extensions when available. All changes come from https://github.com/microsoft/vscode/pull/182947/files. 

**No new changes introduced.**

**Testing:**
1. Tested startup walkthrough launch
2. Tested startup welcome page launch w/o installed extensions
3. Tested welcome page launch offline and network delays
4. Tested extension install and walkthrough list updating to add the walkthrough
5. Tested extension uninstall and walkthrough list updating to remove the walkthrough