### PR TITLE
no need for cell output to update the editor height

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/view/cellParts/cellOutput.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/cellParts/cellOutput.ts
@@ -716,9 +716,6 @@ export class CellOutputContainer extends CellContentPart {
 			DOM.hide(this.templateData.outputShowMoreContainer.domNode);
 		}
 
-		const editorHeight = this.templateData.editor.getContentHeight();
-		this.viewCell.editorHeight = editorHeight;
-
 		this._relayoutCell();
 		// if it's clearing all outputs, or outputs are all rendered synchronously
 		// shrink immediately as the final output height will be zero.


### PR DESCRIPTION
fix https://github.com/microsoft/vscode/issues/195325

I couldn't come up with a scenario where it would be necessary for the cell's output to tell the editor what its size it should be, but there are cases where it fails to calculate the height correctly because the cell isn't rendered and the model doesn't exist, which was occurring in that issue.