### PR TITLE
Add `trace2.configParams` value support

### DIFF
--- a/extensions/git/package.json
+++ b/extensions/git/package.json
@@ -2689,6 +2689,18 @@
           "description": "%config.timeline.showUncommitted%",
           "scope": "window"
         },
+        "git.trace2.configParamKey": {
+          "type": "string",
+          "default": "",
+          "markdownDescription": "%config.trace2.configParamKey%",
+          "scope": "window"
+        },
+        "git.trace2.configParamValue": {
+          "type": "string",
+          "default": "",
+          "description": "%config.trace2.configParamValue%",
+          "scope": "window"
+        },
         "git.showActionButton": {
           "type": "object",
           "additionalProperties": false,

--- a/extensions/git/package.nls.json
+++ b/extensions/git/package.nls.json
@@ -234,6 +234,8 @@
 	"config.terminalGitEditor": "Controls whether to enable VS Code to be the Git editor for Git processes spawned in the integrated terminal. Note: Terminals need to be restarted to pick up a change in this setting.",
 	"config.timeline.showAuthor": "Controls whether to show the commit author in the Timeline view.",
 	"config.timeline.showUncommitted": "Controls whether to show uncommitted changes in the Timeline view.",
+	"config.trace2.configParamKey": "[The Trace2 API can be used to print debug, performance, and telemetry information](https://git-scm.com/docs/api-trace2). This setting does not enable Trace2, it only sets a [trace2.configParams](https://git-scm.com/docs/git-config#Documentation/git-config.txt-trace2configParams) related value that will be used by all git commands that are invoked by Visual Studio Code.\n\n## Example:\nIf you set Config Param Key to `myprefix.trace2.hello` and Config Param Value to `world`, then all git commands will be invoked as `git -c myprefix.trace2.hello=world ...`.\n\nIf you have enabled Trace2 and ran `git config [--system|--global|--local] trace2.configParams \"myprefix.trace2.*\"` then the Trace2 output should now include `myprefix.trace2.hello=world`.",
+	"config.trace2.configParamValue": "See the description for Config Param Key.",
 	"config.timeline.date": "Controls which date to use for items in the Timeline view.",
 	"config.timeline.date.committed": "Use the committed date",
 	"config.timeline.date.authored": "Use the authored date",

--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -383,12 +383,10 @@ export class Git {
 		this.env = options.env || {};
 
 		const onConfigurationChanged = (e?: ConfigurationChangeEvent) => {
-			if (e !== undefined && !e.affectsConfiguration('git.commandsToLog')) {
-				return;
+			if (e === undefined || e.affectsConfiguration('git.commandsToLog')) {
+				const config = workspace.getConfiguration('git');
+				this.commandsToLog = config.get<string[]>('commandsToLog', []);
 			}
-
-			const config = workspace.getConfiguration('git');
-			this.commandsToLog = config.get<string[]>('commandsToLog', []);
 		};
 
 		workspace.onDidChangeConfiguration(onConfigurationChanged, this);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Add support for setting a [`trace2.configParams`](https://git-scm.com/docs/git-config#Documentation/git-config.txt-trace2configParams) related value to be used when running git commands, issue: #196179.

# Example:

Setting the *key* to `myprefix.trace2.hello` and the *value* to `world`, then all git commands will be invoked as `git -c myprefix.trace2.hello=world ...`.

If you have enabled Trace2 and have run `git config [--system|--global|--local] trace2.configParams "myprefix.trace2.*"` then the Trace2 output will include `myprefix.trace2.hello=world` for all commands run by vscode.
