### PR TITLE
when in accessible view, don't add hint about opening help menu

### DIFF
--- a/src/vs/workbench/contrib/accessibility/browser/accessibleView.ts
+++ b/src/vs/workbench/contrib/accessibility/browser/accessibleView.ts
@@ -311,7 +311,7 @@ class AccessibleView extends Disposable {
 			let ariaLabel = '';
 			let helpHint = '';
 			const verbose = this._configurationService.getValue(provider.verbositySettingKey);
-			if (verbose && provider.options.type === AccessibleViewType.View) {
+			if (verbose && provider.options.type === AccessibleViewType.View && !showAccessibleViewHelp) {
 				const accessibilityHelpKeybinding = this._keybindingService.lookupKeybinding(AccessibilityCommandId.OpenAccessibilityHelp)?.getLabel();
 				if (accessibilityHelpKeybinding) {
 					helpHint = localize('ariaAccessibilityHelp', "Use {0} for accessibility help", accessibilityHelpKeybinding);


### PR DESCRIPTION
we now have actions that can be tabbed to, so this is not needed and we can reduce the noise.

fix #190272