### PR TITLE
feat: provide disable-chromium-sandbox runtime argument

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -33,9 +33,12 @@ const portable = bootstrapNode.configurePortable(product);
 // Enable ASAR support
 bootstrap.enableASARSupport();
 
-// Enable sandbox globally unless disabled via `--no-sandbox` argument
 const args = parseCLIArgs();
-if (args['sandbox']) {
+// Configure static command line arguments
+const argvConfig = configureCommandlineSwitchesSync(args);
+// Enable sandbox globally unless disabled via `--no-sandbox` argument
+// or if `disable-chromium-sandbox: true` is set in argv.json.
+if (args['sandbox'] && !argvConfig['disable-chromium-sandbox']) {
 	app.enableSandbox();
 }
 
@@ -51,9 +54,6 @@ app.setPath('userData', userDataPath);
 
 // Resolve code cache path
 const codeCachePath = getCodeCachePath();
-
-// Configure static command line arguments
-const argvConfig = configureCommandlineSwitchesSync(args);
 
 // Disable default menu (https://github.com/electron/electron/issues/35512)
 Menu.setApplicationMenu(null);
@@ -190,7 +190,10 @@ function configureCommandlineSwitchesSync(cliArgs) {
 		'disable-hardware-acceleration',
 
 		// override for the color profile to use
-		'force-color-profile'
+		'force-color-profile',
+
+		// disable chromium sandbox
+		'disable-chromium-sandbox',
 	];
 
 	if (process.platform === 'linux') {
@@ -228,6 +231,9 @@ function configureCommandlineSwitchesSync(cliArgs) {
 			else if (argvValue === true || argvValue === 'true') {
 				if (argvKey === 'disable-hardware-acceleration') {
 					app.disableHardwareAcceleration(); // needs to be called explicitly
+				} else if (argvKey === 'disable-chromium-sandbox') {
+					app.commandLine.appendSwitch('no-sandbox');
+					app.commandLine.appendSwitch('disable-gpu-sandbox');
 				} else {
 					app.commandLine.appendSwitch(argvKey);
 				}

--- a/src/vs/workbench/electron-sandbox/desktop.contribution.ts
+++ b/src/vs/workbench/electron-sandbox/desktop.contribution.ts
@@ -345,6 +345,10 @@ import { applicationConfigurationNodeBase } from 'vs/workbench/common/configurat
 			'log-level': {
 				type: ['string', 'array'],
 				description: localize('argv.logLevel', "Log level to use. Default is 'info'. Allowed values are 'error', 'warn', 'info', 'debug', 'trace', 'off'.")
+			},
+			'disable-chromium-sandbox': {
+				type: 'boolean',
+				description: localize('argv.disableChromiumSandbox', "Disables the Chromium sandbox. This is useful when running VS Code as elevated on Linux and running under Applocker on Windows.")
 			}
 		}
 	};


### PR DESCRIPTION
Addresses https://github.com/microsoft/vscode/issues/184687#issuecomment-1602955630

Users should now be able to persist their sandbox preference via,

```
* Open command palette
* Configure runtime arguments
* "disable-chromium-sandbox": "true"
* Prompted for restart
```
