### PR TITLE
Revert autoclosing of ```` ``` ```` in md

### DIFF
--- a/extensions/markdown-basics/language-configuration.json
+++ b/extensions/markdown-basics/language-configuration.json
@@ -46,10 +46,6 @@
 			"open": "`",
 			"close": "`"
 		},
-		{
-			"open": "```",
-			"close": "```"
-		},
 	],
 	"surroundingPairs": [
 		[


### PR DESCRIPTION
Fixes #192676

Turns out to be more annoying than the value it provides

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
