### PR TITLE
Update tab bar group and order in layoutActions.ts

### DIFF
--- a/src/vs/workbench/browser/actions/layoutActions.ts
+++ b/src/vs/workbench/browser/actions/layoutActions.ts
@@ -553,8 +553,8 @@ registerAction2(ShowSingleEditorTabAction);
 MenuRegistry.appendMenuItem(MenuId.MenubarAppearanceMenu, {
 	submenu: MenuId.EditorTabsBarShowTabsSubmenu,
 	title: localize('tabBar', "Tab Bar"),
-	group: '4_editor',
-	order: 6
+	group: '3_workbench_layout_move',
+	order: 10
 });
 
 // --- Toggle Pinned Tabs On Separate Row


### PR DESCRIPTION
This pull request updates the group and order of the tab bar in layoutActions.ts to better align with the overall layout of the workbench. Specifically, the group has been changed to '3_workbench_layout_move' and the order has been changed to 10. 

#196635