### PR TITLE
Rename `--disable-keytar` to `--use-inmemory-secretstorage`

### DIFF
--- a/scripts/test-integration.bat
+++ b/scripts/test-integration.bat
@@ -35,7 +35,7 @@ if %errorlevel% neq 0 exit /b %errorlevel%
 
 :: Tests in the extension host
 
-set API_TESTS_EXTRA_ARGS=--disable-telemetry --skip-welcome --skip-release-notes --crash-reporter-directory=%VSCODECRASHDIR% --logsPath=%VSCODELOGSDIR% --no-cached-data --disable-updates --disable-keytar --disable-extensions --disable-workspace-trust --user-data-dir=%VSCODEUSERDATADIR%
+set API_TESTS_EXTRA_ARGS=--disable-telemetry --skip-welcome --skip-release-notes --crash-reporter-directory=%VSCODECRASHDIR% --logsPath=%VSCODELOGSDIR% --no-cached-data --disable-updates --use-inmemory-secretstorage --disable-extensions --disable-workspace-trust --user-data-dir=%VSCODEUSERDATADIR%
 
 echo.
 echo ### API tests (folder)

--- a/scripts/test-integration.sh
+++ b/scripts/test-integration.sh
@@ -44,7 +44,7 @@ echo
 
 # Tests in the extension host
 
-API_TESTS_EXTRA_ARGS="--disable-telemetry --skip-welcome --skip-release-notes --crash-reporter-directory=$VSCODECRASHDIR --logsPath=$VSCODELOGSDIR --no-cached-data --disable-updates --disable-keytar --disable-extensions --disable-workspace-trust --user-data-dir=$VSCODEUSERDATADIR"
+API_TESTS_EXTRA_ARGS="--disable-telemetry --skip-welcome --skip-release-notes --crash-reporter-directory=$VSCODECRASHDIR --logsPath=$VSCODELOGSDIR --no-cached-data --disable-updates --use-inmemory-secretstorage --disable-extensions --disable-workspace-trust --user-data-dir=$VSCODEUSERDATADIR"
 
 if [ -z "$INTEGRATION_TEST_APP_NAME" ]; then
 	kill_app() { true; }

--- a/scripts/test-remote-integration.bat
+++ b/scripts/test-remote-integration.bat
@@ -55,7 +55,7 @@ echo Storing log files into '%VSCODELOGSDIR%'
 
 :: Tests in the extension host
 
-set API_TESTS_EXTRA_ARGS=--disable-telemetry --skip-welcome --skip-release-notes --crash-reporter-directory=%VSCODECRASHDIR% --logsPath=%VSCODELOGSDIR% --no-cached-data --disable-updates --disable-keytar --disable-inspect --disable-workspace-trust --user-data-dir=%VSCODEUSERDATADIR%
+set API_TESTS_EXTRA_ARGS=--disable-telemetry --skip-welcome --skip-release-notes --crash-reporter-directory=%VSCODECRASHDIR% --logsPath=%VSCODELOGSDIR% --no-cached-data --disable-updates --use-inmemory-secretstorage --disable-inspect --disable-workspace-trust --user-data-dir=%VSCODEUSERDATADIR%
 
 echo.
 echo ### API tests (folder)

--- a/scripts/test-remote-integration.sh
+++ b/scripts/test-remote-integration.sh
@@ -68,7 +68,7 @@ else
 	kill_app() { killall $INTEGRATION_TEST_APP_NAME || true; }
 fi
 
-API_TESTS_EXTRA_ARGS="--disable-telemetry --skip-welcome --skip-release-notes --crash-reporter-directory=$VSCODECRASHDIR --logsPath=$VSCODELOGSDIR --no-cached-data --disable-updates --disable-keytar --disable-workspace-trust --user-data-dir=$VSCODEUSERDATADIR"
+API_TESTS_EXTRA_ARGS="--disable-telemetry --skip-welcome --skip-release-notes --crash-reporter-directory=$VSCODECRASHDIR --logsPath=$VSCODELOGSDIR --no-cached-data --disable-updates --use-inmemory-secretstorage --disable-workspace-trust --user-data-dir=$VSCODEUSERDATADIR"
 
 echo "Storing crash reports into '$VSCODECRASHDIR'."
 echo "Storing log files into '$VSCODELOGSDIR'."

