### PR TITLE
joh/everyday landfowl

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadChatSlashCommands.ts
+++ b/src/vs/workbench/api/browser/mainThreadChatSlashCommands.ts
@@ -33,8 +33,7 @@ export class MainThreadChatSlashCommands implements MainThreadChatSlashCommandsS
 		if (!this._chatSlashCommandService.hasCommand(name)) {
 			// dynamic slash commands!
 			this._chatSlashCommandService.registerSlashData({
-				name,
-				id: name,
+				command: name,
 				detail
 			});
 		}

--- a/src/vs/workbench/contrib/chat/browser/actions/chatClearActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatClearActions.ts
@@ -19,6 +19,8 @@ import { ChatEditorInput } from 'vs/workbench/contrib/chat/browser/chatEditorInp
 import { ChatViewPane } from 'vs/workbench/contrib/chat/browser/chatViewPane';
 import { CONTEXT_IN_CHAT_SESSION, CONTEXT_PROVIDER_EXISTS } from 'vs/workbench/contrib/chat/common/chatContextKeys';
 
+export const ACTION_ID_CLEAR_CHAT = `workbench.action.chat.clear`;
+
 export function registerClearActions() {
 
 	registerAction2(class ClearEditorAction extends Action2 {
@@ -48,7 +50,7 @@ export function registerClearActions() {
 	registerAction2(class GlobalClearChatAction extends Action2 {
 		constructor() {
 			super({
-				id: `workbench.action.chat.clear`,
+				id: ACTION_ID_CLEAR_CHAT,
 				title: {
 					value: localize('interactiveSession.clear.label', "Clear"),
 					original: 'Clear'

--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -36,7 +36,7 @@ import { IEditorResolverService, RegisteredEditorPriority } from 'vs/workbench/s
 import { LifecyclePhase } from 'vs/workbench/services/lifecycle/common/lifecycle';
 import '../common/chatColors';
 import { registerMoveActions } from 'vs/workbench/contrib/chat/browser/actions/chatMoveActions';
-import { registerClearActions } from 'vs/workbench/contrib/chat/browser/actions/chatClearActions';
+import { ACTION_ID_CLEAR_CHAT, registerClearActions } from 'vs/workbench/contrib/chat/browser/actions/chatClearActions';
 import { AccessibleViewAction, AccessibleViewType, IAccessibleViewService } from 'vs/workbench/contrib/accessibility/browser/accessibleView';
 import { isResponseVM } from 'vs/workbench/contrib/chat/common/chatViewModel';
 import { CONTEXT_IN_CHAT_SESSION } from 'vs/workbench/contrib/chat/common/chatContextKeys';
@@ -48,6 +48,7 @@ import { ChatWelcomeMessageModel } from 'vs/workbench/contrib/chat/common/chatMo
 import { IMarkdownString } from 'vs/base/common/htmlContent';
 import { ChatProviderService, IChatProviderService } from 'vs/workbench/contrib/chat/common/chatProvider';
 import { ChatSlashCommandService, IChatSlashCommandService } from 'vs/workbench/contrib/chat/common/chatSlashCommands';
+import { ICommandService } from 'vs/platform/commands/common/commands';
 
 // Register configuration
 const configurationRegistry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration);
@@ -216,9 +217,28 @@ class ChatAccessibleViewContribution extends Disposable {
 	}
 }
 
+class ChatSlashStaticSlashCommandsContribution extends Disposable {
+
+	constructor(
+		@IChatSlashCommandService slashCommandService: IChatSlashCommandService,
+		@ICommandService commandService: ICommandService,
+	) {
+		super();
+		this._store.add(slashCommandService.registerSlashCommand({
+			command: 'clear',
+			detail: nls.localize('clear', "Clear the session"),
+			sortText: 'z_clear',
+			executeImmediately: true
+		}, async () => {
+			commandService.executeCommand(ACTION_ID_CLEAR_CHAT);
+		}));
+	}
+}
+
 const workbenchContributionsRegistry = Registry.as<IWorkbenchContributionsRegistry>(WorkbenchExtensions.Workbench);
 workbenchContributionsRegistry.registerWorkbenchContribution(ChatResolverContribution, LifecyclePhase.Starting);
 workbenchContributionsRegistry.registerWorkbenchContribution(ChatAccessibleViewContribution, LifecyclePhase.Eventually);
+workbenchContributionsRegistry.registerWorkbenchContribution(ChatSlashStaticSlashCommandsContribution, LifecyclePhase.Eventually);
 Registry.as<IEditorFactoryRegistry>(EditorExtensions.EditorFactory).registerEditorSerializer(ChatEditorInput.TypeID, ChatEditorInputSerializer);
 
 registerChatActions();

--- a/src/vs/workbench/contrib/chat/browser/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatWidget.ts
@@ -13,7 +13,6 @@ import { isEqual } from 'vs/base/common/resources';
 import { URI } from 'vs/base/common/uri';
 import 'vs/css!./media/chat';
 import { ICodeEditor } from 'vs/editor/browser/editorBrowser';
-import { localize } from 'vs/nls';
 import { MenuId } from 'vs/platform/actions/common/actions';
 import { IContextKey, IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 import { IContextMenuService } from 'vs/platform/contextview/browser/contextView';
@@ -21,7 +20,6 @@ import { IInstantiationService } from 'vs/platform/instantiation/common/instanti
 import { ServiceCollection } from 'vs/platform/instantiation/common/serviceCollection';
 import { WorkbenchObjectTree } from 'vs/platform/list/browser/listService';
 import { IViewsService } from 'vs/workbench/common/views';
-import { clearChatSession } from 'vs/workbench/contrib/chat/browser/actions/chatClear';
 import { ChatTreeItem, IChatAccessibilityService, IChatCodeBlockInfo, IChatWidget, IChatWidgetService, IChatWidgetViewContext } from 'vs/workbench/contrib/chat/browser/chat';
 import { ChatInputPart } from 'vs/workbench/contrib/chat/browser/chatInputPart';
 import { ChatAccessibilityProvider, ChatListDelegate, ChatListItemRenderer, IChatRendererDelegate } from 'vs/workbench/contrib/chat/browser/chatListRenderer';
@@ -264,17 +262,7 @@ export class ChatWidget extends Disposable implements IChatWidget {
 
 		if (!this.slashCommandsPromise) {
 			this.slashCommandsPromise = this.chatService.getSlashCommands(this.viewModel.sessionId, CancellationToken.None).then(commands => {
-				// If this becomes a repeated pattern, we should have a real internal slash command provider system
-				const clearCommand: ISlashCommand = {
-					command: 'clear',
-					sortText: 'z_clear',
-					detail: localize('clear', "Clear the session"),
-					executeImmediately: true
-				};
-				this.lastSlashCommands = [
-					...(commands ?? []),
-					clearCommand
-				];
+				this.lastSlashCommands = commands ?? [];
 				return this.lastSlashCommands;
 			});
 		}
@@ -431,13 +419,6 @@ export class ChatWidget extends Disposable implements IChatWidget {
 	async acceptInput(query?: string | IChatReplyFollowup): Promise<void> {
 		if (this.viewModel) {
 			const editorValue = this.inputPart.inputEditor.getValue();
-
-			// Shortcut for /clear command
-			if (!query && editorValue.trim() === '/clear' || typeof query === 'string' && query.trim() === '/clear') {
-				// Small hack, if this becomes a repeated pattern, we should have a real internal slash command provider system
-				this.instantiationService.invokeFunction(clearChatSession, this);
-				return;
-			}
 			this._chatAccessibilityService.acceptRequest();
 			const input = query ?? editorValue;
 			const usedSlashCommand = this.lookupSlashCommand(typeof input === 'string' ? input : input.message);
@@ -605,4 +586,3 @@ export class ChatWidgetService implements IChatWidgetService {
 		);
 	}
 }
-

--- a/src/vs/workbench/contrib/chat/common/chatServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/chatServiceImpl.ts
@@ -597,8 +597,10 @@ export class ChatService extends Disposable implements IChatService {
 
 		const serviceResults = this.chatSlashCommandService.getCommands().map(data => {
 			return <ISlashCommand>{
-				command: data.name,
+				command: data.command,
 				detail: data.detail,
+				sortText: data.sortText,
+				executeImmediately: data.executeImmediately
 			};
 		});
 


### PR DESCRIPTION
- emit event when slash commands change
- further align `IChatSlashData` with `ISashCommand`
- migrate `/clear` onto new contributable slash commands fyi @roblourens
- validate statically contributed slash commands
