### PR TITLE
remove setting with no effect

### DIFF
--- a/src/vs/workbench/contrib/interactive/browser/interactive.contribution.ts
+++ b/src/vs/workbench/contrib/interactive/browser/interactive.contribution.ts
@@ -795,7 +795,8 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).regis
 		[InteractiveWindowSetting.interactiveWindowRestore]: {
 			type: 'boolean',
 			default: false,
-			markdownDescription: localize('interactiveWindow.restore', "Controls whether the Interactive Window sessions/history should be restored across window reloads. Whether the state of controllers used in Interactive Windows is persisted across window reloads are controlled by extensions contributing controllers.")
+			markdownDescription: localize('interactiveWindow.restore', "Controls whether the Interactive Window sessions/history should be restored across window reloads. Whether the state of controllers used in Interactive Windows is persisted across window reloads are controlled by extensions contributing controllers."),
+			deprecationMessage: localize('interactiveWindow.restoreDeprecation', "Restoring the editor is now built in so this setting no longer affects the behavior")
 		}
 	}
 });

--- a/src/vs/workbench/contrib/interactive/browser/interactive.contribution.ts
+++ b/src/vs/workbench/contrib/interactive/browser/interactive.contribution.ts
@@ -791,12 +791,6 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).regis
 			type: 'boolean',
 			default: true,
 			markdownDescription: localize('interactiveWindow.alwaysScrollOnNewCell', "Automatically scroll the interactive window to show the output of the last statement executed. If this value is false, the window will only scroll if the last cell was already the one scrolled to.")
-		},
-		[InteractiveWindowSetting.interactiveWindowRestore]: {
-			type: 'boolean',
-			default: false,
-			markdownDescription: localize('interactiveWindow.restore', "Controls whether the Interactive Window sessions/history should be restored across window reloads. Whether the state of controllers used in Interactive Windows is persisted across window reloads are controlled by extensions contributing controllers."),
-			deprecationMessage: localize('interactiveWindow.restoreDeprecation', "Restoring the editor is now built in so this setting no longer affects the behavior")
 		}
 	}
 });

--- a/src/vs/workbench/contrib/interactive/browser/interactiveCommon.ts
+++ b/src/vs/workbench/contrib/interactive/browser/interactiveCommon.ts
@@ -8,6 +8,5 @@ import { RawContextKey } from 'vs/platform/contextkey/common/contextkey';
 export const INTERACTIVE_INPUT_CURSOR_BOUNDARY = new RawContextKey<'none' | 'top' | 'bottom' | 'both'>('interactiveInputCursorAtBoundary', 'none');
 
 export const InteractiveWindowSetting = {
-	interactiveWindowAlwaysScrollOnNewCell: 'interactiveWindow.alwaysScrollOnNewCell',
-	interactiveWindowRestore: 'interactiveWindow.restore'
+	interactiveWindowAlwaysScrollOnNewCell: 'interactiveWindow.alwaysScrollOnNewCell'
 };


### PR DESCRIPTION
Restoring the Interactive window is now built in through usage of the Working Copy Service so the setting no longer affects the behavior.