### PR TITLE
Add `Go To Recently Run Cell` action to nb toolbar

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/controller/editActions.ts
+++ b/src/vs/workbench/contrib/notebook/browser/controller/editActions.ts
@@ -290,7 +290,7 @@ registerAction2(class ClearAllCellOutputsAction extends NotebookAction {
 						ContextKeyExpr.equals('config.notebook.globalToolbar', true)
 					),
 					group: 'navigation/execute',
-					order: 0
+					order: 20
 				}
 			],
 			icon: icons.clearIcon

--- a/src/vs/workbench/contrib/notebook/browser/notebookIcons.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookIcons.ts
@@ -35,3 +35,4 @@ export const mimetypeIcon = registerIcon('notebook-mimetype', Codicon.code, loca
 export const previousChangeIcon = registerIcon('notebook-diff-editor-previous-change', Codicon.arrowUp, localize('previousChangeIcon', 'Icon for the previous change action in the diff editor.'));
 export const nextChangeIcon = registerIcon('notebook-diff-editor-next-change', Codicon.arrowDown, localize('nextChangeIcon', 'Icon for the next change action in the diff editor.'));
 
+export const gotoRunCellIcon = registerIcon('notebook-goto-run-cell', Codicon.exportIcon, localize('gotoRunCellIcon', 'Icon to go to the recentrly run cell in notebook editors.'));

--- a/src/vs/workbench/contrib/notebook/common/notebookExecutionStateService.ts
+++ b/src/vs/workbench/contrib/notebook/common/notebookExecutionStateService.ts
@@ -47,7 +47,18 @@ export interface INotebookFailStateChangedEvent {
 	notebook: URI;
 }
 
+export interface INotebookSuccessStateChangedEvent {
+	visible: boolean;
+	notebook: URI;
+}
+
 export interface IFailedCellInfo {
+	cellHandle: number;
+	disposable: IDisposable;
+	visible: boolean;
+}
+
+export interface ISuccessfulCellInfo {
 	cellHandle: number;
 	disposable: IDisposable;
 	visible: boolean;
@@ -69,6 +80,7 @@ export interface INotebookExecutionStateService {
 	getExecution(notebook: URI): INotebookExecution | undefined;
 	createExecution(notebook: URI): INotebookExecution;
 	getLastFailedCellForNotebook(notebook: URI): number | undefined;
+	getLastRunCellForNotebook(notebook: URI): number | undefined;
 }
 
 export interface INotebookCellExecution {

--- a/src/vs/workbench/contrib/notebook/test/browser/testNotebookEditor.ts
+++ b/src/vs/workbench/contrib/notebook/test/browser/testNotebookEditor.ts
@@ -448,6 +448,9 @@ class TestNotebookExecutionStateService implements INotebookExecutionStateServic
 	getLastFailedCellForNotebook(notebook: URI): number | undefined {
 		return;
 	}
+	getLastRunCellForNotebook(notebook: URI): number | undefined {
+		return;
+	}
 	getExecution(notebook: URI): INotebookExecution | undefined {
 		return;
 	}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

re: https://github.com/microsoft/vscode/issues/184194

Addresses issues in execution toolbar with pop-in of actions, and ordering of execution group of notebook toolbar. 

Most recently successful cell execution is tracked within `NotebookExecutionStateService.ts`.

Toolbar ordering values are now as follows:
-  Run All // Restart // Clear Outputs // Go To
-  -1 // 5 // 10 // 20

*with restart contributed by jupyter extension (currently restart value is `@2`, but will be changed with [this PR](https://github.com/microsoft/vscode-jupyter/pull/13750))