### PR TITLE
Polish dim unfocused settings and remove element when not used

### DIFF
--- a/src/vs/workbench/contrib/accessibility/browser/accessibilityConfiguration.ts
+++ b/src/vs/workbench/contrib/accessibility/browser/accessibilityConfiguration.ts
@@ -4,9 +4,10 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { localize } from 'vs/nls';
-import { Extensions, IConfigurationNode, IConfigurationRegistry } from 'vs/platform/configuration/common/configurationRegistry';
+import { ConfigurationScope, Extensions, IConfigurationNode, IConfigurationRegistry } from 'vs/platform/configuration/common/configurationRegistry';
 import { Registry } from 'vs/platform/registry/common/platform';
 import { RawContextKey } from 'vs/platform/contextkey/common/contextkey';
+import { workbenchConfigurationNodeBase } from 'vs/workbench/common/configuration';
 
 export const accessibilityHelpIsShown = new RawContextKey<boolean>('accessibilityHelpIsShown', false, true);
 export const accessibleViewIsShown = new RawContextKey<boolean>('accessibleViewIsShown', false, true);
@@ -14,8 +15,19 @@ export const accessibleViewSupportsNavigation = new RawContextKey<boolean>('acce
 export const accessibleViewVerbosityEnabled = new RawContextKey<boolean>('accessibleViewVerbosityEnabled', false, true);
 export const accessibleViewGoToSymbolSupported = new RawContextKey<boolean>('accessibleViewGoToSymbolSupported', false, true);
 
-export const enum AccessibilitySettingId {
-	UnfocusedViewOpacity = 'accessibility.unfocusedViewOpacity'
+/**
+ * Miscellaneous settings tagged with accessibility and implemented in the accessibility contrib but
+ * were better to live under workbench for discoverability.
+ */
+export const enum AccessibilityWorkbenchSettingId {
+	ViewDimUnfocusedEnabled = 'workbench.view.dimUnfocused.enabled',
+	ViewDimUnfocusedOpacity = 'workbench.view.dimUnfocused.opacity'
+}
+
+export const enum ViewDimUnfocusedOpacityProperties {
+	Default = 0.75,
+	Minimum = 0.2,
+	Maximum = 1
 }
 
 export const enum AccessibilityVerbositySettingId {
@@ -82,19 +94,41 @@ const configuration: IConfigurationNode = {
 		[AccessibilityVerbositySettingId.EditorUntitledHint]: {
 			description: localize('verbosity.editor.untitledhint', 'Provide information about relevant actions in an untitled text editor.'),
 			...baseProperty
-		},
-		[AccessibilitySettingId.UnfocusedViewOpacity]: {
-			description: localize('unfocusedViewOpacity', 'The opacity fraction (0.2 to 1.0) to use for unfocused editors and terminals. This will dim inactive views to make the focused view more obvious.'),
-			type: 'number',
-			minimum: 0.2,
-			maximum: 1,
-			default: 1,
-			tags: ['accessibility']
 		}
+		// [AccessibilitySettingId.UnfocusedViewOpacity]: {
+		// 	description: localize('unfocusedViewOpacity', 'The opacity fraction (0.2 to 1.0) to use for unfocused editors and terminals. This will dim inactive views to make the focused view more obvious.'),
+		// 	type: 'number',
+		// 	minimum: 0.2,
+		// 	maximum: 1,
+		// 	default: 1,
+		// 	tags: ['accessibility']
+		// }
 	}
 };
 
 export function registerAccessibilityConfiguration() {
-	const configurationRegistry = Registry.as<IConfigurationRegistry>(Extensions.Configuration);
-	configurationRegistry.registerConfiguration(configuration);
+	const registry = Registry.as<IConfigurationRegistry>(Extensions.Configuration);
+	registry.registerConfiguration(configuration);
+
+	registry.registerConfiguration({
+		...workbenchConfigurationNodeBase,
+		properties: {
+			[AccessibilityWorkbenchSettingId.ViewDimUnfocusedEnabled]: {
+				description: localize('dimUnfocusedEnabled', 'Whether to dim unfocused editors and terminals, making the focused view more obvious.'),
+				type: 'boolean',
+				default: false,
+				tags: ['accessibility'],
+				scope: ConfigurationScope.MACHINE,
+			},
+			[AccessibilityWorkbenchSettingId.ViewDimUnfocusedOpacity]: {
+				description: localize('dimUnfocusedOpacity', 'The opacity fraction (0.2 to 1.0) to use for unfocused editors and terminals. This will only take effect when {0} is enabled.', `\`#${AccessibilityWorkbenchSettingId.ViewDimUnfocusedEnabled}#\``),
+				type: 'number',
+				minimum: ViewDimUnfocusedOpacityProperties.Minimum,
+				maximum: ViewDimUnfocusedOpacityProperties.Maximum,
+				default: ViewDimUnfocusedOpacityProperties.Default,
+				tags: ['accessibility'],
+				scope: ConfigurationScope.MACHINE,
+			}
+		}
+	});
 }

--- a/src/vs/workbench/contrib/accessibility/browser/accessibilityConfiguration.ts
+++ b/src/vs/workbench/contrib/accessibility/browser/accessibilityConfiguration.ts
@@ -95,14 +95,6 @@ const configuration: IConfigurationNode = {
 			description: localize('verbosity.editor.untitledhint', 'Provide information about relevant actions in an untitled text editor.'),
 			...baseProperty
 		}
-		// [AccessibilitySettingId.UnfocusedViewOpacity]: {
-		// 	description: localize('unfocusedViewOpacity', 'The opacity fraction (0.2 to 1.0) to use for unfocused editors and terminals. This will dim inactive views to make the focused view more obvious.'),
-		// 	type: 'number',
-		// 	minimum: 0.2,
-		// 	maximum: 1,
-		// 	default: 1,
-		// 	tags: ['accessibility']
-		// }
 	}
 };
 

