### PR TITLE
fix: invalid endCharacter value in built in PHP validation provider

### DIFF
--- a/extensions/php-language-features/src/features/validationProvider.ts
+++ b/extensions/php-language-features/src/features/validationProvider.ts
@@ -197,7 +197,7 @@ export default class PHPValidationProvider {
 					const message = matches[1];
 					const line = parseInt(matches[3]) - 1;
 					const diagnostic: vscode.Diagnostic = new vscode.Diagnostic(
-						new vscode.Range(line, 0, line, Number.MAX_VALUE),
+						new vscode.Range(line, 0, line, 2 ** 31 - 1), // See https://github.com/microsoft/vscode/issues/80288#issuecomment-650636442 for discussion
 						message
 					);
 					diagnostics.push(diagnostic);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
The build in PHP validation provider sets the Diagnostics Range endCharacter value to Number.MAX_VALUE. This ends up being translated to 1.7976931348623157e+308 in LSP communication with other LSs in the `textDocument/codeAction`request. 

There was already a discussion and a fix for related issues: https://github.com/microsoft/vscode/issues/80288#issuecomment-650636442

Some parts of the codebase use Number.MAX_SAFE_INTEGER and one uses a hardcoded max 32 bit integer value: https://github.com/microsoft/vscode/blob/c05b49710b0fff24aa4380751e02b53c54e784ce/src/vs/workbench/contrib/tasks/common/problemMatcher.ts#L450


![image](https://github.com/microsoft/vscode/assets/2456026/97ffa311-e179-4ee6-b7fd-421fe3a797b7)
