### PR TITLE
Revert "Remove superfluous arg in git smoke.test.ts (#173194)"

### DIFF
--- a/extensions/git/src/test/smoke.test.ts
+++ b/extensions/git/src/test/smoke.test.ts
@@ -122,7 +122,7 @@ suite('git smoke test', function () {
 		repository.state.workingTreeChanges.some(r => r.uri.path === newfile.path && r.status === Status.UNTRACKED);
 		assert.strictEqual(repository.state.indexChanges.length, 0);
 
-		await commands.executeCommand('git.stageAll');
+		await commands.executeCommand('git.stageAll', appjs);
 		await repository.commit('third commit');
 		assert.strictEqual(repository.state.workingTreeChanges.length, 0);
 		assert.strictEqual(repository.state.indexChanges.length, 0);


### PR DESCRIPTION
This reverts commit 9dd556a9e06a6f9b5d7e734fea9ec00d34071a63.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
