### PR TITLE
Simplify ChatModel more

### DIFF
--- a/src/vs/workbench/api/common/extHostTypeConverters.ts
+++ b/src/vs/workbench/api/common/extHostTypeConverters.ts
@@ -2300,14 +2300,14 @@ export namespace ChatResponseProgress {
 			return { placeholder: progress.placeholder, kind: 'asyncContent' } satisfies extHostProtocol.IChatAsyncContentDto;
 		} else if ('markdownContent' in progress) {
 			checkProposedApiEnabled(extension, 'chatAgents2Additions');
-			return { content: MarkdownString.from(progress.markdownContent), kind: 'content' };
+			return { content: MarkdownString.from(progress.markdownContent), kind: 'markdownContent' };
 		} else if ('content' in progress) {
 			if (typeof progress.content === 'string') {
 				return { content: progress.content, kind: 'content' };
 			}
 
 			checkProposedApiEnabled(extension, 'chatAgents2Additions');
-			return { content: MarkdownString.from(progress.content), kind: 'content' };
+			return { content: MarkdownString.from(progress.content), kind: 'markdownContent' };
 		} else if ('documents' in progress) {
 			return {
 				documents: progress.documents.map(d => ({

--- a/src/vs/workbench/api/common/extHostTypeConverters.ts
+++ b/src/vs/workbench/api/common/extHostTypeConverters.ts
@@ -2297,7 +2297,7 @@ export namespace InteractiveEditorResponseFeedbackKind {
 export namespace ChatResponseProgress {
 	export function from(extension: IExtensionDescription, progress: vscode.ChatAgentExtendedProgress): extHostProtocol.IChatProgressDto {
 		if ('placeholder' in progress && 'resolvedContent' in progress) {
-			return { placeholder: progress.placeholder, kind: 'asyncContent' } satisfies extHostProtocol.IChatAsyncContentDto;
+			return { content: progress.placeholder, kind: 'asyncContent' } satisfies extHostProtocol.IChatAsyncContentDto;
 		} else if ('markdownContent' in progress) {
 			checkProposedApiEnabled(extension, 'chatAgents2Additions');
 			return { content: MarkdownString.from(progress.markdownContent), kind: 'markdownContent' };

--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -45,7 +45,7 @@ import { ChatAccessibilityService } from 'vs/workbench/contrib/chat/browser/chat
 import { ICodeEditorService } from 'vs/editor/browser/services/codeEditorService';
 import { AccessibilityVerbositySettingId, AccessibleViewProviderId } from 'vs/workbench/contrib/accessibility/browser/accessibilityConfiguration';
 import { ChatWelcomeMessageModel } from 'vs/workbench/contrib/chat/common/chatModel';
-import { IMarkdownString, MarkdownString } from 'vs/base/common/htmlContent';
+import { IMarkdownString, MarkdownString, isMarkdownString } from 'vs/base/common/htmlContent';
 import { ChatProviderService, IChatProviderService } from 'vs/workbench/contrib/chat/common/chatProvider';
 import { ChatSlashCommandService, IChatSlashCommandService } from 'vs/workbench/contrib/chat/common/chatSlashCommands';
 import { alertFocusChange } from 'vs/workbench/contrib/accessibility/browser/accessibilityContributions';
@@ -243,7 +243,11 @@ class ChatSlashStaticSlashCommandsContribution extends Disposable {
 			const defaultAgent = chatAgentService.getDefaultAgent();
 			const agents = chatAgentService.getAgents();
 			if (defaultAgent?.metadata.helpTextPrefix) {
-				progress.report({ content: defaultAgent.metadata.helpTextPrefix, kind: 'content' });
+				if (isMarkdownString(defaultAgent.metadata.helpTextPrefix)) {
+					progress.report({ content: defaultAgent.metadata.helpTextPrefix, kind: 'markdownContent' });
+				} else {
+					progress.report({ content: defaultAgent.metadata.helpTextPrefix, kind: 'content' });
+				}
 				progress.report({ content: '\n\n', kind: 'content' });
 			}
 
@@ -263,10 +267,14 @@ class ChatSlashStaticSlashCommandsContribution extends Disposable {
 
 					return agentLine + '\n' + commandText;
 				}))).join('\n');
-			progress.report({ content: new MarkdownString(agentText, { isTrusted: { enabledCommands: [SubmitAction.ID] } }), kind: 'content' });
+			progress.report({ content: new MarkdownString(agentText, { isTrusted: { enabledCommands: [SubmitAction.ID] } }), kind: 'markdownContent' });
 			if (defaultAgent?.metadata.helpTextPostfix) {
 				progress.report({ content: '\n\n', kind: 'content' });
-				progress.report({ content: defaultAgent.metadata.helpTextPostfix, kind: 'content' });
+				if (isMarkdownString(defaultAgent.metadata.helpTextPostfix)) {
+					progress.report({ content: defaultAgent.metadata.helpTextPostfix, kind: 'markdownContent' });
+				} else {
+					progress.report({ content: defaultAgent.metadata.helpTextPostfix, kind: 'content' });
+				}
 			}
 		}));
 	}

--- a/src/vs/workbench/contrib/chat/browser/chatMarkdownDecorationsRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatMarkdownDecorationsRenderer.ts
@@ -4,13 +4,14 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as dom from 'vs/base/browser/dom';
-import { IMarkdownString, MarkdownString, isMarkdownString } from 'vs/base/common/htmlContent';
+import { MarkdownString } from 'vs/base/common/htmlContent';
 import { revive } from 'vs/base/common/marshalling';
 import { basename } from 'vs/base/common/resources';
 import { URI } from 'vs/base/common/uri';
 import { Location } from 'vs/editor/common/languages';
+import { IChatProgressResponseContent } from 'vs/workbench/contrib/chat/common/chatModel';
 import { ChatRequestTextPart, IParsedChatRequest } from 'vs/workbench/contrib/chat/common/chatParserTypes';
-import { IChatContentInlineReference, IChatResponseProgressFileTreeData } from 'vs/workbench/contrib/chat/common/chatService';
+import { IChatContentInlineReference } from 'vs/workbench/contrib/chat/common/chatService';
 
 const variableRefUrl = 'http://_vscodedecoration_';
 
@@ -59,21 +60,21 @@ function renderFileWidget(href: string, a: HTMLAnchorElement): void {
 
 const contentRefUrl = 'http://_vscodecontentref_'; // must be lowercase for URI
 
-export function reduceInlineContentReferences(response: ReadonlyArray<IMarkdownString | IChatResponseProgressFileTreeData | IChatContentInlineReference>): ReadonlyArray<IMarkdownString | IChatResponseProgressFileTreeData> {
-	const result: (IMarkdownString | IChatResponseProgressFileTreeData)[] = [];
+export function reduceInlineContentReferences(response: ReadonlyArray<IChatProgressResponseContent>): ReadonlyArray<Exclude<IChatProgressResponseContent, IChatContentInlineReference>> {
+	const result: Exclude<IChatProgressResponseContent, IChatContentInlineReference>[] = [];
 	for (const item of response) {
 		const previousItem = result[result.length - 1];
-		if ('inlineReference' in item) {
+		if (item.kind === 'inlineReference') {
 			const location = 'uri' in item.inlineReference ? item.inlineReference : { uri: item.inlineReference };
 			const printUri = URI.parse(contentRefUrl).with({ fragment: JSON.stringify(location) });
 			const markdownText = `[${item.name || basename(location.uri)}](${printUri.toString()})`;
-			if (isMarkdownString(previousItem)) {
-				result[result.length - 1] = new MarkdownString(previousItem.value + markdownText, { isTrusted: previousItem.isTrusted });
+			if (previousItem?.kind === 'markdownContent') {
+				result[result.length - 1] = { content: new MarkdownString(previousItem.content.value + markdownText, { isTrusted: previousItem.content.isTrusted }), kind: 'markdownContent' };
 			} else {
-				result.push(new MarkdownString(markdownText));
+				result.push({ content: new MarkdownString(markdownText), kind: 'markdownContent' });
 			}
-		} else if (isMarkdownString(item) && isMarkdownString(previousItem)) {
-			result[result.length - 1] = new MarkdownString(previousItem.value + item.value, { isTrusted: previousItem.isTrusted });
+		} else if (item.kind === 'markdownContent' && previousItem?.kind === 'markdownContent') {
+			result[result.length - 1] = { content: new MarkdownString(previousItem.content.value + item.content.value, { isTrusted: previousItem.content.isTrusted }), kind: 'markdownContent' };
 		} else {
 			result.push(item);
 		}

--- a/src/vs/workbench/contrib/chat/common/chatModel.ts
+++ b/src/vs/workbench/contrib/chat/common/chatModel.ts
@@ -84,10 +84,6 @@ export class ChatRequestModel implements IChatRequestModel {
 	}
 }
 
-export interface IPlaceholderMarkdownString extends IMarkdownString {
-	isPlaceholder: boolean;
-}
-
 export class Response implements IResponse {
 	private _onDidChangeValue = new Emitter<void>();
 	public get onDidChangeValue() {
@@ -99,7 +95,7 @@ export class Response implements IResponse {
 	// responseRepr externally presents the response parts with consolidated contiguous strings (excluding tree data)
 	private _responseRepr!: string;
 
-	get value(): (IChatProgressResponseContent)[] {
+	get value(): IChatProgressResponseContent[] {
 		return this._responseParts;
 	}
 

--- a/src/vs/workbench/contrib/chat/common/chatModel.ts
+++ b/src/vs/workbench/contrib/chat/common/chatModel.ts
@@ -169,7 +169,7 @@ export class Response implements IResponse {
 			} else if (part.kind === 'asyncContent') {
 				return part.content;
 			} else {
-				return part.content;
+				return part.content.value;
 			}
 		}).join('\n\n');
 

--- a/src/vs/workbench/contrib/chat/common/chatModel.ts
+++ b/src/vs/workbench/contrib/chat/common/chatModel.ts
@@ -792,7 +792,3 @@ export class ChatWelcomeMessageModel implements IChatWelcomeMessageModel {
 		return this.session.responderAvatarIconUri;
 	}
 }
-
-export function isCompleteInteractiveProgressTreeData(item: unknown): item is { treeData: IChatResponseProgressFileTreeData } {
-	return typeof item === 'object' && !!item && 'treeData' in item;
-}

--- a/src/vs/workbench/contrib/chat/common/chatService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService.ts
@@ -117,7 +117,10 @@ export interface IChatTreeData {
 }
 
 export interface IChatAsyncContent {
-	placeholder: string;
+	/**
+	 * The placeholder to show while the content is loading
+	 */
+	content: string;
 	resolvedContent: Promise<string | IMarkdownString | IChatTreeData>;
 	kind: 'asyncContent';
 }

--- a/src/vs/workbench/contrib/chat/common/chatService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService.ts
@@ -102,8 +102,13 @@ export interface IChatAgentDetection {
 }
 
 export interface IChatContent {
-	content: string | IMarkdownString;
+	content: string;
 	kind: 'content';
+}
+
+export interface IChatMarkdownContent {
+	content: IMarkdownString;
+	kind: 'markdownContent';
 }
 
 export interface IChatTreeData {
@@ -119,6 +124,7 @@ export interface IChatAsyncContent {
 
 export type IChatProgress =
 	| IChatContent
+	| IChatMarkdownContent
 	| IChatTreeData
 	| IChatAsyncContent
 	| IChatUsedContext

--- a/src/vs/workbench/contrib/chat/common/chatService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService.ts
@@ -267,7 +267,7 @@ export interface IChatDynamicRequest {
 }
 
 export interface IChatCompleteResponse {
-	message: string | ReadonlyArray<IMarkdownString | IChatResponseProgressFileTreeData | IChatContentInlineReference>;
+	message: string | ReadonlyArray<IChatProgress>;
 	errorDetails?: IChatResponseErrorDetails;
 	followups?: IChatFollowup[];
 }

--- a/src/vs/workbench/contrib/chat/common/chatServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/chatServiceImpl.ts
@@ -6,7 +6,7 @@
 import { CancelablePromise, createCancelablePromise } from 'vs/base/common/async';
 import { CancellationToken } from 'vs/base/common/cancellation';
 import { Emitter, Event } from 'vs/base/common/event';
-import { MarkdownString, isMarkdownString } from 'vs/base/common/htmlContent';
+import { MarkdownString } from 'vs/base/common/htmlContent';
 import { Iterable } from 'vs/base/common/iterator';
 import { Disposable, DisposableMap, IDisposable, toDisposable } from 'vs/base/common/lifecycle';
 import { revive } from 'vs/base/common/marshalling';
@@ -646,10 +646,7 @@ export class ChatService extends Disposable implements IChatService {
 			model.acceptResponseProgress(request, { content: response.message, kind: 'content' });
 		} else {
 			for (const part of response.message) {
-				const progress: IChatProgress = 'inlineReference' in part ? part :
-					isMarkdownString(part) ? { content: part.value, kind: 'content' } :
-						{ treeData: part, kind: 'treeData' };
-				model.acceptResponseProgress(request, progress, true);
+				model.acceptResponseProgress(request, part, true);
 			}
 		}
 		model.setResponse(request, {

--- a/src/vs/workbench/contrib/chat/common/chatServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/chatServiceImpl.ts
@@ -469,7 +469,7 @@ export class ChatService extends Disposable implements IChatService {
 
 				gotProgress = true;
 
-				if (progress.kind === 'content') {
+				if (progress.kind === 'content' || progress.kind === 'markdownContent') {
 					this.trace('sendRequest', `Provider returned progress for session ${model.sessionId}, ${typeof progress.content === 'string' ? progress.content.length : progress.content.value.length} chars`);
 				} else {
 					this.trace('sendRequest', `Provider returned progress: ${JSON.stringify(progress)}`);

--- a/src/vs/workbench/contrib/chat/test/common/__snapshots__/Response_async_content.0.snap
+++ b/src/vs/workbench/contrib/chat/test/common/__snapshots__/Response_async_content.0.snap
@@ -1,0 +1,12 @@
+[
+  {
+    resolvedContent: {  },
+    content: "text",
+    kind: "asyncContent"
+  },
+  {
+    resolvedContent: {  },
+    content: "text2",
+    kind: "asyncContent"
+  }
+]

--- a/src/vs/workbench/contrib/chat/test/common/__snapshots__/Response_async_content.1.snap
+++ b/src/vs/workbench/contrib/chat/test/common/__snapshots__/Response_async_content.1.snap
@@ -1,0 +1,26 @@
+[
+  {
+    content: {
+      value: "resolved",
+      isTrusted: false,
+      supportThemeIcons: false,
+      supportHtml: false
+    },
+    kind: "markdownContent"
+  },
+  {
+    kind: "treeData",
+    treeData: {
+      label: "label",
+      uri: {
+        scheme: "https",
+        authority: "microsoft.com",
+        path: "/",
+        query: "",
+        fragment: "",
+        _formatted: null,
+        _fsPath: null
+      }
+    }
+  }
+]

--- a/src/vs/workbench/contrib/chat/test/common/__snapshots__/Response_content__markdown.0.snap
+++ b/src/vs/workbench/contrib/chat/test/common/__snapshots__/Response_content__markdown.0.snap
@@ -1,0 +1,11 @@
+[
+  {
+    content: {
+      value: "textmarkdown",
+      isTrusted: { enabledCommands: [  ] },
+      supportThemeIcons: false,
+      supportHtml: false
+    },
+    kind: "markdownContent"
+  }
+]

--- a/src/vs/workbench/contrib/chat/test/common/__snapshots__/Response_inline_reference.0.snap
+++ b/src/vs/workbench/contrib/chat/test/common/__snapshots__/Response_inline_reference.0.snap
@@ -1,0 +1,32 @@
+[
+  {
+    content: {
+      value: "text before",
+      isTrusted: false,
+      supportThemeIcons: false,
+      supportHtml: false
+    },
+    kind: "markdownContent"
+  },
+  {
+    inlineReference: {
+      scheme: "https",
+      authority: "microsoft.com",
+      path: "/",
+      query: "",
+      fragment: "",
+      _formatted: null,
+      _fsPath: null
+    },
+    kind: "inlineReference"
+  },
+  {
+    content: {
+      value: "text after",
+      isTrusted: false,
+      supportThemeIcons: false,
+      supportHtml: false
+    },
+    kind: "markdownContent"
+  }
+]

--- a/src/vs/workbench/contrib/chat/test/common/__snapshots__/Response_markdown__content.0.snap
+++ b/src/vs/workbench/contrib/chat/test/common/__snapshots__/Response_markdown__content.0.snap
@@ -1,0 +1,11 @@
+[
+  {
+    content: {
+      value: "markdowntext",
+      isTrusted: false,
+      supportThemeIcons: false,
+      supportHtml: false
+    },
+    kind: "markdownContent"
+  }
+]

--- a/src/vs/workbench/contrib/chat/test/common/chatModel.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/chatModel.test.ts
@@ -4,16 +4,20 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as assert from 'assert';
-import { timeout } from 'vs/base/common/async';
+import { DeferredPromise, timeout } from 'vs/base/common/async';
+import { MarkdownString } from 'vs/base/common/htmlContent';
+import { URI } from 'vs/base/common/uri';
+import { assertSnapshot } from 'vs/base/test/common/snapshot';
 import { ensureNoDisposablesAreLeakedInTestSuite } from 'vs/base/test/common/utils';
-import { Range } from 'vs/editor/common/core/range';
 import { OffsetRange } from 'vs/editor/common/core/offsetRange';
+import { Range } from 'vs/editor/common/core/range';
 import { TestInstantiationService } from 'vs/platform/instantiation/test/common/instantiationServiceMock';
 import { ILogService, NullLogService } from 'vs/platform/log/common/log';
 import { IStorageService } from 'vs/platform/storage/common/storage';
 import { ChatAgentService, IChatAgentService } from 'vs/workbench/contrib/chat/common/chatAgents';
-import { ChatModel } from 'vs/workbench/contrib/chat/common/chatModel';
+import { ChatModel, Response } from 'vs/workbench/contrib/chat/common/chatModel';
 import { ChatRequestTextPart } from 'vs/workbench/contrib/chat/common/chatParserTypes';
+import { IChatTreeData } from 'vs/workbench/contrib/chat/common/chatService';
 import { IExtensionService } from 'vs/workbench/services/extensions/common/extensions';
 import { TestExtensionService, TestStorageService } from 'vs/workbench/test/common/workbenchTestServices';
 
@@ -114,5 +118,43 @@ suite('ChatModel', () => {
 
 		model.removeRequest(requests[0].id);
 		assert.strictEqual(model.getRequests().length, 0);
+	});
+});
+
+suite('Response', () => {
+	test('content, markdown', async () => {
+		const response = new Response([]);
+		response.updateContent({ content: 'text', kind: 'content' });
+		response.updateContent({ content: new MarkdownString('markdown'), kind: 'markdownContent' });
+		await assertSnapshot(response.value);
+	});
+
+	test('markdown, content', async () => {
+		const response = new Response([]);
+		response.updateContent({ content: new MarkdownString('markdown'), kind: 'markdownContent' });
+		response.updateContent({ content: 'text', kind: 'content' });
+		await assertSnapshot(response.value);
+	});
+
+	test('async content', async () => {
+		const response = new Response([]);
+		const deferred = new DeferredPromise<string>();
+		const deferred2 = new DeferredPromise<IChatTreeData>();
+		response.updateContent({ resolvedContent: deferred.p, content: 'text', kind: 'asyncContent' });
+		response.updateContent({ resolvedContent: deferred2.p, content: 'text2', kind: 'asyncContent' });
+		await assertSnapshot(response.value);
+
+		await deferred2.complete({ kind: 'treeData', treeData: { label: 'label', uri: URI.parse('https://microsoft.com') } });
+		await deferred.complete('resolved');
+		await assertSnapshot(response.value);
+	});
+
+
+	test('inline reference', async () => {
+		const response = new Response([]);
+		response.updateContent({ content: 'text before', kind: 'content' });
+		response.updateContent({ inlineReference: URI.parse('https://microsoft.com'), kind: 'inlineReference' });
+		response.updateContent({ content: 'text after', kind: 'content' });
+		await assertSnapshot(response.value);
 	});
 });

--- a/src/vs/workbench/contrib/chat/test/common/chatModel.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/chatModel.test.ts
@@ -127,6 +127,8 @@ suite('Response', () => {
 		response.updateContent({ content: 'text', kind: 'content' });
 		response.updateContent({ content: new MarkdownString('markdown'), kind: 'markdownContent' });
 		await assertSnapshot(response.value);
+
+		assert.strictEqual(response.asString(), 'textmarkdown');
 	});
 
 	test('markdown, content', async () => {


### PR DESCRIPTION
Trying to use the same progress types all the way through, reduce the number of different types involved, and reduce `a | b | c | d` with different ways of checking the type. Hopefully it will be easier to add new progress types.

It's still a little frustrating working with lots of MarkdownStrings and I would still like to get to a place where we only have raw strings in the model. We only have these to support `enabledCommands` for a couple cases, and maybe we can use raw strings + a separate array of commands for that.

fyi @joyceerhl @ulugbekna 