### PR TITLE
clear workspace tasks promise when supported executions change

### DIFF
--- a/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
+++ b/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
@@ -2201,9 +2201,6 @@ export abstract class AbstractTaskService extends Disposable implements ITaskSer
 		}
 		await this._waitForSupportedExecutions;
 		await this._whenTaskSystemReady;
-		if (this._workspaceTasksPromise) {
-			return this._workspaceTasksPromise;
-		}
 		return this._updateWorkspaceTasks(runSource);
 	}
 
@@ -2748,16 +2745,8 @@ export abstract class AbstractTaskService extends Disposable implements ITaskSer
 		return true;
 	}
 
-	private async _ensureWorkspaceTasks(): Promise<void> {
-		if (!this._workspaceTasksPromise) {
-			await this.getWorkspaceTasks();
-		} else {
-			await this._workspaceTasksPromise;
-		}
-	}
-
 	private async _runTaskCommand(filter?: string | ITaskIdentifier): Promise<void> {
-		await this._ensureWorkspaceTasks();
+		await this.getWorkspaceTasks();
 		if (!filter) {
 			return this._doRunTaskCommand();
 		}
@@ -2915,7 +2904,7 @@ export abstract class AbstractTaskService extends Disposable implements ITaskSer
 			title: strings.fetching
 		};
 		const promise = (async () => {
-			await this._ensureWorkspaceTasks();
+			await this.getWorkspaceTasks();
 			let taskGroupTasks: (Task | ConfiguringTask)[] = [];
 
 			async function runSingleTask(task: Task | undefined, problemMatcherOptions: IProblemMatcherRunOptions | undefined, that: AbstractTaskService) {

--- a/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
+++ b/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
@@ -362,6 +362,8 @@ export abstract class AbstractTaskService extends Disposable implements ITaskSer
 			const processContext = ProcessExecutionSupportedContext.bindTo(this._contextKeyService);
 			processContext.set(process && !isVirtual);
 		}
+		// update tasks so an incomplete list isn't returned when getWorkspaceTasks is called
+		this._workspaceTasksPromise = undefined;
 		this._onDidRegisterSupportedExecutions.fire();
 	}
 
@@ -2201,6 +2203,9 @@ export abstract class AbstractTaskService extends Disposable implements ITaskSer
 		}
 		await this._waitForSupportedExecutions;
 		await this._whenTaskSystemReady;
+		if (this._workspaceTasksPromise) {
+			return this._workspaceTasksPromise;
+		}
 		return this._updateWorkspaceTasks(runSource);
 	}
 

--- a/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
+++ b/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
@@ -374,7 +374,7 @@ export abstract class AbstractTaskService extends Disposable implements ITaskSer
 			this._tasksReconnected = true;
 			return;
 		}
-		this.getWorkspaceTasks().then(async () => {
+		this.getWorkspaceTasks(TaskRunSource.Reconnect).then(async () => {
 			this._tasksReconnected = await this._reconnectTasks();
 		});
 	}
@@ -2349,11 +2349,11 @@ export abstract class AbstractTaskService extends Disposable implements ITaskSer
 		return { workspaceFolder, set: undefined, configurations: undefined, hasErrors: false };
 	}
 
-	private async _computeTasksForSingleConfig(workspaceFolder: IWorkspaceFolder | undefined, config: TaskConfig.IExternalTaskRunnerConfiguration | undefined, runSource: TaskRunSource, custom: CustomTask[], customized: IStringDictionary<ConfiguringTask>, source: TaskConfig.TaskConfigSource, isRecentTask: boolean = false): Promise<boolean> {
-		if (!config || !workspaceFolder) {
+	private async _computeTasksForSingleConfig(workspaceFolder: IWorkspaceFolder, config: TaskConfig.IExternalTaskRunnerConfiguration | undefined, runSource: TaskRunSource, custom: CustomTask[], customized: IStringDictionary<ConfiguringTask>, source: TaskConfig.TaskConfigSource, isRecentTask: boolean = false): Promise<boolean> {
+		if (!config) {
 			return false;
 		}
-		const taskSystemInfo: ITaskSystemInfo | undefined = workspaceFolder ? this._getTaskSystemInfo(workspaceFolder.uri.scheme) : undefined;
+		const taskSystemInfo: ITaskSystemInfo | undefined = this._getTaskSystemInfo(workspaceFolder.uri.scheme);
 		const problemReporter = new ProblemReporter(this._outputChannel);
 		if (!taskSystemInfo) {
 			problemReporter.fatal(nls.localize('TaskSystem.workspaceFolderError', 'Workspace folder was undefined'));
@@ -2746,7 +2746,6 @@ export abstract class AbstractTaskService extends Disposable implements ITaskSer
 	}
 
 	private async _runTaskCommand(filter?: string | ITaskIdentifier): Promise<void> {
-		await this.getWorkspaceTasks();
 		if (!filter) {
 			return this._doRunTaskCommand();
 		}
@@ -2904,7 +2903,6 @@ export abstract class AbstractTaskService extends Disposable implements ITaskSer
 			title: strings.fetching
 		};
 		const promise = (async () => {
-			await this.getWorkspaceTasks();
 			let taskGroupTasks: (Task | ConfiguringTask)[] = [];
 
 			async function runSingleTask(task: Task | undefined, problemMatcherOptions: IProblemMatcherRunOptions | undefined, that: AbstractTaskService) {


### PR DESCRIPTION
fixes #173384 

I got to the bottom of this by creating two builds 

1. removed the `_workspaceTasksPromise` altogether so that every `getWorkspaceTasks` call resulted in `_updateWorkspaceTasks`. here, I couldn't repro the problem
2. one with logs where that promise was in place. I noticed that when this would repro, the promise would get set when only some of the supported executions had been registered

![Screenshot 2023-07-06 at 8 54 45 AM](https://github.com/microsoft/vscode/assets/29464607/17ba4da6-a1f7-4d9d-8e07-2f18d4d80d41)

This is because only the first `_onDidRegisterSupportedExecutions` event is awaited despite the fact that there can be several. We still want that promise because in most cases, we can just return that instead of updating the tasks. 

https://github.com/microsoft/vscode/blob/4f1df73b952ee3526c279b0aea348a4733bb128f/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts#L336-L338

https://github.com/microsoft/vscode/blob/4f1df73b952ee3526c279b0aea348a4733bb128f/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts#L350-L369

This fixes the bug by clearing that promise, setting it to `undefined` when a supported execution gets registered such that workspace tasks will get updated instead of returning a partial list.

https://github.com/microsoft/vscode/blob/4f1df73b952ee3526c279b0aea348a4733bb128f/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts#L2206-L2209

Note that we don't need to await `getWorkspaceTasks` because the run task and run build task commands each end up calling `getWorkspaceTasks` downstream.