### PR TITLE
Support Centered Layout with Maximized Group

### DIFF
--- a/src/vs/workbench/browser/layout.ts
+++ b/src/vs/workbench/browser/layout.ts
@@ -363,6 +363,7 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 		// Group changes
 		this._register(this.editorGroupService.mainPart.onDidAddGroup(() => this.centerMainEditorLayout(this.stateModel.getRuntimeValue(LayoutStateKeys.EDITOR_CENTERED))));
 		this._register(this.editorGroupService.mainPart.onDidRemoveGroup(() => this.centerMainEditorLayout(this.stateModel.getRuntimeValue(LayoutStateKeys.EDITOR_CENTERED))));
+		this._register(this.editorGroupService.mainPart.onDidChangeGroupMaximized(() => this.centerMainEditorLayout(this.stateModel.getRuntimeValue(LayoutStateKeys.EDITOR_CENTERED))));
 
 		// Prevent workbench from scrolling #55456
 		this._register(addDisposableListener(this.mainContainer, EventType.SCROLL, () => this.mainContainer.scrollTop = 0));
@@ -1600,7 +1601,7 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 		const isCenteredLayoutAutoResizing = this.configurationService.getValue('workbench.editor.centeredLayoutAutoResize');
 		if (
 			isCenteredLayoutAutoResizing &&
-			(this.editorGroupService.mainPart.groups.length > 1 || isEditorComplex)
+			((this.editorGroupService.mainPart.groups.length > 1 && !this.editorGroupService.mainPart.hasMaximizedGroup()) || isEditorComplex)
 		) {
 			active = false; // disable centered layout for complex editors or when there is more than one group
 		}

--- a/src/vs/workbench/browser/parts/editor/editorPart.ts
+++ b/src/vs/workbench/browser/parts/editor/editorPart.ts
@@ -424,7 +424,7 @@ export class EditorPart extends Part implements IEditorPart, IEditorGroupsView {
 		this._activeGroup.focus(); // When making views visible the focus can be affected, so restore it
 	}
 
-	private hasMaximizedGroup(): boolean {
+	hasMaximizedGroup(): boolean {
 		return this.gridWidget.hasMaximizedView();
 	}
 
@@ -1129,10 +1129,6 @@ export class EditorPart extends Part implements IEditorPart, IEditorGroupsView {
 	}
 
 	centerLayout(active: boolean): void {
-		if (this.hasMaximizedGroup()) {
-			this.unmaximizeGroup();
-		}
-
 		this.centeredLayoutWidget.activate(active);
 
 		this._activeGroup.focus();

--- a/src/vs/workbench/services/editor/common/editorGroupsService.ts
+++ b/src/vs/workbench/services/editor/common/editorGroupsService.ts
@@ -449,6 +449,11 @@ export interface IEditorPart extends IEditorGroupsContainer {
 	readonly hasRestorableState: boolean;
 
 	/**
+	 * Find out if an editor group is currently maximized.
+	 */
+	hasMaximizedGroup(): boolean;
+
+	/**
 	 * Enable or disable centered editor layout.
 	 */
 	centerLayout(active: boolean): void;

--- a/src/vs/workbench/services/editor/test/browser/editorGroupsService.test.ts
+++ b/src/vs/workbench/services/editor/test/browser/editorGroupsService.test.ts
@@ -1776,6 +1776,9 @@ suite('EditorGroupsService', () => {
 		const rootGroup = part.activeGroup;
 		const editorPartSize = part.getSize(rootGroup);
 
+		// If there is only one group, it should not be considered maximized
+		assert.strictEqual(part.hasMaximizedGroup(), false);
+
 		const rightGroup = part.addGroup(rootGroup, GroupDirection.RIGHT);
 		const rightBottomGroup = part.addGroup(rightGroup, GroupDirection.DOWN);
 
@@ -1788,7 +1791,11 @@ suite('EditorGroupsService', () => {
 			maximizedValue = maximized;
 		});
 
+		assert.strictEqual(part.hasMaximizedGroup(), false);
+
 		part.arrangeGroups(GroupsArrangement.MAXIMIZE, rootGroup);
+
+		assert.strictEqual(part.hasMaximizedGroup(), true);
 
 		// getSize()
 		assert.deepStrictEqual(part.getSize(rootGroup), editorPartSize);
@@ -1798,6 +1805,8 @@ suite('EditorGroupsService', () => {
 		assert.deepStrictEqual(maximizedValue, true);
 
 		part.toggleMaximizeGroup();
+
+		assert.strictEqual(part.hasMaximizedGroup(), false);
 
 		// Size is restored
 		assert.deepStrictEqual(part.getSize(rootGroup), sizeRootGroup);

--- a/src/vs/workbench/test/browser/workbenchTestServices.ts
+++ b/src/vs/workbench/test/browser/workbenchTestServices.ts
@@ -865,6 +865,7 @@ export class TestEditorGroupsService implements IEditorGroupsService {
 	setSize(_group: number | IEditorGroup, _size: { width: number; height: number }): void { }
 	arrangeGroups(_arrangement: GroupsArrangement): void { }
 	toggleMaximizeGroup(): void { }
+	hasMaximizedGroup(): boolean { throw new Error('not implemented'); }
 	toggleExpandGroup(): void { }
 	applyLayout(_layout: EditorGroupLayout): void { }
 	getLayout(): EditorGroupLayout { throw new Error('not implemented'); }


### PR DESCRIPTION
This PR introduces support for a centered layout even when an editor group is maximized. #197551