### PR TITLE
Reduce unnecessary calls to PtyService

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/remoteTerminalBackend.ts
+++ b/src/vs/workbench/contrib/terminal/browser/remoteTerminalBackend.ts
@@ -57,6 +57,7 @@ class RemoteTerminalBackend extends BaseTerminalBackend implements ITerminalBack
 		readonly remoteAuthority: string | undefined,
 		private readonly _remoteTerminalChannel: RemoteTerminalChannelClient,
 		@IRemoteAgentService private readonly _remoteAgentService: IRemoteAgentService,
+		@IInstantiationService private readonly _instantiationService: IInstantiationService,
 		@ILogService logService: ILogService,
 		@ICommandService private readonly _commandService: ICommandService,
 		@IStorageService private readonly _storageService: IStorageService,
@@ -215,7 +216,7 @@ class RemoteTerminalBackend extends BaseTerminalBackend implements ITerminalBack
 			rows,
 			unicodeVersion
 		);
-		const pty = new RemotePty(result.persistentTerminalId, shouldPersist, this._remoteTerminalChannel, this._remoteAgentService, this._logService);
+		const pty = this._instantiationService.createInstance(RemotePty, result.persistentTerminalId, shouldPersist, this._remoteTerminalChannel);
 		this._ptys.set(result.persistentTerminalId, pty);
 		return pty;
 	}
@@ -227,7 +228,7 @@ class RemoteTerminalBackend extends BaseTerminalBackend implements ITerminalBack
 
 		try {
 			await this._remoteTerminalChannel.attachToProcess(id);
-			const pty = new RemotePty(id, true, this._remoteTerminalChannel, this._remoteAgentService, this._logService);
+			const pty = this._instantiationService.createInstance(RemotePty, id, true, this._remoteTerminalChannel);
 			this._ptys.set(id, pty);
 			return pty;
 		} catch (e) {

--- a/src/vs/workbench/contrib/terminal/electron-sandbox/localPty.ts
+++ b/src/vs/workbench/contrib/terminal/electron-sandbox/localPty.ts
@@ -14,8 +14,7 @@ import { IPtyHostProcessReplayEvent, ISerializedCommandDetectionCapability } fro
  * created on the local pty host.
  */
 export class LocalPty extends Disposable implements ITerminalChildProcess {
-	private _inReplay = false;
-	private _properties: IProcessPropertyMap = {
+	private readonly _properties: IProcessPropertyMap = {
 		cwd: '',
 		initialCwd: '',
 		fixedDimensions: { cols: undefined, rows: undefined },
@@ -27,6 +26,10 @@ export class LocalPty extends Disposable implements ITerminalChildProcess {
 		failedShellIntegrationActivation: false,
 		usedShellIntegrationInjection: undefined
 	};
+	private readonly _lastDimensions: { cols: number; rows: number } = { cols: -1, rows: -1 };
+
+	private _inReplay = false;
+
 	private readonly _onProcessData = this._register(new Emitter<IProcessDataEvent | string>());
 	readonly onProcessData = this._onProcessData.event;
 	private readonly _onProcessReplay = this._register(new Emitter<IPtyHostProcessReplayEvent>());
@@ -70,9 +73,11 @@ export class LocalPty extends Disposable implements ITerminalChildProcess {
 		this._localPtyService.input(this.id, data);
 	}
 	resize(cols: number, rows: number): void {
-		if (this._inReplay) {
+		if (this._inReplay || this._lastDimensions.cols === cols && this._lastDimensions.rows === rows) {
 			return;
 		}
+		this._lastDimensions.cols = cols;
+		this._lastDimensions.rows = rows;
 		this._localPtyService.resize(this.id, cols, rows);
 	}
 	async clearBuffer(): Promise<void> {

--- a/src/vs/workbench/contrib/terminal/electron-sandbox/localTerminalBackend.ts
+++ b/src/vs/workbench/contrib/terminal/electron-sandbox/localTerminalBackend.ts
@@ -36,6 +36,7 @@ import { mark } from 'vs/base/common/performance';
 import { ILifecycleService, LifecyclePhase } from 'vs/workbench/services/lifecycle/common/lifecycle';
 import { DeferredPromise } from 'vs/base/common/async';
 import { IStatusbarService } from 'vs/workbench/services/statusbar/browser/statusbar';
+import { memoize } from 'vs/base/common/decorators';
 
 export class LocalTerminalBackendContribution implements IWorkbenchContribution {
 	constructor(
@@ -229,6 +230,7 @@ class LocalTerminalBackend extends BaseTerminalBackend implements ITerminalBacke
 		return this._localPtyService.getProfiles?.(this._workspaceContextService.getWorkspace().id, profiles, defaultProfile, includeDetectedProfiles) || [];
 	}
 
+	@memoize
 	async getEnvironment(): Promise<IProcessEnvironment> {
 		return this._proxy.getEnvironment();
 	}


### PR DESCRIPTION
This speeds up profile resolving/terminal startup:

- `PtyService.getEnvironment` is only called a single time as the value shouldn't change
- `PtyService.resize` is never called using the same args consecutively (per terminal)

Part of #133542
Fixes #185379