### PR TITLE
Fix paste behavior across editors that have pasteAs enabled/disabled

### DIFF
--- a/src/vs/editor/browser/controller/textAreaInput.ts
+++ b/src/vs/editor/browser/controller/textAreaInput.ts
@@ -650,9 +650,9 @@ export class TextAreaInput extends Disposable {
 	}
 }
 
-class ClipboardEventUtils {
+export const ClipboardEventUtils = {
 
-	public static getTextData(clipboardData: DataTransfer): [string, ClipboardStoredMetadata | null] {
+	getTextData(clipboardData: DataTransfer): [string, ClipboardStoredMetadata | null] {
 		const text = clipboardData.getData(Mimes.text);
 		let metadata: ClipboardStoredMetadata | null = null;
 		const rawmetadata = clipboardData.getData('vscode-editor-data');
@@ -674,16 +674,16 @@ class ClipboardEventUtils {
 		}
 
 		return [text, metadata];
-	}
+	},
 
-	public static setTextData(clipboardData: DataTransfer, text: string, html: string | null | undefined, metadata: ClipboardStoredMetadata): void {
+	setTextData(clipboardData: DataTransfer, text: string, html: string | null | undefined, metadata: ClipboardStoredMetadata): void {
 		clipboardData.setData(Mimes.text, text);
 		if (typeof html === 'string') {
 			clipboardData.setData('text/html', html);
 		}
 		clipboardData.setData('vscode-editor-data', JSON.stringify(metadata));
 	}
-}
+};
 
 export class TextAreaWrapper extends Disposable implements ICompleteTextAreaWrapper {
 


### PR DESCRIPTION
Fixes #185681

If pasteAs is disabled, or copy paste controller never writes its own metadata. When you then paste into an editor that has pasteAs enabled, we need to instead use the text area metadata that was written by editor core instead

This seems like a better fix than having the copy paste controller always write the metadata because it means the copy paste controller interferes with fewer copy/paste operations

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
