### PR TITLE
cli: fix error starting remote tunnels

### DIFF
--- a/src/vs/platform/remoteTunnel/node/remoteTunnelService.ts
+++ b/src/vs/platform/remoteTunnel/node/remoteTunnelService.ts
@@ -340,13 +340,13 @@ export class RemoteTunnelService extends Disposable implements IRemoteTunnelServ
 					}
 				});
 				if (!this.environmentService.isBuilt) {
-					onOutput('Building tunnel CLI from sources and run', false);
-					onOutput(`${logLabel} Spawning: cargo run -- tunnel ${commandArgs.join(' ')}`, false);
+					onOutput('Building tunnel CLI from sources and run\n', false);
+					onOutput(`${logLabel} Spawning: cargo run -- tunnel ${commandArgs.join(' ')}\n`, false);
 					tunnelProcess = spawn('cargo', ['run', '--', 'tunnel', ...commandArgs], { cwd: join(this.environmentService.appRoot, 'cli'), stdio });
 				} else {
-					onOutput('Running tunnel CLI', false);
+					onOutput('Running tunnel CLI\n', false);
 					const tunnelCommand = this.getTunnelCommandLocation();
-					onOutput(`${logLabel} Spawning: ${tunnelCommand} tunnel ${commandArgs.join(' ')}`, false);
+					onOutput(`${logLabel} Spawning: ${tunnelCommand} tunnel ${commandArgs.join(' ')}\n`, false);
 					tunnelProcess = spawn(tunnelCommand, ['tunnel', ...commandArgs], { cwd: homedir(), stdio });
 				}
 


### PR DESCRIPTION
Fixes #185585

Output was prefixed which prevented the lines from being split to detect the tunnel status.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
