### PR TITLE
Add a "both" option to `chat.experimental.defaultMode`

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/quickQuestionActions/quickQuestionAction.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/quickQuestionActions/quickQuestionAction.ts
@@ -53,7 +53,7 @@ export class AskQuickQuestionAction extends Action2 {
 			menu: {
 				id: MenuId.LayoutControlMenu,
 				group: '0_workbench_toggles',
-				when: ContextKeyExpr.equals('config.chat.experimental.defaultMode', 'quickQuestion'),
+				when: ContextKeyExpr.notEquals('config.chat.experimental.defaultMode', 'chatView'),
 				order: 0
 			}
 		});

--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -81,7 +81,12 @@ configurationRegistry.registerConfiguration({
 		'chat.experimental.defaultMode': {
 			type: 'string',
 			tags: ['experimental'],
-			enum: ['chatView', 'quickQuestion'],
+			enum: ['chatView', 'quickQuestion', 'both'],
+			enumDescriptions: [
+				nls.localize('interactiveSession.defaultMode.chatView', "Use the chat view as the default mode. Displays the chat icon in the Activity Bar."),
+				nls.localize('interactiveSession.defaultMode.quickQuestion', "Use the quick question as the default mode. Displays the chat icon in the Title Bar."),
+				nls.localize('interactiveSession.defaultMode.both', "Displays the chat icon in the Activity Bar and the Title Bar which open their respective chat modes.")
+			],
 			description: nls.localize('interactiveSession.defaultMode', "Controls the default mode of the chat experience."),
 			default: 'chatView'
 		},

--- a/src/vs/workbench/contrib/chat/browser/chatContributionServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContributionServiceImpl.ts
@@ -127,7 +127,7 @@ export class ChatContributionService implements IChatContributionService {
 			ctorDescriptor: new SyncDescriptor(ChatViewPane, [<IChatViewOptions>{ providerId: providerDescriptor.id }]),
 			when: ContextKeyExpr.and(
 				ContextKeyExpr.deserialize(providerDescriptor.when),
-				ContextKeyExpr.equals('config.chat.experimental.defaultMode', 'chatView')
+				ContextKeyExpr.notEquals('config.chat.experimental.defaultMode', 'quickQuestion')
 			)
 		}];
 		Registry.as<IViewsRegistry>(ViewExtensions.ViewsRegistry).registerViews(viewDescriptor, viewContainer);


### PR DESCRIPTION
This will show the chat in the Activity Bar and the Title Bar.

cc @isidorn

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
