### PR TITLE
allow hover actions to show up in accessible view

### DIFF
--- a/src/vs/workbench/contrib/accessibility/browser/accessibilityContributions.ts
+++ b/src/vs/workbench/contrib/accessibility/browser/accessibilityContributions.ts
@@ -28,7 +28,7 @@ import { getNotificationFromContext } from 'vs/workbench/browser/parts/notificat
 import { IListService, WorkbenchList } from 'vs/platform/list/browser/listService';
 import { NotificationFocusedContext } from 'vs/workbench/common/contextkeys';
 import { IAccessibleViewService, IAccessibleContentProvider, IAccessibleViewOptions, AccessibleViewType } from 'vs/workbench/contrib/accessibility/browser/accessibleView';
-import { IHoverService } from 'vs/workbench/services/hover/browser/hover';
+import { IHoverAction, IHoverService } from 'vs/workbench/services/hover/browser/hover';
 import { alert } from 'vs/base/browser/ui/aria/aria';
 import { AccessibilityHelpAction, AccessibleViewAction } from 'vs/workbench/contrib/accessibility/browser/accessibleViewActions';
 import { IAction } from 'vs/base/common/actions';
@@ -139,12 +139,15 @@ export class HoverAccessibleViewContribution extends Disposable {
 				// The accessible view, itself, uses the context view service to display the text. We don't want to read that.
 				return false;
 			}
+
+			const actions = convertHoverActions(contextViewElement, hoverService.currentHoverActions);
 			accessibleViewService.show({
 				verbositySettingKey: AccessibilityVerbositySettingId.Hover,
 				provideContent() { return extensionHoverContent; },
 				onClose() {
 					hoverService.showAndFocusLastHover();
 				},
+				actions,
 				options: this._options
 			});
 			return true;
@@ -154,6 +157,25 @@ export class HoverAccessibleViewContribution extends Disposable {
 			return true;
 		}, accessibleViewIsShown));
 	}
+}
+
+function convertHoverActions(target: HTMLElement, hoverActions?: IHoverAction[]): IAction[] | undefined {
+	let actions: IAction[] | undefined;
+	if (hoverActions) {
+		actions = [];
+		for (const hoverAction of hoverActions) {
+			actions.push({
+				id: hoverAction.commandId,
+				label: hoverAction.label,
+				run: () => hoverAction.run(target),
+				class: hoverAction.iconClass,
+				enabled: true,
+				tooltip: hoverAction.label
+			});
+		}
+	}
+	console.log(actions);
+	return actions;
 }
 
 export class NotificationAccessibleViewContribution extends Disposable {

--- a/src/vs/workbench/services/hover/browser/hover.ts
+++ b/src/vs/workbench/services/hover/browser/hover.ts
@@ -43,6 +43,11 @@ export interface IHoverService {
 	 * simultaneously. #188822
 	 */
 	showAndFocusLastHover(): void;
+
+	/**
+	 * Gets the current hover's actions, if any, to be used in the accessible view for example
+	 */
+	get currentHoverActions(): IHoverAction[] | undefined;
 }
 
 export interface IHoverWidget extends IDisposable {

--- a/src/vs/workbench/services/hover/browser/hoverService.ts
+++ b/src/vs/workbench/services/hover/browser/hoverService.ts
@@ -7,7 +7,7 @@ import 'vs/css!./media/hover';
 import { InstantiationType, registerSingleton } from 'vs/platform/instantiation/common/extensions';
 import { registerThemingParticipant } from 'vs/platform/theme/common/themeService';
 import { editorHoverBorder } from 'vs/platform/theme/common/colorRegistry';
-import { IHoverService, IHoverOptions, IHoverWidget } from 'vs/workbench/services/hover/browser/hover';
+import { IHoverService, IHoverOptions, IHoverWidget, IHoverAction } from 'vs/workbench/services/hover/browser/hover';
 import { IContextMenuService, IContextViewService } from 'vs/platform/contextview/browser/contextView';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { HoverWidget } from 'vs/workbench/services/hover/browser/hoverWidget';
@@ -18,9 +18,13 @@ import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 import { StandardKeyboardEvent } from 'vs/base/browser/keyboardEvent';
 import { ResultKind } from 'vs/platform/keybinding/common/keybindingResolver';
 import { IAccessibilityService } from 'vs/platform/accessibility/common/accessibility';
-
+// to
 export class HoverService implements IHoverService {
 	declare readonly _serviceBrand: undefined;
+
+	get currentHoverActions(): IHoverAction[] | undefined {
+		return this._currentHoverOptions?.actions;
+	}
 
 	private _currentHoverOptions: IHoverOptions | undefined;
 	private _currentHover: HoverWidget | undefined;

--- a/src/vs/workbench/test/browser/workbenchTestServices.ts
+++ b/src/vs/workbench/test/browser/workbenchTestServices.ts
@@ -164,7 +164,7 @@ import { IUserDataProfileService } from 'vs/workbench/services/userDataProfile/c
 import { EnablementState, IScannedExtension, IWebExtensionsScannerService, IWorkbenchExtensionEnablementService, IWorkbenchExtensionManagementService } from 'vs/workbench/services/extensionManagement/common/extensionManagement';
 import { InstallVSIXOptions, ILocalExtension, IGalleryExtension, InstallOptions, IExtensionIdentifier, UninstallOptions, IExtensionsControlManifest, IGalleryMetadata, IExtensionManagementParticipant, Metadata, InstallExtensionResult, InstallExtensionInfo } from 'vs/platform/extensionManagement/common/extensionManagement';
 import { Codicon } from 'vs/base/common/codicons';
-import { IHoverOptions, IHoverService, IHoverWidget } from 'vs/workbench/services/hover/browser/hover';
+import { IHoverAction, IHoverOptions, IHoverService, IHoverWidget } from 'vs/workbench/services/hover/browser/hover';
 import { IRemoteExtensionsScannerService } from 'vs/platform/remote/common/remoteExtensionsScanner';
 import { IRemoteSocketFactoryService, RemoteSocketFactoryService } from 'vs/platform/remote/common/remoteSocketFactoryService';
 
@@ -752,6 +752,9 @@ class TestHoverService implements IHoverService {
 	showAndFocusLastHover(): void { }
 	hideHover(): void {
 		this.currentHover?.dispose();
+	}
+	get currentHoverActions(): IHoverAction[] | undefined {
+		return;
 	}
 }
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
part of #189486 

I'm starting to wonder if this is the right approach for hovers that contribute links. It makes sense for hovers without them and for hovers with only actions, like the terminal one.

![Screenshot 2023-08-10 at 10 57 17 AM](https://github.com/microsoft/vscode/assets/29464607/647bd720-0425-4b2b-b032-44f6f44c4c4d)

How do we represent links within the accessible view? Do we make them into actions? Is that just complicating things?

![Screenshot 2023-08-10 at 11 10 02 AM](https://github.com/microsoft/vscode/assets/29464607/9b6309b2-54a8-4b3d-9cae-fa26c0a0b8e8)

![Screenshot 2023-08-10 at 10 56 02 AM](https://github.com/microsoft/vscode/assets/29464607/6031904c-effc-4576-ba58-f9d5020aae5f)

Should we only suggest opening the accessible view for hovers which don't have URIs like the terminal one? Is there a way to detect this?

Should we even use the accessible view here or instead when `alt+f2` is used, toggle between a readonly and editable monaco editor?

