### PR TITLE
Add tabSizingFixedMinWidth setting (#185766)

### DIFF
--- a/build/lib/stylelint/vscode-known-variables.json
+++ b/build/lib/stylelint/vscode-known-variables.json
@@ -706,6 +706,7 @@
 		"--tab-dirty-border-top-color",
 		"--tabs-border-bottom-color",
 		"--tab-sizing-current-width",
+		"--tab-sizing-fixed-min-width",
 		"--tab-sizing-fixed-max-width",
 		"--testMessageDecorationFontFamily",
 		"--testMessageDecorationFontSize",

--- a/src/vs/workbench/browser/parts/editor/editor.ts
+++ b/src/vs/workbench/browser/parts/editor/editor.ts
@@ -28,6 +28,7 @@ export const DEFAULT_EDITOR_PART_OPTIONS: IEditorPartOptions = {
 	highlightModifiedTabs: false,
 	tabCloseButton: 'right',
 	tabSizing: 'fit',
+	tabSizingFixedMinWidth: 50,
 	tabSizingFixedMaxWidth: 160,
 	pinnedTabSizing: 'normal',
 	titleScrollbarSizing: 'default',

--- a/src/vs/workbench/browser/parts/editor/media/tabstitlecontrol.css
+++ b/src/vs/workbench/browser/parts/editor/media/tabstitlecontrol.css
@@ -124,7 +124,7 @@
 }
 
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.sizing-fixed {
-	min-width: var(--tab-sizing-current-width, 50px);
+	min-width: var(--tab-sizing-current-width, var(--tab-sizing-fixed-min-width, 50px));
 	max-width: var(--tab-sizing-current-width, var(--tab-sizing-fixed-max-width, 160px));
 	flex: 1 0 0; /* all tabs are evenly sized and grow */
 }

--- a/src/vs/workbench/browser/parts/editor/media/tabstitlecontrol.css
+++ b/src/vs/workbench/browser/parts/editor/media/tabstitlecontrol.css
@@ -133,7 +133,7 @@
 	/* prevent last tab in a row from moving to next row when tab widths are
 	 * fixed in case rounding errors make the fixed tabs grow over the size
 	 * of the tabs container */
-	min-width: calc(var(--tab-sizing-current-width, 50px) - 1px);
+	min-width: calc(var(--tab-sizing-current-width, var(--tab-sizing-fixed-min-width, 50px)) - 1px);
 }
 
 .monaco-workbench .part.editor > .content .editor-group-container > .title > .tabs-and-actions-container.wrapping .tabs-container > .tab.sizing-fit.last-in-row:not(:last-child) {

--- a/src/vs/workbench/browser/parts/editor/tabsTitleControl.ts
+++ b/src/vs/workbench/browser/parts/editor/tabsTitleControl.ts
@@ -234,6 +234,7 @@ export class TabsTitleControl extends TitleControl {
 
 		const options = this.accessor.partOptions;
 		if (options.tabSizing === 'fixed') {
+			tabsContainer.style.setProperty('--tab-sizing-fixed-min-width', `${options.tabSizingFixedMinWidth}px`);
 			tabsContainer.style.setProperty('--tab-sizing-fixed-max-width', `${options.tabSizingFixedMaxWidth}px`);
 
 			// For https://github.com/microsoft/vscode/issues/40290 we want to
@@ -249,6 +250,7 @@ export class TabsTitleControl extends TitleControl {
 				this.updateTabsFixedWidth(false);
 			}));
 		} else if (fromEvent) {
+			tabsContainer.style.removeProperty('--tab-sizing-fixed-min-width');
 			tabsContainer.style.removeProperty('--tab-sizing-fixed-max-width');
 			this.updateTabsFixedWidth(false);
 		}
