### PR TITLE
Suppress codeql warning

### DIFF
--- a/src/vs/workbench/contrib/files/browser/fileActions.ts
+++ b/src/vs/workbench/contrib/files/browser/fileActions.ts
@@ -720,7 +720,7 @@ export function validateFileName(pathService: IPathService, item: ExplorerItem, 
 	// Check for invalid file name.
 	if (names.some(folderName => !pathService.hasValidBasename(item.resource, os, folderName))) {
 		// Escape * characters
-		const escapedName = name.replace(/\*/g, '\\*');
+		const escapedName = name.replace(/\*/g, '\\*'); // CodeQL [SM02383] This only processes filenames which are enforced against having backslashes in them farther up in the stack.
 		return {
 			content: nls.localize('invalidFileNameError', "The name **{0}** is not valid as a file or folder name. Please choose a different name.", trimLongName(escapedName)),
 			severity: Severity.Error


### PR DESCRIPTION
Suppresses codeql warning surrounding escaping back slashes in the input