### PR TITLE
Dispose previous items when rendering output items

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/view/cellParts/cellOutput.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/cellParts/cellOutput.ts
@@ -598,7 +598,7 @@ export class CellOutputContainer extends CellContentPart {
 		if (firstGroupEntries.length + newlyInserted.length + secondGroupEntries.length > this.options.limit) {
 			// exceeds limit again
 			if (firstGroupEntries.length + newlyInserted.length > this.options.limit) {
-				[...deletedEntries, ...secondGroupEntries].forEach(entry => {
+				[...secondGroupEntries].forEach(entry => {
 					entry.element.detach();
 					entry.element.dispose();
 				});
@@ -618,7 +618,7 @@ export class CellOutputContainer extends CellContentPart {
 				// part of secondGroupEntries are pushed out of view
 				// now we have to be creative as secondGroupEntries might not use dedicated containers
 				const elementsPushedOutOfView = secondGroupEntries.slice(this.options.limit - firstGroupEntries.length - newlyInserted.length);
-				[...deletedEntries, ...elementsPushedOutOfView].forEach(entry => {
+				[...elementsPushedOutOfView].forEach(entry => {
 					entry.element.detach();
 					entry.element.dispose();
 				});
@@ -638,12 +638,6 @@ export class CellOutputContainer extends CellContentPart {
 				}
 			}
 		} else {
-			// after splice, it doesn't exceed
-			deletedEntries.forEach(entry => {
-				entry.element.detach();
-				entry.element.dispose();
-			});
-
 			const reRenderRightBoundary = firstGroupEntries.length + newlyInserted.length;
 
 			const newlyInsertedEntries = newlyInserted.map(insert => {
@@ -689,6 +683,12 @@ export class CellOutputContainer extends CellContentPart {
 		// shrink immediately as the final output height will be zero.
 		// if it's rerun, then the output clearing might be temporary, so we don't shrink immediately
 		this._validateFinalOutputHeight(context === CellOutputUpdateContext.Other && this.viewCell.outputsViewModels.length === 0);
+		// after splice, it doesn't exceed
+		deletedEntries.forEach(entry => {
+			entry.element.detach();
+			entry.element.dispose();
+		});
+
 	}
 
 	private _generateShowMoreElement(disposables: DisposableStore): HTMLElement {

--- a/src/vs/workbench/contrib/notebook/common/model/notebookCellTextModel.ts
+++ b/src/vs/workbench/contrib/notebook/common/model/notebookCellTextModel.ts
@@ -291,7 +291,7 @@ export class NotebookCellTextModel extends Disposable implements ICell {
 			}
 
 			this.outputs.splice(splice.start + commonLen, splice.deleteCount - commonLen, ...splice.newOutputs.slice(commonLen));
-			this._onDidChangeOutputs.fire({ start: splice.start + commonLen, deleteCount: splice.deleteCount - commonLen, newOutputs: splice.newOutputs.slice(commonLen) });
+			this._onDidChangeOutputs.fire(splice);
 		} else {
 			this.outputs.splice(splice.start, splice.deleteCount, ...splice.newOutputs);
 			this._onDidChangeOutputs.fire(splice);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
For https://github.com/microsoft/vscode-jupyter/issues/14161


The fault is either here or elsewhere 
https://github.com/microsoft/vscode/blob/main/src/vs/workbench/contrib/notebook/common/model/notebookCellTextModel.ts#L282
```typescript
spliceNotebookCellOutputs(splice: NotebookCellOutputsSplice): void {
    // 
}
```

In this method we have code to dispose the previous outputs when
* We delete output items
* Or when we end up adding new outputs that is less than previous outputs
However we do not have any code to dispose previous outputs when they are replaced
At least thats what I think.
https://github.com/microsoft/vscode/blob/main/src/vs/workbench/contrib/notebook/browser/view/cellParts/cellOutput.ts#L585
```typescript
private _renderNow(splice: NotebookCellOutputsSplice, context: CellOutputUpdateContext) {
```