### PR TITLE
Show focus state on editor tabs in hc themes

### DIFF
--- a/src/vs/workbench/browser/parts/editor/tabsTitleControl.ts
+++ b/src/vs/workbench/browser/parts/editor/tabsTitleControl.ts
@@ -2077,6 +2077,10 @@ registerThemingParticipant((theme, collector) => {
 				outline-offset: -5px;
 			}
 
+			.monaco-workbench .part.editor > .content .editor-group-container.active > .title .tabs-container > .tab.active:focus {
+				outline-style: dashed;
+			}
+
 			.monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.active {
 				outline: 1px dotted;
 				outline-offset: -5px;


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/188127