### PR TITLE
Re #194114. EmptyCellEditorHint in insiders only

### DIFF
--- a/src/vs/workbench/contrib/codeEditor/browser/emptyTextEditorHint/emptyTextEditorHint.ts
+++ b/src/vs/workbench/contrib/codeEditor/browser/emptyTextEditorHint/emptyTextEditorHint.ts
@@ -69,7 +69,7 @@ export class EmptyTextEditorHintContribution implements IEditorContribution {
 		@IInlineChatSessionService inlineChatSessionService: IInlineChatSessionService,
 		@IInlineChatService protected readonly inlineChatService: IInlineChatService,
 		@ITelemetryService private readonly telemetryService: ITelemetryService,
-		@IProductService private readonly productService: IProductService,
+		@IProductService protected readonly productService: IProductService,
 	) {
 		this.toDispose = [];
 		this.toDispose.push(this.editor.onDidChangeModel(() => this.update()));

--- a/src/vs/workbench/contrib/notebook/browser/contrib/editorHint/emptyCellEditorHint.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/editorHint/emptyCellEditorHint.ts
@@ -54,6 +54,11 @@ export class EmptyCellEditorHintContribution extends EmptyTextEditorHintContribu
 	}
 
 	protected override _shouldRenderHint(): boolean {
+		// TODO@rebornix, remove this when we have a better way to present the editor hints in empty cells
+		if (this.productService.quality === 'stable') {
+			return false;
+		}
+
 		const shouldRenderHint = super._shouldRenderHint();
 		if (!shouldRenderHint) {
 			return false;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

It's too late to make improvements to the wording or rendering of the editor hint in notebook cell. Disable it for Stable.