### PR TITLE
Allow optionally pasting html content in clipboard

### DIFF
--- a/src/vs/editor/contrib/dropOrPasteInto/browser/defaultProviders.ts
+++ b/src/vs/editor/contrib/dropOrPasteInto/browser/defaultProviders.ts
@@ -152,6 +152,30 @@ class RelativePathProvider extends SimplePasteAndDropProvider {
 	}
 }
 
+class PasteHtmlProvider implements DocumentPasteEditProvider {
+
+	public readonly id = 'html';
+
+	public readonly pasteMimeTypes = ['text/html'];
+
+	private readonly _yieldTo = [{ mimeType: Mimes.text }];
+
+	async provideDocumentPasteEdits(_model: ITextModel, _ranges: readonly IRange[], dataTransfer: IReadonlyVSDataTransfer, token: CancellationToken): Promise<DocumentPasteEdit | undefined> {
+		const entry = dataTransfer.get('text/html');
+		const htmlText = await entry?.asString();
+		if (!htmlText || token.isCancellationRequested) {
+			return;
+		}
+
+		return {
+			insertText: htmlText,
+			yieldTo: this._yieldTo,
+			label: localize('pasteHtmlLabel', 'Insert HTML'),
+			detail: builtInLabel,
+		};
+	}
+}
+
 async function extractUriList(dataTransfer: IReadonlyVSDataTransfer): Promise<{ readonly uri: URI; readonly originalText: string }[]> {
 	const urlListEntry = dataTransfer.get(Mimes.uriList);
 	if (!urlListEntry) {
@@ -193,5 +217,6 @@ export class DefaultPasteProvidersFeature extends Disposable {
 		this._register(languageFeaturesService.documentPasteEditProvider.register('*', new DefaultTextProvider()));
 		this._register(languageFeaturesService.documentPasteEditProvider.register('*', new PathProvider()));
 		this._register(languageFeaturesService.documentPasteEditProvider.register('*', new RelativePathProvider(workspaceContextService)));
+		this._register(languageFeaturesService.documentPasteEditProvider.register('*', new PasteHtmlProvider()));
 	}
 }


### PR DESCRIPTION
Fixes #57577

This adds a new, non-default paste provider that inserts the `text/html` content from the clipboard

Originally added this just for markdown and html, but I think it's likely useful in other languages too (such as pasting html into a string). Adding to core to keep implementation consistent

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
