### PR TITLE
[WIP] Run on save test profile

### DIFF
--- a/src/vs/workbench/api/common/extHostTesting.ts
+++ b/src/vs/workbench/api/common/extHostTesting.ts
@@ -133,7 +133,7 @@ export class ExtHostTesting implements ExtHostTestingShape {
 			get id() {
 				return controllerId;
 			},
-			createRunProfile: (label, group, runHandler, isDefault, tag?: vscode.TestTag | undefined, supportsContinuousRun?: boolean) => {
+			createRunProfile: (label, group, runHandler, isDefault, tag?: vscode.TestTag | undefined, supportsContinuousRun?: boolean, saveOnRun?: boolean) => {
 				// Derive the profile ID from a hash so that the same profile will tend
 				// to have the same hashes, allowing re-run requests to work across reloads.
 				let profileId = hash(label);
@@ -141,7 +141,7 @@ export class ExtHostTesting implements ExtHostTestingShape {
 					profileId++;
 				}
 
-				return new TestRunProfileImpl(this.proxy, profiles, controllerId, profileId, label, group, runHandler, isDefault, tag, supportsContinuousRun);
+				return new TestRunProfileImpl(this.proxy, profiles, controllerId, profileId, label, group, runHandler, isDefault, tag, supportsContinuousRun, saveOnRun);
 			},
 			createTestItem(id, label, uri) {
 				return new TestItemImpl(controllerId, id, label, uri);
@@ -210,6 +210,7 @@ export class ExtHostTesting implements ExtHostTestingShape {
 				profileId: profile.profileId,
 				controllerId: profile.controllerId,
 			}],
+			saveOnRun: profile.saveOnRun,
 			exclude: req.exclude?.map(t => t.id),
 		}, token);
 	}
