### PR TITLE
Fix race condition of find() and findStop() in BackLayerWebView

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/contrib/find/findMatchDecorationModel.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/find/findMatchDecorationModel.ts
@@ -8,18 +8,20 @@ import { ModelDecorationOptions } from 'vs/editor/common/model/textModel';
 import { FindDecorations } from 'vs/editor/contrib/find/browser/findDecorations';
 import { Range } from 'vs/editor/common/core/range';
 import { overviewRulerSelectionHighlightForeground, overviewRulerFindMatchForeground } from 'vs/platform/theme/common/colorRegistry';
-import { CellFindMatchWithIndex, ICellModelDecorations, ICellModelDeltaDecorations, ICellViewModel, INotebookDeltaDecoration, INotebookEditor, NotebookOverviewRulerLane, } from 'vs/workbench/contrib/notebook/browser/notebookBrowser';
+import { CellFindMatchWithIndex, ICellModelDecorations, ICellModelDeltaDecorations, ICellViewModel, INotebookDeltaDecoration, INotebookEditor, INotebookEditorFindHandle, NotebookOverviewRulerLane, } from 'vs/workbench/contrib/notebook/browser/notebookBrowser';
 
 export class FindMatchDecorationModel extends Disposable {
 	private _allMatchesDecorations: ICellModelDecorations[] = [];
 	private _currentMatchCellDecorations: string[] = [];
 	private _allMatchesCellDecorations: string[] = [];
 	private _currentMatchDecorations: { kind: 'input'; decorations: ICellModelDecorations[] } | { kind: 'output'; index: number } | null = null;
+	private readonly _findHandle: INotebookEditorFindHandle;
 
 	constructor(
 		private readonly _notebookEditor: INotebookEditor
 	) {
 		super();
+		this._findHandle = _notebookEditor.getFindHandle();
 	}
 
 	public get currentMatchDecorations() {
@@ -145,7 +147,7 @@ export class FindMatchDecorationModel extends Disposable {
 	}
 
 	stopWebviewFind() {
-		this._notebookEditor.findStop();
+		this._notebookEditor.findStop(this._findHandle);
 	}
 
 	override dispose() {

--- a/src/vs/workbench/contrib/notebook/browser/contrib/find/notebookFindWidget.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/find/notebookFindWidget.ts
@@ -303,7 +303,7 @@ class NotebookFindWidget extends SimpleFindReplaceWidget implements INotebookEdi
 		super.hide();
 		this._state.change({ isRevealed: false }, false);
 		this._findModel.clear();
-		this._notebookEditor.findStop();
+		this._notebookEditor.findStop(this._notebookEditor.getFindHandle());
 		this._progressBar.stop();
 
 		if (this._hideTimeout === null) {

--- a/src/vs/workbench/contrib/notebook/browser/notebookBrowser.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookBrowser.ts
@@ -674,13 +674,18 @@ export interface INotebookEditor {
 	getNextVisibleCellIndex(index: number): number | undefined;
 	getPreviousVisibleCellIndex(index: number): number | undefined;
 	find(query: string, options: INotebookSearchOptions, token: CancellationToken): Promise<CellFindMatchWithIndex[]>;
+	getFindHandle(): INotebookEditorFindHandle;
 	highlightFind(matchIndex: number): Promise<number>;
 	unHighlightFind(matchIndex: number): Promise<void>;
-	findStop(): void;
+	findStop(handle: INotebookEditorFindHandle): void;
 	showProgress(): void;
 	hideProgress(): void;
 
 	getAbsoluteTopOfElement(cell: ICellViewModel): number;
+}
+
+export interface INotebookEditorFindHandle {
+	readonly timestamp: number;
 }
 
 export interface IActiveNotebookEditor extends INotebookEditor {

--- a/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
@@ -47,7 +47,7 @@ import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 import { contrastBorder, errorForeground, focusBorder, foreground, listInactiveSelectionBackground, registerColor, scrollbarSliderActiveBackground, scrollbarSliderBackground, scrollbarSliderHoverBackground, transparent } from 'vs/platform/theme/common/colorRegistry';
 import { EDITOR_PANE_BACKGROUND, PANEL_BORDER, SIDE_BAR_BACKGROUND } from 'vs/workbench/common/theme';
 import { debugIconStartForeground } from 'vs/workbench/contrib/debug/browser/debugColors';
-import { CellEditState, CellFindMatchWithIndex, CellFocusMode, CellLayoutContext, CellRevealRangeType, CellRevealSyncType, CellRevealType, IActiveNotebookEditorDelegate, IBaseCellEditorOptions, ICellOutputViewModel, ICellViewModel, ICommonCellInfo, IDisplayOutputLayoutUpdateRequest, IFocusNotebookCellOptions, IInsetRenderOutput, IModelDecorationsChangeAccessor, INotebookDeltaDecoration, INotebookEditor, INotebookEditorContribution, INotebookEditorContributionDescription, INotebookEditorCreationOptions, INotebookEditorDelegate, INotebookEditorMouseEvent, INotebookEditorOptions, INotebookEditorViewState, INotebookViewCellsUpdateEvent, INotebookWebviewMessage, RenderOutputType } from 'vs/workbench/contrib/notebook/browser/notebookBrowser';
+import { CellEditState, CellFindMatchWithIndex, CellFocusMode, CellLayoutContext, CellRevealRangeType, CellRevealSyncType, CellRevealType, IActiveNotebookEditorDelegate, IBaseCellEditorOptions, ICellOutputViewModel, ICellViewModel, ICommonCellInfo, IDisplayOutputLayoutUpdateRequest, IFocusNotebookCellOptions, IInsetRenderOutput, IModelDecorationsChangeAccessor, INotebookDeltaDecoration, INotebookEditor, INotebookEditorContribution, INotebookEditorContributionDescription, INotebookEditorCreationOptions, INotebookEditorDelegate, INotebookEditorFindHandle, INotebookEditorMouseEvent, INotebookEditorOptions, INotebookEditorViewState, INotebookViewCellsUpdateEvent, INotebookWebviewMessage, RenderOutputType } from 'vs/workbench/contrib/notebook/browser/notebookBrowser';
 import { NotebookEditorExtensionsRegistry } from 'vs/workbench/contrib/notebook/browser/notebookEditorExtensions';
 import { INotebookEditorService } from 'vs/workbench/contrib/notebook/browser/services/notebookEditorService';
 import { notebookDebug } from 'vs/workbench/contrib/notebook/browser/notebookLogger';
@@ -2438,7 +2438,7 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditorD
 		const findMatches = this._notebookViewModel.find(query, options).filter(match => match.length > 0);
 
 		if (!options.includeMarkupPreview && !options.includeOutput) {
-			this._webview?.findStop();
+			this._webview?.findStop(this._webview?.findHandle);
 			return findMatches;
 		}
 
@@ -2517,6 +2517,10 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditorD
 		return ret;
 	}
 
+	getFindHandle(): INotebookEditorFindHandle {
+		return this._webview?.findHandle ?? { timestamp: NaN };
+	}
+
 	async highlightFind(matchIndex: number): Promise<number> {
 		if (!this._webview) {
 			return 0;
@@ -2533,8 +2537,8 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditorD
 		return this._webview?.findUnHighlight(matchIndex);
 	}
 
-	findStop() {
-		this._webview?.findStop();
+	findStop(handle: INotebookEditorFindHandle) {
+		this._webview?.findStop(handle);
 	}
 
 	//#endregion

--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewMessages.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewMessages.ts
@@ -413,6 +413,7 @@ export interface IFindUnHighlightMessage {
 
 export interface IFindStopMessage {
 	readonly type: 'findStop';
+	readonly findHandleTimestamp: number;
 }
 
 export interface ISearchPreviewInfo {

--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewPreloads.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewPreloads.ts
@@ -1126,6 +1126,7 @@ async function webviewPreloads(ctx: PreloadContext) {
 		return offset + getSelectionOffsetRelativeTo(parentElement, currentNode.parentNode);
 	}
 
+	let findHandleTimestamp = NaN;
 	const find = (query: string, options: { wholeWord?: boolean; caseSensitive?: boolean; includeMarkup: boolean; includeOutput: boolean; shouldGetSearchPreviewInfo: boolean }) => {
 		let find = true;
 		const matches: IFindMatch[] = [];
@@ -1254,6 +1255,7 @@ async function webviewPreloads(ctx: PreloadContext) {
 			console.log(e);
 		}
 
+		findHandleTimestamp = Date.now();
 		if (matches.length && CSS.highlights) {
 			_highlighter = new CSSHighlighter(matches);
 		} else {
@@ -1273,7 +1275,8 @@ async function webviewPreloads(ctx: PreloadContext) {
 				cellId: match.cellId,
 				index,
 				searchPreviewInfo: match.searchPreviewInfo,
-			}))
+			})),
+			findHandleTimestamp,
 		});
 	};
 
@@ -1461,7 +1464,9 @@ async function webviewPreloads(ctx: PreloadContext) {
 				break;
 			}
 			case 'findStop': {
-				_highlighter?.dispose();
+				if (findHandleTimestamp === event.data.findHandleTimestamp) {
+					_highlighter?.dispose();
+				}
 				break;
 			}
 			case 'returnOutputItem': {

--- a/src/vs/workbench/contrib/notebook/test/browser/testNotebookEditor.ts
+++ b/src/vs/workbench/contrib/notebook/test/browser/testNotebookEditor.ts
@@ -41,7 +41,7 @@ import { UndoRedoService } from 'vs/platform/undoRedo/common/undoRedoService';
 import { IWorkspaceTrustRequestService } from 'vs/platform/workspace/common/workspaceTrust';
 import { EditorInput } from 'vs/workbench/common/editor/editorInput';
 import { EditorModel } from 'vs/workbench/common/editor/editorModel';
-import { CellFindMatchWithIndex, IActiveNotebookEditorDelegate, IBaseCellEditorOptions, ICellViewModel, INotebookEditorDelegate } from 'vs/workbench/contrib/notebook/browser/notebookBrowser';
+import { CellFindMatchWithIndex, IActiveNotebookEditorDelegate, IBaseCellEditorOptions, ICellViewModel, INotebookEditorDelegate, INotebookEditorFindHandle } from 'vs/workbench/contrib/notebook/browser/notebookBrowser';
 import { NotebookCellStateChangedEvent } from 'vs/workbench/contrib/notebook/browser/notebookViewEvents';
 import { NotebookCellStatusBarService } from 'vs/workbench/contrib/notebook/browser/services/notebookCellStatusBarServiceImpl';
 import { ListViewInfoAccessor, NotebookCellList } from 'vs/workbench/contrib/notebook/browser/view/notebookCellList';
@@ -282,6 +282,9 @@ function _createTestNotebookEditor(instantiationService: TestInstantiationServic
 		override async find(query: string, options: INotebookSearchOptions): Promise<CellFindMatchWithIndex[]> {
 			const findMatches = viewModel.find(query, options).filter(match => match.length > 0);
 			return findMatches;
+		}
+		override getFindHandle(): INotebookEditorFindHandle {
+			return { timestamp: NaN };
 		}
 		override deltaCellDecorations() { return []; }
 		override onDidChangeVisibleRanges = Event.None;


### PR DESCRIPTION
Fix #187016.

The issue was caused by a race condition which mis-orders `BackLayerWebView.find()` and `BackLayerWebView.findStop()`. Specifically, there could be a chance that

1. On a query entered, `BackLayerWebView.find()` is firstly called, where the old highlighter is disposed, and a new highlighter is created to mark matched texts.
2. Then `BackLayerWebView.findStop()` is called, which tries to dispose the _old_ highlighter, but the _new_ one is actually incorrectly disposed, causing the above issue.

To address the issue, I assign a unique handle to each `find()` call, and `findStop(handle)` will dispose the highlighter only if the supplied handle equals to the handle of last `find()` call. By this way we erase the possibility that a newly created highlighter is incorrectly disposed by old disposers.
