### PR TITLE
[json] don't use md5

### DIFF
--- a/extensions/json-language-features/client/src/node/schemaCache.ts
+++ b/extensions/json-language-features/client/src/node/schemaCache.ts
@@ -143,5 +143,5 @@ export class JSONSchemaCache {
 	}
 }
 function getCacheFileName(uri: string): string {
-	return `${createHash('MD5').update(uri).digest('hex')}.schema.json`;
+	return `${createHash('sha256').update(uri).digest('hex')}.schema.json`;
 }


### PR DESCRIPTION
Following the  Microsoft SDL standards, md5 must not be used anymore