### PR TITLE
snap: Use native wayland client when possible

### DIFF
--- a/resources/linux/snap/electron-launch
+++ b/resources/linux/snap/electron-launch
@@ -140,9 +140,7 @@ append_dir LOCPATH "$SNAP/usr/lib/locale"
 
 # If detect wayland server socket, then set environment so applications prefer
 # wayland, and setup compat symlink (until we use user mounts. Remember,
-# XDG_RUNTIME_DIR is /run/user/<uid>/snap.$SNAP so look in the parent directory
-# for the socket. For details:
-# https://forum.snapcraft.io/t/wayland-dconf-and-xdg-runtime-dir/186/10
+# XDG_RUNTIME_DIR is /run/user/<uid> for classic snaps.
 # Applications that don't support wayland natively may define DISABLE_WAYLAND
 # (to any non-empty value) to skip that logic entirely.
 wayland_available=false
@@ -151,17 +149,12 @@ if [[ -n "$XDG_RUNTIME_DIR" && -z "$DISABLE_WAYLAND" ]]; then
     if [ -n "$WAYLAND_DISPLAY" ]; then
         wdisplay="$WAYLAND_DISPLAY"
     fi
-    wayland_sockpath="$XDG_RUNTIME_DIR/../$wdisplay"
     wayland_snappath="$XDG_RUNTIME_DIR/$wdisplay"
-    if [ -S "$wayland_sockpath" ]; then
+    if [ -S "$wayland_snappath" ]; then
         # if running under wayland, use it
         #export WAYLAND_DEBUG=1
         # shellcheck disable=SC2034
         wayland_available=true
-        # create the compat symlink for now
-        if [ ! -e "$wayland_snappath" ]; then
-            ln -s "$wayland_sockpath" "$wayland_snappath"
-        fi
     fi
 fi
 

--- a/resources/linux/snap/electron-launch
+++ b/resources/linux/snap/electron-launch
@@ -154,7 +154,8 @@ append_dir LOCPATH "$SNAP/usr/lib/locale"
 # Applications that don't support wayland natively may define DISABLE_WAYLAND
 # (to any non-empty value) to skip that logic entirely.
 wayland_available=false
-if [[ -n "$XDG_RUNTIME_DIR" && -z "$DISABLE_WAYLAND" ]]; then
+if [[ -n "$XDG_RUNTIME_DIR" && -z "$DISABLE_WAYLAND" ]] && \
+   [[ "$(snapctl get wayland-native)" == "true" ]]; then
     wdisplay="wayland-0"
     if [ -n "$WAYLAND_DISPLAY" ]; then
         wdisplay="$WAYLAND_DISPLAY"

--- a/resources/linux/snap/electron-launch
+++ b/resources/linux/snap/electron-launch
@@ -106,6 +106,7 @@ copy_env_variable GDK_BACKEND
 copy_env_variable GTK_PATH
 copy_env_variable GTK_EXE_PREFIX
 copy_env_variable GTK_IM_MODULE_FILE
+copy_env_variable LIBGL_DRIVERS_PATH
 
 # XDG Config
 prepend_dir XDG_CONFIG_DIRS "$SNAP/etc/xdg"
@@ -123,6 +124,11 @@ ensure_dir_exists "$XDG_DATA_HOME"
 # Workaround for GLib < 2.53.2 not searching for schemas in $XDG_DATA_HOME:
 #   https://bugzilla.gnome.org/show_bug.cgi?id=741335
 prepend_dir XDG_DATA_DIRS "$XDG_DATA_HOME"
+
+# Use the snap MESA drivers to launch the snap.
+# This is required by wayland, but electron will make better use under X11 too
+prepend_dir LIBGL_DRIVERS_PATH "$SNAP/usr/lib/dri"
+prepend_dir LIBGL_DRIVERS_PATH "$SNAP/usr/lib/$ARCH/dri"
 
 # Set cache folder to local path
 if [[ -d "$SNAP_USER_DATA/.cache" && ! -e "$SNAP_USER_COMMON/.cache" ]]; then

--- a/resources/linux/snap/electron-launch
+++ b/resources/linux/snap/electron-launch
@@ -67,6 +67,10 @@ fi
 # Set $REALHOME to the users real home directory
 REALHOME=$(getent passwd $UID | cut -d ':' -f 6)
 
+
+# Extra launch arguments
+declare -a launch_args
+
 # Set config folder to local path
 ensure_dir_exists "$SNAP_USER_DATA/.config"
 chmod 700 "$SNAP_USER_DATA/.config"
@@ -248,6 +252,7 @@ fi
 # shellcheck disable=SC2154
 if [ "$wayland_available" = true ]; then
   export GDK_BACKEND="wayland"
+  launch_args+=(--enable-native-wayland-client)
 fi
 
 append_dir GTK_PATH "$SNAP/usr/lib/$ARCH/gtk-3.0"
@@ -275,4 +280,8 @@ fi
 
 wait_for_async_execs
 
-exec "$@"
+
+binary="$1"
+shift
+
+exec "$binary" "${launch_args[@]}" "$@"

--- a/resources/linux/snap/snap/hooks/configure
+++ b/resources/linux/snap/snap/hooks/configure
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -eu
+
+wayland_native="$(snapctl get wayland-native)"
+if [[ -z "$wayland_native" ]]; then
+    snapctl set wayland-native=false
+fi

--- a/resources/linux/snap/snapcraft.yaml
+++ b/resources/linux/snap/snapcraft.yaml
@@ -19,6 +19,8 @@ parts:
   code:
     plugin: dump
     source: .
+    build-packages:
+      - patchelf
     stage-packages:
       - ca-certificates
       - libasound2

