### PR TITLE
improve accessibility of inline completions

### DIFF
--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -730,6 +730,11 @@ export interface IEditorOptions {
 	 * Controls whether the editor receives tabs or defers them to the workbench for navigation.
 	 */
 	tabFocusMode?: boolean;
+
+	/**
+	 * Controls whether the accessibility hint should be provided to screen reader users when an inline completion is shown.
+	 */
+	inlineCompletionsAccessibilityVerbose?: boolean;
 }
 
 /**
@@ -5143,7 +5148,8 @@ export const enum EditorOption {
 	layoutInfo,
 	wrappingInfo,
 	defaultColorDecorators,
-	colorDecoratorsActivatedOn
+	colorDecoratorsActivatedOn,
+	inlineCompletionsAccessibilityVerbose
 }
 
 export const EditorOptions = {
@@ -5734,6 +5740,8 @@ export const EditorOptions = {
 	)),
 	suggest: register(new EditorSuggest()),
 	inlineSuggest: register(new InlineEditorSuggest()),
+	inlineCompletionsAccessibilityVerbose: register(new EditorBooleanOption(EditorOption.inlineCompletionsAccessibilityVerbose, 'inlineCompletionsAccessibilityVerbose', false,
+		{ description: nls.localize('inlineCompletionsAccessibilityVerbose', "Controls whether the accessibility hint should be provided to screen reader users when an inline completion is shown.") })),
 	suggestFontSize: register(new EditorIntOption(
 		EditorOption.suggestFontSize, 'suggestFontSize',
 		0, 0, 1000,

--- a/src/vs/editor/common/standalone/standaloneEnums.ts
+++ b/src/vs/editor/common/standalone/standaloneEnums.ts
@@ -318,7 +318,8 @@ export enum EditorOption {
 	layoutInfo = 142,
 	wrappingInfo = 143,
 	defaultColorDecorators = 144,
-	colorDecoratorsActivatedOn = 145
+	colorDecoratorsActivatedOn = 145,
+	inlineCompletionsAccessibilityVerbose = 146
 }
 
 /**

--- a/src/vs/editor/contrib/inlineCompletions/browser/inlineCompletionsController.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/inlineCompletionsController.ts
@@ -192,7 +192,7 @@ export class InlineCompletionsController extends Disposable {
 				const lineText = model.textModel.getLineContent(state.ghostText.lineNumber);
 				this.audioCueService.playAudioCue(AudioCue.inlineSuggestion).then(() => {
 					if (this.editor.getOption(EditorOption.screenReaderAnnounceInlineSuggestion)) {
-						this.provideScreenReaderUpdate(state.ghostText.renderForScreenReader(lineText));
+						this.provideScreenReaderUpdate(lineText + state.ghostText.renderForScreenReader(lineText));
 					}
 				});
 			}

--- a/src/vs/editor/contrib/inlineCompletions/browser/inlineCompletionsController.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/inlineCompletionsController.ts
@@ -149,7 +149,7 @@ export class InlineCompletionsController extends Disposable {
 
 		this._register(this.editor.onDidBlurEditorWidget(() => {
 			// This is a hidden setting very useful for debugging
-			if (this.configurationService.getValue('editor.inlineSuggest.keepOnBlur') ||
+			if (this.contextKeyService.getContextKeyValue<boolean>('accessibleViewIsShown') || this.configurationService.getValue('editor.inlineSuggest.keepOnBlur') ||
 				editor.getOption(EditorOption.inlineSuggest).keepOnBlur) {
 				return;
 			}
@@ -208,9 +208,10 @@ export class InlineCompletionsController extends Disposable {
 	}
 
 	private provideScreenReaderUpdate(content: string): void {
+		const accessibleViewShowing = this.contextKeyService.getContextKeyValue<boolean>('accessibleViewIsShown');
 		const accessibleViewKeybinding = this._keybindingService.lookupKeybinding('editor.action.accessibleView');
 		let hint: string | undefined;
-		if (accessibleViewKeybinding && this.editor.getOption(EditorOption.inlineCompletionsAccessibilityVerbose)) {
+		if (!accessibleViewShowing && accessibleViewKeybinding && this.editor.getOption(EditorOption.inlineCompletionsAccessibilityVerbose)) {
 			hint = localize('showAccessibleViewHint', "Inspect this in the accessible view ({0})", accessibleViewKeybinding.getAriaLabel());
 		}
 		hint ? alert(content + ', ' + hint) : alert(content);

--- a/src/vs/editor/contrib/inlineCompletions/browser/inlineCompletionsController.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/inlineCompletionsController.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { alert, status } from 'vs/base/browser/ui/aria/aria';
+import { alert } from 'vs/base/browser/ui/aria/aria';
 import { Event } from 'vs/base/common/event';
 import { Disposable, toDisposable } from 'vs/base/common/lifecycle';
 import { ITransaction, autorun, constObservable, disposableObservableValue, observableFromEvent, observableValue, transaction } from 'vs/base/common/observable';
@@ -193,8 +193,7 @@ export class InlineCompletionsController extends Disposable {
 				const lineText = model.textModel.getLineContent(state.ghostText.lineNumber);
 				this.audioCueService.playAudioCue(AudioCue.inlineSuggestion).then(() => {
 					if (this.editor.getOption(EditorOption.screenReaderAnnounceInlineSuggestion)) {
-						alert(state.ghostText.renderForScreenReader(lineText));
-						this.provideScreenReaderHint();
+						this.provideScreenReaderUpdate(state.ghostText.renderForScreenReader(lineText));
 					}
 				});
 			}
@@ -203,14 +202,14 @@ export class InlineCompletionsController extends Disposable {
 		this._register(new InlineCompletionsHintsWidget(this.editor, this.model, this.instantiationService));
 	}
 
-	private provideScreenReaderHint(): void {
+	private provideScreenReaderUpdate(content: string): void {
 		const accessibleViewKeybinding = this._keybindingService.lookupKeybinding('editor.action.accessibleView');
 		if (this.configurationService.getValue('accessibility.verbosity.inlineCompletions')) {
 			let hint: string | undefined;
 			if (accessibleViewKeybinding) {
 				hint = localize('showAccessibleViewHint', "Inspect this in the accessible view ({0})", accessibleViewKeybinding.getAriaLabel());
-				status(hint);
 			}
+			hint ? alert(content + ', ' + hint) : alert(content);
 		}
 	}
 

--- a/src/vs/editor/contrib/inlineCompletions/browser/inlineCompletionsController.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/inlineCompletionsController.ts
@@ -80,7 +80,6 @@ export class InlineCompletionsController extends Disposable {
 		super();
 
 		this._register(new InlineCompletionContextKeys(this.contextKeyService, this.model));
-
 		this._register(Event.runAndSubscribe(editor.onDidChangeModel, () => transaction(tx => {
 			/** @description onDidChangeModel */
 			this.model.set(undefined, tx);
