### PR TITLE
Opening quick text search in a diff editor doesn't put selected text in input

### DIFF
--- a/src/vs/workbench/contrib/search/browser/searchView.ts
+++ b/src/vs/workbench/contrib/search/browser/searchView.ts
@@ -1281,13 +1281,6 @@ export class SearchView extends ViewPane {
 		}
 
 		editor = editor ?? this.editorService.activeTextEditorControl;
-		if (isDiffEditor(editor)) {
-			if (editor.getOriginalEditor().hasTextFocus()) {
-				editor = editor.getOriginalEditor();
-			} else {
-				editor = editor.getModifiedEditor();
-			}
-		}
 
 		if (!editor) {
 			return null;
@@ -2147,7 +2140,17 @@ export function getEditorSelectionFromMatch(element: FileMatchOrMatch, viewModel
 	return undefined;
 }
 
-export function getSelectionTextFromEditor(allowUnselectedWord: boolean, editor: IEditor): string | null {
+export function getSelectionTextFromEditor(allowUnselectedWord: boolean, activeEditor: IEditor): string | null {
+
+	let editor = activeEditor;
+
+	if (isDiffEditor(editor)) {
+		if (editor.getOriginalEditor().hasTextFocus()) {
+			editor = editor.getOriginalEditor();
+		} else {
+			editor = editor.getModifiedEditor();
+		}
+	}
 
 	if (!isCodeEditor(editor) || !editor.hasModel()) {
 		return null;


### PR DESCRIPTION
Fixes #194675

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
