### PR TITLE
- only update/reposition inline widget when showing again

### DIFF
--- a/src/vs/editor/common/viewModel/viewModelImpl.ts
+++ b/src/vs/editor/common/viewModel/viewModelImpl.ts
@@ -491,7 +491,12 @@ export class ViewModel extends Disposable implements IViewModel {
 				this.viewLayout.onFlushed(this.getLineCount());
 				this.viewLayout.onHeightMaybeChanged();
 			}
-			stableViewport.recoverViewportStart(this.coordinatesConverter, this.viewLayout);
+
+			const firstModelLineInViewPort = stableViewport.viewportStartModelPosition?.lineNumber;
+			const firstModelLineIsHidden = firstModelLineInViewPort && mergedRanges.some(range => range.startLineNumber <= firstModelLineInViewPort && firstModelLineInViewPort <= range.endLineNumber);
+			if (!firstModelLineIsHidden) {
+				stableViewport.recoverViewportStart(this.coordinatesConverter, this.viewLayout);
+			}
 		} finally {
 			this._eventDispatcher.endEmitViewEvents();
 		}

--- a/src/vs/editor/contrib/zoneWidget/browser/zoneWidget.ts
+++ b/src/vs/editor/contrib/zoneWidget/browser/zoneWidget.ts
@@ -321,6 +321,19 @@ export abstract class ZoneWidget implements IHorizontalSashLayoutProvider {
 		this._positionMarkerId.set([{ range, options: ModelDecorationOptions.EMPTY }]);
 	}
 
+	updatePositionAndHeight(rangeOrPos: IRange | IPosition, heightInLines?: number): void {
+		if (this._viewZone) {
+			rangeOrPos = Range.isIRange(rangeOrPos) ? Range.getStartPosition(rangeOrPos) : rangeOrPos;
+			this._viewZone.afterLineNumber = rangeOrPos.lineNumber;
+			this._viewZone.afterColumn = rangeOrPos.column;
+			this._viewZone.heightInLines = heightInLines ?? this._viewZone.heightInLines;
+
+			this.editor.changeViewZones(accessor => {
+				accessor.layoutZone(this._viewZone!.id);
+			});
+		}
+	}
+
 	hide(): void {
 		if (this._viewZone) {
 			this.editor.changeViewZones(accessor => {

--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatController.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatController.ts
@@ -273,8 +273,12 @@ export class InlineChatController implements IEditorContribution {
 		if (this._strategy) {
 			needsMargin = this._strategy.needsMargin();
 		}
-		this._zone.value.setWidgetMargins(widgetPosition, !needsMargin ? 0 : undefined);
-		this._zone.value.show(widgetPosition);
+		if (!this._zone.value.position) {
+			this._zone.value.setWidgetMargins(widgetPosition, !needsMargin ? 0 : undefined);
+			this._zone.value.show(widgetPosition);
+		} else {
+			this._zone.value.updatePositionAndHeight(widgetPosition);
+		}
 	}
 
 	protected async _nextState(state: State, options: InlineChatRunOptions): Promise<void> {

--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatLivePreviewWidget.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatLivePreviewWidget.ts
@@ -21,7 +21,7 @@ import { LineRange } from 'vs/editor/common/core/lineRange';
 import { LineRangeMapping } from 'vs/editor/common/diff/rangeMapping';
 import { Position } from 'vs/editor/common/core/position';
 import { EditorExtensionsRegistry } from 'vs/editor/browser/editorExtensions';
-import { IEditorDecorationsCollection, ScrollType } from 'vs/editor/common/editorCommon';
+import { IEditorDecorationsCollection } from 'vs/editor/common/editorCommon';
 import { ILogService } from 'vs/platform/log/common/log';
 import { lineRangeAsRange, invertLineRange } from 'vs/workbench/contrib/inlineChat/browser/utils';
 import { ResourceLabel } from 'vs/workbench/browser/labels';
@@ -57,7 +57,7 @@ export class InlineChatLivePreviewWidget extends ZoneWidget {
 		@ILogService private readonly _logService: ILogService,
 		@IAccessibilityService private readonly accessibilityService: IAccessibilityService,
 	) {
-		super(editor, { showArrow: false, showFrame: false, isResizeable: false, isAccessible: true, allowUnlimitedHeight: true, showInHiddenAreas: true, ordinal: 10000 + 1 });
+		super(editor, { showArrow: false, showFrame: false, isResizeable: false, isAccessible: true, allowUnlimitedHeight: true, showInHiddenAreas: true, keepEditorSelection: true, ordinal: 10000 + 1 });
 		super.create();
 		assertType(editor.hasModel());
 
@@ -203,7 +203,7 @@ export class InlineChatLivePreviewWidget extends ZoneWidget {
 		this._hideEditorRanges(this._diffEditor.getOriginalEditor(), ranges.originalDiffHidden);
 		this._hideEditorRanges(this._diffEditor.getModifiedEditor(), ranges.modifiedDiffHidden);
 
-		this._diffEditor.revealLine(ranges.modifiedHidden.startLineNumber, ScrollType.Immediate);
+		// this._diffEditor.revealLine(ranges.modifiedHidden.startLineNumber, ScrollType.Immediate);
 
 		const lineCountModified = ranges.modifiedHidden.length;
 		const lineCountOriginal = ranges.originalHidden.length;


### PR DESCRIPTION
- when hiding the first view port line, don't restore previous view port

again fixes https://github.com/microsoft/vscode-copilot/issues/2288