### PR TITLE
fix: use `textPreformat-background` in MD preview

### DIFF
--- a/src/vs/workbench/contrib/webview/browser/pre/index-no-csp.html
+++ b/src/vs/workbench/contrib/webview/browser/pre/index-no-csp.html
@@ -121,7 +121,12 @@
 			}
 
 			code {
+				font-family: var(--monaco-monospace-font);
 				color: var(--vscode-textPreformat-foreground);
+				font-size: 12px;
+				background-color: var(--vscode-textPreformat-background);
+				padding: 1px 3px;
+				border-radius: 4px;
 			}
 
 			blockquote {

--- a/src/vs/workbench/contrib/webview/browser/pre/index.html
+++ b/src/vs/workbench/contrib/webview/browser/pre/index.html
@@ -5,7 +5,7 @@
 	<meta charset="UTF-8">
 
 	<meta http-equiv="Content-Security-Policy"
-		content="default-src 'none'; script-src 'sha256-QA1gXilHYAUFCvp7MpjgcmyBCFzSKV0SpiecMU8aUVc=' 'self'; frame-src 'self'; style-src 'unsafe-inline';">
+		content="default-src 'none'; script-src 'sha256-Ne5nVg2ZDLxLh1eqzYd1sGbOz022xlokwv+X6+HR1hw=' 'self'; frame-src 'self'; style-src 'unsafe-inline';">
 
 	<!-- Disable pinch zooming -->
 	<meta name="viewport"
@@ -122,7 +122,12 @@
 			}
 
 			code {
+				font-family: var(--monaco-monospace-font);
 				color: var(--vscode-textPreformat-foreground);
+				font-size: 12px;
+				background-color: var(--vscode-textPreformat-background);
+				padding: 1px 3px;
+				border-radius: 4px;
 			}
 
 			blockquote {


### PR DESCRIPTION
With fix:

![image](https://github.com/microsoft/vscode/assets/30305945/20ab3a46-bf89-4b23-b28a-ab2990eb85ea)
![image](https://github.com/microsoft/vscode/assets/30305945/e7b3c81d-7fc5-40c2-999c-5557ee9933d7)
![image](https://github.com/microsoft/vscode/assets/30305945/99948cd3-d388-4f01-904d-cff8d6c1b89e)
![image](https://github.com/microsoft/vscode/assets/30305945/ee245185-b1ee-4d71-b5db-ed5e0cd17b65)
