### PR TITLE
Use `editorBackground` for chat code blocks

### DIFF
--- a/src/vs/workbench/browser/parts/auxiliarybar/media/auxiliaryBarPart.css
+++ b/src/vs/workbench/browser/parts/auxiliarybar/media/auxiliaryBarPart.css
@@ -8,12 +8,6 @@
 	visibility: hidden !important;
 }
 
-.monaco-workbench .part.auxiliarybar > .content .monaco-editor,
-.monaco-workbench .part.auxiliarybar > .content .monaco-editor .margin,
-.monaco-workbench .part.auxiliarybar > .content .monaco-editor .monaco-editor-background {
-	background-color: var(--vscode-sideBar-background);
-}
-
 .monaco-workbench .part.auxiliarybar > .title > .panel-switcher-container > .monaco-action-bar .action-item:hover .action-label,
 .monaco-workbench .part.auxiliarybar > .title > .panel-switcher-container > .monaco-action-bar .action-item:focus .action-label {
 	color: var(--vscode-sideBarTitle-foreground) !important;

--- a/src/vs/workbench/browser/parts/auxiliarybar/media/auxiliaryBarPart.css
+++ b/src/vs/workbench/browser/parts/auxiliarybar/media/auxiliaryBarPart.css
@@ -8,6 +8,12 @@
 	visibility: hidden !important;
 }
 
+.monaco-workbench .part.auxiliarybar > .content .monaco-editor,
+.monaco-workbench .part.auxiliarybar > .content .monaco-editor .margin,
+.monaco-workbench .part.auxiliarybar > .content .monaco-editor .monaco-editor-background {
+	background-color: var(--vscode-sideBar-background);
+}
+
 .monaco-workbench .part.auxiliarybar > .title > .panel-switcher-container > .monaco-action-bar .action-item:hover .action-label,
 .monaco-workbench .part.auxiliarybar > .title > .panel-switcher-container > .monaco-action-bar .action-item:focus .action-label {
 	color: var(--vscode-sideBarTitle-foreground) !important;

--- a/src/vs/workbench/contrib/chat/browser/actions/chatQuickInputActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatQuickInputActions.ts
@@ -18,7 +18,6 @@ import { ServiceCollection } from 'vs/platform/instantiation/common/serviceColle
 import { KeybindingWeight } from 'vs/platform/keybinding/common/keybindingsRegistry';
 import { IQuickInputService, IQuickPick, IQuickPickItem } from 'vs/platform/quickinput/common/quickInput';
 import { editorBackground, editorForeground, inputBackground } from 'vs/platform/theme/common/colorRegistry';
-import { SIDE_BAR_BACKGROUND } from 'vs/workbench/common/theme';
 import { CHAT_CATEGORY } from 'vs/workbench/contrib/chat/browser/actions/chatActions';
 import { IChatWidgetService } from 'vs/workbench/contrib/chat/browser/chat';
 import { IChatViewOptions } from 'vs/workbench/contrib/chat/browser/chatViewPane';

--- a/src/vs/workbench/contrib/chat/browser/actions/chatQuickInputActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatQuickInputActions.ts
@@ -17,7 +17,7 @@ import { IInstantiationService, ServicesAccessor } from 'vs/platform/instantiati
 import { ServiceCollection } from 'vs/platform/instantiation/common/serviceCollection';
 import { KeybindingWeight } from 'vs/platform/keybinding/common/keybindingsRegistry';
 import { IQuickInputService, IQuickPick, IQuickPickItem } from 'vs/platform/quickinput/common/quickInput';
-import { editorBackground, editorForeground } from 'vs/platform/theme/common/colorRegistry';
+import { editorBackground, editorForeground, inputBackground } from 'vs/platform/theme/common/colorRegistry';
 import { SIDE_BAR_BACKGROUND } from 'vs/workbench/common/theme';
 import { CHAT_CATEGORY } from 'vs/workbench/contrib/chat/browser/actions/chatActions';
 import { IChatWidgetService } from 'vs/workbench/contrib/chat/browser/chat';
@@ -219,8 +219,8 @@ class QuickChat extends Disposable {
 				{
 					listForeground: editorForeground,
 					listBackground: editorBackground,
-					inputEditorBackground: SIDE_BAR_BACKGROUND,
-					resultEditorBackground: SIDE_BAR_BACKGROUND
+					inputEditorBackground: inputBackground,
+					resultEditorBackground: editorBackground
 				}));
 		this.widget.render(parent);
 		this.widget.setVisible(true);

