### PR TITLE
fire active, inactive before, after lines are processed for reconnected task terminals

### DIFF
--- a/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
+++ b/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
@@ -1865,8 +1865,8 @@ export abstract class AbstractTaskService extends Disposable implements ITaskSer
 		}
 		if (executeResult.kind === TaskExecuteKind.Active) {
 			const active = executeResult.active;
-			if (active && active.same && runSource === TaskRunSource.FolderOpen) {
-				// ignore, the task is already active, likely from being reconnected.
+			if (active && active.same && runSource === TaskRunSource.FolderOpen || runSource === TaskRunSource.Reconnect) {
+				// ignore, the task is already active, likely from being reconnected or from folder open.
 				this._logService.debug('Ignoring task that is already active', executeResult.task);
 				return executeResult.promise;
 			}

--- a/src/vs/workbench/contrib/tasks/browser/terminalTaskSystem.ts
+++ b/src/vs/workbench/contrib/tasks/browser/terminalTaskSystem.ts
@@ -936,7 +936,7 @@ export class TerminalTaskSystem extends Disposable implements ITaskSystem {
 			});
 			if (trigger === Triggers.reconnect && !!terminal.xterm) {
 				const bufferLines = [];
-
+				this._fireTaskEvent(TaskEvent.general(TaskEventKind.Active, task, terminal?.instanceId));
 				const bufferReverseIterator = terminal.xterm.getBufferReverseIterator();
 				const startRegex = new RegExp(watchingProblemMatcher.beginPatterns.map(pattern => pattern.source).join('|'));
 				for (const nextLine of bufferReverseIterator) {
@@ -948,7 +948,7 @@ export class TerminalTaskSystem extends Disposable implements ITaskSystem {
 				for (let i = bufferLines.length - 1; i >= 0; i--) {
 					watchingProblemMatcher.processLine(bufferLines[i]);
 				}
-				this._fireTaskEvent(TaskEvent.general(TaskEventKind.Active, task, terminal.instanceId));
+				this._fireTaskEvent(TaskEvent.general(TaskEventKind.Inactive, task, terminal.instanceId));
 			}
 		} else {
 			[terminal, error] = await this._createTerminal(task, resolver, workspaceFolder);

--- a/src/vs/workbench/contrib/tasks/browser/terminalTaskSystem.ts
+++ b/src/vs/workbench/contrib/tasks/browser/terminalTaskSystem.ts
@@ -936,7 +936,7 @@ export class TerminalTaskSystem extends Disposable implements ITaskSystem {
 			});
 			if (trigger === Triggers.reconnect && !!terminal.xterm) {
 				const bufferLines = [];
-				this._fireTaskEvent(TaskEvent.general(TaskEventKind.Active, task, terminal?.instanceId));
+				this._fireTaskEvent(TaskEvent.general(TaskEventKind.Active, task, terminal.instanceId));
 				const bufferReverseIterator = terminal.xterm.getBufferReverseIterator();
 				const startRegex = new RegExp(watchingProblemMatcher.beginPatterns.map(pattern => pattern.source).join('|'));
 				for (const nextLine of bufferReverseIterator) {


### PR DESCRIPTION
aligns with what we do when the lines are processed via the watching problem collector vs our reconnection.
fix #192921

also fixes the case where the task is run on folder open before the full task reconnection happens