### PR TITLE
macos - restore ability to reveal any path segment in os from titlebar context menu

### DIFF
--- a/src/vs/platform/actions/common/actions.ts
+++ b/src/vs/platform/actions/common/actions.ts
@@ -126,7 +126,6 @@ export class MenuId {
 	static readonly TestPeekTitle = new MenuId('TestPeekTitle');
 	static readonly TouchBarContext = new MenuId('TouchBarContext');
 	static readonly TitleBarContext = new MenuId('TitleBarContext');
-	static readonly TitleBarTitleContext = new MenuId('TitleBarTitleContext');
 	static readonly TunnelContext = new MenuId('TunnelContext');
 	static readonly TunnelPrivacy = new MenuId('TunnelPrivacy');
 	static readonly TunnelProtocol = new MenuId('TunnelProtocol');

--- a/src/vs/workbench/browser/actions/layoutActions.ts
+++ b/src/vs/workbench/browser/actions/layoutActions.ts
@@ -765,6 +765,7 @@ if (isWindows || isLinux || isWeb) {
 			title: localize('miMenuBarNoMnemonic', "Menu Bar"),
 			toggled: ContextKeyExpr.and(IsMacNativeContext.toNegated(), ContextKeyExpr.notEquals('config.window.menuBarVisibility', 'hidden'), ContextKeyExpr.notEquals('config.window.menuBarVisibility', 'toggle'), ContextKeyExpr.notEquals('config.window.menuBarVisibility', 'compact'))
 		},
+		group: '2_config',
 		when: IsAuxiliaryWindowFocusedContext.toNegated(),
 		order: 0
 	});

--- a/src/vs/workbench/browser/parts/titlebar/titlebarActions.ts
+++ b/src/vs/workbench/browser/parts/titlebar/titlebarActions.ts
@@ -24,7 +24,8 @@ class ToggleConfigAction extends Action2 {
 			menu: {
 				id: MenuId.TitleBarContext,
 				when: mainWindowOnly ? IsAuxiliaryWindowFocusedContext.toNegated() : undefined,
-				order
+				order,
+				group: '2_config'
 			}
 		});
 	}
@@ -55,7 +56,7 @@ registerAction2(class ToggleEditorActions extends Action2 {
 			id: `toggle.${ToggleEditorActions.settingsID}`,
 			title: localize('toggle.editorActions', 'Editor Actions'),
 			toggled: ContextKeyExpr.equals(`config.${ToggleEditorActions.settingsID}`, 'hidden').negate(),
-			menu: { id: MenuId.TitleBarContext, order: 3, when: ContextKeyExpr.equals(`config.workbench.editor.showTabs`, 'none') }
+			menu: { id: MenuId.TitleBarContext, order: 3, when: ContextKeyExpr.equals(`config.workbench.editor.showTabs`, 'none'), group: '2_config' }
 		});
 	}
 

--- a/src/vs/workbench/browser/parts/titlebar/titlebarPart.ts
+++ b/src/vs/workbench/browser/parts/titlebar/titlebarPart.ts
@@ -418,7 +418,7 @@ export class BrowserTitlebarPart extends Part implements ITitlebarPart {
 				if (e.type === EventType.CONTEXT_MENU || (e.target === this.title && e.metaKey)) {
 					EventHelper.stop(e);
 
-					this.onContextMenu(e, e.target === this.title ? MenuId.TitleBarTitleContext : MenuId.TitleBarContext);
+					this.onContextMenu(e, MenuId.TitleBarContext);
 				}
 			}));
 		});

--- a/src/vs/workbench/electron-sandbox/window.ts
+++ b/src/vs/workbench/electron-sandbox/window.ts
@@ -660,7 +660,11 @@ export class NativeWindow extends BaseWindow {
 
 			const commandId = `workbench.action.revealPathInFinder${i}`;
 			this.customTitleContextMenuDisposable.add(CommandsRegistry.registerCommand(commandId, () => this.nativeHostService.showItemInFolder(path.fsPath)));
-			this.customTitleContextMenuDisposable.add(MenuRegistry.appendMenuItem(MenuId.TitleBarTitleContext, { command: { id: commandId, title: label || posix.sep }, order: -i }));
+			this.customTitleContextMenuDisposable.add(MenuRegistry.appendMenuItem(MenuId.TitleBarContext, {
+				command: { id: commandId, title: label || posix.sep },
+				order: -i,
+				group: '1_file'
+			}));
 		}
 	}
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
