### PR TITLE
testing: some polish on coverage behavior

### DIFF
--- a/src/vs/base/common/event.ts
+++ b/src/vs/base/common/event.ts
@@ -708,7 +708,7 @@ export namespace Event {
 	 * Each listener is attached to the observable directly.
 	 */
 	export function fromObservableLight(observable: IObservable<any>): Event<void> {
-		return (listener) => {
+		return (listener, thisArgs, disposables) => {
 			let count = 0;
 			let didChange = false;
 			const observer: IObserver = {
@@ -721,7 +721,7 @@ export namespace Event {
 						observable.reportChanges();
 						if (didChange) {
 							didChange = false;
-							listener();
+							listener.call(thisArgs);
 						}
 					}
 				},
@@ -734,11 +734,19 @@ export namespace Event {
 			};
 			observable.addObserver(observer);
 			observable.reportChanges();
-			return {
+			const disposable = {
 				dispose() {
 					observable.removeObserver(observer);
 				}
 			};
+
+			if (disposables instanceof DisposableStore) {
+				disposables.add(disposable);
+			} else if (Array.isArray(disposables)) {
+				disposables.push(disposable);
+			}
+
+			return disposable;
 		};
 	}
 }

--- a/src/vs/workbench/api/browser/mainThreadTesting.ts
+++ b/src/vs/workbench/api/browser/mainThreadTesting.ts
@@ -131,7 +131,7 @@ export class MainThreadTesting extends Disposable implements MainThreadTestingSh
 				return;
 			}
 
-			const fn = available ? ((token: CancellationToken) => TestCoverage.load({
+			const fn = available ? ((token: CancellationToken) => TestCoverage.load(taskId, {
 				provideFileCoverage: async token => await this.proxy.$provideFileCoverage(runId, taskId, token)
 					.then(c => c.map(IFileCoverage.deserialize)),
 				resolveFileCoverage: (i, token) => this.proxy.$resolveFileCoverage(runId, taskId, i, token)

--- a/src/vs/workbench/contrib/testing/browser/testCoverageBars.ts
+++ b/src/vs/workbench/contrib/testing/browser/testCoverageBars.ts
@@ -8,7 +8,7 @@ import { assertNever } from 'vs/base/common/assert';
 import { IMarkdownString, MarkdownString } from 'vs/base/common/htmlContent';
 import { Lazy } from 'vs/base/common/lazy';
 import { Disposable, DisposableStore, toDisposable } from 'vs/base/common/lifecycle';
-import { ITransaction, autorun, observableValue } from 'vs/base/common/observable';
+import { ITransaction, autorun, observableFromEvent, observableValue } from 'vs/base/common/observable';
 import { isDefined } from 'vs/base/common/types';
 import { URI } from 'vs/base/common/uri';
 import { localize } from 'vs/nls';
@@ -212,10 +212,13 @@ export class ExplorerTestCoverageBars extends ManagedTestCoverageBars implements
 	) {
 		super(options, hoverService, configurationService);
 
+		const isEnabled = observableFromEvent(configurationService.onDidChangeConfiguration, () =>
+			getTestingConfiguration(configurationService, TestingConfigKeys.ShowCoverageInExplorer));
+
 		this._register(autorun(async reader => {
 			let info: AbstractFileCoverage | undefined;
 			const coverage = testCoverageService.selected.read(reader);
-			if (coverage) {
+			if (coverage && isEnabled.read(reader)) {
 				const resource = this.resource.read(reader);
 				if (resource) {
 					info = coverage.getComputedForUri(resource);

--- a/src/vs/workbench/contrib/testing/browser/testExplorerActions.ts
+++ b/src/vs/workbench/contrib/testing/browser/testExplorerActions.ts
@@ -23,6 +23,7 @@ import { KeybindingWeight } from 'vs/platform/keybinding/common/keybindingsRegis
 import { INotificationService } from 'vs/platform/notification/common/notification';
 import { IProgressService, ProgressLocation } from 'vs/platform/progress/common/progress';
 import { IQuickInputService, IQuickPickItem, IQuickPickSeparator } from 'vs/platform/quickinput/common/quickInput';
+import { widgetClose } from 'vs/platform/theme/common/iconRegistry';
 import { IUriIdentityService } from 'vs/platform/uriIdentity/common/uriIdentity';
 import { ViewAction } from 'vs/workbench/browser/parts/views/viewPane';
 import { FocusedViewContext } from 'vs/workbench/common/contextkeys';
@@ -34,6 +35,7 @@ import { TestingExplorerView } from 'vs/workbench/contrib/testing/browser/testin
 import { TestResultsView } from 'vs/workbench/contrib/testing/browser/testingOutputPeek';
 import { TestingConfigKeys, getTestingConfiguration } from 'vs/workbench/contrib/testing/common/configuration';
 import { TestCommandId, TestExplorerViewMode, TestExplorerViewSorting, Testing, testConfigurationGroupNames } from 'vs/workbench/contrib/testing/common/constants';
+import { ITestCoverageService } from 'vs/workbench/contrib/testing/common/testCoverageService';
 import { TestId } from 'vs/workbench/contrib/testing/common/testId';
 import { ITestProfileService, canUseProfileWithTest } from 'vs/workbench/contrib/testing/common/testProfileService';
 import { ITestResult } from 'vs/workbench/contrib/testing/common/testResult';
@@ -1448,6 +1450,26 @@ export class CancelTestRefreshAction extends Action2 {
 	}
 }
 
+export class TestCoverageClose extends Action2 {
+	constructor() {
+		super({
+			id: TestCommandId.CoverageClose,
+			title: { value: localize('testing.closeCoverage', "Close Coverage"), original: 'Close Coverage' },
+			icon: widgetClose,
+			menu: {
+				id: MenuId.ViewTitle,
+				group: 'navigation',
+				order: ActionOrder.Refresh,
+				when: ContextKeyExpr.equals('view', Testing.CoverageViewId)
+			}
+		});
+	}
+
+	public override run(accessor: ServicesAccessor) {
+		accessor.get(ITestCoverageService).closeCoverage();
+	}
+}
+
 export const allTestActions = [
 	CancelTestRefreshAction,
 	CancelTestRunAction,
@@ -1482,6 +1504,7 @@ export const allTestActions = [
 	ShowMostRecentOutputAction,
 	StartContinuousRunAction,
 	StopContinuousRunAction,
+	TestCoverageClose,
 	TestingSortByDurationAction,
 	TestingSortByLocationAction,
 	TestingSortByStatusAction,

--- a/src/vs/workbench/contrib/testing/common/configuration.ts
+++ b/src/vs/workbench/contrib/testing/common/configuration.ts
@@ -20,6 +20,7 @@ export const enum TestingConfigKeys {
 	CountBadge = 'testing.countBadge',
 	ShowAllMessages = 'testing.showAllMessages',
 	CoveragePercent = 'testing.displayedCoveragePercent',
+	ShowCoverageInExplorer = 'testing.showCoverageInExplorer',
 }
 
 export const enum AutoOpenTesting {
@@ -156,6 +157,11 @@ export const testingConfiguration: IConfigurationNode = {
 			type: 'boolean',
 			default: false,
 		},
+		[TestingConfigKeys.ShowCoverageInExplorer]: {
+			description: localize('testing.ShowCoverageInExplorer', "Whether test coverage should be down in the File Explorer view."),
+			type: 'boolean',
+			default: true,
+		},
 		[TestingConfigKeys.CoveragePercent]: {
 			markdownDescription: localize('testing.displayedCoveragePercent', "Configures what percentage is displayed by default for test coverage."),
 			default: TestingDisplayedCoveragePercent.TotalCoverage,
@@ -186,6 +192,7 @@ export interface ITestingConfiguration {
 	[TestingConfigKeys.AlwaysRevealTestOnStateChange]: boolean;
 	[TestingConfigKeys.ShowAllMessages]: boolean;
 	[TestingConfigKeys.CoveragePercent]: TestingDisplayedCoveragePercent;
+	[TestingConfigKeys.ShowCoverageInExplorer]: boolean;
 }
 
 export const getTestingConfiguration = <K extends TestingConfigKeys>(config: IConfigurationService, key: K) => config.getValue<ITestingConfiguration[K]>(key);

--- a/src/vs/workbench/contrib/testing/common/constants.ts
+++ b/src/vs/workbench/contrib/testing/common/constants.ts
@@ -58,6 +58,7 @@ export const enum TestCommandId {
 	CollapseAllAction = 'testing.collapseAll',
 	ConfigureTestProfilesAction = 'testing.configureProfile',
 	ContinousRunUsingForTest = 'testing.continuousRunUsingForTest',
+	CoverageClose = 'testing.coverage.close',
 	DebugAction = 'testing.debug',
 	DebugAllAction = 'testing.debugAll',
 	DebugAtCursor = 'testing.debugAtCursor',

--- a/src/vs/workbench/contrib/testing/common/testCoverage.ts
+++ b/src/vs/workbench/contrib/testing/common/testCoverage.ts
@@ -20,13 +20,13 @@ export interface ICoverageAccessor {
 export class TestCoverage {
 	private _tree?: WellDefinedPrefixTree<ComputedFileCoverage>;
 
-	public static async load(accessor: ICoverageAccessor, token: CancellationToken) {
+	public static async load(taskId: string, accessor: ICoverageAccessor, token: CancellationToken) {
 		const files = await accessor.provideFileCoverage(token);
 		const map = new ResourceMap<FileCoverage>();
 		for (const [i, file] of files.entries()) {
 			map.set(file.uri, new FileCoverage(file, i, accessor));
 		}
-		return new TestCoverage(map);
+		return new TestCoverage(taskId, map);
 	}
 
 	public get tree() {
@@ -34,6 +34,7 @@ export class TestCoverage {
 	}
 
 	constructor(
+		public readonly fromTaskId: string,
 		private readonly fileCoverage: ResourceMap<FileCoverage>,
 	) { }
 

--- a/src/vs/workbench/contrib/testing/test/common/testResultService.test.ts
+++ b/src/vs/workbench/contrib/testing/test/common/testResultService.test.ts
@@ -208,7 +208,11 @@ suite('Workbench - Test Results Service', () => {
 
 		setup(() => {
 			storage = ds.add(new InMemoryResultStorage(ds.add(new TestStorageService()), new NullLogService()));
-			results = ds.add(new TestTestResultService(new MockContextKeyService(), storage, ds.add(new TestProfileService(new MockContextKeyService(), ds.add(new TestStorageService())))));
+			results = ds.add(new TestTestResultService(
+				new MockContextKeyService(),
+				storage,
+				ds.add(new TestProfileService(new MockContextKeyService(), ds.add(new TestStorageService()))),
+			));
 		});
 
 		test('pushes new result', () => {


### PR DESCRIPTION
- Automatically open coverage when it's available, close it if results
  are cleared
- Make display in the explorer configurable
- Allow dismissing coverage from the Test Results view and via a
  navigation action in the coverage view.
- Fix display of compressed elements in test results view.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
