### PR TITLE
revert default behavior back to previous

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/notebook.contribution.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebook.contribution.ts
@@ -1035,7 +1035,7 @@ configurationRegistry.registerConfiguration({
 			type: 'string',
 			enum: ['auto', 'true', 'false'],
 			markdownEnumDescriptions: [
-				nls.localize('notebook.scrolling.anchorToFocusedCell.auto.description', "Anchor to the focused cell unless {0} is set to {1}", 'notebook.scrolling.revealCellBehavior', 'none')
+				nls.localize('notebook.scrolling.anchorToFocusedCell.auto.description', "Anchor to the focused cell when the resized cell is partially visible unless {0} is set to {1}", 'notebook.scrolling.revealCellBehavior', 'none')
 			],
 			default: 'auto'
 		}

--- a/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
@@ -2384,6 +2384,8 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditorD
 					this.revealInView(cell);
 				} else if (options?.revealBehavior === ScrollToRevealBehavior.firstLine) {
 					this.revealFirstLineIfOutsideViewport(cell);
+				} else if (options?.revealBehavior === ScrollToRevealBehavior.fullCell) {
+					this.revealInView(cell);
 				} else {
 					this.revealInCenterIfOutsideViewport(cell);
 				}

--- a/src/vs/workbench/contrib/notebook/browser/view/notebookCellList.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/notebookCellList.ts
@@ -1205,10 +1205,14 @@ export class NotebookCellList extends WorkbenchList<CellViewModel> implements ID
 		const focused = this.getFocus();
 		const focus = focused.length ? focused[0] : null;
 
+		if (this.view.elementTop(index) >= this.view.getScrollTop()) {
+			return this.view.updateElementHeight(index, size, index);
+		}
+
 		const anchorFocusedSetting = this.configurationService.getValue(NotebookSetting.anchorToFocusedCell);
 		const allowScrolling = this.configurationService.getValue(NotebookSetting.scrollToRevealCell) !== 'none';
-		const anchorToFocusedCell = anchorFocusedSetting === 'true' || (allowScrolling && anchorFocusedSetting !== 'false');
-		if (focused && anchorToFocusedCell) {
+		const scrollHeuristic = allowScrolling && anchorFocusedSetting === 'auto' && this.view.elementTop(index) < this.view.getScrollTop();
+		if (focused && (anchorFocusedSetting === 'true' || scrollHeuristic)) {
 			this.view.updateElementHeight(index, size, focus);
 		}
 

--- a/src/vs/workbench/contrib/notebook/test/browser/notebookCellList.test.ts
+++ b/src/vs/workbench/contrib/notebook/test/browser/notebookCellList.test.ts
@@ -6,8 +6,10 @@
 import * as assert from 'assert';
 import { DisposableStore } from 'vs/base/common/lifecycle';
 import { ensureNoDisposablesAreLeakedInTestSuite } from 'vs/base/test/common/utils';
+import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
+import { TestConfigurationService } from 'vs/platform/configuration/test/common/testConfigurationService';
 import { TestInstantiationService } from 'vs/platform/instantiation/test/common/instantiationServiceMock';
-import { CellKind } from 'vs/workbench/contrib/notebook/common/notebookCommon';
+import { CellKind, NotebookSetting } from 'vs/workbench/contrib/notebook/common/notebookCommon';
 import { createNotebookCellList, setupInstantiationService, withTestNotebook } from 'vs/workbench/contrib/notebook/test/browser/testNotebookEditor';
 
 suite('NotebookCellList', () => {
@@ -23,6 +25,10 @@ suite('NotebookCellList', () => {
 	setup(() => {
 		testDisposables = new DisposableStore();
 		instantiationService = setupInstantiationService(testDisposables);
+		const config = new TestConfigurationService({
+			[NotebookSetting.anchorToFocusedCell]: 'auto'
+		});
+		instantiationService.stub(IConfigurationService, config);
 	});
 
 	test('revealElementsInView: reveal fully visible cell should not scroll', async function () {


### PR DESCRIPTION
adjusting for feedback on https://github.com/microsoft/vscode/issues/193231#issuecomment-1733046390

- Go back to minimal scrolling to reveal the full next cell since it behaves better for the more common case.
- The default "auto" `anchorFocusedElement` setting will now behave as it did previously: focused the anchored cell if the one resizing is only partially visible