### PR TITLE
bump version on metadata change

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/contrib/cellCommands/cellCommands.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/cellCommands/cellCommands.ts
@@ -617,6 +617,7 @@ registerAction2(class ToggleCellOutputScrolling extends NotebookMultiCellAction 
 			const currentlyEnabled = cellMetadata['scrollable'] !== undefined ? cellMetadata['scrollable'] : globalScrollSetting;
 			const shouldEnableScrolling = collapsed || !currentlyEnabled;
 			cellMetadata['scrollable'] = shouldEnableScrolling;
+			viewModel.model.bumpVersion();
 			viewModel.resetRenderer();
 		}
 	}

--- a/src/vs/workbench/contrib/notebook/common/model/notebookCellOutputTextModel.ts
+++ b/src/vs/workbench/contrib/notebook/common/model/notebookCellOutputTextModel.ts
@@ -118,5 +118,8 @@ export class NotebookCellOutputTextModel extends Disposable implements ICellOutp
 		};
 	}
 
+	bumpVersion() {
+		this._versionId = this._versionId + 1;
+	}
 
 }

--- a/src/vs/workbench/contrib/notebook/common/notebookCommon.ts
+++ b/src/vs/workbench/contrib/notebook/common/notebookCommon.ts
@@ -218,6 +218,7 @@ export interface ICellOutput {
 	replaceData(items: IOutputDto): void;
 	appendData(items: IOutputItemDto[]): void;
 	appendedSinceVersion(versionId: number, mime: string): VSBuffer | undefined;
+	bumpVersion(): void;
 }
 
 export interface CellInternalMetadataChangedEvent {


### PR DESCRIPTION
fixes https://github.com/microsoft/vscode/issues/188399

UpdateOutput will no-op if the output version is the same as has already been rendered