### PR TITLE
allow variables in the color-theme definition file for workbench color

### DIFF
--- a/src/vs/platform/theme/common/colorRegistry.ts
+++ b/src/vs/platform/theme/common/colorRegistry.ts
@@ -167,13 +167,13 @@ class ColorRegistry implements IColorRegistry {
 		if (needsTransparency) {
 			propertySchemaForSetting.pattern = '^#(?:(?<rgba>[0-9a-fA-f]{3}[0-9a-eA-E])|(?:[0-9a-fA-F]{6}(?:(?![fF]{2})(?:[0-9a-fA-F]{2}))))?$';
 			propertySchemaForSetting.patternErrorMessage = 'This color must be transparent or it will obscure content';
-			if (propertySchemaForTheme.anyOf) {
-				propertySchemaForTheme.anyOf[1] = {
-					...propertySchemaForTheme.anyOf[1],
-					pattern: '^#(?:(?<rgba>[0-9a-fA-f]{3}[0-9a-eA-E])|(?:[0-9a-fA-F]{6}(?:(?![fF]{2})(?:[0-9a-fA-F]{2}))))?$',
-					patternErrorMessage: 'This color must be transparent or it will obscure content'
-				};
-			}
+
+			propertySchemaForTheme.anyOf![1] = {
+				...propertySchemaForTheme.anyOf![1],
+				pattern: '^#(?:(?<rgba>[0-9a-fA-f]{3}[0-9a-eA-E])|(?:[0-9a-fA-F]{6}(?:(?![fF]{2})(?:[0-9a-fA-F]{2}))))?$',
+				patternErrorMessage: 'This color must be transparent or it will obscure content'
+			};
+
 		}
 
 		this.colorReferenceSchema.enum.push(id);

--- a/src/vs/platform/theme/common/colorRegistry.ts
+++ b/src/vs/platform/theme/common/colorRegistry.ts
@@ -94,7 +94,7 @@ export interface IColorRegistry {
 	registerColor(id: string, defaults: ColorDefaults, description: string, needsTransparency?: boolean): ColorIdentifier;
 
 	/**
-	 * Deregister a color from the registry.
+	 * Register a color to the registry.
 	 */
 	deregisterColor(id: string): void;
 

--- a/src/vs/platform/theme/common/colorRegistry.ts
+++ b/src/vs/platform/theme/common/colorRegistry.ts
@@ -109,9 +109,14 @@ export interface IColorRegistry {
 	resolveDefaultColor(id: ColorIdentifier, theme: IColorTheme): Color | undefined;
 
 	/**
-	 * JSON schema for an object to assign color values to one of the color contributions.
+	 * JSON schema for an object to assign color values to one of the color contributions used in settings.
 	 */
 	getColorSchemaForSetting(): IJSONSchema;
+
+	/**
+	 * JSON schema for an object to assign color values to one of the color contributions used in themes (allow accent variables).
+	 */
+	getColorSchemaForTheme(): IJSONSchema;
 
 	/**
 	 * JSON schema to for a reference to a color contribution.

--- a/src/vs/platform/theme/common/colorRegistry.ts
+++ b/src/vs/platform/theme/common/colorRegistry.ts
@@ -94,7 +94,7 @@ export interface IColorRegistry {
 	registerColor(id: string, defaults: ColorDefaults, description: string, needsTransparency?: boolean): ColorIdentifier;
 
 	/**
-	 * Register a color to the registry.
+	 * Deregister a color from the registry.
 	 */
 	deregisterColor(id: string): void;
 

--- a/src/vs/platform/theme/common/tokenClassificationRegistry.ts
+++ b/src/vs/platform/theme/common/tokenClassificationRegistry.ts
@@ -358,7 +358,7 @@ class TokenClassificationRegistry implements ITokenClassificationRegistry {
 		this.tokenStylingSchemaForTheme.patternProperties = {
 			[selectorPattern]: getStylingSchemaEntryForTheme()
 		};
-		this.tokenStylingSchemaForTheme.definitions!.settings.properties!.foreground = {
+		this.tokenStylingSchemaForTheme.definitions!.style.properties!.foreground = {
 			anyOf: [
 				{
 					type: 'string',
@@ -366,10 +366,10 @@ class TokenClassificationRegistry implements ITokenClassificationRegistry {
 					pattern: '^\\$\\w+',
 					patternErrorMessage: nls.localize('error.invalidFormat.colorEntryWithPalette', "Color must either in hex format (e.g. `#ffffff`) or one of the palette (e.g. `$accentName`)")
 				},
-				this.tokenStylingSchemaForSetting.definitions!.settings.properties!.foreground
+				this.tokenStylingSchemaForSetting.definitions!.style.properties!.foreground
 			]
 		};
-		this.tokenStylingSchemaForTheme.definitions!.settings.defaultSnippets!.unshift({ body: { foreground: '\$${1:accentName}', fontStyle: '${2:bold}' } });
+		this.tokenStylingSchemaForTheme.definitions!.style.defaultSnippets!.unshift({ body: { foreground: '\$${1:accentName}', fontStyle: '${2:bold}' } });
 		this.tokenTypeById = Object.create(null);
 		this.tokenModifierById = Object.create(null);
 		this.typeHierarchy = Object.create(null);

--- a/src/vs/workbench/services/preferences/common/preferencesValidation.ts
+++ b/src/vs/workbench/services/preferences/common/preferencesValidation.ts
@@ -112,7 +112,7 @@ function valueValidatesAsType(value: any, type: string): boolean {
 	return true;
 }
 
-function getStringValidators(prop: IConfigurationPropertySchema) {
+function getStringValidators(prop: IConfigurationPropertySchema): Validator<string>[] {
 	const uriRegex = /^(([^:/?#]+?):)?(\/\/([^/?#]*))?([^?#]*)(\?([^#]*))?(#(.*))?/;
 	let patternRegex: RegExp | undefined;
 	if (typeof prop.pattern === 'string') {
@@ -137,7 +137,7 @@ function getStringValidators(prop: IConfigurationPropertySchema) {
 		},
 		{
 			enabled: prop.format === 'color-hex',
-			isValid: ((value: string) => Color.Format.CSS.parseHex(value)),
+			isValid: ((value: string) => !!Color.Format.CSS.parseHex(value)),
 			message: nls.localize('validations.colorFormat', "Invalid color format. Use #RGB, #RGBA, #RRGGBB or #RRGGBBAA.")
 		},
 		{

--- a/src/vs/workbench/services/preferences/common/preferencesValidation.ts
+++ b/src/vs/workbench/services/preferences/common/preferencesValidation.ts
@@ -112,7 +112,7 @@ function valueValidatesAsType(value: any, type: string): boolean {
 	return true;
 }
 
-function getStringValidators(prop: IConfigurationPropertySchema): Validator<string>[] {
+function getStringValidators(prop: IConfigurationPropertySchema) {
 	const uriRegex = /^(([^:/?#]+?):)?(\/\/([^/?#]*))?([^?#]*)(\?([^#]*))?(#(.*))?/;
 	let patternRegex: RegExp | undefined;
 	if (typeof prop.pattern === 'string') {
@@ -137,7 +137,7 @@ function getStringValidators(prop: IConfigurationPropertySchema): Validator<stri
 		},
 		{
 			enabled: prop.format === 'color-hex',
-			isValid: ((value: string) => !!Color.Format.CSS.parseHex(value)),
+			isValid: ((value: string) => Color.Format.CSS.parseHex(value)),
 			message: nls.localize('validations.colorFormat', "Invalid color format. Use #RGB, #RGBA, #RRGGBB or #RRGGBBAA.")
 		},
 		{

--- a/src/vs/workbench/services/themes/common/colorThemeData.ts
+++ b/src/vs/workbench/services/themes/common/colorThemeData.ts
@@ -764,7 +764,7 @@ function _parseColor(colorValue: string | null, colorPalette: { [key: string]: s
 			return hex;
 		}
 	}
-	return null;
+	return '#f00'; //default to red to make it easily detectable
 }
 
 function _loadSyntaxTokens(extensionResourceLoaderService: IExtensionResourceLoaderService, themeLocation: URI, result: { textMateRules: ITextMateThemingRule[]; colors: IColorMap }): Promise<any> {

--- a/src/vs/workbench/services/themes/common/colorThemeData.ts
+++ b/src/vs/workbench/services/themes/common/colorThemeData.ts
@@ -709,6 +709,9 @@ async function _loadColorTheme(extensionResourceLoaderService: IExtensionResourc
 			return null;
 		}
 		result.semanticHighlighting = result.semanticHighlighting || contentValue.semanticHighlighting;
+
+		const colorPalette = contentValue.colorPalette;
+
 		const colors = contentValue.colors;
 		if (colors) {
 			if (typeof colors !== 'object') {
@@ -716,9 +719,9 @@ async function _loadColorTheme(extensionResourceLoaderService: IExtensionResourc
 			}
 			// new JSON color themes format
 			for (const colorId in colors) {
-				const colorHex = colors[colorId];
-				if (typeof colorHex === 'string') { // ignore colors tht are null
-					result.colors[colorId] = Color.fromHex(colors[colorId]);
+				const parsedColor = _parseColor(colors[colorId], colorPalette);
+				if (typeof parsedColor === 'string') { // ignore colors that are null
+					result.colors[colorId] = Color.fromHex(parsedColor);
 				}
 			}
 		}
@@ -748,6 +751,25 @@ async function _loadColorTheme(extensionResourceLoaderService: IExtensionResourc
 	} else {
 		return _loadSyntaxTokens(extensionResourceLoaderService, themeLocation, result);
 	}
+}
+
+function _parseColor(colorValue: string | null, colorPalette: { [key: string]: string } | undefined): string | null {
+	if (!colorValue) {
+		return null;
+	}
+
+	if (colorValue.startsWith('#')) {
+		return colorValue;
+	}
+
+	if (colorPalette && colorValue.startsWith('$')) {
+		const hex = colorPalette[colorValue];
+		if (hex) {
+			return hex;
+		}
+	}
+
+	return null;
 }
 
 function _loadSyntaxTokens(extensionResourceLoaderService: IExtensionResourceLoaderService, themeLocation: URI, result: { textMateRules: ITextMateThemingRule[]; colors: IColorMap }): Promise<any> {

--- a/src/vs/workbench/services/themes/common/colorThemeData.ts
+++ b/src/vs/workbench/services/themes/common/colorThemeData.ts
@@ -730,7 +730,7 @@ async function _loadColorTheme(extensionResourceLoaderService: IExtensionResourc
 					const parsedTokenColor = _parseTokenColor(tokenColor, colorPalette); return parsedTokenColor;
 				});
 				result.textMateRules.push(...parsedTokenColors);
-			} else if (typeof tokenColors === 'string') { //link to textMate file
+			} else if (typeof tokenColors === 'string') { //link to a tmTheme file
 				await _loadSyntaxTokens(extensionResourceLoaderService, resources.joinPath(resources.dirname(themeLocation), tokenColors), result);
 			} else {
 				return Promise.reject(new Error(nls.localize({ key: 'error.invalidformat.tokenColors', comment: ['{0} will be replaced by a path. Values in quotes should not be translated.'] }, "Problem parsing color theme file: {0}. Property 'tokenColors' should be either an array specifying colors or a path to a TextMate theme file", themeLocation.toString())));

--- a/src/vs/workbench/services/themes/common/colorThemeData.ts
+++ b/src/vs/workbench/services/themes/common/colorThemeData.ts
@@ -24,8 +24,6 @@ import { CharCode } from 'vs/base/common/charCode';
 import { StorageScope, IStorageService, StorageTarget } from 'vs/platform/storage/common/storage';
 import { ThemeConfiguration } from 'vs/workbench/services/themes/common/themeConfiguration';
 import { ColorScheme } from 'vs/platform/theme/common/theme';
-import { Extensions as JSONExtensions, IJSONContributionRegistry } from 'vs/platform/jsonschemas/common/jsonContributionRegistry';
-import { themePaletteEnumSchemaId } from 'vs/workbench/services/themes/common/colorThemeSchema';
 
 const colorRegistry = Registry.as<IColorRegistry>(ColorRegistryExtensions.ColorContribution);
 
@@ -712,8 +710,6 @@ async function _loadColorTheme(extensionResourceLoaderService: IExtensionResourc
 		}
 		result.semanticHighlighting = result.semanticHighlighting || contentValue.semanticHighlighting;
 		const colorPalette = contentValue.colorPalette;
-		const schemaRegistry = Registry.as<IJSONContributionRegistry>(JSONExtensions.JSONContribution);
-		schemaRegistry.registerSchema(themePaletteEnumSchemaId, { enum: Object.keys(colorPalette || {}) });
 		const colors = contentValue.colors;
 		if (colors) {
 			if (typeof colors !== 'object') {

--- a/src/vs/workbench/services/themes/common/colorThemeData.ts
+++ b/src/vs/workbench/services/themes/common/colorThemeData.ts
@@ -727,7 +727,7 @@ async function _loadColorTheme(extensionResourceLoaderService: IExtensionResourc
 		if (tokenColors) {
 			if (Array.isArray(tokenColors)) {
 				result.textMateRules.push(...tokenColors);
-			} else if (typeof tokenColors === 'string') {
+			} else if (typeof tokenColors === 'string') { //link to textMate file
 				await _loadSyntaxTokens(extensionResourceLoaderService, resources.joinPath(resources.dirname(themeLocation), tokenColors), result);
 			} else {
 				return Promise.reject(new Error(nls.localize({ key: 'error.invalidformat.tokenColors', comment: ['{0} will be replaced by a path. Values in quotes should not be translated.'] }, "Problem parsing color theme file: {0}. Property 'tokenColors' should be either an array specifying colors or a path to a TextMate theme file", themeLocation.toString())));

--- a/src/vs/workbench/services/themes/common/colorThemeData.ts
+++ b/src/vs/workbench/services/themes/common/colorThemeData.ts
@@ -726,7 +726,10 @@ async function _loadColorTheme(extensionResourceLoaderService: IExtensionResourc
 		const tokenColors = contentValue.tokenColors;
 		if (tokenColors) {
 			if (Array.isArray(tokenColors)) {
-				result.textMateRules.push(...tokenColors);
+				const parsedTokenColors = tokenColors.map(tokenColor => {
+					const parsedTokenColor = _parseTokenColor(tokenColor, colorPalette); return parsedTokenColor;
+				});
+				result.textMateRules.push(...parsedTokenColors);
 			} else if (typeof tokenColors === 'string') { //link to textMate file
 				await _loadSyntaxTokens(extensionResourceLoaderService, resources.joinPath(resources.dirname(themeLocation), tokenColors), result);
 			} else {
@@ -765,6 +768,12 @@ function _parseColor(colorValue: string | null, colorPalette: { [key: string]: s
 		}
 	}
 	return '#f00'; //default to red to make it easily detectable
+}
+
+function _parseTokenColor(tokenColor: any, colorPalette: { [key: string]: string }): ITextMateThemingRule {
+	tokenColor.settings.foreground = _parseColor(tokenColor.settings.foreground, colorPalette);
+	tokenColor.settings.background = _parseColor(tokenColor.settings.background, colorPalette);
+	return tokenColor;
 }
 
 function _loadSyntaxTokens(extensionResourceLoaderService: IExtensionResourceLoaderService, themeLocation: URI, result: { textMateRules: ITextMateThemingRule[]; colors: IColorMap }): Promise<any> {

--- a/src/vs/workbench/services/themes/common/colorThemeData.ts
+++ b/src/vs/workbench/services/themes/common/colorThemeData.ts
@@ -24,6 +24,8 @@ import { CharCode } from 'vs/base/common/charCode';
 import { StorageScope, IStorageService, StorageTarget } from 'vs/platform/storage/common/storage';
 import { ThemeConfiguration } from 'vs/workbench/services/themes/common/themeConfiguration';
 import { ColorScheme } from 'vs/platform/theme/common/theme';
+import { Extensions as JSONExtensions, IJSONContributionRegistry } from 'vs/platform/jsonschemas/common/jsonContributionRegistry';
+import { themePaletteEnumSchemaId } from 'vs/workbench/services/themes/common/colorThemeSchema';
 
 const colorRegistry = Registry.as<IColorRegistry>(ColorRegistryExtensions.ColorContribution);
 
@@ -711,7 +713,8 @@ async function _loadColorTheme(extensionResourceLoaderService: IExtensionResourc
 		result.semanticHighlighting = result.semanticHighlighting || contentValue.semanticHighlighting;
 
 		const colorPalette = contentValue.colorPalette;
-
+		const schemaRegistry = Registry.as<IJSONContributionRegistry>(JSONExtensions.JSONContribution);
+		schemaRegistry.registerSchema(themePaletteEnumSchemaId, { enum: Object.keys(colorPalette || {}) });
 		const colors = contentValue.colors;
 		if (colors) {
 			if (typeof colors !== 'object') {

--- a/src/vs/workbench/services/themes/common/colorThemeData.ts
+++ b/src/vs/workbench/services/themes/common/colorThemeData.ts
@@ -740,7 +740,8 @@ async function _loadColorTheme(extensionResourceLoaderService: IExtensionResourc
 		if (semanticTokenColors && typeof semanticTokenColors === 'object') {
 			for (const key in semanticTokenColors) {
 				try {
-					const rule = readSemanticTokenRule(key, semanticTokenColors[key]);
+					const parsedSemanticTokenColor = _parseSemanticTokenColor(semanticTokenColors[key], colorPalette);
+					const rule = readSemanticTokenRule(key, parsedSemanticTokenColor);
 					if (rule) {
 						result.semanticTokenRules.push(rule);
 					}
@@ -774,6 +775,16 @@ function _parseTokenColor(tokenColor: any, colorPalette: { [key: string]: string
 	tokenColor.settings.foreground = _parseColor(tokenColor.settings.foreground, colorPalette);
 	tokenColor.settings.background = _parseColor(tokenColor.settings.background, colorPalette);
 	return tokenColor;
+}
+
+function _parseSemanticTokenColor(semanticTokenColor: any, colorPalette: { [key: string]: string }) {
+	if (typeof semanticTokenColor === 'string') {
+		semanticTokenColor = _parseColor(semanticTokenColor, colorPalette);
+	}
+	else {
+		semanticTokenColor.foreground = _parseColor(semanticTokenColor.foreground, colorPalette);
+	}
+	return semanticTokenColor;
 }
 
 function _loadSyntaxTokens(extensionResourceLoaderService: IExtensionResourceLoaderService, themeLocation: URI, result: { textMateRules: ITextMateThemingRule[]; colors: IColorMap }): Promise<any> {

--- a/src/vs/workbench/services/themes/common/colorThemeData.ts
+++ b/src/vs/workbench/services/themes/common/colorThemeData.ts
@@ -711,7 +711,6 @@ async function _loadColorTheme(extensionResourceLoaderService: IExtensionResourc
 			return null;
 		}
 		result.semanticHighlighting = result.semanticHighlighting || contentValue.semanticHighlighting;
-
 		const colorPalette = contentValue.colorPalette;
 		const schemaRegistry = Registry.as<IJSONContributionRegistry>(JSONExtensions.JSONContribution);
 		schemaRegistry.registerSchema(themePaletteEnumSchemaId, { enum: Object.keys(colorPalette || {}) });
@@ -760,18 +759,15 @@ function _parseColor(colorValue: string | null, colorPalette: { [key: string]: s
 	if (!colorValue) {
 		return null;
 	}
-
 	if (colorValue.startsWith('#')) {
 		return colorValue;
 	}
-
 	if (colorPalette && colorValue.startsWith('$')) {
 		const hex = colorPalette[colorValue];
 		if (hex) {
 			return hex;
 		}
 	}
-
 	return null;
 }
 

--- a/src/vs/workbench/services/themes/common/colorThemeSchema.ts
+++ b/src/vs/workbench/services/themes/common/colorThemeSchema.ts
@@ -230,20 +230,22 @@ function generateColorThemeSchemas() {
 	const originalWorkbenchColorsSchema = schemaRegistry.getSchemaContributions().schemas[workbenchColorsSchemaId];
 
 	const workbenchColorSchemaForTheme = JSON.parse(JSON.stringify(originalWorkbenchColorsSchema));
+	const themePaletteEnumSchema = schemaRegistry.getSchemaContributions().schemas[themePaletteEnumSchemaId];
 
-	for (const key in workbenchColorSchemaForTheme.properties) {
-		const property = workbenchColorSchemaForTheme.properties[key];
+	if (themePaletteEnumSchema?.enum !== undefined && themePaletteEnumSchema.enum.length > 0) {
+		for (const key in workbenchColorSchemaForTheme.properties) {
+			const property = workbenchColorSchemaForTheme.properties[key];
 
-		delete property.format;
+			delete property.format;
 
-		property.anyOf = [
-			{ $ref: themePaletteEnumSchemaId, errorMessage: nls.localize('error.invalidFormat.colorEntryWithPalette', "Color must either in hex format (e.g. `#ffffff`) or one of the palette (e.g. `$accentName`)") },
-			{ format: 'color-hex' },
-			// 	NOTE: the error message include both message for var and hex
-			// 	because when using anyOf, whenever there is error, only the first message will be used });
-		];
+			property.anyOf = [
+				{ $ref: themePaletteEnumSchemaId, errorMessage: nls.localize('error.invalidFormat.colorEntryWithPalette', "Color must either in hex format (e.g. `#ffffff`) or one of the palette (e.g. `$accentName`)") },
+				{ format: 'color-hex' },
+				// 	NOTE: the error message include both message for var and hex
+				// 	because when using anyOf, whenever there is error, only the first message will be used });
+			];
+		}
 	}
-
 	schemaRegistry.registerSchema(workbenchColorsSchemaForThemeId, workbenchColorSchemaForTheme);
 
 	const colorThemeSchema: IJSONSchema = {

--- a/src/vs/workbench/services/themes/common/colorThemeSchema.ts
+++ b/src/vs/workbench/services/themes/common/colorThemeSchema.ts
@@ -248,6 +248,29 @@ const colorThemeSchema: IJSONSchema = {
 			type: 'object',
 			description: nls.localize('schema.semanticTokenColors', 'Colors for semantic tokens'),
 			$ref: tokenStylingSchemaId
+		},
+		colorPalette: {
+			type: 'object',
+			description: nls.localize('schema.colorPalette', 'Color palette for the theme. Property names must start with a $ sign and followed by one or more letters.'),
+			additionalProperties: false,
+			patternProperties: {
+				'^\\$[a-zA-Z]+': {
+					type: 'string',
+					description: nls.localize('schema.colorPalette.color', 'Color in the palette'),
+					format: 'color-hex',
+				}
+			},
+			defaultSnippets: [
+				{
+					label: 'Color palette',
+					body: {
+						'\$${1:accentName1}': '#ffffff',
+						'\$${2:accentName2}': '#ffffff',
+						'\$${3:accentName3}': '#ffffff',
+						'\$${4:accentName4}': '#ffffff',
+					}
+				}
+			]
 		}
 	}
 };

--- a/src/vs/workbench/services/themes/common/colorThemeSchema.ts
+++ b/src/vs/workbench/services/themes/common/colorThemeSchema.ts
@@ -223,19 +223,15 @@ export const workbenchColorsSchemaForThemeId = 'vscode://schemas/workbench-color
 export const themePaletteEnumSchemaId = 'vscode://schemas/theme-palette-enum';
 let colorThemeSchema: IJSONSchema = generateColorThemeSchemas();
 
-
-
 function generateColorThemeSchemas() {
 	const schemaRegistry = Registry.as<IJSONContributionRegistry>(JSONExtensions.JSONContribution);
 	const originalWorkbenchColorsSchema = schemaRegistry.getSchemaContributions().schemas[workbenchColorsSchemaId];
-
 	const workbenchColorSchemaForTheme = JSON.parse(JSON.stringify(originalWorkbenchColorsSchema));
 	const themePaletteEnumSchema = schemaRegistry.getSchemaContributions().schemas[themePaletteEnumSchemaId];
 
 	if (themePaletteEnumSchema?.enum !== undefined && themePaletteEnumSchema.enum.length > 0) {
 		for (const key in workbenchColorSchemaForTheme.properties) {
 			const property = workbenchColorSchemaForTheme.properties[key];
-
 			delete property.format;
 
 			property.anyOf = [
@@ -314,7 +310,6 @@ export function registerColorThemeSchemas() {
 }
 
 const delay = 500;
-
 const delayer = new RunOnceScheduler(() => { colorThemeSchema = generateColorThemeSchemas(); registerColorThemeSchemas(); }, delay);
 const schemaRegistry = Registry.as<IJSONContributionRegistry>(JSONExtensions.JSONContribution);
 schemaRegistry.onDidChangeSchema(uri => {

--- a/src/vs/workbench/services/themes/common/colorThemeSchema.ts
+++ b/src/vs/workbench/services/themes/common/colorThemeSchema.ts
@@ -285,6 +285,7 @@ function generateColorThemeSchemas() {
 						type: 'string',
 						description: nls.localize('schema.colorPalette.color', 'Color in the palette'),
 						format: 'color-hex',
+						defaultSnippets: [{ body: '#${1:ff0000}' }]
 					}
 				},
 				defaultSnippets: [

--- a/src/vs/workbench/services/themes/common/colorThemeSchema.ts
+++ b/src/vs/workbench/services/themes/common/colorThemeSchema.ts
@@ -9,7 +9,7 @@ import { Extensions as JSONExtensions, IJSONContributionRegistry } from 'vs/plat
 import { IJSONSchema } from 'vs/base/common/jsonSchema';
 
 import { workbenchColorsSchemaForThemeId } from 'vs/platform/theme/common/colorRegistry';
-import { tokenStylingSchemaId } from 'vs/platform/theme/common/tokenClassificationRegistry';
+import { tokenStylingSchemaForThemeId } from 'vs/platform/theme/common/tokenClassificationRegistry';
 
 const textMateScopes = [
 	'comment',
@@ -235,6 +235,8 @@ textmateColorSchemaForTheme.definitions!.settings.properties!.foreground = {
 	]
 };
 
+textmateColorSchemaForTheme.definitions!.settings.defaultSnippets!.unshift({ body: { foreground: '\$${1:accentName}', fontStyle: '${2:bold}' } });
+
 export const colorThemeSchemaId = 'vscode://schemas/color-theme';
 
 const colorThemeSchema: IJSONSchema = {
@@ -265,7 +267,7 @@ const colorThemeSchema: IJSONSchema = {
 		semanticTokenColors: {
 			type: 'object',
 			description: nls.localize('schema.semanticTokenColors', 'Colors for semantic tokens'),
-			$ref: tokenStylingSchemaId
+			$ref: tokenStylingSchemaForThemeId
 		},
 		colorPalette: {
 			type: 'object',

--- a/src/vs/workbench/services/themes/common/colorThemeSchema.ts
+++ b/src/vs/workbench/services/themes/common/colorThemeSchema.ts
@@ -114,10 +114,11 @@ const textMateScopes = [
 	'variable.parameter'
 ];
 
-export const textmateColorsSchemaId = 'vscode://schemas/textmate-colors';
-export const textmateColorGroupSchemaId = `${textmateColorsSchemaId}#/definitions/colorGroup`;
+export const textmateColorsSchemaForSettingId = 'vscode://schemas/textmate-colors-settings';
+export const textmateColorGroupSchemaId = `${textmateColorsSchemaForSettingId}#/definitions/colorGroup`;
+//NOTE: textmateColorGroupSchema is only used in setting, not theme, so no need to create separate schema for theme
 
-const textmateColorSchema: IJSONSchema = {
+const textmateColorSchemaForSetting: IJSONSchema = {
 	type: 'array',
 	definitions: {
 		colorGroup: {
@@ -217,6 +218,23 @@ const textmateColorSchema: IJSONSchema = {
 	}
 };
 
+export const textmateColorsSchemaForThemeId = 'vscode://schemas/textmate-colors-theme';
+const textmateColorSchemaForTheme: IJSONSchema = JSON.parse(JSON.stringify(textmateColorSchemaForSetting));
+
+delete textmateColorSchemaForTheme.definitions!.colorGroup; //colorGroup is not used in theme
+
+textmateColorSchemaForTheme.definitions!.settings.properties!.foreground = {
+	anyOf: [
+		{
+			type: 'string',
+			description: nls.localize('schema.token.foreground', 'Foreground color for the token.'),
+			pattern: '^\\$\\w+',
+			patternErrorMessage: nls.localize('error.invalidFormat.colorEntryWithPalette', "Color must either in hex format (e.g. `#ffffff`) or one of the palette (e.g. `$accentName`)")
+		},
+		textmateColorSchemaForSetting.definitions!.settings.properties!.foreground
+	]
+};
+
 export const colorThemeSchemaId = 'vscode://schemas/color-theme';
 
 const colorThemeSchema: IJSONSchema = {
@@ -236,7 +254,7 @@ const colorThemeSchema: IJSONSchema = {
 			},
 			{
 				description: nls.localize('schema.colors', 'Colors for syntax highlighting'),
-				$ref: textmateColorsSchemaId
+				$ref: textmateColorsSchemaForThemeId
 			}
 			]
 		},
@@ -281,5 +299,6 @@ const colorThemeSchema: IJSONSchema = {
 export function registerColorThemeSchemas() {
 	const schemaRegistry = Registry.as<IJSONContributionRegistry>(JSONExtensions.JSONContribution);
 	schemaRegistry.registerSchema(colorThemeSchemaId, colorThemeSchema);
-	schemaRegistry.registerSchema(textmateColorsSchemaId, textmateColorSchema);
+	schemaRegistry.registerSchema(textmateColorsSchemaForSettingId, textmateColorSchemaForSetting);
+	schemaRegistry.registerSchema(textmateColorsSchemaForThemeId, textmateColorSchemaForTheme);
 }

--- a/src/vs/workbench/services/themes/common/colorThemeSchema.ts
+++ b/src/vs/workbench/services/themes/common/colorThemeSchema.ts
@@ -8,9 +8,8 @@ import { Registry } from 'vs/platform/registry/common/platform';
 import { Extensions as JSONExtensions, IJSONContributionRegistry } from 'vs/platform/jsonschemas/common/jsonContributionRegistry';
 import { IJSONSchema } from 'vs/base/common/jsonSchema';
 
-import { workbenchColorsSchemaId } from 'vs/platform/theme/common/colorRegistry';
+import { workbenchColorsSchemaForThemeId } from 'vs/platform/theme/common/colorRegistry';
 import { tokenStylingSchemaId } from 'vs/platform/theme/common/tokenClassificationRegistry';
-import { RunOnceScheduler } from 'vs/base/common/async';
 
 const textMateScopes = [
 	'comment',
@@ -219,101 +218,68 @@ const textmateColorSchema: IJSONSchema = {
 };
 
 export const colorThemeSchemaId = 'vscode://schemas/color-theme';
-export const workbenchColorsSchemaForThemeId = 'vscode://schemas/workbench-color-for-theme';
-export const themePaletteEnumSchemaId = 'vscode://schemas/theme-palette-enum';
-let colorThemeSchema: IJSONSchema = generateColorThemeSchemas();
 
-function generateColorThemeSchemas() {
-	const schemaRegistry = Registry.as<IJSONContributionRegistry>(JSONExtensions.JSONContribution);
-	const originalWorkbenchColorsSchema = schemaRegistry.getSchemaContributions().schemas[workbenchColorsSchemaId];
-	const workbenchColorSchemaForTheme = JSON.parse(JSON.stringify(originalWorkbenchColorsSchema));
-	const themePaletteEnumSchema = schemaRegistry.getSchemaContributions().schemas[themePaletteEnumSchemaId];
-
-	if (themePaletteEnumSchema?.enum !== undefined && themePaletteEnumSchema.enum.length > 0) {
-		for (const key in workbenchColorSchemaForTheme.properties) {
-			const property = workbenchColorSchemaForTheme.properties[key];
-			delete property.format;
-
-			property.anyOf = [
-				{ $ref: themePaletteEnumSchemaId, errorMessage: nls.localize('error.invalidFormat.colorEntryWithPalette', "Color must either in hex format (e.g. `#ffffff`) or one of the palette (e.g. `$accentName`)") },
-				{ format: 'color-hex' },
-				// 	NOTE: the error message include both message for var and hex
-				// 	because when using anyOf, whenever there is error, only the first message will be used });
-			];
+const colorThemeSchema: IJSONSchema = {
+	type: 'object',
+	allowComments: true,
+	allowTrailingCommas: true,
+	properties: {
+		colors: {
+			description: nls.localize('schema.workbenchColors', 'Colors in the workbench'),
+			$ref: workbenchColorsSchemaForThemeId,
+			additionalProperties: false
+		},
+		tokenColors: {
+			anyOf: [{
+				type: 'string',
+				description: nls.localize('schema.tokenColors.path', 'Path to a tmTheme file (relative to the current file).')
+			},
+			{
+				description: nls.localize('schema.colors', 'Colors for syntax highlighting'),
+				$ref: textmateColorsSchemaId
+			}
+			]
+		},
+		semanticHighlighting: {
+			type: 'boolean',
+			description: nls.localize('schema.supportsSemanticHighlighting', 'Whether semantic highlighting should be enabled for this theme.')
+		},
+		semanticTokenColors: {
+			type: 'object',
+			description: nls.localize('schema.semanticTokenColors', 'Colors for semantic tokens'),
+			$ref: tokenStylingSchemaId
+		},
+		colorPalette: {
+			type: 'object',
+			description: nls.localize('schema.colorPalette', 'Color palette for the theme. Property names must start with a $ sign and followed by one or more letters.'),
+			additionalProperties: false,
+			patternProperties: {
+				'^\\$[a-zA-Z]+': {
+					type: 'string',
+					description: nls.localize('schema.colorPalette.color', 'Color in the palette'),
+					format: 'color-hex',
+					defaultSnippets: [{ body: '#${1:ff0000}' }]
+				}
+			},
+			defaultSnippets: [
+				{
+					label: 'Color palette',
+					body: {
+						'\$${1:accentName1}': '#ffffff',
+						'\$${2:accentName2}': '#ffffff',
+						'\$${3:accentName3}': '#ffffff',
+						'\$${4:accentName4}': '#ffffff',
+					}
+				}
+			]
 		}
 	}
-	schemaRegistry.registerSchema(workbenchColorsSchemaForThemeId, workbenchColorSchemaForTheme);
+};
 
-	const colorThemeSchema: IJSONSchema = {
-		type: 'object',
-		allowComments: true,
-		allowTrailingCommas: true,
-		properties: {
-			colors: {
-				description: nls.localize('schema.workbenchColors', 'Colors in the workbench'),
-				$ref: workbenchColorsSchemaForThemeId,
-				additionalProperties: false
-			},
-			tokenColors: {
-				anyOf: [{
-					type: 'string',
-					description: nls.localize('schema.tokenColors.path', 'Path to a tmTheme file (relative to the current file).')
-				},
-				{
-					description: nls.localize('schema.colors', 'Colors for syntax highlighting'),
-					$ref: textmateColorsSchemaId
-				}
-				]
-			},
-			semanticHighlighting: {
-				type: 'boolean',
-				description: nls.localize('schema.supportsSemanticHighlighting', 'Whether semantic highlighting should be enabled for this theme.')
-			},
-			semanticTokenColors: {
-				type: 'object',
-				description: nls.localize('schema.semanticTokenColors', 'Colors for semantic tokens'),
-				$ref: tokenStylingSchemaId
-			},
-			colorPalette: {
-				type: 'object',
-				description: nls.localize('schema.colorPalette', 'Color palette for the theme. Property names must start with a $ sign and followed by one or more letters.'),
-				additionalProperties: false,
-				patternProperties: {
-					'^\\$[a-zA-Z]+': {
-						type: 'string',
-						description: nls.localize('schema.colorPalette.color', 'Color in the palette'),
-						format: 'color-hex',
-						defaultSnippets: [{ body: '#${1:ff0000}' }]
-					}
-				},
-				defaultSnippets: [
-					{
-						label: 'Color palette',
-						body: {
-							'\$${1:accentName1}': '#ffffff',
-							'\$${2:accentName2}': '#ffffff',
-							'\$${3:accentName3}': '#ffffff',
-							'\$${4:accentName4}': '#ffffff',
-						}
-					}
-				]
-			}
-		}
-	};
-	return colorThemeSchema;
-}
+
 
 export function registerColorThemeSchemas() {
 	const schemaRegistry = Registry.as<IJSONContributionRegistry>(JSONExtensions.JSONContribution);
 	schemaRegistry.registerSchema(colorThemeSchemaId, colorThemeSchema);
 	schemaRegistry.registerSchema(textmateColorsSchemaId, textmateColorSchema);
 }
-
-const delay = 500;
-const delayer = new RunOnceScheduler(() => { colorThemeSchema = generateColorThemeSchemas(); registerColorThemeSchemas(); }, delay);
-const schemaRegistry = Registry.as<IJSONContributionRegistry>(JSONExtensions.JSONContribution);
-schemaRegistry.onDidChangeSchema(uri => {
-	if ((uri === workbenchColorsSchemaId || uri === themePaletteEnumSchemaId) && !delayer.isScheduled()) {
-		delayer.schedule();
-	}
-});

--- a/src/vs/workbench/services/themes/common/themeConfiguration.ts
+++ b/src/vs/workbench/services/themes/common/themeConfiguration.ts
@@ -9,7 +9,7 @@ import { Registry } from 'vs/platform/registry/common/platform';
 import { IConfigurationRegistry, Extensions as ConfigurationExtensions, IConfigurationPropertySchema, IConfigurationNode, ConfigurationScope } from 'vs/platform/configuration/common/configurationRegistry';
 
 import { IJSONSchema } from 'vs/base/common/jsonSchema';
-import { textmateColorsSchemaId, textmateColorGroupSchemaId } from 'vs/workbench/services/themes/common/colorThemeSchema';
+import { textmateColorsSchemaForSettingId, textmateColorGroupSchemaId } from 'vs/workbench/services/themes/common/colorThemeSchema';
 import { workbenchColorsSchemaForSettingId } from 'vs/platform/theme/common/colorRegistry';
 import { tokenStylingSchemaId } from 'vs/platform/theme/common/tokenClassificationRegistry';
 import { ThemeSettings, IWorkbenchColorTheme, IWorkbenchFileIconTheme, IColorCustomizations, ITokenColorCustomizations, IWorkbenchProductIconTheme, ISemanticTokenColorCustomizations, ThemeSettingTarget, ThemeSettingDefaults } from 'vs/workbench/services/themes/common/workbenchThemeService';
@@ -163,7 +163,7 @@ const tokenColorSchema: IJSONSchema = {
 		variables: tokenGroupSettings(nls.localize('editorColors.variables', "Sets the colors and styles for variables declarations and references.")),
 		textMateRules: {
 			description: nls.localize('editorColors.textMateRules', 'Sets colors and styles using textmate theming rules (advanced).'),
-			$ref: textmateColorsSchemaId
+			$ref: textmateColorsSchemaForSettingId
 		},
 		semanticHighlighting: {
 			description: nls.localize('editorColors.semanticHighlighting', 'Whether semantic highlighting should be enabled for this theme.'),

--- a/src/vs/workbench/services/themes/common/themeConfiguration.ts
+++ b/src/vs/workbench/services/themes/common/themeConfiguration.ts
@@ -10,7 +10,7 @@ import { IConfigurationRegistry, Extensions as ConfigurationExtensions, IConfigu
 
 import { IJSONSchema } from 'vs/base/common/jsonSchema';
 import { textmateColorsSchemaId, textmateColorGroupSchemaId } from 'vs/workbench/services/themes/common/colorThemeSchema';
-import { workbenchColorsSchemaId } from 'vs/platform/theme/common/colorRegistry';
+import { workbenchColorsSchemaForSettingId } from 'vs/platform/theme/common/colorRegistry';
 import { tokenStylingSchemaId } from 'vs/platform/theme/common/tokenClassificationRegistry';
 import { ThemeSettings, IWorkbenchColorTheme, IWorkbenchFileIconTheme, IColorCustomizations, ITokenColorCustomizations, IWorkbenchProductIconTheme, ISemanticTokenColorCustomizations, ThemeSettingTarget, ThemeSettingDefaults } from 'vs/workbench/services/themes/common/workbenchThemeService';
 import { IConfigurationService, ConfigurationTarget } from 'vs/platform/configuration/common/configuration';
@@ -81,7 +81,7 @@ const detectColorSchemeSettingSchema: IConfigurationPropertySchema = {
 const colorCustomizationsSchema: IConfigurationPropertySchema = {
 	type: 'object',
 	description: nls.localize('workbenchColors', "Overrides colors from the currently selected color theme."),
-	allOf: [{ $ref: workbenchColorsSchemaId }],
+	allOf: [{ $ref: workbenchColorsSchemaForSettingId }],
 	default: {},
 	defaultSnippets: [{
 		body: {
@@ -227,7 +227,7 @@ export function updateColorThemeConfigurationSchemas(themes: IWorkbenchColorThem
 	const themeSpecificTokenColors: IJSONSchema = { properties: {} };
 	const themeSpecificSemanticTokenColors: IJSONSchema = { properties: {} };
 
-	const workbenchColors = { $ref: workbenchColorsSchemaId, additionalProperties: false };
+	const workbenchColors = { $ref: workbenchColorsSchemaForSettingId, additionalProperties: false };
 	const tokenColors = { properties: tokenColorSchema.properties, additionalProperties: false };
 	for (const t of themes) {
 		// add theme specific color customization ("[Abyss]":{ ... })

--- a/src/vs/workbench/services/themes/common/themeConfiguration.ts
+++ b/src/vs/workbench/services/themes/common/themeConfiguration.ts
@@ -11,7 +11,7 @@ import { IConfigurationRegistry, Extensions as ConfigurationExtensions, IConfigu
 import { IJSONSchema } from 'vs/base/common/jsonSchema';
 import { textmateColorsSchemaForSettingId, textmateColorGroupSchemaId } from 'vs/workbench/services/themes/common/colorThemeSchema';
 import { workbenchColorsSchemaForSettingId } from 'vs/platform/theme/common/colorRegistry';
-import { tokenStylingSchemaId } from 'vs/platform/theme/common/tokenClassificationRegistry';
+import { tokenStylingSchemaForSettingId } from 'vs/platform/theme/common/tokenClassificationRegistry';
 import { ThemeSettings, IWorkbenchColorTheme, IWorkbenchFileIconTheme, IColorCustomizations, ITokenColorCustomizations, IWorkbenchProductIconTheme, ISemanticTokenColorCustomizations, ThemeSettingTarget, ThemeSettingDefaults } from 'vs/workbench/services/themes/common/workbenchThemeService';
 import { IConfigurationService, ConfigurationTarget } from 'vs/platform/configuration/common/configuration';
 import { isWeb } from 'vs/base/common/platform';
@@ -190,7 +190,7 @@ const semanticTokenColorSchema: IJSONSchema = {
 			suggestSortText: '0_enabled'
 		},
 		rules: {
-			$ref: tokenStylingSchemaId,
+			$ref: tokenStylingSchemaForSettingId,
 			description: nls.localize('editorColors.semanticHighlighting.rules', 'Semantic token styling rules for this theme.'),
 			suggestSortText: '0_rules'
 		}

--- a/src/vs/workbench/services/themes/test/node/color-theme-with-pallet.json
+++ b/src/vs/workbench/services/themes/test/node/color-theme-with-pallet.json
@@ -1,0 +1,17 @@
+{
+	"name": "my theme",
+	"colorPalette":{
+		"$primary": "#4e321a",
+		"$secondary": "#110802",
+		"$accent1": "#400000",
+		"$accent2": "#0400ff"
+	},
+	"colors": {
+		"editorGroup.emptyBackground": "$primary",
+		"statusBar.border": "$secondary",
+		"focusBorder": "#0400ff",
+		"badge.background": "#fce566",
+		"badge.foreground": null,
+		"editorGroup.dropBackground": "$notExist"
+	}
+}

--- a/src/vs/workbench/services/themes/test/node/color-theme-with-pallet.json
+++ b/src/vs/workbench/services/themes/test/node/color-theme-with-pallet.json
@@ -1,5 +1,6 @@
 {
 	"name": "my theme",
+	"type": "dark",
 	"colorPalette":{
 		"$primary": "#4e321a",
 		"$secondary": "#110802",
@@ -13,5 +14,62 @@
 		"badge.background": "#fce566",
 		"badge.foreground": null,
 		"editorGroup.dropBackground": "$notExist"
+	},
+	"tokenColors": [
+		{
+			"scope": "comment",
+			"settings": {
+				"foreground": "$accent1"
+			}
+		},
+		{
+			"scope": "string",
+			"settings": {
+				"foreground": "$accent2"
+			}
+		},
+		{
+			"scope": "constant.numeric",
+			"settings": {
+				"foreground": "#555555"
+			}
+		},
+		{
+			"scope": "variable",
+			"settings": {
+				"fontStyle": "",
+				"foreground": "$notExist"
+			}
+		}
+	],
+	"semanticTokenColors": {
+		"strings": "#a31515",
+		"number": "$accent1",
+		"regexp": "$notExist",
+		"comments": {
+			"foreground": "#008000",
+			"fontStyle": "italic",
+			"bold": false,
+			"italic": true,
+			"underline": false,
+			"strikethrough": false
+		},
+		"keywords": {
+			"foreground": "$accent1",
+			"fontStyle": "bold",
+			"bold": true,
+			"italic": false,
+			"underline": false,
+			"strikethrough": false
+		},
+		"functions": {
+			"foreground": "$notExist",
+			"fontStyle": "bold",
+			"bold": true,
+			"italic": false,
+			"underline": false,
+			"strikethrough": false
+
+		}
 	}
 }

--- a/src/vs/workbench/services/themes/test/node/color-theme-without-pallet.json
+++ b/src/vs/workbench/services/themes/test/node/color-theme-without-pallet.json
@@ -1,0 +1,11 @@
+{
+	"name": "my theme",
+	"colors": {
+		"editorGroup.emptyBackground": "$primary",
+		"statusBar.border": "$secondary",
+		"focusBorder": "#0400ff",
+		"badge.background": "#fce566",
+		"badge.foreground": null,
+		"editorGroup.dropBackground": "$notExist"
+	}
+}

--- a/src/vs/workbench/services/themes/test/node/color-theme-without-pallet.json
+++ b/src/vs/workbench/services/themes/test/node/color-theme-without-pallet.json
@@ -1,5 +1,6 @@
 {
 	"name": "my theme",
+	"type": "dark",
 	"colors": {
 		"editorGroup.emptyBackground": "$primary",
 		"statusBar.border": "$secondary",
@@ -7,5 +8,62 @@
 		"badge.background": "#fce566",
 		"badge.foreground": null,
 		"editorGroup.dropBackground": "$notExist"
+	},
+	"tokenColors": [
+		{
+			"scope": "comment",
+			"settings": {
+				"foreground": "$accent1"
+			}
+		},
+		{
+			"scope": "string",
+			"settings": {
+				"foreground": "$accent2"
+			}
+		},
+		{
+			"scope": "constant.numeric",
+			"settings": {
+				"foreground": "#555555"
+			}
+		},
+		{
+			"scope": "variable",
+			"settings": {
+				"fontStyle": "",
+				"foreground": "$notExist"
+			}
+		}
+	],
+	"semanticTokenColors": {
+		"strings": "#a31515",
+		"number": "$accent1",
+		"regexp": "$notExist",
+		"comments": {
+			"foreground": "#008000",
+			"fontStyle": "italic",
+			"bold": false,
+			"italic": true,
+			"underline": false,
+			"strikethrough": false
+		},
+		"keywords": {
+			"foreground": "$accent1",
+			"fontStyle": "bold",
+			"bold": true,
+			"italic": false,
+			"underline": false,
+			"strikethrough": false
+		},
+		"functions": {
+			"foreground": "$notExist",
+			"fontStyle": "bold",
+			"bold": true,
+			"italic": false,
+			"underline": false,
+			"strikethrough": false
+
+		}
 	}
 }

--- a/src/vs/workbench/services/themes/test/node/themeColorParsing.test.ts
+++ b/src/vs/workbench/services/themes/test/node/themeColorParsing.test.ts
@@ -1,0 +1,80 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { FileAccess, Schemas } from 'vs/base/common/network';
+import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
+import { IEnvironmentService } from 'vs/platform/environment/common/environment';
+import { ExtensionResourceLoaderService } from 'vs/platform/extensionResourceLoader/common/extensionResourceLoaderService';
+import { FileService } from 'vs/platform/files/common/fileService';
+import { NullLogService } from 'vs/platform/log/common/log';
+import { IRequestService } from 'vs/platform/request/common/request';
+import { IStorageService } from 'vs/platform/storage/common/storage';
+import { ColorThemeData } from 'vs/workbench/services/themes/common/colorThemeData';
+import { TestProductService, mock } from 'vs/workbench/test/common/workbenchTestServices';
+import * as assert from 'assert';
+import { DiskFileSystemProvider } from 'vs/platform/files/node/diskFileSystemProvider';
+import { getColorRegistry } from 'vs/platform/theme/common/colorRegistry';
+
+
+suite('Theme color parsing', () => {
+	const fileService = new FileService(new NullLogService());
+	const requestService = new (mock<IRequestService>())();
+	const storageService = new (mock<IStorageService>())();
+	const environmentService = new (mock<IEnvironmentService>())();
+	const configurationService = new (mock<IConfigurationService>())();
+	const extensionResourceLoaderService = new ExtensionResourceLoaderService(fileService, storageService, TestProductService, environmentService, configurationService, requestService);
+
+	const diskFileSystemProvider = new DiskFileSystemProvider(new NullLogService());
+	fileService.registerProvider(Schemas.file, diskFileSystemProvider);
+
+	teardown(() => {
+		diskFileSystemProvider.dispose();
+	});
+
+
+	test('parse with palette', async () => {
+		const themeData = ColorThemeData.createUnloadedTheme('bar');
+		themeData.location = FileAccess.asFileUri('vs/workbench/services/themes/test/node/color-theme-with-pallet.json');
+		await themeData.ensureLoaded(extensionResourceLoaderService);
+		const colorRegistry = getColorRegistry();
+
+		assert.strictEqual(themeData.isLoaded, true);
+		assert.strictEqual(themeData.getColor('editorGroup.emptyBackground')?.toString(), '#4e321a');
+		assert.strictEqual(themeData.getColor('statusBar.border')?.toString(), '#110802');
+		assert.strictEqual(themeData.getColor('focusBorder')?.toString(), '#0400ff');
+		assert.strictEqual(themeData.getColor('badge.background')?.toString(), '#fce566');
+
+		const defaultBadgeForeground = colorRegistry.resolveDefaultColor('badge.foreground', themeData);
+		assert.strictEqual(themeData.getColor('badge.foreground')?.toString(), defaultBadgeForeground?.toString());
+		const defaultEditorGroupDropBackground = colorRegistry.resolveDefaultColor('editorGroup.dropBackground', themeData);
+		assert.strictEqual(themeData.getColor('editorGroup.dropBackground')?.toString(), defaultEditorGroupDropBackground);
+
+	});
+
+	test('parse without palette', async () => {
+		const themeData = ColorThemeData.createUnloadedTheme('bar');
+		themeData.location = FileAccess.asFileUri('vs/workbench/services/themes/test/node/color-theme-without-pallet.json');
+		await themeData.ensureLoaded(extensionResourceLoaderService);
+		const colorRegistry = getColorRegistry();
+
+		assert.strictEqual(themeData.isLoaded, true);
+		const defaultEditorGroupEmptyBackground = colorRegistry.resolveDefaultColor('editorGroup.emptyBackground', themeData);
+		assert.strictEqual(themeData.getColor('editorGroup.emptyBackground')?.toString(), defaultEditorGroupEmptyBackground?.toString());
+
+		const defaultStatusBarBorder = colorRegistry.resolveDefaultColor('statusBar.border', themeData);
+		assert.strictEqual(themeData.getColor('statusBar.border')?.toString(), defaultStatusBarBorder?.toString());
+
+		assert.strictEqual(themeData.getColor('focusBorder')?.toString(), '#0400ff');
+		assert.strictEqual(themeData.getColor('badge.background')?.toString(), '#fce566');
+
+		const defaultBadgeForeground = colorRegistry.resolveDefaultColor('badge.foreground', themeData);
+		assert.strictEqual(themeData.getColor('badge.foreground')?.toString(), defaultBadgeForeground?.toString());
+
+		const defaultEditorGroupDropBackground = colorRegistry.resolveDefaultColor('editorGroup.dropBackground', themeData);
+		assert.strictEqual(themeData.getColor('editorGroup.dropBackground')?.toString(), defaultEditorGroupDropBackground?.toString());
+
+	});
+
+});

--- a/src/vs/workbench/services/themes/test/node/themeColorParsing.test.ts
+++ b/src/vs/workbench/services/themes/test/node/themeColorParsing.test.ts
@@ -40,16 +40,16 @@ suite('Theme color parsing', () => {
 		await themeData.ensureLoaded(extensionResourceLoaderService);
 		const colorRegistry = getColorRegistry();
 
-		assert.strictEqual(themeData.isLoaded, true);
-		assert.strictEqual(themeData.getColor('editorGroup.emptyBackground')?.toString(), '#4e321a');
-		assert.strictEqual(themeData.getColor('statusBar.border')?.toString(), '#110802');
-		assert.strictEqual(themeData.getColor('focusBorder')?.toString(), '#0400ff');
-		assert.strictEqual(themeData.getColor('badge.background')?.toString(), '#fce566');
+		assert.equal(themeData.isLoaded, true);
+		assert.equal(themeData.getColor('editorGroup.emptyBackground')?.toString(), '#4e321a');
+		assert.equal(themeData.getColor('statusBar.border')?.toString(), '#110802');
+		assert.equal(themeData.getColor('focusBorder')?.toString(), '#0400ff');
+		assert.equal(themeData.getColor('badge.background')?.toString(), '#fce566');
 
 		const defaultBadgeForeground = colorRegistry.resolveDefaultColor('badge.foreground', themeData);
-		assert.strictEqual(themeData.getColor('badge.foreground')?.toString(), defaultBadgeForeground?.toString());
+		assert.equal(themeData.getColor('badge.foreground')?.toString(), defaultBadgeForeground?.toString());
 		const defaultEditorGroupDropBackground = colorRegistry.resolveDefaultColor('editorGroup.dropBackground', themeData);
-		assert.strictEqual(themeData.getColor('editorGroup.dropBackground')?.toString(), defaultEditorGroupDropBackground);
+		assert.equal(themeData.getColor('editorGroup.dropBackground')?.toString(), defaultEditorGroupDropBackground);
 
 	});
 
@@ -59,21 +59,21 @@ suite('Theme color parsing', () => {
 		await themeData.ensureLoaded(extensionResourceLoaderService);
 		const colorRegistry = getColorRegistry();
 
-		assert.strictEqual(themeData.isLoaded, true);
+		assert.equal(themeData.isLoaded, true);
 		const defaultEditorGroupEmptyBackground = colorRegistry.resolveDefaultColor('editorGroup.emptyBackground', themeData);
-		assert.strictEqual(themeData.getColor('editorGroup.emptyBackground')?.toString(), defaultEditorGroupEmptyBackground?.toString());
+		assert.equal(themeData.getColor('editorGroup.emptyBackground')?.toString(), defaultEditorGroupEmptyBackground?.toString());
 
 		const defaultStatusBarBorder = colorRegistry.resolveDefaultColor('statusBar.border', themeData);
-		assert.strictEqual(themeData.getColor('statusBar.border')?.toString(), defaultStatusBarBorder?.toString());
+		assert.equal(themeData.getColor('statusBar.border')?.toString(), defaultStatusBarBorder?.toString());
 
-		assert.strictEqual(themeData.getColor('focusBorder')?.toString(), '#0400ff');
-		assert.strictEqual(themeData.getColor('badge.background')?.toString(), '#fce566');
+		assert.equal(themeData.getColor('focusBorder')?.toString(), '#0400ff');
+		assert.equal(themeData.getColor('badge.background')?.toString(), '#fce566');
 
 		const defaultBadgeForeground = colorRegistry.resolveDefaultColor('badge.foreground', themeData);
-		assert.strictEqual(themeData.getColor('badge.foreground')?.toString(), defaultBadgeForeground?.toString());
+		assert.equal(themeData.getColor('badge.foreground')?.toString(), defaultBadgeForeground?.toString());
 
 		const defaultEditorGroupDropBackground = colorRegistry.resolveDefaultColor('editorGroup.dropBackground', themeData);
-		assert.strictEqual(themeData.getColor('editorGroup.dropBackground')?.toString(), defaultEditorGroupDropBackground?.toString());
+		assert.equal(themeData.getColor('editorGroup.dropBackground')?.toString(), defaultEditorGroupDropBackground?.toString());
 
 	});
 

--- a/src/vs/workbench/services/themes/test/node/themeColorParsing.test.ts
+++ b/src/vs/workbench/services/themes/test/node/themeColorParsing.test.ts
@@ -16,6 +16,7 @@ import { TestProductService, mock } from 'vs/workbench/test/common/workbenchTest
 import * as assert from 'assert';
 import { DiskFileSystemProvider } from 'vs/platform/files/node/diskFileSystemProvider';
 import { getColorRegistry } from 'vs/platform/theme/common/colorRegistry';
+import { ensureNoDisposablesAreLeakedInTestSuite } from 'vs/base/test/common/utils';
 
 
 suite('Theme color parsing', () => {
@@ -48,8 +49,8 @@ suite('Theme color parsing', () => {
 
 		const defaultBadgeForeground = colorRegistry.resolveDefaultColor('badge.foreground', themeData);
 		assert.equal(themeData.getColor('badge.foreground')?.toString(), defaultBadgeForeground?.toString());
-		const defaultEditorGroupDropBackground = colorRegistry.resolveDefaultColor('editorGroup.dropBackground', themeData);
-		assert.equal(themeData.getColor('editorGroup.dropBackground')?.toString(), defaultEditorGroupDropBackground);
+
+		assert.equal(themeData.getColor('editorGroup.dropBackground')?.toString(), '#ff0000');
 
 	});
 
@@ -60,11 +61,9 @@ suite('Theme color parsing', () => {
 		const colorRegistry = getColorRegistry();
 
 		assert.equal(themeData.isLoaded, true);
-		const defaultEditorGroupEmptyBackground = colorRegistry.resolveDefaultColor('editorGroup.emptyBackground', themeData);
-		assert.equal(themeData.getColor('editorGroup.emptyBackground')?.toString(), defaultEditorGroupEmptyBackground?.toString());
+		assert.equal(themeData.getColor('editorGroup.emptyBackground')?.toString(), '#ff0000');
 
-		const defaultStatusBarBorder = colorRegistry.resolveDefaultColor('statusBar.border', themeData);
-		assert.equal(themeData.getColor('statusBar.border')?.toString(), defaultStatusBarBorder?.toString());
+		assert.equal(themeData.getColor('statusBar.border')?.toString(), '#ff0000');
 
 		assert.equal(themeData.getColor('focusBorder')?.toString(), '#0400ff');
 		assert.equal(themeData.getColor('badge.background')?.toString(), '#fce566');
@@ -72,9 +71,9 @@ suite('Theme color parsing', () => {
 		const defaultBadgeForeground = colorRegistry.resolveDefaultColor('badge.foreground', themeData);
 		assert.equal(themeData.getColor('badge.foreground')?.toString(), defaultBadgeForeground?.toString());
 
-		const defaultEditorGroupDropBackground = colorRegistry.resolveDefaultColor('editorGroup.dropBackground', themeData);
-		assert.equal(themeData.getColor('editorGroup.dropBackground')?.toString(), defaultEditorGroupDropBackground?.toString());
+		assert.equal(themeData.getColor('editorGroup.dropBackground')?.toString(), '#ff0000');
 
 	});
 
+	ensureNoDisposablesAreLeakedInTestSuite();
 });

--- a/src/vs/workbench/services/themes/test/node/themeColorParsing.test.ts
+++ b/src/vs/workbench/services/themes/test/node/themeColorParsing.test.ts
@@ -17,6 +17,7 @@ import * as assert from 'assert';
 import { DiskFileSystemProvider } from 'vs/platform/files/node/diskFileSystemProvider';
 import { getColorRegistry } from 'vs/platform/theme/common/colorRegistry';
 import { ensureNoDisposablesAreLeakedInTestSuite } from 'vs/base/test/common/utils';
+import { ts, assertTokenStyle, undefinedStyle, unsetStyle } from 'vs/workbench/services/themes/test/node/tokenStyleResolving.test';
 
 
 suite('Theme color parsing', () => {
@@ -35,7 +36,7 @@ suite('Theme color parsing', () => {
 	});
 
 
-	test('parse with palette', async () => {
+	test('workbench color parse with palette', async () => {
 		const themeData = ColorThemeData.createUnloadedTheme('bar');
 		themeData.location = FileAccess.asFileUri('vs/workbench/services/themes/test/node/color-theme-with-pallet.json');
 		await themeData.ensureLoaded(extensionResourceLoaderService);
@@ -54,7 +55,7 @@ suite('Theme color parsing', () => {
 
 	});
 
-	test('parse without palette', async () => {
+	test('workbench color parse without palette', async () => {
 		const themeData = ColorThemeData.createUnloadedTheme('bar');
 		themeData.location = FileAccess.asFileUri('vs/workbench/services/themes/test/node/color-theme-without-pallet.json');
 		await themeData.ensureLoaded(extensionResourceLoaderService);
@@ -73,6 +74,49 @@ suite('Theme color parsing', () => {
 
 		assert.equal(themeData.getColor('editorGroup.dropBackground')?.toString(), '#ff0000');
 
+	});
+
+	test('token color parse with palette', async () => {
+		const themeData = ColorThemeData.createUnloadedTheme('bar');
+		themeData.location = FileAccess.asFileUri('vs/workbench/services/themes/test/node/color-theme-with-pallet.json');
+		await themeData.ensureLoaded(extensionResourceLoaderService);
+		assertTokenStyle(themeData.resolveScopes([['comment']]), ts('#400000', undefinedStyle));
+		assertTokenStyle(themeData.resolveScopes([['string']]), ts('#0400ff', undefinedStyle));
+		assertTokenStyle(themeData.resolveScopes([['constant.numeric']]), ts('#555555', undefinedStyle));
+		assertTokenStyle(themeData.resolveScopes([['variable']]), ts('#ff0000', unsetStyle));
+	});
+
+	test('token color parse without palette', async () => {
+		const themeData = ColorThemeData.createUnloadedTheme('bar');
+		themeData.location = FileAccess.asFileUri('vs/workbench/services/themes/test/node/color-theme-without-pallet.json');
+		await themeData.ensureLoaded(extensionResourceLoaderService);
+		assertTokenStyle(themeData.resolveScopes([['comment']]), ts('#ff0000', undefinedStyle));
+		assertTokenStyle(themeData.resolveScopes([['string']]), ts('#ff0000', undefinedStyle));
+		assertTokenStyle(themeData.resolveScopes([['constant.numeric']]), ts('#555555', undefinedStyle));
+		assertTokenStyle(themeData.resolveScopes([['variable']]), ts('#ff0000', unsetStyle));
+	});
+
+	test('semantic token color parse with palette', async () => {
+		const themeData = ColorThemeData.createUnloadedTheme('bar');
+		themeData.location = FileAccess.asFileUri('vs/workbench/services/themes/test/node/color-theme-with-pallet.json');
+		await themeData.ensureLoaded(extensionResourceLoaderService);
+		assert.equal(themeData.resolveTokenStyleValue('strings')?.foreground?.toString(), '#a31515');
+		assert.equal(themeData.resolveTokenStyleValue('number')?.foreground?.toString(), '#400000');
+		assert.equal(themeData.resolveTokenStyleValue('regexp')?.foreground?.toString(), '#ff0000');
+		assert.equal(themeData.resolveTokenStyleValue('comments')?.foreground?.toString(), '#008000');
+		assert.equal(themeData.resolveTokenStyleValue('keywords')?.foreground?.toString(), '#400000');
+		assert.equal(themeData.resolveTokenStyleValue('functions')?.foreground?.toString(), '#ff0000');
+	});
+	test('semantic token color parse without palette', async () => {
+		const themeData = ColorThemeData.createUnloadedTheme('bar');
+		themeData.location = FileAccess.asFileUri('vs/workbench/services/themes/test/node/color-theme-without-pallet.json');
+		await themeData.ensureLoaded(extensionResourceLoaderService);
+		assert.equal(themeData.resolveTokenStyleValue('strings')?.foreground?.toString(), '#a31515');
+		assert.equal(themeData.resolveTokenStyleValue('number')?.foreground?.toString(), '#ff0000');
+		assert.equal(themeData.resolveTokenStyleValue('regexp')?.foreground?.toString(), '#ff0000');
+		assert.equal(themeData.resolveTokenStyleValue('comments')?.foreground?.toString(), '#008000');
+		assert.equal(themeData.resolveTokenStyleValue('keywords')?.foreground?.toString(), '#ff0000');
+		assert.equal(themeData.resolveTokenStyleValue('functions')?.foreground?.toString(), '#ff0000');
 	});
 
 	ensureNoDisposablesAreLeakedInTestSuite();

--- a/src/vs/workbench/services/themes/test/node/tokenStyleResolving.test.ts
+++ b/src/vs/workbench/services/themes/test/node/tokenStyleResolving.test.ts
@@ -21,15 +21,15 @@ import { IStorageService } from 'vs/platform/storage/common/storage';
 import { IEnvironmentService } from 'vs/platform/environment/common/environment';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 
-const undefinedStyle = { bold: undefined, underline: undefined, italic: undefined };
-const unsetStyle = { bold: false, underline: false, italic: false };
+export const undefinedStyle = { bold: undefined, underline: undefined, italic: undefined };
+export const unsetStyle = { bold: false, underline: false, italic: false };
 
-function ts(foreground: string | undefined, styleFlags: { bold?: boolean; underline?: boolean; strikethrough?: boolean; italic?: boolean } | undefined): TokenStyle {
+export function ts(foreground: string | undefined, styleFlags: { bold?: boolean; underline?: boolean; strikethrough?: boolean; italic?: boolean } | undefined): TokenStyle {
 	const foregroundColor = isString(foreground) ? Color.fromHex(foreground) : undefined;
 	return new TokenStyle(foregroundColor, styleFlags?.bold, styleFlags?.underline, styleFlags?.strikethrough, styleFlags?.italic);
 }
 
-function tokenStyleAsString(ts: TokenStyle | undefined | null) {
+export function tokenStyleAsString(ts: TokenStyle | undefined | null) {
 	if (!ts) {
 		return 'tokenstyle-undefined';
 	}
@@ -46,11 +46,11 @@ function tokenStyleAsString(ts: TokenStyle | undefined | null) {
 	return str;
 }
 
-function assertTokenStyle(actual: TokenStyle | undefined | null, expected: TokenStyle | undefined | null, message?: string) {
+export function assertTokenStyle(actual: TokenStyle | undefined | null, expected: TokenStyle | undefined | null, message?: string) {
 	assert.strictEqual(tokenStyleAsString(actual), tokenStyleAsString(expected), message);
 }
 
-function assertTokenStyleMetaData(colorIndex: string[], actual: ITokenStyle | undefined, expected: TokenStyle | undefined | null, message = '') {
+export function assertTokenStyleMetaData(colorIndex: string[], actual: ITokenStyle | undefined, expected: TokenStyle | undefined | null, message = '') {
 	if (expected === undefined || expected === null || actual === undefined) {
 		assert.strictEqual(actual, expected, message);
 		return;
@@ -68,7 +68,7 @@ function assertTokenStyleMetaData(colorIndex: string[], actual: ITokenStyle | un
 }
 
 
-function assertTokenStyles(themeData: ColorThemeData, expected: { [qualifiedClassifier: string]: TokenStyle }, language = 'typescript') {
+export function assertTokenStyles(themeData: ColorThemeData, expected: { [qualifiedClassifier: string]: TokenStyle }, language = 'typescript') {
 	const colorIndex = themeData.tokenColorMap;
 
 	for (const qualifiedClassifier in expected) {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

## Description
For feature request described in #105247 

Mainly there are two new features proposed here

- Allow theme file to have a color palette, and the vars can be used to define a color for the **workbench** color item. _EDIT 2023-12-15_: also for syntax and semantic token.
- _EDIT 2023-12-15_ ~Add snippets and suggestion for the colors, which include all the defined variables in the palette~


This does **NOT** include the following

- _EDIT 2023-12-15_ ~Usage of the palette var for **token** colors (I am interested to explore this, but would like to hear feedback first)~
- Usage of the palette var in Setting [#56855](https://github.com/microsoft/vscode/issues/56855), _EDIT 2023-12-15_ ~as this needs to change the `colorRegistry`, which may affect many other things. (I would also love to explore this option, depending on the feedback)~

_EDIT 2023-12-15 (see comment for screenshots)_

## Some technical details

- The syntax using `$` is based on [this comment](https://github.com/microsoft/vscode/issues/105247#issuecomment-1246443785) by @aeschli 
- The parsing happens right when loading theme data. Any other service etc that uses color from the theme will always see the parsed hex, never the palette var.
- For the snippets/suggestion/validation, I cannot use `workbenchColorsSchemaId` because modifying it would affect many other things. So instead I create a new JSON Schema based on that ([here](https://github.com/d-mahard/vscode/blob/8a1ef6629883352dec9046cb428f3ba06cc1f5df/src/vs/workbench/services/themes/common/colorThemeSchema.ts#L234-L245)), so it will be isolated, only in theme file. However, if there is no palette, there will essentially be no modification to the schema, it is just copied as it is.
- _EDIT 2023-12-15_ ~For the snippets/suggestion/validation, the palette needs to be loaded first, meaning that if there is any change in the palette, VSCode needs to be restarted after the change. However, I think it is safe to assume that a palette change, especially the change of the _keys_, only happens rarely.~



## How to test

I prepared a unit test for the parsing in [themeColorParsing.test.ts](https://github.com/d-mahard/vscode/blob/8a1ef6629883352dec9046cb428f3ba06cc1f5df/src/vs/workbench/services/themes/test/node/themeColorParsing.test.ts)