### PR TITLE
Revert Python docstring color

### DIFF
--- a/extensions/theme-abyss/themes/abyss-color-theme.json
+++ b/extensions/theme-abyss/themes/abyss-color-theme.json
@@ -17,11 +17,8 @@
 			}
 		},
 		{
-			"name": "Comments",
-			"scope": [
-				"comment",
-				"string.quoted.docstring"
-			],
+			"name": "Comment",
+			"scope": "comment",
 			"settings": {
 				"foreground": "#384887"
 			}

--- a/extensions/theme-defaults/themes/dark_vs.json
+++ b/extensions/theme-defaults/themes/dark_vs.json
@@ -57,11 +57,7 @@
 			}
 		},
 		{
-			"name": "Comments",
-			"scope": [
-				"comment",
-				"string.quoted.docstring"
-			],
+			"scope": "comment",
 			"settings": {
 				"foreground": "#6A9955"
 			}

--- a/extensions/theme-defaults/themes/hc_black.json
+++ b/extensions/theme-defaults/themes/hc_black.json
@@ -43,11 +43,7 @@
 			}
 		},
 		{
-			"name": "Comments",
-			"scope": [
-				"comment",
-				"string.quoted.docstring"
-			],
+			"scope": "comment",
 			"settings": {
 				"foreground": "#7ca668"
 			}

--- a/extensions/theme-defaults/themes/hc_light.json
+++ b/extensions/theme-defaults/themes/hc_light.json
@@ -27,11 +27,7 @@
 			}
 		},
 		{
-			"name": "Comments",
-			"scope": [
-				"comment",
-				"string.quoted.docstring"
-			],
+			"scope": "comment",
 			"settings": {
 				"foreground": "#515151"
 			}

--- a/extensions/theme-defaults/themes/light_vs.json
+++ b/extensions/theme-defaults/themes/light_vs.json
@@ -62,11 +62,7 @@
 			}
 		},
 		{
-			"name": "Comments",
-			"scope": [
-				"comment",
-				"string.quoted.docstring"
-			],
+			"scope": "comment",
 			"settings": {
 				"foreground": "#008000"
 			}

--- a/extensions/theme-kimbie-dark/themes/kimbie-dark-color-theme.json
+++ b/extensions/theme-kimbie-dark/themes/kimbie-dark-color-theme.json
@@ -81,8 +81,7 @@
 			"name": "Comments",
 			"scope": [
 				"comment",
-				"punctuation.definition.comment",
-				"string.quoted.docstring"
+				"punctuation.definition.comment"
 			],
 			"settings": {
 				"foreground": "#a57a4c"

--- a/extensions/theme-monokai-dimmed/themes/dimmed-monokai-color-theme.json
+++ b/extensions/theme-monokai-dimmed/themes/dimmed-monokai-color-theme.json
@@ -78,11 +78,8 @@
 			}
 		},
 		{
-			"name": "Comments",
-			"scope": [
-				"comment",
-				"string.quoted.docstring"
-			],
+			"name": "Comment",
+			"scope": "comment",
 			"settings": {
 				"fontStyle": "",
 				"foreground": "#9A9B99"

--- a/extensions/theme-monokai/themes/monokai-color-theme.json
+++ b/extensions/theme-monokai/themes/monokai-color-theme.json
@@ -118,11 +118,8 @@
 			}
 		},
 		{
-			"name": "Comments",
-			"scope": [
-				"comment",
-				"string.quoted.docstring"
-			],
+			"name": "Comment",
+			"scope": "comment",
 			"settings": {
 				"foreground": "#88846f"
 			}

--- a/extensions/theme-quietlight/themes/quietlight-color-theme.json
+++ b/extensions/theme-quietlight/themes/quietlight-color-theme.json
@@ -20,8 +20,7 @@
 			"name": "Comments",
 			"scope": [
 				"comment",
-				"punctuation.definition.comment",
-				"string.quoted.docstring"
+				"punctuation.definition.comment"
 			],
 			"settings": {
 				"fontStyle": "italic",

--- a/extensions/theme-red/themes/Red-color-theme.json
+++ b/extensions/theme-red/themes/Red-color-theme.json
@@ -77,11 +77,8 @@
 			}
 		},
 		{
-			"name": "Comments",
-			"scope": [
-				"comment",
-				"string.quoted.docstring"
-			],
+			"name": "Comment",
+			"scope": "comment",
 			"settings": {
 				"fontStyle": "italic",
 				"foreground": "#e7c0c0ff"

--- a/extensions/theme-solarized-dark/themes/solarized-dark-color-theme.json
+++ b/extensions/theme-solarized-dark/themes/solarized-dark-color-theme.json
@@ -17,11 +17,8 @@
 			}
 		},
 		{
-			"name": "Comments",
-			"scope": [
-				"comment",
-				"string.quoted.docstring"
-			],
+			"name": "Comment",
+			"scope": "comment",
 			"settings": {
 				"fontStyle": "italic",
 				"foreground": "#586E75"

--- a/extensions/theme-solarized-light/themes/solarized-light-color-theme.json
+++ b/extensions/theme-solarized-light/themes/solarized-light-color-theme.json
@@ -17,11 +17,8 @@
 			}
 		},
 		{
-			"name": "Comments",
-			"scope": [
-				"comment",
-				"string.quoted.docstring"
-			],
+			"name": "Comment",
+			"scope": "comment",
 			"settings": {
 				"fontStyle": "italic",
 				"foreground": "#93A1A1"

--- a/extensions/theme-tomorrow-night-blue/themes/tomorrow-night-blue-color-theme.json
+++ b/extensions/theme-tomorrow-night-blue/themes/tomorrow-night-blue-color-theme.json
@@ -78,11 +78,8 @@
 			}
 		},
 		{
-			"name": "Comments",
-			"scope": [
-				"comment",
-				"string.quoted.docstring"
-			],
+			"name": "Comment",
+			"scope": "comment",
 			"settings": {
 				"foreground": "#7285B7"
 			}

--- a/extensions/vscode-colorize-tests/test/colorize-results/test_py.json
+++ b/extensions/vscode-colorize-tests/test/colorize-results/test_py.json
@@ -395,42 +395,42 @@
 		"c": "'''",
 		"t": "source.python string.quoted.docstring.multi.python punctuation.definition.string.begin.python",
 		"r": {
-			"dark_plus": "string.quoted.docstring: #6A9955",
-			"light_plus": "string.quoted.docstring: #008000",
-			"dark_vs": "string.quoted.docstring: #6A9955",
-			"light_vs": "string.quoted.docstring: #008000",
-			"hc_black": "string.quoted.docstring: #7CA668",
-			"dark_modern": "string.quoted.docstring: #6A9955",
-			"hc_light": "string.quoted.docstring: #515151",
-			"light_modern": "string.quoted.docstring: #008000"
+			"dark_plus": "string: #CE9178",
+			"light_plus": "string: #A31515",
+			"dark_vs": "string: #CE9178",
+			"light_vs": "string: #A31515",
+			"hc_black": "string: #CE9178",
+			"dark_modern": "string: #CE9178",
+			"hc_light": "string: #0F4A85",
+			"light_modern": "string: #A31515"
 		}
 	},
 	{
 		"c": "Make the monkey eat N bananas!",
 		"t": "source.python string.quoted.docstring.multi.python",
 		"r": {
-			"dark_plus": "string.quoted.docstring: #6A9955",
-			"light_plus": "string.quoted.docstring: #008000",
-			"dark_vs": "string.quoted.docstring: #6A9955",
-			"light_vs": "string.quoted.docstring: #008000",
-			"hc_black": "string.quoted.docstring: #7CA668",
-			"dark_modern": "string.quoted.docstring: #6A9955",
-			"hc_light": "string.quoted.docstring: #515151",
-			"light_modern": "string.quoted.docstring: #008000"
+			"dark_plus": "string: #CE9178",
+			"light_plus": "string: #A31515",
+			"dark_vs": "string: #CE9178",
+			"light_vs": "string: #A31515",
+			"hc_black": "string: #CE9178",
+			"dark_modern": "string: #CE9178",
+			"hc_light": "string: #0F4A85",
+			"light_modern": "string: #A31515"
 		}
 	},
 	{
 		"c": "'''",
 		"t": "source.python string.quoted.docstring.multi.python punctuation.definition.string.end.python",
 		"r": {
-			"dark_plus": "string.quoted.docstring: #6A9955",
-			"light_plus": "string.quoted.docstring: #008000",
-			"dark_vs": "string.quoted.docstring: #6A9955",
-			"light_vs": "string.quoted.docstring: #008000",
-			"hc_black": "string.quoted.docstring: #7CA668",
-			"dark_modern": "string.quoted.docstring: #6A9955",
-			"hc_light": "string.quoted.docstring: #515151",
-			"light_modern": "string.quoted.docstring: #008000"
+			"dark_plus": "string: #CE9178",
+			"light_plus": "string: #A31515",
+			"dark_vs": "string: #CE9178",
+			"light_vs": "string: #A31515",
+			"hc_black": "string: #CE9178",
+			"dark_modern": "string: #CE9178",
+			"hc_light": "string: #0F4A85",
+			"light_modern": "string: #A31515"
 		}
 	},
 	{
@@ -3181,42 +3181,42 @@
 		"c": "\"\"\"",
 		"t": "source.python string.quoted.docstring.multi.python punctuation.definition.string.begin.python",
 		"r": {
-			"dark_plus": "string.quoted.docstring: #6A9955",
-			"light_plus": "string.quoted.docstring: #008000",
-			"dark_vs": "string.quoted.docstring: #6A9955",
-			"light_vs": "string.quoted.docstring: #008000",
-			"hc_black": "string.quoted.docstring: #7CA668",
-			"dark_modern": "string.quoted.docstring: #6A9955",
-			"hc_light": "string.quoted.docstring: #515151",
-			"light_modern": "string.quoted.docstring: #008000"
+			"dark_plus": "string: #CE9178",
+			"light_plus": "string: #A31515",
+			"dark_vs": "string: #CE9178",
+			"light_vs": "string: #A31515",
+			"hc_black": "string: #CE9178",
+			"dark_modern": "string: #CE9178",
+			"hc_light": "string: #0F4A85",
+			"light_modern": "string: #A31515"
 		}
 	},
 	{
 		"c": "Berechnung der zu zahlenden Steuern fuer ein zu versteuerndes Einkommen von x",
 		"t": "source.python string.quoted.docstring.multi.python",
 		"r": {
-			"dark_plus": "string.quoted.docstring: #6A9955",
-			"light_plus": "string.quoted.docstring: #008000",
-			"dark_vs": "string.quoted.docstring: #6A9955",
-			"light_vs": "string.quoted.docstring: #008000",
-			"hc_black": "string.quoted.docstring: #7CA668",
-			"dark_modern": "string.quoted.docstring: #6A9955",
-			"hc_light": "string.quoted.docstring: #515151",
-			"light_modern": "string.quoted.docstring: #008000"
+			"dark_plus": "string: #CE9178",
+			"light_plus": "string: #A31515",
+			"dark_vs": "string: #CE9178",
+			"light_vs": "string: #A31515",
+			"hc_black": "string: #CE9178",
+			"dark_modern": "string: #CE9178",
+			"hc_light": "string: #0F4A85",
+			"light_modern": "string: #A31515"
 		}
 	},
 	{
 		"c": "\"\"\"",
 		"t": "source.python string.quoted.docstring.multi.python punctuation.definition.string.end.python",
 		"r": {
-			"dark_plus": "string.quoted.docstring: #6A9955",
-			"light_plus": "string.quoted.docstring: #008000",
-			"dark_vs": "string.quoted.docstring: #6A9955",
-			"light_vs": "string.quoted.docstring: #008000",
-			"hc_black": "string.quoted.docstring: #7CA668",
-			"dark_modern": "string.quoted.docstring: #6A9955",
-			"hc_light": "string.quoted.docstring: #515151",
-			"light_modern": "string.quoted.docstring: #008000"
+			"dark_plus": "string: #CE9178",
+			"light_plus": "string: #A31515",
+			"dark_vs": "string: #CE9178",
+			"light_vs": "string: #A31515",
+			"hc_black": "string: #CE9178",
+			"dark_modern": "string: #CE9178",
+			"hc_light": "string: #0F4A85",
+			"light_modern": "string: #A31515"
 		}
 	},
 	{
@@ -7423,56 +7423,56 @@
 		"c": "'''",
 		"t": "source.python string.quoted.docstring.raw.multi.python punctuation.definition.string.begin.python",
 		"r": {
-			"dark_plus": "string.quoted.docstring: #6A9955",
-			"light_plus": "string.quoted.docstring: #008000",
-			"dark_vs": "string.quoted.docstring: #6A9955",
-			"light_vs": "string.quoted.docstring: #008000",
-			"hc_black": "string.quoted.docstring: #7CA668",
-			"dark_modern": "string.quoted.docstring: #6A9955",
-			"hc_light": "string.quoted.docstring: #515151",
-			"light_modern": "string.quoted.docstring: #008000"
+			"dark_plus": "string: #CE9178",
+			"light_plus": "string: #A31515",
+			"dark_vs": "string: #CE9178",
+			"light_vs": "string: #A31515",
+			"hc_black": "string: #CE9178",
+			"dark_modern": "string: #CE9178",
+			"hc_light": "string: #0F4A85",
+			"light_modern": "string: #A31515"
 		}
 	},
 	{
 		"c": "Module docstring",
 		"t": "source.python string.quoted.docstring.raw.multi.python",
 		"r": {
-			"dark_plus": "string.quoted.docstring: #6A9955",
-			"light_plus": "string.quoted.docstring: #008000",
-			"dark_vs": "string.quoted.docstring: #6A9955",
-			"light_vs": "string.quoted.docstring: #008000",
-			"hc_black": "string.quoted.docstring: #7CA668",
-			"dark_modern": "string.quoted.docstring: #6A9955",
-			"hc_light": "string.quoted.docstring: #515151",
-			"light_modern": "string.quoted.docstring: #008000"
+			"dark_plus": "string: #CE9178",
+			"light_plus": "string: #A31515",
+			"dark_vs": "string: #CE9178",
+			"light_vs": "string: #A31515",
+			"hc_black": "string: #CE9178",
+			"dark_modern": "string: #CE9178",
+			"hc_light": "string: #0F4A85",
+			"light_modern": "string: #A31515"
 		}
 	},
 	{
 		"c": "    Some text followed by code sample:",
 		"t": "source.python string.quoted.docstring.raw.multi.python",
 		"r": {
-			"dark_plus": "string.quoted.docstring: #6A9955",
-			"light_plus": "string.quoted.docstring: #008000",
-			"dark_vs": "string.quoted.docstring: #6A9955",
-			"light_vs": "string.quoted.docstring: #008000",
-			"hc_black": "string.quoted.docstring: #7CA668",
-			"dark_modern": "string.quoted.docstring: #6A9955",
-			"hc_light": "string.quoted.docstring: #515151",
-			"light_modern": "string.quoted.docstring: #008000"
+			"dark_plus": "string: #CE9178",
+			"light_plus": "string: #A31515",
+			"dark_vs": "string: #CE9178",
+			"light_vs": "string: #A31515",
+			"hc_black": "string: #CE9178",
+			"dark_modern": "string: #CE9178",
+			"hc_light": "string: #0F4A85",
+			"light_modern": "string: #A31515"
 		}
 	},
 	{
 		"c": "    ",
 		"t": "source.python string.quoted.docstring.raw.multi.python",
 		"r": {
-			"dark_plus": "string.quoted.docstring: #6A9955",
-			"light_plus": "string.quoted.docstring: #008000",
-			"dark_vs": "string.quoted.docstring: #6A9955",
-			"light_vs": "string.quoted.docstring: #008000",
-			"hc_black": "string.quoted.docstring: #7CA668",
-			"dark_modern": "string.quoted.docstring: #6A9955",
-			"hc_light": "string.quoted.docstring: #515151",
-			"light_modern": "string.quoted.docstring: #008000"
+			"dark_plus": "string: #CE9178",
+			"light_plus": "string: #A31515",
+			"dark_vs": "string: #CE9178",
+			"light_vs": "string: #A31515",
+			"hc_black": "string: #CE9178",
+			"dark_modern": "string: #CE9178",
+			"hc_light": "string: #0F4A85",
+			"light_modern": "string: #A31515"
 		}
 	},
 	{
@@ -7493,28 +7493,28 @@
 		"c": "for a in foo(2, b=1,",
 		"t": "source.python string.quoted.docstring.raw.multi.python",
 		"r": {
-			"dark_plus": "string.quoted.docstring: #6A9955",
-			"light_plus": "string.quoted.docstring: #008000",
-			"dark_vs": "string.quoted.docstring: #6A9955",
-			"light_vs": "string.quoted.docstring: #008000",
-			"hc_black": "string.quoted.docstring: #7CA668",
-			"dark_modern": "string.quoted.docstring: #6A9955",
-			"hc_light": "string.quoted.docstring: #515151",
-			"light_modern": "string.quoted.docstring: #008000"
+			"dark_plus": "string: #CE9178",
+			"light_plus": "string: #A31515",
+			"dark_vs": "string: #CE9178",
+			"light_vs": "string: #A31515",
+			"hc_black": "string: #CE9178",
+			"dark_modern": "string: #CE9178",
+			"hc_light": "string: #0F4A85",
+			"light_modern": "string: #A31515"
 		}
 	},
 	{
 		"c": "    ",
 		"t": "source.python string.quoted.docstring.raw.multi.python",
 		"r": {
-			"dark_plus": "string.quoted.docstring: #6A9955",
-			"light_plus": "string.quoted.docstring: #008000",
-			"dark_vs": "string.quoted.docstring: #6A9955",
-			"light_vs": "string.quoted.docstring: #008000",
-			"hc_black": "string.quoted.docstring: #7CA668",
-			"dark_modern": "string.quoted.docstring: #6A9955",
-			"hc_light": "string.quoted.docstring: #515151",
-			"light_modern": "string.quoted.docstring: #008000"
+			"dark_plus": "string: #CE9178",
+			"light_plus": "string: #A31515",
+			"dark_vs": "string: #CE9178",
+			"light_vs": "string: #A31515",
+			"hc_black": "string: #CE9178",
+			"dark_modern": "string: #CE9178",
+			"hc_light": "string: #0F4A85",
+			"light_modern": "string: #A31515"
 		}
 	},
 	{
@@ -7535,28 +7535,28 @@
 		"c": "                c=3):",
 		"t": "source.python string.quoted.docstring.raw.multi.python",
 		"r": {
-			"dark_plus": "string.quoted.docstring: #6A9955",
-			"light_plus": "string.quoted.docstring: #008000",
-			"dark_vs": "string.quoted.docstring: #6A9955",
-			"light_vs": "string.quoted.docstring: #008000",
-			"hc_black": "string.quoted.docstring: #7CA668",
-			"dark_modern": "string.quoted.docstring: #6A9955",
-			"hc_light": "string.quoted.docstring: #515151",
-			"light_modern": "string.quoted.docstring: #008000"
+			"dark_plus": "string: #CE9178",
+			"light_plus": "string: #A31515",
+			"dark_vs": "string: #CE9178",
+			"light_vs": "string: #A31515",
+			"hc_black": "string: #CE9178",
+			"dark_modern": "string: #CE9178",
+			"hc_light": "string: #0F4A85",
+			"light_modern": "string: #A31515"
 		}
 	},
 	{
 		"c": "    ",
 		"t": "source.python string.quoted.docstring.raw.multi.python",
 		"r": {
-			"dark_plus": "string.quoted.docstring: #6A9955",
-			"light_plus": "string.quoted.docstring: #008000",
-			"dark_vs": "string.quoted.docstring: #6A9955",
-			"light_vs": "string.quoted.docstring: #008000",
-			"hc_black": "string.quoted.docstring: #7CA668",
-			"dark_modern": "string.quoted.docstring: #6A9955",
-			"hc_light": "string.quoted.docstring: #515151",
-			"light_modern": "string.quoted.docstring: #008000"
+			"dark_plus": "string: #CE9178",
+			"light_plus": "string: #A31515",
+			"dark_vs": "string: #CE9178",
+			"light_vs": "string: #A31515",
+			"hc_black": "string: #CE9178",
+			"dark_modern": "string: #CE9178",
+			"hc_light": "string: #0F4A85",
+			"light_modern": "string: #A31515"
 		}
 	},
 	{
@@ -7577,56 +7577,56 @@
 		"c": "  print(a)",
 		"t": "source.python string.quoted.docstring.raw.multi.python",
 		"r": {
-			"dark_plus": "string.quoted.docstring: #6A9955",
-			"light_plus": "string.quoted.docstring: #008000",
-			"dark_vs": "string.quoted.docstring: #6A9955",
-			"light_vs": "string.quoted.docstring: #008000",
-			"hc_black": "string.quoted.docstring: #7CA668",
-			"dark_modern": "string.quoted.docstring: #6A9955",
-			"hc_light": "string.quoted.docstring: #515151",
-			"light_modern": "string.quoted.docstring: #008000"
+			"dark_plus": "string: #CE9178",
+			"light_plus": "string: #A31515",
+			"dark_vs": "string: #CE9178",
+			"light_vs": "string: #A31515",
+			"hc_black": "string: #CE9178",
+			"dark_modern": "string: #CE9178",
+			"hc_light": "string: #0F4A85",
+			"light_modern": "string: #A31515"
 		}
 	},
 	{
 		"c": "    0",
 		"t": "source.python string.quoted.docstring.raw.multi.python",
 		"r": {
-			"dark_plus": "string.quoted.docstring: #6A9955",
-			"light_plus": "string.quoted.docstring: #008000",
-			"dark_vs": "string.quoted.docstring: #6A9955",
-			"light_vs": "string.quoted.docstring: #008000",
-			"hc_black": "string.quoted.docstring: #7CA668",
-			"dark_modern": "string.quoted.docstring: #6A9955",
-			"hc_light": "string.quoted.docstring: #515151",
-			"light_modern": "string.quoted.docstring: #008000"
+			"dark_plus": "string: #CE9178",
+			"light_plus": "string: #A31515",
+			"dark_vs": "string: #CE9178",
+			"light_vs": "string: #A31515",
+			"hc_black": "string: #CE9178",
+			"dark_modern": "string: #CE9178",
+			"hc_light": "string: #0F4A85",
+			"light_modern": "string: #A31515"
 		}
 	},
 	{
 		"c": "    1",
 		"t": "source.python string.quoted.docstring.raw.multi.python",
 		"r": {
-			"dark_plus": "string.quoted.docstring: #6A9955",
-			"light_plus": "string.quoted.docstring: #008000",
-			"dark_vs": "string.quoted.docstring: #6A9955",
-			"light_vs": "string.quoted.docstring: #008000",
-			"hc_black": "string.quoted.docstring: #7CA668",
-			"dark_modern": "string.quoted.docstring: #6A9955",
-			"hc_light": "string.quoted.docstring: #515151",
-			"light_modern": "string.quoted.docstring: #008000"
+			"dark_plus": "string: #CE9178",
+			"light_plus": "string: #A31515",
+			"dark_vs": "string: #CE9178",
+			"light_vs": "string: #A31515",
+			"hc_black": "string: #CE9178",
+			"dark_modern": "string: #CE9178",
+			"hc_light": "string: #0F4A85",
+			"light_modern": "string: #A31515"
 		}
 	},
 	{
 		"c": "'''",
 		"t": "source.python string.quoted.docstring.raw.multi.python punctuation.definition.string.end.python",
 		"r": {
-			"dark_plus": "string.quoted.docstring: #6A9955",
-			"light_plus": "string.quoted.docstring: #008000",
-			"dark_vs": "string.quoted.docstring: #6A9955",
-			"light_vs": "string.quoted.docstring: #008000",
-			"hc_black": "string.quoted.docstring: #7CA668",
-			"dark_modern": "string.quoted.docstring: #6A9955",
-			"hc_light": "string.quoted.docstring: #515151",
-			"light_modern": "string.quoted.docstring: #008000"
+			"dark_plus": "string: #CE9178",
+			"light_plus": "string: #A31515",
+			"dark_vs": "string: #CE9178",
+			"light_vs": "string: #A31515",
+			"hc_black": "string: #CE9178",
+			"dark_modern": "string: #CE9178",
+			"hc_light": "string: #0F4A85",
+			"light_modern": "string: #A31515"
 		}
 	}
 ]


### PR DESCRIPTION
This is a temporary fix of #184836 and reverts PR #182162.

Motivation:
- Both the old behavior and the current are WRONG. Neither of them should be preferred in favor of correctness.
- This behavior change is too disruptive to user experience and many people got confused by this sudden change.

Therefore, I'm proposing to revert the change and go back to the old behaviour in the next release. The issue will not be closed by this and we should eventually find a **correct** solution.