### PR TITLE
fix: hidden extension editor description overflow

### DIFF
--- a/src/vs/workbench/contrib/extensions/browser/extensionEditor.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionEditor.ts
@@ -521,6 +521,7 @@ export class ExtensionEditor extends EditorPane {
 		template.builtin.style.display = extension.isBuiltin ? 'inherit' : 'none';
 
 		template.description.textContent = extension.description;
+		template.description.setAttribute('title', extension.description);
 
 		// subtitle
 		template.publisher.classList.toggle('clickable', !!extension.url);


### PR DESCRIPTION
Extension Editor description overflow is hidden

=> add a tooltip

closes [#190645](https://github.com/microsoft/vscode/issues/190645)

![image](https://github.com/microsoft/vscode/assets/61087915/62bb6bce-3f64-4ec5-8ed2-bd226bef3b98)


<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
