### PR TITLE
Allow breadcrumbs with no tab bar

### DIFF
--- a/src/vs/workbench/browser/parts/editor/editorTitleControl.ts
+++ b/src/vs/workbench/browser/parts/editor/editorTitleControl.ts
@@ -77,7 +77,7 @@ export class EditorTitleControl extends Themable {
 	}
 
 	private createBreadcrumbsControl(): BreadcrumbsControlFactory | undefined {
-		if (this.groupsView.partOptions.showTabs !== 'multiple') {
+		if (this.groupsView.partOptions.showTabs === 'single') {
 			return undefined; // Single tabs have breadcrumbs inlined. No tabs have no breadcrumbs.
 		}
 
@@ -175,7 +175,7 @@ export class EditorTitleControl extends Themable {
 		// Update editor tabs control if options changed
 		if (
 			oldOptions.showTabs !== newOptions.showTabs ||
-			(newOptions.showTabs === 'multiple' && oldOptions.pinnedTabsOnSeparateRow !== newOptions.pinnedTabsOnSeparateRow)
+			(newOptions.showTabs !== 'single' && oldOptions.pinnedTabsOnSeparateRow !== newOptions.pinnedTabsOnSeparateRow)
 		) {
 			// Clear old
 			this.editorTabsControlDisposable.clear();

--- a/src/vs/workbench/browser/parts/editor/noEditorTabsControl.ts
+++ b/src/vs/workbench/browser/parts/editor/noEditorTabsControl.ts
@@ -10,6 +10,7 @@ import { Dimension } from 'vs/base/browser/dom';
 import { IEditorTitleControlDimensions } from 'vs/workbench/browser/parts/editor/editorTitleControl';
 
 export class NoEditorTabsControl extends EditorTabsControl {
+	private activeEditor: EditorInput | null = null;
 
 	protected prepareEditorActions(editorActions: IToolbarActions): IToolbarActions {
 		return {
@@ -19,10 +20,27 @@ export class NoEditorTabsControl extends EditorTabsControl {
 	}
 
 	openEditor(editor: EditorInput): boolean {
-		return false;
+		return this.handleOpenedEditors();
 	}
 
 	openEditors(editors: EditorInput[]): boolean {
+		return this.handleOpenedEditors();
+	}
+
+	private handleOpenedEditors(): boolean {
+		const didChange = this.activeEditorChanged();
+		this.activeEditor = this.tabsModel.activeEditor;
+		return didChange;
+	}
+
+	private activeEditorChanged(): boolean {
+		if (
+			!this.activeEditor && this.tabsModel.activeEditor || 				// active editor changed from null => editor
+			this.activeEditor && !this.tabsModel.activeEditor || 				// active editor changed from editor => null
+			(!this.activeEditor || !this.tabsModel.isActive(this.activeEditor))	// active editor changed from editorA => editorB
+		) {
+			return true;
+		}
 		return false;
 	}
 


### PR DESCRIPTION
This pull request updates the behavior of the `EditorTitleControl` class to allow breadcrumbs to be displayed even when there is no tab bar. Additionally, the `NoEditorTabsControl` class has been updated to handle opened editors correctly.

#196695 