### PR TITLE
Fix regression in paste context menu

### DIFF
--- a/src/vs/workbench/contrib/files/browser/fileActions.ts
+++ b/src/vs/workbench/contrib/files/browser/fileActions.ts
@@ -1203,7 +1203,7 @@ export const pasteFileHandler = async (accessor: ServicesAccessor, fileList?: Fi
 };
 
 async function getFilesToPaste(fileList: FileList | undefined, clipboardService: IClipboardService): Promise<readonly URI[]> {
-	if (fileList) {
+	if (fileList && fileList.length > 0) {
 		// with a `fileList` we support natively pasting files from clipboard
 		return [...fileList].filter(file => !!file.path && isAbsolute(file.path)).map(file => URI.file(file.path));
 	} else {


### PR DESCRIPTION
Fixes #198340

What happens is that when the paste context menu is executed it runs the paste command but passes in the target URI as an argument. We don't need this argument and previously would ignore it, but then #195730 came along to support native paste and checks for the existance of a `FileList`. Because the argument is not a list the length will be 0 so we can check length instead of existence to fix this bug.