### PR TITLE
Mobile/Android: support text selection with a pen/stylus.

### DIFF
--- a/src/vs/base/browser/canIUse.ts
+++ b/src/vs/base/browser/canIUse.ts
@@ -43,5 +43,5 @@ export const BrowserFeatures = {
 	// 'ontouchstart' in window always evaluates to true with typescript's modern typings. This causes `window` to be
 	// `never` later in `window.navigator`. That's why we need the explicit `window as Window` cast
 	touch: 'ontouchstart' in mainWindow || navigator.maxTouchPoints > 0,
-	pointerEvents: mainWindow.PointerEvent && ('ontouchstart' in mainWindow || navigator.maxTouchPoints > 0 || navigator.maxTouchPoints > 0)
+	pointerEvents: mainWindow.PointerEvent && ('ontouchstart' in mainWindow || navigator.maxTouchPoints > 0)
 };

--- a/src/vs/editor/browser/controller/pointerHandler.ts
+++ b/src/vs/editor/browser/controller/pointerHandler.ts
@@ -59,27 +59,7 @@ export class PointerEventHandler extends MouseHandler {
 
 		event.preventDefault();
 		this.viewHelper.focusTextArea();
-		const target = this._createMouseTarget(new EditorMouseEvent(event, false, this.viewHelper.viewDomNode), false);
-
-		if (target.position) {
-			// this.viewController.moveTo(target.position);
-			this.viewController.dispatchMouse({
-				position: target.position,
-				mouseColumn: target.position.column,
-				startedOnLineNumbers: false,
-				revealType: NavigationCommandRevealType.Minimal,
-				mouseDownCount: event.tapCount,
-				inSelectionMode: false,
-				altKey: false,
-				ctrlKey: false,
-				metaKey: false,
-				shiftKey: false,
-
-				leftButton: false,
-				middleButton: false,
-				onInjectedText: target.type === MouseTargetType.CONTENT_TEXT && target.detail.injectedText !== null
-			});
-		}
+		this._dispatchGesture(event, /*inSelectionMode*/false);
 	}
 
 	private onChange(event: GestureEvent): void {
@@ -87,24 +67,28 @@ export class PointerEventHandler extends MouseHandler {
 			this._context.viewModel.viewLayout.deltaScrollNow(-event.translationX, -event.translationY);
 		}
 		if (this._lastPointerType === 'pen') {
-			const target = this._createMouseTarget(new EditorMouseEvent(event, false, this.viewHelper.viewDomNode), false);
-			if (target.position) {
-				this.viewController.dispatchMouse({
-					position: target.position,
-					mouseColumn: target.position.column,
-					startedOnLineNumbers: false,
-					revealType: NavigationCommandRevealType.Minimal,
-					mouseDownCount: event.tapCount,
-					inSelectionMode: true,
-					altKey: false,
-					ctrlKey: false,
-					metaKey: false,
-					shiftKey: false,
-					leftButton: false,
-					middleButton: false,
-					onInjectedText: target.type === MouseTargetType.CONTENT_TEXT && target.detail.injectedText !== null
-				});
-			}
+			this._dispatchGesture(event, /*inSelectionMode*/true);
+		}
+	}
+
+	private _dispatchGesture(event: GestureEvent, inSelectionMode: boolean): void {
+		const target = this._createMouseTarget(new EditorMouseEvent(event, false, this.viewHelper.viewDomNode), false);
+		if (target.position) {
+			this.viewController.dispatchMouse({
+				position: target.position,
+				mouseColumn: target.position.column,
+				startedOnLineNumbers: false,
+				revealType: NavigationCommandRevealType.Minimal,
+				mouseDownCount: event.tapCount,
+				inSelectionMode,
+				altKey: false,
+				ctrlKey: false,
+				metaKey: false,
+				shiftKey: false,
+				leftButton: false,
+				middleButton: false,
+				onInjectedText: target.type === MouseTargetType.CONTENT_TEXT && target.detail.injectedText !== null
+			});
 		}
 	}
 
@@ -156,7 +140,7 @@ export class PointerHandler extends Disposable {
 
 	constructor(context: ViewContext, viewController: ViewController, viewHelper: IPointerHandlerHelper) {
 		super();
-		if ((BrowserFeatures.pointerEvents)) {
+		if (BrowserFeatures.pointerEvents) {
 			this.handler = this._register(new PointerEventHandler(context, viewController, viewHelper));
 		} else if (mainWindow.TouchEvent) {
 			this.handler = this._register(new TouchHandler(context, viewController, viewHelper));


### PR DESCRIPTION
Currently it is not possible to use a pointing device on a mobile device to make text selections, leaving the keyboard as the only viable option.

This change enables a pen to be used for selection and this works well for Android-based mobile phones and tablets with support for a pen. As it enables text to be selected with the pen instead of simply scrolling (which you can already do with touch). I've tested the [PointerEventHandler] on a Samsung Z Fold5 android (using touch & S pen) and it works well, I don't see why it should be restricted to IOS, so I've removed the platform flag.

Before this change, pens on android would act as touch input (scrolling when moved) and although I don't have an IOS device on hand to confirm, from looking at the [PointerEventHandler], it would appear that an IOS pen can only be used to perform tap gestures.

I support efforts to make text selection possible using touch-only but in the mean time, this change should help to make VS Code usable on more mobile devices.

Helps to extend, compliment and address:
https://github.com/microsoft/vscode/issues/21812
https://github.com/microsoft/vscode/issues/47770
https://github.com/microsoft/monaco-editor/issues/246 https://github.com/microsoft/monaco-editor/issues/1504