### PR TITLE
Return the session if the user constented

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadAuthentication.ts
+++ b/src/vs/workbench/api/browser/mainThreadAuthentication.ts
@@ -243,8 +243,10 @@ export class MainThreadAuthentication extends Disposable implements MainThreadAu
 			}
 
 			let session;
-			if (sessions?.length && !options.forceNewSession && supportsMultipleAccounts) {
-				session = await this.authenticationService.selectSession(providerId, extensionId, extensionName, scopes, sessions);
+			if (sessions?.length && !options.forceNewSession) {
+				session = supportsMultipleAccounts
+					? await this.authenticationService.selectSession(providerId, extensionId, extensionName, scopes, sessions)
+					: sessions[0];
 			} else {
 				let sessionToRecreate: AuthenticationSession | undefined;
 				if (typeof options.forceNewSession === 'object' && options.forceNewSession.sessionToRecreate) {


### PR DESCRIPTION
If the auth provider doesn't support multiple accounts and we have a valid session and the user consented, then use that session.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fixes https://github.com/microsoft/vscode/issues/195286