### PR TITLE
Show Remote Close action as the last item in the quick pick

### DIFF
--- a/src/vs/workbench/contrib/remote/browser/remoteIndicator.ts
+++ b/src/vs/workbench/contrib/remote/browser/remoteIndicator.ts
@@ -725,6 +725,27 @@ export class RemoteStatusIndicator extends Disposable implements IWorkbenchContr
 				}
 			}
 
+			if (this.extensionGalleryService.isEnabled() && this.remoteMetadataInitialized) {
+
+				const notInstalledItems: QuickPickItem[] = [];
+				for (const metadata of this.remoteExtensionMetadata) {
+					if (!metadata.installed && metadata.isPlatformCompatible) {
+						// Create Install QuickPick with a help link
+						const label = metadata.startConnectLabel;
+						const buttons: IQuickInputButton[] = [{
+							iconClass: ThemeIcon.asClassName(infoIcon),
+							tooltip: nls.localize('remote.startActions.help', "Learn More")
+						}];
+						notInstalledItems.push({ type: 'item', id: metadata.id, label: label, buttons: buttons });
+					}
+				}
+
+				items.push({
+					type: 'separator', label: nls.localize('remote.startActions.install', 'Install')
+				});
+				items.push(...notInstalledItems);
+			}
+
 			items.push({
 				type: 'separator'
 			});
@@ -757,27 +778,6 @@ export class RemoteStatusIndicator extends Disposable implements IWorkbenchContr
 
 			if (items.length === entriesBeforeConfig) {
 				items.pop(); // remove the separator again
-			}
-
-			if (this.extensionGalleryService.isEnabled() && this.remoteMetadataInitialized) {
-
-				const notInstalledItems: QuickPickItem[] = [];
-				for (const metadata of this.remoteExtensionMetadata) {
-					if (!metadata.installed && metadata.isPlatformCompatible) {
-						// Create Install QuickPick with a help link
-						const label = metadata.startConnectLabel;
-						const buttons: IQuickInputButton[] = [{
-							iconClass: ThemeIcon.asClassName(infoIcon),
-							tooltip: nls.localize('remote.startActions.help', "Learn More")
-						}];
-						notInstalledItems.push({ type: 'item', id: metadata.id, label: label, buttons: buttons });
-					}
-				}
-
-				items.push({
-					type: 'separator', label: nls.localize('remote.startActions.install', 'Install')
-				});
-				items.push(...notInstalledItems);
 			}
 
 			return items;


### PR DESCRIPTION
Currently it is nestled between the installed and installable extensions. Changing this so that the close action is always the last item in the remote menu