### PR TITLE
Show trust editor tab icon correctly for `"window.density.editorTabHeight": "compact"` (fix #196209)

### DIFF
--- a/src/vs/workbench/contrib/workspace/browser/media/workspaceTrustEditor.css
+++ b/src/vs/workbench/contrib/workspace/browser/media/workspaceTrustEditor.css
@@ -8,7 +8,6 @@
 	content: '\eb53';
 	background-image: none;
 	font-size: 16px;
-	line-height: 37px !important;
 }
 
 .workspace-trust-editor {


### PR DESCRIPTION
This PR fixes #196209

![image](https://github.com/microsoft/vscode/assets/6726799/1b9a9090-d2d1-4c65-8cad-071e935e5389)

![image](https://github.com/microsoft/vscode/assets/6726799/5ad6f0d7-d39b-4cfd-8f4c-512906b7c471)

The `line-height: 37px !important;` removed by this PR was introduced in #152904 by @sbatten, and predated the ability to set editor tab height.