### PR TITLE
Extend TextEditorLineNumbersStyle with Interval

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadEditor.ts
+++ b/src/vs/workbench/api/browser/mainThreadEditor.ts
@@ -400,13 +400,16 @@ export class MainThreadTextEditor {
 		}
 
 		if (typeof newConfiguration.lineNumbers !== 'undefined') {
-			let lineNumbers: 'on' | 'off' | 'relative';
+			let lineNumbers: 'on' | 'off' | 'relative' | 'interval';
 			switch (newConfiguration.lineNumbers) {
 				case RenderLineNumbersType.On:
 					lineNumbers = 'on';
 					break;
 				case RenderLineNumbersType.Relative:
 					lineNumbers = 'relative';
+					break;
+				case RenderLineNumbersType.Interval:
+					lineNumbers = 'interval';
 					break;
 				default:
 					lineNumbers = 'off';

--- a/src/vs/workbench/api/common/extHostTypeConverters.ts
+++ b/src/vs/workbench/api/common/extHostTypeConverters.ts
@@ -1379,6 +1379,8 @@ export namespace TextEditorLineNumbersStyle {
 				return RenderLineNumbersType.Off;
 			case types.TextEditorLineNumbersStyle.Relative:
 				return RenderLineNumbersType.Relative;
+			case types.TextEditorLineNumbersStyle.Interval:
+				return RenderLineNumbersType.Interval;
 			case types.TextEditorLineNumbersStyle.On:
 			default:
 				return RenderLineNumbersType.On;
@@ -1390,6 +1392,8 @@ export namespace TextEditorLineNumbersStyle {
 				return types.TextEditorLineNumbersStyle.Off;
 			case RenderLineNumbersType.Relative:
 				return types.TextEditorLineNumbersStyle.Relative;
+			case RenderLineNumbersType.Interval:
+				return types.TextEditorLineNumbersStyle.Interval;
 			case RenderLineNumbersType.On:
 			default:
 				return types.TextEditorLineNumbersStyle.On;

--- a/src/vs/workbench/api/common/extHostTypes.ts
+++ b/src/vs/workbench/api/common/extHostTypes.ts
@@ -1821,7 +1821,8 @@ export function asStatusBarItemIdentifier(extension: ExtensionIdentifier, id: st
 export enum TextEditorLineNumbersStyle {
 	Off = 0,
 	On = 1,
-	Relative = 2
+	Relative = 2,
+	Interval = 3
 }
 
 export enum TextDocumentSaveReason {

--- a/src/vscode-dts/vscode.d.ts
+++ b/src/vscode-dts/vscode.d.ts
@@ -657,7 +657,11 @@ declare module 'vscode' {
 		/**
 		 * Render the line numbers with values relative to the primary cursor location.
 		 */
-		Relative = 2
+		Relative = 2,
+		/**
+		 * Render the line numbers on every 10th line number.
+		 */
+		Interval = 3,
 	}
 
 	/**


### PR DESCRIPTION
- Extend `TextEditorLineNumbersStyle` in both extHostTypes.ts and vscode.d.ts with an `Interval` member.
- Update extHostTypeConverters.ts to convert between `TextEditorLineNumbersStyle.Interval` and (the already extant) `RenderLineNumbersType.Interval`.
- Update `MainThreadTextEditor.setConfiguration` to handle `{ ..., lineNumbers: 'interval' }`.

This should allow extensions to read from/write to `vscode.window.activeTextEditor.options.lineNumbers` to detect and apply the `Interval` configuration. This PR was tested by starting a debugging session, and modifying the above field in the Debug Console.

This PR may be relevant to #85471, though that issue is closed, and was locked in January of 2022. (It says there are three comments on there, but I'm not seeing them. I'm guessing they added after the github-actions bot locked the issue and community members can't access them?)

I'd be happy to open a new issue to link this PR to if that would be helpful to the process.