### PR TITLE
Placing the color representation to the right of the codicon in the color picker

### DIFF
--- a/src/vs/editor/contrib/colorPicker/browser/colorPicker.css
+++ b/src/vs/editor/contrib/colorPicker/browser/colorPicker.css
@@ -50,7 +50,7 @@
 	flex: 1;
 }
 
-.colorpicker-header .picked-color .picked-color-representation {
+.colorpicker-header .picked-color .picked-color-presentation {
 	white-space: nowrap;
 	margin-left: 30px;
 	margin-right: 5px;

--- a/src/vs/editor/contrib/colorPicker/browser/colorPicker.css
+++ b/src/vs/editor/contrib/colorPicker/browser/colorPicker.css
@@ -50,6 +50,12 @@
 	flex: 1;
 }
 
+.colorpicker-header .picked-color .picked-color-representation {
+	white-space: nowrap;
+	margin-left: 30px;
+	margin-right: 5px;
+}
+
 .colorpicker-header .picked-color .codicon {
 	color: inherit;
 	font-size: 14px;

--- a/src/vs/editor/contrib/colorPicker/browser/colorPicker.css
+++ b/src/vs/editor/contrib/colorPicker/browser/colorPicker.css
@@ -48,19 +48,19 @@
 	cursor: pointer;
 	color: white;
 	flex: 1;
+	white-space: nowrap;
+	overflow: hidden;
 }
 
 .colorpicker-header .picked-color .picked-color-presentation {
 	white-space: nowrap;
-	margin-left: 30px;
+	margin-left: 5px;
 	margin-right: 5px;
 }
 
 .colorpicker-header .picked-color .codicon {
 	color: inherit;
 	font-size: 14px;
-	position: absolute;
-	left: 8px;
 }
 
 .colorpicker-header .picked-color.light {

--- a/src/vs/editor/contrib/colorPicker/browser/colorPickerWidget.ts
+++ b/src/vs/editor/contrib/colorPicker/browser/colorPickerWidget.ts
@@ -22,15 +22,6 @@ import { IThemeService } from 'vs/platform/theme/common/themeService';
 
 const $ = dom.$;
 
-function elementsOverlapHorizontally(el1: HTMLElement, el2: HTMLElement) {
-	const domRect1 = el1.getBoundingClientRect();
-	const domRect2 = el2.getBoundingClientRect();
-	return !(
-		domRect1.right < domRect2.left ||
-		domRect1.left > domRect2.right
-	);
-}
-
 export class ColorPickerHeader extends Disposable {
 
 	private readonly _domNode: HTMLElement;
@@ -48,7 +39,8 @@ export class ColorPickerHeader extends Disposable {
 
 		this._pickedColorNode = dom.append(this._domNode, $('.picked-color'));
 		this._pickedColorRepresentation = dom.append(this._pickedColorNode, document.createElement('div'));
-		const icon = dom.append(this._pickedColorNode, $('.codicon.codicon-color-mode'));
+		this._pickedColorRepresentation.classList.add('picked-color-representation');
+		dom.append(this._pickedColorNode, $('.codicon.codicon-color-mode'));
 
 		const tooltip = localize('clickToToggleColorOptions', "Click to toggle color options (rgb/hsl/hex)");
 		this._pickedColorNode.setAttribute('title', tooltip);
@@ -78,16 +70,6 @@ export class ColorPickerHeader extends Disposable {
 			this._domNode.classList.add('standalone-colorpicker');
 			this._closeButton = this._register(new CloseButton(this._domNode));
 		}
-
-		const resizeObserver = new ResizeObserver(() => {
-			this._pickedColorRepresentation.style.display = 'block';
-			if (elementsOverlapHorizontally(this._pickedColorRepresentation, icon)) {
-				this._pickedColorRepresentation.style.display = 'none';
-			} else {
-				this._pickedColorRepresentation.style.display = 'block';
-			}
-		});
-		resizeObserver.observe(this._domNode);
 	}
 
 	public get domNode(): HTMLElement {

--- a/src/vs/editor/contrib/colorPicker/browser/colorPickerWidget.ts
+++ b/src/vs/editor/contrib/colorPicker/browser/colorPickerWidget.ts
@@ -26,7 +26,7 @@ export class ColorPickerHeader extends Disposable {
 
 	private readonly _domNode: HTMLElement;
 	private readonly _pickedColorNode: HTMLElement;
-	private readonly _pickedColorRepresentation: HTMLElement;
+	private readonly _pickedColorPresentation: HTMLElement;
 	private readonly _originalColorNode: HTMLElement;
 	private readonly _closeButton: CloseButton | null = null;
 	private backgroundColor: Color;
@@ -38,8 +38,8 @@ export class ColorPickerHeader extends Disposable {
 		dom.append(container, this._domNode);
 
 		this._pickedColorNode = dom.append(this._domNode, $('.picked-color'));
-		this._pickedColorRepresentation = dom.append(this._pickedColorNode, document.createElement('div'));
-		this._pickedColorRepresentation.classList.add('picked-color-representation');
+		this._pickedColorPresentation = dom.append(this._pickedColorNode, document.createElement('div'));
+		this._pickedColorPresentation.classList.add('picked-color-presentation');
 		dom.append(this._pickedColorNode, $('.codicon.codicon-color-mode'));
 
 		const tooltip = localize('clickToToggleColorOptions', "Click to toggle color options (rgb/hsl/hex)");
@@ -95,7 +95,7 @@ export class ColorPickerHeader extends Disposable {
 	}
 
 	private onDidChangePresentation(): void {
-		this._pickedColorRepresentation.textContent = this.model.presentation ? this.model.presentation.label : '';
+		this._pickedColorPresentation.textContent = this.model.presentation ? this.model.presentation.label : '';
 	}
 }
 

--- a/src/vs/editor/contrib/colorPicker/browser/colorPickerWidget.ts
+++ b/src/vs/editor/contrib/colorPicker/browser/colorPickerWidget.ts
@@ -22,13 +22,11 @@ import { IThemeService } from 'vs/platform/theme/common/themeService';
 
 const $ = dom.$;
 
-function elementsOverlap(el1: HTMLElement, el2: HTMLElement) {
+function elementsOverlapHorizontally(el1: HTMLElement, el2: HTMLElement) {
 	const domRect1 = el1.getBoundingClientRect();
 	const domRect2 = el2.getBoundingClientRect();
 	return !(
-		domRect1.top > domRect2.bottom ||
 		domRect1.right < domRect2.left ||
-		domRect1.bottom < domRect2.top ||
 		domRect1.left > domRect2.right
 	);
 }
@@ -83,7 +81,7 @@ export class ColorPickerHeader extends Disposable {
 
 		const resizeObserver = new ResizeObserver(() => {
 			this._pickedColorRepresentation.style.display = 'block';
-			if (elementsOverlap(this._pickedColorRepresentation, icon)) {
+			if (elementsOverlapHorizontally(this._pickedColorRepresentation, icon)) {
 				this._pickedColorRepresentation.style.display = 'none';
 			} else {
 				this._pickedColorRepresentation.style.display = 'block';

--- a/src/vs/editor/contrib/colorPicker/browser/colorPickerWidget.ts
+++ b/src/vs/editor/contrib/colorPicker/browser/colorPickerWidget.ts
@@ -38,9 +38,9 @@ export class ColorPickerHeader extends Disposable {
 		dom.append(container, this._domNode);
 
 		this._pickedColorNode = dom.append(this._domNode, $('.picked-color'));
-		this._pickedColorPresentation = dom.append(this._pickedColorNode, document.createElement('div'));
+		dom.append(this._pickedColorNode, $('span.codicon.codicon-color-mode'));
+		this._pickedColorPresentation = dom.append(this._pickedColorNode, document.createElement('span'));
 		this._pickedColorPresentation.classList.add('picked-color-presentation');
-		dom.append(this._pickedColorNode, $('.codicon.codicon-color-mode'));
 
 		const tooltip = localize('clickToToggleColorOptions', "Click to toggle color options (rgb/hsl/hex)");
 		this._pickedColorNode.setAttribute('title', tooltip);


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/185747

The representation text remains on one line to the right of the codicon in the color picker.  This implementation is chosen because it coincides with how the color stripes render on resize: at some point when sizing down, they disappear.


https://github.com/microsoft/vscode/assets/61460952/cbdace14-89a1-40b5-bcbe-c8effc2b8259


