### PR TITLE
Revert "chore: bump node-pty@1.1.0-beta3"

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "native-is-elevated": "0.7.0",
     "native-keymap": "^3.3.2",
     "native-watchdog": "^1.4.1",
-    "node-pty": "1.1.0-beta3",
+    "node-pty": "1.1.0-beta1",
     "tas-client-umd": "0.1.8",
     "v8-inspect-profiler": "^0.1.0",
     "vscode-oniguruma": "1.7.0",

--- a/remote/package.json
+++ b/remote/package.json
@@ -22,7 +22,7 @@
     "keytar": "7.9.0",
     "minimist": "^1.2.6",
     "native-watchdog": "^1.4.1",
-    "node-pty": "1.1.0-beta3",
+    "node-pty": "1.1.0-beta1",
     "tas-client-umd": "0.1.8",
     "vscode-oniguruma": "1.7.0",
     "vscode-regexpp": "^3.1.0",

--- a/remote/yarn.lock
+++ b/remote/yarn.lock
@@ -560,10 +560,10 @@ node-gyp-build@^4.3.0:
   resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.3.0.tgz#9f256b03e5826150be39c764bf51e993946d71a3"
   integrity sha512-iWjXZvmboq0ja1pUGULQBexmxq8CV4xBhX7VDOTbL7ZR4FOowwY/VOtRxBN/yKxmdGoIp4j5ysNT4u3S2pDQ3Q==
 
-node-pty@1.1.0-beta3:
-  version "1.1.0-beta3"
-  resolved "https://registry.yarnpkg.com/node-pty/-/node-pty-1.1.0-beta3.tgz#c750621a4effddd499fcbd15a2cf7679bee7b60f"
-  integrity sha512-/QnWzklx8QcPcUUTWZSlY/YIz2IXo61KKx7O1H7aZ1YtMvmU1EFS/+hppmUSWV7+9WRCfAdov4K22u8knZ+IzA==
+node-pty@1.1.0-beta1:
+  version "1.1.0-beta1"
+  resolved "https://registry.yarnpkg.com/node-pty/-/node-pty-1.1.0-beta1.tgz#95d4baf406c043b78042f951b325e9713df2beac"
+  integrity sha512-h+1E/gX/brFqsp3yZKGERHOhdo1POG1rrsI+8tEuocqdEddHd029471gq8KOuiHKicd52h2pSU8Gtqb3Vo2PfQ==
   dependencies:
     nan "^2.17.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7155,10 +7155,10 @@ node-gyp-build@^4.3.0:
   resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.3.0.tgz#9f256b03e5826150be39c764bf51e993946d71a3"
   integrity sha512-iWjXZvmboq0ja1pUGULQBexmxq8CV4xBhX7VDOTbL7ZR4FOowwY/VOtRxBN/yKxmdGoIp4j5ysNT4u3S2pDQ3Q==
 
-node-pty@1.1.0-beta3:
-  version "1.1.0-beta3"
-  resolved "https://registry.yarnpkg.com/node-pty/-/node-pty-1.1.0-beta3.tgz#c750621a4effddd499fcbd15a2cf7679bee7b60f"
-  integrity sha512-/QnWzklx8QcPcUUTWZSlY/YIz2IXo61KKx7O1H7aZ1YtMvmU1EFS/+hppmUSWV7+9WRCfAdov4K22u8knZ+IzA==
+node-pty@1.1.0-beta1:
+  version "1.1.0-beta1"
+  resolved "https://registry.yarnpkg.com/node-pty/-/node-pty-1.1.0-beta1.tgz#95d4baf406c043b78042f951b325e9713df2beac"
+  integrity sha512-h+1E/gX/brFqsp3yZKGERHOhdo1POG1rrsI+8tEuocqdEddHd029471gq8KOuiHKicd52h2pSU8Gtqb3Vo2PfQ==
   dependencies:
     nan "^2.17.0"
 


### PR DESCRIPTION
This reverts commit 5083bb50a54c31d181d9d64177b2752538012e9a.

This update caused macOS task integration tests to consistently fail.
