### PR TITLE
testing: improve experience for test-correlated console output

### DIFF
--- a/src/vs/platform/terminal/common/xterm/shellIntegrationAddon.ts
+++ b/src/vs/platform/terminal/common/xterm/shellIntegrationAddon.ts
@@ -236,6 +236,10 @@ export class ShellIntegrationAddon extends Disposable implements IShellIntegrati
 		this._ensureCapabilitiesOrAddFailureTelemetry();
 	}
 
+	getMarkerId(terminal: Terminal, vscodeMarkerId: string) {
+		this._createOrGetBufferMarkDetection(terminal).getMark(vscodeMarkerId);
+	}
+
 	private _handleFinalTermSequence(data: string): boolean {
 		const didHandle = this._doHandleFinalTermSequence(data);
 		if (this._status === ShellIntegrationStatus.Off) {

--- a/src/vs/workbench/contrib/terminal/browser/terminal.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminal.ts
@@ -1041,6 +1041,17 @@ export interface IXtermTerminal extends IDisposable {
 	selectAll(): void;
 
 	/**
+	 * Selects the content between the two markers by their VS Code OSC `SetMarker`
+	 * ID. It's a no-op if either of the two markers are not found.
+	 *
+	 * @param fromMarkerId Start marker ID
+	 * @param toMarkerId End marker ID
+	 * @param scrollIntoView Whether the terminal should scroll to the start of
+	 * the range, defaults tof alse
+	 */
+	selectMarkedRange(fromMarkerId: string, toMarkerId: string, scrollIntoView?: boolean): void;
+
+	/**
 	 * Copies the terminal selection.
 	 * @param {boolean} copyAsHtml Whether to copy selection as HTML, defaults to false.
 	 */
@@ -1096,8 +1107,11 @@ export interface IDetachedXtermTerminal extends IXtermTerminal {
 
 	/**
 	 * Writes data to the terminal.
+	 * @param data data to write
+	 * @param callback Optional callback that fires when the data was processed
+	 * by the parser.
 	 */
-	write(data: string | Uint8Array): void;
+	write(data: string | Uint8Array, callback?: () => void): void;
 
 	/**
 	 * Resizes the terminal.

--- a/src/vs/workbench/contrib/terminal/browser/xterm/xtermTerminal.ts
+++ b/src/vs/workbench/contrib/terminal/browser/xterm/xtermTerminal.ts
@@ -381,8 +381,8 @@ export class XtermTerminal extends DisposableStore implements IXtermTerminal, ID
 		this._anyFocusedTerminalHasSelection.set(isFocused && this.raw.hasSelection());
 	}
 
-	write(data: string | Uint8Array): void {
-		this.raw.write(data);
+	write(data: string | Uint8Array, callback?: () => void): void {
+		this.raw.write(data, callback);
 	}
 
 	resize(columns: number, rows: number): void {
@@ -593,6 +593,24 @@ export class XtermTerminal extends DisposableStore implements IXtermTerminal, ID
 
 	clearSelection(): void {
 		this.raw.clearSelection();
+	}
+
+	selectMarkedRange(fromMarkerId: string, toMarkerId: string, scrollIntoView = false) {
+		const detectionCapability = this.shellIntegration.capabilities.get(TerminalCapability.BufferMarkDetection);
+		if (!detectionCapability) {
+			return;
+		}
+
+		const start = detectionCapability.getMark(fromMarkerId);
+		const end = detectionCapability.getMark(toMarkerId);
+		if (start === undefined || end === undefined) {
+			return;
+		}
+
+		this.raw.selectLines(start.line, end.line);
+		if (scrollIntoView) {
+			this.raw.scrollToLine(start.line);
+		}
 	}
 
 	selectAll(): void {

--- a/src/vs/workbench/contrib/testing/browser/testingOutputPeek.ts
+++ b/src/vs/workbench/contrib/testing/browser/testingOutputPeek.ts
@@ -16,6 +16,7 @@ import { ICompressibleTreeRenderer } from 'vs/base/browser/ui/tree/objectTree';
 import { ITreeContextMenuEvent, ITreeNode } from 'vs/base/browser/ui/tree/tree';
 import { Action, IAction, Separator } from 'vs/base/common/actions';
 import { Delayer, Limiter, RunOnceScheduler } from 'vs/base/common/async';
+import { VSBuffer } from 'vs/base/common/buffer';
 import { Codicon } from 'vs/base/common/codicons';
 import { Color } from 'vs/base/common/color';
 import { Emitter, Event } from 'vs/base/common/event';
@@ -28,6 +29,7 @@ import { Lazy } from 'vs/base/common/lazy';
 import { Disposable, DisposableStore, IDisposable, IReference, MutableDisposable, toDisposable } from 'vs/base/common/lifecycle';
 import { count } from 'vs/base/common/strings';
 import { ThemeIcon } from 'vs/base/common/themables';
+import { isDefined } from 'vs/base/common/types';
 import { URI } from 'vs/base/common/uri';
 import 'vs/css!./testingOutputPeek';
 import { ICodeEditor, IDiffEditorConstructionOptions, isCodeEditor } from 'vs/editor/browser/editorBrowser';
@@ -83,10 +85,10 @@ import { IObservableValue, MutableObservableValue, staticObservableValue } from 
 import { StoredValue } from 'vs/workbench/contrib/testing/common/storedValue';
 import { ITestExplorerFilterState } from 'vs/workbench/contrib/testing/common/testExplorerFilterState';
 import { ITestProfileService } from 'vs/workbench/contrib/testing/common/testProfileService';
-import { ITestResult, LiveTestResult, TestResultItemChange, TestResultItemChangeReason, maxCountPriority, resultItemParents } from 'vs/workbench/contrib/testing/common/testResult';
+import { ITaskRawOutput, ITestResult, ITestRunTaskResults, LiveTestResult, TestResultItemChange, TestResultItemChangeReason, maxCountPriority, resultItemParents } from 'vs/workbench/contrib/testing/common/testResult';
 import { ITestResultService, ResultChangeEvent } from 'vs/workbench/contrib/testing/common/testResultService';
 import { ITestService } from 'vs/workbench/contrib/testing/common/testService';
-import { IRichLocation, ITestErrorMessage, ITestItem, ITestMessage, ITestRunTask, ITestTaskState, TestMessageType, TestResultItem, TestResultState, TestRunProfileBitset } from 'vs/workbench/contrib/testing/common/testTypes';
+import { IRichLocation, ITestErrorMessage, ITestItem, ITestMessage, ITestRunTask, ITestTaskState, TestMessageType, TestResultItem, TestResultState, TestRunProfileBitset, getMarkId } from 'vs/workbench/contrib/testing/common/testTypes';
 import { TestingContextKeys } from 'vs/workbench/contrib/testing/common/testingContextKeys';
 import { IShowResultOptions, ITestingPeekOpener } from 'vs/workbench/contrib/testing/common/testingPeekOpener';
 import { cmpPriority, isFailedState } from 'vs/workbench/contrib/testing/common/testingStates';
@@ -95,6 +97,7 @@ import { IEditorService } from 'vs/workbench/services/editor/common/editorServic
 
 class MessageSubject {
 	public readonly test: ITestItem;
+	public readonly message: ITestMessage;
 	public readonly messages: ITestMessage[];
 	public readonly expectedUri: URI;
 	public readonly actualUri: URI;
@@ -116,7 +119,7 @@ class MessageSubject {
 		this.actualUri = buildTestUri({ ...parts, type: TestUriType.ResultActualOutput });
 		this.messageUri = buildTestUri({ ...parts, type: TestUriType.ResultMessage });
 
-		const message = this.messages[this.messageIndex];
+		const message = this.message = this.messages[this.messageIndex];
 		this.revealLocation = message.location ?? (test.item.uri && test.item.range ? { uri: test.item.uri, range: Range.lift(test.item.range) } : undefined);
 	}
 }
@@ -130,12 +133,24 @@ class TaskSubject {
 	}
 }
 
-type InspectSubject = MessageSubject | TaskSubject;
+class TestOutputSubject {
+	public readonly revealLocation: undefined;
+
+	public get outputUri() {
+		return buildTestUri({ resultId: this.resultId, taskIndex: this.taskIndex, testExtId: this.test.item.extId, type: TestUriType.TestOutput });
+	}
+
+	constructor(public readonly resultId: string, public readonly taskIndex: number, public readonly task: ITestRunTask, public readonly test: TestResultItem) {
+	}
+}
+
+type InspectSubject = MessageSubject | TaskSubject | TestOutputSubject;
 
 const equalsSubject = (a: InspectSubject, b: InspectSubject) =>
 	a.resultId === b.resultId && a.taskIndex === b.taskIndex && (
 		(a instanceof MessageSubject && b instanceof MessageSubject && a.messageIndex === b.messageIndex) ||
-		(a instanceof TaskSubject && b instanceof TaskSubject)
+		(a instanceof TaskSubject && b instanceof TaskSubject) ||
+		(a instanceof TestOutputSubject && b instanceof TestOutputSubject && a.test === b.test)
 	);
 
 /** Iterates through every message in every result */
@@ -233,6 +248,10 @@ export class TestingPeekOpener extends Disposable implements ITestingPeekOpener 
 			return false;
 		}
 
+		if (!('messageIndex' in parsed)) {
+			return false;
+		}
+
 		const message = result.getStateById(parsed.testExtId)?.tasks[parsed.taskIndex].messages[parsed.messageIndex];
 		if (!message?.location) {
 			return false;
@@ -263,12 +282,17 @@ export class TestingPeekOpener extends Disposable implements ITestingPeekOpener 
 		}
 
 		const options = { pinned: false, revealIfOpened: true };
-		if (current instanceof TaskSubject) {
+		if (current instanceof TaskSubject || current instanceof TestOutputSubject) {
 			this.editorService.openEditor({ resource: current.outputUri, options });
 			return;
 		}
 
-		const message = current.messages[current.messageIndex];
+		if (current instanceof TestOutputSubject) {
+			this.editorService.openEditor({ resource: current.outputUri, options });
+			return;
+		}
+
+		const message = current.message;
 		if (current.isDiffable) {
 			this.editorService.openEditor({
 				original: { resource: current.expectedUri },
@@ -375,7 +399,7 @@ export class TestingPeekOpener extends Disposable implements ITestingPeekOpener 
 			}
 
 			mapFindTestMessage(result[1], (_task, message, messageIndex, taskIndex) => {
-				if (!message.location || message.location.uri.toString() !== demandedUriStr) {
+				if (message.type !== TestMessageType.Error || !message.location || message.location.uri.toString() !== demandedUriStr) {
 					return;
 				}
 
@@ -544,8 +568,7 @@ export class TestingOutputPeekController extends Disposable implements IEditorCo
 		}
 
 		if (subject instanceof MessageSubject) {
-			const message = subject.messages[subject.messageIndex];
-			alert(renderStringAsPlaintext(message.message));
+			alert(renderStringAsPlaintext(subject.message.message));
 		}
 
 		this.peek.value.setModel(subject);
@@ -604,7 +627,13 @@ export class TestingOutputPeekController extends Disposable implements IEditorCo
 					testExtId: test.item.extId
 				}));
 				return;
-			} if (subject instanceof MessageSubject && subject.test.extId === test.item.extId && subject.messageIndex === messageIndex && subject.taskIndex === taskIndex && subject.resultId === result.id) {
+			}
+
+			if (subject instanceof TestOutputSubject && subject.test.item.extId === test.item.extId && subject.taskIndex === taskIndex && subject.resultId === result.id) {
+				found = true;
+			}
+
+			if (subject instanceof MessageSubject && subject.test.extId === test.item.extId && subject.messageIndex === messageIndex && subject.taskIndex === taskIndex && subject.resultId === result.id) {
 				found = true;
 			}
 		}
@@ -623,6 +652,13 @@ export class TestingOutputPeekController extends Disposable implements IEditorCo
 		for (const m of allMessages(this.testResults.results)) {
 			if (subject instanceof TaskSubject) {
 				if (m.result.id === subject.resultId) {
+					break;
+				}
+				continue;
+			}
+
+			if (subject instanceof TestOutputSubject) {
+				if (m.test.item.extId === subject.test.item.extId && m.result.id === subject.resultId && m.taskIndex === subject.taskIndex) {
 					break;
 				}
 				continue;
@@ -686,6 +722,14 @@ export class TestingOutputPeekController extends Disposable implements IEditorCo
 
 		if (parts.type === TestUriType.TaskOutput) {
 			return new TaskSubject(parts.resultId, parts.taskIndex);
+		}
+
+		if (parts.type === TestUriType.TestOutput) {
+			const result = this.testResults.results.find(r => r.id === parts.resultId);
+			const test = result?.getStateById(parts.testExtId);
+			const task = result?.tasks[parts.taskIndex];
+			if (!test || !task) { return; }
+			return new TestOutputSubject(parts.resultId, parts.taskIndex, task, test);
 		}
 
 		const { resultId, testExtId, taskIndex, messageIndex } = parts;
@@ -874,7 +918,9 @@ class TestResultsPeek extends PeekViewWidget {
 	protected override _fillBody(containerElement: HTMLElement): void {
 		this.content.fillBody(containerElement);
 		this.content.onDidRequestReveal(sub => {
-			TestingOutputPeekController.get(this.editor)?.show(sub instanceof MessageSubject ? sub.messageUri : sub.outputUri);
+			TestingOutputPeekController.get(this.editor)?.show(sub instanceof MessageSubject
+				? sub.messageUri
+				: sub.outputUri);
 		});
 	}
 
@@ -882,12 +928,12 @@ class TestResultsPeek extends PeekViewWidget {
 	 * Updates the test to be shown.
 	 */
 	public setModel(subject: InspectSubject): Promise<void> {
-		if (subject instanceof TaskSubject) {
+		if (subject instanceof TaskSubject || subject instanceof TestOutputSubject) {
 			this.current = subject;
 			return this.showInPlace(subject);
 		}
 
-		const message = subject.messages[subject.messageIndex];
+		const message = subject.message;
 		const previous = this.current;
 		if (!subject.revealLocation && !previous) {
 			return Promise.resolve();
@@ -910,7 +956,7 @@ class TestResultsPeek extends PeekViewWidget {
 	 */
 	public async showInPlace(subject: InspectSubject) {
 		if (subject instanceof MessageSubject) {
-			const message = subject.messages[subject.messageIndex];
+			const message = subject.message;
 			this.setTitle(firstLine(renderStringAsPlaintext(message.message)), stripIcons(subject.test.label));
 		} else {
 			this.setTitle(localize('testOutputTitle', 'Test Output'));
@@ -1057,7 +1103,7 @@ class DiffContentProvider extends Disposable implements IPeekOutputRenderer {
 		if (!(subject instanceof MessageSubject)) {
 			return this.clear();
 		}
-		const message = subject.messages[subject.messageIndex];
+		const message = subject.message;
 		if (!isDiffable(message)) {
 			return this.clear();
 		}
@@ -1162,7 +1208,7 @@ class MarkdownTestMessagePeek extends Disposable implements IPeekOutputRenderer 
 			return this.textPreview.clear();
 		}
 
-		const message = subject.messages[subject.messageIndex];
+		const message = subject.message;
 		if (isDiffable(message) || typeof message.message === 'string') {
 			return this.textPreview.clear();
 		}
@@ -1198,11 +1244,10 @@ class PlainTextMessagePeek extends Disposable implements IPeekOutputRenderer {
 			return this.clear();
 		}
 
-		const message = subject.messages[subject.messageIndex];
-		if (isDiffable(message) || typeof message.message !== 'string') {
+		const message = subject.message;
+		if (isDiffable(message) || message.type === TestMessageType.Output || typeof message.message !== 'string') {
 			return this.clear();
 		}
-
 
 		const modelRef = this.model.value = await this.modelService.createModelReference(subject.messageUri);
 		if (!this.widget.value) {
@@ -1306,36 +1351,113 @@ class TerminalMessagePeek extends Disposable implements IPeekOutputRenderer {
 
 	public async update(subject: InspectSubject) {
 		this.outputDataListener.clear();
-		if (!(subject instanceof TaskSubject)) {
+		if (subject instanceof TaskSubject) {
+			await this.updateForTaskSubject(subject);
+		} else if (subject instanceof TestOutputSubject || (subject instanceof MessageSubject && subject.message.type === TestMessageType.Output)) {
+			await this.updateForTestSubject(subject);
+		} else {
+			this.clear();
+		}
+	}
+
+	private async updateForTestSubject(subject: TestOutputSubject | MessageSubject) {
+		const that = this;
+		const testItem = subject instanceof TestOutputSubject ? subject.test.item : subject.test;
+		const terminal = await this.updateGenerically<ITaskRawOutput>({
+			subject,
+			getTarget: result => result?.tasks[subject.taskIndex].output,
+			*doInitialWrite(output, results) {
+				that.updateCwd(testItem.uri);
+				const state = subject instanceof TestOutputSubject ? subject.test : results.getStateById(testItem.extId);
+				if (!state) {
+					return;
+				}
+
+				for (const message of state.tasks[subject.taskIndex].messages) {
+					if (message.type === TestMessageType.Output) {
+						yield* output.getRangeIter(message.offset, message.length);
+					}
+				}
+			},
+			doListenForMoreData: (output, result, terminal) => result.onChange(e => {
+				if (e.reason === TestResultItemChangeReason.NewMessage && e.item.item.extId === testItem.extId && e.message.type === TestMessageType.Output) {
+					for (const chunk of output.getRangeIter(e.message.offset, e.message.length)) {
+						terminal.write(chunk.buffer);
+					}
+				}
+			}),
+		});
+
+		if (subject instanceof MessageSubject && subject.message.type === TestMessageType.Output && subject.message.marker !== undefined) {
+			terminal?.selectMarkedRange(getMarkId(subject.message.marker, true), getMarkId(subject.message.marker, false), /* scrollIntoView= */ true);
+		}
+	}
+
+	private updateForTaskSubject(subject: TaskSubject) {
+		return this.updateGenerically<ITestRunTaskResults>({
+			subject,
+			getTarget: result => result?.tasks[subject.taskIndex],
+			doInitialWrite: (task, result) => {
+				// Update the cwd and use the first test to try to hint at the correct cwd,
+				// but often this will fall back to the first workspace folder.
+				this.updateCwd(Iterable.find(result.tests, t => !!t.item.uri)?.item.uri);
+				return task.output.buffers;
+			},
+			doListenForMoreData: (task, _result, terminal) => task.output.onDidWriteData(e => terminal.write(e.buffer)),
+		});
+	}
+
+	private async updateGenerically<T>(opts: {
+		subject: InspectSubject;
+		getTarget: (result: ITestResult) => T | undefined;
+		doInitialWrite: (target: T, result: LiveTestResult) => Iterable<VSBuffer>;
+		doListenForMoreData: (target: T, result: LiveTestResult, terminal: IDetachedXtermTerminal) => IDisposable | undefined;
+	}) {
+		const result = this.resultService.getResult(opts.subject.resultId);
+		if (!result) {
 			return this.clear();
 		}
 
-		const result = this.resultService.getResult(subject.resultId);
-		const task = result?.tasks[subject.taskIndex];
-		if (!task) {
+		const target = opts.getTarget(result);
+		if (!target) {
 			return this.clear();
 		}
-
-		// Update the cwd and use the first test to try to hint at the correct cwd,
-		// but often this will fall back to the first workspace folder.
-		this.updateCwd(Iterable.find(result.tests, t => !!t.item.uri)?.item.uri);
 
 		const terminal = await this.makeTerminal();
+		let didWriteData = false;
+
+		const pendingWrites = new MutableObservableValue(0);
 		if (result instanceof LiveTestResult) {
-			let hadData = false;
-			for (const buffer of task.output.buffers) {
-				hadData ||= buffer.byteLength > 0;
-				terminal.write(buffer.buffer);
-			}
-			if (!hadData && !task.running) {
-				this.writeNotice(terminal, localize('runNoOutout', 'The test run did not record any output.'));
+			for (const chunk of opts.doInitialWrite(target, result)) {
+				didWriteData ||= chunk.byteLength > 0;
+				pendingWrites.value++;
+				terminal.write(chunk.buffer, () => pendingWrites.value--);
 			}
 		} else {
 			this.writeNotice(terminal, localize('runNoOutputForPast', 'Test output is only available for new test runs.'));
 		}
 
 		this.attachTerminalToDom(terminal);
-		this.outputDataListener.value = task.output.onDidWriteData(e => terminal.write(e.buffer));
+		this.outputDataListener.value = result instanceof LiveTestResult ? opts.doListenForMoreData(target, result, terminal) : undefined;
+
+		if (!this.outputDataListener.value && !didWriteData) {
+			this.writeNotice(terminal, localize('runNoOutput', 'The test run did not record any output.'));
+		}
+
+		// Ensure pending writes finish, otherwise the selection in `updateForTestSubject`
+		// can happen before the markers are processed.
+		if (pendingWrites.value > 0) {
+			await new Promise<void>(resolve => {
+				const l = pendingWrites.onDidChange(() => {
+					if (pendingWrites.value === 0) {
+						l.dispose();
+						resolve();
+					}
+				});
+			});
+		}
+
+		return terminal;
 	}
 
 	private updateCwd(testUri?: URI) {
@@ -1505,8 +1627,13 @@ class TestCaseElement implements ITreeElement {
 		return icons.testingStatesToIcons.get(this.state);
 	}
 
+	public get outputSubject() {
+		return new TestOutputSubject(this.results.id, this.taskIndex, this.task, this.test);
+	}
+
 	constructor(
 		private readonly results: ITestResult,
+		private readonly task: ITestRunTask,
 		public readonly test: TestResultItem,
 		public readonly taskIndex: number,
 	) {
@@ -1549,7 +1676,6 @@ class TestMessageElement implements ITreeElement {
 	public readonly uri: URI;
 	public readonly location?: IRichLocation;
 	public readonly description?: string;
-	public readonly marker?: number;
 	public readonly onDidChange = Event.None;
 
 	constructor(
@@ -1561,7 +1687,6 @@ class TestMessageElement implements ITreeElement {
 		const m = test.tasks[taskIndex].messages[messageIndex];
 
 		this.location = m.location;
-		this.marker = m.type === TestMessageType.Output ? m.marker : undefined;
 		this.uri = this.context = buildTestUri({
 			type: TestUriType.ResultMessage,
 			messageIndex,
@@ -1573,7 +1698,7 @@ class TestMessageElement implements ITreeElement {
 		this.id = this.uri.toString();
 
 		const asPlaintext = renderStringAsPlaintext(m.message);
-		const lines = count(asPlaintext.trimRight(), '\n');
+		const lines = count(asPlaintext.trimEnd(), '\n');
 		this.label = firstLine(asPlaintext);
 		if (lines > 0) {
 			this.description = lines > 1
@@ -1649,17 +1774,20 @@ class OutputPeekTree extends Disposable {
 			const tests = Iterable.filter(taskElem.results.tests, test => test.tasks[taskElem.index].state >= TestResultState.Running || test.tasks[taskElem.index].messages.length > 0);
 
 			return Iterable.map(tests, test => ({
-				element: taskElem.itemsCache.getOrCreate(test, () => new TestCaseElement(taskElem.results, test, taskElem.index)),
+				element: taskElem.itemsCache.getOrCreate(test, () => new TestCaseElement(taskElem.results, taskElem.task, test, taskElem.index)),
 				incompressible: true,
 				children: getTestChildren(taskElem.results, test, taskElem.index),
 			}));
 		};
 
 		const getTestChildren = (result: ITestResult, test: TestResultItem, taskIndex: number): Iterable<ICompressedTreeElement<TreeElement>> => {
-			return Iterable.map(test.tasks[taskIndex].messages, (m, messageIndex) => ({
-				element: cc.getOrCreate(m, () => new TestMessageElement(result, test, taskIndex, messageIndex)),
-				incompressible: true,
-			}));
+			return test.tasks[taskIndex].messages
+				.map((m, messageIndex) =>
+					m.type === TestMessageType.Error
+						? { element: cc.getOrCreate(m, () => new TestMessageElement(result, test, taskIndex, messageIndex)), incompressible: true }
+						: undefined
+				)
+				.filter(isDefined);
 		};
 
 		const getResultChildren = (result: ITestResult): Iterable<ICompressedTreeElement<TreeElement>> => {
@@ -1721,7 +1849,7 @@ class OutputPeekTree extends Disposable {
 
 					const itemNode = taskNode.itemsCache.get(e.item);
 					if (itemNode && this.tree.hasElement(itemNode)) {
-						if (e.reason === TestResultItemChangeReason.NewMessage) {
+						if (e.reason === TestResultItemChangeReason.NewMessage && e.message.type === TestMessageType.Error) {
 							this.tree.setChildren(itemNode, getTestChildren(result, e.item, index), { diffIdentityProvider });
 						}
 						itemNode.changeEmitter.fire();
@@ -1778,20 +1906,31 @@ class OutputPeekTree extends Disposable {
 
 		this._register(onDidReveal(async ({ subject, preserveFocus = false }) => {
 			if (subject instanceof TaskSubject) {
-				const resultItem = this.tree.getNode(null).children.find(c => (c.element as TestResultElement)?.id === subject.resultId);
+				const resultItem = this.tree.getNode(null).children.find(c => {
+					if (c.element instanceof TaskElement) {
+						return c.element.results.id === subject.resultId && c.element.index === subject.taskIndex;
+					}
+					if (c.element instanceof TestResultElement) {
+						return c.element.id === subject.resultId;
+					}
+					return false;
+				});
+
 				if (resultItem) {
-					revealItem(resultItem.element as TestResultElement, preserveFocus);
+					revealItem(resultItem.element!, preserveFocus);
 				}
 				return;
 			}
 
-			const messageNode = cc.get(subject.messages[subject.messageIndex]);
-			if (!messageNode || !this.tree.hasElement(messageNode)) {
+			const revealElement = subject instanceof TestOutputSubject
+				? cc.get<TaskElement>(subject.task)?.itemsCache.get(subject.test)
+				: cc.get(subject.message);
+			if (!revealElement || !this.tree.hasElement(revealElement)) {
 				return;
 			}
 
 			const parents: TreeElement[] = [];
-			for (let parent = this.tree.getParentElement(messageNode); parent; parent = this.tree.getParentElement(parent)) {
+			for (let parent = this.tree.getParentElement(revealElement); parent; parent = this.tree.getParentElement(parent)) {
 				parents.unshift(parent);
 			}
 
@@ -1799,11 +1938,11 @@ class OutputPeekTree extends Disposable {
 				this.tree.expand(parent);
 			}
 
-			if (this.tree.getRelativeTop(messageNode) === null) {
-				this.tree.reveal(messageNode, 0.5);
+			if (this.tree.getRelativeTop(revealElement) === null) {
+				this.tree.reveal(revealElement, 0.5);
 			}
 
-			revealItem(messageNode, preserveFocus);
+			revealItem(revealElement, preserveFocus);
 		}));
 
 		this._register(this.tree.onDidOpen(async e => {
@@ -1899,13 +2038,15 @@ class TestRunElementRenderer implements ICompressibleTreeRenderer<ITreeElement, 
 					: undefined
 		});
 
+		const elementDisposable = new DisposableStore();
+		templateDisposable.add(elementDisposable);
 		templateDisposable.add(actionBar);
 
 		return {
 			icon,
 			label,
 			actionBar,
-			elementDisposable: new DisposableStore(),
+			elementDisposable,
 			templateDisposable,
 		};
 	}
@@ -2022,6 +2163,16 @@ class TreeActionsProvider {
 					undefined,
 					() => this.commandService.executeCommand('vscode.revealTest', extId),
 				));
+
+				if (element.test.tasks[element.taskIndex].messages.some(m => m.type === TestMessageType.Output)) {
+					primary.push(new Action(
+						'testing.outputPeek.showResultOutput',
+						localize('testing.showResultOutput', "Show Result Output"),
+						ThemeIcon.asClassName(Codicon.terminal),
+						undefined,
+						() => this.requestReveal.fire(element.outputSubject),
+					));
+				}
 
 				secondary.push(new Action(
 					'testing.outputPeek.revealInExplorer',
@@ -2231,8 +2382,8 @@ export class ToggleTestingPeekHistory extends Action2 {
 class CreationCache<T> {
 	private readonly v = new WeakMap<object, T>();
 
-	public get(key: object) {
-		return this.v.get(key);
+	public get<T2 extends T = T>(key: object): T2 | undefined {
+		return this.v.get(key) as T2 | undefined;
 	}
 
 	public getOrCreate<T2 extends T>(ref: object, factory: () => T2): T2 {

--- a/src/vs/workbench/contrib/testing/common/testResult.ts
+++ b/src/vs/workbench/contrib/testing/common/testResult.ts
@@ -98,7 +98,10 @@ export interface ITaskRawOutput {
 	readonly buffers: VSBuffer[];
 	readonly length: number;
 
-	getRange(start: number, end: number): VSBuffer;
+	/** Gets a continuous buffer for the desired range */
+	getRange(start: number, length: number): VSBuffer;
+	/** Gets an iterator of buffers for the range; may avoid allocation of getRange() */
+	getRangeIter(start: number, length: number): Iterable<VSBuffer>;
 }
 
 const emptyRawOutput: ITaskRawOutput = {
@@ -107,6 +110,7 @@ const emptyRawOutput: ITaskRawOutput = {
 	onDidWriteData: Event.None,
 	endPromise: Promise.resolve(),
 	getRange: () => VSBuffer.alloc(0),
+	getRangeIter: () => [],
 };
 
 export class TaskRawOutput implements ITaskRawOutput {
@@ -131,8 +135,18 @@ export class TaskRawOutput implements ITaskRawOutput {
 	/** @inheritdoc */
 	getRange(start: number, length: number): VSBuffer {
 		const buf = VSBuffer.alloc(length);
-
 		let bufLastWrite = 0;
+		for (const chunk of this.getRangeIter(start, length)) {
+			buf.buffer.set(chunk.buffer, bufLastWrite);
+			bufLastWrite += chunk.byteLength;
+		}
+
+		return bufLastWrite < length ? buf.slice(0, bufLastWrite) : buf;
+	}
+
+	/** @inheritdoc */
+	*getRangeIter(start: number, length: number) {
+		let soFar = 0;
 		let internalLastRead = 0;
 		for (const b of this.buffers) {
 			if (internalLastRead + b.byteLength <= start) {
@@ -141,37 +155,68 @@ export class TaskRawOutput implements ITaskRawOutput {
 			}
 
 			const bstart = Math.max(0, start - internalLastRead);
-			const bend = Math.min(b.byteLength, bstart + length - bufLastWrite);
+			const bend = Math.min(b.byteLength, bstart + length - soFar);
 
-			buf.buffer.set(b.buffer.subarray(bstart, bend), bufLastWrite);
-			bufLastWrite += bend - bstart;
+			yield b.slice(bstart, bend);
+			soFar += bend - bstart;
 			internalLastRead += b.byteLength;
 
-			if (bufLastWrite === buf.byteLength) {
+			if (soFar === length) {
+				break;
+			}
+		}
+	}
+
+	/**
+	 * Appends data to the output, returning the byte range where the data can be found.
+	 */
+	public append(data: VSBuffer, marker?: number) {
+		const offset = this.offset;
+		let length = data.byteLength;
+		if (marker === undefined) {
+			this.push(data);
+			return { offset, length };
+		}
+
+		// Bytes that should be 'trimmed' off the end of data. This is done because
+		// selections in the terminal are based on the entire line, and commonly
+		// the interesting marked range has a trailing new line. We don't want to
+		// select the trailing line (which might have other data)
+		// so we place the marker before all trailing trimbytes.
+		const enum TrimBytes {
+			CR = 13,
+			LF = 10,
+		}
+
+		const start = VSBuffer.fromString(getMarkCode(marker, true));
+		const end = VSBuffer.fromString(getMarkCode(marker, false));
+		length += start.byteLength + end.byteLength;
+
+		this.push(start);
+		let trimLen = data.byteLength;
+		for (; trimLen > 0; trimLen--) {
+			const last = data.buffer[trimLen - 1];
+			if (last !== TrimBytes.CR && last !== TrimBytes.LF) {
 				break;
 			}
 		}
 
-		return bufLastWrite < length ? buf.slice(0, bufLastWrite) : buf;
+		this.push(data.slice(0, trimLen));
+		this.push(end);
+		this.push(data.slice(trimLen));
+
+
+		return { offset, length };
 	}
 
-	/**
-	 * Appends data to the output, returning the byte index where data starts.
-	 */
-	public append(data: VSBuffer, marker?: number): number {
-		let startOffset = this.offset;
-		if (marker !== undefined) {
-			const start = VSBuffer.fromString(getMarkCode(marker, true));
-			const end = VSBuffer.fromString(getMarkCode(marker, false));
-			startOffset += start.byteLength;
-			data = VSBuffer.concat([start, data, end]);
+	private push(data: VSBuffer) {
+		if (data.byteLength === 0) {
+			return;
 		}
 
 		this.buffers.push(data);
 		this.writeDataEmitter.fire(data);
 		this.offset += data.byteLength;
-
-		return startOffset;
 	}
 
 	/** Signals the output has ended. */
@@ -222,7 +267,7 @@ export const enum TestResultItemChangeReason {
 export type TestResultItemChange = { item: TestResultItem; result: ITestResult } & (
 	| { reason: TestResultItemChangeReason.ComputedStateChange }
 	| { reason: TestResultItemChangeReason.OwnStateChange; previousState: TestResultState; previousOwnDuration: number | undefined }
-	| { reason: TestResultItemChangeReason.NewMessage }
+	| { reason: TestResultItemChangeReason.NewMessage; message: ITestMessage }
 );
 
 /**
@@ -314,20 +359,20 @@ export class LiveTestResult implements ITestResult {
 		const index = this.mustGetTaskIndex(taskId);
 		const task = this.tasks[index];
 
-		const offset = task.output.append(output, marker);
+		const { offset, length } = task.output.append(output, marker);
 		const message: ITestOutputMessage = {
 			location,
 			message: removeAnsiEscapeCodes(preview),
 			offset,
-			length: output.byteLength,
-			marker: marker,
+			length,
+			marker,
 			type: TestMessageType.Output,
 		};
 
 		const test = testId && this.testById.get(testId);
 		if (test) {
 			test.tasks[index].messages.push(message);
-			this.changeEmitter.fire({ item: test, result: this, reason: TestResultItemChangeReason.NewMessage });
+			this.changeEmitter.fire({ item: test, result: this, reason: TestResultItemChangeReason.NewMessage, message });
 		} else {
 			task.otherMessages.push(message);
 		}
@@ -397,7 +442,7 @@ export class LiveTestResult implements ITestResult {
 		}
 
 		entry.tasks[this.mustGetTaskIndex(taskId)].messages.push(message);
-		this.changeEmitter.fire({ item: entry, result: this, reason: TestResultItemChangeReason.NewMessage });
+		this.changeEmitter.fire({ item: entry, result: this, reason: TestResultItemChangeReason.NewMessage, message });
 	}
 
 	/**

--- a/src/vs/workbench/contrib/testing/common/testingContentProvider.ts
+++ b/src/vs/workbench/contrib/testing/common/testingContentProvider.ts
@@ -94,6 +94,16 @@ export class TestingContentProvider implements IWorkbenchContribution, ITextMode
 				if (message?.type === TestMessageType.Error) { text = message.actual; }
 				break;
 			}
+			case TestUriType.TestOutput: {
+				text = '';
+				const output = result.tasks[parsed.taskIndex].output;
+				for (const message of test.tasks[parsed.taskIndex].messages) {
+					if (message.type === TestMessageType.Output) {
+						text += removeAnsiEscapeCodes(output.getRange(message.offset, message.length).toString());
+					}
+				}
+				break;
+			}
 			case TestUriType.ResultExpectedOutput: {
 				const message = test.tasks[parsed.taskIndex].messages[parsed.messageIndex];
 				if (message?.type === TestMessageType.Error) { text = message.expected; }

--- a/src/vs/workbench/contrib/testing/test/common/testResultService.test.ts
+++ b/src/vs/workbench/contrib/testing/test/common/testResultService.test.ts
@@ -326,9 +326,11 @@ suite('Workbench - Test Results Service', () => {
 
 			const a1 = ctrl.append(VSBuffer.fromString('12345'), 1);
 			const a2 = ctrl.append(VSBuffer.fromString('67890'), 1234);
+			const a3 = ctrl.append(VSBuffer.fromString('with new line\r\n'), 4);
 
-			assert.deepStrictEqual(ctrl.getRange(a1, 5), VSBuffer.fromString('12345'));
-			assert.deepStrictEqual(ctrl.getRange(a2, 5), VSBuffer.fromString('67890'));
+			assert.deepStrictEqual(ctrl.getRange(a1.offset, a1.length), VSBuffer.fromString('\x1b]633;SetMark;Id=s1;Hidden\x0712345\x1b]633;SetMark;Id=e1;Hidden\x07'));
+			assert.deepStrictEqual(ctrl.getRange(a2.offset, a2.length), VSBuffer.fromString('\x1b]633;SetMark;Id=s1234;Hidden\x0767890\x1b]633;SetMark;Id=e1234;Hidden\x07'));
+			assert.deepStrictEqual(ctrl.getRange(a3.offset, a3.length), VSBuffer.fromString('\x1b]633;SetMark;Id=s4;Hidden\x07with new line\x1b]633;SetMark;Id=e4;Hidden\x07\r\n'));
 		});
 	});
 });


### PR DESCRIPTION
Previously, console messages associated with a test were shown in the
Test Results tree view, and clicking them opened a simple text editor
stripped of ANSI codes

![](https://memes.peet.io/img/23-08-ca47357c-e9e6-49fb-bb60-80a65e49af6e.png)

This was not a great experience, and caused some problems.

Instead, we now have a "Show Output" message for each test with output
in a tree view, which opens terminal output from _just_ that test case.

![](https://memes.peet.io/img/23-08-c3e00702-4f56-4974-9a98-cedcdf26179f.png)

> Input: would selecting the test's range from the entire output be a better experience?

Like the full results terminal, this will stream in data as the test runs.
Additionally, clicking inline test messages now opens a real terminal
with that message selected.

![](https://memes.peet.io/img/23-08-dc4e3b0d-d85c-44ce-abe0-168ce11e8220.png)

cc @Tyriar regarding the new method in IXtermTerminal

Closes #187104 (supplanting the pain point with better ux)

Found a couple quirks with the DiffEditorWidget2 that I didn't catch
in the initial `@deprecated`-triggered migration in debt week
(#189992, #189975), please bear in mind during testing
that these are separate issues.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
