### PR TITLE
Add aria labels in issue reporter

### DIFF
--- a/src/vs/code/electron-sandbox/issue/issueReporterPage.ts
+++ b/src/vs/code/electron-sandbox/issue/issueReporterPage.ts
@@ -11,6 +11,9 @@ const sendProcessInfoLabel = escape(localize('sendProcessInfo', "Include my curr
 const sendWorkspaceInfoLabel = escape(localize('sendWorkspaceInfo', "Include my workspace metadata"));
 const sendExtensionsLabel = escape(localize('sendExtensions', "Include my enabled extensions"));
 const sendExperimentsLabel = escape(localize('sendExperiments', "Include A/B experiment info"));
+const issueTypeLabel = escape(localize('issueTypeLabel', "This is a"));
+const issueSourceLabel = escape(localize('issueSourceLabel', "File on"));
+const issueTitleLabel = escape(localize('issueTitleLabel', "Title"));
 const reviewGuidanceLabel = localize( // intentionally not escaped because of its embedded tags
 	{
 		key: 'reviewGuidanceLabel',
@@ -30,15 +33,15 @@ export default (): string => `
 
 	<div class="section">
 		<div class="input-group">
-			<label class="inline-label" for="issue-type">${escape(localize('issueTypeLabel', "This is a"))}</label>
-			<select id="issue-type" class="inline-form-control">
+			<label class="inline-label" for="issue-type">${issueTypeLabel}</label>
+			<select id="issue-type" class="inline-form-control" aria-label="${issueTypeLabel}">
 				<!-- To be dynamically filled -->
 			</select>
 		</div>
 
 		<div class="input-group" id="problem-source">
-			<label class="inline-label" for="issue-source">${escape(localize('issueSourceLabel', "File on"))} <span class="required-input">*</span></label>
-			<select id="issue-source" class="inline-form-control" required>
+			<label class="inline-label" for="issue-source">${issueSourceLabel} <span class="required-input">*</span></label>
+			<select id="issue-source" class="inline-form-control" required aria-label="${issueSourceLabel}">
 				<!-- To be dynamically filled -->
 			</select>
 			<div id="issue-source-empty-error" class="validation-error hidden" role="alert">${escape(localize('issueSourceEmptyValidation', "An issue source is required."))}</div>
@@ -60,8 +63,8 @@ export default (): string => `
 		</div>
 
 		<div id="issue-title-container" class="input-group">
-			<label class="inline-label" for="issue-title">${escape(localize('issueTitleLabel', "Title"))} <span class="required-input">*</span></label>
-			<input id="issue-title" type="text" class="inline-form-control" placeholder="${escape(localize('issueTitleRequired', "Please enter a title."))}" required>
+			<label class="inline-label" for="issue-title">${issueTitleLabel} <span class="required-input">*</span></label>
+			<input id="issue-title" type="text" class="inline-form-control" placeholder="${escape(localize('issueTitleRequired', "Please enter a title."))}" required aria-label="${issueTitleLabel}">
 			<div id="issue-title-empty-error" class="validation-error hidden" role="alert">${escape(localize('titleEmptyValidation', "A title is required."))}</div>
 			<div id="issue-title-length-validation-error" class="validation-error hidden" role="alert">${escape(localize('titleLengthValidation', "The title is too long."))}</div>
 			<small id="similar-issues">

--- a/src/vs/code/electron-sandbox/issue/issueReporterService.ts
+++ b/src/vs/code/electron-sandbox/issue/issueReporterService.ts
@@ -728,6 +728,8 @@ export class IssueReporter extends Disposable {
 			return;
 		}
 
+		const stepsToReproduce = localize('stepsToReproduce', "Steps to Reproduce");
+
 		if (issueType === IssueType.Bug) {
 			if (!fileOnMarketplace) {
 				show(blockContainer);
@@ -738,8 +740,9 @@ export class IssueReporter extends Disposable {
 				}
 			}
 
-			reset(descriptionTitle, localize('stepsToReproduce', "Steps to Reproduce") + ' ', $('span.required-input', undefined, '*'));
+			reset(descriptionTitle, stepsToReproduce + ' ', $('span.required-input', undefined, '*'));
 			reset(descriptionSubtitle, localize('bugDescription', "Share the steps needed to reliably reproduce the problem. Please include actual and expected results. We support GitHub-flavored Markdown. You will be able to edit your issue and add screenshots when we preview it on GitHub."));
+			descriptionTextArea.ariaLabel = stepsToReproduce;
 		} else if (issueType === IssueType.PerformanceIssue) {
 			if (!fileOnMarketplace) {
 				show(blockContainer);
@@ -755,11 +758,14 @@ export class IssueReporter extends Disposable {
 				show(extensionsBlock);
 			}
 
-			reset(descriptionTitle, localize('stepsToReproduce', "Steps to Reproduce") + ' ', $('span.required-input', undefined, '*'));
+			reset(descriptionTitle, stepsToReproduce + ' ', $('span.required-input', undefined, '*'));
 			reset(descriptionSubtitle, localize('performanceIssueDesciption', "When did this performance issue happen? Does it occur on startup or after a specific series of actions? We support GitHub-flavored Markdown. You will be able to edit your issue and add screenshots when we preview it on GitHub."));
+			descriptionTextArea.ariaLabel = stepsToReproduce;
 		} else if (issueType === IssueType.FeatureRequest) {
-			reset(descriptionTitle, localize('description', "Description") + ' ', $('span.required-input', undefined, '*'));
+			const description = localize('description', "Description");
+			reset(descriptionTitle, description + ' ', $('span.required-input', undefined, '*'));
 			reset(descriptionSubtitle, localize('featureRequestDescription', "Please describe the feature you would like to see. We support GitHub-flavored Markdown. You will be able to edit your issue and add screenshots when we preview it on GitHub."));
+			descriptionTextArea.ariaLabel = description;
 		}
 	}
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
Fixes #194075. This add aria labels to the dropdowns and input boxes in the Issue Reporter so that screen readers announce both the labels and values of these fields. Previously only the values were announced, which impacts screen readers users as they will not be able to get the complete information about the dropdowns and input boxes on the issue reporter window.

Before - only content of combo boxes and input boxes are announced:
![issueReporterAriaLabelsVscode](https://github.com/microsoft/vscode/assets/31145923/b10b88c4-ca58-499e-9146-f9214da91b6e)

After - label and content are announced:
![issueReporterAriaLabelsFixed](https://github.com/microsoft/vscode/assets/31145923/2913b35b-3ebd-44c2-ac55-f89e6e544d16)
