### PR TITLE
Adjust command finished marker in started adjustment

### DIFF
--- a/src/vs/workbench/contrib/terminal/test/browser/capabilities/commandDetectionCapability.test.ts
+++ b/src/vs/workbench/contrib/terminal/test/browser/capabilities/commandDetectionCapability.test.ts
@@ -63,6 +63,7 @@ suite('CommandDetectionCapability', () => {
 	async function printCommandStart(prompt: string) {
 		capability.handlePromptStart();
 		await writeP(xterm, `\r${prompt}`);
+		capability.handleCommandStart();
 	}
 
 


### PR DESCRIPTION
Part of #196634

Before:

![image](https://github.com/microsoft/vscode/assets/2193314/cf409634-70d6-4a4f-a752-3893aea24add)

After (the D is correctly positioned):

![image](https://github.com/microsoft/vscode/assets/2193314/707e7cdc-428b-4b8e-93af-73e8ed8205d6)
