### PR TITLE
Separate Settings editor open and search steps

### DIFF
--- a/test/automation/src/settings.ts
+++ b/test/automation/src/settings.ts
@@ -61,8 +61,6 @@ export class SettingsEditor {
 	}
 
 	async searchSettingsUI(query: string): Promise<void> {
-		await this.openUserSettingsUI();
-
 		await this.code.waitAndClick(SEARCH_BOX);
 		if (process.platform === 'darwin') {
 			await this.code.dispatchKeybinding('cmd+a');

--- a/test/smoke/src/areas/preferences/preferences.test.ts
+++ b/test/smoke/src/areas/preferences/preferences.test.ts
@@ -42,6 +42,7 @@ export function setup(logger: Logger) {
 		it('shows a modified indicator on a modified setting', async function () {
 			const app = this.app as Application;
 
+			await app.workbench.settingsEditor.openUserSettingsUI();
 			await app.workbench.settingsEditor.searchSettingsUI('@id:editor.tabSize');
 			await app.code.waitForSetValue('.settings-editor .setting-item-contents .setting-item-control input', '6');
 			await app.code.waitForElement('.settings-editor .setting-item-contents .setting-item-modified-indicator');
@@ -56,6 +57,7 @@ export function setup(logger: Logger) {
 			await app.code.waitForElements('.line-numbers', false, elements => !!elements.length);
 
 			// Turn off line numbers
+			await app.workbench.settingsEditor.openUserSettingsUI();
 			await app.workbench.settingsEditor.searchSettingsUI('editor.lineNumbers');
 			await app.code.waitAndClick('.settings-editor .monaco-list-rows .setting-item-control select', 2, 2);
 			await app.code.waitAndClick('.context-view .option-text', 2, 2);
@@ -64,9 +66,10 @@ export function setup(logger: Logger) {
 			await app.code.waitForElements('.line-numbers', false, elements => !elements || elements.length === 0);
 		});
 
-		// Skipping test due to it being flaky.
-		it.skip('hides the toc when searching depending on the search behavior', async function () {
+		it('hides the toc when searching depending on the search behavior', async function () {
 			const app = this.app as Application;
+
+			await app.workbench.settingsEditor.openUserSettingsUI();
 
 			// Hide ToC when searching
 			await app.workbench.settingsEditor.searchSettingsUI('workbench.settings.settingsSearchTocBehavior');


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

I noticed some Settings editor smoke tests always pulling up the Command palette, so this change should speed up those smoke tests just a bit, and hopefully make them less flaky.
