### PR TITLE
pin to top if revealed element is larger than viewport

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/view/notebookCellList.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/notebookCellList.ts
@@ -830,7 +830,9 @@ export class NotebookCellList extends WorkbenchList<CellViewModel> implements ID
 
 	private _revealInViewWithMinimalScrolling(viewIndex: number, firstLine?: boolean) {
 		const firstIndex = this.view.firstVisibleIndex;
-		if (viewIndex <= firstIndex) {
+		const elementHeight = this.view.elementHeight(viewIndex);
+
+		if (viewIndex <= firstIndex || elementHeight >= this.view.renderHeight) {
 			this._revealInternal(viewIndex, true, CellRevealPosition.Top, firstLine);
 		} else {
 			this._revealInternal(viewIndex, true, CellRevealPosition.Bottom, firstLine);


### PR DESCRIPTION
fix https://github.com/microsoft/vscode/issues/189735

follows the behavior of the listWidget when cells are revealed using the arrow keys 