### PR TITLE
Allowing extension to specify the position where inline chat should appear 

### DIFF
--- a/src/vs/workbench/api/common/extHostInlineChat.ts
+++ b/src/vs/workbench/api/common/extHostInlineChat.ts
@@ -17,6 +17,7 @@ import * as extHostTypes from 'vs/workbench/api/common/extHostTypes';
 import type * as vscode from 'vscode';
 import { ApiCommand, ApiCommandArgument, ApiCommandResult, ExtHostCommands } from 'vs/workbench/api/common/extHostCommands';
 import { IRange } from 'vs/editor/common/core/range';
+import { IPosition } from 'vs/editor/common/core/position';
 
 class ProviderWrapper {
 
@@ -59,12 +60,14 @@ export class ExtHostInteractiveEditor implements ExtHostInlineChatShape {
 			initialRange?: vscode.Range;
 			message?: string;
 			autoSend?: boolean;
+			position?: vscode.Position;
 		};
 
 		type InteractiveEditorRunOptions = {
 			initialRange?: IRange;
 			message?: string;
 			autoSend?: boolean;
+			position?: IPosition;
 		};
 
 		extHostCommands.registerApiCommand(new ApiCommand(
@@ -78,7 +81,8 @@ export class ExtHostInteractiveEditor implements ExtHostInlineChatShape {
 				return {
 					initialRange: v.initialRange ? typeConvert.Range.from(v.initialRange) : undefined,
 					message: v.message,
-					autoSend: v.autoSend
+					autoSend: v.autoSend,
+					position: v.position ? typeConvert.Position.from(v.position) : undefined,
 				};
 			})],
 			ApiCommandResult.Void

--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatActions.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatActions.ts
@@ -56,7 +56,7 @@ export class StartSessionAction extends EditorAction2 {
 			typeof message !== 'undefined' && typeof message !== 'string'
 			|| typeof autoSend !== 'undefined' && typeof autoSend !== 'boolean'
 			|| typeof initialRange !== 'undefined' && !Range.isIRange(initialRange)
-			|| typeof position !== 'undefined' && typeof !Position.isIPosition(position)) {
+			|| typeof position !== 'undefined' && !Position.isIPosition(position)) {
 			return false;
 		}
 		return true;
@@ -68,7 +68,6 @@ export class StartSessionAction extends EditorAction2 {
 		if (arg && this._isInteractivEditorOptions(arg)) {
 			options = arg;
 		}
-		console.log('options inside of run editor command : ', options);
 		InlineChatController.get(editor)?.run(options);
 	}
 }

--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatActions.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatActions.ts
@@ -29,6 +29,7 @@ import { CONTEXT_ACCESSIBILITY_MODE_ENABLED } from 'vs/platform/accessibility/co
 import { AccessibilityHelpAction } from 'vs/workbench/contrib/accessibility/browser/accessibilityContribution';
 import { Disposable } from 'vs/base/common/lifecycle';
 import { CommandsRegistry } from 'vs/platform/commands/common/commands';
+import { Position } from 'vs/editor/common/core/position';
 
 CommandsRegistry.registerCommandAlias('interactiveEditor.start', 'inlineChat.start');
 
@@ -50,11 +51,12 @@ export class StartSessionAction extends EditorAction2 {
 	}
 
 	private _isInteractivEditorOptions(options: any): options is InlineChatRunOptions {
-		const { initialRange, message, autoSend } = options;
+		const { initialRange, message, autoSend, position } = options;
 		if (
 			typeof message !== 'undefined' && typeof message !== 'string'
 			|| typeof autoSend !== 'undefined' && typeof autoSend !== 'boolean'
-			|| typeof initialRange !== 'undefined' && !Range.isIRange(initialRange)) {
+			|| typeof initialRange !== 'undefined' && !Range.isIRange(initialRange)
+			|| typeof position !== 'undefined' && typeof !Position.isIPosition(position)) {
 			return false;
 		}
 		return true;
@@ -66,6 +68,7 @@ export class StartSessionAction extends EditorAction2 {
 		if (arg && this._isInteractivEditorOptions(arg)) {
 			options = arg;
 		}
+		console.log('options inside of run editor command : ', options);
 		InlineChatController.get(editor)?.run(options);
 	}
 }

