### PR TITLE
get terminal accessible help to show up when in accessible buffer

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/accessibility/browser/terminal.accessibility.contribution.ts
+++ b/src/vs/workbench/contrib/terminalContrib/accessibility/browser/terminal.accessibility.contribution.ts
@@ -78,7 +78,7 @@ export class TerminalAccessibilityHelpContribution extends Disposable {
 				return;
 			}
 			accessibleViewService.show(instantiationService.createInstance(TerminalAccessibleContentProvider, instance, terminal));
-		}, TerminalContextKeys.focus));
+		}, ContextKeyExpr.or(TerminalContextKeys.focus, TerminalContextKeys.accessibleBufferFocus)));
 	}
 }
 registerTerminalContribution(TerminalAccessibilityHelpContribution.ID, TerminalAccessibilityHelpContribution);


### PR DESCRIPTION
fix #188937

this will eventually be refactored when we move over to using the accessible view, but good to fix in the meantime