### PR TITLE
Inline chat polish

### DIFF
--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatController.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatController.ts
@@ -569,7 +569,7 @@ export class InlineChatController implements IEditorContribution {
 					throw new Error('Progress in NOT supported in non-live mode');
 				}
 				progressEdits.push(data.edits);
-				await this._makeChanges(data.edits, false);
+				await this._makeChanges(data.edits, true);
 				await this._strategy?.renderProgressChanges();
 			}
 		});
@@ -650,9 +650,14 @@ export class InlineChatController implements IEditorContribution {
 		assertType(this._strategy);
 
 		// make changes from modelN -> modelN+1
-		const moreMinimalEdits = computeMoreMinimalEdits ? await this._editorWorkerService.computeHumanReadableDiff(this._activeSession.textModelN.uri, lastEdits) : undefined;
+		const moreMinimalEdits = computeMoreMinimalEdits ? await this._editorWorkerService.computeMoreMinimalEdits(this._activeSession.textModelN.uri, lastEdits) : undefined;
 		const editOperations = (moreMinimalEdits ?? lastEdits).map(TextEdit.asEditOperation);
 		this._log('edits from PROVIDER and after making them MORE MINIMAL', this._activeSession.provider.debugName, lastEdits, moreMinimalEdits);
+
+		if (editOperations.length === 0) {
+			// nothing left to do
+			return;
+		}
 
 		try {
 			this._ignoreModelContentChanged = true;

--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatLivePreviewWidget.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatLivePreviewWidget.ts
@@ -80,6 +80,7 @@ export class InlineChatLivePreviewWidget extends ZoneWidget {
 			stickyScroll: { enabled: false },
 			minimap: { enabled: false },
 			isInEmbeddedEditor: true,
+			useInlineViewWhenSpaceIsLimited: false,
 			overflowWidgetsDomNode: editor.getOverflowWidgetsDomNode(),
 			onlyShowAccessibleDiffViewer: this.accessibilityService.isScreenReaderOptimized(),
 		}, {

--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatStrategies.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatStrategies.ts
@@ -484,7 +484,7 @@ export class LivePreviewStrategy extends LiveStrategy {
 			const zone = this._diffZonePool[i];
 			if (zone.isVisible && zone.position) {
 				// above last view zone
-				return zone.position.delta(-1);
+				return zone.position;
 			}
 		}
 		return undefined;


### PR DESCRIPTION
- always use `computeMoreMinimalEdits` to reduce flicker for empty edits
- don't use automatic inline diff'ing for predictable heights
- fix widget positioning off by one
