### PR TITLE
joh/silly swallow

### DIFF
--- a/src/vs/base/browser/ui/button/button.css
+++ b/src/vs/base/browser/ui/button/button.css
@@ -25,6 +25,25 @@
 	text-decoration: none !important;
 }
 
+.monaco-button {
+	color: var(--vscode-button-foreground);
+	background-color: var(--vscode-button-background);
+}
+
+.monaco-button:hover {
+	background-color: var(--vscode-button-hoverBackground);
+}
+
+.monaco-button.secondary {
+	color: var(--vscode-button-secondaryForeground);
+	background-color: var(--vscode-button-secondaryBackground);
+}
+
+.monaco-button.secondary:hover {
+	background-color: var(--vscode-button-secondaryHoverBackground);
+}
+
+
 .monaco-button.disabled:focus,
 .monaco-button.disabled {
 	opacity: 0.4 !important;
@@ -90,11 +109,19 @@
 .monaco-button-dropdown .monaco-button-dropdown-separator {
 	padding: 4px 0;
 	cursor: default;
+	background-color: var(--vscode-button-background);
+	border-top: 1px solid var(--vscode-button-border);
+	border-bottom: 1px solid var(--vscode-button-border);
+}
+
+.monaco-button.secondary + .monaco-button-dropdown-separator {
+	background-color: var(--vscode-button-secondaryBackground);
 }
 
 .monaco-button-dropdown .monaco-button-dropdown-separator > div {
 	height: 100%;
 	width: 1px;
+	background-color: var(--vscode-button-separator);
 }
 
 .monaco-button-dropdown > .monaco-button.monaco-dropdown-button {

--- a/src/vs/platform/actions/browser/buttonbar.ts
+++ b/src/vs/platform/actions/browser/buttonbar.ts
@@ -1,0 +1,121 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { ButtonBar, IButton } from 'vs/base/browser/ui/button/button';
+import { ActionRunner, IAction, WorkbenchActionExecutedClassification, WorkbenchActionExecutedEvent } from 'vs/base/common/actions';
+import { Emitter, Event } from 'vs/base/common/event';
+import { DisposableStore } from 'vs/base/common/lifecycle';
+import { ThemeIcon } from 'vs/base/common/themables';
+import { localize } from 'vs/nls';
+import { MenuId, IMenuService, SubmenuItemAction, MenuItemAction } from 'vs/platform/actions/common/actions';
+import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
+import { IContextMenuService } from 'vs/platform/contextview/browser/contextView';
+import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
+import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
+
+export type IButtonConfigProvider = (action: IAction) => {
+	showIcon?: boolean;
+	showLabel?: boolean;
+} | undefined;
+
+export interface IMenuWorkbenchButtonBarOptions {
+	telemetrySource?: string;
+	buttonConfigProvider?: IButtonConfigProvider;
+}
+
+export class MenuWorkbenchButtonBar extends ButtonBar {
+
+	private readonly _store = new DisposableStore();
+
+	private readonly _onDidChangeMenuItems = new Emitter<this>();
+	readonly onDidChangeMenuItems: Event<this> = this._onDidChangeMenuItems.event;
+
+	constructor(
+		container: HTMLElement,
+		menuId: MenuId,
+		options: IMenuWorkbenchButtonBarOptions | undefined,
+		@IMenuService menuService: IMenuService,
+		@IContextKeyService contextKeyService: IContextKeyService,
+		@IContextMenuService contextMenuService: IContextMenuService,
+		@IKeybindingService keybindingService: IKeybindingService,
+		@ITelemetryService telemetryService: ITelemetryService,
+	) {
+		super(container);
+
+		const menu = menuService.createMenu(menuId, contextKeyService);
+		this._store.add(menu);
+
+		const actionRunner = this._store.add(new ActionRunner());
+		if (options?.telemetrySource) {
+			actionRunner.onDidRun(e => {
+				telemetryService.publicLog2<WorkbenchActionExecutedEvent, WorkbenchActionExecutedClassification>(
+					'workbenchActionExecuted',
+					{ id: e.action.id, from: options.telemetrySource! }
+				);
+			}, this._store);
+		}
+
+		const conifgProvider: IButtonConfigProvider = options?.buttonConfigProvider ?? (() => ({ showLabel: true }));
+
+		const update = () => {
+
+			this.clear();
+
+			const actions = menu
+				.getActions({ renderShortTitle: true })
+				.flatMap(entry => entry[1]);
+
+			for (let i = 0; i < actions.length; i++) {
+				const secondary = i > 0;
+				const actionOrSubmenu = actions[i];
+				let action: MenuItemAction | SubmenuItemAction;
+				let btn: IButton;
+
+				if (actionOrSubmenu instanceof SubmenuItemAction && actionOrSubmenu.actions.length > 0) {
+					const [first, ...rest] = actionOrSubmenu.actions;
+					action = <MenuItemAction>first;
+					btn = this.addButtonWithDropdown({
+						secondary,
+						actionRunner,
+						actions: rest,
+						contextMenuProvider: contextMenuService,
+					});
+				} else {
+					action = actionOrSubmenu;
+					btn = this.addButton({ secondary });
+				}
+
+				btn.enabled = action.enabled;
+				if (conifgProvider(action)?.showLabel ?? true) {
+					btn.label = action.label;
+				} else {
+					btn.element.classList.add('monaco-text-button');
+				}
+				if (conifgProvider(action)?.showIcon && ThemeIcon.isThemeIcon(action.item.icon)) {
+					btn.icon = action.item.icon;
+				}
+				const kb = keybindingService.lookupKeybinding(action.id);
+				if (kb) {
+					btn.element.title = localize('labelWithKeybinding', "{0} ({1})", action.label, kb.getLabel());
+				} else {
+					btn.element.title = action.label;
+
+				}
+				btn.onDidClick(async () => {
+					actionRunner.run(action);
+				});
+			}
+			this._onDidChangeMenuItems.fire(this);
+		};
+		this._store.add(menu.onDidChange(update));
+		update();
+	}
+
+	override dispose() {
+		this._onDidChangeMenuItems.dispose();
+		this._store.dispose();
+		super.dispose();
+	}
+}

--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChat.css
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChat.css
@@ -199,6 +199,10 @@
 	padding: 0 4px;
 }
 
+.monaco-editor .inline-chat .status .actions .monaco-text-button {
+	padding: 2px 4px
+}
+
 .monaco-editor .inline-chat .status .monaco-toolbar .action-item {
 	padding: 0 2px;
 }

--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChat.css
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChat.css
@@ -199,6 +199,14 @@
 	padding: 0 4px;
 }
 
