### PR TITLE
testing: initial test coverage UI

### DIFF
--- a/build/lib/stylelint/vscode-known-variables.json
+++ b/build/lib/stylelint/vscode-known-variables.json
@@ -791,6 +791,7 @@
 		"--z-index-notebook-scrollbar",
 		"--z-index-run-button-container",
 		"--z-index-notebook-sticky-scroll",
-		"--zoom-factor"
+		"--zoom-factor",
+		"--test-bar-width"
 	]
 }

--- a/src/vs/base/common/iterator.ts
+++ b/src/vs/base/common/iterator.ts
@@ -84,9 +84,7 @@ export namespace Iterable {
 
 	export function* concat<T>(...iterables: Iterable<T>[]): Iterable<T> {
 		for (const iterable of iterables) {
-			for (const element of iterable) {
-				yield element;
-			}
+			yield* iterable;
 		}
 	}
 

--- a/src/vs/editor/common/core/position.ts
+++ b/src/vs/editor/common/core/position.ts
@@ -174,4 +174,11 @@ export class Position {
 			&& (typeof obj.column === 'number')
 		);
 	}
+
+	public toJSON(): IPosition {
+		return {
+			lineNumber: this.lineNumber,
+			column: this.column
+		};
+	}
 }

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -621,6 +621,7 @@ declare namespace monaco {
 		 * Test if `obj` is an `IPosition`.
 		 */
 		static isIPosition(obj: any): obj is IPosition;
+		toJSON(): IPosition;
 	}
 
 	/**

--- a/src/vs/workbench/api/browser/mainThreadTesting.ts
+++ b/src/vs/workbench/api/browser/mainThreadTesting.ts
@@ -7,20 +7,20 @@ import { VSBuffer } from 'vs/base/common/buffer';
 import { CancellationToken } from 'vs/base/common/cancellation';
 import { Event } from 'vs/base/common/event';
 import { Disposable, DisposableStore, IDisposable, MutableDisposable, toDisposable } from 'vs/base/common/lifecycle';
-import { revive } from 'vs/base/common/marshalling';
+import { ISettableObservable } from 'vs/base/common/observable';
+import { WellDefinedPrefixTree } from 'vs/base/common/prefixTree';
 import { URI } from 'vs/base/common/uri';
 import { Range } from 'vs/editor/common/core/range';
 import { MutableObservableValue } from 'vs/workbench/contrib/testing/common/observableValue';
-import { ExtensionRunTestsRequest, IFileCoverage, ITestItem, ITestMessage, ITestRunProfile, ITestRunTask, ResolvedTestRunRequest, TestResultState, TestRunProfileBitset, TestsDiffOp } from 'vs/workbench/contrib/testing/common/testTypes';
 import { TestCoverage } from 'vs/workbench/contrib/testing/common/testCoverage';
+import { TestId } from 'vs/workbench/contrib/testing/common/testId';
 import { ITestProfileService } from 'vs/workbench/contrib/testing/common/testProfileService';
 import { LiveTestResult } from 'vs/workbench/contrib/testing/common/testResult';
 import { ITestResultService } from 'vs/workbench/contrib/testing/common/testResultService';
 import { IMainThreadTestController, ITestRootProvider, ITestService } from 'vs/workbench/contrib/testing/common/testService';
-import { extHostNamedCustomer, IExtHostContext } from 'vs/workbench/services/extensions/common/extHostCustomers';
+import { CoverageDetails, ExtensionRunTestsRequest, IFileCoverage, ITestItem, ITestMessage, ITestRunProfile, ITestRunTask, ResolvedTestRunRequest, TestResultState, TestRunProfileBitset, TestsDiffOp } from 'vs/workbench/contrib/testing/common/testTypes';
+import { IExtHostContext, extHostNamedCustomer } from 'vs/workbench/services/extensions/common/extHostCustomers';
 import { ExtHostContext, ExtHostTestingShape, ILocationDto, ITestControllerPatch, MainContext, MainThreadTestingShape } from '../common/extHost.protocol';
-import { WellDefinedPrefixTree } from 'vs/base/common/prefixTree';
-import { TestId } from 'vs/workbench/contrib/testing/common/testId';
 
 @extHostNamedCustomer(MainContext.MainThreadTesting)
 export class MainThreadTesting extends Disposable implements MainThreadTestingShape, ITestRootProvider {
@@ -124,17 +124,21 @@ export class MainThreadTesting extends Disposable implements MainThreadTestingSh
 	/**
 	 * @inheritdoc
 	 */
