### PR TITLE
Smart markdown pasting does not occur in tilde code block

### DIFF
--- a/extensions/markdown-language-features/src/languageFeatures/copyFiles/shared.ts
+++ b/extensions/markdown-language-features/src/languageFeatures/copyFiles/shared.ts
@@ -66,7 +66,8 @@ const smartPasteRegexes = [
 	{ regex: /\[.*\]\(.*\)/g, isMarkdownLink: true, isInline: true }, // Is a Markdown Link
 	{ regex: /!\[.*\]\(.*\)/g, isMarkdownLink: true, isInline: true }, // Is a Markdown Image Link
 	{ regex: /\[([^\]]*)\]\(([^)]*)\)/g, isMarkdownLink: false, isInline: true }, // In a Markdown link
-	{ regex: /^```[\s\S]*?```$/gm, isMarkdownLink: false, isInline: false }, // In a fenced code block
+	{ regex: /^```[\s\S]*?```$/gm, isMarkdownLink: false, isInline: false }, // In a backtick fenced code block
+	{ regex: /^~~~[\s\S]*?~~~$/gm, isMarkdownLink: false, isInline: false }, // In a tildefenced code block
 	{ regex: /^\$\$[\s\S]*?\$\$$/gm, isMarkdownLink: false, isInline: false }, // In a fenced math block
 	{ regex: /`[^`]*`/g, isMarkdownLink: false, isInline: true }, // In inline code
 	{ regex: /\$[^$]*\$/g, isMarkdownLink: false, isInline: true }, // In inline math

--- a/extensions/markdown-language-features/src/test/markdownLink.test.ts
+++ b/extensions/markdown-language-features/src/test/markdownLink.test.ts
@@ -141,8 +141,15 @@ suite('createEditAddingLinksForUriList', () => {
 			assert.strictEqual(smartPaste.pasteAsMarkdownLink, true);
 		});
 
-		test('Should evaluate pasteAsMarkdownLink as false for pasting within a code block', () => {
+		test('Should evaluate pasteAsMarkdownLink as false for pasting within a backtick code block', () => {
 			skinnyDocument.getText = function () { return '```\r\n\r\n```'; };
+			const range = new vscode.Range(0, 5, 0, 5);
+			const smartPaste = checkSmartPaste(skinnyDocument, range);
+			assert.strictEqual(smartPaste.pasteAsMarkdownLink, false);
+		});
+
+		test('Should evaluate pasteAsMarkdownLink as false for pasting within a tilde code block', () => {
+			skinnyDocument.getText = function () { return '~~~\r\n\r\n~~~'; };
 			const range = new vscode.Range(0, 5, 0, 5);
 			const smartPaste = checkSmartPaste(skinnyDocument, range);
 			assert.strictEqual(smartPaste.pasteAsMarkdownLink, false);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

fixes https://github.com/microsoft/vscode/issues/188861