### PR TITLE
Updated Title Toolbar Zoom Condition 

### DIFF
--- a/src/vs/workbench/browser/parts/titlebar/titlebarPart.ts
+++ b/src/vs/workbench/browser/parts/titlebar/titlebarPart.ts
@@ -726,9 +726,9 @@ export class BrowserTitlebarPart extends Part implements ITitlebarPart {
 
 		const noMenubar = this.currentMenubarVisibility === 'hidden' || (!isWeb && isMacintosh);
 		const noCommandCenter = !this.isCommandCenterVisible;
-		const noLayoutControls = !this.layoutControlEnabled;
+		const noToolBarActions = !this.layoutControlEnabled && !this.editorActionsEnabled && !this.activityActionsEnabled;
 
-		return zoomFactor < 1 || (noMenubar && noCommandCenter && noLayoutControls);
+		return zoomFactor < 1 || (noMenubar && noCommandCenter && noToolBarActions);
 	}
 
 	override layout(width: number, height: number): void {


### PR DESCRIPTION
The condition for toolbar visibility in BrowserTitlebarPart has been updated. Previously, the visibility was determined by the layout control alone. Now, it also takes into account the state of editor actions and activity actions. This change ensures that the toolbar visibility accurately reflects the current state of these actions.
Fix: #198956