### PR TITLE
rm task from storage when terminated

### DIFF
--- a/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
+++ b/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
@@ -216,9 +216,9 @@ export abstract class AbstractTaskService extends Disposable implements ITaskSer
 	private _recentlyUsedTasksV1: LRUCache<string, string> | undefined;
 	private _recentlyUsedTasks: LRUCache<string, string> | undefined;
 
-	protected _taskRunningState: IContextKey<boolean>;
-
 	private _persistentTasks: LRUCache<string, string> | undefined;
+
+	protected _taskRunningState: IContextKey<boolean>;
 
 	protected _outputChannel: IOutputChannel;
 	protected readonly _onDidStateChange: Emitter<ITaskEvent>;
@@ -299,6 +299,7 @@ export abstract class AbstractTaskService extends Disposable implements ITaskSer
 
 			if (e.affectsConfiguration(TaskSettingId.Reconnection)) {
 				if (!this._configurationService.getValue(TaskSettingId.Reconnection)) {
+					this._persistentTasks?.clear();
 					this._storageService.remove(AbstractTaskService.PersistentTasks_Key, StorageScope.WORKSPACE);
 				}
 			}
@@ -978,6 +979,7 @@ export abstract class AbstractTaskService extends Disposable implements ITaskSer
 			this._log(nls.localize('taskService.gettingCachedTasks', 'Returning cached tasks {0}', this._persistentTasks.size), true);
 			return this._persistentTasks;
 		}
+		//TODO: should this # be configurable?
 		this._persistentTasks = new LRUCache<string, string>(10);
 		const storageValue = this._storageService.get(AbstractTaskService.PersistentTasks_Key, StorageScope.WORKSPACE);
 		if (storageValue) {
@@ -1020,7 +1022,6 @@ export abstract class AbstractTaskService extends Disposable implements ITaskSer
 				map.get(folder).push(task);
 			}
 		}
-
 		for (const entry of storedTasks.entries()) {
 			const key = entry[0];
 			const task = JSON.parse(entry[1]);
@@ -2353,7 +2354,7 @@ export abstract class AbstractTaskService extends Disposable implements ITaskSer
 
 	private _log(value: string, verbose?: boolean): void {
 		if (verbose && this._configurationService.getValue(TaskSettingId.VerboseLogging) || !verbose) {
-			this._outputChannel.append(value);
+			this._outputChannel.append(value + '\n');
 		}
 	}
 

--- a/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
+++ b/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
@@ -2353,7 +2353,7 @@ export abstract class AbstractTaskService extends Disposable implements ITaskSer
 	}
 
 	private _log(value: string, verbose?: boolean): void {
-		if (verbose && this._configurationService.getValue(TaskSettingId.VerboseLogging) || !verbose) {
+		if (!verbose || this._configurationService.getValue(TaskSettingId.VerboseLogging)) {
 			this._outputChannel.append(value + '\n');
 		}
 	}

--- a/src/vs/workbench/contrib/tasks/browser/task.contribution.ts
+++ b/src/vs/workbench/contrib/tasks/browser/task.contribution.ts
@@ -553,5 +553,10 @@ configurationRegistry.registerConfiguration({
 			],
 			default: 'always',
 		},
+		[TaskSettingId.VerboseLogging]: {
+			type: 'boolean',
+			description: nls.localize('task.verboseLogging', "Enable verbose logging for tasks."),
+			default: false
+		},
 	}
 });

