### PR TITLE
files - allow more file operations to run in the extension host (#172345)

### DIFF
--- a/extensions/vscode-api-tests/src/singlefolder-tests/workspace.fs.test.ts
+++ b/extensions/vscode-api-tests/src/singlefolder-tests/workspace.fs.test.ts
@@ -187,7 +187,6 @@ suite('vscode API - workspace-fs', () => {
 
 	test('vscode.workspace.fs error reporting is weird #132981', async function () {
 
-
 		const uri = await createRandomFile();
 
 		const source = vscode.Uri.joinPath(uri, `./${Math.random().toString(16).slice(2, 8)}`);
@@ -216,5 +215,30 @@ suite('vscode API - workspace-fs', () => {
 			assert.strictEqual(err.code, vscode.FileSystemError.FileNotFound().code);
 			assert.strictEqual(err.code, 'FileNotFound');
 		}
+	});
+
+	test('fs.createFolder creates recursively', async function () {
+
+		const folder = root.with({ path: posix.join(root.path, 'deeply', 'nested', 'folder') });
+
+		await vscode.workspace.fs.createDirectory(folder);
+
+		const stat = await vscode.workspace.fs.stat(folder);
+		assert.strictEqual(stat.type, vscode.FileType.Directory);
+
+		await vscode.workspace.fs.delete(folder, { recursive: true, useTrash: false });
+	});
+
+	test('fs.writeFile creates parents recursively', async function () {
+
+		const folder = root.with({ path: posix.join(root.path, 'other-deeply', 'nested', 'folder') });
+		const file = root.with({ path: posix.join(folder.path, 'file.txt') });
+
+		await vscode.workspace.fs.writeFile(file, Buffer.from('Hello World'));
+
+		const stat = await vscode.workspace.fs.stat(file);
+		assert.strictEqual(stat.type, vscode.FileType.File);
+
+		await vscode.workspace.fs.delete(folder, { recursive: true, useTrash: false });
 	});
 });

--- a/extensions/vscode-api-tests/src/singlefolder-tests/workspace.fs.test.ts
+++ b/extensions/vscode-api-tests/src/singlefolder-tests/workspace.fs.test.ts
@@ -227,6 +227,8 @@ suite('vscode API - workspace-fs', () => {
 		assert.strictEqual(stat.type, vscode.FileType.Directory);
 
 		await vscode.workspace.fs.delete(folder, { recursive: true, useTrash: false });
+
+		await vscode.workspace.fs.createDirectory(folder); // calling on existing folder is also ok!
 	});
 
 	test('fs.writeFile creates parents recursively', async function () {

--- a/src/vs/workbench/api/common/extHost.api.impl.ts
+++ b/src/vs/workbench/api/common/extHost.api.impl.ts
@@ -1020,7 +1020,7 @@ export function createApiFactoryAndRegisterActors(accessor: ServicesAccessor): I
 			registerFileSystemProvider(scheme, provider, options) {
 				return combinedDisposable(
 					extHostFileSystem.registerFileSystemProvider(extension, scheme, provider, options),
-					extHostConsumerFileSystem.addFileSystemProvider(scheme, provider)
+					extHostConsumerFileSystem.addFileSystemProvider(scheme, provider, options)
 				);
 			},
 			get fs() {

--- a/src/vs/workbench/api/common/extHostFileSystemConsumer.ts
+++ b/src/vs/workbench/api/common/extHostFileSystemConsumer.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { MainContext, MainThreadFileSystemShape } from './extHost.protocol';
-import * as vscode from 'vscode';
+import type * as vscode from 'vscode';
 import * as files from 'vs/platform/files/common/files';
 import { FileSystemError } from 'vs/workbench/api/common/extHostTypes';
 import { VSBuffer } from 'vs/base/common/buffer';
@@ -164,7 +164,7 @@ export class ExtHostConsumerFileSystem {
 		while (!providerExtUri.isEqual(directory, providerExtUri.dirname(directory))) {
 			try {
 				const stat = await provider.stat(directory);
-				if ((stat.type & vscode.FileType.Directory) === 0) {
+				if ((stat.type & files.FileType.Directory) === 0) {
 					throw FileSystemError.FileExists(`Unable to create folder '${directory.scheme === Schemas.file ? directory.fsPath : directory.toString(true)}' that already exists but is not a directory`);
 				}
 

--- a/src/vs/workbench/api/common/extHostFileSystemConsumer.ts
+++ b/src/vs/workbench/api/common/extHostFileSystemConsumer.ts
@@ -12,6 +12,10 @@ import { createDecorator } from 'vs/platform/instantiation/common/instantiation'
 import { IExtHostRpcService } from 'vs/workbench/api/common/extHostRpcService';
 import { IExtHostFileSystemInfo } from 'vs/workbench/api/common/extHostFileSystemInfo';
 import { IDisposable, toDisposable } from 'vs/base/common/lifecycle';
+import { ResourceQueue } from 'vs/base/common/async';
+import { IExtUri, extUri, extUriIgnorePathCase } from 'vs/base/common/resources';
+import { Schemas } from 'vs/base/common/network';
+import { IMarkdownString } from 'vs/base/common/htmlContent';
 
 export class ExtHostConsumerFileSystem {
 
@@ -20,7 +24,9 @@ export class ExtHostConsumerFileSystem {
 	readonly value: vscode.FileSystem;
 
 	private readonly _proxy: MainThreadFileSystemShape;
-	private readonly _fileSystemProvider = new Map<string, vscode.FileSystemProvider>();
+	private readonly _fileSystemProvider = new Map<string, { impl: vscode.FileSystemProvider; extUri: IExtUri; isReadonly: boolean }>();
+
+	private readonly writeQueue = new ResourceQueue();
 
 	constructor(
 		@IExtHostRpcService extHostRpc: IExtHostRpcService,
@@ -38,7 +44,7 @@ export class ExtHostConsumerFileSystem {
 					if (provider) {
 						// use shortcut
 						await that._proxy.$ensureActivation(uri.scheme);
-						stat = await provider.stat(uri);
+						stat = await provider.impl.stat(uri);
 					} else {
 						stat = await that._proxy.$stat(uri);
 					}
@@ -60,7 +66,7 @@ export class ExtHostConsumerFileSystem {
 					if (provider) {
 						// use shortcut
 						await that._proxy.$ensureActivation(uri.scheme);
-						return (await provider.readDirectory(uri)).slice(); // safe-copy
+						return (await provider.impl.readDirectory(uri)).slice(); // safe-copy
 					} else {
 						return await that._proxy.$readdir(uri);
 					}
@@ -70,8 +76,14 @@ export class ExtHostConsumerFileSystem {
 			},
 			async createDirectory(uri: vscode.Uri): Promise<void> {
 				try {
-					// no shortcut: does mkdirp
-					return await that._proxy.$mkdir(uri);
+					const provider = that._fileSystemProvider.get(uri.scheme);
+					if (provider && !provider.isReadonly) {
+						// use shortcut
+						await that._proxy.$ensureActivation(uri.scheme);
+						return await that.mkdirp(provider.impl, provider.extUri, uri);
+					} else {
+						return await that._proxy.$mkdir(uri);
+					}
 				} catch (err) {
 					return ExtHostConsumerFileSystem._handleError(err);
 				}
@@ -82,7 +94,7 @@ export class ExtHostConsumerFileSystem {
 					if (provider) {
 						// use shortcut
 						await that._proxy.$ensureActivation(uri.scheme);
-						return (await provider.readFile(uri)).slice(); // safe-copy
+						return (await provider.impl.readFile(uri)).slice(); // safe-copy
 					} else {
 						const buff = await that._proxy.$readFile(uri);
 						return buff.buffer;
@@ -93,8 +105,15 @@ export class ExtHostConsumerFileSystem {
 			},
 			async writeFile(uri: vscode.Uri, content: Uint8Array): Promise<void> {
 				try {
-					// no shortcut: does mkdirp
-					return await that._proxy.$writeFile(uri, VSBuffer.wrap(content));
+					const provider = that._fileSystemProvider.get(uri.scheme);
+					if (provider && !provider.isReadonly) {
+						// use shortcut
+						await that._proxy.$ensureActivation(uri.scheme);
+						await that.mkdirp(provider.impl, provider.extUri, provider.extUri.dirname(uri));
+						return await that.writeQueue.queueFor(uri).queue(() => Promise.resolve(provider.impl.writeFile(uri, content, { create: true, overwrite: true })));
+					} else {
+						return await that._proxy.$writeFile(uri, VSBuffer.wrap(content));
+					}
 				} catch (err) {
 					return ExtHostConsumerFileSystem._handleError(err);
 				}
@@ -102,10 +121,10 @@ export class ExtHostConsumerFileSystem {
 			async delete(uri: vscode.Uri, options?: { recursive?: boolean; useTrash?: boolean }): Promise<void> {
 				try {
 					const provider = that._fileSystemProvider.get(uri.scheme);
-					if (provider) {
+					if (provider && !provider.isReadonly) {
 						// use shortcut
 						await that._proxy.$ensureActivation(uri.scheme);
-						return await provider.delete(uri, { recursive: false, ...options });
+						return await provider.impl.delete(uri, { recursive: false, ...options });
 					} else {
 						return await that._proxy.$delete(uri, { recursive: false, useTrash: false, atomic: false, ...options });
 					}
@@ -137,6 +156,49 @@ export class ExtHostConsumerFileSystem {
 				return undefined;
 			}
 		});
+	}
+
+	private async mkdirp(provider: vscode.FileSystemProvider, providerExtUri: IExtUri, directory: vscode.Uri): Promise<void> {
+		const directoriesToCreate: string[] = [];
+
+		while (!providerExtUri.isEqual(directory, providerExtUri.dirname(directory))) {
+			try {
+				const stat = await provider.stat(directory);
+				if ((stat.type & vscode.FileType.Directory) === 0) {
+					throw FileSystemError.FileExists(`Unable to create folder '${directory.scheme === Schemas.file ? directory.fsPath : directory.toString(true)}' that already exists but is not a directory`);
+				}
+
+				break; // we have hit a directory that exists -> good
+			} catch (error) {
+				if (files.toFileSystemProviderErrorCode(error) !== files.FileSystemProviderErrorCode.FileNotFound) {
+					throw error;
+				}
+
+				// further go up and remember to create this directory
+				directoriesToCreate.push(providerExtUri.basename(directory));
+				directory = providerExtUri.dirname(directory);
+			}
+		}
+
+		for (let i = directoriesToCreate.length - 1; i >= 0; i--) {
+			directory = providerExtUri.joinPath(directory, directoriesToCreate[i]);
+
+			try {
+				await provider.createDirectory(directory);
+			} catch (error) {
+				if (files.toFileSystemProviderErrorCode(error) !== files.FileSystemProviderErrorCode.FileExists) {
+					// For mkdirp() we tolerate that the mkdir() call fails
+					// in case the folder already exists. This follows node.js
+					// own implementation of fs.mkdir({ recursive: true }) and
+					// reduces the chances of race conditions leading to errors
+					// if multiple calls try to create the same folders
+					// As such, we only throw an error here if it is other than
+					// the fact that the file already exists.
+					// (see also https://github.com/microsoft/vscode/issues/89834)
+					throw error;
+				}
+			}
+		}
 	}
 
 	private static _handleError(err: any): never {
@@ -184,8 +246,8 @@ export class ExtHostConsumerFileSystem {
 
 	// ---
 
-	addFileSystemProvider(scheme: string, provider: vscode.FileSystemProvider): IDisposable {
-		this._fileSystemProvider.set(scheme, provider);
+	addFileSystemProvider(scheme: string, provider: vscode.FileSystemProvider, options?: { isCaseSensitive?: boolean; isReadonly?: boolean | IMarkdownString }): IDisposable {
+		this._fileSystemProvider.set(scheme, { impl: provider, extUri: options?.isCaseSensitive ? extUri : extUriIgnorePathCase, isReadonly: !!options?.isReadonly });
 		return toDisposable(() => this._fileSystemProvider.delete(scheme));
 	}
 }

--- a/src/vs/workbench/api/node/extHostDiskFileSystemProvider.ts
+++ b/src/vs/workbench/api/node/extHostDiskFileSystemProvider.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as vscode from 'vscode';
+import type * as vscode from 'vscode';
 import { IExtHostConsumerFileSystem } from 'vs/workbench/api/common/extHostFileSystemConsumer';
 import { Schemas } from 'vs/base/common/network';
 import { ILogService } from 'vs/platform/log/common/log';

--- a/src/vs/workbench/api/node/extHostDiskFileSystemProvider.ts
+++ b/src/vs/workbench/api/node/extHostDiskFileSystemProvider.ts
@@ -9,6 +9,7 @@ import { Schemas } from 'vs/base/common/network';
 import { ILogService } from 'vs/platform/log/common/log';
 import { DiskFileSystemProvider } from 'vs/platform/files/node/diskFileSystemProvider';
 import { FilePermission } from 'vs/platform/files/common/files';
+import { isLinux } from 'vs/base/common/platform';
 
 export class ExtHostDiskFileSystemProvider {
 
@@ -20,7 +21,7 @@ export class ExtHostDiskFileSystemProvider {
 		// Register disk file system provider so that certain
 		// file operations can execute fast within the extension
 		// host without roundtripping.
-		extHostConsumerFileSystem.addFileSystemProvider(Schemas.file, new DiskFileSystemProviderAdapter(logService));
+		extHostConsumerFileSystem.addFileSystemProvider(Schemas.file, new DiskFileSystemProviderAdapter(logService), { isCaseSensitive: isLinux });
 	}
 }
 


### PR DESCRIPTION
Part of https://github.com/microsoft/vscode/issues/172345

Makes `writeFile` and `createDirectory` operations use the shortcut in the extension host.

@rebornix fyi