### PR TITLE
debug: improve performance of stepping

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/debugSession.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugSession.ts
@@ -10,7 +10,7 @@ import { CancellationToken, CancellationTokenSource } from 'vs/base/common/cance
 import { canceled } from 'vs/base/common/errors';
 import { Emitter, Event } from 'vs/base/common/event';
 import { normalizeDriveLetter } from 'vs/base/common/labels';
-import { DisposableStore, IDisposable, MutableDisposable, dispose } from 'vs/base/common/lifecycle';
+import { Disposable, DisposableMap, DisposableStore, IDisposable, MutableDisposable, dispose } from 'vs/base/common/lifecycle';
 import { mixin } from 'vs/base/common/objects';
 import * as platform from 'vs/base/common/platform';
 import * as resources from 'vs/base/common/resources';
@@ -980,81 +980,96 @@ export class DebugSession implements IDebugSession, IDisposable {
 			}
 		}));
 
-		const statusQueue = new Queue<void>();
+
+		const statusQueue = this.rawListeners.add(new ThreadStatusScheduler());
 		this.rawListeners.add(this.raw.onDidStop(async event => {
-			statusQueue.queue(async () => {
-				this.passFocusScheduler.cancel();
-				this.stoppedDetails.push(event.body);
-				await this.fetchThreads(event.body);
-				// If the focus for the current session is on a non-existent thread, clear the focus.
-				const focusedThread = this.debugService.getViewModel().focusedThread;
-				const focusedThreadDoesNotExist = focusedThread !== undefined && focusedThread.session === this && !this.threads.has(focusedThread.threadId);
-				if (focusedThreadDoesNotExist) {
-					this.debugService.focusStackFrame(undefined, undefined);
-				}
-				const thread = typeof event.body.threadId === 'number' ? this.getThread(event.body.threadId) : undefined;
-				if (thread) {
-					// Call fetch call stack twice, the first only return the top stack frame.
-					// Second retrieves the rest of the call stack. For performance reasons #25605
-					const promises = this.model.refreshTopOfCallstack(<Thread>thread);
-					const focus = async () => {
-						if (focusedThreadDoesNotExist || (!event.body.preserveFocusHint && thread.getCallStack().length)) {
-							const focusedStackFrame = this.debugService.getViewModel().focusedStackFrame;
-							if (!focusedStackFrame || focusedStackFrame.thread.session === this) {
-								// Only take focus if nothing is focused, or if the focus is already on the current session
-								const preserveFocus = !this.configurationService.getValue<IDebugConfiguration>('debug').focusEditorOnBreak;
-								await this.debugService.focusStackFrame(undefined, thread, undefined, { preserveFocus });
-							}
+			this.passFocusScheduler.cancel();
+			this.stoppedDetails.push(event.body);
 
-							if (thread.stoppedDetails) {
-								if (thread.stoppedDetails.reason === 'breakpoint' && this.configurationService.getValue<IDebugConfiguration>('debug').openDebug === 'openOnDebugBreak' && !this.suppressDebugView) {
-									await this.paneCompositeService.openPaneComposite(VIEWLET_ID, ViewContainerLocation.Sidebar);
-								}
+			statusQueue.run(
+				this.fetchThreads(event.body).then(() => event.body.threadId === undefined ? this.threadIds : [event.body.threadId]),
+				async (threadId, token) => {
+					const hasLotsOfThreads = event.body.threadId === undefined && this.threadIds.length > 10;
 
-								if (this.configurationService.getValue<IDebugConfiguration>('debug').focusWindowOnBreak && !this.workbenchEnvironmentService.extensionTestsLocationURI) {
-									await this.hostService.focus(window, { force: true /* Application may not be active */ });
-								}
-							}
-						}
-					};
-
-					await promises.topCallStack;
-					focus();
-					await promises.wholeCallStack;
-					const focusedStackFrame = this.debugService.getViewModel().focusedStackFrame;
-					if (!focusedStackFrame || !focusedStackFrame.source || focusedStackFrame.source.presentationHint === 'deemphasize' || focusedStackFrame.presentationHint === 'deemphasize') {
-						// The top stack frame can be deemphesized so try to focus again #68616
-						focus();
+					// If the focus for the current session is on a non-existent thread, clear the focus.
+					const focusedThread = this.debugService.getViewModel().focusedThread;
+					const focusedThreadDoesNotExist = focusedThread !== undefined && focusedThread.session === this && !this.threads.has(focusedThread.threadId);
+					if (focusedThreadDoesNotExist) {
+						this.debugService.focusStackFrame(undefined, undefined);
 					}
-				}
-				this._onDidChangeState.fire();
-			});
+					const thread = typeof threadId === 'number' ? this.getThread(threadId) : undefined;
+					if (thread) {
+						// Call fetch call stack twice, the first only return the top stack frame.
+						// Second retrieves the rest of the call stack. For performance reasons #25605
+						// Second call is only done if there's few threads that stopped in this event.
+						const promises = this.model.refreshTopOfCallstack(<Thread>thread, /* fetchFullStack= */!hasLotsOfThreads);
+						const focus = async () => {
+							if (focusedThreadDoesNotExist || (!event.body.preserveFocusHint && thread.getCallStack().length)) {
+								const focusedStackFrame = this.debugService.getViewModel().focusedStackFrame;
+								if (!focusedStackFrame || focusedStackFrame.thread.session === this) {
+									// Only take focus if nothing is focused, or if the focus is already on the current session
+									const preserveFocus = !this.configurationService.getValue<IDebugConfiguration>('debug').focusEditorOnBreak;
+									await this.debugService.focusStackFrame(undefined, thread, undefined, { preserveFocus });
+								}
+
+								if (thread.stoppedDetails && !token.isCancellationRequested) {
+									if (thread.stoppedDetails.reason === 'breakpoint' && this.configurationService.getValue<IDebugConfiguration>('debug').openDebug === 'openOnDebugBreak' && !this.suppressDebugView) {
+										await this.paneCompositeService.openPaneComposite(VIEWLET_ID, ViewContainerLocation.Sidebar);
+									}
+
+									if (this.configurationService.getValue<IDebugConfiguration>('debug').focusWindowOnBreak && !this.workbenchEnvironmentService.extensionTestsLocationURI) {
+										await this.hostService.focus(window, { force: true /* Application may not be active */ });
+									}
+								}
+							}
+						};
+
+						await promises.topCallStack;
+						if (token.isCancellationRequested) {
+							return;
+						}
+
+						focus();
+
+						await promises.wholeCallStack;
+						if (token.isCancellationRequested) {
+							return;
+						}
+
+						const focusedStackFrame = this.debugService.getViewModel().focusedStackFrame;
+						if (!focusedStackFrame || !focusedStackFrame.source || focusedStackFrame.source.presentationHint === 'deemphasize' || focusedStackFrame.presentationHint === 'deemphasize') {
+							// The top stack frame can be deemphesized so try to focus again #68616
+							focus();
+						}
+					}
+					this._onDidChangeState.fire();
+				},
+			);
 		}));
 
 		this.rawListeners.add(this.raw.onDidThread(event => {
-			statusQueue.queue(async () => {
-				if (event.body.reason === 'started') {
-					// debounce to reduce threadsRequest frequency and improve performance
-					if (!this.fetchThreadsScheduler) {
-						this.fetchThreadsScheduler = new RunOnceScheduler(() => {
-							this.fetchThreads();
-						}, 100);
-						this.rawListeners.add(this.fetchThreadsScheduler);
-					}
-					if (!this.fetchThreadsScheduler.isScheduled()) {
-						this.fetchThreadsScheduler.schedule();
-					}
-				} else if (event.body.reason === 'exited') {
-					this.model.clearThreads(this.getId(), true, event.body.threadId);
-					const viewModel = this.debugService.getViewModel();
-					const focusedThread = viewModel.focusedThread;
-					this.passFocusScheduler.cancel();
-					if (focusedThread && event.body.threadId === focusedThread.threadId) {
-						// De-focus the thread in case it was focused
-						this.debugService.focusStackFrame(undefined, undefined, viewModel.focusedSession, { explicit: false });
-					}
+			statusQueue.cancel([event.body.threadId]);
+			if (event.body.reason === 'started') {
+				// debounce to reduce threadsRequest frequency and improve performance
+				if (!this.fetchThreadsScheduler) {
+					this.fetchThreadsScheduler = new RunOnceScheduler(() => {
+						this.fetchThreads();
+					}, 100);
+					this.rawListeners.add(this.fetchThreadsScheduler);
 				}
-			});
+				if (!this.fetchThreadsScheduler.isScheduled()) {
+					this.fetchThreadsScheduler.schedule();
+				}
+			} else if (event.body.reason === 'exited') {
+				this.model.clearThreads(this.getId(), true, event.body.threadId);
+				const viewModel = this.debugService.getViewModel();
+				const focusedThread = viewModel.focusedThread;
+				this.passFocusScheduler.cancel();
+				if (focusedThread && event.body.threadId === focusedThread.threadId) {
+					// De-focus the thread in case it was focused
+					this.debugService.focusStackFrame(undefined, undefined, viewModel.focusedSession, { explicit: false });
+				}
+			}
 		}));
 
 		this.rawListeners.add(this.raw.onDidTerminateDebugee(async event => {
@@ -1067,23 +1082,25 @@ export class DebugSession implements IDebugSession, IDisposable {
 		}));
 
 		this.rawListeners.add(this.raw.onDidContinued(event => {
-			statusQueue.queue(async () => {
-				const threadId = event.body.allThreadsContinued !== false ? undefined : event.body.threadId;
-				if (typeof threadId === 'number') {
-					this.stoppedDetails = this.stoppedDetails.filter(sd => sd.threadId !== threadId);
-					const tokens = this.cancellationMap.get(threadId);
-					this.cancellationMap.delete(threadId);
-					tokens?.forEach(t => t.dispose(true));
-				} else {
-					this.stoppedDetails = [];
-					this.cancelAllRequests();
-				}
-				this.lastContinuedThreadId = threadId;
-				// We need to pass focus to other sessions / threads with a timeout in case a quick stop event occurs #130321
-				this.passFocusScheduler.schedule();
-				this.model.clearThreads(this.getId(), false, threadId);
-				this._onDidChangeState.fire();
-			});
+			const allThreads = event.body.allThreadsContinued !== false;
+
+			statusQueue.cancel(allThreads ? undefined : [event.body.threadId]);
+
+			const threadId = allThreads ? undefined : event.body.threadId;
+			if (typeof threadId === 'number') {
+				this.stoppedDetails = this.stoppedDetails.filter(sd => sd.threadId !== threadId);
+				const tokens = this.cancellationMap.get(threadId);
+				this.cancellationMap.delete(threadId);
+				tokens?.forEach(t => t.dispose(true));
+			} else {
+				this.stoppedDetails = [];
+				this.cancelAllRequests();
+			}
+			this.lastContinuedThreadId = threadId;
+			// We need to pass focus to other sessions / threads with a timeout in case a quick stop event occurs #130321
+			this.passFocusScheduler.schedule();
+			this.model.clearThreads(this.getId(), false, threadId);
+			this._onDidChangeState.fire();
 		}));
 
 		const outputQueue = new Queue<void>();
@@ -1363,6 +1380,98 @@ export class DebugSession implements IDebugSession, IDisposable {
 		this.repl.appendToRepl(this, data);
 		if (isImportant) {
 			this.notificationService.notify({ message: data.output.toString(), severity: data.sev, source: this.name });
+		}
+	}
+}
+
+/**
+ * Keeps track of events for threads, and cancels any previous operations for
+ * a thread when the thread goes into a new state. Currently, the operations a thread has are:
+ *
+ * - started
+ * - stopped
+ * - continue
+ * - exited
+ *
+ * In each case, the new state preempts the old state, so we don't need to
+ * queue work, just cancel old work. It's up to the caller to make sure that
+ * no UI effects happen at the point when the `token` is cancelled.
+ */
+export class ThreadStatusScheduler extends Disposable {
+	/**
+	 * An array of set of thread IDs. When a 'stopped' event is encountered, the
+	 * editor refreshes its thread IDs. In the meantime, the thread may change
+	 * state it again. So the editor puts a Set into this array when it starts
+	 * the refresh, and checks it after the refresh is finished, to see if
+	 * any of the threads it looked up should now be invalidated.
+	 */
+	private pendingCancellations: Set<number | undefined>[] = [];
+
+	/**
+	 * Cancellation tokens for currently-running operations on threads.
+	 */
+	private readonly threadOps = this._register(new DisposableMap<number, CancellationTokenSource>());
+
+	/**
+	 * Runs the operation.
+	 * If thread is undefined it affects all threads.
+	 */
+	public async run(threadIdsP: Promise<number[]>, operation: (threadId: number, ct: CancellationToken) => Promise<unknown>) {
+		const cancelledWhileLookingUpThreads = new Set<number | undefined>();
+		this.pendingCancellations.push(cancelledWhileLookingUpThreads);
+		const threadIds = await threadIdsP;
+
+		// Now that we got our threads,
+		// 1. Remove our pending set, and
+		// 2. Cancel any slower callers who might also have found this thread
+		for (let i = 0; i < this.pendingCancellations.length; i++) {
+			const s = this.pendingCancellations[i];
+			if (s === cancelledWhileLookingUpThreads) {
+				this.pendingCancellations.splice(i, 1);
+				break;
+			} else {
+				for (const threadId of threadIds) {
+					s.add(threadId);
+				}
+			}
+		}
+
+		if (cancelledWhileLookingUpThreads.has(undefined)) {
+			return;
+		}
+
+		await Promise.all(threadIds.map(threadId => {
+			if (cancelledWhileLookingUpThreads.has(threadId)) {
+				return;
+			}
+			this.threadOps.get(threadId)?.cancel();
+			const cts = new CancellationTokenSource();
+			this.threadOps.set(threadId, cts);
+			return operation(threadId, cts.token);
+		}));
+	}
+
+	/**
+	 * Cancels all ongoing state operations on the given threads.
+	 * If threads is undefined it cancel all threads.
+	 */
+	public cancel(threadIds?: readonly number[]) {
+		if (!threadIds) {
+			for (const [_, op] of this.threadOps) {
+				op.cancel();
+			}
+			this.threadOps.clearAndDisposeAll();
+			for (const s of this.pendingCancellations) {
+				s.add(undefined);
+			}
+		} else {
+			for (const threadId of threadIds) {
+				this.threadOps.get(threadId)?.cancel();
+				this.threadOps.deleteAndDispose(threadId);
+				for (const s of this.pendingCancellations) {
+					s.add(threadId);
+				}
+			}
 		}
 	}
 }

--- a/src/vs/workbench/contrib/debug/common/debugModel.ts
+++ b/src/vs/workbench/contrib/debug/common/debugModel.ts
@@ -1324,13 +1324,13 @@ export class DebugModel extends Disposable implements IDebugModel {
 		return;
 	}
 
-	refreshTopOfCallstack(thread: Thread): { topCallStack: Promise<void>; wholeCallStack: Promise<void> } {
+	refreshTopOfCallstack(thread: Thread, fetchFullStack = true): { topCallStack: Promise<void>; wholeCallStack: Promise<void> } {
 		if (thread.session.capabilities.supportsDelayedStackTraceLoading) {
 			// For improved performance load the first stack frame and then load the rest async.
 			let topCallStack = Promise.resolve();
 			const wholeCallStack = new Promise<void>((c, e) => {
 				topCallStack = thread.fetchCallStack(1).then(() => {
-					if (!this.schedulers.has(thread.getId())) {
+					if (!this.schedulers.has(thread.getId()) && fetchFullStack) {
 						const deferred = new DeferredPromise<void>();
 						this.schedulers.set(thread.getId(), {
 							completeDeferred: deferred,

--- a/src/vs/workbench/contrib/debug/test/browser/debugSession.test.ts
+++ b/src/vs/workbench/contrib/debug/test/browser/debugSession.test.ts
@@ -1,0 +1,109 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from 'vs/base/test/common/utils';
+import { ThreadStatusScheduler } from 'vs/workbench/contrib/debug/browser/debugSession';
+
+
+suite('DebugSession - ThreadStatusScheduler', () => {
+	const ds = ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('cancel base case', async () => {
+		const scheduler = ds.add(new ThreadStatusScheduler());
+
+		await scheduler.run(Promise.resolve([1]), async (threadId, token) => {
+			assert.strictEqual(threadId, 1);
+			assert.strictEqual(token.isCancellationRequested, false);
+			scheduler.cancel([1]);
+			assert.strictEqual(token.isCancellationRequested, true);
+		});
+	});
+
+	test('cancel global', async () => {
+		const scheduler = ds.add(new ThreadStatusScheduler());
+
+		await scheduler.run(Promise.resolve([1]), async (threadId, token) => {
+			assert.strictEqual(threadId, 1);
+			assert.strictEqual(token.isCancellationRequested, false);
+			scheduler.cancel(undefined);
+			assert.strictEqual(token.isCancellationRequested, true);
+		});
+	});
+
+	test('cancels when new work comes in', async () => {
+		const scheduler = ds.add(new ThreadStatusScheduler());
+		let innerCalled = false;
+
+		await scheduler.run(Promise.resolve([1]), async (threadId, token1) => {
+			assert.strictEqual(threadId, 1);
+			assert.strictEqual(token1.isCancellationRequested, false);
+			await scheduler.run(Promise.resolve([1]), async (_threadId, token2) => {
+				innerCalled = true;
+				assert.strictEqual(token1.isCancellationRequested, true);
+				assert.strictEqual(token2.isCancellationRequested, false);
+			});
+		});
+
+		assert.strictEqual(innerCalled, true);
+	});
+
+	test('cancels slower lookups when new lookup is made', async () => {
+		const scheduler = ds.add(new ThreadStatusScheduler());
+		const innerCalled1: number[] = [];
+		const innerCalled2: number[] = [];
+
+		await Promise.all([
+			scheduler.run(Promise.resolve().then(() => { }).then(() => [1, 3]), async threadId => {
+				innerCalled1.push(threadId);
+			}),
+			scheduler.run(Promise.resolve([1, 2]), async threadId => {
+				innerCalled2.push(threadId);
+			})
+		]);
+
+		assert.deepEqual(innerCalled1, [3]);
+		assert.deepEqual(innerCalled2, [1, 2]);
+	});
+
+	test('allows work with other IDs', async () => {
+		const scheduler = ds.add(new ThreadStatusScheduler());
+		let innerCalled = false;
+
+		await scheduler.run(Promise.resolve([1]), async (threadId, token1) => {
+			assert.strictEqual(threadId, 1);
+			assert.strictEqual(token1.isCancellationRequested, false);
+			await scheduler.run(Promise.resolve([2]), async (_threadId, token2) => {
+				innerCalled = true;
+				assert.strictEqual(token1.isCancellationRequested, false);
+				assert.strictEqual(token2.isCancellationRequested, false);
+			});
+		});
+
+		assert.strictEqual(innerCalled, true);
+	});
+
+	test('cancels when called during reslution', async () => {
+		const scheduler = ds.add(new ThreadStatusScheduler());
+		let innerCalled = false;
+
+		await scheduler.run(Promise.resolve().then(() => scheduler.cancel([1])).then(() => [1]), async () => {
+			innerCalled = true;
+		});
+
+		assert.strictEqual(innerCalled, false);
+	});
+
+	test('global cancels when called during reslution', async () => {
+		const scheduler = ds.add(new ThreadStatusScheduler());
+		let innerCalled = false;
+
+		await scheduler.run(Promise.resolve().then(() => scheduler.cancel(undefined)).then(() => [1]), async () => {
+			innerCalled = true;
+		});
+
+		assert.strictEqual(innerCalled, false);
+	});
+});


### PR DESCRIPTION
Previously we did not show a next-stepped state until the entire
stackframe was retrieved, which led to the issue this fixes #185708.
This queuing was done to prevent torn states in similar fast
transitions.

Rather than queuing, this PR uses a small 'scheduler' that uses a
cancellation token to abort any running operations on a per-thread basis.

![](https://memes.peet.io/img/23-11-815b4748-9b45-4b35-9e55-92937b22f4d1.gif)

I also noticed we didn't fully support `allThreadStopped`. I added
support for that as well.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
