### PR TITLE
announce ghost text to screen reader users in inline chat

### DIFF
--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatWidget.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatWidget.ts
@@ -179,6 +179,7 @@ export class InlineChatWidget {
 	private _isLayouting: boolean = false;
 	private _preferredExpansionState: ExpansionState | undefined;
 	private _expansionState: ExpansionState = ExpansionState.NOT_CROPPED;
+	private _slashCommandDetails: { command: string; detail: string }[] = [];
 
 	constructor(
 		private readonly parentEditor: ICodeEditor,
@@ -418,9 +419,12 @@ export class InlineChatWidget {
 	}
 
 	readPlaceholder(): void {
+		const slashCommand = this._slashCommandDetails.find(c => `${c.command} ` === this._inputModel.getValue().substring(1));
 		const hasText = this._inputModel.getValueLength() > 0;
 		if (!hasText) {
 			aria.status(this._elements.placeholder.innerText);
+		} else if (slashCommand) {
+			aria.status(slashCommand.detail);
 		}
 	}
 
@@ -621,6 +625,7 @@ export class InlineChatWidget {
 		if (commands.length === 0) {
 			return;
 		}
+		this._slashCommandDetails = commands.filter(c => c.command && c.detail).map(c => { return { command: c.command!, detail: c.detail! }; });
 
 		const selector: LanguageSelector = { scheme: this._inputModel.uri.scheme, pattern: this._inputModel.uri.path, language: this._inputModel.getLanguageId() };
 		this._slashCommands.add(this._languageFeaturesService.completionProvider.register(selector, new class implements CompletionItemProvider {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
fix part of #186409

@rperez030, there is some ghost text that appears when a slash command is used. we haven't been announcing that to screen readers. it would be fantastic if you could test and let us know what you think of this change 😄 

Alt text: `start code chat` is invoked, I type `/fix` then a space and when I see the ghost text of the description for the command, it is read by the screen reader using aria `status`

https://github.com/microsoft/vscode/assets/29464607/cfbd7de3-9cd4-4ecb-a183-6e44a8307022

