### PR TITLE
Use `SequencerByKey` to sequence operations of the same set of scopes

### DIFF
--- a/extensions/microsoft-authentication/src/common/async.ts
+++ b/extensions/microsoft-authentication/src/common/async.ts
@@ -1,0 +1,49 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Disposable } from 'vscode';
+
+export class SequencerByKey<TKey> {
+
+	private promiseMap = new Map<TKey, Promise<unknown>>();
+
+	queue<T>(key: TKey, promiseTask: () => Promise<T>): Promise<T> {
+		const runningPromise = this.promiseMap.get(key) ?? Promise.resolve();
+		const newPromise = runningPromise
+			.catch(() => { })
+			.then(promiseTask)
+			.finally(() => {
+				if (this.promiseMap.get(key) === newPromise) {
+					this.promiseMap.delete(key);
+				}
+			});
+		this.promiseMap.set(key, newPromise);
+		return newPromise;
+	}
+}
+
+export class IntervalTimer extends Disposable {
+
+	private _token: any;
+
+	constructor() {
+		super(() => this.cancel());
+		this._token = -1;
+	}
+
+	cancel(): void {
+		if (this._token !== -1) {
+			clearInterval(this._token);
+			this._token = -1;
+		}
+	}
+
+	cancelAndSet(runner: () => void, interval: number): void {
+		this.cancel();
+		this._token = setInterval(() => {
+			runner();
+		}, interval);
+	}
+}

--- a/extensions/microsoft-authentication/src/common/uri.ts
+++ b/extensions/microsoft-authentication/src/common/uri.ts
@@ -2,7 +2,7 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import { Disposable, env, UIKind, Uri } from 'vscode';
+import { env, UIKind, Uri } from 'vscode';
 
 const LOCALHOST_ADDRESSES = ['localhost', '127.0.0.1', '0:0:0:0:0:0:0:1', '::1'];
 function isLocalhost(uri: Uri): boolean {
@@ -34,28 +34,4 @@ export function isSupportedEnvironment(uri: Uri): boolean {
 		// github.dev/codespaces local setup (github.localhost)
 		/(?:^|\.)github\.localhost$/.test(uri.authority)
 	);
-}
-
-export class IntervalTimer extends Disposable {
-
-	private _token: any;
-
-	constructor() {
-		super(() => this.cancel());
-		this._token = -1;
-	}
-
-	cancel(): void {
-		if (this._token !== -1) {
-			clearInterval(this._token);
-			this._token = -1;
-		}
-	}
-
-	cancelAndSet(runner: () => void, interval: number): void {
-		this.cancel();
-		this._token = setInterval(() => {
-			runner();
-		}, interval);
-	}
 }

--- a/extensions/microsoft-authentication/src/extension.ts
+++ b/extensions/microsoft-authentication/src/extension.ts
@@ -72,7 +72,7 @@ async function initMicrosoftSovereignCloudAuthProvider(context: vscode.Extension
 					scopes: JSON.stringify(scopes.map(s => s.replace(/[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}/i, '{guid}'))),
 				});
 
-				return await aadService.createSession(scopes.sort());
+				return await aadService.createSession(scopes);
 			} catch (e) {
 				/* __GDPR__
 					"loginFailed" : { "owner": "TylerLeonhardt", "comment": "Used to determine how often users run into issues with the login flow." }
@@ -138,7 +138,7 @@ export async function activate(context: vscode.ExtensionContext) {
 					scopes: JSON.stringify(scopes.map(s => s.replace(/[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}/i, '{guid}'))),
 				});
 
-				return await loginService.createSession(scopes.sort());
+				return await loginService.createSession(scopes);
 			} catch (e) {
 				/* __GDPR__
 					"loginFailed" : { "owner": "TylerLeonhardt", "comment": "Used to determine how often users run into issues with the login flow." }


### PR DESCRIPTION
The idea here is... if a token is currently being refreshed, well then getting a token of those scopes should wait for that to finish.

Core has a really nice `SequencerByKey` for exactly this kind of thing, and so I've stolen that and started to organize the code with a `common` folder.

Oh, I also noticed we were sorting twice and fixed that to only sort once.

ref https://github.com/microsoft/vscode/issues/186693

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
