### PR TITLE
Dispose status bar items on EH restart, but only those that were defined by extensions, not those defined statically

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadStatusBar.ts
+++ b/src/vs/workbench/api/browser/mainThreadStatusBar.ts
@@ -6,11 +6,11 @@
 import { MainThreadStatusBarShape, MainContext, ExtHostContext, StatusBarItemDto } from '../common/extHost.protocol';
 import { ThemeColor } from 'vs/base/common/themables';
 import { extHostNamedCustomer, IExtHostContext } from 'vs/workbench/services/extensions/common/extHostCustomers';
-import { DisposableStore } from 'vs/base/common/lifecycle';
+import { DisposableStore, toDisposable } from 'vs/base/common/lifecycle';
 import { Command } from 'vs/editor/common/languages';
 import { IAccessibilityInformation } from 'vs/platform/accessibility/common/accessibility';
 import { IMarkdownString } from 'vs/base/common/htmlContent';
-import { IExtensionStatusBarItemService } from 'vs/workbench/api/browser/statusBarExtensionPoint';
+import { IExtensionStatusBarItemService, StatusBarUpdateKind } from 'vs/workbench/api/browser/statusBarExtensionPoint';
 import { IStatusbarEntry, StatusbarAlignment } from 'vs/workbench/services/statusbar/browser/statusbar';
 
 @extHostNamedCustomer(MainContext.MainThreadStatusBar)
@@ -57,7 +57,10 @@ export class MainThreadStatusBar implements MainThreadStatusBarShape {
 	}
 
 	$setEntry(entryId: string, id: string, extensionId: string | undefined, name: string, text: string, tooltip: IMarkdownString | string | undefined, command: Command | undefined, color: string | ThemeColor | undefined, backgroundColor: string | ThemeColor | undefined, alignLeft: boolean, priority: number | undefined, accessibilityInformation: IAccessibilityInformation | undefined): void {
-		this.statusbarService.setOrUpdateEntry(entryId, id, extensionId, name, text, tooltip, command, color, backgroundColor, alignLeft, priority, accessibilityInformation);
+		const kind = this.statusbarService.setOrUpdateEntry(entryId, id, extensionId, name, text, tooltip, command, color, backgroundColor, alignLeft, priority, accessibilityInformation);
+		if (kind === StatusBarUpdateKind.DidDefine) {
+			this._store.add(toDisposable(() => this.statusbarService.unsetEntry(entryId)));
+		}
 	}
 
 	$disposeEntry(entryId: string) {


### PR DESCRIPTION
nit: Static items that have been "refined" by extensions will keep the refined state on restart

re https://github.com/microsoft/vscode/issues/186315
