### PR TITLE
allow `aria-live: polite` to be used on macOS, use status instead of alert for chat response announcement

### DIFF
--- a/src/vs/base/browser/ui/aria/aria.ts
+++ b/src/vs/base/browser/ui/aria/aria.ts
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as dom from 'vs/base/browser/dom';
-import { isMacintosh } from 'vs/base/common/platform';
 import 'vs/css!./aria';
 
 // Use a max length since we are inserting the whole msg in the DOM and that can cause browsers to freeze for long messages #94233
@@ -69,16 +68,12 @@ export function status(msg: string): void {
 		return;
 	}
 
-	if (isMacintosh) {
-		alert(msg); // VoiceOver does not seem to support status role
+	if (statusContainer.textContent !== msg) {
+		dom.clearNode(statusContainer2);
+		insertMessage(statusContainer, msg);
 	} else {
-		if (statusContainer.textContent !== msg) {
-			dom.clearNode(statusContainer2);
-			insertMessage(statusContainer, msg);
-		} else {
-			dom.clearNode(statusContainer);
-			insertMessage(statusContainer2, msg);
-		}
+		dom.clearNode(statusContainer);
+		insertMessage(statusContainer2, msg);
 	}
 }
 

--- a/src/vs/workbench/contrib/chat/browser/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatWidget.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as dom from 'vs/base/browser/dom';
-import { alert } from 'vs/base/browser/ui/aria/aria';
+import { status } from 'vs/base/browser/ui/aria/aria';
 import { ITreeContextMenuEvent, ITreeElement } from 'vs/base/browser/ui/tree/tree';
 import { CancellationToken } from 'vs/base/common/cancellation';
 import { Emitter } from 'vs/base/common/event';
@@ -529,7 +529,7 @@ export class ChatAccessibilityService extends Disposable implements IChatAccessi
 			return;
 		}
 		const errorDetails = response.errorDetails ? ` ${response.errorDetails.message}` : '';
-		alert(response.response.value + errorDetails);
+		status(response.response.value + errorDetails);
 	}
 }
 


### PR DESCRIPTION
When `aria-live:assertive` is used, there are some unwanted effects when using NVDA and VoiceOver. 

It seems that `aria-live:polite` IE `status` were not supported on macOS formerly. I tested and it works well. 

cc @rperez030

cc @isidorn 