### PR TITLE
Revert: Allow non-AI actions on empty lines

### DIFF
--- a/src/vs/editor/contrib/codeAction/common/types.ts
+++ b/src/vs/editor/contrib/codeAction/common/types.ts
@@ -127,11 +127,6 @@ export function filtersAction(filter: CodeActionFilter, action: languages.CodeAc
 		}
 	}
 
-	// On empty lines and selections, show only code AI code actions
-	if (rangeOrSelection.isEmpty() && model.getLineContent(rangeOrSelection.startLineNumber).length === 0) {
-		return !!action.isAI;
-	}
-
 	return true;
 }
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

regarding/discovered by https://github.com/microsoft/vscode/issues/199548, small change from: https://github.com/microsoft/vscode/pull/198840

Contributed code actions (and any other code actions in general) were not being shown on empty lines or empty files because only AI fixes would be shown. In empty lines, VS Code typically does not contribute any code actions, but extensions and linters do, and those will not show up when we check for `isAI`

Does not affect whether lightbulbs are shown or not on empty lines from the setting.

Regarding safety - not 100% on this, will defer to @aiday-mar. However, it is just reverting back to the original filtering.



cc. @aiday-mar 