### PR TITLE
Fix reference to worker session

### DIFF
--- a/extensions/typescript-language-features/web/src/webServer.ts
+++ b/extensions/typescript-language-features/web/src/webServer.ts
@@ -2,7 +2,6 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-/// <reference lib='webworker.importscripts' />
 /// <reference lib='webworker' />
 
 import ts from 'typescript/lib/tsserverlibrary';
@@ -12,13 +11,9 @@ import { Logger, parseLogLevel } from './logging';
 import { PathMapper } from './pathMapper';
 import { createSys } from './serverHost';
 import { findArgument, findArgumentStringArray, hasArgument, parseServerMode } from './util/args';
-import { StartSessionOptions, createWorkerSession } from './workerSession';
+import { StartSessionOptions, startWorkerSession } from './workerSession';
 
 const setSys: (s: ts.System) => void = (ts as any).setSys;
-
-// GLOBALS
-let session: WorkerSession | undefined;
-// END GLOBALS
 
 async function initializeSession(
 	args: readonly string[],
@@ -46,8 +41,7 @@ async function initializeSession(
 		removeEventListener('message', listener);
 	});
 	setSys(sys);
-	session = createWorkerSession(ts, sys, fs, sessionOptions, ports.tsserver, pathMapper, logger);
-	session.listen();
+	startWorkerSession(ts, sys, fs, sessionOptions, ports.tsserver, pathMapper, logger);
 }
 
 function parseSessionOptions(args: readonly string[], serverMode: ts.LanguageServiceMode | undefined): StartSessionOptions {

--- a/extensions/typescript-language-features/web/src/workerSession.ts
+++ b/extensions/typescript-language-features/web/src/workerSession.ts
@@ -22,7 +22,7 @@ export interface StartSessionOptions {
 	readonly disableAutomaticTypingAcquisition: boolean;
 }
 
-export function createWorkerSession(
+export function startWorkerSession(
 	ts: typeof import('typescript/lib/tsserverlibrary'),
 	host: ts.server.ServerHost,
 	fs: FileSystem | undefined,
@@ -30,10 +30,10 @@ export function createWorkerSession(
 	port: MessagePort,
 	pathMapper: PathMapper,
 	logger: Logger,
-) {
+): void {
 	const indent: (str: string) => string = (ts as any).server.indent;
 
-	return new class WorkerSession extends ts.server.Session<{}> {
+	const worker = new class WorkerSession extends ts.server.Session<{}> {
 
 		private readonly wasmCancellationToken: WasmCancellationToken;
 		private readonly listener: (message: any) => void;
@@ -121,4 +121,6 @@ export function createWorkerSession(
 			port.onmessage = this.listener;
 		}
 	}();
+
+	worker.listen();
 }


### PR DESCRIPTION
Also removes use of global which doesn't seem to be required (message listener should ensure the object isn't disposed of)