### PR TITLE
testing: add `testResultOutdated` context key

### DIFF
--- a/src/vs/workbench/contrib/testing/common/testingContextKeys.ts
+++ b/src/vs/workbench/contrib/testing/common/testingContextKeys.ts
@@ -59,7 +59,11 @@ export namespace TestingContextKeys {
 		description: localize('testing.testItemIsHidden', 'Boolean indicating whether the test item is hidden')
 	});
 	export const testMessageContext = new RawContextKey<string>('testMessage', undefined, {
-		type: 'boolean',
+		type: 'string',
 		description: localize('testing.testMessage', 'Value set in `testMessage.contextValue`, available in editor/content and testing/message/context')
+	});
+	export const testResultOutdated = new RawContextKey<boolean>('testResultOutdated', undefined, {
+		type: 'boolean',
+		description: localize('testing.testResultOutdated', 'Value available in editor/content and testing/message/context when the result is outdated')
 	});
 }


### PR DESCRIPTION
This can be used in the snapshot scenario to only show the "apply snapshot"
button when the result is not outdated (marking the original failing
result as outdated once its snapshot is updated).

Also cleans up the `InspectSubject` types a little bit.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