@@ -200,17 +199,21 @@ export class InlineCompletionsController extends Disposable {
 		}));
 
 		this._register(new InlineCompletionsHintsWidget(this.editor, this.model, this.instantiationService));
+		this._register(this.configurationService.onDidChangeConfiguration(e => {
+			if (e.affectsConfiguration('accessibility.verbosity.inlineCompletions')) {
+				this.editor.updateOptions({ inlineCompletionsAccessibilityVerbose: this.configurationService.getValue('accessibility.verbosity.inlineCompletions') });
+			}
+		}));
+		this.editor.updateOptions({ inlineCompletionsAccessibilityVerbose: this.configurationService.getValue('accessibility.verbosity.inlineCompletions') });
 	}
 
 	private provideScreenReaderUpdate(content: string): void {
 		const accessibleViewKeybinding = this._keybindingService.lookupKeybinding('editor.action.accessibleView');
-		if (this.configurationService.getValue('accessibility.verbosity.inlineCompletions')) {
-			let hint: string | undefined;
-			if (accessibleViewKeybinding) {
-				hint = localize('showAccessibleViewHint', "Inspect this in the accessible view ({0})", accessibleViewKeybinding.getAriaLabel());
-			}
-			hint ? alert(content + ', ' + hint) : alert(content);
+		let hint: string | undefined;
+		if (accessibleViewKeybinding && this.editor.getOption(EditorOption.inlineCompletionsAccessibilityVerbose)) {
+			hint = localize('showAccessibleViewHint', "Inspect this in the accessible view ({0})", accessibleViewKeybinding.getAriaLabel());
 		}
+		hint ? alert(content + ', ' + hint) : alert(content);
 	}
 
 	/**

--- a/src/vs/editor/contrib/inlineCompletions/browser/inlineCompletionsController.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/inlineCompletionsController.ts
@@ -204,18 +204,11 @@ export class InlineCompletionsController extends Disposable {
 	}
 
 	private provideScreenReaderHint(): void {
-		const showHoverKeybinding = this._keybindingService.lookupKeybinding('editor.action.showHover');
 		const accessibleViewKeybinding = this._keybindingService.lookupKeybinding('editor.action.accessibleView');
 		if (this.configurationService.getValue('accessibility.verbosity.inlineCompletions')) {
 			let hint: string | undefined;
-			if (showHoverKeybinding && accessibleViewKeybinding) {
-				hint = localize('showBothHints', "View more actions ({0}) or inspect this in the accessible view ({1})", showHoverKeybinding.getAriaLabel(), accessibleViewKeybinding.getAriaLabel());
-			} else if (showHoverKeybinding) {
-				hint = localize('showHoverHint', "View more actions ({0})", showHoverKeybinding.getAriaLabel());
-			} else if (accessibleViewKeybinding) {
+			if (accessibleViewKeybinding) {
 				hint = localize('showAccessibleViewHint', "Inspect this in the accessible view ({0})", accessibleViewKeybinding.getAriaLabel());
-			}
-			if (hint) {
 				status(hint);
 			}
 		}

--- a/src/vs/editor/test/browser/testCodeEditor.ts
+++ b/src/vs/editor/test/browser/testCodeEditor.ts
@@ -45,7 +45,8 @@ import { SyncDescriptor } from 'vs/platform/instantiation/common/descriptors';
 import { BrandedService, IInstantiationService, ServiceIdentifier } from 'vs/platform/instantiation/common/instantiation';
 import { ServiceCollection } from 'vs/platform/instantiation/common/serviceCollection';
 import { TestInstantiationService } from 'vs/platform/instantiation/test/common/instantiationServiceMock';
-import { MockContextKeyService } from 'vs/platform/keybinding/test/common/mockKeybindingService';
+import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
+import { MockContextKeyService, MockKeybindingService } from 'vs/platform/keybinding/test/common/mockKeybindingService';
 import { ILogService, NullLogService } from 'vs/platform/log/common/log';
 import { INotificationService } from 'vs/platform/notification/common/notification';
 import { TestNotificationService } from 'vs/platform/notification/test/common/testNotificationService';
@@ -176,6 +177,7 @@ export function createCodeEditorServices(disposables: DisposableStore, services:
 	};
 
 	define(IAccessibilityService, TestAccessibilityService);
+	define(IKeybindingService, MockKeybindingService);
 	define(IClipboardService, TestClipboardService);
 	define(IEditorWorkerService, TestEditorWorkerService);
 	defineInstance(IOpenerService, NullOpenerService);

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -3888,6 +3888,10 @@ declare namespace monaco.editor {
 		 * Controls whether the editor receives tabs or defers them to the workbench for navigation.
 		 */
 		tabFocusMode?: boolean;
+		/**
+		 * Controls whether the accessibility hint should be provided to screen reader users when an inline completion is shown.
+		 */
+		inlineCompletionsAccessibilityVerbose?: boolean;
 	}
 
 	export interface IDiffEditorBaseOptions {
@@ -5024,7 +5028,8 @@ declare namespace monaco.editor {
 		layoutInfo = 142,
 		wrappingInfo = 143,
 		defaultColorDecorators = 144,
-		colorDecoratorsActivatedOn = 145
+		colorDecoratorsActivatedOn = 145,
+		inlineCompletionsAccessibilityVerbose = 146
 	}
 
 	export const EditorOptions: {
@@ -5148,6 +5153,7 @@ declare namespace monaco.editor {
 		stopRenderingLineAfter: IEditorOption<EditorOption.stopRenderingLineAfter, number>;
 		suggest: IEditorOption<EditorOption.suggest, Readonly<Required<ISuggestOptions>>>;
 		inlineSuggest: IEditorOption<EditorOption.inlineSuggest, Readonly<Required<IInlineSuggestOptions>>>;
+		inlineCompletionsAccessibilityVerbose: IEditorOption<EditorOption.inlineCompletionsAccessibilityVerbose, boolean>;
 		suggestFontSize: IEditorOption<EditorOption.suggestFontSize, number>;
 		suggestLineHeight: IEditorOption<EditorOption.suggestLineHeight, number>;
 		suggestOnTriggerCharacters: IEditorOption<EditorOption.suggestOnTriggerCharacters, boolean>;

--- a/src/vs/workbench/contrib/accessibility/browser/accessibility.contribution.ts
+++ b/src/vs/workbench/contrib/accessibility/browser/accessibility.contribution.ts
@@ -10,7 +10,7 @@ import { LifecyclePhase } from 'vs/workbench/services/lifecycle/common/lifecycle
 import { Registry } from 'vs/platform/registry/common/platform';
 import { IAccessibleViewService, AccessibleViewService } from 'vs/workbench/contrib/accessibility/browser/accessibleView';
 import { UnfocusedViewDimmingContribution } from 'vs/workbench/contrib/accessibility/browser/unfocusedViewDimmingContribution';
-import { EditorAccessibilityHelpContribution, HoverAccessibleViewContribution, NotificationAccessibleViewContribution } from 'vs/workbench/contrib/accessibility/browser/accessibilityContributions';
+import { EditorAccessibilityHelpContribution, HoverAccessibleViewContribution, InlineCompletionsAccessibleViewContribution, NotificationAccessibleViewContribution } from 'vs/workbench/contrib/accessibility/browser/accessibilityContributions';
 
 registerAccessibilityConfiguration();
 registerSingleton(IAccessibleViewService, AccessibleViewService, InstantiationType.Delayed);
@@ -22,3 +22,4 @@ workbenchRegistry.registerWorkbenchContribution(UnfocusedViewDimmingContribution
 const workbenchContributionsRegistry = Registry.as<IWorkbenchContributionsRegistry>(WorkbenchExtensions.Workbench);
 workbenchContributionsRegistry.registerWorkbenchContribution(HoverAccessibleViewContribution, LifecyclePhase.Eventually);
 workbenchContributionsRegistry.registerWorkbenchContribution(NotificationAccessibleViewContribution, LifecyclePhase.Eventually);
+workbenchContributionsRegistry.registerWorkbenchContribution(InlineCompletionsAccessibleViewContribution, LifecyclePhase.Eventually);

--- a/src/vs/workbench/contrib/accessibility/browser/accessibilityConfiguration.ts
+++ b/src/vs/workbench/contrib/accessibility/browser/accessibilityConfiguration.ts
@@ -20,6 +20,7 @@ export const enum AccessibilityVerbositySettingId {
 	DiffEditor = 'accessibility.verbosity.diffEditor',
 	Chat = 'accessibility.verbosity.panelChat',
 	InlineChat = 'accessibility.verbosity.inlineChat',
+	InlineCompletions = 'accessibility.verbosity.inlineCompletions',
 	KeybindingsEditor = 'accessibility.verbosity.keybindingsEditor',
 	Notebook = 'accessibility.verbosity.notebook',
 	Editor = 'accessibility.verbosity.editor',
@@ -53,6 +54,10 @@ const configuration: IConfigurationNode = {
 		},
 		[AccessibilityVerbositySettingId.InlineChat]: {
 			description: localize('verbosity.interactiveEditor.description', 'Provide information about how to access the inline editor chat accessibility help menu and alert with hints which describe how to use the feature when the input is focused'),
+			...baseProperty
+		},
+		[AccessibilityVerbositySettingId.InlineCompletions]: {
+			description: localize('verbosity.inlineCompletions.description', 'Provide information about how to access the inline completions hover and accessible view'),
 			...baseProperty
 		},
 		[AccessibilityVerbositySettingId.KeybindingsEditor]: {

--- a/src/vs/workbench/contrib/accessibility/browser/accessibilityContributions.ts
+++ b/src/vs/workbench/contrib/accessibility/browser/accessibilityContributions.ts
@@ -302,7 +302,7 @@ export class InlineCompletionsAccessibleViewContribution extends Disposable {
 			if (!lineText) {
 				return false;
 			}
-			const content = InlineCompletionsController.get(editor)?.model.get()?.ghostText.get()?.renderForScreenReader(lineText);
+			const content = state.ghostText.renderForScreenReader(lineText);
 			if (!content) {
 				return false;
 			}

--- a/src/vs/workbench/contrib/accessibility/browser/accessibilityContributions.ts
+++ b/src/vs/workbench/contrib/accessibility/browser/accessibilityContributions.ts
@@ -313,6 +313,7 @@ export class InlineCompletionsAccessibleViewContribution extends Disposable {
 					verbositySettingKey: AccessibilityVerbositySettingId.InlineCompletions,
 					provideContent() { return lineText + ghostText; },
 					onClose() {
+						model.stop();
 						editor.focus();
 					},
 					next() {
@@ -327,9 +328,11 @@ export class InlineCompletionsAccessibleViewContribution extends Disposable {
 							label: localize('inlineCompletions.accept', "Accept Completion"),
 							tooltip: localize('inlineCompletions.accept', "Accept Completion"),
 							run: () => {
-								alert('Accepted');
-								model.accept(editor);
-								editor.focus();
+								model.accept(editor).then(() => {
+									alert('Accepted');
+									model.stop();
+									editor.focus();
+								});
 							},
 							class: ThemeIcon.asClassName(Codicon.check),
 							enabled: true

--- a/src/vs/workbench/contrib/accessibility/browser/accessibilityContributions.ts
+++ b/src/vs/workbench/contrib/accessibility/browser/accessibilityContributions.ts
@@ -310,7 +310,7 @@ export class InlineCompletionsAccessibleViewContribution extends Disposable {
 				verbositySettingKey: AccessibilityVerbositySettingId.InlineCompletions,
 				provideContent() { return content; },
 				onClose() {
-
+					editor.focus();
 				},
 				options: this._options
 			});

--- a/src/vs/workbench/contrib/accessibility/browser/accessibleView.ts
+++ b/src/vs/workbench/contrib/accessibility/browser/accessibleView.ts
@@ -123,7 +123,7 @@ class AccessibleView extends Disposable {
 		const codeEditorWidgetOptions: ICodeEditorWidgetOptions = {
 			contributions: EditorExtensionsRegistry.getEditorContributions().filter(c => c.id !== CodeActionController.ID)
 		};
-		this._toolbar = this._register(_instantiationService.createInstance(WorkbenchToolBar, this._editorContainer, { ariaLabel: localize('accessibleViewToolbar', "Accessible View Toolbar"), orientation: ActionsOrientation.HORIZONTAL }));
+		this._toolbar = this._register(_instantiationService.createInstance(WorkbenchToolBar, this._editorContainer, { orientation: ActionsOrientation.HORIZONTAL }));
 		this._toolbar.context = { viewId: 'accessibleView' };
 		const toolbarElt = this._toolbar.getElement();
 		toolbarElt.tabIndex = 0;
@@ -309,16 +309,13 @@ class AccessibleView extends Disposable {
 			model.setLanguage(provider.options.language ?? 'markdown');
 			container.appendChild(this._editorContainer);
 			let ariaLabel = '';
-			let helpHint = '';
+			let actionsHint = '';
 			const verbose = this._configurationService.getValue(provider.verbositySettingKey);
 			if (verbose && provider.options.type === AccessibleViewType.View && !showAccessibleViewHelp) {
-				const accessibilityHelpKeybinding = this._keybindingService.lookupKeybinding(AccessibilityCommandId.OpenAccessibilityHelp)?.getLabel();
-				if (accessibilityHelpKeybinding) {
-					helpHint = localize('ariaAccessibilityHelp', "Use {0} for accessibility help", accessibilityHelpKeybinding);
-				}
+				actionsHint = localize('ariaAccessibleViewActions', "Use Shift+Tab to explore actions such as disabling this hint.");
 			}
-			if (helpHint) {
-				ariaLabel = provider.options.ariaLabel ? localize('helpAriaKb', "{0}, {1}", provider.options.ariaLabel, helpHint) : localize('accessible-view', "Accessible View, {0}", helpHint);
+			if (actionsHint) {
+				ariaLabel = provider.options.ariaLabel ? localize('actionsAriaKb', "{0}, {1}", provider.options.ariaLabel, actionsHint) : localize('accessible-view', "Accessible View, {0}", actionsHint);
 			} else {
 				ariaLabel = provider.options.ariaLabel ? provider.options.ariaLabel : localize('helpAriaNoKb', "Accessible View");
 			}
@@ -326,7 +323,7 @@ class AccessibleView extends Disposable {
 			this._editorWidget.updateOptions({ ariaLabel });
 			this._editorWidget.focus();
 		});
-		this._updateToolbar(provider.actions);
+		this._updateToolbar(provider.actions, provider.options.type);
 
 		const disposableStore = new DisposableStore();
 		disposableStore.add(this._editorWidget.onKeyUp((e) => provider.onKeyDown?.(e)));
@@ -355,8 +352,9 @@ class AccessibleView extends Disposable {
 		return disposableStore;
 	}
 
-	private _updateToolbar(providedActions?: IAction[]): void {
+	private _updateToolbar(providedActions?: IAction[], type?: AccessibleViewType): void {
 		this._toolbar.setActions([]);
+		this._toolbar.setAriaLabel(type === AccessibleViewType.Help ? localize('accessibleHelpToolbar', 'Accessibility Help') : localize('accessibleViewToolbar', "Accessible View"));
 		const menuActions: IAction[] = [];
 		const toolbarMenu = this._register(this._menuService.createMenu(MenuId.AccessibleView, this._contextKeyService));
 		createAndFillInActionBarActions(toolbarMenu, {}, menuActions);

--- a/src/vs/workbench/contrib/accessibility/browser/accessibleView.ts
+++ b/src/vs/workbench/contrib/accessibility/browser/accessibleView.ts
@@ -295,7 +295,7 @@ class AccessibleView extends Disposable {
 			}
 		}
 
-		const fragment = message + provider.provideContent() + readMoreLink + disableHelpHint + localize('exit-tip', 'Exit this dialog via the Escape key.');
+		const fragment = message + provider.provideContent() + readMoreLink + disableHelpHint + localize('exit-tip', '\nExit this dialog via the Escape key.');
 
 		this._getTextModel(URI.from({ path: `accessible-view-${provider.verbositySettingKey}`, scheme: 'accessible-view', fragment })).then((model) => {
 			if (!model) {

--- a/src/vs/workbench/contrib/accessibility/browser/accessibleView.ts
+++ b/src/vs/workbench/contrib/accessibility/browser/accessibleView.ts
@@ -410,7 +410,7 @@ class AccessibleView extends Disposable {
 	private _getAccessibleViewHelpDialogContent(providerHasSymbols?: boolean): string {
 		const navigationHint = this._getNavigationHint();
 		const goToSymbolHint = this._getGoToSymbolHint(providerHasSymbols);
-		const toolbarHint = localize('toolbar', "Navigate to the toolbar ({0} or Shift+Tab)");
+		const toolbarHint = localize('toolbar', "Navigate to the toolbar (Shift+Tab))");
 
 		let hint = localize('intro', "In the accessible view, you can:\n");
 		if (navigationHint) {


### PR DESCRIPTION
This:
- Adds an inline completion accessible view 
- Adds a hint to open that (`EditorOption` / verbosity setting controlled)
- Changes the accessible view's aria label from a hint to open the accessibility help menu to one that suggests using `shift+tab` to explore the available actions, citing disabling this hint as an example.
- Enables navigating to the next/previous completion from within the accessible view
- Allows accepting the completion from within the accessible view
- Announces not just the partial text, but the full completion to the screen reader - this makes more sense IMO

fix #186307