### PR TITLE
allow multiple callers for decorating notebook webview

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/contrib/find/findMatchDecorationModel.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/find/findMatchDecorationModel.ts
@@ -18,7 +18,7 @@ export class FindMatchDecorationModel extends Disposable {
 
 	constructor(
 		private readonly _notebookEditor: INotebookEditor,
-		private readonly webviewOwnerID: string,
+		private readonly ownerID: string,
 	) {
 		super();
 	}
@@ -76,7 +76,7 @@ export class FindMatchDecorationModel extends Disposable {
 
 		this.clearCurrentFindMatchDecoration();
 
-		const offset = await this._notebookEditor.highlightFind(index, this.webviewOwnerID);
+		const offset = await this._notebookEditor.findHighlightCurrent(index, this.ownerID);
 		this._currentMatchDecorations = { kind: 'output', index: index };
 
 		this._currentMatchCellDecorations = this._notebookEditor.deltaCellDecorations(this._currentMatchCellDecorations, [{
@@ -102,7 +102,7 @@ export class FindMatchDecorationModel extends Disposable {
 				this._currentMatchDecorations = null;
 			});
 		} else if (this._currentMatchDecorations?.kind === 'output') {
-			this._notebookEditor.unHighlightFind(this._currentMatchDecorations.index, this.webviewOwnerID);
+			this._notebookEditor.findUnHighlightCurrent(this._currentMatchDecorations.index, this.ownerID);
 		}
 
 		this._currentMatchCellDecorations = this._notebookEditor.deltaCellDecorations(this._currentMatchCellDecorations, []);
@@ -146,7 +146,7 @@ export class FindMatchDecorationModel extends Disposable {
 	}
 
 	stopWebviewFind() {
-		this._notebookEditor.findStop(this.webviewOwnerID);
+		this._notebookEditor.findStop(this.ownerID);
 	}
 
 	override dispose() {

--- a/src/vs/workbench/contrib/notebook/browser/contrib/find/findMatchDecorationModel.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/find/findMatchDecorationModel.ts
@@ -17,7 +17,8 @@ export class FindMatchDecorationModel extends Disposable {
 	private _currentMatchDecorations: { kind: 'input'; decorations: ICellModelDecorations[] } | { kind: 'output'; index: number } | null = null;
 
 	constructor(
-		private readonly _notebookEditor: INotebookEditor
+		private readonly _notebookEditor: INotebookEditor,
+		private readonly webviewOwnerID: string,
 	) {
 		super();
 	}
@@ -26,7 +27,7 @@ export class FindMatchDecorationModel extends Disposable {
 		return this._currentMatchDecorations;
 	}
 
-	public clearDecorations() {
+	private clearDecorations() {
 		this.clearCurrentFindMatchDecoration();
 		this.setAllFindMatchesDecorations([]);
 	}
@@ -75,7 +76,7 @@ export class FindMatchDecorationModel extends Disposable {
 
 		this.clearCurrentFindMatchDecoration();
 
-		const offset = await this._notebookEditor.highlightFind(index);
+		const offset = await this._notebookEditor.highlightFind(index, this.webviewOwnerID);
 		this._currentMatchDecorations = { kind: 'output', index: index };
 
 		this._currentMatchCellDecorations = this._notebookEditor.deltaCellDecorations(this._currentMatchCellDecorations, [{
@@ -101,7 +102,7 @@ export class FindMatchDecorationModel extends Disposable {
 				this._currentMatchDecorations = null;
 			});
 		} else if (this._currentMatchDecorations?.kind === 'output') {
-			this._notebookEditor.unHighlightFind(this._currentMatchDecorations.index);
+			this._notebookEditor.unHighlightFind(this._currentMatchDecorations.index, this.webviewOwnerID);
 		}
 
 		this._currentMatchCellDecorations = this._notebookEditor.deltaCellDecorations(this._currentMatchCellDecorations, []);
@@ -145,7 +146,7 @@ export class FindMatchDecorationModel extends Disposable {
 	}
 
 	stopWebviewFind() {
-		this._notebookEditor.findStop();
+		this._notebookEditor.findStop(this.webviewOwnerID);
 	}
 
 	override dispose() {

--- a/src/vs/workbench/contrib/notebook/browser/contrib/find/findModel.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/find/findModel.ts
@@ -111,7 +111,7 @@ export class FindModel extends Disposable {
 			this._registerModelListener(this._notebookEditor.textModel);
 		}
 
-		this._findMatchDecorationModel = new FindMatchDecorationModel(this._notebookEditor);
+		this._findMatchDecorationModel = new FindMatchDecorationModel(this._notebookEditor, this._notebookEditor.getId());
 	}
 
 	private _updateCellStates(e: FindReplaceStateChangedEvent) {

--- a/src/vs/workbench/contrib/notebook/browser/notebookBrowser.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookBrowser.ts
@@ -674,8 +674,8 @@ export interface INotebookEditor {
 	getNextVisibleCellIndex(index: number): number | undefined;
 	getPreviousVisibleCellIndex(index: number): number | undefined;
 	find(query: string, options: INotebookSearchOptions, token: CancellationToken, skipWarmup?: boolean, shouldGetSearchPreviewInfo?: boolean, ownerID?: string): Promise<CellFindMatchWithIndex[]>;
-	highlightFind(matchIndex: number, ownerID?: string): Promise<number>;
-	unHighlightFind(matchIndex: number, ownerID?: string): Promise<void>;
+	findHighlightCurrent(matchIndex: number, ownerID?: string): Promise<number>;
+	findUnHighlightCurrent(matchIndex: number, ownerID?: string): Promise<void>;
 	findStop(ownerID?: string): void;
 	showProgress(): void;
 	hideProgress(): void;

--- a/src/vs/workbench/contrib/notebook/browser/notebookBrowser.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookBrowser.ts
@@ -673,10 +673,10 @@ export interface INotebookEditor {
 	getCellIndex(cell: ICellViewModel): number | undefined;
 	getNextVisibleCellIndex(index: number): number | undefined;
 	getPreviousVisibleCellIndex(index: number): number | undefined;
-	find(query: string, options: INotebookSearchOptions, token: CancellationToken): Promise<CellFindMatchWithIndex[]>;
-	highlightFind(matchIndex: number): Promise<number>;
-	unHighlightFind(matchIndex: number): Promise<void>;
-	findStop(): void;
+	find(query: string, options: INotebookSearchOptions, token: CancellationToken, skipWarmup?: boolean, shouldGetSearchPreviewInfo?: boolean, ownerID?: string): Promise<CellFindMatchWithIndex[]>;
+	highlightFind(matchIndex: number, ownerID?: string): Promise<number>;
+	unHighlightFind(matchIndex: number, ownerID?: string): Promise<void>;
+	findStop(ownerID?: string): void;
 	showProgress(): void;
 	hideProgress(): void;
 

--- a/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
@@ -2439,15 +2439,19 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditorD
 		return Promise.all(requests);
 	}
 
-	async find(query: string, options: INotebookSearchOptions, token: CancellationToken, skipWarmup: boolean = false, shouldGetSearchPreviewInfo = false): Promise<CellFindMatchWithIndex[]> {
+	async find(query: string, options: INotebookSearchOptions, token: CancellationToken, skipWarmup: boolean = false, shouldGetSearchPreviewInfo = false, ownerID?: string): Promise<CellFindMatchWithIndex[]> {
 		if (!this._notebookViewModel) {
 			return [];
+		}
+
+		if (!ownerID) {
+			ownerID = this.getId();
 		}
 
 		const findMatches = this._notebookViewModel.find(query, options).filter(match => match.length > 0);
 
 		if (!options.includeMarkupPreview && !options.includeOutput) {
-			this._webview?.findStop();
+			this._webview?.findStop(ownerID);
 			return findMatches;
 		}
 
@@ -2470,7 +2474,7 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditorD
 				return [];
 			}
 
-			const webviewMatches = await this._webview.find(query, { caseSensitive: options.caseSensitive, wholeWord: options.wholeWord, includeMarkup: !!options.includeMarkupPreview, includeOutput: !!options.includeOutput, shouldGetSearchPreviewInfo });
+			const webviewMatches = await this._webview.find(query, { caseSensitive: options.caseSensitive, wholeWord: options.wholeWord, includeMarkup: !!options.includeMarkupPreview, includeOutput: !!options.includeOutput, shouldGetSearchPreviewInfo, ownerID });
 
 			if (token.isCancellationRequested) {
 				return [];
@@ -2526,24 +2530,24 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditorD
 		return ret;
 	}
 
-	async highlightFind(matchIndex: number): Promise<number> {
+	async highlightFind(matchIndex: number, ownerID?: string): Promise<number> {
 		if (!this._webview) {
 			return 0;
 		}
 
-		return this._webview?.findHighlightCurrent(matchIndex);
+		return this._webview?.findHighlightCurrent(matchIndex, ownerID ?? this.getId());
 	}
 
-	async unHighlightFind(matchIndex: number): Promise<void> {
+	async unHighlightFind(matchIndex: number, ownerID?: string): Promise<void> {
 		if (!this._webview) {
 			return;
 		}
 
-		return this._webview?.findUnHighlightCurrent(matchIndex);
+		return this._webview?.findUnHighlightCurrent(matchIndex, ownerID ?? this.getId());
 	}
 
-	findStop() {
-		this._webview?.findStop();
+	findStop(ownerID?: string) {
+		this._webview?.findStop(ownerID ?? this.getId());
 	}
 
 	//#endregion

--- a/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
@@ -2530,7 +2530,7 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditorD
 		return ret;
 	}
 
-	async highlightFind(matchIndex: number, ownerID?: string): Promise<number> {
+	async findHighlightCurrent(matchIndex: number, ownerID?: string): Promise<number> {
 		if (!this._webview) {
 			return 0;
 		}
@@ -2538,7 +2538,7 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditorD
 		return this._webview?.findHighlightCurrent(matchIndex, ownerID ?? this.getId());
 	}
 
-	async unHighlightFind(matchIndex: number, ownerID?: string): Promise<void> {
+	async findUnHighlightCurrent(matchIndex: number, ownerID?: string): Promise<void> {
 		if (!this._webview) {
 			return;
 		}

--- a/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
@@ -2531,7 +2531,7 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditorD
 			return 0;
 		}
 
-		return this._webview?.findHighlight(matchIndex);
+		return this._webview?.findHighlightCurrent(matchIndex);
 	}
 
 	async unHighlightFind(matchIndex: number): Promise<void> {
@@ -2539,7 +2539,7 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditorD
 			return;
 		}
 
-		return this._webview?.findUnHighlight(matchIndex);
+		return this._webview?.findUnHighlightCurrent(matchIndex);
 	}
 
 	findStop() {

--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView.ts
@@ -1638,10 +1638,10 @@ export class BackLayerWebView<T extends ICommonCellInfo> extends Themable {
 		});
 	}
 
-	async findHighlight(index: number): Promise<number> {
+	async findHighlightCurrent(index: number): Promise<number> {
 		const p = new Promise<number>(resolve => {
 			const sub = this.webview?.onMessage(e => {
-				if (e.message.type === 'didFindHighlight') {
+				if (e.message.type === 'didFindHighlightCurrent') {
 					resolve(e.message.offset);
 					sub?.dispose();
 				}
@@ -1649,7 +1649,7 @@ export class BackLayerWebView<T extends ICommonCellInfo> extends Themable {
 		});
 
 		this._sendMessageToWebview({
-			type: 'findHighlight',
+			type: 'findHighlightCurrent',
 			index
 		});
 
@@ -1657,9 +1657,9 @@ export class BackLayerWebView<T extends ICommonCellInfo> extends Themable {
 		return ret;
 	}
 
-	async findUnHighlight(index: number): Promise<void> {
+	async findUnHighlightCurrent(index: number): Promise<void> {
 		this._sendMessageToWebview({
-			type: 'findUnHighlight',
+			type: 'findUnHighlightCurrent',
 			index
 		});
 	}

--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView.ts
@@ -1608,7 +1608,7 @@ export class BackLayerWebView<T extends ICommonCellInfo> extends Themable {
 		});
 	}
 
-	async find(query: string, options: { wholeWord?: boolean; caseSensitive?: boolean; includeMarkup: boolean; includeOutput: boolean; shouldGetSearchPreviewInfo: boolean }): Promise<IFindMatch[]> {
+	async find(query: string, options: { wholeWord?: boolean; caseSensitive?: boolean; includeMarkup: boolean; includeOutput: boolean; shouldGetSearchPreviewInfo: boolean; ownerID: string }): Promise<IFindMatch[]> {
 		if (query === '') {
 			return [];
 		}
@@ -1632,13 +1632,14 @@ export class BackLayerWebView<T extends ICommonCellInfo> extends Themable {
 		return ret;
 	}
 
-	findStop() {
+	findStop(ownerID: string) {
 		this._sendMessageToWebview({
-			type: 'findStop'
+			type: 'findStop',
+			ownerID
 		});
 	}
 
-	async findHighlightCurrent(index: number): Promise<number> {
+	async findHighlightCurrent(index: number, ownerID: string): Promise<number> {
 		const p = new Promise<number>(resolve => {
 			const sub = this.webview?.onMessage(e => {
 				if (e.message.type === 'didFindHighlightCurrent') {
@@ -1650,17 +1651,19 @@ export class BackLayerWebView<T extends ICommonCellInfo> extends Themable {
 
 		this._sendMessageToWebview({
 			type: 'findHighlightCurrent',
-			index
+			index,
+			ownerID
 		});
 
 		const ret = await p;
 		return ret;
 	}
 
-	async findUnHighlightCurrent(index: number): Promise<void> {
+	async findUnHighlightCurrent(index: number, ownerID: string): Promise<void> {
 		this._sendMessageToWebview({
 			type: 'findUnHighlightCurrent',
-			index
+			index,
+			ownerID
 		});
 	}
 

--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewMessages.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewMessages.ts
@@ -401,13 +401,13 @@ export interface IFindMessage {
 }
 
 
-export interface IFindHighlightMessage {
-	readonly type: 'findHighlight';
+export interface IFindHighlightCurrentMessage {
+	readonly type: 'findHighlightCurrent';
 	readonly index: number;
 }
 
-export interface IFindUnHighlightMessage {
-	readonly type: 'findUnHighlight';
+export interface IFindUnHighlightCurrentMessage {
+	readonly type: 'findUnHighlightCurrent';
 	readonly index: number;
 }
 
@@ -436,8 +436,8 @@ export interface IDidFindMessage extends BaseToWebviewMessage {
 	readonly matches: IFindMatch[];
 }
 
-export interface IDidFindHighlightMessage extends BaseToWebviewMessage {
-	readonly type: 'didFindHighlight';
+export interface IDidFindHighlightCurrentMessage extends BaseToWebviewMessage {
+	readonly type: 'didFindHighlightCurrent';
 	readonly offset: number;
 }
 
@@ -502,7 +502,7 @@ export type FromWebviewMessage = WebviewInitialized |
 	IRenderedMarkupMessage |
 	IRenderedCellOutputMessage |
 	IDidFindMessage |
-	IDidFindHighlightMessage |
+	IDidFindHighlightCurrentMessage |
 	IOutputResizedMessage |
 	IGetOutputItemMessage |
 	ILogRendererDebugMessage |
@@ -534,8 +534,8 @@ export type ToWebviewMessage = IClearMessage |
 	ITokenizedCodeBlockMessage |
 	ITokenizedStylesChangedMessage |
 	IFindMessage |
-	IFindHighlightMessage |
-	IFindUnHighlightMessage |
+	IFindHighlightCurrentMessage |
+	IFindUnHighlightCurrentMessage |
 	IFindStopMessage |
 	IReturnOutputItemMessage;
 

--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewMessages.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewMessages.ts
@@ -397,22 +397,25 @@ export interface ITokenizedStylesChangedMessage {
 export interface IFindMessage {
 	readonly type: 'find';
 	readonly query: string;
-	readonly options: { wholeWord?: boolean; caseSensitive?: boolean; includeMarkup: boolean; includeOutput: boolean; shouldGetSearchPreviewInfo: boolean };
+	readonly options: { wholeWord?: boolean; caseSensitive?: boolean; includeMarkup: boolean; includeOutput: boolean; shouldGetSearchPreviewInfo: boolean; ownerID: string };
 }
 
 
 export interface IFindHighlightCurrentMessage {
 	readonly type: 'findHighlightCurrent';
 	readonly index: number;
+	readonly ownerID: string;
 }
 
 export interface IFindUnHighlightCurrentMessage {
 	readonly type: 'findUnHighlightCurrent';
 	readonly index: number;
+	readonly ownerID: string;
 }
 
 export interface IFindStopMessage {
 	readonly type: 'findStop';
+	readonly ownerID: string;
 }
 
 export interface ISearchPreviewInfo {

--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewPreloads.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewPreloads.ts
@@ -961,7 +961,7 @@ async function webviewPreloads(ctx: PreloadContext) {
 				match.highlightResult?.update(currentMatchColor, match.isShadow ? undefined : 'current-find-match');
 
 				document.getSelection()?.removeAllRanges();
-				postNotebookMessage('didFindHighlight', {
+				postNotebookMessage('didFindHighlightCurrent', {
 					offset
 				});
 			}
@@ -1015,7 +1015,7 @@ async function webviewPreloads(ctx: PreloadContext) {
 					match.originalRange.startContainer.parentElement?.scrollIntoView({ behavior: 'auto', block: 'end', inline: 'nearest' });
 					const rangeOffset = match.originalRange.getBoundingClientRect().top;
 					offset = rangeOffset - outputOffset;
-					postNotebookMessage('didFindHighlight', {
+					postNotebookMessage('didFindHighlightCurrent', {
 						offset
 					});
 				} catch (e) {
@@ -1452,11 +1452,11 @@ async function webviewPreloads(ctx: PreloadContext) {
 				find(event.data.query, event.data.options);
 				break;
 			}
-			case 'findHighlight': {
+			case 'findHighlightCurrent': {
 				_highlighter?.highlightCurrentMatch(event.data.index);
 				break;
 			}
-			case 'findUnHighlight': {
+			case 'findUnHighlightCurrent': {
 				_highlighter?.unHighlightCurrentMatch(event.data.index);
 				break;
 			}

--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewPreloads.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewPreloads.ts
@@ -1007,6 +1007,11 @@ async function webviewPreloads(ctx: PreloadContext) {
 
 		dispose() {
 			document.getSelection()?.removeAllRanges();
+			this._activeHighlightInfo.forEach(highlightInfo => {
+				highlightInfo.matches.forEach(match => {
+					match.highlightResult?.dispose();
+				});
+			});
 		}
 	}
 
@@ -1519,7 +1524,6 @@ async function webviewPreloads(ctx: PreloadContext) {
 			}
 			case 'find': {
 				_highlighter.removeHighlights(event.data.options.ownerID);
-
 				find(event.data.query, event.data.options);
 				break;
 			}

--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewPreloads.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewPreloads.ts
@@ -908,21 +908,30 @@ async function webviewPreloads(ctx: PreloadContext) {
 	}
 
 	interface IHighlighter {
-		highlightCurrentMatch(index: number): void;
-		unHighlightCurrentMatch(index: number): void;
+		addHighlights(matches: IFindMatch[], ownerID: string): void;
+		removeHighlights(ownerID: string): void;
+		highlightCurrentMatch(index: number, ownerID: string): void;
+		unHighlightCurrentMatch(index: number, ownerID: string): void;
 		dispose(): void;
 	}
 
-	let _highlighter: IHighlighter | null = null;
+	interface IHighlightInfo {
+		matches: IFindMatch[];
+		currentMatchIndex: number;
+	}
+
 	const matchColor = window.getComputedStyle(document.getElementById('_defaultColorPalatte')!).color;
 	const currentMatchColor = window.getComputedStyle(document.getElementById('_defaultColorPalatte')!).backgroundColor;
 
 	class JSHighlighter implements IHighlighter {
-		private _findMatchIndex = -1;
+		private _activeHighlightInfo: Map<string, IHighlightInfo>;
 
 		constructor(
-			readonly matches: IFindMatch[],
 		) {
+			this._activeHighlightInfo = new Map();
+		}
+
+		addHighlights(matches: IFindMatch[], ownerID: string): void {
 			for (let i = matches.length - 1; i >= 0; i--) {
 				const match = matches[i];
 				const ret = highlightRange(match.originalRange, true, 'mark', match.isShadow ? {
@@ -932,14 +941,32 @@ async function webviewPreloads(ctx: PreloadContext) {
 				});
 				match.highlightResult = ret;
 			}
+
+			const highlightInfo: IHighlightInfo = {
+				matches,
+				currentMatchIndex: -1
+			};
+			this._activeHighlightInfo.set(ownerID, highlightInfo);
 		}
 
-		highlightCurrentMatch(index: number) {
-			const oldMatch = this.matches[this._findMatchIndex];
+		removeHighlights(ownerID: string): void {
+			this._activeHighlightInfo.get(ownerID)?.matches.forEach(match => {
+				match.highlightResult?.dispose();
+			});
+			this._activeHighlightInfo.delete(ownerID);
+		}
+
+		highlightCurrentMatch(index: number, ownerID: string) {
+			const highlightInfo = this._activeHighlightInfo.get(ownerID);
+			if (!highlightInfo) {
+				console.error('Modified current highlight match before adding highlight list.');
+				return;
+			}
+			const oldMatch = highlightInfo.matches[highlightInfo.currentMatchIndex];
 			oldMatch?.highlightResult?.update(matchColor, oldMatch.isShadow ? undefined : 'find-match');
 
-			const match = this.matches[index];
-			this._findMatchIndex = index;
+			const match = highlightInfo.matches[index];
+			highlightInfo.currentMatchIndex = index;
 			const sel = window.getSelection();
 			if (!!match && !!sel && match.highlightResult) {
 				let offset = 0;
@@ -967,8 +994,12 @@ async function webviewPreloads(ctx: PreloadContext) {
 			}
 		}
 
-		unHighlightCurrentMatch(index: number) {
-			const oldMatch = this.matches[index];
+		unHighlightCurrentMatch(index: number, ownerID: string) {
+			const highlightInfo = this._activeHighlightInfo.get(ownerID);
+			if (!highlightInfo) {
+				return;
+			}
+			const oldMatch = highlightInfo.matches[index];
 			if (oldMatch && oldMatch.highlightResult) {
 				oldMatch.highlightResult.update(matchColor, oldMatch.isShadow ? undefined : 'find-match');
 			}
@@ -976,37 +1007,71 @@ async function webviewPreloads(ctx: PreloadContext) {
 
 		dispose() {
 			document.getSelection()?.removeAllRanges();
-
-			this.matches.forEach(match => {
-				match.highlightResult?.dispose();
-			});
 		}
 	}
 
 	class CSSHighlighter implements IHighlighter {
+		private _activeHighlightInfo: Map<string, IHighlightInfo>;
 		private _matchesHighlight: Highlight;
 		private _currentMatchesHighlight: Highlight;
-		private _findMatchIndex = -1;
 
-		constructor(
-			readonly matches: IFindMatch[],
-		) {
+		constructor() {
+			this._activeHighlightInfo = new Map();
 			this._matchesHighlight = new Highlight();
 			this._matchesHighlight.priority = 1;
 			this._currentMatchesHighlight = new Highlight();
 			this._currentMatchesHighlight.priority = 2;
+			CSS.highlights?.set(`find-highlight`, this._matchesHighlight);
+			CSS.highlights?.set(`current-find-highlight`, this._currentMatchesHighlight);
+		}
+
+		_refreshRegistry(updateMatchesHighlight = true) {
+			// for performance reasons, only update the full list of highlights when we need to
+			if (updateMatchesHighlight) {
+				this._matchesHighlight.clear();
+			}
+
+			this._currentMatchesHighlight.clear();
+
+			this._activeHighlightInfo.forEach((highlightInfo) => {
+
+				if (updateMatchesHighlight) {
+					for (let i = 0; i < highlightInfo.matches.length; i++) {
+						this._matchesHighlight.add(highlightInfo.matches[i].originalRange);
+					}
+				}
+				if (highlightInfo.currentMatchIndex < highlightInfo.matches.length && highlightInfo.currentMatchIndex >= 0) {
+					this._currentMatchesHighlight.add(highlightInfo.matches[highlightInfo.currentMatchIndex].originalRange);
+				}
+			});
+		}
+
+		addHighlights(
+			matches: IFindMatch[],
+			ownerID: string
+		) {
 
 			for (let i = 0; i < matches.length; i++) {
 				this._matchesHighlight.add(matches[i].originalRange);
 			}
-			CSS.highlights?.set('find-highlight', this._matchesHighlight);
-			CSS.highlights?.set('current-find-highlight', this._currentMatchesHighlight);
+
+			const newEntry: IHighlightInfo = {
+				matches,
+				currentMatchIndex: -1,
+			};
+
+			this._activeHighlightInfo.set(ownerID, newEntry);
 		}
 
-		highlightCurrentMatch(index: number): void {
-			this._findMatchIndex = index;
-			const match = this.matches[this._findMatchIndex];
-			const range = match.originalRange;
+		highlightCurrentMatch(index: number, ownerID: string): void {
+			const highlightInfo = this._activeHighlightInfo.get(ownerID);
+			if (!highlightInfo) {
+				console.error('Modified current highlight match before adding highlight list.');
+				return;
+			}
+
+			highlightInfo.currentMatchIndex = index;
+			const match = highlightInfo.matches[index];
 
 			if (match) {
 				let offset = 0;
@@ -1022,13 +1087,21 @@ async function webviewPreloads(ctx: PreloadContext) {
 					console.error(e);
 				}
 			}
-
-			this._currentMatchesHighlight.clear();
-			this._currentMatchesHighlight.add(range);
+			this._refreshRegistry(false);
 		}
 
-		unHighlightCurrentMatch(index: number): void {
-			this._currentMatchesHighlight.clear();
+		unHighlightCurrentMatch(index: number, ownerID: string): void {
+			const highlightInfo = this._activeHighlightInfo.get(ownerID);
+			if (!highlightInfo) {
+				return;
+			}
+
+			highlightInfo.currentMatchIndex = -1;
+		}
+
+		removeHighlights(ownerID: string) {
+			this._activeHighlightInfo.delete(ownerID);
+			this._refreshRegistry();
 		}
 
 		dispose(): void {
@@ -1037,6 +1110,8 @@ async function webviewPreloads(ctx: PreloadContext) {
 			this._matchesHighlight.clear();
 		}
 	}
+
+	const _highlighter = (CSS.highlights) ? new CSSHighlighter() : new JSHighlighter();
 
 	function extractSelectionLine(selection: Selection): ISearchPreviewInfo {
 		const range = selection.getRangeAt(0);
@@ -1126,7 +1201,7 @@ async function webviewPreloads(ctx: PreloadContext) {
 		return offset + getSelectionOffsetRelativeTo(parentElement, currentNode.parentNode);
 	}
 
-	const find = (query: string, options: { wholeWord?: boolean; caseSensitive?: boolean; includeMarkup: boolean; includeOutput: boolean; shouldGetSearchPreviewInfo: boolean }) => {
+	const find = (query: string, options: { wholeWord?: boolean; caseSensitive?: boolean; includeMarkup: boolean; includeOutput: boolean; shouldGetSearchPreviewInfo: boolean; ownerID: string }) => {
 		let find = true;
 		const matches: IFindMatch[] = [];
 
@@ -1254,12 +1329,7 @@ async function webviewPreloads(ctx: PreloadContext) {
 			console.log(e);
 		}
 
-		if (matches.length && CSS.highlights) {
-			_highlighter = new CSSHighlighter(matches);
-		} else {
-			_highlighter = new JSHighlighter(matches);
-		}
-
+		_highlighter.addHighlights(matches, options.ownerID);
 		document.getSelection()?.removeAllRanges();
 
 		viewModel.toggleDragDropEnabled(currentOptions.dragAndDropEnabled);
@@ -1448,20 +1518,21 @@ async function webviewPreloads(ctx: PreloadContext) {
 				break;
 			}
 			case 'find': {
-				_highlighter?.dispose();
+				_highlighter.removeHighlights(event.data.options.ownerID);
+
 				find(event.data.query, event.data.options);
 				break;
 			}
 			case 'findHighlightCurrent': {
-				_highlighter?.highlightCurrentMatch(event.data.index);
+				_highlighter?.highlightCurrentMatch(event.data.index, event.data.ownerID);
 				break;
 			}
 			case 'findUnHighlightCurrent': {
-				_highlighter?.unHighlightCurrentMatch(event.data.index);
+				_highlighter?.unHighlightCurrentMatch(event.data.index, event.data.ownerID);
 				break;
 			}
 			case 'findStop': {
-				_highlighter?.dispose();
+				_highlighter.removeHighlights(event.data.ownerID);
 				break;
 			}
 			case 'returnOutputItem': {

--- a/src/vs/workbench/contrib/notebook/test/browser/testNotebookEditor.ts
+++ b/src/vs/workbench/contrib/notebook/test/browser/testNotebookEditor.ts
@@ -286,6 +286,7 @@ function _createTestNotebookEditor(instantiationService: TestInstantiationServic
 		override deltaCellDecorations() { return []; }
 		override onDidChangeVisibleRanges = Event.None;
 		override visibleRanges: ICellRange[] = [{ start: 0, end: 100 }];
+		override getId(): string { return ''; }
 	};
 
 	return { editor: notebookEditor, viewModel };

--- a/src/vs/workbench/contrib/search/browser/notebookSearch.ts
+++ b/src/vs/workbench/contrib/search/browser/notebookSearch.ts
@@ -14,5 +14,5 @@ export interface INotebookSearchService {
 
 	readonly _serviceBrand: undefined;
 
-	notebookSearch(query: ITextQuery, token: CancellationToken, onProgress?: (result: ISearchProgressItem) => void): Promise<{ completeData: ISearchComplete; scannedFiles: ResourceSet }>;
+	notebookSearch(query: ITextQuery, token: CancellationToken, searchInstanceID: string, onProgress?: (result: ISearchProgressItem) => void): Promise<{ completeData: ISearchComplete; scannedFiles: ResourceSet }>;
 }

--- a/src/vs/workbench/contrib/search/browser/notebookSearchService.ts
+++ b/src/vs/workbench/contrib/search/browser/notebookSearchService.ts
@@ -123,7 +123,7 @@ export class NotebookSearchService implements INotebookSearchService {
 		return Array.from(uris.keys());
 	}
 
-	async notebookSearch(query: ITextQuery, token: CancellationToken, onProgress?: (result: ISearchProgressItem) => void): Promise<{ completeData: ISearchComplete; scannedFiles: ResourceSet }> {
+	async notebookSearch(query: ITextQuery, token: CancellationToken, searchInstanceID: string, onProgress?: (result: ISearchProgressItem) => void): Promise<{ completeData: ISearchComplete; scannedFiles: ResourceSet }> {
 
 		if (query.type !== QueryType.Text) {
 			return {
@@ -139,7 +139,7 @@ export class NotebookSearchService implements INotebookSearchService {
 
 		const localNotebookWidgets = this.getLocalNotebookWidgets();
 		const localNotebookFiles = localNotebookWidgets.map(widget => widget.viewModel!.uri);
-		const localResultPromise = this.getLocalNotebookResults(query, token, localNotebookWidgets);
+		const localResultPromise = this.getLocalNotebookResults(query, token, localNotebookWidgets, searchInstanceID);
 		const searchLocalEnd = Date.now();
 
 		const experimentalNotebooksEnabled = this.configurationService.getValue<ISearchConfigurationProperties>('search').experimental?.closedNotebookRichContentResults ?? false;
@@ -248,7 +248,7 @@ export class NotebookSearchService implements INotebookSearchService {
 		};
 	}
 
-	private async getLocalNotebookResults(query: ITextQuery, token: CancellationToken, widgets: Array<NotebookEditorWidget>): Promise<INotebookSearchMatchResults> {
+	private async getLocalNotebookResults(query: ITextQuery, token: CancellationToken, widgets: Array<NotebookEditorWidget>, searchID: string): Promise<INotebookSearchMatchResults> {
 		const localResults = new ResourceMap<IFileMatchWithCells | null>(uri => this.uriIdentityService.extUri.getComparisonKey(uri));
 		let limitHit = false;
 
@@ -266,7 +266,7 @@ export class NotebookSearchService implements INotebookSearchService {
 					includeMarkupPreview: query.contentPattern.notebookInfo?.isInNotebookMarkdownPreview,
 					includeCodeInput: query.contentPattern.notebookInfo?.isInNotebookCellInput,
 					includeOutput: query.contentPattern.notebookInfo?.isInNotebookCellOutput,
-				}, token, false, true, 'TEMP_SEARCH_ID');
+				}, token, false, true, searchID);
 
 
 			if (matches.length) {

--- a/src/vs/workbench/contrib/search/browser/notebookSearchService.ts
+++ b/src/vs/workbench/contrib/search/browser/notebookSearchService.ts
@@ -266,7 +266,7 @@ export class NotebookSearchService implements INotebookSearchService {
 					includeMarkupPreview: query.contentPattern.notebookInfo?.isInNotebookMarkdownPreview,
 					includeCodeInput: query.contentPattern.notebookInfo?.isInNotebookCellInput,
 					includeOutput: query.contentPattern.notebookInfo?.isInNotebookCellOutput,
-				}, token, false, true);
+				}, token, false, true, 'TEMP_SEARCH_ID');
 
 
 			if (matches.length) {

--- a/src/vs/workbench/contrib/search/browser/searchModel.ts
+++ b/src/vs/workbench/contrib/search/browser/searchModel.ts
@@ -763,7 +763,7 @@ export class FileMatch extends Disposable implements IFileMatch {
 		}
 		this._findMatchDecorationModel?.stopWebviewFind();
 		this._findMatchDecorationModel?.dispose();
-		this._findMatchDecorationModel = new FindMatchDecorationModel(this._notebookEditorWidget);
+		this._findMatchDecorationModel = new FindMatchDecorationModel(this._notebookEditorWidget, 'TEMP_SEARCH_ID');
 	}
 
 	private _removeNotebookHighlights(): void {
@@ -851,7 +851,7 @@ export class FileMatch extends Disposable implements IFileMatch {
 				includeMarkupPreview: this._query.notebookInfo?.isInNotebookMarkdownPreview,
 				includeCodeInput: this._query.notebookInfo?.isInNotebookCellInput,
 				includeOutput: this._query.notebookInfo?.isInNotebookCellOutput,
-			}, CancellationToken.None, false, true);
+			}, CancellationToken.None, false, true, 'TEMP_SEARCH_ID');
 
 		this.updateNotebookMatches(allMatches, true);
 	}

--- a/src/vs/workbench/contrib/search/browser/searchModel.ts
+++ b/src/vs/workbench/contrib/search/browser/searchModel.ts
@@ -397,6 +397,7 @@ export class FileMatch extends Disposable implements IFileMatch {
 		private _parent: FolderMatch,
 		private rawMatch: IFileMatch,
 		private _closestRoot: FolderMatchWorkspaceRoot | null,
+		private readonly searchInstanceID: string,
 		@IModelService private readonly modelService: IModelService,
 		@IReplaceService private readonly replaceService: IReplaceService,
 		@ILabelService readonly labelService: ILabelService,
@@ -763,7 +764,7 @@ export class FileMatch extends Disposable implements IFileMatch {
 		}
 		this._findMatchDecorationModel?.stopWebviewFind();
 		this._findMatchDecorationModel?.dispose();
-		this._findMatchDecorationModel = new FindMatchDecorationModel(this._notebookEditorWidget, 'TEMP_SEARCH_ID');
+		this._findMatchDecorationModel = new FindMatchDecorationModel(this._notebookEditorWidget, this.searchInstanceID);
 	}
 
 	private _removeNotebookHighlights(): void {
@@ -851,7 +852,7 @@ export class FileMatch extends Disposable implements IFileMatch {
 				includeMarkupPreview: this._query.notebookInfo?.isInNotebookMarkdownPreview,
 				includeCodeInput: this._query.notebookInfo?.isInNotebookCellInput,
 				includeOutput: this._query.notebookInfo?.isInNotebookCellOutput,
-			}, CancellationToken.None, false, true, 'TEMP_SEARCH_ID');
+			}, CancellationToken.None, false, true, this.searchInstanceID);
 
 		this.updateNotebookMatches(allMatches, true);
 	}
@@ -1117,7 +1118,7 @@ export class FolderMatch extends Disposable {
 		return this._query;
 	}
 
-	addFileMatch(raw: IFileMatch[], silent: boolean): void {
+	addFileMatch(raw: IFileMatch[], silent: boolean, searchInstanceID: string): void {
 		// when adding a fileMatch that has intermediate directories
 		const added: FileMatch[] = [];
 		const updated: FileMatch[] = [];
@@ -1151,7 +1152,7 @@ export class FolderMatch extends Disposable {
 				existingFileMatch.addContext(rawFileMatch.results);
 			} else {
 				if (this instanceof FolderMatchWorkspaceRoot || this instanceof FolderMatchNoRoot) {
-					const fileMatch = this.createAndConfigureFileMatch(rawFileMatch);
+					const fileMatch = this.createAndConfigureFileMatch(rawFileMatch, searchInstanceID);
 					added.push(fileMatch);
 				}
 			}
@@ -1337,7 +1338,7 @@ export class FolderMatchWorkspaceRoot extends FolderMatchWithResource {
 		return this.uriIdentityService.extUri.isEqual(uri1, ur2);
 	}
 
-	private createFileMatch(query: IPatternInfo, previewOptions: ITextSearchPreviewOptions | undefined, maxResults: number | undefined, parent: FolderMatch, rawFileMatch: IFileMatch, closestRoot: FolderMatchWorkspaceRoot | null,): FileMatch {
+	private createFileMatch(query: IPatternInfo, previewOptions: ITextSearchPreviewOptions | undefined, maxResults: number | undefined, parent: FolderMatch, rawFileMatch: IFileMatch, closestRoot: FolderMatchWorkspaceRoot | null, searchInstanceID: string): FileMatch {
 		const fileMatch =
 			this.instantiationService.createInstance(
 				FileMatch,
@@ -1346,7 +1347,8 @@ export class FolderMatchWorkspaceRoot extends FolderMatchWithResource {
 				maxResults,
 				parent,
 				rawFileMatch,
-				closestRoot
+				closestRoot,
+				searchInstanceID
 			);
 		parent.doAddFile(fileMatch);
 		const disposable = fileMatch.onChange(({ didRemove }) => parent.onFileChange(fileMatch, didRemove));
@@ -1354,7 +1356,7 @@ export class FolderMatchWorkspaceRoot extends FolderMatchWithResource {
 		return fileMatch;
 	}
 
-	createAndConfigureFileMatch(rawFileMatch: IFileMatch<URI>): FileMatch {
+	createAndConfigureFileMatch(rawFileMatch: IFileMatch<URI>, searchInstanceID: string): FileMatch {
 
 		if (!this.uriHasParent(this.resource, rawFileMatch.resource)) {
 			throw Error(`${rawFileMatch.resource} is not a descendant of ${this.resource}`);
@@ -1382,7 +1384,7 @@ export class FolderMatchWorkspaceRoot extends FolderMatchWithResource {
 			parent = folderMatch;
 		}
 
-		return this.createFileMatch(this._query.contentPattern, this._query.previewOptions, this._query.maxResults, parent, rawFileMatch, root);
+		return this.createFileMatch(this._query.contentPattern, this._query.previewOptions, this._query.maxResults, parent, rawFileMatch, root, searchInstanceID);
 	}
 }
 
@@ -1401,14 +1403,15 @@ export class FolderMatchNoRoot extends FolderMatch {
 		super(null, _id, _index, _query, _parent, _searchModel, null, replaceService, instantiationService, labelService, uriIdentityService);
 	}
 
-	createAndConfigureFileMatch(rawFileMatch: IFileMatch): FileMatch {
+	createAndConfigureFileMatch(rawFileMatch: IFileMatch, searchInstanceID: string): FileMatch {
 		const fileMatch = this.instantiationService.createInstance(
 			FileMatch,
 			this._query.contentPattern,
 			this._query.previewOptions,
 			this._query.maxResults,
 			this, rawFileMatch,
-			null);
+			null,
+			searchInstanceID);
 		this.doAddFile(fileMatch);
 		const disposable = fileMatch.onChange(({ didRemove }) => this.onFileChange(fileMatch, didRemove));
 		fileMatch.onDispose(() => disposable.dispose());
@@ -1740,7 +1743,7 @@ export class SearchResult extends Disposable {
 		return this._searchModel;
 	}
 
-	add(allRaw: IFileMatch[], silent: boolean = false): void {
+	add(allRaw: IFileMatch[], searchInstanceID: string, silent: boolean = false): void {
 		// Split up raw into a list per folder so we can do a batch add per folder.
 
 		const { byFolder, other } = this.groupFilesByFolder(allRaw);
@@ -1750,10 +1753,10 @@ export class SearchResult extends Disposable {
 			}
 
 			const folderMatch = this.getFolderMatch(raw[0].resource);
-			folderMatch?.addFileMatch(raw, silent);
+			folderMatch?.addFileMatch(raw, silent, searchInstanceID);
 		});
 
-		this._otherFilesMatch?.addFileMatch(other, silent);
+		this._otherFilesMatch?.addFileMatch(other, silent, searchInstanceID);
 		this.disposePastResults();
 	}
 
@@ -1991,16 +1994,16 @@ export class SearchModel extends Disposable {
 		return this._searchResult;
 	}
 
-	private async doSearch(query: ITextQuery, progressEmitter: Emitter<void>, searchQuery: ITextQuery, onProgress?: (result: ISearchProgressItem) => void): Promise<ISearchComplete> {
+	private async doSearch(query: ITextQuery, progressEmitter: Emitter<void>, searchQuery: ITextQuery, searchInstanceID: string, onProgress?: (result: ISearchProgressItem) => void): Promise<ISearchComplete> {
 		const searchStart = Date.now();
 		const tokenSource = this.currentCancelTokenSource = new CancellationTokenSource();
 		const onProgressCall = (p: ISearchProgressItem) => {
 			progressEmitter.fire();
-			this.onSearchProgress(p);
+			this.onSearchProgress(p, searchInstanceID);
 
 			onProgress?.(p);
 		};
-		const notebookResult = await this.notebookSearchService.notebookSearch(query, this.currentCancelTokenSource.token, onProgressCall);
+		const notebookResult = await this.notebookSearchService.notebookSearch(query, this.currentCancelTokenSource.token, searchInstanceID, onProgressCall);
 		const currentResult = await this.searchService.textSearch(
 			searchQuery,
 			this.currentCancelTokenSource.token, onProgressCall,
@@ -2019,6 +2022,7 @@ export class SearchModel extends Disposable {
 		if (!this.searchConfig.searchOnType) {
 			this.searchResult.clear();
 		}
+		const searchInstanceID = Date.now().toString();
 
 		this._searchResult.query = this._searchQuery;
 
@@ -2028,7 +2032,7 @@ export class SearchModel extends Disposable {
 		// In search on type case, delay the streaming of results just a bit, so that we don't flash the only "local results" fast path
 		this._startStreamDelay = new Promise(resolve => setTimeout(resolve, this.searchConfig.searchOnType ? 150 : 0));
 
-		const currentRequest = this.doSearch(query, progressEmitter, this._searchQuery, onProgress);
+		const currentRequest = this.doSearch(query, progressEmitter, this._searchQuery, searchInstanceID, onProgress);
 
 		const start = Date.now();
 
@@ -2043,7 +2047,7 @@ export class SearchModel extends Disposable {
 		});
 
 		currentRequest.then(
-			value => this.onSearchCompleted(value, Date.now() - start),
+			value => this.onSearchCompleted(value, Date.now() - start, searchInstanceID),
 			e => this.onSearchError(e, Date.now() - start));
 
 		try {
@@ -2059,12 +2063,12 @@ export class SearchModel extends Disposable {
 		}
 	}
 
-	private onSearchCompleted(completed: ISearchComplete | null, duration: number): ISearchComplete | null {
+	private onSearchCompleted(completed: ISearchComplete | null, duration: number, searchInstanceID: string): ISearchComplete | null {
 		if (!this._searchQuery) {
 			throw new Error('onSearchCompleted must be called after a search is started');
 		}
 
-		this._searchResult.add(this._resultQueue);
+		this._searchResult.add(this._resultQueue, searchInstanceID);
 		this._resultQueue.length = 0;
 
 		const options: IPatternInfo = Object.assign({}, this._searchQuery.contentPattern);
@@ -2108,17 +2112,17 @@ export class SearchModel extends Disposable {
 				this.searchCancelledForNewSearch
 					? { exit: SearchCompletionExitCode.NewSearchStarted, results: [], messages: [] }
 					: null,
-				duration);
+				duration, '');
 			this.searchCancelledForNewSearch = false;
 		}
 	}
 
-	private async onSearchProgress(p: ISearchProgressItem) {
+	private async onSearchProgress(p: ISearchProgressItem, searchInstanceID: string) {
 		if ((<IFileMatch>p).resource) {
 			this._resultQueue.push(<IFileMatch>p);
 			await this._startStreamDelay;
 			if (this._resultQueue.length) {
-				this._searchResult.add(this._resultQueue, true);
+				this._searchResult.add(this._resultQueue, searchInstanceID, true);
 				this._resultQueue.length = 0;
 			}
 		}

--- a/src/vs/workbench/contrib/search/test/browser/searchActions.test.ts
+++ b/src/vs/workbench/contrib/search/test/browser/searchActions.test.ts
@@ -120,7 +120,7 @@ suite('Search Actions', () => {
 		}, searchModel.searchResult, searchModel, null);
 		return instantiationService.createInstance(FileMatch, {
 			pattern: ''
-		}, undefined, undefined, folderMatch, rawMatch, null);
+		}, undefined, undefined, folderMatch, rawMatch, null, '');
 	}
 
 	function aMatch(fileMatch: FileMatch): Match {

--- a/src/vs/workbench/contrib/search/test/browser/searchModel.test.ts
+++ b/src/vs/workbench/contrib/search/test/browser/searchModel.test.ts
@@ -160,7 +160,7 @@ suite('SearchModel', () => {
 	function notebookSearchServiceWithInfo(results: IFileMatchWithCells[], tokenSource: CancellationTokenSource | undefined): INotebookSearchService {
 		return <INotebookSearchService>{
 			_serviceBrand: undefined,
-			notebookSearch(query: ISearchQuery, token?: CancellationToken, onProgress?: (result: ISearchProgressItem) => void, notebookURIs?: ResourceSet): Promise<{ completeData: ISearchComplete; scannedFiles: ResourceSet }> {
+			notebookSearch(query: ISearchQuery, token: CancellationToken, searchInstanceID: string, onProgress?: (result: ISearchProgressItem) => void, notebookURIs?: ResourceSet): Promise<{ completeData: ISearchComplete; scannedFiles: ResourceSet }> {
 				token?.onCancellationRequested(() => tokenSource?.cancel());
 				const localResults = new ResourceMap<IFileMatchWithCells | null>(uri => uri.path);
 

--- a/src/vs/workbench/contrib/search/test/browser/searchNotebookHelpers.test.ts
+++ b/src/vs/workbench/contrib/search/test/browser/searchNotebookHelpers.test.ts
@@ -208,7 +208,7 @@ suite('searchNotebookHelpers', () => {
 			}, searchModel.searchResult, searchModel, null);
 			return instantiationService.createInstance(FileMatch, {
 				pattern: ''
-			}, undefined, undefined, folderMatch, rawMatch, null);
+			}, undefined, undefined, folderMatch, rawMatch, null, '');
 		}
 	});
 });

--- a/src/vs/workbench/contrib/search/test/browser/searchResult.test.ts
+++ b/src/vs/workbench/contrib/search/test/browser/searchResult.test.ts
@@ -31,7 +31,7 @@ import { NotebookEditorWidgetService } from 'vs/workbench/contrib/notebook/brows
 import { ICellMatch, IFileMatchWithCells } from 'vs/workbench/contrib/search/browser/searchNotebookHelpers';
 import { ICellViewModel } from 'vs/workbench/contrib/notebook/browser/notebookBrowser';
 import { CellKind } from 'vs/workbench/contrib/notebook/common/notebookCommon';
-import { createFileUriFromPathFromRoot, getRootName } from 'vs/workbench/contrib/search/test/browser/searchTestCommon';
+import { addToSearchResult, createFileUriFromPathFromRoot, getRootName } from 'vs/workbench/contrib/search/test/browser/searchTestCommon';
 
 const lineOneRange = new OneLineRange(1, 0, 1);
 
@@ -176,7 +176,7 @@ suite('SearchResult', () => {
 			new TextSearchMatch('preview 1', new OneLineRange(1, 4, 11)),
 			new TextSearchMatch('preview 2', lineOneRange))];
 
-		testObject.add(target);
+		addToSearchResult(testObject, target);
 
 		assert.strictEqual(3, testObject.count());
 
@@ -206,7 +206,7 @@ suite('SearchResult', () => {
 			aRawMatch('/2',
 				new TextSearchMatch('preview 2', lineOneRange))];
 
-		testObject.add(target);
+		addToSearchResult(testObject, target);
 
 		assert.strictEqual(3, testObject.count());
 
@@ -261,7 +261,7 @@ suite('SearchResult', () => {
 			});
 		const target = [fileMatch1, fileMatch2];
 
-		testObject.add(target);
+		addToSearchResult(testObject, target);
 		assert.strictEqual(6, testObject.count());
 		assert.deepStrictEqual(fileMatch1.cellResults[0].contentResults, (addFileMatch.getCall(0).args[0][0] as IFileMatchWithCells).cellResults[0].contentResults);
 		assert.deepStrictEqual(fileMatch1.cellResults[0].webviewResults, (addFileMatch.getCall(0).args[0][0] as IFileMatchWithCells).cellResults[0].webviewResults);
@@ -274,7 +274,7 @@ suite('SearchResult', () => {
 		const target2 = sinon.spy();
 
 		const testObject = aSearchResult();
-		testObject.add([
+		addToSearchResult(testObject, [
 			aRawMatch('/1',
 				new TextSearchMatch('preview 1', lineOneRange)),
 			aRawMatch('/2',
@@ -293,7 +293,7 @@ suite('SearchResult', () => {
 	test('remove triggers change event', function () {
 		const target = sinon.spy();
 		const testObject = aSearchResult();
-		testObject.add([
+		addToSearchResult(testObject, [
 			aRawMatch('/1',
 				new TextSearchMatch('preview 1', lineOneRange))]);
 		const objectToRemove = testObject.matches()[0];
@@ -308,7 +308,7 @@ suite('SearchResult', () => {
 	test('remove array triggers change event', function () {
 		const target = sinon.spy();
 		const testObject = aSearchResult();
-		testObject.add([
+		addToSearchResult(testObject, [
 			aRawMatch('/1',
 				new TextSearchMatch('preview 1', lineOneRange)),
 			aRawMatch('/2',
@@ -324,7 +324,7 @@ suite('SearchResult', () => {
 
 	test('Removing all line matches and adding back will add file back to result', function () {
 		const testObject = aSearchResult();
-		testObject.add([
+		addToSearchResult(testObject, [
 			aRawMatch('/1',
 				new TextSearchMatch('preview 1', lineOneRange))]);
 		const target = testObject.matches()[0];
@@ -342,7 +342,7 @@ suite('SearchResult', () => {
 		const voidPromise = Promise.resolve(null);
 		instantiationService.stub(IReplaceService, 'replace', voidPromise);
 		const testObject = aSearchResult();
-		testObject.add([
+		addToSearchResult(testObject, [
 			aRawMatch('/1',
 				new TextSearchMatch('preview 1', lineOneRange))]);
 
@@ -356,7 +356,7 @@ suite('SearchResult', () => {
 		const voidPromise = Promise.resolve(null);
 		instantiationService.stub(IReplaceService, 'replace', voidPromise);
 		const testObject = aSearchResult();
-		testObject.add([
+		addToSearchResult(testObject, [
 			aRawMatch('/1',
 				new TextSearchMatch('preview 1', lineOneRange))]);
 		testObject.onChange(target);
@@ -374,7 +374,7 @@ suite('SearchResult', () => {
 		const voidPromise = Promise.resolve(null);
 		instantiationService.stubPromise(IReplaceService, 'replace', voidPromise);
 		const testObject = aSearchResult();
-		testObject.add([
+		addToSearchResult(testObject, [
 			aRawMatch('/1',
 				new TextSearchMatch('preview 1', lineOneRange)),
 			aRawMatch('/2',
@@ -519,7 +519,7 @@ suite('SearchResult', () => {
 		const root = searchResult?.folderMatches()[0];
 		return instantiationService.createInstance(FileMatch, {
 			pattern: ''
-		}, undefined, undefined, root, rawMatch, null);
+		}, undefined, undefined, root, rawMatch, null, '');
 	}
 
 	function aSearchResult(): SearchResult {
@@ -569,7 +569,7 @@ suite('SearchResult', () => {
 			]
 		};
 
-		testObject.add([
+		addToSearchResult(testObject, [
 			aRawMatch('/voo/foo.a',
 				new TextSearchMatch('preview 1', lineOneRange), new TextSearchMatch('preview 2', lineOneRange)),
 			aRawMatch('/with/path/bar.b',
@@ -623,7 +623,7 @@ suite('SearchResult', () => {
 		 *    |- eyy.y
 		 */
 
-		testObject.add([
+		addToSearchResult(testObject, [
 			aRawMatch('/voo/foo.a',
 				new TextSearchMatch('preview 1', lineOneRange), new TextSearchMatch('preview 2', lineOneRange)),
 			aRawMatch('/voo/beep/foo.c',

--- a/src/vs/workbench/contrib/search/test/browser/searchTestCommon.ts
+++ b/src/vs/workbench/contrib/search/test/browser/searchTestCommon.ts
@@ -14,7 +14,9 @@ import { IThemeService } from 'vs/platform/theme/common/themeService';
 import { TestThemeService } from 'vs/platform/theme/test/common/testThemeService';
 import { INotebookEditorService } from 'vs/workbench/contrib/notebook/browser/services/notebookEditorService';
 import { NotebookEditorWidgetService } from 'vs/workbench/contrib/notebook/browser/services/notebookEditorServiceImpl';
+import { SearchResult } from 'vs/workbench/contrib/search/browser/searchModel';
 import { IEditorGroupsService } from 'vs/workbench/services/editor/common/editorGroupsService';
+import { IFileMatch } from 'vs/workbench/services/search/common/search';
 import { TestEditorGroupsService } from 'vs/workbench/test/browser/workbenchTestServices';
 
 export function createFileUriFromPathFromRoot(path?: string): URI {
@@ -38,8 +40,6 @@ export function getRootName(): string {
 	}
 }
 
-
-
 export function stubModelService(instantiationService: TestInstantiationService): IModelService {
 	instantiationService.stub(IThemeService, new TestThemeService());
 	const config = new TestConfigurationService();
@@ -51,4 +51,8 @@ export function stubModelService(instantiationService: TestInstantiationService)
 export function stubNotebookEditorService(instantiationService: TestInstantiationService): INotebookEditorService {
 	instantiationService.stub(IEditorGroupsService, new TestEditorGroupsService());
 	return instantiationService.createInstance(NotebookEditorWidgetService);
+}
+
+export function addToSearchResult(searchResult: SearchResult, allRaw: IFileMatch[], searchInstanceID = '') {
+	searchResult.add(allRaw, searchInstanceID);
 }

--- a/src/vs/workbench/contrib/search/test/browser/searchViewlet.test.ts
+++ b/src/vs/workbench/contrib/search/test/browser/searchViewlet.test.ts
@@ -78,7 +78,7 @@ suite('Search - Viewlet', () => {
 					endColumn: 1
 				}
 			}]
-		}]);
+		}], '');
 
 		const fileMatch = result.matches()[0];
 		const lineMatch = fileMatch.matches()[0];
@@ -181,7 +181,7 @@ suite('Search - Viewlet', () => {
 		};
 		return instantiation.createInstance(FileMatch, {
 			pattern: ''
-		}, undefined, undefined, parentFolder ?? aFolderMatch('', 0), rawMatch, null);
+		}, undefined, undefined, parentFolder ?? aFolderMatch('', 0), rawMatch, null, '');
 	}
 
 	function aFolderMatch(path: string, index: number, parent?: SearchResult): FolderMatch {


### PR DESCRIPTION
Fixes #187016
Fixes #187747
Track callers for webview find and manage decorations on a caller-by-caller basis.
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
