### PR TITLE
Refactoring the hover.ts file

### DIFF
--- a/src/vs/editor/contrib/colorPicker/browser/colorContributions.ts
+++ b/src/vs/editor/contrib/colorPicker/browser/colorContributions.ts
@@ -11,7 +11,7 @@ import { Range } from 'vs/editor/common/core/range';
 import { IEditorContribution } from 'vs/editor/common/editorCommon';
 import { ColorDecorationInjectedTextMarker } from 'vs/editor/contrib/colorPicker/browser/colorDetector';
 import { ColorHoverParticipant } from 'vs/editor/contrib/colorPicker/browser/colorHoverParticipant';
-import { ModesHoverController } from 'vs/editor/contrib/hover/browser/hover';
+import { HoverController } from 'vs/editor/contrib/hover/browser/hover';
 import { HoverStartMode, HoverStartSource } from 'vs/editor/contrib/hover/browser/hoverOperation';
 import { HoverParticipantRegistry } from 'vs/editor/contrib/hover/browser/hoverTypes';
 
@@ -56,7 +56,7 @@ export class ColorContribution extends Disposable implements IEditorContribution
 			return;
 		}
 
-		const hoverController = this._editor.getContribution<ModesHoverController>(ModesHoverController.ID);
+		const hoverController = this._editor.getContribution<HoverController>(HoverController.ID);
 		if (!hoverController) {
 			return;
 		}

