### PR TITLE
Cache command picks for the duration of the quick pick

### DIFF
--- a/src/vs/platform/quickinput/browser/commandsQuickAccess.ts
+++ b/src/vs/platform/quickinput/browser/commandsQuickAccess.ts
@@ -51,6 +51,8 @@ export abstract class AbstractCommandsQuickAccessProvider extends PickerQuickAcc
 
 	protected override readonly options: ICommandsQuickAccessOptions;
 
+	private _cachedPicks: ICommandQuickPick[] | undefined;
+
 	constructor(
 		options: ICommandsQuickAccessOptions,
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
@@ -64,10 +66,14 @@ export abstract class AbstractCommandsQuickAccessProvider extends PickerQuickAcc
 		this.options = options;
 	}
 
-	protected async _getPicks(filter: string, _disposables: DisposableStore, token: CancellationToken, runOptions?: IQuickAccessProviderRunOptions): Promise<Picks<ICommandQuickPick> | FastAndSlowPicks<ICommandQuickPick>> {
+	clearCache() {
+		this._cachedPicks = undefined;
+	}
 
+	protected async _getPicks(filter: string, _disposables: DisposableStore, token: CancellationToken, runOptions?: IQuickAccessProviderRunOptions): Promise<Picks<ICommandQuickPick> | FastAndSlowPicks<ICommandQuickPick>> {
 		// Ask subclass for all command picks
-		const allCommandPicks = await this.getCommandPicks(token);
+		const allCommandPicks = this._cachedPicks ?? await this.getCommandPicks(token);
+		this._cachedPicks = allCommandPicks;
 
 		if (token.isCancellationRequested) {
 			return [];

--- a/src/vs/platform/quickinput/browser/quickAccess.ts
+++ b/src/vs/platform/quickinput/browser/quickAccess.ts
@@ -114,6 +114,7 @@ export class QuickAccessController extends Disposable implements IQuickAccessCon
 			pickPromise = new DeferredPromise<IQuickPickItem[]>();
 			disposables.add(Event.once(picker.onWillAccept)(e => {
 				e.veto();
+				provider?.clearCache?.();
 				picker.hide();
 			}));
 		}
@@ -138,6 +139,8 @@ export class QuickAccessController extends Disposable implements IQuickAccessCon
 
 			// Start to dispose once picker hides
 			disposables.dispose();
+
+			provider?.clearCache?.();
 
 			// Resolve pick promise with selected items
 			pickPromise?.complete(picker.selectedItems.slice(0));
@@ -192,6 +195,7 @@ export class QuickAccessController extends Disposable implements IQuickAccessCon
 		disposables.add(picker.onDidChangeValue(value => {
 			const [providerForValue] = this.getOrInstantiateProvider(value);
 			if (providerForValue !== provider) {
+				providerForValue?.clearCache?.();
 				this.show(value, {
 					// do not rewrite value from user typing!
 					preserveValue: true,

--- a/src/vs/platform/quickinput/common/quickAccess.ts
+++ b/src/vs/platform/quickinput/common/quickAccess.ts
@@ -106,6 +106,12 @@ export interface IQuickAccessProvider {
 	 * closes or is replaced by another picker.
 	 */
 	provide(picker: IQuickPick<IQuickPickItem>, token: CancellationToken, options?: IQuickAccessProviderRunOptions): IDisposable;
+
+	/**
+	 * Clears any cached picks that the provider may have cached on the last
+	 * provide call.
+	 */
+	clearCache?(): void;
 }
 
 export interface IQuickAccessProviderHelp {


### PR DESCRIPTION
Fixes #200548

The PR seems to work, the main things that need clarity are:

- Whether this is the right place to do the caching, I'm sure there's a more elegant way to do this.
- Does it invalidate the cache correctly, are there edge cases I'm missing?
- Should we do this more generally? I'm not sure how dynamic providers can be.

It essentially removes this `getCommandPicks` entirely when filtering, until the provider changes:

![image](https://github.com/microsoft/vscode/assets/2193314/22a2b8dd-6374-4e40-8326-85d8b932d5f9)

Below are some numbers in milliseconds of the duration of `_getPicks` before and after when filtering 1+ letters.

Before

- 12.72
- 10.05
- 17.49
- 10.90
- 11.11
- avg 12.45

After:

- 3.39
- 2.11
- 3.88
- 4.46
- 4.21
- avg 3.61 (-8.84, -72%)

Since the change reduces the work by about 9ms, this is expected to more often than not display the results in 1 less frame on a 60Hz display and almost always in >= 1 less frame on a 144Hz display.