### PR TITLE
Use https

### DIFF
--- a/remote/.yarnrc
+++ b/remote/.yarnrc
@@ -1,4 +1,4 @@
-disturl "http://nodejs.org/dist"
+disturl "https://nodejs.org/dist"
 target "18.15.0"
 ms_build_id "223745"
 runtime "node"


### PR DESCRIPTION
I think downloading the headers even failed for me because of this, after the change it worked.

Anyway, I think http just should not be used.