### PR TITLE
Guarantee that an autorun is not rerun if it is disposed

### DIFF
--- a/src/vs/base/common/observableImpl/autorun.ts
+++ b/src/vs/base/common/observableImpl/autorun.ts
@@ -118,7 +118,7 @@ export class AutorunObserver<TChangeSummary = any> implements IObserver, IReader
 	}
 
 	private _runIfNeeded() {
-		if (this.state === AutorunState.upToDate) {
+		if (this.state === AutorunState.upToDate || this.disposed) {
 			return;
 		}
 


### PR DESCRIPTION
This helps to understand an error telemetry event better.