### PR TITLE
trap focus on escape of accessible view hover

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,5 +1,5 @@
 disturl "https://electronjs.org/headers"
 target "22.3.14"
-ms_build_id "21893604"
+ms_build_id "22695494"
 runtime "electron"
 build_from_source "true"

--- a/build/azure-pipelines/product-build.yml
+++ b/build/azure-pipelines/product-build.yml
@@ -142,19 +142,19 @@ name: "$(Date:yyyyMMdd).$(Rev:r) (${{ parameters.VSCODE_QUALITY }})"
 resources:
   containers:
     - container: vscode-bionic-x64
-      image: vscodehub.azurecr.io/vscode-linux-build-agent:bionic-x64
+      image: vscodehub.azurecr.io/vscode-linux-build-agent@sha256:ea3279b32c851c49c9e1ed24d270c6d0408274802a7a845f22896cff3e35655a
       endpoint: VSCodeHub
       options: --user 0:0 --cap-add SYS_ADMIN
     - container: vscode-arm64
-      image: vscodehub.azurecr.io/vscode-linux-build-agent:bionic-arm64
+      image: vscodehub.azurecr.io/vscode-linux-build-agent@sha256:ffe901d8c1ac63da359b1e33c6da60d836adc6b6a766e626dcc12a24e2edfc6f
       endpoint: VSCodeHub
       options: --user 0:0 --cap-add SYS_ADMIN
     - container: vscode-armhf
-      image: vscodehub.azurecr.io/vscode-linux-build-agent:bionic-armhf
+      image: vscodehub.azurecr.io/vscode-linux-build-agent@sha256:4b76e1f7d47c2087b74ed8bc2138b1f48c39ebc4341073c46a8454e75c4776dc
       endpoint: VSCodeHub
       options: --user 0:0 --cap-add SYS_ADMIN
     - container: snapcraft
-      image: vscodehub.azurecr.io/vscode-linux-build-agent:snapcraft-x64
+      image: vscodehub.azurecr.io/vscode-linux-build-agent@sha256:7c69481e907f50cf9f73abb579d2ae91849db611bb1e0eb19ef1f33d43796d9a
       endpoint: VSCodeHub
   pipelines:
     - pipeline: vscode-7pm-kick-off

