### PR TITLE
fix #198865

### DIFF
--- a/src/vs/base/browser/ui/tree/media/tree.css
+++ b/src/vs/base/browser/ui/tree/media/tree.css
@@ -136,6 +136,9 @@
 	width: 100%;
 	height: 0;
 	z-index: 13; /* Settings editor uses z-index: 12 */
+
+	/* TODO@benibenj temporary solution, all lists should provide their background */
+	background-color: var(--vscode-sideBar-background);
 }
 
 .monaco-list .monaco-scrollable-element .monaco-tree-sticky-container .monaco-tree-sticky-row.monaco-list-row{
@@ -143,6 +146,9 @@
 	width: 100%;
 	opacity: 1 !important; /* Settings editor uses opacity < 1 */
 	overflow: hidden;
+
+	/* TODO@benibenj temporary solution, all lists should provide their background */
+	background-color: var(--vscode-sideBar-background);
 }
 
 .monaco-list .monaco-scrollable-element .monaco-tree-sticky-container .monaco-tree-sticky-row:hover{


### PR DESCRIPTION
This PR adds a temporary background color to monaco-list and monaco-tree-sticky-row. This is a temporary solution until all lists provide their background. The changes are made in the CSS file to ensure the background color matches with the vscode-sideBar-background. fix #198865