### PR TITLE
Fix encryption by not double sequencing

### DIFF
--- a/src/vs/platform/encryption/electron-main/encryptionMainService.ts
+++ b/src/vs/platform/encryption/electron-main/encryptionMainService.ts
@@ -31,8 +31,8 @@ export class EncryptionMainService implements IEncryptionMainService {
 	}
 
 	async encrypt(value: string): Promise<string> {
+		this.logService.trace('[EncryptionMainService] Encrypting value.');
 		try {
-			this.logService.trace('[EncryptionMainService] Encrypting value.');
 			const result = JSON.stringify(safeStorage.encryptString(value));
 			this.logService.trace('[EncryptionMainService] Encrypted value.');
 			return result;
@@ -57,7 +57,14 @@ export class EncryptionMainService implements IEncryptionMainService {
 		const bufferToDecrypt = Buffer.from(parsedValue.data);
 
 		this.logService.trace('[EncryptionMainService] Decrypting value.');
-		return safeStorage.decryptString(bufferToDecrypt);
+		try {
+			const result = safeStorage.decryptString(bufferToDecrypt);
+			this.logService.trace('[EncryptionMainService] Decrypted value.');
+			return result;
+		} catch (e) {
+			this.logService.error(e);
+			throw e;
+		}
 	}
 
 	isEncryptionAvailable(): Promise<boolean> {

--- a/src/vs/workbench/services/secrets/electron-sandbox/secretStorageService.ts
+++ b/src/vs/workbench/services/secrets/electron-sandbox/secretStorageService.ts
@@ -44,7 +44,7 @@ export class NativeSecretStorageService extends BaseSecretStorageService {
 
 		});
 
-		return this._sequencer.queue(key, () => super.set(key, value));
+		return super.set(key, value);
 	}
 
 	private notifyOfNoEncryptionOnce = once(() => this.notifyOfNoEncryption());


### PR DESCRIPTION
super.set adds to the sequencer... I shouldn't do that in the overridden function too otherwise it'll lock up.

Also more trace logging because _why not_?

Thanks for reporting @joyceerhl!

Fixes https://github.com/microsoft/vscode/issues/186226

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
