### PR TITLE
remove unused FormattingOptions.ranges

### DIFF
--- a/src/vs/editor/common/languages.ts
+++ b/src/vs/editor/common/languages.ts
@@ -1280,10 +1280,6 @@ export interface FormattingOptions {
 	 * Prefer spaces over tabs.
 	 */
 	insertSpaces: boolean;
-	/**
-	 * The list of multiple ranges to format at once, if the provider supports it.
-	 */
-	ranges?: Range[];
 }
 /**
  * The document formatting provider interface defines the contract between extensions and

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -7343,10 +7343,6 @@ declare namespace monaco.languages {
 		 * Prefer spaces over tabs.
 		 */
 		insertSpaces: boolean;
-		/**
-		 * The list of multiple ranges to format at once, if the provider supports it.
-		 */
-		ranges?: Range[];
 	}
 
 	/**


### PR DESCRIPTION
Introduced by https://github.com/microsoft/vscode/issues/158776

removed from API types in https://github.com/microsoft/vscode/pull/179166