### PR TITLE
Have sash take over layouting of Quick Chat until reset (double click)

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatQuick.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatQuick.ts
@@ -204,12 +204,19 @@ class QuickChat extends Disposable {
 		this._register(this.widget.onDidClear(() => this.clear()));
 		this._register(this.widget.onDidChangeHeight((e) => this.sash.layout()));
 		const width = parent.offsetWidth;
+		this._register(this.sash.onDidStart(() => {
+			this.widget.isDynamicChatTreeItemLayoutEnabled = false;
+		}));
 		this._register(this.sash.onDidChange((e) => {
 			if (e.currentY < QuickChat.DEFAULT_MIN_HEIGHT || e.currentY > this.maxHeight) {
 				return;
 			}
 			this.widget.layout(e.currentY, width);
 			this.sash.layout();
+		}));
+		this._register(this.sash.onDidReset(() => {
+			this.widget.isDynamicChatTreeItemLayoutEnabled = true;
+			this.widget.layoutDynamicChatTreeItemMode();
 		}));
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatWidget.ts
@@ -207,6 +207,9 @@ export class ChatWidget extends Disposable implements IChatWidget {
 	}
 
 	clear(): void {
+		if (this._dynamicMessageLayoutData) {
+			this._dynamicMessageLayoutData.enabled = true;
+		}
 		this._onDidClear.fire();
 	}
 
@@ -525,13 +528,14 @@ export class ChatWidget extends Disposable implements IChatWidget {
 		this._onDidChangeHeight.fire(height);
 	}
 
-	private _dynamicMessageLayoutData?: { numOfMessages: number; maxHeight: number };
+	private _dynamicMessageLayoutData?: { numOfMessages: number; maxHeight: number; enabled: boolean };
 
 	// An alternative to layout, this allows you to specify the number of ChatTreeItems
 	// you want to show, and the max height of the container. It will then layout the
 	// tree to show that many items.
+	// TODO@TylerLeonhardt: This could use some refactoring to make it clear which layout strategy is being used
 	setDynamicChatTreeItemLayout(numOfChatTreeItems: number, maxHeight: number) {
-		this._dynamicMessageLayoutData = { numOfMessages: numOfChatTreeItems, maxHeight };
+		this._dynamicMessageLayoutData = { numOfMessages: numOfChatTreeItems, maxHeight, enabled: true };
 		this._register(this.renderer.onDidChangeItemHeight(() => this.layoutDynamicChatTreeItemMode()));
 
 		const mutableDisposable = this._register(new MutableDisposable());
@@ -556,7 +560,7 @@ export class ChatWidget extends Disposable implements IChatWidget {
 	}
 
 	updateDynamicChatTreeItemLayout(numOfChatTreeItems: number, maxHeight: number) {
-		this._dynamicMessageLayoutData = { numOfMessages: numOfChatTreeItems, maxHeight };
+		this._dynamicMessageLayoutData = { numOfMessages: numOfChatTreeItems, maxHeight, enabled: true };
 		let hasChanged = false;
 		let height = this.bodyDimension!.height;
 		let width = this.bodyDimension!.width;
@@ -574,8 +578,19 @@ export class ChatWidget extends Disposable implements IChatWidget {
 		}
 	}
 
+	get isDynamicChatTreeItemLayoutEnabled(): boolean {
+		return this._dynamicMessageLayoutData?.enabled ?? false;
+	}
+
+	set isDynamicChatTreeItemLayoutEnabled(value: boolean) {
+		if (!this._dynamicMessageLayoutData) {
+			return;
+		}
+		this._dynamicMessageLayoutData.enabled = value;
+	}
+
 	layoutDynamicChatTreeItemMode(): void {
-		if (!this.viewModel) {
+		if (!this.viewModel || !this._dynamicMessageLayoutData?.enabled) {
 			return;
 		}
 		const inputHeight = this.inputPart.layout(this._dynamicMessageLayoutData!.maxHeight, this.container.offsetWidth);


### PR DESCRIPTION
The new behavior is that when you use the sash to change the height, then you are locked into that. It's not until you double click, or clear the chat that it returns to the original behavior of being open for just the last question.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