--- a/resources/linux/snap/snapcraft.yaml
+++ b/resources/linux/snap/snapcraft.yaml
@@ -51,8 +51,11 @@ parts:
       - libxss1
       - locales-all
       - packagekit-gtk3-module
+      - gnome-settings-daemon-common
       - xdg-utils
     prime:
+      - -lib/udev
+      - -usr/lib/systemd
       - -usr/share/doc
       - -usr/share/fonts
       - -usr/share/icons

--- a/resources/linux/snap/snapcraft.yaml
+++ b/resources/linux/snap/snapcraft.yaml
@@ -41,6 +41,7 @@ parts:
       - libnss3
       - libpango-1.0-0
       - libsecret-1-0
+      - libvulkan1
       - libwayland-egl1
       - libxcomposite1
       - libxdamage1
@@ -61,6 +62,9 @@ parts:
       - -usr/share/icons
       - -usr/share/lintian
       - -usr/share/man
+      - -usr/share/@@NAME@@/libEGL.so*
+      - -usr/share/@@NAME@@/libGLESv2.so*
+      - -usr/share/@@NAME@@/libvulkan.so*
     override-build: |
       snapcraftctl build
       patchelf --force-rpath --set-rpath '$ORIGIN/../../lib/x86_64-linux-gnu:$ORIGIN:/snap/core20/current/lib/x86_64-linux-gnu' $SNAPCRAFT_PART_INSTALL/usr/share/@@NAME@@/chrome_crashpad_handler

--- a/src/main.ts
+++ b/src/main.ts
@@ -56,6 +56,14 @@ if (args['sandbox'] &&
 	app.commandLine.appendSwitch('disable-gpu-sandbox');
 }
 
+if (process.platform === 'linux') {
+	if (args['enable-native-wayland-client'] ||
+		argvConfig['enable-native-wayland-client']) {
+		app.commandLine.appendSwitch('ozone-platform-hint', 'auto');
+		app.commandLine.appendSwitch('enable-features', 'WaylandWindowDecorations');
+	}
+}
+
 // Set userData path before app 'ready' event
 const userDataPath = getUserDataPath(args, product.nameShort ?? 'code-oss-dev');
 if (process.platform === 'win32') {
@@ -564,7 +572,9 @@ function parseCLIArgs(): NativeParsedArgs {
 		],
 		boolean: [
 			'disable-chromium-sandbox',
-		],
+		] + process.platform === 'linux' ? [
+			'enable-native-wayland-client',
+		] : [],
 		default: {
 			'sandbox': true
 		},

--- a/src/vs/platform/environment/common/argv.ts
+++ b/src/vs/platform/environment/common/argv.ts
@@ -125,6 +125,7 @@ export interface NativeParsedArgs {
 	'unresponsive-sample-interval'?: string;
 	'unresponsive-sample-period'?: string;
 	'enable-rdp-display-tracking'?: boolean;
+	'enable-native-wayland-client'?: boolean;
 
 	// chromium command line args: https://electronjs.org/docs/all#supported-chrome-command-line-switches
 	'no-proxy-server'?: boolean;

--- a/src/vs/platform/environment/node/argv.ts
+++ b/src/vs/platform/environment/node/argv.ts
@@ -129,6 +129,7 @@ export const OPTIONS: OptionDescriptions<Required<NativeParsedArgs>> = {
 	'sandbox': { type: 'boolean' },
 	'locate-shell-integration-path': { type: 'string', cat: 't', args: ['shell'], description: localize('locateShellIntegrationPath', "Print the path to a terminal shell integration script. Allowed values are 'bash', 'pwsh', 'zsh' or 'fish'.") },
 	'telemetry': { type: 'boolean', cat: 't', description: localize('telemetry', "Shows all telemetry events which VS code collects.") },
+	'enable-native-wayland-client': { type: 'boolean', cat: 't', description: localize('enableNativeWaylandClient', "Uses native wayland client support when running on Linux. This argument is ignored on Windows & macOS.") },
 
 	'remote': { type: 'string', allowEmptyValue: true },
 	'folder-uri': { type: 'string[]', cat: 'o', args: 'uri' },

--- a/src/vs/workbench/electron-sandbox/desktop.contribution.ts
+++ b/src/vs/workbench/electron-sandbox/desktop.contribution.ts
@@ -444,6 +444,10 @@ import { registerWorkbenchContribution2, WorkbenchPhase } from '../common/contri
 			type: 'string',
 			description: localize('argv.passwordStore', "Configures the backend used to store secrets on Linux. This argument is ignored on Windows & macOS.")
 		};
+		schema.properties!['enable-native-wayland-client'] = {
+			type: 'boolean',
+			description: localize('argv.enableNativeWaylandClient', "Uses native wayland client support when running on Linux. This argument is ignored on Windows & macOS.")
+		};
 	}
 	if (isWindows) {
 		schema.properties!['enable-rdp-display-tracking'] = {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
Electron supports wayland natively since version 12, but when running code from the snap it's not possible to use because of some issues.

Handle them here so that a native client can be used when in wayland (unless `DISABLE_WAYLAND` env variable is used), making code to have proper rendering in HiDPI screens.

This behavior can be reverted using `snap set code wayland-native=false`.

Before:
![Schermata del 2023-11-24 18-24-39](https://github.com/microsoft/vscode/assets/345675/49150d6b-b252-4914-a4d9-81ee1eb05330)

After:
![Schermata del 2023-11-24 18-25-24](https://github.com/microsoft/vscode/assets/345675/10f30002-1fb7-4139-b35f-5c45cb330ae4)
