### PR TITLE
aria-hide search icon

### DIFF
--- a/src/vs/workbench/browser/parts/titlebar/commandCenterControl.ts
+++ b/src/vs/workbench/browser/parts/titlebar/commandCenterControl.ts
@@ -142,6 +142,7 @@ class CommandCenterCenterViewItem extends BaseActionViewItem {
 
 							// icon (search)
 							const searchIcon = document.createElement('span');
+							searchIcon.ariaHidden = 'true';
 							searchIcon.className = action.class ?? '';
 							searchIcon.classList.add('search-icon');
 


### PR DESCRIPTION
fix #197576

Added aria-hidden to the element to remove it from accessibility tree. This element has no accessible text but was reachable via VoiceOver on Mac (and then announced nothing). Now it will be skipped altogether (just like it is on Windows screen readers).