### PR TITLE
fire `onDidReconnectToTasks` when there are no task terminals to reconnect to so tasks run on `folderOpen` 

### DIFF
--- a/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
+++ b/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
@@ -231,6 +231,7 @@ export abstract class AbstractTaskService extends Disposable implements ITaskSer
 	public onDidChangeTaskSystemInfo: Event<void> = this._onDidChangeTaskSystemInfo.event;
 	private _onDidReconnectToTasks: Emitter<void> = new Emitter();
 	public onDidReconnectToTasks: Event<void> = this._onDidReconnectToTasks.event;
+	public get isReconnected(): boolean { return this._tasksReconnected; }
 
 	constructor(
 		@IConfigurationService private readonly _configurationService: IConfigurationService,
@@ -349,6 +350,7 @@ export abstract class AbstractTaskService extends Disposable implements ITaskSer
 					this._attemptTaskReconnection();
 				} else {
 					this._tasksReconnected = true;
+					this._onDidReconnectToTasks.fire();
 				}
 			});
 		}

--- a/src/vs/workbench/contrib/tasks/browser/runAutomaticTasks.ts
+++ b/src/vs/workbench/contrib/tasks/browser/runAutomaticTasks.ts
@@ -31,13 +31,9 @@ export class RunAutomaticTasks extends Disposable implements IWorkbenchContribut
 		if (this._taskService.isReconnected) {
 			this._tryRunTasks();
 		} else {
-			this._register(Event.once(this._taskService.onDidReconnectToTasks)(() => this._tryRunTasks()));
+			this._register(Event.once(this._taskService.onDidReconnectToTasks)(async () => await this._tryRunTasks()));
 		}
-		this._register(this._workspaceTrustManagementService.onDidChangeTrust(async trusted => {
-			if (trusted) {
-				await this._tryRunTasks();
-			}
-		}));
+		this._register(this._workspaceTrustManagementService.onDidChangeTrust(async () => await this._tryRunTasks()));
 	}
 
 	private async _tryRunTasks() {

--- a/src/vs/workbench/contrib/tasks/browser/runAutomaticTasks.ts
+++ b/src/vs/workbench/contrib/tasks/browser/runAutomaticTasks.ts
@@ -33,6 +33,9 @@ export class RunAutomaticTasks extends Disposable implements IWorkbenchContribut
 				this._tryRunTasks();
 			}
 		}));
+		if (this._taskService.isReconnected) {
+			this._tryRunTasks();
+		}
 		this._register(this._workspaceTrustManagementService.onDidChangeTrust(async trusted => {
 			if (trusted) {
 				await this._tryRunTasks();

--- a/src/vs/workbench/contrib/tasks/browser/runAutomaticTasks.ts
+++ b/src/vs/workbench/contrib/tasks/browser/runAutomaticTasks.ts
@@ -28,9 +28,10 @@ export class RunAutomaticTasks extends Disposable implements IWorkbenchContribut
 		@IWorkspaceTrustManagementService private readonly _workspaceTrustManagementService: IWorkspaceTrustManagementService,
 		@ILogService private readonly _logService: ILogService) {
 		super();
-		this._taskService.onDidReconnectToTasks((() => this._tryRunTasks()));
 		if (this._taskService.isReconnected) {
 			this._tryRunTasks();
+		} else {
+			this._register(Event.once(this._taskService.onDidReconnectToTasks)(() => this._tryRunTasks()));
 		}
 		this._register(this._workspaceTrustManagementService.onDidChangeTrust(async trusted => {
 			if (trusted) {

--- a/src/vs/workbench/contrib/tasks/browser/runAutomaticTasks.ts
+++ b/src/vs/workbench/contrib/tasks/browser/runAutomaticTasks.ts
@@ -28,11 +28,7 @@ export class RunAutomaticTasks extends Disposable implements IWorkbenchContribut
 		@IWorkspaceTrustManagementService private readonly _workspaceTrustManagementService: IWorkspaceTrustManagementService,
 		@ILogService private readonly _logService: ILogService) {
 		super();
-		this._taskService.onDidReconnectToTasks((() => {
-			if (this._workspaceTrustManagementService.isWorkspaceTrusted()) {
-				this._tryRunTasks();
-			}
-		}));
+		this._taskService.onDidReconnectToTasks((() => this._tryRunTasks()));
 		if (this._taskService.isReconnected) {
 			this._tryRunTasks();
 		}
@@ -44,6 +40,9 @@ export class RunAutomaticTasks extends Disposable implements IWorkbenchContribut
 	}
 
 	private async _tryRunTasks() {
+		if (!this._workspaceTrustManagementService.isWorkspaceTrusted()) {
+			return;
+		}
 		if (this._hasRunTasks || this._configurationService.getValue(ALLOW_AUTOMATIC_TASKS) === 'off') {
 			return;
 		}

--- a/src/vs/workbench/contrib/tasks/common/taskService.ts
+++ b/src/vs/workbench/contrib/tasks/common/taskService.ts
@@ -64,6 +64,7 @@ export interface IWorkspaceFolderTaskResult extends IWorkspaceTaskResult {
 export interface ITaskService {
 	readonly _serviceBrand: undefined;
 	onDidStateChange: Event<ITaskEvent>;
+	isReconnected: boolean;
 	onDidReconnectToTasks: Event<void>;
 	supportsMultipleTaskExecutions: boolean;
 


### PR DESCRIPTION
fix #193475