### PR TITLE
Re #167719. Disable word highlighting, codelens, sticky provider when the model is very large.

### DIFF
--- a/src/vs/editor/contrib/codelens/browser/codelensController.ts
+++ b/src/vs/editor/contrib/codelens/browser/codelensController.ts
@@ -134,7 +134,7 @@ export class CodeLensContribution implements IEditorContribution {
 			return;
 		}
 
-		if (!this._editor.getOption(EditorOption.codeLens)) {
+		if (!this._editor.getOption(EditorOption.codeLens) || model.isTooLargeForTokenization()) {
 			return;
 		}
 

--- a/src/vs/editor/contrib/links/browser/links.ts
+++ b/src/vs/editor/contrib/links/browser/links.ts
@@ -119,6 +119,10 @@ export class LinkDetector extends Disposable implements IEditorContribution {
 
 		const model = this.editor.getModel();
 
+		if (model.isTooLargeForSyncing()) {
+			return;
+		}
+
 		if (!this.providers.has(model)) {
 			return;
 		}

--- a/src/vs/editor/contrib/stickyScroll/browser/stickyScrollProvider.ts
+++ b/src/vs/editor/contrib/stickyScroll/browser/stickyScrollProvider.ts
@@ -112,7 +112,7 @@ export class StickyLineCandidateProvider extends Disposable implements IStickyLi
 
 	private async updateStickyModel(token: CancellationToken): Promise<void> {
 
-		if (!this._editor.hasModel() || !this._stickyModelProvider) {
+		if (!this._editor.hasModel() || !this._stickyModelProvider || this._editor.getModel().isTooLargeForTokenization()) {
 			this._model = null;
 			return;
 		}

--- a/src/vs/editor/contrib/wordHighlighter/browser/wordHighlighter.ts
+++ b/src/vs/editor/contrib/wordHighlighter/browser/wordHighlighter.ts
@@ -490,7 +490,7 @@ export class WordHighlighterContribution extends Disposable implements IEditorCo
 		this.wordHighlighter = null;
 		this.linkedContributions = new Set();
 		const createWordHighlighterIfPossible = () => {
-			if (editor.hasModel()) {
+			if (editor.hasModel() && !editor.getModel().isTooLargeForTokenization()) {
 				this.wordHighlighter = new WordHighlighter(editor, languageFeaturesService.documentHighlightProvider, () => Iterable.map(this.linkedContributions, c => c.wordHighlighter), contextKeyService);
 			}
 		};

--- a/src/vs/workbench/contrib/codeEditor/browser/largeFileOptimizations.ts
+++ b/src/vs/workbench/contrib/codeEditor/browser/largeFileOptimizations.ts
@@ -44,7 +44,7 @@ export class LargeFileOptimizationsWarner extends Disposable implements IEditorC
 						'Variable 0 will be a file name.'
 					]
 				},
-				"{0}: tokenization, wrapping, folding and sticky scroll have been turned off for this large file in order to reduce memory usage and avoid freezing or crashing.",
+				"{0}: tokenization, wrapping, folding, codelens, word highlighting and sticky scroll have been turned off for this large file in order to reduce memory usage and avoid freezing or crashing.",
 				path.basename(model.uri.path)
 			);
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Currently when opening large files these contribs are still reading the line contents and thus blocking the UI. cc @alexdima @aiday-mar 