### PR TITLE
Add syntax highlighting for `*.repo` files

### DIFF
--- a/extensions/ini/package.json
+++ b/extensions/ini/package.json
@@ -35,7 +35,8 @@
           ".gitattributes",
           ".gitconfig",
           ".gitmodules",
-          ".editorconfig"
+          ".editorconfig",
+          ".repo"
         ],
         "filenames": [
           "gitconfig",


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->


Add syntax highlighting for RPM `*.repo` files to the ini (properties) extension.

Sample file:
```ini
# https://packages.microsoft.com/config/opensuse/15/prod.repo

[packages-microsoft-com-prod]
name=packages-microsoft-com-prod
baseurl=https://packages.microsoft.com/opensuse/15/prod/
enabled=1
gpgcheck=1
gpgkey=https://packages.microsoft.com/keys/microsoft.asc
```

- https://github.com/microsoft/vscode/issues/197860
- https://developers.redhat.com/articles/2022/10/07/whats-inside-rpm-repo-file