### PR TITLE
Directly compare first element

### DIFF
--- a/src/vs/platform/configuration/common/configurationModels.ts
+++ b/src/vs/platform/configuration/common/configurationModels.ts
@@ -211,7 +211,7 @@ export class ConfigurationModel implements IConfigurationModel {
 			}
 		};
 		for (const override of this.overrides) {
-			if (arrays.equals(override.identifiers, [identifier])) {
+			if (override.identifiers[0] === identifier) {
 				contentsForIdentifierOnly = override.contents;
 			} else if (override.identifiers.includes(identifier)) {
 				mergeContents(override.contents);

--- a/src/vs/platform/configuration/common/configurationModels.ts
+++ b/src/vs/platform/configuration/common/configurationModels.ts
@@ -211,7 +211,7 @@ export class ConfigurationModel implements IConfigurationModel {
 			}
 		};
 		for (const override of this.overrides) {
-			if (override.identifiers[0] === identifier) {
+			if (override.identifiers.length === 1 && override.identifiers[0] === identifier) {
 				contentsForIdentifierOnly = override.contents;
 			} else if (override.identifiers.includes(identifier)) {
 				mergeContents(override.contents);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Ref https://github.com/microsoft/vscode/issues/179369

This PR doesn't solve the issue that the function seems to loop through the overrides once in inspect<C> and once again in getContentsForOverrideIdentifer, but it does reduce some function calls.
