### PR TITLE
Fix advanced line wrap if decorations are present

### DIFF
--- a/src/vs/editor/browser/widget/diffEditor/components/diffEditorViewZones/diffEditorViewZones.ts
+++ b/src/vs/editor/browser/widget/diffEditor/components/diffEditorViewZones/diffEditorViewZones.ts
@@ -176,7 +176,7 @@ export class DiffEditorViewZones extends Disposable {
 							if (i > originalModel.getLineCount()) {
 								return { orig: origViewZones, mod: modViewZones };
 							}
-							deletedCodeLineBreaksComputer?.addRequest(originalModel.getLineContent(i), null, null);
+							deletedCodeLineBreaksComputer?.addRequest(originalModel.getLineContent(i), null, null, null);
 						}
 					}
 				}

--- a/src/vs/editor/common/model.ts
+++ b/src/vs/editor/common/model.ts
@@ -1150,6 +1150,12 @@ export interface ITextModel {
 	getAllMarginDecorations(ownerId?: number): IModelDecoration[];
 
 	/**
+	 * Gets all decorations that apply to text.
+	 * @param ownerId If set, it will ignore decorations belonging to other owners.
+	 */
+	getAllTextDecorations(ownerId?: number): IModelDecoration[];
+
+	/**
 	 * Gets all the decorations that should be rendered in the overview ruler as an array.
 	 * @param ownerId If set, it will ignore decorations belonging to other owners.
 	 * @param filterOutValidation If set, it will ignore decorations specific to validation (i.e. warnings, errors).

--- a/src/vs/editor/common/modelLineProjectionData.ts
+++ b/src/vs/editor/common/modelLineProjectionData.ts
@@ -8,7 +8,7 @@ import { WrappingIndent } from './config/editorOptions.js';
 import { FontInfo } from './config/fontInfo.js';
 import { Position } from './core/position.js';
 import { InjectedTextCursorStops, InjectedTextOptions, PositionAffinity } from './model.js';
-import { LineInjectedText } from './textModelEvents.js';
+import { InlineClassName, LineInjectedText } from './textModelEvents.js';
 
 /**
  * *input*:
@@ -336,6 +336,6 @@ export interface ILineBreaksComputer {
 	/**
 	 * Pass in `previousLineBreakData` if the only difference is in breaking columns!!!
 	 */
-	addRequest(lineText: string, injectedText: LineInjectedText[] | null, previousLineBreakData: ModelLineProjectionData | null): void;
+	addRequest(lineText: string, injectedText: LineInjectedText[] | null, inlineClassName: InlineClassName[] | null, previousLineBreakData: ModelLineProjectionData | null): void;
 	finalize(): (ModelLineProjectionData | null)[];
 }

--- a/src/vs/editor/common/viewModel/monospaceLineBreaksComputer.ts
+++ b/src/vs/editor/common/viewModel/monospaceLineBreaksComputer.ts
@@ -8,7 +8,7 @@ import * as strings from '../../../base/common/strings.js';
 import { WrappingIndent, IComputedEditorOptions, EditorOption } from '../config/editorOptions.js';
 import { CharacterClassifier } from '../core/characterClassifier.js';
 import { FontInfo } from '../config/fontInfo.js';
-import { LineInjectedText } from '../textModelEvents.js';
+import { InlineClassName, LineInjectedText } from '../textModelEvents.js';
 import { InjectedTextOptions } from '../model.js';
 import { ILineBreaksComputerFactory, ILineBreaksComputer, ModelLineProjectionData } from '../modelLineProjectionData.js';
 
