### PR TITLE
SCM - tree.updateChildren workaround

### DIFF
--- a/src/vs/workbench/contrib/scm/browser/scmViewPane.ts
+++ b/src/vs/workbench/contrib/scm/browser/scmViewPane.ts
@@ -3099,10 +3099,12 @@ export class SCMViewPane extends ViewPane {
 
 			if (element && this.tree.hasNode(element)) {
 				// Refresh specific repository
-				await this.tree.updateChildren(element);
+				// Use recursive = false so that collapseByDefault is called in setChildren
+				await this.tree.updateChildren(element, false);
 			} else {
 				// Refresh the entire tree
-				await this.tree.updateChildren();
+				// Use recursive = false so that collapseByDefault is called in setChildren
+				await this.tree.updateChildren(undefined, false);
 			}
 
 			if (focusedInput) {


### PR DESCRIPTION
Pass `recursive = false` to `updateChildren()` as a workaround so that `collpaseByDefault()` gets called when the tree is being updated. 