@@ -668,6 +669,7 @@ export class TestRunCoordinator {
 		this.proxy.$startedExtensionTestRun({
 			controllerId,
 			continuous: !!request.continuous,
+			saveOnRun: profile?.saveOnRun ?? true,
 			profile: profile && { group: profileGroupToBitset[profile.kind], id: profile.profileId },
 			exclude: request.exclude?.map(t => TestId.fromExtHostTestItem(t, collection.root.id).toString()) ?? [],
 			id: dto.id,
@@ -1031,6 +1033,17 @@ export class TestRunProfileImpl implements vscode.TestRunProfile {
 		}
 	}
 
+	public get saveOnRun() {
+		return this._saveOnRun;
+	}
+
+	public set saveOnRun(saveOnRun: boolean) {
+		if (saveOnRun !== this._isDefault) {
+			this._isDefault = saveOnRun;
+			this.#proxy.$updateTestRunConfig(this.controllerId, this.profileId, { saveOnRun });
+		}
+	}
+
 	public get isDefault() {
 		return this._isDefault;
 	}
@@ -1075,8 +1088,10 @@ export class TestRunProfileImpl implements vscode.TestRunProfile {
 		public readonly kind: vscode.TestRunProfileKind,
 		public runHandler: (request: vscode.TestRunRequest, token: vscode.CancellationToken) => Thenable<void> | void,
 		private _isDefault = false,
+		private _saveOnRun = true,
 		public _tag: vscode.TestTag | undefined = undefined,
 		private _supportsContinuousRun = false,
+		private _saveOnRun = true,
 	) {
 		this.#proxy = proxy;
 		this.#profiles = profiles;
@@ -1094,6 +1109,7 @@ export class TestRunProfileImpl implements vscode.TestRunProfile {
 			label: _label,
 			group: groupBitset,
 			isDefault: _isDefault,
+			saveOnRun: _saveOnRun,
 			hasConfigurationHandler: false,
 			supportsContinuousRun: _supportsContinuousRun,
 		});

--- a/src/vs/workbench/contrib/testing/browser/testingDecorations.ts
+++ b/src/vs/workbench/contrib/testing/browser/testingDecorations.ts
@@ -851,6 +851,7 @@ abstract class RunTestDecoration {
 				}
 
 				this.testService.runResolvedTests({
+					saveOnRun: profile.saveOnRun,
 					targets: [{
 						profileGroup: profile.group,
 						profileId: profile.profileId,

--- a/src/vs/workbench/contrib/testing/common/testResultService.ts
+++ b/src/vs/workbench/contrib/testing/common/testResultService.ts
@@ -143,6 +143,7 @@ export class TestResultService implements ITestResultService {
 		}
 
 		const resolved: ResolvedTestRunRequest = {
+			saveOnRun: req.saveOnRun,
 			isUiTriggered: false,
 			targets: [],
 			exclude: req.exclude,

--- a/src/vs/workbench/contrib/testing/common/testService.ts
+++ b/src/vs/workbench/contrib/testing/common/testService.ts
@@ -200,6 +200,8 @@ export interface AmbiguousRunTestsRequest {
 	exclude?: InternalTestItem[];
 	/** Whether this was triggered from an auto run. */
 	continuous?: boolean;
+	/** Whether to save all files before executing this run */
+	saveOnRun?: boolean;
 }
 
 export interface ITestService {

--- a/src/vs/workbench/contrib/testing/common/testServiceImpl.ts
+++ b/src/vs/workbench/contrib/testing/common/testServiceImpl.ts
@@ -134,6 +134,7 @@ export class TestService extends Disposable implements ITestService {
 			targets: [],
 			exclude: req.exclude?.map(t => t.item.extId),
 			continuous: req.continuous,
+			saveOnRun: req.saveOnRun
 		};
 
 		// First, try to run the tests using the default run profiles...
@@ -253,7 +254,9 @@ export class TestService extends Disposable implements ITestService {
 					}
 				})
 			);
-			await this.saveAllBeforeTest(req);
+			if (req.saveOnRun) {
+				await this.saveAllBeforeTest(req);
+			}
 			await Promise.all(requests);
 			return result;
 		} finally {

--- a/src/vs/workbench/contrib/testing/common/testTypes.ts
+++ b/src/vs/workbench/contrib/testing/common/testTypes.ts
@@ -60,6 +60,7 @@ export interface ITestRunProfile {
 	tag: string | null;
 	hasConfigurationHandler: boolean;
 	supportsContinuousRun: boolean;
+	saveOnRun: boolean;
 }
 
 /**
@@ -76,6 +77,8 @@ export interface ResolvedTestRunRequest {
 	exclude?: string[];
 	/** Whether this is a continuous test run */
 	continuous?: boolean;
+	/** Whether to save all files before executing this run */
+	saveOnRun?: boolean;
 	/** Whether this was trigged by a user action in UI. Default=true */
 	isUiTriggered?: boolean;
 }
@@ -92,6 +95,8 @@ export interface ExtensionRunTestsRequest {
 	persist: boolean;
 	/** Whether this is a result of a continuous test run request */
 	continuous: boolean;
+	/** Whether to save all files before executing this run */
+	saveOnRun: boolean;
 }
 
 /**

--- a/src/vs/workbench/contrib/testing/test/common/testProfileService.test.ts
+++ b/src/vs/workbench/contrib/testing/test/common/testProfileService.test.ts
@@ -32,6 +32,7 @@ suite('Workbench - TestProfileService', () => {
 			hasConfigurationHandler: false,
 			tag: null,
 			supportsContinuousRun: false,
+			saveOnRun: true,
 			...profile,
 		};
 

--- a/src/vscode-dts/vscode.d.ts
+++ b/src/vscode-dts/vscode.d.ts
@@ -16172,6 +16172,12 @@ declare module 'vscode' {
 		supportsContinuousRun: boolean;
 
 		/**
+		 * Wether to save all unsaved files when running tests using this profile.
+		 * Defaults to true.
+		 */
+		saveOnRun: boolean;
+
+		/**
 		 * Associated tag for the profile. If this is set, only {@link TestItem}
 		 * instances with the same tag will be eligible to execute in this profile.
 		 */


### PR DESCRIPTION
Fixed #158254

### Changes

Add an boolean argument `saveOnRun` to `createRunProfile` that can be set to false to prevent saving all files when running this profile.

### Testing

I don't know yet how to write a test for this. I'd like the test to be written as an extension that uses the VSCode API. Could you someone point to me existing tests like that? I see there are tests for the built-in VSCode extensions that are like that, but I'd like to use a tiny extension purely for the purpose of testing, without it being part of the built-in extension set.


