### PR TITLE
Fix for displaying icons when icon theme is disabled

### DIFF
--- a/src/vs/editor/common/services/getIconClasses.ts
+++ b/src/vs/editor/common/services/getIconClasses.ts
@@ -16,7 +16,7 @@ const fileIconDirectoryRegex = /(?:\/|^)(?:([^\/]+)\/)?([^\/]+)$/;
 
 export function getIconClasses(modelService: IModelService, languageService: ILanguageService, resource: uri | undefined, fileKind?: FileKind, icon?: ThemeIcon): string[] {
 	if (icon) {
-		return [`codicon-${icon.id}`, 'product-icon'];
+		return [`codicon-${icon.id}`, 'predefined-file-icon'];
 	}
 
 	// we always set these base classes even if we do not have a path

--- a/src/vs/workbench/browser/media/style.css
+++ b/src/vs/workbench/browser/media/style.css
@@ -157,6 +157,10 @@ body.web {
 	padding-right: 3px;
 }
 
+.monaco-workbench:not(.file-icons-enabled) .product-icon[class*='codicon-']::before {
+	content: unset !important;
+}
+
 .monaco-workbench.modal-dialog-visible .monaco-progress-container.infinite .progress-bit {
 	display: none; /* stop progress animations when dialogs are visible (https://github.com/microsoft/vscode/issues/138396) */
 }

--- a/src/vs/workbench/browser/media/style.css
+++ b/src/vs/workbench/browser/media/style.css
@@ -150,14 +150,14 @@ body.web {
 	font-size: 16px; /* sets font-size for codicons in workbench (https://github.com/microsoft/vscode/issues/98495) */
 }
 
-.monaco-workbench .product-icon[class*='codicon-']::before {
+.monaco-workbench .predefined-file-icon[class*='codicon-']::before {
 	font-family: 'codicon';
 	width: 16px;
 	padding-left: 3px; /* width (16px) - font-size (13px) = padding-left (3px) */
 	padding-right: 3px;
 }
 
-.monaco-workbench:not(.file-icons-enabled) .product-icon[class*='codicon-']::before {
+.monaco-workbench:not(.file-icons-enabled) .predefined-file-icon[class*='codicon-']::before {
 	content: unset !important;
 }
 

--- a/src/vs/workbench/contrib/terminal/browser/terminalEditorInput.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalEditorInput.ts
@@ -205,7 +205,7 @@ export class TerminalEditorInput extends EditorInput implements IEditorCloseHand
 		if (!this._terminalInstance) {
 			return [];
 		}
-		const extraClasses: string[] = ['terminal-tab', 'product-icon'];
+		const extraClasses: string[] = ['terminal-tab', 'predefined-file-icon'];
 		const colorClass = getColorClass(this._terminalInstance);
 		if (colorClass) {
 			extraClasses.push(colorClass);

--- a/src/vs/workbench/contrib/terminal/browser/terminalIcon.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalIcon.ts
@@ -77,7 +77,7 @@ export function getColorStyleContent(colorTheme: IColorTheme, editor?: boolean):
 		if (color) {
 			if (editor) {
 				css += (
-					`.monaco-workbench .show-file-icons .product-icon.terminal-tab.${colorClass}::before,` +
+					`.monaco-workbench .show-file-icons .predefined-file-icon.terminal-tab.${colorClass}::before,` +
 					`.monaco-workbench .show-file-icons .file-icon.terminal-tab.${colorClass}::before` +
 					`{ color: ${color} !important; }`
 				);


### PR DESCRIPTION
This PR addresses the issue where icons were still being displayed in editors such as settings or extensions, even when the user has explicitly disabled icons via setting `workbench.iconTheme` to `null`. The fix ensures that the user's choice is respected and no icons are shown when the icon theme is disabled.

Fixes #201700