### PR TITLE
Remove debugger; statement for diff computation

### DIFF
--- a/src/vs/editor/common/diff/defaultLinesDiffComputer/algorithms/diffAlgorithm.ts
+++ b/src/vs/editor/common/diff/defaultLinesDiffComputer/algorithms/diffAlgorithm.ts
@@ -180,8 +180,6 @@ export class DateTimeout implements ITimeout {
 		const valid = Date.now() - this.startTime < this.timeout;
 		if (!valid && this.valid) {
 			this.valid = false; // timeout reached
-			// eslint-disable-next-line no-debugger
-			debugger; // WARNING: Most likely debugging caused the timeout. Call `this.disable()` to continue without timing out.
 		}
 		return this.valid;
 	}


### PR DESCRIPTION
With the large files like automatically generated traces kept in version control, it is possible that diff algorithm actually times out. It is not clear why the debugger; statement is needed for this case, it is seems that only reporting a timeout in this case is 'by design'. Also, it is not recommended to keep debugger statements in production code (eslint inspection).

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
