### PR TITLE
Exclude `azurerepos:` files from JS/TS intellisense

### DIFF
--- a/extensions/typescript-language-features/src/configuration/fileSchemes.ts
+++ b/extensions/typescript-language-features/src/configuration/fileSchemes.ts
@@ -10,6 +10,7 @@ export const file = 'file';
 export const untitled = 'untitled';
 export const git = 'git';
 export const github = 'github';
+export const azurerepos = 'azurerepos';
 
 /** Live share scheme */
 export const vsls = 'vsls';
@@ -39,4 +40,5 @@ export const disabledSchemes = new Set([
 	git,
 	vsls,
 	github,
+	azurerepos,
 ]);


### PR DESCRIPTION
Fixes #186385

Instead I believe we want to only work with the `vscode-vfs` files