### PR TITLE
Git - better handle symbolic links

### DIFF
--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -522,7 +522,7 @@ export class Git {
 
 		// Handle symbolic links
 		// Git 2.31 added --path-format flag to rev-parse which allows us to get the relative path of the repository root
-		if (repositoryPath !== repoPath && !isDescendant(repoPath, repositoryPath) && !isDescendant(repositoryPath, repoPath) && this.compareGitVersionTo('2.31.0') !== -1) {
+		if (!pathEquals(repositoryPath, repoPath) && !isDescendant(repoPath, repositoryPath) && !isDescendant(repositoryPath, repoPath) && this.compareGitVersionTo('2.31.0') !== -1) {
 			const relativePathResult = await this.exec(repositoryPath, ['rev-parse', '--path-format=relative', '--show-toplevel',]);
 			return path.resolve(repositoryPath, relativePathResult.stdout.trimLeft().replace(/[\r\n]+$/, ''));
 		}

--- a/extensions/git/src/model.ts
+++ b/extensions/git/src/model.ts
@@ -935,7 +935,7 @@ export class Model implements IBranchProtectionProviderRegistry, IRemoteSourcePu
 		// to match it against the workspace folders and the canonical paths of the workspace folders
 		const workspaceFolderPaths = new Set<string | undefined>([
 			...workspaceFolders.map(folder => folder.uri.fsPath),
-			...await Promise.all(workspaceFolders.map(async folder => await this.getWorkspaceFolderRealPath(folder)))
+			...await Promise.all(workspaceFolders.map(folder => this.getWorkspaceFolderRealPath(folder)))
 		]);
 
 		return !Array.from(workspaceFolderPaths).some(folder => folder && (pathEquals(folder, repositoryPath) || isDescendant(folder, repositoryPath)));

--- a/extensions/git/src/model.ts
+++ b/extensions/git/src/model.ts
@@ -931,12 +931,14 @@ export class Model implements IBranchProtectionProviderRegistry, IRemoteSourcePu
 			return true;
 		}
 
-		const result = await Promise.all(workspaceFolders.map(async folder => {
-			const workspaceFolderRealPath = await this.getWorkspaceFolderRealPath(folder);
-			return workspaceFolderRealPath ? pathEquals(workspaceFolderRealPath, repositoryPath) || isDescendant(workspaceFolderRealPath, repositoryPath) : undefined;
-		}));
+		// The repository path may be a canonical path or it may contain a symbolic link so we have
+		// to match it against the workspace folders and the canonical paths of the workspace folders
+		const workspaceFolderPaths = new Set<string | undefined>([
+			...workspaceFolders.map(folder => folder.uri.fsPath),
+			...await Promise.all(workspaceFolders.map(async folder => await this.getWorkspaceFolderRealPath(folder)))
+		]);
 
-		return !result.some(r => r);
+		return !Array.from(workspaceFolderPaths).some(folder => folder && (pathEquals(folder, repositoryPath) || isDescendant(folder, repositoryPath)));
 	}
 
 	private async getWorkspaceFolderRealPath(workspaceFolder: WorkspaceFolder): Promise<string | undefined> {


### PR DESCRIPTION
If we detect that the workspace folder contains a symbolic link, and the user is running `git 2.31` or later, we use the `--path-format` [flag](https://git-scm.com/docs/git-rev-parse#Documentation/git-rev-parse.txt---path-formatabsoluterelative) to get the path of the repository root path relative to the workspace folder. This enables us to set the repository root to a path that matches the workspace folder.

Related #5970