### PR TITLE
Fix #179566

### DIFF
--- a/src/vs/base/browser/ui/centered/centeredViewLayout.ts
+++ b/src/vs/base/browser/ui/centered/centeredViewLayout.ts
@@ -66,12 +66,12 @@ export class CenteredViewLayout implements IDisposable {
 	private didLayout = false;
 	private emptyViews: ISplitViewView<{ top: number; left: number }>[] | undefined;
 	private readonly splitViewDisposables = new DisposableStore();
-	private centeredLayoutFixedWidth = true;
 
 	constructor(
 		private container: HTMLElement,
 		private view: IView,
-		public state: CenteredViewState = { ...defaultState }
+		public state: CenteredViewState = { ...defaultState },
+		private centeredLayoutFixedWidth: boolean = false
 	) {
 		this.container.appendChild(this.view.element);
 		// Make sure to hide the split view overflow like sashes #52892

--- a/src/vs/workbench/browser/parts/editor/editorPart.ts
+++ b/src/vs/workbench/browser/parts/editor/editorPart.ts
@@ -990,7 +990,7 @@ export class EditorPart extends Part implements IEditorPart, IEditorGroupsView {
 		this.doCreateGridControl(options);
 
 		// Centered layout widget
-		this.centeredLayoutWidget = this._register(new CenteredViewLayout(this.container, this.gridWidgetView, this.profileMemento[EditorPart.EDITOR_PART_CENTERED_VIEW_STORAGE_KEY]));
+		this.centeredLayoutWidget = this._register(new CenteredViewLayout(this.container, this.gridWidgetView, this.profileMemento[EditorPart.EDITOR_PART_CENTERED_VIEW_STORAGE_KEY], this._partOptions.centeredLayoutFixedWidth));
 		this._register(this.onDidChangeEditorPartOptions(e => this.centeredLayoutWidget.setFixedWidth(e.newPartOptions.centeredLayoutFixedWidth ?? false)));
 
 		// Drag & Drop support


### PR DESCRIPTION
CenteredViewLayout options are not passed during initialization which causes the state to be overwritten before the centeredLayoutFixedWidth option can be considered.

Fixes #179566
PR which cause the bug: #167568