### PR TITLE
Revert "adopt atomic write for userdata (#187038)"

### DIFF
--- a/src/vs/code/electron-main/main.ts
+++ b/src/vs/code/electron-main/main.ts
@@ -70,7 +70,6 @@ import { ILoggerMainService, LoggerMainService } from 'vs/platform/log/electron-
 import { LogService } from 'vs/platform/log/common/logService';
 import { massageMessageBoxOptions } from 'vs/platform/dialogs/common/dialogs';
 import { SaveStrategy, StateService } from 'vs/platform/state/node/stateService';
-import { FileUserDataProvider } from 'vs/platform/userData/common/fileUserDataProvider';
 
 /**
  * The main VS Code entry point.
@@ -178,10 +177,6 @@ class CodeMain {
 		services.set(IFileService, fileService);
 		const diskFileSystemProvider = new DiskFileSystemProvider(logService);
 		fileService.registerProvider(Schemas.file, diskFileSystemProvider);
-
-		// Use FileUserDataProvider for user data to
-		// enable atomic read / write operations.
-		fileService.registerProvider(Schemas.vscodeUserData, new FileUserDataProvider(Schemas.file, diskFileSystemProvider, Schemas.vscodeUserData, logService));
 
 		// URI Identity
 		const uriIdentityService = new UriIdentityService(fileService);

--- a/src/vs/code/node/sharedProcess/sharedProcessMain.ts
+++ b/src/vs/code/node/sharedProcess/sharedProcessMain.ts
@@ -26,6 +26,7 @@ import { DiagnosticsService } from 'vs/platform/diagnostics/node/diagnosticsServ
 import { IDownloadService } from 'vs/platform/download/common/download';
 import { DownloadService } from 'vs/platform/download/common/downloadService';
 import { INativeEnvironmentService } from 'vs/platform/environment/common/environment';
+import { SharedProcessEnvironmentService } from 'vs/platform/sharedProcess/node/sharedProcessEnvironmentService';
 import { GlobalExtensionEnablementService } from 'vs/platform/extensionManagement/common/extensionEnablementService';
 import { ExtensionGalleryService } from 'vs/platform/extensionManagement/common/extensionGalleryService';
 import { IExtensionGalleryService, IExtensionManagementService, IExtensionTipsService, IGlobalExtensionEnablementService } from 'vs/platform/extensionManagement/common/extensionManagement';
@@ -111,7 +112,6 @@ import { RemoteStorageService } from 'vs/platform/storage/common/storageService'
 import { IRemoteSocketFactoryService, RemoteSocketFactoryService } from 'vs/platform/remote/common/remoteSocketFactoryService';
 import { RemoteConnectionType } from 'vs/platform/remote/common/remoteAuthorityResolver';
 import { nodeSocketFactory } from 'vs/platform/remote/node/nodeSocketFactory';
-import { NativeEnvironmentService } from 'vs/platform/environment/node/environmentService';
 
 class SharedProcessMain extends Disposable {
 
@@ -191,7 +191,7 @@ class SharedProcessMain extends Disposable {
 		services.set(IPolicyService, policyService);
 
 		// Environment
-		const environmentService = new NativeEnvironmentService(this.configuration.args, productService);
+		const environmentService = new SharedProcessEnvironmentService(this.configuration.args, productService);
 		services.set(INativeEnvironmentService, environmentService);
 
 		// Logger

--- a/src/vs/platform/environment/common/environmentService.ts
+++ b/src/vs/platform/environment/common/environmentService.ts
@@ -5,7 +5,7 @@
 
 import { toLocalISOString } from 'vs/base/common/date';
 import { memoize } from 'vs/base/common/decorators';
-import { FileAccess, Schemas } from 'vs/base/common/network';
+import { FileAccess } from 'vs/base/common/network';
 import { dirname, join, normalize, resolve } from 'vs/base/common/path';
 import { env } from 'vs/base/common/process';
 import { joinPath } from 'vs/base/common/resources';
@@ -65,10 +65,10 @@ export abstract class AbstractNativeEnvironmentService implements INativeEnviron
 	get stateResource(): URI { return joinPath(this.appSettingsHome, 'globalStorage', 'storage.json'); }
 
 	@memoize
-	get userRoamingDataHome(): URI { return this.appSettingsHome.with({ scheme: Schemas.vscodeUserData }); }
+	get userRoamingDataHome(): URI { return this.appSettingsHome; }
 
 	@memoize
-	get userDataSyncHome(): URI { return joinPath(this.appSettingsHome, 'sync'); }
+	get userDataSyncHome(): URI { return joinPath(this.userRoamingDataHome, 'sync'); }
 
 	get logsHome(): URI {
 		if (!this.args.logsPath) {

--- a/src/vs/platform/extensionManagement/common/extensionsProfileScannerService.ts
+++ b/src/vs/platform/extensionManagement/common/extensionsProfileScannerService.ts
@@ -12,7 +12,7 @@ import { URI, UriComponents } from 'vs/base/common/uri';
 import { Metadata, isIExtensionIdentifier } from 'vs/platform/extensionManagement/common/extensionManagement';
 import { areSameExtensions } from 'vs/platform/extensionManagement/common/extensionManagementUtil';
 import { IExtension, IExtensionIdentifier } from 'vs/platform/extensions/common/extensions';
-import { FileOperationResult, IFileService, hasFileAtomicWriteCapability, toFileOperationResult } from 'vs/platform/files/common/files';
+import { FileOperationResult, IFileService, toFileOperationResult } from 'vs/platform/files/common/files';
 import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
 import { ILogService } from 'vs/platform/log/common/log';
 import { IUserDataProfilesService } from 'vs/platform/userDataProfile/common/userDataProfile';
@@ -290,8 +290,7 @@ export abstract class AbstractExtensionsProfileScannerService extends Disposable
 					relativeLocation: this.toRelativePath(e.location),
 					metadata: e.metadata
 				}));
-				const fsp = this.fileService.getProvider(file.scheme);
-				await this.fileService.writeFile(file, VSBuffer.fromString(JSON.stringify(storedProfileExtensions)), fsp && hasFileAtomicWriteCapability(fsp) ? { atomic: { postfix: '.vsctmp' } } : undefined);
+				await this.fileService.writeFile(file, VSBuffer.fromString(JSON.stringify(storedProfileExtensions)));
 			}
 
 			return extensions;

--- a/src/vs/platform/sharedProcess/node/sharedProcessEnvironmentService.ts
+++ b/src/vs/platform/sharedProcess/node/sharedProcessEnvironmentService.ts
@@ -1,0 +1,16 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { memoize } from 'vs/base/common/decorators';
+import { Schemas } from 'vs/base/common/network';
+import { URI } from 'vs/base/common/uri';
+import { NativeEnvironmentService } from 'vs/platform/environment/node/environmentService';
+
+export class SharedProcessEnvironmentService extends NativeEnvironmentService {
+
+	@memoize
+	override get userRoamingDataHome(): URI { return this.appSettingsHome.with({ scheme: Schemas.vscodeUserData }); }
+
+}

--- a/src/vs/platform/userData/common/fileUserDataProvider.ts
+++ b/src/vs/platform/userData/common/fileUserDataProvider.ts
@@ -4,14 +4,13 @@
  *--------------------------------------------------------------------------------------------*/
 import { Event, Emitter } from 'vs/base/common/event';
 import { Disposable, IDisposable, toDisposable } from 'vs/base/common/lifecycle';
