### PR TITLE
Await in terminal editor commands

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminalActions.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalActions.ts
@@ -253,7 +253,7 @@ export function registerTerminalActions() {
 		run: async (c, _, args) => {
 			const options = (isObject(args) && 'location' in args) ? args as ICreateTerminalOptions : { location: TerminalLocation.Editor };
 			const instance = await c.service.createTerminal(options);
-			instance.focusWhenReady();
+			await instance.focusWhenReady();
 		}
 	});
 
@@ -268,7 +268,7 @@ export function registerTerminalActions() {
 			const instance = await c.service.createTerminal({
 				location: { viewColumn: editorGroupsService.activeGroup.index }
 			});
-			instance.focusWhenReady();
+			await instance.focusWhenReady();
 		}
 	});
 
@@ -279,7 +279,7 @@ export function registerTerminalActions() {
 			const instance = await c.service.createTerminal({
 				location: { viewColumn: SIDE_GROUP }
 			});
-			instance.focusWhenReady();
+			await instance.focusWhenReady();
 		}
 	});
 


### PR DESCRIPTION
This allows linking together with runCommands as expected.

Part of #10121

This works now:

```json
{
  "key": "ctrl+alt+`",
  "command": "runCommands",
  "args": {
    "commands": [
      "workbench.action.createTerminalEditor",
      "workbench.action.experimentalMoveEditorIntoNewWindowAction"
    ]
  }
}
```