### PR TITLE
editors - do not focus empty editor group when created

### DIFF
--- a/src/vs/workbench/browser/parts/editor/editorActions.ts
+++ b/src/vs/workbench/browser/parts/editor/editorActions.ts
@@ -2264,8 +2264,12 @@ abstract class AbstractCreateEditorGroupAction extends Action2 {
 	override async run(accessor: ServicesAccessor): Promise<void> {
 		const editorGroupService = accessor.get(IEditorGroupsService);
 
-		const group = editorGroupService.addGroup(editorGroupService.activeGroup, this.direction, { activate: true });
-		group.focus();
+		// We intentionally do not want the new group to be focussed so that
+		// a user can have keyboard focus e.g. in a tree/list, open a new
+		// editor group that is active and then arrow-up/down in the tree/list
+		// to pick an editor to open in that group
+
+		editorGroupService.addGroup(editorGroupService.activeGroup, this.direction, { activate: true });
 	}
 }
 


### PR DESCRIPTION
Reverts changes done for https://github.com/microsoft/vscode/issues/189256