### PR TITLE
add a hotkey that works with the screen reader optimize mode

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/contrib/navigation/arrow.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/navigation/arrow.ts
@@ -110,7 +110,13 @@ registerAction2(class FocusNextCellAction extends NotebookCellAction {
 					),
 					primary: KeyCode.DownArrow,
 					weight: KeybindingWeight.EditorCore
-				}
+				},
+				{
+					when: NOTEBOOK_EDITOR_FOCUSED,
+					primary: KeyMod.CtrlCmd | KeyMod.Alt | KeyCode.PageDown,
+					mac: { primary: KeyMod.CtrlCmd | KeyMod.Alt | KeyCode.PageDown, },
+					weight: KeybindingWeight.WorkbenchContrib
+				},
 			]
 		});
 	}
@@ -181,7 +187,13 @@ registerAction2(class FocusPreviousCellAction extends NotebookCellAction {
 					),
 					primary: KeyCode.UpArrow,
 					weight: KeybindingWeight.WorkbenchContrib, // markdown keybinding, focus on list: higher weight to override list.focusDown
-				}
+				},
+				{
+					when: NOTEBOOK_EDITOR_FOCUSED,
+					primary: KeyMod.CtrlCmd | KeyMod.Alt | KeyCode.PageUp,
+					mac: { primary: KeyMod.CtrlCmd | KeyMod.Alt | KeyCode.PageUp },
+					weight: KeybindingWeight.WorkbenchContrib
+				},
 			],
 		});
 	}

--- a/src/vs/workbench/contrib/notebook/browser/notebookAccessibility.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookAccessibility.ts
@@ -26,7 +26,13 @@ export function getAccessibilityHelpText(accessor: ServicesAccessor): string {
 	content.push(descriptionForCommand('notebook.cell.focusInOutput',
 		localize('notebook.cell.focusInOutput', 'The Focus Output command ({0}) will set focus in the cell\'s output.'),
 		localize('notebook.cell.focusInOutputNoKb', 'The Quit Edit command will set focus in the cell\'s output and is currently not triggerable by a keybinding.'), keybindingService));
-	content.push(localize('notebook.cellNavigation', 'The up and down arrows will move focus between cells while focused on the outer cell container'));
+	content.push(descriptionForCommand('notebook.focusNextEditor',
+		localize('notebook.focusNextEditor', 'The Focus Next Cell Editor command ({0}) will set focus in the next cell\'s editor.'),
+		localize('notebook.focusNextEditorNoKb', 'The Focus Next Cell Editor command will set focus in the next cell\'s editor and is currently not triggerable by a keybinding.'), keybindingService));
+	content.push(descriptionForCommand('notebook.focusPreviousEditor',
+		localize('notebook.focusPreviousEditor', 'The Focus Previous Cell Editor command ({0}) will set focus in the previous cell\'s editor.'),
+		localize('notebook.focusPreviousEditorNoKb', 'The Focus Previous Cell Editor command will set focus in the previous cell\'s editor and is currently not triggerable by a keybinding.'), keybindingService));
+	content.push(localize('notebook.cellNavigation', 'The up and down arrows will also move focus between cells while focused on the outer cell container.'));
 	content.push(descriptionForCommand('notebook.cell.executeAndFocusContainer',
 		localize('notebook.cell.executeAndFocusContainer', 'The Execute Cell command ({0}) executes the cell that currently has focus.',),
 		localize('notebook.cell.executeAndFocusContainerNoKb', 'The Execute Cell command executes the cell that currently has focus and is currently not triggerable by a keybinding.'), keybindingService));


### PR DESCRIPTION
fix https://github.com/microsoft/vscode/issues/176290

follow-up to see the 4 other bindings are necessary: https://github.com/microsoft/vscode/issues/194753