### PR TITLE
Don't use `remoteCredentialsService` when client specified a `secretStorageProvider`

### DIFF
--- a/src/vs/workbench/services/credentials/browser/credentialsService.ts
+++ b/src/vs/workbench/services/credentials/browser/credentialsService.ts
@@ -30,7 +30,11 @@ export class BrowserCredentialsService extends Disposable implements ICredential
 	) {
 		super();
 
-		if (environmentService.remoteAuthority && !environmentService.options?.credentialsProvider) {
+		if (
+			environmentService.remoteAuthority
+			&& !environmentService.options?.credentialsProvider
+			&& !environmentService.options?.secretStorageProvider
+		) {
 			// If we have a remote authority but the embedder didn't provide a credentialsProvider,
 			// we can use the CredentialsService on the remote side
 			const remoteCredentialsService = ProxyChannel.toService<ICredentialsService>(remoteAgentService.getConnection()!.getChannel('credentials'));

--- a/src/vs/workbench/services/credentials/browser/credentialsService.ts
+++ b/src/vs/workbench/services/credentials/browser/credentialsService.ts
@@ -41,8 +41,7 @@ export class BrowserCredentialsService extends Disposable implements ICredential
 			this.credentialsProvider = remoteCredentialsService;
 			this._secretStoragePrefix = remoteCredentialsService.getSecretStoragePrefix();
 		} else {
-			// fall back to InMemoryCredentialsProvider if none was given to us. This should really only be used
-			// when running tests.
+			// fall back to InMemoryCredentialsProvider if none was given to us.
 			this.credentialsProvider = environmentService.options?.credentialsProvider ?? new InMemoryCredentialsProvider();
 			this._secretStoragePrefix = Promise.resolve(this.productService.urlProtocol);
 		}


### PR DESCRIPTION
This is a temporary fix for https://github.com/microsoft/vscode/issues/190537

until we clean up the last of the CredentialsService (which should be in debt week in Sept).

If the client embedder declared a secretStorageProvider, they likely don't want the old credentialsProvider to go over the remote connection... so we use an in-memory provider instead.

Fixed https://github.com/microsoft/vscode/issues/190537

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
