### PR TITLE
Fix debug console after restarting session

### DIFF
--- a/src/vs/workbench/contrib/debug/test/browser/baseDebugView.test.ts
+++ b/src/vs/workbench/contrib/debug/test/browser/baseDebugView.test.ts
@@ -8,7 +8,6 @@ import * as dom from 'vs/base/browser/dom';
 import { HighlightedLabel } from 'vs/base/browser/ui/highlightedlabel/highlightedLabel';
 import { DisposableStore } from 'vs/base/common/lifecycle';
 import { isWindows } from 'vs/base/common/platform';
-import { ensureNoDisposablesAreLeakedInTestSuite } from 'vs/base/test/common/utils';
 import { TestInstantiationService } from 'vs/platform/instantiation/test/common/instantiationServiceMock';
 import { renderExpressionValue, renderVariable, renderViewTree } from 'vs/workbench/contrib/debug/browser/baseDebugView';
 import { LinkDetector } from 'vs/workbench/contrib/debug/browser/linkDetector';
@@ -37,8 +36,6 @@ suite('Debug - Base Debug View', () => {
 	teardown(() => {
 		disposables.dispose();
 	});
-
-	ensureNoDisposablesAreLeakedInTestSuite();
 
 	test('render view tree', () => {
 		const container = $('.container');

--- a/src/vs/workbench/contrib/debug/test/browser/breakpoints.test.ts
+++ b/src/vs/workbench/contrib/debug/test/browser/breakpoints.test.ts
@@ -7,7 +7,6 @@ import * as assert from 'assert';
 import { MarkdownString } from 'vs/base/common/htmlContent';
 import { DisposableStore, dispose } from 'vs/base/common/lifecycle';
 import { URI as uri } from 'vs/base/common/uri';
-import { ensureNoDisposablesAreLeakedInTestSuite } from 'vs/base/test/common/utils';
 import { Range } from 'vs/editor/common/core/range';
 import { ILanguageService } from 'vs/editor/common/languages/language';
 import { OverviewRulerLane } from 'vs/editor/common/model';
@@ -58,8 +57,6 @@ suite('Debug - Breakpoints', () => {
 	teardown(() => {
 		disposables.dispose();
 	});
-
-	ensureNoDisposablesAreLeakedInTestSuite();
 
 	// Breakpoints
 

--- a/src/vs/workbench/contrib/debug/test/browser/callStack.test.ts
+++ b/src/vs/workbench/contrib/debug/test/browser/callStack.test.ts
@@ -9,7 +9,6 @@ import { DisposableStore } from 'vs/base/common/lifecycle';
 import { ThemeIcon } from 'vs/base/common/themables';
 import { Constants } from 'vs/base/common/uint';
 import { generateUuid } from 'vs/base/common/uuid';
-import { ensureNoDisposablesAreLeakedInTestSuite } from 'vs/base/test/common/utils';
 import { Range } from 'vs/editor/common/core/range';
 import { TestConfigurationService } from 'vs/platform/configuration/test/common/testConfigurationService';
 import { TestInstantiationService } from 'vs/platform/instantiation/test/common/instantiationServiceMock';
@@ -84,8 +83,6 @@ suite('Debug - CallStack', () => {
 		disposables.dispose();
 		sinon.restore();
 	});
-
-	ensureNoDisposablesAreLeakedInTestSuite();
 
 	// Threads
 

--- a/src/vs/workbench/contrib/debug/test/browser/debugHover.test.ts
+++ b/src/vs/workbench/contrib/debug/test/browser/debugHover.test.ts
@@ -5,7 +5,6 @@
 
 import * as assert from 'assert';
 import { DisposableStore } from 'vs/base/common/lifecycle';
-import { ensureNoDisposablesAreLeakedInTestSuite } from 'vs/base/test/common/utils';
 import { NullLogService } from 'vs/platform/log/common/log';
 import { findExpressionInStackFrame } from 'vs/workbench/contrib/debug/browser/debugHover';
 import type { IExpression, IScope } from 'vs/workbench/contrib/debug/common/debug';
@@ -23,8 +22,6 @@ suite('Debug - Hover', () => {
 	teardown(() => {
 		disposables.dispose();
 	});
-
-	ensureNoDisposablesAreLeakedInTestSuite();
 
 	test('find expression in stack frame', async () => {
 		const model = createMockDebugModel(disposables);

--- a/src/vs/workbench/contrib/debug/test/browser/repl.test.ts
+++ b/src/vs/workbench/contrib/debug/test/browser/repl.test.ts
@@ -9,7 +9,6 @@ import { TreeVisibility } from 'vs/base/browser/ui/tree/tree';
 import { timeout } from 'vs/base/common/async';
 import { DisposableStore } from 'vs/base/common/lifecycle';
 import severity from 'vs/base/common/severity';
-import { ensureNoDisposablesAreLeakedInTestSuite } from 'vs/base/test/common/utils';
 import { TestConfigurationService } from 'vs/platform/configuration/test/common/testConfigurationService';
 import { RawDebugSession } from 'vs/workbench/contrib/debug/browser/rawDebugSession';
 import { ReplFilter } from 'vs/workbench/contrib/debug/browser/replFilter';
@@ -35,8 +34,6 @@ suite('Debug - REPL', () => {
 	teardown(() => {
 		disposables.dispose();
 	});
-
-	ensureNoDisposablesAreLeakedInTestSuite();
 
 	test('repl output', () => {
 		const session = disposables.add(createTestSession(model));

--- a/src/vs/workbench/contrib/debug/test/common/debugModel.test.ts
+++ b/src/vs/workbench/contrib/debug/test/common/debugModel.test.ts
@@ -7,15 +7,12 @@ import * as assert from 'assert';
 import { DeferredPromise } from 'vs/base/common/async';
 import { DisposableStore } from 'vs/base/common/lifecycle';
 import { mockObject } from 'vs/base/test/common/mock';
-import { ensureNoDisposablesAreLeakedInTestSuite } from 'vs/base/test/common/utils';
 import { NullLogService } from 'vs/platform/log/common/log';
 import { DebugModel, ExceptionBreakpoint, FunctionBreakpoint, Thread } from 'vs/workbench/contrib/debug/common/debugModel';
 import { MockDebugStorage } from 'vs/workbench/contrib/debug/test/common/mockDebug';
 import { TestStorageService } from 'vs/workbench/test/common/workbenchTestServices';
 
 suite('DebugModel', () => {
-	ensureNoDisposablesAreLeakedInTestSuite();
-
 	suite('FunctionBreakpoint', () => {
 		test('Id is saved', () => {
 			const fbp = new FunctionBreakpoint('function', true, 'hit condition', 'condition', 'log message');


### PR DESCRIPTION
Don't add global DebugSession listeners to rawListeners, which are disposed when a DebugSession is restarted
Fix #192653

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
