### PR TITLE
File > Open Recent > recent workspace no longet opens in new window when Ctrl or Shift used in VS Code Insiders (fix #193997)

### DIFF
--- a/src/vs/base/common/actions.ts
+++ b/src/vs/base/common/actions.ts
@@ -265,7 +265,7 @@ export function toAction(props: { id: string; label: string; enabled?: boolean; 
 		class: undefined,
 		enabled: props.enabled ?? true,
 		checked: props.checked ?? false,
-		run: async (...args: unknown[]) => props.run(),
+		run: async (...args: unknown[]) => props.run(...args),
 		tooltip: props.label
 	};
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