--- a/src/vs/editor/contrib/hover/browser/contentHover.ts
+++ b/src/vs/editor/contrib/hover/browser/contentHover.ts
@@ -94,7 +94,7 @@ export class ContentHoverController extends Disposable {
 	/**
 	 * Returns true if the hover shows now or will show.
 	 */
-	public maybeShowAt(mouseEvent: IEditorMouseEvent): boolean {
+	public showsOrWillShow(mouseEvent: IEditorMouseEvent): boolean {
 		if (this._widget.isResizing) {
 			return true;
 		}

--- a/src/vs/editor/contrib/hover/browser/hover.ts
+++ b/src/vs/editor/contrib/hover/browser/hover.ts
@@ -236,8 +236,7 @@ export class HoverController extends Disposable implements IEditorContribution {
 			// When the alt key is pressed, hover remains visible
 			return;
 		}
-		if (this._contentWidget?.isFocused || this._contentWidget?.isResizing
-		) {
+		if (this._contentWidget?.isFocused || this._contentWidget?.isResizing) {
 			return;
 		}
 		if (this._hoverState.mouseDown && this._hoverState.contentHoverFocused) {

--- a/src/vs/editor/contrib/hover/browser/hover.ts
+++ b/src/vs/editor/contrib/hover/browser/hover.ts
@@ -101,9 +101,11 @@ export class HoverController extends Disposable implements IEditorContribution {
 	private _hookListeners(): void {
 
 		const hoverOpts = this._editor.getOption(EditorOption.hover);
-		this._hoverSettings.enabled = hoverOpts.enabled;
-		this._hoverSettings.sticky = hoverOpts.sticky;
-		this._hoverSettings.hidingDelay = hoverOpts.hidingDelay;
+		this._hoverSettings = {
+			enabled: hoverOpts.enabled,
+			sticky: hoverOpts.sticky,
+			hidingDelay: hoverOpts.delay
+		};
 
 		if (hoverOpts.enabled) {
 			this._listenersStore.add(this._editor.onMouseDown((e: IEditorMouseEvent) => this._onEditorMouseDown(e)));

--- a/src/vs/editor/contrib/hover/browser/hover.ts
+++ b/src/vs/editor/contrib/hover/browser/hover.ts
@@ -29,96 +29,109 @@ import { MarkerHoverParticipant } from 'vs/editor/contrib/hover/browser/markerHo
 import { InlineSuggestionHintsContentWidget } from 'vs/editor/contrib/inlineCompletions/browser/inlineCompletionsHintsWidget';
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 import { ResultKind } from 'vs/platform/keybinding/common/keybindingResolver';
+import { RunOnceScheduler } from 'vs/base/common/async';
 import * as nls from 'vs/nls';
 import 'vs/css!./hover';
-import { RunOnceScheduler } from 'vs/base/common/async';
 
 // sticky hover widget which doesn't disappear on focus out and such
 const _sticky = false
 	// || Boolean("true") // done "weirdly" so that a lint warning prevents you from pushing this
 	;
 
-export class ModesHoverController extends Disposable implements IEditorContribution {
+interface IHoverSettings {
+	enabled: boolean;
+	sticky: boolean;
+	hidingDelay: number;
+}
+
+interface IHoverState {
+	mouseDown: boolean;
+	locked: boolean;
+	// TODO @aiday-mar maybe not needed, investigate this
+	contentHoverFocused: boolean;
+	activatedByDecoratorClick: boolean;
+}
+
+export class HoverController extends Disposable implements IEditorContribution {
 
 	public static readonly ID = 'editor.contrib.hover';
 
-	private readonly _toUnhook = new DisposableStore();
+	private readonly _listenersStore = new DisposableStore();
 
-	private _contentWidget: ContentHoverController | null;
+	private _glyphWidget: MarginHoverWidget | undefined;
+	private _contentWidget: ContentHoverController | undefined;
 
-	getWidgetContent(): string | undefined { return this._contentWidget?.getWidgetContent(); }
-
-	private _glyphWidget: MarginHoverWidget | null;
-
-	private _isMouseDown: boolean;
-	private _hoverClicked: boolean;
-	private _isHoverEnabled!: boolean;
-	private _isHoverSticky!: boolean;
-	private _hidingDelay!: number;
-	private _hoverActivatedByColorDecoratorClick: boolean = false;
-	private _reactToEditorMouseMoveRunner: RunOnceScheduler;
 	private _mouseMoveEvent: IEditorMouseEvent | undefined;
-	private _isLocked: boolean = false;
+	private _reactToEditorMouseMoveRunner: RunOnceScheduler;
 
-	static get(editor: ICodeEditor): ModesHoverController | null {
-		return editor.getContribution<ModesHoverController>(ModesHoverController.ID);
-	}
+	private _hoverSettings!: IHoverSettings;
+	private _hoverState: IHoverState = {
+		mouseDown: false,
+		locked: false,
+		contentHoverFocused: false,
+		activatedByDecoratorClick: false
+	};
 
-	constructor(private readonly _editor: ICodeEditor,
+	constructor(
+		private readonly _editor: ICodeEditor,
 		@IInstantiationService private readonly _instantiationService: IInstantiationService,
 		@IOpenerService private readonly _openerService: IOpenerService,
 		@ILanguageService private readonly _languageService: ILanguageService,
 		@IKeybindingService private readonly _keybindingService: IKeybindingService
 	) {
 		super();
-		this._isMouseDown = false;
-		this._hoverClicked = false;
-		this._contentWidget = null;
-		this._glyphWidget = null;
-		this._reactToEditorMouseMoveRunner = this._register(new RunOnceScheduler(() => this._reactToEditorMouseMove(this._mouseMoveEvent), 0));
-
-		this._hookEvents();
+		this._reactToEditorMouseMoveRunner = this._register(
+			new RunOnceScheduler(
+				() => this._reactToEditorMouseMove(this._mouseMoveEvent), 0
+			)
+		);
+		this._hookListeners();
 		this._register(this._editor.onDidChangeConfiguration((e: ConfigurationChangedEvent) => {
 			if (e.hasChanged(EditorOption.hover)) {
-				this._unhookEvents();
-				this._hookEvents();
+				this._unhookListeners();
+				this._hookListeners();
 			}
 		}));
 	}
 
-	private _hookEvents(): void {
+	static get(editor: ICodeEditor): HoverController | null {
+		return editor.getContribution<HoverController>(HoverController.ID);
+	}
+
+	private _hookListeners(): void {
 
 		const hoverOpts = this._editor.getOption(EditorOption.hover);
-		this._isHoverEnabled = hoverOpts.enabled;
-		this._isHoverSticky = hoverOpts.sticky;
-		this._hidingDelay = hoverOpts.hidingDelay;
-		if (this._isHoverEnabled) {
-			this._toUnhook.add(this._editor.onMouseDown((e: IEditorMouseEvent) => this._onEditorMouseDown(e)));
-			this._toUnhook.add(this._editor.onMouseUp((e: IEditorMouseEvent) => this._onEditorMouseUp(e)));
-			this._toUnhook.add(this._editor.onMouseMove((e: IEditorMouseEvent) => this._onEditorMouseMove(e)));
-			this._toUnhook.add(this._editor.onKeyDown((e: IKeyboardEvent) => this._onKeyDown(e)));
-			this._toUnhook.add(this._editor.onKeyUp((e: IKeyboardEvent) => this._onKeyUp(e)));
+		this._hoverSettings.enabled = hoverOpts.enabled;
+		this._hoverSettings.sticky = hoverOpts.sticky;
+		this._hoverSettings.hidingDelay = hoverOpts.hidingDelay;
+
+		if (hoverOpts.enabled) {
+			this._listenersStore.add(this._editor.onMouseDown((e: IEditorMouseEvent) => this._onEditorMouseDown(e)));
+			this._listenersStore.add(this._editor.onMouseUp(() => this._onEditorMouseUp()));
+			this._listenersStore.add(this._editor.onMouseMove((e: IEditorMouseEvent) => this._onEditorMouseMove(e)));
+			this._listenersStore.add(this._editor.onKeyDown((e: IKeyboardEvent) => this._onKeyDown(e)));
+			this._listenersStore.add(this._editor.onKeyUp((e: IKeyboardEvent) => this._onKeyUp(e)));
 		} else {
-			this._toUnhook.add(this._editor.onMouseMove((e: IEditorMouseEvent) => this._onEditorMouseMove(e)));
-			this._toUnhook.add(this._editor.onKeyDown((e: IKeyboardEvent) => this._onKeyDown(e)));
+			this._listenersStore.add(this._editor.onMouseMove((e: IEditorMouseEvent) => this._onEditorMouseMove(e)));
+			this._listenersStore.add(this._editor.onKeyDown((e: IKeyboardEvent) => this._onKeyDown(e)));
 		}
 
-		this._toUnhook.add(this._editor.onMouseLeave((e) => this._onEditorMouseLeave(e)));
-		this._toUnhook.add(this._editor.onDidChangeModel(() => {
+		this._listenersStore.add(this._editor.onMouseLeave((e) => this._onEditorMouseLeave(e)));
+		this._listenersStore.add(this._editor.onDidChangeModel(() => {
 			this._cancelScheduler();
 			this._hideWidgets();
 		}));
-		this._toUnhook.add(this._editor.onDidChangeModelContent(() => this._cancelScheduler()));
-		this._toUnhook.add(this._editor.onDidScrollChange((e: IScrollEvent) => this._onEditorScrollChanged(e)));
+		this._listenersStore.add(this._editor.onDidChangeModelContent(() => this._cancelScheduler()));
+		this._listenersStore.add(this._editor.onDidScrollChange((e: IScrollEvent) => this._onEditorScrollChanged(e)));
+	}
+
+	private _unhookListeners(): void {
+		this._listenersStore.clear();
 	}
 
 	private _cancelScheduler() {
 		this._mouseMoveEvent = undefined;
 		this._reactToEditorMouseMoveRunner.cancel();
-	}
-
-	private _unhookEvents(): void {
-		this._toUnhook.clear();
 	}
 
 	private _onEditorScrollChanged(e: IScrollEvent): void {
@@ -128,50 +141,58 @@ export class ModesHoverController extends Disposable implements IEditorContribut
 	}
 
 	private _onEditorMouseDown(mouseEvent: IEditorMouseEvent): void {
-		this._isMouseDown = true;
 
+		this._hoverState.mouseDown = true;
 		const target = mouseEvent.target;
 
 		if (target.type === MouseTargetType.CONTENT_WIDGET && target.detail === ContentHoverWidget.ID) {
-			this._hoverClicked = true;
 			// mouse down on top of content hover widget
+			this._hoverState.contentHoverFocused = true;
 			return;
 		}
 
 		if (target.type === MouseTargetType.OVERLAY_WIDGET && target.detail === MarginHoverWidget.ID) {
-			// mouse down on top of overlay hover widget
+			// mouse down on top of margin hover widget
 			return;
 		}
 
 		if (target.type !== MouseTargetType.OVERLAY_WIDGET) {
-			this._hoverClicked = false;
+			this._hoverState.contentHoverFocused = false;
 		}
-		if (!this._contentWidget?.widget.isResizing) {
-			this._hideWidgets();
+
+		if (this._contentWidget?.widget.isResizing) {
+			return;
 		}
+
+		this._hideWidgets();
 	}
 
-	private _onEditorMouseUp(mouseEvent: IEditorMouseEvent): void {
-		this._isMouseDown = false;
+	private _onEditorMouseUp(): void {
+		this._hoverState.mouseDown = false;
 	}
 
 	private _onEditorMouseLeave(mouseEvent: IPartialEditorMouseEvent): void {
+
 		this._cancelScheduler();
-		const targetEm = (mouseEvent.event.browserEvent.relatedTarget) as HTMLElement;
-		if (this._contentWidget?.widget.isResizing || this._contentWidget?.containsNode(targetEm)) {
+		const targetElement = (mouseEvent.event.browserEvent.relatedTarget) as HTMLElement;
+
+		if (this._contentWidget?.widget.isResizing || this._contentWidget?.containsNode(targetElement)) {
 			// When the content widget is resizing
-			// when the mouse is inside hover widget
+			// When the mouse is inside hover widget
 			return;
 		}
-		if (!_sticky) {
-			this._hideWidgets();
+		if (_sticky) {
+			return;
 		}
+		this._hideWidgets();
 	}
 
 	private _isMouseOverWidget(mouseEvent: IEditorMouseEvent): boolean {
+
 		const target = mouseEvent.target;
+		const sticky = this._hoverSettings.sticky;
 		if (
-			this._isHoverSticky
+			sticky
 			&& target.type === MouseTargetType.CONTENT_WIDGET
 			&& target.detail === ContentHoverWidget.ID
 		) {
@@ -179,7 +200,7 @@ export class ModesHoverController extends Disposable implements IEditorContribut
 			return true;
 		}
 		if (
-			this._isHoverSticky
+			sticky
 			&& this._contentWidget?.containsNode(mouseEvent.event.browserEvent.view?.document.activeElement)
 			&& !mouseEvent.event.browserEvent.view?.getSelection()?.isCollapsed
 		) {
@@ -187,16 +208,16 @@ export class ModesHoverController extends Disposable implements IEditorContribut
 			return true;
 		}
 		if (
-			!this._isHoverSticky
+			!sticky
 			&& target.type === MouseTargetType.CONTENT_WIDGET
 			&& target.detail === ContentHoverWidget.ID
 			&& this._contentWidget?.isColorPickerVisible
 		) {
-			// though the hover is not sticky, the color picker needs to.
+			// though the hover is not sticky, the color picker is sticky
 			return true;
 		}
 		if (
-			this._isHoverSticky
+			sticky
 			&& target.type === MouseTargetType.OVERLAY_WIDGET
 			&& target.detail === MarginHoverWidget.ID
 		) {
@@ -207,18 +228,21 @@ export class ModesHoverController extends Disposable implements IEditorContribut
 	}
 
 	private _onEditorMouseMove(mouseEvent: IEditorMouseEvent): void {
+
 		this._mouseMoveEvent = mouseEvent;
-		if (this._isLocked) {
+		if (this._hoverState.locked) {
 			// When the alt key is pressed, hover remains visible
 			return;
 		}
-		if (this._contentWidget?.isFocused || this._contentWidget?.isResizing) {
+		if (this._contentWidget?.isFocused || this._contentWidget?.isResizing
+		) {
 			return;
 		}
-		if (this._isMouseDown && this._hoverClicked) {
+		if (this._hoverState.mouseDown && this._hoverState.contentHoverFocused) {
 			return;
 		}
-		if (this._isHoverSticky && this._contentWidget?.isVisibleFromKeyboard) {
+		const sticky = this._hoverSettings.sticky;
+		if (sticky && this._contentWidget?.isVisibleFromKeyboard) {
 			// Sticky mode is on and the hover has been shown via keyboard
 			// so moving the mouse has no effect
 			return;
@@ -233,9 +257,10 @@ export class ModesHoverController extends Disposable implements IEditorContribut
 
 		// If the mouse is not over the widget, and if sticky is on,
 		// then give it a grace period before reacting to the mouse event
-		if (this._contentWidget?.isVisible && this._isHoverSticky && this._hidingDelay > 0) {
+		const hidingDelay = this._hoverSettings.hidingDelay;
+		if (this._contentWidget?.isVisible && sticky && hidingDelay > 0) {
 			if (!this._reactToEditorMouseMoveRunner.isScheduled()) {
-				this._reactToEditorMouseMoveRunner.schedule(this._hidingDelay);
+				this._reactToEditorMouseMoveRunner.schedule(hidingDelay);
 			}
 			return;
 		}
@@ -243,20 +268,28 @@ export class ModesHoverController extends Disposable implements IEditorContribut
 	}
 
 	private _reactToEditorMouseMove(mouseEvent: IEditorMouseEvent | undefined): void {
+
 		if (!mouseEvent) {
 			return;
 		}
 
 		const target = mouseEvent.target;
-
 		const mouseOnDecorator = target.element?.classList.contains('colorpicker-color-decoration');
 		const decoratorActivatedOn = this._editor.getOption(EditorOption.colorDecoratorsActivatedOn);
 
-		if ((mouseOnDecorator && (
-			(decoratorActivatedOn === 'click' && !this._hoverActivatedByColorDecoratorClick) ||
-			(decoratorActivatedOn === 'hover' && !this._isHoverEnabled && !_sticky) ||
-			(decoratorActivatedOn === 'clickAndHover' && !this._isHoverEnabled && !this._hoverActivatedByColorDecoratorClick)))
-			|| !mouseOnDecorator && !this._isHoverEnabled && !this._hoverActivatedByColorDecoratorClick
+		const enabled = this._hoverSettings.enabled;
+		const activatedByDecoratorClick = this._hoverState.activatedByDecoratorClick;
+		if (
+			(
+				mouseOnDecorator && (
+					(decoratorActivatedOn === 'click' && !activatedByDecoratorClick) ||
+					(decoratorActivatedOn === 'hover' && !enabled && !_sticky) ||
+					(decoratorActivatedOn === 'clickAndHover' && !enabled && !activatedByDecoratorClick))
+			)
+			||
+			(
+				!mouseOnDecorator && !enabled && !activatedByDecoratorClick
+			)
 		) {
 			this._hideWidgets();
 			return;
@@ -264,17 +297,15 @@ export class ModesHoverController extends Disposable implements IEditorContribut
 
 		const contentWidget = this._getOrCreateContentWidget();
 
-		if (contentWidget.maybeShowAt(mouseEvent)) {
+		if (contentWidget.showsOrWillShow(mouseEvent)) {
 			this._glyphWidget?.hide();
 			return;
 		}
 
 		if (target.type === MouseTargetType.GUTTER_GLYPH_MARGIN && target.position) {
 			this._contentWidget?.hide();
-			if (!this._glyphWidget) {
-				this._glyphWidget = new MarginHoverWidget(this._editor, this._languageService, this._openerService);
-			}
-			this._glyphWidget.startShowingAt(target.position.lineNumber);
+			const glyphWidget = this._getOrCreateGlyphWidget();
+			glyphWidget.startShowingAt(target.position.lineNumber);
 			return;
 		}
 		if (_sticky) {
@@ -290,14 +321,30 @@ export class ModesHoverController extends Disposable implements IEditorContribut
 		this._toggleLockedState(e.altKey);
 
 		const resolvedKeyboardEvent = this._keybindingService.softDispatch(e, this._editor.getDomNode());
-		// If the beginning of a multi-chord keybinding is pressed, or the command aims to focus the hover, set the variable to true, otherwise false
-		const mightTriggerFocus = (resolvedKeyboardEvent.kind === ResultKind.MoreChordsNeeded || (resolvedKeyboardEvent.kind === ResultKind.KbFound && resolvedKeyboardEvent.commandId === 'editor.action.showHover' && this._contentWidget?.isVisible));
 
-		if (e.keyCode !== KeyCode.Ctrl && e.keyCode !== KeyCode.Alt && e.keyCode !== KeyCode.Meta && e.keyCode !== KeyCode.Shift
-			&& !mightTriggerFocus) {
+		// If the beginning of a multi-chord keybinding is pressed,
+		// or the command aims to focus the hover,
+		// set the variable to true, otherwise false
+		const mightTriggerFocus = (
+			resolvedKeyboardEvent.kind === ResultKind.MoreChordsNeeded ||
+			(resolvedKeyboardEvent.kind === ResultKind.KbFound
+				&& resolvedKeyboardEvent.commandId === 'editor.action.showHover'
+				&& this._contentWidget?.isVisible
+			)
+		);
+
+		if (
+			e.keyCode === KeyCode.Ctrl
+			|| e.keyCode === KeyCode.Alt
+			|| e.keyCode === KeyCode.Meta
+			|| e.keyCode === KeyCode.Shift
+			|| mightTriggerFocus
+		) {
 			// Do not hide hover when a modifier key is pressed
-			this._hideWidgets();
+			return;
 		}
+
+		this._hideWidgets();
 	}
 
 	private _onKeyUp(e: IKeyboardEvent): void {
@@ -305,9 +352,9 @@ export class ModesHoverController extends Disposable implements IEditorContribut
 	}
 
 	private _toggleLockedState(locked: boolean) {
-		if (this._isLocked !== locked) {
-			this._isLocked = locked;
-			this._contentWidget?.widget.toggleLocked(this._isLocked);
+		if (this._hoverState.locked !== locked) {
+			this._hoverState.locked = locked;
+			this._contentWidget?.widget.toggleLocked(this._hoverState.locked);
 		}
 	}
 
@@ -315,11 +362,18 @@ export class ModesHoverController extends Disposable implements IEditorContribut
 		if (_sticky) {
 			return;
 		}
-		if ((this._isMouseDown && this._hoverClicked && this._contentWidget?.isColorPickerVisible) || InlineSuggestionHintsContentWidget.dropDownVisible) {
+		if (
+			(
+				this._hoverState.mouseDown
+				&& this._hoverState.contentHoverFocused
+				&& this._contentWidget?.isColorPickerVisible
+			)
+			|| InlineSuggestionHintsContentWidget.dropDownVisible
+		) {
 			return;
 		}
-		this._hoverActivatedByColorDecoratorClick = false;
-		this._hoverClicked = false;
+		this._hoverState.activatedByDecoratorClick = false;
+		this._hoverState.contentHoverFocused = false;
 		this._glyphWidget?.hide();
 		this._contentWidget?.hide();
 	}
@@ -331,8 +385,21 @@ export class ModesHoverController extends Disposable implements IEditorContribut
 		return this._contentWidget;
 	}
 
-	public showContentHover(range: Range, mode: HoverStartMode, source: HoverStartSource, focus: boolean, activatedByColorDecoratorClick: boolean = false): void {
-		this._hoverActivatedByColorDecoratorClick = activatedByColorDecoratorClick;
+	private _getOrCreateGlyphWidget(): MarginHoverWidget {
+		if (!this._glyphWidget) {
+			this._glyphWidget = new MarginHoverWidget(this._editor, this._languageService, this._openerService);
+		}
+		return this._glyphWidget;
+	}
+
+	public showContentHover(
+		range: Range,
+		mode: HoverStartMode,
+		source: HoverStartSource,
+		focus: boolean,
+		activatedByColorDecoratorClick: boolean = false
+	): void {
+		this._hoverState.activatedByDecoratorClick = activatedByColorDecoratorClick;
 		this._getOrCreateContentWidget().startShowingAtRange(range, mode, source, focus);
 	}
 
@@ -372,6 +439,10 @@ export class ModesHoverController extends Disposable implements IEditorContribut
 		this._contentWidget?.goToBottom();
 	}
 
+	public getWidgetContent(): string | undefined {
+		return this._contentWidget?.getWidgetContent();
+	}
+
 	public get isColorPickerVisible(): boolean | undefined {
 		return this._contentWidget?.isColorPickerVisible;
 	}
@@ -382,8 +453,8 @@ export class ModesHoverController extends Disposable implements IEditorContribut
 
 	public override dispose(): void {
 		super.dispose();
-		this._unhookEvents();
-		this._toUnhook.dispose();
+		this._unhookListeners();
+		this._listenersStore.dispose();
 		this._glyphWidget?.dispose();
 		this._contentWidget?.dispose();
 	}
@@ -443,7 +514,8 @@ class ShowOrFocusHoverAction extends EditorAction {
 		if (!editor.hasModel()) {
 			return;
 		}
-		const controller = ModesHoverController.get(editor);
+
+		const controller = HoverController.get(editor);
 		if (!controller) {
 			return;
 		}
@@ -494,7 +566,7 @@ class ShowDefinitionPreviewHoverAction extends EditorAction {
 	}
 
 	public run(accessor: ServicesAccessor, editor: ICodeEditor): void {
-		const controller = ModesHoverController.get(editor);
+		const controller = HoverController.get(editor);
 		if (!controller) {
 			return;
 		}
@@ -509,6 +581,7 @@ class ShowDefinitionPreviewHoverAction extends EditorAction {
 		if (!goto) {
 			return;
 		}
+
 		const promise = goto.startFindDefinitionFromCursor(position);
 		promise.then(() => {
 			controller.showContentHover(range, HoverStartMode.Immediate, HoverStartSource.Keyboard, true);
@@ -538,7 +611,7 @@ class ScrollUpHoverAction extends EditorAction {
 	}
 
 	public run(accessor: ServicesAccessor, editor: ICodeEditor): void {
-		const controller = ModesHoverController.get(editor);
+		const controller = HoverController.get(editor);
 		if (!controller) {
 			return;
 		}
@@ -568,7 +641,7 @@ class ScrollDownHoverAction extends EditorAction {
 	}
 
 	public run(accessor: ServicesAccessor, editor: ICodeEditor): void {
-		const controller = ModesHoverController.get(editor);
+		const controller = HoverController.get(editor);
 		if (!controller) {
 			return;
 		}
@@ -598,7 +671,7 @@ class ScrollLeftHoverAction extends EditorAction {
 	}
 
 	public run(accessor: ServicesAccessor, editor: ICodeEditor): void {
-		const controller = ModesHoverController.get(editor);
+		const controller = HoverController.get(editor);
 		if (!controller) {
 			return;
 		}
@@ -628,7 +701,7 @@ class ScrollRightHoverAction extends EditorAction {
 	}
 
 	public run(accessor: ServicesAccessor, editor: ICodeEditor): void {
-		const controller = ModesHoverController.get(editor);
+		const controller = HoverController.get(editor);
 		if (!controller) {
 			return;
 		}
@@ -659,7 +732,7 @@ class PageUpHoverAction extends EditorAction {
 	}
 
 	public run(accessor: ServicesAccessor, editor: ICodeEditor): void {
-		const controller = ModesHoverController.get(editor);
+		const controller = HoverController.get(editor);
 		if (!controller) {
 			return;
 		}
@@ -691,7 +764,7 @@ class PageDownHoverAction extends EditorAction {
 	}
 
 	public run(accessor: ServicesAccessor, editor: ICodeEditor): void {
-		const controller = ModesHoverController.get(editor);
+		const controller = HoverController.get(editor);
 		if (!controller) {
 			return;
 		}
@@ -722,7 +795,7 @@ class GoToTopHoverAction extends EditorAction {
 	}
 
 	public run(accessor: ServicesAccessor, editor: ICodeEditor): void {
-		const controller = ModesHoverController.get(editor);
+		const controller = HoverController.get(editor);
 		if (!controller) {
 			return;
 		}
@@ -754,7 +827,7 @@ class GoToBottomHoverAction extends EditorAction {
 	}
 
 	public run(accessor: ServicesAccessor, editor: ICodeEditor): void {
-		const controller = ModesHoverController.get(editor);
+		const controller = HoverController.get(editor);
 		if (!controller) {
 			return;
 		}
@@ -762,7 +835,7 @@ class GoToBottomHoverAction extends EditorAction {
 	}
 }
 
-registerEditorContribution(ModesHoverController.ID, ModesHoverController, EditorContributionInstantiation.BeforeFirstInteraction);
+registerEditorContribution(HoverController.ID, HoverController, EditorContributionInstantiation.BeforeFirstInteraction);
 registerEditorAction(ShowOrFocusHoverAction);
 registerEditorAction(ShowDefinitionPreviewHoverAction);
 registerEditorAction(ScrollUpHoverAction);

--- a/src/vs/workbench/contrib/accessibility/browser/accessibilityContributions.ts
+++ b/src/vs/workbench/contrib/accessibility/browser/accessibilityContributions.ts
@@ -15,7 +15,7 @@ import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 import { AccessibilityVerbositySettingId, AccessibleViewProviderId, accessibleViewIsShown } from 'vs/workbench/contrib/accessibility/browser/accessibilityConfiguration';
 import * as strings from 'vs/base/common/strings';
 import { ICommandService } from 'vs/platform/commands/common/commands';
-import { ModesHoverController } from 'vs/editor/contrib/hover/browser/hover';
+import { HoverController } from 'vs/editor/contrib/hover/browser/hover';
 import { IContextViewService } from 'vs/platform/contextview/browser/contextView';
 import { EditorContextKeys } from 'vs/editor/common/editorContextKeys';
 import { getNotificationFromContext } from 'vs/workbench/browser/parts/notifications/notificationsCommands';
@@ -51,7 +51,7 @@ export class HoverAccessibleViewContribution extends Disposable {
 			const accessibleViewService = accessor.get(IAccessibleViewService);
 			const codeEditorService = accessor.get(ICodeEditorService);
 			const editor = codeEditorService.getActiveCodeEditor() || codeEditorService.getFocusedCodeEditor();
-			const editorHoverContent = editor ? ModesHoverController.get(editor)?.getWidgetContent() ?? undefined : undefined;
+			const editorHoverContent = editor ? HoverController.get(editor)?.getWidgetContent() ?? undefined : undefined;
 			if (!editor || !editorHoverContent) {
 				return false;
 			}
@@ -61,7 +61,7 @@ export class HoverAccessibleViewContribution extends Disposable {
 				verbositySettingKey: AccessibilityVerbositySettingId.Hover,
 				provideContent() { return editorHoverContent; },
 				onClose() {
-					ModesHoverController.get(editor)?.focus();
+					HoverController.get(editor)?.focus();
 				},
 				options: this._options
 			});

--- a/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
@@ -17,7 +17,7 @@ import { EditorExtensionsRegistry } from 'vs/editor/browser/editorExtensions';
 import { CodeEditorWidget } from 'vs/editor/browser/widget/codeEditorWidget';
 import { ITextModel } from 'vs/editor/common/model';
 import { IModelService } from 'vs/editor/common/services/model';
-import { ModesHoverController } from 'vs/editor/contrib/hover/browser/hover';
+import { HoverController } from 'vs/editor/contrib/hover/browser/hover';
 import { localize } from 'vs/nls';
 import { IAccessibilityService } from 'vs/platform/accessibility/common/accessibility';
 import { MenuWorkbenchToolBar } from 'vs/platform/actions/browser/toolbar';
@@ -251,7 +251,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 
 		this._inputEditorElement = dom.append(inputContainer, $('.interactive-input-editor'));
 		const editorOptions = getSimpleCodeEditorWidgetOptions();
-		editorOptions.contributions?.push(...EditorExtensionsRegistry.getSomeEditorContributions([ModesHoverController.ID]));
+		editorOptions.contributions?.push(...EditorExtensionsRegistry.getSomeEditorContributions([HoverController.ID]));
 		this._inputEditor = this._register(scopedInstantiationService.createInstance(CodeEditorWidget, this._inputEditorElement, options, editorOptions));
 
 		this._register(this._inputEditor.onDidChangeModelContent(() => {

--- a/src/vs/workbench/contrib/debug/browser/debugEditorContribution.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugEditorContribution.ts
@@ -35,7 +35,7 @@ import { IModelDeltaDecoration, ITextModel, InjectedTextCursorStops } from 'vs/e
 import { IFeatureDebounceInformation, ILanguageFeatureDebounceService } from 'vs/editor/common/services/languageFeatureDebounce';
 import { ILanguageFeaturesService } from 'vs/editor/common/services/languageFeatures';
 import { IModelService } from 'vs/editor/common/services/model';
-import { ModesHoverController } from 'vs/editor/contrib/hover/browser/hover';
+import { HoverController } from 'vs/editor/contrib/hover/browser/hover';
 import { HoverStartMode, HoverStartSource } from 'vs/editor/contrib/hover/browser/hoverOperation';
 import * as nls from 'vs/nls';
 import { CommandsRegistry, ICommandService } from 'vs/platform/commands/common/commands';
@@ -389,7 +389,7 @@ export class DebugEditorContribution implements IDebugEditorContribution {
 	}
 
 	private showEditorHover(position: Position, focus: boolean) {
-		const hoverController = this.editor.getContribution<ModesHoverController>(ModesHoverController.ID);
+		const hoverController = this.editor.getContribution<HoverController>(HoverController.ID);
 		const range = new Range(position.lineNumber, position.column, position.lineNumber, position.column);
 		hoverController?.showContentHover(range, HoverStartMode.Immediate, HoverStartSource.Mouse, focus);
 	}

--- a/src/vs/workbench/contrib/interactive/browser/interactiveEditor.ts
+++ b/src/vs/workbench/contrib/interactive/browser/interactiveEditor.ts
@@ -48,7 +48,7 @@ import { ContextMenuController } from 'vs/editor/contrib/contextmenu/browser/con
 import { SuggestController } from 'vs/editor/contrib/suggest/browser/suggestController';
 import { SnippetController2 } from 'vs/editor/contrib/snippet/browser/snippetController2';
 import { TabCompletionController } from 'vs/workbench/contrib/snippets/browser/tabCompletion';
-import { ModesHoverController } from 'vs/editor/contrib/hover/browser/hover';
+import { HoverController } from 'vs/editor/contrib/hover/browser/hover';
 import { MarkerController } from 'vs/editor/contrib/gotoError/browser/gotoError';
 import { EditorInput } from 'vs/workbench/common/editor/editorInput';
 import { ITextResourceConfigurationService } from 'vs/editor/common/services/textResourceConfiguration';
@@ -381,7 +381,7 @@ export class InteractiveEditor extends EditorPane {
 			cellEditorContributions: EditorExtensionsRegistry.getSomeEditorContributions([
 				SelectionClipboardContributionID,
 				ContextMenuController.ID,
-				ModesHoverController.ID,
+				HoverController.ID,
 				MarkerController.ID
 			]),
 			options: this._notebookOptions
@@ -398,7 +398,7 @@ export class InteractiveEditor extends EditorPane {
 					ParameterHintsController.ID,
 					SnippetController2.ID,
 					TabCompletionController.ID,
-					ModesHoverController.ID,
+					HoverController.ID,
 					MarkerController.ID
 				])
 			}

--- a/src/vs/workbench/contrib/scm/browser/scmViewPane.ts
+++ b/src/vs/workbench/contrib/scm/browser/scmViewPane.ts
@@ -57,7 +57,7 @@ import { compare, format } from 'vs/base/common/strings';
 import { SuggestController } from 'vs/editor/contrib/suggest/browser/suggestController';
 import { SnippetController2 } from 'vs/editor/contrib/snippet/browser/snippetController2';
 import { ServiceCollection } from 'vs/platform/instantiation/common/serviceCollection';
-import { ModesHoverController } from 'vs/editor/contrib/hover/browser/hover';
+import { HoverController } from 'vs/editor/contrib/hover/browser/hover';
 import { ColorDetector } from 'vs/editor/contrib/colorPicker/browser/colorDetector';
 import { LinkDetector } from 'vs/editor/contrib/links/browser/links';
 import { IOpenerService } from 'vs/platform/opener/common/opener';
@@ -2199,7 +2199,7 @@ class SCMInputWidget {
 				LinkDetector.ID,
 				MenuPreventer.ID,
 				MessageController.ID,
-				ModesHoverController.ID,
+				HoverController.ID,
 				SelectionClipboardContributionID,
 				SnippetController2.ID,
 				SuggestController.ID,


### PR DESCRIPTION
Refactoring the code since it has had many modifications and the coding style is inconsistent accross the file


⚠️ This refactoring has uncovered some potential problems in the file.
For example it is not clear if `contentHoverFocused` is needed, because we already have the _isFocused parameter of the content widget.