### PR TITLE
add `alertCleared` to accessibility service, adopt everywhere

### DIFF
--- a/src/vs/platform/accessibility/browser/accessibilityService.ts
+++ b/src/vs/platform/accessibility/browser/accessibilityService.ts
@@ -7,6 +7,7 @@ import { addDisposableListener } from 'vs/base/browser/dom';
 import { alert } from 'vs/base/browser/ui/aria/aria';
 import { Emitter, Event } from 'vs/base/common/event';
 import { Disposable } from 'vs/base/common/lifecycle';
+import { localize } from 'vs/nls';
 import { AccessibilitySupport, CONTEXT_ACCESSIBILITY_MODE_ENABLED, IAccessibilityService } from 'vs/platform/accessibility/common/accessibility';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { IContextKey, IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
@@ -114,5 +115,10 @@ export class AccessibilityService extends Disposable implements IAccessibilitySe
 
 	alert(message: string): void {
 		alert(message);
+	}
+	alertCleared(): void {
+		if (this.isScreenReaderOptimized()) {
+			alert(localize('cleared', "Cleared"));
+		}
 	}
 }

--- a/src/vs/platform/accessibility/common/accessibility.ts
+++ b/src/vs/platform/accessibility/common/accessibility.ts
@@ -21,6 +21,7 @@ export interface IAccessibilityService {
 	getAccessibilitySupport(): AccessibilitySupport;
 	setAccessibilitySupport(accessibilitySupport: AccessibilitySupport): void;
 	alert(message: string): void;
+	alertCleared(): void;
 }
 
 export const enum AccessibilitySupport {

--- a/src/vs/platform/accessibility/test/common/testAccessibilityService.ts
+++ b/src/vs/platform/accessibility/test/common/testAccessibilityService.ts
@@ -19,4 +19,5 @@ export class TestAccessibilityService implements IAccessibilityService {
 	setAccessibilitySupport(accessibilitySupport: AccessibilitySupport): void { }
 	getAccessibilitySupport(): AccessibilitySupport { return AccessibilitySupport.Unknown; }
 	alert(message: string): void { }
+	alertCleared(): void { }
 }

--- a/src/vs/workbench/contrib/chat/browser/actions/chatClearActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatClearActions.ts
@@ -18,7 +18,6 @@ import { IChatWidgetService } from 'vs/workbench/contrib/chat/browser/chat';
 import { ChatEditorInput } from 'vs/workbench/contrib/chat/browser/chatEditorInput';
 import { ChatViewPane } from 'vs/workbench/contrib/chat/browser/chatViewPane';
 import { CONTEXT_IN_CHAT_SESSION, CONTEXT_PROVIDER_EXISTS } from 'vs/workbench/contrib/chat/common/chatContextKeys';
-import { alert } from 'vs/base/browser/ui/aria/aria';
 import { IAccessibilityService } from 'vs/platform/accessibility/common/accessibility';
 
 export const ACTION_ID_CLEAR_CHAT = `workbench.action.chat.clear`;
@@ -119,7 +118,5 @@ export function getClearAction(viewId: string, providerId: string) {
 }
 
 function announceChatCleared(accessor: ServicesAccessor): void {
-	if (accessor.get(IAccessibilityService).isScreenReaderOptimized()) {
-		alert(localize('chatCleared', "Cleared"));
-	}
+	accessor.get(IAccessibilityService).alertCleared();
 }

--- a/src/vs/workbench/contrib/debug/browser/repl.ts
+++ b/src/vs/workbench/contrib/debug/browser/repl.ts
@@ -69,6 +69,7 @@ import { Variable } from 'vs/workbench/contrib/debug/common/debugModel';
 import { ReplEvaluationResult, ReplGroup } from 'vs/workbench/contrib/debug/common/replModel';
 import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
 import { registerNavigableContainer } from 'vs/workbench/browser/actions/widgetNavigationCommands';
+import { IAccessibilityService } from 'vs/platform/accessibility/common/accessibility';
 
 const $ = dom.$;
 
@@ -975,8 +976,9 @@ registerAction2(class extends ViewAction<Repl> {
 	}
 
 	runInView(_accessor: ServicesAccessor, view: Repl): void {
+		const accessibilityService = _accessor.get(IAccessibilityService);
 		view.clearRepl();
-		aria.status(localize('debugConsoleCleared', "Debug console was cleared"));
+		accessibilityService.alertCleared();
 	}
 });
 

