### PR TITLE
Turn off aiQuickFix by default for stable

### DIFF
--- a/extensions/typescript-language-features/package.json
+++ b/extensions/typescript-language-features/package.json
@@ -145,7 +145,7 @@
       "properties": {
         "typescript.experimental.aiQuickFix": {
           "type": "boolean",
-          "default": true,
+          "default": false,
           "description": "%typescript.experimental.aiQuickFix%",
           "scope": "resource"
         },


### PR DESCRIPTION
Let's re-evaluate turning this on by default when the experience is better.