### PR TITLE
Initial attempt to support editor commands

### DIFF
--- a/src/vs/editor/browser/coreCommands.ts
+++ b/src/vs/editor/browser/coreCommands.ts
@@ -22,7 +22,7 @@ import { Range } from 'vs/editor/common/core/range';
 import { Handler, ScrollType } from 'vs/editor/common/editorCommon';
 import { EditorContextKeys } from 'vs/editor/common/editorContextKeys';
 import { VerticalRevealType } from 'vs/editor/common/viewEvents';
-import { ICommandHandlerDescription } from 'vs/platform/commands/common/commands';
+import { ICommandMetadata } from 'vs/platform/commands/common/commands';
 import { ContextKeyExpr } from 'vs/platform/contextkey/common/contextkey';
 import { ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
 import { KeybindingWeight, KeybindingsRegistry } from 'vs/platform/keybinding/common/keybindingsRegistry';
@@ -74,7 +74,7 @@ export namespace EditorScroll_ {
 		return true;
 	};
 
-	export const description = <ICommandHandlerDescription>{
+	export const metadata = <ICommandMetadata>{
 		description: 'Scroll editor in the given direction',
 		args: [
 			{
@@ -252,7 +252,7 @@ export namespace RevealLine_ {
 		return true;
 	};
 
-	export const description = <ICommandHandlerDescription>{
+	export const metadata = <ICommandMetadata>{
 		description: 'Reveal the given line at the given logical position',
 		args: [
 			{
@@ -589,7 +589,7 @@ export namespace CoreNavigationCommands {
 			super({
 				id: 'cursorMove',
 				precondition: undefined,
-				description: CursorMove_.description
+				metadata: CursorMove_.metadata
 			});
 		}
 
@@ -1110,7 +1110,7 @@ export namespace CoreNavigationCommands {
 			primary: KeyCode.End,
 			mac: { primary: KeyCode.End, secondary: [KeyMod.CtrlCmd | KeyCode.RightArrow] }
 		},
-		description: {
+		metadata: {
 			description: `Go to End`,
 			args: [{
 				name: 'args',
@@ -1139,7 +1139,7 @@ export namespace CoreNavigationCommands {
 			primary: KeyMod.Shift | KeyCode.End,
 			mac: { primary: KeyMod.Shift | KeyCode.End, secondary: [KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.RightArrow] }
 		},
-		description: {
+		metadata: {
 			description: `Select to End`,
 			args: [{
 				name: 'args',
@@ -1307,7 +1307,7 @@ export namespace CoreNavigationCommands {
 			super({
 				id: 'editorScroll',
 				precondition: undefined,
-				description: EditorScroll_.description
+				metadata: EditorScroll_.metadata
 			});
 		}
 
@@ -1828,7 +1828,7 @@ export namespace CoreNavigationCommands {
 			super({
 				id: 'revealLine',
 				precondition: undefined,
-				description: RevealLine_.description
+				metadata: RevealLine_.metadata
 			});
 		}
 
@@ -2125,11 +2125,11 @@ class EditorHandlerCommand extends Command {
 
 	private readonly _handlerId: string;
 
-	constructor(id: string, handlerId: string, description?: ICommandHandlerDescription) {
+	constructor(id: string, handlerId: string, metadata?: ICommandMetadata) {
 		super({
 			id: id,
 			precondition: undefined,
-			description: description
+			metadata
 		});
 		this._handlerId = handlerId;
 	}
@@ -2144,9 +2144,9 @@ class EditorHandlerCommand extends Command {
 	}
 }
 
-function registerOverwritableCommand(handlerId: string, description?: ICommandHandlerDescription): void {
+function registerOverwritableCommand(handlerId: string, metadata?: ICommandMetadata): void {
 	registerCommand(new EditorHandlerCommand('default:' + handlerId, handlerId));
-	registerCommand(new EditorHandlerCommand(handlerId, handlerId, description));
+	registerCommand(new EditorHandlerCommand(handlerId, handlerId, metadata));
 }
 
 registerOverwritableCommand(Handler.Type, {

--- a/src/vs/editor/browser/editorExtensions.ts
+++ b/src/vs/editor/browser/editorExtensions.ts
@@ -13,7 +13,7 @@ import { ITextModel } from 'vs/editor/common/model';
 import { IModelService } from 'vs/editor/common/services/model';
 import { ITextModelService } from 'vs/editor/common/services/resolverService';
 import { MenuId, MenuRegistry, Action2 } from 'vs/platform/actions/common/actions';
-import { CommandsRegistry, ICommandHandlerDescription } from 'vs/platform/commands/common/commands';
+import { CommandsRegistry, ICommandMetadata } from 'vs/platform/commands/common/commands';
 import { ContextKeyExpr, IContextKeyService, ContextKeyExpression } from 'vs/platform/contextkey/common/contextkey';
 import { ServicesAccessor as InstantiationServicesAccessor, BrandedService, IInstantiationService, IConstructorSignature } from 'vs/platform/instantiation/common/instantiation';
 import { IKeybindings, KeybindingsRegistry, KeybindingWeight } from 'vs/platform/keybinding/common/keybindingsRegistry';
@@ -96,7 +96,7 @@ export interface ICommandOptions {
 	id: string;
 	precondition: ContextKeyExpression | undefined;
 	kbOpts?: ICommandKeybindingsOptions | ICommandKeybindingsOptions[];
-	description?: ICommandHandlerDescription;
+	metadata?: ICommandMetadata;
 	menuOpts?: ICommandMenuOptions | ICommandMenuOptions[];
 }
 export abstract class Command {
@@ -104,14 +104,14 @@ export abstract class Command {
 	public readonly precondition: ContextKeyExpression | undefined;
 	private readonly _kbOpts: ICommandKeybindingsOptions | ICommandKeybindingsOptions[] | undefined;
 	private readonly _menuOpts: ICommandMenuOptions | ICommandMenuOptions[] | undefined;
-	private readonly _description: ICommandHandlerDescription | undefined;
+	private readonly _metadata: ICommandMetadata | undefined;
 
 	constructor(opts: ICommandOptions) {
 		this.id = opts.id;
 		this.precondition = opts.precondition;
 		this._kbOpts = opts.kbOpts;
 		this._menuOpts = opts.menuOpts;
-		this._description = opts.description;
+		this._metadata = opts.metadata;
 	}
 
 	public register(): void {
@@ -153,7 +153,7 @@ export abstract class Command {
 		CommandsRegistry.registerCommand({
 			id: this.id,
 			handler: (accessor, args) => this.runCommand(accessor, args),
-			description: this._description
+			metadata: this._metadata
 		});
 	}
 

--- a/src/vs/editor/browser/editorExtensions.ts
+++ b/src/vs/editor/browser/editorExtensions.ts
@@ -376,11 +376,13 @@ export abstract class EditorAction extends EditorCommand {
 
 	public readonly label: string;
 	public readonly alias: string;
+	public readonly metadata: ICommandMetadata | undefined;
 
 	constructor(opts: IActionOptions) {
 		super(EditorAction.convertOptions(opts));
 		this.label = opts.label;
 		this.alias = opts.alias;
+		this.metadata = opts.metadata;
 	}
 
 	public runEditorCommand(accessor: ServicesAccessor, editor: ICodeEditor, args: any): void | Promise<void> {

--- a/src/vs/editor/browser/widget/codeEditorWidget.ts
+++ b/src/vs/editor/browser/widget/codeEditorWidget.ts
@@ -344,6 +344,7 @@ export class CodeEditorWidget extends Disposable implements editorBrowser.ICodeE
 				action.id,
 				action.label,
 				action.alias,
+				action.metadata,
 				action.precondition ?? undefined,
 				(): Promise<void> => {
 					return this._instantiationService.invokeFunction((accessor) => {

--- a/src/vs/editor/common/cursor/cursorMoveCommands.ts
+++ b/src/vs/editor/common/cursor/cursorMoveCommands.ts
@@ -9,7 +9,7 @@ import { MoveOperations } from 'vs/editor/common/cursor/cursorMoveOperations';
 import { WordOperations } from 'vs/editor/common/cursor/cursorWordOperations';
 import { IPosition, Position } from 'vs/editor/common/core/position';
 import { Range } from 'vs/editor/common/core/range';
-import { ICommandHandlerDescription } from 'vs/platform/commands/common/commands';
+import { ICommandMetadata } from 'vs/platform/commands/common/commands';
 import { IViewModel } from 'vs/editor/common/viewModel';
 
 export class CursorMoveCommands {
@@ -596,7 +596,7 @@ export namespace CursorMove {
 		return true;
 	};
 
-	export const description = <ICommandHandlerDescription>{
+	export const metadata = <ICommandMetadata>{
 		description: 'Move cursor to a logical position in the view',
 		args: [
 			{

--- a/src/vs/editor/common/editorAction.ts
+++ b/src/vs/editor/common/editorAction.ts
@@ -4,33 +4,20 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { IEditorAction } from 'vs/editor/common/editorCommon';
+import { ICommandMetadata } from 'vs/platform/commands/common/commands';
 import { IContextKeyService, ContextKeyExpression } from 'vs/platform/contextkey/common/contextkey';
 
 export class InternalEditorAction implements IEditorAction {
 
-	public readonly id: string;
-	public readonly label: string;
-	public readonly alias: string;
-
-	private readonly _precondition: ContextKeyExpression | undefined;
-	private readonly _run: (args: unknown) => Promise<void>;
-	private readonly _contextKeyService: IContextKeyService;
-
 	constructor(
-		id: string,
-		label: string,
-		alias: string,
-		precondition: ContextKeyExpression | undefined,
-		run: () => Promise<void>,
-		contextKeyService: IContextKeyService
-	) {
-		this.id = id;
-		this.label = label;
-		this.alias = alias;
-		this._precondition = precondition;
-		this._run = run;
-		this._contextKeyService = contextKeyService;
-	}
+		public readonly id: string,
+		public readonly label: string,
+		public readonly alias: string,
+		public readonly metadata: ICommandMetadata | undefined,
+		private readonly _precondition: ContextKeyExpression | undefined,
+		private readonly _run: (args: unknown) => Promise<void>,
+		private readonly _contextKeyService: IContextKeyService
+	) { }
 
 	public isSupported(): boolean {
 		return this._contextKeyService.contextMatchesRules(this._precondition);

--- a/src/vs/editor/common/editorCommon.ts
+++ b/src/vs/editor/common/editorCommon.ts
@@ -15,6 +15,7 @@ import { IRange, Range } from 'vs/editor/common/core/range';
 import { ISelection, Selection } from 'vs/editor/common/core/selection';
 import { IModelDecoration, IModelDecorationsChangeAccessor, IModelDeltaDecoration, ITextModel, IValidEditOperation, OverviewRulerLane, TrackedRangeStickiness } from 'vs/editor/common/model';
 import { IModelDecorationsChangedEvent } from 'vs/editor/common/textModelEvents';
+import { ICommandMetadata } from 'vs/platform/commands/common/commands';
 
 /**
  * A builder and helper for edit operations for a command.
@@ -155,6 +156,7 @@ export interface IEditorAction {
 	readonly id: string;
 	readonly label: string;
 	readonly alias: string;
+	readonly metadata: ICommandMetadata | undefined;
 	isSupported(): boolean;
 	run(args?: unknown): Promise<void>;
 }

--- a/src/vs/editor/common/standalone/standaloneEnums.ts
+++ b/src/vs/editor/common/standalone/standaloneEnums.ts
@@ -572,28 +572,28 @@ export enum KeyCode {
 	 * Either the angle bracket key or the backslash key on the RT 102-key keyboard.
 	 */
 	IntlBackslash = 97,
-	Numpad0 = 98,
-	Numpad1 = 99,
-	Numpad2 = 100,
-	Numpad3 = 101,
-	Numpad4 = 102,
-	Numpad5 = 103,
-	Numpad6 = 104,
-	Numpad7 = 105,
-	Numpad8 = 106,
-	Numpad9 = 107,
-	NumpadMultiply = 108,
-	NumpadAdd = 109,
-	NUMPAD_SEPARATOR = 110,
-	NumpadSubtract = 111,
-	NumpadDecimal = 112,
-	NumpadDivide = 113,
+	Numpad0 = 98,// VK_NUMPAD0, 0x60, Numeric keypad 0 key
+	Numpad1 = 99,// VK_NUMPAD1, 0x61, Numeric keypad 1 key
+	Numpad2 = 100,// VK_NUMPAD2, 0x62, Numeric keypad 2 key
+	Numpad3 = 101,// VK_NUMPAD3, 0x63, Numeric keypad 3 key
+	Numpad4 = 102,// VK_NUMPAD4, 0x64, Numeric keypad 4 key
+	Numpad5 = 103,// VK_NUMPAD5, 0x65, Numeric keypad 5 key
+	Numpad6 = 104,// VK_NUMPAD6, 0x66, Numeric keypad 6 key
+	Numpad7 = 105,// VK_NUMPAD7, 0x67, Numeric keypad 7 key
+	Numpad8 = 106,// VK_NUMPAD8, 0x68, Numeric keypad 8 key
+	Numpad9 = 107,// VK_NUMPAD9, 0x69, Numeric keypad 9 key
+	NumpadMultiply = 108,// VK_MULTIPLY, 0x6A, Multiply key
+	NumpadAdd = 109,// VK_ADD, 0x6B, Add key
+	NUMPAD_SEPARATOR = 110,// VK_SEPARATOR, 0x6C, Separator key
+	NumpadSubtract = 111,// VK_SUBTRACT, 0x6D, Subtract key
+	NumpadDecimal = 112,// VK_DECIMAL, 0x6E, Decimal key
+	NumpadDivide = 113,// VK_DIVIDE, 0x6F,
 	/**
 	 * Cover all key codes when IME is processing input.
 	 */
 	KEY_IN_COMPOSITION = 114,
-	ABNT_C1 = 115,
-	ABNT_C2 = 116,
+	ABNT_C1 = 115,// Brazilian (ABNT) Keyboard
+	ABNT_C2 = 116,// Brazilian (ABNT) Keyboard
 	AudioVolumeMute = 117,
 	AudioVolumeUp = 118,
 	AudioVolumeDown = 119,

--- a/src/vs/editor/contrib/bracketMatching/browser/bracketMatching.ts
+++ b/src/vs/editor/contrib/bracketMatching/browser/bracketMatching.ts
@@ -52,7 +52,7 @@ class SelectToBracketAction extends EditorAction {
 			label: nls.localize('smartSelect.selectToBracket', "Select to Bracket"),
 			alias: 'Select to Bracket',
 			precondition: undefined,
-			description: {
+			metadata: {
 				description: `Select to Bracket`,
 				args: [{
 					name: 'args',

--- a/src/vs/editor/contrib/bracketMatching/browser/bracketMatching.ts
+++ b/src/vs/editor/contrib/bracketMatching/browser/bracketMatching.ts
@@ -53,7 +53,7 @@ class SelectToBracketAction extends EditorAction {
 			alias: 'Select to Bracket',
 			precondition: undefined,
 			metadata: {
-				description: `Select to Bracket`,
+				description: nls.localize2('smartSelect.selectToBracketDescription', "Select the text inside and including the brackets or curly braces"),
 				args: [{
 					name: 'args',
 					schema: {

--- a/src/vs/editor/contrib/codeAction/browser/codeActionCommands.ts
+++ b/src/vs/editor/contrib/codeAction/browser/codeActionCommands.ts
@@ -90,7 +90,7 @@ export class CodeActionCommand extends EditorCommand {
 		super({
 			id: codeActionCommandId,
 			precondition: ContextKeyExpr.and(EditorContextKeys.writable, EditorContextKeys.hasCodeActionsProvider),
-			description: {
+			metadata: {
 				description: 'Trigger a code action',
 				args: [{ name: 'args', schema: argsSchema, }]
 			}
@@ -143,7 +143,7 @@ export class RefactorAction extends EditorAction {
 					EditorContextKeys.writable,
 					contextKeyForSupportedActions(CodeActionKind.Refactor)),
 			},
-			description: {
+			metadata: {
 				description: 'Refactor...',
 				args: [{ name: 'args', schema: argsSchema }]
 			}
@@ -186,7 +186,7 @@ export class SourceAction extends EditorAction {
 					EditorContextKeys.writable,
 					contextKeyForSupportedActions(CodeActionKind.Source)),
 			},
-			description: {
+			metadata: {
 				description: 'Source Action...',
 				args: [{ name: 'args', schema: argsSchema }]
 			}

--- a/src/vs/editor/contrib/dropOrPasteInto/browser/copyPasteContribution.ts
+++ b/src/vs/editor/contrib/dropOrPasteInto/browser/copyPasteContribution.ts
@@ -40,7 +40,7 @@ registerEditorAction(class extends EditorAction {
 			label: nls.localize('pasteAs', "Paste As..."),
 			alias: 'Paste As...',
 			precondition: undefined,
-			description: {
+			metadata: {
 				description: 'Paste as',
 				args: [{
 					name: 'args',

--- a/src/vs/editor/contrib/find/browser/findController.ts
+++ b/src/vs/editor/contrib/find/browser/findController.ts
@@ -597,7 +597,7 @@ export class StartFindWithArgsAction extends EditorAction {
 				primary: 0,
 				weight: KeybindingWeight.EditorContrib
 			},
-			description: findArgDescription
+			metadata: findArgDescription
 		});
 	}
 

--- a/src/vs/editor/contrib/folding/browser/folding.ts
+++ b/src/vs/editor/contrib/folding/browser/folding.ts
@@ -623,7 +623,7 @@ class UnfoldAction extends FoldingAction<FoldingArguments> {
 				},
 				weight: KeybindingWeight.EditorContrib
 			},
-			description: {
+			metadata: {
 				description: 'Unfold the content in the editor',
 				args: [
 					{
@@ -708,7 +708,7 @@ class FoldAction extends FoldingAction<FoldingArguments> {
 				},
 				weight: KeybindingWeight.EditorContrib
 			},
-			description: {
+			metadata: {
 				description: 'Fold the content in the editor',
 				args: [
 					{

--- a/src/vs/editor/contrib/gotoSymbol/browser/goToCommands.ts
+++ b/src/vs/editor/contrib/gotoSymbol/browser/goToCommands.ts
@@ -798,7 +798,7 @@ class GenericGoToLocationAction extends SymbolNavigationAction {
 
 CommandsRegistry.registerCommand({
 	id: 'editor.action.goToLocations',
-	description: {
+	metadata: {
 		description: 'Go to locations from a position in a file',
 		args: [
 			{ name: 'uri', description: 'The text document in which to start', constraint: URI },
@@ -841,7 +841,7 @@ CommandsRegistry.registerCommand({
 
 CommandsRegistry.registerCommand({
 	id: 'editor.action.peekLocations',
-	description: {
+	metadata: {
 		description: 'Peek locations from a position in a file',
 		args: [
 			{ name: 'uri', description: 'The text document in which to start', constraint: URI },

--- a/src/vs/editor/contrib/hover/browser/hover.ts
+++ b/src/vs/editor/contrib/hover/browser/hover.ts
@@ -380,7 +380,7 @@ class ShowOrFocusHoverAction extends EditorAction {
 					'If the hover is already visible, it will take focus.'
 				]
 			}, "Show or Focus Hover"),
-			description: {
+			metadata: {
 				description: `Show or Focus Hover`,
 				args: [{
 					name: 'args',

--- a/src/vs/editor/contrib/multicursor/browser/multicursor.ts
+++ b/src/vs/editor/contrib/multicursor/browser/multicursor.ts
@@ -1079,7 +1079,7 @@ export class FocusNextCursor extends EditorAction {
 		super({
 			id: 'editor.action.focusNextCursor',
 			label: nls.localize('mutlicursor.focusNextCursor', "Focus Next Cursor"),
-			description: {
+			metadata: {
 				description: nls.localize('mutlicursor.focusNextCursor.description', "Focuses the next cursor"),
 				args: [],
 			},
@@ -1118,7 +1118,7 @@ export class FocusPreviousCursor extends EditorAction {
 		super({
 			id: 'editor.action.focusPreviousCursor',
 			label: nls.localize('mutlicursor.focusPreviousCursor', "Focus Previous Cursor"),
-			description: {
+			metadata: {
 				description: nls.localize('mutlicursor.focusPreviousCursor.description', "Focuses the previous cursor"),
 				args: [],
 			},

--- a/src/vs/editor/contrib/quickAccess/browser/commandsQuickAccess.ts
+++ b/src/vs/editor/contrib/quickAccess/browser/commandsQuickAccess.ts
@@ -5,6 +5,7 @@
 
 import { stripIcons } from 'vs/base/common/iconLabels';
 import { IEditor } from 'vs/editor/common/editorCommon';
+import { isLocalizedString } from 'vs/platform/action/common/action';
 import { ICommandService } from 'vs/platform/commands/common/commands';
 import { IDialogService } from 'vs/platform/dialogs/common/dialogs';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
@@ -38,10 +39,17 @@ export abstract class AbstractEditorCommandsQuickAccessProvider extends Abstract
 
 		const editorCommandPicks: ICommandQuickPick[] = [];
 		for (const editorAction of activeTextEditorControl.getSupportedActions()) {
+			const metadataDescription = editorAction.metadata?.description;
+			const commandDescription = metadataDescription === undefined || isLocalizedString(metadataDescription)
+				? metadataDescription
+				// TODO: this type will eventually not be a string and when that happens, this should simplified.
+				: { value: metadataDescription, original: metadataDescription };
+
 			editorCommandPicks.push({
 				commandId: editorAction.id,
 				commandAlias: editorAction.alias,
 				label: stripIcons(editorAction.label) || editorAction.id,
+				commandDescription,
 			});
 		}
 

--- a/src/vs/editor/standalone/browser/standaloneCodeEditor.ts
+++ b/src/vs/editor/standalone/browser/standaloneCodeEditor.ts
@@ -367,6 +367,8 @@ export class StandaloneCodeEditor extends CodeEditorWidget implements IStandalon
 			uniqueId,
 			label,
 			label,
+			// TODO: support this somehow? Do I need the metadata to be a part of the API?
+			undefined,
 			precondition,
 			(...args: unknown[]) => Promise.resolve(_descriptor.run(this, ...args)),
 			this._contextKeyService

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -3,6 +3,10 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+// TODO
+// eslint-disable-next-line local/code-import-patterns
+import { ICommandMetadata } from 'vs/platform/commands/common/commands';
+
 declare let MonacoEnvironment: monaco.Environment | undefined;
 
 interface Window {
@@ -2469,6 +2473,7 @@ declare namespace monaco.editor {
 		readonly id: string;
 		readonly label: string;
 		readonly alias: string;
+		readonly metadata: ICommandMetadata | undefined;
 		isSupported(): boolean;
 		run(args?: unknown): Promise<void>;
 	}

--- a/src/vs/platform/action/common/action.ts
+++ b/src/vs/platform/action/common/action.ts
@@ -7,7 +7,7 @@ import { URI, UriDto } from 'vs/base/common/uri';
 import { ContextKeyExpression } from 'vs/platform/contextkey/common/contextkey';
 import { ThemeIcon } from 'vs/base/common/themables';
 import { Categories } from './actionCommonCategories';
-import { ICommandHandlerDescription } from 'vs/platform/commands/common/commands';
+import { ICommandMetadata } from 'vs/platform/commands/common/commands';
 
 export interface ILocalizedString {
 
@@ -80,7 +80,7 @@ export interface ICommandAction {
 	 * - when showing keybindings that have no other UX
 	 * - when searching for commands in the Command Palette
 	 */
-	description?: ICommandHandlerDescription;
+	metadata?: ICommandMetadata;
 	category?: keyof typeof Categories | ILocalizedString | string;
 	tooltip?: string | ILocalizedString;
 	icon?: Icon;

--- a/src/vs/platform/action/common/action.ts
+++ b/src/vs/platform/action/common/action.ts
@@ -7,6 +7,7 @@ import { URI, UriDto } from 'vs/base/common/uri';
 import { ContextKeyExpression } from 'vs/platform/contextkey/common/contextkey';
 import { ThemeIcon } from 'vs/base/common/themables';
 import { Categories } from './actionCommonCategories';
+import { ICommandHandlerDescription } from 'vs/platform/commands/common/commands';
 
 export interface ILocalizedString {
 
@@ -19,6 +20,13 @@ export interface ILocalizedString {
 	 * The original (non localized value of the string)
 	 */
 	original: string;
+}
+
+export function isLocalizedString(thing: any): thing is ILocalizedString {
+	return thing
+		&& typeof thing === 'object'
+		&& typeof thing.original === 'string'
+		&& typeof thing.value === 'string';
 }
 
 export interface ICommandActionTitle extends ILocalizedString {
@@ -66,6 +74,13 @@ export interface ICommandAction {
 	id: string;
 	title: string | ICommandActionTitle;
 	shortTitle?: string | ICommandActionTitle;
+	/**
+	 * Metadata about this command, used for:
+	 * - API commands
+	 * - when showing keybindings that have no other UX
+	 * - when searching for commands in the Command Palette
+	 */
+	description?: ICommandHandlerDescription;
 	category?: keyof typeof Categories | ILocalizedString | string;
 	tooltip?: string | ILocalizedString;
 	icon?: Icon;

--- a/src/vs/platform/actions/common/actions.ts
+++ b/src/vs/platform/actions/common/actions.ts
@@ -455,8 +455,8 @@ export class MenuItemAction implements IAction {
 		this.enabled = !item.precondition || contextKeyService.contextMatchesRules(item.precondition);
 		this.checked = undefined;
 
-		if (item.description) {
-			this.description = isLocalizedString(item.description.description) ? item.description.description : { value: item.description.description, original: item.description.description };
+		if (item.metadata) {
+			this.description = isLocalizedString(item.metadata.description) ? item.metadata.description : { value: item.metadata.description, original: item.metadata.description };
 		}
 
 		let icon: ThemeIcon | undefined;
@@ -576,7 +576,7 @@ export function registerAction2(ctor: { new(): Action2 }): IDisposable {
 	disposables.add(CommandsRegistry.registerCommand({
 		id: command.id,
 		handler: (accessor, ...args) => action.run(accessor, ...args),
-		description: command.description,
+		metadata: command.metadata,
 	}));
 
 	// menu

--- a/src/vs/platform/actions/common/actions.ts
+++ b/src/vs/platform/actions/common/actions.ts
@@ -8,9 +8,9 @@ import { ThemeIcon } from 'vs/base/common/themables';
 import { Event, MicrotaskEmitter } from 'vs/base/common/event';
 import { DisposableStore, IDisposable, toDisposable } from 'vs/base/common/lifecycle';
 import { LinkedList } from 'vs/base/common/linkedList';
-import { ICommandAction, ICommandActionTitle, Icon, ILocalizedString } from 'vs/platform/action/common/action';
+import { ICommandAction, ICommandActionTitle, Icon, ILocalizedString, isLocalizedString } from 'vs/platform/action/common/action';
 import { Categories } from 'vs/platform/action/common/actionCommonCategories';
-import { CommandsRegistry, ICommandHandlerDescription, ICommandService } from 'vs/platform/commands/common/commands';
+import { CommandsRegistry, ICommandService } from 'vs/platform/commands/common/commands';
 import { ContextKeyExpr, ContextKeyExpression, IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 import { createDecorator, ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
 import { IKeybindingRule, KeybindingsRegistry } from 'vs/platform/keybinding/common/keybindingsRegistry';
@@ -436,6 +436,7 @@ export class MenuItemAction implements IAction {
 	readonly id: string;
 	readonly label: string;
 	readonly tooltip: string;
+	readonly description?: ILocalizedString | undefined;
 	readonly class: string | undefined;
 	readonly enabled: boolean;
 	readonly checked?: boolean;
@@ -453,6 +454,10 @@ export class MenuItemAction implements IAction {
 		this.tooltip = (typeof item.tooltip === 'string' ? item.tooltip : item.tooltip?.value) ?? '';
 		this.enabled = !item.precondition || contextKeyService.contextMatchesRules(item.precondition);
 		this.checked = undefined;
+
+		if (item.description) {
+			this.description = isLocalizedString(item.description.description) ? item.description.description : { value: item.description.description, original: item.description.description };
+		}
 
 		let icon: ThemeIcon | undefined;
 
@@ -514,12 +519,6 @@ interface IAction2CommonOptions extends ICommandAction {
 	 * One keybinding.
 	 */
 	keybinding?: OneOrN<Omit<IKeybindingRule, 'id'>>;
-
-	/**
-	 * Metadata about this command, used for API commands or when
-	 * showing keybindings that have no other UX.
-	 */
-	description?: ICommandHandlerDescription;
 }
 
 interface IBaseAction2Options extends IAction2CommonOptions {
@@ -571,13 +570,13 @@ export function registerAction2(ctor: { new(): Action2 }): IDisposable {
 	const disposables = new DisposableStore();
 	const action = new ctor();
 
-	const { f1, menu, keybinding, description, ...command } = action.desc;
+	const { f1, menu, keybinding, ...command } = action.desc;
 
 	// command
 	disposables.add(CommandsRegistry.registerCommand({
 		id: command.id,
 		handler: (accessor, ...args) => action.run(accessor, ...args),
-		description: description,
+		description: command.description,
 	}));
 
 	// menu

--- a/src/vs/platform/actions/common/actions.ts
+++ b/src/vs/platform/actions/common/actions.ts
@@ -8,7 +8,7 @@ import { ThemeIcon } from 'vs/base/common/themables';
 import { Event, MicrotaskEmitter } from 'vs/base/common/event';
 import { DisposableStore, IDisposable, toDisposable } from 'vs/base/common/lifecycle';
 import { LinkedList } from 'vs/base/common/linkedList';
-import { ICommandAction, ICommandActionTitle, Icon, ILocalizedString, isLocalizedString } from 'vs/platform/action/common/action';
+import { ICommandAction, ICommandActionTitle, Icon, ILocalizedString } from 'vs/platform/action/common/action';
 import { Categories } from 'vs/platform/action/common/actionCommonCategories';
 import { CommandsRegistry, ICommandService } from 'vs/platform/commands/common/commands';
 import { ContextKeyExpr, ContextKeyExpression, IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
@@ -436,7 +436,6 @@ export class MenuItemAction implements IAction {
 	readonly id: string;
 	readonly label: string;
 	readonly tooltip: string;
-	readonly description?: ILocalizedString | undefined;
 	readonly class: string | undefined;
 	readonly enabled: boolean;
 	readonly checked?: boolean;
@@ -454,10 +453,6 @@ export class MenuItemAction implements IAction {
 		this.tooltip = (typeof item.tooltip === 'string' ? item.tooltip : item.tooltip?.value) ?? '';
 		this.enabled = !item.precondition || contextKeyService.contextMatchesRules(item.precondition);
 		this.checked = undefined;
-
-		if (item.metadata) {
-			this.description = isLocalizedString(item.metadata.description) ? item.metadata.description : { value: item.metadata.description, original: item.metadata.description };
-		}
 
 		let icon: ThemeIcon | undefined;
 

--- a/src/vs/platform/commands/common/commands.ts
+++ b/src/vs/platform/commands/common/commands.ts
@@ -35,10 +35,10 @@ export interface ICommandHandler {
 export interface ICommand {
 	id: string;
 	handler: ICommandHandler;
-	description?: ICommandHandlerDescription | null;
+	metadata?: ICommandMetadata | null;
 }
 
-export interface ICommandHandlerDescription {
+export interface ICommandMetadata {
 	/**
 	 * NOTE: Please use an ILocalizedString. string is in the type for backcompat for now.
 	 * A short summary of what the command does. This will be used in:
@@ -87,9 +87,9 @@ export const CommandsRegistry: ICommandRegistry = new class implements ICommandR
 		}
 
 		// add argument validation if rich command metadata is provided
-		if (idOrCommand.description && Array.isArray(idOrCommand.description.args)) {
+		if (idOrCommand.metadata && Array.isArray(idOrCommand.metadata.args)) {
 			const constraints: Array<TypeConstraint | undefined> = [];
-			for (const arg of idOrCommand.description.args) {
+			for (const arg of idOrCommand.metadata.args) {
 				constraints.push(arg.constraint);
 			}
 			const actualHandler = idOrCommand.handler;

--- a/src/vs/platform/commands/common/commands.ts
+++ b/src/vs/platform/commands/common/commands.ts
@@ -9,6 +9,7 @@ import { IJSONSchema } from 'vs/base/common/jsonSchema';
 import { IDisposable, toDisposable } from 'vs/base/common/lifecycle';
 import { LinkedList } from 'vs/base/common/linkedList';
 import { TypeConstraint, validateConstraints } from 'vs/base/common/types';
+import { ILocalizedString } from 'vs/platform/action/common/action';
 import { createDecorator, ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
 
 export const ICommandService = createDecorator<ICommandService>('commandService');
@@ -38,8 +39,15 @@ export interface ICommand {
 }
 
 export interface ICommandHandlerDescription {
-	readonly description: string;
-	readonly args: ReadonlyArray<{
+	/**
+	 * NOTE: Please use an ILocalizedString. string is in the type for backcompat for now.
+	 * A short summary of what the command does. This will be used in:
+	 * - API commands
+	 * - when showing keybindings that have no other UX
+	 * - when searching for commands in the Command Palette
+	 */
+	readonly description: ILocalizedString | string;
+	readonly args?: ReadonlyArray<{
 		readonly name: string;
 		readonly isOptional?: boolean;
 		readonly description?: string;
@@ -79,7 +87,7 @@ export const CommandsRegistry: ICommandRegistry = new class implements ICommandR
 		}
 
 		// add argument validation if rich command metadata is provided
-		if (idOrCommand.description) {
+		if (idOrCommand.description && Array.isArray(idOrCommand.description.args)) {
 			const constraints: Array<TypeConstraint | undefined> = [];
 			for (const arg of idOrCommand.description.args) {
 				constraints.push(arg.constraint);

--- a/src/vs/platform/commands/test/common/commands.test.ts
+++ b/src/vs/platform/commands/test/common/commands.test.ts
@@ -66,7 +66,7 @@ suite('Command Tests', function () {
 			handler: function (accessor, args) {
 				return true;
 			},
-			description: {
+			metadata: {
 				description: 'a command',
 				args: [{ name: 'value', constraint: Number }]
 			}

--- a/src/vs/platform/contextkey/browser/contextKeyService.ts
+++ b/src/vs/platform/contextkey/browser/contextKeyService.ts
@@ -618,7 +618,7 @@ CommandsRegistry.registerCommand({
 	handler() {
 		return [...RawContextKey.all()].sort((a, b) => a.key.localeCompare(b.key));
 	},
-	description: {
+	metadata: {
 		description: localize('getContextKeyInfo', "A command that returns information about context keys"),
 		args: []
 	}

--- a/src/vs/platform/keybinding/common/keybindingsRegistry.ts
+++ b/src/vs/platform/keybinding/common/keybindingsRegistry.ts
@@ -5,7 +5,7 @@
 
 import { decodeKeybinding, Keybinding } from 'vs/base/common/keybindings';
 import { OperatingSystem, OS } from 'vs/base/common/platform';
-import { CommandsRegistry, ICommandHandler, ICommandHandlerDescription } from 'vs/platform/commands/common/commands';
+import { CommandsRegistry, ICommandHandler, ICommandMetadata } from 'vs/platform/commands/common/commands';
 import { ContextKeyExpression } from 'vs/platform/contextkey/common/contextkey';
 import { Registry } from 'vs/platform/registry/common/platform';
 import { combinedDisposable, DisposableStore, IDisposable, toDisposable } from 'vs/base/common/lifecycle';
@@ -66,7 +66,7 @@ export const enum KeybindingWeight {
 
 export interface ICommandAndKeybindingRule extends IKeybindingRule {
 	handler: ICommandHandler;
-	description?: ICommandHandlerDescription | null;
+	metadata?: ICommandMetadata | null;
 }
 
 export interface IKeybindingsRegistry {

--- a/src/vs/workbench/api/browser/mainThreadCommands.ts
+++ b/src/vs/workbench/api/browser/mainThreadCommands.ts
@@ -5,7 +5,7 @@
 
 import { DisposableMap, IDisposable } from 'vs/base/common/lifecycle';
 import { revive } from 'vs/base/common/marshalling';
-import { CommandsRegistry, ICommandHandlerDescription, ICommandService } from 'vs/platform/commands/common/commands';
+import { CommandsRegistry, ICommandMetadata, ICommandService } from 'vs/platform/commands/common/commands';
 import { IExtHostContext, extHostNamedCustomer } from 'vs/workbench/services/extensions/common/extHostCustomers';
 import { IExtensionService } from 'vs/workbench/services/extensions/common/extensions';
 import { Dto, SerializableObjectWithBuffers } from 'vs/workbench/services/extensions/common/proxyIdentifier';
@@ -36,13 +36,13 @@ export class MainThreadCommands implements MainThreadCommandsShape {
 	}
 
 	private async _generateCommandsDocumentation(): Promise<void> {
-		const result = await this._proxy.$getContributedCommandHandlerDescriptions();
+		const result = await this._proxy.$getContributedCommandMetadata();
 
 		// add local commands
 		const commands = CommandsRegistry.getCommands();
 		for (const [id, command] of commands) {
-			if (command.description) {
-				result[id] = command.description;
+			if (command.metadata) {
+				result[id] = command.metadata;
 			}
 		}
 
@@ -99,7 +99,7 @@ export class MainThreadCommands implements MainThreadCommandsShape {
 
 // --- command doc
 
-function _generateMarkdown(description: string | Dto<ICommandHandlerDescription> | ICommandHandlerDescription): string {
+function _generateMarkdown(description: string | Dto<ICommandMetadata> | ICommandMetadata): string {
 	if (typeof description === 'string') {
 		return description;
 	} else {

--- a/src/vs/workbench/api/browser/mainThreadCommands.ts
+++ b/src/vs/workbench/api/browser/mainThreadCommands.ts
@@ -10,6 +10,7 @@ import { IExtHostContext, extHostNamedCustomer } from 'vs/workbench/services/ext
 import { IExtensionService } from 'vs/workbench/services/extensions/common/extensions';
 import { Dto, SerializableObjectWithBuffers } from 'vs/workbench/services/extensions/common/proxyIdentifier';
 import { ExtHostCommandsShape, ExtHostContext, MainContext, MainThreadCommandsShape } from '../common/extHost.protocol';
+import { isString } from 'vs/base/common/types';
 
 
 @extHostNamedCustomer(MainContext.MainThreadCommands)
@@ -102,7 +103,11 @@ function _generateMarkdown(description: string | Dto<ICommandHandlerDescription>
 	if (typeof description === 'string') {
 		return description;
 	} else {
-		const parts = [description.description];
+		const descriptionString = isString(description.description)
+			? description.description
+			// Our docs website is in English, so keep the original here.
+			: description.description.original;
+		const parts = [descriptionString];
 		parts.push('\n\n');
 		if (description.args) {
 			for (const arg of description.args) {

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -27,6 +27,7 @@ import { CharacterPair, CommentRule, EnterAction } from 'vs/editor/common/langua
 import { EndOfLineSequence } from 'vs/editor/common/model';
 import { IModelChangedEvent } from 'vs/editor/common/model/mirrorTextModel';
 import { IAccessibilityInformation } from 'vs/platform/accessibility/common/accessibility';
+import { ILocalizedString } from 'vs/platform/action/common/action';
 import { ConfigurationTarget, IConfigurationChange, IConfigurationData, IConfigurationOverrides } from 'vs/platform/configuration/common/configuration';
 import { ConfigurationScope } from 'vs/platform/configuration/common/configurationRegistry';
 import { IExtensionIdWithVersion } from 'vs/platform/extensionManagement/common/extensionStorage';
@@ -1543,8 +1544,15 @@ export interface MainThreadTimelineShape extends IDisposable {
 // -- extension host
 
 export interface ICommandHandlerDescriptionDto {
-	readonly description: string;
-	readonly args: ReadonlyArray<{
+	/**
+	 * NOTE: Please use an ILocalizedString. string is in the type for backcompat for now.
+	 * A short summary of what the command does. This will be used in:
+	 * - API commands
+	 * - when showing keybindings that have no other UX
+	 * - when searching for commands in the Command Palette
+	 */
+	readonly description: ILocalizedString | string;
+	readonly args?: ReadonlyArray<{
 		readonly name: string;
 		readonly isOptional?: boolean;
 		readonly description?: string;

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -1543,7 +1543,7 @@ export interface MainThreadTimelineShape extends IDisposable {
 
 // -- extension host
 
-export interface ICommandHandlerDescriptionDto {
+export interface ICommandMetadataDto {
 	/**
 	 * NOTE: Please use an ILocalizedString. string is in the type for backcompat for now.
 	 * A short summary of what the command does. This will be used in:
@@ -1562,7 +1562,7 @@ export interface ICommandHandlerDescriptionDto {
 
 export interface ExtHostCommandsShape {
 	$executeContributedCommand(id: string, ...args: any[]): Promise<unknown>;
-	$getContributedCommandHandlerDescriptions(): Promise<{ [id: string]: string | ICommandHandlerDescriptionDto }>;
+	$getContributedCommandMetadata(): Promise<{ [id: string]: string | ICommandMetadataDto }>;
 }
 
 export interface ExtHostConfigurationShape {

--- a/src/vs/workbench/api/common/extHostCommands.ts
+++ b/src/vs/workbench/api/common/extHostCommands.ts
@@ -233,7 +233,7 @@ export class ExtHostCommands implements ExtHostCommandsShape {
 			throw new Error('Unknown command');
 		}
 		const { callback, thisArg, description } = command;
-		if (description) {
+		if (description?.args) {
 			for (let i = 0; i < description.args.length; i++) {
 				try {
 					validateConstraint(args[i], description.args[i].constraint);

--- a/src/vs/workbench/api/common/extHostCommands.ts
+++ b/src/vs/workbench/api/common/extHostCommands.ts
@@ -6,11 +6,11 @@
 /* eslint-disable local/code-no-native-private */
 
 import { validateConstraint } from 'vs/base/common/types';
-import { ICommandHandlerDescription } from 'vs/platform/commands/common/commands';
+import { ICommandMetadata } from 'vs/platform/commands/common/commands';
 import * as extHostTypes from 'vs/workbench/api/common/extHostTypes';
 import * as extHostTypeConverter from 'vs/workbench/api/common/extHostTypeConverters';
 import { cloneAndChange } from 'vs/base/common/objects';
-import { MainContext, MainThreadCommandsShape, ExtHostCommandsShape, ICommandDto, ICommandHandlerDescriptionDto, MainThreadTelemetryShape } from './extHost.protocol';
+import { MainContext, MainThreadCommandsShape, ExtHostCommandsShape, ICommandDto, ICommandMetadataDto, MainThreadTelemetryShape } from './extHost.protocol';
 import { isNonEmptyArray } from 'vs/base/common/arrays';
 import * as languages from 'vs/editor/common/languages';
 import type * as vscode from 'vscode';
@@ -35,7 +35,7 @@ import { IExtHostTelemetry } from 'vs/workbench/api/common/extHostTelemetry';
 interface CommandHandler {
 	callback: Function;
 	thisArg: any;
-	description?: ICommandHandlerDescription;
+	metadata?: ICommandMetadata;
 	extension?: IExtensionDescription;
 }
 
@@ -144,7 +144,7 @@ export class ExtHostCommands implements ExtHostCommandsShape {
 		});
 	}
 
-	registerCommand(global: boolean, id: string, callback: <T>(...args: any[]) => T | Thenable<T>, thisArg?: any, description?: ICommandHandlerDescription, extension?: IExtensionDescription): extHostTypes.Disposable {
+	registerCommand(global: boolean, id: string, callback: <T>(...args: any[]) => T | Thenable<T>, thisArg?: any, metadata?: ICommandMetadata, extension?: IExtensionDescription): extHostTypes.Disposable {
 		this._logService.trace('ExtHostCommands#registerCommand', id);
 
 		if (!id.trim().length) {
@@ -155,7 +155,7 @@ export class ExtHostCommands implements ExtHostCommandsShape {
 			throw new Error(`command '${id}' already exists`);
 		}
 
-		this._commands.set(id, { callback, thisArg, description, extension });
+		this._commands.set(id, { callback, thisArg, metadata, extension });
 		if (global) {
 			this.#proxy.$registerCommand(id);
 		}
@@ -232,13 +232,13 @@ export class ExtHostCommands implements ExtHostCommandsShape {
 		if (!command) {
 			throw new Error('Unknown command');
 		}
-		const { callback, thisArg, description } = command;
-		if (description?.args) {
-			for (let i = 0; i < description.args.length; i++) {
+		const { callback, thisArg, metadata } = command;
+		if (metadata?.args) {
+			for (let i = 0; i < metadata.args.length; i++) {
 				try {
-					validateConstraint(args[i], description.args[i].constraint);
+					validateConstraint(args[i], metadata.args[i].constraint);
 				} catch (err) {
-					throw new Error(`Running the contributed command: '${id}' failed.Illegal argument '${description.args[i].name}' - ${description.args[i].description} `);
+					throw new Error(`Running the contributed command: '${id}' failed. Illegal argument '${metadata.args[i].name}' - ${metadata.args[i].description}`);
 				}
 			}
 		}
@@ -325,12 +325,12 @@ export class ExtHostCommands implements ExtHostCommandsShape {
 		});
 	}
 
-	$getContributedCommandHandlerDescriptions(): Promise<{ [id: string]: string | ICommandHandlerDescriptionDto }> {
-		const result: { [id: string]: string | ICommandHandlerDescription } = Object.create(null);
+	$getContributedCommandMetadata(): Promise<{ [id: string]: string | ICommandMetadataDto }> {
+		const result: { [id: string]: string | ICommandMetadata } = Object.create(null);
 		for (const [id, command] of this._commands) {
-			const { description } = command;
-			if (description) {
-				result[id] = description;
+			const { metadata } = command;
+			if (metadata) {
+				result[id] = metadata;
 			}
 		}
 		return Promise.resolve(result);

--- a/src/vs/workbench/browser/actions/developerActions.ts
+++ b/src/vs/workbench/browser/actions/developerActions.ts
@@ -353,8 +353,8 @@ class ToggleScreencastModeAction extends Action2 {
 
 		const fromCommandsRegistry = CommandsRegistry.getCommand(commandId);
 
-		if (fromCommandsRegistry && fromCommandsRegistry.description?.description) {
-			return { title: typeof fromCommandsRegistry.description.description === 'string' ? fromCommandsRegistry.description.description : fromCommandsRegistry.description.description.value };
+		if (fromCommandsRegistry && fromCommandsRegistry.metadata?.description) {
+			return { title: typeof fromCommandsRegistry.metadata.description === 'string' ? fromCommandsRegistry.metadata.description : fromCommandsRegistry.metadata.description.value };
 		}
 
 		return undefined;

--- a/src/vs/workbench/browser/actions/developerActions.ts
+++ b/src/vs/workbench/browser/actions/developerActions.ts
@@ -354,7 +354,7 @@ class ToggleScreencastModeAction extends Action2 {
 		const fromCommandsRegistry = CommandsRegistry.getCommand(commandId);
 
 		if (fromCommandsRegistry && fromCommandsRegistry.description?.description) {
-			return { title: fromCommandsRegistry.description.description };
+			return { title: typeof fromCommandsRegistry.description.description === 'string' ? fromCommandsRegistry.description.description : fromCommandsRegistry.description.description.value };
 		}
 
 		return undefined;

--- a/src/vs/workbench/browser/actions/quickAccessActions.ts
+++ b/src/vs/workbench/browser/actions/quickAccessActions.ts
@@ -126,7 +126,7 @@ registerAction2(class QuickAccessAction extends Action2 {
 				value: localize('quickOpen', "Go to File..."),
 				original: 'Go to File...'
 			},
-			description: {
+			metadata: {
 				description: `Quick access`,
 				args: [{
 					name: 'prefix',

--- a/src/vs/workbench/browser/actions/workspaceCommands.ts
+++ b/src/vs/workbench/browser/actions/workspaceCommands.ts
@@ -200,7 +200,7 @@ CommandsRegistry.registerCommand({
 		const uriToOpen: IWindowOpenable = (hasWorkspaceFileExtension(uri) || uri.scheme === Schemas.untitled) ? { workspaceUri: uri } : { folderUri: uri };
 		return commandService.executeCommand('_files.windowOpen', [uriToOpen], options);
 	},
-	description: {
+	metadata: {
 		description: 'Open a folder or workspace in the current window or new window depending on the newWindow argument. Note that opening in the same window will shutdown the current extension host process and start a new one on the given folder/workspace unless the newWindow parameter is set to true.',
 		args: [
 			{
@@ -241,7 +241,7 @@ CommandsRegistry.registerCommand({
 
 		return commandService.executeCommand('_files.newWindow', commandOptions);
 	},
-	description: {
+	metadata: {
 		description: 'Opens an new window depending on the newWindow argument.',
 		args: [
 			{
@@ -274,7 +274,7 @@ CommandsRegistry.registerCommand({
 
 		return workspacesService.removeRecentlyOpened([path]);
 	},
-	description: {
+	metadata: {
 		description: 'Removes an entry with the given path from the recently opened list.',
 		args: [
 			{ name: 'path', description: 'URI or URI string to remove from recently opened.', constraint: (value: any) => typeof value === 'string' || value instanceof URI }

--- a/src/vs/workbench/browser/parts/editor/editorCommands.ts
+++ b/src/vs/workbench/browser/parts/editor/editorCommands.ts
@@ -159,7 +159,7 @@ function registerActiveEditorMoveCopyCommand(): void {
 		when: EditorContextKeys.editorTextFocus,
 		primary: 0,
 		handler: (accessor, args) => moveCopyActiveEditor(true, args, accessor),
-		description: {
+		metadata: {
 			description: localize('editorCommand.activeEditorMove.description', "Move the active editor by tabs or groups"),
 			args: [
 				{
@@ -178,7 +178,7 @@ function registerActiveEditorMoveCopyCommand(): void {
 		when: EditorContextKeys.editorTextFocus,
 		primary: 0,
 		handler: (accessor, args) => moveCopyActiveEditor(false, args, accessor),
-		description: {
+		metadata: {
 			description: localize('editorCommand.activeEditorCopy.description', "Copy the active editor by groups"),
 			args: [
 				{
@@ -323,7 +323,7 @@ function registerEditorGroupsLayoutCommands(): void {
 	CommandsRegistry.registerCommand({
 		id: 'vscode.setEditorLayout',
 		handler: (accessor: ServicesAccessor, args: EditorGroupLayout) => applyEditorLayout(accessor, args),
-		description: {
+		metadata: {
 			description: 'Set Editor Layout',
 			args: [{
 				name: 'args',
@@ -353,7 +353,7 @@ function registerEditorGroupsLayoutCommands(): void {
 
 			return editorGroupService.getLayout();
 		},
-		description: {
+		metadata: {
 			description: 'Get Editor Layout',
 			args: [],
 			returns: 'An editor layout object, in the same format as vscode.setEditorLayout'
@@ -526,7 +526,7 @@ function registerOpenEditorAPICommands(): void {
 		handler: (accessor, arg) => {
 			accessor.get(ICommandService).executeCommand(API_OPEN_EDITOR_COMMAND_ID, arg);
 		},
-		description: {
+		metadata: {
 			description: 'Opens the provided resource in the editor.',
 			args: [{ name: 'Uri' }]
 		}
@@ -584,7 +584,7 @@ function registerOpenEditorAPICommands(): void {
 		handler: (accessor, left, right, label) => {
 			accessor.get(ICommandService).executeCommand(API_OPEN_DIFF_EDITOR_COMMAND_ID, left, right, label);
 		},
-		description: {
+		metadata: {
 			description: 'Opens the provided resources in the diff editor to compare their contents.',
 			args: [
 				{ name: 'left', description: 'Left-hand side resource of the diff editor' },

--- a/src/vs/workbench/browser/parts/views/viewsService.ts
+++ b/src/vs/workbench/browser/parts/views/viewsService.ts
@@ -502,7 +502,7 @@ export class ViewsService extends Disposable implements IViewsService {
 						mac: viewDescriptor.focusCommand?.keybindings?.mac,
 						win: viewDescriptor.focusCommand?.keybindings?.win
 					},
-					description: {
+					metadata: {
 						description: title,
 						args: [
 							{

--- a/src/vs/workbench/contrib/commands/common/commands.contribution.ts
+++ b/src/vs/workbench/contrib/commands/common/commands.contribution.ts
@@ -24,7 +24,7 @@ class RunCommands extends Action2 {
 			id: 'runCommands',
 			title: { value: nls.localize('runCommands', "Run Commands"), original: 'Run Commands' },
 			f1: false,
-			description: {
+			metadata: {
 				description: nls.localize('runCommands.description', "Run several commands"),
 				args: [
 					{

--- a/src/vs/workbench/contrib/extensions/browser/extensions.contribution.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensions.contribution.ts
@@ -285,7 +285,7 @@ CommandsRegistry.registerCommand('extension.open', async (accessor: ServicesAcce
 
 CommandsRegistry.registerCommand({
 	id: 'workbench.extensions.installExtension',
-	description: {
+	metadata: {
 		description: localize('workbench.extensions.installExtension.description', "Install the given extension"),
 		args: [
 			{
@@ -364,7 +364,7 @@ CommandsRegistry.registerCommand({
 
 CommandsRegistry.registerCommand({
 	id: 'workbench.extensions.uninstallExtension',
-	description: {
+	metadata: {
 		description: localize('workbench.extensions.uninstallExtension.description', "Uninstall the given extension"),
 		args: [
 			{
@@ -400,7 +400,7 @@ CommandsRegistry.registerCommand({
 
 CommandsRegistry.registerCommand({
 	id: 'workbench.extensions.search',
-	description: {
+	metadata: {
 		description: localize('workbench.extensions.search.description', "Search for a specific extension"),
 		args: [
 			{

--- a/src/vs/workbench/contrib/files/browser/fileActions.contribution.ts
+++ b/src/vs/workbench/contrib/files/browser/fileActions.contribution.ts
@@ -7,7 +7,7 @@ import * as nls from 'vs/nls';
 import { ToggleAutoSaveAction, FocusFilesExplorer, GlobalCompareResourcesAction, ShowActiveFileInExplorer, CompareWithClipboardAction, NEW_FILE_COMMAND_ID, NEW_FILE_LABEL, NEW_FOLDER_COMMAND_ID, NEW_FOLDER_LABEL, TRIGGER_RENAME_LABEL, MOVE_FILE_TO_TRASH_LABEL, COPY_FILE_LABEL, PASTE_FILE_LABEL, FileCopiedContext, renameHandler, moveFileToTrashHandler, copyFileHandler, pasteFileHandler, deleteFileHandler, cutFileHandler, DOWNLOAD_COMMAND_ID, openFilePreserveFocusHandler, DOWNLOAD_LABEL, ShowOpenedFileInNewWindow, UPLOAD_COMMAND_ID, UPLOAD_LABEL, CompareNewUntitledTextFilesAction, SetActiveEditorReadonlyInSession, SetActiveEditorWriteableInSession, ToggleActiveEditorReadonlyInSession, ResetActiveEditorReadonlyInSession } from 'vs/workbench/contrib/files/browser/fileActions';
 import { revertLocalChangesCommand, acceptLocalChangesCommand, CONFLICT_RESOLUTION_CONTEXT } from 'vs/workbench/contrib/files/browser/editors/textFileSaveErrorHandler';
 import { MenuId, MenuRegistry, registerAction2 } from 'vs/platform/actions/common/actions';
-import { ILocalizedString } from 'vs/platform/action/common/action';
+import { ICommandAction } from 'vs/platform/action/common/action';
 import { KeyMod, KeyCode } from 'vs/base/common/keyCodes';
 import { openWindowCommand, newWindowCommand } from 'vs/workbench/contrib/files/browser/fileCommands';
 import { COPY_PATH_COMMAND_ID, REVEAL_IN_EXPLORER_COMMAND_ID, OPEN_TO_SIDE_COMMAND_ID, REVERT_FILE_COMMAND_ID, SAVE_FILE_COMMAND_ID, SAVE_FILE_LABEL, SAVE_FILE_AS_COMMAND_ID, SAVE_FILE_AS_LABEL, SAVE_ALL_IN_GROUP_COMMAND_ID, OpenEditorsGroupContext, COMPARE_WITH_SAVED_COMMAND_ID, COMPARE_RESOURCE_COMMAND_ID, SELECT_FOR_COMPARE_COMMAND_ID, ResourceSelectedForCompareContext, OpenEditorsDirtyEditorContext, COMPARE_SELECTED_COMMAND_ID, REMOVE_ROOT_FOLDER_COMMAND_ID, REMOVE_ROOT_FOLDER_LABEL, SAVE_FILES_COMMAND_ID, COPY_RELATIVE_PATH_COMMAND_ID, SAVE_FILE_WITHOUT_FORMATTING_COMMAND_ID, SAVE_FILE_WITHOUT_FORMATTING_LABEL, OpenEditorsReadonlyEditorContext, OPEN_WITH_EXPLORER_COMMAND_ID, NEW_UNTITLED_FILE_COMMAND_ID, NEW_UNTITLED_FILE_LABEL, SAVE_ALL_COMMAND_ID } from 'vs/workbench/contrib/files/browser/fileConstants';
@@ -189,29 +189,91 @@ function appendSaveConflictEditorTitleAction(id: string, title: string, icon: Th
 
 // Menu registration - command palette
 
-export function appendToCommandPalette(id: string, title: ILocalizedString, category: ILocalizedString, when?: ContextKeyExpression): void {
+export function appendToCommandPalette({ id, title, category, description }: ICommandAction, when?: ContextKeyExpression): void {
 	MenuRegistry.appendMenuItem(MenuId.CommandPalette, {
 		command: {
 			id,
 			title,
-			category
+			category,
+			description
 		},
 		when
 	});
 }
 
-appendToCommandPalette(COPY_PATH_COMMAND_ID, { value: nls.localize('copyPathOfActive', "Copy Path of Active File"), original: 'Copy Path of Active File' }, Categories.File);
-appendToCommandPalette(COPY_RELATIVE_PATH_COMMAND_ID, { value: nls.localize('copyRelativePathOfActive', "Copy Relative Path of Active File"), original: 'Copy Relative Path of Active File' }, Categories.File);
-appendToCommandPalette(SAVE_FILE_COMMAND_ID, { value: SAVE_FILE_LABEL, original: 'Save' }, Categories.File);
-appendToCommandPalette(SAVE_FILE_WITHOUT_FORMATTING_COMMAND_ID, { value: SAVE_FILE_WITHOUT_FORMATTING_LABEL, original: 'Save without Formatting' }, Categories.File);
-appendToCommandPalette(SAVE_ALL_IN_GROUP_COMMAND_ID, { value: nls.localize('saveAllInGroup', "Save All in Group"), original: 'Save All in Group' }, Categories.File);
-appendToCommandPalette(SAVE_FILES_COMMAND_ID, { value: nls.localize('saveFiles', "Save All Files"), original: 'Save All Files' }, Categories.File);
-appendToCommandPalette(REVERT_FILE_COMMAND_ID, { value: nls.localize('revert', "Revert File"), original: 'Revert File' }, Categories.File);
-appendToCommandPalette(COMPARE_WITH_SAVED_COMMAND_ID, { value: nls.localize('compareActiveWithSaved', "Compare Active File with Saved"), original: 'Compare Active File with Saved' }, Categories.File);
-appendToCommandPalette(SAVE_FILE_AS_COMMAND_ID, { value: SAVE_FILE_AS_LABEL, original: 'Save As...' }, Categories.File);
-appendToCommandPalette(NEW_FILE_COMMAND_ID, { value: NEW_FILE_LABEL, original: 'New File' }, Categories.File, WorkspaceFolderCountContext.notEqualsTo('0'));
-appendToCommandPalette(NEW_FOLDER_COMMAND_ID, { value: NEW_FOLDER_LABEL, original: 'New Folder' }, Categories.File, WorkspaceFolderCountContext.notEqualsTo('0'));
-appendToCommandPalette(NEW_UNTITLED_FILE_COMMAND_ID, { value: NEW_UNTITLED_FILE_LABEL, original: 'New Untitled Text File' }, Categories.File);
+appendToCommandPalette({
+	id: COPY_PATH_COMMAND_ID,
+	title: { value: nls.localize('copyPathOfActive', "Copy Path of Active File"), original: 'Copy Path of Active File' },
+	category: Categories.File
+});
+appendToCommandPalette({
+	id: COPY_RELATIVE_PATH_COMMAND_ID,
+	title: { value: nls.localize('copyRelativePathOfActive', "Copy Relative Path of Active File"), original: 'Copy Relative Path of Active File' },
+	category: Categories.File
+});
+
+appendToCommandPalette({
+	id: SAVE_FILE_COMMAND_ID,
+	title: { value: SAVE_FILE_LABEL, original: 'Save' },
+	category: Categories.File
+});
+
+appendToCommandPalette({
+	id: SAVE_FILE_WITHOUT_FORMATTING_COMMAND_ID,
+	title: { value: SAVE_FILE_WITHOUT_FORMATTING_LABEL, original: 'Save without Formatting' },
+	category: Categories.File
+});
+
+appendToCommandPalette({
+	id: SAVE_ALL_IN_GROUP_COMMAND_ID,
+	title: { value: nls.localize('saveAllInGroup', "Save All in Group"), original: 'Save All in Group' },
+	category: Categories.File
+});
+
+appendToCommandPalette({
+	id: SAVE_FILES_COMMAND_ID,
+	title: { value: nls.localize('saveFiles', "Save All Files"), original: 'Save All Files' },
+	category: Categories.File
+});
+
+appendToCommandPalette({
+	id: REVERT_FILE_COMMAND_ID,
+	title: { value: nls.localize('revert', "Revert File"), original: 'Revert File' },
+	category: Categories.File
+});
+
+appendToCommandPalette({
+	id: COMPARE_WITH_SAVED_COMMAND_ID,
+	title: { value: nls.localize('compareActiveWithSaved', "Compare Active File with Saved"), original: 'Compare Active File with Saved' },
+	category: Categories.File
+});
+
+appendToCommandPalette({
+	id: SAVE_FILE_AS_COMMAND_ID,
+	title: { value: SAVE_FILE_AS_LABEL, original: 'Save As...' },
+	category: Categories.File
+});
+
+appendToCommandPalette({
+	id: NEW_FILE_COMMAND_ID,
+	title: { value: NEW_FILE_LABEL, original: 'New File' },
+	category: Categories.File
+}, WorkspaceFolderCountContext.notEqualsTo('0'));
+
+appendToCommandPalette({
+	id: NEW_FOLDER_COMMAND_ID,
+	title: { value: NEW_FOLDER_LABEL, original: 'New Folder' },
+	category: Categories.File,
+	description: {
+		description: { value: nls.localize('newFolderDescription', "Create a new folder or directory"), original: 'Create a new folder or directory' }
+	}
+}, WorkspaceFolderCountContext.notEqualsTo('0'));
+
+appendToCommandPalette({
+	id: NEW_UNTITLED_FILE_COMMAND_ID,
+	title: { value: NEW_UNTITLED_FILE_LABEL, original: 'New Untitled Text File' },
+	category: Categories.File
+});
 
 // Menu registration - open editors
 

--- a/src/vs/workbench/contrib/files/browser/fileActions.contribution.ts
+++ b/src/vs/workbench/contrib/files/browser/fileActions.contribution.ts
@@ -189,13 +189,13 @@ function appendSaveConflictEditorTitleAction(id: string, title: string, icon: Th
 
 // Menu registration - command palette
 
-export function appendToCommandPalette({ id, title, category, description }: ICommandAction, when?: ContextKeyExpression): void {
+export function appendToCommandPalette({ id, title, category, metadata }: ICommandAction, when?: ContextKeyExpression): void {
 	MenuRegistry.appendMenuItem(MenuId.CommandPalette, {
 		command: {
 			id,
 			title,
 			category,
-			description
+			metadata
 		},
 		when
 	});
@@ -264,7 +264,7 @@ appendToCommandPalette({
 	id: NEW_FOLDER_COMMAND_ID,
 	title: { value: NEW_FOLDER_LABEL, original: 'New Folder' },
 	category: Categories.File,
-	description: {
+	metadata: {
 		description: { value: nls.localize('newFolderDescription', "Create a new folder or directory"), original: 'Create a new folder or directory' }
 	}
 }, WorkspaceFolderCountContext.notEqualsTo('0'));

--- a/src/vs/workbench/contrib/files/browser/fileActions.contribution.ts
+++ b/src/vs/workbench/contrib/files/browser/fileActions.contribution.ts
@@ -264,9 +264,7 @@ appendToCommandPalette({
 	id: NEW_FOLDER_COMMAND_ID,
 	title: { value: NEW_FOLDER_LABEL, original: 'New Folder' },
 	category: Categories.File,
-	metadata: {
-		description: { value: nls.localize('newFolderDescription', "Create a new folder or directory"), original: 'Create a new folder or directory' }
-	}
+	metadata: { description: nls.localize2('newFolderDescription', "Create a new folder or directory") }
 }, WorkspaceFolderCountContext.notEqualsTo('0'));
 
 appendToCommandPalette({

--- a/src/vs/workbench/contrib/files/browser/fileCommands.ts
+++ b/src/vs/workbench/contrib/files/browser/fileCommands.ts
@@ -663,7 +663,7 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 	primary: isWeb ? (isWindows ? KeyChord(KeyMod.CtrlCmd | KeyCode.KeyK, KeyCode.KeyN) : KeyMod.CtrlCmd | KeyMod.Alt | KeyCode.KeyN) : KeyMod.CtrlCmd | KeyCode.KeyN,
 	secondary: isWeb ? [KeyMod.CtrlCmd | KeyCode.KeyN] : undefined,
 	id: NEW_UNTITLED_FILE_COMMAND_ID,
-	description: {
+	metadata: {
 		description: NEW_UNTITLED_FILE_LABEL,
 		args: [
 			{

--- a/src/vs/workbench/contrib/files/electron-sandbox/fileActions.contribution.ts
+++ b/src/vs/workbench/contrib/files/electron-sandbox/fileActions.contribution.ts
@@ -90,4 +90,8 @@ MenuRegistry.appendMenuItem(MenuId.ExplorerContext, {
 // Command Palette
 
 const category = { value: nls.localize('filesCategory', "File"), original: 'File' };
-appendToCommandPalette(REVEAL_IN_OS_COMMAND_ID, { value: REVEAL_IN_OS_LABEL, original: isWindows ? 'Reveal in File Explorer' : isMacintosh ? 'Reveal in Finder' : 'Open Containing Folder' }, category, REVEAL_IN_OS_WHEN_CONTEXT);
+appendToCommandPalette({
+	id: REVEAL_IN_OS_COMMAND_ID,
+	title: { value: REVEAL_IN_OS_LABEL, original: isWindows ? 'Reveal in File Explorer' : isMacintosh ? 'Reveal in Finder' : 'Open Containing Folder' },
+	category: category
+}, REVEAL_IN_OS_WHEN_CONTEXT);

--- a/src/vs/workbench/contrib/interactive/browser/interactive.contribution.ts
+++ b/src/vs/workbench/contrib/interactive/browser/interactive.contribution.ts
@@ -304,7 +304,7 @@ registerAction2(class extends Action2 {
 			title: { value: localize('interactive.open', "Open Interactive Window"), original: 'Open Interactive Window' },
 			f1: false,
 			category: interactiveWindowCategory,
-			description: {
+			metadata: {
 				description: localize('interactive.open', "Open Interactive Window"),
 				args: [
 					{
@@ -437,7 +437,7 @@ registerAction2(class extends Action2 {
 			],
 			icon: icons.executeIcon,
 			f1: false,
-			description: {
+			metadata: {
 				description: 'Execute the Contents of the Input Box',
 				args: [
 					{

--- a/src/vs/workbench/contrib/issue/common/issue.contribution.ts
+++ b/src/vs/workbench/contrib/issue/common/issue.contribution.ts
@@ -7,7 +7,7 @@ import { localize } from 'vs/nls';
 import { ICommandAction } from 'vs/platform/action/common/action';
 import { Categories } from 'vs/platform/action/common/actionCommonCategories';
 import { MenuId, MenuRegistry } from 'vs/platform/actions/common/actions';
-import { CommandsRegistry, ICommandHandlerDescription } from 'vs/platform/commands/common/commands';
+import { CommandsRegistry, ICommandMetadata } from 'vs/platform/commands/common/commands';
 import { IssueReporterData } from 'vs/platform/issue/common/issue';
 import { IProductService } from 'vs/platform/product/common/productService';
 import { IWorkbenchContribution } from 'vs/workbench/common/contributions';
@@ -16,7 +16,7 @@ import { IWorkbenchIssueService } from 'vs/workbench/services/issue/common/issue
 const OpenIssueReporterActionId = 'workbench.action.openIssueReporter';
 const OpenIssueReporterApiId = 'vscode.openIssueReporter';
 
-const OpenIssueReporterCommandDescription: ICommandHandlerDescription = {
+const OpenIssueReporterCommandMetadata: ICommandMetadata = {
 	description: 'Open the issue reporter and optionally prefill part of the form.',
 	args: [
 		{
@@ -76,7 +76,7 @@ export class BaseIssueContribution implements IWorkbenchContribution {
 
 				return accessor.get(IWorkbenchIssueService).openReporter(data);
 			},
-			description: OpenIssueReporterCommandDescription
+			metadata: OpenIssueReporterCommandMetadata
 		});
 
 		CommandsRegistry.registerCommand({
@@ -91,7 +91,7 @@ export class BaseIssueContribution implements IWorkbenchContribution {
 
 				return accessor.get(IWorkbenchIssueService).openReporter(data);
 			},
-			description: OpenIssueReporterCommandDescription
+			metadata: OpenIssueReporterCommandMetadata
 		});
 
 		const reportIssue: ICommandAction = {

--- a/src/vs/workbench/contrib/localization/common/localizationsActions.ts
+++ b/src/vs/workbench/contrib/localization/common/localizationsActions.ts
@@ -22,6 +22,12 @@ export class ConfigureDisplayLanguageAction extends Action2 {
 			title: localize2('configureLocale', "Configure Display Language"),
 			menu: {
 				id: MenuId.CommandPalette
+			},
+			description: {
+				description: {
+					value: localize('configureLocaleDescription', "Changes the locale of VS Code based on installed language packs. Common languages include French, Chinese, Spanish, Japanese, German, Korean, and more."),
+					original: 'Changes the locale of VS Code based on installed language packs. Common languages include French, Chinese, Spanish, Japanese, German, Korean, and more.'
+				}
 			}
 		});
 	}

--- a/src/vs/workbench/contrib/localization/common/localizationsActions.ts
+++ b/src/vs/workbench/contrib/localization/common/localizationsActions.ts
@@ -24,10 +24,7 @@ export class ConfigureDisplayLanguageAction extends Action2 {
 				id: MenuId.CommandPalette
 			},
 			metadata: {
-				description: {
-					value: localize('configureLocaleDescription', "Changes the locale of VS Code based on installed language packs. Common languages include French, Chinese, Spanish, Japanese, German, Korean, and more."),
-					original: 'Changes the locale of VS Code based on installed language packs. Common languages include French, Chinese, Spanish, Japanese, German, Korean, and more.'
-				}
+				description: localize2('configureLocaleDescription', "Changes the locale of VS Code based on installed language packs. Common languages include French, Chinese, Spanish, Japanese, German, Korean, and more.")
 			}
 		});
 	}

--- a/src/vs/workbench/contrib/localization/common/localizationsActions.ts
+++ b/src/vs/workbench/contrib/localization/common/localizationsActions.ts
@@ -23,7 +23,7 @@ export class ConfigureDisplayLanguageAction extends Action2 {
 			menu: {
 				id: MenuId.CommandPalette
 			},
-			description: {
+			metadata: {
 				description: {
 					value: localize('configureLocaleDescription', "Changes the locale of VS Code based on installed language packs. Common languages include French, Chinese, Spanish, Japanese, German, Korean, and more."),
 					original: 'Changes the locale of VS Code based on installed language packs. Common languages include French, Chinese, Spanish, Japanese, German, Korean, and more.'

--- a/src/vs/workbench/contrib/notebook/browser/contrib/cellCommands/cellCommands.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/cellCommands/cellCommands.ts
@@ -501,7 +501,7 @@ registerAction2(class extends NotebookMultiCellAction {
 				value: localize('notebookActions.toggleOutputs', "Toggle Outputs"),
 				original: 'Toggle Outputs'
 			},
-			description: {
+			metadata: {
 				description: localize('notebookActions.toggleOutputs', "Toggle Outputs"),
 				args: cellExecutionArgs
 			}

--- a/src/vs/workbench/contrib/notebook/browser/controller/editActions.ts
+++ b/src/vs/workbench/contrib/notebook/browser/controller/editActions.ts
@@ -349,7 +349,7 @@ registerAction2(class ChangeCellLanguageAction extends NotebookCellAction<ICellR
 		super({
 			id: CHANGE_CELL_LANGUAGE,
 			title: localize('changeLanguage', 'Change Cell Language'),
-			description: {
+			metadata: {
 				description: localize('changeLanguage', 'Change Cell Language'),
 				args: [
 					{

--- a/src/vs/workbench/contrib/notebook/browser/controller/executeActions.ts
+++ b/src/vs/workbench/contrib/notebook/browser/controller/executeActions.ts
@@ -130,7 +130,7 @@ registerAction2(class ExecuteNotebookAction extends NotebookAction {
 			id: EXECUTE_NOTEBOOK_COMMAND_ID,
 			title: localize('notebookActions.executeNotebook', "Run All"),
 			icon: icons.executeAllIcon,
-			description: {
+			metadata: {
 				description: localize('notebookActions.executeNotebook', "Run All"),
 				args: [
 					{
@@ -209,7 +209,7 @@ registerAction2(class ExecuteCell extends NotebookMultiCellAction {
 				when: executeThisCellCondition,
 				group: 'inline'
 			},
-			description: {
+			metadata: {
 				description: localize('notebookActions.execute', "Execute Cell"),
 				args: cellExecutionArgs
 			},
@@ -332,7 +332,7 @@ registerAction2(class ExecuteCellFocusContainer extends NotebookMultiCellAction 
 			id: EXECUTE_CELL_FOCUS_CONTAINER_COMMAND_ID,
 			precondition: executeThisCellCondition,
 			title: localize('notebookActions.executeAndFocusContainer', "Execute Cell and Focus Container"),
-			description: {
+			metadata: {
 				description: localize('notebookActions.executeAndFocusContainer', "Execute Cell and Focus Container"),
 				args: cellExecutionArgs
 			},
@@ -378,7 +378,7 @@ registerAction2(class CancelExecuteCell extends NotebookMultiCellAction {
 				when: cellCancelCondition,
 				group: 'inline'
 			},
-			description: {
+			metadata: {
 				description: localize('notebookActions.cancel', "Stop Cell Execution"),
 				args: [
 					{

--- a/src/vs/workbench/contrib/notebook/browser/controller/foldingController.ts
+++ b/src/vs/workbench/contrib/notebook/browser/controller/foldingController.ts
@@ -19,7 +19,7 @@ import { IEditorService } from 'vs/workbench/services/editor/common/editorServic
 import { NOTEBOOK_ACTIONS_CATEGORY } from 'vs/workbench/contrib/notebook/browser/controller/coreActions';
 import { localize } from 'vs/nls';
 import { FoldingRegion } from 'vs/editor/contrib/folding/browser/foldingRanges';
-import { ICommandHandlerDescription } from 'vs/platform/commands/common/commands';
+import { ICommandMetadata } from 'vs/platform/commands/common/commands';
 import { NotebookViewModel } from 'vs/workbench/contrib/notebook/browser/viewModel/notebookViewModelImpl';
 
 export class FoldingController extends Disposable implements INotebookEditorContribution {
@@ -153,7 +153,7 @@ registerNotebookContribution(FoldingController.id, FoldingController);
 const NOTEBOOK_FOLD_COMMAND_LABEL = localize('fold.cell', "Fold Cell");
 const NOTEBOOK_UNFOLD_COMMAND_LABEL = localize('unfold.cell', "Unfold Cell");
 
-const FOLDING_COMMAND_ARGS: Pick<ICommandHandlerDescription, 'args'> = {
+const FOLDING_COMMAND_ARGS: Pick<ICommandMetadata, 'args'> = {
 	args: [{
 		isOptional: true,
 		name: 'index',
@@ -195,7 +195,7 @@ registerAction2(class extends Action2 {
 				secondary: [KeyCode.LeftArrow],
 				weight: KeybindingWeight.WorkbenchContrib
 			},
-			description: {
+			metadata: {
 				description: NOTEBOOK_FOLD_COMMAND_LABEL,
 				args: FOLDING_COMMAND_ARGS.args
 			},
@@ -265,7 +265,7 @@ registerAction2(class extends Action2 {
 				secondary: [KeyCode.RightArrow],
 				weight: KeybindingWeight.WorkbenchContrib
 			},
-			description: {
+			metadata: {
 				description: NOTEBOOK_UNFOLD_COMMAND_LABEL,
 				args: FOLDING_COMMAND_ARGS.args
 			},

--- a/src/vs/workbench/contrib/notebook/browser/viewParts/notebookKernelView.ts
+++ b/src/vs/workbench/contrib/notebook/browser/viewParts/notebookKernelView.ts
@@ -67,7 +67,7 @@ registerAction2(class extends Action2 {
 				group: 'status',
 				order: -10
 			}],
-			description: {
+			metadata: {
 				description: localize('notebookActions.selectKernel.args', "Notebook Kernel Args"),
 				args: [
 					{

--- a/src/vs/workbench/contrib/output/browser/output.contribution.ts
+++ b/src/vs/workbench/contrib/output/browser/output.contribution.ts
@@ -359,7 +359,7 @@ class OutputContribution extends Disposable implements IWorkbenchContribution {
 					menu: {
 						id: MenuId.CommandPalette,
 					},
-					description: {
+					metadata: {
 						description: 'workbench.action.openLogFile',
 						args: [{
 							name: 'logFile',

--- a/src/vs/workbench/contrib/quickaccess/browser/commandsQuickAccess.ts
+++ b/src/vs/workbench/contrib/quickaccess/browser/commandsQuickAccess.ts
@@ -37,6 +37,7 @@ import { IChatService } from 'vs/workbench/contrib/chat/common/chatService';
 import { ASK_QUICK_QUESTION_ACTION_ID } from 'vs/workbench/contrib/chat/browser/actions/chatQuickInputActions';
 import { CommandInformationResult, IAiRelatedInformationService, RelatedInformationType } from 'vs/workbench/services/aiRelatedInformation/common/aiRelatedInformation';
 import { CHAT_OPEN_ACTION_ID } from 'vs/workbench/contrib/chat/browser/actions/chatActions';
+import { isLocalizedString } from 'vs/platform/action/common/action';
 
 export class CommandsQuickAccessProvider extends AbstractEditorCommandsQuickAccessProvider {
 
@@ -235,11 +236,16 @@ export class CommandsQuickAccessProvider extends AbstractEditorCommandsQuickAcce
 				aliasCategory ? `${aliasCategory}: ${aliasLabel}` : `${category}: ${aliasLabel}` :
 				aliasLabel;
 
+			const metadataDescription = action.item.metadata?.description;
+			const commandDescription = metadataDescription === undefined || isLocalizedString(metadataDescription)
+				? metadataDescription
+				// TODO: this type will eventually not be a string and when that happens, this should simplified.
+				: { value: metadataDescription, original: metadataDescription };
 			globalCommandPicks.push({
 				commandId: action.item.id,
 				commandAlias,
 				label: stripIcons(label),
-				commandDescription: action.description,
+				commandDescription,
 			});
 		}
 

--- a/src/vs/workbench/contrib/quickaccess/browser/commandsQuickAccess.ts
+++ b/src/vs/workbench/contrib/quickaccess/browser/commandsQuickAccess.ts
@@ -238,7 +238,8 @@ export class CommandsQuickAccessProvider extends AbstractEditorCommandsQuickAcce
 			globalCommandPicks.push({
 				commandId: action.item.id,
 				commandAlias,
-				label: stripIcons(label)
+				label: stripIcons(label),
+				commandDescription: action.description,
 			});
 		}
 

--- a/src/vs/workbench/contrib/remote/electron-sandbox/remote.contribution.ts
+++ b/src/vs/workbench/contrib/remote/electron-sandbox/remote.contribution.ts
@@ -204,7 +204,7 @@ if (isMacintosh) {
 		weight: KeybindingWeight.WorkbenchContrib,
 		primary: KeyMod.CtrlCmd | KeyCode.KeyO,
 		when: RemoteFileDialogContext,
-		description: { description: OpenLocalFileFolderCommand.LABEL, args: [] },
+		metadata: { description: OpenLocalFileFolderCommand.LABEL, args: [] },
 		handler: OpenLocalFileFolderCommand.handler()
 	});
 } else {
@@ -213,7 +213,7 @@ if (isMacintosh) {
 		weight: KeybindingWeight.WorkbenchContrib,
 		primary: KeyMod.CtrlCmd | KeyCode.KeyO,
 		when: RemoteFileDialogContext,
-		description: { description: OpenLocalFileCommand.LABEL, args: [] },
+		metadata: { description: OpenLocalFileCommand.LABEL, args: [] },
 		handler: OpenLocalFileCommand.handler()
 	});
 	KeybindingsRegistry.registerCommandAndKeybindingRule({
@@ -221,7 +221,7 @@ if (isMacintosh) {
 		weight: KeybindingWeight.WorkbenchContrib,
 		primary: KeyChord(KeyMod.CtrlCmd | KeyCode.KeyK, KeyMod.CtrlCmd | KeyCode.KeyO),
 		when: RemoteFileDialogContext,
-		description: { description: OpenLocalFolderCommand.LABEL, args: [] },
+		metadata: { description: OpenLocalFolderCommand.LABEL, args: [] },
 		handler: OpenLocalFolderCommand.handler()
 	});
 }
@@ -231,6 +231,6 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 	weight: KeybindingWeight.WorkbenchContrib,
 	primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KeyS,
 	when: RemoteFileDialogContext,
-	description: { description: SaveLocalFileCommand.LABEL, args: [] },
+	metadata: { description: SaveLocalFileCommand.LABEL, args: [] },
 	handler: SaveLocalFileCommand.handler()
 });

--- a/src/vs/workbench/contrib/scm/browser/scm.contribution.ts
+++ b/src/vs/workbench/contrib/scm/browser/scm.contribution.ts
@@ -302,7 +302,7 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).regis
 
 KeybindingsRegistry.registerCommandAndKeybindingRule({
 	id: 'scm.acceptInput',
-	description: { description: localize('scm accept', "Source Control: Accept Input"), args: [] },
+	metadata: { description: localize('scm accept', "Source Control: Accept Input"), args: [] },
 	weight: KeybindingWeight.WorkbenchContrib,
 	when: ContextKeyExpr.has('scmRepository'),
 	primary: KeyMod.CtrlCmd | KeyCode.Enter,

--- a/src/vs/workbench/contrib/search/browser/searchActionsFind.ts
+++ b/src/vs/workbench/contrib/search/browser/searchActionsFind.ts
@@ -172,7 +172,7 @@ registerAction2(class FindInFilesAction extends Action2 {
 				mnemonicTitle: nls.localize({ key: 'miFindInFiles', comment: ['&& denotes a mnemonic'] }, "Find &&in Files"),
 				original: 'Find in Files'
 			},
-			description: {
+			metadata: {
 				description: nls.localize('findInFiles.description', "Open a workspace search"),
 				args: [
 					{

--- a/src/vs/workbench/contrib/searchEditor/browser/searchEditor.contribution.ts
+++ b/src/vs/workbench/contrib/searchEditor/browser/searchEditor.contribution.ts
@@ -202,7 +202,7 @@ const translateLegacyConfig = (legacyConfig: LegacySearchEditorArgs & OpenSearch
 };
 
 export type OpenSearchEditorArgs = Partial<SearchConfiguration & { triggerSearch: boolean; focusResults: boolean; location: 'reuse' | 'new' }>;
-const openArgDescription = {
+const openArgMetadata = {
 	description: 'Open a new search editor. Arguments passed can include variables like ${relativeFileDirname}.',
 	args: [{
 		name: 'Open new Search Editor args',
@@ -255,7 +255,7 @@ registerAction2(class extends Action2 {
 			title: { value: localize('search.openNewSearchEditor', "New Search Editor"), original: 'New Search Editor' },
 			category,
 			f1: true,
-			description: openArgDescription
+			metadata: openArgMetadata
 		});
 	}
 	async run(accessor: ServicesAccessor, args: LegacySearchEditorArgs | OpenSearchEditorArgs) {
@@ -270,7 +270,7 @@ registerAction2(class extends Action2 {
 			title: { value: localize('search.openSearchEditor', "Open Search Editor"), original: 'Open Search Editor' },
 			category,
 			f1: true,
-			description: openArgDescription
+			metadata: openArgMetadata
 		});
 	}
 	async run(accessor: ServicesAccessor, args: LegacySearchEditorArgs | OpenSearchEditorArgs) {
@@ -285,7 +285,7 @@ registerAction2(class extends Action2 {
 			title: { value: localize('search.openNewEditorToSide', "Open New Search Editor to the Side"), original: 'Open new Search Editor to the Side' },
 			category,
 			f1: true,
-			description: openArgDescription
+			metadata: openArgMetadata
 		});
 	}
 	async run(accessor: ServicesAccessor, args: LegacySearchEditorArgs | OpenSearchEditorArgs) {

--- a/src/vs/workbench/contrib/snippets/browser/commands/insertSnippet.ts
+++ b/src/vs/workbench/contrib/snippets/browser/commands/insertSnippet.ts
@@ -55,7 +55,7 @@ export class InsertSnippetAction extends SnippetEditorAction {
 			},
 			f1: true,
 			precondition: EditorContextKeys.writable,
-			description: {
+			metadata: {
 				description: `Insert Snippet`,
 				args: [{
 					name: 'args',

--- a/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
+++ b/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
@@ -434,7 +434,7 @@ export abstract class AbstractTaskService extends Disposable implements ITaskSer
 					await this._runTaskCommand(arg);
 				}
 			},
-			description: {
+			metadata: {
 				description: 'Run Task',
 				args: [{
 					name: 'args',

--- a/src/vs/workbench/contrib/terminal/browser/terminalActions.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalActions.ts
@@ -930,7 +930,7 @@ export function registerTerminalActions() {
 		id: TerminalCommandId.SendSequence,
 		title: terminalStrings.sendSequence,
 		f1: false,
-		description: {
+		metadata: {
 			description: terminalStrings.sendSequence.value,
 			args: [{
 				name: 'args',
@@ -952,7 +952,7 @@ export function registerTerminalActions() {
 	registerTerminalAction({
 		id: TerminalCommandId.NewWithCwd,
 		title: terminalStrings.newWithCwd,
-		description: {
+		metadata: {
 			description: terminalStrings.newWithCwd.value,
 			args: [{
 				name: 'args',
@@ -982,7 +982,7 @@ export function registerTerminalActions() {
 	registerActiveInstanceAction({
 		id: TerminalCommandId.RenameWithArgs,
 		title: terminalStrings.renameWithArgs,
-		description: {
+		metadata: {
 			description: terminalStrings.renameWithArgs.value,
 			args: [{
 				name: 'args',
@@ -1672,7 +1672,7 @@ export function refreshTerminalActions(detectedProfiles: ITerminalProfile[]) {
 				f1: true,
 				category,
 				precondition: ContextKeyExpr.or(TerminalContextKeys.processSupported, TerminalContextKeys.webExtensionContributedProfile),
-				description: {
+				metadata: {
 					description: TerminalCommandId.NewWithProfile,
 					args: [{
 						name: 'args',

--- a/src/vs/workbench/services/keybinding/browser/keybindingService.ts
+++ b/src/vs/workbench/services/keybinding/browser/keybindingService.ts
@@ -923,18 +923,18 @@ class KeybindingsJsonSchema {
 
 		const allCommands = CommandsRegistry.getCommands();
 		for (const [commandId, command] of allCommands) {
-			const commandDescription = command.description;
+			const commandMetadata = command.metadata;
 
-			addKnownCommand(commandId, commandDescription?.description);
+			addKnownCommand(commandId, commandMetadata?.description);
 
-			if (!commandDescription || !commandDescription.args || commandDescription.args.length !== 1 || !commandDescription.args[0].schema) {
+			if (!commandMetadata || !commandMetadata.args || commandMetadata.args.length !== 1 || !commandMetadata.args[0].schema) {
 				continue;
 			}
 
-			const argsSchema = commandDescription.args[0].schema;
+			const argsSchema = commandMetadata.args[0].schema;
 			const argsRequired = (
-				(typeof commandDescription.args[0].isOptional !== 'undefined')
-					? (!commandDescription.args[0].isOptional)
+				(typeof commandMetadata.args[0].isOptional !== 'undefined')
+					? (!commandMetadata.args[0].isOptional)
 					: (Array.isArray(argsSchema.required) && argsSchema.required.length > 0)
 			);
 			const addition = {

--- a/src/vs/workbench/services/keybinding/browser/keybindingService.ts
+++ b/src/vs/workbench/services/keybinding/browser/keybindingService.ts
@@ -53,6 +53,7 @@ import { getAllUnboundCommands } from 'vs/workbench/services/keybinding/browser/
 import { IUserKeybindingItem, KeybindingIO, OutputBuilder } from 'vs/workbench/services/keybinding/common/keybindingIO';
 import { IUserDataProfileService } from 'vs/workbench/services/userDataProfile/common/userDataProfile';
 import { IUriIdentityService } from 'vs/platform/uriIdentity/common/uriIdentity';
+import { ILocalizedString, isLocalizedString } from 'vs/platform/action/common/action';
 
 interface ContributedKeyBinding {
 	command: string;
@@ -906,13 +907,13 @@ class KeybindingsJsonSchema {
 		this.commandsEnumDescriptions.length = 0;
 
 		const knownCommands = new Set<string>();
-		const addKnownCommand = (commandId: string, description?: string | undefined) => {
+		const addKnownCommand = (commandId: string, description?: string | ILocalizedString | undefined) => {
 			if (!/^_/.test(commandId)) {
 				if (!knownCommands.has(commandId)) {
 					knownCommands.add(commandId);
 
 					this.commandsEnum.push(commandId);
-					this.commandsEnumDescriptions.push(description);
+					this.commandsEnumDescriptions.push(isLocalizedString(description) ? description.value : description);
 
 					// Also add the negative form for keybinding removal
 					this.removalCommandsEnum.push(`-${commandId}`);
@@ -924,7 +925,7 @@ class KeybindingsJsonSchema {
 		for (const [commandId, command] of allCommands) {
 			const commandDescription = command.description;
 
-			addKnownCommand(commandId, commandDescription ? commandDescription.description : undefined);
+			addKnownCommand(commandId, commandDescription?.description);
 
 			if (!commandDescription || !commandDescription.args || commandDescription.args.length !== 1 || !commandDescription.args[0].schema) {
 				continue;

--- a/src/vs/workbench/services/keybinding/browser/unboundCommands.ts
+++ b/src/vs/workbench/services/keybinding/browser/unboundCommands.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { CommandsRegistry, ICommandHandlerDescription } from 'vs/platform/commands/common/commands';
+import { CommandsRegistry, ICommandMetadata } from 'vs/platform/commands/common/commands';
 import { isNonEmptyArray } from 'vs/base/common/arrays';
 import { EditorExtensionsRegistry } from 'vs/editor/browser/editorExtensions';
 import { MenuRegistry, MenuId, isIMenuItem } from 'vs/platform/actions/common/actions';
@@ -24,8 +24,8 @@ export function getAllUnboundCommands(boundCommands: Map<string, boolean>): stri
 		}
 		if (!includeCommandWithArgs) {
 			const command = CommandsRegistry.getCommand(id);
-			if (command && typeof command.description === 'object'
-				&& isNonEmptyArray((<ICommandHandlerDescription>command.description).args)) { // command with args
+			if (command && typeof command.metadata === 'object'
+				&& isNonEmptyArray((<ICommandMetadata>command.metadata).args)) { // command with args
 				return;
 			}
 		}


### PR DESCRIPTION
This depends on https://github.com/microsoft/vscode/pull/193937 and would allow Editor Commands' descriptions to be picked up in the TF-IDF indexing of commands.

The problem I currently struggle with is what to do with this introduction of `ICommandMetadata`... do we want to add it to monaco? Do we want to add maybe a subset of it (just the description property)?

Additionally, I noticed that the concept of a LocalizedString isn't a thing in the monaco API... so that would be _another_ thing to introduce.

Should we add these types? Or should we have `description` be a `string` and then use that instead?

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
