### PR TITLE
Continue chat session seamlessly when EH crashes.

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatEditorInput.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditorInput.ts
@@ -101,7 +101,6 @@ export class ChatEditorInput extends EditorInput {
 
 		this.sessionId = this.model.sessionId;
 		this.providerId = this.model.providerId;
-		await this.model.waitForInitialization();
 		this._register(this.model.onDidChange(() => this._onDidChangeLabel.fire()));
 
 		return this._register(new ChatEditorModel(this.model));

--- a/src/vs/workbench/contrib/chat/common/chatModel.ts
+++ b/src/vs/workbench/contrib/chat/common/chatModel.ts
@@ -195,7 +195,6 @@ export interface IChatModel {
 	readonly requestInProgress: boolean;
 	readonly inputPlaceholder?: string;
 	getRequests(): IChatRequestModel[];
-	waitForInitialization(): Promise<void>;
 	toExport(): IExportableChatData;
 	toJSON(): ISerializableChatData;
 }
@@ -383,6 +382,11 @@ export class ChatModel extends Disposable implements IChatModel {
 			}
 			return request;
 		});
+	}
+
+	startReinitialize(): void {
+		this._session = undefined;
+		this._isInitializedDeferred = new DeferredPromise<void>();
 	}
 
 	initialize(session: IChat, welcomeMessage: ChatWelcomeMessageModel | undefined): void {


### PR DESCRIPTION
Need to sync the existing ChatModel to the new EH and reinitialize it for the new chat provider instance.
Fix microsoft/vscode-copilot#155

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
