### PR TITLE
remove theme participant

### DIFF
--- a/src/vs/workbench/contrib/interactive/browser/interactive.contribution.ts
+++ b/src/vs/workbench/contrib/interactive/browser/interactive.contribution.ts
@@ -34,8 +34,7 @@ import { IInstantiationService, ServicesAccessor } from 'vs/platform/instantiati
 import { KeybindingWeight } from 'vs/platform/keybinding/common/keybindingsRegistry';
 import { ILogService } from 'vs/platform/log/common/log';
 import { Registry } from 'vs/platform/registry/common/platform';
-import { contrastBorder, listInactiveSelectionBackground, registerColor, transparent } from 'vs/platform/theme/common/colorRegistry';
-import { registerThemingParticipant } from 'vs/platform/theme/common/themeService';
+import { contrastBorder, ifDefinedThenElse, listInactiveSelectionBackground, registerColor } from 'vs/platform/theme/common/colorRegistry';
 import { EditorPaneDescriptor, IEditorPaneRegistry } from 'vs/workbench/browser/editor';
 import { Extensions as WorkbenchExtensions, IWorkbenchContribution, IWorkbenchContributionsRegistry } from 'vs/workbench/common/contributions';
 import { EditorExtensions, EditorsOrder, IEditorFactoryRegistry, IEditorSerializer, IUntypedEditorInput } from 'vs/workbench/common/editor';
@@ -759,33 +758,20 @@ registerAction2(class extends Action2 {
 	}
 });
 
-registerThemingParticipant((theme) => {
-	registerColor('interactive.activeCodeBorder', {
-		dark: theme.getColor(peekViewBorder) ?? '#007acc',
-		light: theme.getColor(peekViewBorder) ?? '#007acc',
-		hcDark: contrastBorder,
-		hcLight: contrastBorder
-	}, localize('interactive.activeCodeBorder', 'The border color for the current interactive code cell when the editor has focus.'));
+registerColor('interactive.activeCodeBorder', {
+	dark: ifDefinedThenElse(peekViewBorder, peekViewBorder, '#007acc'),
+	light: ifDefinedThenElse(peekViewBorder, peekViewBorder, '#007acc'),
+	hcDark: contrastBorder,
+	hcLight: contrastBorder
+}, localize('interactive.activeCodeBorder', 'The border color for the current interactive code cell when the editor has focus.'));
 
-	// registerColor('interactive.activeCodeBackground', {
-	// 	dark: (theme.getColor(peekViewEditorBackground) ?? Color.fromHex('#001F33')).transparent(0.25),
-	// 	light: (theme.getColor(peekViewEditorBackground) ?? Color.fromHex('#F2F8FC')).transparent(0.25),
-	// 	hc: Color.black
-	// }, localize('interactive.activeCodeBackground', 'The background color for the current interactive code cell when the editor has focus.'));
-
-	registerColor('interactive.inactiveCodeBorder', {
-		dark: theme.getColor(listInactiveSelectionBackground) ?? transparent(listInactiveSelectionBackground, 1),
-		light: theme.getColor(listInactiveSelectionBackground) ?? transparent(listInactiveSelectionBackground, 1),
-		hcDark: PANEL_BORDER,
-		hcLight: PANEL_BORDER
-	}, localize('interactive.inactiveCodeBorder', 'The border color for the current interactive code cell when the editor does not have focus.'));
-
-	// registerColor('interactive.inactiveCodeBackground', {
-	// 	dark: (theme.getColor(peekViewResultsBackground) ?? Color.fromHex('#252526')).transparent(0.25),
-	// 	light: (theme.getColor(peekViewResultsBackground) ?? Color.fromHex('#F3F3F3')).transparent(0.25),
-	// 	hc: Color.black
-	// }, localize('interactive.inactiveCodeBackground', 'The backgorund color for the current interactive code cell when the editor does not have focus.'));
-});
+registerColor('interactive.inactiveCodeBorder', {
+	//dark: theme.getColor(listInactiveSelectionBackground) ?? transparent(listInactiveSelectionBackground, 1),
+	dark: ifDefinedThenElse(listInactiveSelectionBackground, listInactiveSelectionBackground, '#37373D'),
+	light: ifDefinedThenElse(listInactiveSelectionBackground, listInactiveSelectionBackground, '#E4E6F1'),
+	hcDark: PANEL_BORDER,
+	hcLight: PANEL_BORDER
+}, localize('interactive.inactiveCodeBorder', 'The border color for the current interactive code cell when the editor does not have focus.'));
 
 Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).registerConfiguration({
 	id: 'interactiveWindow',


### PR DESCRIPTION
fix https://github.com/microsoft/vscode/issues/197635

This will actually still use the themed colors for the fallback values, as it seems was originally intended.