### PR TITLE
Improve pty host diagnostics and introduce hidden simulated latency settings

### DIFF
--- a/src/vs/code/electron-main/app.ts
+++ b/src/vs/code/electron-main/app.ts
@@ -935,7 +935,7 @@ export class CodeApplication extends Disposable {
 			graceTime: LocalReconnectConstants.GraceTime,
 			shortGraceTime: LocalReconnectConstants.ShortGraceTime,
 			scrollback: this.configurationService.getValue<number>(TerminalSettingId.PersistentSessionScrollback) ?? 100
-		}, this.environmentMainService, this.lifecycleMainService, this.logService);
+		}, this.configurationService, this.environmentMainService, this.lifecycleMainService, this.logService);
 		const ptyHostService = new PtyHostService(
 			ptyHostStarter,
 			this.configurationService,

--- a/src/vs/platform/terminal/common/terminal.ts
+++ b/src/vs/platform/terminal/common/terminal.ts
@@ -107,7 +107,14 @@ export const enum TerminalSettingId {
 	ShellIntegrationCommandHistory = 'terminal.integrated.shellIntegration.history',
 	ShellIntegrationSuggestEnabled = 'terminal.integrated.shellIntegration.suggestEnabled',
 	EnableImages = 'terminal.integrated.enableImages',
-	SmoothScrolling = 'terminal.integrated.smoothScrolling'
+	SmoothScrolling = 'terminal.integrated.smoothScrolling',
+
+	// Debug settings that are hidden from user
+
+	/** Simulated latency applied to all calls made to the pty host */
+	DeveloperPtyHostLatency = 'terminal.integrated.developer.ptyHost.latency',
+	/** Simulated startup delay of the pty host process */
+	DeveloperPtyHostStartupDelay = 'terminal.integrated.developer.ptyHost.startupDelay',
 }
 
 export const enum PosixShellType {

--- a/src/vs/platform/terminal/electron-main/electronPtyHostStarter.ts
+++ b/src/vs/platform/terminal/electron-main/electronPtyHostStarter.ts
@@ -8,7 +8,7 @@ import { parsePtyHostDebugPort } from 'vs/platform/environment/node/environmentS
 import { ILifecycleMainService } from 'vs/platform/lifecycle/electron-main/lifecycleMainService';
 import { ILogService } from 'vs/platform/log/common/log';
 import { NullTelemetryService } from 'vs/platform/telemetry/common/telemetryUtils';
-import { IReconnectConstants } from 'vs/platform/terminal/common/terminal';
+import { IReconnectConstants, TerminalSettingId } from 'vs/platform/terminal/common/terminal';
 import { IPtyHostConnection, IPtyHostStarter } from 'vs/platform/terminal/node/ptyHost';
 import { UtilityProcess } from 'vs/platform/utilityProcess/electron-main/utilityProcess';
 import { Client as MessagePortClient } from 'vs/base/parts/ipc/electron-main/ipc.mp';
@@ -17,6 +17,7 @@ import { validatedIpcMain } from 'vs/base/parts/ipc/electron-main/ipcMain';
 import { DisposableStore, toDisposable } from 'vs/base/common/lifecycle';
 import { Emitter } from 'vs/base/common/event';
 import { deepClone } from 'vs/base/common/objects';
+import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 
 export class ElectronPtyHostStarter implements IPtyHostStarter {
 
@@ -29,6 +30,7 @@ export class ElectronPtyHostStarter implements IPtyHostStarter {
 
 	constructor(
 		private readonly _reconnectConstants: IReconnectConstants,
+		@IConfigurationService private readonly _configurationService: IConfigurationService,
 		@IEnvironmentService private readonly _environmentService: INativeEnvironmentService,
 		@ILifecycleMainService private readonly _lifecycleMainService: ILifecycleMainService,
 		@ILogService private readonly _logService: ILogService
@@ -73,7 +75,7 @@ export class ElectronPtyHostStarter implements IPtyHostStarter {
 	}
 
 	private _createPtyHostConfiguration(lastPtyId: number) {
-		return {
+		const config: { [key: string]: string } = {
 			...deepClone(process.env),
 			VSCODE_LAST_PTY_ID: String(lastPtyId),
 			VSCODE_AMD_ENTRYPOINT: 'vs/platform/terminal/node/ptyHostMain',
@@ -81,8 +83,17 @@ export class ElectronPtyHostStarter implements IPtyHostStarter {
 			VSCODE_VERBOSE_LOGGING: 'true', // transmit console logs from server to client,
 			VSCODE_RECONNECT_GRACE_TIME: String(this._reconnectConstants.graceTime),
 			VSCODE_RECONNECT_SHORT_GRACE_TIME: String(this._reconnectConstants.shortGraceTime),
-			VSCODE_RECONNECT_SCROLLBACK: String(this._reconnectConstants.scrollback)
+			VSCODE_RECONNECT_SCROLLBACK: String(this._reconnectConstants.scrollback),
 		};
+		const simulatedLatency = this._configurationService.getValue(TerminalSettingId.DeveloperPtyHostLatency);
+		if (simulatedLatency && typeof simulatedLatency === 'number') {
+			config.VSCODE_LATENCY = String(simulatedLatency);
+		}
+		const startupDelay = this._configurationService.getValue(TerminalSettingId.DeveloperPtyHostStartupDelay);
+		if (startupDelay && typeof startupDelay === 'number') {
+			config.VSCODE_STARTUP_DELAY = String(startupDelay);
+		}
+		return config;
 	}
 
 	private _onWindowConnection(e: IpcMainEvent, nonce: string) {

--- a/src/vs/platform/terminal/node/ptyHostMain.ts
+++ b/src/vs/platform/terminal/node/ptyHostMain.ts
@@ -20,49 +20,73 @@ import { IReconnectConstants, TerminalIpcChannels } from 'vs/platform/terminal/c
 import { HeartbeatService } from 'vs/platform/terminal/node/heartbeatService';
 import { PtyService } from 'vs/platform/terminal/node/ptyService';
 import { isUtilityProcess } from 'vs/base/parts/sandbox/node/electronTypes';
+import { timeout } from 'vs/base/common/async';
 
-const _isUtilityProcess = isUtilityProcess(process);
+startPtyHost();
 
-let server: ChildProcessServer<string> | UtilityProcessServer;
-if (_isUtilityProcess) {
-	server = new UtilityProcessServer();
-} else {
-	server = new ChildProcessServer(TerminalIpcChannels.PtyHost);
+async function startPtyHost() {
+	// Parse environment variables
+	const startupDelay = parseInt(process.env.VSCODE_STARTUP_DELAY ?? '0');
+	const simulatedLatency = parseInt(process.env.VSCODE_LATENCY ?? '0');
+	const reconnectConstants: IReconnectConstants = {
+		graceTime: parseInt(process.env.VSCODE_RECONNECT_GRACE_TIME || '0'),
+		shortGraceTime: parseInt(process.env.VSCODE_RECONNECT_SHORT_GRACE_TIME || '0'),
+		scrollback: parseInt(process.env.VSCODE_RECONNECT_SCROLLBACK || '100')
+	};
+	const lastPtyId = parseInt(process.env.VSCODE_LAST_PTY_ID || '0');
+
+	// Sanitize environment
+	delete process.env.VSCODE_RECONNECT_GRACE_TIME;
+	delete process.env.VSCODE_RECONNECT_SHORT_GRACE_TIME;
+	delete process.env.VSCODE_RECONNECT_SCROLLBACK;
+	delete process.env.VSCODE_LATENCY;
+	delete process.env.VSCODE_STARTUP_DELAY;
+	delete process.env.VSCODE_LAST_PTY_ID;
+
+	// Setup RPC
+	const _isUtilityProcess = isUtilityProcess(process);
+	let server: ChildProcessServer<string> | UtilityProcessServer;
+	if (_isUtilityProcess) {
+		server = new UtilityProcessServer();
+	} else {
+		server = new ChildProcessServer(TerminalIpcChannels.PtyHost);
+	}
+
+	// Services
+	const productService: IProductService = { _serviceBrand: undefined, ...product };
+	const environmentService = new NativeEnvironmentService(parseArgs(process.argv, OPTIONS), productService);
+	const loggerService = new LoggerService(getLogLevel(environmentService), environmentService.logsHome);
+	server.registerChannel(TerminalIpcChannels.Logger, new LoggerChannel(loggerService, () => DefaultURITransformer));
+	const logger = loggerService.createLogger('ptyhost', { name: localize('ptyHost', "Pty Host") });
+	const logService = new LogService(logger, [new ConsoleLogger()]);
+
+	// Log and apply developer config
+	if (startupDelay) {
+		logService.warn(`Pty Host startup is delayed ${startupDelay}ms`);
+		await timeout(startupDelay);
+	}
+	if (simulatedLatency) {
+		logService.warn(`Pty host is simulating ${simulatedLatency}ms latency`);
+	}
+
+	// Heartbeat responsiveness tracking
+	const heartbeatService = new HeartbeatService();
+	server.registerChannel(TerminalIpcChannels.Heartbeat, ProxyChannel.fromService(heartbeatService));
+
+	// Init pty service
+	const ptyService = new PtyService(lastPtyId, logService, productService, reconnectConstants, simulatedLatency);
+	const ptyServiceChannel = ProxyChannel.fromService(ptyService);
+	server.registerChannel(TerminalIpcChannels.PtyHost, ptyServiceChannel);
+
+	// Register a channel for direct communication via Message Port
+	if (_isUtilityProcess) {
+		server.registerChannel(TerminalIpcChannels.PtyHostWindow, ptyServiceChannel);
+	}
+
+	// Clean up
+	process.once('exit', () => {
+		logService.dispose();
+		heartbeatService.dispose();
+		ptyService.dispose();
+	});
 }
-
-const lastPtyId = parseInt(process.env.VSCODE_LAST_PTY_ID || '0');
-delete process.env.VSCODE_LAST_PTY_ID;
-
-const productService: IProductService = { _serviceBrand: undefined, ...product };
-const environmentService = new NativeEnvironmentService(parseArgs(process.argv, OPTIONS), productService);
-
-// Logging
-const loggerService = new LoggerService(getLogLevel(environmentService), environmentService.logsHome);
-server.registerChannel(TerminalIpcChannels.Logger, new LoggerChannel(loggerService, () => DefaultURITransformer));
-const logger = loggerService.createLogger('ptyhost', { name: localize('ptyHost', "Pty Host") });
-const logService = new LogService(logger, [new ConsoleLogger()]);
-
-const heartbeatService = new HeartbeatService();
-server.registerChannel(TerminalIpcChannels.Heartbeat, ProxyChannel.fromService(heartbeatService));
-
-const reconnectConstants: IReconnectConstants = {
-	graceTime: parseInt(process.env.VSCODE_RECONNECT_GRACE_TIME || '0'),
-	shortGraceTime: parseInt(process.env.VSCODE_RECONNECT_SHORT_GRACE_TIME || '0'),
-	scrollback: parseInt(process.env.VSCODE_RECONNECT_SCROLLBACK || '100')
-};
-delete process.env.VSCODE_RECONNECT_GRACE_TIME;
-delete process.env.VSCODE_RECONNECT_SHORT_GRACE_TIME;
-delete process.env.VSCODE_RECONNECT_SCROLLBACK;
-
-const ptyService = new PtyService(lastPtyId, logService, productService, reconnectConstants);
-const ptyServiceChannel = ProxyChannel.fromService(ptyService);
-server.registerChannel(TerminalIpcChannels.PtyHost, ptyServiceChannel);
-if (_isUtilityProcess) {
-	server.registerChannel(TerminalIpcChannels.PtyHostWindow, ptyServiceChannel);
-}
-
-process.once('exit', () => {
-	logService.dispose();
-	heartbeatService.dispose();
-	ptyService.dispose();
-});

--- a/src/vs/platform/terminal/node/ptyHostService.ts
+++ b/src/vs/platform/terminal/node/ptyHostService.ts
@@ -149,6 +149,7 @@ export class PtyHostService extends Disposable implements IPtyService {
 		// Setup heartbeat service and trigger a heartbeat immediately to reset the timeouts
 		const heartbeatService = ProxyChannel.toService<IHeartbeatService>(client.getChannel(TerminalIpcChannels.Heartbeat));
 		heartbeatService.onBeat(() => this._handleHeartbeat());
+		// TODO: Starting the heartbeat tracking now causes problems
 		this._handleHeartbeat();
 
 		// Handle exit

--- a/src/vs/platform/terminal/node/ptyService.ts
+++ b/src/vs/platform/terminal/node/ptyService.ts
@@ -43,9 +43,6 @@ export function traceRpc(_target: any, key: string, descriptor: any) {
 		if (fn!.length !== 0) {
 			console.warn('Memoize should only be used in functions with zero parameters');
 		}
-	} else if (typeof descriptor.get === 'function') {
-		fnKey = 'get';
-		fn = descriptor.get;
 	}
 
 	if (!fn) {
@@ -59,7 +56,7 @@ export function traceRpc(_target: any, key: string, descriptor: any) {
 		if (this.traceRpcArgs.simulatedLatency) {
 			await timeout(this.traceRpcArgs.simulatedLatency);
 		}
-		const result = await fn.apply(this, args);
+		const result = await fn!.apply(this, args);
 		if (this.traceRpcArgs.logService.getLevel() === LogLevel.Trace) {
 			this.traceRpcArgs.logService.trace(`[RPC Response] PtyService#${fnKey}`, result);
 		}
@@ -576,22 +573,6 @@ export class PtyService extends Disposable implements IPtyService {
 		}
 		return pty;
 	}
-
-	// private async _traceRpc<T>(impl: () => T, ...args: unknown[]): Promise<T> {
-	// 	let method: string | undefined;
-	// 	if (this._logService.getLevel() === LogLevel.Trace) {
-	// 		method = this._getCallingMethod(new Error().stack);
-	// 		this._logService.trace(`[RPC Request] PtyService#${method}(${args.map(e => JSON.stringify(e)).join(', ')})`);
-	// 	}
-	// 	if (this._simulatedLatency) {
-	// 		await timeout(this._simulatedLatency);
-	// 	}
-	// 	const result = impl();
-	// 	if (this._logService.getLevel() === LogLevel.Trace) {
-	// 		this._logService.trace(`[RPC Response] PtyService#${method}`, result);
-	// 	}
-	// 	return result;
-	// }
 }
 
 const enum InteractionState {

--- a/src/vs/platform/terminal/node/terminalProcess.ts
+++ b/src/vs/platform/terminal/node/terminalProcess.ts
@@ -236,7 +236,7 @@ export class TerminalProcess extends Disposable implements ITerminalChildProcess
 			}
 			return undefined;
 		} catch (err) {
-			this._logService.trace('IPty#spawn native exception', err);
+			this._logService.trace('node-pty.node-pty.IPty#spawn native exception', err);
 			return { message: `A native exception occurred during launch (${err.message})` };
 		}
 	}
@@ -294,7 +294,7 @@ export class TerminalProcess extends Disposable implements ITerminalChildProcess
 	): Promise<void> {
 		const args = shellIntegrationInjection?.newArgs || shellLaunchConfig.args || [];
 		await this._throttleKillSpawn();
-		this._logService.trace('IPty#spawn', shellLaunchConfig.executable, args, options);
+		this._logService.trace('node-pty.IPty#spawn', shellLaunchConfig.executable, args, options);
 		const ptyProcess = spawn(shellLaunchConfig.executable!, args, options);
 		this._ptyProcess = ptyProcess;
 		this._childProcessMonitor = this._register(new ChildProcessMonitor(ptyProcess.pid, this._logService));
@@ -312,7 +312,7 @@ export class TerminalProcess extends Disposable implements ITerminalChildProcess
 			}
 
 			// Refire the data event
-			this._logService.trace('IPty#onData', data);
+			this._logService.trace('node-pty.IPty#onData', data);
 			this._onProcessData.fire(data);
 			if (this._closeTimeout) {
 				this._queueProcessExit();
@@ -374,7 +374,7 @@ export class TerminalProcess extends Disposable implements ITerminalChildProcess
 		try {
 			if (this._ptyProcess) {
 				await this._throttleKillSpawn();
-				this._logService.trace('IPty#kill');
+				this._logService.trace('node-pty.IPty#kill');
 				this._ptyProcess.kill();
 			}
 		} catch (ex) {
@@ -508,7 +508,7 @@ export class TerminalProcess extends Disposable implements ITerminalChildProcess
 
 	private _doWrite(): void {
 		const object = this._writeQueue.shift()!;
-		this._logService.trace('IPty#write', object.data);
+		this._logService.trace('node-pty.IPty#write', object.data);
 		if (object.isBinary) {
 			this._ptyProcess!.write(Buffer.from(object.data, 'binary') as any);
 		} else {
@@ -537,12 +537,12 @@ export class TerminalProcess extends Disposable implements ITerminalChildProcess
 				return;
 			}
 
-			this._logService.trace('IPty#resize', cols, rows);
+			this._logService.trace('node-pty.IPty#resize', cols, rows);
 			try {
 				this._ptyProcess.resize(cols, rows);
 			} catch (e) {
 				// Swallow error if the pty has already exited
-				this._logService.trace('IPty#resize exception ' + e.message);
+				this._logService.trace('node-pty.IPty#resize exception ' + e.message);
 				if (this._exitCode !== undefined &&
 					e.message !== 'ioctl(2) failed, EBADF' &&
 					e.message !== 'Cannot resize a pty that has already exited') {
@@ -594,7 +594,7 @@ export class TerminalProcess extends Disposable implements ITerminalChildProcess
 					resolve(this._initialCwd);
 					return;
 				}
-				this._logService.trace('IPty#pid');
+				this._logService.trace('node-pty.IPty#pid');
 				exec('lsof -OPln -p ' + this._ptyProcess.pid + ' | grep cwd', { env: { ...process.env, LANG: 'en_US.UTF-8' } }, (error, stdout, stderr) => {
 					if (!error && stdout !== '') {
 						resolve(stdout.substring(stdout.indexOf('/'), stdout.length - 1));
@@ -610,7 +610,7 @@ export class TerminalProcess extends Disposable implements ITerminalChildProcess
 			if (!this._ptyProcess) {
 				return this._initialCwd;
 			}
-			this._logService.trace('IPty#pid');
+			this._logService.trace('node-pty.IPty#pid');
 			try {
 				return await Promises.readlink(`/proc/${this._ptyProcess.pid}/cwd`);
 			} catch (error) {

--- a/src/vs/workbench/contrib/terminal/electron-sandbox/localTerminalBackend.ts
+++ b/src/vs/workbench/contrib/terminal/electron-sandbox/localTerminalBackend.ts
@@ -183,6 +183,7 @@ class LocalTerminalBackend extends BaseTerminalBackend implements ITerminalBacke
 		shouldPersist: boolean
 	): Promise<ITerminalChildProcess> {
 		const executableEnv = await this._shellEnvironmentService.getShellEnv();
+		// TODO: Using _proxy here bypasses the lastPtyId tracking on the main process
 		const id = await this._proxy.createProcess(shellLaunchConfig, cwd, cols, rows, unicodeVersion, env, executableEnv, options, shouldPersist, this._getWorkspaceId(), this._getWorkspaceName());
 		const pty = this._instantiationService.createInstance(LocalPty, id, shouldPersist);
 		this._ptys.set(id, pty);


### PR DESCRIPTION
This standardizes the trace logging in the pty host so it's super easy to add the log via the `@traceRpc` decorator, this is now used in all public methods on `PtyService`. It also logs the request function name, args and the response function name and return result:

![image](https://github.com/microsoft/vscode/assets/2193314/251e1b01-5ef1-4ad9-a494-0ba584b8e49e)

There are also 2 hidden settings introduced which will allow us to simulate a slower machine and network:

```
  "terminal.integrated.developer.ptyHost.latency": 200,
  "terminal.integrated.developer.ptyHost.startupDelay": 2000,
```

These are warned on startup:

![image](https://github.com/microsoft/vscode/assets/2193314/9f562c13-df76-46a5-a0b7-6f61382e6c99)

The 2 TODOs will be resolved in later PRs

Part of #130320
Part of #133542 