### PR TITLE
editors - try to improve filtered model lookup times

### DIFF
--- a/src/vs/workbench/common/editor/editorGroupModel.ts
+++ b/src/vs/workbench/common/editor/editorGroupModel.ts
@@ -176,14 +176,14 @@ export interface IReadonlyEditorGroupModel {
 
 	getEditors(order: EditorsOrder, options?: { excludeSticky?: boolean }): readonly EditorInput[];
 	getEditorByIndex(index: number): EditorInput | undefined;
-	indexOf(candidate: EditorInput | IUntypedEditorInput | null, editors?: EditorInput[], options?: IMatchEditorOptions): number;
+	indexOf(editor: EditorInput | IUntypedEditorInput | null, editors?: EditorInput[], options?: IMatchEditorOptions): number;
 	isActive(editor: EditorInput | IUntypedEditorInput): boolean;
 	isPinned(editorOrIndex: EditorInput | number): boolean;
-	isSticky(candidateOrIndex: EditorInput | number): boolean;
+	isSticky(editorOrIndex: EditorInput | number): boolean;
 	isFirst(editor: EditorInput): boolean;
 	isLast(editor: EditorInput): boolean;
-	findEditor(candidate: EditorInput | null, options?: IMatchEditorOptions): [EditorInput, number /* index */] | undefined;
-	contains(candidate: EditorInput | IUntypedEditorInput, options?: IMatchEditorOptions): boolean;
+	findEditor(editor: EditorInput | null, options?: IMatchEditorOptions): [EditorInput, number /* index */] | undefined;
+	contains(editor: EditorInput | IUntypedEditorInput, options?: IMatchEditorOptions): boolean;
 }
 
 interface IEditorGroupModel extends IReadonlyEditorGroupModel {

--- a/src/vs/workbench/common/editor/filteredEditorGroupModel.ts
+++ b/src/vs/workbench/common/editor/filteredEditorGroupModel.ts
@@ -43,6 +43,11 @@ abstract class FilteredEditorGroupModel extends Disposable implements IReadonlyE
 	isSticky(editorOrIndex: number | EditorInput): boolean { return this.model.isSticky(editorOrIndex); }
 	isActive(editor: EditorInput | IUntypedEditorInput): boolean { return this.model.isActive(editor); }
 
+	getEditors(order: EditorsOrder, options?: { excludeSticky?: boolean }): readonly EditorInput[] {
+		const editors = this.model.getEditors(order, options);
+		return editors.filter(e => this.contains(e));
+	}
+
 	findEditor(candidate: EditorInput | null, options?: IMatchEditorOptions | undefined): [EditorInput, number] | undefined {
 		const result = this.model.findEditor(candidate, options);
 		if (!result) {
@@ -55,7 +60,6 @@ abstract class FilteredEditorGroupModel extends Disposable implements IReadonlyE
 	abstract isLast(editor: EditorInput): boolean;
 	abstract getEditorByIndex(index: number): EditorInput | undefined;
 	abstract indexOf(editor: EditorInput): number;
-	abstract getEditors(order: EditorsOrder, options?: { excludeSticky?: boolean }): readonly EditorInput[];
 	abstract contains(candidate: EditorInput | IUntypedEditorInput, options?: IMatchEditorOptions | undefined): boolean;
 
 	abstract filter(editorOrIndex: EditorInput | number): boolean;
@@ -72,7 +76,10 @@ export class StickyEditorGroupModel extends FilteredEditorGroupModel {
 		if (options?.excludeSticky) {
 			return [];
 		}
-		return this.model.getEditors(EditorsOrder.SEQUENTIAL).slice(0, this.model.stickyCount);
+		if (order === EditorsOrder.SEQUENTIAL) {
+			return this.model.getEditors(EditorsOrder.SEQUENTIAL).slice(0, this.model.stickyCount);
+		}
+		return super.getEditors(order, options);
 	}
 
 	override isSticky(editorOrIndex: number | EditorInput): boolean {
@@ -121,7 +128,10 @@ export class UnstickyEditorGroupModel extends FilteredEditorGroupModel {
 	}
 
 	override getEditors(order: EditorsOrder, options?: { excludeSticky?: boolean }): readonly EditorInput[] {
-		return this.model.getEditors(EditorsOrder.SEQUENTIAL).slice(this.model.stickyCount);
+		if (order === EditorsOrder.SEQUENTIAL) {
+			return this.model.getEditors(EditorsOrder.SEQUENTIAL).slice(this.model.stickyCount);
+		}
+		return super.getEditors(order, options);
 	}
 
 	isFirst(editor: EditorInput): boolean {

--- a/src/vs/workbench/common/editor/filteredEditorGroupModel.ts
+++ b/src/vs/workbench/common/editor/filteredEditorGroupModel.ts
@@ -45,7 +45,7 @@ abstract class FilteredEditorGroupModel extends Disposable implements IReadonlyE
 
 	getEditors(order: EditorsOrder, options?: { excludeSticky?: boolean }): readonly EditorInput[] {
 		const editors = this.model.getEditors(order, options);
-		return editors.filter(e => this.contains(e));
+		return editors.filter(e => this.filter(e));
 	}
 
 	findEditor(candidate: EditorInput | null, options?: IMatchEditorOptions | undefined): [EditorInput, number] | undefined {

--- a/src/vs/workbench/common/editor/filteredEditorGroupModel.ts
+++ b/src/vs/workbench/common/editor/filteredEditorGroupModel.ts
@@ -21,7 +21,7 @@ abstract class FilteredEditorGroupModel extends Disposable implements IReadonlyE
 
 		this._register(this.model.onDidModelChange(e => {
 			const candidateOrIndex = e.editorIndex ?? e.editor;
-			if (typeof candidateOrIndex === 'number' || candidateOrIndex) {
+			if (typeof candidateOrIndex !== 'undefined') {
 				if (!this.filter(candidateOrIndex)) {
 					return; // exclude events for excluded items
 				}

--- a/src/vs/workbench/common/editor/filteredEditorGroupModel.ts
+++ b/src/vs/workbench/common/editor/filteredEditorGroupModel.ts
@@ -43,11 +43,6 @@ abstract class FilteredEditorGroupModel extends Disposable implements IReadonlyE
 	isSticky(editorOrIndex: number | EditorInput): boolean { return this.model.isSticky(editorOrIndex); }
 	isActive(editor: EditorInput | IUntypedEditorInput): boolean { return this.model.isActive(editor); }
 
-	getEditors(order: EditorsOrder, options?: { excludeSticky?: boolean }): readonly EditorInput[] {
-		const editors = this.model.getEditors(order, options);
-		return editors.filter(e => this.filter(e));
-	}
-
 	findEditor(candidate: EditorInput | null, options?: IMatchEditorOptions | undefined): [EditorInput, number] | undefined {
 		const result = this.model.findEditor(candidate, options);
 		if (!result) {
@@ -60,6 +55,7 @@ abstract class FilteredEditorGroupModel extends Disposable implements IReadonlyE
 	abstract isLast(editor: EditorInput): boolean;
 	abstract getEditorByIndex(index: number): EditorInput | undefined;
 	abstract indexOf(editor: EditorInput): number;
+	abstract getEditors(order: EditorsOrder, options?: { excludeSticky?: boolean }): readonly EditorInput[];
 	abstract contains(candidate: EditorInput | IUntypedEditorInput, options?: IMatchEditorOptions | undefined): boolean;
 
 	abstract filter(editorOrIndex: EditorInput | number): boolean;
@@ -76,7 +72,7 @@ export class StickyEditorGroupModel extends FilteredEditorGroupModel {
 		if (options?.excludeSticky) {
 			return [];
 		}
-		return super.getEditors(order, options);
+		return this.model.getEditors(EditorsOrder.SEQUENTIAL).slice(0, this.model.stickyCount);
 	}
 
 	override isSticky(editorOrIndex: number | EditorInput): boolean {
@@ -125,7 +121,7 @@ export class UnstickyEditorGroupModel extends FilteredEditorGroupModel {
 	}
 
 	override getEditors(order: EditorsOrder, options?: { excludeSticky?: boolean }): readonly EditorInput[] {
-		return this.model.getEditors(order, { ...options, excludeSticky: true });
+		return this.model.getEditors(EditorsOrder.SEQUENTIAL).slice(this.model.stickyCount);
 	}
 
 	isFirst(editor: EditorInput): boolean {

--- a/src/vs/workbench/common/editor/filteredEditorGroupModel.ts
+++ b/src/vs/workbench/common/editor/filteredEditorGroupModel.ts
@@ -21,7 +21,7 @@ abstract class FilteredEditorGroupModel extends Disposable implements IReadonlyE
 
 		this._register(this.model.onDidModelChange(e => {
 			const candidateOrIndex = e.editorIndex ?? e.editor;
-			if (typeof candidateOrIndex !== 'undefined') {
+			if (candidateOrIndex !== undefined) {
 				if (!this.filter(candidateOrIndex)) {
 					return; // exclude events for excluded items
 				}
@@ -62,7 +62,7 @@ abstract class FilteredEditorGroupModel extends Disposable implements IReadonlyE
 	abstract indexOf(editor: EditorInput | IUntypedEditorInput | null, editors?: EditorInput[], options?: IMatchEditorOptions): number;
 	abstract contains(editor: EditorInput | IUntypedEditorInput, options?: IMatchEditorOptions): boolean;
 
-	abstract filter(editorOrIndex: EditorInput | number): boolean;
+	protected abstract filter(editorOrIndex: EditorInput | number): boolean;
 }
 
 export class StickyEditorGroupModel extends FilteredEditorGroupModel {
@@ -107,7 +107,7 @@ export class StickyEditorGroupModel extends FilteredEditorGroupModel {
 		return editorIndex >= 0 && editorIndex < this.model.stickyCount;
 	}
 
-	filter(candidateOrIndex: EditorInput | number): boolean {
+	protected filter(candidateOrIndex: EditorInput | number): boolean {
 		return this.model.isSticky(candidateOrIndex);
 	}
 }
@@ -152,7 +152,7 @@ export class UnstickyEditorGroupModel extends FilteredEditorGroupModel {
 		return editorIndex >= this.model.stickyCount && editorIndex < this.model.count;
 	}
 
-	filter(candidateOrIndex: EditorInput | number): boolean {
+	protected filter(candidateOrIndex: EditorInput | number): boolean {
 		return !this.model.isSticky(candidateOrIndex);
 	}
 }

--- a/src/vs/workbench/test/browser/parts/editor/filteredEditorGroupModel.test.ts
+++ b/src/vs/workbench/test/browser/parts/editor/filteredEditorGroupModel.test.ts
@@ -272,18 +272,18 @@ suite('FilteredEditorGroupModel', () => {
 		model.openEditor(input2, { pinned: true, sticky: false });
 
 
-		assert.strictEqual(stickyFilteredEditorGroup.isEmpty, true);
-		assert.strictEqual(unstickyFilteredEditorGroup.isEmpty, false);
+		assert.strictEqual(stickyFilteredEditorGroup.count === 0, true);
+		assert.strictEqual(unstickyFilteredEditorGroup.count === 0, false);
 
 		model.stick(input1);
 
-		assert.strictEqual(stickyFilteredEditorGroup.isEmpty, false);
-		assert.strictEqual(unstickyFilteredEditorGroup.isEmpty, false);
+		assert.strictEqual(stickyFilteredEditorGroup.count === 0, false);
+		assert.strictEqual(unstickyFilteredEditorGroup.count === 0, false);
 
 		model.stick(input2);
 
-		assert.strictEqual(stickyFilteredEditorGroup.isEmpty, false);
-		assert.strictEqual(unstickyFilteredEditorGroup.isEmpty, true);
+		assert.strictEqual(stickyFilteredEditorGroup.count === 0, false);
+		assert.strictEqual(unstickyFilteredEditorGroup.count === 0, true);
 	});
 
 	test('Sticky/Unsticky editors', async () => {


### PR DESCRIPTION
My feeling is that the filtered editor groups model can still be tweaked further to make lookup times minimal. Especially in cases where we can leverage the `editorIndex`, we avoid a loop over all editors because with an index in hand we do not have to find the editor in the first place.

Opening this as draft because I want to invite you to also think about further tweaks if possible.