### PR TITLE
Debug API proposal: Expose selected configuration

### DIFF
--- a/extensions/vscode-api-tests/package.json
+++ b/extensions/vscode-api-tests/package.json
@@ -8,6 +8,7 @@
     "authSession",
     "contribViewsRemote",
     "contribStatusBarItems",
+    "debugSelectedConfiguration",
     "customEditorMove",
     "diffCommand",
     "documentFiltersExclusive",

--- a/src/vs/workbench/api/browser/mainThreadDebugService.ts
+++ b/src/vs/workbench/api/browser/mainThreadDebugService.ts
@@ -83,6 +83,10 @@ export class MainThreadDebugService implements MainThreadDebugServiceShape, IDeb
 				this._proxy.$acceptStackFrameFocus(dto);
 			}
 		}));
+		this._proxy.$signalActiveConfigurationChanged(false, this.debugService.getConfigurationManager().selectedConfiguration?.name);
+		this.debugService.getConfigurationManager().onDidSelectConfiguration(() => {
+			this._proxy.$signalActiveConfigurationChanged(true, this.debugService.getConfigurationManager().selectedConfiguration?.name);
+		});
 		this.sendBreakpointsAndListen();
 	}
 
@@ -169,6 +173,10 @@ export class MainThreadDebugService implements MainThreadDebugServiceShape, IDeb
 			}
 		}
 		return Promise.resolve();
+	}
+
+	public $setSelectedConfiguration(name: string) {
+		this.debugService.getConfigurationManager().selectConfiguration(undefined, name);
 	}
 
 	public $unregisterBreakpoints(breakpointIds: string[], functionBreakpointIds: string[], dataBreakpointIds: string[]): Promise<void> {

--- a/src/vs/workbench/api/common/extHost.api.impl.ts
+++ b/src/vs/workbench/api/common/extHost.api.impl.ts
@@ -1154,6 +1154,10 @@ export function createApiFactoryAndRegisterActors(accessor: ServicesAccessor): I
 			get stackFrameFocus() {
 				return extHostDebugService.stackFrameFocus;
 			},
+			get selectedConfiguration() {
+				const selectedConfigurationName = extHostDebugService.selectedConfigurationName;
+				return selectedConfigurationName ? { name: selectedConfigurationName } : undefined;
+			},
 			onDidStartDebugSession(listener, thisArg?, disposables?) {
 				return extHostDebugService.onDidStartDebugSession(listener, thisArg, disposables);
 			},
@@ -1168,6 +1172,9 @@ export function createApiFactoryAndRegisterActors(accessor: ServicesAccessor): I
 			},
 			onDidChangeBreakpoints(listener, thisArgs?, disposables?) {
 				return extHostDebugService.onDidChangeBreakpoints(listener, thisArgs, disposables);
+			},
+			onDidChangeSelectedConfiguration(listener, thisArgs?, disposables?) {
+				return extHostDebugService.onDidChangeSelectedConfiguration(listener, thisArgs, disposables);
 			},
 			onDidChangeStackFrameFocus(listener, thisArg?, disposables?) {
 				checkProposedApiEnabled(extension, 'debugFocus');
@@ -1199,6 +1206,9 @@ export function createApiFactoryAndRegisterActors(accessor: ServicesAccessor): I
 			},
 			asDebugSourceUri(source: vscode.DebugProtocolSource, session?: vscode.DebugSession): vscode.Uri {
 				return extHostDebugService.asDebugSourceUri(source, session);
+			},
+			setSelectedConfiguration(name) {
+				return extHostDebugService.setSelectedConfiguration(name);
 			}
 		};
 

--- a/src/vs/workbench/api/common/extHost.api.impl.ts
+++ b/src/vs/workbench/api/common/extHost.api.impl.ts
@@ -1155,6 +1155,7 @@ export function createApiFactoryAndRegisterActors(accessor: ServicesAccessor): I
 				return extHostDebugService.stackFrameFocus;
 			},
 			get selectedConfiguration() {
+				checkProposedApiEnabled(extension, 'debugSelectedConfiguration');
 				const selectedConfigurationName = extHostDebugService.selectedConfigurationName;
 				return selectedConfigurationName ? { name: selectedConfigurationName } : undefined;
 			},
