### PR TITLE
Show theme id if it differs from label

### DIFF
--- a/src/vs/workbench/contrib/themes/browser/themes.contribution.ts
+++ b/src/vs/workbench/contrib/themes/browser/themes.contribution.ts
@@ -328,6 +328,7 @@ class InstalledThemesPicker {
 				quickpick.placeholder = this.placeholderMessage;
 				quickpick.activeItems = [picks[autoFocusIndex] as ThemeItem];
 				quickpick.canSelectMany = false;
+				quickpick.matchOnDescription = true;
 				quickpick.onDidAccept(async _ => {
 					isCompleted = true;
 					const theme = quickpick.selectedItems[0];
@@ -545,7 +546,13 @@ function isItem(i: QuickPickInput<ThemeItem>): i is ThemeItem {
 }
 
 function toEntry(theme: IWorkbenchTheme): ThemeItem {
-	const item: ThemeItem = { id: theme.id, theme: theme, label: theme.label, description: theme.description };
+	const settingId = theme.settingsId ?? undefined;
+	const item: ThemeItem = {
+		id: theme.id,
+		theme: theme,
+		label: theme.label,
+		description: theme.description || (theme.label === settingId ? undefined : settingId),
+	};
 	if (theme.extensionData) {
 		item.buttons = [configureButton];
 	}


### PR DESCRIPTION
The idea here is that when the label is localized, it will be different than the id... so the id will be displayed next to the label.

This is similar to Configure Display Language... and also somewhat similar to the Command Palette showing the English label under the localized label.

Fixes https://github.com/microsoft/vscode/issues/192223

Here's what English looks like:
![image](https://github.com/microsoft/vscode/assets/2644648/e0cc27be-7cf6-4897-bd10-de15e1a4dc5e)

you can see that some of the labels aren't the same as the id so the id shows up the right. For a localized build, it would look something like this but with the labels being in another language:
![image](https://github.com/microsoft/vscode/assets/2644648/3ead56cc-7099-4af1-8a6c-b366723f2870)

> I'd have to do a full build to get localization so excuse my laziness in providing an actual screenshot

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

cc @Tyriar