### PR TITLE
Aux window: Alt+f4 closes the workspace instead of the aux window (fix #196239)

### DIFF
--- a/src/vs/workbench/electron-sandbox/actions/windowActions.ts
+++ b/src/vs/workbench/electron-sandbox/actions/windowActions.ts
@@ -62,6 +62,11 @@ export class CloseWindowAction extends Action2 {
 	override async run(accessor: ServicesAccessor): Promise<void> {
 		const nativeHostService = accessor.get(INativeHostService);
 
+		const window = getActiveWindow();
+		if (isAuxiliaryWindow(window)) {
+			return nativeHostService.closeWindowById(await window.vscodeWindowId);
+		}
+
 		return nativeHostService.closeWindow();
 	}
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
