### PR TITLE
Fix updating relative number for sticky scroll

### DIFF
--- a/src/vs/editor/contrib/stickyScroll/browser/stickyScrollController.ts
+++ b/src/vs/editor/contrib/stickyScroll/browser/stickyScrollController.ts
@@ -435,7 +435,7 @@ export class StickyScrollController extends Disposable implements IEditorContrib
 		if (lineNumberOption.renderType === RenderLineNumbersType.Relative) {
 			this._sessionStore.add(this._editor.onDidChangeCursorPosition(() => {
 				this._showEndForLine = null;
-				this._renderStickyScroll();
+				this._renderStickyScroll(-1);
 			}));
 		}
 	}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fixes issue where line number is not updated properly when cursor changes and relative line numbers is activated. I.e. the following settings:


```json
   "editor.stickyScroll.enabled": true,
   "editor.lineNumbers": "relative"
```

The default value of the `rebuildFromLine` argument is `Infinity` for the `_renderStickyScroll` function, changing it to `-1` solves the problem and correctly updates relative lines for sticky scroll.

- https://github.com/microsoft/vscode/issues/195711