### PR TITLE
Enable terminal sticky scroll by default in insiders

### DIFF
--- a/src/vs/workbench/contrib/terminal/common/terminalConfiguration.ts
+++ b/src/vs/workbench/contrib/terminal/common/terminalConfiguration.ts
@@ -627,7 +627,7 @@ const terminalConfiguration: IConfigurationNode = {
 			default: false
 		},
 		[TerminalSettingId.StickyScrollEnabled]: {
-			markdownDescription: localize('terminal.integrated.stickyScroll.enabled', "Experimental: Shows the current command at the top of the terminal."),
+			markdownDescription: localize('terminal.integrated.stickyScroll.enabled', "Shows the current command at the top of the terminal."),
 			type: 'boolean',
 			default: product.quality !== 'stable'
 		},

--- a/src/vs/workbench/contrib/terminal/common/terminalConfiguration.ts
+++ b/src/vs/workbench/contrib/terminal/common/terminalConfiguration.ts
@@ -11,6 +11,7 @@ import { isMacintosh, isWindows } from 'vs/base/common/platform';
 import { Registry } from 'vs/platform/registry/common/platform';
 import { Codicon } from 'vs/base/common/codicons';
 import { terminalColorSchema, terminalIconSchema } from 'vs/platform/terminal/common/terminalPlatformConfiguration';
+import product from 'vs/platform/product/common/product';
 
 const terminalDescriptors = '\n- ' + [
 	'`\${cwd}`: ' + localize("cwd", "the terminal's current working directory"),
@@ -628,7 +629,7 @@ const terminalConfiguration: IConfigurationNode = {
 		[TerminalSettingId.StickyScrollEnabled]: {
 			markdownDescription: localize('terminal.integrated.stickyScroll.enabled', "Experimental: Shows the current command at the top of the terminal."),
 			type: 'boolean',
-			default: false
+			default: product.quality !== 'stable'
 		},
 		[TerminalSettingId.StickyScrollMaxLineCount]: {
 			markdownDescription: localize('terminal.integrated.stickyScroll.maxLineCount', "Defines the maximum number of sticky lines to show. Sticky scroll lines will never exceed 40% of the viewport regardless of this setting."),


### PR DESCRIPTION
Fixes #199678
