### PR TITLE
file watcher - reuse instances of `Uri` in event handlers in extension host (for #194341)

### DIFF
--- a/src/vs/workbench/api/common/extHostFileSystemEventService.ts
+++ b/src/vs/workbench/api/common/extHostFileSystemEventService.ts
@@ -16,6 +16,7 @@ import { FileOperation } from 'vs/platform/files/common/files';
 import { CancellationToken } from 'vs/base/common/cancellation';
 import { ILogService } from 'vs/platform/log/common/log';
 import { IExtHostWorkspace } from 'vs/workbench/api/common/extHostWorkspace';
+import { Lazy } from 'vs/base/common/lazy';
 
 class FileSystemWatcher implements vscode.FileSystemWatcher {
 
@@ -137,32 +138,14 @@ class LazyRevivedFileSystemEvents implements FileSystemEvents {
 
 	constructor(private readonly _events: FileSystemEvents) { }
 
-	private _created: URI[] | undefined = undefined;
-	get created(): URI[] {
-		if (!this._created) {
-			this._created = this._events.created.map(URI.revive) as URI[];
-		}
+	private _created = new Lazy(() => this._events.created.map(URI.revive) as URI[]);
+	get created(): URI[] { return this._created.value; }
 
-		return this._created;
-	}
+	private _changed = new Lazy(() => this._events.changed.map(URI.revive) as URI[]);
+	get changed(): URI[] { return this._changed.value; }
 
-	private _changed: URI[] | undefined = undefined;
-	get changed(): URI[] {
-		if (!this._changed) {
-			this._changed = this._events.changed.map(URI.revive) as URI[];
-		}
-
-		return this._changed;
-	}
-
-	private _deleted: URI[] | undefined = undefined;
-	get deleted(): URI[] {
-		if (!this._deleted) {
-			this._deleted = this._events.deleted.map(URI.revive) as URI[];
-		}
-
-		return this._deleted;
-	}
+	private _deleted = new Lazy(() => this._events.deleted.map(URI.revive) as URI[]);
+	get deleted(): URI[] { return this._deleted.value; }
 }
 
 export class ExtHostFileSystemEventService implements ExtHostFileSystemEventServiceShape {

--- a/src/vs/workbench/api/common/extHostFileSystemEventService.ts
+++ b/src/vs/workbench/api/common/extHostFileSystemEventService.ts
@@ -140,7 +140,7 @@ class LazyRevivedFileSystemEvents implements FileSystemEvents {
 	private _created: URI[] | undefined = undefined;
 	get created(): URI[] {
 		if (!this._created) {
-			this._created = this._events.created.map(created => URI.revive(created));
+			this._created = this._events.created.map(URI.revive) as URI[];
 		}
 
 		return this._created;
@@ -149,7 +149,7 @@ class LazyRevivedFileSystemEvents implements FileSystemEvents {
 	private _changed: URI[] | undefined = undefined;
 	get changed(): URI[] {
 		if (!this._changed) {
-			this._changed = this._events.changed.map(changed => URI.revive(changed));
+			this._changed = this._events.changed.map(URI.revive) as URI[];
 		}
 
 		return this._changed;
@@ -158,7 +158,7 @@ class LazyRevivedFileSystemEvents implements FileSystemEvents {
 	private _deleted: URI[] | undefined = undefined;
 	get deleted(): URI[] {
 		if (!this._deleted) {
-			this._deleted = this._events.deleted.map(deleted => URI.revive(deleted));
+			this._deleted = this._events.deleted.map(URI.revive) as URI[];
 		}
 
 		return this._deleted;

--- a/src/vs/workbench/api/common/extHostFileSystemEventService.ts
+++ b/src/vs/workbench/api/common/extHostFileSystemEventService.ts
@@ -133,6 +133,38 @@ interface IExtensionListener<E> {
 	(e: E): any;
 }
 
+class LazyRevivedFileSystemEvents implements FileSystemEvents {
+
+	constructor(private readonly _events: FileSystemEvents) { }
+
+	private _created: URI[] | undefined = undefined;
+	get created(): URI[] {
+		if (!this._created) {
+			this._created = this._events.created.map(created => URI.revive(created));
+		}
+
+		return this._created;
+	}
+
+	private _changed: URI[] | undefined = undefined;
+	get changed(): URI[] {
+		if (!this._changed) {
+			this._changed = this._events.changed.map(changed => URI.revive(changed));
+		}
+
+		return this._changed;
+	}
+
+	private _deleted: URI[] | undefined = undefined;
+	get deleted(): URI[] {
+		if (!this._deleted) {
+			this._deleted = this._events.deleted.map(deleted => URI.revive(deleted));
+		}
+
+		return this._deleted;
+	}
+}
+
 export class ExtHostFileSystemEventService implements ExtHostFileSystemEventServiceShape {
 
 	private readonly _onFileSystemEvent = new Emitter<FileSystemEvents>();
@@ -163,7 +195,7 @@ export class ExtHostFileSystemEventService implements ExtHostFileSystemEventServ
 	}
 
 	$onFileEvent(events: FileSystemEvents) {
-		this._onFileSystemEvent.fire(events);
+		this._onFileSystemEvent.fire(new LazyRevivedFileSystemEvents(events));
 	}
 
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
