### PR TITLE
Updates workbench.action.generateColorTheme command to return content

### DIFF
--- a/src/vs/workbench/contrib/themes/browser/themes.contribution.ts
+++ b/src/vs/workbench/contrib/themes/browser/themes.contribution.ts
@@ -584,7 +584,7 @@ registerAction2(class extends Action2 {
 		});
 	}
 
-	override run(accessor: ServicesAccessor) {
+	override run(accessor: ServicesAccessor, openInEditor: boolean = true) {
 		const themeService = accessor.get(IWorkbenchThemeService);
 
 		const theme = themeService.getColorTheme();
@@ -597,7 +597,9 @@ registerAction2(class extends Action2 {
 			if (color) {
 				resultingColors[colorId] = Color.Format.CSS.formatHexA(color, true);
 			} else {
-				inherited.push(colorId);
+				if (openInEditor) {
+					inherited.push(colorId);
+				}
 			}
 		}
 		const nullDefaults = [];
@@ -618,6 +620,9 @@ registerAction2(class extends Action2 {
 			colors: resultingColors,
 			tokenColors: theme.tokenColors.filter(t => !!t.scope)
 		}, null, '\t');
+		if (!openInEditor) {
+			return contents;
+		}
 		contents = contents.replace(/\"__/g, '//"');
 
 		const editorService = accessor.get(IEditorService);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
This PR would allow users to execute the `generateColorTheme` command programmatically with an option to return the theme content as JSON rather than opening the content in a new editor tab. This is useful for authors of extensions who want to style their webviews with the same theme as the rest of the editor. Specifically those with embedded editors or code snippets. 

```
const themeJSON = await commands.executeCommand('workbench.action.generateColorTheme', false);
```

Tracked in: https://github.com/github/copilot-client/issues/4460
Related https://github.com/microsoft/vscode/issues/168190
Also related https://github.com/microsoft/vscode/issues/32813