### PR TITLE
Add Settings editor smoke tests (take 2)

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
@@ -1685,6 +1685,7 @@ export class SettingsEditor2 extends EditorPane {
 				this.searchResultLabel = null;
 				this.updateInputAriaLabel();
 				this.countElement.style.display = 'none';
+				this.countElement.innerText = '';
 				this.layout(this.dimension);
 			}
 

--- a/test/automation/src/settings.ts
+++ b/test/automation/src/settings.ts
@@ -56,7 +56,7 @@ export class SettingsEditor {
 
 	async openUserSettingsUI(): Promise<void> {
 		await this.quickaccess.runCommand('workbench.action.openSettings2');
-		await this.code.waitForElement('.settings-group-title-label');
+		await this.code.waitForElement('.settings-editor');
 	}
 
 	async searchSettingsUI(query: string): Promise<void> {

--- a/test/automation/src/settings.ts
+++ b/test/automation/src/settings.ts
@@ -61,6 +61,9 @@ export class SettingsEditor {
 
 	async searchSettingsUI(query: string): Promise<void> {
 		await this.openUserSettingsUI();
+		await this.code.waitAndClick('.settings-editor .suggest-input-container .monaco-editor textarea');
+		await this.code.dispatchKeybinding('ctrl+a');
+		await this.code.dispatchKeybinding('backspace');
 		await this.code.waitForTypeInEditor('.settings-editor .suggest-input-container .monaco-editor textarea', query);
 	}
 }

--- a/test/automation/src/settings.ts
+++ b/test/automation/src/settings.ts
@@ -68,6 +68,8 @@ export class SettingsEditor {
 			await this.code.dispatchKeybinding('ctrl+a');
 		}
 		await this.code.dispatchKeybinding('Delete');
+		await this.code.waitForElements('.settings-editor .settings-count-widget', false, results => !results || (results?.length === 1 && !results[0].textContent));
 		await this.code.waitForTypeInEditor('.settings-editor .suggest-input-container .monaco-editor textarea', query);
+		await this.code.waitForElements('.settings-editor .settings-count-widget', false, results => results?.length === 1 && results[0].textContent.includes('Found'));
 	}
 }

--- a/test/automation/src/settings.ts
+++ b/test/automation/src/settings.ts
@@ -53,4 +53,14 @@ export class SettingsEditor {
 		await this.quickaccess.runCommand('workbench.action.openSettingsJson');
 		await this.editor.waitForEditorFocus('settings.json', 1);
 	}
+
+	async openUserSettingsUI(): Promise<void> {
+		await this.quickaccess.runCommand('workbench.action.openSettings2');
+		await this.code.waitForElement('.settings-group-title-label');
+	}
+
+	async searchSettingsUI(query: string): Promise<void> {
+		await this.openUserSettingsUI();
+		await this.code.waitForTypeInEditor('.settings-editor .suggest-input-container .monaco-editor textarea', query);
+	}
 }

--- a/test/automation/src/settings.ts
+++ b/test/automation/src/settings.ts
@@ -62,8 +62,12 @@ export class SettingsEditor {
 	async searchSettingsUI(query: string): Promise<void> {
 		await this.openUserSettingsUI();
 		await this.code.waitAndClick('.settings-editor .suggest-input-container .monaco-editor textarea');
-		await this.code.dispatchKeybinding('ctrl+a');
-		await this.code.dispatchKeybinding('backspace');
+		if (process.platform === 'darwin') {
+			await this.code.dispatchKeybinding('cmd+a');
+		} else {
+			await this.code.dispatchKeybinding('ctrl+a');
+		}
+		await this.code.dispatchKeybinding('Delete');
 		await this.code.waitForTypeInEditor('.settings-editor .suggest-input-container .monaco-editor textarea', query);
 	}
 }

