### PR TITLE
chore: rename color var for comment input box

### DIFF
--- a/build/lib/stylelint/vscode-known-variables.json
+++ b/build/lib/stylelint/vscode-known-variables.json
@@ -180,7 +180,7 @@
 		"--vscode-editorCodeLens-foreground",
 		"--vscode-editorCommentsWidget-rangeActiveBackground",
 		"--vscode-editorCommentsWidget-rangeBackground",
-		"--vscode-editorCommentsWidget-replyButtonBackground",
+		"--vscode-editorCommentsWidget-replyInputBackground",
 		"--vscode-editorCommentsWidget-resolvedBorder",
 		"--vscode-editorCommentsWidget-unresolvedBorder",
 		"--vscode-editorCursor-background",

--- a/src/vs/workbench/contrib/comments/browser/commentColors.ts
+++ b/src/vs/workbench/contrib/comments/browser/commentColors.ts
@@ -5,14 +5,15 @@
 
 import { Color } from 'vs/base/common/color';
 import * as languages from 'vs/editor/common/languages';
+import { peekViewTitleBackground } from 'vs/editor/contrib/peekView/browser/peekView';
 import * as nls from 'vs/nls';
-import { contrastBorder, disabledForeground, inputBackground, listFocusOutline, registerColor, transparent } from 'vs/platform/theme/common/colorRegistry';
+import { contrastBorder, disabledForeground, listFocusOutline, registerColor, transparent } from 'vs/platform/theme/common/colorRegistry';
 import { IColorTheme } from 'vs/platform/theme/common/themeService';
 
 const resolvedCommentViewIcon = registerColor('commentsView.resolvedIcon', { dark: disabledForeground, light: disabledForeground, hcDark: contrastBorder, hcLight: contrastBorder }, nls.localize('resolvedCommentIcon', 'Icon color for resolved comments.'));
 const unresolvedCommentViewIcon = registerColor('commentsView.unresolvedIcon', { dark: listFocusOutline, light: listFocusOutline, hcDark: contrastBorder, hcLight: contrastBorder }, nls.localize('unresolvedCommentIcon', 'Icon color for unresolved comments.'));
 
-registerColor('editorCommentsWidget.replyInputBackground', { dark: inputBackground, light: inputBackground, hcDark: inputBackground, hcLight: inputBackground }, nls.localize('commentReplyInputBackground', 'Background color for comment reply input box.'));
+registerColor('editorCommentsWidget.replyInputBackground', { dark: peekViewTitleBackground, light: peekViewTitleBackground, hcDark: peekViewTitleBackground, hcLight: peekViewTitleBackground }, nls.localize('commentReplyInputBackground', 'Background color for comment reply input box.'));
 const resolvedCommentBorder = registerColor('editorCommentsWidget.resolvedBorder', { dark: resolvedCommentViewIcon, light: resolvedCommentViewIcon, hcDark: contrastBorder, hcLight: contrastBorder }, nls.localize('resolvedCommentBorder', 'Color of borders and arrow for resolved comments.'));
 const unresolvedCommentBorder = registerColor('editorCommentsWidget.unresolvedBorder', { dark: unresolvedCommentViewIcon, light: unresolvedCommentViewIcon, hcDark: contrastBorder, hcLight: contrastBorder }, nls.localize('unresolvedCommentBorder', 'Color of borders and arrow for unresolved comments.'));
 export const commentThreadRangeBackground = registerColor('editorCommentsWidget.rangeBackground', { dark: transparent(unresolvedCommentBorder, .1), light: transparent(unresolvedCommentBorder, .1), hcDark: transparent(unresolvedCommentBorder, .1), hcLight: transparent(unresolvedCommentBorder, .1) }, nls.localize('commentThreadRangeBackground', 'Color of background for comment ranges.'));

--- a/src/vs/workbench/contrib/comments/browser/commentColors.ts
+++ b/src/vs/workbench/contrib/comments/browser/commentColors.ts
@@ -5,15 +5,14 @@
 
 import { Color } from 'vs/base/common/color';
 import * as languages from 'vs/editor/common/languages';
-import { peekViewTitleBackground } from 'vs/editor/contrib/peekView/browser/peekView';
 import * as nls from 'vs/nls';
