### PR TITLE
Have auth proxy use application storage service

### DIFF
--- a/src/vs/code/electron-main/auth.ts
+++ b/src/vs/code/electron-main/auth.ts
@@ -8,11 +8,14 @@ import { CancellationToken } from 'vs/base/common/cancellation';
 import { Event } from 'vs/base/common/event';
 import { hash } from 'vs/base/common/hash';
 import { Disposable } from 'vs/base/common/lifecycle';
+import { withNullAsUndefined } from 'vs/base/common/types';
 import { generateUuid } from 'vs/base/common/uuid';
 import { ICredentialsMainService } from 'vs/platform/credentials/common/credentials';
 import { IEncryptionMainService } from 'vs/platform/encryption/common/encryptionService';
 import { ILogService } from 'vs/platform/log/common/log';
 import { IProductService } from 'vs/platform/product/common/productService';
+import { StorageScope, StorageTarget } from 'vs/platform/storage/common/storage';
+import { IApplicationStorageMainService } from 'vs/platform/storage/electron-main/storageMainService';
 import { IWindowsMainService } from 'vs/platform/windows/electron-main/windows';
 
 interface ElectronAuthenticationResponseDetails extends AuthenticationResponseDetails {
@@ -56,7 +59,8 @@ enum ProxyAuthState {
 
 export class ProxyAuthHandler extends Disposable {
 
-	private readonly PROXY_CREDENTIALS_SERVICE_KEY = `${this.productService.urlProtocol}.proxy-credentials`;
+	private readonly OLD_PROXY_CREDENTIALS_SERVICE_KEY = `${this.productService.urlProtocol}.proxy-credentials`;
+	private readonly PROXY_CREDENTIALS_SERVICE_KEY = 'proxy-credentials://';
 
 	private pendingProxyResolve: Promise<Credentials | undefined> | undefined = undefined;
 
@@ -69,6 +73,7 @@ export class ProxyAuthHandler extends Disposable {
 		@IWindowsMainService private readonly windowsMainService: IWindowsMainService,
 		@ICredentialsMainService private readonly credentialsService: ICredentialsMainService,
 		@IEncryptionMainService private readonly encryptionMainService: IEncryptionMainService,
+		@IApplicationStorageMainService private readonly applicationStorageMainService: IApplicationStorageMainService,
 		@IProductService private readonly productService: IProductService
 	) {
 		super();
@@ -141,6 +146,30 @@ export class ProxyAuthHandler extends Disposable {
 		return undefined;
 	}
 
+	// TODO: remove this migration in a release or two.
+	private async getAndMigrateProxyCredentials(authInfoHash: string): Promise<{ storedUsername: string | undefined; storedPassword: string | undefined }> {
+		// Find any previously stored credentials
+		try {
+			let encryptedSerializedProxyCredentials = this.applicationStorageMainService.get(this.PROXY_CREDENTIALS_SERVICE_KEY + authInfoHash, StorageScope.APPLICATION);
+			if (!encryptedSerializedProxyCredentials) {
+				encryptedSerializedProxyCredentials = withNullAsUndefined(await this.credentialsService.getPassword(this.OLD_PROXY_CREDENTIALS_SERVICE_KEY, authInfoHash));
+				if (encryptedSerializedProxyCredentials) {
+					this.applicationStorageMainService.store(this.PROXY_CREDENTIALS_SERVICE_KEY + authInfoHash, encryptedSerializedProxyCredentials, StorageScope.APPLICATION, StorageTarget.MACHINE);
+					// Remove it from the old location since it's in the new location.
+					await this.credentialsService.deletePassword(this.OLD_PROXY_CREDENTIALS_SERVICE_KEY, authInfoHash);
+				}
+			}
+			if (encryptedSerializedProxyCredentials) {
+				const credentials: Credentials = JSON.parse(await this.encryptionMainService.decrypt(encryptedSerializedProxyCredentials));
+
+				return { storedUsername: credentials.username, storedPassword: credentials.password };
+			}
+		} catch (error) {
+			this.logService.error(error); // handle errors by asking user for login via dialog
+		}
+		return { storedUsername: undefined, storedPassword: undefined };
+	}
+
 	private async doResolveProxyCredentials(authInfo: AuthInfo): Promise<Credentials | undefined> {
 		this.logService.trace('auth#doResolveProxyCredentials - enter', authInfo);
 
@@ -149,21 +178,7 @@ export class ProxyAuthHandler extends Disposable {
 		// given the properties of the auth request
 		// (see https://github.com/microsoft/vscode/issues/109497)
 		const authInfoHash = String(hash({ scheme: authInfo.scheme, host: authInfo.host, port: authInfo.port }));
-
-		// Find any previously stored credentials
-		let storedUsername: string | undefined = undefined;
-		let storedPassword: string | undefined = undefined;
-		try {
-			const encryptedSerializedProxyCredentials = await this.credentialsService.getPassword(this.PROXY_CREDENTIALS_SERVICE_KEY, authInfoHash);
-			if (encryptedSerializedProxyCredentials) {
-				const credentials: Credentials = JSON.parse(await this.encryptionMainService.decrypt(encryptedSerializedProxyCredentials));
-
-				storedUsername = credentials.username;
-				storedPassword = credentials.password;
-			}
-		} catch (error) {
-			this.logService.error(error); // handle errors by asking user for login via dialog
-		}
+		const { storedUsername, storedPassword } = await this.getAndMigrateProxyCredentials(authInfoHash);
 
 		// Reply with stored credentials unless we used them already.
 		// In that case we need to show a login dialog again because
@@ -212,9 +227,11 @@ export class ProxyAuthHandler extends Disposable {
 						try {
 							if (reply.remember) {
 								const encryptedSerializedCredentials = await this.encryptionMainService.encrypt(JSON.stringify(credentials));
-								await this.credentialsService.setPassword(this.PROXY_CREDENTIALS_SERVICE_KEY, authInfoHash, encryptedSerializedCredentials);
+								this.applicationStorageMainService.store(this.PROXY_CREDENTIALS_SERVICE_KEY + authInfoHash, encryptedSerializedCredentials, StorageScope.APPLICATION, StorageTarget.MACHINE);
 							} else {
-								await this.credentialsService.deletePassword(this.PROXY_CREDENTIALS_SERVICE_KEY, authInfoHash);
+								this.applicationStorageMainService.remove(this.PROXY_CREDENTIALS_SERVICE_KEY + authInfoHash, StorageScope.APPLICATION);
+								// Remove it from the old location if it was stored there
+								await this.credentialsService.deletePassword(this.OLD_PROXY_CREDENTIALS_SERVICE_KEY, authInfoHash);
 							}
 						} catch (error) {
 							this.logService.error(error); // handle gracefully

--- a/src/vs/code/electron-main/auth.ts
+++ b/src/vs/code/electron-main/auth.ts
@@ -234,8 +234,6 @@ export class ProxyAuthHandler extends Disposable {
 								this.applicationStorageMainService.store(this.PROXY_CREDENTIALS_SERVICE_KEY + authInfoHash, encryptedSerializedCredentials, StorageScope.APPLICATION, StorageTarget.MACHINE);
 							} else {
 								this.applicationStorageMainService.remove(this.PROXY_CREDENTIALS_SERVICE_KEY + authInfoHash, StorageScope.APPLICATION);
-								// Remove it from the old location if it was stored there
-								await this.credentialsService.deletePassword(this.OLD_PROXY_CREDENTIALS_SERVICE_KEY, authInfoHash);
 							}
 						} catch (error) {
 							this.logService.error(error); // handle gracefully


### PR DESCRIPTION
Since this code is already using the encryption service, it already takes advantage of the better encryption provided by Electron so it can be stored in the normal storage service.

With that said, we do need a migration path, so this handles that migration.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

ref https://github.com/microsoft/vscode/issues/186241