### PR TITLE
debug: close read-only tabs on end debug session

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/debug.contribution.ts
+++ b/src/vs/workbench/contrib/debug/browser/debug.contribution.ts
@@ -439,6 +439,11 @@ configurationRegistry.registerConfiguration({
 			description: nls.localize({ comment: ['This is the description for a setting'], key: 'openExplorerOnEnd' }, "Automatically open the explorer view at the end of a debug session."),
 			default: false
 		},
+		'debug.closeReadonlyTabsOnEnd': {
+			type: 'boolean',
+			description: nls.localize({ comment: ['This is the description for a setting'], key: 'closeReadonlyTabsOnEnd' }, "At the end of a debug session, all the read-only tabs associated with that session will be closed"),
+			default: false
+		},
 		'debug.inlineValues': {
 			type: 'string',
 			'enum': ['on', 'off', 'auto'],

--- a/src/vs/workbench/contrib/debug/common/debug.ts
+++ b/src/vs/workbench/contrib/debug/common/debug.ts
@@ -686,6 +686,7 @@ export interface IDebugConfiguration {
 	extensionHostDebugAdapter: boolean;
 	enableAllHovers: boolean;
 	showSubSessionsInToolBar: boolean;
+	closeReadonlyTabsOnEnd: boolean;
 	console: {
 		fontSize: number;
 		fontFamily: string;


### PR DESCRIPTION
The issue: #197949.
The issue was that in a debugging session, user could open some read-only files from the test environment, but when the session ended, there was no need to the read-only tabs to stay open, since the user couldn't edit them and it causes frustration for them.
To test it, you can simply start a debug session and open some read-only files from that debugging environment, like the files in the LOADED_SCRIPTS section and end the session, all the tabs that are read only and opened from the debug context should be closed. 