### PR TITLE
auto open the accessibility view for hovers

### DIFF
--- a/src/vs/workbench/contrib/accessibility/browser/accessibility.contribution.ts
+++ b/src/vs/workbench/contrib/accessibility/browser/accessibility.contribution.ts
@@ -113,14 +113,21 @@ class HoverAccessibleViewContribution extends Disposable {
 			const accessibleViewService = accessor.get(IAccessibleViewService);
 			const codeEditorService = accessor.get(ICodeEditorService);
 			const editor = codeEditorService.getActiveCodeEditor() || codeEditorService.getFocusedCodeEditor();
-			const editorHoverContent = editor ? ModesHoverController.get(editor)?.getWidgetContent() ?? undefined : undefined;
-			if (!editorHoverContent) {
+			if (!editor) {
+				return false;
+			}
+			const controller = ModesHoverController.get(editor);
+			const editorHoverContent = controller?.getWidgetContent();
+			if (!controller || !editorHoverContent) {
 				return false;
 			}
 			accessibleViewService.show({
 				verbositySettingKey: 'hover',
 				provideContent() { return editorHoverContent; },
-				onClose() { },
+				onClose() {
+					controller.hideWidgets();
+
+				},
 				options: this._options
 			});
 			return true;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

cc @jooyoungseo and @rperez030

JooYoung requested the accessible view open automatically when show hover is invoked and I think that makes sense. #188325

@Tyriar would be good to have a review. it's currently hacky bc:
- I cannot access the accessibility view code from the hover code due to layering rules, I had to use the command service. 
- I had to expose `hideWidgets` - not sure if there's a better way around this
Any thoughts would be appreciated.

Note that we'd also want to do this for extension contributed hovers.

This auto-opening feature would solve this discoverability issue #188319 