### PR TITLE
Improve styling of terminal dev mode text box

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/media/terminal.css
+++ b/src/vs/workbench/contrib/terminal/browser/media/terminal.css
@@ -53,14 +53,26 @@
 	outline: 0 !important;
 }
 
-.xterm.dev-mode .xterm-helper-textarea {
+.monaco-workbench .xterm.dev-mode .xterm-helper-textarea {
 	z-index: 36 !important;
-	opacity: 1 !important;
-	left: 0 !important;
-	width: fit-content !important;
+	opacity: 0.8 !important;
+	right: 0 !important;
+	left: initial !important;
+	width: 50% !important;
+	background-color: var(--vscode-terminal-background, var(--vscode-panel-background));
+	color: var(--vscode-terminal-foreground);
+	transform: translateY(-100%);
 }
 .monaco-workbench .xterm.dev-mode .xterm-helper-textarea:focus {
-	opacity: 1 !important;
+	opacity: 0.8 !important;
+}
+.monaco-workbench .xterm.dev-mode .xterm-helpers {
+	/* This could maybe be done outside of .dev-mode, but I'm scared to break something */
+	left: 0;
+	right: 0;
+}
+.monaco-workbench .xterm.dev-mode .xterm-helper-textarea:hover {
+	opacity: 0.25 !important;
 }
 
 .monaco-workbench .xterm .xterm-helper-textarea:focus {


### PR DESCRIPTION
Fixes #196757

![image](https://github.com/microsoft/vscode/assets/2193314/d182bde8-e89c-4132-922e-78836ea65b30)

On hover:

![image](https://github.com/microsoft/vscode/assets/2193314/704cca11-c3d8-4e71-b9d4-285dd86de397)
