### PR TITLE
only trigger view creation when notebook is opened

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/contrib/notebookVariables/notebookVariables.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/notebookVariables/notebookVariables.ts
@@ -26,9 +26,6 @@ export class NotebookVariables extends Disposable implements IWorkbenchContribut
 		@IConfigurationService configurationService: IConfigurationService,
 	) {
 		super();
-		if (this.initializeView()) {
-			return;
-		}
 
 		this.listener = this.editorService.onDidEditorsChange(() => {
 			if (configurationService.getValue('notebook.experimental.notebookVariablesView')


### PR DESCRIPTION
gets rid of the case that the view is created without the setting