### PR TITLE
Fix #186473. Hide select kernel action from f1 when active editor is not notebook.

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/viewParts/notebookKernelView.ts
+++ b/src/vs/workbench/contrib/notebook/browser/viewParts/notebookKernelView.ts
@@ -48,6 +48,7 @@ registerAction2(class extends Action2 {
 			title: { value: localize('notebookActions.selectKernel', "Select Notebook Kernel"), original: 'Select Notebook Kernel' },
 			icon: selectKernelIcon,
 			f1: true,
+			precondition: NOTEBOOK_IS_ACTIVE_EDITOR,
 			menu: [{
 				id: MenuId.EditorTitle,
 				when: ContextKeyExpr.and(


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