--- a/extensions/markdown-language-features/media/markdown.css
+++ b/extensions/markdown-language-features/media/markdown.css
@@ -9,6 +9,7 @@ html, body {
 	padding: 0 26px;
 	line-height: var(--markdown-line-height, 22px);
 	word-wrap: break-word;
+	overscroll-behavior-x: none;
 }
 
 body {

--- a/extensions/markdown-language-features/package.json
+++ b/extensions/markdown-language-features/package.json
@@ -502,7 +502,7 @@
           "type": "boolean",
           "scope": "resource",
           "markdownDescription": "%configuration.markdown.editor.pasteUrlAsFormattedLink.enabled%",
-          "default": true
+          "default": false
         },
         "markdown.validate.enabled": {
           "type": "boolean",

--- a/extensions/markdown-language-features/src/languageFeatures/copyFiles/shared.ts
+++ b/extensions/markdown-language-features/src/languageFeatures/copyFiles/shared.ts
@@ -17,6 +17,11 @@ enum MediaKind {
 	Audio,
 }
 
+const externalUriSchemes = [
+	'http',
+	'https',
+];
+
 export const mediaFileExtensions = new Map<string, MediaKind>([
 	// Images
 	['bmp', MediaKind.Image],
@@ -161,7 +166,12 @@ export function createUriListSnippet(
 				insertedLinkCount++;
 				snippet.appendText('[');
 				snippet.appendPlaceholder(escapeBrackets(title) || 'Title', placeholderValue);
-				snippet.appendText(`](${escapeMarkdownLinkPath(mdPath)})`);
+				if (externalUriSchemes.includes(uri.scheme)) {
+					const uriString = uri.toString(true);
+					snippet.appendText(`](${uriString})`);
+				} else {
+					snippet.appendText(`](${escapeMarkdownLinkPath(mdPath)})`);
+				}
 			}
 		}
 
@@ -292,7 +302,6 @@ function escapeMarkdownLinkPath(mdPath: string): string {
 
 function escapeBrackets(value: string): string {
 	value = value.replace(/[\[\]]/g, '\\$&');
-	// value = value.replace(/\r\n\r\n/g, '\n\n');
 	return value;
 }
 

--- a/extensions/markdown-language-features/src/preview/documentRenderer.ts
+++ b/extensions/markdown-language-features/src/preview/documentRenderer.ts
@@ -103,7 +103,7 @@ export class MdDocumentRenderer {
 				${this._getStyles(resourceProvider, sourceUri, config, imageInfo)}
 				<base href="${resourceProvider.asWebviewUri(markdownDocument.uri)}">
 			</head>
-			<body class="vscode-body style="overscroll-behavior-x: none;" ${config.scrollBeyondLastLine ? 'scrollBeyondLastLine' : ''} ${config.wordWrap ? 'wordWrap' : ''} ${config.markEditorSelection ? 'showEditorSelection' : ''}">
+			<body class="vscode-body ${config.scrollBeyondLastLine ? 'scrollBeyondLastLine' : ''} ${config.wordWrap ? 'wordWrap' : ''} ${config.markEditorSelection ? 'showEditorSelection' : ''}">
 				${body.html}
 				${this._getScripts(resourceProvider, nonce)}
 			</body>

--- a/extensions/package.json
+++ b/extensions/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "description": "Dependencies shared by all extensions",
   "dependencies": {
-    "typescript": "5.1.3"
+    "typescript": "5.1.6"
   },
   "scripts": {
     "postinstall": "node ./postinstall.mjs"

--- a/extensions/yarn.lock
+++ b/extensions/yarn.lock
@@ -228,10 +228,10 @@ to-regex-range@^5.0.1:
   dependencies:
     is-number "^7.0.0"
 
-typescript@5.1.3:
-  version "5.1.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.1.3.tgz#8d84219244a6b40b6fb2b33cc1c062f715b9e826"
-  integrity sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==
+typescript@5.1.6:
+  version "5.1.6"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.1.6.tgz#02f8ac202b6dad2c0dd5e0913745b47a37998274"
+  integrity sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==
 
 vscode-grammar-updater@^1.1.0:
   version "1.1.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "code-oss-dev",
   "version": "1.80.2",
-  "distro": "b12d0f94278d485affdf25a13a8563e0a792a7cc",
+  "distro": "bf3ffa1f97d095824c9611557eb1d09ba167b779",
   "author": {
     "name": "Microsoft Corporation"
   },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "code-oss-dev",
   "version": "1.80.0",
-  "distro": "4ec8f427013e8d904920b6bdd931e78344401c19",
+  "distro": "b12d0f94278d485affdf25a13a8563e0a792a7cc",
   "author": {
     "name": "Microsoft Corporation"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "code-oss-dev",
-  "version": "1.80.0",
+  "version": "1.80.1",
   "distro": "b12d0f94278d485affdf25a13a8563e0a792a7cc",
   "author": {
     "name": "Microsoft Corporation"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "code-oss-dev",
-  "version": "1.80.1",
+  "version": "1.80.2",
   "distro": "b12d0f94278d485affdf25a13a8563e0a792a7cc",
   "author": {
     "name": "Microsoft Corporation"

--- a/src/vs/editor/browser/widget/diffEditorWidget2/style.css
+++ b/src/vs/editor/browser/widget/diffEditorWidget2/style.css
@@ -78,12 +78,12 @@
 	border: 2px solid var(--vscode-diffEditor-move-border);
 }
 
-.monaco-editor .moved-blocks-lines {
+.monaco-diff-editor .moved-blocks-lines {
 	position: absolute;
 	pointer-events: none;
 }
 
-.monaco-editor .moved-blocks-lines path {
+.monaco-diff-editor .moved-blocks-lines path {
 	fill: none;
 	stroke: var(--vscode-diffEditor-move-border);
 	stroke-width: 2;

--- a/src/vs/editor/common/diff/algorithms/joinSequenceDiffs.ts
+++ b/src/vs/editor/common/diff/algorithms/joinSequenceDiffs.ts
@@ -52,7 +52,7 @@ export function joinSequenceDiffs(sequence1: ISequence, sequence2: ISequence, se
 
 	// First move them all to the left as much as possible and join them if possible
 	for (let i = 1; i < sequenceDiffs.length; i++) {
-		const prevResult = sequenceDiffs[i - 1];
+		const prevResult = result[result.length - 1];
 		let cur = sequenceDiffs[i];
 
 		if (cur.seq1Range.isEmpty || cur.seq2Range.isEmpty) {

--- a/src/vs/editor/contrib/snippet/browser/snippetController2.ts
+++ b/src/vs/editor/contrib/snippet/browser/snippetController2.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { KeyCode, KeyMod } from 'vs/base/common/keyCodes';
-import { Disposable, DisposableStore, IDisposable } from 'vs/base/common/lifecycle';
+import { DisposableStore, IDisposable } from 'vs/base/common/lifecycle';
 import { assertType } from 'vs/base/common/types';
 import { ICodeEditor } from 'vs/editor/browser/editorBrowser';
 import { EditorCommand, EditorContributionInstantiation, registerEditorCommand, registerEditorContribution } from 'vs/editor/browser/editorExtensions';
@@ -188,10 +188,10 @@ export class SnippetController2 implements IEditorContribution {
 
 			const model = this._editor.getModel();
 
-			let registration: IDisposable = Disposable.None;
+			let registration: IDisposable | undefined;
 			let isRegistered = false;
 			const disable = () => {
-				registration.dispose();
+				registration?.dispose();
 				isRegistered = false;
 			};
 
@@ -203,11 +203,11 @@ export class SnippetController2 implements IEditorContribution {
 						scheme: model.uri.scheme,
 						exclusive: true
 					}, provider);
+					this._snippetListener.add(registration);
 					isRegistered = true;
 				}
 			};
 
-			this._snippetListener.add(registration);
 			this._choiceCompletions = { provider, enable, disable };
 		}
 

--- a/src/vs/platform/extensionManagement/common/abstractExtensionManagementService.ts
+++ b/src/vs/platform/extensionManagement/common/abstractExtensionManagementService.ts
@@ -436,8 +436,8 @@ export abstract class AbstractExtensionManagementService extends Disposable impl
 						try {
 							compatible = await this.checkAndGetCompatibleVersion(galleryExtension, false, installPreRelease);
 						} catch (error) {
-							if (error instanceof ExtensionManagementError && error.code === ExtensionManagementErrorCode.IncompatibleTargetPlatform && !isDependency) {
-								this.logService.info('Skipping the packed extension as it cannot be installed', galleryExtension.identifier.id);
+							if (!isDependency) {
+								this.logService.info('Skipping the packed extension as it cannot be installed', galleryExtension.identifier.id, getErrorMessage(error));
 								continue;
 							} else {
 								throw error;

--- a/src/vs/platform/terminal/common/environmentVariableCollection.ts
+++ b/src/vs/platform/terminal/common/environmentVariableCollection.ts
@@ -138,25 +138,24 @@ export class MergedEnvironmentVariableCollection implements IMergedEnvironmentVa
 
 	getVariableMap(scope: EnvironmentVariableScope | undefined): Map<string, IExtensionOwnedEnvironmentVariableMutator[]> {
 		const result = new Map<string, IExtensionOwnedEnvironmentVariableMutator[]>();
-		this.map.forEach((mutators, _key) => {
+		for (const mutators of this.map.values()) {
 			const filteredMutators = mutators.filter(m => filterScope(m, scope));
 			if (filteredMutators.length > 0) {
 				// All of these mutators are for the same variable because they are in the same scope, hence choose anyone to form a key.
 				result.set(filteredMutators[0].variable, filteredMutators);
 			}
-		});
+		}
 		return result;
 	}
 
 	getDescriptionMap(scope: EnvironmentVariableScope | undefined): Map<string, string | undefined> {
 		const result = new Map<string, string | undefined>();
-		this.descriptionMap.forEach((mutators, _key) => {
+		for (const mutators of this.descriptionMap.values()) {
 			const filteredMutators = mutators.filter(m => filterScope(m, scope, true));
-			if (filteredMutators.length > 0) {
-				// There should be exactly one description per extension per scope.
-				result.set(filteredMutators[0].extensionIdentifier, filteredMutators[0].description);
+			for (const mutator of filteredMutators) {
+				result.set(mutator.extensionIdentifier, mutator.description);
 			}
-		});
+		}
 		return result;
 	}
 

--- a/src/vs/workbench/contrib/terminal/browser/terminalView.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalView.ts
@@ -125,17 +125,9 @@ export class TerminalViewPane extends ViewPane {
 		return (decorationsEnabled === 'both' || decorationsEnabled === 'gutter') && this._configurationService.getValue(TerminalSettingId.ShellIntegrationEnabled);
 	}
 
-	private _initializeTerminal(checkRestoredTerminals: boolean) {
-		if (this.isBodyVisible() && this._terminalService.isProcessSupportRegistered && this._terminalService.connectionState === TerminalConnectionState.Connected) {
-			let shouldCreate = this._terminalGroupService.groups.length === 0;
-			// When triggered just after reconnection, also check there are no groups that could be
-			// getting restored currently
-			if (checkRestoredTerminals) {
-				shouldCreate &&= this._terminalService.restoredGroupCount === 0;
-			}
-			if (shouldCreate) {
-				this._terminalService.createTerminal({ location: TerminalLocation.Panel });
-			}
+	private _initializeTerminal() {
+		if (this.isBodyVisible() && this._terminalService.isProcessSupportRegistered && this._terminalService.connectionState === TerminalConnectionState.Connected && this._terminalService.restoredGroupCount === 0 && this._terminalGroupService.groups.length === 0) {
+			this._terminalService.createTerminal({ location: TerminalLocation.Panel });
 		}
 	}
 
@@ -175,7 +167,7 @@ export class TerminalViewPane extends ViewPane {
 				if (!this._terminalService.isProcessSupportRegistered) {
 					this._onDidChangeViewWelcomeState.fire();
 				}
-				this._initializeTerminal(false);
+				this._initializeTerminal();
 				// we don't know here whether or not it should be focused, so
 				// defer focusing the panel to the focus() call
 				// to prevent overriding preserveFocus for extensions
@@ -187,7 +179,7 @@ export class TerminalViewPane extends ViewPane {
 			}
 			this._terminalGroupService.updateVisibility();
 		}));
-		this._register(this._terminalService.onDidChangeConnectionState(() => this._initializeTerminal(true)));
+		this._register(this._terminalService.onDidChangeConnectionState(() => this._initializeTerminal()));
 		this.layoutBody(this._parentDomElement.offsetHeight, this._parentDomElement.offsetWidth);
 	}
 

--- a/src/vs/workbench/contrib/terminal/browser/terminalView.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalView.ts
@@ -125,9 +125,17 @@ export class TerminalViewPane extends ViewPane {
 		return (decorationsEnabled === 'both' || decorationsEnabled === 'gutter') && this._configurationService.getValue(TerminalSettingId.ShellIntegrationEnabled);
 	}
 
-	private _initializeTerminal() {
-		if (this.isBodyVisible() && this._terminalService.isProcessSupportRegistered && this._terminalService.connectionState === TerminalConnectionState.Connected && this._terminalService.restoredGroupCount === 0 && this._terminalGroupService.groups.length === 0) {
-			this._terminalService.createTerminal({ location: TerminalLocation.Panel });
+	private _initializeTerminal(checkRestoredTerminals: boolean) {
+		if (this.isBodyVisible() && this._terminalService.isProcessSupportRegistered && this._terminalService.connectionState === TerminalConnectionState.Connected) {
+			let shouldCreate = this._terminalGroupService.groups.length === 0;
+			// When triggered just after reconnection, also check there are no groups that could be
+			// getting restored currently
+			if (checkRestoredTerminals) {
+				shouldCreate &&= this._terminalService.restoredGroupCount === 0;
+			}
+			if (shouldCreate) {
+				this._terminalService.createTerminal({ location: TerminalLocation.Panel });
+			}
 		}
 	}
 
@@ -167,7 +175,7 @@ export class TerminalViewPane extends ViewPane {
 				if (!this._terminalService.isProcessSupportRegistered) {
 					this._onDidChangeViewWelcomeState.fire();
 				}
-				this._initializeTerminal();
+				this._initializeTerminal(false);
 				// we don't know here whether or not it should be focused, so
 				// defer focusing the panel to the focus() call
 				// to prevent overriding preserveFocus for extensions
@@ -179,7 +187,7 @@ export class TerminalViewPane extends ViewPane {
 			}
 			this._terminalGroupService.updateVisibility();
 		}));
-		this._register(this._terminalService.onDidChangeConnectionState(() => this._initializeTerminal()));
+		this._register(this._terminalService.onDidChangeConnectionState(() => this._initializeTerminal(true)));
 		this.layoutBody(this._parentDomElement.offsetHeight, this._parentDomElement.offsetWidth);
 	}
 

--- a/src/vs/workbench/contrib/terminal/common/terminalConfiguration.ts
+++ b/src/vs/workbench/contrib/terminal/common/terminalConfiguration.ts
@@ -587,7 +587,7 @@ const terminalConfiguration: IConfigurationNode = {
 		},
 		[TerminalSettingId.EnableImages]: {
 			restricted: true,
-			markdownDescription: localize('terminal.integrated.enableImages', "Enables image support in the terminal. Both sixel and iTerm's inline image protocol are supported on Linux and macOS, Windows support will light up automatically when ConPTY passes through the sequences. Images will currently not be restored between window reloads/reconnects."),
+			markdownDescription: localize('terminal.integrated.enableImages', "Enables image support in the terminal, this will only work when {0} is enabled. Both sixel and iTerm's inline image protocol are supported on Linux and macOS, Windows support will light up automatically when ConPTY passes through the sequences. Images will currently not be restored between window reloads/reconnects.", `\`#${TerminalSettingId.GpuAcceleration}#\``),
 			type: 'boolean',
 			default: true
 		},

--- a/src/vs/workbench/services/hover/browser/hover.ts
+++ b/src/vs/workbench/services/hover/browser/hover.ts
@@ -139,6 +139,7 @@ export interface IHoverOptions {
 	 * Whether to trap focus in the following ways:
 	 * - When the hover closes, focus goes to the element that had focus before the hover opened
 	 * - If there are elements in the hover to focus, focus stays inside of the hover when tabbing
+	 * Note that this is overridden to true when in screen reader optimized mode.
 	 */
 	trapFocus?: boolean;
 

--- a/src/vs/workbench/services/hover/browser/hoverService.ts
+++ b/src/vs/workbench/services/hover/browser/hoverService.ts
@@ -17,6 +17,7 @@ import { addDisposableListener, EventType } from 'vs/base/browser/dom';
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 import { StandardKeyboardEvent } from 'vs/base/browser/keyboardEvent';
 import { ResultKind } from 'vs/platform/keybinding/common/keybindingResolver';
+import { IAccessibilityService } from 'vs/platform/accessibility/common/accessibility';
 
 export class HoverService implements IHoverService {
 	declare readonly _serviceBrand: undefined;
@@ -30,22 +31,27 @@ export class HoverService implements IHoverService {
 		@IInstantiationService private readonly _instantiationService: IInstantiationService,
 		@IContextViewService private readonly _contextViewService: IContextViewService,
 		@IContextMenuService contextMenuService: IContextMenuService,
-		@IKeybindingService private readonly _keybindingService: IKeybindingService
+		@IKeybindingService private readonly _keybindingService: IKeybindingService,
+		@IAccessibilityService private readonly _accessibilityService: IAccessibilityService
 	) {
 		contextMenuService.onDidShowContextMenu(() => this.hideHover());
 	}
 
-	showHover(options: IHoverOptions, focus?: boolean): IHoverWidget | undefined {
+	showHover(options: Readonly<IHoverOptions>, focus?: boolean): IHoverWidget | undefined {
 		if (getHoverOptionsIdentity(this._currentHoverOptions) === getHoverOptionsIdentity(options)) {
 			return undefined;
 		}
 		this._currentHoverOptions = options;
-		if (options.trapFocus && document.activeElement) {
-			this._lastFocusedElementBeforeOpen = document.activeElement as HTMLElement;
-		} else {
-			this._lastFocusedElementBeforeOpen = undefined;
+		this._lastHoverOptions = options;
+		const trapFocus = options.trapFocus || this._accessibilityService.isScreenReaderOptimized();
+		// HACK, remove this check when #189076 is fixed
+		if (!skipLastFocusedUpdate) {
+			if (trapFocus && document.activeElement) {
+				this._lastFocusedElementBeforeOpen = document.activeElement as HTMLElement;
+			} else {
+				this._lastFocusedElementBeforeOpen = undefined;
+			}
 		}
-
 		const hoverDisposables = new DisposableStore();
 		const hover = this._instantiationService.createInstance(HoverWidget, options);
 		hover.onDispose(() => {
@@ -106,6 +112,13 @@ export class HoverService implements IHoverService {
 		if (!entry.isIntersecting) {
 			hover.dispose();
 		}
+	}
+
+	showAndFocusLastHover(): void {
+		if (!this._lastHoverOptions) {
+			return;
+		}
+		this.showHover(this._lastHoverOptions, true);
 	}
 
 	private _keyDown(e: KeyboardEvent, hover: HoverWidget, hideOnKeyDown: boolean) {


### PR DESCRIPTION
fixes #188822

When a SR user opens the accessible view for a workbench hover and presses escape, the hover is focused. Pressing escape again should have refocused the previously focused element, but was not.

This was because:
1) When `show` is called on the `HoverService`, the previously focused element is only cached if the option of `trapFocus` is passed in. That was not the case for some examples - like in the GHPR view. We should always trap focus when `show` is called and screen reader optimized mode is enabled so users don't lose context.
2) Because we cannot have multiple context views open simultaneously, tracked here #189076, we have to call `show` of the hover again when the accessible view is escaped. If the cached `lastFocusedElement` is overridden with this call, we lose context. So the fix is to check if `show` is as a result of this case and skip setting that if so.