### PR TITLE
fix: memory leak in color picker widget

### DIFF
--- a/src/vs/editor/contrib/colorPicker/browser/colorPickerWidget.ts
+++ b/src/vs/editor/contrib/colorPicker/browser/colorPickerWidget.ts
@@ -117,9 +117,9 @@ class CloseButton extends Disposable {
 
 		const closeButton = dom.append(innerDiv, $('.button' + ThemeIcon.asCSSSelector(registerIcon('color-picker-close', Codicon.close, localize('closeIcon', 'Icon to close the color picker')))));
 		closeButton.classList.add('close-icon');
-		this._button.onclick = () => {
+		this._register(dom.addDisposableListener(this._button, dom.EventType.CLICK, () => {
 			this._onClicked.fire();
-		};
+		}));
 	}
 }
 
@@ -455,9 +455,9 @@ export class InsertButton extends Disposable {
 		this._button = dom.append(container, document.createElement('button'));
 		this._button.classList.add('insert-button');
 		this._button.textContent = 'Insert';
-		this._button.onclick = e => {
+		this._register(dom.addDisposableListener(this._button, dom.EventType.CLICK, () => {
 			this._onClicked.fire();
-		};
+		}));
 	}
 
 	public get button(): HTMLElement {


### PR DESCRIPTION
Fixes #199814

### Output with `--measure event-listeners`

```json
{
  "eventListeners": [],
  "isLeak": false
}
```