+.monaco-editor .inline-chat .status .actions > .monaco-button.codicon {
+	display: flex;
+}
+
+.monaco-editor .inline-chat .status .actions > .monaco-button.codicon::before {
+	align-self: center;
+}
+
 .monaco-editor .inline-chat .status .actions .monaco-text-button {
 	padding: 2px 4px
 }

--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChat.css
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChat.css
@@ -134,6 +134,7 @@
 	padding-left: 10px;
 	padding-right: 4px;
 	margin-left: auto;
+	align-self: center;
 }
 
 .monaco-editor .inline-chat .markdownMessage {
@@ -183,28 +184,32 @@
 	color: var(--vscode-editorWarning-foreground);
 }
 
+.monaco-editor .inline-chat .status .actions  {
+	display: flex;
+}
+
+.monaco-editor .inline-chat .status .actions > .monaco-button,
+.monaco-editor .inline-chat .status .actions > .monaco-button-dropdown {
+	margin-right: 6px;
+}
+
+.monaco-editor .inline-chat .status .actions > .monaco-button-dropdown > .monaco-dropdown-button {
+	display: flex;
+	align-items: center;
+	padding: 0 4px;
+}
+
 .monaco-editor .inline-chat .status .monaco-toolbar .action-item {
 	padding: 0 2px;
 }
 
