### PR TITLE
fix: devcontainer cache generation pipeline with Electron v25

### DIFF
--- a/.devcontainer/prebuilt/prepare.sh
+++ b/.devcontainer/prebuilt/prepare.sh
@@ -5,5 +5,11 @@
 # running commands like "yarn install" from the ground up. Developers (and should) still run these commands
 # after the actual dev container is created, but only differences will be processed.
 
+# npm >= v9 removed the node-gyp finder script that is bundled with npm
+# which allows to use the bundled node-gyp binary, prefer the following
+# as alternative,
+# Refs https://github.com/npm/cli/commit/3a7378d889707d2a4c1f8a6397dda87825e9f5a3
+npm install -g node-gyp
+
 yarn install --network-timeout 180000
 yarn electron


### PR DESCRIPTION
Addresses the failure seen in https://github.com/microsoft/vscode/actions/runs/5785283604/job/15678095549