### PR TITLE
Experimental notebook save delegate on remote extension host

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadNotebook.ts
+++ b/src/vs/workbench/api/browser/mainThreadNotebook.ts
@@ -72,7 +72,10 @@ export class MainThreadNotebooks implements MainThreadNotebookShape {
 					extensionId: extension.id.value,
 				});
 				return result;
-			}
+			},
+			save: (uri, versionId, options, token) => {
+				return this._proxy.$saveNotebook(handle, uri, versionId, options, token);
+			},
 		}));
 
 		if (data) {

--- a/src/vs/workbench/api/browser/mainThreadNotebook.ts
+++ b/src/vs/workbench/api/browser/mainThreadNotebook.ts
@@ -73,8 +73,13 @@ export class MainThreadNotebooks implements MainThreadNotebookShape {
 				});
 				return result;
 			},
-			save: (uri, versionId, options, token) => {
-				return this._proxy.$saveNotebook(handle, uri, versionId, options, token);
+			save: async (uri, versionId, options, token) => {
+				const stat = await this._proxy.$saveNotebook(handle, uri, versionId, options, token);
+				return {
+					...stat,
+					children: undefined,
+					resource: uri
+				};
 			},
 		}));
 

--- a/src/vs/workbench/api/common/extHost.api.impl.ts
+++ b/src/vs/workbench/api/common/extHost.api.impl.ts
@@ -170,7 +170,7 @@ export function createApiFactoryAndRegisterActors(accessor: ServicesAccessor): I
 	const extHostDocuments = rpcProtocol.set(ExtHostContext.ExtHostDocuments, new ExtHostDocuments(rpcProtocol, extHostDocumentsAndEditors));
 	const extHostDocumentContentProviders = rpcProtocol.set(ExtHostContext.ExtHostDocumentContentProviders, new ExtHostDocumentContentProvider(rpcProtocol, extHostDocumentsAndEditors, extHostLogService));
 	const extHostDocumentSaveParticipant = rpcProtocol.set(ExtHostContext.ExtHostDocumentSaveParticipant, new ExtHostDocumentSaveParticipant(extHostLogService, extHostDocuments, rpcProtocol.getProxy(MainContext.MainThreadBulkEdits)));
-	const extHostNotebook = rpcProtocol.set(ExtHostContext.ExtHostNotebook, new ExtHostNotebookController(rpcProtocol, extHostCommands, extHostDocumentsAndEditors, extHostDocuments));
+	const extHostNotebook = rpcProtocol.set(ExtHostContext.ExtHostNotebook, new ExtHostNotebookController(rpcProtocol, extHostCommands, extHostDocumentsAndEditors, extHostDocuments, extHostConsumerFileSystem));
 	const extHostNotebookDocuments = rpcProtocol.set(ExtHostContext.ExtHostNotebookDocuments, new ExtHostNotebookDocuments(extHostNotebook));
 	const extHostNotebookEditors = rpcProtocol.set(ExtHostContext.ExtHostNotebookEditors, new ExtHostNotebookEditors(extHostLogService, extHostNotebook));
 	const extHostNotebookKernels = rpcProtocol.set(ExtHostContext.ExtHostNotebookKernels, new ExtHostNotebookKernels(rpcProtocol, initData, extHostNotebook, extHostCommands, extHostLogService));

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -2280,6 +2280,7 @@ export interface ExtHostNotebookShape extends ExtHostNotebookDocumentsAndEditors
 
 	$dataToNotebook(handle: number, data: VSBuffer, token: CancellationToken): Promise<SerializableObjectWithBuffers<NotebookDataDto>>;
 	$notebookToData(handle: number, data: SerializableObjectWithBuffers<NotebookDataDto>, token: CancellationToken): Promise<VSBuffer>;
