### PR TITLE
[typescript-language-features] Add option for excluding library symbols in "Go to Symbol in Workspace"

### DIFF
--- a/extensions/typescript-language-features/package.json
+++ b/extensions/typescript-language-features/package.json
@@ -1275,6 +1275,12 @@
           "default": false,
           "description": "%configuration.preferGoToSourceDefinition%",
           "scope": "window"
+        },
+        "typescript.workspaceSymbols.excludeLibrarySymbols": {
+          "type": "boolean",
+          "default": true,
+          "markdownDescription": "%typescript.workspaceSymbols.excludeLibrarySymbols%",
+          "scope": "window"
         }
       }
     },

--- a/extensions/typescript-language-features/package.nls.json
+++ b/extensions/typescript-language-features/package.nls.json
@@ -153,6 +153,7 @@
 	"typescript.preferences.includePackageJsonAutoImports.on": "Always search dependencies.",
 	"typescript.preferences.includePackageJsonAutoImports.off": "Never search dependencies.",
 	"typescript.preferences.autoImportFileExcludePatterns": "Specify glob patterns of files to exclude from auto imports. Relative paths are resolved relative to the workspace root. Patterns are evaluated using tsconfig.json [`exclude`](https://www.typescriptlang.org/tsconfig#exclude) semantics. Requires using TypeScript 4.8 or newer in the workspace.",
+	"typescript.workspaceSymbols.excludeLibrarySymbols": "Exclude symbols that come from library files in `Go To Symbol in Workspace` results.",
 	"typescript.updateImportsOnFileMove.enabled": "Enable/disable automatic updating of import paths when you rename or move a file in VS Code.",
 	"typescript.updateImportsOnFileMove.enabled.prompt": "Prompt on each rename.",
 	"typescript.updateImportsOnFileMove.enabled.always": "Always update paths automatically.",

--- a/extensions/typescript-language-features/package.nls.json
+++ b/extensions/typescript-language-features/package.nls.json
@@ -153,7 +153,7 @@
 	"typescript.preferences.includePackageJsonAutoImports.on": "Always search dependencies.",
 	"typescript.preferences.includePackageJsonAutoImports.off": "Never search dependencies.",
 	"typescript.preferences.autoImportFileExcludePatterns": "Specify glob patterns of files to exclude from auto imports. Relative paths are resolved relative to the workspace root. Patterns are evaluated using tsconfig.json [`exclude`](https://www.typescriptlang.org/tsconfig#exclude) semantics. Requires using TypeScript 4.8 or newer in the workspace.",
-	"typescript.workspaceSymbols.excludeLibrarySymbols": "Exclude symbols that come from library files in `Go To Symbol in Workspace` results.",
+	"typescript.workspaceSymbols.excludeLibrarySymbols": "Exclude symbols that come from library files in `Go To Symbol in Workspace` results. Requires using TypeScript 5.3+ in the workspace.",
 	"typescript.updateImportsOnFileMove.enabled": "Enable/disable automatic updating of import paths when you rename or move a file in VS Code.",
 	"typescript.updateImportsOnFileMove.enabled.prompt": "Prompt on each rename.",
 	"typescript.updateImportsOnFileMove.enabled.always": "Always update paths automatically.",

--- a/extensions/typescript-language-features/src/configuration/configuration.ts
+++ b/extensions/typescript-language-features/src/configuration/configuration.ts
@@ -122,6 +122,7 @@ export interface TypeScriptServiceConfiguration {
 	readonly enableTsServerTracing: boolean;
 	readonly localNodePath: string | null;
 	readonly globalNodePath: string | null;
+	readonly workspaceSymbolsExcludeLibrarySymbols: boolean;
 }
 
 export function areServiceConfigurationsEqual(a: TypeScriptServiceConfiguration, b: TypeScriptServiceConfiguration): boolean {
@@ -158,6 +159,7 @@ export abstract class BaseServiceConfigurationProvider implements ServiceConfigu
 			enableTsServerTracing: this.readEnableTsServerTracing(configuration),
 			localNodePath: this.readLocalNodePath(configuration),
 			globalNodePath: this.readGlobalNodePath(configuration),
+			workspaceSymbolsExcludeLibrarySymbols: this.readWorkspaceSymbolsExcludeLibrarySymbols(configuration),
 		};
 	}
 
@@ -254,5 +256,9 @@ export abstract class BaseServiceConfigurationProvider implements ServiceConfigu
 
 	private readWebProjectWideIntellisenseSuppressSemanticErrors(configuration: vscode.WorkspaceConfiguration): boolean {
 		return configuration.get<boolean>('typescript.tsserver.web.projectWideIntellisense.suppressSemanticErrors', true);
+	}
+
+	private readWorkspaceSymbolsExcludeLibrarySymbols(configuration: vscode.WorkspaceConfiguration): boolean {
+		return configuration.get<boolean>('typescript.workspaceSymbols.excludeLibrarySymbols', true);
 	}
 }

--- a/extensions/typescript-language-features/src/typescriptServiceClient.ts
+++ b/extensions/typescript-language-features/src/typescriptServiceClient.ts
@@ -558,7 +558,6 @@ export default class TypeScriptServiceClient extends Disposable implements IType
 				providePrefixAndSuffixTextForRename: true,
 				allowRenameOfImportPath: true,
 				includePackageJsonAutoImports: this._configuration.includePackageJsonAutoImports,
-				// @ts-expect-error until TS 5.3
 				excludeLibrarySymbolsInNavTo: this._configuration.workspaceSymbolsExcludeLibrarySymbols,
 			},
 			watchOptions

--- a/extensions/typescript-language-features/src/typescriptServiceClient.ts
+++ b/extensions/typescript-language-features/src/typescriptServiceClient.ts
@@ -558,6 +558,8 @@ export default class TypeScriptServiceClient extends Disposable implements IType
 				providePrefixAndSuffixTextForRename: true,
 				allowRenameOfImportPath: true,
 				includePackageJsonAutoImports: this._configuration.includePackageJsonAutoImports,
+				// @ts-expect-error until TS 5.3
+				excludeLibrarySymbolsInNavTo: this._configuration.workspaceSymbolsExcludeLibrarySymbols,
 			},
 			watchOptions
 		};


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fixes https://github.com/microsoft/TypeScript/issues/48194.
Partially fixes #46718 (still doesn't allow for custom exclusion based on `search.excludes`).
TS Server PR: https://github.com/microsoft/TypeScript/pull/55605.