### PR TITLE
Fix DeleteOperation not being canceled

### DIFF
--- a/src/vs/workbench/contrib/bulkEdit/browser/bulkFileEdits.ts
+++ b/src/vs/workbench/contrib/bulkEdit/browser/bulkFileEdits.ts
@@ -264,7 +264,7 @@ class DeleteOperation implements IFileOperation {
 				}
 			}
 			if (fileContent !== undefined) {
-				undoes.push(new CreateEdit(edit.oldUri, edit.options, fileContent.value));
+				undoes.push(new CreateEdit(edit.oldUri, { ...edit.options, ignoreIfExists: true }, fileContent.value));
 			}
 		}
 

--- a/src/vs/workbench/services/workingCopy/common/workingCopyFileService.ts
+++ b/src/vs/workbench/services/workingCopy/common/workingCopyFileService.ts
@@ -449,12 +449,14 @@ export class WorkingCopyFileService extends Disposable implements IWorkingCopyFi
 		}
 
 		// now actually delete from disk
+		const deletedFiles: URI[] = [];
 		try {
 			for (const operation of operations) {
 				if (token.isCancellationRequested) {
 					break;
 				}
 				await this.fileService.del(operation.resource, { recursive: operation.recursive, useTrash: operation.useTrash });
+				deletedFiles.push(operation.resource);
 			}
 		} catch (error) {
 
@@ -464,6 +466,7 @@ export class WorkingCopyFileService extends Disposable implements IWorkingCopyFi
 			throw error;
 		}
 
+		event.files = deletedFiles.map(resource => ({ target: resource }));
 		// after event
 		await this._onDidRunWorkingCopyFileOperation.fireAsync(event, CancellationToken.None /* intentional: we currently only forward cancellation to participants */);
 	}

--- a/src/vs/workbench/services/workingCopy/common/workingCopyFileService.ts
+++ b/src/vs/workbench/services/workingCopy/common/workingCopyFileService.ts
@@ -451,6 +451,9 @@ export class WorkingCopyFileService extends Disposable implements IWorkingCopyFi
 		// now actually delete from disk
 		try {
 			for (const operation of operations) {
+				if (token.isCancellationRequested) {
+					break;
+				}
 				await this.fileService.del(operation.resource, { recursive: operation.recursive, useTrash: operation.useTrash });
 			}
 		} catch (error) {


### PR DESCRIPTION
If you attempt to cancel the deletion of multiple selected files, the cancellation will not take effect and the deletion process will continue. Added a check to verify if the cancellation token has been requested within the delete loop.