### PR TITLE
Fix the case of the placeholder

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/breakpointWidget.ts
+++ b/src/vs/workbench/contrib/debug/browser/breakpointWidget.ts
@@ -132,11 +132,11 @@ export class BreakpointWidget extends ZoneWidget implements IPrivateBreakpointWi
 	private get placeholder(): string {
 		switch (this.context) {
 			case Context.LOG_MESSAGE:
-				return nls.localize('breakpointWidgetLogMessagePlaceholder', "Message to log when breakpoint is hit. Expressions within {} are interpolated. 'Enter' to accept, 'esc' to cancel.");
+				return nls.localize('breakpointWidgetLogMessagePlaceholder', "Message to log when breakpoint is hit. Expressions within {} are interpolated. 'Enter' to accept, 'Esc' to cancel.");
 			case Context.HIT_COUNT:
-				return nls.localize('breakpointWidgetHitCountPlaceholder', "Break when hit count condition is met. 'Enter' to accept, 'esc' to cancel.");
+				return nls.localize('breakpointWidgetHitCountPlaceholder', "Break when hit count condition is met. 'Enter' to accept, 'Esc' to cancel.");
 			default:
-				return nls.localize('breakpointWidgetExpressionPlaceholder', "Break when expression evaluates to true. 'Enter' to accept, 'esc' to cancel.");
+				return nls.localize('breakpointWidgetExpressionPlaceholder', "Break when expression evaluates to true. 'Enter' to accept, 'Esc' to cancel.");
 		}
 	}
 


### PR DESCRIPTION
The placeholder of the breakpoint expression input is different for 'Enter' and 'esc'. So I have updated the 'esc' => 'Esc' as that's what how they mention it on keyboard.

![image](https://github.com/microsoft/vscode/assets/50770619/41f62e4c-f319-4ef6-9f89-08f9bab155ae)
