### PR TITLE
Do not show description for all workspace folders when viewing environment contributions of a specific one

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/environmentChanges/browser/terminal.environmentChanges.contribution.ts
+++ b/src/vs/workbench/contrib/terminalContrib/environmentChanges/browser/terminal.environmentChanges.contribution.ts
@@ -48,18 +48,23 @@ registerActiveInstanceAction({
 
 function describeEnvironmentChanges(collection: IMergedEnvironmentVariableCollection, scope: EnvironmentVariableScope | undefined): string {
 	let content = `# ${localize('envChanges', 'Terminal Environment Changes')}`;
+	const globalDescriptions = collection.getDescriptionMap(undefined);
+	const workspaceDescriptions = collection.getDescriptionMap(scope);
 	for (const [ext, coll] of collection.collections) {
 		content += `\n\n## ${localize('extension', 'Extension: {0}', ext)}`;
 		content += '\n';
-		if (coll.descriptionMap && coll.descriptionMap.size > 0) {
-			for (const desc of coll.descriptionMap.values()) {
-				content += `\n${desc.description}`;
-				if (desc.scope?.workspaceFolder) {
-					content += ` (${localize('ScopedEnvironmentContributionInfo', 'workspace')})`;
-				}
-			}
-			content += '\n';
+		const globalDescription = globalDescriptions.get(ext);
+		if (globalDescription) {
+			content += `\n${globalDescription}`;
 		}
+		const workspaceDescription = workspaceDescriptions.get(ext);
+		if (workspaceDescription) {
+			// Only show '(workspace)' suffix if there is already a description for the extension.
+			const workspaceSuffix = globalDescription ? ` (${localize('ScopedEnvironmentContributionInfo', 'workspace')})` : '';
+			content += `\n${workspaceDescription}${workspaceSuffix}`;
+		}
+		content += '\n';
+
 		for (const mutator of coll.map.values()) {
 			if (filterScope(mutator, scope) === false) {
 				continue;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
For https://github.com/microsoft/vscode/issues/171173

Should only show description for `.venv` in this case:

![image](https://github.com/microsoft/vscode/assets/13199757/71f08a5c-4117-479f-8f9c-b2a547e6a30b)
