### PR TITLE
Fixing incorrect indent

### DIFF
--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatController.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatController.ts
@@ -307,7 +307,7 @@ export class InlineChatController implements IEditorContribution {
 			}
 		});
 
-		this._showWidget(false);
+		this._showWidget(true);
 
 		this._sessionStore.add(this._editor.onDidChangeModel((e) => {
 			const msg = this._activeSession?.lastExchange

--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatStrategies.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatStrategies.ts
@@ -366,7 +366,7 @@ export class LiveStrategy extends EditModeStrategy {
 	}
 
 	override needsMargin(): boolean {
-		return Boolean(this._session.lastTextModelChanges.length);
+		return !Boolean(this._session.lastTextModelChanges.length);
 	}
 
 	hasFocus(): boolean {


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/185973

Previously showWidget was called twice, now it is called three times. The second call should take in initialRender = true.

There appeared to be a second error related to the needsMargin() function which was sending the wrong boolean. The negation of the boolean had to be sent.