### PR TITLE
Fix nested list style in Markdown preview

### DIFF
--- a/extensions/markdown-language-features/media/markdown.css
+++ b/extensions/markdown-language-features/media/markdown.css
@@ -106,10 +106,10 @@ sup {
 	line-height: 0;
 }
 
-ul ul,
-ul ol,
-ol ul,
-ol ol {
+ul ul:first-child,
+ul ol:first-child,
+ol ul:first-child,
+ol ol:first-child {
 	margin-bottom: 0;
 }
 
@@ -136,6 +136,10 @@ textarea:focus {
 
 p {
 	margin-bottom: 16px;
+}
+
+li p {
+	margin-bottom: 0.7em;
 }
 
 ul,


### PR DESCRIPTION
fix #190860 

There could be two cases for nested list:

```markdown
- a
  - b
- c
```

renders into

```html
<ul>
 <li>a
   <ul><li>b</li></ul>
 </li>
 <li>c</li>
</ul>
```

---

```markdown
- a
  - b

  some text
- c
```
renders into
```html
<ul>
 <li><p>a</p>
   <ul><li>b</li></ul>
   <p>some text</p>
 </li>
 <li><p>c</p></li>
</ul>
```

---

PR #124445 fixed the first case, but did not take the second case into consideration. This PR carries the following modification:
 1. Instead of setting all `ul ul` with `margin-bottom: 0`, we set only `ul ul:first-child`, which should match exactly the first case;
 2. For the second case, we keep the `margin-bottom` of nested ul/ol, and further, we adjust `li p`'s `margin-bottom` to `0.7em`, which is the same as that of ul/ol and makes the style more consistent.