### PR TITLE
cli: adding forwarding for local port for remote tunnels

### DIFF
--- a/cli/src/bin/code/main.rs
+++ b/cli/src/bin/code/main.rs
@@ -114,6 +114,9 @@ async fn main() -> Result<(), std::convert::Infallible> {
 				Some(args::TunnelSubcommand::Service(service_args)) => {
 					tunnels::service(context_no_logger(), service_args).await
 				}
+				Some(args::TunnelSubcommand::ForwardInternal(forward_args)) => {
+					tunnels::forward(context_no_logger(), forward_args).await
+				}
 				None => tunnels::serve(context_no_logger(), tunnel_args.serve_args).await,
 			},
 		},

--- a/cli/src/commands/args.rs
+++ b/cli/src/commands/args.rs
@@ -640,6 +640,10 @@ pub enum TunnelSubcommand {
 	/// (Preview) Manages the tunnel when installed as a system service,
 	#[clap(subcommand)]
 	Service(TunnelServiceSubCommands),
+
+	/// (Preview) Forwards local port using the dev tunnel
+	#[clap(hide = true)]
+	ForwardInternal(TunnelForwardArgs),
 }
 
 #[derive(Subcommand, Debug, Clone)]
@@ -673,6 +677,16 @@ pub struct TunnelServiceInstallArgs {
 pub struct TunnelRenameArgs {
 	/// The name you'd like to rename your machine to.
 	pub name: String,
+}
+
+#[derive(Args, Debug, Clone)]
+pub struct TunnelForwardArgs {
+	/// One or more ports to forward.
+	pub ports: Vec<u16>,
+
+	/// Login args -- used for convenience so the forwarding call is a single action.
+	#[clap(flatten)]
+	pub login: LoginArgs,
 }
 
 #[derive(Subcommand, Debug, Clone)]

--- a/cli/src/commands/tunnels.rs
+++ b/cli/src/commands/tunnels.rs
@@ -10,11 +10,15 @@ use serde::Serialize;
 use sha2::{Digest, Sha256};
 use std::{str::FromStr, time::Duration};
 use sysinfo::Pid;
+use tokio::{
+	io::{AsyncBufReadExt, BufReader},
+	sync::watch,
+};
 
 use super::{
 	args::{
-		AuthProvider, CliCore, CommandShellArgs, ExistingTunnelArgs, TunnelRenameArgs,
-		TunnelServeArgs, TunnelServiceSubCommands, TunnelUserSubCommands,
+		AuthProvider, CliCore, CommandShellArgs, ExistingTunnelArgs, TunnelForwardArgs,
+		TunnelRenameArgs, TunnelServeArgs, TunnelServiceSubCommands, TunnelUserSubCommands,
 	},
 	CommandContext,
 };
@@ -22,12 +26,16 @@ use super::{
 use crate::{
 	async_pipe::{get_socket_name, listen_socket_rw_stream, AsyncRWAccepter},
 	auth::Auth,
-	constants::{APPLICATION_NAME, TUNNEL_CLI_LOCK_NAME, TUNNEL_SERVICE_LOCK_NAME},
+	constants::{
+		APPLICATION_NAME, CONTROL_PORT, IS_A_TTY, TUNNEL_CLI_LOCK_NAME, TUNNEL_SERVICE_LOCK_NAME,
+	},
 	log,
 	state::LauncherPaths,
 	tunnels::{
 		code_server::CodeServerArgs,
-		create_service_manager, dev_tunnels, legal,
+		create_service_manager,
+		dev_tunnels::{self, DevTunnels},
+		forwarding, legal,
 		paths::get_all_servers,
 		protocol, serve_stream,
 		shutdown_signal::ShutdownRequest,
@@ -200,7 +208,7 @@ pub async fn service(
 
 			if let Some(name) = &args.name {
 				// ensure the name matches, and tunnel exists
-				dev_tunnels::DevTunnels::new(&ctx.log, auth, &ctx.paths)
+				dev_tunnels::DevTunnels::new_remote_tunnel(&ctx.log, auth, &ctx.paths)
 					.rename_tunnel(name)
 					.await?;
 			} else {
@@ -274,7 +282,7 @@ pub async fn user(ctx: CommandContext, user_args: TunnelUserSubCommands) -> Resu
 /// Remove the tunnel used by this tunnel, if any.
 pub async fn rename(ctx: CommandContext, rename_args: TunnelRenameArgs) -> Result<i32, AnyError> {
 	let auth = Auth::new(&ctx.paths, ctx.log.clone());
-	let mut dt = dev_tunnels::DevTunnels::new(&ctx.log, auth, &ctx.paths);
+	let mut dt = dev_tunnels::DevTunnels::new_remote_tunnel(&ctx.log, auth, &ctx.paths);
 	dt.rename_tunnel(&rename_args.name).await?;
 	ctx.log.result(format!(
 		"Successfully renamed this tunnel to {}",
@@ -287,7 +295,7 @@ pub async fn rename(ctx: CommandContext, rename_args: TunnelRenameArgs) -> Resul
 /// Remove the tunnel used by this tunnel, if any.
 pub async fn unregister(ctx: CommandContext) -> Result<i32, AnyError> {
 	let auth = Auth::new(&ctx.paths, ctx.log.clone());
-	let mut dt = dev_tunnels::DevTunnels::new(&ctx.log, auth, &ctx.paths);
+	let mut dt = dev_tunnels::DevTunnels::new_remote_tunnel(&ctx.log, auth, &ctx.paths);
 	dt.remove_tunnel().await?;
 	Ok(0)
 }
@@ -395,6 +403,88 @@ pub async fn serve(ctx: CommandContext, gateway_args: TunnelServeArgs) -> Result
 	result
 }
 
+/// Internal command used by port forwarding. It reads requests for forwarded ports
+/// on lines from stdin, as JSON. It uses singleton logic as well (though on
+/// a different tunnel than the main one used for the control server) so that
+/// all forward requests on a single machine go through a single hosted tunnel
+/// process. Without singleton logic, requests could get routed to processes
+/// that aren't forwarding a given port and then fail.
+pub async fn forward(
+	ctx: CommandContext,
+	mut forward_args: TunnelForwardArgs,
+) -> Result<i32, AnyError> {
+	// Spooky: check IS_A_TTY before starting the stdin reader, since IS_A_TTY will
+	// access stdin but a lock will later be held on stdin by the line-reader.
+	if *IS_A_TTY {
+		trace!(ctx.log, "port forwarding is an internal preview feature");
+	}
+
+	// #region stdin reading logic:
+	let (own_ports_tx, own_ports_rx) = watch::channel(vec![]);
+	let ports_process_log = ctx.log.clone();
+	tokio::spawn(async move {
+		let mut lines = BufReader::new(tokio::io::stdin()).lines();
+		while let Ok(Some(line)) = lines.next_line().await {
+			match serde_json::from_str(&line) {
+				Ok(p) => {
+					let _ = own_ports_tx.send(p);
+				}
+				Err(e) => warning!(ports_process_log, "error parsing ports: {}", e),
+			}
+		}
+	});
+
+	// #region singleton acquisition
+	let shutdown = ShutdownRequest::create_rx([ShutdownRequest::CtrlC]);
+	let server = loop {
+		if shutdown.is_open() {
+			return Ok(0);
+		}
+
+		match acquire_singleton(&ctx.paths.forwarding_lockfile()).await {
+			Ok(SingletonConnection::Client(stream)) => {
+				debug!(ctx.log, "starting as client to singleton");
+				let r = forwarding::client(forwarding::SingletonClientArgs {
+					log: ctx.log.clone(),
+					shutdown: shutdown.clone(),
+					stream,
+					port_requests: own_ports_rx.clone(),
+				})
+				.await;
+				if let Err(e) = r {
+					warning!(ctx.log, "error contacting forwarding singleton: {}", e);
+				}
+			}
+			Ok(SingletonConnection::Singleton(server)) => break server,
+			Err(e) => {
+				warning!(ctx.log, "error access singleton, retrying: {}", e);
+				tokio::time::sleep(Duration::from_secs(2)).await
+			}
+		}
+	};
+
+	// #region singleton handler
+	let auth = Auth::new(&ctx.paths, ctx.log.clone());
+	println!("preauth {:?}", forward_args.login);
+	if let (Some(p), Some(at)) = (
+		forward_args.login.provider.take(),
+		forward_args.login.access_token.take(),
+	) {
+		auth.login(Some(p.into()), Some(at)).await?;
+	}
+	println!("auth done");
+
+	let mut tunnels = DevTunnels::new_port_forwarding(&ctx.log, auth, &ctx.paths);
+	let tunnel = tunnels
+		.start_new_launcher_tunnel(None, true, &forward_args.ports)
+		.await?;
+	println!("made tunnel");
+
+	forwarding::server(ctx.log, tunnel, server, own_ports_rx, shutdown).await?;
+
+	Ok(0)
+}
+
 fn get_connection_token(tunnel: &ActiveTunnel) -> String {
 	let mut hash = Sha256::new();
 	hash.update(tunnel.id.as_bytes());
@@ -442,7 +532,7 @@ async fn serve_with_csa(
 			return Ok(0);
 		}
 
-		match acquire_singleton(paths.tunnel_lockfile()).await {
+		match acquire_singleton(&paths.tunnel_lockfile()).await {
 			Ok(SingletonConnection::Client(stream)) => {
 				debug!(log, "starting as client to singleton");
 				let should_exit = start_singleton_client(SingletonClientArgs {
@@ -471,15 +561,19 @@ async fn serve_with_csa(
 	let _lock = app_mutex_name.map(AppMutex::new);
 
 	let auth = Auth::new(&paths, log.clone());
-	let mut dt = dev_tunnels::DevTunnels::new(&log, auth, &paths);
+	let mut dt = dev_tunnels::DevTunnels::new_remote_tunnel(&log, auth, &paths);
 	loop {
 		let tunnel = if let Some(t) =
 			fulfill_existing_tunnel_args(gateway_args.tunnel.clone(), &gateway_args.name)
 		{
 			dt.start_existing_tunnel(t).await
 		} else {
-			dt.start_new_launcher_tunnel(gateway_args.name.as_deref(), gateway_args.random_name)
-				.await
+			dt.start_new_launcher_tunnel(
+				gateway_args.name.as_deref(),
+				gateway_args.random_name,
+				&[CONTROL_PORT],
+			)
+			.await
 		}?;
 
 		csa.connection_token = Some(get_connection_token(&tunnel));

--- a/cli/src/singleton.rs
+++ b/cli/src/singleton.rs
@@ -53,12 +53,12 @@ struct LockFileMatter {
 
 /// Tries to acquire the singleton homed at the given lock file, either starting
 /// a new singleton if it doesn't exist, or connecting otherwise.
-pub async fn acquire_singleton(lock_file: PathBuf) -> Result<SingletonConnection, CodeError> {
+pub async fn acquire_singleton(lock_file: &Path) -> Result<SingletonConnection, CodeError> {
 	let file = OpenOptions::new()
 		.read(true)
 		.write(true)
 		.create(true)
-		.open(&lock_file)
+		.open(lock_file)
 		.map_err(CodeError::SingletonLockfileOpenFailed)?;
 
 	match FileLock::acquire(file) {
@@ -158,7 +158,7 @@ mod tests {
 	#[tokio::test]
 	async fn test_acquires_singleton() {
 		let dir = tempfile::tempdir().expect("expected to make temp dir");
-		let s = acquire_singleton(dir.path().join("lock"))
+		let s = acquire_singleton(&dir.path().join("lock"))
 			.await
 			.expect("expected to acquire");
 
@@ -172,7 +172,7 @@ mod tests {
 	async fn test_acquires_client() {
 		let dir = tempfile::tempdir().expect("expected to make temp dir");
 		let lockfile = dir.path().join("lock");
-		let s1 = acquire_singleton(lockfile.clone())
+		let s1 = acquire_singleton(&lockfile)
 			.await
 			.expect("expected to acquire1");
 		match s1 {
@@ -182,7 +182,7 @@ mod tests {
 			_ => panic!("expected to be singleton"),
 		};
 
-		let s2 = acquire_singleton(lockfile)
+		let s2 = acquire_singleton(&lockfile)
 			.await
 			.expect("expected to acquire2");
 		match s2 {

--- a/cli/src/state.rs
+++ b/cli/src/state.rs
@@ -187,6 +187,14 @@ impl LauncherPaths {
 		))
 	}
 
+	/// Lockfile for port forwarding
+	pub fn forwarding_lockfile(&self) -> PathBuf {
+		self.root.join(format!(
+			"forwarding-{}.lock",
+			VSCODE_CLI_QUALITY.unwrap_or("oss")
+		))
+	}
+
 	/// Suggested path for tunnel service logs, when using file logs
 	pub fn service_log_file(&self) -> PathBuf {
 		self.root.join("tunnel-service.log")

--- a/cli/src/tunnels.rs
+++ b/cli/src/tunnels.rs
@@ -11,6 +11,7 @@ pub mod protocol;
 pub mod shutdown_signal;
 pub mod singleton_client;
 pub mod singleton_server;
+pub mod forwarding;
 
 mod wsl_detect;
 mod challenge;

--- a/cli/src/tunnels/forwarding.rs
+++ b/cli/src/tunnels/forwarding.rs
@@ -1,0 +1,284 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+use std::{
+	collections::HashMap,
+	sync::{Arc, Mutex},
+};
+
+use tokio::{
+	pin,
+	sync::{mpsc, watch},
+};
+
+use crate::{
+	async_pipe::{socket_stream_split, AsyncPipe},
+	json_rpc::{new_json_rpc, start_json_rpc},
+	log,
+	singleton::SingletonServer,
+	util::{errors::CodeError, sync::Barrier},
+};
+
+use super::{
+	dev_tunnels::ActiveTunnel,
+	protocol::{
+		self,
+		forward_singleton::{PortList, SetPortsResponse},
+	},
+	shutdown_signal::ShutdownSignal,
+};
+
+type PortMap = HashMap<u16, u32>;
+
+/// The PortForwardingHandle is given out to multiple consumers to allow
+/// them to set_ports that they want to be forwarded.
+struct PortForwardingSender {
+	/// Todo: when `SyncUnsafeCell` is no longer nightly, we can use it here with
+	/// the following comment:
+	///
+	/// SyncUnsafeCell is used and safe here because PortForwardingSender is used
+	/// exclusively in synchronous dispatch *and* we create a new sender in the
+	/// context for each connection, in `serve_singleton_rpc`.
+	///
+	/// If PortForwardingSender is ever used in a different context, this should
+	/// be refactored, e.g. to use locks or `&mut self` in set_ports`
+	///
+	/// see https://doc.rust-lang.org/stable/std/cell/struct.SyncUnsafeCell.html
+	current: Mutex<PortList>,
+	sender: Arc<Mutex<watch::Sender<PortMap>>>,
+}
+
+impl PortForwardingSender {
+	pub fn set_ports(&self, ports: PortList) {
+		let mut current = self.current.lock().unwrap();
+		self.sender.lock().unwrap().send_modify(|v| {
+			for p in current.iter() {
+				if !ports.contains(p) {
+					match v.get(p) {
+						Some(1) => {
+							v.remove(p);
+						}
+						Some(n) => {
+							v.insert(*p, n - 1);
+						}
+						None => unreachable!("removed port not in map"),
+					}
+				}
+			}
+
+			for p in ports.iter() {
+				if !current.contains(p) {
+					match v.get(p) {
+						Some(n) => v.insert(*p, n + 1),
+						None => v.insert(*p, 1),
+					};
+				}
+			}
+
+			current.splice(.., ports);
+		});
+	}
+}
+
+impl Clone for PortForwardingSender {
+	fn clone(&self) -> Self {
+		Self {
+			current: Mutex::new(vec![]),
+			sender: self.sender.clone(),
+		}
+	}
+}
+
+impl Drop for PortForwardingSender {
+	fn drop(&mut self) {
+		self.set_ports(vec![]);
+	}
+}
+
+struct PortForwardingReceiver {
+	receiver: watch::Receiver<PortMap>,
+}
+
+impl PortForwardingReceiver {
+	pub fn new() -> (PortForwardingSender, Self) {
+		let (sender, receiver) = watch::channel(HashMap::new());
+		let handle = PortForwardingSender {
+			current: Mutex::new(vec![]),
+			sender: Arc::new(Mutex::new(sender)),
+		};
+
+		let tracker = Self { receiver };
+
+		(handle, tracker)
+	}
+
+	/// Applies all changes from PortForwardingHandles to the tunnel.
+	pub async fn apply_to(&mut self, log: log::Logger, tunnel: Arc<ActiveTunnel>) {
+		let mut current = vec![];
+		while self.receiver.changed().await.is_ok() {
+			let next = self.receiver.borrow().keys().copied().collect::<Vec<_>>();
+
+			for p in current.iter() {
+				if !next.contains(p) {
+					match tunnel.remove_port(*p).await {
+						Ok(_) => info!(log, "stopped forwarding port {}", p),
+						Err(e) => error!(log, "failed to stop forwarding port {}: {}", p, e),
+					}
+				}
+			}
+			for p in next.iter() {
+				if !current.contains(p) {
+					match tunnel.add_port_tcp(*p).await {
+						Ok(_) => info!(log, "forwarding port {}", p),
+						Err(e) => error!(log, "failed to forward port {}: {}", p, e),
+					}
+				}
+			}
+
+			current = next;
+		}
+	}
+}
+
+pub struct SingletonClientArgs {
+	pub log: log::Logger,
+	pub stream: AsyncPipe,
+	pub shutdown: Barrier<ShutdownSignal>,
+	pub port_requests: watch::Receiver<PortList>,
+}
+
+#[derive(Clone)]
+struct SingletonServerContext {
+	log: log::Logger,
+	handle: PortForwardingSender,
+	tunnel: Arc<ActiveTunnel>,
+}
+
+/// Serves a client singleton for port forwarding.
+pub async fn client(args: SingletonClientArgs) -> Result<(), std::io::Error> {
+	let mut rpc = new_json_rpc();
+	let (msg_tx, msg_rx) = mpsc::unbounded_channel();
+	let SingletonClientArgs {
+		log,
+		shutdown,
+		stream,
+		mut port_requests,
+	} = args;
+
+	debug!(
+		log,
+		"An existing port forwarding process is running on this machine, connecting to it..."
+	);
+
+	let caller = rpc.get_caller(msg_tx);
+	let rpc = rpc.methods(()).build(log.clone());
+	let (read, write) = socket_stream_split(stream);
+
+	let serve = start_json_rpc(rpc, read, write, msg_rx, shutdown);
+	let forward = async move {
+		while port_requests.changed().await.is_ok() {
+			let ports = port_requests.borrow().clone();
+			let r = caller
+				.call::<_, _, protocol::forward_singleton::SetPortsResponse>(
+					protocol::forward_singleton::METHOD_SET_PORTS,
+					protocol::forward_singleton::SetPortsParams { ports },
+				)
+				.await
+				.unwrap();
+
+			match r {
+				Err(e) => error!(log, "failed to set ports: {:?}", e),
+				Ok(r) => print_forwarding_addr(&r),
+			};
+		}
+	};
+
+	tokio::select! {
+		r = serve => r.map(|_| ()),
+		_ = forward => Ok(()),
+	}
+}
+
+/// Serves a port-forwarding singleton.
+pub async fn server(
+	log: log::Logger,
+	tunnel: ActiveTunnel,
+	server: SingletonServer,
+	mut port_requests: watch::Receiver<PortList>,
+	shutdown_rx: Barrier<ShutdownSignal>,
+) -> Result<(), CodeError> {
+	let tunnel = Arc::new(tunnel);
+	let (forward_tx, mut forward_rx) = PortForwardingReceiver::new();
+
+	let forward_own_tunnel = tunnel.clone();
+	let forward_own_tx = forward_tx.clone();
+	let forward_own = async move {
+		while port_requests.changed().await.is_ok() {
+			forward_own_tx.set_ports(port_requests.borrow().clone());
+			print_forwarding_addr(&SetPortsResponse {
+				port_format: forward_own_tunnel.get_port_format().ok(),
+			});
+		}
+	};
+
+	tokio::select! {
+		_ = forward_own => Ok(()),
+		_ = forward_rx.apply_to(log.clone(), tunnel.clone()) => Ok(()),
+		r = serve_singleton_rpc(server, log, tunnel, forward_tx, shutdown_rx) => r,
+	}
+}
+
+async fn serve_singleton_rpc(
+	mut server: SingletonServer,
+	log: log::Logger,
+	tunnel: Arc<ActiveTunnel>,
+	forward_tx: PortForwardingSender,
+	shutdown_rx: Barrier<ShutdownSignal>,
+) -> Result<(), CodeError> {
+	let mut own_shutdown = shutdown_rx.clone();
+	let shutdown_fut = own_shutdown.wait();
+	pin!(shutdown_fut);
+
+	loop {
+		let cnx = tokio::select! {
+			c = server.accept() => c?,
+			_ = &mut shutdown_fut => return Ok(()),
+		};
+
+		let (read, write) = socket_stream_split(cnx);
+		let shutdown_rx = shutdown_rx.clone();
+
+		let handle = forward_tx.clone();
+		let log = log.clone();
+		let tunnel = tunnel.clone();
+		tokio::spawn(async move {
+			// we make an rpc for the connection instead of re-using a dispatcher
+			// so that we can have the "handle" drop when the connection drops.
+			let rpc = new_json_rpc();
+			let mut rpc = rpc.methods(SingletonServerContext {
+				log: log.clone(),
+				handle,
+				tunnel,
+			});
+
+			rpc.register_sync(
+				protocol::forward_singleton::METHOD_SET_PORTS,
+				|p: protocol::forward_singleton::SetPortsParams, ctx| {
+					info!(ctx.log, "client setting ports to {:?}", p.ports);
+					ctx.handle.set_ports(p.ports);
+					Ok(SetPortsResponse {
+						port_format: ctx.tunnel.get_port_format().ok(),
+					})
+				},
+			);
+
+			let _ = start_json_rpc(rpc.build(log), read, write, (), shutdown_rx).await;
+		});
+	}
+}
+
+fn print_forwarding_addr(r: &SetPortsResponse) {
+	eprintln!("{}\n", serde_json::to_string(r).unwrap());
+}

--- a/cli/src/tunnels/port_forwarder.rs
+++ b/cli/src/tunnels/port_forwarder.rs
@@ -91,7 +91,7 @@ impl PortForwardingProcessor {
 			self.forwarded.insert(port);
 		}
 
-		tunnel.get_port_uri(port).await
+		tunnel.get_port_uri(port)
 	}
 }
 

--- a/cli/src/tunnels/protocol.rs
+++ b/cli/src/tunnels/protocol.rs
@@ -214,6 +214,24 @@ pub struct ChallengeVerifyParams {
 	pub response: String,
 }
 
+pub mod forward_singleton {
+	use serde::{Deserialize, Serialize};
+
+	pub const METHOD_SET_PORTS: &str = "set_ports";
+
+	pub type PortList = Vec<u16>;
+
+	#[derive(Serialize, Deserialize)]
+	pub struct SetPortsParams {
+		pub ports: PortList,
+	}
+
+	#[derive(Serialize, Deserialize)]
+	pub struct SetPortsResponse {
+		pub port_format: Option<String>,
+	}
+}
+
 pub mod singleton {
 	use crate::log;
 	use serde::{Deserialize, Serialize};

--- a/cli/src/tunnels/singleton_server.rs
+++ b/cli/src/tunnels/singleton_server.rs
@@ -217,7 +217,7 @@ impl BroadcastLogSink {
 		}
 	}
 
-	fn get_brocaster(&self) -> broadcast::Sender<Vec<u8>> {
+	pub fn get_brocaster(&self) -> broadcast::Sender<Vec<u8>> {
 		self.tx.clone()
 	}
 

--- a/cli/src/util/errors.rs
+++ b/cli/src/util/errors.rs
@@ -2,7 +2,7 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
- use crate::{
+use crate::{
 	constants::{APPLICATION_NAME, CONTROL_PORT, DOCUMENTATION_URL, QUALITYLESS_PRODUCT_NAME},
 	rpc::ResponseError,
 };
@@ -515,6 +515,8 @@ pub enum CodeError {
 	AuthMismatch,
 	#[error("keyring communication timed out after 5s")]
 	KeyringTimeout,
+	#[error("no host is connected to the tunnel relay")]
+	NoTunnelEndpoint,
 }
 
 makeAnyError!(


### PR DESCRIPTION
This reuses a lot of the logic we use for the normal VS Code Server
tunnel to do port forwarding. It does use a _different_ tunnel than what
Remote Tunnels would otherwise use for the control server. The reason
for this is that ports exist on a tunnel instance, and if we reused the
same tunnel then a client would expect all CLI hosts to serve all
tunnels, where the port forwarding instance would not provide the VS
Code server. It also reuses the singleton logic so all ports on a
machine are handled by a single CLI instance for the same reason: we
can't have different instances hosting subsets of
ports on a single tunnel.

Currently all ports are under the default privacy: support for
public/private tunnels is either later today or next iteration.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
