### PR TITLE
don't include `aria-checked` property unless an item is checkable

### DIFF
--- a/src/vs/base/browser/ui/actionbar/actionViewItems.ts
+++ b/src/vs/base/browser/ui/actionbar/actionViewItems.ts
@@ -419,7 +419,7 @@ export class ActionViewItem extends BaseActionViewItem {
 				this.label.setAttribute('role', 'checkbox');
 			} else {
 				this.label.classList.remove('checked');
-				this.label.setAttribute('aria-checked', '');
+				this.label.removeAttribute('aria-checked');
 				this.label.setAttribute('role', this.getDefaultAriaRole());
 			}
 		}


### PR DESCRIPTION
fix #198228

@jrieken added this to fix https://github.com/microsoft/vscode-internalbacklog/issues/4036