### PR TITLE
cli: allow command-shell to listen on a prescribed port

### DIFF
--- a/cli/src/commands/args.rs
+++ b/cli/src/commands/args.rs
@@ -220,8 +220,8 @@ pub struct CommandShellArgs {
 	#[clap(long)]
 	pub on_socket: bool,
 	/// Listen on a port instead of stdin/stdout.
-	#[clap(long)]
-	pub on_port: bool,
+	#[clap(long, num_args = 0..=1, default_missing_value = "0")]
+	pub on_port: Option<u16>,
 	/// Require the given token string to be given in the handshake.
 	#[clap(long)]
 	pub require_token: Option<String>,

--- a/cli/src/commands/tunnels.rs
+++ b/cli/src/commands/tunnels.rs
@@ -8,7 +8,11 @@ use base64::{engine::general_purpose as b64, Engine as _};
 use futures::{stream::FuturesUnordered, StreamExt};
 use serde::Serialize;
 use sha2::{Digest, Sha256};
-use std::{str::FromStr, time::Duration};
+use std::{
+	net::{IpAddr, Ipv4Addr, SocketAddr},
+	str::FromStr,
+	time::Duration,
+};
 use sysinfo::Pid;
 use tokio::{
 	io::{AsyncBufReadExt, BufReader},
@@ -157,8 +161,9 @@ pub async fn command_shell(ctx: CommandContext, args: CommandShellArgs) -> Resul
 
 			Box::new(listener)
 		}
-		(true, _) => {
-			let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+		(Some(p), _) => {
+			let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), p);
+			let listener = tokio::net::TcpListener::bind(addr)
 				.await
 				.map_err(|e| wrap(e, "error listening on port"))?;
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-internalbacklog/issues/4623

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
