### PR TITLE
Fix auto indent when pasting lines that begin with a comment

### DIFF
--- a/src/vs/editor/contrib/indentation/browser/indentation.ts
+++ b/src/vs/editor/contrib/indentation/browser/indentation.ts
@@ -16,7 +16,6 @@ import { ICommand, ICursorStateComputerData, IEditOperationBuilder, IEditorContr
 import { EditorContextKeys } from 'vs/editor/common/editorContextKeys';
 import { EndOfLineSequence, ITextModel } from 'vs/editor/common/model';
 import { TextEdit } from 'vs/editor/common/languages';
-import { StandardTokenType } from 'vs/editor/common/encodedTokenAttributes';
 import { ILanguageConfigurationService } from 'vs/editor/common/languages/languageConfigurationRegistry';
 import { IndentConsts } from 'vs/editor/common/languages/supports/indentRules';
 import { IModelService } from 'vs/editor/common/services/model';
@@ -633,18 +632,7 @@ export class AutoIndentOnPaste implements IEditorContribution {
 	private shouldIgnoreLine(model: ITextModel, lineNumber: number): boolean {
 		model.tokenization.forceTokenization(lineNumber);
 		const nonWhitespaceColumn = model.getLineFirstNonWhitespaceColumn(lineNumber);
-		if (nonWhitespaceColumn === 0) {
-			return true;
-		}
-		const tokens = model.tokenization.getLineTokens(lineNumber);
-		if (tokens.getCount() > 0) {
-			const firstNonWhitespaceTokenIndex = tokens.findTokenIndexAtOffset(nonWhitespaceColumn);
-			if (firstNonWhitespaceTokenIndex >= 0 && tokens.getStandardTokenType(firstNonWhitespaceTokenIndex) === StandardTokenType.Comment) {
-				return true;
-			}
-		}
-
-		return false;
+		return nonWhitespaceColumn === 0;
 	}
 
 	public dispose(): void {


### PR DESCRIPTION
Fixes #201420

The special handling for comments was originally added in 886f472 to fix #29753, but it had the side effect of causing #201420 -- preventing a desired auto indent in the majority of cases when pasting lines beginning with a comment (basically, all cases except multiline docblock style comments at the leftmost indentation level). That case has since been solved in a different way by e77b196, so removing this special handling gives us the best of both worlds.
