### PR TITLE
polish rootFolderNames

### DIFF
--- a/src/vs/workbench/services/themes/browser/fileIconThemeData.ts
+++ b/src/vs/workbench/services/themes/browser/fileIconThemeData.ts
@@ -314,14 +314,16 @@ export class FileIconThemeLoader {
 				const rootFolderNames = associations.rootFolderNames;
 				if (rootFolderNames) {
 					for (const key in rootFolderNames) {
-						addSelector(`${qualifier} .${escapeCSS(key)}-root-name-folder-icon.rootfolder-icon::before`, rootFolderNames[key]);
+						const name = key.toLowerCase();
+						addSelector(`${qualifier} .${escapeCSS(name)}-root-name-folder-icon.rootfolder-icon::before`, rootFolderNames[key]);
 						result.hasFolderIcons = true;
 					}
 				}
 				const rootFolderNamesExpanded = associations.rootFolderNamesExpanded;
 				if (rootFolderNamesExpanded) {
 					for (const key in rootFolderNamesExpanded) {
-						addSelector(`${qualifier} ${expanded} .${escapeCSS(key)}-root-name-folder-icon.rootfolder-icon::before`, rootFolderNamesExpanded[key]);
+						const name = key.toLowerCase();
+						addSelector(`${qualifier} ${expanded} .${escapeCSS(name)}-root-name-folder-icon.rootfolder-icon::before`, rootFolderNamesExpanded[key]);
 						result.hasFolderIcons = true;
 					}
 				}

--- a/src/vs/workbench/services/themes/common/fileIconThemeSchema.ts
+++ b/src/vs/workbench/services/themes/common/fileIconThemeSchema.ts
@@ -114,6 +114,18 @@ const schema: IJSONSchema = {
 				folderNamesExpanded: {
 					$ref: '#/definitions/folderNamesExpanded'
 				},
+				rootFolder: {
+					$ref: '#/definitions/rootFolder'
+				},
+				rootFolderExpanded: {
+					$ref: '#/definitions/rootFolderExpanded'
+				},
+				rootFolderNames: {
+					$ref: '#/definitions/rootFolderNames'
+				},
+				rootFolderNamesExpanded: {
+					$ref: '#/definitions/rootFolderNamesExpanded'
+				},
 				fileExtensions: {
 					$ref: '#/definitions/fileExtensions'
 				},

--- a/src/vs/workbench/services/themes/common/fileIconThemeSchema.ts
+++ b/src/vs/workbench/services/themes/common/fileIconThemeSchema.ts
@@ -39,7 +39,7 @@ const schema: IJSONSchema = {
 		},
 		rootFolderNames: {
 			type: 'object',
-			description: nls.localize('schema.rootFolderNames', 'Associates root folder names to icons. The object key is the root folder name, not including any path segments. No patterns or wildcards are allowed. Root folder name matching is case insensitive.'),
+			description: nls.localize('schema.rootFolderNames', 'Associates root folder names to icons. The object key is the root folder name. No patterns or wildcards are allowed. Root folder name matching is case insensitive.'),
 			additionalProperties: {
 				type: 'string',
 				description: nls.localize('schema.folderName', 'The ID of the icon definition for the association.')

--- a/src/vs/workbench/services/themes/common/fileIconThemeSchema.ts
+++ b/src/vs/workbench/services/themes/common/fileIconThemeSchema.ts
@@ -29,6 +29,14 @@ const schema: IJSONSchema = {
 			description: nls.localize('schema.file', 'The default file icon, shown for all files that don\'t match any extension, filename or language id.')
 
 		},
+		rootFolder: {
+			type: 'string',
+			description: nls.localize('schema.rootFolder', 'The folder icon for collapsed root folders, and if rootFolderExpanded is not set, also for expanded root folders.')
+		},
+		rootFolderExpanded: {
+			type: 'string',
+			description: nls.localize('schema.rootFolderExpanded', 'The folder icon for expanded root folders. The expanded root folder icon is optional. If not set, the icon defined for root folder will be shown.')
+		},
 		rootFolderNames: {
 			type: 'object',
 			description: nls.localize('schema.rootFolderNames', 'Associates root folder names to icons. The object key is the root folder name, not including any path segments. No patterns or wildcards are allowed. Root folder name matching is case insensitive.'),
@@ -221,6 +229,12 @@ const schema: IJSONSchema = {
 		},
 		folderNamesExpanded: {
 			$ref: '#/definitions/folderNamesExpanded'
+		},
+		rootFolder: {
+			$ref: '#/definitions/rootFolder'
+		},
+		rootFolderExpanded: {
+			$ref: '#/definitions/rootFolderExpanded'
 		},
 		rootFolderNames: {
 			$ref: '#/definitions/rootFolderNames'

--- a/src/vs/workbench/services/themes/common/fileIconThemeSchema.ts
+++ b/src/vs/workbench/services/themes/common/fileIconThemeSchema.ts
@@ -31,7 +31,7 @@ const schema: IJSONSchema = {
 		},
 		rootFolderNames: {
 			type: 'object',
-			description: nls.localize('schema.rootFolderNames', 'Associates root folder names to icons. The object key is the folder name, not including any path segments. No patterns or wildcards are allowed. Folder name matching is case insensitive.'),
+			description: nls.localize('schema.rootFolderNames', 'Associates root folder names to icons. The object key is the root folder name, not including any path segments. No patterns or wildcards are allowed. Root folder name matching is case insensitive.'),
 			additionalProperties: {
 				type: 'string',
 				description: nls.localize('schema.folderName', 'The ID of the icon definition for the association.')
@@ -39,10 +39,10 @@ const schema: IJSONSchema = {
 		},
 		rootFolderNamesExpanded: {
 			type: 'object',
-			description: nls.localize('schema.rootFolderNamesExpanded', 'Associates root folder names to icons for expanded folders. The object key is the folder name, not including any path segments. No patterns or wildcards are allowed. Folder name matching is case insensitive.'),
+			description: nls.localize('schema.rootFolderNamesExpanded', 'Associates root folder names to icons for expanded root folders. The object key is the root folder name. No patterns or wildcards are allowed. Root folder name matching is case insensitive.'),
 			additionalProperties: {
 				type: 'string',
-				description: nls.localize('schema.folderNameExpanded', 'The ID of the icon definition for the association.')
+				description: nls.localize('schema.rootFolderNameExpanded', 'The ID of the icon definition for the association.')
 			}
 		},
 		folderNames: {
@@ -221,6 +221,12 @@ const schema: IJSONSchema = {
 		},
 		folderNamesExpanded: {
 			$ref: '#/definitions/folderNamesExpanded'
+		},
+		rootFolderNames: {
+			$ref: '#/definitions/rootFolderNames'
+		},
+		rootFolderNamesExpanded: {
+			$ref: '#/definitions/rootFolderNamesExpanded'
 		},
 		fileExtensions: {
 			$ref: '#/definitions/fileExtensions'


### PR DESCRIPTION
Polish and fixes icon scheme schema.
Icon themes names are case insensitive for all other properties. Change it for rootFolderNames as well.