### PR TITLE
terminal: enable link detectors in detached terminals

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/detachedTerminal.ts
+++ b/src/vs/workbench/contrib/terminal/browser/detachedTerminal.ts
@@ -1,0 +1,101 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Delayer } from 'vs/base/common/async';
+import { onUnexpectedError } from 'vs/base/common/errors';
+import { Disposable } from 'vs/base/common/lifecycle';
+import { OperatingSystem } from 'vs/base/common/platform';
+import { MicrotaskDelay } from 'vs/base/common/symbols';
+import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
+import { TerminalCapabilityStore } from 'vs/platform/terminal/common/capabilities/terminalCapabilityStore';
+import { IMergedEnvironmentVariableCollection } from 'vs/platform/terminal/common/environmentVariable';
+import { ITerminalBackend } from 'vs/platform/terminal/common/terminal';
+import { IDetachedTerminalInstance, IDetachedXTermOptions, IDetachedXtermTerminal, ITerminalContribution, IXtermAttachToElementOptions } from 'vs/workbench/contrib/terminal/browser/terminal';
+import { TerminalExtensionsRegistry } from 'vs/workbench/contrib/terminal/browser/terminalExtensions';
+import { TerminalWidgetManager } from 'vs/workbench/contrib/terminal/browser/widgets/widgetManager';
+import { XtermTerminal } from 'vs/workbench/contrib/terminal/browser/xterm/xtermTerminal';
+import { IEnvironmentVariableInfo } from 'vs/workbench/contrib/terminal/common/environmentVariable';
+import { ITerminalProcessInfo, ProcessState } from 'vs/workbench/contrib/terminal/common/terminal';
+
+export class DeatachedTerminal extends Disposable implements IDetachedTerminalInstance {
+	private readonly _widgets = this._register(new TerminalWidgetManager());
+	public readonly capabilities = new TerminalCapabilityStore();
+	private readonly _contributions: Map<string, ITerminalContribution> = new Map();
+
+	public get xterm(): IDetachedXtermTerminal {
+		return this._xterm;
+	}
+
+	constructor(
+		private readonly _xterm: XtermTerminal,
+		options: IDetachedXTermOptions,
+		@IInstantiationService instantiationService: IInstantiationService,
+	) {
+		super();
+		this._register(_xterm);
+
+		// Initialize contributions
+		const contributionDescs = TerminalExtensionsRegistry.getTerminalContributions();
+		for (const desc of contributionDescs) {
+			if (this._contributions.has(desc.id)) {
+				onUnexpectedError(new Error(`Cannot have two terminal contributions with the same id ${desc.id}`));
+				continue;
+			}
+			if (desc.canRunInDetachedTerminals === false) {
+				continue;
+			}
+
+			let contribution: ITerminalContribution;
+			try {
+				contribution = instantiationService.createInstance(desc.ctor, this, options.processInfo, this._widgets);
+				this._contributions.set(desc.id, contribution);
+				this._register(contribution);
+			} catch (err) {
+				onUnexpectedError(err);
+			}
+		}
+
+		// xterm is already by the time DetachedTerminal is created, so trigger everything
+		// on the next microtask, allowing the caller to do any extra initialization
+		this._register(new Delayer(MicrotaskDelay)).trigger(() => {
+			for (const contr of this._contributions.values()) {
+				contr.xtermReady?.(this._xterm);
+			}
+		});
+	}
+
+	attachToElement(container: HTMLElement, options?: Partial<IXtermAttachToElementOptions> | undefined): void {
+		const screenElement = this._xterm.attachToElement(container, options);
+		this._widgets.attachToElement(screenElement);
+	}
+}
+
+/**
+ * Implements {@link ITerminalProcessInfo} for a detached terminal where most
+ * properties are stubbed. Properties are mutable and can be updated by
+ * the instantiator.
+ */
+export class DetachedProcessInfo implements ITerminalProcessInfo {
+	processState = ProcessState.Running;
+	ptyProcessReady = Promise.resolve();
+	shellProcessId: number | undefined;
+	remoteAuthority: string | undefined;
+	os: OperatingSystem | undefined;
+	userHome: string | undefined;
+	initialCwd = '';
+	environmentVariableInfo: IEnvironmentVariableInfo | undefined;
+	persistentProcessId: number | undefined;
+	shouldPersist = false;
+	hasWrittenData = false;
+	hasChildProcesses = false;
+	backend: ITerminalBackend | undefined;
+	capabilities = new TerminalCapabilityStore();
+	shellIntegrationNonce = '';
+	extEnvironmentVariableCollection: IMergedEnvironmentVariableCollection | undefined;
+
+	constructor(initialValues: Partial<ITerminalProcessInfo>) {
+		Object.assign(this, initialValues);
+	}
+}

