### PR TITLE
disable editor hint mouse click in empty cell editor.

### DIFF
--- a/src/vs/workbench/contrib/codeEditor/browser/emptyTextEditorHint/emptyTextEditorHint.ts
+++ b/src/vs/workbench/contrib/codeEditor/browser/emptyTextEditorHint/emptyTextEditorHint.ts
@@ -52,6 +52,10 @@ Registry.as<IConfigurationMigrationRegistry>(Extensions.ConfigurationMigration)
 		])
 	}]);
 
+export interface IEmptyTextEditorHintOptions {
+	readonly clickable?: boolean;
+}
+
 export const emptyTextEditorHintSetting = 'workbench.editor.empty.hint';
 export class EmptyTextEditorHintContribution implements IEditorContribution {
 
@@ -92,6 +96,10 @@ export class EmptyTextEditorHintContribution implements IEditorContribution {
 		}));
 	}
 
+	protected _getOptions(): IEmptyTextEditorHintOptions {
+		return { clickable: true };
+	}
+
 	protected _shouldRenderHint() {
 		const configValue = this.configurationService.getValue(emptyTextEditorHintSetting);
 		if (configValue === 'hidden') {
@@ -123,6 +131,7 @@ export class EmptyTextEditorHintContribution implements IEditorContribution {
 		if (this._shouldRenderHint()) {
 			this.textHintContentWidget = new EmptyTextEditorHintContentWidget(
 				this.editor,
+				this._getOptions(),
 				this.editorGroupsService,
 				this.commandService,
 				this.configurationService,
@@ -151,6 +160,7 @@ class EmptyTextEditorHintContentWidget implements IContentWidget {
 
 	constructor(
 		private readonly editor: ICodeEditor,
+		private readonly options: IEmptyTextEditorHintOptions,
 		private readonly editorGroupsService: IEditorGroupsService,
 		private readonly commandService: ICommandService,
 		private readonly configurationService: IConfigurationService,
@@ -236,11 +246,17 @@ class EmptyTextEditorHintContentWidget implements IContentWidget {
 			const actionPart = localize('emptyHintText', 'Press {0} to ask {1} to do something. ', keybindingHintLabel, providerName);
 
 			const [before, after] = actionPart.split(keybindingHintLabel).map((fragment) => {
-				const hintPart = $('a', undefined, fragment);
-				hintPart.style.fontStyle = 'italic';
-				hintPart.style.cursor = 'pointer';
-				hintPart.onclick = handleClick;
-				return hintPart;
+				if (this.options.clickable) {
+					const hintPart = $('a', undefined, fragment);
+					hintPart.style.fontStyle = 'italic';
+					hintPart.style.cursor = 'pointer';
+					hintPart.onclick = handleClick;
+					return hintPart;
+				} else {
+					const hintPart = $('span', undefined, fragment);
+					hintPart.style.fontStyle = 'italic';
+					return hintPart;
+				}
 			});
 
 			hintElement.appendChild(before);
@@ -249,8 +265,11 @@ class EmptyTextEditorHintContentWidget implements IContentWidget {
 			label.set(keybindingHint);
 			label.element.style.width = 'min-content';
 			label.element.style.display = 'inline';
-			label.element.style.cursor = 'pointer';
-			label.element.onclick = handleClick;
+
+			if (this.options.clickable) {
+				label.element.style.cursor = 'pointer';
+				label.element.onclick = handleClick;
+			}
 
 			hintElement.appendChild(after);
 

--- a/src/vs/workbench/contrib/notebook/browser/contrib/editorHint/emptyCellEditorHint.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/editorHint/emptyCellEditorHint.ts
@@ -11,7 +11,7 @@ import { IConfigurationService } from 'vs/platform/configuration/common/configur
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 import { IProductService } from 'vs/platform/product/common/productService';
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
-import { EmptyTextEditorHintContribution } from 'vs/workbench/contrib/codeEditor/browser/emptyTextEditorHint/emptyTextEditorHint';
+import { EmptyTextEditorHintContribution, IEmptyTextEditorHintOptions } from 'vs/workbench/contrib/codeEditor/browser/emptyTextEditorHint/emptyTextEditorHint';
 import { IInlineChatSessionService } from 'vs/workbench/contrib/inlineChat/browser/inlineChatSession';
 import { IInlineChatService } from 'vs/workbench/contrib/inlineChat/common/inlineChat';
 import { getNotebookEditorFromEditorPane } from 'vs/workbench/contrib/notebook/browser/notebookBrowser';
@@ -53,12 +53,11 @@ export class EmptyCellEditorHintContribution extends EmptyTextEditorHintContribu
 		this.toDispose.push(activeEditor.onDidChangeActiveCell(() => this.update()));
 	}
 
-	protected override _shouldRenderHint(): boolean {
-		// TODO@rebornix, remove this when we have a better way to present the editor hints in empty cells
-		if (this.productService.quality === 'stable') {
-			return false;
-		}
+	protected override _getOptions(): IEmptyTextEditorHintOptions {
+		return { clickable: false };
+	}
 
+	protected override _shouldRenderHint(): boolean {
 		const shouldRenderHint = super._shouldRenderHint();
 		if (!shouldRenderHint) {
 			return false;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Disable the mouse click in notebook empty cell so users can easily click into the cell.
