### PR TITLE
Various improvements to terminal sticky scroll and command navigation

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -168,6 +168,7 @@
 
 	// Temporarily enabled for self-hosting
 	"terminal.integrated.enableStickyScroll": true,
+	"terminal.integrated.stickyScroll.enabled": true,
 
 	// Temporarily enabled for self-hosting
 	"scm.experimental.showSyncInformation": {

--- a/src/vs/platform/terminal/common/capabilities/commandDetectionCapability.ts
+++ b/src/vs/platform/terminal/common/capabilities/commandDetectionCapability.ts
@@ -230,13 +230,13 @@ export class CommandDetectionCapability extends Disposable implements ICommandDe
 		}
 
 		// Line is before any registered commands
-		if (this._commands[0].marker!.line > line) {
+		if ((this._commands[0].promptStartMarker ?? this._commands[0].marker!).line > line) {
 			return undefined;
 		}
 
 		// Iterate backwards through commands to find the right one
 		for (let i = this.commands.length - 1; i >= 0; i--) {
-			if (this.commands[i].marker!.line <= line - 1) {
+			if ((this.commands[i].promptStartMarker ?? this.commands[i].marker!).line <= line - 1) {
 				return this.commands[i];
 			}
 		}

--- a/src/vs/platform/terminal/common/capabilities/commandDetectionCapability.ts
+++ b/src/vs/platform/terminal/common/capabilities/commandDetectionCapability.ts
@@ -1084,26 +1084,29 @@ export function getLinesForCommand(buffer: IBuffer, command: ITerminalCommand, c
 	return lines;
 }
 
-export function getPromptRowCount(command: ITerminalCommand, buffer: IBuffer): number {
-	if (!command.marker || !command.promptStartMarker) {
+export function getPromptRowCount(command: ITerminalCommand | ICurrentPartialCommand, buffer: IBuffer): number {
+	const marker = 'hasOutput' in command ? command.marker : command.commandStartMarker;
+	if (!marker || !command.promptStartMarker) {
 		return 1;
 	}
 	let promptRowCount = 1;
 	let promptStartLine = command.promptStartMarker.line;
 	// Trim any leading whitespace-only lines to retain vertical space
-	while (promptStartLine < command.marker.line && (buffer.getLine(promptStartLine)?.translateToString(true) ?? '').length === 0) {
+	while (promptStartLine < marker.line && (buffer.getLine(promptStartLine)?.translateToString(true) ?? '').length === 0) {
 		promptStartLine++;
 	}
-	promptRowCount = command.marker.line - promptStartLine + 1;
+	promptRowCount = marker.line - promptStartLine + 1;
 	return promptRowCount;
 }
 
-export function getCommandRowCount(command: ITerminalCommand): number {
-	if (!command.marker || !command.executedMarker) {
+export function getCommandRowCount(command: ITerminalCommand | ICurrentPartialCommand): number {
+	const marker = 'hasOutput' in command ? command.marker : command.commandStartMarker;
+	const executedMarker = 'hasOutput' in command ? command.executedMarker : command.commandExecutedMarker;
+	if (!marker || !executedMarker) {
 		return 1;
 	}
-	const commandExecutedLine = Math.max(command.executedMarker.line, command.marker.line);
-	const commandRowCount = commandExecutedLine - command.marker.line + 1;
+	const commandExecutedLine = Math.max(executedMarker.line, marker.line);
+	const commandRowCount = commandExecutedLine - marker.line + 1;
 	return commandRowCount;
 
 }

--- a/src/vs/platform/terminal/common/capabilities/commandDetectionCapability.ts
+++ b/src/vs/platform/terminal/common/capabilities/commandDetectionCapability.ts
@@ -1085,20 +1085,27 @@ export function getLinesForCommand(buffer: IBuffer, command: ITerminalCommand, c
 }
 
 export function getPromptRowCount(command: ITerminalCommand, buffer: IBuffer): number {
-	if (!command.marker) {
+	if (!command.marker || !command.promptStartMarker) {
 		return 1;
 	}
 	let promptRowCount = 1;
-	let promptStartLine = command.marker.line;
-	if (command.promptStartMarker) {
-		promptStartLine = Math.min(command.promptStartMarker?.line ?? command.marker.line, command.marker.line);
-		// Trim any leading whitespace-only lines to retain vertical space
-		while (promptStartLine < command.marker.line && (buffer.getLine(promptStartLine)?.translateToString(true) ?? '').length === 0) {
-			promptStartLine++;
-		}
-		promptRowCount = command.marker.line - promptStartLine + 1;
+	let promptStartLine = command.promptStartMarker.line;
+	// Trim any leading whitespace-only lines to retain vertical space
+	while (promptStartLine < command.marker.line && (buffer.getLine(promptStartLine)?.translateToString(true) ?? '').length === 0) {
+		promptStartLine++;
 	}
+	promptRowCount = command.marker.line - promptStartLine + 1;
 	return promptRowCount;
+}
+
+export function getCommandRowCount(command: ITerminalCommand): number {
+	if (!command.marker || !command.executedMarker) {
+		return 1;
+	}
+	const commandExecutedLine = Math.max(command.executedMarker.line, command.marker.line);
+	const commandRowCount = commandExecutedLine - command.marker.line + 1;
+	return commandRowCount;
+
 }
 
 function getXtermLineContent(buffer: IBuffer, lineStart: number, lineEnd: number, cols: number): string {

--- a/src/vs/platform/terminal/common/capabilities/commandDetectionCapability.ts
+++ b/src/vs/platform/terminal/common/capabilities/commandDetectionCapability.ts
@@ -1106,7 +1106,12 @@ export function getCommandRowCount(command: ITerminalCommand | ICurrentPartialCo
 		return 1;
 	}
 	const commandExecutedLine = Math.max(executedMarker.line, marker.line);
-	const commandRowCount = commandExecutedLine - marker.line + 1;
+	let commandRowCount = commandExecutedLine - marker.line + 1;
+	// Trim the last line if the cursor X is in the left-most cell
+	const executedX = 'hasOutput' in command ? command.executedX : command.commandExecutedX;
+	if (executedX === 0) {
+		commandRowCount--;
+	}
 	return commandRowCount;
 
 }

--- a/src/vs/platform/terminal/common/capabilities/commandDetectionCapability.ts
+++ b/src/vs/platform/terminal/common/capabilities/commandDetectionCapability.ts
@@ -3,12 +3,12 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Barrier, timeout } from 'vs/base/common/async';
+import { RunOnceScheduler } from 'vs/base/common/async';
 import { debounce } from 'vs/base/common/decorators';
 import { Emitter } from 'vs/base/common/event';
 import { Disposable, MandatoryMutableDisposable, MutableDisposable } from 'vs/base/common/lifecycle';
 import { ILogService } from 'vs/platform/log/common/log';
-import { ICommandDetectionCapability, TerminalCapability, ITerminalCommand, IHandleCommandOptions, ICommandInvalidationRequest, CommandInvalidationReason, ISerializedTerminalCommand, ISerializedCommandDetectionCapability } from 'vs/platform/terminal/common/capabilities/capabilities';
+import { CommandInvalidationReason, ICommandDetectionCapability, ICommandInvalidationRequest, IHandleCommandOptions, ISerializedCommandDetectionCapability, ISerializedTerminalCommand, ITerminalCommand, TerminalCapability } from 'vs/platform/terminal/common/capabilities/capabilities';
 import { ITerminalOutputMatch, ITerminalOutputMatcher } from 'vs/platform/terminal/common/terminal';
 
 // Importing types is safe in any layer
@@ -583,6 +583,12 @@ class UnixPtyHeuristics extends Disposable {
 	}
 }
 
+const enum AdjustCommandStartMarkerConstants {
+	MaxCheckLineCount = 5,
+	Interval = 20,
+	MaximumPollCount = 50,
+}
+
 /**
  * An object that integrated with and decorates the command detection capability to add heuristics
  * that adjust various markers to work better with Windows and ConPTY. This isn't depended upon the
@@ -592,7 +598,6 @@ class UnixPtyHeuristics extends Disposable {
 class WindowsPtyHeuristics extends Disposable {
 
 	private _onCursorMoveListener = this._register(new MutableDisposable());
-	private _commandStartedWindowsBarrier?: Barrier;
 	private _windowsPromptPollingInProcess: boolean = false;
 
 	constructor(
@@ -664,44 +669,98 @@ class WindowsPtyHeuristics extends Disposable {
 		}
 	}
 
+	private _tryAdjustCommandStartMarkerScheduler?: RunOnceScheduler;
+	private _tryAdjustCommandStartMarkerScannedLineCount: number = 0;
+	private _tryAdjustCommandStartMarkerPollCount: number = 0;
+
 	async handleCommandStart() {
+
 		if (this._windowsPromptPollingInProcess) {
 			this._windowsPromptPollingInProcess = false;
 		}
-		this._commandStartedWindowsBarrier = new Barrier();
 		this._capability.currentCommand.commandStartX = this._terminal.buffer.active.cursorX;
 
 		// On Windows track all cursor movements after the command start sequence
 		this._hooks.commandMarkers.length = 0;
 
-		let prompt: string | undefined = this._getWindowsPrompt();
-		// Conpty could have the wrong cursor position at this point.
-		if (!this._cursorOnNextLine() || !prompt) {
-			this._windowsPromptPollingInProcess = true;
-			// Poll for 1000ms until the cursor position is correct.
-			let i = 0;
-			for (; i < 50; i++) {
-				await timeout(20);
-				prompt = this._getWindowsPrompt();
-				if (this._store.isDisposed || !this._windowsPromptPollingInProcess || this._cursorOnNextLine() && prompt) {
-					if (!this._windowsPromptPollingInProcess) {
-						this._logService.debug('CommandDetectionCapability#_handleCommandStartWindows polling cancelled');
-					}
-					break;
+		const initialCommandStartMarker = this._capability.currentCommand.commandStartMarker = this._terminal.registerMarker(0)!;
+		this._capability.currentCommand.commandStartX = 0;
+
+		// DEBUG: Add a decoration for the original unadjusted command start position
+		// if ('registerDecoration' in this._terminal) {
+		// 	const d = (this._terminal as any).registerDecoration({
+		// 		marker: this._capability.currentCommand.commandStartMarker,
+		// 		x: this._capability.currentCommand.commandStartX
+		// 	});
+		// 	d?.onRender((e: HTMLElement) => {
+		// 		e.textContent = 'b';
+		// 		e.classList.add('xterm-sequence-decoration', 'top', 'right');
+		// 		e.title = 'Initial command start position';
+		// 	});
+		// }
+
+		// The command started sequence may be printed before the actual prompt is, for example a
+		// multi-line prompt will typically look like this where D, A and B signify the command
+		// finished, prompt started and command started sequences respectively:
+		//
+		//     D/my/cwdB
+		//     > C
+		//
+		// Due to this, it's likely that this will be called before the line has been parsed.
+		// Unfortunately, it is also the case that the actual command start data may not be parsed
+		// by the end of the task either, so a microtask cannot be used.
+		//
+		// The strategy used is to begin polling and scanning downwards for up to the next 5 lines.
+		// If it looks like a prompt is found, the command started location is adjusted. If the
+		// command executed sequences comes in before polling is done, polling is canceled and the
+		// final polling task is executed synchronously.
+		this._tryAdjustCommandStartMarkerScannedLineCount = 0;
+		this._tryAdjustCommandStartMarkerPollCount = 0;
+		this._tryAdjustCommandStartMarkerScheduler = new RunOnceScheduler(() => this._tryAdjustCommandStartMarker(initialCommandStartMarker), AdjustCommandStartMarkerConstants.Interval);
+		this._tryAdjustCommandStartMarkerScheduler.schedule();
+
+		// TODO: Cache details about polling for the future - eg. if it always fails, stop bothering
+	}
+
+	private _tryAdjustCommandStartMarker(start: IMarker) {
+		if (this._store.isDisposed) {
+			return;
+		}
+		const buffer = this._terminal.buffer.active;
+		let scannedLineCount = this._tryAdjustCommandStartMarkerScannedLineCount;
+		while (scannedLineCount < AdjustCommandStartMarkerConstants.MaxCheckLineCount && start.line + scannedLineCount < buffer.baseY + this._terminal.rows) {
+			if (this._cursorOnNextLine()) {
+				const prompt = this._getWindowsPrompt(start.line + scannedLineCount);
+				if (prompt) {
+					this._capability.currentCommand.commandStartMarker = this._terminal.registerMarker(0)!;
+					// use the regex to set the position as it's possible input has occurred
+					this._capability.currentCommand.commandStartX = prompt.length;
+					this._logService.debug('CommandDetectionCapability#_tryAdjustCommandStartMarker successfully adjusted', `${start.line} -> ${this._capability.currentCommand.commandStartMarker}:${this._capability.currentCommand.commandStartX}`);
+					this._flushPendingHandleCommandStartTask();
+					return;
 				}
 			}
-			this._windowsPromptPollingInProcess = false;
-			if (i >= 50) {
-				this._logService.debug('CommandDetectionCapability#_handleCommandStartWindows reached max attempts, ', this._cursorOnNextLine(), this._getWindowsPrompt());
-			} else if (prompt) {
-				// use the regex to set the position as it's possible input has occurred
-				this._capability.currentCommand.commandStartX = prompt.length;
+			scannedLineCount++;
+		}
+		if (scannedLineCount < AdjustCommandStartMarkerConstants.MaxCheckLineCount) {
+			this._tryAdjustCommandStartMarkerScannedLineCount = scannedLineCount;
+			if (this._tryAdjustCommandStartMarkerPollCount < AdjustCommandStartMarkerConstants.MaximumPollCount) {
+				this._tryAdjustCommandStartMarkerScheduler?.schedule();
+			} else {
+				this._flushPendingHandleCommandStartTask();
 			}
 		} else {
-			// HACK: Fire command started on the following frame on Windows to allow the cursor
-			// position to update as conpty often prints the sequence on a different line to the
-			// actual line the command started on.
-			await timeout(0);
+			this._flushPendingHandleCommandStartTask();
+		}
+	}
+
+	private _flushPendingHandleCommandStartTask() {
+		// Perform final try adjust if necessary
+		if (this._tryAdjustCommandStartMarkerScheduler) {
+			// Max out poll count to ensure it's the last run
+			this._tryAdjustCommandStartMarkerPollCount = AdjustCommandStartMarkerConstants.MaximumPollCount;
+			this._tryAdjustCommandStartMarkerScheduler.flush();
+			this._tryAdjustCommandStartMarkerScheduler = undefined;
 		}
 
 		if (!this._capability.currentCommand.commandExecutedMarker) {
@@ -714,7 +773,7 @@ class WindowsPtyHeuristics extends Disposable {
 				}
 			});
 		}
-		this._capability.currentCommand.commandStartMarker = this._terminal.registerMarker(0);
+
 		if (this._capability.currentCommand.commandStartMarker) {
 			const line = this._terminal.buffer.active.getLine(this._capability.currentCommand.commandStartMarker.line);
 			if (line) {
@@ -723,14 +782,13 @@ class WindowsPtyHeuristics extends Disposable {
 		}
 		this._hooks.onCommandStartedEmitter.fire({ marker: this._capability.currentCommand.commandStartMarker } as ITerminalCommand);
 		this._logService.debug('CommandDetectionCapability#_handleCommandStartWindows', this._capability.currentCommand.commandStartX, this._capability.currentCommand.commandStartMarker?.line);
-		this._commandStartedWindowsBarrier.open();
 	}
 
 	handleCommandExecuted(options: IHandleCommandOptions | undefined) {
-		// TODO: Flush here?
-		// await this._commandStartedWindowsBarrier?.wait();
-		// On Windows, use the gathered cursor move markers to correct the command start and
-		// executed markers
+		if (this._tryAdjustCommandStartMarkerScheduler) {
+			this._flushPendingHandleCommandStartTask();
+		}
+		// Use the gathered cursor move markers to correct the command start and executed markers
 		this._onCursorMoveListener.clear();
 		this._evaluateCommandMarkers();
 		this._capability.currentCommand.commandExecutedX = this._terminal.buffer.active.cursorX;
@@ -865,8 +923,8 @@ class WindowsPtyHeuristics extends Disposable {
 		});
 	}
 
-	private _getWindowsPrompt(): string | undefined {
-		const line = this._terminal.buffer.active.getLine(this._terminal.buffer.active.baseY + this._terminal.buffer.active.cursorY);
+	private _getWindowsPrompt(y: number = this._terminal.buffer.active.baseY + this._terminal.buffer.active.cursorY): string | undefined {
+		const line = this._terminal.buffer.active.getLine(y);
 		if (!line) {
 			return;
 		}

--- a/src/vs/platform/terminal/common/terminal.ts
+++ b/src/vs/platform/terminal/common/terminal.ts
@@ -118,7 +118,8 @@ export const enum TerminalSettingId {
 	FocusAfterRun = 'terminal.integrated.focusAfterRun',
 	AccessibleViewPreserveCursorPosition = 'terminal.integrated.accessibleViewPreserveCursorPosition',
 	AccessibleViewFocusOnCommandExecution = 'terminal.integrated.accessibleViewFocusOnCommandExecution',
-	EnableStickyScroll = 'terminal.integrated.enableStickyScroll',
+	StickyScrollEnabled = 'terminal.integrated.stickyScroll.enabled',
+	StickyScrollMaxLineCount = 'terminal.integrated.stickyScroll.maxLineCount',
 
 	// Debug settings that are hidden from user
 

--- a/src/vs/workbench/contrib/terminal/browser/xterm-private.d.ts
+++ b/src/vs/workbench/contrib/terminal/browser/xterm-private.d.ts
@@ -11,6 +11,7 @@ export type XtermAttributes = Omit<IBufferCell, 'getWidth' | 'getChars' | 'getCo
 
 export interface IXtermCore {
 	viewport?: {
+		readonly scrollBarWidth: number;
 		_innerRefresh(): void;
 	};
 	_onData: IEventEmitter<string>;

--- a/src/vs/workbench/contrib/terminal/browser/xterm/markNavigationAddon.ts
+++ b/src/vs/workbench/contrib/terminal/browser/xterm/markNavigationAddon.ts
@@ -12,7 +12,7 @@ import { timeout } from 'vs/base/common/async';
 import { IThemeService } from 'vs/platform/theme/common/themeService';
 import { TERMINAL_OVERVIEW_RULER_CURSOR_FOREGROUND_COLOR } from 'vs/workbench/contrib/terminal/common/terminalColorRegistry';
 import { getWindow } from 'vs/base/browser/dom';
-import { getPromptRowCount } from 'vs/platform/terminal/common/capabilities/commandDetectionCapability';
+import { getCommandRowCount, getPromptRowCount } from 'vs/platform/terminal/common/capabilities/commandDetectionCapability';
 
 enum Boundary {
 	Top,
@@ -236,10 +236,11 @@ export class MarkNavigationAddon extends Disposable implements IMarkTracker, ITe
 		}
 
 		const promptRowCount = getPromptRowCount(command, this._terminal.buffer.active);
+		const commandRowCount = getCommandRowCount(command);
 		this._scrollToMarker(
 			command.marker.line - (promptRowCount - 1),
 			position,
-			command.marker
+			command.marker.line + (commandRowCount - 1)
 		);
 	}
 

--- a/src/vs/workbench/contrib/terminal/browser/xterm/markNavigationAddon.ts
+++ b/src/vs/workbench/contrib/terminal/browser/xterm/markNavigationAddon.ts
@@ -330,13 +330,7 @@ export class MarkNavigationAddon extends Disposable implements IMarkTracker, ITe
 			return;
 		}
 		if (this._selectionStart === null) {
-			// Special case for bottom marker; skip any empty commands as it's unlikely the user
-			// will want to select empty commands
-			if (this._currentMarker === Boundary.Bottom) {
-				this._selectionStart = this._getMarkers(false)[this._findPreviousMarker(false)];
-			} else {
-				this._selectionStart = this._currentMarker;
-			}
+			this._selectionStart = this._currentMarker;
 		}
 		if (this._capabilities.has(TerminalCapability.CommandDetection)) {
 			this.scrollToPreviousMark(ScrollPosition.Middle, true, true);

--- a/src/vs/workbench/contrib/terminal/browser/xterm/markNavigationAddon.ts
+++ b/src/vs/workbench/contrib/terminal/browser/xterm/markNavigationAddon.ts
@@ -276,7 +276,7 @@ export class MarkNavigationAddon extends Disposable implements IMarkTracker, ITe
 							element.classList.add('bottom');
 						}
 					} else {
-						element.classList.add('terminal-scroll-highlight', 'terminal-scroll-highlight-outline');
+						element.classList.add('terminal-scroll-highlight');
 					}
 					if (this._terminal?.element) {
 						element.style.marginLeft = `-${getWindow(this._terminal.element).getComputedStyle(this._terminal.element).paddingLeft}`;

--- a/src/vs/workbench/contrib/terminal/browser/xterm/markNavigationAddon.ts
+++ b/src/vs/workbench/contrib/terminal/browser/xterm/markNavigationAddon.ts
@@ -51,7 +51,7 @@ export class MarkNavigationAddon extends Disposable implements IMarkTracker, ITe
 		const markCapability = this._capabilities.get(TerminalCapability.BufferMarkDetection);
 		let markers: IMarker[] = [];
 		if (commandCapability) {
-			markers = coalesce(commandCapability.commands.filter(e => e.exitCode !== undefined).map(e => e.marker));
+			markers = coalesce(commandCapability.commands.filter(e => skipEmptyCommands ? e.exitCode !== undefined : true).map(e => e.marker));
 		} else if (partialCommandCapability) {
 			markers.push(...partialCommandCapability.commands);
 		}
@@ -127,12 +127,12 @@ export class MarkNavigationAddon extends Disposable implements IMarkTracker, ITe
 		} else if (this._currentMarker === Boundary.Top) {
 			markerIndex = -1;
 		} else if (this._isDisposable) {
-			markerIndex = this._findPreviousMarker(this._terminal, skipEmptyCommands);
+			markerIndex = this._findPreviousMarker(skipEmptyCommands);
 			this._currentMarker.dispose();
 			this._isDisposable = false;
 		} else {
 			if (skipEmptyCommands && this._isEmptyCommand(this._currentMarker)) {
-				markerIndex = this._findPreviousMarker(this._terminal, true);
+				markerIndex = this._findPreviousMarker(true);
 			} else {
 				markerIndex = this._getMarkers(skipEmptyCommands).indexOf(this._currentMarker) - 1;
 			}
@@ -173,12 +173,12 @@ export class MarkNavigationAddon extends Disposable implements IMarkTracker, ITe
 		} else if (this._currentMarker === Boundary.Top) {
 			markerIndex = 0;
 		} else if (this._isDisposable) {
-			markerIndex = this._findNextMarker(this._terminal, skipEmptyCommands);
+			markerIndex = this._findNextMarker(skipEmptyCommands);
 			this._currentMarker.dispose();
 			this._isDisposable = false;
 		} else {
 			if (skipEmptyCommands && this._isEmptyCommand(this._currentMarker)) {
-				markerIndex = this._findNextMarker(this._terminal, true);
+				markerIndex = this._findNextMarker(true);
 			} else {
 				markerIndex = this._getMarkers(skipEmptyCommands).indexOf(this._currentMarker) + 1;
 			}
@@ -443,7 +443,7 @@ export class MarkNavigationAddon extends Disposable implements IMarkTracker, ITe
 		}
 	}
 
-	private _findPreviousMarker(xterm: Terminal, skipEmptyCommands: boolean = false): number {
+	private _findPreviousMarker(skipEmptyCommands: boolean = false): number {
 		if (this._currentMarker === Boundary.Top) {
 			return 0;
 		} else if (this._currentMarker === Boundary.Bottom) {
@@ -460,7 +460,7 @@ export class MarkNavigationAddon extends Disposable implements IMarkTracker, ITe
 		return -1;
 	}
 
-	private _findNextMarker(xterm: Terminal, skipEmptyCommands: boolean = false): number {
+	private _findNextMarker(skipEmptyCommands: boolean = false): number {
 		if (this._currentMarker === Boundary.Top) {
 			return 0;
 		} else if (this._currentMarker === Boundary.Bottom) {

--- a/src/vs/workbench/contrib/terminal/browser/xterm/markNavigationAddon.ts
+++ b/src/vs/workbench/contrib/terminal/browser/xterm/markNavigationAddon.ts
@@ -51,7 +51,7 @@ export class MarkNavigationAddon extends Disposable implements IMarkTracker, ITe
 		const markCapability = this._capabilities.get(TerminalCapability.BufferMarkDetection);
 		let markers: IMarker[] = [];
 		if (commandCapability) {
-			markers = coalesce(commandCapability.commands.map(e => e.marker));
+			markers = coalesce(commandCapability.commands.filter(e => e.exitCode !== undefined).map(e => e.marker));
 		} else if (partialCommandCapability) {
 			markers.push(...partialCommandCapability.commands);
 		}
@@ -103,7 +103,7 @@ export class MarkNavigationAddon extends Disposable implements IMarkTracker, ITe
 		return !this._getMarkers(true).includes(marker);
 	}
 
-	scrollToPreviousMark(scrollPosition: ScrollPosition = ScrollPosition.Middle, retainSelection: boolean = false, skipEmptyCommands: boolean = false): void {
+	scrollToPreviousMark(scrollPosition: ScrollPosition = ScrollPosition.Middle, retainSelection: boolean = false, skipEmptyCommands: boolean = true): void {
 		if (!this._terminal) {
 			return;
 		}

--- a/src/vs/workbench/contrib/terminal/common/terminalConfiguration.ts
+++ b/src/vs/workbench/contrib/terminal/common/terminalConfiguration.ts
@@ -625,12 +625,20 @@ const terminalConfiguration: IConfigurationNode = {
 			type: 'boolean',
 			default: false
 		},
-		[TerminalSettingId.EnableStickyScroll]: {
-			markdownDescription: localize('terminal.integrated.enableStickyScroll', "Experimental: Whether to enable the sticky scroll overlay at the top of the terminal."),
+		[TerminalSettingId.StickyScrollEnabled]: {
+			markdownDescription: localize('terminal.integrated.stickyScroll.enabled', "Experimental: Shows the current command at the top of the terminal."),
 			type: 'boolean',
 			default: false,
 			// TODO: Prevent setting at folder level after it becomes stable,
-			// scope: ConfigurationScope.RESOURCE
+			// scope: ConfigurationScope.APPLICATION
+		},
+		[TerminalSettingId.StickyScrollMaxLineCount]: {
+			markdownDescription: localize('terminal.integrated.stickyScroll.maxLineCount', "Defines the maximum number of sticky lines to show."),
+			type: 'number',
+			default: 5,
+			minimum: 1,
+			maximum: 10,
+			scope: ConfigurationScope.APPLICATION
 		}
 	}
 };

--- a/src/vs/workbench/contrib/terminalContrib/stickyScroll/browser/media/stickyScroll.css
+++ b/src/vs/workbench/contrib/terminalContrib/stickyScroll/browser/media/stickyScroll.css
@@ -8,7 +8,6 @@
 	position: absolute;
 	left: 0;
 	right: 0;
-	top: 0;
 	z-index: 32; /* Must be higher than .xterm-viewport and decorations */
 	background: var(--vscode-terminalStickyScroll-background, var(--vscode-terminal-background, var(--vscode-panel-background)));
 	box-shadow: var(--vscode-scrollbar-shadow) 0 3px 2px -2px;

--- a/src/vs/workbench/contrib/terminalContrib/stickyScroll/browser/terminalStickyScrollContribution.ts
+++ b/src/vs/workbench/contrib/terminalContrib/stickyScroll/browser/terminalStickyScrollContribution.ts
@@ -45,7 +45,7 @@ export class TerminalStickyScrollContribution extends Disposable implements ITer
 		super();
 
 		this._register(Event.runAndSubscribe(this._configurationService.onDidChangeConfiguration, e => {
-			if (!e || e.affectsConfiguration(TerminalSettingId.EnableStickyScroll)) {
+			if (!e || e.affectsConfiguration(TerminalSettingId.StickyScrollEnabled)) {
 				this._refreshState();
 			}
 		}));
@@ -109,6 +109,6 @@ export class TerminalStickyScrollContribution extends Disposable implements ITer
 
 	private _shouldBeEnabled(): boolean {
 		const capability = this._instance.capabilities.get(TerminalCapability.CommandDetection);
-		return !!(this._configurationService.getValue(TerminalSettingId.EnableStickyScroll) && capability && this._xterm?.raw?.element);
+		return !!(this._configurationService.getValue(TerminalSettingId.StickyScrollEnabled) && capability && this._xterm?.raw?.element);
 	}
 }

--- a/src/vs/workbench/contrib/terminalContrib/stickyScroll/browser/terminalStickyScrollOverlay.ts
+++ b/src/vs/workbench/contrib/terminalContrib/stickyScroll/browser/terminalStickyScrollOverlay.ts
@@ -14,7 +14,7 @@ import { Disposable, MutableDisposable, combinedDisposable, toDisposable } from 
 import 'vs/css!./media/stickyScroll';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { ICommandDetectionCapability, ITerminalCommand } from 'vs/platform/terminal/common/capabilities/capabilities';
-import { getPromptRowCount } from 'vs/platform/terminal/common/capabilities/commandDetectionCapability';
+import { getCommandRowCount, getPromptRowCount } from 'vs/platform/terminal/common/capabilities/commandDetectionCapability';
 import { TerminalSettingId } from 'vs/platform/terminal/common/terminal';
 import { IThemeService } from 'vs/platform/theme/common/themeService';
 import { IXtermColorProvider, IXtermTerminal } from 'vs/workbench/contrib/terminal/browser/terminal';
@@ -170,16 +170,11 @@ export class TerminalStickyScrollOverlay extends Disposable {
 			return;
 		}
 
-		// Determine prompt line count
-		const promptRowCount = getPromptRowCount(command, this._xterm.raw.buffer.active);
-
-		// Determine command line count
-		const commandExecutedLine = Math.max(command.executedMarker?.line ?? marker.line, marker.line);
-		const commandRowCount = commandExecutedLine - marker.line;
-
 		// Determine sticky scroll line count
+		const promptRowCount = getPromptRowCount(command, this._xterm.raw.buffer.active);
+		const commandRowCount = getCommandRowCount(command);
 		const stickyScrollLineStart = marker.line - (promptRowCount - 1);
-		const stickyScrollLineCount = Math.min(promptRowCount + commandRowCount, this._maxLineCount);
+		const stickyScrollLineCount = Math.min(promptRowCount + commandRowCount - 1, this._maxLineCount);
 
 		// Clear attrs, reset cursor position, clear right
 		const content = this._serializeAddon.serialize({

--- a/src/vs/workbench/contrib/terminalContrib/stickyScroll/browser/terminalStickyScrollOverlay.ts
+++ b/src/vs/workbench/contrib/terminalContrib/stickyScroll/browser/terminalStickyScrollOverlay.ts
@@ -150,12 +150,13 @@ export class TerminalStickyScrollOverlay extends Disposable {
 		const command = this._commandDetection.getCommandForLine(this._xterm.raw.buffer.active.viewportY + 1);
 		this._currentStickyCommand = undefined;
 
-		// Sticky scroll only works with non-partial commands
+		// No command
 		if (!command) {
 			this._setVisible(false);
 			return;
 		}
 
+		// Partial command
 		if (!('marker' in command)) {
 			const partialCommand = this._commandDetection.currentCommand;
 			if (partialCommand?.commandStartMarker && partialCommand.commandExecutedMarker) {

--- a/src/vs/workbench/contrib/terminalContrib/stickyScroll/browser/terminalStickyScrollOverlay.ts
+++ b/src/vs/workbench/contrib/terminalContrib/stickyScroll/browser/terminalStickyScrollOverlay.ts
@@ -18,6 +18,7 @@ import { ICurrentPartialCommand, getCommandRowCount, getPromptRowCount } from 'v
 import { TerminalSettingId } from 'vs/platform/terminal/common/terminal';
 import { IThemeService } from 'vs/platform/theme/common/themeService';
 import { IXtermColorProvider, IXtermTerminal } from 'vs/workbench/contrib/terminal/browser/terminal';
+import { IXtermCore } from 'vs/workbench/contrib/terminal/browser/xterm-private';
 import { TERMINAL_CONFIG_SECTION } from 'vs/workbench/contrib/terminal/common/terminal';
 import { terminalStickyScrollHoverBackground } from 'vs/workbench/contrib/terminalContrib/stickyScroll/browser/terminalStickyScrollColorRegistry';
 
@@ -241,6 +242,11 @@ export class TerminalStickyScrollOverlay extends Disposable {
 		this._element.append(hoverOverlay);
 		this._xterm.raw.element.parentElement.append(this._element);
 		this._register(toDisposable(() => this._element?.remove()));
+
+		const scrollBarWidth = (this._xterm.raw as any as { _core: IXtermCore })._core.viewport?.scrollBarWidth;
+		if (scrollBarWidth !== undefined) {
+			this._element.style.right = `${scrollBarWidth}px`;
+		}
 
 		this._stickyScrollOverlay.open(this._element);
 

--- a/src/vs/workbench/contrib/terminalContrib/stickyScroll/browser/terminalStickyScrollOverlay.ts
+++ b/src/vs/workbench/contrib/terminalContrib/stickyScroll/browser/terminalStickyScrollOverlay.ts
@@ -194,7 +194,7 @@ export class TerminalStickyScrollOverlay extends Disposable {
 			this._stickyScrollOverlay.write('\x1b[0m\x1b[H\x1b[2J');
 			this._stickyScrollOverlay.write(content);
 			this._currentContent = content;
-			// Debug log to show the command
+			// DEBUG: Log to show the command line we know
 			// this._stickyScrollOverlay.write(` [${command?.command}]`);
 		}
 

--- a/src/vs/workbench/contrib/terminalContrib/stickyScroll/browser/terminalStickyScrollOverlay.ts
+++ b/src/vs/workbench/contrib/terminalContrib/stickyScroll/browser/terminalStickyScrollOverlay.ts
@@ -288,7 +288,7 @@ export class TerminalStickyScrollOverlay extends Disposable {
 		if (!this._stickyScrollOverlay) {
 			return;
 		}
-		this._stickyScrollOverlay.resize(this._xterm.raw.cols, 1);
+		this._stickyScrollOverlay.resize(this._xterm.raw.cols, this._stickyScrollOverlay.rows);
 		this._stickyScrollOverlay.options = this._getOptions();
 		this._syncGpuAccelerationState();
 	}

--- a/src/vs/workbench/contrib/terminalContrib/stickyScroll/browser/terminalStickyScrollOverlay.ts
+++ b/src/vs/workbench/contrib/terminalContrib/stickyScroll/browser/terminalStickyScrollOverlay.ts
@@ -170,13 +170,16 @@ export class TerminalStickyScrollOverlay extends Disposable {
 			return;
 		}
 
-		// TODO: Support multi-line commands
-
-		// Determine prompt length
+		// Determine prompt line count
 		const promptRowCount = getPromptRowCount(command, this._xterm.raw.buffer.active);
 
+		// Determine command line count
+		const commandExecutedLine = Math.max(command.executedMarker?.line ?? marker.line, marker.line);
+		const commandRowCount = commandExecutedLine - marker.line;
+
+		// Determine sticky scroll line count
 		const stickyScrollLineStart = marker.line - (promptRowCount - 1);
-		const stickyScrollLineCount = Math.min(promptRowCount, this._maxLineCount);
+		const stickyScrollLineCount = Math.min(promptRowCount + commandRowCount, this._maxLineCount);
 
 		// Clear attrs, reset cursor position, clear right
 		const content = this._serializeAddon.serialize({

--- a/test/smoke/src/areas/terminal/terminal-stickyScroll.test.ts
+++ b/test/smoke/src/areas/terminal/terminal-stickyScroll.test.ts
@@ -17,7 +17,7 @@ export function setup() {
 			terminal = app.workbench.terminal;
 			settingsEditor = app.workbench.settingsEditor;
 			await setTerminalTestSettings(app, [
-				['terminal.integrated.enableStickyScroll', 'true']
+				['terminal.integrated.stickyScroll.enabled', 'true']
 			]);
 		});
 


### PR DESCRIPTION
Fixes #197736
Fixes #197995
Fixes #197997
Fixes #197831
Fixes #197841
Fixes #198007
Fixes #197968
Fixes #197969
Fixes #198008
Fixes #198012
Fixes #155543
Fixes #198041

Summary:

- Command detection
  - Improve command started position adjustment
- Sticky scroll
  - Change enabled setting to align with editor
  - Add sticky scroll max line count
  - Support sticky scroll multi-line commands
    ![image](https://github.com/microsoft/vscode/assets/2193314/bc03e67f-3894-42e3-9a7b-f7c9e4f1882b)
  - Support for the currently running command
    ![image](https://github.com/microsoft/vscode/assets/2193314/e327c1c8-c415-42da-9b18-76506a2d4bf5)
  - Consistent highlight color on hover and works better with powerline
    ![image](https://github.com/microsoft/vscode/assets/2193314/834bf581-440a-4767-a9e3-847021aac15e)
  - Fixed sticky scroll overlapping with the scroll bar/overview ruler
    ![image](https://github.com/microsoft/vscode/assets/2193314/ea8dff4b-f9a0-4910-bf1c-24776f9a75cd)
  - The overlay now scrolls when needed to avoid overlapping the following command
    ![image](https://github.com/microsoft/vscode/assets/2193314/ae6e152b-3163-4811-8523-01b8425b3983)
  - Fix occasional overlay resize to 1 row
- Command navigation
  - Highlight multi-line commands in command navigation
    ![image](https://github.com/microsoft/vscode/assets/2193314/127d14fd-c20b-4679-8947-39ee8222d029)
  - Fix command navigation outline reappearing sometimes
  - Fixed command navigation may not navigate to all entries (can no longer reproduce, I believe it was happening due to inaccurate and badly overlapping SI markers)
  - It will now completely skip "empty commands"
  - It will now prefer the command's prompt start marker of the command start marker