### PR TITLE
Load data urls with fetch instead of using file service

### DIFF
--- a/src/vs/platform/extensionResourceLoader/browser/extensionResourceLoaderService.ts
+++ b/src/vs/platform/extensionResourceLoader/browser/extensionResourceLoaderService.ts
@@ -32,7 +32,7 @@ class ExtensionResourceLoaderService extends AbstractExtensionResourceLoaderServ
 	async readExtensionResource(uri: URI): Promise<string> {
 		uri = FileAccess.uriToBrowserUri(uri);
 
-		if (uri.scheme !== Schemas.http && uri.scheme !== Schemas.https) {
+		if (uri.scheme !== Schemas.http && uri.scheme !== Schemas.https && uri.scheme !== Schemas.data) {
 			const result = await this._fileService.readFile(uri);
 			return result.value.toString();
 		}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Do not try to load data uris using file service

I don't think it has any impact on VSCode itself as I don't think it's possible to have data urls for extension resources but it can't hurt either

I need it because I use that service with monaco-editor and the bundler can decide to use data urls for extension resources