### PR TITLE
feat: support format on type in SCM input

### DIFF
--- a/src/vs/editor/contrib/format/browser/formatActions.ts
+++ b/src/vs/editor/contrib/format/browser/formatActions.ts
@@ -27,7 +27,7 @@ import { IInstantiationService } from 'vs/platform/instantiation/common/instanti
 import { KeybindingWeight } from 'vs/platform/keybinding/common/keybindingsRegistry';
 import { IEditorProgressService, Progress } from 'vs/platform/progress/common/progress';
 
-class FormatOnType implements IEditorContribution {
+export class FormatOnType implements IEditorContribution {
 
 	public static readonly ID = 'editor.contrib.autoFormat';
 

--- a/src/vs/workbench/contrib/scm/browser/scmViewPane.ts
+++ b/src/vs/workbench/contrib/scm/browser/scmViewPane.ts
@@ -96,6 +96,7 @@ import { IDragAndDropData } from 'vs/base/browser/dnd';
 import { fillEditorsDragData } from 'vs/workbench/browser/dnd';
 import { ElementsDragAndDropData } from 'vs/base/browser/ui/list/listView';
 import { CodeDataTransfers } from 'vs/platform/dnd/browser/dnd';
+import { FormatOnType } from 'vs/editor/contrib/format/browser/formatActions';
 
 type TreeElement = ISCMRepository | ISCMInput | ISCMActionButton | ISCMResourceGroup | IResourceNode<ISCMResource, ISCMResourceGroup> | ISCMResource;
 
@@ -2025,6 +2026,7 @@ class SCMInputWidget {
 			quickSuggestions: false,
 			scrollbar: { alwaysConsumeMouseWheel: false },
 			overflowWidgetsDomNode,
+			formatOnType: true,
 			renderWhitespace: 'none',
 			dropIntoEditor: { enabled: true }
 		};
@@ -2045,6 +2047,7 @@ class SCMInputWidget {
 				SuggestController.ID,
 				InlineCompletionsController.ID,
 				CodeActionController.ID,
+				FormatOnType.ID
 			])
 		};
 


### PR DESCRIPTION
I exclusively use the SCM input box for writing commit messages and have
wanted the ability to wrap my commit messages to fit the 50/72 rule so
they show up nicely on GitHub. @connor4312 wraps commit messages but by
using a vertical editor ruler. Since the SCM input box is hooked up to
code actions, I've implemented a quick fix for the input box that shows
up with `Ctrl+.` (https://github.com/joyceerhl/vscode-git-fit-commit),
but since the lightbulb is disabled for the SCM input, it's easy to miss
that a fix is available. I would also like to make formatting more
automatic, but unfortunately the SCM input isn't hooked up to format on
type yet--so this PR enables format on type for the SCM input box.
