### PR TITLE
Don’t re-wrap `prepareStackTrace` when assigned back to itself

### DIFF
--- a/src/vs/workbench/api/common/extensionHostMain.ts
+++ b/src/vs/workbench/api/common/extensionHostMain.ts
@@ -103,7 +103,7 @@ abstract class ErrorHandler {
 					prepareStackTraceAndFindExtension(error, stackTrace);
 					return v.call(Error, error, stackTrace);
 				};
-				
+
 				Object.assign(_prepareStackTrace, { [_wasWrapped]: true });
 			},
 		});

--- a/src/vs/workbench/api/common/extensionHostMain.ts
+++ b/src/vs/workbench/api/common/extensionHostMain.ts
@@ -85,7 +85,7 @@ abstract class ErrorHandler {
 			return `${error.name || 'Error'}: ${error.message || ''}${stackTraceMessage}`;
 		}
 
-		let _wasWrapped = Symbol('prepareStackTrace wrapped');
+		const _wasWrapped = Symbol('prepareStackTrace wrapped');
 		let _prepareStackTrace = prepareStackTraceAndFindExtension;
 		Object.assign(_prepareStackTrace, { [_wasWrapped]: true });
 		Object.defineProperty(Error, 'prepareStackTrace', {
@@ -96,7 +96,7 @@ abstract class ErrorHandler {
 			set(v) {
 				if (v && (v as any)[_wasWrapped]) {
 					_prepareStackTrace = v;
-					return
+					return;
 				}
 
 				_prepareStackTrace = function (error, stackTrace) {

--- a/src/vs/workbench/api/test/common/extensionHostMain.test.ts
+++ b/src/vs/workbench/api/test/common/extensionHostMain.test.ts
@@ -1,0 +1,218 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { SerializedError, errorHandler, onUnexpectedError } from 'vs/base/common/errors';
+import { TernarySearchTree } from 'vs/base/common/ternarySearchTree';
+import { URI } from 'vs/base/common/uri';
+import { mock } from 'vs/base/test/common/mock';
+import { ExtensionIdentifier, IExtensionDescription, IRelaxedExtensionDescription } from 'vs/platform/extensions/common/extensions';
+import { InstantiationService } from 'vs/platform/instantiation/common/instantiationService';
+import { ServiceCollection } from 'vs/platform/instantiation/common/serviceCollection';
+import { ILogService, NullLogService } from 'vs/platform/log/common/log';
+import { MainThreadExtensionServiceShape } from 'vs/workbench/api/common/extHost.protocol';
+import { ExtensionPaths, IExtHostExtensionService } from 'vs/workbench/api/common/extHostExtensionService';
+import { IExtHostRpcService } from 'vs/workbench/api/common/extHostRpcService';
+import { IExtHostTelemetry } from 'vs/workbench/api/common/extHostTelemetry';
+import { ErrorHandler } from 'vs/workbench/api/common/extensionHostMain';
+import { nullExtensionDescription } from 'vs/workbench/services/extensions/common/extensions';
+import { ProxyIdentifier, Proxied } from 'vs/workbench/services/extensions/common/proxyIdentifier';
+
+
+suite('ExtensionHostMain#ErrorHandler - Wrapping prepareStackTrace can cause slowdown and eventual stack overflow #184926 ', function () {
+
+	const extensionsIndex = TernarySearchTree.forUris<IExtensionDescription>();
+	const mainThreadExtensionsService = new class extends mock<MainThreadExtensionServiceShape>() {
+		override $onExtensionRuntimeError(extensionId: ExtensionIdentifier, data: SerializedError): void {
+
+		}
+	};
+
+	const collection = new ServiceCollection(
+		[ILogService, new NullLogService()],
+		[IExtHostTelemetry, new class extends mock<IExtHostTelemetry>() {
+			declare readonly _serviceBrand: undefined;
+			override onExtensionError(extension: ExtensionIdentifier, error: Error): boolean {
+				return true;
+			}
+		}],
+		[IExtHostExtensionService, new class extends mock<IExtHostExtensionService & any>() {
+			declare readonly _serviceBrand: undefined;
+			getExtensionPathIndex() {
+				return new class extends ExtensionPaths {
+					override findSubstr(key: URI): Readonly<IRelaxedExtensionDescription> | undefined {
+						findSubstrCount++;
+						return nullExtensionDescription;
+					}
+
+				}(extensionsIndex);
+			}
+		}],
+		[IExtHostRpcService, new class extends mock<IExtHostRpcService>() {
+			declare readonly _serviceBrand: undefined;
+			override getProxy<T>(identifier: ProxyIdentifier<T>): Proxied<T> {
+				return <any>mainThreadExtensionsService;
+			}
+		}]
+	);
+
+	const insta = new InstantiationService(collection, false);
+
+	let existingErrorHandler: (e: any) => void;
+	let findSubstrCount = 0;
+
+	suiteSetup(async function () {
+		existingErrorHandler = errorHandler.getUnexpectedErrorHandler();
+		await insta.invokeFunction(ErrorHandler.installFullHandler);
+	});
+
+	suiteTeardown(function () {
+		errorHandler.setUnexpectedErrorHandler(existingErrorHandler);
+	});
+
+	setup(async function () {
+		findSubstrCount = 0;
+	});
+
+	test('basics', function () {
+
+		const err = new Error('test1');
+
+		onUnexpectedError(err);
+
+		assert.strictEqual(findSubstrCount, 1);
+
+	});
+
+	test('set/reset prepareStackTrace-callback', function () {
+
+		const original = Error.prepareStackTrace;
+		Error.prepareStackTrace = (_error, _stack) => 'stack';
+		const probeErr = new Error();
+		const stack = probeErr.stack;
+		assert.ok(stack);
+		Error.prepareStackTrace = original;
+		assert.strictEqual(findSubstrCount, 1);
+
+		// already checked
+		onUnexpectedError(probeErr);
+		assert.strictEqual(findSubstrCount, 1);
+
+		// one more error
+		const err = new Error('test2');
+		onUnexpectedError(err);
+
+		assert.strictEqual(findSubstrCount, 2);
+	});
+
+	test('wrap prepareStackTrace-callback', function () {
+
+		function do_something_else(params: string) {
+			return params;
+		}
+
+		const original = Error.prepareStackTrace;
+		Error.prepareStackTrace = (...args) => {
+			return do_something_else(original?.(...args));
+		};
+		const probeErr = new Error();
+		const stack = probeErr.stack;
+		assert.ok(stack);
+
+
+		onUnexpectedError(probeErr);
+		assert.strictEqual(findSubstrCount, 1);
+	});
+
+	test('prevent rewrapping', function () {
+
+		let do_something_count = 0;
+		function do_something(params: any) {
+			do_something_count++;
+		}
+
+		Error.prepareStackTrace = (result, stack) => {
+			do_something(stack);
+			return 'fakestack';
+		};
+
+		for (let i = 0; i < 2_500; ++i) {
+			Error.prepareStackTrace = Error.prepareStackTrace;
+		}
+
+		const probeErr = new Error();
+		const stack = probeErr.stack;
+		assert.strictEqual(stack, 'fakestack');
+
+		onUnexpectedError(probeErr);
+		assert.strictEqual(findSubstrCount, 1);
+
+		const probeErr2 = new Error();
+		onUnexpectedError(probeErr2);
+		assert.strictEqual(findSubstrCount, 2);
+		assert.strictEqual(do_something_count, 2);
+	});
+});
+
+suite('ExtensionHostMain#ErrorHandler - from https://gist.github.com/thecrypticace/f0f2e182082072efdaf0f8e1537d2cce', function () {
+
+	test("Restored, separate operations", () => {
+		// Actual Test
+		let original;
+
+		// Operation 1
+		original = Error.prepareStackTrace;
+		for (let i = 0; i < 12_500; ++i) { Error.prepareStackTrace = Error.prepareStackTrace; }
+		assert.ok(new Error().stack);
+		Error.prepareStackTrace = original;
+
+		// Operation 2
+		original = Error.prepareStackTrace;
+		for (let i = 0; i < 12_500; ++i) { Error.prepareStackTrace = Error.prepareStackTrace; }
+		assert.ok(new Error().stack);
+		Error.prepareStackTrace = original;
+
+		// Operation 3
+		original = Error.prepareStackTrace;
+		for (let i = 0; i < 12_500; ++i) { Error.prepareStackTrace = Error.prepareStackTrace; }
+		assert.ok(new Error().stack);
+		Error.prepareStackTrace = original;
+
+		// Operation 4
+		original = Error.prepareStackTrace;
+		for (let i = 0; i < 12_500; ++i) { Error.prepareStackTrace = Error.prepareStackTrace; }
+		assert.ok(new Error().stack);
+		Error.prepareStackTrace = original;
+	});
+
+	test("Never restored, separate operations", () => {
+		// Operation 1
+		for (let i = 0; i < 12_500; ++i) { Error.prepareStackTrace = Error.prepareStackTrace; }
+		assert.ok(new Error().stack);
+
+		// Operation 2
+		for (let i = 0; i < 12_500; ++i) { Error.prepareStackTrace = Error.prepareStackTrace; }
+		assert.ok(new Error().stack);
+
+		// Operation 3
+		for (let i = 0; i < 12_500; ++i) { Error.prepareStackTrace = Error.prepareStackTrace; }
+		assert.ok(new Error().stack);
+
+		// Operation 4
+		for (let i = 0; i < 12_500; ++i) { Error.prepareStackTrace = Error.prepareStackTrace; }
+		assert.ok(new Error().stack);
+	});
+
+	test("Restored, too many uses before restoration", async () => {
+		const original = Error.prepareStackTrace;
+		Error.prepareStackTrace = (_, stack) => stack;
+
+		// Operation 1 — more uses of `prepareStackTrace`
+		for (let i = 0; i < 10_000; ++i) { Error.prepareStackTrace = Error.prepareStackTrace; }
+		assert.ok(new Error().stack);
+
+		Error.prepareStackTrace = original;
+	});
+});

--- a/src/vs/workbench/api/test/common/extensionHostMain.test.ts
+++ b/src/vs/workbench/api/test/common/extensionHostMain.test.ts
@@ -154,65 +154,75 @@ suite('ExtensionHostMain#ErrorHandler - Wrapping prepareStackTrace can cause slo
 		assert.strictEqual(findSubstrCount, 2);
 		assert.strictEqual(do_something_count, 2);
 	});
-});
 
-suite('ExtensionHostMain#ErrorHandler - from https://gist.github.com/thecrypticace/f0f2e182082072efdaf0f8e1537d2cce', function () {
 
-	test("Restored, separate operations", () => {
-		// Actual Test
-		let original;
+	suite('https://gist.github.com/thecrypticace/f0f2e182082072efdaf0f8e1537d2cce', function () {
 
-		// Operation 1
-		original = Error.prepareStackTrace;
-		for (let i = 0; i < 12_500; ++i) { Error.prepareStackTrace = Error.prepareStackTrace; }
-		assert.ok(new Error().stack);
-		Error.prepareStackTrace = original;
+		test("Restored, separate operations", () => {
+			// Actual Test
+			let original;
 
-		// Operation 2
-		original = Error.prepareStackTrace;
-		for (let i = 0; i < 12_500; ++i) { Error.prepareStackTrace = Error.prepareStackTrace; }
-		assert.ok(new Error().stack);
-		Error.prepareStackTrace = original;
+			// Operation 1
+			original = Error.prepareStackTrace;
+			for (let i = 0; i < 12_500; ++i) { Error.prepareStackTrace = Error.prepareStackTrace; }
+			const err1 = new Error();
+			assert.ok(err1.stack);
+			assert.strictEqual(findSubstrCount, 1);
+			Error.prepareStackTrace = original;
 
-		// Operation 3
-		original = Error.prepareStackTrace;
-		for (let i = 0; i < 12_500; ++i) { Error.prepareStackTrace = Error.prepareStackTrace; }
-		assert.ok(new Error().stack);
-		Error.prepareStackTrace = original;
+			// Operation 2
+			original = Error.prepareStackTrace;
+			for (let i = 0; i < 12_500; ++i) { Error.prepareStackTrace = Error.prepareStackTrace; }
+			assert.ok(new Error().stack);
+			assert.strictEqual(findSubstrCount, 2);
+			Error.prepareStackTrace = original;
 
-		// Operation 4
-		original = Error.prepareStackTrace;
-		for (let i = 0; i < 12_500; ++i) { Error.prepareStackTrace = Error.prepareStackTrace; }
-		assert.ok(new Error().stack);
-		Error.prepareStackTrace = original;
-	});
+			// Operation 3
+			original = Error.prepareStackTrace;
+			for (let i = 0; i < 12_500; ++i) { Error.prepareStackTrace = Error.prepareStackTrace; }
+			assert.ok(new Error().stack);
+			assert.strictEqual(findSubstrCount, 3);
+			Error.prepareStackTrace = original;
 
-	test("Never restored, separate operations", () => {
-		// Operation 1
-		for (let i = 0; i < 12_500; ++i) { Error.prepareStackTrace = Error.prepareStackTrace; }
-		assert.ok(new Error().stack);
+			// Operation 4
+			original = Error.prepareStackTrace;
+			for (let i = 0; i < 12_500; ++i) { Error.prepareStackTrace = Error.prepareStackTrace; }
+			assert.ok(new Error().stack);
+			assert.strictEqual(findSubstrCount, 4);
+			Error.prepareStackTrace = original;
 
-		// Operation 2
-		for (let i = 0; i < 12_500; ++i) { Error.prepareStackTrace = Error.prepareStackTrace; }
-		assert.ok(new Error().stack);
+			// Back to Operation 1
+			assert.ok(err1.stack);
+			assert.strictEqual(findSubstrCount, 4);
+		});
 
-		// Operation 3
-		for (let i = 0; i < 12_500; ++i) { Error.prepareStackTrace = Error.prepareStackTrace; }
-		assert.ok(new Error().stack);
+		test("Never restored, separate operations", () => {
+			// Operation 1
+			for (let i = 0; i < 12_500; ++i) { Error.prepareStackTrace = Error.prepareStackTrace; }
+			assert.ok(new Error().stack);
 
-		// Operation 4
-		for (let i = 0; i < 12_500; ++i) { Error.prepareStackTrace = Error.prepareStackTrace; }
-		assert.ok(new Error().stack);
-	});
+			// Operation 2
+			for (let i = 0; i < 12_500; ++i) { Error.prepareStackTrace = Error.prepareStackTrace; }
+			assert.ok(new Error().stack);
 
-	test("Restored, too many uses before restoration", async () => {
-		const original = Error.prepareStackTrace;
-		Error.prepareStackTrace = (_, stack) => stack;
+			// Operation 3
+			for (let i = 0; i < 12_500; ++i) { Error.prepareStackTrace = Error.prepareStackTrace; }
+			assert.ok(new Error().stack);
 
-		// Operation 1 — more uses of `prepareStackTrace`
-		for (let i = 0; i < 10_000; ++i) { Error.prepareStackTrace = Error.prepareStackTrace; }
-		assert.ok(new Error().stack);
+			// Operation 4
+			for (let i = 0; i < 12_500; ++i) { Error.prepareStackTrace = Error.prepareStackTrace; }
+			assert.ok(new Error().stack);
+		});
 
-		Error.prepareStackTrace = original;
+		test("Restored, too many uses before restoration", async () => {
+			const original = Error.prepareStackTrace;
+			Error.prepareStackTrace = (_, stack) => stack;
+
+			// Operation 1 — more uses of `prepareStackTrace`
+			for (let i = 0; i < 10_000; ++i) { Error.prepareStackTrace = Error.prepareStackTrace; }
+			assert.ok(new Error().stack);
+
+			Error.prepareStackTrace = original;
+		});
 	});
 });


### PR DESCRIPTION
See issue #184926 for details/background.

Here I've added a marker `Symbol` to prevent repeated wrapping of the functions assigned to `prepareStackTrace`.

Patterns that get the original handler, set a new one temporarily, and then restore the original are pervasive in packages that use `Error.prepareStackTrace` given that it is a global property.

An example would be code that codes the following:
```js
let original = Error.prepareStackTrace;
Error.prepareStackTrace = (, stack) => stack;
let stack = new Error.stack();
Error.prepareStackTrace = original;
```

As described in the issue filed above, the last line will result in a second wrapping of the handler. And if this code is run repeatedly, for example because code is formatted on save and an extension uses code of this style (directory or indirectly) — it can result in an eventual stack overflow.

I'm not 100% sold on this approach but am opening this as to have a concrete implementation to discuss.

Testing this PR is simple-ish if you're okay using other extensions (e.g. the Prettier extension + a project with a custom Prettier plugin that loops the error stack restoration code) but could also be tested without that.

If you want to go the route of using the Prettier extension to test this PR you can do that with a couple of files in a project that format typescript code:

```js
// prettier.config.js
module.exports = {
  pluginSearchDirs: false,
  plugins: [
    require('./test-plugin.js')
  ],
};
```

```js
// test-plugin.js
// @ts-check
let prettierParserTypescript = require('prettier/parser-typescript');

let orig = prettierParserTypescript.parsers.typescript;
/** @type {Record<string, import('prettier').Parser>} */
const parsers = {
  typescript: {
    ...orig,
    parse(text, parsers, options) {
      // VSCode's extension host process file wraps every set in a function
      // This means that whenever you restore it the stack grows unbounded
      for (let i = 0; i < 2**16; ++i) {
        const original = Error.prepareStackTrace;
        Error.prepareStackTrace = original;  
      }

      return orig.parse(text, parsers, options);
    },
  },
};

module.exports.parsers = parsers;
```