### PR TITLE
fix undo notebook action leak

### DIFF
--- a/src/vs/workbench/contrib/notebook/common/model/notebookTextModel.ts
+++ b/src/vs/workbench/contrib/notebook/common/model/notebookTextModel.ts
@@ -735,6 +735,7 @@ export class NotebookTextModel extends Disposable implements INotebookTextModel 
 				this._bindCellContentHandler(cell, e);
 			});
 			this._cellListeners.set(cell.handle, dirtyStateListener);
+			this._register(cell);
 			return cell;
 		});
 

--- a/src/vs/workbench/contrib/notebook/test/browser/contrib/notebookUndoRedo.test.ts
+++ b/src/vs/workbench/contrib/notebook/test/browser/contrib/notebookUndoRedo.test.ts
@@ -4,20 +4,20 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as assert from 'assert';
-import { DisposableStore } from 'vs/base/common/lifecycle';
-import { ILanguageService } from 'vs/editor/common/languages/language';
+import { ensureNoDisposablesAreLeakedInTestSuite } from 'vs/base/test/common/utils';
 import { CellEditType, CellKind, SelectionStateType } from 'vs/workbench/contrib/notebook/common/notebookCommon';
-import { createNotebookCellList, TestCell, withTestNotebook } from 'vs/workbench/contrib/notebook/test/browser/testNotebookEditor';
+import { createNotebookCellList, withTestNotebook } from 'vs/workbench/contrib/notebook/test/browser/testNotebookEditor';
 
 suite('Notebook Undo/Redo', () => {
+	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
+
 	test('Basics', async function () {
 		await withTestNotebook(
 			[
 				['# header 1', 'markdown', CellKind.Markup, [], {}],
 				['body', 'markdown', CellKind.Markup, [], {}],
 			],
-			async (editor, viewModel, _ds, accessor) => {
-				const languageService = accessor.get(ILanguageService);
+			async (editor, viewModel, _ds, _accessor) => {
 				assert.strictEqual(viewModel.length, 2);
 				assert.strictEqual(viewModel.getVersionId(), 0);
 				assert.strictEqual(viewModel.getAlternativeId(), '0_0,1;1,1');
@@ -41,7 +41,7 @@ suite('Notebook Undo/Redo', () => {
 
 				editor.textModel.applyEdits([{
 					editType: CellEditType.Replace, index: 0, count: 0, cells: [
-						new TestCell(viewModel.viewType, 3, '# header 2', 'markdown', CellKind.Code, [], languageService),
+						{ source: '# header 3', language: 'markdown', cellKind: CellKind.Markup, outputs: [], mime: undefined }
 					]
 				}], true, undefined, () => undefined, undefined, true);
 				assert.strictEqual(viewModel.getVersionId(), 4);
@@ -60,8 +60,7 @@ suite('Notebook Undo/Redo', () => {
 				['# header 1', 'markdown', CellKind.Markup, [], {}],
 				['body', 'markdown', CellKind.Markup, [], {}],
 			],
-			async (editor, viewModel, _ds, accessor) => {
-				const languageService = accessor.get(ILanguageService);
+			async (editor, _viewModel, _ds, _accessor) => {
 				editor.textModel.applyEdits([{
 					editType: CellEditType.Replace, index: 0, count: 2, cells: []
 				}], true, undefined, () => undefined, undefined, true);
@@ -69,7 +68,7 @@ suite('Notebook Undo/Redo', () => {
 				assert.doesNotThrow(() => {
 					editor.textModel.applyEdits([{
 						editType: CellEditType.Replace, index: 0, count: 2, cells: [
-							new TestCell(viewModel.viewType, 3, '# header 2', 'markdown', CellKind.Code, [], languageService),
+							{ source: '# header 2', language: 'markdown', cellKind: CellKind.Markup, outputs: [], mime: undefined }
 						]
 					}], true, undefined, () => undefined, undefined, true);
 				});
@@ -101,15 +100,14 @@ suite('Notebook Undo/Redo', () => {
 				['# header 1', 'markdown', CellKind.Markup, [], {}],
 				['body', 'markdown', CellKind.Markup, [], {}],
 			],
-			async (editor, viewModel, _ds, accessor) => {
-				const languageService = accessor.get(ILanguageService);
+			async (editor, viewModel, _ds, _accessor) => {
 				editor.textModel.applyEdits([{
 					editType: CellEditType.Replace, index: 0, count: 2, cells: []
 				}], true, undefined, () => undefined, undefined, true);
 
 				editor.textModel.applyEdits([{
 					editType: CellEditType.Replace, index: 0, count: 2, cells: [
-						new TestCell(viewModel.viewType, 3, '# header 2', 'markdown', CellKind.Code, [], languageService),
+						{ source: '# header 2', language: 'markdown', cellKind: CellKind.Markup, outputs: [], mime: undefined }
 					]
 				}], true, undefined, () => undefined, undefined, true);
 
@@ -134,14 +132,13 @@ suite('Notebook Undo/Redo', () => {
 				['body', 'markdown', CellKind.Markup, [], {}],
 			],
 			async (editor, viewModel, _ds, accessor) => {
-				const languageService = accessor.get(ILanguageService);
-				const cellList = createNotebookCellList(accessor, new DisposableStore());
+				const cellList = createNotebookCellList(accessor, disposables);
 				cellList.attachViewModel(viewModel);
 				cellList.setFocus([1]);
 
 				editor.textModel.applyEdits([{
 					editType: CellEditType.Replace, index: 2, count: 0, cells: [
-						new TestCell(viewModel.viewType, 3, '# header 2', 'markdown', CellKind.Code, [], languageService)
+						{ source: '# header 2', language: 'markdown', cellKind: CellKind.Markup, outputs: [], mime: undefined }
 					]
 				}], true, { focus: { start: 1, end: 2 }, selections: [{ start: 1, end: 2 }], kind: SelectionStateType.Index }, () => {
 					return {
@@ -175,11 +172,9 @@ suite('Notebook Undo/Redo', () => {
 				['body', 'markdown', CellKind.Markup, [], {}],
 			],
 			async (editor, viewModel, _ds, accessor) => {
-				const languageService = accessor.get(ILanguageService);
-
 				editor.textModel.applyEdits([{
 					editType: CellEditType.Replace, index: 2, count: 0, cells: [
-						new TestCell(viewModel.viewType, 3, '# header 2', 'markdown', CellKind.Code, [], languageService)
+						{ source: '# header 2', language: 'markdown', cellKind: CellKind.Markup, outputs: [], mime: undefined }
 					]
 				}, {
 					editType: CellEditType.Metadata, index: 0, metadata: { inputCollapsed: false }

--- a/src/vs/workbench/contrib/notebook/test/browser/testNotebookEditor.ts
+++ b/src/vs/workbench/contrib/notebook/test/browser/testNotebookEditor.ts
@@ -416,7 +416,7 @@ export async function withTestNotebook<R = any>(cells: [source: string, lang: st
 	});
 }
 
-export function createNotebookCellList(instantiationService: TestInstantiationService, disposables: DisposableStore, viewContext?: ViewContext) {
+export function createNotebookCellList(instantiationService: TestInstantiationService, disposables: Pick<DisposableStore, 'add'>, viewContext?: ViewContext) {
 	const delegate: IListVirtualDelegate<CellViewModel> = {
 		getHeight(element: CellViewModel) { return element.getHeight(17); },
 		getTemplateId() { return 'template'; }


### PR DESCRIPTION
https://github.com/microsoft/vscode/issues/190503

fix a prod leak where undo-ing a cell add would remove the cell from the notebook's cell list, but it couldn't be disposed while the notebook is still alive since redo would need that cell object. So we need to register the cell that the notebook creates to be disposed along with the notebook.