### PR TITLE
joh/cautious cephalopod

### DIFF
--- a/src/vs/base/browser/ui/list/listWidget.ts
+++ b/src/vs/base/browser/ui/list/listWidget.ts
@@ -129,11 +129,16 @@ class Trait<T> implements ISpliceable<boolean>, IDisposable {
 
 		const diff = elements.length - deleteCount;
 		const end = start + deleteCount;
-		const sortedIndexes = [
-			...this.sortedIndexes.filter(i => i < start),
-			...elements.map((hasTrait, i) => hasTrait ? i + start : -1).filter(i => i !== -1),
-			...this.sortedIndexes.filter(i => i >= end).map(i => i + diff)
-		];
+		const newSortedStart = this.sortedIndexes.filter(i => i < start);
+		const newSortedMiddle: number[] = [];
+		const newSortedEnd = this.sortedIndexes.filter(i => i >= end).map(i => i + diff);
+		for (let i = 0; i < elements.length; i++) {
+			const hasTrait = elements[i];
+			if (hasTrait) {
+				newSortedMiddle.push(i + start);
+			}
+		}
+		const sortedIndexes = newSortedStart.concat(newSortedMiddle, newSortedEnd);
 
 		const length = this.length + diff;
 

--- a/src/vs/base/browser/ui/list/listWidget.ts
+++ b/src/vs/base/browser/ui/list/listWidget.ts
@@ -226,12 +226,15 @@ class TraitSpliceable<T> implements ISpliceable<T> {
 
 	splice(start: number, deleteCount: number, elements: T[]): void {
 		if (!this.identityProvider) {
-			return this.trait.splice(start, deleteCount, elements.map(() => false));
+			return this.trait.splice(start, deleteCount, new Array(elements.length).fill(false));
 		}
 
-		const pastElementsWithTrait = this.trait.get().map(i => this.identityProvider!.getId(this.view.element(i)).toString());
-		const elementsWithTrait = elements.map(e => pastElementsWithTrait.indexOf(this.identityProvider!.getId(e).toString()) > -1);
+		const pastElementsWithTrait = new Set<string>(this.trait.get().map(i => this.identityProvider!.getId(this.view.element(i)).toString()));
+		if (pastElementsWithTrait.size === 0) {
+			return this.trait.splice(start, deleteCount, new Array(elements.length).fill(false));
+		}
 
+		const elementsWithTrait: boolean[] = elements.map(e => pastElementsWithTrait.has(this.identityProvider!.getId(e).toString()));
 		this.trait.splice(start, deleteCount, elementsWithTrait);
 	}
 }


### PR DESCRIPTION
Follow up from @TylerLeonhardt's quick pick performance fireworks: https://github.com/microsoft/vscode/issues/184615

- improve performance of `TraitSpliceable#splice`, avoid O(n2), avoid loop when not removing anything
- improve `Trait#splice` by reducing how often arrays are iterated over (from eight to four)
