### PR TITLE
Change the pty host responsiveness notification to a status bar item

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/baseTerminalBackend.ts
+++ b/src/vs/workbench/contrib/terminal/browser/baseTerminalBackend.ts
@@ -9,14 +9,19 @@ import { Schemas } from 'vs/base/common/network';
 import { withNullAsUndefined } from 'vs/base/common/types';
 import { localize } from 'vs/nls';
 import { ILogService } from 'vs/platform/log/common/log';
-import { INotificationHandle, INotificationService, IPromptChoice, Severity } from 'vs/platform/notification/common/notification';
 import { ICrossVersionSerializedTerminalState, IPtyHostController, ISerializedTerminalState } from 'vs/platform/terminal/common/terminal';
+import { themeColorFromId } from 'vs/platform/theme/common/themeService';
 import { IWorkspaceContextService } from 'vs/platform/workspace/common/workspace';
+import { STATUS_BAR_WARNING_ITEM_BACKGROUND, STATUS_BAR_WARNING_ITEM_FOREGROUND } from 'vs/workbench/common/theme';
+import { TerminalCommandId } from 'vs/workbench/contrib/terminal/common/terminal';
 import { IConfigurationResolverService } from 'vs/workbench/services/configurationResolver/common/configurationResolver';
 import { IHistoryService } from 'vs/workbench/services/history/common/history';
