### PR TITLE
Update NPS URL to include context parameters

### DIFF
--- a/src/vs/workbench/contrib/surveys/browser/nps.contribution.ts
+++ b/src/vs/workbench/contrib/surveys/browser/nps.contribution.ts
@@ -71,7 +71,7 @@ class NPSContribution implements IWorkbenchContribution {
 			[{
 				label: nls.localize('takeSurvey', "Take Survey"),
 				run: () => {
-					openerService.open(URI.parse(`${productService.npsSurveyUrl}?o=${encodeURIComponent(platform)}&v=${encodeURIComponent(productService.version)}&m=${encodeURIComponent(telemetryService.machineId)}`));
+					openerService.open(URI.parse(`${productService.npsSurveyUrl}?ctx=${encodeURIComponent(`{"ProductVersion":"${productService.version}","Platform":"${platform}","MachineId":"${telemetryService.machineId}"`)}`));
 					storageService.store(IS_CANDIDATE_KEY, false, StorageScope.APPLICATION, StorageTarget.USER);
 					storageService.store(SKIP_VERSION_KEY, productService.version, StorageScope.APPLICATION, StorageTarget.USER);
 				}

--- a/src/vs/workbench/contrib/surveys/browser/nps.contribution.ts
+++ b/src/vs/workbench/contrib/surveys/browser/nps.contribution.ts
@@ -71,7 +71,7 @@ class NPSContribution implements IWorkbenchContribution {
 			[{
 				label: nls.localize('takeSurvey', "Take Survey"),
 				run: () => {
-					openerService.open(URI.parse(`${productService.npsSurveyUrl}?ctx=${encodeURIComponent(`{"ProductVersion":"${productService.version}","Platform":"${platform}","MachineId":"${telemetryService.machineId}"`)}`));
+					openerService.open(URI.parse(`${productService.npsSurveyUrl}?ctx=${encodeURIComponent(`{"ProductVersion":"${productService.version}","Platform":"${platform}","MachineId":"${telemetryService.machineId}"}`)}`));
 					storageService.store(IS_CANDIDATE_KEY, false, StorageScope.APPLICATION, StorageTarget.USER);
 					storageService.store(SKIP_VERSION_KEY, productService.version, StorageScope.APPLICATION, StorageTarget.USER);
 				}


### PR DESCRIPTION
Backporting changes made in ADS to be able to capture Product version and other parameters via context params.
ref PR: https://github.com/microsoft/azuredatastudio/pull/24723

Survey URL format details: https://meganvwalker.com/passing-variables-through-the-forms-pro-survey-url/

We internally received this information from the Survey teams.