### PR TITLE
Navigating to previous comment thread with shift+alt+f9 does not work on Linux

### DIFF
--- a/src/vs/workbench/contrib/comments/browser/commentsEditorContribution.ts
+++ b/src/vs/workbench/contrib/comments/browser/commentsEditorContribution.ts
@@ -43,7 +43,6 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 		controller.nextCommentThread();
 	},
 	weight: KeybindingWeight.EditorContrib,
-	when: EditorContextKeys.focus,
 	primary: KeyMod.Alt | KeyCode.F9,
 });
 
@@ -62,7 +61,6 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 		controller.previousCommentThread();
 	},
 	weight: KeybindingWeight.EditorContrib,
-	when: EditorContextKeys.focus,
 	primary: KeyMod.Shift | KeyMod.Alt | KeyCode.F9
 });
 


### PR DESCRIPTION
Fixes #194182