### PR TITLE
Add server message to user-facing error on 429 for tunnel creation

### DIFF
--- a/cli/src/commands/args.rs
+++ b/cli/src/commands/args.rs
@@ -611,7 +611,7 @@ pub enum TunnelSubcommand {
 	/// Restarts any running tunnel on the system.
 	Restart,
 
-	/// Gets whether there is a tunnel running on the current machineiou.
+	/// Gets whether there is a tunnel running on the current machine.
 	Status,
 
 	/// Rename the name of this machine associated with port forwarding service.

--- a/cli/src/tunnels/dev_tunnels.rs
+++ b/cli/src/tunnels/dev_tunnels.rs
@@ -471,9 +471,8 @@ impl DevTunnels {
 						continue;
 					}
 
-					let error_details = e.get_details();
-					if error_details.is_some() {
-						let detail = error_details.unwrap().detail.unwrap_or("unknown".to_string());
+					if let Some(d) = e.get_details() {
+						let detail = d.detail.unwrap_or("unknown".to_string());
 						return Err(AnyError::from(TunnelCreationFailed(
 							name.to_string(),
 							detail,

--- a/cli/src/tunnels/dev_tunnels.rs
+++ b/cli/src/tunnels/dev_tunnels.rs
@@ -471,9 +471,18 @@ impl DevTunnels {
 						continue;
 					}
 
+					let error_details = e.get_details();
+					if error_details.is_some() {
+						let detail = error_details.unwrap().detail.unwrap_or("unknown".to_string());
+						return Err(AnyError::from(TunnelCreationFailed(
+							name.to_string(),
+							detail,
+						)));
+					}
+
 					return Err(AnyError::from(TunnelCreationFailed(
 						name.to_string(),
-						"You've exceeded the 10 machine limit for the port fowarding service. Please remove other machines before trying to add this machine.".to_string(),
+						"You have exceeded a limit for the port fowarding service. Please remove other machines before trying to add this machine.".to_string(),
 					)));
 				}
 				Err(e) => {

--- a/cli/src/tunnels/dev_tunnels.rs
+++ b/cli/src/tunnels/dev_tunnels.rs
@@ -472,7 +472,7 @@ impl DevTunnels {
 					}
 
 					if let Some(d) = e.get_details() {
-						let detail = d.detail.unwrap_or("unknown".to_string());
+						let detail = d.detail.unwrap_or_else(|| "unknown".to_string());
 						return Err(AnyError::from(TunnelCreationFailed(
 							name.to_string(),
 							detail,


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

See issue: #185598

I tested this by running the CLI against a test server that would return a custom limit error. Although the equivalent behavior is not generally available, you can at least test part of this change by creating 10+ tunnels, then running the CLI to create another.

Output from my testing:
```
❯ .\target\debug\code.exe tunnel
✔ What would you like to call this machine? · my-tunnel
[2023-06-19 10:31:41] info Creating tunnel with the name: my-tunnel
[2023-06-19 10:31:42] error Could not create tunnel with name: my-tunnel
Reason: The request was denied because it would exceed the limit for 'User Bandwidth Consumption' (500MB/M).
```