### PR TITLE
Focusing previously focused notification does not announce their content (fix #188762)

### DIFF
--- a/src/vs/workbench/browser/parts/notifications/notificationsCenter.ts
+++ b/src/vs/workbench/browser/parts/notifications/notificationsCenter.ts
@@ -78,7 +78,10 @@ export class NotificationsCenter extends Themable implements INotificationsCente
 	show(): void {
 		if (this._isVisible) {
 			const notificationsList = assertIsDefined(this.notificationsList);
+
+			// Make visible and focus first
 			notificationsList.show(true /* focus */);
+			notificationsList.focusFirst();
 
 			return; // already visible
 		}

--- a/src/vs/workbench/browser/parts/notifications/notificationsCommands.ts
+++ b/src/vs/workbench/browser/parts/notifications/notificationsCommands.ts
@@ -104,7 +104,7 @@ export function registerNotificationCommands(center: INotificationsCenterControl
 	});
 
 	// Toggle Notifications Center
-	CommandsRegistry.registerCommand(TOGGLE_NOTIFICATIONS_CENTER, accessor => {
+	CommandsRegistry.registerCommand(TOGGLE_NOTIFICATIONS_CENTER, () => {
 		if (center.isVisible) {
 			center.hide();
 		} else {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
