### PR TITLE
better handling of unregistered languages in notebook cells

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/contrib/cellStatusBar/statusBarProviders.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/cellStatusBar/statusBarProviders.ts
@@ -15,6 +15,7 @@ import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 import { Registry } from 'vs/platform/registry/common/platform';
 import { Extensions as WorkbenchExtensions, IWorkbenchContributionsRegistry } from 'vs/workbench/common/contributions';
 import { CHANGE_CELL_LANGUAGE, DETECT_CELL_LANGUAGE } from 'vs/workbench/contrib/notebook/browser/notebookBrowser';
+import { warningStateIcon } from 'vs/workbench/contrib/notebook/browser/notebookIcons';
 import { INotebookCellStatusBarService } from 'vs/workbench/contrib/notebook/common/notebookCellStatusBarService';
 import { CellKind, CellStatusbarAlignment, INotebookCellStatusBarItem, INotebookCellStatusBarItemList, INotebookCellStatusBarItemProvider } from 'vs/workbench/contrib/notebook/common/notebookCommon';
 import { INotebookKernelService } from 'vs/workbench/contrib/notebook/common/notebookKernelService';
@@ -38,19 +39,36 @@ class CellStatusBarLanguagePickerProvider implements INotebookCellStatusBarItemP
 			return;
 		}
 
-		const languageId = cell.cellKind === CellKind.Markup ?
-			'markdown' :
-			(this._languageService.getLanguageIdByLanguageName(cell.language) || cell.language);
-		const text = this._languageService.getLanguageName(languageId) || languageId;
-		const item = <INotebookCellStatusBarItem>{
-			text,
+		const statusBarItems: INotebookCellStatusBarItem[] = [];
+		let displayLanguage = cell.language;
+		if (cell.cellKind === CellKind.Markup) {
+			displayLanguage = 'markdown';
+		} else {
+			const registeredId = this._languageService.getLanguageIdByLanguageName(cell.language);
+			if (registeredId) {
+				displayLanguage = this._languageService.getLanguageName(displayLanguage) ?? displayLanguage;
+			} else {
+				// add unregistered lanugage warning item
+				const searchTooltip = localize('notebook.cell.status.searchLanguageExtensions', "Unknown cell language '{0}' - Search for notebook extensions", cell.language);
+				statusBarItems.push(<INotebookCellStatusBarItem>{
+					text: `$(${warningStateIcon.id})`,
+					command: { id: 'workbench.extensions.search', arguments: [`@tag:${cell.language}`] },
+					tooltip: searchTooltip,
+					alignment: CellStatusbarAlignment.Right,
+					priority: -Number.MAX_SAFE_INTEGER + 1
+				});
+			}
+		}
+
+		statusBarItems.push(<INotebookCellStatusBarItem>{
+			text: displayLanguage,
 			command: CHANGE_CELL_LANGUAGE,
 			tooltip: localize('notebook.cell.status.language', "Select Cell Language Mode"),
 			alignment: CellStatusbarAlignment.Right,
 			priority: -Number.MAX_SAFE_INTEGER
-		};
+		});
 		return {
-			items: [item]
+			items: statusBarItems
 		};
 	}
 }

--- a/src/vs/workbench/contrib/notebook/browser/contrib/cellStatusBar/statusBarProviders.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/cellStatusBar/statusBarProviders.ts
@@ -15,7 +15,6 @@ import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 import { Registry } from 'vs/platform/registry/common/platform';
 import { Extensions as WorkbenchExtensions, IWorkbenchContributionsRegistry } from 'vs/workbench/common/contributions';
 import { CHANGE_CELL_LANGUAGE, DETECT_CELL_LANGUAGE } from 'vs/workbench/contrib/notebook/browser/notebookBrowser';
-import { warningStateIcon } from 'vs/workbench/contrib/notebook/browser/notebookIcons';
 import { INotebookCellStatusBarService } from 'vs/workbench/contrib/notebook/common/notebookCellStatusBarService';
 import { CellKind, CellStatusbarAlignment, INotebookCellStatusBarItem, INotebookCellStatusBarItemList, INotebookCellStatusBarItemProvider } from 'vs/workbench/contrib/notebook/common/notebookCommon';
 import { INotebookKernelService } from 'vs/workbench/contrib/notebook/common/notebookKernelService';
