### PR TITLE
Multi-diff editor: add `Expand All Diffs` action

### DIFF
--- a/src/vs/editor/browser/widget/multiDiffEditorWidget/multiDiffEditorViewModel.ts
+++ b/src/vs/editor/browser/widget/multiDiffEditorWidget/multiDiffEditorViewModel.ts
@@ -35,6 +35,14 @@ export class MultiDiffEditorViewModel extends Disposable {
 		});
 	}
 
+	public expandAll(): void {
+		transaction(tx => {
+			for (const d of this.items.get()) {
+				d.collapsed.set(false, tx);
+			}
+		});
+	}
+
 	constructor(
 		private readonly _model: IMultiDiffEditorModel,
 		private readonly _instantiationService: IInstantiationService,

--- a/src/vs/editor/browser/widget/multiDiffEditorWidget/multiDiffEditorWidgetImpl.ts
+++ b/src/vs/editor/browser/widget/multiDiffEditorWidget/multiDiffEditorWidgetImpl.ts
@@ -99,6 +99,15 @@ export class MultiDiffEditorWidgetImpl extends Disposable {
 
 		this._contextKeyService.createKey(EditorContextKeys.inMultiDiffEditor.key, true);
 
+		const ctxAllCollapsed = this._parentContextKeyService.createKey<boolean>(EditorContextKeys.multiDiffEditorAllCollapsed.key, false);
+		this._register(autorun((reader) => {
+			const viewModel = this._viewModel.read(reader);
+			if (viewModel) {
+				const allCollapsed = viewModel.items.read(reader).every(item => item.collapsed.read(reader));
+				ctxAllCollapsed.set(allCollapsed);
+			}
+		}));
+
 		this._register(autorun((reader) => {
 			const lastActiveDiffItem = this.lastActiveDiffItem.read(reader);
 			transaction(tx => {

--- a/src/vs/editor/common/editorContextKeys.ts
+++ b/src/vs/editor/common/editorContextKeys.ts
@@ -28,6 +28,7 @@ export namespace EditorContextKeys {
 	export const inDiffEditor = new RawContextKey<boolean>('inDiffEditor', false, nls.localize('inDiffEditor', "Whether the context is a diff editor"));
 	export const isEmbeddedDiffEditor = new RawContextKey<boolean>('isEmbeddedDiffEditor', false, nls.localize('isEmbeddedDiffEditor', "Whether the context is an embedded diff editor"));
 	export const inMultiDiffEditor = new RawContextKey<boolean>('inMultiDiffEditor', false, nls.localize('inMultiDiffEditor', "Whether the context is a multi diff editor"));
+	export const multiDiffEditorAllCollapsed = new RawContextKey<boolean>('multiDiffEditorAllCollapsed', undefined, nls.localize('multiDiffEditorAllCollapsed', "Whether all files in multi diff editor are collapsed"));
 	export const hasChanges = new RawContextKey<boolean>('diffEditorHasChanges', false, nls.localize('diffEditorHasChanges', "Whether the diff editor has changes"));
 
 	export const comparingMovedCode = new RawContextKey<boolean>('comparingMovedCode', false, nls.localize('comparingMovedCode', "Whether a moved code block is selected for comparison"));

--- a/src/vs/workbench/contrib/multiDiffEditor/browser/multiDiffEditor.contribution.ts
+++ b/src/vs/workbench/contrib/multiDiffEditor/browser/multiDiffEditor.contribution.ts
@@ -135,12 +135,13 @@ export class CollapseAllAction extends Action2 {
 			id: 'multiDiffEditor.collapseAll',
 			title: { value: localize('collapseAllDiffs', "Collapse All Diffs"), original: 'Collapse All Diffs' },
 			icon: Codicon.collapseAll,
-			precondition: ContextKeyExpr.equals('activeEditor', MultiDiffEditor.ID),
+			precondition: ContextKeyExpr.and(ContextKeyExpr.equals('activeEditor', MultiDiffEditor.ID), ContextKeyExpr.not('multiDiffEditorAllCollapsed')),
 			menu: {
-				when: ContextKeyExpr.equals('activeEditor', MultiDiffEditor.ID),
+				when: ContextKeyExpr.and(ContextKeyExpr.equals('activeEditor', MultiDiffEditor.ID), ContextKeyExpr.not('multiDiffEditorAllCollapsed')),
 				id: MenuId.EditorTitle,
 				group: 'navigation',
 			},
+			f1: true,
 		});
 	}
 
@@ -155,8 +156,36 @@ export class CollapseAllAction extends Action2 {
 	}
 }
 
+export class ExpandAllAction extends Action2 {
+	constructor() {
+		super({
+			id: 'multiDiffEditor.expandAll',
+			title: { value: localize('ExpandAllDiffs', "Expand All Diffs"), original: 'Expand All Diffs' },
+			icon: Codicon.expandAll,
+			precondition: ContextKeyExpr.and(ContextKeyExpr.equals('activeEditor', MultiDiffEditor.ID), ContextKeyExpr.has('multiDiffEditorAllCollapsed')),
+			menu: {
+				when: ContextKeyExpr.and(ContextKeyExpr.equals('activeEditor', MultiDiffEditor.ID), ContextKeyExpr.has('multiDiffEditorAllCollapsed')),
+				id: MenuId.EditorTitle,
+				group: 'navigation',
+			},
+			f1: true,
+		});
+	}
+
+	async run(accessor: ServicesAccessor, ...args: any[]): Promise<void> {
+		const editorService = accessor.get(IEditorService);
+		const activeEditor = editorService.activeEditor;
+
+		if (activeEditor instanceof MultiDiffEditorInput) {
+			const viewModel = await activeEditor.getViewModel();
+			viewModel.expandAll();
+		}
+	}
+}
+
 registerAction2(GoToFileAction);
 registerAction2(CollapseAllAction);
+registerAction2(ExpandAllAction);
 
 Registry.as<IConfigurationRegistry>(Extensions.Configuration).registerConfiguration({
 	properties: {


### PR DESCRIPTION
This PR closes #199598.

When all files in a multi-diff editor have been collapsed the `Collapse All Diffs` action button is replaced by an `Expand All Diffs` one.