### PR TITLE
fix fish shell integration problems

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/media/fish_xdg_data/fish/vendor_conf.d/shellIntegration.fish
+++ b/src/vs/workbench/contrib/terminal/browser/media/fish_xdg_data/fish/vendor_conf.d/shellIntegration.fish
@@ -122,7 +122,6 @@ function __preserve_fish_prompt --on-event fish_prompt
 		end
 	end
 end
-__preserve_fish_prompt
 
 # Sent whenever a new fish prompt is about to be displayed.
 # Updates the current working directory.
@@ -164,11 +163,11 @@ function __init_vscode_shell_integration
 		function fish_mode_prompt
 			__vsc_fish_prompt_start
 			__vsc_fish_mode_prompt
+			__vsc_fish_cmd_start
 		end
 
 		function fish_prompt
 			__vsc_fish_prompt
-			__vsc_fish_cmd_start
 		end
 	else
 		# No fish_mode_prompt, so put everything in fish_prompt.
@@ -179,3 +178,4 @@ function __init_vscode_shell_integration
 		end
 	end
 end
+__preserve_fish_prompt


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
fix #185750

Issue 1:
- Move function invocation below function definitions 

Issue 2:
- When `fish_mode_prompt` is defined, put `__vsc_fish_cmd_start` in that instead of `fish_prompt` so shell integration works
