### PR TITLE
Log `extensionLocation` not `location` in error message of `getCustomBuiltinExtensionsFromLocations`

### DIFF
--- a/src/vs/workbench/services/extensionManagement/browser/webExtensionsScannerService.ts
+++ b/src/vs/workbench/services/extensionManagement/browser/webExtensionsScannerService.ts
@@ -239,7 +239,7 @@ export class WebExtensionsScannerService extends Disposable implements IWebExten
 					this.logService.info(`Skipping invalid additional builtin extension ${webExtension.identifier.id}`);
 				}
 			} catch (error) {
-				this.logService.info(`Error while fetching the additional builtin extension ${location.toString()}.`, getErrorMessage(error));
+				this.logService.info(`Error while fetching the additional builtin extension ${extensionLocation.toString()}.`, getErrorMessage(error));
 			}
 		}));
 		return result;


### PR DESCRIPTION
In #183467 the variable name for the extension location in `getCustomBuiltinExtensionsFromLocations` was changed from `location` to `extensionLocation`; however, in the error message we still log `location.toString()` which now just logs the browser url of the web app.

We should update this to `extensionLocation` to restore the original functionality of the error message which was to report the extension url which was causing issues.