### PR TITLE
Show breadcrumbs also for untitled files

### DIFF
--- a/src/vs/workbench/browser/parts/editor/breadcrumbsControl.ts
+++ b/src/vs/workbench/browser/parts/editor/breadcrumbsControl.ts
@@ -287,7 +287,7 @@ export class BreadcrumbsControl {
 		const uri = EditorResourceAccessor.getCanonicalUri(this._editorGroup.activeEditor, { supportSideBySide: SideBySideEditor.PRIMARY });
 		const wasHidden = this.isHidden();
 
-		if (!uri || !this._fileService.hasProvider(uri)) {
+		if (!uri) {
 			// cleanup and return when there is no input or when
 			// we cannot handle this input
 			this._ckBreadcrumbsPossible.set(false);
@@ -299,6 +299,7 @@ export class BreadcrumbsControl {
 			}
 		}
 
+		const hideIfEmpty = !this._fileService.hasProvider(uri);
 		// display uri which can be derived from certain inputs
 		const fileInfoUri = EditorResourceAccessor.getOriginalUri(this._editorGroup.activeEditor, { supportSideBySide: SideBySideEditor.PRIMARY });
 
@@ -323,19 +324,26 @@ export class BreadcrumbsControl {
 			};
 			const items = model.getElements().map(element => element instanceof FileElement ? new FileItem(model, element, options, this._labels) : new OutlineItem(model, element, options));
 			if (items.length === 0) {
-				this._widget.setEnabled(false);
-				this._widget.setItems([new class extends BreadcrumbsItem {
-					render(container: HTMLElement): void {
-						container.innerText = localize('empty', "no elements");
-					}
-					equals(other: BreadcrumbsItem): boolean {
-						return other === this;
-					}
-					dispose(): void {
+				if (hideIfEmpty) {
+					this._ckBreadcrumbsPossible.set(false);
+					this.hide();
+				} else {
+					this._ckBreadcrumbsPossible.set(true);
+					this._widget.setEnabled(false);
+					this._widget.setItems([new class extends BreadcrumbsItem {
+						render(container: HTMLElement): void {
+							container.innerText = localize('empty', "no elements");
+						}
+						equals(other: BreadcrumbsItem): boolean {
+							return other === this;
+						}
+						dispose(): void {
 
-					}
-				}]);
+						}
+					}]);
+				}
 			} else {
+				this.show();
 				this._widget.setEnabled(true);
 				this._widget.setItems(items);
 				this._widget.reveal(items[items.length - 1]);


### PR DESCRIPTION
Breadcrumbs used to be enabled for untitled files (#54094, 9768dabba7).
Following a complain about having an empty bar (#74924), it was removed
(#75325).

This change enables breadcrumbs for new files, but only if the language
is not plaintext. So for a completely new file without contents nothing
is shown, but when a language is detected/chosen it will appear.

Fixes #84746.