### PR TITLE
Mark all .tsbuildinfo files as json

### DIFF
--- a/extensions/typescript-basics/package.json
+++ b/extensions/typescript-basics/package.json
@@ -55,8 +55,8 @@
       },
       {
         "id": "json",
-        "filenames": [
-          "tsconfig.tsbuildinfo"
+        "extensions": [
+          ".tsbuildinfo"
         ]
       }
     ],


### PR DESCRIPTION
TypeScript emits a `.tsbuildinfo` file whose file base name matches the TypeScript configuration file. Typically this configuration file is named `tsconfig.json`, meaning TypeScript will generate `tsconfig.tsbuildinfo`. However, if the config file is named differently, TypeScript will generate another `.tsbuildinfo` file.
