### PR TITLE
Return focus to where it came from

### DIFF
--- a/src/vs/platform/quickinput/browser/quickInput.ts
+++ b/src/vs/platform/quickinput/browser/quickInput.ts
@@ -1410,6 +1410,10 @@ export class QuickInputController extends Disposable {
 		const focusTracker = dom.trackFocus(container);
 		this._register(focusTracker);
 		this._register(dom.addDisposableListener(container, dom.EventType.FOCUS, e => {
+			// Ignore focus events within container
+			if (dom.isAncestor(e.relatedTarget as HTMLElement, container)) {
+				return;
+			}
 			this.previousFocusElement = e.relatedTarget instanceof HTMLElement ? e.relatedTarget : undefined;
 		}, true));
 		this._register(focusTracker.onDidBlur(() => {
@@ -1799,25 +1803,27 @@ export class QuickInputController extends Disposable {
 
 	hide(reason?: QuickInputHideReason) {
 		const controller = this.controller;
-		if (controller) {
-			const focusChanged = !this.ui?.container.contains(document.activeElement);
-			this.controller = null;
-			this.onHideEmitter.fire();
-			this.getUI().container.style.display = 'none';
-			if (!focusChanged) {
-				let currentElement = this.previousFocusElement;
-				while (currentElement && !currentElement.offsetParent) {
-					currentElement = currentElement.parentElement ?? undefined;
-				}
-				if (currentElement?.offsetParent) {
-					currentElement.focus();
-					this.previousFocusElement = undefined;
-				} else {
-					this.options.returnFocus();
-				}
-			}
-			controller.didHide(reason);
+		if (!controller) {
+			return;
 		}
+
+		const focusChanged = !dom.isAncestor(document.activeElement, this.ui?.container ?? null);
+		this.controller = null;
+		this.onHideEmitter.fire();
+		this.getUI().container.style.display = 'none';
+		if (!focusChanged) {
+			let currentElement = this.previousFocusElement;
+			while (currentElement && !currentElement.offsetParent) {
+				currentElement = currentElement.parentElement ?? undefined;
+			}
+			if (currentElement?.offsetParent) {
+				currentElement.focus();
+				this.previousFocusElement = undefined;
+			} else {
+				this.options.returnFocus();
+			}
+		}
+		controller.didHide(reason);
 	}
 
 	focus() {


### PR DESCRIPTION
The original checks were too shallow. They need to check recursively to handle the widget (chat) correctly. This uses `dom.isAncestor` in some important spots.

Fixes https://github.com/microsoft/vscode/issues/189968

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
