### PR TITLE
terminal: allow the find widget to work in detached terminals

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminal.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminal.ts
@@ -150,14 +150,65 @@ export interface IDetachedXTermOptions {
 }
 
 /**
+ * A generic interface implemented in both the {@link ITerminalInstance} (an
+ * interface used for terminals attached to the terminal panel or editor) and
+ * {@link IDetachedTerminalInstance} (a terminal used elsewhere in VS Code UI).
+ */
+export interface IAnyTerminalInstance {
+	readonly capabilities: ITerminalCapabilityStore;
+
+	/**
+	 * DOM element the terminal is mounted in.
+	 */
+	readonly domElement?: HTMLElement;
+
+	/**
+	 * Current selection in the terminal.
+	 */
+	readonly selection: string | undefined;
+
+	/**
+	 * Check if anything is selected in terminal.
+	 */
+	hasSelection(): boolean;
+
+	/**
+	 * Clear current selection.
+	 */
+	clearSelection(): void;
+
+	/**
+	 * Focuses the terminal instance if it's able to (the xterm.js instance must exist).
+	 *
+	 * @param force Force focus even if there is a selection.
+	 */
+	focus(force?: boolean): void;
+
+	/**
+	 * Force the scroll bar to be visible until {@link resetScrollbarVisibility} is called.
+	 */
+	forceScrollbarVisibility(): void;
+
+	/**
+	 * Resets the scroll bar to only be visible when needed, this does nothing unless
+	 * {@link forceScrollbarVisibility} was called.
+	 */
+	resetScrollbarVisibility(): void;
+
+	/**
+	 * Gets a terminal contribution by its ID.
+	 */
+	getContribution<T extends ITerminalContribution>(id: string): T | null;
+}
+
+/**
  * A {@link ITerminalInstance}-like object that emulates a subset of
  * capabilities. This instance is returned from {@link ITerminalService.createDetachedTerminal}
  * to represent terminals that appear in other parts of the VS Code UI outside
  * of the "Terminal" view or editors.
  */
