### PR TITLE
Cannot read properties of undefined (reading 'getSearchHistory')

### DIFF
--- a/src/vs/workbench/contrib/search/browser/searchView.ts
+++ b/src/vs/workbench/contrib/search/browser/searchView.ts
@@ -2076,6 +2076,9 @@ export class SearchView extends ViewPane {
 	}
 
 	private _saveSearchHistoryService() {
+		if (this.searchWidget === undefined) {
+			return;
+		}
 		const history: ISearchHistoryValues = Object.create(null);
 
 		const searchHistory = this.searchWidget.getSearchHistory();


### PR DESCRIPTION
Fixes #189330

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
