### PR TITLE
Switch back to `node` as default for `moduleResolution`

### DIFF
--- a/extensions/typescript-language-features/src/tsconfig.ts
+++ b/extensions/typescript-language-features/src/tsconfig.ts
@@ -27,7 +27,7 @@ export function inferredProjectCompilerOptions(
 ): Proto.ExternalProjectCompilerOptions {
 	const projectConfig: Proto.ExternalProjectCompilerOptions = {
 		module: 'ESNext' as Proto.ModuleKind,
-		moduleResolution: (version.gte(API.v500) ? 'Bundler' : 'Node') as Proto.ModuleResolutionKind,
+		moduleResolution: 'Node' as Proto.ModuleResolutionKind,
 		target: 'ES2022' as Proto.ScriptTarget,
 		jsx: 'react' as Proto.JsxEmit,
 	};


### PR DESCRIPTION
Fixes #196554

Looks like bundler breaks `require()` intellisense. Reverts part of 6ebac1703b67db1b688fac0ce762264d622d8398

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
