### PR TITLE
Unify remote menu and start entry items for desktop

### DIFF
--- a/src/vs/workbench/contrib/remote/browser/remoteIndicator.ts
+++ b/src/vs/workbench/contrib/remote/browser/remoteIndicator.ts
@@ -645,7 +645,6 @@ export class RemoteStatusIndicator extends Disposable implements IWorkbenchContr
 			context: { [EXTENSION_INSTALL_SKIP_WALKTHROUGH_CONTEXT]: true }
 		});
 
-		// this.telemetryService.publicLog2<RemoteStartActionEvent, RemoteStartActionClassification>('remoteStartList.ActionExecuted', { command: 'workbench.extensions.installExtension', remoteExtensionId: extensionId });
 		await retry(async () => {
 			const ext = await this.extensionService.getExtension(metadata.id);
 			if (!ext) {
@@ -653,11 +652,13 @@ export class RemoteStatusIndicator extends Disposable implements IWorkbenchContr
 			}
 			return ext;
 		}, 300, 10);
-
-		await this.extensionService.activateByEvent(`onCommand:${metadata.startCommand}`);
 		this.commandService.executeCommand(metadata.startCommand);
 
-		// this.telemetryService.publicLog2<RemoteStartActionEvent, RemoteStartActionClassification>('remoteStartList.ActionExecuted', { command: command, remoteExtensionId: extensionId });
+		this.telemetryService.publicLog2<WorkbenchActionExecutedEvent, WorkbenchActionExecutedClassification>('workbenchActionExecuted', {
+			id: 'remoteInstallAndRun',
+			detail: extensionId,
+			from: 'remote indicator'
+		});
 	}
 
 	private showRemoteMenu() {

--- a/src/vs/workbench/contrib/remote/browser/remoteIndicator.ts
+++ b/src/vs/workbench/contrib/remote/browser/remoteIndicator.ts
@@ -7,7 +7,7 @@ import * as nls from 'vs/nls';
 import { STATUS_BAR_HOST_NAME_BACKGROUND, STATUS_BAR_HOST_NAME_FOREGROUND } from 'vs/workbench/common/theme';
 import { themeColorFromId } from 'vs/platform/theme/common/themeService';
 import { IRemoteAgentService, remoteConnectionLatencyMeasurer } from 'vs/workbench/services/remote/common/remoteAgentService';
-import { RunOnceScheduler } from 'vs/base/common/async';
+import { RunOnceScheduler, retry } from 'vs/base/common/async';
 import { Event } from 'vs/base/common/event';
 import { Disposable, dispose } from 'vs/base/common/lifecycle';
 import { MenuId, IMenuService, MenuItemAction, MenuRegistry, registerAction2, Action2, SubmenuItemAction } from 'vs/platform/actions/common/actions';
@@ -18,12 +18,12 @@ import { ContextKeyExpr, IContextKeyService, RawContextKey } from 'vs/platform/c
 import { ICommandService } from 'vs/platform/commands/common/commands';
 import { Schemas } from 'vs/base/common/network';
 import { IExtensionService } from 'vs/workbench/services/extensions/common/extensions';
-import { QuickPickItem, IQuickInputService } from 'vs/platform/quickinput/common/quickInput';
+import { QuickPickItem, IQuickInputService, IQuickInputButton } from 'vs/platform/quickinput/common/quickInput';
 import { IBrowserWorkbenchEnvironmentService } from 'vs/workbench/services/environment/browser/environmentService';
 import { PersistentConnectionEventType } from 'vs/platform/remote/common/remoteAgentConnection';
 import { IRemoteAuthorityResolverService } from 'vs/platform/remote/common/remoteAuthorityResolver';
 import { IHostService } from 'vs/workbench/services/host/browser/host';
-import { PlatformToString, isWeb, platform } from 'vs/base/common/platform';
+import { PlatformName, PlatformToString, isWeb, platform } from 'vs/base/common/platform';
 import { once } from 'vs/base/common/functional';
 import { truncate } from 'vs/base/common/strings';
 import { IWorkspaceContextService } from 'vs/platform/workspace/common/workspace';
@@ -32,7 +32,7 @@ import { getVirtualWorkspaceLocation } from 'vs/platform/workspace/common/virtua
 import { getCodiconAriaLabel } from 'vs/base/common/iconLabels';
 import { ILogService } from 'vs/platform/log/common/log';
 import { ReloadWindowAction } from 'vs/workbench/browser/actions/windowActions';
-import { IExtensionGalleryService } from 'vs/platform/extensionManagement/common/extensionManagement';
+import { EXTENSION_INSTALL_SKIP_WALKTHROUGH_CONTEXT, IExtensionGalleryService, IExtensionManagementService } from 'vs/platform/extensionManagement/common/extensionManagement';
 import { IExtensionsViewPaneContainer, LIST_WORKSPACE_UNSUPPORTED_EXTENSIONS_COMMAND_ID, VIEWLET_ID } from 'vs/workbench/contrib/extensions/common/extensions';
 import { ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
 import { IMarkdownString, MarkdownString } from 'vs/base/common/htmlContent';
@@ -46,6 +46,12 @@ import { KeyCode, KeyMod } from 'vs/base/common/keyCodes';
 import { IProductService } from 'vs/platform/product/common/productService';
 import { DomEmitter } from 'vs/base/browser/event';
 import { registerColor } from 'vs/platform/theme/common/colorRegistry';
+import { ExtensionIdentifier } from 'vs/platform/extensions/common/extensions';
+import { CancellationToken, CancellationTokenSource } from 'vs/base/common/cancellation';
+import { ThemeIcon } from 'vs/base/common/themables';
+import { infoIcon } from 'vs/workbench/contrib/extensions/browser/extensionsIcons';
+import { IOpenerService } from 'vs/platform/opener/common/opener';
+import { URI } from 'vs/base/common/uri';
 
 export const STATUS_BAR_OFFLINE_BACKGROUND = registerColor('statusBar.offlineBackground', {
 	dark: '#6c1717',
@@ -62,6 +68,19 @@ export const STATUS_BAR_OFFLINE_FOREGROUND = registerColor('statusBar.offlineFor
 }, nls.localize('statusBarOfflineForeground', "Status bar foreground color when the workbench is offline. The status bar is shown in the bottom of the window"));
 
 type ActionGroup = [string, Array<MenuItemAction | SubmenuItemAction>];
+
+interface RemoteExtensionMetadata {
+	id: string;
+	installed: boolean;
+	dependencies: string[];
+	isPlatformCompatible: boolean;
+	helpLink: string;
+	startConnectLabel: string;
+	startCommand: string;
+	priority: number;
+	supportedPlatforms?: PlatformName[];
+}
+
 export class RemoteStatusIndicator extends Disposable implements IWorkbenchContribution {
 
 	private static readonly REMOTE_ACTIONS_COMMAND_ID = 'workbench.action.remote.showMenu';
@@ -93,7 +112,8 @@ export class RemoteStatusIndicator extends Disposable implements IWorkbenchContr
 	private measureNetworkConnectionLatencyScheduler: RunOnceScheduler | undefined = undefined;
 
 	private loggedInvalidGroupNames: { [group: string]: boolean } = Object.create(null);
-
+	private readonly remoteExtensionMetadata: RemoteExtensionMetadata[];
+	private _isInitialized: boolean = false;
 	constructor(
 		@IStatusbarService private readonly statusbarService: IStatusbarService,
 		@IBrowserWorkbenchEnvironmentService private readonly environmentService: IBrowserWorkbenchEnvironmentService,
@@ -111,8 +131,28 @@ export class RemoteStatusIndicator extends Disposable implements IWorkbenchContr
 		@IExtensionGalleryService private readonly extensionGalleryService: IExtensionGalleryService,
 		@ITelemetryService private readonly telemetryService: ITelemetryService,
 		@IProductService private readonly productService: IProductService,
+		@IExtensionManagementService private readonly extensionManagementService: IExtensionManagementService,
+		@IOpenerService private readonly openerService: IOpenerService,
 	) {
 		super();
+
+		const remoteExtensionTips = { ...this.productService.remoteExtensionTips, ...this.productService.virtualWorkspaceExtensionTips };
+		this.remoteExtensionMetadata = Object.values(remoteExtensionTips).filter(value => value.startEntry !== undefined).map(value => {
+			return {
+				id: value.extensionId,
+				installed: false,
+				friendlyName: value.friendlyName,
+				isPlatformCompatible: false,
+				dependencies: [],
+				helpLink: value.startEntry?.helpLink ?? '',
+				startConnectLabel: value.startEntry?.startConnectLabel ?? '',
+				startCommand: value.startEntry?.startCommand ?? '',
+				priority: value.startEntry?.priority ?? 10,
+				supportedPlatforms: value.supportedPlatforms
+			};
+		});
+
+		this.remoteExtensionMetadata.sort((ext1, ext2) => ext1.priority - ext2.priority);
 
 		// Set initial connection state
 		if (this.remoteAuthority) {
@@ -127,6 +167,7 @@ export class RemoteStatusIndicator extends Disposable implements IWorkbenchContr
 
 		this.updateWhenInstalledExtensionsRegistered();
 		this.updateRemoteStatusIndicator();
+		this.initializeRemoteMetadata();
 	}
 
 	private registerActions(): void {
@@ -253,6 +294,53 @@ export class RemoteStatusIndicator extends Disposable implements IWorkbenchContr
 				this._register(new DomEmitter(window, 'offline')).event
 			)(() => this.setNetworkState(navigator.onLine ? 'online' : 'offline')));
 		}
+
+		this._register(this.extensionService.onDidChangeExtensions(async (result) => {
+			for (const ext of result.added) {
+				const index = this.remoteExtensionMetadata.findIndex(value => ExtensionIdentifier.equals(value.id, ext.identifier));
+				if (index > -1) {
+					this.remoteExtensionMetadata[index].installed = true;
+				}
+			}
+		}));
+
+		this._register(this.extensionManagementService.onDidUninstallExtension(async (result) => {
+			const index = this.remoteExtensionMetadata.findIndex(value => ExtensionIdentifier.equals(value.id, result.identifier.id));
+			if (index > -1) {
+				this.remoteExtensionMetadata[index].installed = false;
+			}
+		}));
+	}
+
+	private async initializeRemoteMetadata(): Promise<void> {
+
+		if (this._isInitialized) {
+			return;
+		}
+
+		const currentPlatform = PlatformToString(platform);
+		for (let i = 0; i < this.remoteExtensionMetadata.length; i++) {
+			const extensionId = this.remoteExtensionMetadata[i].id;
+			const supportedPlatforms = this.remoteExtensionMetadata[i].supportedPlatforms;
+			// Update compatibility
+			const token = new CancellationTokenSource();
+			const galleryExtension = (await this.extensionGalleryService.getExtensions([{ id: extensionId }], token.token))[0];
+			if (!await this.extensionManagementService.canInstall(galleryExtension)) {
+				this.remoteExtensionMetadata[i].isPlatformCompatible = false;
+			}
+			else if (supportedPlatforms && !supportedPlatforms.includes(currentPlatform)) {
+				this.remoteExtensionMetadata[i].isPlatformCompatible = false;
+			}
+			else {
+				this.remoteExtensionMetadata[i].isPlatformCompatible = true;
+				this.remoteExtensionMetadata[i].dependencies = galleryExtension.properties.extensionPack ?? [];
+			}
+
+			// Check if installed and enabled
+			this.remoteExtensionMetadata[i].installed = (await this.extensionManagementService.getInstalled()).find(value => ExtensionIdentifier.equals(value.identifier.id, extensionId)) ? true : false;
+		}
+
+		this._isInitialized = true;
 	}
 
 	private updateVirtualWorkspaceLocation() {
@@ -547,6 +635,31 @@ export class RemoteStatusIndicator extends Disposable implements IWorkbenchContr
 		return markdownTooltip;
 	}
 
+	private async installAndRunStartCommand(metadata: RemoteExtensionMetadata) {
+		const extensionId = metadata.id;
+		const galleryExtension = (await this.extensionGalleryService.getExtensions([{ id: extensionId }], CancellationToken.None))[0];
+
+		await this.extensionManagementService.installFromGallery(galleryExtension, {
+			isMachineScoped: false,
+			donotIncludePackAndDependencies: false,
+			context: { [EXTENSION_INSTALL_SKIP_WALKTHROUGH_CONTEXT]: true }
+		});
+
+		// this.telemetryService.publicLog2<RemoteStartActionEvent, RemoteStartActionClassification>('remoteStartList.ActionExecuted', { command: 'workbench.extensions.installExtension', remoteExtensionId: extensionId });
+		await retry(async () => {
+			const ext = await this.extensionService.getExtension(metadata.id);
+			if (!ext) {
+				throw Error('Failed to find installed remote extension');
+			}
+			return ext;
+		}, 300, 10);
+
+		await this.extensionService.activateByEvent(`onCommand:${metadata.startCommand}`);
+		this.commandService.executeCommand(metadata.startCommand);
+
+		// this.telemetryService.publicLog2<RemoteStartActionEvent, RemoteStartActionClassification>('remoteStartList.ActionExecuted', { command: command, remoteExtensionId: extensionId });
+	}
+
 	private showRemoteMenu() {
 		const getCategoryLabel = (action: MenuItemAction) => {
 			if (action.item.category) {
@@ -642,17 +755,29 @@ export class RemoteStatusIndicator extends Disposable implements IWorkbenchContr
 				}
 			}
 
-			if (this.extensionGalleryService.isEnabled() && this.hasAdditionalRemoteExtensions()) {
-				items.push({
-					id: RemoteStatusIndicator.INSTALL_REMOTE_EXTENSIONS_ID,
-					label: nls.localize('installRemotes', "Install Additional Remote Extensions..."),
-
-					alwaysShow: true
-				});
-			}
-
 			if (items.length === entriesBeforeConfig) {
 				items.pop(); // remove the separator again
+			}
+
+			if (this.extensionGalleryService.isEnabled()) {
+
+				const notInstalledItems: QuickPickItem[] = [];
+				for (const metadata of this.remoteExtensionMetadata) {
+					if (!metadata.installed && metadata.isPlatformCompatible) {
+						// Create Install QuickPick with a help link
+						const label = metadata.startConnectLabel;
+						const buttons: IQuickInputButton[] = [{
+							iconClass: ThemeIcon.asClassName(infoIcon),
+							tooltip: nls.localize('remote.startActions.help', "Learn More")
+						}];
+						notInstalledItems.push({ type: 'item', id: metadata.id, label: label, buttons: buttons });
+					}
+				}
+
+				items.push({
+					type: 'separator', label: nls.localize('remote.startActions.install', 'Install')
+				});
+				items.push(...notInstalledItems);
 			}
 
 			return items;
@@ -663,19 +788,35 @@ export class RemoteStatusIndicator extends Disposable implements IWorkbenchContr
 		quickPick.items = computeItems();
 		quickPick.sortByLabel = false;
 		quickPick.canSelectMany = false;
-		once(quickPick.onDidAccept)((_ => {
+		once(quickPick.onDidAccept)((async _ => {
 			const selectedItems = quickPick.selectedItems;
 			if (selectedItems.length === 1) {
 				const commandId = selectedItems[0].id!;
-				this.telemetryService.publicLog2<WorkbenchActionExecutedEvent, WorkbenchActionExecutedClassification>('workbenchActionExecuted', {
-					id: commandId,
-					from: 'remote indicator'
-				});
-				this.commandService.executeCommand(commandId);
+				const remoteExtension = this.remoteExtensionMetadata.find(value => ExtensionIdentifier.equals(value.id, commandId));
+				if (remoteExtension) {
+					quickPick.items = [];
+					quickPick.busy = true;
+					quickPick.placeholder = nls.localize('remote.startActions.installingExtension', 'Installing extension... ');
+					quickPick.hide();
+					await this.installAndRunStartCommand(remoteExtension);
+				}
+				else {
+					this.telemetryService.publicLog2<WorkbenchActionExecutedEvent, WorkbenchActionExecutedClassification>('workbenchActionExecuted', {
+						id: commandId,
+						from: 'remote indicator'
+					});
+					this.commandService.executeCommand(commandId);
+				}
+				quickPick.hide();
 			}
-
-			quickPick.hide();
 		}));
+
+		once(quickPick.onDidTriggerItemButton)(async (e) => {
+			const remoteExtension = this.remoteExtensionMetadata.find(value => ExtensionIdentifier.equals(value.id, e.item.id));
+			if (remoteExtension) {
+				await this.openerService.open(URI.parse(remoteExtension.helpLink));
+			}
+		});
 
 		// refresh the items when actions change
 		const legacyItemUpdater = this.legacyIndicatorMenu.onDidChange(() => quickPick.items = computeItems());
@@ -685,21 +826,6 @@ export class RemoteStatusIndicator extends Disposable implements IWorkbenchContr
 		quickPick.onDidHide(itemUpdater.dispose);
 
 		quickPick.show();
-	}
-
-	private hasAdditionalRemoteExtensions() {
-		const extensionTips = { ...this.productService.remoteExtensionTips, ...this.productService.virtualWorkspaceExtensionTips };
-		const currentPlatform = PlatformToString(platform);
-		for (const extension of Object.values(extensionTips)) {
-			const { extensionId: recommendedExtensionId, supportedPlatforms } = extension;
-			if (!supportedPlatforms || supportedPlatforms.includes(currentPlatform)) {
-				// if this recommended extension isn't already installed, return early
-				if (!this.extensionService.extensions.some((extension) => extension.id?.toLowerCase() === recommendedExtensionId.toLowerCase())) {
-					return true;
-				}
-			}
-		}
-		return false;
 	}
 
 	private hasRemoteMenuCommands(ignoreInstallAdditional: boolean): boolean {

--- a/src/vs/workbench/contrib/remote/browser/remoteStartEntry.contribution.ts
+++ b/src/vs/workbench/contrib/remote/browser/remoteStartEntry.contribution.ts
@@ -1,0 +1,12 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Registry } from 'vs/platform/registry/common/platform';
+import { Extensions as WorkbenchExtensions, IWorkbenchContributionsRegistry } from 'vs/workbench/common/contributions';
+import { LifecyclePhase } from 'vs/workbench/services/lifecycle/common/lifecycle';
+import { RemoteStartEntry } from 'vs/workbench/contrib/remote/browser/remoteStartEntry';
+
+Registry.as<IWorkbenchContributionsRegistry>(WorkbenchExtensions.Workbench)
+	.registerWorkbenchContribution(RemoteStartEntry, LifecyclePhase.Restored);

--- a/src/vs/workbench/contrib/remote/browser/remoteStartEntry.ts
+++ b/src/vs/workbench/contrib/remote/browser/remoteStartEntry.ts
@@ -15,15 +15,14 @@ import { ExtensionIdentifier } from 'vs/platform/extensions/common/extensions';
 import { IWorkbenchExtensionEnablementService } from 'vs/workbench/services/extensionManagement/common/extensionManagement';
 import { IContextKeyService, RawContextKey } from 'vs/platform/contextkey/common/contextkey';
 import { WorkbenchActionExecutedClassification, WorkbenchActionExecutedEvent } from 'vs/base/common/actions';
-import { isWeb } from 'vs/base/common/platform';
 
 export const showStartEntryInWeb = new RawContextKey<boolean>('showRemoteStartEntryInWeb', false);
 export class RemoteStartEntry extends Disposable implements IWorkbenchContribution {
 
 	private static readonly REMOTE_WEB_START_ENTRY_ACTIONS_COMMAND_ID = 'workbench.action.remote.showWebStartEntryActions';
 
-	private readonly remoteExtensionId!: string;
-	private readonly startCommand!: string;
+	private readonly remoteExtensionId: string;
+	private readonly startCommand: string;
 
 	constructor(
 		@ICommandService private readonly commandService: ICommandService,
@@ -34,16 +33,10 @@ export class RemoteStartEntry extends Disposable implements IWorkbenchContributi
 		@IContextKeyService private readonly contextKeyService: IContextKeyService) {
 
 		super();
-		if (!isWeb) {
-			return;
-		}
 
 		const remoteExtensionTips = this.productService.remoteExtensionTips?.['tunnel'];
-		if (!remoteExtensionTips) {
-			return;
-		}
-		this.startCommand = remoteExtensionTips.startEntry?.startCommand ?? '';
-		this.remoteExtensionId = remoteExtensionTips.extensionId;
+		this.startCommand = remoteExtensionTips?.startEntry?.startCommand ?? '';
+		this.remoteExtensionId = remoteExtensionTips?.extensionId ?? '';
 
 		this._init();
 		this.registerActions();

--- a/src/vs/workbench/contrib/remote/browser/remoteStartEntry.ts
+++ b/src/vs/workbench/contrib/remote/browser/remoteStartEntry.ts
@@ -7,28 +7,14 @@ import * as nls from 'vs/nls';
 import { Disposable } from 'vs/base/common/lifecycle';
 import { IWorkbenchContribution } from 'vs/workbench/common/contributions';
 import { ICommandService } from 'vs/platform/commands/common/commands';
-import { QuickPickItem, IQuickInputService, IQuickInputButton } from 'vs/platform/quickinput/common/quickInput';
-import { once } from 'vs/base/common/functional';
 import { IProductService } from 'vs/platform/product/common/productService';
-import { Action2, MenuRegistry, registerAction2 } from 'vs/platform/actions/common/actions';
-import { IExtensionService } from 'vs/workbench/services/extensions/common/extensions';
-import { EXTENSION_INSTALL_SKIP_WALKTHROUGH_CONTEXT, IExtensionGalleryService, IExtensionManagementService } from 'vs/platform/extensionManagement/common/extensionManagement';
-import { retry } from 'vs/base/common/async';
-import { Registry } from 'vs/platform/registry/common/platform';
-import { ConfigurationScope, Extensions as ConfigurationExtensions, IConfigurationRegistry } from 'vs/platform/configuration/common/configurationRegistry';
-import { workbenchConfigurationNodeBase } from 'vs/workbench/common/configuration';
-import { CancellationToken } from 'vs/base/common/cancellation';
+import { Action2, registerAction2 } from 'vs/platform/actions/common/actions';
+import { IExtensionManagementService } from 'vs/platform/extensionManagement/common/extensionManagement';
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
-import { ContextKeyExpr, IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 import { ExtensionIdentifier } from 'vs/platform/extensions/common/extensions';
 import { IWorkbenchExtensionEnablementService } from 'vs/workbench/services/extensionManagement/common/extensionManagement';
-import { ThemeIcon } from 'vs/base/common/themables';
-import { infoIcon } from 'vs/workbench/contrib/extensions/browser/extensionsIcons';
-import { IOpenerService } from 'vs/platform/opener/common/opener';
-import { URI } from 'vs/base/common/uri';
-import { PlatformName, PlatformToString, isWeb, platform } from 'vs/base/common/platform';
-
-const STATUSBAR_REMOTEINDICATOR_CONTRIBUTION = 'statusBar/remoteIndicator';
+import { IContextKeyService, RawContextKey } from 'vs/platform/contextkey/common/contextkey';
+import { isWeb } from 'vs/base/common/platform';
 
 type RemoteStartActionClassification = {
 	command: { classification: 'PublicNonPersonalData'; purpose: 'FeatureInsight'; comment: 'The command being executed by the remote start entry.' };
@@ -41,86 +27,35 @@ type RemoteStartActionEvent = {
 	command: string;
 	remoteExtensionId?: string;
 };
-
-interface RemoteCommand {
-	command: string;
-	commandContext: string | undefined;
-}
-
-interface RemoteExtensionMetadata {
-	id: string;
-	friendlyName: string;
-	remoteCommands: RemoteCommand[];
-	installed: boolean;
-	dependencies: string[];
-	isPlatformCompatible: boolean;
-	helpLink: string;
-	startConnectLabel: string;
-	startCommand: string;
-	priority: number;
-	supportedPlatforms?: PlatformName[];
-}
-
+export const showStartEntryInWeb = new RawContextKey<boolean>('showRemoteStartEntryInWeb', false);
 export class RemoteStartEntry extends Disposable implements IWorkbenchContribution {
 
-	private static readonly REMOTE_START_ENTRY_ACTIONS_COMMAND_ID = 'workbench.action.remote.showStartEntryActions';
-	private static readonly REMOTE_TUNNEL_START_ENTRY_ACTIONS_COMMAND_ID = 'workbench.action.remote.showTunnelStartEntryActions';
+	private static readonly REMOTE_WEB_START_ENTRY_ACTIONS_COMMAND_ID = 'workbench.action.remote.showWebStartEntryActions';
 
-	private readonly remoteExtensionMetadata: RemoteExtensionMetadata[];
-	private _isInitialized: boolean = false;
+	private readonly remoteExtensionId!: string;
+	private startCommand!: string;
 
 	constructor(
-		@IQuickInputService private readonly quickInputService: IQuickInputService,
 		@ICommandService private readonly commandService: ICommandService,
 		@IProductService private readonly productService: IProductService,
-		@IExtensionService private readonly extensionService: IExtensionService,
 		@IExtensionManagementService private readonly extensionManagementService: IExtensionManagementService,
 		@IWorkbenchExtensionEnablementService private readonly extensionEnablementService: IWorkbenchExtensionEnablementService,
-		@IExtensionGalleryService private readonly extensionGalleryService: IExtensionGalleryService,
 		@ITelemetryService private readonly telemetryService: ITelemetryService,
-		@IContextKeyService private readonly contextKeyService: IContextKeyService,
-		@IOpenerService private readonly openerService: IOpenerService) {
+		@IContextKeyService private readonly contextKeyService: IContextKeyService) {
 
 		super();
-		const enable = this.extensionGalleryService.isEnabled() && (this.productService.remoteExtensionTips ?? false) && this.productService.quality !== 'stable';
-		registerConfiguration(enable);
-
-		if (isWeb) {
-			const remoteExtensionTips = this.productService.remoteExtensionTips?.['tunnel'];
-			this.remoteExtensionMetadata = remoteExtensionTips ? [{
-				id: remoteExtensionTips.extensionId,
-				installed: false,
-				friendlyName: remoteExtensionTips.friendlyName,
-				remoteCommands: [],
-				isPlatformCompatible: false,
-				dependencies: [],
-				helpLink: remoteExtensionTips.startEntry?.helpLink ?? '',
-				startConnectLabel: remoteExtensionTips.startEntry?.startConnectLabel ?? '',
-				startCommand: remoteExtensionTips.startEntry?.startCommand ?? '',
-				priority: remoteExtensionTips.startEntry?.priority ?? 10
-			}] : [];
-		}
-		else {
-			const remoteExtensionTips = { ...this.productService.remoteExtensionTips, ...this.productService.virtualWorkspaceExtensionTips };
-			this.remoteExtensionMetadata = Object.values(remoteExtensionTips).filter(value => value.startEntry !== undefined).map(value => {
-				return {
-					id: value.extensionId,
-					installed: false,
-					friendlyName: value.friendlyName,
-					remoteCommands: [],
-					isPlatformCompatible: false,
-					dependencies: [],
-					helpLink: value.startEntry?.helpLink ?? '',
-					startConnectLabel: value.startEntry?.startConnectLabel ?? '',
-					startCommand: value.startEntry?.startCommand ?? '',
-					priority: value.startEntry?.priority ?? 10,
-					supportedPlatforms: value.supportedPlatforms
-				};
-			});
-
-			this.remoteExtensionMetadata.sort((ext1, ext2) => ext1.priority - ext2.priority);
+		if (!isWeb) {
+			return;
 		}
 
+		const remoteExtensionTips = this.productService.remoteExtensionTips?.['tunnel'];
+		if (!remoteExtensionTips) {
+			return;
+		}
+		this.startCommand = remoteExtensionTips.startEntry?.startCommand ?? '';
+		this.remoteExtensionId = remoteExtensionTips.extensionId;
+
+		this._init();
 		this.registerActions();
 		this.registerListeners();
 	}
@@ -133,59 +68,28 @@ export class RemoteStartEntry extends Disposable implements IWorkbenchContributi
 		registerAction2(class extends Action2 {
 			constructor() {
 				super({
-					id: RemoteStartEntry.REMOTE_START_ENTRY_ACTIONS_COMMAND_ID,
+					id: RemoteStartEntry.REMOTE_WEB_START_ENTRY_ACTIONS_COMMAND_ID,
 					category,
-					title: { value: nls.localize('remote.showStartEntryActions', "Show Remote Start Entry Actions"), original: 'Show Remote Start Entry Actions' },
+					title: { value: nls.localize('remote.showWebStartEntryActions', "Show Remote Start Entry for web"), original: 'Show Remote Start Entry for web' },
 					f1: false
 				});
 			}
 
 			async run(): Promise<void> {
-				await startEntry.showRemoteStartActions();
-			}
-		});
-
-		registerAction2(class extends Action2 {
-			constructor() {
-				super({
-					id: RemoteStartEntry.REMOTE_TUNNEL_START_ENTRY_ACTIONS_COMMAND_ID,
-					category,
-					title: { value: nls.localize('remote.showTunnelStartEntryActions', "Show Start Entry for Remote Tunnels"), original: 'Show Start Entry for Remote Tunnels' },
-					f1: false
-				});
-			}
-
-			async run(): Promise<void> {
-				await startEntry.showRemoteTunnelStartActions();
+				await startEntry.showWebRemoteStartActions();
 			}
 		});
 	}
 
 	private registerListeners(): void {
-		this._register(this.extensionService.onDidChangeExtensions(async (result) => {
-			for (const ext of result.added) {
-				const index = this.remoteExtensionMetadata.findIndex(value => ExtensionIdentifier.equals(value.id, ext.identifier));
-				if (index > -1) {
-					this.remoteExtensionMetadata[index].installed = true;
-					this.remoteExtensionMetadata[index].remoteCommands = await this.getRemoteCommands(ext.identifier.value);
-				}
-			}
-		}));
-
-		this._register(this.extensionManagementService.onDidUninstallExtension(async (result) => {
-			const index = this.remoteExtensionMetadata.findIndex(value => ExtensionIdentifier.equals(value.id, result.identifier.id));
-			if (index > -1) {
-				this.remoteExtensionMetadata[index].installed = false;
-			}
-		}));
-
 		this._register(this.extensionEnablementService.onEnablementChanged(async (result) => {
+
 			for (const ext of result) {
-				const index = this.remoteExtensionMetadata.findIndex(value => ExtensionIdentifier.equals(value.id, ext.identifier.id));
-				if (index > -1) {
-					// update remote commands for extension if we never fetched it when it was disabled.
-					if (this.extensionEnablementService.isEnabled(ext) && this.remoteExtensionMetadata[index].remoteCommands.length === 0) {
-						this.remoteExtensionMetadata[index].remoteCommands = await this.getRemoteCommands(ext.identifier.id);
+				if (ExtensionIdentifier.equals(this.remoteExtensionId, ext.identifier.id)) {
+					if (this.extensionEnablementService.isEnabled(ext)) {
+						showStartEntryInWeb.bindTo(this.contextKeyService).set(true);
+					} else {
+						showStartEntryInWeb.bindTo(this.contextKeyService).set(false);
 					}
 				}
 			}
@@ -193,202 +97,18 @@ export class RemoteStartEntry extends Disposable implements IWorkbenchContributi
 	}
 
 	private async _init(): Promise<void> {
-		if (this._isInitialized) {
-			return;
-		}
-		const currentPlatform = PlatformToString(platform);
-		for (let i = 0; i < this.remoteExtensionMetadata.length; i++) {
-			const extensionId = this.remoteExtensionMetadata[i].id;
-			const supportedPlatforms = this.remoteExtensionMetadata[i].supportedPlatforms;
-			// Update compatibility
-			const galleryExtension = (await this.extensionGalleryService.getExtensions([{ id: extensionId }], CancellationToken.None))[0];
-			if (!await this.extensionManagementService.canInstall(galleryExtension)) {
-				this.remoteExtensionMetadata[i].isPlatformCompatible = false;
+
+		// Check if installed and enabled
+		const installed = (await this.extensionManagementService.getInstalled()).find(value => ExtensionIdentifier.equals(value.identifier.id, this.remoteExtensionId));
+		if (installed) {
+			if (this.extensionEnablementService.isEnabled(installed)) {
+				showStartEntryInWeb.bindTo(this.contextKeyService).set(true);
 			}
-			else if (supportedPlatforms && !supportedPlatforms.includes(currentPlatform)) {
-				this.remoteExtensionMetadata[i].isPlatformCompatible = false;
-			}
-			else {
-				this.remoteExtensionMetadata[i].isPlatformCompatible = true;
-				this.remoteExtensionMetadata[i].dependencies = galleryExtension.properties.extensionPack ?? [];
-			}
-
-			// Check if installed and enabled
-			const installed = (await this.extensionManagementService.getInstalled()).find(value => ExtensionIdentifier.equals(value.identifier.id, extensionId));
-			if (installed) {
-				this.remoteExtensionMetadata[i].installed = true;
-				if (this.extensionEnablementService.isEnabled(installed)) {
-					// update commands if enabled
-					this.remoteExtensionMetadata[i].remoteCommands = await this.getRemoteCommands(extensionId);
-				}
-			}
-		}
-
-		this._isInitialized = true;
-	}
-
-	private async getRemoteCommands(remoteExtensionId: string): Promise<RemoteCommand[]> {
-
-		const extension = await retry(async () => {
-			const ext = await this.extensionService.getExtension(remoteExtensionId);
-			if (!ext) {
-				throw Error('Failed to find installed remote extension');
-			}
-			return ext;
-		}, 300, 10);
-
-		const menus = extension?.contributes?.menus;
-		if (!menus) {
-			throw Error('Failed to find remoteIndicator menu');
-		}
-
-		const commands: RemoteCommand[] = [];
-		for (const contextMenu in menus) {
-			// The remote start entry pulls the first command from the statusBar/remoteIndicator menu contribution
-			if (contextMenu === STATUSBAR_REMOTEINDICATOR_CONTRIBUTION) {
-				for (const command of menus[contextMenu]) {
-					commands.push({ command: command.command, commandContext: command.when });
-				}
-			}
-		}
-
-		return commands;
-	}
-
-	private async showRemoteStartActions() {
-		await this._init();
-
-		const computeItems = async () => {
-			const installedItems: QuickPickItem[] = [];
-			const notInstalledItems: QuickPickItem[] = [];
-			for (const metadata of this.remoteExtensionMetadata) {
-
-				if (metadata.installed) {
-					// Create QuickPicks to display available remote commands
-					installedItems.push({ type: 'separator', label: metadata.friendlyName });
-					installedItems.push(...this.getRemoteCommandQuickPickItems(metadata.remoteCommands));
-				}
-				else if (!metadata.installed && metadata.isPlatformCompatible) {
-					// Create Install QuickPick with a help link
-					const label = metadata.startConnectLabel;
-					const buttons: IQuickInputButton[] = [{
-						iconClass: ThemeIcon.asClassName(infoIcon),
-						tooltip: nls.localize('remote.startActions.help', "Learn More")
-					}];
-					notInstalledItems.push({ type: 'item', id: metadata.id, label: label, buttons: buttons });
-				}
-			}
-
-			installedItems.push({
-				type: 'separator', label: nls.localize('remote.startActions.install', 'Install')
-			});
-			return installedItems.concat(notInstalledItems);
-		};
-
-		const quickPick = this.quickInputService.createQuickPick();
-		quickPick.placeholder = nls.localize('remote.startActions.quickPickPlaceholder', 'Select an option to connect');
-		quickPick.items = await computeItems();
-		quickPick.sortByLabel = false;
-		quickPick.canSelectMany = false;
-		quickPick.ignoreFocusOut = false;
-		once(quickPick.onDidAccept)(async () => {
-
-			const selectedItems = quickPick.selectedItems;
-			if (selectedItems.length === 1) {
-				const selectedItem = selectedItems[0].id!;
-				const remoteExtension = this.remoteExtensionMetadata.find(value => ExtensionIdentifier.equals(value.id, selectedItem));
-				if (remoteExtension) {
-
-					quickPick.items = [];
-					quickPick.busy = true;
-					quickPick.placeholder = nls.localize('remote.startActions.installingExtension', 'Installing extension... ');
-					await this.installAndRunStartCommand(remoteExtension);
-				}
-				else {
-					this.executeCommandWithTelemetry(selectedItem);
-				}
-				quickPick.dispose();
-			}
-		});
-
-		once(quickPick.onDidTriggerItemButton)(async (e) => {
-			const remoteExtension = this.remoteExtensionMetadata.find(value => ExtensionIdentifier.equals(value.id, e.item.id));
-			if (remoteExtension) {
-				await this.openerService.open(URI.parse(remoteExtension.helpLink));
-			}
-		});
-
-		quickPick.onDidHide(() => quickPick.dispose());
-		quickPick.show();
-	}
-
-	private async showRemoteTunnelStartActions() {
-		await this._init();
-		const metadata = this.remoteExtensionMetadata[0];
-		if (metadata.installed) {
-			this.executeCommandWithTelemetry(metadata.startCommand);
 		}
 	}
 
-	private async installAndRunStartCommand(metadata: RemoteExtensionMetadata) {
-		const extensionId = metadata.id;
-		const galleryExtension = (await this.extensionGalleryService.getExtensions([{ id: extensionId }], CancellationToken.None))[0];
-		await this.extensionManagementService.installFromGallery(galleryExtension, {
-			isMachineScoped: false,
-			donotIncludePackAndDependencies: false,
-			context: { [EXTENSION_INSTALL_SKIP_WALKTHROUGH_CONTEXT]: true }
-		});
-
-		this.telemetryService.publicLog2<RemoteStartActionEvent, RemoteStartActionClassification>('remoteStartList.ActionExecuted', { command: 'workbench.extensions.installExtension', remoteExtensionId: extensionId });
-
-		const commands = await this.getRemoteCommands(metadata?.id);
-		const command = (commands.find(value => value.command === metadata.startCommand) ?? commands[0]).command;
-		await this.extensionService.activateByEvent(`onCommand:${command}`);
-		this.commandService.executeCommand(command);
-
-		this.telemetryService.publicLog2<RemoteStartActionEvent, RemoteStartActionClassification>('remoteStartList.ActionExecuted', { command: command, remoteExtensionId: extensionId });
+	private async showWebRemoteStartActions() {
+		this.commandService.executeCommand(this.startCommand);
+		this.telemetryService.publicLog2<RemoteStartActionEvent, RemoteStartActionClassification>('remoteStartList.ActionExecuted', { command: this.startCommand });
 	}
-
-	private executeCommandWithTelemetry(command: string) {
-		this.commandService.executeCommand(command);
-		this.telemetryService.publicLog2<RemoteStartActionEvent, RemoteStartActionClassification>('remoteStartList.ActionExecuted', { command: command });
-	}
-
-	private getRemoteCommandQuickPickItems(remoteCommands: RemoteCommand[]): QuickPickItem[] {
-		const quickPickItems: QuickPickItem[] = [];
-		for (const command of remoteCommands) {
-
-			const expression = ContextKeyExpr.deserialize(command.commandContext);
-			if (!this.contextKeyService.contextMatchesRules(expression)) {
-				continue;
-			}
-
-			const commandAction = MenuRegistry.getCommand(command.command);
-			const label = typeof commandAction?.title === 'string' ? commandAction.title : commandAction?.title?.value;
-			if (label) {
-				quickPickItems.push({
-					type: 'item',
-					label: label,
-					id: command.command
-				});
-			}
-		}
-		return quickPickItems;
-	}
-}
-
-function registerConfiguration(enabled: boolean): void {
-	const configurationRegistry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration);
-	configurationRegistry.registerConfiguration({
-		...workbenchConfigurationNodeBase,
-		properties: {
-			'workbench.remote.experimental.showStartListEntry': {
-				scope: ConfigurationScope.MACHINE,
-				type: 'boolean',
-				default: enabled,
-				tags: ['experimental'],
-				description: nls.localize('workbench.remote.showStartListEntry', "When enabled, a start list entry for getting started with remote experiences in shown on the welcome page.")
-			}
-		}
-	});
 }

--- a/src/vs/workbench/contrib/remote/browser/remoteStartEntry.ts
+++ b/src/vs/workbench/contrib/remote/browser/remoteStartEntry.ts
@@ -14,26 +14,16 @@ import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 import { ExtensionIdentifier } from 'vs/platform/extensions/common/extensions';
 import { IWorkbenchExtensionEnablementService } from 'vs/workbench/services/extensionManagement/common/extensionManagement';
 import { IContextKeyService, RawContextKey } from 'vs/platform/contextkey/common/contextkey';
+import { WorkbenchActionExecutedClassification, WorkbenchActionExecutedEvent } from 'vs/base/common/actions';
 import { isWeb } from 'vs/base/common/platform';
 
-type RemoteStartActionClassification = {
-	command: { classification: 'PublicNonPersonalData'; purpose: 'FeatureInsight'; comment: 'The command being executed by the remote start entry.' };
-	remoteExtensionId?: { classification: 'PublicNonPersonalData'; purpose: 'FeatureInsight'; comment: 'The remote extension id being used.' };
-	owner: 'bhavyau';
-	comment: 'Help understand which remote extensions are most commonly used from the remote start entry';
-};
-
-type RemoteStartActionEvent = {
-	command: string;
-	remoteExtensionId?: string;
-};
 export const showStartEntryInWeb = new RawContextKey<boolean>('showRemoteStartEntryInWeb', false);
 export class RemoteStartEntry extends Disposable implements IWorkbenchContribution {
 
 	private static readonly REMOTE_WEB_START_ENTRY_ACTIONS_COMMAND_ID = 'workbench.action.remote.showWebStartEntryActions';
 
 	private readonly remoteExtensionId!: string;
-	private startCommand!: string;
+	private readonly startCommand!: string;
 
 	constructor(
 		@ICommandService private readonly commandService: ICommandService,
@@ -109,6 +99,9 @@ export class RemoteStartEntry extends Disposable implements IWorkbenchContributi
 
 	private async showWebRemoteStartActions() {
 		this.commandService.executeCommand(this.startCommand);
-		this.telemetryService.publicLog2<RemoteStartActionEvent, RemoteStartActionClassification>('remoteStartList.ActionExecuted', { command: this.startCommand });
+		this.telemetryService.publicLog2<WorkbenchActionExecutedEvent, WorkbenchActionExecutedClassification>('workbenchActionExecuted', {
+			id: this.startCommand,
+			from: 'remote start entry'
+		});
 	}
 }

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.contribution.ts
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.contribution.ts
@@ -31,7 +31,6 @@ import { IExtensionService } from 'vs/workbench/services/extensions/common/exten
 import { StartupPageContribution, } from 'vs/workbench/contrib/welcomeGettingStarted/browser/startupPage';
 import { ExtensionsInput } from 'vs/workbench/contrib/extensions/common/extensionsInput';
 import { Categories } from 'vs/platform/action/common/actionCommonCategories';
-import { RemoteStartEntry } from 'vs/workbench/contrib/remote/browser/remoteStartEntry';
 
 export * as icons from 'vs/workbench/contrib/welcomeGettingStarted/browser/gettingStartedIcons';
 
@@ -297,7 +296,6 @@ class WorkspacePlatformContribution {
 Registry.as<IWorkbenchContributionsRegistry>(WorkbenchExtensions.Workbench)
 	.registerWorkbenchContribution(WorkspacePlatformContribution, LifecyclePhase.Restored);
 
-
 const configurationRegistry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration);
 configurationRegistry.registerConfiguration({
 	...workbenchConfigurationNodeBase,
@@ -332,9 +330,5 @@ configurationRegistry.registerConfiguration({
 	}
 });
 
-
 Registry.as<IWorkbenchContributionsRegistry>(WorkbenchExtensions.Workbench)
 	.registerWorkbenchContribution(StartupPageContribution, LifecyclePhase.Restored);
-
-Registry.as<IWorkbenchContributionsRegistry>(WorkbenchExtensions.Workbench)
-	.registerWorkbenchContribution(RemoteStartEntry, LifecyclePhase.Restored);

--- a/src/vs/workbench/contrib/welcomeGettingStarted/common/gettingStartedContent.ts
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/common/gettingStartedContent.ts
@@ -146,22 +146,22 @@ export const startEntries: GettingStartedStartEntryContent = [
 		id: 'topLevelRemoteOpen',
 		title: localize('gettingStarted.topLevelRemoteOpen.title', "Connect to..."),
 		description: localize('gettingStarted.topLevelRemoteOpen.description', "Connect to remote development workspaces."),
-		when: '!isWeb && config.workbench.remote.experimental.showStartListEntry',
+		when: '!isWeb',
 		icon: Codicon.remote,
 		content: {
 			type: 'startEntry',
-			command: 'command:workbench.action.remote.showStartEntryActions',
+			command: 'command:workbench.action.remote.showMenu',
 		}
 	},
 	{
 		id: 'topLevelOpenTunnel',
 		title: localize('gettingStarted.topLevelOpenTunnel.title', "Open Tunnel..."),
 		description: localize('gettingStarted.topLevelOpenTunnel.description', "Connect to a remote machine through a Tunnel"),
-		when: 'isWeb && config.workbench.remote.experimental.showStartListEntry',
+		when: 'isWeb && showRemoteStartEntryInWeb',
 		icon: Codicon.remote,
 		content: {
 			type: 'startEntry',
-			command: 'command:workbench.action.remote.showTunnelStartEntryActions',
+			command: 'command:workbench.action.remote.showWebStartEntryActions',
 		}
 	},
 ];

--- a/src/vs/workbench/workbench.web.main.ts
+++ b/src/vs/workbench/workbench.web.main.ts
@@ -158,6 +158,9 @@ import 'vs/workbench/contrib/issue/browser/issue.contribution';
 // Splash
 import 'vs/workbench/contrib/splash/browser/splash.contribution';
 
+// Remote Start Entry for the Web
+import 'vs/workbench/contrib/remote/browser/remoteStartEntry.contribution';
+
 //#endregion
 
 


### PR DESCRIPTION
Addresses: https://github.com/microsoft/vscode/issues/184845

Changes: 
**remoteIndicator.ts** - Moved code over from `remoteStartEntry.ts` for displaying and installing installable extensions in the remote menu quick pick. 

**remoteStartEntry.ts** - Removed all code related to fetching remote commands. We now rely entirely on the remote menu for this. Only code remaining in the remote start entry is the code to execute start command for tunnel since the welcome page for the web contains a `Connect to tunnel` entry instead. `Continue on` menu items now also show up in the remote start entry

**gettingStartedContent.ts** - switch over to using the `remote.showMenu` command. 