### PR TITLE
Update org in reference repo

### DIFF
--- a/extensions/r/cgmanifest.json
+++ b/extensions/r/cgmanifest.json
@@ -4,8 +4,8 @@
 			"component": {
 				"type": "git",
 				"git": {
-					"name": "Ikuyadeu/vscode-R",
-					"repositoryUrl": "https://github.com/Ikuyadeu/vscode-R",
+					"name": "REditorSupport/vscode-R",
+					"repositoryUrl": "https://github.com/REditorSupport/vscode-R",
 					"commitHash": "ff60e426f66503f3c9533c7a62a8fd3f9f6c53df"
 				}
 			},

--- a/extensions/r/package.json
+++ b/extensions/r/package.json
@@ -9,7 +9,7 @@
     "vscode": "*"
   },
   "scripts": {
-    "update-grammar": "node ../node_modules/vscode-grammar-updater/bin Ikuyadeu/vscode-R syntax/r.json ./syntaxes/r.tmLanguage.json"
+    "update-grammar": "node ../node_modules/vscode-grammar-updater/bin REditorSupport/vscode-R syntax/r.json ./syntaxes/r.tmLanguage.json"
   },
   "contributes": {
     "languages": [

--- a/extensions/r/syntaxes/r.tmLanguage.json
+++ b/extensions/r/syntaxes/r.tmLanguage.json
@@ -1,10 +1,10 @@
 {
 	"information_for_contributors": [
-		"This file has been converted from https://github.com/Ikuyadeu/vscode-R/blob/master/syntax/r.json",
+		"This file has been converted from https://github.com/REditorSupport/vscode-R/blob/master/syntax/r.json",
 		"If you want to provide a fix or improvement, please create a pull request against the original repository.",
 		"Once accepted there, we are happy to receive an update request."
 	],
-	"version": "https://github.com/Ikuyadeu/vscode-R/commit/ff60e426f66503f3c9533c7a62a8fd3f9f6c53df",
+	"version": "https://github.com/REditorSupport/vscode-R/commit/ff60e426f66503f3c9533c7a62a8fd3f9f6c53df",
 	"name": "R",
 	"scopeName": "source.r",
 	"patterns": [


### PR DESCRIPTION
This threw me off in #194352 -- I was not familiar with the original repo owner so I assumed this info was stale. The link now redirects to the REditorSupport org, but having the correct source in the plain text is still preferable for human readers.