-import { IFileSystemProviderWithFileReadWriteCapability, IFileChange, IWatchOptions, IStat, IFileOverwriteOptions, FileType, IFileWriteOptions, IFileDeleteOptions, FileSystemProviderCapabilities, IFileSystemProviderWithFileReadStreamCapability, IFileReadStreamOptions, IFileSystemProviderWithFileAtomicReadCapability, IFileSystemProviderWithFileFolderCopyCapability, hasFileFolderCopyCapability, hasFileAtomicWriteCapability } from 'vs/platform/files/common/files';
+import { IFileSystemProviderWithFileReadWriteCapability, IFileChange, IWatchOptions, IStat, IFileOverwriteOptions, FileType, IFileWriteOptions, IFileDeleteOptions, FileSystemProviderCapabilities, IFileSystemProviderWithFileReadStreamCapability, IFileReadStreamOptions, IFileSystemProviderWithFileAtomicReadCapability, IFileSystemProviderWithFileFolderCopyCapability, hasFileFolderCopyCapability } from 'vs/platform/files/common/files';
 import { URI } from 'vs/base/common/uri';
 import { CancellationToken } from 'vs/base/common/cancellation';
 import { newWriteableStream, ReadableStreamEvents } from 'vs/base/common/stream';
 import { ILogService } from 'vs/platform/log/common/log';
 import { TernarySearchTree } from 'vs/base/common/ternarySearchTree';
 import { VSBuffer } from 'vs/base/common/buffer';
