### PR TITLE
Edits to setting descriptions

### DIFF
--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -4937,7 +4937,7 @@ class EditorDropIntoEditor extends BaseEditorOption<EditorOption.dropIntoEditor,
 				'editor.dropIntoEditor.enabled': {
 					type: 'boolean',
 					default: defaults.enabled,
-					markdownDescription: nls.localize('dropIntoEditor.enabled', "Controls whether you can drag and drop a file into a text editor by holding down `Shift`-key (instead of opening the file in an editor)."),
+					markdownDescription: nls.localize('dropIntoEditor.enabled', "Controls whether you can drag and drop a file into a text editor by holding down the `Shift` key (instead of opening the file in an editor)."),
 				},
 				'editor.dropIntoEditor.showDropSelector': {
 					type: 'string',

--- a/src/vs/workbench/browser/workbench.contribution.ts
+++ b/src/vs/workbench/browser/workbench.contribution.ts
@@ -246,7 +246,7 @@ const registry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Con
 			'workbench.editor.dragToOpenWindow': {
 				'type': 'boolean',
 				'default': true,
-				'markdownDescription': localize('dragToOpenWindow', "Controls if editors can be dragged out of the window to open them in a new window. Press and hold `Alt`-key while dragging to toggle this dynamically.")
+				'markdownDescription': localize('dragToOpenWindow', "Controls if editors can be dragged out of the window to open them in a new window. Press and hold the `Alt` key while dragging to toggle this dynamically.")
 			},
 			'workbench.editor.focusRecentEditorAfterClose': {
 				'type': 'boolean',
@@ -505,11 +505,11 @@ const registry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Con
 				'type': 'string',
 				'enum': ['side', 'top', 'hidden'],
 				'default': 'side',
-				'markdownDescription': localize({ comment: ['This is the description for a setting'], key: 'activityBarLocation' }, "Controls the location of the activity bar. It can either show to the `side` or `top` (requires {0} set to {1}) of the primary side bar or `hidden`.", '`#window.titleBarStyle#`', '`custom`'),
+				'markdownDescription': localize({ comment: ['This is the description for a setting'], key: 'activityBarLocation' }, "Controls the location of the Activity Bar. It can either show to the `side` or `top` (requires {0} set to {1}) of the Primary Side Bar or `hidden`.", '`#window.titleBarStyle#`', '`custom`'),
 				'enumDescriptions': [
-					localize('workbench.activityBar.location.side', "Show the activity bar to the side of the primary side bar."),
-					localize('workbench.activityBar.location.top', "Show the activity bar on top of the primary side bar."),
-					localize('workbench.activityBar.location.hide', "Hide the activity bar.")
+					localize('workbench.activityBar.location.side', "Show the Activity Bar to the side of the Primary Side Bar."),
+					localize('workbench.activityBar.location.top', "Show the Activity Bar on top of the Primary Side Bar."),
+					localize('workbench.activityBar.location.hide', "Hide the Activity Bar.")
 				]
 			},
 			'workbench.activityBar.iconClickBehavior': {
@@ -762,7 +762,7 @@ const registry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Con
 			'zenMode.showTabs': {
 				'type': 'string',
 				'enum': ['multiple', 'single', 'none'],
-				'description': localize('zenMode.showTabs', "Controls whether turning on Zen Mode should show multiple editor tabs, a single editor tab or hide the editor title area completely."),
+				'description': localize('zenMode.showTabs', "Controls whether turning on Zen Mode should show multiple editor tabs, a single editor tab, or hide the editor title area completely."),
 				'enumDescriptions': [
 					localize('zenMode.showTabs.multiple', "Each editor is displayed as a tab in the editor title area."),
 					localize('zenMode.showTabs.single', "The active editor is displayed as a single large tab in the editor title area."),

--- a/src/vs/workbench/contrib/accessibility/browser/accessibilityConfiguration.ts
+++ b/src/vs/workbench/contrib/accessibility/browser/accessibilityConfiguration.ts
@@ -103,7 +103,7 @@ const configuration: IConfigurationNode = {
 			...baseProperty
 		},
 		[AccessibilityVerbositySettingId.InlineCompletions]: {
-			description: localize('verbosity.inlineCompletions.description', 'Provide information about how to access the inline completions hover and accessible view.'),
+			description: localize('verbosity.inlineCompletions.description', 'Provide information about how to access the inline completions hover and Accessible View.'),
 			...baseProperty
 		},
 		[AccessibilityVerbositySettingId.KeybindingsEditor]: {
@@ -115,11 +115,11 @@ const configuration: IConfigurationNode = {
 			...baseProperty
 		},
 		[AccessibilityVerbositySettingId.Hover]: {
-			description: localize('verbosity.hover', 'Provide information about how to open the hover in an accessible view.'),
+			description: localize('verbosity.hover', 'Provide information about how to open the hover in an Accessible View.'),
 			...baseProperty
 		},
 		[AccessibilityVerbositySettingId.Notification]: {
-			description: localize('verbosity.notification', 'Provide information about how to open the notification in an accessible view.'),
+			description: localize('verbosity.notification', 'Provide information about how to open the notification in an Accessible View.'),
 			...baseProperty
 		},
 		[AccessibilityVerbositySettingId.EmptyEditorHint]: {
@@ -155,14 +155,14 @@ const configuration: IConfigurationNode = {
 			tags: ['accessibility']
 		},
 		[AccessibilityVoiceSettingId.SpeechTimeout]: {
-			'markdownDescription': localize('voice.speechTimeout', "Define the duration for which the voice speech recognition remains active after you stop speaking. For example in a chat session the transcribed text is submitted automatically after the timeout is met. Set to `0` to disable this feature."),
+			'markdownDescription': localize('voice.speechTimeout', "The duration in milliseconds that voice speech recognition remains active after you stop speaking. For example in a chat session, the transcribed text is submitted automatically after the timeout is met. Set to `0` to disable this feature."),
 			'type': 'number',
 			'default': SpeechTimeoutDefault,
 			'minimum': 0,
 			'tags': ['accessibility']
 		},
 		[AccessibilityWorkbenchSettingId.AccessibleViewCloseOnKeyPress]: {
-			markdownDescription: localize('terminal.integrated.accessibleView.closeOnKeyPress', "On keypress, close the accessible view and focus the element from which it was invoked."),
+			markdownDescription: localize('terminal.integrated.accessibleView.closeOnKeyPress', "On keypress, close the Accessible View and focus the element from which it was invoked."),
 			type: 'boolean',
 			default: true
 		},
@@ -193,7 +193,7 @@ export function registerAccessibilityConfiguration() {
 				scope: ConfigurationScope.APPLICATION,
 			},
 			[AccessibilityWorkbenchSettingId.HideAccessibleView]: {
-				description: localize('accessibility.hideAccessibleView', "Controls whether the accessible view is hidden."),
+				description: localize('accessibility.hideAccessibleView', "Controls whether the Accessible View is hidden."),
 				type: 'boolean',
 				default: false,
 				tags: ['accessibility']

--- a/src/vs/workbench/contrib/audioCues/browser/audioCues.contribution.ts
+++ b/src/vs/workbench/contrib/audioCues/browser/audioCues.contribution.ts
@@ -133,7 +133,7 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).regis
 			default: 'off'
 		},
 		'audioCues.clear': {
-			'description': localize('audioCues.clear', "Plays a sound when a feature is cleared (for example, the terminal, debug console, or output channel). When this is disabled, an aria alert will announce 'Cleared'."),
+			'description': localize('audioCues.clear', "Plays a sound when a feature is cleared (for example, the terminal, Debug Console, or Output channel). When this is disabled, an ARIA alert will announce 'Cleared'."),
 			...audioCueFeatureBase,
 			default: 'off'
 		},

--- a/src/vs/workbench/contrib/remote/common/remote.contribution.ts
+++ b/src/vs/workbench/contrib/remote/common/remote.contribution.ts
@@ -314,7 +314,7 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration)
 			},
 			'remote.autoForwardPortsSource': {
 				type: 'string',
-				markdownDescription: localize('remote.autoForwardPortsSource', "Sets the source from which ports are automatically forwarded when {0} is true. On Windows and Mac remotes, the `process` and `hybrid` options have no effect and `output` will be used.", '`#remote.autoForwardPorts#`'),
+				markdownDescription: localize('remote.autoForwardPortsSource', "Sets the source from which ports are automatically forwarded when {0} is true. On Windows and macOS remotes, the `process` and `hybrid` options have no effect and `output` will be used.", '`#remote.autoForwardPorts#`'),
 				enum: ['process', 'output', 'hybrid'],
 				enumDescriptions: [
 					localize('remote.autoForwardPortsSource.process', "Ports will be automatically forwarded when discovered by watching for processes that are started and include a port."),


### PR DESCRIPTION
Using upper case for VS Code "things" like Activity Bar, Primary Side Bar, and Accessible View
Other typos and punctuation
