### PR TITLE
Improve mouse handling in sticky scroll

### DIFF
--- a/src/vs/editor/browser/controller/mouseTarget.ts
+++ b/src/vs/editor/browser/controller/mouseTarget.ts
@@ -29,7 +29,7 @@ const enum HitTestResultType {
 class UnknownHitTestResult {
 	readonly type = HitTestResultType.Unknown;
 	constructor(
-		readonly hitTarget: Element | null = null
+		readonly hitTarget: HTMLElement | null = null
 	) { }
 }
 
@@ -72,31 +72,31 @@ export class MouseTarget {
 		}
 		return range ?? null;
 	}
-	public static createUnknown(element: Element | null, mouseColumn: number, position: Position | null): IMouseTargetUnknown {
+	public static createUnknown(element: HTMLElement | null, mouseColumn: number, position: Position | null): IMouseTargetUnknown {
 		return { type: MouseTargetType.UNKNOWN, element, mouseColumn, position, range: this._deduceRage(position) };
 	}
-	public static createTextarea(element: Element | null, mouseColumn: number): IMouseTargetTextarea {
+	public static createTextarea(element: HTMLElement | null, mouseColumn: number): IMouseTargetTextarea {
 		return { type: MouseTargetType.TEXTAREA, element, mouseColumn, position: null, range: null };
 	}
-	public static createMargin(type: MouseTargetType.GUTTER_GLYPH_MARGIN | MouseTargetType.GUTTER_LINE_NUMBERS | MouseTargetType.GUTTER_LINE_DECORATIONS, element: Element | null, mouseColumn: number, position: Position, range: EditorRange, detail: IMouseTargetMarginData): IMouseTargetMargin {
+	public static createMargin(type: MouseTargetType.GUTTER_GLYPH_MARGIN | MouseTargetType.GUTTER_LINE_NUMBERS | MouseTargetType.GUTTER_LINE_DECORATIONS, element: HTMLElement | null, mouseColumn: number, position: Position, range: EditorRange, detail: IMouseTargetMarginData): IMouseTargetMargin {
 		return { type, element, mouseColumn, position, range, detail };
 	}
-	public static createViewZone(type: MouseTargetType.GUTTER_VIEW_ZONE | MouseTargetType.CONTENT_VIEW_ZONE, element: Element | null, mouseColumn: number, position: Position, detail: IMouseTargetViewZoneData): IMouseTargetViewZone {
+	public static createViewZone(type: MouseTargetType.GUTTER_VIEW_ZONE | MouseTargetType.CONTENT_VIEW_ZONE, element: HTMLElement | null, mouseColumn: number, position: Position, detail: IMouseTargetViewZoneData): IMouseTargetViewZone {
 		return { type, element, mouseColumn, position, range: this._deduceRage(position), detail };
 	}
-	public static createContentText(element: Element | null, mouseColumn: number, position: Position, range: EditorRange | null, detail: IMouseTargetContentTextData): IMouseTargetContentText {
+	public static createContentText(element: HTMLElement | null, mouseColumn: number, position: Position, range: EditorRange | null, detail: IMouseTargetContentTextData): IMouseTargetContentText {
 		return { type: MouseTargetType.CONTENT_TEXT, element, mouseColumn, position, range: this._deduceRage(position, range), detail };
 	}
-	public static createContentEmpty(element: Element | null, mouseColumn: number, position: Position, detail: IMouseTargetContentEmptyData): IMouseTargetContentEmpty {
+	public static createContentEmpty(element: HTMLElement | null, mouseColumn: number, position: Position, detail: IMouseTargetContentEmptyData): IMouseTargetContentEmpty {
 		return { type: MouseTargetType.CONTENT_EMPTY, element, mouseColumn, position, range: this._deduceRage(position), detail };
 	}
-	public static createContentWidget(element: Element | null, mouseColumn: number, detail: string): IMouseTargetContentWidget {
+	public static createContentWidget(element: HTMLElement | null, mouseColumn: number, detail: string): IMouseTargetContentWidget {
 		return { type: MouseTargetType.CONTENT_WIDGET, element, mouseColumn, position: null, range: null, detail };
 	}
-	public static createScrollbar(element: Element | null, mouseColumn: number, position: Position): IMouseTargetScrollbar {
+	public static createScrollbar(element: HTMLElement | null, mouseColumn: number, position: Position): IMouseTargetScrollbar {
 		return { type: MouseTargetType.SCROLLBAR, element, mouseColumn, position, range: this._deduceRage(position) };
 	}
-	public static createOverlayWidget(element: Element | null, mouseColumn: number, detail: string): IMouseTargetOverlayWidget {
+	public static createOverlayWidget(element: HTMLElement | null, mouseColumn: number, detail: string): IMouseTargetOverlayWidget {
 		return { type: MouseTargetType.OVERLAY_WIDGET, element, mouseColumn, position: null, range: null, detail };
 	}
 	public static createOutsideEditor(mouseColumn: number, position: Position, outsidePosition: 'above' | 'below' | 'left' | 'right', outsideDistance: number): IMouseTargetOutsideEditor {
@@ -389,10 +389,10 @@ abstract class BareHitTestRequest {
 
 class HitTestRequest extends BareHitTestRequest {
 	private readonly _ctx: HitTestContext;
-	public readonly target: Element | null;
+	public readonly target: HTMLElement | null;
 	public readonly targetPath: Uint8Array;
 
-	constructor(ctx: HitTestContext, editorPos: EditorPagePosition, pos: PageCoordinates, relativePos: CoordinatesRelativeToEditor, target: Element | null) {
+	constructor(ctx: HitTestContext, editorPos: EditorPagePosition, pos: PageCoordinates, relativePos: CoordinatesRelativeToEditor, target: HTMLElement | null) {
 		super(ctx, editorPos, pos, relativePos);
 		this._ctx = ctx;
 
@@ -445,13 +445,13 @@ class HitTestRequest extends BareHitTestRequest {
 		return MouseTarget.createOverlayWidget(this.target, this._getMouseColumn(), detail);
 	}
 
-	public withTarget(target: Element | null): HitTestRequest {
+	public withTarget(target: HTMLElement | null): HitTestRequest {
 		return new HitTestRequest(this._ctx, this.editorPos, this.pos, this.relativePos, target);
 	}
 }
 
 interface ResolvedHitTestRequest extends HitTestRequest {
-	readonly target: Element;
+	readonly target: HTMLElement;
 }
 
 const EMPTY_CONTENT_AFTER_LINES: IMouseTargetContentEmptyData = { isAfterLines: true };

--- a/src/vs/editor/browser/editorBrowser.ts
+++ b/src/vs/editor/browser/editorBrowser.ts
@@ -358,7 +358,7 @@ export interface IBaseMouseTarget {
 	/**
 	 * The target element
 	 */
-	readonly element: Element | null;
+	readonly element: HTMLElement | null;
 	/**
 	 * The 'approximate' editor position
 	 */

--- a/src/vs/editor/browser/viewParts/lines/viewLines.ts
+++ b/src/vs/editor/browser/viewParts/lines/viewLines.ts
@@ -364,7 +364,7 @@ export class ViewLines extends ViewPart implements IVisibleLinesHost<ViewLine>, 
 			return null;
 		}
 
-		let column = this._visibleLines.getVisibleLine(lineNumber).getColumnOfNodeOffset(lineNumber, spanNode, offset);
+		let column = this._visibleLines.getVisibleLine(lineNumber).getColumnOfNodeOffset(spanNode, offset);
 		const minColumn = this._context.viewModel.getLineMinColumn(lineNumber);
 		if (column < minColumn) {
 			column = minColumn;

--- a/src/vs/editor/contrib/folding/browser/folding.ts
+++ b/src/vs/editor/contrib/folding/browser/folding.ts
@@ -407,7 +407,7 @@ export class FoldingController extends Disposable implements IEditorContribution
 		switch (e.target.type) {
 			case MouseTargetType.GUTTER_LINE_DECORATIONS: {
 				const data = e.target.detail;
-				const offsetLeftInGutter = (e.target.element as HTMLElement).offsetLeft;
+				const offsetLeftInGutter = e.target.element!.offsetLeft;
 				const gutterOffsetX = data.offsetX - offsetLeftInGutter;
 
 				// const gutterOffsetX = data.offsetX - data.glyphMarginWidth - data.lineNumbersWidth - data.glyphMarginLeft;

--- a/src/vs/editor/contrib/gotoSymbol/browser/link/clickLinkGesture.ts
+++ b/src/vs/editor/contrib/gotoSymbol/browser/link/clickLinkGesture.ts
@@ -100,6 +100,13 @@ function createOptions(multiCursorModifier: 'altKey' | 'ctrlKey' | 'metaKey'): C
 	return new ClickLinkOptions(KeyCode.Alt, 'altKey', KeyCode.Ctrl, 'ctrlKey');
 }
 
+export interface IClickLinkGestureOptions {
+	/**
+	 * Return 0 if the mouse event should not be considered.
+	 */
+	extractLineNumberFromMouseEvent?: (e: ClickLinkMouseEvent) => number;
+}
+
 export class ClickLinkGesture extends Disposable {
 
 	private readonly _onMouseMoveOrRelevantKeyDown: Emitter<[ClickLinkMouseEvent, ClickLinkKeyboardEvent | null]> = this._register(new Emitter<[ClickLinkMouseEvent, ClickLinkKeyboardEvent | null]>());
@@ -112,18 +119,18 @@ export class ClickLinkGesture extends Disposable {
 	public readonly onCancel: Event<void> = this._onCancel.event;
 
 	private readonly _editor: ICodeEditor;
-	private readonly _alwaysFireExecuteOnMouseUp?: boolean;
+	private readonly _extractLineNumberFromMouseEvent: (e: ClickLinkMouseEvent) => number;
 	private _opts: ClickLinkOptions;
 
 	private _lastMouseMoveEvent: ClickLinkMouseEvent | null;
 	private _hasTriggerKeyOnMouseDown: boolean;
 	private _lineNumberOnMouseDown: number;
 
-	constructor(editor: ICodeEditor, alwaysFireOnMouseUp?: boolean) {
+	constructor(editor: ICodeEditor, opts?: IClickLinkGestureOptions) {
 		super();
 
 		this._editor = editor;
-		this._alwaysFireExecuteOnMouseUp = alwaysFireOnMouseUp;
+		this._extractLineNumberFromMouseEvent = opts?.extractLineNumberFromMouseEvent ?? ((e) => e.target.position ? e.target.position.lineNumber : 0);
 		this._opts = createOptions(this._editor.getOption(EditorOption.multiCursorModifier));
 
 		this._lastMouseMoveEvent = null;
@@ -178,12 +185,12 @@ export class ClickLinkGesture extends Disposable {
 		// release the mouse button without wanting to do the navigation.
 		// With this flag we prevent goto definition if the mouse was down before the trigger key was pressed.
 		this._hasTriggerKeyOnMouseDown = mouseEvent.hasTriggerModifier;
-		this._lineNumberOnMouseDown = mouseEvent.target.position ? mouseEvent.target.position.lineNumber : 0;
+		this._lineNumberOnMouseDown = this._extractLineNumberFromMouseEvent(mouseEvent);
 	}
 
 	private _onEditorMouseUp(mouseEvent: ClickLinkMouseEvent): void {
-		const currentLineNumber = mouseEvent.target.position ? mouseEvent.target.position.lineNumber : 0;
-		if (this._hasTriggerKeyOnMouseDown && this._lineNumberOnMouseDown && this._lineNumberOnMouseDown === currentLineNumber || this._alwaysFireExecuteOnMouseUp) {
+		const currentLineNumber = this._extractLineNumberFromMouseEvent(mouseEvent);
+		if (this._hasTriggerKeyOnMouseDown && this._lineNumberOnMouseDown && this._lineNumberOnMouseDown === currentLineNumber) {
 			this._onExecute.fire(mouseEvent);
 		}
 	}

--- a/src/vs/editor/contrib/stickyScroll/browser/stickyScrollController.ts
+++ b/src/vs/editor/contrib/stickyScroll/browser/stickyScrollController.ts
@@ -210,21 +210,13 @@ export class StickyScrollController extends Disposable implements IEditorContrib
 				// not on a span element rendering text
 				return null;
 			}
-
-			const text = mouseTargetElement.innerText;
-			if (this._stickyScrollWidget.hoverOnColumn === -1) {
-				return null;
-			}
-
-			const lineNumber = this._stickyScrollWidget.getLineNumberFromChildDomNode(mouseTargetElement);
-			if (lineNumber === null) {
+			const position = this._stickyScrollWidget.getEditorPositionFromNode(mouseTargetElement);
+			if (!position) {
 				// not hovering a sticky scroll line
 				return null;
 			}
-			const column = this._stickyScrollWidget.hoverOnColumn;
-
 			return {
-				range: new Range(lineNumber, column, lineNumber, column + text.length),
+				range: new Range(position.lineNumber, position.column, position.lineNumber, position.column + mouseTargetElement.innerText.length),
 				textElement: mouseTargetElement
 			};
 		};
@@ -283,8 +275,8 @@ export class StickyScrollController extends Disposable implements IEditorContrib
 				// not hovering over our widget
 				return;
 			}
-			const lineNumber = this._stickyScrollWidget.getLineNumberFromChildDomNode(e.target.element);
-			if (lineNumber === null) {
+			const position = this._stickyScrollWidget.getEditorPositionFromNode(e.target.element);
+			if (!position) {
 				// not hovering a sticky scroll line
 				return;
 			}
@@ -294,7 +286,7 @@ export class StickyScrollController extends Disposable implements IEditorContrib
 					if (this._focused) {
 						this._disposeFocusStickyScrollStore();
 					}
-					this._revealPosition({ lineNumber, column: 1 });
+					this._revealPosition({ lineNumber: position.lineNumber, column: 1 });
 				}
 				this._instaService.invokeFunction(goToDefinitionWithLocation, e, this._editor as IActiveCodeEditor, { uri: this._editor.getModel()!.uri, range: this._stickyRangeProjectedOnEditor! });
 
@@ -303,7 +295,7 @@ export class StickyScrollController extends Disposable implements IEditorContrib
 				if (this._focused) {
 					this._disposeFocusStickyScrollStore();
 				}
-				this._revealPosition({ lineNumber, column: this._stickyScrollWidget.hoverOnColumn });
+				this._revealPosition(position);
 			}
 		}));
 		return linkGestureStore;

--- a/src/vs/editor/contrib/stickyScroll/browser/stickyScrollWidget.ts
+++ b/src/vs/editor/contrib/stickyScroll/browser/stickyScrollWidget.ts
@@ -24,6 +24,7 @@ export class StickyScrollWidgetState {
 }
 
 const _ttPolicy = createTrustedTypesPolicy('stickyScrollViewLayer', { createHTML: value => value });
+const STICKY_LINE_NUMBER_ATTR = 'data-sticky-line-number';
 
 export class StickyScrollWidget extends Disposable implements IOverlayWidget {
 
@@ -36,7 +37,6 @@ export class StickyScrollWidget extends Disposable implements IOverlayWidget {
 	private _stickyLines: HTMLElement[] = [];
 	private _lineNumbers: number[] = [];
 	private _lastLineRelativePosition: number = 0;
-	private _hoverOnLine: number = -1;
 	private _hoverOnColumn: number = -1;
 	private _minContentWidthInPx: number = 0;
 
@@ -81,10 +81,6 @@ export class StickyScrollWidget extends Disposable implements IOverlayWidget {
 			this._updateWidgetWidth();
 		}));
 		this._updateWidgetWidth();
-	}
-
-	get hoverOnLine(): number {
-		return this._hoverOnLine;
 	}
 
 	get hoverOnColumn(): number {
@@ -224,6 +220,7 @@ export class StickyScrollWidget extends Disposable implements IOverlayWidget {
 		this._editor.applyFontInfo(innerLineNumberHTML);
 
 		lineHTMLNode.setAttribute('role', 'listitem');
+		lineHTMLNode.setAttribute(STICKY_LINE_NUMBER_ATTR, String(line));
 		lineHTMLNode.tabIndex = 0;
 
 		lineNumberHTMLNode.style.lineHeight = `${lineHeight}px`;
@@ -250,8 +247,7 @@ export class StickyScrollWidget extends Disposable implements IOverlayWidget {
 				const mouseOverEvent = new StandardMouseEvent(e);
 				const text = mouseOverEvent.target.innerText;
 
-				// Line and column number of the hover needed for the control clicking feature
-				this._hoverOnLine = line;
+				// column number of the hover needed for the control clicking feature
 				// TODO: workaround to find the column index, perhaps need a more solid solution
 				this._hoverOnColumn = this._editor.getModel().getLineContent(line).indexOf(text) + 1 || -1;
 			}
@@ -292,5 +288,20 @@ export class StickyScrollWidget extends Disposable implements IOverlayWidget {
 		if (0 <= index && index < this._stickyLines.length) {
 			this._stickyLines[index].focus();
 		}
+	}
+
+	/**
+	 * Given a child dom node, tries to find the line number attribute
+	 * that was stored in the node. Returns null if none is found.
+	 */
+	getLineNumberFromChildDomNode(domNode: HTMLElement | null): number | null {
+		while (domNode && domNode !== this._rootDomNode) {
+			const line = domNode.getAttribute(STICKY_LINE_NUMBER_ATTR);
+			if (line) {
+				return parseInt(line, 10);
+			}
+			domNode = domNode.parentElement;
+		}
+		return null;
 	}
 }

--- a/src/vs/editor/contrib/stickyScroll/browser/stickyScrollWidget.ts
+++ b/src/vs/editor/contrib/stickyScroll/browser/stickyScrollWidget.ts
@@ -282,13 +282,24 @@ export class StickyScrollWidget extends Disposable implements IOverlayWidget {
 			// This is not a leaf node
 			return null;
 		}
-		const index = this._getStickyLineIndexFromChildDomNode(spanDomNode);
+		const renderedStickyLine = this._getRenderedStickyLineFromChildDomNode(spanDomNode);
+		if (!renderedStickyLine) {
+			return null;
+		}
+		const column = getColumnOfNodeOffset(renderedStickyLine.characterMapping, spanDomNode, 0);
+		return new Position(renderedStickyLine.lineNumber, column);
+	}
+
+	getLineNumberFromChildDomNode(domNode: HTMLElement | null): number | null {
+		return this._getRenderedStickyLineFromChildDomNode(domNode)?.lineNumber ?? null;
+	}
+
+	private _getRenderedStickyLineFromChildDomNode(domNode: HTMLElement | null): RenderedStickyLine | null {
+		const index = this._getStickyLineIndexFromChildDomNode(domNode);
 		if (index === null || index < 0 || index >= this._stickyLines.length) {
 			return null;
 		}
-		const renderedStickyLine = this._stickyLines[index];
-		const column = getColumnOfNodeOffset(renderedStickyLine.characterMapping, spanDomNode, 0);
-		return new Position(renderedStickyLine.lineNumber, column);
+		return this._stickyLines[index];
 	}
 
 	/**

--- a/src/vs/editor/contrib/stickyScroll/browser/stickyScrollWidget.ts
+++ b/src/vs/editor/contrib/stickyScroll/browser/stickyScrollWidget.ts
@@ -4,17 +4,17 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as dom from 'vs/base/browser/dom';
-import { StandardMouseEvent } from 'vs/base/browser/mouseEvent';
 import { createTrustedTypesPolicy } from 'vs/base/browser/trustedTypes';
-import { Disposable, DisposableStore } from 'vs/base/common/lifecycle';
+import { Disposable } from 'vs/base/common/lifecycle';
 import 'vs/css!./stickyScroll';
 import { ICodeEditor, IOverlayWidget, IOverlayWidgetPosition } from 'vs/editor/browser/editorBrowser';
+import { getColumnOfNodeOffset } from 'vs/editor/browser/viewParts/lines/viewLine';
 import { EmbeddedCodeEditorWidget } from 'vs/editor/browser/widget/embeddedCodeEditorWidget';
 import { EditorLayoutInfo, EditorOption, RenderLineNumbersType } from 'vs/editor/common/config/editorOptions';
 import { Position } from 'vs/editor/common/core/position';
 import { StringBuilder } from 'vs/editor/common/core/stringBuilder';
 import { LineDecoration } from 'vs/editor/common/viewLayout/lineDecorations';
-import { RenderLineInput, renderViewLine } from 'vs/editor/common/viewLayout/viewLineRenderer';
+import { CharacterMapping, RenderLineInput, renderViewLine } from 'vs/editor/common/viewLayout/viewLineRenderer';
 
 export class StickyScrollWidgetState {
 	constructor(
@@ -24,7 +24,7 @@ export class StickyScrollWidgetState {
 }
 
 const _ttPolicy = createTrustedTypesPolicy('stickyScrollViewLayer', { createHTML: value => value });
-const STICKY_LINE_NUMBER_ATTR = 'data-sticky-line-number';
+const STICKY_LINE_INDEX_ATTR = 'data-sticky-line-index';
 
 export class StickyScrollWidget extends Disposable implements IOverlayWidget {
 
@@ -32,12 +32,10 @@ export class StickyScrollWidget extends Disposable implements IOverlayWidget {
 	private readonly _lineNumbersDomNode: HTMLElement = document.createElement('div');
 	private readonly _linesDomNodeScrollable: HTMLElement = document.createElement('div');
 	private readonly _linesDomNode: HTMLElement = document.createElement('div');
-	private readonly _disposableStore = this._register(new DisposableStore());
 
-	private _stickyLines: HTMLElement[] = [];
+	private _stickyLines: RenderedStickyLine[] = [];
 	private _lineNumbers: number[] = [];
 	private _lastLineRelativePosition: number = 0;
-	private _hoverOnColumn: number = -1;
 	private _minContentWidthInPx: number = 0;
 
 	constructor(
@@ -83,10 +81,6 @@ export class StickyScrollWidget extends Disposable implements IOverlayWidget {
 		this._updateWidgetWidth();
 	}
 
-	get hoverOnColumn(): number {
-		return this._hoverOnColumn;
-	}
-
 	get lineNumbers(): number[] {
 		return this._lineNumbers;
 	}
@@ -103,7 +97,6 @@ export class StickyScrollWidget extends Disposable implements IOverlayWidget {
 		dom.clearNode(this._lineNumbersDomNode);
 		dom.clearNode(this._linesDomNode);
 		this._stickyLines = [];
-		this._disposableStore.clear();
 		const editorLineHeight = this._editor.getOption(EditorOption.lineHeight);
 		const futureWidgetHeight = state.lineNumbers.length * editorLineHeight + state.lastLineRelativePosition;
 
@@ -134,10 +127,10 @@ export class StickyScrollWidget extends Disposable implements IOverlayWidget {
 
 		const layoutInfo = this._editor.getLayoutInfo();
 		for (const [index, line] of this._lineNumbers.entries()) {
-			const { lineNumberHTMLNode, lineHTMLNode } = this._renderChildNode(index, line, layoutInfo);
+			const { lineNumberHTMLNode, renderedStickyLine } = this._renderChildNode(index, line, layoutInfo);
 			this._lineNumbersDomNode.appendChild(lineNumberHTMLNode);
-			this._linesDomNode.appendChild(lineHTMLNode);
-			this._stickyLines.push(lineHTMLNode);
+			this._linesDomNode.appendChild(renderedStickyLine.domNode);
+			this._stickyLines.push(renderedStickyLine);
 		}
 
 		const editorLineHeight = this._editor.getOption(EditorOption.lineHeight);
@@ -157,7 +150,7 @@ export class StickyScrollWidget extends Disposable implements IOverlayWidget {
 		this._editor.layoutOverlayWidget(this);
 	}
 
-	private _renderChildNode(index: number, line: number, layoutInfo: EditorLayoutInfo): { lineNumberHTMLNode: HTMLSpanElement; lineHTMLNode: HTMLSpanElement } {
+	private _renderChildNode(index: number, line: number, layoutInfo: EditorLayoutInfo): { lineNumberHTMLNode: HTMLSpanElement; renderedStickyLine: RenderedStickyLine } {
 		const viewModel = this._editor._getViewModel();
 		const viewLineNumber = viewModel!.coordinatesConverter.convertModelPositionToViewPosition(new Position(line, 1)).lineNumber;
 		const lineRenderingData = viewModel!.getViewLineRenderingData(viewLineNumber);
@@ -181,7 +174,7 @@ export class StickyScrollWidget extends Disposable implements IOverlayWidget {
 		);
 
 		const sb = new StringBuilder(2000);
-		renderViewLine(renderLineInput, sb);
+		const renderOutput = renderViewLine(renderLineInput, sb);
 
 		let newLine;
 		if (_ttPolicy) {
@@ -220,7 +213,7 @@ export class StickyScrollWidget extends Disposable implements IOverlayWidget {
 		this._editor.applyFontInfo(innerLineNumberHTML);
 
 		lineHTMLNode.setAttribute('role', 'listitem');
-		lineHTMLNode.setAttribute(STICKY_LINE_NUMBER_ATTR, String(line));
+		lineHTMLNode.setAttribute(STICKY_LINE_INDEX_ATTR, String(index));
 		lineHTMLNode.tabIndex = 0;
 
 		lineNumberHTMLNode.style.lineHeight = `${lineHeight}px`;
@@ -241,26 +234,17 @@ export class StickyScrollWidget extends Disposable implements IOverlayWidget {
 		lineHTMLNode.style.top = isLastLine ? lastLineTop : intermediateLineTop;
 		lineNumberHTMLNode.style.top = isLastLine ? lastLineTop : intermediateLineTop;
 
-		// Each child has a listener which fires when the mouse hovers over the child
-		this._disposableStore.add(dom.addDisposableListener(lineHTMLNode, 'mouseover', (e) => {
-			if (this._editor.hasModel()) {
-				const mouseOverEvent = new StandardMouseEvent(e);
-				const text = mouseOverEvent.target.innerText;
-
-				// column number of the hover needed for the control clicking feature
-				// TODO: workaround to find the column index, perhaps need a more solid solution
-				this._hoverOnColumn = this._editor.getModel().getLineContent(line).indexOf(text) + 1 || -1;
-			}
-		}));
-
-		return { lineNumberHTMLNode, lineHTMLNode };
+		return {
+			lineNumberHTMLNode,
+			renderedStickyLine: new RenderedStickyLine(line, lineHTMLNode, renderOutput.characterMapping)
+		};
 	}
 
 	private _updateMinContentWidth() {
 		this._minContentWidthInPx = 0;
 		for (const stickyLine of this._stickyLines) {
-			if (stickyLine.scrollWidth > this._minContentWidthInPx) {
-				this._minContentWidthInPx = stickyLine.scrollWidth;
+			if (stickyLine.domNode.scrollWidth > this._minContentWidthInPx) {
+				this._minContentWidthInPx = stickyLine.domNode.scrollWidth;
 			}
 		}
 		this._minContentWidthInPx += this._editor.getLayoutInfo().verticalScrollbarWidth;
@@ -286,17 +270,34 @@ export class StickyScrollWidget extends Disposable implements IOverlayWidget {
 
 	focusLineWithIndex(index: number) {
 		if (0 <= index && index < this._stickyLines.length) {
-			this._stickyLines[index].focus();
+			this._stickyLines[index].domNode.focus();
 		}
+	}
+
+	/**
+	 * Given a leaf dom node, tries to find the editor position.
+	 */
+	getEditorPositionFromNode(spanDomNode: HTMLElement | null): Position | null {
+		if (!spanDomNode || spanDomNode.children.length > 0) {
+			// This is not a leaf node
+			return null;
+		}
+		const index = this._getStickyLineIndexFromChildDomNode(spanDomNode);
+		if (index === null || index < 0 || index >= this._stickyLines.length) {
+			return null;
+		}
+		const renderedStickyLine = this._stickyLines[index];
+		const column = getColumnOfNodeOffset(renderedStickyLine.characterMapping, spanDomNode, 0);
+		return new Position(renderedStickyLine.lineNumber, column);
 	}
 
 	/**
 	 * Given a child dom node, tries to find the line number attribute
 	 * that was stored in the node. Returns null if none is found.
 	 */
-	getLineNumberFromChildDomNode(domNode: HTMLElement | null): number | null {
+	private _getStickyLineIndexFromChildDomNode(domNode: HTMLElement | null): number | null {
 		while (domNode && domNode !== this._rootDomNode) {
-			const line = domNode.getAttribute(STICKY_LINE_NUMBER_ATTR);
+			const line = domNode.getAttribute(STICKY_LINE_INDEX_ATTR);
 			if (line) {
 				return parseInt(line, 10);
 			}
@@ -304,4 +305,12 @@ export class StickyScrollWidget extends Disposable implements IOverlayWidget {
 		}
 		return null;
 	}
+}
+
+class RenderedStickyLine {
+	constructor(
+		public readonly lineNumber: number,
+		public readonly domNode: HTMLElement,
+		public readonly characterMapping: CharacterMapping
+	) { }
 }

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -5535,7 +5535,7 @@ declare namespace monaco.editor {
 		/**
 		 * The target element
 		 */
-		readonly element: Element | null;
+		readonly element: HTMLElement | null;
 		/**
 		 * The 'approximate' editor position
 		 */

--- a/src/vs/workbench/contrib/scm/browser/dirtydiffDecorator.ts
+++ b/src/vs/workbench/contrib/scm/browser/dirtydiffDecorator.ts
@@ -918,7 +918,7 @@ export class DirtyDiffController extends Disposable implements DirtyDiffContribu
 		}
 
 		const data = e.target.detail;
-		const offsetLeftInGutter = (e.target.element as HTMLElement).offsetLeft;
+		const offsetLeftInGutter = e.target.element.offsetLeft;
 		const gutterOffsetX = data.offsetX - offsetLeftInGutter;
 
 		// TODO@joao TODO@alex TODO@martin this is such that we don't collide with folding


### PR DESCRIPTION
* Change IBaseMouseTarget.element to be an HTMLElement
* Eliminate StickyScrollWidget.hoverOnLine and use the DOM to store the rendered line number
* Extract duplicated `getColumnOfNodeOffset`
* Avoid using a mouseover listener to determine the position
* Handle regular clicks with a separate mouse up listener