### PR TITLE
eng: add io warmup for webkit tests in ci

### DIFF
--- a/src/vs/workbench/contrib/notebook/test/browser/notebookStickyScroll.test.ts
+++ b/src/vs/workbench/contrib/notebook/test/browser/notebookStickyScroll.test.ts
@@ -6,7 +6,6 @@
 import * as assert from 'assert';
 import { Event } from 'vs/base/common/event';
 import { DisposableStore } from 'vs/base/common/lifecycle';
-import { isWeb } from 'vs/base/common/platform';
 import { mock } from 'vs/base/test/common/mock';
 import { assertSnapshot } from 'vs/base/test/common/snapshot';
 import { ensureNoDisposablesAreLeakedInTestSuite } from 'vs/base/test/common/utils';
@@ -20,8 +19,7 @@ import { CellKind } from 'vs/workbench/contrib/notebook/common/notebookCommon';
 import { createNotebookCellList, setupInstantiationService, withTestNotebook } from 'vs/workbench/contrib/notebook/test/browser/testNotebookEditor';
 import { OutlineTarget } from 'vs/workbench/services/outline/browser/outline';
 
-
-(isWeb ? suite.skip : suite)('NotebookEditorStickyScroll', () => {
+suite('NotebookEditorStickyScroll', () => {
 	let disposables: DisposableStore;
 	let instantiationService: TestInstantiationService;
 

--- a/test/unit/browser/index.js
+++ b/test/unit/browser/index.js
@@ -132,13 +132,15 @@ async function runTestsInBrowser(testModules, browserType) {
 	const page = await context.newPage();
 	const target = url.pathToFileURL(path.join(__dirname, 'renderer.html'));
 	if (argv.build) {
-		if (process.env.BUILD_ARTIFACTSTAGINGDIRECTORY) {
-			target.search = `?build=true&ci=true`;
-		} else {
-			target.search = `?build=true`;
-		}
-	} else if (process.env.BUILD_ARTIFACTSTAGINGDIRECTORY) {
-		target.search = `?ci=true`;
+		target.searchParams.set('build', 'true');
+	}
+	if (process.env.BUILD_ARTIFACTSTAGINGDIRECTORY) {
+		target.searchParams.set('ci', 'true');
+	}
+
+	// see comment on warmupExposedMethods in renderer.html for what's going on
+	if (browserType === 'webkit') {
+		target.searchParams.set('ioWarmup', __dirname);
 	}
 
 	const emitter = new events.EventEmitter();

--- a/test/unit/browser/renderer.html
+++ b/test/unit/browser/renderer.html
@@ -129,8 +129,25 @@
 			}
 		}
 
+		/**
+		 * There is some bug in WebKit on macOS in CI only that causes the first
+		 * invokation of the file functions to (sometimes) take an inordinately
+		 * long period of time to run. Get around this by invoking them here.
+		 */
+		async function doIoWarmup() {
+			const dir = url.searchParams.get('ioWarmup');
+			if (!dir) {
+				return;
+			}
+
+			// these are the only two functions actually used in CI presently:
+			await __readFileInTests(dir + '/' + 'renderer.html');
+			await __readDirInTests(dir);
+		}
+
 		window.loadAndRun = async function loadAndRun({ modules, grep }, manual = false) {
 			// load
+			await doIoWarmup();
 			await loadModules(modules);
 			// await new Promise((resolve, reject) => {
 			// 	require(modules, resolve, err => {
@@ -152,7 +169,8 @@
 			});
 		}
 
-		const modules = new URL(window.location.href).searchParams.getAll('m');
+		const url = new URL(window.location.href);
+		const modules = url.searchParams.getAll('m');
 		if (Array.isArray(modules) && modules.length > 0) {
 			console.log('MANUALLY running tests', modules);
 


### PR DESCRIPTION
Should fix the issue that @roblourens and @Yoyokrazy were hitting with snapshot tests on macOS WebKit in CI. Not pretty, but I'd rather do this than spend a bunch of time chasing down something that certainly seems to be a browser issue.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
