### PR TITLE
Use correct index in QuickInputList map

### DIFF
--- a/src/vs/platform/quickinput/browser/quickInputList.ts
+++ b/src/vs/platform/quickinput/browser/quickInputList.ts
@@ -690,8 +690,9 @@ export class QuickInputList {
 				this._listElementChecked
 			);
 
+			const resultIndex = result.length;
 			result.push(element);
-			elementsToIndexes.set(element.item ?? element.separator!, index);
+			elementsToIndexes.set(element.item ?? element.separator!, resultIndex);
 			return result;
 		}, [] as IListElement[]);
 		this.elementsToIndexes = elementsToIndexes;

--- a/src/vs/workbench/services/semanticSimilarity/common/semanticSimilarityService.ts
+++ b/src/vs/workbench/services/semanticSimilarity/common/semanticSimilarityService.ts
@@ -8,6 +8,8 @@ import { CancellationToken } from 'vs/base/common/cancellation';
 import { CancelablePromise, createCancelablePromise, raceCancellablePromises, timeout } from 'vs/base/common/async';
 import { IDisposable } from 'vs/base/common/lifecycle';
 import { InstantiationType, registerSingleton } from 'vs/platform/instantiation/common/extensions';
+import { StopWatch } from 'vs/base/common/stopwatch';
+import { ILogService } from 'vs/platform/log/common/log';
 
 export const ISemanticSimilarityService = createDecorator<ISemanticSimilarityService>('ISemanticSimilarityService');
 
@@ -30,6 +32,8 @@ export class SemanticSimilarityService implements ISemanticSimilarityService {
 
 	private readonly _providers: ISemanticSimilarityProvider[] = [];
 
+	constructor(@ILogService private readonly logService: ILogService) { }
+
 	isEnabled(): boolean {
 		return this._providers.length > 0;
 	}
@@ -50,6 +54,8 @@ export class SemanticSimilarityService implements ISemanticSimilarityService {
 		if (this._providers.length === 0) {
 			throw new Error('No semantic similarity providers registered');
 		}
+
+		const stopwatch = StopWatch.create();
 
 		const cancellablePromises: Array<CancelablePromise<number[]>> = [];
 
@@ -83,8 +89,13 @@ export class SemanticSimilarityService implements ISemanticSimilarityService {
 			throw new Error('Semantic similarity provider timed out');
 		}));
 
-		const result = await raceCancellablePromises(cancellablePromises);
-		return result;
+		try {
+			const result = await raceCancellablePromises(cancellablePromises);
+			return result;
+		} finally {
+			stopwatch.stop();
+			this.logService.trace(`[SemanticSimilarityService]: getSimilarityScore took ${stopwatch.elapsed()}ms`);
+		}
 	}
 }
 


### PR DESCRIPTION
I was using the value of index before we combined quickpickitems and separators... when I should have been using the result's index.

This fixes that, and also adds a stopwatch for semantic similarity so we can log how see it takes.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fixes https://github.com/microsoft/vscode/issues/184684