### PR TITLE
Measure and report basic terminal performance marks

### DIFF
--- a/src/vs/workbench/contrib/performance/browser/perfviewEditor.ts
+++ b/src/vs/workbench/contrib/performance/browser/perfviewEditor.ts
@@ -25,6 +25,7 @@ import { ByteSize, IFileService } from 'vs/platform/files/common/files';
 import { ILabelService } from 'vs/platform/label/common/label';
 import { isWeb } from 'vs/base/common/platform';
 import { IFilesConfigurationService } from 'vs/workbench/services/filesConfiguration/common/filesConfigurationService';
+import { ITerminalService } from 'vs/workbench/contrib/terminal/browser/terminal';
 
 export class PerfviewContrib {
 
@@ -87,7 +88,8 @@ class PerfModelContentProvider implements ITextModelContentProvider {
 		@ILifecycleService private readonly _lifecycleService: ILifecycleService,
 		@ITimerService private readonly _timerService: ITimerService,
 		@IExtensionService private readonly _extensionService: IExtensionService,
-		@IProductService private readonly _productService: IProductService
+		@IProductService private readonly _productService: IProductService,
+		@ITerminalService private readonly _terminalService: ITerminalService
 	) { }
 
 	provideTextContent(resource: URI): Promise<ITextModel> {
@@ -113,7 +115,8 @@ class PerfModelContentProvider implements ITextModelContentProvider {
 		Promise.all([
 			this._timerService.whenReady(),
 			this._lifecycleService.when(LifecyclePhase.Eventually),
-			this._extensionService.whenInstalledExtensionsRegistered()
+			this._extensionService.whenInstalledExtensionsRegistered(),
+			this._terminalService.whenConnected
 		]).then(() => {
 			if (this._model && !this._model.isDisposed()) {
 
@@ -233,7 +236,7 @@ class PerfModelContentProvider implements ITextModelContentProvider {
 				md.value += `${name}\t${startTime}\t${delta}\t${total}\n`;
 				lastStartTime = startTime;
 			}
-			md.value += '```\n';
+			md.value += '```\n\n';
 		}
 	}
 

--- a/src/vs/workbench/contrib/performance/browser/perfviewEditor.ts
+++ b/src/vs/workbench/contrib/performance/browser/perfviewEditor.ts
@@ -236,7 +236,7 @@ class PerfModelContentProvider implements ITextModelContentProvider {
 				md.value += `${name}\t${startTime}\t${delta}\t${total}\n`;
 				lastStartTime = startTime;
 			}
-			md.value += '```\n\n';
+			md.value += '```\n';
 		}
 	}
 

--- a/src/vs/workbench/contrib/terminal/browser/terminal.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminal.ts
@@ -157,6 +157,7 @@ export interface ITerminalService extends ITerminalInstanceHost {
 	configHelper: ITerminalConfigHelper;
 	isProcessSupportRegistered: boolean;
 	readonly connectionState: TerminalConnectionState;
+	readonly whenConnected: Promise<void>;
 	readonly defaultLocation: TerminalLocation;
 
 	onDidChangeActiveGroup: Event<ITerminalGroup | undefined>;


### PR DESCRIPTION
Part of #185393

@jrieken changes to timer service:

- Terminal reconnection typically happens after restored, this seems preferable to delaying `LifecyclePhase.Restored`. I also looked into including terminal stats in `IStartupMetrics.timers` but that's a layer breaker.

---

Example output below which shows `getTerminalLayout` info and the first `recreateTerminal` take a long time, the latter is quite unexpected.

## Raw Perf Marks: terminal

```
Name	Timestamp	Delta	Total
code/terminal/willGetTerminalBackend	1726.2000000029802	0	0
code/terminal/didGetTerminalBackend	1744.1000000089407	17.900000005960464	17.900000005960464
code/terminal/willReconnect	1744.1000000089407	0	17.900000005960464
code/terminal/willGetTerminalLayoutInfo	1744.9000000059605	0.7999999970197678	18.700000002980232
code/terminal/didGetTerminalLayoutInfo	2035.2000000029802	290.29999999701977	309
code/terminal/willRecreateTerminalGroups	2035.2000000029802	0	309
code/terminal/willRecreateTerminal/5	2035.2000000029802	0	309
code/terminal/didRecreateTerminal/5	2351.6000000089407	316.40000000596046	625.4000000059605
code/terminal/willRecreateTerminal/6	2351.7000000029802	0.09999999403953552	625.5
code/terminal/didRecreateTerminal/6	2364.9000000059605	13.200000002980232	638.7000000029802
code/terminal/willRecreateTerminal/7	2366.800000011921	1.9000000059604645	640.6000000089407
code/terminal/didRecreateTerminal/7	2371.9000000059605	5.0999999940395355	645.7000000029802
code/terminal/willRecreateTerminal/8	2374.1000000089407	2.2000000029802322	647.9000000059605
code/terminal/didRecreateTerminal/8	2381.5	7.399999991059303	655.2999999970198
code/terminal/willRecreateTerminal/9	2384	2.5	657.7999999970198
code/terminal/didRecreateTerminal/9	2391.1000000089407	7.100000008940697	664.9000000059605
code/terminal/didRecreateTerminalGroups	2394.6000000089407	3.5	668.4000000059605
code/terminal/didReconnect	2396	1.3999999910593033	669.7999999970198
```