### PR TITLE
Revert "don't show screen reader notification question"

### DIFF
--- a/src/vs/workbench/contrib/accessibility/browser/accessibilityStatus.ts
+++ b/src/vs/workbench/contrib/accessibility/browser/accessibilityStatus.ts
@@ -4,17 +4,24 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Disposable, MutableDisposable } from 'vs/base/common/lifecycle';
+import { Event } from 'vs/base/common/event';
+import Severity from 'vs/base/common/severity';
 import { localize } from 'vs/nls';
 import { IAccessibilityService } from 'vs/platform/accessibility/common/accessibility';
-import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
+import { CommandsRegistry } from 'vs/platform/commands/common/commands';
+import { ConfigurationTarget, IConfigurationService } from 'vs/platform/configuration/common/configuration';
+import { INotificationHandle, INotificationService, NotificationPriority } from 'vs/platform/notification/common/notification';
 import { IWorkbenchContribution } from 'vs/workbench/common/contributions';
 import { IStatusbarEntryAccessor, IStatusbarService, StatusbarAlignment } from 'vs/workbench/services/statusbar/browser/statusbar';
 
 export class AccessibilityStatus extends Disposable implements IWorkbenchContribution {
+	private screenReaderNotification: INotificationHandle | null = null;
+	private promptedScreenReader: boolean = false;
 	private readonly screenReaderModeElement = this._register(new MutableDisposable<IStatusbarEntryAccessor>());
 
 	constructor(
-		@IConfigurationService configurationService: IConfigurationService,
+		@IConfigurationService private readonly configurationService: IConfigurationService,
+		@INotificationService private readonly notificationService: INotificationService,
 		@IAccessibilityService private readonly _accessibilityService: IAccessibilityService,
 		@IStatusbarService private readonly statusbarService: IStatusbarService
 	) {
@@ -26,9 +33,33 @@ export class AccessibilityStatus extends Disposable implements IWorkbenchContrib
 				this.onScreenReaderModeChange();
 			}
 		}));
+		CommandsRegistry.registerCommand({ id: 'showEditorScreenReaderNotification', handler: () => this.showScreenReaderNotification() });
 		this.updateScreenReaderModeElement(this._accessibilityService.isScreenReaderOptimized());
 	}
 
+	private showScreenReaderNotification(): void {
+		this.screenReaderNotification = this.notificationService.prompt(
+			Severity.Info,
+			localize('screenReaderDetectedExplanation.question', "Are you using a screen reader to operate VS Code?"),
+			[{
+				label: localize('screenReaderDetectedExplanation.answerYes', "Yes"),
+				run: () => {
+					this.configurationService.updateValue('editor.accessibilitySupport', 'on', ConfigurationTarget.USER);
+				}
+			}, {
+				label: localize('screenReaderDetectedExplanation.answerNo', "No"),
+				run: () => {
+					this.configurationService.updateValue('editor.accessibilitySupport', 'off', ConfigurationTarget.USER);
+				}
+			}],
+			{
+				sticky: true,
+				priority: NotificationPriority.URGENT
+			}
+		);
+
+		Event.once(this.screenReaderNotification.onDidClose)(() => this.screenReaderNotification = null);
+	}
 	private updateScreenReaderModeElement(visible: boolean): void {
 		if (visible) {
 			if (!this.screenReaderModeElement.value) {
@@ -37,6 +68,7 @@ export class AccessibilityStatus extends Disposable implements IWorkbenchContrib
 					name: localize('status.editor.screenReaderMode', "Screen Reader Mode"),
 					text,
 					ariaLabel: text,
+					command: 'showEditorScreenReaderNotification',
 					kind: 'prominent'
 				}, 'status.editor.screenReaderMode', StatusbarAlignment.RIGHT, 100.6);
 			}
@@ -46,6 +78,22 @@ export class AccessibilityStatus extends Disposable implements IWorkbenchContrib
 	}
 
 	private onScreenReaderModeChange(): void {
+
+		// We only support text based editors
+		const screenReaderDetected = this._accessibilityService.isScreenReaderOptimized();
+		if (screenReaderDetected) {
+			const screenReaderConfiguration = this.configurationService.getValue('editor.accessibilitySupport');
+			if (screenReaderConfiguration === 'auto') {
+				if (!this.promptedScreenReader) {
+					this.promptedScreenReader = true;
+					setTimeout(() => this.showScreenReaderNotification(), 100);
+				}
+			}
+		}
+
+		if (this.screenReaderNotification) {
+			this.screenReaderNotification.close();
+		}
 		this.updateScreenReaderModeElement(this._accessibilityService.isScreenReaderOptimized());
 	}
 }


### PR DESCRIPTION
Reverts microsoft/vscode#194671

Fixes #196505, #196370

I don't know why this caused issues, thus just reverting as that's the safest thing to do and this change wasn't necessary.