### PR TITLE
Revert "Add Settings editor smoke tests"

### DIFF
--- a/test/automation/src/settings.ts
+++ b/test/automation/src/settings.ts
@@ -53,21 +53,4 @@ export class SettingsEditor {
 		await this.quickaccess.runCommand('workbench.action.openSettingsJson');
 		await this.editor.waitForEditorFocus('settings.json', 1);
 	}
-
-	async openUserSettingsUI(): Promise<void> {
-		await this.quickaccess.runCommand('workbench.action.openSettings2');
-		await this.code.waitForElement('.settings-editor');
-	}
-
-	async searchSettingsUI(query: string): Promise<void> {
-		await this.openUserSettingsUI();
-		await this.code.waitAndClick('.settings-editor .suggest-input-container .monaco-editor textarea');
-		if (process.platform === 'darwin') {
-			await this.code.dispatchKeybinding('cmd+a');
-		} else {
-			await this.code.dispatchKeybinding('ctrl+a');
-		}
-		await this.code.dispatchKeybinding('Delete');
-		await this.code.waitForTypeInEditor('.settings-editor .suggest-input-container .monaco-editor textarea', query);
-	}
 }

--- a/test/smoke/src/areas/preferences/preferences.test.ts
+++ b/test/smoke/src/areas/preferences/preferences.test.ts
@@ -19,7 +19,7 @@ export function setup(logger: Logger) {
 			await app.code.waitForElements('.line-numbers', false, elements => !!elements.length);
 
 			await app.workbench.settingsEditor.addUserSetting('editor.lineNumbers', '"off"');
-			await app.code.waitForElements('.line-numbers', false, elements => !elements || elements.length === 0);
+			await app.code.waitForElements('.line-numbers', false, result => !result || result.length === 0);
 		});
 
 		it('changes "workbench.action.toggleSidebarPosition" command key binding and verifies it', async function () {
@@ -31,36 +31,6 @@ export function setup(logger: Logger) {
 
 			await app.code.dispatchKeybinding('ctrl+u');
 			await app.workbench.activitybar.waitForActivityBar(ActivityBarPosition.RIGHT);
-		});
-	});
-
-	describe('Settings editor', () => {
-
-		// Shared before/after handling
-		installAllHandlers(logger);
-
-		it('shows a modified indicator on a modified setting', async function () {
-			const app = this.app as Application;
-
-			await app.workbench.settingsEditor.searchSettingsUI('@id:editor.tabSize');
-			await app.code.waitForSetValue('.settings-editor .setting-item-contents .setting-item-control input', '6');
-			await app.code.waitForElement('.settings-editor .setting-item-contents .setting-item-modified-indicator');
-			await app.code.waitForSetValue('.settings-editor .setting-item-contents .setting-item-control input', '4');
-		});
-
-		it('turns off editor line numbers and verifies the live change', async function () {
-			const app = this.app as Application;
-
-			await app.workbench.editors.newUntitledFile();
-			await app.code.dispatchKeybinding('enter');
-			await app.code.waitForElements('.line-numbers', false, elements => !!elements.length);
-
-			await app.workbench.settingsEditor.searchSettingsUI('editor.lineNumbers');
-			await app.code.waitAndClick('.settings-editor .monaco-list-rows .setting-item-control select', 2, 2);
-			await app.code.waitAndClick('.context-view .option-text', 2, 2);
-
-			await app.workbench.editors.selectTab('Untitled-1');
-			await app.code.waitForElements('.line-numbers', false, elements => !elements || elements.length === 0);
 		});
 	});
 }


### PR DESCRIPTION
Reverts microsoft/vscode#189687

The tests are too flaky.
Revert created using the GitHub UI hence the Unverified label.