### PR TITLE
For open diff editors, resolve the underlying original editor to set …

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/welcomeView.ts
+++ b/src/vs/workbench/contrib/debug/browser/welcomeView.ts
@@ -20,7 +20,7 @@ import { IOpenerService } from 'vs/platform/opener/common/opener';
 import { WorkbenchStateContext } from 'vs/workbench/common/contextkeys';
 import { OpenFolderAction, OpenFileAction, OpenFileFolderAction } from 'vs/workbench/browser/actions/workspaceActions';
 import { isMacintosh, isWeb } from 'vs/base/common/platform';
-import { isCodeEditor } from 'vs/editor/browser/editorBrowser';
+import { isCodeEditor, isDiffEditor } from 'vs/editor/browser/editorBrowser';
 import { IStorageService, StorageScope, StorageTarget } from 'vs/platform/storage/common/storage';
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 import { DisposableStore } from 'vs/base/common/lifecycle';
@@ -62,7 +62,11 @@ export class WelcomeView extends ViewPane {
 		this.debugStartLanguageContext.set(lastSetLanguage);
 
 		const setContextKey = () => {
-			const editorControl = this.editorService.activeTextEditorControl;
+			let editorControl = this.editorService.activeTextEditorControl;
+			if (isDiffEditor(editorControl)) {
+				editorControl = editorControl.getOriginalEditor();
+			}
+
 			if (isCodeEditor(editorControl)) {
 				const model = editorControl.getModel();
 				const language = model ? model.getLanguageId() : undefined;
@@ -82,7 +86,11 @@ export class WelcomeView extends ViewPane {
 		this._register(editorService.onDidActiveEditorChange(() => {
 			disposables.clear();
 
-			const editorControl = this.editorService.activeTextEditorControl;
+			let editorControl = this.editorService.activeTextEditorControl;
+			if (isDiffEditor(editorControl)) {
+				editorControl = editorControl.getOriginalEditor();
+			}
+
 			if (isCodeEditor(editorControl)) {
 				disposables.add(editorControl.onDidChangeModelLanguage(setContextKey));
 			}

--- a/src/vs/workbench/contrib/debug/browser/welcomeView.ts
+++ b/src/vs/workbench/contrib/debug/browser/welcomeView.ts
@@ -64,7 +64,7 @@ export class WelcomeView extends ViewPane {
 		const setContextKey = () => {
 			let editorControl = this.editorService.activeTextEditorControl;
 			if (isDiffEditor(editorControl)) {
-				editorControl = editorControl.getOriginalEditor();
+				editorControl = editorControl.getModifiedEditor();
 			}
 
 			if (isCodeEditor(editorControl)) {
@@ -88,7 +88,7 @@ export class WelcomeView extends ViewPane {
 
 			let editorControl = this.editorService.activeTextEditorControl;
 			if (isDiffEditor(editorControl)) {
-				editorControl = editorControl.getOriginalEditor();
+				editorControl = editorControl.getModifiedEditor();
 			}
 
 			if (isCodeEditor(editorControl)) {


### PR DESCRIPTION
…the appropriate language debugger.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
Resolves https://github.com/microsoft/vscode/issues/201596

The debug view's welcome state shows an `Open a file which can be debugged or run` when a supported file is open while in diff view. Instead for diff editors resolve the underlying original editor to allow launching debuggers with resolved language debugger when in diff view.

![image](https://github.com/microsoft/vscode/assets/13228044/a853dd00-0b7c-4da4-935f-fd8f9d0f7538)
 