### PR TITLE
Refresh from root

### DIFF
--- a/src/vs/base/browser/ui/tree/asyncDataTree.ts
+++ b/src/vs/base/browser/ui/tree/asyncDataTree.ts
@@ -531,8 +531,8 @@ export class AsyncDataTree<TInput, T, TFilterData = void> implements IDisposable
 		}
 	}
 
-	async updateChildren(element: TInput | T = this.root.element, recursive = true, rerender = false, options?: IAsyncDataTreeUpdateChildrenOptions<T>): Promise<void> {
-		const firstRefreshableElement = this.getFirstExpandedParent(element);
+	async updateChildren(element: TInput | T = this.root.element, recursive = true, rerender = false, options?: IAsyncDataTreeUpdateChildrenOptions<T>, subtreeChanged: boolean = false): Promise<void> {
+		const firstRefreshableElement = subtreeChanged ? this.getFirstExpandedParent(element) : element;
 		const forceRecursive = firstRefreshableElement !== element;
 		await this._updateChildren(firstRefreshableElement, recursive || forceRecursive, rerender, undefined, options);
 	}

--- a/src/vs/workbench/contrib/files/browser/explorerService.ts
+++ b/src/vs/workbench/contrib/files/browser/explorerService.ts
@@ -458,7 +458,7 @@ export class ExplorerService implements IExplorerService {
 						await this.view?.refresh(false, oldNestedParent);
 					}
 					// Refresh Parent (View)
-					await this.view?.refresh(shouldDeepRefresh, parent);
+					await this.view?.refresh(shouldDeepRefresh, parent, undefined, true);
 				}
 			}));
 		}

--- a/src/vs/workbench/contrib/files/browser/files.ts
+++ b/src/vs/workbench/contrib/files/browser/files.ts
@@ -52,7 +52,7 @@ export const IExplorerService = createDecorator<IExplorerService>('explorerServi
 export interface IExplorerView {
 	autoReveal: boolean | 'force' | 'focusNoScroll';
 	getContext(respectMultiSelection: boolean): ExplorerItem[];
-	refresh(recursive: boolean, item?: ExplorerItem): Promise<void>;
+	refresh(recursive: boolean, item?: ExplorerItem, cancelEditing?: boolean, subtreeChanged?: boolean): Promise<void>;
 	selectResource(resource: URI | undefined, reveal?: boolean | string): Promise<void>;
 	setTreeInput(): Promise<void>;
 	itemsCopied(tats: ExplorerItem[], cut: boolean, previousCut: ExplorerItem[] | undefined): void;

--- a/src/vs/workbench/contrib/files/browser/views/explorerView.ts
+++ b/src/vs/workbench/contrib/files/browser/views/explorerView.ts
@@ -670,7 +670,7 @@ export class ExplorerView extends ViewPane implements IExplorerView {
 	 * Refresh the contents of the explorer to get up to date data from the disk about the file structure.
 	 * If the item is passed we refresh only that level of the tree, otherwise we do a full refresh.
 	 */
-	refresh(recursive: boolean, item?: ExplorerItem, cancelEditing: boolean = true): Promise<void> {
+	refresh(recursive: boolean, item?: ExplorerItem, cancelEditing: boolean = true, subtreeChanged: boolean = false): Promise<void> {
 		if (!this.tree || !this.isBodyVisible() || (item && !this.tree.hasNode(item))) {
 			// Tree node doesn't exist yet, when it becomes visible we will refresh
 			return Promise.resolve(undefined);
@@ -683,7 +683,7 @@ export class ExplorerView extends ViewPane implements IExplorerView {
 		const toRefresh = item || this.tree.getInput();
 		return this.tree.updateChildren(toRefresh, recursive, !!item, {
 			diffIdentityProvider: identityProvider
-		});
+		}, subtreeChanged);
 	}
 
 	override getOptimalWidth(): number {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fixes #200262

The sub-tree refresh is not performed on the collapsed TreeNode ([code](https://github.com/microsoft/vscode/blob/66c869c41f95221f297172dea95892381b19dbaf/src/vs/base/browser/ui/tree/asyncDataTree.ts#L811-L815)). Although this behavior is intended (#121567) it also prevents an update on a deleted element if it is located inside a collapsed folder.

I've updated the `updateChildren` implementation to initiate updates starting from the nearest uncollapsed parent of the target element (which is the parent of the deleted element). This change ensures that the entire subtree will be updated accordingly.

In order to avoid regression issues in the `AsyncDataTree` tests for cases `issue #121567` and `issue #80098,` I limited new logic only for post-deletion renders.

The TypeScript signature of IExplorerView.refresh was lacking the cancelEditing parameter, which I resolved by including the required parameter.