--- a/src/vs/workbench/contrib/accessibility/browser/unfocusedViewDimmingContribution.ts
+++ b/src/vs/workbench/contrib/accessibility/browser/unfocusedViewDimmingContribution.ts
@@ -8,7 +8,7 @@ import { Disposable, toDisposable } from 'vs/base/common/lifecycle';
 import { clamp } from 'vs/base/common/numbers';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { IWorkbenchContribution } from 'vs/workbench/common/contributions';
-import { AccessibilitySettingId } from 'vs/workbench/contrib/accessibility/browser/accessibilityConfiguration';
+import { AccessibilityWorkbenchSettingId, ViewDimUnfocusedOpacityProperties } from 'vs/workbench/contrib/accessibility/browser/accessibilityConfiguration';
 
 export class UnfocusedViewDimmingContribution extends Disposable implements IWorkbenchContribution {
 	constructor(
@@ -22,24 +22,22 @@ export class UnfocusedViewDimmingContribution extends Disposable implements IWor
 		this._register(toDisposable(() => elStyle.remove()));
 
 		this._register(Event.runAndSubscribe(configurationService.onDidChangeConfiguration, e => {
-			if (e && !e.affectsConfiguration(AccessibilitySettingId.UnfocusedViewOpacity)) {
+			if (e && !e.affectsConfiguration(AccessibilityWorkbenchSettingId.ViewDimUnfocusedEnabled) && !e.affectsConfiguration(AccessibilityWorkbenchSettingId.ViewDimUnfocusedOpacity)) {
 				return;
-			}
-
-			let opacity: number;
-			const opacityConfig = configurationService.getValue(AccessibilitySettingId.UnfocusedViewOpacity);
-			if (typeof opacityConfig !== 'number') {
-				opacity = 1;
-			} else {
-				opacity = clamp(opacityConfig, 0.2, 1);
 			}
 
 			let cssTextContent = '';
 
-			// Only add the styles if the feature is used
-			if (opacity !== 1) {
-				const rules = new Set<string>();
+			const enabled = ensureBoolean(configurationService.getValue(AccessibilityWorkbenchSettingId.ViewDimUnfocusedEnabled), false);
+			if (enabled) {
+				const opacity = clamp(
+					ensureNumber(configurationService.getValue(AccessibilityWorkbenchSettingId.ViewDimUnfocusedOpacity), ViewDimUnfocusedOpacityProperties.Default),
+					ViewDimUnfocusedOpacityProperties.Minimum,
+					ViewDimUnfocusedOpacityProperties.Maximum
+				);
+
 				if (opacity !== 1) {
+					const rules = new Set<string>();
 					const filterRule = `filter: opacity(${opacity});`;
 					// Terminal tabs
 					rules.add(`.monaco-workbench .pane-body.integrated-terminal:not(:focus-within) .tabs-container { ${filterRule} }`);
@@ -49,11 +47,20 @@ export class UnfocusedViewDimmingContribution extends Disposable implements IWor
 					rules.add(`.monaco-workbench .editor-instance:not(:focus-within) .monaco-editor { ${filterRule} }`);
 					// Terminal editors
 					rules.add(`.monaco-workbench .editor-instance:not(:focus-within) .terminal-wrapper { ${filterRule} }`);
+					cssTextContent = [...rules].join('\n');
 				}
-				cssTextContent = [...rules].join('\n');
-			}
 
-			elStyle.textContent = cssTextContent;
+				elStyle.textContent = cssTextContent;
+			}
 		}));
 	}
+}
+
+
+function ensureBoolean(value: unknown, defaultValue: boolean): boolean {
+	return typeof value === 'boolean' ? value : defaultValue;
+}
+
+function ensureNumber(value: unknown, defaultValue: number): number {
+	return typeof value === 'number' ? value : defaultValue;
 }

--- a/src/vs/workbench/contrib/accessibility/browser/unfocusedViewDimmingContribution.ts
+++ b/src/vs/workbench/contrib/accessibility/browser/unfocusedViewDimmingContribution.ts
@@ -11,15 +11,14 @@ import { IWorkbenchContribution } from 'vs/workbench/common/contributions';
 import { AccessibilityWorkbenchSettingId, ViewDimUnfocusedOpacityProperties } from 'vs/workbench/contrib/accessibility/browser/accessibilityConfiguration';
 
 export class UnfocusedViewDimmingContribution extends Disposable implements IWorkbenchContribution {
+	private _styleElement?: HTMLStyleElement;
+
 	constructor(
 		@IConfigurationService configurationService: IConfigurationService,
 	) {
 		super();
 
-		const elStyle = document.createElement('style');
-		elStyle.className = 'accessibilityUnfocusedViewOpacity';
-		document.head.appendChild(elStyle);
-		this._register(toDisposable(() => elStyle.remove()));
+		this._register(toDisposable(() => this._removeStyleElement()));
 
 		this._register(Event.runAndSubscribe(configurationService.onDidChangeConfiguration, e => {
 			if (e && !e.affectsConfiguration(AccessibilityWorkbenchSettingId.ViewDimUnfocusedEnabled) && !e.affectsConfiguration(AccessibilityWorkbenchSettingId.ViewDimUnfocusedOpacity)) {
@@ -50,9 +49,28 @@ export class UnfocusedViewDimmingContribution extends Disposable implements IWor
 					cssTextContent = [...rules].join('\n');
 				}
 
-				elStyle.textContent = cssTextContent;
+			}
+
+			if (cssTextContent.length === 0) {
+				this._removeStyleElement();
+			} else {
+				this._getStyleElement().textContent = cssTextContent;
 			}
 		}));
+	}
+
+	private _getStyleElement(): HTMLStyleElement {
+		if (!this._styleElement) {
+			this._styleElement = document.createElement('style');
+			this._styleElement.className = 'accessibilityUnfocusedViewOpacity';
+			document.head.appendChild(this._styleElement);
+		}
+		return this._styleElement;
+	}
+
+	private _removeStyleElement(): void {
+		this._styleElement?.remove();
+		this._styleElement = undefined;
 	}
 }
 


### PR DESCRIPTION
This is a follow up to the discussion at https://github.com/microsoft/vscode/issues/30522#issuecomment-1681231319. The `accessibility.unfocusedViewOpacity` setting has been split into `workbench.view.dimUnfocused.enabled` and `workbench.view.dimUnfocused.opacity`. They remain implemented in the accessibility contrib and still include the accessibility tag so they can be accessed via `@tag:accessibility`.

The element is also removed when the enabled setting is false.

Fixes https://github.com/microsoft/vscode/issues/30522