### PR TITLE
allow chat keybindings to be used by all

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/chatCodeblockActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatCodeblockActions.ts
@@ -436,6 +436,9 @@ export function registerChatCodeBlockActions() {
 				}],
 				keybinding: [{
 					primary: KeyMod.CtrlCmd | KeyMod.Alt | KeyCode.Enter,
+					mac: {
+						primary: KeyMod.WinCtrl | KeyMod.Alt | KeyCode.Enter
+					},
 					weight: KeybindingWeight.EditorContrib,
 					when: CONTEXT_IN_CHAT_SESSION,
 				}]

--- a/src/vs/workbench/contrib/chat/browser/actions/chatCodeblockActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatCodeblockActions.ts
@@ -18,7 +18,6 @@ import { ITextModel } from 'vs/editor/common/model';
 import { ILanguageFeaturesService } from 'vs/editor/common/services/languageFeatures';
 import { CopyAction } from 'vs/editor/contrib/clipboard/browser/clipboard';
 import { localize } from 'vs/nls';
-import { CONTEXT_ACCESSIBILITY_MODE_ENABLED } from 'vs/platform/accessibility/common/accessibility';
 import { Action2, MenuId, registerAction2 } from 'vs/platform/actions/common/actions';
 import { IClipboardService } from 'vs/platform/clipboard/common/clipboardService';
 import { ContextKeyExpr } from 'vs/platform/contextkey/common/contextkey';
@@ -196,7 +195,7 @@ export function registerChatCodeBlockActions() {
 					when: CONTEXT_IN_CHAT_SESSION,
 				},
 				keybinding: {
-					when: ContextKeyExpr.and(CONTEXT_IN_CHAT_SESSION, CONTEXT_ACCESSIBILITY_MODE_ENABLED),
+					when: CONTEXT_IN_CHAT_SESSION,
 					primary: KeyMod.CtrlCmd | KeyCode.Enter,
 					mac: { primary: KeyMod.WinCtrl | KeyCode.Enter },
 					weight: KeybindingWeight.WorkbenchContrib
@@ -437,17 +436,8 @@ export function registerChatCodeBlockActions() {
 				}],
 				keybinding: [{
 					primary: KeyMod.CtrlCmd | KeyMod.Alt | KeyCode.Enter,
-					mac: {
-						primary: KeyMod.WinCtrl | KeyCode.Enter,
-					},
 					weight: KeybindingWeight.EditorContrib,
-					when: ContextKeyExpr.and(CONTEXT_IN_CHAT_SESSION, CONTEXT_ACCESSIBILITY_MODE_ENABLED.negate()),
-				},
-				{
-					primary: KeyMod.CtrlCmd | KeyCode.Slash,
-					mac: { primary: KeyMod.WinCtrl | KeyCode.Slash },
-					weight: KeybindingWeight.WorkbenchContrib,
-					when: ContextKeyExpr.and(CONTEXT_IN_CHAT_SESSION, CONTEXT_ACCESSIBILITY_MODE_ENABLED),
+					when: CONTEXT_IN_CHAT_SESSION,
 				}]
 			});
 		}


### PR DESCRIPTION
Uses `ctrl+enter` for `Insert at Cursor` and `ctrl+alt+enter` for `Insert into Terminal` for all platforms.

fixes https://github.com/microsoft/vscode-copilot/issues/2556