### PR TITLE
fine tune when native text area is updated

### DIFF
--- a/src/vs/editor/browser/controller/textAreaHandler.ts
+++ b/src/vs/editor/browser/controller/textAreaHandler.ts
@@ -36,6 +36,7 @@ import { ColorId, ITokenPresentation } from 'vs/editor/common/encodedTokenAttrib
 import { Color } from 'vs/base/common/color';
 import { IME } from 'vs/base/common/ime';
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
+import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 
 export interface IVisibleRangeProvider {
 	visibleRangeForPosition(position: Position): HorizontalPosition | null;
@@ -145,7 +146,8 @@ export class TextAreaHandler extends ViewPart {
 		context: ViewContext,
 		viewController: ViewController,
 		visibleRangeProvider: IVisibleRangeProvider,
-		@IKeybindingService private readonly _keybindingService: IKeybindingService
+		@IKeybindingService private readonly _keybindingService: IKeybindingService,
+		@IInstantiationService private readonly _instantiationService: IInstantiationService
 	) {
 		super(context);
 
@@ -303,7 +305,7 @@ export class TextAreaHandler extends ViewPart {
 		};
 
 		const textAreaWrapper = this._register(new TextAreaWrapper(this.textArea.domNode));
-		this._textAreaInput = this._register(new TextAreaInput(textAreaInputHost, textAreaWrapper, platform.OS, {
+		this._textAreaInput = this._register(this._instantiationService.createInstance(TextAreaInput, textAreaInputHost, textAreaWrapper, platform.OS, {
 			isAndroid: browser.isAndroid,
 			isChrome: browser.isChrome,
 			isFirefox: browser.isFirefox,

--- a/src/vs/editor/browser/controller/textAreaHandler.ts
+++ b/src/vs/editor/browser/controller/textAreaHandler.ts
@@ -480,7 +480,7 @@ export class TextAreaHandler extends ViewPart {
 	}
 
 	public writeScreenReaderContent(reason: string): void {
-		this._textAreaInput.writeScreenReaderContent(reason);
+		this._textAreaInput.writeNativeTextAreaContent(reason);
 	}
 
 	public override dispose(): void {
@@ -631,7 +631,7 @@ export class TextAreaHandler extends ViewPart {
 		}
 
 		if (e.hasChanged(EditorOption.accessibilitySupport)) {
-			this._textAreaInput.writeScreenReaderContent('strategy changed');
+			this._textAreaInput.writeNativeTextAreaContent('strategy changed');
 		}
 
 		return true;
@@ -641,7 +641,7 @@ export class TextAreaHandler extends ViewPart {
 		this._modelSelections = e.modelSelections.slice(0);
 		// We must update the <textarea> synchronously, otherwise long press IME on macos breaks.
 		// See https://github.com/microsoft/vscode/issues/165821
-		this._textAreaInput.writeScreenReaderContent('selection changed');
+		this._textAreaInput.writeNativeTextAreaContent('selection changed');
 		return true;
 	}
 	public override onDecorationsChanged(e: viewEvents.ViewDecorationsChangedEvent): boolean {
@@ -728,7 +728,7 @@ export class TextAreaHandler extends ViewPart {
 	}
 
 	public render(ctx: RestrictedRenderingContext): void {
-		this._textAreaInput.writeScreenReaderContent('render');
+		this._textAreaInput.writeNativeTextAreaContent('render');
 		this._render();
 	}
 

--- a/src/vs/editor/browser/controller/textAreaInput.ts
+++ b/src/vs/editor/browser/controller/textAreaInput.ts
@@ -442,7 +442,7 @@ export class TextAreaInput extends Disposable {
 
 			this._setHasFocus(true);
 
-			if (this._accessibilityService.isScreenReaderOptimized() && this._browser.isSafari && !hadFocus && this._hasFocus) {
+			if (this._browser.isSafari && !hadFocus && this._hasFocus) {
 				// When "tabbing into" the textarea, immediately after dispatching the 'focus' event,
 				// Safari will always move the selection at offset 0 in the textarea
 				if (!this._asyncFocusGainWriteScreenReaderContent.value) {

--- a/src/vs/editor/browser/controller/textAreaInput.ts
+++ b/src/vs/editor/browser/controller/textAreaInput.ts
@@ -196,7 +196,7 @@ export class TextAreaInput extends Disposable {
 
 	private readonly _asyncTriggerCut: RunOnceScheduler;
 
-	private _asyncFocusGainWriteScreenReaderContent: MutableDisposable<RunOnceScheduler> = new MutableDisposable();
+	private _asyncFocusGainWriteScreenReaderContent: MutableDisposable<RunOnceScheduler> = this._register(new MutableDisposable());
 
 	private _textAreaState: TextAreaState;
 
@@ -442,7 +442,7 @@ export class TextAreaInput extends Disposable {
 
 			this._setHasFocus(true);
 
-			if (this._browser.isSafari && !hadFocus && this._hasFocus) {
+			if (this._accessibilityService.isScreenReaderOptimized() && this._browser.isSafari && !hadFocus && this._hasFocus) {
 				// When "tabbing into" the textarea, immediately after dispatching the 'focus' event,
 				// Safari will always move the selection at offset 0 in the textarea
 				if (!this._asyncFocusGainWriteScreenReaderContent.value) {

--- a/src/vs/editor/browser/controller/textAreaInput.ts
+++ b/src/vs/editor/browser/controller/textAreaInput.ts
@@ -637,7 +637,7 @@ export class TextAreaInput extends Disposable {
 
 	public writeNativeTextAreaContent(reason: string): void {
 		if ((!this._accessibilityService.isScreenReaderOptimized() && reason === 'render') || this._currentComposition) {
-			// Do not write on async focus gain / render unless a screen reader is being used #192278
+			// Do not write to the text on render unless a screen reader is being used #192278
 			// Do not write to the text area when doing composition
 			return;
 		}

--- a/src/vs/editor/test/browser/controller/imeTester.ts
+++ b/src/vs/editor/test/browser/controller/imeTester.ts
@@ -148,7 +148,7 @@ function doCreateTest(description: string, inputStr: string, expectedStr: string
 	const updatePosition = (off: number, len: number) => {
 		cursorOffset = off;
 		cursorLength = len;
-		handler.writeScreenReaderContent('selection changed');
+		handler.writeNativeTextAreaContent('selection changed');
 		handler.focusTextArea();
 	};
 

--- a/src/vs/editor/test/browser/controller/imeTester.ts
+++ b/src/vs/editor/test/browser/controller/imeTester.ts
@@ -12,6 +12,8 @@ import * as dom from 'vs/base/browser/dom';
 import * as browser from 'vs/base/browser/browser';
 import * as platform from 'vs/base/common/platform';
 import { mainWindow } from 'vs/base/browser/window';
+import { TestAccessibilityService } from 'vs/platform/accessibility/test/common/testAccessibilityService';
+import { NullLogService } from 'vs/platform/log/common/log';
 
 // To run this test, open imeTester.html
 
@@ -127,7 +129,7 @@ function doCreateTest(description: string, inputStr: string, expectedStr: string
 		isFirefox: browser.isFirefox,
 		isChrome: browser.isChrome,
 		isSafari: browser.isSafari,
-	});
+	}, new TestAccessibilityService(), new NullLogService());
 
 	const output = document.createElement('pre');
 	output.className = 'output';

--- a/src/vs/editor/test/browser/controller/textAreaInput.test.ts
+++ b/src/vs/editor/test/browser/controller/textAreaInput.test.ts
@@ -12,6 +12,8 @@ import { ClipboardDataToCopy, IBrowser, ICompleteTextAreaWrapper, ITextAreaInput
 import { TextAreaState } from 'vs/editor/browser/controller/textAreaState';
 import { Position } from 'vs/editor/common/core/position';
 import { IRecorded, IRecordedEvent, IRecordedTextareaState } from 'vs/editor/test/browser/controller/imeRecordedTypes';
+import { TestAccessibilityService } from 'vs/platform/accessibility/test/common/testAccessibilityService';
+import { NullLogService } from 'vs/platform/log/common/log';
 
 suite('TextAreaInput', () => {
 
@@ -203,7 +205,7 @@ suite('TextAreaInput', () => {
 
 			public hasFocus(): boolean { return true; }
 		});
-		const input = disposables.add(new TextAreaInput(host, wrapper, recorded.env.OS, recorded.env.browser));
+		const input = disposables.add(new TextAreaInput(host, wrapper, recorded.env.OS, recorded.env.browser, new TestAccessibilityService(), new NullLogService()));
 
 		wrapper._initialize(recorded.initial);
 		input._initializeFromTest();


### PR DESCRIPTION
The function called `writeScreenReaderContent` was also used for other things:

https://github.com/microsoft/vscode/blob/84aa769b9e5d187f18648b6ff86aa445602c9477/src/vs/editor/browser/controller/textAreaInput.ts#L463-L464

I have renamed it `writeNativeTextAreaContent` as that's what I believe it represents. 

Skipping the update when the reason is `render` when not in screen reader mode has performance benefits and doesn't break anything. I've tried other variants and it breaks smoke tests.

fix #192278