### PR TITLE
Remove titlebar and include side buttons in quick chat

### DIFF
--- a/src/vs/platform/quickinput/browser/quickInput.ts
+++ b/src/vs/platform/quickinput/browser/quickInput.ts
@@ -1264,8 +1264,7 @@ export class QuickWidget extends QuickInput implements IQuickWidget {
 
 		const visibilities: Visibilities = {
 			title: !!this.title || !!this.step || !!this.buttons.length,
-			description: !!this.description || !!this.step,
-			progressBar: true
+			description: !!this.description || !!this.step
 		};
 
 		this.ui.setVisibilities(visibilities);

--- a/src/vs/workbench/contrib/chat/browser/actions/chatQuickInputActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatQuickInputActions.ts
@@ -3,32 +3,71 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as dom from 'vs/base/browser/dom';
-import { CancellationToken } from 'vs/base/common/cancellation';
 import { Codicon } from 'vs/base/common/codicons';
 import { KeyCode, KeyMod } from 'vs/base/common/keyCodes';
-import { Disposable, DisposableStore } from 'vs/base/common/lifecycle';
-import { ThemeIcon } from 'vs/base/common/themables';
 import { localize } from 'vs/nls';
 import { Action2, MenuId, registerAction2 } from 'vs/platform/actions/common/actions';
-import { ICommandService } from 'vs/platform/commands/common/commands';
-import { ContextKeyExpr, IContextKeyService, IScopedContextKeyService } from 'vs/platform/contextkey/common/contextkey';
-import { IInstantiationService, ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
-import { ServiceCollection } from 'vs/platform/instantiation/common/serviceCollection';
+import { ContextKeyExpr } from 'vs/platform/contextkey/common/contextkey';
+import { ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
 import { KeybindingWeight } from 'vs/platform/keybinding/common/keybindingsRegistry';
-import { IQuickInputService, IQuickWidget } from 'vs/platform/quickinput/common/quickInput';
-import { editorBackground, editorForeground, inputBackground } from 'vs/platform/theme/common/colorRegistry';
 import { CHAT_CATEGORY } from 'vs/workbench/contrib/chat/browser/actions/chatActions';
-import { IChatWidgetService } from 'vs/workbench/contrib/chat/browser/chat';
-import { IChatViewOptions } from 'vs/workbench/contrib/chat/browser/chatViewPane';
-import { ChatWidget } from 'vs/workbench/contrib/chat/browser/chatWidget';
+import { IQuickChatService } from 'vs/workbench/contrib/chat/browser/chat';
 import { CONTEXT_PROVIDER_EXISTS } from 'vs/workbench/contrib/chat/common/chatContextKeys';
-import { ChatModel } from 'vs/workbench/contrib/chat/common/chatModel';
 import { IChatService } from 'vs/workbench/contrib/chat/common/chatService';
 
-export const ASK_QUICK_QUESTION_ACTION_ID = 'chat.action.askQuickQuestion';
+export const ASK_QUICK_QUESTION_ACTION_ID = 'workbench.action.quickchat.toggle';
 export function registerQuickChatActions() {
 	registerAction2(QuickChatGlobalAction);
+
+	registerAction2(class OpenInChatViewAction extends Action2 {
+		constructor() {
+			super({
+				id: 'workbench.action.quickchat.openInChatView',
+				title: {
+					value: localize('chat.openInChatView.label', "Open in Chat View"),
+					original: 'Open in Chat View'
+				},
+				f1: false,
+				category: CHAT_CATEGORY,
+				icon: Codicon.commentDiscussion,
+				menu: {
+					id: MenuId.ChatInputSide,
+					group: 'navigation',
+					order: 10
+				}
+			});
+		}
+
+		run(accessor: ServicesAccessor) {
+			const quickChatService = accessor.get(IQuickChatService);
+			quickChatService.openInChatView();
+		}
+	});
+
+	registerAction2(class CloseQuickChatAction extends Action2 {
+		constructor() {
+			super({
+				id: 'workbench.action.quickchat.close',
+				title: {
+					value: localize('chat.closeQuickChat.label', "Close Quick Chat"),
+					original: 'Close Quick Chat'
+				},
+				f1: false,
+				category: CHAT_CATEGORY,
+				icon: Codicon.close,
+				menu: {
+					id: MenuId.ChatInputSide,
+					group: 'navigation',
+					order: 20
+				}
+			});
+		}
+
+		run(accessor: ServicesAccessor) {
+			const quickChatService = accessor.get(IQuickChatService);
+			quickChatService.close();
+		}
+	});
 }
 
 class QuickChatGlobalAction extends Action2 {
@@ -56,13 +95,13 @@ class QuickChatGlobalAction extends Action2 {
 		});
 	}
 
-	override async run(accessor: ServicesAccessor, query: string): Promise<void> {
+	override run(accessor: ServicesAccessor, query?: string): void {
 		const chatService = accessor.get(IChatService);
-		const commandService = accessor.get(ICommandService);
+		const quickChatService = accessor.get(IQuickChatService);
 		// Grab the first provider and run its command
 		const info = chatService.getProviderInfos()[0];
 		if (info) {
-			await commandService.executeCommand(`workbench.action.openQuickChat.${info.id}`, query);
+			quickChatService.toggle(info.id, query);
 		}
 	}
 }
@@ -77,10 +116,6 @@ class QuickChatGlobalAction extends Action2 {
  */
 export function getQuickChatActionForProvider(id: string, label: string) {
 	return class AskQuickChatAction extends Action2 {
-		_currentTimer: any | undefined;
-		_input: IQuickWidget | undefined;
-		_currentChat: QuickChat | undefined;
-
 		constructor() {
 			super({
 				id: `workbench.action.openQuickChat.${id}`,
@@ -90,198 +125,9 @@ export function getQuickChatActionForProvider(id: string, label: string) {
 			});
 		}
 
-		override run(accessor: ServicesAccessor, query: string): void {
-			const quickInputService = accessor.get(IQuickInputService);
-			const chatService = accessor.get(IChatService);
-			const instantiationService = accessor.get(IInstantiationService);
-
-			// First things first, clear the existing timer that will dispose the session
-			clearTimeout(this._currentTimer);
-			this._currentTimer = undefined;
-
-			// If the input is already shown, hide it. This provides a toggle behavior of the quick pick
-			if (this._input !== undefined) {
-				this._input.hide();
-				return;
-			}
-
-			// Check if any providers are available. If not, show nothing
-			// This shouldn't be needed because of the precondition, but just in case
-			const providerInfo = chatService.getProviderInfos()[0];
-			if (!providerInfo) {
-				return;
-			}
-
-			const disposableStore = new DisposableStore();
-
-			//#region Setup quick pick
-
-			this._input = quickInputService.createQuickWidget();
-			disposableStore.add(this._input);
-
-			const containerSession = dom.$('.interactive-session');
-			this._input.widget = containerSession;
-
-			this._currentChat ??= instantiationService.createInstance(QuickChat, {
-				providerId: providerInfo.id,
-			});
-			// show needs to come before the current chat rendering
-			this._input.show();
-			this._currentChat.render(containerSession);
-
-			const clearButton = {
-				iconClass: ThemeIcon.asClassName(Codicon.clearAll),
-				tooltip: localize('clear', "Clear"),
-			};
-			this._input.buttons = [
-				clearButton,
-				{
-					iconClass: ThemeIcon.asClassName(Codicon.commentDiscussion),
-					tooltip: localize('openInChat', "Open In Chat View"),
-				}
-			];
-			this._input.title = providerInfo.displayName;
-
-			disposableStore.add(this._input.onDidHide(() => {
-				disposableStore.dispose();
-				this._input = undefined;
-				this._currentTimer = setTimeout(() => {
-					this._currentChat?.dispose();
-					this._currentChat = undefined;
-				}, 1000 * 30); // 30 seconds
-			}));
-
-			disposableStore.add(this._input.onDidTriggerButton((e) => {
-				if (e === clearButton) {
-					this._currentChat?.clear();
-				} else {
-					this._currentChat?.openChatView();
-				}
-			}));
-
-			//#endregion
-
-			this._currentChat.focus();
-
-			if (query) {
-				this._currentChat.setValue(query);
-				this._currentChat.acceptInput();
-			}
+		override run(accessor: ServicesAccessor, query?: string): void {
+			const quickChatService = accessor.get(IQuickChatService);
+			quickChatService.toggle(id, query);
 		}
 	};
-}
-
-class QuickChat extends Disposable {
-	private widget!: ChatWidget;
-	private model: ChatModel | undefined;
-	private _currentQuery: string | undefined;
-
-	private _scopedContextKeyService!: IScopedContextKeyService;
-	get scopedContextKeyService() {
-		return this._scopedContextKeyService;
-	}
-
-	constructor(
-		private readonly _options: IChatViewOptions,
-		@IInstantiationService private readonly instantiationService: IInstantiationService,
-		@IContextKeyService private readonly contextKeyService: IContextKeyService,
-		@IChatService private readonly chatService: IChatService,
-		@IChatWidgetService private readonly _chatWidgetService: IChatWidgetService
-	) {
-		super();
-	}
-
-	clear() {
-		this.model?.dispose();
-		this.model = undefined;
-		this.updateModel();
-		this.widget.inputEditor.setValue('');
-	}
-
-	focus(): void {
-		if (this.widget) {
-			this.widget.focusInput();
-		}
-	}
-
-	render(parent: HTMLElement): void {
-		this._scopedContextKeyService?.dispose();
-		this._scopedContextKeyService = this._register(this.contextKeyService.createScoped(parent));
-		const scopedInstantiationService = this.instantiationService.createChild(new ServiceCollection([IContextKeyService, this.scopedContextKeyService]));
-		this.widget?.dispose();
-		this.widget = this._register(
-			scopedInstantiationService.createInstance(
-				ChatWidget,
-				{ resource: true, renderInputOnTop: true, renderStyle: 'compact' },
-				{
-					listForeground: editorForeground,
-					listBackground: editorBackground,
-					inputEditorBackground: inputBackground,
-					resultEditorBackground: editorBackground
-				}));
-		this.widget.render(parent);
-		this.widget.setVisible(true);
-		this.widget.setDynamicChatTreeItemLayout(2, 600);
-		this.updateModel();
-		if (this._currentQuery) {
-			this.widget.inputEditor.setSelection({
-				startLineNumber: 1,
-				startColumn: 1,
-				endLineNumber: 1,
-				endColumn: this._currentQuery.length + 1
-			});
-		}
-
-		this.registerListeners();
-	}
-
-	private registerListeners(): void {
-		this._register(this.widget.inputEditor.onDidChangeModelContent((e) => {
-			this._currentQuery = this.widget.inputEditor.getValue();
-		}));
-		this._register(this.widget.onDidClear(() => this.clear()));
-	}
-
-	async acceptInput(): Promise<void> {
-		return this.widget.acceptInput();
-	}
-
-	async openChatView(): Promise<void> {
-		const widget = await this._chatWidgetService.revealViewForProvider(this._options.providerId);
-		if (!widget?.viewModel || !this.model) {
-			return;
-		}
-
-		for (const request of this.model.getRequests()) {
-			if (request.response?.response.value || request.response?.errorDetails) {
-				this.chatService.addCompleteRequest(widget.viewModel.sessionId,
-					request.message as string,
-					{
-						message: request.response.response.asString(),
-						errorDetails: request.response.errorDetails
-					});
-			} else if (request.message) {
-
-			}
-		}
-
-		const value = this.widget.inputEditor.getValue();
-		if (value) {
-			widget.inputEditor.setValue(value);
-		}
-		widget.focusInput();
-	}
-
-	setValue(value: string): void {
-		this.widget.inputEditor.setValue(value);
-	}
-
-	private updateModel(): void {
-		this.model ??= this.chatService.startSession(this._options.providerId, CancellationToken.None);
-		if (!this.model) {
-			throw new Error('Could not start chat session');
-		}
-
-		this.widget.setModel(this.model, { inputValue: this._currentQuery });
-	}
 }

--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -22,7 +22,7 @@ import { registerChatExecuteActions } from 'vs/workbench/contrib/chat/browser/ac
 import { registerQuickChatActions } from 'vs/workbench/contrib/chat/browser/actions/chatQuickInputActions';
 import { registerChatTitleActions } from 'vs/workbench/contrib/chat/browser/actions/chatTitleActions';
 import { registerChatExportActions } from 'vs/workbench/contrib/chat/browser/actions/chatImportExport';
-import { IChatAccessibilityService, IChatWidget, IChatWidgetService } from 'vs/workbench/contrib/chat/browser/chat';
+import { IChatAccessibilityService, IChatWidget, IChatWidgetService, IQuickChatService } from 'vs/workbench/contrib/chat/browser/chat';
 import { ChatContributionService } from 'vs/workbench/contrib/chat/browser/chatContributionServiceImpl';
 import { ChatEditor, IChatEditorOptions } from 'vs/workbench/contrib/chat/browser/chatEditor';
 import { ChatEditorInput, ChatEditorInputSerializer } from 'vs/workbench/contrib/chat/browser/chatEditorInput';
@@ -52,6 +52,7 @@ import { AccessibleViewAction } from 'vs/workbench/contrib/accessibility/browser
 import { ICommandService } from 'vs/platform/commands/common/commands';
 import { ChatVariablesService, IChatVariablesService } from 'vs/workbench/contrib/chat/common/chatVariables';
 import { registerChatFileTreeActions } from 'vs/workbench/contrib/chat/browser/actions/chatFileTreeActions';
+import { QuickChatService } from 'vs/workbench/contrib/chat/browser/chatQuick';
 
 // Register configuration
 const configurationRegistry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration);
@@ -258,6 +259,7 @@ registerClearActions();
 registerSingleton(IChatService, ChatService, InstantiationType.Delayed);
 registerSingleton(IChatContributionService, ChatContributionService, InstantiationType.Delayed);
 registerSingleton(IChatWidgetService, ChatWidgetService, InstantiationType.Delayed);
+registerSingleton(IQuickChatService, QuickChatService, InstantiationType.Delayed);
 registerSingleton(IChatAccessibilityService, ChatAccessibilityService, InstantiationType.Delayed);
 registerSingleton(IChatWidgetHistoryService, ChatWidgetHistoryService, InstantiationType.Delayed);
 registerSingleton(IChatProviderService, ChatProviderService, InstantiationType.Delayed);

--- a/src/vs/workbench/contrib/chat/browser/chat.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.ts
@@ -11,6 +11,7 @@ import { URI } from 'vs/base/common/uri';
 import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
 
 export const IChatWidgetService = createDecorator<IChatWidgetService>('chatWidgetService');
+export const IQuickChatService = createDecorator<IQuickChatService>('quickChatService');
 export const IChatAccessibilityService = createDecorator<IChatAccessibilityService>('chatAccessibilityService');
 
 export interface IChatWidgetService {
@@ -32,6 +33,13 @@ export interface IChatWidgetService {
 	getWidgetBySessionId(sessionId: string): IChatWidget | undefined;
 }
 
+export interface IQuickChatService {
+	readonly _serviceBrand: undefined;
+	toggle(providerId: string, query?: string): void;
+	focus(): void;
+	close(): void;
+	openInChatView(): void;
+}
 
 export interface IChatAccessibilityService {
 	readonly _serviceBrand: undefined;

--- a/src/vs/workbench/contrib/chat/browser/chatQuick.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatQuick.ts
@@ -1,0 +1,209 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as dom from 'vs/base/browser/dom';
+import { CancellationToken } from 'vs/base/common/cancellation';
+import { Disposable, DisposableStore } from 'vs/base/common/lifecycle';
+import { IContextKeyService, IScopedContextKeyService } from 'vs/platform/contextkey/common/contextkey';
+import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
+import { ServiceCollection } from 'vs/platform/instantiation/common/serviceCollection';
+import { IQuickInputService, IQuickWidget } from 'vs/platform/quickinput/common/quickInput';
+import { editorBackground, editorForeground, inputBackground } from 'vs/platform/theme/common/colorRegistry';
+import { IChatWidgetService, IQuickChatService } from 'vs/workbench/contrib/chat/browser/chat';
+import { IChatViewOptions } from 'vs/workbench/contrib/chat/browser/chatViewPane';
+import { ChatWidget } from 'vs/workbench/contrib/chat/browser/chatWidget';
+import { ChatModel } from 'vs/workbench/contrib/chat/common/chatModel';
+import { IChatService } from 'vs/workbench/contrib/chat/common/chatService';
+
+export class QuickChatService implements IQuickChatService {
+	readonly _serviceBrand: undefined;
+
+	_input: IQuickWidget | undefined;
+	_currentChat: QuickChat | undefined;
+
+	constructor(
+		@IQuickInputService private readonly quickInputService: IQuickInputService,
+		@IChatService private readonly chatService: IChatService,
+		@IInstantiationService private readonly instantiationService: IInstantiationService,
+	) { }
+
+	get focused(): boolean {
+		const widget = this._input?.widget as HTMLElement;
+		if (!widget) {
+			return false;
+		}
+		return dom.isAncestor(document.activeElement, widget);
+	}
+
+	toggle(providerId: string, query?: string | undefined): void {
+		// If the input is already shown, hide it. This provides a toggle behavior of the quick pick
+		if (this.focused) {
+			this.close();
+			return;
+		}
+
+		// Check if any providers are available. If not, show nothing
+		// This shouldn't be needed because of the precondition, but just in case
+		const providerInfo = this.chatService.getProviderInfos().find(info => info.id === providerId);
+		if (!providerInfo) {
+			return;
+		}
+
+		const disposableStore = new DisposableStore();
+
+		this._input = this.quickInputService.createQuickWidget();
+		this._input.contextKey = 'chatInputVisible';
+		this._input.ignoreFocusOut = true;
+		disposableStore.add(this._input);
+
+		const containerSession = dom.$('.interactive-session');
+		this._input.widget = containerSession;
+
+		this._currentChat ??= this.instantiationService.createInstance(QuickChat, {
+			providerId: providerInfo.id,
+		});
+
+		// show needs to come before the current chat rendering
+		this._input.show();
+		this._currentChat.render(containerSession);
+
+		disposableStore.add(this._input.onDidHide(() => {
+			disposableStore.dispose();
+			this._input = undefined;
+		}));
+
+		this._currentChat.focus();
+
+		if (query) {
+			this._currentChat.setValue(query);
+			this._currentChat.acceptInput();
+		}
+	}
+	focus(): void {
+		this._currentChat?.focus();
+	}
+	close(): void {
+		this._input?.dispose();
+	}
+	async openInChatView(): Promise<void> {
+		await this._currentChat?.openChatView();
+		this.close();
+	}
+}
+
+class QuickChat extends Disposable {
+	private widget!: ChatWidget;
+	private model: ChatModel | undefined;
+	private _currentQuery: string | undefined;
+
+	private _scopedContextKeyService!: IScopedContextKeyService;
+	get scopedContextKeyService() {
+		return this._scopedContextKeyService;
+	}
+
+	constructor(
+		private readonly _options: IChatViewOptions,
+		@IInstantiationService private readonly instantiationService: IInstantiationService,
+		@IContextKeyService private readonly contextKeyService: IContextKeyService,
+		@IChatService private readonly chatService: IChatService,
+		@IChatWidgetService private readonly _chatWidgetService: IChatWidgetService
+	) {
+		super();
+	}
+
+	clear() {
+		this.model?.dispose();
+		this.model = undefined;
+		this.updateModel();
+		this.widget.inputEditor.setValue('');
+	}
+
+	focus(): void {
+		if (this.widget) {
+			this.widget.focusInput();
+		}
+	}
+
+	render(parent: HTMLElement): void {
+		this._scopedContextKeyService?.dispose();
+		this._scopedContextKeyService = this._register(this.contextKeyService.createScoped(parent));
+		const scopedInstantiationService = this.instantiationService.createChild(new ServiceCollection([IContextKeyService, this.scopedContextKeyService]));
+		this.widget?.dispose();
+		this.widget = this._register(
+			scopedInstantiationService.createInstance(
+				ChatWidget,
+				{ resource: true, renderInputOnTop: true, renderStyle: 'compact' },
+				{
+					listForeground: editorForeground,
+					listBackground: editorBackground,
+					inputEditorBackground: inputBackground,
+					resultEditorBackground: editorBackground
+				}));
+		this.widget.render(parent);
+		this.widget.setVisible(true);
+		this.widget.setDynamicChatTreeItemLayout(2, 600);
+		this.updateModel();
+		if (this._currentQuery) {
+			this.widget.inputEditor.setSelection({
+				startLineNumber: 1,
+				startColumn: 1,
+				endLineNumber: 1,
+				endColumn: this._currentQuery.length + 1
+			});
+		}
+
+		this.registerListeners();
+	}
+
+	private registerListeners(): void {
+		this._register(this.widget.inputEditor.onDidChangeModelContent((e) => {
+			this._currentQuery = this.widget.inputEditor.getValue();
+		}));
+		this._register(this.widget.onDidClear(() => this.clear()));
+	}
+
+	async acceptInput(): Promise<void> {
+		return this.widget.acceptInput();
+	}
+
+	async openChatView(): Promise<void> {
+		const widget = await this._chatWidgetService.revealViewForProvider(this._options.providerId);
+		if (!widget?.viewModel || !this.model) {
+			return;
+		}
+
+		for (const request of this.model.getRequests()) {
+			if (request.response?.response.value || request.response?.errorDetails) {
+				this.chatService.addCompleteRequest(widget.viewModel.sessionId,
+					request.message as string,
+					{
+						message: request.response.response.asString(),
+						errorDetails: request.response.errorDetails
+					});
+			} else if (request.message) {
+
+			}
+		}
+
+		const value = this.widget.inputEditor.getValue();
+		if (value) {
+			widget.inputEditor.setValue(value);
+		}
+		widget.focusInput();
+	}
+
+	setValue(value: string): void {
+		this.widget.inputEditor.setValue(value);
+	}
+
+	private updateModel(): void {
+		this.model ??= this.chatService.startSession(this._options.providerId, CancellationToken.None);
+		if (!this.model) {
+			throw new Error('Could not start chat session');
+		}
+
+		this.widget.setModel(this.model, { inputValue: this._currentQuery });
+	}
+}


### PR DESCRIPTION
This adds buttons to the right of the chat box. These buttons were previously on the quick pick's titlebar, but in order to have a smooth transition between Command Palette and Quick Chat we wanted to move away from the title bar.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

<img width="673" alt="image" src="https://github.com/microsoft/vscode/assets/2644648/dd99d3bf-4584-4496-af13-119556a85bb6">

Fixes https://github.com/microsoft/vscode/issues/190736