### PR TITLE
Disable md paste file path in untitled notebooks

### DIFF
--- a/extensions/markdown-language-features/src/languageFeatures/copyFiles/dropResourceProvider.ts
+++ b/extensions/markdown-language-features/src/languageFeatures/copyFiles/dropResourceProvider.ts
@@ -7,6 +7,7 @@ import * as vscode from 'vscode';
 import { Mime, mediaMimes } from '../../util/mimes';
 import { Schemes } from '../../util/schemes';
 import { createEditForMediaFiles, tryGetUriListSnippet } from './shared';
+import { getParentDocumentUri } from '../../util/document';
 
 class ResourceDropProvider implements vscode.DocumentDropEditProvider {
 
@@ -58,7 +59,7 @@ class ResourceDropProvider implements vscode.DocumentDropEditProvider {
 	}
 
 	private async _getMediaFilesEdit(document: vscode.TextDocument, dataTransfer: vscode.DataTransfer, token: vscode.CancellationToken): Promise<vscode.DocumentDropEdit | undefined> {
-		if (document.uri.scheme === Schemes.untitled) {
+		if (getParentDocumentUri(document.uri).scheme === Schemes.untitled) {
 			return;
 		}
 

--- a/extensions/markdown-language-features/src/languageFeatures/copyFiles/pasteResourceProvider.ts
+++ b/extensions/markdown-language-features/src/languageFeatures/copyFiles/pasteResourceProvider.ts
@@ -7,6 +7,7 @@ import * as vscode from 'vscode';
 import { Mime, mediaMimes } from '../../util/mimes';
 import { Schemes } from '../../util/schemes';
 import { PasteUrlAsFormattedLink, createEditAddingLinksForUriList, createEditForMediaFiles, getPasteUrlAsFormattedLinkSetting } from './shared';
+import { getParentDocumentUri } from '../../util/document';
 
 class PasteResourceEditProvider implements vscode.DocumentPasteEditProvider {
 
@@ -64,7 +65,7 @@ class PasteResourceEditProvider implements vscode.DocumentPasteEditProvider {
 	}
 
 	private async _getMediaFilesEdit(document: vscode.TextDocument, dataTransfer: vscode.DataTransfer, token: vscode.CancellationToken): Promise<vscode.DocumentPasteEdit | undefined> {
-		if (document.uri.scheme === Schemes.untitled) {
+		if (getParentDocumentUri(document.uri).scheme === Schemes.untitled) {
 			return;
 		}
 


### PR DESCRIPTION
Fixes #194809

Since the notebook does not exist on disk yet, there's no way to write a relative path in it. Just disable the feature since there's nothing else we can reasonably do here

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