--- a/src/vs/workbench/contrib/terminal/browser/terminal.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminal.ts
@@ -149,6 +149,12 @@ export interface IDetachedXTermOptions {
 	processInfo: ITerminalProcessInfo;
 }
 
+/**
+ * A {@link ITerminalInstance}-like object that emulates a subset of
+ * capabilities. This instance is returned from {@link ITerminalService.createDetachedTerminal}
+ * to represent terminals that appear in other parts of the VS Code UI outside
+ * of the "Terminal" view or editors.
+ */
 export interface IDetachedTerminalInstance extends IDisposable {
 	readonly xterm: IDetachedXtermTerminal;
 	readonly capabilities: ITerminalCapabilityStore;

--- a/src/vs/workbench/contrib/terminal/browser/terminalExtensions.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalExtensions.ts
@@ -13,7 +13,7 @@ export type TerminalContributionCtor = IConstructorSignature<ITerminalContributi
 export type DetachedTerminalContributionCtor = IConstructorSignature<ITerminalContribution, [IDetachedTerminalInstance, ITerminalProcessInfo, TerminalWidgetManager]>;
 
 export type ITerminalContributionDescription = { readonly id: string } & (
-	| { readonly canRunInDetachedTerminals: false; readonly ctor: TerminalContributionCtor | DetachedTerminalContributionCtor }
+	| { readonly canRunInDetachedTerminals: false; readonly ctor: TerminalContributionCtor }
 	| { readonly canRunInDetachedTerminals: true; readonly ctor: DetachedTerminalContributionCtor }
 );
 

--- a/src/vs/workbench/contrib/terminal/browser/terminalExtensions.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalExtensions.ts
@@ -9,12 +9,14 @@ import { IDetachedTerminalInstance, ITerminalContribution, ITerminalInstance } f
 import { TerminalWidgetManager } from 'vs/workbench/contrib/terminal/browser/widgets/widgetManager';
 import { ITerminalProcessInfo, ITerminalProcessManager } from 'vs/workbench/contrib/terminal/common/terminal';
 
+/** Constructor compatible with full terminal instances, is assignable to {@link DetachedCompatibleTerminalContributionCtor} */
 export type TerminalContributionCtor = IConstructorSignature<ITerminalContribution, [ITerminalInstance, ITerminalProcessManager, TerminalWidgetManager]>;
-export type DetachedTerminalContributionCtor = IConstructorSignature<ITerminalContribution, [IDetachedTerminalInstance, ITerminalProcessInfo, TerminalWidgetManager]>;
+/** Constructor compatible with detached terminals */
+export type DetachedCompatibleTerminalContributionCtor = IConstructorSignature<ITerminalContribution, [IDetachedTerminalInstance, ITerminalProcessInfo, TerminalWidgetManager]>;
 
 export type ITerminalContributionDescription = { readonly id: string } & (
 	| { readonly canRunInDetachedTerminals: false; readonly ctor: TerminalContributionCtor }
-	| { readonly canRunInDetachedTerminals: true; readonly ctor: DetachedTerminalContributionCtor }
+	| { readonly canRunInDetachedTerminals: true; readonly ctor: DetachedCompatibleTerminalContributionCtor }
 );
 
 export function registerTerminalContribution<Services extends BrandedService[]>(id: string, ctor: { new(instance: ITerminalInstance, processManager: ITerminalProcessManager, widgetManager: TerminalWidgetManager, ...services: Services): ITerminalContribution }, canRunInDetachedTerminals?: false): void;

--- a/src/vs/workbench/contrib/terminal/browser/terminalService.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalService.ts
@@ -29,7 +29,7 @@ import { ThemeIcon } from 'vs/base/common/themables';
 import { IWorkspaceContextService } from 'vs/platform/workspace/common/workspace';
 import { VirtualWorkspaceContext } from 'vs/workbench/common/contextkeys';
 import { IEditableData, IViewsService } from 'vs/workbench/common/views';
-import { ICreateTerminalOptions, IDetachedXTermOptions, IDetachedXtermTerminal, IRequestAddInstanceToGroupEvent, ITerminalEditorService, ITerminalGroup, ITerminalGroupService, ITerminalInstance, ITerminalInstanceHost, ITerminalInstanceService, ITerminalLocationOptions, ITerminalService, ITerminalServiceNativeDelegate, IXtermTerminal, TerminalConnectionState, TerminalEditorLocation } from 'vs/workbench/contrib/terminal/browser/terminal';
+import { ICreateTerminalOptions, IDetachedTerminalInstance, IDetachedXTermOptions, IRequestAddInstanceToGroupEvent, ITerminalEditorService, ITerminalGroup, ITerminalGroupService, ITerminalInstance, ITerminalInstanceHost, ITerminalInstanceService, ITerminalLocationOptions, ITerminalService, ITerminalServiceNativeDelegate, IXtermTerminal, TerminalConnectionState, TerminalEditorLocation } from 'vs/workbench/contrib/terminal/browser/terminal';
 import { getCwdForSplit } from 'vs/workbench/contrib/terminal/browser/terminalActions';
 import { TerminalConfigHelper } from 'vs/workbench/contrib/terminal/browser/terminalConfigHelper';
 import { TerminalEditorInput } from 'vs/workbench/contrib/terminal/browser/terminalEditorInput';
@@ -52,6 +52,7 @@ import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 import { TerminalCapabilityStore } from 'vs/platform/terminal/common/capabilities/terminalCapabilityStore';
 import { ITimerService } from 'vs/workbench/services/timer/browser/timerService';
 import { mark } from 'vs/base/common/performance';
+import { DeatachedTerminal } from 'vs/workbench/contrib/terminal/browser/detachedTerminal';
 
 export class TerminalService extends Disposable implements ITerminalService {
 	declare _serviceBrand: undefined;
@@ -1018,7 +1019,7 @@ export class TerminalService extends Disposable implements ITerminalService {
 		return this._createTerminal(shellLaunchConfig, location, options);
 	}
 
-	async createDetachedXterm(options: IDetachedXTermOptions): Promise<IDetachedXtermTerminal> {
+	async createDetachedTerminal(options: IDetachedXTermOptions): Promise<IDetachedTerminalInstance> {
 		const ctor = await TerminalInstance.getXtermConstructor(this._keybindingService, this._contextKeyService);
 		const instance = this._instantiationService.createInstance(
 			XtermTerminal,
@@ -1040,7 +1041,7 @@ export class TerminalService extends Disposable implements ITerminalService {
 		this._detachedXterms.add(instance);
 		instance.onDidDispose(() => this._detachedXterms.delete(instance));
 
-		return instance;
+		return new DeatachedTerminal(instance, options, this._instantiationService);
 	}
 
 	private async _resolveCwd(shellLaunchConfig: IShellLaunchConfig, splitActiveTerminal: boolean, options?: ICreateTerminalOptions): Promise<void> {

--- a/src/vs/workbench/contrib/terminal/browser/terminalService.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalService.ts
@@ -1021,7 +1021,7 @@ export class TerminalService extends Disposable implements ITerminalService {
 
 	async createDetachedTerminal(options: IDetachedXTermOptions): Promise<IDetachedTerminalInstance> {
 		const ctor = await TerminalInstance.getXtermConstructor(this._keybindingService, this._contextKeyService);
-		const instance = this._instantiationService.createInstance(
+		const xterm = this._instantiationService.createInstance(
 			XtermTerminal,
 			ctor,
 			this._configHelper,
@@ -1035,13 +1035,16 @@ export class TerminalService extends Disposable implements ITerminalService {
 		);
 
 		if (options.readonly) {
-			instance.raw.attachCustomKeyEventHandler(() => false);
+			xterm.raw.attachCustomKeyEventHandler(() => false);
 		}
 
-		this._detachedXterms.add(instance);
-		instance.onDidDispose(() => this._detachedXterms.delete(instance));
+		this._detachedXterms.add(xterm);
+		const l = xterm.onDidDispose(() => {
+			this._detachedXterms.delete(xterm);
+			l.dispose();
+		});
 
-		return new DeatachedTerminal(instance, options, this._instantiationService);
+		return new DeatachedTerminal(xterm, options, this._instantiationService);
 	}
 
 	private async _resolveCwd(shellLaunchConfig: IShellLaunchConfig, splitActiveTerminal: boolean, options?: ICreateTerminalOptions): Promise<void> {

--- a/src/vs/workbench/contrib/terminal/common/terminal.ts
+++ b/src/vs/workbench/contrib/terminal/common/terminal.ts
@@ -253,7 +253,8 @@ export interface IDefaultShellAndArgsRequest {
 	callback: (shell: string, args: string[] | string | undefined) => void;
 }
 
-export interface ITerminalProcessManager extends IDisposable {
+/** Read-only process information that can apply to detached terminals. */
+export interface ITerminalProcessInfo {
 	readonly processState: ProcessState;
 	readonly ptyProcessReady: Promise<void>;
 	readonly shellProcessId: number | undefined;
@@ -270,7 +271,11 @@ export interface ITerminalProcessManager extends IDisposable {
 	readonly capabilities: ITerminalCapabilityStore;
 	readonly shellIntegrationNonce: string;
 	readonly extEnvironmentVariableCollection: IMergedEnvironmentVariableCollection | undefined;
+}
 
+export const isTerminalProcessManager = (t: ITerminalProcessInfo | ITerminalProcessManager): t is ITerminalProcessManager => typeof (t as ITerminalProcessManager).write === 'function';
+
+export interface ITerminalProcessManager extends IDisposable, ITerminalProcessInfo {
 	readonly onPtyDisconnect: Event<void>;
 	readonly onPtyReconnect: Event<void>;
 

--- a/src/vs/workbench/contrib/terminalContrib/links/browser/terminal.links.contribution.ts
+++ b/src/vs/workbench/contrib/terminalContrib/links/browser/terminal.links.contribution.ts
@@ -10,11 +10,11 @@ import { ContextKeyExpr } from 'vs/platform/contextkey/common/contextkey';
 import { InstantiationType, registerSingleton } from 'vs/platform/instantiation/common/extensions';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { KeybindingWeight } from 'vs/platform/keybinding/common/keybindingsRegistry';
-import { ITerminalContribution, ITerminalInstance, IXtermTerminal } from 'vs/workbench/contrib/terminal/browser/terminal';
+import { IDetachedTerminalInstance, ITerminalContribution, ITerminalInstance, IXtermTerminal, isDetachedTerminalInstance } from 'vs/workbench/contrib/terminal/browser/terminal';
 import { registerActiveInstanceAction } from 'vs/workbench/contrib/terminal/browser/terminalActions';
 import { registerTerminalContribution } from 'vs/workbench/contrib/terminal/browser/terminalExtensions';
 import { TerminalWidgetManager } from 'vs/workbench/contrib/terminal/browser/widgets/widgetManager';
-import { ITerminalProcessManager, TerminalCommandId } from 'vs/workbench/contrib/terminal/common/terminal';
+import { ITerminalProcessInfo, ITerminalProcessManager, TerminalCommandId, isTerminalProcessManager } from 'vs/workbench/contrib/terminal/common/terminal';
 import { TerminalContextKeys } from 'vs/workbench/contrib/terminal/common/terminalContextKey';
 import { terminalStrings } from 'vs/workbench/contrib/terminal/common/terminalStrings';
 import { ITerminalLinkProviderService } from 'vs/workbench/contrib/terminalContrib/links/browser/links';
@@ -40,8 +40,8 @@ class TerminalLinkContribution extends DisposableStore implements ITerminalContr
 	private _linkResolver: TerminalLinkResolver;
 
 	constructor(
-		private readonly _instance: ITerminalInstance,
-		private readonly _processManager: ITerminalProcessManager,
+		private readonly _instance: ITerminalInstance | IDetachedTerminalInstance,
+		private readonly _processManager: ITerminalProcessManager | ITerminalProcessInfo,
 		private readonly _widgetManager: TerminalWidgetManager,
 		@IInstantiationService private readonly _instantiationService: IInstantiationService,
 		@ITerminalLinkProviderService private readonly _terminalLinkProviderService: ITerminalLinkProviderService
@@ -52,18 +52,24 @@ class TerminalLinkContribution extends DisposableStore implements ITerminalContr
 
 	xtermReady(xterm: IXtermTerminal & { raw: RawXtermTerminal }): void {
 		const linkManager = this._instantiationService.createInstance(TerminalLinkManager, xterm.raw, this._processManager, this._instance.capabilities, this._linkResolver);
-		this._processManager.onProcessReady(() => {
+		if (isTerminalProcessManager(this._processManager)) {
+			this._processManager.onProcessReady(() => {
+				linkManager.setWidgetManager(this._widgetManager);
+			});
+		} else {
 			linkManager.setWidgetManager(this._widgetManager);
-		});
+		}
 		this._linkManager = this.add(linkManager);
 
 		// Attach the link provider(s) to the instance and listen for changes
-		for (const linkProvider of this._terminalLinkProviderService.linkProviders) {
-			this._linkManager.registerExternalLinkProvider(linkProvider.provideLinks.bind(linkProvider, this._instance));
+		if (!isDetachedTerminalInstance(this._instance)) {
+			for (const linkProvider of this._terminalLinkProviderService.linkProviders) {
+				this._linkManager.registerExternalLinkProvider(linkProvider.provideLinks.bind(linkProvider, this._instance));
+			}
+			this.add(this._terminalLinkProviderService.onDidAddLinkProvider(e => {
+				linkManager.registerExternalLinkProvider(e.provideLinks.bind(e, this._instance as ITerminalInstance));
+			}));
 		}
-		this.add(this._terminalLinkProviderService.onDidAddLinkProvider(e => {
-			linkManager.registerExternalLinkProvider(e.provideLinks.bind(e, this._instance));
-		}));
 		// TODO: Currently only a single link provider is supported; the one registered by the ext host
 		this.add(this._terminalLinkProviderService.onDidRemoveLinkProvider(e => {
 			linkManager.dispose();
@@ -97,7 +103,7 @@ class TerminalLinkContribution extends DisposableStore implements ITerminalContr
 	}
 }
 
-registerTerminalContribution(TerminalLinkContribution.ID, TerminalLinkContribution);
+registerTerminalContribution(TerminalLinkContribution.ID, TerminalLinkContribution, true);
 
 const category = terminalStrings.actionCategory;
 


### PR DESCRIPTION
Initially the direction was to make `TerminalLinkManager` more general
and use it explicitly in detached terminals.

But I ended up getting nudged in the direction of making terminalContribs
work with detached terminals instead. All the link detection logic is
in terminalContrib which is a layer that can't be imported from the main
terminal code. And it also depends on the raw xterm instance, which we
don't want to expose to callers, so I wouldn't want to have the caller
manually do something like new `TerminalLinkManager(deatchedXterm.raw, ...)`

So that made me think I should either make a new contrib system for
detached terminals, or allow existing contribs to signal that they
could run for detached terminals too. In the PR, I did the latter.

![](https://memes.peet.io/img/23-08-cce27de3-f2da-45cf-acee-6731480722ed.png)

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fixes https://github.com/microsoft/vscode/issues/188055