### PR TITLE
disable / enable actions in the accessible view depending on context

### DIFF
--- a/src/vs/editor/contrib/inlineCompletions/browser/inlineCompletionsController.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/inlineCompletionsController.ts
@@ -192,7 +192,7 @@ export class InlineCompletionsController extends Disposable {
 				const lineText = model.textModel.getLineContent(state.ghostText.lineNumber);
 				this.audioCueService.playAudioCue(AudioCue.inlineSuggestion).then(() => {
 					if (this.editor.getOption(EditorOption.screenReaderAnnounceInlineSuggestion)) {
-						this.provideScreenReaderUpdate(lineText + state.ghostText.renderForScreenReader(lineText));
+						this.provideScreenReaderUpdate(state.ghostText.renderForScreenReader(lineText));
 					}
 				});
 			}

--- a/src/vs/workbench/contrib/accessibility/browser/accessibilityConfiguration.ts
+++ b/src/vs/workbench/contrib/accessibility/browser/accessibilityConfiguration.ts
@@ -10,6 +10,9 @@ import { RawContextKey } from 'vs/platform/contextkey/common/contextkey';
 
 export const accessibilityHelpIsShown = new RawContextKey<boolean>('accessibilityHelpIsShown', false, true);
 export const accessibleViewIsShown = new RawContextKey<boolean>('accessibleViewIsShown', false, true);
