### PR TITLE
inline chat: display detect intent for the duration of the request & allow re-running the request without intent detection

### DIFF
--- a/src/vs/workbench/api/common/extHostInlineChat.ts
+++ b/src/vs/workbench/api/common/extHostInlineChat.ts
@@ -151,6 +151,7 @@ export class ExtHostInteractiveEditor implements ExtHostInlineChatShape {
 			wholeRange: typeConvert.Range.to(request.wholeRange),
 			attempt: request.attempt,
 			live: request.live,
+			withIntentDetection: request.withIntentDetection,
 		};
 
 

--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChat.css
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChat.css
@@ -154,6 +154,26 @@
 	color: var(--vscode-chat-slashCommandForeground);
 }
 
+.monaco-editor .inline-chat .detectedIntent {
+	color: var(--vscode-descriptionForeground);
+	padding: 5px 0px 5px 5px;
+}
+
+.monaco-editor .inline-chat .detectedIntent.hidden {
+	display: none;
+}
+
+.monaco-editor .inline-chat .detectedIntent .slash-command-pill CODE {
+	border-radius: 3px;
+	padding: 0 1px;
+	background-color: var(--vscode-chat-slashCommandBackground);
+	color: var(--vscode-chat-slashCommandForeground);
+}
+
+.monaco-editor .inline-chat .detectedIntent .slash-command-pill a {
+	color: var(--vscode-textLink-foreground);
+	cursor: pointer;
+}
 
 /* .monaco-editor .inline-chat .markdownMessage .message * {
 	margin: unset;

--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatWidget.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatWidget.ts
@@ -172,6 +172,7 @@ export class InlineChatWidget {
 				h('div.widget-toolbar@widgetToolbar')
 			]),
 			h('div.progress@progress'),
+			h('div.detectedIntent.hidden@detectedIntent'),
 			h('div.previewDiff.hidden@previewDiff'),
 			h('div.previewCreateTitle.show-file-icons@previewCreateTitle'),
 			h('div.previewCreate.hidden@previewCreate'),
@@ -220,6 +221,9 @@ export class InlineChatWidget {
 	private readonly _onDidChangeInput = this._store.add(new Emitter<this>());
 	readonly onDidChangeInput: Event<this> = this._onDidChangeInput.event;
 
+	private readonly _onRequestWithoutIntentDetection = this._store.add(new Emitter<void>());
+	readonly onRequestWithoutIntentDetection: Event<void> = this._onRequestWithoutIntentDetection.event;
+
 	private _lastDim: Dimension | undefined;
 	private _isLayouting: boolean = false;
 	private _preferredExpansionState: ExpansionState | undefined;
@@ -231,6 +235,7 @@ export class InlineChatWidget {
 	private readonly _editorOptions: ChatEditorOptions;
 	private _chatMessageDisposables = this._store.add(new DisposableStore());
 	private _followUpDisposables = this._store.add(new DisposableStore());
+	private _slashCommandUsedDisposables = this._store.add(new DisposableStore());
 
 	private _chatMessage: MarkdownString | undefined;
 
@@ -506,12 +511,13 @@ export class InlineChatWidget {
 	getHeight(): number {
 		const base = getTotalHeight(this._elements.progress) + getTotalHeight(this._elements.status);
 		const editorHeight = this._inputEditor.getContentHeight() + 12 /* padding and border */;
+		const detectedIntentHeight = getTotalHeight(this._elements.detectedIntent);
 		const followUpsHeight = getTotalHeight(this._elements.followUps);
 		const chatResponseHeight = getTotalHeight(this._elements.chatMessage);
 		const previewDiffHeight = this._previewDiffEditor.hasValue && this._previewDiffEditor.value.getModel() ? 12 + Math.min(300, Math.max(0, this._previewDiffEditor.value.getContentHeight())) : 0;
 		const previewCreateTitleHeight = getTotalHeight(this._elements.previewCreateTitle);
 		const previewCreateHeight = this._previewCreateEditor.hasValue && this._previewCreateEditor.value.getModel() ? 18 + Math.min(300, Math.max(0, this._previewCreateEditor.value.getContentHeight())) : 0;
