### PR TITLE
fix: restore slash command input border radius

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/contrib/chatInputEditorContrib.ts
+++ b/src/vs/workbench/contrib/chat/browser/contrib/chatInputEditorContrib.ts
@@ -76,7 +76,8 @@ class InputEditorDecorations extends Disposable {
 		const theme = this.themeService.getColorTheme();
 		this.codeEditorService.registerDecorationType(decorationDescription, slashCommandTextDecorationType, {
 			color: theme.getColor(chatSlashCommandForeground)?.toString(),
-			backgroundColor: theme.getColor(chatSlashCommandBackground)?.toString()
+			backgroundColor: theme.getColor(chatSlashCommandBackground)?.toString(),
+			borderRadius: '3px'
 		});
 		this.codeEditorService.registerDecorationType(decorationDescription, variableTextDecorationType, {
 			color: theme.getColor(chatSlashCommandForeground)?.toString(),


### PR DESCRIPTION
fyi @roblourens I assume this wasn't intentional as part of https://github.com/microsoft/vscode/commit/bc6b75eb2c93aa375f71ec75bd6b71159b25772a since slash commands still have a radius in rendered requests