### PR TITLE
Ignore powerline symbols in word links

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/links/browser/terminalWordLinkDetector.ts
+++ b/src/vs/workbench/contrib/terminalContrib/links/browser/terminalWordLinkDetector.ts
@@ -127,6 +127,10 @@ export class TerminalWordLinkDetector extends Disposable implements ITerminalLin
 
 	private _refreshSeparatorCodes(): void {
 		const separators = this._configurationService.getValue<ITerminalConfiguration>(TERMINAL_CONFIG_SECTION).wordSeparators;
-		this._separatorRegex = new RegExp(`[${escapeRegExpCharacters(separators)}]`, 'g');
+		let powerlineSymbols = '';
+		for (let i = 0xe0b0; i <= 0xe0bf; i++) {
+			powerlineSymbols += String.fromCharCode(i);
+		}
+		this._separatorRegex = new RegExp(`[${escapeRegExpCharacters(separators)}${powerlineSymbols}]`, 'g');
 	}
 }

--- a/src/vs/workbench/contrib/terminalContrib/links/test/browser/terminalWordLinkDetector.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/links/test/browser/terminalWordLinkDetector.test.ts
@@ -72,6 +72,14 @@ suite('Workbench - TerminalWordLinkDetector', () => {
 		});
 	});
 
+	suite('should ignore powerline symbols', () => {
+		for (let i = 0xe0b0; i <= 0xe0bf; i++) {
+			test(`\\u${i.toString(16)}`, async () => {
+				await assertLink(`${String.fromCharCode(i)}foo${String.fromCharCode(i)}`, [{ range: [[2, 1], [4, 1]], text: 'foo' }]);
+			});
+		}
+	});
+
 	// These are failing - the link's start x is 1 px too far to the right bc it starts
 	// with a wide character, which the terminalLinkHelper currently doesn't account for
 	test.skip('should support wide characters', async () => {


### PR DESCRIPTION
Fixes #189222
![image](https://github.com/microsoft/vscode/assets/2193314/bd03cea1-bf8b-4324-a747-8c2d79c44efc)

![image](https://github.com/microsoft/vscode/assets/2193314/9fc31ae0-97f5-4b8d-8c38-b01622228a7b)