+import { IStatusbarEntry, IStatusbarEntryAccessor, IStatusbarService, StatusbarAlignment } from 'vs/workbench/services/statusbar/browser/statusbar';
 
 export abstract class BaseTerminalBackend extends Disposable {
 	private _isPtyHostUnresponsive: boolean = false;
+
+	get isResponsive(): boolean { return !this._isPtyHostUnresponsive; }
 
 	protected readonly _onPtyHostRestart = this._register(new Emitter<void>());
 	readonly onPtyHostRestart = this._onPtyHostRestart.event;
@@ -26,55 +31,63 @@ export abstract class BaseTerminalBackend extends Disposable {
 	readonly onPtyHostResponsive = this._onPtyHostResponsive.event;
 
 	constructor(
-		eventSource: IPtyHostController,
+		private readonly _ptyHostController: IPtyHostController,
 		protected readonly _logService: ILogService,
-		notificationService: INotificationService,
 		historyService: IHistoryService,
 		configurationResolverService: IConfigurationResolverService,
+		statusBarService: IStatusbarService,
 		protected readonly _workspaceContextService: IWorkspaceContextService
 	) {
 		super();
 
+		let unresponsiveStatusBarEntry: IStatusbarEntry;
+		let statusBarAccessor: IStatusbarEntryAccessor;
+
 		// Attach pty host listeners
-		if (eventSource.onPtyHostExit) {
-			this._register(eventSource.onPtyHostExit(() => {
+		if (this._ptyHostController.onPtyHostExit) {
+			this._register(this._ptyHostController.onPtyHostExit(() => {
 				this._logService.error(`The terminal's pty host process exited, the connection to all terminal processes was lost`);
 			}));
 		}
-		let unresponsiveNotification: INotificationHandle | undefined;
-		if (eventSource.onPtyHostStart) {
-			this._register(eventSource.onPtyHostStart(() => {
+		if (this._ptyHostController.onPtyHostStart) {
+			this._register(this._ptyHostController.onPtyHostStart(() => {
 				this._onPtyHostRestart.fire();
-				unresponsiveNotification?.close();
-				unresponsiveNotification = undefined;
+				statusBarAccessor?.dispose();
 				this._isPtyHostUnresponsive = false;
 			}));
 		}
-		if (eventSource.onPtyHostUnresponsive) {
-			this._register(eventSource.onPtyHostUnresponsive(() => {
-				const choices: IPromptChoice[] = [{
-					label: localize('restartPtyHost', "Restart pty host"),
-					run: () => eventSource.restartPtyHost!()
-				}];
-				unresponsiveNotification = notificationService.prompt(Severity.Error, localize('nonResponsivePtyHost', "The connection to the terminal's pty host process is unresponsive, the terminals may stop working."), choices);
+		if (this._ptyHostController.onPtyHostUnresponsive) {
+			this._register(this._ptyHostController.onPtyHostUnresponsive(() => {
+				statusBarAccessor?.dispose();
+				if (!unresponsiveStatusBarEntry) {
+					unresponsiveStatusBarEntry = {
+						name: localize('ptyHostStatus', 'Pty Host Status'),
+						text: `$(debug-disconnect) ${localize('ptyHostStatus.short', 'Pty Host')}`,
+						tooltip: localize('nonResponsivePtyHost', "The connection to the terminal's pty host process is unresponsive, terminals may stop working. Click to manually restart the pty host."),
+						ariaLabel: localize('ptyHostStatus.ariaLabel', 'Pty Host is unresponsive'),
+						command: TerminalCommandId.RestartPtyHost,
+						backgroundColor: themeColorFromId(STATUS_BAR_WARNING_ITEM_BACKGROUND),
+						color: themeColorFromId(STATUS_BAR_WARNING_ITEM_FOREGROUND),
+					};
+				}
+				statusBarAccessor = statusBarService.addEntry(unresponsiveStatusBarEntry, 'ptyHostStatus', StatusbarAlignment.LEFT);
 				this._isPtyHostUnresponsive = true;
 				this._onPtyHostUnresponsive.fire();
 			}));
 		}
-		if (eventSource.onPtyHostResponsive) {
-			this._register(eventSource.onPtyHostResponsive(() => {
+		if (this._ptyHostController.onPtyHostResponsive) {
+			this._register(this._ptyHostController.onPtyHostResponsive(() => {
 				if (!this._isPtyHostUnresponsive) {
 					return;
 				}
 				this._logService.info('The pty host became responsive again');
-				unresponsiveNotification?.close();
-				unresponsiveNotification = undefined;
+				statusBarAccessor?.dispose();
 				this._isPtyHostUnresponsive = false;
 				this._onPtyHostResponsive.fire();
 			}));
 		}
-		if (eventSource.onPtyHostRequestResolveVariables) {
-			this._register(eventSource.onPtyHostRequestResolveVariables(async e => {
+		if (this._ptyHostController.onPtyHostRequestResolveVariables) {
+			this._register(this._ptyHostController.onPtyHostRequestResolveVariables(async e => {
 				// Only answer requests for this workspace
 				if (e.workspaceId !== this._workspaceContextService.getWorkspace().id) {
 					return;
@@ -85,9 +98,13 @@ export abstract class BaseTerminalBackend extends Disposable {
 					return configurationResolverService.resolveAsync(lastActiveWorkspaceRoot, t);
 				});
 				const result = await Promise.all(resolveCalls);
-				eventSource.acceptPtyHostResolvedVariables?.(e.requestId, result);
+				this._ptyHostController.acceptPtyHostResolvedVariables?.(e.requestId, result);
 			}));
 		}
+	}
+
+	restartPtyHost(): void {
+		this._ptyHostController.restartPtyHost?.();
 	}
 
 	protected _deserializeTerminalState(serializedState: string | undefined): ISerializedTerminalState[] | undefined {

--- a/src/vs/workbench/contrib/terminal/browser/remoteTerminalBackend.ts
+++ b/src/vs/workbench/contrib/terminal/browser/remoteTerminalBackend.ts
@@ -10,7 +10,6 @@ import { ICommandService } from 'vs/platform/commands/common/commands';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { ILogService } from 'vs/platform/log/common/log';
-import { INotificationService } from 'vs/platform/notification/common/notification';
 import { Registry } from 'vs/platform/registry/common/platform';
 import { IRemoteAuthorityResolverService } from 'vs/platform/remote/common/remoteAuthorityResolver';
 import { IStorageService, StorageScope, StorageTarget } from 'vs/platform/storage/common/storage';
@@ -28,6 +27,7 @@ import { TerminalStorageKeys } from 'vs/workbench/contrib/terminal/common/termin
 import { IConfigurationResolverService } from 'vs/workbench/services/configurationResolver/common/configurationResolver';
 import { IHistoryService } from 'vs/workbench/services/history/common/history';
 import { IRemoteAgentService } from 'vs/workbench/services/remote/common/remoteAgentService';
+import { IStatusbarService } from 'vs/workbench/services/statusbar/browser/statusbar';
 
 export class RemoteTerminalBackendContribution implements IWorkbenchContribution {
 	constructor(
@@ -60,14 +60,14 @@ class RemoteTerminalBackend extends BaseTerminalBackend implements ITerminalBack
 		@ILogService logService: ILogService,
 		@ICommandService private readonly _commandService: ICommandService,
 		@IStorageService private readonly _storageService: IStorageService,
-		@INotificationService notificationService: INotificationService,
 		@IRemoteAuthorityResolverService private readonly _remoteAuthorityResolverService: IRemoteAuthorityResolverService,
 		@IWorkspaceContextService workspaceContextService: IWorkspaceContextService,
 		@IConfigurationResolverService configurationResolverService: IConfigurationResolverService,
 		@IHistoryService private readonly _historyService: IHistoryService,
 		@IConfigurationService private readonly _configurationService: IConfigurationService,
+		@IStatusbarService statusBarService: IStatusbarService,
 	) {
-		super(_remoteTerminalChannel, logService, notificationService, _historyService, configurationResolverService, workspaceContextService);
+		super(_remoteTerminalChannel, logService, _historyService, configurationResolverService, statusBarService, workspaceContextService);
 
 		this._remoteTerminalChannel.onProcessData(e => this._ptys.get(e.id)?.handleData(e.event));
 		this._remoteTerminalChannel.onProcessReplay(e => {

--- a/src/vs/workbench/contrib/terminal/browser/terminal.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminal.ts
@@ -77,6 +77,7 @@ export interface ITerminalInstanceService {
 	 */
 	getBackend(remoteAuthority?: string): Promise<ITerminalBackend | undefined>;
 
+	getRegisteredBackends(): IterableIterator<ITerminalBackend>;
 	didRegisterBackend(remoteAuthority?: string): void;
 }
 

--- a/src/vs/workbench/contrib/terminal/browser/terminalInstanceService.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalInstanceService.ts
@@ -104,6 +104,10 @@ export class TerminalInstanceService extends Disposable implements ITerminalInst
 		return backend;
 	}
 
+	getRegisteredBackends(): IterableIterator<ITerminalBackend> {
+		return Registry.as<ITerminalBackendRegistry>(TerminalExtensions.Backend).backends.values();
+	}
+
 	didRegisterBackend(remoteAuthority?: string) {
 		this._backendRegistration.get(remoteAuthority)?.resolve();
 	}

--- a/src/vs/workbench/contrib/terminal/common/terminal.ts
+++ b/src/vs/workbench/contrib/terminal/common/terminal.ts
@@ -100,6 +100,8 @@ export interface IShellLaunchConfigResolveOptions {
 export interface ITerminalBackend {
 	readonly remoteAuthority: string | undefined;
 
+	readonly isResponsive: boolean;
+
 	/**
 	 * Fired when the ptyHost process becomes non-responsive, this should disable stdin for all
 	 * terminals using this pty host connection and mark them as disconnected.
@@ -145,6 +147,8 @@ export interface ITerminalBackend {
 		options: ITerminalProcessOptions,
 		shouldPersist: boolean
 	): Promise<ITerminalChildProcess>;
+
+	restartPtyHost(): void;
 }
 
 export const TerminalExtensions = {
@@ -152,6 +156,11 @@ export const TerminalExtensions = {
 };
 
 export interface ITerminalBackendRegistry {
+	/**
+	 * Gets all backends in the registry.
+	 */
+	backends: ReadonlyMap<string, ITerminalBackend>;
+
 	/**
 	 * Registers a terminal backend for a remote authority.
 	 */
@@ -165,6 +174,8 @@ export interface ITerminalBackendRegistry {
 
 class TerminalBackendRegistry implements ITerminalBackendRegistry {
 	private readonly _backends = new Map<string, ITerminalBackend>();
+
+	get backends(): ReadonlyMap<string, ITerminalBackend> { return this._backends; }
 
 	registerTerminalBackend(backend: ITerminalBackend): void {
 		const key = this._sanitizeRemoteAuthority(backend.remoteAuthority);
@@ -578,8 +589,6 @@ export const enum TerminalCommandId {
 	MoveToTerminalPanel = 'workbench.action.terminal.moveToTerminalPanel',
 	SetDimensions = 'workbench.action.terminal.setDimensions',
 	ClearPreviousSessionHistory = 'workbench.action.terminal.clearPreviousSessionHistory',
-	WriteDataToTerminal = 'workbench.action.terminal.writeDataToTerminal',
-	ShowTextureAtlas = 'workbench.action.terminal.showTextureAtlas',
 	ShowTerminalAccessibilityHelp = 'workbench.action.terminal.showAccessibilityHelp',
 	SelectPrevSuggestion = 'workbench.action.terminal.selectPrevSuggestion',
 	SelectPrevPageSuggestion = 'workbench.action.terminal.selectPrevPageSuggestion',
@@ -589,6 +598,12 @@ export const enum TerminalCommandId {
 	HideSuggestWidget = 'workbench.action.terminal.hideSuggestWidget',
 	FocusHover = 'workbench.action.terminal.focusHover',
 	ShowEnvironmentContributions = 'workbench.action.terminal.showEnvironmentContributions',
+
+	// Developer commands
+
+	WriteDataToTerminal = 'workbench.action.terminal.writeDataToTerminal',
+	ShowTextureAtlas = 'workbench.action.terminal.showTextureAtlas',
+	RestartPtyHost = 'workbench.action.terminal.restartPtyHost',
 }
 
 export const DEFAULT_COMMANDS_TO_SKIP_SHELL: string[] = [

--- a/src/vs/workbench/contrib/terminal/electron-sandbox/localTerminalBackend.ts
+++ b/src/vs/workbench/contrib/terminal/electron-sandbox/localTerminalBackend.ts
@@ -11,7 +11,6 @@ import { IConfigurationService } from 'vs/platform/configuration/common/configur
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { ILabelService } from 'vs/platform/label/common/label';
 import { ILogService } from 'vs/platform/log/common/log';
-import { INotificationService } from 'vs/platform/notification/common/notification';
 import { Registry } from 'vs/platform/registry/common/platform';
 import { IStorageService, StorageScope, StorageTarget } from 'vs/platform/storage/common/storage';
 import { ILocalPtyService, IProcessPropertyMap, IPtyService, IShellLaunchConfig, ITerminalChildProcess, ITerminalEnvironment, ITerminalProcessOptions, ITerminalsLayoutInfo, ITerminalsLayoutInfoById, ProcessPropertyType, TerminalIpcChannels, TerminalSettingId, TitleEventSource } from 'vs/platform/terminal/common/terminal';
@@ -36,6 +35,7 @@ import { getDelayedChannel, ProxyChannel } from 'vs/base/parts/ipc/common/ipc';
 import { mark } from 'vs/base/common/performance';
 import { ILifecycleService, LifecyclePhase } from 'vs/workbench/services/lifecycle/common/lifecycle';
 import { DeferredPromise } from 'vs/base/common/async';
+import { IStatusbarService } from 'vs/workbench/services/statusbar/browser/statusbar';
 
 export class LocalTerminalBackendContribution implements IWorkbenchContribution {
 	constructor(
@@ -74,11 +74,11 @@ class LocalTerminalBackend extends BaseTerminalBackend implements ITerminalBacke
 		@IHistoryService private readonly _historyService: IHistoryService,
 		@ITerminalProfileResolverService private readonly _terminalProfileResolverService: ITerminalProfileResolverService,
 		@IEnvironmentVariableService private readonly _environmentVariableService: IEnvironmentVariableService,
-		@INotificationService notificationService: INotificationService,
 		@IHistoryService historyService: IHistoryService,
-		@INativeWorkbenchEnvironmentService private readonly _environmentService: INativeWorkbenchEnvironmentService
+		@INativeWorkbenchEnvironmentService private readonly _environmentService: INativeWorkbenchEnvironmentService,
+		@IStatusbarService statusBarService: IStatusbarService,
 	) {
-		super(_localPtyService, logService, notificationService, historyService, _configurationResolverService, workspaceContextService);
+		super(_localPtyService, logService, historyService, _configurationResolverService, statusBarService, workspaceContextService);
 
 		this._proxy = ProxyChannel.toService<IPtyService>(getDelayedChannel(this._clientEventually.p.then(client => client.getChannel(TerminalIpcChannels.PtyHostWindow))));
 

--- a/src/vs/workbench/test/browser/workbenchTestServices.ts
+++ b/src/vs/workbench/test/browser/workbenchTestServices.ts
@@ -1795,6 +1795,7 @@ export class TestTerminalInstanceService implements ITerminalInstanceService {
 	createInstance(options: ICreateTerminalOptions, target: TerminalLocation): ITerminalInstance { throw new Error('Method not implemented.'); }
 	async getBackend(remoteAuthority?: string): Promise<ITerminalBackend | undefined> { throw new Error('Method not implemented.'); }
 	didRegisterBackend(remoteAuthority?: string): void { throw new Error('Method not implemented.'); }
+	getRegisteredBackends(): IterableIterator<ITerminalBackend> { throw new Error('Method not implemented.'); }
 }
 
 export class TestTerminalEditorService implements ITerminalEditorService {


### PR DESCRIPTION
Part of #130320

Simulated a failure with `"terminal.integrated.developer.ptyHost.startupDelay": 10000`:

![image](https://github.com/microsoft/vscode/assets/2193314/eb585a8a-94c3-4834-b610-1cb5f8288e98)

New developer command:

![image](https://github.com/microsoft/vscode/assets/2193314/33c51669-5486-498b-934d-93bc9ef039cd)

I discovered https://github.com/microsoft/vscode/issues/185254 when working on this, it's not a regression from main.