--- a/src/vs/workbench/contrib/output/browser/output.contribution.ts
+++ b/src/vs/workbench/contrib/output/browser/output.contribution.ts
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as nls from 'vs/nls';
-import * as aria from 'vs/base/browser/ui/aria/aria';
 import { KeyMod, KeyChord, KeyCode } from 'vs/base/common/keyCodes';
 import { ModesRegistry } from 'vs/editor/common/languages/modesRegistry';
 import { Registry } from 'vs/platform/registry/common/platform';
@@ -29,6 +28,7 @@ import { registerIcon } from 'vs/platform/theme/common/iconRegistry';
 import { Categories } from 'vs/platform/action/common/actionCommonCategories';
 import { Disposable, dispose, IDisposable, toDisposable } from 'vs/base/common/lifecycle';
 import { IFilesConfigurationService } from 'vs/workbench/services/filesConfiguration/common/filesConfigurationService';
+import { IAccessibilityService } from 'vs/platform/accessibility/common/accessibility';
 
 // Register Service
 registerSingleton(IOutputService, OutputService, InstantiationType.Delayed);
@@ -221,10 +221,11 @@ class OutputContribution extends Disposable implements IWorkbenchContribution {
 			}
 			async run(accessor: ServicesAccessor): Promise<void> {
 				const outputService = accessor.get(IOutputService);
+				const accesibilityService = accessor.get(IAccessibilityService);
 				const activeChannel = outputService.getActiveChannel();
 				if (activeChannel) {
 					activeChannel.clear();
-					aria.status(nls.localize('outputCleared', "Output was cleared"));
+					accesibilityService.alertCleared();
 				}
 			}
 		}));

--- a/src/vs/workbench/contrib/terminal/browser/xterm/xtermTerminal.ts
+++ b/src/vs/workbench/contrib/terminal/browser/xterm/xtermTerminal.ts
@@ -43,7 +43,7 @@ import { IClipboardService } from 'vs/platform/clipboard/common/clipboardService
 import { debounce } from 'vs/base/common/decorators';
 import { MouseWheelClassifier } from 'vs/base/browser/ui/scrollbar/scrollableElement';
 import { IMouseWheelEvent, StandardWheelEvent } from 'vs/base/browser/mouseEvent';
