### PR TITLE
Escape removes the edits done by color picker

### DIFF
--- a/src/vs/editor/contrib/colorPicker/browser/colorHoverParticipant.ts
+++ b/src/vs/editor/contrib/colorPicker/browser/colorHoverParticipant.ts
@@ -205,7 +205,8 @@ function renderHoverParts(participant: ColorHoverParticipant | StandaloneColorPi
 			editorUpdatedByColorPicker = true;
 			range = _updateEditorModel(editor, range, model, context);
 		}));
-		disposables.add(editor.onKeyUp((e) => {
+		// need to remove the part of the code that automatically makes the hover disappear
+		disposables.add(editor.onKeyDown((e) => {
 			console.log('inside of on key up');
 			if (e.equals(KeyCode.Escape)) {
 				_revertEditorModel(editor);

--- a/src/vs/editor/contrib/colorPicker/browser/colorHoverParticipant.ts
+++ b/src/vs/editor/contrib/colorPicker/browser/colorHoverParticipant.ts
@@ -179,6 +179,8 @@ async function _createColorHover(participant: ColorHoverParticipant | Standalone
 }
 
 function renderHoverParts(participant: ColorHoverParticipant | StandaloneColorPickerParticipant, editor: ICodeEditor, themeService: IThemeService, hoverParts: ColorHover[] | StandaloneColorPickerHover[], context: IEditorHoverRenderContext) {
+	console.log('entered into renderHoverParts');
+
 	if (hoverParts.length === 0 || !editor.hasModel()) {
 		return Disposable.None;
 	}
@@ -206,6 +208,15 @@ function renderHoverParts(participant: ColorHoverParticipant | StandaloneColorPi
 			range = _updateEditorModel(editor, range, model, context);
 		}));
 		// need to remove the part of the code that automatically makes the hover disappear
+		console.log('context.onHide : ', context.onHide);
+
+		if (context.onHide) {
+			console.log('entered into case when context.onHide is defined');
+
+			context.onHide(() => {
+				console.log('entered into the on hide event of the context');
+			});
+		}
 		disposables.add(editor.onKeyDown((e) => {
 			console.log('inside of on key up');
 			if (e.equals(KeyCode.Escape)) {
@@ -227,12 +238,14 @@ function renderHoverParts(participant: ColorHoverParticipant | StandaloneColorPi
 	return disposables;
 }
 
+// TODO: need to find a way to reset this number when the hover disappears
 let NUMBER_COLOR_EDITS: number = 0;
 
 function pushUndoStopCount(editor: ICodeEditor) {
 	console.log('inside of push undo stop');
 	editor.pushUndoStop();
 	NUMBER_COLOR_EDITS += 1;
+	console.log('NUMBER_COLOR_EDITS : ', NUMBER_COLOR_EDITS);
 }
 
 function _revertEditorModel(editor: ICodeEditor) {
@@ -271,12 +284,12 @@ function _updateEditorModel(editor: ICodeEditor, range: Range, model: ColorPicke
 
 	if (model.presentation.additionalTextEdits) {
 		textEdits = [...model.presentation.additionalTextEdits];
+		pushUndoStopCount(editor);
 		editor.executeEdits('colorpicker', textEdits);
 		if (context) {
 			context.hide();
 		}
 	}
-	pushUndoStopCount(editor);
 	return newRange;
 }
 

--- a/src/vs/editor/contrib/colorPicker/browser/colorHoverParticipant.ts
+++ b/src/vs/editor/contrib/colorPicker/browser/colorHoverParticipant.ts
@@ -229,6 +229,7 @@ function renderHoverParts(participant: ColorHoverParticipant | StandaloneColorPi
 let NUMBER_COLOR_EDITS: number = 0;
 
 function pushUndoStopCount(editor: ICodeEditor) {
+	console.log('inside of push undo stop');
 	editor.pushUndoStop();
 	NUMBER_COLOR_EDITS += 1;
 }

--- a/src/vs/editor/contrib/hover/browser/contentHover.ts
+++ b/src/vs/editor/contrib/hover/browser/contentHover.ts
@@ -24,6 +24,7 @@ import { AsyncIterableObject } from 'vs/base/common/async';
 import { EditorContextKeys } from 'vs/editor/common/editorContextKeys';
 import { IContextKey, IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 import { ResizableContentWidget } from 'vs/editor/contrib/hover/browser/resizableContentWidget';
+import { Emitter, Event } from 'vs/base/common/event';
 const $ = dom.$;
 
 export class ContentHoverController extends Disposable {
@@ -276,7 +277,12 @@ export class ContentHoverController extends Disposable {
 			statusBar,
 			setColorPicker: (widget) => colorPicker = widget,
 			onContentsChanged: () => this._widget.onContentsChanged(),
-			hide: () => this.hide()
+			hide: () => this.hide(),
+			// TODO
+			onHide: (listener: (e: void) => any) => {
+				console.log('inside of onHide of the context');
+				disposables.add(this._widget.onHide(listener));
+			},
 		};
 
 		for (const participant of this._participants) {
@@ -463,6 +469,9 @@ export class ContentHoverWidget extends ResizableContentWidget {
 	private readonly _hover: HoverWidget = this._register(new HoverWidget());
 	private readonly _hoverVisibleKey: IContextKey<boolean>;
 	private readonly _hoverFocusedKey: IContextKey<boolean>;
+
+	private readonly _onHide = this._register(new Emitter<void>());
+	public readonly onHide: Event<void> = this._onHide.event;
 
 	public get isColorPickerVisible(): boolean {
 		return Boolean(this._visibleData?.colorPicker);
@@ -735,6 +744,8 @@ export class ContentHoverWidget extends ResizableContentWidget {
 		this._resizableNode.clearSashHoverState();
 		this._hoverFocusedKey.set(false);
 		this._editor.layoutContentWidget(this);
+		console.log('before firing _onHide inside of hide');
+		this._onHide.fire();
 		if (stoleFocus) {
 			this._editor.focus();
 		}

--- a/src/vs/editor/contrib/hover/browser/hoverTypes.ts
+++ b/src/vs/editor/contrib/hover/browser/hoverTypes.ts
@@ -114,6 +114,10 @@ export interface IEditorHoverRenderContext {
 	 * Hide the hover.
 	 */
 	hide(): void;
+	/**
+	 * Listener which listens on the hide event of the hover
+	 */
+	onHide?(listener: (e: void) => any): void;
 }
 
 export interface IEditorHoverParticipant<T extends IHoverPart = IHoverPart> {


### PR DESCRIPTION
:warning: Work in progress

Currently working on how to detect when the escape key is pressed and when the content hover is hidden from the color participant code

Fixes https://github.com/microsoft/vscode/issues/31641