### PR TITLE
Set icon label's aria label

### DIFF
--- a/src/vs/base/browser/ui/iconLabel/iconLabel.ts
+++ b/src/vs/base/browser/ui/iconLabel/iconLabel.ts
@@ -120,6 +120,7 @@ export class IconLabel extends Disposable {
 	setLabel(label: string | string[], description?: string, options?: IIconLabelValueOptions): void {
 		const labelClasses = ['monaco-icon-label'];
 		const containerClasses = ['monaco-icon-label-container'];
+		let ariaLabel: string = '';
 		if (options) {
 			if (options.extraClasses) {
 				labelClasses.push(...options.extraClasses);
@@ -136,9 +137,13 @@ export class IconLabel extends Disposable {
 			if (options.disabledCommand) {
 				containerClasses.push('disabled');
 			}
+			if (options.title) {
+				ariaLabel += options.title;
+			}
 		}
 
 		this.domNode.className = labelClasses.join(' ');
+		this.domNode.element.setAttribute('aria-label', ariaLabel);
 		this.labelContainer.className = containerClasses.join(' ');
 		this.setupHover(options?.descriptionTitle ? this.labelContainer : this.element, options?.title);
 


### PR DESCRIPTION
Fixes #189784

@meganrogge I wasn't sure how to do audio cues or if that's something we want, but I've set the aria label to match that of the title attribute so screen readers can benefit