### PR TITLE
allow task quickpick to show if no task is running when `rerun task` is invoked

### DIFF
--- a/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
+++ b/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
@@ -2898,6 +2898,10 @@ export abstract class AbstractTaskService extends Disposable implements ITaskSer
 				if (executeResult) {
 					return this._handleExecuteResult(executeResult);
 				} else {
+					if (!this._taskRunningState.get()) {
+						// No task running, prompt to ask which to run
+						this._doRunTaskCommand();
+					}
 					return Promise.resolve(undefined);
 				}
 			});


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
fix #194935