### PR TITLE
Save input value as IChatTransferData for restoring after transfer

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadChat.ts
+++ b/src/vs/workbench/api/browser/mainThreadChat.ts
@@ -58,9 +58,14 @@ export class MainThreadChat extends Disposable implements MainThreadChatShape {
 	}
 
 	$transferChatSession(sessionId: number, toWorkspace: UriComponents): void {
-		const widget = this._chatWidgetService.lastFocusedWidget;
+		const sessionIdStr = this._chatService.getSessionId(sessionId);
+		if (!sessionIdStr) {
+			throw new Error(`Failed to transfer session. Unknown session provider ID: ${sessionId}`);
+		}
+
+		const widget = this._chatWidgetService.getWidgetBySessionId(sessionIdStr);
 		const inputValue = widget?.inputEditor.getValue() ?? '';
-		this._chatService.transferChatSession({ sessionProviderId: sessionId, inputValue: inputValue }, URI.revive(toWorkspace));
+		this._chatService.transferChatSession({ sessionId: sessionIdStr, inputValue: inputValue }, URI.revive(toWorkspace));
 	}
 
 	async $registerChatProvider(handle: number, id: string): Promise<void> {

--- a/src/vs/workbench/api/browser/mainThreadChat.ts
+++ b/src/vs/workbench/api/browser/mainThreadChat.ts
@@ -58,7 +58,9 @@ export class MainThreadChat extends Disposable implements MainThreadChatShape {
 	}
 
 	$transferChatSession(sessionId: number, toWorkspace: UriComponents): void {
-		this._chatService.transferChatSession(sessionId, URI.revive(toWorkspace));
+		const widget = this._chatWidgetService.lastFocusedWidget;
+		const inputValue = widget?.inputEditor.getValue() ?? '';
+		this._chatService.transferChatSession({ sessionProviderId: sessionId, inputValue: inputValue }, URI.revive(toWorkspace));
 	}
 
 	async $registerChatProvider(handle: number, id: string): Promise<void> {

--- a/src/vs/workbench/contrib/chat/browser/chat.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.ts
@@ -28,6 +28,8 @@ export interface IChatWidgetService {
 	revealViewForProvider(providerId: string): Promise<IChatWidget | undefined>;
 
 	getWidgetByInputUri(uri: URI): IChatWidget | undefined;
+
+	getWidgetBySessionId(sessionId: string): IChatWidget | undefined;
 }
 
 

--- a/src/vs/workbench/contrib/chat/browser/chatViewPane.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatViewPane.ts
@@ -102,7 +102,14 @@ export class ChatViewPane extends ViewPane implements IChatViewPane {
 			}));
 			this._widget.render(parent);
 
