### PR TITLE
Themed editor input icons

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatEditorInput.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditorInput.ts
@@ -12,11 +12,14 @@ import { ThemeIcon } from 'vs/base/common/themables';
 import { URI } from 'vs/base/common/uri';
 import * as nls from 'vs/nls';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
+import { registerIcon } from 'vs/platform/theme/common/iconRegistry';
 import { EditorInputCapabilities, IEditorSerializer, IUntypedEditorInput } from 'vs/workbench/common/editor';
 import { EditorInput } from 'vs/workbench/common/editor/editorInput';
 import type { IChatEditorOptions } from 'vs/workbench/contrib/chat/browser/chatEditor';
 import { IChatModel } from 'vs/workbench/contrib/chat/common/chatModel';
 import { IChatService } from 'vs/workbench/contrib/chat/common/chatService';
+
+const ChatEditorIcon = registerIcon('chat-editor-label-icon', Codicon.commentDiscussion, nls.localize('chatEditorLabelIcon', 'Icon of the chat editor label.'));
 
 export class ChatEditorInput extends EditorInput {
 	static readonly countsInUse = new Set<number>();
@@ -84,7 +87,7 @@ export class ChatEditorInput extends EditorInput {
 	}
 
 	override getIcon(): ThemeIcon {
-		return Codicon.commentDiscussion;
+		return ChatEditorIcon;
 	}
 
 	override async resolve(): Promise<ChatEditorModel | null> {

--- a/src/vs/workbench/contrib/debug/common/disassemblyViewInput.ts
+++ b/src/vs/workbench/contrib/debug/common/disassemblyViewInput.ts
@@ -7,6 +7,9 @@ import { EditorInput } from 'vs/workbench/common/editor/editorInput';
 import { localize } from 'vs/nls';
 import { ThemeIcon } from 'vs/base/common/themables';
 import { Codicon } from 'vs/base/common/codicons';
+import { registerIcon } from 'vs/platform/theme/common/iconRegistry';
+
+const DisassemblyEditorIcon = registerIcon('disassembly-editor-label-icon', Codicon.debug, localize('disassemblyEditorLabelIcon', 'Icon of the disassembly editor label.'));
 
 export class DisassemblyViewInput extends EditorInput {
 
@@ -32,7 +35,7 @@ export class DisassemblyViewInput extends EditorInput {
 	}
 
 	override getIcon(): ThemeIcon {
-		return Codicon.debug;
+		return DisassemblyEditorIcon;
 	}
 
 	override matches(other: unknown): boolean {

--- a/src/vs/workbench/contrib/extensions/common/extensionsInput.ts
+++ b/src/vs/workbench/contrib/extensions/common/extensionsInput.ts
@@ -14,6 +14,9 @@ import { join } from 'vs/base/common/path';
 import { IEditorOptions } from 'vs/platform/editor/common/editor';
 import { ThemeIcon } from 'vs/base/common/themables';
 import { Codicon } from 'vs/base/common/codicons';
+import { registerIcon } from 'vs/platform/theme/common/iconRegistry';
+
+const ExtensionEditorIcon = registerIcon('extension-editor-label-icon', Codicon.extensions, localize('extensionEditorLabelIcon', 'Icon of the extension editor label.'));
 
 export interface IExtensionEditorOptions extends IEditorOptions {
 	showPreReleaseVersion?: boolean;
@@ -51,7 +54,7 @@ export class ExtensionsInput extends EditorInput {
 	}
 
 	override getIcon(): ThemeIcon | undefined {
-		return Codicon.extensions;
+		return ExtensionEditorIcon;
 	}
 
 	override matches(other: EditorInput | IUntypedEditorInput): boolean {

--- a/src/vs/workbench/contrib/extensions/common/runtimeExtensionsInput.ts
+++ b/src/vs/workbench/contrib/extensions/common/runtimeExtensionsInput.ts
@@ -9,6 +9,9 @@ import { EditorInputCapabilities, IUntypedEditorInput } from 'vs/workbench/commo
 import { EditorInput } from 'vs/workbench/common/editor/editorInput';
 import { ThemeIcon } from 'vs/base/common/themables';
 import { Codicon } from 'vs/base/common/codicons';
+import { registerIcon } from 'vs/platform/theme/common/iconRegistry';
+
+const RuntimeExtensionsEditorIcon = registerIcon('runtime-extensions-editor-label-icon', Codicon.extensions, nls.localize('runtimeExtensionEditorLabelIcon', 'Icon of the runtime extensions editor label.'));
 
 export class RuntimeExtensionsInput extends EditorInput {
 
@@ -41,7 +44,7 @@ export class RuntimeExtensionsInput extends EditorInput {
 	}
 
 	override getIcon(): ThemeIcon {
-		return Codicon.extensions;
+		return RuntimeExtensionsEditorIcon;
 	}
 
 	override matches(other: EditorInput | IUntypedEditorInput): boolean {

--- a/src/vs/workbench/contrib/multiDiffEditor/browser/multiDiffEditorInput.ts
+++ b/src/vs/workbench/contrib/multiDiffEditor/browser/multiDiffEditorInput.ts
@@ -20,10 +20,13 @@ import { ITextModelService } from 'vs/editor/common/services/resolverService';
 import { ITextResourceConfigurationService } from 'vs/editor/common/services/textResourceConfiguration';
 import { localize } from 'vs/nls';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
+import { registerIcon } from 'vs/platform/theme/common/iconRegistry';
 import { IEditorConfiguration } from 'vs/workbench/browser/parts/editor/textEditor';
 import { DEFAULT_EDITOR_ASSOCIATION, EditorInputCapabilities } from 'vs/workbench/common/editor';
 import { EditorInput } from 'vs/workbench/common/editor/editorInput';
 import { ILanguageSupport } from 'vs/workbench/services/textfile/common/textfiles';
+
+const MultiDiffEditorIcon = registerIcon('multi-diff-editor-label-icon', Codicon.diffMultiple, localize('multiDiffEditorLabelIcon', 'Icon of the multi diff editor label.'));
 
 /* hot-reload:patch-prototype-methods */
 export class MultiDiffEditorInput extends EditorInput implements ILanguageSupport {
@@ -52,7 +55,7 @@ export class MultiDiffEditorInput extends EditorInput implements ILanguageSuppor
 	}
 
 	override getIcon(): ThemeIcon {
-		return Codicon.diffMultiple;
+		return MultiDiffEditorIcon;
 	}
 
 	constructor(

--- a/src/vs/workbench/contrib/searchEditor/browser/searchEditorInput.ts
+++ b/src/vs/workbench/contrib/searchEditor/browser/searchEditorInput.ts
@@ -34,6 +34,7 @@ import { IResourceEditorInput } from 'vs/platform/editor/common/editor';
 import { IDisposable } from 'vs/base/common/lifecycle';
 import { Codicon } from 'vs/base/common/codicons';
 import { ThemeIcon } from 'vs/base/common/themables';
+import { registerIcon } from 'vs/platform/theme/common/iconRegistry';
 
 export type SearchConfiguration = {
 	query: string;
@@ -56,6 +57,8 @@ export type SearchConfiguration = {
 
 export const SEARCH_EDITOR_EXT = '.code-search';
 
+const SearchEditorIcon = registerIcon('search-editor-label-icon', Codicon.search, localize('searchEditorLabelIcon', 'Icon of the search editor label.'));
+
 export class SearchEditorInput extends EditorInput {
 	static readonly ID: string = SearchEditorInputTypeId;
 
@@ -68,7 +71,7 @@ export class SearchEditorInput extends EditorInput {
 	}
 
 	override getIcon(): ThemeIcon {
-		return Codicon.search;
+		return SearchEditorIcon;
 	}
 
 	override get capabilities(): EditorInputCapabilities {

--- a/src/vs/workbench/services/preferences/browser/keybindingsEditorInput.ts
+++ b/src/vs/workbench/services/preferences/browser/keybindingsEditorInput.ts
@@ -8,6 +8,7 @@ import { OS } from 'vs/base/common/platform';
 import { ThemeIcon } from 'vs/base/common/themables';
 import * as nls from 'vs/nls';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
+import { registerIcon } from 'vs/platform/theme/common/iconRegistry';
 import { IUntypedEditorInput } from 'vs/workbench/common/editor';
 import { EditorInput } from 'vs/workbench/common/editor/editorInput';
 import { KeybindingsEditorModel } from 'vs/workbench/services/preferences/browser/keybindingsEditorModel';
@@ -17,6 +18,8 @@ export interface IKeybindingsEditorSearchOptions {
 	recordKeybindings: boolean;
 	sortByPrecedence: boolean;
 }
+
+const KeybindingsEditorIcon = registerIcon('keybindings-editor-label-icon', Codicon.keyboard, nls.localize('keybindingsEditorLabelIcon', 'Icon of the keybindings editor label.'));
 
 export class KeybindingsEditorInput extends EditorInput {
 
@@ -42,7 +45,7 @@ export class KeybindingsEditorInput extends EditorInput {
 	}
 
 	override getIcon(): ThemeIcon {
-		return Codicon.keyboard;
+		return KeybindingsEditorIcon;
 	}
 
 	override async resolve(): Promise<KeybindingsEditorModel> {

--- a/src/vs/workbench/services/preferences/common/preferencesEditorInput.ts
+++ b/src/vs/workbench/services/preferences/common/preferencesEditorInput.ts
@@ -8,10 +8,13 @@ import { Schemas } from 'vs/base/common/network';
 import { ThemeIcon } from 'vs/base/common/themables';
 import { URI } from 'vs/base/common/uri';
 import * as nls from 'vs/nls';
+import { registerIcon } from 'vs/platform/theme/common/iconRegistry';
 import { IUntypedEditorInput } from 'vs/workbench/common/editor';
 import { EditorInput } from 'vs/workbench/common/editor/editorInput';
 import { IPreferencesService } from 'vs/workbench/services/preferences/common/preferences';
 import { Settings2EditorModel } from 'vs/workbench/services/preferences/common/preferencesModels';
+
+const SettingsEditorIcon = registerIcon('settings-editor-label-icon', Codicon.settings, nls.localize('settingsEditorLabelIcon', 'Icon of the settings editor label.'));
 
 export class SettingsEditor2Input extends EditorInput {
 
@@ -44,7 +47,7 @@ export class SettingsEditor2Input extends EditorInput {
 	}
 
 	override getIcon(): ThemeIcon {
-		return Codicon.settings;
+		return SettingsEditorIcon;
 	}
 
 	override async resolve(): Promise<Settings2EditorModel> {

--- a/src/vs/workbench/services/workspaces/browser/workspaceTrustEditorInput.ts
+++ b/src/vs/workbench/services/workspaces/browser/workspaceTrustEditorInput.ts
@@ -8,8 +8,11 @@ import { Schemas } from 'vs/base/common/network';
 import { ThemeIcon } from 'vs/base/common/themables';
 import { URI } from 'vs/base/common/uri';
 import { localize } from 'vs/nls';
+import { registerIcon } from 'vs/platform/theme/common/iconRegistry';
 import { EditorInputCapabilities, IUntypedEditorInput } from 'vs/workbench/common/editor';
 import { EditorInput } from 'vs/workbench/common/editor/editorInput';
+
+const WorkspaceTrustEditorIcon = registerIcon('workspace-trust-editor-label-icon', Codicon.shield, localize('workspaceTrustEditorLabelIcon', 'Icon of the workspace trust editor label.'));
 
 export class WorkspaceTrustEditorInput extends EditorInput {
 	static readonly ID: string = 'workbench.input.workspaceTrust';
@@ -36,6 +39,6 @@ export class WorkspaceTrustEditorInput extends EditorInput {
 	}
 
 	override getIcon(): ThemeIcon {
-		return Codicon.shield;
+		return WorkspaceTrustEditorIcon;
 	}
 }


### PR DESCRIPTION
This PR introduces themed icons for various editor inputs. Previously, the icons were static and did not adapt to the current theme. With this change, each editor input now registers its own icon, which can be themed. This affects the chat, disassembly, extension, runtime extensions, multi diff, search, keybindings, settings, and workspace trust editors.