### PR TITLE
Added scm.inputMinLines configuration

### DIFF
--- a/src/vs/workbench/contrib/scm/browser/scm.contribution.ts
+++ b/src/vs/workbench/contrib/scm/browser/scm.contribution.ts
@@ -267,7 +267,7 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).regis
 			markdownDescription: localize('inputMinLines', "Controls the minimum number of lines that the input will auto-grow from."),
 			minimum: 1,
 			maximum: 50,
-			default: 3
+			default: 1
 		},
 		'scm.alwaysShowRepositories': {
 			type: 'boolean',

--- a/src/vs/workbench/contrib/scm/browser/scm.contribution.ts
+++ b/src/vs/workbench/contrib/scm/browser/scm.contribution.ts
@@ -262,6 +262,13 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).regis
 			maximum: 50,
 			default: 10
 		},
+		'scm.inputMinLines': {
+			type: 'number',
+			markdownDescription: localize('inputMinLines', "Controls the minimum number of lines that the input will auto-grow from."),
+			minimum: 1,
+			maximum: 50,
+			default: 3
+		},
 		'scm.alwaysShowRepositories': {
 			type: 'boolean',
 			markdownDescription: localize('alwaysShowRepository', "Controls whether repositories should always be visible in the Source Control view."),

--- a/src/vs/workbench/contrib/scm/browser/scmViewPane.ts
+++ b/src/vs/workbench/contrib/scm/browser/scmViewPane.ts
@@ -2262,7 +2262,8 @@ class SCMInputWidget {
 	}
 
 	getContentHeight(): number {
-		const editorContentHeight = this.inputEditor.getContentHeight();
+		const inputEditorMinHeight = this.getInputEditorMinHeight();
+		const editorContentHeight = Math.max(this.inputEditor.getContentHeight(), inputEditorMinHeight);
 		const editorContextHeightMax = this.getInputEditorMaxHeight();
 
 		return Math.min(editorContentHeight, editorContextHeightMax);
@@ -2407,6 +2408,11 @@ class SCMInputWidget {
 		return typeof inputMaxLines === 'number' ? clamp(inputMaxLines, 1, 50) : 10;
 	}
 
+	private getInputEditorMinLines(): number {
+		const inputMinLines = this.configurationService.getValue('scm.inputMinLines');
+		return typeof inputMinLines === 'number' ? clamp(inputMinLines, 1, 50) : 1;
+	}
+
 	private getInputEditorMaxHeight(): number {
 		const maxLines = this.getInputEditorMaxLines();
 		const fontSize = this.getInputEditorFontSize();
@@ -2414,6 +2420,15 @@ class SCMInputWidget {
 		const { top, bottom } = this.inputEditor.getOption(EditorOption.padding);
 
 		return maxLines * lineHeight + top + bottom;
+	}
+
+	private getInputEditorMinHeight(): number {
+		const minLines = this.getInputEditorMinLines();
+		const fontSize = this.getInputEditorFontSize();
+		const lineHeight = this.computeLineHeight(fontSize);
+		const { top, bottom } = this.inputEditor.getOption(EditorOption.padding);
+
+		return minLines * lineHeight + top + bottom;
 	}
 
 	private getToolbarWidth(): number {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
 https://github.com/microsoft/vscode/issues/200341
I have added the configuration scm.inputMinLines in src/vs/workbench/contrib/scm/browser/scm.contribution.ts, that describes the minimum size of the 'commit' box in the source control tab. I have set the default to 3 lines of size. Meaning, the box will be as large as it is with 3 lines of text, even when the text is shorter than that.
In order to test, run the project as described in the 'How To Contribute' page, check out the Source Control tab at the Activity Bar, and watch the result. 

![image](https://github.com/microsoft/vscode/assets/103818169/8a8a316f-d087-420f-ba07-46a4a2cbd2aa)

-->
