### PR TITLE
ci: fix missing auth token for cli build

### DIFF
--- a/build/azure-pipelines/cli/cli-compile-and-publish.yml
+++ b/build/azure-pipelines/cli/cli-compile-and-publish.yml
@@ -64,6 +64,7 @@ steps:
         env:
           CARGO_NET_GIT_FETCH_WITH_CLI: true
           VSCODE_CLI_COMMIT: $(Build.SourceVersion)
+          GITHUB_TOKEN: "$(github-distro-mixin-password)"
           ${{ each pair in parameters.VSCODE_CLI_ENV }}:
             ${{ pair.key }}: ${{ pair.value }}
 


### PR DESCRIPTION
Refs https://monacotools.visualstudio.com/Monaco/_build/results?buildId=249003&view=results