--- a/src/vs/workbench/contrib/chat/browser/chatEditor.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditor.ts
@@ -12,12 +12,11 @@ import { IInstantiationService } from 'vs/platform/instantiation/common/instanti
 import { ServiceCollection } from 'vs/platform/instantiation/common/serviceCollection';
 import { IStorageService, StorageScope, StorageTarget } from 'vs/platform/storage/common/storage';
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
-import { editorBackground, editorForeground } from 'vs/platform/theme/common/colorRegistry';
+import { editorBackground, editorForeground, inputBackground } from 'vs/platform/theme/common/colorRegistry';
 import { IThemeService } from 'vs/platform/theme/common/themeService';
 import { EditorPane } from 'vs/workbench/browser/parts/editor/editorPane';
 import { IEditorOpenContext } from 'vs/workbench/common/editor';
 import { Memento } from 'vs/workbench/common/memento';
-import { SIDE_BAR_BACKGROUND } from 'vs/workbench/common/theme';
 import { ChatEditorInput } from 'vs/workbench/contrib/chat/browser/chatEditorInput';
 import { IViewState, ChatWidget } from 'vs/workbench/contrib/chat/browser/chatWidget';
 import { IChatModel, ISerializableChatData } from 'vs/workbench/contrib/chat/common/chatModel';
@@ -66,8 +65,8 @@ export class ChatEditor extends EditorPane {
 				{
 					listForeground: editorForeground,
 					listBackground: editorBackground,
-					inputEditorBackground: SIDE_BAR_BACKGROUND,
-					resultEditorBackground: SIDE_BAR_BACKGROUND
+					inputEditorBackground: inputBackground,
+					resultEditorBackground: editorBackground
 				}));
 		this.widget.render(parent);
 		this.widget.setVisible(true);

--- a/src/vs/workbench/contrib/chat/browser/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/media/chat.css
@@ -251,8 +251,8 @@
 	margin: 16px 0;
 }
 
-.interactive-response .monaco-editor .margin,
-.interactive-response .monaco-editor .monaco-editor-background {
+.interactive-session .interactive-item-container.interactive-response .rendered-markdown .interactive-result-editor-wrapper .interactive-result-editor .monaco-editor,
+.interactive-session .interactive-item-container.interactive-response .rendered-markdown .interactive-result-editor-wrapper .interactive-result-editor .monaco-editor .margin {
 	background-color: var(--vscode-interactive-result-editor-background-color);
 }
 

--- a/src/vs/workbench/contrib/chat/browser/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/media/chat.css
@@ -251,8 +251,9 @@
 	margin: 16px 0;
 }
 
-.interactive-session .interactive-item-container.interactive-response .rendered-markdown .interactive-result-editor-wrapper .interactive-result-editor .monaco-editor,
-.interactive-session .interactive-item-container.interactive-response .rendered-markdown .interactive-result-editor-wrapper .interactive-result-editor .monaco-editor .margin {
+.interactive-session .interactive-item-container.interactive-response .interactive-result-editor-wrapper .interactive-result-editor .monaco-editor,
+.interactive-session .interactive-item-container.interactive-response .interactive-result-editor-wrapper .interactive-result-editor .monaco-editor .margin,
+.interactive-session .interactive-item-container.interactive-response .interactive-result-editor-wrapper .interactive-result-editor .monaco-editor .monaco-editor-background {
 	background-color: var(--vscode-interactive-result-editor-background-color);
 }
 


### PR DESCRIPTION
Fixes issue where code blocks did not use `editorBackground` and always matched the background of the sidebar

## Before

https://github.com/microsoft/vscode/assets/25163139/7bf05874-2032-4d17-8a4b-fb5edae7afa5

## After

https://github.com/microsoft/vscode/assets/25163139/3587dd6d-c9ec-4637-9510-551d6be07abb

