### PR TITLE
tabHeight setting name change

### DIFF
--- a/src/vs/platform/window/common/window.ts
+++ b/src/vs/platform/window/common/window.ts
@@ -137,6 +137,11 @@ export interface IWindowSettings {
 	readonly enableMenuBarMnemonics: boolean;
 	readonly closeWhenEmpty: boolean;
 	readonly clickThroughInactive: boolean;
+	readonly density: IDensitySettings;
+}
+
+export interface IDensitySettings {
+	editorTabHeight: 'default' | 'compact';
 }
 
 export function getTitleBarStyle(configurationService: IConfigurationService): 'native' | 'custom' {

--- a/src/vs/platform/window/common/window.ts
+++ b/src/vs/platform/window/common/window.ts
@@ -141,7 +141,7 @@ export interface IWindowSettings {
 }
 
 export interface IDensitySettings {
-	editorTabHeight: 'default' | 'compact';
+	readonly editorTabHeight: 'default' | 'compact';
 }
 
 export function getTitleBarStyle(configurationService: IConfigurationService): 'native' | 'custom' {

--- a/src/vs/workbench/browser/parts/editor/editor.ts
+++ b/src/vs/workbench/browser/parts/editor/editor.ts
@@ -15,6 +15,7 @@ import { ISerializableView } from 'vs/base/browser/ui/grid/grid';
 import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
 import { isObject } from 'vs/base/common/types';
 import { IEditorOptions } from 'vs/platform/editor/common/editor';
+import { IWindowsConfiguration } from 'vs/platform/window/common/window';
 
 export interface IEditorPartCreationOptions {
 	restorePreviousState: boolean;
@@ -32,7 +33,7 @@ export const DEFAULT_EDITOR_PART_OPTIONS: IEditorPartOptions = {
 	tabSizingFixedMaxWidth: 160,
 	pinnedTabSizing: 'normal',
 	pinnedTabsOnSeparateRow: false,
-	tabHeight: 'normal',
+	tabHeight: 'default',
 	preventPinnedEditorClose: 'keyboardAndMouse',
 	titleScrollbarSizing: 'default',
 	focusRecentEditorAfterClose: true,
@@ -50,7 +51,7 @@ export const DEFAULT_EDITOR_PART_OPTIONS: IEditorPartOptions = {
 };
 
 export function impactsEditorPartOptions(event: IConfigurationChangeEvent): boolean {
-	return event.affectsConfiguration('workbench.editor') || event.affectsConfiguration('workbench.iconTheme');
+	return event.affectsConfiguration('workbench.editor') || event.affectsConfiguration('workbench.iconTheme') || event.affectsConfiguration('window.density');
 }
 
 export function getEditorPartOptions(configurationService: IConfigurationService, themeService: IThemeService): IEditorPartOptions {
@@ -77,6 +78,11 @@ export function getEditorPartOptions(configurationService: IConfigurationService
 		} else {
 			options.autoLockGroups = undefined;
 		}
+	}
+
+	const windowConfig = configurationService.getValue<IWindowsConfiguration>();
+	if (windowConfig?.window?.density?.editorTabHeight !== undefined) {
+		options.tabHeight = windowConfig.window.density.editorTabHeight;
 	}
 
 	return options;
@@ -204,7 +210,7 @@ export interface IInternalEditorOpenOptions extends IInternalEditorTitleControlO
 	supportSideBySide?: SideBySideEditor.ANY | SideBySideEditor.BOTH;
 
 	/**
-	 * When set to `true`, pass DOM focus into the tab control. 
+	 * When set to `true`, pass DOM focus into the tab control.
 	 */
 	focusTabControl?: boolean;
 }

--- a/src/vs/workbench/browser/parts/editor/editor.ts
+++ b/src/vs/workbench/browser/parts/editor/editor.ts
@@ -81,7 +81,7 @@ export function getEditorPartOptions(configurationService: IConfigurationService
 	}
 
 	const windowConfig = configurationService.getValue<IWindowsConfiguration>();
-	if (windowConfig?.window?.density?.editorTabHeight !== undefined) {
+	if (windowConfig?.window?.density?.editorTabHeight) {
 		options.tabHeight = windowConfig.window.density.editorTabHeight;
 	}
 

--- a/src/vs/workbench/browser/workbench.contribution.ts
+++ b/src/vs/workbench/browser/workbench.contribution.ts
@@ -165,10 +165,10 @@ const registry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Con
 				'minimum': 38,
 				'markdownDescription': localize({ comment: ['This is the description for a setting. Values surrounded by single quotes are not to be translated.'], key: 'workbench.editor.tabSizingFixedMaxWidth' }, "Controls the maximum width of tabs when `#workbench.editor.tabSizing#` size is set to `fixed`.")
 			},
-			'workbench.editor.tabHeight': {
+			'window.density.editorTabHeight': {
 				'type': 'string',
-				'enum': ['normal', 'compact'],
-				'default': 'normal',
+				'enum': ['default', 'compact'],
+				'default': 'default',
 				'markdownDescription': localize({ comment: ['This is the description for a setting. Values surrounded by single quotes are not to be translated.'], key: 'workbench.editor.tabHeight' }, "Controls the height of editor tabs. Also applies to the title control bar when `#workbench.editor.showTabs#` is disabled.")
 			},
 			'workbench.editor.pinnedTabSizing': {

--- a/src/vs/workbench/common/editor.ts
+++ b/src/vs/workbench/common/editor.ts
@@ -1100,7 +1100,7 @@ interface IEditorPartConfiguration {
 	tabSizingFixedMaxWidth?: number;
 	pinnedTabSizing?: 'normal' | 'compact' | 'shrink';
 	pinnedTabsOnSeparateRow?: boolean;
-	tabHeight?: 'normal' | 'compact';
+	tabHeight?: 'default' | 'compact';
 	preventPinnedEditorClose?: PreventPinnedEditorClose;
 	titleScrollbarSizing?: 'default' | 'large';
 	focusRecentEditorAfterClose?: boolean;


### PR DESCRIPTION
There are multiple ways of doing this. I added the density setting in `IWindowSettings`, however, IWorkbenchEditorConfiguration might also need to reference it as it forces us to do 2 configurationService lookups.

Maybe?:
```
export interface IWorkbenchEditorConfiguration {
	workbench?: {
		editor?: IEditorPartConfiguration;
		iconTheme?: string;
	};
	window?: {
		density?: {
			editorTabHeight: 'default' | 'compact';
		};
	};
}
```

#193660