### PR TITLE
Mark chat codeblock textmodel as 'simple'

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/codeBlockPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/codeBlockPart.ts
@@ -167,7 +167,7 @@ export class CodeBlockPart extends Disposable implements ICodeBlockPart {
 			WordHighlighterContribution.get(this.editor)?.restoreViewState(true);
 		}));
 
-		this.textModel = this._register(this.modelService.createModel('', null, undefined));
+		this.textModel = this._register(this.modelService.createModel('', null, undefined, true));
 		this.editor.setModel(this.textModel);
 	}
 


### PR DESCRIPTION
Fix microsoft/vscode-copilot#2719

cc @mjbvz is this the right fix? The boolean is `isForSimpleWidget`. I think I should have had this set. Previously the code editor did not have `isSimpleWidget` set when we were trying to have all the editor features show up in code blocks. Then I disabled that for the editor and so I think the TextModel should have the matching flag set.