### PR TITLE
Fixes #187140

### DIFF
--- a/src/vs/workbench/services/textMate/browser/worker/textMateWorkerModel.ts
+++ b/src/vs/workbench/services/textMate/browser/worker/textMateWorkerModel.ts
@@ -3,21 +3,22 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { importAMDNodeModule } from 'vs/amdX';
 import { RunOnceScheduler } from 'vs/base/common/async';
 import { observableValue } from 'vs/base/common/observable';
+import { setTimeout0 } from 'vs/base/common/platform';
 import { URI } from 'vs/base/common/uri';
 import { LineRange } from 'vs/editor/common/core/lineRange';
 import { LanguageId } from 'vs/editor/common/encodedTokenAttributes';
 import { IModelChangedEvent, MirrorTextModel } from 'vs/editor/common/model/mirrorTextModel';
 import { TokenizerWithStateStore } from 'vs/editor/common/model/textModelTokens';
-import type { diffStateStacksRefEq, StateStack, StackDiff } from 'vscode-textmate';
 import { ContiguousMultilineTokensBuilder } from 'vs/editor/common/tokens/contiguousMultilineTokensBuilder';
 import { LineTokens } from 'vs/editor/common/tokens/lineTokens';
 import { TextMateTokenizationSupport } from 'vs/workbench/services/textMate/browser/tokenizationSupport/textMateTokenizationSupport';
 import { TokenizationSupportWithLineLimit } from 'vs/workbench/services/textMate/browser/tokenizationSupport/tokenizationSupportWithLineLimit';
 import { StateDeltas } from 'vs/workbench/services/textMate/browser/workerHost/textMateWorkerHost';
+import type { StackDiff, StateStack, diffStateStacksRefEq } from 'vscode-textmate';
 import { TextMateTokenizationWorker } from './textMate.worker';
-import { importAMDNodeModule } from 'vs/amdX';
 
 export class TextMateWorkerModel extends MirrorTextModel {
 	private _tokenizationStateStore: TokenizerWithStateStore<StateStack> | null = null;
@@ -169,7 +170,7 @@ export class TextMateWorkerModel extends MirrorTextModel {
 			const deltaMs = new Date().getTime() - startTime;
 			if (deltaMs > 20) {
 				// yield to check for changes
-				setTimeout(() => this._tokenize(), 3);
+				setTimeout0(() => this._tokenize());
 				return;
 			}
 		}


### PR DESCRIPTION
Fixes #187140

Before, checker.ts would be tokenized in ~23.5 seconds. Now it is 22 seconds.