### PR TITLE
fix: don't show inline chat hint with ghost text

### DIFF
--- a/src/vs/editor/contrib/inlineCompletions/browser/ghostTextWidget.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/ghostTextWidget.ts
@@ -25,6 +25,7 @@ import { InlineDecorationType } from 'vs/editor/common/viewModel';
 import { GhostText, GhostTextReplacement } from 'vs/editor/contrib/inlineCompletions/browser/ghostText';
 import { ColumnRange, applyObservableDecorations } from 'vs/editor/contrib/inlineCompletions/browser/utils';
 
+export const GHOST_TEXT_DESCRIPTION = 'ghost-text';
 export interface IGhostTextWidgetModel {
 	readonly targetTextModel: IObservable<ITextModel | undefined>;
 	readonly ghostText: IObservable<GhostText | GhostTextReplacement | undefined>;
@@ -100,7 +101,7 @@ export class GhostTextWidget extends Disposable {
 			}
 
 			if (lines.length > 0) {
-				addToAdditionalLines(lines, 'ghost-text');
+				addToAdditionalLines(lines, GHOST_TEXT_DESCRIPTION);
 				if (hiddenTextStartColumn === undefined && part.column <= textBufferLine.length) {
 					hiddenTextStartColumn = part.column;
 				}
@@ -151,7 +152,7 @@ export class GhostTextWidget extends Disposable {
 			decorations.push({
 				range: Range.fromPositions(new Position(uiState.lineNumber, p.column)),
 				options: {
-					description: 'ghost-text',
+					description: GHOST_TEXT_DESCRIPTION,
 					after: { content: p.text, inlineClassName: p.preview ? 'ghost-text-decoration-preview' : 'ghost-text-decoration', cursorStops: InjectedTextCursorStops.Left },
 					showIfCollapsed: true,
 				}

--- a/src/vs/workbench/contrib/codeEditor/browser/emptyTextEditorHint/emptyTextEditorHint.ts
+++ b/src/vs/workbench/contrib/codeEditor/browser/emptyTextEditorHint/emptyTextEditorHint.ts
@@ -34,6 +34,7 @@ import { Registry } from 'vs/platform/registry/common/platform';
 import { Extensions, IConfigurationMigrationRegistry } from 'vs/workbench/common/configuration';
 import { LOG_MODE_ID, OUTPUT_MODE_ID } from 'vs/workbench/services/output/common/output';
 import { SEARCH_RESULT_LANGUAGE_ID } from 'vs/workbench/services/search/common/search';
+import { GHOST_TEXT_DESCRIPTION } from 'vs/editor/contrib/inlineCompletions/browser/ghostTextWidget';
 
 const $ = dom.$;
 
@@ -91,17 +92,41 @@ export class EmptyTextEditorHintContribution implements IEditorContribution {
 		}));
 	}
 
-	private update(): void {
-		this.textHintContentWidget?.dispose();
+	private _shouldRenderHint() {
 		const configValue = this.configurationService.getValue(emptyTextEditorHintSetting);
+		if (configValue === 'hidden') {
+			return false;
+		}
+
+		if (this.editor.getOption(EditorOption.readOnly)) {
+			return false;
+		}
+
+		const hasGhostText = this.editor.getLineDecorations(0)?.find((d) => d.options.description === GHOST_TEXT_DESCRIPTION);
+		if (hasGhostText) {
+			return false;
+		}
+
 		const model = this.editor.getModel();
+		const languageId = model?.getLanguageId();
+		if (languageId === OUTPUT_MODE_ID || languageId === LOG_MODE_ID || languageId === SEARCH_RESULT_LANGUAGE_ID) {
+			return false;
+		}
+
+		const isNotebookCell = model?.uri.scheme === Schemas.vscodeNotebookCell;
+		if (isNotebookCell) {
+			return false;
+		}
 
 		const inlineChatProviders = [...this.inlineChatService.getAllProvider()];
-		const languageId = model?.getLanguageId();
-		const shouldRenderInlineChatHint = !this.editor.getOption(EditorOption.readOnly) && languageId !== OUTPUT_MODE_ID && languageId !== LOG_MODE_ID && languageId !== SEARCH_RESULT_LANGUAGE_ID && inlineChatProviders.length > 0;
 		const shouldRenderDefaultHint = model?.uri.scheme === Schemas.untitled && languageId === PLAINTEXT_LANGUAGE_ID && !inlineChatProviders.length;
+		return inlineChatProviders.length > 0 || shouldRenderDefaultHint;
+	}
 
-		if ((shouldRenderDefaultHint || shouldRenderInlineChatHint) && configValue !== 'hidden') {
+	private update(): void {
+		this.textHintContentWidget?.dispose();
+
+		if (this._shouldRenderHint()) {
 			this.textHintContentWidget = new EmptyTextEditorHintContentWidget(
 				this.editor,
 				this.editorGroupsService,


### PR DESCRIPTION
Also disables inline chat hint in notebook cells.
`ICodeEditor.hasTextFocus()` is always false for notebook cells. We need
a way to ensure we only show the hint for the active notebook cell

cc @rebornix
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
