### PR TITLE
Centre numbers vertically in top activity bar badges (fix #196691)

### DIFF
--- a/src/vs/workbench/browser/parts/media/paneCompositePart.css
+++ b/src/vs/workbench/browser/parts/media/paneCompositePart.css
@@ -172,13 +172,13 @@
 
 .monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon .badge.compact .badge-content {
 	position: absolute;
-	top: 12px;
+	top: 11px;
 	right: 0px;
 	font-size: 9px;
 	font-weight: 600;
 	min-width: 12px;
-	height: 12px;
-	line-height: 12px;
+	height: 13px;
+	line-height: 13px;
 	padding: 0 2px;
 	border-radius: 16px;
 	text-align: center;


### PR DESCRIPTION
This PR fixes #196691