### PR TITLE
Prevent error when getModifierState is not defined

### DIFF
--- a/src/vs/base/browser/keyboardEvent.ts
+++ b/src/vs/base/browser/keyboardEvent.ts
@@ -142,7 +142,7 @@ export class StandardKeyboardEvent implements IKeyboardEvent {
 		this.shiftKey = e.shiftKey;
 		this.altKey = e.altKey;
 		this.metaKey = e.metaKey;
-		this.altGraphKey = e.getModifierState('AltGraph');
+		this.altGraphKey = e.getModifierState?.('AltGraph');
 		this.keyCode = extractKeyCode(e);
 		this.code = e.code;
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Do not trigger a type error when the getModifierState function is not defined on a KeyboardEvent

Fixes https://github.com/microsoft/vscode/issues/198308
