### PR TITLE
Allow for markdown in color documentation

### DIFF
--- a/src/vs/editor/contrib/suggest/browser/suggestWidgetRenderer.ts
+++ b/src/vs/editor/contrib/suggest/browser/suggestWidgetRenderer.ts
@@ -45,9 +45,10 @@ const _completionItemColor = new class ColorExtractor {
 			out[0] = item.completion.detail;
 			return true;
 		}
-		if (typeof item.completion.documentation === 'string') {
-			const match = ColorExtractor._regexRelaxed.exec(item.completion.documentation);
-			if (match && (match.index === 0 || match.index + match[0].length === item.completion.documentation.length)) {
+		const documentation = typeof item.completion.documentation === 'string' ? item.completion.documentation : item.completion.documentation?.value;
+		if (typeof documentation === 'string') {
+			const match = ColorExtractor._regexRelaxed.exec(documentation);
+			if (match && (match.index === 0 || match.index + match[0].length === documentation.length)) {
 				out[0] = match[0];
 				return true;
 			}


### PR DESCRIPTION
Extends the suggestion widget renderer for `CompletionKind.Color` to add support for `MarkupContent`, in addition to the existing `string`. This way completion items can be documented with Markdown, while keeping the color preview.

Fixes #185055

### Testing

I looked around for existing unit tests I might extend, but came up short. As for manual testing, you'd need an extension that provides color suggestions with markdown. 

If you feel comfortable installing from VSIX, I've attached a prerelease build of my extension where I do this. 

[some-sass-2.13.2-preview.zip](https://github.com/microsoft/vscode/files/11739051/some-sass-2.13.2-preview.zip)

- Branch, in case you'd like to build from source: https://github.com/wkillerud/vscode-scss/tree/june-with-markdown
- Diff from what's published on Marketplace: https://github.com/wkillerud/vscode-scss/compare/main...wkillerud:vscode-scss:june-with-markdown?expand=1

Once installed, create `_colors.scss` with a documented color variable, such as this one:

```scss
/* _colors.scss */

/// @type Color
/// @deprecated No longer in use for new features
$color-info: #000afa;
```

Create another file `main.scss` and use it:

```scss
/* main.scss */
@use "./colors" as var;

.a {
    color: var.$color-
}
```

You should see a suggestion similar to this, with `<hr>` being rendered instead of plaintext `____`:

![](https://github.com/microsoft/vscode/assets/1223410/2f507511-7bb4-4e8b-b0f0-18ae85a86a7e)


<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
