### PR TITLE
when processing lines for reconnected task terminals, fire task active event so statuses are updated

### DIFF
--- a/src/vs/workbench/contrib/tasks/browser/taskTerminalStatus.ts
+++ b/src/vs/workbench/contrib/tasks/browser/taskTerminalStatus.ts
@@ -49,6 +49,7 @@ export class TaskTerminalStatus extends Disposable {
 				case TaskEventKind.Inactive: this.eventInactive(event); break;
 				case TaskEventKind.ProcessEnded: this.eventEnd(event); break;
 			}
+			console.log(event.kind);
 		}));
 	}
 

--- a/src/vs/workbench/contrib/tasks/browser/taskTerminalStatus.ts
+++ b/src/vs/workbench/contrib/tasks/browser/taskTerminalStatus.ts
@@ -49,7 +49,6 @@ export class TaskTerminalStatus extends Disposable {
 				case TaskEventKind.Inactive: this.eventInactive(event); break;
 				case TaskEventKind.ProcessEnded: this.eventEnd(event); break;
 			}
-			console.log(event.kind);
 		}));
 	}
 

--- a/src/vs/workbench/contrib/tasks/browser/terminalTaskSystem.ts
+++ b/src/vs/workbench/contrib/tasks/browser/terminalTaskSystem.ts
@@ -948,6 +948,7 @@ export class TerminalTaskSystem extends Disposable implements ITaskSystem {
 				for (let i = bufferLines.length - 1; i >= 0; i--) {
 					watchingProblemMatcher.processLine(bufferLines[i]);
 				}
+				this._fireTaskEvent(TaskEvent.general(TaskEventKind.Active, task, terminal.instanceId));
 			}
 		} else {
 			[terminal, error] = await this._createTerminal(task, resolver, workspaceFolder);


### PR DESCRIPTION
fix #190987


https://github.com/microsoft/vscode/assets/29464607/cd682ad4-de2a-4189-8053-5efcd4af09a2

