### PR TITLE
notebook sticky line memory-leaks

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/viewModel/notebookOutlineProvider.ts
+++ b/src/vs/workbench/contrib/notebook/browser/viewModel/notebookOutlineProvider.ts
@@ -184,7 +184,8 @@ export class NotebookCellOutlineProvider {
 	}
 
 	dispose(): void {
-		// selectionListener.clear();
+		this._entries.length = 0;
+		this._activeEntry = undefined;
 		this._entriesDisposables.dispose();
 		this._dispoables.dispose();
 	}

--- a/src/vs/workbench/contrib/notebook/browser/viewParts/notebookEditorStickyScroll.ts
+++ b/src/vs/workbench/contrib/notebook/browser/viewParts/notebookEditorStickyScroll.ts
@@ -55,8 +55,7 @@ class NotebookStickyLine extends Disposable {
 		public readonly notebookEditor: INotebookEditor,
 	) {
 		super();
-		this._register(DOM.addDisposableListener(this.element, DOM.EventType.CLICK, (e) => {
-			console.log('click on sticky line');
+		this._register(DOM.addDisposableListener(this.element, DOM.EventType.CLICK, () => {
 			this.focusCell();
 		}));
 	}
@@ -78,7 +77,6 @@ class NotebookStickyLine extends Disposable {
 		}
 		return count;
 	}
-
 }
 
 
@@ -134,6 +132,9 @@ export class NotebookStickyScroll extends Disposable {
 			this.init();
 		} else {
 			this._disposables.clear();
+			this.currentStickyLines.forEach((value) => {
+				value.dispose();
+			});
 			DOM.clearNode(this.domNode);
 			this.updateDisplay();
 		}
@@ -444,6 +445,9 @@ export class NotebookStickyScroll extends Disposable {
 
 	override dispose() {
 		this._disposables.dispose();
+		this.currentStickyLines.forEach((value) => {
+			value.dispose();
+		});
 		super.dispose();
 	}
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

fixes some misc memory leakes with notebookOutlineProvider and StickyScroll.

- rendered sticky lines were not disposed of upon config changes or nb close. 
- `_entries` and `_activeEntry` were not disposed of at all within NotebookCellOutlineProvider