-	$signalCoverageAvailable(runId: string, taskId: string): void {
+	$signalCoverageAvailable(runId: string, taskId: string, available: boolean): void {
 		this.withLiveRun(runId, run => {
 			const task = run.tasks.find(t => t.id === taskId);
 			if (!task) {
 				return;
 			}
 
-			(task.coverage as MutableObservableValue<TestCoverage>).value = new TestCoverage({
-				provideFileCoverage: async token => revive<IFileCoverage[]>(await this.proxy.$provideFileCoverage(runId, taskId, token)),
-				resolveFileCoverage: (i, token) => this.proxy.$resolveFileCoverage(runId, taskId, i, token),
-			});
+			const fn = available ? ((token: CancellationToken) => TestCoverage.load({
+				provideFileCoverage: async token => await this.proxy.$provideFileCoverage(runId, taskId, token)
+					.then(c => c.map(IFileCoverage.deserialize)),
+				resolveFileCoverage: (i, token) => this.proxy.$resolveFileCoverage(runId, taskId, i, token)
+					.then(d => d.map(CoverageDetails.deserialize)),
+			}, token)) : undefined;
+
+			(task.coverage as ISettableObservable<undefined | ((tkn: CancellationToken) => Promise<TestCoverage>)>).set(fn, undefined);
 		});
 	}
 

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -2617,12 +2617,12 @@ export interface ExtHostTestingShape {
 	/** Expands a test item's children, by the given number of levels. */
 	$expandTest(testId: string, levels: number): Promise<void>;
 	/** Requests file coverage for a test run. Errors if not available. */
-	$provideFileCoverage(runId: string, taskId: string, token: CancellationToken): Promise<Dto<IFileCoverage[]>>;
+	$provideFileCoverage(runId: string, taskId: string, token: CancellationToken): Promise<IFileCoverage.Serialized[]>;
 	/**
 	 * Requests coverage details for the file index in coverage data for the run.
 	 * Requires file coverage to have been previously requested via $provideFileCoverage.
 	 */
-	$resolveFileCoverage(runId: string, taskId: string, fileIndex: number, token: CancellationToken): Promise<CoverageDetails[]>;
+	$resolveFileCoverage(runId: string, taskId: string, fileIndex: number, token: CancellationToken): Promise<CoverageDetails.Serialized[]>;
 	/** Configures a test run config. */
 	$configureRunProfile(controllerId: string, configId: number): void;
 	/** Asks the controller to refresh its tests */
@@ -2693,7 +2693,7 @@ export interface MainThreadTestingShape {
 	/** Appends raw output to the test run.. */
 	$appendOutputToRun(runId: string, taskId: string, output: VSBuffer, location?: ILocationDto, testId?: string): void;
 	/** Triggered when coverage is added to test results. */
-	$signalCoverageAvailable(runId: string, taskId: string): void;
+	$signalCoverageAvailable(runId: string, taskId: string, available: boolean): void;
 	/** Signals a task in a test run started. */
 	$startedTestRunTask(runId: string, task: ITestRunTask): void;
 	/** Signals a task in a test run ended. */

--- a/src/vs/workbench/api/common/extHostTesting.ts
+++ b/src/vs/workbench/api/common/extHostTesting.ts
@@ -5,7 +5,6 @@
 
 /* eslint-disable local/code-no-native-private */
 
-import { mapFindFirst } from 'vs/base/common/arraysFind';
 import { RunOnceScheduler } from 'vs/base/common/async';
 import { VSBuffer } from 'vs/base/common/buffer';
 import { CancellationToken, CancellationTokenSource } from 'vs/base/common/cancellation';
@@ -28,7 +27,7 @@ import { TestRunProfileKind, TestRunRequest } from 'vs/workbench/api/common/extH
 import { TestCommandId } from 'vs/workbench/contrib/testing/common/constants';
 import { TestId, TestIdPathParts, TestPosition } from 'vs/workbench/contrib/testing/common/testId';
 import { InvalidTestItemError } from 'vs/workbench/contrib/testing/common/testItemCollection';
-import { AbstractIncrementalTestCollection, CoverageDetails, ICallProfileRunHandler, IFileCoverage, ISerializedTestResults, IStartControllerTests, IStartControllerTestsResult, ITestErrorMessage, ITestItem, ITestItemContext, ITestMessageMenuArgs, IncrementalChangeCollector, IncrementalTestCollectionItem, InternalTestItem, TestResultState, TestRunProfileBitset, TestsDiff, TestsDiffOp, isStartControllerTests } from 'vs/workbench/contrib/testing/common/testTypes';
+import { AbstractIncrementalTestCollection, CoverageDetails, ICallProfileRunHandler, IFileCoverage, ISerializedTestResults, IStartControllerTests, IStartControllerTestsResult, ITestErrorMessage, ITestItem, ITestItemContext, ITestMessageMenuArgs, IncrementalChangeCollector, IncrementalTestCollectionItem, InternalTestItem, KEEP_N_LAST_COVERAGE_REPORTS, TestResultState, TestRunProfileBitset, TestsDiff, TestsDiffOp, isStartControllerTests } from 'vs/workbench/contrib/testing/common/testTypes';
 import { checkProposedApiEnabled } from 'vs/workbench/services/extensions/common/extensions';
 import type * as vscode from 'vscode';
 
@@ -234,17 +233,19 @@ export class ExtHostTesting extends Disposable implements ExtHostTestingShape {
 	/**
 	 * @inheritdoc
 	 */
-	$provideFileCoverage(runId: string, taskId: string, token: CancellationToken): Promise<IFileCoverage[]> {
-		const coverage = mapFindFirst(this.runTracker.trackers, t => t.id === runId ? t.getCoverage(taskId) : undefined);
-		return coverage?.provideFileCoverage(token) ?? Promise.resolve([]);
+	async $provideFileCoverage(runId: string, taskId: string, token: CancellationToken): Promise<IFileCoverage.Serialized[]> {
+		const coverage = this.runTracker.getCoverageReport(runId, taskId);
+		const fileCoverage = await coverage?.provideFileCoverage(token);
+		return fileCoverage ?? [];
 	}
 
 	/**
 	 * @inheritdoc
 	 */
-	$resolveFileCoverage(runId: string, taskId: string, fileIndex: number, token: CancellationToken): Promise<CoverageDetails[]> {
-		const coverage = mapFindFirst(this.runTracker.trackers, t => t.id === runId ? t.getCoverage(taskId) : undefined);
-		return coverage?.resolveFileCoverage(fileIndex, token) ?? Promise.resolve([]);
+	async $resolveFileCoverage(runId: string, taskId: string, fileIndex: number, token: CancellationToken): Promise<CoverageDetails.Serialized[]> {
+		const coverage = this.runTracker.getCoverageReport(runId, taskId);
+		const details = await coverage?.resolveFileCoverage(fileIndex, token);
+		return details ?? [];
 	}
 
 	/** @inheritdoc */
@@ -430,10 +431,16 @@ const enum TestRunTrackerState {
 
 class TestRunTracker extends Disposable {
 	private state = TestRunTrackerState.Running;
-	private readonly tasks = new Map</* task ID */string, { run: vscode.TestRun; coverage: TestRunCoverageBearer }>();
+	private readonly tasks = new Map</* task ID */string, { run: vscode.TestRun }>();
 	private readonly sharedTestIds = new Set<string>();
 	private readonly cts: CancellationTokenSource;
 	private readonly endEmitter = this._register(new Emitter<void>());
+	private readonly coverageEmitter = this._register(new Emitter<{ runId: string; taskId: string; coverage: TestRunCoverageBearer | undefined }>());
+
+	/**
+	 * Fired when a coverage provider is added or removed from a task.
+	 */
+	public readonly onDidCoverage = this.coverageEmitter.event;
 
 	/**
 	 * Fires when a test ends, and no more tests are left running.
@@ -457,6 +464,7 @@ class TestRunTracker extends Disposable {
 	constructor(
 		private readonly dto: TestRunDto,
 		private readonly proxy: MainThreadTestingShape,
+		private readonly extension: IRelaxedExtensionDescription,
 		parentToken?: CancellationToken,
 	) {
 		super();
@@ -476,17 +484,14 @@ class TestRunTracker extends Disposable {
 		}
 	}
 
-	/** Gets coverage for a task ID. */
-	public getCoverage(taskId: string) {
-		return this.tasks.get(taskId)?.coverage;
-	}
-
 	/** Creates the public test run interface to give to extensions. */
 	public createRun(name: string | undefined): vscode.TestRun {
 		const runId = this.dto.id;
 		const ctrlId = this.dto.controllerId;
 		const taskId = generateUuid();
-		const coverage = new TestRunCoverageBearer(this.proxy, runId, taskId);
+		const extension = this.extension;
+		const coverageEmitter = this.coverageEmitter;
+		let coverage: TestRunCoverageBearer | undefined;
 
 		const guardTestMutation = <Args extends unknown[]>(fn: (test: vscode.TestItem, ...args: Args) => void) =>
 			(test: vscode.TestItem, ...args: Args) => {
@@ -524,10 +529,12 @@ class TestRunTracker extends Disposable {
 			token: this.cts.token,
 			name,
 			get coverageProvider() {
-				return coverage.coverageProvider;
+				return coverage?.provider;
 			},
 			set coverageProvider(provider) {
-				coverage.coverageProvider = provider;
+				checkProposedApiEnabled(extension, 'testCoverage');
+				coverage = provider && new TestRunCoverageBearer(provider);
+				coverageEmitter.fire({ taskId, runId, coverage });
 			},
 			//#region state mutation
 			enqueued: guardTestMutation(test => {
@@ -586,7 +593,7 @@ class TestRunTracker extends Disposable {
 			}
 		};
 
-		this.tasks.set(taskId, { run, coverage });
+		this.tasks.set(taskId, { run });
 		this.proxy.$startedTestRunTask(runId, { id: taskId, name, running: true });
 
 		return run;
@@ -641,18 +648,33 @@ class TestRunTracker extends Disposable {
 	}
 }
 
+interface CoverageReportRecord {
+	runId: string;
+	coverage: Map<string, TestRunCoverageBearer | undefined>;
+}
+
 /**
  * Queues runs for a single extension and provides the currently-executing
  * run so that `createTestRun` can be properly correlated.
  */
 export class TestRunCoordinator {
-	private tracked = new Map<vscode.TestRunRequest, TestRunTracker>();
+	private readonly tracked = new Map<vscode.TestRunRequest, TestRunTracker>();
+	private readonly coverageReports: CoverageReportRecord[] = [];
 
 	public get trackers() {
 		return this.tracked.values();
 	}
 
 	constructor(private readonly proxy: MainThreadTestingShape) { }
+
+	/**
+	 * Gets a coverage report for a given run and task ID.
+	 */
+	public getCoverageReport(runId: string, taskId: string) {
+		return this.coverageReports
+			.find(r => r.runId === runId)
+			?.coverage.get(taskId);
+	}
 
 	/**
 	 * Registers a request as being invoked by the main thread, so
@@ -718,9 +740,27 @@ export class TestRunCoordinator {
 	}
 
 	private getTracker(req: vscode.TestRunRequest, dto: TestRunDto, extension: IRelaxedExtensionDescription, token?: CancellationToken) {
-		const tracker = new TestRunTracker(dto, this.proxy, token);
+		const tracker = new TestRunTracker(dto, this.proxy, extension, token);
 		this.tracked.set(req, tracker);
-		Event.once(tracker.onEnd)(() => this.tracked.delete(req));
+
+		let coverageReports: CoverageReportRecord | undefined;
+		const coverageListener = tracker.onDidCoverage(({ runId, taskId, coverage }) => {
+			if (!coverageReports) {
+				coverageReports = { runId, coverage: new Map() };
+				this.coverageReports.unshift(coverageReports);
+				if (this.coverageReports.length > KEEP_N_LAST_COVERAGE_REPORTS) {
+					this.coverageReports.pop();
+				}
+			}
+
+			coverageReports.coverage.set(taskId, coverage);
+			this.proxy.$signalCoverageAvailable(runId, taskId, !!coverage);
+		});
+
+		Event.once(tracker.onEnd)(() => {
+			this.tracked.delete(req);
+			coverageListener.dispose();
+		});
 		return tracker;
 	}
 }
@@ -794,40 +834,13 @@ export class TestRunDto {
 }
 
 class TestRunCoverageBearer {
-	private _coverageProvider?: vscode.TestCoverageProvider;
 	private fileCoverage?: Promise<vscode.FileCoverage[] | null | undefined>;
 
-	public set coverageProvider(provider: vscode.TestCoverageProvider | undefined) {
-		if (this._coverageProvider) {
-			throw new Error('The TestCoverageProvider cannot be replaced after being provided');
-		}
+	constructor(public readonly provider: vscode.TestCoverageProvider) { }
 
-		if (!provider) {
-			return;
-		}
-
-		this._coverageProvider = provider;
-		this.proxy.$signalCoverageAvailable(this.runId, this.taskId);
-	}
-
-	public get coverageProvider() {
-		return this._coverageProvider;
-	}
-
-	constructor(
-		private readonly proxy: MainThreadTestingShape,
-		private readonly runId: string,
-		private readonly taskId: string,
-	) {
-	}
-
-	public async provideFileCoverage(token: CancellationToken): Promise<IFileCoverage[]> {
-		if (!this._coverageProvider) {
-			return [];
-		}
-
+	public async provideFileCoverage(token: CancellationToken): Promise<IFileCoverage.Serialized[]> {
 		if (!this.fileCoverage) {
-			this.fileCoverage = (async () => this._coverageProvider!.provideFileCoverage(token))();
+			this.fileCoverage = (async () => this.provider.provideFileCoverage(token))();
 		}
 
 		try {
@@ -839,15 +852,15 @@ class TestRunCoverageBearer {
 		}
 	}
 
-	public async resolveFileCoverage(index: number, token: CancellationToken): Promise<CoverageDetails[]> {
+	public async resolveFileCoverage(index: number, token: CancellationToken): Promise<CoverageDetails.Serialized[]> {
 		const fileCoverage = await this.fileCoverage;
 		let file = fileCoverage?.[index];
-		if (!this._coverageProvider || !fileCoverage || !file) {
+		if (!this.provider || !fileCoverage || !file) {
 			return [];
 		}
 
 		if (!file.detailedCoverage) {
-			file = fileCoverage[index] = await this._coverageProvider.resolveFileCoverage?.(file, token) ?? file;
+			file = fileCoverage[index] = await this.provider.resolveFileCoverage?.(file, token) ?? file;
 		}
 
 		return file.detailedCoverage?.map(Convert.TestCoverage.fromDetailed) ?? [];

--- a/src/vs/workbench/api/common/extHostTypeConverters.ts
+++ b/src/vs/workbench/api/common/extHostTypeConverters.ts
@@ -1968,14 +1968,14 @@ export namespace TestResults {
 
 export namespace TestCoverage {
 	function fromCoveredCount(count: vscode.CoveredCount): ICoveredCount {
-		return { covered: count.covered, total: count.covered };
+		return { covered: count.covered, total: count.total };
 	}
 
 	function fromLocation(location: vscode.Range | vscode.Position) {
 		return 'line' in location ? Position.from(location) : Range.from(location);
 	}
 
-	export function fromDetailed(coverage: vscode.DetailedCoverage): CoverageDetails {
+	export function fromDetailed(coverage: vscode.DetailedCoverage): CoverageDetails.Serialized {
 		if ('branches' in coverage) {
 			return {
 				count: coverage.executionCount,
@@ -1988,13 +1988,14 @@ export namespace TestCoverage {
 		} else {
 			return {
 				type: DetailType.Function,
+				name: coverage.name,
 				count: coverage.executionCount,
 				location: fromLocation(coverage.location),
 			};
 		}
 	}
 
-	export function fromFile(coverage: vscode.FileCoverage): IFileCoverage {
+	export function fromFile(coverage: vscode.FileCoverage): IFileCoverage.Serialized {
 		return {
 			uri: coverage.uri,
 			statement: fromCoveredCount(coverage.statementCoverage),

--- a/src/vs/workbench/api/common/extHostTypes.ts
+++ b/src/vs/workbench/api/common/extHostTypes.ts
@@ -3928,12 +3928,10 @@ export class TestTag implements vscode.TestTag {
 //#endregion
 
 //#region Test Coverage
-@es5ClassCompat
 export class CoveredCount implements vscode.CoveredCount {
 	constructor(public covered: number, public total: number) { }
 }
 
-@es5ClassCompat
 export class FileCoverage implements vscode.FileCoverage {
 	public static fromDetails(uri: vscode.Uri, details: vscode.DetailedCoverage[]): vscode.FileCoverage {
 		const statements = new CoveredCount(0, 0);
@@ -3977,7 +3975,6 @@ export class FileCoverage implements vscode.FileCoverage {
 	) { }
 }
 
-@es5ClassCompat
 export class StatementCoverage implements vscode.StatementCoverage {
 	constructor(
 		public executionCount: number,
@@ -3986,7 +3983,6 @@ export class StatementCoverage implements vscode.StatementCoverage {
 	) { }
 }
 
-@es5ClassCompat
 export class BranchCoverage implements vscode.BranchCoverage {
 	constructor(
 		public executionCount: number,
@@ -3994,9 +3990,9 @@ export class BranchCoverage implements vscode.BranchCoverage {
 	) { }
 }
 
-@es5ClassCompat
 export class FunctionCoverage implements vscode.FunctionCoverage {
 	constructor(
+		public readonly name: string,
 		public executionCount: number,
 		public location: Position | Range,
 	) { }

--- a/src/vs/workbench/contrib/testing/browser/icons.ts
+++ b/src/vs/workbench/contrib/testing/browser/icons.ts
@@ -33,6 +33,8 @@ export const testingTurnContinuousRunOff = registerIcon('testing-turn-continuous
 export const testingContinuousIsOn = registerIcon('testing-continuous-is-on', Codicon.eye, localize('testingTurnContinuousRunIsOn', 'Icon when continuous run is on for a test ite,.'));
 export const testingCancelRefreshTests = registerIcon('testing-cancel-refresh-tests', Codicon.stop, localize('testingCancelRefreshTests', 'Icon on the button to cancel refreshing tests.'));
 
+export const testingCoverage = registerIcon('testing-coverage', Codicon.lightBulb, localize('testingCoverage', 'Icon representing test coverage'));
+
 export const testingStatesToIcons = new Map<TestResultState, ThemeIcon>([
 	[TestResultState.Errored, registerIcon('testing-error-icon', Codicon.issues, localize('testingErrorIcon', 'Icon shown for tests that have an error.'))],
 	[TestResultState.Failed, registerIcon('testing-failed-icon', Codicon.error, localize('testingFailedIcon', 'Icon shown for tests that failed.'))],

--- a/src/vs/workbench/contrib/testing/browser/media/testing.css
+++ b/src/vs/workbench/contrib/testing/browser/media/testing.css
@@ -42,7 +42,8 @@
 }
 
 .test-explorer .test-item .label,
-.test-output-peek-tree .test-peek-item .name {
+.test-output-peek-tree .test-peek-item .name,
+.test-coverage-list-item-label {
 	flex-grow: 1;
 	width: 0;
 	overflow: hidden;
@@ -337,4 +338,34 @@
 }
 .monaco-editor .testing-inline-message-severity-1 {
 	color: var(--vscode-testing-message-info-decorationForeground) !important;
+}
+
+.test-coverage-list-item {
+	display: flex;
+}
+
+.test-coverage-bars {
+	display: flex;
+	align-items: center;
+	gap: 4px;
+	font-size: 11px;
+	margin-right: 0.8em;
+}
+
+.test-coverage-bars .bar {
+	width: 16px;
+	height: 8px;
+	border: 1px solid currentColor;
+	border-radius: 2px;
+	position: relative;
+	overflow: hidden;
+}
+
+.test-coverage-bars .bar::before {
+	content: '';
+	background: currentColor;
+	width: var(--test-bar-width);
+	height: 100%;
+	position: absolute;
+	opacity: 0.7;
 }

--- a/src/vs/workbench/contrib/testing/browser/testCoverageBars.ts
+++ b/src/vs/workbench/contrib/testing/browser/testCoverageBars.ts
@@ -1,0 +1,241 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { h } from 'vs/base/browser/dom';
+import { assertNever } from 'vs/base/common/assert';
+import { Emitter } from 'vs/base/common/event';
+import { IMarkdownString, MarkdownString } from 'vs/base/common/htmlContent';
+import { Lazy } from 'vs/base/common/lazy';
+import { Disposable, DisposableStore, toDisposable } from 'vs/base/common/lifecycle';
+import { ITransaction, autorun, observableValue } from 'vs/base/common/observable';
+import { isDefined } from 'vs/base/common/types';
+import { URI } from 'vs/base/common/uri';
+import { localize } from 'vs/nls';
+import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
+import { asCssVariableName, chartsGreen, chartsRed, chartsYellow } from 'vs/platform/theme/common/colorRegistry';
+import { TestingConfigKeys, TestingDisplayedCoveragePercent, getTestingConfiguration } from 'vs/workbench/contrib/testing/common/configuration';
+import { AbstractFileCoverage } from 'vs/workbench/contrib/testing/common/testCoverage';
+import { ITestCoverageService } from 'vs/workbench/contrib/testing/common/testCoverageService';
+import { ICoveredCount } from 'vs/workbench/contrib/testing/common/testTypes';
+import { IHoverService } from 'vs/workbench/services/hover/browser/hover';
+
+export interface TestCoverageBarsOptions {
+	/**
+	 * Whether the bars should be shown in a more compact way, where only the
+	 * overall bar is shown and more details are given in the hover.
+	 */
+	compact: boolean;
+	/**
+	 * Container in which is render the bars.
+	 */
+	container: HTMLElement;
+}
+
+const colorThresholds = [
+	{ color: asCssVariableName(chartsGreen), threshold: 0.9 },
+	{ color: asCssVariableName(chartsYellow), threshold: 0.6 },
+	{ color: asCssVariableName(chartsRed), threshold: -Infinity },
+];
+
+export class ManagedTestCoverageBars extends Disposable {
+	private _coverage?: AbstractFileCoverage;
+	private readonly el = new Lazy(() => {
+		if (this.options.compact) {
+			const el = h('.test-coverage-bars.compact', [
+				h('.tpc@overall'),
+				h('.bar@tpcBar'),
+			]);
+			this.attachHover(el.tpcBar, getOverallHoverText);
+			return el;
+		} else {
+			const el = h('.test-coverage-bars', [
+				h('.tpc@overall'),
+				h('.bar@statement'),
+				h('.bar@function'),
+				h('.bar@branch'),
+			]);
+			this.attachHover(el.statement, stmtCoverageText);
+			this.attachHover(el.function, fnCoverageText);
+			this.attachHover(el.branch, branchCoverageText);
+			return el;
+		}
+	});
+
+	private readonly changeEmitter = this._register(new Emitter<void>());
+	private readonly visibleStore = this._register(new DisposableStore());
+
+	/**
+	 * Event that fires whenver the displayed coverage is shown.
+	 */
+	public readonly onDidChange = this.changeEmitter.event;
+
+	constructor(
+		private readonly options: TestCoverageBarsOptions,
+		@IHoverService private readonly hoverService: IHoverService,
+		@IConfigurationService private readonly configurationService: IConfigurationService,
+	) {
+		super();
+	}
+
+	private attachHover(target: HTMLElement, factory: (coverage: AbstractFileCoverage) => string | IMarkdownString | undefined) {
+		target.onmouseenter = () => {
+			if (!this._coverage) {
+				return;
+			}
+
+			const content = factory(this._coverage);
+			if (!content) {
+				return;
+			}
+
+			const hover = this.hoverService.showHover({
+				content,
+				target,
+				appearance: {
+					showPointer: true,
+					compact: true,
+					skipFadeInAnimation: true,
+				}
+			});
+			if (hover) {
+				this.visibleStore.add(hover);
+			}
+		};
+	}
+
+	public setCoverageInfo(coverage: AbstractFileCoverage | undefined) {
+		const ds = this.visibleStore;
+		if (!coverage) {
+			if (this._coverage) {
+				this._coverage = undefined;
+				ds.clear();
+				this.changeEmitter.fire();
+			}
+			return;
+		}
+
+		if (!this._coverage) {
+			const root = this.el.value.root;
+			ds.add(toDisposable(() => this.options.container.removeChild(root)));
+			this.options.container.appendChild(root);
+			ds.add(this.configurationService.onDidChangeConfiguration(c => {
+				if (c.affectsConfiguration(TestingConfigKeys.CoveragePercent) && this._coverage) {
+					this.doRender(this._coverage);
+				}
+			}));
+		}
+
+		this._coverage = coverage;
+		this.doRender(coverage);
+	}
+
+	private doRender(coverage: AbstractFileCoverage) {
+		const el = this.el.value;
+
+		const overallStat = calculateDisplayedStat(coverage, getTestingConfiguration(this.configurationService, TestingConfigKeys.CoveragePercent));
+		el.overall.textContent = displayPercent(overallStat);
+
+		if ('tpcBar' in el) { // compact mode
+			renderBar(el.tpcBar, overallStat);
+		} else {
+			renderBar(el.statement, percent(coverage.statement));
+			renderBar(el.function, coverage.function && percent(coverage.function));
+			renderBar(el.branch, coverage.branch && percent(coverage.branch));
+		}
+
+		this.changeEmitter.fire();
+	}
+}
+
+const percent = (cc: ICoveredCount) => cc.total === 0 ? 1 : cc.covered / cc.total;
+const precision = 2;
+const epsilon = 10e-8;
+
+const renderBar = (bar: HTMLElement, pct: number | undefined) => {
+	if (pct === undefined) {
+		bar.style.display = 'none';
+	} else {
+		bar.style.display = 'block';
+		bar.style.setProperty('--test-bar-width', `${pct * 100}%`);
+		bar.style.color = `var(${colorThresholds.find(t => pct >= t.threshold)!.color})`;
+	}
+};
+
+const calculateDisplayedStat = (coverage: AbstractFileCoverage, method: TestingDisplayedCoveragePercent) => {
+	switch (method) {
+		case TestingDisplayedCoveragePercent.Statement:
+			return percent(coverage.statement);
+		case TestingDisplayedCoveragePercent.Minimum: {
+			let value = percent(coverage.statement);
+			if (coverage.branch) { value = Math.min(value, percent(coverage.branch)); }
+			if (coverage.function) { value = Math.min(value, percent(coverage.function)); }
+			return value;
+		}
+		case TestingDisplayedCoveragePercent.TotalCoverage:
+			return coverage.tpc;
+		default:
+			assertNever(method);
+	}
+
+};
+
+const displayPercent = (value: number) => {
+	const display = (value * 100).toFixed(precision);
+
+	// avoid showing 100% coverage if it just rounds up:
+	if (value < 1 - epsilon && display === '100') {
+		return '99.99%';
+	}
+
+	return `${display}%`;
+};
+
+const stmtCoverageText = (coverage: AbstractFileCoverage) => localize('statementCoverage', '{0}/{1} statements covered ({2})', coverage.statement.covered, coverage.statement.total, displayPercent(percent(coverage.statement)));
+const fnCoverageText = (coverage: AbstractFileCoverage) => coverage.function && localize('functionCoverage', '{0}/{1} functions covered ({2})', coverage.function.covered, coverage.function.total, displayPercent(percent(coverage.function)));
+const branchCoverageText = (coverage: AbstractFileCoverage) => coverage.branch && localize('branchCoverage', '{0}/{1} branches covered ({2})', coverage.branch.covered, coverage.branch.total, displayPercent(percent(coverage.branch)));
+
+const getOverallHoverText = (coverage: AbstractFileCoverage) => new MarkdownString([
+	stmtCoverageText(coverage),
+	fnCoverageText(coverage),
+	branchCoverageText(coverage),
+].filter(isDefined).join('\n\n'));
+
+/**
+ * Renders test coverage bars for a resource in the given container. It will
+ * not render anything unless a test coverage report has been opened.
+ */
+export class TestCoverageBars extends ManagedTestCoverageBars {
+	private readonly resource = observableValue<URI | undefined>(this, undefined);
+
+	constructor(
+		options: TestCoverageBarsOptions,
+		@IHoverService hoverService: IHoverService,
+		@IConfigurationService configurationService: IConfigurationService,
+		@ITestCoverageService testCoverageService: ITestCoverageService,
+	) {
+		super(options, hoverService, configurationService);
+
+		this._register(autorun(async reader => {
+			let info: AbstractFileCoverage | undefined;
+			const coverage = testCoverageService.selected.read(reader);
+			if (coverage) {
+				const resource = this.resource.read(reader);
+				if (resource) {
+					info = coverage.getUri(resource);
+				}
+			}
+
+			this.setCoverageInfo(info);
+		}));
+	}
+
+	/**
+	 * Sets the resource for which coverage bars will be rendered. May immediately
+	 * cause the rendering of coverage bars.
+	 */
+	public setResource(resource: URI, transaction?: ITransaction) {
+		this.resource.set(resource, transaction);
+	}
+}

--- a/src/vs/workbench/contrib/testing/browser/testCoverageView.ts
+++ b/src/vs/workbench/contrib/testing/browser/testCoverageView.ts
@@ -1,0 +1,318 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IIdentityProvider, IListVirtualDelegate } from 'vs/base/browser/ui/list/list';
+import { ITreeCompressionDelegate } from 'vs/base/browser/ui/tree/asyncDataTree';
+import { ICompressedTreeNode } from 'vs/base/browser/ui/tree/compressedObjectTreeModel';
+import { ICompressibleTreeRenderer } from 'vs/base/browser/ui/tree/objectTree';
+import { IAsyncDataSource, ITreeNode } from 'vs/base/browser/ui/tree/tree';
+import { FuzzyScore, createMatches } from 'vs/base/common/filters';
+import { Iterable } from 'vs/base/common/iterator';
+import { Disposable, DisposableStore, MutableDisposable } from 'vs/base/common/lifecycle';
+import { ResourceMap } from 'vs/base/common/map';
+import { autorun } from 'vs/base/common/observable';
+import { IPrefixTreeNode, WellDefinedPrefixTree } from 'vs/base/common/prefixTree';
+import { basenameOrAuthority } from 'vs/base/common/resources';
+import { URI } from 'vs/base/common/uri';
+import { localize } from 'vs/nls';
+import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
+import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
+import { IContextMenuService } from 'vs/platform/contextview/browser/contextView';
+import { EditorOpenSource } from 'vs/platform/editor/common/editor';
+import { FileKind } from 'vs/platform/files/common/files';
+import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
+import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
+import { ILabelService } from 'vs/platform/label/common/label';
+import { WorkbenchCompressibleAsyncDataTree } from 'vs/platform/list/browser/listService';
+import { IOpenerService } from 'vs/platform/opener/common/opener';
+import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
+import { IThemeService } from 'vs/platform/theme/common/themeService';
+import { IResourceLabel, ResourceLabels } from 'vs/workbench/browser/labels';
+import { IViewPaneOptions, ViewPane } from 'vs/workbench/browser/parts/views/viewPane';
+import { IViewDescriptorService } from 'vs/workbench/common/views';
+import { ManagedTestCoverageBars } from 'vs/workbench/contrib/testing/browser/testCoverageBars';
+import { AbstractFileCoverage, ComputedFileCoverage, FileCoverage, TestCoverage } from 'vs/workbench/contrib/testing/common/testCoverage';
+import { ITestCoverageService } from 'vs/workbench/contrib/testing/common/testCoverageService';
+import { DetailType, ICoveredCount, IFileCoverage, IFunctionCoverage } from 'vs/workbench/contrib/testing/common/testTypes';
+import { ACTIVE_GROUP, IEditorService, SIDE_GROUP } from 'vs/workbench/services/editor/common/editorService';
+
+export class TestCoverageView extends ViewPane {
+	private readonly tree = new MutableDisposable<TestCoverageTree>();
+
+	constructor(
+		options: IViewPaneOptions,
+		@IKeybindingService keybindingService: IKeybindingService,
+		@IContextMenuService contextMenuService: IContextMenuService,
+		@IConfigurationService configurationService: IConfigurationService,
+		@IContextKeyService contextKeyService: IContextKeyService,
+		@IViewDescriptorService viewDescriptorService: IViewDescriptorService,
+		@IInstantiationService instantiationService: IInstantiationService,
+		@IOpenerService openerService: IOpenerService,
+		@IThemeService themeService: IThemeService,
+		@ITelemetryService telemetryService: ITelemetryService,
+		@ITestCoverageService private readonly coverageService: ITestCoverageService,
+	) {
+		super(options, keybindingService, contextMenuService, configurationService, contextKeyService, viewDescriptorService, instantiationService, openerService, themeService, telemetryService);
+	}
+
+	protected override renderBody(container: HTMLElement): void {
+		super.renderBody(container);
+
+		const labels = this._register(this.instantiationService.createInstance(ResourceLabels, { onDidChangeVisibility: this.onDidChangeBodyVisibility }));
+
+		this._register(autorun(reader => {
+			const coverage = this.coverageService.selected.read(reader);
+			if (coverage) {
+				const t = (this.tree.value ??= this.instantiationService.createInstance(TestCoverageTree, container, labels));
+				t.setInput(coverage);
+			} else {
+				this.tree.clear();
+			}
+		}));
+	}
+
+	protected override layoutBody(height: number, width: number): void {
+		super.layoutBody(height, width);
+		this.tree.value?.layout(height, width);
+	}
+}
+
+class TestCoverageInput {
+	public readonly tree: WellDefinedPrefixTree<ComputedFileCoverage>;
+
+	constructor(files: ResourceMap<FileCoverage>) {
+		const tree = this.tree = new WellDefinedPrefixTree();
+
+		// 1. Initial iteration
+		for (const file of files.values()) {
+			tree.insert(this.treePathForUri(file.uri), file);
+		}
+
+		// 2. Depth-first iteration to create computed nodes
+		const calculateComputed = (path: string[], node: TestCoverageFileNode): AbstractFileCoverage => {
+			if (node.value) {
+				return node.value;
+			}
+
+			const fileCoverage: IFileCoverage = {
+				uri: this.treePathToUri(path),
+				statement: ICoveredCount.empty(),
+			};
+
+			if (node.children) {
+				for (const [prefix, child] of node.children) {
+					path.push(prefix);
+					const v = calculateComputed(path, child);
+					path.pop();
+
+					ICoveredCount.sum(fileCoverage.statement, v.statement);
+					if (v.branch) { ICoveredCount.sum(fileCoverage.branch ??= ICoveredCount.empty(), v.branch); }
+					if (v.function) { ICoveredCount.sum(fileCoverage.function ??= ICoveredCount.empty(), v.function); }
+				}
+			}
+
+			return node.value = new ComputedFileCoverage(fileCoverage);
+		};
+
+		for (const node of tree.nodes) {
+			calculateComputed([], node);
+		}
+	}
+
+	private *treePathForUri(uri: URI) {
+		yield uri.scheme;
+		yield uri.authority;
+		yield* uri.path.split('/');
+	}
+
+	private treePathToUri(path: string[]) {
+		return URI.from({ scheme: path[0], authority: path[1], path: path.slice(2).join('/') });
+	}
+}
+
+
+/** Type of nodes returned from {@link TestCoverage}. Note: value is *always* defined. */
+type TestCoverageFileNode = IPrefixTreeNode<ComputedFileCoverage | FileCoverage>;
+
+type CoverageTreeElement = TestCoverageFileNode | IFunctionCoverage;
+
+const isFileCoverage = (c: CoverageTreeElement): c is TestCoverageFileNode => 'value' in c;
+const isFunctionCoverage = (c: CoverageTreeElement): c is IFunctionCoverage => 'type' in c && c.type === DetailType.Function;
+
+class TestCoverageTree extends Disposable {
+	private readonly tree: WorkbenchCompressibleAsyncDataTree<TestCoverageInput | undefined, CoverageTreeElement, void>;
+
+	constructor(
+		container: HTMLElement,
+		labels: ResourceLabels,
+		@IInstantiationService instantiationService: IInstantiationService,
+		@IEditorService editorService: IEditorService,
+	) {
+		super();
+
+		this.tree = <WorkbenchCompressibleAsyncDataTree<TestCoverageInput | undefined, CoverageTreeElement, void>>instantiationService.createInstance(
+			WorkbenchCompressibleAsyncDataTree,
+			'TestCoverageView',
+			container,
+			new TestCoverageTreeListDelegate(),
+			new TestCoverageCompressionDelegate(),
+			[instantiationService.createInstance(FileCoverageRenderer, labels)],
+			instantiationService.createInstance(TestCoverageDataSource),
+			{
+				accessibilityProvider: {
+					getAriaLabel(element: CoverageTreeElement) {
+						if (isFileCoverage(element)) {
+							const name = basenameOrAuthority(element.value!.uri);
+							return localize('testCoverageItemLabel', "{0} coverage: {0}%", name, (element.value!.tpc * 100).toFixed(2));
+						}
+
+						return element.name;
+					},
+					getWidgetAriaLabel() {
+						return localize('testCoverageTreeLabel', "Test Coverage Explorer");
+					}
+				},
+				autoExpandSingleChildren: true,
+				identityProvider: new TestCoverageIdentityProvider(),
+			}
+		);
+
+		this._register(this.tree);
+		this._register(this.tree.onDidOpen(e => {
+			let resource: URI | undefined;
+			if (e.element && isFileCoverage(e.element) && !e.element.children?.size) {
+				resource = e.element.value!.uri;
+			}
+			if (!resource) {
+				return;
+			}
+
+			editorService.openEditor({
+				resource,
+				options: { preserveFocus: e.editorOptions.preserveFocus, pinned: e.editorOptions.pinned, source: EditorOpenSource.USER }
+			}, e.sideBySide ? SIDE_GROUP : ACTIVE_GROUP);
+		}));
+	}
+
+	public setInput(coverage: TestCoverage) {
+		this.tree.setInput(new TestCoverageInput(coverage.getAllFiles()));
+	}
+
+	public layout(height: number, width: number) {
+		this.tree.layout(height, width);
+	}
+}
+
+class TestCoverageDataSource implements IAsyncDataSource<TestCoverageInput, CoverageTreeElement> {
+
+	public hasChildren(element: CoverageTreeElement | TestCoverageInput): boolean {
+		return element instanceof TestCoverageInput || (isFileCoverage(element) && !!element.children?.size);
+	}
+
+	public async getChildren(element: CoverageTreeElement | TestCoverageInput): Promise<Iterable<CoverageTreeElement>> {
+		if (element instanceof TestCoverageInput) {
+			const files = [];
+			for (let node of element.tree.nodes) {
+				// when showing initial children, only show from the first file or tee
+				while (!(node.value instanceof FileCoverage) && node.children?.size === 1) {
+					node = Iterable.first(node.children.values())!;
+				}
+				files.push(node);
+			}
+			return files;
+		}
+
+		if (isFileCoverage(element) && element.children) {
+			return element.children.values();
+		}
+
+		return Iterable.empty();
+	}
+}
+
+class TestCoverageCompressionDelegate implements ITreeCompressionDelegate<CoverageTreeElement> {
+	isIncompressible(element: CoverageTreeElement): boolean {
+		return isFunctionCoverage(element);
+	}
+}
+
+class TestCoverageTreeListDelegate implements IListVirtualDelegate<CoverageTreeElement> {
+	getHeight(element: CoverageTreeElement): number {
+		return 22;
+	}
+
+	getTemplateId(_element: CoverageTreeElement): string {
+		return FileCoverageRenderer.ID;
+	}
+}
+
+interface TemplateData {
+	container: HTMLElement;
+	bars: ManagedTestCoverageBars;
+	templateDisposables: DisposableStore;
+	label: IResourceLabel;
+}
+
+class FileCoverageRenderer implements ICompressibleTreeRenderer<CoverageTreeElement, FuzzyScore, TemplateData> {
+	public static readonly ID = 'F';
+	public readonly templateId = FileCoverageRenderer.ID;
+
+	constructor(
+		private readonly labels: ResourceLabels,
+		@ILabelService private readonly labelService: ILabelService,
+		@IInstantiationService private readonly instantiationService: IInstantiationService,
+	) { }
+
+	/** @inheritdoc */
+	public renderTemplate(container: HTMLElement): TemplateData {
+		const templateDisposables = new DisposableStore();
+		container.classList.add('test-coverage-list-item');
+
+		return {
+			container,
+			bars: templateDisposables.add(this.instantiationService.createInstance(ManagedTestCoverageBars, { compact: false, container })),
+			label: templateDisposables.add(this.labels.create(container, {
+				supportHighlights: true,
+			})),
+			templateDisposables,
+		};
+	}
+
+	/** @inheritdoc */
+	public renderElement(node: ITreeNode<CoverageTreeElement, FuzzyScore>, _index: number, templateData: TemplateData): void {
+		this.doRender(node.element as TestCoverageFileNode, templateData, node.filterData);
+	}
+
+	/** @inheritdoc */
+	public renderCompressedElements(node: ITreeNode<ICompressedTreeNode<CoverageTreeElement>, FuzzyScore>, _index: number, templateData: TemplateData): void {
+		const chain = node.element.elements;
+		const lastElement = chain[chain.length - 1];
+		this.doRender(lastElement as TestCoverageFileNode, templateData, node.filterData);
+	}
+
+	public disposeTemplate(templateData: TemplateData) {
+		templateData.templateDisposables.dispose();
+	}
+
+	/** @inheritdoc */
+	private doRender(element: TestCoverageFileNode, templateData: TemplateData, filterData: FuzzyScore | undefined) {
+		const file = element.value!;
+
+		templateData.bars.setCoverageInfo(file);
+		templateData.label.setFile(file.uri, {
+			fileKind: element.children?.size ? FileKind.FOLDER : FileKind.FILE,
+			matches: createMatches(filterData),
+			separator: this.labelService.getSeparator(file.uri.scheme, file.uri.authority),
+			hidePath: true,
+			extraClasses: ['test-coverage-list-item-label'],
+		});
+	}
+}
+
+class TestCoverageIdentityProvider implements IIdentityProvider<CoverageTreeElement> {
+	public getId(element: CoverageTreeElement) {
+		return isFileCoverage(element) ? element.value!.uri.toString() : element.name;
+	}
+}

--- a/src/vs/workbench/contrib/testing/browser/testing.contribution.ts
+++ b/src/vs/workbench/contrib/testing/browser/testing.contribution.ts
@@ -44,10 +44,13 @@ import { ITestingPeekOpener } from 'vs/workbench/contrib/testing/common/testingP
 import { LifecyclePhase } from 'vs/workbench/services/lifecycle/common/lifecycle';
 import { allTestActions, discoverAndRunTests } from './testExplorerActions';
 import './testingConfigurationUi';
+import { ITestCoverageService, TestCoverageService } from 'vs/workbench/contrib/testing/common/testCoverageService';
+import { TestCoverageView } from 'vs/workbench/contrib/testing/browser/testCoverageView';
 
 registerSingleton(ITestService, TestService, InstantiationType.Delayed);
 registerSingleton(ITestResultStorage, TestResultStorage, InstantiationType.Delayed);
 registerSingleton(ITestProfileService, TestProfileService, InstantiationType.Delayed);
+registerSingleton(ITestCoverageService, TestCoverageService, InstantiationType.Delayed);
 registerSingleton(ITestingContinuousRunService, TestingContinuousRunService, InstantiationType.Delayed);
 registerSingleton(ITestResultService, TestResultService, InstantiationType.Delayed);
 registerSingleton(ITestExplorerFilterState, TestExplorerFilterState, InstantiationType.Delayed);
@@ -112,8 +115,17 @@ viewsRegistry.registerViews([{
 	weight: 80,
 	order: -999,
 	containerIcon: testingViewIcon,
-	// temporary until release, at which point we can show the welcome view:
 	when: ContextKeyExpr.greater(TestingContextKeys.providerCount.key, 0),
+}, {
+	id: Testing.CoverageViewId,
+	name: localize2('testCoverage', "Test Coverage"),
+	ctorDescriptor: new SyncDescriptor(TestCoverageView),
+	canToggleVisibility: true,
+	canMoveView: true,
+	weight: 80,
+	order: -998,
+	containerIcon: testingViewIcon,
+	when: TestingContextKeys.isTestCoverageOpen,
 }], viewContainer);
 
 allTestActions.forEach(registerAction2);

--- a/src/vs/workbench/contrib/testing/browser/testingOutputPeek.ts
+++ b/src/vs/workbench/contrib/testing/browser/testingOutputPeek.ts
@@ -28,6 +28,7 @@ import { KeyCode, KeyMod } from 'vs/base/common/keyCodes';
 import { Lazy } from 'vs/base/common/lazy';
 import { Disposable, DisposableStore, IDisposable, IReference, MutableDisposable, toDisposable } from 'vs/base/common/lifecycle';
 import { MarshalledId } from 'vs/base/common/marshallingIds';
+import { autorun } from 'vs/base/common/observable';
 import { count } from 'vs/base/common/strings';
 import { ThemeIcon } from 'vs/base/common/themables';
 import { isDefined } from 'vs/base/common/types';
@@ -64,6 +65,7 @@ import { KeybindingWeight } from 'vs/platform/keybinding/common/keybindingsRegis
 import { WorkbenchCompressibleObjectTree } from 'vs/platform/list/browser/listService';
 import { INotificationService } from 'vs/platform/notification/common/notification';
 import { IOpenerService } from 'vs/platform/opener/common/opener';
+import { IProgressService } from 'vs/platform/progress/common/progress';
 import { IStorageService, StorageScope, StorageTarget } from 'vs/platform/storage/common/storage';
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 import { TerminalCapability } from 'vs/platform/terminal/common/capabilities/capabilities';
@@ -86,6 +88,7 @@ import { AutoOpenPeekViewWhen, TestingConfigKeys, getTestingConfiguration } from
 import { Testing } from 'vs/workbench/contrib/testing/common/constants';
 import { IObservableValue, MutableObservableValue, staticObservableValue } from 'vs/workbench/contrib/testing/common/observableValue';
 import { StoredValue } from 'vs/workbench/contrib/testing/common/storedValue';
+import { ITestCoverageService } from 'vs/workbench/contrib/testing/common/testCoverageService';
 import { ITestExplorerFilterState } from 'vs/workbench/contrib/testing/common/testExplorerFilterState';
 import { ITestProfileService } from 'vs/workbench/contrib/testing/common/testProfileService';
 import { ITaskRawOutput, ITestResult, ITestRunTaskResults, LiveTestResult, TestResultItemChange, TestResultItemChangeReason, maxCountPriority, resultItemParents } from 'vs/workbench/contrib/testing/common/testResult';
@@ -781,6 +784,7 @@ class TestResultsViewContent extends Disposable {
 		private readonly options: {
 			historyVisible: IObservableValue<boolean>;
 			showRevealLocationOnMessages: boolean;
+			locationForProgress: string;
 		},
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
 		@ITextModelService protected readonly modelService: ITextModelService,
@@ -812,7 +816,7 @@ class TestResultsViewContent extends Disposable {
 			OutputPeekTree,
 			treeContainer,
 			this.didReveal.event,
-			{ showRevealLocationOnMessages }
+			{ showRevealLocationOnMessages, locationForProgress: this.options.locationForProgress },
 		));
 
 		this.onDidRequestReveal = tree.onDidRequestReview;
@@ -963,7 +967,7 @@ class TestResultsPeek extends PeekViewWidget {
 			this.scopedContextKeyService = this._disposables.add(this.contextKeyService.createScoped(container));
 			TestingContextKeys.isInPeek.bindTo(this.scopedContextKeyService).set(true);
 			const instaService = this.instantiationService.createChild(new ServiceCollection([IContextKeyService, this.scopedContextKeyService]));
-			this.content = this._disposables.add(instaService.createInstance(TestResultsViewContent, this.editor, { historyVisible: this.testingPeek.historyVisible, showRevealLocationOnMessages: false }));
+			this.content = this._disposables.add(instaService.createInstance(TestResultsViewContent, this.editor, { historyVisible: this.testingPeek.historyVisible, showRevealLocationOnMessages: false, locationForProgress: Testing.ResultsViewId }));
 		}
 
 		super._fillContainer(container);
@@ -1055,6 +1059,7 @@ export class TestResultsView extends ViewPane {
 	private readonly content = this._register(this.instantiationService.createInstance(TestResultsViewContent, undefined, {
 		historyVisible: staticObservableValue(true),
 		showRevealLocationOnMessages: true,
+		locationForProgress: Testing.ExplorerViewId,
 	}));
 
 	constructor(
@@ -1666,6 +1671,23 @@ class TestResultElement implements ITreeElement {
 	constructor(public readonly value: ITestResult) { }
 }
 
+const coverageLabel = localize('openTestCoverage', 'View Test Coverage');
+
+class CoverageElement implements ITreeElement {
+	public readonly type = 'coverage';
+	public readonly context: undefined;
+	public readonly id = `coverage-${this.results.id}/${this.task.id}`;
+	public readonly label = coverageLabel;
+	public readonly onDidChange = Event.None;
+	public readonly icon = icons.testingCoverage;
+
+	constructor(
+		private readonly results: ITestResult,
+		public readonly task: ITestRunTaskResults,
+	) { }
+
+}
+
 class TestCaseElement implements ITreeElement {
 	public readonly type = 'test';
 	public readonly context = this.test.item.extId;
@@ -1721,7 +1743,7 @@ class TaskElement implements ITreeElement {
 		return this.results.tasks[this.index].running ? icons.testingStatesToIcons.get(TestResultState.Running) : undefined;
 	}
 
-	constructor(public readonly results: ITestResult, public readonly task: ITestRunTask, public readonly index: number) {
+	constructor(public readonly results: ITestResult, public readonly task: ITestRunTaskResults, public readonly index: number) {
 		this.id = `${results.id}/${index}`;
 		this.task = results.tasks[index];
 		this.context = String(index);
@@ -1788,7 +1810,7 @@ class TestMessageElement implements ITreeElement {
 	}
 }
 
-type TreeElement = TestResultElement | TestCaseElement | TestMessageElement | TaskElement;
+type TreeElement = TestResultElement | TestCaseElement | TestMessageElement | TaskElement | CoverageElement;
 
 class OutputPeekTree extends Disposable {
 	private disposed = false;
@@ -1801,11 +1823,13 @@ class OutputPeekTree extends Disposable {
 	constructor(
 		container: HTMLElement,
 		onDidReveal: Event<{ subject: InspectSubject; preserveFocus: boolean }>,
-		options: { showRevealLocationOnMessages: boolean },
+		options: { showRevealLocationOnMessages: boolean; locationForProgress: string },
 		@IContextMenuService private readonly contextMenuService: IContextMenuService,
 		@ITestResultService results: ITestResultService,
 		@IInstantiationService instantiationService: IInstantiationService,
 		@ITestExplorerFilterState explorerFilter: ITestExplorerFilterState,
+		@ITestCoverageService coverageService: ITestCoverageService,
+		@IProgressService progressService: IProgressService,
 	) {
 		super();
 
@@ -1851,13 +1875,24 @@ class OutputPeekTree extends Disposable {
 
 		const cc = new CreationCache<TreeElement>();
 		const getTaskChildren = (taskElem: TaskElement): Iterable<ICompressedTreeElement<TreeElement>> => {
-			const tests = Iterable.filter(taskElem.results.tests, test => test.tasks[taskElem.index].state >= TestResultState.Running || test.tasks[taskElem.index].messages.length > 0);
-
-			return Iterable.map(tests, test => ({
-				element: taskElem.itemsCache.getOrCreate(test, () => new TestCaseElement(taskElem.results, taskElem.task, test, taskElem.index)),
+			const { results, index, itemsCache, task } = taskElem;
+			const tests = Iterable.filter(results.tests, test => test.tasks[index].state >= TestResultState.Running || test.tasks[index].messages.length > 0);
+			let result: Iterable<ICompressedTreeElement<TreeElement>> = Iterable.map(tests, test => ({
+				element: itemsCache.getOrCreate(test, () => new TestCaseElement(results, task, test, index)),
 				incompressible: true,
-				children: getTestChildren(taskElem.results, test, taskElem.index),
+				children: getTestChildren(results, test, index),
 			}));
+
+			if (task.coverage.get()) {
+				result = Iterable.concat(
+					Iterable.single<ICompressedTreeElement<TreeElement>>({
+						element: new CoverageElement(results, task),
+					}),
+					result,
+				);
+			}
+
+			return result;
 		};
 
 		const getTestChildren = (result: ITestResult, test: TestResultItem, taskIndex: number): Iterable<ICompressedTreeElement<TreeElement>> => {
@@ -1903,10 +1938,17 @@ class OutputPeekTree extends Disposable {
 			taskChildrenToUpdate.clear();
 		}, 300));
 
+		const queueTaskChildrenUpdate = (taskNode: TaskElement) => {
+			taskChildrenToUpdate.add(taskNode);
+			if (!taskChildrenUpdate.isScheduled()) {
+				taskChildrenUpdate.schedule();
+			}
+		};
+
 		const attachToResults = (result: LiveTestResult) => {
 			const resultNode = cc.get(result)! as TestResultElement;
 			const disposable = new DisposableStore();
-			disposable.add(result.onNewTask(() => {
+			disposable.add(result.onNewTask(i => {
 				if (result.tasks.length === 1) {
 					this.requestReveal.fire(new TaskSubject(result, 0)); // reveal the first task in new runs
 				}
@@ -1914,6 +1956,14 @@ class OutputPeekTree extends Disposable {
 				if (this.tree.hasElement(resultNode)) {
 					this.tree.setChildren(resultNode, getResultChildren(result), { diffIdentityProvider });
 				}
+
+				// note: tasks are bounded and their lifetime is equivalent to that of
+				// the test result, so this doesn't leak indefinitely.
+				const task = result.tasks[i];
+				disposable.add(autorun(reader => {
+					task.coverage.read(reader); // add it to the autorun
+					queueTaskChildrenUpdate(cc.get(task) as TaskElement);
+				}));
 			}));
 			disposable.add(result.onEndTask(index => {
 				(cc.get(result.tasks[index]) as TaskElement | undefined)?.changeEmitter.fire();
@@ -1935,10 +1985,7 @@ class OutputPeekTree extends Disposable {
 						return;
 					}
 
-					taskChildrenToUpdate.add(taskNode);
-					if (!taskChildrenUpdate.isScheduled()) {
-						taskChildrenUpdate.schedule();
-					}
+					queueTaskChildrenUpdate(taskNode);
 				}
 			}));
 
@@ -2027,6 +2074,12 @@ class OutputPeekTree extends Disposable {
 		this._register(this.tree.onDidOpen(async e => {
 			if (e.element instanceof TestMessageElement) {
 				this.requestReveal.fire(new MessageSubject(e.element.result, e.element.test, e.element.taskIndex, e.element.messageIndex));
+			} else if (e.element instanceof CoverageElement) {
+				const task = e.element.task;
+				progressService.withProgress(
+					{ location: options.locationForProgress },
+					() => coverageService.openCoverage(task, true)
+				);
 			}
 		}));
 

--- a/src/vs/workbench/contrib/testing/common/configuration.ts
+++ b/src/vs/workbench/contrib/testing/common/configuration.ts
@@ -19,6 +19,7 @@ export const enum TestingConfigKeys {
 	AlwaysRevealTestOnStateChange = 'testing.alwaysRevealTestOnStateChange',
 	CountBadge = 'testing.countBadge',
 	ShowAllMessages = 'testing.showAllMessages',
+	CoveragePercent = 'testing.displayedCoveragePercent',
 }
 
 export const enum AutoOpenTesting {
@@ -45,6 +46,12 @@ export const enum TestingCountBadge {
 	Off = 'off',
 	Passed = 'passed',
 	Skipped = 'skipped',
+}
+
+export const enum TestingDisplayedCoveragePercent {
+	TotalCoverage = 'totalCoverage',
+	Statement = 'statement',
+	Minimum = 'minimum',
 }
 
 export const testingConfiguration: IConfigurationNode = {
@@ -149,6 +156,20 @@ export const testingConfiguration: IConfigurationNode = {
 			type: 'boolean',
 			default: false,
 		},
+		[TestingConfigKeys.CoveragePercent]: {
+			markdownDescription: localize('testing.displayedCoveragePercent', "Configures what percentage is displayed by default for test coverage."),
+			default: TestingDisplayedCoveragePercent.TotalCoverage,
+			enum: [
+				TestingDisplayedCoveragePercent.TotalCoverage,
+				TestingDisplayedCoveragePercent.Statement,
+				TestingDisplayedCoveragePercent.Minimum,
+			],
+			enumDescriptions: [
+				localize('testing.displayedCoveragePercent.totalCoverage', 'A calculate of the combined statement, function, and branch coverage.'),
+				localize('testing.displayedCoveragePercent.statement', 'The statement coverage.'),
+				localize('testing.displayedCoveragePercent.minimum', 'The minimum of statement, function, and branch coverage.'),
+			],
+		},
 	}
 };
 
@@ -164,6 +185,7 @@ export interface ITestingConfiguration {
 	[TestingConfigKeys.OpenTesting]: AutoOpenTesting;
 	[TestingConfigKeys.AlwaysRevealTestOnStateChange]: boolean;
 	[TestingConfigKeys.ShowAllMessages]: boolean;
+	[TestingConfigKeys.CoveragePercent]: TestingDisplayedCoveragePercent;
 }
 
 export const getTestingConfiguration = <K extends TestingConfigKeys>(config: IConfigurationService, key: K) => config.getValue<ITestingConfiguration[K]>(key);

--- a/src/vs/workbench/contrib/testing/common/configuration.ts
+++ b/src/vs/workbench/contrib/testing/common/configuration.ts
@@ -165,7 +165,7 @@ export const testingConfiguration: IConfigurationNode = {
 				TestingDisplayedCoveragePercent.Minimum,
 			],
 			enumDescriptions: [
-				localize('testing.displayedCoveragePercent.totalCoverage', 'A calculate of the combined statement, function, and branch coverage.'),
+				localize('testing.displayedCoveragePercent.totalCoverage', 'A calculation of the combined statement, function, and branch coverage.'),
 				localize('testing.displayedCoveragePercent.statement', 'The statement coverage.'),
 				localize('testing.displayedCoveragePercent.minimum', 'The minimum of statement, function, and branch coverage.'),
 			],

--- a/src/vs/workbench/contrib/testing/common/constants.ts
+++ b/src/vs/workbench/contrib/testing/common/constants.ts
@@ -13,6 +13,7 @@ export const enum Testing {
 	ExplorerViewId = 'workbench.view.testing',
 	OutputPeekContributionId = 'editor.contrib.testingOutputPeek',
 	DecorationsContributionId = 'editor.contrib.testingDecorations',
+	CoverageViewId = 'workbench.view.testCoverage',
 
 	ResultsPanelId = 'workbench.panel.testResults',
 	ResultsViewId = 'workbench.panel.testResults.view',

--- a/src/vs/workbench/contrib/testing/common/testCoverageService.ts
+++ b/src/vs/workbench/contrib/testing/common/testCoverageService.ts
@@ -1,0 +1,87 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { CancellationTokenSource } from 'vs/base/common/cancellation';
+import { Disposable, MutableDisposable } from 'vs/base/common/lifecycle';
+import { IObservable, observableValue } from 'vs/base/common/observable';
+import { localize } from 'vs/nls';
+import { IContextKey, IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
+import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
+import { INotificationService } from 'vs/platform/notification/common/notification';
+import { IViewsService } from 'vs/workbench/common/views';
+import { Testing } from 'vs/workbench/contrib/testing/common/constants';
+import { TestCoverage } from 'vs/workbench/contrib/testing/common/testCoverage';
+import { ITestRunTaskResults } from 'vs/workbench/contrib/testing/common/testResult';
+import { TestingContextKeys } from 'vs/workbench/contrib/testing/common/testingContextKeys';
+
+export const ITestCoverageService = createDecorator<ITestCoverageService>('testCoverageService');
+
+export interface ITestCoverageService {
+	readonly _serviceBrand: undefined;
+
+	/**
+	 * Settable observable that can be used to show the test coverage instance
+	 * currently in the editor.
+	 */
+	readonly selected: IObservable<TestCoverage | undefined>;
+
+	/**
+	 * Opens a test coverage report from a task, optionally focusing it in the editor.
+	 */
+	openCoverage(task: ITestRunTaskResults, focus?: boolean): Promise<void>;
+
+	/**
+	 * Closes any open coverage.
+	 */
+	closeCoverage(): void;
+}
+
+export class TestCoverageService extends Disposable implements ITestCoverageService {
+	declare readonly _serviceBrand: undefined;
+	private readonly _isOpenKey: IContextKey<boolean>;
+	private readonly lastOpenCts = this._register(new MutableDisposable<CancellationTokenSource>());
+
+	public readonly selected = observableValue<TestCoverage | undefined>('testCoverage', undefined);
+
+	constructor(
+		@IContextKeyService contextKeyService: IContextKeyService,
+		@IViewsService private readonly viewsService: IViewsService,
+		@INotificationService private readonly notificationService: INotificationService,
+	) {
+		super();
+		this._isOpenKey = TestingContextKeys.isTestCoverageOpen.bindTo(contextKeyService);
+	}
+
+	/** @inheritdoc */
+	public async openCoverage(task: ITestRunTaskResults, focus = true) {
+		this.lastOpenCts.value?.cancel();
+		const cts = this.lastOpenCts.value = new CancellationTokenSource();
+		const getCoverage = task.coverage.get();
+		if (!getCoverage) {
+			return;
+		}
+
+		try {
+			const coverage = await getCoverage(cts.token);
+			this.selected.set(coverage, undefined);
+			this._isOpenKey.set(true);
+		} catch (e) {
+			if (!cts.token.isCancellationRequested) {
+				this.notificationService.error(localize('testCoverageError', 'Failed to load test coverage: {}', String(e)));
+			}
+			return;
+		}
+
+		if (focus && !cts.token.isCancellationRequested) {
+			this.viewsService.openView(Testing.CoverageViewId, true);
+		}
+	}
+
+	/** @inheritdoc */
+	public closeCoverage() {
+		this._isOpenKey.set(false);
+		this.selected.set(undefined, undefined);
+	}
+}

--- a/src/vs/workbench/contrib/testing/common/testingContextKeys.ts
+++ b/src/vs/workbench/contrib/testing/common/testingContextKeys.ts
@@ -21,6 +21,7 @@ export namespace TestingContextKeys {
 	export const supportsContinuousRun = new RawContextKey('testing.supportsContinuousRun', false, { type: 'boolean', description: localize('testing.supportsContinuousRun', 'Indicates whether continous test running is supported') });
 	export const isParentRunningContinuously = new RawContextKey('testing.isParentRunningContinuously', false, { type: 'boolean', description: localize('testing.isParentRunningContinuously', 'Indicates whether the parent of a test is continuously running, set in the menu context of test items') });
 	export const activeEditorHasTests = new RawContextKey('testing.activeEditorHasTests', false, { type: 'boolean', description: localize('testing.activeEditorHasTests', 'Indicates whether any tests are present in the current editor') });
+	export const isTestCoverageOpen = new RawContextKey('testing.isTestCoverageOpen', false, { type: 'boolean', description: localize('testing.isTestCoverageOpen', 'Indicates whether a test coverage report is open') });
 
 	export const capabilityToContextKey: { [K in TestRunProfileBitset]: RawContextKey<boolean> } = {
 		[TestRunProfileBitset.Run]: hasRunnableTests,

--- a/src/vscode-dts/vscode.proposed.testCoverage.d.ts
+++ b/src/vscode-dts/vscode.proposed.testCoverage.d.ts
@@ -176,6 +176,11 @@ declare module 'vscode' {
 	 */
 	export class FunctionCoverage {
 		/**
+		 * Name of the function or method.
+		 */
+		name: string;
+
+		/**
 		 * The number of times this function was executed. If zero, the
 		 * function will be marked as un-covered.
 		 */
@@ -190,7 +195,7 @@ declare module 'vscode' {
 		 * @param executionCount The number of times this function was executed.
 		 * @param location The function position.
 		 */
-		constructor(executionCount: number, location: Position | Range);
+		constructor(name: string, executionCount: number, location: Position | Range);
 	}
 
 	export type DetailedCoverage = StatementCoverage | FunctionCoverage;


### PR DESCRIPTION
This continues on the coverage API I started a few years ago. It adds initial integration where a "Show Test Coverage" tree item is shown in the Test Results view, which then opens a dedicated Test Coverage view. The Test Coverage view is a fairly basic tree view following the draft design, with further improvements to come.

The 'bars' widget is also built in a reusable way such that it can be integrated into the explorer, as this was a popular ask both inside and outside the team.

For #123713.

<img width="383" alt="image" src="https://github.com/microsoft/vscode/assets/2230985/b9e08225-ea41-4c44-a803-42b1e6c2f1fd">

<img width="405" alt="image" src="https://github.com/microsoft/vscode/assets/2230985/6f8f3114-469e-4fb6-aa46-764bc119444d">
