### PR TITLE
Update IExplorerView interface

### DIFF
--- a/src/vs/workbench/contrib/files/browser/files.ts
+++ b/src/vs/workbench/contrib/files/browser/files.ts
@@ -52,8 +52,8 @@ export const IExplorerService = createDecorator<IExplorerService>('explorerServi
 export interface IExplorerView {
 	autoReveal: boolean | 'force' | 'focusNoScroll';
 	getContext(respectMultiSelection: boolean): ExplorerItem[];
-	refresh(recursive: boolean, item?: ExplorerItem): Promise<void>;
-	selectResource(resource: URI | undefined, reveal?: boolean | string): Promise<void>;
+	refresh(recursive: boolean, item?: ExplorerItem, cancelEditing?: boolean): Promise<void>;
+	selectResource(resource: URI | undefined, reveal?: boolean | string, retry?: number): Promise<void>;
 	setTreeInput(): Promise<void>;
 	itemsCopied(tats: ExplorerItem[], cut: boolean, previousCut: ExplorerItem[] | undefined): void;
 	setEditable(stat: ExplorerItem, isEditing: boolean): Promise<void>;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
Several methods in the [IExplorerView interface](https://github.com/microsoft/vscode/blob/03e191825d23faae8b1311597571f884ca543def/src/vs/workbench/contrib/files/browser/files.ts#L52) are missing arguments present in the implementation.
Specifically, the `refresh` method lacks the [cancelEditing argument](https://github.com/microsoft/vscode/blob/03e191825d23faae8b1311597571f884ca543def/src/vs/workbench/contrib/files/browser/views/explorerView.ts#L685), and the `selectResource` method lacks the [retry argument](https://github.com/microsoft/vscode/blob/03e191825d23faae8b1311597571f884ca543def/src/vs/workbench/contrib/files/browser/views/explorerView.ts#L784)