### PR TITLE
remote: fix first half of svg icons not loading

### DIFF
--- a/src/vs/workbench/browser/web.api.ts
+++ b/src/vs/workbench/browser/web.api.ts
@@ -826,5 +826,5 @@ export interface IRemoteResourceRequest {
 	/**
 	 * A method called by the editor to issue a response to the request.
 	 */
-	respondWith(statusCode: number, body: Uint8Array): void;
+	respondWith(statusCode: number, body: Uint8Array, headers: Record<string, string>): void;
 }


### PR DESCRIPTION
For https://github.com/microsoft/vscode/issues/184858

Svg's won't display if their response doesn't have the right content-type. Requires adoption in vscode.dev.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
