### PR TITLE
Open folders "x unsaved" label text is displayed in multiple lines (fix #177601)

### DIFF
--- a/src/vs/workbench/contrib/files/browser/media/explorerviewlet.css
+++ b/src/vs/workbench/contrib/files/browser/media/explorerviewlet.css
@@ -57,23 +57,6 @@
 	flex: 0; /* do not steal space when label is hidden because we are in edit mode */
 }
 
-.explorer-folders-view .pane-header .count {
-	min-width: fit-content;
-	display: flex;
-	align-items: center;
-}
-
-.pane.horizontal:not(.expanded) .pane-header .dirty-count.monaco-count-badge,
-.pane-header .dirty-count.monaco-count-badge.hidden {
-	display: none;
-}
-
-.dirty-count.monaco-count-badge {
-	padding: 2px 4px;
-	margin-left: 6px;
-	min-height: auto;
-}
-
 .explorer-folders-view .explorer-item.nonexistent-root {
 	opacity: 0.5;
 }

--- a/src/vs/workbench/contrib/files/browser/views/media/openeditors.css
+++ b/src/vs/workbench/contrib/files/browser/views/media/openeditors.css
@@ -3,6 +3,23 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+.pane-header .open-editors-dirty-count-container {
+	min-width: fit-content;
+	display: flex;
+	align-items: center;
+}
+
+.pane.horizontal:not(.expanded) .pane-header .open-editors-dirty-count-container > .dirty-count.monaco-count-badge,
+.pane-header .open-editors-dirty-count-container > .dirty-count.monaco-count-badge.hidden {
+	display: none;
+}
+
+.pane-header .open-editors-dirty-count-container > .dirty-count.monaco-count-badge {
+	padding: 2px 4px;
+	margin-left: 6px;
+	min-height: auto;
+}
+
 .open-editors .monaco-list .monaco-list-row:hover > .monaco-action-bar,
 .open-editors .monaco-list .monaco-list-row.focused > .monaco-action-bar,
 .open-editors .monaco-list .monaco-list-row.dirty > .monaco-action-bar,

--- a/src/vs/workbench/contrib/files/browser/views/openEditorsView.ts
+++ b/src/vs/workbench/contrib/files/browser/views/openEditorsView.ts
@@ -170,7 +170,7 @@ export class OpenEditorsView extends ViewPane {
 	protected override renderHeaderTitle(container: HTMLElement): void {
 		super.renderHeaderTitle(container, this.title);
 
-		const count = dom.append(container, $('.count'));
+		const count = dom.append(container, $('.open-editors-dirty-count-container'));
 		this.dirtyCountElement = dom.append(count, $('.dirty-count.monaco-count-badge.long'));
 
 		this.dirtyCountElement.style.backgroundColor = asCssVariable(badgeBackground);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
