### PR TITLE
fix: prevent duplicate reason(#186206)

### DIFF
--- a/src/vs/editor/contrib/unicodeHighlighter/browser/unicodeHighlighter.ts
+++ b/src/vs/editor/contrib/unicodeHighlighter/browser/unicodeHighlighter.ts
@@ -429,6 +429,7 @@ export class UnicodeHighlighterHoverParticipant implements IEditorHoverParticipa
 		}
 
 		const result: MarkdownHover[] = [];
+		const existedReason = new Map<string, boolean>();
 		let index = 300;
 		for (const d of lineDecorations) {
 
@@ -479,6 +480,11 @@ export class UnicodeHighlighterHoverParticipant implements IEditorHoverParticipa
 					);
 					break;
 			}
+
+			if (existedReason.has(reason)) {
+				continue;
+			}
+			existedReason.set(reason, true);
 
 			const adjustSettingsArgs: ShowExcludeOptionsArgs = {
 				codePoint: codePoint,

--- a/src/vs/editor/contrib/unicodeHighlighter/browser/unicodeHighlighter.ts
+++ b/src/vs/editor/contrib/unicodeHighlighter/browser/unicodeHighlighter.ts
@@ -429,7 +429,7 @@ export class UnicodeHighlighterHoverParticipant implements IEditorHoverParticipa
 		}
 
 		const result: MarkdownHover[] = [];
-		const existedReason = new Map<string, boolean>();
+		const existedReason = new Set<string>();
 		let index = 300;
 		for (const d of lineDecorations) {
 
@@ -484,7 +484,7 @@ export class UnicodeHighlighterHoverParticipant implements IEditorHoverParticipa
 			if (existedReason.has(reason)) {
 				continue;
 			}
-			existedReason.set(reason, true);
+			existedReason.add(reason);
 
 			const adjustSettingsArgs: ShowExcludeOptionsArgs = {
 				codePoint: codePoint,


### PR DESCRIPTION
Fix #186206

I spent times to find a way removing duplicate lineDecorations, but later I realize they are not so "duplicate", it's useful when two unicode characters come together, for example:
<img width="524" alt="Screen Shot 2023-07-15 at 23 12 53" src="https://github.com/microsoft/vscode/assets/18526463/d6bfb942-040d-4f35-bf8d-0aa30c72f186">

So I choose preventing duplicate reasons as a solution.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
