### PR TITLE
Simplify `'solid' || ''` in viewPaneContainer.ts

### DIFF
--- a/src/vs/workbench/browser/parts/views/viewPaneContainer.ts
+++ b/src/vs/workbench/browser/parts/views/viewPaneContainer.ts
@@ -140,7 +140,7 @@ class ViewPaneDropOverlay extends Themable {
 		this.overlay.style.outlineWidth = activeContrastBorderColor ? '2px' : '';
 
 		this.overlay.style.borderColor = activeContrastBorderColor || '';
-		this.overlay.style.borderStyle = 'solid' || '';
+		this.overlay.style.borderStyle = 'solid';
 		this.overlay.style.borderWidth = '0px';
 	}
 


### PR DESCRIPTION
There is a slightly odd string in viewPaneContrainer.ts which is set to `'solid' || ''`. Since the LHS is constant and truthy, this is identical to just setting the value to `'solid'` (but slightly less readable).

My guess is that this was initially a variable, and then became constant. There is probably no issue as I assume most compilers would compile this out, but ours gives an error of `JSC_SUSPICIOUS_LEFT_OPERAND_OF_LOGICAL_OPERATOR` so we patch it out.