### PR TITLE
Add debug logs for reattaching to wrong terminal

### DIFF
--- a/src/vs/platform/terminal/node/ptyService.ts
+++ b/src/vs/platform/terminal/node/ptyService.ts
@@ -240,6 +240,7 @@ export class PtyService extends Disposable implements IPtyService {
 		);
 		// Don't start the process here as there's no terminal to answer CPR
 		this._revivedPtyIdMap.set(terminal.id, { newId, state: terminal });
+		this._logService.info(`Revived process, old id ${terminal.id} -> new id ${newId}`);
 	}
 
 	@traceRpc
@@ -532,6 +533,7 @@ export class PtyService extends Disposable implements IPtyService {
 	private async _expandTerminalInstance(t: ITerminalInstanceLayoutInfoById): Promise<IRawTerminalInstanceLayoutInfo<IProcessDetails | null>> {
 		try {
 			const revivedPtyId = this._revivedPtyIdMap.get(t.terminal)?.newId;
+			this._logService.info(`Expanding terminal instance, old id ${t.terminal} -> new id ${revivedPtyId}`);
 			this._revivedPtyIdMap.delete(t.terminal);
 			const persistentProcessId = revivedPtyId ?? t.terminal;
 			const persistentProcess = this._throwIfNoPty(persistentProcessId);
@@ -542,6 +544,8 @@ export class PtyService extends Disposable implements IPtyService {
 			};
 		} catch (e) {
 			this._logService.warn(`Couldn't get layout info, a terminal was probably disconnected`, e.message);
+			this._logService.info('Reattach to wrong terminal debug info - layout info by id', t);
+			this._logService.info('Reattach to wrong terminal debug info - _revivePtyIdMap', Array.from(this._revivedPtyIdMap.values()));
 			// this will be filtered out and not reconnected
 			return {
 				terminal: null,


### PR DESCRIPTION
Part of #133542

This is just adding logs so is pretty safe to go in during endgame. Also the verbose logs (`Reattach to wrong terminal debug info`) only happen when something goes wrong.