### PR TITLE
Use a better id for QuickPickList

### DIFF
--- a/src/vs/platform/quickinput/browser/quickInputList.ts
+++ b/src/vs/platform/quickinput/browser/quickInputList.ts
@@ -466,7 +466,17 @@ export class QuickInputList {
 		const delegate = new ListElementDelegate();
 		const accessibilityProvider = new QuickInputAccessibilityProvider();
 		this.list = options.createList('QuickInput', this.container, delegate, [new ListElementRenderer(this.options.styles.colorScheme)], {
-			identityProvider: { getId: element => element.saneLabel },
+			identityProvider: {
+				getId: element => {
+					// always prefer item over separator because if item is defined, it must be the main item type
+					// always prefer a defined id if one was specified and use label as a fallback
+					return element.item?.id
+						?? element.item?.label
+						?? element.separator?.id
+						?? element.separator?.label
+						?? '';
+				}
+			},
 			setRowLineHeight: false,
 			multipleSelectionSupport: false,
 			horizontalScrolling: false,


### PR DESCRIPTION
Using saneLabel before is computationally more intense then just checking a few properties. Additionally, this wasn't taking into account the `id`.

So this change is not only faster, but also more accurate!

ref https://github.com/microsoft/vscode/issues/184615

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
