### PR TITLE
FIX: conflict actions bar overlapping Complete Merge button fixed

### DIFF
--- a/src/vs/workbench/browser/codeeditor.ts
+++ b/src/vs/workbench/browser/codeeditor.ts
@@ -153,6 +153,7 @@ export class FloatingClickWidget extends Widget implements IOverlayWidget {
 		this._domNode.style.padding = '6px 11px';
 		this._domNode.style.borderRadius = '2px';
 		this._domNode.style.cursor = 'pointer';
+		this._domNode.style.zIndex = '1';
 
 		if (keyBindingAction) {
 			const keybinding = keybindingService.lookupKeybinding(keyBindingAction);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR Fixes #184567 

The issue was in the Merge Editor on the Result tab. If the conflict actions bar intersects with the Complete Merge button and if any action is selected in the conflict actions bar, the conflict actions bar overlaps the Complete Merge button within the z-index's stacking context, preventing us from clicking the button. For more information, please check out the linked issue.  

Now, here is the result after the fix!

[Complete Merge Issue Resolved Screen Recordnig.webm](https://github.com/microsoft/vscode/assets/59523732/cc61752a-c13c-4aa4-8c1b-5bbcb0c0544a)
