### PR TITLE
Reverting #189955 to fix issue with selectors in certain themes and adding specificity

### DIFF
--- a/src/vs/base/browser/ui/list/listWidget.ts
+++ b/src/vs/base/browser/ui/list/listWidget.ts
@@ -830,7 +830,7 @@ export class DefaultStyleController implements IStyleController {
 		}
 
 		if (styles.listFocusForeground) {
-			content.push(`.monaco-list${suffix}:focus .monaco-list-row.focused:not(.monaco-list-row.action.option-disabled) { color: ${styles.listFocusForeground}; }`);
+			content.push(`.monaco-list${suffix}:focus .monaco-list-row.focused { color: ${styles.listFocusForeground}; }`);
 		}
 
 		if (styles.listActiveSelectionBackground) {

--- a/src/vs/platform/actionWidget/browser/actionWidget.css
+++ b/src/vs/platform/actionWidget/browser/actionWidget.css
@@ -94,7 +94,7 @@
 
 .action-widget .monaco-list-row.action.option-disabled,
 .action-widget .monaco-list-row.action.option-disabled .codicon {
-	color: var(--vscode-disabledForeground);
+	color: var(--vscode-disabledForeground) !important;
 }
 
 .action-widget .monaco-list-row.action:not(.option-disabled) .codicon {

--- a/src/vs/platform/actionWidget/browser/actionWidget.css
+++ b/src/vs/platform/actionWidget/browser/actionWidget.css
@@ -93,9 +93,11 @@
 }
 
 .action-widget .monaco-list-row.action.option-disabled,
+.action-widget .monaco-list:focus .monaco-list-row.focused.action.option-disabled,
 .action-widget .monaco-list-row.action.option-disabled .codicon {
-	color: var(--vscode-disabledForeground) !important;
+	color: var(--vscode-disabledForeground);
 }
+
 
 .action-widget .monaco-list-row.action:not(.option-disabled) .codicon {
 	color: inherit;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

The fix in #189955 works in certain themes but has odd interactions with other list widget use cases (since the action widget is the only list widget instance that has "disabled" options). Reverting to fix #190016 and adding specificity fix #187492. 