### PR TITLE
Make text button text selection consistent

### DIFF
--- a/src/vs/workbench/contrib/search/browser/media/searchview.css
+++ b/src/vs/workbench/contrib/search/browser/media/searchview.css
@@ -179,6 +179,7 @@
 
 .search-view .message a {
 	color: var(--vscode-textLink-foreground);
+	user-select: none !important;
 }
 
 .search-view .message a:hover,

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/media/gettingStarted.css
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/media/gettingStarted.css
@@ -617,6 +617,7 @@
 
 .monaco-workbench .part.editor>.content .gettingStartedContainer .index-list.getting-started .button-link {
 	margin: 0;
+	user-select: none;
 }
 
 .monaco-workbench .part.editor>.content .gettingStartedContainer .index-list.getting-started .see-all-walkthroughs {
@@ -935,6 +936,7 @@
 
 .monaco-workbench .part.editor > .content .gettingStartedContainer a:not(.hide-category-button) {
 	color: var(--vscode-textLink-foreground);
+	user-select: none;
 }
 
 .monaco-workbench .part.editor > .content .gettingStartedContainer .button-link {
@@ -971,6 +973,7 @@
 
 .monaco-workbench .part.editor > .content .gettingStartedContainer button.button-link  {
 	border: inherit;
+	user-select: none;
 }
 
 .monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlideCategories .progress-bar-outer {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
This pull request makes text button text unselectable to ensure consistency with other text buttons. Here is a non-exhaustive list of text buttons and their behavior:

Text can be selected:
“See More Themes…” (Welcome)
“Open Folder” (Search)

Text can be selected with control-click:
“Mark Done” (Welcome)
“Next Section” (Welcome)
“privacy statement” (Welcome)
“opt out” (Welcome)
“More…” (Walkthroughs)
“New File…” (Welcome)
“Open…” (Welcome)
“Close Git Repository…” (Welcome)
“Connect to” (Welcome)

Text cannot be selected:
“add a folder” (Explorer) “read our docs” (Source Control)
“Open a file” (Run and Debug)
“open a folder” (Run and Debug)
“Show all automatic debug configurations” (Run and Debug)

This was partially attempted in https://github.com/microsoft/vscode/pull/179497 but ultimately reverted due to a lack of consistency.

@daviddossett for design.