### PR TITLE
Log latency stats and remove old unused latency mechanism

### DIFF
--- a/src/vs/platform/terminal/common/terminal.ts
+++ b/src/vs/platform/terminal/common/terminal.ts
@@ -300,6 +300,10 @@ export interface IPtyService {
 	 */
 	listProcesses(): Promise<IProcessDetails[]>;
 	getPerformanceMarks(): Promise<performance.PerformanceMark[]>;
+	/**
+	 * Measures and returns the latency of the current and all other processes to the pty host.
+	 */
+	getLatency(): Promise<IPtyHostLatencyMeasurement[]>;
 
 	start(id: number): Promise<ITerminalLaunchError | { injectedArgs: string[] } | undefined>;
 	shutdown(id: number, immediate: boolean): Promise<void>;
@@ -308,7 +312,6 @@ export interface IPtyService {
 	clearBuffer(id: number): Promise<void>;
 	getInitialCwd(id: number): Promise<string>;
 	getCwd(id: number): Promise<string>;
-	getLatency(id: number): Promise<number>;
 	acknowledgeDataEvent(id: number, charCount: number): Promise<void>;
 	setUnicodeVersion(id: number, version: '6' | '11'): Promise<void>;
 	processBinary(id: number, data: string): Promise<void>;
@@ -365,6 +368,11 @@ export interface IPtyHostController {
  * process) and is able to launch and forward requests to the pty host.
 */
 export interface IPtyHostService extends IPtyService, IPtyHostController {
+}
+
+export interface IPtyHostLatencyMeasurement {
+	label: string;
+	latency: number;
 }
 
 /**
@@ -739,7 +747,6 @@ export interface ITerminalChildProcess {
 
 	getInitialCwd(): Promise<string>;
 	getCwd(): Promise<string>;
-	getLatency(): Promise<number>;
 	refreshProperty<T extends ProcessPropertyType>(property: T): Promise<IProcessPropertyMap[T]>;
 	updateProperty<T extends ProcessPropertyType>(property: T, value: IProcessPropertyMap[T]): Promise<void>;
 }
@@ -992,6 +999,7 @@ export interface ITerminalBackend {
 	attachToProcess(id: number): Promise<ITerminalChildProcess | undefined>;
 	attachToRevivedProcess(id: number): Promise<ITerminalChildProcess | undefined>;
 	listProcesses(): Promise<IProcessDetails[]>;
+	getLatency(): Promise<IPtyHostLatencyMeasurement[]>;
 	getDefaultSystemShell(osOverride?: OperatingSystem): Promise<string>;
 	getProfiles(profiles: unknown, defaultProfile: unknown, includeDetectedProfiles?: boolean): Promise<ITerminalProfile[]>;
 	getWslPath(original: string, direction: 'unix-to-win' | 'win-to-unix'): Promise<string>;

--- a/src/vs/platform/terminal/node/ptyHostService.ts
+++ b/src/vs/platform/terminal/node/ptyHostService.ts
@@ -13,13 +13,14 @@ import { RemoteLoggerChannelClient } from 'vs/platform/log/common/logIpc';
 import { getResolvedShellEnv } from 'vs/platform/shell/node/shellEnv';
 import { IPtyHostProcessReplayEvent } from 'vs/platform/terminal/common/capabilities/capabilities';
 import { RequestStore } from 'vs/platform/terminal/common/requestStore';
-import { HeartbeatConstants, IHeartbeatService, IProcessDataEvent, IProcessProperty, IProcessPropertyMap, IProcessReadyEvent, IPtyHostService, IPtyService, IRequestResolveVariablesEvent, ISerializedTerminalState, IShellLaunchConfig, ITerminalLaunchError, ITerminalProcessOptions, ITerminalProfile, ITerminalsLayoutInfo, ProcessPropertyType, TerminalIcon, TerminalIpcChannels, TerminalSettingId, TitleEventSource } from 'vs/platform/terminal/common/terminal';
+import { HeartbeatConstants, IHeartbeatService, IProcessDataEvent, IProcessProperty, IProcessPropertyMap, IProcessReadyEvent, IPtyHostLatencyMeasurement, IPtyHostService, IPtyService, IRequestResolveVariablesEvent, ISerializedTerminalState, IShellLaunchConfig, ITerminalLaunchError, ITerminalProcessOptions, ITerminalProfile, ITerminalsLayoutInfo, ProcessPropertyType, TerminalIcon, TerminalIpcChannels, TerminalSettingId, TitleEventSource } from 'vs/platform/terminal/common/terminal';
 import { registerTerminalPlatformConfiguration } from 'vs/platform/terminal/common/terminalPlatformConfiguration';
 import { IGetTerminalLayoutInfoArgs, IProcessDetails, ISetTerminalLayoutInfoArgs } from 'vs/platform/terminal/common/terminalProcess';
 import { IPtyHostConnection, IPtyHostStarter } from 'vs/platform/terminal/node/ptyHost';
 import { detectAvailableProfiles } from 'vs/platform/terminal/node/terminalProfiles';
 import * as performance from 'vs/base/common/performance';
 import { getSystemShell } from 'vs/base/node/shell';
+import { StopWatch } from 'vs/base/common/stopwatch';
 
 enum Constants {
 	MaxRestarts = 5
@@ -272,8 +273,17 @@ export class PtyHostService extends Disposable implements IPtyHostService {
 	getCwd(id: number): Promise<string> {
 		return this._proxy.getCwd(id);
 	}
-	getLatency(id: number): Promise<number> {
-		return this._proxy.getLatency(id);
+	async getLatency(): Promise<IPtyHostLatencyMeasurement[]> {
+		const sw = new StopWatch();
+		const results = await this._proxy.getLatency();
+		sw.stop();
+		return [
+			{
+				label: 'ptyhostservice<->ptyhost',
+				latency: sw.elapsed()
+			},
+			...results
+		];
 	}
 	orphanQuestionReply(id: number): Promise<void> {
 		return this._proxy.orphanQuestionReply(id);

--- a/src/vs/platform/terminal/node/ptyService.ts
+++ b/src/vs/platform/terminal/node/ptyService.ts
@@ -12,7 +12,7 @@ import { URI } from 'vs/base/common/uri';
 import { getSystemShell } from 'vs/base/node/shell';
 import { ILogService, LogLevel } from 'vs/platform/log/common/log';
 import { RequestStore } from 'vs/platform/terminal/common/requestStore';
-import { IProcessDataEvent, IProcessReadyEvent, IPtyService, IRawTerminalInstanceLayoutInfo, IReconnectConstants, IShellLaunchConfig, ITerminalInstanceLayoutInfoById, ITerminalLaunchError, ITerminalsLayoutInfo, ITerminalTabLayoutInfoById, TerminalIcon, IProcessProperty, TitleEventSource, ProcessPropertyType, IProcessPropertyMap, IFixedTerminalDimensions, IPersistentTerminalProcessLaunchConfig, ICrossVersionSerializedTerminalState, ISerializedTerminalState, ITerminalProcessOptions } from 'vs/platform/terminal/common/terminal';
+import { IProcessDataEvent, IProcessReadyEvent, IPtyService, IRawTerminalInstanceLayoutInfo, IReconnectConstants, IShellLaunchConfig, ITerminalInstanceLayoutInfoById, ITerminalLaunchError, ITerminalsLayoutInfo, ITerminalTabLayoutInfoById, TerminalIcon, IProcessProperty, TitleEventSource, ProcessPropertyType, IProcessPropertyMap, IFixedTerminalDimensions, IPersistentTerminalProcessLaunchConfig, ICrossVersionSerializedTerminalState, ISerializedTerminalState, ITerminalProcessOptions, IPtyHostLatencyMeasurement } from 'vs/platform/terminal/common/terminal';
 import { TerminalDataBufferer } from 'vs/platform/terminal/common/terminalDataBuffering';
 import { escapeNonWindowsPath } from 'vs/platform/terminal/common/terminalEnvironment';
 import { Terminal as XtermTerminal } from 'xterm-headless';
@@ -399,8 +399,8 @@ export class PtyService extends Disposable implements IPtyService {
 		return this._throwIfNoPty(id).setUnicodeVersion(version);
 	}
 	@traceRpc
-	async getLatency(id: number): Promise<number> {
-		return 0;
+	async getLatency(): Promise<IPtyHostLatencyMeasurement[]> {
+		return [];
 	}
 	@traceRpc
 	async orphanQuestionReply(id: number): Promise<void> {
@@ -873,9 +873,6 @@ class PersistentTerminalProcess extends Disposable {
 	}
 	getCwd(): Promise<string> {
 		return this._terminalProcess.getCwd();
-	}
-	getLatency(): Promise<number> {
-		return this._terminalProcess.getLatency();
 	}
 
 	async triggerReplay(): Promise<void> {

--- a/src/vs/platform/terminal/node/terminalProcess.ts
+++ b/src/vs/platform/terminal/node/terminalProcess.ts
@@ -627,10 +627,6 @@ export class TerminalProcess extends Disposable implements ITerminalChildProcess
 		return this._initialCwd;
 	}
 
-	getLatency(): Promise<number> {
-		return Promise.resolve(0);
-	}
-
 	getWindowsPty(): IProcessReadyWindowsPty | undefined {
 		return isWindows ? {
 			backend: 'useConpty' in this._ptyOptions && this._ptyOptions.useConpty ? 'conpty' : 'winpty',

--- a/src/vs/server/node/remoteTerminalChannel.ts
+++ b/src/vs/server/node/remoteTerminalChannel.ts
@@ -117,6 +117,7 @@ export class RemoteTerminalChannel extends Disposable implements IServerChannel<
 			case RemoteTerminalChannelRequest.DetachFromProcess: return this._ptyHostService.detachFromProcess.apply(this._ptyHostService, args);
 
 			case RemoteTerminalChannelRequest.ListProcesses: return this._ptyHostService.listProcesses.apply(this._ptyHostService, args);
+			case RemoteTerminalChannelRequest.GetLatency: return this._ptyHostService.getLatency.apply(this._ptyHostService, args);
 			case RemoteTerminalChannelRequest.GetPerformanceMarks: return this._ptyHostService.getPerformanceMarks.apply(this._ptyHostService, args);
 			case RemoteTerminalChannelRequest.OrphanQuestionReply: return this._ptyHostService.orphanQuestionReply.apply(this._ptyHostService, args);
 			case RemoteTerminalChannelRequest.AcceptPtyHostResolvedVariables: return this._ptyHostService.acceptPtyHostResolvedVariables.apply(this._ptyHostService, args);

--- a/src/vs/workbench/api/common/extHostTerminalService.ts
+++ b/src/vs/workbench/api/common/extHostTerminalService.ts
@@ -313,10 +313,6 @@ class ExtHostPseudoterminal implements ITerminalChildProcess {
 		return Promise.resolve('');
 	}
 
-	getLatency(): Promise<number> {
-		return Promise.resolve(0);
-	}
-
 	startSendingEvents(initialDimensions: ITerminalDimensionsDto | undefined): void {
 		// Attach the listeners
 		this._pty.onDidWrite(e => this._onProcessData.fire(e));

--- a/src/vs/workbench/contrib/terminal/browser/remotePty.ts
+++ b/src/vs/workbench/contrib/terminal/browser/remotePty.ts
@@ -209,8 +209,4 @@ export class RemotePty extends Disposable implements ITerminalChildProcess {
 	handleOrphanQuestion() {
 		this._remoteTerminalChannel.orphanQuestionReply(this.id);
 	}
-
-	async getLatency(): Promise<number> {
-		return 0;
-	}
 }

--- a/src/vs/workbench/contrib/terminal/browser/remoteTerminalBackend.ts
+++ b/src/vs/workbench/contrib/terminal/browser/remoteTerminalBackend.ts
@@ -267,7 +267,7 @@ class RemoteTerminalBackend extends BaseTerminalBackend implements ITerminalBack
 		sw.stop();
 		return [
 			{
-				label: 'window<->ptyhost',
+				label: 'window<->ptyhostservice<->ptyhost',
 				latency: sw.elapsed()
 			},
 			...results

--- a/src/vs/workbench/contrib/terminal/browser/remoteTerminalBackend.ts
+++ b/src/vs/workbench/contrib/terminal/browser/remoteTerminalBackend.ts
@@ -8,6 +8,7 @@ import { Emitter } from 'vs/base/common/event';
 import { revive } from 'vs/base/common/marshalling';
 import { PerformanceMark, mark } from 'vs/base/common/performance';
 import { IProcessEnvironment, OperatingSystem } from 'vs/base/common/platform';
+import { StopWatch } from 'vs/base/common/stopwatch';
 import { ICommandService } from 'vs/platform/commands/common/commands';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
@@ -15,7 +16,7 @@ import { Registry } from 'vs/platform/registry/common/platform';
 import { IRemoteAuthorityResolverService } from 'vs/platform/remote/common/remoteAuthorityResolver';
 import { IStorageService, StorageScope, StorageTarget } from 'vs/platform/storage/common/storage';
 import { ISerializedTerminalCommand } from 'vs/platform/terminal/common/capabilities/capabilities';
-import { IShellLaunchConfig, IShellLaunchConfigDto, ITerminalBackend, ITerminalBackendRegistry, ITerminalChildProcess, ITerminalEnvironment, ITerminalLogService, ITerminalProcessOptions, ITerminalProfile, ITerminalsLayoutInfo, ITerminalsLayoutInfoById, ProcessPropertyType, TerminalExtensions, TerminalIcon, TerminalSettingId, TitleEventSource } from 'vs/platform/terminal/common/terminal';
+import { IPtyHostLatencyMeasurement, IShellLaunchConfig, IShellLaunchConfigDto, ITerminalBackend, ITerminalBackendRegistry, ITerminalChildProcess, ITerminalEnvironment, ITerminalLogService, ITerminalProcessOptions, ITerminalProfile, ITerminalsLayoutInfo, ITerminalsLayoutInfoById, ProcessPropertyType, TerminalExtensions, TerminalIcon, TerminalSettingId, TitleEventSource } from 'vs/platform/terminal/common/terminal';
 import { IProcessDetails } from 'vs/platform/terminal/common/terminalProcess';
 import { IWorkspaceContextService } from 'vs/platform/workspace/common/workspace';
 import { IWorkbenchContribution } from 'vs/workbench/common/contributions';
@@ -258,6 +259,19 @@ class RemoteTerminalBackend extends BaseTerminalBackend implements ITerminalBack
 
 	async listProcesses(): Promise<IProcessDetails[]> {
 		return this._remoteTerminalChannel.listProcesses();
+	}
+
+	async getLatency(): Promise<IPtyHostLatencyMeasurement[]> {
+		const sw = new StopWatch();
+		const results = await this._remoteTerminalChannel.getLatency();
+		sw.stop();
+		return [
+			{
+				label: 'window<->ptyhost',
+				latency: sw.elapsed()
+			},
+			...results
+		];
 	}
 
 	async updateProperty<T extends ProcessPropertyType>(id: number, property: T, value: any): Promise<void> {

--- a/src/vs/workbench/contrib/terminal/browser/terminalProcessExtHostProxy.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalProcessExtHostProxy.ts
@@ -34,17 +34,13 @@ export class TerminalProcessExtHostProxy extends Disposable implements ITerminal
 	readonly onRequestInitialCwd: Event<void> = this._onRequestInitialCwd.event;
 	private readonly _onRequestCwd = this._register(new Emitter<void>());
 	readonly onRequestCwd: Event<void> = this._onRequestCwd.event;
-	private readonly _onRequestLatency = this._register(new Emitter<void>());
-	readonly onRequestLatency: Event<void> = this._onRequestLatency.event;
 	private readonly _onDidChangeProperty = this._register(new Emitter<IProcessProperty<any>>());
 	readonly onDidChangeProperty = this._onDidChangeProperty.event;
 	private readonly _onProcessExit = this._register(new Emitter<number | undefined>());
 	readonly onProcessExit: Event<number | undefined> = this._onProcessExit.event;
 
-
 	private _pendingInitialCwdRequests: ((value: string | PromiseLike<string>) => void)[] = [];
 	private _pendingCwdRequests: ((value: string | PromiseLike<string>) => void)[] = [];
-	private _pendingLatencyRequests: ((value: number | PromiseLike<number>) => void)[] = [];
 
 	constructor(
 		public instanceId: number,
@@ -112,12 +108,6 @@ export class TerminalProcessExtHostProxy extends Disposable implements ITerminal
 		}
 	}
 
-	emitLatency(latency: number): void {
-		while (this._pendingLatencyRequests.length > 0) {
-			this._pendingLatencyRequests.pop()!(latency);
-		}
-	}
-
 	async start(): Promise<ITerminalLaunchError | undefined> {
 		return this._terminalService.requestStartExtensionTerminal(this, this._cols, this._rows);
 	}
@@ -162,13 +152,6 @@ export class TerminalProcessExtHostProxy extends Disposable implements ITerminal
 		return new Promise<string>(resolve => {
 			this._onRequestCwd.fire();
 			this._pendingCwdRequests.push(resolve);
-		});
-	}
-
-	getLatency(): Promise<number> {
-		return new Promise<number>(resolve => {
-			this._onRequestLatency.fire();
-			this._pendingLatencyRequests.push(resolve);
 		});
 	}
 

--- a/src/vs/workbench/contrib/terminal/common/remote/remoteTerminalChannel.ts
+++ b/src/vs/workbench/contrib/terminal/common/remote/remoteTerminalChannel.ts
@@ -17,7 +17,7 @@ import { IEditorService } from 'vs/workbench/services/editor/common/editorServic
 import { Schemas } from 'vs/base/common/network';
 import { ILabelService } from 'vs/platform/label/common/label';
 import { IEnvironmentVariableService } from 'vs/workbench/contrib/terminal/common/environmentVariable';
-import { IProcessDataEvent, IRequestResolveVariablesEvent, IShellLaunchConfigDto, ITerminalLaunchError, ITerminalProfile, ITerminalsLayoutInfo, ITerminalsLayoutInfoById, TerminalIcon, IProcessProperty, ProcessPropertyType, IProcessPropertyMap, TitleEventSource, ISerializedTerminalState, IPtyHostController, ITerminalProcessOptions, IProcessReadyEvent, ITerminalLogService } from 'vs/platform/terminal/common/terminal';
+import { IProcessDataEvent, IRequestResolveVariablesEvent, IShellLaunchConfigDto, ITerminalLaunchError, ITerminalProfile, ITerminalsLayoutInfo, ITerminalsLayoutInfoById, TerminalIcon, IProcessProperty, ProcessPropertyType, IProcessPropertyMap, TitleEventSource, ISerializedTerminalState, IPtyHostController, ITerminalProcessOptions, IProcessReadyEvent, ITerminalLogService, IPtyHostLatencyMeasurement } from 'vs/platform/terminal/common/terminal';
 import { IGetTerminalLayoutInfoArgs, IProcessDetails, ISetTerminalLayoutInfoArgs } from 'vs/platform/terminal/common/terminalProcess';
 import { IProcessEnvironment, OperatingSystem } from 'vs/base/common/platform';
 import { ICompleteTerminalConfiguration } from 'vs/workbench/contrib/terminal/common/terminal';
@@ -202,6 +202,9 @@ export class RemoteTerminalChannelClient implements IPtyHostController {
 	}
 	listProcesses(): Promise<IProcessDetails[]> {
 		return this._channel.call(RemoteTerminalChannelRequest.ListProcesses);
+	}
+	getLatency(): Promise<IPtyHostLatencyMeasurement[]> {
+		return this._channel.call(RemoteTerminalChannelRequest.GetLatency);
 	}
 	getPerformanceMarks(): Promise<performance.PerformanceMark[]> {
 		return this._channel.call(RemoteTerminalChannelRequest.GetPerformanceMarks);

--- a/src/vs/workbench/contrib/terminal/common/remote/terminal.ts
+++ b/src/vs/workbench/contrib/terminal/common/remote/terminal.ts
@@ -63,6 +63,7 @@ export const enum RemoteTerminalChannelRequest {
 	AttachToProcess = '$attachToProcess',
 	DetachFromProcess = '$detachFromProcess',
 	ListProcesses = '$listProcesses',
+	GetLatency = '$getLatency',
 	GetPerformanceMarks = '$getPerformanceMarks',
 	OrphanQuestionReply = '$orphanQuestionReply',
 	AcceptPtyHostResolvedVariables = '$acceptPtyHostResolvedVariables',

--- a/src/vs/workbench/contrib/terminal/common/terminal.ts
+++ b/src/vs/workbench/contrib/terminal/common/terminal.ts
@@ -299,7 +299,6 @@ export interface ITerminalProcessManager extends IDisposable {
 	acknowledgeDataEvent(charCount: number): void;
 	processBinary(data: string): void;
 
-	getLatency(): Promise<number>;
 	refreshProperty<T extends ProcessPropertyType>(type: T): Promise<IProcessPropertyMap[T]>;
 	updateProperty<T extends ProcessPropertyType>(property: T, value: IProcessPropertyMap[T]): Promise<void>;
 	getBackendOS(): Promise<OperatingSystem>;
@@ -331,7 +330,6 @@ export interface ITerminalProcessExtHostProxy extends IDisposable {
 	emitData(data: string): void;
 	emitProcessProperty(property: IProcessProperty<any>): void;
 	emitReady(pid: number, cwd: string, windowsPty: IProcessReadyWindowsPty | undefined): void;
-	emitLatency(latency: number): void;
 	emitExit(exitCode: number | undefined): void;
 
 	onInput: Event<string>;
@@ -341,7 +339,6 @@ export interface ITerminalProcessExtHostProxy extends IDisposable {
 	onShutdown: Event<boolean>;
 	onRequestInitialCwd: Event<void>;
 	onRequestCwd: Event<void>;
-	onRequestLatency: Event<void>;
 }
 
 export interface IStartExtensionTerminalRequest {

--- a/src/vs/workbench/contrib/terminal/electron-sandbox/localPty.ts
+++ b/src/vs/workbench/contrib/terminal/electron-sandbox/localPty.ts
@@ -102,10 +102,6 @@ export class LocalPty extends Disposable implements ITerminalChildProcess {
 	async updateProperty<T extends ProcessPropertyType>(type: T, value: IProcessPropertyMap[T]): Promise<void> {
 		return this._proxy.updateProperty(this.id, type, value);
 	}
-	getLatency(): Promise<number> {
-		// TODO: The idea here was to add the result plus the time it took to get the latency
-		return this._proxy.getLatency(this.id);
-	}
 	acknowledgeDataEvent(charCount: number): void {
 		if (this._inReplay) {
 			return;

--- a/src/vs/workbench/contrib/terminal/electron-sandbox/localTerminalBackend.ts
+++ b/src/vs/workbench/contrib/terminal/electron-sandbox/localTerminalBackend.ts
@@ -12,7 +12,7 @@ import { IInstantiationService } from 'vs/platform/instantiation/common/instanti
 import { ILabelService } from 'vs/platform/label/common/label';
 import { Registry } from 'vs/platform/registry/common/platform';
 import { IStorageService, StorageScope, StorageTarget } from 'vs/platform/storage/common/storage';
-import { ILocalPtyService, IProcessPropertyMap, IPtyService, IShellLaunchConfig, ITerminalBackend, ITerminalBackendRegistry, ITerminalChildProcess, ITerminalEnvironment, ITerminalLogService, ITerminalProcessOptions, ITerminalsLayoutInfo, ITerminalsLayoutInfoById, ProcessPropertyType, TerminalExtensions, TerminalIpcChannels, TerminalSettingId, TitleEventSource } from 'vs/platform/terminal/common/terminal';
+import { ILocalPtyService, IProcessPropertyMap, IPtyHostLatencyMeasurement, IPtyService, IShellLaunchConfig, ITerminalBackend, ITerminalBackendRegistry, ITerminalChildProcess, ITerminalEnvironment, ITerminalLogService, ITerminalProcessOptions, ITerminalsLayoutInfo, ITerminalsLayoutInfoById, ProcessPropertyType, TerminalExtensions, TerminalIpcChannels, TerminalSettingId, TitleEventSource } from 'vs/platform/terminal/common/terminal';
 import { IGetTerminalLayoutInfoArgs, IProcessDetails, ISetTerminalLayoutInfoArgs } from 'vs/platform/terminal/common/terminalProcess';
 import { IWorkspaceContextService } from 'vs/platform/workspace/common/workspace';
 import { IWorkbenchContribution } from 'vs/workbench/common/contributions';
@@ -36,6 +36,7 @@ import { ILifecycleService, LifecyclePhase } from 'vs/workbench/services/lifecyc
 import { DeferredPromise } from 'vs/base/common/async';
 import { IStatusbarService } from 'vs/workbench/services/statusbar/browser/statusbar';
 import { memoize } from 'vs/base/common/decorators';
+import { StopWatch } from 'vs/base/common/stopwatch';
 
 export class LocalTerminalBackendContribution implements IWorkbenchContribution {
 	constructor(
@@ -243,6 +244,30 @@ class LocalTerminalBackend extends BaseTerminalBackend implements ITerminalBacke
 	async listProcesses(): Promise<IProcessDetails[]> {
 		await this._connectToDirectProxy();
 		return this._proxy.listProcesses();
+	}
+
+	async getLatency(): Promise<IPtyHostLatencyMeasurement[]> {
+		const measurements: IPtyHostLatencyMeasurement[] = [];
+		const sw = new StopWatch();
+		if (this._directProxy) {
+			await this._directProxy.getLatency();
+			sw.stop();
+			measurements.push({
+				label: 'window<->ptyhost (message port)',
+				latency: sw.elapsed()
+			});
+			sw.reset();
+		}
+		const results = await this._localPtyService.getLatency();
+		sw.stop();
+		measurements.push({
+			label: 'window<->main<->ptyhost',
+			latency: sw.elapsed()
+		});
+		return [
+			...measurements,
+			...results
+		];
 	}
 
 	async getPerformanceMarks(): Promise<PerformanceMark[]> {

--- a/src/vs/workbench/contrib/terminal/electron-sandbox/localTerminalBackend.ts
+++ b/src/vs/workbench/contrib/terminal/electron-sandbox/localTerminalBackend.ts
@@ -261,7 +261,7 @@ class LocalTerminalBackend extends BaseTerminalBackend implements ITerminalBacke
 		const results = await this._localPtyService.getLatency();
 		sw.stop();
 		measurements.push({
-			label: 'window<->main<->ptyhost',
+			label: 'window<->ptyhostservice<->ptyhost',
 			latency: sw.elapsed()
 		});
 		return [

--- a/src/vs/workbench/contrib/terminal/test/browser/terminalProcessManager.test.ts
+++ b/src/vs/workbench/contrib/terminal/test/browser/terminalProcessManager.test.ts
@@ -51,7 +51,6 @@ class TestTerminalChildProcess implements ITerminalChildProcess {
 	async setUnicodeVersion(version: '6' | '11'): Promise<void> { }
 	async getInitialCwd(): Promise<string> { return ''; }
 	async getCwd(): Promise<string> { return ''; }
-	async getLatency(): Promise<number> { return 0; }
 	async processBinary(data: string): Promise<void> { }
 	refreshProperty(property: any): Promise<any> { return Promise.resolve(''); }
 }

--- a/src/vs/workbench/services/terminal/common/embedderTerminalService.ts
+++ b/src/vs/workbench/services/terminal/common/embedderTerminalService.ts
@@ -139,9 +139,6 @@ class EmbedderTerminalProcess extends Disposable implements ITerminalChildProces
 	async getCwd(): Promise<string> {
 		return '';
 	}
-	async getLatency(): Promise<number> {
-		return 0;
-	}
 	refreshProperty<T extends ProcessPropertyType>(property: ProcessPropertyType): Promise<IProcessPropertyMap[T]> {
 		throw new Error(`refreshProperty is not suppported in EmbedderTerminalProcess. property: ${property}`);
 	}


### PR DESCRIPTION
Fixes #187274

This change measures latency in an idle callback after each terminal process is created.

Example logs:

```
2023-07-07 08:38:15.407 [info] Latency measurements for test+test backend
window<->ptyhostservice<->ptyhost: 16.70ms
ptyhostservice<->ptyhost: 0.75ms []

2023-07-07 08:38:44.243 [info] Latency measurements for local backend
window<->ptyhost (message port): 0.40ms
window<->ptyhostservice<->ptyhost: 1.30ms
ptyhostservice<->ptyhost: 0.45ms []
```