### PR TITLE
Add configuration to show all test messages.

### DIFF
--- a/src/vs/workbench/contrib/testing/browser/testingDecorations.ts
+++ b/src/vs/workbench/contrib/testing/browser/testingDecorations.ts
@@ -318,7 +318,7 @@ export class TestingDecorationService extends Disposable implements ITestingDeco
 				}
 			}
 
-			const messageLines = new Map</* line number */ number, /* last test message */ ITestMessage>();
+			const messageLines = new Set<number>();
 			if (getTestingConfiguration(this.configurationService, TestingConfigKeys.ShowAllMessages)) {
 				this.results.results.forEach(lastResult => this.applyDecorationsFromResult(lastResult, messageLines, uriStr, lastDecorations, model, newDecorations));
 			} else {
@@ -352,7 +352,7 @@ export class TestingDecorationService extends Disposable implements ITestingDeco
 		return newDecorations || lastDecorations;
 	}
 
-	private applyDecorationsFromResult(lastResult: ITestResult, messageLines: Map<Number, ITestMessage>, uriStr: string, lastDecorations: CachedDecorations, model: ITextModel, newDecorations: CachedDecorations) {
+	private applyDecorationsFromResult(lastResult: ITestResult, messageLines: Set<Number>, uriStr: string, lastDecorations: CachedDecorations, model: ITextModel, newDecorations: CachedDecorations) {
 		if (this.testService.showInlineOutput.value && lastResult instanceof LiveTestResult) {
 			for (const task of lastResult.tasks) {
 				for (const m of task.otherMessages) {
@@ -385,7 +385,7 @@ export class TestingDecorationService extends Disposable implements ITestingDeco
 							}), model);
 
 							newDecorations.addMessage(decoration);
-							messageLines.set(line, decoration.testMessage);
+							messageLines.add(line);
 						}
 					}
 				}

--- a/src/vs/workbench/contrib/testing/browser/testingDecorations.ts
+++ b/src/vs/workbench/contrib/testing/browser/testingDecorations.ts
@@ -44,7 +44,7 @@ import { DefaultGutterClickAction, TestingConfigKeys, getTestingConfiguration } 
 import { Testing, labelForTestInState } from 'vs/workbench/contrib/testing/common/constants';
 import { TestId } from 'vs/workbench/contrib/testing/common/testId';
 import { ITestProfileService } from 'vs/workbench/contrib/testing/common/testProfileService';
-import { LiveTestResult } from 'vs/workbench/contrib/testing/common/testResult';
+import { ITestResult, LiveTestResult } from 'vs/workbench/contrib/testing/common/testResult';
 import { ITestResultService } from 'vs/workbench/contrib/testing/common/testResultService';
 import { ITestService, getContextForTestItem, testsInFile } from 'vs/workbench/contrib/testing/common/testService';
 import { IRichLocation, ITestMessage, ITestRunProfile, IncrementalTestCollectionItem, InternalTestItem, TestDiffOpType, TestMessageType, TestResultItem, TestResultState, TestRunProfileBitset } from 'vs/workbench/contrib/testing/common/testTypes';
@@ -318,47 +318,11 @@ export class TestingDecorationService extends Disposable implements ITestingDeco
 				}
 			}
 
-			const lastResult = this.results.results[0];
-			if (this.testService.showInlineOutput.value && lastResult instanceof LiveTestResult) {
-				for (const task of lastResult.tasks) {
-					for (const m of task.otherMessages) {
-						if (!this.invalidatedMessages.has(m) && m.location?.uri.toString() === uriStr) {
-							const decoration = lastDecorations.getMessage(m) || this.instantiationService.createInstance(TestMessageDecoration, m, undefined, model);
-							newDecorations.addMessage(decoration);
-						}
-					}
-				}
-
-				const messageLines = new Map</* line number */ number, /* last test message */ ITestMessage>();
-				for (const test of lastResult.tests) {
-					for (let taskId = 0; taskId < test.tasks.length; taskId++) {
-						const state = test.tasks[taskId];
-						for (let i = 0; i < state.messages.length; i++) {
-							const m = state.messages[i];
-							if (this.invalidatedMessages.has(m) || m.location?.uri.toString() !== uriStr) {
-								continue;
-							}
-
-							// Only add one message per line number. Overlapping messages
-							// don't appear well, and the peek will show all of them (#134129)
-							const line = m.location.range.startLineNumber;
-							if (messageLines.has(line)) {
-								newDecorations.removeMessage(messageLines.get(line)!);
-							}
-
-							const decoration = lastDecorations.getMessage(m) || this.instantiationService.createInstance(TestMessageDecoration, m, buildTestUri({
-								type: TestUriType.ResultActualOutput,
-								messageIndex: i,
-								taskIndex: taskId,
-								resultId: lastResult.id,
-								testExtId: test.item.extId,
-							}), model);
-
-							newDecorations.addMessage(decoration);
-							messageLines.set(line, decoration.testMessage);
-						}
-					}
-				}
+			const messageLines = new Map</* line number */ number, /* last test message */ ITestMessage>();
+			if (getTestingConfiguration(this.configurationService, TestingConfigKeys.ShowAllMessages)) {
+				this.results.results.forEach(lastResult => this.applyDecorationsFromResult(lastResult, messageLines, uriStr, lastDecorations, model, newDecorations));
+			} else {
+				this.applyDecorationsFromResult(this.results.results[0], messageLines, uriStr, lastDecorations, model, newDecorations);
 			}
 
 			const saveFromRemoval = new Set<string>();
@@ -386,6 +350,47 @@ export class TestingDecorationService extends Disposable implements ITestingDeco
 		});
 
 		return newDecorations || lastDecorations;
