### PR TITLE
Alias `Thenable` to `PromiseLike`

### DIFF
--- a/extensions/emmet/src/test/cssAbbreviationAction.test.ts
+++ b/extensions/emmet/src/test/cssAbbreviationAction.test.ts
@@ -183,7 +183,9 @@ nav#
 				assert.strictEqual((<string>emmetCompletionItem.documentation || '').replace(/\|/g, ''), expandedText, `Docs of completion item doesnt match.`);
 			};
 
-			return Promise.all<CompletionList>([completionPromise1, completionPromise2]).then(([result1, result2]) => {
+			return Promise.all([completionPromise1, completionPromise2]).then(([result1, result2]) => {
+				assert.ok(result1);
+				assert.ok(result2);
 				callBack(result1, '#121212');
 				callBack(result2, '!important');
 				editor.selections = [new Selection(2, 12, 2, 12), new Selection(2, 14, 2, 14)];
@@ -244,7 +246,9 @@ nav#
 				assert.strictEqual((<string>emmetCompletionItem.documentation || '').replace(/\|/g, ''), expandedText, `Docs of completion item doesnt match.`);
 			};
 
-			return Promise.all<CompletionList>([completionPromise1, completionPromise2]).then(([result1, result2]) => {
+			return Promise.all([completionPromise1, completionPromise2]).then(([result1, result2]) => {
+				assert.ok(result1);
+				assert.ok(result2);
 				callBack(result1, '#121212');
 				callBack(result2, '!important');
 				editor.selections = [new Selection(3, 12, 3, 12), new Selection(3, 14, 3, 14)];
@@ -303,7 +307,9 @@ nav#
 				assert.strictEqual((<string>emmetCompletionItem.documentation || '').replace(/\|/g, ''), expandedText, `Docs of completion item doesnt match.`);
 			};
 
-			return Promise.all<CompletionList>([completionPromise1, completionPromise2]).then(([result1, result2]) => {
+			return Promise.all([completionPromise1, completionPromise2]).then(([result1, result2]) => {
+				assert.ok(result1);
+				assert.ok(result2);
 				callBack(result1, '#121212');
 				callBack(result2, '!important');
 				editor.selections = [new Selection(2, 12, 2, 12), new Selection(2, 14, 2, 14)];
@@ -361,7 +367,9 @@ nav#
 				assert.strictEqual(emmetCompletionItem.filterText, abbreviation, `FilterText of completion item doesnt match.`);
 			};
 
-			return Promise.all<CompletionList>([completionPromise1, completionPromise2]).then(([result1, result2]) => {
+			return Promise.all([completionPromise1, completionPromise2]).then(([result1, result2]) => {
+				assert.ok(result1);
+				assert.ok(result2);
 				callBack(result1);
 				callBack(result2);
 				return Promise.resolve();
@@ -421,7 +429,11 @@ nav#
 				assert.strictEqual(emmetCompletionItem.filterText, abbreviation, `FilterText of completion item doesnt match.`);
 			};
 
-			return Promise.all<CompletionList>([completionPromise1, completionPromise2, completionPromise3, completionPromise4]).then(([result1, result2, result3, result4]) => {
+			return Promise.all([completionPromise1, completionPromise2, completionPromise3, completionPromise4]).then(([result1, result2, result3, result4]) => {
+				assert.ok(result1);
+				assert.ok(result2);
+				assert.ok(result3);
+				assert.ok(result4);
 				callBack(result1, 'p10', 'padding: 10px;');
 				callBack(result2, 'p20', 'padding: 20px;');
 				callBack(result3, 'p30', 'padding: 30px;');

--- a/extensions/microsoft-authentication/src/betterSecretStorage.ts
+++ b/extensions/microsoft-authentication/src/betterSecretStorage.ts
@@ -240,11 +240,8 @@ export class BetterTokenStorage<T> {
 				},
 				err => {
 					Logger.error(err);
-					resolve(tokens);
-				}).then(resolve, err => {
-					Logger.error(err);
-					resolve(tokens);
-				});
+					return tokens;
+				}).then(resolve);
 		});
 		this._operationInProgress = false;
 	}

--- a/src/typings/thenable.d.ts
+++ b/src/typings/thenable.d.ts
@@ -9,13 +9,4 @@
  * enables reusing existing code without migrating to a specific promise implementation. Still,
  * we recommend the use of native promises which are available in VS Code.
  */
-interface Thenable<T> {
-	/**
-	* Attaches callbacks for the resolution and/or rejection of the Promise.
-	* @param onfulfilled The callback to execute when the Promise is resolved.
-	* @param onrejected The callback to execute when the Promise is rejected.
-	* @returns A Promise for the completion of which ever callback is executed.
-	*/
-	then<TResult>(onfulfilled?: (value: T) => TResult | Thenable<TResult>, onrejected?: (reason: any) => TResult | Thenable<TResult>): Thenable<TResult>;
-	then<TResult>(onfulfilled?: (value: T) => TResult | Thenable<TResult>, onrejected?: (reason: any) => void): Thenable<TResult>;
-}
+interface Thenable<T> extends PromiseLike<T> { }

--- a/src/vscode-dts/vscode.d.ts
+++ b/src/vscode-dts/vscode.d.ts
@@ -17990,19 +17990,4 @@ declare module 'vscode' {
  * enables reusing existing code without migrating to a specific promise implementation. Still,
  * we recommend the use of native promises which are available in this editor.
  */
-interface Thenable<T> {
-	/**
-	* Attaches callbacks for the resolution and/or rejection of the Promise.
-	* @param onfulfilled The callback to execute when the Promise is resolved.
-	* @param onrejected The callback to execute when the Promise is rejected.
-	* @returns A Promise for the completion of which ever callback is executed.
-	*/
-	then<TResult>(onfulfilled?: (value: T) => TResult | Thenable<TResult>, onrejected?: (reason: any) => TResult | Thenable<TResult>): Thenable<TResult>;
-	/**
-	* Attaches callbacks for the resolution and/or rejection of the Promise.
-	* @param onfulfilled The callback to execute when the Promise is resolved.
-	* @param onrejected The callback to execute when the Promise is rejected.
-	* @returns A Promise for the completion of which ever callback is executed.
-	*/
-	then<TResult>(onfulfilled?: (value: T) => TResult | Thenable<TResult>, onrejected?: (reason: any) => void): Thenable<TResult>;
-}
+interface Thenable<T> extends PromiseLike<T> { }


### PR DESCRIPTION
Fixes #192385

While fixing some typing issues with `Thenable`, I noticed I was duplicating the typings for `PromiseLike`. This PR updates `Thenable` to be an alias for `PromiseLike`
