### PR TITLE
cli: improve `code tunnel` with existing tunnels

### DIFF
--- a/cli/src/commands/args.rs
+++ b/cli/src/commands/args.rs
@@ -548,6 +548,7 @@ pub enum OutputFormat {
 #[derive(Args, Clone, Debug, Default)]
 pub struct ExistingTunnelArgs {
 	/// Name you'd like to assign preexisting tunnel to use to connect the tunnel
+	/// Old option, new code sohuld just use `--name`.
 	#[clap(long, hide = true)]
 	pub tunnel_name: Option<String>,
 


### PR DESCRIPTION
- Apply the name/tunnel-name from the CLI automatically
	(do a normal tag sync). Previously the CLI could host tunnels that
	were unusable unless the consumer did the tag setup, which they
	should not.
- Allow "tunnel ID" to be specified in the new `<id>.<cluster>` format
  that devtunnels has adopted.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
