### PR TITLE
Move contributing to Command Center to registration time & have Chat show up in Command Center

### DIFF
--- a/src/vs/platform/quickinput/common/quickAccess.ts
+++ b/src/vs/platform/quickinput/common/quickAccess.ts
@@ -125,6 +125,19 @@ export interface IQuickAccessProviderHelp {
 	 * The command to bring up this quick access provider.
 	 */
 	readonly commandId?: string;
+
+	/**
+	 * The order of help entries in the Command Center.
+	 * Lower values will be placed above higher values.
+	 * No value will hide this help entry from the Command Center.
+	 */
+	readonly commandCenterOrder?: number;
+
+	/**
+	 * An optional label to use for the Command Center entry. If not set
+	 * the description will be used instead.
+	 */
+	readonly commandCenterLabel?: string;
 }
 
 export interface IQuickAccessProviderDescriptor {

--- a/src/vs/workbench/contrib/chat/browser/actions/chatQuickInputActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatQuickInputActions.ts
@@ -7,13 +7,11 @@ import { Codicon } from 'vs/base/common/codicons';
 import { KeyCode, KeyMod } from 'vs/base/common/keyCodes';
 import { localize } from 'vs/nls';
 import { Action2, MenuId, registerAction2 } from 'vs/platform/actions/common/actions';
-import { ContextKeyExpr } from 'vs/platform/contextkey/common/contextkey';
 import { ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
 import { KeybindingWeight } from 'vs/platform/keybinding/common/keybindingsRegistry';
 import { CHAT_CATEGORY } from 'vs/workbench/contrib/chat/browser/actions/chatActions';
 import { IQuickChatService } from 'vs/workbench/contrib/chat/browser/chat';
 import { CONTEXT_PROVIDER_EXISTS } from 'vs/workbench/contrib/chat/common/chatContextKeys';
-import { IChatService } from 'vs/workbench/contrib/chat/common/chatService';
 
 export const ASK_QUICK_QUESTION_ACTION_ID = 'workbench.action.quickchat.toggle';
 export function registerQuickChatActions() {
@@ -85,24 +83,13 @@ class QuickChatGlobalAction extends Action2 {
 				linux: {
 					primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyMod.Alt | KeyCode.KeyI
 				}
-			},
-			menu: {
-				id: MenuId.LayoutControlMenu,
-				group: '0_workbench_toggles',
-				when: ContextKeyExpr.notEquals('config.chat.experimental.defaultMode', 'chatView'),
-				order: 0
 			}
 		});
 	}
 
 	override run(accessor: ServicesAccessor, query?: string): void {
-		const chatService = accessor.get(IChatService);
 		const quickChatService = accessor.get(IQuickChatService);
-		// Grab the first provider and run its command
-		const info = chatService.getProviderInfos()[0];
-		if (info) {
-			quickChatService.toggle(info.id, query);
-		}
+		quickChatService.toggle(undefined, query);
 	}
 }
 

--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -86,18 +86,6 @@ configurationRegistry.registerConfiguration({
 			type: 'number',
 			description: nls.localize('interactiveSession.editor.lineHeight', "Controls the line height in pixels in chat codeblocks. Use 0 to compute the line height from the font size."),
 			default: 0
-		},
-		'chat.experimental.defaultMode': {
-			type: 'string',
-			tags: ['experimental'],
-			enum: ['chatView', 'quickQuestion', 'both'],
-			enumDescriptions: [
-				nls.localize('interactiveSession.defaultMode.chatView', "Use the chat view as the default mode. Displays the chat icon in the Activity Bar."),
-				nls.localize('interactiveSession.defaultMode.quickQuestion', "Use the quick question as the default mode. Displays the chat icon in the Title Bar."),
-				nls.localize('interactiveSession.defaultMode.both', "Displays the chat icon in the Activity Bar and the Title Bar which open their respective chat modes.")
-			],
-			description: nls.localize('interactiveSession.defaultMode', "Controls the default mode of the chat experience."),
-			default: 'chatView'
 		}
 	}
 });

