### PR TITLE
Don't call fireSimulatedContinuedEvent if the debug adapter sent a Stopped event before the response of the next/stepIn/etc request

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/rawDebugSession.ts
+++ b/src/vs/workbench/contrib/debug/browser/rawDebugSession.ts
@@ -76,6 +76,7 @@ export class RawDebugSession implements IDisposable {
 	// DA events
 	private readonly _onDidExitAdapter = new Emitter<AdapterEndEvent>();
 	private debugAdapter: IDebugAdapter | null;
+	private stoppedSinceLastStep = false;
 
 	private toDispose: IDisposable[] = [];
 
@@ -122,6 +123,7 @@ export class RawDebugSession implements IDisposable {
 					break;
 				case 'stopped':
 					this.didReceiveStoppedEvent = true;		// telemetry: remember that debugger stopped successfully
+					this.stoppedSinceLastStep = true;
 					this._onDidStop.fire(<DebugProtocol.StoppedEvent>event);
 					break;
 				case 'continued':
@@ -326,29 +328,43 @@ export class RawDebugSession implements IDisposable {
 	}
 
 	async next(args: DebugProtocol.NextArguments): Promise<DebugProtocol.NextResponse | undefined> {
+		this.stoppedSinceLastStep = false;
 		const response = await this.send('next', args);
-		this.fireSimulatedContinuedEvent(args.threadId);
+		if (!this.stoppedSinceLastStep) {
+			if (!this.stoppedSinceLastStep) {
+				this.fireSimulatedContinuedEvent(args.threadId);
+			}
+		}
 		return response;
 	}
 
 	async stepIn(args: DebugProtocol.StepInArguments): Promise<DebugProtocol.StepInResponse | undefined> {
+		this.stoppedSinceLastStep = false;
 		const response = await this.send('stepIn', args);
-		this.fireSimulatedContinuedEvent(args.threadId);
+		if (!this.stoppedSinceLastStep) {
+			this.fireSimulatedContinuedEvent(args.threadId);
+		}
 		return response;
 	}
 
 	async stepOut(args: DebugProtocol.StepOutArguments): Promise<DebugProtocol.StepOutResponse | undefined> {
+		this.stoppedSinceLastStep = false;
 		const response = await this.send('stepOut', args);
-		this.fireSimulatedContinuedEvent(args.threadId);
+		if (!this.stoppedSinceLastStep) {
+			this.fireSimulatedContinuedEvent(args.threadId);
+		}
 		return response;
 	}
 
 	async continue(args: DebugProtocol.ContinueArguments): Promise<DebugProtocol.ContinueResponse | undefined> {
+		this.stoppedSinceLastStep = false;
 		const response = await this.send<DebugProtocol.ContinueResponse>('continue', args);
 		if (response && response.body && response.body.allThreadsContinued !== undefined) {
 			this.allThreadsContinued = response.body.allThreadsContinued;
 		}
-		this.fireSimulatedContinuedEvent(args.threadId, this.allThreadsContinued);
+		if (!this.stoppedSinceLastStep) {
+			this.fireSimulatedContinuedEvent(args.threadId, this.allThreadsContinued);
+		}
 
 		return response;
 	}
@@ -380,8 +396,11 @@ export class RawDebugSession implements IDisposable {
 
 	async restartFrame(args: DebugProtocol.RestartFrameArguments, threadId: number): Promise<DebugProtocol.RestartFrameResponse | undefined> {
 		if (this.capabilities.supportsRestartFrame) {
+			this.stoppedSinceLastStep = false;
 			const response = await this.send('restartFrame', args);
-			this.fireSimulatedContinuedEvent(threadId);
+			if (!this.stoppedSinceLastStep) {
+				this.fireSimulatedContinuedEvent(threadId);
+			}
 			return response;
 		}
 		return Promise.reject(new Error('restartFrame not supported'));
@@ -484,8 +503,11 @@ export class RawDebugSession implements IDisposable {
 
 	async stepBack(args: DebugProtocol.StepBackArguments): Promise<DebugProtocol.StepBackResponse | undefined> {
 		if (this.capabilities.supportsStepBack) {
+			this.stoppedSinceLastStep = false;
 			const response = await this.send('stepBack', args);
-			this.fireSimulatedContinuedEvent(args.threadId);
+			if (!this.stoppedSinceLastStep) {
+				this.fireSimulatedContinuedEvent(args.threadId);
+			}
 			return response;
 		}
 		return Promise.reject(new Error('stepBack not supported'));
@@ -493,8 +515,11 @@ export class RawDebugSession implements IDisposable {
 
 	async reverseContinue(args: DebugProtocol.ReverseContinueArguments): Promise<DebugProtocol.ReverseContinueResponse | undefined> {
 		if (this.capabilities.supportsStepBack) {
+			this.stoppedSinceLastStep = false;
 			const response = await this.send('reverseContinue', args);
-			this.fireSimulatedContinuedEvent(args.threadId);
+			if (!this.stoppedSinceLastStep) {
+				this.fireSimulatedContinuedEvent(args.threadId);
+			}
 			return response;
 		}
 		return Promise.reject(new Error('reverseContinue not supported'));
@@ -509,8 +534,11 @@ export class RawDebugSession implements IDisposable {
 
 	async goto(args: DebugProtocol.GotoArguments): Promise<DebugProtocol.GotoResponse | undefined> {
 		if (this.capabilities.supportsGotoTargetsRequest) {
+			this.stoppedSinceLastStep = false;
 			const response = await this.send('goto', args);
-			this.fireSimulatedContinuedEvent(args.threadId);
+			if (!this.stoppedSinceLastStep) {
+				this.fireSimulatedContinuedEvent(args.threadId);
+			}
 			return response;
 		}
 

--- a/src/vs/workbench/contrib/debug/browser/rawDebugSession.ts
+++ b/src/vs/workbench/contrib/debug/browser/rawDebugSession.ts
@@ -331,9 +331,7 @@ export class RawDebugSession implements IDisposable {
 		this.stoppedSinceLastStep = false;
 		const response = await this.send('next', args);
 		if (!this.stoppedSinceLastStep) {
-			if (!this.stoppedSinceLastStep) {
-				this.fireSimulatedContinuedEvent(args.threadId);
-			}
+			this.fireSimulatedContinuedEvent(args.threadId);
 		}
 		return response;
 	}


### PR DESCRIPTION
Fix #185785

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
