### PR TITLE
working copy - allow to override backup delay (#172345)

### DIFF
--- a/src/vs/workbench/services/workingCopy/common/fileWorkingCopy.ts
+++ b/src/vs/workbench/services/workingCopy/common/fileWorkingCopy.ts
@@ -23,6 +23,18 @@ export interface IFileWorkingCopyModelFactory<M extends IFileWorkingCopyModel> {
 	createModel(resource: URI, contents: VSBufferReadableStream, token: CancellationToken): Promise<M>;
 }
 
+export interface IFileWorkingCopyModelConfiguration {
+
+	/**
+	 * The delay in milliseconds to wait before triggering
+	 * a backup after the content of the model has changed.
+	 *
+	 * If not configured, a sensible default will be taken
+	 * based on user settings.
+	 */
+	readonly backupDelay?: number;
+}
+
 /**
  * A generic file working copy model to be reused by untitled
  * and stored file working copies.
@@ -49,6 +61,12 @@ export interface IFileWorkingCopyModel extends IDisposable {
 	 * An event emitted right before disposing the model.
 	 */
 	readonly onWillDispose: Event<void>;
+
+	/**
+	 * Optional additional configuration for the model that drives
+	 * some of the working copy behaviour.
+	 */
+	readonly configuration?: IFileWorkingCopyModelConfiguration;
 
 	/**
 	 * Snapshots the model's current content for writing. This must include

--- a/src/vs/workbench/services/workingCopy/common/storedFileWorkingCopy.ts
+++ b/src/vs/workbench/services/workingCopy/common/storedFileWorkingCopy.ts
@@ -757,6 +757,10 @@ export class StoredFileWorkingCopy<M extends IStoredFileWorkingCopyModel> extend
 
 	//#region Backup
 
+	get backupDelay(): number | undefined {
+		return this.model?.configuration?.backupDelay;
+	}
+
 	async backup(token: CancellationToken): Promise<IWorkingCopyBackup> {
 
 		// Fill in metadata if we are resolved

--- a/src/vs/workbench/services/workingCopy/common/untitledFileWorkingCopy.ts
+++ b/src/vs/workbench/services/workingCopy/common/untitledFileWorkingCopy.ts
@@ -252,6 +252,10 @@ export class UntitledFileWorkingCopy<M extends IUntitledFileWorkingCopyModel> ex
 
 	//#region Backup
 
+	get backupDelay(): number | undefined {
+		return this.model?.configuration?.backupDelay;
+	}
+
 	async backup(token: CancellationToken): Promise<IWorkingCopyBackup> {
 		let content: VSBufferReadableStream | undefined = undefined;
 

--- a/src/vs/workbench/services/workingCopy/common/workingCopy.ts
+++ b/src/vs/workbench/services/workingCopy/common/workingCopy.ts
@@ -183,6 +183,15 @@ export interface IWorkingCopy extends IWorkingCopyIdentifier {
 	//#region Save / Backup
 
 	/**
+	 * The delay in milliseconds to wait before triggering
+	 * a backup after the content of the model has changed.
+	 *
+	 * If not configured, a sensible default will be taken
+	 * based on user settings.
+	 */
+	readonly backupDelay?: number;
+
+	/**
 	 * The workbench may call this method often after it receives
 	 * the `onDidChangeContent` event for the working copy. The motivation
 	 * is to allow to quit VSCode with dirty working copies present.

--- a/src/vs/workbench/services/workingCopy/common/workingCopyBackupTracker.ts
+++ b/src/vs/workbench/services/workingCopy/common/workingCopyBackupTracker.ts
@@ -87,7 +87,7 @@ export abstract class WorkingCopyBackupTracker extends Disposable {
 	// have different scheduling delays based on auto save. This helps to
 	// avoid a (not critical but also not really wanted) race between saving
 	// (after 1s per default) and making a backup of the working copy.
-	private static readonly BACKUP_SCHEDULE_DELAYS = {
+	private static readonly DEFAULT_BACKUP_SCHEDULE_DELAYS = {
 		[AutoSaveMode.OFF]: 1000,
 		[AutoSaveMode.ON_FOCUS_CHANGE]: 1000,
 		[AutoSaveMode.ON_WINDOW_CHANGE]: 1000,
@@ -220,12 +220,16 @@ export abstract class WorkingCopyBackupTracker extends Disposable {
 	}
 
 	protected getBackupScheduleDelay(workingCopy: IWorkingCopy): number {
+		if (typeof workingCopy.backupDelay === 'number') {
+			return workingCopy.backupDelay; // respect working copy override
+		}
+
 		let autoSaveMode = this.filesConfigurationService.getAutoSaveMode();
 		if (workingCopy.capabilities & WorkingCopyCapabilities.Untitled) {
 			autoSaveMode = AutoSaveMode.OFF; // auto-save is never on for untitled working copies
 		}
 
-		return WorkingCopyBackupTracker.BACKUP_SCHEDULE_DELAYS[autoSaveMode];
+		return WorkingCopyBackupTracker.DEFAULT_BACKUP_SCHEDULE_DELAYS[autoSaveMode];
 	}
 
 	protected getContentVersion(workingCopy: IWorkingCopy): number {

--- a/src/vs/workbench/services/workingCopy/test/browser/workingCopyBackupTracker.test.ts
+++ b/src/vs/workbench/services/workingCopy/test/browser/workingCopyBackupTracker.test.ts
@@ -146,16 +146,16 @@ suite('WorkingCopyBackupTracker (browser)', function () {
 
 		class TestBackupWorkingCopy extends TestWorkingCopy {
 
-			backupDelay = 0;
-
 			constructor(resource: URI) {
 				super(resource);
 
 				accessor.workingCopyService.registerWorkingCopy(this);
 			}
 
+			readonly backupDelay = 10;
+
 			override async backup(token: CancellationToken): Promise<IWorkingCopyBackup> {
-				await timeout(this.backupDelay);
+				await timeout(0);
 
 				return {};
 			}


### PR DESCRIPTION
Part of #172345

Increases the delay before attempting to backup a notebook to `10s` if connected to a remote. The value was picked a bit randomly, feel free to tweak as needed.