### PR TITLE
Dropping a group on tab container append on both

### DIFF
--- a/src/vs/workbench/browser/parts/editor/multiEditorTabsControl.ts
+++ b/src/vs/workbench/browser/parts/editor/multiEditorTabsControl.ts
@@ -390,7 +390,7 @@ export class MultiEditorTabsControl extends EditorTabsControl {
 				tabsContainer.classList.remove('scroll');
 
 				if (e.target === tabsContainer) {
-					this.onDrop(e, this.tabsModel.count, tabsContainer);
+					this.onDrop(e, this.groupView.count, tabsContainer);
 				}
 			}
 		}));


### PR DESCRIPTION
Old: When dropping an editor group on the container of the pinned tab bar the unpinned tabs would PREPEND.

New: When dropping an editor group on the container of the pinned tab bar the unpinned tabs will APPEND.
