### PR TITLE
themes - add a setting to hardcode the native theme source

### DIFF
--- a/src/vs/platform/theme/electron-main/themeMainService.ts
+++ b/src/vs/platform/theme/electron-main/themeMainService.ts
@@ -48,6 +48,7 @@ export class ThemeMainService extends Disposable implements IThemeMainService {
 	constructor(@IStateService private stateService: IStateService, @IConfigurationService private configurationService: IConfigurationService) {
 		super();
 
+		// System Theme
 		this._register(this.configurationService.onDidChangeConfiguration(e => {
 			if (e.affectsConfiguration('window.systemColorTheme')) {
 				this.onDidChangeSystemColorThemeConfiguration();
@@ -56,9 +57,7 @@ export class ThemeMainService extends Disposable implements IThemeMainService {
 		this.onDidChangeSystemColorThemeConfiguration();
 
 		// Color Scheme changes
-		nativeTheme.on('updated', () => {
-			this._onDidChangeColorScheme.fire(this.getColorScheme());
-		});
+		this._register(Event.fromNodeEventEmitter(nativeTheme, 'updated')(() => this._onDidChangeColorScheme.fire(this.getColorScheme())));
 	}
 
 	private onDidChangeSystemColorThemeConfiguration(): void {

--- a/src/vs/platform/theme/electron-main/themeMainService.ts
+++ b/src/vs/platform/theme/electron-main/themeMainService.ts
@@ -48,10 +48,31 @@ export class ThemeMainService extends Disposable implements IThemeMainService {
 	constructor(@IStateService private stateService: IStateService, @IConfigurationService private configurationService: IConfigurationService) {
 		super();
 
+		this._register(this.configurationService.onDidChangeConfiguration(e => {
+			if (e.affectsConfiguration('window.systemColorTheme')) {
+				this.onDidChangeSystemColorThemeConfiguration();
+			}
+		}));
+		this.onDidChangeSystemColorThemeConfiguration();
+
 		// Color Scheme changes
 		nativeTheme.on('updated', () => {
 			this._onDidChangeColorScheme.fire(this.getColorScheme());
 		});
+	}
+
+	private onDidChangeSystemColorThemeConfiguration(): void {
+		switch (this.configurationService.getValue('window.systemColorTheme')) {
+			case 'dark':
+				nativeTheme.themeSource = 'dark';
+				break;
+			case 'light':
+				nativeTheme.themeSource = 'light';
+				break;
+			default:
+				nativeTheme.themeSource = 'system';
+				break;
+		}
 	}
 
 	getColorScheme(): IColorScheme {

--- a/src/vs/workbench/services/themes/electron-sandbox/themes.contribution.ts
+++ b/src/vs/workbench/services/themes/electron-sandbox/themes.contribution.ts
@@ -16,11 +16,11 @@ configurationRegistry.registerConfiguration({
 			'enum': ['default', 'auto', 'light', 'dark'],
 			'enumDescriptions': [
 				localize('window.systemColorTheme.default', "System color theme matches the configured OS theme."),
-				localize('window.systemColorTheme.auto', "Enforce a light system color theme when a light color theme is configured for the workbench and the same for configured dark workbench themes."),
+				localize('window.systemColorTheme.auto', "Enforce a light system color theme when a light workbench color theme is configured and the same for configured dark workbench color themes."),
 				localize('window.systemColorTheme.light', "Enforce a light system color theme."),
 				localize('window.systemColorTheme.dark', "Enforce a dark system color theme."),
 			],
-			'description': localize('window.systemColorTheme', "The system color theme applies to native UI elements such as dialogs and menus. Even if your OS is configured in light mode, you can select a dark system color theme."),
+			'markdownDescription': localize('window.systemColorTheme', "The system color theme applies to native UI elements such as native dialogs, menus and title bar. Even if your OS is configured in light appearance mode, you can select a dark system color theme for the window. You can also configure to automatically adjust based on the `#workbench.colorTheme#` setting."),
 			'default': 'default',
 			'included': !isLinux, // not supported on Linux (https://github.com/electron/electron/issues/28887)
 			'scope': ConfigurationScope.APPLICATION

--- a/src/vs/workbench/services/themes/electron-sandbox/themes.contribution.ts
+++ b/src/vs/workbench/services/themes/electron-sandbox/themes.contribution.ts
@@ -6,6 +6,7 @@
 import { localize } from 'vs/nls';
 import { Registry } from 'vs/platform/registry/common/platform';
 import { IConfigurationRegistry, Extensions as ConfigurationExtensions, ConfigurationScope } from 'vs/platform/configuration/common/configurationRegistry';
+import { isLinux } from 'vs/base/common/platform';
 
 const configurationRegistry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration);
 configurationRegistry.registerConfiguration({
@@ -20,6 +21,7 @@ configurationRegistry.registerConfiguration({
 			],
 			'description': localize('window.systemColorTheme', "The system color theme applies to native UI elements such as dialogs and menus. Even if your OS is configured in light mode, you can select a dark system color theme."),
 			'default': 'default',
+			'included': !isLinux, // not supported on Linux (https://github.com/electron/electron/issues/28887)
 			'scope': ConfigurationScope.APPLICATION
 		}
 	}

--- a/src/vs/workbench/services/themes/electron-sandbox/themes.contribution.ts
+++ b/src/vs/workbench/services/themes/electron-sandbox/themes.contribution.ts
@@ -13,9 +13,10 @@ configurationRegistry.registerConfiguration({
 	'properties': {
 		'window.systemColorTheme': {
 			'type': 'string',
-			'enum': ['default', 'light', 'dark'],
+			'enum': ['default', 'auto', 'light', 'dark'],
 			'enumDescriptions': [
 				localize('window.systemColorTheme.default', "System color theme matches the configured OS theme."),
+				localize('window.systemColorTheme.auto', "Enforce a light system color theme when a light color theme is configured for the workbench and the same for configured dark workbench themes."),
 				localize('window.systemColorTheme.light', "Enforce a light system color theme."),
 				localize('window.systemColorTheme.dark', "Enforce a dark system color theme."),
 			],

--- a/src/vs/workbench/services/themes/electron-sandbox/themes.contribution.ts
+++ b/src/vs/workbench/services/themes/electron-sandbox/themes.contribution.ts
@@ -1,0 +1,26 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { localize } from 'vs/nls';
+import { Registry } from 'vs/platform/registry/common/platform';
+import { IConfigurationRegistry, Extensions as ConfigurationExtensions, ConfigurationScope } from 'vs/platform/configuration/common/configurationRegistry';
+
+const configurationRegistry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration);
+configurationRegistry.registerConfiguration({
+	'properties': {
+		'window.systemColorTheme': {
+			'type': 'string',
+			'enum': ['default', 'light', 'dark'],
+			'enumDescriptions': [
+				localize('window.systemColorTheme.default', "System color theme matches the configured OS theme."),
+				localize('window.systemColorTheme.light', "Enforce a light system color theme."),
+				localize('window.systemColorTheme.dark', "Enforce a dark system color theme."),
+			],
+			'description': localize('window.systemColorTheme', "The system color theme applies to native UI elements such as dialogs and menus. Even if your OS is configured in light mode, you can select a dark system color theme."),
+			'default': 'default',
+			'scope': ConfigurationScope.APPLICATION
+		}
+	}
+});

--- a/src/vs/workbench/workbench.desktop.main.ts
+++ b/src/vs/workbench/workbench.desktop.main.ts
@@ -134,8 +134,9 @@ import 'vs/workbench/contrib/configExporter/electron-sandbox/configurationExport
 // Terminal
 import 'vs/workbench/contrib/terminal/electron-sandbox/terminal.contribution';
 
-// Themes Support
+// Themes
 import 'vs/workbench/contrib/themes/browser/themes.test.contribution';
+import 'vs/workbench/services/themes/electron-sandbox/themes.contribution';
 
 // User Data Sync
 import 'vs/workbench/contrib/userDataSync/electron-sandbox/userDataSync.contribution';


### PR DESCRIPTION
fix https://github.com/microsoft/vscode/issues/120420

Enables to see dark or light native UI control colors independent from how the OS is configured (except for Linux where this is not supported yet).

Adds a new setting `window.systemColorTheme` to override the `nativeTheme.themeSource` in Desktop:
* `default`: as before, no change
* `auto`: update based on the theme used in VS Code
* `dark`: set to `dark`
* `light`: set to `light`

I am open for ideas how to name this setting better if at all.