### PR TITLE
Add preview and help text for "Go to line" during file quick open (fix #186143)

### DIFF
--- a/src/vs/base/common/async.ts
+++ b/src/vs/base/common/async.ts
@@ -20,8 +20,8 @@ export interface CancelablePromise<T> extends Promise<T> {
 	cancel(): void;
 }
 
-export function createCancelablePromise<T>(callback: (token: CancellationToken) => Promise<T>): CancelablePromise<T> {
-	const source = new CancellationTokenSource();
+export function createCancelablePromise<T>(callback: (token: CancellationToken) => Promise<T>, parentToken?: CancellationToken): CancelablePromise<T> {
+	const source = new CancellationTokenSource(parentToken);
 
 	const thenable = callback(source.token);
 	const promise = new Promise<T>((resolve, reject) => {

--- a/src/vs/editor/contrib/quickAccess/browser/gotoLineQuickAccess.ts
+++ b/src/vs/editor/contrib/quickAccess/browser/gotoLineQuickAccess.ts
@@ -120,7 +120,7 @@ export abstract class AbstractGotoLineQuickAccessProvider extends AbstractEditor
 		};
 	}
 
-	private getPickLabel(editor: IEditor, lineNumber: number, column: number | undefined): string {
+	public getPickLabel(editor: IEditor, lineNumber: number, column: number | undefined): string {
 
 		// Location valid: indicate this as picker label
 		if (this.isValidLineNumber(editor, lineNumber)) {


### PR DESCRIPTION
This PR adds preview and help text when "Go to line" is triggered by `<file>:<line>,<column>` command pattern. 

Fixes #186143 

Screenshot:


https://github.com/microsoft/vscode/assets/4702188/f25e45c2-27b8-4fe5-a83f-36c37de74417

