### PR TITLE
Fix typo in chat code block action title

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/chatCodeblockActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatCodeblockActions.ts
@@ -353,8 +353,8 @@ export function registerChatCodeBlockActions() {
 			super({
 				id: 'workbench.action.chat.insertIntoNewFile',
 				title: {
-					value: localize('interactive.insertIntoNewFile.label', "Insert Into New File"),
-					original: 'Insert Into New File'
+					value: localize('interactive.insertIntoNewFile.label', "Insert into New File"),
+					original: 'Insert into New File'
 				},
 				precondition: CONTEXT_PROVIDER_EXISTS,
 				f1: true,


### PR DESCRIPTION
Corrected a typo in the title of the "Insert into New File" action in the chat code block. Changed "Insert Into New File" to "Insert into New File" for consistency.

Fixes https://github.com/microsoft/vscode/issues/197569