### PR TITLE
Fix can't use cmd+up/down in terminal after closing find widget

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/find/browser/terminalFindWidget.ts
+++ b/src/vs/workbench/contrib/terminalContrib/find/browser/terminalFindWidget.ts
@@ -84,7 +84,7 @@ export class TerminalFindWidget extends SimpleFindWidget {
 	override hide() {
 		super.hide();
 		this._findWidgetVisible.reset();
-		this._instance.focus();
+		this._instance.focus(true);
 		this._instance.xterm?.clearSearchDecorations();
 	}
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
Fix #186781

Force focus when hiding find widget as `terminalInstance.focus` checks `window.getSelection`
