### PR TITLE
disposed model check

### DIFF
--- a/src/vs/editor/contrib/wordHighlighter/browser/wordHighlighter.ts
+++ b/src/vs/editor/contrib/wordHighlighter/browser/wordHighlighter.ts
@@ -533,6 +533,10 @@ class WordHighlighter {
 		const lineNumber = editorSelection.startLineNumber;
 		const startColumn = editorSelection.startColumn;
 
+		if (this.model.isDisposed()) {
+			return null;
+		}
+
 		return this.model.getWordAtPosition({
 			lineNumber: lineNumber,
 			column: startColumn


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

re: #196949

Funky interaction with cells restoring viewState causes the editor to try to recompute highlights based on a cell with a disposed model. Simple `isDisposed()` check patches the issue, though doesn't address the root issue. Listeners are being investigated and tracked via: #197116