### PR TITLE
match quick pick styling

### DIFF
--- a/src/vs/workbench/contrib/accessibility/browser/accessibleView.ts
+++ b/src/vs/workbench/contrib/accessibility/browser/accessibleView.ts
@@ -26,10 +26,10 @@ import { getSimpleEditorOptions } from 'vs/workbench/contrib/codeEditor/browser/
 import { CodeActionController } from 'vs/editor/contrib/codeAction/browser/codeActionController';
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 import { AccessibilityVerbositySettingId, AccessibleViewAction, AccessibleViewNextAction, AccessibleViewPreviousAction } from 'vs/workbench/contrib/accessibility/browser/accessibilityContribution';
+import { ILayoutService } from 'vs/platform/layout/browser/layoutService';
 
-const enum DEFAULT {
-	WIDTH = 800,
-	TOP = 3
+const enum DIMENSIONS {
+	MAX_WIDTH = 600
 }
 
 export interface IAccessibleContentProvider {
@@ -89,7 +89,8 @@ class AccessibleView extends Disposable {
 		@IContextViewService private readonly _contextViewService: IContextViewService,
 		@IContextKeyService private readonly _contextKeyService: IContextKeyService,
 		@IAccessibilityService private readonly _accessibilityService: IAccessibilityService,
-		@IKeybindingService private readonly _keybindingService: IKeybindingService
+		@IKeybindingService private readonly _keybindingService: IKeybindingService,
+		@ILayoutService private readonly _layoutService: ILayoutService
 	) {
 		super();
 		this._accessiblityHelpIsShown = accessibilityHelpIsShown.bindTo(this._contextKeyService);
@@ -128,7 +129,7 @@ class AccessibleView extends Disposable {
 
 	show(provider: IAccessibleContentProvider): void {
 		const delegate: IContextViewDelegate = {
-			getAnchor: () => { return { x: (window.innerWidth / 2) - (DEFAULT.WIDTH / 2), y: DEFAULT.TOP }; },
+			getAnchor: () => { return { x: (window.innerWidth / 2) - ((Math.min(this._layoutService.dimension.width * 0.62 /* golden cut */, DIMENSIONS.MAX_WIDTH)) / 2), y: this._layoutService.offset.quickPickTop }; },
 			render: (container) => {
 				container.classList.add('accessible-view-container');
 				return this._render(provider, container);
@@ -228,11 +229,16 @@ class AccessibleView extends Disposable {
 		}));
 		disposableStore.add(this._editorWidget.onDidBlurEditorText(() => this._contextViewService.hideContextView()));
 		disposableStore.add(this._editorWidget.onDidContentSizeChange(() => this._layout()));
+		disposableStore.add(this._layoutService.onDidLayout(() => this._layout()));
 		return disposableStore;
 	}
 
 	private _layout(): void {
-		this._editorWidget.layout({ width: DEFAULT.WIDTH, height: this._editorWidget.getContentHeight() });
+		const dimension = this._layoutService.dimension;
+		const maxHeight = dimension.height && dimension.height * .4;
+		const height = Math.min(maxHeight, this._editorWidget.getContentHeight());
+		const width = Math.min(dimension.width * 0.62 /* golden cut */, DIMENSIONS.MAX_WIDTH);
+		this._editorWidget.layout({ width, height });
 	}
 
 	private async _getTextModel(resource: URI): Promise<ITextModel | null> {

--- a/src/vs/workbench/contrib/codeEditor/browser/accessibility/accessibility.css
+++ b/src/vs/workbench/contrib/codeEditor/browser/accessibility/accessibility.css
@@ -9,4 +9,7 @@
 	color: var(--vscode-editorWidget-foreground);
 	box-shadow: 0 2px 8px var(--vscode-widget-shadow);
 	border: 2px solid var(--vscode-focusBorder);
+	border-radius: 6px;
+	margin-top: -1px;
+	z-index: 2550;
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
given that a screen reader will have to go line by line, I wonder if we should go with a larger width 🤔 . We can get feedback and for now match the styling of the quickpick, though they have very different functions/content so should be considered separately.

fixes #188838
fixes #186520

https://github.com/microsoft/vscode/assets/29464607/dcf0a381-f706-4853-bc2f-b3eacbcc6d3e