--- a/src/vs/workbench/contrib/chat/browser/chat.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.ts
@@ -35,7 +35,8 @@ export interface IChatWidgetService {
 
 export interface IQuickChatService {
 	readonly _serviceBrand: undefined;
-	toggle(providerId: string, query?: string): void;
+	enabled: boolean;
+	toggle(providerId?: string, query?: string): void;
 	focus(): void;
 	close(): void;
 	openInChatView(): void;

--- a/src/vs/workbench/contrib/chat/browser/chatContributionServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContributionServiceImpl.ts
@@ -126,10 +126,7 @@ export class ChatContributionService implements IChatContributionService {
 			canToggleVisibility: false,
 			canMoveView: true,
 			ctorDescriptor: new SyncDescriptor(ChatViewPane, [<IChatViewOptions>{ providerId: providerDescriptor.id }]),
-			when: ContextKeyExpr.and(
-				ContextKeyExpr.deserialize(providerDescriptor.when),
-				ContextKeyExpr.notEquals('config.chat.experimental.defaultMode', 'quickQuestion')
-			)
+			when: ContextKeyExpr.deserialize(providerDescriptor.when)
 		}];
 		Registry.as<IViewsRegistry>(ViewExtensions.ViewsRegistry).registerViews(viewDescriptor, viewContainer);
 

--- a/src/vs/workbench/contrib/chat/browser/chatQuick.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatQuick.ts
@@ -29,6 +29,10 @@ export class QuickChatService implements IQuickChatService {
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
 	) { }
 
+	get enabled(): boolean {
+		return this.chatService.getProviderInfos().length > 0;
+	}
+
 	get focused(): boolean {
 		const widget = this._input?.widget as HTMLElement;
 		if (!widget) {
@@ -37,7 +41,7 @@ export class QuickChatService implements IQuickChatService {
 		return dom.isAncestor(document.activeElement, widget);
 	}
 
-	toggle(providerId: string, query?: string | undefined): void {
+	toggle(providerId?: string, query?: string | undefined): void {
 		// If the input is already shown, hide it. This provides a toggle behavior of the quick pick
 		if (this.focused) {
 			this.close();
@@ -46,7 +50,9 @@ export class QuickChatService implements IQuickChatService {
 
 		// Check if any providers are available. If not, show nothing
 		// This shouldn't be needed because of the precondition, but just in case
-		const providerInfo = this.chatService.getProviderInfos().find(info => info.id === providerId);
+		const providerInfo = providerId
+			? this.chatService.getProviderInfos().find(info => info.id === providerId)
+			: this.chatService.getProviderInfos()[0];
 		if (!providerInfo) {
 			return;
 		}

--- a/src/vs/workbench/contrib/codeEditor/browser/quickaccess/gotoSymbolQuickAccess.ts
+++ b/src/vs/workbench/contrib/codeEditor/browser/quickaccess/gotoSymbolQuickAccess.ts
@@ -273,7 +273,15 @@ Registry.as<IQuickAccessRegistry>(QuickaccessExtensions.Quickaccess).registerQui
 	contextKey: 'inFileSymbolsPicker',
 	placeholder: localize('gotoSymbolQuickAccessPlaceholder', "Type the name of a symbol to go to."),
 	helpEntries: [
-		{ description: localize('gotoSymbolQuickAccess', "Go to Symbol in Editor"), prefix: AbstractGotoSymbolQuickAccessProvider.PREFIX, commandId: GotoSymbolAction.ID },
-		{ description: localize('gotoSymbolByCategoryQuickAccess', "Go to Symbol in Editor by Category"), prefix: AbstractGotoSymbolQuickAccessProvider.PREFIX_BY_CATEGORY }
+		{
+			description: localize('gotoSymbolQuickAccess', "Go to Symbol in Editor"),
+			prefix: AbstractGotoSymbolQuickAccessProvider.PREFIX,
+			commandId: GotoSymbolAction.ID,
+			commandCenterOrder: 40
+		},
+		{
+			description: localize('gotoSymbolByCategoryQuickAccess', "Go to Symbol in Editor by Category"),
+			prefix: AbstractGotoSymbolQuickAccessProvider.PREFIX_BY_CATEGORY
+		}
 	]
 });

--- a/src/vs/workbench/contrib/debug/browser/debug.contribution.ts
+++ b/src/vs/workbench/contrib/debug/browser/debug.contribution.ts
@@ -77,7 +77,11 @@ Registry.as<IQuickAccessRegistry>(QuickAccessExtensions.Quickaccess).registerQui
 	prefix: DEBUG_QUICK_ACCESS_PREFIX,
 	contextKey: 'inLaunchConfigurationsPicker',
 	placeholder: nls.localize('startDebugPlaceholder', "Type the name of a launch configuration to run."),
-	helpEntries: [{ description: nls.localize('startDebuggingHelp', "Start Debugging"), commandId: SELECT_AND_START_ID }]
+	helpEntries: [{
+		description: nls.localize('startDebuggingHelp', "Start Debugging"),
+		commandId: SELECT_AND_START_ID,
+		commandCenterOrder: 50
+	}]
 });
 
 // Register quick access for debug console

--- a/src/vs/workbench/contrib/quickaccess/browser/quickAccess.contribution.ts
+++ b/src/vs/workbench/contrib/quickaccess/browser/quickAccess.contribution.ts
@@ -24,7 +24,11 @@ quickAccessRegistry.registerQuickAccessProvider({
 	ctor: HelpQuickAccessProvider,
 	prefix: HelpQuickAccessProvider.PREFIX,
 	placeholder: localize('helpQuickAccessPlaceholder', "Type '{0}' to get help on the actions you can take from here.", HelpQuickAccessProvider.PREFIX),
-	helpEntries: [{ description: localize('helpQuickAccess', "Show all Quick Access Providers") }]
+	helpEntries: [{
+		description: localize('helpQuickAccess', "Show all Quick Access Providers"),
+		commandCenterOrder: 70,
+		commandCenterLabel: localize('more', 'More')
+	}]
 });
 
 quickAccessRegistry.registerQuickAccessProvider({
@@ -40,7 +44,7 @@ quickAccessRegistry.registerQuickAccessProvider({
 	prefix: CommandsQuickAccessProvider.PREFIX,
 	contextKey: 'inCommandsPicker',
 	placeholder: localize('commandsQuickAccessPlaceholder', "Type the name of a command to run."),
-	helpEntries: [{ description: localize('commandsQuickAccess', "Show and Run Commands"), commandId: ShowAllCommandsAction.ID }]
+	helpEntries: [{ description: localize('commandsQuickAccess', "Show and Run Commands"), commandId: ShowAllCommandsAction.ID, commandCenterOrder: 20 }]
 });
 
 //#endregion

--- a/src/vs/workbench/contrib/search/browser/anythingQuickAccess.ts
+++ b/src/vs/workbench/contrib/search/browser/anythingQuickAccess.ts
@@ -40,7 +40,7 @@ import { Schemas } from 'vs/base/common/network';
 import { IFilesConfigurationService, AutoSaveMode } from 'vs/workbench/services/filesConfiguration/common/filesConfigurationService';
 import { ResourceMap } from 'vs/base/common/map';
 import { SymbolsQuickAccessProvider } from 'vs/workbench/contrib/search/browser/symbolsQuickAccess';
-import { AnythingQuickAccessProviderRunOptions, DefaultQuickAccessFilterValue } from 'vs/platform/quickinput/common/quickAccess';
+import { AnythingQuickAccessProviderRunOptions, DefaultQuickAccessFilterValue, Extensions, IQuickAccessRegistry } from 'vs/platform/quickinput/common/quickAccess';
 import { IWorkbenchQuickAccessConfiguration } from 'vs/workbench/browser/quickaccess';
 import { GotoSymbolQuickAccessProvider } from 'vs/workbench/contrib/codeEditor/browser/quickaccess/gotoSymbolQuickAccess';
 import { ITextModelService } from 'vs/editor/common/services/resolverService';
@@ -52,11 +52,11 @@ import { Codicon } from 'vs/base/common/codicons';
 import { ThemeIcon } from 'vs/base/common/themables';
 import { IUriIdentityService } from 'vs/platform/uriIdentity/common/uriIdentity';
 import { stripIcons } from 'vs/base/common/iconLabels';
-import { HelpQuickAccessProvider } from 'vs/platform/quickinput/browser/helpQuickAccess';
-import { CommandsQuickAccessProvider } from 'vs/workbench/contrib/quickaccess/browser/commandsQuickAccess';
-import { DEBUG_QUICK_ACCESS_PREFIX } from 'vs/workbench/contrib/debug/browser/debugCommands';
-import { TasksQuickAccessProvider } from 'vs/workbench/contrib/tasks/browser/tasksQuickAccess';
 import { Lazy } from 'vs/base/common/lazy';
+import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
+import { Registry } from 'vs/platform/registry/common/platform';
+import { ASK_QUICK_QUESTION_ACTION_ID } from 'vs/workbench/contrib/chat/browser/actions/chatQuickInputActions';
+import { IQuickChatService } from 'vs/workbench/contrib/chat/browser/chat';
 
 interface IAnythingQuickPickItem extends IPickerQuickAccessItem, IQuickPickItemWithResource { }
 
@@ -187,6 +187,8 @@ export class AnythingQuickAccessProvider extends PickerQuickAccessProvider<IAnyt
 		@ITextModelService private readonly textModelService: ITextModelService,
 		@IUriIdentityService private readonly uriIdentityService: IUriIdentityService,
 		@IQuickInputService private readonly quickInputService: IQuickInputService,
+		@IKeybindingService private readonly keybindingService: IKeybindingService,
+		@IQuickChatService private readonly quickChatService: IQuickChatService,
 	) {
 		super(AnythingQuickAccessProvider.PREFIX, {
 			canAcceptInBackground: true,
@@ -756,68 +758,54 @@ export class AnythingQuickAccessProvider extends PickerQuickAccessProvider<IAnyt
 
 	//#endregion
 
-	//#region Help (if enabled)
+	//#region Command Center (if enabled)
 
-	private helpQuickAccess = this.instantiationService.createInstance(HelpQuickAccessProvider);
+	private readonly lazyRegistry = new Lazy(() => Registry.as<IQuickAccessRegistry>(Extensions.Quickaccess));
 
 	private getHelpPicks(query: IPreparedQuery, token: CancellationToken, runOptions?: AnythingQuickAccessProviderRunOptions): IAnythingQuickPickItem[] {
 		if (query.normalized) {
 			return []; // If there's a filter, we don't show the help
 		}
 
-		type IHelpAnythingQuickPickItem = IAnythingQuickPickItem & { prefix: string };
-		const providers: Array<IHelpAnythingQuickPickItem> = this.helpQuickAccess.getQuickAccessProviders();
-		const mapOfProviders = new Map<string, IHelpAnythingQuickPickItem>();
-		for (const provider of providers) {
-			mapOfProviders.set(provider.prefix, provider);
+		type IHelpAnythingQuickPickItem = IAnythingQuickPickItem & { commandCenterOrder: number };
+		const providers: IHelpAnythingQuickPickItem[] = this.lazyRegistry.value.getQuickAccessProviders()
+			.filter(p => p.helpEntries.some(h => h.commandCenterOrder !== undefined))
+			.flatMap(provider => provider.helpEntries
+				.filter(h => h.commandCenterOrder !== undefined)
+				.map(helpEntry => {
+					const providerSpecificOptions: AnythingQuickAccessProviderRunOptions | undefined = {
+						...runOptions,
+						includeHelp: provider.prefix === AnythingQuickAccessProvider.PREFIX ? false : runOptions?.includeHelp
+					};
+
+					const label = helpEntry.commandCenterLabel ?? helpEntry.description!;
+					return {
+						label,
+						description: helpEntry.prefix ?? provider.prefix,
+						commandCenterOrder: helpEntry.commandCenterOrder!,
+						keybinding: helpEntry.commandId ? this.keybindingService.lookupKeybinding(helpEntry.commandId) : undefined,
+						ariaLabel: localize('helpPickAriaLabel', "{0}, {1}", label, helpEntry.description),
+						accept: () => {
+							this.quickInputService.quickAccess.show(provider.prefix, {
+								preserveValue: true,
+								providerOptions: providerSpecificOptions
+							});
+						}
+					};
+				}));
+
+		// TODO: There has to be a better place for this, but it's the first time we are adding a non-quick access provider
+		// to the command center, so for now, let's do this.
+		if (this.quickChatService.enabled) {
+			providers.push({
+				label: localize('chat', "Open Quick Chat"),
+				commandCenterOrder: 30,
+				keybinding: this.keybindingService.lookupKeybinding(ASK_QUICK_QUESTION_ACTION_ID),
+				accept: () => this.quickChatService.toggle()
+			});
 		}
 
-		const importantProviders: Array<IHelpAnythingQuickPickItem> = [];
-		const AddProvider = (prefix: string, modifications: Partial<IAnythingQuickPickItem> = {}) => {
-			if (mapOfProviders.has(prefix)) {
-				const provider = mapOfProviders.get(prefix)!;
-
-				// We swap the label and description in this to emphasize the ability
-				// not the prefix.
-				provider.label = provider.description!;
-				provider.description = provider.prefix;
-
-				// If the user chooses 'Go to File' the help should go away as if they were
-				// entering a new mode
-				const providerSpecificOptions: AnythingQuickAccessProviderRunOptions | undefined = {
-					...runOptions,
-					includeHelp: provider.prefix === AnythingQuickAccessProvider.PREFIX ? false : runOptions?.includeHelp
-				};
-
-				importantProviders.push({
-					...mapOfProviders.get(prefix)!,
-					...modifications,
-					accept: () => {
-						this.quickInputService.quickAccess.show(provider.prefix, {
-							preserveValue: true,
-							providerOptions: providerSpecificOptions
-						});
-					}
-				});
-			}
-		};
-
-		// TODO@TylerLeonhardt ideally this hardcoded list and hardcoded dependency moves
-		// into a provider model where when I register a quick access provider I can enlist
-		// for showing up in command center
-
-		// Acts as the ordering too
-		AddProvider(AnythingQuickAccessProvider.PREFIX);
-		AddProvider(CommandsQuickAccessProvider.PREFIX);
-		AddProvider(GotoSymbolQuickAccessProvider.PREFIX);
-		AddProvider(DEBUG_QUICK_ACCESS_PREFIX);
-		AddProvider(TasksQuickAccessProvider.PREFIX);
-		AddProvider(HelpQuickAccessProvider.PREFIX, {
-			// More concise
-			label: localize('more', 'More')
-		});
-
-		return importantProviders;
+		return providers.sort((a, b) => a.commandCenterOrder - b.commandCenterOrder);
 	}
 
 	//#endregion

--- a/src/vs/workbench/contrib/search/browser/search.contribution.ts
+++ b/src/vs/workbench/contrib/search/browser/search.contribution.ts
@@ -107,7 +107,11 @@ quickAccessRegistry.registerQuickAccessProvider({
 	prefix: AnythingQuickAccessProvider.PREFIX,
 	placeholder: nls.localize('anythingQuickAccessPlaceholder', "Search files by name (append {0} to go to line or {1} to go to symbol)", AbstractGotoLineQuickAccessProvider.PREFIX, GotoSymbolQuickAccessProvider.PREFIX),
 	contextKey: defaultQuickAccessContextKeyValue,
-	helpEntries: [{ description: nls.localize('anythingQuickAccess', "Go to File"), commandId: 'workbench.action.quickOpen' }]
+	helpEntries: [{
+		description: nls.localize('anythingQuickAccess', "Go to File"),
+		commandId: 'workbench.action.quickOpen',
+		commandCenterOrder: 10
+	}]
 });
 
 quickAccessRegistry.registerQuickAccessProvider({

--- a/src/vs/workbench/contrib/tasks/browser/task.contribution.ts
+++ b/src/vs/workbench/contrib/tasks/browser/task.contribution.ts
@@ -408,7 +408,7 @@ quickAccessRegistry.registerQuickAccessProvider({
 	prefix: TasksQuickAccessProvider.PREFIX,
 	contextKey: tasksPickerContextKey,
 	placeholder: nls.localize('tasksQuickAccessPlaceholder', "Type the name of a task to run."),
-	helpEntries: [{ description: nls.localize('tasksQuickAccessHelp', "Run Task") }]
+	helpEntries: [{ description: nls.localize('tasksQuickAccessHelp', "Run Task"), commandCenterOrder: 60 }]
 });
 
 // tasks.json validation


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Instead of the AnythingQuickAccess using the HelpQuickAccess and having to declare the order in that file, I've changed to model for the actual providers to say if and where it should be in the Command Center.

I should have done it like this in the first place... and it does make it easier to add Chat in the mix.

This PR also adds Quick Chat into the command center and makes the required changes to light that up.