### PR TITLE
chore: add arm64 emulation property to perf telemetry

### DIFF
--- a/src/vs/platform/native/common/native.ts
+++ b/src/vs/platform/native/common/native.ts
@@ -116,6 +116,7 @@ export interface ICommonNativeHostService {
 
 	isAdmin(): Promise<boolean>;
 	writeElevated(source: URI, target: URI, options?: { unlock?: boolean }): Promise<void>;
+	isRunningUnderARM64Translation(): Promise<boolean>;
 
 	getOSProperties(): Promise<IOSProperties>;
 	getOSStatistics(): Promise<IOSStatistics>;

--- a/src/vs/platform/native/electron-main/nativeHostMainService.ts
+++ b/src/vs/platform/native/electron-main/nativeHostMainService.ts
@@ -521,6 +521,13 @@ export class NativeHostMainService extends Disposable implements INativeHostMain
 		});
 	}
 
+	async isRunningUnderARM64Translation(): Promise<boolean> {
+		if (isLinux) {
+			return false;
+		}
+		return app.runningUnderARM64Translation;
+	}
+
 	@memoize
 	private get cliPath(): string {
 

--- a/src/vs/workbench/services/timer/browser/timerService.ts
+++ b/src/vs/workbench/services/timer/browser/timerService.ts
@@ -78,7 +78,8 @@ export interface IMemoryInfo {
 		"hasAccessibilitySupport" : { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "isMeasurement": true },
 		"isVMLikelyhood" : { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "isMeasurement": true },
 		"emptyWorkbench" : { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "isMeasurement": true },
-		"loadavg" : { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth" }
+		"loadavg" : { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth" },
+		"isARM64Emulated" : { "classification": "SystemMetaData", "purpose": "PerformanceAndHealth", "isMeasurement": true }
 	}
 */
 export interface IStartupMetrics {
@@ -388,6 +389,7 @@ export interface IStartupMetrics {
 	readonly meminfo?: IMemoryInfo;
 	readonly cpus?: { count: number; speed: number; model: string };
 	readonly loadavg?: number[];
+	readonly isARM64Emulated?: boolean;
 }
 
 export interface ITimerService {
@@ -727,6 +729,7 @@ export class TimerService extends AbstractTimerService {
 	}
 	protected async _extendStartupInfo(info: Writeable<IStartupMetrics>): Promise<void> {
 		info.isVMLikelyhood = 0;
+		info.isARM64Emulated = false;
 		info.platform = navigator.userAgent;
 		info.release = navigator.appVersion;
 	}

--- a/src/vs/workbench/services/timer/electron-sandbox/timerService.ts
+++ b/src/vs/workbench/services/timer/electron-sandbox/timerService.ts
@@ -53,10 +53,11 @@ export class TimerService extends AbstractTimerService {
 
 	protected async _extendStartupInfo(info: Writeable<IStartupMetrics>): Promise<void> {
 		try {
-			const [osProperties, osStatistics, virtualMachineHint] = await Promise.all([
+			const [osProperties, osStatistics, virtualMachineHint, isARM64Emulated] = await Promise.all([
 				this._nativeHostService.getOSProperties(),
 				this._nativeHostService.getOSStatistics(),
-				this._nativeHostService.getOSVirtualMachineHint()
+				this._nativeHostService.getOSVirtualMachineHint(),
+				this._nativeHostService.isRunningUnderARM64Translation()
 			]);
 
 			info.totalmem = osStatistics.totalmem;
@@ -65,6 +66,7 @@ export class TimerService extends AbstractTimerService {
 			info.release = osProperties.release;
 			info.arch = osProperties.arch;
 			info.loadavg = osStatistics.loadavg;
+			info.isARM64Emulated = isARM64Emulated;
 
 			const processMemoryInfo = await process.getProcessMemoryInfo();
 			info.meminfo = {

--- a/src/vs/workbench/test/electron-sandbox/workbenchTestServices.ts
+++ b/src/vs/workbench/test/electron-sandbox/workbenchTestServices.ts
@@ -107,6 +107,7 @@ export class TestNativeHostService implements INativeHostService {
 	async setRepresentedFilename(path: string): Promise<void> { }
 	async isAdmin(): Promise<boolean> { return false; }
 	async writeElevated(source: URI, target: URI): Promise<void> { }
+	async isRunningUnderARM64Translation(): Promise<boolean> { return false; }
 	async getOSProperties(): Promise<IOSProperties> { return Object.create(null); }
 	async getOSStatistics(): Promise<IOSStatistics> { return Object.create(null); }
 	async getOSVirtualMachineHint(): Promise<number> { return 0; }


### PR DESCRIPTION
Follow-up to https://github.com/microsoft/vscode/pull/181191