### PR TITLE
WIP -- rework nb codeactions + api change

### DIFF
--- a/src/vs/editor/common/languages.ts
+++ b/src/vs/editor/common/languages.ts
@@ -744,7 +744,7 @@ export interface CodeAction {
 	command?: Command;
 	edit?: WorkspaceEdit;
 	diagnostics?: IMarkerData[];
-	kind?: string;
+	kind?: CodeActionKind;
 	isPreferred?: boolean;
 	disabled?: string;
 }
@@ -754,11 +754,16 @@ export const enum CodeActionTriggerType {
 	Auto = 2,
 }
 
+export interface CodeActionKind {
+	value: string;
+	notebook?: boolean;
+}
+
 /**
  * @internal
  */
 export interface CodeActionContext {
-	only?: string;
+	only?: CodeActionKind;
 	trigger: CodeActionTriggerType;
 }
 
@@ -788,7 +793,7 @@ export interface CodeActionProvider {
 	/**
 	 * Optional list of CodeActionKinds that this provider returns.
 	 */
-	readonly providedCodeActionKinds?: ReadonlyArray<string>;
+	readonly providedCodeActionKinds?: ReadonlyArray<CodeActionKind>;
 
 	readonly documentation?: ReadonlyArray<{ readonly kind: string; readonly command: Command }>;
 

--- a/src/vs/editor/contrib/codeAction/browser/codeAction.ts
+++ b/src/vs/editor/contrib/codeAction/browser/codeAction.ts
@@ -74,7 +74,7 @@ class ManagedCodeActionSet extends Disposable implements CodeActionSet {
 	}
 
 	public get hasAutoFix() {
-		return this.validActions.some(({ action: fix }) => !!fix.kind && CodeActionKind.QuickFix.contains(new CodeActionKind(fix.kind)) && !!fix.isPreferred);
+		return this.validActions.some(({ action: fix }) => !!fix.kind && CodeActionKind.QuickFix.contains(new CodeActionKind(fix.kind.value)) && !!fix.isPreferred);
 	}
 }
 
@@ -90,8 +90,8 @@ export async function getCodeActions(
 ): Promise<CodeActionSet> {
 	const filter = trigger.filter || {};
 
-	const codeActionContext: languages.CodeActionContext = {
-		only: filter.include?.value,
+	const codeActionContext = {
+		only: filter.include,
 		trigger: trigger.type,
 	};
 
@@ -159,7 +159,7 @@ function getCodeActionProviders(
 				// We don't know what type of actions this provider will return.
 				return true;
 			}
-			return provider.providedCodeActionKinds.some(kind => mayIncludeActionsOfKind(filter, new CodeActionKind(kind)));
+			return provider.providedCodeActionKinds.some(kind => mayIncludeActionsOfKind(filter, new CodeActionKind(kind.value)));
 		});
 }
 
