### PR TITLE
Fix explorer paste

### DIFF
--- a/src/vs/workbench/contrib/files/browser/explorerService.ts
+++ b/src/vs/workbench/contrib/files/browser/explorerService.ts
@@ -286,9 +286,6 @@ export class ExplorerService implements IExplorerService {
 		const previouslyCutItems = this.cutItems;
 		this.cutItems = cut ? items : undefined;
 		await this.clipboardService.writeResources(items.map(s => s.resource));
-		if (items.length === 1) {
-			await this.clipboardService.writeText(items[0].name);
-		}
 
 		this.view?.itemsCopied(items, cut, previouslyCutItems);
 	}

--- a/src/vs/workbench/contrib/files/browser/views/explorerView.ts
+++ b/src/vs/workbench/contrib/files/browser/views/explorerView.ts
@@ -329,8 +329,9 @@ export class ExplorerView extends ViewPane implements IExplorerView {
 			if (!this.hasFocus() || this.readonlyContext.get()) {
 				return;
 			}
-
-			await this.commandService.executeCommand('filesExplorer.paste', event.clipboardData?.files);
+			if (event.clipboardData?.files?.length) {
+				await this.commandService.executeCommand('filesExplorer.paste', event.clipboardData?.files);
+			}
 		}));
 	}
 


### PR DESCRIPTION
Fixes #200581


Seems like there was two issues here

1. You cannot write both a resource and text to the clipboard at the same time
2. Paste was being double triggered causing errors. We shouldn't trigger the native paste handler when no native files are present


cc @bpasero Is there anyway to do the first point?

It seems like reading resources returns nothing if I write text after writing a resource. My hope was that I could have both text and resources written and when pasting depending on the context the proper one would be read

https://github.com/microsoft/vscode/blob/d85df5daa40f962aee331ae13b18e685824db1af/src/vs/workbench/contrib/files/browser/fileActions.ts#L1211-L1220