### PR TITLE
Writes module manager to global require function to allow for external module hot reloading

### DIFF
--- a/src/vs/loader.js
+++ b/src/vs/loader.js
@@ -1248,6 +1248,7 @@ var AMDLoader;
 			this._buildInfoPath = [];
 			this._buildInfoDefineStack = [];
 			this._buildInfoDependencies = [];
+			this._requireFunc.moduleManager = this;
 		}
 		reset() {
 			return new ModuleManager(this._env, this._scriptLoader, this._defineFunc, this._requireFunc, this._loaderAvailableTimestamp);


### PR DESCRIPTION
See https://github.com/microsoft/vscode-loader/pull/51.

This allows the debugger to access the cached modules and to replace them with updated modules.