### PR TITLE
No more top padding workaround for cell toolbar sticky scroll

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/contrib/execute/executionEditorProgress.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/execute/executionEditorProgress.ts
@@ -42,8 +42,6 @@ export class ExecutionEditorProgressController extends Disposable implements INo
 			return;
 		}
 
-		const scrollPadding = this._notebookEditor.notebookOptions.computeTopInsertToolbarHeight(this._notebookEditor.textModel.viewType);
-
 		const cellExecutions = this._notebookExecutionStateService.getCellExecutionsForNotebook(this._notebookEditor.textModel?.uri)
 			.filter(exe => exe.state === NotebookCellExecutionState.Executing);
 		const notebookExecution = this._notebookExecutionStateService.getExecution(this._notebookEditor.textModel?.uri);
@@ -52,7 +50,7 @@ export class ExecutionEditorProgressController extends Disposable implements INo
 				for (const cell of this._notebookEditor.getCellsInRange(range)) {
 					if (cell.handle === exe.cellHandle) {
 						const top = this._notebookEditor.getAbsoluteTopOfElement(cell);
-						if (this._notebookEditor.scrollTop < top + scrollPadding + 5) {
+						if (this._notebookEditor.scrollTop < top + 5) {
 							return true;
 						}
 					}

--- a/src/vs/workbench/contrib/notebook/browser/view/cellParts/cellToolbarStickyScroll.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/cellParts/cellToolbarStickyScroll.ts
@@ -15,8 +15,7 @@ export function registerCellToolbarStickyScroll(notebookEditor: INotebookEditor,
 		if (cell.isInputCollapsed) {
 			element.style.top = '';
 		} else {
-			const scrollPadding = notebookEditor.notebookOptions.computeTopInsertToolbarHeight(notebookEditor.textModel?.viewType);
-			const scrollTop = notebookEditor.scrollTop - scrollPadding;
+			const scrollTop = notebookEditor.scrollTop;
 			const elementTop = notebookEditor.getAbsoluteTopOfElement(cell);
 			const diff = scrollTop - elementTop + extraOffset;
 			const maxTop = cell.layoutInfo.editorHeight + cell.layoutInfo.statusBarHeight - 45; // subtract roughly the height of the execution order label plus padding


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

The top padding is now part of the list view so we don't have to workaround anymore.