### PR TITLE
Fix 'enter' not working in chat suggest widget

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/chatActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatActions.ts
@@ -11,7 +11,7 @@ import { ICodeEditor } from 'vs/editor/browser/editorBrowser';
 import { EditorAction2, ServicesAccessor } from 'vs/editor/browser/editorExtensions';
 import { ICodeEditorService } from 'vs/editor/browser/services/codeEditorService';
 import { EditorContextKeys } from 'vs/editor/common/editorContextKeys';
-import { localize } from 'vs/nls';
+import { localize, localize2 } from 'vs/nls';
 import { Action2, IAction2Options, MenuId, registerAction2 } from 'vs/platform/actions/common/actions';
 import { ContextKeyExpr } from 'vs/platform/contextkey/common/contextkey';
 import { KeybindingWeight } from 'vs/platform/keybinding/common/keybindingsRegistry';
@@ -26,8 +26,10 @@ import { IChatWidgetService } from 'vs/workbench/contrib/chat/browser/chat';
 import { IChatEditorOptions } from 'vs/workbench/contrib/chat/browser/chatEditor';
 import { ChatEditorInput } from 'vs/workbench/contrib/chat/browser/chatEditorInput';
 import { ChatViewPane } from 'vs/workbench/contrib/chat/browser/chatViewPane';
+import { IChatAgentService } from 'vs/workbench/contrib/chat/common/chatAgents';
 import { CONTEXT_IN_CHAT_INPUT, CONTEXT_IN_CHAT_SESSION, CONTEXT_PROVIDER_EXISTS, CONTEXT_REQUEST, CONTEXT_RESPONSE } from 'vs/workbench/contrib/chat/common/chatContextKeys';
 import { IChatContributionService } from 'vs/workbench/contrib/chat/common/chatContributionService';
+import { chatAgentLeader } from 'vs/workbench/contrib/chat/common/chatParserTypes';
 import { IChatDetail, IChatService } from 'vs/workbench/contrib/chat/common/chatService';
 import { IChatWidgetHistoryService } from 'vs/workbench/contrib/chat/common/chatWidgetHistoryService';
 import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
@@ -73,8 +75,67 @@ class QuickChatGlobalAction extends Action2 {
 	}
 }
 
