### PR TITLE
auxiliary window - block `script-src` via CSP

### DIFF
--- a/src/vs/workbench/services/auxiliaryWindow/browser/auxiliaryWindowService.ts
+++ b/src/vs/workbench/services/auxiliaryWindow/browser/auxiliaryWindowService.ts
@@ -79,6 +79,11 @@ export class BrowserAuxiliaryWindowService implements IAuxiliaryWindowService {
 		if (originalCSPMetaTag) {
 			const csp = auxiliaryWindow.document.head.appendChild(document.createElement('meta'));
 			copyAttributes(originalCSPMetaTag, csp);
+
+			const content = csp.getAttribute('content');
+			if (content) {
+				csp.setAttribute('content', content.replace(/(script-src[^\;]*)/, `script-src 'none'`));
+			}
 		}
 	}
 


### PR DESCRIPTION
We do not expect to run any JavaScript in auxiliary windows for now.

//cc @jrieken

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
