### PR TITLE
some Some grid operations cause the `activeElement` to get lost (fix #189256)

### DIFF
--- a/src/vs/workbench/browser/parts/editor/editorActions.ts
+++ b/src/vs/workbench/browser/parts/editor/editorActions.ts
@@ -2264,7 +2264,8 @@ abstract class AbstractCreateEditorGroupAction extends Action2 {
 	override async run(accessor: ServicesAccessor): Promise<void> {
 		const editorGroupService = accessor.get(IEditorGroupsService);
 
-		editorGroupService.addGroup(editorGroupService.activeGroup, this.direction, { activate: true });
+		const group = editorGroupService.addGroup(editorGroupService.activeGroup, this.direction, { activate: true });
+		group.focus();
 	}
 }
 

--- a/src/vs/workbench/browser/parts/editor/editorPart.ts
+++ b/src/vs/workbench/browser/parts/editor/editorPart.ts
@@ -515,19 +515,10 @@ export class EditorPart extends Part implements IEditorGroupsService, IEditorGro
 	addGroup(location: IEditorGroupView | GroupIdentifier, direction: GroupDirection, options?: IAddGroupOptions): IEditorGroupView {
 		const locationView = this.assertGroupView(location);
 
-		const restoreFocus = this.shouldRestoreFocus(locationView.element);
-
 		const group = this.doAddGroup(locationView, direction);
 
 		if (options?.activate) {
 			this.doSetGroupActive(group);
-		}
-
-		// Restore focus if we had it previously after completing the grid
-		// operation. That operation might cause reparenting of grid views
-		// which moves focus to the <body> element otherwise.
-		if (restoreFocus) {
-			locationView.focus();
 		}
 
 		return group;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
