### PR TITLE
Fix keyboard popping out again on android

### DIFF
--- a/src/vs/base/browser/ui/contextview/contextview.ts
+++ b/src/vs/base/browser/ui/contextview/contextview.ts
@@ -246,7 +246,7 @@ export class ContextView extends Disposable {
 			return;
 		}
 
-		if (this.delegate!.canRelayout === false && !(platform.isIOS && BrowserFeatures.pointerEvents)) {
+		if (this.delegate!.canRelayout === false && !(platform.isIOS && BrowserFeatures.pointerEvents) && !platform.isAndroid) {
 			this.hide();
 			return;
 		}

--- a/src/vs/workbench/browser/parts/titlebar/menubarControl.ts
+++ b/src/vs/workbench/browser/parts/titlebar/menubarControl.ts
@@ -11,7 +11,7 @@ import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 import { IAction, Action, SubmenuAction, Separator, IActionRunner, ActionRunner, WorkbenchActionExecutedEvent, WorkbenchActionExecutedClassification, toAction } from 'vs/base/common/actions';
 import { addDisposableListener, Dimension, EventType } from 'vs/base/browser/dom';
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
-import { isMacintosh, isWeb, isIOS, isNative } from 'vs/base/common/platform';
+import { isMacintosh, isWeb, isIOS, isNative, isAndroid } from 'vs/base/common/platform';
 import { IConfigurationService, IConfigurationChangeEvent } from 'vs/platform/configuration/common/configuration';
 import { Event, Emitter } from 'vs/base/common/event';
 import { Disposable, DisposableStore } from 'vs/base/common/lifecycle';
@@ -791,7 +791,7 @@ export class CustomMenubarControl extends MenubarControl {
 		super.registerListeners();
 
 		this._register(addDisposableListener(mainWindow, EventType.RESIZE, () => {
-			if (this.menubar && !(isIOS && BrowserFeatures.pointerEvents)) {
+			if (this.menubar && !(isIOS && BrowserFeatures.pointerEvents) && !isAndroid) {
 				this.menubar.blur();
 			}
 		}));


### PR DESCRIPTION
Fix keyboard popping out on android

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
On android:
this commit before: 
when the editor container has the focus, clicking outside buttons will cause keyboard to popup again.

this commit stop hiding popped up menu and the keyboard will not pop up again
