### PR TITLE
Quick search: Not possible to search for space in front

### DIFF
--- a/src/vs/platform/quickinput/browser/pickerQuickAccess.ts
+++ b/src/vs/platform/quickinput/browser/pickerQuickAccess.ts
@@ -70,6 +70,9 @@ export interface IPickerQuickAccessProviderOptions<T extends IPickerQuickAccessI
 	 * Enables to show a pick entry when no results are returned from a search.
 	 */
 	readonly noResultsPick?: T | ((filter: string) => T);
+
+	/** Whether to skip trimming the pick filter string */
+	readonly shouldSkipTrimPickFilter?: boolean;
 }
 
 export type Pick<T> = T | IQuickPickSeparator;
@@ -138,7 +141,12 @@ export abstract class PickerQuickAccessProvider<T extends IPickerQuickAccessItem
 
 			// Collect picks and support both long running and short or combined
 			const picksToken = picksCts.token;
-			const picksFilter = picker.value.substr(this.prefix.length).trim();
+			let picksFilter = picker.value.substring(this.prefix.length);
+
+			if (!this.options?.shouldSkipTrimPickFilter) {
+				picksFilter = picksFilter.trim();
+			}
+
 			const providedPicks = this._getPicks(picksFilter, picksDisposables, picksToken, runOptions);
 
 			const applyPicks = (picks: Picks<T>, skipEmpty?: boolean): boolean => {

--- a/src/vs/workbench/contrib/search/browser/quickTextSearch/textSearchQuickAccess.ts
+++ b/src/vs/workbench/contrib/search/browser/quickTextSearch/textSearchQuickAccess.ts
@@ -70,7 +70,7 @@ export class TextSearchQuickAccess extends PickerQuickAccessProvider<IPickerQuic
 		@IViewsService private readonly _viewsService: IViewsService,
 		@IConfigurationService private readonly _configurationService: IConfigurationService,
 	) {
-		super(TEXT_SEARCH_QUICK_ACCESS_PREFIX, { canAcceptInBackground: true });
+		super(TEXT_SEARCH_QUICK_ACCESS_PREFIX, { canAcceptInBackground: true, shouldSkipTrimPickFilter: true });
 
 		this.queryBuilder = this._instantiationService.createInstance(QueryBuilder);
 		this.searchModel = this._instantiationService.createInstance(SearchModel);


### PR DESCRIPTION
Fixes #192765

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
Adds a flag to the `options` in `PickerQuickAccessProvider`, which toggles whether to skip trimming the filter string.