### PR TITLE
Remove cycle  browserHostService.ts -> web.api.ts.

### DIFF
--- a/src/vs/code/browser/workbench/workbench.ts
+++ b/src/vs/code/browser/workbench/workbench.ts
@@ -17,9 +17,8 @@ import { URI, UriComponents } from 'vs/base/common/uri';
 import product from 'vs/platform/product/common/product';
 import { ISecretStorageProvider } from 'vs/platform/secrets/common/secrets';
 import { isFolderToOpen, isWorkspaceToOpen } from 'vs/platform/window/common/window';
-import type { IWorkbenchConstructionOptions } from 'vs/workbench/browser/web.api';
+import type { IWorkbenchConstructionOptions, IWorkspace, IWorkspaceProvider } from 'vs/workbench/browser/web.api';
 import { AuthenticationSessionInfo } from 'vs/workbench/services/authentication/browser/authenticationService';
-import type { IWorkspace, IWorkspaceProvider } from 'vs/workbench/services/host/browser/browserHostService';
 import type { IURLCallbackProvider } from 'vs/workbench/services/url/browser/urlService';
 import { create } from 'vs/workbench/workbench.web.main';
 

--- a/src/vs/workbench/browser/web.api.ts
+++ b/src/vs/workbench/browser/web.api.ts
@@ -10,12 +10,12 @@ import type { IURLCallbackProvider } from 'vs/workbench/services/url/browser/url
 import type { LogLevel } from 'vs/platform/log/common/log';
 import type { IUpdateProvider } from 'vs/workbench/services/update/browser/updateService';
 import type { Event } from 'vs/base/common/event';
-import type { IWorkspaceProvider } from 'vs/workbench/services/host/browser/browserHostService';
 import type { IProductConfiguration } from 'vs/base/common/product';
 import type { ISecretStorageProvider } from 'vs/platform/secrets/common/secrets';
 import type { TunnelProviderFeatures } from 'vs/platform/tunnel/common/tunnel';
 import type { IProgress, IProgressCompositeOptions, IProgressDialogOptions, IProgressNotificationOptions, IProgressOptions, IProgressStep, IProgressWindowOptions } from 'vs/platform/progress/common/progress';
 import type { ITextEditorOptions } from 'vs/platform/editor/common/editor';
+import type { IFolderToOpen, IWorkspaceToOpen } from 'vs/platform/window/common/window';
 import type { EditorGroupLayout } from 'vs/workbench/services/editor/common/editorGroupsService';
 import type { IEmbedderTerminalOptions } from 'vs/workbench/services/terminal/common/embedderTerminalService';
 
