### PR TITLE
Show Dynamic Configuration Providers with No Context (file opened)

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/debugAdapterManager.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugAdapterManager.ts
@@ -341,9 +341,10 @@ export class AdapterManager extends Disposable implements IAdapterManager {
 		// Or if a breakpoint can be set in the current file (good hint that an extension can handle it)
 		if ((!languageLabel || gettingConfigurations || (model && this.canSetBreakpointsIn(model))) && candidates.length === 0) {
 			await this.activateDebuggers('onDebugInitialConfigurations');
+
 			candidates = this.debuggers
 				.filter(a => a.enabled)
-				.filter(dbg => dbg.hasInitialConfiguration() || dbg.hasConfigurationProvider());
+				.filter(dbg => dbg.hasInitialConfiguration() || dbg.hasDynamicConfigurationProviders() || dbg.hasConfigurationProvider());
 		}
 
 		if (candidates.length === 0 && languageLabel) {

--- a/src/vs/workbench/contrib/debug/common/debug.ts
+++ b/src/vs/workbench/contrib/debug/common/debug.ts
@@ -904,7 +904,7 @@ export interface IConfigurationManager {
 	 */
 	onDidSelectConfiguration: Event<void>;
 
-	hasDebugConfigurationProvider(debugType: string): boolean;
+	hasDebugConfigurationProvider(debugType: string, triggerKind?: DebugConfigurationProviderTriggerKind): boolean;
 	getDynamicProviders(): Promise<{ label: string; type: string; pick: () => Promise<{ launch: ILaunch; config: IConfig } | undefined> }[]>;
 
 	registerDebugConfigurationProvider(debugConfigurationProvider: IDebugConfigurationProvider): IDisposable;

--- a/src/vs/workbench/contrib/debug/common/debugger.ts
+++ b/src/vs/workbench/contrib/debug/common/debugger.ts
@@ -7,7 +7,7 @@ import * as nls from 'vs/nls';
 import { isObject } from 'vs/base/common/types';
 import { IJSONSchema, IJSONSchemaMap, IJSONSchemaSnippet } from 'vs/base/common/jsonSchema';
 import { IWorkspaceFolder } from 'vs/platform/workspace/common/workspace';
-import { IConfig, IDebuggerContribution, IDebugAdapter, IDebugger, IDebugSession, IAdapterManager, IDebugService, debuggerDisabledMessage, IDebuggerMetadata } from 'vs/workbench/contrib/debug/common/debug';
+import { IConfig, IDebuggerContribution, IDebugAdapter, IDebugger, IDebugSession, IAdapterManager, IDebugService, debuggerDisabledMessage, IDebuggerMetadata, DebugConfigurationProviderTriggerKind } from 'vs/workbench/contrib/debug/common/debug';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { IConfigurationResolverService } from 'vs/workbench/services/configurationResolver/common/configurationResolver';
 import * as ConfigurationResolverUtils from 'vs/workbench/services/configurationResolver/common/configurationResolverUtils';
@@ -174,6 +174,10 @@ export class Debugger implements IDebugger, IDebuggerMetadata {
 
 	hasInitialConfiguration(): boolean {
 		return !!this.debuggerContribution.initialConfigurations;
+	}
+
+	hasDynamicConfigurationProviders(): boolean {
+		return this.debugService.getConfigurationManager().hasDebugConfigurationProvider(this.type, DebugConfigurationProviderTriggerKind.Dynamic);
 	}
 
 	hasConfigurationProvider(): boolean {


### PR DESCRIPTION
This PR adds support to show dynamic configurations when a file is not selected.

The changes introduces a new method to the Debugger class called `hasDynamicConfigurationProviders`. It utilizes the existing `ConfigurationManager.hasDebugConfigurationProvider` but passing `Dynamic TiggerKind` instead of Initial.

Fixes: https://github.com/microsoft/vscode/issues/193828

Start Debugging before changes:
![image](https://github.com/microsoft/vscode/assets/3953714/249bd231-4b6b-4192-a944-c49443aa7d63)

Start Debugging after changes:
![image](https://github.com/microsoft/vscode/assets/3953714/433ef8d3-5bce-46cc-878b-99ff6de2f70b)

Note: For the images above, only C# Extension and C# Dev Kit Extensions are installed. 