--- a/test/smoke/src/areas/preferences/preferences.test.ts
+++ b/test/smoke/src/areas/preferences/preferences.test.ts
@@ -16,10 +16,10 @@ export function setup(logger: Logger) {
 			const app = this.app as Application;
 
 			await app.workbench.settingsEditor.openUserSettingsFile();
-			await app.code.waitForElements('.margin .line-numbers', false, elements => !!elements.length);
+			await app.code.waitForElements('.line-numbers', false, elements => !!elements.length);
 
 			await app.workbench.settingsEditor.addUserSetting('editor.lineNumbers', '"off"');
-			await app.code.waitForElements('.margin .line-numbers', false, elements => !elements || elements.length === 0);
+			await app.code.waitForElements('.line-numbers', false, elements => !elements || elements.length === 0);
 		});
 
 		it('changes "workbench.action.toggleSidebarPosition" command key binding and verifies it', async function () {
@@ -53,14 +53,14 @@ export function setup(logger: Logger) {
 
 			await app.workbench.editors.newUntitledFile();
 			await app.code.dispatchKeybinding('enter');
-			await app.code.waitForElements('.margin .line-numbers', false, elements => !!elements.length);
+			await app.code.waitForElements('.line-numbers', false, elements => !!elements.length);
 
 			await app.workbench.settingsEditor.searchSettingsUI('editor.lineNumbers');
 			await app.code.waitAndClick('.settings-editor .monaco-list-rows .setting-item-control select', 2, 2);
 			await app.code.waitAndClick('.context-view .option-text', 2, 2);
 
 			await app.workbench.editors.selectTab('Untitled-1');
-			await app.code.waitForElements('.margin .line-numbers', false, elements => !elements || elements.length === 0);
+			await app.code.waitForElements('.line-numbers', false, elements => !elements || elements.length === 0);
 		});
 	});
 }

--- a/test/smoke/src/areas/preferences/preferences.test.ts
+++ b/test/smoke/src/areas/preferences/preferences.test.ts
@@ -16,10 +16,10 @@ export function setup(logger: Logger) {
 			const app = this.app as Application;
 
 			await app.workbench.settingsEditor.openUserSettingsFile();
-			await app.code.waitForElements('.line-numbers', false, elements => !!elements.length);
+			await app.code.waitForElements('.margin .line-numbers', false, elements => !!elements.length);
 
 			await app.workbench.settingsEditor.addUserSetting('editor.lineNumbers', '"off"');
-			await app.code.waitForElements('.line-numbers', false, result => !result || result.length === 0);
+			await app.code.waitForElements('.margin .line-numbers', false, elements => !elements || elements.length === 0);
 		});
 
 		it('changes "workbench.action.toggleSidebarPosition" command key binding and verifies it', async function () {
@@ -43,9 +43,24 @@ export function setup(logger: Logger) {
 			const app = this.app as Application;
 
 			await app.workbench.settingsEditor.searchSettingsUI('@id:editor.tabSize');
-			await app.code.waitForSetValue('.settings-editor .setting-item-contents .setting-item-control input', '15');
+			await app.code.waitForSetValue('.settings-editor .setting-item-contents .setting-item-control input', '6');
 			await app.code.waitForElement('.settings-editor .setting-item-contents .setting-item-modified-indicator');
-			await app.code.waitForSetValue('.settings-editor .setting-item-contents .setting-item-control input', '14');
+			await app.code.waitForSetValue('.settings-editor .setting-item-contents .setting-item-control input', '4');
+		});
+
+		it('turns off editor line numbers and verifies the live change', async function () {
+			const app = this.app as Application;
+
+			await app.workbench.editors.newUntitledFile();
+			await app.code.dispatchKeybinding('enter');
+			await app.code.waitForElements('.margin .line-numbers', false, elements => !!elements.length);
+
+			await app.workbench.settingsEditor.searchSettingsUI('editor.lineNumbers');
+			await app.code.waitAndClick('.settings-editor .monaco-list-rows .setting-item-control select', 2, 2);
+			await app.code.waitAndClick('.context-view .option-text', 2, 2);
+
+			await app.workbench.editors.selectTab('Untitled-1');
+			await app.code.waitForElements('.margin .line-numbers', false, elements => !elements || elements.length === 0);
 		});
 	});
 }

--- a/test/smoke/src/areas/preferences/preferences.test.ts
+++ b/test/smoke/src/areas/preferences/preferences.test.ts
@@ -33,4 +33,19 @@ export function setup(logger: Logger) {
 			await app.workbench.activitybar.waitForActivityBar(ActivityBarPosition.RIGHT);
 		});
 	});
+
+	describe('Settings editor', () => {
+
+		// Shared before/after handling
+		installAllHandlers(logger);
+
+		it('shows a modified indicator on a modified setting', async function () {
+			const app = this.app as Application;
+
+			await app.workbench.settingsEditor.searchSettingsUI('@id:editor.tabSize');
+			await app.code.waitForSetValue('.settings-editor .setting-item-contents .setting-item-control input', '15');
+			await app.code.waitForElement('.settings-editor .setting-item-contents .setting-item-modified-indicator');
+			await app.code.waitForSetValue('.settings-editor .setting-item-contents .setting-item-control input', '14');
+		});
+	});
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Includes a Settings editor fix to remove the search results count label text when a search is cleared, so that the Settings editor smoke test has a way to know the search has completed.

Fixes #141054
