### PR TITLE
Simple Browser: replace placeholder URL with user editable defaultURL value

### DIFF
--- a/extensions/simple-browser/package.json
+++ b/extensions/simple-browser/package.json
@@ -5,7 +5,7 @@
   "enabledApiProposals": [
     "externalUriOpener"
   ],
-  "version": "1.0.0",
+  "version": "1.0.1",
   "icon": "media/icon.png",
   "publisher": "vscode",
   "license": "MIT",
@@ -51,7 +51,13 @@
             "default": true,
             "title": "Focus Lock Indicator Enabled",
             "description": "%configuration.focusLockIndicator.enabled.description%"
-          }
+          },
+					"simpleBrowser.defaultURL": {
+						"type": "string",
+						"default": "http://localhost:3000",
+						"title": "Default URL",
+						"description": "The default URL in the input field when starting Simple Browser."
+					}
         }
       }
     ]

--- a/extensions/simple-browser/package.json
+++ b/extensions/simple-browser/package.json
@@ -52,11 +52,11 @@
             "title": "Focus Lock Indicator Enabled",
             "description": "%configuration.focusLockIndicator.enabled.description%"
           },
-					"simpleBrowser.defaultURL": {
+					"simpleBrowser.default.URL": {
 						"type": "string",
 						"default": "http://localhost:3000",
 						"title": "Default URL",
-						"description": "The default URL in the input field when starting Simple Browser."
+						"description": "%configuration.default.URL.description%"
 					}
         }
       }

--- a/extensions/simple-browser/package.json
+++ b/extensions/simple-browser/package.json
@@ -52,12 +52,12 @@
             "title": "Focus Lock Indicator Enabled",
             "description": "%configuration.focusLockIndicator.enabled.description%"
           },
-					"simpleBrowser.default.URL": {
-						"type": "string",
-						"default": "http://localhost:3000",
-						"title": "Default URL",
-						"description": "%configuration.default.URL.description%"
-					}
+          "simpleBrowser.default.URL": {
+            "type": "string",
+            "default": "http://localhost:3000",
+            "title": "Default URL",
+            "description": "%configuration.default.URL.description%"
+          }
         }
       }
     ]

--- a/extensions/simple-browser/package.nls.json
+++ b/extensions/simple-browser/package.nls.json
@@ -1,5 +1,6 @@
 {
 	"displayName": "Simple Browser",
 	"description": "A very basic built-in webview for displaying web content.",
-	"configuration.focusLockIndicator.enabled.description": "Enable/disable the floating indicator that shows when focused in the simple browser."
+	"configuration.focusLockIndicator.enabled.description": "Enable/disable the floating indicator that shows when focused in the simple browser.",
+	"configuration.default.URL.description": "The default URL in the input field when starting Simple Browser."
 }

--- a/extensions/simple-browser/src/extension.ts
+++ b/extensions/simple-browser/src/extension.ts
@@ -43,9 +43,11 @@ export function activate(context: vscode.ExtensionContext) {
 	}));
 
 	context.subscriptions.push(vscode.commands.registerCommand(showCommand, async (url?: string) => {
+		const configuration = vscode.workspace.getConfiguration('simpleBrowser');
+		const defaultURL = configuration.get<string>('defaultURL', 'http://localhost:3000');
 		if (!url) {
 			url = await vscode.window.showInputBox({
-				placeHolder: vscode.l10n.t("https://example.com"),
+				value: vscode.l10n.t(defaultURL),
 				prompt: vscode.l10n.t("Enter url to visit")
 			});
 		}

--- a/extensions/simple-browser/src/extension.ts
+++ b/extensions/simple-browser/src/extension.ts
@@ -44,7 +44,7 @@ export function activate(context: vscode.ExtensionContext) {
 
 	context.subscriptions.push(vscode.commands.registerCommand(showCommand, async (url?: string) => {
 		const configuration = vscode.workspace.getConfiguration('simpleBrowser');
-		const defaultURL = configuration.get<string>('defaultURL', 'http://localhost:3000');
+		const defaultURL = configuration.get<string>('default.URL', 'http://localhost:3000');
 		if (!url) {
 			url = await vscode.window.showInputBox({
 				value: vscode.l10n.t(defaultURL),


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR replaces the placeholder URL with a user editable defaultURL value. Or that's what I thought it would do but I can't get the configuration property I added to show up in Settings. I'm very new to extension authoring and PRs in general.

It seems like `simpleBrowser.defaultURL` works if you add a URL in your settings.json and reload the window but it still says "Unknown Configuration value" which made me a bit confused. Any help is appreciated!

Anyway what this PR does right now is adds a real value with `localhost:3000` so you don't have to type all of that when running Simple Browser: Show.

fixes https://github.com/microsoft/vscode/issues/170862