### PR TITLE
[Acc] Keyboard accessible tooltips- Fixes #132344

### DIFF
--- a/src/vs/base/browser/ui/actionbar/actionViewItems.ts
+++ b/src/vs/base/browser/ui/actionbar/actionViewItems.ts
@@ -219,7 +219,7 @@ export class BaseActionViewItem extends Disposable implements IActionViewItem {
 			return;
 		}
 		const title = this.getTooltip() ?? '';
-		this.updateAriaLabel();
+		this.updateAriaLabel(title);
 		if (!this.options.hoverDelegate) {
 			this.element.title = title;
 		} else {
@@ -233,9 +233,8 @@ export class BaseActionViewItem extends Disposable implements IActionViewItem {
 		}
 	}
 
-	protected updateAriaLabel(): void {
+	protected updateAriaLabel(title: string): void {
 		if (this.element) {
-			const title = this.getTooltip() ?? '';
 			this.element.setAttribute('aria-label', title);
 		}
 	}
@@ -404,10 +403,10 @@ export class ActionViewItem extends BaseActionViewItem {
 		}
 	}
 
-	protected override updateAriaLabel(): void {
+	protected override updateAriaLabel(title: string): void {
 		if (this.label) {
-			const title = this.getTooltip() ?? '';
 			this.label.setAttribute('aria-label', title);
+			this.label.title = title;
 		}
 	}
 

--- a/src/vs/platform/windows/electron-main/windows.ts
+++ b/src/vs/platform/windows/electron-main/windows.ts
@@ -132,7 +132,7 @@ export function defaultBrowserWindowOptions(accessor: ServicesAccessor, windowSt
 			autoplayPolicy: 'user-gesture-required',
 			// Enable experimental css highlight api https://chromestatus.com/feature/5436441440026624
 			// Refs https://github.com/microsoft/vscode/issues/140098
-			enableBlinkFeatures: 'HighlightAPI',
+			enableBlinkFeatures: 'HighlightAPI, KeyboardAccessibleTooltip',
 			...overrides?.webPreferences,
 			sandbox: true
 		},

--- a/src/vs/workbench/browser/parts/editor/breadcrumbsControl.ts
+++ b/src/vs/workbench/browser/parts/editor/breadcrumbsControl.ts
@@ -130,6 +130,9 @@ class FileItem extends BreadcrumbsItem {
 	render(container: HTMLElement): void {
 		// file/folder
 		const label = this._labels.create(container);
+		this._disposables.add(label.onDidRender(() => {
+			container.title = container.children[0]?.ariaLabel ?? '';
+		}));
 		label.setFile(this.element.uri, {
 			hidePath: true,
 			hideIcon: this.element.kind === FileKind.FOLDER || !this.options.showFileIcons,

--- a/src/vs/workbench/contrib/codeEditor/browser/outline/documentSymbolsTree.ts
+++ b/src/vs/workbench/contrib/codeEditor/browser/outline/documentSymbolsTree.ts
@@ -134,12 +134,14 @@ export class DocumentSymbolRenderer implements ITreeRenderer<OutlineElement, Fuz
 	renderElement(node: ITreeNode<OutlineElement, FuzzyScore>, _index: number, template: DocumentSymbolTemplate): void {
 		const { element } = node;
 		const extraClasses = ['nowrap'];
+		const title = localize('title.template', "{0} ({1})", element.symbol.name, symbolKindNames[element.symbol.kind]);
 		const options: IIconLabelValueOptions = {
 			matches: createMatches(node.filterData),
 			labelEscapeNewLines: true,
 			extraClasses,
-			title: localize('title.template', "{0} ({1})", element.symbol.name, symbolKindNames[element.symbol.kind])
+			title
 		};
+		template.container.title = title;
 		if (this._configurationService.getValue(OutlineConfigKeys.icons)) {
 			// add styles for the icons
 			template.iconClass.className = '';


### PR DESCRIPTION
Enables the Blink feature keyboard accessible tooltips

Ensures some elements with tabindex=-1 have the title attribute (breadcrumbs and the editor title toolbar), allowing keyboard accessible tooltips

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fixes #132344 

I navigate with the keyboard and see tooltips in the breadcrumb and the editor title (Split Editor Right) and the layout toggles (Toggle Panel)

However, when using the mouse, some things have double tooltips like the layout toggles.