### PR TITLE
prioritize html links since they can wrap other link types

### DIFF
--- a/extensions/notebook-renderers/src/linkify.ts
+++ b/extensions/notebook-renderers/src/linkify.ts
@@ -27,9 +27,21 @@ type LinkPart = {
 };
 
 export class LinkDetector {
-	constructor(
-	) {
-		// noop
+
+	// used by unit tests
+	static injectedHtmlCreator: (value: string) => string;
+
+	private shouldGenerateHtml(trustHtml: boolean) {
+		return trustHtml && (!!LinkDetector.injectedHtmlCreator || !!ttPolicy);
+	}
+
+	private createHtml(value: string) {
+		if (LinkDetector.injectedHtmlCreator) {
+			return LinkDetector.injectedHtmlCreator(value);
+		}
+		else {
+			return ttPolicy?.createHTML(value).toString();
+		}
 	}
 
 	/**
@@ -71,9 +83,9 @@ export class LinkDetector {
 						container.appendChild(this.createWebLink(part.value));
 						break;
 					case 'html':
-						if (ttPolicy && trustHtml) {
+						if (this.shouldGenerateHtml(!!trustHtml)) {
 							const span = document.createElement('span');
-							span.innerHTML = ttPolicy.createHTML(part.value).toString();
+							span.innerHTML = this.createHtml(part.value)!;
 							container.appendChild(span);
 						} else {
 							container.appendChild(document.createTextNode(part.value));

--- a/extensions/notebook-renderers/src/linkify.ts
+++ b/extensions/notebook-renderers/src/linkify.ts
@@ -142,8 +142,8 @@ export class LinkDetector {
 			return [{ kind: 'text', value: text, captures: [] }];
 		}
 
-		const regexes: RegExp[] = [WEB_LINK_REGEX, PATH_LINK_REGEX, HTML_LINK_REGEX];
-		const kinds: LinkKind[] = ['web', 'path', 'html'];
+		const regexes: RegExp[] = [HTML_LINK_REGEX, WEB_LINK_REGEX, PATH_LINK_REGEX];
+		const kinds: LinkKind[] = ['html', 'web', 'path'];
 		const result: LinkPart[] = [];
 
 		const splitOne = (text: string, regexIndex: number) => {

--- a/extensions/notebook-renderers/src/test/linkify.test.ts
+++ b/extensions/notebook-renderers/src/test/linkify.test.ts
@@ -1,0 +1,44 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { JSDOM } from "jsdom";
+import { LinkDetector, linkify } from '../linkify';
+
+const dom = new JSDOM();
+global.document = dom.window.document;
+
+suite('Notebook builtin output link detection', () => {
+
+	LinkDetector.injectedHtmlCreator = (value: string) => value;
+
+	test('no links', () => {
+		const htmlWithLinks = linkify('hello', true, undefined, true);
+		assert.equal(htmlWithLinks.innerHTML, 'hello');
+	});
+
+	test('web link detection', () => {
+		const htmlWithLinks = linkify('something www.example.com something', true, undefined, true);
+
+		assert.equal(htmlWithLinks.innerHTML, 'something <a href="www.example.com">www.example.com</a> something');
+		assert.equal(htmlWithLinks.textContent, 'something www.example.com something');
+	});
+
+	test('html link detection', () => {
+		const htmlWithLinks = linkify('something <a href="www.example.com">link</a> something', true, undefined, true);
+
+		assert.equal(htmlWithLinks.innerHTML, 'something <span><a href="www.example.com">link</a></span> something');
+		assert.equal(htmlWithLinks.textContent, 'something link something');
+	});
+
+	test('html link without trust', () => {
+		const trustHtml = false;
+		const htmlWithLinks = linkify('something <a href="file.py">link</a> something', true, undefined, trustHtml);
+
+		assert.equal(htmlWithLinks.innerHTML, 'something &lt;a href="file.py"&gt;link&lt;/a&gt; something');
+		assert.equal(htmlWithLinks.textContent, 'something <a href="file.py">link</a> something');
+	});
+});
+

--- a/extensions/notebook-renderers/src/test/notebookRenderer.test.ts
+++ b/extensions/notebook-renderers/src/test/notebookRenderer.test.ts
@@ -8,6 +8,7 @@ import { activate } from '..';
 import { RendererApi } from 'vscode-notebook-renderer';
 import { IDisposable, IRichRenderContext, OutputWithAppend, RenderOptions } from '../rendererTypes';
 import { JSDOM } from "jsdom";
+import { LinkDetector } from '../linkify';
 
 const dom = new JSDOM();
 global.document = dom.window.document;
@@ -273,6 +274,7 @@ suite('Notebook builtin output renderer', () => {
 	});
 
 	test(`Render with wordwrap and scrolling for error output`, async () => {
+		LinkDetector.injectedHtmlCreator = (value: string) => value;
 		const context = createContext({ outputWordWrap: true, outputScrolling: true });
 		const renderer = await activate(context);
 		assert.ok(renderer, 'Renderer not created');

--- a/extensions/notebook-renderers/src/test/notebookRenderer.test.ts
+++ b/extensions/notebook-renderers/src/test/notebookRenderer.test.ts
@@ -15,13 +15,12 @@ global.document = dom.window.document;
 suite('Notebook builtin output renderer', () => {
 
 	const error = {
-		name: "NameError",
-		message: "name 'x' is not defined",
+		name: "TypeError",
+		message: "Expected type `str`, but received type `<class \'int\'>`",
 		stack: "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m" +
-			"\n\u001b[1;31mNameError\u001b[0m                                 Traceback (most recent call last)" +
-			"\nCell \u001b[1;32mIn[3], line 1\u001b[0m" +
-			"\n\u001b[1;32m----> 1\u001b[0m \u001b[39mprint\u001b[39m(x)" +
-			"\n\n\u001b[1;31mNameError\u001b[0m: name 'x' is not defined"
+			"\u001b[1;31mTypeError\u001b[0m                                 Traceback (most recent call last)" +
+			"\u001b[1;32mc:\\src\\test\\ws1\\testing.py\u001b[0m in \u001b[0;36mline 2\n\u001b[0;32m      <a href='file:///c%3A/src/test/ws1/testing.py?line=34'>35</a>\u001b[0m \u001b[39m# %%\u001b[39;00m\n\u001b[1;32m----> <a href='file:///c%3A/src/test/ws1/testing.py?line=35'>36</a>\u001b[0m \u001b[39mraise\u001b[39;00m \u001b[39mTypeError\u001b[39;00m(\u001b[39m'\u001b[39m\u001b[39merror = f\u001b[39m\u001b[39m\"\u001b[39m\u001b[39mExpected type `str`, but received type `\u001b[39m\u001b[39m{\u001b[39m\u001b[39mtype(name)}`\u001b[39m\u001b[39m\"\u001b[39m\u001b[39m'\u001b[39m)\n" +
+			"\u001b[1;31mTypeError\u001b[0m: Expected type `str`, but received type `<class \'int\'>`\""
 	};
 
 	const errorMimeType = 'application/vnd.code.notebook.error';
@@ -233,7 +232,7 @@ suite('Notebook builtin output renderer', () => {
 
 		assert.ok(firstOutputElement.innerHTML.indexOf('>first stream content') > -1, `Content was not added to output element: ${outputHtml.cellElement.innerHTML}`);
 		assert.ok(firstOutputElement.innerHTML.indexOf('appended1') > -1, `Content was not appended to output element: ${outputHtml.cellElement.innerHTML}`);
-		assert.ok(secondOutputElement.innerHTML.indexOf('>NameError</') > -1, `Content was not added to output element: ${outputHtml.cellElement.innerHTML}`);
+		assert.ok(secondOutputElement.innerHTML.indexOf('>TypeError</') > -1, `Content was not added to output element: ${outputHtml.cellElement.innerHTML}`);
 		assert.ok(thirdOutputElement.innerHTML.indexOf('>second stream content') > -1, `Content was not added to output element: ${outputHtml.cellElement.innerHTML}`);
 		assert.ok(thirdOutputElement.innerHTML.indexOf('appended3') > -1, `Content was not appended to output element: ${outputHtml.cellElement.innerHTML}`);
 	});
@@ -287,7 +286,9 @@ suite('Notebook builtin output renderer', () => {
 		assert.ok(outputElement.classList.contains('remove-padding'), 'Padding should be removed for scrollable outputs');
 		assert.ok(inserted.classList.contains('word-wrap') && inserted.classList.contains('scrollable'),
 			`output content classList should contain word-wrap and scrollable ${inserted.classList}`);
-		assert.ok(inserted.innerHTML.indexOf('>: name \'x\' is not defined</') > -1, `Content was not added to output element:\n ${outputElement.innerHTML}`);
+		assert.ok(inserted.innerHTML.indexOf('>Expected type `str`, but received type') > -1, `Content was not added to output element:\n ${outputElement.innerHTML}`);
+		assert.ok(inserted.textContent!.indexOf('Expected type `str`, but received type `<class \'int\'>`') > -1, `Content was not added to output element:\n ${outputElement.textContent}`);
+		assert.ok(inserted.textContent!.indexOf('<a href') === -1, 'HTML links should be rendered');
 	});
 
 	test(`Replace content in element for error output`, async () => {
@@ -303,7 +304,7 @@ suite('Notebook builtin output renderer', () => {
 		await renderer!.renderOutputItem(outputItem2, outputElement);
 
 		const inserted = outputElement.firstChild as HTMLElement;
-		assert.ok(inserted.innerHTML.indexOf('>: name \'x\' is not defined</') === -1, `Content was not removed from output element:\n ${outputElement.innerHTML}`);
+		assert.ok(inserted.innerHTML.indexOf('Expected type `str`, but received type') === -1, `Content was not removed from output element:\n ${outputElement.innerHTML}`);
 		assert.ok(inserted.innerHTML.indexOf('>replaced content</') !== -1, `Content was not added to output element:\n ${outputElement.innerHTML}`);
 	});
 
@@ -392,7 +393,7 @@ suite('Notebook builtin output renderer', () => {
 		await renderer!.renderOutputItem(outputItem3, thirdOutputElement);
 
 		assert.ok(firstOutputElement.innerHTML.indexOf('>first stream content</') > -1, `Content was not added to output element: ${outputHtml.cellElement.innerHTML}`);
-		assert.ok(secondOutputElement.innerHTML.indexOf('>NameError</') > -1, `Content was not added to output element: ${outputHtml.cellElement.innerHTML}`);
+		assert.ok(secondOutputElement.innerHTML.indexOf('>TypeError</') > -1, `Content was not added to output element: ${outputHtml.cellElement.innerHTML}`);
 		assert.ok(thirdOutputElement.innerHTML.indexOf('>second stream content</') > -1, `Content was not added to output element: ${outputHtml.cellElement.innerHTML}`);
 	});
 


### PR DESCRIPTION
fix https://github.com/microsoft/vscode/issues/192605

we were detecting the file link within the html <a> element, rather than the full element, so it wasn't rendered as a link.