### PR TITLE
expand windows prompt regex so textarea is synced

### DIFF
--- a/src/vs/platform/terminal/common/capabilities/commandDetectionCapability.ts
+++ b/src/vs/platform/terminal/common/capabilities/commandDetectionCapability.ts
@@ -443,7 +443,7 @@ export class CommandDetectionCapability extends Disposable implements ICommandDe
 			return;
 		}
 		// TODO: fine tune prompt regex to accomodate for unique configurtions.
-		return line.translateToString(true)?.match(/^(?<prompt>.*(?:PS.+>\s)|(?:[A-Z]:\\.*>))/)?.groups?.prompt;
+		return line.translateToString(true)?.match(/^(?<prompt>(\(.+\)\s)?(?:PS.+>\s)|(?:[A-Z]:\\.*>))/)?.groups?.prompt;
 	}
 
 	handleGenericCommand(options?: IHandleCommandOptions): void {

--- a/src/vs/platform/terminal/common/capabilities/commandDetectionCapability.ts
+++ b/src/vs/platform/terminal/common/capabilities/commandDetectionCapability.ts
@@ -443,7 +443,7 @@ export class CommandDetectionCapability extends Disposable implements ICommandDe
 			return;
 		}
 		// TODO: fine tune prompt regex to accomodate for unique configurtions.
-		return line.translateToString(true)?.match(/^(?<prompt>(?:PS.+>\s)|(?:[A-Z]:\\.*>))/)?.groups?.prompt;
+		return line.translateToString(true)?.match(/^(?<prompt>.*(?:PS.+>\s)|(?:[A-Z]:\\.*>))/)?.groups?.prompt;
 	}
 
 	handleGenericCommand(options?: IHandleCommandOptions): void {


### PR DESCRIPTION
`(conda) PS C:\Users\YourUsername>` didn't work before. Need to test on Windows

fix #195834