### PR TITLE
Bump windows-registry to 1.1.0

### DIFF
--- a/build/.moduleignore.darwin
+++ b/build/.moduleignore.darwin
@@ -2,3 +2,10 @@
 @vscode/windows-mutex/**/*.node
 @vscode/windows-mutex/*.md
 @vscode/windows-mutex/package.json
+
+@vscode/windows-registry/dist/**
+@vscode/windows-registry/**/*.node
+@vscode/windows-registry/*.md
+@vscode/windows-registry/*.txt
+@vscode/windows-registry/package.json
+!@vscode/windows-registry/dist/index.d.ts

--- a/build/.moduleignore.linux
+++ b/build/.moduleignore.linux
@@ -2,3 +2,10 @@
 @vscode/windows-mutex/**/*.node
 @vscode/windows-mutex/*.md
 @vscode/windows-mutex/package.json
+
+@vscode/windows-registry/dist/**
+@vscode/windows-registry/**/*.node
+@vscode/windows-registry/*.md
+@vscode/windows-registry/*.txt
+@vscode/windows-registry/package.json
+!@vscode/windows-registry/dist/index.d.ts

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "@vscode/sudo-prompt": "9.3.1",
     "@vscode/vscode-languagedetection": "1.0.21",
     "@vscode/windows-mutex": "^0.4.4",
+    "@vscode/windows-registry": "^1.1.0",
     "graceful-fs": "4.2.8",
     "http-proxy-agent": "^2.1.0",
     "https-proxy-agent": "^2.2.3",
@@ -227,7 +228,6 @@
   },
   "optionalDependencies": {
     "@vscode/windows-process-tree": "0.4.2",
-    "@vscode/windows-registry": "1.0.10",
     "windows-foreground-love": "0.5.0"
   }
 }

--- a/remote/package.json
+++ b/remote/package.json
@@ -11,6 +11,7 @@
     "@vscode/ripgrep": "^1.15.4",
     "@vscode/spdlog": "^0.13.10",
     "@vscode/vscode-languagedetection": "1.0.21",
+    "@vscode/windows-registry": "^1.1.0",
     "cookie": "^0.4.0",
     "graceful-fs": "4.2.8",
     "http-proxy-agent": "^2.1.0",
@@ -36,7 +37,6 @@
     "yazl": "^2.4.3"
   },
   "optionalDependencies": {
-    "@vscode/windows-process-tree": "0.4.2",
-    "@vscode/windows-registry": "1.0.10"
+    "@vscode/windows-process-tree": "0.4.2"
   }
 }

--- a/remote/yarn.lock
+++ b/remote/yarn.lock
@@ -108,10 +108,10 @@
   dependencies:
     nan "^2.17.0"
 
-"@vscode/windows-registry@1.0.10":
-  version "1.0.10"
-  resolved "https://registry.yarnpkg.com/@vscode/windows-registry/-/windows-registry-1.0.10.tgz#17e4e2f8fdd41990206d1bab2daf99c803206247"
-  integrity sha512-n2rLdTgv95fQUpDxZqgAURg9neQGymtOKkLW4eYP2SODmaxoL2WzgrxEz1kW0w5TI+J4tsPeuZylpRfrDJKQWw==
+"@vscode/windows-registry@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@vscode/windows-registry/-/windows-registry-1.1.0.tgz#03dace7c29c46f658588b9885b9580e453ad21f9"
+  integrity sha512-5AZzuWJpGscyiMOed0IuyEwt6iKmV5Us7zuwCDCFYMIq7tsvooO9BUiciywsvuthGz6UG4LSpeDeCxvgMVhnIw==
 
 agent-base@4:
   version "4.2.0"

--- a/src/typings/windows-registry.d.ts
+++ b/src/typings/windows-registry.d.ts
@@ -1,9 +1,0 @@
-/*---------------------------------------------------------------------------------------------
- *  Copyright (c) Microsoft Corporation. All rights reserved.
- *  Licensed under the MIT License. See License.txt in the project root for license information.
- *--------------------------------------------------------------------------------------------*/
-
-declare module '@vscode/windows-registry' {
-	export type HKEY = 'HKEY_CURRENT_USER' | 'HKEY_LOCAL_MACHINE' | 'HKEY_CLASSES_ROOT' | 'HKEY_USERS' | 'HKEY_CURRENT_CONFIG';
-	export function GetStringRegKey(hive: HKEY, path: string, name: string): string | undefined;
-}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1407,10 +1407,10 @@
   dependencies:
     nan "^2.17.0"
 
-"@vscode/windows-registry@1.0.10":
-  version "1.0.10"
-  resolved "https://registry.yarnpkg.com/@vscode/windows-registry/-/windows-registry-1.0.10.tgz#17e4e2f8fdd41990206d1bab2daf99c803206247"
-  integrity sha512-n2rLdTgv95fQUpDxZqgAURg9neQGymtOKkLW4eYP2SODmaxoL2WzgrxEz1kW0w5TI+J4tsPeuZylpRfrDJKQWw==
+"@vscode/windows-registry@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@vscode/windows-registry/-/windows-registry-1.1.0.tgz#03dace7c29c46f658588b9885b9580e453ad21f9"
+  integrity sha512-5AZzuWJpGscyiMOed0IuyEwt6iKmV5Us7zuwCDCFYMIq7tsvooO9BUiciywsvuthGz6UG4LSpeDeCxvgMVhnIw==
 
 "@webassemblyjs/ast@1.11.1":
   version "1.11.1"


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

windows-registry is now a package that can be installed on all platforms, but only run on Windows. Therefore, types are provided for all platforms, but trying to actually construct on object on non-Windows platforms results in an exception.

I also updated the OS-specific moduleignore files so that only the typings file is preserved in the packaged product.