@@ -361,6 +361,47 @@ export interface IWorkbenchConstructionOptions {
 
 	//#endregion
 
+}
+
+
+/**
+ * A workspace to open in the workbench can either be:
+ * - a workspace file with 0-N folders (via `workspaceUri`)
+ * - a single folder (via `folderUri`)
+ * - empty (via `undefined`)
+ */
+export type IWorkspace = IWorkspaceToOpen | IFolderToOpen | undefined;
+
+export interface IWorkspaceProvider {
+
+	/**
+	 * The initial workspace to open.
+	 */
+	readonly workspace: IWorkspace;
+
+	/**
+	 * Arbitrary payload from the `IWorkspaceProvider.open` call.
+	 */
+	readonly payload?: object;
+
+	/**
+	 * Return `true` if the provided [workspace](#IWorkspaceProvider.workspace) is trusted, `false` if not trusted, `undefined` if unknown.
+	 */
+	readonly trusted: boolean | undefined;
+
+	/**
+	 * Asks to open a workspace in the current or a new window.
+	 *
+	 * @param workspace the workspace to open.
+	 * @param options optional options for the workspace to open.
+	 * - `reuse`: whether to open inside the current window or a new window
+	 * - `payload`: arbitrary payload that should be made available
+	 * to the opening window via the `IWorkspaceProvider.payload` property.
+	 * @param payload optional payload to send to the workspace to open.
+	 *
+	 * @returns true if successfully opened, false otherwise.
+	 */
+	open(workspace: IWorkspace, options?: { reuse?: boolean; payload?: object }): Promise<boolean>;
 }
 
 export interface IResourceUriProvider {

--- a/src/vs/workbench/browser/web.main.ts
+++ b/src/vs/workbench/browser/web.main.ts
@@ -32,7 +32,7 @@ import { WorkspaceService } from 'vs/workbench/services/configuration/browser/co
 import { ConfigurationCache } from 'vs/workbench/services/configuration/common/configurationCache';
 import { ISignService } from 'vs/platform/sign/common/sign';
 import { SignService } from 'vs/platform/sign/browser/signService';
-import { IWorkbenchConstructionOptions, IWorkbench, ITunnel } from 'vs/workbench/browser/web.api';
+import { IWorkbenchConstructionOptions, IWorkbench, IWorkspace, ITunnel } from 'vs/workbench/browser/web.api';
 import { BrowserStorageService } from 'vs/workbench/services/storage/browser/storageService';
 import { IStorageService } from 'vs/platform/storage/common/storage';
 import { toLocalISOString } from 'vs/base/common/date';
@@ -63,7 +63,6 @@ import { HTMLFileSystemProvider } from 'vs/platform/files/browser/htmlFileSystem
 import { IOpenerService } from 'vs/platform/opener/common/opener';
 import { mixin, safeStringify } from 'vs/base/common/objects';
 import { IndexedDB } from 'vs/base/browser/indexedDB';
-import { IWorkspace } from 'vs/workbench/services/host/browser/browserHostService';
 import { WebFileSystemAccess } from 'vs/platform/files/browser/webFileSystemAccess';
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 import { IProgressService } from 'vs/platform/progress/common/progress';

--- a/src/vs/workbench/contrib/debug/browser/extensionHostDebugService.ts
+++ b/src/vs/workbench/contrib/debug/browser/extensionHostDebugService.ts
@@ -14,8 +14,8 @@ import { ILogService } from 'vs/platform/log/common/log';
 import { IStorageService, StorageScope, StorageTarget } from 'vs/platform/storage/common/storage';
 import { isFolderToOpen, isWorkspaceToOpen } from 'vs/platform/window/common/window';
 import { IWorkspaceContextService, isSingleFolderWorkspaceIdentifier, isWorkspaceIdentifier, toWorkspaceIdentifier, hasWorkspaceFileExtension } from 'vs/platform/workspace/common/workspace';
+import { IWorkspace, IWorkspaceProvider } from 'vs/workbench/browser/web.api';
 import { IBrowserWorkbenchEnvironmentService } from 'vs/workbench/services/environment/browser/environmentService';
-import { IWorkspace, IWorkspaceProvider } from 'vs/workbench/services/host/browser/browserHostService';
 import { IHostService } from 'vs/workbench/services/host/browser/host';
 import { IRemoteAgentService } from 'vs/workbench/services/remote/common/remoteAgentService';
 

--- a/src/vs/workbench/services/host/browser/browserHostService.ts
+++ b/src/vs/workbench/services/host/browser/browserHostService.ts
@@ -9,9 +9,10 @@ import { InstantiationType, registerSingleton } from 'vs/platform/instantiation/
 import { ILayoutService } from 'vs/platform/layout/browser/layoutService';
 import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
-import { IWindowSettings, IWindowOpenable, IOpenWindowOptions, isFolderToOpen, isWorkspaceToOpen, isFileToOpen, IOpenEmptyWindowOptions, IPathData, IFileToOpen, IWorkspaceToOpen, IFolderToOpen, IPoint } from 'vs/platform/window/common/window';
+import { IWindowSettings, IWindowOpenable, IOpenWindowOptions, isFolderToOpen, isWorkspaceToOpen, isFileToOpen, IOpenEmptyWindowOptions, IPathData, IFileToOpen, IPoint } from 'vs/platform/window/common/window';
 import { isResourceEditorInput, pathsToEditors } from 'vs/workbench/common/editor';
 import { whenEditorClosed } from 'vs/workbench/browser/editor';
+import { IWorkspace, IWorkspaceProvider } from 'vs/workbench/browser/web.api';
 import { IFileService } from 'vs/platform/files/common/files';
 import { ILabelService, Verbosity } from 'vs/platform/label/common/label';
 import { ModifierKeyEmitter, disposableWindowInterval, getActiveDocument, getWindowId, onDidRegisterWindow, trackFocus } from 'vs/base/browser/dom';
@@ -38,46 +39,6 @@ import { ITextEditorOptions } from 'vs/platform/editor/common/editor';
 import { IUserDataProfileService } from 'vs/workbench/services/userDataProfile/common/userDataProfile';
 import { coalesce } from 'vs/base/common/arrays';
 import { mainWindow, isAuxiliaryWindow } from 'vs/base/browser/window';
-
-/**
- * A workspace to open in the workbench can either be:
- * - a workspace file with 0-N folders (via `workspaceUri`)
- * - a single folder (via `folderUri`)
- * - empty (via `undefined`)
- */
-export type IWorkspace = IWorkspaceToOpen | IFolderToOpen | undefined;
-
-export interface IWorkspaceProvider {
-
-	/**
-	 * The initial workspace to open.
-	 */
-	readonly workspace: IWorkspace;
-
-	/**
-	 * Arbitrary payload from the `IWorkspaceProvider.open` call.
-	 */
-	readonly payload?: object;
-
-	/**
-	 * Return `true` if the provided [workspace](#IWorkspaceProvider.workspace) is trusted, `false` if not trusted, `undefined` if unknown.
-	 */
-	readonly trusted: boolean | undefined;
-
-	/**
-	 * Asks to open a workspace in the current or a new window.
-	 *
-	 * @param workspace the workspace to open.
-	 * @param options optional options for the workspace to open.
-	 * - `reuse`: whether to open inside the current window or a new window
-	 * - `payload`: arbitrary payload that should be made available
-	 * to the opening window via the `IWorkspaceProvider.payload` property.
-	 * @param payload optional payload to send to the workspace to open.
-	 *
-	 * @returns true if successfully opened, false otherwise.
-	 */
-	open(workspace: IWorkspace, options?: { reuse?: boolean; payload?: object }): Promise<boolean>;
-}
 
 enum HostShutdownReason {
 


### PR DESCRIPTION
Before this change, `IWorkbenchConstructionOptions` in web.api.ts depended on `IWorkspaceProvider` in browserHostService.ts, which depends on some types from web.api.ts.

While this apparently does not pose problems in VS Code's build, other build system of downstream projects do not allow this, and it is also overall harder to follow the code if "the API" depends on types defined in ""the implementation".

Fixes #198220.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
