### PR TITLE
Add debug settings for changing variable editor

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/debug.contribution.ts
+++ b/src/vs/workbench/contrib/debug/browser/debug.contribution.ts
@@ -595,6 +595,16 @@ configurationRegistry.registerConfiguration({
 			type: 'boolean',
 			markdownDescription: nls.localize({ comment: ['This is the description for a setting'], key: 'debug.hideLauncherWhileDebugging' }, "Hide 'Start Debugging' control in title bar of 'Run and Debug' view while debugging is active. Only relevant when `{0}` is not `docked`.", '#debug.toolBarLocation#'),
 			default: false
-		}
+		},
+		'debug.variableEditorExtensionId': {
+			type: 'string',
+			description: nls.localize('debug.variableEditorExtensionId', "ID of extension to use for viewing debug variables."),
+			default: 'ms-vscode.hexeditor'
+		},
+		'debug.variableEditorEditorId': {
+			type: 'string',
+			description: nls.localize('debug.variableEditorEditorId', "ID of editor to use for viewing debug variables."),
+			default: 'hexEditor.hexedit'
+		},
 	}
 });

--- a/src/vs/workbench/contrib/debug/common/debug.ts
+++ b/src/vs/workbench/contrib/debug/common/debug.ts
@@ -707,6 +707,8 @@ export interface IDebugConfiguration {
 	};
 	autoExpandLazyVariables: boolean;
 	enableStatusBarColor: boolean;
+	variableEditorExtensionId: string;
+	variableEditorEditorId: string;
 }
 
 export interface IGlobalConfig {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

With reference to #155597, this PR adds the ability to specify the extension and editor view to use for viewing and editing variables in the debugger.

This is a simple implementation to allow the user to choose a different extension rather than the hard-coded HexEdit extension.

While this works, I fully expect a better (and more complicated) approach would be to have some sort of capability offered by extensions which can be detected by VS Code to expose the options in a better way.

To test this, observe the extension ID and editor ID are exposed in the debug configuration and default to the current behaviour. These can be updated to match the details of the [eclipse.cdt-memory-inspector](https://marketplace.visualstudio.com/items?itemName=eclipse-cdt.memory-inspector) extension as follows:

- Variable Editor Editor ID: memory-inspector.inspect
- Variable Editor Extension ID: eclipse-cdt.memory-inspector

![Screenshot 2023-11-04 at 20 24 21](https://github.com/microsoft/vscode/assets/61341/3c7bbbc0-776a-4007-83c4-1040ad5358a6)

This extension has been [updated](https://github.com/eclipse-cdt-cloud/vscode-memory-inspector/pull/39) to use the same API as the HexEditor and should show as expected when selecting the `View Binary Data` button:

![Screenshot 2023-11-04 at 20 25 32](https://github.com/microsoft/vscode/assets/61341/f230752a-7240-424a-b939-1e392794cfe3)

The specified extension should be installed on demand if required.