### PR TITLE
Git - fix stage/unstage selected ranges in nested git repositories

### DIFF
--- a/extensions/git/src/model.ts
+++ b/extensions/git/src/model.ts
@@ -5,7 +5,7 @@
 
 import { workspace, WorkspaceFoldersChangeEvent, Uri, window, Event, EventEmitter, QuickPickItem, Disposable, SourceControl, SourceControlResourceGroup, TextEditor, Memento, commands, LogOutputChannel, l10n, ProgressLocation, WorkspaceFolder } from 'vscode';
 import TelemetryReporter from '@vscode/extension-telemetry';
-import { Repository, RepositoryState } from './repository';
+import { IRepositoryResolver, Repository, RepositoryState } from './repository';
 import { memoize, sequentialize, debounce } from './decorators';
 import { dispose, anyEvent, filterEvent, isDescendant, pathEquals, toDisposable, eventToPromise } from './util';
 import { Git } from './git';
@@ -170,7 +170,7 @@ class UnsafeRepositoriesManager {
 	}
 }
 
-export class Model implements IBranchProtectionProviderRegistry, IRemoteSourcePublisherRegistry, IPostCommitCommandsProviderRegistry, IPushErrorHandlerRegistry {
+export class Model implements IRepositoryResolver, IBranchProtectionProviderRegistry, IRemoteSourcePublisherRegistry, IPostCommitCommandsProviderRegistry, IPushErrorHandlerRegistry {
 
 	private _onDidOpenRepository = new EventEmitter<Repository>();
 	readonly onDidOpenRepository: Event<Repository> = this._onDidOpenRepository.event;

--- a/extensions/git/src/model.ts
+++ b/extensions/git/src/model.ts
@@ -578,7 +578,7 @@ export class Model implements IBranchProtectionProviderRegistry, IRemoteSourcePu
 
 			// Open repository
 			const [dotGit, repositoryRootRealPath] = await Promise.all([this.git.getRepositoryDotGit(repositoryRoot), this.getRepositoryRootRealPath(repositoryRoot)]);
-			const repository = new Repository(this.git.open(repositoryRoot, repositoryRootRealPath, dotGit, this.logger), this, this, this, this, this.globalState, this.logger, this.telemetryReporter);
+			const repository = new Repository(this.git.open(repositoryRoot, repositoryRootRealPath, dotGit, this.logger), this, this, this, this, this, this.globalState, this.logger, this.telemetryReporter);
 
 			this.open(repository);
 			this._closedRepositoriesManager.deleteRepository(repository.root);

--- a/extensions/git/src/repository.ts
+++ b/extensions/git/src/repository.ts
@@ -23,6 +23,7 @@ import { ActionButtonCommand } from './actionButton';
 import { IPostCommitCommandsProviderRegistry, CommitCommandsCenter } from './postCommitCommands';
 import { Operation, OperationKind, OperationManager, OperationResult } from './operation';
 import { GitBranchProtectionProvider, IBranchProtectionProviderRegistry } from './branchProtection';
+import { Model } from './model';
 
 const timeout = (millis: number) => new Promise(c => setTimeout(c, millis));
 
@@ -784,6 +785,7 @@ export class Repository implements Disposable {
 
 	constructor(
 		private readonly repository: BaseRepository,
+		private readonly model: Model,
 		private pushErrorHandlerRegistry: IPushErrorHandlerRegistry,
 		remoteSourcePublisherRegistry: IRemoteSourcePublisherRegistry,
 		postCommitCommandsProviderRegistry: IPostCommitCommandsProviderRegistry,
@@ -1017,6 +1019,12 @@ export class Repository implements Disposable {
 
 		// Ignore path that is inside a submodule
 		if (this.submodules.some(s => isDescendant(path.join(this.repository.root, s.path), uri.path))) {
+			return undefined;
+		}
+
+		// Ignore path that is not inside the current repository
+		const repository = this.model.getRepository(uri);
+		if (repository && !pathEquals(repository.root, this.repository.root)) {
 			return undefined;
 		}
 

--- a/extensions/git/src/repository.ts
+++ b/extensions/git/src/repository.ts
@@ -1012,19 +1012,14 @@ export class Repository implements Disposable {
 			return;
 		}
 
-		// Ignore path that is inside a merge group
-		if (this.mergeGroup.resourceStates.some(r => r.resourceUri.path === uri.path)) {
-			return undefined;
-		}
-
-		// Ignore path that is inside a submodule
-		if (this.submodules.some(s => isDescendant(path.join(this.repository.root, s.path), uri.path))) {
-			return undefined;
-		}
-
 		// Ignore path that is not inside the current repository
 		const repository = this.model.getRepository(uri);
 		if (repository && !pathEquals(repository.root, this.repository.root)) {
+			return undefined;
+		}
+
+		// Ignore path that is inside a merge group
+		if (this.mergeGroup.resourceStates.some(r => r.resourceUri.path === uri.path)) {
 			return undefined;
 		}
 


### PR DESCRIPTION
Related #188967

When opening a folder/workspace that contains nested git repositories some operations (ex: stage/unstage selected ranges) do not work as expected. I have tracked this down to the fact that the QuickDiffService will return **both** repositories instead of only the inner repository. Due to that, the diff information provided to the stage/unstage selected ranges commands is incorrect. 

The issue could be fixed either in the git extension or in the QuickDiffService. The changes in this pull request fixes the issue in the git extension but I would like to get your thoughs on whether this should be fixed in the git extension or the QuickDiffService. Thanks!