### PR TITLE
Add sticky hover option to HoverService

### DIFF
--- a/src/vs/workbench/services/hover/browser/hover.ts
+++ b/src/vs/workbench/services/hover/browser/hover.ts
@@ -156,6 +156,11 @@ export interface IHoverOptions {
 	 * element's container hiding on `focusout`.
 	 */
 	container?: HTMLElement;
+
+	/**
+	 * Whether to make the hover sticky, this means it will not be hidden when the mouse leaves the hover.
+	 */
+	sticky?: boolean;
 }
 
 export interface IHoverAction {

--- a/src/vs/workbench/services/userDataProfile/browser/userDataProfileImportExportService.ts
+++ b/src/vs/workbench/services/userDataProfile/browser/userDataProfileImportExportService.ts
@@ -389,7 +389,7 @@ export class UserDataProfileImportExportService extends Disposable implements IU
 				target: profileIconElement,
 				hoverPosition: HoverPosition.BELOW,
 				showPointer: true,
-				hideOnHover: false,
+				sticky: true,
 			}, true);
 			if (hoverWidget) {
 				iconSelectBox.layout(dimension);


### PR DESCRIPTION
This PR adds a new `sticky` option to the `IHoverOptions` interface and the `HoverService` class, allowing hovers to remain visible even when the mouse leaves the hover. This is useful for cases where users need to interact with the hover content.

Fixes https://github.com/microsoft/vscode/issues/194094