### PR TITLE
add syntax highlighting for Less operator `or`

### DIFF
--- a/extensions/less/syntaxes/less.tmLanguage.json
+++ b/extensions/less/syntaxes/less.tmLanguage.json
@@ -335,7 +335,7 @@
 			"name": "keyword.operator.less"
 		},
 		{
-			"match": "\\b(not|and|when)\\b",
+			"match": "\\b(not|and|or|when)\\b",
 			"name": "keyword.control.logical.operator.less"
 		},
 		{


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR adds syntax highlighting for Less operator `or`.

Code example: (copied from Less official repository)

```less
.orderOfEvaluation(@a1, @a2, @a3) when ((@a1) and (@a2) or (@a3)) {}
```

The original repository `atom/language-less` has been archived, so I think it's OK to edit file here directly.