### PR TITLE
Show viewport links immediately, all links on filter

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/links/browser/terminal.links.contribution.ts
+++ b/src/vs/workbench/contrib/terminalContrib/links/browser/terminal.links.contribution.ts
@@ -78,18 +78,15 @@ class TerminalLinkContribution extends DisposableStore implements ITerminalContr
 				this.showLinkQuickpick(true);
 			});
 		}
-		const links = await this._getLinks(extended);
-		if (!links) {
-			return;
-		}
+		const links = await this._getLinks();
 		return await this._terminalLinkQuickpick.show(links);
 	}
 
-	private async _getLinks(extended?: boolean): Promise<IDetectedLinks | undefined> {
+	private async _getLinks(): Promise<{ viewport: IDetectedLinks; all: Promise<IDetectedLinks> }> {
 		if (!this._linkManager) {
 			throw new Error('terminal links are not ready, cannot generate link quick pick');
 		}
-		return this._linkManager.getLinks(extended);
+		return this._linkManager.getLinks();
 	}
 
 	async openRecentLink(type: 'localFile' | 'url'): Promise<void> {

--- a/src/vs/workbench/contrib/terminalContrib/links/test/browser/terminalLinkManager.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/links/test/browser/terminalLinkManager.test.ts
@@ -103,9 +103,9 @@ suite('TerminalLinkManager', () => {
 	suite('getLinks and open recent link', () => {
 		test('should return no links', async () => {
 			const links = await linkManager.getLinks();
-			equals(links.webLinks, []);
-			equals(links.wordLinks, []);
-			equals(links.fileLinks, []);
+			equals(links.viewport.webLinks, []);
+			equals(links.viewport.wordLinks, []);
+			equals(links.viewport.fileLinks, []);
 			const webLink = await linkManager.openRecentLink('url');
 			strictEqual(webLink, undefined);
 			const fileLink = await linkManager.openRecentLink('localFile');
@@ -128,8 +128,8 @@ suite('TerminalLinkManager', () => {
 			};
 			linkManager.setLinks({ wordLinks: [link1, link2] });
 			const links = await linkManager.getLinks();
-			deepStrictEqual(links.wordLinks?.[0].text, link2.text);
-			deepStrictEqual(links.wordLinks?.[1].text, link1.text);
+			deepStrictEqual(links.viewport.wordLinks?.[0].text, link2.text);
+			deepStrictEqual(links.viewport.wordLinks?.[1].text, link1.text);
 			const webLink = await linkManager.openRecentLink('url');
 			strictEqual(webLink, undefined);
 			const fileLink = await linkManager.openRecentLink('localFile');
@@ -148,8 +148,8 @@ suite('TerminalLinkManager', () => {
 			};
 			linkManager.setLinks({ webLinks: [link1, link2] });
 			const links = await linkManager.getLinks();
-			deepStrictEqual(links.webLinks?.[0].text, link2.text);
-			deepStrictEqual(links.webLinks?.[1].text, link1.text);
+			deepStrictEqual(links.viewport.webLinks?.[0].text, link2.text);
+			deepStrictEqual(links.viewport.webLinks?.[1].text, link1.text);
 			const webLink = await linkManager.openRecentLink('url');
 			strictEqual(webLink, link2);
 			const fileLink = await linkManager.openRecentLink('localFile');
@@ -168,8 +168,8 @@ suite('TerminalLinkManager', () => {
 			};
 			linkManager.setLinks({ fileLinks: [link1, link2] });
 			const links = await linkManager.getLinks();
-			deepStrictEqual(links.fileLinks?.[0].text, link2.text);
-			deepStrictEqual(links.fileLinks?.[1].text, link1.text);
+			deepStrictEqual(links.viewport.fileLinks?.[0].text, link2.text);
+			deepStrictEqual(links.viewport.fileLinks?.[1].text, link1.text);
 			const webLink = await linkManager.openRecentLink('url');
 			strictEqual(webLink, undefined);
 			linkManager.setLinks({ fileLinks: [link2] });


### PR DESCRIPTION
This also de-duplicates word links when they are shown in other categories and shows categories on filter.

Fixes #188108

---

Initial open (almost instant):

![image](https://github.com/microsoft/vscode/assets/2193314/1cb1f8bd-3ffc-45e9-b080-eb28621846c5)

Filtering shows whole buffer's results (may take time to come in due to potentially many FS checks):

![image](https://github.com/microsoft/vscode/assets/2193314/bbcf0891-c855-4188-b405-5a18f0812c3f)

All results show if you clear the filter:

![image](https://github.com/microsoft/vscode/assets/2193314/b8f36fe9-7df0-4033-9734-db92dd229f87)
