### PR TITLE
editors - further improve `isFirst` and `isLast` and add test for `sticky: true` with `index`

### DIFF
--- a/src/vs/workbench/common/editor/editorGroupModel.ts
+++ b/src/vs/workbench/common/editor/editorGroupModel.ts
@@ -174,14 +174,14 @@ export interface IReadonlyEditorGroupModel {
 	readonly activeEditor: EditorInput | null;
 	readonly previewEditor: EditorInput | null;
 
-	getEditors(order: EditorsOrder, options?: { excludeSticky?: boolean }): readonly EditorInput[];
+	getEditors(order: EditorsOrder, options?: { excludeSticky?: boolean }): EditorInput[];
 	getEditorByIndex(index: number): EditorInput | undefined;
 	indexOf(editor: EditorInput | IUntypedEditorInput | null, editors?: EditorInput[], options?: IMatchEditorOptions): number;
 	isActive(editor: EditorInput | IUntypedEditorInput): boolean;
 	isPinned(editorOrIndex: EditorInput | number): boolean;
 	isSticky(editorOrIndex: EditorInput | number): boolean;
-	isFirst(editor: EditorInput): boolean;
-	isLast(editor: EditorInput): boolean;
+	isFirst(editor: EditorInput, editors?: EditorInput[]): boolean;
+	isLast(editor: EditorInput, editors?: EditorInput[]): boolean;
 	findEditor(editor: EditorInput | null, options?: IMatchEditorOptions): [EditorInput, number /* index */] | undefined;
 	contains(editor: EditorInput | IUntypedEditorInput, options?: IMatchEditorOptions): boolean;
 }
@@ -937,19 +937,19 @@ export class EditorGroupModel extends Disposable implements IEditorGroupModel {
 		return [this.editors[index], index];
 	}
 
