### PR TITLE
Allow quick fixes to be shown in aux window

### DIFF
--- a/src/vs/platform/actionWidget/browser/actionList.ts
+++ b/src/vs/platform/actionWidget/browser/actionList.ts
@@ -314,7 +314,6 @@ export class ActionList<T> extends Disposable {
 	}
 
 	private onFocus() {
-		this._list.getFocus();
 		const focused = this._list.getFocus();
 		if (focused.length === 0) {
 			return;

--- a/src/vs/platform/actionWidget/browser/actionList.ts
+++ b/src/vs/platform/actionWidget/browser/actionList.ts
@@ -314,7 +314,7 @@ export class ActionList<T> extends Disposable {
 	}
 
 	private onFocus() {
-		this._list.domFocus();
+		this._list.getFocus();
 		const focused = this._list.getFocus();
 		if (focused.length === 0) {
 			return;


### PR DESCRIPTION
fixes: https://github.com/microsoft/vscode/issues/200922

changed from domFocus to getFocus. domFocus was being incorrectly called early, which gets the main window because it had not been attached yet. 

initially tried attaching earlier by using `container.ownerDocument` to create the div, but it threw at https://github.com/microsoft/vscode/blob/9621add46007f7a1ab37d1fce9bcdcecca62aeb0/src/vs/workbench/services/auxiliaryWindow/browser/auxiliaryWindowService.ts#L281C12-L281C12

![Recording 2023-12-19 at 21 21 59](https://github.com/microsoft/vscode/assets/54879025/f39794b1-1ab1-4e60-af02-11c615d9a0f3)



cc. @bpasero 