### PR TITLE
Unicode codepoint 0x202E causes the default filename in the tab title to also be right to left (fix #190133)

### DIFF
--- a/src/vs/workbench/services/untitled/common/untitledTextEditorModel.ts
+++ b/src/vs/workbench/services/untitled/common/untitledTextEditorModel.ts
@@ -419,7 +419,8 @@ export class UntitledTextEditorModel extends BaseTextEditorModel implements IUnt
 				startColumn: 1,
 				endColumn: UntitledTextEditorModel.FIRST_LINE_NAME_CANDIDATE_MAX_LENGTH + 1		// first cap at FIRST_LINE_NAME_CANDIDATE_MAX_LENGTH
 			})
-			.trim().replace(/\s+/g, ' '); 														// normalize whitespaces
+			.trim().replace(/\s+/g, ' ') 														// normalize whitespaces
+			.replace(/\u202E/g, '');															// drop Right-to-Left Override character (#190133)
 		firstLineText = firstLineText.substr(0, getCharContainingOffset(						// finally cap at FIRST_LINE_NAME_MAX_LENGTH (grapheme aware #111235)
 			firstLineText,
 			UntitledTextEditorModel.FIRST_LINE_NAME_MAX_LENGTH)[0]

--- a/src/vs/workbench/services/untitled/test/browser/untitledTextEditor.test.ts
+++ b/src/vs/workbench/services/untitled/test/browser/untitledTextEditor.test.ts
@@ -542,10 +542,14 @@ suite('Untitled text editors', () => {
 		assert.strictEqual(input.getName(), '123456789012345678901234567890123456789');
 		assert.strictEqual(model.name, '123456789012345678901234567890123456789');
 
-		assert.strictEqual(counter, 6);
+		model.textEditorModel?.setValue('hello\u202Eworld'); // do not allow RTL in names (#190133)
+		assert.strictEqual(input.getName(), 'helloworld');
+		assert.strictEqual(model.name, 'helloworld');
+
+		assert.strictEqual(counter, 7);
 
 		model.textEditorModel?.setValue('Hello\nWorld');
-		assert.strictEqual(counter, 7);
+		assert.strictEqual(counter, 8);
 
 		function createSingleEditOp(text: string, positionLineNumber: number, positionColumn: number, selectionLineNumber: number = positionLineNumber, selectionColumn: number = positionColumn): ISingleEditOperation {
 			const range = new Range(
@@ -563,7 +567,7 @@ suite('Untitled text editors', () => {
 		}
 
 		model.textEditorModel?.applyEdits([createSingleEditOp('hello', 2, 2)]);
-		assert.strictEqual(counter, 7); // change was not on first line
+		assert.strictEqual(counter, 8); // change was not on first line
 
 		input.dispose();
 		model.dispose();


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
