### PR TITLE
Fix quick fixes on Windows

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/quickFix/browser/quickFixAddon.ts
+++ b/src/vs/workbench/contrib/terminalContrib/quickFix/browser/quickFixAddon.ts
@@ -189,14 +189,6 @@ export class TerminalQuickFixAddon extends Disposable implements ITerminalAddon,
 			this._disposeQuickFix(this._lastQuickFixId, false);
 		}
 
-
-		// Wait for the next command to start to ensure the quick fix marker is created on the next
-		// prompt line
-		const commandDetection = this._capabilities.get(TerminalCapability.CommandDetection);
-		if (commandDetection) {
-			await Event.toPromise(commandDetection.onCommandStarted);
-		}
-
 		const resolver = async (selector: ITerminalQuickFixOptions, lines?: string[]) => {
 			if (lines === undefined) {
 				return undefined;


### PR DESCRIPTION
Now the command finished event will fire right before command started which means we don't need this extra await anymore.

Fixes #199448
