### PR TITLE
Adding persistance mechanism to content hover sizes

### DIFF
--- a/src/vs/editor/contrib/hover/browser/contentHover.ts
+++ b/src/vs/editor/contrib/hover/browser/contentHover.ts
@@ -459,8 +459,7 @@ const CONTAINER_HEIGHT_PADDING = 6;
 export class ContentHoverWidget extends ResizableContentWidget {
 
 	public static ID = 'editor.contrib.resizableContentHoverWidget';
-	private static _lastHeight: number = 0;
-	private static _lastWidth: number = 0;
+	private static _lastDimensions: dom.Dimension = new dom.Dimension(0, 0);
 
 	private _visibleData: ContentHoverVisibleData | undefined;
 	private _positionPreference: ContentWidgetPositionPreference | undefined;
@@ -584,8 +583,7 @@ export class ContentHoverWidget extends ResizableContentWidget {
 	}
 
 	protected override _resize(size: dom.Dimension): void {
-		ContentHoverWidget._lastHeight = size.height;
-		ContentHoverWidget._lastWidth = size.width;
+		ContentHoverWidget._lastDimensions = new dom.Dimension(size.width, size.height);
 		this._setAdjustedHoverWidgetDimensions(size);
 		this._resizableNode.layout(size.height, size.width);
 		this._setResizableNodeMaxDimensions();
@@ -658,8 +656,8 @@ export class ContentHoverWidget extends ResizableContentWidget {
 	}
 
 	private _layout(): void {
-		const height = Math.max(this._editor.getLayoutInfo().height / 4, 250, ContentHoverWidget._lastHeight);
-		const width = Math.max(this._editor.getLayoutInfo().width * 0.66, 500, ContentHoverWidget._lastWidth);
+		const height = Math.max(this._editor.getLayoutInfo().height / 4, 250, ContentHoverWidget._lastDimensions.height);
+		const width = Math.max(this._editor.getLayoutInfo().width * 0.66, 500, ContentHoverWidget._lastDimensions.width);
 		const { fontSize, lineHeight } = this._editor.getOption(EditorOption.fontInfo);
 		const contentsDomNode = this._hover.contentsDomNode;
 		contentsDomNode.style.fontSize = `${fontSize}px`;
@@ -685,8 +683,8 @@ export class ContentHoverWidget extends ResizableContentWidget {
 	}
 
 	private _updateContentsDomNodeMaxDimensions() {
-		const width = Math.max(this._editor.getLayoutInfo().width * 0.66, 500, ContentHoverWidget._lastWidth);
-		const height = Math.max(this._editor.getLayoutInfo().height / 4, 250, ContentHoverWidget._lastHeight);
+		const height = Math.max(this._editor.getLayoutInfo().height / 4, 250, ContentHoverWidget._lastDimensions.height);
+		const width = Math.max(this._editor.getLayoutInfo().width * 0.66, 500, ContentHoverWidget._lastDimensions.width);
 		this._setContentsDomNodeMaxDimensions(width, height);
 	}
 

--- a/src/vs/editor/contrib/hover/browser/contentHover.ts
+++ b/src/vs/editor/contrib/hover/browser/contentHover.ts
@@ -459,6 +459,8 @@ const CONTAINER_HEIGHT_PADDING = 6;
 export class ContentHoverWidget extends ResizableContentWidget {
 
 	public static ID = 'editor.contrib.resizableContentHoverWidget';
+	private static _lastHeight: number = 0;
+	private static _lastWidth: number = 0;
 
 	private _visibleData: ContentHoverVisibleData | undefined;
 	private _positionPreference: ContentWidgetPositionPreference | undefined;
@@ -582,6 +584,8 @@ export class ContentHoverWidget extends ResizableContentWidget {
 	}
 
 	protected override _resize(size: dom.Dimension): void {
+		ContentHoverWidget._lastHeight = size.height;
+		ContentHoverWidget._lastWidth = size.width;
 		this._setAdjustedHoverWidgetDimensions(size);
 		this._resizableNode.layout(size.height, size.width);
 		this._setResizableNodeMaxDimensions();
@@ -654,12 +658,13 @@ export class ContentHoverWidget extends ResizableContentWidget {
 	}
 
 	private _layout(): void {
-		const height = Math.max(this._editor.getLayoutInfo().height / 4, 250);
+		const height = Math.max(this._editor.getLayoutInfo().height / 4, 250, ContentHoverWidget._lastHeight);
+		const width = Math.max(this._editor.getLayoutInfo().width * 0.66, 500, ContentHoverWidget._lastWidth);
 		const { fontSize, lineHeight } = this._editor.getOption(EditorOption.fontInfo);
 		const contentsDomNode = this._hover.contentsDomNode;
 		contentsDomNode.style.fontSize = `${fontSize}px`;
 		contentsDomNode.style.lineHeight = `${lineHeight / fontSize}`;
-		this._setContentsDomNodeMaxDimensions(Math.max(this._editor.getLayoutInfo().width * 0.66, 500), height);
+		this._setContentsDomNodeMaxDimensions(width, height);
 	}
 
 	private _updateFont(): void {
@@ -680,8 +685,8 @@ export class ContentHoverWidget extends ResizableContentWidget {
 	}
 
 	private _updateContentsDomNodeMaxDimensions() {
-		const width = Math.max(this._editor.getLayoutInfo().width * 0.66, 500);
-		const height = Math.max(this._editor.getLayoutInfo().height / 4, 250);
+		const width = Math.max(this._editor.getLayoutInfo().width * 0.66, 500, ContentHoverWidget._lastWidth);
+		const height = Math.max(this._editor.getLayoutInfo().height / 4, 250, ContentHoverWidget._lastHeight);
 		this._setContentsDomNodeMaxDimensions(width, height);
 	}
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/185743

The persistance mechanism work as follows. When the content hover is resized, its size at that moment is remembered. During the next rendering of a content hover, the maximum size of the content hover is set to be:

```
maxSize = Math.max(defaultMaxSize, previousSize)
```

The previous size is stored as static variables (for the width and height) in the ContentHoverWidget class. Therefore on restarting VS Code, the persisted size will be lost. 