### PR TITLE
organize imports setting enabled for vscode repo

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -150,4 +150,7 @@
 	"editor.experimental.asyncTokenization": true,
 	"editor.experimental.asyncTokenizationVerification": true,
 	"diffEditor.experimental.useVersion2": true,
+	"editor.codeActionsOnSave": {
+		"source.organizeImports": true,
+	}
 }


### PR DESCRIPTION
it will control how the editor automatically organizes and sorts import statements and also help remove unused imports.