### PR TITLE
cli: fix windows service-mode not working

### DIFF
--- a/cli/src/tunnels/code_server.rs
+++ b/cli/src/tunnels/code_server.rs
@@ -566,7 +566,17 @@ impl<'a> ServerBuilder<'a> {
 	}
 
 	fn get_base_command(&self) -> Command {
+		#[cfg(not(windows))]
 		let mut cmd = Command::new(&self.server_paths.executable);
+		#[cfg(windows)]
+		let mut cmd = {
+			let mut cmd = Command::new("cmd");
+			cmd.arg("/Q");
+			cmd.arg("/C");
+			cmd.arg(&self.server_paths.executable);
+			cmd
+		};
+
 		cmd.stdin(std::process::Stdio::null())
 			.args(self.server_params.code_server_args.command_arguments());
 		cmd


### PR DESCRIPTION
It seems like we need to run the server (a batch file) with cmd explicitly when the server itself is not run from a command prompt.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