@@ -172,7 +172,7 @@ function* getAdditionalDocumentationForShowingActions(
 	if (model && actionsToShow.length) {
 		for (const provider of registry.all(model)) {
 			if (provider._getAdditionalMenuItems) {
-				yield* provider._getAdditionalMenuItems?.({ trigger: trigger.type, only: trigger.filter?.include?.value }, actionsToShow.map(item => item.action));
+				yield* provider._getAdditionalMenuItems?.({ trigger: trigger.type, only: trigger.filter?.include }, actionsToShow.map(item => item.action));
 			}
 		}
 	}
@@ -215,7 +215,7 @@ function getDocumentationFromProvider(
 		}
 
 		for (const entry of documentation) {
-			if (entry.kind.contains(new CodeActionKind(action.kind))) {
+			if (entry.kind.contains(new CodeActionKind(action.kind.value))) {
 				return entry.command;
 			}
 		}
@@ -258,7 +258,7 @@ export async function applyCodeAction(
 
 	telemetryService.publicLog2<ApplyCodeActionEvent, ApplyCodeEventClassification>('codeAction.applyCodeAction', {
 		codeActionTitle: item.action.title,
-		codeActionKind: item.action.kind,
+		codeActionKind: item.action.kind?.value,
 		codeActionIsPreferred: !!item.action.isPreferred,
 		reason: codeActionReason,
 	});

--- a/src/vs/editor/contrib/codeAction/browser/codeActionKeybindingResolver.ts
+++ b/src/vs/editor/contrib/codeAction/browser/codeActionKeybindingResolver.ts
@@ -68,7 +68,7 @@ export class CodeActionKeybindingResolver {
 		if (!action.kind) {
 			return undefined;
 		}
-		const kind = new CodeActionKind(action.kind);
+		const kind = new CodeActionKind(action.kind.value);
 
 		return candidates
 			.filter(candidate => candidate.kind.contains(kind))

--- a/src/vs/editor/contrib/codeAction/browser/codeActionMenu.ts
+++ b/src/vs/editor/contrib/codeAction/browser/codeActionMenu.ts
@@ -53,7 +53,7 @@ export function toMenuItems(
 	const menuEntries = codeActionGroups.map(group => ({ group, actions: [] as CodeActionItem[] }));
 
 	for (const action of inputCodeActions) {
-		const kind = action.action.kind ? new CodeActionKind(action.action.kind) : CodeActionKind.None;
+		const kind = action.action.kind ? new CodeActionKind(action.action.kind.value) : CodeActionKind.None;
 		for (const menuEntry of menuEntries) {
 			if (menuEntry.group.kind.contains(kind)) {
 				menuEntry.actions.push(action);

--- a/src/vs/editor/contrib/codeAction/browser/codeActionModel.ts
+++ b/src/vs/editor/contrib/codeAction/browser/codeActionModel.ts
@@ -188,7 +188,7 @@ export class CodeActionModel extends Disposable {
 			&& this._registry.has(model)
 			&& !this._editor.getOption(EditorOption.readOnly)
 		) {
-			const supportedActions: string[] = this._registry.all(model).flatMap(provider => provider.providedCodeActionKinds ?? []);
+			const supportedActions: string[] = this._registry.all(model).flatMap(provider => provider.providedCodeActionKinds ?? []).flatMap(kind => kind.value);
 			this._supportedCodeActions.set(supportedActions.join(' '));
 
 			this._codeActionOracle.value = new CodeActionOracle(this._editor, this._markerService, trigger => {

--- a/src/vs/editor/contrib/codeAction/common/types.ts
+++ b/src/vs/editor/contrib/codeAction/common/types.ts
@@ -25,6 +25,8 @@ export class CodeActionKind {
 	public static readonly SourceFixAll = CodeActionKind.Source.append('fixAll');
 	public static readonly SurroundWith = CodeActionKind.Refactor.append('surround');
 
+	public notebook?: boolean;
+
 	constructor(
 		public readonly value: string
 	) { }
@@ -95,7 +97,7 @@ export function mayIncludeActionsOfKind(filter: CodeActionFilter, providedKind: 
 }
 
 export function filtersAction(filter: CodeActionFilter, action: languages.CodeAction): boolean {
-	const actionKind = action.kind ? new CodeActionKind(action.kind) : undefined;
+	const actionKind = action.kind ? new CodeActionKind(action.kind.value) : undefined;
 
 	// Filter out actions by kind
 	if (filter.include) {

--- a/src/vs/editor/contrib/codeAction/test/browser/codeAction.test.ts
+++ b/src/vs/editor/contrib/codeAction/test/browser/codeAction.test.ts
@@ -137,9 +137,9 @@ suite('CodeAction', () => {
 
 	test('getCodeActions should filter by scope', async () => {
 		const provider = staticCodeActionProvider(
-			{ title: 'a', kind: 'a' },
-			{ title: 'b', kind: 'b' },
-			{ title: 'a.b', kind: 'a.b' }
+			{ title: 'a', kind: new CodeActionKind('a') },
+			{ title: 'b', kind: new CodeActionKind('b') },
+			{ title: 'a.b', kind: new CodeActionKind('a.b') }
 		);
 
 		disposables.add(registry.register('fooLang', provider));
@@ -168,7 +168,7 @@ suite('CodeAction', () => {
 			provideCodeActions(_model: any, _range: Range, context: languages.CodeActionContext, _token: any): languages.CodeActionList {
 				return {
 					actions: [
-						{ title: context.only || '', kind: context.only }
+						{ title: context.only?.value || '', kind: context.only }
 					],
 					dispose: () => { }
 				};
@@ -184,8 +184,8 @@ suite('CodeAction', () => {
 
 	test('getCodeActions should not return source code action by default', async () => {
 		const provider = staticCodeActionProvider(
-			{ title: 'a', kind: CodeActionKind.Source.value },
-			{ title: 'b', kind: 'b' }
+			{ title: 'a', kind: CodeActionKind.Source },
+			{ title: 'b', kind: new CodeActionKind('b') }
 		);
 
 		disposables.add(registry.register('fooLang', provider));
@@ -205,9 +205,9 @@ suite('CodeAction', () => {
 
 	test('getCodeActions should support filtering out some requested source code actions #84602', async () => {
 		const provider = staticCodeActionProvider(
-			{ title: 'a', kind: CodeActionKind.Source.value },
-			{ title: 'b', kind: CodeActionKind.Source.append('test').value },
-			{ title: 'c', kind: 'c' }
+			{ title: 'a', kind: CodeActionKind.Source },
+			{ title: 'b', kind: CodeActionKind.Source.append('test') },
+			{ title: 'c', kind: new CodeActionKind('c') }
 		);
 
 		disposables.add(registry.register('fooLang', provider));
@@ -230,19 +230,19 @@ suite('CodeAction', () => {
 		const subType = CodeActionKind.Refactor.append('sub');
 
 		disposables.add(registry.register('fooLang', staticCodeActionProvider(
-			{ title: 'a', kind: baseType.value }
+			{ title: 'a', kind: baseType }
 		)));
 
 		let didInvoke = false;
 		disposables.add(registry.register('fooLang', new class implements languages.CodeActionProvider {
 
-			providedCodeActionKinds = [subType.value];
+			providedCodeActionKinds = [subType];
 
 			provideCodeActions(): languages.ProviderResult<languages.CodeActionList> {
 				didInvoke = true;
 				return {
 					actions: [
-						{ title: 'x', kind: subType.value }
+						{ title: 'x', kind: subType }
 					],
 					dispose: () => { }
 				};
@@ -270,7 +270,7 @@ suite('CodeAction', () => {
 				return { actions: [], dispose: () => { } };
 			}
 
-			providedCodeActionKinds = [CodeActionKind.Refactor.value];
+			providedCodeActionKinds = [CodeActionKind.Refactor];
 		};
 
 		disposables.add(registry.register('fooLang', provider));

--- a/src/vs/editor/contrib/codeAction/test/browser/codeActionKeybindingResolver.test.ts
+++ b/src/vs/editor/contrib/codeAction/test/browser/codeActionKeybindingResolver.test.ts
@@ -40,15 +40,15 @@ suite('CodeActionKeybindingResolver', () => {
 			undefined);
 
 		assert.strictEqual(
-			resolver({ title: '', kind: CodeActionKind.Refactor.value }),
+			resolver({ title: '', kind: CodeActionKind.Refactor }),
 			refactorKeybinding.resolvedKeybinding);
 
 		assert.strictEqual(
-			resolver({ title: '', kind: CodeActionKind.Refactor.append('extract').value }),
+			resolver({ title: '', kind: CodeActionKind.Refactor.append('extract') }),
 			refactorKeybinding.resolvedKeybinding);
 
 		assert.strictEqual(
-			resolver({ title: '', kind: CodeActionKind.QuickFix.value }),
+			resolver({ title: '', kind: CodeActionKind.QuickFix }),
 			undefined);
 	});
 
@@ -58,11 +58,11 @@ suite('CodeActionKeybindingResolver', () => {
 		).getResolver();
 
 		assert.strictEqual(
-			resolver({ title: '', kind: CodeActionKind.Refactor.value }),
+			resolver({ title: '', kind: CodeActionKind.Refactor }),
 			refactorKeybinding.resolvedKeybinding);
 
 		assert.strictEqual(
-			resolver({ title: '', kind: CodeActionKind.Refactor.append('extract').value }),
+			resolver({ title: '', kind: CodeActionKind.Refactor.append('extract') }),
 			refactorExtractKeybinding.resolvedKeybinding);
 	});
 
@@ -72,7 +72,7 @@ suite('CodeActionKeybindingResolver', () => {
 		).getResolver();
 
 		assert.strictEqual(
-			resolver({ title: '', kind: CodeActionKind.SourceOrganizeImports.value }),
+			resolver({ title: '', kind: CodeActionKind.SourceOrganizeImports }),
 			organizeImportsKeybinding.resolvedKeybinding);
 	});
 });

--- a/src/vs/editor/standalone/browser/standaloneLanguages.ts
+++ b/src/vs/editor/standalone/browser/standaloneLanguages.ts
@@ -693,7 +693,7 @@ export interface CodeActionContext {
 	/**
 	 * Requested kind of actions to return.
 	 */
-	readonly only?: string;
+	readonly only?: languages.CodeActionKind;
 
 	/**
 	 * The reason why code actions were requested.
@@ -731,7 +731,7 @@ export interface CodeActionProviderMetadata {
 	 * list of kinds may either be generic, such as `["quickfix", "refactor", "source"]`, or list out every kind provided,
 	 * such as `["quickfix.removeLine", "source.fixAll" ...]`.
 	 */
-	readonly providedCodeActionKinds?: readonly string[];
+	readonly providedCodeActionKinds?: readonly languages.CodeActionKind[];
 
 	readonly documentation?: ReadonlyArray<{ readonly kind: string; readonly command: languages.Command }>;
 }

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -6347,7 +6347,7 @@ declare namespace monaco.languages {
 		/**
 		 * Requested kind of actions to return.
 		 */
-		readonly only?: string;
+		readonly only?: CodeActionKind;
 		/**
 		 * The reason why code actions were requested.
 		 */
@@ -6381,7 +6381,7 @@ declare namespace monaco.languages {
 		 * list of kinds may either be generic, such as `["quickfix", "refactor", "source"]`, or list out every kind provided,
 		 * such as `["quickfix.removeLine", "source.fixAll" ...]`.
 		 */
-		readonly providedCodeActionKinds?: readonly string[];
+		readonly providedCodeActionKinds?: readonly CodeActionKind[];
 		readonly documentation?: ReadonlyArray<{
 			readonly kind: string;
 			readonly command: Command;
@@ -6979,7 +6979,7 @@ declare namespace monaco.languages {
 		command?: Command;
 		edit?: WorkspaceEdit;
 		diagnostics?: editor.IMarkerData[];
-		kind?: string;
+		kind?: CodeActionKind;
 		isPreferred?: boolean;
 		disabled?: string;
 	}
@@ -6987,6 +6987,11 @@ declare namespace monaco.languages {
 	export enum CodeActionTriggerType {
 		Invoke = 1,
 		Auto = 2
+	}
+
+	export interface CodeActionKind {
+		value: string;
+		notebook?: boolean;
 	}
 
 	export interface CodeActionList extends IDisposable {

--- a/src/vs/workbench/api/common/extHost.api.impl.ts
+++ b/src/vs/workbench/api/common/extHost.api.impl.ts
@@ -1398,6 +1398,7 @@ export function createApiFactoryAndRegisterActors(accessor: ServicesAccessor): I
 			CandidatePortSource: CandidatePortSource,
 			CodeAction: extHostTypes.CodeAction,
 			CodeActionKind: extHostTypes.CodeActionKind,
+			CodeActionKind2: extHostTypes.CodeActionKind,
 			CodeActionTriggerKind: extHostTypes.CodeActionTriggerKind,
 			CodeLens: extHostTypes.CodeLens,
 			Color: extHostTypes.Color,
@@ -1578,7 +1579,6 @@ export function createApiFactoryAndRegisterActors(accessor: ServicesAccessor): I
 			InteractiveEditorResponseFeedbackKind: extHostTypes.InteractiveEditorResponseFeedbackKind,
 			StackFrameFocus: extHostTypes.StackFrameFocus,
 			ThreadFocus: extHostTypes.ThreadFocus,
-			NotebookCodeActionKind: extHostTypes.NotebookCodeActionKind,
 			RelatedInformationType: extHostTypes.RelatedInformationType
 		};
 	};

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -1873,7 +1873,7 @@ export interface ICodeActionDto {
 	edit?: IWorkspaceEditDto;
 	diagnostics?: Dto<IMarkerData[]>;
 	command?: ICommandDto;
-	kind?: string;
+	kind?: languages.CodeActionKind;
 	isPreferred?: boolean;
 	disabled?: string;
 }
@@ -1884,7 +1884,7 @@ export interface ICodeActionListDto {
 }
 
 export interface ICodeActionProviderMetadataDto {
-	readonly providedKinds?: readonly string[];
+	readonly providedKinds?: readonly languages.CodeActionKind[];
 	readonly documentation?: ReadonlyArray<{ readonly kind: string; readonly command: ICommandDto }>;
 }
 

--- a/src/vs/workbench/api/common/extHostApiCommands.ts
+++ b/src/vs/workbench/api/common/extHostApiCommands.ts
@@ -293,7 +293,7 @@ const newCommands: ApiCommand[] = [
 				} else {
 					const ret = new types.CodeAction(
 						codeAction.title,
-						codeAction.kind ? new types.CodeActionKind(codeAction.kind) : undefined
+						codeAction.kind ? new types.CodeActionKind(codeAction.kind.value) : undefined
 					);
 					if (codeAction.edit) {
 						ret.edit = typeConverters.WorkspaceEdit.to(codeAction.edit);

--- a/src/vs/workbench/api/common/extHostTypes.ts
+++ b/src/vs/workbench/api/common/extHostTypes.ts
@@ -1378,7 +1378,8 @@ export class CodeActionKind {
 	public static Source: CodeActionKind;
 	public static SourceOrganizeImports: CodeActionKind;
 	public static SourceFixAll: CodeActionKind;
-	public static Notebook: CodeActionKind;
+
+	public notebook?: boolean;
 
 	constructor(
 		public readonly value: string
@@ -1397,16 +1398,6 @@ export class CodeActionKind {
 	}
 }
 
-export class NotebookCodeActionKind extends CodeActionKind {
-	public static override Notebook: CodeActionKind;
-
-	constructor(
-		public override readonly value: string
-	) {
-		super(value);
-	}
-}
-
 CodeActionKind.Empty = new CodeActionKind('');
 CodeActionKind.QuickFix = CodeActionKind.Empty.append('quickfix');
 CodeActionKind.Refactor = CodeActionKind.Empty.append('refactor');
@@ -1417,7 +1408,6 @@ CodeActionKind.RefactorRewrite = CodeActionKind.Refactor.append('rewrite');
 CodeActionKind.Source = CodeActionKind.Empty.append('source');
 CodeActionKind.SourceOrganizeImports = CodeActionKind.Source.append('organizeImports');
 CodeActionKind.SourceFixAll = CodeActionKind.Source.append('fixAll');
-CodeActionKind.Notebook = CodeActionKind.Empty.append('notebook');
 
 @es5ClassCompat
 export class SelectionRange {

--- a/src/vs/workbench/contrib/codeActions/browser/documentationContribution.ts
+++ b/src/vs/workbench/contrib/codeActions/browser/documentationContribution.ts
@@ -68,8 +68,8 @@ export class CodeActionDocumentationContribution extends Disposable implements I
 	}
 
 	public _getAdditionalMenuItems(context: languages.CodeActionContext, actions: readonly languages.CodeAction[]): languages.Command[] {
-		if (context.only !== CodeActionKind.Refactor.value) {
-			if (!actions.some(action => action.kind && CodeActionKind.Refactor.contains(new CodeActionKind(action.kind)))) {
+		if (context.only?.value !== CodeActionKind.Refactor.value) {
+			if (!actions.some(action => action.kind && CodeActionKind.Refactor.contains(new CodeActionKind(action.kind.value)))) {
 				return [];
 			}
 		}

--- a/src/vs/workbench/contrib/notebook/browser/notebook.contribution.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebook.contribution.ts
@@ -966,8 +966,21 @@ configurationRegistry.registerConfiguration({
 		[NotebookSetting.codeActionsOnSave]: {
 			markdownDescription: nls.localize('notebook.codeActionsOnSave', "Experimental. Run a series of CodeActions for a notebook on save. CodeActions must be specified, the file must not be saved after delay, and the editor must not be shutting down. Example: `source.fixAll: true`"),
 			type: 'object',
-			additionalProperties: {
-				type: 'boolean'
+			properties: {
+				enabled: {
+					// todo: update this alongside the code actions on save setting #190516
+					// type: 'string',
+					// enum: ['always', 'never', 'explicit'],
+					// enumDescriptions: [nls.localize('alwaysSave', 'Always triggers Code Actions on save'), nls.localize('neverSave', 'Never triggers Code Actions on save'), nls.localize('explicitSave', 'Triggers Code Actions only when explicitly saved')],
+					// default: 'explicit',
+					type: 'boolean',
+					default: false
+				},
+				scope: {
+					type: 'string',
+					enum: ['notebook', 'cell', 'both'],
+					default: 'cell'
+				}
 			},
 			default: {}
 		},

--- a/src/vs/workbench/contrib/preferences/browser/preferencesRenderers.ts
+++ b/src/vs/workbench/contrib/preferences/browser/preferencesRenderers.ts
@@ -728,7 +728,7 @@ class UnsupportedSettingsRenderer extends Disposable implements languages.CodeAc
 				title: nls.localize('manage workspace trust', "Manage Workspace Trust")
 			},
 			diagnostics,
-			kind: CodeActionKind.QuickFix.value
+			kind: CodeActionKind.QuickFix
 		}];
 	}
 

--- a/src/vs/workbench/contrib/snippets/browser/snippetCodeActionProvider.ts
+++ b/src/vs/workbench/contrib/snippets/browser/snippetCodeActionProvider.ts
@@ -24,7 +24,7 @@ class SurroundWithSnippetCodeActionProvider implements CodeActionProvider {
 	private static readonly _MAX_CODE_ACTIONS = 4;
 
 	private static readonly _overflowCommandCodeAction: CodeAction = {
-		kind: CodeActionKind.SurroundWith.value,
+		kind: CodeActionKind.SurroundWith,
 		title: SurroundWithSnippetEditorAction.options.title.value,
 		command: {
 			id: SurroundWithSnippetEditorAction.options.id,
@@ -54,7 +54,7 @@ class SurroundWithSnippetCodeActionProvider implements CodeActionProvider {
 			}
 			actions.push({
 				title: localize('codeAction', "Surround With: {0}", snippet.name),
-				kind: CodeActionKind.SurroundWith.value,
+				kind: CodeActionKind.SurroundWith,
 				edit: asWorkspaceEdit(model, range, snippet)
 			});
 		}
@@ -72,14 +72,14 @@ class FileTemplateCodeActionProvider implements CodeActionProvider {
 
 	private static readonly _overflowCommandCodeAction: CodeAction = {
 		title: localize('overflow.start.title', 'Start with Snippet'),
-		kind: CodeActionKind.SurroundWith.value,
+		kind: CodeActionKind.SurroundWith,
 		command: {
 			id: ApplyFileSnippetAction.Id,
 			title: ''
 		}
 	};
 
-	readonly providedCodeActionKinds?: readonly string[] = [CodeActionKind.SurroundWith.value];
+	readonly providedCodeActionKinds?: readonly CodeActionKind[] = [CodeActionKind.SurroundWith];
 
 	constructor(@ISnippetsService private readonly _snippetService: ISnippetsService) { }
 
@@ -97,7 +97,7 @@ class FileTemplateCodeActionProvider implements CodeActionProvider {
 			}
 			actions.push({
 				title: localize('title', 'Start with: {0}', snippet.name),
-				kind: CodeActionKind.SurroundWith.value,
+				kind: CodeActionKind.SurroundWith,
 				edit: asWorkspaceEdit(model, model.getFullModelRange(), snippet)
 			});
 		}

--- a/src/vscode-dts/vscode.proposed.notebookCodeActions.d.ts
+++ b/src/vscode-dts/vscode.proposed.notebookCodeActions.d.ts
@@ -6,12 +6,156 @@
 declare module 'vscode' {
 
 	// https://github.com/microsoft/vscode/issues/179213
+	export class CodeActionKind2 {
+		/**
+		 * Empty kind.
+		 */
+		static readonly Empty: CodeActionKind2;
 
-	export class NotebookCodeActionKind {
-		// can only return MULTI CELL workspaceEdits
-		// ex: notebook.organizeImprots
-		static readonly Notebook: CodeActionKind;
+		/**
+		 * Base kind for quickfix actions: `quickfix`.
+		 *
+		 * Quick fix actions address a problem in the code and are shown in the normal code action context menu.
+		 */
+		static readonly QuickFix: CodeActionKind2;
 
-		constructor(value: string);
+		/**
+		 * Base kind for refactoring actions: `refactor`
+		 *
+		 * Refactoring actions are shown in the refactoring context menu.
+		 */
+		static readonly Refactor: CodeActionKind2;
+
+		/**
+		 * Base kind for refactoring extraction actions: `refactor.extract`
+		 *
+		 * Example extract actions:
+		 *
+		 * - Extract method
+		 * - Extract function
+		 * - Extract variable
+		 * - Extract interface from class
+		 * - ...
+		 */
+		static readonly RefactorExtract: CodeActionKind2;
+
+		/**
+		 * Base kind for refactoring inline actions: `refactor.inline`
+		 *
+		 * Example inline actions:
+		 *
+		 * - Inline function
+		 * - Inline variable
+		 * - Inline constant
+		 * - ...
+		 */
+		static readonly RefactorInline: CodeActionKind2;
+
+		/**
+		 * Base kind for refactoring move actions: `refactor.move`
+		 *
+		 * Example move actions:
+		 *
+		 * - Move a function to a new file
+		 * - Move a property between classes
+		 * - Move method to base class
+		 * - ...
+		 */
+		static readonly RefactorMove: CodeActionKind2;
+
+		/**
+		 * Base kind for refactoring rewrite actions: `refactor.rewrite`
+		 *
+		 * Example rewrite actions:
+		 *
+		 * - Convert JavaScript function to class
+		 * - Add or remove parameter
+		 * - Encapsulate field
+		 * - Make method static
+		 * - ...
+		 */
+		static readonly RefactorRewrite: CodeActionKind2;
+
+		/**
+		 * Base kind for source actions: `source`
+		 *
+		 * Source code actions apply to the entire file. They must be explicitly requested and will not show in the
+		 * normal [lightbulb](https://code.visualstudio.com/docs/editor/editingevolved#_code-action) menu. Source actions
+		 * can be run on save using `editor.codeActionsOnSave` and are also shown in the `source` context menu.
+		 */
+		static readonly Source: CodeActionKind2;
+
+		/**
+		 * Base kind for an organize imports source action: `source.organizeImports`.
+		 */
+		static readonly SourceOrganizeImports: CodeActionKind2;
+
+		/**
+		 * Base kind for auto-fix source actions: `source.fixAll`.
+		 *
+		 * Fix all actions automatically fix errors that have a clear fix that do not require user input.
+		 * They should not suppress errors or perform unsafe fixes such as generating new types or classes.
+		 */
+		static readonly SourceFixAll: CodeActionKind2;
+
+		/**
+		 * Private constructor, use statix `CodeActionKind2.XYZ` to derive from an existing code action kind.
+		 *
+		 * @param value The value of the kind, such as `refactor.extract.function`.
+		 */
+		private constructor(value: string);
+
+		/**
+		 * String value of the kind, e.g. `"refactor.extract.function"`.
+		 */
+		readonly value: string;
+
+		/**
+		 * Boolean value representing the scope of the CodeAction
+		 *
+		 * - `true`  - The CodeAction is scoped to the entire notebook. It is called only against the first cell.
+		 * - `false` - The CodeAction is scoped to a singular cell. It is called against each cell asynchronously in parallel.
+		 */
+		public notebook?: boolean;
+
+		/**
+		 * Create a new kind by appending a more specific selector to the current kind.
+		 *
+		 * Does not modify the current kind.
+		 */
+		append(parts: string): CodeActionKind2;
+
+		/**
+		 * Checks if this code action kind intersects `other`.
+		 *
+		 * The kind `"refactor.extract"` for example intersects `refactor`, `"refactor.extract"` and ``"refactor.extract.function"`,
+		 * but not `"unicorn.refactor.extract"`, or `"refactor.extractAll"`.
+		 *
+		 * @param other Kind to check.
+		 */
+		intersects(other: CodeActionKind2): boolean;
+
+		/**
+		 * Checks if `other` is a sub-kind of this `CodeActionKind2`.
+		 *
+		 * The kind `"refactor.extract"` for example contains `"refactor.extract"` and ``"refactor.extract.function"`,
+		 * but not `"unicorn.refactor.extract"`, or `"refactor.extractAll"` or `refactor`.
+		 *
+		 * @param other Kind to check.
+		 */
+		contains(other: CodeActionKind2): boolean;
 	}
+
+	export interface CodeActionProviderMetadata2 {
+		readonly providedCodeActionKinds?: readonly CodeActionKind2[];
+	}
+
+	export interface CodeActionContext2 {
+		readonly triggerKind: CodeActionTriggerKind;
+
+		readonly diagnostics: readonly Diagnostic[];
+
+		readonly only: CodeActionKind2 | undefined;
+	}
+
 }


### PR DESCRIPTION
big rework. 

still wip

mostly using this to ensure tests are stable.

--- 
testing on ghinb joh/civic-tahr

settings.json:
```
    "notebook.codeActionsOnSave": {
        "source.normalizeVariableNames.ghinb": {
            "enabled": true,
            "scope": "notebook"
        },
        "source.false1nb.ghinb": {
            "enabled": false,
            "scope": "notebook"
        },
        "source.false2cell.ghinb": {
            "enabled": false,
            "scope": "cell"
        },
        "source.normalizeVariableNames.ghinb": {
            "enabled": true,
            "scope": "cell"
        }
    }
```

when the top and bottom (same name dif scope) are uncommented, only the cell one runs. not sure y. need to sleep.