### PR TITLE
avoid to enter the infinite loop when item.children is empty.

### DIFF
--- a/src/vs/workbench/contrib/files/browser/views/explorerView.ts
+++ b/src/vs/workbench/contrib/files/browser/views/explorerView.ts
@@ -807,13 +807,16 @@ export class ExplorerView extends ViewPane implements IExplorerView {
 			} catch (e) {
 				return this.selectResource(resource, reveal, retry + 1);
 			}
-
-			for (const child of item.children.values()) {
-				if (this.uriIdentityService.extUri.isEqualOrParent(resource, child.resource)) {
-					item = child;
-					break;
-				}
+			if (!item.children.size) {
 				item = null;
+			} else {
+				for (const child of item.children.values()) {
+					if (this.uriIdentityService.extUri.isEqualOrParent(resource, child.resource)) {
+						item = child;
+						break;
+					}
+					item = null;
+				}
 			}
 		}
 


### PR DESCRIPTION
Problem description:
When you create folders continuously and quickly, you will enter an infinite loop, causing the interaction to become unresponsive under the code server mode

