### PR TITLE
Add `markdown.preview.focusOnOpenToSide` setting (#190940)

### DIFF
--- a/extensions/markdown-language-features/package.json
+++ b/extensions/markdown-language-features/package.json
@@ -378,6 +378,12 @@
           "description": "%markdown.preview.doubleClickToSwitchToEditor.desc%",
           "scope": "resource"
         },
+        "markdown.preview.focusOnOpen": {
+          "type": "boolean",
+          "default": true,
+          "description": "%markdown.preview.focusOnOpen.desc%",
+          "scope": "resource"
+        },
         "markdown.preview.openMarkdownLinks": {
           "type": "string",
           "default": "inPreview",

--- a/extensions/markdown-language-features/package.json
+++ b/extensions/markdown-language-features/package.json
@@ -378,10 +378,10 @@
           "description": "%markdown.preview.doubleClickToSwitchToEditor.desc%",
           "scope": "resource"
         },
-        "markdown.preview.focusOnOpen": {
+        "markdown.preview.focusOnOpenToSide": {
           "type": "boolean",
           "default": true,
-          "description": "%markdown.preview.focusOnOpen.desc%",
+          "description": "%markdown.preview.focusOnOpenToSide.desc%",
           "scope": "resource"
         },
         "markdown.preview.openMarkdownLinks": {

--- a/extensions/markdown-language-features/package.nls.json
+++ b/extensions/markdown-language-features/package.nls.json
@@ -6,6 +6,7 @@
 	"markdown.preview.linkify": "Convert URL-like text to links in the Markdown preview.",
 	"markdown.preview.typographer": "Enable some language-neutral replacement and quotes beautification in the Markdown preview.",
 	"markdown.preview.doubleClickToSwitchToEditor.desc": "Double-click in the Markdown preview to switch to the editor.",
+	"markdown.preview.focusOnOpen.desc": "Focus on the Markdown preview after opening it.",
 	"markdown.preview.fontFamily.desc": "Controls the font family used in the Markdown preview.",
 	"markdown.preview.fontSize.desc": "Controls the font size in pixels used in the Markdown preview.",
 	"markdown.preview.lineHeight.desc": "Controls the line height used in the Markdown preview. This number is relative to the font size.",

--- a/extensions/markdown-language-features/package.nls.json
+++ b/extensions/markdown-language-features/package.nls.json
@@ -6,7 +6,7 @@
 	"markdown.preview.linkify": "Convert URL-like text to links in the Markdown preview.",
 	"markdown.preview.typographer": "Enable some language-neutral replacement and quotes beautification in the Markdown preview.",
 	"markdown.preview.doubleClickToSwitchToEditor.desc": "Double-click in the Markdown preview to switch to the editor.",
-	"markdown.preview.focusOnOpen.desc": "Focus on the Markdown preview after opening it.",
+	"markdown.preview.focusOnOpenToSide.desc": "Focus on the Markdown preview after opening it to the side.",
 	"markdown.preview.fontFamily.desc": "Controls the font family used in the Markdown preview.",
 	"markdown.preview.fontSize.desc": "Controls the font size in pixels used in the Markdown preview.",
 	"markdown.preview.lineHeight.desc": "Controls the line height used in the Markdown preview. This number is relative to the font size.",

--- a/extensions/markdown-language-features/src/preview/preview.ts
+++ b/extensions/markdown-language-features/src/preview/preview.ts
@@ -605,10 +605,11 @@ export class DynamicMarkdownPreview extends Disposable implements IManagedMarkdo
 		contributionProvider: MarkdownContributionProvider,
 		opener: MdLinkOpener,
 	): DynamicMarkdownPreview {
+		const preserveFocus = !vscode.workspace.getConfiguration('markdown.preview', input.resource).get<boolean>('focusOnOpen');
 		const webview = vscode.window.createWebviewPanel(
 			DynamicMarkdownPreview.viewType,
 			DynamicMarkdownPreview._getPreviewTitle(input.resource, input.locked),
-			previewColumn, { enableFindWidget: true, });
+			{ viewColumn: previewColumn, preserveFocus }, { enableFindWidget: true, });
 
 		webview.iconPath = contentProvider.iconPath;
 

--- a/extensions/markdown-language-features/src/preview/preview.ts
+++ b/extensions/markdown-language-features/src/preview/preview.ts
@@ -605,7 +605,7 @@ export class DynamicMarkdownPreview extends Disposable implements IManagedMarkdo
 		contributionProvider: MarkdownContributionProvider,
 		opener: MdLinkOpener,
 	): DynamicMarkdownPreview {
-		const preserveFocus = !vscode.workspace.getConfiguration('markdown.preview', input.resource).get<boolean>('focusOnOpen');
+		const preserveFocus = previewColumn === vscode.ViewColumn.Beside && !vscode.workspace.getConfiguration('markdown.preview', input.resource).get<boolean>('focusOnOpenToSide');
 		const webview = vscode.window.createWebviewPanel(
 			DynamicMarkdownPreview.viewType,
 			DynamicMarkdownPreview._getPreviewTitle(input.resource, input.locked),


### PR DESCRIPTION
This PR closes #190940 by adding a new `markdown.preview.focusOnOpenToSide` setting.

![image](https://github.com/microsoft/vscode/assets/6726799/d8704054-eff9-4ef5-bd8b-ddf8ac0b4a18)

This defaults to `true` so existing behaviour is retained.

It intentionally only affects what happens when a to-the-side Markdown preview is initially opened. This means that for keyboard users who set this `false` their first entry of Ctrl+K V on a Markdown document will open the preview to the side without shifting focus there, but using that keycombo again will shift focus.