### PR TITLE
Show busy indicator in remote menu when initializing.

### DIFF
--- a/src/vs/workbench/contrib/remote/browser/remoteIndicator.ts
+++ b/src/vs/workbench/contrib/remote/browser/remoteIndicator.ts
@@ -836,7 +836,6 @@ export class RemoteStatusIndicator extends Disposable implements IWorkbenchContr
 			this._register(this.onDidChangeEntries(() => {
 				// If quick pick is open, update the quick pick items after initialization.
 				quickPick.busy = false;
-				quickPick.placeholder = nls.localize('remoteActions', "Select an option to open a Remote Window");
 				quickPick.items = computeItems();
 			}));
 		}

--- a/src/vs/workbench/contrib/remote/browser/remoteIndicator.ts
+++ b/src/vs/workbench/contrib/remote/browser/remoteIndicator.ts
@@ -8,8 +8,8 @@ import { STATUS_BAR_HOST_NAME_BACKGROUND, STATUS_BAR_HOST_NAME_FOREGROUND } from
 import { themeColorFromId } from 'vs/platform/theme/common/themeService';
 import { IRemoteAgentService, remoteConnectionLatencyMeasurer } from 'vs/workbench/services/remote/common/remoteAgentService';
 import { RunOnceScheduler, retry } from 'vs/base/common/async';
-import { Event } from 'vs/base/common/event';
-import { Disposable, dispose } from 'vs/base/common/lifecycle';
+import { Emitter, Event } from 'vs/base/common/event';
+import { Disposable } from 'vs/base/common/lifecycle';
 import { MenuId, IMenuService, MenuItemAction, MenuRegistry, registerAction2, Action2, SubmenuItemAction } from 'vs/platform/actions/common/actions';
 import { IWorkbenchContribution } from 'vs/workbench/common/contributions';
 import { StatusbarAlignment, IStatusbarService, IStatusbarEntryAccessor, IStatusbarEntry } from 'vs/workbench/services/statusbar/browser/statusbar';
@@ -115,6 +115,9 @@ export class RemoteStatusIndicator extends Disposable implements IWorkbenchContr
 	private loggedInvalidGroupNames: { [group: string]: boolean } = Object.create(null);
 	private readonly remoteExtensionMetadata: RemoteExtensionMetadata[];
 	private remoteMetadataInitialized: boolean = false;
+	private readonly _onDidChangeEntries = this._register(new Emitter<void>());
+	private readonly onDidChangeEntries: Event<void> = this._onDidChangeEntries.event;
+
 	constructor(
 		@IStatusbarService private readonly statusbarService: IStatusbarService,
 		@IBrowserWorkbenchEnvironmentService private readonly environmentService: IBrowserWorkbenchEnvironmentService,
@@ -341,6 +344,7 @@ export class RemoteStatusIndicator extends Disposable implements IWorkbenchContr
 		}
 
 		this.remoteMetadataInitialized = true;
+		this._onDidChangeEntries.fire();
 		showRemoteStartEntry.bindTo(this.contextKeyService).set(true);
 		this.updateRemoteStatusIndicator();
 	}
@@ -551,15 +555,8 @@ export class RemoteStatusIndicator extends Disposable implements IWorkbenchContr
 			}
 		}
 
-		// Show when there are commands or installable remote extensions.
-		if (this.hasRemoteMenuCommands(true) || this.remoteExtensionMetadata.some(ext => !ext.installed && ext.isPlatformCompatible)) {
-			this.renderRemoteStatusIndicator(`$(remote)`, nls.localize('noHost.tooltip', "Open a Remote Window"));
-			return;
-		}
-
-		// No Remote Extensions: hide status indicator
-		dispose(this.remoteStatusEntry);
-		this.remoteStatusEntry = undefined;
+		this.renderRemoteStatusIndicator(`$(remote)`, nls.localize('noHost.tooltip', "Open a Remote Window"));
+		return;
 	}
 
 	private renderRemoteStatusIndicator(initialText: string, initialTooltip?: string | MarkdownString, command?: string, showProgress?: boolean): void {
@@ -573,7 +570,7 @@ export class RemoteStatusIndicator extends Disposable implements IWorkbenchContr
 			text,
 			showProgress,
 			tooltip,
-			command: command ?? (this.hasRemoteMenuCommands(false) || this.remoteExtensionMetadata.some(ext => !ext.installed && ext.isPlatformCompatible)) ? RemoteStatusIndicator.REMOTE_ACTIONS_COMMAND_ID : undefined
+			command: command ?? RemoteStatusIndicator.REMOTE_ACTIONS_COMMAND_ID
 		};
 
 		if (this.remoteStatusEntry) {
@@ -834,17 +831,16 @@ export class RemoteStatusIndicator extends Disposable implements IWorkbenchContr
 		const itemUpdater = this.remoteIndicatorMenu.onDidChange(() => quickPick.items = computeItems());
 		quickPick.onDidHide(itemUpdater.dispose);
 
-		quickPick.show();
-	}
-
-	private hasRemoteMenuCommands(ignoreInstallAdditional: boolean): boolean {
-		if (this.remoteAuthority !== undefined || this.virtualWorkspaceLocation !== undefined) {
-			if (RemoteStatusIndicator.SHOW_CLOSE_REMOTE_COMMAND_ID) {
-				return true;
-			}
-		} else if (!ignoreInstallAdditional && this.extensionGalleryService.isEnabled()) {
-			return true;
+		if (!this.remoteMetadataInitialized) {
+			quickPick.busy = true;
+			this._register(this.onDidChangeEntries(() => {
+				// If quick pick is open, update the quick pick items after initialization.
+				quickPick.busy = false;
+				quickPick.placeholder = nls.localize('remoteActions', "Select an option to open a Remote Window");
+				quickPick.items = computeItems();
+			}));
 		}
-		return this.getRemoteMenuActions().length > 0;
+
+		quickPick.show();
 	}
 }


### PR DESCRIPTION
Fixes:
https://github.com/microsoft/vscode/issues/186278

Changing up the remote indicator experience to be always enabled from startup (with https://github.com/microsoft/vscode/issues/184845 we have added the ability to install remote extensions). Since initialization may not have completed yet, we show a busy indicator if quick pick is opened. 

See experience below of opening remote indicator on startup:
![Recording 2023-07-04 at 18 00 41](https://github.com/microsoft/vscode/assets/25044782/5989e143-d52b-4747-a5a0-230e64df0986)

