### PR TITLE
fix: preserve atsign in uri path

### DIFF
--- a/src/vs/base/common/uri.ts
+++ b/src/vs/base/common/uri.ts
@@ -546,6 +546,7 @@ function encodeURIComponentFast(uriComponent: string, isPath: boolean, isAuthori
 			|| code === CharCode.Underline
 			|| code === CharCode.Tilde
 			|| (isPath && code === CharCode.Slash)
+			|| (isPath && code === CharCode.AtSign)
 			|| (isAuthority && code === CharCode.OpenSquareBracket)
 			|| (isAuthority && code === CharCode.CloseSquareBracket)
 			|| (isAuthority && code === CharCode.Colon)

--- a/src/vs/base/test/common/uri.test.ts
+++ b/src/vs/base/test/common/uri.test.ts
@@ -626,4 +626,8 @@ suite('URI', () => {
 		assert.strictEqual(URI.parse('http://user@[FEDC:BA98:7654:3210:FEDC:BA98:7654:3210]:80/index.html').toString(), 'http://user@[fedc:ba98:7654:3210:fedc:ba98:7654:3210]:80/index.html');
 		assert.strictEqual(URI.parse('http://us[er@[FEDC:BA98:7654:3210:FEDC:BA98:7654:3210]:80/index.html').toString(), 'http://us%5Ber@[fedc:ba98:7654:3210:fedc:ba98:7654:3210]:80/index.html');
 	});
+
+	test('vscode-uri: URI.toString() wrongly encode absolute paths', function () {
+		assert.strictEqual(URI.parse('http://example.com/@scope/foo').toString(), 'http://example.com/@scope/foo');
+	});
 });


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
Fixes #199106 

According to https://datatracker.ietf.org/doc/html/rfc3986#section-3.3

> pchar         = unreserved / pct-encoded / sub-delims / ":" / "@"

`:` and `@` should be allowed in absolute paths.

However, preserving `:` breaks Windows drive test cases, which I am not sure which is expected.