### PR TITLE
Fixing the cancellation error on quick typing in sticky scroll

### DIFF
--- a/src/vs/editor/contrib/stickyScroll/browser/stickyScrollModelProvider.ts
+++ b/src/vs/editor/contrib/stickyScroll/browser/stickyScrollModelProvider.ts
@@ -120,8 +120,8 @@ export class StickyModelProvider implements IStickyModelProvider {
 				}
 			}
 			return null;
-		}).catch(() => {
-			// error thrown when cancel is called on _updateScheduler while previous promise has not completed
+		}).catch((error) => {
+			onUnexpectedError(error);
 			return null;
 		});
 	}

--- a/src/vs/editor/contrib/stickyScroll/browser/stickyScrollModelProvider.ts
+++ b/src/vs/editor/contrib/stickyScroll/browser/stickyScrollModelProvider.ts
@@ -120,6 +120,9 @@ export class StickyModelProvider implements IStickyModelProvider {
 				}
 			}
 			return null;
+		}).catch(() => {
+			// error thrown when cancel is called on _updateScheduler while previous promise has not completed
+			return null;
 		});
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/179863

Error is thrown because when trigger scheduler is cancelled and the promise it is meant to fulfil is not fulfilled yet, it throws an error. The trigger scheduler however is called on every model change, and if you type sufficiently quickly the above conditions are verified and errors are thrown. The fix presented here is to ignore errors thrown inside of the promise.