### PR TITLE
Resolved conflicts between System High Contrast (HC) and VS Code High Contrast in ExtensionEditor

### DIFF
--- a/src/vs/workbench/contrib/markdown/browser/markdownDocumentRenderer.ts
+++ b/src/vs/workbench/contrib/markdown/browser/markdownDocumentRenderer.ts
@@ -142,6 +142,18 @@ pre code {
 .vscode-dark td {
 	border-color: rgba(255, 255, 255, 0.18);
 }
+
+@media (forced-colors: active) and (prefers-color-scheme: light){
+	body {
+		forced-color-adjust: none;
+	}
+}
+
+@media (forced-colors: active) and (prefers-color-scheme: dark){
+	body {
+		forced-color-adjust: none;
+	}
+}
 `;
 
 const allowedProtocols = [Schemas.http, Schemas.https, Schemas.command];


### PR DESCRIPTION
Fixed #186682

- Added media queries for Markdown to resolve the style conflict between System High Contrast and VS Code High Contrast.
- This ensures that ExtensionEditor does not encounter conflicts between VS Code high contrast and system high contrast.