### PR TITLE
Don't show tips in watermark if keys are unbound

### DIFF
--- a/src/vs/workbench/browser/parts/editor/editorGroupWatermark.ts
+++ b/src/vs/workbench/browser/parts/editor/editorGroupWatermark.ts
@@ -141,12 +141,16 @@ export class EditorGroupWatermark extends Disposable {
 		const update = () => {
 			clearNode(box);
 			selected.map(entry => {
+				const keys = this.keybindingService.lookupKeybinding(entry.id);
+				if (!keys) {
+					return;
+				}
 				const dl = append(box, $('dl'));
 				const dt = append(dl, $('dt'));
 				dt.textContent = entry.text;
 				const dd = append(dl, $('dd'));
 				const keybinding = new KeybindingLabel(dd, OS, { renderUnboundKeybindings: true, ...defaultKeybindingLabelStyles });
-				keybinding.set(this.keybindingService.lookupKeybinding(entry.id));
+				keybinding.set(keys);
 			});
 		};
 


### PR DESCRIPTION
Fixes: https://github.com/microsoft/vscode/issues/192923