### PR TITLE
Fix case clause termination in shellscript grammar

### DIFF
--- a/extensions/shellscript/syntaxes/shell-unix-bash.tmLanguage.json
+++ b/extensions/shellscript/syntaxes/shell-unix-bash.tmLanguage.json
@@ -268,7 +268,7 @@
 			"patterns": [
 				{
 					"begin": "(?=\\S)",
-					"end": ";;",
+					"end": ";;?&?",
 					"endCaptures": {
 						"0": {
 							"name": "punctuation.terminator.case-clause.shell"
@@ -311,7 +311,7 @@
 						},
 						{
 							"begin": "(?<=\\))",
-							"end": "(?=;;)",
+							"end": "(?=;;?&?)",
 							"name": "meta.scope.case-clause-body.shell",
 							"patterns": [
 								{


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fixes #192701: added support for all three terminations, `;;`, `;&`, and `;;&`.

![Shellscript case](https://github.com/microsoft/vscode/assets/6264315/6de41346-9629-4f8e-afd0-a24d91a4aec8)
