### PR TITLE
prevent screen reader from reading a user's chat request on enter

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
@@ -32,6 +32,7 @@ import { IChatReplyFollowup } from 'vs/workbench/contrib/chat/common/chatService
 import { IChatWidgetHistoryService } from 'vs/workbench/contrib/chat/common/chatWidgetHistoryService';
 import { AccessibilityVerbositySettingId } from 'vs/workbench/contrib/accessibility/browser/accessibilityContribution';
 import { IAccessibilityService } from 'vs/platform/accessibility/common/accessibility';
+import { isWindows } from 'vs/base/common/platform';
 
 const $ = dom.$;
 
@@ -156,11 +157,12 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		if (!domNode) {
 			return;
 		}
-		if (this.accessibilityService.isScreenReaderOptimized()) {
+		const handleDom = this.accessibilityService.isScreenReaderOptimized() && !isWindows;
+		if (handleDom) {
 			this._inputEditorElement.removeChild(domNode);
 		}
 		this._inputEditor.setValue('');
-		if (this.accessibilityService.isScreenReaderOptimized()) {
+		if (handleDom) {
 			this._inputEditorElement.appendChild(domNode);
 		}
 		this._inputEditor.focus();

--- a/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
@@ -157,6 +157,9 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		if (!domNode) {
 			return;
 		}
+		// Remove the input editor from the DOM temporarily to avoid the screen reader
+		// from reading the cleared text (the request) to the user. On Windows, we don't need to do this
+		// and it could cause issues.
 		const handleDom = this.accessibilityService.isScreenReaderOptimized() && !isWindows;
 		if (handleDom) {
 			this._inputEditorElement.removeChild(domNode);

--- a/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
@@ -31,6 +31,7 @@ import { CONTEXT_CHAT_INPUT_HAS_TEXT, CONTEXT_IN_CHAT_INPUT } from 'vs/workbench
 import { IChatReplyFollowup } from 'vs/workbench/contrib/chat/common/chatService';
 import { IChatWidgetHistoryService } from 'vs/workbench/contrib/chat/common/chatWidgetHistoryService';
 import { AccessibilityVerbositySettingId } from 'vs/workbench/contrib/accessibility/browser/accessibilityContribution';
+import { IAccessibilityService } from 'vs/platform/accessibility/common/accessibility';
 
 const $ = dom.$;
 
@@ -80,7 +81,8 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
 		@IContextKeyService private readonly contextKeyService: IContextKeyService,
 		@IConfigurationService private readonly configurationService: IConfigurationService,
-		@IKeybindingService private readonly keybindingService: IKeybindingService
+		@IKeybindingService private readonly keybindingService: IKeybindingService,
+		@IAccessibilityService private readonly accessibilityService: IAccessibilityService
 	) {
 		super();
 
@@ -154,9 +156,13 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		if (!domNode) {
 			return;
 		}
-		this._inputEditorElement.removeChild(domNode);
+		if (this.accessibilityService.isScreenReaderOptimized()) {
+			this._inputEditorElement.removeChild(domNode);
+		}
 		this._inputEditor.setValue('');
-		this._inputEditorElement.appendChild(domNode);
+		if (this.accessibilityService.isScreenReaderOptimized()) {
+			this._inputEditorElement.appendChild(domNode);
+		}
 		this._inputEditor.focus();
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
@@ -59,6 +59,8 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 	private followupsDisposables = this._register(new DisposableStore());
 
 	private _inputEditor!: CodeEditorWidget;
+	private _inputEditorElement!: HTMLElement;
+
 	public get inputEditor() {
 		return this._inputEditor;
 	}
@@ -148,8 +150,14 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 			this.history.add(editorValue);
 		}
 
-		this._inputEditor.focus();
+		const domNode = this._inputEditor.getDomNode();
+		if (!domNode) {
+			return;
+		}
+		this._inputEditorElement.removeChild(domNode);
 		this._inputEditor.setValue('');
+		this._inputEditorElement.appendChild(domNode);
+		this._inputEditor.focus();
 	}
 
 	render(container: HTMLElement, initialValue: string, widget: IChatWidget) {
@@ -181,8 +189,8 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		options.suggest = { showIcons: false };
 		options.scrollbar = { ...(options.scrollbar ?? {}), vertical: 'hidden' };
 
-		const inputEditorElement = dom.append(inputContainer, $('.interactive-input-editor'));
-		this._inputEditor = this._register(scopedInstantiationService.createInstance(CodeEditorWidget, inputEditorElement, options, getSimpleCodeEditorWidgetOptions()));
+		this._inputEditorElement = dom.append(inputContainer, $('.interactive-input-editor'));
+		this._inputEditor = this._register(scopedInstantiationService.createInstance(CodeEditorWidget, this._inputEditorElement, options, getSimpleCodeEditorWidgetOptions()));
 
 		this._register(this._inputEditor.onDidChangeModelContent(() => {
 			const currentHeight = Math.min(this._inputEditor.getContentHeight(), INPUT_EDITOR_MAX_HEIGHT);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
fixes https://github.com/microsoft/vscode-internalbacklog/issues/4181

cc @jooyoungseo, @rperez030

Since a user has just typed their input, we don't want a screen reader to read it when enter is pressed. This is also important to fix as it blocks the progress audio cue that we will have as an option. 

Unblocks https://github.com/microsoft/vscode-copilot/issues/197