--- a/src/vs/platform/environment/common/argv.ts
+++ b/src/vs/platform/environment/common/argv.ts
@@ -91,7 +91,7 @@ export interface NativeParsedArgs {
 	'export-default-configuration'?: string;
 	'install-source'?: string;
 	'disable-updates'?: boolean;
-	'disable-keytar'?: boolean;
+	'use-inmemory-secretstorage'?: boolean;
 	'password-store'?: string;
 	'disable-workspace-trust'?: boolean;
 	'disable-crash-reporter'?: boolean;

--- a/src/vs/platform/environment/common/environment.ts
+++ b/src/vs/platform/environment/common/environment.ts
@@ -141,8 +141,8 @@ export interface INativeEnvironmentService extends IEnvironmentService {
 	extensionsDownloadLocation: URI;
 	builtinExtensionsPath: string;
 
-	// --- use keytar for credentials
-	disableKeytar?: boolean;
+	// --- use in-memory Secret Storage
+	useInMemorySecretStorage?: boolean;
 
 	crossOriginIsolated?: boolean;
 

--- a/src/vs/platform/environment/common/environmentService.ts
+++ b/src/vs/platform/environment/common/environmentService.ts
@@ -237,7 +237,7 @@ export abstract class AbstractNativeEnvironmentService implements INativeEnviron
 	get disableWorkspaceTrust(): boolean { return !!this.args['disable-workspace-trust']; }
 
 	@memoize
-	get disableKeytar(): boolean { return !!this.args['disable-keytar']; }
+	get useInMemorySecretStorage(): boolean { return !!this.args['use-inmemory-secretstorage']; }
 
 	@memoize
 	get policyFile(): URI | undefined {

--- a/src/vs/platform/environment/node/argv.ts
+++ b/src/vs/platform/environment/node/argv.ts
@@ -149,7 +149,7 @@ export const OPTIONS: OptionDescriptions<Required<NativeParsedArgs>> = {
 	'skip-welcome': { type: 'boolean' },
 	'disable-telemetry': { type: 'boolean' },
 	'disable-updates': { type: 'boolean' },
-	'disable-keytar': { type: 'boolean' },
+	'use-inmemory-secretstorage': { type: 'boolean', deprecates: ['disable-keytar'] },
 	'password-store': { type: 'string' },
 	'disable-workspace-trust': { type: 'boolean' },
 	'disable-crash-reporter': { type: 'boolean' },

--- a/src/vs/workbench/services/secrets/electron-sandbox/secretStorageService.ts
+++ b/src/vs/workbench/services/secrets/electron-sandbox/secretStorageService.ts
@@ -31,8 +31,7 @@ export class NativeSecretStorageService extends BaseSecretStorageService {
 		@ILogService logService: ILogService
 	) {
 		super(
-			// TODO: rename disableKeytar to disableSecretStorage or similar
-			!!_environmentService.disableKeytar,
+			!!_environmentService.useInMemorySecretStorage,
 			storageService,
 			encryptionService,
 			logService
@@ -43,7 +42,7 @@ export class NativeSecretStorageService extends BaseSecretStorageService {
 		this._sequencer.queue(key, async () => {
 			await this.resolvedStorageService;
 
-			if (this.type !== 'persisted' && !this._environmentService.disableKeytar) {
+			if (this.type !== 'persisted' && !this._environmentService.useInMemorySecretStorage) {
 				this._logService.trace('[NativeSecretStorageService] Notifying user that secrets are not being stored on disk.');
 				await this.notifyOfNoEncryptionOnce();
 			}

--- a/test/automation/src/electron.ts
+++ b/test/automation/src/electron.ts
@@ -29,7 +29,7 @@ export async function resolveElectronConfiguration(options: LaunchOptions): Prom
 		'--disable-telemetry',
 		'--no-cached-data',
 		'--disable-updates',
-		'--disable-keytar',
+		'--use-inmemory-secretstorage',
 		`--crash-reporter-directory=${crashesPath}`,
 		'--disable-workspace-trust',
 		`--extensions-dir=${extensionsPath}`,


### PR DESCRIPTION
This renames the flag as the title suggests but keeps `--disable-keytar` in the `deprecates` section so it still works.

Fixes https://github.com/microsoft/vscode/issues/191498

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
