### PR TITLE
Honor `--disable-keytar` and fix event handling in the browser

### DIFF
--- a/src/vs/platform/secrets/common/secrets.ts
+++ b/src/vs/platform/secrets/common/secrets.ts
@@ -10,7 +10,6 @@ import { IStorageService, InMemoryStorageService, StorageScope, StorageTarget } 
 import { Emitter, Event } from 'vs/base/common/event';
 import { ILogService } from 'vs/platform/log/common/log';
 import { DisposableStore } from 'vs/base/common/lifecycle';
-import { Lazy } from 'vs/base/common/lazy';
 
 export const ISecretStorageService = createDecorator<ISecretStorageService>('secretStorageService');
 
@@ -26,13 +25,13 @@ export interface ISecretStorageService extends ISecretStorageProvider {
 	onDidChangeSecret: Event<string>;
 }
 
-export abstract class BaseSecretStorageService implements ISecretStorageService {
+export class BaseSecretStorageService implements ISecretStorageService {
 	declare readonly _serviceBrand: undefined;
 
-	private _storagePrefix = 'secret://';
+	private readonly _storagePrefix = 'secret://';
 
-	private readonly _onDidChangeSecret = new Emitter<string>();
-	onDidChangeSecret: Event<string> = this._onDidChangeSecret.event;
+	protected readonly onDidChangeSecretEmitter = new Emitter<string>();
+	onDidChangeSecret: Event<string> = this.onDidChangeSecretEmitter.event;
 
 	protected readonly _sequencer = new SequencerByKey<string>();
 
@@ -40,7 +39,10 @@ export abstract class BaseSecretStorageService implements ISecretStorageService 
 
 	private readonly _onDidChangeValueDisposable = new DisposableStore();
 
+	protected resolvedStorageService = this.initialize();
+
 	constructor(
+		private readonly _useInMemoryStorage: boolean,
 		@IStorageService private _storageService: IStorageService,
 		@IEncryptionService protected _encryptionService: IEncryptionService,
 		@ILogService protected readonly _logService: ILogService
@@ -48,11 +50,6 @@ export abstract class BaseSecretStorageService implements ISecretStorageService 
 
 	get type() {
 		return this._type;
-	}
-
-	private lazyStorageService: Lazy<Promise<IStorageService>> = new Lazy(() => this.initialize());
-	protected get resolvedStorageService() {
-		return this.lazyStorageService.value;
 	}
 
 	private onDidChangeValue(key: string): void {
@@ -63,7 +60,7 @@ export abstract class BaseSecretStorageService implements ISecretStorageService 
 		const secretKey = key.slice(this._storagePrefix.length);
 
 		this._logService.trace(`[SecretStorageService] Notifying change in value for secret: ${secretKey}`);
-		this._onDidChangeSecret.fire(secretKey);
+		this.onDidChangeSecretEmitter.fire(secretKey);
 	}
 
 	get(key: string): Promise<string | undefined> {
@@ -80,7 +77,10 @@ export abstract class BaseSecretStorageService implements ISecretStorageService 
 
 			try {
 				this._logService.trace('[secrets] decrypting gotten secret for key:', fullKey);
-				const result = await this._encryptionService.decrypt(encrypted);
+				// If the storage service is in-memory, we don't need to decrypt
+				const result = this._type === 'in-memory'
+					? encrypted
+					: await this._encryptionService.decrypt(encrypted);
 				this._logService.trace('[secrets] decrypted secret for key:', fullKey);
 				return result;
 			} catch (e) {
@@ -98,7 +98,10 @@ export abstract class BaseSecretStorageService implements ISecretStorageService 
 			this._logService.trace('[secrets] encrypting secret for key:', key);
 			let encrypted;
 			try {
-				encrypted = await this._encryptionService.encrypt(value);
+				// If the storage service is in-memory, we don't need to encrypt
+				encrypted = this._type === 'in-memory'
+					? value
+					: await this._encryptionService.encrypt(value);
 			} catch (e) {
 				this._logService.error(e);
 				throw e;
@@ -123,10 +126,14 @@ export abstract class BaseSecretStorageService implements ISecretStorageService 
 
 	private async initialize(): Promise<IStorageService> {
 		let storageService;
-		if (await this._encryptionService.isEncryptionAvailable()) {
+		if (!this._useInMemoryStorage && await this._encryptionService.isEncryptionAvailable()) {
 			this._type = 'persisted';
 			storageService = this._storageService;
 		} else {
+			// If we already have an in-memory storage service, we don't need to recreate it
+			if (this._type === 'in-memory') {
+				return this._storageService;
+			}
 			this._logService.trace('[SecretStorageService] Encryption is not available, falling back to in-memory storage');
 			this._type = 'in-memory';
 			storageService = new InMemoryStorageService();
@@ -140,7 +147,7 @@ export abstract class BaseSecretStorageService implements ISecretStorageService 
 	}
 
 	protected reinitialize(): void {
-		this.lazyStorageService = new Lazy(() => this.initialize());
+		this.resolvedStorageService = this.initialize();
 	}
 
 	private getKey(key: string): string {

--- a/src/vs/platform/secrets/test/common/secrets.test.ts
+++ b/src/vs/platform/secrets/test/common/secrets.test.ts
@@ -1,0 +1,197 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+import { timeout } from 'vs/base/common/async';
+import { IEncryptionService, KnownStorageProvider } from 'vs/platform/encryption/common/encryptionService';
+import { NullLogService } from 'vs/platform/log/common/log';
+import { BaseSecretStorageService } from 'vs/platform/secrets/common/secrets';
+import { InMemoryStorageService } from 'vs/platform/storage/common/storage';
+
+class TestEncryptionService implements IEncryptionService {
+	_serviceBrand: undefined;
+	private encryptedPrefix = 'encrypted+'; // prefix to simulate encryption
+	setUsePlainTextEncryption(): Promise<void> {
+		return Promise.resolve();
+	}
+	getKeyStorageProvider(): Promise<KnownStorageProvider> {
+		return Promise.resolve(KnownStorageProvider.basicText);
+	}
+	encrypt(value: string): Promise<string> {
+		return Promise.resolve(this.encryptedPrefix + value);
+	}
+	decrypt(value: string): Promise<string> {
+		return Promise.resolve(value.substring(this.encryptedPrefix.length));
+	}
+	isEncryptionAvailable(): Promise<boolean> {
+		return Promise.resolve(true);
+	}
+}
+
+class TestNoEncryptionService implements IEncryptionService {
+	_serviceBrand: undefined;
+	setUsePlainTextEncryption(): Promise<void> {
+		throw new Error('Method not implemented.');
+	}
+	getKeyStorageProvider(): Promise<KnownStorageProvider> {
+		throw new Error('Method not implemented.');
+	}
+	encrypt(value: string): Promise<string> {
+		throw new Error('Method not implemented.');
+	}
+	decrypt(value: string): Promise<string> {
+		throw new Error('Method not implemented.');
+	}
+	isEncryptionAvailable(): Promise<boolean> {
+		return Promise.resolve(false);
+	}
+}
+
+suite('secrets', () => {
+	suite('BaseSecretStorageService useInMemoryStorage=true', () => {
+		let service: BaseSecretStorageService;
+		let spyEncryptionService: sinon.SinonSpiedInstance<TestEncryptionService>;
+		let sandbox: sinon.SinonSandbox;
+
+		setup(() => {
+			sandbox = sinon.createSandbox();
+			spyEncryptionService = sandbox.spy(new TestEncryptionService());
+			service = new BaseSecretStorageService(true, new InMemoryStorageService(), spyEncryptionService, new NullLogService());
+		});
+
+		teardown(() => {
+			sandbox.restore();
+		});
+
+		test('type', async () => {
+			// allow initialization to complete
+			await timeout(0);
+			assert.strictEqual(service.type, 'in-memory');
+		});
+
+		test('set and get', async () => {
+			const key = 'my-secret';
+			const value = 'my-secret-value';
+			await service.set(key, value);
+			const result = await service.get(key);
+			assert.strictEqual(result, value);
+
+			// Additionally ensure the encryptionservice was not used
+			assert.strictEqual(spyEncryptionService.encrypt.callCount, 0);
+			assert.strictEqual(spyEncryptionService.decrypt.callCount, 0);
+		});
+
+		test('delete', async () => {
+			const key = 'my-secret';
+			const value = 'my-secret-value';
+			await service.set(key, value);
+			await service.delete(key);
+			const result = await service.get(key);
+			assert.strictEqual(result, undefined);
+		});
+
+		test('onDidChangeSecret', async () => {
+			const key = 'my-secret';
+			const value = 'my-secret-value';
+			let eventFired = false;
+			service.onDidChangeSecret((changedKey) => {
+				assert.strictEqual(changedKey, key);
+				eventFired = true;
+			});
+			await service.set(key, value);
+			assert.strictEqual(eventFired, true);
+		});
+	});
+
+	suite('BaseSecretStorageService useInMemoryStorage=false', () => {
+		let service: BaseSecretStorageService;
+		let spyEncryptionService: sinon.SinonSpiedInstance<TestEncryptionService>;
+		let sandbox: sinon.SinonSandbox;
+
+		setup(() => {
+			sandbox = sinon.createSandbox();
+			spyEncryptionService = sandbox.spy(new TestEncryptionService());
+			service = new BaseSecretStorageService(false, new InMemoryStorageService(), spyEncryptionService, new NullLogService());
+		});
+
+		teardown(() => {
+			sandbox.restore();
+		});
+
+		test('type', async () => {
+			// allow initialization to complete
+			await timeout(0);
+			assert.strictEqual(service.type, 'persisted');
+		});
+
+		test('set and get', async () => {
+			const key = 'my-secret';
+			const value = 'my-secret-value';
+			await service.set(key, value);
+			const result = await service.get(key);
+			assert.strictEqual(result, value);
+
+			// Additionally ensure the encryptionservice was not used
+			assert.strictEqual(spyEncryptionService.encrypt.callCount, 1);
+			assert.strictEqual(spyEncryptionService.decrypt.callCount, 1);
+		});
+
+		test('delete', async () => {
+			const key = 'my-secret';
+			const value = 'my-secret-value';
+			await service.set(key, value);
+			await service.delete(key);
+			const result = await service.get(key);
+			assert.strictEqual(result, undefined);
+		});
+
+		test('onDidChangeSecret', async () => {
+			const key = 'my-secret';
+			const value = 'my-secret-value';
+			let eventFired = false;
+			service.onDidChangeSecret((changedKey) => {
+				assert.strictEqual(changedKey, key);
+				eventFired = true;
+			});
+			await service.set(key, value);
+			assert.strictEqual(eventFired, true);
+		});
+	});
+
+	suite('BaseSecretStorageService useInMemoryStorage=false, encryption not available', () => {
+		let service: BaseSecretStorageService;
+		let spyNoEncryptionService: sinon.SinonSpiedInstance<TestEncryptionService>;
+		let sandbox: sinon.SinonSandbox;
+
+		setup(() => {
+			sandbox = sinon.createSandbox();
+			spyNoEncryptionService = sandbox.spy(new TestNoEncryptionService());
+			service = new BaseSecretStorageService(false, new InMemoryStorageService(), spyNoEncryptionService, new NullLogService());
+		});
+
+		teardown(() => {
+			sandbox.restore();
+		});
+
+		test('type', async () => {
+			// allow initialization to complete
+			await timeout(0);
+			assert.strictEqual(service.type, 'in-memory');
+		});
+
+		test('set and get', async () => {
+			const key = 'my-secret';
+			const value = 'my-secret-value';
+			await service.set(key, value);
+			const result = await service.get(key);
+			assert.strictEqual(result, value);
+
+			// Additionally ensure the encryptionservice was not used
+			assert.strictEqual(spyNoEncryptionService.encrypt.callCount, 0);
+			assert.strictEqual(spyNoEncryptionService.decrypt.callCount, 0);
+		});
+	});
+});

--- a/src/vs/workbench/services/secrets/browser/secretStorageService.ts
+++ b/src/vs/workbench/services/secrets/browser/secretStorageService.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { SequencerByKey } from 'vs/base/common/async';
 import { IEncryptionService } from 'vs/platform/encryption/common/encryptionService';
 import { InstantiationType, registerSingleton } from 'vs/platform/instantiation/common/extensions';
 import { ILogService } from 'vs/platform/log/common/log';
@@ -13,6 +14,7 @@ import { IBrowserWorkbenchEnvironmentService } from 'vs/workbench/services/envir
 export class BrowserSecretStorageService extends BaseSecretStorageService {
 
 	private readonly _secretStorageProvider: ISecretStorageProvider | undefined;
+	private readonly _embedderSequencer: SequencerByKey<string> | undefined;
 
 	constructor(
 		@IStorageService storageService: IStorageService,
@@ -20,16 +22,19 @@ export class BrowserSecretStorageService extends BaseSecretStorageService {
 		@IBrowserWorkbenchEnvironmentService environmentService: IBrowserWorkbenchEnvironmentService,
 		@ILogService logService: ILogService
 	) {
-		super(storageService, encryptionService, logService);
+		// We don't have encryption in the browser so instead we use the
+		// in-memory base class implementation instead.
+		super(true, storageService, encryptionService, logService);
 
 		if (environmentService.options?.secretStorageProvider) {
 			this._secretStorageProvider = environmentService.options.secretStorageProvider;
+			this._embedderSequencer = new SequencerByKey<string>();
 		}
 	}
 
 	override get(key: string): Promise<string | undefined> {
 		if (this._secretStorageProvider) {
-			return this._secretStorageProvider.get(key);
+			return this._embedderSequencer!.queue(key, () => this._secretStorageProvider!.get(key));
 		}
 
 		return super.get(key);
@@ -37,7 +42,10 @@ export class BrowserSecretStorageService extends BaseSecretStorageService {
 
 	override set(key: string, value: string): Promise<void> {
 		if (this._secretStorageProvider) {
-			return this._secretStorageProvider.set(key, value);
+			return this._embedderSequencer!.queue(key, async () => {
+				await this._secretStorageProvider!.set(key, value);
+				this.onDidChangeSecretEmitter.fire(key);
+			});
 		}
 
 		return super.set(key, value);
@@ -45,7 +53,10 @@ export class BrowserSecretStorageService extends BaseSecretStorageService {
 
 	override delete(key: string): Promise<void> {
 		if (this._secretStorageProvider) {
-			return this._secretStorageProvider.delete(key);
+			return this._embedderSequencer!.queue(key, async () => {
+				await this._secretStorageProvider!.delete(key);
+				this.onDidChangeSecretEmitter.fire(key);
+			});
 		}
 
 		return super.delete(key);

--- a/src/vs/workbench/services/secrets/electron-sandbox/secretStorageService.ts
+++ b/src/vs/workbench/services/secrets/electron-sandbox/secretStorageService.ts
@@ -9,7 +9,7 @@ import Severity from 'vs/base/common/severity';
 import { localize } from 'vs/nls';
 import { IDialogService } from 'vs/platform/dialogs/common/dialogs';
 import { IEncryptionService, KnownStorageProvider, PasswordStoreCLIOption, isGnome, isKwallet } from 'vs/platform/encryption/common/encryptionService';
-import { IEnvironmentService } from 'vs/platform/environment/common/environment';
+import { INativeEnvironmentService } from 'vs/platform/environment/common/environment';
 import { InstantiationType, registerSingleton } from 'vs/platform/instantiation/common/extensions';
 import { ILogService } from 'vs/platform/log/common/log';
 import { INotificationService, IPromptChoice } from 'vs/platform/notification/common/notification';
@@ -25,12 +25,18 @@ export class NativeSecretStorageService extends BaseSecretStorageService {
 		@IDialogService private readonly _dialogService: IDialogService,
 		@IOpenerService private readonly _openerService: IOpenerService,
 		@IJSONEditingService private readonly _jsonEditingService: IJSONEditingService,
-		@IEnvironmentService private readonly _environmentService: IEnvironmentService,
+		@INativeEnvironmentService private readonly _environmentService: INativeEnvironmentService,
 		@IStorageService storageService: IStorageService,
 		@IEncryptionService encryptionService: IEncryptionService,
 		@ILogService logService: ILogService
 	) {
-		super(storageService, encryptionService, logService);
+		super(
+			// TODO: rename disableKeytar to disableSecretStorage or similar
+			!!_environmentService.disableKeytar,
+			storageService,
+			encryptionService,
+			logService
+		);
 	}
 
 	override set(key: string, value: string): Promise<void> {


### PR DESCRIPTION
We have always had a way to disable reading from the keyring and use an in-memory secrets storage: `--disable-keytar`.

This honors that flag in the new SecretStorage world... in a follow up PR we will migrate that flag to `--disable-secret-storage`.

Additionally, I found a bug where we weren't firing events that we successfully set/deleted secrets in the browser version of secretStorageService and this fixes that by firing those events.

This also reverts https://github.com/microsoft/vscode/pull/189489 so that `BaseSecretStorageService.type` reads correctly early on... plus there's more discussion to be had in https://github.com/microsoft/vscode/issues/189481

Oh, and tests :rocket:

Fixes https://github.com/microsoft/vscode/issues/188432

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
