### PR TITLE
Command Center File Name No Tab Bar

### DIFF
--- a/src/vs/workbench/browser/parts/titlebar/commandCenterControl.ts
+++ b/src/vs/workbench/browser/parts/titlebar/commandCenterControl.ts
@@ -20,6 +20,7 @@ import { IInstantiationService } from 'vs/platform/instantiation/common/instanti
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 import { IQuickInputService } from 'vs/platform/quickinput/common/quickInput';
 import { WindowTitle } from 'vs/workbench/browser/parts/titlebar/windowTitle';
+import { Verbosity } from 'vs/workbench/common/editor';
 import { IEditorGroupsService } from 'vs/workbench/services/editor/common/editorGroupsService';
 
 export class CommandCenterControl {
@@ -179,7 +180,7 @@ class CommandCenterCenterViewItem extends BaseActionViewItem {
 							if (that._windowTitle.isCustomTitleFormat()) {
 								label = that._windowTitle.getWindowTitle();
 							} else if (that._editorGroupService.partOptions.showTabs === 'none') {
-								label = that._windowTitle.fileName ?? label;
+								label = that._editorGroupService.activeGroup.activeEditor?.getTitle(Verbosity.SHORT) ?? label;
 							}
 
 							if (!label) {

--- a/src/vs/workbench/browser/parts/titlebar/commandCenterControl.ts
+++ b/src/vs/workbench/browser/parts/titlebar/commandCenterControl.ts
@@ -22,6 +22,7 @@ import { IQuickInputService } from 'vs/platform/quickinput/common/quickInput';
 import { WindowTitle } from 'vs/workbench/browser/parts/titlebar/windowTitle';
 import { Verbosity } from 'vs/workbench/common/editor';
 import { IEditorGroupsService } from 'vs/workbench/services/editor/common/editorGroupsService';
+import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
 
 export class CommandCenterControl {
 
@@ -84,6 +85,7 @@ class CommandCenterCenterViewItem extends BaseActionViewItem {
 		@IKeybindingService private _keybindingService: IKeybindingService,
 		@IInstantiationService private _instaService: IInstantiationService,
 		@IEditorGroupsService private _editorGroupService: IEditorGroupsService,
+		@IEditorService private _editorService: IEditorService,
 	) {
 		super(undefined, _submenu.actions.find(action => action.id === 'workbench.action.quickOpenWithModes') ?? _submenu.actions[0], options);
 	}
@@ -179,8 +181,8 @@ class CommandCenterCenterViewItem extends BaseActionViewItem {
 							let label = that._windowTitle.workspaceName;
 							if (that._windowTitle.isCustomTitleFormat()) {
 								label = that._windowTitle.getWindowTitle();
-							} else if (that._editorGroupService.partOptions.showTabs === 'none') {
-								label = that._editorGroupService.activeGroup.activeEditor?.getTitle(Verbosity.SHORT) ?? label;
+							} else if (that._editorGroupService.partOptions.showTabs === 'none' && that._editorService.activeEditor) {
+								label = that._editorService.activeEditor.getTitle(Verbosity.SHORT);
 							}
 
 							if (!label) {

--- a/src/vs/workbench/browser/parts/titlebar/windowTitle.ts
+++ b/src/vs/workbench/browser/parts/titlebar/windowTitle.ts
@@ -47,7 +47,6 @@ export class WindowTitle extends Disposable {
 
 	get value() { return this.title ?? ''; }
 	get workspaceName() { return this.labelService.getWorkspaceLabel(this.contextService.getWorkspace()); }
-	get fileName() { return this.editorService.activeEditor?.getTitle(Verbosity.SHORT); }
 
 	private title: string | undefined;
 	private titleIncludesFocusedView: boolean = false;

--- a/src/vs/workbench/browser/parts/titlebar/windowTitle.ts
+++ b/src/vs/workbench/browser/parts/titlebar/windowTitle.ts
@@ -47,6 +47,7 @@ export class WindowTitle extends Disposable {
 
 	get value() { return this.title ?? ''; }
 	get workspaceName() { return this.labelService.getWorkspaceLabel(this.contextService.getWorkspace()); }
+	get fileName() { return this.editorService.activeEditor?.getTitle(Verbosity.SHORT); }
 
 	private title: string | undefined;
 	private titleIncludesFocusedView: boolean = false;


### PR DESCRIPTION
When `workbench.editor.showTabs: 'none'`, then the file name is displayed in the command center. The user can modify the title format to change what is displayed.