### PR TITLE
Update inline chat functionality with markdown support streaming

### DIFF
--- a/src/vs/workbench/api/common/extHostInlineChat.ts
+++ b/src/vs/workbench/api/common/extHostInlineChat.ts
@@ -153,7 +153,7 @@ export class ExtHostInteractiveEditor implements ExtHostInlineChatShape {
 
 
 		let done = false;
-		const progress: vscode.Progress<{ message?: string; edits?: vscode.TextEdit[]; slashCommand?: vscode.InteractiveEditorSlashCommand }> = {
+		const progress: vscode.Progress<vscode.InteractiveEditorProgressItem> = {
 			report: async value => {
 				if (!request.live) {
 					throw new Error('Progress reporting is only supported for live sessions');
@@ -164,7 +164,8 @@ export class ExtHostInteractiveEditor implements ExtHostInlineChatShape {
 				await this._proxy.$handleProgressChunk(request.requestId, {
 					message: value.message,
 					edits: value.edits?.map(typeConvert.TextEdit.from),
-					slashCommand: value.slashCommand?.command
+					slashCommand: value.slashCommand?.command,
+					markdownFragment: extHostTypes.MarkdownString.isMarkdownString(value.content) ? value.content.value : value.content
 				});
 			}
 		};

--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatSession.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatSession.ts
@@ -26,6 +26,7 @@ import { isCancellationError } from 'vs/base/common/errors';
 import { ISingleEditOperation } from 'vs/editor/common/core/editOperation';
 import { raceCancellation } from 'vs/base/common/async';
 import { LineRangeMapping } from 'vs/editor/common/diff/rangeMapping';
+import { IMarkdownString } from 'vs/base/common/htmlContent';
 
 export type Recording = {
 	when: Date;
@@ -281,7 +282,8 @@ export class ErrorResponse {
 export class MarkdownResponse {
 	constructor(
 		readonly localUri: URI,
-		readonly raw: IInlineChatMessageResponse
+		readonly raw: IInlineChatMessageResponse,
+		readonly mdContent: IMarkdownString,
 	) { }
 }
 

--- a/src/vs/workbench/contrib/inlineChat/common/inlineChat.ts
+++ b/src/vs/workbench/contrib/inlineChat/common/inlineChat.ts
@@ -84,6 +84,7 @@ export interface IInlineChatMessageResponse {
 }
 
 export interface IInlineChatProgressItem {
+	markdownFragment?: string;
 	edits?: TextEdit[];
 	message?: string;
 	slashCommand?: string;

--- a/src/vscode-dts/vscode.proposed.interactive.d.ts
+++ b/src/vscode-dts/vscode.proposed.interactive.d.ts
@@ -52,6 +52,7 @@ declare module 'vscode' {
 		message?: string;
 		edits?: TextEdit[];
 		slashCommand?: InteractiveEditorSlashCommand;
+		content?: string | MarkdownString;
 	}
 
 	export enum InteractiveEditorResponseFeedbackKind {


### PR DESCRIPTION
This pull request updates the inline chat functionality to support markdown streaming. This allows users to send messages with markdown formatting in real-time during interactive sessions. The changes include updates to the ExtHostInteractiveEditor and InlineChatController classes, as well as the addition of a new MarkdownString class. 