+/* TODO@jrieken not needed? */
 .monaco-editor .inline-chat .status .monaco-toolbar .action-label.checked {
 	color: var(--vscode-inputOption-activeForeground);
 	background-color: var(--vscode-inputOption-activeBackground);
 	outline: 1px solid var(--vscode-inputOption-activeBorder);
 }
 
-.monaco-editor .inline-chat .status .monaco-toolbar .action-item.button-item .action-label {
-	color: var(--vscode-button-foreground);
-	background-color: var(--vscode-button-background);
-	border-radius: 2px;
-	padding: 4px 6px;
-	line-height: 18px;
-}
-
-.monaco-editor .inline-chat .status .monaco-toolbar .action-item.button-item .action-label>.codicon {
-	color: unset;
-	font-size: 14px;
-}
 
 /* preview */
 

--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatActions.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatActions.ts
@@ -10,7 +10,7 @@ import { EditorAction2 } from 'vs/editor/browser/editorExtensions';
 import { EmbeddedCodeEditorWidget, EmbeddedDiffEditorWidget } from 'vs/editor/browser/widget/embeddedCodeEditorWidget';
 import { EditorContextKeys } from 'vs/editor/common/editorContextKeys';
 import { InlineChatController, InlineChatRunOptions } from 'vs/workbench/contrib/inlineChat/browser/inlineChatController';
-import { CTX_INLINE_CHAT_FOCUSED, CTX_INLINE_CHAT_HAS_ACTIVE_REQUEST, CTX_INLINE_CHAT_HAS_PROVIDER, CTX_INLINE_CHAT_INNER_CURSOR_FIRST, CTX_INLINE_CHAT_INNER_CURSOR_LAST, CTX_INLINE_CHAT_EMPTY, CTX_INLINE_CHAT_OUTER_CURSOR_POSITION, CTX_INLINE_CHAT_VISIBLE, MENU_INLINE_CHAT_WIDGET, MENU_INLINE_CHAT_WIDGET_DISCARD, MENU_INLINE_CHAT_WIDGET_STATUS, CTX_INLINE_CHAT_LAST_FEEDBACK, CTX_INLINE_CHAT_SHOWING_DIFF, CTX_INLINE_CHAT_EDIT_MODE, EditMode, CTX_INLINE_CHAT_LAST_RESPONSE_TYPE, MENU_INLINE_CHAT_WIDGET_MARKDOWN_MESSAGE, CTX_INLINE_CHAT_MESSAGE_CROP_STATE, CTX_INLINE_CHAT_DOCUMENT_CHANGED, CTX_INLINE_CHAT_DID_EDIT, CTX_INLINE_CHAT_HAS_STASHED_SESSION, MENU_INLINE_CHAT_WIDGET_FEEDBACK, ACTION_ACCEPT_CHANGES } from 'vs/workbench/contrib/inlineChat/common/inlineChat';
+import { CTX_INLINE_CHAT_FOCUSED, CTX_INLINE_CHAT_HAS_ACTIVE_REQUEST, CTX_INLINE_CHAT_HAS_PROVIDER, CTX_INLINE_CHAT_INNER_CURSOR_FIRST, CTX_INLINE_CHAT_INNER_CURSOR_LAST, CTX_INLINE_CHAT_EMPTY, CTX_INLINE_CHAT_OUTER_CURSOR_POSITION, CTX_INLINE_CHAT_VISIBLE, MENU_INLINE_CHAT_WIDGET, MENU_INLINE_CHAT_WIDGET_DISCARD, MENU_INLINE_CHAT_WIDGET_STATUS, CTX_INLINE_CHAT_LAST_FEEDBACK, CTX_INLINE_CHAT_SHOWING_DIFF, CTX_INLINE_CHAT_EDIT_MODE, EditMode, CTX_INLINE_CHAT_LAST_RESPONSE_TYPE, MENU_INLINE_CHAT_WIDGET_MARKDOWN_MESSAGE, CTX_INLINE_CHAT_MESSAGE_CROP_STATE, CTX_INLINE_CHAT_DOCUMENT_CHANGED, CTX_INLINE_CHAT_DID_EDIT, CTX_INLINE_CHAT_HAS_STASHED_SESSION, MENU_INLINE_CHAT_WIDGET_FEEDBACK, ACTION_ACCEPT_CHANGES, ACTION_REGENERATE_RESPONSE } from 'vs/workbench/contrib/inlineChat/common/inlineChat';
 import { localize } from 'vs/nls';
 import { IAction2Options, MenuRegistry } from 'vs/platform/actions/common/actions';
 import { IClipboardService } from 'vs/platform/clipboard/common/clipboardService';
