### PR TITLE
Decreasing the opacity of the code action menu sparkle icon

### DIFF
--- a/build/lib/stylelint/vscode-known-variables.json
+++ b/build/lib/stylelint/vscode-known-variables.json
@@ -241,6 +241,7 @@
 		"--vscode-editorInlayHint-typeBackground",
 		"--vscode-editorInlayHint-typeForeground",
 		"--vscode-editorLightBulb-foreground",
+		"--vscode-editorLightBulbAi-foreground",
 		"--vscode-editorLightBulbAutoFix-foreground",
 		"--vscode-editorLineNumber-activeForeground",
 		"--vscode-editorLineNumber-dimmedForeground",

--- a/src/vs/editor/contrib/codeAction/browser/lightBulbWidget.css
+++ b/src/vs/editor/contrib/codeAction/browser/lightBulbWidget.css
@@ -24,8 +24,7 @@
 }
 
 .monaco-editor .lightBulbWidget.codicon-sparkle-filled {
-	color: var(--vscode-icon-foreground);
-	opacity: 0.5;
+	color: var(--vscode-editorLightBulbAi-foreground, var(--vscode-icon-foreground));
 }
 
 .monaco-editor .lightBulbWidget:before {

--- a/src/vs/editor/contrib/codeAction/browser/lightBulbWidget.css
+++ b/src/vs/editor/contrib/codeAction/browser/lightBulbWidget.css
@@ -23,6 +23,11 @@
 	color: var(--vscode-editorLightBulbAutoFix-foreground, var(--vscode-editorLightBulb-foreground));
 }
 
+.monaco-editor .lightBulbWidget.codicon-sparkle-filled {
+	color: var(--vscode-icon-foreground);
+	opacity: 0.5;
+}
+
 .monaco-editor .lightBulbWidget:before {
 	position: relative;
 	z-index: 2;

--- a/src/vs/platform/theme/common/colorRegistry.ts
+++ b/src/vs/platform/theme/common/colorRegistry.ts
@@ -400,6 +400,7 @@ export const editorInlayHintParameterBackground = registerColor('editorInlayHint
  */
 export const editorLightBulbForeground = registerColor('editorLightBulb.foreground', { dark: '#FFCC00', light: '#DDB100', hcDark: '#FFCC00', hcLight: '#007ACC' }, nls.localize('editorLightBulbForeground', "The color used for the lightbulb actions icon."));
 export const editorLightBulbAutoFixForeground = registerColor('editorLightBulbAutoFix.foreground', { dark: '#75BEFF', light: '#007ACC', hcDark: '#75BEFF', hcLight: '#007ACC' }, nls.localize('editorLightBulbAutoFixForeground', "The color used for the lightbulb auto fix actions icon."));
+export const editorLightBulbAiForeground = registerColor('editorLightBulbAi.foreground', { dark: darken(iconForeground, 0.4), light: lighten(iconForeground, 1.7), hcDark: iconForeground, hcLight: iconForeground }, nls.localize('editorLightBulbAiForeground', "The color used for the lightbulb AI icon."));
 
 /**
  * Diff Editor Colors


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/199528