-import { contrastBorder, disabledForeground, listFocusOutline, registerColor, transparent } from 'vs/platform/theme/common/colorRegistry';
+import { contrastBorder, disabledForeground, inputBackground, listFocusOutline, registerColor, transparent } from 'vs/platform/theme/common/colorRegistry';
 import { IColorTheme } from 'vs/platform/theme/common/themeService';
 
 const resolvedCommentViewIcon = registerColor('commentsView.resolvedIcon', { dark: disabledForeground, light: disabledForeground, hcDark: contrastBorder, hcLight: contrastBorder }, nls.localize('resolvedCommentIcon', 'Icon color for resolved comments.'));
 const unresolvedCommentViewIcon = registerColor('commentsView.unresolvedIcon', { dark: listFocusOutline, light: listFocusOutline, hcDark: contrastBorder, hcLight: contrastBorder }, nls.localize('unresolvedCommentIcon', 'Icon color for unresolved comments.'));
 
-registerColor('editorCommentsWidget.replyButtonBackground', { dark: peekViewTitleBackground, light: peekViewTitleBackground, hcDark: peekViewTitleBackground, hcLight: peekViewTitleBackground }, nls.localize('commentReplyButtonBackground', 'Background color for comment reply button.'));
+registerColor('editorCommentsWidget.replyInputBackground', { dark: inputBackground, light: inputBackground, hcDark: inputBackground, hcLight: inputBackground }, nls.localize('commentReplyInputBackground', 'Background color for comment reply input box.'));
 const resolvedCommentBorder = registerColor('editorCommentsWidget.resolvedBorder', { dark: resolvedCommentViewIcon, light: resolvedCommentViewIcon, hcDark: contrastBorder, hcLight: contrastBorder }, nls.localize('resolvedCommentBorder', 'Color of borders and arrow for resolved comments.'));
 const unresolvedCommentBorder = registerColor('editorCommentsWidget.unresolvedBorder', { dark: unresolvedCommentViewIcon, light: unresolvedCommentViewIcon, hcDark: contrastBorder, hcLight: contrastBorder }, nls.localize('unresolvedCommentBorder', 'Color of borders and arrow for unresolved comments.'));
 export const commentThreadRangeBackground = registerColor('editorCommentsWidget.rangeBackground', { dark: transparent(unresolvedCommentBorder, .1), light: transparent(unresolvedCommentBorder, .1), hcDark: transparent(unresolvedCommentBorder, .1), hcLight: transparent(unresolvedCommentBorder, .1) }, nls.localize('commentThreadRangeBackground', 'Color of background for comment ranges.'));

--- a/src/vs/workbench/contrib/comments/browser/media/review.css
+++ b/src/vs/workbench/contrib/comments/browser/media/review.css
@@ -352,7 +352,7 @@
 .review-widget .body .comment-form .monaco-editor,
 .review-widget .body .comment-form .monaco-editor .monaco-editor-background,
 .review-widget .body .edit-container .monaco-editor .monaco-editor-background {
-	background-color: var(--vscode-peekViewTitle-background);
+	background-color: var(--vscode-editorCommentsWidget-replyInputBackground);
 }
 
 .review-widget .body .comment-form .monaco-editor,

--- a/src/vs/workbench/contrib/comments/browser/media/review.css
+++ b/src/vs/workbench/contrib/comments/browser/media/review.css
@@ -338,7 +338,7 @@
 	white-space: nowrap;
 	border: 0px;
 	outline: 1px solid transparent;
-	background-color: var(--vscode-editorCommentsWidget-replyButtonBackground);
+	background-color: var(--vscode-editorCommentsWidget-replyInputBackground);
 	color: var(--vscode-editor-foreground);
 	font-size: inherit;
 	font-family: var(--monaco-monospace-font);


### PR DESCRIPTION
Fix: https://github.com/microsoft/vscode/issues/196584
Follow-up from https://github.com/microsoft/vscode/pull/197738

Changes:

- rename var name to match the actual color item (button → input box)
- change default color to derive from [inputBackground](https://github.com/microsoft/vscode/blob/26b39c1f9e3bd615c6f4440a6a209e4ee2cba36c/src/vs/platform/theme/common/colorRegistry.ts#L240)

@alexr00 

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
