### PR TITLE
Only launch the pty host when it's needed

### DIFF
--- a/src/vs/platform/terminal/common/terminal.ts
+++ b/src/vs/platform/terminal/common/terminal.ts
@@ -953,8 +953,16 @@ export interface ITerminalBackend {
 	readonly remoteAuthority: string | undefined;
 
 	readonly isResponsive: boolean;
-	readonly whenConnected: Promise<void>;
-	setConnected(): void;
+
+	/**
+	 * A promise that resolves when the backend is ready to be used, ie. after terminal persistence
+	 * has been actioned.
+	 */
+	readonly whenReady: Promise<void>;
+	/**
+	 * Signal to the backend that persistence has been actioned and is ready for use.
+	 */
+	setReady(): void;
 
 	/**
 	 * Fired when the ptyHost process becomes non-responsive, this should disable stdin for all

--- a/src/vs/platform/terminal/common/terminal.ts
+++ b/src/vs/platform/terminal/common/terminal.ts
@@ -956,8 +956,6 @@ export interface ITerminalBackend {
 	readonly whenConnected: Promise<void>;
 	setConnected(): void;
 
-	readonly whenPtyHostReady: Promise<void>;
-
 	/**
 	 * Fired when the ptyHost process becomes non-responsive, this should disable stdin for all
 	 * terminals using this pty host connection and mark them as disconnected.

--- a/src/vs/platform/terminal/common/terminal.ts
+++ b/src/vs/platform/terminal/common/terminal.ts
@@ -956,6 +956,8 @@ export interface ITerminalBackend {
 	readonly whenConnected: Promise<void>;
 	setConnected(): void;
 
+	readonly whenPtyHostReady: Promise<void>;
+
 	/**
 	 * Fired when the ptyHost process becomes non-responsive, this should disable stdin for all
 	 * terminals using this pty host connection and mark them as disconnected.

--- a/src/vs/platform/terminal/node/ptyHostService.ts
+++ b/src/vs/platform/terminal/node/ptyHostService.ts
@@ -223,7 +223,10 @@ export class PtyHostService extends Disposable implements IPtyService {
 	listProcesses(): Promise<IProcessDetails[]> {
 		return this._proxy.listProcesses();
 	}
-	getPerformanceMarks(): Promise<performance.PerformanceMark[]> {
+	async getPerformanceMarks(): Promise<performance.PerformanceMark[]> {
+		if (!this.__proxy) {
+			return [];
+		}
 		return this._proxy.getPerformanceMarks();
 	}
 	reduceConnectionGraceTime(): Promise<void> {
@@ -279,13 +282,16 @@ export class PtyHostService extends Disposable implements IPtyService {
 	getDefaultSystemShell(osOverride?: OperatingSystem): Promise<string> {
 		return this._proxy.getDefaultSystemShell(osOverride);
 	}
-	// TODO: Should this only be available on the pty host service?
 	async getProfiles(workspaceId: string, profiles: unknown, defaultProfile: unknown, includeDetectedProfiles: boolean = false): Promise<ITerminalProfile[]> {
 		const shellEnv = await this._resolveShellEnv();
 		return detectAvailableProfiles(profiles, defaultProfile, includeDetectedProfiles, this._configurationService, shellEnv, undefined, this._logService, this._resolveVariables.bind(this, workspaceId));
 	}
-	// TODO: Should this only be available on the pty host service?
-	getEnvironment(): Promise<IProcessEnvironment> {
+	async getEnvironment(): Promise<IProcessEnvironment> {
+		// If the pty host is yet to be launched, just return the environment of this process as it
+		// is essentially the same when used to evaluate terminal profiles.
+		if (!this.__proxy) {
+			return { ...process.env };
+		}
 		return this._proxy.getEnvironment();
 	}
 	getWslPath(original: string, direction: 'unix-to-win' | 'win-to-unix'): Promise<string> {

--- a/src/vs/platform/terminal/node/ptyHostService.ts
+++ b/src/vs/platform/terminal/node/ptyHostService.ts
@@ -279,10 +279,12 @@ export class PtyHostService extends Disposable implements IPtyService {
 	getDefaultSystemShell(osOverride?: OperatingSystem): Promise<string> {
 		return this._proxy.getDefaultSystemShell(osOverride);
 	}
+	// TODO: Should this only be available on the pty host service?
 	async getProfiles(workspaceId: string, profiles: unknown, defaultProfile: unknown, includeDetectedProfiles: boolean = false): Promise<ITerminalProfile[]> {
 		const shellEnv = await this._resolveShellEnv();
 		return detectAvailableProfiles(profiles, defaultProfile, includeDetectedProfiles, this._configurationService, shellEnv, undefined, this._logService, this._resolveVariables.bind(this, workspaceId));
 	}
+	// TODO: Should this only be available on the pty host service?
 	getEnvironment(): Promise<IProcessEnvironment> {
 		return this._proxy.getEnvironment();
 	}

--- a/src/vs/workbench/contrib/terminal/browser/remoteTerminalBackend.ts
+++ b/src/vs/workbench/contrib/terminal/browser/remoteTerminalBackend.ts
@@ -50,8 +50,8 @@ class RemoteTerminalBackend extends BaseTerminalBackend implements ITerminalBack
 	private readonly _ptys: Map<number, RemotePty> = new Map();
 
 	private readonly _whenConnected = new DeferredPromise<void>();
-	get whenConnected(): Promise<void> { return this._whenConnected.p; }
-	setConnected(): void { this._whenConnected.complete(); }
+	get whenReady(): Promise<void> { return this._whenConnected.p; }
+	setReady(): void { this._whenConnected.complete(); }
 
 	private readonly _onDidRequestDetach = this._register(new Emitter<{ requestId: number; workspaceId: string; instanceId: number }>());
 	readonly onDidRequestDetach = this._onDidRequestDetach.event;

--- a/src/vs/workbench/contrib/terminal/browser/terminalProfileResolverService.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalProfileResolverService.ts
@@ -28,7 +28,6 @@ import { ITerminalInstanceService } from 'vs/workbench/contrib/terminal/browser/
 export interface IProfileContextProvider {
 	getDefaultSystemShell(remoteAuthority: string | undefined, os: OperatingSystem): Promise<string>;
 	getEnvironment(remoteAuthority: string | undefined): Promise<IProcessEnvironment>;
-	getShellEnvironment(remoteAuthority: string | undefined): Promise<IProcessEnvironment | undefined>;
 }
 
 const generatedProfileName = 'Generated';
@@ -275,8 +274,7 @@ export abstract class BaseTerminalProfileResolverService implements ITerminalPro
 	}
 
 	private async _resolveProfile(profile: ITerminalProfile, options: IShellLaunchConfigResolveOptions): Promise<ITerminalProfile> {
-		// TODO: is it a problem using the shell env here?
-		const env = await this._context.getShellEnvironment(options.remoteAuthority) || await this._context.getEnvironment(options.remoteAuthority);
+		const env = await this._context.getEnvironment(options.remoteAuthority);
 
 		if (options.os === OperatingSystem.Windows) {
 			// Change Sysnative to System32 if the OS is Windows but NOT WoW64. It's
@@ -429,13 +427,6 @@ export class BrowserTerminalProfileResolverService extends BaseTerminalProfileRe
 						return env;
 					}
 					return backend.getEnvironment();
-				},
-				getShellEnvironment: async (remoteAuthority) => {
-					const backend = await terminalInstanceService.getBackend(remoteAuthority);
-					if (!remoteAuthority || !backend) {
-						return env;
-					}
-					return backend.getShellEnvironment();
 				}
 			},
 			configurationService,

--- a/src/vs/workbench/contrib/terminal/browser/terminalService.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalService.ts
@@ -282,6 +282,25 @@ export class TerminalService implements ITerminalService {
 
 		const isPersistentRemote = !!this._environmentService.remoteAuthority && enableTerminalReconnection;
 
+		this._primaryBackend?.onDidRequestDetach(async (e) => {
+			const instanceToDetach = this.getInstanceFromResource(getTerminalUri(e.workspaceId, e.instanceId));
+			if (instanceToDetach) {
+				const persistentProcessId = instanceToDetach?.persistentProcessId;
+				if (persistentProcessId && !instanceToDetach.shellLaunchConfig.isFeatureTerminal && !instanceToDetach.shellLaunchConfig.customPtyImplementation) {
+					if (instanceToDetach.target === TerminalLocation.Editor) {
+						this._terminalEditorService.detachInstance(instanceToDetach);
+					} else {
+						this._terminalGroupService.getGroupForInstance(instanceToDetach)?.removeInstance(instanceToDetach);
+					}
+					await instanceToDetach.detachProcessAndDispose(TerminalExitReason.User);
+					await this._primaryBackend?.acceptDetachInstanceReply(e.requestId, persistentProcessId);
+				} else {
+					// will get rejected without a persistentProcessId to attach to
+					await this._primaryBackend?.acceptDetachInstanceReply(e.requestId, undefined);
+				}
+			}
+		});
+
 		mark('code/terminal/willReconnect');
 		let reconnectedPromise: Promise<any>;
 		if (isPersistentRemote) {
@@ -300,30 +319,11 @@ export class TerminalService implements ITerminalService {
 			mark('code/terminal/didReplay');
 			mark('code/terminal/willGetPerformanceMarks');
 			await Promise.all(Array.from(this._terminalInstanceService.getRegisteredBackends()).map(async backend => {
-				this._timerService.setPerformanceMarks(backend.remoteAuthority === undefined ? 'localPtyHost' : 'remotePtyHost', await backend.getPerformanceMarks());
+				this._timerService.setPerformanceMarks(backend.remoteAuthority === undefined ? 'localPtyHost' : 'remotePtyHost', (instances.length > 0 ? await backend.getPerformanceMarks() : []));
 				backend.setConnected();
 			}));
 			mark('code/terminal/didGetPerformanceMarks');
 			this._whenConnected.complete();
-		});
-
-		this._primaryBackend?.onDidRequestDetach(async (e) => {
-			const instanceToDetach = this.getInstanceFromResource(getTerminalUri(e.workspaceId, e.instanceId));
-			if (instanceToDetach) {
-				const persistentProcessId = instanceToDetach?.persistentProcessId;
-				if (persistentProcessId && !instanceToDetach.shellLaunchConfig.isFeatureTerminal && !instanceToDetach.shellLaunchConfig.customPtyImplementation) {
-					if (instanceToDetach.target === TerminalLocation.Editor) {
-						this._terminalEditorService.detachInstance(instanceToDetach);
-					} else {
-						this._terminalGroupService.getGroupForInstance(instanceToDetach)?.removeInstance(instanceToDetach);
-					}
-					await instanceToDetach.detachProcessAndDispose(TerminalExitReason.User);
-					await this._primaryBackend?.acceptDetachInstanceReply(e.requestId, persistentProcessId);
-				} else {
-					// will get rejected without a persistentProcessId to attach to
-					await this._primaryBackend?.acceptDetachInstanceReply(e.requestId, undefined);
-				}
-			}
 		});
 	}
 

--- a/src/vs/workbench/contrib/terminal/browser/terminalService.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalService.ts
@@ -320,7 +320,7 @@ export class TerminalService implements ITerminalService {
 			mark('code/terminal/willGetPerformanceMarks');
 			await Promise.all(Array.from(this._terminalInstanceService.getRegisteredBackends()).map(async backend => {
 				this._timerService.setPerformanceMarks(backend.remoteAuthority === undefined ? 'localPtyHost' : 'remotePtyHost', (instances.length > 0 ? await backend.getPerformanceMarks() : []));
-				backend.setConnected();
+				backend.setReady();
 			}));
 			mark('code/terminal/didGetPerformanceMarks');
 			this._whenConnected.complete();

--- a/src/vs/workbench/contrib/terminal/browser/terminalService.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalService.ts
@@ -319,7 +319,7 @@ export class TerminalService implements ITerminalService {
 			mark('code/terminal/didReplay');
 			mark('code/terminal/willGetPerformanceMarks');
 			await Promise.all(Array.from(this._terminalInstanceService.getRegisteredBackends()).map(async backend => {
-				this._timerService.setPerformanceMarks(backend.remoteAuthority === undefined ? 'localPtyHost' : 'remotePtyHost', (instances.length > 0 ? await backend.getPerformanceMarks() : []));
+				this._timerService.setPerformanceMarks(backend.remoteAuthority === undefined ? 'localPtyHost' : 'remotePtyHost', await backend.getPerformanceMarks());
 				backend.setReady();
 			}));
 			mark('code/terminal/didGetPerformanceMarks');

--- a/src/vs/workbench/contrib/terminal/electron-sandbox/localTerminalBackend.ts
+++ b/src/vs/workbench/contrib/terminal/electron-sandbox/localTerminalBackend.ts
@@ -56,7 +56,7 @@ class LocalTerminalBackend extends BaseTerminalBackend implements ITerminalBacke
 	private _directProxyClientEventually: DeferredPromise<MessagePortClient> | undefined;
 	private _directProxy: IPtyService | undefined;
 	/**
-	 * Communicate to the direct proxy (renderer<->ptyhost) is it's available, otherwise use the
+	 * Communicate to the direct proxy (renderer<->ptyhost) if it's available, otherwise use the
 	 * indirect proxy (renderer<->main<->ptyhost). The latter may not need to actually launch the
 	 * pty host, for example when detecting profiles.
 	 */

--- a/src/vs/workbench/contrib/terminal/electron-sandbox/localTerminalBackend.ts
+++ b/src/vs/workbench/contrib/terminal/electron-sandbox/localTerminalBackend.ts
@@ -277,7 +277,6 @@ class LocalTerminalBackend extends BaseTerminalBackend implements ITerminalBacke
 	}
 
 	async setTerminalLayoutInfo(layoutInfo?: ITerminalsLayoutInfoById): Promise<void> {
-		await this._connectToDirectProxy();
 		const args: ISetTerminalLayoutInfoArgs = {
 			workspaceId: this._getWorkspaceId(),
 			tabs: layoutInfo ? layoutInfo.tabs : []

--- a/src/vs/workbench/contrib/terminal/electron-sandbox/terminalProfileResolverService.ts
+++ b/src/vs/workbench/contrib/terminal/electron-sandbox/terminalProfileResolverService.ts
@@ -41,6 +41,13 @@ export class ElectronTerminalProfileResolverService extends BaseTerminalProfileR
 						throw new ErrorNoTelemetry(`Cannot get environment when there is no backend for remote authority '${remoteAuthority}'`);
 					}
 					return backend.getEnvironment();
+				},
+				getShellEnvironment: async (remoteAuthority) => {
+					const backend = await terminalInstanceService.getBackend(remoteAuthority);
+					if (!backend) {
+						throw new ErrorNoTelemetry(`Cannot get environment when there is no backend for remote authority '${remoteAuthority}'`);
+					}
+					return backend.getShellEnvironment();
 				}
 			},
 			configurationService,

