### PR TITLE
fix nb codeactions running on autosave when set `true` [release]

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/contrib/saveParticipants/saveParticipants.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/saveParticipants/saveParticipants.ts
@@ -329,7 +329,8 @@ class CodeActionOnSaveParticipant implements IStoredFileWorkingCopySaveParticipa
 		if (context.reason === SaveReason.AUTO) {
 			// currently this won't happen, as vs/editor/contrib/codeAction/browser/codeAction.ts L#104 filters out codeactions on autosave. Just future-proofing
 			// ? notebook CodeActions on autosave seems dangerous (perf-wise)
-			saveTrigger = 'always';
+			// saveTrigger = 'always'; // TODO@Yoyokrazy, support during debt
+			return undefined;
 		} else if (context.reason === SaveReason.EXPLICIT) {
 			saveTrigger = 'explicit';
 		} else {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fix #194437

edit: matching PR in main here (https://github.com/microsoft/vscode/pull/194502)

Notebook CodeActions were running on autosave due to an oversight when tweaking logic to support Boolean settings. Boolean support is needed to keep parity with `editor.codeActionsOnSave`.

Support for `always` in `notebook.codeActionsOnSave` is coming soon and will address this as well.
