### PR TITLE
fix: missing translation for new-empty-windows desktop action

### DIFF
--- a/resources/linux/code.desktop
+++ b/resources/linux/code.desktop
@@ -14,5 +14,6 @@ Keywords=vscode;
 
 [Desktop Action new-empty-window]
 Name=New Empty Window
+Name[es]=Nueva ventana vacía
 Exec=@@EXEC@@ --new-window %F
 Icon=@@ICON@@


### PR DESCRIPTION
Currently 'new-empty-windows' Desktop Action is displayed on English regardless of OS language, see below:

**BEFORE:**
![imagen](https://github.com/microsoft/vscode/assets/1280022/7149122b-7c71-4224-85b3-f3671a4bf1f3)


**AFTER:**
![imagen](https://github.com/microsoft/vscode/assets/1280022/b4289728-6dc2-4c38-8f3b-806d1576787e)

