### PR TITLE
wait for task system info before running any task

### DIFF
--- a/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
+++ b/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
@@ -2749,16 +2749,7 @@ export abstract class AbstractTaskService extends Disposable implements ITaskSer
 		return true;
 	}
 
-	private async _ensureWorkspaceTasks(): Promise<void> {
-		if (!this._workspaceTasksPromise) {
-			await this.getWorkspaceTasks();
-		} else {
-			await this._workspaceTasksPromise;
-		}
-	}
-
 	private async _runTaskCommand(filter?: string | ITaskIdentifier): Promise<void> {
-		await this._ensureWorkspaceTasks();
 		if (!filter) {
 			return this._doRunTaskCommand();
 		}
@@ -2916,7 +2907,6 @@ export abstract class AbstractTaskService extends Disposable implements ITaskSer
 			title: strings.fetching
 		};
 		const promise = (async () => {
-			await this._ensureWorkspaceTasks();
 			let taskGroupTasks: (Task | ConfiguringTask)[] = [];
 
 			async function runSingleTask(task: Task | undefined, problemMatcherOptions: IProblemMatcherRunOptions | undefined, that: AbstractTaskService) {

--- a/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
+++ b/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
@@ -210,7 +210,7 @@ export abstract class AbstractTaskService extends Disposable implements ITaskSer
 	protected _taskSystemInfos: Map<string, ITaskSystemInfo[]>;
 
 	protected _workspaceTasksPromise?: Promise<Map<string, IWorkspaceFolderTaskResult>>;
-	protected _whenTaskSystemReady?: Promise<void>;
+	protected readonly _whenTaskSystemReady: Promise<void>;
 
 	protected _taskSystem?: ITaskSystem;
 	protected _taskSystemListeners?: IDisposable[] = [];

--- a/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
+++ b/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
@@ -2207,11 +2207,9 @@ export abstract class AbstractTaskService extends Disposable implements ITaskSer
 		if (!(await this._trust())) {
 			return new Map();
 		}
-		await this._waitForTaskSystem();
 		await this._waitForSupportedExecutions;
-		// The build task might be run before folder open. On folder open, we need to update the tasks so that
-		// all tasks are parsed. #173384
-		if (runSource !== TaskRunSource.FolderOpen && this._workspaceTasksPromise) {
+		await this._waitForTaskSystem();
+		if (this._workspaceTasksPromise) {
 			return this._workspaceTasksPromise;
 		}
 		return this._updateWorkspaceTasks(runSource);

--- a/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
+++ b/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
@@ -2756,8 +2756,16 @@ export abstract class AbstractTaskService extends Disposable implements ITaskSer
 		return true;
 	}
 
+	private async _ensureWorkspaceTasks(): Promise<void> {
+		if (!this._workspaceTasksPromise) {
+			await this.getWorkspaceTasks();
+		} else {
+			await this._workspaceTasksPromise;
+		}
+	}
+
 	private async _runTaskCommand(filter?: string | ITaskIdentifier): Promise<void> {
-		await this._waitForTaskSystem();
+		await this._ensureWorkspaceTasks();
 		if (!filter) {
 			return this._doRunTaskCommand();
 		}
@@ -2915,7 +2923,7 @@ export abstract class AbstractTaskService extends Disposable implements ITaskSer
 			title: strings.fetching
 		};
 		const promise = (async () => {
-			await this._waitForTaskSystem();
+			await this._ensureWorkspaceTasks();
 			let taskGroupTasks: (Task | ConfiguringTask)[] = [];
 
 			async function runSingleTask(task: Task | undefined, problemMatcherOptions: IProblemMatcherRunOptions | undefined, that: AbstractTaskService) {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

When I reproduce the issue, here's the output I see: https://github.com/microsoft/vscode/issues/173384#issuecomment-1622109886

https://github.com/microsoft/vscode/blob/5a82dbde13ba694bfa174b35d9cb39507a35b171/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts#L2129

https://github.com/microsoft/vscode/blob/5a82dbde13ba694bfa174b35d9cb39507a35b171/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts#L2363

and those lines are reached if we try to get the workspace tasks before this has happened

https://github.com/microsoft/vscode/blob/5a82dbde13ba694bfa174b35d9cb39507a35b171/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts#L653-L661

so we now will do for runTask, runBuildTask, and reconnectTasks what `runAutomaticTasks` does to avoid such issues

https://github.com/microsoft/vscode/blob/5a82dbde13ba694bfa174b35d9cb39507a35b171/src/vs/workbench/contrib/tasks/browser/runAutomaticTasks.ts#L47-L51

fix #173384