### PR TITLE
change default of defaultViewSortKey to status

### DIFF
--- a/src/vs/workbench/contrib/scm/browser/scm.contribution.ts
+++ b/src/vs/workbench/contrib/scm/browser/scm.contribution.ts
@@ -237,7 +237,7 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).regis
 				localize('scm.defaultViewSortKey.status', "Sort the repository changes by Source Control status.")
 			],
 			description: localize('scm.defaultViewSortKey', "Controls the default Source Control repository changes sort order when viewed as a list."),
-			default: 'path'
+			default: 'status'
 		},
 		'scm.autoReveal': {
 			type: 'boolean',


### PR DESCRIPTION
I remember most SCM UI I used is status first. Would it make more sense to make it the default?