### PR TITLE
Placing AI code actions always at the bottom of the quick fix menu

### DIFF
--- a/src/vs/editor/contrib/codeAction/browser/codeAction.ts
+++ b/src/vs/editor/contrib/codeAction/browser/codeAction.ts
@@ -38,11 +38,7 @@ export const fixAllCommandId = 'editor.action.fixAll';
 class ManagedCodeActionSet extends Disposable implements CodeActionSet {
 
 	private static codeActionsPreferredComparator(a: languages.CodeAction, b: languages.CodeAction): number {
-		if (a.isAI && !b.isAI) {
-			return 1;
-		} else if (!a.isAI && b.isAI) {
-			return -1;
-		} else if (a.isPreferred && !b.isPreferred) {
+		if (a.isPreferred && !b.isPreferred) {
 			return -1;
 		} else if (!a.isPreferred && b.isPreferred) {
 			return 1;
@@ -52,6 +48,11 @@ class ManagedCodeActionSet extends Disposable implements CodeActionSet {
 	}
 
 	private static codeActionsComparator({ action: a }: CodeActionItem, { action: b }: CodeActionItem): number {
+		if (a.isAI && !b.isAI) {
+			return 1;
+		} else if (!a.isAI && b.isAI) {
+			return -1;
+		}
 		if (isNonEmptyArray(a.diagnostics)) {
 			return isNonEmptyArray(b.diagnostics) ? ManagedCodeActionSet.codeActionsPreferredComparator(a, b) : -1;
 		} else if (isNonEmptyArray(b.diagnostics)) {


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/195305

The AI code actions are placed always at the bottom of the menu and then they are sorted between each other in terms of the usual metric.

<img width="616" alt="Screenshot 2023-10-11 at 12 32 10" src="https://github.com/microsoft/vscode/assets/61460952/e7a8f4f8-fbef-409f-b477-d710fcd3ce4c">
