### PR TITLE
Add IPtyHostService

### DIFF
--- a/src/vs/platform/terminal/common/terminal.ts
+++ b/src/vs/platform/terminal/common/terminal.ts
@@ -264,7 +264,9 @@ export interface IFixedTerminalDimensions {
 	rows?: number;
 }
 
-export const IPtyService = createDecorator<IPtyService>('ptyService');
+/**
+ * A service that communicates with a pty host.
+*/
 export interface IPtyService {
 	readonly _serviceBrand: undefined;
 
@@ -344,6 +346,7 @@ export interface IPtyService {
 	// TODO: Make mandatory and remove impl from pty host service
 	refreshIgnoreProcessNames?(names: string[]): Promise<void>;
 }
+export const IPtyService = createDecorator<IPtyService>('ptyService');
 
 export interface IPtyHostController {
 	readonly onPtyHostExit: Event<number>;
@@ -357,7 +360,10 @@ export interface IPtyHostController {
 	getProfiles(workspaceId: string, profiles: unknown, defaultProfile: unknown, includeDetectedProfiles?: boolean): Promise<ITerminalProfile[]>;
 }
 
-export const IPtyHostService = createDecorator<IPtyHostService>('ptyHostService');
+/**
+ * A service that communicates with a pty host controller (eg. main or server
+ * process) and is able to launch and forward requests to the pty host.
+*/
 export interface IPtyHostService extends IPtyService, IPtyHostController {
 }
 

--- a/src/vs/platform/terminal/node/ptyHostService.ts
+++ b/src/vs/platform/terminal/node/ptyHostService.ts
@@ -13,7 +13,7 @@ import { RemoteLoggerChannelClient } from 'vs/platform/log/common/logIpc';
 import { getResolvedShellEnv } from 'vs/platform/shell/node/shellEnv';
 import { IPtyHostProcessReplayEvent } from 'vs/platform/terminal/common/capabilities/capabilities';
 import { RequestStore } from 'vs/platform/terminal/common/requestStore';
-import { HeartbeatConstants, IHeartbeatService, IProcessDataEvent, IProcessProperty, IProcessPropertyMap, IProcessReadyEvent, IPtyService, IRequestResolveVariablesEvent, ISerializedTerminalState, IShellLaunchConfig, ITerminalLaunchError, ITerminalProcessOptions, ITerminalProfile, ITerminalsLayoutInfo, ProcessPropertyType, TerminalIcon, TerminalIpcChannels, TerminalSettingId, TitleEventSource } from 'vs/platform/terminal/common/terminal';
+import { HeartbeatConstants, IHeartbeatService, IProcessDataEvent, IProcessProperty, IProcessPropertyMap, IProcessReadyEvent, IPtyHostService, IPtyService, IRequestResolveVariablesEvent, ISerializedTerminalState, IShellLaunchConfig, ITerminalLaunchError, ITerminalProcessOptions, ITerminalProfile, ITerminalsLayoutInfo, ProcessPropertyType, TerminalIcon, TerminalIpcChannels, TerminalSettingId, TitleEventSource } from 'vs/platform/terminal/common/terminal';
 import { registerTerminalPlatformConfiguration } from 'vs/platform/terminal/common/terminalPlatformConfiguration';
 import { IGetTerminalLayoutInfoArgs, IProcessDetails, ISetTerminalLayoutInfoArgs } from 'vs/platform/terminal/common/terminalProcess';
 import { IPtyHostConnection, IPtyHostStarter } from 'vs/platform/terminal/node/ptyHost';
@@ -29,7 +29,7 @@ enum Constants {
  * This service implements IPtyService by launching a pty host process, forwarding messages to and
  * from the pty host process and manages the connection.
  */
-export class PtyHostService extends Disposable implements IPtyService {
+export class PtyHostService extends Disposable implements IPtyHostService {
 	declare readonly _serviceBrand: undefined;
 
 	private __connection?: IPtyHostConnection;
@@ -230,6 +230,9 @@ export class PtyHostService extends Disposable implements IPtyService {
 	detachFromProcess(id: number, forcePersist?: boolean): Promise<void> {
 		return this._proxy.detachFromProcess(id, forcePersist);
 	}
+	shutdownAll(): Promise<void> {
+		return this._proxy.shutdownAll();
+	}
 	listProcesses(): Promise<IProcessDetails[]> {
 		return this._proxy.listProcesses();
 	}
@@ -354,7 +357,7 @@ export class PtyHostService extends Disposable implements IPtyService {
 	}
 
 	private _disposePtyHost(): void {
-		this._proxy.shutdownAll?.();
+		this._proxy.shutdownAll();
 		this._connection.store.dispose();
 	}
 

--- a/src/vs/platform/terminal/node/ptyService.ts
+++ b/src/vs/platform/terminal/node/ptyService.ts
@@ -12,7 +12,7 @@ import { URI } from 'vs/base/common/uri';
 import { getSystemShell } from 'vs/base/node/shell';
 import { ILogService, LogLevel } from 'vs/platform/log/common/log';
 import { RequestStore } from 'vs/platform/terminal/common/requestStore';
-import { IProcessDataEvent, IProcessReadyEvent, IPtyService, IRawTerminalInstanceLayoutInfo, IReconnectConstants, IRequestResolveVariablesEvent, IShellLaunchConfig, ITerminalInstanceLayoutInfoById, ITerminalLaunchError, ITerminalsLayoutInfo, ITerminalTabLayoutInfoById, TerminalIcon, IProcessProperty, TitleEventSource, ProcessPropertyType, IProcessPropertyMap, IFixedTerminalDimensions, IPersistentTerminalProcessLaunchConfig, ICrossVersionSerializedTerminalState, ISerializedTerminalState, ITerminalProcessOptions } from 'vs/platform/terminal/common/terminal';
+import { IProcessDataEvent, IProcessReadyEvent, IPtyService, IRawTerminalInstanceLayoutInfo, IReconnectConstants, IShellLaunchConfig, ITerminalInstanceLayoutInfoById, ITerminalLaunchError, ITerminalsLayoutInfo, ITerminalTabLayoutInfoById, TerminalIcon, IProcessProperty, TitleEventSource, ProcessPropertyType, IProcessPropertyMap, IFixedTerminalDimensions, IPersistentTerminalProcessLaunchConfig, ICrossVersionSerializedTerminalState, ISerializedTerminalState, ITerminalProcessOptions } from 'vs/platform/terminal/common/terminal';
 import { TerminalDataBufferer } from 'vs/platform/terminal/common/terminalDataBuffering';
 import { escapeNonWindowsPath } from 'vs/platform/terminal/common/terminalEnvironment';
 import { Terminal as XtermTerminal } from 'xterm-headless';
@@ -135,12 +135,6 @@ export class PtyService extends Disposable implements IPtyService {
 		ignoreProcessNames.length = 0;
 		ignoreProcessNames.push(...names);
 	}
-
-	onPtyHostExit?: Event<number> | undefined;
-	onPtyHostStart?: Event<void> | undefined;
-	onPtyHostUnresponsive?: Event<void> | undefined;
-	onPtyHostResponsive?: Event<void> | undefined;
-	onPtyHostRequestResolveVariables?: Event<IRequestResolveVariablesEvent> | undefined;
 
 	@traceRpc
 	async requestDetachInstance(workspaceId: string, instanceId: number): Promise<IProcessDetails | undefined> {

--- a/src/vs/server/node/remoteTerminalChannel.ts
+++ b/src/vs/server/node/remoteTerminalChannel.ts
@@ -14,7 +14,7 @@ import { IURITransformer } from 'vs/base/common/uriIpc';
 import { IServerChannel } from 'vs/base/parts/ipc/common/ipc';
 import { createRandomIPCHandle } from 'vs/base/parts/ipc/node/ipc.net';
 import { RemoteAgentConnectionContext } from 'vs/platform/remote/common/remoteAgentEnvironment';
-import { IPtyService, IShellLaunchConfig, ITerminalProfile } from 'vs/platform/terminal/common/terminal';
+import { IPtyHostService, IShellLaunchConfig, ITerminalProfile } from 'vs/platform/terminal/common/terminal';
 import { IGetTerminalLayoutInfoArgs, ISetTerminalLayoutInfoArgs } from 'vs/platform/terminal/common/terminalProcess';
 import { IWorkspaceFolder } from 'vs/platform/workspace/common/workspace';
 import { createURITransformer } from 'vs/workbench/api/node/uriTransformer';
@@ -97,7 +97,7 @@ export class RemoteTerminalChannel extends Disposable implements IServerChannel<
 	constructor(
 		private readonly _environmentService: IServerEnvironmentService,
 		private readonly _logService: ILogService,
-		private readonly _ptyService: IPtyService,
+		private readonly _ptyHostService: IPtyHostService,
 		private readonly _productService: IProductService,
 		private readonly _extensionManagementService: IExtensionManagementService,
 		private readonly _configurationService: IConfigurationService
@@ -107,52 +107,52 @@ export class RemoteTerminalChannel extends Disposable implements IServerChannel<
 
 	async call(ctx: RemoteAgentConnectionContext, command: string, args?: any): Promise<any> {
 		switch (command) {
-			case '$restartPtyHost': return this._ptyService.restartPtyHost?.apply(this._ptyService, args);
+			case '$restartPtyHost': return this._ptyHostService.restartPtyHost?.apply(this._ptyHostService, args);
 
 			case '$createProcess': {
 				const uriTransformer = createURITransformer(ctx.remoteAuthority);
 				return this._createProcess(uriTransformer, <ICreateTerminalProcessArguments>args);
 			}
-			case '$attachToProcess': return this._ptyService.attachToProcess.apply(this._ptyService, args);
-			case '$detachFromProcess': return this._ptyService.detachFromProcess.apply(this._ptyService, args);
+			case '$attachToProcess': return this._ptyHostService.attachToProcess.apply(this._ptyHostService, args);
+			case '$detachFromProcess': return this._ptyHostService.detachFromProcess.apply(this._ptyHostService, args);
 
-			case '$listProcesses': return this._ptyService.listProcesses.apply(this._ptyService, args);
-			case '$getPerformanceMarks': return this._ptyService.getPerformanceMarks.apply(this._ptyService, args);
-			case '$orphanQuestionReply': return this._ptyService.orphanQuestionReply.apply(this._ptyService, args);
-			case '$acceptPtyHostResolvedVariables': return this._ptyService.acceptPtyHostResolvedVariables?.apply(this._ptyService, args);
+			case '$listProcesses': return this._ptyHostService.listProcesses.apply(this._ptyHostService, args);
+			case '$getPerformanceMarks': return this._ptyHostService.getPerformanceMarks.apply(this._ptyHostService, args);
+			case '$orphanQuestionReply': return this._ptyHostService.orphanQuestionReply.apply(this._ptyHostService, args);
+			case '$acceptPtyHostResolvedVariables': return this._ptyHostService.acceptPtyHostResolvedVariables?.apply(this._ptyHostService, args);
 
-			case '$start': return this._ptyService.start.apply(this._ptyService, args);
-			case '$input': return this._ptyService.input.apply(this._ptyService, args);
-			case '$acknowledgeDataEvent': return this._ptyService.acknowledgeDataEvent.apply(this._ptyService, args);
-			case '$shutdown': return this._ptyService.shutdown.apply(this._ptyService, args);
-			case '$resize': return this._ptyService.resize.apply(this._ptyService, args);
-			case '$clearBuffer': return this._ptyService.clearBuffer.apply(this._ptyService, args);
-			case '$getInitialCwd': return this._ptyService.getInitialCwd.apply(this._ptyService, args);
-			case '$getCwd': return this._ptyService.getCwd.apply(this._ptyService, args);
+			case '$start': return this._ptyHostService.start.apply(this._ptyHostService, args);
+			case '$input': return this._ptyHostService.input.apply(this._ptyHostService, args);
+			case '$acknowledgeDataEvent': return this._ptyHostService.acknowledgeDataEvent.apply(this._ptyHostService, args);
+			case '$shutdown': return this._ptyHostService.shutdown.apply(this._ptyHostService, args);
+			case '$resize': return this._ptyHostService.resize.apply(this._ptyHostService, args);
+			case '$clearBuffer': return this._ptyHostService.clearBuffer.apply(this._ptyHostService, args);
+			case '$getInitialCwd': return this._ptyHostService.getInitialCwd.apply(this._ptyHostService, args);
+			case '$getCwd': return this._ptyHostService.getCwd.apply(this._ptyHostService, args);
 
-			case '$processBinary': return this._ptyService.processBinary.apply(this._ptyService, args);
+			case '$processBinary': return this._ptyHostService.processBinary.apply(this._ptyHostService, args);
 
 			case '$sendCommandResult': return this._sendCommandResult(args[0], args[1], args[2]);
-			case '$installAutoReply': return this._ptyService.installAutoReply.apply(this._ptyService, args);
-			case '$uninstallAllAutoReplies': return this._ptyService.uninstallAllAutoReplies.apply(this._ptyService, args);
+			case '$installAutoReply': return this._ptyHostService.installAutoReply.apply(this._ptyHostService, args);
+			case '$uninstallAllAutoReplies': return this._ptyHostService.uninstallAllAutoReplies.apply(this._ptyHostService, args);
 			case '$getDefaultSystemShell': return this._getDefaultSystemShell.apply(this, args);
 			case '$getProfiles': return this._getProfiles.apply(this, args);
 			case '$getEnvironment': return this._getEnvironment();
 			case '$getWslPath': return this._getWslPath(args[0], args[1]);
-			case '$getTerminalLayoutInfo': return this._ptyService.getTerminalLayoutInfo(<IGetTerminalLayoutInfoArgs>args);
-			case '$setTerminalLayoutInfo': return this._ptyService.setTerminalLayoutInfo(<ISetTerminalLayoutInfoArgs>args);
-			case '$serializeTerminalState': return this._ptyService.serializeTerminalState.apply(this._ptyService, args);
-			case '$reviveTerminalProcesses': return this._ptyService.reviveTerminalProcesses.apply(this._ptyService, args);
-			case '$getRevivedPtyNewId': return this._ptyService.getRevivedPtyNewId.apply(this._ptyService, args);
-			case '$setUnicodeVersion': return this._ptyService.setUnicodeVersion.apply(this._ptyService, args);
+			case '$getTerminalLayoutInfo': return this._ptyHostService.getTerminalLayoutInfo(<IGetTerminalLayoutInfoArgs>args);
+			case '$setTerminalLayoutInfo': return this._ptyHostService.setTerminalLayoutInfo(<ISetTerminalLayoutInfoArgs>args);
+			case '$serializeTerminalState': return this._ptyHostService.serializeTerminalState.apply(this._ptyHostService, args);
+			case '$reviveTerminalProcesses': return this._ptyHostService.reviveTerminalProcesses.apply(this._ptyHostService, args);
+			case '$getRevivedPtyNewId': return this._ptyHostService.getRevivedPtyNewId.apply(this._ptyHostService, args);
+			case '$setUnicodeVersion': return this._ptyHostService.setUnicodeVersion.apply(this._ptyHostService, args);
 			case '$reduceConnectionGraceTime': return this._reduceConnectionGraceTime();
-			case '$updateIcon': return this._ptyService.updateIcon.apply(this._ptyService, args);
-			case '$updateTitle': return this._ptyService.updateTitle.apply(this._ptyService, args);
-			case '$updateProperty': return this._ptyService.updateProperty.apply(this._ptyService, args);
-			case '$refreshProperty': return this._ptyService.refreshProperty.apply(this._ptyService, args);
-			case '$requestDetachInstance': return this._ptyService.requestDetachInstance(args[0], args[1]);
-			case '$acceptDetachedInstance': return this._ptyService.acceptDetachInstanceReply(args[0], args[1]);
-			case '$freePortKillProcess': return this._ptyService.freePortKillProcess?.apply(this._ptyService, args);
+			case '$updateIcon': return this._ptyHostService.updateIcon.apply(this._ptyHostService, args);
+			case '$updateTitle': return this._ptyHostService.updateTitle.apply(this._ptyHostService, args);
+			case '$updateProperty': return this._ptyHostService.updateProperty.apply(this._ptyHostService, args);
+			case '$refreshProperty': return this._ptyHostService.refreshProperty.apply(this._ptyHostService, args);
+			case '$requestDetachInstance': return this._ptyHostService.requestDetachInstance(args[0], args[1]);
+			case '$acceptDetachedInstance': return this._ptyHostService.acceptDetachInstanceReply(args[0], args[1]);
+			case '$freePortKillProcess': return this._ptyHostService.freePortKillProcess?.apply(this._ptyHostService, args);
 		}
 
 		throw new Error(`IPC Command ${command} not found`);
@@ -160,19 +160,19 @@ export class RemoteTerminalChannel extends Disposable implements IServerChannel<
 
 	listen(_: any, event: string, arg: any): Event<any> {
 		switch (event) {
-			case '$onPtyHostExitEvent': return this._ptyService.onPtyHostExit || Event.None;
-			case '$onPtyHostStartEvent': return this._ptyService.onPtyHostStart || Event.None;
-			case '$onPtyHostUnresponsiveEvent': return this._ptyService.onPtyHostUnresponsive || Event.None;
-			case '$onPtyHostResponsiveEvent': return this._ptyService.onPtyHostResponsive || Event.None;
-			case '$onPtyHostRequestResolveVariablesEvent': return this._ptyService.onPtyHostRequestResolveVariables || Event.None;
-			case '$onProcessDataEvent': return this._ptyService.onProcessData;
-			case '$onProcessReadyEvent': return this._ptyService.onProcessReady;
-			case '$onProcessExitEvent': return this._ptyService.onProcessExit;
-			case '$onProcessReplayEvent': return this._ptyService.onProcessReplay;
-			case '$onProcessOrphanQuestion': return this._ptyService.onProcessOrphanQuestion;
+			case '$onPtyHostExitEvent': return this._ptyHostService.onPtyHostExit || Event.None;
+			case '$onPtyHostStartEvent': return this._ptyHostService.onPtyHostStart || Event.None;
+			case '$onPtyHostUnresponsiveEvent': return this._ptyHostService.onPtyHostUnresponsive || Event.None;
+			case '$onPtyHostResponsiveEvent': return this._ptyHostService.onPtyHostResponsive || Event.None;
+			case '$onPtyHostRequestResolveVariablesEvent': return this._ptyHostService.onPtyHostRequestResolveVariables || Event.None;
+			case '$onProcessDataEvent': return this._ptyHostService.onProcessData;
+			case '$onProcessReadyEvent': return this._ptyHostService.onProcessReady;
+			case '$onProcessExitEvent': return this._ptyHostService.onProcessExit;
+			case '$onProcessReplayEvent': return this._ptyHostService.onProcessReplay;
+			case '$onProcessOrphanQuestion': return this._ptyHostService.onProcessOrphanQuestion;
 			case '$onExecuteCommand': return this.onExecuteCommand;
-			case '$onDidRequestDetach': return this._ptyService.onDidRequestDetach || Event.None;
-			case '$onDidChangeProperty': return this._ptyService.onDidChangeProperty;
+			case '$onDidRequestDetach': return this._ptyHostService.onDidRequestDetach || Event.None;
+			case '$onDidChangeProperty': return this._ptyHostService.onDidChangeProperty;
 			default:
 				break;
 		}
@@ -251,12 +251,12 @@ export class RemoteTerminalChannel extends Disposable implements IServerChannel<
 		const ipcHandlePath = createRandomIPCHandle();
 		env.VSCODE_IPC_HOOK_CLI = ipcHandlePath;
 
-		const persistentProcessId = await this._ptyService.createProcess(shellLaunchConfig, initialCwd, args.cols, args.rows, args.unicodeVersion, env, baseEnv, args.options, args.shouldPersistTerminal, args.workspaceId, args.workspaceName);
+		const persistentProcessId = await this._ptyHostService.createProcess(shellLaunchConfig, initialCwd, args.cols, args.rows, args.unicodeVersion, env, baseEnv, args.options, args.shouldPersistTerminal, args.workspaceId, args.workspaceName);
 		const commandsExecuter: ICommandsExecuter = {
 			executeCommand: <T>(id: string, ...args: any[]): Promise<T> => this._executeCommand(persistentProcessId, id, args, uriTransformer)
 		};
 		const cliServer = new CLIServerBase(commandsExecuter, this._logService, ipcHandlePath);
-		this._ptyService.onProcessExit(e => e.id === persistentProcessId && cliServer.dispose());
+		this._ptyHostService.onProcessExit(e => e.id === persistentProcessId && cliServer.dispose());
 
 		return {
 			persistentTerminalId: persistentProcessId,
@@ -316,11 +316,11 @@ export class RemoteTerminalChannel extends Disposable implements IServerChannel<
 	}
 
 	private _getDefaultSystemShell(osOverride?: platform.OperatingSystem): Promise<string> {
-		return this._ptyService.getDefaultSystemShell(osOverride);
+		return this._ptyHostService.getDefaultSystemShell(osOverride);
 	}
 
 	private async _getProfiles(workspaceId: string, profiles: unknown, defaultProfile: unknown, includeDetectedProfiles?: boolean): Promise<ITerminalProfile[]> {
-		return this._ptyService.getProfiles?.(workspaceId, profiles, defaultProfile, includeDetectedProfiles) || [];
+		return this._ptyHostService.getProfiles?.(workspaceId, profiles, defaultProfile, includeDetectedProfiles) || [];
 	}
 
 	private _getEnvironment(): platform.IProcessEnvironment {
@@ -328,11 +328,11 @@ export class RemoteTerminalChannel extends Disposable implements IServerChannel<
 	}
 
 	private _getWslPath(original: string, direction: 'unix-to-win' | 'win-to-unix'): Promise<string> {
-		return this._ptyService.getWslPath(original, direction);
+		return this._ptyHostService.getWslPath(original, direction);
 	}
 
 
 	private _reduceConnectionGraceTime(): Promise<void> {
-		return this._ptyService.reduceConnectionGraceTime();
+		return this._ptyHostService.reduceConnectionGraceTime();
 	}
 }

--- a/src/vs/server/node/remoteTerminalChannel.ts
+++ b/src/vs/server/node/remoteTerminalChannel.ts
@@ -107,7 +107,7 @@ export class RemoteTerminalChannel extends Disposable implements IServerChannel<
 
 	async call(ctx: RemoteAgentConnectionContext, command: string, args?: any): Promise<any> {
 		switch (command) {
-			case '$restartPtyHost': return this._ptyHostService.restartPtyHost?.apply(this._ptyHostService, args);
+			case '$restartPtyHost': return this._ptyHostService.restartPtyHost.apply(this._ptyHostService, args);
 
 			case '$createProcess': {
 				const uriTransformer = createURITransformer(ctx.remoteAuthority);
@@ -119,7 +119,7 @@ export class RemoteTerminalChannel extends Disposable implements IServerChannel<
 			case '$listProcesses': return this._ptyHostService.listProcesses.apply(this._ptyHostService, args);
 			case '$getPerformanceMarks': return this._ptyHostService.getPerformanceMarks.apply(this._ptyHostService, args);
 			case '$orphanQuestionReply': return this._ptyHostService.orphanQuestionReply.apply(this._ptyHostService, args);
-			case '$acceptPtyHostResolvedVariables': return this._ptyHostService.acceptPtyHostResolvedVariables?.apply(this._ptyHostService, args);
+			case '$acceptPtyHostResolvedVariables': return this._ptyHostService.acceptPtyHostResolvedVariables.apply(this._ptyHostService, args);
 
 			case '$start': return this._ptyHostService.start.apply(this._ptyHostService, args);
 			case '$input': return this._ptyHostService.input.apply(this._ptyHostService, args);
@@ -152,7 +152,7 @@ export class RemoteTerminalChannel extends Disposable implements IServerChannel<
 			case '$refreshProperty': return this._ptyHostService.refreshProperty.apply(this._ptyHostService, args);
 			case '$requestDetachInstance': return this._ptyHostService.requestDetachInstance(args[0], args[1]);
 			case '$acceptDetachedInstance': return this._ptyHostService.acceptDetachInstanceReply(args[0], args[1]);
-			case '$freePortKillProcess': return this._ptyHostService.freePortKillProcess?.apply(this._ptyHostService, args);
+			case '$freePortKillProcess': return this._ptyHostService.freePortKillProcess.apply(this._ptyHostService, args);
 		}
 
 		throw new Error(`IPC Command ${command} not found`);
@@ -320,7 +320,7 @@ export class RemoteTerminalChannel extends Disposable implements IServerChannel<
 	}
 
 	private async _getProfiles(workspaceId: string, profiles: unknown, defaultProfile: unknown, includeDetectedProfiles?: boolean): Promise<ITerminalProfile[]> {
-		return this._ptyHostService.getProfiles?.(workspaceId, profiles, defaultProfile, includeDetectedProfiles) || [];
+		return this._ptyHostService.getProfiles(workspaceId, profiles, defaultProfile, includeDetectedProfiles) || [];
 	}
 
 	private _getEnvironment(): platform.IProcessEnvironment {

--- a/src/vs/server/node/serverServices.ts
+++ b/src/vs/server/node/serverServices.ts
@@ -48,7 +48,7 @@ import { ITelemetryService, TelemetryLevel } from 'vs/platform/telemetry/common/
 import { ITelemetryServiceConfig } from 'vs/platform/telemetry/common/telemetryService';
 import { getPiiPathsFromEnvironment, isInternalTelemetry, ITelemetryAppender, NullAppender, supportsTelemetry } from 'vs/platform/telemetry/common/telemetryUtils';
 import ErrorTelemetry from 'vs/platform/telemetry/node/errorTelemetry';
-import { IPtyService, IPtyHostService, TerminalSettingId } from 'vs/platform/terminal/common/terminal';
+import { IPtyService, TerminalSettingId } from 'vs/platform/terminal/common/terminal';
 import { PtyHostService } from 'vs/platform/terminal/node/ptyHostService';
 import { IUriIdentityService } from 'vs/platform/uriIdentity/common/uriIdentity';
 import { UriIdentityService } from 'vs/platform/uriIdentity/common/uriIdentityService';
@@ -199,7 +199,6 @@ export async function setupServerServices(connectionToken: ServerConnectionToken
 	);
 	const ptyHostService = instantiationService.createInstance(PtyHostService, ptyHostStarter);
 	services.set(IPtyService, ptyHostService);
-	services.set(IPtyHostService, ptyHostService);
 
 	services.set(ICredentialsMainService, new SyncDescriptor(CredentialsWebMainService));
 

--- a/src/vs/server/node/serverServices.ts
+++ b/src/vs/server/node/serverServices.ts
@@ -48,7 +48,7 @@ import { ITelemetryService, TelemetryLevel } from 'vs/platform/telemetry/common/
 import { ITelemetryServiceConfig } from 'vs/platform/telemetry/common/telemetryService';
 import { getPiiPathsFromEnvironment, isInternalTelemetry, ITelemetryAppender, NullAppender, supportsTelemetry } from 'vs/platform/telemetry/common/telemetryUtils';
 import ErrorTelemetry from 'vs/platform/telemetry/node/errorTelemetry';
-import { IPtyService, TerminalSettingId } from 'vs/platform/terminal/common/terminal';
+import { IPtyService, IPtyHostService, TerminalSettingId } from 'vs/platform/terminal/common/terminal';
 import { PtyHostService } from 'vs/platform/terminal/node/ptyHostService';
 import { IUriIdentityService } from 'vs/platform/uriIdentity/common/uriIdentity';
 import { UriIdentityService } from 'vs/platform/uriIdentity/common/uriIdentityService';
@@ -197,8 +197,9 @@ export async function setupServerServices(connectionToken: ServerConnectionToken
 			scrollback: configurationService.getValue<number>(TerminalSettingId.PersistentSessionScrollback) ?? 100
 		}
 	);
-	const ptyService = instantiationService.createInstance(PtyHostService, ptyHostStarter);
-	services.set(IPtyService, ptyService);
+	const ptyHostService = instantiationService.createInstance(PtyHostService, ptyHostStarter);
+	services.set(IPtyService, ptyHostService);
+	services.set(IPtyHostService, ptyHostService);
 
 	services.set(ICredentialsMainService, new SyncDescriptor(CredentialsWebMainService));
 
@@ -213,7 +214,7 @@ export async function setupServerServices(connectionToken: ServerConnectionToken
 		const telemetryChannel = new ServerTelemetryChannel(accessor.get(IServerTelemetryService), oneDsAppender);
 		socketServer.registerChannel('telemetry', telemetryChannel);
 
-		socketServer.registerChannel(REMOTE_TERMINAL_CHANNEL_NAME, new RemoteTerminalChannel(environmentService, logService, ptyService, productService, extensionManagementService, configurationService));
+		socketServer.registerChannel(REMOTE_TERMINAL_CHANNEL_NAME, new RemoteTerminalChannel(environmentService, logService, ptyHostService, productService, extensionManagementService, configurationService));
 
 		const remoteExtensionsScanner = new RemoteExtensionsScannerService(instantiationService.createInstance(ExtensionManagementCLI, logService), environmentService, userDataProfilesService, extensionsScannerService, logService, extensionGalleryService, languagePackService);
 		socketServer.registerChannel(RemoteExtensionsScannerChannelName, new RemoteExtensionsScannerChannel(remoteExtensionsScanner, (ctx: RemoteAgentConnectionContext) => getUriTransformer(ctx.remoteAuthority)));

--- a/src/vs/workbench/contrib/terminal/electron-sandbox/localTerminalBackend.ts
+++ b/src/vs/workbench/contrib/terminal/electron-sandbox/localTerminalBackend.ts
@@ -258,8 +258,7 @@ class LocalTerminalBackend extends BaseTerminalBackend implements ITerminalBacke
 	}
 
 	async getProfiles(profiles: unknown, defaultProfile: unknown, includeDetectedProfiles?: boolean) {
-		// TODO: Differentiate interfaces of direct to pty host and pty host service (or just move them all to pty host)
-		return this._proxy.getProfiles?.(this._workspaceContextService.getWorkspace().id, profiles, defaultProfile, includeDetectedProfiles) || [];
+		return this._localPtyService.getProfiles(this._workspaceContextService.getWorkspace().id, profiles, defaultProfile, includeDetectedProfiles) || [];
 	}
 
 	@memoize


### PR DESCRIPTION
This is a new service which extends IPtyService and provides additional methods on the process that manages the connection to the pty host:

- IPtyService: Talk to the pty host, this may be direct via a message port of via the main/server procs.
- IPtyHostService: Talk to the pty host management interfaces on the main/server procs. These are no longer available as optional methods on IPtyService to be clear about where they happen (eg. getProfiles).

Fixes #186935

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
