### PR TITLE
use `visibility` instead of `position` to hide accessible view

### DIFF
--- a/src/vs/workbench/contrib/accessibility/browser/accessibleView.ts
+++ b/src/vs/workbench/contrib/accessibility/browser/accessibleView.ts
@@ -170,6 +170,9 @@ export class AccessibleView extends Disposable {
 
 		this._container = document.createElement('div');
 		this._container.classList.add('accessible-view');
+		if (this._configurationService.getValue('accessibility.hideAccessibleView')) {
+			this._container.classList.add('hide');
+		}
 		const codeEditorWidgetOptions: ICodeEditorWidgetOptions = {
 			contributions: EditorExtensionsRegistry.getEditorContributions().filter(c => c.id !== CodeActionController.ID)
 		};

--- a/src/vs/workbench/contrib/accessibility/browser/accessibleView.ts
+++ b/src/vs/workbench/contrib/accessibility/browser/accessibleView.ts
@@ -38,7 +38,7 @@ import { ILayoutService } from 'vs/platform/layout/browser/layoutService';
 import { IOpenerService } from 'vs/platform/opener/common/opener';
 import { IPickerQuickAccessItem } from 'vs/platform/quickinput/browser/pickerQuickAccess';
 import { IQuickInputService } from 'vs/platform/quickinput/common/quickInput';
-import { AccessibilityVerbositySettingId, AccessibilityWorkbenchSettingId, AccessibleViewProviderId, accessibilityHelpIsShown, accessibleViewCurrentProviderId, accessibleViewGoToSymbolSupported, accessibleViewIsShown, accessibleViewOnLastLine, accessibleViewSupportsNavigation, accessibleViewVerbosityEnabled } from 'vs/workbench/contrib/accessibility/browser/accessibilityConfiguration';
+import { AccessibilityVerbositySettingId, AccessibleViewProviderId, accessibilityHelpIsShown, accessibleViewCurrentProviderId, accessibleViewGoToSymbolSupported, accessibleViewIsShown, accessibleViewOnLastLine, accessibleViewSupportsNavigation, accessibleViewVerbosityEnabled } from 'vs/workbench/contrib/accessibility/browser/accessibilityConfiguration';
 import { AccessibilityCommandId } from 'vs/workbench/contrib/accessibility/common/accessibilityCommands';
 import { getSimpleEditorOptions } from 'vs/workbench/contrib/codeEditor/browser/simpleEditorOptions';
 
@@ -215,8 +215,8 @@ export class AccessibleView extends Disposable {
 				this._accessibleViewVerbosityEnabled.set(this._configurationService.getValue(this._currentProvider.verbositySettingKey));
 				this._updateToolbar(this._currentProvider.actions, this._currentProvider.options.type);
 			}
-			if (e.affectsConfiguration(AccessibilityWorkbenchSettingId.HideAccessibleView)) {
-				this._container.classList.toggle('hide', this._configurationService.getValue(AccessibilityWorkbenchSettingId.HideAccessibleView));
+			if (e.affectsConfiguration('accessibility.hideAccessibleView')) {
+				this._container.classList.toggle('hide', this._configurationService.getValue('accessibility.hideAccessibleView'));
 			}
 		}));
 		this._register(this._editorWidget.onDidDispose(() => this._resetContextKeys()));

--- a/src/vs/workbench/contrib/accessibility/browser/accessibleView.ts
+++ b/src/vs/workbench/contrib/accessibility/browser/accessibleView.ts
@@ -38,7 +38,7 @@ import { ILayoutService } from 'vs/platform/layout/browser/layoutService';
 import { IOpenerService } from 'vs/platform/opener/common/opener';
 import { IPickerQuickAccessItem } from 'vs/platform/quickinput/browser/pickerQuickAccess';
 import { IQuickInputService } from 'vs/platform/quickinput/common/quickInput';
-import { AccessibilityVerbositySettingId, AccessibleViewProviderId, accessibilityHelpIsShown, accessibleViewCurrentProviderId, accessibleViewGoToSymbolSupported, accessibleViewIsShown, accessibleViewOnLastLine, accessibleViewSupportsNavigation, accessibleViewVerbosityEnabled } from 'vs/workbench/contrib/accessibility/browser/accessibilityConfiguration';
+import { AccessibilityVerbositySettingId, AccessibilityWorkbenchSettingId, AccessibleViewProviderId, accessibilityHelpIsShown, accessibleViewCurrentProviderId, accessibleViewGoToSymbolSupported, accessibleViewIsShown, accessibleViewOnLastLine, accessibleViewSupportsNavigation, accessibleViewVerbosityEnabled } from 'vs/workbench/contrib/accessibility/browser/accessibilityConfiguration';
 import { AccessibilityCommandId } from 'vs/workbench/contrib/accessibility/common/accessibilityCommands';
 import { getSimpleEditorOptions } from 'vs/workbench/contrib/codeEditor/browser/simpleEditorOptions';
 
@@ -170,7 +170,7 @@ export class AccessibleView extends Disposable {
 
 		this._container = document.createElement('div');
 		this._container.classList.add('accessible-view');
-		if (this._configurationService.getValue('accessibility.hideAccessibleView')) {
+		if (this._configurationService.getValue(AccessibilityWorkbenchSettingId.HideAccessibleView)) {
 			this._container.classList.add('hide');
 		}
 		const codeEditorWidgetOptions: ICodeEditorWidgetOptions = {
@@ -218,8 +218,8 @@ export class AccessibleView extends Disposable {
 				this._accessibleViewVerbosityEnabled.set(this._configurationService.getValue(this._currentProvider.verbositySettingKey));
 				this._updateToolbar(this._currentProvider.actions, this._currentProvider.options.type);
 			}
-			if (e.affectsConfiguration('accessibility.hideAccessibleView')) {
-				this._container.classList.toggle('hide', this._configurationService.getValue('accessibility.hideAccessibleView'));
+			if (e.affectsConfiguration(AccessibilityWorkbenchSettingId.HideAccessibleView)) {
+				this._container.classList.toggle('hide', this._configurationService.getValue(AccessibilityWorkbenchSettingId.HideAccessibleView));
 			}
 		}));
 		this._register(this._editorWidget.onDidDispose(() => this._resetContextKeys()));

--- a/src/vs/workbench/contrib/codeEditor/browser/accessibility/accessibility.css
+++ b/src/vs/workbench/contrib/codeEditor/browser/accessibility/accessibility.css
@@ -55,4 +55,5 @@
 
 .accessible-view.hide {
 	opacity: 0;
+	pointer-events: none;
 }

--- a/src/vs/workbench/contrib/codeEditor/browser/accessibility/accessibility.css
+++ b/src/vs/workbench/contrib/codeEditor/browser/accessibility/accessibility.css
@@ -54,7 +54,5 @@
 }
 
 .accessible-view.hide {
-	position: fixed;
-	top: -2000px;
-	left:-2000px;
+	opacity: 0;
 }

--- a/src/vs/workbench/contrib/codeEditor/browser/accessibility/accessibility.css
+++ b/src/vs/workbench/contrib/codeEditor/browser/accessibility/accessibility.css
@@ -54,6 +54,6 @@
 }
 
 .accessible-view.hide {
-	opacity: 0;
+	visibility: hidden;
 	pointer-events: none;
 }


### PR DESCRIPTION
fix #195288