### PR TITLE
`onDidChangeEmmiter` fires constantly when it shouldn't

### DIFF
--- a/extensions/html-language-features/client/src/languageParticipants.ts
+++ b/extensions/html-language-features/client/src/languageParticipants.ts
@@ -55,7 +55,7 @@ export function getLanguageParticipants(): LanguageParticipants {
 				}
 			}
 		}
-		return !isEqualSet(languages, oldLanguages) || !isEqualSet(oldLanguages, oldAutoInsert);
+		return !isEqualSet(languages, oldLanguages) || !isEqualSet(autoInsert, oldAutoInsert);
 	}
 	update();
 


### PR DESCRIPTION
It was checking against the wrong variable