### PR TITLE
monaco: improve handling of glyph margins

### DIFF
--- a/src/vs/editor/browser/view.ts
+++ b/src/vs/editor/browser/view.ts
@@ -246,7 +246,7 @@ export class View extends ViewEventHandler {
 
 	private _computeGlyphMarginLanes(): GlyphMarginLanesModel {
 		const model = this._context.viewModel.model;
-		type Glyph = { range: Range; lane: GlyphMarginLane };
+		type Glyph = { range: Range; lane: GlyphMarginLane; persist?: boolean };
 		let glyphs: Glyph[] = [];
 		let maxLineNumber = 0;
 
@@ -254,7 +254,7 @@ export class View extends ViewEventHandler {
 		glyphs = glyphs.concat(model.getAllMarginDecorations().map((decoration) => {
 			const lane = decoration.options.glyphMargin?.position ?? GlyphMarginLane.Center;
 			maxLineNumber = Math.max(maxLineNumber, decoration.range.endLineNumber);
-			return { range: decoration.range, lane };
+			return { range: decoration.range, lane, persist: decoration.options.glyphMargin?.persistLane };
 		}));
 
 		// Add all glyph margin widgets
@@ -269,7 +269,7 @@ export class View extends ViewEventHandler {
 
 		const lanes = new GlyphMarginLanesModel(maxLineNumber);
 		for (const glyph of glyphs) {
-			lanes.push(glyph.lane, glyph.range);
+			lanes.push(glyph.lane, glyph.range, glyph.persist);
 		}
 
 		this._glyphMarginWidgets.updateLanesModel(lanes);

--- a/src/vs/editor/browser/view.ts
+++ b/src/vs/editor/browser/view.ts
@@ -56,6 +56,7 @@ import { GlyphMarginWidgets } from 'vs/editor/browser/viewParts/glyphMargin/glyp
 import { GlyphMarginLane } from 'vs/editor/common/model';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { CodeWindow } from 'vs/base/browser/window';
+import { GlyphMarginLanesModel } from 'vs/editor/browser/viewParts/glyphMargin/glyphLanesModel';
 
 
 export interface IContentWidgetData {
@@ -243,54 +244,37 @@ export class View extends ViewEventHandler {
 		this._pointerHandler = this._register(new PointerHandler(this._context, viewController, this._createPointerHandlerHelper()));
 	}
 
-	private _computeGlyphMarginLaneCount(): number {
+	private _computeGlyphMarginLanes(): GlyphMarginLanesModel {
 		const model = this._context.viewModel.model;
 		type Glyph = { range: Range; lane: GlyphMarginLane };
 		let glyphs: Glyph[] = [];
+		let maxLineNumber = 0;
 
 		// Add all margin decorations
 		glyphs = glyphs.concat(model.getAllMarginDecorations().map((decoration) => {
 			const lane = decoration.options.glyphMargin?.position ?? GlyphMarginLane.Center;
+			maxLineNumber = Math.max(maxLineNumber, decoration.range.endLineNumber);
 			return { range: decoration.range, lane };
 		}));
 
 		// Add all glyph margin widgets
 		glyphs = glyphs.concat(this._glyphMarginWidgets.getWidgets().map((widget) => {
 			const range = model.validateRange(widget.preference.range);
+			maxLineNumber = Math.max(maxLineNumber, range.endLineNumber);
 			return { range, lane: widget.preference.lane };
 		}));
 
 		// Sorted by their start position
 		glyphs.sort((a, b) => Range.compareRangesUsingStarts(a.range, b.range));
 
-		const maxLane = GlyphMarginLane.Right;
-		const lanes: (Range | undefined)[] = Array.from({ length: maxLane + 1 });
-		let requiredLanes = 1;
-
-		for (const decoration of glyphs) {
-			// assign only if the range of `decoration` ends after, which means it has a higher chance to overlap with the other lane
-			if (!lanes[decoration.lane] || Range.compareRangesUsingEnds(lanes[decoration.lane]!, decoration.range) < 0) {
-				lanes[decoration.lane] = decoration.range;
-			}
-
-			let requiredLanesHere = 0;
-			for (let i = 1; i <= maxLane; i++) {
-				const lane = lanes[i];
-				if (!lane || lane.endLineNumber < decoration.range.startLineNumber) {
-					lanes[i] = undefined;
-					continue;
-				}
-
-				requiredLanesHere++;
-			}
-
-			requiredLanes = Math.max(requiredLanes, requiredLanesHere);
-			if (requiredLanes === maxLane) {
-				return requiredLanes;
-			}
+		const lanes = new GlyphMarginLanesModel(maxLineNumber);
+		for (const glyph of glyphs) {
+			lanes.push(glyph.lane, glyph.range);
 		}
 
-		return requiredLanes;
+		this._glyphMarginWidgets.updateLanesModel(lanes);
+
+		return lanes;
 	}
 
 	private _createPointerHandlerHelper(): IPointerHandlerHelper {
@@ -485,7 +469,8 @@ export class View extends ViewEventHandler {
 			prepareRenderText: () => {
 				if (this._shouldRecomputeGlyphMarginLanes) {
 					this._shouldRecomputeGlyphMarginLanes = false;
-					this._context.configuration.setGlyphMarginDecorationLaneCount(this._computeGlyphMarginLaneCount());
+					const model = this._computeGlyphMarginLanes();
+					this._context.configuration.setGlyphMarginDecorationLaneCount(model.requiredLanes);
 				}
 				inputLatency.onRenderStart();
 			},

--- a/src/vs/editor/browser/viewParts/glyphMargin/glyphLanesModel.ts
+++ b/src/vs/editor/browser/viewParts/glyphMargin/glyphLanesModel.ts
@@ -1,0 +1,57 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Range } from 'vs/editor/common/core/range';
+import { GlyphMarginLane, IGlyphMarginLanesModel } from 'vs/editor/common/model';
+
+
+const MAX_LANE = GlyphMarginLane.Right;
+
+export class GlyphMarginLanesModel implements IGlyphMarginLanesModel {
+	private readonly lanes: Uint8Array;
+	private _requiredLanes = 1; // always render at least one lane
+
+	constructor(maxLine: number) {
+		this.lanes = new Uint8Array(Math.ceil((maxLine * MAX_LANE) / 8));
+	}
+
+	public get requiredLanes() {
+		return this._requiredLanes;
+	}
+
+	/** Adds a new range to the model. Assumes ranges are added in ascending order of line number. */
+	public push(lane: GlyphMarginLane, range: Range): void {
+		for (let i = range.startLineNumber; i <= range.endLineNumber; i++) {
+			const bit = (MAX_LANE * i) + (lane - 1);
+			this.lanes[bit >>> 3] |= (1 << (bit % 8));
+			this._requiredLanes = Math.max(this._requiredLanes, this.countAtLine(i));
+		}
+	}
+
+	public getLanesAtLine(lineNumber: number): GlyphMarginLane[] {
+		const lanes: GlyphMarginLane[] = [];
+		let bit = MAX_LANE * lineNumber;
+		for (let i = 0; i < MAX_LANE; i++) {
+			if (this.lanes[bit >>> 3] & (1 << (bit % 8))) {
+				lanes.push(i + 1);
+			}
+			bit++;
+		}
+
+		return lanes.length ? lanes : [GlyphMarginLane.Center];
+	}
+
+	private countAtLine(lineNumber: number): number {
+		let bit = MAX_LANE * lineNumber;
+		let count = 0;
+		for (let i = 0; i < MAX_LANE; i++) {
+			if (this.lanes[bit >>> 3] & (1 << (bit % 8))) {
+				count++;
+			}
+			bit++;
+		}
+		return count;
+	}
+}

--- a/src/vs/editor/browser/viewParts/glyphMargin/glyphMargin.ts
+++ b/src/vs/editor/browser/viewParts/glyphMargin/glyphMargin.ts
@@ -10,8 +10,10 @@ import { IGlyphMarginWidget, IGlyphMarginWidgetPosition } from 'vs/editor/browse
 import { DynamicViewOverlay } from 'vs/editor/browser/view/dynamicViewOverlay';
 import { RenderingContext, RestrictedRenderingContext } from 'vs/editor/browser/view/renderingContext';
 import { ViewPart } from 'vs/editor/browser/view/viewPart';
+import { GlyphMarginLanesModel } from 'vs/editor/browser/viewParts/glyphMargin/glyphLanesModel';
 import { EditorOption } from 'vs/editor/common/config/editorOptions';
 import { Range } from 'vs/editor/common/core/range';
+import { GlyphMarginLane, IGlyphMarginLanesModel } from 'vs/editor/common/model';
 import * as viewEvents from 'vs/editor/common/viewEvents';
 import { ViewContext } from 'vs/editor/common/viewModel/viewContext';
 
@@ -121,6 +123,7 @@ export class GlyphMarginWidgets extends ViewPart {
 
 	public domNode: FastDomNode<HTMLElement>;
 
+	private _lanesModel: IGlyphMarginLanesModel;
 	private _lineHeight: number;
 	private _glyphMargin: boolean;
 	private _glyphMarginLeft: number;
@@ -135,6 +138,7 @@ export class GlyphMarginWidgets extends ViewPart {
 	constructor(context: ViewContext) {
 		super(context);
 		this._context = context;
+		this._lanesModel = new GlyphMarginLanesModel(0);
 
 		const options = this._context.configuration.options;
 		const layoutInfo = options.get(EditorOption.layoutInfo);
@@ -246,6 +250,10 @@ export class GlyphMarginWidgets extends ViewPart {
 		}
 	}
 
+	public updateLanesModel(model: GlyphMarginLanesModel) {
+		this._lanesModel = model;
+	}
+
 	// --- end widget management
 
 	private _collectDecorationBasedGlyphRenderRequest(ctx: RenderingContext, requests: GlyphRenderRequest[]): void {
@@ -261,11 +269,12 @@ export class GlyphMarginWidgets extends ViewPart {
 
 			const startLineNumber = Math.max(d.range.startLineNumber, visibleStartLineNumber);
 			const endLineNumber = Math.min(d.range.endLineNumber, visibleEndLineNumber);
-			const lane = Math.min(d.options.glyphMargin?.position ?? 1, this._glyphMarginDecorationLaneCount);
+			const lane = d.options.glyphMargin?.position ?? GlyphMarginLane.Center;
 			const zIndex = d.options.zIndex ?? 0;
 
 			for (let lineNumber = startLineNumber; lineNumber <= endLineNumber; lineNumber++) {
-				requests.push(new DecorationBasedGlyphRenderRequest(lineNumber, lane, zIndex, glyphMarginClassName));
+				const laneIndex = this._lanesModel.getLanesAtLine(lineNumber).indexOf(lane);
+				requests.push(new DecorationBasedGlyphRenderRequest(lineNumber, laneIndex, zIndex, glyphMarginClassName));
 			}
 		}
 	}
@@ -284,8 +293,8 @@ export class GlyphMarginWidgets extends ViewPart {
 
 			// The widget is in the viewport, find a good line for it
 			const widgetLineNumber = Math.max(startLineNumber, visibleStartLineNumber);
-			const lane = Math.min(widget.preference.lane, this._glyphMarginDecorationLaneCount);
-			requests.push(new WidgetBasedGlyphRenderRequest(widgetLineNumber, lane, widget.preference.zIndex, widget));
+			const laneIndex = this._lanesModel.getLanesAtLine(widgetLineNumber).indexOf(widget.preference.lane);
+			requests.push(new WidgetBasedGlyphRenderRequest(widgetLineNumber, laneIndex, widget.preference.zIndex, widget));
 		}
 	}
 
@@ -300,7 +309,7 @@ export class GlyphMarginWidgets extends ViewPart {
 		// don't change this sort unless you understand `prepareRender` below.
 		requests.sort((a, b) => {
 			if (a.lineNumber === b.lineNumber) {
-				if (a.lane === b.lane) {
+				if (a.laneIndex === b.laneIndex) {
 					if (a.zIndex === b.zIndex) {
 						if (b.type === a.type) {
 							if (a.type === GlyphRenderRequestType.Decoration && b.type === GlyphRenderRequestType.Decoration) {
@@ -312,7 +321,7 @@ export class GlyphMarginWidgets extends ViewPart {
 					}
 					return b.zIndex - a.zIndex;
 				}
-				return a.lane - b.lane;
+				return a.laneIndex - b.laneIndex;
 			}
 			return a.lineNumber - b.lineNumber;
 		});
@@ -343,7 +352,7 @@ export class GlyphMarginWidgets extends ViewPart {
 			}
 
 			// Requests are sorted by lineNumber and lane, so we read all requests for this particular location
-			const requestsAtLocation = requests.takeWhile((el) => el.lineNumber === first.lineNumber && el.lane === first.lane);
+			const requestsAtLocation = requests.takeWhile((el) => el.lineNumber === first.lineNumber && el.laneIndex === first.laneIndex);
 			if (!requestsAtLocation || requestsAtLocation.length === 0) {
 				// not possible
 				break;
@@ -369,7 +378,7 @@ export class GlyphMarginWidgets extends ViewPart {
 				// widgets cannot be combined
 				winner.widget.renderInfo = {
 					lineNumber: winner.lineNumber,
-					lane: winner.lane,
+					laneIndex: winner.laneIndex,
 				};
 			}
 		}
@@ -397,7 +406,7 @@ export class GlyphMarginWidgets extends ViewPart {
 				widget.domNode.setDisplay('none');
 			} else {
 				const top = ctx.viewportData.relativeVerticalOffset[widget.renderInfo.lineNumber - ctx.viewportData.startLineNumber];
-				const left = this._glyphMarginLeft + (widget.renderInfo.lane - 1) * this._lineHeight;
+				const left = this._glyphMarginLeft + widget.renderInfo.laneIndex * this._lineHeight;
 
 				widget.domNode.setDisplay('block');
 				widget.domNode.setTop(top);
@@ -411,7 +420,7 @@ export class GlyphMarginWidgets extends ViewPart {
 		for (let i = 0; i < this._decorationGlyphsToRender.length; i++) {
 			const dec = this._decorationGlyphsToRender[i];
 			const top = ctx.viewportData.relativeVerticalOffset[dec.lineNumber - ctx.viewportData.startLineNumber];
-			const left = this._glyphMarginLeft + (dec.lane - 1) * this._lineHeight;
+			const left = this._glyphMarginLeft + dec.laneIndex * this._lineHeight;
 
 			let domNode: FastDomNode<HTMLElement>;
 			if (i < this._managedDomNodes.length) {
@@ -451,7 +460,7 @@ export interface IWidgetData {
 
 export interface IRenderInfo {
 	lineNumber: number;
-	lane: number;
+	laneIndex: number;
 }
 
 const enum GlyphRenderRequestType {
@@ -467,13 +476,13 @@ class DecorationBasedGlyphRenderRequest {
 
 	constructor(
 		public readonly lineNumber: number,
-		public readonly lane: number,
+		public readonly laneIndex: number,
 		public readonly zIndex: number,
 		public readonly className: string,
 	) { }
 
 	accept(combinedClassName: string): DecorationBasedGlyph {
-		return new DecorationBasedGlyph(this.lineNumber, this.lane, combinedClassName);
+		return new DecorationBasedGlyph(this.lineNumber, this.laneIndex, combinedClassName);
 	}
 }
 
@@ -485,7 +494,7 @@ class WidgetBasedGlyphRenderRequest {
 
 	constructor(
 		public readonly lineNumber: number,
-		public readonly lane: number,
+		public readonly laneIndex: number,
 		public readonly zIndex: number,
 		public readonly widget: IWidgetData,
 	) { }
@@ -496,7 +505,7 @@ type GlyphRenderRequest = DecorationBasedGlyphRenderRequest | WidgetBasedGlyphRe
 class DecorationBasedGlyph {
 	constructor(
 		public readonly lineNumber: number,
-		public readonly lane: number,
+		public readonly laneIndex: number,
 		public readonly combinedClassName: string
 	) { }
 }

--- a/src/vs/editor/common/model.ts
+++ b/src/vs/editor/common/model.ts
@@ -81,6 +81,12 @@ export interface IModelDecorationGlyphMarginOptions {
 	 * The position in the glyph margin.
 	 */
 	position: GlyphMarginLane;
+
+	/**
+	 * Whether the glyph margin lane in {@link position} should be rendered even
+	 * outside of this decoration's range.
+	 */
+	persistLane?: boolean;
 }
 
 /**

--- a/src/vs/editor/common/model.ts
+++ b/src/vs/editor/common/model.ts
@@ -43,6 +43,18 @@ export enum GlyphMarginLane {
 	Right = 3,
 }
 
+export interface IGlyphMarginLanesModel {
+	/**
+	 * The number of lanes that should be rendered in the editor.
+	 */
+	readonly requiredLanes: number;
+
+	/**
+	 * Gets the lanes that should be rendered starting at a given line number.
+	 */
+	getLanesAtLine(lineNumber: number): GlyphMarginLane[];
+}
+
 /**
  * Position in the minimap to render the decoration.
  */

--- a/src/vs/editor/common/model/textModel.ts
+++ b/src/vs/editor/common/model/textModel.ts
@@ -2204,9 +2204,11 @@ export class ModelDecorationOverviewRulerOptions extends DecorationOptions {
 
 export class ModelDecorationGlyphMarginOptions {
 	readonly position: model.GlyphMarginLane;
+	readonly persistLane: boolean | undefined;
 
 	constructor(options: model.IModelDecorationGlyphMarginOptions | null | undefined) {
 		this.position = options?.position ?? model.GlyphMarginLane.Center;
+		this.persistLane = options?.persistLane;
 	}
 }
 

--- a/src/vs/editor/test/browser/view/glyphLanesModel.test.ts
+++ b/src/vs/editor/test/browser/view/glyphLanesModel.test.ts
@@ -1,0 +1,63 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from 'vs/base/test/common/utils';
+import { GlyphMarginLanesModel, } from 'vs/editor/browser/viewParts/glyphMargin/glyphLanesModel';
+import { Range } from 'vs/editor/common/core/range';
+import { GlyphMarginLane } from 'vs/editor/common/model';
+
+suite('GlyphLanesModel', () => {
+	let model: GlyphMarginLanesModel;
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	const lineRange = (startLineNumber: number, endLineNumber: number) => new Range(startLineNumber, 1, endLineNumber, 1);
+	const assertLines = (fromLine: number, n: number, expected: GlyphMarginLane[][]) => {
+		const result: GlyphMarginLane[][] = [];
+		for (let i = 0; i < n; i++) {
+			result.push(model.getLanesAtLine(fromLine + i));
+		}
+		assert.deepStrictEqual(result, expected, `fromLine: ${fromLine}, n: ${n}`);
+	};
+
+	setup(() => {
+		model = new GlyphMarginLanesModel(10);
+	});
+
+	test('handles empty', () => {
+		assert.equal(model.requiredLanes, 1);
+		assertLines(1, 1, [
+			[GlyphMarginLane.Center],
+		]);
+	});
+
+	test('works with a single line range', () => {
+		model.push(GlyphMarginLane.Left, lineRange(2, 3));
+		assert.equal(model.requiredLanes, 1);
+		assertLines(1, 5, [
+			[GlyphMarginLane.Center], // 1
+			[GlyphMarginLane.Left], // 2
+			[GlyphMarginLane.Left], // 3
+			[GlyphMarginLane.Center], // 4
+			[GlyphMarginLane.Center], // 5
+		]);
+	});
+
+	test('handles overlaps', () => {
+		model.push(GlyphMarginLane.Left, lineRange(6, 9));
+		model.push(GlyphMarginLane.Right, lineRange(5, 7));
+		model.push(GlyphMarginLane.Center, lineRange(7, 8));
+		assert.equal(model.requiredLanes, 3);
+		assertLines(5, 6, [
+			[GlyphMarginLane.Right], // 5
+			[GlyphMarginLane.Left, GlyphMarginLane.Right], // 6
+			[GlyphMarginLane.Left, GlyphMarginLane.Center, GlyphMarginLane.Right], // 7
+			[GlyphMarginLane.Left, GlyphMarginLane.Center], // 8
+			[GlyphMarginLane.Left], // 9
+			[GlyphMarginLane.Center], // 10
+		]);
+	});
+});

--- a/src/vs/editor/test/browser/view/glyphLanesModel.test.ts
+++ b/src/vs/editor/test/browser/view/glyphLanesModel.test.ts
@@ -46,6 +46,18 @@ suite('GlyphLanesModel', () => {
 		]);
 	});
 
+	test('persists ranges', () => {
+		model.push(GlyphMarginLane.Left, lineRange(2, 3), true);
+		assert.equal(model.requiredLanes, 1);
+		assertLines(1, 5, [
+			[GlyphMarginLane.Left], // 1
+			[GlyphMarginLane.Left], // 2
+			[GlyphMarginLane.Left], // 3
+			[GlyphMarginLane.Left], // 4
+			[GlyphMarginLane.Left], // 5
+		]);
+	});
+
 	test('handles overlaps', () => {
 		model.push(GlyphMarginLane.Left, lineRange(6, 9));
 		model.push(GlyphMarginLane.Right, lineRange(5, 7));

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -1584,6 +1584,17 @@ declare namespace monaco.editor {
 		Right = 3
 	}
 
+	export interface IGlyphMarginLanesModel {
+		/**
+		 * The number of lanes that should be rendered in the editor.
+		 */
+		readonly requiredLanes: number;
+		/**
+		 * Gets the lanes that should be rendered starting at a given line number.
+		 */
+		getLanesAtLine(lineNumber: number): GlyphMarginLane[];
+	}
+
 	/**
 	 * Position in the minimap to render the decoration.
 	 */

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -1621,6 +1621,11 @@ declare namespace monaco.editor {
 		 * The position in the glyph margin.
 		 */
 		position: GlyphMarginLane;
+		/**
+		 * Whether the glyph margin lane in {@link position} should be rendered even
+		 * outside of this decoration's range.
+		 */
+		persistLane?: boolean;
 	}
 
 	/**

--- a/src/vs/workbench/contrib/testing/browser/codeCoverageDecorations.ts
+++ b/src/vs/workbench/contrib/testing/browser/codeCoverageDecorations.ts
@@ -67,7 +67,7 @@ export class CodeCoverageDecorations extends Disposable implements IEditorContri
 					const cls = detail.count > 0 ? 'coverage-deco-hit' : 'coverage-deco-miss';
 					decorations.push(e.addDecoration(range, {
 						showIfCollapsed: false,
-						glyphMargin: { position: GlyphMarginLane.Left },
+						glyphMargin: { position: GlyphMarginLane.Left, persistLane: true },
 						description: localize('testing.hitCount', 'Hit count: {0}', detail.count),
 						glyphMarginClassName: `coverage-deco-gutter ${cls}`,
 						className: `coverage-deco-inline ${cls}`,
@@ -79,7 +79,7 @@ export class CodeCoverageDecorations extends Disposable implements IEditorContri
 							const branchRange = location instanceof Range ? location : Range.fromPositions(location);
 							decorations.push(e.addDecoration(branchRange, {
 								showIfCollapsed: false,
-								glyphMargin: { position: GlyphMarginLane.Left },
+								glyphMargin: { position: GlyphMarginLane.Left, persistLane: true },
 								description: localize('testing.hitCount', 'Hit count: {0}', detail.count),
 								glyphMarginClassName: `coverage-deco-gutter ${cls}`,
 								className: `coverage-deco-inline ${cls}`,

--- a/src/vs/workbench/contrib/testing/browser/testing.contribution.ts
+++ b/src/vs/workbench/contrib/testing/browser/testing.contribution.ts
@@ -48,6 +48,7 @@ import { ITestCoverageService, TestCoverageService } from 'vs/workbench/contrib/
 import { TestCoverageView } from 'vs/workbench/contrib/testing/browser/testCoverageView';
 import { ExplorerExtensions, IExplorerFileContributionRegistry } from 'vs/workbench/contrib/files/browser/explorerFileContrib';
 import { ExplorerTestCoverageBars } from 'vs/workbench/contrib/testing/browser/testCoverageBars';
+// import { CodeCoverageDecorations } from 'vs/workbench/contrib/testing/browser/codeCoverageDecorations';
 
 registerSingleton(ITestService, TestService, InstantiationType.Delayed);
 registerSingleton(ITestResultStorage, TestResultStorage, InstantiationType.Delayed);
@@ -143,6 +144,7 @@ Registry.as<IWorkbenchContributionsRegistry>(WorkbenchExtensions.Workbench).regi
 
 registerEditorContribution(Testing.OutputPeekContributionId, TestingOutputPeekController, EditorContributionInstantiation.AfterFirstRender);
 registerEditorContribution(Testing.DecorationsContributionId, TestingDecorations, EditorContributionInstantiation.AfterFirstRender);
+// registerEditorContribution(Testing.CoverageDecorationsContributionId, CodeCoverageDecorations, EditorContributionInstantiation.Eventually);
 
 CommandsRegistry.registerCommand({
 	id: '_revealTestInExplorer',


### PR DESCRIPTION
In my previous PR #202048, I added another glyph margin lane. However
I didn't realize in some cases the support I added was incomplete since
the rendering code did not fully handle an unbounded number of lanes.

Also, I noticed in existing issues with hover and click handling because
some parts of VS Code still assume there's at most a single glyph widget
visible. It is hard to determine which glyph widget is interacted with
without checking what classes are applied to the glyph element, which
is what most existing code does. And we probably shouldn't do that in
e.g. the MouseHandler to determine what glyph is being clicked on.

So in this PR I added a `GlyphMarginLanesModel` that contains the
information necessary for rendering. I also want to expose it in a place
that the MouseHandler or MouseTarget can get at, but I wasn't sure the
best way to do that, any suggestions @alexdima?

Implementation-wise I opted for a flag Uint8Array. A 1024 line file with
decorations on the last line, it would take 384 bytes to hold decoration
positions. I also tried out a Range array based implementation, but I
think this is faster (for cases where there are lots of decorations)
and much simpler, in exchange for higher memory usage in pathological cases
(very long files with decorations near the end.)

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
