### PR TITLE
fix: invalid enum check in HoverFocusBehavior logic

### DIFF
--- a/src/vs/editor/contrib/hover/browser/hover.ts
+++ b/src/vs/editor/contrib/hover/browser/hover.ts
@@ -523,7 +523,7 @@ class ShowOrFocusHoverAction extends EditorAction {
 
 		const focusArgument = args?.focus;
 		let focusOption = HoverFocusBehavior.FocusIfVisible;
-		if (focusArgument in HoverFocusBehavior) {
+		if (Object.values(HoverFocusBehavior).includes(focusArgument)) {
 			focusOption = focusArgument;
 		} else if (typeof focusArgument === 'boolean' && focusArgument) {
 			focusOption = HoverFocusBehavior.AutoFocusImmediately;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

## Problem
The existing implementation uses the `in` operator to check if a string is a valid enum member in `HoverFocusBehavior`. This check is ineffective because the `in` operator checks for the presence of keys in an object, not string values.

Related information: https://stackoverflow.com/a/43805090

<img width="646" alt="图片" src="https://github.com/microsoft/vscode/assets/35302658/3e8aef15-d50a-4f87-9904-de515c32387d">

## Solution
This PR fixes the issue by replacing the `in` operator with `Object.values()` combined with `includes()` to properly check if the provided `focusArgument` is a valid string value of the `HoverFocusBehavior` enum.

The change ensures that the focus behavior logic is correctly applied, preventing any unintended focus behavior due to incorrect enum value checks.