### PR TITLE
open editors - disable focus tracking in some cases

### DIFF
--- a/src/vs/workbench/contrib/files/browser/views/openEditorsView.ts
+++ b/src/vs/workbench/contrib/files/browser/views/openEditorsView.ts
@@ -74,6 +74,7 @@ export class OpenEditorsView extends ViewPane {
 	private groupFocusedContext!: IContextKey<boolean>;
 	private dirtyEditorFocusedContext!: IContextKey<boolean>;
 	private readonlyEditorFocusedContext!: IContextKey<boolean>;
+	private blockFocusActiveEditorTracking = false;
 
 	constructor(
 		options: IViewletViewOptions,
@@ -277,19 +278,24 @@ export class OpenEditorsView extends ViewPane {
 			}
 		}));
 		this._register(this.list.onDidOpen(e => {
-			if (!e.element) {
+			const element = e.element;
+			if (!element) {
 				return;
-			} else if (e.element instanceof OpenEditor) {
+			} else if (element instanceof OpenEditor) {
 				if (dom.isMouseEvent(e.browserEvent) && e.browserEvent.button === 1) {
 					return; // middle click already handled above: closes the editor
 				}
 
-				this.openEditor(e.element, { preserveFocus: e.editorOptions.preserveFocus, pinned: e.editorOptions.pinned, sideBySide: e.sideBySide });
+				this.withActiveEditorFocusTrackingDisabled(() => {
+					this.openEditor(element, { preserveFocus: e.editorOptions.preserveFocus, pinned: e.editorOptions.pinned, sideBySide: e.sideBySide });
+				});
 			} else {
-				this.editorGroupService.activateGroup(e.element);
-				if (!e.editorOptions.preserveFocus) {
-					e.element.focus();
-				}
+				this.withActiveEditorFocusTrackingDisabled(() => {
+					this.editorGroupService.activateGroup(element);
+					if (!e.editorOptions.preserveFocus) {
+						element.focus();
+					}
+				});
 			}
 		}));
 
@@ -401,8 +407,17 @@ export class OpenEditorsView extends ViewPane {
 		});
 	}
 
+	private withActiveEditorFocusTrackingDisabled(fn: () => void): void {
+		this.blockFocusActiveEditorTracking = true;
+		try {
+			fn();
+		} finally {
+			this.blockFocusActiveEditorTracking = false;
+		}
+	}
+
 	private focusActiveEditor(): void {
-		if (!this.list) {
+		if (!this.list || this.blockFocusActiveEditorTracking) {
 			return;
 		}
 


### PR DESCRIPTION
Specifically with auxiliary windows, it is possible that a auxiliary window has focus and the user clicks into the inactive open editors view.
That click would activate the main window and trigger the focus tracker but we already know where the focus is going to be based on the click.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
