### PR TITLE
mapped edits: support de/serialization of mapped edits context so that it can be used across vscode sessions

### DIFF
--- a/src/vs/workbench/contrib/chat/common/chatModel.ts
+++ b/src/vs/workbench/contrib/chat/common/chatModel.ts
@@ -62,14 +62,6 @@ export interface IChatResponseModel {
 	setVote(vote: InteractiveSessionVoteDirection): void;
 }
 
-export function isRequest(item: unknown): item is IChatRequestModel {
-	return !!item && typeof (item as IChatRequestModel).message !== 'undefined';
-}
-
-export function isResponse(item: unknown): item is IChatResponseModel {
-	return !isRequest(item);
-}
-
 export class ChatRequestModel implements IChatRequestModel {
 	private static nextId = 0;
 

--- a/src/vs/workbench/contrib/chat/common/chatService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService.ts
@@ -8,7 +8,7 @@ import { Event } from 'vs/base/common/event';
 import { IMarkdownString } from 'vs/base/common/htmlContent';
 import { IDisposable } from 'vs/base/common/lifecycle';
 import { URI } from 'vs/base/common/uri';
-import { IRange } from 'vs/editor/common/core/range';
+import { Range, IRange } from 'vs/editor/common/core/range';
 import { ProviderResult } from 'vs/editor/common/languages';
 import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
 import { IChatModel, ChatModel, ISerializableChatData } from 'vs/workbench/contrib/chat/common/chatModel';
@@ -59,9 +59,29 @@ export type IDocumentContext = {
 	ranges: IRange[];
 };
 
+export function isIDocumentContext(obj: unknown): obj is IDocumentContext {
+	return (
+		!!obj &&
+		typeof obj === 'object' &&
+		'uri' in obj && obj.uri instanceof URI &&
+		'version' in obj && typeof obj.version === 'number' &&
+		'ranges' in obj && Array.isArray(obj.ranges) && obj.ranges.every(Range.isIRange)
+	);
+}
+
 export type IUsedContext = {
 	documents: IDocumentContext[];
 };
+
+export function isIUsedContext(obj: unknown): obj is IUsedContext {
+	return (
+		!!obj &&
+		typeof obj === 'object' &&
+		'documents' in obj &&
+		Array.isArray(obj.documents) &&
+		obj.documents.every(isIDocumentContext)
+	);
+}
 
 export type IChatProgress =
 	| { content: string | IMarkdownString }

--- a/src/vs/workbench/contrib/chat/test/common/__snapshots__/Chat_can_deserialize.0.snap
+++ b/src/vs/workbench/contrib/chat/test/common/__snapshots__/Chat_can_deserialize.0.snap
@@ -1,0 +1,68 @@
+{
+  requesterUsername: "test",
+  requesterAvatarIconUri: undefined,
+  responderUsername: "test",
+  responderAvatarIconUri: undefined,
+  welcomeMessage: undefined,
+  requests: [
+    {
+      providerRequestId: undefined,
+      message: {
+        text: "test request",
+        parts: [
+          {
+            range: {
+              start: 0,
+              endExclusive: 12
+            },
+            editorRange: {
+              startLineNumber: 1,
+              startColumn: 1,
+              endLineNumber: 1,
+              endColumn: 13
+            },
+            text: "test request",
+            kind: "text"
+          }
+        ]
+      },
+      response: [
+        {
+          value: "",
+          isTrusted: false,
+          supportThemeIcons: false,
+          supportHtml: false
+        }
+      ],
+      responseErrorDetails: undefined,
+      followups: undefined,
+      isCanceled: false,
+      vote: undefined,
+      agent: undefined,
+      usedContext: { documents: [
+          {
+            uri: {
+              scheme: "file",
+              authority: "",
+              path: "/test/path/to/file",
+              query: "",
+              fragment: "",
+              _formatted: null,
+              _fsPath: null
+            },
+            version: 3,
+            ranges: [
+              {
+                startLineNumber: 1,
+                startColumn: 1,
+                endLineNumber: 2,
+                endColumn: 2
+              }
+            ]
+          }
+        ] }
+    }
+  ],
+  providerId: "ChatProviderWithUsedContext",
+  providerState: undefined
+}

--- a/src/vs/workbench/contrib/chat/test/common/__snapshots__/Chat_can_serialize.0.snap
+++ b/src/vs/workbench/contrib/chat/test/common/__snapshots__/Chat_can_serialize.0.snap
@@ -1,0 +1,10 @@
+{
+  requesterUsername: "",
+  requesterAvatarIconUri: undefined,
+  responderUsername: "",
+  responderAvatarIconUri: undefined,
+  welcomeMessage: undefined,
+  requests: [  ],
+  providerId: "ChatProviderWithUsedContext",
+  providerState: undefined
+}

--- a/src/vs/workbench/contrib/chat/test/common/__snapshots__/Chat_can_serialize.1.snap
+++ b/src/vs/workbench/contrib/chat/test/common/__snapshots__/Chat_can_serialize.1.snap
@@ -1,0 +1,68 @@
+{
+  requesterUsername: "test",
+  requesterAvatarIconUri: undefined,
+  responderUsername: "test",
+  responderAvatarIconUri: undefined,
+  welcomeMessage: undefined,
+  requests: [
+    {
+      providerRequestId: undefined,
+      message: {
+        parts: [
+          {
+            range: {
+              start: 0,
+              endExclusive: 12
+            },
+            editorRange: {
+              startLineNumber: 1,
+              startColumn: 1,
+              endLineNumber: 1,
+              endColumn: 13
+            },
+            text: "test request",
+            kind: "text"
+          }
+        ],
+        text: "test request"
+      },
+      response: [
+        {
+          value: "",
+          isTrusted: false,
+          supportThemeIcons: false,
+          supportHtml: false
+        }
+      ],
+      responseErrorDetails: undefined,
+      followups: undefined,
+      isCanceled: false,
+      vote: undefined,
+      agent: undefined,
+      usedContext: { documents: [
+          {
+            uri: {
+              scheme: "file",
+              authority: "",
+              path: "/test/path/to/file",
+              query: "",
+              fragment: "",
+              _formatted: null,
+              _fsPath: null
+            },
+            version: 3,
+            ranges: [
+              {
+                startLineNumber: 1,
+                startColumn: 1,
+                endLineNumber: 2,
+                endColumn: 2
+              }
+            ]
+          }
+        ] }
+    }
+  ],
+  providerId: "ChatProviderWithUsedContext",
+  providerState: undefined
+}


### PR DESCRIPTION
reservation/concern: the document versions are obsolete/incorrect, what should we do with them?

@roblourens @jrieken would appreciate if you could have a look, thanks heaps! 