### PR TITLE
fix: bracket pair fails in nested template string(#190564)

### DIFF
--- a/extensions/javascript/package.json
+++ b/extensions/javascript/package.json
@@ -69,7 +69,7 @@
         },
         "tokenTypes": {
           "meta.template.expression": "other",
-          "meta.template.expression string": "string",
+          "meta.template.expression string.quoted": "string",
           "meta.template.expression comment": "comment",
           "entity.name.type.instance.jsdoc": "other",
           "entity.name.function.tagged-template": "other",
@@ -89,7 +89,7 @@
         },
         "tokenTypes": {
           "meta.template.expression": "other",
-          "meta.template.expression string": "string",
+          "meta.template.expression string.quoted": "string",
           "meta.template.expression comment": "comment",
           "entity.name.type.instance.jsdoc": "other",
           "entity.name.function.tagged-template": "other",

--- a/extensions/typescript-basics/package.json
+++ b/extensions/typescript-basics/package.json
@@ -75,7 +75,7 @@
         ],
         "tokenTypes": {
           "meta.template.expression": "other",
-          "meta.template.expression string": "string",
+          "meta.template.expression string.quoted": "string",
           "meta.template.expression comment": "comment",
           "entity.name.type.instance.jsdoc": "other",
           "entity.name.function.tagged-template": "other",
@@ -102,7 +102,7 @@
         },
         "tokenTypes": {
           "meta.template.expression": "other",
-          "meta.template.expression string": "string",
+          "meta.template.expression string.quoted": "string",
           "meta.template.expression comment": "comment",
           "entity.name.type.instance.jsdoc": "other",
           "entity.name.function.tagged-template": "other",


### PR DESCRIPTION
Fix #190564

In `extensions/typescript-basics/syntaxes/TypeScript.tmLanguage.json`, The selectors which start with "string" are "string.quoted", "string.regexp" and "string.template", in fact we should only treat "string.quoted" as string. Please check!
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
