### PR TITLE
Fix some problems with progress edits

### DIFF
--- a/src/vs/platform/progress/test/common/progress.test.ts
+++ b/src/vs/platform/progress/test/common/progress.test.ts
@@ -1,0 +1,49 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { runWithFakedTimers } from 'vs/base/test/common/timeTravelScheduler';
+import { Progress } from 'vs/platform/progress/common/progress';
+
+suite('Progress', () => {
+	test('multiple report calls are processed in sequence', async () => {
+		await runWithFakedTimers({ useFakeTimers: true, maxTaskCount: 100 }, async () => {
+			const executionOrder: string[] = [];
+			const timeout = (time: number) => {
+				return new Promise<void>(resolve => setTimeout(resolve, time));
+			};
+			const executor = async (value: number) => {
+				executionOrder.push(`start ${value}`);
+				if (value === 1) {
+					// 1 is slowest
+					await timeout(100);
+				} else if (value === 2) {
+					// 2 is also slow
+					await timeout(50);
+				} else {
+					// 3 is fast
+					await timeout(10);
+				}
+				executionOrder.push(`end ${value}`);
+			};
+			const progress = new Progress<number>(executor, { async: true });
+
+			progress.report(1);
+			progress.report(2);
+			progress.report(3);
+
+			await timeout(1000);
+
+			assert.deepStrictEqual(executionOrder, [
+				'start 1',
+				'end 1',
+				'start 2',
+				'end 2',
+				'start 3',
+				'end 3',
+			]);
+		});
+	});
+});

--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatController.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatController.ts
@@ -547,7 +547,7 @@ export class InlineChatController implements IEditorContribution {
 			}
 			if (data.edits) {
 				progressEdits.push(data.edits);
-				await this._makeChanges(progressEdits);
+				await this._makeChanges(progressEdits, false);
 			}
 		}, { async: true });
 		const task = this._activeSession.provider.provideResponse(this._activeSession.session, request, progress, requestCts.token);
@@ -561,12 +561,15 @@ export class InlineChatController implements IEditorContribution {
 			this._ctxHasActiveRequest.set(true);
 			reply = await raceCancellationError(Promise.resolve(task), requestCts.token);
 
+			// we must wait for all edits that came in via progress to complete
+			await progress.drain();
+
 			if (reply?.type === InlineChatResponseType.Message) {
 				response = new MarkdownResponse(this._activeSession.textModelN.uri, reply);
 			} else if (reply) {
 				const editResponse = new EditResponse(this._activeSession.textModelN.uri, this._activeSession.textModelN.getAlternativeVersionId(), reply, progressEdits);
 				if (editResponse.allLocalEdits.length > progressEdits.length) {
-					await this._makeChanges(editResponse.allLocalEdits);
+					await this._makeChanges(editResponse.allLocalEdits, true);
 				}
 				response = editResponse;
 			} else {
@@ -619,7 +622,7 @@ export class InlineChatController implements IEditorContribution {
 		return State.SHOW_RESPONSE;
 	}
 
-	private async _makeChanges(allEdits: TextEdit[][]) {
+	private async _makeChanges(allEdits: TextEdit[][], computeMoreMinimalEdits: boolean) {
 		assertType(this._activeSession);
 		assertType(this._strategy);
 
@@ -628,9 +631,10 @@ export class InlineChatController implements IEditorContribution {
 		}
 
 		// diff-changes from model0 -> modelN+1
-		for (const edits of allEdits) {
+		{
+			const lastEdits = allEdits[allEdits.length - 1];
 			const textModelNplus1 = this._modelService.createModel(createTextBufferFactoryFromSnapshot(this._activeSession.textModelN.createSnapshot()), null, undefined, true);
-			textModelNplus1.applyEdits(edits.map(TextEdit.asEditOperation));
+			textModelNplus1.applyEdits(lastEdits.map(TextEdit.asEditOperation));
 			const diff = await this._editorWorkerService.computeDiff(this._activeSession.textModel0.uri, textModelNplus1.uri, { ignoreTrimWhitespace: false, maxComputationTimeMs: 5000, computeMoves: false }, 'advanced');
 			this._activeSession.lastTextModelChanges = diff?.changes ?? [];
 			textModelNplus1.dispose();
@@ -638,7 +642,7 @@ export class InlineChatController implements IEditorContribution {
 
 		// make changes from modelN -> modelN+1
 		const lastEdits = allEdits[allEdits.length - 1];
-		const moreMinimalEdits = await this._editorWorkerService.computeHumanReadableDiff(this._activeSession.textModelN.uri, lastEdits);
+		const moreMinimalEdits = computeMoreMinimalEdits ? await this._editorWorkerService.computeHumanReadableDiff(this._activeSession.textModelN.uri, lastEdits) : undefined;
 		const editOperations = (moreMinimalEdits ?? lastEdits).map(TextEdit.asEditOperation);
 		this._log('edits from PROVIDER and after making them MORE MINIMAL', this._activeSession.provider.debugName, lastEdits, moreMinimalEdits);
 


### PR DESCRIPTION
* the async progress handler was running before the previous invocation finished
* the final edit handling was not waiting for the progress edits to finish
* there was a problem with how `lastTextModelChanges` was computed in case of multiple edits coming in
* there is a problem in the human readable diff / more minimal edits, for now we avoid calling it from the progress

fyi @jrieken I'm rushing a bit to get these changes in for tomorrow's build.