### PR TITLE
Fix #182014: ISO Date format

### DIFF
--- a/src/vs/workbench/contrib/extensions/browser/extensionEditor.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionEditor.ts
@@ -945,22 +945,25 @@ export class ExtensionEditor extends EditorPane {
 		append(moreInfoContainer, $('.additional-details-title', undefined, localize('Marketplace Info', "More Info")));
 		const moreInfo = append(moreInfoContainer, $('.more-info'));
 		if (gallery) {
+			const pub = new Date(gallery.releaseDate);
+			const last_rel = new Date(gallery.lastUpdated);
 			append(moreInfo,
 				$('.more-info-entry', undefined,
 					$('div', undefined, localize('published', "Published")),
-					$('div', undefined, new Date(gallery.releaseDate).toLocaleString(language, { hourCycle: 'h23' }))
+					$('div', undefined, [pub.getFullYear(), pub.getMonth() + 1, pub.getDate()].join('-').concat(', ' + pub.toLocaleTimeString(language, { hourCycle: 'h23' })))
 				),
 				$('.more-info-entry', undefined,
 					$('div', undefined, localize('last released', "Last released")),
-					$('div', undefined, new Date(gallery.lastUpdated).toLocaleString(language, { hourCycle: 'h23' }))
+					$('div', undefined, [last_rel.getFullYear(), last_rel.getMonth() + 1, last_rel.getDate()].join('-').concat(', ' + last_rel.toLocaleTimeString(language, { hourCycle: 'h23' })))
 				)
 			);
 		}
 		if (extension.local && extension.local.installedTimestamp) {
+			const last_up = new Date(extension.local.installedTimestamp);
 			append(moreInfo,
 				$('.more-info-entry', undefined,
 					$('div', undefined, localize('last updated', "Last updated")),
-					$('div', undefined, new Date(extension.local.installedTimestamp).toLocaleString(language, { hourCycle: 'h23' }))
+					$('div', undefined, [last_up.getFullYear(), last_up.getMonth() + 1, last_up.getDate()].join('-').concat(', ' + last_up.toLocaleTimeString(language, { hourCycle: 'h23' })))
 				)
 			);
 		}


### PR DESCRIPTION
Fixes #182014 

This change addresses the date formatting on the Extensions page to align with `ISO-8601` `(yyyy/mm/dd)`.

Sample Output:

![ISO_format](https://github.com/microsoft/vscode/assets/89381263/4b4309a3-47a3-4db3-9060-750ccabd0d3e)


<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
