### PR TITLE
fix: terminal renaming not functioning as expected in editor area

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminalActions.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalActions.ts
@@ -1902,7 +1902,9 @@ async function focusActiveTerminal(instance: ITerminalInstance, c: ITerminalServ
 
 async function renameWithQuickPick(c: ITerminalServicesCollection, accessor: ServicesAccessor, resource?: unknown) {
 	let instance: ITerminalInstance | undefined = resource as ITerminalInstance;
-	if (!instance) {
+	// Check if the 'instance' does not exist or if 'instance.rename' is not defined
+	if (!instance || !instance?.rename) {
+		// If not, obtain the resource instance using 'getResourceOrActiveInstance'
 		instance = getResourceOrActiveInstance(c, resource);
 	}
 


### PR DESCRIPTION
Fixes #202267

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

In the 'renameWithQuickPick' function, added a condition to check if 'instance' is falsy or if 'instance.rename' is not defined before attempting to call it. This ensures that the 'rename' method is available on 'instance' before execution, preventing potential errors when 'resource' might not have the 'rename' property.

https://github.com/microsoft/vscode/assets/17526893/bdc993e2-dcc4-4162-975e-c7bd56b99d75

