### PR TITLE
testing: fix performance when unloading a bunch of tests

### DIFF
--- a/src/vs/workbench/contrib/testing/browser/explorerProjections/treeProjection.ts
+++ b/src/vs/workbench/contrib/testing/browser/explorerProjections/treeProjection.ts
@@ -224,8 +224,9 @@ export class TreeProjection extends Disposable implements ITestTreeProjection {
 					}
 
 					// The first element will cause the root to be hidden
-					const affectsRootElement = toRemove.depth === 1 && toRemove.parent?.children.size === 1;
-					this.changedParents.add(affectsRootElement ? null : toRemove.parent);
+					const parent = toRemove.parent;
+					const affectsRootElement = toRemove.depth === 1 && parent?.children.size === 1;
+					this.changedParents.add(affectsRootElement ? null : parent);
 
 					const queue: Iterable<TestExplorerTreeElement>[] = [[toRemove]];
 					while (queue.length) {
@@ -234,6 +235,10 @@ export class TreeProjection extends Disposable implements ITestTreeProjection {
 								queue.push(this.unstoreItem(item));
 							}
 						}
+					}
+
+					if (parent instanceof TreeTestItemElement) {
+						refreshComputedState(computedStateAccessor, parent, undefined, !!parent.duration).forEach(i => i.fireChange());
 					}
 				}
 			}
@@ -290,10 +295,6 @@ export class TreeProjection extends Disposable implements ITestTreeProjection {
 		const parent = treeElement.parent;
 		parent?.children.delete(treeElement);
 		this.items.delete(treeElement.test.item.extId);
-		if (parent instanceof TreeTestItemElement) {
-			refreshComputedState(computedStateAccessor, parent, undefined, !!treeElement.duration).forEach(i => i.fireChange());
-		}
-
 		return treeElement.children;
 	}
 


### PR DESCRIPTION
We were unnecessary recomputing the state for child items, when we only needed to do so for the removed root

Fixes #193240

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
