### PR TITLE
Repopulate slash command in chat input editor

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/contrib/chatInputEditorContrib.ts
+++ b/src/vs/workbench/contrib/chat/browser/contrib/chatInputEditorContrib.ts
@@ -148,7 +148,7 @@ class InputEditorSlashCommandFollowups extends Disposable {
 
 		const slashCommands = await this.widget.getSlashCommands();
 
-		if (this.widget.inputEditor.getValue().trim().length === 0) {
+		if (this.widget.inputEditor.getValue().trim().length !== 0) {
 			return;
 		}
 

--- a/src/vs/workbench/contrib/chat/browser/contrib/chatInputEditorContrib.ts
+++ b/src/vs/workbench/contrib/chat/browser/contrib/chatInputEditorContrib.ts
@@ -137,13 +137,18 @@ class InputEditorSlashCommandFollowups extends Disposable {
 
 	constructor(
 		private readonly widget: IChatWidget,
-		private readonly chatService: IChatService
+		@IChatService private readonly chatService: IChatService
 	) {
 		super();
-		if (this.widget.viewModel?.sessionId) {
+		this._register(this.chatService.onDidCompleteSlashCommand(({ slashCommand, sessionId }) => this.repopulateSlashCommand(slashCommand, sessionId)));
+	}
+
+	private getSlashCommands() {
+		if (!this.slashCommands && this.widget.viewModel?.sessionId) {
 			this.slashCommands = this.chatService.getSlashCommands(this.widget.viewModel?.sessionId, new CancellationTokenSource().token);
 		}
-		this._register(this.chatService.onDidCompleteSlashCommand(({ slashCommand, sessionId }) => this.repopulateSlashCommand(slashCommand, sessionId)));
+
+		return this.slashCommands;
 	}
 
 	private async repopulateSlashCommand(slashCommand: string, sessionId: string) {
@@ -151,7 +156,7 @@ class InputEditorSlashCommandFollowups extends Disposable {
 			return;
 		}
 
-		const slashCommands = await this.slashCommands;
+		const slashCommands = await this.getSlashCommands();
 
 		if (this.widget.inputEditor.getValue().trim().length === 0) {
 			return;

--- a/src/vs/workbench/contrib/chat/browser/contrib/chatInputEditorContrib.ts
+++ b/src/vs/workbench/contrib/chat/browser/contrib/chatInputEditorContrib.ts
@@ -153,7 +153,7 @@ class InputEditorSlashCommandFollowups extends Disposable {
 		}
 
 		if (slashCommands?.find(c => c.command === slashCommand)?.shouldRepopulate) {
-			this.widget.inputEditor.setValue(`/${slashCommand}`);
+			this.widget.inputEditor.setValue(`/${slashCommand} `);
 		}
 	}
 }

--- a/src/vs/workbench/contrib/chat/browser/contrib/chatInputEditorContrib.ts
+++ b/src/vs/workbench/contrib/chat/browser/contrib/chatInputEditorContrib.ts
@@ -153,7 +153,10 @@ class InputEditorSlashCommandFollowups extends Disposable {
 		}
 
 		if (slashCommands?.find(c => c.command === slashCommand)?.shouldRepopulate) {
-			this.widget.inputEditor.setValue(`/${slashCommand} `);
+			const value = `/${slashCommand} `;
+			this.widget.inputEditor.setValue(value);
+			this.widget.inputEditor.setPosition({ lineNumber: 1, column: value.length + 1 });
+
 		}
 	}
 }

--- a/src/vs/workbench/contrib/chat/browser/contrib/chatInputEditorContrib.ts
+++ b/src/vs/workbench/contrib/chat/browser/contrib/chatInputEditorContrib.ts
@@ -21,6 +21,7 @@ import { IChatWidget, IChatWidgetService } from 'vs/workbench/contrib/chat/brows
 import { ChatWidget } from 'vs/workbench/contrib/chat/browser/chatWidget';
 import { LifecyclePhase } from 'vs/workbench/services/lifecycle/common/lifecycle';
 import { ChatInputPart } from 'vs/workbench/contrib/chat/browser/chatInputPart';
+import { IChatService } from 'vs/workbench/contrib/chat/common/chatService';
 
 const decorationDescription = 'chat';
 const slashCommandPlaceholderDecorationType = 'chat-session-detail';
@@ -131,7 +132,23 @@ class InputEditorDecorations extends Disposable {
 	}
 }
 
-ChatWidget.CONTRIBS.push(InputEditorDecorations);
+class InputEditorSlashCommandFollowups extends Disposable {
+	constructor(
+		private readonly widget: IChatWidget,
+		private readonly chatService: IChatService
+	) {
+		super();
+		this._register(this.chatService.onDidCompleteSlashCommand((command) => this.prependSlashCommand(command)));
+	}
+
+	private prependSlashCommand(command: string) {
+		if (this.widget.inputEditor.getValue().trim().length === 0) {
+			this.widget.inputEditor.setValue(`/${command}`);
+		}
+	}
+}
+
+ChatWidget.CONTRIBS.push(InputEditorDecorations, InputEditorSlashCommandFollowups);
 
 class SlashCommandCompletions extends Disposable {
 	constructor(

--- a/src/vs/workbench/contrib/chat/browser/contrib/chatInputEditorContrib.ts
+++ b/src/vs/workbench/contrib/chat/browser/contrib/chatInputEditorContrib.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Extensions as WorkbenchExtensions, IWorkbenchContributionsRegistry } from 'vs/workbench/common/contributions';
-import { CancellationToken, CancellationTokenSource } from 'vs/base/common/cancellation';
+import { CancellationToken } from 'vs/base/common/cancellation';
 import { Disposable } from 'vs/base/common/lifecycle';
 import { ICodeEditorService } from 'vs/editor/browser/services/codeEditorService';
 import { Position } from 'vs/editor/common/core/position';
@@ -21,7 +21,7 @@ import { IChatWidget, IChatWidgetService } from 'vs/workbench/contrib/chat/brows
 import { ChatWidget } from 'vs/workbench/contrib/chat/browser/chatWidget';
 import { LifecyclePhase } from 'vs/workbench/services/lifecycle/common/lifecycle';
 import { ChatInputPart } from 'vs/workbench/contrib/chat/browser/chatInputPart';
-import { IChatService, ISlashCommand } from 'vs/workbench/contrib/chat/common/chatService';
+import { IChatService } from 'vs/workbench/contrib/chat/common/chatService';
 
 const decorationDescription = 'chat';
 const slashCommandPlaceholderDecorationType = 'chat-session-detail';
@@ -133,8 +133,6 @@ class InputEditorDecorations extends Disposable {
 }
 
 class InputEditorSlashCommandFollowups extends Disposable {
-	private slashCommands: Promise<ISlashCommand[] | undefined> | undefined;
-
 	constructor(
 		private readonly widget: IChatWidget,
 		@IChatService private readonly chatService: IChatService
@@ -143,20 +141,12 @@ class InputEditorSlashCommandFollowups extends Disposable {
 		this._register(this.chatService.onDidCompleteSlashCommand(({ slashCommand, sessionId }) => this.repopulateSlashCommand(slashCommand, sessionId)));
 	}
 
-	private getSlashCommands() {
-		if (!this.slashCommands && this.widget.viewModel?.sessionId) {
-			this.slashCommands = this.chatService.getSlashCommands(this.widget.viewModel?.sessionId, new CancellationTokenSource().token);
-		}
-
-		return this.slashCommands;
-	}
-
 	private async repopulateSlashCommand(slashCommand: string, sessionId: string) {
 		if (this.widget.viewModel?.sessionId !== sessionId) {
 			return;
 		}
 
-		const slashCommands = await this.getSlashCommands();
+		const slashCommands = await this.widget.getSlashCommands();
 
 		if (this.widget.inputEditor.getValue().trim().length === 0) {
 			return;

--- a/src/vs/workbench/contrib/chat/common/chatService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService.ts
@@ -67,6 +67,7 @@ export interface ISlashCommandProvider {
 
 export interface ISlashCommand {
 	command: string;
+	shouldRepopulate?: boolean;
 	provider?: ISlashCommandProvider;
 	sortText?: string;
 	detail?: string;

--- a/src/vs/workbench/contrib/chat/common/chatService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService.ts
@@ -177,7 +177,7 @@ export interface IChatService {
 	_serviceBrand: undefined;
 	transferredSessionId: string | undefined;
 
-	onDidCompleteSlashCommand: Event<string>;
+	onDidCompleteSlashCommand: Event<{ slashCommand: string; sessionId: string }>;
 	registerProvider(provider: IChatProvider): IDisposable;
 	registerSlashCommandProvider(provider: ISlashCommandProvider): IDisposable;
 	getProviderInfos(): IChatProviderInfo[];

--- a/src/vs/workbench/contrib/chat/common/chatService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService.ts
@@ -176,6 +176,8 @@ export const IChatService = createDecorator<IChatService>('IChatService');
 export interface IChatService {
 	_serviceBrand: undefined;
 	transferredSessionId: string | undefined;
+
+	onDidCompleteSlashCommand: Event<string>;
 	registerProvider(provider: IChatProvider): IDisposable;
 	registerSlashCommandProvider(provider: ISlashCommandProvider): IDisposable;
 	getProviderInfos(): IChatProviderInfo[];

--- a/src/vs/workbench/contrib/chat/common/chatServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/chatServiceImpl.ts
@@ -135,6 +135,9 @@ export class ChatService extends Disposable implements IChatService {
 	private readonly _onDidPerformUserAction = this._register(new Emitter<IChatUserActionEvent>());
 	public readonly onDidPerformUserAction: Event<IChatUserActionEvent> = this._onDidPerformUserAction.event;
 
+	private readonly _onDidCompleteSlashCommand = this._register(new Emitter<string>());
+	public readonly onDidCompleteSlashCommand = this._onDidCompleteSlashCommand.event;
+
 	constructor(
 		@IStorageService private readonly storageService: IStorageService,
 		@ILogService private readonly logService: ILogService,
@@ -465,9 +468,15 @@ export class ChatService extends Disposable implements IChatService {
 					Promise.resolve(provider.provideFollowups(model.session!, CancellationToken.None)).then(followups => {
 						model.setFollowups(request, withNullAsUndefined(followups));
 						model.completeResponse(request);
+						if (usedSlashCommand?.command) {
+							this._onDidCompleteSlashCommand.fire(usedSlashCommand.command);
+						}
 					});
 				} else {
 					model.completeResponse(request);
+					if (usedSlashCommand?.command) {
+						this._onDidCompleteSlashCommand.fire(usedSlashCommand.command);
+					}
 				}
 			}
 		});

--- a/src/vs/workbench/contrib/chat/common/chatServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/chatServiceImpl.ts
@@ -135,7 +135,7 @@ export class ChatService extends Disposable implements IChatService {
 	private readonly _onDidPerformUserAction = this._register(new Emitter<IChatUserActionEvent>());
 	public readonly onDidPerformUserAction: Event<IChatUserActionEvent> = this._onDidPerformUserAction.event;
 
-	private readonly _onDidCompleteSlashCommand = this._register(new Emitter<string>());
+	private readonly _onDidCompleteSlashCommand = this._register(new Emitter<{ slashCommand: string; sessionId: string }>());
 	public readonly onDidCompleteSlashCommand = this._onDidCompleteSlashCommand.event;
 
 	constructor(
@@ -469,13 +469,13 @@ export class ChatService extends Disposable implements IChatService {
 						model.setFollowups(request, withNullAsUndefined(followups));
 						model.completeResponse(request);
 						if (usedSlashCommand?.command) {
-							this._onDidCompleteSlashCommand.fire(usedSlashCommand.command);
+							this._onDidCompleteSlashCommand.fire({ slashCommand: usedSlashCommand.command, sessionId: model.sessionId });
 						}
 					});
 				} else {
 					model.completeResponse(request);
 					if (usedSlashCommand?.command) {
-						this._onDidCompleteSlashCommand.fire(usedSlashCommand.command);
+						this._onDidCompleteSlashCommand.fire({ slashCommand: usedSlashCommand.command, sessionId: model.sessionId });
 					}
 				}
 			}

--- a/src/vscode-dts/vscode.proposed.interactive.d.ts
+++ b/src/vscode-dts/vscode.proposed.interactive.d.ts
@@ -128,6 +128,7 @@ declare module 'vscode' {
 
 	export interface InteractiveSessionSlashCommand {
 		command: string;
+		shouldRepopulate?: boolean;
 		kind: CompletionItemKind;
 		detail?: string;
 	}


### PR DESCRIPTION
This allows us to clearly indicate that you can ask a followup question about a slash command (and get good results that are on-topic).

I will send another PR to allow more easily deleting this prepopulated slash command (ideally the user can just hit backspace once to clear it).