### PR TITLE
Exclude query strings from detected local links

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/links/browser/terminalLinkParsing.ts
+++ b/src/vs/workbench/contrib/terminalContrib/links/browser/terminalLinkParsing.ts
@@ -293,7 +293,7 @@ enum RegexPathConstants {
 	PathSeparatorClause = '\\/',
 	// '":; are allowed in paths but they are often separators so ignore them
 	// Also disallow \\ to prevent a catastropic backtracking case #24795
-	ExcludedPathCharactersClause = '[^\\0<>\\s!`&*()\'":;\\\\]',
+	ExcludedPathCharactersClause = '[^\\0<>\\?\\s!`&*()\'":;\\\\]',
 	ExcludedStartPathCharactersClause = '[^\\0<>\\s!`&*()\\[\\]\'":;\\\\]',
 
 	WinOtherPathPrefix = '\\.\\.?|\\~',

--- a/src/vs/workbench/contrib/terminalContrib/links/test/browser/terminalLinkParsing.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/links/test/browser/terminalLinkParsing.test.ts
@@ -478,6 +478,39 @@ suite('TerminalLinkParsing', () => {
 			}
 		});
 
+		suite('query strings', () => {
+			for (const os of operatingSystems) {
+				test(`should exclude query strings from link paths ${osLabel[os]}`, () => {
+					deepStrictEqual(
+						detectLinks(`${osTestPath[os]}?a=b`, os),
+						[
+							{
+								path: {
+									index: 0,
+									text: osTestPath[os]
+								},
+								prefix: undefined,
+								suffix: undefined
+							}
+						] as IParsedLink[]
+					);
+					deepStrictEqual(
+						detectLinks(`${osTestPath[os]}?a=b&c=d`, os),
+						[
+							{
+								path: {
+									index: 0,
+									text: osTestPath[os]
+								},
+								prefix: undefined,
+								suffix: undefined
+							}
+						] as IParsedLink[]
+					);
+				});
+			}
+		});
+
 		suite('should detect file names in git diffs', () => {
 			test('--- a/foo/bar', () => {
 				deepStrictEqual(


### PR DESCRIPTION
This was already happening on Windows, but now on Linux and macOS the ? will be not allowed in any detected file path

Fixes #183958
