### PR TITLE
use diff't keybinding for navigating commands in the accessible buffer for mac when in screen reader mode

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/accessibility/browser/terminal.accessibility.contribution.ts
+++ b/src/vs/workbench/contrib/terminalContrib/accessibility/browser/terminal.accessibility.contribution.ts
@@ -129,8 +129,14 @@ registerTerminalAction({
 	keybinding: [
 		{
 			primary: KeyMod.CtrlCmd | KeyCode.DownArrow,
-			weight: KeybindingWeight.WorkbenchContrib + 2,
-			when: TerminalContextKeys.accessibleBufferFocus
+			when: ContextKeyExpr.and(TerminalContextKeys.accessibleBufferFocus, CONTEXT_ACCESSIBILITY_MODE_ENABLED.negate()),
+			weight: KeybindingWeight.WorkbenchContrib + 2
+		},
+		{
+			primary: KeyMod.CtrlCmd | KeyCode.DownArrow,
+			mac: { primary: KeyMod.Alt | KeyCode.DownArrow },
+			when: ContextKeyExpr.and(TerminalContextKeys.accessibleBufferFocus, CONTEXT_ACCESSIBILITY_MODE_ENABLED),
+			weight: KeybindingWeight.WorkbenchContrib + 2
 		}
 	],
 	run: async (c) => {
@@ -151,8 +157,14 @@ registerTerminalAction({
 	keybinding: [
 		{
 			primary: KeyMod.CtrlCmd | KeyCode.UpArrow,
-			weight: KeybindingWeight.WorkbenchContrib + 2,
-			when: TerminalContextKeys.accessibleBufferFocus
+			when: ContextKeyExpr.and(TerminalContextKeys.accessibleBufferFocus, CONTEXT_ACCESSIBILITY_MODE_ENABLED.negate()),
+			weight: KeybindingWeight.WorkbenchContrib + 2
+		},
+		{
+			primary: KeyMod.CtrlCmd | KeyCode.UpArrow,
+			mac: { primary: KeyMod.Alt | KeyCode.UpArrow },
+			when: ContextKeyExpr.and(TerminalContextKeys.accessibleBufferFocus, CONTEXT_ACCESSIBILITY_MODE_ENABLED),
+			weight: KeybindingWeight.WorkbenchContrib + 2
 		}
 	],
 	run: async (c) => {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
fix #186678

cc @tyriar