### PR TITLE
Support transferring input placeholder across workspaces

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadChat.ts
+++ b/src/vs/workbench/api/browser/mainThreadChat.ts
@@ -5,11 +5,11 @@
 
 import { Emitter } from 'vs/base/common/event';
 import { Disposable, DisposableMap } from 'vs/base/common/lifecycle';
-import { URI, UriComponents } from 'vs/base/common/uri';
+import { URI } from 'vs/base/common/uri';
 import { ExtHostChatShape, ExtHostContext, IChatRequestDto, MainContext, MainThreadChatShape } from 'vs/workbench/api/common/extHost.protocol';
 import { IChatWidgetService } from 'vs/workbench/contrib/chat/browser/chat';
 import { IChatContributionService } from 'vs/workbench/contrib/chat/common/chatContributionService';
-import { IChat, IChatDynamicRequest, IChatProgress, IChatRequest, IChatResponse, IChatService } from 'vs/workbench/contrib/chat/common/chatService';
+import { IChat, IChatDynamicRequest, IChatProgress, IChatRequest, IChatResponse, IChatService, IChatTransferredState } from 'vs/workbench/contrib/chat/common/chatService';
 import { IExtHostContext, extHostNamedCustomer } from 'vs/workbench/services/extensions/common/extHostCustomers';
 
 @extHostNamedCustomer(MainContext.MainThreadChat)
@@ -53,8 +53,8 @@ export class MainThreadChat extends Disposable implements MainThreadChatShape {
 		this._providerRegistrations.deleteAndDispose(handle);
 	}
 
