### PR TITLE
Turning off the editor gutter icon 

### DIFF
--- a/src/vs/workbench/contrib/inlineChat/common/inlineChat.ts
+++ b/src/vs/workbench/contrib/inlineChat/common/inlineChat.ts
@@ -224,7 +224,7 @@ Registry.as<IConfigurationRegistry>(Extensions.Configuration).registerConfigurat
 		},
 		'inlineChat.showGutterIcon': {
 			description: localize('showGutterIcon', "Controls when the gutter icon for spawning inline chat is shown."),
-			default: ShowGutterIcon.Always,
+			default: ShowGutterIcon.Never,
 			type: 'string',
 			enum: [ShowGutterIcon.Always, ShowGutterIcon.MouseOver, ShowGutterIcon.Never],
 			markdownEnumDescriptions: [


### PR DESCRIPTION
Turning off the editor gutter icon by default