### PR TITLE
Make hover widget status bar stick to the bottom

### DIFF
--- a/src/vs/base/browser/ui/hover/hover.css
+++ b/src/vs/base/browser/ui/hover/hover.css
@@ -110,6 +110,8 @@
 }
 
 .monaco-hover .hover-row.status-bar {
+	position: sticky;
+	bottom: 0;
 	font-size: 12px;
 	line-height: 22px;
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

I always find myself annoyed that "Quick fix" action can be tricky to point at with a mouse. The hover widget, which is this action is a part of, may include very long error messages or even worse - add new ones on the fly once new errors are computed.

I figured that it would make sense to make the "status bar" always stick to the bottom of this widget.

Behaviour before:

https://github.com/microsoft/vscode/assets/6554045/aa39edc9-ab19-4f6e-8cc8-99d24f2fd035

And after the proposed change:

https://github.com/microsoft/vscode/assets/6554045/6a09f78f-f35b-42ff-b2a9-6f899483a08b