--- a/src/vs/workbench/contrib/tasks/browser/taskQuickPick.ts
+++ b/src/vs/workbench/contrib/tasks/browser/taskQuickPick.ts
@@ -149,11 +149,11 @@ export class TaskQuickPick extends Disposable {
 			const definition = configuredTasks[j].getDefinition()?._key;
 			const type = configuredTasks[j].type;
 			const label = configuredTasks[j]._label;
-			const recentKey = configuredTasks[j].getRecentlyUsedKey();
+			const recentKey = configuredTasks[j].getKey();
 			const findIndex = recentTasks.findIndex((value) => {
 				return (workspaceFolder && definition && value.getWorkspaceFolder()?.uri.toString() === workspaceFolder
 					&& ((value.getDefinition()?._key === definition) || (value.type === type && value._label === label)))
-					|| (recentKey && value.getRecentlyUsedKey() === recentKey);
+					|| (recentKey && value.getKey() === recentKey);
 			});
 			if (findIndex === -1) {
 				dedupedConfiguredTasks.push(configuredTasks[j]);
@@ -231,7 +231,7 @@ export class TaskQuickPick extends Disposable {
 		picker.onDidTriggerItemButton(async (context) => {
 			const task = context.item.task;
 			if (context.button.iconClass === ThemeIcon.asClassName(removeTaskIcon)) {
-				const key = (task && !Types.isString(task)) ? task.getRecentlyUsedKey() : undefined;
+				const key = (task && !Types.isString(task)) ? task.getKey() : undefined;
 				if (key) {
 					this._taskService.removeRecentlyUsedTask(key);
 				}

--- a/src/vs/workbench/contrib/tasks/browser/tasksQuickAccess.ts
+++ b/src/vs/workbench/contrib/tasks/browser/tasksQuickAccess.ts
@@ -65,7 +65,7 @@ export class TasksQuickAccessProvider extends PickerQuickAccessProvider<IPickerQ
 			quickAccessEntry.highlights = { label: highlights };
 			quickAccessEntry.trigger = (index) => {
 				if ((index === 1) && (quickAccessEntry.buttons?.length === 2)) {
-					const key = (task && !isString(task)) ? task.getRecentlyUsedKey() : undefined;
+					const key = (task && !isString(task)) ? task.getKey() : undefined;
 					if (key) {
 						this._taskService.removeRecentlyUsedTask(key);
 					}

--- a/src/vs/workbench/contrib/tasks/browser/terminalTaskSystem.ts
+++ b/src/vs/workbench/contrib/tasks/browser/terminalTaskSystem.ts
@@ -386,9 +386,9 @@ export class TerminalTaskSystem extends Disposable implements ITaskSystem {
 	}
 
 	public getLastInstance(task: Task): Task | undefined {
-		const recentKey = task.getRecentlyUsedKey();
+		const recentKey = task.getKey();
 		return Object.values(this._activeTasks).reverse().find(
-			(value) => recentKey && recentKey === value.task.getRecentlyUsedKey())?.task;
+			(value) => recentKey && recentKey === value.task.getKey())?.task;
 	}
 
 	public getBusyTasks(): Task[] {
@@ -408,9 +408,9 @@ export class TerminalTaskSystem extends Disposable implements ITaskSystem {
 	}
 
 	private _getInstances(task: Task): IActiveTerminalData[] {
-		const recentKey = task.getRecentlyUsedKey();
+		const recentKey = task.getKey();
 		return Object.values(this._activeTasks).filter(
-			(value) => recentKey && recentKey === value.task.getRecentlyUsedKey());
+			(value) => recentKey && recentKey === value.task.getKey());
 	}
 
 	private _removeFromActiveTasks(task: Task | string): void {

--- a/src/vs/workbench/contrib/tasks/common/tasks.ts
+++ b/src/vs/workbench/contrib/tasks/common/tasks.ts
@@ -1266,7 +1266,8 @@ export const enum TaskSettingId {
 	QuickOpenSkip = 'task.quickOpen.skip',
 	QuickOpenShowAll = 'task.quickOpen.showAll',
 	AllowAutomaticTasks = 'task.allowAutomaticTasks',
-	Reconnection = 'task.reconnection'
+	Reconnection = 'task.reconnection',
+	VerboseLogging = 'task.verboseLogging'
 }
 
 export const enum TasksSchemaProperties {

--- a/src/vs/workbench/contrib/tasks/common/tasks.ts
+++ b/src/vs/workbench/contrib/tasks/common/tasks.ts
@@ -617,7 +617,7 @@ export abstract class CommonTask {
 		return this._id;
 	}
 
-	public getRecentlyUsedKey(): string | undefined {
+	public getKey(): string | undefined {
 		return undefined;
 	}
 
@@ -788,10 +788,13 @@ export class CustomTask extends CommonTask {
 	}
 
 	public override getCommonTaskId(): string {
-		return this._source.customizes ? super.getCommonTaskId() : (this.getRecentlyUsedKey() ?? super.getCommonTaskId());
+		return this._source.customizes ? super.getCommonTaskId() : (this.getKey() ?? super.getCommonTaskId());
 	}
 
-	public override getRecentlyUsedKey(): string | undefined {
+	/**
+	 * @returns A key representing the task
+	 */
+	public override getKey(): string | undefined {
 		interface ICustomKey {
 			type: string;
 			folder: string;
@@ -875,7 +878,7 @@ export class ConfiguringTask extends CommonTask {
 		return this._source.kind === TaskSourceKind.User ? USER_TASKS_GROUP_KEY : this._source.config.workspaceFolder?.uri.toString();
 	}
 
-	public override getRecentlyUsedKey(): string | undefined {
+	public override getKey(): string | undefined {
 		interface ICustomKey {
 			type: string;
 			folder: string;
@@ -963,7 +966,7 @@ export class ContributedTask extends CommonTask {
 		return undefined;
 	}
 
-	public override getRecentlyUsedKey(): string | undefined {
+	public override getKey(): string | undefined {
 		interface IContributedKey {
 			type: string;
 			scope: number;


### PR DESCRIPTION
The wrong key was being used, so the task wouldn't get deleted when it was terminated. https://github.com/microsoft/vscode/pull/197381/files#diff-f77e08d48fa5a43f6cd385c0bac2c04ee2123565ead5f0f4b60e23c8af821b76R344

Also, aptly renamed `getRecentlyUsedKey` -> `getKey` and added a bunch of logs behind a setting