### PR TITLE
Make `executeSelectionRangeProvider` respect settings for `editor.smartSelect`

### DIFF
--- a/src/vs/editor/contrib/smartSelect/browser/smartSelect.ts
+++ b/src/vs/editor/contrib/smartSelect/browser/smartSelect.ts
@@ -29,6 +29,7 @@ import { LanguageFeatureRegistry } from 'vs/editor/common/languageFeatureRegistr
 import { ITextModelService } from 'vs/editor/common/services/resolverService';
 import { assertType } from 'vs/base/common/types';
 import { URI } from 'vs/base/common/uri';
+import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 
 class SelectionRanges {
 
@@ -311,10 +312,17 @@ CommandsRegistry.registerCommand('_executeSelectionRangeProvider', async functio
 	assertType(URI.isUri(resource));
 
 	const registry = accessor.get(ILanguageFeaturesService).selectionRangeProvider;
+	const configurationService = accessor.get(IConfigurationService);
 	const reference = await accessor.get(ITextModelService).createModelReference(resource);
 
+	const options: SelectionRangesOptions = configurationService.getValue<SelectionRangesOptions | undefined>('editor.smartSelect', { resource }) ?? {
+		// TODO: how to avoid repeating defaults here?
+		selectLeadingAndTrailingWhitespace: true,
+		selectSubwords: true
+	};
+
 	try {
-		return provideSelectionRanges(registry, reference.object.textEditorModel, positions, { selectLeadingAndTrailingWhitespace: true, selectSubwords: true }, CancellationToken.None);
+		return provideSelectionRanges(registry, reference.object.textEditorModel, positions, options, CancellationToken.None);
 	} finally {
 		reference.dispose();
 	}

--- a/src/vs/editor/contrib/smartSelect/browser/smartSelect.ts
+++ b/src/vs/editor/contrib/smartSelect/browser/smartSelect.ts
@@ -315,11 +315,7 @@ CommandsRegistry.registerCommand('_executeSelectionRangeProvider', async functio
 	const configurationService = accessor.get(ITextResourceConfigurationService);
 	const reference = await accessor.get(ITextModelService).createModelReference(resource);
 
-	const options: SelectionRangesOptions = configurationService.getValue<SelectionRangesOptions | undefined>(resource, 'editor.smartSelect') ?? {
-		// TODO: how to avoid repeating defaults here?
-		selectLeadingAndTrailingWhitespace: true,
-		selectSubwords: true
-	};
+	const options: SelectionRangesOptions = configurationService.getValue<SelectionRangesOptions>(resource, 'editor.smartSelect');
 
 	try {
 		return provideSelectionRanges(registry, reference.object.textEditorModel, positions, options, CancellationToken.None);

--- a/src/vs/editor/contrib/smartSelect/browser/smartSelect.ts
+++ b/src/vs/editor/contrib/smartSelect/browser/smartSelect.ts
@@ -29,7 +29,6 @@ import { LanguageFeatureRegistry } from 'vs/editor/common/languageFeatureRegistr
 import { ITextModelService } from 'vs/editor/common/services/resolverService';
 import { assertType } from 'vs/base/common/types';
 import { URI } from 'vs/base/common/uri';
-import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { ITextResourceConfigurationService } from 'vs/editor/common/services/textResourceConfiguration';
 
 class SelectionRanges {

--- a/src/vs/editor/contrib/smartSelect/browser/smartSelect.ts
+++ b/src/vs/editor/contrib/smartSelect/browser/smartSelect.ts
@@ -30,6 +30,7 @@ import { ITextModelService } from 'vs/editor/common/services/resolverService';
 import { assertType } from 'vs/base/common/types';
 import { URI } from 'vs/base/common/uri';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
+import { ITextResourceConfigurationService } from 'vs/editor/common/services/textResourceConfiguration';
 
 class SelectionRanges {
 
@@ -312,10 +313,10 @@ CommandsRegistry.registerCommand('_executeSelectionRangeProvider', async functio
 	assertType(URI.isUri(resource));
 
 	const registry = accessor.get(ILanguageFeaturesService).selectionRangeProvider;
-	const configurationService = accessor.get(IConfigurationService);
+	const configurationService = accessor.get(ITextResourceConfigurationService);
 	const reference = await accessor.get(ITextModelService).createModelReference(resource);
 
-	const options: SelectionRangesOptions = configurationService.getValue<SelectionRangesOptions | undefined>('editor.smartSelect', { resource }) ?? {
+	const options: SelectionRangesOptions = configurationService.getValue<SelectionRangesOptions | undefined>(resource, 'editor.smartSelect') ?? {
 		// TODO: how to avoid repeating defaults here?
 		selectLeadingAndTrailingWhitespace: true,
 		selectSubwords: true

--- a/src/vs/workbench/api/test/browser/extHostApiCommands.test.ts
+++ b/src/vs/workbench/api/test/browser/extHostApiCommands.test.ts
@@ -90,7 +90,7 @@ suite('ExtHostLanguageFeatureCommands', function () {
 	suiteSetup(() => {
 		model = createTextModel(
 			[
-				'This is the first line   ',
+				'This is the first line',
 				'This is the second line',
 				'This is the third line',
 			].join('\n'),
@@ -1405,6 +1405,11 @@ suite('ExtHostLanguageFeatureCommands', function () {
 	});
 
 	test('Selection Range should respect settings', async function () {
+		model.setValue([
+			'This is the first line   ',
+			'This is the second line',
+			'This is the third line',
+		].join('\n'));
 		// TODO: how to reset this config after this test to avoid polluting other tests?
 		testConfigurationService.setUserConfiguration('editor', { smartSelect: { selectLeadingAndTrailingWhitespace: false } });
 

--- a/src/vs/workbench/api/test/browser/extHostApiCommands.test.ts
+++ b/src/vs/workbench/api/test/browser/extHostApiCommands.test.ts
@@ -62,6 +62,8 @@ import { IExtHostTelemetry } from 'vs/workbench/api/common/extHostTelemetry';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { TestConfigurationService } from 'vs/platform/configuration/test/common/testConfigurationService';
 import { IEnvironmentService } from 'vs/platform/environment/common/environment';
+import { ITextResourceConfigurationService } from 'vs/editor/common/services/textResourceConfiguration';
+import { TestTextResourceConfigurationService } from 'vs/workbench/test/browser/workbenchTestServices';
 
 function assertRejects(fn: () => Promise<any>, message: string = 'Expected rejection') {
 	return fn().then(() => assert.ok(false, message), _err => assert.ok(true));
@@ -153,6 +155,7 @@ suite('ExtHostLanguageFeatureCommands', function () {
 		services.set(IOutlineModelService, new SyncDescriptor(OutlineModelService));
 		testConfigurationService = new TestConfigurationService();
 		services.set(IConfigurationService, testConfigurationService);
+		services.set(ITextResourceConfigurationService, new TestTextResourceConfigurationService(testConfigurationService));
 
 		const insta = new InstantiationService(services);
 

--- a/src/vs/workbench/api/test/browser/extHostApiCommands.test.ts
+++ b/src/vs/workbench/api/test/browser/extHostApiCommands.test.ts
@@ -153,7 +153,14 @@ suite('ExtHostLanguageFeatureCommands', function () {
 		});
 		services.set(ILanguageFeatureDebounceService, new SyncDescriptor(LanguageFeatureDebounceService));
 		services.set(IOutlineModelService, new SyncDescriptor(OutlineModelService));
-		testConfigurationService = new TestConfigurationService();
+		testConfigurationService = new TestConfigurationService({
+			editor: {
+				smartSelect: {
+					selectLeadingAndTrailingWhitespace: true,
+					selectSubwords: true
+				}
+			}
+		});
 		services.set(IConfigurationService, testConfigurationService);
 		services.set(ITextResourceConfigurationService, new TestTextResourceConfigurationService(testConfigurationService));
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Closes https://github.com/microsoft/vscode/issues/189972
