### PR TITLE
Add setting to allow inline completions and suggest widget to coexist

### DIFF
--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -519,7 +519,7 @@ export interface IEditorOptions {
 	acceptSuggestionOnEnter?: 'on' | 'smart' | 'off';
 	/**
 	 * Whether inline completion and suggest widget can be shown at the same times, accepted by different keys.
-	 * Defaults to true.
+	 * Defaults to false.
 	 */
 	allowInlineCompletionCoexist?: boolean;
 	/**
@@ -5220,7 +5220,7 @@ export const EditorOptions = {
 	// inspired by this discussion: https://github.com/orgs/community/discussions/9430
 	allowInlineCompletionCoexist: register(new EditorBooleanOption(
 		EditorOption.allowInlineCompletionCoexist, 'allowInlineCompletionCoexist',
-		true,
+		false,
 		{ markdownDescription: nls.localize('allowInlineCompletionCoexist', "Controls whether inline completions and drop-down suggestions can be shown at the same time even if they don't agree. If on, tab will be used to accept the inline completion, and enter will be used to accept the suggestion.") }
 	)),
 	ariaLabel: register(new EditorStringOption(

--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -518,6 +518,11 @@ export interface IEditorOptions {
 	 */
 	acceptSuggestionOnEnter?: 'on' | 'smart' | 'off';
 	/**
+	 * Whether inline completion and suggest widget can be shown at the same times, accepted by different keys.
+	 * Defaults to true.
+	 */
+	allowInlineCompletionCoexist?: boolean;
+	/**
 	 * Accept suggestions on provider defined characters.
 	 * Defaults to true.
 	 */
@@ -5040,6 +5045,7 @@ export const enum EditorOption {
 	acceptSuggestionOnEnter,
 	accessibilitySupport,
 	accessibilityPageSize,
+	allowInlineCompletionCoexist,
 	ariaLabel,
 	ariaRequired,
 	autoClosingBrackets,
@@ -5211,6 +5217,12 @@ export const EditorOptions = {
 			description: nls.localize('accessibilityPageSize', "Controls the number of lines in the editor that can be read out by a screen reader at once. When we detect a screen reader we automatically set the default to be 500. Warning: this has a performance implication for numbers larger than the default."),
 			tags: ['accessibility']
 		})),
+	// inspired by this discussion: https://github.com/orgs/community/discussions/9430
+	allowInlineCompletionCoexist: register(new EditorBooleanOption(
+		EditorOption.allowInlineCompletionCoexist, 'allowInlineCompletionCoexist',
+		true,
+		{ markdownDescription: nls.localize('allowInlineCompletionCoexist', "Controls whether inline completions and drop-down suggestions can be shown at the same time even if they don't agree. If on, tab will be used to accept the inline completion, and enter will be used to accept the suggestion.") }
+	)),
 	ariaLabel: register(new EditorStringOption(
 		EditorOption.ariaLabel, 'ariaLabel', nls.localize('editorViewAccessibleLabel', "Editor content")
 	)),

--- a/src/vs/editor/contrib/inlineCompletions/browser/commands.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/commands.ts
@@ -148,7 +148,8 @@ export class AcceptInlineCompletion extends EditorAction {
 					InlineCompletionContextKeys.inlineSuggestionVisible,
 					EditorContextKeys.tabMovesFocus.toNegated(),
 					InlineCompletionContextKeys.inlineSuggestionHasIndentationLessThanTabSize,
-					SuggestContext.Visible.toNegated(),
+					// we do not want to disable this just because the suggest context exists, if we allow them to coexist
+					ContextKeyExpr.or(SuggestContext.Visible.toNegated(), SuggestContext.AllowInlineCompletionCoexist),
 					EditorContextKeys.hoverFocused.toNegated(),
 				),
 			}

