### PR TITLE
[Accessibility] ctrl+k, ctrl+shift+n does not open actionable notification items (fix #193715)

### DIFF
--- a/src/vs/workbench/browser/parts/notifications/notificationsCommands.ts
+++ b/src/vs/workbench/browser/parts/notifications/notificationsCommands.ts
@@ -93,7 +93,6 @@ export function registerNotificationCommands(center: INotificationsCenterControl
 	KeybindingsRegistry.registerCommandAndKeybindingRule({
 		id: SHOW_NOTIFICATIONS_CENTER,
 		weight: KeybindingWeight.WorkbenchContrib,
-		when: NotificationsCenterVisibleContext.negate(),
 		primary: KeyChord(KeyMod.CtrlCmd | KeyCode.KeyK, KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KeyN),
 		handler: () => {
 			toasts.hide();


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
