### PR TITLE
only apply accessible view hint to hover when it is focused, not shown

### DIFF
--- a/src/vs/editor/contrib/hover/browser/contentHover.ts
+++ b/src/vs/editor/contrib/hover/browser/contentHover.ts
@@ -782,9 +782,9 @@ export class ContentHoverWidget extends ResizableContentWidget {
 			this._hover.containerDomNode.focus();
 		}
 		hoverData.colorPicker?.layout();
-
 		// The aria label overrides the label, so if we add to it, add the contents of the hover
-		const accessibleViewHint = getHoverAccessibleViewHint(this._configurationService.getValue('accessibility.verbosity.hover') === true && this._accessibilityService.isScreenReaderOptimized(), this._keybindingService.lookupKeybinding('editor.action.accessibleView')?.getAriaLabel() ?? '');
+		const hoverFocused = this._hover.containerDomNode.ownerDocument.activeElement === this._hover.containerDomNode;
+		const accessibleViewHint = hoverFocused && getHoverAccessibleViewHint(this._configurationService.getValue('accessibility.verbosity.hover') === true && this._accessibilityService.isScreenReaderOptimized(), this._keybindingService.lookupKeybinding('editor.action.accessibleView')?.getAriaLabel() ?? '');
 		if (accessibleViewHint) {
 			this._hover.contentsDomNode.ariaLabel = this._hover.contentsDomNode.textContent + ', ' + accessibleViewHint;
 		}

--- a/src/vs/workbench/services/hover/browser/hoverWidget.ts
+++ b/src/vs/workbench/services/hover/browser/hoverWidget.ts
@@ -302,7 +302,8 @@ export class HoverWidget extends Widget {
 
 	public render(container: HTMLElement): void {
 		container.appendChild(this._hoverContainer);
-		const accessibleViewHint = getHoverAccessibleViewHint(this._configurationService.getValue('accessibility.verbosity.hover') === true && this._accessibilityService.isScreenReaderOptimized(), this._keybindingService.lookupKeybinding('editor.action.accessibleView')?.getAriaLabel());
+		const hoverFocused = this._hoverContainer.contains(this._hoverContainer.ownerDocument.activeElement);
+		const accessibleViewHint = hoverFocused && getHoverAccessibleViewHint(this._configurationService.getValue('accessibility.verbosity.hover') === true && this._accessibilityService.isScreenReaderOptimized(), this._keybindingService.lookupKeybinding('editor.action.accessibleView')?.getAriaLabel());
 		if (accessibleViewHint) {
 
 			status(accessibleViewHint);


### PR DESCRIPTION
By design, we show but do not focus the tooltip of status bar/activity bar items so that screen readers don't have to deal with a focus change. 

On Windows, showing the tooltip still causes NVDA to detect a change in the live region. So, we have to check if the hover is focused to determine whether or not we should include the accessible view hint.

![image (20)](https://github.com/microsoft/vscode/assets/29464607/3def1634-b599-4f88-ac5c-5f2cf4de6aeb)

fix #199959