### PR TITLE
Enable the family autodetection algorithm

### DIFF
--- a/src/vs/server/node/remoteExtensionHostAgentServer.ts
+++ b/src/vs/server/node/remoteExtensionHostAgentServer.ts
@@ -551,7 +551,8 @@ class RemoteExtensionHostAgentServer extends Disposable implements IServerAPI {
 			const socket = net.createConnection(
 				{
 					host: host,
-					port: port
+					port: port,
+					autoSelectFamily: true
 				}, () => {
 					socket.removeListener('error', e);
 					socket.pause();


### PR DESCRIPTION
to support a case where localhost resolves first to the ipv6 address and only second to the ipv4 address, and the desired server listens only on ipv4

Fixes #191945