### PR TITLE
remote: allow loading resources for managed remote authorities

### DIFF
--- a/src/vs/base/common/network.ts
+++ b/src/vs/base/common/network.ts
@@ -53,6 +53,8 @@ export namespace Schemas {
 
 	export const vscodeRemoteResource = 'vscode-remote-resource';
 
+	export const vscodeManagedRemoteResource = 'vscode-managed-remote-resource';
+
 	export const vscodeUserData = 'vscode-userdata';
 
 	export const vscodeCustomEditor = 'vscode-custom-editor';

--- a/src/vs/code/electron-sandbox/workbench/workbench-dev.html
+++ b/src/vs/code/electron-sandbox/workbench/workbench-dev.html
@@ -14,6 +14,7 @@
 					data:
 					blob:
 					vscode-remote-resource:
+					vscode-managed-remote-resource:
 					https:
 				;
 				media-src
@@ -40,6 +41,7 @@
 				font-src
 					'self'
 					vscode-remote-resource:
+					vscode-managed-remote-resource:
 				;
 				require-trusted-types-for
 					'script'

--- a/src/vs/code/electron-sandbox/workbench/workbench.html
+++ b/src/vs/code/electron-sandbox/workbench/workbench.html
@@ -14,6 +14,7 @@
 					data:
 					blob:
 					vscode-remote-resource:
+					vscode-managed-remote-resource:
 					https:
 				;
 				media-src
@@ -40,6 +41,7 @@
 				font-src
 					'self'
 					vscode-remote-resource:
+					vscode-managed-remote-resource:
 				;
 				require-trusted-types-for
 					'script'

--- a/src/vs/platform/remote/common/electronRemoteResources.ts
+++ b/src/vs/platform/remote/common/electronRemoteResources.ts
@@ -1,0 +1,35 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { UriComponents } from 'vs/base/common/uri';
+import { Client, IClientRouter, IConnectionHub } from 'vs/base/parts/ipc/common/ipc';
+
+export const NODE_REMOTE_RESOURCE_IPC_METHOD_NAME = 'request';
+
+export const NODE_REMOTE_RESOURCE_CHANNEL_NAME = 'remoteResourceHandler';
+
+export type NodeRemoteResourceResponse = { body: /* base64 */ string; mimeType?: string; statusCode: number };
+
+export class NodeRemoteResourceRouter implements IClientRouter<string> {
+	async routeCall(hub: IConnectionHub<string>, command: string, arg?: any): Promise<Client<string>> {
+		if (command !== NODE_REMOTE_RESOURCE_IPC_METHOD_NAME) {
+			throw new Error(`Call not found: ${command}`);
+		}
+
+		const uri = arg[0] as (UriComponents | undefined);
+		if (uri?.authority) {
+			const connection = hub.connections.find(c => c.ctx === uri.authority);
+			if (connection) {
+				return connection;
+			}
+		}
+
+		throw new Error(`Caller not found`);
+	}
+
+	routeEvent(_: IConnectionHub<string>, event: string): Promise<Client<string>> {
+		throw new Error(`Event not found: ${event}`);
+	}
+}

--- a/src/vs/platform/remote/electron-sandbox/electronRemoteResourceLoader.ts
+++ b/src/vs/platform/remote/electron-sandbox/electronRemoteResourceLoader.ts
@@ -1,0 +1,72 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { VSBuffer, encodeBase64 } from 'vs/base/common/buffer';
+import { Event } from 'vs/base/common/event';
+import { Disposable } from 'vs/base/common/lifecycle';
+import { getMediaOrTextMime } from 'vs/base/common/mime';
+import { Schemas } from 'vs/base/common/network';
+import { URI } from 'vs/base/common/uri';
+import { IServerChannel } from 'vs/base/parts/ipc/common/ipc';
+import { FileOperationError, FileOperationResult, IFileContent, IFileService } from 'vs/platform/files/common/files';
+import { IMainProcessService } from 'vs/platform/ipc/common/mainProcessService';
+import { NODE_REMOTE_RESOURCE_CHANNEL_NAME, NODE_REMOTE_RESOURCE_IPC_METHOD_NAME, NodeRemoteResourceResponse } from 'vs/platform/remote/common/electronRemoteResources';
+
+export class ElectronRemoteResourceLoader extends Disposable {
+	constructor(
+		private readonly windowId: number,
+		@IMainProcessService mainProcessService: IMainProcessService,
+		@IFileService private readonly fileService: IFileService,
+	) {
+		super();
+
+		const channel: IServerChannel = {
+			listen<T>(_: unknown, event: string): Event<T> {
+				throw new Error(`Event not found: ${event}`);
+			},
+
+			call: (_: unknown, command: string, arg?: any): Promise<any> => {
+				switch (command) {
+					case NODE_REMOTE_RESOURCE_IPC_METHOD_NAME: return this.doRequest(URI.revive(arg[0]));
+				}
+
+				throw new Error(`Call not found: ${command}`);
+			}
+		};
+
+		mainProcessService.registerChannel(NODE_REMOTE_RESOURCE_CHANNEL_NAME, channel);
+	}
+
+	private async doRequest(uri: URI): Promise<NodeRemoteResourceResponse> {
+		let content: IFileContent;
+		try {
+			const params = new URLSearchParams(uri.query);
+			const actual = uri.with({
+				scheme: params.get('scheme')!,
+				authority: params.get('authority')!,
+				query: '',
+			});
+			content = await this.fileService.readFile(actual);
+		} catch (e) {
+			const str = encodeBase64(VSBuffer.fromString(e.message));
+			if (e instanceof FileOperationError && e.fileOperationResult === FileOperationResult.FILE_NOT_FOUND) {
+				return { statusCode: 404, body: str };
+			} else {
+				return { statusCode: 500, body: str };
+			}
+		}
+
+		const mimeType = uri.path && getMediaOrTextMime(uri.path);
+		return { statusCode: 200, body: encodeBase64(content.value), mimeType };
+	}
+
+	public getResourceUriProvider() {
+		return (uri: URI) => uri.with({
+			scheme: Schemas.vscodeRemoteResource,
+			authority: `window:${this.windowId}`,
+			query: new URLSearchParams({ authority: uri.authority, scheme: uri.scheme }).toString(),
+		});
+	}
+}

--- a/src/vs/platform/remote/test/electron-sandbox/remoteAuthorityResolverService.test.ts
+++ b/src/vs/platform/remote/test/electron-sandbox/remoteAuthorityResolverService.test.ts
@@ -12,7 +12,7 @@ import { RemoteAuthorityResolverService } from 'vs/platform/remote/electron-sand
 suite('RemoteAuthorityResolverService', () => {
 	test('issue #147318: RemoteAuthorityResolverError keeps the same type', async () => {
 		const productService: IProductService = { _serviceBrand: undefined, ...product };
-		const service = new RemoteAuthorityResolverService(productService);
+		const service = new RemoteAuthorityResolverService(productService, undefined as any);
 		const result = service.resolveAuthority('test+x');
 		service._setResolvedAuthorityError('test+x', new RemoteAuthorityResolverError('something', RemoteAuthorityResolverErrorCode.TemporarilyNotAvailable));
 		try {

--- a/src/vs/workbench/electron-sandbox/desktop.main.ts
+++ b/src/vs/workbench/electron-sandbox/desktop.main.ts
@@ -57,6 +57,7 @@ import { UserDataProfileService } from 'vs/workbench/services/userDataProfile/co
 import { IUserDataProfileService } from 'vs/workbench/services/userDataProfile/common/userDataProfile';
 import { BrowserSocketFactory } from 'vs/platform/remote/browser/browserSocketFactory';
 import { RemoteSocketFactoryService, IRemoteSocketFactoryService } from 'vs/platform/remote/common/remoteSocketFactoryService';
+import { ElectronRemoteResourceLoader } from 'vs/platform/remote/electron-sandbox/electronRemoteResourceLoader';
 
 export class DesktopMain extends Disposable {
 
@@ -197,11 +198,6 @@ export class DesktopMain extends Disposable {
 		const utilityProcessWorkerWorkbenchService = new UtilityProcessWorkerWorkbenchService(this.configuration.windowId, logService, mainProcessService);
 		serviceCollection.set(IUtilityProcessWorkerWorkbenchService, utilityProcessWorkerWorkbenchService);
 
-		// Remote
-		const remoteAuthorityResolverService = new RemoteAuthorityResolverService(productService);
-		serviceCollection.set(IRemoteAuthorityResolverService, remoteAuthorityResolverService);
-
-
 		// !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 		//
 		// NOTE: Please do NOT register services here. Use `registerSingleton()`
@@ -219,6 +215,10 @@ export class DesktopMain extends Disposable {
 		// Files
 		const fileService = this._register(new FileService(logService));
 		serviceCollection.set(IWorkbenchFileService, fileService);
+
+		// Remote
+		const remoteAuthorityResolverService = new RemoteAuthorityResolverService(productService, new ElectronRemoteResourceLoader(environmentService.window.id, mainProcessService, fileService));
+		serviceCollection.set(IRemoteAuthorityResolverService, remoteAuthorityResolverService);
 
 		// Local Files
 		const diskFileSystemProvider = this._register(new DiskFileSystemProvider(mainProcessService, utilityProcessWorkerWorkbenchService, logService));


### PR DESCRIPTION
This implements basically the same 'loopback' that vscode.dev does via
a service worker to load resources for managed remote authorities in
Electron. Except instead of using a service worker, it uses a buffer
protocol via a new 'vscode-managed-remote-resource' scheme. It finds
the window that the request came from and asks it to load the remote
file.

I initially looked at folding it into the existing 'vscode-remote-resource'
scheme, but we needed a "buffer protocol" for this and it seems http
protocols can _only_ respond with an HTTP URL, which we don't want here.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
