### PR TITLE
testing: `testRun.appendOutput` formatting is the same as test failure formatting.

### DIFF
--- a/src/vs/workbench/contrib/testing/browser/testingDecorations.ts
+++ b/src/vs/workbench/contrib/testing/browser/testingDecorations.ts
@@ -366,26 +366,29 @@ export class TestingDecorationService extends Disposable implements ITestingDeco
 			for (const test of lastResult.tests) {
 				for (let taskId = 0; taskId < test.tasks.length; taskId++) {
 					const state = test.tasks[taskId];
-					for (let i = 0; i < state.messages.length; i++) {
-						const m = state.messages[i];
-						if (this.invalidatedMessages.has(m) || m.location?.uri.toString() !== uriStr) {
-							continue;
-						}
+					// push error decorations first so they take precedence over normal output
+					for (const kind of [TestMessageType.Error, TestMessageType.Output]) {
+						for (let i = 0; i < state.messages.length; i++) {
+							const m = state.messages[i];
+							if (m.type !== kind || this.invalidatedMessages.has(m) || m.location?.uri.toString() !== uriStr) {
+								continue;
+							}
 
-						// Only add one message per line number. Overlapping messages
-						// don't appear well, and the peek will show all of them (#134129)
-						const line = m.location.range.startLineNumber;
-						if (!messageLines.has(line)) {
-							const decoration = lastDecorations.getMessage(m) || this.instantiationService.createInstance(TestMessageDecoration, m, buildTestUri({
-								type: TestUriType.ResultActualOutput,
-								messageIndex: i,
-								taskIndex: taskId,
-								resultId: lastResult.id,
-								testExtId: test.item.extId,
-							}), model);
+							// Only add one message per line number. Overlapping messages
+							// don't appear well, and the peek will show all of them (#134129)
+							const line = m.location.range.startLineNumber;
+							if (!messageLines.has(line)) {
+								const decoration = lastDecorations.getMessage(m) || this.instantiationService.createInstance(TestMessageDecoration, m, buildTestUri({
+									type: TestUriType.ResultActualOutput,
+									messageIndex: i,
+									taskIndex: taskId,
+									resultId: lastResult.id,
+									testExtId: test.item.extId,
+								}), model);
 
-							newDecorations.addMessage(decoration);
-							messageLines.add(line);
+								newDecorations.addMessage(decoration);
+								messageLines.add(line);
+							}
 						}
 					}
 				}

--- a/src/vs/workbench/contrib/testing/browser/testingOutputPeek.ts
+++ b/src/vs/workbench/contrib/testing/browser/testingOutputPeek.ts
@@ -73,7 +73,7 @@ import { TerminalCapabilityStore } from 'vs/platform/terminal/common/capabilitie
 import { formatMessageForTerminal } from 'vs/platform/terminal/common/terminalStrings';
 import { editorBackground } from 'vs/platform/theme/common/colorRegistry';
 import { widgetClose } from 'vs/platform/theme/common/iconRegistry';
-import { IColorTheme, IThemeService } from 'vs/platform/theme/common/themeService';
+import { IThemeService } from 'vs/platform/theme/common/themeService';
 import { IWorkspaceContextService } from 'vs/platform/workspace/common/workspace';
 import { IViewPaneOptions, ViewPane } from 'vs/workbench/browser/parts/views/viewPane';
 import { EditorModel } from 'vs/workbench/common/editor/editorModel';
@@ -85,7 +85,7 @@ import { getXtermScaledDimensions } from 'vs/workbench/contrib/terminal/browser/
 import { TERMINAL_BACKGROUND_COLOR } from 'vs/workbench/contrib/terminal/common/terminalColorRegistry';
 import { getTestItemContextOverlay } from 'vs/workbench/contrib/testing/browser/explorerProjections/testItemContextOverlay';
 import * as icons from 'vs/workbench/contrib/testing/browser/icons';
-import { testingPeekBorder, testingPeekHeaderBackground } from 'vs/workbench/contrib/testing/browser/theme';
+import { testingMessagePeekBorder, testingPeekBorder, testingPeekHeaderBackground, testingPeekMessageHeaderBackground } from 'vs/workbench/contrib/testing/browser/theme';
 import { AutoOpenPeekViewWhen, TestingConfigKeys, getTestingConfiguration } from 'vs/workbench/contrib/testing/common/configuration';
 import { Testing } from 'vs/workbench/contrib/testing/common/constants';
 import { IObservableValue, MutableObservableValue, staticObservableValue } from 'vs/workbench/contrib/testing/common/observableValue';
@@ -941,7 +941,7 @@ class TestResultsPeek extends PeekViewWidget {
 
 	constructor(
 		editor: ICodeEditor,
-		@IThemeService themeService: IThemeService,
+		@IThemeService private readonly themeService: IThemeService,
 		@IPeekViewService peekViewService: IPeekViewService,
 		@ITestingPeekOpener private readonly testingPeek: ITestingPeekOpener,
 		@IContextKeyService private readonly contextKeyService: IContextKeyService,
@@ -953,13 +953,14 @@ class TestResultsPeek extends PeekViewWidget {
 
 		this._disposables.add(themeService.onDidColorThemeChange(this.applyTheme, this));
 		this._disposables.add(this.onDidClose(() => this.visibilityChange.fire(false)));
-		this.applyTheme(themeService.getColorTheme());
 		peekViewService.addExclusiveWidget(editor, this);
 	}
 
-	private applyTheme(theme: IColorTheme) {
-		const borderColor = theme.getColor(testingPeekBorder) || Color.transparent;
-		const headerBg = theme.getColor(testingPeekHeaderBackground) || Color.transparent;
+	private applyTheme() {
+		const theme = this.themeService.getColorTheme();
+		const isError = this.current instanceof MessageSubject && this.current.message.type === TestMessageType.Error;
+		const borderColor = (isError ? theme.getColor(testingPeekBorder) : theme.getColor(testingMessagePeekBorder)) || Color.transparent;
+		const headerBg = (isError ? theme.getColor(testingPeekHeaderBackground) : theme.getColor(testingPeekMessageHeaderBackground)) || Color.transparent;
 		const editorBg = theme.getColor(editorBackground);
 		this.style({
 			arrowColor: borderColor,
@@ -1038,6 +1039,7 @@ class TestResultsPeek extends PeekViewWidget {
 		} else {
 			this.setTitle(localize('testOutputTitle', 'Test Output'));
 		}
+		this.applyTheme();
 		await this.content.reveal({ subject: subject, preserveFocus: false });
 	}
 

--- a/src/vs/workbench/contrib/testing/browser/theme.ts
+++ b/src/vs/workbench/contrib/testing/browser/theme.ts
@@ -5,7 +5,7 @@
 
 import { Color, RGBA } from 'vs/base/common/color';
 import { localize } from 'vs/nls';
-import { contrastBorder, editorErrorForeground, editorForeground, registerColor, transparent } from 'vs/platform/theme/common/colorRegistry';
+import { contrastBorder, editorErrorForeground, editorForeground, editorInfoForeground, registerColor, transparent } from 'vs/platform/theme/common/colorRegistry';
 import { TestMessageType, TestResultState } from 'vs/workbench/contrib/testing/common/testTypes';
 
 export const testingColorIconFailed = registerColor('testing.iconFailed', {
@@ -64,12 +64,26 @@ export const testingPeekBorder = registerColor('testing.peekBorder', {
 	hcLight: contrastBorder
 }, localize('testing.peekBorder', 'Color of the peek view borders and arrow.'));
 
+export const testingMessagePeekBorder = registerColor('testing.messagePeekBorder', {
+	dark: editorInfoForeground,
+	light: editorInfoForeground,
+	hcDark: contrastBorder,
+	hcLight: contrastBorder
+}, localize('testing.messagePeekBorder', 'Color of the peek view borders and arrow when peeking a logged message.'));
+
 export const testingPeekHeaderBackground = registerColor('testing.peekHeaderBackground', {
 	dark: transparent(editorErrorForeground, 0.1),
 	light: transparent(editorErrorForeground, 0.1),
 	hcDark: null,
 	hcLight: null
 }, localize('testing.peekBorder', 'Color of the peek view borders and arrow.'));
+
+export const testingPeekMessageHeaderBackground = registerColor('testing.messagePeekHeaderBackground', {
+	dark: transparent(editorInfoForeground, 0.1),
+	light: transparent(editorInfoForeground, 0.1),
+	hcDark: null,
+	hcLight: null
+}, localize('testing.messagePeekHeaderBackground', 'Color of the peek view borders and arrow when peeking a logged message.'));
 
 export const testMessageSeverityColors: {
 	[K in TestMessageType]: {


### PR DESCRIPTION
Fixes #200716

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
