### PR TITLE
Warning message doesn't show up when code-insiders --status is run while no instances are open

### DIFF
--- a/src/vs/code/electron-main/main.ts
+++ b/src/vs/code/electron-main/main.ts
@@ -381,9 +381,6 @@ class CodeMain {
 		}
 
 		// Print --status usage info
-		// Note: intentionally using `console.log` here so that we
-		// ensure this message ends up in stdout from the calling
-		// terminal.
 		if (environmentMainService.args.status) {
 			console.log(localize('statusWarning', "Warning: The --status argument can only be used if {0} is already running. Please run it again after {0} has started.", productService.nameShort));
 

--- a/src/vs/code/electron-main/main.ts
+++ b/src/vs/code/electron-main/main.ts
@@ -381,8 +381,11 @@ class CodeMain {
 		}
 
 		// Print --status usage info
+		// Note: intentionally using `console.log` here so that we
+		// ensure this message ends up in stdout from the calling
+		// terminal.
 		if (environmentMainService.args.status) {
-			logService.warn(localize('statusWarning', "Warning: The --status argument can only be used if {0} is already running. Please run it again after {0} has started.", productService.nameShort));
+			console.log(localize('statusWarning', "Warning: The --status argument can only be used if {0} is already running. Please run it again after {0} has started.", productService.nameShort));
 
 			throw new ExpectedError('Terminating...');
 		}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
