### PR TITLE
Use workspace ID in revive pty id map

### DIFF
--- a/src/vs/platform/terminal/common/terminal.ts
+++ b/src/vs/platform/terminal/common/terminal.ts
@@ -337,7 +337,7 @@ export interface IPtyService extends IPtyHostController {
 	getProfiles?(workspaceId: string, profiles: unknown, defaultProfile: unknown, includeDetectedProfiles?: boolean): Promise<ITerminalProfile[]>;
 	getEnvironment(): Promise<IProcessEnvironment>;
 	getWslPath(original: string, direction: 'unix-to-win' | 'win-to-unix'): Promise<string>;
-	getRevivedPtyNewId(id: number): Promise<number | undefined>;
+	getRevivedPtyNewId(workspaceId: string, id: number): Promise<number | undefined>;
 	setTerminalLayoutInfo(args: ISetTerminalLayoutInfoArgs): Promise<void>;
 	getTerminalLayoutInfo(args: IGetTerminalLayoutInfoArgs): Promise<ITerminalsLayoutInfo | undefined>;
 	reduceConnectionGraceTime(): Promise<void>;
@@ -353,7 +353,7 @@ export interface IPtyService extends IPtyHostController {
 	 * Revives a workspaces terminal processes, these can then be reconnected to using the normal
 	 * flow for restoring terminals after reloading.
 	 */
-	reviveTerminalProcesses(state: ISerializedTerminalState[], dateTimeFormatLocate: string): Promise<void>;
+	reviveTerminalProcesses(workspaceId: string, state: ISerializedTerminalState[], dateTimeFormatLocate: string): Promise<void>;
 	refreshProperty<T extends ProcessPropertyType>(id: number, property: T): Promise<IProcessPropertyMap[T]>;
 	updateProperty<T extends ProcessPropertyType>(id: number, property: T, value: IProcessPropertyMap[T]): Promise<void>;
 

--- a/src/vs/platform/terminal/node/ptyHostService.ts
+++ b/src/vs/platform/terminal/node/ptyHostService.ts
@@ -298,8 +298,8 @@ export class PtyHostService extends Disposable implements IPtyService {
 		return this._proxy.getWslPath(original, direction);
 	}
 
-	getRevivedPtyNewId(id: number): Promise<number | undefined> {
-		return this._proxy.getRevivedPtyNewId(id);
+	getRevivedPtyNewId(workspaceId: string, id: number): Promise<number | undefined> {
+		return this._proxy.getRevivedPtyNewId(workspaceId, id);
 	}
 
 	setTerminalLayoutInfo(args: ISetTerminalLayoutInfoArgs): Promise<void> {
@@ -328,8 +328,8 @@ export class PtyHostService extends Disposable implements IPtyService {
 		return this._proxy.serializeTerminalState(ids);
 	}
 
-	async reviveTerminalProcesses(state: ISerializedTerminalState[], dateTimeFormatLocate: string) {
-		return this._proxy.reviveTerminalProcesses(state, dateTimeFormatLocate);
+	async reviveTerminalProcesses(workspaceId: string, state: ISerializedTerminalState[], dateTimeFormatLocate: string) {
+		return this._proxy.reviveTerminalProcesses(workspaceId, state, dateTimeFormatLocate);
 	}
 
 	async refreshProperty<T extends ProcessPropertyType>(id: number, property: T): Promise<IProcessPropertyMap[T]> {

--- a/src/vs/platform/terminal/node/ptyService.ts
+++ b/src/vs/platform/terminal/node/ptyService.ts
@@ -71,7 +71,7 @@ export class PtyService extends Disposable implements IPtyService {
 	private readonly _ptys: Map<number, PersistentTerminalProcess> = new Map();
 	private readonly _workspaceLayoutInfos = new Map<WorkspaceId, ISetTerminalLayoutInfoArgs>();
 	private readonly _detachInstanceRequestStore: RequestStore<IProcessDetails | undefined, { workspaceId: string; instanceId: number }>;
-	private readonly _revivedPtyIdMap: Map<number, { newId: number; state: ISerializedTerminalState }> = new Map();
+	private readonly _revivedPtyIdMap: Map<string, { newId: number; state: ISerializedTerminalState }> = new Map();
 	private readonly _autoReplies: Map<string, string> = new Map();
 
 	private _lastPtyId: number = 0;
@@ -210,15 +210,15 @@ export class PtyService extends Disposable implements IPtyService {
 	}
 
 	@traceRpc
-	async reviveTerminalProcesses(state: ISerializedTerminalState[], dateTimeFormatLocale: string) {
+	async reviveTerminalProcesses(workspaceId: string, state: ISerializedTerminalState[], dateTimeFormatLocale: string) {
 		const promises: Promise<void>[] = [];
 		for (const terminal of state) {
-			promises.push(this._reviveTerminalProcess(terminal));
+			promises.push(this._reviveTerminalProcess(workspaceId, terminal));
 		}
 		await Promise.all(promises);
 	}
 
-	private async _reviveTerminalProcess(terminal: ISerializedTerminalState): Promise<void> {
+	private async _reviveTerminalProcess(workspaceId: string, terminal: ISerializedTerminalState): Promise<void> {
 		const restoreMessage = localize('terminal-history-restored', "History restored");
 		// TODO: We may at some point want to show date information in a hover via a custom sequence:
 		//   new Date(terminal.timestamp).toLocaleDateString(dateTimeFormatLocale)
@@ -246,8 +246,9 @@ export class PtyService extends Disposable implements IPtyService {
 			terminal.replayEvent.events[0].data
 		);
 		// Don't start the process here as there's no terminal to answer CPR
-		this._revivedPtyIdMap.set(terminal.id, { newId, state: terminal });
-		this._logService.info(`Revived process, old id ${terminal.id} -> new id ${newId}`);
+		const oldId = this._getRevivingProcessId(workspaceId, terminal.id);
+		this._revivedPtyIdMap.set(oldId, { newId, state: terminal });
+		this._logService.info(`Revived process, old id ${oldId} -> new id ${newId}`);
 	}
 
 	@traceRpc
@@ -499,11 +500,11 @@ export class PtyService extends Disposable implements IPtyService {
 	}
 
 	@traceRpc
-	async getRevivedPtyNewId(id: number): Promise<number | undefined> {
+	async getRevivedPtyNewId(workspaceId: string, id: number): Promise<number | undefined> {
 		try {
-			return this._revivedPtyIdMap.get(id)?.newId;
+			return this._revivedPtyIdMap.get(this._getRevivingProcessId(workspaceId, id))?.newId;
 		} catch (e) {
-			this._logService.warn(`Couldn't find terminal ID ${id}`, e.message);
+			this._logService.warn(`Couldn't find terminal ID ${workspaceId}-${id}`, e.message);
 		}
 		return undefined;
 	}
@@ -518,7 +519,7 @@ export class PtyService extends Disposable implements IPtyService {
 		performance.mark('code/willGetTerminalLayoutInfo');
 		const layout = this._workspaceLayoutInfos.get(args.workspaceId);
 		if (layout) {
-			const expandedTabs = await Promise.all(layout.tabs.map(async tab => this._expandTerminalTab(tab)));
+			const expandedTabs = await Promise.all(layout.tabs.map(async tab => this._expandTerminalTab(args.workspaceId, tab)));
 			const tabs = expandedTabs.filter(t => t.terminals.length > 0);
 			performance.mark('code/didGetTerminalLayoutInfo');
 			return { tabs };
@@ -527,8 +528,8 @@ export class PtyService extends Disposable implements IPtyService {
 		return undefined;
 	}
 
-	private async _expandTerminalTab(tab: ITerminalTabLayoutInfoById): Promise<ITerminalTabLayoutInfoDto> {
-		const expandedTerminals = (await Promise.all(tab.terminals.map(t => this._expandTerminalInstance(t))));
+	private async _expandTerminalTab(workspaceId: string, tab: ITerminalTabLayoutInfoById): Promise<ITerminalTabLayoutInfoDto> {
+		const expandedTerminals = (await Promise.all(tab.terminals.map(t => this._expandTerminalInstance(workspaceId, t))));
 		const filtered = expandedTerminals.filter(term => term.terminal !== null) as IRawTerminalInstanceLayoutInfo<IProcessDetails>[];
 		return {
 			isActive: tab.isActive,
@@ -537,11 +538,12 @@ export class PtyService extends Disposable implements IPtyService {
 		};
 	}
 
-	private async _expandTerminalInstance(t: ITerminalInstanceLayoutInfoById): Promise<IRawTerminalInstanceLayoutInfo<IProcessDetails | null>> {
+	private async _expandTerminalInstance(workspaceId: string, t: ITerminalInstanceLayoutInfoById): Promise<IRawTerminalInstanceLayoutInfo<IProcessDetails | null>> {
 		try {
-			const revivedPtyId = this._revivedPtyIdMap.get(t.terminal)?.newId;
-			this._logService.info(`Expanding terminal instance, old id ${t.terminal} -> new id ${revivedPtyId}`);
-			this._revivedPtyIdMap.delete(t.terminal);
+			const oldId = this._getRevivingProcessId(workspaceId, t.terminal);
+			const revivedPtyId = this._revivedPtyIdMap.get(oldId)?.newId;
+			this._logService.info(`Expanding terminal instance, old id ${oldId} -> new id ${revivedPtyId}`);
+			this._revivedPtyIdMap.delete(oldId);
 			const persistentProcessId = revivedPtyId ?? t.terminal;
 			const persistentProcess = this._throwIfNoPty(persistentProcessId);
 			const processDetails = persistentProcess && await this._buildProcessDetails(t.terminal, persistentProcess, revivedPtyId !== undefined);
@@ -559,6 +561,10 @@ export class PtyService extends Disposable implements IPtyService {
 				relativeSize: t.relativeSize
 			};
 		}
+	}
+
+	private _getRevivingProcessId(workspaceId: string, ptyId: number): string {
+		return `${workspaceId}-${ptyId}`;
 	}
 
 	private async _buildProcessDetails(id: number, persistentProcess: PersistentTerminalProcess, wasRevived: boolean = false): Promise<IProcessDetails> {

--- a/src/vs/workbench/contrib/terminal/electron-sandbox/localTerminalBackend.ts
+++ b/src/vs/workbench/contrib/terminal/electron-sandbox/localTerminalBackend.ts
@@ -232,7 +232,7 @@ class LocalTerminalBackend extends BaseTerminalBackend implements ITerminalBacke
 	async attachToRevivedProcess(id: number): Promise<ITerminalChildProcess | undefined> {
 		await this._connectToDirectProxy();
 		try {
-			const newId = await this._proxy.getRevivedPtyNewId(id) ?? id;
+			const newId = await this._proxy.getRevivedPtyNewId(this._getWorkspaceId(), id) ?? id;
 			return await this.attachToProcess(newId);
 		} catch (e) {
 			this._logService.warn(`Couldn't attach to process ${e.message}`);
@@ -288,9 +288,8 @@ class LocalTerminalBackend extends BaseTerminalBackend implements ITerminalBacke
 	}
 
 	async getTerminalLayoutInfo(): Promise<ITerminalsLayoutInfo | undefined> {
-		const layoutArgs: IGetTerminalLayoutInfoArgs = {
-			workspaceId: this._getWorkspaceId()
-		};
+		const workspaceId = this._getWorkspaceId();
+		const layoutArgs: IGetTerminalLayoutInfoArgs = { workspaceId };
 
 		// Revive processes if needed
 		const serializedState = this._storageService.get(TerminalStorageKeys.TerminalBufferState, StorageScope.WORKSPACE);
@@ -317,7 +316,7 @@ class LocalTerminalBackend extends BaseTerminalBackend implements ITerminalBacke
 			mark('code/terminal/didGetReviveEnvironments');
 
 			mark('code/terminal/willReviveTerminalProcesses');
-			await this._proxy.reviveTerminalProcesses(parsed, Intl.DateTimeFormat().resolvedOptions().locale);
+			await this._proxy.reviveTerminalProcesses(workspaceId, parsed, Intl.DateTimeFormat().resolvedOptions().locale);
 			mark('code/terminal/didReviveTerminalProcesses');
 			this._storageService.remove(TerminalStorageKeys.TerminalBufferState, StorageScope.WORKSPACE);
 			// If reviving processes, send the terminal layout info back to the pty host as it


### PR DESCRIPTION
Fixes #133542

Before:

```
2023-07-03 13:01:56.461 [info] Expanding terminal instance, old id 1 -> new id 3
2023-07-03 13:01:56.461 [info] Expanding terminal instance, old id 2 -> new id 4
2023-07-03 13:01:57.086 [info] Expanding terminal instance, old id 1 -> new id undefined
2023-07-03 13:01:57.086 [info] Expanding terminal instance, old id 2 -> new id undefined
```

After:

```
2023-07-03 13:48:49.293 [info] Expanding terminal instance, old id a1b26a62c0dc8506dbab12536639ec57-3 -> new id 1
2023-07-03 13:48:49.294 [info] Expanding terminal instance, old id a1b26a62c0dc8506dbab12536639ec57-4 -> new id 2
2023-07-03 13:48:49.935 [info] Expanding terminal instance, old id 1b927216d3a88da4037d872d0731b799-1 -> new id 3
2023-07-03 13:48:49.935 [info] Expanding terminal instance, old id 1b927216d3a88da4037d872d0731b799-2 -> new id 4
```