### PR TITLE
Record telemetry for when the explorer fails to enter edit mode

### DIFF
--- a/src/vs/workbench/contrib/files/browser/explorerService.ts
+++ b/src/vs/workbench/contrib/files/browser/explorerService.ts
@@ -26,6 +26,7 @@ import { IHostService } from 'vs/workbench/services/host/browser/host';
 import { IExpression } from 'vs/base/common/glob';
 import { ResourceGlobMatcher } from 'vs/workbench/common/resources';
 import { IFilesConfigurationService } from 'vs/workbench/services/filesConfiguration/common/filesConfigurationService';
+import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 
 export const UNDO_REDO_SOURCE = new UndoRedoSource();
 
@@ -54,7 +55,8 @@ export class ExplorerService implements IExplorerService {
 		@IBulkEditService private readonly bulkEditService: IBulkEditService,
 		@IProgressService private readonly progressService: IProgressService,
 		@IHostService hostService: IHostService,
-		@IFilesConfigurationService private readonly filesConfigurationService: IFilesConfigurationService
+		@IFilesConfigurationService private readonly filesConfigurationService: IFilesConfigurationService,
+		@ITelemetryService private readonly telemetryService: ITelemetryService
 	) {
 		this.config = this.configurationService.getValue('explorer');
 
@@ -228,7 +230,52 @@ export class ExplorerService implements IExplorerService {
 			this.editable = { stat, data };
 		}
 		const isEditing = this.isEditable(stat);
-		await this.view.setEditable(stat, isEditing);
+		try {
+			await this.view.setEditable(stat, isEditing);
+		} catch {
+			const parent = stat.parent;
+			type ExplorerViewEditableErrorData = {
+				parentIsDirectory: boolean | undefined;
+				isDirectory: boolean | undefined;
+				isReadonly: boolean | undefined;
+				parentIsReadonly: boolean | undefined;
+				parentIsExcluded: boolean | undefined;
+				isExcluded: boolean | undefined;
+				parentIsRoot: boolean | undefined;
+				isRoot: boolean | undefined;
+				parentHasNests: boolean | undefined;
+				hasNests: boolean | undefined;
+			};
+			type ExplorerViewEditableErrorClassification = {
+				owner: 'lramos15';
+				comment: 'Helps gain a broard understanding of why users are unable to edit files in the explorer';
+				parentIsDirectory: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'Whether the parent of the editable element is a directory' };
+				isDirectory: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'Whether the editable element is a directory' };
+				isReadonly: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'Whether the editable element is readonly' };
+				parentIsReadonly: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'Whether the parent of the editable element is readonly' };
+				parentIsExcluded: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'Whether the parent of the editable element is excluded from being shown in the explorer' };
+				isExcluded: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'Whether the editable element is excluded from being shown in the explorer' };
+				parentIsRoot: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'Whether the parent of the editable element is a root' };
+				isRoot: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'Whether the editable element is a root' };
+				parentHasNests: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'Whether the parent of the editable element has nested children' };
+				hasNests: { classification: 'SystemMetaData'; purpose: 'PerformanceAndHealth'; isMeasurement: true; comment: 'Whether the editable element has nested children' };
+			};
+			const errorData = {
+				parentIsDirectory: parent?.isDirectory,
+				isDirectory: stat.isDirectory,
+				isReadonly: !!stat.isReadonly,
+				parentIsReadonly: !!parent?.isReadonly,
+				parentIsExcluded: parent?.isExcluded,
+				isExcluded: stat.isExcluded,
+				parentIsRoot: parent?.isRoot,
+				isRoot: stat.isRoot,
+				parentHasNests: parent?.hasNests,
+				hasNests: stat.hasNests,
+			};
+			this.telemetryService.publicLogError2<ExplorerViewEditableErrorData, ExplorerViewEditableErrorClassification>('explorerView.setEditableError', errorData);
+			return;
+		}
+
 
 		if (!this.editable && this.fileChangeEvents.length && !this.onFileChangesScheduler.isScheduled()) {
 			this.onFileChangesScheduler.schedule();


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Collects more telemetry about why there are so many errors setting the explorer editable to hopefully track reproducible steps

Fixes #189332
Fixes #176925
Fixes #172786
Fixes #170858
Fixes #170856