### PR TITLE
Fix invalid match on `exited` DAP event

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/rawDebugSession.ts
+++ b/src/vs/workbench/contrib/debug/browser/rawDebugSession.ts
@@ -142,7 +142,7 @@ export class RawDebugSession implements IDisposable {
 				case 'terminated':
 					this._onDidTerminateDebugee.fire(<DebugProtocol.TerminatedEvent>event);
 					break;
-				case 'exit':
+				case 'exited':
 					this._onDidExitDebugee.fire(<DebugProtocol.ExitedEvent>event);
 					break;
 				case 'progressStart':


### PR DESCRIPTION
DAP spec states that the event is `exited` not `exit` https://microsoft.github.io/debug-adapter-protocol/specification#Events_Exited
Fixes https://github.com/microsoft/vscode/issues/192116
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
