### PR TITLE
Only show devMode markers on hover

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/developer/browser/media/developer.css
+++ b/src/vs/workbench/contrib/terminalContrib/developer/browser/media/developer.css
@@ -27,6 +27,10 @@
 
 .monaco-workbench .xterm.dev-mode .xterm-sequence-decoration {
 	background-color: var(--vscode-terminal-background, var(--vscode-panel-background));
+	display: none !important;
+}
+.monaco-workbench .xterm.dev-mode:hover .xterm-sequence-decoration {
+	display: block !important;
 }
 .monaco-workbench .xterm.dev-mode .xterm-sequence-decoration.left {
 	direction: rtl;


### PR DESCRIPTION
Fixes #199775
