### PR TITLE
fix: some commands not showing in screencast mode

### DIFF
--- a/src/vs/platform/actions/common/actions.ts
+++ b/src/vs/platform/actions/common/actions.ts
@@ -311,6 +311,10 @@ export interface IMenuRegistry {
 	appendMenuItems(items: Iterable<{ id: MenuId; item: IMenuItem | ISubmenuItem }>): IDisposable;
 	appendMenuItem(menu: MenuId, item: IMenuItem | ISubmenuItem): IDisposable;
 	getMenuItems(loc: MenuId): Array<IMenuItem | ISubmenuItem>;
+	/**
+	 * Do not use this unless perf is not a concern. It will search through all Menu items linearly.
+	 */
+	searchMenuItemsForCommand(id: string): ICommandAction | undefined;
 }
 
 export const MenuRegistry: IMenuRegistry = new class implements IMenuRegistry {
@@ -364,6 +368,17 @@ export const MenuRegistry: IMenuRegistry = new class implements IMenuRegistry {
 			result.add(this.appendMenuItem(id, item));
 		}
 		return result;
+	}
+
+	searchMenuItemsForCommand(id: string): ICommandAction | undefined {
+		for (const item of this._menuItems.values()) {
+			for (const subitem of item) {
+				if (isIMenuItem(subitem) && subitem.command.id === id) {
+					return subitem.command;
+				}
+			}
+		}
+		return undefined;
 	}
 
 	getMenuItems(id: MenuId): Array<IMenuItem | ISubmenuItem> {

--- a/src/vs/workbench/browser/actions/developerActions.ts
+++ b/src/vs/workbench/browser/actions/developerActions.ts
@@ -293,7 +293,8 @@ class ToggleScreencastModeAction extends Action2 {
 			}
 
 			const keybinding = keybindingService.resolveKeyboardEvent(event);
-			const command = (this._isKbFound(shortcut) && shortcut.commandId) ? MenuRegistry.getCommand(shortcut.commandId) : null;
+			const commandId = this._isKbFound(shortcut) && shortcut.commandId;
+			const command = (commandId) ? (MenuRegistry.getCommand(commandId) || MenuRegistry.searchMenuItemsForCommand(commandId)) : null;
 
 			let commandAndGroupLabel = '';
 			let keyLabel: string | undefined | null = keybinding.getLabel();


### PR DESCRIPTION
Fixes #188938

Due to how the MenuItems are stored it's not possible to query them in O(1) unless we start storing them as a different data structure.

As this search is only needed in a very small use case (Screencast mode with a Keyboard shortcut hit), I feel adding a linear search is still fine.

https://github.com/microsoft/vscode/assets/2021979/cc76be65-f0ba-4c4c-bbf0-c80cc15bca70


<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