@@ -31,7 +31,7 @@ export class MonospaceLineBreaksComputerFactory implements ILineBreaksComputerFa
 		const injectedTexts: (LineInjectedText[] | null)[] = [];
 		const previousBreakingData: (ModelLineProjectionData | null)[] = [];
 		return {
-			addRequest: (lineText: string, injectedText: LineInjectedText[] | null, previousLineBreakData: ModelLineProjectionData | null) => {
+			addRequest: (lineText: string, injectedText: LineInjectedText[] | null, inlineClassNames: InlineClassName[] | null, previousLineBreakData: ModelLineProjectionData | null) => {
 				requests.push(lineText);
 				injectedTexts.push(injectedText);
 				previousBreakingData.push(previousLineBreakData);

--- a/src/vs/editor/common/viewModel/viewModelImpl.ts
+++ b/src/vs/editor/common/viewModel/viewModelImpl.ts
@@ -329,7 +329,11 @@ export class ViewModel extends Disposable implements IViewModel {
 								if (injectedText) {
 									injectedText = injectedText.filter(element => (!element.ownerId || element.ownerId === this._editorId));
 								}
-								lineBreaksComputer.addRequest(line, injectedText, null);
+								let inlineClassNames = change.inlineClassNames[lineIdx];
+								if (inlineClassNames) {
+									inlineClassNames = inlineClassNames.filter(element => (!element.ownerId || element.ownerId === this._editorId));
+								}
+								lineBreaksComputer.addRequest(line, injectedText, inlineClassNames, null);
 							}
 							break;
 						}
@@ -338,7 +342,12 @@ export class ViewModel extends Disposable implements IViewModel {
 							if (change.injectedText) {
 								injectedText = change.injectedText.filter(element => (!element.ownerId || element.ownerId === this._editorId));
 							}
-							lineBreaksComputer.addRequest(change.detail, injectedText, null);
+
+							let inlineClassNames: textModelEvents.InlineClassName[] | null = null;
+							if (change.inlineClassNames) {
+								inlineClassNames = change.inlineClassNames.filter(element => (!element.ownerId || element.ownerId === this._editorId));
+							}
+							lineBreaksComputer.addRequest(change.detail, injectedText, inlineClassNames, null);
 							break;
 						}
 					}

--- a/src/vs/editor/common/viewModel/viewModelLines.ts
+++ b/src/vs/editor/common/viewModel/viewModelLines.ts
@@ -12,7 +12,7 @@ import { Range } from '../core/range.js';
 import { IModelDecoration, IModelDeltaDecoration, ITextModel, PositionAffinity } from '../model.js';
 import { IActiveIndentGuideInfo, BracketGuideOptions, IndentGuide, IndentGuideHorizontalLine } from '../textModelGuides.js';
 import { ModelDecorationOptions } from '../model/textModel.js';
-import { LineInjectedText } from '../textModelEvents.js';
+import { InlineClassName, LineInjectedText, lineMetaFromDecorations } from '../textModelEvents.js';
 import * as viewEvents from '../viewEvents.js';
 import { createModelLineProjection, IModelLineProjection } from './modelLineProjection.js';
 import { ILineBreaksComputer, ModelLineProjectionData, InjectedText, ILineBreaksComputerFactory } from '../modelLineProjectionData.js';
@@ -128,14 +128,22 @@ export class ViewModelLinesFromProjectedModel implements IViewModelLines {
 		}
 
 		const linesContent = this.model.getLinesContent();
-		const injectedTextDecorations = this.model.getInjectedTextDecorations(this._editorId);
+		const injectedTextDecorations = this.model.getAllTextDecorations(this._editorId);
 		const lineCount = linesContent.length;
 		const lineBreaksComputer = this.createLineBreaksComputer();
 
-		const injectedTextQueue = new arrays.ArrayQueue(LineInjectedText.fromDecorations(injectedTextDecorations));
+		const { inlineClassNames, lineInjectedTexts } = lineMetaFromDecorations(injectedTextDecorations, this.model);
+		const injectedTextQueue = new arrays.ArrayQueue(lineInjectedTexts);
+		const inlineClassNameQueue = new arrays.ArrayQueue(inlineClassNames);
 		for (let i = 0; i < lineCount; i++) {
 			const lineInjectedText = injectedTextQueue.takeWhile(t => t.lineNumber === i + 1);
-			lineBreaksComputer.addRequest(linesContent[i], lineInjectedText, previousLineBreaks ? previousLineBreaks[i] : null);
+			const inlineClassName = inlineClassNameQueue.takeWhile(t => t.lineNumber === i + 1);
+			lineBreaksComputer.addRequest(
+				linesContent[i],
+				lineInjectedText,
+				inlineClassName,
+				previousLineBreaks ? previousLineBreaks[i] : null
+			);
 		}
 		const linesBreaks = lineBreaksComputer.finalize();
 
@@ -1146,7 +1154,7 @@ export class ViewModelLinesFromModelAsIs implements IViewModelLines {
 	public createLineBreaksComputer(): ILineBreaksComputer {
 		const result: null[] = [];
 		return {
-			addRequest: (lineText: string, injectedText: LineInjectedText[] | null, previousLineBreakData: ModelLineProjectionData | null) => {
+			addRequest: (lineText: string, injectedText: LineInjectedText[] | null, inlineClassName: InlineClassName[] | null, previousLineBreakData: ModelLineProjectionData | null) => {
 				result.push(null);
 			},
 			finalize: () => {

--- a/src/vs/editor/standalone/browser/standaloneEditor.ts
+++ b/src/vs/editor/standalone/browser/standaloneEditor.ts
@@ -26,6 +26,7 @@ import { NullState, nullTokenize } from '../../common/languages/nullTokenize.js'
 import { FindMatch, ITextModel, TextModelResolvedOptions } from '../../common/model.js';
 import { IModelService } from '../../common/services/model.js';
 import * as standaloneEnums from '../../common/standalone/standaloneEnums.js';
+import { lineMetaFromDecorations } from '../../common/textModelEvents.js';
 import { Colorizer, IColorizerElementOptions, IColorizerOptions } from './colorizer.js';
 import { IActionDescriptor, IStandaloneCodeEditor, IStandaloneDiffEditor, IStandaloneDiffEditorConstructionOptions, IStandaloneEditorConstructionOptions, StandaloneDiffEditor2, StandaloneEditor, createTextModel } from './standaloneCodeEditor.js';
 import { IEditorOverrideServices, StandaloneKeybindingService, StandaloneServices } from './standaloneServices.js';
@@ -567,6 +568,8 @@ export function createMonacoEditorAPI(): typeof monaco.editor {
 		registerLinkOpener: registerLinkOpener,
 		// eslint-disable-next-line local/code-no-any-casts
 		registerEditorOpener: <any>registerEditorOpener,
+
+		lineMetaFromDecorations: <any>lineMetaFromDecorations,
 
 		// enums
 		AccessibilitySupport: standaloneEnums.AccessibilitySupport,

--- a/src/vs/editor/test/common/model/model.test.ts
+++ b/src/vs/editor/test/common/model/model.test.ts
@@ -117,7 +117,7 @@ suite('Editor Model - Model', () => {
 		thisModel.applyEdits([EditOperation.insert(new Position(1, 1), 'foo ')]);
 		assert.deepStrictEqual(e, new ModelRawContentChangedEvent(
 			[
-				new ModelRawLineChanged(1, 'foo My First Line', null)
+				new ModelRawLineChanged(1, 'foo My First Line', null, null)
 			],
 			2,
 			false,
@@ -137,8 +137,8 @@ suite('Editor Model - Model', () => {
 		thisModel.applyEdits([EditOperation.insert(new Position(1, 3), ' new line\nNo longer')]);
 		assert.deepStrictEqual(e, new ModelRawContentChangedEvent(
 			[
-				new ModelRawLineChanged(1, 'My new line', null),
-				new ModelRawLinesInserted(2, 2, ['No longer First Line'], [null]),
+				new ModelRawLineChanged(1, 'My new line', null, null),
+				new ModelRawLinesInserted(2, 2, ['No longer First Line'], [null], [null]),
 			],
 			2,
 			false,
@@ -216,7 +216,7 @@ suite('Editor Model - Model', () => {
 		thisModel.applyEdits([EditOperation.delete(new Range(1, 1, 1, 2))]);
 		assert.deepStrictEqual(e, new ModelRawContentChangedEvent(
 			[
-				new ModelRawLineChanged(1, 'y First Line', null),
+				new ModelRawLineChanged(1, 'y First Line', null, null),
 			],
 			2,
 			false,
@@ -236,7 +236,7 @@ suite('Editor Model - Model', () => {
 		thisModel.applyEdits([EditOperation.delete(new Range(1, 1, 1, 14))]);
 		assert.deepStrictEqual(e, new ModelRawContentChangedEvent(
 			[
-				new ModelRawLineChanged(1, '', null),
+				new ModelRawLineChanged(1, '', null, null),
 			],
 			2,
 			false,
@@ -256,7 +256,7 @@ suite('Editor Model - Model', () => {
 		thisModel.applyEdits([EditOperation.delete(new Range(1, 4, 2, 6))]);
 		assert.deepStrictEqual(e, new ModelRawContentChangedEvent(
 			[
-				new ModelRawLineChanged(1, 'My Second Line', null),
+				new ModelRawLineChanged(1, 'My Second Line', null, null),
 				new ModelRawLinesDeleted(2, 2),
 			],
 			2,
@@ -277,7 +277,7 @@ suite('Editor Model - Model', () => {
 		thisModel.applyEdits([EditOperation.delete(new Range(1, 4, 3, 5))]);
 		assert.deepStrictEqual(e, new ModelRawContentChangedEvent(
 			[
-				new ModelRawLineChanged(1, 'My Third Line', null),
+				new ModelRawLineChanged(1, 'My Third Line', null, null),
 				new ModelRawLinesDeleted(2, 3),
 			],
 			2,

--- a/src/vs/editor/test/common/viewModel/monospaceLineBreaksComputer.test.ts
+++ b/src/vs/editor/test/common/viewModel/monospaceLineBreaksComputer.test.ts
@@ -65,7 +65,7 @@ function getLineBreakData(factory: ILineBreaksComputerFactory, tabSize: number, 
 	}, false);
 	const lineBreaksComputer = factory.createLineBreaksComputer(fontInfo, tabSize, breakAfter, wrappingIndent, wordBreak, wrapOnEscapedLineFeeds);
 	const previousLineBreakDataClone = previousLineBreakData ? new ModelLineProjectionData(null, null, previousLineBreakData.breakOffsets.slice(0), previousLineBreakData.breakOffsetsVisibleColumn.slice(0), previousLineBreakData.wrappedTextIndentLength) : null;
-	lineBreaksComputer.addRequest(text, null, previousLineBreakDataClone);
+	lineBreaksComputer.addRequest(text, null, null, previousLineBreakDataClone);
 	return lineBreaksComputer.finalize()[0];
 }
 

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -2303,6 +2303,11 @@ declare namespace monaco.editor {
 		 */
 		getAllMarginDecorations(ownerId?: number): IModelDecoration[];
 		/**
+		 * Gets all decorations that apply to text.
+		 * @param ownerId If set, it will ignore decorations belonging to other owners.
+		 */
+		getAllTextDecorations(ownerId?: number): IModelDecoration[];
+		/**
 		 * Gets all the decorations that should be rendered in the overview ruler as an array.
 		 * @param ownerId If set, it will ignore decorations belonging to other owners.
 		 * @param filterOutValidation If set, it will ignore decorations specific to validation (i.e. warnings, errors).
@@ -3068,6 +3073,11 @@ declare namespace monaco.editor {
 		 */
 		readonly text: string;
 	}
+
+	export function lineMetaFromDecorations(decorations: IModelDecoration[]): {
+		inlineClassNames: any;
+		lineInjectedTexts: any;
+	};
 
 	/**
 	 * Describes the reason the cursor has changed its position.


### PR DESCRIPTION
Decorations may affect line wrapping. For example, they make make the text bold, or increase or decrease font size. This wasn’t originally taken into account to calculate the the break offsets.

This was discovered as part of #194609, but it’s actually unrelated. This not only affects line breaking if decorations make text bigger, but also if they make it smaller, bolder, etc.

Fixes #295163