--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatController.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatController.ts
@@ -185,8 +185,6 @@ export class InlineChatController implements IEditorContribution {
 
 	// ---- state machine
 
-	// TODO: maybe should instead use the position inside of the line number?
-	// Makes the code more difficult but more coherent
 	private _showWidget(initialRender: boolean = false, position?: IPosition) {
 		assertType(this._editor.hasModel());
 
@@ -222,7 +220,6 @@ export class InlineChatController implements IEditorContribution {
 
 		let session: Session | undefined = options.existingSession;
 
-		console.log('options : ', options);
 		this._showWidget(true, options.position);
 		this._zone.value.widget.updateInfo(localize('welcome.1', "AI-generated code may be incorrect"));
 		this._zone.value.widget.placeholder = this._getPlaceholderText();
@@ -311,7 +308,6 @@ export class InlineChatController implements IEditorContribution {
 			}
 		});
 
-		console.log('options : ', options);
 		this._showWidget(true, options.position);
 
 		this._sessionStore.add(this._editor.onDidChangeModel((e) => {

--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatController.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatController.ts
@@ -14,7 +14,7 @@ import { StopWatch } from 'vs/base/common/stopwatch';
 import { assertType } from 'vs/base/common/types';
 import { ICodeEditor } from 'vs/editor/browser/editorBrowser';
 import { EditOperation } from 'vs/editor/common/core/editOperation';
-import { Position } from 'vs/editor/common/core/position';
+import { IPosition, Position } from 'vs/editor/common/core/position';
 import { IRange, Range } from 'vs/editor/common/core/range';
 import { IEditorContribution, ScrollType } from 'vs/editor/common/editorCommon';
 import { ModelDecorationOptions, createTextBufferFactoryFromSnapshot } from 'vs/editor/common/model/textModel';
@@ -66,6 +66,7 @@ export interface InlineChatRunOptions {
 	autoSend?: boolean;
 	existingSession?: Session;
 	isUnstashed?: boolean;
+	position?: IPosition;
 }
 
 export class InlineChatController implements IEditorContribution {
@@ -184,12 +185,14 @@ export class InlineChatController implements IEditorContribution {
 
 	// ---- state machine
 
-	private _showWidget(initialRender: boolean = false) {
+	// TODO: maybe should instead use the position inside of the line number?
+	// Makes the code more difficult but more coherent
+	private _showWidget(initialRender: boolean = false, position?: IPosition) {
 		assertType(this._editor.hasModel());
 
 		let widgetPosition: Position;
 		if (initialRender) {
-			widgetPosition = this._editor.getSelection().getEndPosition();
+			widgetPosition = position ? Position.lift(position) : this._editor.getSelection().getEndPosition();
 			this._zone.value.setContainerMargins();
 			this._zone.value.setWidgetMargins(widgetPosition);
 		} else {
@@ -219,7 +222,8 @@ export class InlineChatController implements IEditorContribution {
 
 		let session: Session | undefined = options.existingSession;
 
-		this._showWidget(true);
+		console.log('options : ', options);
+		this._showWidget(true, options.position);
 		this._zone.value.widget.updateInfo(localize('welcome.1', "AI-generated code may be incorrect"));
 		this._zone.value.widget.placeholder = this._getPlaceholderText();
 
@@ -307,7 +311,8 @@ export class InlineChatController implements IEditorContribution {
 			}
 		});
 
-		this._showWidget(true);
+		console.log('options : ', options);
+		this._showWidget(true, options.position);
 
 		this._sessionStore.add(this._editor.onDidChangeModel((e) => {
 			const msg = this._activeSession?.lastExchange


### PR DESCRIPTION
Part of the fix for https://github.com/microsoft/vscode-copilot/issues/447

Second part of the fix: https://github.com/microsoft/vscode-copilot/pull/659

This PR adds code in order to allow extension calls to `vscode.editorChat.start` to specify the position at which the inline chat should appear. 