### PR TITLE
[CLI] Add --show-origin option to extensions list

### DIFF
--- a/cli/src/bin/code/legacy_args.rs
+++ b/cli/src/bin/code/legacy_args.rs
@@ -70,6 +70,7 @@ pub fn try_parse_legacy(
 				subcommand: ExtensionSubcommand::List(ListExtensionArgs {
 					category: get_first_arg_value("category"),
 					show_versions: args.contains_key("show-versions"),
+					show_origin: args.contains_key("show-origin"),
 				}),
 				desktop_code_options,
 			})),
@@ -117,6 +118,7 @@ mod tests {
 			"--category",
 			"themes",
 			"--show-versions",
+			"--show-origin",
 		];
 		let cli = try_parse_legacy(args).unwrap();
 

--- a/cli/src/commands/args.rs
+++ b/cli/src/commands/args.rs
@@ -264,6 +264,9 @@ impl ExtensionSubcommand {
 				if args.show_versions {
 					target.push("--show-versions".to_string());
 				}
+				if args.show_origin {
+					target.push("--show-origin".to_string());
+				}
 				if let Some(category) = &args.category {
 					target.push(format!("--category={}", category));
 				}
@@ -297,6 +300,10 @@ pub struct ListExtensionArgs {
 	/// Show versions of installed extensions, when using --list-extensions.
 	#[clap(long)]
 	pub show_versions: bool,
+
+	/// Show origin of installed extensions, when using --list-extensions.
+	#[clap(long)]
+	pub show_origin: bool,
 }
 
 #[derive(Args, Debug, Clone)]

--- a/cli/src/tunnels/code_server.rs
+++ b/cli/src/tunnels/code_server.rs
@@ -60,6 +60,7 @@ pub struct CodeServerArgs {
 	pub uninstall_extensions: Vec<String>,
 	pub list_extensions: bool,
 	pub show_versions: bool,
+	pub show_origin: bool,
 	pub category: Option<String>,
 	pub pre_release: bool,
 	pub force: bool,
@@ -133,6 +134,9 @@ impl CodeServerArgs {
 			args.push(String::from("--list-extensions"));
 			if self.show_versions {
 				args.push(String::from("--show-versions"));
+			}
+			if self.show_origin {
+				args.push(String::from("--show_origin"));
 			}
 			if let Some(i) = &self.category {
 				args.push(format!("--category={}", i));

--- a/resources/completions/bash/code
+++ b/resources/completions/bash/code
@@ -46,7 +46,7 @@ _@@APPNAME@@()
 		COMPREPLY=( $( compgen -W '-d --diff --folder-uri -a --add -g
 			--goto -n --new-window -r --reuse-window -w --wait --locale=
 			--user-data-dir -v --version -h --help --extensions-dir
-			--list-extensions --show-versions --install-extension
+			--list-extensions --show-versions --show-origin --install-extension
 			--uninstall-extension --enable-proposed-api --verbose --log -s
 			--status -p --performance --prof-startup --disable-extensions
 			--disable-extension --inspect-extensions

--- a/resources/completions/zsh/_code
+++ b/resources/completions/zsh/_code
@@ -19,6 +19,7 @@ arguments=(
 	'--list-extensions[list the installed extensions]'
 	'--category[filters installed extension list by category, when using --list-extensions]'
 	'--show-versions[show versions of installed extensions, when using --list-extensions]'
+	'--show-origin[Show origin of installed extensions, when using --list-extensions]'
 	'--install-extension[install an extension]:id or path:_files -g "*.vsix(-.)"'
 	'--uninstall-extension[uninstall an extension]:id or path:_files -g "*.vsix(-.)"'
 	'--enable-proposed-api[enables proposed API features for extensions]::extension id: '

--- a/src/vs/code/node/cliProcessMain.ts
+++ b/src/vs/code/node/cliProcessMain.ts
@@ -266,7 +266,7 @@ class CliMain extends Disposable {
 
 		// List Extensions
 		if (this.argv['list-extensions']) {
-			return instantiationService.createInstance(ExtensionManagementCLI, new ConsoleLogger(LogLevel.Info, false)).listExtensions(!!this.argv['show-versions'], this.argv['category'], profileLocation);
+			return instantiationService.createInstance(ExtensionManagementCLI, new ConsoleLogger(LogLevel.Info, false)).listExtensions(!!this.argv['show-versions'], !!this.argv['show-origin'], this.argv['category'], profileLocation);
 		}
 
 		// Install Extension

--- a/src/vs/platform/environment/common/argv.ts
+++ b/src/vs/platform/environment/common/argv.ts
@@ -77,6 +77,7 @@ export interface NativeParsedArgs {
 	'disable-extension'?: string[]; // undefined or array of 1 or more
 	'list-extensions'?: boolean;
 	'show-versions'?: boolean;
+	'show-origin'?: boolean;
 	'category'?: string;
 	'install-extension'?: string[]; // undefined or array of 1 or more
 	'pre-release'?: boolean;

--- a/src/vs/platform/environment/node/argv.ts
+++ b/src/vs/platform/environment/node/argv.ts
@@ -96,6 +96,7 @@ export const OPTIONS: OptionDescriptions<Required<NativeParsedArgs>> = {
 	'builtin-extensions-dir': { type: 'string' },
 	'list-extensions': { type: 'boolean', cat: 'e', description: localize('listExtensions', "List the installed extensions.") },
 	'show-versions': { type: 'boolean', cat: 'e', description: localize('showVersions', "Show versions of installed extensions, when using --list-extensions.") },
+	'show-origin': { type: 'boolean', cat: 'e', description: localize('showOrigin', "Show origin of installed extensions, when using --list-extensions.") },
 	'category': { type: 'string', allowEmptyValue: true, cat: 'e', description: localize('category', "Filters installed extensions by provided category, when using --list-extensions."), args: 'category' },
 	'install-extension': { type: 'string[]', cat: 'e', args: 'ext-id | path', description: localize('installExtension', "Installs or updates an extension. The argument is either an extension id or a path to a VSIX. The identifier of an extension is '${publisher}.${name}'. Use '--force' argument to update to latest version. To install a specific version provide '@${version}'. For example: 'vscode.csharp@1.2.3'.") },
 	'pre-release': { type: 'boolean', cat: 'e', description: localize('install prerelease', "Installs the pre-release version of the extension, when using --install-extension") },

--- a/src/vs/platform/extensionManagement/common/extensionManagementCLI.ts
+++ b/src/vs/platform/extensionManagement/common/extensionManagementCLI.ts
@@ -28,6 +28,18 @@ function getId(manifest: IExtensionManifest, withVersion?: boolean): string {
 	}
 }
 
+function getOrigin(extension: ILocalExtension): string {
+	if (extension.isBuiltin) {
+		return `builtin`;
+	} else if (extension.preRelease) {
+		return `prerelease`;
+	} else if (!extension.identifier.uuid) {
+		return `vscx`;
+	} else {
+		return `marketplace`;
+	}
+}
+
 type InstallVSIXInfo = { vsix: URI; installOptions: InstallOptions };
 type InstallExtensionInfo = { id: string; version?: string; installOptions: InstallOptions };
 
@@ -43,7 +55,7 @@ export class ExtensionManagementCLI {
 		return undefined;
 	}
 
-	public async listExtensions(showVersions: boolean, category?: string, profileLocation?: URI): Promise<void> {
+	public async listExtensions(showVersions: boolean, showOrigin: boolean, category?: string, profileLocation?: URI): Promise<void> {
 		let extensions = await this.extensionManagementService.getInstalled(ExtensionType.User, profileLocation);
 		const categories = EXTENSION_CATEGORIES.map(c => c.toLowerCase());
 		if (category && category !== '') {
@@ -74,7 +86,11 @@ export class ExtensionManagementCLI {
 		for (const extension of extensions) {
 			if (lastId !== extension.identifier.id) {
 				lastId = extension.identifier.id;
-				this.logger.info(getId(extension.manifest, showVersions));
+				if (showOrigin) {
+					this.logger.info(`${getId(extension.manifest, showVersions)} (${getOrigin(extension)})`);
+				} else {
+					this.logger.info(getId(extension.manifest, showVersions));
+				}
 			}
 		}
 	}

--- a/src/vs/server/node/remoteExtensionHostAgentCli.ts
+++ b/src/vs/server/node/remoteExtensionHostAgentCli.ts
@@ -145,7 +145,7 @@ class CliMain extends Disposable {
 
 		// List Extensions
 		if (this.args['list-extensions']) {
-			return extensionManagementCLI.listExtensions(!!this.args['show-versions'], this.args['category']);
+			return extensionManagementCLI.listExtensions(!!this.args['show-versions'], !!this.args['show-origin'], this.args['category']);
 		}
 
 		// Install Extension

--- a/src/vs/server/node/server.cli.ts
+++ b/src/vs/server/node/server.cli.ts
@@ -70,6 +70,7 @@ const isSupportedForPipe = (optionId: keyof RemoteParsedArgs) => {
 		case 'list-extensions':
 		case 'force':
 		case 'show-versions':
+		case 'show-origin':
 		case 'category':
 		case 'verbose':
 		case 'remote':
@@ -221,7 +222,7 @@ export async function main(desc: ProductDescription, args: string[]): Promise<vo
 			const cmdLine: string[] = [];
 			parsedArgs['install-extension']?.forEach(id => cmdLine.push('--install-extension', id));
 			parsedArgs['uninstall-extension']?.forEach(id => cmdLine.push('--uninstall-extension', id));
-			['list-extensions', 'force', 'show-versions', 'category'].forEach(opt => {
+			['list-extensions', 'force', 'show-versions', 'show-origin', 'category'].forEach(opt => {
 				const value = parsedArgs[<keyof NativeParsedArgs>opt];
 				if (value !== undefined) {
 					cmdLine.push(`--${opt}=${value}`);
@@ -296,7 +297,7 @@ export async function main(desc: ProductDescription, args: string[]): Promise<vo
 		if (parsedArgs['install-extension'] !== undefined || parsedArgs['uninstall-extension'] !== undefined || parsedArgs['list-extensions']) {
 			sendToPipe({
 				type: 'extensionManagement',
-				list: parsedArgs['list-extensions'] ? { showVersions: parsedArgs['show-versions'], category: parsedArgs['category'] } : undefined,
+				list: parsedArgs['list-extensions'] ? { showVersions: parsedArgs['show-versions'], showOrigin: parsedArgs['show-origin'], category: parsedArgs['category'] } : undefined,
 				install: asExtensionIdOrVSIX(parsedArgs['install-extension']),
 				uninstall: asExtensionIdOrVSIX(parsedArgs['uninstall-extension']),
 				force: parsedArgs['force']

--- a/src/vs/server/node/serverEnvironmentService.ts
+++ b/src/vs/server/node/serverEnvironmentService.ts
@@ -64,6 +64,7 @@ export const serverOptions: OptionDescriptions<Required<ServerParsedArgs>> = {
 	'locate-extension': OPTIONS['locate-extension'],
 
 	'show-versions': OPTIONS['show-versions'],
+	'show-origin': OPTIONS['show-origin'],
 	'category': OPTIONS['category'],
 	'force': OPTIONS['force'],
 	'do-not-sync': OPTIONS['do-not-sync'],
@@ -181,6 +182,7 @@ export interface ServerParsedArgs {
 	'list-extensions'?: boolean;
 	'locate-extension'?: string[];
 	'show-versions'?: boolean;
+	'show-origin'?: boolean;
 	'category'?: string;
 	force?: boolean; // used by install-extension
 	'do-not-sync'?: boolean; // used by install-extension

--- a/src/vs/workbench/api/browser/mainThreadCLICommands.ts
+++ b/src/vs/workbench/api/browser/mainThreadCLICommands.ts
@@ -45,7 +45,7 @@ CommandsRegistry.registerCommand('_remoteCLI.getSystemStatus', function (accesso
 });
 
 interface ManageExtensionsArgs {
-	list?: { showVersions?: boolean; category?: string };
+	list?: { showVersions?: boolean; showOrigin?: boolean; category?: string };
 	install?: (string | URI)[];
 	uninstall?: string[];
 	force?: boolean;
@@ -68,7 +68,7 @@ CommandsRegistry.registerCommand('_remoteCLI.manageExtensions', async function (
 	const cliService = instantiationService.createChild(new ServiceCollection([IExtensionManagementService, remoteExtensionManagementService])).createInstance(RemoteExtensionManagementCLI, logger);
 
 	if (args.list) {
-		await cliService.listExtensions(!!args.list.showVersions, args.list.category, undefined);
+		await cliService.listExtensions(!!args.list.showVersions, !!args.list.showOrigin, args.list.category, undefined);
 	} else {
 		const revive = (inputs: (string | UriComponents)[]) => inputs.map(input => isString(input) ? input : URI.revive(input));
 		if (Array.isArray(args.install) && args.install.length) {

--- a/src/vs/workbench/api/node/extHostCLIServer.ts
+++ b/src/vs/workbench/api/node/extHostCLIServer.ts
@@ -37,7 +37,7 @@ export interface StatusPipeArgs {
 
 export interface ExtensionManagementPipeArgs {
 	type: 'extensionManagement';
-	list?: { showVersions?: boolean; category?: string };
+	list?: { showVersions?: boolean; showOrigin?: boolean; category?: string };
 	install?: string[];
 	uninstall?: string[];
 	force?: boolean;


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/196155

This PR add to the `--list-extensions` command (in the extension management CLI) an option `--show-origin` that return the origin of each extension while listing them.
It will allow external tools that use this command to parse this result and distinguish between:
- Released extensions in the marketplace
- Prerelease extensions from the marketplace
- Not published (i.e. vscx) extensions

Example of return:
```
$ ./scripts/code-cli.sh --list-extensions --show-origin
ms-python.python (prerelease)
ms-python.vscode-pylance (marketplace)
vscode-sampless.helloworld-sample (vscx)
```

This is also compatible with `--show-versions` argument:
```
$ ./scripts/code-cli.sh --list-extensions --show-versions --show-origin
ms-python.python@2023.21.13141007 (prerelease)
ms-python.vscode-pylance@2023.11.10 (marketplace)
vscode-sampless.helloworld-sample@0.0.1 (vscx)
```

This have been linted using yarn and tested with the provided test.sh script.
