### PR TITLE
fix(typescript-language-features): tsdk trust

### DIFF
--- a/extensions/typescript-language-features/src/tsServer/versionManager.ts
+++ b/extensions/typescript-language-features/src/tsServer/versionManager.ts
@@ -28,21 +28,20 @@ export class TypeScriptVersionManager extends Disposable {
 	) {
 		super();
 
+
 		this._currentVersion = this.versionProvider.defaultVersion;
 
-		if (this.useWorkspaceTsdkSetting) {
-			if (vscode.workspace.isTrusted) {
-				const localVersion = this.versionProvider.localVersion;
-				if (localVersion) {
-					this._currentVersion = localVersion;
-				}
-			} else {
-				this._disposables.push(vscode.workspace.onDidGrantWorkspaceTrust(() => {
-					if (this.versionProvider.localVersion) {
-						this.updateActiveVersion(this.versionProvider.localVersion);
-					}
-				}));
+		if (vscode.workspace.isTrusted || this.useWorkspaceTsdkSetting) {
+			const localVersion = this.versionProvider.localVersion;
+			if (localVersion) {
+				this._currentVersion = localVersion;
 			}
+		} else {
+			this._disposables.push(vscode.workspace.onDidGrantWorkspaceTrust(() => {
+				if (this.versionProvider.localVersion) {
+					this.updateActiveVersion(this.versionProvider.localVersion);
+				}
+			}));
 		}
 
 		if (this.isInPromptWorkspaceTsdkState(configuration)) {
@@ -172,6 +171,7 @@ export class TypeScriptVersionManager extends Disposable {
 
 	private isInPromptWorkspaceTsdkState(configuration: TypeScriptServiceConfiguration) {
 		return (
+			!vscode.workspace.isTrusted &&
 			configuration.localTsdk !== null
 			&& configuration.enablePromptUseWorkspaceTsdk === true
 			&& this.suppressPromptWorkspaceTsdkSetting === false


### PR DESCRIPTION
Closes #135713

I work at Wix where we develop an Online IDE using VSCode for Wix users.
We are using yarn PnP for installing packages and store those packages in a global cache for all users.
To use yarn PnP you have to use the custom typescript sdk.
In order to run this binary, vscode prompts the user to allow it.
We populate the code in the workspace and it should be trusted.
I'm not sure what causes VSCode to trust the workspace, but it is trusted. Still, VSCode doesn't trust the binary that's in the same workspace.

This PR addresses this by only prompting the user to "Allow" the binary if the workspace itself isn't trusted.