-		return base + editorHeight + followUpsHeight + chatResponseHeight + previewDiffHeight + previewCreateTitleHeight + previewCreateHeight + 18 /* padding */ + 8 /*shadow*/;
+		return base + editorHeight + detectedIntentHeight + followUpsHeight + chatResponseHeight + previewDiffHeight + previewCreateTitleHeight + previewCreateHeight + 18 /* padding */ + 8 /*shadow*/;
 	}
 
 	updateProgress(show: boolean) {
@@ -672,11 +678,28 @@ export class InlineChatWidget {
 			return;
 		}
 
-		this._elements.infoLabel.classList.toggle('hidden', false);
-		const label = localize('slashCommandUsed', "Using {0} to generate response...", `\`\`/${details.command}\`\``);
+		this._elements.detectedIntent.classList.toggle('hidden', false);
 
-		const e = renderFormattedText(label, { inline: true, renderCodeSegments: true, className: 'slash-command-pill' });
-		reset(this._elements.infoLabel, e);
+		this._slashCommandUsedDisposables.clear();
+
+		const label = localize('slashCommandUsed', "Using {0} to generate response. [[Re-run without]]", `\`\`/${details.command}\`\``);
+		const usingSlashCommandText = renderFormattedText(label, {
+			inline: true,
+			renderCodeSegments: true,
+			className: 'slash-command-pill',
+			actionHandler: {
+				callback: (content) => {
+					if (content !== '0') {
+						return;
+					}
+					this._elements.detectedIntent.classList.toggle('hidden', true);
+					this._onRequestWithoutIntentDetection.fire();
+				},
+				disposables: this._slashCommandUsedDisposables,
+			}
+		});
+
+		reset(this._elements.detectedIntent, usingSlashCommandText);
 		this._onDidChangeHeight.fire();
 	}
 
@@ -718,6 +741,7 @@ export class InlineChatWidget {
 		this.updateFollowUps(undefined);
 
 		reset(this._elements.statusLabel);
+		this._elements.detectedIntent.classList.toggle('hidden', true);
 		this._elements.statusLabel.classList.toggle('hidden', true);
 		this._elements.extraToolbar.classList.add('hidden');
 		this._elements.statusToolbar.classList.add('hidden');
@@ -864,6 +888,7 @@ export class InlineChatWidget {
 
 		const updateSlashDecorations = () => {
 			this._slashCommandContentWidget.hide();
+			this._elements.detectedIntent.classList.toggle('hidden', true);
 
 			const newDecorations: IModelDeltaDecoration[] = [];
 			for (const command of commands) {

--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatWidget.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatWidget.ts
@@ -682,7 +682,7 @@ export class InlineChatWidget {
 
 		this._slashCommandUsedDisposables.clear();
 
-		const label = localize('slashCommandUsed', "Using {0} to generate response. [[Re-run without]]", `\`\`/${details.command}\`\``);
+		const label = localize('slashCommandUsed', "Using {0} to generate response ([[re-run without]])", `\`\`/${details.command}\`\``);
 		const usingSlashCommandText = renderFormattedText(label, {
 			inline: true,
 			renderCodeSegments: true,

--- a/src/vs/workbench/contrib/inlineChat/common/inlineChat.ts
+++ b/src/vs/workbench/contrib/inlineChat/common/inlineChat.ts
@@ -45,6 +45,7 @@ export interface IInlineChatRequest {
 	attempt: number;
 	requestId: string;
 	live: boolean;
+	withIntentDetection: boolean;
 }
 
 export type IInlineChatResponse = IInlineChatEditResponse | IInlineChatBulkEditResponse;

--- a/src/vs/workbench/contrib/notebook/browser/view/cellParts/chat/cellChatController.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/cellParts/chat/cellChatController.ts
@@ -288,7 +288,8 @@ export class NotebookCellChatController extends Disposable {
 			attempt: 0,
 			selection: { selectionStartLineNumber: 1, selectionStartColumn: 1, positionLineNumber: 1, positionColumn: 1 },
 			wholeRange: { startLineNumber: 1, startColumn: 1, endLineNumber: 1, endColumn: 1 },
-			live: true
+			live: true,
+			withIntentDetection: true, // TODO: don't hard code but allow in corresponding UI to run without intent detection?
 		};
 
 		const requestCts = new CancellationTokenSource();

--- a/src/vscode-dts/vscode.proposed.interactive.d.ts
+++ b/src/vscode-dts/vscode.proposed.interactive.d.ts
@@ -33,6 +33,7 @@ declare module 'vscode' {
 		wholeRange: Range;
 		attempt: number;
 		live: boolean;
+		withIntentDetection: boolean;
 	}
 
 	// todo@API make classes


### PR DESCRIPTION

https://github.com/microsoft/vscode/assets/16353531/66718040-bb0b-4948-b1a6-7ce7f8bee3ba

(please, ignore copilot icon missing in inline chat, that's because I have copilot installed from sources) 


@rebornix , now `cellChatController` hard-codes `withIntentDetection` that's used by an extension whether to run the request with intent detection -- I just have very little knowledge about inline chat implementation in notebooks (ordinary (as in other editors) inline chat in notebooks works correctly). Let me know if I can help with un-hardcoding this somehow