### PR TITLE
quickopen: file url

### DIFF
--- a/src/vs/workbench/contrib/search/browser/anythingQuickAccess.ts
+++ b/src/vs/workbench/contrib/search/browser/anythingQuickAccess.ts
@@ -9,7 +9,7 @@ import { IPickerQuickAccessItem, PickerQuickAccessProvider, TriggerAction, FastA
 import { prepareQuery, IPreparedQuery, compareItemsByFuzzyScore, scoreItemFuzzy, FuzzyScorerCache } from '../../../../base/common/fuzzyScorer.js';
 import { IFileQueryBuilderOptions, QueryBuilder } from '../../../services/search/common/queryBuilder.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
-import { getOutOfWorkspaceEditorResources, extractRangeFromFilter, IWorkbenchSearchConfiguration } from '../common/search.js';
+import { getOutOfWorkspaceEditorResources, extractRangeFromFileUrl, extractRangeFromFilter, IWorkbenchSearchConfiguration } from '../common/search.js';
 import { ISearchService, ISearchComplete } from '../../../services/search/common/search.js';
 import { IWorkspaceContextService } from '../../../../platform/workspace/common/workspace.js';
 import { untildify } from '../../../../base/common/labels.js';
@@ -251,7 +251,10 @@ export class AnythingQuickAccessProvider extends PickerQuickAccessProvider<IAnyt
 
 		// Find a suitable range from the pattern looking for ":", "#" or ","
 		// unless we have the `@` editor symbol character inside the filter
-		const filterWithRange = extractRangeFromFilter(originalFilter, [GotoSymbolQuickAccessProvider.PREFIX]);
+		const filterWithRange =
+			// Treat "file://" url as file path with selection
+			extractRangeFromFileUrl(originalFilter) ??
+			extractRangeFromFilter(originalFilter, [GotoSymbolQuickAccessProvider.PREFIX]);
 
 		// Update filter with normalized values
 		let filter: string;

--- a/src/vs/workbench/contrib/search/common/search.ts
+++ b/src/vs/workbench/contrib/search/common/search.ts
@@ -19,6 +19,7 @@ import { isNumber } from '../../../../base/common/types.js';
 import { RawContextKey } from '../../../../platform/contextkey/common/contextkey.js';
 import { compare } from '../../../../base/common/strings.js';
 import { groupBy } from '../../../../base/common/arrays.js';
+import { extractSelection } from '../../../../platform/opener/common/opener.js';
 
 export interface IWorkspaceSymbol {
 	name: string;
@@ -154,6 +155,31 @@ const LINE_COLON_PATTERN = /\s?[#:\(](?:line )?(\d*)(?:[#:,](\d*))?\)?:?\s*$/;
 export interface IFilterAndRange {
 	filter: string;
 	range: IRange;
+}
+
+export function extractRangeFromFileUrl(filter: string): IFilterAndRange | undefined {
+	if (!filter.startsWith('file://')) {
+		return undefined;
+	}
+	const { uri, selection } = extractSelection(URI.parse(filter));
+	let range: IRange;
+	if (selection) {
+		const { startLineNumber, startColumn, endLineNumber, endColumn } = selection;
+		range = {
+			startLineNumber,
+			startColumn,
+			endLineNumber: endLineNumber ?? startLineNumber,
+			endColumn: endColumn ?? startColumn
+		};
+	} else {
+		range = {
+			startLineNumber: 1,
+			startColumn: 1,
+			endLineNumber: 1,
+			endColumn: 1
+		};
+	}
+	return { filter: uri.fsPath, range };
 }
 
 export function extractRangeFromFilter(filter: string, unless?: string[]): IFilterAndRange | undefined {


### PR DESCRIPTION
Action: "Go to file..." (`workbench.action.quickOpen`)

Example query: `/etc/hosts`
Result: found "file results"

Example query: `file:///etc/hosts`
Result (expected): found "file results"
Result (actual): "No matching results"

VSCode supports opening `file://` url with selection, e.g. when clicking such links in editor.

P.S. I often copy `file://` urls from chrome to open them in vscode