### PR TITLE
Switch to using sha256 for checksums (fixes CodeQL warning)

### DIFF
--- a/build/gulpfile.vscode.js
+++ b/build/gulpfile.vscode.js
@@ -184,7 +184,7 @@ function computeChecksum(filename) {
 	const contents = fs.readFileSync(filename);
 
 	const hash = crypto
-		.createHash('md5')
+		.createHash('sha256')
 		.update(contents)
 		.digest('base64')
 		.replace(/=+$/, '');

--- a/src/vs/platform/checksum/node/checksumService.ts
+++ b/src/vs/platform/checksum/node/checksumService.ts
@@ -18,7 +18,7 @@ export class ChecksumService implements IChecksumService {
 	async checksum(resource: URI): Promise<string> {
 		const stream = (await this.fileService.readFileStream(resource)).value;
 		return new Promise<string>((resolve, reject) => {
-			const hash = createHash('md5');
+			const hash = createHash('sha256');
 
 			listenStream(stream, {
 				onData: data => hash.update(data.buffer),

--- a/src/vs/platform/checksum/test/node/checksumService.test.ts
+++ b/src/vs/platform/checksum/test/node/checksumService.test.ts
@@ -35,7 +35,7 @@ suite('Checksum Service', () => {
 		const checksumService = new ChecksumService(fileService);
 
 		const checksum = await checksumService.checksum(URI.file(FileAccess.asFileUri('vs/platform/checksum/test/node/fixtures/lorem.txt').fsPath));
-		assert.ok(checksum === '8mi5KF8kcb817zmlal1kZA' || checksum === 'DnUKbJ1bHPPNZoHgHV25sg'); // depends on line endings git config
+		assert.ok(checksum === 'd/9bMU0ydNCmc/hg8ItWeiLT/ePnf7gyPRQVGpd6tRI' || checksum === 'eJeeTIS0dzi8MZY+nHhjPBVtNbmGqxfVvgEOB4sqVIc'); // depends on line endings git config
 	});
 
 	ensureNoDisposablesAreLeakedInTestSuite();


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
