### PR TITLE
Fix for #200257 plus existing trailing non-numerics regex fix

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/links/browser/terminalLinkOpeners.ts
+++ b/src/vs/workbench/contrib/terminalContrib/links/browser/terminalLinkOpeners.ts
@@ -115,7 +115,7 @@ export class TerminalSearchLinkOpener implements ITerminalLinkOpener {
 		// "Check your code Test.tsx:12:45." -> Test.tsx:12:45
 		// "Check your code Test.tsx:12." -> Test.tsx:12
 
-		text = text.replace(/:[\d]+\.$/, (match) => match.slice(0, -1));
+		text = text.replace(/\.$/, '');
 
 		// If any of the names of the folders in the workspace matches
 		// a prefix of the link, remove that prefix and continue

--- a/src/vs/workbench/contrib/terminalContrib/links/browser/terminalLinkOpeners.ts
+++ b/src/vs/workbench/contrib/terminalContrib/links/browser/terminalLinkOpeners.ts
@@ -110,6 +110,13 @@ export class TerminalSearchLinkOpener implements ITerminalLinkOpener {
 		// would break absolute Windows paths (eg. `C:/Users/...`).
 		text = text.replace(/:[^\\/\d][^\d]+$/, '');
 
+		// Remove any trailing periods after the line/column numbers, to prevent breaking the search feature, #200257
+		// Examples:
+		// "Check your code Test.tsx:12:45." -> Test.tsx:12:45
+		// "Check your code Test.tsx:12." -> Test.tsx:12
+
+		text = text.replace(/:[\d]+\.$/, (match) => match.slice(0, -1));
+
 		// If any of the names of the folders in the workspace matches
 		// a prefix of the link, remove that prefix and continue
 		this._workspaceContextService.getWorkspace().folders.forEach((folder) => {

--- a/src/vs/workbench/contrib/terminalContrib/links/browser/terminalLinkOpeners.ts
+++ b/src/vs/workbench/contrib/terminalContrib/links/browser/terminalLinkOpeners.ts
@@ -108,7 +108,7 @@ export class TerminalSearchLinkOpener implements ITerminalLinkOpener {
 		// - Grep output: <link>:<result line>
 		// This only happens when the colon is _not_ followed by a forward- or back-slash as that
 		// would break absolute Windows paths (eg. `C:/Users/...`).
-		text = text.replace(/:[^\\/][^\d]+$/, '');
+		text = text.replace(/:[^\\/\d][^\d]+$/, '');
 
 		// If any of the names of the folders in the workspace matches
 		// a prefix of the link, remove that prefix and continue

--- a/src/vs/workbench/contrib/terminalContrib/links/browser/terminalLinkOpeners.ts
+++ b/src/vs/workbench/contrib/terminalContrib/links/browser/terminalLinkOpeners.ts
@@ -108,7 +108,7 @@ export class TerminalSearchLinkOpener implements ITerminalLinkOpener {
 		// - Grep output: <link>:<result line>
 		// This only happens when the colon is _not_ followed by a forward- or back-slash as that
 		// would break absolute Windows paths (eg. `C:/Users/...`).
-		text = text.replace(/:[^\\/\d][^\d]+$/, '');
+		text = text.replace(/:[^\\/\d][^\d]*$/, '');
 
 		// Remove any trailing periods after the line/column numbers, to prevent breaking the search feature, #200257
 		// Examples:

--- a/src/vs/workbench/contrib/terminalContrib/links/test/browser/terminalLinkOpeners.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/links/test/browser/terminalLinkOpeners.test.ts
@@ -342,6 +342,32 @@ suite('Workbench - TerminalLinkOpeners', () => {
 					},
 				});
 			});
+
+			test('should extract line and column from links and remove trailing periods', async () => {
+				localFileOpener = instantiationService.createInstance(TerminalLocalFileLinkOpener);
+				const localFolderOpener = instantiationService.createInstance(TerminalLocalFolderInWorkspaceLinkOpener);
+				opener = instantiationService.createInstance(TestTerminalSearchLinkOpener, capabilities, '/folder', localFileOpener, localFolderOpener, () => OperatingSystem.Linux);
+				fileService.setFiles([
+					URI.from({ scheme: Schemas.file, path: '/folder/foo/bar.txt' })
+				]);
+				await opener.open({
+					text: './foo/bar.txt:10:5.',
+					bufferRange: { start: { x: 1, y: 1 }, end: { x: 8, y: 1 } },
+					type: TerminalBuiltinLinkType.Search
+				});
+				deepStrictEqual(activationResult, {
+					link: 'file:///folder/foo/bar.txt',
+					source: 'editor',
+					selection: {
+						startColumn: 5,
+						startLineNumber: 10,
+						endColumn: undefined,
+						endLineNumber: undefined
+					},
+				});
+			});
+
+
 		});
 
 		suite('Windows', () => {
@@ -438,6 +464,45 @@ suite('Workbench - TerminalLinkOpeners', () => {
 				});
 				deepStrictEqual(activationResult, {
 					link: 'file:///c%3A/space%20folder/foo/bar.txt',
+					source: 'editor',
+					selection: {
+						startColumn: 5,
+						startLineNumber: 10,
+						endColumn: undefined,
+						endLineNumber: undefined
+					},
+				});
+			});
+
+			test('should extract line and column from links and remove trailing periods', async () => {
+				localFileOpener = instantiationService.createInstance(TerminalLocalFileLinkOpener);
+				const localFolderOpener = instantiationService.createInstance(TerminalLocalFolderInWorkspaceLinkOpener);
+				opener = instantiationService.createInstance(TestTerminalSearchLinkOpener, capabilities, 'c:/folder', localFileOpener, localFolderOpener, () => OperatingSystem.Windows);
+				fileService.setFiles([
+					URI.from({ scheme: Schemas.file, path: 'c:/folder/foo/bar.txt' })
+				]);
+				await opener.open({
+					text: './foo/bar.txt:10:5.',
+					bufferRange: { start: { x: 1, y: 1 }, end: { x: 8, y: 1 } },
+					type: TerminalBuiltinLinkType.Search
+				});
+				deepStrictEqual(activationResult, {
+					link: 'file:///c%3A/folder/foo/bar.txt',
+					source: 'editor',
+					selection: {
+						startColumn: 5,
+						startLineNumber: 10,
+						endColumn: undefined,
+						endLineNumber: undefined
+					},
+				});
+				await opener.open({
+					text: '.\\foo\\bar.txt:10:5',
+					bufferRange: { start: { x: 1, y: 1 }, end: { x: 8, y: 1 } },
+					type: TerminalBuiltinLinkType.Search
+				});
+				deepStrictEqual(activationResult, {
+					link: 'file:///c%3A/folder/foo/bar.txt',
 					source: 'editor',
 					selection: {
 						startColumn: 5,

--- a/src/vs/workbench/contrib/terminalContrib/links/test/browser/terminalLinkOpeners.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/links/test/browser/terminalLinkOpeners.test.ts
@@ -319,7 +319,7 @@ suite('Workbench - TerminalLinkOpeners', () => {
 				});
 			});
 
-			test('should extract line and column from links in a workspace containing spaces', async () => {
+			test('should extract column and/or line numbers from links in a workspace containing spaces', async () => {
 				localFileOpener = instantiationService.createInstance(TerminalLocalFileLinkOpener);
 				const localFolderOpener = instantiationService.createInstance(TerminalLocalFolderInWorkspaceLinkOpener);
 				opener = instantiationService.createInstance(TestTerminalSearchLinkOpener, capabilities, '/space folder', localFileOpener, localFolderOpener, () => OperatingSystem.Linux);
@@ -341,9 +341,24 @@ suite('Workbench - TerminalLinkOpeners', () => {
 						endLineNumber: undefined
 					},
 				});
+				await opener.open({
+					text: './foo/bar.txt:10',
+					bufferRange: { start: { x: 1, y: 1 }, end: { x: 8, y: 1 } },
+					type: TerminalBuiltinLinkType.Search
+				});
+				deepStrictEqual(activationResult, {
+					link: 'file:///space%20folder/foo/bar.txt',
+					source: 'editor',
+					selection: {
+						startColumn: 1,
+						startLineNumber: 10,
+						endColumn: undefined,
+						endLineNumber: undefined
+					},
+				});
 			});
 
-			test('should extract line and column from links and remove trailing periods', async () => {
+			test('should extract column and/or line numbers from links and remove trailing periods', async () => {
 				localFileOpener = instantiationService.createInstance(TerminalLocalFileLinkOpener);
 				const localFolderOpener = instantiationService.createInstance(TerminalLocalFolderInWorkspaceLinkOpener);
 				opener = instantiationService.createInstance(TestTerminalSearchLinkOpener, capabilities, '/folder', localFileOpener, localFolderOpener, () => OperatingSystem.Linux);
@@ -365,8 +380,125 @@ suite('Workbench - TerminalLinkOpeners', () => {
 						endLineNumber: undefined
 					},
 				});
+				await opener.open({
+					text: './foo/bar.txt:10.',
+					bufferRange: { start: { x: 1, y: 1 }, end: { x: 8, y: 1 } },
+					type: TerminalBuiltinLinkType.Search
+				});
+				deepStrictEqual(activationResult, {
+					link: 'file:///folder/foo/bar.txt',
+					source: 'editor',
+					selection: {
+						startColumn: 1,
+						startLineNumber: 10,
+						endColumn: undefined,
+						endLineNumber: undefined
+					},
+				});
 			});
 
+			test('should extract column and/or line numbers from links and remove grepped lines', async () => {
+				localFileOpener = instantiationService.createInstance(TerminalLocalFileLinkOpener);
+				const localFolderOpener = instantiationService.createInstance(TerminalLocalFolderInWorkspaceLinkOpener);
+				opener = instantiationService.createInstance(TestTerminalSearchLinkOpener, capabilities, '/folder', localFileOpener, localFolderOpener, () => OperatingSystem.Linux);
+				fileService.setFiles([
+					URI.from({ scheme: Schemas.file, path: '/folder/foo/bar.txt' })
+				]);
+				await opener.open({
+					text: './foo/bar.txt:10:5:import { ILoveVSCode } from \'./foo/bar.ts\';',
+					bufferRange: { start: { x: 1, y: 1 }, end: { x: 8, y: 1 } },
+					type: TerminalBuiltinLinkType.Search
+				});
+				deepStrictEqual(activationResult, {
+					link: 'file:///folder/foo/bar.txt',
+					source: 'editor',
+					selection: {
+						startColumn: 5,
+						startLineNumber: 10,
+						endColumn: undefined,
+						endLineNumber: undefined
+					},
+				});
+				await opener.open({
+					text: './foo/bar.txt:10:import { ILoveVSCode } from \'./foo/bar.ts\';',
+					bufferRange: { start: { x: 1, y: 1 }, end: { x: 8, y: 1 } },
+					type: TerminalBuiltinLinkType.Search
+				});
+				deepStrictEqual(activationResult, {
+					link: 'file:///folder/foo/bar.txt',
+					source: 'editor',
+					selection: {
+						startColumn: 1,
+						startLineNumber: 10,
+						endColumn: undefined,
+						endLineNumber: undefined
+					},
+				});
+			});
+
+			// Test for https://github.com/microsoft/vscode/pull/200919#discussion_r1428124196
+			test('should extract column and/or line numbers from links and remove grepped lines incl singular spaces', async () => {
+				localFileOpener = instantiationService.createInstance(TerminalLocalFileLinkOpener);
+				const localFolderOpener = instantiationService.createInstance(TerminalLocalFolderInWorkspaceLinkOpener);
+				opener = instantiationService.createInstance(TestTerminalSearchLinkOpener, capabilities, '/folder', localFileOpener, localFolderOpener, () => OperatingSystem.Linux);
+				fileService.setFiles([
+					URI.from({ scheme: Schemas.file, path: '/folder/foo/bar.txt' })
+				]);
+				await opener.open({
+					text: './foo/bar.txt:10:5: ',
+					bufferRange: { start: { x: 1, y: 1 }, end: { x: 8, y: 1 } },
+					type: TerminalBuiltinLinkType.Search
+				});
+				deepStrictEqual(activationResult, {
+					link: 'file:///folder/foo/bar.txt',
+					source: 'editor',
+					selection: {
+						startColumn: 5,
+						startLineNumber: 10,
+						endColumn: undefined,
+						endLineNumber: undefined
+					},
+				});
+				await opener.open({
+					text: './foo/bar.txt:10: ',
+					bufferRange: { start: { x: 1, y: 1 }, end: { x: 8, y: 1 } },
+					type: TerminalBuiltinLinkType.Search
+				});
+				deepStrictEqual(activationResult, {
+					link: 'file:///folder/foo/bar.txt',
+					source: 'editor',
+					selection: {
+						startColumn: 1,
+						startLineNumber: 10,
+						endColumn: undefined,
+						endLineNumber: undefined
+					},
+				});
+			});
+
+			test('should extract line numbers from links and remove ruby stack traces', async () => {
+				localFileOpener = instantiationService.createInstance(TerminalLocalFileLinkOpener);
+				const localFolderOpener = instantiationService.createInstance(TerminalLocalFolderInWorkspaceLinkOpener);
+				opener = instantiationService.createInstance(TestTerminalSearchLinkOpener, capabilities, '/folder', localFileOpener, localFolderOpener, () => OperatingSystem.Linux);
+				fileService.setFiles([
+					URI.from({ scheme: Schemas.file, path: '/folder/foo/bar.rb' })
+				]);
+				await opener.open({
+					text: './foo/bar.rb:30:in `<main>`',
+					bufferRange: { start: { x: 1, y: 1 }, end: { x: 8, y: 1 } },
+					type: TerminalBuiltinLinkType.Search
+				});
+				deepStrictEqual(activationResult, {
+					link: 'file:///folder/foo/bar.rb',
+					source: 'editor',
+					selection: {
+						startColumn: 1,
+						startLineNumber: 30,
+						endColumn: undefined,
+						endLineNumber: undefined
+					},
+				});
+			});
 
 		});
 
@@ -435,7 +567,7 @@ suite('Workbench - TerminalLinkOpeners', () => {
 				});
 			});
 
-			test('should extract line and column from links in a workspace containing spaces', async () => {
+			test('should extract column and/or line numbers from links in a workspace containing spaces', async () => {
 				localFileOpener = instantiationService.createInstance(TerminalLocalFileLinkOpener);
 				const localFolderOpener = instantiationService.createInstance(TerminalLocalFolderInWorkspaceLinkOpener);
 				opener = instantiationService.createInstance(TestTerminalSearchLinkOpener, capabilities, 'c:/space folder', localFileOpener, localFolderOpener, () => OperatingSystem.Windows);
@@ -458,6 +590,21 @@ suite('Workbench - TerminalLinkOpeners', () => {
 					},
 				});
 				await opener.open({
+					text: './foo/bar.txt:10',
+					bufferRange: { start: { x: 1, y: 1 }, end: { x: 8, y: 1 } },
+					type: TerminalBuiltinLinkType.Search
+				});
+				deepStrictEqual(activationResult, {
+					link: 'file:///c%3A/space%20folder/foo/bar.txt',
+					source: 'editor',
+					selection: {
+						startColumn: 1,
+						startLineNumber: 10,
+						endColumn: undefined,
+						endLineNumber: undefined
+					},
+				});
+				await opener.open({
 					text: '.\\foo\\bar.txt:10:5',
 					bufferRange: { start: { x: 1, y: 1 }, end: { x: 8, y: 1 } },
 					type: TerminalBuiltinLinkType.Search
@@ -472,9 +619,24 @@ suite('Workbench - TerminalLinkOpeners', () => {
 						endLineNumber: undefined
 					},
 				});
+				await opener.open({
+					text: '.\\foo\\bar.txt:10',
+					bufferRange: { start: { x: 1, y: 1 }, end: { x: 8, y: 1 } },
+					type: TerminalBuiltinLinkType.Search
+				});
+				deepStrictEqual(activationResult, {
+					link: 'file:///c%3A/space%20folder/foo/bar.txt',
+					source: 'editor',
+					selection: {
+						startColumn: 1,
+						startLineNumber: 10,
+						endColumn: undefined,
+						endLineNumber: undefined
+					},
+				});
 			});
 
-			test('should extract line and column from links and remove trailing periods', async () => {
+			test('should extract column and/or line numbers from links and remove trailing periods', async () => {
 				localFileOpener = instantiationService.createInstance(TerminalLocalFileLinkOpener);
 				const localFolderOpener = instantiationService.createInstance(TerminalLocalFolderInWorkspaceLinkOpener);
 				opener = instantiationService.createInstance(TestTerminalSearchLinkOpener, capabilities, 'c:/folder', localFileOpener, localFolderOpener, () => OperatingSystem.Windows);
@@ -497,7 +659,61 @@ suite('Workbench - TerminalLinkOpeners', () => {
 					},
 				});
 				await opener.open({
-					text: '.\\foo\\bar.txt:10:5',
+					text: './foo/bar.txt:10.',
+					bufferRange: { start: { x: 1, y: 1 }, end: { x: 8, y: 1 } },
+					type: TerminalBuiltinLinkType.Search
+				});
+				deepStrictEqual(activationResult, {
+					link: 'file:///c%3A/folder/foo/bar.txt',
+					source: 'editor',
+					selection: {
+						startColumn: 1,
+						startLineNumber: 10,
+						endColumn: undefined,
+						endLineNumber: undefined
+					},
+				});
+				await opener.open({
+					text: '.\\foo\\bar.txt:2:5.',
+					bufferRange: { start: { x: 1, y: 1 }, end: { x: 8, y: 1 } },
+					type: TerminalBuiltinLinkType.Search
+				});
+				deepStrictEqual(activationResult, {
+					link: 'file:///c%3A/folder/foo/bar.txt',
+					source: 'editor',
+					selection: {
+						startColumn: 5,
+						startLineNumber: 2,
+						endColumn: undefined,
+						endLineNumber: undefined
+					},
+				});
+				await opener.open({
+					text: '.\\foo\\bar.txt:2.',
+					bufferRange: { start: { x: 1, y: 1 }, end: { x: 8, y: 1 } },
+					type: TerminalBuiltinLinkType.Search
+				});
+				deepStrictEqual(activationResult, {
+					link: 'file:///c%3A/folder/foo/bar.txt',
+					source: 'editor',
+					selection: {
+						startColumn: 1,
+						startLineNumber: 2,
+						endColumn: undefined,
+						endLineNumber: undefined
+					},
+				});
+			});
+
+			test('should extract column and/or line numbers from links and remove grepped lines', async () => {
+				localFileOpener = instantiationService.createInstance(TerminalLocalFileLinkOpener);
+				const localFolderOpener = instantiationService.createInstance(TerminalLocalFolderInWorkspaceLinkOpener);
+				opener = instantiationService.createInstance(TestTerminalSearchLinkOpener, capabilities, 'c:/folder', localFileOpener, localFolderOpener, () => OperatingSystem.Windows);
+				fileService.setFiles([
+					URI.from({ scheme: Schemas.file, path: 'c:/folder/foo/bar.txt' })
+				]);
+				await opener.open({
+					text: './foo/bar.txt:10:5:import { ILoveVSCode } from \'./foo/bar.ts\';',
 					bufferRange: { start: { x: 1, y: 1 }, end: { x: 8, y: 1 } },
 					type: TerminalBuiltinLinkType.Search
 				});
@@ -507,6 +723,160 @@ suite('Workbench - TerminalLinkOpeners', () => {
 					selection: {
 						startColumn: 5,
 						startLineNumber: 10,
+						endColumn: undefined,
+						endLineNumber: undefined
+					},
+				});
+				await opener.open({
+					text: './foo/bar.txt:10:import { ILoveVSCode } from \'./foo/bar.ts\';',
+					bufferRange: { start: { x: 1, y: 1 }, end: { x: 8, y: 1 } },
+					type: TerminalBuiltinLinkType.Search
+				});
+				deepStrictEqual(activationResult, {
+					link: 'file:///c%3A/folder/foo/bar.txt',
+					source: 'editor',
+					selection: {
+						startColumn: 1,
+						startLineNumber: 10,
+						endColumn: undefined,
+						endLineNumber: undefined
+					},
+				});
+				await opener.open({
+					text: '.\\foo\\bar.txt:10:5:import { ILoveVSCode } from \'./foo/bar.ts\';',
+					bufferRange: { start: { x: 1, y: 1 }, end: { x: 8, y: 1 } },
+					type: TerminalBuiltinLinkType.Search
+				});
+				deepStrictEqual(activationResult, {
+					link: 'file:///c%3A/folder/foo/bar.txt',
+					source: 'editor',
+					selection: {
+						startColumn: 5,
+						startLineNumber: 10,
+						endColumn: undefined,
+						endLineNumber: undefined
+					},
+				});
+				await opener.open({
+					text: '.\\foo\\bar.txt:10:import { ILoveVSCode } from \'./foo/bar.ts\';',
+					bufferRange: { start: { x: 1, y: 1 }, end: { x: 8, y: 1 } },
+					type: TerminalBuiltinLinkType.Search
+				});
+				deepStrictEqual(activationResult, {
+					link: 'file:///c%3A/folder/foo/bar.txt',
+					source: 'editor',
+					selection: {
+						startColumn: 1,
+						startLineNumber: 10,
+						endColumn: undefined,
+						endLineNumber: undefined
+					},
+				});
+			});
+
+			// Test for https://github.com/microsoft/vscode/pull/200919#discussion_r1428124196
+			test('should extract column and/or line numbers from links and remove grepped lines incl singular spaces', async () => {
+				localFileOpener = instantiationService.createInstance(TerminalLocalFileLinkOpener);
+				const localFolderOpener = instantiationService.createInstance(TerminalLocalFolderInWorkspaceLinkOpener);
+				opener = instantiationService.createInstance(TestTerminalSearchLinkOpener, capabilities, 'c:/folder', localFileOpener, localFolderOpener, () => OperatingSystem.Windows);
+				fileService.setFiles([
+					URI.from({ scheme: Schemas.file, path: 'c:/folder/foo/bar.txt' })
+				]);
+				await opener.open({
+					text: './foo/bar.txt:10:5: ',
+					bufferRange: { start: { x: 1, y: 1 }, end: { x: 8, y: 1 } },
+					type: TerminalBuiltinLinkType.Search
+				});
+				deepStrictEqual(activationResult, {
+					link: 'file:///c%3A/folder/foo/bar.txt',
+					source: 'editor',
+					selection: {
+						startColumn: 5,
+						startLineNumber: 10,
+						endColumn: undefined,
+						endLineNumber: undefined
+					},
+				});
+				await opener.open({
+					text: './foo/bar.txt:10: ',
+					bufferRange: { start: { x: 1, y: 1 }, end: { x: 8, y: 1 } },
+					type: TerminalBuiltinLinkType.Search
+				});
+				deepStrictEqual(activationResult, {
+					link: 'file:///c%3A/folder/foo/bar.txt',
+					source: 'editor',
+					selection: {
+						startColumn: 1,
+						startLineNumber: 10,
+						endColumn: undefined,
+						endLineNumber: undefined
+					},
+				});
+				await opener.open({
+					text: '.\\foo\\bar.txt:10:5: ',
+					bufferRange: { start: { x: 1, y: 1 }, end: { x: 8, y: 1 } },
+					type: TerminalBuiltinLinkType.Search
+				});
+				deepStrictEqual(activationResult, {
+					link: 'file:///c%3A/folder/foo/bar.txt',
+					source: 'editor',
+					selection: {
+						startColumn: 5,
+						startLineNumber: 10,
+						endColumn: undefined,
+						endLineNumber: undefined
+					},
+				});
+				await opener.open({
+					text: '.\\foo\\bar.txt:10: ',
+					bufferRange: { start: { x: 1, y: 1 }, end: { x: 8, y: 1 } },
+					type: TerminalBuiltinLinkType.Search
+				});
+				deepStrictEqual(activationResult, {
+					link: 'file:///c%3A/folder/foo/bar.txt',
+					source: 'editor',
+					selection: {
+						startColumn: 1,
+						startLineNumber: 10,
+						endColumn: undefined,
+						endLineNumber: undefined
+					},
+				});
+			});
+
+			test('should extract line numbers from links and remove ruby stack traces', async () => {
+				localFileOpener = instantiationService.createInstance(TerminalLocalFileLinkOpener);
+				const localFolderOpener = instantiationService.createInstance(TerminalLocalFolderInWorkspaceLinkOpener);
+				opener = instantiationService.createInstance(TestTerminalSearchLinkOpener, capabilities, 'c:/folder', localFileOpener, localFolderOpener, () => OperatingSystem.Windows);
+				fileService.setFiles([
+					URI.from({ scheme: Schemas.file, path: 'c:/folder/foo/bar.rb' })
+				]);
+				await opener.open({
+					text: './foo/bar.rb:30:in `<main>`',
+					bufferRange: { start: { x: 1, y: 1 }, end: { x: 8, y: 1 } },
+					type: TerminalBuiltinLinkType.Search
+				});
+				deepStrictEqual(activationResult, {
+					link: 'file:///c%3A/folder/foo/bar.rb',
+					source: 'editor',
+					selection: {
+						startColumn: 1, // Since Ruby doesn't appear to put columns in stack traces, this should be 1
+						startLineNumber: 30,
+						endColumn: undefined,
+						endLineNumber: undefined
+					},
+				});
+				await opener.open({
+					text: '.\\foo\\bar.rb:30:in `<main>`',
+					bufferRange: { start: { x: 1, y: 1 }, end: { x: 8, y: 1 } },
+					type: TerminalBuiltinLinkType.Search
+				});
+				deepStrictEqual(activationResult, {
+					link: 'file:///c%3A/folder/foo/bar.rb',
+					source: 'editor',
+					selection: {
+						startColumn: 1, // Since Ruby doesn't appear to put columns in stack traces, this should be 1
+						startLineNumber: 30,
 						endColumn: undefined,
 						endLineNumber: undefined
 					},

--- a/src/vs/workbench/contrib/terminalContrib/links/test/browser/terminalLinkOpeners.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/links/test/browser/terminalLinkOpeners.test.ts
@@ -366,6 +366,15 @@ suite('Workbench - TerminalLinkOpeners', () => {
 					URI.from({ scheme: Schemas.file, path: '/folder/foo/bar.txt' })
 				]);
 				await opener.open({
+					text: './foo/bar.txt.',
+					bufferRange: { start: { x: 1, y: 1 }, end: { x: 8, y: 1 } },
+					type: TerminalBuiltinLinkType.Search
+				});
+				deepStrictEqual(activationResult, {
+					link: 'file:///folder/foo/bar.txt',
+					source: 'editor',
+				});
+				await opener.open({
 					text: './foo/bar.txt:10:5.',
 					bufferRange: { start: { x: 1, y: 1 }, end: { x: 8, y: 1 } },
 					type: TerminalBuiltinLinkType.Search
@@ -644,6 +653,15 @@ suite('Workbench - TerminalLinkOpeners', () => {
 					URI.from({ scheme: Schemas.file, path: 'c:/folder/foo/bar.txt' })
 				]);
 				await opener.open({
+					text: './foo/bar.txt.',
+					bufferRange: { start: { x: 1, y: 1 }, end: { x: 8, y: 1 } },
+					type: TerminalBuiltinLinkType.Search
+				});
+				deepStrictEqual(activationResult, {
+					link: 'file:///c%3A/folder/foo/bar.txt',
+					source: 'editor',
+				});
+				await opener.open({
 					text: './foo/bar.txt:10:5.',
 					bufferRange: { start: { x: 1, y: 1 }, end: { x: 8, y: 1 } },
 					type: TerminalBuiltinLinkType.Search
@@ -672,6 +690,15 @@ suite('Workbench - TerminalLinkOpeners', () => {
 						endColumn: undefined,
 						endLineNumber: undefined
 					},
+				});
+				await opener.open({
+					text: '.\\foo\\bar.txt.',
+					bufferRange: { start: { x: 1, y: 1 }, end: { x: 8, y: 1 } },
+					type: TerminalBuiltinLinkType.Search
+				});
+				deepStrictEqual(activationResult, {
+					link: 'file:///c%3A/folder/foo/bar.txt',
+					source: 'editor',
 				});
 				await opener.open({
 					text: '.\\foo\\bar.txt:2:5.',


### PR DESCRIPTION
This is a draft PR for a fix for issue #200257 

Whilst figuring how to fix the issue I created, it appeared that the regex at [terminalLinkOpeners.ts:111](https://github.com/microsoft/vscode/blob/37fe2d06d65db4b50303c5f5e8ca589a50f2287a/src/vs/workbench/contrib/terminalContrib/links/browser/terminalLinkOpeners.ts#L111) was incorrect. Here are the old and new regex side by side, with what I expect the original coder intended. I also tested grep output with filenames/line numbers, and that seems to be correct also.

![orig-ruby-regex](https://github.com/microsoft/vscode/assets/25756001/5eab5773-c81a-4392-824e-3f8b736230e9)
![fixed-ruby-regex](https://github.com/microsoft/vscode/assets/25756001/03116c4e-a864-4f8e-b5b2-7f93b631eb39)
![grep-regex-ok](https://github.com/microsoft/vscode/assets/25756001/070a723a-2488-48fd-b649-c71e2294425a)

The trailing period issue has also been fixed with a new text.replace step with (hopefully) a correct regex, that currently only removes trailing periods from line/column numbers (for instance, "test.ts." should be left alone).

The big question possibly is, is there any reason why a trailing period on a link should remain? If not, I guess you could just remove any trailing period regardless of it's preceding text.
 