### PR TITLE
Turning off by default the setting `inlineChat.showToolbarIcon`

### DIFF
--- a/src/vs/workbench/contrib/inlineChat/common/inlineChat.ts
+++ b/src/vs/workbench/contrib/inlineChat/common/inlineChat.ts
@@ -240,7 +240,7 @@ Registry.as<IConfigurationRegistry>(Extensions.Configuration).registerConfigurat
 		},
 		'inlineChat.showToolbarIcon': {
 			description: localize('showToolbarIcon', "Controls whether the toolbar icon spawning the inline chat is enabled."),
-			default: true,
+			default: false,
 			type: 'boolean'
 		}
 	}


### PR DESCRIPTION
Turning off by default the `inlineChat.showToolbarIcon` setting