### PR TITLE
Fix syncing extensions when new property is added

### DIFF
--- a/src/vs/platform/userDataSync/common/extensionsMerge.ts
+++ b/src/vs/platform/userDataSync/common/extensionsMerge.ts
@@ -278,7 +278,7 @@ function areSame(fromExtension: ISyncExtension, toExtension: ISyncExtension, che
 		return false;
 	}
 
-	if (fromExtension.isApplicationScoped !== toExtension.isApplicationScoped) {
+	if (!!fromExtension.isApplicationScoped !== !!toExtension.isApplicationScoped) {
 		/* extension application scope has changed */
 		return false;
 	}
@@ -395,30 +395,32 @@ function isSameExtensionState(a: IStringDictionary<any> = {}, b: IStringDictiona
 
 // massage incoming extension - add optional properties
 function massageIncomingExtension(extension: ISyncExtension): ISyncExtension {
-	return { ...extension, ...{ disabled: !!extension.disabled, installed: !!extension.installed, isApplicationScoped: !!extension.isApplicationScoped } };
+	return { ...extension, ...{ disabled: !!extension.disabled, installed: !!extension.installed } };
 }
 
 // massage outgoing extension - remove optional properties
 function massageOutgoingExtension(extension: ISyncExtension, key: string): ISyncExtension {
 	const massagedExtension: ISyncExtension = {
+		...extension,
 		identifier: {
 			id: extension.identifier.id,
 			uuid: key.startsWith('uuid:') ? key.substring('uuid:'.length) : undefined
 		},
-		version: extension.version,
 		/* set following always so that to differentiate with older clients */
 		preRelease: !!extension.preRelease,
 		pinned: !!extension.pinned,
-		isApplicationScoped: !!extension.isApplicationScoped,
 	};
-	if (extension.disabled) {
-		massagedExtension.disabled = true;
+	if (!extension.disabled) {
+		delete massagedExtension.disabled;
 	}
-	if (extension.installed) {
-		massagedExtension.installed = true;
+	if (!extension.installed) {
+		delete massagedExtension.installed;
 	}
-	if (extension.state) {
-		massagedExtension.state = extension.state;
+	if (!extension.state) {
+		delete massagedExtension.state;
+	}
+	if (!extension.isApplicationScoped) {
+		delete massagedExtension.isApplicationScoped;
 	}
 	return massagedExtension;
 }

--- a/src/vs/platform/userDataSync/common/extensionsSync.ts
+++ b/src/vs/platform/userDataSync/common/extensionsSync.ts
@@ -101,7 +101,8 @@ export class ExtensionsSynchroniser extends AbstractSynchroniser implements IUse
 	*/
 	/* Version 4: Change settings from `sync.${setting}` to `settingsSync.{setting}` */
 	/* Version 5: Introduce extension state */
-	protected readonly version: number = 5;
+	/* Version 6: Added isApplicationScoped property */
+	protected readonly version: number = 6;
 
 	private readonly previewResource: URI = this.extUri.joinPath(this.syncPreviewFolder, 'extensions.json');
 	private readonly baseResource: URI = this.previewResource.with({ scheme: USER_DATA_SYNC_SCHEME, authority: 'base' });
@@ -377,7 +378,7 @@ export class LocalExtensionsProvider {
 				.map(extension => {
 					const { identifier, isBuiltin, manifest, preRelease, pinned, isApplicationScoped } = extension;
 					const syncExntesion: ILocalSyncExtension = { identifier, preRelease, version: manifest.version, pinned: !!pinned };
-					if (!isApplicationScopedExtension(manifest)) {
+					if (isApplicationScoped && !isApplicationScopedExtension(manifest)) {
 						syncExntesion.isApplicationScoped = isApplicationScoped;
 					}
 					if (disabledExtensions.some(disabledExtension => areSameExtensions(disabledExtension, identifier))) {

--- a/src/vs/platform/userDataSync/test/common/extensionsMerge.test.ts
+++ b/src/vs/platform/userDataSync/test/common/extensionsMerge.test.ts
@@ -1344,7 +1344,7 @@ suite('ExtensionsMerge', () => {
 		assert.deepStrictEqual(actual.local.added, []);
 		assert.deepStrictEqual(actual.local.removed, []);
 		assert.deepStrictEqual(actual.local.updated, []);
-		assert.deepStrictEqual(actual.remote?.all, localExtensions);
+		assert.deepStrictEqual(actual.remote?.all, [anExpectedSyncExtension({ identifier: { id: 'a', uuid: 'a' } })]);
 	});
 
 	test('sync merging when applicaiton scope is changed locally', () => {
@@ -1392,7 +1392,6 @@ suite('ExtensionsMerge', () => {
 			pinned: false,
 			preRelease: false,
 			installed: true,
-			isApplicationScoped: false,
 			...extension
 		};
 	}
@@ -1403,7 +1402,6 @@ suite('ExtensionsMerge', () => {
 			version: '1.0.0',
 			pinned: false,
 			preRelease: false,
-			isApplicationScoped: false,
 			...extension
 		};
 	}
@@ -1415,7 +1413,6 @@ suite('ExtensionsMerge', () => {
 			pinned: false,
 			preRelease: false,
 			installed: true,
-			isApplicationScoped: false,
 			...extension
 		};
 	}
@@ -1427,7 +1424,6 @@ suite('ExtensionsMerge', () => {
 			pinned: false,
 			preRelease: false,
 			installed: true,
-			isApplicationScoped: false,
 			...extension
 		};
 	}


### PR DESCRIPTION
- make isApplicationScoped property optional
- bump the version so that older clients wont remove isApplicationScoped
- make the client compatible when new properties are added later