### PR TITLE
Mark most DisposableStore properties readonly

### DIFF
--- a/src/vs/base/browser/ui/grid/gridview.ts
+++ b/src/vs/base/browser/ui/grid/gridview.ts
@@ -778,7 +778,7 @@ class LeafNode implements ISplitView<ILayoutContext>, IDisposable {
 	private _onDidViewChange: Event<number | undefined>;
 	readonly onDidChange: Event<number | undefined>;
 
-	private disposables = new DisposableStore();
+	private readonly disposables = new DisposableStore();
 
 	constructor(
 		readonly view: IView,

--- a/src/vs/base/browser/ui/sash/sash.ts
+++ b/src/vs/base/browser/ui/sash/sash.ts
@@ -173,7 +173,7 @@ interface IPointerEventFactory {
 
 class MouseEventFactory implements IPointerEventFactory {
 
-	private disposables = new DisposableStore();
+	private readonly disposables = new DisposableStore();
 
 	@memoize
 	get onPointerMove(): Event<PointerEvent> {
@@ -192,7 +192,7 @@ class MouseEventFactory implements IPointerEventFactory {
 
 class GestureEventFactory implements IPointerEventFactory {
 
-	private disposables = new DisposableStore();
+	private readonly disposables = new DisposableStore();
 
 	@memoize
 	get onPointerMove(): Event<PointerEvent> {

--- a/src/vs/base/browser/ui/tree/abstractTree.ts
+++ b/src/vs/base/browser/ui/tree/abstractTree.ts
@@ -1027,7 +1027,7 @@ class FindController<T, TFilterData> implements IDisposable {
 	private readonly _onDidChangeOpenState = new Emitter<boolean>();
 	readonly onDidChangeOpenState = this._onDidChangeOpenState.event;
 
-	private enabledDisposables = new DisposableStore();
+	private readonly enabledDisposables = new DisposableStore();
 	private readonly disposables = new DisposableStore();
 
 	constructor(
@@ -1085,8 +1085,7 @@ class FindController<T, TFilterData> implements IDisposable {
 		this._history = this.widget.getHistory();
 		this.widget = undefined;
 
-		this.enabledDisposables.dispose();
-		this.enabledDisposables = new DisposableStore();
+		this.enabledDisposables.clear();
 
 		this.previousPattern = this.pattern;
 		this.onDidChangeValue('');

--- a/src/vs/base/parts/ipc/common/ipc.ts
+++ b/src/vs/base/parts/ipc/common/ipc.ts
@@ -798,7 +798,7 @@ export class IPCServer<TContext = string> implements IChannelServer<TContext>, I
 	private readonly _onDidRemoveConnection = new Emitter<Connection<TContext>>();
 	readonly onDidRemoveConnection: Event<Connection<TContext>> = this._onDidRemoveConnection.event;
 
-	private disposables = new DisposableStore();
+	private readonly disposables = new DisposableStore();
 
 	get connections(): Connection<TContext>[] {
 		const result: Connection<TContext>[] = [];

--- a/src/vs/base/parts/ipc/test/common/ipc.test.ts
+++ b/src/vs/base/parts/ipc/test/common/ipc.test.ts
@@ -113,7 +113,7 @@ interface ITestService {
 
 class TestService implements ITestService {
 
-	private disposables = new DisposableStore();
+	private readonly disposables = new DisposableStore();
 
 	private readonly _onPong = new Emitter<string>();
 	readonly onPong = this._onPong.event;

--- a/src/vs/editor/contrib/codelens/browser/codelensController.ts
+++ b/src/vs/editor/contrib/codelens/browser/codelensController.ts
@@ -39,7 +39,7 @@ export class CodeLensContribution implements IEditorContribution {
 	private readonly _resolveCodeLensesScheduler: RunOnceScheduler;
 
 	private _getCodeLensModelPromise: CancelablePromise<CodeLensModel> | undefined;
-	private _oldCodeLensModels = new DisposableStore();
+	private readonly _oldCodeLensModels = new DisposableStore();
 	private _currentCodeLensModel: CodeLensModel | undefined;
 	private _resolveCodeLensesPromise: CancelablePromise<any> | undefined;
 

--- a/src/vs/editor/contrib/snippet/browser/snippetController2.ts
+++ b/src/vs/editor/contrib/snippet/browser/snippetController2.ts
@@ -62,7 +62,7 @@ export class SnippetController2 implements IEditorContribution {
 	private readonly _hasPrevTabstop: IContextKey<boolean>;
 
 	private _session?: SnippetSession;
-	private _snippetListener = new DisposableStore();
+	private readonly _snippetListener = new DisposableStore();
 	private _modelVersionId: number = -1;
 	private _currentChoice?: Choice;
 

--- a/src/vs/platform/list/browser/listService.ts
+++ b/src/vs/platform/list/browser/listService.ts
@@ -54,7 +54,7 @@ export class ListService implements IListService {
 
 	declare readonly _serviceBrand: undefined;
 
-	private disposables = new DisposableStore();
+	private readonly disposables = new DisposableStore();
 	private lists: IRegisteredList[] = [];
 	private _lastFocusedWidget: WorkbenchListWidget | undefined = undefined;
 	private _hasCreatedStyleController: boolean = false;

--- a/src/vs/workbench/api/common/extHostCodeInsets.ts
+++ b/src/vs/workbench/api/common/extHostCodeInsets.ts
@@ -15,7 +15,7 @@ import { ExtHostEditorInsetsShape, MainThreadEditorInsetsShape } from './extHost
 export class ExtHostEditorInsets implements ExtHostEditorInsetsShape {
 
 	private _handlePool = 0;
-	private _disposables = new DisposableStore();
+	private readonly _disposables = new DisposableStore();
 	private _insets = new Map<number, { editor: vscode.TextEditor; inset: vscode.WebviewEditorInset; onDidReceiveMessage: Emitter<any> }>();
 
 	constructor(

--- a/src/vs/workbench/api/node/extHostSearch.ts
+++ b/src/vs/workbench/api/node/extHostSearch.ts
@@ -29,7 +29,7 @@ export class NativeExtHostSearch extends ExtHostSearch implements IDisposable {
 
 	private _registeredEHSearchProvider = false;
 
-	private _disposables = new DisposableStore();
+	private readonly _disposables = new DisposableStore();
 
 	constructor(
 		@IExtHostRpcService extHostRpc: IExtHostRpcService,

--- a/src/vs/workbench/browser/parts/views/viewPane.ts
+++ b/src/vs/workbench/browser/parts/views/viewPane.ts
@@ -105,7 +105,7 @@ class ViewWelcomeController {
 		return visibleItems.map(v => v.descriptor);
 	}
 
-	private disposables = new DisposableStore();
+	private readonly disposables = new DisposableStore();
 
 	constructor(
 		private id: string,

--- a/src/vs/workbench/contrib/codeEditor/browser/outline/documentSymbolsOutline.ts
+++ b/src/vs/workbench/contrib/codeEditor/browser/outline/documentSymbolsOutline.ts
@@ -112,7 +112,7 @@ class DocumentSymbolsOutline implements IOutline<DocumentSymbolItem> {
 	readonly onDidChange: Event<OutlineChangeEvent> = this._onDidChange.event;
 
 	private _outlineModel?: OutlineModel;
-	private _outlineDisposables = new DisposableStore();
+	private readonly _outlineDisposables = new DisposableStore();
 
 	private readonly _breadcrumbsDataSource: DocumentSymbolBreadcrumbsSource;
 

--- a/src/vs/workbench/contrib/debug/browser/debugService.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugService.ts
@@ -70,7 +70,7 @@ export class DebugService implements IDebugService {
 	private taskRunner: DebugTaskRunner;
 	private configurationManager: ConfigurationManager;
 	private adapterManager: AdapterManager;
-	private disposables = new DisposableStore();
+	private readonly disposables = new DisposableStore();
 	private debugType!: IContextKey<string>;
 	private debugState!: IContextKey<string>;
 	private inDebugMode!: IContextKey<boolean>;

--- a/src/vs/workbench/contrib/debug/browser/debugSession.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugSession.ts
@@ -52,7 +52,7 @@ export class DebugSession implements IDebugSession, IDisposable {
 	private threads = new Map<number, Thread>();
 	private threadIds: number[] = [];
 	private cancellationMap = new Map<number, CancellationTokenSource[]>();
-	private rawListeners = new DisposableStore();
+	private readonly rawListeners = new DisposableStore();
 	private fetchThreadsScheduler: RunOnceScheduler | undefined;
 	private passFocusScheduler: RunOnceScheduler;
 	private lastContinuedThreadId: number | undefined;

--- a/src/vs/workbench/contrib/inlayHints/browser/inlayHintsAccessibilty.ts
+++ b/src/vs/workbench/contrib/inlayHints/browser/inlayHintsAccessibilty.ts
@@ -35,7 +35,7 @@ export class InlayHintsAccessibility implements IEditorContribution {
 	private readonly _ariaElement: HTMLSpanElement;
 	private readonly _ctxIsReading: IContextKey<boolean>;
 
-	private _sessionDispoosables = new DisposableStore();
+	private readonly _sessionDispoosables = new DisposableStore();
 
 	constructor(
 		private readonly _editor: ICodeEditor,

--- a/src/vs/workbench/contrib/languageDetection/browser/languageDetection.contribution.ts
+++ b/src/vs/workbench/contrib/languageDetection/browser/languageDetection.contribution.ts
@@ -35,7 +35,7 @@ class LanguageDetectionStatusContribution implements IWorkbenchContribution {
 	private readonly _disposables = new DisposableStore();
 	private _combinedEntry?: IStatusbarEntryAccessor;
 	private _delayer = new ThrottledDelayer(1000);
-	private _renderDisposables = new DisposableStore();
+	private readonly _renderDisposables = new DisposableStore();
 
 	constructor(
 		@ILanguageDetectionService private readonly _languageDetectionService: ILanguageDetectionService,

--- a/src/vs/workbench/contrib/languageStatus/browser/languageStatus.contribution.ts
+++ b/src/vs/workbench/contrib/languageStatus/browser/languageStatus.contribution.ts
@@ -72,7 +72,7 @@ class EditorStatusContribution implements IWorkbenchContribution {
 	private _model?: LanguageStatusViewModel;
 	private _combinedEntry?: IStatusbarEntryAccessor;
 	private _dedicatedEntries = new Map<string, IStatusbarEntryAccessor>();
-	private _renderDisposables = new DisposableStore();
+	private readonly _renderDisposables = new DisposableStore();
 
 	constructor(
 		@ILanguageStatusService private readonly _languageStatusService: ILanguageStatusService,

--- a/src/vs/workbench/contrib/notebook/browser/contrib/outline/notebookOutline.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/outline/notebookOutline.ts
@@ -211,7 +211,7 @@ export class NotebookCellOutline implements IOutline<OutlineEntry> {
 	}
 
 	private _outlineProvider: NotebookCellOutlineProvider | undefined;
-	private _localDisposables = new DisposableStore();
+	private readonly _localDisposables = new DisposableStore();
 
 	constructor(
 		private readonly _editor: INotebookEditorPane,

--- a/src/vs/workbench/contrib/scm/browser/activity.ts
+++ b/src/vs/workbench/contrib/scm/browser/activity.ts
@@ -33,7 +33,7 @@ export class SCMStatusController implements IWorkbenchContribution {
 	private focusDisposable: IDisposable = Disposable.None;
 	private focusedRepository: ISCMRepository | undefined = undefined;
 	private readonly badgeDisposable = new MutableDisposable<IDisposable>();
-	private disposables = new DisposableStore();
+	private readonly disposables = new DisposableStore();
 	private repositoryDisposables = new Set<IDisposable>();
 
 	constructor(
@@ -207,7 +207,7 @@ export class SCMStatusController implements IWorkbenchContribution {
 		this.focusDisposable.dispose();
 		this.statusBarDisposable.dispose();
 		this.badgeDisposable.dispose();
-		this.disposables = dispose(this.disposables);
+		this.disposables.dispose();
 		dispose(this.repositoryDisposables.values());
 		this.repositoryDisposables.clear();
 	}
@@ -217,7 +217,7 @@ export class SCMActiveResourceContextKeyController implements IWorkbenchContribu
 
 	private activeResourceHasChangesContextKey: IContextKey<boolean>;
 	private activeResourceRepositoryContextKey: IContextKey<string | undefined>;
-	private disposables = new DisposableStore();
+	private readonly disposables = new DisposableStore();
 	private repositoryDisposables = new Set<IDisposable>();
 
 	constructor(
@@ -281,7 +281,7 @@ export class SCMActiveResourceContextKeyController implements IWorkbenchContribu
 	}
 
 	dispose(): void {
-		this.disposables = dispose(this.disposables);
+		this.disposables.dispose();
 		dispose(this.repositoryDisposables.values());
 		this.repositoryDisposables.clear();
 	}

--- a/src/vs/workbench/contrib/scm/browser/dirtydiffDecorator.ts
+++ b/src/vs/workbench/contrib/scm/browser/dirtydiffDecorator.ts
@@ -714,7 +714,7 @@ export class DirtyDiffController extends Disposable implements DirtyDiffContribu
 	private session: IDisposable = Disposable.None;
 	private mouseDownInfo: { lineNumber: number } | null = null;
 	private enabled = false;
-	private gutterActionDisposables = new DisposableStore();
+	private readonly gutterActionDisposables = new DisposableStore();
 	private stylesheet: HTMLStyleElement;
 
 	constructor(
@@ -741,8 +741,7 @@ export class DirtyDiffController extends Disposable implements DirtyDiffContribu
 	private onDidChangeGutterAction(): void {
 		const gutterAction = this.configurationService.getValue<'diff' | 'none'>('scm.diffDecorationsGutterAction');
 
-		this.gutterActionDisposables.dispose();
-		this.gutterActionDisposables = new DisposableStore();
+		this.gutterActionDisposables.clear();
 
 		if (gutterAction === 'diff') {
 			this.gutterActionDisposables.add(this.editor.onMouseDown(e => this.onEditorMouseDown(e)));

--- a/src/vs/workbench/contrib/scm/browser/menus.ts
+++ b/src/vs/workbench/contrib/scm/browser/menus.ts
@@ -33,7 +33,7 @@ export class SCMTitleMenu implements IDisposable {
 	readonly onDidChangeTitle = this._onDidChangeTitle.event;
 
 	readonly menu: IMenu;
-	private disposables = new DisposableStore();
+	private readonly disposables = new DisposableStore();
 
 	constructor(
 		@IMenuService menuService: IMenuService,

--- a/src/vs/workbench/contrib/scm/browser/scmSyncViewPane.ts
+++ b/src/vs/workbench/contrib/scm/browser/scmSyncViewPane.ts
@@ -410,7 +410,7 @@ class SCMSyncPaneViewModel {
 	private repositories = new Map<ISCMRepository, IDisposable>();
 	private alwaysShowRepositories = false;
 
-	private disposables = new DisposableStore();
+	private readonly disposables = new DisposableStore();
 
 	constructor(
 		private readonly tree: WorkbenchAsyncDataTree<TreeElement, TreeElement>,

--- a/src/vs/workbench/contrib/scm/browser/scmViewPane.ts
+++ b/src/vs/workbench/contrib/scm/browser/scmViewPane.ts
@@ -453,7 +453,7 @@ class ResourceRenderer implements ICompressibleTreeRenderer<ISCMResource | IReso
 	static readonly TEMPLATE_ID = 'resource';
 	get templateId(): string { return ResourceRenderer.TEMPLATE_ID; }
 
-	private disposables = new DisposableStore();
+	private readonly disposables = new DisposableStore();
 	private renderedResources = new Map<ResourceTemplate, RenderedResourceData>();
 
 	constructor(
@@ -1036,7 +1036,7 @@ class RepositoryVisibilityActionController {
 	private items = new Map<ISCMRepository, RepositoryVisibilityItem>();
 	private repositoryCountContextKey: IContextKey<number>;
 	private repositoryVisibilityCountContextKey: IContextKey<number>;
-	private disposables = new DisposableStore();
+	private readonly disposables = new DisposableStore();
 
 	constructor(
 		@ISCMViewService private scmViewService: ISCMViewService,
@@ -1178,12 +1178,12 @@ class ViewModel {
 	}
 
 	private items = new Map<ISCMRepository, IRepositoryItem>();
-	private visibilityDisposables = new DisposableStore();
+	private readonly visibilityDisposables = new DisposableStore();
 	private scrollTop: number | undefined;
 	private alwaysShowRepositories = false;
 	private showActionButton = false;
 	private firstVisible = true;
-	private disposables = new DisposableStore();
+	private readonly disposables = new DisposableStore();
 
 	private modeContextKey: IContextKey<ViewModelMode>;
 	private sortKeyContextKey: IContextKey<ViewModelSortKey>;
@@ -1352,7 +1352,6 @@ class ViewModel {
 
 	setVisible(visible: boolean): void {
 		if (visible) {
-			this.visibilityDisposables = new DisposableStore();
 			this.scmViewService.onDidChangeVisibleRepositories(this._onDidChangeVisibleRepositories, this, this.visibilityDisposables);
 			this._onDidChangeVisibleRepositories({ added: this.scmViewService.visibleRepositories, removed: Iterable.empty() });
 
@@ -1366,7 +1365,7 @@ class ViewModel {
 		} else {
 			this.updateViewState();
 
-			this.visibilityDisposables.dispose();
+			this.visibilityDisposables.clear();
 			this._onDidChangeVisibleRepositories({ added: Iterable.empty(), removed: [...this.items.keys()] });
 			this.scrollTop = this.tree.scrollTop;
 		}
@@ -1807,11 +1806,11 @@ class SCMInputWidget {
 	private editorContainer: HTMLElement;
 	private placeholderTextContainer: HTMLElement;
 	private inputEditor: CodeEditorWidget;
-	private disposables = new DisposableStore();
+	private readonly disposables = new DisposableStore();
 
 	private model: { readonly input: ISCMInput; textModelRef?: IReference<IResolvedTextEditorModel> } | undefined;
 	private repositoryIdContextKey: IContextKey<string | undefined>;
-	private repositoryDisposables = new DisposableStore();
+	private readonly repositoryDisposables = new DisposableStore();
 
 	private validation: IInputValidation | undefined;
 	private validationDisposable: IDisposable = Disposable.None;
@@ -1837,8 +1836,7 @@ class SCMInputWidget {
 		this.clearValidation();
 		this.editorContainer.classList.remove('synthetic-focus');
 
-		this.repositoryDisposables.dispose();
-		this.repositoryDisposables = new DisposableStore();
+		this.repositoryDisposables.clear();
 		this.repositoryIdContextKey.set(input?.repository.id);
 
 		if (!input) {

--- a/src/vs/workbench/contrib/scm/browser/scmViewService.ts
+++ b/src/vs/workbench/contrib/scm/browser/scmViewService.ts
@@ -57,7 +57,7 @@ export class SCMViewService implements ISCMViewService {
 	private didFinishLoading: boolean = false;
 	private didSelectRepository: boolean = false;
 	private previousState: ISCMViewServiceState | undefined;
-	private disposables = new DisposableStore();
+	private readonly disposables = new DisposableStore();
 
 	private _repositories: ISCMRepositoryView[] = [];
 

--- a/src/vs/workbench/contrib/scm/common/scmService.ts
+++ b/src/vs/workbench/contrib/scm/common/scmService.ts
@@ -213,7 +213,7 @@ class WillSaveHistoryEvent {
 
 class SCMInputHistory {
 
-	private disposables = new DisposableStore();
+	private readonly disposables = new DisposableStore();
 	private readonly histories = new Map<string, ResourceMap<HistoryNavigator2<string>>>();
 
 	private readonly _onWillSaveHistory = this.disposables.add(new Emitter<WillSaveHistoryEvent>());

--- a/src/vs/workbench/contrib/update/browser/releaseNotesEditor.ts
+++ b/src/vs/workbench/contrib/update/browser/releaseNotesEditor.ts
@@ -37,7 +37,7 @@ export class ReleaseNotesManager {
 
 	private _currentReleaseNotes: WebviewInput | undefined = undefined;
 	private _lastText: string | undefined;
-	private disposables = new DisposableStore();
+	private readonly disposables = new DisposableStore();
 
 	public constructor(
 		@IEnvironmentService private readonly _environmentService: IEnvironmentService,


### PR DESCRIPTION
This prevents a common cause of leaks: reassigning the property without first disposing of the old value


