### PR TITLE
Update dev container node version

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/devcontainers/typescript-node:16-bullseye
+FROM mcr.microsoft.com/devcontainers/typescript-node:18-bookworm
 
 ADD install-vscode.sh /root/
 RUN /root/install-vscode.sh


### PR DESCRIPTION
VSCode requires version Node version 18-20, however 20 doesn't work because it is incompatible with `eslint-plugin-jsdoc@39.3.2`.

Fixes #190331 