### PR TITLE
Revert "treat soon to be saved by auto-save as saving"

### DIFF
--- a/src/vs/workbench/contrib/notebook/common/notebookEditorInput.ts
+++ b/src/vs/workbench/contrib/notebook/common/notebookEditorInput.ts
@@ -24,7 +24,7 @@ import { VSBuffer } from 'vs/base/common/buffer';
 import { IWorkingCopyIdentifier } from 'vs/workbench/services/workingCopy/common/workingCopy';
 import { NotebookProviderInfo } from 'vs/workbench/contrib/notebook/common/notebookProvider';
 import { NotebookPerfMarks } from 'vs/workbench/contrib/notebook/common/notebookPerformance';
-import { AutoSaveMode, IFilesConfigurationService } from 'vs/workbench/services/filesConfiguration/common/filesConfigurationService';
+import { IFilesConfigurationService } from 'vs/workbench/services/filesConfiguration/common/filesConfigurationService';
 import { IExtensionService } from 'vs/workbench/services/extensions/common/extensions';
 import { localize } from 'vs/nls';
 import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
@@ -214,14 +214,6 @@ export class NotebookEditorInput extends AbstractResourceEditorInput {
 		}
 
 		return await this._editorModelReference.object.saveAs(target);
-	}
-
-	override isSaving(): boolean {
-		if (this.isDirty() && !this.hasCapability(EditorInputCapabilities.Untitled) && this.filesConfigurationService.getAutoSaveMode() === AutoSaveMode.AFTER_SHORT_DELAY) {
-			return true; // will be saved soon
-		}
-
-		return super.isSaving();
 	}
 
 	private async _suggestName(provider: NotebookProviderInfo, suggestedFilename: string) {


### PR DESCRIPTION
fixes https://github.com/microsoft/vscode/issues/188452

This reverts commit 66b0f928408be2f70fb477f12bd4501175f7d14b.

after the save fails, the file no longer shows dirty at all - there is no error state for the notebook editor, so it always claims that it is just about to save.
That makes it hard to understand that there are unsaved changes.