### PR TITLE
resolve final newline regression for notebooks

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/contrib/saveParticipants/saveParticipants.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/saveParticipants/saveParticipants.ts
@@ -253,7 +253,10 @@ class FinalNewLineParticipant implements IStoredFileWorkingCopySaveParticipant {
 	) { }
 
 	async participate(workingCopy: IStoredFileWorkingCopy<IStoredFileWorkingCopyModel>, context: { reason: SaveReason }, progress: IProgress<IProgressStep>, _token: CancellationToken): Promise<void> {
-		if (this.configurationService.getValue('files.insertFinalNewline')) {
+		// waiting on notebook-specific override before this feature can sync with 'files.insertFinalNewline'
+		// if (this.configurationService.getValue('files.insertFinalNewline')) {
+
+		if (this.configurationService.getValue<boolean>(NotebookSetting.insertFinalNewline)) {
 			await this.doInsertFinalNewLine(workingCopy, context.reason === SaveReason.AUTO, progress);
 		}
 	}

--- a/src/vs/workbench/contrib/notebook/browser/notebook.contribution.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebook.contribution.ts
@@ -964,6 +964,12 @@ configurationRegistry.registerConfiguration({
 			tags: ['notebookLayout'],
 			default: false
 		},
+		[NotebookSetting.insertFinalNewline]: {
+			markdownDescription: nls.localize('notebook.insertFinalNewline', "When enabled, insert a final new line into the end of code cells when saving a notebook."),
+			type: 'boolean',
+			tags: ['notebookLayout'],
+			default: false
+		},
 		[NotebookSetting.codeActionsOnSave]: {
 			markdownDescription: nls.localize('notebook.codeActionsOnSave', 'Run a series of Code Actions for a notebook on save. Code Actions must be specified, the file must not be saved after delay, and the editor must not be shutting down. Example: `"notebook.source.organizeImports": "explicit"`'),
 			type: 'object',
@@ -1044,5 +1050,3 @@ configurationRegistry.registerConfiguration({
 		}
 	}
 });
-
-

--- a/src/vs/workbench/contrib/notebook/common/notebookCommon.ts
+++ b/src/vs/workbench/contrib/notebook/common/notebookCommon.ts
@@ -950,6 +950,7 @@ export const NotebookSetting = {
 	outputScrolling: 'notebook.output.scrolling',
 	textOutputLineLimit: 'notebook.output.textLineLimit',
 	formatOnSave: 'notebook.formatOnSave.enabled',
+	insertFinalNewline: 'notebook.insertFinalNewline',
 	formatOnCellExecution: 'notebook.formatOnCellExecution',
 	codeActionsOnSave: 'notebook.codeActionsOnSave',
 	outputWordWrap: 'notebook.output.wordWrap',


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Re: #195011, #195223

Separate the insert final newline behavior into a separate setting for notebooks. Temporary until there is a possibility of a notebook specific setting override.

Setting JSON: `"notebook.insertFinalNewline": false`
