### PR TITLE
Fix disappearing editorGutter element in editor

### DIFF
--- a/src/vs/workbench/contrib/scm/browser/dirtydiffDecorator.ts
+++ b/src/vs/workbench/contrib/scm/browser/dirtydiffDecorator.ts
@@ -1674,8 +1674,14 @@ export class DirtyDiffWorkbenchController extends Disposable implements ext.IWor
 		for (const [uri, item] of this.items) {
 			for (const editorId of item.keys()) {
 				if (!this.editorService.visibleTextEditorControls.find(editor => isCodeEditor(editor) && editor.getModel()?.uri.toString() === uri.toString() && editor.getId() === editorId)) {
-					dispose(item.values());
-					this.items.delete(uri);
+					if (item.has(editorId)) {
+						const dirtyDiffItem = item.get(editorId);
+						dirtyDiffItem?.dispose();
+						item.delete(editorId);
+						if (item.size === 0) {
+							this.items.delete(uri);
+						}
+					}
 				}
 			}
 		}


### PR DESCRIPTION
This pull request fixes the issue where the editorGutter element in the editor disappears. The issue was caused by the dirtydiffDecorator not properly disposing of the item when the editor is no longer visible. The fix involves checking if the item exists before disposing of it and deleting it from the map if it is empty. Fixes #195762.