### PR TITLE
Preselect correct row in Extension Log Level quickpick (fix #194515)

### DIFF
--- a/src/vs/workbench/contrib/logs/common/logsActions.ts
+++ b/src/vs/workbench/contrib/logs/common/logsActions.ts
@@ -107,7 +107,7 @@ export class SetLogLevelAction extends Action {
 			const quickPick = this.quickInputService.createQuickPick();
 			quickPick.placeholder = logChannel ? nls.localize('selectLogLevelFor', " {0}: Select log level", logChannel?.label) : nls.localize('selectLogLevel', "Select log level");
 			quickPick.items = entries;
-			quickPick.activeItems = [entries[this.loggerService.getLogLevel()]];
+			quickPick.activeItems = entries.filter((entry) => entry.level === this.loggerService.getLogLevel());
 			let selectedItem: LogLevelQuickPickItem | undefined;
 			disposables.add(quickPick.onDidTriggerItemButton(e => {
 				quickPick.hide();


### PR DESCRIPTION
This PR fixes #194515
