### PR TITLE
fix: part of freeze with `debug.inlineValues: on` in large files

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/debugEditorContribution.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugEditorContribution.ts
@@ -125,7 +125,7 @@ function replaceWsWithNoBreakWs(str: string): string {
 	return str.replace(/[ \t]/g, strings.noBreakWhitespace);
 }
 
-function createInlineValueDecorationsInsideRange(expressions: ReadonlyArray<IExpression>, range: Range, model: ITextModel, wordToLineNumbersMap: Map<string, number[]>): IModelDeltaDecoration[] {
+function createInlineValueDecorationsInsideRange(expressions: ReadonlyArray<IExpression>, ranges: Range[], model: ITextModel, wordToLineNumbersMap: Map<string, number[]>): IModelDeltaDecoration[] {
 	const nameValueMap = new Map<string, string>();
 	for (const expr of expressions) {
 		nameValueMap.set(expr.name, expr.value);
@@ -142,7 +142,7 @@ function createInlineValueDecorationsInsideRange(expressions: ReadonlyArray<IExp
 		const lineNumbers = wordToLineNumbersMap.get(name);
 		if (lineNumbers) {
 			for (const lineNumber of lineNumbers) {
-				if (range.containsPosition(new Position(lineNumber, 0))) {
+				if (ranges.some(r => lineNumber >= r.startLineNumber && lineNumber <= r.endLineNumber)) {
 					if (!lineToNamesMap.has(lineNumber)) {
 						lineToNamesMap.set(lineNumber, []);
 					}
@@ -168,49 +168,39 @@ function createInlineValueDecorationsInsideRange(expressions: ReadonlyArray<IExp
 	return decorations;
 }
 
-function getWordToLineNumbersMap(model: ITextModel | null): Map<string, number[]> {
-	const result = new Map<string, number[]>();
-	if (!model) {
-		return result;
+function getWordToLineNumbersMap(model: ITextModel, lineNumber: number, result: Map<string, number[]>) {
+	const lineLength = model.getLineLength(lineNumber);
+	// If line is too long then skip the line
+	if (lineLength > MAX_TOKENIZATION_LINE_LEN) {
+		return;
 	}
 
-	// For every word in every line, map its ranges for fast lookup
-	for (let lineNumber = 1, len = model.getLineCount(); lineNumber <= len; ++lineNumber) {
-		const lineLength = model.getLineLength(lineNumber);
-		// If line is too long then skip the line
-		if (lineLength > MAX_TOKENIZATION_LINE_LEN) {
-			continue;
-		}
+	const lineContent = model.getLineContent(lineNumber);
+	model.tokenization.forceTokenization(lineNumber);
+	const lineTokens = model.tokenization.getLineTokens(lineNumber);
+	for (let tokenIndex = 0, tokenCount = lineTokens.getCount(); tokenIndex < tokenCount; tokenIndex++) {
+		const tokenType = lineTokens.getStandardTokenType(tokenIndex);
 
-		const lineContent = model.getLineContent(lineNumber);
-		model.tokenization.forceTokenization(lineNumber);
-		const lineTokens = model.tokenization.getLineTokens(lineNumber);
-		for (let tokenIndex = 0, tokenCount = lineTokens.getCount(); tokenIndex < tokenCount; tokenIndex++) {
-			const tokenType = lineTokens.getStandardTokenType(tokenIndex);
+		// Token is a word and not a comment
+		if (tokenType === StandardTokenType.Other) {
+			DEFAULT_WORD_REGEXP.lastIndex = 0; // We assume tokens will usually map 1:1 to words if they match
 
-			// Token is a word and not a comment
-			if (tokenType === StandardTokenType.Other) {
-				DEFAULT_WORD_REGEXP.lastIndex = 0; // We assume tokens will usually map 1:1 to words if they match
+			const tokenStartOffset = lineTokens.getStartOffset(tokenIndex);
+			const tokenEndOffset = lineTokens.getEndOffset(tokenIndex);
+			const tokenStr = lineContent.substring(tokenStartOffset, tokenEndOffset);
+			const wordMatch = DEFAULT_WORD_REGEXP.exec(tokenStr);
 
-				const tokenStartOffset = lineTokens.getStartOffset(tokenIndex);
-				const tokenEndOffset = lineTokens.getEndOffset(tokenIndex);
-				const tokenStr = lineContent.substring(tokenStartOffset, tokenEndOffset);
-				const wordMatch = DEFAULT_WORD_REGEXP.exec(tokenStr);
+			if (wordMatch) {
 
-				if (wordMatch) {
-
-					const word = wordMatch[0];
-					if (!result.has(word)) {
-						result.set(word, []);
-					}
-
-					result.get(word)!.push(lineNumber);
+				const word = wordMatch[0];
+				if (!result.has(word)) {
+					result.set(word, []);
 				}
+
+				result.get(word)!.push(lineNumber);
 			}
 		}
 	}
-
-	return result;
 }
 
 export class DebugEditorContribution implements IDebugEditorContribution {
@@ -310,13 +300,7 @@ export class DebugEditorContribution implements IDebugEditorContribution {
 		this.updateHoverConfiguration();
 	}
 
-	private _wordToLineNumbersMap: Map<string, number[]> | undefined = undefined;
-	private get wordToLineNumbersMap(): Map<string, number[]> {
-		if (!this._wordToLineNumbersMap) {
-			this._wordToLineNumbersMap = getWordToLineNumbersMap(this.editor.getModel());
-		}
-		return this._wordToLineNumbersMap;
-	}
+	private _wordToLineNumbersMap: WordsToLineNumbersCache | undefined;
 
 	private updateHoverConfiguration(): void {
 		const model = this.editor.getModel();
@@ -465,6 +449,7 @@ export class DebugEditorContribution implements IDebugEditorContribution {
 			this.hoverWidget.hide();
 		}
 		this.showHoverScheduler.cancel();
+		this.defaultHoverLockout.clear();
 	}
 
 	// hover business
@@ -686,6 +671,7 @@ export class DebugEditorContribution implements IDebugEditorContribution {
 
 		this.removeInlineValuesScheduler.cancel();
 
+		const viewRanges = this.editor.getVisibleRangesPlusViewportAboveBelow();
 		let allDecorations: IModelDeltaDecoration[];
 
 		if (this.languageFeaturesService.inlineValuesProvider.has(model)) {
@@ -709,13 +695,12 @@ export class DebugEditorContribution implements IDebugEditorContribution {
 			};
 			const token = new CancellationTokenSource().token;
 
-			const ranges = this.editor.getVisibleRangesPlusViewportAboveBelow();
 			const providers = this.languageFeaturesService.inlineValuesProvider.ordered(model).reverse();
 
 			allDecorations = [];
 			const lineDecorations = new Map<number, InlineSegment[]>();
 
-			const promises = flatten(providers.map(provider => ranges.map(range => Promise.resolve(provider.provideInlineValues(model, range, ctx, token)).then(async (result) => {
+			const promises = flatten(providers.map(provider => viewRanges.map(range => Promise.resolve(provider.provideInlineValues(model, range, ctx, token)).then(async (result) => {
 				if (result) {
 					for (const iv of result) {
 
@@ -795,12 +780,18 @@ export class DebugEditorContribution implements IDebugEditorContribution {
 			const decorationsPerScope = await Promise.all(scopes.map(async scope => {
 				const variables = await scope.getChildren();
 
-				let range = new Range(0, 0, stackFrame.range.startLineNumber, stackFrame.range.startColumn);
+				let scopeRange = new Range(0, 0, stackFrame.range.startLineNumber, stackFrame.range.startColumn);
 				if (scope.range) {
-					range = range.setStartPosition(scope.range.startLineNumber, scope.range.startColumn);
+					scopeRange = scopeRange.setStartPosition(scope.range.startLineNumber, scope.range.startColumn);
 				}
 
-				return createInlineValueDecorationsInsideRange(variables, range, model, this.wordToLineNumbersMap);
+				const ownRanges = viewRanges.map(r => r.intersectRanges(scopeRange)).filter(isDefined);
+				this._wordToLineNumbersMap ??= new WordsToLineNumbersCache(model);
+				for (const range of ownRanges) {
+					this._wordToLineNumbersMap.ensureRangePopulated(range);
+				}
+
+				return createInlineValueDecorationsInsideRange(variables, ownRanges, model, this._wordToLineNumbersMap.value);
 			}));
 
 			allDecorations = distinct(decorationsPerScope.reduce((previous, current) => previous.concat(current), []),
@@ -821,6 +812,28 @@ export class DebugEditorContribution implements IDebugEditorContribution {
 		this.toDispose = dispose(this.toDispose);
 
 		this.oldDecorations.clear();
+	}
+}
+
+class WordsToLineNumbersCache {
+	// we use this as an array of bits where each 1 bit is a line number that's been parsed
+	private readonly intervals: Uint8Array;
+	public readonly value = new Map<string, number[]>();
+
+	constructor(private readonly model: ITextModel) {
+		this.intervals = new Uint8Array(Math.ceil(model.getLineCount() / 8));
+	}
+
+	/** Ensures that variables names in the given range have been identified. */
+	public ensureRangePopulated(range: Range) {
+		for (let lineNumber = range.startLineNumber; lineNumber <= range.endLineNumber; lineNumber++) {
+			const bin = lineNumber >> 3;  /* Math.floor(i / 8) */
+			const bit = 1 << (lineNumber & 0b111); /* 1 << (i % 8) */
+			if (!(this.intervals[bin] & bit)) {
+				getWordToLineNumbersMap(this.model, lineNumber, this.value);
+				this.intervals[bin] |= bit;
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes #187783

We now limit inline value display to the area around the viewport, which is what we do with an extension-provided InlineValueProvider anyway. This saves having to force tokenization for the entire file, and instead only in the interested range.

It can still stall if the tokenizer is slow, but there's not a
workaround for that aside from the extension providing their own inline
value provider.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