+	}
+
+	private applyDecorationsFromResult(lastResult: ITestResult, messageLines: Map<Number, ITestMessage>, uriStr: string, lastDecorations: CachedDecorations, model: ITextModel, newDecorations: CachedDecorations) {
+		if (this.testService.showInlineOutput.value && lastResult instanceof LiveTestResult) {
+			for (const task of lastResult.tasks) {
+				for (const m of task.otherMessages) {
+					if (!this.invalidatedMessages.has(m) && m.location?.uri.toString() === uriStr) {
+						const decoration = lastDecorations.getMessage(m) || this.instantiationService.createInstance(TestMessageDecoration, m, undefined, model);
+						newDecorations.addMessage(decoration);
+					}
+				}
+			}
+
+			for (const test of lastResult.tests) {
+				for (let taskId = 0; taskId < test.tasks.length; taskId++) {
+					const state = test.tasks[taskId];
+					for (let i = 0; i < state.messages.length; i++) {
+						const m = state.messages[i];
+						if (this.invalidatedMessages.has(m) || m.location?.uri.toString() !== uriStr) {
+							continue;
+						}
+
+						// Only add one message per line number. Overlapping messages
+						// don't appear well, and the peek will show all of them (#134129)
+						const line = m.location.range.startLineNumber;
+						if (!messageLines.has(line)) {
+							const decoration = lastDecorations.getMessage(m) || this.instantiationService.createInstance(TestMessageDecoration, m, buildTestUri({
+								type: TestUriType.ResultActualOutput,
+								messageIndex: i,
+								taskIndex: taskId,
+								resultId: lastResult.id,
+								testExtId: test.item.extId,
+							}), model);
+
+							newDecorations.addMessage(decoration);
+							messageLines.set(line, decoration.testMessage);
+						}
+					}
+				}
+			}
+		}
 	}
 }
 

--- a/src/vs/workbench/contrib/testing/common/configuration.ts
+++ b/src/vs/workbench/contrib/testing/common/configuration.ts
@@ -17,7 +17,8 @@ export const enum TestingConfigKeys {
 	GutterEnabled = 'testing.gutterEnabled',
 	SaveBeforeTest = 'testing.saveBeforeTest',
 	AlwaysRevealTestOnStateChange = 'testing.alwaysRevealTestOnStateChange',
-	CountBadge = 'testing.countBadge'
+	CountBadge = 'testing.countBadge',
+	ShowAllMessages = 'testing.showAllMessages',
 }
 
 export const enum AutoOpenTesting {
@@ -70,6 +71,11 @@ export const testingConfiguration: IConfigurationNode = {
 				localize('testing.automaticallyOpenPeekView.failureInVisibleDocument', "Open automatically when a test fails in a visible document."),
 				localize('testing.automaticallyOpenPeekView.never', "Never automatically open."),
 			],
+		},
+		[TestingConfigKeys.ShowAllMessages]: {
+			description: localize('testing.showAllMessages', "Controls whether to show messages from all test runs."),
+			type: 'boolean',
+			default: true,
 		},
 		[TestingConfigKeys.AutoOpenPeekViewDuringContinuousRun]: {
 			description: localize('testing.automaticallyOpenPeekViewDuringContinuousRun', "Controls whether to automatically open the Peek view during continuous run mode."),
@@ -154,6 +160,7 @@ export interface ITestingConfiguration {
 	[TestingConfigKeys.SaveBeforeTest]: boolean;
 	[TestingConfigKeys.OpenTesting]: AutoOpenTesting;
 	[TestingConfigKeys.AlwaysRevealTestOnStateChange]: boolean;
+	[TestingConfigKeys.ShowAllMessages]: boolean;
 }
 
 export const getTestingConfiguration = <K extends TestingConfigKeys>(config: IConfigurationService, key: K) => config.getValue<ITestingConfiguration[K]>(key);


### PR DESCRIPTION
Introduce `testing.showAllMessages` configuration, which defaults to true. When false, only the first message is shown, and the rest are ignored. When true, the most recent message for each line is shown from all past test runs.

Fixes #184826.

cc @connor4312 