### PR TITLE
add `css.format.spaceAroundSelectorSeparator: true` to the workspace and add spacing around `>`

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -167,5 +167,6 @@
 	],
 	"[github-issues]": {
 		"editor.wordWrap": "on"
-	}
+	},
+	"css.format.spaceAroundSelectorSeparator": true,
 }

--- a/src/vs/base/browser/ui/iconLabel/iconlabel.css
+++ b/src/vs/base/browser/ui/iconLabel/iconlabel.css
@@ -51,7 +51,7 @@
 	opacity: 0.5;
 }
 
-.monaco-icon-label>.monaco-icon-label-container>.monaco-icon-suffix-container>.label-suffix {
+.monaco-icon-label > .monaco-icon-label-container > .monaco-icon-suffix-container > .label-suffix {
 	opacity: .7;
 	white-space: pre;
 }

--- a/src/vs/editor/contrib/codelens/browser/codelensWidget.css
+++ b/src/vs/editor/contrib/codelens/browser/codelensWidget.css
@@ -16,24 +16,24 @@
 	font-family: var(--vscode-editorCodeLens-fontFamily), var(--vscode-editorCodeLens-fontFamilyDefault);
 }
 
-.monaco-editor .codelens-decoration>span,
-.monaco-editor .codelens-decoration>a {
+.monaco-editor .codelens-decoration > span,
+.monaco-editor .codelens-decoration > a {
 	user-select: none;
 	-webkit-user-select: none;
 	white-space: nowrap;
 	vertical-align: sub;
 }
 
-.monaco-editor .codelens-decoration>a {
+.monaco-editor .codelens-decoration > a {
 	text-decoration: none;
 }
 
-.monaco-editor .codelens-decoration>a:hover {
+.monaco-editor .codelens-decoration > a:hover {
 	cursor: pointer;
 	color: var(--vscode-editorLink-activeForeground) !important;
 }
 
-.monaco-editor .codelens-decoration>a:hover .codicon {
+.monaco-editor .codelens-decoration > a:hover .codicon {
 	color: var(--vscode-editorLink-activeForeground) !important;
 }
 
@@ -45,7 +45,7 @@
 	font-size: var(--vscode-editorCodeLens-fontSize);
 }
 
-.monaco-editor .codelens-decoration>a:hover .codicon::before {
+.monaco-editor .codelens-decoration > a:hover .codicon::before {
 	cursor: pointer;
 }
 

--- a/src/vs/editor/contrib/suggest/browser/media/suggest.css
+++ b/src/vs/editor/contrib/suggest/browser/media/suggest.css
@@ -71,24 +71,24 @@
 	margin-right: 0.3em;
 }
 
-.monaco-editor .suggest-widget.with-status-bar .monaco-list .monaco-list-row>.contents>.main>.right>.readMore,
-.monaco-editor .suggest-widget.with-status-bar .monaco-list .monaco-list-row.focused.string-label>.contents>.main>.right>.readMore {
+.monaco-editor .suggest-widget.with-status-bar .monaco-list .monaco-list-row > .contents > .main > .right > .readMore,
+.monaco-editor .suggest-widget.with-status-bar .monaco-list .monaco-list-row.focused.string-label > .contents > .main > .right > .readMore {
 	display: none;
 }
 
-.monaco-editor .suggest-widget.with-status-bar:not(.docs-side) .monaco-list .monaco-list-row:hover>.contents>.main>.right.can-expand-details>.details-label {
+.monaco-editor .suggest-widget.with-status-bar:not(.docs-side) .monaco-list .monaco-list-row:hover > .contents > .main > .right.can-expand-details > .details-label {
 	width: 100%;
 }
 
 /* Styles for Message element for when widget is loading or is empty */
 
-.monaco-editor .suggest-widget>.message {
+.monaco-editor .suggest-widget > .message {
 	padding-left: 22px;
 }
 
 /** Styles for the list element **/
 
-.monaco-editor .suggest-widget>.tree {
+.monaco-editor .suggest-widget > .tree {
 	height: 100%;
 	width: 100%;
 }
@@ -120,14 +120,14 @@
 	color: var(--vscode-editorSuggestWidget-selectedIconForeground);
 }
 
-.monaco-editor .suggest-widget .monaco-list .monaco-list-row>.contents {
+.monaco-editor .suggest-widget .monaco-list .monaco-list-row > .contents {
 	flex: 1;
 	height: 100%;
 	overflow: hidden;
 	padding-left: 2px;
 }
 
-.monaco-editor .suggest-widget .monaco-list .monaco-list-row>.contents>.main {
+.monaco-editor .suggest-widget .monaco-list .monaco-list-row > .contents > .main {
 	display: flex;
 	overflow: hidden;
 	text-overflow: ellipsis;
@@ -135,12 +135,12 @@
 	justify-content: space-between;
 }
 
-.monaco-editor .suggest-widget .monaco-list .monaco-list-row>.contents>.main>.left,
-.monaco-editor .suggest-widget .monaco-list .monaco-list-row>.contents>.main>.right {
+.monaco-editor .suggest-widget .monaco-list .monaco-list-row > .contents > .main > .left,
+.monaco-editor .suggest-widget .monaco-list .monaco-list-row > .contents > .main > .right {
 	display: flex;
 }
 
-.monaco-editor .suggest-widget .monaco-list .monaco-list-row:not(.focused)>.contents>.main .monaco-icon-label {
+.monaco-editor .suggest-widget .monaco-list .monaco-list-row:not(.focused) > .contents > .main .monaco-icon-label {
 	color: var(--vscode-editorSuggestWidget-foreground);
 }
 
@@ -148,48 +148,48 @@
 	font-weight: bold;
 }
 
-.monaco-editor .suggest-widget .monaco-list .monaco-list-row>.contents>.main .monaco-highlighted-label .highlight {
+.monaco-editor .suggest-widget .monaco-list .monaco-list-row > .contents > .main .monaco-highlighted-label .highlight {
 	color: var(--vscode-editorSuggestWidget-highlightForeground);
 }
 
-.monaco-editor .suggest-widget .monaco-list .monaco-list-row.focused>.contents>.main .monaco-highlighted-label .highlight {
+.monaco-editor .suggest-widget .monaco-list .monaco-list-row.focused > .contents > .main .monaco-highlighted-label .highlight {
 	color: var(--vscode-editorSuggestWidget-focusHighlightForeground);
 }
 
 /** ReadMore Icon styles **/
 
-.monaco-editor .suggest-details>.monaco-scrollable-element>.body>.header>.codicon-close,
-.monaco-editor .suggest-widget .monaco-list .monaco-list-row>.contents>.main>.right>.readMore::before {
+.monaco-editor .suggest-details > .monaco-scrollable-element > .body > .header > .codicon-close,
+.monaco-editor .suggest-widget .monaco-list .monaco-list-row > .contents > .main > .right > .readMore::before {
 	color: inherit;
 	opacity: 1;
 	font-size: 14px;
 	cursor: pointer;
 }
 
-.monaco-editor .suggest-details>.monaco-scrollable-element>.body>.header>.codicon-close {
+.monaco-editor .suggest-details > .monaco-scrollable-element > .body > .header > .codicon-close {
 	position: absolute;
 	top: 6px;
 	right: 2px;
 }
 
-.monaco-editor .suggest-details>.monaco-scrollable-element>.body>.header>.codicon-close:hover,
-.monaco-editor .suggest-widget .monaco-list .monaco-list-row>.contents>.main>.right>.readMore:hover {
+.monaco-editor .suggest-details > .monaco-scrollable-element > .body > .header > .codicon-close:hover,
+.monaco-editor .suggest-widget .monaco-list .monaco-list-row > .contents > .main > .right > .readMore:hover {
 	opacity: 1;
 }
 
 /** signature, qualifier, type/details opacity **/
 
-.monaco-editor .suggest-widget .monaco-list .monaco-list-row>.contents>.main>.right>.details-label {
+.monaco-editor .suggest-widget .monaco-list .monaco-list-row > .contents > .main > .right > .details-label {
 	opacity: 0.7;
 }
 
-.monaco-editor .suggest-widget .monaco-list .monaco-list-row>.contents>.main>.left>.signature-label {
+.monaco-editor .suggest-widget .monaco-list .monaco-list-row > .contents > .main > .left > .signature-label {
 	overflow: hidden;
 	text-overflow: ellipsis;
 	opacity: 0.6;
 }
 
-.monaco-editor .suggest-widget .monaco-list .monaco-list-row>.contents>.main>.left>.qualifier-label {
+.monaco-editor .suggest-widget .monaco-list .monaco-list-row > .contents > .main > .left > .qualifier-label {
 	margin-left: 12px;
 	opacity: 0.4;
 	font-size: 85%;
@@ -201,7 +201,7 @@
 
 /** Type Info and icon next to the label in the focused completion item **/
 
-.monaco-editor .suggest-widget .monaco-list .monaco-list-row>.contents>.main>.right>.details-label {
+.monaco-editor .suggest-widget .monaco-list .monaco-list-row > .contents > .main > .right > .details-label {
 	font-size: 85%;
 	margin-left: 1.1em;
 	overflow: hidden;
@@ -209,58 +209,58 @@
 	white-space: nowrap;
 }
 
-.monaco-editor .suggest-widget .monaco-list .monaco-list-row>.contents>.main>.right>.details-label>.monaco-tokenized-source {
+.monaco-editor .suggest-widget .monaco-list .monaco-list-row > .contents > .main > .right > .details-label > .monaco-tokenized-source {
 	display: inline;
 }
 
 /** Details: if using CompletionItem#details, show on focus **/
 
-.monaco-editor .suggest-widget .monaco-list .monaco-list-row>.contents>.main>.right>.details-label {
+.monaco-editor .suggest-widget .monaco-list .monaco-list-row > .contents > .main > .right > .details-label {
 	display: none;
 }
 
-.monaco-editor .suggest-widget:not(.shows-details) .monaco-list .monaco-list-row.focused>.contents>.main>.right>.details-label {
+.monaco-editor .suggest-widget:not(.shows-details) .monaco-list .monaco-list-row.focused > .contents > .main > .right > .details-label {
 	display: inline;
 }
 
 /** Details: if using CompletionItemLabel#details, always show **/
 
-.monaco-editor .suggest-widget .monaco-list .monaco-list-row:not(.string-label)>.contents>.main>.right>.details-label,
-.monaco-editor .suggest-widget.docs-side .monaco-list .monaco-list-row.focused:not(.string-label)>.contents>.main>.right>.details-label {
+.monaco-editor .suggest-widget .monaco-list .monaco-list-row:not(.string-label) > .contents > .main > .right > .details-label,
+.monaco-editor .suggest-widget.docs-side .monaco-list .monaco-list-row.focused:not(.string-label) > .contents > .main > .right > .details-label {
 	display: inline;
 }
 
 /** Ellipsis on hover **/
 
-.monaco-editor .suggest-widget:not(.docs-side) .monaco-list .monaco-list-row.focused:hover>.contents>.main>.right.can-expand-details>.details-label {
+.monaco-editor .suggest-widget:not(.docs-side) .monaco-list .monaco-list-row.focused:hover > .contents > .main > .right.can-expand-details > .details-label {
 	width: calc(100% - 26px);
 }
 
-.monaco-editor .suggest-widget .monaco-list .monaco-list-row>.contents>.main>.left {
+.monaco-editor .suggest-widget .monaco-list .monaco-list-row > .contents > .main > .left {
 	flex-shrink: 1;
 	flex-grow: 1;
 	overflow: hidden;
 }
 
-.monaco-editor .suggest-widget .monaco-list .monaco-list-row>.contents>.main>.left>.monaco-icon-label {
+.monaco-editor .suggest-widget .monaco-list .monaco-list-row > .contents > .main > .left > .monaco-icon-label {
 	flex-shrink: 0;
 }
 
-.monaco-editor .suggest-widget .monaco-list .monaco-list-row:not(.string-label)>.contents>.main>.left>.monaco-icon-label {
+.monaco-editor .suggest-widget .monaco-list .monaco-list-row:not(.string-label) > .contents > .main > .left > .monaco-icon-label {
 	max-width: 100%;
 }
 
-.monaco-editor .suggest-widget .monaco-list .monaco-list-row.string-label>.contents>.main>.left>.monaco-icon-label {
+.monaco-editor .suggest-widget .monaco-list .monaco-list-row.string-label > .contents > .main > .left > .monaco-icon-label {
 	flex-shrink: 1;
 }
 
-.monaco-editor .suggest-widget .monaco-list .monaco-list-row>.contents>.main>.right {
+.monaco-editor .suggest-widget .monaco-list .monaco-list-row > .contents > .main > .right {
 	overflow: hidden;
 	flex-shrink: 4;
 	max-width: 70%;
 }
 
-.monaco-editor .suggest-widget .monaco-list .monaco-list-row>.contents>.main>.right>.readMore {
+.monaco-editor .suggest-widget .monaco-list .monaco-list-row > .contents > .main > .right > .readMore {
 	display: inline-block;
 	position: absolute;
 	right: 10px;
@@ -271,23 +271,23 @@
 
 /** Do NOT display ReadMore when docs is side/below **/
 
-.monaco-editor .suggest-widget.docs-side .monaco-list .monaco-list-row>.contents>.main>.right>.readMore {
+.monaco-editor .suggest-widget.docs-side .monaco-list .monaco-list-row > .contents > .main > .right > .readMore {
 	display: none !important;
 }
 
 /** Do NOT display ReadMore when using plain CompletionItemLabel (details/documentation might not be resolved) **/
 
-.monaco-editor .suggest-widget .monaco-list .monaco-list-row.string-label>.contents>.main>.right>.readMore {
+.monaco-editor .suggest-widget .monaco-list .monaco-list-row.string-label > .contents > .main > .right > .readMore {
 	display: none;
 }
 
 /** Focused item can show ReadMore, but can't when docs is side/below **/
 
-.monaco-editor .suggest-widget .monaco-list .monaco-list-row.focused.string-label>.contents>.main>.right>.readMore {
+.monaco-editor .suggest-widget .monaco-list .monaco-list-row.focused.string-label > .contents > .main > .right > .readMore {
 	display: inline-block;
 }
 
-.monaco-editor .suggest-widget .monaco-list .monaco-list-row.focused:hover>.contents>.main>.right>.readMore {
+.monaco-editor .suggest-widget .monaco-list .monaco-list-row.focused:hover > .contents > .main > .right > .readMore {
 	visibility: visible;
 }
 
@@ -298,7 +298,7 @@
 	text-decoration: unset;
 }
 
-.monaco-editor .suggest-widget .monaco-list .monaco-list-row .monaco-icon-label.deprecated>.monaco-icon-label-container>.monaco-icon-name-container {
+.monaco-editor .suggest-widget .monaco-list .monaco-list-row .monaco-icon-label.deprecated > .monaco-icon-label-container > .monaco-icon-name-container {
 	text-decoration: line-through;
 }
 
@@ -372,17 +372,17 @@
 	display: none;
 }
 
-.monaco-editor .suggest-details>.monaco-scrollable-element {
+.monaco-editor .suggest-details > .monaco-scrollable-element {
 	flex: 1;
 }
 
-.monaco-editor .suggest-details>.monaco-scrollable-element>.body {
+.monaco-editor .suggest-details > .monaco-scrollable-element > .body {
 	box-sizing: border-box;
 	height: 100%;
 	width: 100%;
 }
 
-.monaco-editor .suggest-details>.monaco-scrollable-element>.body>.header>.type {
+.monaco-editor .suggest-details > .monaco-scrollable-element > .body > .header > .type {
 	flex: 2;
 	overflow: hidden;
 	text-overflow: ellipsis;
@@ -392,55 +392,55 @@
 	padding: 4px 0 12px 5px;
 }
 
-.monaco-editor .suggest-details>.monaco-scrollable-element>.body>.header>.type.auto-wrap {
+.monaco-editor .suggest-details > .monaco-scrollable-element > .body > .header > .type.auto-wrap {
 	white-space: normal;
 	word-break: break-all;
 }
 
-.monaco-editor .suggest-details>.monaco-scrollable-element>.body>.docs {
+.monaco-editor .suggest-details > .monaco-scrollable-element > .body > .docs {
 	margin: 0;
 	padding: 4px 5px;
 	white-space: pre-wrap;
 }
 
-.monaco-editor .suggest-details.no-type>.monaco-scrollable-element>.body>.docs {
+.monaco-editor .suggest-details.no-type > .monaco-scrollable-element > .body > .docs {
 	margin-right: 24px;
 	overflow: hidden;
 }
 
-.monaco-editor .suggest-details>.monaco-scrollable-element>.body>.docs.markdown-docs {
+.monaco-editor .suggest-details > .monaco-scrollable-element > .body > .docs.markdown-docs {
 	padding: 0;
 	white-space: initial;
 	min-height: calc(1rem + 8px);
 }
 
-.monaco-editor .suggest-details>.monaco-scrollable-element>.body>.docs.markdown-docs>div,
-.monaco-editor .suggest-details>.monaco-scrollable-element>.body>.docs.markdown-docs>span:not(:empty) {
+.monaco-editor .suggest-details > .monaco-scrollable-element > .body > .docs.markdown-docs > div,
+.monaco-editor .suggest-details > .monaco-scrollable-element > .body > .docs.markdown-docs > span:not(:empty) {
 	padding: 4px 5px;
 }
 
-.monaco-editor .suggest-details>.monaco-scrollable-element>.body>.docs.markdown-docs>div>p:first-child {
+.monaco-editor .suggest-details > .monaco-scrollable-element > .body > .docs.markdown-docs > div > p:first-child {
 	margin-top: 0;
 }
 
-.monaco-editor .suggest-details>.monaco-scrollable-element>.body>.docs.markdown-docs>div>p:last-child {
+.monaco-editor .suggest-details > .monaco-scrollable-element > .body > .docs.markdown-docs > div > p:last-child {
 	margin-bottom: 0;
 }
 
-.monaco-editor .suggest-details>.monaco-scrollable-element>.body>.docs.markdown-docs .monaco-tokenized-source {
+.monaco-editor .suggest-details > .monaco-scrollable-element > .body > .docs.markdown-docs .monaco-tokenized-source {
 	white-space: pre;
 }
 
-.monaco-editor .suggest-details>.monaco-scrollable-element>.body>.docs .code {
+.monaco-editor .suggest-details > .monaco-scrollable-element > .body > .docs .code {
 	white-space: pre-wrap;
 	word-wrap: break-word;
 }
 
-.monaco-editor .suggest-details>.monaco-scrollable-element>.body>.docs.markdown-docs .codicon {
+.monaco-editor .suggest-details > .monaco-scrollable-element > .body > .docs.markdown-docs .codicon {
 	vertical-align: sub;
 }
 
-.monaco-editor .suggest-details>.monaco-scrollable-element>.body>p:empty {
+.monaco-editor .suggest-details > .monaco-scrollable-element > .body > p:empty {
 	display: none;
 }
 

--- a/src/vs/workbench/browser/parts/activitybar/media/activityaction.css
+++ b/src/vs/workbench/browser/parts/activitybar/media/activityaction.css
@@ -234,7 +234,7 @@
 
 /* Right aligned */
 
-.monaco-workbench .activitybar.right>.content :not(.monaco-menu)>.monaco-action-bar .profile-badge,
+.monaco-workbench .activitybar.right > .content :not(.monaco-menu) > .monaco-action-bar .profile-badge,
 .monaco-workbench .activitybar.right > .content :not(.monaco-menu) > .monaco-action-bar .badge {
 	left: auto;
 	right: 0;

--- a/src/vs/workbench/browser/parts/editor/media/breadcrumbscontrol.css
+++ b/src/vs/workbench/browser/parts/editor/media/breadcrumbscontrol.css
@@ -3,17 +3,17 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-.monaco-workbench .part.editor>.content .editor-group-container .breadcrumbs-control.hidden {
+.monaco-workbench .part.editor > .content .editor-group-container .breadcrumbs-control.hidden {
 	display: none;
 }
 
-.monaco-workbench .part.editor>.content .editor-group-container .breadcrumbs-control .monaco-breadcrumb-item.selected .monaco-icon-label,
-.monaco-workbench .part.editor>.content .editor-group-container .breadcrumbs-control .monaco-breadcrumb-item.focused .monaco-icon-label {
+.monaco-workbench .part.editor > .content .editor-group-container .breadcrumbs-control .monaco-breadcrumb-item.selected .monaco-icon-label,
+.monaco-workbench .part.editor > .content .editor-group-container .breadcrumbs-control .monaco-breadcrumb-item.focused .monaco-icon-label {
 	text-decoration-line: underline;
 }
 
-.monaco-workbench .part.editor>.content .editor-group-container .breadcrumbs-control .monaco-breadcrumb-item.selected .hint-more,
-.monaco-workbench .part.editor>.content .editor-group-container .breadcrumbs-control .monaco-breadcrumb-item.focused .hint-more {
+.monaco-workbench .part.editor > .content .editor-group-container .breadcrumbs-control .monaco-breadcrumb-item.selected .hint-more,
+.monaco-workbench .part.editor > .content .editor-group-container .breadcrumbs-control .monaco-breadcrumb-item.focused .hint-more {
 	text-decoration-line: underline;
 }
 
@@ -41,22 +41,22 @@
 	flex-direction: column;
 }
 
-.monaco-workbench .monaco-breadcrumbs-picker .highlighting-tree>.input {
+.monaco-workbench .monaco-breadcrumbs-picker .highlighting-tree > .input {
 	padding: 5px 9px;
 	position: relative;
 	box-sizing: border-box;
 	height: 36px;
 }
 
-.monaco-workbench .monaco-breadcrumbs-picker .highlighting-tree>.tree {
+.monaco-workbench .monaco-breadcrumbs-picker .highlighting-tree > .tree {
 	height: calc(100% - 36px);
 }
 
-.monaco-workbench .monaco-breadcrumbs-picker .highlighting-tree.inactive>.input {
+.monaco-workbench .monaco-breadcrumbs-picker .highlighting-tree.inactive > .input {
 	display: none;
 }
 
-.monaco-workbench .monaco-breadcrumbs-picker .highlighting-tree.inactive>.tree {
+.monaco-workbench .monaco-breadcrumbs-picker .highlighting-tree.inactive > .tree {
 	height: 100%;
 }
 

--- a/src/vs/workbench/contrib/comments/browser/media/review.css
+++ b/src/vs/workbench/contrib/comments/browser/media/review.css
@@ -298,8 +298,8 @@
 	width: auto;
 }
 
-.review-widget .body .comment-additional-actions .button-bar>.monaco-text-button,
-.review-widget .body .comment-additional-actions .button-bar>.monaco-button-dropdown {
+.review-widget .body .comment-additional-actions .button-bar > .monaco-text-button,
+.review-widget .body .comment-additional-actions .button-bar > .monaco-button-dropdown {
 	margin: 0 10px 0 0;
 }
 

--- a/src/vs/workbench/contrib/extensions/browser/media/extensionActions.css
+++ b/src/vs/workbench/contrib/extensions/browser/media/extensionActions.css
@@ -10,12 +10,12 @@
 	text-overflow: ellipsis;
 }
 
-.monaco-action-bar .action-item>.action-label.extension-action.label,
-.monaco-action-bar .action-dropdown-item>.action-label.extension-action.label {
+.monaco-action-bar .action-item > .action-label.extension-action.label,
+.monaco-action-bar .action-dropdown-item > .action-label.extension-action.label {
 	padding: 0 5px;
 }
 
-.monaco-action-bar .action-dropdown-item>.monaco-dropdown .action-label {
+.monaco-action-bar .action-dropdown-item > .monaco-dropdown .action-label {
 	padding: 0;
 }
 
@@ -36,7 +36,7 @@
 }
 
 .monaco-action-bar .action-item .action-label.extension-action.label,
-.monaco-action-bar .action-item.action-dropdown-item>.action-dropdown-item-separator {
+.monaco-action-bar .action-item.action-dropdown-item > .action-dropdown-item-separator {
 	background-color: var(--vscode-extensionButton-background) !important;
 }
 
@@ -48,12 +48,12 @@
 	background-color: var(--vscode-extensionButton-hoverBackground) !important;
 }
 
-.monaco-action-bar .action-item.action-dropdown-item>.action-dropdown-item-separator>div {
+.monaco-action-bar .action-item.action-dropdown-item > .action-dropdown-item-separator > div {
 	background-color: var(--vscode-extensionButton-separator);
 }
 
 .monaco-action-bar .action-item .action-label.extension-action.label.prominent,
-.monaco-action-bar .action-item.action-dropdown-item>.action-dropdown-item-separator.prominent {
+.monaco-action-bar .action-item.action-dropdown-item > .action-dropdown-item-separator.prominent {
 	background-color: var(--vscode-extensionButton-prominentBackground);
 }
 
@@ -69,7 +69,7 @@
 	border: 1px solid var(--vscode-contrastBorder);
 }
 
-.monaco-action-bar .action-item.action-dropdown-item>.action-dropdown-item-separator {
+.monaco-action-bar .action-item.action-dropdown-item > .action-dropdown-item-separator {
 	border-top: 1px solid var(--vscode-contrastBorder);
 	border-bottom: 1px solid var(--vscode-contrastBorder);
 }

--- a/src/vs/workbench/contrib/extensions/browser/media/runtimeExtensionsEditor.css
+++ b/src/vs/workbench/contrib/extensions/browser/media/runtimeExtensionsEditor.css
@@ -31,7 +31,7 @@
 	text-align: right;
 }
 
-.runtime-extensions-editor .extension .desc>.msg>span:not(:last-child)::after {
+.runtime-extensions-editor .extension .desc > .msg > span:not(:last-child)::after {
 	content: '\2022';
 	padding: 0 4px;
 	opacity: .8;

--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChat.css
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChat.css
@@ -93,7 +93,7 @@
 }
 
 /* UGLY - fighting against workbench styles */
-.monaco-workbench .part.editor>.content .monaco-editor .inline-chat .progress .monaco-progress-container {
+.monaco-workbench .part.editor > .content .monaco-editor .inline-chat .progress .monaco-progress-container {
 	top: 0;
 }
 

--- a/src/vs/workbench/contrib/languageStatus/browser/media/languageStatus.css
+++ b/src/vs/workbench/contrib/languageStatus/browser/media/languageStatus.css
@@ -25,7 +25,7 @@
 	}
 }
 
-.monaco-workbench .statusbar DIV#status\.languageStatus A>SPAN.codicon.wiggle {
+.monaco-workbench .statusbar DIV#status\.languageStatus A > SPAN.codicon.wiggle {
 	animation-duration: .8s;
 	animation-iteration-count: 1;
 	animation-name: wiggle;
@@ -62,60 +62,60 @@
 	border-bottom: 1px solid var(--vscode-notifications-border);
 }
 
-.monaco-workbench .hover-language-status>.severity {
+.monaco-workbench .hover-language-status > .severity {
 	padding-right: 8px;
 	flex: 1;
 	margin: auto;
 	display: none;
 }
 
-.monaco-workbench .hover-language-status>.severity.sev3 {
+.monaco-workbench .hover-language-status > .severity.sev3 {
 	color: var(--vscode-notificationsErrorIcon-foreground)
 }
 
-.monaco-workbench .hover-language-status>.severity.sev2 {
+.monaco-workbench .hover-language-status > .severity.sev2 {
 	color: var(--vscode-notificationsInfoIcon-foreground)
 }
 
-.monaco-workbench .hover-language-status>.severity.show {
+.monaco-workbench .hover-language-status > .severity.show {
 	display: inherit;
 }
 
-.monaco-workbench .hover-language-status>.element {
+.monaco-workbench .hover-language-status > .element {
 	display: flex;
 	justify-content: space-between;
 	vertical-align: middle;
 	flex-grow: 100;
 }
 
-.monaco-workbench .hover-language-status>.element>.left>.detail:not(:empty)::before {
+.monaco-workbench .hover-language-status > .element > .left > .detail:not(:empty)::before {
 	content: '\2013';
 	padding: 0 4px;
 	opacity: 0.6;
 }
 
-.monaco-workbench .hover-language-status>.element>.left>.label:empty {
+.monaco-workbench .hover-language-status > .element > .left > .label:empty {
 	display: none;
 }
 
-.monaco-workbench .hover-language-status>.element .left {
+.monaco-workbench .hover-language-status > .element .left {
 	margin: auto 0;
 }
 
-.monaco-workbench .hover-language-status>.element .right {
+.monaco-workbench .hover-language-status > .element .right {
 	margin: auto 0;
 	display: flex;
 }
 
-.monaco-workbench .hover-language-status>.element .right:not(:empty) {
+.monaco-workbench .hover-language-status > .element .right:not(:empty) {
 	padding-left: 16px;
 }
 
-.monaco-workbench .hover-language-status>.element .right .monaco-link {
+.monaco-workbench .hover-language-status > .element .right .monaco-link {
 	margin: auto 0;
 	white-space: nowrap;
 }
 
-.monaco-workbench .hover-language-status>.element .right .monaco-action-bar:not(:first-child) {
+.monaco-workbench .hover-language-status > .element .right .monaco-action-bar:not(:first-child) {
 	padding-left: 8px;
 }

--- a/src/vs/workbench/contrib/notebook/browser/media/notebook.css
+++ b/src/vs/workbench/contrib/notebook/browser/media/notebook.css
@@ -258,7 +258,7 @@
 	text-align: center;
 }
 
-.monaco-workbench .notebookOverlay>.cell-list-container>.monaco-list>.monaco-scrollable-element>.monaco-list-rows>.monaco-list-row .cell-statusbar-hidden .execution-count-label {
+.monaco-workbench .notebookOverlay > .cell-list-container > .monaco-list > .monaco-scrollable-element > .monaco-list-rows > .monaco-list-row .cell-statusbar-hidden .execution-count-label {
 	line-height: 15px;
 }
 

--- a/src/vs/workbench/contrib/notebook/browser/media/notebookCellChat.css
+++ b/src/vs/workbench/contrib/notebook/browser/media/notebookCellChat.css
@@ -97,7 +97,7 @@
 }
 
 /* UGLY - fighting against workbench styles */
-.monaco-workbench .part.editor>.content .monaco-editor .inline-chat .progress .monaco-progress-container {
+.monaco-workbench .part.editor > .content .monaco-editor .inline-chat .progress .monaco-progress-container {
 	top: 0;
 }
 

--- a/src/vs/workbench/contrib/notebook/browser/media/notebookFolding.css
+++ b/src/vs/workbench/contrib/notebook/browser/media/notebookFolding.css
@@ -43,7 +43,7 @@
 	padding: 4px 4px 4px 4px;
 }
 
-.monaco-workbench .notebookOverlay>.cell-list-container .notebook-folded-hint {
+.monaco-workbench .notebookOverlay > .cell-list-container .notebook-folded-hint {
 	position: absolute;
 	user-select: none;
 }

--- a/src/vs/workbench/contrib/remote/browser/media/remoteViewlet.css
+++ b/src/vs/workbench/contrib/remote/browser/media/remoteViewlet.css
@@ -13,7 +13,7 @@
 	flex-wrap: nowrap;
 }
 
-.remote-help-content .monaco-list .monaco-list-row .remote-help-tree-node-item>.remote-help-tree-node-item-icon {
+.remote-help-content .monaco-list .monaco-list-row .remote-help-tree-node-item > .remote-help-tree-node-item-icon {
 	background-size: 16px;
 	background-position: left center;
 	background-repeat: no-repeat;

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/media/gettingStarted.css
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/media/gettingStarted.css
@@ -8,7 +8,7 @@
 	background-image: url('../../../../browser/media/code-icon.svg');
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer {
+.monaco-workbench .part.editor > .content .gettingStartedContainer {
 	box-sizing: border-box;
 	line-height: 22px;
 	position: relative;
@@ -20,26 +20,26 @@
 	outline: none;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer.loading {
+.monaco-workbench .part.editor > .content .gettingStartedContainer.loading {
 	display: none;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer img {
+.monaco-workbench .part.editor > .content .gettingStartedContainer img {
 	max-width: 100%;
 	max-height: 100%;
 	object-fit: contain;
 	pointer-events: none;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer {
+.monaco-workbench .part.editor > .content .gettingStartedContainer {
 	font-size: 13px;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .gettingStarted {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStarted {
 	height: 100%;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer h1 {
+.monaco-workbench .part.editor > .content .gettingStartedContainer h1 {
 	padding: 5px 0 0;
 	margin: 0;
 	border: none;
@@ -48,24 +48,24 @@
 	white-space: nowrap;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .title {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .title {
 	margin-top: 1em;
 	margin-bottom: 1em;
 	flex: 1 100%;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .subtitle {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .subtitle {
 	margin-top: .6em;
 	font-size: 2em;
 	display: block;
 }
 
-.monaco-workbench.hc-black .part.editor>.content .gettingStartedContainer .subtitle,
-.monaco-workbench.hc-light .part.editor>.content .gettingStartedContainer .subtitle {
+.monaco-workbench.hc-black .part.editor > .content .gettingStartedContainer .subtitle,
+.monaco-workbench.hc-light .part.editor > .content .gettingStartedContainer .subtitle {
 	font-weight: 200;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer h2 {
+.monaco-workbench .part.editor > .content .gettingStartedContainer h2 {
 	font-weight: 400;
 	margin-top: 0;
 	margin-bottom: 5px;
@@ -73,12 +73,12 @@
 	line-height: initial;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer a:focus {
+.monaco-workbench .part.editor > .content .gettingStartedContainer a:focus {
 	outline: 1px solid -webkit-focus-ring-color;
 	outline-offset: -1px;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .gettingStartedSlide {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlide {
 	width: 100%;
 	height: 100%;
 	padding: 0;
@@ -88,23 +88,23 @@
 	top: 0;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .gettingStartedSlideCategories {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlideCategories {
 	padding: 12px 24px;
 }
 
 /* duplicated until the getting-started specific setting is removed */
-.monaco-workbench .part.editor>.content .gettingStartedContainer.animatable .gettingStartedSlide {
+.monaco-workbench .part.editor > .content .gettingStartedContainer.animatable .gettingStartedSlide {
 	/* keep consistant with SLIDE_TRANSITION_TIME_MS in gettingStarted.ts */
 	transition: left 0.25s, opacity 0.25s;
 }
 
-.monaco-workbench.reduce-motion .part.editor>.content .gettingStartedContainer .gettingStartedSlide,
-.monaco-workbench.reduce-motion .part.editor>.content .gettingStartedContainer.animatable .gettingStartedSlide {
+.monaco-workbench.reduce-motion .part.editor > .content .gettingStartedContainer .gettingStartedSlide,
+.monaco-workbench.reduce-motion .part.editor > .content .gettingStartedContainer.animatable .gettingStartedSlide {
 	/* keep consistant with SLIDE_TRANSITION_TIME_MS in gettingStarted.ts */
 	transition: left 0.0s, opacity 0.0s;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .gettingStartedSlideCategories>.gettingStartedCategoriesContainer {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlideCategories > .gettingStartedCategoriesContainer {
 	display: grid;
 	height: 100%;
 	max-width: 1200px;
@@ -117,73 +117,73 @@
 		". footer footer footer .";
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer.width-constrained .gettingStartedSlideCategories>.gettingStartedCategoriesContainer {
+.monaco-workbench .part.editor > .content .gettingStartedContainer.width-constrained .gettingStartedSlideCategories > .gettingStartedCategoriesContainer {
 	grid-template-rows: auto min-content minmax(min-content, auto) min-content;
 	grid-template-columns: 1fr;
 	grid-template-areas: "header" "left-column" "right-column" "footer";
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer.height-constrained .gettingStartedSlideCategories>.gettingStartedCategoriesContainer {
+.monaco-workbench .part.editor > .content .gettingStartedContainer.height-constrained .gettingStartedSlideCategories > .gettingStartedCategoriesContainer {
 	grid-template-rows: auto minmax(min-content, auto) min-content;
 	grid-template-areas: "header" "left-column right-column" "footer footer";
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer.height-constrained.width-constrained .gettingStartedSlideCategories>.gettingStartedCategoriesContainer {
+.monaco-workbench .part.editor > .content .gettingStartedContainer.height-constrained.width-constrained .gettingStartedSlideCategories > .gettingStartedCategoriesContainer {
 	grid-template-rows: min-content minmax(min-content, auto) min-content;
 	grid-template-columns: 1fr;
 	grid-template-areas: "left-column" "right-column" "footer";
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer.width-constrained .gettingStartedSlideCategories>.gettingStartedCategoriesContainer>.header, .monaco-workbench .part.editor>.content .gettingStartedContainer.height-constrained .gettingStartedSlideCategories>.gettingStartedCategoriesContainer>.header {
+.monaco-workbench .part.editor > .content .gettingStartedContainer.width-constrained .gettingStartedSlideCategories > .gettingStartedCategoriesContainer > .header, .monaco-workbench .part.editor > .content .gettingStartedContainer.height-constrained .gettingStartedSlideCategories > .gettingStartedCategoriesContainer > .header {
 	display: none;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .gettingStartedSlideCategories li.showWalkthroughsEntry {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlideCategories li.showWalkthroughsEntry {
 	display: none;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer.noWalkthroughs .gettingStartedSlideCategories li.showWalkthroughsEntry, .gettingStartedContainer.noExtensions {
+.monaco-workbench .part.editor > .content .gettingStartedContainer.noWalkthroughs .gettingStartedSlideCategories li.showWalkthroughsEntry, .gettingStartedContainer.noExtensions {
 	display: unset;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .gettingStartedSlideCategories>.gettingStartedCategoriesContainer>* {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlideCategories > .gettingStartedCategoriesContainer > * {
 	overflow: hidden;
 	text-overflow: ellipsis;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .gettingStartedSlideCategories>.gettingStartedCategoriesContainer>.categories-column>div {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlideCategories > .gettingStartedCategoriesContainer > .categories-column > div {
 	margin-bottom: 32px;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .gettingStartedSlideCategories>.gettingStartedCategoriesContainer>.categories-column-left {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlideCategories > .gettingStartedCategoriesContainer > .categories-column-left {
 	grid-area: left-column;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .gettingStartedSlideCategories>.gettingStartedCategoriesContainer>.categories-column-right {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlideCategories > .gettingStartedCategoriesContainer > .categories-column-right {
 	grid-area: right-column;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .gettingStartedSlideCategories>.gettingStartedCategoriesContainer>.header {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlideCategories > .gettingStartedCategoriesContainer > .header {
 	grid-area: header;
 	align-self: end;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .gettingStartedSlideCategories>.gettingStartedCategoriesContainer>.footer {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlideCategories > .gettingStartedCategoriesContainer > .footer {
 	grid-area: footer;
 	justify-self: center;
 	text-align: center;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .gettingStartedSlideCategories .categories-slide-container {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlideCategories .categories-slide-container {
 	width: 90%;
 	max-width: 1200px;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .gettingStartedSlideCategories .gap {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlideCategories .gap {
 	flex: 150px 0 1000
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .gettingStartedSlideCategories .category-title {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlideCategories .category-title {
 	margin: 4px 0 4px;
 	font-size: 14px;
 	font-weight: 500;
@@ -194,58 +194,58 @@
 	white-space: nowrap;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .gettingStartedSlideCategories .category-progress {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlideCategories .category-progress {
 	position: absolute;
 	bottom: 0;
 	left: 0;
 	width: 100%;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .gettingStartedSlide .getting-started-category.no-progress {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlide .getting-started-category.no-progress {
 	padding: 3px 6px;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .getting-started-category.no-progress .category-progress {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .getting-started-category.no-progress .category-progress {
 	display: none;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .gettingStartedSlideCategories ul {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlideCategories ul {
 	list-style: none;
 	margin: 0;
 	line-height: 24px;
 	padding-left: 0;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .gettingStartedSlideCategories li {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlideCategories li {
 	list-style: none;
 	white-space: nowrap;
 	overflow: hidden;
 	text-overflow: ellipsis;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .gettingStartedSlideCategories .path {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlideCategories .path {
 	padding-left: 1em;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .icon-widget,
-.monaco-workbench .part.editor>.content .gettingStartedContainer .gettingStartedSlideCategories .icon-widget,
-.monaco-workbench .part.editor>.content .gettingStartedContainer .gettingStartedSlideCategories .featured-icon {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .icon-widget,
+.monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlideCategories .icon-widget,
+.monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlideCategories .featured-icon {
 	font-size: 20px;
 	padding-right: 8px;
 	position: relative;
 	top: 3px;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .gettingStartedSlideCategories .codicon:not(.icon-widget, .featured-icon, .hide-category-button) {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlideCategories .codicon:not(.icon-widget, .featured-icon, .hide-category-button) {
 	margin: 0 2px;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .gettingStartedSlideCategories .codicon:first-child {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlideCategories .codicon:first-child {
 	margin-left: 0;
 }
 
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .gettingStartedSlideCategories .start-container img {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlideCategories .start-container img {
 	padding-right: 8px;
 	position: relative;
 	top: 3px;
@@ -253,20 +253,20 @@
 	max-height: 16px;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .gettingStartedSlideCategories .keybinding-label {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlideCategories .keybinding-label {
 	padding-left: 1em;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .gettingStartedSlideCategories .progress-bar-outer {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlideCategories .progress-bar-outer {
 	height: 4px;
 	margin-top: 4px;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .gettingStartedSlideCategories .progress-bar-inner {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlideCategories .progress-bar-inner {
 	height: 100%;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .gettingStartedSlide .getting-started-category {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlide .getting-started-category {
 	width: calc(100% - 16px);
 	font-size: 13px;
 	box-sizing: border-box;
@@ -276,36 +276,36 @@
 	text-align: left;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .gettingStartedSlideCategories .getting-started-category {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlideCategories .getting-started-category {
 	position: relative;
 	border-radius: 6px;
 	overflow: hidden;
 }
 
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .gettingStartedSlide .getting-started-category .main-content {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlide .getting-started-category .main-content {
 	display: flex;
 	align-items: center;
 	justify-content: flex-start;
 	width: 100%;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .gettingStartedSlide .getting-started-category .featured-description-content,
-.monaco-workbench .part.editor>.content .gettingStartedContainer .gettingStartedSlide .getting-started-category .description-content {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlide .getting-started-category .featured-description-content,
+.monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlide .getting-started-category .description-content {
 	text-align: left;
 	margin-left: 28px;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .gettingStartedSlide .getting-started-category .description-content > .codicon {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlide .getting-started-category .description-content > .codicon {
 	padding-right: 1px;
 	font-size: 16px;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .gettingStartedSlide .getting-started-category .description-content:not(:empty){
+.monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlide .getting-started-category .description-content:not(:empty){
 	margin-bottom: 8px;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .gettingStartedSlide .getting-started-category .featured-description-content:not(:empty){
+.monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlide .getting-started-category .featured-description-content:not(:empty){
 	margin-bottom: 8px;
 	margin-left: 32px;
 	overflow: hidden;
@@ -314,7 +314,7 @@
 	-webkit-box-orient: vertical;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .gettingStartedSlide .getting-started-category .new-badge {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlide .getting-started-category .new-badge {
 	justify-self: flex-end;
 	align-self: flex-start;
 	border-radius: 4px;
@@ -324,13 +324,13 @@
 	white-space: nowrap;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .gettingStartedSlide .getting-started-category .featured-badge {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlide .getting-started-category .featured-badge {
 	position: relative;
 	top: -4px;
 	left: -8px;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .gettingStartedSlide .getting-started-category .featured {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlide .getting-started-category .featured {
 	border-top: 30px solid var(--vscode-activityBarBadge-background);
 	width: 30px;
 	box-sizing: border-box;
@@ -339,23 +339,23 @@
 	position: absolute;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .gettingStartedSlide .getting-started-category .featured .featured-icon {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlide .getting-started-category .featured .featured-icon {
 	top: -30px;
 	left: 4px;
 	font-size: 14px;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .gettingStartedSlide .getting-started-category .codicon.hide-category-button {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlide .getting-started-category .codicon.hide-category-button {
 	margin-left: auto;
 	top: 4px;
 	right: 8px;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .gettingStartedSlide .getting-started-category.featured .icon-widget {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlide .getting-started-category.featured .icon-widget {
 	visibility: hidden;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .gettingStartedSlideCategories .getting-started-category img.category-icon {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlideCategories .getting-started-category img.category-icon {
 	padding-right: 8px;
 	max-width: 20px;
 	max-height: 20px;
@@ -363,7 +363,7 @@
 	top: auto;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .gettingStartedSlideCategories .getting-started-category img.featured-icon {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlideCategories .getting-started-category img.featured-icon {
 	padding-right: 8px;
 	max-width: 24px;
 	max-height: 24px;
@@ -371,80 +371,80 @@
 	position: relative;
 	top: auto;
 }
-.monaco-workbench .part.editor>.content .gettingStartedContainer .gettingStartedSlideDetails .getting-started-category img.category-icon {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlideDetails .getting-started-category img.category-icon {
 	margin-right: 10px;
 	margin-left: 10px;
 	max-width: 32px;
 	max-height: 32px;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .gettingStartedSlideDetails {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlideDetails {
 	display: flex;
 	flex-direction: column;
 	overflow: hidden;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .gettingStartedSlideDetails .gap {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlideDetails .gap {
 	flex: 150px 0 1000
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .gettingStartedSlideDetails .getting-started-category {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlideDetails .getting-started-category {
 	display: flex;
 	margin-bottom: 24px;
 	min-height: auto;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .gettingStartedSlideDetails .getting-started-detail-columns .gap {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlideDetails .getting-started-detail-columns .gap {
 	flex: 150px 1 1000
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .gettingStartedSlideDetails .gettingStartedDetailsContent>.getting-started-category>.codicon-getting-started-setup {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlideDetails .gettingStartedDetailsContent > .getting-started-category > .codicon-getting-started-setup {
 	margin-right: 8px;
 	font-size: 28px;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .gettingStartedSlideDetails .getting-started-detail-columns {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlideDetails .getting-started-detail-columns {
 	display: flex;
 	justify-content: flex-start;
 	padding: 40px 40px 0;
 	max-height: calc(100% - 40px);
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .gettingStartedSlideDetails .getting-started-step {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlideDetails .getting-started-step {
 	display: flex;
 	width: 100%;
 	overflow: hidden;
 	border-radius: 6px;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .gettingStartedSlideDetails .getting-started-step .button-container:not(:last-of-type) {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlideDetails .getting-started-step .button-container:not(:last-of-type) {
 	margin-bottom: 6px;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .gettingStartedSlideDetails .getting-started-step.expanded {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlideDetails .getting-started-step.expanded {
 	cursor: default !important;
 	border: 1px solid var(--vscode-welcomePage-tileBorder);
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .gettingStartedSlideDetails .getting-started-step.expanded h3 {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlideDetails .getting-started-step.expanded h3 {
 	color: var(--vscode-walkthrough-stepTitle-foreground);
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .gettingStartedSlideDetails .getting-started-step.expanded>.codicon {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlideDetails .getting-started-step.expanded > .codicon {
 	cursor: pointer !important;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .gettingStartedSlideDetails .getting-started-step:not(.expanded) {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlideDetails .getting-started-step:not(.expanded) {
 	height: 48px;
 	background: none;
 	color: var(--vscode-descriptionForeground);
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .gettingStartedSlideDetails .getting-started-step:not(.expanded):hover {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlideDetails .getting-started-step:not(.expanded):hover {
 	background: var(--vscode-welcomePage-tileHoverBackground);
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .gettingStartedSlideDetails .getting-started-step:not(.expanded) .step-title {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlideDetails .getting-started-step:not(.expanded) .step-title {
 	white-space: nowrap;
 	text-overflow: ellipsis;
 	display: inline-block;
@@ -452,66 +452,66 @@
 	width: inherit;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .gettingStartedSlideDetails .getting-started-step .step-title .codicon {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlideDetails .getting-started-step .step-title .codicon {
 	position: relative;
 	top: 2px;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .gettingStartedSlideDetails .getting-started-detail-columns .getting-started-detail-left>div {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlideDetails .getting-started-detail-columns .getting-started-detail-left > div {
 	width: 100%;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .gettingStartedSlideDetails .getting-started-step:not(.expanded) .step-description-container {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlideDetails .getting-started-step:not(.expanded) .step-description-container {
 	visibility: hidden;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .gettingStartedSlideDetails .getting-started-step .step-container {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlideDetails .getting-started-step .step-container {
 	width: 100%;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .gettingStartedSlideDetails .getting-started-step .step-description {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlideDetails .getting-started-step .step-description {
 	padding-top: 8px;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .gettingStartedSlideDetails .getting-started-step .actions {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlideDetails .getting-started-step .actions {
 	margin-top: 12px;
 	display: flex;
 	align-items: center;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .gettingStartedSlideDetails .getting-started-step .shortcut-message {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlideDetails .getting-started-step .shortcut-message {
 	display: flex;
 	color: var(--vscode-descriptionForeground);
 	font-size: 12px;
 	margin-top: 12px;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .gettingStartedSlideDetails .getting-started-step .shortcut-message .keybinding {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlideDetails .getting-started-step .shortcut-message .keybinding {
 	font-weight: 600;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .gettingStartedSlideDetails .getting-started-step .step-next {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlideDetails .getting-started-step .step-next {
 	margin-left: auto;
 	margin-right: 10px;
 	padding: 6px 12px;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .gettingStartedSlideDetails .getting-started-step .codicon.hidden {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlideDetails .getting-started-step .codicon.hidden {
 	display: none;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .gettingStartedSlideDetails .getting-started-step .codicon-getting-started-step-unchecked,
-.monaco-workbench .part.editor>.content .gettingStartedContainer .gettingStartedSlideDetails .getting-started-step .codicon-getting-started-step-checked {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlideDetails .getting-started-step .codicon-getting-started-step-unchecked,
+.monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlideDetails .getting-started-step .codicon-getting-started-step-checked {
 	margin-right: 8px;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .gettingStartedSlideDetails .getting-started-step-action {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlideDetails .getting-started-step-action {
 	padding: 6px 12px;
 	font-size: 13px;
 	margin-bottom: 0;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .gettingStartedSlideDetails .getting-started-detail-left {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlideDetails .getting-started-detail-left {
 	min-width: 330px;
 	width: 40%;
 	max-width: 400px;
@@ -519,15 +519,15 @@
 	flex-direction: column;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .full-height-scrollable {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .full-height-scrollable {
 	height: 100%;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .gettingStartedSlideDetails .getting-started-detail-container {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlideDetails .getting-started-detail-container {
 	height: 100%;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .gettingStartedSlideDetails .gettingStartedDetailsContent {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlideDetails .gettingStartedDetailsContent {
 	height: 100%;
 	max-width: 1200px;
 	margin: 0 auto;
@@ -543,7 +543,7 @@
 		". footer footer footer .";
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer.width-semi-constrained .gettingStartedSlideDetails .gettingStartedDetailsContent {
+.monaco-workbench .part.editor > .content .gettingStartedContainer.width-semi-constrained .gettingStartedSlideDetails .gettingStartedDetailsContent {
 	max-width: 500px;
 	grid-template-columns: auto;
 	grid-template-rows: 30px max-content minmax(30%, max-content) minmax(30%, 1fr) auto;
@@ -551,45 +551,45 @@
 	grid-template-areas: "back" "title" "steps" "media" "footer";
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer.width-semi-constrained .gettingStartedSlideDetails .gettingStartedDetailsContent.markdown {
+.monaco-workbench .part.editor > .content .gettingStartedContainer.width-semi-constrained .gettingStartedSlideDetails .gettingStartedDetailsContent.markdown {
 	grid-template-rows: 30px max-content minmax(30%, max-content) minmax(40%, 1fr) auto;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer.width-semi-constrained.height-constrained .gettingStartedSlideDetails .gettingStartedDetailsContent {
+.monaco-workbench .part.editor > .content .gettingStartedContainer.width-semi-constrained.height-constrained .gettingStartedSlideDetails .gettingStartedDetailsContent {
 	grid-template-rows: 0 max-content minmax(25%, max-content) minmax(25%, 1fr) auto;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .gettingStartedSlideDetails .gettingStartedDetailsContent>.prev-button {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlideDetails .gettingStartedDetailsContent > .prev-button {
 	grid-area: back;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .gettingStartedSlideDetails .gettingStartedDetailsContent>.getting-started-category {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlideDetails .gettingStartedDetailsContent > .getting-started-category {
 	grid-area: title;
 	align-self: flex-end;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .gettingStartedSlideDetails .gettingStartedDetailsContent>.steps-container {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlideDetails .gettingStartedDetailsContent > .steps-container {
 	height: 100%;
 	grid-area: steps;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .gettingStartedSlideDetails .gettingStartedDetailsContent>.getting-started-media {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlideDetails .gettingStartedDetailsContent > .getting-started-media {
 	grid-area: media;
 	align-self: center;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .gettingStartedSlideDetails .gettingStartedDetailsContent.markdown>.getting-started-media {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlideDetails .gettingStartedDetailsContent.markdown > .getting-started-media {
 	height: inherit;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .gettingStartedSlideDetails .gettingStartedDetailsContent.image>.getting-started-media {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlideDetails .gettingStartedDetailsContent.image > .getting-started-media {
 	grid-area: title-start / media-start / steps-end / media-end;
 	align-self: unset;
 	display: flex;
 	justify-content: center;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer.width-semi-constrained .gettingStartedSlideDetails .gettingStartedDetailsContent.image>.getting-started-media {
+.monaco-workbench .part.editor > .content .gettingStartedContainer.width-semi-constrained .gettingStartedSlideDetails .gettingStartedDetailsContent.image > .getting-started-media {
 	grid-area: media;
 	height: inherit;
 	width: inherit;
@@ -597,14 +597,14 @@
 	justify-content: center;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .gettingStartedSlideDetails .gettingStartedDetailsContent>.getting-started-footer {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlideDetails .gettingStartedDetailsContent > .getting-started-footer {
 	grid-area: footer;
 	align-self: flex-end;
 	justify-self: center;
 	text-align: center;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .gettingStartedSlideDetails .getting-started-detail-right {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlideDetails .getting-started-detail-right {
 	display: flex;
 	align-items: flex-start;
 	justify-content: center;
@@ -615,36 +615,36 @@
 	max-width: 800px;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .index-list.getting-started .button-link {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .index-list.getting-started .button-link {
 	margin: 0;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .index-list.getting-started .see-all-walkthroughs {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .index-list.getting-started .see-all-walkthroughs {
 	display: none;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer.someWalkthroughsHidden .index-list.getting-started .see-all-walkthroughs {
+.monaco-workbench .part.editor > .content .gettingStartedContainer.someWalkthroughsHidden .index-list.getting-started .see-all-walkthroughs {
 	display: inline;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer.noExtensions .index-list.featured-extensions {
+.monaco-workbench .part.editor > .content .gettingStartedContainer.noExtensions .index-list.featured-extensions {
 	display: none;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer.noWalkthroughs .index-list.getting-started  {
+.monaco-workbench .part.editor > .content .gettingStartedContainer.noWalkthroughs .index-list.getting-started  {
 	display: none;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .gettingStartedSlideDetails .getting-started-detail-right img {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlideDetails .getting-started-detail-right img {
 	object-fit: contain;
 	cursor: unset;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .gettingStartedSlideDetails .getting-started-detail-right img.clickable {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlideDetails .getting-started-detail-right img.clickable {
 	cursor: pointer;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer button {
+.monaco-workbench .part.editor > .content .gettingStartedContainer button {
 	border: none;
 	color: inherit;
 	text-align: left;
@@ -655,21 +655,21 @@
 	font-family: inherit;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer button:hover {
+.monaco-workbench .part.editor > .content .gettingStartedContainer button:hover {
 	cursor: pointer;
 }
 
 /* Don't show focus outline on mouse click. Instead only show outline on keyboard focus. */
-.monaco-workbench .part.editor>.content .gettingStartedContainer button:focus {
+.monaco-workbench .part.editor > .content .gettingStartedContainer button:focus {
 	outline: none;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer button:focus-visible {
+.monaco-workbench .part.editor > .content .gettingStartedContainer button:focus-visible {
 	outline: 1px solid var(--vscode-focusBorder);
 	outline-offset: -1px;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .prev-button.button-link {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .prev-button.button-link {
 	position: absolute;
 	left: 40px;
 	top: 5px;
@@ -679,91 +679,91 @@
 	display: none;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer.width-semi-constrained .prev-button.button-link {
+.monaco-workbench .part.editor > .content .gettingStartedContainer.width-semi-constrained .prev-button.button-link {
 	left: 0;
 	top: -10px;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer.height-constrained .prev-button.button-link {
+.monaco-workbench .part.editor > .content .gettingStartedContainer.height-constrained .prev-button.button-link {
 	left: 0;
 	top: -10px;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer.height-constrained .prev-button.button-link .codicon {
+.monaco-workbench .part.editor > .content .gettingStartedContainer.height-constrained .prev-button.button-link .codicon {
 	font-size: 20px;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer.height-constrained .prev-button.button-link .moreText {
+.monaco-workbench .part.editor > .content .gettingStartedContainer.height-constrained .prev-button.button-link .moreText {
 	display: none;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .prev-button:hover {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .prev-button:hover {
 	cursor: pointer;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .prev-button .codicon {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .prev-button .codicon {
 	position: relative;
 	top: 3px;
 	left: -4px;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .button-link .codicon-arrow-right {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .button-link .codicon-arrow-right {
 	padding-left: 4px;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .button-link .codicon-check-all {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .button-link .codicon-check-all {
 	padding-right: 4px;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .gettingStartedSlide .skip {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlide .skip {
 	display: block;
 	margin: 2px auto;
 	width: fit-content;
 	text-align: center;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .gettingStartedSlideDetails h2 {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlideDetails h2 {
 	font-size: 26px;
 	font-weight: normal;
 	margin: 0 0 8px 0;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .gettingStartedSlideDetails h2 .codicon {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlideDetails h2 .codicon {
 	font-size: 20px;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .gettingStartedSlideDetails h3 {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlideDetails h3 {
 	font-size: 13px;
 	font-weight: 600;
 	margin: 0;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .gettingStartedSlideDetails .subtitle {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlideDetails .subtitle {
 	font-size: 16px;
 	margin: 0;
 	padding: 0;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .gettingStarted.showCategories .gettingStartedSlideDetails {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStarted.showCategories .gettingStartedSlideDetails {
 	left: 100%;
 	opacity: 0;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .gettingStarted.showDetails .gettingStartedSlideCategories {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStarted.showDetails .gettingStartedSlideCategories {
 	left: -100%;
 	opacity: 0;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .gettingStarted.showDetails .categoriesScrollbar .scrollbar.vertical {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStarted.showDetails .categoriesScrollbar .scrollbar.vertical {
 	display: none;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .done-next-container {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .done-next-container {
 	display: flex;
 	padding: 16px;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .button-link {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .button-link {
 	padding: 0;
 	background: transparent;
 	margin: 2px;
@@ -773,20 +773,20 @@
 	max-width: 100%;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .done-next-container .button-link {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .done-next-container .button-link {
 	display: flex;
 	align-items: center;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .button-link.next {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .button-link.next {
 	margin-left: auto;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .button-link:hover {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .button-link:hover {
 	background: transparent;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .gettingStartedSlide .openAWalkthrough>button, .monaco-workbench .part.editor>.content .gettingStartedContainer .gettingStartedSlide .showOnStartup {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlide .openAWalkthrough > button, .monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlide .showOnStartup {
 	text-align: center;
 	display: flex;
 	justify-content: center;
@@ -794,7 +794,7 @@
 	gap: 8px;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .gettingStartedSlide .getting-started-checkbox {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlide .getting-started-checkbox {
 	color: inherit !important;
 	height: 18px;
 	width: 18px;
@@ -805,45 +805,45 @@
 }
 
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .gettingStartedSlide .getting-started-checkbox.codicon:not(.checked)::before  {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlide .getting-started-checkbox.codicon:not(.checked)::before  {
 	opacity: 0;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .gettingStartedSlideCategories>.gettingStartedCategoriesContainer>.footer p {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlideCategories > .gettingStartedCategoriesContainer > .footer p {
 	margin: 0;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .gettingStartedSlideCategories>.gettingStartedCategoriesContainer .index-list.start-container {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlideCategories > .gettingStartedCategoriesContainer .index-list.start-container {
 	min-height: 156px;
 	margin-bottom: 16px;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .gettingStartedSlideCategories>.gettingStartedCategoriesContainer>.footer>button {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlideCategories > .gettingStartedCategoriesContainer > .footer > button {
 	text-align: center;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .getting-started-category .codicon {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .getting-started-category .codicon {
 	top: 0px;
 }
 
-.monaco-workbench .part.editor>.content .getting-started-category .codicon-star-full::before {
+.monaco-workbench .part.editor > .content .getting-started-category .codicon-star-full::before {
 	vertical-align: middle;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .hide-category-button {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .hide-category-button {
 	visibility: hidden;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .getting-started-category:focus-within .hide-category-button,
-.monaco-workbench .part.editor>.content .gettingStartedContainer .getting-started-category:hover .hide-category-button {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .getting-started-category:focus-within .hide-category-button,
+.monaco-workbench .part.editor > .content .gettingStartedContainer .getting-started-category:hover .hide-category-button {
 	visibility: visible;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .gettingStartedSlideDetails .getting-started-step .step-description-container span {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlideDetails .getting-started-step .step-description-container span {
 	line-height: 1.3em;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .gettingStartedSlideDetails .getting-started-step .step-description-container .monaco-button, .monaco-workbench .part.editor>.content .gettingStartedContainer .max-lines-3 {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlideDetails .getting-started-step .step-description-container .monaco-button, .monaco-workbench .part.editor > .content .gettingStartedContainer .max-lines-3 {
 	/* Supported everywhere: https://developer.mozilla.org/en-US/docs/Web/CSS/-webkit-line-clamp#browser_compatibility */
 	-webkit-line-clamp: 3;
 	display: -webkit-box;
@@ -851,7 +851,7 @@
 	overflow: hidden;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .gettingStartedSlideDetails .getting-started-step .step-description-container .monaco-button {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlideDetails .getting-started-step .step-description-container .monaco-button {
 	height: 24px;
 	width: fit-content;
 	display: flex;
@@ -860,16 +860,16 @@
 	min-width: max-content;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .hide-category-button {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .hide-category-button {
 	padding: 3px;
 	border-radius: 5px;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .hide-category-button::before {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .hide-category-button::before {
 	vertical-align: unset;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .hide-category-button:hover {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .hide-category-button:hover {
 	background-color: var(--vscode-toolbar-hoverBackground);
 }
 
@@ -980,26 +980,26 @@
 	background-color: var(--vscode-welcomePage-progress-foreground);
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .gettingStartedSlide .getting-started-category .new-badge {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlide .getting-started-category .new-badge {
 	color: var(--vscode-activityBarBadge-foreground);
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .gettingStartedSlide .getting-started-category .featured .featured-icon {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlide .getting-started-category .featured .featured-icon {
 	color: var(--vscode-activityBarBadge-foreground);
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .gettingStartedSlide .getting-started-category .new-badge {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlide .getting-started-category .new-badge {
 	background-color: var(--vscode-activityBarBadge-background);
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .gettingStartedSlide .getting-started-checkbox {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlide .getting-started-checkbox {
 	background-color: var(--vscode-checkbox-background) !important;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .gettingStartedSlide .getting-started-checkbox {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlide .getting-started-checkbox {
 	color: var(--vscode-checkbox-foreground) !important;
 }
 
-.monaco-workbench .part.editor>.content .gettingStartedContainer .gettingStartedSlide .getting-started-checkbox {
+.monaco-workbench .part.editor > .content .gettingStartedContainer .gettingStartedSlide .getting-started-checkbox {
 	border-color: var(--vscode-checkbox-border) !important;
 }

--- a/src/vs/workbench/contrib/welcomeWalkthrough/browser/media/walkThroughPart.css
+++ b/src/vs/workbench/contrib/welcomeWalkthrough/browser/media/walkThroughPart.css
@@ -159,7 +159,7 @@
 	border-color: var(--vscode-contrastBorder);
 }
 
-.monaco-workbench .part.editor>.content .walkThroughContent .monaco-editor-background,
-.monaco-workbench .part.editor>.content .walkThroughContent .margin-view-overlays {
+.monaco-workbench .part.editor > .content .walkThroughContent .monaco-editor-background,
+.monaco-workbench .part.editor > .content .walkThroughContent .margin-view-overlays {
 	background: var(--vscode-walkThrough-embeddedEditorBackground);
 }

--- a/src/vs/workbench/services/suggest/browser/media/suggest.css
+++ b/src/vs/workbench/services/suggest/browser/media/suggest.css
@@ -69,8 +69,8 @@
 	margin-right: 0.3em;
 }
 
-.monaco-workbench .workbench-suggest-widget.with-status-bar .monaco-list .monaco-list-row>.contents>.main>.right>.readMore,
-.monaco-workbench .workbench-suggest-widget.with-status-bar .monaco-list .monaco-list-row.focused.string-label>.contents>.main>.right>.readMore {
+.monaco-workbench .workbench-suggest-widget.with-status-bar .monaco-list .monaco-list-row > .contents > .main > .right > .readMore,
+.monaco-workbench .workbench-suggest-widget.with-status-bar .monaco-list .monaco-list-row.focused.string-label > .contents > .main > .right > .readMore {
 	display: none;
 }
 
@@ -96,14 +96,14 @@
 	color: var(--vscode-editorSuggestWidget-selectedIconForeground);
 }
 
-.workbench-suggest-widget .monaco-list .monaco-list-row>.contents {
+.workbench-suggest-widget .monaco-list .monaco-list-row > .contents {
 	flex: 1;
 	height: 100%;
 	overflow: hidden;
 	padding-left: 2px;
 }
 
-.workbench-suggest-widget .monaco-list .monaco-list-row>.contents>.main {
+.workbench-suggest-widget .monaco-list .monaco-list-row > .contents > .main {
 	display: flex;
 	overflow: hidden;
 	text-overflow: ellipsis;
@@ -111,12 +111,12 @@
 	justify-content: space-between;
 }
 
-.workbench-suggest-widget .monaco-list .monaco-list-row>.contents>.main>.left,
-.workbench-suggest-widget .monaco-list .monaco-list-row>.contents>.main>.right {
+.workbench-suggest-widget .monaco-list .monaco-list-row > .contents > .main > .left,
+.workbench-suggest-widget .monaco-list .monaco-list-row > .contents > .main > .right {
 	display: flex;
 }
 
-.workbench-suggest-widget .monaco-list .monaco-list-row:not(.focused)>.contents>.main .monaco-icon-label {
+.workbench-suggest-widget .monaco-list .monaco-list-row:not(.focused) > .contents > .main .monaco-icon-label {
 	color: var(--vscode-editorSuggestWidget-foreground);
 }
 
@@ -124,11 +124,11 @@
 	font-weight: bold;
 }
 
-.workbench-suggest-widget .monaco-list .monaco-list-row>.contents>.main .monaco-highlighted-label .highlight {
+.workbench-suggest-widget .monaco-list .monaco-list-row > .contents > .main .monaco-highlighted-label .highlight {
 	color: var(--vscode-editorSuggestWidget-highlightForeground);
 }
 
-.workbench-suggest-widget .monaco-list .monaco-list-row.focused>.contents>.main .monaco-highlighted-label .highlight {
+.workbench-suggest-widget .monaco-list .monaco-list-row.focused > .contents > .main .monaco-highlighted-label .highlight {
 	color: var(--vscode-editorSuggestWidget-focusHighlightForeground);
 }
 
@@ -154,14 +154,14 @@
 	color: var(--vscode-editorSuggestWidget-selectedIconForeground);
 }
 
-.workbench-suggest-widget .monaco-list .monaco-list-row>.contents {
+.workbench-suggest-widget .monaco-list .monaco-list-row > .contents {
 	flex: 1;
 	height: 100%;
 	overflow: hidden;
 	padding-left: 2px;
 }
 
-.workbench-suggest-widget .monaco-list .monaco-list-row>.contents>.main {
+.workbench-suggest-widget .monaco-list .monaco-list-row > .contents > .main {
 	display: flex;
 	overflow: hidden;
 	text-overflow: ellipsis;
@@ -169,12 +169,12 @@
 	justify-content: space-between;
 }
 
-.workbench-suggest-widget .monaco-list .monaco-list-row>.contents>.main>.left,
-.workbench-suggest-widget .monaco-list .monaco-list-row>.contents>.main>.right {
+.workbench-suggest-widget .monaco-list .monaco-list-row > .contents > .main > .left,
+.workbench-suggest-widget .monaco-list .monaco-list-row > .contents > .main > .right {
 	display: flex;
 }
 
-.workbench-suggest-widget .monaco-list .monaco-list-row:not(.focused)>.contents>.main .monaco-icon-label {
+.workbench-suggest-widget .monaco-list .monaco-list-row:not(.focused) > .contents > .main .monaco-icon-label {
 	color: var(--vscode-editorSuggestWidget-foreground);
 }
 
@@ -182,11 +182,11 @@
 	font-weight: bold;
 }
 
-.workbench-suggest-widget .monaco-list .monaco-list-row>.contents>.main .monaco-highlighted-label .highlight {
+.workbench-suggest-widget .monaco-list .monaco-list-row > .contents > .main .monaco-highlighted-label .highlight {
 	color: var(--vscode-editorSuggestWidget-highlightForeground);
 }
 
-.workbench-suggest-widget .monaco-list .monaco-list-row.focused>.contents>.main .monaco-highlighted-label .highlight {
+.workbench-suggest-widget .monaco-list .monaco-list-row.focused > .contents > .main .monaco-highlighted-label .highlight {
 	color: var(--vscode-editorSuggestWidget-focusHighlightForeground);
 }
 
@@ -197,7 +197,7 @@
 	text-decoration: unset;
 }
 
-.workbench-suggest-widget .monaco-list .monaco-list-row .monaco-icon-label.deprecated>.monaco-icon-label-container>.monaco-icon-name-container {
+.workbench-suggest-widget .monaco-list .monaco-list-row .monaco-icon-label.deprecated > .monaco-icon-label-container > .monaco-icon-name-container {
 	text-decoration: line-through;
 }
 
@@ -239,17 +239,17 @@
 }
 /** signature, qualifier, type/details opacity **/
 
-.workbench-suggest-widget .monaco-list .monaco-list-row>.contents>.main>.right>.details-label {
+.workbench-suggest-widget .monaco-list .monaco-list-row > .contents > .main > .right > .details-label {
 	opacity: 0.7;
 }
 
-.workbench-suggest-widget .monaco-list .monaco-list-row>.contents>.main>.left>.signature-label {
+.workbench-suggest-widget .monaco-list .monaco-list-row > .contents > .main > .left > .signature-label {
 	overflow: hidden;
 	text-overflow: ellipsis;
 	opacity: 0.6;
 }
 
-.workbench-suggest-widget .monaco-list .monaco-list-row>.contents>.main>.left>.qualifier-label {
+.workbench-suggest-widget .monaco-list .monaco-list-row > .contents > .main > .left > .qualifier-label {
 	margin-left: 12px;
 	opacity: 0.4;
 	font-size: 85%;
@@ -261,7 +261,7 @@
 
 /** Type Info and icon next to the label in the focused completion item **/
 
-.workbench-suggest-widget .monaco-list .monaco-list-row>.contents>.main>.right>.details-label {
+.workbench-suggest-widget .monaco-list .monaco-list-row > .contents > .main > .right > .details-label {
 	font-size: 85%;
 	margin-left: 1.1em;
 	overflow: hidden;
@@ -269,59 +269,59 @@
 	white-space: nowrap;
 }
 
-.workbench-suggest-widget .monaco-list .monaco-list-row>.contents>.main>.right>.details-label>.monaco-tokenized-source {
+.workbench-suggest-widget .monaco-list .monaco-list-row > .contents > .main > .right > .details-label > .monaco-tokenized-source {
 	display: inline;
 }
 
 /** Details: if using CompletionItem#details, show on focus **/
 
-.workbench-suggest-widget .monaco-list .monaco-list-row>.contents>.main>.right>.details-label {
+.workbench-suggest-widget .monaco-list .monaco-list-row > .contents > .main > .right > .details-label {
 	display: none;
 }
 
-.workbench-suggest-widget:not(.shows-details) .monaco-list .monaco-list-row.focused>.contents>.main>.right>.details-label {
+.workbench-suggest-widget:not(.shows-details) .monaco-list .monaco-list-row.focused > .contents > .main > .right > .details-label {
 	display: inline;
 }
 
 /** Details: if using CompletionItemLabel#details, always show **/
 
-.workbench-suggest-widget .monaco-list .monaco-list-row:not(.string-label)>.contents>.main>.right>.details-label,
-.workbench-suggest-widget.docs-side .monaco-list .monaco-list-row.focused:not(.string-label)>.contents>.main>.right>.details-label {
+.workbench-suggest-widget .monaco-list .monaco-list-row:not(.string-label) > .contents > .main > .right > .details-label,
+.workbench-suggest-widget.docs-side .monaco-list .monaco-list-row.focused:not(.string-label) > .contents > .main > .right > .details-label {
 	display: inline;
 }
 
 
 /** Ellipsis on hover **/
 
-.workbench-suggest-widget:not(.docs-side) .monaco-list .monaco-list-row.focused:hover>.contents>.main>.right.can-expand-details>.details-label {
+.workbench-suggest-widget:not(.docs-side) .monaco-list .monaco-list-row.focused:hover > .contents > .main > .right.can-expand-details > .details-label {
 	width: calc(100% - 26px);
 }
 
-.workbench-suggest-widget .monaco-list .monaco-list-row>.contents>.main>.left {
+.workbench-suggest-widget .monaco-list .monaco-list-row > .contents > .main > .left {
 	flex-shrink: 1;
 	flex-grow: 1;
 	overflow: hidden;
 }
 
-.workbench-suggest-widget .monaco-list .monaco-list-row>.contents>.main>.left>.monaco-icon-label {
+.workbench-suggest-widget .monaco-list .monaco-list-row > .contents > .main > .left > .monaco-icon-label {
 	flex-shrink: 0;
 }
 
-.workbench-suggest-widget .monaco-list .monaco-list-row:not(.string-label)>.contents>.main>.left>.monaco-icon-label {
+.workbench-suggest-widget .monaco-list .monaco-list-row:not(.string-label) > .contents > .main > .left > .monaco-icon-label {
 	max-width: 100%;
 }
 
-.workbench-suggest-widget .monaco-list .monaco-list-row.string-label>.contents>.main>.left>.monaco-icon-label {
+.workbench-suggest-widget .monaco-list .monaco-list-row.string-label > .contents > .main > .left > .monaco-icon-label {
 	flex-shrink: 1;
 }
 
-.workbench-suggest-widget .monaco-list .monaco-list-row>.contents>.main>.right {
+.workbench-suggest-widget .monaco-list .monaco-list-row > .contents > .main > .right {
 	overflow: hidden;
 	flex-shrink: 4;
 	max-width: 70%;
 }
 
-.workbench-suggest-widget .monaco-list .monaco-list-row>.contents>.main>.right>.readMore {
+.workbench-suggest-widget .monaco-list .monaco-list-row > .contents > .main > .right > .readMore {
 	display: inline-block;
 	position: absolute;
 	right: 10px;

--- a/src/vs/workbench/services/userDataProfile/browser/media/userDataProfileView.css
+++ b/src/vs/workbench/services/userDataProfile/browser/media/userDataProfileView.css
@@ -7,43 +7,43 @@
 	display: inherit;
 }
 
-.monaco-workbench .pane>.pane-body>.profile-view-message-container {
+.monaco-workbench .pane > .pane-body > .profile-view-message-container {
 	display: flex;
 	padding: 13px 20px 0px 20px;
 	box-sizing: border-box;
 }
 
-.monaco-workbench .pane>.pane-body>.profile-view-message-container p {
+.monaco-workbench .pane > .pane-body > .profile-view-message-container p {
 	margin-block-start: 0em;
 	margin-block-end: 0em;
 }
 
-.monaco-workbench .pane>.pane-body>.profile-view-message-container a {
+.monaco-workbench .pane > .pane-body > .profile-view-message-container a {
 	color: var(--vscode-textLink-foreground)
 }
 
-.monaco-workbench .pane>.pane-body>.profile-view-message-container a:hover {
+.monaco-workbench .pane > .pane-body > .profile-view-message-container a:hover {
 	text-decoration: underline;
 	color: var(--vscode-textLink-activeForeground)
 }
 
-.monaco-workbench .pane>.pane-body>.profile-view-message-container a:active {
+.monaco-workbench .pane > .pane-body > .profile-view-message-container a:active {
 	color: var(--vscode-textLink-activeForeground)
 }
 
-.monaco-workbench .pane>.pane-body>.profile-view-message-container.hide {
+.monaco-workbench .pane > .pane-body > .profile-view-message-container.hide {
 	display: none;
 }
 
-.monaco-workbench .pane>.pane-body>.profile-view-buttons-container {
+.monaco-workbench .pane > .pane-body > .profile-view-buttons-container {
 	display: flex;
 	flex-direction: column;
 	padding: 13px 20px;
 	box-sizing: border-box;
 }
 
-.monaco-workbench .pane>.pane-body>.profile-view-buttons-container>.monaco-button,
-.monaco-workbench .pane>.pane-body>.profile-view-buttons-container>.monaco-button-dropdown {
+.monaco-workbench .pane > .pane-body > .profile-view-buttons-container > .monaco-button,
+.monaco-workbench .pane > .pane-body > .profile-view-buttons-container > .monaco-button-dropdown {
 	margin-block-start: 13px;
 	margin-inline-start: 0px;
 	margin-inline-end: 0px;
@@ -52,11 +52,11 @@
 	margin-right: auto;
 }
 
-.monaco-workbench .pane>.pane-body>.profile-view-buttons-container>.monaco-button-dropdown {
+.monaco-workbench .pane > .pane-body > .profile-view-buttons-container > .monaco-button-dropdown {
 	width: 100%;
 }
 
-.monaco-workbench .pane>.pane-body>.profile-view-buttons-container>.monaco-button-dropdown>.monaco-dropdown-button {
+.monaco-workbench .pane > .pane-body > .profile-view-buttons-container > .monaco-button-dropdown > .monaco-dropdown-button {
 	display: flex;
 	align-items: center;
 	padding: 0 4px;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
Fixes https://github.com/microsoft/vscode/issues/169664. I believe I discussed this with the team earlier in the year, but never implemented it. The new setting enforces spaces around ` > ` so I added the spacing (which causes most of the diff)