### PR TITLE
Match beginning of line in multi-line link prefix matcher

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/links/browser/terminalMultiLineLinkDetector.ts
+++ b/src/vs/workbench/contrib/terminalContrib/links/browser/terminalMultiLineLinkDetector.ts
@@ -33,7 +33,7 @@ const lineNumberPrefixMatchers = [
 	// Eslint:
 	//   /some/file
 	//     16:5  error ...
-	/ *(?<link>(?<line>\d+):(?<col>\d+)?)/
+	/^ *(?<link>(?<line>\d+):(?<col>\d+)?)/
 ];
 
 const gitDiffMatchers = [


### PR DESCRIPTION
Fixes #193585
