### PR TITLE
Fix losing input history when clearing the chat session

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatWidget.ts
@@ -439,6 +439,9 @@ export class ChatWidget extends Disposable implements IChatWidget {
 			}
 		}));
 		this.viewModelDisposables.add(this.viewModel.onDidDisposeModel(() => {
+			// Ensure that view state is saved here, because we will load it again when a new model is assigned
+			this.inputPart.saveState();
+
 			// Disposes the viewmodel and listeners
 			this.viewModel = undefined;
 			this.onDidChangeItems();


### PR DESCRIPTION
This pull request fixes the issue of losing input history when clearing the chat session. It ensures that the view state is saved before disposing the view model, so that it can be loaded again when a new model is assigned.