### PR TITLE
Don't dispose the CancellationTokenSource until all onCancellationRequested handlers have run

### DIFF
--- a/src/vs/base/common/async.ts
+++ b/src/vs/base/common/async.ts
@@ -28,7 +28,6 @@ export function createCancelablePromise<T>(callback: (token: CancellationToken) 
 	const promise = new Promise<T>((resolve, reject) => {
 		const subscription = source.token.onCancellationRequested(() => {
 			subscription.dispose();
-			source.dispose();
 			reject(new CancellationError());
 		});
 		Promise.resolve(thenable).then(value => {
@@ -45,6 +44,7 @@ export function createCancelablePromise<T>(callback: (token: CancellationToken) 
 	return <CancelablePromise<T>>new class {
 		cancel() {
 			source.cancel();
+			source.dispose();
 		}
 		then<TResult1 = T, TResult2 = never>(resolve?: ((value: T) => TResult1 | Promise<TResult1>) | undefined | null, reject?: ((reason: any) => TResult2 | Promise<TResult2>) | undefined | null): Promise<TResult1 | TResult2> {
 			return promise.then(resolve, reject);


### PR DESCRIPTION
Fix https://github.com/microsoft/vscode/issues/199068

The CancelablePromise disposes its CancellationTokenSource inside a onCancellationRequested listener. That means that any other onCancellationRequested listeners that were added after that one won't be called, because the EventEmitter has been disposed. In practice that means that any listener that was added after an async step inside the callback function is not called.