### PR TITLE
Fixes automatically triggered code actions

### DIFF
--- a/src/vs/editor/contrib/codeAction/browser/codeActionController.ts
+++ b/src/vs/editor/contrib/codeAction/browser/codeActionController.ts
@@ -273,7 +273,6 @@ export class CodeActionController extends Disposable implements IEditorContribut
 				currentDecorations.clear();
 			},
 			onHover: async (action: CodeActionItem, token: CancellationToken) => {
-				await action.resolve(token);
 				if (token.isCancellationRequested) {
 					return;
 				}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

fixes https://github.com/microsoft/vscode/issues/196589

Code actions that didn't have definite edits were being re-run via the additional call to `resolve` (which called `resolveCodeAction` when there were no edits), which results in some code actions being immediately run on hover.
