### PR TITLE
Correct the #196696 fix which caused oval badges

### DIFF
--- a/src/vs/workbench/browser/parts/media/paneCompositePart.css
+++ b/src/vs/workbench/browser/parts/media/paneCompositePart.css
@@ -176,7 +176,7 @@
 	right: 0px;
 	font-size: 9px;
 	font-weight: 600;
-	min-width: 12px;
+	min-width: 13px;
 	height: 13px;
 	line-height: 13px;
 	padding: 0 2px;


### PR DESCRIPTION
@sandy081 this contains a CSS tweak I missed from #196696, without which the badges became oval.