+export class ChatSubmitSecondaryAgentEditorAction extends EditorAction2 {
+	static readonly ID = 'workbench.action.chat.submitSecondaryAgent';
+
+	constructor() {
+		super({
+			id: ChatSubmitSecondaryAgentEditorAction.ID,
+			title: localize2({ key: 'actions.chat.submitSecondaryAgent', comment: ['Send input from the chat input box to the secondary agent'] }, "Submit to Secondary Agent"),
+			precondition: CONTEXT_IN_CHAT_INPUT,
+			keybinding: {
+				when: EditorContextKeys.textInputFocus,
+				primary: KeyMod.CtrlCmd | KeyCode.Enter,
+				weight: KeybindingWeight.EditorContrib
+			}
+		});
+	}
+
+	runEditorCommand(accessor: ServicesAccessor, editor: ICodeEditor): void | Promise<void> {
+		const editorUri = editor.getModel()?.uri;
+		if (editorUri) {
+			const agentService = accessor.get(IChatAgentService);
+			const secondaryAgent = agentService.getSecondaryAgent();
+			if (!secondaryAgent) {
+				return;
+			}
+
+			const widgetService = accessor.get(IChatWidgetService);
+			widgetService.getWidgetByInputUri(editorUri)?.acceptInputWithPrefix(`${chatAgentLeader}${secondaryAgent.id}`);
+		}
+	}
+}
+
+export class ChatSubmitEditorAction extends EditorAction2 {
+	static readonly ID = 'workbench.action.chat.acceptInput';
+
+	constructor() {
+		super({
+			id: ChatSubmitEditorAction.ID,
+			title: localize2({ key: 'actions.chat.submit', comment: ['Apply input from the chat input box'] }, "Submit"),
+			precondition: CONTEXT_IN_CHAT_INPUT,
+			keybinding: {
+				when: EditorContextKeys.textInputFocus,
+				primary: KeyCode.Enter,
+				weight: KeybindingWeight.EditorContrib
+			}
+		});
+	}
+
+	runEditorCommand(accessor: ServicesAccessor, editor: ICodeEditor): void | Promise<void> {
+		const editorUri = editor.getModel()?.uri;
+		if (editorUri) {
+			const widgetService = accessor.get(IChatWidgetService);
+			widgetService.getWidgetByInputUri(editorUri)?.acceptInput();
+		}
+	}
+}
+
 export function registerChatActions() {
 	registerAction2(QuickChatGlobalAction);
+	registerAction2(ChatSubmitEditorAction);
+
+	registerAction2(ChatSubmitSecondaryAgentEditorAction);
 
 	registerAction2(class ClearChatHistoryAction extends Action2 {
 		constructor() {

--- a/src/vs/workbench/contrib/chat/browser/actions/chatExecuteActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatExecuteActions.ts
@@ -4,16 +4,12 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Codicon } from 'vs/base/common/codicons';
-import { KeyCode, KeyMod } from 'vs/base/common/keyCodes';
 import { ServicesAccessor } from 'vs/editor/browser/editorExtensions';
-import { localize, localize2 } from 'vs/nls';
+import { localize } from 'vs/nls';
 import { Action2, MenuId, registerAction2 } from 'vs/platform/actions/common/actions';
-import { KeybindingWeight } from 'vs/platform/keybinding/common/keybindingsRegistry';
 import { CHAT_CATEGORY } from 'vs/workbench/contrib/chat/browser/actions/chatActions';
 import { IChatWidget, IChatWidgetService } from 'vs/workbench/contrib/chat/browser/chat';
-import { IChatAgentService } from 'vs/workbench/contrib/chat/common/chatAgents';
-import { CONTEXT_CHAT_INPUT_HAS_TEXT, CONTEXT_CHAT_REQUEST_IN_PROGRESS, CONTEXT_IN_CHAT_INPUT } from 'vs/workbench/contrib/chat/common/chatContextKeys';
-import { chatAgentLeader } from 'vs/workbench/contrib/chat/common/chatParserTypes';
+import { CONTEXT_CHAT_INPUT_HAS_TEXT, CONTEXT_CHAT_REQUEST_IN_PROGRESS } from 'vs/workbench/contrib/chat/common/chatContextKeys';
 import { IChatService } from 'vs/workbench/contrib/chat/common/chatService';
 
 export interface IChatExecuteActionContext {
@@ -40,11 +36,6 @@ export class SubmitAction extends Action2 {
 				when: CONTEXT_CHAT_REQUEST_IN_PROGRESS.negate(),
 				group: 'navigation',
 			},
-			keybinding: {
-				when: CONTEXT_IN_CHAT_INPUT,
-				primary: KeyCode.Enter,
-				weight: KeybindingWeight.WorkbenchContrib
-			},
 		});
 	}
 
@@ -57,43 +48,8 @@ export class SubmitAction extends Action2 {
 	}
 }
 
