### PR TITLE
Copy width & height from the ResizeObserver callback

### DIFF
--- a/src/vs/editor/browser/config/elementSizeObserver.ts
+++ b/src/vs/editor/browser/config/elementSizeObserver.ts
@@ -47,10 +47,10 @@ export class ElementSizeObserver extends Disposable {
 			// Otherwise we will postpone to the next animation frame.
 			// We'll use `observeContentRect` to store the content rect we received.
 
-			let observeContentRect: DOMRectReadOnly | null = null;
+			let observedDimenstion: IDimension | null = null;
 			const observeNow = () => {
-				if (observeContentRect) {
-					this.observe({ width: observeContentRect.width, height: observeContentRect.height });
+				if (observedDimenstion) {
+					this.observe({ width: observedDimenstion.width, height: observedDimenstion.height });
 				} else {
 					this.observe();
 				}
@@ -75,7 +75,11 @@ export class ElementSizeObserver extends Disposable {
 			};
 
 			this._resizeObserver = new ResizeObserver((entries) => {
-				observeContentRect = (entries && entries[0] && entries[0].contentRect ? entries[0].contentRect : null);
+				if (entries && entries[0] && entries[0].contentRect) {
+					observedDimenstion = { width: entries[0].contentRect.width, height: entries[0].contentRect.height };
+				} else {
+					observedDimenstion = null;
+				}
 				shouldObserve = true;
 				update();
 			});


### PR DESCRIPTION
Avoids "ResizeObserver loop completed with undelivered notifications" error

Fixes microsoft/monaco-editor#4311
Ref https://github.com/microsoft/vscode/issues/183324