### PR TITLE
Migrating the labels from IE to IC

### DIFF
--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatActions.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatActions.ts
@@ -98,7 +98,7 @@ export class UnstashSessionAction extends EditorAction2 {
 
 abstract class AbstractInlineChatAction extends EditorAction2 {
 
-	static readonly category = { value: localize('cat', 'Interactive Editor'), original: 'Interactive Editor' };
+	static readonly category = { value: localize('cat', 'Inline Chat'), original: 'Inline Chat' };
 
 	constructor(desc: IAction2Options) {
 		super({

--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatSession.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatSession.ts
@@ -64,7 +64,7 @@ export enum ExpansionState {
 
 class SessionWholeRange {
 
-	private static readonly _options = { description: 'interactiveEditor/session/wholeRange' };
+	private static readonly _options = { description: 'inlineChat/session/wholeRange' };
 
 	private readonly _store = new DisposableStore();
 	private readonly _decorationIds: string[] = [];

--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatWidget.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatWidget.ts
@@ -54,7 +54,7 @@ import { ExpansionState } from 'vs/workbench/contrib/inlineChat/browser/inlineCh
 import { IdleValue } from 'vs/base/common/async';
 import * as aria from 'vs/base/browser/ui/aria/aria';
 
-const defaultAriaLabel = localize('aria-label', "Interactive Editor Input");
+const defaultAriaLabel = localize('aria-label', "Inline Chat Input");
 
 const _inputEditorOptions: IEditorConstructionOptions = {
 	padding: { top: 3, bottom: 2 },


### PR DESCRIPTION
The labels in relation to the telemetry services and storage services that mention the interactive editor are left as is