### PR TITLE
Fix config error in comment handling of xml.tmLanguage.json #184852

### DIFF
--- a/extensions/xml/syntaxes/xml.tmLanguage.json
+++ b/extensions/xml/syntaxes/xml.tmLanguage.json
@@ -356,10 +356,10 @@
 					"captures": {
 						"0": {
 							"name": "punctuation.definition.comment.xml"
-						},
-						"end": "--%>",
-						"name": "comment.block.xml"
-					}
+						}
+					},
+					"end": "--%>",
+					"name": "comment.block.xml"
 				},
 				{
 					"begin": "<!--",


### PR DESCRIPTION
Fixes the config issue in the TextMate config file
/extensions/xml/syntaxes/xml.tmLanguage.json where two capture properties (end, name) are added at the wrong indention level.

The associated issue, #184852, was resolved with the intention to seek a replacement for the XML TextMate file. However, nine months have passed, and no progress has been achieved.

The fix for this issue is straightforward, so I ask you to consider implementing it. Finding and incorporating an alternative for the XML TextMate file may take a considerable amount of time. In the meantime, this pull request ensures that the currently shipped TextMate file remains functional.

Thanks!