### PR TITLE
add help menu for accessible views

### DIFF
--- a/src/vs/workbench/contrib/accessibility/browser/accessibility.contribution.ts
+++ b/src/vs/workbench/contrib/accessibility/browser/accessibility.contribution.ts
@@ -12,7 +12,7 @@ import { ToggleTabFocusModeAction } from 'vs/editor/contrib/toggleTabFocusMode/b
 import { localize } from 'vs/nls';
 import { InstantiationType, registerSingleton } from 'vs/platform/instantiation/common/extensions';
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
-import { AccessibilityVerbositySettingId, registerAccessibilityConfiguration } from 'vs/workbench/contrib/accessibility/browser/accessibilityConfiguration';
+import { AccessibilityVerbositySettingId, accessibleViewIsShown, registerAccessibilityConfiguration } from 'vs/workbench/contrib/accessibility/browser/accessibilityConfiguration';
 import * as strings from 'vs/base/common/strings';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { IWorkbenchContributionsRegistry, Extensions as WorkbenchExtensions } from 'vs/workbench/common/contributions';
@@ -153,6 +153,10 @@ class HoverAccessibleViewContribution extends Disposable {
 			});
 			return true;
 		}));
+		this._register(AccessibilityHelpAction.addImplementation(115, 'accessible-view', accessor => {
+			accessor.get(IAccessibleViewService).showAccessibleViewHelp();
+			return true;
+		}, accessibleViewIsShown));
 	}
 }
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
fixes #189824 

adds help menus for the accessible views and adds a hint to the aria label about opening accessibility help to reduce aria label size. 

there's still an issue where when going from the view to the help dialog, the focus on macos doesn't get updated

cc @rperez030 this is the same thing where the focus is on the right element, but VoiceOver doesn't notice that until the cursor is moved.