### PR TITLE
preferred_username should be... preferred

### DIFF
--- a/extensions/microsoft-authentication/src/AADHelper.ts
+++ b/extensions/microsoft-authentication/src/AADHelper.ts
@@ -536,7 +536,7 @@ export class AzureActiveDirectoryService {
 			scope: scopeData.scopeStr,
 			sessionId,
 			account: {
-				label: claims.email ?? claims.preferred_username ?? claims.unique_name ?? 'user@example.com',
+				label: claims.preferred_username ?? claims.email ?? claims.unique_name ?? 'user@example.com',
 				id,
 				type: claims.tid === MSA_TID || claims.tid === MSA_PASSTHRU_TID ? MicrosoftAccountType.MSA : MicrosoftAccountType.AAD
 			}


### PR DESCRIPTION
Apparently it's possible for preferred_username to be like `foo@mybiz.com` while `email` is set to `foo@mybizemail.com` but you'd want the preferred username to be displayed here... This is the more correct ordering.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
