### PR TITLE
cli: allow installation as a service from the UI

### DIFF
--- a/cli/src/commands/args.rs
+++ b/cli/src/commands/args.rs
@@ -649,6 +649,10 @@ pub struct TunnelServiceInstallArgs {
 	/// If set, the user accepts the server license terms and the server will be started without a user prompt.
 	#[clap(long)]
 	pub accept_server_license_terms: bool,
+
+	/// Sets the machine name for port forwarding service
+	#[clap(long)]
+	pub name: Option<String>,
 }
 
 #[derive(Args, Debug, Clone)]

--- a/cli/src/rpc.rs
+++ b/cli/src/rpc.rs
@@ -117,7 +117,7 @@ impl<S: Serialization, C: Send + Sync + 'static> RpcMethodBuilder<S, C> {
 					Ok(p) => p,
 					Err(err) => {
 						return id.map(|id| {
-							serial.serialize(&ErrorResponse {
+							serial.serialize(ErrorResponse {
 								id,
 								error: ResponseError {
 									code: 0,
@@ -131,7 +131,7 @@ impl<S: Serialization, C: Send + Sync + 'static> RpcMethodBuilder<S, C> {
 				match callback(param.params, &context) {
 					Ok(result) => id.map(|id| serial.serialize(&SuccessResponse { id, result })),
 					Err(err) => id.map(|id| {
-						serial.serialize(&ErrorResponse {
+						serial.serialize(ErrorResponse {
 							id,
 							error: ResponseError {
 								code: -1,
@@ -161,7 +161,7 @@ impl<S: Serialization, C: Send + Sync + 'static> RpcMethodBuilder<S, C> {
 					Ok(p) => p,
 					Err(err) => {
 						return future::ready(id.map(|id| {
-							serial.serialize(&ErrorResponse {
+							serial.serialize(ErrorResponse {
 								id,
 								error: ResponseError {
 									code: 0,
@@ -182,7 +182,7 @@ impl<S: Serialization, C: Send + Sync + 'static> RpcMethodBuilder<S, C> {
 							id.map(|id| serial.serialize(&SuccessResponse { id, result }))
 						}
 						Err(err) => id.map(|id| {
-							serial.serialize(&ErrorResponse {
+							serial.serialize(ErrorResponse {
 								id,
 								error: ResponseError {
 									code: -1,
@@ -222,7 +222,7 @@ impl<S: Serialization, C: Send + Sync + 'static> RpcMethodBuilder<S, C> {
 						return (
 							None,
 							future::ready(id.map(|id| {
-								serial.serialize(&ErrorResponse {
+								serial.serialize(ErrorResponse {
 									id,
 									error: ResponseError {
 										code: 0,
@@ -255,7 +255,7 @@ impl<S: Serialization, C: Send + Sync + 'static> RpcMethodBuilder<S, C> {
 					match callback(servers, param.params, context).await {
 						Ok(r) => id.map(|id| serial.serialize(&SuccessResponse { id, result: r })),
 						Err(err) => id.map(|id| {
-							serial.serialize(&ErrorResponse {
+							serial.serialize(ErrorResponse {
 								id,
 								error: ResponseError {
 									code: -1,
@@ -427,7 +427,7 @@ impl<S: Serialization, C: Send + Sync> RpcDispatcher<S, C> {
 				Some(Method::Async(callback)) => MaybeSync::Future(callback(id, body)),
 				Some(Method::Duplex(callback)) => MaybeSync::Stream(callback(id, body)),
 				None => MaybeSync::Sync(id.map(|id| {
-					self.serializer.serialize(&ErrorResponse {
+					self.serializer.serialize(ErrorResponse {
 						id,
 						error: ResponseError {
 							code: -1,

--- a/src/vs/base/node/nodeStreams.ts
+++ b/src/vs/base/node/nodeStreams.ts
@@ -1,0 +1,62 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import { Transform } from 'stream';
+import { binaryIndexOf } from 'vs/base/common/buffer';
+
+/**
+ * A Transform stream that splits the input on the "splitter" substring.
+ * The resulting chunks will contain (and trail with) the splitter match.
+ * The last chunk when the stream ends will be emitted even if a splitter
+ * is not encountered.
+ */
+export class StreamSplitter extends Transform {
+	private buffer: Buffer | undefined;
+	private readonly splitter: Buffer | number;
+	private readonly spitterLen: number;
+
+	constructor(splitter: string | number | Buffer) {
+		super();
+		if (typeof splitter === 'number') {
+			this.splitter = splitter;
+			this.spitterLen = 1;
+		} else {
+			const buf = Buffer.isBuffer(splitter) ? splitter : Buffer.from(splitter);
+			this.splitter = buf.length === 1 ? buf[0] : buf;
+			this.spitterLen = buf.length;
+		}
+	}
+
+	override _transform(chunk: Buffer, _encoding: string, callback: (error?: Error | null, data?: any) => void): void {
+		if (!this.buffer) {
+			this.buffer = chunk;
+		} else {
+			this.buffer = Buffer.concat([this.buffer, chunk]);
+		}
+
+		let offset = 0;
+		while (offset < this.buffer.length) {
+			const index = typeof this.splitter === 'number'
+				? this.buffer.indexOf(this.splitter, offset)
+				: binaryIndexOf(this.buffer, this.splitter, offset);
+			if (index === -1) {
+				break;
+			}
+
+			this.push(this.buffer.slice(offset, index + this.spitterLen));
+			offset = index + this.spitterLen;
+		}
+
+		this.buffer = offset === this.buffer.length ? undefined : this.buffer.slice(offset);
+		callback();
+	}
+
+	override _flush(callback: (error?: Error | null, data?: any) => void): void {
+		if (this.buffer) {
+			this.push(this.buffer);
+		}
+
+		callback();
+	}
+}

--- a/src/vs/base/test/node/nodeStreams.test.ts
+++ b/src/vs/base/test/node/nodeStreams.test.ts
@@ -1,0 +1,51 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+
+import { Writable } from 'stream';
+import * as assert from 'assert';
+import { StreamSplitter } from 'vs/base/node/nodeStreams';
+
+suite('StreamSplitter', () => {
+	test('should split a stream on a single character splitter', (done) => {
+		const chunks: string[] = [];
+		const splitter = new StreamSplitter('\n');
+		const writable = new Writable({
+			write(chunk, _encoding, callback) {
+				chunks.push(chunk.toString());
+				callback();
+			},
+		});
+
+		splitter.pipe(writable);
+		splitter.write('hello\nwor');
+		splitter.write('ld\n');
+		splitter.write('foo\nbar\nz');
+		splitter.end(() => {
+			assert.deepStrictEqual(chunks, ['hello\n', 'world\n', 'foo\n', 'bar\n', 'z']);
+			done();
+		});
+	});
+
+	test('should split a stream on a multi-character splitter', (done) => {
+		const chunks: string[] = [];
+		const splitter = new StreamSplitter('---');
+		const writable = new Writable({
+			write(chunk, _encoding, callback) {
+				chunks.push(chunk.toString());
+				callback();
+			},
+		});
+
+		splitter.pipe(writable);
+		splitter.write('hello---wor');
+		splitter.write('ld---');
+		splitter.write('foo---bar---z');
+		splitter.end(() => {
+			assert.deepStrictEqual(chunks, ['hello---', 'world---', 'foo---', 'bar---', 'z']);
+			done();
+		});
+	});
+});

--- a/src/vs/platform/remoteTunnel/common/remoteTunnel.ts
+++ b/src/vs/platform/remoteTunnel/common/remoteTunnel.ts
@@ -21,17 +21,32 @@ export interface IRemoteTunnelService {
 	readonly onDidChangeTunnelStatus: Event<TunnelStatus>;
 	getTunnelStatus(): Promise<TunnelStatus>;
 
-	getSession(): Promise<IRemoteTunnelSession | undefined>;
-	readonly onDidChangeSession: Event<IRemoteTunnelSession | undefined>;
+	getMode(): Promise<TunnelMode>;
+	readonly onDidChangeMode: Event<TunnelMode>;
 
 	readonly onDidTokenFailed: Event<IRemoteTunnelSession | undefined>;
-	initialize(session: IRemoteTunnelSession | undefined): Promise<TunnelStatus>;
+	initialize(mode: TunnelMode): Promise<TunnelStatus>;
 
-	startTunnel(session: IRemoteTunnelSession): Promise<TunnelStatus>;
+	startTunnel(mode: ActiveTunnelMode): Promise<TunnelStatus>;
 	stopTunnel(): Promise<void>;
 	getTunnelName(): Promise<string | undefined>;
 
 }
+
+export interface ActiveTunnelMode {
+	readonly active: true;
+	readonly session: IRemoteTunnelSession;
+	readonly asService: boolean;
+}
+
+export interface InactiveTunnelMode {
+	readonly active: false;
+}
+
+export const INACTIVE_TUNNEL_MODE: InactiveTunnelMode = { active: false };
+
+/** Saved mode for the tunnel. */
+export type TunnelMode = ActiveTunnelMode | InactiveTunnelMode;
 
 export type TunnelStatus = TunnelStates.Connected | TunnelStates.Disconnected | TunnelStates.Connecting | TunnelStates.Uninitialized;
 
@@ -46,13 +61,14 @@ export namespace TunnelStates {
 	export interface Connected {
 		readonly type: 'connected';
 		readonly info: ConnectionInfo;
+		readonly serviceInstallFailed: boolean;
 	}
 	export interface Disconnected {
 		readonly type: 'disconnected';
 		readonly onTokenFailed?: IRemoteTunnelSession;
 	}
 	export const disconnected = (onTokenFailed?: IRemoteTunnelSession): Disconnected => ({ type: 'disconnected', onTokenFailed });
-	export const connected = (info: ConnectionInfo): Connected => ({ type: 'connected', info });
+	export const connected = (info: ConnectionInfo, serviceInstallFailed: boolean): Connected => ({ type: 'connected', info, serviceInstallFailed });
 	export const connecting = (progress?: string): Connecting => ({ type: 'connecting', progress });
 	export const uninitialized: Uninitialized = { type: 'uninitialized' };
 

--- a/src/vs/workbench/contrib/remoteTunnel/electron-sandbox/remoteTunnel.contribution.ts
+++ b/src/vs/workbench/contrib/remoteTunnel/electron-sandbox/remoteTunnel.contribution.ts
@@ -3,40 +3,39 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Disposable, DisposableStore } from 'vs/base/common/lifecycle';
-import { Action2, MenuId, registerAction2 } from 'vs/platform/actions/common/actions';
-import { IProductService } from 'vs/platform/product/common/productService';
-import { CONFIGURATION_KEY_HOST_NAME, CONFIGURATION_KEY_PREFIX, CONFIGURATION_KEY_PREVENT_SLEEP, ConnectionInfo, IRemoteTunnelSession, IRemoteTunnelService, LOGGER_NAME, LOG_ID } from 'vs/platform/remoteTunnel/common/remoteTunnel';
-import { AuthenticationSession, IAuthenticationService } from 'vs/workbench/services/authentication/common/authentication';
-import { localize } from 'vs/nls';
-import { IWorkbenchContributionsRegistry, Extensions as WorkbenchExtensions, IWorkbenchContribution } from 'vs/workbench/common/contributions';
-import { Registry } from 'vs/platform/registry/common/platform';
-import { LifecyclePhase } from 'vs/workbench/services/lifecycle/common/lifecycle';
-import { ContextKeyExpr, IContextKey, IContextKeyService, RawContextKey } from 'vs/platform/contextkey/common/contextkey';
-import { ILocalizedString } from 'vs/platform/action/common/action';
-import { IDialogService } from 'vs/platform/dialogs/common/dialogs';
-import { IStorageService, StorageScope, StorageTarget } from 'vs/platform/storage/common/storage';
-import { ILogger, ILoggerService, ILogService } from 'vs/platform/log/common/log';
-import { INativeEnvironmentService } from 'vs/platform/environment/common/environment';
-import { IExtensionService } from 'vs/workbench/services/extensions/common/extensions';
-import { IQuickInputService, IQuickPickItem, IQuickPickSeparator, QuickPickItem } from 'vs/platform/quickinput/common/quickInput';
-import { IOutputService } from 'vs/workbench/services/output/common/output';
-import { IFileService } from 'vs/platform/files/common/files';
-import { IConfigurationRegistry, Extensions as ConfigurationExtensions, ConfigurationScope } from 'vs/platform/configuration/common/configurationRegistry';
-import { IProgress, IProgressService, IProgressStep, ProgressLocation } from 'vs/platform/progress/common/progress';
-import { ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
-import { INotificationService, Severity } from 'vs/platform/notification/common/notification';
-import { ICommandService } from 'vs/platform/commands/common/commands';
-import { IPreferencesService } from 'vs/workbench/services/preferences/common/preferences';
-import { IOpenerService } from 'vs/platform/opener/common/opener';
 import { Action } from 'vs/base/common/actions';
-import { IClipboardService } from 'vs/platform/clipboard/common/clipboardService';
-import { IWorkspaceContextService, isUntitledWorkspace } from 'vs/platform/workspace/common/workspace';
+import { Disposable, DisposableStore } from 'vs/base/common/lifecycle';
 import { Schemas } from 'vs/base/common/network';
-import { URI } from 'vs/base/common/uri';
-import { joinPath } from 'vs/base/common/resources';
 import { ITunnelApplicationConfig } from 'vs/base/common/product';
+import { joinPath } from 'vs/base/common/resources';
 import { isNumber, isObject, isString } from 'vs/base/common/types';
+import { URI } from 'vs/base/common/uri';
+import { localize } from 'vs/nls';
+import { ILocalizedString } from 'vs/platform/action/common/action';
+import { Action2, MenuId, registerAction2 } from 'vs/platform/actions/common/actions';
+import { IClipboardService } from 'vs/platform/clipboard/common/clipboardService';
+import { ICommandService } from 'vs/platform/commands/common/commands';
+import { Extensions as ConfigurationExtensions, ConfigurationScope, IConfigurationRegistry } from 'vs/platform/configuration/common/configurationRegistry';
+import { ContextKeyExpr, IContextKey, IContextKeyService, RawContextKey } from 'vs/platform/contextkey/common/contextkey';
+import { IDialogService } from 'vs/platform/dialogs/common/dialogs';
+import { INativeEnvironmentService } from 'vs/platform/environment/common/environment';
+import { ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
+import { ILogger, ILoggerService } from 'vs/platform/log/common/log';
+import { INotificationService, Severity } from 'vs/platform/notification/common/notification';
+import { IOpenerService } from 'vs/platform/opener/common/opener';
+import { IProductService } from 'vs/platform/product/common/productService';
+import { IProgress, IProgressService, IProgressStep, ProgressLocation } from 'vs/platform/progress/common/progress';
+import { IQuickInputService, IQuickPickItem, IQuickPickSeparator, QuickPickItem } from 'vs/platform/quickinput/common/quickInput';
+import { Registry } from 'vs/platform/registry/common/platform';
+import { CONFIGURATION_KEY_HOST_NAME, CONFIGURATION_KEY_PREFIX, CONFIGURATION_KEY_PREVENT_SLEEP, ConnectionInfo, INACTIVE_TUNNEL_MODE, IRemoteTunnelService, IRemoteTunnelSession, LOGGER_NAME, LOG_ID, TunnelStatus } from 'vs/platform/remoteTunnel/common/remoteTunnel';
+import { IStorageService, StorageScope, StorageTarget } from 'vs/platform/storage/common/storage';
+import { IWorkspaceContextService, isUntitledWorkspace } from 'vs/platform/workspace/common/workspace';
+import { IWorkbenchContribution, IWorkbenchContributionsRegistry, Extensions as WorkbenchExtensions } from 'vs/workbench/common/contributions';
+import { AuthenticationSession, IAuthenticationService } from 'vs/workbench/services/authentication/common/authentication';
+import { IExtensionService } from 'vs/workbench/services/extensions/common/extensions';
+import { LifecyclePhase } from 'vs/workbench/services/lifecycle/common/lifecycle';
+import { IOutputService } from 'vs/workbench/services/output/common/output';
+import { IPreferencesService } from 'vs/workbench/services/preferences/common/preferences';
 
 export const REMOTE_TUNNEL_CATEGORY: ILocalizedString = {
 	original: 'Remote-Tunnels',
@@ -103,10 +102,8 @@ export class RemoteTunnelWorkbenchContribution extends Disposable implements IWo
 		@IProductService productService: IProductService,
 		@IStorageService private readonly storageService: IStorageService,
 		@ILoggerService loggerService: ILoggerService,
-		@ILogService logService: ILogService,
 		@IQuickInputService private readonly quickInputService: IQuickInputService,
 		@INativeEnvironmentService private environmentService: INativeEnvironmentService,
-		@IFileService fileService: IFileService,
 		@IRemoteTunnelService private remoteTunnelService: IRemoteTunnelService,
 		@ICommandService private commandService: ICommandService,
 		@IWorkspaceContextService private workspaceContextService: IWorkspaceContextService,
@@ -127,26 +124,28 @@ export class RemoteTunnelWorkbenchContribution extends Disposable implements IWo
 		}
 		this.serverConfiguration = serverConfiguration;
 
-		this._register(this.remoteTunnelService.onDidChangeTunnelStatus(status => {
-			this.connectionInfo = undefined;
-			if (status.type === 'disconnected') {
-				if (status.onTokenFailed) {
-					this.expiredSessions.add(status.onTokenFailed.sessionId);
-				}
-				this.connectionStateContext.set('disconnected');
-			} else if (status.type === 'connecting') {
-				this.connectionStateContext.set('connecting');
-			} else if (status.type === 'connected') {
-				this.connectionInfo = status.info;
-				this.connectionStateContext.set('connected');
-			}
-		}));
+		this._register(this.remoteTunnelService.onDidChangeTunnelStatus(s => this.handleTunnelStatusUpdate(s)));
 
 		this.registerCommands();
 
 		this.initialize();
 
 		this.recommendRemoteExtensionIfNeeded();
+	}
+
+	private handleTunnelStatusUpdate(status: TunnelStatus) {
+		this.connectionInfo = undefined;
+		if (status.type === 'disconnected') {
+			if (status.onTokenFailed) {
+				this.expiredSessions.add(status.onTokenFailed.sessionId);
+			}
+			this.connectionStateContext.set('disconnected');
+		} else if (status.type === 'connecting') {
+			this.connectionStateContext.set('connecting');
+		} else if (status.type === 'connected') {
+			this.connectionInfo = status.info;
+			this.connectionStateContext.set('connected');
+		}
 	}
 
 	private async recommendRemoteExtensionIfNeeded() {
@@ -228,10 +227,17 @@ export class RemoteTunnelWorkbenchContribution extends Disposable implements IWo
 	}
 
 	private async initialize(): Promise<void> {
-		const session = await this.remoteTunnelService.getSession();
-		if (session && session.token) {
+		const [mode, status] = await Promise.all([
+			this.remoteTunnelService.getMode(),
+			this.remoteTunnelService.getTunnelStatus(),
+		]);
+
+		this.handleTunnelStatusUpdate(status);
+
+		if (mode.active && mode.session.token) {
 			return; // already initialized, token available
 		}
+
 		return await this.progressService.withProgress(
 			{
 				location: ProgressLocation.Window,
@@ -248,13 +254,13 @@ export class RemoteTunnelWorkbenchContribution extends Disposable implements IWo
 					}
 				});
 				let newSession: IRemoteTunnelSession | undefined;
-				if (session) {
-					const token = await this.getSessionToken(session);
+				if (mode.active) {
+					const token = await this.getSessionToken(mode.session);
 					if (token) {
-						newSession = { ...session, token };
+						newSession = { ...mode.session, token };
 					}
 				}
-				const status = await this.remoteTunnelService.initialize(newSession);
+				const status = await this.remoteTunnelService.initialize(mode.active && newSession ? { ...mode, session: newSession } : INACTIVE_TUNNEL_MODE);
 				listener.dispose();
 
 				if (status.type === 'connected') {
@@ -267,7 +273,7 @@ export class RemoteTunnelWorkbenchContribution extends Disposable implements IWo
 	}
 
 
-	private async startTunnel(): Promise<ConnectionInfo | undefined> {
+	private async startTunnel(asService: boolean): Promise<ConnectionInfo | undefined> {
 		if (this.connectionInfo) {
 			return this.connectionInfo;
 		}
@@ -301,6 +307,19 @@ export class RemoteTunnelWorkbenchContribution extends Disposable implements IWo
 									listener.dispose();
 									completed = true;
 									s(status.info);
+									if (status.serviceInstallFailed) {
+										this.notificationService.notify({
+											severity: Severity.Warning,
+											message: localize(
+												{
+													key: 'remoteTunnel.serviceInstallFailed',
+													comment: ['{Locked="](command:{0})"}']
+												},
+												"Installation as a service failed, and we fell back to running the tunnel for this session. See the [error log](command:{0}) for details.",
+												RemoteTunnelCommandIds.showLog,
+											),
+										});
+									}
 									break;
 								case 'disconnected':
 									listener.dispose();
@@ -312,7 +331,7 @@ export class RemoteTunnelWorkbenchContribution extends Disposable implements IWo
 						});
 						const token = authenticationSession.session.idToken ?? authenticationSession.session.accessToken;
 						const account: IRemoteTunnelSession = { sessionId: authenticationSession.session.id, token, providerId: authenticationSession.providerId, accountLabel: authenticationSession.session.account.label };
-						this.remoteTunnelService.startTunnel(account).then(status => {
+						this.remoteTunnelService.startTunnel({ active: true, asService, session: account }).then(status => {
 							if (!completed && (status.type === 'connected' || status.type === 'disconnected')) {
 								listener.dispose();
 								if (status.type === 'connected') {
@@ -403,7 +422,7 @@ export class RemoteTunnelWorkbenchContribution extends Disposable implements IWo
 	private async getAllSessions(): Promise<ExistingSessionItem[]> {
 		const authenticationProviders = await this.getAuthenticationProviders();
 		const accounts = new Map<string, ExistingSessionItem>();
-		const currentAccount = await this.remoteTunnelService.getSession();
+		const currentAccount = await this.remoteTunnelService.getMode();
 		let currentSession: ExistingSessionItem | undefined;
 
 		for (const provider of authenticationProviders) {
@@ -413,7 +432,7 @@ export class RemoteTunnelWorkbenchContribution extends Disposable implements IWo
 				if (!this.expiredSessions.has(session.id)) {
 					const item = this.createExistingSessionItem(session, provider.id);
 					accounts.set(item.session.account.id, item);
-					if (currentAccount && currentAccount.sessionId === session.id) {
+					if (currentAccount.active && currentAccount.session.sessionId === session.id) {
 						currentSession = item;
 					}
 				}
@@ -483,6 +502,8 @@ export class RemoteTunnelWorkbenchContribution extends Disposable implements IWo
 				const commandService = accessor.get(ICommandService);
 				const storageService = accessor.get(IStorageService);
 				const dialogService = accessor.get(IDialogService);
+				const quickInputService = accessor.get(IQuickInputService);
+				const productService = accessor.get(IProductService);
 
 				const didNotifyPreview = storageService.getBoolean(REMOTE_TUNNEL_PROMPTED_PREVIEW_STORAGE_KEY, StorageScope.APPLICATION, false);
 				if (!didNotifyPreview) {
@@ -497,12 +518,33 @@ export class RemoteTunnelWorkbenchContribution extends Disposable implements IWo
 					storageService.store(REMOTE_TUNNEL_PROMPTED_PREVIEW_STORAGE_KEY, true, StorageScope.APPLICATION, StorageTarget.USER);
 				}
 
-				const connectionInfo = await that.startTunnel();
+				const disposables = new DisposableStore();
+				const quickPick = quickInputService.createQuickPick<IQuickPickItem & { service: boolean }>();
+				quickPick.placeholder = localize('tunnel.enable.placeholder', 'Select how you want to enable access');
+				quickPick.items = [
+					{ service: false, label: localize('tunnel.enable.session', 'Turn on for this session'), description: localize('tunnel.enable.session.description', 'Run whenever {0} is open', productService.nameShort) },
+					{ service: true, label: localize('tunnel.enable.service', 'Install as a service'), description: localize('tunnel.enable.service.description', 'Run whenever you\'re logged in') }
+				];
+
+				const asService = await new Promise<boolean | undefined>(resolve => {
+					disposables.add(quickPick.onDidAccept(() => resolve(quickPick.selectedItems[0]?.service)));
+					disposables.add(quickPick.onDidHide(() => resolve(undefined)));
+					quickPick.show();
+				});
+
+				quickPick.dispose();
+
+				if (asService === undefined) {
+					return; // no-op
+				}
+
+				const connectionInfo = await that.startTunnel(/* installAsService= */ asService);
+
 				if (connectionInfo) {
 					const linkToOpen = that.getLinkToOpen(connectionInfo);
 					const remoteExtension = that.serverConfiguration.extension;
 					const linkToOpenForMarkdown = linkToOpen.toString(false).replace(/\)/g, '%29');
-					await notificationService.notify({
+					notificationService.notify({
 						severity: Severity.Info,
 						message:
 							localize(
@@ -525,7 +567,7 @@ export class RemoteTunnelWorkbenchContribution extends Disposable implements IWo
 					const usedOnHostMessage: UsedOnHostMessage = { hostName: connectionInfo.tunnelName, timeStamp: new Date().getTime() };
 					storageService.store(REMOTE_TUNNEL_USED_STORAGE_KEY, JSON.stringify(usedOnHostMessage), StorageScope.APPLICATION, StorageTarget.USER);
 				} else {
-					await notificationService.notify({
+					notificationService.notify({
 						severity: Severity.Info,
 						message: localize('progress.turnOn.failed',
 							"Unable to turn on the remote tunnel access. Check the Remote Tunnel Service log for details."),
@@ -699,7 +741,7 @@ export class RemoteTunnelWorkbenchContribution extends Disposable implements IWo
 
 
 	private async showManageOptions() {
-		const account = await this.remoteTunnelService.getSession();
+		const account = await this.remoteTunnelService.getMode();
 
 		return new Promise<void>((c, e) => {
 			const disposables = new DisposableStore();
@@ -721,7 +763,7 @@ export class RemoteTunnelWorkbenchContribution extends Disposable implements IWo
 			items.push({ id: RemoteTunnelCommandIds.showLog, label: localize('manage.showLog', 'Show Log') });
 			items.push({ type: 'separator' });
 			items.push({ id: RemoteTunnelCommandIds.configure, label: localize('manage.tunnelName', 'Change Tunnel Name'), description: this.connectionInfo?.tunnelName });
-			items.push({ id: RemoteTunnelCommandIds.turnOff, label: RemoteTunnelCommandLabels.turnOff, description: account ? `${account.accountLabel} (${account.providerId})` : undefined });
+			items.push({ id: RemoteTunnelCommandIds.turnOff, label: RemoteTunnelCommandLabels.turnOff, description: account.active ? `${account.session.accountLabel} (${account.session.providerId})` : undefined });
 
 			quickPick.items = items;
 			disposables.add(quickPick.onDidAccept(() => {


### PR DESCRIPTION
- When turning on remote tunnel access, a quickpick is now shown asking
  users whether it should be installed as a service or just run in
	the session.
- Picking the service install will install the tunnel as a service on
  the machine, and start it.
- Turning off remote tunnel access will uninstall the service only if
  we were the ones to install it.
- This involved some refactoring to add extra state to the RemoteTunnelService.
  There's now a "mode" that includes the previous "session" and reflects
	the desired end state.
- I also did a cleanup with a `StreamSplitter` to ensure output of the
  CLI gets read line-by-line. This was depended upon by the remote tunnel
	service code, but it's not actually guaranteed.
- Changes in the CLI: allow setting the tunnel name while installing the
  service, and make both service un/installation and renames idempotent.

Closes https://github.com/microsoft/vscode/issues/184663

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
