### PR TITLE
fix stack trace linking

### DIFF
--- a/extensions/notebook-renderers/src/stackTraceHelper.ts
+++ b/extensions/notebook-renderers/src/stackTraceHelper.ts
@@ -31,7 +31,7 @@ export function formatStackTrace(stack: string) {
 
 const formatSequence = /\u001b\[.+?m/g;
 const fileRegex = /File\s+(?:\u001b\[.+?m)?(.+):(\d+)/;
-const lineNumberRegex = /^((?:\u001b\[.+?m)?[ ->]*?)(\d+)(.*)/;
+const lineNumberRegex = /^((?:\u001b\[.+?m)?[ \->]+?)(\d+)(?:\u001b\[0m)?( .*)/;
 const cellRegex = /(?<prefix>Cell\s+(?:\u001b\[.+?m)?In\s*\[(?<executionCount>\d+)\],\s*)(?<lineLabel>line (?<lineNumber>\d+)).*/;
 // older versions of IPython ~8.3.0
 const inputRegex = /(?<prefix>Input\s+?(?:\u001b\[.+?m)(?<cellLabel>In\s*\[(?<executionCount>\d+)\]))(?<postfix>.*)/;

--- a/extensions/notebook-renderers/src/stackTraceHelper.ts
+++ b/extensions/notebook-renderers/src/stackTraceHelper.ts
@@ -31,7 +31,7 @@ export function formatStackTrace(stack: string) {
 
 const formatSequence = /\u001b\[.+?m/g;
 const fileRegex = /File\s+(?:\u001b\[.+?m)?(.+):(\d+)/;
-const lineNumberRegex = /((?:\u001b\[.+?m)?[ ->]*?)(\d+)(.*)/;
+const lineNumberRegex = /^((?:\u001b\[.+?m)?[ ->]*?)(\d+)(.*)/;
 const cellRegex = /(?<prefix>Cell\s+(?:\u001b\[.+?m)?In\s*\[(?<executionCount>\d+)\],\s*)(?<lineLabel>line (?<lineNumber>\d+)).*/;
 // older versions of IPython ~8.3.0
 const inputRegex = /(?<prefix>Input\s+?(?:\u001b\[.+?m)(?<cellLabel>In\s*\[(?<executionCount>\d+)\]))(?<postfix>.*)/;
@@ -41,7 +41,7 @@ function isIpythonStackTrace(stack: string) {
 }
 
 function stripFormatting(text: string) {
-	return text.replace(formatSequence, '');
+	return text.replace(formatSequence, '').trim();
 }
 
 type cellLocation = { kind: 'cell'; path: string };

--- a/extensions/notebook-renderers/src/test/stackTraceHelper.test.ts
+++ b/extensions/notebook-renderers/src/test/stackTraceHelper.test.ts
@@ -43,8 +43,6 @@ suite('StackTraceHelper', () => {
 		assert.ok(formatted.indexOf('<a href=\'C:\\venvs\\myLib.py:2\'>2</a>') > 0, 'Missing frame link in ' + formatted);
 	});
 
-
-
 	test('IPython stack line numbers are linkified for IPython 8.3', () => {
 		// stack frames within functions do not list the line number, i.e.
 		// 'Input In [1], in myfunc()' vs
@@ -93,7 +91,11 @@ suite('StackTraceHelper', () => {
 			'\u001b[1;36m  Cell \u001b[1;32mIn[6], line 1\u001b[1;36m\u001b[0m\n' +
 			'\u001b[1;33m    print(\u001b[0m\n' +
 			'\u001b[1;37m          ^\u001b[0m\n' +
-			'\u001b[1;31mSyntaxError\u001b[0m\u001b[1;31m:\u001b[0m incomplete input\n';
+			'\u001b[1;31mSyntaxError\u001b[0m\u001b[1;31m:\u001b[0m incomplete input\n' +
+			// contrived examples to check for more false positives
+			'1  print(\n' +
+			'a 1  print(\n' +
+			'   1a  print(\n';
 
 		const formattedLines = formatStackTrace(stack).split('\n');
 		assert.ok(/<a href='vscode-notebook-cell.*>/.test(formattedLines[0]), 'line should contain a link: ' + formattedLines[0]);

--- a/extensions/notebook-renderers/src/test/stackTraceHelper.test.ts
+++ b/extensions/notebook-renderers/src/test/stackTraceHelper.test.ts
@@ -88,4 +88,16 @@ suite('StackTraceHelper', () => {
 		assert.ok(!/<a href=.*>\d<\/a>/.test(formatted), formatted);
 	});
 
+	test('IPython stack without line numbers are not linkified', () => {
+		const stack =
+			'\u001b[1;36m  Cell \u001b[1;32mIn[6], line 1\u001b[1;36m\u001b[0m\n' +
+			'\u001b[1;33m    print(\u001b[0m\n' +
+			'\u001b[1;37m          ^\u001b[0m\n' +
+			'\u001b[1;31mSyntaxError\u001b[0m\u001b[1;31m:\u001b[0m incomplete input\n';
+
+		const formattedLines = formatStackTrace(stack).split('\n');
+		assert.ok(/<a href='vscode-notebook-cell.*>/.test(formattedLines[0]), 'line should contain a link: ' + formattedLines[0]);
+		formattedLines.slice(1).forEach(line => assert.ok(!/<a href=.*>/.test(line), 'line should not contain a link: ' + line));
+	});
+
 });


### PR DESCRIPTION
fix https://github.com/microsoft/vscode-jupyter/issues/14666

the line number regex was basically matching anything with a number within the string including the ASCII formatting characters that are always there.
