### PR TITLE
Accept a trailing colon in --goto format.

### DIFF
--- a/src/vs/platform/environment/node/argvHelper.ts
+++ b/src/vs/platform/environment/node/argvHelper.ts
@@ -42,7 +42,7 @@ function parseAndValidate(cmdLineArgs: string[], reportWarnings: boolean): Nativ
 
 	const args = parseArgs(cmdLineArgs, OPTIONS, reportWarnings ? errorReporter : undefined);
 	if (args.goto) {
-		args._.forEach(arg => assert(/^(\w:)?[^:]+(:\d*){0,2}$/.test(arg), localize('gotoValidation', "Arguments in `--goto` mode should be in the format of `FILE(:LINE(:CHARACTER))`.")));
+		args._.forEach(arg => assert(/^(\w:)?[^:]+(:\d*){0,2}:?$/.test(arg), localize('gotoValidation', "Arguments in `--goto` mode should be in the format of `FILE(:LINE(:CHARACTER))`.")));
 	}
 
 	return args;

--- a/src/vs/workbench/contrib/search/common/search.ts
+++ b/src/vs/workbench/contrib/search/common/search.ts
@@ -148,8 +148,8 @@ export function getOutOfWorkspaceEditorResources(accessor: ServicesAccessor): UR
 	return resources as URI[];
 }
 
-// Supports patterns of <path><#|:|(><line><#|:|,><col?>
-const LINE_COLON_PATTERN = /\s?[#:\(](?:line )?(\d*)(?:[#:,](\d*))?\)?\s*$/;
+// Supports patterns of <path><#|:|(><line><#|:|,><col?><:?>
+const LINE_COLON_PATTERN = /\s?[#:\(](?:line )?(\d*)(?:[#:,](\d*))?\)?:?\s*$/;
 
 export interface IFilterAndRange {
 	filter: string;


### PR DESCRIPTION
Fixes #186173

See #186173 for motivation.

Only the validation code needs modification, as [the parsing code](https://github.com/microsoft/vscode/blob/b97d99f428c6a4b5366f9612b775dd8b473ae523/src/vs/base/common/extpath.ts#L355) already works fine with a trailing colon.