### PR TITLE
fix #194202

### DIFF
--- a/src/vs/workbench/browser/parts/editor/media/multieditortabscontrol.css
+++ b/src/vs/workbench/browser/parts/editor/media/multieditortabscontrol.css
@@ -193,7 +193,8 @@
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container.disable-sticky-tabs > .tab.sizing-fit.sticky-shrink,
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container.disable-sticky-tabs > .tab.sizing-shrink.sticky-shrink,
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container.disable-sticky-tabs > .tab.sizing-fixed.sticky-shrink {
-	position: static; /** disable sticky positions for sticky compact/shrink/fixed tabs if the available space is too little */
+	position: relative; /** disable sticky positions for sticky compact/shrink/fixed tabs if the available space is too little */
+	left: 0 !important;
 }
 
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.sizing-shrink.tab-actions-left::after,

--- a/src/vs/workbench/browser/parts/editor/media/multieditortabscontrol.css
+++ b/src/vs/workbench/browser/parts/editor/media/multieditortabscontrol.css
@@ -193,8 +193,15 @@
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container.disable-sticky-tabs > .tab.sizing-fit.sticky-shrink,
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container.disable-sticky-tabs > .tab.sizing-shrink.sticky-shrink,
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container.disable-sticky-tabs > .tab.sizing-fixed.sticky-shrink {
-	position: relative; /** disable sticky positions for sticky compact/shrink/fixed tabs if the available space is too little */
-	left: 0 !important;
+
+	/**
+	 * If sticky tabs are explicitly disabled, because width is too little, make sure
+	 * to reset all styles associated with sticky tabs. This includes position, z-index
+	 * and left property (which is set on the element itself, hence important is needed).
+	 */
+	position: relative;
+	z-index: unset;
+	left: unset !important;
 }
 
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.sizing-shrink.tab-actions-left::after,


### PR DESCRIPTION
#194202

Change positio from static to relative as the tab border is set with absolut positioning. Makes sure to overwrite style.left set on the HTML element itself