### PR TITLE
paste markdown link off by default

### DIFF
--- a/extensions/markdown-language-features/package.json
+++ b/extensions/markdown-language-features/package.json
@@ -502,7 +502,7 @@
           "type": "boolean",
           "scope": "resource",
           "markdownDescription": "%configuration.markdown.editor.pasteUrlAsFormattedLink.enabled%",
-          "default": true
+          "default": false
         },
         "markdown.validate.enabled": {
           "type": "boolean",


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

The automatic pasting of markdown links has been turned off by default. 
Because of https://github.com/microsoft/vscode/issues/186913 and https://github.com/microsoft/vscode/issues/186913


