### PR TITLE
Fix "Run to cursor" not doing anything when run from command palette when debug is not active

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/debugEditorActions.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugEditorActions.ts
@@ -251,10 +251,11 @@ export class RunToCursorAction extends EditorAction {
 			id: RunToCursorAction.ID,
 			label: RunToCursorAction.LABEL,
 			alias: 'Debug: Run to Cursor',
-			precondition: ContextKeyExpr.and(CONTEXT_IN_DEBUG_MODE, PanelFocusContext.toNegated(), CONTEXT_DEBUG_STATE.isEqualTo('stopped'), EditorContextKeys.editorTextFocus),
+			precondition: ContextKeyExpr.and(CONTEXT_DEBUGGERS_AVAILABLE, PanelFocusContext.toNegated(), EditorContextKeys.editorTextFocus),
 			contextMenuOpts: {
 				group: 'debug',
-				order: 2
+				order: 2,
+				when: CONTEXT_IN_DEBUG_MODE
 			}
 		});
 	}


### PR DESCRIPTION
Fix #186080

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
