### PR TITLE
Restore sinon sandbox

### DIFF
--- a/src/vs/platform/telemetry/test/browser/telemetryService.test.ts
+++ b/src/vs/platform/telemetry/test/browser/telemetryService.test.ts
@@ -292,6 +292,7 @@ suite('TelemetryService', () => {
 
 		errorTelemetry.dispose();
 		service.dispose();
+		sinon.restore();
 	}));
 
 	test('Error Telemetry removes PII from filename with spaces', sinonTestFn(function (this: any) {
@@ -314,6 +315,7 @@ suite('TelemetryService', () => {
 
 		errorTelemetry.dispose();
 		service.dispose();
+		sinon.restore();
 	}));
 
 	test('Uncaught Error Telemetry removes PII from filename', sinonTestFn(function (this: any) {
@@ -342,6 +344,7 @@ suite('TelemetryService', () => {
 
 		errorTelemetry.dispose();
 		service.dispose();
+		sinon.restore();
 	}));
 
 	test('Unexpected Error Telemetry removes PII', sinonTestFn(function (this: any) {
@@ -398,6 +401,7 @@ suite('TelemetryService', () => {
 
 		errorTelemetry.dispose();
 		service.dispose();
+		sinon.restore();
 	}));
 
 	test('Unexpected Error Telemetry removes PII but preserves Code file path', sinonTestFn(function (this: any) {
@@ -465,6 +469,7 @@ suite('TelemetryService', () => {
 
 		errorTelemetry.dispose();
 		service.dispose();
+		sinon.restore();
 	}));
 
 	test('Unexpected Error Telemetry removes PII but preserves Code file path with node modules', sinonTestFn(function (this: any) {
@@ -559,6 +564,7 @@ suite('TelemetryService', () => {
 
 		errorTelemetry.dispose();
 		service.dispose();
+		sinon.restore();
 	}));
 
 	test('Unexpected Error Telemetry removes PII but preserves Missing Model error message', sinonTestFn(function (this: any) {
@@ -623,6 +629,7 @@ suite('TelemetryService', () => {
 
 		errorTelemetry.dispose();
 		service.dispose();
+		sinon.restore();
 	}));
 
 	test('Unexpected Error Telemetry removes PII but preserves No Such File error message', sinonTestFn(function (this: any) {
@@ -692,6 +699,7 @@ suite('TelemetryService', () => {
 
 			errorTelemetry.dispose();
 			service.dispose();
+			sinon.restore();
 		} finally {
 			Errors.setUnexpectedErrorHandler(origErrorHandler);
 		}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
Fixes #187471

I couldn't figure out how to get `afterEach` to work in this context so I called restore at the end of each test using a stub. Similar to how service disposal is handled.