### PR TITLE
Basic 'chat agent' API

### DIFF
--- a/src/vs/workbench/api/browser/extensionHost.contribution.ts
+++ b/src/vs/workbench/api/browser/extensionHost.contribution.ts
@@ -21,6 +21,7 @@ import './mainThreadLocalization';
 import './mainThreadBulkEdits';
 import './mainThreadChatProvider';
 import './mainThreadChatSlashCommands';
+import './mainThreadChatAgents';
 import './mainThreadChatVariables';
 import './mainThreadCodeInsets';
 import './mainThreadCLICommands';

--- a/src/vs/workbench/api/browser/mainThreadChatAgents.ts
+++ b/src/vs/workbench/api/browser/mainThreadChatAgents.ts
@@ -15,7 +15,7 @@ import { IExtHostContext, extHostNamedCustomer } from 'vs/workbench/services/ext
 @extHostNamedCustomer(MainContext.MainThreadChatAgents)
 export class MainThreadChatAgents implements MainThreadChatAgentsShape {
 
-	private readonly _commands = new DisposableMap<number>;
+	private readonly _agents = new DisposableMap<number>;
 	private readonly _pendingProgress = new Map<number, IProgress<IChatSlashFragment>>();
 	private readonly _proxy: ExtHostChatAgentsShape;
 
@@ -27,11 +27,11 @@ export class MainThreadChatAgents implements MainThreadChatAgentsShape {
 	}
 
 	$unregisterAgent(handle: number): void {
-		throw new Error('Method not implemented.');
+		this._agents.deleteAndDispose(handle);
 	}
 
 	dispose(): void {
-		this._commands.clearAndDisposeAll();
+		this._agents.clearAndDisposeAll();
 	}
 
 	$registerAgent(handle: number, name: string, metadata: IChatAgentMetadata): void {
@@ -52,7 +52,7 @@ export class MainThreadChatAgents implements MainThreadChatAgentsShape {
 				this._pendingProgress.delete(requestId);
 			}
 		});
-		this._commands.set(handle, d);
+		this._agents.set(handle, d);
 	}
 
 	async $handleProgressChunk(requestId: number, chunk: IChatSlashFragment): Promise<void> {
@@ -60,6 +60,6 @@ export class MainThreadChatAgents implements MainThreadChatAgentsShape {
 	}
 
 	$unregisterCommand(handle: number): void {
-		this._commands.deleteAndDispose(handle);
+		this._agents.deleteAndDispose(handle);
 	}
 }

--- a/src/vs/workbench/api/browser/mainThreadChatAgents.ts
+++ b/src/vs/workbench/api/browser/mainThreadChatAgents.ts
@@ -39,7 +39,7 @@ export class MainThreadChatAgents implements MainThreadChatAgentsShape {
 			// dynamic!
 			this._chatAgentService.registerAgentData({
 				id: name,
-				metadata
+				metadata: revive(metadata)
 			});
 		}
 

--- a/src/vs/workbench/api/browser/mainThreadChatAgents.ts
+++ b/src/vs/workbench/api/browser/mainThreadChatAgents.ts
@@ -1,0 +1,65 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { DisposableMap } from 'vs/base/common/lifecycle';
+import { revive } from 'vs/base/common/marshalling';
+import { IProgress } from 'vs/platform/progress/common/progress';
+import { ExtHostChatAgentsShape, ExtHostContext, MainContext, MainThreadChatAgentsShape } from 'vs/workbench/api/common/extHost.protocol';
+import { IChatAgentMetadata, IChatAgentService } from 'vs/workbench/contrib/chat/common/chatAgents';
+import { IChatSlashFragment } from 'vs/workbench/contrib/chat/common/chatSlashCommands';
+import { IExtHostContext, extHostNamedCustomer } from 'vs/workbench/services/extensions/common/extHostCustomers';
+
+
+@extHostNamedCustomer(MainContext.MainThreadChatAgents)
+export class MainThreadChatAgents implements MainThreadChatAgentsShape {
+
+	private readonly _commands = new DisposableMap<number>;
+	private readonly _pendingProgress = new Map<number, IProgress<IChatSlashFragment>>();
+	private readonly _proxy: ExtHostChatAgentsShape;
+
+	constructor(
+		extHostContext: IExtHostContext,
+		@IChatAgentService private readonly _chatAgentService: IChatAgentService
+	) {
+		this._proxy = extHostContext.getProxy(ExtHostContext.ExtHostChatAgents);
+	}
+
+	$unregisterAgent(handle: number): void {
+		throw new Error('Method not implemented.');
+	}
+
+	dispose(): void {
+		this._commands.clearAndDisposeAll();
+	}
+
+	$registerAgent(handle: number, name: string, metadata: IChatAgentMetadata): void {
+		if (!this._chatAgentService.hasAgent(name)) {
+			// dynamic!
+			this._chatAgentService.registerAgentData({
+				id: name,
+				metadata
+			});
+		}
+
+		const d = this._chatAgentService.registerAgentCallback(name, async (prompt, progress, history, token) => {
+			const requestId = Math.random();
+			this._pendingProgress.set(requestId, progress);
+			try {
+				return await this._proxy.$invokeAgent(handle, requestId, prompt, { history }, token);
+			} finally {
+				this._pendingProgress.delete(requestId);
+			}
+		});
+		this._commands.set(handle, d);
+	}
+
+	async $handleProgressChunk(requestId: number, chunk: IChatSlashFragment): Promise<void> {
+		this._pendingProgress.get(requestId)?.report(revive(chunk));
+	}
+
+	$unregisterCommand(handle: number): void {
+		this._commands.deleteAndDispose(handle);
+	}
+}

--- a/src/vs/workbench/api/common/extHost.api.impl.ts
+++ b/src/vs/workbench/api/common/extHost.api.impl.ts
@@ -108,6 +108,7 @@ import { ExtHostChatSlashCommands } from 'vs/workbench/api/common/extHostChatSla
 import { ExtHostChatVariables } from 'vs/workbench/api/common/extHostChatVariables';
 import { ExtHostRelatedInformation } from 'vs/workbench/api/common/extHostAiRelatedInformation';
 import { ExtHostAiEmbeddingVector } from 'vs/workbench/api/common/extHostEmbeddingVector';
