### PR TITLE
Explicitly clear web resources clipboard on copy

### DIFF
--- a/src/vs/editor/contrib/dropOrPasteInto/browser/copyPasteController.ts
+++ b/src/vs/editor/contrib/dropOrPasteInto/browser/copyPasteController.ts
@@ -114,7 +114,18 @@ export class CopyPasteController extends Disposable implements IEditorContributi
 	}
 
 	private handleCopy(e: ClipboardEvent) {
-		if (!e.clipboardData || !this._editor.hasTextFocus() || !this.isPasteAsEnabled()) {
+		if (!this._editor.hasTextFocus()) {
+			return;
+		}
+
+		if (platform.isWeb) {
+			// Explicitly clear the web resources clipboard.
+			// This is needed because on web, the browser clipboard is faked out using an in-memory store.
+			// This means the resources clipboard is not properly updated when copying from the editor.
+			this._clipboardService.writeResources([]);
+		}
+
+		if (!e.clipboardData || !this.isPasteAsEnabled()) {
 			return;
 		}
 


### PR DESCRIPTION
Fixes #185466

Proper fix would be to use a future web clipboard API that lets you write any data types to the system clipboard. However this API does not currently exist :/

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
