### PR TITLE
fix: don't set font size for code spans in webview

### DIFF
--- a/src/vs/workbench/contrib/webview/browser/pre/index-no-csp.html
+++ b/src/vs/workbench/contrib/webview/browser/pre/index-no-csp.html
@@ -123,7 +123,6 @@
 			code {
 				font-family: var(--monaco-monospace-font);
 				color: var(--vscode-textPreformat-foreground);
-				font-size: 12px;
 				background-color: var(--vscode-textPreformat-background);
 				padding: 1px 3px;
 				border-radius: 4px;

--- a/src/vs/workbench/contrib/webview/browser/pre/index.html
+++ b/src/vs/workbench/contrib/webview/browser/pre/index.html
@@ -5,7 +5,7 @@
 	<meta charset="UTF-8">
 
 	<meta http-equiv="Content-Security-Policy"
-		content="default-src 'none'; script-src 'sha256-Ne5nVg2ZDLxLh1eqzYd1sGbOz022xlokwv+X6+HR1hw=' 'self'; frame-src 'self'; style-src 'unsafe-inline';">
+		content="default-src 'none'; script-src 'sha256-frEVWVmmI4TWHGHXZaCTWqGQI9jv+i8hv+sOa87Gqlc=' 'self'; frame-src 'self'; style-src 'unsafe-inline';">
 
 	<!-- Disable pinch zooming -->
 	<meta name="viewport"
@@ -124,7 +124,6 @@
 			code {
 				font-family: var(--monaco-monospace-font);
 				color: var(--vscode-textPreformat-foreground);
-				font-size: 12px;
 				background-color: var(--vscode-textPreformat-background);
 				padding: 1px 3px;
 				border-radius: 4px;


### PR DESCRIPTION
This regresses rendering of code spans in Github Pull Requests titles

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
