### PR TITLE
Compile debug version of native-keymap

### DIFF
--- a/build/azure-pipelines/linux/product-build-linux.yml
+++ b/build/azure-pipelines/linux/product-build-linux.yml
@@ -150,6 +150,8 @@ steps:
       displayName: Mixin distro node modules
 
   - ${{ else }}:
+    # Ref https://github.com/microsoft/vscode/issues/189019
+    # for the node-gyp rebuild step
     - script: |
         set -e
 
@@ -161,6 +163,9 @@ steps:
           fi
           echo "Yarn failed $i, trying again..."
         done
+
+        cd node_modules/native-keymap && node-gyp rebuild --debug
+        cd ../.. && ./.github/workflows/check-clean-git-state.sh
       env:
         npm_config_arch: $(NPM_ARCH)
         ELECTRON_SKIP_BINARY_DOWNLOAD: 1
@@ -168,13 +173,6 @@ steps:
         GITHUB_TOKEN: "$(github-distro-mixin-password)"
       displayName: Install dependencies
       condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'))
-
-  # Ref https://github.com/microsoft/vscode/issues/189019
-  - ${{ if eq(parameters.VSCODE_QUALITY, 'oss') }}:
-    - script: |
-        cd node_modules/native-keymap && node-gyp rebuild --debug
-        cd ../.. && ./.github/workflows/check-clean-git-state.sh
-      displayName: Compile debug version of native-keymap
 
   - script: |
       set -e

--- a/build/azure-pipelines/linux/product-build-linux.yml
+++ b/build/azure-pipelines/linux/product-build-linux.yml
@@ -169,6 +169,13 @@ steps:
       displayName: Install dependencies
       condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'))
 
+  # Ref https://github.com/microsoft/vscode/issues/189019
+  - ${{ if eq(parameters.VSCODE_QUALITY, 'oss') }}:
+    - script: |
+        cd node_modules/native-keymap && node-gyp rebuild --debug
+        cd ../.. && ./.github/workflows/check-clean-git-state.sh
+      displayName: Compile debug version of native-keymap
+
   - script: |
       set -e
       node build/azure-pipelines/common/listNodeModules.js .build/node_modules_list.txt

--- a/build/azure-pipelines/product-compile.yml
+++ b/build/azure-pipelines/product-compile.yml
@@ -70,6 +70,11 @@ steps:
     displayName: Install dependencies
     condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'))
 
+  # Ref https://github.com/microsoft/vscode/issues/189019
+  - ${{ if eq(parameters.VSCODE_QUALITY, 'oss') }}:
+    - script: cd node_modules/native-keymap && node-gyp rebuild --debug && ./.github/workflows/check-clean-git-state.sh
+      displayName: Compile debug version of native-keymap
+
   - ${{ if ne(parameters.VSCODE_QUALITY, 'oss') }}:
     - script: node build/azure-pipelines/distro/mixin-npm
       condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'))

--- a/build/azure-pipelines/product-compile.yml
+++ b/build/azure-pipelines/product-compile.yml
@@ -72,7 +72,9 @@ steps:
 
   # Ref https://github.com/microsoft/vscode/issues/189019
   - ${{ if eq(parameters.VSCODE_QUALITY, 'oss') }}:
-    - script: cd node_modules/native-keymap && node-gyp rebuild --debug && ./.github/workflows/check-clean-git-state.sh
+    - script: |
+        cd node_modules/native-keymap && node-gyp rebuild --debug
+        cd ../.. && ./.github/workflows/check-clean-git-state.sh
       displayName: Compile debug version of native-keymap
 
   - ${{ if ne(parameters.VSCODE_QUALITY, 'oss') }}:

--- a/build/azure-pipelines/product-compile.yml
+++ b/build/azure-pipelines/product-compile.yml
@@ -70,13 +70,6 @@ steps:
     displayName: Install dependencies
     condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'))
 
-  # Ref https://github.com/microsoft/vscode/issues/189019
-  - ${{ if eq(parameters.VSCODE_QUALITY, 'oss') }}:
-    - script: |
-        cd node_modules/native-keymap && node-gyp rebuild --debug
-        cd ../.. && ./.github/workflows/check-clean-git-state.sh
-      displayName: Compile debug version of native-keymap
-
   - ${{ if ne(parameters.VSCODE_QUALITY, 'oss') }}:
     - script: node build/azure-pipelines/distro/mixin-npm
       condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'))


### PR DESCRIPTION
Ref https://github.com/microsoft/vscode/issues/189019

I confirmed that the debug rebuild clears out the build directory automatically, so there's no build/Release directory afterwards.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
