### PR TITLE
Also check for secret storage provider before using old API

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadSecretState.ts
+++ b/src/vs/workbench/api/browser/mainThreadSecretState.ts
@@ -110,6 +110,7 @@ class OldMainThreadSecretState extends Disposable implements MainThreadSecretSta
 export class MainThreadSecretState extends Disposable implements MainThreadSecretStateShape {
 	private readonly _proxy: ExtHostSecretStateShape;
 
+	// TODO: Remove this when all known embedders implement a secret storage provider
 	private readonly _oldMainThreadSecretState: OldMainThreadSecretState | undefined;
 
 	private readonly _sequencer = new SequencerByKey<string>();
@@ -131,7 +132,11 @@ export class MainThreadSecretState extends Disposable implements MainThreadSecre
 
 		this._proxy = extHostContext.getProxy(ExtHostContext.ExtHostSecretState);
 
-		if (environmentService.options?.credentialsProvider) {
+		// If the embedder doesn't implement a secret storage provider, then we need to use the old API
+		// to ensure that secrets are still stored in a secure way. This is only temporary until all
+		// embedders implement a secret storage provider.
+		// TODO: Remove this when all known embedders implement a secret storage provider
+		if (environmentService.options?.credentialsProvider && !environmentService.options?.secretStorageProvider) {
 			this._oldMainThreadSecretState = this._register(new OldMainThreadSecretState(
 				this._proxy,
 				credentialsService,
@@ -158,7 +163,7 @@ export class MainThreadSecretState extends Disposable implements MainThreadSecre
 	}
 
 	private async doGetPassword(extensionId: string, key: string): Promise<string | undefined> {
-		// TODO: Remove this when we remove the old API
+		// TODO: Remove this when all known embedders implement a secret storage provider
 		if (this._oldMainThreadSecretState) {
 			return await this._oldMainThreadSecretState.$getPassword(extensionId, key);
 		}
@@ -184,7 +189,7 @@ export class MainThreadSecretState extends Disposable implements MainThreadSecre
 	}
 
 	private async doSetPassword(extensionId: string, key: string, value: string): Promise<void> {
-		// TODO: Remove this when we remove the old API
+		// TODO: Remove this when all known embedders implement a secret storage provider
 		if (this._oldMainThreadSecretState) {
 			return await this._oldMainThreadSecretState.$setPassword(extensionId, key, value);
 		}
@@ -200,7 +205,7 @@ export class MainThreadSecretState extends Disposable implements MainThreadSecre
 	}
 
 	private async doDeletePassword(extensionId: string, key: string): Promise<void> {
-		// TODO: Remove this when we remove the old API
+		// TODO: Remove this when all known embedders implement a secret storage provider
 		if (this._oldMainThreadSecretState) {
 			return await this._oldMainThreadSecretState.$deletePassword(extensionId, key);
 		}


### PR DESCRIPTION
This allows a nice migration path for web environments:
1. Embedder implements a secret storage provider in addition to the credentials provider they already have
2. Wait a release or 2
3. Remove the credentials provider from the embedder

Once all known embedders do number 1, we can delete the `_oldMainThreadSecretState` entirely. Once all known embedders do 1-3, then web environments won't block the removal of the CredentialsService.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
