### PR TITLE
testing: fix most disposable leaks in testing, tree

### DIFF
--- a/src/vs/base/browser/ui/list/listView.ts
+++ b/src/vs/base/browser/ui/list/listView.ts
@@ -403,11 +403,11 @@ export class ListView<T> implements IListView<T> {
 
 		this.disposables.add(Gesture.addTarget(this.rowsContainer));
 
-		this.scrollable = new Scrollable({
+		this.scrollable = this.disposables.add(new Scrollable({
 			forceIntegerValues: true,
 			smoothScrollDuration: (options.smoothScrolling ?? false) ? 125 : 0,
 			scheduleAtNextAnimationFrame: cb => scheduleAtNextAnimationFrame(cb)
-		});
+		}));
 		this.scrollableElement = this.disposables.add(new SmoothScrollableElement(this.rowsContainer, {
 			alwaysConsumeMouseWheel: options.alwaysConsumeMouseWheel ?? DefaultOptions.alwaysConsumeMouseWheel,
 			horizontal: ScrollbarVisibility.Auto,

--- a/src/vs/base/browser/ui/list/listWidget.ts
+++ b/src/vs/base/browser/ui/list/listWidget.ts
@@ -293,12 +293,15 @@ class KeyboardController<T> implements IDisposable {
 
 	private readonly disposables = new DisposableStore();
 	private readonly multipleSelectionDisposables = new DisposableStore();
+	private multipleSelectionSupport: boolean | undefined;
 
 	@memoize
-	private get onKeyDown(): Event.IChainableEvent<StandardKeyboardEvent> {
-		return this.disposables.add(Event.chain(this.disposables.add(new DomEmitter(this.view.domNode, 'keydown')).event)
-			.filter(e => !isInputElement(e.target as HTMLElement))
-			.map(e => new StandardKeyboardEvent(e)));
+	private get onKeyDown(): Event<StandardKeyboardEvent> {
+		return Event.chain2(
+			this.disposables.add(new DomEmitter(this.view.domNode, 'keydown')).event, $ =>
+			$.filter(e => !isInputElement(e.target as HTMLElement))
+				.map(e => new StandardKeyboardEvent(e))
+		);
 	}
 
 	constructor(
@@ -306,25 +309,32 @@ class KeyboardController<T> implements IDisposable {
 		private view: IListView<T>,
 		options: IListOptions<T>
 	) {
-		this.onKeyDown.filter(e => e.keyCode === KeyCode.Enter).on(this.onEnter, this, this.disposables);
-		this.onKeyDown.filter(e => e.keyCode === KeyCode.UpArrow).on(this.onUpArrow, this, this.disposables);
-		this.onKeyDown.filter(e => e.keyCode === KeyCode.DownArrow).on(this.onDownArrow, this, this.disposables);
-		this.onKeyDown.filter(e => e.keyCode === KeyCode.PageUp).on(this.onPageUpArrow, this, this.disposables);
-		this.onKeyDown.filter(e => e.keyCode === KeyCode.PageDown).on(this.onPageDownArrow, this, this.disposables);
-		this.onKeyDown.filter(e => e.keyCode === KeyCode.Escape).on(this.onEscape, this, this.disposables);
-
-		if (options.multipleSelectionSupport !== false) {
-			this.onKeyDown.filter(e => (platform.isMacintosh ? e.metaKey : e.ctrlKey) && e.keyCode === KeyCode.KeyA).on(this.onCtrlA, this, this.multipleSelectionDisposables);
-		}
+		this.multipleSelectionSupport = options.multipleSelectionSupport;
+		this.disposables.add(this.onKeyDown(e => {
+			switch (e.keyCode) {
+				case KeyCode.Enter:
+					return this.onEnter(e);
+				case KeyCode.UpArrow:
+					return this.onUpArrow(e);
+				case KeyCode.DownArrow:
+					return this.onDownArrow(e);
+				case KeyCode.PageUp:
+					return this.onPageUpArrow(e);
+				case KeyCode.PageDown:
+					return this.onPageDownArrow(e);
+				case KeyCode.Escape:
+					return this.onEscape(e);
+				case KeyCode.KeyA:
+					if (this.multipleSelectionSupport && (platform.isMacintosh ? e.metaKey : e.ctrlKey)) {
+						this.onCtrlA(e);
+					}
+			}
+		}));
 	}
 
 	updateOptions(optionsUpdate: IListOptionsUpdate): void {
 		if (optionsUpdate.multipleSelectionSupport !== undefined) {
-			this.multipleSelectionDisposables.clear();
-
-			if (optionsUpdate.multipleSelectionSupport) {
-				this.onKeyDown.filter(e => (platform.isMacintosh ? e.metaKey : e.ctrlKey) && e.keyCode === KeyCode.KeyA).on(this.onCtrlA, this, this.multipleSelectionDisposables);
-			}
+			this.multipleSelectionSupport = optionsUpdate.multipleSelectionSupport;
 		}
 	}
 
@@ -464,15 +474,15 @@ class TypeNavigationController<T> implements IDisposable {
 
 		let typing = false;
 
-		const onChar = this.enabledDisposables.add(Event.chain(this.enabledDisposables.add(new DomEmitter(this.view.domNode, 'keydown')).event))
-			.filter(e => !isInputElement(e.target as HTMLElement))
-			.filter(() => this.mode === TypeNavigationMode.Automatic || this.triggered)
-			.map(event => new StandardKeyboardEvent(event))
-			.filter(e => typing || this.keyboardNavigationEventFilter(e))
-			.filter(e => this.delegate.mightProducePrintableCharacter(e))
-			.forEach(e => EventHelper.stop(e, true))
-			.map(event => event.browserEvent.key)
-			.event;
+		const onChar = Event.chain2(this.enabledDisposables.add(new DomEmitter(this.view.domNode, 'keydown')).event, $ =>
+			$.filter(e => !isInputElement(e.target as HTMLElement))
+				.filter(() => this.mode === TypeNavigationMode.Automatic || this.triggered)
+				.map(event => new StandardKeyboardEvent(event))
+				.filter(e => typing || this.keyboardNavigationEventFilter(e))
+				.filter(e => this.delegate.mightProducePrintableCharacter(e))
+				.forEach(e => EventHelper.stop(e, true))
+				.map(event => event.browserEvent.key)
+		);
 
 		const onClear = Event.debounce<string, null>(onChar, () => null, 800, undefined, undefined, undefined, this.enabledDisposables);
 		const onInput = Event.reduce<string | null, string | null>(Event.any(onChar, onClear), (r, i) => i === null ? null : ((r || '') + i), undefined, this.enabledDisposables);
@@ -570,12 +580,14 @@ class DOMFocusController<T> implements IDisposable {
 		private list: List<T>,
 		private view: IListView<T>
 	) {
-		const onKeyDown = this.disposables.add(Event.chain(this.disposables.add(new DomEmitter(view.domNode, 'keydown')).event))
+		const onKeyDown = Event.chain2(this.disposables.add(new DomEmitter(view.domNode, 'keydown')).event, $ => $
 			.filter(e => !isInputElement(e.target as HTMLElement))
-			.map(e => new StandardKeyboardEvent(e));
+			.map(e => new StandardKeyboardEvent(e))
+		);
 
-		onKeyDown.filter(e => e.keyCode === KeyCode.Tab && !e.ctrlKey && !e.metaKey && !e.shiftKey && !e.altKey)
-			.on(this.onTab, this, this.disposables);
+		const onTab = Event.chain2(onKeyDown, $ => $.filter(e => e.keyCode === KeyCode.Tab && !e.ctrlKey && !e.metaKey && !e.shiftKey && !e.altKey));
+
+		onTab(this.onTab, this, this.disposables);
 	}
 
 	private onTab(e: StandardKeyboardEvent): void {
@@ -1348,31 +1360,29 @@ export class List<T> implements ISpliceable<T>, IDisposable {
 	@memoize get onContextMenu(): Event<IListContextMenuEvent<T>> {
 		let didJustPressContextMenuKey = false;
 
-		const fromKeyDown = this.disposables.add(Event.chain(this.disposables.add(new DomEmitter(this.view.domNode, 'keydown')).event))
-			.map(e => new StandardKeyboardEvent(e))
-			.filter(e => didJustPressContextMenuKey = e.keyCode === KeyCode.ContextMenu || (e.shiftKey && e.keyCode === KeyCode.F10))
-			.map(e => EventHelper.stop(e, true))
-			.filter(() => false)
-			.event as Event<any>;
+		const fromKeyDown: Event<any> = Event.chain2(this.disposables.add(new DomEmitter(this.view.domNode, 'keydown')).event, $ =>
+			$.map(e => new StandardKeyboardEvent(e))
+				.filter(e => didJustPressContextMenuKey = e.keyCode === KeyCode.ContextMenu || (e.shiftKey && e.keyCode === KeyCode.F10))
+				.map(e => EventHelper.stop(e, true))
+				.filter(() => false));
 
-		const fromKeyUp = this.disposables.add(Event.chain(this.disposables.add(new DomEmitter(this.view.domNode, 'keyup')).event))
-			.forEach(() => didJustPressContextMenuKey = false)
-			.map(e => new StandardKeyboardEvent(e))
-			.filter(e => e.keyCode === KeyCode.ContextMenu || (e.shiftKey && e.keyCode === KeyCode.F10))
-			.map(e => EventHelper.stop(e, true))
-			.map(({ browserEvent }) => {
-				const focus = this.getFocus();
-				const index = focus.length ? focus[0] : undefined;
-				const element = typeof index !== 'undefined' ? this.view.element(index) : undefined;
-				const anchor = typeof index !== 'undefined' ? this.view.domElement(index) as HTMLElement : this.view.domNode;
-				return { index, element, anchor, browserEvent };
-			})
-			.event;
+		const fromKeyUp = Event.chain2(this.disposables.add(new DomEmitter(this.view.domNode, 'keyup')).event, $ =>
+			$.forEach(() => didJustPressContextMenuKey = false)
+				.map(e => new StandardKeyboardEvent(e))
+				.filter(e => e.keyCode === KeyCode.ContextMenu || (e.shiftKey && e.keyCode === KeyCode.F10))
+				.map(e => EventHelper.stop(e, true))
+				.map(({ browserEvent }) => {
+					const focus = this.getFocus();
+					const index = focus.length ? focus[0] : undefined;
+					const element = typeof index !== 'undefined' ? this.view.element(index) : undefined;
+					const anchor = typeof index !== 'undefined' ? this.view.domElement(index) as HTMLElement : this.view.domNode;
+					return { index, element, anchor, browserEvent };
+				}));
 
-		const fromMouse = this.disposables.add(Event.chain(this.view.onContextMenu))
-			.filter(_ => !didJustPressContextMenuKey)
-			.map(({ element, index, browserEvent }) => ({ element, index, anchor: new StandardMouseEvent(browserEvent), browserEvent }))
-			.event;
+		const fromMouse = Event.chain2(this.view.onContextMenu, $ =>
+			$.filter(_ => !didJustPressContextMenuKey)
+				.map(({ element, index, browserEvent }) => ({ element, index, anchor: new StandardMouseEvent(browserEvent), browserEvent }))
+		);
 
 		return Event.any<IListContextMenuEvent<T>>(fromKeyDown, fromKeyUp, fromMouse);
 	}

--- a/src/vs/base/browser/ui/tree/abstractTree.ts
+++ b/src/vs/base/browser/ui/tree/abstractTree.ts
@@ -19,7 +19,7 @@ import { getVisibleState, isFilterResult } from 'vs/base/browser/ui/tree/indexTr
 import { ICollapseStateChangeEvent, ITreeContextMenuEvent, ITreeDragAndDrop, ITreeEvent, ITreeFilter, ITreeModel, ITreeModelSpliceEvent, ITreeMouseEvent, ITreeNavigator, ITreeNode, ITreeRenderer, TreeDragOverBubble, TreeError, TreeFilterResult, TreeMouseEventTarget, TreeVisibility } from 'vs/base/browser/ui/tree/tree';
 import { Action } from 'vs/base/common/actions';
 import { distinct, equals, firstOrDefault, range } from 'vs/base/common/arrays';
-import { disposableTimeout, timeout } from 'vs/base/common/async';
+import { Delayer, disposableTimeout, timeout } from 'vs/base/common/async';
 import { Codicon } from 'vs/base/common/codicons';
 import { ThemeIcon } from 'vs/base/common/themables';
 import { SetMap } from 'vs/base/common/collections';
@@ -814,9 +814,7 @@ class FindWidget<T, TFilterData> extends Disposable {
 		this.mode = mode;
 
 		const emitter = this._register(new DomEmitter(this.findInput.inputBox.inputElement, 'keydown'));
-		const onKeyDown = this._register(Event.chain(emitter.event))
-			.map(e => new StandardKeyboardEvent(e))
-			.event;
+		const onKeyDown = Event.chain2(emitter.event, $ => $.map(e => new StandardKeyboardEvent(e)));
 
 		this._register(onKeyDown((e): any => {
 			// Using equals() so we reserve modified keys for future use
@@ -886,9 +884,7 @@ class FindWidget<T, TFilterData> extends Disposable {
 			}));
 		}));
 
-		const onGrabKeyDown = this._register(Event.chain(this._register(new DomEmitter(this.elements.grab, 'keydown')).event))
-			.map(e => new StandardKeyboardEvent(e))
-			.event;
+		const onGrabKeyDown = Event.chain2(this._register(new DomEmitter(this.elements.grab, 'keydown')).event, $ => $.map(e => new StandardKeyboardEvent(e)));
 
 		this._register(onGrabKeyDown((e): any => {
 			let right: number | undefined;
@@ -1624,9 +1620,10 @@ export abstract class AbstractTree<T, TFilterData, TRef> implements IDisposable 
 		// We debounce it with 0 delay since these events may fire in the same stack and we only
 		// want to run this once. It also doesn't matter if it runs on the next tick since it's only
 		// a nice to have UI feature.
-		onDidChangeActiveNodes.input = Event.chain(Event.any<any>(onDidModelSplice, this.focus.onDidChange, this.selection.onDidChange))
-			.debounce(() => null, 0)
-			.map(() => {
+		const activeNodesEmitter = this.disposables.add(new Emitter<ITreeNode<T, TFilterData>[]>());
+		const activeNodesDebounce = this.disposables.add(new Delayer(0));
+		this.disposables.add(Event.any<any>(onDidModelSplice, this.focus.onDidChange, this.selection.onDidChange)(() => {
+			activeNodesDebounce.trigger(() => {
 				const set = new Set<ITreeNode<T, TFilterData>>();
 
 				for (const node of this.focus.getNodes()) {
@@ -1637,17 +1634,20 @@ export abstract class AbstractTree<T, TFilterData, TRef> implements IDisposable 
 					set.add(node);
 				}
 
-				return [...set.values()];
-			}).event;
+				activeNodesEmitter.fire([...set.values()]);
+			});
+		}));
+		onDidChangeActiveNodes.input = activeNodesEmitter.event;
 
 		if (_options.keyboardSupport !== false) {
-			const onKeyDown = Event.chain(this.view.onKeyDown)
-				.filter(e => !isInputElement(e.target as HTMLElement))
-				.map(e => new StandardKeyboardEvent(e));
+			const onKeyDown = Event.chain2(this.view.onKeyDown, $ =>
+				$.filter(e => !isInputElement(e.target as HTMLElement))
+					.map(e => new StandardKeyboardEvent(e))
+			);
 
-			onKeyDown.filter(e => e.keyCode === KeyCode.LeftArrow).on(this.onLeftArrow, this, this.disposables);
-			onKeyDown.filter(e => e.keyCode === KeyCode.RightArrow).on(this.onRightArrow, this, this.disposables);
-			onKeyDown.filter(e => e.keyCode === KeyCode.Space).on(this.onSpace, this, this.disposables);
+			Event.chain2(onKeyDown, $ => $.filter(e => e.keyCode === KeyCode.LeftArrow))(this.onLeftArrow, this, this.disposables);
+			Event.chain2(onKeyDown, $ => $.filter(e => e.keyCode === KeyCode.RightArrow))(this.onRightArrow, this, this.disposables);
+			Event.chain2(onKeyDown, $ => $.filter(e => e.keyCode === KeyCode.Space))(this.onSpace, this, this.disposables);
 		}
 
 		if ((_options.findWidgetEnabled ?? true) && _options.keyboardNavigationLabelProvider && _options.contextViewProvider) {

--- a/src/vs/base/test/common/event.test.ts
+++ b/src/vs/base/test/common/event.test.ts
@@ -1507,4 +1507,82 @@ suite('Event utils', () => {
 			assert.deepStrictEqual(calls, [1]);
 		});
 	});
+
+	suite('chain2', () => {
+		let store: DisposableStore;
+		let em: Emitter<number>;
+		let calls: number[];
+
+		teardown(() => {
+			store.dispose();
+		});
+
+		ensureNoDisposablesAreLeakedInTestSuite();
+
+		setup(() => {
+			store = new DisposableStore();
+			em = new Emitter<number>();
+			store.add(em);
+			calls = [];
+		});
+
+		test('maps', () => {
+			const ev = Event.chain2(em.event, $ => $.map(v => v * 2));
+			store.add(ev(v => calls.push(v)));
+			em.fire(1);
+			em.fire(2);
+			em.fire(3);
+			assert.deepStrictEqual(calls, [2, 4, 6]);
+		});
+
+		test('filters', () => {
+			const ev = Event.chain2(em.event, $ => $.filter(v => v % 2 === 0));
+			store.add(ev(v => calls.push(v)));
+			em.fire(1);
+			em.fire(2);
+			em.fire(3);
+			em.fire(4);
+			assert.deepStrictEqual(calls, [2, 4]);
+		});
+
+		test('reduces', () => {
+			const ev = Event.chain2(em.event, $ => $.reduce((acc, v) => acc + v, 0));
+			store.add(ev(v => calls.push(v)));
+			em.fire(1);
+			em.fire(2);
+			em.fire(3);
+			em.fire(4);
+			assert.deepStrictEqual(calls, [1, 3, 6, 10]);
+		});
+
+		test('latches', () => {
+			const ev = Event.chain2(em.event, $ => $.latch());
+			store.add(ev(v => calls.push(v)));
+			em.fire(1);
+			em.fire(1);
+			em.fire(2);
+			em.fire(2);
+			em.fire(3);
+			em.fire(3);
+			em.fire(1);
+			assert.deepStrictEqual(calls, [1, 2, 3, 1]);
+		});
+
+		test('does everything', () => {
+			const ev = Event.chain2(em.event, $ => $
+				.filter(v => v % 2 === 0)
+				.map(v => v * 2)
+				.reduce((acc, v) => acc + v, 0)
+				.latch()
+			);
+
+			store.add(ev(v => calls.push(v)));
+			em.fire(1);
+			em.fire(2);
+			em.fire(3);
+			em.fire(4);
+			em.fire(0);
+			assert.deepStrictEqual(calls, [4, 12]);
+		});
+	});
 });

--- a/src/vs/workbench/contrib/testing/common/observableValue.ts
+++ b/src/vs/workbench/contrib/testing/common/observableValue.ts
@@ -35,7 +35,8 @@ export class MutableObservableValue<T> extends Disposable implements IObservable
 
 	public static stored<T>(stored: StoredValue<T>, defaultValue: T) {
 		const o = new MutableObservableValue(stored.get(defaultValue));
-		o.onDidChange(value => stored.store(value));
+		o._register(stored);
+		o._register(o.onDidChange(value => stored.store(value)));
 		return o;
 	}
 

--- a/src/vs/workbench/contrib/testing/common/testExplorerFilterState.ts
+++ b/src/vs/workbench/contrib/testing/common/testExplorerFilterState.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 import { Emitter, Event } from 'vs/base/common/event';
 import { splitGlobAware } from 'vs/base/common/glob';
+import { Disposable } from 'vs/base/common/lifecycle';
 import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
 import { IStorageService, StorageScope, StorageTarget } from 'vs/platform/storage/common/storage';
 import { IObservableValue, MutableObservableValue } from 'vs/workbench/contrib/testing/common/observableValue';
@@ -68,7 +69,7 @@ export const ITestExplorerFilterState = createDecorator<ITestExplorerFilterState
 const tagRe = /!?@([^ ,:]+)/g;
 const trimExtraWhitespace = (str: string) => str.replace(/\s\s+/g, ' ').trim();
 
-export class TestExplorerFilterState implements ITestExplorerFilterState {
+export class TestExplorerFilterState extends Disposable implements ITestExplorerFilterState {
 	declare _serviceBrand: undefined;
 	private readonly focusEmitter = new Emitter<void>();
 	/**
@@ -86,20 +87,22 @@ export class TestExplorerFilterState implements ITestExplorerFilterState {
 	public excludeTags = new Set<string>();
 
 	/** @inheritdoc */
-	public readonly text = new MutableObservableValue('');
+	public readonly text = this._register(new MutableObservableValue(''));
 
 	/** @inheritdoc */
-	public readonly fuzzy = MutableObservableValue.stored(new StoredValue<boolean>({
+	public readonly fuzzy = this._register(MutableObservableValue.stored(new StoredValue<boolean>({
 		key: 'testHistoryFuzzy',
 		scope: StorageScope.PROFILE,
 		target: StorageTarget.USER,
-	}, this.storageService), false);
+	}, this.storageService), false));
 
-	public readonly reveal = new MutableObservableValue</* test ID */string | undefined>(undefined);
+	public readonly reveal = this._register(new MutableObservableValue</* test ID */string | undefined>(undefined));
 
 	public readonly onDidRequestInputFocus = this.focusEmitter.event;
 
-	constructor(@IStorageService private readonly storageService: IStorageService) { }
+	constructor(@IStorageService private readonly storageService: IStorageService) {
+		super();
+	}
 
 	/** @inheritdoc */
 	public focusInput() {

--- a/src/vs/workbench/contrib/testing/common/testResultService.ts
+++ b/src/vs/workbench/contrib/testing/common/testResultService.ts
@@ -7,6 +7,7 @@ import { findFirstInSorted } from 'vs/base/common/arrays';
 import { RunOnceScheduler } from 'vs/base/common/async';
 import { Emitter, Event } from 'vs/base/common/event';
 import { once } from 'vs/base/common/functional';
+import { DisposableStore } from 'vs/base/common/lifecycle';
 import { generateUuid } from 'vs/base/common/uuid';
 import { IContextKey, IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
@@ -179,8 +180,9 @@ export class TestResultService implements ITestResultService {
 		}
 
 		if (result instanceof LiveTestResult) {
-			result.onComplete(() => this.onComplete(result));
-			result.onChange(this.testChangeEmitter.fire, this.testChangeEmitter);
+			const ds = new DisposableStore();
+			ds.add(result.onComplete(() => this.onComplete(result)));
+			ds.add(result.onChange(this.testChangeEmitter.fire, this.testChangeEmitter));
 			this.isRunning.set(true);
 			this.changeResultEmitter.fire({ started: result });
 		} else {

--- a/src/vs/workbench/contrib/testing/common/testResultStorage.ts
+++ b/src/vs/workbench/contrib/testing/common/testResultStorage.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { bufferToStream, newWriteableBufferStream, VSBuffer, VSBufferReadableStream, VSBufferWriteableStream } from 'vs/base/common/buffer';
+import { Disposable } from 'vs/base/common/lifecycle';
 import { isDefined } from 'vs/base/common/types';
 import { URI } from 'vs/base/common/uri';
 import { IEnvironmentService } from 'vs/platform/environment/common/environment';
@@ -44,19 +45,20 @@ export const ITestResultStorage = createDecorator('ITestResultStorage');
  */
 const currentRevision = 1;
 
-export abstract class BaseTestResultStorage implements ITestResultStorage {
+export abstract class BaseTestResultStorage extends Disposable implements ITestResultStorage {
 	declare readonly _serviceBrand: undefined;
 
-	protected readonly stored = new StoredValue<ReadonlyArray<{ rev: number; id: string; bytes: number }>>({
+	protected readonly stored = this._register(new StoredValue<ReadonlyArray<{ rev: number; id: string; bytes: number }>>({
 		key: 'storedTestResults',
 		scope: StorageScope.WORKSPACE,
 		target: StorageTarget.MACHINE
-	}, this.storageService);
+	}, this.storageService));
 
 	constructor(
 		@IStorageService private readonly storageService: IStorageService,
 		@ILogService private readonly logService: ILogService,
 	) {
+		super();
 	}
 
 	/**

--- a/src/vs/workbench/contrib/testing/test/browser/explorerProjections/hierarchalByLocation.test.ts
+++ b/src/vs/workbench/contrib/testing/test/browser/explorerProjections/hierarchalByLocation.test.ts
@@ -5,6 +5,8 @@
 
 import * as assert from 'assert';
 import { Emitter } from 'vs/base/common/event';
+import { DisposableStore } from 'vs/base/common/lifecycle';
+import { ensureNoDisposablesAreLeakedInTestSuite } from 'vs/base/test/common/utils';
 import { TreeProjection } from 'vs/workbench/contrib/testing/browser/explorerProjections/treeProjection';
 import { TestId } from 'vs/workbench/contrib/testing/common/testId';
 import { TestResultItemChange, TestResultItemChangeReason } from 'vs/workbench/contrib/testing/common/testResult';
@@ -19,9 +21,17 @@ suite('Workbench - Testing Explorer Hierarchal by Location Projection', () => {
 	let harness: TestTreeTestHarness<TestHierarchicalByLocationProjection>;
 	let onTestChanged: Emitter<TestResultItemChange>;
 	let resultsService: any;
+	let ds: DisposableStore;
+
+	teardown(() => {
+		ds.dispose();
+	});
+
+	ensureNoDisposablesAreLeakedInTestSuite();
 
 	setup(() => {
-		onTestChanged = new Emitter();
+		ds = new DisposableStore();
+		onTestChanged = ds.add(new Emitter());
 		resultsService = {
 			results: [],
 			onResultsChanged: () => undefined,
@@ -29,11 +39,7 @@ suite('Workbench - Testing Explorer Hierarchal by Location Projection', () => {
 			getStateById: () => ({ state: { state: 0 }, computedState: 0 }),
 		};
 
-		harness = new TestTreeTestHarness(l => new TestHierarchicalByLocationProjection({}, l, resultsService as any));
-	});
-
-	teardown(() => {
-		harness.dispose();
+		harness = ds.add(new TestTreeTestHarness(l => new TestHierarchicalByLocationProjection({}, l, resultsService as any)));
 	});
 
 	test('renders initial tree', async () => {

--- a/src/vs/workbench/contrib/testing/test/browser/testObjectTree.ts
+++ b/src/vs/workbench/contrib/testing/test/browser/testObjectTree.ts
@@ -104,7 +104,7 @@ export class TestTreeTestHarness<T extends ITestTreeProjection = ITestTreeProjec
 	constructor(makeTree: (listener: ITestService) => T, public readonly c = testStubs.nested()) {
 		super();
 		this._register(c);
-		this.c.onDidGenerateDiff(d => this.c.setDiff(d /* don't clear during testing */));
+		this._register(this.c.onDidGenerateDiff(d => this.c.setDiff(d /* don't clear during testing */)));
 
 		const collection = new MainThreadTestCollection((testId, levels) => {
 			this.c.expand(testId, levels);

--- a/src/vs/workbench/contrib/testing/test/common/testExplorerFilterState.test.ts
+++ b/src/vs/workbench/contrib/testing/test/common/testExplorerFilterState.test.ts
@@ -4,14 +4,24 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as assert from 'assert';
+import { DisposableStore } from 'vs/base/common/lifecycle';
+import { ensureNoDisposablesAreLeakedInTestSuite } from 'vs/base/test/common/utils';
 import { InMemoryStorageService } from 'vs/platform/storage/common/storage';
 import { TestExplorerFilterState, TestFilterTerm } from 'vs/workbench/contrib/testing/common/testExplorerFilterState';
 
-
 suite('TestExplorerFilterState', () => {
 	let t: TestExplorerFilterState;
+	let ds: DisposableStore;
+
+	teardown(() => {
+		ds.dispose();
+	});
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
 	setup(() => {
-		t = new TestExplorerFilterState(new InMemoryStorageService());
+		ds = new DisposableStore();
+		t = ds.add(new TestExplorerFilterState(ds.add(new InMemoryStorageService())));
 	});
 
 	const assertFilteringFor = (expected: { [T in TestFilterTerm]?: boolean }) => {

--- a/src/vs/workbench/contrib/testing/test/common/testProfileService.test.ts
+++ b/src/vs/workbench/contrib/testing/test/common/testProfileService.test.ts
@@ -6,6 +6,8 @@
 
 
 import * as assert from 'assert';
+import { DisposableStore } from 'vs/base/common/lifecycle';
+import { ensureNoDisposablesAreLeakedInTestSuite } from 'vs/base/test/common/utils';
 import { MockContextKeyService } from 'vs/platform/keybinding/test/common/mockKeybindingService';
 import { TestProfileService } from 'vs/workbench/contrib/testing/common/testProfileService';
 import { ITestRunProfile, TestRunProfileBitset } from 'vs/workbench/contrib/testing/common/testTypes';
@@ -13,13 +15,22 @@ import { TestStorageService } from 'vs/workbench/test/common/workbenchTestServic
 
 suite('Workbench - TestProfileService', () => {
 	let t: TestProfileService;
+	let ds: DisposableStore;
 	let idCounter = 0;
+
+	teardown(() => {
+		ds.dispose();
+	});
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
 	setup(() => {
 		idCounter = 0;
-		t = new TestProfileService(
+		ds = new DisposableStore();
+		t = ds.add(new TestProfileService(
 			new MockContextKeyService(),
-			new TestStorageService(),
-		);
+			ds.add(new TestStorageService()),
+		));
 	});
 
 	const addProfile = (profile: Partial<ITestRunProfile>) => {

--- a/src/vs/workbench/contrib/testing/test/common/testingUri.test.ts
+++ b/src/vs/workbench/contrib/testing/test/common/testingUri.test.ts
@@ -4,9 +4,12 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from 'vs/base/test/common/utils';
 import { buildTestUri, ParsedTestUri, parseTestUri, TestUriType } from 'vs/workbench/contrib/testing/common/testingUri';
 
 suite('Workbench - Testing URIs', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
 	test('round trip', () => {
 		const uris: ParsedTestUri[] = [
 			{ type: TestUriType.ResultActualOutput, taskIndex: 1, messageIndex: 42, resultId: 'r', testExtId: 't' },


### PR DESCRIPTION
This fixes disposable leaks in the testing tests. These tests also
encompass tree views. One big source of leaks I found was `Event.chain`:
technically, every step in the chain is an IDisposable and needs to be
disposed. However, this is very noisy and unergonomic.

As an alternative, I introduce a very small `chain2` implementation
which only requires disposing the resulting event listener, like an
ordinary emitter. It doesn't support debouncing, though it could we if
want it to; there was only a single usable of the chained `debounce`
method in our codebase.

For #190503

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
