### PR TITLE
forwarding: add a warning for public ports

### DIFF
--- a/extensions/tunnel-forwarding/src/extension.ts
+++ b/extensions/tunnel-forwarding/src/extension.ts
@@ -201,7 +201,7 @@ class TunnelProvider implements vscode.TunnelProvider {
 		const continueOpt = vscode.l10n.t('Continue');
 		const dontShowAgain = vscode.l10n.t("Don't show again");
 		const r = await vscode.window.showWarningMessage(
-			vscode.l10n.t("You're about to create a publicly forwarded port. Anyone on internet will be able to connect the service listening on port {0}. You should only proceed if this service is secure and non-sensitive.", portNumber),
+			vscode.l10n.t("You're about to create a publicly forwarded port. Anyone on the internet will be able to connect to the service listening on port {0}. You should only proceed if this service is secure and non-sensitive.", portNumber),
 			{ modal: true },
 			continueOpt,
 			dontShowAgain,

--- a/extensions/tunnel-forwarding/src/extension.ts
+++ b/extensions/tunnel-forwarding/src/extension.ts
@@ -67,7 +67,7 @@ export async function activate(context: vscode.ExtensionContext) {
 	}
 
 	const logger = new Logger(vscode.l10n.t('Port Forwarding'));
-	const provider = new TunnelProvider(logger);
+	const provider = new TunnelProvider(logger, context);
 
 	context.subscriptions.push(
 		vscode.commands.registerCommand('tunnel-forwarding.showLog', () => logger.show()),
@@ -120,6 +120,8 @@ class Logger {
 	}
 }
 
+const didWarnPublicKey = 'didWarnPublic';
+
 class TunnelProvider implements vscode.TunnelProvider {
 	private readonly tunnels = new Set<Tunnel>();
 	private readonly stateChange = new vscode.EventEmitter<StateT>();
@@ -136,10 +138,16 @@ class TunnelProvider implements vscode.TunnelProvider {
 
 	public readonly onDidStateChange = this.stateChange.event;
 
-	constructor(private readonly logger: Logger) { }
+	constructor(private readonly logger: Logger, private readonly context: vscode.ExtensionContext) { }
 
 	/** @inheritdoc */
-	public async provideTunnel(tunnelOptions: vscode.TunnelOptions): Promise<vscode.Tunnel> {
+	public async provideTunnel(tunnelOptions: vscode.TunnelOptions): Promise<vscode.Tunnel | undefined> {
+		if (tunnelOptions.privacy === TunnelPrivacyId.Public) {
+			if (!(await this.consentPublicPort(tunnelOptions.remoteAddress.port))) {
+				return;
+			}
+		}
+
 		const tunnel = new Tunnel(
 			tunnelOptions.remoteAddress,
 			(tunnelOptions.privacy as TunnelPrivacyId) || TunnelPrivacyId.Private,
@@ -182,6 +190,31 @@ class TunnelProvider implements vscode.TunnelProvider {
 		this.killRunningProcess();
 		await this.setupPortForwardingProcess(); // will show progress
 		this.updateActivePortsIfRunning();
+	}
+
+	private async consentPublicPort(portNumber: number) {
+		const didWarn = this.context.globalState.get(didWarnPublicKey, false);
+		if (didWarn) {
+			return true;
+		}
+
+		const continueOpt = vscode.l10n.t('Continue');
+		const dontShowAgain = vscode.l10n.t("Don't show again");
+		const r = await vscode.window.showWarningMessage(
+			vscode.l10n.t("You're about to create a publicly forwarded port. Anyone on internet will be able to connect the service listening on port {0}. You should only proceed if this service is secure and non-sensitive.", portNumber),
+			{ modal: true },
+			continueOpt,
+			dontShowAgain,
+		);
+		if (r === continueOpt) {
+			// continue
+		} else if (r === dontShowAgain) {
+			await this.context.globalState.update(didWarnPublicKey, true);
+		} else {
+			return false;
+		}
+
+		return true;
 	}
 
 	private isInStateWithProcess(process: ChildProcessWithoutNullStreams) {


### PR DESCRIPTION
A number of users have raised some security concerns about port
forwarding. Forwarded ports are private (requiring auth with the same
GH account that did the forwarding) by default. When making a port
public, show the following dialog:

![](https://memes.peet.io/img/23-09-3f3351c7-cdcd-46e5-9d0f-123e4dda6b3c.png)

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
