### PR TITLE
Allow quick chat toggle to take partial input

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/chatQuickInputActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatQuickInputActions.ts
@@ -84,7 +84,35 @@ class QuickChatGlobalAction extends Action2 {
 				linux: {
 					primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyMod.Alt | KeyCode.KeyI
 				}
-			}
+			},
+			metadata: {
+				description: localize('toggle.desc', 'abc'),
+				args: [{
+					name: 'args',
+					schema: {
+						anyOf: [
+							{
+								type: 'object',
+								required: ['query'],
+								properties: {
+									query: {
+										description: localize('toggle.query', "The query to open the quick chat with"),
+										type: 'string'
+									},
+									isPartialQuery: {
+										description: localize('toggle.isPartialQuery', "Whether the query is partial; it will wait for more user input"),
+										type: 'boolean'
+									}
+								},
+							},
+							{
+								type: 'string',
+								description: localize('toggle.query', "The query to open the quick chat with")
+							}
+						]
+					}
+				}]
+			},
 		});
 	}
 

--- a/src/vs/workbench/contrib/chat/browser/chat.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.ts
@@ -10,6 +10,7 @@ import { Event } from 'vs/base/common/event';
 import { URI } from 'vs/base/common/uri';
 import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
 import { IChatWidgetContrib } from 'vs/workbench/contrib/chat/browser/chatWidget';
+import { Selection } from 'vs/editor/common/core/selection';
 
 export const IChatWidgetService = createDecorator<IChatWidgetService>('chatWidgetService');
 export const IQuickChatService = createDecorator<IQuickChatService>('quickChatService');
@@ -38,11 +39,26 @@ export interface IQuickChatService {
 	readonly _serviceBrand: undefined;
 	readonly onDidClose: Event<void>;
 	readonly enabled: boolean;
-	toggle(providerId?: string, query?: string): void;
+	toggle(providerId?: string, options?: IQuickChatOpenOptions): void;
 	focus(): void;
-	open(): void;
+	open(providerId?: string, options?: IQuickChatOpenOptions): void;
 	close(): void;
 	openInChatView(): void;
+}
+
+export interface IQuickChatOpenOptions {
+	/**
+	 * The query for quick chat.
+	 */
+	query: string;
+	/**
+	 * Whether the query is partial and will await more input from the user.
+	 */
+	isPartialQuery?: boolean;
+	/**
+	 * An optional selection range to apply to the query text box.
+	 */
+	selection?: Selection;
 }
 
 export interface IChatAccessibilityService {

--- a/src/vs/workbench/contrib/chat/browser/chatQuick.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatQuick.ts
@@ -9,13 +9,14 @@ import { disposableTimeout } from 'vs/base/common/async';
 import { CancellationToken } from 'vs/base/common/cancellation';
 import { Emitter } from 'vs/base/common/event';
 import { Disposable, DisposableStore, IDisposable, MutableDisposable } from 'vs/base/common/lifecycle';
+import { Selection } from 'vs/editor/common/core/selection';
 import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { ServiceCollection } from 'vs/platform/instantiation/common/serviceCollection';
 import { ILayoutService } from 'vs/platform/layout/browser/layoutService';
 import { IQuickInputService, IQuickWidget } from 'vs/platform/quickinput/common/quickInput';
 import { editorBackground, inputBackground, quickInputBackground, quickInputForeground } from 'vs/platform/theme/common/colorRegistry';
-import { IChatWidgetService, IQuickChatService } from 'vs/workbench/contrib/chat/browser/chat';
+import { IChatWidgetService, IQuickChatService, IQuickChatOpenOptions } from 'vs/workbench/contrib/chat/browser/chat';
 import { IChatViewOptions } from 'vs/workbench/contrib/chat/browser/chatViewPane';
 import { ChatWidget } from 'vs/workbench/contrib/chat/browser/chatWidget';
 import { ChatModel } from 'vs/workbench/contrib/chat/common/chatModel';
@@ -53,16 +54,17 @@ export class QuickChatService extends Disposable implements IQuickChatService {
 		return dom.isAncestorOfActiveElement(widget);
 	}
 
-	toggle(providerId?: string, query?: string | undefined): void {
-		// If the input is already shown, hide it. This provides a toggle behavior of the quick pick
-		if (this.focused) {
+	toggle(providerId?: string, options?: IQuickChatOpenOptions): void {
+		// If the input is already shown, hide it. This provides a toggle behavior of the quick
+		// pick. This should not happen when there is a query.
+		if (this.focused && !options?.query) {
 			this.close();
 		} else {
-			this.open(providerId, query);
+			this.open(providerId, options);
 		}
 	}
 
-	open(providerId?: string, query?: string | undefined): void {
+	open(providerId?: string, options?: IQuickChatOpenOptions): void {
 		if (this._input) {
 			return this.focus();
 		}
@@ -107,9 +109,11 @@ export class QuickChatService extends Disposable implements IQuickChatService {
 
 		this._currentChat.focus();
 
-		if (query) {
-			this._currentChat.setValue(query);
-			this._currentChat.acceptInput();
+		if (options?.query) {
+			this._currentChat.setValue(options.query, options.selection);
+			if (!options.isPartialQuery) {
+				this._currentChat.acceptInput();
+			}
 		}
 	}
 	focus(): void {
@@ -155,12 +159,12 @@ class QuickChat extends Disposable {
 		this.widget.inputEditor.setValue('');
 	}
 
-	focus(): void {
+	focus(selection?: Selection): void {
 		if (this.widget) {
 			this.widget.focusInput();
 			const value = this.widget.inputEditor.getValue();
 			if (value) {
-				this.widget.inputEditor.setSelection({
+				this.widget.inputEditor.setSelection(selection ?? {
 					startLineNumber: 1,
 					startColumn: 1,
 					endLineNumber: 1,
@@ -291,9 +295,9 @@ class QuickChat extends Disposable {
 		widget.focusInput();
 	}
 
-	setValue(value: string): void {
+	setValue(value: string, selection?: Selection): void {
 		this.widget.inputEditor.setValue(value);
-		this.focus();
+		this.focus(selection);
 	}
 
 	private updateModel(): void {


### PR DESCRIPTION
Part of microsoft/vscode#184411

---

With this change, this keybinding:

```json
    {
        "key": "ctrl+i",
        "command": "workbench.action.quickchat.toggle",
        "args": {
            "query": "@vscode /createWorkspace ",
            "isPartialQuery": true
        }
    },
```

Opens the quick chat in this state:

![image](https://github.com/microsoft/vscode/assets/2193314/d94cc0e3-42dd-4408-aca2-95a49bdd16dd)

This also forces the toggle command to always open the quick chat when there is a query provided.