### PR TITLE
fix: gutter testing spinner icon broken due to line height

### DIFF
--- a/src/vs/editor/browser/viewParts/glyphMargin/glyphMargin.css
+++ b/src/vs/editor/browser/viewParts/glyphMargin/glyphMargin.css
@@ -16,4 +16,17 @@
 	position: absolute;
 	display: flex;
 	align-items: center;
+	justify-content: center;
+}
+
+/*
+	Ensure spinning icons are pixel-perfectly centered and avoid wobble.
+	This is only applied to icons that spin to avoid unnecessary
+	GPU layers and blurry subpixel AA.
+*/
+.monaco-editor .glyph-margin-widgets .cgmr.codicon-modifier-spin::before  {
+	position: absolute;
+	top: 50%;
+	left: 50%;
+	transform: translate(-50%, -50%);
 }


### PR DESCRIPTION
Getting the 1px "wobble" entirely out was annoying. I initially assumed the countainer had to be either an odd or dimension for flexbox to center the icon, but this seemed to not be sufficient. For example, a line height of 36 and 40 were wobble-free, but 38 was not.

So instead take a sledgehammer at spinning icons and center them with a transform position.

Fixes #183269

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
