### PR TITLE
start to deprecate boolean for codeActionsOnSave

### DIFF
--- a/src/vs/workbench/contrib/codeActions/browser/codeActionsContribution.ts
+++ b/src/vs/workbench/contrib/codeActions/browser/codeActionsContribution.ts
@@ -20,7 +20,7 @@ import { IExtensionPoint } from 'vs/workbench/services/extensions/common/extensi
 const createCodeActionsAutoSave = (description: string): IJSONSchema => {
 	return {
 		type: 'string',
-		enum: ['always', 'explicit', 'never'],
+		enum: ['always', 'explicit', 'never', true, false],
 		enumDescriptions: [
 			nls.localize('alwaysSave', 'Triggers Code Actions on explicit saves and auto saves triggered by window or focus changes.'),
 			nls.localize('explicitSave', 'Triggers Code Actions only when explicitly saved'),
@@ -28,7 +28,7 @@ const createCodeActionsAutoSave = (description: string): IJSONSchema => {
 			nls.localize('explicitSaveBoolean', 'Triggers Code Actions only when explicitly saved. This value will be deprecated in favor of "explicit".'),
 			nls.localize('neverSaveBoolean', 'Never triggers Code Actions on save. This value will be deprecated in favor of "never".')
 		],
-		default: true,
+		default: 'explicit',
 		description: description
 	};
 };
@@ -55,7 +55,7 @@ const codeActionsOnSaveSchema: IConfigurationPropertySchema = {
 	type: ['object', 'array'],
 	additionalProperties: {
 		type: 'string',
-		enum: ['always', 'explicit', 'never'],
+		enum: ['always', 'explicit', 'never', true, false],
 	},
 	default: {},
 	scope: ConfigurationScope.LANGUAGE_OVERRIDABLE,

--- a/src/vs/workbench/contrib/codeActions/browser/codeActionsContribution.ts
+++ b/src/vs/workbench/contrib/codeActions/browser/codeActionsContribution.ts
@@ -19,8 +19,8 @@ import { IExtensionPoint } from 'vs/workbench/services/extensions/common/extensi
 
 const createCodeActionsAutoSave = (description: string): IJSONSchema => {
 	return {
-		type: ['string', 'boolean'],
-		enum: ['always', 'explicit', 'never', true, false],
+		type: 'string',
+		enum: ['always', 'explicit', 'never'],
 		enumDescriptions: [
 			nls.localize('alwaysSave', 'Triggers Code Actions on explicit saves and auto saves triggered by window or focus changes.'),
 			nls.localize('explicitSave', 'Triggers Code Actions only when explicitly saved'),
@@ -43,7 +43,7 @@ const codeActionsOnSaveSchema: IConfigurationPropertySchema = {
 			type: 'object',
 			properties: codeActionsOnSaveDefaultProperties,
 			additionalProperties: {
-				type: ['string', 'boolean']
+				type: 'string'
 			},
 		},
 		{
@@ -54,8 +54,8 @@ const codeActionsOnSaveSchema: IConfigurationPropertySchema = {
 	markdownDescription: nls.localize('editor.codeActionsOnSave', 'Run Code Actions for the editor on save. Code Actions must be specified and the editor must not be shutting down. Example: `"source.organizeImports": "explicit" `'),
 	type: ['object', 'array'],
 	additionalProperties: {
-		type: ['string', 'boolean'],
-		enum: ['always', 'explicit', 'never', true, false],
+		type: 'string',
+		enum: ['always', 'explicit', 'never'],
 	},
 	default: {},
 	scope: ConfigurationScope.LANGUAGE_OVERRIDABLE,


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

fixes https://github.com/microsoft/vscode/issues/200802

- Still allows booleans to be used, but warning will now be shown that `always`, `never`, and `explicit` are expected.
<img width="273" alt="Screenshot 2024-01-04 at 8 42 21 AM" src="https://github.com/microsoft/vscode/assets/54879025/a925c013-5127-4b51-b282-0da0c334797b">

<img width="842" alt="Screenshot 2024-01-04 at 8 42 15 AM" src="https://github.com/microsoft/vscode/assets/54879025/d50449c6-9c70-4661-9784-817d63e2143f">
