### PR TITLE
Comment on a tracker issue whenever an issue is added to Backlog Candidates

### DIFF
--- a/.github/workflows/backlog-candidates.yml
+++ b/.github/workflows/backlog-candidates.yml
@@ -1,20 +1,25 @@
-name: Add comment to Backlog Candidate Tracker issue when an issue is milestoned
+name: Add comment to Backlog Candidate Tracker issue when any issue is milestoned to Backlog Candidates
 on:
   issues:
     types:
       - milestoned
 jobs:
   add-comment:
-    if: github.event.milestone.title == 'Backlog Candidate'
+    if: github.event.milestone.title == 'Backlog Candidates'
     runs-on: ubuntu-latest
     permissions:
       issues: write
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      REPO: ${{ github.repository }}
+      TRACKER_ISSUE: 198675
     steps:
+      - name: unlock issue
+        run: gh issue unlock "$TRACKER_ISSUE" --repo "$REPO"
       - name: Add comment
         run: gh issue comment "$TRACKER_ISSUE" --repo "$REPO" --body "$BODY"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TRACKER_ISSUE: 5
-          REPO: ${{ github.repository }}
           BODY: >
-            Issue #${{ github.event.issue.number }} has been made a Backlog Candidate. If you want to support this issue, please add a thumbs up reaction to its description within 60 days.
+            Issue #${{ github.event.issue.number }} (${{ github.event.issue.title }}) has been made a Backlog Candidate. If you want to support this issue, add a thumbs up reaction (:+1:) to its description within 60 days. Read more about this process [here](https://github.com/microsoft/vscode/wiki/Issues-Triaging#managing-feature-requests).
+      - name: lock issue
+        run: gh issue lock "$TRACKER_ISSUE" --repo "$REPO"

--- a/.github/workflows/backlog-candidates.yml
+++ b/.github/workflows/backlog-candidates.yml
@@ -1,0 +1,20 @@
+name: Add comment to Backlog Candidate Tracker issue when an issue is milestoned
+on:
+  issues:
+    types:
+      - milestoned
+jobs:
+  add-comment:
+    if: github.event.milestone.title == 'Backlog Candidate'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Add comment
+        run: gh issue comment "$TRACKER_ISSUE" --repo "$REPO" --body "$BODY"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TRACKER_ISSUE: 5
+          REPO: ${{ github.repository }}
+          BODY: >
+            Issue #${{ github.event.issue.number }} has been made a Backlog Candidate. If you want to support this issue, please add a thumbs up reaction to its description within 60 days.


### PR DESCRIPTION
If merged, this PR will add a comment to #198675 whenever an issue is milestoned to Backlog Candidates.

People interested in reviewing candidates and potentially upvoting them need only subscribe to #198675 to get notifications. If they upvote a candidate they can subsequently get notifications about its progress.