### PR TITLE
commands: add hideActivityBar and hideStatusBar

### DIFF
--- a/src/vs/workbench/browser/actions/layoutActions.ts
+++ b/src/vs/workbench/browser/actions/layoutActions.ts
@@ -67,6 +67,48 @@ registerAction2(class extends Action2 {
 	}
 });
 
+// --- Hide Activity Bar
+
+registerAction2(class extends Action2 {
+
+	constructor() {
+		super({
+			id: 'workbench.action.hideActivityBar',
+			title: {
+				value: localize('hideActivityBar', "Hide Acitivity Bar"),
+				original: 'Hide Acitivity Bar'
+			},
+			category: Categories.View,
+			f1: true
+		});
+	}
+
+	run(accessor: ServicesAccessor): void {
+		accessor.get(IWorkbenchLayoutService).setPartHidden(true, Parts.ACTIVITYBAR_PART);
+	}
+});
+
+// --- Hide Status Bar
+
+registerAction2(class extends Action2 {
+
+	constructor() {
+		super({
+			id: 'workbench.action.hideStatusBar',
+			title: {
+				value: localize('hideStatusBar', "Hide Status Bar"),
+				original: 'Hide Status Bar'
+			},
+			category: Categories.View,
+			f1: true
+		});
+	}
+
+	run(accessor: ServicesAccessor): void {
+		accessor.get(IWorkbenchLayoutService).setPartHidden(true, Parts.STATUSBAR_PART);
+	}
+});
+
 // --- Toggle Activity Bar
 
 export class ToggleActivityBarVisibilityAction extends Action2 {

--- a/src/vs/workbench/browser/layout.ts
+++ b/src/vs/workbench/browser/layout.ts
@@ -1843,6 +1843,8 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 				return this.setAuxiliaryBarHidden(hidden);
 			case Parts.PANEL_PART:
 				return this.setPanelHidden(hidden);
+			case Parts.STATUSBAR_PART:
+				return this.setStatusBarHidden(hidden);
 		}
 	}
 

--- a/src/vs/workbench/services/layout/browser/layoutService.ts
+++ b/src/vs/workbench/services/layout/browser/layoutService.ts
@@ -168,7 +168,7 @@ export interface IWorkbenchLayoutService extends ILayoutService {
 	/**
 	 * Set part hidden or not
 	 */
-	setPartHidden(hidden: boolean, part: Exclude<Parts, Parts.STATUSBAR_PART | Parts.TITLEBAR_PART>): void;
+	setPartHidden(hidden: boolean, part: Exclude<Parts, Parts.TITLEBAR_PART>): void;
 
 	/**
 	 * Maximizes the panel height if the panel is not already maximized.


### PR DESCRIPTION
This'll help extensions hide these deterministically instead of just toggling and hoping for the best (without having a way of telling if they're visible or not).

Assuming this is okay, I don't have an opinion on surfacing these in the Command Palette, although I'm surfacing them ATM.

(Working around #191959.)