### PR TITLE
allow using breadcrumbs view keybinding for go to symbol in accessible view

### DIFF
--- a/src/vs/workbench/contrib/accessibility/browser/accessibleViewActions.ts
+++ b/src/vs/workbench/contrib/accessibility/browser/accessibleViewActions.ts
@@ -76,6 +76,7 @@ class AccessibleViewGoToSymbolAction extends Action2 {
 			precondition: ContextKeyExpr.and(accessibleViewIsShown, accessibleViewGoToSymbolSupported),
 			keybinding: {
 				primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KeyO,
+				secondary: [KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.Period],
 				weight: KeybindingWeight.WorkbenchContrib + 10
 			},
 			icon: Codicon.symbolField,


### PR DESCRIPTION
Go to symbol and the breadcrumbs view are similar from the perspective of a SR user, so we want to allow using this keybinding to make use of muscle memory / increase discoverability 
fix #189974

cc @jooyoungseo