### PR TITLE
Fix #188571

### DIFF
--- a/src/vs/workbench/contrib/files/browser/views/explorerView.ts
+++ b/src/vs/workbench/contrib/files/browser/views/explorerView.ts
@@ -659,7 +659,7 @@ export class ExplorerView extends ViewPane implements IExplorerView {
 		}
 
 		const toRefresh = item || this.tree.getInput();
-		return this.tree.updateChildren(toRefresh, recursive, false, {
+		return this.tree.updateChildren(toRefresh, recursive, !!item, {
 			diffIdentityProvider: identityProvider
 		});
 	}


### PR DESCRIPTION
Re-render the subtree when editing so state is properly shown.

If this fix causes a perf regression the options are then
1. Re-render only when setting the tree into edit mode
2. Move edit state deeper into the explorer model instead of being owned by the explorer service so we can take advantage of smart splicing. Downside of this is it's hard to enforce only one item being editable at a time as the explorer items are unaware of the rest of the tree.