### PR TITLE
fix fuzzyScore boost for uppercase full match

### DIFF
--- a/src/vs/base/common/filters.ts
+++ b/src/vs/base/common/filters.ts
@@ -745,12 +745,13 @@ function _doScore(
 		return Number.MIN_SAFE_INTEGER;
 	}
 
-	let score = 1;
-	let isGapLocation = false;
+	let score: number;
+	let isGapLocation: boolean;
 	if (wordPos === (patternPos - patternStart)) {
 		// common prefix: `foobar <-> foobaz`
 		//                            ^^^^^
 		score = pattern[patternPos] === word[wordPos] ? 7 : 5;
+		isGapLocation = false;
 
 	} else if (isUpperCaseAtPos(wordPos, word, wordLow) && (wordPos === 0 || !isUpperCaseAtPos(wordPos - 1, word, wordLow))) {
 		// hitting upper-case: `foo <-> forOthers`
@@ -762,20 +763,20 @@ function _doScore(
 		// hitting a separator: `. <-> foo.bar`
 		//                                ^
 		score = 5;
+		isGapLocation = false;
 
 	} else if (isSeparatorAtPos(wordLow, wordPos - 1) || isWhitespaceAtPos(wordLow, wordPos - 1)) {
 		// post separator: `foo <-> bar_foo`
 		//                              ^^^
 		score = 5;
 		isGapLocation = true;
+	} else {
+		score = 1;
+		isGapLocation = isUpperCaseAtPos(wordPos, word, wordLow);
 	}
 
 	if (score > 1 && patternPos === patternStart) {
 		outFirstMatchStrong[0] = true;
-	}
-
-	if (!isGapLocation) {
-		isGapLocation = isUpperCaseAtPos(wordPos, word, wordLow) || isSeparatorAtPos(wordLow, wordPos - 1) || isWhitespaceAtPos(wordLow, wordPos - 1);
 	}
 
 	//

--- a/src/vs/base/test/common/filters.test.ts
+++ b/src/vs/base/test/common/filters.test.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 import * as assert from 'assert';
-import { anyScore, createMatches, fuzzyScore, fuzzyScoreGraceful, fuzzyScoreGracefulAggressive, FuzzyScorer, IFilter, IMatch, matchesCamelCase, matchesContiguousSubString, matchesPrefix, matchesStrictPrefix, matchesSubString, matchesWords, or } from 'vs/base/common/filters';
+import { anyScore, createMatches, fuzzyScore, fuzzyScoreGraceful, fuzzyScoreGracefulAggressive, FuzzyScoreOptions, FuzzyScorer, IFilter, IMatch, matchesCamelCase, matchesContiguousSubString, matchesPrefix, matchesStrictPrefix, matchesSubString, matchesWords, or } from 'vs/base/common/filters';
 
 function filterOk(filter: IFilter, word: string, wordToMatchAgainst: string, highlights?: { start: number; end: number }[]) {
 	const r = filter(word, wordToMatchAgainst);
@@ -567,22 +567,48 @@ suite('Filters', () => {
 		assertMatches('bar', 'foobar', 'foo^b^a^r', anyScore);
 	});
 
+	function assertScores(
+		filter: typeof fuzzyScore,
+		assertion: (a: number, b: number) => void,
+		pattern: string,
+		a: string,
+		b: string,
+		options?: FuzzyScoreOptions,
+	): void {
+		const patternLow = pattern.toLowerCase();
+		const aScore = filter(pattern, patternLow, 0, a, a.toLowerCase(), 0, options);
+		const bScore = filter(pattern, patternLow, 0, b, b.toLowerCase(), 0, options);
+		assert.ok(aScore);
+		assert.ok(bScore);
+		assertion(aScore[0], bScore[0]);
+	}
+
+	function assertLessThan(a: number, b: number, message?: string): void {
+		assert.ok(a < b, message);
+	}
+
 	test('configurable full match boost', function () {
 		const prefix = 'create';
 		const a = 'createModelServices';
 		const b = 'create';
 
-		const aBoost = fuzzyScore(prefix, prefix, 0, a, a.toLowerCase(), 0, { boostFullMatch: true, firstMatchCanBeWeak: true });
-		const bBoost = fuzzyScore(prefix, prefix, 0, b, b.toLowerCase(), 0, { boostFullMatch: true, firstMatchCanBeWeak: true });
-		assert.ok(aBoost);
-		assert.ok(bBoost);
-		assert.ok(aBoost[0] < bBoost[0]);
+		assertScores(fuzzyScore, assertLessThan, prefix, a, b, { boostFullMatch: true, firstMatchCanBeWeak: false });
+		assertScores(fuzzyScore, assert.strictEqual, prefix, a, b, { boostFullMatch: false, firstMatchCanBeWeak: false });
+	});
 
-		const aScore = fuzzyScore(prefix, prefix, 0, a, a.toLowerCase(), 0, { boostFullMatch: false, firstMatchCanBeWeak: true });
-		const bScore = fuzzyScore(prefix, prefix, 0, b, b.toLowerCase(), 0, { boostFullMatch: false, firstMatchCanBeWeak: true });
-		assert.ok(aScore);
-		assert.ok(bScore);
-		assert.ok(aScore[0] === bScore[0]);
+	test('pattern ending in uppercase character should not get extra boost', function () {
+		assertScores(fuzzyScore, assertLessThan, 'F', 'Foo', 'F', { boostFullMatch: true, firstMatchCanBeWeak: false });
+		assertScores(fuzzyScore, assert.strictEqual, 'F', 'Foo', 'F', { boostFullMatch: false, firstMatchCanBeWeak: false });
+
+		assertScores(fuzzyScore, assertLessThan, 'aB', 'aBc', 'aB', { boostFullMatch: true, firstMatchCanBeWeak: false });
+		assertScores(fuzzyScore, assert.strictEqual, 'aB', 'aBc', 'aB', { boostFullMatch: false, firstMatchCanBeWeak: false });
+
+		// matching `F` against `F` and `f` against `f` should have the same scores
+		const upperScore = fuzzyScore('F', 'f', 0, 'F', 'f', 0);
+		const lowerScore = fuzzyScore('f', 'f', 0, 'f', 'f', 0);
+		assert.ok(upperScore);
+		assert.ok(lowerScore);
+		assert.equal(upperScore[0], lowerScore[0]);
 	});
 
 	test('Unexpected suggest highlighting ignores whole word match in favor of matching first letter#147423', function () {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Changes `fuzzyScore` to not treat uppercase characters in a common prefix as gap locations.

If you match `FOO` against `FOO` and `FOOBAR`, the score against `FOO` is +4 compared to `FOOBAR`: +2 for being a full match, and +2 because gap locations at the end of the word are only penalized -3 instead of -5. This PR fixes the latter +2. This makes the scores equal when `boostFullMatch: false`.

Fixes https://github.com/microsoft/vscode/issues/187147