### PR TITLE
Allow text in error message popups to be copied or at least selected (fix #193243)

### DIFF
--- a/src/vs/workbench/browser/parts/editor/media/editorplaceholder.css
+++ b/src/vs/workbench/browser/parts/editor/media/editorplaceholder.css
@@ -44,6 +44,8 @@
 	max-width: 450px;
 	text-align: center;
 	word-break: break-word;
+	user-select: text;
+	-webkit-user-select: text;
 }
 
 .monaco-editor-pane-placeholder .editor-placeholder-buttons-container {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
