### PR TITLE
Revert "Git - Close Repository command should be disabled when there is only one repository opened (#184637)"

### DIFF
--- a/extensions/git/package.json
+++ b/extensions/git/package.json
@@ -88,7 +88,7 @@
         "command": "git.close",
         "title": "%command.close%",
         "category": "Git",
-        "enablement": "!operationInProgress && gitOpenRepositoryCount > 1"
+        "enablement": "!operationInProgress"
       },
       {
         "command": "git.refresh",
@@ -773,7 +773,7 @@
         },
         {
           "command": "git.close",
-          "when": "config.git.enabled && !git.missing && gitOpenRepositoryCount > 1"
+          "when": "config.git.enabled && !git.missing && gitOpenRepositoryCount != 0"
         },
         {
           "command": "git.refresh",


### PR DESCRIPTION
This reverts commit 2cccaaee8a88e96c36da64ab191a36b15e700dae.