-import { alert } from 'vs/base/browser/ui/aria/aria';
+import { IAccessibilityService } from 'vs/platform/accessibility/common/accessibility';
 
 const enum RenderConstants {
 	/**
@@ -203,7 +203,8 @@ export class XtermTerminal extends Disposable implements IXtermTerminal, IDetach
 		@IThemeService private readonly _themeService: IThemeService,
 		@ITelemetryService private readonly _telemetryService: ITelemetryService,
 		@IClipboardService private readonly _clipboardService: IClipboardService,
-		@IContextKeyService contextKeyService: IContextKeyService
+		@IContextKeyService contextKeyService: IContextKeyService,
+		@IAccessibilityService private readonly _accessibilityService: IAccessibilityService
 	) {
 		super();
 		const font = this._configHelper.getFont(undefined, true);
@@ -589,7 +590,7 @@ export class XtermTerminal extends Disposable implements IXtermTerminal, IDetach
 		// the prompt being written
 		this._capabilities.get(TerminalCapability.CommandDetection)?.handlePromptStart();
 		this._capabilities.get(TerminalCapability.CommandDetection)?.handleCommandStart();
-		alert(localize('terminalCleared', "Cleared"));
+		this._accessibilityService.alertCleared();
 	}
 
 	hasSelection(): boolean {

--- a/src/vs/workbench/contrib/terminalContrib/accessibility/browser/terminal.accessibility.contribution.ts
+++ b/src/vs/workbench/contrib/terminalContrib/accessibility/browser/terminal.accessibility.contribution.ts
@@ -29,8 +29,9 @@ import type { Terminal } from 'xterm';
 import { Position } from 'vs/editor/common/core/position';
 import { ICommandWithEditorLine, TerminalAccessibleBufferProvider } from 'vs/workbench/contrib/terminalContrib/accessibility/browser/terminalAccessibleBufferProvider';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
-import { TerminalSettingId } from 'vs/platform/terminal/common/terminal';
+import { TerminalSettingId, WindowsShellType } from 'vs/platform/terminal/common/terminal';
 import { Event } from 'vs/base/common/event';
+import { isWindows } from 'vs/base/common/platform';
 
 class TextAreaSyncContribution extends DisposableStore implements ITerminalContribution {
 	static readonly ID = 'terminal.textAreaSync';
@@ -46,7 +47,7 @@ class TextAreaSyncContribution extends DisposableStore implements ITerminalContr
 		super();
 	}
 	xtermReady(xterm: IXtermTerminal & { raw: Terminal }): void {
-		const addon = this._instantiationService.createInstance(TextAreaSyncAddon, this._instance.capabilities);
+		const addon = this._instantiationService.createInstance(TextAreaSyncAddon, isWindows ? this._instance.shellType as WindowsShellType : undefined, this._instance.capabilities);
 		xterm.raw.loadAddon(addon);
 		addon.activate(xterm.raw);
 	}
@@ -89,7 +90,7 @@ export class TerminalAccessibleViewContribution extends Disposable implements IT
 		}));
 	}
 	xtermReady(xterm: IXtermTerminal & { raw: Terminal }): void {
-		const addon = this._instantiationService.createInstance(TextAreaSyncAddon, this._instance.capabilities);
+		const addon = this._instantiationService.createInstance(TextAreaSyncAddon, isWindows ? this._instance.shellType as WindowsShellType : undefined, this._instance.capabilities);
 		xterm.raw.loadAddon(addon);
 		addon.activate(xterm.raw);
 		this._xterm = xterm;

--- a/src/vs/workbench/contrib/terminalContrib/accessibility/browser/textAreaSyncAddon.ts
+++ b/src/vs/workbench/contrib/terminalContrib/accessibility/browser/textAreaSyncAddon.ts
@@ -6,7 +6,7 @@
 import { Disposable, DisposableStore, MutableDisposable } from 'vs/base/common/lifecycle';
 import { IAccessibilityService } from 'vs/platform/accessibility/common/accessibility';
 import { ITerminalCapabilityStore, TerminalCapability } from 'vs/platform/terminal/common/capabilities/capabilities';
-import { ITerminalLogService } from 'vs/platform/terminal/common/terminal';
+import { ITerminalLogService, WindowsShellType } from 'vs/platform/terminal/common/terminal';
 import type { Terminal, ITerminalAddon } from 'xterm';
 import { debounce } from 'vs/base/common/decorators';
 import { addDisposableListener } from 'vs/base/browser/dom';
@@ -30,6 +30,7 @@ export class TextAreaSyncAddon extends Disposable implements ITerminalAddon {
 	}
 
 	constructor(
+		private readonly _windowsShell: WindowsShellType | undefined,
 		private readonly _capabilities: ITerminalCapabilityStore,
 		@IAccessibilityService private readonly _accessibilityService: IAccessibilityService,
 		@ITerminalLogService private readonly _logService: ITerminalLogService
@@ -87,7 +88,7 @@ export class TextAreaSyncAddon extends Disposable implements ITerminalAddon {
 		}
 		const commandCapability = this._capabilities.get(TerminalCapability.CommandDetection);
 		const currentCommand = commandCapability?.currentCommand;
-		if (!currentCommand) {
+		if (!currentCommand || (this._windowsShell && (this._windowsShell === 'pwsh' && !currentCommand.command?.includes('PS')) || (this._windowsShell === 'cmd' && !currentCommand.command?.includes('C:')))) {
 			this._logService.debug(`TextAreaSyncAddon#updateCommandAndCursor: no current command`);
 			return;
 		}

--- a/src/vs/workbench/contrib/terminalContrib/accessibility/test/browser/bufferContentTracker.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/accessibility/test/browser/bufferContentTracker.test.ts
@@ -7,6 +7,8 @@ import * as assert from 'assert';
 import { importAMDNodeModule } from 'vs/amdX';
 import { isWindows } from 'vs/base/common/platform';
 import { ensureNoDisposablesAreLeakedInTestSuite } from 'vs/base/test/common/utils';
+import { IAccessibilityService } from 'vs/platform/accessibility/common/accessibility';
+import { TestAccessibilityService } from 'vs/platform/accessibility/test/common/testAccessibilityService';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { TestConfigurationService } from 'vs/platform/configuration/test/common/testConfigurationService';
 import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
@@ -65,6 +67,7 @@ suite('Buffer Content Tracker', () => {
 		instantiationService.stub(IContextMenuService, store.add(instantiationService.createInstance(ContextMenuService)));
 		instantiationService.stub(ILifecycleService, store.add(new TestLifecycleService()));
 		instantiationService.stub(IContextKeyService, store.add(new MockContextKeyService()));
+		instantiationService.stub(IAccessibilityService, new TestAccessibilityService());
 		configHelper = store.add(instantiationService.createInstance(TerminalConfigHelper));
 		capabilities = store.add(new TerminalCapabilityStore());
 		if (!isWindows) {


### PR DESCRIPTION
Reduces verbosity and streamlines this across components so that one day we can replace this with an audio cue

fix #194672