### PR TITLE
Update condition names to allow node

### DIFF
--- a/extensions/shared.webpack.config.js
+++ b/extensions/shared.webpack.config.js
@@ -31,7 +31,7 @@ function withNodeDefaults(/**@type WebpackConfig & { context: string }*/extConfi
 		},
 
 		resolve: {
-			conditionNames: ['import', 'require'],
+			conditionNames: ['import', 'require', 'node-addons', 'node'],
 			mainFields: ['module', 'main'],
 			extensions: ['.ts', '.js'] // support ts-files and js-files
 		},


### PR DESCRIPTION
Previously, if an extension depended on a library like [uuid](https://github.com/uuidjs/uuid), only the `default` condition would match, which would use the browser version of the library and fail at runtime.

The [commit](https://github.com/microsoft/vscode/pull/195157/commits/34f8bba1a57e09af2eab59d9f3a09e74088b3a73) that introduced `conditionNames` mentions that it was to prefer import over require. From my understanding, the order of the `conditionNames` array does not matter, and only the order in the `"exports"` key in the `package.json` matters (see e.g. [this GitHub comment](https://github.com/webpack/enhanced-resolve/issues/318#issuecomment-1055518577)). So it is a little unclear why this was introduced. Perhaps the `conditionNames` key in the webpack config should just be removed entirely?