### PR TITLE
Restrict remote search provider to top 5

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/preferencesSearch.ts
+++ b/src/vs/workbench/contrib/preferences/browser/preferencesSearch.ts
@@ -354,7 +354,7 @@ class RemoteSearchKeysProvider {
 
 export class RemoteSearchProvider implements ISearchProvider {
 	private static readonly AI_RELATED_INFORMATION_THRESHOLD = 0.73;
-	private static readonly AI_RELATED_INFORMATION_MAX_PICKS = 10;
+	private static readonly AI_RELATED_INFORMATION_MAX_PICKS = 5;
 
 	private readonly _keysProvider: RemoteSearchKeysProvider;
 	private _filter: string = '';

--- a/src/vs/workbench/contrib/preferences/browser/preferencesSearch.ts
+++ b/src/vs/workbench/contrib/preferences/browser/preferencesSearch.ts
@@ -354,7 +354,7 @@ class RemoteSearchKeysProvider {
 
 export class RemoteSearchProvider implements ISearchProvider {
 	private static readonly AI_RELATED_INFORMATION_THRESHOLD = 0.73;
-	private static readonly AI_RELATED_INFORMATION_MAX_PICKS = 15;
+	private static readonly AI_RELATED_INFORMATION_MAX_PICKS = 10;
 
 	private readonly _keysProvider: RemoteSearchKeysProvider;
 	private _filter: string = '';


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Showing 15 remote settings at a time with a low threshold results in a lot of irrelevant settings for a user to scroll through. The scrolling is made worse by the fact that settings occupy more vertical space than commands. Instead of increasing the threshold directly, I'm limiting the remote results to the top 5 scoring ones.