### PR TITLE
Warn on opaque needsTransparency colors, expose to workbench

### DIFF
--- a/src/vs/platform/theme/common/colorRegistry.ts
+++ b/src/vs/platform/theme/common/colorRegistry.ts
@@ -142,7 +142,7 @@ class ColorRegistry implements IColorRegistry {
 		}
 		if (needsTransparency) {
 			propertySchema.pattern = '^#(?:(?<rgba>[0-9a-fA-f]{3}[0-9a-eA-E])|(?:[0-9a-fA-F]{6}(?:(?![fF]{2})(?:[0-9a-fA-F]{2}))))?$';
-			propertySchema.patternErrorMessage = 'This color must be transparent or it will obscure the selection';
+			propertySchema.patternErrorMessage = 'This color must be transparent or it will obscure content';
 		}
 		this.colorSchema.properties[id] = propertySchema;
 		this.colorReferenceSchema.enum.push(id);

--- a/src/vs/platform/theme/common/colorRegistry.ts
+++ b/src/vs/platform/theme/common/colorRegistry.ts
@@ -88,9 +88,10 @@ export interface IColorRegistry {
 	 * Register a color to the registry.
 	 * @param id The color id as used in theme description files
 	 * @param defaults The default values
+	 * @param needsTransparency Whether the color requires transparency
 	 * @description the description
 	 */
-	registerColor(id: string, defaults: ColorDefaults, description: string): ColorIdentifier;
+	registerColor(id: string, defaults: ColorDefaults, description: string, needsTransparency?: boolean): ColorIdentifier;
 
 	/**
 	 * Register a color to the registry.
@@ -138,6 +139,10 @@ class ColorRegistry implements IColorRegistry {
 		const propertySchema: IJSONSchema = { type: 'string', description, format: 'color-hex', defaultSnippets: [{ body: '${1:#ff0000}' }] };
 		if (deprecationMessage) {
 			propertySchema.deprecationMessage = deprecationMessage;
+		}
+		if (needsTransparency) {
+			propertySchema.pattern = '^#(?:(?<rgba>[0-9a-fA-f]{3}[0-9a-eA-E])|(?:[0-9a-fA-F]{6}(?:(?![fF]{2})(?:[0-9a-fA-F]{2}))))?$';
+			propertySchema.patternErrorMessage = 'This color must be transparent or it will obscure the selection';
 		}
 		this.colorSchema.properties[id] = propertySchema;
 		this.colorReferenceSchema.enum.push(id);

--- a/src/vs/workbench/contrib/terminal/common/terminalColorRegistry.ts
+++ b/src/vs/workbench/contrib/terminal/common/terminalColorRegistry.ts
@@ -77,7 +77,7 @@ export const TERMINAL_FIND_MATCH_BACKGROUND_COLOR = registerColor('terminal.find
 	// Use regular selection background in high contrast with a thick border
 	hcDark: null,
 	hcLight: '#0F4A85'
-}, nls.localize('terminal.findMatchBackground', 'Color of the current search match in the terminal. The color must not be opaque so as not to hide underlying terminal content.'));
+}, nls.localize('terminal.findMatchBackground', 'Color of the current search match in the terminal. The color must not be opaque so as not to hide underlying terminal content.'), true);
 export const TERMINAL_HOVER_HIGHLIGHT_BACKGROUND_COLOR = registerColor('terminal.hoverHighlightBackground', {
 	dark: transparent(editorHoverHighlight, 0.5),
 	light: transparent(editorHoverHighlight, 0.5),
@@ -95,7 +95,7 @@ export const TERMINAL_FIND_MATCH_HIGHLIGHT_BACKGROUND_COLOR = registerColor('ter
 	light: editorFindMatchHighlight,
 	hcDark: null,
 	hcLight: null
-}, nls.localize('terminal.findMatchHighlightBackground', 'Color of the other search matches in the terminal. The color must not be opaque so as not to hide underlying terminal content.'));
+}, nls.localize('terminal.findMatchHighlightBackground', 'Color of the other search matches in the terminal. The color must not be opaque so as not to hide underlying terminal content.'), true);
 export const TERMINAL_FIND_MATCH_HIGHLIGHT_BORDER_COLOR = registerColor('terminal.findMatchHighlightBorder', {
 	dark: null,
 	light: null,
@@ -113,7 +113,7 @@ export const TERMINAL_DRAG_AND_DROP_BACKGROUND = registerColor('terminal.dropBac
 	light: EDITOR_DRAG_AND_DROP_BACKGROUND,
 	hcDark: EDITOR_DRAG_AND_DROP_BACKGROUND,
 	hcLight: EDITOR_DRAG_AND_DROP_BACKGROUND
-}, nls.localize('terminal.dragAndDropBackground', "Background color when dragging on top of terminals. The color should have transparency so that the terminal contents can still shine through."));
+}, nls.localize('terminal.dragAndDropBackground', "Background color when dragging on top of terminals. The color should have transparency so that the terminal contents can still shine through."), true);
 export const TERMINAL_TAB_ACTIVE_BORDER = registerColor('terminal.tab.activeBorder', {
 	dark: TAB_ACTIVE_BORDER,
 	light: TAB_ACTIVE_BORDER,


### PR DESCRIPTION
fixes #200050

The relatively complex regex matches `#000e`, `#000000fe` but not `#000f`, `#000000ff`

![image](https://github.com/microsoft/vscode/assets/2193314/ed835296-9270-4525-bcd7-8e33d055c8a3)
![image](https://github.com/microsoft/vscode/assets/2193314/36ff6bbb-31f0-4b51-a61d-f028b4a74220)
