### PR TITLE
Fix removing tunnels when the tunnel factory throws an error

### DIFF
--- a/src/vs/platform/tunnel/common/tunnel.ts
+++ b/src/vs/platform/tunnel/common/tunnel.ts
@@ -416,7 +416,7 @@ export abstract class AbstractTunnelService implements ITunnelService {
 		const hostMap = this._tunnels.get(remoteHost);
 		if (hostMap) {
 			const tunnel = hostMap.get(remotePort);
-			const tunnelResult = await tunnel.value;
+			const tunnelResult = tunnel ? await tunnel.value : null;
 			if (!tunnelResult) {
 				hostMap.delete(remotePort);
 			}

--- a/src/vs/platform/tunnel/common/tunnel.ts
+++ b/src/vs/platform/tunnel/common/tunnel.ts
@@ -416,7 +416,7 @@ export abstract class AbstractTunnelService implements ITunnelService {
 		const hostMap = this._tunnels.get(remoteHost);
 		if (hostMap) {
 			const tunnel = hostMap.get(remotePort);
-			const tunnelResult = tunnel ? await tunnel.value : null;
+			const tunnelResult = tunnel ? await tunnel.value : undefined;
 			if (!tunnelResult) {
 				hostMap.delete(remotePort);
 			}

--- a/src/vs/platform/tunnel/common/tunnel.ts
+++ b/src/vs/platform/tunnel/common/tunnel.ts
@@ -416,7 +416,7 @@ export abstract class AbstractTunnelService implements ITunnelService {
 		const hostMap = this._tunnels.get(remoteHost);
 		if (hostMap) {
 			const tunnel = hostMap.get(remotePort);
-			const tunnelResult = await tunnel;
+			const tunnelResult = await tunnel.value;
 			if (!tunnelResult) {
 				hostMap.delete(remotePort);
 			}


### PR DESCRIPTION
If the tunnel factory in the web throws an error, VS Code will catch that error but maintain a port mapping for that port, which means if you try to forward the same port again, it won't re-call the tunnel factory since it thinks it's already forwarding the port.

**Steps to reproduce**

1. The tunnel gets added to the tunnel service's map: https://github.com/microsoft/vscode/blob/e7ee47c5ec2046533cb9017d7c403b32e2bfebd2/src/vs/platform/tunnel/common/tunnel.ts#L468
1. It will catch the error and return `undefined`: https://github.com/microsoft/vscode/blob/e7ee47c5ec2046533cb9017d7c403b32e2bfebd2/src/vs/workbench/contrib/remote/browser/tunnelFactory.ts#L65C1-L68
1. If the tunnel promise ends up resolving to an empty value, it will try to remove the empty mapping: https://github.com/microsoft/vscode/blob/e7ee47c5ec2046533cb9017d7c403b32e2bfebd2/src/vs/platform/tunnel/common/tunnel.ts#L344
2. But as part of that it again tries to resolve the promise, but instead of `await`'ing the tunnel promise it `await`s the object from the tunnel map that _contains_ the promise: https://github.com/microsoft/vscode/blob/e7ee47c5ec2046533cb9017d7c403b32e2bfebd2/src/vs/platform/tunnel/common/tunnel.ts#L419
1. So it doesn't actually remove the port mapping since the result isn't undefined: https://github.com/microsoft/vscode/blob/e7ee47c5ec2046533cb9017d7c403b32e2bfebd2/src/vs/platform/tunnel/common/tunnel.ts#L420

cc @alexr00 