### PR TITLE
persist parent task such that on reload, statuses resume

### DIFF
--- a/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
+++ b/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
@@ -335,7 +335,7 @@ export abstract class AbstractTaskService extends Disposable implements ITaskSer
 			} else if ((this._willRestart || (e.kind === TaskEventKind.Terminated && e.exitReason === TerminalExitReason.User)) && e.taskId) {
 				this.removePersistentTask(e.taskId);
 			} else if (e.kind === TaskEventKind.DependsOnStarted && e.__task && e.dependencyIsBackgroundTask) {
-				this._setPersistentTask(e.__task);
+				this._setPersistentTask(e.__task, true);
 				const dependencies = e.__task.configurationProperties.dependsOn;
 				if (dependencies) {
 					this._dependencyTaskMap.set(e.__task._id, dependencies);
@@ -1126,7 +1126,7 @@ export abstract class AbstractTaskService extends Disposable implements ITaskSer
 		this._storageService.store(AbstractTaskService.RecentlyUsedTasks_KeyV2, JSON.stringify(keyValues), StorageScope.WORKSPACE, StorageTarget.MACHINE);
 	}
 
-	private async _setPersistentTask(task: Task): Promise<void> {
+	private async _setPersistentTask(task: Task, dependencyIsBackgroundTask?: boolean): Promise<void> {
 		if (!this._configurationService.getValue(TaskSettingId.Reconnection)) {
 			return;
 		}
@@ -1144,7 +1144,7 @@ export abstract class AbstractTaskService extends Disposable implements ITaskSer
 					key = customized[configuration].getRecentlyUsedKey()!;
 				}
 			}
-			if (!task.configurationProperties.isBackground) {
+			if (!task.configurationProperties.isBackground || !dependencyIsBackgroundTask) {
 				return;
 			}
 			this._getTasksFromStorage('persistent').set(key, JSON.stringify(customizations));

--- a/src/vs/workbench/contrib/tasks/common/tasks.ts
+++ b/src/vs/workbench/contrib/tasks/common/tasks.ts
@@ -1150,11 +1150,13 @@ export interface ITaskStartedEvent extends ITaskCommon {
 	kind: TaskEventKind.Start;
 	terminalId: number;
 	resolvedVariables: Map<string, string>;
+	dependencyTask?: boolean;
 }
 
 export interface ITaskGeneralEvent extends ITaskCommon {
 	kind: TaskEventKind.AcquiredInput | TaskEventKind.DependsOnStarted | TaskEventKind.Active | TaskEventKind.Inactive | TaskEventKind.End;
 	terminalId: number | undefined;
+	dependencyIsBackgroundTask: boolean | undefined;
 }
 
 export type ITaskEvent =
@@ -1184,12 +1186,13 @@ export namespace TaskEvent {
 		};
 	}
 
-	export function start(task: Task, terminalId: number, resolvedVariables: Map<string, string>): ITaskStartedEvent {
+	export function start(task: Task, terminalId: number, resolvedVariables: Map<string, string>, dependencyTask?: boolean): ITaskStartedEvent {
 		return {
 			...common(task),
 			kind: TaskEventKind.Start,
 			terminalId,
 			resolvedVariables,
+			dependencyTask
 		};
 	}
 
@@ -1219,11 +1222,12 @@ export namespace TaskEvent {
 		};
 	}
 
-	export function general(kind: TaskEventKind.AcquiredInput | TaskEventKind.DependsOnStarted | TaskEventKind.Active | TaskEventKind.Inactive | TaskEventKind.End, task: Task, terminalId?: number): ITaskGeneralEvent {
+	export function general(kind: TaskEventKind.AcquiredInput | TaskEventKind.DependsOnStarted | TaskEventKind.Active | TaskEventKind.Inactive | TaskEventKind.End, task: Task, terminalId?: number, dependencyIsBackgroundTask?: boolean): ITaskGeneralEvent {
 		return {
 			...common(task),
 			kind,
 			terminalId,
+			dependencyIsBackgroundTask
 		};
 	}
 


### PR DESCRIPTION
fix #190987

The issue here was we were persisting the dependency tasks instead of the main one, so the task event, `DependsOnStarted`, was not happening. 

This saves only the main task and removes it when all dependency tasks have been terminated. 

There is one edge case where if you delete only one of the dependency tasks, on reload, the main task will get run again. But in order to truly fix that, we would need to save the persistent task of the remaining active dependency tasks when one is deleted and remove the main one from those that are persisted. Currently, there's no way to do this. 

This still works if you run a dependency task directly via `Run Tasks`. It will persist in that case.