### PR TITLE
Fix multiple tab opening of Simple Browser

### DIFF
--- a/extensions/simple-browser/src/simpleBrowserManager.ts
+++ b/extensions/simple-browser/src/simpleBrowserManager.ts
@@ -21,6 +21,9 @@ export class SimpleBrowserManager {
 
 	public show(inputUri: string | vscode.Uri, options?: ShowOptions): void {
 		const url = typeof inputUri === 'string' ? inputUri : inputUri.toString(true);
+		if (this.existInTabGroup()) {
+			return;
+		}
 		if (this._activeView) {
 			this._activeView.show(url, options);
 		} else {
@@ -36,6 +39,10 @@ export class SimpleBrowserManager {
 		const view = SimpleBrowserView.restore(this.extensionUri, url, panel);
 		this.registerWebviewListeners(view);
 		this._activeView ??= view;
+	}
+
+	private existInTabGroup(): boolean {
+		return !!vscode.window.tabGroups.activeTabGroup.tabs.find(tabGroup => tabGroup.label === SimpleBrowserView.title);
 	}
 
 	private registerWebviewListeners(view: SimpleBrowserView) {

--- a/extensions/simple-browser/src/simpleBrowserView.ts
+++ b/extensions/simple-browser/src/simpleBrowserView.ts
@@ -15,7 +15,7 @@ export interface ShowOptions {
 export class SimpleBrowserView extends Disposable {
 
 	public static readonly viewType = 'simpleBrowser.view';
-	private static readonly title = vscode.l10n.t("Simple Browser");
+	public static readonly title = vscode.l10n.t("Simple Browser");
 
 	private static getWebviewLocalResourceRoots(extensionUri: vscode.Uri): readonly vscode.Uri[] {
 		return [


### PR DESCRIPTION
## Why
In https://github.com/microsoft/vscode/issues/182795 it was shown that a new Simple Browser 
tab was created whenever the vscode window has 
been reloaded with an active view not being a Simple 
Browser tab. This led to strange user experience and 
weird editor behaviour.

## What
Make sure no new instance of the Simple Browser will 
be created if there exist already one in the active tab 
group.

Fixes https://github.com/microsoft/vscode/issues/182795
