### PR TITLE
# Fix dropping of partialAccepts

### DIFF
--- a/src/vs/editor/contrib/inlineCompletions/browser/inlineCompletionsModel.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/inlineCompletionsModel.ts
@@ -301,7 +301,7 @@ export class InlineCompletionsModel extends Disposable {
 					...completion.additionalTextEdits
 				]
 			);
-			editor.setPosition(completion.snippetInfo.range.getStartPosition());
+			editor.setPosition(completion.snippetInfo.range.getStartPosition(), 'inlineCompletionAccept');
 			SnippetController2.get(editor)?.insert(completion.snippetInfo.snippet, { undoStopBefore: false });
 		} else {
 			editor.executeEdits(
@@ -413,7 +413,7 @@ export class InlineCompletionsModel extends Disposable {
 					EditOperation.replace(Range.fromPositions(position), partialText),
 				]);
 				const length = lengthOfText(partialText);
-				editor.setPosition(addPositions(position, length));
+				editor.setPosition(addPositions(position, length), 'inlineCompletionPartialAccept');
 			} finally {
 				this._isAcceptingPartially = false;
 			}


### PR DESCRIPTION
# PartialAcceptances auto clear completions

[repro in monaco env](https://microsoft.github.io/monaco-editor/playground.html?source=v0.45.0-dev-20231013#XQAAAAKjFQAAAAAAAABBqQkHQ5NjdMjwa-jY7SIQ9S7DNlzs5W-mwj0fe1ZCDRFc9ws9XQE0SJE1jc2VKxhaLFIw9vEWSxW3yscxjluBbJuetpg8d5BCIdogK6CBmgyKHIOVjH6uO-oA-RA-rcpQdGBlgwMT7NDeGjyzFiPQvQI6_Y6V1lQAJzGNzCTB341dSrjn82lURgM-qiuCD7PCE6MkpqgB5y9h3ll72DQ4_CRftgkoCxKvWWuvsuMBuXu3LsYGT_1PgKRhLj7Gm0v7dSVe6TH6Px1zeefXavJG24A83Ud-yGDPZpOu8f6raa1WvxeRa1X2sporsXMY8pkLmqPJqXNIPEg7sYkud9matrXdYhmSzasgVhNJf4P7BVTkODedW_2dIf5HX98C0orDp4Aoy9w1WDa6AYZzrMmTT_4L8cIHiVpEbGix2M8TmYBP8V7jcx3mIU85WSd9kNCM1svxFjAe77OScaSINAmXz3A2PDf0DkCdP3pxGGypMd1OkfxBk0yrjWRWZZ-RM8f4rYSyrPGfWPwUHM4-iluvT9VKYsGDC188P1BTIWCxiiHhQFhOrMyBK9NLtx8hT-Jjk7s3MjVWZ9eLD_RNSytB73wadIUf1AkPC9T2YKbz-TGETujulqLm5T3efNqExRfmjtIKik0c94E6g9_ZIL895IPAJtvSD35UX8E-o0k9wJ467pkIXENteLQcmq8MnAyhd2tRgFq1TIGZFdQqHCGKq0xC_rwi8Twu2dSjB-PFVNaWDNSiNssAAbsCc3PKpMI3fHjyMJ1pDbnYvZk2ZfNB2WI9PKJu1a5VSbR2X2noa8MhQKgpelV5i1SRME_GPpggHB3p4_5J3VSEo1MqUL0p4UvKU3UCNKYd6p_D1H_HItFDkTxPn_iUmcBD8iQbrFQEvaxX5sONB9qJo1W2JIG3nIxgZd6OSm2wD8UGTB6iO0OInuN2Vxy3sxQpBGjkUAwl5OTR_yJcWpbkLoWzlMKIKE8Y4K5Zp2GfGbH6PxUsGbkcn_tfkW9TyDCOSoKIXkybjZ343n8CIGM0jpUO7lakSCO7eOixk-hRlybv_lmigRGUwhbchxw9M6oUYNHqj4Dr10qac2jNtqTX5QF0pyJu8RuY3aNhlzQX7RIqsT3EoVrv7UUkbqN6Qin6g-hMGSuycAAQ4ZDCh8e0aPrZBtKJ529CXEn3hcqTkqRbb4C6jlVluEx4JLFllhFXeUfSPyywiHpU9mMXxVLFC5Vg8dWQuHLV64g74Oj-3t4izgpaPuX_zgWWtR4EiYA9ILBVMb_s6i8OT_-ineSVE1vM0n8Av-U6bJuLr-En4H8v_MtJdxJnHmXV5vyHsIO_SWWt6iubEKZ3FyZNoioZ2ssCJA9PI93o0cHK0A13dYJHY4Uquk5UjPKFxS8EJfF80xEJII2Tio6gsKRz2A-MF7z7fgupr2QELIQgGiJX0Td7J0EIQwGT3BFQxMLliAxWfXfTk6bJ3weTAI2GhAbrSMCkCvnTMMTWQa-2lyNWO4SsaasrZzG1oer5SoDG_9YQmDr32Uv8EhauWI2g5vZAPAKaFm7qXLQzJSmGFELuUKfGna7I1fUrxZ3295Z21xv0bt3t_WUfdpoRy_XpOpxGH90pXtgWtyTOZqatqg9_Wrtqehp1OaVd3hMp2_QOpB6evAxbKJqNya_NfWs0flBFGpH4aaVUp0NPDcVxy1wLmdTae-BFyWKnReww7JTUoRFBGo6wkZFY7b0TssqYC6hGMnT45nLrMPDKY7vPo4MIEbrzsNsqOI3GleKlBjRkyKydrxgZ8C2bhFIAQKT3ctK77yp10MaEDzErq1EkI9ecH9WUr1E1ihpfRdIfbI8Ip5hv4lqGDrzOlvXFFk72TG8WaDu7uUpNHmG_HsuGdR6tGAAfoxMDA0CXxjQ9GoU7tEwlZ4CE7aJbQrJw8ZGJqrakwQ-rojYo4vl-a8clhSWLyaXMekP62ZjavWtanl-7H3i8MGmP_JFHWOV9cExDglomOwanWHVo-5r_dqXBTBZ_-kV8vx_px7VHocr-lM14GkzjjMeYNQJ-QNZyxv4i6AbHNayRLBHRwKxpnQK96ZC8rqu0QXn-Wc99Dso1e_mTq4rkhGwVurgLU0WntPaIzxZAbNTwJM7zbLv5fGdamQPJ00xcghEs7PwujyP8lV5R5G1-vsVrW-XonWpyOSnM2AoKBLXXcvHtkIE7OvoCEVOoMjdm0wdEmcMpdjSOe22S9nf9jKjv34IFq6t0wHFabNH8LO3TFOgt0KvOszXgRGYuSVIqMj624eP2iuc08uwSs1L0k4art-3rPClpJRm4p0z8PJ4DFMyiSOT5kjkXxzO6Um7oPU3wJplHj_x3StF7aawUaT9bxXq6lMZwFHa2L9n1RG02V3vX10FNRIr8yG5YjJpf7DnpxVOd6UinwrX8J2I7UQ3FKTVBo67jsjXK0BS1-TlhrGbf0SX37XHcykhhKDMgtEB9Rc0thFf9-oukj3ALUJPWm-3zYuB8yJr9pKwr_PVfHw)

TLDR: Issue with partially accepting characters that are already provided in the editor

Reproduction steps:
1. place cursor in given position -> def foo(ba<cursor>)
2. type r
3. try to partially accept completion (2x to get out of the def brackets)

Expected result:
the completion is persisted on screen as it was partially accepted and the prefix doesn't diverge

Actual result:
The completion is dropped.

Reasoning:
From my investigation this happens due to the explicit signal of cursor position change with type `api`. This is not the case while the user partially accepts completions, with only ghosted text (not yet in the editor).

Suggestion:
- provide more comprehensive reason for position change, which should signal this is partialAcceptance/Acceptance and is a user trigger, not neccesarily an `api` **OR** update the `onCursorChange` to not trigger `model.stop()` when partialAccept is in progress (The earlier proposal might help in understanding what actually changes the position and there do not seem to be existing `source === 'api'` bindings, so no part of the system should be impacted)
- To keep the interaction consistent we might want to also change the setPosition on Accept, as there is already explicit cleanup happening after the edits are executed.