@@ -163,14 +163,15 @@ export class ReRunRequestAction extends AbstractInlineChatAction {
 
 	constructor() {
 		super({
-			id: 'inlineChat.regenerate',
+			id: ACTION_REGENERATE_RESPONSE,
 			title: localize('rerun', 'Regenerate Response'),
+			shortTitle: localize('rerunShort', 'Regenerate'),
 			icon: Codicon.refresh,
 			precondition: ContextKeyExpr.and(CTX_INLINE_CHAT_VISIBLE, CTX_INLINE_CHAT_EMPTY.negate(), CTX_INLINE_CHAT_LAST_RESPONSE_TYPE),
 			menu: {
 				id: MENU_INLINE_CHAT_WIDGET_STATUS,
-				group: '0_main',
-				order: 1,
+				group: '2_feedback',
+				order: 3,
 			}
 		});
 	}

--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatActions.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatActions.ts
@@ -169,7 +169,7 @@ export class ReRunRequestAction extends AbstractInlineChatAction {
 			icon: Codicon.refresh,
 			precondition: ContextKeyExpr.and(CTX_INLINE_CHAT_VISIBLE, CTX_INLINE_CHAT_EMPTY.negate(), CTX_INLINE_CHAT_LAST_RESPONSE_TYPE),
 			menu: {
-				id: MENU_INLINE_CHAT_WIDGET_FEEDBACK,
+				id: MENU_INLINE_CHAT_WIDGET_STATUS,
 				group: '2_feedback',
 				order: 3,
 			}

--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatActions.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatActions.ts
@@ -169,7 +169,7 @@ export class ReRunRequestAction extends AbstractInlineChatAction {
 			icon: Codicon.refresh,
 			precondition: ContextKeyExpr.and(CTX_INLINE_CHAT_VISIBLE, CTX_INLINE_CHAT_EMPTY.negate(), CTX_INLINE_CHAT_LAST_RESPONSE_TYPE),
 			menu: {
-				id: MENU_INLINE_CHAT_WIDGET_STATUS,
+				id: MENU_INLINE_CHAT_WIDGET_FEEDBACK,
 				group: '2_feedback',
 				order: 3,
 			}

--- a/src/vs/workbench/contrib/inlineChat/common/inlineChat.ts
+++ b/src/vs/workbench/contrib/inlineChat/common/inlineChat.ts
@@ -122,6 +122,7 @@ export const CTX_INLINE_CHAT_EDIT_MODE = new RawContextKey<EditMode>('config.inl
 // --- (select) action identifier
 
 export const ACTION_ACCEPT_CHANGES = 'interactive.acceptChanges';
+export const ACTION_REGENERATE_RESPONSE = 'inlineChat.regenerate';
 
 // --- menus
 


### PR DESCRIPTION
- add button default styles via theme variables, remove buttons on dispose, allow to clear buttonbar
- use button bar for accept, discard, and regen
- tweak padding of btns
- move regenerate into RHS menu (for now)
- extract `MenuWorkbenchButtonBar` as a thing, use for main buttons in inline chat
