### PR TITLE
perf - delay line decoration compute (#194560)

### DIFF
--- a/src/vs/workbench/contrib/codeEditor/browser/emptyTextEditorHint/emptyTextEditorHint.ts
+++ b/src/vs/workbench/contrib/codeEditor/browser/emptyTextEditorHint/emptyTextEditorHint.ts
@@ -193,7 +193,7 @@ class EmptyTextEditorHintContentWidget implements IContentWidget {
 			|| d.options.before?.content
 			|| d.options.after?.content
 		));
-		console.log(res);
+
 		return res;
 	}
 

--- a/src/vs/workbench/contrib/codeEditor/browser/emptyTextEditorHint/emptyTextEditorHint.ts
+++ b/src/vs/workbench/contrib/codeEditor/browser/emptyTextEditorHint/emptyTextEditorHint.ts
@@ -112,16 +112,6 @@ export class EmptyTextEditorHintContribution implements IEditorContribution {
 			return false;
 		}
 
-		const conflictingDecoration = this.editor.getLineDecorations(1)?.find((d) =>
-			d.options.beforeContentClassName
-			|| d.options.afterContentClassName
-			|| d.options.before?.content
-			|| d.options.after?.content
-		);
-		if (conflictingDecoration) {
-			return false;
-		}
-
 		const inlineChatProviders = [...this.inlineChatService.getAllProvider()];
 		const shouldRenderDefaultHint = model?.uri.scheme === Schemas.untitled && languageId === PLAINTEXT_LANGUAGE_ID && !inlineChatProviders.length;
 		return inlineChatProviders.length > 0 || shouldRenderDefaultHint;
@@ -187,13 +177,24 @@ class EmptyTextEditorHintContentWidget implements IContentWidget {
 	}
 
 	private onDidChangeModelContent(): void {
-		if (!this.editor.getModel()?.getValueLength()) {
+		if (!this.editor.getModel()?.getValueLength() && !this.hasConflictingDecorations()) {
 			this.editor.addContentWidget(this);
 			this.isVisible = true;
 		} else {
 			this.editor.removeContentWidget(this);
 			this.isVisible = false;
 		}
+	}
+
+	private hasConflictingDecorations(): boolean {
+		const res = Boolean(this.editor.getLineDecorations(1)?.find((d) =>
+			d.options.beforeContentClassName
+			|| d.options.afterContentClassName
+			|| d.options.before?.content
+			|| d.options.after?.content
+		));
+		console.log(res);
+		return res;
 	}
 
 	getId(): string {


### PR DESCRIPTION
For #194560

This moves the rather expensive call to `getLineDecorations` to a place where we already check for `getValueLength` and thus limits this call to empty editors only.

Since this widget seems to be re-created on each decoration change event from the editor, I believe this to not cause any new bugs, but please confirm.