### PR TITLE
Fire an input event on `editor.action.clipboardPasteAction`

### DIFF
--- a/src/vs/workbench/browser/actions/textInputActions.ts
+++ b/src/vs/workbench/browser/actions/textInputActions.ts
@@ -64,6 +64,7 @@ export class TextInputActionsProvider extends Disposable implements IWorkbenchCo
 						element.value = `${element.value.substring(0, selectionStart)}${clipboardText}${element.value.substring(selectionEnd, element.value.length)}`;
 						element.selectionStart = selectionStart + clipboardText.length;
 						element.selectionEnd = element.selectionStart;
+						element.dispatchEvent(new Event('input'));
 					}
 				}
 			}),

--- a/src/vs/workbench/browser/actions/textInputActions.ts
+++ b/src/vs/workbench/browser/actions/textInputActions.ts
@@ -64,7 +64,7 @@ export class TextInputActionsProvider extends Disposable implements IWorkbenchCo
 						element.value = `${element.value.substring(0, selectionStart)}${clipboardText}${element.value.substring(selectionEnd, element.value.length)}`;
 						element.selectionStart = selectionStart + clipboardText.length;
 						element.selectionEnd = element.selectionStart;
-						element.dispatchEvent(new Event('input'));
+						element.dispatchEvent(new Event('input', { bubbles: true, cancelable: true }));
 					}
 				}
 			}),

--- a/src/vs/workbench/browser/actions/textInputActions.ts
+++ b/src/vs/workbench/browser/actions/textInputActions.ts
@@ -15,7 +15,7 @@ import { LifecyclePhase } from 'vs/workbench/services/lifecycle/common/lifecycle
 import { isNative } from 'vs/base/common/platform';
 import { IClipboardService } from 'vs/platform/clipboard/common/clipboardService';
 import { StandardMouseEvent } from 'vs/base/browser/mouseEvent';
-import { Event } from 'vs/base/common/event';
+import { Event as BaseEvent } from 'vs/base/common/event';
 
 export class TextInputActionsProvider extends Disposable implements IWorkbenchContribution {
 
@@ -78,7 +78,7 @@ export class TextInputActionsProvider extends Disposable implements IWorkbenchCo
 	private registerListeners(): void {
 
 		// Context menu support in input/textarea
-		this._register(Event.runAndSubscribe(this.layoutService.onDidAddContainer, ({ container, disposables }) => {
+		this._register(BaseEvent.runAndSubscribe(this.layoutService.onDidAddContainer, ({ container, disposables }) => {
 			disposables.add(addDisposableListener(container, 'contextmenu', e => this.onContextMenu(getWindow(container), e)));
 		}, { container: this.layoutService.mainContainer, disposables: this._store }));
 	}


### PR DESCRIPTION
This fixes #186998

In VS Code web, when `editor.action.clipboardPasteAction` is triggered (eg by right clicking on an input and selecting paste) it updates the value by setting `element.value = ...`. However, this does not trigger the oninput handler which a the QuickInputs use to detect changes. As such right click and paste does not update the input causing #186998.

This can be fixed by updating the paste action to dispatch an input event on the element.