-			const sessionId = this.chatService.transferredSessionId ?? this.viewState.sessionId;
+			let sessionId: string | undefined;
+			if (this.chatService.transferredSessionId) {
+				sessionId = this.chatService.transferredSessionId;
+				this.viewState.inputValue = this.chatService.transferredInputValue;
+			} else {
+				sessionId = this.viewState.sessionId;
+			}
+
 			const initialModel = sessionId ? this.chatService.getOrRestoreSession(sessionId) : undefined;
 			this.updateModel(initialModel);
 		} catch (e) {

--- a/src/vs/workbench/contrib/chat/browser/chatViewPane.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatViewPane.ts
@@ -71,8 +71,8 @@ export class ChatViewPane extends ViewPane implements IChatViewPane {
 	private updateModel(model?: IChatModel | undefined): void {
 		this.modelDisposables.clear();
 
-		model = model ?? (this.chatService.transferredSessionId
-			? this.chatService.getOrRestoreSession(this.chatService.transferredSessionId)
+		model = model ?? (this.chatService.transferredSessionData?.sessionId
+			? this.chatService.getOrRestoreSession(this.chatService.transferredSessionData.sessionId)
 			: this.chatService.startSession(this.chatViewOptions.providerId, CancellationToken.None));
 		if (!model) {
 			throw new Error('Could not start chat session');
@@ -103,9 +103,9 @@ export class ChatViewPane extends ViewPane implements IChatViewPane {
 			this._widget.render(parent);
 
 			let sessionId: string | undefined;
-			if (this.chatService.transferredSessionId) {
-				sessionId = this.chatService.transferredSessionId;
-				this.viewState.inputValue = this.chatService.transferredInputValue;
+			if (this.chatService.transferredSessionData) {
+				sessionId = this.chatService.transferredSessionData.sessionId;
+				this.viewState.inputValue = this.chatService.transferredSessionData.inputValue;
 			} else {
 				sessionId = this.viewState.sessionId;
 			}

--- a/src/vs/workbench/contrib/chat/browser/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatWidget.ts
@@ -574,6 +574,10 @@ export class ChatWidgetService implements IChatWidgetService {
 		return this._widgets.find(w => isEqual(w.inputUri, uri));
 	}
 
+	getWidgetBySessionId(sessionId: string): ChatWidget | undefined {
+		return this._widgets.find(w => w.viewModel?.sessionId === sessionId);
+	}
+
 	async revealViewForProvider(providerId: string): Promise<ChatWidget | undefined> {
 		const viewId = this.chatContributionService.getViewIdForProvider(providerId);
 		const view = await this.viewsService.openView<ChatViewPane>(viewId);

--- a/src/vs/workbench/contrib/chat/common/chatService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService.ts
@@ -194,6 +194,7 @@ export const IChatService = createDecorator<IChatService>('IChatService');
 export interface IChatService {
 	_serviceBrand: undefined;
 	transferredSessionId: string | undefined;
+	transferredInputValue: string | undefined;
 
 	onDidSubmitSlashCommand: Event<{ slashCommand: string; sessionId: string }>;
 	registerProvider(provider: IChatProvider): IDisposable;
@@ -221,5 +222,5 @@ export interface IChatService {
 	onDidPerformUserAction: Event<IChatUserActionEvent>;
 	notifyUserAction(event: IChatUserActionEvent): void;
 
-	transferChatSession(sessionProviderId: number, toWorkspace: URI): void;
+	transferChatSession(transferredSessionData: { sessionProviderId: number; inputValue: string }, toWorkspace: URI): void;
 }

--- a/src/vs/workbench/contrib/chat/common/chatService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService.ts
@@ -189,12 +189,16 @@ export interface IChatProviderInfo {
 	displayName: string;
 }
 
+export interface IChatTransferredSessionData {
+	sessionId: string;
+	inputValue: string;
+}
+
 export const IChatService = createDecorator<IChatService>('IChatService');
 
 export interface IChatService {
 	_serviceBrand: undefined;
-	transferredSessionId: string | undefined;
-	transferredInputValue: string | undefined;
+	transferredSessionData: IChatTransferredSessionData | undefined;
 
 	onDidSubmitSlashCommand: Event<{ slashCommand: string; sessionId: string }>;
 	registerProvider(provider: IChatProvider): IDisposable;
@@ -202,6 +206,7 @@ export interface IChatService {
 	getProviderInfos(): IChatProviderInfo[];
 	startSession(providerId: string, token: CancellationToken): ChatModel | undefined;
 	getSession(sessionId: string): IChatModel | undefined;
+	getSessionId(sessionProviderId: number): string | undefined;
 	getOrRestoreSession(sessionId: string): IChatModel | undefined;
 	loadSessionFromContent(data: ISerializableChatData): IChatModel | undefined;
 
@@ -222,5 +227,5 @@ export interface IChatService {
 	onDidPerformUserAction: Event<IChatUserActionEvent>;
 	notifyUserAction(event: IChatUserActionEvent): void;
 
-	transferChatSession(transferredSessionData: { sessionProviderId: number; inputValue: string }, toWorkspace: URI): void;
+	transferChatSession(transferredSessionData: IChatTransferredSessionData, toWorkspace: URI): void;
 }


### PR DESCRIPTION
This fixes restoring chat input on transferring to a new workspace. 