### PR TITLE
Add missing spaces after generic `implements`

### DIFF
--- a/extensions/references-view/src/references/model.ts
+++ b/extensions/references-view/src/references/model.ts
@@ -257,7 +257,7 @@ export class ReferencesModel implements SymbolItemNavigation<FileItem | Referenc
 	}
 }
 
-class ReferencesTreeDataProvider implements vscode.TreeDataProvider<FileItem | ReferenceItem>{
+class ReferencesTreeDataProvider implements vscode.TreeDataProvider<FileItem | ReferenceItem> {
 
 	private readonly _listener: vscode.Disposable;
 	private readonly _onDidChange = new vscode.EventEmitter<FileItem | ReferenceItem | undefined>();

--- a/extensions/references-view/src/tree.ts
+++ b/extensions/references-view/src/tree.ts
@@ -237,7 +237,7 @@ class HistoryItem {
 	}
 }
 
-class TreeInputHistory implements vscode.TreeDataProvider<HistoryItem>{
+class TreeInputHistory implements vscode.TreeDataProvider<HistoryItem> {
 
 	private readonly _onDidChangeTreeData = new vscode.EventEmitter<HistoryItem | undefined>();
 	readonly onDidChangeTreeData = this._onDidChangeTreeData.event;

--- a/src/vs/base/common/async.ts
+++ b/src/vs/base/common/async.ts
@@ -632,7 +632,7 @@ export interface ILimiter<T> {
  * A helper to queue N promises and run them all with a max degree of parallelism. The helper
  * ensures that at any time no more than M promises are running at the same time.
  */
-export class Limiter<T> implements ILimiter<T>{
+export class Limiter<T> implements ILimiter<T> {
 
 	private _size = 0;
 	private runningPromises: number;

--- a/src/vs/workbench/browser/parts/editor/breadcrumbs.ts
+++ b/src/vs/workbench/browser/parts/editor/breadcrumbs.ts
@@ -87,7 +87,7 @@ export abstract class BreadcrumbsConfig<T> {
 					}
 				});
 
-				return new class implements BreadcrumbsConfig<T>{
+				return new class implements BreadcrumbsConfig<T> {
 					readonly name = name;
 					readonly onDidChange = onDidChange.event;
 					getValue(overrides?: IConfigurationOverrides): T {

--- a/src/vs/workbench/contrib/codeEditor/browser/outline/documentSymbolsOutline.ts
+++ b/src/vs/workbench/contrib/codeEditor/browser/outline/documentSymbolsOutline.ts
@@ -36,7 +36,7 @@ import { ILanguageFeaturesService } from 'vs/editor/common/services/languageFeat
 
 type DocumentSymbolItem = OutlineGroup | OutlineElement;
 
-class DocumentSymbolBreadcrumbsSource implements IBreadcrumbsDataSource<DocumentSymbolItem>{
+class DocumentSymbolBreadcrumbsSource implements IBreadcrumbsDataSource<DocumentSymbolItem> {
 
 	private _breadcrumbs: (OutlineGroup | OutlineElement)[] = [];
 

--- a/src/vs/workbench/contrib/debug/browser/disassemblyView.ts
+++ b/src/vs/workbench/contrib/debug/browser/disassemblyView.ts
@@ -176,7 +176,7 @@ export class DisassemblyView extends EditorPane {
 		this._enableSourceCodeRender = this._configurationService.getValue<IDebugConfiguration>('debug').disassemblyView.showSourceCode;
 		const lineHeight = this.fontInfo.lineHeight;
 		const thisOM = this;
-		const delegate = new class implements ITableVirtualDelegate<IDisassembledInstructionEntry>{
+		const delegate = new class implements ITableVirtualDelegate<IDisassembledInstructionEntry> {
 			headerRowHeight: number = 0; // No header
 			getHeight(row: IDisassembledInstructionEntry): number {
 				if (thisOM.isSourceCodeRender && row.showSourceLocation && row.instruction.location?.path && row.instruction.line) {

--- a/src/vs/workbench/contrib/extensions/browser/abstractRuntimeExtensionsEditor.ts
+++ b/src/vs/workbench/contrib/extensions/browser/abstractRuntimeExtensionsEditor.ts
@@ -197,7 +197,7 @@ export abstract class AbstractRuntimeExtensionsEditor extends EditorPane {
 
 		const TEMPLATE_ID = 'runtimeExtensionElementTemplate';
 
-		const delegate = new class implements IListVirtualDelegate<IRuntimeExtension>{
+		const delegate = new class implements IListVirtualDelegate<IRuntimeExtension> {
 			getHeight(element: IRuntimeExtension): number {
 				return 70;
 			}

--- a/src/vs/workbench/contrib/externalUriOpener/test/common/externalUriOpenerService.test.ts
+++ b/src/vs/workbench/contrib/externalUriOpener/test/common/externalUriOpenerService.test.ts
@@ -17,7 +17,7 @@ import { IPickOptions, IQuickInputService, IQuickPickItem, QuickPickInput } from
 import { ExternalUriOpenerService, IExternalOpenerProvider, IExternalUriOpener } from 'vs/workbench/contrib/externalUriOpener/common/externalUriOpenerService';
 
 
-class MockQuickInputService implements Partial<IQuickInputService>{
+class MockQuickInputService implements Partial<IQuickInputService> {
 
 	constructor(
 		private readonly pickIndex: number

--- a/src/vs/workbench/contrib/markers/browser/markersTable.ts
+++ b/src/vs/workbench/contrib/markers/browser/markersTable.ts
@@ -57,7 +57,7 @@ interface IMarkerHighlightedLabelColumnTemplateData {
 	readonly highlightedLabel: HighlightedLabel;
 }
 
-class MarkerSeverityColumnRenderer implements ITableRenderer<MarkerTableItem, IMarkerIconColumnTemplateData>{
+class MarkerSeverityColumnRenderer implements ITableRenderer<MarkerTableItem, IMarkerIconColumnTemplateData> {
 
 	static readonly TEMPLATE_ID = 'severity';
 
@@ -168,7 +168,7 @@ class MarkerCodeColumnRenderer implements ITableRenderer<MarkerTableItem, IMarke
 	disposeTemplate(templateData: IMarkerCodeColumnTemplateData): void { }
 }
 
-class MarkerMessageColumnRenderer implements ITableRenderer<MarkerTableItem, IMarkerHighlightedLabelColumnTemplateData>{
+class MarkerMessageColumnRenderer implements ITableRenderer<MarkerTableItem, IMarkerHighlightedLabelColumnTemplateData> {
 
 	static readonly TEMPLATE_ID = 'message';
 
@@ -189,7 +189,7 @@ class MarkerMessageColumnRenderer implements ITableRenderer<MarkerTableItem, IMa
 	disposeTemplate(templateData: IMarkerHighlightedLabelColumnTemplateData): void { }
 }
 
-class MarkerFileColumnRenderer implements ITableRenderer<MarkerTableItem, IMarkerFileColumnTemplateData>{
+class MarkerFileColumnRenderer implements ITableRenderer<MarkerTableItem, IMarkerFileColumnTemplateData> {
 
 	static readonly TEMPLATE_ID = 'file';
 
@@ -220,7 +220,7 @@ class MarkerFileColumnRenderer implements ITableRenderer<MarkerTableItem, IMarke
 	disposeTemplate(templateData: IMarkerFileColumnTemplateData): void { }
 }
 
-class MarkerOwnerColumnRenderer implements ITableRenderer<MarkerTableItem, IMarkerHighlightedLabelColumnTemplateData>{
+class MarkerOwnerColumnRenderer implements ITableRenderer<MarkerTableItem, IMarkerHighlightedLabelColumnTemplateData> {
 
 	static readonly TEMPLATE_ID = 'owner';
 

--- a/src/vs/workbench/contrib/notebook/common/notebookEditorModel.ts
+++ b/src/vs/workbench/contrib/notebook/common/notebookEditorModel.ts
@@ -312,7 +312,7 @@ export class NotebookFileWorkingCopyModel extends Disposable implements IStoredF
 	}
 }
 
-export class NotebookFileWorkingCopyModelFactory implements IStoredFileWorkingCopyModelFactory<NotebookFileWorkingCopyModel>, IUntitledFileWorkingCopyModelFactory<NotebookFileWorkingCopyModel>{
+export class NotebookFileWorkingCopyModelFactory implements IStoredFileWorkingCopyModelFactory<NotebookFileWorkingCopyModel>, IUntitledFileWorkingCopyModelFactory<NotebookFileWorkingCopyModel> {
 
 	constructor(
 		private readonly _viewType: string,

--- a/src/vs/workbench/contrib/terminal/test/browser/terminalProfileService.integrationTest.ts
+++ b/src/vs/workbench/contrib/terminal/test/browser/terminalProfileService.integrationTest.ts
@@ -28,7 +28,7 @@ import { TestThemeService } from 'vs/platform/theme/test/common/testThemeService
 import { IPickOptions, IQuickInputService, Omit, QuickPickInput } from 'vs/platform/quickinput/common/quickInput';
 import { CancellationToken } from 'vs/base/common/cancellation';
 
-class TestTerminalProfileService extends TerminalProfileService implements Partial<ITerminalProfileService>{
+class TestTerminalProfileService extends TerminalProfileService implements Partial<ITerminalProfileService> {
 	hasRefreshedProfiles: Promise<void> | undefined;
 	override refreshAvailableProfiles(): void {
 		this.hasRefreshedProfiles = this._refreshAvailableProfilesNow();
@@ -42,7 +42,7 @@ class TestTerminalProfileService extends TerminalProfileService implements Parti
 	}
 }
 
-class MockTerminalProfileService implements Partial<ITerminalProfileService>{
+class MockTerminalProfileService implements Partial<ITerminalProfileService> {
 	hasRefreshedProfiles: Promise<void> | undefined;
 	_defaultProfileName: string | undefined;
 	availableProfiles?: ITerminalProfile[] | undefined = [];


### PR DESCRIPTION
Keeps things more consistent. Should eventually be fixed on TS side https://github.com/microsoft/TypeScript/issues/56699

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