+	$saveNotebook(handle: number, uri: UriComponents, versionId: number, options: files.IWriteFileOptions, token: CancellationToken): Promise<files.IStat>;
 }
 
 export interface ExtHostNotebookDocumentSaveParticipantShape {

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -2274,13 +2274,15 @@ export interface NotebookCellDto {
 	internalMetadata?: notebookCommon.NotebookCellInternalMetadata;
 }
 
+export type INotebookPartialFileStatsWithMetadata = Omit<files.IFileStatWithMetadata, 'resource' | 'children'>;
+
 export interface ExtHostNotebookShape extends ExtHostNotebookDocumentsAndEditorsShape {
 	$provideNotebookCellStatusBarItems(handle: number, uri: UriComponents, index: number, token: CancellationToken): Promise<INotebookCellStatusBarListDto | undefined>;
 	$releaseNotebookCellStatusBarItems(id: number): void;
 
 	$dataToNotebook(handle: number, data: VSBuffer, token: CancellationToken): Promise<SerializableObjectWithBuffers<NotebookDataDto>>;
 	$notebookToData(handle: number, data: SerializableObjectWithBuffers<NotebookDataDto>, token: CancellationToken): Promise<VSBuffer>;
-	$saveNotebook(handle: number, uri: UriComponents, versionId: number, options: files.IWriteFileOptions, token: CancellationToken): Promise<files.IStat>;
+	$saveNotebook(handle: number, uri: UriComponents, versionId: number, options: files.IWriteFileOptions, token: CancellationToken): Promise<INotebookPartialFileStatsWithMetadata>;
 }
 
 export interface ExtHostNotebookDocumentSaveParticipantShape {

--- a/src/vs/workbench/api/common/extHostNotebookDocument.ts
+++ b/src/vs/workbench/api/common/extHostNotebookDocument.ts
@@ -186,6 +186,10 @@ export class ExtHostNotebookDocument {
 		this._disposed = true;
 	}
 
+	get versionId(): number {
+		return this._versionId;
+	}
+
 	get apiNotebook(): vscode.NotebookDocument {
 		if (!this._notebook) {
 			const that = this;

--- a/src/vs/workbench/api/test/browser/extHostNotebook.test.ts
+++ b/src/vs/workbench/api/test/browser/extHostNotebook.test.ts
@@ -24,6 +24,8 @@ import { ExtHostNotebookDocuments } from 'vs/workbench/api/common/extHostNoteboo
 import { SerializableObjectWithBuffers } from 'vs/workbench/services/extensions/common/proxyIdentifier';
 import { VSBuffer } from 'vs/base/common/buffer';
 import { IExtHostTelemetry } from 'vs/workbench/api/common/extHostTelemetry';
+import { ExtHostConsumerFileSystem } from 'vs/workbench/api/common/extHostFileSystemConsumer';
+import { ExtHostFileSystemInfo } from 'vs/workbench/api/common/extHostFileSystemInfo';
 
 suite('NotebookCell#Document', function () {
 
@@ -34,6 +36,7 @@ suite('NotebookCell#Document', function () {
 	let extHostDocuments: ExtHostDocuments;
 	let extHostNotebooks: ExtHostNotebookController;
 	let extHostNotebookDocuments: ExtHostNotebookDocuments;
+	let extHostConsumerFileSystem: ExtHostConsumerFileSystem;
 
 	const notebookUri = URI.parse('test:///notebook.file');
 	const disposables = new DisposableStore();
@@ -53,11 +56,12 @@ suite('NotebookCell#Document', function () {
 		});
 		extHostDocumentsAndEditors = new ExtHostDocumentsAndEditors(rpcProtocol, new NullLogService());
 		extHostDocuments = new ExtHostDocuments(rpcProtocol, extHostDocumentsAndEditors);
+		extHostConsumerFileSystem = new ExtHostConsumerFileSystem(rpcProtocol, new ExtHostFileSystemInfo());
 		extHostNotebooks = new ExtHostNotebookController(rpcProtocol, new ExtHostCommands(rpcProtocol, new NullLogService(), new class extends mock<IExtHostTelemetry>() {
 			override onExtensionError(): boolean {
 				return true;
 			}
-		}), extHostDocumentsAndEditors, extHostDocuments);
+		}), extHostDocumentsAndEditors, extHostDocuments, extHostConsumerFileSystem);
 		extHostNotebookDocuments = new ExtHostNotebookDocuments(extHostNotebooks);
 
 		const reg = extHostNotebooks.registerNotebookSerializer(nullExtensionDescription, 'test', new class extends mock<vscode.NotebookSerializer>() { });

--- a/src/vs/workbench/api/test/browser/extHostNotebookKernel.test.ts
+++ b/src/vs/workbench/api/test/browser/extHostNotebookKernel.test.ts
@@ -26,6 +26,8 @@ import { SerializableObjectWithBuffers } from 'vs/workbench/services/extensions/
 import { TestRPCProtocol } from 'vs/workbench/api/test/common/testRPCProtocol';
 import { mock } from 'vs/workbench/test/common/workbenchTestServices';
 import { IExtHostTelemetry } from 'vs/workbench/api/common/extHostTelemetry';
+import { ExtHostConsumerFileSystem } from 'vs/workbench/api/common/extHostFileSystemConsumer';
+import { ExtHostFileSystemInfo } from 'vs/workbench/api/common/extHostFileSystemInfo';
 
 suite('NotebookKernel', function () {
 
@@ -37,6 +39,7 @@ suite('NotebookKernel', function () {
 	let extHostNotebooks: ExtHostNotebookController;
 	let extHostNotebookDocuments: ExtHostNotebookDocuments;
 	let extHostCommands: ExtHostCommands;
+	let extHostConsumerFileSystem: ExtHostConsumerFileSystem;
 
 	const notebookUri = URI.parse('test:///notebook.file');
 	const kernelData = new Map<number, INotebookKernelDto2>();
@@ -94,7 +97,8 @@ suite('NotebookKernel', function () {
 				return true;
 			}
 		});
-		extHostNotebooks = new ExtHostNotebookController(rpcProtocol, extHostCommands, extHostDocumentsAndEditors, extHostDocuments);
+		extHostConsumerFileSystem = new ExtHostConsumerFileSystem(rpcProtocol, new ExtHostFileSystemInfo());
+		extHostNotebooks = new ExtHostNotebookController(rpcProtocol, extHostCommands, extHostDocumentsAndEditors, extHostDocuments, extHostConsumerFileSystem);
 
 		extHostNotebookDocuments = new ExtHostNotebookDocuments(extHostNotebooks);
 

--- a/src/vs/workbench/contrib/notebook/common/notebookEditorModel.ts
+++ b/src/vs/workbench/contrib/notebook/common/notebookEditorModel.ts
@@ -11,10 +11,10 @@ import { IMarkdownString } from 'vs/base/common/htmlContent';
 import { Disposable, DisposableStore } from 'vs/base/common/lifecycle';
 import { Schemas } from 'vs/base/common/network';
 import { filter } from 'vs/base/common/objects';
-import { basename } from 'vs/base/common/resources';
 import { assertType } from 'vs/base/common/types';
 import { URI } from 'vs/base/common/uri';
-import { IWriteFileOptions, IFileStatWithMetadata, FileType, FilePermission, etag } from 'vs/platform/files/common/files';
+import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
+import { IWriteFileOptions, IFileStatWithMetadata } from 'vs/platform/files/common/files';
 import { IRevertOptions, ISaveOptions, IUntypedEditorInput } from 'vs/workbench/common/editor';
 import { EditorModel } from 'vs/workbench/common/editor/editorModel';
 import { NotebookTextModel } from 'vs/workbench/contrib/notebook/common/model/notebookTextModel';
@@ -177,10 +177,12 @@ export class NotebookFileWorkingCopyModel extends Disposable implements IStoredF
 	readonly onWillDispose: Event<void>;
 
 	readonly configuration: IFileWorkingCopyModelConfiguration | undefined = undefined;
+	save: ((options: IWriteFileOptions, token: CancellationToken) => Promise<IFileStatWithMetadata>) | undefined;
 
 	constructor(
 		private readonly _notebookModel: NotebookTextModel,
-		private readonly _notebookService: INotebookService
+		private readonly _notebookService: INotebookService,
+		private readonly _configurationService: IConfigurationService
 	) {
 		super();
 
@@ -211,6 +213,20 @@ export class NotebookFileWorkingCopyModel extends Disposable implements IStoredF
 				// remote hosts the extension of the notebook with the contents truth
 				backupDelay: 10000
 			};
+
+			// Override save behavior to avoid transferring the buffer across the wire 3 times
+			if (this._configurationService.getValue('notebook.experimental.remoteSave')) {
+				this.save = async (options: IWriteFileOptions, token: CancellationToken) => {
+					const serializer = await this.getNotebookSerializer();
+
+					if (token.isCancellationRequested) {
+						throw new CancellationError();
+					}
+
+					const stat = await serializer.save(this._notebookModel.uri, this._notebookModel.versionId, options, token);
+					return stat;
+				};
+			}
 		}
 	}
 
@@ -254,38 +270,6 @@ export class NotebookFileWorkingCopyModel extends Disposable implements IStoredF
 		return bufferToStream(bytes);
 	}
 
-	async save(options: IWriteFileOptions, token: CancellationToken): Promise<IFileStatWithMetadata> {
-		const serializer = await this.getNotebookSerializer();
-
-		if (token.isCancellationRequested) {
-			throw new CancellationError();
-		}
-
-		// const stat = await this.validateWriteFile(provider, resource, options);
-		// const handle = await provider.open(resource, { create: true, unlock: options?.unlock ?? false });
-
-
-		const stat = await serializer.save(this._notebookModel.uri, this._notebookModel.versionId, options, token);
-		const fileStat: IFileStatWithMetadata = {
-			resource: this._notebookModel.uri,
-			// name: providerExtUri.basename(resource),
-			name: basename(this._notebookModel.uri),
-			isFile: (stat.type & FileType.File) !== 0,
-			isDirectory: (stat.type & FileType.Directory) !== 0,
-			isSymbolicLink: (stat.type & FileType.SymbolicLink) !== 0,
-			mtime: stat.mtime,
-			ctime: stat.ctime,
-			size: stat.size,
-			readonly: Boolean((stat.permissions ?? 0) & FilePermission.Readonly), // || Boolean(provider.capabilities & FileSystemProviderCapabilities.Readonly),
-			// readonly: Boolean((stat.permissions ?? 0) & FilePermission.Readonly) || Boolean(provider.capabilities & FileSystemProviderCapabilities.Readonly),
-			locked: Boolean((stat.permissions ?? 0) & FilePermission.Locked),
-			etag: etag({ mtime: stat.mtime, size: stat.size }),
-			children: undefined
-		};
-
-		return fileStat;
-	}
-
 	async update(stream: VSBufferReadableStream, token: CancellationToken): Promise<void> {
 		const serializer = await this.getNotebookSerializer();
 
@@ -321,6 +305,7 @@ export class NotebookFileWorkingCopyModelFactory implements IStoredFileWorkingCo
 	constructor(
 		private readonly _viewType: string,
 		@INotebookService private readonly _notebookService: INotebookService,
+		@IConfigurationService private readonly _configurationService: IConfigurationService,
 	) { }
 
 	async createModel(resource: URI, stream: VSBufferReadableStream, token: CancellationToken): Promise<NotebookFileWorkingCopyModel> {
@@ -338,7 +323,7 @@ export class NotebookFileWorkingCopyModelFactory implements IStoredFileWorkingCo
 		}
 
 		const notebookModel = this._notebookService.createNotebookTextModel(info.viewType, resource, data, info.serializer.options);
-		return new NotebookFileWorkingCopyModel(notebookModel, this._notebookService);
+		return new NotebookFileWorkingCopyModel(notebookModel, this._notebookService, this._configurationService);
 	}
 }
 

--- a/src/vs/workbench/contrib/notebook/common/notebookEditorModelResolverServiceImpl.ts
+++ b/src/vs/workbench/contrib/notebook/common/notebookEditorModelResolverServiceImpl.ts
@@ -20,6 +20,7 @@ import { Schemas } from 'vs/base/common/network';
 import { NotebookProviderInfo } from 'vs/workbench/contrib/notebook/common/notebookProvider';
 import { assertIsDefined } from 'vs/base/common/types';
 import { CancellationToken } from 'vs/base/common/cancellation';
+import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 
 class NotebookModelReferenceCollection extends ReferenceCollection<Promise<IResolvedNotebookEditorModel>> {
 
@@ -40,6 +41,7 @@ class NotebookModelReferenceCollection extends ReferenceCollection<Promise<IReso
 		@IInstantiationService private readonly _instantiationService: IInstantiationService,
 		@INotebookService private readonly _notebookService: INotebookService,
 		@ILogService private readonly _logService: ILogService,
+		@IConfigurationService private readonly _configurationService: IConfigurationService,
 	) {
 		super();
 	}
@@ -65,7 +67,7 @@ class NotebookModelReferenceCollection extends ReferenceCollection<Promise<IReso
 		const workingCopyTypeId = NotebookWorkingCopyTypeIdentifier.create(viewType);
 		let workingCopyManager = this._workingCopyManagers.get(workingCopyTypeId);
 		if (!workingCopyManager) {
-			const factory = new NotebookFileWorkingCopyModelFactory(viewType, this._notebookService);
+			const factory = new NotebookFileWorkingCopyModelFactory(viewType, this._notebookService, this._configurationService);
 			workingCopyManager = <IFileWorkingCopyManager<NotebookFileWorkingCopyModel, NotebookFileWorkingCopyModel>><any>this._instantiationService.createInstance(
 				FileWorkingCopyManager,
 				workingCopyTypeId,

--- a/src/vs/workbench/contrib/notebook/common/notebookService.ts
+++ b/src/vs/workbench/contrib/notebook/common/notebookService.ts
@@ -14,6 +14,7 @@ import { NotebookCellTextModel } from 'vs/workbench/contrib/notebook/common/mode
 import { IDisposable } from 'vs/base/common/lifecycle';
 import { VSBuffer } from 'vs/base/common/buffer';
 import { ConfigurationTarget } from 'vs/platform/configuration/common/configuration';
+import { IStat, IWriteFileOptions } from 'vs/platform/files/common/files';
 
 
 export const INotebookService = createDecorator<INotebookService>('notebookService');
@@ -29,6 +30,7 @@ export interface INotebookSerializer {
 	options: TransientOptions;
 	dataToNotebook(data: VSBuffer): Promise<NotebookData>;
 	notebookToData(data: NotebookData): Promise<VSBuffer>;
+	save(uri: URI, versionId: number, options: IWriteFileOptions, token: CancellationToken): Promise<IStat>;
 }
 
 export interface INotebookRawData {

--- a/src/vs/workbench/contrib/notebook/common/notebookService.ts
+++ b/src/vs/workbench/contrib/notebook/common/notebookService.ts
@@ -14,7 +14,7 @@ import { NotebookCellTextModel } from 'vs/workbench/contrib/notebook/common/mode
 import { IDisposable } from 'vs/base/common/lifecycle';
 import { VSBuffer } from 'vs/base/common/buffer';
 import { ConfigurationTarget } from 'vs/platform/configuration/common/configuration';
-import { IStat, IWriteFileOptions } from 'vs/platform/files/common/files';
+import { IFileStatWithMetadata, IWriteFileOptions } from 'vs/platform/files/common/files';
 
 
 export const INotebookService = createDecorator<INotebookService>('notebookService');
@@ -30,7 +30,7 @@ export interface INotebookSerializer {
 	options: TransientOptions;
 	dataToNotebook(data: VSBuffer): Promise<NotebookData>;
 	notebookToData(data: NotebookData): Promise<VSBuffer>;
-	save(uri: URI, versionId: number, options: IWriteFileOptions, token: CancellationToken): Promise<IStat>;
+	save(uri: URI, versionId: number, options: IWriteFileOptions, token: CancellationToken): Promise<IFileStatWithMetadata>;
 }
 
 export interface INotebookRawData {

--- a/src/vs/workbench/contrib/notebook/test/browser/notebookEditorModel.test.ts
+++ b/src/vs/workbench/contrib/notebook/test/browser/notebookEditorModel.test.ts
@@ -10,6 +10,7 @@ import { DisposableStore } from 'vs/base/common/lifecycle';
 import { Mimes } from 'vs/base/common/mime';
 import { URI } from 'vs/base/common/uri';
 import { mock } from 'vs/base/test/common/mock';
+import { TestConfigurationService } from 'vs/platform/configuration/test/common/testConfigurationService';
 import { ExtensionIdentifier } from 'vs/platform/extensions/common/extensions';
 import { TestInstantiationService } from 'vs/platform/instantiation/test/common/instantiationServiceMock';
 import { NotebookTextModel } from 'vs/workbench/contrib/notebook/common/model/notebookTextModel';
@@ -22,6 +23,7 @@ suite('NotebookFileWorkingCopyModel', function () {
 
 	let disposables: DisposableStore;
 	let instantiationService: TestInstantiationService;
+	const configurationService = new TestConfigurationService();
 
 	suiteSetup(() => {
 		disposables = new DisposableStore();
@@ -54,7 +56,8 @@ suite('NotebookFileWorkingCopyModel', function () {
 							return VSBuffer.fromString('');
 						}
 					}
-				)
+				),
+				configurationService
 			);
 
 			await model.snapshot(CancellationToken.None);
@@ -75,7 +78,8 @@ suite('NotebookFileWorkingCopyModel', function () {
 							return VSBuffer.fromString('');
 						}
 					}
-				)
+				),
+				configurationService
 			);
 			await model.snapshot(CancellationToken.None);
 			assert.strictEqual(callCount, 1);
@@ -106,7 +110,8 @@ suite('NotebookFileWorkingCopyModel', function () {
 							return VSBuffer.fromString('');
 						}
 					}
-				)
+				),
+				configurationService
 			);
 
 			await model.snapshot(CancellationToken.None);
@@ -127,7 +132,8 @@ suite('NotebookFileWorkingCopyModel', function () {
 							return VSBuffer.fromString('');
 						}
 					}
-				)
+				),
+				configurationService
 			);
 			await model.snapshot(CancellationToken.None);
 			assert.strictEqual(callCount, 1);
@@ -158,7 +164,8 @@ suite('NotebookFileWorkingCopyModel', function () {
 							return VSBuffer.fromString('');
 						}
 					}
-				)
+				),
+				configurationService
 			);
 
 			await model.snapshot(CancellationToken.None);
@@ -179,7 +186,8 @@ suite('NotebookFileWorkingCopyModel', function () {
 							return VSBuffer.fromString('');
 						}
 					}
-				)
+				),
+				configurationService
 			);
 			await model.snapshot(CancellationToken.None);
 			assert.strictEqual(callCount, 1);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Experimental fix for https://github.com/microsoft/vscode/issues/172345:

* Delegate save to remote extension ExthostNotebook when we enable `notebook.experimental.remoteSave`.
* The save only happens if we are connected to Remote EH
* The save request is sent to FS only when the `ExtHostNotebookDocument` and the `NotebookEditorModel` in the renderer process have the same version id

Currently didn't implement all FS checks we have on file save yet.