### PR TITLE
Dispose instances of test instantiation service

### DIFF
--- a/src/vs/editor/test/browser/testCodeEditor.ts
+++ b/src/vs/editor/test/browser/testCodeEditor.ts
@@ -201,7 +201,7 @@ export function createCodeEditorServices(disposables: DisposableStore, services:
 	define(ILanguageFeatureDebounceService, LanguageFeatureDebounceService);
 	define(ILanguageFeaturesService, LanguageFeaturesService);
 
-	const instantiationService = new TestInstantiationService(services, true);
+	const instantiationService = disposables.add(new TestInstantiationService(services, true));
 	disposables.add(toDisposable(() => {
 		for (const id of serviceIdentifiers) {
 			const instanceOrDescriptor = services.get(id);

--- a/src/vs/editor/test/common/services/textResourceConfigurationService.test.ts
+++ b/src/vs/editor/test/common/services/textResourceConfigurationService.test.ts
@@ -15,6 +15,7 @@ import { URI } from 'vs/base/common/uri';
 
 suite('TextResourceConfigurationService - Update', () => {
 
+	let instantiationService: TestInstantiationService;
 	let configurationValue: IConfigurationValue<any> = {};
 	let updateArgs: any[];
 	const configurationService = new class extends TestConfigurationService {
@@ -30,11 +31,15 @@ suite('TextResourceConfigurationService - Update', () => {
 	let testObject: TextResourceConfigurationService;
 
 	setup(() => {
-		const instantiationService = new TestInstantiationService();
+		instantiationService = new TestInstantiationService();
 		instantiationService.stub(IModelService, <Partial<IModelService>>{ getModel() { return null; } });
 		instantiationService.stub(ILanguageService, <Partial<ILanguageService>>{ guessLanguageIdByFilepathOrFirstLine() { return language; } });
 		instantiationService.stub(IConfigurationService, configurationService);
 		testObject = instantiationService.createInstance(TextResourceConfigurationService);
+	});
+
+	teardown(() => {
+		instantiationService.dispose();
 	});
 
 	test('updateValue writes without target and overrides when no language is defined', async () => {

--- a/src/vs/platform/contextkey/test/browser/contextkey.test.ts
+++ b/src/vs/platform/contextkey/test/browser/contextkey.test.ts
@@ -83,7 +83,7 @@ suite('ContextKeyService', () => {
 		const disposables = new DisposableStore();
 		const configurationService: IConfigurationService = new TestConfigurationService();
 		const contextKeyService: IContextKeyService = disposables.add(new ContextKeyService(configurationService));
-		const instantiationService = new TestInstantiationService(new ServiceCollection(
+		const instantiationService = disposables.add(new TestInstantiationService(new ServiceCollection(
 			[IConfigurationService, configurationService],
 			[IContextKeyService, contextKeyService],
 			[ITelemetryService, new class extends mock<ITelemetryService>() {
@@ -91,7 +91,7 @@ suite('ContextKeyService', () => {
 					//
 				}
 			}]
-		));
+		)));
 
 		const uri = URI.parse('test://abc');
 		contextKeyService.createKey<string>('notebookCellResource', undefined).set(uri.toString());
@@ -99,6 +99,7 @@ suite('ContextKeyService', () => {
 
 		const expr = ContextKeyExpr.in('notebookCellResource', 'jupyter.runByLineCells');
 		assert.deepStrictEqual(contextKeyService.contextMatchesRules(expr), true);
+		disposables.dispose();
 	});
 
 	test('suppress update event from parent when one key is overridden by child', () => {

--- a/src/vs/platform/extensionManagement/test/common/extensionsProfileScannerService.test.ts
+++ b/src/vs/platform/extensionManagement/test/common/extensionsProfileScannerService.test.ts
@@ -33,7 +33,7 @@ suite('ExtensionsProfileScannerService', () => {
 	let instantiationService: TestInstantiationService;
 
 	setup(async () => {
-		instantiationService = new TestInstantiationService();
+		instantiationService = disposables.add(new TestInstantiationService());
 		const logService = new NullLogService();
 		const fileService = disposables.add(new FileService(logService));
 		const fileSystemProvider = disposables.add(new InMemoryFileSystemProvider());

--- a/src/vs/platform/extensionManagement/test/node/extensionsScannerService.test.ts
+++ b/src/vs/platform/extensionManagement/test/node/extensionsScannerService.test.ts
@@ -60,7 +60,7 @@ suite('NativeExtensionsScanerService Test', () => {
 
 	setup(async () => {
 		translations = {};
-		instantiationService = new TestInstantiationService();
+		instantiationService = disposables.add(new TestInstantiationService());
 		const logService = new NullLogService();
 		const fileService = disposables.add(new FileService(logService));
 		const fileSystemProvider = disposables.add(new InMemoryFileSystemProvider());

--- a/src/vs/platform/instantiation/test/common/instantiationServiceMock.ts
+++ b/src/vs/platform/instantiation/test/common/instantiationServiceMock.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as sinon from 'sinon';
-import { DisposableStore, toDisposable } from 'vs/base/common/lifecycle';
+import { DisposableStore, IDisposable, toDisposable } from 'vs/base/common/lifecycle';
 import { SyncDescriptor } from 'vs/platform/instantiation/common/descriptors';
 import { ServiceIdentifier } from 'vs/platform/instantiation/common/instantiation';
 import { InstantiationService, Trace } from 'vs/platform/instantiation/common/instantiationService';
@@ -17,7 +17,7 @@ interface IServiceMock<T> {
 
 const isSinonSpyLike = (fn: Function): fn is sinon.SinonSpy => fn && 'callCount' in fn;
 
-export class TestInstantiationService extends InstantiationService {
+export class TestInstantiationService extends InstantiationService implements IDisposable {
 
 	private _servciesMap: Map<ServiceIdentifier<any>, any>;
 
@@ -129,6 +129,10 @@ export class TestInstantiationService extends InstantiationService {
 	override createChild(services: ServiceCollection): TestInstantiationService {
 		return new TestInstantiationService(services, false, this);
 	}
+
+	dispose() {
+		sinon.restore();
+	}
 }
 
 interface SinonOptions {
@@ -157,7 +161,7 @@ export function createServices(disposables: DisposableStore, services: ServiceId
 		define(id, ctor);
 	}
 
-	const instantiationService = new TestInstantiationService(serviceCollection, true);
+	const instantiationService = disposables.add(new TestInstantiationService(serviceCollection, true));
 	disposables.add(toDisposable(() => {
 		for (const id of serviceIdentifiers) {
 			const instanceOrDescriptor = serviceCollection.get(id);

--- a/src/vs/platform/telemetry/test/common/telemetryLogAppender.test.ts
+++ b/src/vs/platform/telemetry/test/common/telemetryLogAppender.test.ts
@@ -93,6 +93,7 @@ suite('TelemetryLogAdapter', () => {
 		const testObject = new TelemetryLogAppender(new NullLogService(), testLoggerService, testInstantiationService.stub(IEnvironmentService, {}), testInstantiationService.stub(IProductService, {}));
 		testObject.log('testEvent', { hello: 'world', isTrue: true, numberBetween1And3: 2 });
 		assert.strictEqual(testLoggerService.createLogger().logs.length, 2);
+		testInstantiationService.dispose();
 	});
 
 	test('Log Telemetry if log level is trace', async () => {
@@ -108,5 +109,6 @@ suite('TelemetryLogAdapter', () => {
 				isTrue: 1, numberBetween1And3: 2
 			}
 		}]));
+		testInstantiationService.dispose();
 	});
 });

--- a/src/vs/platform/terminal/test/common/requestStore.test.ts
+++ b/src/vs/platform/terminal/test/common/requestStore.test.ts
@@ -17,6 +17,10 @@ suite('RequestStore', () => {
 		instantiationService.stub(ILogService, new LogService(new ConsoleLogger()));
 	});
 
+	teardown(() => {
+		instantiationService.dispose();
+	});
+
 	test('should resolve requests', async () => {
 		const store: RequestStore<{ data: string }, { arg: string }> = instantiationService.createInstance(RequestStore<{ data: string }, { arg: string }>, undefined);
 		let eventArgs: { requestId: number; arg: string } | undefined;

--- a/src/vs/workbench/api/test/browser/extHostAuthentication.test.ts
+++ b/src/vs/workbench/api/test/browser/extHostAuthentication.test.ts
@@ -127,6 +127,10 @@ suite('ExtHostAuthentication', () => {
 			{ supportsMultipleAccounts: true }));
 	});
 
+	suiteTeardown(() => {
+		instantiationService.dispose();
+	});
+
 	teardown(() => {
 		disposables.dispose();
 	});

--- a/src/vs/workbench/api/test/browser/extHostLanguageFeatures.test.ts
+++ b/src/vs/workbench/api/test/browser/extHostLanguageFeatures.test.ts
@@ -67,6 +67,7 @@ suite('ExtHostLanguageFeatures', function () {
 	let rpcProtocol: TestRPCProtocol;
 	let languageFeaturesService: ILanguageFeaturesService;
 	let originalErrorHandler: (e: any) => any;
+	let instantiationService: TestInstantiationService;
 
 	suiteSetup(() => {
 
@@ -87,7 +88,7 @@ suite('ExtHostLanguageFeatures', function () {
 		// Use IInstantiationService to get typechecking when instantiating
 		let inst: IInstantiationService;
 		{
-			const instantiationService = new TestInstantiationService();
+			instantiationService = new TestInstantiationService();
 			instantiationService.stub(IMarkerService, MarkerService);
 			instantiationService.set(ILanguageFeaturesService, languageFeaturesService);
 			instantiationService.set(IUriIdentityService, new class extends mock<IUriIdentityService>() {
@@ -140,6 +141,7 @@ suite('ExtHostLanguageFeatures', function () {
 		setUnexpectedErrorHandler(originalErrorHandler);
 		model.dispose();
 		mainThread.dispose();
+		instantiationService.dispose();
 	});
 
 	teardown(() => {

--- a/src/vs/workbench/api/test/browser/extHostTreeViews.test.ts
+++ b/src/vs/workbench/api/test/browser/extHostTreeViews.test.ts
@@ -50,6 +50,7 @@ suite('ExtHostTreeView', function () {
 	let tree: { [key: string]: any };
 	let labels: { [key: string]: string };
 	let nodes: { [key: string]: { key: string } };
+	let instantiationService: TestInstantiationService;
 
 	setup(() => {
 		tree = {
@@ -70,7 +71,7 @@ suite('ExtHostTreeView', function () {
 		// Use IInstantiationService to get typechecking when instantiating
 		let inst: IInstantiationService;
 		{
-			const instantiationService = new TestInstantiationService();
+			instantiationService = new TestInstantiationService();
 			inst = instantiationService;
 		}
 
@@ -92,6 +93,10 @@ suite('ExtHostTreeView', function () {
 		testObject.createTreeView('testNodeWithHighlightsTreeProvider', { treeDataProvider: aNodeWithHighlightedLabelTreeDataProvider() }, extensionsDescription);
 
 		return loadCompleteTree('testNodeTreeProvider');
+	});
+
+	teardown(() => {
+		instantiationService.dispose();
 	});
 
 	test('construct node tree', () => {

--- a/src/vs/workbench/api/test/browser/mainThreadConfiguration.test.ts
+++ b/src/vs/workbench/api/test/browser/mainThreadConfiguration.test.ts
@@ -59,6 +59,10 @@ suite('MainThreadConfiguration', function () {
 		});
 	});
 
+	teardown(() => {
+		instantiationService.dispose();
+	});
+
 	test('update resource configuration without configuration target defaults to workspace in multi root workspace when no resource is provided', function () {
 		instantiationService.stub(IWorkspaceContextService, <IWorkspaceContextService>{ getWorkbenchState: () => WorkbenchState.WORKSPACE });
 		const testObject: MainThreadConfiguration = instantiationService.createInstance(MainThreadConfiguration, SingleProxyRPCProtocol(proxy));

--- a/src/vs/workbench/contrib/chat/test/common/chatModel.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/chatModel.test.ts
@@ -19,7 +19,7 @@ suite('ChatModel', () => {
 	let instantiationService: TestInstantiationService;
 
 	suiteSetup(async () => {
-		instantiationService = new TestInstantiationService();
+		instantiationService = testDisposables.add(new TestInstantiationService());
 		instantiationService.stub(IStorageService, new TestStorageService());
 		instantiationService.stub(ILogService, new NullLogService());
 		instantiationService.stub(IExtensionService, new TestExtensionService());

--- a/src/vs/workbench/contrib/chat/test/common/chatService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/chatService.test.ts
@@ -71,6 +71,10 @@ suite('Chat', () => {
 		instantiationService.stub(IWorkspaceContextService, new TestContextService());
 	});
 
+	suiteTeardown(() => {
+		instantiationService.dispose();
+	});
+
 	teardown(() => {
 		testDisposables.clear();
 	});

--- a/src/vs/workbench/contrib/debug/test/browser/breakpoints.test.ts
+++ b/src/vs/workbench/contrib/debug/test/browser/breakpoints.test.ts
@@ -430,5 +430,6 @@ suite('Debug - Breakpoints', () => {
 		assert.strictEqual(decorations[0].options.overviewRuler, null);
 
 		textModel.dispose();
+		instantiationService.dispose();
 	});
 });

--- a/src/vs/workbench/contrib/debug/test/browser/debugConfigurationManager.test.ts
+++ b/src/vs/workbench/contrib/debug/test/browser/debugConfigurationManager.test.ts
@@ -48,12 +48,13 @@ suite('debugConfigurationManager', () => {
 	const configurationService = new TestConfigurationService();
 	setup(() => {
 		const fileService = disposables.add(new FileService(new NullLogService()));
+		const instantiationService = disposables.add(new TestInstantiationService(new ServiceCollection([IPreferencesService, preferencesService], [IConfigurationService, configurationService])));
 		_debugConfigurationManager = new ConfigurationManager(
 			adapterManager,
 			new TestContextService(),
 			configurationService,
 			new TestQuickInputService(),
-			new TestInstantiationService(new ServiceCollection([IPreferencesService, preferencesService], [IConfigurationService, configurationService])),
+			instantiationService,
 			new TestStorageService(),
 			new TestExtensionService(),
 			new TestHistoryService(),

--- a/src/vs/workbench/contrib/extensions/test/electron-sandbox/extension.test.ts
+++ b/src/vs/workbench/contrib/extensions/test/electron-sandbox/extension.test.ts
@@ -23,6 +23,10 @@ suite('Extension Test', () => {
 		instantiationService.stub(IProductService, <Partial<IProductService>>{ quality: 'insiders' });
 	});
 
+	teardown(() => {
+		instantiationService.dispose();
+	});
+
 	test('extension is not outdated when there is no local and gallery', () => {
 		const extension = instantiationService.createInstance(Extension, () => ExtensionState.Installed, () => undefined, undefined, undefined, undefined);
 		assert.strictEqual(extension.outdated, false);

--- a/src/vs/workbench/contrib/extensions/test/electron-sandbox/extensionRecommendationsService.test.ts
+++ b/src/vs/workbench/contrib/extensions/test/electron-sandbox/extensionRecommendationsService.test.ts
@@ -309,6 +309,10 @@ suite('ExtensionRecommendationsService Test', () => {
 
 	teardown(() => (<ExtensionRecommendationsService>testObject).dispose());
 
+	suiteTeardown(() => {
+		instantiationService.dispose();
+	});
+
 	function setUpFolderWorkspace(folderName: string, recommendedExtensions: string[], ignoredRecommendations: string[] = []): Promise<void> {
 		return setUpFolder(folderName, recommendedExtensions, ignoredRecommendations);
 	}

--- a/src/vs/workbench/contrib/extensions/test/electron-sandbox/extensionsActions.test.ts
+++ b/src/vs/workbench/contrib/extensions/test/electron-sandbox/extensionsActions.test.ts
@@ -72,7 +72,7 @@ function setupTest() {
 	uninstallEvent = new Emitter<UninstallExtensionEvent>();
 	didUninstallEvent = new Emitter<DidUninstallExtensionEvent>();
 
-	instantiationService = new TestInstantiationService();
+	instantiationService = disposables.add(new TestInstantiationService());
 
 	instantiationService.stub(IEnvironmentService, TestEnvironmentService);
 	instantiationService.stub(IWorkbenchEnvironmentService, TestEnvironmentService);

--- a/src/vs/workbench/contrib/extensions/test/electron-sandbox/extensionsViews.test.ts
+++ b/src/vs/workbench/contrib/extensions/test/electron-sandbox/extensionsViews.test.ts
@@ -204,6 +204,10 @@ suite('ExtensionsViews Tests', () => {
 		testableView.dispose();
 	});
 
+	suiteTeardown(() => {
+		instantiationService.dispose();
+	});
+
 	test('Test query types', () => {
 		assert.strictEqual(ExtensionsListView.isBuiltInExtensionsQuery('@builtin'), true);
 		assert.strictEqual(ExtensionsListView.isLocalExtensionsQuery('@installed'), true);

--- a/src/vs/workbench/contrib/extensions/test/electron-sandbox/extensionsWorkbenchService.test.ts
+++ b/src/vs/workbench/contrib/extensions/test/electron-sandbox/extensionsWorkbenchService.test.ts
@@ -135,7 +135,7 @@ suite('ExtensionsWorkbenchServiceTest', () => {
 		(<TestExtensionEnablementService>instantiationService.get(IWorkbenchExtensionEnablementService)).reset();
 	});
 
-	teardown(() => {
+	suiteTeardown(() => {
 		(<ExtensionsWorkbenchService>testObject).dispose();
 	});
 

--- a/src/vs/workbench/contrib/externalUriOpener/test/common/externalUriOpenerService.test.ts
+++ b/src/vs/workbench/contrib/externalUriOpener/test/common/externalUriOpenerService.test.ts
@@ -48,6 +48,10 @@ suite('ExternalUriOpenerService', () => {
 		});
 	});
 
+	teardown(() => {
+		instantiationService.dispose();
+	});
+
 	test('Should not open if there are no openers', async () => {
 		const externalUriOpenerService: ExternalUriOpenerService = instantiationService.createInstance(ExternalUriOpenerService);
 

--- a/src/vs/workbench/contrib/notebook/test/browser/testNotebookEditor.ts
+++ b/src/vs/workbench/contrib/notebook/test/browser/testNotebookEditor.ts
@@ -169,7 +169,7 @@ export class NotebookEditorTestModel extends EditorModel implements INotebookEdi
 }
 
 export function setupInstantiationService(disposables = new DisposableStore()) {
-	const instantiationService = new TestInstantiationService();
+	const instantiationService = disposables.add(new TestInstantiationService());
 	instantiationService.stub(ILanguageService, disposables.add(new LanguageService()));
 	instantiationService.stub(IUndoRedoService, instantiationService.createInstance(UndoRedoService));
 	instantiationService.stub(IConfigurationService, new TestConfigurationService());

--- a/src/vs/workbench/contrib/search/test/browser/searchActions.test.ts
+++ b/src/vs/workbench/contrib/search/test/browser/searchActions.test.ts
@@ -36,6 +36,10 @@ suite('Search Actions', () => {
 		counter = 0;
 	});
 
+	teardown(() => {
+		instantiationService.dispose();
+	});
+
 	test('get next element to focus after removing a match when it has next sibling file', function () {
 		const fileMatch1 = aFileMatch();
 		const fileMatch2 = aFileMatch();

--- a/src/vs/workbench/contrib/search/test/browser/searchNotebookHelpers.test.ts
+++ b/src/vs/workbench/contrib/search/test/browser/searchNotebookHelpers.test.ts
@@ -115,6 +115,11 @@ suite('searchNotebookHelpers', () => {
 		);
 
 	});
+
+	teardown(() => {
+		instantiationService.dispose();
+	});
+
 	suite('notebookEditorMatchesToTextSearchResults', () => {
 
 		function assertRangesEqual(actual: ISearchRange | ISearchRange[], expected: ISearchRange[]) {

--- a/src/vs/workbench/contrib/search/test/browser/searchResult.test.ts
+++ b/src/vs/workbench/contrib/search/test/browser/searchResult.test.ts
@@ -51,7 +51,9 @@ suite('SearchResult', () => {
 		instantiationService.stub(ILogService, new NullLogService());
 	});
 
-	teardown(() => sinon.restore());
+	teardown(() => {
+		instantiationService.dispose();
+	});
 
 	test('Line Match', function () {
 		const fileMatch = aFileMatch('folder/file.txt', null!);

--- a/src/vs/workbench/contrib/search/test/browser/searchViewlet.test.ts
+++ b/src/vs/workbench/contrib/search/test/browser/searchViewlet.test.ts
@@ -45,6 +45,10 @@ suite('Search - Viewlet', () => {
 		instantiation.stub(ILogService, new NullLogService());
 	});
 
+	teardown(() => {
+		instantiation.dispose();
+	});
+
 	test('Data Source', function () {
 		const result: SearchResult = aSearchResult();
 		result.query = {

--- a/src/vs/workbench/contrib/tasks/test/browser/taskTerminalStatus.test.ts
+++ b/src/vs/workbench/contrib/tasks/test/browser/taskTerminalStatus.test.ts
@@ -76,6 +76,9 @@ suite('Task Terminal Status', () => {
 		testTask = instantiationService.createInstance(TestTask) as unknown as Task;
 		problemCollector = instantiationService.createInstance(TestProblemCollector) as any;
 	});
+	teardown(() => {
+		instantiationService.dispose();
+	});
 	test('Should add failed status when there is an exit code on task end', async () => {
 		taskTerminalStatus.addTerminal(testTask, testTerminal, problemCollector);
 		taskService.triggerStateChange({ kind: TaskEventKind.ProcessStarted });

--- a/src/vs/workbench/contrib/tasks/test/common/taskConfiguration.test.ts
+++ b/src/vs/workbench/contrib/tasks/test/common/taskConfiguration.test.ts
@@ -1802,6 +1802,9 @@ suite('Task configuration conversions', () => {
 		parseContext.namedProblemMatchers = { 'real': namedProblemMatcher };
 		parseContext.uuidMap = new UUIDMap();
 	});
+	teardown(() => {
+		instantiationService.dispose();
+	});
 	suite('ProblemMatcherConverter.from', () => {
 		test('returns [] and an error for an unknown problem matcher', () => {
 			const result = (ProblemMatcherConverter.from('$fake', parseContext));

--- a/src/vs/workbench/contrib/terminal/test/browser/capabilities/commandDetectionCapability.test.ts
+++ b/src/vs/workbench/contrib/terminal/test/browser/capabilities/commandDetectionCapability.test.ts
@@ -26,6 +26,7 @@ suite('CommandDetectionCapability', () => {
 	let xterm: Terminal;
 	let capability: TestCommandDetectionCapability;
 	let addEvents: ITerminalCommand[];
+	let instantiationService: TestInstantiationService;
 
 	function assertCommands(expectedCommands: TestTerminalCommandMatch[]) {
 		deepStrictEqual(capability.commands.map(e => e.command), expectedCommands.map(e => e.command));
@@ -59,12 +60,16 @@ suite('CommandDetectionCapability', () => {
 		const TerminalCtor = (await importAMDNodeModule<typeof import('xterm')>('xterm', 'lib/xterm.js')).Terminal;
 
 		xterm = new TerminalCtor({ allowProposedApi: true, cols: 80 });
-		const instantiationService = new TestInstantiationService();
+		instantiationService = new TestInstantiationService();
 		instantiationService.stub(IContextMenuService, { showContextMenu(delegate: IContextMenuDelegate): void { } } as Partial<IContextMenuService>);
 		capability = new TestCommandDetectionCapability(xterm, new NullLogService());
 		addEvents = [];
 		capability.onCommandFinished(e => addEvents.push(e));
 		assertCommands([]);
+	});
+
+	teardown(() => {
+		instantiationService.dispose();
 	});
 
 	test('should not add commands when no capability methods are triggered', async () => {

--- a/src/vs/workbench/contrib/terminal/test/browser/terminalInstance.test.ts
+++ b/src/vs/workbench/contrib/terminal/test/browser/terminalInstance.test.ts
@@ -190,6 +190,10 @@ suite('Workbench - TerminalInstance', () => {
 			emptyContextService.setWorkspace(emptyWorkspace);
 		});
 
+		teardown(() => {
+			instantiationService.dispose();
+		});
+
 		test('should resolve to "" when the template variables are empty', () => {
 			configurationService = new TestConfigurationService({ terminal: { integrated: { tabs: { separator: ' - ', title: '', description: '' } } } });
 			configHelper = new TerminalConfigHelper(configurationService, null!, null!, null!, null!);

--- a/src/vs/workbench/contrib/terminal/test/browser/terminalInstanceService.test.ts
+++ b/src/vs/workbench/contrib/terminal/test/browser/terminalInstanceService.test.ts
@@ -36,6 +36,10 @@ suite('Workbench - TerminalInstanceService', () => {
 		terminalInstanceService = instantiationService.createInstance(TerminalInstanceService);
 	});
 
+	teardown(() => {
+		instantiationService.dispose();
+	});
+
 	suite('convertProfileToShellLaunchConfig', () => {
 		test('should return an empty shell launch config when undefined is provided', () => {
 			deepStrictEqual(terminalInstanceService.convertProfileToShellLaunchConfig(), {});

--- a/src/vs/workbench/contrib/terminal/test/browser/terminalProfileService.integrationTest.ts
+++ b/src/vs/workbench/contrib/terminal/test/browser/terminalProfileService.integrationTest.ts
@@ -201,6 +201,9 @@ suite('TerminalProfileService', () => {
 		}
 		configurationService.setUserConfiguration('terminal', { integrated: defaultTerminalConfig });
 	});
+	teardown(() => {
+		instantiationService.dispose();
+	});
 	suite('Contributed Profiles', () => {
 		test('should filter out contributed profiles set to null (Linux)', async () => {
 			remoteAgentService.setEnvironment(OperatingSystem.Linux);

--- a/src/vs/workbench/contrib/terminal/test/browser/terminalService.test.ts
+++ b/src/vs/workbench/contrib/terminal/test/browser/terminalService.test.ts
@@ -57,6 +57,10 @@ suite('Workbench - TerminalService', () => {
 		instantiationService.stub(ITerminalService, terminalService);
 	});
 
+	teardown(() => {
+		instantiationService.dispose();
+	});
+
 	suite('safeDisposeTerminal', () => {
 		let onExitEmitter: Emitter<number | undefined>;
 

--- a/src/vs/workbench/contrib/terminal/test/browser/xterm/decorationAddon.test.ts
+++ b/src/vs/workbench/contrib/terminal/test/browser/xterm/decorationAddon.test.ts
@@ -22,23 +22,22 @@ import { TestLifecycleService } from 'vs/workbench/test/browser/workbenchTestSer
 import { importAMDNodeModule } from 'vs/amdX';
 
 suite('DecorationAddon', async () => {
-
-	const TerminalCtor = (await importAMDNodeModule<typeof import('xterm')>('xterm', 'lib/xterm.js')).Terminal;
-	class TestTerminal extends TerminalCtor {
-		override registerDecoration(decorationOptions: IDecorationOptions): IDecoration | undefined {
-			if (decorationOptions.marker.isDisposed) {
-				return undefined;
-			}
-			const element = document.createElement('div');
-			return { marker: decorationOptions.marker, element, onDispose: () => { }, isDisposed: false, dispose: () => { }, onRender: (element: HTMLElement) => { return element; } } as unknown as IDecoration;
-		}
-	}
-
 	let decorationAddon: DecorationAddon;
-	let xterm: TestTerminal;
+	let xterm: any;
 	let instantiationService: TestInstantiationService;
 
-	setup(() => {
+	setup(async () => {
+		const TerminalCtor = (await importAMDNodeModule<typeof import('xterm')>('xterm', 'lib/xterm.js')).Terminal;
+		class TestTerminal extends TerminalCtor {
+			override registerDecoration(decorationOptions: IDecorationOptions): IDecoration | undefined {
+				if (decorationOptions.marker.isDisposed) {
+					return undefined;
+				}
+				const element = document.createElement('div');
+				return { marker: decorationOptions.marker, element, onDispose: () => { }, isDisposed: false, dispose: () => { }, onRender: (element: HTMLElement) => { return element; } } as unknown as IDecoration;
+			}
+		}
+
 		instantiationService = new TestInstantiationService();
 		const configurationService = new TestConfigurationService({
 			workbench: {

--- a/src/vs/workbench/contrib/terminal/test/browser/xterm/decorationAddon.test.ts
+++ b/src/vs/workbench/contrib/terminal/test/browser/xterm/decorationAddon.test.ts
@@ -21,7 +21,7 @@ import { ILifecycleService } from 'vs/workbench/services/lifecycle/common/lifecy
 import { TestLifecycleService } from 'vs/workbench/test/browser/workbenchTestServices';
 import { importAMDNodeModule } from 'vs/amdX';
 
-suite('DecorationAddon', async () => {
+suite('DecorationAddon', () => {
 	let decorationAddon: DecorationAddon;
 	let xterm: any;
 	let instantiationService: TestInstantiationService;

--- a/src/vs/workbench/contrib/terminal/test/browser/xterm/decorationAddon.test.ts
+++ b/src/vs/workbench/contrib/terminal/test/browser/xterm/decorationAddon.test.ts
@@ -36,9 +36,10 @@ suite('DecorationAddon', async () => {
 
 	let decorationAddon: DecorationAddon;
 	let xterm: TestTerminal;
+	let instantiationService: TestInstantiationService;
 
 	setup(() => {
-		const instantiationService = new TestInstantiationService();
+		instantiationService = new TestInstantiationService();
 		const configurationService = new TestConfigurationService({
 			workbench: {
 				hover: { delay: 5 },
@@ -65,6 +66,10 @@ suite('DecorationAddon', async () => {
 		instantiationService.stub(ILifecycleService, new TestLifecycleService());
 		decorationAddon = instantiationService.createInstance(DecorationAddon, capabilities);
 		xterm.loadAddon(decorationAddon);
+	});
+
+	teardown(() => {
+		instantiationService.dispose();
 	});
 
 	suite('registerDecoration', async () => {

--- a/src/vs/workbench/contrib/terminal/test/browser/xterm/decorationAddon.test.ts
+++ b/src/vs/workbench/contrib/terminal/test/browser/xterm/decorationAddon.test.ts
@@ -10,7 +10,7 @@ import { ILogService, NullLogService } from 'vs/platform/log/common/log';
 import { DecorationAddon } from 'vs/workbench/contrib/terminal/browser/xterm/decorationAddon';
 import { TerminalCapabilityStore } from 'vs/platform/terminal/common/capabilities/terminalCapabilityStore';
 import { TestConfigurationService } from 'vs/platform/configuration/test/common/testConfigurationService';
-import type { IDecoration, IDecorationOptions } from 'xterm';
+import type { IDecoration, IDecorationOptions, Terminal as RawXtermTerminal } from 'xterm';
 import { ITerminalCommand, TerminalCapability } from 'vs/platform/terminal/common/capabilities/capabilities';
 import { CommandDetectionCapability } from 'vs/platform/terminal/common/capabilities/commandDetectionCapability';
 import { IContextMenuService } from 'vs/platform/contextview/browser/contextView';
@@ -23,7 +23,7 @@ import { importAMDNodeModule } from 'vs/amdX';
 
 suite('DecorationAddon', () => {
 	let decorationAddon: DecorationAddon;
-	let xterm: any;
+	let xterm: RawXtermTerminal;
 	let instantiationService: TestInstantiationService;
 
 	setup(async () => {

--- a/src/vs/workbench/contrib/terminal/test/browser/xterm/xtermTerminal.test.ts
+++ b/src/vs/workbench/contrib/terminal/test/browser/xterm/xtermTerminal.test.ts
@@ -132,6 +132,10 @@ suite('XtermTerminal', () => {
 		TestWebglAddon.isEnabled = false;
 	});
 
+	teardown(() => {
+		instantiationService.dispose();
+	});
+
 	test('should use fallback dimensions of 80x30', () => {
 		strictEqual(xterm.raw.cols, 80);
 		strictEqual(xterm.raw.rows, 30);

--- a/src/vs/workbench/contrib/terminal/test/common/environmentVariableService.test.ts
+++ b/src/vs/workbench/contrib/terminal/test/common/environmentVariableService.test.ts
@@ -47,6 +47,10 @@ suite('EnvironmentVariable - EnvironmentVariableService', () => {
 		environmentVariableService = instantiationService.createInstance(TestEnvironmentVariableService);
 	});
 
+	teardown(() => {
+		instantiationService.dispose();
+	});
+
 	test('should persist collections to the storage service and be able to restore from them', () => {
 		const collection = new Map<string, IEnvironmentVariableMutator>();
 		collection.set('A-key', { value: 'a', type: EnvironmentVariableMutatorType.Replace, variable: 'A' });

--- a/src/vs/workbench/contrib/terminal/test/common/history.test.ts
+++ b/src/vs/workbench/contrib/terminal/test/common/history.test.ts
@@ -56,6 +56,10 @@ suite('Terminal history', () => {
 			history = instantiationService.createInstance(TerminalPersistedHistory<number>, 'test');
 		});
 
+		teardown(() => {
+			instantiationService.dispose();
+		});
+
 		test('should support adding items to the cache and respect LRU', () => {
 			history.add('foo', 1);
 			deepStrictEqual(Array.from(history.entries), [
@@ -151,6 +155,10 @@ suite('Terminal history', () => {
 			} as Pick<IRemoteAgentService, 'getConnection' | 'getEnvironment'>);
 		});
 
+		teardown(() => {
+			instantiationService.dispose();
+		});
+
 		if (!isWindows) {
 			suite('local', async () => {
 				let originalEnvValues: { HOME: string | undefined };
@@ -237,6 +245,10 @@ suite('Terminal history', () => {
 				async getEnvironment() { return remoteEnvironment; },
 				getConnection() { return remoteConnection; }
 			} as Pick<IRemoteAgentService, 'getConnection' | 'getEnvironment'>);
+		});
+
+		teardown(() => {
+			instantiationService.dispose();
 		});
 
 		if (!isWindows) {
@@ -326,6 +338,10 @@ suite('Terminal history', () => {
 				async getEnvironment() { return remoteEnvironment; },
 				getConnection() { return remoteConnection; }
 			} as Pick<IRemoteAgentService, 'getConnection' | 'getEnvironment'>);
+		});
+
+		teardown(() => {
+			instantiationService.dispose();
 		});
 
 		suite('local', async () => {
@@ -431,6 +447,10 @@ suite('Terminal history', () => {
 				async getEnvironment() { return remoteEnvironment; },
 				getConnection() { return remoteConnection; }
 			} as Pick<IRemoteAgentService, 'getConnection' | 'getEnvironment'>);
+		});
+
+		teardown(() => {
+			instantiationService.dispose();
 		});
 
 		if (!isWindows) {

--- a/src/vs/workbench/contrib/terminalContrib/accessibility/test/browser/bufferContentTracker.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/accessibility/test/browser/bufferContentTracker.test.ts
@@ -54,7 +54,6 @@ suite('Buffer Content Tracker', () => {
 		configurationService = new TestConfigurationService({ terminal: { integrated: defaultTerminalConfig } });
 		instantiationService = new TestInstantiationService();
 		themeService = new TestThemeService();
-		instantiationService = new TestInstantiationService();
 		instantiationService.stub(IConfigurationService, configurationService);
 		instantiationService.stub(IThemeService, themeService);
 		instantiationService.stub(ITerminalLogService, new NullLogService());
@@ -74,6 +73,9 @@ suite('Buffer Content Tracker', () => {
 		configurationService = new TestConfigurationService({ terminal: { integrated: { tabs: { separator: ' - ', title: '${cwd}', description: '${cwd}' } } } });
 		configHelper = new TerminalConfigHelper(configurationService, null!, null!, null!, null!);
 		bufferTracker = instantiationService.createInstance(BufferContentTracker, xterm);
+	});
+	teardown(() => {
+		instantiationService.dispose();
 	});
 	test('should not clear the prompt line', async () => {
 		assert.strictEqual(bufferTracker.lines.length, 0);

--- a/src/vs/workbench/contrib/terminalContrib/links/test/browser/terminalLinkManager.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/links/test/browser/terminalLinkManager.test.ts
@@ -96,6 +96,10 @@ suite('TerminalLinkManager', () => {
 		} as Partial<ITerminalCapabilityStore> as any, instantiationService.createInstance(TerminalLinkResolver));
 	});
 
+	teardown(() => {
+		instantiationService.dispose();
+	});
+
 	suite('getLinks and open recent link', () => {
 		test('should return no links', async () => {
 			const links = await linkManager.getLinks();

--- a/src/vs/workbench/contrib/terminalContrib/links/test/browser/terminalLinkOpeners.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/links/test/browser/terminalLinkOpeners.test.ts
@@ -113,6 +113,10 @@ suite('Workbench - TerminalLinkOpeners', () => {
 		xterm = new TerminalCtor({ allowProposedApi: true });
 	});
 
+	teardown(() => {
+		instantiationService.dispose();
+	});
+
 	suite('TerminalSearchLinkOpener', () => {
 		let opener: TestTerminalSearchLinkOpener;
 		let capabilities: TerminalCapabilityStore;

--- a/src/vs/workbench/contrib/terminalContrib/links/test/browser/terminalLocalLinkDetector.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/links/test/browser/terminalLocalLinkDetector.test.ts
@@ -192,6 +192,10 @@ suite('Workbench - TerminalLocalLinkDetector', () => {
 		xterm = new TerminalCtor({ allowProposedApi: true, cols: 80, rows: 30 });
 	});
 
+	teardown(() => {
+		instantiationService.dispose();
+	});
+
 	suite('platform independent', () => {
 		setup(() => {
 			detector = instantiationService.createInstance(TerminalLocalLinkDetector, xterm, new TerminalCapabilityStore(), {

--- a/src/vs/workbench/contrib/terminalContrib/links/test/browser/terminalMultiLineLinkDetector.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/links/test/browser/terminalMultiLineLinkDetector.test.ts
@@ -151,6 +151,10 @@ suite('Workbench - TerminalMultiLineLinkDetector', () => {
 		xterm = new TerminalCtor({ allowProposedApi: true, cols: 80, rows: 30 });
 	});
 
+	teardown(() => {
+		instantiationService.dispose();
+	});
+
 	suite('macOS/Linux', () => {
 		setup(() => {
 			detector = instantiationService.createInstance(TerminalMultiLineLinkDetector, xterm, {

--- a/src/vs/workbench/contrib/terminalContrib/links/test/browser/terminalUriLinkDetector.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/links/test/browser/terminalUriLinkDetector.test.ts
@@ -22,9 +22,10 @@ suite('Workbench - TerminalUriLinkDetector', () => {
 	let detector: TerminalUriLinkDetector;
 	let xterm: Terminal;
 	let validResources: URI[] = [];
+	let instantiationService: TestInstantiationService;
 
 	setup(async () => {
-		const instantiationService = new TestInstantiationService();
+		instantiationService = new TestInstantiationService();
 		configurationService = new TestConfigurationService();
 		instantiationService.stub(IConfigurationService, configurationService);
 		instantiationService.stub(IFileService, {
@@ -46,6 +47,10 @@ suite('Workbench - TerminalUriLinkDetector', () => {
 			userHome: '/home',
 			backend: undefined
 		}, instantiationService.createInstance(TerminalLinkResolver));
+	});
+
+	teardown(() => {
+		instantiationService.dispose();
 	});
 
 	async function assertLink(

--- a/src/vs/workbench/contrib/terminalContrib/links/test/browser/terminalWordLinkDetector.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/links/test/browser/terminalWordLinkDetector.test.ts
@@ -18,9 +18,10 @@ suite('Workbench - TerminalWordLinkDetector', () => {
 	let configurationService: TestConfigurationService;
 	let detector: TerminalWordLinkDetector;
 	let xterm: Terminal;
+	let instantiationService: TestInstantiationService;
 
 	setup(async () => {
-		const instantiationService = new TestInstantiationService();
+		instantiationService = new TestInstantiationService();
 		configurationService = new TestConfigurationService();
 		await configurationService.setUserConfiguration('terminal', { integrated: { wordSeparators: '' } });
 
@@ -30,6 +31,10 @@ suite('Workbench - TerminalWordLinkDetector', () => {
 		const TerminalCtor = (await importAMDNodeModule<typeof import('xterm')>('xterm', 'lib/xterm.js')).Terminal;
 		xterm = new TerminalCtor({ allowProposedApi: true, cols: 80, rows: 30 });
 		detector = instantiationService.createInstance(TerminalWordLinkDetector, xterm);
+	});
+
+	teardown(() => {
+		instantiationService.dispose();
 	});
 
 	async function assertLink(

--- a/src/vs/workbench/contrib/terminalContrib/quickFix/test/browser/quickFixAddon.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/quickFix/test/browser/quickFixAddon.test.ts
@@ -38,8 +38,9 @@ suite('QuickFixAddon', () => {
 	let openerService: OpenerService;
 	let labelService: LabelService;
 	let terminal: Terminal;
+	let instantiationService: TestInstantiationService;
 	setup(async () => {
-		const instantiationService = new TestInstantiationService();
+		instantiationService = new TestInstantiationService();
 		const TerminalCtor = (await importAMDNodeModule<typeof import('xterm')>('xterm', 'lib/xterm.js')).Terminal;
 		terminal = new TerminalCtor({
 			allowProposedApi: true,
@@ -67,6 +68,9 @@ suite('QuickFixAddon', () => {
 
 		quickFixAddon = instantiationService.createInstance(TerminalQuickFixAddon, [], capabilities);
 		terminal.loadAddon(quickFixAddon);
+	});
+	teardown(() => {
+		instantiationService.dispose();
 	});
 	suite('registerCommandFinishedListener & getMatchActions', () => {
 		suite('gitSimilarCommand', async () => {

--- a/src/vs/workbench/services/dialogs/test/electron-sandbox/fileDialogService.test.ts
+++ b/src/vs/workbench/services/dialogs/test/electron-sandbox/fileDialogService.test.ts
@@ -78,7 +78,7 @@ suite('FileDialogService', function () {
 
 	setup(async function () {
 		disposables = new DisposableStore();
-		instantiationService = <TestInstantiationService>workbenchInstantiationService(undefined, disposables);
+		disposables.add(instantiationService = <TestInstantiationService>workbenchInstantiationService(undefined, disposables));
 		const configurationService = new TestConfigurationService();
 		await configurationService.setUserConfiguration('files', { simpleDialog: { enable: true } });
 		instantiationService.stub(IConfigurationService, configurationService);

--- a/src/vs/workbench/services/extensionManagement/test/browser/extensionEnablementService.test.ts
+++ b/src/vs/workbench/services/extensionManagement/test/browser/extensionEnablementService.test.ts
@@ -141,6 +141,7 @@ suite('ExtensionEnablementService Test', () => {
 
 	teardown(() => {
 		(<ExtensionEnablementService>testObject).dispose();
+		instantiationService.dispose();
 	});
 
 	test('test disable an extension globally', async () => {

--- a/src/vs/workbench/services/extensions/test/browser/extensionService.test.ts
+++ b/src/vs/workbench/services/extensions/test/browser/extensionService.test.ts
@@ -222,7 +222,7 @@ suite('ExtensionService', () => {
 
 	setup(() => {
 		disposables = new DisposableStore();
-		instantiationService = createServices(disposables, [
+		disposables.add(instantiationService = createServices(disposables, [
 			// custom
 			[IExtensionService, MyTestExtensionService],
 			// default
@@ -246,7 +246,7 @@ suite('ExtensionService', () => {
 			[IUriIdentityService, UriIdentityService],
 			[IRemoteExtensionsScannerService, TestRemoteExtensionsScannerService],
 			[IRemoteAuthorityResolverService, RemoteAuthorityResolverService]
-		]);
+		]));
 		extService = <MyTestExtensionService>instantiationService.get(IExtensionService);
 	});
 

--- a/src/vs/workbench/services/extensions/test/common/extensionManifestPropertiesService.test.ts
+++ b/src/vs/workbench/services/extensions/test/common/extensionManifestPropertiesService.test.ts
@@ -106,7 +106,10 @@ if (!isWeb) {
 			instantiationService.stub(IConfigurationService, testConfigurationService);
 		});
 
-		teardown(() => testObject.dispose());
+		teardown(() => {
+			testObject.dispose();
+			instantiationService.dispose();
+		});
 
 		function assertUntrustedWorkspaceSupport(extensionManifest: IExtensionManifest, expected: ExtensionUntrustedWorkspaceSupportType): void {
 			testObject = instantiationService.createInstance(ExtensionManifestPropertiesService);

--- a/src/vs/workbench/services/preferences/test/browser/keybindingsEditorModel.test.ts
+++ b/src/vs/workbench/services/preferences/test/browser/keybindingsEditorModel.test.ts
@@ -48,6 +48,10 @@ suite('KeybindingsEditorModel', () => {
 		CommandsRegistry.registerCommand('command_without_keybinding', () => { });
 	});
 
+	teardown(() => {
+		instantiationService.dispose();
+	});
+
 	test('fetch returns default keybindings', async () => {
 		const expected = prepareKeybindingService(
 			aResolvedKeybindingItem({ command: 'a' + uuid.generateUuid(), firstChord: { keyCode: KeyCode.Escape } }),

--- a/src/vs/workbench/services/search/test/browser/queryBuilder.test.ts
+++ b/src/vs/workbench/services/search/test/browser/queryBuilder.test.ts
@@ -58,6 +58,10 @@ suite('QueryBuilder', () => {
 		queryBuilder = instantiationService.createInstance(QueryBuilder);
 	});
 
+	teardown(() => {
+		instantiationService.dispose();
+	});
+
 	test('simple text pattern', () => {
 		assertEqualTextQueries(
 			queryBuilder.text(PATTERN_INFO),

--- a/src/vs/workbench/services/userActivity/test/browser/domActivityTracker.test.ts
+++ b/src/vs/workbench/services/userActivity/test/browser/domActivityTracker.test.ts
@@ -12,12 +12,14 @@ import * as assert from 'assert';
 suite('DomActivityTracker', () => {
 	let uas: UserActivityService;
 	let dom: DomActivityTracker;
+	let insta: TestInstantiationService;
 	let clock: sinon.SinonFakeTimers;
 	const maxTimeToBecomeIdle = 3 * 30_000; // (MIN_INTERVALS_WITHOUT_ACTIVITY + 1) * CHECK_INTERVAL;
 
 	setup(() => {
 		clock = sinon.useFakeTimers();
-		uas = new UserActivityService(new TestInstantiationService());
+		insta = new TestInstantiationService();
+		uas = new UserActivityService(insta);
 		dom = new DomActivityTracker(uas);
 	});
 
@@ -25,6 +27,7 @@ suite('DomActivityTracker', () => {
 		dom.dispose();
 		uas.dispose();
 		clock.restore();
+		insta.dispose();
 	});
 
 

--- a/src/vs/workbench/services/views/test/browser/viewDescriptorService.test.ts
+++ b/src/vs/workbench/services/views/test/browser/viewDescriptorService.test.ts
@@ -30,7 +30,7 @@ suite('ViewDescriptorService', () => {
 	let instantiationService: TestInstantiationService;
 
 	setup(() => {
-		instantiationService = <TestInstantiationService>workbenchInstantiationService(undefined, disposables);
+		disposables.add(instantiationService = <TestInstantiationService>workbenchInstantiationService(undefined, disposables));
 		instantiationService.stub(IContextKeyService, instantiationService.createInstance(ContextKeyService));
 	});
 

--- a/src/vs/workbench/services/workspaces/test/common/workspaceTrust.test.ts
+++ b/src/vs/workbench/services/workspaces/test/common/workspaceTrust.test.ts
@@ -42,6 +42,10 @@ suite('Workspace Trust', () => {
 		instantiationService.stub(IRemoteAuthorityResolverService, new class extends mock<IRemoteAuthorityResolverService>() { });
 	});
 
+	teardown(() => {
+		instantiationService.dispose();
+	});
+
 	suite('Enablement', () => {
 		let testObject: WorkspaceTrustEnablementService;
 

--- a/src/vs/workbench/test/browser/parts/editor/editorGroupModel.test.ts
+++ b/src/vs/workbench/test/browser/parts/editor/editorGroupModel.test.ts
@@ -1064,6 +1064,7 @@ suite('EditorGroupModel', () => {
 
 		assert.strictEqual(events.closed.length, 3);
 		assert.strictEqual(group.count, 0);
+		inst.dispose();
 	});
 
 	test('Multiple Editors - Pinned and Not Active', function () {
@@ -1320,6 +1321,7 @@ suite('EditorGroupModel', () => {
 
 		assert.ok(!group.activeEditor);
 		assert.strictEqual(group.count, 0);
+		inst.dispose();
 	});
 
 	test('Multiple Editors - move editor', function () {
@@ -1673,6 +1675,7 @@ suite('EditorGroupModel', () => {
 		assert.strictEqual(group.activeEditor!.matches(input1), true);
 		assert.strictEqual(group.previewEditor!.matches(input1), true);
 		assert.strictEqual(group.isActive(input1), true);
+		inst.dispose();
 	});
 
 	test('Multiple Groups, Multiple editors - persist', function () {
@@ -1743,6 +1746,7 @@ suite('EditorGroupModel', () => {
 		assert.strictEqual(group2.getEditors(EditorsOrder.MOST_RECENTLY_ACTIVE)[0].matches(g2_input1), true);
 		assert.strictEqual(group2.getEditors(EditorsOrder.MOST_RECENTLY_ACTIVE)[1].matches(g2_input3), true);
 		assert.strictEqual(group2.getEditors(EditorsOrder.MOST_RECENTLY_ACTIVE)[2].matches(g2_input2), true);
+		inst.dispose();
 	});
 
 	test('Single group, multiple editors - persist (some not persistable)', function () {
@@ -1787,6 +1791,7 @@ suite('EditorGroupModel', () => {
 
 		assert.strictEqual(group.getEditors(EditorsOrder.MOST_RECENTLY_ACTIVE)[0].matches(serializableInput2), true);
 		assert.strictEqual(group.getEditors(EditorsOrder.MOST_RECENTLY_ACTIVE)[1].matches(serializableInput1), true);
+		inst.dispose();
 	});
 
 	test('Single group, multiple editors - persist (some not persistable, sticky editors)', function () {
@@ -1822,6 +1827,7 @@ suite('EditorGroupModel', () => {
 
 		assert.strictEqual(group.count, 2);
 		assert.strictEqual(group.stickyCount, 0);
+		inst.dispose();
 	});
 
 	test('Multiple groups, multiple editors - persist (some not persistable, causes empty group)', function () {
@@ -1858,6 +1864,7 @@ suite('EditorGroupModel', () => {
 		assert.strictEqual(group1.count, 2);
 		assert.strictEqual(group1.getEditors(EditorsOrder.SEQUENTIAL)[0].matches(serializableInput1), true);
 		assert.strictEqual(group1.getEditors(EditorsOrder.SEQUENTIAL)[1].matches(serializableInput2), true);
+		inst.dispose();
 	});
 
 	test('Multiple Editors - Editor Dispose', function () {

--- a/src/vs/workbench/test/browser/parts/editor/editorModel.test.ts
+++ b/src/vs/workbench/test/browser/parts/editor/editorModel.test.ts
@@ -75,6 +75,10 @@ suite('EditorModel', () => {
 		languageService = instantiationService.stub(ILanguageService, LanguageService);
 	});
 
+	teardown(() => {
+		instantiationService.dispose();
+	});
+
 	test('basics', async () => {
 		let counter = 0;
 

--- a/src/vs/workbench/test/browser/workbenchTestServices.ts
+++ b/src/vs/workbench/test/browser/workbenchTestServices.ts
@@ -243,7 +243,7 @@ export function workbenchInstantiationService(
 	},
 	disposables: DisposableStore = new DisposableStore()
 ): TestInstantiationService {
-	const instantiationService = new TestInstantiationService(new ServiceCollection([ILifecycleService, new TestLifecycleService()]));
+	const instantiationService = disposables.add(new TestInstantiationService(new ServiceCollection([ILifecycleService, new TestLifecycleService()])));
 
 	instantiationService.stub(IEditorWorkerService, new TestEditorWorkerService());
 	instantiationService.stub(IWorkingCopyService, disposables.add(new TestWorkingCopyService()));


### PR DESCRIPTION
This will call `sinon.restore()` and prevent a memory leak
Part of #187471