### PR TITLE
Remove redundant task system message and early return affecting FSPs (fix #192490)

### DIFF
--- a/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
+++ b/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
@@ -2387,10 +2387,6 @@ export abstract class AbstractTaskService extends Disposable implements ITaskSer
 		}
 		const taskSystemInfo: ITaskSystemInfo | undefined = this._getTaskSystemInfo(workspaceFolder.uri.scheme);
 		const problemReporter = new ProblemReporter(this._outputChannel);
-		if (!taskSystemInfo) {
-			problemReporter.fatal(nls.localize('TaskSystem.workspaceFolderError', 'Workspace folder was undefined'));
-			return true;
-		}
 		const parseResult = TaskConfig.parse(workspaceFolder, this._workspace, taskSystemInfo ? taskSystemInfo.platform : Platform.platform, config, problemReporter, source, this._contextKeyService, isRecentTask);
 		let hasErrors = false;
 		if (!parseResult.validationStatus.isOK() && (parseResult.validationStatus.state !== ValidationState.Info)) {


### PR DESCRIPTION
This PR fixes #192490

At the time #168209 fixed #164051`_computeTasksForSingleConfig` permitted `workspaceFolder` to be passed undefined. Since https://github.com/microsoft/vscode/commit/42e9acc5a8efae6150f49926221171ca8f93ad54 that is no longer the case, so I have removed what #168209 added, which in any case was incorrect as it adversely impacted FileSystemProviders (their schemas don't have dedicated task systems).