### PR TITLE
make interrupt always visible for IW

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/controller/executeActions.ts
+++ b/src/vs/workbench/contrib/notebook/browser/controller/executeActions.ts
@@ -573,6 +573,10 @@ registerAction2(class InterruptNotebook extends CancelNotebook {
 				value: localize('notebookActions.interruptNotebook', "Interrupt"),
 				original: 'Interrupt'
 			},
+			precondition: ContextKeyExpr.and(
+				NOTEBOOK_HAS_SOMETHING_RUNNING,
+				NOTEBOOK_INTERRUPTIBLE_KERNEL
+			),
 			icon: icons.stopIcon,
 			menu: [
 				{
@@ -598,11 +602,6 @@ registerAction2(class InterruptNotebook extends CancelNotebook {
 				},
 				{
 					id: MenuId.InteractiveToolbar,
-					when: ContextKeyExpr.and(
-						NOTEBOOK_HAS_SOMETHING_RUNNING,
-						NOTEBOOK_INTERRUPTIBLE_KERNEL,
-						ContextKeyExpr.equals('activeEditor', 'workbench.editor.interactive')
-					),
 					group: 'navigation/execute'
 				}
 			]


### PR DESCRIPTION
for https://github.com/microsoft/vscode-jupyter/issues/13673

following up on other changes to reduce the amount of movement in the notebook toolbar, this will keep the interrupt button visible, and disable it when it has no effect.