### PR TITLE
First attempt for fixing bug submitted in #196493

### DIFF
--- a/src/vs/platform/terminal/node/terminalProfiles.ts
+++ b/src/vs/platform/terminal/node/terminalProfiles.ts
@@ -405,8 +405,9 @@ async function detectAvailableUnixProfiles(
 	const detectedProfiles: Map<string, IUnresolvedTerminalProfile> = new Map();
 
 	// Add non-quick launch profiles
-	if (includeDetectedProfiles) {
-		const contents = (await fsProvider.readFile('/etc/shells')).toString();
+	const shellsPath = '/etc/shells';
+	if (includeDetectedProfiles && await fsProvider.existsFile(shellsPath)) {
+		const contents = (await fsProvider.readFile(shellsPath)).toString();
 		const profiles = (
 			(testPaths || contents.split('\n'))
 				.map(e => {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
Trying to fix [#196493](https://github.com/microsoft/vscode/issues/196493).
I assume, this is the least invasive way of fixing the given issue: Usually profile-lookups are enabled (I backtraced calls until literal "true").
Semantically, this should result in expected behaviour: If `/etc/shells` file does not exist, any attempt of reading it, is useless.
Usually this file is readable, if available.
