### PR TITLE
Support . as a row:column separator in terminal link detector

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/links/browser/terminalLinkParsing.ts
+++ b/src/vs/workbench/contrib/terminalContrib/links/browser/terminalLinkParsing.ts
@@ -71,11 +71,14 @@ function generateLinkSuffixRegex(eolOnly: boolean) {
 	const lineAndColumnRegexClauses = [
 		// foo:339
 		// foo:339:12
+		// foo:339.12
 		// foo 339
 		// foo 339:12                             [#140780]
+		// foo 339.12
 		// "foo",339
 		// "foo",339:12
-		`(?::| |['"],)${r()}(:${c()})?` + eolSuffix,
+		// "foo",339.12
+		`(?::| |['"],)${r()}([:.]${c()})?` + eolSuffix,
 		// The quotes below are optional          [#171652]
 		// "foo", line 339                        [#40468]
 		// "foo", line 339, col 12

--- a/src/vs/workbench/contrib/terminalContrib/links/test/browser/terminalLinkParsing.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/links/test/browser/terminalLinkParsing.test.ts
@@ -51,6 +51,7 @@ const testLinks: ITestLink[] = [
 	// Double quotes
 	{ link: '"foo",339', prefix: '"', suffix: '",339', hasRow: true, hasCol: false },
 	{ link: '"foo",339:12', prefix: '"', suffix: '",339:12', hasRow: true, hasCol: true },
+	{ link: '"foo",339.12', prefix: '"', suffix: '",339.12', hasRow: true, hasCol: true },
 	{ link: '"foo", line 339', prefix: '"', suffix: '", line 339', hasRow: true, hasCol: false },
 	{ link: '"foo", line 339, col 12', prefix: '"', suffix: '", line 339, col 12', hasRow: true, hasCol: true },
 	{ link: '"foo", line 339, column 12', prefix: '"', suffix: '", line 339, column 12', hasRow: true, hasCol: true },
@@ -69,6 +70,7 @@ const testLinks: ITestLink[] = [
 	// Single quotes
 	{ link: '\'foo\',339', prefix: '\'', suffix: '\',339', hasRow: true, hasCol: false },
 	{ link: '\'foo\',339:12', prefix: '\'', suffix: '\',339:12', hasRow: true, hasCol: true },
+	{ link: '\'foo\',339.12', prefix: '\'', suffix: '\',339.12', hasRow: true, hasCol: true },
 	{ link: '\'foo\', line 339', prefix: '\'', suffix: '\', line 339', hasRow: true, hasCol: false },
 	{ link: '\'foo\', line 339, col 12', prefix: '\'', suffix: '\', line 339, col 12', hasRow: true, hasCol: true },
 	{ link: '\'foo\', line 339, column 12', prefix: '\'', suffix: '\', line 339, column 12', hasRow: true, hasCol: true },

--- a/src/vs/workbench/contrib/terminalContrib/links/test/browser/terminalLinkParsing.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/links/test/browser/terminalLinkParsing.test.ts
@@ -43,8 +43,10 @@ const testLinks: ITestLink[] = [
 	{ link: 'foo', prefix: undefined, suffix: undefined, hasRow: false, hasCol: false },
 	{ link: 'foo:339', prefix: undefined, suffix: ':339', hasRow: true, hasCol: false },
 	{ link: 'foo:339:12', prefix: undefined, suffix: ':339:12', hasRow: true, hasCol: true },
+	{ link: 'foo:339.12', prefix: undefined, suffix: ':339.12', hasRow: true, hasCol: true },
 	{ link: 'foo 339', prefix: undefined, suffix: ' 339', hasRow: true, hasCol: false },
 	{ link: 'foo 339:12', prefix: undefined, suffix: ' 339:12', hasRow: true, hasCol: true },
+	{ link: 'foo 339.12', prefix: undefined, suffix: ' 339.12', hasRow: true, hasCol: true },
 
 	// Double quotes
 	{ link: '"foo",339', prefix: '"', suffix: '",339', hasRow: true, hasCol: false },


### PR DESCRIPTION
The motivation here is the Sail language compiler which outputs errors conforming to the GNU style

https://www.gnu.org/prep/standards/html_node/Errors.html

I think they must be the only people in the world actually using the `line0.col0-line1.col1` format. I did have an attempt to capture the ending line/column but it is very difficult with regex, and not that useful anyway so I've opted for the simpler option of just ignoring the `-` part.

Fixes #190350

The easiest way to test this is to make a file `test.txt` containing something like this:

```
Error: some error test.txt:1.10
```

Then `cat` it in the integrated terminal and click the links.