### PR TITLE
fix syntax highlighting for SCSS when at-rule lacks semicolon

### DIFF
--- a/extensions/scss/syntaxes/scss.tmLanguage.json
+++ b/extensions/scss/syntaxes/scss.tmLanguage.json
@@ -105,7 +105,7 @@
 					"name": "keyword.control.content.scss"
 				}
 			},
-			"end": "\\s*((?=;))",
+			"end": "\\s*((?=[;}]))",
 			"name": "meta.content.scss",
 			"patterns": [
 				{
@@ -797,7 +797,7 @@
 					"name": "punctuation.definition.keyword.scss"
 				}
 			},
-			"end": "\\s*((?=;))",
+			"end": "\\s*((?=[;}]))",
 			"name": "meta.at-rule.return.scss",
 			"patterns": [
 				{


### PR DESCRIPTION
SCSS syntax highlighting breaks when the at-rules `@content` and `@return` lack semicolons, despite it being legal syntactically to omit them. 

See:

<img src="https://github.com/sass/sass-spec/assets/39542938/39daefc1-a941-44f5-b5d4-c3f55e09efab" width="290">
<img src="https://github.com/sass/sass-spec/assets/39542938/bde09292-6f84-44a4-8011-732956955c0e" width="250">
 
This is a minimal example of the bug, where line 6 in the first image has the incorrect syntax highlighting. This bug interacts poorly with a number of other syntaxes; for example, highlighting will fail to recognize comments following such a rule.

There is a contributor note at the top of this file to edit the associated atom repo before making the change in vscode. The associated atom repo has been archived, so I am opening this PR here directly. 