### PR TITLE
Comments: Fix comments stealing focus when they update

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadComments.ts
+++ b/src/vs/workbench/api/browser/mainThreadComments.ts
@@ -489,6 +489,10 @@ export class MainThreadComments extends Disposable implements MainThreadComments
 		this._commentService.unregisterCommentController();
 
 		this._register(this._commentService.onDidChangeActiveCommentThread(async thread => {
+			if (!thread) {
+				return;
+			}
+
 			const handle = (thread as MainThreadCommentThread<IRange | ICellRange>).controllerHandle;
 			const controller = this._commentControllers.get(handle);
 

--- a/src/vs/workbench/contrib/comments/browser/commentThreadBody.ts
+++ b/src/vs/workbench/contrib/comments/browser/commentThreadBody.ts
@@ -31,6 +31,7 @@ export class CommentThreadBody<T extends IRange | ICellRange = IRange> extends D
 
 	private _commentDisposable = new Map<CommentNode<T>, IDisposable>();
 	private _markdownRenderer: MarkdownRenderer;
+	private _hasFocus = false;
 
 	get length() {
 		return this._commentThread.comments ? this._commentThread.comments.length : 0;
@@ -59,6 +60,11 @@ export class CommentThreadBody<T extends IRange | ICellRange = IRange> extends D
 		this._register(dom.addDisposableListener(container, dom.EventType.FOCUS_IN, e => {
 			// TODO @rebornix, limit T to IRange | ICellRange
 			this.commentService.setActiveCommentThread(this._commentThread);
+			this._hasFocus = true;
+		}));
+		this._register(dom.addDisposableListener(container, dom.EventType.FOCUS_OUT, e => {
+			this.commentService.setActiveCommentThread(null);
+			this._hasFocus = false;
 		}));
 
 		this._markdownRenderer = this._register(new MarkdownRenderer(this._options, this.languageService, this.openerService));
@@ -240,6 +246,10 @@ export class CommentThreadBody<T extends IRange | ICellRange = IRange> extends D
 	}
 
 	private _setFocusedComment(value: number | undefined) {
+		if (!this._hasFocus) {
+			return;
+		}
+
 		if (this._focusedComment !== undefined) {
 			this._commentElements[this._focusedComment]?.setFocus(false);
 		}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Closes: https://github.com/microsoft/vscode/issues/187935

VS Code calls `_setFocusedComment` whenever a comment thread is updated. It should only do this if the focus is _still_ on the comment thread.