### PR TITLE
Swap erroneous `super.` access to `this.`

### DIFF
--- a/src/vs/workbench/api/common/extHostTesting.ts
+++ b/src/vs/workbench/api/common/extHostTesting.ts
@@ -920,7 +920,7 @@ class MirroredTestCollection extends AbstractIncrementalTestCollection<MirroredC
 	 * Gets a list of root test items.
 	 */
 	public get rootTests() {
-		return super.roots;
+		return this.roots;
 	}
 
 	/**


### PR DESCRIPTION
Thanks to https://github.com/microsoft/TypeScript/pull/54056, TypeScript now detects and appropriately errors on accesses of instance properties through `super`. These accesses do not work at runtime at all.

https://github.com/microsoft/TypeScript/issues/55848 ran TypeScript nightly and found that VS Code has at least this occurrence of `super.instanceProperty`.