### PR TITLE
Add Start Inline Chat button to editor title menu

### DIFF
--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatActions.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatActions.ts
@@ -29,9 +29,11 @@ import { Disposable } from 'vs/base/common/lifecycle';
 import { CommandsRegistry } from 'vs/platform/commands/common/commands';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { AccessibilityHelpAction } from 'vs/workbench/contrib/accessibility/browser/accessibleViewActions';
+import { registerIcon } from 'vs/platform/theme/common/iconRegistry';
 
 CommandsRegistry.registerCommandAlias('interactiveEditor.start', 'inlineChat.start');
 export const LOCALIZED_START_INLINE_CHAT_STRING = localize('run', 'Start Inline Chat');
+const START_INLINE_CHAT = registerIcon('inline-chat', Codicon.sparkle, localize('startInlineChat', 'Icon which spawns the inline chat from the editor toolbar.'));
 
 export class StartSessionAction extends EditorAction2 {
 
@@ -47,11 +49,12 @@ export class StartSessionAction extends EditorAction2 {
 				primary: KeyMod.CtrlCmd | KeyCode.KeyI,
 				secondary: [KeyChord(KeyMod.CtrlCmd | KeyCode.KeyK, KeyCode.KeyI)],
 			},
+			icon: START_INLINE_CHAT,
 			menu: [{
 				id: MenuId.EditorTitle,
 				when: ContextKeyExpr.and(CTX_INLINE_CHAT_HAS_PROVIDER, EditorContextKeys.writable),
 				group: 'navigation',
-				order: 0,
+				order: -1000000, // at the very front
 			}],
 		});
 	}

--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatActions.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatActions.ts
@@ -29,21 +29,15 @@ import { Disposable } from 'vs/base/common/lifecycle';
 import { CommandsRegistry } from 'vs/platform/commands/common/commands';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { AccessibilityHelpAction } from 'vs/workbench/contrib/accessibility/browser/accessibleViewActions';
-import { registerIcon } from 'vs/platform/theme/common/iconRegistry';
 
-const START_INLINE_CHAT_SESSION = 'inlineChat.start';
-const START_INLINE_CHAT_ICON = registerIcon('inline-chat', Codicon.sparkle, localize('startInlineChatIcon', 'Icon which spawns the inline chat from the editor title.'));
-
-CommandsRegistry.registerCommandAlias('interactiveEditor.start', START_INLINE_CHAT_SESSION);
+CommandsRegistry.registerCommandAlias('interactiveEditor.start', 'inlineChat.start');
 export const LOCALIZED_START_INLINE_CHAT_STRING = localize('run', 'Start Inline Chat');
-
-MenuRegistry.appendMenuItem(MenuId.EditorTitle, { command: { id: START_INLINE_CHAT_SESSION, icon: START_INLINE_CHAT_ICON, title: localize('startInlineChat.label', "Start Inline Chat ") }, order: 1, group: 'navigation', when: ContextKeyExpr.and(CTX_INLINE_CHAT_HAS_PROVIDER, EditorContextKeys.writable) });
 
 export class StartSessionAction extends EditorAction2 {
 
 	constructor() {
 		super({
-			id: START_INLINE_CHAT_SESSION,
+			id: 'inlineChat.start',
 			title: { value: LOCALIZED_START_INLINE_CHAT_STRING, original: 'Start Inline Chat' },
 			category: AbstractInlineChatAction.category,
 			f1: true,
@@ -52,7 +46,13 @@ export class StartSessionAction extends EditorAction2 {
 				weight: KeybindingWeight.WorkbenchContrib,
 				primary: KeyMod.CtrlCmd | KeyCode.KeyI,
 				secondary: [KeyChord(KeyMod.CtrlCmd | KeyCode.KeyK, KeyCode.KeyI)],
-			}
+			},
+			menu: [{
+				id: MenuId.EditorTitle,
+				when: ContextKeyExpr.and(CTX_INLINE_CHAT_HAS_PROVIDER, EditorContextKeys.writable),
+				group: 'navigation',
+				order: 0,
+			}],
 		});
 	}
 

--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatActions.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatActions.ts
@@ -33,7 +33,7 @@ import { registerIcon } from 'vs/platform/theme/common/iconRegistry';
 
 CommandsRegistry.registerCommandAlias('interactiveEditor.start', 'inlineChat.start');
 export const LOCALIZED_START_INLINE_CHAT_STRING = localize('run', 'Start Inline Chat');
-const START_INLINE_CHAT = registerIcon('inline-chat', Codicon.sparkle, localize('startInlineChat', 'Icon which spawns the inline chat from the editor toolbar.'));
+const START_INLINE_CHAT = registerIcon('start-inline-chat', Codicon.sparkle, localize('startInlineChat', 'Icon which spawns the inline chat from the editor toolbar.'));
 
 export class StartSessionAction extends EditorAction2 {
 

--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatActions.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatActions.ts
@@ -29,15 +29,21 @@ import { Disposable } from 'vs/base/common/lifecycle';
 import { CommandsRegistry } from 'vs/platform/commands/common/commands';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { AccessibilityHelpAction } from 'vs/workbench/contrib/accessibility/browser/accessibleViewActions';
+import { registerIcon } from 'vs/platform/theme/common/iconRegistry';
 
-CommandsRegistry.registerCommandAlias('interactiveEditor.start', 'inlineChat.start');
+const START_INLINE_CHAT_SESSION = 'inlineChat.start';
+const START_INLINE_CHAT_ICON = registerIcon('inline-chat', Codicon.sparkle, localize('startInlineChatIcon', 'Icon which spawns the inline chat from the editor title.'));
+
+CommandsRegistry.registerCommandAlias('interactiveEditor.start', START_INLINE_CHAT_SESSION);
 export const LOCALIZED_START_INLINE_CHAT_STRING = localize('run', 'Start Inline Chat');
+
+MenuRegistry.appendMenuItem(MenuId.EditorTitle, { command: { id: START_INLINE_CHAT_SESSION, icon: START_INLINE_CHAT_ICON, title: localize('startInlineChat.label', "Start Inline Chat ") }, order: 1, group: 'navigation', when: ContextKeyExpr.and(CTX_INLINE_CHAT_HAS_PROVIDER, EditorContextKeys.writable) });
 
 export class StartSessionAction extends EditorAction2 {
 
 	constructor() {
 		super({
-			id: 'inlineChat.start',
+			id: START_INLINE_CHAT_SESSION,
 			title: { value: LOCALIZED_START_INLINE_CHAT_STRING, original: 'Start Inline Chat' },
 			category: AbstractInlineChatAction.category,
 			f1: true,


### PR DESCRIPTION
This pull request adds a new button to the editor title menu that allows users to start an inline chat session. The button is represented by a sparkle icon and executes the `inlineChat.start` command.