### PR TITLE
cli: propagate server closing

### DIFF
--- a/cli/src/tunnels/protocol.rs
+++ b/cli/src/tunnels/protocol.rs
@@ -16,6 +16,7 @@ use serde::{Deserialize, Serialize};
 #[allow(non_camel_case_types)]
 pub enum ClientRequestMethod<'a> {
 	servermsg(RefServerMessageParams<'a>),
+	serverclose(ServerClosedParams),
 	serverlog(ServerLog<'a>),
 	makehttpreq(HttpRequestParams<'a>),
 	version(VersionResponse),
@@ -87,6 +88,11 @@ pub struct ServerMessageParams {
 	pub i: u16,
 	#[serde(with = "serde_bytes")]
 	pub body: Vec<u8>,
+}
+
+#[derive(Serialize, Debug)]
+pub struct ServerClosedParams {
+	pub i: u16,
 }
 
 #[derive(Serialize, Debug)]

--- a/cli/src/tunnels/server_bridge.rs
+++ b/cli/src/tunnels/server_bridge.rs
@@ -32,6 +32,7 @@ impl ServerBridge {
 				match read.read(&mut read_buf).await {
 					Err(_) => return,
 					Ok(0) => {
+						let _ = target.server_closed().await;
 						return; // EOF
 					}
 					Ok(s) => {


### PR DESCRIPTION
Previously this was never needed since the connection was only used for
the ext host, which never closed.

Part 1 of fixing #192521

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
