### PR TITLE
adjust focused cell anchor behavior when resizing cells

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/view/notebookCellList.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/notebookCellList.ts
@@ -1207,14 +1207,20 @@ export class NotebookCellList extends WorkbenchList<CellViewModel> implements ID
 		const focused = this.getFocus();
 		const focus = focused.length ? focused[0] : null;
 
-		const anchorFocusedSetting = this.configurationService.getValue(NotebookSetting.anchorToFocusedCell);
-		const allowScrolling = this.configurationService.getValue(NotebookSetting.scrollToRevealCell) !== 'none';
-		const scrollHeuristic = allowScrolling && anchorFocusedSetting === 'auto' && this.view.elementTop(index) < this.view.getScrollTop();
-		if (focused && (anchorFocusedSetting === 'on' || scrollHeuristic)) {
-			this.view.updateElementHeight(index, size, focus);
+		// If the cell is growing, we should favor anchoring to the focused cell
+		if (focused) {
+			const cellEditorIsFocused = this.view.element(focused[0]).focusMode === CellFocusMode.Editor;
+			const anchorFocusedSetting = this.configurationService.getValue(NotebookSetting.anchorToFocusedCell);
+			const growing = this.view.elementHeight(index) < size;
+			const allowScrolling = this.configurationService.getValue(NotebookSetting.scrollToRevealCell) !== 'none';
+			const autoAnchor = allowScrolling && growing && anchorFocusedSetting !== 'off';
+
+			if (cellEditorIsFocused || autoAnchor || anchorFocusedSetting === 'on') {
+				return this.view.updateElementHeight(index, size, focus);
+			}
 		}
 
-		this.view.updateElementHeight(index, size, null);
+		return this.view.updateElementHeight(index, size, null);
 	}
 
 	// override

