### PR TITLE
Support debug tool bar float on custom title bar

### DIFF
--- a/src/vs/workbench/browser/layout.ts
+++ b/src/vs/workbench/browser/layout.ts
@@ -1185,7 +1185,7 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 		}
 
 		// with the command center enabled, we should always show
-		if (this.configurationService.getValue<boolean>('window.commandCenter')) {
+		if (this.configurationService.getValue<boolean>(LayoutSettings.COMMAND_CENTER)) {
 			return true;
 		}
 

--- a/src/vs/workbench/browser/parts/titlebar/titlebarPart.ts
+++ b/src/vs/workbench/browser/parts/titlebar/titlebarPart.ts
@@ -24,7 +24,7 @@ import { CustomMenubarControl } from 'vs/workbench/browser/parts/titlebar/menuba
 import { IInstantiationService, ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
 import { Emitter, Event } from 'vs/base/common/event';
 import { IStorageService } from 'vs/platform/storage/common/storage';
-import { Parts, IWorkbenchLayoutService } from 'vs/workbench/services/layout/browser/layoutService';
+import { Parts, IWorkbenchLayoutService, LayoutSettings } from 'vs/workbench/services/layout/browser/layoutService';
 import { createActionViewItem } from 'vs/platform/actions/browser/menuEntryActionViewItem';
 import { Action2, MenuId, registerAction2 } from 'vs/platform/actions/common/actions';
 import { ContextKeyExpr, IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
@@ -42,8 +42,6 @@ import { SimpleAccountActivityActionViewItem, SimpleGlobalActivityActionViewItem
 import { HoverPosition } from 'vs/base/browser/ui/hover/hoverWidget';
 
 export class TitlebarPart extends Part implements ITitleService {
-
-	private static readonly configCommandCenter = 'window.commandCenter';
 
 	declare readonly _serviceBrand: undefined;
 
@@ -134,7 +132,7 @@ export class TitlebarPart extends Part implements ITitleService {
 	}
 
 	get isCommandCenterVisible() {
-		return this.configurationService.getValue<boolean>(TitlebarPart.configCommandCenter);
+		return this.configurationService.getValue<boolean>(LayoutSettings.COMMAND_CENTER);
 	}
 
 	private registerListeners(): void {
@@ -169,7 +167,7 @@ export class TitlebarPart extends Part implements ITitleService {
 			this._onDidChange.fire(undefined);
 		}
 
-		if (event.affectsConfiguration(TitlebarPart.configCommandCenter)) {
+		if (event.affectsConfiguration(LayoutSettings.COMMAND_CENTER)) {
 			this.updateTitle();
 			this._onDidChangeCommandCenterVisibility.fire();
 			this._onDidChange.fire(undefined);
@@ -475,7 +473,7 @@ class ToogleConfigAction extends Action2 {
 
 registerAction2(class ToogleCommandCenter extends ToogleConfigAction {
 	constructor() {
-		super('window.commandCenter', localize('toggle.commandCenter', 'Command Center'), 1);
+		super(LayoutSettings.COMMAND_CENTER, localize('toggle.commandCenter', 'Command Center'), 1);
 	}
 });
 

--- a/src/vs/workbench/browser/workbench.contribution.ts
+++ b/src/vs/workbench/browser/workbench.contribution.ts
@@ -11,7 +11,7 @@ import { ConfigurationMigrationWorkbenchContribution, DynamicWorkbenchConfigurat
 import { isStandalone } from 'vs/base/browser/browser';
 import { IWorkbenchContributionsRegistry, Extensions as WorkbenchExtensions } from 'vs/workbench/common/contributions';
 import { LifecyclePhase } from 'vs/workbench/services/lifecycle/common/lifecycle';
-import { ActivityBarPosition, LayoutSettings } from 'vs/workbench/services/layout/browser/layoutService';
+import { ActivityBarPosition, EditorTabsMode, LayoutSettings } from 'vs/workbench/services/layout/browser/layoutService';
 
 const registry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration);
 
@@ -38,9 +38,9 @@ const registry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Con
 				description: localize('tabScrollbarHeight', "Controls the height of the scrollbars used for tabs and breadcrumbs in the editor title area."),
 				default: 'default',
 			},
-			'workbench.editor.showTabs': {
+			[LayoutSettings.EDITOR_TABS_MODE]: {
 				'type': 'string',
-				'enum': ['multiple', 'single', 'none'],
+				'enum': [EditorTabsMode.MULTIPLE, EditorTabsMode.SINGLE, EditorTabsMode.NONE],
 				'enumDescriptions': [
 					localize('workbench.editor.showTabs.multiple', "Each editor is displayed as a tab in the editor title area."),
 					localize('workbench.editor.showTabs.single', "The active editor is displayed as a single large tab in the editor title area."),
@@ -622,7 +622,7 @@ const registry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Con
 				'default': isMacintosh ? ' \u2014 ' : ' - ',
 				'markdownDescription': localize("window.titleSeparator", "Separator used by {0}.", '`#window.title#`')
 			},
-			'window.commandCenter': {
+			[LayoutSettings.COMMAND_CENTER]: {
 				type: 'boolean',
 				default: true,
 				markdownDescription: isWeb ?
@@ -796,11 +796,11 @@ Registry.as<IConfigurationMigrationRegistry>(Extensions.ConfigurationMigration)
 			return [['workbench.editor.doubleClickTabToToggleEditorGroupSizes', { value: value }]];
 		}
 	}, {
-		key: 'workbench.editor.showTabs', migrateFn: (value: any) => {
+		key: LayoutSettings.EDITOR_TABS_MODE, migrateFn: (value: any) => {
 			if (typeof value === 'boolean') {
-				value = value ? 'multiple' : 'single';
+				value = value ? EditorTabsMode.MULTIPLE : EditorTabsMode.SINGLE;
 			}
-			return [['workbench.editor.showTabs', { value: value }]];
+			return [[LayoutSettings.EDITOR_TABS_MODE, { value }]];
 		}
 	}, {
 		key: 'zenMode.hideTabs', migrateFn: (value: any) => {

--- a/src/vs/workbench/contrib/debug/browser/debugToolBar.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugToolBar.ts
@@ -169,7 +169,7 @@ export class DebugToolBar extends Themable implements IWorkbenchContribution {
 				// Prevent default to stop editor selecting text #8524
 				mouseMoveEvent.preventDefault();
 				// Reduce x by width of drag handle to reduce jarring #16604
-				this.setCoordinates(mouseMoveEvent.posx - 14, mouseMoveEvent.posy);
+				this.setCoordinates(mouseMoveEvent.posx - 14, mouseMoveEvent.posy - 14);
 			});
 
 			const mouseUpListener = dom.addDisposableGenericMouseUpListener(window, (e: MouseEvent) => {

--- a/src/vs/workbench/contrib/debug/browser/debugToolBar.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugToolBar.ts
@@ -73,7 +73,6 @@ export class DebugToolBar extends Themable implements IWorkbenchContribution {
 
 		this.$el = dom.$('div.debug-toolbar');
 		this.$el.style.top = `${layoutService.mainContainerOffset.top}px`;
-		this.setHeight();
 
 		this.dragArea = dom.append(this.$el, dom.$('div.drag-area' + ThemeIcon.asCSSSelector(icons.debugGripper)));
 
@@ -135,7 +134,6 @@ export class DebugToolBar extends Themable implements IWorkbenchContribution {
 			}
 			if (e.affectsConfiguration(LayoutSettings.EDITOR_TABS_MODE) || e.affectsConfiguration(LayoutSettings.COMMAND_CENTER)) {
 				this._yRange = undefined;
-				this.setHeight();
 				this.setYCoordinate();
 			}
 		}));
@@ -191,6 +189,11 @@ export class DebugToolBar extends Themable implements IWorkbenchContribution {
 			const position = parseFloat(left) / window.innerWidth;
 			this.storageService.store(DEBUG_TOOLBAR_POSITION_KEY, position, StorageScope.PROFILE, StorageTarget.MACHINE);
 		}
+		if (this.yCoordinate) {
+			this.storageService.store(DEBUG_TOOLBAR_Y_KEY, this.yCoordinate, StorageScope.PROFILE, StorageTarget.MACHINE);
+		} else {
+			this.storageService.remove(DEBUG_TOOLBAR_Y_KEY, StorageScope.PROFILE);
+		}
 	}
 
 	override updateStyles(): void {
@@ -239,7 +242,6 @@ export class DebugToolBar extends Themable implements IWorkbenchContribution {
 		y = Math.max(yMin, Math.min(y, yMax));
 		this.$el.style.top = `${y}px`;
 		this.yCoordinate = y;
-		this.storageService.store(DEBUG_TOOLBAR_Y_KEY, y, StorageScope.PROFILE, StorageTarget.MACHINE);
 	}
 
 	private _yRange: [number, number] | undefined;
@@ -263,10 +265,6 @@ export class DebugToolBar extends Themable implements IWorkbenchContribution {
 			this._yRange = [yMin, yMax];
 		}
 		return this._yRange;
-	}
-
-	private setHeight(): void {
-		this.$el.style.height = `${this.configurationService.getValue(LayoutSettings.EDITOR_TABS_MODE) === EditorTabsMode.NONE && this.configurationService.getValue(LayoutSettings.COMMAND_CENTER) !== true ? 26 : 32}px`;
 	}
 
 	private show(): void {

--- a/src/vs/workbench/contrib/debug/browser/media/debugToolBar.css
+++ b/src/vs/workbench/contrib/debug/browser/media/debugToolBar.css
@@ -6,6 +6,7 @@
 .monaco-workbench .debug-toolbar {
 	position: absolute;
 	z-index: 3000;
+	height: 26px;
 	display: flex;
 	padding-left: 7px;
 	border-radius: 4px;

--- a/src/vs/workbench/contrib/debug/browser/media/debugToolBar.css
+++ b/src/vs/workbench/contrib/debug/browser/media/debugToolBar.css
@@ -5,11 +5,11 @@
 
 .monaco-workbench .debug-toolbar {
 	position: absolute;
-	z-index: 39;
-	height: 32px;
+	z-index: 3000;
 	display: flex;
 	padding-left: 7px;
 	border-radius: 4px;
+	-webkit-app-region: no-drag;
 }
 
 .monaco-workbench .debug-toolbar .monaco-action-bar .action-item {

--- a/src/vs/workbench/services/layout/browser/layoutService.ts
+++ b/src/vs/workbench/services/layout/browser/layoutService.ts
@@ -25,12 +25,20 @@ export const enum Parts {
 
 export const enum LayoutSettings {
 	ACTIVITY_BAR_LOCATION = 'workbench.activityBar.location',
+	EDITOR_TABS_MODE = 'workbench.editor.showTabs',
+	COMMAND_CENTER = 'window.commandCenter',
 }
 
 export const enum ActivityBarPosition {
 	SIDE = 'side',
 	TOP = 'top',
 	HIDDEN = 'hidden'
+}
+
+export const enum EditorTabsMode {
+	MULTIPLE = 'multiple',
+	SINGLE = 'single',
+	NONE = 'none'
 }
 
 export const enum Position {


### PR DESCRIPTION
**Motivation**: My setup contains custom titlebar without command center and tabs hidden and I want to have debug tool bar on the custom title bar.

![image](https://github.com/microsoft/vscode/assets/10746682/8b86e270-6a3f-4fae-8a18-3a34276c13a5)

Floating debug tool bar is allowed to be placed anywhere in the two rows below the title bar. I enabled this to also be placed on the custom title bar. Please check the following gif.

![Recording 2023-10-31 at 14 29 46](https://github.com/microsoft/vscode/assets/10746682/bd97a635-9dc0-494a-8140-809e2c2694d0)

Also note that, I have shortened the tool bar when tabs and command center are hidden to match the titlebar height. In general I liked the shortened version. So, how about shortening the debug tool bar always?

CC @isidorn