### PR TITLE
Dedupe strings in tf-idf index & include `exactLabelMatch` in `runCommand` in smoke tests

### DIFF
--- a/src/vs/platform/quickinput/browser/commandsQuickAccess.ts
+++ b/src/vs/platform/quickinput/browser/commandsQuickAccess.ts
@@ -286,10 +286,10 @@ export abstract class AbstractCommandsQuickAccessProvider extends PickerQuickAcc
 	// TF-IDF string to be indexed
 	private getTfIdfChunk({ label, commandAlias, commandDescription }: ICommandQuickPick) {
 		let chunk = label;
-		if (commandAlias) {
+		if (commandAlias && commandAlias !== label) {
 			chunk += ` - ${commandAlias}`;
 		}
-		if (commandDescription) {
+		if (commandDescription && commandDescription.value !== label) {
 			// If the original is the same as the value, don't add it
 			chunk += ` - ${commandDescription.value === commandDescription.original ? commandDescription.value : `${commandDescription.value} (${commandDescription.original})`}`;
 		}

--- a/src/vs/workbench/contrib/extensions/browser/extensions.contribution.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensions.contribution.ts
@@ -1636,7 +1636,7 @@ class ExtensionStorageCleaner implements IWorkbenchContribution {
 }
 
 const workbenchRegistry = Registry.as<IWorkbenchContributionsRegistry>(WorkbenchExtensions.Workbench);
-workbenchRegistry.registerWorkbenchContribution(ExtensionsContributions, LifecyclePhase.Ready);
+workbenchRegistry.registerWorkbenchContribution(ExtensionsContributions, LifecyclePhase.Restored);
 workbenchRegistry.registerWorkbenchContribution(StatusUpdater, LifecyclePhase.Eventually);
 workbenchRegistry.registerWorkbenchContribution(MaliciousExtensionChecker, LifecyclePhase.Eventually);
 workbenchRegistry.registerWorkbenchContribution(KeymapExtensions, LifecyclePhase.Restored);

--- a/src/vs/workbench/contrib/extensions/browser/extensions.contribution.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensions.contribution.ts
@@ -1636,7 +1636,7 @@ class ExtensionStorageCleaner implements IWorkbenchContribution {
 }
 
 const workbenchRegistry = Registry.as<IWorkbenchContributionsRegistry>(WorkbenchExtensions.Workbench);
-workbenchRegistry.registerWorkbenchContribution(ExtensionsContributions, LifecyclePhase.Restored);
+workbenchRegistry.registerWorkbenchContribution(ExtensionsContributions, LifecyclePhase.Ready);
 workbenchRegistry.registerWorkbenchContribution(StatusUpdater, LifecyclePhase.Eventually);
 workbenchRegistry.registerWorkbenchContribution(MaliciousExtensionChecker, LifecyclePhase.Eventually);
 workbenchRegistry.registerWorkbenchContribution(KeymapExtensions, LifecyclePhase.Restored);

--- a/test/automation/src/extensions.ts
+++ b/test/automation/src/extensions.ts
@@ -19,7 +19,7 @@ export class Extensions extends Viewlet {
 	}
 
 	async searchForExtension(id: string): Promise<any> {
-		await this.commands.runCommand('workbench.extensions.action.focusExtensionsView');
+		await this.commands.runCommand('Focus on Extensions View', { exactLabelMatch: true });
 		await this.code.waitForTypeInEditor('div.extensions-viewlet[id="workbench.view.extensions"] .monaco-editor textarea', `@id:${id}`);
 		await this.code.waitForTextContent(`div.part.sidebar div.composite.title h2`, 'Extensions: Marketplace');
 

--- a/test/automation/src/extensions.ts
+++ b/test/automation/src/extensions.ts
@@ -19,7 +19,7 @@ export class Extensions extends Viewlet {
 	}
 
 	async searchForExtension(id: string): Promise<any> {
-		await this.commands.runCommand('Focus on Extensions View', { exactLabelMatch: true });
+		await this.commands.runCommand('Extensions: Focus on Extensions View', { exactLabelMatch: true });
 		await this.code.waitForTypeInEditor('div.extensions-viewlet[id="workbench.view.extensions"] .monaco-editor textarea', `@id:${id}`);
 		await this.code.waitForTextContent(`div.part.sidebar div.composite.title h2`, 'Extensions: Marketplace');
 

--- a/test/automation/src/quickaccess.ts
+++ b/test/automation/src/quickaccess.ts
@@ -170,8 +170,11 @@ export class QuickAccess {
 		}
 	}
 
-	async runCommand(commandId: string, keepOpen?: boolean): Promise<void> {
+	async runCommand(commandId: string, options?: { keepOpen?: boolean; exactLabelMatch?: boolean }): Promise<void> {
 		let retries = 0;
+
+		const keepOpen = options?.keepOpen;
+		const exactLabelMatch = options?.exactLabelMatch;
 
 		while (++retries < 5) {
 
@@ -183,7 +186,7 @@ export class QuickAccess {
 
 			// Retry for as long as the command not found
 			const text = await this.quickInput.waitForQuickInputElementText();
-			if (text === 'No matching commands') {
+			if (text === 'No matching commands' || (exactLabelMatch && text !== commandId)) {
 				this.code.logger.log(`QuickAccess: No matching commands, will retry...`);
 				await this.quickInput.closeQuickInput();
 				await this.code.wait(1000);

--- a/test/automation/src/task.ts
+++ b/test/automation/src/task.ts
@@ -35,7 +35,7 @@ export class Task {
 	async assertTasks(filter: string, expected: ITaskConfigurationProperties[], type: 'run' | 'configure') {
 		await this.code.dispatchKeybinding('right');
 		await this.editors.saveOpenedFile();
-		type === 'run' ? await this.quickaccess.runCommand('workbench.action.tasks.runTask', true) : await this.quickaccess.runCommand('workbench.action.tasks.configureTask', true);
+		type === 'run' ? await this.quickaccess.runCommand('workbench.action.tasks.runTask', { keepOpen: true }) : await this.quickaccess.runCommand('workbench.action.tasks.configureTask', { keepOpen: true });
 		if (expected.length === 0) {
 			await this.quickinput.waitForQuickInputElements(e => e.length > 1 && e.every(label => label.trim() !== filter.trim()));
 		} else {

--- a/test/automation/src/terminal.ts
+++ b/test/automation/src/terminal.ts
@@ -80,7 +80,7 @@ export class Terminal {
 
 	async runCommand(commandId: TerminalCommandId, expectedLocation?: 'editor' | 'panel'): Promise<void> {
 		const keepOpen = commandId === TerminalCommandId.Join;
-		await this.quickaccess.runCommand(commandId, keepOpen);
+		await this.quickaccess.runCommand(commandId, { keepOpen });
 		if (keepOpen) {
 			await this.code.dispatchKeybinding('enter');
 			await this.quickinput.waitForQuickInputClosed();
@@ -106,8 +106,8 @@ export class Terminal {
 	}
 
 	async runCommandWithValue(commandId: TerminalCommandIdWithValue, value?: string, altKey?: boolean): Promise<void> {
-		const shouldKeepOpen = !!value || commandId === TerminalCommandIdWithValue.NewWithProfile || commandId === TerminalCommandIdWithValue.Rename || (commandId === TerminalCommandIdWithValue.SelectDefaultProfile && value !== 'PowerShell');
-		await this.quickaccess.runCommand(commandId, shouldKeepOpen);
+		const keepOpen = !!value || commandId === TerminalCommandIdWithValue.NewWithProfile || commandId === TerminalCommandIdWithValue.Rename || (commandId === TerminalCommandIdWithValue.SelectDefaultProfile && value !== 'PowerShell');
+		await this.quickaccess.runCommand(commandId, { keepOpen });
 		// Running the command should hide the quick input in the following frame, this next wait
 		// ensures that the quick input is opened again before proceeding to avoid a race condition
 		// where the enter keybinding below would close the quick input if it's triggered before the

--- a/test/automation/src/workbench.ts
+++ b/test/automation/src/workbench.ts
@@ -24,7 +24,7 @@ import { Localization } from './localization';
 import { Task } from './task';
 
 export interface Commands {
-	runCommand(command: string): Promise<any>;
+	runCommand(command: string, options?: { exactLabelMatch?: boolean }): Promise<any>;
 }
 
 export class Workbench {


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/194909

This bug was causing things to get a higher score than they deserved.

Also, in order to get the smoke tests to pass this also introduces a new `exactLabelMatch` property to `runCommand`.

### Full Context

The smoke tests install some extensions and they type `workbench.extensions.action.focusExtensionsView` into the Command Palette which causes a certain command to show up that puts focus in the extension view so the extensions can be installed.

the `runCommand` had retry logic and would pick the first result of the quick pick regardless of what it is.
Previously, if you were to type something like a command name (`workbench.extensions.action.focusExtensionsView`), chances are it wouldn’t match any command except for the one command with that id…if there were no results, it was because the command wasn’t registered yet…so because of the retry logic, that eventually would work as we wait for VS Code to actually register that command.
but with the similar commands feature, now things start to match in cases it didn’t match previously… and in this case, it’s matching things on the first try because those commands are actually registered when the one we’re actually looking for isn’t registered yet.

Before my fix to TF-IDF chunking `'workbench.extensions.action.focusExtensionsView'` still matched nothing in TF-IDF (similar commands)… so the tests still pass… but once I tweaked the TF-IDF chunk, suddenly things were matching… and that caused the smoke test to fail.

I had 5 ideas for fixing this:

Smoke Test change ideas:
* have runCommand use the label of the command instead of the id and wait for exact label match.
* have the smoke tests wait more before starting
Command Palette change ideas:
* have a setting to disable similar commands in the smoke tests because it’s getting in the way
* introduce a new `@id:` prefix (similar in the Extension Pane) in the command palette that will look up the command id and do nothing else
Extension change ideas:
* extensions stuff needs to be registered more eagerly

This is the first one on the list since it's the most straightforward.