### PR TITLE
Calling `_onEnablementOrModelChanged`inside of the constructor

### DIFF
--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatDecorations.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatDecorations.ts
@@ -60,6 +60,7 @@ export class InlineChatDecorationsContribution extends Disposable implements IEd
 		}));
 		this._register(this._inlineChatService.onDidChangeProviders(() => this._onEnablementOrModelChanged()));
 		this._register(this._editor.onDidChangeModel(() => this._onEnablementOrModelChanged()));
+		this._onEnablementOrModelChanged();
 	}
 
 	private _onEnablementOrModelChanged(): void {


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/196484
Fixes https://github.com/microsoft/vscode/issues/196486
Fixes https://github.com/microsoft/vscode/issues/196503

This error happens because we do not call the method `_onEnablementOrModelChangedinside` from the constructor