### PR TITLE
Upsize progress badge on top activity bar to match #196696 change

### DIFF
--- a/src/vs/workbench/browser/parts/media/paneCompositePart.css
+++ b/src/vs/workbench/browser/parts/media/paneCompositePart.css
@@ -185,9 +185,10 @@
 }
 
 .monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon .badge.compact.progress-badge .badge-content::before {
-	mask-size: 13px;
-	-webkit-mask-size: 13px;
-	top: 2px;
+	mask-size: 11px;
+	-webkit-mask-size: 11px;
+	top: 3px;
+	left: 1px;
 }
 
 /* active item indicator */

--- a/src/vs/workbench/browser/parts/media/paneCompositePart.css
+++ b/src/vs/workbench/browser/parts/media/paneCompositePart.css
@@ -185,8 +185,8 @@
 }
 
 .monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon .badge.compact.progress-badge .badge-content::before {
-	mask-size: 12px;
-	-webkit-mask-size: 12px;
+	mask-size: 13px;
+	-webkit-mask-size: 13px;
 	top: 2px;
 }
 


### PR DESCRIPTION
Makes a progress badge on an already-badged top activity bar icon completely overlay the existing badge, whose size increased in #196696
