### PR TITLE
Revert "enable COI for desktop via `coep: credentialless`, change command line flag from "enable-coi" to "disable-coi" (#186720)"

### DIFF
--- a/src/vs/base/common/network.ts
+++ b/src/vs/base/common/network.ts
@@ -289,12 +289,10 @@ export const FileAccess = new FileAccessImpl();
 
 export namespace COI {
 
-	const coepDefault = platform.isElectron ? 'credentialless' : 'require-corp';
-
 	const coiHeaders = new Map<'3' | '2' | '1' | string, Record<string, string>>([
 		['1', { 'Cross-Origin-Opener-Policy': 'same-origin' }],
-		['2', { 'Cross-Origin-Embedder-Policy': coepDefault }],
-		['3', { 'Cross-Origin-Opener-Policy': 'same-origin', 'Cross-Origin-Embedder-Policy': coepDefault }],
+		['2', { 'Cross-Origin-Embedder-Policy': 'require-corp' }],
+		['3', { 'Cross-Origin-Opener-Policy': 'same-origin', 'Cross-Origin-Embedder-Policy': 'require-corp' }],
 	]);
 
 	export const CoopAndCoep = Object.freeze(coiHeaders.get('3'));

--- a/src/vs/platform/environment/common/argv.ts
+++ b/src/vs/platform/environment/common/argv.ts
@@ -111,7 +111,7 @@ export interface NativeParsedArgs {
 	'profile-temp'?: boolean;
 	'disable-chromium-sandbox'?: boolean;
 
-	'disable-coi'?: boolean;
+	'enable-coi'?: boolean;
 
 	// chromium command line args: https://electronjs.org/docs/all#supported-chrome-command-line-switches
 	'no-proxy-server'?: boolean;

--- a/src/vs/platform/environment/electron-main/environmentMainService.ts
+++ b/src/vs/platform/environment/electron-main/environmentMainService.ts
@@ -63,7 +63,7 @@ export class EnvironmentMainService extends NativeEnvironmentService implements 
 	get disableKeytar(): boolean { return !!this.args['disable-keytar']; }
 
 	@memoize
-	get crossOriginIsolated(): boolean { return !this.args['disable-coi']; }
+	get crossOriginIsolated(): boolean { return !!this.args['enable-coi']; }
 
 	@memoize
 	get codeCachePath(): string | undefined { return process.env['VSCODE_CODE_CACHE_PATH'] || undefined; }

--- a/src/vs/platform/environment/node/argv.ts
+++ b/src/vs/platform/environment/node/argv.ts
@@ -164,7 +164,7 @@ export const OPTIONS: OptionDescriptions<Required<NativeParsedArgs>> = {
 	'continueOn': { type: 'string' },
 	'locate-shell-integration-path': { type: 'string', args: ['bash', 'pwsh', 'zsh', 'fish'] },
 
-	'disable-coi': { type: 'boolean' },
+	'enable-coi': { type: 'boolean' },
 
 	// chromium flags
 	'no-proxy-server': { type: 'boolean' },


### PR DESCRIPTION
This reverts commit eafde5a28081c115bb0b06e5199be8f2822a737c.
