### PR TITLE
Add the option to skip the prompt to save the workspace config (fix #187794)

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadFileSystemEventService.ts
+++ b/src/vs/workbench/api/browser/mainThreadFileSystemEventService.ts
@@ -168,7 +168,7 @@ export class MainThreadFileSystemEventService implements MainThreadFileSystemEve
 								label: localize('cancel', "Skip Changes"),
 								run: () => Choice.Cancel
 							},
-							checkbox: { label: localize('again', "Don't ask again") }
+							checkbox: { label: localize('again', "Do not ask me again") }
 						});
 						if (result === Choice.Cancel) {
 							// no changes wanted, don't persist cancel option

--- a/src/vs/workbench/contrib/mergeEditor/browser/mergeEditorInputModel.ts
+++ b/src/vs/workbench/contrib/mergeEditor/browser/mergeEditorInputModel.ts
@@ -473,7 +473,7 @@ class WorkspaceMergeEditorInputModel extends EditorModel implements IMergeEditor
 				primaryButton: someUnhandledConflicts
 					? localize({ key: 'workspace.closeWithConflicts', comment: ['&& denotes a mnemonic'] }, '&&Close with Conflicts')
 					: localize({ key: 'workspace.close', comment: ['&& denotes a mnemonic'] }, '&&Close'),
-				checkbox: { label: localize('noMoreWarn', "Don't ask again") }
+				checkbox: { label: localize('noMoreWarn', "Do not ask me again") }
 			});
 
 			if (checkboxChecked) {

--- a/src/vs/workbench/electron-sandbox/desktop.contribution.ts
+++ b/src/vs/workbench/electron-sandbox/desktop.contribution.ts
@@ -154,7 +154,6 @@ import { applicationConfigurationNodeBase, securityConfigurationNodeBase } from 
 			'window.confirmSaveUntitledWorkspace': {
 				'type': 'boolean',
 				'default': true,
-				'scope': ConfigurationScope.APPLICATION,
 				'description': localize('confirmSaveUntitledWorkspace', "Controls whether a confirmation dialog shows asking to save or discard an opened untitled workspace in the window when switching to another workspace."),
 			},
 			'window.openWithoutArgumentsInNewWindow': {

--- a/src/vs/workbench/electron-sandbox/desktop.contribution.ts
+++ b/src/vs/workbench/electron-sandbox/desktop.contribution.ts
@@ -151,6 +151,12 @@ import { applicationConfigurationNodeBase, securityConfigurationNodeBase } from 
 		'title': localize('windowConfigurationTitle', "Window"),
 		'type': 'object',
 		'properties': {
+			'window.confirmSaveUntitledWorkspace': {
+				'type': 'boolean',
+				'default': true,
+				'scope': ConfigurationScope.APPLICATION,
+				'description': localize('confirmSaveUntitledWorkspace', "Controls whether a confirmation dialog shows asking to save or discard an opened untitled workspace in the window when switching to another workspace."),
+			},
 			'window.openWithoutArgumentsInNewWindow': {
 				'type': 'string',
 				'enum': ['on', 'off'],

--- a/src/vs/workbench/services/extensions/browser/extensionUrlHandler.ts
+++ b/src/vs/workbench/services/extensions/browser/extensionUrlHandler.ts
@@ -180,7 +180,7 @@ class ExtensionUrlHandler implements IExtensionUrlHandler, IURLHandler {
 			const result = await this.dialogService.confirm({
 				message: localize('confirmUrl', "Allow '{0}' extension to open this URI?", extensionDisplayName),
 				checkbox: {
-					label: localize('rememberConfirmUrl', "Don't ask again for this extension."),
+					label: localize('rememberConfirmUrl', "Do not ask me again for this extension"),
 				},
 				detail: uriString,
 				primaryButton: localize({ key: 'open', comment: ['&& denotes a mnemonic'] }, "&&Open")

--- a/src/vs/workbench/services/workspaces/browser/abstractWorkspaceEditingService.ts
+++ b/src/vs/workbench/services/workspaces/browser/abstractWorkspaceEditingService.ts
@@ -37,7 +37,7 @@ export abstract class AbstractWorkspaceEditingService implements IWorkspaceEditi
 	constructor(
 		@IJSONEditingService private readonly jsonEditingService: IJSONEditingService,
 		@IWorkspaceContextService protected readonly contextService: WorkspaceService,
-		@IWorkbenchConfigurationService private readonly configurationService: IWorkbenchConfigurationService,
+		@IWorkbenchConfigurationService protected readonly configurationService: IWorkbenchConfigurationService,
 		@INotificationService private readonly notificationService: INotificationService,
 		@ICommandService private readonly commandService: ICommandService,
 		@IFileService private readonly fileService: IFileService,

--- a/src/vs/workbench/services/workspaces/electron-sandbox/workspaceEditingService.ts
+++ b/src/vs/workbench/services/workspaces/electron-sandbox/workspaceEditingService.ts
@@ -88,7 +88,7 @@ export class NativeWorkspaceEditingService extends AbstractWorkspaceEditingServi
 			return false; // Windows/Linux: quits when last window is closed, so do not ask then
 		}
 
-		const confirmSaveUntitledWorkspace = this.configurationService.getValue('window.confirmSaveUntitledWorkspace') !== false;
+		const confirmSaveUntitledWorkspace = this.configurationService.getValue<boolean>('window.confirmSaveUntitledWorkspace') !== false;
 		if (!confirmSaveUntitledWorkspace) {
 			return false; // no confirmation configured
 		}

--- a/src/vs/workbench/services/workspaces/electron-sandbox/workspaceEditingService.ts
+++ b/src/vs/workbench/services/workspaces/electron-sandbox/workspaceEditingService.ts
@@ -93,6 +93,7 @@ export class NativeWorkspaceEditingService extends AbstractWorkspaceEditingServi
 			return false; // no confirmation configured
 		}
 
+		let canceled = false;
 		const { result, checkboxChecked } = await this.dialogService.prompt<boolean>({
 			type: Severity.Warning,
 			message: localize('saveWorkspaceMessage', "Do you want to save your workspace configuration as a file?"),
@@ -136,14 +137,18 @@ export class NativeWorkspaceEditingService extends AbstractWorkspaceEditingServi
 				}
 			],
 			cancelButton: {
-				run: () => true // veto
+				run: () => {
+					canceled = true;
+
+					return true; // veto
+				}
 			},
 			checkbox: {
 				label: localize('doNotAskAgain', "Do not ask me again")
 			}
 		});
 
-		if (checkboxChecked) {
+		if (!canceled && checkboxChecked) {
 			await this.configurationService.updateValue('window.confirmSaveUntitledWorkspace', false, ConfigurationTarget.USER);
 		}
 


### PR DESCRIPTION
fix #187794