### PR TITLE
feat: add configurable scm discard changes warning message #190483

### DIFF
--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -1631,7 +1631,12 @@ export class CommandCenter {
 			}
 		}
 
-		const pick = await window.showWarningMessage(message, { modal: true }, yes);
+		let pick: string | undefined;
+		if (CommandCenter.getScmDiscardChangesUserConfig() === false) {
+			pick = yes;
+		}
+
+		pick = pick || await window.showWarningMessage(message, { modal: true }, yes);
 
 		if (pick !== yes) {
 			return;
@@ -1670,7 +1675,12 @@ export class CommandCenter {
 				: l10n.t('Discard {0} Tracked Files', trackedResources.length);
 
 			const yesAll = l10n.t('Discard All {0} Files', resources.length);
-			const pick = await window.showWarningMessage(message, { modal: true }, yesTracked, yesAll);
+
+			let pick: string | undefined;
+			if (CommandCenter.getScmDiscardChangesUserConfig() === false) {
+				pick = yesAll;
+			}
+			pick = pick || await window.showWarningMessage(message, { modal: true }, yesTracked, yesAll);
 
 			if (pick === yesTracked) {
 				resources = trackedResources;
@@ -1717,7 +1727,12 @@ export class CommandCenter {
 		const yes = resources.length === 1
 			? l10n.t('Discard 1 File')
 			: l10n.t('Discard All {0} Files', resources.length);
-		const pick = await window.showWarningMessage(message, { modal: true }, yes);
+
+		let pick: string | undefined;
+		if (CommandCenter.getScmDiscardChangesUserConfig() === false) {
+			pick = yes;
+		}
+		pick = pick || await window.showWarningMessage(message, { modal: true }, yes);
 
 		if (pick !== yes) {
 			return;
@@ -1729,7 +1744,12 @@ export class CommandCenter {
 	private async _cleanUntrackedChange(repository: Repository, resource: Resource): Promise<void> {
 		const message = l10n.t('Are you sure you want to DELETE {0}?\nThis is IRREVERSIBLE!\nThis file will be FOREVER LOST if you proceed.', path.basename(resource.resourceUri.fsPath));
 		const yes = l10n.t('Delete file');
-		const pick = await window.showWarningMessage(message, { modal: true }, yes);
+
+		let pick: string | undefined;
+		if (CommandCenter.getScmDiscardChangesUserConfig() === false) {
+			pick = yes;
+		}
+		pick = pick || await window.showWarningMessage(message, { modal: true }, yes);
 
 		if (pick !== yes) {
 			return;
@@ -1741,13 +1761,22 @@ export class CommandCenter {
 	private async _cleanUntrackedChanges(repository: Repository, resources: Resource[]): Promise<void> {
 		const message = l10n.t('Are you sure you want to DELETE {0} files?\nThis is IRREVERSIBLE!\nThese files will be FOREVER LOST if you proceed.', resources.length);
 		const yes = l10n.t('Delete Files');
-		const pick = await window.showWarningMessage(message, { modal: true }, yes);
+
+		let pick: string | undefined;
+		if (CommandCenter.getScmDiscardChangesUserConfig() === false) {
+			pick = yes;
+		}
+		pick = pick || await window.showWarningMessage(message, { modal: true }, yes);
 
 		if (pick !== yes) {
 			return;
 		}
 
 		await repository.clean(resources.map(r => r.resourceUri));
+	}
+
+	private static getScmDiscardChangesUserConfig(): boolean {
+		return workspace.getConfiguration('scm')['confirmDiscardChanges'];
 	}
 
 	private async smartCommit(

--- a/src/vs/workbench/contrib/scm/browser/scm.contribution.ts
+++ b/src/vs/workbench/contrib/scm/browser/scm.contribution.ts
@@ -244,6 +244,11 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).regis
 			description: localize('autoReveal', "Controls whether the Source Control view should automatically reveal and select files when opening them."),
 			default: true
 		},
+		'scm.confirmDiscardChanges': {
+			type: 'boolean',
+			description: localize('confirmDiscardChanges', "Controls whether the Source Control view should ask for confirmation when discarding changes."),
+			default: true
+		},
 		'scm.inputFontFamily': {
 			type: 'string',
 			markdownDescription: localize('inputFontFamily', "Controls the font for the input message. Use `default` for the workbench user interface font family, `editor` for the `#editor.fontFamily#`'s value, or a custom font family."),


### PR DESCRIPTION

[#190483](https://github.com/microsoft/vscode/issues/190483)

How to test:
1. deselect user config (image1) 
2.  source control changes are now discarded without a warning dialogue

![image](https://github.com/microsoft/vscode/assets/61087915/307618c5-aa2d-4c50-9807-1ff5f6400df6)

