### PR TITLE
Notebook UI heading tweaks

### DIFF
--- a/extensions/markdown-language-features/notebook/index.ts
+++ b/extensions/markdown-language-features/notebook/index.ts
@@ -176,23 +176,23 @@ export const activate: ActivationFunction<void> = (ctx) => {
 
 		hr {
 			border: 0;
-			height: 2px;
-		}
-
-		hr,
-		h1,
-		h2 {
-			border-bottom: 1px solid var(--vscode-notebook-cellBorderColor);
+			height: 1px;
+			border-bottom: 1px solid;
 		}
 
 		h1 {
 			font-size: 2em;
+			margin-top: 0;
 			padding-bottom: 0.3em;
+			border-bottom-width: 1px;
+			border-bottom-style: solid;
 		}
 
 		h2 {
 			font-size: 1.5em;
 			padding-bottom: 0.3em;
+			border-bottom-width: 1px;
+			border-bottom-style: solid;
 		}
 
 		h3 {
@@ -242,6 +242,20 @@ export const activate: ActivationFunction<void> = (ctx) => {
 			margin-top: 24px;
 			margin-bottom: 16px;
 			line-height: 1.25;
+		}
+
+		.vscode-light h1,
+		.vscode-light h2,
+		.vscode-light hr,
+		.vscode-light td {
+			border-color: rgba(0, 0, 0, 0.18);
+		}
+
+		.vscode-dark h1,
+		.vscode-dark h2,
+		.vscode-dark hr,
+		.vscode-dark td {
+			border-color: rgba(255, 255, 255, 0.18);
 		}
 
 		/* makes all markdown cells consistent */

--- a/extensions/markdown-language-features/notebook/index.ts
+++ b/extensions/markdown-language-features/notebook/index.ts
@@ -177,41 +177,38 @@ export const activate: ActivationFunction<void> = (ctx) => {
 		hr {
 			border: 0;
 			height: 2px;
-			border-bottom: 2px solid;
 		}
 
-		h2, h3, h4, h5, h6 {
-			font-weight: normal;
+		hr,
+		h1,
+		h2 {
+			border-bottom: 1px solid var(--vscode-notebook-cellBorderColor);
 		}
 
 		h1 {
-			font-size: 2.3em;
+			font-size: 2em;
+			padding-bottom: 0.3em;
 		}
 
 		h2 {
-			font-size: 2em;
-		}
-
-		h3 {
-			font-size: 1.7em;
-		}
-
-		h3 {
 			font-size: 1.5em;
+			padding-bottom: 0.3em;
+		}
+
+		h3 {
+			font-size: 1.25em;
 		}
 
 		h4 {
-			font-size: 1.3em;
+			font-size: 1em;
 		}
 
 		h5 {
-			font-size: 1.2em;
+			font-size: 0.875em;
 		}
 
-		h1,
-		h2,
-		h3 {
-			font-weight: normal;
+		h6 {
+			font-size: 0.85em;
 		}
 
 		div {
@@ -229,10 +226,22 @@ export const activate: ActivationFunction<void> = (ctx) => {
 		}
 
 		/* Removes bottom margin when only one item exists in markdown cell */
-		#preview > *:only-child,
-		#preview > *:last-child {
+		#preview > *:not(h1):not(h2):only-child,
+		#preview > *:not(h1):not(h2):last-child {
 			margin-bottom: 0;
 			padding-bottom: 0;
+		}
+
+		h1,
+		h2,
+		h3,
+		h4,
+		h5,
+		h6 {
+			font-weight: 600;
+			margin-top: 24px;
+			margin-bottom: 16px;
+			line-height: 1.25;
 		}
 
 		/* makes all markdown cells consistent */

--- a/src/vs/workbench/contrib/markdown/browser/markdownDocumentRenderer.ts
+++ b/src/vs/workbench/contrib/markdown/browser/markdownDocumentRenderer.ts
@@ -132,12 +132,14 @@ pre code {
 }
 
 .vscode-light h1,
+.vscode-light h2,
 .vscode-light hr,
 .vscode-light td {
 	border-color: rgba(0, 0, 0, 0.18);
 }
 
 .vscode-dark h1,
+.vscode-dark h2,
 .vscode-dark hr,
 .vscode-dark td {
 	border-color: rgba(255, 255, 255, 0.18);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
Hi there 👋 

I am Christian and part of the development team that has build a VS Code extension called [Runme](https://runme.dev/). It is an extension that renders markdown files as notebooks and allows them to execute/run the code snippets in their. Runme is currently featured on the [VS Code Marketplace](https://marketplace.visualstudio.com/vscode) and grows fast day by day.

Some of the feedback we have received is that the markdown within notebooks doesn't render the same way markdown preview extension would render it. Here is example:

__Markdown Example rendered in VS Code notebook view__

![Screenshot 2023-07-17 at 14 55 06](https://github.com/microsoft/vscode/assets/731337/f5f94e90-947d-4020-9eea-08d9b0b4d88b)

__Markdown Example rendered with [Markdown Preview Enhanced](https://marketplace.visualstudio.com/items?itemName=shd101wyy.markdown-preview-enhanced)__
![Screenshot 2023-07-17 at 15 42 44](https://github.com/microsoft/vscode/assets/731337/379d79a0-a74c-45f9-b1f5-06854ff8b81d)

We have been looking at many markdown preview extensions and we see the UI diverging mostly in the following areas:
- headings are generally too big
- size difference between h5 and h6 too significant
- headings have no bottom border
- `<hr />` element height is too big (2px vs. 1px)

I am proposing some small tweaks to the `markdown-language-features` extension that adjusts the styles so that it comes marginally closer to how VS Code would render markdown usually.

See a preview here:
![vscode-ui-tweak](https://github.com/microsoft/vscode/assets/731337/55f77b03-7f7d-4f3e-90ae-b02a0ae80d62)

It lowers the visual difference between viewing markdown within a markdown preview extension or within the notebook UI.

Happy to answer any questions.
Thanks for reviewing.