### PR TITLE
fix: revert settings search results ordering

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/settingsTreeModels.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsTreeModels.ts
@@ -866,7 +866,7 @@ export class SearchResultModel extends SettingsTreeModel {
 		viewState: ISettingsEditorViewState,
 		settingsOrderByTocIndex: Map<string, number> | null,
 		isWorkspaceTrusted: boolean,
-		@IWorkbenchConfigurationService private readonly configurationService: IWorkbenchConfigurationService,
+		@IWorkbenchConfigurationService configurationService: IWorkbenchConfigurationService,
 		@IWorkbenchEnvironmentService private readonly environmentService: IWorkbenchEnvironmentService,
 		@ILanguageService languageService: ILanguageService,
 		@IUserDataProfileService userDataProfileService: IUserDataProfileService,
@@ -884,18 +884,13 @@ export class SearchResultModel extends SettingsTreeModel {
 			}
 		}
 
-		const tocHiddenDuringSearch = this.configurationService.getValue('workbench.settings.settingsSearchTocBehavior') === 'hide';
-		if (!tocHiddenDuringSearch) {
-			// Sort the settings according to internal order if indexed.
-			if (this.settingsOrderByTocIndex) {
-				filterMatches.sort((a, b) => compareTwoNullableNumbers(a.setting.internalOrder, b.setting.internalOrder));
-			}
-			return filterMatches;
+		// The search only has filters, so we can sort by the order in the TOC.
+		if (!this._viewState.query) {
+			return filterMatches.sort((a, b) => compareTwoNullableNumbers(a.setting.internalOrder, b.setting.internalOrder));
 		}
 
-		// The table of contents is hidden during the search.
-		// The settings could appear in a more haphazard order.
-		// Sort the settings according to their score.
+		// Sort the settings according to their relevancy.
+		// https://github.com/microsoft/vscode/issues/197773
 		filterMatches.sort((a, b) => {
 			if (a.matchType !== b.matchType) {
 				// Sort by match type if the match types are not the same.

--- a/src/vs/workbench/contrib/preferences/common/preferencesContribution.ts
+++ b/src/vs/workbench/contrib/preferences/common/preferencesContribution.ts
@@ -152,8 +152,8 @@ registry.registerConfiguration({
 			'type': 'string',
 			'enum': ['hide', 'filter'],
 			'enumDescriptions': [
-				nls.localize('settingsSearchTocBehavior.hide', "Hide the Table of Contents while searching. The search results will not be grouped by category, and instead will be sorted by similarity to the query, with exact keyword matches coming first."),
-				nls.localize('settingsSearchTocBehavior.filter', "Filter the Table of Contents to just categories that have matching settings. Clicking a category will filter the results to that category. The search results will be grouped by category."),
+				nls.localize('settingsSearchTocBehavior.hide', "Hide the Table of Contents while searching."),
+				nls.localize('settingsSearchTocBehavior.filter', "Filter the Table of Contents to just categories that have matching settings. Clicking on a category will filter the results to that category."),
 			],
 			'description': nls.localize('settingsSearchTocBehavior', "Controls the behavior of the Settings editor Table of Contents while searching. If this setting is being changed in the Settings editor, the setting will take effect after the search query is modified."),
 			'default': 'filter',


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/197773

This PR partially reverts the ordering algorithm of the Settings editor search results so that keyword match results show up first. The table of contents order is still calculated and used in two cases:

1. When the search query only has filters, such as if the user is filtering down to a feature area with `@feature`, or an extension area with `@ext`.
2. As a last resort for two items that are determined to have the same relevancy.
