### PR TITLE
testing: use overflow ellipsis in test tree

### DIFF
--- a/src/vs/base/browser/ui/tree/compressedObjectTreeModel.ts
+++ b/src/vs/base/browser/ui/tree/compressedObjectTreeModel.ts
@@ -7,6 +7,7 @@ import { IIdentityProvider } from 'vs/base/browser/ui/list/list';
 import { IIndexTreeModelSpliceOptions, IList } from 'vs/base/browser/ui/tree/indexTreeModel';
 import { IObjectTreeModel, IObjectTreeModelOptions, IObjectTreeModelSetChildrenOptions, ObjectTreeModel } from 'vs/base/browser/ui/tree/objectTreeModel';
 import { ICollapseStateChangeEvent, IObjectTreeElement, ITreeModel, ITreeModelSpliceEvent, ITreeNode, TreeError, TreeFilterResult, TreeVisibility, WeakMapper } from 'vs/base/browser/ui/tree/tree';
+import { equals } from 'vs/base/common/arrays';
 import { Event } from 'vs/base/common/event';
 import { Iterable } from 'vs/base/common/iterator';
 
@@ -169,6 +170,16 @@ export class CompressedObjectTreeModel<T extends NonNullable<any>, TFilterData e
 		const decompressedElement = decompress(node);
 		const splicedElement = splice(decompressedElement, element, children);
 		const recompressedElement = (this.enabled ? compress : noCompress)(splicedElement);
+
+		// If the recompressed node is identical to the original, just set its children.
+		// Saves work and churn diffing the parent element.
+		const elementComparator = options.diffIdentityProvider
+			? ((a: T, b: T) => options.diffIdentityProvider!.getId(a) === options.diffIdentityProvider!.getId(b))
+			: undefined;
+		if (equals(recompressedElement.element.elements, node.element.elements, elementComparator)) {
+			this._setChildren(compressedNode, recompressedElement.children || Iterable.empty(), { diffIdentityProvider, diffDepth: 1 });
+			return;
+		}
 
 		const parentChildren = parent.children
 			.map(child => child === node ? recompressedElement : child);

--- a/src/vs/workbench/contrib/testing/browser/media/testing.css
+++ b/src/vs/workbench/contrib/testing/browser/media/testing.css
@@ -43,13 +43,19 @@
 
 .test-explorer .test-item .label,
 .test-output-peek-tree .test-peek-item .name {
-	display: flex;
-	align-items: center;
 	flex-grow: 1;
-	gap: 0.15em;
 	width: 0;
 	overflow: hidden;
 	white-space: nowrap;
+	text-overflow: ellipsis;
+}
+
+.test-output-peek-tree .test-peek-item .name .codicon,
+.test-explorer .test-item .label .codicon {
+	vertical-align: middle;
+	font-size: 1em;
+	transform: scale(1.25);
+	margin: 0 0.125em;
 }
 
 .test-explorer .test-item,
@@ -106,15 +112,6 @@
 
 .test-explorer .monaco-list-row .error p {
 	margin: 0;
-}
-
-.test-explorer .name,
-.test-output-peek-tree .name {
-	overflow: hidden;
-	text-overflow: ellipsis;
-	flex-grow: 1;
-	height: 22px;
-	align-items: center;
 }
 
 .test-explorer .computed-state,


### PR DESCRIPTION
Fixes #186320

Had to abandon flexbox for this, so do manual tweaks to make codicons show nicely:

![](https://memes.peet.io/img/23-06-321bf892-8f69-4548-9c76-465f33205c8e.png)

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
