### PR TITLE
Add Tab Bar submenu to View Appearance menu

### DIFF
--- a/src/vs/workbench/browser/actions/layoutActions.ts
+++ b/src/vs/workbench/browser/actions/layoutActions.ts
@@ -548,6 +548,15 @@ export class ShowSingleEditorTabAction extends Action2 {
 }
 registerAction2(ShowSingleEditorTabAction);
 
+// --- Tab Bar Submenu in View Appearance Menu
+
+MenuRegistry.appendMenuItem(MenuId.MenubarAppearanceMenu, {
+	submenu: MenuId.EditorTabsBarShowTabsSubmenu,
+	title: localize('tabBar', "Tab Bar"),
+	group: '4_editor',
+	order: 6
+});
+
 // --- Toggle Pinned Tabs On Separate Row
 
 registerAction2(class extends Action2 {


### PR DESCRIPTION
This pull request adds a new submenu to the View Appearance menu that allows users to customize the behavior of the tab bar in the editor. The submenu includes options to show or hide tabs. This change was made in response to issue #196309.