### PR TITLE
Added horizontal scrollbar to keybindings editor

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/keybindingsEditor.ts
+++ b/src/vs/workbench/contrib/preferences/browser/keybindingsEditor.ts
@@ -503,7 +503,7 @@ export class KeybindingsEditor extends EditorPane implements IKeybindingsEditorP
 			],
 			{
 				identityProvider: { getId: (e: IKeybindingItemEntry) => e.id },
-				horizontalScrolling: false,
+				horizontalScrolling: true,
 				accessibilityProvider: new AccessibilityProvider(this.configurationService),
 				keyboardNavigationLabelProvider: { getKeyboardNavigationLabel: (e: IKeybindingItemEntry) => e.keybindingItem.commandLabel || e.keybindingItem.command },
 				overrideStyles: {

--- a/src/vs/workbench/contrib/preferences/browser/media/keybindingsEditor.css
+++ b/src/vs/workbench/contrib/preferences/browser/media/keybindingsEditor.css
@@ -100,7 +100,7 @@
 .keybindings-editor > .keybindings-body > .keybindings-table-container .monaco-table-tr .monaco-table-td {
 	align-items: center;
 	display: flex;
-	overflow: hidden;
+	overflow: visible;
 }
 
 /** Actions column styling **/


### PR DESCRIPTION
Fixes [#192604](https://github.com/microsoft/vscode/issues/192604)
Added horizontal scrollbar to keybindings editor so that the full text of the 'source' column can be viewed. 