### PR TITLE
Removes the complementary role from the ARIA status container

### DIFF
--- a/src/vs/base/browser/ui/aria/aria.ts
+++ b/src/vs/base/browser/ui/aria/aria.ts
@@ -31,7 +31,6 @@ export function setARIAContainer(parent: HTMLElement) {
 	const createStatusContainer = () => {
 		const element = document.createElement('div');
 		element.className = 'monaco-status';
-		element.setAttribute('role', 'complementary');
 		element.setAttribute('aria-live', 'polite');
 		element.setAttribute('aria-atomic', 'true');
 		ariaContainer.appendChild(element);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
This removes the complementary landmark that is generated when statuss messages are send to assistive technology via aria-live updates. It closes #188228. Refer to the associated issue for instructions on how to test [https://github.com/microsoft/vscode/issues/188228#issuecomment-1645027861](https://github.com/microsoft/vscode/issues/188228#issuecomment-1645027861).