### PR TITLE
watcher - emit `URI` instead of `string` for faster `fsPath` compute  (for #194341)

### DIFF
--- a/src/vs/platform/files/common/io.ts
+++ b/src/vs/platform/files/common/io.ts
@@ -16,12 +16,12 @@ export interface ICreateReadStreamOptions extends IFileReadStreamOptions {
 	/**
 	 * The size of the buffer to use before sending to the stream.
 	 */
-	bufferSize: number;
+	readonly bufferSize: number;
 
 	/**
 	 * Allows to massage any possibly error that happens during reading.
 	 */
-	errorTransformer?: IErrorTransformer;
+	readonly errorTransformer?: IErrorTransformer;
 }
 
 /**

--- a/src/vs/platform/files/test/common/watcher.test.ts
+++ b/src/vs/platform/files/test/common/watcher.test.ts
@@ -8,7 +8,7 @@ import { Emitter, Event } from 'vs/base/common/event';
 import { Disposable, DisposableStore } from 'vs/base/common/lifecycle';
 import { isLinux, isWindows } from 'vs/base/common/platform';
 import { isEqual } from 'vs/base/common/resources';
-import { URI as uri } from 'vs/base/common/uri';
+import { URI } from 'vs/base/common/uri';
 import { ensureNoDisposablesAreLeakedInTestSuite } from 'vs/base/test/common/utils';
 import { FileChangesEvent, FileChangeType, IFileChange } from 'vs/platform/files/common/files';
 import { IDiskFileChange, coalesceEvents, toFileChanges, parseWatcherPatterns } from 'vs/platform/files/common/watcher';
@@ -122,14 +122,14 @@ suite('Watcher Events Normalizer', () => {
 	test('simple add/update/delete', done => {
 		const watch = disposables.add(new TestFileWatcher());
 
-		const added = uri.file('/users/data/src/added.txt');
-		const updated = uri.file('/users/data/src/updated.txt');
-		const deleted = uri.file('/users/data/src/deleted.txt');
+		const added = URI.file('/users/data/src/added.txt');
+		const updated = URI.file('/users/data/src/updated.txt');
+		const deleted = URI.file('/users/data/src/deleted.txt');
 
 		const raw: IDiskFileChange[] = [
-			{ path: added.fsPath, type: FileChangeType.ADDED },
-			{ path: updated.fsPath, type: FileChangeType.UPDATED },
-			{ path: deleted.fsPath, type: FileChangeType.DELETED },
+			{ resource: added, type: FileChangeType.ADDED },
+			{ resource: updated, type: FileChangeType.UPDATED },
+			{ resource: deleted, type: FileChangeType.DELETED },
 		];
 
 		disposables.add(watch.onDidFilesChange(({ event, raw }) => {
@@ -149,25 +149,25 @@ suite('Watcher Events Normalizer', () => {
 		test(`delete only reported for top level folder (${path})`, done => {
 			const watch = disposables.add(new TestFileWatcher());
 
-			const deletedFolderA = uri.file(path === Path.UNIX ? '/users/data/src/todelete1' : path === Path.WINDOWS ? 'C:\\users\\data\\src\\todelete1' : '\\\\localhost\\users\\data\\src\\todelete1');
-			const deletedFolderB = uri.file(path === Path.UNIX ? '/users/data/src/todelete2' : path === Path.WINDOWS ? 'C:\\users\\data\\src\\todelete2' : '\\\\localhost\\users\\data\\src\\todelete2');
-			const deletedFolderBF1 = uri.file(path === Path.UNIX ? '/users/data/src/todelete2/file.txt' : path === Path.WINDOWS ? 'C:\\users\\data\\src\\todelete2\\file.txt' : '\\\\localhost\\users\\data\\src\\todelete2\\file.txt');
-			const deletedFolderBF2 = uri.file(path === Path.UNIX ? '/users/data/src/todelete2/more/test.txt' : path === Path.WINDOWS ? 'C:\\users\\data\\src\\todelete2\\more\\test.txt' : '\\\\localhost\\users\\data\\src\\todelete2\\more\\test.txt');
-			const deletedFolderBF3 = uri.file(path === Path.UNIX ? '/users/data/src/todelete2/super/bar/foo.txt' : path === Path.WINDOWS ? 'C:\\users\\data\\src\\todelete2\\super\\bar\\foo.txt' : '\\\\localhost\\users\\data\\src\\todelete2\\super\\bar\\foo.txt');
-			const deletedFileA = uri.file(path === Path.UNIX ? '/users/data/src/deleteme.txt' : path === Path.WINDOWS ? 'C:\\users\\data\\src\\deleteme.txt' : '\\\\localhost\\users\\data\\src\\deleteme.txt');
+			const deletedFolderA = URI.file(path === Path.UNIX ? '/users/data/src/todelete1' : path === Path.WINDOWS ? 'C:\\users\\data\\src\\todelete1' : '\\\\localhost\\users\\data\\src\\todelete1');
+			const deletedFolderB = URI.file(path === Path.UNIX ? '/users/data/src/todelete2' : path === Path.WINDOWS ? 'C:\\users\\data\\src\\todelete2' : '\\\\localhost\\users\\data\\src\\todelete2');
+			const deletedFolderBF1 = URI.file(path === Path.UNIX ? '/users/data/src/todelete2/file.txt' : path === Path.WINDOWS ? 'C:\\users\\data\\src\\todelete2\\file.txt' : '\\\\localhost\\users\\data\\src\\todelete2\\file.txt');
+			const deletedFolderBF2 = URI.file(path === Path.UNIX ? '/users/data/src/todelete2/more/test.txt' : path === Path.WINDOWS ? 'C:\\users\\data\\src\\todelete2\\more\\test.txt' : '\\\\localhost\\users\\data\\src\\todelete2\\more\\test.txt');
+			const deletedFolderBF3 = URI.file(path === Path.UNIX ? '/users/data/src/todelete2/super/bar/foo.txt' : path === Path.WINDOWS ? 'C:\\users\\data\\src\\todelete2\\super\\bar\\foo.txt' : '\\\\localhost\\users\\data\\src\\todelete2\\super\\bar\\foo.txt');
+			const deletedFileA = URI.file(path === Path.UNIX ? '/users/data/src/deleteme.txt' : path === Path.WINDOWS ? 'C:\\users\\data\\src\\deleteme.txt' : '\\\\localhost\\users\\data\\src\\deleteme.txt');
 
-			const addedFile = uri.file(path === Path.UNIX ? '/users/data/src/added.txt' : path === Path.WINDOWS ? 'C:\\users\\data\\src\\added.txt' : '\\\\localhost\\users\\data\\src\\added.txt');
-			const updatedFile = uri.file(path === Path.UNIX ? '/users/data/src/updated.txt' : path === Path.WINDOWS ? 'C:\\users\\data\\src\\updated.txt' : '\\\\localhost\\users\\data\\src\\updated.txt');
+			const addedFile = URI.file(path === Path.UNIX ? '/users/data/src/added.txt' : path === Path.WINDOWS ? 'C:\\users\\data\\src\\added.txt' : '\\\\localhost\\users\\data\\src\\added.txt');
+			const updatedFile = URI.file(path === Path.UNIX ? '/users/data/src/updated.txt' : path === Path.WINDOWS ? 'C:\\users\\data\\src\\updated.txt' : '\\\\localhost\\users\\data\\src\\updated.txt');
 
 			const raw: IDiskFileChange[] = [
-				{ path: deletedFolderA.fsPath, type: FileChangeType.DELETED },
-				{ path: deletedFolderB.fsPath, type: FileChangeType.DELETED },
-				{ path: deletedFolderBF1.fsPath, type: FileChangeType.DELETED },
-				{ path: deletedFolderBF2.fsPath, type: FileChangeType.DELETED },
-				{ path: deletedFolderBF3.fsPath, type: FileChangeType.DELETED },
-				{ path: deletedFileA.fsPath, type: FileChangeType.DELETED },
-				{ path: addedFile.fsPath, type: FileChangeType.ADDED },
-				{ path: updatedFile.fsPath, type: FileChangeType.UPDATED }
+				{ resource: deletedFolderA, type: FileChangeType.DELETED },
+				{ resource: deletedFolderB, type: FileChangeType.DELETED },
+				{ resource: deletedFolderBF1, type: FileChangeType.DELETED },
+				{ resource: deletedFolderBF2, type: FileChangeType.DELETED },
+				{ resource: deletedFolderBF3, type: FileChangeType.DELETED },
+				{ resource: deletedFileA, type: FileChangeType.DELETED },
+				{ resource: addedFile, type: FileChangeType.ADDED },
+				{ resource: updatedFile, type: FileChangeType.UPDATED }
 			];
 
 			disposables.add(watch.onDidFilesChange(({ event, raw }) => {
@@ -190,14 +190,14 @@ suite('Watcher Events Normalizer', () => {
 	test('event coalescer: ignore CREATE followed by DELETE', done => {
 		const watch = disposables.add(new TestFileWatcher());
 
-		const created = uri.file('/users/data/src/related');
-		const deleted = uri.file('/users/data/src/related');
-		const unrelated = uri.file('/users/data/src/unrelated');
+		const created = URI.file('/users/data/src/related');
+		const deleted = URI.file('/users/data/src/related');
+		const unrelated = URI.file('/users/data/src/unrelated');
 
 		const raw: IDiskFileChange[] = [
-			{ path: created.fsPath, type: FileChangeType.ADDED },
-			{ path: deleted.fsPath, type: FileChangeType.DELETED },
-			{ path: unrelated.fsPath, type: FileChangeType.UPDATED },
+			{ resource: created, type: FileChangeType.ADDED },
+			{ resource: deleted, type: FileChangeType.DELETED },
+			{ resource: unrelated, type: FileChangeType.UPDATED },
 		];
 
 		disposables.add(watch.onDidFilesChange(({ event, raw }) => {
@@ -215,14 +215,14 @@ suite('Watcher Events Normalizer', () => {
 	test('event coalescer: flatten DELETE followed by CREATE into CHANGE', done => {
 		const watch = disposables.add(new TestFileWatcher());
 
-		const deleted = uri.file('/users/data/src/related');
-		const created = uri.file('/users/data/src/related');
-		const unrelated = uri.file('/users/data/src/unrelated');
+		const deleted = URI.file('/users/data/src/related');
+		const created = URI.file('/users/data/src/related');
+		const unrelated = URI.file('/users/data/src/unrelated');
 
 		const raw: IDiskFileChange[] = [
-			{ path: deleted.fsPath, type: FileChangeType.DELETED },
-			{ path: created.fsPath, type: FileChangeType.ADDED },
-			{ path: unrelated.fsPath, type: FileChangeType.UPDATED },
+			{ resource: deleted, type: FileChangeType.DELETED },
+			{ resource: created, type: FileChangeType.ADDED },
+			{ resource: unrelated, type: FileChangeType.UPDATED },
 		];
 
 		disposables.add(watch.onDidFilesChange(({ event, raw }) => {
@@ -241,14 +241,14 @@ suite('Watcher Events Normalizer', () => {
 	test('event coalescer: ignore UPDATE when CREATE received', done => {
 		const watch = disposables.add(new TestFileWatcher());
 
-		const created = uri.file('/users/data/src/related');
-		const updated = uri.file('/users/data/src/related');
-		const unrelated = uri.file('/users/data/src/unrelated');
+		const created = URI.file('/users/data/src/related');
+		const updated = URI.file('/users/data/src/related');
+		const unrelated = URI.file('/users/data/src/unrelated');
 
 		const raw: IDiskFileChange[] = [
-			{ path: created.fsPath, type: FileChangeType.ADDED },
-			{ path: updated.fsPath, type: FileChangeType.UPDATED },
-			{ path: unrelated.fsPath, type: FileChangeType.UPDATED },
+			{ resource: created, type: FileChangeType.ADDED },
+			{ resource: updated, type: FileChangeType.UPDATED },
+			{ resource: unrelated, type: FileChangeType.UPDATED },
 		];
 
 		disposables.add(watch.onDidFilesChange(({ event, raw }) => {
@@ -268,16 +268,16 @@ suite('Watcher Events Normalizer', () => {
 	test('event coalescer: apply DELETE', done => {
 		const watch = disposables.add(new TestFileWatcher());
 
-		const updated = uri.file('/users/data/src/related');
-		const updated2 = uri.file('/users/data/src/related');
-		const deleted = uri.file('/users/data/src/related');
-		const unrelated = uri.file('/users/data/src/unrelated');
+		const updated = URI.file('/users/data/src/related');
+		const updated2 = URI.file('/users/data/src/related');
+		const deleted = URI.file('/users/data/src/related');
+		const unrelated = URI.file('/users/data/src/unrelated');
 
 		const raw: IDiskFileChange[] = [
-			{ path: updated.fsPath, type: FileChangeType.UPDATED },
-			{ path: updated2.fsPath, type: FileChangeType.UPDATED },
-			{ path: unrelated.fsPath, type: FileChangeType.UPDATED },
-			{ path: updated.fsPath, type: FileChangeType.DELETED }
+			{ resource: updated, type: FileChangeType.UPDATED },
+			{ resource: updated2, type: FileChangeType.UPDATED },
+			{ resource: unrelated, type: FileChangeType.UPDATED },
+			{ resource: updated, type: FileChangeType.DELETED }
 		];
 
 		disposables.add(watch.onDidFilesChange(({ event, raw }) => {
@@ -297,12 +297,12 @@ suite('Watcher Events Normalizer', () => {
 	test('event coalescer: track case renames', done => {
 		const watch = disposables.add(new TestFileWatcher());
 
-		const oldPath = uri.file('/users/data/src/added');
-		const newPath = uri.file('/users/data/src/ADDED');
+		const oldPath = URI.file('/users/data/src/added');
+		const newPath = URI.file('/users/data/src/ADDED');
 
 		const raw: IDiskFileChange[] = [
-			{ path: newPath.fsPath, type: FileChangeType.ADDED },
-			{ path: oldPath.fsPath, type: FileChangeType.DELETED }
+			{ resource: newPath, type: FileChangeType.ADDED },
+			{ resource: oldPath, type: FileChangeType.DELETED }
 		];
 
 		disposables.add(watch.onDidFilesChange(({ event, raw }) => {

--- a/src/vs/platform/files/test/node/nodejsWatcher.integrationTest.ts
+++ b/src/vs/platform/files/test/node/nodejsWatcher.integrationTest.ts
@@ -114,7 +114,7 @@ import { FileAccess } from 'vs/base/common/network';
 		await new Promise<void>(resolve => {
 			const disposable = service.onDidChangeFile(events => {
 				for (const event of events) {
-					if (event.path === path && event.type === type) {
+					if (event.resource.fsPath === path && event.type === type) {
 						disposable.dispose();
 						resolve();
 						break;

--- a/src/vs/platform/files/test/node/parcelWatcher.integrationTest.ts
+++ b/src/vs/platform/files/test/node/parcelWatcher.integrationTest.ts
@@ -112,7 +112,7 @@ import { FileAccess } from 'vs/base/common/network';
 		const res = await new Promise<IDiskFileChange[]>((resolve, reject) => {
 			const disposable = service.onDidChangeFile(events => {
 				for (const event of events) {
-					if (event.path === path && event.type === type) {
+					if (event.resource.fsPath === path && event.type === type) {
 						disposable.dispose();
 						if (failOnEventReason) {
 							reject(new Error(`Unexpected file event: ${failOnEventReason}`));


### PR DESCRIPTION
Not only do we now emit `Uri` from the watcher (or more specifically: `UriComponents`), but we will also have `.fsPath` computed in the watcher process. This is because each event goes through the coalescing process:

https://github.com/microsoft/vscode/blob/7ca0b35bd6cf7da0a1087907c3ccd12c8235f96d/src/vs/platform/files/common/watcher.ts#L318-L324


fyi @jrieken 