### PR TITLE
Fixing incorrect background color

### DIFF
--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatStrategies.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatStrategies.ts
@@ -435,6 +435,13 @@ export class LivePreviewStrategy extends LiveStrategy {
 	override hasFocus(): boolean {
 		return super.hasFocus() || this._diffZone.value.hasFocus() || this._previewZone.value.hasFocus();
 	}
+
+	override getWidgetPosition(): Position | undefined {
+		if (this._session.lastTextModelChanges.length) {
+			return this._session.wholeRange.value.getEndPosition();
+		}
+		return;
+	}
 }
 
 function showSingleCreateFile(accessor: ServicesAccessor, edit: EditResponse) {


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/185970

The error was happening because we were using the getWidget strategy from Live strategy which calculated the widget line number as 5 despite the widget appearing at the end of the selection when inline diff is toggled on. The subsequent check for if the widget is within the zone would then not be correct.

<img width="1162" alt="Screenshot 2023-06-23 at 12 33 22" src="https://github.com/microsoft/vscode/assets/61460952/df2b4995-b12f-4721-b9fc-2cac70609537">

The fix here is to render at the end of the activeSession.wholeRange
