### PR TITLE
editor: include lane in GUTTER_GLYPH_MARGIN hover events

### DIFF
--- a/src/vs/editor/browser/controller/mouseTarget.ts
+++ b/src/vs/editor/browser/controller/mouseTarget.ts
@@ -20,6 +20,7 @@ import * as dom from 'vs/base/browser/dom';
 import { AtomicTabMoveOperations, Direction } from 'vs/editor/common/cursor/cursorAtomicMoveOperations';
 import { PositionAffinity } from 'vs/editor/common/model';
 import { InjectedText } from 'vs/editor/common/modelLineProjectionData';
+import { Mutable } from 'vs/base/common/types';
 
 const enum HitTestResultType {
 	Unknown,
@@ -672,7 +673,7 @@ export class MouseTargetFactory {
 			const res = ctx.getFullLineRangeAtCoord(request.mouseVerticalOffset);
 			const pos = res.range.getStartPosition();
 			let offset = Math.abs(request.relativePos.x);
-			const detail: IMouseTargetMarginData = {
+			const detail: Mutable<IMouseTargetMarginData> = {
 				isAfterLines: res.isAfterLines,
 				glyphMarginLeft: ctx.layoutInfo.glyphMarginLeft,
 				glyphMarginWidth: ctx.layoutInfo.glyphMarginWidth,
@@ -684,6 +685,9 @@ export class MouseTargetFactory {
 
 			if (offset <= ctx.layoutInfo.glyphMarginWidth) {
 				// On the glyph margin
+				const modelCoordinate = ctx.viewModel.coordinatesConverter.convertViewPositionToModelPosition(res.range.getStartPosition());
+				const lanes = ctx.viewModel.glyphLanes.getLanesAtLine(modelCoordinate.lineNumber);
+				detail.glyphMarginLane = lanes[Math.floor(offset / ctx.lineHeight)];
 				return request.fulfillMargin(MouseTargetType.GUTTER_GLYPH_MARGIN, pos, res.range, detail);
 			}
 			offset -= ctx.layoutInfo.glyphMarginWidth;

--- a/src/vs/editor/browser/editorBrowser.ts
+++ b/src/vs/editor/browser/editorBrowser.ts
@@ -405,6 +405,7 @@ export interface IMouseTargetMarginData {
 	readonly isAfterLines: boolean;
 	readonly glyphMarginLeft: number;
 	readonly glyphMarginWidth: number;
+	readonly glyphMarginLane?: GlyphMarginLane;
 	readonly lineNumbersWidth: number;
 	readonly offsetX: number;
 }

--- a/src/vs/editor/browser/viewParts/glyphMargin/glyphLanesModel.ts
+++ b/src/vs/editor/browser/viewParts/glyphMargin/glyphLanesModel.ts
@@ -15,7 +15,7 @@ export class GlyphMarginLanesModel implements IGlyphMarginLanesModel {
 	private _requiredLanes = 1; // always render at least one lane
 
 	constructor(maxLine: number) {
-		this.lanes = new Uint8Array(Math.ceil((maxLine * MAX_LANE) / 8));
+		this.lanes = new Uint8Array(Math.ceil(((maxLine + 1) * MAX_LANE) / 8));
 	}
 
 	public get requiredLanes() {

--- a/src/vs/editor/browser/viewParts/glyphMargin/glyphMargin.ts
+++ b/src/vs/editor/browser/viewParts/glyphMargin/glyphMargin.ts
@@ -10,11 +10,10 @@ import { IGlyphMarginWidget, IGlyphMarginWidgetPosition } from 'vs/editor/browse
 import { DynamicViewOverlay } from 'vs/editor/browser/view/dynamicViewOverlay';
 import { RenderingContext, RestrictedRenderingContext } from 'vs/editor/browser/view/renderingContext';
 import { ViewPart } from 'vs/editor/browser/view/viewPart';
-import { GlyphMarginLanesModel } from 'vs/editor/browser/viewParts/glyphMargin/glyphLanesModel';
 import { EditorOption } from 'vs/editor/common/config/editorOptions';
 import { Position } from 'vs/editor/common/core/position';
 import { Range } from 'vs/editor/common/core/range';
-import { GlyphMarginLane, IGlyphMarginLanesModel } from 'vs/editor/common/model';
+import { GlyphMarginLane } from 'vs/editor/common/model';
 import * as viewEvents from 'vs/editor/common/viewEvents';
 import { ViewContext } from 'vs/editor/common/viewModel/viewContext';
 
@@ -124,7 +123,6 @@ export class GlyphMarginWidgets extends ViewPart {
 
 	public domNode: FastDomNode<HTMLElement>;
 
-	private _lanesModel: IGlyphMarginLanesModel;
 	private _lineHeight: number;
 	private _glyphMargin: boolean;
 	private _glyphMarginLeft: number;
@@ -139,7 +137,6 @@ export class GlyphMarginWidgets extends ViewPart {
 	constructor(context: ViewContext) {
 		super(context);
 		this._context = context;
-		this._lanesModel = new GlyphMarginLanesModel(0);
 
 		const options = this._context.configuration.options;
 		const layoutInfo = options.get(EditorOption.layoutInfo);
@@ -251,10 +248,6 @@ export class GlyphMarginWidgets extends ViewPart {
 		}
 	}
 
-	public updateLanesModel(model: GlyphMarginLanesModel) {
-		this._lanesModel = model;
-	}
-
 	// --- end widget management
 
 	private _collectDecorationBasedGlyphRenderRequest(ctx: RenderingContext, requests: GlyphRenderRequest[]): void {
@@ -275,7 +268,7 @@ export class GlyphMarginWidgets extends ViewPart {
 
 			for (let lineNumber = startLineNumber; lineNumber <= endLineNumber; lineNumber++) {
 				const modelPosition = this._context.viewModel.coordinatesConverter.convertViewPositionToModelPosition(new Position(lineNumber, 0));
-				const laneIndex = this._lanesModel.getLanesAtLine(modelPosition.lineNumber).indexOf(lane);
+				const laneIndex = this._context.viewModel.glyphLanes.getLanesAtLine(modelPosition.lineNumber).indexOf(lane);
 				requests.push(new DecorationBasedGlyphRenderRequest(lineNumber, laneIndex, zIndex, glyphMarginClassName));
 			}
 		}
@@ -296,7 +289,7 @@ export class GlyphMarginWidgets extends ViewPart {
 			// The widget is in the viewport, find a good line for it
 			const widgetLineNumber = Math.max(startLineNumber, visibleStartLineNumber);
 			const modelPosition = this._context.viewModel.coordinatesConverter.convertViewPositionToModelPosition(new Position(widgetLineNumber, 0));
-			const laneIndex = this._lanesModel.getLanesAtLine(modelPosition.lineNumber).indexOf(widget.preference.lane);
+			const laneIndex = this._context.viewModel.glyphLanes.getLanesAtLine(modelPosition.lineNumber).indexOf(widget.preference.lane);
 			requests.push(new WidgetBasedGlyphRenderRequest(widgetLineNumber, laneIndex, widget.preference.zIndex, widget));
 		}
 	}

--- a/src/vs/editor/browser/viewParts/glyphMargin/glyphMargin.ts
+++ b/src/vs/editor/browser/viewParts/glyphMargin/glyphMargin.ts
@@ -12,6 +12,7 @@ import { RenderingContext, RestrictedRenderingContext } from 'vs/editor/browser/
 import { ViewPart } from 'vs/editor/browser/view/viewPart';
 import { GlyphMarginLanesModel } from 'vs/editor/browser/viewParts/glyphMargin/glyphLanesModel';
 import { EditorOption } from 'vs/editor/common/config/editorOptions';
+import { Position } from 'vs/editor/common/core/position';
 import { Range } from 'vs/editor/common/core/range';
 import { GlyphMarginLane, IGlyphMarginLanesModel } from 'vs/editor/common/model';
 import * as viewEvents from 'vs/editor/common/viewEvents';
@@ -273,7 +274,8 @@ export class GlyphMarginWidgets extends ViewPart {
 			const zIndex = d.options.zIndex ?? 0;
 
 			for (let lineNumber = startLineNumber; lineNumber <= endLineNumber; lineNumber++) {
-				const laneIndex = this._lanesModel.getLanesAtLine(lineNumber).indexOf(lane);
+				const modelPosition = this._context.viewModel.coordinatesConverter.convertViewPositionToModelPosition(new Position(lineNumber, 0));
+				const laneIndex = this._lanesModel.getLanesAtLine(modelPosition.lineNumber).indexOf(lane);
 				requests.push(new DecorationBasedGlyphRenderRequest(lineNumber, laneIndex, zIndex, glyphMarginClassName));
 			}
 		}
@@ -293,7 +295,8 @@ export class GlyphMarginWidgets extends ViewPart {
 
 			// The widget is in the viewport, find a good line for it
 			const widgetLineNumber = Math.max(startLineNumber, visibleStartLineNumber);
-			const laneIndex = this._lanesModel.getLanesAtLine(widgetLineNumber).indexOf(widget.preference.lane);
+			const modelPosition = this._context.viewModel.coordinatesConverter.convertViewPositionToModelPosition(new Position(widgetLineNumber, 0));
+			const laneIndex = this._lanesModel.getLanesAtLine(modelPosition.lineNumber).indexOf(widget.preference.lane);
 			requests.push(new WidgetBasedGlyphRenderRequest(widgetLineNumber, laneIndex, widget.preference.zIndex, widget));
 		}
 	}

--- a/src/vs/editor/common/model.ts
+++ b/src/vs/editor/common/model.ts
@@ -53,6 +53,18 @@ export interface IGlyphMarginLanesModel {
 	 * Gets the lanes that should be rendered starting at a given line number.
 	 */
 	getLanesAtLine(lineNumber: number): GlyphMarginLane[];
+
+	/**
+	 * Resets the model and ensures it can contain at least `maxLine` lines.
+	 */
+	reset(maxLine: number): void;
+
+	/**
+	 * Registers that a lane should be visible at the Range in the model.
+	 * @param persist - if true, notes that the lane should always be visible,
+	 * even on lines where there's no specific request for that lane.
+	 */
+	push(lane: GlyphMarginLane, range: Range, persist?: boolean): void;
 }
 
 /**

--- a/src/vs/editor/common/viewModel.ts
+++ b/src/vs/editor/common/viewModel.ts
@@ -12,7 +12,7 @@ import { CursorConfiguration, CursorState, EditOperationType, IColumnSelectData,
 import { CursorChangeReason } from 'vs/editor/common/cursorEvents';
 import { INewScrollPosition, ScrollType } from 'vs/editor/common/editorCommon';
 import { EditorTheme } from 'vs/editor/common/editorTheme';
-import { EndOfLinePreference, IModelDecorationOptions, ITextModel, PositionAffinity } from 'vs/editor/common/model';
+import { EndOfLinePreference, IGlyphMarginLanesModel, IModelDecorationOptions, ITextModel, PositionAffinity } from 'vs/editor/common/model';
 import { ILineBreaksComputer, InjectedText } from 'vs/editor/common/modelLineProjectionData';
 import { BracketGuideOptions, IActiveIndentGuideInfo, IndentGuide } from 'vs/editor/common/textModelGuides';
 import { IViewLineTokens } from 'vs/editor/common/tokens/lineTokens';
@@ -28,6 +28,8 @@ export interface IViewModel extends ICursorSimpleModel {
 	readonly viewLayout: IViewLayout;
 
 	readonly cursorConfig: CursorConfiguration;
+
+	readonly glyphLanes: IGlyphMarginLanesModel;
 
 	addViewEventHandler(eventHandler: ViewEventHandler): void;
 	removeViewEventHandler(eventHandler: ViewEventHandler): void;

--- a/src/vs/editor/common/viewModel/glyphLanesModel.ts
+++ b/src/vs/editor/common/viewModel/glyphLanesModel.ts
@@ -10,7 +10,7 @@ import { GlyphMarginLane, IGlyphMarginLanesModel } from 'vs/editor/common/model'
 const MAX_LANE = GlyphMarginLane.Right;
 
 export class GlyphMarginLanesModel implements IGlyphMarginLanesModel {
-	private readonly lanes: Uint8Array;
+	private lanes: Uint8Array;
 	private persist = 0;
 	private _requiredLanes = 1; // always render at least one lane
 
@@ -18,11 +18,20 @@ export class GlyphMarginLanesModel implements IGlyphMarginLanesModel {
 		this.lanes = new Uint8Array(Math.ceil(((maxLine + 1) * MAX_LANE) / 8));
 	}
 
+	public reset(maxLine: number) {
+		const bytes = Math.ceil(((maxLine + 1) * MAX_LANE) / 8);
+		if (this.lanes.length < bytes) {
+			this.lanes = new Uint8Array(bytes);
+		} else {
+			this.lanes.fill(0);
+		}
+		this._requiredLanes = 1;
+	}
+
 	public get requiredLanes() {
 		return this._requiredLanes;
 	}
 
-	/** Adds a new range to the model. Assumes ranges are added in ascending order of line number. */
 	public push(lane: GlyphMarginLane, range: Range, persist?: boolean): void {
 		if (persist) {
 			this.persist |= (1 << (lane - 1));

--- a/src/vs/editor/common/viewModel/viewModelImpl.ts
+++ b/src/vs/editor/common/viewModel/viewModelImpl.ts
@@ -19,7 +19,7 @@ import { Range } from 'vs/editor/common/core/range';
 import { ISelection, Selection } from 'vs/editor/common/core/selection';
 import { ICommand, ICursorState, IViewState, ScrollType } from 'vs/editor/common/editorCommon';
 import { IEditorConfiguration } from 'vs/editor/common/config/editorConfiguration';
-import { EndOfLinePreference, IAttachedView, ICursorStateComputer, IIdentifiedSingleEditOperation, ITextModel, PositionAffinity, TrackedRangeStickiness } from 'vs/editor/common/model';
+import { EndOfLinePreference, IAttachedView, ICursorStateComputer, IGlyphMarginLanesModel, IIdentifiedSingleEditOperation, ITextModel, PositionAffinity, TrackedRangeStickiness } from 'vs/editor/common/model';
 import { IActiveIndentGuideInfo, BracketGuideOptions, IndentGuide } from 'vs/editor/common/textModelGuides';
 import { ModelDecorationMinimapOptions, ModelDecorationOptions, ModelDecorationOverviewRulerOptions } from 'vs/editor/common/model/textModel';
 import * as textModelEvents from 'vs/editor/common/textModelEvents';
@@ -39,6 +39,7 @@ import { ViewModelDecorations } from 'vs/editor/common/viewModel/viewModelDecora
 import { FocusChangedEvent, HiddenAreasChangedEvent, ModelContentChangedEvent, ModelDecorationsChangedEvent, ModelLanguageChangedEvent, ModelLanguageConfigurationChangedEvent, ModelOptionsChangedEvent, ModelTokensChangedEvent, OutgoingViewModelEvent, ReadOnlyEditAttemptEvent, ScrollChangedEvent, ViewModelEventDispatcher, ViewModelEventsCollector, ViewZonesChangedEvent } from 'vs/editor/common/viewModelEventDispatcher';
 import { IViewModelLines, ViewModelLinesFromModelAsIs, ViewModelLinesFromProjectedModel } from 'vs/editor/common/viewModel/viewModelLines';
 import { IThemeService } from 'vs/platform/theme/common/themeService';
+import { GlyphMarginLanesModel } from 'vs/editor/common/viewModel/glyphLanesModel';
 
 const USE_IDENTITY_LINES_COLLECTION = true;
 
@@ -58,6 +59,7 @@ export class ViewModel extends Disposable implements IViewModel {
 	public readonly viewLayout: ViewLayout;
 	private readonly _cursor: CursorsController;
 	private readonly _decorations: ViewModelDecorations;
+	public readonly glyphLanes: IGlyphMarginLanesModel;
 
 	constructor(
 		editorId: number,
@@ -81,6 +83,7 @@ export class ViewModel extends Disposable implements IViewModel {
 		this._updateConfigurationViewLineCount = this._register(new RunOnceScheduler(() => this._updateConfigurationViewLineCountNow(), 0));
 		this._hasFocus = false;
 		this._viewportStart = ViewportStart.create(this.model);
+		this.glyphLanes = new GlyphMarginLanesModel(0);
 
 		if (USE_IDENTITY_LINES_COLLECTION && this.model.isTooLargeForTokenization()) {
 

--- a/src/vs/editor/contrib/hover/browser/hover.ts
+++ b/src/vs/editor/contrib/hover/browser/hover.ts
@@ -294,10 +294,10 @@ export class HoverController extends Disposable implements IEditorContribution {
 			return;
 		}
 
-		if (target.type === MouseTargetType.GUTTER_GLYPH_MARGIN && target.position) {
+		if (target.type === MouseTargetType.GUTTER_GLYPH_MARGIN && target.position && target.detail.glyphMarginLane) {
 			this._contentWidget?.hide();
 			const glyphWidget = this._getOrCreateGlyphWidget();
-			glyphWidget.startShowingAt(target.position.lineNumber);
+			glyphWidget.startShowingAt(target.position.lineNumber, target.detail.glyphMarginLane);
 			return;
 		}
 		if (_sticky) {

--- a/src/vs/editor/test/common/viewModel/glyphLanesModel.test.ts
+++ b/src/vs/editor/test/common/viewModel/glyphLanesModel.test.ts
@@ -5,7 +5,7 @@
 
 import * as assert from 'assert';
 import { ensureNoDisposablesAreLeakedInTestSuite } from 'vs/base/test/common/utils';
-import { GlyphMarginLanesModel, } from 'vs/editor/browser/viewParts/glyphMargin/glyphLanesModel';
+import { GlyphMarginLanesModel, } from 'vs/editor/common/viewModel/glyphLanesModel';
 import { Range } from 'vs/editor/common/core/range';
 import { GlyphMarginLane } from 'vs/editor/common/model';
 

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -1593,6 +1593,16 @@ declare namespace monaco.editor {
 		 * Gets the lanes that should be rendered starting at a given line number.
 		 */
 		getLanesAtLine(lineNumber: number): GlyphMarginLane[];
+		/**
+		 * Resets the model and ensures it can contain at least `maxLine` lines.
+		 */
+		reset(maxLine: number): void;
+		/**
+		 * Registers that a lane should be visible at the Range in the model.
+		 * @param persist - if true, notes that the lane should always be visible,
+		 * even on lines where there's no specific request for that lane.
+		 */
+		push(lane: GlyphMarginLane, range: Range, persist?: boolean): void;
 	}
 
 	/**
@@ -5464,6 +5474,7 @@ declare namespace monaco.editor {
 		readonly isAfterLines: boolean;
 		readonly glyphMarginLeft: number;
 		readonly glyphMarginWidth: number;
+		readonly glyphMarginLane?: GlyphMarginLane;
 		readonly lineNumbersWidth: number;
 		readonly offsetX: number;
 	}

--- a/src/vs/workbench/contrib/testing/browser/testingDecorations.ts
+++ b/src/vs/workbench/contrib/testing/browser/testingDecorations.ts
@@ -25,7 +25,7 @@ import { EditorOption } from 'vs/editor/common/config/editorOptions';
 import { overviewRulerError, overviewRulerInfo } from 'vs/editor/common/core/editorColorRegistry';
 import { IRange } from 'vs/editor/common/core/range';
 import { IEditorContribution } from 'vs/editor/common/editorCommon';
-import { IModelDeltaDecoration, ITextModel, OverviewRulerLane, TrackedRangeStickiness } from 'vs/editor/common/model';
+import { GlyphMarginLane, IModelDeltaDecoration, ITextModel, OverviewRulerLane, TrackedRangeStickiness } from 'vs/editor/common/model';
 import { IModelService } from 'vs/editor/common/services/model';
 import { localize } from 'vs/nls';
 import { createAndFillInContextMenuActions } from 'vs/platform/actions/browser/menuEntryActionViewItem';
@@ -56,6 +56,7 @@ import { TestUriType, buildTestUri, parseTestUri } from 'vs/workbench/contrib/te
 
 const MAX_INLINE_MESSAGE_LENGTH = 128;
 const MAX_TESTS_IN_SUBMENU = 30;
+const GLYPH_MARGIN_LANE = GlyphMarginLane.Center;
 
 function isOriginalInDiffEditor(codeEditorService: ICodeEditorService, codeEditor: ICodeEditor): boolean {
 	const diffEditors = codeEditorService.listDiffEditors();
@@ -586,6 +587,7 @@ const createRunTestDecoration = (tests: readonly IncrementalTestCollectionItem[]
 
 				return hoverMessage;
 			},
+			glyphMargin: { position: GLYPH_MARGIN_LANE },
 			glyphMarginClassName,
 			stickiness: TrackedRangeStickiness.NeverGrowsWhenTypingAtEdges,
 			zIndex: 10000,
@@ -741,6 +743,7 @@ abstract class RunTestDecoration {
 	/** @inheritdoc */
 	public click(e: IEditorMouseEvent): boolean {
 		if (e.target.type !== MouseTargetType.GUTTER_GLYPH_MARGIN
+			|| e.target.detail.glyphMarginLane !== GLYPH_MARGIN_LANE
 			// handled by editor gutter context menu
 			|| e.event.rightButton
 			|| isMacintosh && e.event.leftButton && e.event.ctrlKey


### PR DESCRIPTION
Also fixes handling of testing clicks and margin hovers which were not
aware of multiple lanes. Hover messages are now shown correctly and
tests no longer run if e.g. a breakpoint decoration on the same line is
clicked.

Fixes handling of decorations when word wrap is on as well.

Note sure if this was the best way to do this, let me know.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
