### PR TITLE
Light version is always used for `iconPath`

### DIFF
--- a/src/vs/platform/quickinput/browser/quickInput.ts
+++ b/src/vs/platform/quickinput/browser/quickInput.ts
@@ -40,6 +40,7 @@ export interface IQuickInputOptions {
 	backKeybindingLabel(): string | undefined;
 	setContextKey(id?: string): void;
 	linkOpenerDelegate(content: string): void;
+	colorSchemeDelegate(): ColorScheme;
 	returnFocus(): void;
 	createList<T>(
 		user: string,
@@ -62,7 +63,6 @@ export interface IQuickInputStyles {
 	readonly keybindingLabel: IKeybindingLabelStyles;
 	readonly list: IListStyles;
 	readonly pickerGroup: { pickerGroupBorder: string | undefined; pickerGroupForeground: string | undefined };
-	readonly colorScheme: ColorScheme;
 }
 
 export interface IQuickInputWidgetStyles {

--- a/src/vs/platform/quickinput/browser/quickInput.ts
+++ b/src/vs/platform/quickinput/browser/quickInput.ts
@@ -31,7 +31,6 @@ import { IInputBox, IKeyMods, IQuickInput, IQuickInputButton, IQuickInputHideEve
 import { QuickInputBox } from './quickInputBox';
 import { QuickInputList, QuickInputListFocus } from './quickInputList';
 import { getIconClass, renderQuickInputDescription } from './quickInputUtils';
-import { ColorScheme } from 'vs/platform/theme/common/theme';
 
 export interface IQuickInputOptions {
 	idPrefix: string;
@@ -40,7 +39,6 @@ export interface IQuickInputOptions {
 	backKeybindingLabel(): string | undefined;
 	setContextKey(id?: string): void;
 	linkOpenerDelegate(content: string): void;
-	colorSchemeDelegate(): ColorScheme;
 	returnFocus(): void;
 	createList<T>(
 		user: string,

--- a/src/vs/platform/quickinput/browser/quickInputController.ts
+++ b/src/vs/platform/quickinput/browser/quickInputController.ts
@@ -21,6 +21,7 @@ import { QuickInputBox } from 'vs/platform/quickinput/browser/quickInputBox';
 import { QuickInputList, QuickInputListFocus } from 'vs/platform/quickinput/browser/quickInputList';
 import { QuickInputUI, Writeable, IQuickInputStyles, IQuickInputOptions, QuickPick, backButton, InputBox, Visibilities, QuickWidget } from 'vs/platform/quickinput/browser/quickInput';
 import { ILayoutService } from 'vs/platform/layout/browser/layoutService';
+import { IThemeService } from 'vs/platform/theme/common/themeService';
 
 const $ = dom.$;
 
@@ -50,7 +51,8 @@ export class QuickInputController extends Disposable {
 
 	private previousFocusElement?: HTMLElement;
 
-	constructor(private options: IQuickInputOptions) {
+	constructor(private options: IQuickInputOptions,
+		private readonly themeService: IThemeService) {
 		super();
 		this.idPrefix = options.idPrefix;
 		this.parentElement = options.container;
@@ -145,7 +147,7 @@ export class QuickInputController extends Disposable {
 		const description1 = dom.append(container, $('.quick-input-description'));
 
 		const listId = this.idPrefix + 'list';
-		const list = this._register(new QuickInputList(container, listId, this.options));
+		const list = this._register(new QuickInputList(container, listId, this.options, this.themeService));
 		inputBox.setAttribute('aria-controls', listId);
 		this._register(list.onDidChangeFocus(() => {
 			inputBox.setAttribute('aria-activedescendant', list.getActiveDescendant() ?? '');

--- a/src/vs/platform/quickinput/browser/quickInputList.ts
+++ b/src/vs/platform/quickinput/browser/quickInputList.ts
@@ -34,7 +34,8 @@ import { getIconClass } from 'vs/platform/quickinput/browser/quickInputUtils';
 import { IQuickPickItem, IQuickPickItemButtonEvent, IQuickPickSeparator, IQuickPickSeparatorButtonEvent, QuickPickItem } from 'vs/platform/quickinput/common/quickInput';
 import { Lazy } from 'vs/base/common/lazy';
 import { URI } from 'vs/base/common/uri';
-import { ColorScheme, isDark } from 'vs/platform/theme/common/theme';
+import { isDark } from 'vs/platform/theme/common/theme';
+import { IThemeService } from 'vs/platform/theme/common/themeService';
 
 const $ = dom.$;
 
@@ -234,7 +235,7 @@ class ListElementRenderer implements IListRenderer<IListElement, IListElementTem
 
 	static readonly ID = 'listelement';
 
-	constructor(private readonly colorSchemeDelegate: () => ColorScheme) { }
+	constructor(private readonly themeService: IThemeService) { }
 
 	get templateId() {
 		return ListElementRenderer.ID;
@@ -299,7 +300,7 @@ class ListElementRenderer implements IListRenderer<IListElement, IListElementTem
 		const { labelHighlights, descriptionHighlights, detailHighlights } = element;
 
 		if (element.item?.iconPath) {
-			const icon = isDark(this.colorSchemeDelegate()) ? element.item.iconPath.dark : (element.item.iconPath.light ?? element.item.iconPath.dark);
+			const icon = isDark(this.themeService.getColorTheme().type) ? element.item.iconPath.dark : (element.item.iconPath.light ?? element.item.iconPath.dark);
 			const iconUrl = URI.revive(icon);
 			data.icon.className = 'quick-input-list-icon';
 			data.icon.style.backgroundImage = dom.asCSSUrl(iconUrl);
@@ -459,12 +460,13 @@ export class QuickInputList {
 		private parent: HTMLElement,
 		id: string,
 		private options: IQuickInputOptions,
+		themeService: IThemeService
 	) {
 		this.id = id;
 		this.container = dom.append(this.parent, $('.quick-input-list'));
 		const delegate = new ListElementDelegate();
 		const accessibilityProvider = new QuickInputAccessibilityProvider();
-		this.list = options.createList('QuickInput', this.container, delegate, [new ListElementRenderer(this.options.colorSchemeDelegate)], {
+		this.list = options.createList('QuickInput', this.container, delegate, [new ListElementRenderer(themeService)], {
 			identityProvider: {
 				getId: element => {
 					// always prefer item over separator because if item is defined, it must be the main item type

--- a/src/vs/platform/quickinput/browser/quickInputList.ts
+++ b/src/vs/platform/quickinput/browser/quickInputList.ts
@@ -234,7 +234,7 @@ class ListElementRenderer implements IListRenderer<IListElement, IListElementTem
 
 	static readonly ID = 'listelement';
 
-	constructor(private readonly colorScheme: ColorScheme) { }
+	constructor(private readonly colorSchemeDelegate: () => ColorScheme) { }
 
 	get templateId() {
 		return ListElementRenderer.ID;
@@ -299,7 +299,7 @@ class ListElementRenderer implements IListRenderer<IListElement, IListElementTem
 		const { labelHighlights, descriptionHighlights, detailHighlights } = element;
 
 		if (element.item?.iconPath) {
-			const icon = isDark(this.colorScheme) ? element.item.iconPath.dark : (element.item.iconPath.light ?? element.item.iconPath.dark);
+			const icon = isDark(this.colorSchemeDelegate()) ? element.item.iconPath.dark : (element.item.iconPath.light ?? element.item.iconPath.dark);
 			const iconUrl = URI.revive(icon);
 			data.icon.className = 'quick-input-list-icon';
 			data.icon.style.backgroundImage = dom.asCSSUrl(iconUrl);
@@ -464,7 +464,7 @@ export class QuickInputList {
 		this.container = dom.append(this.parent, $('.quick-input-list'));
 		const delegate = new ListElementDelegate();
 		const accessibilityProvider = new QuickInputAccessibilityProvider();
-		this.list = options.createList('QuickInput', this.container, delegate, [new ListElementRenderer(this.options.styles.colorScheme)], {
+		this.list = options.createList('QuickInput', this.container, delegate, [new ListElementRenderer(this.options.colorSchemeDelegate)], {
 			identityProvider: {
 				getId: element => {
 					// always prefer item over separator because if item is defined, it must be the main item type

--- a/src/vs/platform/quickinput/browser/quickInputService.ts
+++ b/src/vs/platform/quickinput/browser/quickInputService.ts
@@ -78,6 +78,7 @@ export class QuickInputService extends Themable implements IQuickInputService {
 					openerService.open(content, { allowCommands: true, fromUserGesture: true });
 				});
 			},
+			colorSchemeDelegate: () => this.themeService.getColorTheme().type,
 			returnFocus: () => host.focus(),
 			createList: <T>(
 				user: string,
@@ -225,8 +226,7 @@ export class QuickInputService extends Themable implements IQuickInputService {
 			pickerGroup: {
 				pickerGroupBorder: asCssVariable(pickerGroupBorder),
 				pickerGroupForeground: asCssVariable(pickerGroupForeground),
-			},
-			colorScheme: this.themeService.getColorTheme().type
+			}
 		};
 	}
 }

--- a/src/vs/platform/quickinput/browser/quickInputService.ts
+++ b/src/vs/platform/quickinput/browser/quickInputService.ts
@@ -78,7 +78,6 @@ export class QuickInputService extends Themable implements IQuickInputService {
 					openerService.open(content, { allowCommands: true, fromUserGesture: true });
 				});
 			},
-			colorSchemeDelegate: () => this.themeService.getColorTheme().type,
 			returnFocus: () => host.focus(),
 			createList: <T>(
 				user: string,
@@ -99,7 +98,8 @@ export class QuickInputService extends Themable implements IQuickInputService {
 		const controller = this._register(new QuickInputController({
 			...defaultOptions,
 			...options
-		}));
+		},
+			this.themeService));
 
 		controller.layout(host.dimension, host.offset.quickPickTop);
 

--- a/src/vs/platform/quickinput/test/browser/quickinput.test.ts
+++ b/src/vs/platform/quickinput/test/browser/quickinput.test.ts
@@ -15,7 +15,7 @@ import { unthemedKeybindingLabelOptions } from 'vs/base/browser/ui/keybindingLab
 import { unthemedProgressBarOptions } from 'vs/base/browser/ui/progressbar/progressbar';
 import { QuickInputController } from 'vs/platform/quickinput/browser/quickInputController';
 import { IQuickPick, IQuickPickItem } from 'vs/platform/quickinput/common/quickInput';
-import { ColorScheme } from 'vs/platform/theme/common/theme';
+import { TestThemeService } from 'vs/platform/theme/test/common/testThemeService';
 
 // Sets up an `onShow` listener to allow us to wait until the quick pick is shown (useful when triggering an `accept()` right after launching a quick pick)
 // kick this off before you launch the picker and then await the promise returned after you launch the picker.
@@ -82,10 +82,10 @@ suite('QuickInput', () => { // https://github.com/microsoft/vscode/issues/147543
 				pickerGroup: {
 					pickerGroupBorder: undefined,
 					pickerGroupForeground: undefined,
-				},
-				colorScheme: ColorScheme.DARK
+				}
 			}
-		});
+		},
+			new TestThemeService());
 
 		// initial layout
 		controller.layout({ height: 20, width: 40 }, 0);


### PR DESCRIPTION
I'm not sure if this is the way you'd prefer this to be fixed, but it is a way to fix it. I can pass the theme service all the way to the `ListElementRenderer` if you'd prefer!

Fixes #188830