### PR TITLE
testing: fix appendOutput not showing up in real time

### DIFF
--- a/src/vs/workbench/contrib/testing/browser/explorerProjections/listProjection.ts
+++ b/src/vs/workbench/contrib/testing/browser/explorerProjections/listProjection.ts
@@ -12,6 +12,7 @@ import { flatTestItemDelimiter } from 'vs/workbench/contrib/testing/browser/expl
 import { ITestTreeProjection, TestExplorerTreeElement, TestItemTreeElement, TestTreeErrorMessage, getChildrenForParent, testIdentityProvider } from 'vs/workbench/contrib/testing/browser/explorerProjections/index';
 import { ISerializedTestTreeCollapseState, isCollapsedInSerializedTestTree } from 'vs/workbench/contrib/testing/browser/explorerProjections/testingViewState';
 import { TestId } from 'vs/workbench/contrib/testing/common/testId';
+import { TestResultItemChangeReason } from 'vs/workbench/contrib/testing/common/testResult';
 import { ITestResultService } from 'vs/workbench/contrib/testing/common/testResultService';
 import { ITestService } from 'vs/workbench/contrib/testing/common/testService';
 import { ITestItemUpdate, InternalTestItem, TestDiffOpType, TestItemExpandState, TestResultState, TestsDiff, applyTestItemUpdate } from 'vs/workbench/contrib/testing/common/testTypes';
@@ -106,6 +107,10 @@ export class ListProjection extends Disposable implements ITestTreeProjection {
 
 		// when test states change, reflect in the tree
 		this._register(results.onTestChanged(ev => {
+			if (ev.reason === TestResultItemChangeReason.NewMessage) {
+				return; // no effect in the tree
+			}
+
 			let result = ev.item;
 			// if the state is unset, or the latest run is not making the change,
 			// double check that it's valid. Retire calls might cause previous

--- a/src/vs/workbench/contrib/testing/browser/explorerProjections/treeProjection.ts
+++ b/src/vs/workbench/contrib/testing/browser/explorerProjections/treeProjection.ts
@@ -139,6 +139,10 @@ export class TreeProjection extends Disposable implements ITestTreeProjection {
 
 		// when test states change, reflect in the tree
 		this._register(results.onTestChanged(ev => {
+			if (ev.reason === TestResultItemChangeReason.NewMessage) {
+				return; // no effect in the tree
+			}
+
 			let result = ev.item;
 			// if the state is unset, or the latest run is not making the change,
 			// double check that it's valid. Retire calls might cause previous

--- a/src/vs/workbench/contrib/testing/browser/testingOutputPeek.ts
+++ b/src/vs/workbench/contrib/testing/browser/testingOutputPeek.ts
@@ -1696,7 +1696,9 @@ class OutputPeekTree extends Disposable {
 
 					const itemNode = taskNode.itemsCache.get(e.item);
 					if (itemNode && this.tree.hasElement(itemNode)) {
-						this.tree.setChildren(itemNode, getTestChildren(result, e.item, index), { diffIdentityProvider });
+						if (e.reason === TestResultItemChangeReason.NewMessage) {
+							this.tree.setChildren(itemNode, getTestChildren(result, e.item, index), { diffIdentityProvider });
+						}
 						itemNode.changeEmitter.fire();
 						return;
 					}


### PR DESCRIPTION
Fire a test change event when output changes. Previously it only appeared when something else forced decorations to sync.

Fixes #184825

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
