### PR TITLE
Fix config error in xml.tmLanguage.json #184852

### DIFF
--- a/extensions/xml/syntaxes/xml.tmLanguage.json
+++ b/extensions/xml/syntaxes/xml.tmLanguage.json
@@ -356,10 +356,10 @@
 					"captures": {
 						"0": {
 							"name": "punctuation.definition.comment.xml"
-						},
-						"end": "--%>",
-						"name": "comment.block.xml"
-					}
+						}
+					},
+					"end": "--%>",
+					"name": "comment.block.xml"
 				},
 				{
 					"begin": "<!--",


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR fixes a config issue in the TextMate config file /extensions/xml/syntaxes/xml.tmLanguage.json
where two properties are added at the wrong indention level. This PR places the properties at the correct level.

Fixes https://github.com/microsoft/vscode/issues/184852