### PR TITLE
cli: explicitly deny anonymous control port access

### DIFF
--- a/src/vs/workbench/contrib/testing/browser/explorerProjections/index.ts
+++ b/src/vs/workbench/contrib/testing/browser/explorerProjections/index.ts
@@ -164,9 +164,11 @@ export const getChildrenForParent = (serialized: ISerializedTestTreeCollapseStat
 			: {
 				element,
 				collapsible: element.test.expand !== TestItemExpandState.NotExpandable,
-				collapsed: isCollapsedInSerializedTestTree(serialized, element.test.item.extId) ?? element.depth > 0
-					? ObjectTreeElementCollapseState.PreserveOrCollapsed
-					: ObjectTreeElementCollapseState.PreserveOrExpanded,
+				collapsed: element.test.item.error
+					? ObjectTreeElementCollapseState.Expanded
+					: (isCollapsedInSerializedTestTree(serialized, element.test.item.extId) ?? element.depth > 0
+						? ObjectTreeElementCollapseState.PreserveOrCollapsed
+						: ObjectTreeElementCollapseState.PreserveOrExpanded),
 				children: getChildrenForParent(serialized, rootsWithChildren, element),
 			}
 	));

--- a/src/vs/workbench/contrib/testing/browser/explorerProjections/index.ts
+++ b/src/vs/workbench/contrib/testing/browser/explorerProjections/index.ts
@@ -165,7 +165,7 @@ export const getChildrenForParent = (serialized: ISerializedTestTreeCollapseStat
 				element,
 				collapsible: element.test.expand !== TestItemExpandState.NotExpandable,
 				collapsed: element.test.item.error
-					? ObjectTreeElementCollapseState.Expanded
+					? ObjectTreeElementCollapseState.PreserveOrExpanded
 					: (isCollapsedInSerializedTestTree(serialized, element.test.item.extId) ?? element.depth > 0
 						? ObjectTreeElementCollapseState.PreserveOrCollapsed
 						: ObjectTreeElementCollapseState.PreserveOrExpanded),

--- a/src/vs/workbench/contrib/testing/browser/media/testing.css
+++ b/src/vs/workbench/contrib/testing/browser/media/testing.css
@@ -111,6 +111,16 @@
 	display: none;
 }
 
+.test-explorer .monaco-list-row .error {
+	outline: 1px solid var(--vscode-inputValidation-errorBorder);
+	background: var(--vscode-inputValidation-errorBackground);
+	padding: 2px 4px;
+	border-radius: 2px;
+	margin: 3px 12px 3px 3px;
+	line-height: 17px;
+	font-size: 12px;
+}
+
 .test-explorer .monaco-list-row .error p {
 	margin: 0;
 }

--- a/src/vs/workbench/contrib/testing/browser/testingExplorerView.ts
+++ b/src/vs/workbench/contrib/testing/browser/testingExplorerView.ts
@@ -1280,8 +1280,8 @@ class TreeKeyboardNavigationLabelProvider implements IKeyboardNavigationLabelPro
 }
 
 class ListDelegate implements IListVirtualDelegate<TestExplorerTreeElement> {
-	getHeight(_element: TestExplorerTreeElement) {
-		return 22;
+	getHeight(element: TestExplorerTreeElement) {
+		return element instanceof TestTreeErrorMessage ? 17 + 10 : 22;
 	}
 
 	getTemplateId(element: TestExplorerTreeElement) {


### PR DESCRIPTION
Prevents inheriting any ACL set at the tunnel level which may allow different access for forwarded ports

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
