### PR TITLE
Restore chat code block background color

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/media/chat.css
@@ -264,7 +264,7 @@
 .interactive-response .interactive-result-code-block .interactive-result-editor .monaco-editor,
 .interactive-response .interactive-result-code-block .interactive-result-editor .monaco-editor .margin,
 .interactive-response .interactive-result-code-block .interactive-result-editor .monaco-editor .monaco-editor-background {
-	background-color: var(--vscode-interactive-result-editor-background-color);
+	background-color: var(--vscode-interactive-result-editor-background-color) !important;
 }
 
 .interactive-item-compact .interactive-result-code-block {


### PR DESCRIPTION
This keeps regressing, hence using `!important` here