### PR TITLE
Fix recently-broken cleanup of obsolete (superseded) extension folders

### DIFF
--- a/src/vs/platform/extensionManagement/node/extensionManagementService.ts
+++ b/src/vs/platform/extensionManagement/node/extensionManagementService.ts
@@ -570,7 +570,7 @@ export class ExtensionsScanner extends Disposable {
 	}
 
 	async removeExtension(extension: ILocalExtension | IScannedExtension, type: string): Promise<void> {
-		if (this.uriIdentityService.extUri.isEqualOrParent(this.extensionsScannerService.userExtensionsLocation, extension.location)) {
+		if (this.uriIdentityService.extUri.isEqualOrParent(extension.location, this.extensionsScannerService.userExtensionsLocation)) {
 			return this.deleteExtensionFromLocation(extension.identifier.id, extension.location, type);
 		}
 	}


### PR DESCRIPTION
This PR fixes #189334

@andreamah I think the fix deserves to be a candidate for upcoming 1.81