--- a/src/vs/workbench/contrib/notebook/test/browser/notebookCellList.test.ts
+++ b/src/vs/workbench/contrib/notebook/test/browser/notebookCellList.test.ts
@@ -22,12 +22,14 @@ suite('NotebookCellList', () => {
 
 	ensureNoDisposablesAreLeakedInTestSuite();
 
+	let config: TestConfigurationService;
 	setup(() => {
 		testDisposables = new DisposableStore();
 		instantiationService = setupInstantiationService(testDisposables);
-		const config = new TestConfigurationService({
+		config = new TestConfigurationService({
 			[NotebookSetting.anchorToFocusedCell]: 'auto'
 		});
+
 		instantiationService.stub(IConfigurationService, config);
 	});
 
@@ -201,7 +203,7 @@ suite('NotebookCellList', () => {
 			});
 	});
 
-	test('updateElementHeight with anchor #121723', async function () {
+	test('updateElementHeight with anchor', async function () {
 		await withTestNotebook(
 			[
 				['# header a', 'markdown', CellKind.Markup, [], {}],
@@ -231,6 +233,7 @@ suite('NotebookCellList', () => {
 				assert.deepStrictEqual(cellList.getViewScrollBottom(), 210);
 
 				// scroll to 5
+				cellList.updateElementHeight2(viewModel.cellAt(0)!, 50);
 				cellList.scrollTop = 5;
 				assert.deepStrictEqual(cellList.scrollTop, 5);
 				assert.deepStrictEqual(cellList.getViewScrollBottom(), 215);
@@ -239,13 +242,14 @@ suite('NotebookCellList', () => {
 				cellList.updateElementHeight2(viewModel.cellAt(0)!, 100);
 				assert.deepStrictEqual(cellList.scrollHeight, 400);
 
-				// the first cell grows, but it's partially visible, so we won't push down the focused cell
+				// the first cell grows, but we anchor to the focused cell, so the notebook will scroll down
 				assert.deepStrictEqual(cellList.scrollTop, 55);
 				assert.deepStrictEqual(cellList.getViewScrollBottom(), 265);
 
+				// We don't anchor to the focused cell when cells shrink
 				cellList.updateElementHeight2(viewModel.cellAt(0)!, 50);
-				assert.deepStrictEqual(cellList.scrollTop, 5);
-				assert.deepStrictEqual(cellList.getViewScrollBottom(), 215);
+				assert.deepStrictEqual(cellList.scrollTop, 55);
+				assert.deepStrictEqual(cellList.getViewScrollBottom(), 265);
 
 				// focus won't be visible after cell 0 grow to 250, so let's try to keep the focused cell visible
 				cellList.updateElementHeight2(viewModel.cellAt(0)!, 250);
@@ -254,7 +258,103 @@ suite('NotebookCellList', () => {
 			});
 	});
 
-	test('updateElementHeight with anchor #121723: focus element out of viewport', async function () {
+	test('updateElementHeight with no scrolling', async function () {
+		config.setUserConfiguration(NotebookSetting.scrollToRevealCell, 'none');
+		await withTestNotebook(
+			[
+				['# header a', 'markdown', CellKind.Markup, [], {}],
+				['var b = 1;', 'javascript', CellKind.Code, [], {}],
+				['# header b', 'markdown', CellKind.Markup, [], {}],
+				['var b = 2;', 'javascript', CellKind.Code, [], {}],
+				['# header c', 'markdown', CellKind.Markup, [], {}]
+			],
+			async (editor, viewModel, disposables) => {
+				viewModel.restoreEditorViewState({
+					editingCells: [false, false, false, false, false],
+					editorViewStates: [null, null, null, null, null],
+					cellTotalHeights: [50, 100, 50, 100, 50],
+					cellLineNumberStates: {},
+					collapsedInputCells: {},
+					collapsedOutputCells: {},
+				});
+				const cellList = createNotebookCellList(instantiationService, disposables);
+				cellList.attachViewModel(viewModel);
+
+				// render height 210, it can render 3 full cells and 1 partial cell
+				cellList.layout(210, 100);
+
+				// init scrollTop and scrollBottom
+				assert.deepStrictEqual(cellList.scrollTop, 0);
+				assert.deepStrictEqual(cellList.getViewScrollBottom(), 210);
+
+				// scroll to 5
+				cellList.updateElementHeight2(viewModel.cellAt(0)!, 50);
+				cellList.scrollTop = 5;
+				assert.deepStrictEqual(cellList.scrollTop, 5);
+				assert.deepStrictEqual(cellList.getViewScrollBottom(), 215);
+
+				cellList.setFocus([1]);
+				cellList.updateElementHeight2(viewModel.cellAt(0)!, 100);
+				assert.deepStrictEqual(cellList.scrollHeight, 400);
+
+				// Any change in cell size should not affect the scroll height with scrollToReveal set to none
+				assert.deepStrictEqual(cellList.scrollTop, 5);
+
+				cellList.updateElementHeight2(viewModel.cellAt(0)!, 50);
+				assert.deepStrictEqual(cellList.scrollTop, 5);
+
+				cellList.updateElementHeight2(viewModel.cellAt(0)!, 250);
+				assert.deepStrictEqual(cellList.scrollTop, 5);
+			});
+	});
+
+	test('updateElementHeight with no scroll setting and cell editor focused', async function () {
+		config.setUserConfiguration(NotebookSetting.scrollToRevealCell, 'none');
+		await withTestNotebook(
+			[
+				['# header a', 'markdown', CellKind.Markup, [], {}],
+				['var b = 1;', 'javascript', CellKind.Code, [], {}],
+				['# header b', 'markdown', CellKind.Markup, [], {}],
+				['var b = 2;', 'javascript', CellKind.Code, [], {}],
+				['# header c', 'markdown', CellKind.Markup, [], {}]
+			],
+			async (editor, viewModel, disposables) => {
+				viewModel.restoreEditorViewState({
+					editingCells: [false, false, false, false, false],
+					editorViewStates: [null, null, null, null, null],
+					cellTotalHeights: [50, 100, 50, 100, 50],
+					cellLineNumberStates: {},
+					collapsedInputCells: {},
+					collapsedOutputCells: {},
+				});
+				const cellList = createNotebookCellList(instantiationService, disposables);
+				cellList.attachViewModel(viewModel);
+
+				// render height 210, it can render 3 full cells and 1 partial cell
+				cellList.layout(210, 100);
+
+				// init scrollTop and scrollBottom
+				assert.deepStrictEqual(cellList.scrollTop, 0);
+				assert.deepStrictEqual(cellList.getViewScrollBottom(), 210);
+
+				cellList.setFocus([1]);
+
+				editor.focusNotebookCell(cellList.viewModel?.cellAt(1)!, 'editor');
+				cellList.updateElementHeight2(viewModel.cellAt(0)!, 100);
+				assert.deepStrictEqual(cellList.scrollHeight, 400);
+
+				// We have the cell editor focused, so we should anchor to that cell
+				assert.deepStrictEqual(cellList.scrollTop, 50);
+
+				cellList.updateElementHeight2(viewModel.cellAt(0)!, 50);
+				assert.deepStrictEqual(cellList.scrollTop, 0);
+
+				cellList.updateElementHeight2(viewModel.cellAt(0)!, 250);
+				assert.deepStrictEqual(cellList.scrollTop, 250 + 100 - cellList.renderHeight);
+			});
+	});
+
+	test('updateElementHeight with focused element out of viewport', async function () {
 		await withTestNotebook(
 			[
 				['# header a', 'markdown', CellKind.Markup, [], {}],

--- a/src/vs/workbench/contrib/notebook/test/browser/testNotebookEditor.ts
+++ b/src/vs/workbench/contrib/notebook/test/browser/testNotebookEditor.ts
@@ -41,7 +41,7 @@ import { UndoRedoService } from 'vs/platform/undoRedo/common/undoRedoService';
 import { IWorkspaceTrustRequestService } from 'vs/platform/workspace/common/workspaceTrust';
 import { EditorInput } from 'vs/workbench/common/editor/editorInput';
 import { EditorModel } from 'vs/workbench/common/editor/editorModel';
-import { CellFindMatchWithIndex, IActiveNotebookEditorDelegate, IBaseCellEditorOptions, ICellViewModel, INotebookEditorDelegate } from 'vs/workbench/contrib/notebook/browser/notebookBrowser';
+import { CellFindMatchWithIndex, CellFocusMode, IActiveNotebookEditorDelegate, IBaseCellEditorOptions, ICellViewModel, INotebookEditorDelegate } from 'vs/workbench/contrib/notebook/browser/notebookBrowser';
 import { NotebookCellStateChangedEvent, NotebookLayoutInfo } from 'vs/workbench/contrib/notebook/browser/notebookViewEvents';
 import { NotebookCellStatusBarService } from 'vs/workbench/contrib/notebook/browser/services/notebookCellStatusBarServiceImpl';
 import { ListViewInfoAccessor, NotebookCellList } from 'vs/workbench/contrib/notebook/browser/view/notebookCellList';
@@ -276,7 +276,11 @@ function _createTestNotebookEditor(instantiationService: TestInstantiationServic
 		override async revealRangeInCenterIfOutsideViewportAsync() { }
 		override async layoutNotebookCell() { }
 		override async removeInset() { }
-		override async focusNotebookCell() { }
+		override async focusNotebookCell(cell: ICellViewModel, focusItem: 'editor' | 'container' | 'output') {
+			cell.focusMode = focusItem === 'editor' ? CellFocusMode.Editor
+				: focusItem === 'output' ? CellFocusMode.Output
+					: CellFocusMode.Container;
+		}
 		override cellAt(index: number) { return viewModel.cellAt(index)!; }
 		override getCellIndex(cell: ICellViewModel) { return viewModel.getCellIndex(cell); }
 		override getCellsInRange(range?: ICellRange) { return viewModel.getCellsInRange(range); }


### PR DESCRIPTION
fix https://github.com/microsoft/vscode/issues/194516

https://github.com/microsoft/vscode/pull/195283 reduced the amount of resizing that cells do, so this PR attempts to make the auto setting for anchoring the focused cell work more smoothly.

Basically, anchor to the focused cell if 
- the cell editor is focused (User is editing the code, so it should stay steady)
- the cell is growing (prevent the focused cell from being pushed out of view) unless the user set the notebook to not scroll on execute

Shrinking an output is less common since an output won't be resized as the cell is executing, so issues like https://github.com/microsoft/vscode/issues/193835 shouldn't occur anymore