### PR TITLE
Revert "Codesign Debian package for PMC API (#191140)"

### DIFF
--- a/build/azure-pipelines/linux/product-build-linux.yml
+++ b/build/azure-pipelines/linux/product-build-linux.yml
@@ -312,9 +312,6 @@ steps:
       continueOnError: true
       displayName: Download ESRPClient
 
-    - script: node build/azure-pipelines/common/sign $(Agent.ToolsDirectory)/esrpclient/*/*/net6.0/esrpcli.dll pgp $(ESRP-PKI) $(esrp-aad-username) $(esrp-aad-password) .build/linux/deb '*.deb'
-      displayName: Codesign deb
-
     - script: node build/azure-pipelines/common/sign $(Agent.ToolsDirectory)/esrpclient/*/*/net6.0/esrpcli.dll pgp $(ESRP-PKI) $(esrp-aad-username) $(esrp-aad-password) .build/linux/rpm '*.rpm'
       displayName: Codesign rpm
 


### PR DESCRIPTION
This reverts commit 083fca132543aa91a7e1de2dc23857d70ea56dd3.

**Reason for revert:**

Debian package publishing is failing currently https://github.com/microsoft/vscode-publishers/actions/runs/6016585797/job/16320884293, although not sure of the cause this change seems a likely cause. Reverting for confirmation.