### PR TITLE
Update Rust grammar from upstream repository

### DIFF
--- a/extensions/rust/syntaxes/rust.tmLanguage.json
+++ b/extensions/rust/syntaxes/rust.tmLanguage.json
@@ -888,7 +888,7 @@
 			"patterns": [
 				{
 					"comment": "namespace (non-type, non-function path segment)",
-					"match": "(?<![A-Za-z0-9_])([a-z0-9_]+)((?<!super|self)::)",
+					"match": "(?<![A-Za-z0-9_])([A-Za-z0-9_]+)((?<!super|self)::)",
 					"captures": {
 						"1": {
 							"name": "entity.name.namespace.rust"


### PR DESCRIPTION
PR #194614 aimed to include the commit
https://github.com/dustypomerleau/rust-syntax/commit/328a68299533bc2b8c71028be741cce78a9e0d53 but it looks like it actually took the prior commit.

Update the grammar to correctly reflect the upstream repo.