### PR TITLE
[October Recovery 1] Showing `toggle inline chat icon` only when providers available

### DIFF
--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatDecorations.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatDecorations.ts
@@ -145,6 +145,11 @@ export class InlineChatDecorationsContribution extends Disposable implements IEd
 }
 
 GutterActionsRegistry.registerGutterActionsGenerator(({ lineNumber, editor, accessor }, result) => {
+	const inlineChatService = accessor.get(IInlineChatService);
+	const noProviders = Iterable.isEmpty(inlineChatService.getAllProvider());
+	if (noProviders) {
+		return;
+	}
 	const configurationService = accessor.get(IConfigurationService);
 	result.push(new Action(
 		'inlineChat.toggleShowGutterIcon',


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/196776