### PR TITLE
Fixes #198566: ellipsize left-cut search preview

### DIFF
--- a/src/vs/base/common/strings.ts
+++ b/src/vs/base/common/strings.ts
@@ -710,10 +710,11 @@ export function isEmojiImprecise(x: number): boolean {
 /**
  * Given a string and a max length returns a shorted version. Shorting
  * happens at favorable positions - such as whitespace or punctuation characters.
+ * The return value can be longer than the given value of `n`. Leading whitespace is always trimmed.
  */
 export function lcut(text: string, n: number, prefix = '') {
 	if (text.length < n) {
-		return text;
+		return text.trimStart();
 	}
 
 	const re = /\b/g;

--- a/src/vs/base/common/strings.ts
+++ b/src/vs/base/common/strings.ts
@@ -711,7 +711,7 @@ export function isEmojiImprecise(x: number): boolean {
  * Given a string and a max length returns a shorted version. Shorting
  * happens at favorable positions - such as whitespace or punctuation characters.
  */
-export function lcut(text: string, n: number) {
+export function lcut(text: string, n: number, prefix = '') {
 	if (text.length < n) {
 		return text;
 	}
@@ -727,7 +727,11 @@ export function lcut(text: string, n: number) {
 		re.lastIndex += 1;
 	}
 
-	return text.substring(i).replace(/^\s/, '');
+	if (i === 0) {
+		return text.trimStart();
+	}
+
+	return prefix + text.substring(i).trimStart();
 }
 
 // Escape codes, compiled from https://invisible-island.net/xterm/ctlseqs/ctlseqs.html#h3-Functions-using-CSI-_-ordered-by-the-final-character_s_

--- a/src/vs/base/common/strings.ts
+++ b/src/vs/base/common/strings.ts
@@ -713,14 +713,16 @@ export function isEmojiImprecise(x: number): boolean {
  * The return value can be longer than the given value of `n`. Leading whitespace is always trimmed.
  */
 export function lcut(text: string, n: number, prefix = '') {
-	if (text.length < n) {
-		return text.trimStart();
+	const trimmed = text.trimStart();
+
+	if (trimmed.length < n) {
+		return trimmed;
 	}
 
 	const re = /\b/g;
 	let i = 0;
-	while (re.test(text)) {
-		if (text.length - re.lastIndex < n) {
+	while (re.test(trimmed)) {
+		if (trimmed.length - re.lastIndex < n) {
 			break;
 		}
 
@@ -729,10 +731,10 @@ export function lcut(text: string, n: number, prefix = '') {
 	}
 
 	if (i === 0) {
-		return text.trimStart();
+		return trimmed;
 	}
 
-	return prefix + text.substring(i).trimStart();
+	return prefix + trimmed.substring(i).trimStart();
 }
 
 // Escape codes, compiled from https://invisible-island.net/xterm/ctlseqs/ctlseqs.html#h3-Functions-using-CSI-_-ordered-by-the-final-character_s_

--- a/src/vs/base/test/common/strings.test.ts
+++ b/src/vs/base/test/common/strings.test.ts
@@ -133,6 +133,13 @@ suite('Strings', () => {
 		assert.strictEqual(strings.lcut('foo bar', 5), 'foo bar');
 		assert.strictEqual(strings.lcut('test string 0.1.2.3', 3), '2.3');
 
+		assert.strictEqual(strings.lcut('foo bar', 0, '…'), '…');
+		assert.strictEqual(strings.lcut('foo bar', 1, '…'), '…bar');
+		assert.strictEqual(strings.lcut('foo bar', 3, '…'), '…bar');
+		assert.strictEqual(strings.lcut('foo bar', 4, '…'), '…bar'); // Leading whitespace trimmed
+		assert.strictEqual(strings.lcut('foo bar', 5, '…'), 'foo bar');
+		assert.strictEqual(strings.lcut('test string 0.1.2.3', 3, '…'), '…2.3');
+
 		assert.strictEqual(strings.lcut('', 10), '');
 		assert.strictEqual(strings.lcut('a', 10), 'a');
 	});

--- a/src/vs/base/test/common/strings.test.ts
+++ b/src/vs/base/test/common/strings.test.ts
@@ -144,12 +144,14 @@ suite('Strings', () => {
 		assert.strictEqual(strings.lcut('a', 10), 'a');
 		assert.strictEqual(strings.lcut(' a', 10), 'a');
 		assert.strictEqual(strings.lcut('            a', 10), 'a');
+		assert.strictEqual(strings.lcut(' bbbb       a', 10), 'bbbb       a');
 		assert.strictEqual(strings.lcut('............a', 10), '............a');
 
 		assert.strictEqual(strings.lcut('', 10, '…'), '');
 		assert.strictEqual(strings.lcut('a', 10, '…'), 'a');
 		assert.strictEqual(strings.lcut(' a', 10, '…'), 'a');
 		assert.strictEqual(strings.lcut('            a', 10, '…'), 'a');
+		assert.strictEqual(strings.lcut(' bbbb       a', 10, '…'), 'bbbb       a');
 		assert.strictEqual(strings.lcut('............a', 10, '…'), '............a');
 	});
 

--- a/src/vs/base/test/common/strings.test.ts
+++ b/src/vs/base/test/common/strings.test.ts
@@ -142,6 +142,15 @@ suite('Strings', () => {
 
 		assert.strictEqual(strings.lcut('', 10), '');
 		assert.strictEqual(strings.lcut('a', 10), 'a');
+		assert.strictEqual(strings.lcut(' a', 10), 'a');
+		assert.strictEqual(strings.lcut('            a', 10), 'a');
+		assert.strictEqual(strings.lcut('............a', 10), '............a');
+
+		assert.strictEqual(strings.lcut('', 10, '…'), '');
+		assert.strictEqual(strings.lcut('a', 10, '…'), 'a');
+		assert.strictEqual(strings.lcut(' a', 10, '…'), 'a');
+		assert.strictEqual(strings.lcut('            a', 10, '…'), 'a');
+		assert.strictEqual(strings.lcut('............a', 10, '…'), '............a');
 	});
 
 	test('escape', () => {

--- a/src/vs/workbench/contrib/search/browser/searchModel.ts
+++ b/src/vs/workbench/contrib/search/browser/searchModel.ts
@@ -90,13 +90,12 @@ export class Match {
 	}
 
 	@memoize
-	preview(): { before: string; inside: string; after: string } {
-		let before = this._oneLinePreviewText.substring(0, this._rangeInPreviewText.startColumn - 1),
-			inside = this.getMatchString(),
-			after = this._oneLinePreviewText.substring(this._rangeInPreviewText.endColumn - 1);
+	preview(): { before: string; fullBefore: string; inside: string; after: string } {
+		const fullBefore = this._oneLinePreviewText.substring(0, this._rangeInPreviewText.startColumn - 1),
+			before = lcut(fullBefore, 26, '…');
 
-		before = lcut(before, 26);
-		before = before.trimStart();
+		let inside = this.getMatchString(),
+			after = this._oneLinePreviewText.substring(this._rangeInPreviewText.endColumn - 1);
 
 		let charsRemaining = Match.MAX_PREVIEW_CHARS - before.length;
 		inside = inside.substr(0, charsRemaining);
@@ -105,6 +104,7 @@ export class Match {
 
 		return {
 			before,
+			fullBefore,
 			inside,
 			after,
 		};

--- a/src/vs/workbench/contrib/search/browser/searchResultsView.ts
+++ b/src/vs/workbench/contrib/search/browser/searchResultsView.ts
@@ -361,7 +361,7 @@ export class MatchRenderer extends Disposable implements ICompressibleTreeRender
 		templateData.match.classList.toggle('replace', replace);
 		templateData.replace.textContent = replace ? match.replaceString : '';
 		templateData.after.textContent = preview.after;
-		templateData.parent.title = (preview.before + (replace ? match.replaceString : preview.inside) + preview.after).trim().substr(0, 999);
+		templateData.parent.title = (preview.fullBefore + (replace ? match.replaceString : preview.inside) + preview.after).trim().substr(0, 999);
 
 		IsEditableItemKey.bindTo(templateData.contextKeyService).set(!(match instanceof MatchInNotebook && match.isReadonly()));
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This fixes #198566 

The second screenshot in the issue is done with this PR in place.

Comments:

* In `strings.ts`, perhaps `lcut()` should have the prefix default to '…' – it seems that the search preview generation is the only user of this function, and it would be consistent with `truncate()`.
* In `searchModel.ts`, we don't need to do `trimStart()` on `before` because `lcut()` already does that (and already did it before this PR, too).