### PR TITLE
for screen reader users, use `cmd+r` for mac `Run recent command` 

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminalActions.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalActions.ts
@@ -365,7 +365,6 @@ export function registerTerminalActions() {
 		keybinding: [
 			{
 				primary: KeyMod.CtrlCmd | KeyCode.KeyR,
-				mac: { primary: KeyMod.WinCtrl | KeyCode.KeyR },
 				when: ContextKeyExpr.and(TerminalContextKeys.focus, CONTEXT_ACCESSIBILITY_MODE_ENABLED),
 				weight: KeybindingWeight.WorkbenchContrib
 			},


### PR DESCRIPTION
Only conflict with this that I saw was in OSS, where that reloads the window instead of running recent command in screen reader mode. I don't think that's a big issue.
fix #189340