### PR TITLE
allow turning on accessibility help from within the help menu

### DIFF
--- a/src/vs/workbench/contrib/accessibility/browser/accessibleView.ts
+++ b/src/vs/workbench/contrib/accessibility/browser/accessibleView.ts
@@ -145,8 +145,6 @@ class AccessibleView extends Disposable {
 					const url: string = provider.options.readMoreUrl!;
 					alert(AccessibilityHelpNLS.openingDocs);
 					this._openerService.open(URI.parse(url));
-				} else if (e.ctrlKey && e.keyCode === KeyCode.KeyM) {
-
 				}
 				e.stopPropagation();
 				provider.onKeyDown?.(e);

--- a/src/vs/workbench/contrib/accessibility/browser/accessibleView.ts
+++ b/src/vs/workbench/contrib/accessibility/browser/accessibleView.ts
@@ -16,6 +16,7 @@ import { AccessibilityHelpNLS } from 'vs/editor/common/standaloneStrings';
 import { LinkDetector } from 'vs/editor/contrib/links/browser/links';
 import { localize } from 'vs/nls';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
+import { IContextKey, IContextKeyService, RawContextKey } from 'vs/platform/contextkey/common/contextkey';
 import { IContextViewDelegate, IContextViewService } from 'vs/platform/contextview/browser/contextView';
 import { IInstantiationService, createDecorator } from 'vs/platform/instantiation/common/instantiation';
 import { IOpenerService } from 'vs/platform/opener/common/opener';
@@ -56,20 +57,23 @@ export interface IAccessibleViewOptions {
 	type: AccessibleViewType;
 }
 
+export const accessibilityHelpIsShown = new RawContextKey<boolean>('accessibilityHelpIsShown', false, true);
 class AccessibleView extends Disposable {
 	private _editorWidget: CodeEditorWidget;
+	private _accessiblityHelpIsShown: IContextKey<boolean>;
 	get editorWidget() { return this._editorWidget; }
 	private _editorContainer: HTMLElement;
 	private _keyListener: IDisposable | undefined;
-
 	constructor(
 		@IOpenerService private readonly _openerService: IOpenerService,
 		@IInstantiationService private readonly _instantiationService: IInstantiationService,
 		@IConfigurationService private readonly _configurationService: IConfigurationService,
 		@IModelService private readonly _modelService: IModelService,
-		@IContextViewService private readonly _contextViewService: IContextViewService
+		@IContextViewService private readonly _contextViewService: IContextViewService,
+		@IContextKeyService private readonly _contextKeyService: IContextKeyService
 	) {
 		super();
+		this._accessiblityHelpIsShown = accessibilityHelpIsShown.bindTo(this._contextKeyService);
 		this._editorContainer = document.createElement('div');
 		this._editorContainer.classList.add('accessible-view');
 		const codeEditorWidgetOptions: ICodeEditorWidgetOptions = {
@@ -96,9 +100,17 @@ class AccessibleView extends Disposable {
 			getAnchor: () => this._editorContainer,
 			render: (container) => {
 				return this._render(provider, container);
+			},
+			onHide: () => {
+				if (provider.options.type === AccessibleViewType.HelpMenu) {
+					this._accessiblityHelpIsShown.reset();
+				}
 			}
 		};
 		this._contextViewService.showContextView(delegate);
+		if (provider.options.type === AccessibleViewType.HelpMenu) {
+			this._accessiblityHelpIsShown.set(true);
+		}
 	}
 
 	private _render(provider: IAccessibleContentProvider, container: HTMLElement): IDisposable {
@@ -133,6 +145,8 @@ class AccessibleView extends Disposable {
 					const url: string = provider.options.readMoreUrl!;
 					alert(AccessibilityHelpNLS.openingDocs);
 					this._openerService.open(URI.parse(url));
+				} else if (e.ctrlKey && e.keyCode === KeyCode.KeyM) {
+
 				}
 				e.stopPropagation();
 				provider.onKeyDown?.(e);

--- a/src/vs/workbench/contrib/codeEditor/browser/accessibility/accessibility.ts
+++ b/src/vs/workbench/contrib/codeEditor/browser/accessibility/accessibility.ts
@@ -26,6 +26,8 @@ import { IOpenerService } from 'vs/platform/opener/common/opener';
 import { AccessibilitySupport, IAccessibilityService } from 'vs/platform/accessibility/common/accessibility';
 import { Action2, registerAction2 } from 'vs/platform/actions/common/actions';
 import { TabFocus, TabFocusContext } from 'vs/editor/browser/config/tabFocus';
+import { accessibilityHelpIsShown } from 'vs/workbench/contrib/accessibility/browser/accessibleView';
+import { KeybindingWeight } from 'vs/platform/keybinding/common/keybindingsRegistry';
 
 const CONTEXT_ACCESSIBILITY_WIDGET_VISIBLE = new RawContextKey<boolean>('accessibilityHelpWidgetVisible', false);
 
@@ -279,6 +281,11 @@ class ToggleScreenReaderMode extends Action2 {
 			id: 'editor.action.toggleScreenReaderAccessibilityMode',
 			title: { value: nls.localize('toggleScreenReaderMode', "Toggle Screen Reader Accessibility Mode"), original: 'Toggle Screen Reader Accessibility Mode' },
 			f1: true,
+			keybinding: {
+				primary: KeyMod.CtrlCmd | KeyCode.KeyE,
+				weight: KeybindingWeight.WorkbenchContrib + 10,
+				when: accessibilityHelpIsShown
+			}
 		});
 	}
 


### PR DESCRIPTION
I had thought this was working because had set a custom keybinding for this command - when I reset that, it didn't work on any platform because I failed to carryover the custom key handler from the original editor accessibility help menu.

fix #186434