### PR TITLE
joh/bright felidae

### DIFF
--- a/src/vs/editor/contrib/suggest/browser/suggestController.ts
+++ b/src/vs/editor/contrib/suggest/browser/suggestController.ts
@@ -379,7 +379,7 @@ export class SuggestController implements IEditorContribution {
 
 			tasks.push(item.resolve(cts.token).then(() => {
 				if (!item.completion.additionalTextEdits || cts.token.isCancellationRequested) {
-					return false;
+					return undefined;
 				}
 				if (position && item.completion.additionalTextEdits.some(edit => Position.isBefore(position!, Range.getStartPosition(edit.range)))) {
 					return false;
@@ -406,10 +406,12 @@ export class SuggestController implements IEditorContribution {
 					providerId: { classification: 'PublicNonPersonalData'; purpose: 'FeatureInsight'; comment: 'Provider of the completions item' };
 					applied: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'If async additional text edits could be applied' };
 				};
-				this._telemetryService.publicLog2<AsyncSuggestEdits, AsyncSuggestEditsClassification>('suggest.asyncAdditionalEdits', {
-					providerId: item.extensionId?.value ?? 'unknown',
-					applied
-				});
+				if (typeof applied === 'boolean') {
+					this._telemetryService.publicLog2<AsyncSuggestEdits, AsyncSuggestEditsClassification>('suggest.asyncAdditionalEdits', {
+						providerId: item.extensionId?.value ?? 'unknown',
+						applied
+					});
+				}
 			}).finally(() => {
 				docListener.dispose();
 				typeListener.dispose();

--- a/src/vs/editor/contrib/suggest/browser/suggestController.ts
+++ b/src/vs/editor/contrib/suggest/browser/suggestController.ts
@@ -399,6 +399,18 @@ export class SuggestController implements IEditorContribution {
 				return true;
 			}).then(applied => {
 				this._logService.trace('[suggest] async resolving of edits DONE (ms, applied?)', sw.elapsed(), applied);
+				type AsyncSuggestEdits = { providerId: string; applied: boolean };
+				type AsyncSuggestEditsClassification = {
+					owner: 'jrieken';
+					comment: 'Information about async additional text edits';
+					providerId: { classification: 'PublicNonPersonalData'; purpose: 'FeatureInsight'; comment: 'Provider of the completions item' };
+					applied: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'If async additional text edits could be applied' };
+				};
+				this._telemetryService.publicLog2<AsyncSuggestEdits, AsyncSuggestEditsClassification>('suggest.asyncAdditionalEdits', {
+					providerId: item.extensionId?.value ?? 'unknown',
+					applied
+				});
+			}).finally(() => {
 				docListener.dispose();
 				typeListener.dispose();
 			}));

--- a/src/vs/editor/contrib/suggest/browser/suggestController.ts
+++ b/src/vs/editor/contrib/suggest/browser/suggestController.ts
@@ -332,6 +332,7 @@ export class SuggestController implements IEditorContribution {
 		// keep item in memory
 		this._memoryService.memorize(model, this.editor.getPosition(), item);
 
+		const isResolved = item.isResolved;
 
 		if (Array.isArray(item.completion.additionalTextEdits)) {
 
@@ -346,7 +347,7 @@ export class SuggestController implements IEditorContribution {
 			);
 			scrollState.restoreRelativeVerticalPositionOfCursor(this.editor);
 
-		} else if (!item.isResolved) {
+		} else if (!isResolved) {
 			// async additional edits
 			const sw = new StopWatch(true);
 			let position: IPosition | undefined;
@@ -467,7 +468,7 @@ export class SuggestController implements IEditorContribution {
 
 		// clear only now - after all tasks are done
 		Promise.all(tasks).finally(() => {
-			this._reportSuggestionAcceptedTelemetry(item, model, event);
+			this._reportSuggestionAcceptedTelemetry(item, model, event, isResolved);
 
 			this.model.clear();
 			cts.dispose();
@@ -475,12 +476,12 @@ export class SuggestController implements IEditorContribution {
 	}
 
 	private _telemetryGate: number = 0;
-	private _reportSuggestionAcceptedTelemetry(item: CompletionItem, model: ITextModel, acceptedSuggestion: ISelectedSuggestion) {
+	private _reportSuggestionAcceptedTelemetry(item: CompletionItem, model: ITextModel, acceptedSuggestion: ISelectedSuggestion, itemResolved: boolean) {
 		if (this._telemetryGate++ % 100 !== 0) {
 			return;
 		}
 
-		type AcceptedSuggestion = { providerId: string; fileExtension: string; languageId: string; basenameHash: string; kind: number };
+		type AcceptedSuggestion = { providerId: string; fileExtension: string; languageId: string; basenameHash: string; kind: number; itemResolved: boolean };
 		type AcceptedSuggestionClassification = {
 			owner: 'jrieken';
 			comment: 'Information accepting completion items';
@@ -488,7 +489,8 @@ export class SuggestController implements IEditorContribution {
 			basenameHash: { classification: 'PublicNonPersonalData'; purpose: 'FeatureInsight'; comment: 'Hash of the basename of the file into which the completion was inserted' };
 			fileExtension: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'File extension of the file into which the completion was inserted' };
 			languageId: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Language type of the file into which the completion was inserted' };
-			kind: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The completion item kind' };
+			kind: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'The completion item kind' };
+			itemResolved: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; isMeasurement: true; comment: 'If the item was inserted before resolving was done' };
 		};
 		// _debugDisplayName looks like `vscode.css-language-features(/-:)`, where the last bit is the trigger chars
 		// normalize it to just the extension ID and lowercase
@@ -499,6 +501,7 @@ export class SuggestController implements IEditorContribution {
 			basenameHash: hash(basename(model.uri)).toString(16),
 			languageId: model.getLanguageId(),
 			fileExtension: extname(model.uri),
+			itemResolved
 		});
 	}
 

--- a/src/vs/workbench/api/common/extHostLanguageFeatures.ts
+++ b/src/vs/workbench/api/common/extHostLanguageFeatures.ts
@@ -1040,12 +1040,20 @@ class CompletionsAdapter {
 			additionalTextEdits: resolvedItem.additionalTextEdits
 		};
 
-		if (item.insertText !== resolvedItem.insertText) {
+		if (CompletionsAdapter._insertTextIdent(item.insertText) !== CompletionsAdapter._insertTextIdent(resolvedItem.insertText)) {
 			this._apiDeprecation.report('CompletionItem.insertText', this._extension, 'extension MAY NOT change \'insertText\' of a CompletionItem during resolve');
 			enforcedResolvedItem.insertText = resolvedItem.insertText;
 		}
 
 		return this._convertCompletionItem(enforcedResolvedItem, id);
+	}
+
+	private static _insertTextIdent(insertText: string | vscode.SnippetString | undefined) {
+		switch (typeof insertText) {
+			case 'string': return insertText;
+			case 'undefined': return undefined;
+			case 'object': return insertText.value;
+		}
 	}
 
 	releaseCompletionItems(id: number): any {


### PR DESCRIPTION
- fixed flawed API deprecation warning
- add telemetry to know how often an item is inserted before resolve is done
- add telemetry to measure how successful async additional edits can be applied
- refine async edits telemetry
