### PR TITLE
Fix Throttler dispose warning in unit tests

### DIFF
--- a/src/vs/base/parts/storage/common/storage.ts
+++ b/src/vs/base/parts/storage/common/storage.ts
@@ -123,7 +123,7 @@ export class Storage extends Disposable implements IStorage {
 
 	private cache = new Map<string, string>();
 
-	private readonly flushDelayer = new ThrottledDelayer<void>(Storage.DEFAULT_FLUSH_DELAY);
+	private readonly flushDelayer = this._register(new ThrottledDelayer<void>(Storage.DEFAULT_FLUSH_DELAY));
 
 	private pendingDeletes = new Set<string>();
 	private pendingInserts = new Map<string, string>();
@@ -405,12 +405,6 @@ export class Storage extends Disposable implements IStorage {
 
 	isInMemory(): boolean {
 		return this.options.hint === StorageHint.STORAGE_IN_MEMORY;
-	}
-
-	override dispose(): void {
-		this.flushDelayer.dispose();
-
-		super.dispose();
 	}
 }
 


### PR DESCRIPTION
This was happening because dispose was being overridden so the isDisposed check before a store is disposed again wasn't happening just for the throttler.

Fixes #192427
Fixes #192434
Part of #192425
