### PR TITLE
Fixes Diff Algorithm Bug

### DIFF
--- a/src/vs/editor/common/diff/algorithms/joinSequenceDiffs.ts
+++ b/src/vs/editor/common/diff/algorithms/joinSequenceDiffs.ts
@@ -52,7 +52,7 @@ export function joinSequenceDiffs(sequence1: ISequence, sequence2: ISequence, se
 
 	// First move them all to the left as much as possible and join them if possible
 	for (let i = 1; i < sequenceDiffs.length; i++) {
-		const prevResult = sequenceDiffs[i - 1];
+		const prevResult = result[result.length - 1];
 		let cur = sequenceDiffs[i];
 
 		if (cur.seq1Range.isEmpty || cur.seq2Range.isEmpty) {


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-internalbacklog/issues/4466

`prevResult` has to account for already shifted and joined diffs - otherwise a diff gets joined with a diff that already moved.
Also, using the wrong `prevResult` results in lost diffs - however, at least one remains.