### PR TITLE
Introduce a concept of Command Descriptions for TF-IDF indexing

### DIFF
--- a/src/vs/platform/action/common/action.ts
+++ b/src/vs/platform/action/common/action.ts
@@ -7,6 +7,7 @@ import { URI, UriDto } from 'vs/base/common/uri';
 import { ContextKeyExpression } from 'vs/platform/contextkey/common/contextkey';
 import { ThemeIcon } from 'vs/base/common/themables';
 import { Categories } from './actionCommonCategories';
+import { ICommandHandlerDescription } from 'vs/platform/commands/common/commands';
 
 export interface ILocalizedString {
 
@@ -19,6 +20,13 @@ export interface ILocalizedString {
 	 * The original (non localized value of the string)
 	 */
 	original: string;
+}
+
+export function isLocalizedString(thing: any): thing is ILocalizedString {
+	return thing
+		&& typeof thing === 'object'
+		&& typeof thing.original === 'string'
+		&& typeof thing.value === 'string';
 }
 
 export interface ICommandActionTitle extends ILocalizedString {
@@ -66,6 +74,13 @@ export interface ICommandAction {
 	id: string;
 	title: string | ICommandActionTitle;
 	shortTitle?: string | ICommandActionTitle;
+	/**
+	 * Metadata about this command, used for:
+	 * - API commands
+	 * - when showing keybindings that have no other UX
+	 * - when searching for commands in the Command Palette
+	 */
+	description?: ILocalizedString | ICommandHandlerDescription;
 	category?: keyof typeof Categories | ILocalizedString | string;
 	tooltip?: string | ILocalizedString;
 	icon?: Icon;

--- a/src/vs/platform/commands/common/commands.ts
+++ b/src/vs/platform/commands/common/commands.ts
@@ -9,6 +9,7 @@ import { IJSONSchema } from 'vs/base/common/jsonSchema';
 import { IDisposable, toDisposable } from 'vs/base/common/lifecycle';
 import { LinkedList } from 'vs/base/common/linkedList';
 import { TypeConstraint, validateConstraints } from 'vs/base/common/types';
+import { ILocalizedString } from 'vs/platform/action/common/action';
 import { createDecorator, ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
 
 export const ICommandService = createDecorator<ICommandService>('commandService');
@@ -34,7 +35,7 @@ export interface ICommandHandler {
 export interface ICommand {
 	id: string;
 	handler: ICommandHandler;
-	description?: ICommandHandlerDescription | null;
+	description?: ILocalizedString | ICommandHandlerDescription;
 }
 
 export interface ICommandHandlerDescription {
@@ -47,6 +48,13 @@ export interface ICommandHandlerDescription {
 		readonly schema?: IJSONSchema;
 	}>;
 	readonly returns?: string;
+}
+
+export function isCommandHandlerDescription(thing: any): thing is ICommandHandlerDescription {
+	return thing
+		&& typeof thing === 'object'
+		&& typeof thing.description === 'string'
+		&& Array.isArray(thing.args);
 }
 
 export interface ICommandRegistry {
@@ -79,7 +87,7 @@ export const CommandsRegistry: ICommandRegistry = new class implements ICommandR
 		}
 
 		// add argument validation if rich command metadata is provided
-		if (idOrCommand.description) {
+		if (isCommandHandlerDescription(idOrCommand.description)) {
 			const constraints: Array<TypeConstraint | undefined> = [];
 			for (const arg of idOrCommand.description.args) {
 				constraints.push(arg.constraint);

--- a/src/vs/platform/keybinding/common/keybindingsRegistry.ts
+++ b/src/vs/platform/keybinding/common/keybindingsRegistry.ts
@@ -66,7 +66,7 @@ export const enum KeybindingWeight {
 
 export interface ICommandAndKeybindingRule extends IKeybindingRule {
 	handler: ICommandHandler;
-	description?: ICommandHandlerDescription | null;
+	description?: ICommandHandlerDescription;
 }
 
 export interface IKeybindingsRegistry {

--- a/src/vs/workbench/api/browser/mainThreadCommands.ts
+++ b/src/vs/workbench/api/browser/mainThreadCommands.ts
@@ -10,6 +10,7 @@ import { IExtHostContext, extHostNamedCustomer } from 'vs/workbench/services/ext
 import { IExtensionService } from 'vs/workbench/services/extensions/common/extensions';
 import { Dto, SerializableObjectWithBuffers } from 'vs/workbench/services/extensions/common/proxyIdentifier';
 import { ExtHostCommandsShape, ExtHostContext, MainContext, MainThreadCommandsShape } from '../common/extHost.protocol';
+import { ILocalizedString, isLocalizedString } from 'vs/platform/action/common/action';
 
 
 @extHostNamedCustomer(MainContext.MainThreadCommands)
@@ -35,7 +36,7 @@ export class MainThreadCommands implements MainThreadCommandsShape {
 	}
 
 	private async _generateCommandsDocumentation(): Promise<void> {
-		const result = await this._proxy.$getContributedCommandHandlerDescriptions();
+		const result: Record<string, string | ICommandHandlerDescription | ILocalizedString> = await this._proxy.$getContributedCommandHandlerDescriptions();
 
 		// add local commands
 		const commands = CommandsRegistry.getCommands();
@@ -98,9 +99,12 @@ export class MainThreadCommands implements MainThreadCommandsShape {
 
 // --- command doc
 
-function _generateMarkdown(description: string | Dto<ICommandHandlerDescription> | ICommandHandlerDescription): string {
+function _generateMarkdown(description: string | ILocalizedString | Dto<ICommandHandlerDescription> | ICommandHandlerDescription): string {
 	if (typeof description === 'string') {
 		return description;
+	} else if (isLocalizedString(description)) {
+		// Our docs website is in English, so keep the original here.
+		return description.original;
 	} else {
 		const parts = [description.description];
 		parts.push('\n\n');

--- a/src/vs/workbench/contrib/files/browser/fileActions.contribution.ts
+++ b/src/vs/workbench/contrib/files/browser/fileActions.contribution.ts
@@ -7,7 +7,7 @@ import * as nls from 'vs/nls';
 import { ToggleAutoSaveAction, FocusFilesExplorer, GlobalCompareResourcesAction, ShowActiveFileInExplorer, CompareWithClipboardAction, NEW_FILE_COMMAND_ID, NEW_FILE_LABEL, NEW_FOLDER_COMMAND_ID, NEW_FOLDER_LABEL, TRIGGER_RENAME_LABEL, MOVE_FILE_TO_TRASH_LABEL, COPY_FILE_LABEL, PASTE_FILE_LABEL, FileCopiedContext, renameHandler, moveFileToTrashHandler, copyFileHandler, pasteFileHandler, deleteFileHandler, cutFileHandler, DOWNLOAD_COMMAND_ID, openFilePreserveFocusHandler, DOWNLOAD_LABEL, ShowOpenedFileInNewWindow, UPLOAD_COMMAND_ID, UPLOAD_LABEL, CompareNewUntitledTextFilesAction, SetActiveEditorReadonlyInSession, SetActiveEditorWriteableInSession, ToggleActiveEditorReadonlyInSession, ResetActiveEditorReadonlyInSession } from 'vs/workbench/contrib/files/browser/fileActions';
 import { revertLocalChangesCommand, acceptLocalChangesCommand, CONFLICT_RESOLUTION_CONTEXT } from 'vs/workbench/contrib/files/browser/editors/textFileSaveErrorHandler';
 import { MenuId, MenuRegistry, registerAction2 } from 'vs/platform/actions/common/actions';
-import { ILocalizedString } from 'vs/platform/action/common/action';
+import { ICommandAction } from 'vs/platform/action/common/action';
 import { KeyMod, KeyCode } from 'vs/base/common/keyCodes';
 import { openWindowCommand, newWindowCommand } from 'vs/workbench/contrib/files/browser/fileCommands';
 import { COPY_PATH_COMMAND_ID, REVEAL_IN_EXPLORER_COMMAND_ID, OPEN_TO_SIDE_COMMAND_ID, REVERT_FILE_COMMAND_ID, SAVE_FILE_COMMAND_ID, SAVE_FILE_LABEL, SAVE_FILE_AS_COMMAND_ID, SAVE_FILE_AS_LABEL, SAVE_ALL_IN_GROUP_COMMAND_ID, OpenEditorsGroupContext, COMPARE_WITH_SAVED_COMMAND_ID, COMPARE_RESOURCE_COMMAND_ID, SELECT_FOR_COMPARE_COMMAND_ID, ResourceSelectedForCompareContext, OpenEditorsDirtyEditorContext, COMPARE_SELECTED_COMMAND_ID, REMOVE_ROOT_FOLDER_COMMAND_ID, REMOVE_ROOT_FOLDER_LABEL, SAVE_FILES_COMMAND_ID, COPY_RELATIVE_PATH_COMMAND_ID, SAVE_FILE_WITHOUT_FORMATTING_COMMAND_ID, SAVE_FILE_WITHOUT_FORMATTING_LABEL, OpenEditorsReadonlyEditorContext, OPEN_WITH_EXPLORER_COMMAND_ID, NEW_UNTITLED_FILE_COMMAND_ID, NEW_UNTITLED_FILE_LABEL, SAVE_ALL_COMMAND_ID } from 'vs/workbench/contrib/files/browser/fileConstants';
@@ -189,29 +189,89 @@ function appendSaveConflictEditorTitleAction(id: string, title: string, icon: Th
 
 // Menu registration - command palette
 
-export function appendToCommandPalette(id: string, title: ILocalizedString, category: ILocalizedString, when?: ContextKeyExpression): void {
+export function appendToCommandPalette({ id, title, category, description }: ICommandAction, when?: ContextKeyExpression): void {
 	MenuRegistry.appendMenuItem(MenuId.CommandPalette, {
 		command: {
 			id,
 			title,
-			category
+			category,
+			description
 		},
 		when
 	});
 }
 
-appendToCommandPalette(COPY_PATH_COMMAND_ID, { value: nls.localize('copyPathOfActive', "Copy Path of Active File"), original: 'Copy Path of Active File' }, Categories.File);
-appendToCommandPalette(COPY_RELATIVE_PATH_COMMAND_ID, { value: nls.localize('copyRelativePathOfActive', "Copy Relative Path of Active File"), original: 'Copy Relative Path of Active File' }, Categories.File);
-appendToCommandPalette(SAVE_FILE_COMMAND_ID, { value: SAVE_FILE_LABEL, original: 'Save' }, Categories.File);
-appendToCommandPalette(SAVE_FILE_WITHOUT_FORMATTING_COMMAND_ID, { value: SAVE_FILE_WITHOUT_FORMATTING_LABEL, original: 'Save without Formatting' }, Categories.File);
-appendToCommandPalette(SAVE_ALL_IN_GROUP_COMMAND_ID, { value: nls.localize('saveAllInGroup', "Save All in Group"), original: 'Save All in Group' }, Categories.File);
-appendToCommandPalette(SAVE_FILES_COMMAND_ID, { value: nls.localize('saveFiles', "Save All Files"), original: 'Save All Files' }, Categories.File);
-appendToCommandPalette(REVERT_FILE_COMMAND_ID, { value: nls.localize('revert', "Revert File"), original: 'Revert File' }, Categories.File);
-appendToCommandPalette(COMPARE_WITH_SAVED_COMMAND_ID, { value: nls.localize('compareActiveWithSaved', "Compare Active File with Saved"), original: 'Compare Active File with Saved' }, Categories.File);
-appendToCommandPalette(SAVE_FILE_AS_COMMAND_ID, { value: SAVE_FILE_AS_LABEL, original: 'Save As...' }, Categories.File);
-appendToCommandPalette(NEW_FILE_COMMAND_ID, { value: NEW_FILE_LABEL, original: 'New File' }, Categories.File, WorkspaceFolderCountContext.notEqualsTo('0'));
-appendToCommandPalette(NEW_FOLDER_COMMAND_ID, { value: NEW_FOLDER_LABEL, original: 'New Folder' }, Categories.File, WorkspaceFolderCountContext.notEqualsTo('0'));
-appendToCommandPalette(NEW_UNTITLED_FILE_COMMAND_ID, { value: NEW_UNTITLED_FILE_LABEL, original: 'New Untitled Text File' }, Categories.File);
+appendToCommandPalette({
+	id: COPY_PATH_COMMAND_ID,
+	title: { value: nls.localize('copyPathOfActive', "Copy Path of Active File"), original: 'Copy Path of Active File' },
+	category: Categories.File
+});
+appendToCommandPalette({
+	id: COPY_RELATIVE_PATH_COMMAND_ID,
+	title: { value: nls.localize('copyRelativePathOfActive', "Copy Relative Path of Active File"), original: 'Copy Relative Path of Active File' },
+	category: Categories.File
+});
+
+appendToCommandPalette({
+	id: SAVE_FILE_COMMAND_ID,
+	title: { value: SAVE_FILE_LABEL, original: 'Save' },
+	category: Categories.File
+});
+
+appendToCommandPalette({
+	id: SAVE_FILE_WITHOUT_FORMATTING_COMMAND_ID,
+	title: { value: SAVE_FILE_WITHOUT_FORMATTING_LABEL, original: 'Save without Formatting' },
+	category: Categories.File
+});
+
+appendToCommandPalette({
+	id: SAVE_ALL_IN_GROUP_COMMAND_ID,
+	title: { value: nls.localize('saveAllInGroup', "Save All in Group"), original: 'Save All in Group' },
+	category: Categories.File
+});
+
+appendToCommandPalette({
+	id: SAVE_FILES_COMMAND_ID,
+	title: { value: nls.localize('saveFiles', "Save All Files"), original: 'Save All Files' },
+	category: Categories.File
+});
+
+appendToCommandPalette({
+	id: REVERT_FILE_COMMAND_ID,
+	title: { value: nls.localize('revert', "Revert File"), original: 'Revert File' },
+	category: Categories.File
+});
+
+appendToCommandPalette({
+	id: COMPARE_WITH_SAVED_COMMAND_ID,
+	title: { value: nls.localize('compareActiveWithSaved', "Compare Active File with Saved"), original: 'Compare Active File with Saved' },
+	category: Categories.File
+});
+
+appendToCommandPalette({
+	id: SAVE_FILE_AS_COMMAND_ID,
+	title: { value: SAVE_FILE_AS_LABEL, original: 'Save As...' },
+	category: Categories.File
+});
+
+appendToCommandPalette({
+	id: NEW_FILE_COMMAND_ID,
+	title: { value: NEW_FILE_LABEL, original: 'New File' },
+	category: Categories.File
+}, WorkspaceFolderCountContext.notEqualsTo('0'));
+
+appendToCommandPalette({
+	id: NEW_FOLDER_COMMAND_ID,
+	title: { value: NEW_FOLDER_LABEL, original: 'New Folder' },
+	category: Categories.File,
+	description: { value: nls.localize('newFolderDescription', "Create a new folder or directory"), original: 'Create a new folder or directory' }
+}, WorkspaceFolderCountContext.notEqualsTo('0'));
+
+appendToCommandPalette({
+	id: NEW_UNTITLED_FILE_COMMAND_ID,
+	title: { value: NEW_UNTITLED_FILE_LABEL, original: 'New Untitled Text File' },
+	category: Categories.File
+});
 
 // Menu registration - open editors
 

--- a/src/vs/workbench/contrib/files/electron-sandbox/fileActions.contribution.ts
+++ b/src/vs/workbench/contrib/files/electron-sandbox/fileActions.contribution.ts
@@ -90,4 +90,8 @@ MenuRegistry.appendMenuItem(MenuId.ExplorerContext, {
 // Command Palette
 
 const category = { value: nls.localize('filesCategory', "File"), original: 'File' };
-appendToCommandPalette(REVEAL_IN_OS_COMMAND_ID, { value: REVEAL_IN_OS_LABEL, original: isWindows ? 'Reveal in File Explorer' : isMacintosh ? 'Reveal in Finder' : 'Open Containing Folder' }, category, REVEAL_IN_OS_WHEN_CONTEXT);
+appendToCommandPalette({
+	id: REVEAL_IN_OS_COMMAND_ID,
+	title: { value: REVEAL_IN_OS_LABEL, original: isWindows ? 'Reveal in File Explorer' : isMacintosh ? 'Reveal in Finder' : 'Open Containing Folder' },
+	category: category
+}, REVEAL_IN_OS_WHEN_CONTEXT);

--- a/src/vs/workbench/contrib/localization/common/localizationsActions.ts
+++ b/src/vs/workbench/contrib/localization/common/localizationsActions.ts
@@ -23,6 +23,10 @@ export class ConfigureDisplayLanguageAction extends Action2 {
 			title: { original: 'Configure Display Language', value: ConfigureDisplayLanguageAction.LABEL },
 			menu: {
 				id: MenuId.CommandPalette
+			},
+			description: {
+				value: localize('configureLocaleDescription', "Changes the locale of VS Code based on installed language packs. Common languages include French, Chinese, Spanish, Japanese, German, Korean, and more."),
+				original: 'Changes the locale of VS Code based on installed language packs. Common languages include French, Chinese, Spanish, Japanese, German, Korean, and more.'
 			}
 		});
 	}

--- a/src/vs/workbench/contrib/quickaccess/browser/commandsQuickAccess.ts
+++ b/src/vs/workbench/contrib/quickaccess/browser/commandsQuickAccess.ts
@@ -238,7 +238,8 @@ export class CommandsQuickAccessProvider extends AbstractEditorCommandsQuickAcce
 			globalCommandPicks.push({
 				commandId: action.item.id,
 				commandAlias,
-				label: stripIcons(label)
+				label: stripIcons(label),
+				commandDescription: action.description,
 			});
 		}
 

--- a/src/vs/workbench/services/keybinding/browser/keybindingService.ts
+++ b/src/vs/workbench/services/keybinding/browser/keybindingService.ts
@@ -25,7 +25,7 @@ import { dirname } from 'vs/base/common/resources';
 
 // platform
 import { MenuRegistry } from 'vs/platform/actions/common/actions';
-import { CommandsRegistry, ICommandService } from 'vs/platform/commands/common/commands';
+import { CommandsRegistry, ICommandHandlerDescription, ICommandService, isCommandHandlerDescription } from 'vs/platform/commands/common/commands';
 import { ContextKeyExpr, ContextKeyExpression, IContextKey, IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 import { ExtensionIdentifier } from 'vs/platform/extensions/common/extensions';
 import { FileOperation, IFileService } from 'vs/platform/files/common/files';
@@ -42,6 +42,7 @@ import { ILogService } from 'vs/platform/log/common/log';
 import { INotificationService } from 'vs/platform/notification/common/notification';
 import { Registry } from 'vs/platform/registry/common/platform';
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
+import { ILocalizedString, isLocalizedString } from 'vs/platform/action/common/action';
 
 // workbench
 import { commandsExtensionPoint } from 'vs/workbench/services/actions/common/menusExtensionPoint';
@@ -906,13 +907,18 @@ class KeybindingsJsonSchema {
 		this.commandsEnumDescriptions.length = 0;
 
 		const knownCommands = new Set<string>();
-		const addKnownCommand = (commandId: string, description?: string | undefined) => {
+		const addKnownCommand = (commandId: string, description?: ILocalizedString | ICommandHandlerDescription | undefined) => {
 			if (!/^_/.test(commandId)) {
 				if (!knownCommands.has(commandId)) {
 					knownCommands.add(commandId);
 
 					this.commandsEnum.push(commandId);
-					this.commandsEnumDescriptions.push(description);
+
+					this.commandsEnumDescriptions.push(
+						isLocalizedString(description)
+							? description.value
+							: description?.description
+					);
 
 					// Also add the negative form for keybinding removal
 					this.removalCommandsEnum.push(`-${commandId}`);
@@ -924,9 +930,9 @@ class KeybindingsJsonSchema {
 		for (const [commandId, command] of allCommands) {
 			const commandDescription = command.description;
 
-			addKnownCommand(commandId, commandDescription ? commandDescription.description : undefined);
+			addKnownCommand(commandId, commandDescription);
 
-			if (!commandDescription || !commandDescription.args || commandDescription.args.length !== 1 || !commandDescription.args[0].schema) {
+			if (!isCommandHandlerDescription(commandDescription) || commandDescription.args.length !== 1 || !commandDescription.args[0].schema) {
 				continue;
 			}
 

--- a/src/vs/workbench/services/keybinding/browser/unboundCommands.ts
+++ b/src/vs/workbench/services/keybinding/browser/unboundCommands.ts
@@ -3,8 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { CommandsRegistry, ICommandHandlerDescription } from 'vs/platform/commands/common/commands';
-import { isNonEmptyArray } from 'vs/base/common/arrays';
+import { CommandsRegistry, isCommandHandlerDescription } from 'vs/platform/commands/common/commands';
 import { EditorExtensionsRegistry } from 'vs/editor/browser/editorExtensions';
 import { MenuRegistry, MenuId, isIMenuItem } from 'vs/platform/actions/common/actions';
 
@@ -24,8 +23,7 @@ export function getAllUnboundCommands(boundCommands: Map<string, boolean>): stri
 		}
 		if (!includeCommandWithArgs) {
 			const command = CommandsRegistry.getCommand(id);
-			if (command && typeof command.description === 'object'
-				&& isNonEmptyArray((<ICommandHandlerDescription>command.description).args)) { // command with args
+			if (command && isCommandHandlerDescription(command.description) && command.description.args.length) { // command with args
 				return;
 			}
 		}


### PR DESCRIPTION
COMPETING PR TO https://github.com/microsoft/vscode/pull/193631

This allows workbench actions to contribute ILocalizedStrings as description (or they can still use the complex `ICommandHandlerDescription` type).

If a description is contributed, then that will be included in the TF-IDF chunk calculation. This allows us to include additional relevant information that will help the Command Palette find the command you're looking for.

![image](https://github.com/microsoft/vscode/assets/2644648/e02b8b4b-baa0-4307-bc13-150e6cd4ec97)
![image](https://github.com/microsoft/vscode/assets/2644648/0cb11f85-cb41-483e-8d5d-978906b36566)

Additionally, these descriptions are diplayed in the keybindings.json editing experience:

![image](https://github.com/microsoft/vscode/assets/2644648/62f0ed8b-cef1-415e-bbc4-671ca0d0180a)
 

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

#### Next steps

After this goes in, I'll work on lighting up the same for Editor Commands.