### PR TITLE
Update markdown h1-h6 styles

### DIFF
--- a/extensions/markdown-language-features/media/markdown.css
+++ b/extensions/markdown-language-features/media/markdown.css
@@ -21,9 +21,11 @@ p, ol, ul, pre {
 	margin-top: 0;
 }
 
-h2, h3, h4, h5, h6 {
-	font-weight: normal;
-	margin-bottom: 0.2em;
+h1, h2, h3, h4, h5, h6 {
+	font-weight: 600;
+	margin-top: 24px;
+	margin-bottom: 16px;
+	line-height: 1.25;
 }
 
 #code-csp-warning {
@@ -133,7 +135,7 @@ textarea:focus {
 }
 
 p {
-	margin-bottom: 0.7em;
+	margin-bottom: 16px;
 }
 
 ul,
@@ -148,11 +150,34 @@ hr {
 }
 
 h1 {
+	font-size: 2em;
+	margin-top: 0;
 	padding-bottom: 0.3em;
-	line-height: 1.2;
 	border-bottom-width: 1px;
 	border-bottom-style: solid;
-	font-weight: normal;
+}
+
+h2 {
+	font-size: 1.5em;
+	padding-bottom: 0.3em;
+	border-bottom-width: 1px;
+	border-bottom-style: solid;
+}
+
+h3 {
+	font-size: 1.25em;
+}
+
+h4 {
+	font-size: 1em;
+}
+
+h5 {
+	font-size: 0.875em;
+}
+
+h6 {
+	font-size: 0.85em;
 }
 
 table {
@@ -222,12 +247,14 @@ pre {
 }
 
 .vscode-light h1,
+.vscode-light h2,
 .vscode-light hr,
 .vscode-light td {
 	border-color: rgba(0, 0, 0, 0.18);
 }
 
 .vscode-dark h1,
+.vscode-dark h2,
 .vscode-dark hr,
 .vscode-dark td {
 	border-color: rgba(255, 255, 255, 0.18);

--- a/extensions/markdown-language-features/media/markdown.css
+++ b/extensions/markdown-language-features/media/markdown.css
@@ -145,8 +145,8 @@ ol {
 
 hr {
 	border: 0;
-	height: 2px;
-	border-bottom: 2px solid;
+	height: 1px;
+	border-bottom: 1px solid;
 }
 
 h1 {


### PR DESCRIPTION
Fixes #185768

<img width="1272" alt="CleanShot 2023-06-21 at 10 54 54@2x" src="https://github.com/microsoft/vscode/assets/25163139/9edc146d-7f29-43ee-a73e-9172f4c4072e">
