### PR TITLE
Fix comment typo in standaloneLanguages.ts

### DIFF
--- a/src/vs/editor/standalone/browser/standaloneLanguages.ts
+++ b/src/vs/editor/standalone/browser/standaloneLanguages.ts
@@ -70,7 +70,7 @@ export function onLanguage(languageId: string, callback: () => void): IDisposabl
 
 /**
  * An event emitted when a language is associated for the first time with a text model or
- * whena language is encountered during the tokenization of another language.
+ * when a language is encountered during the tokenization of another language.
  * @event
  */
 export function onLanguageEncountered(languageId: string, callback: () => void): IDisposable {

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -6241,7 +6241,7 @@ declare namespace monaco.languages {
 
 	/**
 	 * An event emitted when a language is associated for the first time with a text model or
-	 * whena language is encountered during the tokenization of another language.
+	 * when a language is encountered during the tokenization of another language.
 	 * @event
 	 */
 	export function onLanguageEncountered(languageId: string, callback: () => void): IDisposable;

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -6241,7 +6241,7 @@ declare namespace monaco.languages {
 
 	/**
 	 * An event emitted when a language is associated for the first time with a text model or
-	 * when a language is encountered during the tokenization of another language.
+	 * whena language is encountered during the tokenization of another language.
 	 * @event
 	 */
 	export function onLanguageEncountered(languageId: string, callback: () => void): IDisposable;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

~I just fixed comment typo in `src/vs/monaco.d.ts`.~

Actually , the file is generated automatically. Instead of that, fix a comment in `src/vs/editor/standalone/browser/standaloneLanguages.ts`

I know it's not a big deal, so close it if it's annoying.
