### PR TITLE
eng: replace Event.chain with Event.chain2

### DIFF
--- a/src/vs/base/browser/ui/list/listWidget.ts
+++ b/src/vs/base/browser/ui/list/listWidget.ts
@@ -297,7 +297,7 @@ class KeyboardController<T> implements IDisposable {
 
 	@memoize
 	private get onKeyDown(): Event<StandardKeyboardEvent> {
-		return Event.chain2(
+		return Event.chain(
 			this.disposables.add(new DomEmitter(this.view.domNode, 'keydown')).event, $ =>
 			$.filter(e => !isInputElement(e.target as HTMLElement))
 				.map(e => new StandardKeyboardEvent(e))
@@ -474,7 +474,7 @@ class TypeNavigationController<T> implements IDisposable {
 
 		let typing = false;
 
-		const onChar = Event.chain2(this.enabledDisposables.add(new DomEmitter(this.view.domNode, 'keydown')).event, $ =>
+		const onChar = Event.chain(this.enabledDisposables.add(new DomEmitter(this.view.domNode, 'keydown')).event, $ =>
 			$.filter(e => !isInputElement(e.target as HTMLElement))
 				.filter(() => this.mode === TypeNavigationMode.Automatic || this.triggered)
 				.map(event => new StandardKeyboardEvent(event))
@@ -580,12 +580,12 @@ class DOMFocusController<T> implements IDisposable {
 		private list: List<T>,
 		private view: IListView<T>
 	) {
-		const onKeyDown = Event.chain2(this.disposables.add(new DomEmitter(view.domNode, 'keydown')).event, $ => $
+		const onKeyDown = Event.chain(this.disposables.add(new DomEmitter(view.domNode, 'keydown')).event, $ => $
 			.filter(e => !isInputElement(e.target as HTMLElement))
 			.map(e => new StandardKeyboardEvent(e))
 		);
 
-		const onTab = Event.chain2(onKeyDown, $ => $.filter(e => e.keyCode === KeyCode.Tab && !e.ctrlKey && !e.metaKey && !e.shiftKey && !e.altKey));
+		const onTab = Event.chain(onKeyDown, $ => $.filter(e => e.keyCode === KeyCode.Tab && !e.ctrlKey && !e.metaKey && !e.shiftKey && !e.altKey));
 
 		onTab(this.onTab, this, this.disposables);
 	}
@@ -1360,13 +1360,13 @@ export class List<T> implements ISpliceable<T>, IDisposable {
 	@memoize get onContextMenu(): Event<IListContextMenuEvent<T>> {
 		let didJustPressContextMenuKey = false;
 
-		const fromKeyDown: Event<any> = Event.chain2(this.disposables.add(new DomEmitter(this.view.domNode, 'keydown')).event, $ =>
+		const fromKeyDown: Event<any> = Event.chain(this.disposables.add(new DomEmitter(this.view.domNode, 'keydown')).event, $ =>
 			$.map(e => new StandardKeyboardEvent(e))
 				.filter(e => didJustPressContextMenuKey = e.keyCode === KeyCode.ContextMenu || (e.shiftKey && e.keyCode === KeyCode.F10))
 				.map(e => EventHelper.stop(e, true))
 				.filter(() => false));
 
-		const fromKeyUp = Event.chain2(this.disposables.add(new DomEmitter(this.view.domNode, 'keyup')).event, $ =>
+		const fromKeyUp = Event.chain(this.disposables.add(new DomEmitter(this.view.domNode, 'keyup')).event, $ =>
 			$.forEach(() => didJustPressContextMenuKey = false)
 				.map(e => new StandardKeyboardEvent(e))
 				.filter(e => e.keyCode === KeyCode.ContextMenu || (e.shiftKey && e.keyCode === KeyCode.F10))
@@ -1379,7 +1379,7 @@ export class List<T> implements ISpliceable<T>, IDisposable {
 					return { index, element, anchor, browserEvent };
 				}));
 
-		const fromMouse = Event.chain2(this.view.onContextMenu, $ =>
+		const fromMouse = Event.chain(this.view.onContextMenu, $ =>
 			$.filter(_ => !didJustPressContextMenuKey)
 				.map(({ element, index, browserEvent }) => ({ element, index, anchor: new StandardMouseEvent(browserEvent), browserEvent }))
 		);

--- a/src/vs/base/browser/ui/selectBox/selectBoxCustom.ts
+++ b/src/vs/base/browser/ui/selectBox/selectBoxCustom.ts
@@ -752,20 +752,21 @@ export class SelectBoxList extends Disposable implements ISelectBoxDelegate, ILi
 
 		// SetUp list keyboard controller - control navigation, disabled items, focus
 		const onKeyDown = this._register(new DomEmitter(this.selectDropDownListContainer, 'keydown'));
-		const onSelectDropDownKeyDown = Event.chain(onKeyDown.event)
-			.filter(() => this.selectList.length > 0)
-			.map(e => new StandardKeyboardEvent(e));
+		const onSelectDropDownKeyDown = Event.chain(onKeyDown.event, $ =>
+			$.filter(() => this.selectList.length > 0)
+				.map(e => new StandardKeyboardEvent(e))
+		);
 
-		this._register(onSelectDropDownKeyDown.filter(e => e.keyCode === KeyCode.Enter).on(e => this.onEnter(e), this));
-		this._register(onSelectDropDownKeyDown.filter(e => e.keyCode === KeyCode.Tab).on(e => this.onEnter(e), this)); // Tab should behave the same as enter, #79339
-		this._register(onSelectDropDownKeyDown.filter(e => e.keyCode === KeyCode.Escape).on(e => this.onEscape(e), this));
-		this._register(onSelectDropDownKeyDown.filter(e => e.keyCode === KeyCode.UpArrow).on(e => this.onUpArrow(e), this));
-		this._register(onSelectDropDownKeyDown.filter(e => e.keyCode === KeyCode.DownArrow).on(e => this.onDownArrow(e), this));
-		this._register(onSelectDropDownKeyDown.filter(e => e.keyCode === KeyCode.PageDown).on(this.onPageDown, this));
-		this._register(onSelectDropDownKeyDown.filter(e => e.keyCode === KeyCode.PageUp).on(this.onPageUp, this));
-		this._register(onSelectDropDownKeyDown.filter(e => e.keyCode === KeyCode.Home).on(this.onHome, this));
-		this._register(onSelectDropDownKeyDown.filter(e => e.keyCode === KeyCode.End).on(this.onEnd, this));
-		this._register(onSelectDropDownKeyDown.filter(e => (e.keyCode >= KeyCode.Digit0 && e.keyCode <= KeyCode.KeyZ) || (e.keyCode >= KeyCode.Semicolon && e.keyCode <= KeyCode.NumpadDivide)).on(this.onCharacter, this));
+		this._register(Event.chain(onSelectDropDownKeyDown, $ => $.filter(e => e.keyCode === KeyCode.Enter))(this.onEnter, this));
+		this._register(Event.chain(onSelectDropDownKeyDown, $ => $.filter(e => e.keyCode === KeyCode.Tab))(this.onEnter, this)); // Tab should behave the same as enter, #79339
+		this._register(Event.chain(onSelectDropDownKeyDown, $ => $.filter(e => e.keyCode === KeyCode.Escape))(this.onEscape, this));
+		this._register(Event.chain(onSelectDropDownKeyDown, $ => $.filter(e => e.keyCode === KeyCode.UpArrow))(this.onUpArrow, this));
+		this._register(Event.chain(onSelectDropDownKeyDown, $ => $.filter(e => e.keyCode === KeyCode.DownArrow))(this.onDownArrow, this));
+		this._register(Event.chain(onSelectDropDownKeyDown, $ => $.filter(e => e.keyCode === KeyCode.PageDown))(this.onPageDown, this));
+		this._register(Event.chain(onSelectDropDownKeyDown, $ => $.filter(e => e.keyCode === KeyCode.PageUp))(this.onPageUp, this));
+		this._register(Event.chain(onSelectDropDownKeyDown, $ => $.filter(e => e.keyCode === KeyCode.Home))(this.onHome, this));
+		this._register(Event.chain(onSelectDropDownKeyDown, $ => $.filter(e => e.keyCode === KeyCode.End))(this.onEnd, this));
+		this._register(Event.chain(onSelectDropDownKeyDown, $ => $.filter(e => (e.keyCode >= KeyCode.Digit0 && e.keyCode <= KeyCode.KeyZ) || (e.keyCode >= KeyCode.Semicolon && e.keyCode <= KeyCode.NumpadDivide)))(this.onCharacter, this));
 
 		// SetUp list mouse controller - control navigation, disabled items, focus
 		this._register(dom.addDisposableListener(this.selectList.getHTMLElement(), dom.EventType.POINTER_UP, e => this.onPointerUp(e)));

--- a/src/vs/base/browser/ui/tree/abstractTree.ts
+++ b/src/vs/base/browser/ui/tree/abstractTree.ts
@@ -814,7 +814,7 @@ class FindWidget<T, TFilterData> extends Disposable {
 		this.mode = mode;
 
 		const emitter = this._register(new DomEmitter(this.findInput.inputBox.inputElement, 'keydown'));
-		const onKeyDown = Event.chain2(emitter.event, $ => $.map(e => new StandardKeyboardEvent(e)));
+		const onKeyDown = Event.chain(emitter.event, $ => $.map(e => new StandardKeyboardEvent(e)));
 
 		this._register(onKeyDown((e): any => {
 			// Using equals() so we reserve modified keys for future use
@@ -884,7 +884,7 @@ class FindWidget<T, TFilterData> extends Disposable {
 			}));
 		}));
 
-		const onGrabKeyDown = Event.chain2(this._register(new DomEmitter(this.elements.grab, 'keydown')).event, $ => $.map(e => new StandardKeyboardEvent(e)));
+		const onGrabKeyDown = Event.chain(this._register(new DomEmitter(this.elements.grab, 'keydown')).event, $ => $.map(e => new StandardKeyboardEvent(e)));
 
 		this._register(onGrabKeyDown((e): any => {
 			let right: number | undefined;
@@ -1640,14 +1640,14 @@ export abstract class AbstractTree<T, TFilterData, TRef> implements IDisposable 
 		onDidChangeActiveNodes.input = activeNodesEmitter.event;
 
 		if (_options.keyboardSupport !== false) {
-			const onKeyDown = Event.chain2(this.view.onKeyDown, $ =>
+			const onKeyDown = Event.chain(this.view.onKeyDown, $ =>
 				$.filter(e => !isInputElement(e.target as HTMLElement))
 					.map(e => new StandardKeyboardEvent(e))
 			);
 
-			Event.chain2(onKeyDown, $ => $.filter(e => e.keyCode === KeyCode.LeftArrow))(this.onLeftArrow, this, this.disposables);
-			Event.chain2(onKeyDown, $ => $.filter(e => e.keyCode === KeyCode.RightArrow))(this.onRightArrow, this, this.disposables);
-			Event.chain2(onKeyDown, $ => $.filter(e => e.keyCode === KeyCode.Space))(this.onSpace, this, this.disposables);
+			Event.chain(onKeyDown, $ => $.filter(e => e.keyCode === KeyCode.LeftArrow))(this.onLeftArrow, this, this.disposables);
+			Event.chain(onKeyDown, $ => $.filter(e => e.keyCode === KeyCode.RightArrow))(this.onRightArrow, this, this.disposables);
+			Event.chain(onKeyDown, $ => $.filter(e => e.keyCode === KeyCode.Space))(this.onSpace, this, this.disposables);
 		}
 
 		if ((_options.findWidgetEnabled ?? true) && _options.keyboardNavigationLabelProvider && _options.contextViewProvider) {

--- a/src/vs/base/test/common/event.test.ts
+++ b/src/vs/base/test/common/event.test.ts
@@ -1527,7 +1527,7 @@ suite('Event utils', () => {
 		});
 
 		test('maps', () => {
-			const ev = Event.chain2(em.event, $ => $.map(v => v * 2));
+			const ev = Event.chain(em.event, $ => $.map(v => v * 2));
 			store.add(ev(v => calls.push(v)));
 			em.fire(1);
 			em.fire(2);
@@ -1536,7 +1536,7 @@ suite('Event utils', () => {
 		});
 
 		test('filters', () => {
-			const ev = Event.chain2(em.event, $ => $.filter(v => v % 2 === 0));
+			const ev = Event.chain(em.event, $ => $.filter(v => v % 2 === 0));
 			store.add(ev(v => calls.push(v)));
 			em.fire(1);
 			em.fire(2);
@@ -1546,7 +1546,7 @@ suite('Event utils', () => {
 		});
 
 		test('reduces', () => {
-			const ev = Event.chain2(em.event, $ => $.reduce((acc, v) => acc + v, 0));
+			const ev = Event.chain(em.event, $ => $.reduce((acc, v) => acc + v, 0));
 			store.add(ev(v => calls.push(v)));
 			em.fire(1);
 			em.fire(2);
@@ -1556,7 +1556,7 @@ suite('Event utils', () => {
 		});
 
 		test('latches', () => {
-			const ev = Event.chain2(em.event, $ => $.latch());
+			const ev = Event.chain(em.event, $ => $.latch());
 			store.add(ev(v => calls.push(v)));
 			em.fire(1);
 			em.fire(1);
@@ -1569,7 +1569,7 @@ suite('Event utils', () => {
 		});
 
 		test('does everything', () => {
-			const ev = Event.chain2(em.event, $ => $
+			const ev = Event.chain(em.event, $ => $
 				.filter(v => v % 2 === 0)
 				.map(v => v * 2)
 				.reduce((acc, v) => acc + v, 0)

--- a/src/vs/editor/contrib/parameterHints/browser/parameterHintsWidget.ts
+++ b/src/vs/editor/contrib/parameterHints/browser/parameterHintsWidget.ts
@@ -14,7 +14,7 @@ import { escapeRegExpCharacters } from 'vs/base/common/strings';
 import { assertIsDefined } from 'vs/base/common/types';
 import 'vs/css!./parameterHints';
 import { ContentWidgetPositionPreference, ICodeEditor, IContentWidget, IContentWidgetPosition } from 'vs/editor/browser/editorBrowser';
-import { ConfigurationChangedEvent, EditorOption } from 'vs/editor/common/config/editorOptions';
+import { EditorOption } from 'vs/editor/common/config/editorOptions';
 import * as languages from 'vs/editor/common/languages';
 import { ILanguageService } from 'vs/editor/common/languages/language';
 import { IMarkdownRenderResult, MarkdownRenderer } from 'vs/editor/contrib/markdownRenderer/browser/markdownRenderer';
@@ -130,9 +130,10 @@ export class ParameterHintsWidget extends Disposable implements IContentWidget {
 
 		updateFont();
 
-		this._register(Event.chain<ConfigurationChangedEvent>(this.editor.onDidChangeConfiguration.bind(this.editor))
-			.filter(e => e.hasChanged(EditorOption.fontInfo))
-			.on(updateFont, null));
+		this._register(Event.chain(
+			this.editor.onDidChangeConfiguration.bind(this.editor),
+			$ => $.filter(e => e.hasChanged(EditorOption.fontInfo))
+		)(updateFont));
 
 		this._register(this.editor.onDidLayoutChange(e => this.updateMaxHeight()));
 		this.updateMaxHeight();

--- a/src/vs/platform/opener/browser/link.ts
+++ b/src/vs/platform/opener/browser/link.ts
@@ -93,10 +93,10 @@ export class Link extends Disposable {
 
 		const onClickEmitter = this._register(new DomEmitter(this.el, 'click'));
 		const onKeyPress = this._register(new DomEmitter(this.el, 'keypress'));
-		const onEnterPress = Event.chain(onKeyPress.event)
-			.map(e => new StandardKeyboardEvent(e))
-			.filter(e => e.keyCode === KeyCode.Enter)
-			.event;
+		const onEnterPress = Event.chain(onKeyPress.event, $ =>
+			$.map(e => new StandardKeyboardEvent(e))
+				.filter(e => e.keyCode === KeyCode.Enter)
+		);
 		const onTap = this._register(new DomEmitter(this.el, TouchEventType.Tap)).event;
 		this._register(Gesture.addTarget(this.el));
 		const onOpen = Event.any<EventLike>(onClickEmitter.event, onEnterPress, onTap);

--- a/src/vs/platform/quickinput/browser/quickInputUtils.ts
+++ b/src/vs/platform/quickinput/browser/quickInputUtils.ts
@@ -67,11 +67,11 @@ export function renderQuickInputDescription(description: string, container: HTML
 
 			const onClick = actionHandler.disposables.add(new DomEmitter(anchor, dom.EventType.CLICK)).event;
 			const onKeydown = actionHandler.disposables.add(new DomEmitter(anchor, dom.EventType.KEY_DOWN)).event;
-			const onSpaceOrEnter = actionHandler.disposables.add(Event.chain(onKeydown)).filter(e => {
+			const onSpaceOrEnter = Event.chain(onKeydown, $ => $.filter(e => {
 				const event = new StandardKeyboardEvent(e);
 
 				return event.equals(KeyCode.Space) || event.equals(KeyCode.Enter);
-			}).event;
+			}));
 
 			actionHandler.disposables.add(Gesture.addTarget(anchor));
 			const onTap = actionHandler.disposables.add(new DomEmitter(anchor, GestureEventType.Tap)).event;

--- a/src/vs/workbench/browser/parts/notifications/notificationsViewer.ts
+++ b/src/vs/workbench/browser/parts/notifications/notificationsViewer.ts
@@ -171,11 +171,11 @@ class NotificationMessageRenderer {
 					const onClick = actionHandler.toDispose.add(new DomEmitter(anchor, EventType.CLICK)).event;
 
 					const onKeydown = actionHandler.toDispose.add(new DomEmitter(anchor, EventType.KEY_DOWN)).event;
-					const onSpaceOrEnter = actionHandler.toDispose.add(Event.chain(onKeydown)).filter(e => {
+					const onSpaceOrEnter = Event.chain(onKeydown, $ => $.filter(e => {
 						const event = new StandardKeyboardEvent(e);
 
 						return event.equals(KeyCode.Space) || event.equals(KeyCode.Enter);
-					}).event;
+					}));
 
 					actionHandler.toDispose.add(Gesture.addTarget(anchor));
 					const onTap = actionHandler.toDispose.add(new DomEmitter(anchor, GestureEventType.Tap)).event;

--- a/src/vs/workbench/contrib/codeEditor/browser/suggestEnabledInput/suggestEnabledInput.ts
+++ b/src/vs/workbench/contrib/codeEditor/browser/suggestEnabledInput/suggestEnabledInput.ts
@@ -209,9 +209,8 @@ export class SuggestEnabledInput extends Widget {
 			this.stylingContainer.classList.remove('synthetic-focus');
 		})));
 
-		const onKeyDownMonaco = Event.chain(this.inputWidget.onKeyDown);
-		this._register(onKeyDownMonaco.filter(e => e.keyCode === KeyCode.Enter).on(e => { e.preventDefault(); /** Do nothing. Enter causes new line which is not expected. */ }, this));
-		this._register(onKeyDownMonaco.filter(e => e.keyCode === KeyCode.DownArrow && (isMacintosh ? e.metaKey : e.ctrlKey)).on(() => this._onShouldFocusResults.fire(), this));
+		this._register(Event.chain(this.inputWidget.onKeyDown, $ => $.filter(e => e.keyCode === KeyCode.Enter))(e => { e.preventDefault(); /** Do nothing. Enter causes new line which is not expected. */ }, this));
+		this._register(Event.chain(this.inputWidget.onKeyDown, $ => $.filter(e => e.keyCode === KeyCode.DownArrow && (isMacintosh ? e.metaKey : e.ctrlKey)))(() => this._onShouldFocusResults.fire(), this));
 
 		let preexistingContent = this.getValue();
 		const inputWidgetModel = this.inputWidget.getModel();

--- a/src/vs/workbench/contrib/extensions/browser/extensionEditor.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionEditor.ts
@@ -398,10 +398,12 @@ export class ExtensionEditor extends EditorPane {
 			this._register(disposable);
 		}
 
-		this._register(Event.chain(extensionActionBar.onDidRun)
-			.map(({ error }) => error)
-			.filter(error => !!error)
-			.on(this.onError, this));
+		const onError = Event.chain(extensionActionBar.onDidRun, $ =>
+			$.map(({ error }) => error)
+				.filter(error => !!error)
+		);
+
+		this._register(onError(this.onError, this));
 
 		const body = append(root, $('.body'));
 		const navbar = new NavBar(body);

--- a/src/vs/workbench/contrib/extensions/common/extensionsUtils.ts
+++ b/src/vs/workbench/contrib/extensions/common/extensionsUtils.ts
@@ -75,13 +75,12 @@ export class KeymapExtensions extends Disposable implements IWorkbenchContributi
 function onExtensionChanged(accessor: ServicesAccessor): Event<IExtensionIdentifier[]> {
 	const extensionService = accessor.get(IExtensionManagementService);
 	const extensionEnablementService = accessor.get(IWorkbenchExtensionEnablementService);
-	const onDidInstallExtensions = Event.chain(extensionService.onDidInstallExtensions)
-		.filter(e => e.some(({ operation }) => operation === InstallOperation.Install))
-		.map(e => e.map(({ identifier }) => identifier))
-		.event;
+	const onDidInstallExtensions = Event.chain(extensionService.onDidInstallExtensions, $ =>
+		$.filter(e => e.some(({ operation }) => operation === InstallOperation.Install))
+			.map(e => e.map(({ identifier }) => identifier))
+	);
 	return Event.debounce<IExtensionIdentifier[], IExtensionIdentifier[]>(Event.any(
-		Event.chain(Event.any(onDidInstallExtensions, Event.map(extensionService.onDidUninstallExtension, e => [e.identifier])))
-			.event,
+		Event.any(onDidInstallExtensions, Event.map(extensionService.onDidUninstallExtension, e => [e.identifier])),
 		Event.map(extensionEnablementService.onEnablementChanged, extensions => extensions.map(e => e.identifier))
 	), (result: IExtensionIdentifier[] | undefined, identifiers: IExtensionIdentifier[]) => {
 		result = result || [];

--- a/src/vs/workbench/contrib/markers/browser/markersTable.ts
+++ b/src/vs/workbench/contrib/markers/browser/markersTable.ts
@@ -326,11 +326,11 @@ export class MarkersTable extends Disposable implements IProblemsWidget {
 		const list = this.table.domNode.querySelector('.monaco-list-rows')! as HTMLElement;
 
 		// mouseover/mouseleave event handlers
-		const onRowHover = Event.chain(this._register(new DomEmitter(list, 'mouseover')).event)
-			.map(e => DOM.findParentWithClass(e.target as HTMLElement, 'monaco-list-row', 'monaco-list-rows'))
-			.filter<HTMLElement>(((e: HTMLElement | null) => !!e) as any)
-			.map(e => parseInt(e.getAttribute('data-index')!))
-			.event;
+		const onRowHover = Event.chain(this._register(new DomEmitter(list, 'mouseover')).event, $ =>
+			$.map(e => DOM.findParentWithClass(e.target as HTMLElement, 'monaco-list-row', 'monaco-list-rows'))
+				.filter<HTMLElement>(((e: HTMLElement | null) => !!e) as any)
+				.map(e => parseInt(e.getAttribute('data-index')!))
+		);
 
 		const onListLeave = Event.map(this._register(new DomEmitter(list, 'mouseleave')).event, () => -1);
 

--- a/src/vs/workbench/contrib/scm/browser/dirtydiffDecorator.ts
+++ b/src/vs/workbench/contrib/scm/browser/dirtydiffDecorator.ts
@@ -862,10 +862,12 @@ export class DirtyDiffController extends Disposable implements DirtyDiffContribu
 
 		const disposables = new DisposableStore();
 		disposables.add(Event.once(this.widget.onDidClose)(this.close, this));
-		Event.chain(model.onDidChange)
-			.filter(e => e.diff.length > 0)
-			.map(e => e.diff)
-			.event(this.onDidModelChange, this, disposables);
+		const onDidModelChange = Event.chain(model.onDidChange, $ =>
+			$.filter(e => e.diff.length > 0)
+				.map(e => e.diff)
+		);
+
+		onDidModelChange(this.onDidModelChange, this, disposables);
 
 		disposables.add(this.widget);
 		disposables.add(toDisposable(() => {


### PR DESCRIPTION
Followup from #192026

Removes the original leak-prone implementation of Event.chain and
replaces it with `chain2` which only requires disposable of the
resulting listener.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
