### PR TITLE
Remove background color for chat requests

### DIFF
--- a/build/lib/stylelint/vscode-known-variables.json
+++ b/build/lib/stylelint/vscode-known-variables.json
@@ -36,7 +36,6 @@
 		"--vscode-charts-purple",
 		"--vscode-charts-red",
 		"--vscode-charts-yellow",
-		"--vscode-chat-requestBackground",
 		"--vscode-chat-requestBorder",
 		"--vscode-chat-slashCommandBackground",
 		"--vscode-chat-slashCommandForeground",

--- a/src/vs/workbench/contrib/chat/browser/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/media/chat.css
@@ -124,7 +124,6 @@
 }
 
 .interactive-request {
-	background-color: var(--vscode-chat-requestBackground);
 	border-bottom: 1px solid var(--vscode-chat-requestBorder);
 	border-top: 1px solid var(--vscode-chat-requestBorder);
 }

--- a/src/vs/workbench/contrib/chat/common/chatColors.ts
+++ b/src/vs/workbench/contrib/chat/common/chatColors.ts
@@ -7,13 +7,6 @@ import { Color, RGBA } from 'vs/base/common/color';
 import { localize } from 'vs/nls';
 import { badgeBackground, badgeForeground, registerColor } from 'vs/platform/theme/common/colorRegistry';
 
-
-export const chatRequestBackground = registerColor(
-	'chat.requestBackground',
-	{ dark: new Color(new RGBA(255, 255, 255, 0.03)), light: new Color(new RGBA(0, 0, 0, 0.03)), hcDark: null, hcLight: null, },
-	localize('chat.requestBackground', 'The background color of a chat request.')
-);
-
 export const chatRequestBorder = registerColor(
 	'chat.requestBorder',
 	{ dark: new Color(new RGBA(255, 255, 255, 0.10)), light: new Color(new RGBA(0, 0, 0, 0.10)), hcDark: null, hcLight: null, },


### PR DESCRIPTION
Continues work to reduce visual noise in chat. This also solves problems where it clashed with editor background and panel borders.

<img width="569" alt="CleanShot 2023-08-11 at 15 55 45@2x" src="https://github.com/microsoft/vscode/assets/25163139/0ce5324c-18ee-4813-aedf-73f91ba524a8">
