### PR TITLE
Disable Local Server flow for REH

### DIFF
--- a/extensions/github-authentication/src/flows.ts
+++ b/extensions/github-authentication/src/flows.ts
@@ -200,7 +200,9 @@ const allFlows: IFlow[] = [
 			// other flows that work well.
 			supportsGitHubEnterpriseServer: false,
 			supportsHostedGitHubEnterprise: true,
-			supportsRemoteExtensionHost: true,
+			// Opening a port on the remote side can't be open in the browser on
+			// the client side so this flow won't work in remote extension hosts
+			supportsRemoteExtensionHost: false,
 			// Web worker can't open a port to listen for the redirect
 			supportsWebWorkerExtensionHost: false,
 			// exchanging a code for a token requires a client secret


### PR DESCRIPTION
Because spinning up ports on the remote won't always work. Instead, we have the trusty device code flow.

Fixes https://github.com/microsoft/vscode/issues/191866
Fixes https://github.com/microsoft/vscode/issues/191867

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
