### PR TITLE
testing: fix setting of `testing.isInPeek` context key

### DIFF
--- a/src/vs/workbench/contrib/testing/common/testingContextKeys.ts
+++ b/src/vs/workbench/contrib/testing/common/testingContextKeys.ts
@@ -35,7 +35,7 @@ export namespace TestingContextKeys {
 	export const viewMode = new RawContextKey<TestExplorerViewMode>('testing.explorerViewMode', TestExplorerViewMode.List);
 	export const viewSorting = new RawContextKey<TestExplorerViewSorting>('testing.explorerViewSorting', TestExplorerViewSorting.ByLocation);
 	export const isRunning = new RawContextKey<boolean>('testing.isRunning', false);
-	export const isInPeek = new RawContextKey<boolean>('testing.isInPeek', true);
+	export const isInPeek = new RawContextKey<boolean>('testing.isInPeek', false);
 	export const isPeekVisible = new RawContextKey<boolean>('testing.isPeekVisible', false);
 
 	export const peekItemType = new RawContextKey<string | undefined>('peekItemType', undefined, {


### PR DESCRIPTION
Fixes #186979

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
