### PR TITLE
fix nb-sticky css

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/media/notebookEditorStickyScroll.css
+++ b/src/vs/workbench/contrib/notebook/browser/media/notebookEditorStickyScroll.css
@@ -11,6 +11,13 @@
 	width: 100%;
 	font-family: var(--notebook-cell-input-preview-font-family);
 }
+
+.monaco-workbench.hc-light .notebookOverlay .notebook-sticky-scroll-container,
+.monaco-workbench.hc-black .notebookOverlay .notebook-sticky-scroll-container {
+	background-color: var(--vscode-editorStickyScroll-background);
+	border-bottom: 1px solid var(--vscode-contrastBorder);
+}
+
 .monaco-workbench
 	.notebookOverlay
 	.notebook-sticky-scroll-container


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

fix: #189195

fixes styling for `hc-light` and `hc-black` themes in vscode. Adds background color and bottom border to sticky-container.