+import { ExtHostChatAgents } from 'vs/workbench/api/common/extHostChatAgents';
 
 export interface IExtensionRegistries {
 	mine: ExtensionDescriptionRegistry;
@@ -209,6 +210,7 @@ export function createApiFactoryAndRegisterActors(accessor: ServicesAccessor): I
 	const extHostInteractiveEditor = rpcProtocol.set(ExtHostContext.ExtHostInlineChat, new ExtHostInteractiveEditor(rpcProtocol, extHostCommands, extHostDocuments, extHostLogService));
 	const extHostChatProvider = rpcProtocol.set(ExtHostContext.ExtHostChatProvider, new ExtHostChatProvider(rpcProtocol, extHostLogService));
 	const extHostChatSlashCommands = rpcProtocol.set(ExtHostContext.ExtHostChatSlashCommands, new ExtHostChatSlashCommands(rpcProtocol, extHostChatProvider, extHostLogService));
+	const extHostChatAgents = rpcProtocol.set(ExtHostContext.ExtHostChatAgents, new ExtHostChatAgents(rpcProtocol, extHostChatProvider, extHostLogService));
 	const extHostChatVariables = rpcProtocol.set(ExtHostContext.ExtHostChatVariables, new ExtHostChatVariables(rpcProtocol));
 	const extHostChat = rpcProtocol.set(ExtHostContext.ExtHostChat, new ExtHostChat(rpcProtocol, extHostLogService));
 	const extHostAiRelatedInformation = rpcProtocol.set(ExtHostContext.ExtHostAiRelatedInformation, new ExtHostRelatedInformation(rpcProtocol));
@@ -1360,7 +1362,12 @@ export function createApiFactoryAndRegisterActors(accessor: ServicesAccessor): I
 			registerMappedEditsProvider(selector: vscode.DocumentSelector, provider: vscode.MappedEditsProvider) {
 				checkProposedApiEnabled(extension, 'mappedEditsProvider');
 				return extHostLanguageFeatures.registerMappedEditsProvider(extension, selector, provider);
+			},
+			registerAgent(name: string, agent: vscode.ChatAgent, metadata: vscode.ChatAgentMetadata) {
+				checkProposedApiEnabled(extension, 'chatAgents');
+				return extHostChatAgents.registerAgent(extension.identifier, name, agent, metadata);
 			}
+
 		};
 
 		return <typeof vscode>{

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -77,6 +77,7 @@ import { IChatMessage, IChatResponseFragment, IChatResponseProviderMetadata } fr
 import { IChatSlashFragment } from 'vs/workbench/contrib/chat/common/chatSlashCommands';
 import { IChatRequestVariableValue, IChatVariableData } from 'vs/workbench/contrib/chat/common/chatVariables';
 import { RelatedInformationResult, RelatedInformationType } from 'vs/workbench/services/aiRelatedInformation/common/aiRelatedInformation';
+import { IChatAgentMetadata } from 'vs/workbench/contrib/chat/common/chatAgents';
 
 export interface IWorkspaceData extends IStaticWorkspaceData {
 	folders: { uri: UriComponents; name: string; index: number }[];
@@ -1152,6 +1153,16 @@ export interface MainThreadChatSlashCommandsShape extends IDisposable {
 
 export interface ExtHostChatSlashCommandsShape {
 	$executeCommand(handle: number, requestId: number, prompt: string, context: { history: IChatMessage[] }, token: CancellationToken): Promise<any>;
+}
+
+export interface MainThreadChatAgentsShape extends IDisposable {
+	$registerAgent(handle: number, name: string, metadata: IChatAgentMetadata): void;
+	$unregisterAgent(handle: number): void;
+	$handleProgressChunk(requestId: number, chunk: IChatSlashFragment): Promise<void>;
+}
+
+export interface ExtHostChatAgentsShape {
+	$invokeAgent(handle: number, requestId: number, prompt: string, context: { history: IChatMessage[] }, token: CancellationToken): Promise<any>;
 }
 
 export interface MainThreadChatVariablesShape extends IDisposable {
@@ -2605,6 +2616,7 @@ export const MainContext = {
 	MainThreadBulkEdits: createProxyIdentifier<MainThreadBulkEditsShape>('MainThreadBulkEdits'),
 	MainThreadChatProvider: createProxyIdentifier<MainThreadChatProviderShape>('MainThreadChatProvider'),
 	MainThreadChatSlashCommands: createProxyIdentifier<MainThreadChatSlashCommandsShape>('MainThreadChatSlashCommands'),
+	MainThreadChatAgents: createProxyIdentifier<MainThreadChatAgentsShape>('MainThreadChatAgents'),
 	MainThreadChatVariables: createProxyIdentifier<MainThreadChatVariablesShape>('MainThreadChatVariables'),
 	MainThreadClipboard: createProxyIdentifier<MainThreadClipboardShape>('MainThreadClipboard'),
 	MainThreadCommands: createProxyIdentifier<MainThreadCommandsShape>('MainThreadCommands'),
@@ -2725,6 +2737,7 @@ export const ExtHostContext = {
 	ExtHostInlineChat: createProxyIdentifier<ExtHostInlineChatShape>('ExtHostInlineChatShape'),
 	ExtHostChat: createProxyIdentifier<ExtHostChatShape>('ExtHostChat'),
 	ExtHostChatSlashCommands: createProxyIdentifier<ExtHostChatSlashCommandsShape>('ExtHostChatSlashCommands'),
+	ExtHostChatAgents: createProxyIdentifier<ExtHostChatAgentsShape>('ExtHostChatAgents'),
 	ExtHostChatVariables: createProxyIdentifier<ExtHostChatVariablesShape>('ExtHostChatVariables'),
 	ExtHostChatProvider: createProxyIdentifier<ExtHostChatProviderShape>('ExtHostChatProvider'),
 	ExtHostAiRelatedInformation: createProxyIdentifier<ExtHostAiRelatedInformationShape>('ExtHostAiRelatedInformation'),

--- a/src/vs/workbench/api/common/extHostChatAgents.ts
+++ b/src/vs/workbench/api/common/extHostChatAgents.ts
@@ -1,0 +1,91 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { DeferredPromise, raceCancellation } from 'vs/base/common/async';
+import { CancellationToken } from 'vs/base/common/cancellation';
+import { IDisposable, toDisposable } from 'vs/base/common/lifecycle';
+import { ExtensionIdentifier } from 'vs/platform/extensions/common/extensions';
+import { ILogService } from 'vs/platform/log/common/log';
+import { Progress } from 'vs/platform/progress/common/progress';
+import { ExtHostChatAgentsShape, IMainContext, MainContext, MainThreadChatAgentsShape } from 'vs/workbench/api/common/extHost.protocol';
+import { ExtHostChatProvider } from 'vs/workbench/api/common/extHostChatProvider';
+import * as typeConvert from 'vs/workbench/api/common/extHostTypeConverters';
+import { ChatMessageRole } from 'vs/workbench/api/common/extHostTypes';
+import { IChatMessage } from 'vs/workbench/contrib/chat/common/chatProvider';
+import type * as vscode from 'vscode';
+
+export class ExtHostChatAgents implements ExtHostChatAgentsShape {
+
+	private static _idPool = 0;
+
+	private readonly _agents = new Map<number, { extension: ExtensionIdentifier; agent: vscode.ChatAgent }>();
+	private readonly _proxy: MainThreadChatAgentsShape;
+
+	constructor(
+		mainContext: IMainContext,
+		private readonly _extHostChatProvider: ExtHostChatProvider,
+		private readonly _logService: ILogService,
+	) {
+		this._proxy = mainContext.getProxy(MainContext.MainThreadChatAgents);
+	}
+
+	registerAgent(extension: ExtensionIdentifier, name: string, agent: vscode.ChatAgent, metadata: vscode.ChatAgentMetadata): IDisposable {
+		const handle = ExtHostChatAgents._idPool++;
+		this._agents.set(handle, { extension, agent });
+		this._proxy.$registerAgent(handle, name, metadata);
+
+		return toDisposable(() => {
+			this._proxy.$unregisterAgent(handle);
+			this._agents.delete(handle);
+		});
+	}
+
+	async $invokeAgent(handle: number, requestId: number, prompt: string, context: { history: IChatMessage[] }, token: CancellationToken): Promise<any> {
+		const data = this._agents.get(handle);
+		if (!data) {
+			this._logService.warn(`[CHAT](${handle}) CANNOT invoke agent because the agent is not registered`);
+			return;
+		}
+
+		let done = false;
+		function throwIfDone() {
+			if (done) {
+				throw new Error('Only valid while executing the command');
+			}
+		}
+
+		const commandExecution = new DeferredPromise<void>();
+		token.onCancellationRequested(() => commandExecution.complete());
+		setTimeout(() => commandExecution.complete(), 3 * 1000);
+		this._extHostChatProvider.allowListExtensionWhile(data.extension, commandExecution.p);
+
+		const task = data.agent(
+			{ role: ChatMessageRole.User, content: prompt },
+			{ history: context.history.map(typeConvert.ChatMessage.to) },
+			new Progress<vscode.ChatAgentResponse>(p => {
+				throwIfDone();
+				this._proxy.$handleProgressChunk(requestId, { content: isInteractiveProgressFileTree(p.message) ? p.message : p.message.value });
+			}),
+			token
+		);
+
+		try {
+			return await raceCancellation(Promise.resolve(task).then((v) => {
+				if (v && 'followUp' in v) {
+					const convertedFollowup = v?.followUp?.map(f => typeConvert.ChatFollowup.from(f));
+					return { followUp: convertedFollowup };
+				}
+				return undefined;
+			}), token);
+		} finally {
+			done = true;
+			commandExecution.complete();
+		}
+	}
+}
+
+function isInteractiveProgressFileTree(thing: unknown): thing is vscode.InteractiveProgressFileTree {
+	return !!thing && typeof thing === 'object' && 'treeData' in thing;
+}

--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -54,6 +54,7 @@ import { ICommandService } from 'vs/platform/commands/common/commands';
 import { ChatVariablesService, IChatVariablesService } from 'vs/workbench/contrib/chat/common/chatVariables';
 import { registerChatFileTreeActions } from 'vs/workbench/contrib/chat/browser/actions/chatFileTreeActions';
 import { QuickChatService } from 'vs/workbench/contrib/chat/browser/chatQuick';
+import { ChatAgentService, IChatAgentService } from 'vs/workbench/contrib/chat/common/chatAgents';
 
 // Register configuration
 const configurationRegistry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration);
@@ -253,4 +254,5 @@ registerSingleton(IChatAccessibilityService, ChatAccessibilityService, Instantia
 registerSingleton(IChatWidgetHistoryService, ChatWidgetHistoryService, InstantiationType.Delayed);
 registerSingleton(IChatProviderService, ChatProviderService, InstantiationType.Delayed);
 registerSingleton(IChatSlashCommandService, ChatSlashCommandService, InstantiationType.Delayed);
+registerSingleton(IChatAgentService, ChatAgentService, InstantiationType.Delayed);
 registerSingleton(IChatVariablesService, ChatVariablesService, InstantiationType.Delayed);

--- a/src/vs/workbench/contrib/chat/browser/chatSlashCommandContentWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSlashCommandContentWidget.ts
@@ -48,7 +48,7 @@ export class SlashCommandContentWidget extends Disposable implements IContentWid
 	}
 
 	setCommandText(slashCommand: string) {
-		this._domNode.innerText = `/${slashCommand} `;
+		this._domNode.innerText = `@${slashCommand} `;
 		this._lastSlashCommandText = slashCommand;
 	}
 
@@ -63,7 +63,7 @@ export class SlashCommandContentWidget extends Disposable implements IContentWid
 
 		const firstLine = this._editor.getModel()?.getLineContent(1);
 		const selection = this._editor.getSelection();
-		const withSlash = `/${this._lastSlashCommandText} `;
+		const withSlash = `@${this._lastSlashCommandText} `;
 		if (!firstLine?.startsWith(withSlash) || !selection?.isEmpty() || selection?.startLineNumber !== 1 || selection?.startColumn !== withSlash.length + 1) {
 			return;
 		}

--- a/src/vs/workbench/contrib/chat/browser/chatSlashCommandContentWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatSlashCommandContentWidget.ts
@@ -48,7 +48,7 @@ export class SlashCommandContentWidget extends Disposable implements IContentWid
 	}
 
 	setCommandText(slashCommand: string) {
-		this._domNode.innerText = `@${slashCommand} `;
+		this._domNode.innerText = `/${slashCommand} `;
 		this._lastSlashCommandText = slashCommand;
 	}
 
@@ -63,7 +63,7 @@ export class SlashCommandContentWidget extends Disposable implements IContentWid
 
 		const firstLine = this._editor.getModel()?.getLineContent(1);
 		const selection = this._editor.getSelection();
-		const withSlash = `@${this._lastSlashCommandText} `;
+		const withSlash = `/${this._lastSlashCommandText} `;
 		if (!firstLine?.startsWith(withSlash) || !selection?.isEmpty() || selection?.startLineNumber !== 1 || selection?.startColumn !== withSlash.length + 1) {
 			return;
 		}

--- a/src/vs/workbench/contrib/chat/browser/contrib/chatInputEditorContrib.ts
+++ b/src/vs/workbench/contrib/chat/browser/contrib/chatInputEditorContrib.ts
@@ -38,7 +38,6 @@ const variableTextDecorationType = 'chat-variable-text';
 
 class InputEditorDecorations extends Disposable {
 
-	// private _slashCommandContentWidget: SlashCommandContentWidget | undefined;
 	private _previouslyUsedSlashCommands = new Set<string>();
 
 	constructor(

--- a/src/vs/workbench/contrib/chat/browser/contrib/chatInputEditorContrib.ts
+++ b/src/vs/workbench/contrib/chat/browser/contrib/chatInputEditorContrib.ts
@@ -444,7 +444,7 @@ class AgentCompletions extends Disposable {
 						return <CompletionItem>{
 							label: withSlash,
 							insertText: `@${a.id} ${withSlash} `,
-							detail: c.description,
+							detail: `(@${a.id}) ${c.description}`,
 							range: new Range(1, 1, 1, 1),
 							kind: CompletionItemKind.Text, // The icons are disabled here anyway
 						};

--- a/src/vs/workbench/contrib/chat/common/chatAgents.ts
+++ b/src/vs/workbench/contrib/chat/common/chatAgents.ts
@@ -8,6 +8,7 @@ import { Event, Emitter } from 'vs/base/common/event';
 import { Iterable } from 'vs/base/common/iterator';
 import { IJSONSchema } from 'vs/base/common/jsonSchema';
 import { Disposable, DisposableStore, IDisposable, combinedDisposable, toDisposable } from 'vs/base/common/lifecycle';
+import { URI } from 'vs/base/common/uri';
 import { localize } from 'vs/nls';
 import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
 import { IProgress } from 'vs/platform/progress/common/progress';
@@ -81,6 +82,8 @@ export interface IChatAgentMetadata {
 	subCommands: IChatAgentCommand[];
 	requireCommand?: boolean; // Do some agents not have a default action?
 	isImplicit?: boolean; // Only @workspace. slash commands get promoted to the top-level and this agent is invoked when those are used
+	fullName?: string;
+	icon?: URI;
 }
 
 export type IChatAgentCallback = { (prompt: string, progress: IProgress<IChatAgentFragment>, history: IChatMessage[], token: CancellationToken): Promise<{ followUp: IChatFollowup[] } | void> };

--- a/src/vs/workbench/contrib/chat/common/chatAgents.ts
+++ b/src/vs/workbench/contrib/chat/common/chatAgents.ts
@@ -1,0 +1,206 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { CancellationToken } from 'vs/base/common/cancellation';
+import { Event, Emitter } from 'vs/base/common/event';
+import { Iterable } from 'vs/base/common/iterator';
+import { IJSONSchema } from 'vs/base/common/jsonSchema';
+import { Disposable, DisposableStore, IDisposable, combinedDisposable, toDisposable } from 'vs/base/common/lifecycle';
+import { localize } from 'vs/nls';
+import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
+import { IProgress } from 'vs/platform/progress/common/progress';
+import { Registry } from 'vs/platform/registry/common/platform';
+import { IWorkbenchContribution, IWorkbenchContributionsRegistry, Extensions as WorkbenchExtensions } from 'vs/workbench/common/contributions';
+import { IChatMessage } from 'vs/workbench/contrib/chat/common/chatProvider';
+import { IChatFollowup, IChatResponseProgressFileTreeData } from 'vs/workbench/contrib/chat/common/chatService';
+import { IExtensionService, isProposedApiEnabled } from 'vs/workbench/services/extensions/common/extensions';
+import { ExtensionsRegistry } from 'vs/workbench/services/extensions/common/extensionsRegistry';
+import { LifecyclePhase } from 'vs/workbench/services/lifecycle/common/lifecycle';
+
+//#region extension point
+
+const agentItem: IJSONSchema = {
+	type: 'object',
+	required: ['agent', 'detail'],
+	properties: {
+		agent: {
+			type: 'string',
+			markdownDescription: localize('agent', "The name of the agent which will be used as prefix.")
+		},
+		detail: {
+			type: 'string',
+			markdownDescription: localize('details', "The details of the agent.")
+		},
+	}
+};
+
+const agentItems: IJSONSchema = {
+	description: localize('vscode.extension.contributes.slashes', "Contributes agents to chat"),
+	oneOf: [
+		agentItem,
+		{
+			type: 'array',
+			items: agentItem
+		}
+	]
+};
+
+export const agentsExtPoint = ExtensionsRegistry.registerExtensionPoint<IChatAgentData | IChatAgentData[]>({
+	extensionPoint: 'agents',
+	jsonSchema: agentItems
+});
+
+//#region agent service, commands etc
+
+export interface IChatAgentData {
+	id: string;
+	metadata: IChatAgentMetadata;
+}
+
+function isAgentData(data: any): data is IChatAgentData {
+	return typeof data === 'object' && data &&
+		typeof data.id === 'string' &&
+		typeof data.detail === 'string';
+	// (typeof data.sortText === 'undefined' || typeof data.sortText === 'string') &&
+	// (typeof data.executeImmediately === 'undefined' || typeof data.executeImmediately === 'boolean');
+}
+
+export interface IChatAgentFragment {
+	content: string | { treeData: IChatResponseProgressFileTreeData };
+}
+
+export interface IChatAgentCommand {
+	name: string;
+	description: string;
+}
+
+export interface IChatAgentMetadata {
+	description: string;
+	subCommands: IChatAgentCommand[];
+	requireCommand?: boolean; // Do some agents not have a default action?
+	isImplicit?: boolean; // Only @workspace. slash commands get promoted to the top-level and this agent is invoked when those are used
+}
+
+export type IChatAgentCallback = { (prompt: string, progress: IProgress<IChatAgentFragment>, history: IChatMessage[], token: CancellationToken): Promise<{ followUp: IChatFollowup[] } | void> };
+
+export const IChatAgentService = createDecorator<IChatAgentService>('chatAgentService');
+
+export interface IChatAgentService {
+	_serviceBrand: undefined;
+	readonly onDidChangeAgents: Event<void>;
+	registerAgentData(data: IChatAgentData): IDisposable;
+	registerAgentCallback(id: string, callback: IChatAgentCallback): IDisposable;
+	registerAgent(data: IChatAgentData, callback: IChatAgentCallback): IDisposable;
+	invokeAgent(id: string, prompt: string, progress: IProgress<IChatAgentFragment>, history: IChatMessage[], token: CancellationToken): Promise<{ followUp: IChatFollowup[] } | void>;
+	getAgents(): Array<IChatAgentData>;
+	hasAgent(id: string): boolean;
+}
+
+type Tuple = { data: IChatAgentData; callback?: IChatAgentCallback };
+
+export class ChatAgentService extends Disposable implements IChatAgentService {
+
+	public static readonly AGENT_LEADER = '@';
+
+	declare _serviceBrand: undefined;
+
+	private readonly _agents = new Map<string, Tuple>();
+
+	private readonly _onDidChangeAgents = this._register(new Emitter<void>());
+	readonly onDidChangeAgents: Event<void> = this._onDidChangeAgents.event;
+
+	constructor(@IExtensionService private readonly _extensionService: IExtensionService) {
+		super();
+	}
+
+	override dispose(): void {
+		super.dispose();
+		this._agents.clear();
+	}
+
+	registerAgentData(data: IChatAgentData): IDisposable {
+		if (this._agents.has(data.id)) {
+			throw new Error(`Already registered an agent with id ${data.id}}`);
+		}
+		this._agents.set(data.id, { data });
+		this._onDidChangeAgents.fire();
+
+		return toDisposable(() => {
+			if (this._agents.delete(data.id)) {
+				this._onDidChangeAgents.fire();
+			}
+		});
+	}
+
+	registerAgentCallback(id: string, agentCallback: IChatAgentCallback): IDisposable {
+		const data = this._agents.get(id);
+		if (!data) {
+			throw new Error(`No agent with id ${id} registered`);
+		}
+		data.callback = agentCallback;
+		return toDisposable(() => data.callback = undefined);
+	}
+
+	registerAgent(data: IChatAgentData, callback: IChatAgentCallback): IDisposable {
+		return combinedDisposable(
+			this.registerAgentData(data),
+			this.registerAgentCallback(data.id, callback)
+		);
+	}
+
+	getAgents(): Array<IChatAgentData> {
+		return Array.from(this._agents.values(), v => v.data);
+	}
+
+	hasAgent(id: string): boolean {
+		return this._agents.has(id);
+	}
+
+	async invokeAgent(id: string, prompt: string, progress: IProgress<IChatAgentFragment>, history: IChatMessage[], token: CancellationToken): Promise<{ followUp: IChatFollowup[] } | void> {
+		const data = this._agents.get(id);
+		if (!data) {
+			throw new Error('No agent with id ${id} NOT registered');
+		}
+		if (!data.callback) {
+			await this._extensionService.activateByEvent(`onChatAgent:${id}`);
+		}
+		if (!data.callback) {
+			throw new Error(`No agent with id ${id} NOT resolved`);
+		}
+
+		return await data.callback(prompt, progress, history, token);
+	}
+}
+
+class ChatAgentContribution implements IWorkbenchContribution {
+	constructor(@IChatAgentService chatAgentService: IChatAgentService) {
+		const contributions = new DisposableStore();
+
+		agentsExtPoint.setHandler(extensions => {
+			contributions.clear();
+
+			for (const entry of extensions) {
+				if (!isProposedApiEnabled(entry.description, 'chatAgents')) {
+					entry.collector.error(`The ${agentsExtPoint.name} is proposed API`);
+					continue;
+				}
+
+				const { value } = entry;
+
+				for (const candidate of Iterable.wrap(value)) {
+
+					if (!isAgentData(candidate)) {
+						entry.collector.error(localize('invalid', "Invalid {0}: {1}", agentsExtPoint.name, JSON.stringify(candidate)));
+						continue;
+					}
+
+					contributions.add(chatAgentService.registerAgentData({ ...candidate }));
+				}
+			}
+		});
+	}
+}
+
+Registry.as<IWorkbenchContributionsRegistry>(WorkbenchExtensions.Workbench).registerWorkbenchContribution(ChatAgentContribution, LifecyclePhase.Restored);

--- a/src/vs/workbench/contrib/chat/common/chatModel.ts
+++ b/src/vs/workbench/contrib/chat/common/chatModel.ts
@@ -10,6 +10,7 @@ import { Disposable } from 'vs/base/common/lifecycle';
 import { URI, UriComponents } from 'vs/base/common/uri';
 import { generateUuid } from 'vs/base/common/uuid';
 import { ILogService } from 'vs/platform/log/common/log';
+import { IChatAgentData, IChatAgentService } from 'vs/workbench/contrib/chat/common/chatAgents';
 import { IChat, IChatFollowup, IChatProgress, IChatReplyFollowup, IChatResponse, IChatResponseErrorDetails, IChatResponseProgressFileTreeData, InteractiveSessionVoteDirection } from 'vs/workbench/contrib/chat/common/chatService';
 
 export interface IChatRequestModel {
@@ -232,16 +233,17 @@ export class ChatResponseModel extends Disposable implements IChatResponseModel 
 	}
 
 	public get username(): string {
-		return this.session.responderUsername;
+		return this.agent?.metadata.fullName ?? this.session.responderUsername;
 	}
 
 	public get avatarIconUri(): URI | undefined {
-		return this.session.responderAvatarIconUri;
+		return this.agent?.metadata.icon ?? this.session.responderAvatarIconUri;
 	}
 
 	constructor(
 		_response: IMarkdownString | (IMarkdownString | IChatResponseProgressFileTreeData)[],
 		public readonly session: ChatModel,
+		public readonly agent: IChatAgentData | undefined,
 		private _isComplete: boolean = false,
 		private _isCanceled = false,
 		private _vote?: InteractiveSessionVoteDirection,
@@ -309,10 +311,18 @@ export interface ISerializableChatsData {
 	[sessionId: string]: ISerializableChatData;
 }
 
+export interface ISerializableChatAgentData {
+	id: string;
+	description: string;
+	fullName?: string;
+	icon?: UriComponents;
+}
+
 export interface ISerializableChatRequestData {
 	providerRequestId: string | undefined;
 	message: string;
 	response: (IMarkdownString | IChatResponseProgressFileTreeData)[] | undefined;
+	agent?: ISerializableChatAgentData;
 	responseErrorDetails: IChatResponseErrorDetails | undefined;
 	followups: IChatFollowup[] | undefined;
 	isCanceled: boolean | undefined;
@@ -455,7 +465,8 @@ export class ChatModel extends Disposable implements IChatModel {
 	constructor(
 		public readonly providerId: string,
 		private readonly initialData: ISerializableChatData | IExportableChatData | undefined,
-		@ILogService private readonly logService: ILogService
+		@ILogService private readonly logService: ILogService,
+		@IChatAgentService private readonly chatAgentService: IChatAgentService,
 	) {
 		super();
 
@@ -484,7 +495,8 @@ export class ChatModel extends Disposable implements IChatModel {
 		return requests.map((raw: ISerializableChatRequestData) => {
 			const request = new ChatRequestModel(this, raw.message, raw.providerRequestId);
 			if (raw.response || raw.responseErrorDetails) {
-				request.response = new ChatResponseModel(raw.response ?? [new MarkdownString(raw.response)], this, true, raw.isCanceled, raw.vote, raw.providerRequestId, raw.responseErrorDetails, raw.followups);
+				const agent = raw.agent && this.chatAgentService.getAgents().find(a => a.id === raw.agent!.id); // TODO do something reasonable if this agent has disappeared since the last session
+				request.response = new ChatResponseModel(raw.response ?? [new MarkdownString(raw.response)], this, agent, true, raw.isCanceled, raw.vote, raw.providerRequestId, raw.responseErrorDetails, raw.followups);
 			}
 			return request;
 		});
@@ -531,13 +543,13 @@ export class ChatModel extends Disposable implements IChatModel {
 		return this._requests;
 	}
 
-	addRequest(message: string | IChatReplyFollowup): ChatRequestModel {
+	addRequest(message: string | IChatReplyFollowup, chatAgent: IChatAgentData | undefined): ChatRequestModel {
 		if (!this._session) {
 			throw new Error('addRequest: No session');
 		}
 
 		const request = new ChatRequestModel(this, message);
-		request.response = new ChatResponseModel(new MarkdownString(''), this);
+		request.response = new ChatResponseModel(new MarkdownString(''), this, chatAgent);
 
 		this._requests.push(request);
 		this._onDidChange.fire({ kind: 'addRequest', request });
@@ -550,7 +562,7 @@ export class ChatModel extends Disposable implements IChatModel {
 		}
 
 		if (!request.response) {
-			request.response = new ChatResponseModel(new MarkdownString(''), this);
+			request.response = new ChatResponseModel(new MarkdownString(''), this, undefined);
 		}
 
 		if (request.response.isComplete) {
@@ -593,7 +605,7 @@ export class ChatModel extends Disposable implements IChatModel {
 		}
 
 		if (!request.response) {
-			request.response = new ChatResponseModel(new MarkdownString(''), this);
+			request.response = new ChatResponseModel(new MarkdownString(''), this, undefined);
 		}
 
 		request.response.setErrorDetails(rawResponse.errorDetails);
@@ -642,7 +654,13 @@ export class ChatModel extends Disposable implements IChatModel {
 					responseErrorDetails: r.response?.errorDetails,
 					followups: r.response?.followups,
 					isCanceled: r.response?.isCanceled,
-					vote: r.response?.vote
+					vote: r.response?.vote,
+					agent: r.response?.agent ? {
+						id: r.response.agent.id,
+						description: r.response.agent.metadata.description,
+						fullName: r.response.agent.metadata.fullName,
+						icon: r.response.agent.metadata.icon
+					} : undefined,
 				};
 			}),
 			providerId: this.providerId,

--- a/src/vs/workbench/contrib/chat/common/chatModel.ts
+++ b/src/vs/workbench/contrib/chat/common/chatModel.ts
@@ -543,7 +543,7 @@ export class ChatModel extends Disposable implements IChatModel {
 		return this._requests;
 	}
 
-	addRequest(message: string | IChatReplyFollowup, chatAgent: IChatAgentData | undefined): ChatRequestModel {
+	addRequest(message: string | IChatReplyFollowup, chatAgent?: IChatAgentData): ChatRequestModel {
 		if (!this._session) {
 			throw new Error('addRequest: No session');
 		}

--- a/src/vs/workbench/contrib/chat/common/chatServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/chatServiceImpl.ts
@@ -21,6 +21,7 @@ import { Progress } from 'vs/platform/progress/common/progress';
 import { IStorageService, StorageScope, StorageTarget } from 'vs/platform/storage/common/storage';
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 import { IWorkspaceContextService } from 'vs/platform/workspace/common/workspace';
+import { IChatAgentService } from 'vs/workbench/contrib/chat/common/chatAgents';
 import { CONTEXT_PROVIDER_EXISTS } from 'vs/workbench/contrib/chat/common/chatContextKeys';
 import { ChatModel, ChatWelcomeMessageModel, IChatModel, ISerializableChatData, ISerializableChatsData, isCompleteInteractiveProgressTreeData } from 'vs/workbench/contrib/chat/common/chatModel';
 import { ChatMessageRole, IChatMessage } from 'vs/workbench/contrib/chat/common/chatProvider';
@@ -152,7 +153,8 @@ export class ChatService extends Disposable implements IChatService {
 		@IContextKeyService private readonly contextKeyService: IContextKeyService,
 		@IWorkspaceContextService private readonly workspaceContextService: IWorkspaceContextService,
 		@IChatSlashCommandService private readonly chatSlashCommandService: IChatSlashCommandService,
-		@IChatVariablesService private readonly chatVariablesService: IChatVariablesService
+		@IChatVariablesService private readonly chatVariablesService: IChatVariablesService,
+		@IChatAgentService private readonly chatAgentService: IChatAgentService
 	) {
 		super();
 
@@ -437,6 +439,8 @@ export class ChatService extends Disposable implements IChatService {
 
 		const resolvedCommand = typeof message === 'string' && message.startsWith('/') ? await this.handleSlashCommand(model.sessionId, message) : message;
 
+		const resolvedAgent = typeof message === 'string' ? this.resolveAgent(message) : undefined;
+
 		let gotProgress = false;
 		const requestType = typeof message === 'string' ?
 			(message.startsWith('/') ? 'slashCommand' : 'string') :
@@ -487,7 +491,25 @@ export class ChatService extends Disposable implements IChatService {
 				let rawResponse: IChatResponse | null | undefined;
 				let slashCommandFollowups: IChatFollowup[] | void = [];
 
-				if ((typeof resolvedCommand === 'string' && typeof message === 'string' && this.chatSlashCommandService.hasCommand(resolvedCommand))) {
+				if (typeof message === 'string' && resolvedAgent) {
+					const history: IChatMessage[] = [];
+					for (const request of model.getRequests()) {
+						if (typeof request.message !== 'string' || !request.response) {
+							continue;
+						}
+						if (isMarkdownString(request.response.response.value)) {
+							history.push({ role: ChatMessageRole.User, content: request.message });
+							history.push({ role: ChatMessageRole.Assistant, content: request.response.response.value.value });
+						}
+					}
+					const agentResult = await this.chatAgentService.invokeAgent(resolvedAgent, message.substring(resolvedAgent.length + 1).trimStart(), new Progress<IChatSlashFragment>(p => {
+						const { content } = p;
+						const data = isCompleteInteractiveProgressTreeData(content) ? content : { content };
+						progressCallback(data);
+					}), history, token);
+					slashCommandFollowups = agentResult?.followUp;
+					rawResponse = { session: model.session! };
+				} else if ((typeof resolvedCommand === 'string' && typeof message === 'string' && this.chatSlashCommandService.hasCommand(resolvedCommand))) {
 					// contributed slash commands
 					// TODO: spell this out in the UI
 					const history: IChatMessage[] = [];
@@ -596,6 +618,16 @@ export class ChatService extends Disposable implements IChatService {
 			}
 		}
 		return command;
+	}
+
+	private resolveAgent(prompt: string): string | undefined {
+		prompt = prompt.trim();
+		const agents = this.chatAgentService.getAgents();
+		if (!prompt.startsWith('@')) {
+			return;
+		}
+
+		return agents.find(a => prompt.match(new RegExp(`@${a.id}($|\\s)`)))?.id;
 	}
 
 	async getSlashCommands(sessionId: string, token: CancellationToken): Promise<ISlashCommand[] | undefined> {

--- a/src/vs/workbench/contrib/chat/common/chatViewModel.ts
+++ b/src/vs/workbench/contrib/chat/common/chatViewModel.ts
@@ -10,8 +10,8 @@ import { URI } from 'vs/base/common/uri';
 import { localize } from 'vs/nls';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { ILogService } from 'vs/platform/log/common/log';
-import { IChatRequestModel, IChatResponseModel, IChatModel, IChatWelcomeMessageContent, IResponse, Response } from 'vs/workbench/contrib/chat/common/chatModel';
-import { IChatResponseErrorDetails, IChatReplyFollowup, IChatResponseCommandFollowup, InteractiveSessionVoteDirection, IChatResponseProgressFileTreeData } from 'vs/workbench/contrib/chat/common/chatService';
+import { IChatModel, IChatRequestModel, IChatResponseModel, IChatWelcomeMessageContent, IResponse, Response } from 'vs/workbench/contrib/chat/common/chatModel';
+import { IChatReplyFollowup, IChatResponseCommandFollowup, IChatResponseErrorDetails, IChatResponseProgressFileTreeData, InteractiveSessionVoteDirection } from 'vs/workbench/contrib/chat/common/chatService';
 import { countWords } from 'vs/workbench/contrib/chat/common/chatWordCounter';
 
 export function isRequestVM(item: unknown): item is IChatRequestViewModel {

--- a/src/vs/workbench/contrib/chat/test/common/chatModel.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/chatModel.test.ts
@@ -24,7 +24,7 @@ suite('ChatModel', () => {
 		instantiationService.stub(IStorageService, testDisposables.add(new TestStorageService()));
 		instantiationService.stub(ILogService, new NullLogService());
 		instantiationService.stub(IExtensionService, new TestExtensionService());
-		instantiationService.stub(IChatAgentService, instantiationService.createInstance(ChatAgentService));
+		instantiationService.stub(IChatAgentService, testDisposables.add(instantiationService.createInstance(ChatAgentService)));
 	});
 
 	test('Waits for initialization', async () => {

--- a/src/vs/workbench/contrib/chat/test/common/chatModel.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/chatModel.test.ts
@@ -9,6 +9,7 @@ import { ensureNoDisposablesAreLeakedInTestSuite } from 'vs/base/test/common/uti
 import { TestInstantiationService } from 'vs/platform/instantiation/test/common/instantiationServiceMock';
 import { ILogService, NullLogService } from 'vs/platform/log/common/log';
 import { IStorageService } from 'vs/platform/storage/common/storage';
+import { ChatAgentService, IChatAgentService } from 'vs/workbench/contrib/chat/common/chatAgents';
 import { ChatModel } from 'vs/workbench/contrib/chat/common/chatModel';
 import { IExtensionService } from 'vs/workbench/services/extensions/common/extensions';
 import { TestExtensionService, TestStorageService } from 'vs/workbench/test/common/workbenchTestServices';
@@ -23,10 +24,11 @@ suite('ChatModel', () => {
 		instantiationService.stub(IStorageService, testDisposables.add(new TestStorageService()));
 		instantiationService.stub(ILogService, new NullLogService());
 		instantiationService.stub(IExtensionService, new TestExtensionService());
+		instantiationService.stub(IChatAgentService, instantiationService.createInstance(ChatAgentService));
 	});
 
 	test('Waits for initialization', async () => {
-		const model = testDisposables.add(new ChatModel('provider', undefined, new NullLogService()));
+		const model = testDisposables.add(instantiationService.createInstance(ChatModel, 'provider', undefined));
 
 		let hasInitialized = false;
 		model.waitForInitialization().then(() => {
@@ -42,7 +44,7 @@ suite('ChatModel', () => {
 	});
 
 	test('Initialization fails when model is disposed', async () => {
-		const model = testDisposables.add(new ChatModel('provider', undefined, new NullLogService()));
+		const model = testDisposables.add(instantiationService.createInstance(ChatModel, 'provider', undefined));
 		model.dispose();
 
 		await assert.rejects(() => model.waitForInitialization());

--- a/src/vs/workbench/contrib/chat/test/common/chatService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/chatService.test.ts
@@ -20,6 +20,7 @@ import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 import { NullTelemetryService } from 'vs/platform/telemetry/common/telemetryUtils';
 import { IWorkspaceContextService } from 'vs/platform/workspace/common/workspace';
 import { IViewsService } from 'vs/workbench/common/views';
+import { ChatAgentService, IChatAgentService } from 'vs/workbench/contrib/chat/common/chatAgents';
 import { IChatContributionService } from 'vs/workbench/contrib/chat/common/chatContributionService';
 import { IChat, IChatProgress, IChatProvider, IChatRequest, IChatResponse, IPersistedChatState, ISlashCommand } from 'vs/workbench/contrib/chat/common/chatService';
 import { ChatService } from 'vs/workbench/contrib/chat/common/chatServiceImpl';
@@ -81,6 +82,7 @@ suite('Chat', () => {
 		instantiationService.stub(IChatContributionService, new TestExtensionService());
 		instantiationService.stub(IWorkspaceContextService, new TestContextService());
 		instantiationService.stub(IChatSlashCommandService, testDisposables.add(instantiationService.createInstance(ChatSlashCommandService)));
+		instantiationService.stub(IChatAgentService, testDisposables.add(instantiationService.createInstance(ChatAgentService)));
 	});
 
 	test('retrieveSession', async () => {

--- a/src/vs/workbench/services/extensions/common/extensionsApiProposals.ts
+++ b/src/vs/workbench/services/extensions/common/extensionsApiProposals.ts
@@ -11,6 +11,7 @@ export const allApiProposals = Object.freeze({
 	authSession: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.authSession.d.ts',
 	canonicalUriProvider: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.canonicalUriProvider.d.ts',
 	chat: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.chat.d.ts',
+	chatAgents: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.chatAgents.d.ts',
 	chatProvider: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.chatProvider.d.ts',
 	chatRequestAccess: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.chatRequestAccess.d.ts',
 	chatSlashCommands: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.chatSlashCommands.d.ts',

--- a/src/vscode-dts/vscode.proposed.chatAgents.d.ts
+++ b/src/vscode-dts/vscode.proposed.chatAgents.d.ts
@@ -24,6 +24,8 @@ declare module 'vscode' {
 
 	export interface ChatAgentMetadata {
 		description: string;
+		fullName?: string;
+		icon?: Uri;
 		subCommands: ChatAgentCommand[];
 		requireCommand?: boolean; // Do some agents not have a default action?
 		isImplicit?: boolean; // Only @workspace. slash commands get promoted to the top-level and this agent is invoked when those are used
@@ -34,6 +36,6 @@ declare module 'vscode' {
 	}
 
 	export namespace chat {
-		export function registerAgent(name: string, agent: ChatAgent, metadata: ChatAgentMetadata): Disposable;
+		export function registerAgent(id: string, agent: ChatAgent, metadata: ChatAgentMetadata): Disposable;
 	}
 }

--- a/src/vscode-dts/vscode.proposed.chatAgents.d.ts
+++ b/src/vscode-dts/vscode.proposed.chatAgents.d.ts
@@ -1,0 +1,39 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+declare module 'vscode' {
+
+	export interface ChatAgentContext {
+		history: ChatMessage[];
+	}
+
+	export interface ChatAgentResponse {
+		message: MarkdownString | InteractiveProgressFileTree;
+	}
+
+	export interface ChatAgentResult {
+		followUp?: InteractiveSessionFollowup[];
+	}
+
+	export interface ChatAgentCommand {
+		name: string;
+		description: string;
+	}
+
+	export interface ChatAgentMetadata {
+		description: string;
+		subCommands: ChatAgentCommand[];
+		requireCommand?: boolean; // Do some agents not have a default action?
+		isImplicit?: boolean; // Only @workspace. slash commands get promoted to the top-level and this agent is invoked when those are used
+	}
+
+	export interface ChatAgent {
+		(prompt: ChatMessage, context: ChatAgentContext, progress: Progress<ChatAgentResponse>, token: CancellationToken): Thenable<ChatAgentResult | void>;
+	}
+
+	export namespace chat {
+		export function registerAgent(name: string, agent: ChatAgent, metadata: ChatAgentMetadata): Disposable;
+	}
+}


### PR DESCRIPTION
I basically copy/pasted @jrieken's chat slash command API and modified it to work for agents. This is leaving all the existing stuff in place so we can adopt this incrementally.

It's all a bit complicated right now, we have slash commands from two different sources, variables that still use `@` (this will change), and now agents using `@` and agent subcommands using `/`. I imagine that both slash command APIs will go away in favor of this one.

This API can drive remote agents and it can also drive the local agents that will absorb our existing slash commands.