### PR TITLE
add go to symbol in the accessible view

### DIFF
--- a/extensions/javascript/syntaxes/Readme.md
+++ b/extensions/javascript/syntaxes/Readme.md
@@ -8,4 +8,3 @@ The script does the following changes:
 - fileTypes .tsx -> .js & .jsx
 - scopeName scope.tsx -> scope.js
 - update all rule names .tsx -> .js
-

--- a/extensions/javascript/syntaxes/Readme.md
+++ b/extensions/javascript/syntaxes/Readme.md
@@ -8,3 +8,4 @@ The script does the following changes:
 - fileTypes .tsx -> .js & .jsx
 - scopeName scope.tsx -> scope.js
 - update all rule names .tsx -> .js
+

--- a/src/vs/workbench/contrib/accessibility/browser/accessibleView.ts
+++ b/src/vs/workbench/contrib/accessibility/browser/accessibleView.ts
@@ -33,7 +33,6 @@ import { IQuickInputService } from 'vs/platform/quickinput/common/quickInput';
 import { IPickerQuickAccessItem } from 'vs/platform/quickinput/browser/pickerQuickAccess';
 import { marked } from 'vs/base/common/marked/marked';
 
-
 const enum DIMENSIONS {
 	MAX_WIDTH = 600
 }
@@ -164,8 +163,8 @@ class AccessibleView extends Disposable {
 		} else {
 			this._accessibleViewIsShown.set(true);
 		}
-		if (symbol) {
-			this.showSymbol(this._currentProvider!, symbol);
+		if (symbol && this._currentProvider) {
+			this.showSymbol(this._currentProvider, symbol);
 		}
 		this._currentProvider = provider;
 	}

--- a/src/vs/workbench/contrib/accessibility/browser/accessibleView.ts
+++ b/src/vs/workbench/contrib/accessibility/browser/accessibleView.ts
@@ -200,6 +200,7 @@ class AccessibleView extends Disposable {
 					break;
 				case 'list':
 					label = token.items?.map(i => i.text).join(', ');
+					break;
 			}
 			if (label) {
 				symbols.push({ label, ariaLabel: localize('symbolLabel', "{0} {1}", token.type, label), iconClass: token.type });
@@ -209,8 +210,8 @@ class AccessibleView extends Disposable {
 	}
 
 	showSymbol(provider: IAccessibleContentProvider, symbol: IAccessibleViewSymbol): void {
-		const index = provider.provideContent().split('\n').findIndex(line => line.includes(symbol.label.split('\n')[0]));
-		if (index >= 0) {
+		const index = provider.provideContent().split('\n').findIndex(line => line.includes(symbol.label.split('\n')[0])) ?? -1;
+		if (index) {
 			this.show(provider);
 			this._editorWidget.revealLine(index + 1);
 			this._editorWidget.setSelection({ startLineNumber: index + 1, startColumn: 1, endLineNumber: index + 1, endColumn: 1 });
@@ -472,6 +473,9 @@ class AccessibleViewSymbolQuickPick {
 
 	}
 	show(provider: IAccessibleContentProvider): void {
+		if (provider.options.language !== 'markdown') {
+			return;
+		}
 		const quickPick = this._quickInputService.createQuickPick<IAccessibleViewSymbol>();
 		const picks = [];
 		const symbols = this._accessibleView.getSymbols();


### PR DESCRIPTION
https://github.com/microsoft/vscode/assets/29464607/8c7bdc8b-37f4-48cf-b53f-da8e0b4afa57

fixes https://github.com/microsoft/vscode/issues/188702

@mjbvz since the accessible view is not attached to an editor pane, the default language features won't work here - thus, this code.

the idea is most of the time the language will be `markdown`. when it's not, we defer to the provider for symbols IE quick pick items.

https://github.com/microsoft/vscode/blob/a1f77aa87bfe760dbcaef480f9dd39131e8244ed/src/vs/workbench/contrib/accessibility/browser/accessibleView.ts#L190-L195
https://github.com/microsoft/vscode/blob/a1f77aa87bfe760dbcaef480f9dd39131e8244ed/src/vs/workbench/contrib/accessibility/browser/accessibleView.ts#L223

do you have a suggestion for a better / more performant / more precise approach?

