### PR TITLE
Be lazier in account menu & secrets

### DIFF
--- a/src/vs/platform/secrets/common/secrets.ts
+++ b/src/vs/platform/secrets/common/secrets.ts
@@ -10,6 +10,7 @@ import { IStorageService, InMemoryStorageService, StorageScope, StorageTarget } 
 import { Emitter, Event } from 'vs/base/common/event';
 import { ILogService } from 'vs/platform/log/common/log';
 import { DisposableStore } from 'vs/base/common/lifecycle';
+import { Lazy } from 'vs/base/common/lazy';
 
 export const ISecretStorageService = createDecorator<ISecretStorageService>('secretStorageService');
 
@@ -39,28 +40,24 @@ export class BaseSecretStorageService implements ISecretStorageService {
 
 	private readonly _onDidChangeValueDisposable = new DisposableStore();
 
-	protected resolvedStorageService = this.initialize();
-
 	constructor(
 		private readonly _useInMemoryStorage: boolean,
 		@IStorageService private _storageService: IStorageService,
 		@IEncryptionService protected _encryptionService: IEncryptionService,
-		@ILogService protected readonly _logService: ILogService
+		@ILogService protected readonly _logService: ILogService,
 	) { }
 
+	/**
+	 * @Note initialize must be called first so that this can be resolved properly
+	 * otherwise it will return 'unknown'.
+	 */
 	get type() {
 		return this._type;
 	}
 
-	private onDidChangeValue(key: string): void {
-		if (!key.startsWith(this._storagePrefix)) {
-			return;
-		}
-
-		const secretKey = key.slice(this._storagePrefix.length);
-
-		this._logService.trace(`[SecretStorageService] Notifying change in value for secret: ${secretKey}`);
-		this.onDidChangeSecretEmitter.fire(secretKey);
+	private _lazyStorageService: Lazy<Promise<IStorageService>> = new Lazy(() => this.initialize());
+	protected get resolvedStorageService() {
+		return this._lazyStorageService.value;
 	}
 
 	get(key: string): Promise<string | undefined> {
@@ -147,7 +144,18 @@ export class BaseSecretStorageService implements ISecretStorageService {
 	}
 
 	protected reinitialize(): void {
-		this.resolvedStorageService = this.initialize();
+		this._lazyStorageService = new Lazy(() => this.initialize());
+	}
+
+	private onDidChangeValue(key: string): void {
+		if (!key.startsWith(this._storagePrefix)) {
+			return;
+		}
+
+		const secretKey = key.slice(this._storagePrefix.length);
+
+		this._logService.trace(`[SecretStorageService] Notifying change in value for secret: ${secretKey}`);
+		this.onDidChangeSecretEmitter.fire(secretKey);
 	}
 
 	private getKey(key: string): string {

--- a/src/vs/platform/secrets/test/common/secrets.test.ts
+++ b/src/vs/platform/secrets/test/common/secrets.test.ts
@@ -5,7 +5,6 @@
 
 import * as assert from 'assert';
 import * as sinon from 'sinon';
-import { timeout } from 'vs/base/common/async';
 import { IEncryptionService, KnownStorageProvider } from 'vs/platform/encryption/common/encryptionService';
 import { NullLogService } from 'vs/platform/log/common/log';
 import { BaseSecretStorageService } from 'vs/platform/secrets/common/secrets';
@@ -67,8 +66,10 @@ suite('secrets', () => {
 		});
 
 		test('type', async () => {
-			// allow initialization to complete
-			await timeout(0);
+			assert.strictEqual(service.type, 'unknown');
+			// trigger lazy initialization
+			await service.set('my-secret', 'my-secret-value');
+
 			assert.strictEqual(service.type, 'in-memory');
 		});
 
@@ -122,8 +123,10 @@ suite('secrets', () => {
 		});
 
 		test('type', async () => {
-			// allow initialization to complete
-			await timeout(0);
+			assert.strictEqual(service.type, 'unknown');
+			// trigger lazy initialization
+			await service.set('my-secret', 'my-secret-value');
+
 			assert.strictEqual(service.type, 'persisted');
 		});
 
@@ -177,8 +180,10 @@ suite('secrets', () => {
 		});
 
 		test('type', async () => {
-			// allow initialization to complete
-			await timeout(0);
+			assert.strictEqual(service.type, 'unknown');
+			// trigger lazy initialization
+			await service.set('my-secret', 'my-secret-value');
+
 			assert.strictEqual(service.type, 'in-memory');
 		});
 


### PR DESCRIPTION
With this change, two things happen:

1. The secret service will be initialized lazily
2. The Account menu will wait for startup to finish before loading the accounts in the menu

ref https://github.com/microsoft/vscode/issues/189481

cc @bpasero

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
