### PR TITLE
Simplify local settings search

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/preferencesSearch.ts
+++ b/src/vs/workbench/contrib/preferences/browser/preferencesSearch.ts
@@ -204,6 +204,12 @@ export class SettingMatches {
 			keyMatchingWords.clear();
 		}
 
+		// Also check if the user tried searching by id.
+		const keyIdMatches = matchesContiguousSubString(searchString, setting.key);
+		if (keyIdMatches?.length) {
+			keyMatchingWords.set(setting.key, keyIdMatches.map(match => this.toKeyRange(setting, match)));
+		}
+
 		// Check if the value contains all the words.
 		if (setting.enum?.length) {
 			// Search all string values of enums.

--- a/src/vs/workbench/contrib/preferences/browser/preferencesSearch.ts
+++ b/src/vs/workbench/contrib/preferences/browser/preferencesSearch.ts
@@ -172,8 +172,6 @@ export class SettingMatches {
 		const words = new Set<string>(searchString.split(' '));
 		const settingKeyAsWords: string = this._keyToLabel(setting.key);
 
-		const settingValue = this.configurationService.getValue(setting.key);
-
 		if (this.searchDescription) {
 			for (const word of words) {
 				// Search the description lines.
@@ -199,7 +197,7 @@ export class SettingMatches {
 		}
 		// For now, only allow a match if all words match in the key.
 		if (keyMatchingWords.size === words.size) {
-			this.matchType |= SettingMatchType.KeyMatchesAllWords;
+			this.matchType |= SettingMatchType.KeyMatch;
 		} else {
 			keyMatchingWords.clear();
 		}
@@ -225,18 +223,21 @@ export class SettingMatches {
 					valueMatchingWords.clear();
 				}
 			}
-		} else if (typeof settingValue === 'string') {
-			for (const word of words) {
-				const valueMatches = matchesContiguousSubString(word, settingValue);
-				if (valueMatches?.length) {
-					valueMatchingWords.set(word, valueMatches.map(match => this.toValueRange(setting, match)));
+		} else {
+			const settingValue = this.configurationService.getValue(setting.key);
+			if (typeof settingValue === 'string') {
+				for (const word of words) {
+					const valueMatches = matchesContiguousSubString(word, settingValue);
+					if (valueMatches?.length) {
+						valueMatchingWords.set(word, valueMatches.map(match => this.toValueRange(setting, match)));
+					}
 				}
-			}
-			if (valueMatchingWords.size === words.size) {
-				this.matchType |= SettingMatchType.DescriptionOrValueMatch;
-			} else {
-				// Clear out the match for now. We want to require all words to match in the value.
-				valueMatchingWords.clear();
+				if (valueMatchingWords.size === words.size) {
+					this.matchType |= SettingMatchType.DescriptionOrValueMatch;
+				} else {
+					// Clear out the match for now. We want to require all words to match in the value.
+					valueMatchingWords.clear();
+				}
 			}
 		}
 

--- a/src/vs/workbench/contrib/preferences/browser/preferencesSearch.ts
+++ b/src/vs/workbench/contrib/preferences/browser/preferencesSearch.ts
@@ -170,8 +170,8 @@ export class SettingMatches {
 		const valueMatchingWords: Map<string, IRange[]> = new Map<string, IRange[]>();
 
 		const words = new Set<string>(searchString.split(' '));
-		const settingKeyAsWords: string = this._keyToLabel(setting.key);
 
+		// Description search
 		if (this.searchDescription) {
 			for (const word of words) {
 				// Search the description lines.
@@ -188,6 +188,8 @@ export class SettingMatches {
 			}
 		}
 
+		// Key search
+		const settingKeyAsWords: string = this._keyToLabel(setting.key);
 		for (const word of words) {
 			// Check if the key contains the word.
 			const keyMatches = matchesWords(word, settingKeyAsWords, true);
@@ -204,6 +206,7 @@ export class SettingMatches {
 
 		// Check if the value contains all the words.
 		if (setting.enum?.length) {
+			// Search all string values of enums.
 			for (const option of setting.enum) {
 				if (typeof option !== 'string') {
 					continue;
@@ -224,6 +227,7 @@ export class SettingMatches {
 				}
 			}
 		} else {
+			// Search single string value.
 			const settingValue = this.configurationService.getValue(setting.key);
 			if (typeof settingValue === 'string') {
 				for (const word of words) {

--- a/src/vs/workbench/services/preferences/common/preferences.ts
+++ b/src/vs/workbench/services/preferences/common/preferences.ts
@@ -140,8 +140,7 @@ export enum SettingMatchType {
 	None = 0,
 	RemoteMatch = 1 << 0,
 	DescriptionOrValueMatch = 1 << 1,
-	KeyMatch = 1 << 2,
-	KeyMatchesAllWords = 1 << 3
+	KeyMatch = 1 << 2
 }
 
 export interface ISettingMatch {

--- a/src/vs/workbench/services/preferences/common/preferences.ts
+++ b/src/vs/workbench/services/preferences/common/preferences.ts
@@ -139,8 +139,9 @@ export interface IFilterResult {
 export enum SettingMatchType {
 	None = 0,
 	RemoteMatch = 1 << 0,
-	WholeWordMatch = 1 << 1,
-	KeyMatch = 1 << 2
+	DescriptionOrValueMatch = 1 << 1,
+	KeyMatch = 1 << 2,
+	KeyMatchesAllWords = 1 << 3
 }
 
 export interface ISettingMatch {

--- a/src/vs/workbench/services/preferences/common/preferences.ts
+++ b/src/vs/workbench/services/preferences/common/preferences.ts
@@ -134,13 +134,13 @@ export interface IFilterResult {
 /**
  * The ways a setting could match a query,
  * sorted in increasing order of relevance.
- * For now, ignore description and value matches.
  */
 export enum SettingMatchType {
 	None = 0,
-	RemoteMatch = 1 << 0,
-	DescriptionOrValueMatch = 1 << 1,
-	KeyMatch = 1 << 2
+	LanguageTagSettingMatch = 1 << 0,
+	RemoteMatch = 1 << 1,
+	DescriptionOrValueMatch = 1 << 2,
+	KeyMatch = 1 << 3
 }
 
 export interface ISettingMatch {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR simplifies local settings search in the following ways:

1. It doesn't search the overrides of a setting. The only settings with overrides are language tag settings such as `[markdown]`. If we want to show those settings, I can add another rank below remote settings in order to show those at the very end.
2. It only considers a match to occur when _all of_ the query words show up in the setting's wordified key, description, or one of the string setting values, or when the query is a substring of the setting ID. In other words, if the query is "A B", and the description has the word "A" and the key has the word "B", it wouldn't show up as a result.
