### PR TITLE
fix: loading minimist in packaged builds

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -27,17 +27,17 @@ const { getUNCHost, addUNCHostToAllowlist } = require('./vs/base/node/unc');
 const product = require('../product.json');
 const { app, protocol, crashReporter, Menu } = require('electron');
 
-// Enable sandbox globally unless disabled via `--no-sandbox` argument
-const args = parseCLIArgs();
-if (args['sandbox']) {
-	app.enableSandbox();
-}
-
 // Enable portable support
 const portable = bootstrapNode.configurePortable(product);
 
 // Enable ASAR support
 bootstrap.enableASARSupport();
+
+// Enable sandbox globally unless disabled via `--no-sandbox` argument
+const args = parseCLIArgs();
+if (args['sandbox']) {
+	app.enableSandbox();
+}
 
 // Set userData path before app 'ready' event
 const userDataPath = getUserDataPath(args, product.nameShort ?? 'code-oss-dev');


### PR DESCRIPTION
Follow-up to https://github.com/microsoft/vscode/pull/184897

Fixes product builds [broken](https://dev.azure.com/monacotools/Monaco/_build/results?buildId=218254&view=results) due to following error 


```

    at Module.require (node:internal/modules/cjs/loader:1082:19)
    at require (node:internal/modules/cjs/helpers:102:18)
    at parseCLIArgs (/__w/1/VSCode-linux-x64/resources/app/out/main.js:8:2077)
    at Object.<anonymous> (/__w/1/VSCode-linux-x64/resources/app/out/main.js:7:8143)
    at Module._compile (node:internal/modules/cjs/loader:1188:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1243:10)
    at Module.load (node:internal/modules/cjs/loader:1058:32)
    at Module._load (node:internal/modules/cjs/loader:893:12)
    at f._load (node:electron/js2c/asar_bundle:2:13330)
    at node:electron/js2c/browser_init:2:117044
    at node:electron/js2c/browser_init:2:117247
    at node:electron/js2c/browser_init:2:117251
    at NativeModule.compileForInternalLoader (node:internal/bootstrap/loaders:329:7)
    at NativeModule.compileForPublicLoader (node:internal/bootstrap/loaders:269:10)
    at loadNativeModule (node:internal/modules/cjs/helpers:49:9)
    at Module._load (node:internal/modules/cjs/loader:872:15)
    at f._load (node:electron/js2c/asar_bundle:2:13330)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:81:12)
    at node:internal/main/run_main_module:17:47
```