-	$transferChatSession(sessionId: number, toWorkspace: UriComponents): void {
-		this._chatService.transferChatSession(sessionId, URI.revive(toWorkspace));
+	$transferChatSession(sessionId: number, transferState: IChatTransferredState): void {
+		this._chatService.transferChatSession(sessionId, transferState);
 	}
 
 	async $registerChatProvider(handle: number, id: string): Promise<void> {

--- a/src/vs/workbench/api/common/extHost.api.impl.ts
+++ b/src/vs/workbench/api/common/extHost.api.impl.ts
@@ -1306,9 +1306,9 @@ export function createApiFactoryAndRegisterActors(accessor: ServicesAccessor): I
 				checkProposedApiEnabled(extension, 'interactiveUserActions');
 				return extHostChat.onDidPerformUserAction;
 			},
-			transferChatSession(session: vscode.InteractiveSession, toWorkspace: vscode.Uri) {
+			transferChatSession(session: vscode.InteractiveSession, transferedSessionState: vscode.InteractiveTransferredSessionState) {
 				checkProposedApiEnabled(extension, 'interactive');
-				return extHostChat.transferChatSession(session, toWorkspace);
+				return extHostChat.transferChatSession(session, transferedSessionState);
 			}
 		};
 

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -51,7 +51,7 @@ import { SaveReason } from 'vs/workbench/common/editor';
 import { IRevealOptions, ITreeItem, IViewBadge } from 'vs/workbench/common/views';
 import { CallHierarchyItem } from 'vs/workbench/contrib/callHierarchy/common/callHierarchy';
 import { DebugConfigurationProviderTriggerKind, IAdapterDescriptor, IConfig, IDebugSessionReplMode } from 'vs/workbench/contrib/debug/common/debug';
-import { IChatProgress, IChatResponseErrorDetails, IChatDynamicRequest, IChatFollowup, IChatReplyFollowup, IChatUserActionEvent, ISlashCommand } from 'vs/workbench/contrib/chat/common/chatService';
+import { IChatProgress, IChatResponseErrorDetails, IChatDynamicRequest, IChatFollowup, IChatReplyFollowup, IChatUserActionEvent, ISlashCommand, IChatTransferredState } from 'vs/workbench/contrib/chat/common/chatService';
 import * as notebookCommon from 'vs/workbench/contrib/notebook/common/notebookCommon';
 import { CellExecutionUpdateType } from 'vs/workbench/contrib/notebook/common/notebookExecutionService';
 import { ICellExecutionComplete, ICellExecutionStateUpdate } from 'vs/workbench/contrib/notebook/common/notebookExecutionStateService';
@@ -1173,7 +1173,7 @@ export interface MainThreadChatShape extends IDisposable {
 	$sendRequestToProvider(providerId: string, message: IChatDynamicRequest): void;
 	$unregisterChatProvider(handle: number): Promise<void>;
 	$acceptResponseProgress(handle: number, sessionId: number, progress: IChatProgress): void;
-	$transferChatSession(sessionId: number, toWorkspace: UriComponents): void;
+	$transferChatSession(sessionId: number, transferState: IChatTransferredState): void;
 
 	$registerSlashCommandProvider(handle: number, chatProviderId: string): Promise<void>;
 	$unregisterSlashCommandProvider(handle: number): Promise<void>;

--- a/src/vs/workbench/api/common/extHostChat.ts
+++ b/src/vs/workbench/api/common/extHostChat.ts
@@ -14,7 +14,7 @@ import { IRelaxedExtensionDescription } from 'vs/platform/extensions/common/exte
 import { ILogService } from 'vs/platform/log/common/log';
 import { ExtHostChatShape, IChatRequestDto, IChatResponseDto, IChatDto, IMainContext, MainContext, MainThreadChatShape } from 'vs/workbench/api/common/extHost.protocol';
 import * as typeConvert from 'vs/workbench/api/common/extHostTypeConverters';
-import { IChatFollowup, IChatProgress, IChatReplyFollowup, IChatUserActionEvent, ISlashCommand } from 'vs/workbench/contrib/chat/common/chatService';
+import { IChatFollowup, IChatProgress, IChatReplyFollowup, IChatTransferredState, IChatUserActionEvent, ISlashCommand } from 'vs/workbench/contrib/chat/common/chatService';
 import type * as vscode from 'vscode';
 
 class ChatProviderWrapper<T> {
@@ -61,13 +61,13 @@ export class ExtHostChat implements ExtHostChatShape {
 		});
 	}
 
-	transferChatSession(session: vscode.InteractiveSession, newWorkspace: vscode.Uri): void {
+	transferChatSession(session: vscode.InteractiveSession, transferState: IChatTransferredState): void {
 		const sessionId = Iterable.find(this._chatSessions.keys(), key => this._chatSessions.get(key) === session) ?? 0;
 		if (typeof sessionId !== 'number') {
 			return;
 		}
 
-		this._proxy.$transferChatSession(sessionId, newWorkspace);
+		this._proxy.$transferChatSession(sessionId, transferState);
 	}
 
 	addChatRequest(context: vscode.InteractiveSessionRequestArgs): void {

--- a/src/vs/workbench/api/common/extHostChat.ts
+++ b/src/vs/workbench/api/common/extHostChat.ts
@@ -98,7 +98,7 @@ export class ExtHostChat implements ExtHostChatShape {
 			requesterAvatarIconUri: session.requester?.icon,
 			responderUsername: session.responder?.name,
 			responderAvatarIconUri: session.responder?.icon,
-			inputPlaceholder: session.inputPlaceholder,
+			inputPlaceholder: session.inputValue,
 		};
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/chatViewPane.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatViewPane.ts
@@ -103,7 +103,7 @@ export class ChatViewPane extends ViewPane implements IChatViewPane {
 			this._widget.render(parent);
 
 			const sessionId = this.chatService.transferredSessionId ?? this.viewState.sessionId;
-			this.viewState.inputValue = this.chatService.transferredInputPlaceholder ?? '';
+			this.viewState.inputValue = this.chatService.transferredInputValue ?? '';
 			const initialModel = sessionId ? this.chatService.getOrRestoreSession(sessionId) : undefined;
 			this.updateModel(initialModel);
 		} catch (e) {

--- a/src/vs/workbench/contrib/chat/browser/chatViewPane.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatViewPane.ts
@@ -103,6 +103,7 @@ export class ChatViewPane extends ViewPane implements IChatViewPane {
 			this._widget.render(parent);
 
 			const sessionId = this.chatService.transferredSessionId ?? this.viewState.sessionId;
+			this.viewState.inputValue = this.chatService.transferredInputPlaceholder ?? '';
 			const initialModel = sessionId ? this.chatService.getOrRestoreSession(sessionId) : undefined;
 			this.updateModel(initialModel);
 		} catch (e) {

--- a/src/vs/workbench/contrib/chat/common/chatService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService.ts
@@ -193,13 +193,13 @@ export const IChatService = createDecorator<IChatService>('IChatService');
 
 export interface IChatTransferredState {
 	toWorkspace: URI;
-	inputPlaceholder?: string;
+	inputValue?: string;
 }
 
 export interface IChatService {
 	_serviceBrand: undefined;
 	transferredSessionId: string | undefined;
-	transferredInputPlaceholder: string | undefined;
+	transferredInputValue: string | undefined;
 
 	onDidSubmitSlashCommand: Event<{ slashCommand: string; sessionId: string }>;
 	registerProvider(provider: IChatProvider): IDisposable;

--- a/src/vs/workbench/contrib/chat/common/chatService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService.ts
@@ -191,9 +191,15 @@ export interface IChatProviderInfo {
 
 export const IChatService = createDecorator<IChatService>('IChatService');
 
+export interface IChatTransferredState {
+	toWorkspace: URI;
+	inputPlaceholder?: string;
+}
+
 export interface IChatService {
 	_serviceBrand: undefined;
 	transferredSessionId: string | undefined;
+	transferredInputPlaceholder: string | undefined;
 
 	onDidSubmitSlashCommand: Event<{ slashCommand: string; sessionId: string }>;
 	registerProvider(provider: IChatProvider): IDisposable;
@@ -221,5 +227,5 @@ export interface IChatService {
 	onDidPerformUserAction: Event<IChatUserActionEvent>;
 	notifyUserAction(event: IChatUserActionEvent): void;
 
-	transferChatSession(sessionProviderId: number, toWorkspace: URI): void;
+	transferChatSession(sessionProviderId: number, transferState: IChatTransferredState): void;
 }

--- a/src/vs/workbench/contrib/chat/common/chatServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/chatServiceImpl.ts
@@ -132,9 +132,9 @@ export class ChatService extends Disposable implements IChatService {
 		return this._transferred?.sessionId;
 	}
 
-	private _transferredInputPlaceholder: string | undefined;
-	public get transferredInputPlaceholder(): string | undefined {
-		return this._transferredInputPlaceholder;
+	private _transferredInputValue: string | undefined;
+	public get transferredInputValue(): string | undefined {
+		return this._transferredInputValue;
 	}
 
 	private readonly _onDidPerformUserAction = this._register(new Emitter<IChatUserActionEvent>());
@@ -271,7 +271,7 @@ export class ChatService extends Disposable implements IChatService {
 		// Keep data that isn't for the current workspace and that hasn't expired yet
 		const filtered = data.filter(item => URI.revive(item.sessionTransferState?.toWorkspace)?.toString() !== thisWorkspace && (currentTime - item.timestampInMilliseconds < SESSION_TRANSFER_EXPIRATION_IN_MILLISECONDS));
 		this.storageService.store(globalChatKey, JSON.stringify(filtered), StorageScope.PROFILE, StorageTarget.MACHINE);
-		this._transferredInputPlaceholder = transferred?.sessionTransferState?.inputPlaceholder;
+		this._transferredInputValue = transferred?.sessionTransferState?.inputValue;
 		return transferred?.chat;
 	}
 

--- a/src/vscode-dts/vscode.proposed.interactive.d.ts
+++ b/src/vscode-dts/vscode.proposed.interactive.d.ts
@@ -93,7 +93,7 @@ declare module 'vscode' {
 	export interface InteractiveSession {
 		requester: InteractiveSessionParticipantInformation;
 		responder: InteractiveSessionParticipantInformation;
-		inputPlaceholder?: string;
+		inputValue?: string;
 
 		saveState?(): InteractiveSessionState;
 	}

--- a/src/vscode-dts/vscode.proposed.interactive.d.ts
+++ b/src/vscode-dts/vscode.proposed.interactive.d.ts
@@ -182,6 +182,11 @@ declare module 'vscode' {
 		metadata?: any;
 	}
 
+	export interface InteractiveTransferredSessionState {
+		toWorkspace: Uri;
+		inputPlaceholder?: string;
+	}
+
 	export namespace interactive {
 		// current version of the proposal.
 		export const _version: 1 | number;
@@ -193,6 +198,6 @@ declare module 'vscode' {
 
 		export function registerInteractiveEditorSessionProvider(provider: InteractiveEditorSessionProvider): Disposable;
 
-		export function transferChatSession(session: InteractiveSession, toWorkspace: Uri): void;
+		export function transferChatSession(session: InteractiveSession, transferredSessionState: InteractiveTransferredSessionState): void;
 	}
 }


### PR DESCRIPTION
Fixes: 
In the /createWorkspace scenario, creating and opening a new workspace does not pre-populate the slash command since the input view state is not transferred across workspaces.
