### PR TITLE
Links are not automatically pasted as Markdown link if nothing is selected

### DIFF
--- a/extensions/markdown-language-features/src/languageFeatures/copyFiles/shared.ts
+++ b/extensions/markdown-language-features/src/languageFeatures/copyFiles/shared.ts
@@ -151,6 +151,9 @@ export async function createEditAddingLinksForUriList(
 
 export function checkSmartPaste(document: SkinnyTextDocument, selectedRange: vscode.Range): SmartPaste {
 	const SmartPaste: SmartPaste = { pasteAsMarkdownLink: true, updateTitle: false };
+	if (selectedRange.isEmpty || /^[\s\n]*$/.test(document.getText(selectedRange))) {
+		return { pasteAsMarkdownLink: false, updateTitle: false };
+	}
 	for (const regex of smartPasteRegexes) {
 		const matches = [...document.getText().matchAll(regex.regex)];
 		for (const match of matches) {

--- a/extensions/markdown-language-features/src/test/markdownLink.test.ts
+++ b/extensions/markdown-language-features/src/test/markdownLink.test.ts
@@ -148,9 +148,22 @@ suite('createEditAddingLinksForUriList', () => {
 		};
 
 		test('Should evaluate pasteAsMarkdownLink as true for selected plain text', () => {
-			const range = new vscode.Range(0, 5, 0, 5);
+			const range = new vscode.Range(0, 0, 0, 12);
 			const smartPaste = checkSmartPaste(skinnyDocument, range);
 			assert.strictEqual(smartPaste.pasteAsMarkdownLink, true);
+		});
+
+		test('Should evaluate pasteAsMarkdownLink as false for no selection', () => {
+			const range = new vscode.Range(0, 0, 0, 0);
+			const smartPaste = checkSmartPaste(skinnyDocument, range);
+			assert.strictEqual(smartPaste.pasteAsMarkdownLink, false);
+		});
+
+		test('Should evaluate pasteAsMarkdownLink as false for selected whitespace and new lines', () => {
+			skinnyDocument.getText = function () { return '   \r\n\r\n'; };
+			const range = new vscode.Range(0, 0, 0, 7);
+			const smartPaste = checkSmartPaste(skinnyDocument, range);
+			assert.strictEqual(smartPaste.pasteAsMarkdownLink, false);
 		});
 
 		test('Should evaluate pasteAsMarkdownLink as false for pasting within a backtick code block', () => {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

If nothing (or whitespace or new lines) is selected, the link will paste as plain text: https://github.com/microsoft/vscode/issues/188871

However, if a markdown link is selected, the link will be pasted as a markdown link with a default 'Title.' I will change this so that plain text is pasted.
