### PR TITLE
Fix `--disable-keytar` handling in the renderer process

### DIFF
--- a/src/vs/platform/environment/common/environmentService.ts
+++ b/src/vs/platform/environment/common/environmentService.ts
@@ -237,6 +237,9 @@ export abstract class AbstractNativeEnvironmentService implements INativeEnviron
 	get disableWorkspaceTrust(): boolean { return !!this.args['disable-workspace-trust']; }
 
 	@memoize
+	get disableKeytar(): boolean { return !!this.args['disable-keytar']; }
+
+	@memoize
 	get policyFile(): URI | undefined {
 		if (this.args['__enable-file-policy']) {
 			const vscodePortable = env['VSCODE_PORTABLE'];

--- a/src/vs/platform/environment/electron-main/environmentMainService.ts
+++ b/src/vs/platform/environment/electron-main/environmentMainService.ts
@@ -60,9 +60,6 @@ export class EnvironmentMainService extends NativeEnvironmentService implements 
 	get disableUpdates(): boolean { return !!this.args['disable-updates']; }
 
 	@memoize
-	get disableKeytar(): boolean { return !!this.args['disable-keytar']; }
-
-	@memoize
 	get crossOriginIsolated(): boolean { return !!this.args['enable-coi']; }
 
 	@memoize

--- a/src/vs/platform/secrets/common/secrets.ts
+++ b/src/vs/platform/secrets/common/secrets.ts
@@ -127,6 +127,7 @@ export class BaseSecretStorageService implements ISecretStorageService {
 	private async initialize(): Promise<IStorageService> {
 		let storageService;
 		if (!this._useInMemoryStorage && await this._encryptionService.isEncryptionAvailable()) {
+			this._logService.trace(`[SecretStorageService] Encryption is available, using persisted storage`);
 			this._type = 'persisted';
 			storageService = this._storageService;
 		} else {

--- a/src/vs/workbench/services/secrets/electron-sandbox/secretStorageService.ts
+++ b/src/vs/workbench/services/secrets/electron-sandbox/secretStorageService.ts
@@ -43,7 +43,7 @@ export class NativeSecretStorageService extends BaseSecretStorageService {
 		this._sequencer.queue(key, async () => {
 			await this.resolvedStorageService;
 
-			if (this.type !== 'persisted') {
+			if (this.type !== 'persisted' && !this._environmentService.disableKeytar) {
 				this._logService.trace('[NativeSecretStorageService] Notifying user that secrets are not being stored on disk.');
 				await this.notifyOfNoEncryptionOnce();
 			}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
The `--disable-keytar` part of the EnvironmentService was only in the Main process, this brings it to the renderer too. Also, I missed a spot where I needed to check for the disablement of keytar.

Fixes https://github.com/microsoft/vscode/issues/189526
ref https://github.com/microsoft/vscode/pull/189514

cc @bpasero 