### PR TITLE
Add `typescript.implementationsCodeLens.showOnInterfaceMethods` setting (#136282)

### DIFF
--- a/extensions/typescript-language-features/package.json
+++ b/extensions/typescript-language-features/package.json
@@ -259,6 +259,12 @@
           "description": "%typescript.implementationsCodeLens.enabled%",
           "scope": "window"
         },
+        "typescript.implementationsCodeLens.showOnInterfaceMethods": {
+          "type": "boolean",
+          "default": false,
+          "description": "%typescript.implementationsCodeLens.showOnInterfaceMethods%",
+          "scope": "window"
+        },
         "typescript.tsserver.enableTracing": {
           "type": "boolean",
           "default": false,

--- a/extensions/typescript-language-features/package.nls.json
+++ b/extensions/typescript-language-features/package.nls.json
@@ -58,6 +58,7 @@
 	"typescript.referencesCodeLens.enabled": "Enable/disable references CodeLens in TypeScript files.",
 	"typescript.referencesCodeLens.showOnAllFunctions": "Enable/disable references CodeLens on all functions in TypeScript files.",
 	"typescript.implementationsCodeLens.enabled": "Enable/disable implementations CodeLens. This CodeLens shows the implementers of an interface.",
+	"typescript.implementationsCodeLens.showOnInterfaceMethods": "Enable/disable implementations CodeLens on interface methods.",
 	"typescript.openTsServerLog.title": "Open TS Server log",
 	"typescript.restartTsServer": "Restart TS Server",
 	"typescript.selectTypeScriptVersion.title": "Select TypeScript Version...",

--- a/extensions/typescript-language-features/src/languageFeatures/codeLens/baseCodeLensProvider.ts
+++ b/extensions/typescript-language-features/src/languageFeatures/codeLens/baseCodeLensProvider.ts
@@ -9,6 +9,7 @@ import type * as Proto from '../../tsServer/protocol/protocol';
 import * as typeConverters from '../../typeConverters';
 import { ITypeScriptServiceClient } from '../../typescriptService';
 import { escapeRegExp } from '../../utils/regexp';
+import { Disposable } from '../../utils/dispose';
 
 
 export class ReferencesCodeLens extends vscode.CodeLens {
@@ -21,9 +22,8 @@ export class ReferencesCodeLens extends vscode.CodeLens {
 	}
 }
 
-export abstract class TypeScriptBaseCodeLensProvider implements vscode.CodeLensProvider<ReferencesCodeLens> {
-	protected readonly subscriptions: vscode.Disposable[] = [];
-	protected changeEmitter = new vscode.EventEmitter<void>();
+export abstract class TypeScriptBaseCodeLensProvider extends Disposable implements vscode.CodeLensProvider<ReferencesCodeLens>{
+	protected changeEmitter = this._register(new vscode.EventEmitter<void>());
 	public onDidChangeCodeLenses = this.changeEmitter.event;
 
 	public static readonly cancelledCommand: vscode.Command = {
@@ -40,10 +40,8 @@ export abstract class TypeScriptBaseCodeLensProvider implements vscode.CodeLensP
 	public constructor(
 		protected client: ITypeScriptServiceClient,
 		private readonly cachedResponse: CachedResponse<Proto.NavTreeResponse>
-	) { }
-
-	public dispose() {
-		this.subscriptions.forEach(s => s.dispose());
+	) {
+		super();
 	}
 
 	async provideCodeLenses(document: vscode.TextDocument, token: vscode.CancellationToken): Promise<ReferencesCodeLens[]> {

--- a/extensions/typescript-language-features/src/languageFeatures/codeLens/baseCodeLensProvider.ts
+++ b/extensions/typescript-language-features/src/languageFeatures/codeLens/baseCodeLensProvider.ts
@@ -22,6 +22,9 @@ export class ReferencesCodeLens extends vscode.CodeLens {
 }
 
 export abstract class TypeScriptBaseCodeLensProvider implements vscode.CodeLensProvider<ReferencesCodeLens> {
+	protected readonly subscriptions: vscode.Disposable[] = [];
+	protected changeEmitter = new vscode.EventEmitter<void>();
+	public onDidChangeCodeLenses = this.changeEmitter.event;
 
 	public static readonly cancelledCommand: vscode.Command = {
 		// Cancellation is not an error. Just show nothing until we can properly re-compute the code lens
@@ -39,6 +42,9 @@ export abstract class TypeScriptBaseCodeLensProvider implements vscode.CodeLensP
 		private readonly cachedResponse: CachedResponse<Proto.NavTreeResponse>
 	) { }
 
+	public dispose() {
+		this.subscriptions.forEach(s => s.dispose());
+	}
 
 	async provideCodeLenses(document: vscode.TextDocument, token: vscode.CancellationToken): Promise<ReferencesCodeLens[]> {
 		const filepath = this.client.toOpenTsFilePath(document);

--- a/extensions/typescript-language-features/src/languageFeatures/codeLens/implementationsCodeLens.ts
+++ b/extensions/typescript-language-features/src/languageFeatures/codeLens/implementationsCodeLens.ts
@@ -23,7 +23,7 @@ export default class TypeScriptImplementationsCodeLensProvider extends TypeScrip
 		private readonly language: LanguageDescription
 	) {
 		super(client, _cachedResponse);
-		this.subscriptions.push(
+		this._register(
 			vscode.workspace.onDidChangeConfiguration(evt => {
 				if (evt.affectsConfiguration(`${language.id}.implementationsCodeLens.showOnInterfaceMethods`)) {
 					this.changeEmitter.fire();

--- a/extensions/typescript-language-features/src/languageFeatures/codeLens/implementationsCodeLens.ts
+++ b/extensions/typescript-language-features/src/languageFeatures/codeLens/implementationsCodeLens.ts
@@ -17,6 +17,20 @@ import { ExecutionTarget } from '../../tsServer/server';
 
 
 export default class TypeScriptImplementationsCodeLensProvider extends TypeScriptBaseCodeLensProvider {
+	public constructor(
+		client: ITypeScriptServiceClient,
+		protected _cachedResponse: CachedResponse<Proto.NavTreeResponse>,
+		private readonly language: LanguageDescription
+	) {
+		super(client, _cachedResponse);
+		this.subscriptions.push(
+			vscode.workspace.onDidChangeConfiguration(evt => {
+				if (evt.affectsConfiguration(`${language.id}.implementationsCodeLens.showOnInterfaceMethods`)) {
+					this.changeEmitter.fire();
+				}
+			})
+		);
+	}
 
 	public async resolveCodeLens(
 		codeLens: ReferencesCodeLens,
@@ -71,8 +85,11 @@ export default class TypeScriptImplementationsCodeLensProvider extends TypeScrip
 	protected extractSymbol(
 		document: vscode.TextDocument,
 		item: Proto.NavigationTree,
-		_parent: Proto.NavigationTree | undefined
+		parent: Proto.NavigationTree | undefined
 	): vscode.Range | undefined {
+		if (item.kind === PConst.Kind.method && parent && parent.kind === PConst.Kind.interface && vscode.workspace.getConfiguration(this.language.id).get<boolean>('implementationsCodeLens.showOnInterfaceMethods')) {
+			return getSymbolRange(document, item);
+		}
 		switch (item.kind) {
 			case PConst.Kind.interface:
 				return getSymbolRange(document, item);
@@ -102,6 +119,6 @@ export function register(
 		requireSomeCapability(client, ClientCapability.Semantic),
 	], () => {
 		return vscode.languages.registerCodeLensProvider(selector.semantic,
-			new TypeScriptImplementationsCodeLensProvider(client, cachedResponse));
+			new TypeScriptImplementationsCodeLensProvider(client, cachedResponse, language));
 	});
 }

--- a/extensions/typescript-language-features/src/languageFeatures/codeLens/referencesCodeLens.ts
+++ b/extensions/typescript-language-features/src/languageFeatures/codeLens/referencesCodeLens.ts
@@ -23,7 +23,7 @@ export class TypeScriptReferencesCodeLensProvider extends TypeScriptBaseCodeLens
 		private readonly language: LanguageDescription
 	) {
 		super(client, _cachedResponse);
-		this.subscriptions.push(
+		this._register(
 			vscode.workspace.onDidChangeConfiguration(evt => {
 				if (evt.affectsConfiguration(`${language.id}.referencesCodeLens.showOnAllFunctions`)) {
 					this.changeEmitter.fire();

--- a/extensions/typescript-language-features/src/languageFeatures/codeLens/referencesCodeLens.ts
+++ b/extensions/typescript-language-features/src/languageFeatures/codeLens/referencesCodeLens.ts
@@ -23,6 +23,13 @@ export class TypeScriptReferencesCodeLensProvider extends TypeScriptBaseCodeLens
 		private readonly language: LanguageDescription
 	) {
 		super(client, _cachedResponse);
+		this.subscriptions.push(
+			vscode.workspace.onDidChangeConfiguration(evt => {
+				if (evt.affectsConfiguration(`${language.id}.referencesCodeLens.showOnAllFunctions`)) {
+					this.changeEmitter.fire();
+				}
+			})
+		);
 	}
 
 	public async resolveCodeLens(codeLens: ReferencesCodeLens, token: vscode.CancellationToken): Promise<vscode.CodeLens> {


### PR DESCRIPTION
This closes #136282

It also refreshes codelenses when the existing `typescript.referencesCodeLens.showOnAllFunctions` setting changes.