@@ -721,6 +723,7 @@ export class TabsTitleControl extends TitleControl {
 
 		// Update tabs sizing
 		if (
+			oldOptions.tabSizingFixedMinWidth !== newOptions.tabSizingFixedMinWidth ||
 			oldOptions.tabSizingFixedMaxWidth !== newOptions.tabSizingFixedMaxWidth ||
 			oldOptions.tabSizing !== newOptions.tabSizing
 		) {

--- a/src/vs/workbench/browser/workbench.contribution.ts
+++ b/src/vs/workbench/browser/workbench.contribution.ts
@@ -153,13 +153,13 @@ const registry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Con
 			'workbench.editor.tabSizingFixedMinWidth': {
 				'type': 'number',
 				'default': 50,
-				'minimum': 5,
+				'minimum': 38,
 				'markdownDescription': localize({ comment: ['This is the description for a setting. Values surrounded by single quotes are not to be translated.'], key: 'workbench.editor.tabSizingFixedMinWidth' }, "Controls the minimum width of tabs when `#workbench.editor.tabSizing#` size is set to `fixed`.")
 			},
 			'workbench.editor.tabSizingFixedMaxWidth': {
 				'type': 'number',
 				'default': 160,
-				'minimum': 5,
+				'minimum': 38,
 				'markdownDescription': localize({ comment: ['This is the description for a setting. Values surrounded by single quotes are not to be translated.'], key: 'workbench.editor.tabSizingFixedMaxWidth' }, "Controls the maximum width of tabs when `#workbench.editor.tabSizing#` size is set to `fixed`.")
 			},
 			'workbench.editor.pinnedTabSizing': {

--- a/src/vs/workbench/browser/workbench.contribution.ts
+++ b/src/vs/workbench/browser/workbench.contribution.ts
@@ -150,10 +150,16 @@ const registry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Con
 				],
 				'markdownDescription': localize({ comment: ['This is the description for a setting. Values surrounded by single quotes are not to be translated.'], key: 'tabSizing' }, "Controls the size of editor tabs. This value is ignored when `#workbench.editor.showTabs#` is disabled.")
 			},
+			'workbench.editor.tabSizingFixedMinWidth': {
+				'type': 'number',
+				'default': 50,
+				'minimum': 5,
+				'markdownDescription': localize({ comment: ['This is the description for a setting. Values surrounded by single quotes are not to be translated.'], key: 'workbench.editor.tabSizingFixedMinWidth' }, "Controls the minimum width of tabs when `#workbench.editor.tabSizing#` size is set to `fixed`.")
+			},
 			'workbench.editor.tabSizingFixedMaxWidth': {
 				'type': 'number',
 				'default': 160,
-				'minimum': 50,
+				'minimum': 5,
 				'markdownDescription': localize({ comment: ['This is the description for a setting. Values surrounded by single quotes are not to be translated.'], key: 'workbench.editor.tabSizingFixedMaxWidth' }, "Controls the maximum width of tabs when `#workbench.editor.tabSizing#` size is set to `fixed`.")
 			},
 			'workbench.editor.pinnedTabSizing': {

--- a/src/vs/workbench/common/editor.ts
+++ b/src/vs/workbench/common/editor.ts
@@ -1095,6 +1095,7 @@ interface IEditorPartConfiguration {
 	highlightModifiedTabs?: boolean;
 	tabCloseButton?: 'left' | 'right' | 'off';
 	tabSizing?: 'fit' | 'shrink' | 'fixed';
+	tabSizingFixedMinWidth?: number;
 	tabSizingFixedMaxWidth?: number;
 	pinnedTabSizing?: 'normal' | 'compact' | 'shrink';
 	titleScrollbarSizing?: 'default' | 'large';


### PR DESCRIPTION
This PR simply adds a `tabSizingFixedMinWidth` setting to address the request in #185766. 

With the minimum being configurable, with diverse users presumably choosing both higher and lower values than the default, there is no longer a reason to have a setting minimum for the `MaxWidth`, so I set both to have minimum of 5px, which is the left padding in tabs and in my testing tabs never went any smaller.


