### PR TITLE
Don't fire PtyService.onDidChangeProperty twice

### DIFF
--- a/src/vs/platform/terminal/node/ptyService.ts
+++ b/src/vs/platform/terminal/node/ptyService.ts
@@ -270,7 +270,6 @@ export class PtyService extends Disposable implements IPtyService {
 			options
 		};
 		const persistentProcess = new PersistentTerminalProcess(id, process, workspaceId, workspaceName, shouldPersist, cols, rows, processLaunchOptions, unicodeVersion, this._reconnectConstants, this._logService, isReviving && typeof shellLaunchConfig.initialText === 'string' ? shellLaunchConfig.initialText : undefined, rawReviveBuffer, shellLaunchConfig.icon, shellLaunchConfig.color, shellLaunchConfig.name, shellLaunchConfig.fixedDimensions);
-		process.onDidChangeProperty(property => this._onDidChangeProperty.fire({ id, property }));
 		process.onProcessExit(event => {
 			persistentProcess.dispose();
 			this._ptys.delete(id);


### PR DESCRIPTION
Fixes #185396

Before

<img width="803" alt="Screenshot 2023-06-16 at 3 49 36 pm" src="https://github.com/microsoft/vscode/assets/2193314/d6fe6d05-0399-4857-a63f-6fc377aa9d77">

After

<img width="922" alt="Screenshot 2023-06-16 at 3 54 19 pm" src="https://github.com/microsoft/vscode/assets/2193314/b0b821df-48e9-4fa6-9082-00a21f2a755d">
