### PR TITLE
Updates editor configuration before creating the view model.

### DIFF
--- a/src/vs/workbench/browser/parts/editor/textEditor.ts
+++ b/src/vs/workbench/browser/parts/editor/textEditor.ts
@@ -259,7 +259,7 @@ export abstract class AbstractTextEditor<T extends IEditorViewState> extends Abs
 		return input.resource;
 	}
 
-	private updateEditorConfiguration(resource = this.getActiveResource()): void {
+	protected updateEditorConfiguration(resource = this.getActiveResource()): void {
 		let configuration: IEditorConfiguration | undefined = undefined;
 		if (resource) {
 			configuration = this.textResourceConfigurationService.getValue<IEditorConfiguration>(resource);


### PR DESCRIPTION
This avoids unnecessary diff computations.