### PR TITLE
Updated inferred JS/TS project config

### DIFF
--- a/extensions/typescript-language-features/src/tsServer/api.ts
+++ b/extensions/typescript-language-features/src/tsServer/api.ts
@@ -19,7 +19,6 @@ export class API {
 	public static readonly v320 = API.fromSimpleString('3.2.0');
 	public static readonly v333 = API.fromSimpleString('3.3.3');
 	public static readonly v340 = API.fromSimpleString('3.4.0');
-	public static readonly v345 = API.fromSimpleString('3.4.5');
 	public static readonly v350 = API.fromSimpleString('3.5.0');
 	public static readonly v370 = API.fromSimpleString('3.7.0');
 	public static readonly v380 = API.fromSimpleString('3.8.0');
@@ -32,8 +31,8 @@ export class API {
 	public static readonly v440 = API.fromSimpleString('4.4.0');
 	public static readonly v460 = API.fromSimpleString('4.6.0');
 	public static readonly v470 = API.fromSimpleString('4.7.0');
-	public static readonly v480 = API.fromSimpleString('4.8.0');
 	public static readonly v490 = API.fromSimpleString('4.9.0');
+	public static readonly v500 = API.fromSimpleString('5.0.0');
 	public static readonly v510 = API.fromSimpleString('5.1.0');
 	public static readonly v520 = API.fromSimpleString('5.2.0');
 

--- a/extensions/typescript-language-features/src/tsconfig.ts
+++ b/extensions/typescript-language-features/src/tsconfig.ts
@@ -4,10 +4,11 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
+import { TypeScriptServiceConfiguration } from './configuration/configuration';
+import { API } from './tsServer/api';
 import type * as Proto from './tsServer/protocol/protocol';
 import { ITypeScriptServiceClient, ServerResponse } from './typescriptService';
 import { nulToken } from './utils/cancellation';
-import { TypeScriptServiceConfiguration } from './configuration/configuration';
 
 
 export const enum ProjectType {
@@ -19,18 +20,21 @@ export function isImplicitProjectConfigFile(configFileName: string) {
 	return configFileName.startsWith('/dev/null/');
 }
 
-const defaultProjectConfig = Object.freeze<Proto.ExternalProjectCompilerOptions>({
-	module: 'ESNext' as Proto.ModuleKind,
-	moduleResolution: 'Node' as Proto.ModuleResolutionKind,
-	target: 'ES2020' as Proto.ScriptTarget,
-	jsx: 'react' as Proto.JsxEmit,
-});
-
 export function inferredProjectCompilerOptions(
+	version: API,
 	projectType: ProjectType,
 	serviceConfig: TypeScriptServiceConfiguration,
 ): Proto.ExternalProjectCompilerOptions {
-	const projectConfig = { ...defaultProjectConfig };
+	const projectConfig: Proto.ExternalProjectCompilerOptions = {
+		module: 'ESNext' as Proto.ModuleKind,
+		moduleResolution: (version.gte(API.v500) ? 'Bundler' : 'Node') as Proto.ModuleResolutionKind,
+		target: 'ES2022' as Proto.ScriptTarget,
+		jsx: 'react' as Proto.JsxEmit,
+	};
+
+	if (version.gte(API.v500)) {
+		projectConfig.allowImportingTsExtensions = true;
+	}
 
 	if (serviceConfig.implicitProjectConfiguration.checkJs) {
 		projectConfig.checkJs = true;
@@ -51,7 +55,6 @@ export function inferredProjectCompilerOptions(
 		projectConfig.strictFunctionTypes = true;
 	}
 
-
 	if (serviceConfig.implicitProjectConfiguration.module) {
 		projectConfig.module = serviceConfig.implicitProjectConfiguration.module as Proto.ModuleKind;
 	}
@@ -68,10 +71,11 @@ export function inferredProjectCompilerOptions(
 }
 
 function inferredProjectConfigSnippet(
+	version: API,
 	projectType: ProjectType,
 	config: TypeScriptServiceConfiguration
 ) {
-	const baseConfig = inferredProjectCompilerOptions(projectType, config);
+	const baseConfig = inferredProjectCompilerOptions(version, projectType, config);
 	const compilerOptions = Object.keys(baseConfig).map(key => `"${key}": ${JSON.stringify(baseConfig[key])}`);
 	return new vscode.SnippetString(`{
 	"compilerOptions": {
@@ -85,6 +89,7 @@ function inferredProjectConfigSnippet(
 }
 
 export async function openOrCreateConfig(
+	version: API,
 	projectType: ProjectType,
 	rootPath: vscode.Uri,
 	configuration: TypeScriptServiceConfiguration,
@@ -98,7 +103,7 @@ export async function openOrCreateConfig(
 		const doc = await vscode.workspace.openTextDocument(configFile.with({ scheme: 'untitled' }));
 		const editor = await vscode.window.showTextDocument(doc, col);
 		if (editor.document.getText().length === 0) {
-			await editor.insertSnippet(inferredProjectConfigSnippet(projectType, configuration));
+			await editor.insertSnippet(inferredProjectConfigSnippet(version, projectType, configuration));
 		}
 		return editor;
 	}
@@ -131,7 +136,7 @@ export async function openProjectConfigOrPromptToCreate(
 
 	switch (selected) {
 		case CreateConfigItem:
-			openOrCreateConfig(projectType, rootPath, client.configuration);
+			openOrCreateConfig(client.apiVersion, projectType, rootPath, client.configuration);
 			return;
 	}
 }

--- a/extensions/typescript-language-features/src/typescriptServiceClient.ts
+++ b/extensions/typescript-language-features/src/typescriptServiceClient.ts
@@ -585,7 +585,7 @@ export default class TypeScriptServiceClient extends Disposable implements IType
 
 	private getCompilerOptionsForInferredProjects(configuration: TypeScriptServiceConfiguration): Proto.ExternalProjectCompilerOptions {
 		return {
-			...inferredProjectCompilerOptions(ProjectType.TypeScript, configuration),
+			...inferredProjectCompilerOptions(this.apiVersion, ProjectType.TypeScript, configuration),
 			allowJs: true,
 			allowSyntheticDefaultImports: true,
 			allowNonTsExtensions: true,

--- a/extensions/typescript-language-features/src/ui/intellisenseStatus.ts
+++ b/extensions/typescript-language-features/src/ui/intellisenseStatus.ts
@@ -73,7 +73,7 @@ export class IntellisenseStatus extends Disposable {
 		commandManager.register({
 			id: this.createOrOpenConfigCommandId,
 			execute: async (root: vscode.Uri, projectType: ProjectType) => {
-				await openOrCreateConfig(projectType, root, this._client.configuration);
+				await openOrCreateConfig(this._client.apiVersion, projectType, root, this._client.configuration);
 			},
 		});
 

--- a/extensions/typescript-language-features/src/ui/largeProjectStatus.ts
+++ b/extensions/typescript-language-features/src/ui/largeProjectStatus.ts
@@ -97,6 +97,7 @@ function onConfigureExcludesSelected(
 		const root = client.getWorkspaceRootForResource(vscode.Uri.file(configFileName));
 		if (root) {
 			openOrCreateConfig(
+				client.apiVersion,
 				/tsconfig\.?.*\.json/.test(configFileName) ? ProjectType.TypeScript : ProjectType.JavaScript,
 				root,
 				client.configuration);


### PR DESCRIPTION
- Switch to target es2022 by default
- Also switch default module resolution to `bundler` if using more recent TS versions

/cc @andrewbranch 