--- a/src/vs/editor/contrib/suggest/browser/suggest.ts
+++ b/src/vs/editor/contrib/suggest/browser/suggest.ts
@@ -36,7 +36,7 @@ export const Context = {
 	MultipleSuggestions: new RawContextKey<boolean>('suggestWidgetMultipleSuggestions', false, localize('suggestWidgetMultipleSuggestions', "Whether there are multiple suggestions to pick from")),
 	MakesTextEdit: new RawContextKey<boolean>('suggestionMakesTextEdit', true, localize('suggestionMakesTextEdit', "Whether inserting the current suggestion yields in a change or has everything already been typed")),
 	AcceptSuggestionsOnEnter: new RawContextKey<boolean>('acceptSuggestionOnEnter', true, localize('acceptSuggestionOnEnter', "Whether suggestions are inserted when pressing Enter")),
-	AllowInlineCompletionCoexist: new RawContextKey<boolean>('allowInlineCompletionCoexist', true, localize('allowInlineCompletionCoexist', "Whether inline completions and suggestions are allowed to show at the same time even if they don't agree")),
+	AllowInlineCompletionCoexist: new RawContextKey<boolean>('allowInlineCompletionCoexist', false, localize('allowInlineCompletionCoexist', "Whether inline completions and suggestions are allowed to show at the same time even if they don't agree")),
 	HasInsertAndReplaceRange: new RawContextKey<boolean>('suggestionHasInsertAndReplaceRange', false, localize('suggestionHasInsertAndReplaceRange', "Whether the current suggestion has insert and replace behaviour")),
 	InsertMode: new RawContextKey<'insert' | 'replace'>('suggestionInsertMode', undefined, { type: 'string', description: localize('suggestionInsertMode', "Whether the default behaviour is to insert or replace") }),
 	CanResolve: new RawContextKey<boolean>('suggestionCanResolve', false, localize('suggestionCanResolve', "Whether the current suggestion supports to resolve further details")),

--- a/src/vs/editor/contrib/suggest/browser/suggest.ts
+++ b/src/vs/editor/contrib/suggest/browser/suggest.ts
@@ -36,6 +36,7 @@ export const Context = {
 	MultipleSuggestions: new RawContextKey<boolean>('suggestWidgetMultipleSuggestions', false, localize('suggestWidgetMultipleSuggestions', "Whether there are multiple suggestions to pick from")),
 	MakesTextEdit: new RawContextKey<boolean>('suggestionMakesTextEdit', true, localize('suggestionMakesTextEdit', "Whether inserting the current suggestion yields in a change or has everything already been typed")),
 	AcceptSuggestionsOnEnter: new RawContextKey<boolean>('acceptSuggestionOnEnter', true, localize('acceptSuggestionOnEnter', "Whether suggestions are inserted when pressing Enter")),
+	AllowInlineCompletionCoexist: new RawContextKey<boolean>('allowInlineCompletionCoexist', true, localize('allowInlineCompletionCoexist', "Whether inline completions and suggestions are allowed to show at the same time even if they don't agree")),
 	HasInsertAndReplaceRange: new RawContextKey<boolean>('suggestionHasInsertAndReplaceRange', false, localize('suggestionHasInsertAndReplaceRange', "Whether the current suggestion has insert and replace behaviour")),
 	InsertMode: new RawContextKey<'insert' | 'replace'>('suggestionInsertMode', undefined, { type: 'string', description: localize('suggestionInsertMode', "Whether the default behaviour is to insert or replace") }),
 	CanResolve: new RawContextKey<boolean>('suggestionCanResolve', false, localize('suggestionCanResolve', "Whether the current suggestion supports to resolve further details")),

--- a/src/vs/editor/contrib/suggest/browser/suggestController.ts
+++ b/src/vs/editor/contrib/suggest/browser/suggestController.ts
@@ -281,9 +281,11 @@ export class SuggestController implements IEditorContribution {
 
 		// Manage the acceptSuggestionsOnEnter context key
 		const acceptSuggestionsOnEnter = SuggestContext.AcceptSuggestionsOnEnter.bindTo(_contextKeyService);
+		const allowInlineCompletionCoexist = SuggestContext.AllowInlineCompletionCoexist.bindTo(_contextKeyService);
 		const updateFromConfig = () => {
 			const acceptSuggestionOnEnter = this.editor.getOption(EditorOption.acceptSuggestionOnEnter);
 			acceptSuggestionsOnEnter.set(acceptSuggestionOnEnter === 'on' || acceptSuggestionOnEnter === 'smart');
+			allowInlineCompletionCoexist.set(this.editor.getOption(EditorOption.allowInlineCompletionCoexist));
 		};
 		this._toDispose.add(this.editor.onDidChangeConfiguration(() => updateFromConfig()));
 		updateFromConfig();

--- a/src/vs/editor/contrib/suggest/browser/suggestModel.ts
+++ b/src/vs/editor/contrib/suggest/browser/suggestModel.ts
@@ -24,7 +24,7 @@ import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 import { ILogService } from 'vs/platform/log/common/log';
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 import { CompletionModel } from './completionModel';
-import { CompletionDurations, CompletionItem, CompletionOptions, getSnippetSuggestSupport, provideSuggestionItems, QuickSuggestionsOptions, SnippetSortOrder } from './suggest';
+import { CompletionDurations, CompletionItem, CompletionOptions, Context, getSnippetSuggestSupport, provideSuggestionItems, QuickSuggestionsOptions, SnippetSortOrder } from './suggest';
 import { IWordAtPosition } from 'vs/editor/common/core/wordHelper';
 import { ILanguageFeaturesService } from 'vs/editor/common/services/languageFeatures';
 import { FuzzyScoreOptions } from 'vs/base/common/filters';
@@ -106,6 +106,11 @@ export const enum State {
 }
 
 function canShowQuickSuggest(editor: ICodeEditor, contextKeyService: IContextKeyService, configurationService: IConfigurationService): boolean {
+	if (Boolean(contextKeyService.getContextKeyValue(Context.AllowInlineCompletionCoexist.key))) {
+		// we always allow!
+		return true;
+	}
+
 	if (!Boolean(contextKeyService.getContextKeyValue(InlineCompletionContextKeys.inlineSuggestionVisible.key))) {
 		// Allow if there is no inline suggestion.
 		return true;
@@ -118,6 +123,11 @@ function canShowQuickSuggest(editor: ICodeEditor, contextKeyService: IContextKey
 }
 
 function canShowSuggestOnTriggerCharacters(editor: ICodeEditor, contextKeyService: IContextKeyService, configurationService: IConfigurationService): boolean {
+	if (Boolean(contextKeyService.getContextKeyValue(Context.AllowInlineCompletionCoexist.key))) {
+		// we always allow!
+		return true;
+	}
+
 	if (!Boolean(contextKeyService.getContextKeyValue('inlineSuggestionVisible'))) {
 		// Allow if there is no inline suggestion.
 		return true;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Solves https://github.com/orgs/community/discussions/9430.

Adds a new setting, `allowInlineCompletionCoexist`. If off, this PR has no effect. If on:

1. Inline completions and suggest widgets can show up independently from each other, without either of them suppressing the other.
2. Inline completions are accepted by tab, and suggestions are accepted by enter.

In particular, this means that even if the suggest widget is faster than the inline completion, it won't suppress the (sometimes more correct) inline completion from showing up later. It also avoids a race condition on "tab", because now tab is always inline completion and enter is always symbolic suggestion.

Some user love for this setting:

<img width="821" alt="Screenshot 2023-10-21 at 2 29 08 PM" src="https://github.com/microsoft/vscode/assets/2716295/ebb4dd7e-a78c-4c76-a644-a5fd8a08a1b0">
