### PR TITLE
Improve dependency injection

### DIFF
--- a/src/vs/platform/instantiation/common/instantiationService.ts
+++ b/src/vs/platform/instantiation/common/instantiationService.ts
@@ -195,8 +195,10 @@ export class InstantiationService implements IInstantiationService {
 
 				if (instanceOrDesc instanceof SyncDescriptor) {
 					const d = { id: dependency.id, desc: instanceOrDesc, _trace: item._trace.branch(dependency.id, true) };
+					if (!graph.lookup(d)) {
+						stack.push(d);
+					}
 					graph.insertEdge(item, d);
-					stack.push(d);
 				}
 			}
 		}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

In some circumstances with a lot of services inter-dependencies, the `UNABLE to detect cycle, dumping graph` can be triggered because the loop limit is reached. The problem seems to be that the same service is processed multiple times.

It can happen when overriding services in monaco-editor.