--- a/src/vs/workbench/contrib/terminal/electron-sandbox/terminalProfileResolverService.ts
+++ b/src/vs/workbench/contrib/terminal/electron-sandbox/terminalProfileResolverService.ts
@@ -41,13 +41,6 @@ export class ElectronTerminalProfileResolverService extends BaseTerminalProfileR
 						throw new ErrorNoTelemetry(`Cannot get environment when there is no backend for remote authority '${remoteAuthority}'`);
 					}
 					return backend.getEnvironment();
-				},
-				getShellEnvironment: async (remoteAuthority) => {
-					const backend = await terminalInstanceService.getBackend(remoteAuthority);
-					if (!backend) {
-						throw new ErrorNoTelemetry(`Cannot get environment when there is no backend for remote authority '${remoteAuthority}'`);
-					}
-					return backend.getShellEnvironment();
 				}
 			},
 			configurationService,

--- a/src/vs/workbench/services/timer/browser/timerService.ts
+++ b/src/vs/workbench/services/timer/browser/timerService.ts
@@ -504,7 +504,7 @@ export abstract class AbstractTimerService implements ITimerService {
 			this._extensionService.whenInstalledExtensionsRegistered(), // extensions registered
 			_lifecycleService.when(LifecyclePhase.Restored),			// workbench created and parts restored
 			layoutService.whenRestored,									// layout restored (including visible editors resolved)
-			Promise.all(Array.from(Registry.as<ITerminalBackendRegistry>(TerminalExtensions.Backend).backends.values()).map(e => e.whenConnected))
+			Promise.all(Array.from(Registry.as<ITerminalBackendRegistry>(TerminalExtensions.Backend).backends.values()).map(e => e.whenReady))
 		]).then(() => {
 			// set perf mark from renderer
 			this.setPerformanceMarks('renderer', perf.getMarks());


### PR DESCRIPTION
Fixes #182637 

This change makes the pty host only spawn when it's actually needed, resulting in less RAM usage (Linux/macOS: ~50mb,  Windows: ~100mb) and less work between `LifecyclePhase.Restored` and `Eventually` when the terminal is not used.

Implementation notes:

- `LocalTerminalBackend` no longer tries to connect to the pty host message port automatically (spawning the pty host if needed), instead it only connects when creating/attaching/listing processes.
- `LocalTerminalBackend._proxy` now returns the message port proxy if it exists, otherwise `ILocalPtyService` (goes via main process).
- Certain calls will be evaluated on `PtyHostService` (main process) like `getPerformanceMarks` and `getEnvironment`, these calls are needed in order to start up the terminal contrib and evaluate profiles. This means they will no longer spawn the pty host when called.