### PR TITLE
fix: only use action toggled title when toggle state is on

### DIFF
--- a/src/vs/platform/actions/common/actions.ts
+++ b/src/vs/platform/actions/common/actions.ts
@@ -460,7 +460,7 @@ export class MenuItemAction implements IAction {
 				icon = toggled.icon;
 			}
 
-			if (toggled.title) {
+			if (this.checked && toggled.title) {
 				this.label = typeof toggled.title === 'string' ? toggled.title : toggled.title.value;
 			}
 		}


### PR DESCRIPTION
Fixes #182066

cc @rebornix it looks like you added this code initially :)

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
