### PR TITLE
On `Enter` accept current color in the color hover

### DIFF
--- a/src/vs/editor/contrib/colorPicker/browser/colorHoverParticipant.ts
+++ b/src/vs/editor/contrib/colorPicker/browser/colorHoverParticipant.ts
@@ -49,6 +49,8 @@ export class ColorHoverParticipant implements IEditorHoverParticipant<ColorHover
 
 	public readonly hoverOrdinal: number = 2;
 
+	private _context: IEditorHoverRenderContext | undefined;
+
 	constructor(
 		private readonly _editor: ICodeEditor,
 		@IThemeService private readonly _themeService: IThemeService,
@@ -86,7 +88,13 @@ export class ColorHoverParticipant implements IEditorHoverParticipant<ColorHover
 	}
 
 	public renderHoverParts(context: IEditorHoverRenderContext, hoverParts: ColorHover[]): IDisposable {
+		this._context = context;
 		return renderHoverParts(this, this._editor, this._themeService, hoverParts, context);
+	}
+
+	public onAccept() {
+		this._context?.hide();
+		this._editor.focus();
 	}
 }
 

--- a/src/vs/editor/contrib/hover/browser/contentHover.ts
+++ b/src/vs/editor/contrib/hover/browser/contentHover.ts
@@ -373,6 +373,12 @@ export class ContentHoverController extends Disposable {
 		};
 	}
 
+	public accept() {
+		for (const participant of this._participants) {
+			participant.onAccept?.();
+		}
+	}
+
 	public focus(): void {
 		this._widget.focus();
 	}

--- a/src/vs/editor/contrib/hover/browser/hover.ts
+++ b/src/vs/editor/contrib/hover/browser/hover.ts
@@ -269,6 +269,10 @@ export class ModesHoverController implements IEditorContribution {
 		this._getOrCreateContentWidget().startShowingAtRange(range, mode, source, focus);
 	}
 
+	public accept(): void {
+		this._contentWidget?.accept();
+	}
+
 	public focus(): void {
 		this._contentWidget?.focus();
 	}
@@ -676,6 +680,35 @@ class GoToBottomHoverAction extends EditorAction {
 	}
 }
 
+class AcceptHoverAction extends EditorAction {
+	constructor() {
+		super({
+			id: 'editor.action.acceptHover',
+			label: nls.localize({
+				key: 'acceptHover',
+				comment: [
+					'Action that toggles the onAccept method of the content hover participants.'
+				]
+			}, "Accept Hover"),
+			alias: 'Accept Hover',
+			precondition: EditorContextKeys.hoverFocused,
+			kbOpts: {
+				kbExpr: EditorContextKeys.hoverFocused,
+				primary: KeyCode.Enter,
+				weight: KeybindingWeight.EditorContrib
+			}
+		});
+	}
+
+	public run(accessor: ServicesAccessor, editor: ICodeEditor): void {
+		const controller = ModesHoverController.get(editor);
+		if (!controller) {
+			return;
+		}
+		controller.accept();
+	}
+}
+
 registerEditorContribution(ModesHoverController.ID, ModesHoverController, EditorContributionInstantiation.BeforeFirstInteraction);
 registerEditorAction(ShowOrFocusHoverAction);
 registerEditorAction(ShowDefinitionPreviewHoverAction);
@@ -687,6 +720,7 @@ registerEditorAction(PageUpHoverAction);
 registerEditorAction(PageDownHoverAction);
 registerEditorAction(GoToTopHoverAction);
 registerEditorAction(GoToBottomHoverAction);
+registerEditorAction(AcceptHoverAction);
 HoverParticipantRegistry.register(MarkdownHoverParticipant);
 HoverParticipantRegistry.register(MarkerHoverParticipant);
 

--- a/src/vs/editor/contrib/hover/browser/hoverTypes.ts
+++ b/src/vs/editor/contrib/hover/browser/hoverTypes.ts
@@ -123,6 +123,7 @@ export interface IEditorHoverParticipant<T extends IHoverPart = IHoverPart> {
 	computeAsync?(anchor: HoverAnchor, lineDecorations: IModelDecoration[], token: CancellationToken): AsyncIterableObject<T>;
 	createLoadingMessage?(anchor: HoverAnchor): T | null;
 	renderHoverParts(context: IEditorHoverRenderContext, hoverParts: T[]): IDisposable;
+	onAccept?(): void;
 }
 
 export type IEditorHoverParticipantCtor = IConstructorSignature<IEditorHoverParticipant, [ICodeEditor]>;


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/31651

With the standard color picker embedded inside of the content hover widget, the text corresponding to the color changes as the color is chosen. What is needed is therefore to hide the content hover on escape when there is an embedded color picker widge.t 