### PR TITLE
tunnels: implement default port forwarding for managed RA's

### DIFF
--- a/src/vs/platform/remote/common/managedSocket.ts
+++ b/src/vs/platform/remote/common/managedSocket.ts
@@ -4,6 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { VSBuffer, encodeBase64 } from 'vs/base/common/buffer';
+import { Emitter, Event, PauseableEmitter } from 'vs/base/common/event';
+import { Disposable, DisposableStore } from 'vs/base/common/lifecycle';
+import { ISocket, SocketCloseEvent, SocketDiagnostics, SocketDiagnosticsEventType } from 'vs/base/parts/ipc/common/ipc.net';
 
 export const makeRawSocketHeaders = (path: string, query: string, deubgLabel: string) => {
 	// https://tools.ietf.org/html/rfc6455#section-4
@@ -24,3 +27,119 @@ export const makeRawSocketHeaders = (path: string, query: string, deubgLabel: st
 };
 
 export const socketRawEndHeaderSequence = VSBuffer.fromString('\r\n\r\n');
+
+export interface RemoteSocketHalf {
+	onData: Emitter<VSBuffer>;
+	onClose: Emitter<SocketCloseEvent>;
+	onEnd: Emitter<void>;
+}
+
+/** Should be called immediately after making a ManagedSocket to make it ready for data flow. */
+export async function connectManagedSocket<T extends ManagedSocket>(
+	socket: T,
+	path: string, query: string, debugLabel: string,
+	half: RemoteSocketHalf
+): Promise<T> {
+	socket.write(VSBuffer.fromString(makeRawSocketHeaders(path, query, debugLabel)));
+
+	const d = new DisposableStore();
+	try {
+		return await new Promise<T>((resolve, reject) => {
+			let dataSoFar: VSBuffer | undefined;
+			d.add(socket.onData(d_1 => {
+				if (!dataSoFar) {
+					dataSoFar = d_1;
+				} else {
+					dataSoFar = VSBuffer.concat([dataSoFar, d_1], dataSoFar.byteLength + d_1.byteLength);
+				}
+
+				const index = dataSoFar.indexOf(socketRawEndHeaderSequence);
+				if (index === -1) {
+					return;
+				}
+
+				resolve(socket);
+				// pause data events until the socket consumer is hooked up. We may
+				// immediately emit remaining data, but if not there may still be
+				// microtasks queued which would fire data into the abyss.
+				socket.pauseData();
+
+				const rest = dataSoFar.slice(index + socketRawEndHeaderSequence.byteLength);
+				if (rest.byteLength) {
+					half.onData.fire(rest);
+				}
+			}));
+
+			d.add(socket.onClose(err => reject(err ?? new Error('socket closed'))));
+			d.add(socket.onEnd(() => reject(new Error('socket ended'))));
+		});
+	} catch (e) {
+		socket.dispose();
+		throw e;
+	} finally {
+		d.dispose();
+	}
+}
+
+export abstract class ManagedSocket extends Disposable implements ISocket {
+	private readonly pausableDataEmitter = this._register(new PauseableEmitter<VSBuffer>());
+
+	public onData: Event<VSBuffer> = (...args) => {
+		if (this.pausableDataEmitter.isPaused) {
+			queueMicrotask(() => this.pausableDataEmitter.resume());
+		}
+		return this.pausableDataEmitter.event(...args);
+	};
+	public onClose: Event<SocketCloseEvent>;
+	public onEnd: Event<void>;
+
+	private readonly didDisposeEmitter = this._register(new Emitter<void>());
+	public onDidDispose = this.didDisposeEmitter.event;
+
+	private ended = false;
+
+	protected constructor(
+		private readonly debugLabel: string,
+		half: RemoteSocketHalf,
+	) {
+		super();
+
+		this._register(half.onData);
+		this._register(half.onData.event(data => this.pausableDataEmitter.fire(data)));
+
+		this.onClose = this._register(half.onClose).event;
+		this.onEnd = this._register(half.onEnd).event;
+	}
+
+	/** Pauses data events until a new listener comes in onData() */
+	public pauseData() {
+		this.pausableDataEmitter.pause();
+	}
+
+	/** Flushes data to the socket. */
+	public drain(): Promise<void> {
+		return Promise.resolve();
+	}
+
+	/** Ends the remote socket. */
+	public end(): void {
+		this.ended = true;
+		this.closeRemote();
+	}
+
+	public abstract write(buffer: VSBuffer): void;
+	protected abstract closeRemote(): void;
+
+	traceSocketEvent(type: SocketDiagnosticsEventType, data?: any): void {
+		SocketDiagnostics.traceSocketEvent(this, this.debugLabel, type, data);
+	}
+
+	override dispose(): void {
+		if (!this.ended) {
+			this.closeRemote();
+		}
+
+		this.didDisposeEmitter.fire();
+		super.dispose();
+	}
+}

--- a/src/vs/platform/tunnel/node/tunnelService.ts
+++ b/src/vs/platform/tunnel/node/tunnelService.ts
@@ -9,15 +9,17 @@ import { BROWSER_RESTRICTED_PORTS, findFreePortFaster } from 'vs/base/node/ports
 import { NodeSocket } from 'vs/base/parts/ipc/node/ipc.net';
 
 import { Barrier } from 'vs/base/common/async';
+import { VSBuffer } from 'vs/base/common/buffer';
 import { Disposable } from 'vs/base/common/lifecycle';
+import { OS } from 'vs/base/common/platform';
+import { ISocket } from 'vs/base/parts/ipc/common/ipc.net';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { ILogService } from 'vs/platform/log/common/log';
 import { IProductService } from 'vs/platform/product/common/productService';
-import { connectRemoteAgentTunnel, IAddressProvider, IConnectionOptions } from 'vs/platform/remote/common/remoteAgentConnection';
-import { AbstractTunnelService, isAllInterfaces, ISharedTunnelsService as ISharedTunnelsService, isLocalhost, isPortPrivileged, isTunnelProvider, ITunnelProvider, ITunnelService, RemoteTunnel, TunnelPrivacyId } from 'vs/platform/tunnel/common/tunnel';
-import { ISignService } from 'vs/platform/sign/common/sign';
-import { OS } from 'vs/base/common/platform';
+import { IAddressProvider, IConnectionOptions, connectRemoteAgentTunnel } from 'vs/platform/remote/common/remoteAgentConnection';
 import { IRemoteSocketFactoryService } from 'vs/platform/remote/common/remoteSocketFactoryService';
+import { ISignService } from 'vs/platform/sign/common/sign';
+import { AbstractTunnelService, ISharedTunnelsService, ITunnelProvider, ITunnelService, RemoteTunnel, TunnelPrivacyId, isAllInterfaces, isLocalhost, isPortPrivileged, isTunnelProvider } from 'vs/platform/tunnel/common/tunnel';
 
 async function createRemoteTunnel(options: IConnectionOptions, defaultTunnelHost: string, tunnelRemoteHost: string, tunnelRemotePort: number, tunnelLocalPort?: number): Promise<RemoteTunnel> {
 	let readyTunnel: NodeRemoteTunnel | undefined;
@@ -32,7 +34,7 @@ async function createRemoteTunnel(options: IConnectionOptions, defaultTunnelHost
 	return readyTunnel!;
 }
 
-class NodeRemoteTunnel extends Disposable implements RemoteTunnel {
+export class NodeRemoteTunnel extends Disposable implements RemoteTunnel {
 
 	public readonly tunnelRemotePort: number;
 	public tunnelLocalPort!: number;
@@ -113,7 +115,7 @@ class NodeRemoteTunnel extends Disposable implements RemoteTunnel {
 
 		const tunnelRemoteHost = (isLocalhost(this.tunnelRemoteHost) || isAllInterfaces(this.tunnelRemoteHost)) ? 'localhost' : this.tunnelRemoteHost;
 		const protocol = await connectRemoteAgentTunnel(this._options, tunnelRemoteHost, this.tunnelRemotePort);
-		const remoteSocket = (<NodeSocket>protocol.getSocket()).socket;
+		const remoteSocket = protocol.getSocket();
 		const dataChunk = protocol.readEntireBuffer();
 		protocol.dispose();
 
@@ -132,17 +134,15 @@ class NodeRemoteTunnel extends Disposable implements RemoteTunnel {
 			if (localSocket.localAddress) {
 				this._socketsDispose.delete(localSocket.localAddress);
 			}
-			remoteSocket.destroy();
+			remoteSocket.end();
 		});
 
-		remoteSocket.on('end', () => localSocket.end());
-		remoteSocket.on('close', () => localSocket.end());
-		remoteSocket.on('error', () => {
-			localSocket.destroy();
-		});
+		if (remoteSocket instanceof NodeSocket) {
+			this._mirrorNodeSocket(localSocket, remoteSocket);
+		} else {
+			this._mirrorGenericSocket(localSocket, remoteSocket);
+		}
 
-		localSocket.pipe(remoteSocket);
-		remoteSocket.pipe(localSocket);
 		if (localSocket.localAddress) {
 			this._socketsDispose.set(localSocket.localAddress, () => {
 				// Need to end instead of unpipe, otherwise whatever is connected locally could end up "stuck" with whatever state it had until manually exited.
@@ -150,6 +150,26 @@ class NodeRemoteTunnel extends Disposable implements RemoteTunnel {
 				remoteSocket.end();
 			});
 		}
+	}
+
+	private _mirrorGenericSocket(localSocket: net.Socket, remoteSocket: ISocket) {
+		remoteSocket.onClose(() => localSocket.destroy());
+		remoteSocket.onEnd(() => localSocket.end());
+		remoteSocket.onData(d => localSocket.write(d.buffer));
+
+		localSocket.on('end', () => remoteSocket.end());
+		localSocket.on('close', () => remoteSocket.dispose());
+		localSocket.on('data', d => remoteSocket.write(VSBuffer.wrap(d)));
+		localSocket.resume();
+	}
+
+	private _mirrorNodeSocket(localSocket: net.Socket, remoteNodeSocket: NodeSocket) {
+		const remoteSocket = remoteNodeSocket.socket;
+		remoteSocket.on('end', () => localSocket.end());
+		remoteSocket.on('close', () => localSocket.end());
+		remoteSocket.on('error', () => {
+			localSocket.destroy();
+		});
 	}
 }
 

--- a/src/vs/platform/tunnel/node/tunnelService.ts
+++ b/src/vs/platform/tunnel/node/tunnelService.ts
@@ -134,7 +134,11 @@ export class NodeRemoteTunnel extends Disposable implements RemoteTunnel {
 			if (localSocket.localAddress) {
 				this._socketsDispose.delete(localSocket.localAddress);
 			}
-			remoteSocket.end();
+			if (remoteSocket instanceof NodeSocket) {
+				remoteSocket.socket.destroy();
+			} else {
+				remoteSocket.end();
+			}
 		});
 
 		if (remoteSocket instanceof NodeSocket) {
@@ -156,10 +160,6 @@ export class NodeRemoteTunnel extends Disposable implements RemoteTunnel {
 		remoteSocket.onClose(() => localSocket.destroy());
 		remoteSocket.onEnd(() => localSocket.end());
 		remoteSocket.onData(d => localSocket.write(d.buffer));
-
-		localSocket.on('end', () => remoteSocket.end());
-		localSocket.on('close', () => remoteSocket.dispose());
-		localSocket.on('data', d => remoteSocket.write(VSBuffer.wrap(d)));
 		localSocket.resume();
 	}
 

--- a/src/vs/platform/tunnel/node/tunnelService.ts
+++ b/src/vs/platform/tunnel/node/tunnelService.ts
@@ -9,7 +9,6 @@ import { BROWSER_RESTRICTED_PORTS, findFreePortFaster } from 'vs/base/node/ports
 import { NodeSocket } from 'vs/base/parts/ipc/node/ipc.net';
 
 import { Barrier } from 'vs/base/common/async';
-import { VSBuffer } from 'vs/base/common/buffer';
 import { Disposable } from 'vs/base/common/lifecycle';
 import { OS } from 'vs/base/common/platform';
 import { ISocket } from 'vs/base/parts/ipc/common/ipc.net';

--- a/src/vs/platform/tunnel/node/tunnelService.ts
+++ b/src/vs/platform/tunnel/node/tunnelService.ts
@@ -170,6 +170,9 @@ export class NodeRemoteTunnel extends Disposable implements RemoteTunnel {
 		remoteSocket.on('error', () => {
 			localSocket.destroy();
 		});
+
+		remoteSocket.pipe(localSocket);
+		localSocket.pipe(remoteSocket);
 	}
 }
 

--- a/src/vs/workbench/api/browser/mainThreadManagedSockets.ts
+++ b/src/vs/workbench/api/browser/mainThreadManagedSockets.ts
@@ -3,15 +3,15 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { MainContext, ExtHostContext, MainThreadManagedSocketsShape, ExtHostManagedSocketsShape } from 'vs/workbench/api/common/extHost.protocol';
-import { extHostNamedCustomer, IExtHostContext } from 'vs/workbench/services/extensions/common/extHostCustomers';
-import { Disposable, DisposableStore, IDisposable } from 'vs/base/common/lifecycle';
-import { ManagedRemoteConnection, RemoteConnectionType } from 'vs/platform/remote/common/remoteAuthorityResolver';
 import { VSBuffer } from 'vs/base/common/buffer';
+import { Emitter } from 'vs/base/common/event';
+import { Disposable, IDisposable } from 'vs/base/common/lifecycle';
+import { ISocket, SocketCloseEventType } from 'vs/base/parts/ipc/common/ipc.net';
+import { ManagedSocket, RemoteSocketHalf, connectManagedSocket } from 'vs/platform/remote/common/managedSocket';
+import { ManagedRemoteConnection, RemoteConnectionType } from 'vs/platform/remote/common/remoteAuthorityResolver';
 import { IRemoteSocketFactoryService, ISocketFactory } from 'vs/platform/remote/common/remoteSocketFactoryService';
-import { ISocket, SocketCloseEvent, SocketCloseEventType, SocketDiagnostics, SocketDiagnosticsEventType } from 'vs/base/parts/ipc/common/ipc.net';
-import { Emitter, Event, PauseableEmitter } from 'vs/base/common/event';
-import { makeRawSocketHeaders, socketRawEndHeaderSequence } from 'vs/platform/remote/common/managedSocket';
+import { ExtHostContext, ExtHostManagedSocketsShape, MainContext, MainThreadManagedSocketsShape } from 'vs/workbench/api/common/extHost.protocol';
+import { IExtHostContext, extHostNamedCustomer } from 'vs/workbench/services/extensions/common/extHostCustomers';
 
 @extHostNamedCustomer(MainContext.MainThreadManagedSockets)
 export class MainThreadManagedSockets extends Disposable implements MainThreadManagedSocketsShape {
@@ -51,7 +51,7 @@ export class MainThreadManagedSockets extends Disposable implements MainThreadMa
 						};
 						that._remoteSockets.set(socketId, half);
 
-						ManagedSocket.connect(socketId, that._proxy, path, query, debugLabel, half)
+						MainThreadManagedSocket.connect(socketId, that._proxy, path, query, debugLabel, half)
 							.then(
 								socket => {
 									socket.onDidDispose(() => that._remoteSockets.delete(socketId));
@@ -91,117 +91,35 @@ export class MainThreadManagedSockets extends Disposable implements MainThreadMa
 	}
 }
 
-export interface RemoteSocketHalf {
-	onData: Emitter<VSBuffer>;
-	onClose: Emitter<SocketCloseEvent>;
-	onEnd: Emitter<void>;
-}
-
-export class ManagedSocket extends Disposable implements ISocket {
+class MainThreadManagedSocket extends ManagedSocket {
 	public static connect(
 		socketId: number,
 		proxy: ExtHostManagedSocketsShape,
 		path: string, query: string, debugLabel: string,
-
 		half: RemoteSocketHalf
-	): Promise<ManagedSocket> {
-		const socket = new ManagedSocket(socketId, proxy, debugLabel, half.onClose, half.onData, half.onEnd);
-
-		socket.write(VSBuffer.fromString(makeRawSocketHeaders(path, query, debugLabel)));
-
-		const d = new DisposableStore();
-		return new Promise<ManagedSocket>((resolve, reject) => {
-			let dataSoFar: VSBuffer | undefined;
-			d.add(socket.onData(d => {
-				if (!dataSoFar) {
-					dataSoFar = d;
-				} else {
-					dataSoFar = VSBuffer.concat([dataSoFar, d], dataSoFar.byteLength + d.byteLength);
-				}
-
-				const index = dataSoFar.indexOf(socketRawEndHeaderSequence);
-				if (index === -1) {
-					return;
-				}
-
-				resolve(socket);
-				// pause data events until the socket consumer is hooked up. We may
-				// immediately emit remaining data, but if not there may still be
-				// microtasks queued which would fire data into the abyss.
-				socket.pauseData();
-
-				const rest = dataSoFar.slice(index + socketRawEndHeaderSequence.byteLength);
-				if (rest.byteLength) {
-					half.onData.fire(rest);
-				}
-			}));
-
-			d.add(socket.onClose(err => reject(err ?? new Error('socket closed'))));
-			d.add(socket.onEnd(() => reject(new Error('socket ended'))));
-		}).finally(() => d.dispose());
+	): Promise<MainThreadManagedSocket> {
+		const socket = new MainThreadManagedSocket(socketId, proxy, debugLabel, half);
+		return connectManagedSocket(socket, path, query, debugLabel, half);
 	}
-
-	private readonly pausableDataEmitter = this._register(new PauseableEmitter<VSBuffer>());
-
-	public onData: Event<VSBuffer> = (...args) => {
-		if (this.pausableDataEmitter.isPaused) {
-			queueMicrotask(() => this.pausableDataEmitter.resume());
-		}
-		return this.pausableDataEmitter.event(...args);
-	};
-	public onClose: Event<SocketCloseEvent>;
-	public onEnd: Event<void>;
-
-	private readonly didDisposeEmitter = this._register(new Emitter<void>());
-	public onDidDispose = this.didDisposeEmitter.event;
-
-	private ended = false;
 
 	private constructor(
 		private readonly socketId: number,
 		private readonly proxy: ExtHostManagedSocketsShape,
-		private readonly debugLabel: string,
-		onCloseEmitter: Emitter<SocketCloseEvent>,
-		onDataEmitter: Emitter<VSBuffer>,
-		onEndEmitter: Emitter<void>,
+		debugLabel: string,
+		half: RemoteSocketHalf,
 	) {
-		super();
-
-		this._register(onDataEmitter);
-		this._register(onDataEmitter.event(data => this.pausableDataEmitter.fire(data)));
-
-		this.onClose = this._register(onCloseEmitter).event;
-		this.onEnd = this._register(onEndEmitter).event;
+		super(debugLabel, half);
 	}
 
-	/** Pauses data events until a new listener comes in onData() */
-	pauseData() {
-		this.pausableDataEmitter.pause();
-	}
-
-	write(buffer: VSBuffer): void {
+	public override write(buffer: VSBuffer): void {
 		this.proxy.$remoteSocketWrite(this.socketId, buffer);
 	}
 
-	end(): void {
-		this.ended = true;
+	protected override  closeRemote(): void {
 		this.proxy.$remoteSocketEnd(this.socketId);
 	}
 
-	drain(): Promise<void> {
+	public override drain(): Promise<void> {
 		return this.proxy.$remoteSocketDrain(this.socketId);
-	}
-
-	traceSocketEvent(type: SocketDiagnosticsEventType, data?: any): void {
-		SocketDiagnostics.traceSocketEvent(this, this.debugLabel, type, data);
-	}
-
-	override dispose(): void {
-		if (!this.ended) {
-			this.proxy.$remoteSocketEnd(this.socketId);
-		}
-
-		this.didDisposeEmitter.fire();
-		super.dispose();
 	}
 }

--- a/src/vs/workbench/api/browser/mainThreadManagedSockets.ts
+++ b/src/vs/workbench/api/browser/mainThreadManagedSockets.ts
@@ -91,7 +91,7 @@ export class MainThreadManagedSockets extends Disposable implements MainThreadMa
 	}
 }
 
-class MainThreadManagedSocket extends ManagedSocket {
+export class MainThreadManagedSocket extends ManagedSocket {
 	public static connect(
 		socketId: number,
 		proxy: ExtHostManagedSocketsShape,

--- a/src/vs/workbench/api/common/extHostExtensionService.ts
+++ b/src/vs/workbench/api/common/extHostExtensionService.ts
@@ -861,9 +861,11 @@ export abstract class AbstractExtHostExtensionService extends Disposable impleme
 					performance.mark(`code/extHost/willResolveAuthority/${authorityPrefix}`);
 					result = await resolver.resolve(remoteAuthority, { resolveAttempt, execServer });
 					performance.mark(`code/extHost/didResolveAuthorityOK/${authorityPrefix}`);
-					// todo@connor4312: we probably need to chain tunnels too, how does this work with 'public' tunnels?
 					logInfo(`setting tunnel factory...`);
-					this._register(await this._extHostTunnelService.setTunnelFactory(resolver));
+					this._register(await this._extHostTunnelService.setTunnelFactory(
+						resolver,
+						ExtHostManagedResolvedAuthority.isManagedResolvedAuthority(result) ? result : undefined
+					));
 				} else {
 					logInfo(`invoking resolveExecServer() for ${remoteAuthority}`);
 					performance.mark(`code/extHost/willResolveExecServer/${authorityPrefix}`);

--- a/src/vs/workbench/api/node/extHost.node.services.ts
+++ b/src/vs/workbench/api/node/extHost.node.services.ts
@@ -24,6 +24,8 @@ import { NodeExtHostVariableResolverProviderService } from 'vs/workbench/api/nod
 import { IExtHostVariableResolverProvider } from 'vs/workbench/api/common/extHostVariableResolverService';
 import { ExtHostLogService } from 'vs/workbench/api/common/extHostLogService';
 import { SyncDescriptor } from 'vs/platform/instantiation/common/descriptors';
+import { ISignService } from 'vs/platform/sign/common/sign';
+import { SignService } from 'vs/platform/sign/node/signService';
 
 // #########################################################################
 // ###                                                                   ###
@@ -34,6 +36,7 @@ import { SyncDescriptor } from 'vs/platform/instantiation/common/descriptors';
 registerSingleton(IExtHostExtensionService, ExtHostExtensionService, InstantiationType.Eager);
 registerSingleton(ILoggerService, ExtHostLoggerService, InstantiationType.Delayed);
 registerSingleton(ILogService, new SyncDescriptor(ExtHostLogService, [false], true));
+registerSingleton(ISignService, SignService, InstantiationType.Delayed);
 registerSingleton(IExtensionStoragePaths, ExtensionStoragePaths, InstantiationType.Eager);
 
 registerSingleton(IExtHostDebugService, ExtHostDebugService, InstantiationType.Eager);

--- a/src/vs/workbench/api/node/extHostTunnelService.ts
+++ b/src/vs/workbench/api/node/extHostTunnelService.ts
@@ -4,17 +4,26 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { exec } from 'child_process';
+import { VSBuffer } from 'vs/base/common/buffer';
+import { Emitter } from 'vs/base/common/event';
+import { DisposableStore } from 'vs/base/common/lifecycle';
 import { MovingAverage } from 'vs/base/common/numbers';
 import { isLinux } from 'vs/base/common/platform';
 import * as resources from 'vs/base/common/resources';
 import { URI } from 'vs/base/common/uri';
 import * as pfs from 'vs/base/node/pfs';
+import { ISocket, SocketCloseEventType } from 'vs/base/parts/ipc/common/ipc.net';
 import { ILogService } from 'vs/platform/log/common/log';
+import { ManagedSocket, RemoteSocketHalf, connectManagedSocket } from 'vs/platform/remote/common/managedSocket';
+import { ManagedRemoteConnection } from 'vs/platform/remote/common/remoteAuthorityResolver';
+import { ISignService } from 'vs/platform/sign/common/sign';
 import { isAllInterfaces, isLocalhost } from 'vs/platform/tunnel/common/tunnel';
+import { NodeRemoteTunnel } from 'vs/platform/tunnel/node/tunnelService';
 import { IExtHostInitDataService } from 'vs/workbench/api/common/extHostInitDataService';
 import { IExtHostRpcService } from 'vs/workbench/api/common/extHostRpcService';
 import { ExtHostTunnelService } from 'vs/workbench/api/common/extHostTunnelService';
 import { CandidatePort } from 'vs/workbench/services/remote/common/tunnelModel';
+import * as vscode from 'vscode';
 
 export function getSockets(stdout: string): Record<string, { pid: number; socket: number }> {
 	const lines = stdout.trim().split('\n');
@@ -171,8 +180,9 @@ export class NodeExtHostTunnelService extends ExtHostTunnelService {
 
 	constructor(
 		@IExtHostRpcService extHostRpc: IExtHostRpcService,
-		@IExtHostInitDataService initData: IExtHostInitDataService,
-		@ILogService logService: ILogService
+		@IExtHostInitDataService private readonly initData: IExtHostInitDataService,
+		@ILogService logService: ILogService,
+		@ISignService private readonly signService: ISignService,
 	) {
 		super(extHostRpc, initData, logService);
 		if (isLinux && initData.remote.isRemote && initData.remote.authority) {
@@ -296,5 +306,103 @@ export class NodeExtHostTunnelService extends ExtHostTunnelService {
 				return foundCandidates;
 			}
 		});
+	}
+
+	protected override makeManagedTunnelFactory(authority: vscode.ManagedResolvedAuthority): vscode.RemoteAuthorityResolver['tunnelFactory'] {
+		return async (tunnelOptions) => {
+			const t = new NodeRemoteTunnel(
+				{
+					commit: this.initData.commit,
+					quality: this.initData.quality,
+					logService: this.logService,
+					ipcLogger: null,
+					// services and address providers have stubs since we don't need
+					// the connection identification that the renderer process uses
+					remoteSocketFactoryService: {
+						_serviceBrand: undefined,
+						async connect(_connectTo: ManagedRemoteConnection, path: string, query: string, debugLabel: string): Promise<ISocket> {
+							const result = await authority.makeConnection();
+							return ExtHostManagedSocket.connect(result, path, query, debugLabel);
+						},
+						register() {
+							throw new Error('not implemented');
+						},
+					},
+					addressProvider: {
+						getAddress() {
+							return Promise.resolve({
+								connectTo: new ManagedRemoteConnection(0),
+								connectionToken: authority.connectionToken,
+							});
+						},
+					},
+					signService: this.signService,
+				},
+				'localhost',
+				tunnelOptions.remoteAddress.host || 'localhost',
+				tunnelOptions.remoteAddress.port,
+				tunnelOptions.localAddressPort,
+			);
+
+			await t.waitForReady();
+
+			const disposeEmitter = new Emitter<void>();
+
+			return {
+				localAddress: t.localAddress,
+				remoteAddress: { port: t.tunnelRemotePort, host: t.tunnelRemoteHost },
+				onDidDispose: disposeEmitter.event,
+				dispose: () => {
+					t.dispose();
+					disposeEmitter.fire();
+					disposeEmitter.dispose();
+				},
+			};
+		};
+	}
+}
+
+class ExtHostManagedSocket extends ManagedSocket {
+	public static connect(
+		passing: vscode.ManagedMessagePassing,
+		path: string, query: string, debugLabel: string,
+	): Promise<ExtHostManagedSocket> {
+		const d = new DisposableStore();
+		const half: RemoteSocketHalf = {
+			onClose: d.add(new Emitter()),
+			onData: d.add(new Emitter()),
+			onEnd: d.add(new Emitter()),
+		};
+
+		d.add(passing.onDidReceiveMessage(d => half.onData.fire(VSBuffer.wrap(d))));
+		d.add(passing.onDidEnd(() => half.onEnd.fire()));
+		d.add(passing.onDidClose(error => half.onClose.fire({
+			type: SocketCloseEventType.NodeSocketCloseEvent,
+			error,
+			hadError: !!error
+		})));
+
+		const socket = new ExtHostManagedSocket(passing, debugLabel, half);
+		socket._register(d);
+		return connectManagedSocket(socket, path, query, debugLabel, half);
+	}
+
+	constructor(
+		private readonly passing: vscode.ManagedMessagePassing,
+		debugLabel: string,
+		half: RemoteSocketHalf,
+	) {
+		super(debugLabel, half);
+	}
+
+	public override write(buffer: VSBuffer): void {
+		this.passing.send(buffer.buffer);
+	}
+	protected override closeRemote(): void {
+		this.passing.end();
+	}
+
+	public override async drain(): Promise<void> {
+		await this.passing.drain?.();
 	}
 }

--- a/src/vs/workbench/api/test/browser/mainThreadManagedSockets.test.ts
+++ b/src/vs/workbench/api/test/browser/mainThreadManagedSockets.test.ts
@@ -10,7 +10,8 @@ import { Emitter } from 'vs/base/common/event';
 import { DisposableStore } from 'vs/base/common/lifecycle';
 import { SocketCloseEvent } from 'vs/base/parts/ipc/common/ipc.net';
 import { mock } from 'vs/base/test/common/mock';
-import { ManagedSocket, RemoteSocketHalf } from 'vs/workbench/api/browser/mainThreadManagedSockets';
+import { RemoteSocketHalf } from 'vs/platform/remote/common/managedSocket';
+import { MainThreadManagedSocket } from 'vs/workbench/api/browser/mainThreadManagedSockets';
 import { ExtHostManagedSocketsShape } from 'vs/workbench/api/common/extHost.protocol';
 
 suite('MainThreadManagedSockets', () => {
@@ -68,7 +69,7 @@ suite('MainThreadManagedSockets', () => {
 		});
 
 		async function doConnect() {
-			const socket = ManagedSocket.connect(1, extHost, '/hello', 'world=true', '', half);
+			const socket = MainThreadManagedSocket.connect(1, extHost, '/hello', 'world=true', '', half);
 			await extHost.expectEvent(evt => evt.data && evt.data.startsWith('GET ws://localhost/hello?world=true&skipWebSocketFrames=true HTTP/1.1\r\nConnection: Upgrade\r\nUpgrade: websocket\r\nSec-WebSocket-Key:'), 'websocket open event');
 			half.onData.fire(VSBuffer.fromString('Opened successfully ;)\r\n\r\n'));
 			return await socket;
@@ -79,7 +80,7 @@ suite('MainThreadManagedSockets', () => {
 		});
 
 		test('includes trailing connection data', async () => {
-			const socketProm = ManagedSocket.connect(1, extHost, '/hello', 'world=true', '', half);
+			const socketProm = MainThreadManagedSocket.connect(1, extHost, '/hello', 'world=true', '', half);
 			await extHost.expectEvent(evt => evt.data && evt.data.includes('GET ws://localhost'), 'websocket open event');
 			half.onData.fire(VSBuffer.fromString('Opened successfully ;)\r\n\r\nSome trailing data'));
 			const socket = await socketProm;


### PR DESCRIPTION
The default implementation of port forwarding works from the shared
process to traditional addressed remote authorities. However, this
didn't work with managed remote authorities.

Rather than implementing a chain of message passing from the shared
process back up to the extension host, this PR reuses the
`NodeRemoteTunnel` to provide default forwarding logic in the Node ext
host. It also makes the `ManagedSocket` more generic for reuse there.

Fixes #190859

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
