### PR TITLE
fix: do not hide hover on model content change of editor

### DIFF
--- a/src/vs/editor/contrib/hover/browser/hover.ts
+++ b/src/vs/editor/contrib/hover/browser/hover.ts
@@ -107,7 +107,7 @@ export class ModesHoverController extends Disposable implements IEditorContribut
 
 		this._toUnhook.add(this._editor.onMouseLeave((e) => this._onEditorMouseLeave(e)));
 		this._toUnhook.add(this._editor.onDidChangeModel(hideWidgetsCancelSchedulerEventHandler));
-		this._toUnhook.add(this._editor.onDidChangeModelContent(hideWidgetsCancelSchedulerEventHandler));
+		this._toUnhook.add(this._editor.onDidChangeModelContent(() => this._cancelScheduler()));
 		this._toUnhook.add(this._editor.onDidScrollChange((e: IScrollEvent) => this._onEditorScrollChanged(e)));
 	}
 

--- a/src/vs/editor/contrib/hover/browser/hover.ts
+++ b/src/vs/editor/contrib/hover/browser/hover.ts
@@ -86,10 +86,6 @@ export class ModesHoverController extends Disposable implements IEditorContribut
 	}
 
 	private _hookEvents(): void {
-		const hideWidgetsCancelSchedulerEventHandler = () => {
-			this._cancelScheduler();
-			this._hideWidgets();
-		};
 
 		const hoverOpts = this._editor.getOption(EditorOption.hover);
 		this._isHoverEnabled = hoverOpts.enabled;
@@ -106,7 +102,10 @@ export class ModesHoverController extends Disposable implements IEditorContribut
 		}
 
 		this._toUnhook.add(this._editor.onMouseLeave((e) => this._onEditorMouseLeave(e)));
-		this._toUnhook.add(this._editor.onDidChangeModel(hideWidgetsCancelSchedulerEventHandler));
+		this._toUnhook.add(this._editor.onDidChangeModel(() => {
+			this._cancelScheduler();
+			this._hideWidgets();
+		}));
 		this._toUnhook.add(this._editor.onDidChangeModelContent(() => this._cancelScheduler()));
 		this._toUnhook.add(this._editor.onDidScrollChange((e: IScrollEvent) => this._onEditorScrollChanged(e)));
 	}


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/197588.

What I did
So the issue arised in 18.4.0 with https://github.com/microsoft/vscode/pull/196709, in particular [this](https://github.com/microsoft/vscode/commit/33b2e4a29c4ff7f8e7c988f19add209bd53ed55e#diff-790d9803b8477b256b7f571260cda4f3d5b033b6405e3586bf3e98d08236087aR110) line.
The reason of the issue is because whenever a color is picked through any of the selectors, a change is immediately triggered on the editor. That triggers the editor's onDidChangeModelContent emitter, therefore the hover widget triggers the _hideWidgets method.
So it's actually a very easy flow to understand: color picker changes editor content -> editor triggers emitter -> hover widget hides itself.

I have changed the method called on model content change so that we just cancel the scheduler and we don't hide the widget as well.
I just need some help with debugging the previous issue https://github.com/microsoft/vscode/issues/196660 in order to make sure that this is not introducing regressions on that one.

(ref #198066)