-	isFirst(candidate: EditorInput | null): boolean {
-		return this.matches(this.editors[0], candidate);
+	isFirst(candidate: EditorInput | null, editors = this.editors): boolean {
+		return this.matches(editors[0], candidate);
 	}
 
-	isLast(candidate: EditorInput | null): boolean {
-		return this.matches(this.editors[this.editors.length - 1], candidate);
+	isLast(candidate: EditorInput | null, editors = this.editors): boolean {
+		return this.matches(editors[editors.length - 1], candidate);
 	}
 
 	contains(candidate: EditorInput | IUntypedEditorInput, options?: IMatchEditorOptions): boolean {
 		return this.indexOf(candidate, this.editors, options) !== -1;
 	}
 
-	private matches(editor: EditorInput | null, candidate: EditorInput | IUntypedEditorInput | null, options?: IMatchEditorOptions): boolean {
+	private matches(editor: EditorInput | null | undefined, candidate: EditorInput | IUntypedEditorInput | null, options?: IMatchEditorOptions): boolean {
 		if (!editor || !candidate) {
 			return false;
 		}

--- a/src/vs/workbench/common/editor/filteredEditorGroupModel.ts
+++ b/src/vs/workbench/common/editor/filteredEditorGroupModel.ts
@@ -41,7 +41,15 @@ abstract class FilteredEditorGroupModel extends Disposable implements IReadonlyE
 	isSticky(editorOrIndex: EditorInput | number): boolean { return this.model.isSticky(editorOrIndex); }
 	isActive(editor: EditorInput | IUntypedEditorInput): boolean { return this.model.isActive(editor); }
 
-	getEditors(order: EditorsOrder, options?: { excludeSticky?: boolean }): readonly EditorInput[] {
+	isFirst(editor: EditorInput): boolean {
+		return this.model.isFirst(editor, this.getEditors(EditorsOrder.SEQUENTIAL));
+	}
+
+	isLast(editor: EditorInput): boolean {
+		return this.model.isLast(editor, this.getEditors(EditorsOrder.SEQUENTIAL));
+	}
+
+	getEditors(order: EditorsOrder, options?: { excludeSticky?: boolean }): EditorInput[] {
 		const editors = this.model.getEditors(order, options);
 		return editors.filter(e => this.filter(e));
 	}
@@ -56,8 +64,6 @@ abstract class FilteredEditorGroupModel extends Disposable implements IReadonlyE
 
 	abstract get count(): number;
 
-	abstract isFirst(editor: EditorInput): boolean;
-	abstract isLast(editor: EditorInput): boolean;
 	abstract getEditorByIndex(index: number): EditorInput | undefined;
 	abstract indexOf(editor: EditorInput | IUntypedEditorInput | null, editors?: EditorInput[], options?: IMatchEditorOptions): number;
 	abstract contains(editor: EditorInput | IUntypedEditorInput, options?: IMatchEditorOptions): boolean;
@@ -68,7 +74,7 @@ abstract class FilteredEditorGroupModel extends Disposable implements IReadonlyE
 export class StickyEditorGroupModel extends FilteredEditorGroupModel {
 	get count(): number { return this.model.stickyCount; }
 
-	override getEditors(order: EditorsOrder, options?: { excludeSticky?: boolean }): readonly EditorInput[] {
+	override getEditors(order: EditorsOrder, options?: { excludeSticky?: boolean }): EditorInput[] {
 		if (options?.excludeSticky) {
 			return [];
 		}
@@ -80,14 +86,6 @@ export class StickyEditorGroupModel extends FilteredEditorGroupModel {
 
 	override isSticky(editorOrIndex: number | EditorInput): boolean {
 		return true;
-	}
-
-	isFirst(editor: EditorInput): boolean {
-		return this.model.isFirst(editor);
-	}
-
-	isLast(editor: EditorInput): boolean {
-		return this.model.indexOf(editor) === this.model.stickyCount - 1;
 	}
 
 	getEditorByIndex(index: number): EditorInput | undefined {
@@ -120,19 +118,11 @@ export class UnstickyEditorGroupModel extends FilteredEditorGroupModel {
 		return false;
 	}
 
-	override getEditors(order: EditorsOrder, options?: { excludeSticky?: boolean }): readonly EditorInput[] {
+	override getEditors(order: EditorsOrder, options?: { excludeSticky?: boolean }): EditorInput[] {
 		if (order === EditorsOrder.SEQUENTIAL) {
 			return this.model.getEditors(EditorsOrder.SEQUENTIAL).slice(this.model.stickyCount);
 		}
 		return super.getEditors(order, options);
-	}
-
-	isFirst(editor: EditorInput): boolean {
-		return this.model.indexOf(editor) === this.model.stickyCount;
-	}
-
-	isLast(editor: EditorInput): boolean {
-		return this.model.isLast(editor);
 	}
 
 	getEditorByIndex(index: number): EditorInput | undefined {

--- a/src/vs/workbench/services/editor/test/browser/editorGroupsService.test.ts
+++ b/src/vs/workbench/services/editor/test/browser/editorGroupsService.test.ts
@@ -1455,6 +1455,28 @@ suite('EditorGroupsService', () => {
 		editorGroupModelChangeListener.dispose();
 	});
 
+	test('sticky: true wins over index', async () => {
+		const [part] = await createPart();
+		const group = part.activeGroup;
+
+		assert.strictEqual(group.stickyCount, 0);
+
+		const input = createTestFileEditorInput(URI.file('foo/bar'), TEST_EDITOR_INPUT_ID);
+		const inputInactive = createTestFileEditorInput(URI.file('foo/bar/inactive'), TEST_EDITOR_INPUT_ID);
+		const inputSticky = createTestFileEditorInput(URI.file('foo/bar/sticky'), TEST_EDITOR_INPUT_ID);
+
+		await group.openEditor(input, { pinned: true });
+		await group.openEditor(inputInactive, { inactive: true });
+		await group.openEditor(inputSticky, { sticky: true, index: 2 });
+
+		assert.strictEqual(group.stickyCount, 1);
+		assert.strictEqual(group.isSticky(inputSticky), true);
+
+		assert.strictEqual(group.getIndexOfEditor(input), 1);
+		assert.strictEqual(group.getIndexOfEditor(inputInactive), 2);
+		assert.strictEqual(group.getIndexOfEditor(inputSticky), 0);
+	});
+
 	test('moveEditor with context (across groups)', async () => {
 		const [part] = await createPart();
 		const group = part.activeGroup;


### PR DESCRIPTION
Follow up from yesterdays call on how to further improve lookup times, this one is an easy one for `isLast` and `isFirst` and even allows to move the implementation up to the base class.