### PR TITLE
fix: stall on "starting new singleton" on linux if keychain blocks

### DIFF
--- a/cli/src/util/errors.rs
+++ b/cli/src/util/errors.rs
@@ -2,7 +2,7 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-use crate::{
+ use crate::{
 	constants::{APPLICATION_NAME, CONTROL_PORT, DOCUMENTATION_URL, QUALITYLESS_PRODUCT_NAME},
 	rpc::ResponseError,
 };
@@ -511,6 +511,8 @@ pub enum CodeError {
 	AuthChallengeNotIssued,
 	#[error("unauthorized client refused")]
 	AuthMismatch,
+	#[error("keyring communication timed out after 5s")]
+	KeyringTimeout,
 }
 
 makeAnyError!(


### PR DESCRIPTION
Adds a 5s timeout to keychain access on Linux. We had an issue about this a long time ago, but I never repro'd it until today and can't find the original...

If this timeout is hit, it'll fall back to the file-based keychain.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
