### PR TITLE
Remove comments continue on

### DIFF
--- a/src/vs/workbench/contrib/comments/browser/commentService.ts
+++ b/src/vs/workbench/contrib/comments/browser/commentService.ts
@@ -173,6 +173,9 @@ export class CommentService extends Disposable implements ICommentService {
 		const storageListener = this._register(new DisposableStore());
 
 		storageListener.add(this.storageService.onDidChangeValue(StorageScope.WORKSPACE, CONTINUE_ON_COMMENTS, storageListener)((v) => {
+			if (!this.configurationService.getValue<ICommentsConfiguration | undefined>(COMMENTS_SECTION)?.experimentalContinueOn) {
+				return;
+			}
 			if (!v.external) {
 				return;
 			}
@@ -193,6 +196,9 @@ export class CommentService extends Disposable implements ICommentService {
 			}
 		}));
 		this._register(storageService.onWillSaveState(() => {
+			if (!this.configurationService.getValue<ICommentsConfiguration | undefined>(COMMENTS_SECTION)?.experimentalContinueOn) {
+				return;
+			}
 			for (const provider of this._continueOnCommentProviders) {
 				const pendingComments = provider.provideContinueOnComments();
 				this._addContinueOnComments(pendingComments);

--- a/src/vs/workbench/contrib/comments/common/commentsConfiguration.ts
+++ b/src/vs/workbench/contrib/comments/common/commentsConfiguration.ts
@@ -9,6 +9,7 @@ export interface ICommentsConfiguration {
 	visible: boolean;
 	maxHeight: boolean;
 	collapseOnResolve: boolean;
+	experimentalContinueOn: boolean;
 }
 
 export const COMMENTS_SECTION = 'comments';


### PR DESCRIPTION
There's a URI issue in the data in the storage service for comments. Putting this feature behind a hidden setting for now so that we don't save incorrect data.