### PR TITLE
store title passed from jupyter to use as tab name

### DIFF
--- a/src/vs/workbench/contrib/interactive/browser/interactive.contribution.ts
+++ b/src/vs/workbench/contrib/interactive/browser/interactive.contribution.ts
@@ -392,6 +392,7 @@ registerAction2(class extends Action2 {
 
 			counter++;
 		} while (existingNotebookDocument.has(notebookUri.toString()));
+		InteractiveEditorInput.setName(notebookUri, title);
 
 		logService.debug('Open new interactive window:', notebookUri.toString(), inputUri.toString());
 

--- a/src/vs/workbench/contrib/interactive/browser/interactiveEditorInput.ts
+++ b/src/vs/workbench/contrib/interactive/browser/interactiveEditorInput.ts
@@ -25,6 +25,14 @@ export class InteractiveEditorInput extends EditorInput implements ICompositeNot
 		return instantiationService.createInstance(InteractiveEditorInput, resource, inputResource, title, language);
 	}
 
+	private static windowNames: Record<string, string> = {};
+
+	static setName(notebookUri: URI, title: string | undefined) {
+		if (title) {
+			this.windowNames[notebookUri.path] = title;
+		}
+	}
+
 	static readonly ID: string = 'workbench.input.interactive';
 
 	public override get editorId(): string {
@@ -35,7 +43,7 @@ export class InteractiveEditorInput extends EditorInput implements ICompositeNot
 		return InteractiveEditorInput.ID;
 	}
 
-	private _initTitle?: string;
+	private name: string;
 
 	get language() {
 		return this._inputModelRef?.object.textEditorModel.getLanguageId() ?? this._initLanguage;
@@ -91,7 +99,7 @@ export class InteractiveEditorInput extends EditorInput implements ICompositeNot
 		super();
 		this._notebookEditorInput = input;
 		this._register(this._notebookEditorInput);
-		this._initTitle = title;
+		this.name = title ?? InteractiveEditorInput.windowNames[resource.path] ?? paths.basename(resource.path, paths.extname(resource.path));
 		this._initLanguage = languageId;
 		this._resource = resource;
 		this._inputResource = inputResource;
@@ -209,14 +217,7 @@ export class InteractiveEditorInput extends EditorInput implements ICompositeNot
 	}
 
 	override getName() {
-		if (this._initTitle) {
-			return this._initTitle;
-		}
-
-		const p = this.primary.resource!.path;
-		const basename = paths.basename(p);
-
-		return basename.substr(0, basename.length - paths.extname(p).length);
+		return this.name;
 	}
 
 	override isModified() {

--- a/src/vs/workbench/services/workingCopy/common/workingCopyBackupService.ts
+++ b/src/vs/workbench/services/workingCopy/common/workingCopyBackupService.ts
@@ -134,8 +134,9 @@ export abstract class WorkingCopyBackupService implements IWorkingCopyBackupServ
 		if (backupWorkspaceHome) {
 			return new WorkingCopyBackupServiceImpl(backupWorkspaceHome, this.fileService, this.logService);
 		}
-
-		return new InMemoryWorkingCopyBackupService();
+		else {
+			return new WorkingCopyBackupServiceImpl(URI.file('c:\\temp\\backup'), this.fileService, this.logService);
+		}
 	}
 
 	reinitialize(backupWorkspaceHome: URI | undefined): void {

--- a/src/vs/workbench/services/workingCopy/common/workingCopyBackupService.ts
+++ b/src/vs/workbench/services/workingCopy/common/workingCopyBackupService.ts
@@ -134,9 +134,8 @@ export abstract class WorkingCopyBackupService implements IWorkingCopyBackupServ
 		if (backupWorkspaceHome) {
 			return new WorkingCopyBackupServiceImpl(backupWorkspaceHome, this.fileService, this.logService);
 		}
-		else {
-			return new WorkingCopyBackupServiceImpl(URI.file('c:\\temp\\backup'), this.fileService, this.logService);
-		}
+
+		return new InMemoryWorkingCopyBackupService();
 	}
 
 	reinitialize(backupWorkspaceHome: URI | undefined): void {


### PR DESCRIPTION
fixes https://github.com/microsoft/vscode/issues/188031

the interactiveEditorInput is initially indirectly created by the editor service, so we just need to store the title to be looked up at the point of creation.

title can still be passed in directly when deserializing the editor during recovery.