### PR TITLE
fix: terminal editors should use editor group context key service

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminal.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminal.ts
@@ -26,6 +26,7 @@ import { EditorGroupColumn } from 'vs/workbench/services/editor/common/editorGro
 import { ISimpleSelectedSuggestion } from 'vs/workbench/services/suggest/browser/simpleSuggestWidget';
 import type { IMarker, ITheme, Terminal as RawXtermTerminal } from '@xterm/xterm';
 import { ScrollPosition } from 'vs/workbench/contrib/terminal/browser/xterm/markNavigationAddon';
+import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 
 export const ITerminalService = createDecorator<ITerminalService>('terminalService');
 export const ITerminalEditorService = createDecorator<ITerminalEditorService>('terminalEditorService');
@@ -998,6 +999,11 @@ export interface ITerminalInstance extends IBaseTerminalInstance {
 	 * If successful, places commandToRun on the command line
 	 */
 	freePortKillProcess(port: string, commandToRun: string): Promise<void>;
+
+	/**
+	 * Update the parent context key service to use for this terminal instance.
+	 */
+	setParentContextKeyService(parentContextKeyService: IContextKeyService): void;
 }
 
 export const enum XtermTerminalConstants {

--- a/src/vs/workbench/contrib/terminal/browser/terminalEditorInput.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalEditorInput.ts
@@ -42,6 +42,9 @@ export class TerminalEditorInput extends EditorInput implements IEditorCloseHand
 
 	setGroup(group: IEditorGroup | undefined) {
 		this._group = group;
+		if (group?.scopedContextKeyService) {
+			this._terminalInstance?.setParentContextKeyService(group.scopedContextKeyService);
+		}
 	}
 
 	get group(): IEditorGroup | undefined {
@@ -127,7 +130,7 @@ export class TerminalEditorInput extends EditorInput implements IEditorCloseHand
 		@IInstantiationService private readonly _instantiationService: IInstantiationService,
 		@IConfigurationService private readonly _configurationService: IConfigurationService,
 		@ILifecycleService private readonly _lifecycleService: ILifecycleService,
-		@IContextKeyService _contextKeyService: IContextKeyService,
+		@IContextKeyService private _contextKeyService: IContextKeyService,
 		@IDialogService private readonly _dialogService: IDialogService
 	) {
 		super();
@@ -221,6 +224,7 @@ export class TerminalEditorInput extends EditorInput implements IEditorCloseHand
 	detachInstance() {
 		if (!this._isShuttingDown) {
 			this._terminalInstance?.detachFromElement();
+			this._terminalInstance?.setParentContextKeyService(this._contextKeyService);
 			this._isDetached = true;
 		}
 	}

--- a/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
@@ -184,6 +184,7 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 	private _usedShellIntegrationInjection: boolean = false;
 	get usedShellIntegrationInjection(): boolean { return this._usedShellIntegrationInjection; }
 	private _lineDataEventAddon: LineDataEventAddon | undefined;
+	private readonly _scopedContextKeyService: IContextKeyService;
 
 	readonly capabilities = new TerminalCapabilityStoreMultiplexer();
 	readonly statusList: ITerminalStatusList;
@@ -409,6 +410,7 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 		}
 
 		const scopedContextKeyService = this._register(_contextKeyService.createScoped(this._wrapperElement));
+		this._scopedContextKeyService = scopedContextKeyService;
 		this._scopedInstantiationService = instantiationService.createChild(new ServiceCollection(
 			[IContextKeyService, scopedContextKeyService]
 		));
@@ -2217,6 +2219,10 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 
 	resetScrollbarVisibility(): void {
 		this._wrapperElement.classList.remove('force-scrollbar');
+	}
+
+	setParentContextKeyService(parentContextKeyService: IContextKeyService): void {
+		this._scopedContextKeyService.updateParent(parentContextKeyService);
 	}
 }
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
Fixes https://github.com/microsoft/vscode/issues/174161

When a terminal is moved into the editor area, its context key service should be reparented under the editor group's context key service (and should be parented under the default context key service when a terminal editor is moved back into the panel).

I've tested that the missing context keys reported in the issue are now set after moving a terminal into the editor area, that they are updated when e.g. pinning the editor, and that they are unset after moving them back into the panel.