-import { isObject } from 'vs/base/common/types';
 
 /**
  * This is a wrapper on top of the local filesystem provider which will
@@ -86,9 +85,6 @@ export class FileUserDataProvider extends Disposable implements
 	}
 
 	writeFile(resource: URI, content: Uint8Array, opts: IFileWriteOptions): Promise<void> {
-		if (!isObject(opts.atomic) && hasFileAtomicWriteCapability(this.fileSystemProvider)) {
-			opts = { ...opts, atomic: { postfix: '.vsctmp' } };
-		}
 		return this.fileSystemProvider.writeFile(this.toFileSystemResource(resource), content, opts);
 	}
 

--- a/src/vs/server/node/serverEnvironmentService.ts
+++ b/src/vs/server/node/serverEnvironmentService.ts
@@ -9,8 +9,6 @@ import { NativeEnvironmentService } from 'vs/platform/environment/node/environme
 import { OPTIONS, OptionDescriptions } from 'vs/platform/environment/node/argv';
 import { refineServiceDecorator } from 'vs/platform/instantiation/common/instantiation';
 import { IEnvironmentService, INativeEnvironmentService } from 'vs/platform/environment/common/environment';
-import { memoize } from 'vs/base/common/decorators';
-import { URI } from 'vs/base/common/uri';
 
 export const serverOptions: OptionDescriptions<Required<ServerParsedArgs>> = {
 
@@ -213,7 +211,5 @@ export interface IServerEnvironmentService extends INativeEnvironmentService {
 }
 
 export class ServerEnvironmentService extends NativeEnvironmentService implements IServerEnvironmentService {
-	@memoize
-	override get userRoamingDataHome(): URI { return this.appSettingsHome; }
 	override get args(): ServerParsedArgs { return super.args as ServerParsedArgs; }
 }

--- a/src/vs/workbench/electron-sandbox/desktop.main.ts
+++ b/src/vs/workbench/electron-sandbox/desktop.main.ts
@@ -224,8 +224,7 @@ export class DesktopMain extends Disposable {
 		const diskFileSystemProvider = this._register(new DiskFileSystemProvider(mainProcessService, utilityProcessWorkerWorkbenchService, logService));
 		fileService.registerProvider(Schemas.file, diskFileSystemProvider);
 
-		// Use FileUserDataProvider for user data to
-		// enable atomic read / write operations.
+		// User Data Provider
 		fileService.registerProvider(Schemas.vscodeUserData, this._register(new FileUserDataProvider(Schemas.file, diskFileSystemProvider, Schemas.vscodeUserData, logService)));
 
 		// URI Identity

--- a/src/vs/workbench/services/environment/electron-sandbox/environmentService.ts
+++ b/src/vs/workbench/services/environment/electron-sandbox/environmentService.ts
@@ -85,6 +85,9 @@ export class NativeWorkbenchEnvironmentService extends AbstractNativeEnvironment
 	}
 
 	@memoize
+	override get userRoamingDataHome(): URI { return this.appSettingsHome.with({ scheme: Schemas.vscodeUserData }); }
+
+	@memoize
 	get windowLogsPath(): URI { return joinPath(this.logsHome, `window${this.configuration.windowId}`); }
 
 	@memoize


### PR DESCRIPTION
This reverts commit 1157e96e241152529a1351fd93b33994bfb5e72d.

The commit was causing 

```
code-insiders --install-extension ms-python.python
Installing extensions...
Error while installing extensions: ENOPRO: No file system provider found for resource 'vscode-userdata:/c%3A/Users/aamunger/.vscode-insiders/extensions/extensions.json'
ENOPRO: No file system provider found for resource 'vscode-userdata:/c%3A/Users/aamunger/.vscode-insiders/extensions/extensions.json'
```

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