-export interface IDetachedTerminalInstance extends IDisposable {
+export interface IDetachedTerminalInstance extends IDisposable, IAnyTerminalInstance {
 	readonly xterm: IDetachedXtermTerminal;
-	readonly capabilities: ITerminalCapabilityStore;
 
 	/**
 	 * Attached the terminal to the given element. This should be preferred over
@@ -178,7 +229,7 @@ export interface ITerminalService extends ITerminalInstanceHost {
 	/** Gets all terminal instances, including editor and terminal view (group) instances. */
 	readonly instances: readonly ITerminalInstance[];
 	/** Gets detached terminal instances created via {@link createDetachedXterm}. */
-	readonly detachedXterms: Iterable<IXtermTerminal>;
+	readonly detachedInstances: Iterable<IDetachedTerminalInstance>;
 	readonly configHelper: ITerminalConfigHelper;
 	readonly defaultLocation: TerminalLocation;
 
@@ -478,7 +529,7 @@ export interface ISearchOptions {
 	incremental?: boolean;
 }
 
-export interface ITerminalInstance {
+export interface ITerminalInstance extends IAnyTerminalInstance {
 	/**
 	 * The ID of the terminal instance, this is an arbitrary number only used to uniquely identify
 	 * terminal instances within a window.
@@ -510,7 +561,6 @@ export interface ITerminalInstance {
 	readonly cwd?: string;
 	readonly initialCwd?: string;
 	readonly os?: OperatingSystem;
-	readonly capabilities: ITerminalCapabilityStore;
 	readonly usedShellIntegrationInjection: boolean;
 	readonly injectedArgs: string[] | undefined;
 	readonly extEnvironmentVariableCollection: IMergedEnvironmentVariableCollection | undefined;
@@ -750,37 +800,15 @@ export interface ITerminalInstance {
 	detachProcessAndDispose(reason: TerminalExitReason): Promise<void>;
 
 	/**
-	 * Check if anything is selected in terminal.
-	 */
-	hasSelection(): boolean;
-
-	/**
 	 * Copies the terminal selection to the clipboard.
 	 */
 	copySelection(asHtml?: boolean, command?: ITerminalCommand): Promise<void>;
-
-	/**
-	 * Current selection in the terminal.
-	 */
-	readonly selection: string | undefined;
-
-	/**
-	 * Clear current selection.
-	 */
-	clearSelection(): void;
 
 	/**
 	 * When the panel is hidden or a terminal in the editor area becomes inactive, reset the focus context key
 	 * to avoid issues like #147180.
 	 */
 	resetFocusContextKey(): void;
-
-	/**
-	 * Focuses the terminal instance if it's able to (the xterm.js instance must exist).
-	 *
-	 * @param force Force focus even if there is a selection.
-	 */
-	focus(force?: boolean): void;
 
 	/**
 	 * Focuses the terminal instance when it's ready (the xterm.js instance much exist). This is the
@@ -977,22 +1005,6 @@ export interface ITerminalInstance {
 	 * Hides the suggest widget.
 	 */
 	hideSuggestWidget(): void;
-
-	/**
-	 * Force the scroll bar to be visible until {@link resetScrollbarVisibility} is called.
-	 */
-	forceScrollbarVisibility(): void;
-
-	/**
-	 * Resets the scroll bar to only be visible when needed, this does nothing unless
-	 * {@link forceScrollbarVisibility} was called.
-	 */
-	resetScrollbarVisibility(): void;
-
-	/**
-	 * Gets a terminal contribution by its ID.
-	 */
-	getContribution<T extends ITerminalContribution>(id: string): T | null;
 }
 
 export const enum XtermTerminalConstants {

--- a/src/vs/workbench/contrib/terminal/browser/terminal.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminal.ts
@@ -154,7 +154,7 @@ export interface IDetachedXTermOptions {
  * interface used for terminals attached to the terminal panel or editor) and
  * {@link IDetachedTerminalInstance} (a terminal used elsewhere in VS Code UI).
  */
-export interface IAnyTerminalInstance {
+export interface IBaseTerminalInstance {
 	readonly capabilities: ITerminalCapabilityStore;
 
 	/**
@@ -207,7 +207,7 @@ export interface IAnyTerminalInstance {
  * to represent terminals that appear in other parts of the VS Code UI outside
  * of the "Terminal" view or editors.
  */
-export interface IDetachedTerminalInstance extends IDisposable, IAnyTerminalInstance {
+export interface IDetachedTerminalInstance extends IDisposable, IBaseTerminalInstance {
 	readonly xterm: IDetachedXtermTerminal;
 
 	/**
@@ -529,7 +529,7 @@ export interface ISearchOptions {
 	incremental?: boolean;
 }
 
-export interface ITerminalInstance extends IAnyTerminalInstance {
+export interface ITerminalInstance extends IBaseTerminalInstance {
 	/**
 	 * The ID of the terminal instance, this is an arbitrary number only used to uniquely identify
 	 * terminal instances within a window.

--- a/src/vs/workbench/contrib/terminal/browser/terminalActions.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalActions.ts
@@ -32,7 +32,7 @@ import { IWorkspaceContextService, IWorkspaceFolder } from 'vs/platform/workspac
 import { PICK_WORKSPACE_FOLDER_COMMAND_ID } from 'vs/workbench/browser/actions/workspaceCommands';
 import { CLOSE_EDITOR_COMMAND_ID } from 'vs/workbench/browser/parts/editor/editorCommands';
 import { ResourceContextKey } from 'vs/workbench/common/contextkeys';
-import { Direction, ICreateTerminalOptions, ITerminalEditorService, ITerminalGroupService, ITerminalInstance, ITerminalInstanceService, ITerminalService, IXtermTerminal } from 'vs/workbench/contrib/terminal/browser/terminal';
+import { Direction, ICreateTerminalOptions, IDetachedTerminalInstance, ITerminalEditorService, ITerminalGroupService, ITerminalInstance, ITerminalInstanceService, ITerminalService, IXtermTerminal } from 'vs/workbench/contrib/terminal/browser/terminal';
 import { TerminalQuickAccessProvider } from 'vs/workbench/contrib/terminal/browser/terminalQuickAccess';
 import { IRemoteTerminalAttachTarget, ITerminalConfigHelper, ITerminalProfileResolverService, ITerminalProfileService, TerminalCommandId } from 'vs/workbench/contrib/terminal/common/terminal';
 import { TerminalContextKeys } from 'vs/workbench/contrib/terminal/common/terminalContextKey';
@@ -251,15 +251,15 @@ export function registerActiveInstanceAction(
  * This includes detached xterm terminals that are not managed by an {@link ITerminalInstance}.
  */
 export function registerActiveXtermAction(
-	options: IAction2Options & { run: (activeTerminal: IXtermTerminal, accessor: ServicesAccessor, instance?: ITerminalInstance, args?: unknown) => void | Promise<unknown> }
+	options: IAction2Options & { run: (activeTerminal: IXtermTerminal, accessor: ServicesAccessor, instance: ITerminalInstance | IDetachedTerminalInstance, args?: unknown) => void | Promise<unknown> }
 ): IDisposable {
 	const originalRun = options.run;
 	return registerTerminalAction({
 		...options,
 		run: (c, accessor, args) => {
-			const activeDetached = Iterable.find(c.service.detachedXterms, d => d.isFocused);
+			const activeDetached = Iterable.find(c.service.detachedInstances, d => d.xterm.isFocused);
 			if (activeDetached) {
-				return originalRun(activeDetached, accessor, undefined, args);
+				return originalRun(activeDetached.xterm, accessor, activeDetached, args);
 			}
 
 			const activeInstance = c.service.activeInstance;

--- a/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
@@ -88,7 +88,6 @@ import { ISimpleSelectedSuggestion } from 'vs/workbench/services/suggest/browser
 import type { IMarker, Terminal as XTermTerminal } from '@xterm/xterm';
 import { AccessibilityCommandId } from 'vs/workbench/contrib/accessibility/common/accessibilityCommands';
 import { terminalStrings } from 'vs/workbench/contrib/terminal/common/terminalStrings';
-import { $window } from 'vs/base/browser/window';
 
 const enum Constants {
 	/**
@@ -1211,7 +1210,7 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 		if (!this.xterm) {
 			return;
 		}
-		if (force || !$window.getSelection()?.toString()) {
+		if (force || !dom.getActiveWindow().getSelection()?.toString()) {
 			this.xterm.raw.focus();
 			this._onDidRequestFocus.fire();
 		}

--- a/src/vs/workbench/contrib/terminalContrib/find/browser/terminal.find.contribution.ts
+++ b/src/vs/workbench/contrib/terminalContrib/find/browser/terminal.find.contribution.ts
@@ -28,7 +28,7 @@ class TerminalFindContribution extends Disposable implements ITerminalContributi
 	 * Currently focused find widget. This is used to track action context since
 	 * 'active terminals' are only tracked for non-detached terminal instanecs.
 	 */
-	static activeFindWidget: TerminalFindContribution | null = null;
+	static activeFindWidget?: TerminalFindContribution;
 
 	static get(instance: ITerminalInstance | IDetachedTerminalInstance): TerminalFindContribution | null {
 		return instance.getContribution<TerminalFindContribution>(TerminalFindContribution.ID);
@@ -60,7 +60,7 @@ class TerminalFindContribution extends Disposable implements ITerminalContributi
 				}
 			});
 			findWidget.focusTracker.onDidBlur(() => {
-				TerminalFindContribution.activeFindWidget = null;
+				TerminalFindContribution.activeFindWidget = undefined;
 				this._instance.resetScrollbarVisibility();
 			});
 
@@ -88,7 +88,7 @@ class TerminalFindContribution extends Disposable implements ITerminalContributi
 
 	override dispose() {
 		if (TerminalFindContribution.activeFindWidget === this) {
-			TerminalFindContribution.activeFindWidget = null;
+			TerminalFindContribution.activeFindWidget = undefined;
 		}
 		super.dispose();
 		this._findWidget.rawValue?.dispose();

--- a/src/vs/workbench/contrib/terminalContrib/find/browser/terminal.find.contribution.ts
+++ b/src/vs/workbench/contrib/terminalContrib/find/browser/terminal.find.contribution.ts
@@ -12,11 +12,11 @@ import { ContextKeyExpr } from 'vs/platform/contextkey/common/contextkey';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { KeybindingWeight } from 'vs/platform/keybinding/common/keybindingsRegistry';
 import { findInFilesCommand } from 'vs/workbench/contrib/search/browser/searchActionsFind';
-import { ITerminalContribution, ITerminalInstance, ITerminalService, IXtermTerminal } from 'vs/workbench/contrib/terminal/browser/terminal';
-import { registerActiveInstanceAction } from 'vs/workbench/contrib/terminal/browser/terminalActions';
+import { IDetachedTerminalInstance, ITerminalContribution, ITerminalInstance, ITerminalService, IXtermTerminal, isDetachedTerminalInstance } from 'vs/workbench/contrib/terminal/browser/terminal';
+import { registerActiveInstanceAction, registerActiveXtermAction } from 'vs/workbench/contrib/terminal/browser/terminalActions';
 import { registerTerminalContribution } from 'vs/workbench/contrib/terminal/browser/terminalExtensions';
 import { TerminalWidgetManager } from 'vs/workbench/contrib/terminal/browser/widgets/widgetManager';
-import { ITerminalProcessManager, TerminalCommandId } from 'vs/workbench/contrib/terminal/common/terminal';
+import { ITerminalProcessInfo, ITerminalProcessManager, TerminalCommandId } from 'vs/workbench/contrib/terminal/common/terminal';
 import { TerminalContextKeys } from 'vs/workbench/contrib/terminal/common/terminalContextKey';
 import { TerminalFindWidget } from 'vs/workbench/contrib/terminalContrib/find/browser/terminalFindWidget';
 import type { Terminal as RawXtermTerminal } from '@xterm/xterm';
@@ -24,7 +24,13 @@ import type { Terminal as RawXtermTerminal } from '@xterm/xterm';
 class TerminalFindContribution extends Disposable implements ITerminalContribution {
 	static readonly ID = 'terminal.find';
 
-	static get(instance: ITerminalInstance): TerminalFindContribution | null {
+	/**
+	 * Currently focused find widget. This is used to track action context since
+	 * 'active terminals' are only tracked for non-detached terminal instanecs.
+	 */
+	static activeFindWidget: TerminalFindContribution | null = null;
+
+	static get(instance: ITerminalInstance | IDetachedTerminalInstance): TerminalFindContribution | null {
 		return instance.getContribution<TerminalFindContribution>(TerminalFindContribution.ID);
 	}
 
@@ -34,8 +40,8 @@ class TerminalFindContribution extends Disposable implements ITerminalContributi
 	get findWidget(): TerminalFindWidget { return this._findWidget.value; }
 
 	constructor(
-		private readonly _instance: ITerminalInstance,
-		processManager: ITerminalProcessManager,
+		private readonly _instance: ITerminalInstance | IDetachedTerminalInstance,
+		processManager: ITerminalProcessManager | ITerminalProcessInfo,
 		widgetManager: TerminalWidgetManager,
 		@IInstantiationService instantiationService: IInstantiationService,
 		@ITerminalService terminalService: ITerminalService
@@ -47,14 +53,22 @@ class TerminalFindContribution extends Disposable implements ITerminalContributi
 
 			// Track focus and set state so we can force the scroll bar to be visible
 			findWidget.focusTracker.onDidFocus(() => {
+				TerminalFindContribution.activeFindWidget = this;
 				this._instance.forceScrollbarVisibility();
-				terminalService.setActiveInstance(this._instance);
+				if (!isDetachedTerminalInstance(this._instance)) {
+					terminalService.setActiveInstance(this._instance);
+				}
 			});
 			findWidget.focusTracker.onDidBlur(() => {
+				TerminalFindContribution.activeFindWidget = null;
 				this._instance.resetScrollbarVisibility();
 			});
 
-			this._instance.domElement.appendChild(findWidget.getDomNode());
+			if (!this._instance.domElement) {
+				throw new Error('FindWidget expected terminal DOM to be initialized');
+			}
+
+			this._instance.domElement?.appendChild(findWidget.getDomNode());
 			if (this._lastLayoutDimensions) {
 				findWidget.layout(this._lastLayoutDimensions.width);
 			}
@@ -63,7 +77,7 @@ class TerminalFindContribution extends Disposable implements ITerminalContributi
 		});
 	}
 
-	layout(xterm: IXtermTerminal & { raw: RawXtermTerminal }, dimension: IDimension): void {
+	layout(_xterm: IXtermTerminal & { raw: RawXtermTerminal }, dimension: IDimension): void {
 		this._lastLayoutDimensions = dimension;
 		this._findWidget.rawValue?.layout(dimension.width);
 	}
@@ -73,98 +87,106 @@ class TerminalFindContribution extends Disposable implements ITerminalContributi
 	}
 
 	override dispose() {
+		if (TerminalFindContribution.activeFindWidget === this) {
+			TerminalFindContribution.activeFindWidget = null;
+		}
 		super.dispose();
 		this._findWidget.rawValue?.dispose();
 	}
 
 }
-registerTerminalContribution(TerminalFindContribution.ID, TerminalFindContribution);
+registerTerminalContribution(TerminalFindContribution.ID, TerminalFindContribution, true);
 
-registerActiveInstanceAction({
+registerActiveXtermAction({
 	id: TerminalCommandId.FindFocus,
 	title: { value: localize('workbench.action.terminal.focusFind', "Focus Find"), original: 'Focus Find' },
 	keybinding: {
 		primary: KeyMod.CtrlCmd | KeyCode.KeyF,
-		when: ContextKeyExpr.or(TerminalContextKeys.findFocus, TerminalContextKeys.focus),
+		when: ContextKeyExpr.or(TerminalContextKeys.findFocus, TerminalContextKeys.focusInAny),
 		weight: KeybindingWeight.WorkbenchContrib
 	},
 	precondition: ContextKeyExpr.or(TerminalContextKeys.processSupported, TerminalContextKeys.terminalHasBeenCreated),
-	run: (activeInstance) => {
-		TerminalFindContribution.get(activeInstance)?.findWidget.reveal();
+	run: (_xterm, _accessor, activeInstance) => {
+		const contr = TerminalFindContribution.activeFindWidget || TerminalFindContribution.get(activeInstance);
+		contr?.findWidget.reveal();
 	}
 });
 
-registerActiveInstanceAction({
+registerActiveXtermAction({
 	id: TerminalCommandId.FindHide,
 	title: { value: localize('workbench.action.terminal.hideFind', "Hide Find"), original: 'Hide Find' },
 	keybinding: {
 		primary: KeyCode.Escape,
 		secondary: [KeyMod.Shift | KeyCode.Escape],
-		when: ContextKeyExpr.and(TerminalContextKeys.focus, TerminalContextKeys.findVisible),
+		when: ContextKeyExpr.and(TerminalContextKeys.focusInAny, TerminalContextKeys.findVisible),
 		weight: KeybindingWeight.WorkbenchContrib
 	},
 	precondition: ContextKeyExpr.or(TerminalContextKeys.processSupported, TerminalContextKeys.terminalHasBeenCreated),
-	run: (activeInstance) => {
-		TerminalFindContribution.get(activeInstance)?.findWidget.hide();
+	run: (_xterm, _accessor, activeInstance) => {
+		const contr = TerminalFindContribution.activeFindWidget || TerminalFindContribution.get(activeInstance);
+		contr?.findWidget.hide();
 	}
 });
 
-registerActiveInstanceAction({
+registerActiveXtermAction({
 	id: TerminalCommandId.ToggleFindRegex,
 	title: { value: localize('workbench.action.terminal.toggleFindRegex', "Toggle Find Using Regex"), original: 'Toggle Find Using Regex' },
 	keybinding: {
 		primary: KeyMod.Alt | KeyCode.KeyR,
 		mac: { primary: KeyMod.CtrlCmd | KeyMod.Alt | KeyCode.KeyR },
-		when: ContextKeyExpr.or(TerminalContextKeys.focus, TerminalContextKeys.findFocus),
+		when: ContextKeyExpr.or(TerminalContextKeys.focusInAny, TerminalContextKeys.findFocus),
 		weight: KeybindingWeight.WorkbenchContrib
 	},
 	precondition: ContextKeyExpr.or(TerminalContextKeys.processSupported, TerminalContextKeys.terminalHasBeenCreated),
-	run: (activeInstance) => {
-		const state = TerminalFindContribution.get(activeInstance)?.findWidget.state;
+	run: (_xterm, _accessor, activeInstance) => {
+		const contr = TerminalFindContribution.activeFindWidget || TerminalFindContribution.get(activeInstance);
+		const state = contr?.findWidget.state;
 		state?.change({ isRegex: !state.isRegex }, false);
 	}
 });
 
-registerActiveInstanceAction({
+registerActiveXtermAction({
 	id: TerminalCommandId.ToggleFindWholeWord,
 	title: { value: localize('workbench.action.terminal.toggleFindWholeWord', "Toggle Find Using Whole Word"), original: 'Toggle Find Using Whole Word' },
 	keybinding: {
 		primary: KeyMod.Alt | KeyCode.KeyW,
 		mac: { primary: KeyMod.CtrlCmd | KeyMod.Alt | KeyCode.KeyW },
-		when: ContextKeyExpr.or(TerminalContextKeys.focus, TerminalContextKeys.findFocus),
+		when: ContextKeyExpr.or(TerminalContextKeys.focusInAny, TerminalContextKeys.findFocus),
 		weight: KeybindingWeight.WorkbenchContrib
 	},
 	precondition: ContextKeyExpr.or(TerminalContextKeys.processSupported, TerminalContextKeys.terminalHasBeenCreated),
-	run: (activeInstance) => {
-		const state = TerminalFindContribution.get(activeInstance)?.findWidget.state;
+	run: (_xterm, _accessor, activeInstance) => {
+		const contr = TerminalFindContribution.activeFindWidget || TerminalFindContribution.get(activeInstance);
+		const state = contr?.findWidget.state;
 		state?.change({ wholeWord: !state.wholeWord }, false);
 	}
 });
 
-registerActiveInstanceAction({
+registerActiveXtermAction({
 	id: TerminalCommandId.ToggleFindCaseSensitive,
 	title: { value: localize('workbench.action.terminal.toggleFindCaseSensitive', "Toggle Find Using Case Sensitive"), original: 'Toggle Find Using Case Sensitive' },
 	keybinding: {
 		primary: KeyMod.Alt | KeyCode.KeyC,
 		mac: { primary: KeyMod.CtrlCmd | KeyMod.Alt | KeyCode.KeyC },
-		when: ContextKeyExpr.or(TerminalContextKeys.focus, TerminalContextKeys.findFocus),
+		when: ContextKeyExpr.or(TerminalContextKeys.focusInAny, TerminalContextKeys.findFocus),
 		weight: KeybindingWeight.WorkbenchContrib
 	},
 	precondition: ContextKeyExpr.or(TerminalContextKeys.processSupported, TerminalContextKeys.terminalHasBeenCreated),
-	run: (activeInstance) => {
-		const state = TerminalFindContribution.get(activeInstance)?.findWidget.state;
+	run: (_xterm, _accessor, activeInstance) => {
+		const contr = TerminalFindContribution.activeFindWidget || TerminalFindContribution.get(activeInstance);
+		const state = contr?.findWidget.state;
 		state?.change({ matchCase: !state.matchCase }, false);
 	}
 });
 
-registerActiveInstanceAction({
+registerActiveXtermAction({
 	id: TerminalCommandId.FindNext,
 	title: { value: localize('workbench.action.terminal.findNext', "Find Next"), original: 'Find Next' },
 	keybinding: [
 		{
 			primary: KeyCode.F3,
 			mac: { primary: KeyMod.CtrlCmd | KeyCode.KeyG, secondary: [KeyCode.F3] },
-			when: ContextKeyExpr.or(TerminalContextKeys.focus, TerminalContextKeys.findFocus),
+			when: ContextKeyExpr.or(TerminalContextKeys.focusInAny, TerminalContextKeys.findFocus),
 			weight: KeybindingWeight.WorkbenchContrib
 		},
 		{
@@ -174,8 +196,9 @@ registerActiveInstanceAction({
 		}
 	],
 	precondition: ContextKeyExpr.or(TerminalContextKeys.processSupported, TerminalContextKeys.terminalHasBeenCreated),
-	run: (activeInstance) => {
-		const widget = TerminalFindContribution.get(activeInstance)?.findWidget;
+	run: (_xterm, _accessor, activeInstance) => {
+		const contr = TerminalFindContribution.activeFindWidget || TerminalFindContribution.get(activeInstance);
+		const widget = contr?.findWidget;
 		if (widget) {
 			widget.show();
 			widget.find(false);
@@ -183,14 +206,14 @@ registerActiveInstanceAction({
 	}
 });
 
-registerActiveInstanceAction({
+registerActiveXtermAction({
 	id: TerminalCommandId.FindPrevious,
 	title: { value: localize('workbench.action.terminal.findPrevious', "Find Previous"), original: 'Find Previous' },
 	keybinding: [
 		{
 			primary: KeyMod.Shift | KeyCode.F3,
 			mac: { primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KeyG, secondary: [KeyMod.Shift | KeyCode.F3] },
-			when: ContextKeyExpr.or(TerminalContextKeys.focus, TerminalContextKeys.findFocus),
+			when: ContextKeyExpr.or(TerminalContextKeys.focusInAny, TerminalContextKeys.findFocus),
 			weight: KeybindingWeight.WorkbenchContrib
 		},
 		{
@@ -200,8 +223,9 @@ registerActiveInstanceAction({
 		}
 	],
 	precondition: ContextKeyExpr.or(TerminalContextKeys.processSupported, TerminalContextKeys.terminalHasBeenCreated),
-	run: (activeInstance) => {
-		const widget = TerminalFindContribution.get(activeInstance)?.findWidget;
+	run: (_xterm, _accessor, activeInstance) => {
+		const contr = TerminalFindContribution.activeFindWidget || TerminalFindContribution.get(activeInstance);
+		const widget = contr?.findWidget;
 		if (widget) {
 			widget.show();
 			widget.find(true);

--- a/src/vs/workbench/contrib/terminalContrib/find/browser/terminalFindWidget.ts
+++ b/src/vs/workbench/contrib/terminalContrib/find/browser/terminalFindWidget.ts
@@ -6,7 +6,7 @@
 import { SimpleFindWidget } from 'vs/workbench/contrib/codeEditor/browser/find/simpleFindWidget';
 import { IContextViewService } from 'vs/platform/contextview/browser/contextView';
 import { IContextKeyService, IContextKey } from 'vs/platform/contextkey/common/contextkey';
-import { ITerminalInstance, IXtermTerminal, XtermTerminalConstants } from 'vs/workbench/contrib/terminal/browser/terminal';
+import { IDetachedTerminalInstance, ITerminalInstance, IXtermTerminal, XtermTerminalConstants } from 'vs/workbench/contrib/terminal/browser/terminal';
 import { TerminalContextKeys } from 'vs/workbench/contrib/terminal/common/terminalContextKey';
 import { IThemeService } from 'vs/platform/theme/common/themeService';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
@@ -23,7 +23,7 @@ export class TerminalFindWidget extends SimpleFindWidget {
 	private _findWidgetVisible: IContextKey<boolean>;
 
 	constructor(
-		private _instance: ITerminalInstance,
+		private _instance: ITerminalInstance | IDetachedTerminalInstance,
 		@IContextViewService _contextViewService: IContextViewService,
 		@IKeybindingService keybindingService: IKeybindingService,
 		@IContextKeyService private readonly _contextKeyService: IContextKeyService,


### PR DESCRIPTION
- Abstracts some methods to an `IAnyTerminalInstance` interface that
  is common between attached and detached terminal instances.
- Some minor changes in the find contribution to make it work with
  detached instances after that.
- Make the find widget track the `activeFindWidget` since commands
  previously depended on the active terminal, which is not tracked for
	detached terminals (the alternative would be making the active
	terminal instance tracker also track detached terminals)

And then it 'just works' in the test results terminal

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
