### PR TITLE
Do heuristic syntax highlighting immediately when showing diff editor

### DIFF
--- a/src/vs/editor/browser/editorBrowser.ts
+++ b/src/vs/editor/browser/editorBrowser.ts
@@ -1276,6 +1276,8 @@ export interface IDiffEditor extends editorCommon.IEditor {
 	accessibleDiffViewerNext(): void;
 
 	accessibleDiffViewerPrev(): void;
+
+	handleInitialized(): void;
 }
 
 /**

--- a/src/vs/editor/browser/widget/diffEditor/diffEditorWidget.ts
+++ b/src/vs/editor/browser/widget/diffEditor/diffEditorWidget.ts
@@ -373,6 +373,11 @@ export class DiffEditorWidget extends DelegatingEditor implements IDiffEditor {
 		}
 	}
 
+	public handleInitialized(): void {
+		this._editors.original.handleInitialized();
+		this._editors.modified.handleInitialized();
+	}
+
 	public createViewModel(model: IDiffEditorModel): IDiffEditorViewModel {
 		return this._instantiationService.createInstance(DiffEditorViewModel, model, this._options, this);
 	}

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -5991,6 +5991,7 @@ declare namespace monaco.editor {
 		updateOptions(newOptions: IDiffEditorOptions): void;
 		accessibleDiffViewerNext(): void;
 		accessibleDiffViewerPrev(): void;
+		handleInitialized(): void;
 	}
 
 	export class FontInfo extends BareFontInfo {

--- a/src/vs/workbench/browser/parts/editor/textDiffEditor.ts
+++ b/src/vs/workbench/browser/parts/editor/textDiffEditor.ts
@@ -147,6 +147,8 @@ export class TextDiffEditor extends AbstractTextEditor<IDiffEditorViewState> imp
 				originalEditable: !resolvedDiffEditorModel.originalModel?.isReadonly()
 			});
 
+			control.handleInitialized();
+
 			// Start to measure input lifecycle
 			this.inputLifecycleStopWatch = new StopWatch(false);
 		} catch (error) {


### PR DESCRIPTION
Before:
![wqGylLJ7cB](https://github.com/microsoft/vscode/assets/2931520/cdbfbfe9-74b1-4167-a48b-cdac3d012a6f)


After:
![PF9GsQE40E](https://github.com/microsoft/vscode/assets/2931520/3aad58bc-6254-4f89-a042-766350277b4d)
