### PR TITLE
process-explorer: fix not updating pid/name mapping correctly

### DIFF
--- a/src/vs/code/electron-sandbox/processExplorer/processExplorerMain.ts
+++ b/src/vs/code/electron-sandbox/processExplorer/processExplorerMain.ts
@@ -245,7 +245,7 @@ class ProcessExplorer {
 		this.setEventHandlers(data);
 
 		ipcRenderer.on('vscode:pidToNameResponse', (event: unknown, pidToNames: [number, string][]) => {
-			this.mapPidToName = new Map<number, string>();
+			this.mapPidToName.clear();
 
 			for (const [pid, name] of pidToNames) {
 				this.mapPidToName.set(pid, name);


### PR DESCRIPTION
The mapPidToName was getting reassigned rather than mutated which prevented the ProcessRenderer from seeing the correct names if they got updated.

Fixes #172120

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
