### PR TITLE
fix: add command API for setting active debug session by ID

### DIFF
--- a/src/vs/workbench/api/common/extHostApiCommands.ts
+++ b/src/vs/workbench/api/common/extHostApiCommands.ts
@@ -390,6 +390,13 @@ const newCommands: ApiCommand[] = [
 			return result.map(typeConverters.InlineValue.to);
 		})
 	),
+
+	new ApiCommand(
+		'debug.debugSessionFocus', '_debugSessionFocus', 'Set the active debug session',
+		[ApiCommandArgument.String],
+		ApiCommandResult.Void
+	),
+
 	// --- open'ish commands
 	new ApiCommand(
 		'vscode.open', '_workbench.open', 'Opens the provided resource in the editor. Can be a text or binary file, or an http(s) URL. If you need more control over the options for opening a text file, use vscode.window.showTextDocument instead.',

--- a/src/vs/workbench/contrib/debug/browser/debugCommands.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugCommands.ts
@@ -72,6 +72,7 @@ export const CALLSTACK_TOP_ID = 'workbench.action.debug.callStackTop';
 export const CALLSTACK_BOTTOM_ID = 'workbench.action.debug.callStackBottom';
 export const CALLSTACK_UP_ID = 'workbench.action.debug.callStackUp';
 export const CALLSTACK_DOWN_ID = 'workbench.action.debug.callStackDown';
+export const INTERNAL_SET_SESSION_FOCUS_ID = '_debugSessionFocus';
 
 export const DEBUG_COMMAND_CATEGORY: ILocalizedString = { original: 'Debug', value: nls.localize('debug', 'Debug') };
 export const RESTART_LABEL = { value: nls.localize('restartDebug', "Restart"), original: 'Restart' };
@@ -1022,3 +1023,18 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 		await paneCompositeService.openPaneComposite(VIEWLET_ID, ViewContainerLocation.Sidebar, true);
 	}
 });
+
+
+CommandsRegistry.registerCommand({
+	id: INTERNAL_SET_SESSION_FOCUS_ID,
+	handler: async (accessor: ServicesAccessor, sessionId: string) => {
+		const debugService = accessor.get(IDebugService);
+		const commandService = accessor.get(ICommandService);
+		const session = debugService.getModel().getSession(sessionId);
+		if (session) {
+			return commandService.executeCommand(FOCUS_SESSION_ID, session);
+		}
+		return undefined;
+	}
+});
+


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Adding a Built-In Command to allow setting of the active debug session by ID.

command id: 
debug.debugSessionFocus

command args 
sessionId: string

command return value: 
void 


This would allow me to mostly workaround issue #190973 
https://github.com/microsoft/vscode/issues/190973


I did not see another example of a debug-related built-in command.
Would have liked to return the session, if successful, but didn't see how to do that easily?
(perhaps it should return a boolean?)