### PR TITLE
Merge Editor: setting to show only conflicts in overview rulers

### DIFF
--- a/src/vs/workbench/contrib/mergeEditor/browser/mergeEditor.contribution.ts
+++ b/src/vs/workbench/contrib/mergeEditor/browser/mergeEditor.contribution.ts
@@ -53,7 +53,12 @@ Registry.as<IConfigurationRegistry>(Extensions.Configuration).registerConfigurat
 		'mergeEditor.showDeletionMarkers': {
 			type: 'boolean',
 			default: true,
-			description: 'Controls if deletions in base or one of the inputs should be indicated by a vertical bar.',
+			description: localize('mergeEditor.showDeletionMarkers', 'Controls if deletions in base or one of the inputs should be indicated by a vertical bar.'),
+		},
+		'mergeEditor.showOnlyConflictingChangesInOverviewRulers': {
+			type: 'boolean',
+			default: false,
+			description: localize('mergeEditor.showOnlyConflictingChangesInOverviewRulers', 'Controls if decorations for only conflicting changes should be shown in the overview rulers.'),
 		},
 	}
 });

--- a/src/vs/workbench/contrib/mergeEditor/browser/view/editors/baseCodeEditorView.ts
+++ b/src/vs/workbench/contrib/mergeEditor/browser/view/editors/baseCodeEditorView.ts
@@ -80,6 +80,7 @@ export class BaseCodeEditorView extends CodeEditorView {
 		const activeModifiedBaseRange = viewModel.activeModifiedBaseRange.read(reader);
 		const showNonConflictingChanges = viewModel.showNonConflictingChanges.read(reader);
 		const showDeletionMarkers = this.showDeletionMarkers.read(reader);
+		const showOnlyConflictingChangesInOverviewRulers = this.showOnlyConflictingChangesInOverviewRulers.read(reader);
 
 		const result: IModelDeltaDecoration[] = [];
 		for (const modifiedBaseRange of model.modifiedBaseRanges.read(reader)) {
@@ -148,7 +149,7 @@ export class BaseCodeEditorView extends CodeEditorView {
 						position: MinimapPosition.Gutter,
 						color: { id: isHandled ? handledConflictMinimapOverViewRulerColor : unhandledConflictMinimapOverViewRulerColor },
 					},
-					overviewRuler: modifiedBaseRange.isConflicting ? {
+					overviewRuler: (modifiedBaseRange.isConflicting || !showOnlyConflictingChangesInOverviewRulers) ? {
 						position: OverviewRulerLane.Center,
 						color: { id: isHandled ? handledConflictMinimapOverViewRulerColor : unhandledConflictMinimapOverViewRulerColor },
 					} : undefined

--- a/src/vs/workbench/contrib/mergeEditor/browser/view/editors/codeEditorView.ts
+++ b/src/vs/workbench/contrib/mergeEditor/browser/view/editors/codeEditorView.ts
@@ -64,6 +64,7 @@ export abstract class CodeEditorView extends Disposable {
 	protected readonly checkboxesVisible = observableConfigValue<boolean>('mergeEditor.showCheckboxes', false, this.configurationService);
 	protected readonly showDeletionMarkers = observableConfigValue<boolean>('mergeEditor.showDeletionMarkers', true, this.configurationService);
 	protected readonly useSimplifiedDecorations = observableConfigValue<boolean>('mergeEditor.useSimplifiedDecorations', false, this.configurationService);
+	protected readonly showOnlyConflictingChangesInOverviewRulers = observableConfigValue<boolean>('mergeEditor.showOnlyConflictingChangesInOverviewRulers', false, this.configurationService);
 
 	public readonly editor = this.instantiationService.createInstance(
 		CodeEditorWidget,

--- a/src/vs/workbench/contrib/mergeEditor/browser/view/editors/inputCodeEditorView.ts
+++ b/src/vs/workbench/contrib/mergeEditor/browser/view/editors/inputCodeEditorView.ts
@@ -125,6 +125,7 @@ export class InputCodeEditorView extends CodeEditorView {
 
 		const showNonConflictingChanges = viewModel.showNonConflictingChanges.read(reader);
 		const showDeletionMarkers = this.showDeletionMarkers.read(reader);
+		const showOnlyConflictingChangesInOverviewRulers = this.showOnlyConflictingChangesInOverviewRulers.read(reader);
 		const diffWithThis = viewModel.baseCodeEditorView.read(reader) !== undefined && viewModel.baseShowDiffAgainst.read(reader) === this.inputNumber;
 		const useSimplifiedDecorations = !diffWithThis && this.useSimplifiedDecorations.read(reader);
 
@@ -170,7 +171,7 @@ export class InputCodeEditorView extends CodeEditorView {
 						position: MinimapPosition.Gutter,
 						color: { id: isHandled ? handledConflictMinimapOverViewRulerColor : unhandledConflictMinimapOverViewRulerColor },
 					},
-					overviewRuler: modifiedBaseRange.isConflicting ? {
+					overviewRuler: (modifiedBaseRange.isConflicting || !showOnlyConflictingChangesInOverviewRulers) ? {
 						position: OverviewRulerLane.Center,
 						color: { id: isHandled ? handledConflictMinimapOverViewRulerColor : unhandledConflictMinimapOverViewRulerColor },
 					} : undefined

--- a/src/vs/workbench/contrib/mergeEditor/browser/view/editors/resultCodeEditorView.ts
+++ b/src/vs/workbench/contrib/mergeEditor/browser/view/editors/resultCodeEditorView.ts
@@ -135,6 +135,8 @@ export class ResultCodeEditorView extends CodeEditorView {
 		const textModel = model.resultTextModel;
 		const result = new Array<IModelDeltaDecoration>();
 
+		const showOnlyConflictingChangesInOverviewRulers = this.showOnlyConflictingChangesInOverviewRulers.read(reader);
+
 		const baseRangeWithStoreAndTouchingDiffs = join(
 			model.modifiedBaseRanges.read(reader),
 			model.baseResultDiffs.read(reader),
@@ -186,7 +188,7 @@ export class ResultCodeEditorView extends CodeEditorView {
 							position: MinimapPosition.Gutter,
 							color: { id: isHandled ? handledConflictMinimapOverViewRulerColor : unhandledConflictMinimapOverViewRulerColor },
 						},
-						overviewRuler: modifiedBaseRange.isConflicting ? {
+						overviewRuler: (modifiedBaseRange.isConflicting || !showOnlyConflictingChangesInOverviewRulers) ? {
 							position: OverviewRulerLane.Center,
 							color: { id: isHandled ? handledConflictMinimapOverViewRulerColor : unhandledConflictMinimapOverViewRulerColor },
 						} : undefined


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
This PR resolves #161980 by adding a new setting, `mergeEditor.showOnlyConflictingChangesInOverviewRulers`, that is false by default, so all changes, conflicting or not, will be highlighted in the Merge Editor's overview rulers by default. If the user chooses (e.g., the author of #156037 has many changes to merge and wants to focus on conflicting changes), this setting can be enabled to highlight only conflicting changes in the overview rulers.

# Testing

The easiest way to test this PR is to start a merge from the command line, e.g., `.\scripts\code.bat --merge --wait a.txt b.txt c.txt d.txt`, where:

## Example of non-conflicting change

- a.txt: `One`
- b.txt: `Two`
- c.txt: `One`
- d.txt: `One`

This change should be highlighted in the overview rulers only if the setting is disabled.

## Example of conflicting change

- a.txt: `One`
- b.txt: `Two`
- c.txt: `Three`
- d.txt: `Three`

This change should always be highlighted in the overview rulers.

# Notes

1. This PR also makes the description of `mergeEditor.showDeletionMarkers` localizable. I can remove this quick fix if the reviewer prefers it to not be in this PR.
2. There are three overview rulers displayed in the Merge Editor, so the setting name and description refer to "rulers", not "ruler", but I can change them to use the singular form if the reviewer prefers.