-export class SubmitSecondaryAgentAction extends Action2 {
-	static readonly ID = 'workbench.action.chat.submitSecondaryAgent';
-
-	constructor() {
-		super({
-			id: SubmitSecondaryAgentAction.ID,
-			title: localize2('chat.label.submitSecondaryAgent', "Submit to Secondary Agent"),
-			f1: false,
-			category: CHAT_CATEGORY,
-			precondition: CONTEXT_CHAT_INPUT_HAS_TEXT,
-			keybinding: {
-				when: CONTEXT_IN_CHAT_INPUT,
-				primary: KeyMod.CtrlCmd | KeyCode.Enter,
-				weight: KeybindingWeight.WorkbenchContrib
-			},
-		});
-	}
-
-	run(accessor: ServicesAccessor, ...args: any[]) {
-		const context: IChatExecuteActionContext | undefined = args[0];
-
-		const agentService = accessor.get(IChatAgentService);
-		const secondaryAgent = agentService.getSecondaryAgent();
-		if (!secondaryAgent) {
-			return;
-		}
-
-		const widgetService = accessor.get(IChatWidgetService);
-		const widget = context?.widget ?? widgetService.lastFocusedWidget;
-		widget?.acceptInputWithPrefix(`${chatAgentLeader}${secondaryAgent.id}`);
-	}
-}
-
 export function registerChatExecuteActions() {
 	registerAction2(SubmitAction);
-	registerAction2(SubmitSecondaryAgentAction);
-
 	registerAction2(class CancelAction extends Action2 {
 		constructor() {
 			super({

--- a/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
@@ -31,7 +31,7 @@ import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 import { DEFAULT_FONT_FAMILY } from 'vs/workbench/browser/style';
 import { AccessibilityVerbositySettingId } from 'vs/workbench/contrib/accessibility/browser/accessibilityConfiguration';
 import { AccessibilityCommandId } from 'vs/workbench/contrib/accessibility/common/accessibilityCommands';
-import { IChatExecuteActionContext, SubmitAction, SubmitSecondaryAgentAction } from 'vs/workbench/contrib/chat/browser/actions/chatExecuteActions';
+import { IChatExecuteActionContext, SubmitAction } from 'vs/workbench/contrib/chat/browser/actions/chatExecuteActions';
 import { IChatWidget } from 'vs/workbench/contrib/chat/browser/chat';
 import { ChatFollowups } from 'vs/workbench/contrib/chat/browser/chatFollowups';
 import { IChatAgentService } from 'vs/workbench/contrib/chat/common/chatAgents';
@@ -41,6 +41,7 @@ import { IChatReplyFollowup } from 'vs/workbench/contrib/chat/common/chatService
 import { IChatResponseViewModel } from 'vs/workbench/contrib/chat/common/chatViewModel';
 import { IChatWidgetHistoryService } from 'vs/workbench/contrib/chat/common/chatWidgetHistoryService';
 import { getSimpleCodeEditorWidgetOptions, getSimpleEditorOptions } from 'vs/workbench/contrib/codeEditor/browser/simpleEditorOptions';
+import { ChatSubmitEditorAction, ChatSubmitSecondaryAgentEditorAction } from 'vs/workbench/contrib/chat/browser/actions/chatActions';
 
 const $ = dom.$;
 
@@ -358,7 +359,7 @@ class SubmitButtonActionViewItem extends ActionViewItem {
 	) {
 		super(context, action, options);
 
-		const primaryKeybinding = keybindingService.lookupKeybinding(SubmitAction.ID)?.getLabel();
+		const primaryKeybinding = keybindingService.lookupKeybinding(ChatSubmitEditorAction.ID)?.getLabel();
 		let tooltip = action.label;
 		if (primaryKeybinding) {
 			tooltip += ` (${primaryKeybinding})`;
@@ -366,7 +367,7 @@ class SubmitButtonActionViewItem extends ActionViewItem {
 
 		const secondaryAgent = chatAgentService.getSecondaryAgent();
 		if (secondaryAgent) {
-			const secondaryKeybinding = keybindingService.lookupKeybinding(SubmitSecondaryAgentAction.ID)?.getLabel();
+			const secondaryKeybinding = keybindingService.lookupKeybinding(ChatSubmitSecondaryAgentEditorAction.ID)?.getLabel();
 			if (secondaryKeybinding) {
 				tooltip += `\n${chatAgentLeader}${secondaryAgent.id} (${secondaryKeybinding})`;
 			}

--- a/src/vs/workbench/contrib/chat/browser/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/media/chat.css
@@ -612,7 +612,12 @@
 	opacity: 0.7;
 }
 
-.interactive-item-container .progress-steps .progress-step .codicon-check {
+.interactive-item-container .progress-steps .progress-step .codicon {
+	/* Very aggressive list styles try to apply focus colors to every codicon in a list row. */
+	color: var(--vscode-icon-foreground) !important;
+}
+
+.interactive-item-container .progress-steps .progress-step .codicon.codicon-check {
 	font-size: 14px;
-	color: var(--vscode-debugIcon-startForeground);
+	color: var(--vscode-debugIcon-startForeground) !important;
 }


### PR DESCRIPTION
Actually, we do need the EditorActions that I removed in #199099

Also fix progress message codicon colors