### PR TITLE
Replace `Date.now()` with UUID for `delegatingCommandId`

### DIFF
--- a/src/vs/workbench/api/common/extHostCommands.ts
+++ b/src/vs/workbench/api/common/extHostCommands.ts
@@ -31,6 +31,7 @@ import { StopWatch } from 'vs/base/common/stopwatch';
 import { ExtensionIdentifier, IExtensionDescription } from 'vs/platform/extensions/common/extensions';
 import { TelemetryTrustedValue } from 'vs/platform/telemetry/common/telemetryUtils';
 import { IExtHostTelemetry } from 'vs/workbench/api/common/extHostTelemetry';
+import { generateUuid } from 'vs/base/common/uuid';
 
 interface CommandHandler {
 	callback: Function;
@@ -342,7 +343,7 @@ export const IExtHostCommands = createDecorator<IExtHostCommands>('IExtHostComma
 
 export class CommandsConverter implements extHostTypeConverter.Command.ICommandsConverter {
 
-	readonly delegatingCommandId: string = `__vsc${Date.now().toString(36)} `;
+	readonly delegatingCommandId: string = `__vsc${generateUuid()}`;
 	private readonly _cache = new Map<string, vscode.Command>();
 	private _cachIdPool = 0;
 


### PR DESCRIPTION
This PR changes the generation of `delegatingCommandId` in the extension host from using `Date.now()` to using UUID. This is to prevent potential conflicts when multiple extension hosts are created at the same time, which could lead to command invocations being sent to the wrong extension host.