### PR TITLE
Add a side-menu in chat

### DIFF
--- a/src/vs/platform/actions/common/actions.ts
+++ b/src/vs/platform/actions/common/actions.ts
@@ -187,6 +187,7 @@ export class MenuId {
 	static readonly ChatCodeBlock = new MenuId('ChatCodeblock');
 	static readonly ChatMessageTitle = new MenuId('ChatMessageTitle');
 	static readonly ChatExecute = new MenuId('ChatExecute');
+	static readonly ChatInputSide = new MenuId('ChatInputSide');
 	static readonly AccessibleView = new MenuId('AccessibleView');
 
 	/**

--- a/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
@@ -241,13 +241,15 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		toolbar.getElement().classList.add('interactive-execute-toolbar');
 		toolbar.context = <IChatExecuteActionContext>{ widget };
 
-		const toolbarSide = this._register(this.instantiationService.createInstance(MenuWorkbenchToolBar, inputAndSideToolbar, MenuId.ChatInputSide, {
-			menuOptions: {
-				shouldForwardArgs: true
-			}
-		}));
-		toolbarSide.getElement().classList.add('chat-side-toolbar');
-		toolbarSide.context = <IChatExecuteActionContext>{ widget };
+		if (this.options.renderStyle === 'compact') {
+			const toolbarSide = this._register(this.instantiationService.createInstance(MenuWorkbenchToolBar, inputAndSideToolbar, MenuId.ChatInputSide, {
+				menuOptions: {
+					shouldForwardArgs: true
+				}
+			}));
+			toolbarSide.getElement().classList.add('chat-side-toolbar');
+			toolbarSide.context = <IChatExecuteActionContext>{ widget };
+		}
 
 		this.inputModel = this.modelService.getModel(this.inputUri) || this.modelService.createModel('', null, this.inputUri, true);
 		this.inputModel.updateOptions({ bracketColorizationOptions: { enabled: false, independentColorPoolPerBracketType: false } });

--- a/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
@@ -180,7 +180,8 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		this.container = dom.append(container, $('.interactive-input-part'));
 
 		this.followupsContainer = dom.append(this.container, $('.interactive-input-followups'));
-		const inputContainer = dom.append(this.container, $('.interactive-input-and-toolbar'));
+		const inputAndSideToolbar = dom.append(this.container, $('.interactive-input-and-side-toolbar'));
+		const inputContainer = dom.append(inputAndSideToolbar, $('.interactive-input-and-execute-toolbar'));
 
 		const inputScopedContextKeyService = this._register(this.contextKeyService.createScoped(inputContainer));
 		CONTEXT_IN_CHAT_INPUT.bindTo(inputScopedContextKeyService).set(true);
@@ -240,6 +241,14 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		toolbar.getElement().classList.add('interactive-execute-toolbar');
 		toolbar.context = <IChatExecuteActionContext>{ widget };
 
+		const toolbarSide = this._register(this.instantiationService.createInstance(MenuWorkbenchToolBar, inputAndSideToolbar, MenuId.ChatInputSide, {
+			menuOptions: {
+				shouldForwardArgs: true
+			}
+		}));
+		toolbarSide.getElement().classList.add('chat-side-toolbar');
+		toolbarSide.context = <IChatExecuteActionContext>{ widget };
+
 		this.inputModel = this.modelService.getModel(this.inputUri) || this.modelService.createModel('', null, this.inputUri, true);
 		this.inputModel.updateOptions({ bracketColorizationOptions: { enabled: false, independentColorPoolPerBracketType: false } });
 		this._inputEditor.setModel(this.inputModel);
@@ -280,9 +289,10 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		const editorBorder = 2;
 		const editorPadding = 8;
 		const executeToolbarWidth = 25;
+		const sideToolbarWidth = this.options.renderStyle === 'compact' ? 20 : 0;
 
 		const initialEditorScrollWidth = this._inputEditor.getScrollWidth();
-		this._inputEditor.layout({ width: width - inputPartHorizontalPadding - editorBorder - editorPadding - executeToolbarWidth, height: inputEditorHeight });
+		this._inputEditor.layout({ width: width - inputPartHorizontalPadding - editorBorder - editorPadding - executeToolbarWidth - sideToolbarWidth, height: inputEditorHeight });
 
 		if (allowRecurse && initialEditorScrollWidth < 10) {
 			// This is probably the initial layout. Now that the editor is layed out with its correct width, it should report the correct contentHeight

--- a/src/vs/workbench/contrib/chat/browser/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/media/chat.css
@@ -221,7 +221,7 @@
 	margin: 0 0 8px 0;
 }
 
-.interactive-session .interactive-input-and-toolbar {
+.interactive-session .interactive-input-and-execute-toolbar {
 	display: flex;
 	box-sizing: border-box;
 	cursor: text;
@@ -235,16 +235,22 @@
 	justify-content: space-between;
 }
 
-.interactive-session .interactive-input-and-toolbar.focused {
+.interactive-session .interactive-input-and-side-toolbar {
+	display: flex;
+	gap: 6px;
+	align-items: center;
+}
+
+.interactive-session .interactive-input-and-execute-toolbar.focused {
 	border-color: var(--vscode-focusBorder);
 }
 
-.interactive-session .interactive-input-and-toolbar .monaco-editor,
-.interactive-session .interactive-input-and-toolbar .monaco-editor .monaco-editor-background {
+.interactive-session .interactive-input-and-execute-toolbar .monaco-editor,
+.interactive-session .interactive-input-and-execute-toolbar .monaco-editor .monaco-editor-background {
 	background-color: var(--vscode-input-background) !important;
 }
 
-.interactive-session .interactive-input-and-toolbar .monaco-editor .cursors-layer {
+.interactive-session .interactive-input-and-execute-toolbar .monaco-editor .cursors-layer {
 	padding-left: 4px;
 }
 
@@ -411,20 +417,14 @@
 
 .quick-input-widget .interactive-session .interactive-input-part {
 	padding: 8px 6px 6px 6px;
-	border-top: 0;
 }
 
 .quick-input-widget .interactive-session .interactive-input-part .interactive-execute-toolbar {
 	bottom: 1px;
 }
 
-.quick-input-widget .interactive-session .interactive-input-and-toolbar {
+.quick-input-widget .interactive-session .interactive-input-and-execute-toolbar {
 	margin: 0;
-	border-radius: 2px;
-}
-
-.quick-input-widget .interactive-session .interactive-input-and-toolbar .chat-slash-command-content-widget {
-	top: 2px !important;
 }
 
 /* #endregion */


### PR DESCRIPTION
Adds a new menu to the right of the input box but outside of it, not inside like execute.

![image](https://github.com/microsoft/vscode/assets/2644648/06fc908d-e3bf-4b0c-b38e-a07bd11b47e3)

This PR doesn't add anything that takes advantage of this, but that'll be in the next PR.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
