### PR TITLE
fix: remove emulation check and notification on windows

### DIFF
--- a/src/vs/code/electron-main/app.ts
+++ b/src/vs/code/electron-main/app.ts
@@ -1279,7 +1279,7 @@ export class CodeApplication extends Disposable {
 		// Crash reporter
 		this.updateCrashReporterEnablement();
 
-		if (app.runningUnderARM64Translation) {
+		if (isMacintosh && app.runningUnderARM64Translation) {
 			this.windowsMainService?.sendToFocused('vscode:showTranslatedBuildWarning');
 		}
 

--- a/src/vs/platform/native/electron-main/nativeHostMainService.ts
+++ b/src/vs/platform/native/electron-main/nativeHostMainService.ts
@@ -490,7 +490,7 @@ export class NativeHostMainService extends Disposable implements INativeHostMain
 	}
 
 	async isRunningUnderARM64Translation(): Promise<boolean> {
-		if (isLinux) {
+		if (isLinux || isWindows) {
 			return false;
 		}
 		return app.runningUnderARM64Translation;

--- a/src/vs/workbench/electron-sandbox/window.ts
+++ b/src/vs/workbench/electron-sandbox/window.ts
@@ -236,15 +236,8 @@ export class NativeWindow extends Disposable {
 					label: localize('downloadArmBuild', "Download"),
 					run: () => {
 						const quality = this.productService.quality;
-						let stableURL = '';
-						let insidersURL = '';
-						if (isMacintosh) {
-							stableURL = 'https://code.visualstudio.com/docs/?dv=osx';
-							insidersURL = 'https://code.visualstudio.com/docs/?dv=osx&build=insiders';
-						} else if (isWindows) {
-							stableURL = 'https://code.visualstudio.com/docs/?dv=win32arm64user';
-							insidersURL = 'https://code.visualstudio.com/docs/?dv=win32arm64user&build=insiders';
-						}
+						const stableURL = 'https://code.visualstudio.com/docs/?dv=osx';
+						const insidersURL = 'https://code.visualstudio.com/docs/?dv=osx&build=insiders';
 						this.openerService.open(quality === 'stable' ? stableURL : insidersURL);
 					}
 				}]


### PR DESCRIPTION
`app.runningUnderARM64Translation` will return incorrect value on windows since the API currently checks the machine architecture rather than if the process is a WoW process, refs https://github.com/electron/electron/blob/9226cc662b9c6cf3404d59c50cae0f0ccc1a0a0d/shell/browser/api/electron_api_app.cc#L1492-L1496. Removing the check on windows to avoid false notifications.