### PR TITLE
style: remove the default activity bar icon size

### DIFF
--- a/src/vs/workbench/browser/parts/media/paneCompositePart.css
+++ b/src/vs/workbench/browser/parts/media/paneCompositePart.css
@@ -53,10 +53,6 @@
 	padding: 0 5px;
 }
 
-.monaco-workbench .pane-composite-part > .title > .composite-bar-container >.composite-bar .monaco-action-bar .action-label.codicon {
-	font-size: 18px;
-}
-
 .monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon .action-label:not(.codicon) {
 	width: 16px;
 	height: 16px;


### PR DESCRIPTION
fix #197648

# before

![before](https://github.com/microsoft/vscode/assets/32186630/92859d89-a53b-452e-9f7a-4321425bdbdd)

# after

![after](https://github.com/microsoft/vscode/assets/32186630/4aa5b0b5-abc3-4515-bd77-2c2e590f01d1)