### PR TITLE
Add Command to Fully Expand Tree Items

### DIFF
--- a/src/vs/workbench/browser/actions/listCommands.ts
+++ b/src/vs/workbench/browser/actions/listCommands.ts
@@ -389,6 +389,26 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 	}
 });
 
+KeybindingsRegistry.registerCommandAndKeybindingRule({
+	id: 'list.expandAllFromFocus',
+	weight: KeybindingWeight.WorkbenchContrib,
+	when: WorkbenchListFocusContextKey,
+	handler: accessor => {
+		const focused = accessor.get(IListService).lastFocusedList;
+		const fakeKeyboardEvent = getSelectionKeyboardEvent('keydown', true);
+		// Trees
+		if (focused instanceof ObjectTree || focused instanceof DataTree || focused instanceof AsyncDataTree) {
+			const tree = focused;
+			const focus = tree.getFocus();
+
+			if (focus.length > 0) {
+				tree.expand(focus[0], true);
+			}
+			tree.setSelection(focus, fakeKeyboardEvent);
+			tree.setAnchor(focus[0]);
+		}
+	}
+});
 
 KeybindingsRegistry.registerCommandAndKeybindingRule({
 	id: 'list.focusParent',


### PR DESCRIPTION
Addresses #157410 adding a `list.expandAllFromFocus` command that will expand recursively from the focused item in the list, mirroring the existing `list.collapseAllToFocus` command.

Fixes #157410.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