@@ -49,10 +48,10 @@ class CellStatusBarLanguagePickerProvider implements INotebookCellStatusBarItemP
 				displayLanguage = this._languageService.getLanguageName(displayLanguage) ?? displayLanguage;
 			} else {
 				// add unregistered lanugage warning item
-				const searchTooltip = localize('notebook.cell.status.searchLanguageExtensions', "Unknown cell language '{0}' - Search for notebook extensions", cell.language);
-				statusBarItems.push(<INotebookCellStatusBarItem>{
-					text: `$(${warningStateIcon.id})`,
-					command: { id: 'workbench.extensions.search', arguments: [`@tag:${cell.language}`] },
+				const searchTooltip = localize('notebook.cell.status.searchLanguageExtensions', "Unknown cell language - Search for '{0}' extensions", cell.language);
+				statusBarItems.push({
+					text: `$(dialog-warning)`,
+					command: { id: 'workbench.extensions.search', arguments: [`@tag:${cell.language}`], title: 'Search Extensions' },
 					tooltip: searchTooltip,
 					alignment: CellStatusbarAlignment.Right,
 					priority: -Number.MAX_SAFE_INTEGER + 1
@@ -60,7 +59,7 @@ class CellStatusBarLanguagePickerProvider implements INotebookCellStatusBarItemP
 			}
 		}
 
-		statusBarItems.push(<INotebookCellStatusBarItem>{
+		statusBarItems.push({
 			text: displayLanguage,
 			command: CHANGE_CELL_LANGUAGE,
 			tooltip: localize('notebook.cell.status.language', "Select Cell Language Mode"),

--- a/src/vs/workbench/contrib/notebook/browser/notebookIcons.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookIcons.ts
@@ -22,6 +22,7 @@ export const clearIcon = registerIcon('notebook-clear', Codicon.clearAll, locali
 export const splitCellIcon = registerIcon('notebook-split-cell', Codicon.splitVertical, localize('splitCellIcon', 'Icon to split a cell in notebook editors.'));
 export const successStateIcon = registerIcon('notebook-state-success', Codicon.check, localize('successStateIcon', 'Icon to indicate a success state in notebook editors.'));
 export const errorStateIcon = registerIcon('notebook-state-error', Codicon.error, localize('errorStateIcon', 'Icon to indicate an error state in notebook editors.'));
+export const warningStateIcon = registerIcon('notebook-state-warning', Codicon.warning, localize('warningStateIcon', 'Icon to an item that may need attention.'));
 export const pendingStateIcon = registerIcon('notebook-state-pending', Codicon.clock, localize('pendingStateIcon', 'Icon to indicate a pending state in notebook editors.'));
 export const executingStateIcon = registerIcon('notebook-state-executing', Codicon.sync, localize('executingStateIcon', 'Icon to indicate an executing state in notebook editors.'));
 

--- a/src/vs/workbench/contrib/notebook/browser/notebookIcons.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookIcons.ts
@@ -22,7 +22,6 @@ export const clearIcon = registerIcon('notebook-clear', Codicon.clearAll, locali
 export const splitCellIcon = registerIcon('notebook-split-cell', Codicon.splitVertical, localize('splitCellIcon', 'Icon to split a cell in notebook editors.'));
 export const successStateIcon = registerIcon('notebook-state-success', Codicon.check, localize('successStateIcon', 'Icon to indicate a success state in notebook editors.'));
 export const errorStateIcon = registerIcon('notebook-state-error', Codicon.error, localize('errorStateIcon', 'Icon to indicate an error state in notebook editors.'));
-export const warningStateIcon = registerIcon('notebook-state-warning', Codicon.warning, localize('warningStateIcon', 'Icon to an item that may need attention.'));
 export const pendingStateIcon = registerIcon('notebook-state-pending', Codicon.clock, localize('pendingStateIcon', 'Icon to indicate a pending state in notebook editors.'));
 export const executingStateIcon = registerIcon('notebook-state-executing', Codicon.sync, localize('executingStateIcon', 'Icon to indicate an executing state in notebook editors.'));
 


### PR DESCRIPTION
fixes https://github.com/microsoft/vscode/issues/187516

reuse same guard used to not switch to plaintext (the fallback language) when the cells language is unknown to the language service.
Also display a warning icon that will search for extensions to get support for that language.