### PR TITLE
dialogs - rename setting to `files.dialog.defaultPath`

### DIFF
--- a/src/vs/workbench/contrib/files/browser/files.contribution.ts
+++ b/src/vs/workbench/contrib/files/browser/files.contribution.ts
@@ -323,9 +323,9 @@ configurationRegistry.registerConfiguration({
 			'default': 'askUser',
 			'scope': ConfigurationScope.LANGUAGE_OVERRIDABLE
 		},
-		'files.dialog.homePath': {
+		'files.dialog.defaultPath': {
 			'type': 'string',
-			'description': nls.localize('fileDialogHomePath', "Default path for file dialogs, overriding user's home path. Only used in the absence of a context-specific path, such as most recently opened file or folder."),
+			'description': nls.localize('fileDialogDefaultPath', "Default path for file dialogs, overriding user's home path. Only used in the absence of a context-specific path, such as most recently opened file or folder."),
 			'scope': ConfigurationScope.MACHINE
 		},
 		'files.simpleDialog.enable': {

--- a/src/vs/workbench/services/dialogs/browser/abstractFileDialogService.ts
+++ b/src/vs/workbench/services/dialogs/browser/abstractFileDialogService.ts
@@ -93,8 +93,9 @@ export abstract class AbstractFileDialogService implements IFileDialogService {
 	}
 
 	async preferredHome(schemeFilter = this.getSchemeFilterForWindow()): Promise<URI> {
+
 		// Seek a user-local or user-remote machine-scoped override path string depending on whether caller wants a local or a remote home
-		const inspectedValue = this.configurationService.inspect<string>('files.dialog.homePath');
+		const inspectedValue = this.configurationService.inspect<string>('files.dialog.defaultPath');
 		const dialogHomePath = schemeFilter === Schemas.file ? inspectedValue.userLocalValue : inspectedValue.userRemoteValue;
 		const userHomePromise = this.pathService.userHome({ preferLocal: schemeFilter === Schemas.file });
 		if (!dialogHomePath) {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
