### PR TITLE
Repopulate slash command when user submits query

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/contrib/chatInputEditorContrib.ts
+++ b/src/vs/workbench/contrib/chat/browser/contrib/chatInputEditorContrib.ts
@@ -138,7 +138,7 @@ class InputEditorSlashCommandFollowups extends Disposable {
 		@IChatService private readonly chatService: IChatService
 	) {
 		super();
-		this._register(this.chatService.onDidCompleteSlashCommand(({ slashCommand, sessionId }) => this.repopulateSlashCommand(slashCommand, sessionId)));
+		this._register(this.chatService.onDidSubmitSlashCommand(({ slashCommand, sessionId }) => this.repopulateSlashCommand(slashCommand, sessionId)));
 	}
 
 	private async repopulateSlashCommand(slashCommand: string, sessionId: string) {

--- a/src/vs/workbench/contrib/chat/common/chatService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService.ts
@@ -178,7 +178,7 @@ export interface IChatService {
 	_serviceBrand: undefined;
 	transferredSessionId: string | undefined;
 
-	onDidCompleteSlashCommand: Event<{ slashCommand: string; sessionId: string }>;
+	onDidSubmitSlashCommand: Event<{ slashCommand: string; sessionId: string }>;
 	registerProvider(provider: IChatProvider): IDisposable;
 	registerSlashCommandProvider(provider: ISlashCommandProvider): IDisposable;
 	getProviderInfos(): IChatProviderInfo[];

--- a/src/vs/workbench/contrib/chat/common/chatServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/chatServiceImpl.ts
@@ -135,8 +135,8 @@ export class ChatService extends Disposable implements IChatService {
 	private readonly _onDidPerformUserAction = this._register(new Emitter<IChatUserActionEvent>());
 	public readonly onDidPerformUserAction: Event<IChatUserActionEvent> = this._onDidPerformUserAction.event;
 
-	private readonly _onDidCompleteSlashCommand = this._register(new Emitter<{ slashCommand: string; sessionId: string }>());
-	public readonly onDidCompleteSlashCommand = this._onDidCompleteSlashCommand.event;
+	private readonly _onDidSubmitSlashCommand = this._register(new Emitter<{ slashCommand: string; sessionId: string }>());
+	public readonly onDidSubmitSlashCommand = this._onDidSubmitSlashCommand.event;
 
 	constructor(
 		@IStorageService private readonly storageService: IStorageService,
@@ -446,6 +446,9 @@ export class ChatService extends Disposable implements IChatService {
 
 				model.cancelRequest(request);
 			});
+			if (usedSlashCommand?.command) {
+				this._onDidSubmitSlashCommand.fire({ slashCommand: usedSlashCommand.command, sessionId: model.sessionId });
+			}
 			let rawResponse = await provider.provideReply({ session: model.session!, message: resolvedCommand }, progressCallback, token);
 			if (token.isCancellationRequested) {
 				return;
@@ -475,15 +478,9 @@ export class ChatService extends Disposable implements IChatService {
 					Promise.resolve(provider.provideFollowups(model.session!, CancellationToken.None)).then(followups => {
 						model.setFollowups(request, withNullAsUndefined(followups));
 						model.completeResponse(request);
-						if (usedSlashCommand?.command) {
-							this._onDidCompleteSlashCommand.fire({ slashCommand: usedSlashCommand.command, sessionId: model.sessionId });
-						}
 					});
 				} else {
 					model.completeResponse(request);
-					if (usedSlashCommand?.command) {
-						this._onDidCompleteSlashCommand.fire({ slashCommand: usedSlashCommand.command, sessionId: model.sessionId });
-					}
 				}
 			}
 		});


### PR DESCRIPTION
Reworks the opt-in repopulating behavior to happen immediately after the user submits a new question. After selfhosting on the repopulated slash command behavior today, it feels less surprising to have the slash command reappear instantly than to have to wait for the response to come back in full.