### PR TITLE
Resolve profiles on main in parallel

### DIFF
--- a/src/vs/platform/terminal/node/terminalProfiles.ts
+++ b/src/vs/platform/terminal/node/terminalProfiles.ts
@@ -167,84 +167,99 @@ async function transformToTerminalProfiles(
 	logService?: ILogService,
 	variableResolver?: (text: string[]) => Promise<string[]>,
 ): Promise<ITerminalProfile[]> {
-	const resultProfiles: ITerminalProfile[] = [];
+	const promises: Promise<ITerminalProfile | undefined>[] = [];
 	for (const [profileName, profile] of entries) {
-		if (profile === null) { continue; }
-		let originalPaths: (string | ITerminalUnsafePath)[];
-		let args: string[] | string | undefined;
-		let icon: ThemeIcon | URI | { light: URI; dark: URI } | undefined = undefined;
-		// use calculated values if path is not specified
-		if ('source' in profile && !('path' in profile)) {
-			const source = profileSources?.get(profile.source);
-			if (!source) {
-				continue;
-			}
-			originalPaths = source.paths;
+		promises.push(getValidatedProfile(profileName, profile, defaultProfileName, fsProvider, shellEnv, logService, variableResolver));
+	}
+	return (await Promise.all(promises)).filter(e => !!e) as ITerminalProfile[];
+}
 
-			// if there are configured args, override the default ones
-			args = profile.args || source.args;
-			if (profile.icon) {
-				icon = validateIcon(profile.icon);
-			} else if (source.icon) {
-				icon = source.icon;
-			}
-		} else {
-			originalPaths = Array.isArray(profile.path) ? profile.path : [profile.path];
-			args = isWindows ? profile.args : Array.isArray(profile.args) ? profile.args : undefined;
+async function getValidatedProfile(
+	profileName: string,
+	profile: IUnresolvedTerminalProfile,
+	defaultProfileName: string | undefined,
+	fsProvider: IFsProvider,
+	shellEnv: typeof process.env = process.env,
+	logService?: ILogService,
+	variableResolver?: (text: string[]) => Promise<string[]>
+): Promise<ITerminalProfile | undefined> {
+	if (profile === null) {
+		return undefined;
+	}
+	let originalPaths: (string | ITerminalUnsafePath)[];
+	let args: string[] | string | undefined;
+	let icon: ThemeIcon | URI | { light: URI; dark: URI } | undefined = undefined;
+	// use calculated values if path is not specified
+	if ('source' in profile && !('path' in profile)) {
+		const source = profileSources?.get(profile.source);
+		if (!source) {
+			return undefined;
+		}
+		originalPaths = source.paths;
+
+		// if there are configured args, override the default ones
+		args = profile.args || source.args;
+		if (profile.icon) {
 			icon = validateIcon(profile.icon);
+		} else if (source.icon) {
+			icon = source.icon;
 		}
+	} else {
+		originalPaths = Array.isArray(profile.path) ? profile.path : [profile.path];
+		args = isWindows ? profile.args : Array.isArray(profile.args) ? profile.args : undefined;
+		icon = validateIcon(profile.icon);
+	}
 
-		let paths: (string | ITerminalUnsafePath)[];
-		if (variableResolver) {
-			// Convert to string[] for resolve
-			const mapped = originalPaths.map(e => typeof e === 'string' ? e : e.path);
-			const resolved = await variableResolver(mapped);
-			// Convert resolved back to (T | string)[]
-			paths = new Array(originalPaths.length);
-			for (let i = 0; i < originalPaths.length; i++) {
-				if (typeof originalPaths[i] === 'string') {
-					paths[i] = resolved[i];
-				} else {
-					paths[i] = {
-						path: resolved[i],
-						isUnsafe: true
-					};
-				}
-			}
-		} else {
-			paths = originalPaths.slice();
-		}
+	let paths: (string | ITerminalUnsafePath)[];
+	if (variableResolver) {
+		// Convert to string[] for resolve
+		const mapped = originalPaths.map(e => typeof e === 'string' ? e : e.path);
 
-		let requiresUnsafePath: string | undefined;
-		if (profile.requiresPath) {
-			// Validate requiresPath exists
-			let actualRequiredPath: string;
-			if (isString(profile.requiresPath)) {
-				actualRequiredPath = profile.requiresPath;
+		const resolved = await variableResolver(mapped);
+		// Convert resolved back to (T | string)[]
+		paths = new Array(originalPaths.length);
+		for (let i = 0; i < originalPaths.length; i++) {
+			if (typeof originalPaths[i] === 'string') {
+				paths[i] = resolved[i];
 			} else {
-				actualRequiredPath = profile.requiresPath.path;
-				if (profile.requiresPath.isUnsafe) {
-					requiresUnsafePath = actualRequiredPath;
-				}
-			}
-			const result = await fsProvider.existsFile(actualRequiredPath);
-			if (!result) {
-				continue;
+				paths[i] = {
+					path: resolved[i],
+					isUnsafe: true
+				};
 			}
 		}
+	} else {
+		paths = originalPaths.slice();
+	}
 
-		const validatedProfile = await validateProfilePaths(profileName, defaultProfileName, paths, fsProvider, shellEnv, args, profile.env, profile.overrideName, profile.isAutoDetected, requiresUnsafePath);
-		if (validatedProfile) {
-			validatedProfile.isAutoDetected = profile.isAutoDetected;
-			validatedProfile.icon = icon;
-			validatedProfile.color = profile.color;
-			resultProfiles.push(validatedProfile);
+	let requiresUnsafePath: string | undefined;
+	if (profile.requiresPath) {
+		// Validate requiresPath exists
+		let actualRequiredPath: string;
+		if (isString(profile.requiresPath)) {
+			actualRequiredPath = profile.requiresPath;
 		} else {
-			logService?.debug('Terminal profile not validated', profileName, originalPaths);
+			actualRequiredPath = profile.requiresPath.path;
+			if (profile.requiresPath.isUnsafe) {
+				requiresUnsafePath = actualRequiredPath;
+			}
+		}
+		const result = await fsProvider.existsFile(actualRequiredPath);
+		if (!result) {
+			return;
 		}
 	}
-	logService?.debug('Validated terminal profiles', resultProfiles);
-	return resultProfiles;
+
+	const validatedProfile = await validateProfilePaths(profileName, defaultProfileName, paths, fsProvider, shellEnv, args, profile.env, profile.overrideName, profile.isAutoDetected, requiresUnsafePath);
+	if (!validatedProfile) {
+		logService?.debug('Terminal profile not validated', profileName, originalPaths);
+		return undefined;
+	}
+
+	validatedProfile.isAutoDetected = profile.isAutoDetected;
+	validatedProfile.icon = icon;
+	validatedProfile.color = profile.color;
+	return validatedProfile;
 }
 
 function validateIcon(icon: string | TerminalIcon | undefined): TerminalIcon | undefined {


### PR DESCRIPTION
Part of #185393

This actually makes getProfiles fast enough on my macbook that by the time createTerminal is called for reconnecting terminals the profiles are already available 🎉, so it no longer shows up in the terminal startup stats!

Before 801ms

```
2023-06-23 14:25:19.783 [trace] transformToTerminalProfiles variableResolver done
2023-06-23 14:25:19.783 [trace] transformToTerminalProfiles validate profile paths
2023-06-23 14:25:19.783 [trace] transformToTerminalProfiles validate profile paths done
2023-06-23 14:25:19.783 [trace] transformToTerminalProfiles variableResolver
2023-06-23 14:25:20.117 [trace] transformToTerminalProfiles variableResolver done
2023-06-23 14:25:20.117 [trace] transformToTerminalProfiles validate profile paths
2023-06-23 14:25:20.120 [trace] transformToTerminalProfiles validate profile paths done
2023-06-23 14:25:20.120 [trace] transformToTerminalProfiles variableResolver
2023-06-23 14:25:20.224 [trace] transformToTerminalProfiles variableResolver done
2023-06-23 14:25:20.224 [trace] transformToTerminalProfiles validate profile paths
2023-06-23 14:25:20.225 [trace] transformToTerminalProfiles validate profile paths done
2023-06-23 14:25:20.225 [trace] transformToTerminalProfiles variableResolver
2023-06-23 14:25:20.293 [trace] transformToTerminalProfiles variableResolver done
2023-06-23 14:25:20.293 [trace] transformToTerminalProfiles validate profile paths
2023-06-23 14:25:20.296 [trace] transformToTerminalProfiles validate profile paths done
2023-06-23 14:25:20.296 [trace] transformToTerminalProfiles variableResolver
2023-06-23 14:25:20.364 [trace] transformToTerminalProfiles variableResolver done
2023-06-23 14:25:20.364 [trace] transformToTerminalProfiles validate profile paths
2023-06-23 14:25:20.384 [trace] menubarService#updateMenubar 1
2023-06-23 14:25:20.388 [trace] transformToTerminalProfiles validate profile paths done
2023-06-23 14:25:20.388 [trace] transformToTerminalProfiles variableResolver
2023-06-23 14:25:20.477 [trace] transformToTerminalProfiles variableResolver done
2023-06-23 14:25:20.477 [trace] transformToTerminalProfiles validate profile paths
2023-06-23 14:25:20.502 [trace] transformToTerminalProfiles validate profile paths done
2023-06-23 14:25:20.518 [trace] transformToTerminalProfiles variableResolver
2023-06-23 14:25:20.557 [trace] transformToTerminalProfiles variableResolver done
2023-06-23 14:25:20.557 [trace] transformToTerminalProfiles validate profile paths
2023-06-23 14:25:20.563 [trace] transformToTerminalProfiles validate profile paths done
2023-06-23 14:25:20.563 [trace] transformToTerminalProfiles variableResolver
2023-06-23 14:25:20.589 [trace] transformToTerminalProfiles variableResolver done
2023-06-23 14:25:20.589 [trace] transformToTerminalProfiles validate profile paths
2023-06-23 14:25:20.590 [trace] transformToTerminalProfiles validate profile paths done
```

After 187ms

```
2023-06-23 14:43:52.154 [trace] transformToTerminalProfiles
2023-06-23 14:43:52.154 [trace] transformToTerminalProfiles variableResolver
2023-06-23 14:43:52.154 [trace] transformToTerminalProfiles variableResolver
2023-06-23 14:43:52.154 [trace] transformToTerminalProfiles variableResolver
2023-06-23 14:43:52.155 [trace] transformToTerminalProfiles variableResolver
2023-06-23 14:43:52.155 [trace] transformToTerminalProfiles variableResolver
2023-06-23 14:43:52.155 [trace] transformToTerminalProfiles variableResolver
2023-06-23 14:43:52.155 [trace] transformToTerminalProfiles variableResolver
2023-06-23 14:43:52.155 [trace] transformToTerminalProfiles variableResolver
2023-06-23 14:43:52.155 [trace] transformToTerminalProfiles variableResolver
2023-06-23 14:43:52.156 [trace] transformToTerminalProfiles variableResolver
2023-06-23 14:43:52.156 [trace] transformToTerminalProfiles variableResolver
2023-06-23 14:43:52.314 [trace] [UtilityProcess id: 1, type: extensionHost, pid: <none>]: creating new...
2023-06-23 14:43:52.317 [trace] transformToTerminalProfiles variableResolver done
2023-06-23 14:43:52.317 [trace] transformToTerminalProfiles validate profile paths
2023-06-23 14:43:52.318 [trace] transformToTerminalProfiles variableResolver done
2023-06-23 14:43:52.319 [trace] transformToTerminalProfiles validate profile paths
2023-06-23 14:43:52.319 [trace] transformToTerminalProfiles variableResolver done
2023-06-23 14:43:52.319 [trace] transformToTerminalProfiles validate profile paths
2023-06-23 14:43:52.319 [trace] transformToTerminalProfiles variableResolver done
2023-06-23 14:43:52.320 [trace] transformToTerminalProfiles validate profile paths
2023-06-23 14:43:52.320 [trace] transformToTerminalProfiles variableResolver done
2023-06-23 14:43:52.320 [trace] transformToTerminalProfiles validate profile paths
2023-06-23 14:43:52.321 [trace] transformToTerminalProfiles variableResolver done
2023-06-23 14:43:52.321 [trace] transformToTerminalProfiles validate profile paths
2023-06-23 14:43:52.321 [trace] transformToTerminalProfiles variableResolver done
2023-06-23 14:43:52.321 [trace] transformToTerminalProfiles validate profile paths
2023-06-23 14:43:52.322 [trace] transformToTerminalProfiles variableResolver done
2023-06-23 14:43:52.322 [trace] transformToTerminalProfiles validate profile paths
2023-06-23 14:43:52.322 [trace] transformToTerminalProfiles variableResolver done
2023-06-23 14:43:52.323 [trace] transformToTerminalProfiles validate profile paths
2023-06-23 14:43:52.323 [trace] transformToTerminalProfiles variableResolver done
2023-06-23 14:43:52.323 [trace] transformToTerminalProfiles validate profile paths
2023-06-23 14:43:52.324 [trace] transformToTerminalProfiles variableResolver done
2023-06-23 14:43:52.324 [trace] transformToTerminalProfiles validate profile paths
2023-06-23 14:43:52.325 [trace] transformToTerminalProfiles validate profile paths done
2023-06-23 14:43:52.325 [trace] transformToTerminalProfiles validate profile paths done
2023-06-23 14:43:52.325 [trace] transformToTerminalProfiles validate profile paths done
2023-06-23 14:43:52.325 [trace] transformToTerminalProfiles validate profile paths done
2023-06-23 14:43:52.328 [trace] [UtilityProcess id: 1, type: extensionHost, pid: 8838]: successfully created
2023-06-23 14:43:52.329 [trace] transformToTerminalProfiles validate profile paths done
2023-06-23 14:43:52.330 [trace] transformToTerminalProfiles validate profile paths done
2023-06-23 14:43:52.339 [trace] transformToTerminalProfiles validate profile paths done
2023-06-23 14:43:52.340 [trace] transformToTerminalProfiles validate profile paths done
2023-06-23 14:43:52.340 [trace] transformToTerminalProfiles validate profile paths done
2023-06-23 14:43:52.340 [trace] transformToTerminalProfiles validate profile paths done
2023-06-23 14:43:52.341 [trace] transformToTerminalProfiles validate profile paths done
```