### PR TITLE
Extract cell container left margin

### DIFF
--- a/src/vs/workbench/contrib/interactive/browser/interactive.contribution.ts
+++ b/src/vs/workbench/contrib/interactive/browser/interactive.contribution.ts
@@ -490,7 +490,7 @@ registerAction2(class extends Action2 {
 				historyService.addToHistory(notebookDocument.uri, '');
 				textModel.setValue('');
 
-				const collapseState = editorControl.notebookEditor.notebookOptions.getLayoutConfiguration().interactiveWindowCollapseCodeCells === 'fromEditor' ?
+				const collapseState = editorControl.notebookEditor.notebookOptions.getDisplayOptions().interactiveWindowCollapseCodeCells === 'fromEditor' ?
 					{
 						inputCollapsed: false,
 						outputCollapsed: false

--- a/src/vs/workbench/contrib/interactive/browser/interactiveEditor.ts
+++ b/src/vs/workbench/contrib/interactive/browser/interactiveEditor.ts
@@ -219,10 +219,12 @@ export class InteractiveEditor extends EditorPane {
 		const styleSheets: string[] = [];
 
 		const {
-			focusIndicator,
 			codeCellLeftMargin,
 			cellRunGutter
 		} = this._notebookOptions.getLayoutConfiguration();
+		const {
+			focusIndicator
+		} = this._notebookOptions.getDisplayOptions();
 		const leftMargin = this._notebookOptions.getCellEditorContainerLeftMargin();
 
 		styleSheets.push(`

--- a/src/vs/workbench/contrib/interactive/browser/interactiveEditor.ts
+++ b/src/vs/workbench/contrib/interactive/browser/interactiveEditor.ts
@@ -223,7 +223,7 @@ export class InteractiveEditor extends EditorPane {
 			codeCellLeftMargin,
 			cellRunGutter
 		} = this._notebookOptions.getLayoutConfiguration();
-		const leftMargin = codeCellLeftMargin + cellRunGutter;
+		const leftMargin = this._notebookOptions.getCellEditorContainerLeftMargin();
 
 		styleSheets.push(`
 			.interactive-editor .input-cell-container {
@@ -405,11 +405,7 @@ export class InteractiveEditor extends EditorPane {
 		if (this._lastLayoutDimensions) {
 			this._notebookEditorContainer.style.height = `${this._lastLayoutDimensions.dimension.height - this.inputCellContainerHeight}px`;
 			this._notebookWidget.value!.layout(new DOM.Dimension(this._lastLayoutDimensions.dimension.width, this._lastLayoutDimensions.dimension.height - this.inputCellContainerHeight), this._notebookEditorContainer);
-			const {
-				codeCellLeftMargin,
-				cellRunGutter
-			} = this._notebookOptions.getLayoutConfiguration();
-			const leftMargin = codeCellLeftMargin + cellRunGutter;
+			const leftMargin = this._notebookOptions.getCellEditorContainerLeftMargin();
 			const maxHeight = Math.min(this._lastLayoutDimensions.dimension.height / 2, this.inputCellEditorHeight);
 			this._codeEditorWidget.layout(this._validateDimension(this._lastLayoutDimensions.dimension.width - leftMargin - INPUT_CELL_HORIZONTAL_PADDING_RIGHT, maxHeight));
 			this._inputFocusIndicator.style.height = `${this.inputCellEditorHeight}px`;
@@ -615,11 +611,7 @@ export class InteractiveEditor extends EditorPane {
 	private _layoutWidgets(dimension: DOM.Dimension, position: DOM.IDomPosition) {
 		const contentHeight = this._codeEditorWidget.hasModel() ? this._codeEditorWidget.getContentHeight() : this.inputCellEditorHeight;
 		const maxHeight = Math.min(dimension.height / 2, contentHeight);
-		const {
-			codeCellLeftMargin,
-			cellRunGutter
-		} = this._notebookOptions.getLayoutConfiguration();
-		const leftMargin = codeCellLeftMargin + cellRunGutter;
+		const leftMargin = this._notebookOptions.getCellEditorContainerLeftMargin();
 
 		const inputCellContainerHeight = maxHeight + INPUT_CELL_VERTICAL_PADDING * 2;
 		this._notebookEditorContainer.style.height = `${dimension.height - inputCellContainerHeight}px`;

--- a/src/vs/workbench/contrib/notebook/browser/contrib/editorStatusBar/editorStatusBar.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/editorStatusBar/editorStatusBar.ts
@@ -96,7 +96,7 @@ export class KernelStatus extends Disposable implements IWorkbenchContribution {
 		}
 
 		const updateStatus = () => {
-			if (activeEditor.notebookOptions.getLayoutConfiguration().globalToolbar) {
+			if (activeEditor.notebookOptions.getDisplayOptions().globalToolbar) {
 				// kernel info rendered in the notebook toolbar already
 				this._kernelInfoElement.clear();
 				return;

--- a/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
@@ -558,7 +558,7 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditorD
 		const cellToolbarLocation = this._notebookOptions.computeCellToolbarLocation(this.viewModel?.viewType);
 		this._overlayContainer.classList.add(`cell-title-toolbar-${cellToolbarLocation}`);
 
-		const cellToolbarInteraction = this._notebookOptions.getLayoutConfiguration().cellToolbarInteraction;
+		const cellToolbarInteraction = this._notebookOptions.getDisplayOptions().cellToolbarInteraction;
 		let cellToolbarInteractionState = 'hover';
 		this._overlayContainer.classList.remove('cell-toolbar-hover');
 		this._overlayContainer.classList.remove('cell-toolbar-click');
@@ -619,15 +619,18 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditorD
 			markdownCellBottomMargin,
 			markdownCellTopMargin,
 			collapsedIndicatorHeight,
-			compactView,
 			focusIndicator,
 			insertToolbarPosition,
-			insertToolbarAlignment,
-			fontSize,
 			outputFontSize,
 			focusIndicatorLeftMargin,
 			focusIndicatorGap
 		} = this._notebookOptions.getLayoutConfiguration();
+
+		const {
+			insertToolbarAlignment,
+			compactView,
+			fontSize
+		} = this._notebookOptions.getDisplayOptions();
 
 		const getCellEditorContainerLeftMargin = this._notebookOptions.getCellEditorContainerLeftMargin();
 

--- a/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
@@ -629,6 +629,8 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditorD
 			focusIndicatorGap
 		} = this._notebookOptions.getLayoutConfiguration();
 
+		const getCellEditorContainerLeftMargin = this._notebookOptions.getCellEditorContainerLeftMargin();
+
 		const { bottomToolbarGap, bottomToolbarHeight } = this._notebookOptions.computeBottomToolbarDimensions(this.viewModel?.viewType);
 
 		const styleSheets: string[] = [];
@@ -647,7 +649,7 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditorD
 		`);
 
 		if (compactView) {
-			styleSheets.push(`.notebookOverlay .cell-list-container > .monaco-list > .monaco-scrollable-element > .monaco-list-rows > .markdown-cell-row div.cell.code { margin-left: ${codeCellLeftMargin + cellRunGutter}px; }`);
+			styleSheets.push(`.notebookOverlay .cell-list-container > .monaco-list > .monaco-scrollable-element > .monaco-list-rows > .markdown-cell-row div.cell.code { margin-left: ${getCellEditorContainerLeftMargin}px; }`);
 		} else {
 			styleSheets.push(`.notebookOverlay .cell-list-container > .monaco-list > .monaco-scrollable-element > .monaco-list-rows > .markdown-cell-row div.cell.code { margin-left: ${codeCellLeftMargin}px; }`);
 		}
@@ -777,18 +779,18 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditorD
 			}`);
 		}
 
-		styleSheets.push(`.notebookOverlay .cell-list-container > .monaco-list > .monaco-scrollable-element > .monaco-list-rows > .code-cell-row div.cell.code { margin-left: ${codeCellLeftMargin + cellRunGutter}px; }`);
+		styleSheets.push(`.notebookOverlay .cell-list-container > .monaco-list > .monaco-scrollable-element > .monaco-list-rows > .code-cell-row div.cell.code { margin-left: ${getCellEditorContainerLeftMargin}px; }`);
 		styleSheets.push(`.notebookOverlay .cell-list-container > .monaco-list > .monaco-scrollable-element > .monaco-list-rows > .monaco-list-row div.cell { margin-right: ${cellRightMargin}px; }`);
 		styleSheets.push(`.notebookOverlay .cell-list-container > .monaco-list > .monaco-scrollable-element > .monaco-list-rows > .monaco-list-row > .cell-inner-container { padding-top: ${cellTopMargin}px; }`);
 		styleSheets.push(`.notebookOverlay .cell-list-container > .monaco-list > .monaco-scrollable-element > .monaco-list-rows > .markdown-cell-row > .cell-inner-container { padding-bottom: ${markdownCellBottomMargin}px; padding-top: ${markdownCellTopMargin}px; }`);
 		styleSheets.push(`.notebookOverlay .cell-list-container > .monaco-list > .monaco-scrollable-element > .monaco-list-rows > .markdown-cell-row > .cell-inner-container.webview-backed-markdown-cell { padding: 0; }`);
 		styleSheets.push(`.notebookOverlay .cell-list-container > .monaco-list > .monaco-scrollable-element > .monaco-list-rows > .markdown-cell-row > .webview-backed-markdown-cell.markdown-cell-edit-mode .cell.code { padding-bottom: ${markdownCellBottomMargin}px; padding-top: ${markdownCellTopMargin}px; }`);
-		styleSheets.push(`.notebookOverlay .output { margin: 0px ${cellRightMargin}px 0px ${codeCellLeftMargin + cellRunGutter}px; }`);
-		styleSheets.push(`.notebookOverlay .output { width: calc(100% - ${codeCellLeftMargin + cellRunGutter + cellRightMargin}px); }`);
+		styleSheets.push(`.notebookOverlay .output { margin: 0px ${cellRightMargin}px 0px ${getCellEditorContainerLeftMargin}px; }`);
+		styleSheets.push(`.notebookOverlay .output { width: calc(100% - ${getCellEditorContainerLeftMargin + cellRightMargin}px); }`);
 
 		// comment
-		styleSheets.push(`.notebookOverlay .cell-list-container > .monaco-list > .monaco-scrollable-element > .monaco-list-rows > .monaco-list-row .cell-comment-container { left: ${codeCellLeftMargin + cellRunGutter}px; }`);
-		styleSheets.push(`.notebookOverlay .cell-list-container > .monaco-list > .monaco-scrollable-element > .monaco-list-rows > .monaco-list-row .cell-comment-container { width: calc(100% - ${codeCellLeftMargin + cellRunGutter + cellRightMargin}px); }`);
+		styleSheets.push(`.notebookOverlay .cell-list-container > .monaco-list > .monaco-scrollable-element > .monaco-list-rows > .monaco-list-row .cell-comment-container { left: ${getCellEditorContainerLeftMargin}px; }`);
+		styleSheets.push(`.notebookOverlay .cell-list-container > .monaco-list > .monaco-scrollable-element > .monaco-list-rows > .monaco-list-row .cell-comment-container { width: calc(100% - ${getCellEditorContainerLeftMargin + cellRightMargin}px); }`);
 
 		// output collapse button
 		styleSheets.push(`.monaco-workbench .notebookOverlay .output .output-collapse-container .expandButton { left: -${cellRunGutter}px; }`);
@@ -799,15 +801,15 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditorD
 		}`);
 
 		// show more container
-		styleSheets.push(`.notebookOverlay .output-show-more-container { margin: 0px ${cellRightMargin}px 0px ${codeCellLeftMargin + cellRunGutter}px; }`);
-		styleSheets.push(`.notebookOverlay .output-show-more-container { width: calc(100% - ${codeCellLeftMargin + cellRunGutter + cellRightMargin}px); }`);
+		styleSheets.push(`.notebookOverlay .output-show-more-container { margin: 0px ${cellRightMargin}px 0px ${getCellEditorContainerLeftMargin}px; }`);
+		styleSheets.push(`.notebookOverlay .output-show-more-container { width: calc(100% - ${getCellEditorContainerLeftMargin + cellRightMargin}px); }`);
 
 		styleSheets.push(`.notebookOverlay .cell-list-container > .monaco-list > .monaco-scrollable-element > .monaco-list-rows > .monaco-list-row div.cell.markdown { padding-left: ${cellRunGutter}px; }`);
 		styleSheets.push(`.monaco-workbench .notebookOverlay > .cell-list-container .notebook-folding-indicator { left: ${(markdownCellGutter - 20) / 2 + markdownCellLeftMargin}px; }`);
 		styleSheets.push(`.notebookOverlay > .cell-list-container .notebook-folded-hint { left: ${markdownCellGutter + markdownCellLeftMargin + 8}px; }`);
 		styleSheets.push(`.notebookOverlay .monaco-list .monaco-list-row :not(.webview-backed-markdown-cell) .cell-focus-indicator-top { height: ${cellTopMargin}px; }`);
 		styleSheets.push(`.notebookOverlay .monaco-list .monaco-list-row .cell-focus-indicator-side { bottom: ${bottomToolbarGap}px; }`);
-		styleSheets.push(`.notebookOverlay .monaco-list .monaco-list-row.code-cell-row .cell-focus-indicator-left { width: ${codeCellLeftMargin + cellRunGutter}px; }`);
+		styleSheets.push(`.notebookOverlay .monaco-list .monaco-list-row.code-cell-row .cell-focus-indicator-left { width: ${getCellEditorContainerLeftMargin}px; }`);
 		styleSheets.push(`.notebookOverlay .monaco-list .monaco-list-row.markdown-cell-row .cell-focus-indicator-left { width: ${codeCellLeftMargin}px; }`);
 		styleSheets.push(`.notebookOverlay .monaco-list .monaco-list-row .cell-focus-indicator.cell-focus-indicator-right { width: ${cellRightMargin}px; }`);
 		styleSheets.push(`.notebookOverlay .monaco-list .monaco-list-row .cell-focus-indicator-bottom { height: ${cellBottomMargin}px; }`);
@@ -838,7 +840,7 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditorD
 			right: ${cellRightMargin + 26}px;
 		}
 		.monaco-workbench .notebookOverlay.cell-title-toolbar-left > .cell-list-container > .monaco-list > .monaco-scrollable-element > .monaco-list-rows > .monaco-list-row .cell-title-toolbar {
-			left: ${codeCellLeftMargin + cellRunGutter + 16}px;
+			left: ${getCellEditorContainerLeftMargin + 16}px;
 		}
 		.monaco-workbench .notebookOverlay.cell-title-toolbar-hidden > .cell-list-container > .monaco-list > .monaco-scrollable-element > .monaco-list-rows > .monaco-list-row .cell-title-toolbar {
 			display: none;

--- a/src/vs/workbench/contrib/notebook/browser/notebookOptions.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookOptions.ts
@@ -32,6 +32,32 @@ export function getEditorTopPadding() {
 
 export const OutputInnerContainerTopPadding = 4;
 
+export interface NotebookDisplayOptions {
+	showCellStatusBar: ShowCellStatusBarType;
+	cellToolbarLocation: string | { [key: string]: string };
+	cellToolbarInteraction: string;
+	compactView: boolean;
+	focusIndicator: 'border' | 'gutter';
+	insertToolbarPosition: 'betweenCells' | 'notebookToolbar' | 'both' | 'hidden';
+	insertToolbarAlignment: 'left' | 'center';
+	globalToolbar: boolean;
+	stickyScroll: boolean;
+	consolidatedOutputButton: boolean;
+	consolidatedRunButton: boolean;
+	showFoldingControls: 'always' | 'never' | 'mouseover';
+	dragAndDropEnabled: boolean;
+	interactiveWindowCollapseCodeCells: InteractiveWindowCollapseCodeCells;
+	outputScrolling: boolean;
+	outputWordWrap: boolean;
+	outputLineLimit: number;
+	fontSize: number;
+	outputFontSize: number;
+	outputFontFamily: string;
+	outputLineHeight: number;
+	markupFontSize: number;
+	editorOptionsCustomizations: any | undefined;
+}
+
 export interface NotebookLayoutConfiguration {
 	cellRightMargin: number;
 	cellRunGutter: number;
@@ -45,39 +71,14 @@ export interface NotebookLayoutConfiguration {
 	markdownCellBottomMargin: number;
 	markdownPreviewPadding: number;
 	markdownFoldHintHeight: number;
-	// bottomToolbarGap: number;
-	// bottomToolbarHeight: number;
 	editorToolbarHeight: number;
 	editorTopPadding: number;
 	editorBottomPadding: number;
 	editorBottomPaddingWithoutStatusBar: number;
 	collapsedIndicatorHeight: number;
-	showCellStatusBar: ShowCellStatusBarType;
 	cellStatusBarHeight: number;
-	cellToolbarLocation: string | { [key: string]: string };
-	cellToolbarInteraction: string;
-	compactView: boolean;
-	focusIndicator: 'border' | 'gutter';
-	insertToolbarPosition: 'betweenCells' | 'notebookToolbar' | 'both' | 'hidden';
-	insertToolbarAlignment: 'left' | 'center';
-	globalToolbar: boolean;
-	stickyScroll: boolean;
-	consolidatedOutputButton: boolean;
-	consolidatedRunButton: boolean;
-	showFoldingControls: 'always' | 'never' | 'mouseover';
-	dragAndDropEnabled: boolean;
-	fontSize: number;
-	outputFontSize: number;
-	outputFontFamily: string;
-	outputLineHeight: number;
-	markupFontSize: number;
 	focusIndicatorLeftMargin: number;
-	editorOptionsCustomizations: any | undefined;
 	focusIndicatorGap: number;
-	interactiveWindowCollapseCodeCells: InteractiveWindowCollapseCodeCells;
-	outputScrolling: boolean;
-	outputWordWrap: boolean;
-	outputLineLimit: number;
 }
 
 export interface NotebookOptionsChangeEvent {
@@ -128,7 +129,7 @@ const compactConfigConstants = Object.freeze({
 });
 
 export class NotebookOptions extends Disposable {
-	private _layoutConfiguration: NotebookLayoutConfiguration;
+	private _layoutConfiguration: NotebookLayoutConfiguration & NotebookDisplayOptions;
 	protected readonly _onDidChangeOptions = this._register(new Emitter<NotebookOptionsChangeEvent>());
 	readonly onDidChangeOptions = this._onDidChangeOptions.event;
 
@@ -536,7 +537,11 @@ export class NotebookOptions extends Disposable {
 			};
 	}
 
-	getLayoutConfiguration(): NotebookLayoutConfiguration {
+	getLayoutConfiguration(): NotebookLayoutConfiguration & NotebookDisplayOptions {
+		return this._layoutConfiguration;
+	}
+
+	getDisplayOptions(): NotebookDisplayOptions {
 		return this._layoutConfiguration;
 	}
 

--- a/src/vs/workbench/contrib/notebook/browser/notebookOptions.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookOptions.ts
@@ -540,6 +540,14 @@ export class NotebookOptions extends Disposable {
 		return this._layoutConfiguration;
 	}
 
+	getCellEditorContainerLeftMargin() {
+		const {
+			codeCellLeftMargin,
+			cellRunGutter
+		} = this._layoutConfiguration;
+		return codeCellLeftMargin + cellRunGutter;
+	}
+
 	computeCollapsedMarkdownCellHeight(viewType: string): number {
 		const { bottomToolbarGap } = this.computeBottomToolbarDimensions(viewType);
 		return this._layoutConfiguration.markdownCellTopMargin

--- a/src/vs/workbench/contrib/notebook/browser/view/cellParts/cellDnd.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/cellParts/cellDnd.ts
@@ -307,7 +307,7 @@ export class CellDragAndDropController extends Disposable {
 		}
 
 		const onDragEnd = () => {
-			if (!this.notebookEditor.notebookOptions.getLayoutConfiguration().dragAndDropEnabled || !!this.notebookEditor.isReadOnly) {
+			if (!this.notebookEditor.notebookOptions.getDisplayOptions().dragAndDropEnabled || !!this.notebookEditor.isReadOnly) {
 				return;
 			}
 
@@ -324,7 +324,7 @@ export class CellDragAndDropController extends Disposable {
 				return;
 			}
 
-			if (!this.notebookEditor.notebookOptions.getLayoutConfiguration().dragAndDropEnabled || !!this.notebookEditor.isReadOnly) {
+			if (!this.notebookEditor.notebookOptions.getDisplayOptions().dragAndDropEnabled || !!this.notebookEditor.isReadOnly) {
 				return;
 			}
 
@@ -343,7 +343,7 @@ export class CellDragAndDropController extends Disposable {
 	}
 
 	public startExplicitDrag(cell: ICellViewModel, _dragOffsetY: number) {
-		if (!this.notebookEditor.notebookOptions.getLayoutConfiguration().dragAndDropEnabled || !!this.notebookEditor.isReadOnly) {
+		if (!this.notebookEditor.notebookOptions.getDisplayOptions().dragAndDropEnabled || !!this.notebookEditor.isReadOnly) {
 			return;
 		}
 
@@ -352,7 +352,7 @@ export class CellDragAndDropController extends Disposable {
 	}
 
 	public explicitDrag(cell: ICellViewModel, dragOffsetY: number) {
-		if (!this.notebookEditor.notebookOptions.getLayoutConfiguration().dragAndDropEnabled || !!this.notebookEditor.isReadOnly) {
+		if (!this.notebookEditor.notebookOptions.getDisplayOptions().dragAndDropEnabled || !!this.notebookEditor.isReadOnly) {
 			return;
 		}
 

--- a/src/vs/workbench/contrib/notebook/browser/view/cellParts/cellOutput.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/cellParts/cellOutput.ts
@@ -286,7 +286,7 @@ class CellOutputElement extends Disposable {
 			return;
 		}
 
-		const useConsolidatedButton = this.notebookEditor.notebookOptions.getLayoutConfiguration().consolidatedOutputButton;
+		const useConsolidatedButton = this.notebookEditor.notebookOptions.getDisplayOptions().consolidatedOutputButton;
 
 		outputItemDiv.style.position = 'relative';
 		const mimeTypePicker = DOM.$('.cell-output-toolbar');

--- a/src/vs/workbench/contrib/notebook/browser/view/cellParts/cellToolbars.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/cellParts/cellToolbars.ts
@@ -46,7 +46,7 @@ export class BetweenCellToolbar extends CellOverlayPart {
 		const betweenCellToolbar = this._register(new ToolBar(this._bottomCellToolbarContainer, this.contextMenuService, {
 			actionViewItemProvider: action => {
 				if (action instanceof MenuItemAction) {
-					if (this._notebookEditor.notebookOptions.getLayoutConfiguration().insertToolbarAlignment === 'center') {
+					if (this._notebookEditor.notebookOptions.getDisplayOptions().insertToolbarAlignment === 'center') {
 						return this.instantiationService.createInstance(CodiconActionViewItem, action, undefined);
 					} else {
 						return this.instantiationService.createInstance(MenuEntryActionViewItem, action, undefined);

--- a/src/vs/workbench/contrib/notebook/browser/view/cellParts/markupCell.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/cellParts/markupCell.ts
@@ -233,7 +233,7 @@ export class MarkupCell extends Disposable {
 	}
 
 	private updateFoldingIconShowClass() {
-		const showFoldingIcon = this.notebookEditor.notebookOptions.getLayoutConfiguration().showFoldingControls;
+		const showFoldingIcon = this.notebookEditor.notebookOptions.getDisplayOptions().showFoldingControls;
 		this.templateData.foldingIndicator.classList.remove('mouseover', 'always');
 		this.templateData.foldingIndicator.classList.add(showFoldingIcon);
 	}

--- a/src/vs/workbench/contrib/notebook/browser/viewModel/cellEditorOptions.ts
+++ b/src/vs/workbench/contrib/notebook/browser/viewModel/cellEditorOptions.ts
@@ -83,8 +83,7 @@ export class BaseCellEditorOptions extends Disposable implements IBaseCellEditor
 
 	private _computeEditorOptions() {
 		const editorOptions = deepClone(this.configurationService.getValue<IEditorOptions>('editor', { overrideIdentifier: this.language }));
-		const layoutConfig = this.notebookOptions.getLayoutConfiguration();
-		const editorOptionsOverrideRaw = layoutConfig.editorOptionsCustomizations ?? {};
+		const editorOptionsOverrideRaw = this.notebookOptions.getDisplayOptions().editorOptionsCustomizations ?? {};
 		const editorOptionsOverride: { [key: string]: any } = {};
 		for (const key in editorOptionsOverrideRaw) {
 			if (key.indexOf('editor.') === 0) {

--- a/src/vs/workbench/contrib/notebook/browser/viewParts/notebookEditorStickyScroll.ts
+++ b/src/vs/workbench/contrib/notebook/browser/viewParts/notebookEditorStickyScroll.ts
@@ -116,7 +116,7 @@ export class NotebookStickyScroll extends Disposable {
 	) {
 		super();
 
-		if (this.notebookEditor.notebookOptions.getLayoutConfiguration().stickyScroll) {
+		if (this.notebookEditor.notebookOptions.getDisplayOptions().stickyScroll) {
 			this.init();
 		}
 
@@ -143,7 +143,7 @@ export class NotebookStickyScroll extends Disposable {
 	}
 
 	private updateConfig() {
-		if (this.notebookEditor.notebookOptions.getLayoutConfiguration().stickyScroll) {
+		if (this.notebookEditor.notebookOptions.getDisplayOptions().stickyScroll) {
 			this.init();
 		} else {
 			this._disposables.clear();
@@ -154,7 +154,7 @@ export class NotebookStickyScroll extends Disposable {
 	}
 
 	private setTop() {
-		if (this.notebookEditor.notebookOptions.getLayoutConfiguration().globalToolbar) {
+		if (this.notebookEditor.notebookOptions.getDisplayOptions().globalToolbar) {
 			this.domNode.style.top = '26px';
 		} else {
 			this.domNode.style.top = '0px';

--- a/src/vs/workbench/contrib/notebook/browser/viewParts/notebookEditorToolbar.ts
+++ b/src/vs/workbench/contrib/notebook/browser/viewParts/notebookEditorToolbar.ts
@@ -253,7 +253,7 @@ export class NotebookEditorWorkbenchToolbar extends Disposable {
 		this._notebookGlobalActionsMenu = this._register(this.menuService.createMenu(this.notebookEditor.creationOptions.menuIds.notebookToolbar, this.contextKeyService));
 		this._register(this._notebookGlobalActionsMenu);
 
-		this._useGlobalToolbar = this.notebookOptions.getLayoutConfiguration().globalToolbar;
+		this._useGlobalToolbar = this.notebookOptions.getDisplayOptions().globalToolbar;
 		this._renderLabel = this._convertConfiguration(this.configurationService.getValue(NotebookSetting.globalToolbarShowLabel));
 		this._updateStrategy();
 
@@ -337,7 +337,7 @@ export class NotebookEditorWorkbenchToolbar extends Disposable {
 
 		this._register(this.notebookOptions.onDidChangeOptions(e => {
 			if (e.globalToolbar !== undefined) {
-				this._useGlobalToolbar = this.notebookOptions.getLayoutConfiguration().globalToolbar;
+				this._useGlobalToolbar = this.notebookOptions.getDisplayOptions().globalToolbar;
 				this._showNotebookActionsinEditorToolbar();
 			}
 		}));

--- a/src/vs/workbench/contrib/notebook/browser/viewParts/notebookEditorWidgetContextKeys.ts
+++ b/src/vs/workbench/contrib/notebook/browser/viewParts/notebookEditorWidgetContextKeys.ts
@@ -194,7 +194,7 @@ export class NotebookEditorContextKeys {
 	}
 
 	private _updateForNotebookOptions(): void {
-		const layout = this._editor.notebookOptions.getLayoutConfiguration();
+		const layout = this._editor.notebookOptions.getDisplayOptions();
 		this._useConsolidatedOutputButton.set(layout.consolidatedOutputButton);
 		this._cellToolbarLocation.set(this._editor.notebookOptions.computeCellToolbarLocation(this._editor.textModel?.viewType));
 	}


### PR DESCRIPTION
Separate display and layout options.

This pull request includes changes to the notebook editor's display and layout options. Specifically, it extracts the cell container left margin and separates the display and layout options. This ensures that the notebook editor's options are more organized and easier to manage.