### PR TITLE
chore: group editor acccessibility options

### DIFF
--- a/src/vs/editor/browser/controller/textAreaHandler.ts
+++ b/src/vs/editor/browser/controller/textAreaHandler.ts
@@ -560,7 +560,7 @@ export class TextAreaHandler extends ViewPart {
 	private _setAccessibilityOptions(options: IComputedEditorOptions): void {
 		this._accessibilitySupport = options.get(EditorOption.accessibilitySupport);
 		const accessibilityPageSize = options.get(EditorOption.accessibilityPageSize);
-		if (this._accessibilitySupport === AccessibilitySupport.Enabled && accessibilityPageSize === EditorOptions.accessibilityPageSize.defaultValue) {
+		if (this._accessibilitySupport === AccessibilitySupport.Enabled && accessibilityPageSize === EditorOptions.accessibility.accessibilityPageSize.defaultValue) {
 			// If a screen reader is attached and the default value is not set we should automatically increase the page size to 500 for a better experience
 			this._accessibilityPageSize = 500;
 		} else {

--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -5133,22 +5133,24 @@ export const EditorOptions = {
 			markdownDescription: nls.localize('acceptSuggestionOnEnter', "Controls whether suggestions should be accepted on `Enter`, in addition to `Tab`. Helps to avoid ambiguity between inserting new lines or accepting suggestions.")
 		}
 	)),
-	accessibilitySupport: register(new EditorAccessibilitySupport()),
-	accessibilityPageSize: register(new EditorIntOption(EditorOption.accessibilityPageSize, 'accessibilityPageSize', 10, 1, Constants.MAX_SAFE_SMALL_INTEGER,
-		{
-			description: nls.localize('accessibilityPageSize', "Controls the number of lines in the editor that can be read out by a screen reader at once. When we detect a screen reader we automatically set the default to be 500. Warning: this has a performance implication for numbers larger than the default."),
-			tags: ['accessibility']
-		})),
-	ariaLabel: register(new EditorStringOption(
-		EditorOption.ariaLabel, 'ariaLabel', nls.localize('editorViewAccessibleLabel', "Editor content")
-	)),
-	screenReaderAnnounceInlineSuggestion: register(new EditorBooleanOption(
-		EditorOption.screenReaderAnnounceInlineSuggestion, 'screenReaderAnnounceInlineSuggestion', true,
-		{
-			description: nls.localize('screenReaderAnnounceInlineSuggestion', "Control whether inline suggestions are announced by a screen reader."),
-			tags: ['accessibility']
-		}
-	)),
+	accessibility: {
+		accessibilitySupport: register(new EditorAccessibilitySupport()),
+		accessibilityPageSize: register(new EditorIntOption(EditorOption.accessibilityPageSize, 'accessibilityPageSize', 10, 1, Constants.MAX_SAFE_SMALL_INTEGER,
+			{
+				description: nls.localize('accessibilityPageSize', "Controls the number of lines in the editor that can be read out by a screen reader at once. When we detect a screen reader we automatically set the default to be 500. Warning: this has a performance implication for numbers larger than the default."),
+				tags: ['accessibility']
+			})),
+		ariaLabel: register(new EditorStringOption(
+			EditorOption.ariaLabel, 'ariaLabel', nls.localize('editorViewAccessibleLabel', "Editor content")
+		)),
+		screenReaderAnnounceInlineSuggestion: register(new EditorBooleanOption(
+			EditorOption.screenReaderAnnounceInlineSuggestion, 'screenReaderAnnounceInlineSuggestion', true,
+			{
+				description: nls.localize('screenReaderAnnounceInlineSuggestion', "Control whether inline suggestions are announced by a screen reader."),
+				tags: ['accessibility']
+			}
+		)),
+	},
 	autoClosingBrackets: register(new EditorStringEnumOption(
 		EditorOption.autoClosingBrackets, 'autoClosingBrackets',
 		'languageDefined' as 'always' | 'languageDefined' | 'beforeWhitespace' | 'never',

--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -5865,6 +5865,15 @@ export const EditorOptions = {
 };
 
 type EditorOptionsType = typeof EditorOptions;
-type FindEditorOptionsKeyById<T extends EditorOption> = { [K in keyof EditorOptionsType]: EditorOptionsType[K]['id'] extends T ? K : never }[keyof EditorOptionsType];
+type AccessibilityOptionsType = typeof EditorOptions.accessibility;
+type EditorOptionsWithoutAccessibilityType = Omit<EditorOptionsType, 'accessibility'>;
+
+type FindEditorOptionsKeyById<T extends EditorOption> = { [K in keyof EditorOptionsWithoutAccessibilityType]: EditorOptionsWithoutAccessibilityType[K]['id'] extends T ? K : never }[keyof EditorOptionsWithoutAccessibilityType];
+type FindAccessibilityOptionsKeyById<T extends EditorOption> = { [K in keyof AccessibilityOptionsType]: AccessibilityOptionsType[K]['id'] extends T ? K : never }[keyof AccessibilityOptionsType];
+
 type ComputedEditorOptionValue<T extends IEditorOption<any, any>> = T extends IEditorOption<any, infer R> ? R : never;
-export type FindComputedEditorOptionValueById<T extends EditorOption> = NonNullable<ComputedEditorOptionValue<EditorOptionsType[FindEditorOptionsKeyById<T>]>>;
+
+type ComputedEditorOptionValueWithoutAccessibility<T extends EditorOption> = ComputedEditorOptionValue<EditorOptionsWithoutAccessibilityType[FindEditorOptionsKeyById<T>]>;
+type ComputedAccessibilityOptionValue<T extends EditorOption> = ComputedEditorOptionValue<AccessibilityOptionsType[FindAccessibilityOptionsKeyById<T>]>;
+
+export type FindComputedEditorOptionValueById<T extends EditorOption> = NonNullable<ComputedEditorOptionValueWithoutAccessibility<T> | ComputedAccessibilityOptionValue<T>>;


### PR DESCRIPTION
Updates the structure of the EditorOptions object to group all accessibility-related options under a new accessibility property.

addresses issue https://github.com/microsoft/vscode/issues/187314

@hediet 