### PR TITLE
Align open editors with explorer

### DIFF
--- a/src/vs/workbench/browser/parts/editor/editorCommands.ts
+++ b/src/vs/workbench/browser/parts/editor/editorCommands.ts
@@ -1521,7 +1521,7 @@ export function getMultiSelectedEditorContexts(editorContext: IEditorCommandsCon
 		if (focus) {
 			const selection: Array<IEditorIdentifier | IEditorGroup> = list.getSelectedElements().filter(onlyEditorGroupAndEditor);
 
-			if (selection.length > 0) {
+			if (selection.length > 1) {
 				return selection.map(elementToContext);
 			}
 


### PR DESCRIPTION
Fixes #193574

The UX is still not perfect here, as I feel if you explicilty click the X button it should close that entry, but instead it executes `closeActiveEditor`. This more closely aligns with what we do in the explorer at least so they're the same (except the explorer doesn't have an explicit button). If a selection is of length 1 we prefer focus, otherwise we're in a multi select context and should prefer the selection.