### PR TITLE
use basicText

### DIFF
--- a/src/vs/workbench/services/secrets/electron-sandbox/secretStorageService.ts
+++ b/src/vs/workbench/services/secrets/electron-sandbox/secretStorageService.ts
@@ -66,7 +66,7 @@ export class NativeSecretStorageService extends BaseSecretStorageService {
 		}
 
 		const provider = await this._encryptionService.getKeyStorageProvider();
-		if (provider === KnownStorageProvider.keychainAccess) {
+		if (provider === KnownStorageProvider.basicText) {
 			const detail = localize('usePlainTextExtraSentence', "Open the troubleshooting guide to address this or you can use weaker encryption that doesn't use the OS keyring.");
 			const usePlainTextButton: IPromptChoice = {
 				label: localize('usePlainText', "Use weaker encryption"),


### PR DESCRIPTION
I had changed it to keychainAccess while testing on mac but it always should have bedn basicText.

Needed for unblocking TPI https://github.com/microsoft/vscode/issues/186239