@@ -1174,6 +1175,7 @@ export function createApiFactoryAndRegisterActors(accessor: ServicesAccessor): I
 				return extHostDebugService.onDidChangeBreakpoints(listener, thisArgs, disposables);
 			},
 			onDidChangeSelectedConfiguration(listener, thisArgs?, disposables?) {
+				checkProposedApiEnabled(extension, 'debugSelectedConfiguration');
 				return extHostDebugService.onDidChangeSelectedConfiguration(listener, thisArgs, disposables);
 			},
 			onDidChangeStackFrameFocus(listener, thisArg?, disposables?) {
@@ -1208,6 +1210,7 @@ export function createApiFactoryAndRegisterActors(accessor: ServicesAccessor): I
 				return extHostDebugService.asDebugSourceUri(source, session);
 			},
 			setSelectedConfiguration(name) {
+				checkProposedApiEnabled(extension, 'debugSelectedConfiguration');
 				return extHostDebugService.setSelectedConfiguration(name);
 			}
 		};

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -1406,6 +1406,7 @@ export interface MainThreadDebugServiceShape extends IDisposable {
 	$appendDebugConsole(value: string): void;
 	$registerBreakpoints(breakpoints: Array<ISourceMultiBreakpointDto | IFunctionBreakpointDto | IDataBreakpointDto>): Promise<void>;
 	$unregisterBreakpoints(breakpointIds: string[], functionBreakpointIds: string[], dataBreakpointIds: string[]): Promise<void>;
+	$setSelectedConfiguration(name: string): void;
 }
 
 export interface IOpenUriOptions {
@@ -2143,6 +2144,7 @@ export interface ExtHostDebugServiceShape {
 	$acceptBreakpointsDelta(delta: IBreakpointsDeltaDto): void;
 	$acceptDebugSessionNameChanged(session: IDebugSessionDto, name: string): void;
 	$acceptStackFrameFocus(focus: IThreadFocusDto | IStackFrameFocusDto | undefined): void;
+	$signalActiveConfigurationChanged(fireEvent: boolean, configurationName: string | undefined): void;
 }
 
 

--- a/src/vs/workbench/services/extensions/common/extensionsApiProposals.ts
+++ b/src/vs/workbench/services/extensions/common/extensionsApiProposals.ts
@@ -27,6 +27,7 @@ export const allApiProposals = Object.freeze({
 	contribViewsWelcome: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.contribViewsWelcome.d.ts',
 	customEditorMove: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.customEditorMove.d.ts',
 	debugFocus: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.debugFocus.d.ts',
+	debugSelectedConfiguration: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.debugSelectedConfiguration.d.ts',
 	diffCommand: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.diffCommand.d.ts',
 	diffContentOptions: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.diffContentOptions.d.ts',
 	documentFiltersExclusive: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.documentFiltersExclusive.d.ts',

--- a/src/vscode-dts/vscode.d.ts
+++ b/src/vscode-dts/vscode.d.ts
@@ -15200,10 +15200,6 @@ declare module 'vscode' {
 		Dynamic = 2
 	}
 
-	export interface SelectedDebugConfiguration {
-		name: string;
-	}
-
 	/**
 	 * Namespace for debug functionality.
 	 */
@@ -15226,11 +15222,6 @@ declare module 'vscode' {
 		 * List of breakpoints.
 		 */
 		export let breakpoints: readonly Breakpoint[];
-
-		/**
-		 * The debug configuration, which is currently selected by the user.
-		 */
-		export const selectedConfiguration: SelectedDebugConfiguration | undefined;
 
 		/**
 		 * An {@link Event} which fires when the {@link debug.activeDebugSession active debug session}
@@ -15258,11 +15249,6 @@ declare module 'vscode' {
 		 * An {@link Event} that is emitted when the set of breakpoints is added, removed, or changed.
 		 */
 		export const onDidChangeBreakpoints: Event<BreakpointsChangeEvent>;
-
-		/**
-		 * An {@link Event} that is emitted when the set of breakpoints is added, removed, or changed.
-		 */
-		export const onDidChangeSelectedConfiguration: Event<void>;
 
 		/**
 		 * Register a {@link DebugConfigurationProvider debug configuration provider} for a specific debug type.
@@ -15343,13 +15329,6 @@ declare module 'vscode' {
 		 * @return A uri that can be used to load the contents of the source.
 		 */
 		export function asDebugSourceUri(source: DebugProtocolSource, session?: DebugSession): Uri;
-
-		/**
-		 * Change selected debug configuration by name. This will also fire a 'onDidChangeConfiguration' event.
-		 *
-		 * @param name Name
-		 */
-		export function setSelectedConfiguration(name: string): void;
 	}
 
 	/**

--- a/src/vscode-dts/vscode.d.ts
+++ b/src/vscode-dts/vscode.d.ts
@@ -1207,7 +1207,7 @@ declare module 'vscode' {
 		 * or accept the snippet.
 		 *
 		 * @param snippet The snippet to insert in this edit.
-		 * @param location Position or range at which to insert the snippet, defaults to the current editor selection or selections.
+		 * @param location Position o r range at which to insert the snippet, defaults to the current editor selection or selections.
 		 * @param options The undo/redo behavior around this edit. By default, undo stops will be created before and after this edit.
 		 * @return A promise that resolves with a value indicating if the snippet could be inserted. Note that the promise does not signal
 		 * that the snippet is completely filled-in or accepted.
@@ -15200,6 +15200,10 @@ declare module 'vscode' {
 		Dynamic = 2
 	}
 
+	export interface SelectedDebugConfiguration {
+		name: string;
+	}
+
 	/**
 	 * Namespace for debug functionality.
 	 */
@@ -15222,6 +15226,13 @@ declare module 'vscode' {
 		 * List of breakpoints.
 		 */
 		export let breakpoints: readonly Breakpoint[];
+
+		/**
+		 * The debug configuration, which is currently selected by the user.
+		 */
+		export const selectedConfiguration: SelectedDebugConfiguration | undefined;
+
+		export function setSelectedConfiguration(name: string): void;
 
 		/**
 		 * An {@link Event} which fires when the {@link debug.activeDebugSession active debug session}
@@ -15249,6 +15260,11 @@ declare module 'vscode' {
 		 * An {@link Event} that is emitted when the set of breakpoints is added, removed, or changed.
 		 */
 		export const onDidChangeBreakpoints: Event<BreakpointsChangeEvent>;
+
+		/**
+		 * An {@link Event} that is emitted when the set of breakpoints is added, removed, or changed.
+		 */
+		export const onDidChangeSelectedConfiguration: Event<void>;
 
 		/**
 		 * Register a {@link DebugConfigurationProvider debug configuration provider} for a specific debug type.

--- a/src/vscode-dts/vscode.d.ts
+++ b/src/vscode-dts/vscode.d.ts
@@ -1207,7 +1207,7 @@ declare module 'vscode' {
 		 * or accept the snippet.
 		 *
 		 * @param snippet The snippet to insert in this edit.
-		 * @param location Position o r range at which to insert the snippet, defaults to the current editor selection or selections.
+		 * @param location Position or range at which to insert the snippet, defaults to the current editor selection or selections.
 		 * @param options The undo/redo behavior around this edit. By default, undo stops will be created before and after this edit.
 		 * @return A promise that resolves with a value indicating if the snippet could be inserted. Note that the promise does not signal
 		 * that the snippet is completely filled-in or accepted.
@@ -15232,8 +15232,6 @@ declare module 'vscode' {
 		 */
 		export const selectedConfiguration: SelectedDebugConfiguration | undefined;
 
-		export function setSelectedConfiguration(name: string): void;
-
 		/**
 		 * An {@link Event} which fires when the {@link debug.activeDebugSession active debug session}
 		 * has changed. *Note* that the event also fires when the active debug session changes
@@ -15345,6 +15343,13 @@ declare module 'vscode' {
 		 * @return A uri that can be used to load the contents of the source.
 		 */
 		export function asDebugSourceUri(source: DebugProtocolSource, session?: DebugSession): Uri;
+
+		/**
+		 * Change selected debug configuration by name. This will also fire a 'onDidChangeConfiguration' event.
+		 *
+		 * @param name Name
+		 */
+		export function setSelectedConfiguration(name: string): void;
 	}
 
 	/**

--- a/src/vscode-dts/vscode.proposed.debugSelectedConfiguration.d.ts
+++ b/src/vscode-dts/vscode.proposed.debugSelectedConfiguration.d.ts
@@ -1,0 +1,31 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+declare module 'vscode' {
+
+	export interface SelectedDebugConfiguration {
+		name: string;
+	}
+
+	export namespace debug {
+		/**
+		 * The debug configuration, which is currently selected by the user.
+		 */
+		export const selectedConfiguration: SelectedDebugConfiguration | undefined;
+
+		/**
+		 * An {@link Event} that is emitted when the set of breakpoints is added, removed, or changed.
+		 */
+		export const onDidChangeSelectedConfiguration: Event<void>;
+
+		/**
+		 * Change selected debug configuration by name. This will also fire a 'onDidChangeConfiguration' event.
+		 * If the name of new configuration cannot be found, the selected configuration stays unchanged.
+		 *
+		 * @param name Name of new debug configuration
+		 */
+		export function setSelectedConfiguration(name: string): void;
+	}
+}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

It introduces 3 new interactaction points with `debug` API:

```ts
console.log('initial:', vscode.debug.selectedConfiguration); // initial Launch Extension

vscode.debug.onDidChangeSelectedConfiguration(() => {
  console.log('changed:', vscode.debug.selectedConfiguration); // changed Launch Extension
});

const changeLaunchName = () => {
  vscode.debug.setSelectedConfiguration('Launch Extension')
}
```

Use cases:
- Intelligent extension can help user with picking right launch configuration (in specific cases this API shape would also allow to have UI in sync, preventing any unexpected surprises for the user).

closes https://github.com/microsoft/vscode/issues/173788