### PR TITLE
filter nb codeactions before provider call -- fix #184028

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadLanguageFeatures.ts
+++ b/src/vs/workbench/api/browser/mainThreadLanguageFeatures.ts
@@ -335,8 +335,8 @@ export class MainThreadLanguageFeatures extends Disposable implements MainThread
 		const provider: languages.CodeActionProvider = {
 			provideCodeActions: async (model: ITextModel, rangeOrSelection: EditorRange | Selection, context: languages.CodeActionContext, token: CancellationToken): Promise<languages.CodeActionList | undefined> => {
 
-				// if provideCodeActions was trigged by an INVOKE, do not filter notebook CA providers
-				if (context.trigger !== languages.CodeActionTriggerType.Invoke) {
+				// if provideCodeActions was trigged automatically (lightbulb, doc load, etc) filter notebook CA providers
+				if (context.trigger === languages.CodeActionTriggerType.Auto) {
 					// provide was automatic, notebook codeActions should NOT be provided, so check:
 					// - if the model is a notebook
 					// - if the provider provides anything that is NOT nb kind

--- a/src/vs/workbench/api/common/extHostLanguageFeatures.ts
+++ b/src/vs/workbench/api/common/extHostLanguageFeatures.ts
@@ -7,7 +7,7 @@ import { URI, UriComponents } from 'vs/base/common/uri';
 import { equals, mixin } from 'vs/base/common/objects';
 import type * as vscode from 'vscode';
 import * as typeConvert from 'vs/workbench/api/common/extHostTypeConverters';
-import { Range, Disposable, CompletionList, SnippetString, CodeActionKind, SymbolInformation, DocumentSymbol, SemanticTokensEdits, SemanticTokens, SemanticTokensEdit, Location, InlineCompletionTriggerKind, InternalDataTransferItem, CodeActionTriggerKind } from 'vs/workbench/api/common/extHostTypes';
+import { Range, Disposable, CompletionList, SnippetString, CodeActionKind, SymbolInformation, DocumentSymbol, SemanticTokensEdits, SemanticTokens, SemanticTokensEdit, Location, InlineCompletionTriggerKind, InternalDataTransferItem } from 'vs/workbench/api/common/extHostTypes';
 import { ISingleEditOperation } from 'vs/editor/common/core/editOperation';
 import * as languages from 'vs/editor/common/languages';
 import { ExtHostDocuments } from 'vs/workbench/api/common/extHostDocuments';
@@ -376,7 +376,6 @@ class CodeActionAdapter {
 
 	private readonly _cache = new Cache<vscode.CodeAction | vscode.Command>('CodeAction');
 	private readonly _disposables = new Map<number, DisposableStore>();
-	private readonly nbKind = new CodeActionKind('notebook');
 
 	constructor(
 		private readonly _documents: ExtHostDocuments,
@@ -436,10 +435,6 @@ class CodeActionAdapter {
 					command: this._commands.toInternal(candidate, disposables),
 				});
 			} else {
-				if (codeActionContext.triggerKind !== CodeActionTriggerKind.Invoke && candidate.kind && this.nbKind.contains(candidate.kind)) {
-					continue;
-				}
-
 				if (codeActionContext.only) {
 					if (!candidate.kind) {
 						this._logService.warn(`${this._extension.identifier.value} - Code actions of kind '${codeActionContext.only.value} 'requested but returned code action does not have a 'kind'. Code action will be dropped. Please set 'CodeAction.kind'.`);


### PR DESCRIPTION
Fix: #184028

Previously all codeaction providers were called via the adapter within ExtHostLangFeatures, regardless of kind. nb kinds were simply not pushed to the final array of CodeActions passed out of the adapter.

Filter was moved to `mainThreadLanguageFeatures.ts` where `CodeActionProviderMetadata.providedKinds` can be leveraged. We now return undefined if the following check evaluates to true:
- trigger type is Automatic `&&`
- document model is a vscode-notebook-cell `&&`
- metadata.providedKinds ONLY contains `notebook.` kinds