### PR TITLE
Custom context menu runs or selects action under mouse when opened (fix #189167)

### DIFF
--- a/src/vs/base/browser/ui/contextview/contextview.ts
+++ b/src/vs/base/browser/ui/contextview/contextview.ts
@@ -296,7 +296,11 @@ export class ContextView extends Disposable {
 			around = {
 				top: anchor.posy,
 				left: anchor.posx,
-				width: 1,
+				// We are about to position the context view where the mouse
+				// cursor is. To prevent the view being exactly under the mouse
+				// when showing and thus potentially triggering an action within,
+				// we treat the mouse location like a small sized block element.
+				width: 2,
 				height: 2
 			};
 		}


### PR DESCRIPTION
The refactoring in context menu changed a semantic in custom context menus that now lead to #189167. Previously we had a `width: 2` hardcoded when opening menus from the editor:

https://github.com/microsoft/vscode/blob/252e5463d60e63238250799aef7375787f68b4ee/src/vs/editor/contrib/contextmenu/browser/contextmenu.ts#L106

This puts the custom menu sufficiently enough away from the mouse cursor to prevent accidental click on open.

This change brings that back but in the place where we deal with all context menus from anywhere, e.g. including the explorer.