### PR TITLE
Fallback to hybrid after 20 process ports

### DIFF
--- a/src/vs/workbench/contrib/remote/browser/remoteExplorer.ts
+++ b/src/vs/workbench/contrib/remote/browser/remoteExplorer.ts
@@ -231,7 +231,7 @@ export class AutomaticPortForwarding extends Disposable implements IWorkbenchCon
 						severity: Severity.Info,
 						actions: {
 							primary: [
-								new Action('switchBack', nls.localize('remote.autoForwardPortsSource.fallback.switchBack', "Switch back to `process` based automatic port forwarding"), undefined, true, async () => {
+								new Action('switchBack', nls.localize('remote.autoForwardPortsSource.fallback.switchBack', "Switch back to process based automatic port forwarding"), undefined, true, async () => {
 									await this.configurationService.updateValue(PORT_AUTO_SOURCE_SETTING, PORT_AUTO_SOURCE_SETTING_PROCESS);
 									// this.storageService.store(CAN_PROC_FALLBACK, false, StorageScope.WORKSPACE, StorageTarget.USER);
 									this.portListener?.dispose();

--- a/src/vs/workbench/contrib/remote/browser/remoteExplorer.ts
+++ b/src/vs/workbench/contrib/remote/browser/remoteExplorer.ts
@@ -33,8 +33,12 @@ import { IHostService } from 'vs/workbench/services/host/browser/host';
 import { IConfigurationRegistry, Extensions as ConfigurationExtensions } from 'vs/platform/configuration/common/configurationRegistry';
 import { ILogService } from 'vs/platform/log/common/log';
 import { IWorkbenchConfigurationService } from 'vs/workbench/services/configuration/common/configuration';
+import { IRemoteAgentEnvironment } from 'vs/platform/remote/common/remoteAgentEnvironment';
+import { Action } from 'vs/base/common/actions';
+import { IStorageService, StorageScope } from 'vs/platform/storage/common/storage';
 
 export const VIEWLET_ID = 'workbench.view.remote';
+export const CAN_PROC_FALLBACK = 'processPortForwardingFallback';
 
 export class ForwardedPortsView extends Disposable implements IWorkbenchContribution {
 	private contextKeyListener?: IDisposable;
@@ -175,21 +179,25 @@ export class PortRestore implements IWorkbenchContribution {
 
 
 export class AutomaticPortForwarding extends Disposable implements IWorkbenchContribution {
+	private procForwarder: ProcAutomaticPortForwarding | undefined;
+	private outputForwarder: OutputAutomaticPortForwarding | undefined;
+	private portListener: IDisposable | undefined;
 
 	constructor(
-		@ITerminalService terminalService: ITerminalService,
-		@INotificationService notificationService: INotificationService,
-		@IOpenerService openerService: IOpenerService,
-		@IExternalUriOpenerService externalOpenerService: IExternalUriOpenerService,
-		@IRemoteExplorerService remoteExplorerService: IRemoteExplorerService,
-		@IWorkbenchEnvironmentService environmentService: IWorkbenchEnvironmentService,
-		@IContextKeyService contextKeyService: IContextKeyService,
-		@IWorkbenchConfigurationService configurationService: IWorkbenchConfigurationService,
-		@IDebugService debugService: IDebugService,
-		@IRemoteAgentService remoteAgentService: IRemoteAgentService,
-		@ITunnelService tunnelService: ITunnelService,
-		@IHostService hostService: IHostService,
-		@ILogService logService: ILogService
+		@ITerminalService private readonly terminalService: ITerminalService,
+		@INotificationService private readonly notificationService: INotificationService,
+		@IOpenerService private readonly openerService: IOpenerService,
+		@IExternalUriOpenerService private readonly externalOpenerService: IExternalUriOpenerService,
+		@IRemoteExplorerService private readonly remoteExplorerService: IRemoteExplorerService,
+		@IWorkbenchEnvironmentService readonly environmentService: IWorkbenchEnvironmentService,
+		@IContextKeyService private readonly contextKeyService: IContextKeyService,
+		@IWorkbenchConfigurationService private readonly configurationService: IWorkbenchConfigurationService,
+		@IDebugService private readonly debugService: IDebugService,
+		@IRemoteAgentService readonly remoteAgentService: IRemoteAgentService,
+		@ITunnelService private readonly tunnelService: ITunnelService,
+		@IHostService private readonly hostService: IHostService,
+		@ILogService private readonly logService: ILogService,
+		@IStorageService private readonly storageService: IStorageService
 	) {
 		super();
 		if (!environmentService.remoteAuthority) {
@@ -197,24 +205,68 @@ export class AutomaticPortForwarding extends Disposable implements IWorkbenchCon
 		}
 
 		configurationService.whenRemoteConfigurationLoaded().then(() => remoteAgentService.getEnvironment()).then(environment => {
-			if (environment?.os !== OperatingSystem.Linux) {
-				Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration)
-					.registerDefaultConfigurations([{ overrides: { 'remote.autoForwardPortsSource': PORT_AUTO_SOURCE_SETTING_OUTPUT } }]);
-				this._register(new OutputAutomaticPortForwarding(terminalService, notificationService, openerService, externalOpenerService,
-					remoteExplorerService, configurationService, debugService, tunnelService, hostService, logService, contextKeyService, () => false));
-			} else {
-				const useProc = () => (configurationService.getValue(PORT_AUTO_SOURCE_SETTING) === PORT_AUTO_SOURCE_SETTING_PROCESS);
-				if (useProc()) {
-					this._register(new ProcAutomaticPortForwarding(false, configurationService, remoteExplorerService, notificationService,
-						openerService, externalOpenerService, tunnelService, hostService, logService, contextKeyService));
-				} else if (configurationService.getValue(PORT_AUTO_SOURCE_SETTING) === PORT_AUTO_SOURCE_SETTING_HYBRID) {
-					this._register(new ProcAutomaticPortForwarding(true, configurationService, remoteExplorerService, notificationService,
-						openerService, externalOpenerService, tunnelService, hostService, logService, contextKeyService));
+			this.setup(environment);
+			this._register(configurationService.onDidChangeConfiguration(e => {
+				if (e.affectsConfiguration(PORT_AUTO_SOURCE_SETTING)) {
+					this.setup(environment);
 				}
-				this._register(new OutputAutomaticPortForwarding(terminalService, notificationService, openerService, externalOpenerService,
-					remoteExplorerService, configurationService, debugService, tunnelService, hostService, logService, contextKeyService, useProc));
-			}
+			}));
 		});
+	}
+
+	private canFallbackToHybrid(): boolean {
+		return this.storageService.getBoolean(CAN_PROC_FALLBACK, StorageScope.WORKSPACE, true);
+	}
+
+	private listenForPorts(environment: IRemoteAgentEnvironment | null) {
+		if (this.procForwarder && !this.portListener && this.canFallbackToHybrid()) {
+			this.portListener = this._register(this.remoteExplorerService.tunnelModel.onForwardPort(async () => {
+				const autoForwardedCount = Array.from(this.remoteExplorerService.tunnelModel.forwarded.values()).filter(tunnel => tunnel.source.source === TunnelSource.Auto).length;
+				if (autoForwardedCount > 20) {
+					await this.configurationService.updateValue(PORT_AUTO_SOURCE_SETTING, PORT_AUTO_SOURCE_SETTING_HYBRID);
+					this.setup(environment);
+					this.notificationService.notify({
+						message: nls.localize('remote.autoForwardPortsSource.fallback', "Over 20 ports have been automatically forwarded. The `process` based automatic port forwarding has been switched to `hybrid` in settings."),
+						severity: Severity.Info,
+						actions: {
+							primary: [
+								new Action('switchBack', nls.localize('remote.autoForwardPortsSource.fallback.switchBack', "Switch back to `process` based automatic port forwarding"), undefined, true, async () => {
+									await this.configurationService.updateValue(PORT_AUTO_SOURCE_SETTING, PORT_AUTO_SOURCE_SETTING_PROCESS);
+									// this.storageService.store(CAN_PROC_FALLBACK, false, StorageScope.WORKSPACE, StorageTarget.USER);
+									this.portListener?.dispose();
+								})
+							]
+						}
+					});
+				}
+			}));
+		} else {
+			this.portListener?.dispose();
+		}
+	}
+
+
+	private setup(environment: IRemoteAgentEnvironment | null) {
+		this.procForwarder?.dispose();
+		this.outputForwarder?.dispose();
+		if (environment?.os !== OperatingSystem.Linux) {
+			Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration)
+				.registerDefaultConfigurations([{ overrides: { 'remote.autoForwardPortsSource': PORT_AUTO_SOURCE_SETTING_OUTPUT } }]);
+			this.outputForwarder = this._register(new OutputAutomaticPortForwarding(this.terminalService, this.notificationService, this.openerService, this.externalOpenerService,
+				this.remoteExplorerService, this.configurationService, this.debugService, this.tunnelService, this.hostService, this.logService, this.contextKeyService, () => false));
+		} else {
+			const useProc = () => (this.configurationService.getValue(PORT_AUTO_SOURCE_SETTING) === PORT_AUTO_SOURCE_SETTING_PROCESS);
+			if (useProc()) {
+				this.procForwarder = this._register(new ProcAutomaticPortForwarding(false, this.configurationService, this.remoteExplorerService, this.notificationService,
+					this.openerService, this.externalOpenerService, this.tunnelService, this.hostService, this.logService, this.contextKeyService));
+			} else if (this.configurationService.getValue(PORT_AUTO_SOURCE_SETTING) === PORT_AUTO_SOURCE_SETTING_HYBRID) {
+				this.procForwarder = this._register(new ProcAutomaticPortForwarding(true, this.configurationService, this.remoteExplorerService, this.notificationService,
+					this.openerService, this.externalOpenerService, this.tunnelService, this.hostService, this.logService, this.contextKeyService));
+			}
+			this.outputForwarder = this._register(new OutputAutomaticPortForwarding(this.terminalService, this.notificationService, this.openerService, this.externalOpenerService,
+				this.remoteExplorerService, this.configurationService, this.debugService, this.tunnelService, this.hostService, this.logService, this.contextKeyService, useProc));
+		}
+		this.listenForPorts(environment);
 	}
 }
 

--- a/src/vs/workbench/contrib/remote/common/remote.contribution.ts
+++ b/src/vs/workbench/contrib/remote/common/remote.contribution.ts
@@ -314,7 +314,7 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration)
 			},
 			'remote.autoForwardPortsSource': {
 				type: 'string',
-				markdownDescription: localize('remote.autoForwardPortsSource', "Sets the source from which ports are automatically forwarded when {0} is true. On Windows and Mac remotes, the `process` and `hybrid` options have no effect and `output` will be used. Requires a reload to take effect.", '`#remote.autoForwardPorts#`'),
+				markdownDescription: localize('remote.autoForwardPortsSource', "Sets the source from which ports are automatically forwarded when {0} is true. On Windows and Mac remotes, the `process` and `hybrid` options have no effect and `output` will be used.", '`#remote.autoForwardPorts#`'),
 				enum: ['process', 'output', 'hybrid'],
 				enumDescriptions: [
 					localize('remote.autoForwardPortsSource.process', "Ports will be automatically forwarded when discovered by watching for processes that are started and include a port."),


### PR DESCRIPTION
Additionally the `remote.autoForwardPortsSource` setting has been updated to remove the `markdownDescription` reference to a reload being required for changes to take effect.