### PR TITLE
Respect @ symbol search when there is no line/colon pattern after

### DIFF
--- a/src/vs/workbench/contrib/search/common/search.ts
+++ b/src/vs/workbench/contrib/search/common/search.ts
@@ -157,7 +157,11 @@ export interface IFilterAndRange {
 }
 
 export function extractRangeFromFilter(filter: string, unless?: string[]): IFilterAndRange | undefined {
-	if (!filter || unless?.some(value => filter.indexOf(value) === 0)) {
+	// Ignore when the unless character not the first character or is before the line colon pattern
+	if (!filter || unless?.some(value => {
+		const unlessCharPos = filter.indexOf(value);
+		return unlessCharPos === 0 || unlessCharPos > 0 && !LINE_COLON_PATTERN.test(filter.substring(unlessCharPos + 1));
+	})) {
 		return undefined;
 	}
 

--- a/src/vs/workbench/contrib/search/test/common/extractRange.test.ts
+++ b/src/vs/workbench/contrib/search/test/common/extractRange.test.ts
@@ -12,7 +12,6 @@ suite('extractRangeFromFilter', () => {
 		assert.ok(!extractRangeFromFilter(''));
 		assert.ok(!extractRangeFromFilter('/some/path'));
 		assert.ok(!extractRangeFromFilter('/some/path/file.txt'));
-		assert.ok(!extractRangeFromFilter('/some/@path'), 'paths like as /node_modules/@types/ should be supported');
 
 		for (const lineSep of [':', '#', '(', ':line ']) {
 			for (const colSep of [':', '#', ',']) {
@@ -44,9 +43,56 @@ suite('extractRangeFromFilter', () => {
 		assert.strictEqual(res?.range.startColumn, 20);
 	});
 
-	test('unless', async function () {
-		const res = extractRangeFromFilter('@/some/path/file.txt (19,20)', ['@']);
-
-		assert.ok(!res);
+	suite('unless', async function () {
+		const testSpecs = [
+			// alpha-only symbol after unless
+			{ filter: '/some/path/file.txt@alphasymbol', unless: ['@'], result: undefined },
+			// unless as first char
+			{ filter: '@/some/path/file.txt (19,20)', unless: ['@'], result: undefined },
+			// unless as last char
+			{ filter: '/some/path/file.txt (19,20)@', unless: ['@'], result: undefined },
+			// unless before ,
+			{
+				filter: '/some/@path/file.txt (19,20)', unless: ['@'], result: {
+					filter: '/some/@path/file.txt',
+					range: {
+						endColumn: 20,
+						endLineNumber: 19,
+						startColumn: 20,
+						startLineNumber: 19
+					}
+				}
+			},
+			// unless before :
+			{
+				filter: '/some/@path/file.txt:19:20', unless: ['@'], result: {
+					filter: '/some/@path/file.txt',
+					range: {
+						endColumn: 20,
+						endLineNumber: 19,
+						startColumn: 20,
+						startLineNumber: 19
+					}
+				}
+			},
+			// unless before #
+			{
+				filter: '/some/@path/file.txt#19', unless: ['@'], result: {
+					filter: '/some/@path/file.txt',
+					range: {
+						endColumn: 1,
+						endLineNumber: 19,
+						startColumn: 1,
+						startLineNumber: 19
+					}
+				}
+			},
+		];
+		for (const { filter, unless, result } of testSpecs) {
+			test(`${filter} - ${JSON.stringify(unless)}`, () => {
+				assert.deepStrictEqual(extractRangeFromFilter(filter, unless), result);
+			});
+		}
 	});
 });
+


### PR DESCRIPTION
Fixes #185998

![image](https://github.com/microsoft/vscode/assets/2193314/25618516-137c-456c-b991-be8af4f243e7)

![image](https://github.com/microsoft/vscode/assets/2193314/7dfce8d8-fbff-455d-bd2c-41fd9d29db25)

![image](https://github.com/microsoft/vscode/assets/2193314/50bbf1a3-e77c-4ec9-bafc-f336c0cc7559)
![image](https://github.com/microsoft/vscode/assets/2193314/058ca36a-e9b0-4eb8-979c-1205bd23839a)