+export const accessibleViewSupportsNavigation = new RawContextKey<boolean>('accessibleViewSupportsNavigation', false, true);
+export const accessibleViewVerbosityEnabled = new RawContextKey<boolean>('accessibleViewVerbosityEnabled', false, true);
+export const accessibleViewGoToSymbolSupported = new RawContextKey<boolean>('accessibleViewGoToSymbolSupported', false, true);
 
 export const enum AccessibilitySettingId {
 	UnfocusedViewOpacity = 'accessibility.unfocusedViewOpacity'

--- a/src/vs/workbench/contrib/accessibility/browser/accessibilityContributions.ts
+++ b/src/vs/workbench/contrib/accessibility/browser/accessibilityContributions.ts
@@ -62,7 +62,7 @@ class AccessibilityHelpProvider implements IAccessibleContentProvider {
 	onClose() {
 		this._editor.focus();
 	}
-	options: IAccessibleViewOptions = { type: AccessibleViewType.Help, ariaLabel: localize('editor-help', "editor accessibility help"), readMoreUrl: 'https://go.microsoft.com/fwlink/?linkid=851010' };
+	options: IAccessibleViewOptions = { type: AccessibleViewType.Help, readMoreUrl: 'https://go.microsoft.com/fwlink/?linkid=851010' };
 	verbositySettingKey = AccessibilityVerbositySettingId.Editor;
 	constructor(
 		private readonly _editor: ICodeEditor,
@@ -107,9 +107,7 @@ class AccessibilityHelpProvider implements IAccessibleContentProvider {
 
 export class HoverAccessibleViewContribution extends Disposable {
 	static ID: 'hoverAccessibleViewContribution';
-	private _options: IAccessibleViewOptions = {
-		ariaLabel: localize('hoverAccessibleView', "Hover Accessible View"), language: 'typescript', type: AccessibleViewType.View
-	};
+	private _options: IAccessibleViewOptions = { language: 'typescript', type: AccessibleViewType.View };
 	constructor() {
 		super();
 		this._register(AccessibleViewAction.addImplementation(95, 'hover', accessor => {
@@ -225,10 +223,7 @@ export class NotificationAccessibleViewContribution extends Disposable {
 						renderAccessibleView();
 					},
 					verbositySettingKey: AccessibilityVerbositySettingId.Notification,
-					options: {
-						ariaLabel: localize('notification', "Notification Accessible View"),
-						type: AccessibleViewType.View
-					},
+					options: { type: AccessibleViewType.View },
 					actions: getActionsFromNotification(notification)
 				});
 				return true;
@@ -281,9 +276,7 @@ export function alertFocusChange(index: number | undefined, length: number | und
 
 export class InlineCompletionsAccessibleViewContribution extends Disposable {
 	static ID: 'inlineCompletionsAccessibleViewContribution';
-	private _options: IAccessibleViewOptions = {
-		ariaLabel: localize('inlineCompletionsAccessibleView', "Inline Completions Accessible View"), type: AccessibleViewType.View
-	};
+	private _options: IAccessibleViewOptions = { type: AccessibleViewType.View };
 	constructor() {
 		super();
 		this._register(AccessibleViewAction.addImplementation(95, 'inline-completions', accessor => {

--- a/src/vs/workbench/contrib/accessibility/browser/accessibleView.ts
+++ b/src/vs/workbench/contrib/accessibility/browser/accessibleView.ts
@@ -85,7 +85,6 @@ export const enum AccessibleViewType {
 }
 
 export interface IAccessibleViewOptions {
-	ariaLabel: string;
 	readMoreUrl?: string;
 	/**
 	 * Defaults to markdown
@@ -330,23 +329,17 @@ class AccessibleView extends Disposable {
 			}
 			model.setLanguage(provider.options.language ?? 'markdown');
 			container.appendChild(this._editorContainer);
-			let ariaLabel = '';
 			let actionsHint = '';
 			const verbose = this._configurationService.getValue(provider.verbositySettingKey);
-			if (verbose && !showAccessibleViewHelp && (this._accessibleViewSupportsNavigation.get() || this._accessibleViewVerbosityEnabled.get() || this._accessibleViewGoToSymbolSupported.get())) {
+			const hasActions = this._accessibleViewSupportsNavigation.get() || this._accessibleViewVerbosityEnabled.get() || this._accessibleViewGoToSymbolSupported.get() || this._currentProvider?.actions;
+			if (verbose && !showAccessibleViewHelp && hasActions) {
 				actionsHint = localize('ariaAccessibleViewActions', "Use Shift+Tab to explore actions such as disabling this hint.");
 			}
+			let ariaLabel = provider.options.type === AccessibleViewType.Help ? localize('accessibility-help', "Accessibility Help") : localize('accessible-view', "Accessible View");
 			if (actionsHint && provider.options.type === AccessibleViewType.View) {
-				ariaLabel = provider.options.ariaLabel ? localize('actionsAriaKb', "{0}, {1}", provider.options.ariaLabel, actionsHint) : localize('accessible-view-hint', "Accessible View, {0}", actionsHint);
+				ariaLabel = localize('accessible-view-hint', "Accessible View, {0}", actionsHint);
 			} else if (actionsHint) {
-				ariaLabel = provider.options.ariaLabel ? localize('actionsAriaKb', "{0}, {1}", provider.options.ariaLabel, actionsHint) : localize('accessibility-help-hint', "Accessibility Help, {0}", actionsHint);
-			}
-			if (!ariaLabel) {
-				if (provider.options.type === AccessibleViewType.View) {
-					ariaLabel = provider.options.ariaLabel ? provider.options.ariaLabel : localize('accessible-view', "Accessible View");
-				} else {
-					ariaLabel = provider.options.ariaLabel ? provider.options.ariaLabel : localize('accessible-help', "Accessibility Help");
-				}
+				ariaLabel = localize('accessibility-help-hint', "Accessibility Help, {0}", actionsHint);
 			}
 			this._editorWidget.updateOptions({ ariaLabel });
 			this._editorWidget.focus();
@@ -430,10 +423,7 @@ class AccessibleView extends Disposable {
 		const accessibleViewHelpProvider: IAccessibleContentProvider = {
 			provideContent: () => this._getAccessibleViewHelpDialogContent(this._goToSymbolsSupported()),
 			onClose: () => this.show(currentProvider),
-			options: {
-				ariaLabel: localize('accessibleViewHelp', "Accessible View Help"),
-				type: AccessibleViewType.Help,
-			},
+			options: { type: AccessibleViewType.Help },
 			verbositySettingKey: this._currentProvider.verbositySettingKey
 		};
 		this._contextViewService.hideContextView();

--- a/src/vs/workbench/contrib/accessibility/browser/accessibleView.ts
+++ b/src/vs/workbench/contrib/accessibility/browser/accessibleView.ts
@@ -32,7 +32,7 @@ import { IOpenerService } from 'vs/platform/opener/common/opener';
 import { IPickerQuickAccessItem } from 'vs/platform/quickinput/browser/pickerQuickAccess';
 import { IQuickInputService } from 'vs/platform/quickinput/common/quickInput';
 import { AccessibilityCommandId } from 'vs/workbench/contrib/accessibility/common/accessibilityCommands';
-import { AccessibilityVerbositySettingId, accessibilityHelpIsShown, accessibleViewIsShown } from 'vs/workbench/contrib/accessibility/browser/accessibilityConfiguration';
+import { AccessibilityVerbositySettingId, accessibilityHelpIsShown, accessibleViewGoToSymbolSupported, accessibleViewIsShown, accessibleViewSupportsNavigation, accessibleViewVerbosityEnabled } from 'vs/workbench/contrib/accessibility/browser/accessibilityConfiguration';
 import { getSimpleEditorOptions } from 'vs/workbench/contrib/codeEditor/browser/simpleEditorOptions';
 import { IAction } from 'vs/base/common/actions';
 import { createAndFillInActionBarActions } from 'vs/platform/actions/browser/menuEntryActionViewItem';
@@ -96,8 +96,13 @@ export interface IAccessibleViewOptions {
 
 class AccessibleView extends Disposable {
 	private _editorWidget: CodeEditorWidget;
+
 	private _accessiblityHelpIsShown: IContextKey<boolean>;
 	private _accessibleViewIsShown: IContextKey<boolean>;
+	private _accessibleViewSupportsNavigation: IContextKey<boolean>;
+	private _accessibleViewVerbosityEnabled: IContextKey<boolean>;
+	private _accessibleViewGoToSymbolSupported: IContextKey<boolean>;
+
 	get editorWidget() { return this._editorWidget; }
 	private _editorContainer: HTMLElement;
 	private _currentProvider: IAccessibleContentProvider | undefined;
@@ -116,8 +121,13 @@ class AccessibleView extends Disposable {
 		@IMenuService private readonly _menuService: IMenuService
 	) {
 		super();
+
 		this._accessiblityHelpIsShown = accessibilityHelpIsShown.bindTo(this._contextKeyService);
 		this._accessibleViewIsShown = accessibleViewIsShown.bindTo(this._contextKeyService);
+		this._accessibleViewSupportsNavigation = accessibleViewSupportsNavigation.bindTo(this._contextKeyService);
+		this._accessibleViewVerbosityEnabled = accessibleViewVerbosityEnabled.bindTo(this._contextKeyService);
+		this._accessibleViewGoToSymbolSupported = accessibleViewGoToSymbolSupported.bindTo(this._contextKeyService);
+
 		this._editorContainer = document.createElement('div');
 		this._editorContainer.classList.add('accessible-view');
 		const codeEditorWidgetOptions: ICodeEditorWidgetOptions = {
@@ -149,8 +159,12 @@ class AccessibleView extends Disposable {
 			}
 		}));
 		this._register(this._configurationService.onDidChangeConfiguration(e => {
-			if (this._currentProvider && this._accessiblityHelpIsShown.get() && e.affectsConfiguration(this._currentProvider.verbositySettingKey)) {
-				this.show(this._currentProvider);
+			if (this._currentProvider && e.affectsConfiguration(this._currentProvider.verbositySettingKey)) {
+				if (this._accessiblityHelpIsShown.get()) {
+					this.show(this._currentProvider);
+				}
+				this._accessibleViewVerbosityEnabled.set(this._configurationService.getValue(this._currentProvider.verbositySettingKey));
+				this._updateToolbar(this._currentProvider.actions, this._currentProvider.options.type);
 			}
 		}));
 	}
@@ -264,6 +278,14 @@ class AccessibleView extends Disposable {
 			this._accessibleViewIsShown.set(shown);
 			this._accessiblityHelpIsShown.set(!shown);
 		}
+		if (provider.next && provider.previous) {
+			this._accessibleViewSupportsNavigation.set(true);
+		} else {
+			this._accessibleViewSupportsNavigation.reset();
+		}
+		const verbosityEnabled: boolean = this._configurationService.getValue(provider.verbositySettingKey);
+		this._accessibleViewVerbosityEnabled.set(verbosityEnabled);
+		this._accessibleViewGoToSymbolSupported.set(this._goToSymbolsSupported() ? this.getSymbols()?.length! > 0 : false);
 	}
 
 	private _render(provider: IAccessibleContentProvider, container: HTMLElement, showAccessibleViewHelp?: boolean): IDisposable {
@@ -311,15 +333,21 @@ class AccessibleView extends Disposable {
 			let ariaLabel = '';
 			let actionsHint = '';
 			const verbose = this._configurationService.getValue(provider.verbositySettingKey);
-			if (verbose && provider.options.type === AccessibleViewType.View && !showAccessibleViewHelp) {
+			if (verbose && !showAccessibleViewHelp && (this._accessibleViewSupportsNavigation.get() || this._accessibleViewVerbosityEnabled.get() || this._accessibleViewGoToSymbolSupported.get())) {
 				actionsHint = localize('ariaAccessibleViewActions', "Use Shift+Tab to explore actions such as disabling this hint.");
 			}
-			if (actionsHint) {
-				ariaLabel = provider.options.ariaLabel ? localize('actionsAriaKb', "{0}, {1}", provider.options.ariaLabel, actionsHint) : localize('accessible-view', "Accessible View, {0}", actionsHint);
-			} else {
-				ariaLabel = provider.options.ariaLabel ? provider.options.ariaLabel : localize('helpAriaNoKb', "Accessible View");
+			if (actionsHint && provider.options.type === AccessibleViewType.View) {
+				ariaLabel = provider.options.ariaLabel ? localize('actionsAriaKb', "{0}, {1}", provider.options.ariaLabel, actionsHint) : localize('accessible-view-hint', "Accessible View, {0}", actionsHint);
+			} else if (actionsHint) {
+				ariaLabel = provider.options.ariaLabel ? localize('actionsAriaKb', "{0}, {1}", provider.options.ariaLabel, actionsHint) : localize('accessibility-help-hint', "Accessibility Help, {0}", actionsHint);
 			}
-
+			if (!ariaLabel) {
+				if (provider.options.type === AccessibleViewType.View) {
+					ariaLabel = provider.options.ariaLabel ? provider.options.ariaLabel : localize('accessible-view', "Accessible View");
+				} else {
+					ariaLabel = provider.options.ariaLabel ? provider.options.ariaLabel : localize('accessible-help', "Accessibility Help");
+				}
+			}
 			this._editorWidget.updateOptions({ ariaLabel });
 			this._editorWidget.focus();
 		});
@@ -385,6 +413,13 @@ class AccessibleView extends Disposable {
 		return this._modelService.createModel(resource.fragment, null, resource, false);
 	}
 
+	private _goToSymbolsSupported(): boolean {
+		if (!this._currentProvider) {
+			return false;
+		}
+		return this._currentProvider.options.language === 'markdown' || this._currentProvider.options.language === undefined || !!this._currentProvider.getSymbols;
+	}
+
 	public showAccessibleViewHelp(): void {
 		if (!this._currentProvider) {
 			return;
@@ -392,9 +427,8 @@ class AccessibleView extends Disposable {
 		}
 		const currentProvider = Object.assign({}, this._currentProvider);
 		currentProvider.options = Object.assign({}, currentProvider.options);
-		const currentProviderHasSymbols = this._currentProvider.options.language === 'markdown' || this._currentProvider.options.language === undefined || !!this._currentProvider.getSymbols;
 		const accessibleViewHelpProvider: IAccessibleContentProvider = {
-			provideContent: () => this._getAccessibleViewHelpDialogContent(currentProviderHasSymbols),
+			provideContent: () => this._getAccessibleViewHelpDialogContent(this._goToSymbolsSupported()),
 			onClose: () => this.show(currentProvider),
 			options: {
 				ariaLabel: localize('accessibleViewHelp', "Accessible View Help"),

--- a/src/vs/workbench/contrib/accessibility/browser/accessibleViewActions.ts
+++ b/src/vs/workbench/contrib/accessibility/browser/accessibleViewActions.ts
@@ -11,7 +11,7 @@ import { Action2, MenuId, registerAction2 } from 'vs/platform/actions/common/act
 import { ContextKeyExpr } from 'vs/platform/contextkey/common/contextkey';
 import { KeybindingWeight } from 'vs/platform/keybinding/common/keybindingsRegistry';
 import { AccessibilityCommandId } from 'vs/workbench/contrib/accessibility/common/accessibilityCommands';
-import { accessibilityHelpIsShown, accessibleViewIsShown } from 'vs/workbench/contrib/accessibility/browser/accessibilityConfiguration';
+import { accessibilityHelpIsShown, accessibleViewGoToSymbolSupported, accessibleViewIsShown, accessibleViewSupportsNavigation, accessibleViewVerbosityEnabled } from 'vs/workbench/contrib/accessibility/browser/accessibilityConfiguration';
 import { IAccessibleViewService } from 'vs/workbench/contrib/accessibility/browser/accessibleView';
 
 const accessibleViewMenu = {
@@ -28,7 +28,7 @@ class AccessibleViewNextAction extends Action2 {
 	constructor() {
 		super({
 			id: AccessibilityCommandId.ShowNext,
-			precondition: accessibleViewIsShown,
+			precondition: ContextKeyExpr.and(accessibleViewIsShown, accessibleViewSupportsNavigation),
 			keybinding: {
 				primary: KeyMod.Alt | KeyCode.BracketRight,
 				weight: KeybindingWeight.WorkbenchContrib
@@ -49,7 +49,7 @@ class AccessibleViewPreviousAction extends Action2 {
 	constructor() {
 		super({
 			id: AccessibilityCommandId.ShowPrevious,
-			precondition: accessibleViewIsShown,
+			precondition: ContextKeyExpr.and(accessibleViewIsShown, accessibleViewSupportsNavigation),
 			keybinding: {
 				primary: KeyMod.Alt | KeyCode.BracketLeft,
 				weight: KeybindingWeight.WorkbenchContrib
@@ -70,7 +70,7 @@ class AccessibleViewGoToSymbolAction extends Action2 {
 	constructor() {
 		super({
 			id: AccessibilityCommandId.GoToSymbol,
-			precondition: accessibleViewIsShown,
+			precondition: ContextKeyExpr.and(accessibleViewIsShown, accessibleViewGoToSymbolSupported),
 			keybinding: {
 				primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KeyO,
 				weight: KeybindingWeight.WorkbenchContrib + 10
@@ -134,8 +134,8 @@ class AccessibleViewDisableHintAction extends Action2 {
 	constructor() {
 		super({
 			id: AccessibilityCommandId.DisableVerbosityHint,
+			precondition: ContextKeyExpr.and(ContextKeyExpr.or(accessibleViewIsShown, accessibilityHelpIsShown), accessibleViewVerbosityEnabled),
 			keybinding: {
-				when: ContextKeyExpr.or(accessibleViewIsShown, accessibilityHelpIsShown),
 				primary: KeyMod.Alt | KeyCode.F6,
 				weight: KeybindingWeight.WorkbenchContrib
 			},
@@ -143,8 +143,7 @@ class AccessibleViewDisableHintAction extends Action2 {
 			menu: [commandPalette,
 				{
 					id: MenuId.AccessibleView,
-					group: 'navigation',
-					when: ContextKeyExpr.or(accessibleViewIsShown, accessibilityHelpIsShown)
+					group: 'navigation'
 				}],
 			title: localize('editor.action.accessibleViewDisableHint', "Disable Accessible View Hint")
 		});

--- a/src/vs/workbench/contrib/chat/browser/actions/chatAccessibilityHelp.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatAccessibilityHelp.ts
@@ -84,6 +84,6 @@ export async function runAccessibilityHelpAction(accessor: ServicesAccessor, edi
 				InlineChatController.get(editor)?.focus();
 			}
 		},
-		options: { type: AccessibleViewType.Help, ariaLabel: type === 'panelChat' ? localize('chat-help-label', "Chat accessibility help") : localize('inline-chat-label', "Inline chat accessibility help") }
+		options: { type: AccessibleViewType.Help }
 	});
 }

--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -212,7 +212,7 @@ class ChatAccessibleViewContribution extends Disposable {
 						alertFocusChange(responseIndex, length, 'previous');
 						renderAccessibleView(accessibleViewService, widgetService, codeEditorService);
 					},
-					options: { ariaLabel: nls.localize('chatAccessibleView', "Chat Accessible View"), type: AccessibleViewType.View }
+					options: { type: AccessibleViewType.View }
 				});
 				return true;
 			}

--- a/src/vs/workbench/contrib/codeEditor/browser/diffEditorHelper.ts
+++ b/src/vs/workbench/contrib/codeEditor/browser/diffEditorHelper.ts
@@ -111,7 +111,7 @@ function createScreenReaderHelp(): IDisposable {
 			onClose: () => {
 				codeEditor.focus();
 			},
-			options: { type: AccessibleViewType.Help, ariaLabel: localize('chat-help-label', "Diff editor accessibility help") }
+			options: { type: AccessibleViewType.Help }
 		});
 	}, ContextKeyExpr.and(
 		ContextKeyEqualsExpr.create('diffEditorVersion', 2),

--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChat.contribution.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChat.contribution.ts
@@ -18,7 +18,6 @@ import { AccessibilityVerbositySettingId } from 'vs/workbench/contrib/accessibil
 import { AccessibleViewType, IAccessibleViewService } from 'vs/workbench/contrib/accessibility/browser/accessibleView';
 import { Disposable } from 'vs/base/common/lifecycle';
 import { ICodeEditorService } from 'vs/editor/browser/services/codeEditorService';
-import { localize } from 'vs/nls';
 import { Extensions, IWorkbenchContributionsRegistry, Extensions as WorkbenchExtensions } from 'vs/workbench/common/contributions';
 import { ContextKeyExpr } from 'vs/platform/contextkey/common/contextkey';
 import { AccessibleViewAction } from 'vs/workbench/contrib/accessibility/browser/accessibleViewActions';
@@ -87,7 +86,7 @@ class InlineChatAccessibleViewContribution extends Disposable {
 					controller.focus();
 				},
 
-				options: { ariaLabel: localize('inlineChatAccessibleView', "Inline Chat Accessible View"), type: AccessibleViewType.View }
+				options: { type: AccessibleViewType.View }
 			});
 			return true;
 		}, ContextKeyExpr.or(CTX_INLINE_CHAT_FOCUSED, CTX_INLINE_CHAT_RESPONSE_FOCUSED)));

--- a/src/vs/workbench/contrib/notebook/browser/notebookAccessibility.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookAccessibility.ts
@@ -54,7 +54,7 @@ export async function runAccessibilityHelpAction(accessor: ServicesAccessor, edi
 		onClose: () => {
 			editor.focus();
 		},
-		options: { type: AccessibleViewType.Help, ariaLabel: 'Notebook accessibility help' }
+		options: { type: AccessibleViewType.Help }
 	});
 }
 
@@ -114,10 +114,7 @@ export function showAccessibleOutput(accessibleViewService: IAccessibleViewServi
 			notebookEditor?.setFocus(selections[0]);
 			activePane?.focus();
 		},
-		options: {
-			ariaLabel: localize('NotebookCellOutputAccessibleView', "Notebook Cell Output Accessible View"),
-			type: AccessibleViewType.View
-		}
+		options: { type: AccessibleViewType.View }
 	});
 	return true;
 }

--- a/src/vs/workbench/contrib/terminalContrib/accessibility/browser/terminalAccessibilityHelp.ts
+++ b/src/vs/workbench/contrib/terminalContrib/accessibility/browser/terminalAccessibilityHelp.ts
@@ -38,7 +38,6 @@ export class TerminalAccessibleContentProvider extends Disposable implements IAc
 	}
 	options: IAccessibleViewOptions = {
 		type: AccessibleViewType.Help,
-		ariaLabel: localize('terminal-help-label', "terminal accessibility help"),
 		readMoreUrl: 'https://code.visualstudio.com/docs/editor/accessibility#_terminal-accessibility'
 	};
 	verbositySettingKey = AccessibilityVerbositySettingId.Terminal;


### PR DESCRIPTION
Also disallow setting an `aria label` for the view/ help dialogue as the user already knows the context as they've had to invoke it from there.  We want to make sure this is as concise as possible.