### PR TITLE
Get folded ranges

### DIFF
--- a/src/vs/editor/contrib/folding/browser/folding.ts
+++ b/src/vs/editor/contrib/folding/browser/folding.ts
@@ -1221,21 +1221,14 @@ for (let i = 1; i <= 7; i++) {
 }
 
 CommandsRegistry.registerCommand('_getFoldedRanges', async function (accessor, ...args) {
-	const [resource] = args;
-	if (!(resource instanceof URI)) {
-		throw illegalArgument();
-	}
-
 	const codeEditorService = accessor.get(ICodeEditorService);
-	const codeEditorsList = codeEditorService.listCodeEditors();
-
-	const editors = codeEditorsList.filter((value) => value.getModel()?.uri.toString() === resource.toString());
-	if (editors.length !== 1) {
+	const editor = codeEditorService.getFocusedCodeEditor();
+	if (!editor) {
 		return undefined;
 	}
 
 
-	const foldingController = FoldingController.get(editors[0]);
+	const foldingController = FoldingController.get(editor);
 	if (!foldingController) {
 		return undefined;
 	}
@@ -1243,6 +1236,7 @@ CommandsRegistry.registerCommand('_getFoldedRanges', async function (accessor, .
 	const foldingModelPromise = foldingController.getFoldingModel();
 	if (!foldingModelPromise) {
 		return undefined;
+
 	}
 
 	const foldingModel = await foldingModelPromise;

--- a/src/vs/editor/contrib/folding/browser/folding.ts
+++ b/src/vs/editor/contrib/folding/browser/folding.ts
@@ -41,6 +41,7 @@ import { CommandsRegistry } from 'vs/platform/commands/common/commands';
 import { URI } from 'vs/base/common/uri';
 import { IModelService } from 'vs/editor/common/services/model';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
+import { ICodeEditorService } from 'vs/editor/browser/services/codeEditorService';
 
 const CONTEXT_FOLDING_ENABLED = new RawContextKey<boolean>('foldingEnabled', false);
 
@@ -1218,6 +1219,45 @@ for (let i = 1; i <= 7; i++) {
 		})
 	);
 }
+
+CommandsRegistry.registerCommand('_getFoldedRanges', async function (accessor, ...args) {
+	const [resource] = args;
+	if (!(resource instanceof URI)) {
+		throw illegalArgument();
+	}
+
+	const codeEditorService = accessor.get(ICodeEditorService);
+	const codeEditorsList = codeEditorService.listCodeEditors();
+
+	const editors = codeEditorsList.filter((value) => value.getModel()?.uri.toString() === resource.toString());
+	if (editors.length !== 1) {
+		return undefined;
+	}
+
+
+	const foldingController = FoldingController.get(editors[0]);
+	if (!foldingController) {
+		return undefined;
+	}
+
+	const foldingModelPromise = foldingController.getFoldingModel();
+	if (!foldingModelPromise) {
+		return undefined;
+	}
+
+	const foldingModel = await foldingModelPromise;
+	if (!foldingModel) {
+		return undefined;
+	}
+
+	const ranges = foldingModel.regions.getCollapsedRanges();
+	const result: FoldingRange[] = [];
+	ranges.forEach((range) => {
+		result.push({ start: range[0], end: range[1] });
+	});
+	return result;
+});
+
 
 CommandsRegistry.registerCommand('_executeFoldingRangeProvider', async function (accessor, ...args) {
 	const [resource] = args;

--- a/src/vs/editor/contrib/folding/browser/foldingRanges.ts
+++ b/src/vs/editor/contrib/folding/browser/foldingRanges.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+
 export interface ILineRange {
 	startLineNumber: number;
 	endLineNumber: number;
@@ -243,6 +244,18 @@ export class FoldingRegions {
 			res[i] = `[${foldSourceAbbr[this.getSource(i)]}${this.isCollapsed(i) ? '+' : '-'}] ${this.getStartLineNumber(i)}/${this.getEndLineNumber(i)}`;
 		}
 		return res.join(', ');
+	}
+
+	public getCollapsedRanges(): [number, number][] {
+		const res: [number, number][] = [];
+		for (let i = 0; i < this.length; i++) {
+			if (!this.isCollapsed(i)) {
+				continue;
+			}
+
+			res.push([this.getStartLineNumber(i), this.getEndLineNumber(i)]);
+		}
+		return res;
 	}
 
 	public toFoldRange(index: number): FoldRange {

--- a/src/vs/workbench/api/common/extHostApiCommands.ts
+++ b/src/vs/workbench/api/common/extHostApiCommands.ts
@@ -353,7 +353,7 @@ const newCommands: ApiCommand[] = [
 
 	new ApiCommand(
 		'vscode.getFoldedRanges', '_getFoldedRanges', 'Get folded ranges',
-		[ApiCommandArgument.Uri],
+		[],
 		new ApiCommandResult<languages.FoldingRange[] | undefined, vscode.FoldingRange[] | undefined>('A promise that resolves to an array of FoldingRange objects', (result, args) => {
 			if (result) {
 				return result.map(typeConverters.FoldingRange.to);

--- a/src/vs/workbench/api/common/extHostApiCommands.ts
+++ b/src/vs/workbench/api/common/extHostApiCommands.ts
@@ -351,6 +351,17 @@ const newCommands: ApiCommand[] = [
 		})
 	),
 
+	new ApiCommand(
+		'vscode.getFoldedRanges', '_getFoldedRanges', 'Get folded ranges',
+		[ApiCommandArgument.Uri],
+		new ApiCommandResult<languages.FoldingRange[] | undefined, vscode.FoldingRange[] | undefined>('A promise that resolves to an array of FoldingRange objects', (result, args) => {
+			if (result) {
+				return result.map(typeConverters.FoldingRange.to);
+			}
+			return undefined;
+		})
+	),
+
 	// --- notebooks
 	new ApiCommand(
 		'vscode.resolveNotebookContentProviders', '_resolveNotebookContentProvider', 'Resolve Notebook Content Providers',


### PR DESCRIPTION
I am writing an AI coding assistant extension. In order to sync the assistant world view with the user world view, I would like to know what lines are folded.

I suggest to expose the folded lines of the editor in focus. Does it sound like a desireable api?
I am adding a draft implementation
Thanks
Omri

Related issues:
https://github.com/microsoft/vscode/issues/36638
https://github.com/microsoft/vscode/issues/82980
