### PR TITLE
debug: fix incomplete support of DAP invalidated event

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/debugSession.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugSession.ts
@@ -61,6 +61,7 @@ export class DebugSession implements IDebugSession, IDisposable {
 	private lastContinuedThreadId: number | undefined;
 	private repl: ReplModel;
 	private stoppedDetails: IRawStoppedDetails[] = [];
+	private readonly statusQueue = this.rawListeners.add(new ThreadStatusScheduler());
 
 	private readonly _onDidChangeState = new Emitter<void>();
 	private readonly _onDidEndAdapter = new Emitter<AdapterEndEvent | undefined>();
@@ -984,74 +985,8 @@ export class DebugSession implements IDebugSession, IDisposable {
 		}));
 
 
-		const statusQueue = this.rawListeners.add(new ThreadStatusScheduler());
-		this.rawListeners.add(this.raw.onDidStop(async event => {
-			this.passFocusScheduler.cancel();
-			this.stoppedDetails.push(event.body);
-
-			statusQueue.run(
-				this.fetchThreads(event.body).then(() => event.body.threadId === undefined ? this.threadIds : [event.body.threadId]),
-				async (threadId, token) => {
-					const hasLotsOfThreads = event.body.threadId === undefined && this.threadIds.length > 10;
-
-					// If the focus for the current session is on a non-existent thread, clear the focus.
-					const focusedThread = this.debugService.getViewModel().focusedThread;
-					const focusedThreadDoesNotExist = focusedThread !== undefined && focusedThread.session === this && !this.threads.has(focusedThread.threadId);
-					if (focusedThreadDoesNotExist) {
-						this.debugService.focusStackFrame(undefined, undefined);
-					}
-					const thread = typeof threadId === 'number' ? this.getThread(threadId) : undefined;
-					if (thread) {
-						// Call fetch call stack twice, the first only return the top stack frame.
-						// Second retrieves the rest of the call stack. For performance reasons #25605
-						// Second call is only done if there's few threads that stopped in this event.
-						const promises = this.model.refreshTopOfCallstack(<Thread>thread, /* fetchFullStack= */!hasLotsOfThreads);
-						const focus = async () => {
-							if (focusedThreadDoesNotExist || (!event.body.preserveFocusHint && thread.getCallStack().length)) {
-								const focusedStackFrame = this.debugService.getViewModel().focusedStackFrame;
-								if (!focusedStackFrame || focusedStackFrame.thread.session === this) {
-									// Only take focus if nothing is focused, or if the focus is already on the current session
-									const preserveFocus = !this.configurationService.getValue<IDebugConfiguration>('debug').focusEditorOnBreak;
-									await this.debugService.focusStackFrame(undefined, thread, undefined, { preserveFocus });
-								}
-
-								if (thread.stoppedDetails && !token.isCancellationRequested) {
-									if (thread.stoppedDetails.reason === 'breakpoint' && this.configurationService.getValue<IDebugConfiguration>('debug').openDebug === 'openOnDebugBreak' && !this.suppressDebugView) {
-										await this.paneCompositeService.openPaneComposite(VIEWLET_ID, ViewContainerLocation.Sidebar);
-									}
-
-									if (this.configurationService.getValue<IDebugConfiguration>('debug').focusWindowOnBreak && !this.workbenchEnvironmentService.extensionTestsLocationURI) {
-										const activeWindow = getActiveWindow();
-										if (!activeWindow.document.hasFocus()) {
-											await this.hostService.focus(mainWindow, { force: true /* Application may not be active */ });
-										}
-									}
-								}
-							}
-						};
-
-						await promises.topCallStack;
-						if (token.isCancellationRequested) {
-							return;
-						}
-
-						focus();
-
-						await promises.wholeCallStack;
-						if (token.isCancellationRequested) {
-							return;
-						}
-
-						const focusedStackFrame = this.debugService.getViewModel().focusedStackFrame;
-						if (!focusedStackFrame || !focusedStackFrame.source || focusedStackFrame.source.presentationHint === 'deemphasize' || focusedStackFrame.presentationHint === 'deemphasize') {
-							// The top stack frame can be deemphesized so try to focus again #68616
-							focus();
-						}
-					}
-					this._onDidChangeState.fire();
-				},
-			);
-		}));
+		const statusQueue = this.statusQueue;
+		this.rawListeners.add(this.raw.onDidStop(event => this.handleStop(event.body)));
 
 		this.rawListeners.add(this.raw.onDidThread(event => {
 			statusQueue.cancel([event.body.threadId]);
@@ -1268,11 +1203,15 @@ export class DebugSession implements IDebugSession, IDisposable {
 			this._onDidInvalidMemory.fire(event);
 		}));
 		this.rawListeners.add(this.raw.onDidInvalidated(async event => {
-			if (!(event.body.areas && event.body.areas.length === 1 && (event.body.areas[0] === 'variables' || event.body.areas[0] === 'watch'))) {
-				// If invalidated event only requires to update variables or watch, do that, otherwise refatch threads https://github.com/microsoft/vscode/issues/106745
+			const areas = event.body.areas || ['all'];
+			// If invalidated event only requires to update variables or watch, do that, otherwise refetch threads https://github.com/microsoft/vscode/issues/106745
+			if (areas.includes('threads') || areas.includes('stacks') || areas.includes('all')) {
 				this.cancelAllRequests();
 				this.model.clearThreads(this.getId(), true);
-				await this.fetchThreads(this.getStoppedDetails());
+
+				const details = this.stoppedDetails;
+				this.stoppedDetails.length = 1;
+				await Promise.all(details.map(d => this.handleStop(d)));
 			}
 
 			const viewModel = this.debugService.getViewModel();
@@ -1282,6 +1221,74 @@ export class DebugSession implements IDebugSession, IDisposable {
 		}));
 
 		this.rawListeners.add(this.raw.onDidExitAdapter(event => this.onDidExitAdapter(event)));
+	}
+
+	private async handleStop(event: IRawStoppedDetails) {
+		this.passFocusScheduler.cancel();
+		this.stoppedDetails.push(event);
+
+		this.statusQueue.run(
+			this.fetchThreads(event).then(() => event.threadId === undefined ? this.threadIds : [event.threadId]),
+			async (threadId, token) => {
+				const hasLotsOfThreads = event.threadId === undefined && this.threadIds.length > 10;
+
+				// If the focus for the current session is on a non-existent thread, clear the focus.
+				const focusedThread = this.debugService.getViewModel().focusedThread;
+				const focusedThreadDoesNotExist = focusedThread !== undefined && focusedThread.session === this && !this.threads.has(focusedThread.threadId);
+				if (focusedThreadDoesNotExist) {
+					this.debugService.focusStackFrame(undefined, undefined);
+				}
+				const thread = typeof threadId === 'number' ? this.getThread(threadId) : undefined;
+				if (thread) {
+					// Call fetch call stack twice, the first only return the top stack frame.
+					// Second retrieves the rest of the call stack. For performance reasons #25605
+					// Second call is only done if there's few threads that stopped in this event.
+					const promises = this.model.refreshTopOfCallstack(<Thread>thread, /* fetchFullStack= */!hasLotsOfThreads);
+					const focus = async () => {
+						if (focusedThreadDoesNotExist || (!event.preserveFocusHint && thread.getCallStack().length)) {
+							const focusedStackFrame = this.debugService.getViewModel().focusedStackFrame;
+							if (!focusedStackFrame || focusedStackFrame.thread.session === this) {
+								// Only take focus if nothing is focused, or if the focus is already on the current session
+								const preserveFocus = !this.configurationService.getValue<IDebugConfiguration>('debug').focusEditorOnBreak;
+								await this.debugService.focusStackFrame(undefined, thread, undefined, { preserveFocus });
+							}
+
+							if (thread.stoppedDetails && !token.isCancellationRequested) {
+								if (thread.stoppedDetails.reason === 'breakpoint' && this.configurationService.getValue<IDebugConfiguration>('debug').openDebug === 'openOnDebugBreak' && !this.suppressDebugView) {
+									await this.paneCompositeService.openPaneComposite(VIEWLET_ID, ViewContainerLocation.Sidebar);
+								}
+
+								if (this.configurationService.getValue<IDebugConfiguration>('debug').focusWindowOnBreak && !this.workbenchEnvironmentService.extensionTestsLocationURI) {
+									const activeWindow = getActiveWindow();
+									if (!activeWindow.document.hasFocus()) {
+										await this.hostService.focus(mainWindow, { force: true /* Application may not be active */ });
+									}
+								}
+							}
+						}
+					};
+
+					await promises.topCallStack;
+					if (token.isCancellationRequested) {
+						return;
+					}
+
+					focus();
+
+					await promises.wholeCallStack;
+					if (token.isCancellationRequested) {
+						return;
+					}
+
+					const focusedStackFrame = this.debugService.getViewModel().focusedStackFrame;
+					if (!focusedStackFrame || !focusedStackFrame.source || focusedStackFrame.source.presentationHint === 'deemphasize' || focusedStackFrame.presentationHint === 'deemphasize') {
+						// The top stack frame can be deemphesized so try to focus again #68616
+						focus();
+					}
+				}
+				this._onDidChangeState.fire();
+			},
+		);
 	}
 
 	private onDidExitAdapter(event?: AdapterEndEvent): void {

--- a/src/vs/workbench/contrib/debug/common/debug.ts
+++ b/src/vs/workbench/contrib/debug/common/debug.ts
@@ -118,6 +118,7 @@ export interface IRawStoppedDetails {
 	text?: string;
 	totalFrames?: number;
 	allThreadsStopped?: boolean;
+	preserveFocusHint?: boolean;
 	framesErrorMessage?: string;
 	hitBreakpointIds?: number[];
 }


### PR DESCRIPTION
Re-process stopped details to regenerate stacktraces if asked to invalid threads or stacks.

Fixes #188606

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
