### PR TITLE
fix #186651 -- notebook action tab border only on icon, not label

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/media/notebookToolbar.css
+++ b/src/vs/workbench/contrib/notebook/browser/media/notebookToolbar.css
@@ -40,6 +40,18 @@
 	height: 22px;
 }
 
+.monaco-workbench .notebookOverlay .notebook-toolbar-container .notebook-toolbar-left .monaco-action-bar li a[tabindex="0"]:focus {
+	outline: none !important;
+}
+
+.monaco-workbench .notebookOverlay .notebook-toolbar-container .notebook-toolbar-left .monaco-action-bar li:has(a:focus) {
+	outline-width: 1px;
+	outline-style: solid;
+	outline-offset: -1px;
+	outline-color: var(--vscode-focusBorder);
+	opacity: 1;
+}
+
 .monaco-workbench .notebookOverlay .notebook-toolbar-container .notebook-toolbar-left .monaco-action-bar .action-item .action-label.separator {
 	margin: 5px 0px !important;
 	padding: 0px !important;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
fix #186651

Override base toolbar action highlighting, change border to surround action + label.

Future debt: change structure of actions within toolbar, allow for generic implementation of labels and highlighting