### PR TITLE
focus hover on escape of accessible view so context isn't lost

### DIFF
--- a/src/vs/workbench/contrib/accessibility/browser/accessibility.contribution.ts
+++ b/src/vs/workbench/contrib/accessibility/browser/accessibility.contribution.ts
@@ -27,6 +27,7 @@ import { getNotificationFromContext } from 'vs/workbench/browser/parts/notificat
 import { IListService, WorkbenchList } from 'vs/platform/list/browser/listService';
 import { NotificationFocusedContext } from 'vs/workbench/common/contextkeys';
 import { IAccessibleViewService, AccessibleViewService, IAccessibleContentProvider, IAccessibleViewOptions, AccessibleViewType, accessibleViewIsShown } from 'vs/workbench/contrib/accessibility/browser/accessibleView';
+import { IHoverService } from 'vs/workbench/services/hover/browser/hover';
 
 registerAccessibilityConfiguration();
 registerSingleton(IAccessibleViewService, AccessibleViewService, InstantiationType.Delayed);
@@ -133,6 +134,8 @@ class HoverAccessibleViewContribution extends Disposable {
 			const contextViewService = accessor.get(IContextViewService);
 			const contextViewElement = contextViewService.getContextViewElement();
 			const extensionHoverContent = contextViewElement?.textContent ?? undefined;
+			const hoverService = accessor.get(IHoverService);
+
 			if (contextViewElement.classList.contains('accessible-view-container') || !extensionHoverContent) {
 				// The accessible view, itself, uses the context view service to display the text. We don't want to read that.
 				return false;
@@ -140,7 +143,9 @@ class HoverAccessibleViewContribution extends Disposable {
 			accessibleViewService.show({
 				verbositySettingKey: AccessibilityVerbositySettingId.Hover,
 				provideContent() { return extensionHoverContent; },
-				onClose() { },
+				onClose() {
+					hoverService.showAndFocusLastHover();
+				},
 				options: this._options
 			});
 			return true;

--- a/src/vs/workbench/services/hover/browser/hover.ts
+++ b/src/vs/workbench/services/hover/browser/hover.ts
@@ -37,6 +37,12 @@ export interface IHoverService {
 	 * "locked" via the alt/option key.
 	 */
 	hideHover(): void;
+
+	/**
+	 * This should only be used until we have the ability to show multiple context views
+	 * simultaneously. #188822
+	 */
+	showAndFocusLastHover(): void;
 }
 
 export interface IHoverWidget extends IDisposable {

--- a/src/vs/workbench/services/hover/browser/hoverService.ts
+++ b/src/vs/workbench/services/hover/browser/hoverService.ts
@@ -23,6 +23,7 @@ export class HoverService implements IHoverService {
 
 	private _currentHoverOptions: IHoverOptions | undefined;
 	private _currentHover: HoverWidget | undefined;
+	private _lastHoverOptions: IHoverOptions | undefined;
 
 	private _lastFocusedElementBeforeOpen: HTMLElement | undefined;
 
@@ -40,6 +41,7 @@ export class HoverService implements IHoverService {
 			return undefined;
 		}
 		this._currentHoverOptions = options;
+		this._lastHoverOptions = options;
 		if (options.trapFocus && document.activeElement) {
 			this._lastFocusedElementBeforeOpen = document.activeElement as HTMLElement;
 		} else {
@@ -106,6 +108,13 @@ export class HoverService implements IHoverService {
 		if (!entry.isIntersecting) {
 			hover.dispose();
 		}
+	}
+
+	showAndFocusLastHover(): void {
+		if (!this._lastHoverOptions) {
+			return;
+		}
+		this.showHover(this._lastHoverOptions, true);
 	}
 
 	private _keyDown(e: KeyboardEvent, hover: HoverWidget, hideOnKeyDown: boolean) {

--- a/src/vs/workbench/test/browser/workbenchTestServices.ts
+++ b/src/vs/workbench/test/browser/workbenchTestServices.ts
@@ -749,6 +749,7 @@ class TestHoverService implements IHoverService {
 		};
 		return this.currentHover;
 	}
+	showAndFocusLastHover(): void { }
 	hideHover(): void {
 		this.currentHover?.dispose();
 	}


### PR DESCRIPTION
this fix is not ideal, but it's a critical issue and makes the feature unusable since focus is lost for screen reader users.

fix #188822

see gif at the bottom of the issue