### PR TITLE
testing: fix explorer input uses wrong background color

### DIFF
--- a/src/vs/workbench/contrib/codeEditor/browser/suggestEnabledInput/suggestEnabledInput.css
+++ b/src/vs/workbench/contrib/codeEditor/browser/suggestEnabledInput/suggestEnabledInput.css
@@ -26,5 +26,5 @@
 
 .suggest-input-container .monaco-editor,
 .suggest-input-container .monaco-editor .lines-content {
-	background: none;
+	background: none !important;
 }


### PR DESCRIPTION
Sidebar has styling that sets the monaco editor background color.

Fixes #198301

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
