### PR TITLE
fix: avoid lookbehind regex for TF-IDF

### DIFF
--- a/src/vs/base/common/tfIdf.ts
+++ b/src/vs/base/common/tfIdf.ts
@@ -88,8 +88,7 @@ export class TfIdfCalculator {
 		for (const [word] of input.matchAll(/\b\p{Letter}[\p{Letter}\d]{2,}\b/gu)) {
 			yield normalize(word);
 
-			// eslint-disable-next-line local/code-no-look-behind-regex
-			const camelParts = word.split(/(?<=[a-z])(?=[A-Z])/g);
+			const camelParts = word.replace(/([a-z])([A-Z])/g, '$1 $2').split(/\s+/g);
 			if (camelParts.length > 1) {
 				for (const part of camelParts) {
 					// Require at least 3 letters in the parts of a camel case word


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fixes https://github.com/microsoft/vscode/issues/197473 by using another approach to split camel-case words that doesn't use lookbehind regexes.
