### PR TITLE
add accessible view hint to hover aria labels instead of using `status`, provide way to disable the hint 

### DIFF
--- a/src/vs/base/browser/ui/hover/hoverWidget.ts
+++ b/src/vs/base/browser/ui/hover/hoverWidget.ts
@@ -96,10 +96,6 @@ export class HoverAction extends Disposable {
 	}
 }
 
-export function getHoverAriaLabel(shouldHaveHint?: boolean, keybinding?: any): string | undefined {
-	if (shouldHaveHint) {
-		const hint = keybinding ? localize('hoverAccessibleViewHint', "Inspect this in the accessible view with {0}", keybinding) : localize('hoverAccessibleViewHintNoKb', "Inspect this in the accessible view via the command Open Accessible View which is currently not triggerable via keybinding");
-		return hint;
-	}
-	return;
+export function getHoverAriaLabel(shouldHaveHint?: boolean, keybinding?: string | null): string | undefined {
+	return shouldHaveHint ? localize('acessibleViewHint', "Inspect this in the accessible view with {0}.", keybinding) : localize('acessibleViewHintNoKbOpen', "Inspect this in the accessible view via the command Open Accessible View which is currently not triggerable via keybinding.");
 }

--- a/src/vs/base/browser/ui/hover/hoverWidget.ts
+++ b/src/vs/base/browser/ui/hover/hoverWidget.ts
@@ -9,6 +9,7 @@ import { DomScrollableElement } from 'vs/base/browser/ui/scrollbar/scrollableEle
 import { KeyCode } from 'vs/base/common/keyCodes';
 import { Disposable } from 'vs/base/common/lifecycle';
 import 'vs/css!./hover';
+import { localize } from 'vs/nls';
 
 const $ = dom.$;
 
@@ -93,4 +94,12 @@ export class HoverAction extends Disposable {
 			this.actionContainer.setAttribute('aria-disabled', 'true');
 		}
 	}
+}
+
+export function getHoverAriaLabel(shouldHaveHint?: boolean, keybinding?: any): string | undefined {
+	if (shouldHaveHint) {
+		const hint = keybinding ? localize('hoverAccessibleViewHint', "Inspect this in the accessible view with {0}", keybinding) : localize('hoverAccessibleViewHintNoKb', "Inspect this in the accessible view via the command Open Accessible View which is currently not triggerable via keybinding");
+		return hint;
+	}
+	return;
 }

