### PR TITLE
Added null check before building getting started slide.

### DIFF
--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts
@@ -1151,7 +1151,7 @@ export class GettingStartedPage extends EditorPane {
 		this.featuredExtensionsList?.layout(size);
 		this.recentlyOpenedList?.layout(size);
 
-		if (this.editorInput.selectedStep && this.currentMediaType) {
+		if (this.editorInput?.selectedStep && this.currentMediaType) {
 			this.mediaDisposables.clear();
 			this.stepDisposables.clear();
 			this.buildMediaComponent(this.editorInput.selectedStep);


### PR DESCRIPTION
This code was introduced yesterday with: https://github.com/microsoft/vscode/pull/186267

Prevents this from happening if some of the welcome page components try to layout before the editor is fully initialized.
<img width="496" alt="image" src="https://github.com/microsoft/vscode/assets/25044782/d485c55e-97e0-4b2c-b229-6bf113055621">
