### PR TITLE
get children when node expands

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadNotebookKernels.ts
+++ b/src/vs/workbench/api/browser/mainThreadNotebookKernels.ts
@@ -101,7 +101,7 @@ abstract class MainThreadKernel implements INotebookKernel {
 
 	abstract executeNotebookCellsRequest(uri: URI, cellHandles: number[]): Promise<void>;
 	abstract cancelNotebookCellExecution(uri: URI, cellHandles: number[]): Promise<void>;
-	abstract provideVariables(notebookUri: URI, variableName: string | undefined, kind: 'named' | 'indexed', start: number, token: CancellationToken): AsyncIterableObject<VariablesResult>;
+	abstract provideVariables(notebookUri: URI, parentId: number | undefined, kind: 'named' | 'indexed', start: number, token: CancellationToken): AsyncIterableObject<VariablesResult>;
 }
 
 class MainThreadKernelDetectionTask implements INotebookKernelDetectionTask {
@@ -242,7 +242,7 @@ export class MainThreadNotebookKernels implements MainThreadNotebookKernelsShape
 			async cancelNotebookCellExecution(uri: URI, handles: number[]): Promise<void> {
 				await that._proxy.$cancelCells(handle, uri, handles);
 			}
-			provideVariables(notebookUri: URI, parentName: string | undefined, kind: 'named' | 'indexed', start: number, token: CancellationToken): AsyncIterableObject<VariablesResult> {
+			provideVariables(notebookUri: URI, parentId: number | undefined, kind: 'named' | 'indexed', start: number, token: CancellationToken): AsyncIterableObject<VariablesResult> {
 				const requestId = `${handle}variables${that.variableRequestIndex++}`;
 				if (that.variableRequestMap.has(requestId)) {
 					return that.variableRequestMap.get(requestId)!.asyncIterable;
@@ -250,7 +250,7 @@ export class MainThreadNotebookKernels implements MainThreadNotebookKernelsShape
 
 				const source = new AsyncIterableSource<VariablesResult>();
 				that.variableRequestMap.set(requestId, source);
-				that._proxy.$provideVariables(handle, requestId, notebookUri, parentName, kind, start, token).then(() => {
+				that._proxy.$provideVariables(handle, requestId, notebookUri, parentId, kind, start, token).then(() => {
 					source.resolve();
 					that.variableRequestMap.delete(requestId);
 				}).catch((err) => {

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -80,7 +80,6 @@ import { CandidatePort } from 'vs/workbench/services/remote/common/tunnelModel';
 import { ITextQueryBuilderOptions } from 'vs/workbench/services/search/common/queryBuilder';
 import * as search from 'vs/workbench/services/search/common/search';
 import { ISaveProfileResult } from 'vs/workbench/services/userDataProfile/common/userDataProfile';
-import { VariablesResult } from 'vscode';
 
 export interface IWorkspaceData extends IStaticWorkspaceData {
 	folders: { uri: UriComponents; name: string; index: number }[];
@@ -1113,6 +1112,14 @@ export interface ICellExecutionCompleteDto extends ICellExecutionComplete {
 }
 
 export type ICellExecuteUpdateDto = ICellExecuteOutputEditDto | ICellExecuteOutputItemEditDto | ICellExecutionStateUpdateDto;
+
+export interface VariablesResult {
+	id: number;
+	name: string;
+	value: string;
+	hasNamedChildren: boolean;
+	indexedChildrenCount: number;
+}
 
 export interface MainThreadNotebookKernelsShape extends IDisposable {
 	$postMessage(handle: number, editorId: string | undefined, message: any): Promise<boolean>;
@@ -2544,7 +2551,7 @@ export interface ExtHostNotebookKernelsShape {
 	$acceptKernelMessageFromRenderer(handle: number, editorId: string, message: any): void;
 	$cellExecutionChanged(uri: UriComponents, cellHandle: number, state: notebookCommon.NotebookCellExecutionState | undefined): void;
 	$provideKernelSourceActions(handle: number, token: CancellationToken): Promise<notebookCommon.INotebookKernelSourceAction[]>;
-	$provideVariables(handle: number, requestId: string, notebookUri: UriComponents, variableName: string | undefined, kind: 'named' | 'indexed', start: number, token: CancellationToken): Promise<void>;
+	$provideVariables(handle: number, requestId: string, notebookUri: UriComponents, parentId: number | undefined, kind: 'named' | 'indexed', start: number, token: CancellationToken): Promise<void>;
 }
 
 export interface ExtHostInteractiveShape {

--- a/src/vs/workbench/contrib/notebook/browser/contrib/notebookVariables/notebookVariables.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/notebookVariables/notebookVariables.ts
@@ -43,7 +43,8 @@ export class NotebookVariables extends Disposable implements IWorkbenchContribut
 		if (debugViewContainer) {
 			const viewsRegistry = Registry.as<IViewsRegistry>(Extensions.ViewsRegistry);
 			const viewDescriptor = {
-				id: 'NOTEBOOK_VARIABLES', name: nls.localize2('notebookVariables', "Notebook Variables"), containerIcon: variablesViewIcon, ctorDescriptor: new SyncDescriptor(NotebookVariablesView),
+				id: 'NOTEBOOK_VARIABLES', name: nls.localize2('notebookVariables', "Notebook Variables"),
+				containerIcon: variablesViewIcon, ctorDescriptor: new SyncDescriptor(NotebookVariablesView),
 				order: 50, weight: 5, canToggleVisibility: true, canMoveView: true, collapsed: true, when: ContextKeyExpr.notEquals(NOTEBOOK_KERNEL.key, ''),
 			};
 

--- a/src/vs/workbench/contrib/notebook/browser/contrib/notebookVariables/notebookVariablesDataSource.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/notebookVariables/notebookVariablesDataSource.ts
@@ -1,0 +1,100 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IAsyncDataSource } from 'vs/base/browser/ui/tree/tree';
+import { CancellationToken } from 'vs/base/common/cancellation';
+import { NotebookTextModel } from 'vs/workbench/contrib/notebook/common/model/notebookTextModel';
+import { INotebookKernelService, VariablesResult } from 'vs/workbench/contrib/notebook/common/notebookKernelService';
+
+export interface INotebookScope {
+	type: 'root';
+	readonly notebook: NotebookTextModel | undefined;
+}
+
+export interface INotebookVariableElement {
+	type: 'variable';
+	readonly id: string;
+	readonly label: string;
+	readonly value: string;
+	readonly indexedChildrenCount: number;
+	readonly hasNamedChildren: boolean;
+}
+
+export class NotebookVariableDataSource implements IAsyncDataSource<INotebookScope, INotebookVariableElement> {
+
+	private notebook: NotebookTextModel | undefined = undefined;
+
+	constructor(private readonly notebookKernelService: INotebookKernelService) { }
+
+	hasChildren(element: INotebookScope | INotebookVariableElement): boolean {
+		return element.type === 'root' || element.hasNamedChildren || element.indexedChildrenCount > 0;
+	}
+
+	async getChildren(element: INotebookScope | INotebookVariableElement): Promise<Array<INotebookVariableElement>> {
+		if (element.type === 'root') {
+			this.notebook = element.notebook;
+			return this.getRootVariables();
+		} else {
+			return this.getVariables(element);
+		}
+	}
+
+	async getVariables(parent: INotebookVariableElement): Promise<INotebookVariableElement[]> {
+		if (!this.notebook) {
+			return [];
+		}
+		const selectedKernel = this.notebookKernelService.getMatchingKernel(this.notebook).selected;
+		if (selectedKernel && selectedKernel.hasVariableProvider) {
+
+			let children: INotebookVariableElement[] = [];
+			if (parent.hasNamedChildren) {
+				const variables = selectedKernel.provideVariables(this.notebook.uri, parent.label, 'named', 0, CancellationToken.None);
+				const childNodes = await variables
+					.map(variable => { return this.createVariableElement(variable); })
+					.toPromise();
+				children = children.concat(childNodes);
+			}
+			if (parent.indexedChildrenCount > 0) {
+				const variables = selectedKernel.provideVariables(this.notebook.uri, parent.label, 'indexed', 0, CancellationToken.None);
+				const childNodes = await variables
+					.map(variable => { return this.createVariableElement(variable); })
+					.toPromise();
+				children = children.concat(childNodes);
+			}
+
+			return children;
+		}
+		return [];
+	}
+
+	async getRootVariables(): Promise<INotebookVariableElement[]> {
+		if (!this.notebook) {
+			return [];
+		}
+
+		const selectedKernel = this.notebookKernelService.getMatchingKernel(this.notebook).selected;
+		if (selectedKernel && selectedKernel.hasVariableProvider) {
+			const variables = selectedKernel.provideVariables(this.notebook.uri, undefined, 'named', 0, CancellationToken.None);
+			return await variables
+				.map(variable => { return this.createVariableElement(variable); })
+				.toPromise();
+		}
+
+		return [];
+	}
+
+	private index = 0;
+	private createVariableElement(variable: VariablesResult): INotebookVariableElement {
+
+		return {
+			type: 'variable',
+			id: `${this.index++}`, // TODO : get an ID from extHost
+			label: variable.variable.name,
+			value: variable.variable.value,
+			indexedChildrenCount: variable.indexedChildrenCount,
+			hasNamedChildren: variable.namedChildrenCount > 0
+		};
+	}
+}

--- a/src/vs/workbench/contrib/notebook/browser/contrib/notebookVariables/notebookVariablesDataSource.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/notebookVariables/notebookVariablesDataSource.ts
@@ -15,8 +15,8 @@ export interface INotebookScope {
 
 export interface INotebookVariableElement {
 	type: 'variable';
-	readonly id: string;
-	readonly label: string;
+	readonly id: number;
+	readonly name: string;
 	readonly value: string;
 	readonly indexedChildrenCount: number;
 	readonly hasNamedChildren: boolean;
@@ -50,14 +50,14 @@ export class NotebookVariableDataSource implements IAsyncDataSource<INotebookSco
 
 			let children: INotebookVariableElement[] = [];
 			if (parent.hasNamedChildren) {
-				const variables = selectedKernel.provideVariables(this.notebook.uri, parent.label, 'named', 0, CancellationToken.None);
+				const variables = selectedKernel.provideVariables(this.notebook.uri, parent.id, 'named', 0, CancellationToken.None);
 				const childNodes = await variables
 					.map(variable => { return this.createVariableElement(variable); })
 					.toPromise();
 				children = children.concat(childNodes);
 			}
 			if (parent.indexedChildrenCount > 0) {
-				const variables = selectedKernel.provideVariables(this.notebook.uri, parent.label, 'indexed', 0, CancellationToken.None);
+				const variables = selectedKernel.provideVariables(this.notebook.uri, parent.id, 'indexed', 0, CancellationToken.None);
 				const childNodes = await variables
 					.map(variable => { return this.createVariableElement(variable); })
 					.toPromise();
@@ -85,16 +85,10 @@ export class NotebookVariableDataSource implements IAsyncDataSource<INotebookSco
 		return [];
 	}
 
-	private index = 0;
 	private createVariableElement(variable: VariablesResult): INotebookVariableElement {
-
 		return {
 			type: 'variable',
-			id: `${this.index++}`, // TODO : get an ID from extHost
-			label: variable.variable.name,
-			value: variable.variable.value,
-			indexedChildrenCount: variable.indexedChildrenCount,
-			hasNamedChildren: variable.namedChildrenCount > 0
+			...variable
 		};
 	}
 }

--- a/src/vs/workbench/contrib/notebook/browser/contrib/notebookVariables/notebookVariablesTree.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/notebookVariables/notebookVariablesTree.ts
@@ -39,7 +39,7 @@ export class NotebookVariableRenderer implements ITreeRenderer<INotebookVariable
 	}
 
 	renderElement(element: ITreeNode<INotebookVariableElement, FuzzyScore>, _index: number, templateData: { wrapper: HTMLElement }): void {
-		templateData.wrapper.innerText = `${element.element.label}: ${element.element.value}`;
+		templateData.wrapper.innerText = `${element.element.name}: ${element.element.value}`;
 	}
 
 	disposeTemplate(): void {
@@ -54,6 +54,6 @@ export class NotebookVariableAccessibilityProvider implements IListAccessibility
 	}
 
 	getAriaLabel(element: INotebookVariableElement): string {
-		return localize('notebookVariableAriaLabel', "Variable {0}, value {1}", element.label, element.value);
+		return localize('notebookVariableAriaLabel', "Variable {0}, value {1}", element.name, element.value);
 	}
 }

--- a/src/vs/workbench/contrib/notebook/browser/contrib/notebookVariables/notebookVariablesTree.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/notebookVariables/notebookVariablesTree.ts
@@ -10,14 +10,7 @@ import { ITreeNode, ITreeRenderer } from 'vs/base/browser/ui/tree/tree';
 import { FuzzyScore } from 'vs/base/common/filters';
 import { localize } from 'vs/nls';
 import { WorkbenchObjectTree } from 'vs/platform/list/browser/listService';
-
-export interface INotebookVariableElement {
-	readonly id: string;
-	readonly label: string;
-	readonly value: string;
-	readonly indexedChildrenCount: number;
-	readonly hasNamedChildren: boolean;
-}
+import { INotebookVariableElement } from 'vs/workbench/contrib/notebook/browser/contrib/notebookVariables/notebookVariablesDataSource';
 
 export class NotebookVariablesTree extends WorkbenchObjectTree<INotebookVariableElement> { }
 

--- a/src/vs/workbench/contrib/notebook/browser/contrib/notebookVariables/notebookVariablesTree.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/notebookVariables/notebookVariablesTree.ts
@@ -15,6 +15,8 @@ export interface INotebookVariableElement {
 	readonly id: string;
 	readonly label: string;
 	readonly value: string;
+	readonly indexedChildrenCount: number;
+	readonly hasNamedChildren: boolean;
 }
 
 export class NotebookVariablesTree extends WorkbenchObjectTree<INotebookVariableElement> { }
@@ -43,8 +45,8 @@ export class NotebookVariableRenderer implements ITreeRenderer<INotebookVariable
 		return { wrapper };
 	}
 
-	renderElement(element: ITreeNode<INotebookVariableElement, FuzzyScore>, index: number, templateData: { wrapper: HTMLElement }, height: number | undefined): void {
-		templateData.wrapper.innerText = `${element.element.label} - ${element.element.value}`;
+	renderElement(element: ITreeNode<INotebookVariableElement, FuzzyScore>, _index: number, templateData: { wrapper: HTMLElement }): void {
+		templateData.wrapper.innerText = `${element.element.label}: ${element.element.value}`;
 	}
 
 	disposeTemplate(): void {

--- a/src/vs/workbench/contrib/notebook/browser/contrib/notebookVariables/notebookVariablesView.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/notebookVariables/notebookVariablesView.ts
@@ -72,7 +72,6 @@ export class NotebookVariablesView extends ViewPane {
 			{
 				accessibilityProvider: new NotebookVariableAccessibilityProvider(),
 				identityProvider: { getId: (e: INotebookVariableElement) => e.id },
-				hideTwistiesOfChildlessElements: true,
 			});
 
 		this.tree.layout();

--- a/src/vs/workbench/contrib/notebook/browser/contrib/notebookVariables/notebookVariablesView.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/notebookVariables/notebookVariablesView.ts
@@ -3,8 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { IObjectTreeElement } from 'vs/base/browser/ui/tree/tree';
-import { CancellationToken } from 'vs/base/common/cancellation';
 import { URI } from 'vs/base/common/uri';
 import * as nls from 'vs/nls';
 import { ILocalizedString } from 'vs/platform/action/common/action';
@@ -14,18 +12,19 @@ import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 import { IContextMenuService } from 'vs/platform/contextview/browser/contextView';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
-import { WorkbenchObjectTree } from 'vs/platform/list/browser/listService';
+import { WorkbenchAsyncDataTree } from 'vs/platform/list/browser/listService';
 import { IOpenerService } from 'vs/platform/opener/common/opener';
 import { IQuickInputService } from 'vs/platform/quickinput/common/quickInput';
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 import { IThemeService } from 'vs/platform/theme/common/themeService';
 import { IViewPaneOptions, ViewPane } from 'vs/workbench/browser/parts/views/viewPane';
 import { IViewDescriptorService } from 'vs/workbench/common/views';
-import { NotebookVariableAccessibilityProvider, NotebookVariableRenderer, INotebookVariableElement, NotebookVariablesDelegate } from 'vs/workbench/contrib/notebook/browser/contrib/notebookVariables/notebookVariablesTree';
+import { INotebookScope, INotebookVariableElement, NotebookVariableDataSource } from 'vs/workbench/contrib/notebook/browser/contrib/notebookVariables/notebookVariablesDataSource';
+import { NotebookVariableAccessibilityProvider, NotebookVariableRenderer, NotebookVariablesDelegate } from 'vs/workbench/contrib/notebook/browser/contrib/notebookVariables/notebookVariablesTree';
 import { getNotebookEditorFromEditorPane } from 'vs/workbench/contrib/notebook/browser/notebookBrowser';
 import { NotebookTextModel } from 'vs/workbench/contrib/notebook/common/model/notebookTextModel';
 import { ICellExecutionStateChangedEvent, IExecutionStateChangedEvent, INotebookExecutionStateService } from 'vs/workbench/contrib/notebook/common/notebookExecutionStateService';
-import { INotebookKernelService, VariablesResult } from 'vs/workbench/contrib/notebook/common/notebookKernelService';
+import { INotebookKernelService } from 'vs/workbench/contrib/notebook/common/notebookKernelService';
 import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
 
 export class NotebookVariablesView extends ViewPane {
@@ -33,7 +32,7 @@ export class NotebookVariablesView extends ViewPane {
 	static readonly ID = 'notebookVariablesView';
 	static readonly TITLE: ILocalizedString = nls.localize2('notebook.notebookVariables', "Notebook Variables");
 
-	private tree: WorkbenchObjectTree<INotebookVariableElement> | undefined;
+	private tree: WorkbenchAsyncDataTree<INotebookScope, INotebookVariableElement> | undefined;
 	private activeNotebook: NotebookTextModel | undefined;
 
 	constructor(
@@ -63,57 +62,26 @@ export class NotebookVariablesView extends ViewPane {
 	protected override renderBody(container: HTMLElement): void {
 		super.renderBody(container);
 
-		this.tree = <WorkbenchObjectTree<INotebookVariableElement>>this.instantiationService.createInstance(
-			WorkbenchObjectTree,
+		this.tree = <WorkbenchAsyncDataTree<INotebookScope, INotebookVariableElement>>this.instantiationService.createInstance(
+			WorkbenchAsyncDataTree,
 			'notebookVariablesTree',
 			container,
 			new NotebookVariablesDelegate(),
 			[new NotebookVariableRenderer()],
+			new NotebookVariableDataSource(this.notebookKernelService),
 			{
-				identityProvider: { getId: (e: INotebookVariableElement) => e.id },
-				horizontalScrolling: false,
-				hideTwistiesOfChildlessElements: true,
 				accessibilityProvider: new NotebookVariableAccessibilityProvider(),
-				setRowLineHeight: false,
+				identityProvider: { getId: (e: INotebookVariableElement) => e.id },
+				hideTwistiesOfChildlessElements: true,
 			});
 
 		this.tree.layout();
-		this.tree?.setChildren(null, []);
-
-		this.tree.onDidChangeCollapseState(e => {
-			if (!e.node.collapsed && e.node.element && this.activeNotebook) {
-				this.updateChildren(this.activeNotebook, e.node.element);
-			}
-		});
+		this.tree.setInput({ type: 'root', notebook: this.activeNotebook });
 	}
 
 	protected override layoutBody(height: number, width: number): void {
 		super.layoutBody(height, width);
 		this.tree?.layout(height, width);
-	}
-
-	private async updateChildren(notebook: NotebookTextModel, element: INotebookVariableElement) {
-		const selectedKernel = this.notebookKernelService.getMatchingKernel(notebook).selected;
-		if (selectedKernel && selectedKernel.hasVariableProvider) {
-
-			let children: IObjectTreeElement<INotebookVariableElement>[] = [];
-			if (element.hasNamedChildren) {
-				const variables = selectedKernel.provideVariables(notebook.uri, element.label, 'named', 0, CancellationToken.None);
-				const childNodes = await variables
-					.map(variable => { return this.createTreeItem(variable); })
-					.toPromise();
-				children = children.concat(childNodes);
-			}
-			if (element.indexedChildrenCount > 0) {
-				const variables = selectedKernel.provideVariables(notebook.uri, element.label, 'indexed', 0, CancellationToken.None);
-				const childNodes = await variables
-					.map(variable => { return this.createTreeItem(variable); })
-					.toPromise();
-				children = children.concat(childNodes);
-			}
-
-			this.tree?.setChildren(element, children);
-		}
 	}
 
 	private handleActiveEditorChange() {
@@ -122,7 +90,8 @@ export class NotebookVariablesView extends ViewPane {
 			const notebookDocument = getNotebookEditorFromEditorPane(activeEditorPane)?.getViewModel()?.notebookDocument;
 			if (notebookDocument && notebookDocument !== this.activeNotebook) {
 				this.activeNotebook = notebookDocument;
-				this.updateVariables(this.activeNotebook);
+				this.tree?.setInput({ type: 'root', notebook: this.activeNotebook });
+				this.tree?.updateChildren();
 			}
 		}
 	}
@@ -131,62 +100,15 @@ export class NotebookVariablesView extends ViewPane {
 		if (this.activeNotebook) {
 			// changed === undefined -> excecution ended
 			if (event.changed === undefined && event.affectsNotebook(this.activeNotebook?.uri)) {
-				this.updateVariables(this.activeNotebook);
+				this.tree?.updateChildren();
 			}
 		}
 	}
 
 	private handleVariablesChanged(notebookUri: URI) {
 		if (this.activeNotebook && notebookUri.toString() === this.activeNotebook.uri.toString()) {
-			this.updateVariables(this.activeNotebook);
+			this.tree?.setInput({ type: 'root', notebook: this.activeNotebook });
+			this.tree?.updateChildren();
 		}
-	}
-
-	private async updateVariables(notebook: NotebookTextModel) {
-		const selectedKernel = this.notebookKernelService.getMatchingKernel(notebook).selected;
-		if (selectedKernel && selectedKernel.hasVariableProvider) {
-
-			const variables = selectedKernel.provideVariables(notebook.uri, undefined, 'named', 0, CancellationToken.None);
-			const treeData = await variables
-				.map(variable => { return this.createTreeItem(variable); })
-				.toPromise();
-
-			this.tree?.setChildren(null, treeData);
-		}
-	}
-
-	private index = 0;
-
-	private createTreeItem(variable: VariablesResult): IObjectTreeElement<INotebookVariableElement> {
-		let collapsed: boolean | undefined = undefined;
-		let children: IObjectTreeElement<INotebookVariableElement>[] | undefined = undefined;
-		if (variable.namedChildrenCount > 0 || variable.indexedChildrenCount > 0) {
-			collapsed = true;
-			children = [
-				{
-					element: {
-						id: `${this.index + 1}-placeholder`,
-						label: ' ',
-						value: '...',
-						indexedChildrenCount: 0,
-						hasNamedChildren: false,
-					}
-				}
-			];
-		}
-
-		const element = {
-			element: {
-				id: `${this.index++}`,
-				label: variable.variable.name,
-				value: variable.variable.value,
-				indexedChildrenCount: variable.indexedChildrenCount,
-				hasNamedChildren: variable.namedChildrenCount > 0,
-			},
-			children,
-			collapsed
-		};
-
-		return element;
 	}
 }

--- a/src/vs/workbench/contrib/notebook/common/notebookKernelService.ts
+++ b/src/vs/workbench/contrib/notebook/common/notebookKernelService.ts
@@ -38,14 +38,11 @@ export interface INotebookKernelChangeEvent {
 	hasVariableProvider?: true;
 }
 
-export interface Variable {
+export interface VariablesResult {
+	id: number;
 	name: string;
 	value: string;
-}
-
-export interface VariablesResult {
-	variable: Variable;
-	namedChildrenCount: number;
+	hasNamedChildren: boolean;
 	indexedChildrenCount: number;
 }
 
@@ -70,7 +67,7 @@ export interface INotebookKernel {
 	executeNotebookCellsRequest(uri: URI, cellHandles: number[]): Promise<void>;
 	cancelNotebookCellExecution(uri: URI, cellHandles: number[]): Promise<void>;
 
-	provideVariables(notebookUri: URI, variableName: string | undefined, kind: 'named' | 'indexed', start: number, token: CancellationToken): AsyncIterableObject<VariablesResult>;
+	provideVariables(notebookUri: URI, parentId: number | undefined, kind: 'named' | 'indexed', start: number, token: CancellationToken): AsyncIterableObject<VariablesResult>;
 }
 
 export const enum ProxyKernelState {

--- a/src/vs/workbench/contrib/notebook/test/browser/notebookExecutionService.test.ts
+++ b/src/vs/workbench/contrib/notebook/test/browser/notebookExecutionService.test.ts
@@ -174,7 +174,7 @@ class TestNotebookKernel implements INotebookKernel {
 	preloadUris: URI[] = [];
 	preloadProvides: string[] = [];
 	supportedLanguages: string[] = [];
-	provideVariables(notebookUri: URI, variableName: string | undefined, kind: 'named' | 'indexed', start: number, token: CancellationToken): AsyncIterableObject<VariablesResult> {
+	provideVariables(notebookUri: URI, parentId: number | undefined, kind: 'named' | 'indexed', start: number, token: CancellationToken): AsyncIterableObject<VariablesResult> {
 		return AsyncIterableObject.EMPTY;
 	}
 	executeNotebookCellsRequest(): Promise<void> {

--- a/src/vs/workbench/contrib/notebook/test/browser/notebookExecutionStateService.test.ts
+++ b/src/vs/workbench/contrib/notebook/test/browser/notebookExecutionStateService.test.ts
@@ -362,7 +362,7 @@ class TestNotebookKernel implements INotebookKernel {
 	supportedLanguages: string[] = [];
 	async executeNotebookCellsRequest(): Promise<void> { }
 	async cancelNotebookCellExecution(uri: URI, cellHandles: number[]): Promise<void> { }
-	provideVariables(notebookUri: URI, variableName: string | undefined, kind: 'named' | 'indexed', start: number, token: CancellationToken): AsyncIterableObject<VariablesResult> {
+	provideVariables(notebookUri: URI, parentId: number | undefined, kind: 'named' | 'indexed', start: number, token: CancellationToken): AsyncIterableObject<VariablesResult> {
 		return AsyncIterableObject.EMPTY;
 	}
 

--- a/src/vs/workbench/contrib/notebook/test/browser/notebookKernelHistory.test.ts
+++ b/src/vs/workbench/contrib/notebook/test/browser/notebookKernelHistory.test.ts
@@ -186,7 +186,7 @@ class TestNotebookKernel implements INotebookKernel {
 	cancelNotebookCellExecution(): Promise<void> {
 		throw new Error('Method not implemented.');
 	}
-	provideVariables(notebookUri: URI, variableName: string | undefined, kind: 'named' | 'indexed', start: number, token: CancellationToken): AsyncIterableObject<VariablesResult> {
+	provideVariables(notebookUri: URI, parentId: number | undefined, kind: 'named' | 'indexed', start: number, token: CancellationToken): AsyncIterableObject<VariablesResult> {
 		return AsyncIterableObject.EMPTY;
 	}
 

--- a/src/vs/workbench/contrib/notebook/test/browser/notebookKernelService.test.ts
+++ b/src/vs/workbench/contrib/notebook/test/browser/notebookKernelService.test.ts
@@ -199,7 +199,7 @@ class TestNotebookKernel implements INotebookKernel {
 	cancelNotebookCellExecution(): Promise<void> {
 		throw new Error('Method not implemented.');
 	}
-	provideVariables(notebookUri: URI, variableName: string | undefined, kind: 'named' | 'indexed', start: number, token: CancellationToken): AsyncIterableObject<VariablesResult> {
+	provideVariables(notebookUri: URI, parentId: number | undefined, kind: 'named' | 'indexed', start: number, token: CancellationToken): AsyncIterableObject<VariablesResult> {
 		return AsyncIterableObject.EMPTY;
 	}
 

--- a/src/vscode-dts/vscode.proposed.notebookVariableProvider.d.ts
+++ b/src/vscode-dts/vscode.proposed.notebookVariableProvider.d.ts
@@ -16,7 +16,7 @@ declare module 'vscode' {
 
 	interface VariablesResult {
 		variable: Variable;
-		namedChildrenCount: number;
+		hasNamedChildren: boolean;
 		indexedChildrenCount: number;
 	}
 


### PR DESCRIPTION
https://github.com/microsoft/vscode/issues/165445

- switched to an async tree so that getting children can be done lazily
- added an ID field to the variables on vscode side so we can look up the correct variable instance to ask for children
- It seems like we would benefit from sharing the ID with the extension as well to be able to keep using the same instances
  - Every time we ask for the root variables, we no longer know how to reliably match them up to what we currently have