--- a/src/vs/editor/contrib/hover/browser/contentHover.ts
+++ b/src/vs/editor/contrib/hover/browser/contentHover.ts
@@ -24,9 +24,10 @@ import { AsyncIterableObject } from 'vs/base/common/async';
 import { EditorContextKeys } from 'vs/editor/common/editorContextKeys';
 import { IContextKey, IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 import { ResizableContentWidget } from 'vs/editor/contrib/hover/browser/resizableContentWidget';
-import { localize } from 'vs/nls';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { IAccessibilityService } from 'vs/platform/accessibility/common/accessibility';
+import { localize } from 'vs/nls';
+
 const $ = dom.$;
 
 export class ContentHoverController extends Disposable {
@@ -528,11 +529,8 @@ export class ContentHoverWidget extends ResizableContentWidget {
 		this._setHoverData(undefined);
 		this._layout();
 		this._editor.addContentWidget(this);
-		if (this._configurationService.getValue('accessibility.verbosity.hover') && this._accessibilityService.isScreenReaderOptimized()) {
-			const keybinding = this._keybindingService.lookupKeybinding('editor.action.accessibleView')?.getAriaLabel();
-			const hint = keybinding ? localize('chatAccessibleViewHint', "Inspect this in the accessible view with {0}", keybinding) : localize('chatAccessibleViewHintNoKb', "Inspect this in the accessible view via the command Open Accessible View which is currently not triggerable via keybinding");
-			this._hover.containerDomNode.ariaLabel = hint;
-		}
+
+		this._hover.containerDomNode.ariaLabel = getHoverAriaLabel(this._configurationService, this._accessibilityService, this._keybindingService) ?? '';
 	}
 
 	public override dispose(): void {
@@ -998,4 +996,13 @@ function computeDistanceFromPointToRectangle(pointX: number, pointY: number, lef
 	const dx = Math.max(Math.abs(pointX - x) - width / 2, 0);
 	const dy = Math.max(Math.abs(pointY - y) - height / 2, 0);
 	return Math.sqrt(dx * dx + dy * dy);
+}
+
+export function getHoverAriaLabel(configurationService: IConfigurationService, accessibilityService: IAccessibilityService, keybindingService: IKeybindingService): string | undefined {
+	if (configurationService.getValue('accessibility.verbosity.hover') && accessibilityService.isScreenReaderOptimized()) {
+		const keybinding = keybindingService.lookupKeybinding('editor.action.accessibleView')?.getAriaLabel();
+		const hint = keybinding ? localize('hoverAccessibleViewHint', "Inspect this in the accessible view with {0}", keybinding) : localize('hoverAccessibleViewHintNoKb', "Inspect this in the accessible view via the command Open Accessible View which is currently not triggerable via keybinding");
+		return hint;
+	}
+	return;
 }

--- a/src/vs/editor/contrib/hover/browser/contentHover.ts
+++ b/src/vs/editor/contrib/hover/browser/contentHover.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as dom from 'vs/base/browser/dom';
-import { HoverAction, HoverWidget } from 'vs/base/browser/ui/hover/hoverWidget';
+import { HoverAction, HoverWidget, getHoverAriaLabel } from 'vs/base/browser/ui/hover/hoverWidget';
 import { coalesce } from 'vs/base/common/arrays';
 import { CancellationToken } from 'vs/base/common/cancellation';
 import { KeyCode } from 'vs/base/common/keyCodes';
@@ -26,7 +26,6 @@ import { IContextKey, IContextKeyService } from 'vs/platform/contextkey/common/c
 import { ResizableContentWidget } from 'vs/editor/contrib/hover/browser/resizableContentWidget';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { IAccessibilityService } from 'vs/platform/accessibility/common/accessibility';
-import { localize } from 'vs/nls';
 
 const $ = dom.$;
 
@@ -530,7 +529,7 @@ export class ContentHoverWidget extends ResizableContentWidget {
 		this._layout();
 		this._editor.addContentWidget(this);
 
-		this._hover.containerDomNode.ariaLabel = getHoverAriaLabel(this._configurationService, this._accessibilityService, this._keybindingService) ?? '';
+		this._hover.containerDomNode.ariaLabel = getHoverAriaLabel(this._configurationService.getValue('accessibility.verbosity.hover') === true && this._accessibilityService.isScreenReaderOptimized(), this._keybindingService.lookupKeybinding('editor.action.accessibleView')?.getAriaLabel()) ?? '';
 	}
 
 	public override dispose(): void {
@@ -996,13 +995,4 @@ function computeDistanceFromPointToRectangle(pointX: number, pointY: number, lef
 	const dx = Math.max(Math.abs(pointX - x) - width / 2, 0);
 	const dy = Math.max(Math.abs(pointY - y) - height / 2, 0);
 	return Math.sqrt(dx * dx + dy * dy);
-}
-
-export function getHoverAriaLabel(configurationService: IConfigurationService, accessibilityService: IAccessibilityService, keybindingService: IKeybindingService): string | undefined {
-	if (configurationService.getValue('accessibility.verbosity.hover') && accessibilityService.isScreenReaderOptimized()) {
-		const keybinding = keybindingService.lookupKeybinding('editor.action.accessibleView')?.getAriaLabel();
-		const hint = keybinding ? localize('hoverAccessibleViewHint', "Inspect this in the accessible view with {0}", keybinding) : localize('hoverAccessibleViewHintNoKb', "Inspect this in the accessible view via the command Open Accessible View which is currently not triggerable via keybinding");
-		return hint;
-	}
-	return;
 }

--- a/src/vs/editor/contrib/hover/browser/hover.ts
+++ b/src/vs/editor/contrib/hover/browser/hover.ts
@@ -17,7 +17,7 @@ import { GotoDefinitionAtPositionEditorContribution } from 'vs/editor/contrib/go
 import { HoverStartMode, HoverStartSource } from 'vs/editor/contrib/hover/browser/hoverOperation';
 import { ContentHoverWidget, ContentHoverController } from 'vs/editor/contrib/hover/browser/contentHover';
 import { MarginHoverWidget } from 'vs/editor/contrib/hover/browser/marginHover';
-import { AccessibilitySupport, IAccessibilityService } from 'vs/platform/accessibility/common/accessibility';
+import { AccessibilitySupport } from 'vs/platform/accessibility/common/accessibility';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { KeybindingWeight } from 'vs/platform/keybinding/common/keybindingsRegistry';
 import { IOpenerService } from 'vs/platform/opener/common/opener';
@@ -31,8 +31,6 @@ import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 import { ResultKind } from 'vs/platform/keybinding/common/keybindingResolver';
 import * as nls from 'vs/nls';
 import 'vs/css!./hover';
-import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
-import { status } from 'vs/base/browser/ui/aria/aria';
 
 // sticky hover widget which doesn't disappear on focus out and such
 const _sticky = false
@@ -363,9 +361,6 @@ class ShowOrFocusHoverAction extends EditorAction {
 	}
 
 	public run(accessor: ServicesAccessor, editor: ICodeEditor, args: any): void {
-		const configurationService = accessor.get(IConfigurationService);
-		const accessibilityService = accessor.get(IAccessibilityService);
-		const keybindingService = accessor.get(IKeybindingService);
 		if (!editor.hasModel()) {
 			return;
 		}
@@ -381,11 +376,6 @@ class ShowOrFocusHoverAction extends EditorAction {
 			controller.focus();
 		} else {
 			controller.showContentHover(range, HoverStartMode.Immediate, HoverStartSource.Keyboard, focus);
-		}
-		if (configurationService.getValue('accessibility.verbosity.hover') && accessibilityService.isScreenReaderOptimized()) {
-			const keybinding = keybindingService.lookupKeybinding('editor.action.accessibleView')?.getAriaLabel();
-			const hint = keybinding ? nls.localize('chatAccessibleViewHint', "Inspect this in the accessible view with {0}", keybinding) : nls.localize('chatAccessibleViewHintNoKb', "Inspect this in the accessible view via the command Open Accessible View which is currently not triggerable via keybinding");
-			status(hint);
 		}
 	}
 }

--- a/src/vs/workbench/contrib/accessibility/browser/accessibleView.ts
+++ b/src/vs/workbench/contrib/accessibility/browser/accessibleView.ts
@@ -35,7 +35,6 @@ import { marked } from 'vs/base/common/marked/marked';
 
 
 class AccessibleViewDisableHintAction extends Action2 {
-	static id: 'editor.action.accessibleViewDisableHint';
 	constructor() {
 		super({
 			id: 'editor.action.accessibleViewDisableHint',
@@ -365,10 +364,10 @@ class AccessibleView extends Disposable {
 
 	private _getNavigationAriaHint(verbositySettingKey: AccessibilityVerbositySettingId): string {
 		let hint = '';
-		const nextKeybinding = this._keybindingService.lookupKeybinding(AccessibleViewNextAction.id)?.getAriaLabel();
-		const previousKeybinding = this._keybindingService.lookupKeybinding(AccessibleViewPreviousAction.id)?.getAriaLabel();
+		const nextKeybinding = this._keybindingService.lookupKeybinding('editor.action.accessibleViewNext')?.getAriaLabel();
+		const previousKeybinding = this._keybindingService.lookupKeybinding('editor.action.accessibleViewPrevious')?.getAriaLabel();
 		if (this._configurationService.getValue(verbositySettingKey)) {
-			hint = (nextKeybinding && previousKeybinding) ? localize('accessibleViewNextPreviousHint', "Show the next {0} or previous {1} item in the accessible view", nextKeybinding, previousKeybinding) : localize('chatAccessibleViewNextPreviousHintNoKb', "Show the next or previous item in the accessible view by configuring keybindings for Show Next / Previous in Accessible View");
+			hint = (nextKeybinding && previousKeybinding) ? localize('accessibleViewNextPreviousHint', "Show the next ({0}) or previous ({1}) item in the accessible view", nextKeybinding, previousKeybinding) : localize('chatAccessibleViewNextPreviousHintNoKb', "Show the next or previous item in the accessible view by configuring keybindings for Show Next / Previous in Accessible View");
 		}
 		return hint;
 	}
@@ -376,8 +375,8 @@ class AccessibleView extends Disposable {
 		if (!this._configurationService.getValue(verbositySettingKey)) {
 			return '';
 		}
-		const disableKeybinding = this._keybindingService.lookupKeybinding(AccessibleViewDisableHintAction.id)?.getAriaLabel();
-		return disableKeybinding ? localize('acessibleViewDisableHint', "Disable the hint to open the accessible view by pressing {1}.", disableKeybinding) : localize('accessibleViewDisableHintNoKb', 'Add a keybinding for the command Disable Accessible View Hint to disable this hint."');
+		const disableKeybinding = this._keybindingService.lookupKeybinding('editor.action.accessibleViewDisableHint', this._contextKeyService)?.getAriaLabel();
+		return !!disableKeybinding ? localize('acessibleViewDisableHint', "Disable the hint to open the accessible view by pressing ({0}).", disableKeybinding) : localize('accessibleViewDisableHintNoKb', 'Add a keybinding for the command Disable Accessible View Hint to disable this hint."');
 	}
 }
 
@@ -414,16 +413,11 @@ export class AccessibleViewService extends Disposable implements IAccessibleView
 			return null;
 		}
 		const keybinding = this._keybindingService.lookupKeybinding(AccessibleViewAction.id)?.getAriaLabel();
-		const disableKeybinding = this._keybindingService.lookupKeybinding(AccessibleViewDisableHintAction.id)?.getAriaLabel();
 		let hint = null;
-		if (keybinding && disableKeybinding) {
-			hint = localize('acessibleViewHint', "Inspect this in the accessible view with {0}", keybinding, disableKeybinding);
-		} else if (keybinding && !disableKeybinding) {
-			hint = localize('acessibleViewHintNoKbDisable', "Inspect this in the accessible view with {0}. Add a keybinding for the command Disable Accessible View Hint to disable this hint.", keybinding);
-		} else if (!keybinding && disableKeybinding) {
-			hint = localize('acessibleViewHintNoKbOpen', "Inspect this in the accessible view via the command Open Accessible View which is currently not triggerable via keybinding. Disable this hint via {0}.", disableKeybinding);
+		if (keybinding) {
+			hint = localize('acessibleViewHint', "Inspect this in the accessible view with {0}", keybinding);
 		} else {
-			hint = localize('acessibleViewHintNoKbEither', "Inspect this in the accessible view via the command Open Accessible View which is currently not triggerable via keybinding, Disable this hint by adding a keybinding for the command Disable Accessible View Hint.");
+			hint = localize('acessibleViewHintNoKbEither', "Inspect this in the accessible view via the command Open Accessible View which is currently not triggerable via keybinding.");
 		}
 		return hint;
 	}
@@ -433,7 +427,6 @@ export class AccessibleViewService extends Disposable implements IAccessibleView
 }
 
 class AccessibleViewNextAction extends Action2 {
-	static id: 'editor.action.accessibleViewNext';
 	constructor() {
 		super({
 			id: 'editor.action.accessibleViewNext',
@@ -458,7 +451,6 @@ registerAction2(AccessibleViewNextAction);
 
 
 class AccessibleViewGoToSymbolAction extends Action2 {
-	static id: 'editor.action.accessibleViewGoToSymbol';
 	constructor() {
 		super({
 			id: 'editor.action.accessibleViewGoToSymbol',
@@ -482,7 +474,6 @@ class AccessibleViewGoToSymbolAction extends Action2 {
 registerAction2(AccessibleViewGoToSymbolAction);
 
 class AccessibleViewPreviousAction extends Action2 {
-	static id: 'editor.action.accessibleViewPrevious';
 	constructor() {
 		super({
 			id: 'editor.action.accessibleViewPrevious',

--- a/src/vs/workbench/contrib/chat/browser/actions/chatAccessibilityHelp.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatAccessibilityHelp.ts
@@ -74,7 +74,7 @@ export async function runAccessibilityHelpAction(accessor: ServicesAccessor, edi
 	inputEditor.getSupportedActions();
 	const helpText = getAccessibilityHelpText(accessor, type);
 	accessibleViewService.show({
-		verbositySettingKey: type as AccessibilityVerbositySettingId,
+		verbositySettingKey: type === 'panelChat' ? AccessibilityVerbositySettingId.Chat : AccessibilityVerbositySettingId.InlineChat,
 		provideContent: () => helpText,
 		onClose: () => {
 			if (type === 'panelChat' && cachedPosition) {

--- a/src/vs/workbench/contrib/terminalContrib/accessibility/browser/terminalAccessibilityHelp.ts
+++ b/src/vs/workbench/contrib/terminalContrib/accessibility/browser/terminalAccessibilityHelp.ts
@@ -20,7 +20,6 @@ import { TerminalContextKeys } from 'vs/workbench/contrib/terminal/common/termin
 import type { Terminal } from 'xterm';
 
 export const enum ClassName {
-	AccessibleBuffer = 'terminal-accessibility-help',
 	Active = 'active',
 	EditorTextArea = 'textarea'
 }

--- a/src/vs/workbench/services/hover/browser/hoverWidget.ts
+++ b/src/vs/workbench/services/hover/browser/hoverWidget.ts
@@ -122,7 +122,6 @@ export class HoverWidget extends Widget {
 			const keybinding = this._keybindingService.lookupKeybinding('editor.action.accessibleView')?.getAriaLabel();
 			const hint = keybinding ? localize('chatAccessibleViewHint', "Inspect this in the accessible view with {0}", keybinding) : localize('chatAccessibleViewHintNoKb', "Inspect this in the accessible view via the command Open Accessible View which is currently not triggerable via keybinding");
 			this._hover.containerDomNode.ariaLabel = hint;
-			this._hover.contentsDomNode.ariaLabel = hint;
 		}
 		this._hoverPosition = options.hoverPosition ?? HoverPosition.ABOVE;
 

--- a/src/vs/workbench/services/hover/browser/hoverWidget.ts
+++ b/src/vs/workbench/services/hover/browser/hoverWidget.ts
@@ -11,7 +11,7 @@ import { IHoverTarget, IHoverOptions } from 'vs/workbench/services/hover/browser
 import { KeyCode } from 'vs/base/common/keyCodes';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { EDITOR_FONT_DEFAULTS, IEditorOptions } from 'vs/editor/common/config/editorOptions';
-import { HoverAction, HoverPosition, HoverWidget as BaseHoverWidget } from 'vs/base/browser/ui/hover/hoverWidget';
+import { HoverAction, HoverPosition, HoverWidget as BaseHoverWidget, getHoverAriaLabel } from 'vs/base/browser/ui/hover/hoverWidget';
 import { Widget } from 'vs/base/browser/ui/widget';
 import { AnchorPosition } from 'vs/base/browser/ui/contextview/contextview';
 import { IOpenerService } from 'vs/platform/opener/common/opener';
@@ -21,7 +21,6 @@ import { isMarkdownString } from 'vs/base/common/htmlContent';
 import { localize } from 'vs/nls';
 import { isMacintosh } from 'vs/base/common/platform';
 import { IAccessibilityService } from 'vs/platform/accessibility/common/accessibility';
-import { getHoverAriaLabel } from 'vs/editor/contrib/hover/browser/contentHover';
 
 const $ = dom.$;
 type TargetRect = {
@@ -120,7 +119,7 @@ export class HoverWidget extends Widget {
 			this._enableFocusTraps = true;
 		}
 
-		this._hover.containerDomNode.ariaLabel = getHoverAriaLabel(this._configurationService, this._accessibilityService, this._keybindingService) ?? '';
+		this._hover.containerDomNode.ariaLabel = getHoverAriaLabel(this._configurationService.getValue('accessibility.verbosity.hover') === true && this._accessibilityService.isScreenReaderOptimized(), this._keybindingService.lookupKeybinding('editor.action.accessibleView')?.getAriaLabel()) ?? '';
 
 		this._hoverPosition = options.hoverPosition ?? HoverPosition.ABOVE;
 

--- a/src/vs/workbench/services/hover/browser/hoverWidget.ts
+++ b/src/vs/workbench/services/hover/browser/hoverWidget.ts
@@ -20,6 +20,7 @@ import { MarkdownRenderer, openLinkFromMarkdown } from 'vs/editor/contrib/markdo
 import { isMarkdownString } from 'vs/base/common/htmlContent';
 import { localize } from 'vs/nls';
 import { isMacintosh } from 'vs/base/common/platform';
+import { IAccessibilityService } from 'vs/platform/accessibility/common/accessibility';
 
 const $ = dom.$;
 type TargetRect = {
@@ -89,6 +90,7 @@ export class HoverWidget extends Widget {
 		@IConfigurationService private readonly _configurationService: IConfigurationService,
 		@IOpenerService private readonly _openerService: IOpenerService,
 		@IInstantiationService private readonly _instantiationService: IInstantiationService,
+		@IAccessibilityService private readonly _accessibilityService: IAccessibilityService
 	) {
 		super();
 
@@ -116,7 +118,12 @@ export class HoverWidget extends Widget {
 		if (options.trapFocus) {
 			this._enableFocusTraps = true;
 		}
-
+		if (this._configurationService.getValue('accessibility.verbosity.hover') && this._accessibilityService.isScreenReaderOptimized()) {
+			const keybinding = this._keybindingService.lookupKeybinding('editor.action.accessibleView')?.getAriaLabel();
+			const hint = keybinding ? localize('chatAccessibleViewHint', "Inspect this in the accessible view with {0}", keybinding) : localize('chatAccessibleViewHintNoKb', "Inspect this in the accessible view via the command Open Accessible View which is currently not triggerable via keybinding");
+			this._hover.containerDomNode.ariaLabel = hint;
+			this._hover.contentsDomNode.ariaLabel = hint;
+		}
 		this._hoverPosition = options.hoverPosition ?? HoverPosition.ABOVE;
 
 		// Don't allow mousedown out of the widget, otherwise preventDefault will call and text will

--- a/src/vs/workbench/services/hover/browser/hoverWidget.ts
+++ b/src/vs/workbench/services/hover/browser/hoverWidget.ts
@@ -21,6 +21,7 @@ import { isMarkdownString } from 'vs/base/common/htmlContent';
 import { localize } from 'vs/nls';
 import { isMacintosh } from 'vs/base/common/platform';
 import { IAccessibilityService } from 'vs/platform/accessibility/common/accessibility';
+import { getHoverAriaLabel } from 'vs/editor/contrib/hover/browser/contentHover';
 
 const $ = dom.$;
 type TargetRect = {
@@ -118,11 +119,9 @@ export class HoverWidget extends Widget {
 		if (options.trapFocus) {
 			this._enableFocusTraps = true;
 		}
-		if (this._configurationService.getValue('accessibility.verbosity.hover') && this._accessibilityService.isScreenReaderOptimized()) {
-			const keybinding = this._keybindingService.lookupKeybinding('editor.action.accessibleView')?.getAriaLabel();
-			const hint = keybinding ? localize('chatAccessibleViewHint', "Inspect this in the accessible view with {0}", keybinding) : localize('chatAccessibleViewHintNoKb', "Inspect this in the accessible view via the command Open Accessible View which is currently not triggerable via keybinding");
-			this._hover.containerDomNode.ariaLabel = hint;
-		}
+
+		this._hover.containerDomNode.ariaLabel = getHoverAriaLabel(this._configurationService, this._accessibilityService, this._keybindingService) ?? '';
+
 		this._hoverPosition = options.hoverPosition ?? HoverPosition.ABOVE;
 
 		// Don't allow mousedown out of the widget, otherwise preventDefault will call and text will


### PR DESCRIPTION
fixes #188748
fixes #189675 