### PR TITLE
Partially revert #188964

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatSlashCommandContentWidget.css
+++ b/src/vs/workbench/contrib/chat/browser/chatSlashCommandContentWidget.css
@@ -5,7 +5,6 @@
 
 .chat-slash-command-content-widget {
 	padding: 0.1em 0.3em;
-	top: 7px !important;
 	border-radius: 2px;
 	background-color: var(--vscode-textCodeBlock-background);
 	color: var(--vscode-textLink-foreground);


### PR DESCRIPTION
This will cause a 1px offset in panel chat, but it fixes the breakage of how slash commands are rendered in inline chat