### PR TITLE
Respect early returns from pre-existing bash debug traps

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/media/shellIntegration-bash.sh
+++ b/src/vs/workbench/contrib/terminal/browser/media/shellIntegration-bash.sh
@@ -256,8 +256,8 @@ else
 		__vsc_preexec_all() {
 			if [ "$__vsc_in_command_execution" = "0" ]; then
 				__vsc_in_command_execution="1"
-				builtin eval "${__vsc_dbg_trap}"
 				__vsc_preexec
+				builtin eval "${__vsc_dbg_trap}"
 			fi
 		}
 		trap '__vsc_preexec_all "$_"' DEBUG


### PR DESCRIPTION
Fixes #179483

Before

<img width="297" alt="Screenshot 2023-12-05 at 11 53 06" src="https://github.com/microsoft/vscode/assets/2193314/2b3d3654-a636-4627-a764-3f6e23a1b0e4">

After

<img width="303" alt="Screenshot 2023-12-05 at 11 52 57" src="https://github.com/microsoft/vscode/assets/2193314/8229e2fb-7ca0-4bbe-a58a-b5ad8f82fb72">
