### PR TITLE
Generalize Ctrl+DownArrow and Ctrl+UpArrow to most input-result widgets (Fix #179967)

### DIFF
--- a/src/vs/workbench/browser/actions/listCommands.ts
+++ b/src/vs/workbench/browser/actions/listCommands.ts
@@ -7,7 +7,7 @@ import { KeyMod, KeyCode } from 'vs/base/common/keyCodes';
 import { ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
 import { KeybindingsRegistry, KeybindingWeight } from 'vs/platform/keybinding/common/keybindingsRegistry';
 import { List } from 'vs/base/browser/ui/list/listWidget';
-import { WorkbenchListFocusContextKey, IListService, WorkbenchListSupportsMultiSelectContextKey, ListWidget, WorkbenchListHasSelectionOrFocus, getSelectionKeyboardEvent, WorkbenchListWidget, WorkbenchListSelectionNavigation, WorkbenchTreeElementCanCollapse, WorkbenchTreeElementHasParent, WorkbenchTreeElementHasChild, WorkbenchTreeElementCanExpand, RawWorkbenchListFocusContextKey, WorkbenchTreeFindOpen, WorkbenchListSupportsFind } from 'vs/platform/list/browser/listService';
+import { WorkbenchListFocusContextKey, IListService, WorkbenchListSupportsMultiSelectContextKey, ListWidget, WorkbenchListHasSelectionOrFocus, getSelectionKeyboardEvent, WorkbenchListWidget, WorkbenchListSelectionNavigation, WorkbenchTreeElementCanCollapse, WorkbenchTreeElementHasParent, WorkbenchTreeElementHasChild, WorkbenchTreeElementCanExpand, RawWorkbenchListFocusContextKey, WorkbenchTreeFindOpen, WorkbenchListSupportsFind, WorkbenchListScrollAtBottomContextKey, WorkbenchListScrollAtTopContextKey } from 'vs/platform/list/browser/listService';
 import { PagedList } from 'vs/base/browser/ui/list/listPaging';
 import { equals, range } from 'vs/base/common/arrays';
 import { ContextKeyExpr } from 'vs/platform/contextkey/common/contextkey';
@@ -692,7 +692,12 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 KeybindingsRegistry.registerCommandAndKeybindingRule({
 	id: 'list.scrollUp',
 	weight: KeybindingWeight.WorkbenchContrib,
-	when: WorkbenchListFocusContextKey,
+	// Since the default keybindings for list.scrollUp and widgetNavigation.focusPrevious
+	// are both Ctrl+UpArrow, we disable this command when the scrollbar is at
+	// top-most position. This will give chance for widgetNavigation.focusPrevious to execute
+	when: ContextKeyExpr.and(
+		WorkbenchListFocusContextKey,
+		WorkbenchListScrollAtTopContextKey?.negate()),
 	primary: KeyMod.CtrlCmd | KeyCode.UpArrow,
 	handler: accessor => {
 		const focused = accessor.get(IListService).lastFocusedList;
@@ -708,7 +713,10 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 KeybindingsRegistry.registerCommandAndKeybindingRule({
 	id: 'list.scrollDown',
 	weight: KeybindingWeight.WorkbenchContrib,
-	when: WorkbenchListFocusContextKey,
+	// same as above
+	when: ContextKeyExpr.and(
+		WorkbenchListFocusContextKey,
+		WorkbenchListScrollAtBottomContextKey?.negate()),
 	primary: KeyMod.CtrlCmd | KeyCode.DownArrow,
 	handler: accessor => {
 		const focused = accessor.get(IListService).lastFocusedList;

--- a/src/vs/workbench/browser/actions/widgetNavigationCommands.ts
+++ b/src/vs/workbench/browser/actions/widgetNavigationCommands.ts
@@ -1,0 +1,149 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { KeyMod, KeyCode } from 'vs/base/common/keyCodes';
+import { ContextKeyExpr, IContextKey, IContextKeyService, RawContextKey } from 'vs/platform/contextkey/common/contextkey';
+import { KeybindingWeight, KeybindingsRegistry } from 'vs/platform/keybinding/common/keybindingsRegistry';
+import { WorkbenchListFocusContextKey, WorkbenchListScrollAtBottomContextKey, WorkbenchListScrollAtTopContextKey } from 'vs/platform/list/browser/listService';
+import { Event } from 'vs/base/common/event';
+import { combinedDisposable, toDisposable, IDisposable, Disposable } from 'vs/base/common/lifecycle';
+import { Registry } from 'vs/platform/registry/common/platform';
+import { IWorkbenchContributionsRegistry, Extensions as WorkbenchExtensions } from 'vs/workbench/common/contributions';
+import { LifecyclePhase } from 'vs/workbench/services/lifecycle/common/lifecycle';
+
+/** INavigatableContainer represents a logical container composed of widgets that can
+	be navigated back and forth with key shortcuts */
+interface INavigatableContainer {
+	/**
+	 * The container may coomposed of multiple parts that share no DOM ancestor
+	 * (e.g., the main body and filter box of MarkersView may be separated).
+	 * To track the focus of container we must pass in focus/blur events of all parts
+	 * as `focusNotifiers`.
+	 *
+	 * Each element of `focusNotifiers` notifies the focus/blur event for a part of
+	 * the container. The container is considered focused if at least one part being
+	 * focused, and blurred if all parts being blurred.
+	 */
+	readonly focusNotifiers: readonly IFocusNotifier[];
+	focusPreviousWidget(): void;
+	focusNextWidget(): void;
+}
+
+interface IFocusNotifier {
+	readonly onDidFocus: Event<any>;
+	readonly onDidBlur: Event<any>;
+}
+
+function handleFocusEventsGroup(group: readonly IFocusNotifier[], handler: (isFocus: boolean) => void): IDisposable {
+	const focusedIndices = new Set<number>();
+	return combinedDisposable(...group.map((events, index) => combinedDisposable(
+		events.onDidFocus(() => {
+			if (!focusedIndices.size) {
+				handler(true);
+			}
+			focusedIndices.add(index);
+		}),
+		events.onDidBlur(() => {
+			focusedIndices.delete(index);
+			if (!focusedIndices.size) {
+				handler(false);
+			}
+		}),
+	)));
+}
+
+const NavigatableContainerFocusedContextKey = new RawContextKey<boolean>('navigatableContainerFocused', false);
+
+class NavigatableContainerManager implements IDisposable {
+	private static INSTANCE: NavigatableContainerManager | undefined;
+
+	private readonly containers = new Set<INavigatableContainer>();
+	private lastContainer: INavigatableContainer | undefined;
+	private focused: IContextKey<boolean>;
+
+
+	constructor(@IContextKeyService contextKeyService: IContextKeyService) {
+		this.focused = NavigatableContainerFocusedContextKey.bindTo(contextKeyService);
+		NavigatableContainerManager.INSTANCE = this;
+	}
+
+	dispose(): void {
+		this.containers.clear();
+		this.focused.reset();
+		NavigatableContainerManager.INSTANCE = undefined;
+	}
+
+	static register(container: INavigatableContainer): IDisposable {
+		const instance = this.INSTANCE;
+		if (!instance) {
+			return Disposable.None;
+		}
+		instance.containers.add(container);
+
+		return combinedDisposable(
+			handleFocusEventsGroup(container.focusNotifiers, (isFocus) => {
+				if (isFocus) {
+					instance.focused.set(true);
+					instance.lastContainer = container;
+				} else if (instance.lastContainer === container) {
+					instance.focused.set(false);
+					instance.lastContainer = undefined;
+				}
+			}),
+			toDisposable(() => {
+				instance.containers.delete(container);
+				if (instance.lastContainer === container) {
+					instance.focused.set(false);
+					instance.lastContainer = undefined;
+				}
+			})
+		);
+	}
+
+	static getActive(): INavigatableContainer | undefined {
+		return this.INSTANCE?.lastContainer;
+	}
+}
+
+export function registerNavigatableContainer(container: INavigatableContainer): IDisposable {
+	return NavigatableContainerManager.register(container);
+}
+
+Registry.as<IWorkbenchContributionsRegistry>(WorkbenchExtensions.Workbench)
+	.registerWorkbenchContribution(NavigatableContainerManager, LifecyclePhase.Starting);
+
+KeybindingsRegistry.registerCommandAndKeybindingRule({
+	id: 'widgetNavigation.focusPrevious',
+	weight: KeybindingWeight.WorkbenchContrib,
+	when: ContextKeyExpr.and(
+		NavigatableContainerFocusedContextKey,
+		ContextKeyExpr.or(
+			WorkbenchListFocusContextKey?.negate(),
+			WorkbenchListScrollAtTopContextKey,
+		)
+	),
+	primary: KeyMod.CtrlCmd | KeyCode.UpArrow,
+	handler: () => {
+		const activeContainer = NavigatableContainerManager.getActive();
+		activeContainer?.focusPreviousWidget();
+	}
+});
+
+KeybindingsRegistry.registerCommandAndKeybindingRule({
+	id: 'widgetNavigation.focusNext',
+	weight: KeybindingWeight.WorkbenchContrib,
+	when: ContextKeyExpr.and(
+		NavigatableContainerFocusedContextKey,
+		ContextKeyExpr.or(
+			WorkbenchListFocusContextKey?.negate(),
+			WorkbenchListScrollAtBottomContextKey,
+		)
+	),
+	primary: KeyMod.CtrlCmd | KeyCode.DownArrow,
+	handler: () => {
+		const activeContainer = NavigatableContainerManager.getActive();
+		activeContainer?.focusNextWidget();
+	}
+});

--- a/src/vs/workbench/browser/parts/views/viewFilter.ts
+++ b/src/vs/workbench/browser/parts/views/viewFilter.ts
@@ -81,6 +81,10 @@ export class FilterWidget extends Widget {
 	private moreFiltersActionViewItem: MoreFiltersActionViewItem | undefined;
 	private isMoreFiltersChecked: boolean = false;
 
+	private focusTracker: DOM.IFocusTracker;
+	public get onDidFocus() { return this.focusTracker.onDidFocus; }
+	public get onDidBlur() { return this.focusTracker.onDidBlur; }
+
 	constructor(
 		private readonly options: IFilterWidgetOptions,
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
@@ -97,13 +101,17 @@ export class FilterWidget extends Widget {
 		}
 
 		this.element = DOM.$('.viewpane-filter');
-		this.filterInputBox = this.createInput(this.element);
+		[this.filterInputBox, this.focusTracker] = this.createInput(this.element);
 
 		const controlsContainer = DOM.append(this.element, DOM.$('.viewpane-filter-controls'));
 		this.filterBadge = this.createBadge(controlsContainer);
 		this.toolbar = this._register(this.createToolBar(controlsContainer));
 
 		this.adjustInputBox();
+	}
+
+	hasFocus(): boolean {
+		return this.filterInputBox.hasFocus();
 	}
 
 	focus(): void {
@@ -145,7 +153,7 @@ export class FilterWidget extends Widget {
 		}
 	}
 
-	private createInput(container: HTMLElement): ContextScopedHistoryInputBox {
+	private createInput(container: HTMLElement): [ContextScopedHistoryInputBox, DOM.IFocusTracker] {
 		const inputBox = this._register(this.instantiationService.createInstance(ContextScopedHistoryInputBox, container, this.contextViewService, {
 			placeholder: this.options.placeholder,
 			ariaLabel: this.options.ariaLabel,
@@ -171,7 +179,7 @@ export class FilterWidget extends Widget {
 			this._register(focusTracker.onDidBlur(() => this.focusContextKey!.set(false)));
 			this._register(toDisposable(() => this.focusContextKey!.reset()));
 		}
-		return inputBox;
+		return [inputBox, focusTracker];
 	}
 
 	private createBadge(container: HTMLElement): HTMLElement {

--- a/src/vs/workbench/contrib/comments/browser/commentsView.ts
+++ b/src/vs/workbench/contrib/comments/browser/commentsView.ts
@@ -42,6 +42,7 @@ import { ITreeElement } from 'vs/base/browser/ui/tree/tree';
 import { Iterable } from 'vs/base/common/iterator';
 import { CommentController } from 'vs/workbench/contrib/comments/browser/commentsController';
 import { Range } from 'vs/editor/common/core/range';
+import { registerNavigatableContainer } from 'vs/workbench/browser/actions/widgetNavigationCommands';
 
 const CONTEXT_KEY_HAS_COMMENTS = new RawContextKey<boolean>('commentsView.hasComments', false);
 const CONTEXT_KEY_SOME_COMMENTS_EXPANDED = new RawContextKey<boolean>('commentsView.someCommentsExpanded', false);
@@ -143,6 +144,23 @@ export class CommentsPanel extends FilterViewPane implements ICommentsView {
 		this.viewState['showUnresolved'] = this.filters.showUnresolved;
 		this.stateMemento.saveMemento();
 		super.saveState();
+	}
+
+	override render(): void {
+		super.render();
+		this._register(registerNavigatableContainer({
+			focusNotifiers: [this, this.filterWidget],
+			focusNextWidget: () => {
+				if (this.filterWidget.hasFocus()) {
+					this.focus();
+				}
+			},
+			focusPreviousWidget: () => {
+				if (!this.filterWidget.hasFocus()) {
+					this.focusFilter();
+				}
+			}
+		}));
 	}
 
 	public focusFilter(): void {

--- a/src/vs/workbench/contrib/debug/browser/repl.ts
+++ b/src/vs/workbench/contrib/debug/browser/repl.ts
@@ -68,6 +68,7 @@ import { CONTEXT_DEBUG_STATE, CONTEXT_IN_DEBUG_REPL, CONTEXT_MULTI_SESSION_REPL,
 import { Variable } from 'vs/workbench/contrib/debug/common/debugModel';
 import { ReplEvaluationResult, ReplGroup } from 'vs/workbench/contrib/debug/common/replModel';
 import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
+import { registerNavigatableContainer } from 'vs/workbench/browser/actions/widgetNavigationCommands';
 
 const $ = dom.$;
 
@@ -562,6 +563,27 @@ export class Repl extends FilterViewPane implements IHistoryNavigationWidget {
 	}
 
 	// --- Creation
+
+	override render(): void {
+		super.render();
+		this._register(registerNavigatableContainer({
+			focusNotifiers: [this, this.filterWidget],
+			focusNextWidget: () => {
+				if (this.filterWidget.hasFocus()) {
+					this.tree?.domFocus();
+				} else if (this.tree?.getHTMLElement() === document.activeElement) {
+					this.focus();
+				}
+			},
+			focusPreviousWidget: () => {
+				if (this.replInput.hasTextFocus()) {
+					this.tree?.domFocus();
+				} else if (this.tree?.getHTMLElement() === document.activeElement) {
+					this.focusFilter();
+				}
+			}
+		}));
+	}
 
 	protected override renderBody(parent: HTMLElement): void {
 		super.renderBody(parent);

--- a/src/vs/workbench/contrib/extensions/browser/extensionsViewlet.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsViewlet.ts
@@ -12,7 +12,7 @@ import { IWorkbenchContribution } from 'vs/workbench/common/contributions';
 import { Disposable, MutableDisposable } from 'vs/base/common/lifecycle';
 import { Event } from 'vs/base/common/event';
 import { Action } from 'vs/base/common/actions';
-import { append, $, Dimension, hide, show, DragAndDropObserver } from 'vs/base/browser/dom';
+import { append, $, Dimension, hide, show, DragAndDropObserver, trackFocus } from 'vs/base/browser/dom';
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 import { IInstantiationService, ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
 import { IExtensionService } from 'vs/workbench/services/extensions/common/extensions';
@@ -61,6 +61,7 @@ import { extractEditorsAndFilesDropData } from 'vs/platform/dnd/browser/dnd';
 import { extname } from 'vs/base/common/resources';
 import { areSameExtensions } from 'vs/platform/extensionManagement/common/extensionManagementUtil';
 import { ILocalizedString } from 'vs/platform/action/common/action';
+import { registerNavigatableContainer } from 'vs/workbench/browser/actions/widgetNavigationCommands';
 
 export const DefaultViewsContext = new RawContextKey<boolean>('defaultExtensionViews', true);
 export const ExtensionsSortByContext = new RawContextKey<string>('extensionsSortByValue', '');
@@ -610,6 +611,22 @@ export class ExtensionsViewPaneContainer extends ViewPaneContainer implements IE
 		}));
 
 		super.create(append(this.root, $('.extensions')));
+
+		const focusTracker = this._register(trackFocus(this.root));
+		const isSearchBoxFocused = () => this.searchBox?.inputWidget.hasWidgetFocus();
+		this._register(registerNavigatableContainer({
+			focusNotifiers: [focusTracker],
+			focusNextWidget: () => {
+				if (isSearchBoxFocused()) {
+					this.focusListView();
+				}
+			},
+			focusPreviousWidget: () => {
+				if (!isSearchBoxFocused()) {
+					this.searchBox?.focus();
+				}
+			}
+		}));
 	}
 
 	override focus(): void {

--- a/src/vs/workbench/contrib/markers/browser/markersView.ts
+++ b/src/vs/workbench/contrib/markers/browser/markersView.ts
@@ -54,6 +54,7 @@ import { ResourceListDnDHandler } from 'vs/workbench/browser/dnd';
 import { ITableContextMenuEvent, ITableEvent } from 'vs/base/browser/ui/table/table';
 import { MarkersTable } from 'vs/workbench/contrib/markers/browser/markersTable';
 import { Markers, MarkersContextKeys, MarkersViewMode } from 'vs/workbench/contrib/markers/common/markers';
+import { registerNavigatableContainer } from 'vs/workbench/browser/actions/widgetNavigationCommands';
 
 function createResourceMarkersIterator(resourceMarkers: ResourceMarkers): Iterable<ITreeElement<MarkerElement>> {
 	return Iterable.map(resourceMarkers.markers, m => {
@@ -177,6 +178,23 @@ export class MarkersView extends FilterViewPane implements IMarkersView {
 		this._register(this.configurationService.onDidChangeConfiguration(e => {
 			if (this.filters.excludedFiles && e.affectsConfiguration('files.exclude')) {
 				this.updateFilter();
+			}
+		}));
+	}
+
+	override render(): void {
+		super.render();
+		this._register(registerNavigatableContainer({
+			focusNotifiers: [this, this.filterWidget],
+			focusNextWidget: () => {
+				if (this.filterWidget.hasFocus()) {
+					this.focus();
+				}
+			},
+			focusPreviousWidget: () => {
+				if (!this.filterWidget.hasFocus()) {
+					this.focusFilter();
+				}
 			}
 		}));
 	}

--- a/src/vs/workbench/contrib/preferences/browser/keybindingsEditor.ts
+++ b/src/vs/workbench/contrib/preferences/browser/keybindingsEditor.ts
@@ -56,6 +56,7 @@ import { CompletionItemKind } from 'vs/editor/common/languages';
 import { settingsTextInputBorder } from 'vs/workbench/contrib/preferences/common/settingsEditorColorRegistry';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { AccessibilityVerbositySettingId } from 'vs/workbench/contrib/accessibility/browser/accessibilityContribution';
+import { registerNavigatableContainer } from 'vs/workbench/browser/actions/widgetNavigationCommands';
 
 const $ = DOM.$;
 
@@ -132,6 +133,23 @@ export class KeybindingsEditor extends EditorPane implements IKeybindingsEditorP
 		this.sortByPrecedenceAction = new Action(KEYBINDINGS_EDITOR_COMMAND_SORTBY_PRECEDENCE, localize('sortByPrecedeneLabel', "Sort by Precedence (Highest first)"), ThemeIcon.asClassName(keybindingsSortIcon));
 		this.sortByPrecedenceAction.checked = false;
 		this.overflowWidgetsDomNode = $('.keybindings-overflow-widgets-container.monaco-editor');
+	}
+
+	override create(parent: HTMLElement): void {
+		super.create(parent);
+		this._register(registerNavigatableContainer({
+			focusNotifiers: [this],
+			focusNextWidget: () => {
+				if (this.searchWidget.hasFocus()) {
+					this.focusKeybindings();
+				}
+			},
+			focusPreviousWidget: () => {
+				if (!this.searchWidget.hasFocus()) {
+					this.focusSearch();
+				}
+			}
+		}));
 	}
 
 	protected createEditor(parent: HTMLElement): void {

--- a/src/vs/workbench/contrib/testing/browser/testingExplorerView.ts
+++ b/src/vs/workbench/contrib/testing/browser/testingExplorerView.ts
@@ -71,6 +71,7 @@ import { ITestingPeekOpener } from 'vs/workbench/contrib/testing/common/testingP
 import { cmpPriority, isFailedState, isStateWithResult } from 'vs/workbench/contrib/testing/common/testingStates';
 import { IActivityService, NumberBadge } from 'vs/workbench/services/activity/common/activity';
 import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
+import { registerNavigatableContainer } from 'vs/workbench/browser/actions/widgetNavigationCommands';
 
 const enum LastFocusState {
 	Input,
@@ -246,6 +247,23 @@ export class TestingExplorerView extends ViewPane {
 		}
 
 		return { include: [...include], exclude };
+	}
+
+	override render(): void {
+		super.render();
+		this._register(registerNavigatableContainer({
+			focusNotifiers: [this],
+			focusNextWidget: () => {
+				if (!this.viewModel.tree.isDOMFocused()) {
+					this.viewModel.tree.domFocus();
+				}
+			},
+			focusPreviousWidget: () => {
+				if (this.viewModel.tree.isDOMFocused()) {
+					this.filter.value?.focus();
+				}
+			}
+		}));
 	}
 
 	/**

--- a/src/vs/workbench/workbench.common.main.ts
+++ b/src/vs/workbench/workbench.common.main.ts
@@ -25,6 +25,7 @@ import 'vs/workbench/browser/actions/windowActions';
 import 'vs/workbench/browser/actions/workspaceActions';
 import 'vs/workbench/browser/actions/workspaceCommands';
 import 'vs/workbench/browser/actions/quickAccessActions';
+import 'vs/workbench/browser/actions/widgetNavigationCommands';
 
 //#endregion
 


### PR DESCRIPTION
Fix #179967.

This adds Ctrl+UpArrow and Ctrl+DownArrow navigation to
 - ExtensionsViewPaneContainer
 - KeybindingsEditor
 - CommentsPanel
 - MarkersView
 - Repl

The two keybindings are uniformly controlled by two new commands `inputResults.focusResults` and `inputResults.focusInput`.
