### PR TITLE
Turning off sticky scroll when model is too large for tokenization

### DIFF
--- a/src/vs/editor/contrib/stickyScroll/browser/stickyScrollController.ts
+++ b/src/vs/editor/contrib/stickyScroll/browser/stickyScrollController.ts
@@ -370,7 +370,6 @@ export class StickyScrollController extends Disposable implements IEditorContrib
 
 	private _readConfiguration() {
 		const options = this._editor.getOption(EditorOption.stickyScroll);
-
 		if (options.enabled === false) {
 			this._editor.removeOverlayWidget(this._stickyScrollWidget);
 			this._sessionStore.clear();
@@ -429,10 +428,10 @@ export class StickyScrollController extends Disposable implements IEditorContrib
 	}
 
 	private _renderStickyScroll() {
-		if (!(this._editor.hasModel())) {
+		const model = this._editor.getModel();
+		if (!model || model.isTooLargeForTokenization()) {
 			return;
 		}
-		const model = this._editor.getModel();
 		const stickyLineVersion = this._stickyLineCandidateProvider.getVersionId();
 		if (stickyLineVersion === undefined || stickyLineVersion === model.getVersionId()) {
 			this._widgetState = this.findScrollWidgetState();

--- a/src/vs/editor/contrib/stickyScroll/browser/stickyScrollController.ts
+++ b/src/vs/editor/contrib/stickyScroll/browser/stickyScrollController.ts
@@ -430,6 +430,7 @@ export class StickyScrollController extends Disposable implements IEditorContrib
 	private _renderStickyScroll() {
 		const model = this._editor.getModel();
 		if (!model || model.isTooLargeForTokenization()) {
+			this._stickyScrollWidget.setState(undefined);
 			return;
 		}
 		const stickyLineVersion = this._stickyLineCandidateProvider.getVersionId();

--- a/src/vs/editor/contrib/stickyScroll/browser/stickyScrollWidget.ts
+++ b/src/vs/editor/contrib/stickyScroll/browser/stickyScrollWidget.ts
@@ -99,9 +99,11 @@ export class StickyScrollWidget extends Disposable implements IOverlayWidget {
 		return this._lineNumbers;
 	}
 
-	setState(state: StickyScrollWidgetState): void {
-		dom.clearNode(this._lineNumbersDomNode);
-		dom.clearNode(this._linesDomNode);
+	setState(state: StickyScrollWidgetState | undefined): void {
+		this._clearStickyWidget();
+		if (!state) {
+			return;
+		}
 		this._stickyLines = [];
 		const editorLineHeight = this._editor.getOption(EditorOption.lineHeight);
 		const futureWidgetHeight = state.startLineNumbers.length * editorLineHeight + state.lastLineRelativePosition;
@@ -129,6 +131,12 @@ export class StickyScrollWidget extends Disposable implements IOverlayWidget {
 		this._rootDomNode.style.width = `${layoutInfo.width - layoutInfo.minimap.minimapCanvasOuterWidth - layoutInfo.verticalScrollbarWidth}px`;
 	}
 
+	private _clearStickyWidget() {
+		dom.clearNode(this._lineNumbersDomNode);
+		dom.clearNode(this._linesDomNode);
+		this._rootDomNode.style.display = 'none';
+	}
+
 	private _renderRootNode(): void {
 
 		if (!this._editor._getViewModel()) {
@@ -145,7 +153,11 @@ export class StickyScrollWidget extends Disposable implements IOverlayWidget {
 
 		const editorLineHeight = this._editor.getOption(EditorOption.lineHeight);
 		const widgetHeight: number = this._lineNumbers.length * editorLineHeight + this._lastLineRelativePosition;
-		this._rootDomNode.style.display = widgetHeight > 0 ? 'block' : 'none';
+		if (widgetHeight === 0) {
+			this._clearStickyWidget();
+			return;
+		}
+		this._rootDomNode.style.display = 'block';
 		this._lineNumbersDomNode.style.height = `${widgetHeight}px`;
 		this._linesDomNodeScrollable.style.height = `${widgetHeight}px`;
 		this._rootDomNode.style.height = `${widgetHeight}px`;

--- a/src/vs/workbench/contrib/codeEditor/browser/largeFileOptimizations.ts
+++ b/src/vs/workbench/contrib/codeEditor/browser/largeFileOptimizations.ts
@@ -44,7 +44,7 @@ export class LargeFileOptimizationsWarner extends Disposable implements IEditorC
 						'Variable 0 will be a file name.'
 					]
 				},
-				"{0}: tokenization, wrapping and folding have been turned off for this large file in order to reduce memory usage and avoid freezing or crashing.",
+				"{0}: tokenization, wrapping, folding and sticky scroll have been turned off for this large file in order to reduce memory usage and avoid freezing or crashing.",
 				path.basename(model.uri.path)
 			);
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/191064