### PR TITLE
fix syntax highlighting for .git-blame-ignore-revs

### DIFF
--- a/extensions/git-base/package.json
+++ b/extensions/git-base/package.json
@@ -79,7 +79,8 @@
         ],
         "extensions": [
           ".gitignore_global",
-          ".gitignore"
+          ".gitignore",
+          ".git-blame-ignore-revs"
         ],
         "configuration": "./languages/ignore.language-configuration.json"
       }


### PR DESCRIPTION
Closes #181998

`.git-blame-ignore-revs` now uses the same syntax highlighting as `.gitignore`. This will prevent extensions like prettier erroneously assuming that the file is markdown. 


<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
