### PR TITLE
Have widget handle KEY_DOWN event

### DIFF
--- a/src/vs/platform/quickinput/browser/quickInput.ts
+++ b/src/vs/platform/quickinput/browser/quickInput.ts
@@ -1421,17 +1421,20 @@ export class QuickInputController extends Disposable {
 		this._register(dom.addDisposableListener(container, dom.EventType.FOCUS, (e: FocusEvent) => {
 			inputBox.setFocus();
 		}));
-		this._register(dom.addDisposableListener(container, dom.EventType.KEY_DOWN, (e: KeyboardEvent) => {
-			const event = new StandardKeyboardEvent(e);
+		// TODO: Turn into commands instead of handling KEY_DOWN
+		this._register(dom.addStandardDisposableListener(container, dom.EventType.KEY_DOWN, (event) => {
+			if (dom.isAncestor(event.target, widget)) {
+				return; // Ignore event if target is inside widget to allow the widget to handle the event.
+			}
 			switch (event.keyCode) {
 				case KeyCode.Enter:
-					dom.EventHelper.stop(e, true);
+					dom.EventHelper.stop(event, true);
 					if (this.enabled) {
 						this.onDidAcceptEmitter.fire();
 					}
 					break;
 				case KeyCode.Escape:
-					dom.EventHelper.stop(e, true);
+					dom.EventHelper.stop(event, true);
 					this.hide(QuickInputHideReason.Gesture);
 					break;
 				case KeyCode.Tab:
@@ -1467,17 +1470,17 @@ export class QuickInputController extends Disposable {
 						if (event.shiftKey && event.target === stops[0]) {
 							// Clear the focus from the list in order to allow
 							// screen readers to read operations in the input box.
-							dom.EventHelper.stop(e, true);
+							dom.EventHelper.stop(event, true);
 							list.clearFocus();
 						} else if (!event.shiftKey && dom.isAncestor(event.target, stops[stops.length - 1])) {
-							dom.EventHelper.stop(e, true);
+							dom.EventHelper.stop(event, true);
 							stops[0].focus();
 						}
 					}
 					break;
 				case KeyCode.Space:
 					if (event.ctrlKey) {
-						dom.EventHelper.stop(e, true);
+						dom.EventHelper.stop(event, true);
 						this.getUI().list.toggleHover();
 					}
 					break;

--- a/src/vs/workbench/contrib/chat/browser/actions/chatQuickInputActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatQuickInputActions.ts
@@ -123,12 +123,6 @@ class AskQuickQuestionAction extends Action2 {
 			}, 1000 * 30); // 30 seconds
 		}));
 
-		//#endregion
-
-		disposableStore.add(this._input.onDidAccept(() => {
-			this._currentChat?.acceptInput();
-		}));
-
 		disposableStore.add(this._input.onDidTriggerButton((e) => {
 			if (e === clearButton) {
 				this._currentChat?.clear();
@@ -136,6 +130,8 @@ class AskQuickQuestionAction extends Action2 {
 				this._currentChat?.openChatView();
 			}
 		}));
+
+		//#endregion
 
 		this._currentChat.focus();
 


### PR DESCRIPTION
The widget should have full control of this event so that the chat can do what it wants.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
