### PR TITLE
highlight fixable errors when hovering/selecting code action

### DIFF
--- a/src/vs/editor/contrib/codeAction/browser/codeAction.ts
+++ b/src/vs/editor/contrib/codeAction/browser/codeAction.ts
@@ -133,7 +133,7 @@ export async function getCodeActions(
 			const filteredActions = (providedCodeActions?.actions || []).filter(action => action && filtersAction(filter, action));
 			const documentation = getDocumentationFromProvider(provider, filteredActions, filter.include);
 			return {
-				actions: filteredActions.map(action => new CodeActionItem(action, provider)),
+				actions: filteredActions.map(action => new CodeActionItem(action, provider, true)),
 				documentation
 			};
 		} catch (err) {

--- a/src/vs/editor/contrib/codeAction/browser/codeAction.ts
+++ b/src/vs/editor/contrib/codeAction/browser/codeAction.ts
@@ -133,7 +133,7 @@ export async function getCodeActions(
 			const filteredActions = (providedCodeActions?.actions || []).filter(action => action && filtersAction(filter, action));
 			const documentation = getDocumentationFromProvider(provider, filteredActions, filter.include);
 			return {
-				actions: filteredActions.map(action => new CodeActionItem(action, provider, true)),
+				actions: filteredActions.map(action => new CodeActionItem(action, provider)),
 				documentation
 			};
 		} catch (err) {

--- a/src/vs/editor/contrib/codeAction/browser/codeActionController.ts
+++ b/src/vs/editor/contrib/codeAction/browser/codeActionController.ts
@@ -279,7 +279,7 @@ export class CodeActionController extends Disposable implements IEditorContribut
 				return { canPreview: !!action.action.edit?.edits.length };
 			},
 			onFocus: (action: CodeActionItem | undefined) => {
-				if (action && action.highlightRange && action.action.diagnostics) {
+				if (action && action.action.diagnostics) {
 					currentDecorations.clear();
 					const decorations: IModelDeltaDecoration[] = action.action.diagnostics.map(diagnostic => ({ range: diagnostic, options: CodeActionController.DECORATION }));
 					currentDecorations.set(decorations);

--- a/src/vs/editor/contrib/codeAction/browser/codeActionController.ts
+++ b/src/vs/editor/contrib/codeAction/browser/codeActionController.ts
@@ -280,7 +280,8 @@ export class CodeActionController extends Disposable implements IEditorContribut
 			},
 			onFocus: (action: CodeActionItem | undefined) => {
 				if (action && action.highlightRange && action.action.diagnostics) {
-					const decorations: IModelDeltaDecoration[] = [{ range: action.action.diagnostics[0], options: CodeActionController.DECORATION }];
+					currentDecorations.clear();
+					const decorations: IModelDeltaDecoration[] = action.action.diagnostics.map(diagnostic => ({ range: diagnostic, options: CodeActionController.DECORATION }));
 					currentDecorations.set(decorations);
 					const diagnostic = action.action.diagnostics[0];
 					const selectionText = this._editor.getModel()?.getWordAtPosition({ lineNumber: diagnostic.startLineNumber, column: diagnostic.startColumn })?.word;

--- a/src/vs/editor/contrib/codeAction/browser/codeActionModel.ts
+++ b/src/vs/editor/contrib/codeAction/browser/codeActionModel.ts
@@ -24,6 +24,8 @@ import { IConfigurationService } from 'vs/platform/configuration/common/configur
 
 export const SUPPORTED_CODE_ACTIONS = new RawContextKey<string>('supportedCodeAction', '');
 
+export const APPLY_FIX_ALL_COMMAND_ID = '_typescript.applyFixAllCodeAction';
+
 type TriggeredCodeAction = {
 	readonly selection: Selection;
 	readonly trigger: CodeActionTrigger;
@@ -237,7 +239,7 @@ export class CodeActionModel extends Disposable {
 						const allMarkers = this._markerService.read({ resource: model.uri });
 						if (foundQuickfix) {
 							for (const action of codeActionSet.validActions) {
-								if (action.action.command?.arguments?.some(arg => typeof arg === 'string' && arg.includes('_typescript.applyFixAllCodeAction'))) {
+								if (action.action.command?.arguments?.some(arg => typeof arg === 'string' && arg.includes(APPLY_FIX_ALL_COMMAND_ID))) {
 									action.action.diagnostics = [...allMarkers.filter(marker => marker.relatedInformation)];
 								}
 							}
@@ -271,7 +273,7 @@ export class CodeActionModel extends Disposable {
 
 										if (actionsAtMarker.validActions.length !== 0) {
 											for (const action of actionsAtMarker.validActions) {
-												if (action.action.command?.arguments?.some(arg => typeof arg === 'string' && arg.includes('_typescript.applyFixAllCodeAction'))) {
+												if (action.action.command?.arguments?.some(arg => typeof arg === 'string' && arg.includes(APPLY_FIX_ALL_COMMAND_ID))) {
 													action.action.diagnostics = [...allMarkers.filter(marker => marker.relatedInformation)];
 												}
 											}

--- a/src/vs/editor/contrib/codeAction/browser/codeActionModel.ts
+++ b/src/vs/editor/contrib/codeAction/browser/codeActionModel.ts
@@ -274,17 +274,6 @@ export class CodeActionModel extends Disposable {
 												if (action.action.command?.arguments?.some(arg => typeof arg === 'string' && arg.includes('_typescript.applyFixAllCodeAction'))) {
 													action.action.diagnostics = [...allMarkers.filter(marker => marker.relatedInformation)];
 												}
-
-												if (codeActionSet.allActions.length === 0) {
-													allCodeActions.push(...actionsAtMarker.allActions);
-												}
-
-												// Already filtered through to only get quickfixes, so no need to filter again.
-												if (Math.abs(currPosition.column - col) < distance) {
-													currentActions.unshift(...actionsAtMarker.validActions);
-												} else {
-													currentActions.push(...actionsAtMarker.validActions);
-												}
 											}
 
 											if (codeActionSet.allActions.length === 0) {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

if there are multiple fixable errors that have context, highlight them on mouse hover or keyboard selection. Also allows highlighting on current fixable error.

Sets up groundwork for highlighting provided by code actions (this is a case handled within vs code, not by external extensions).

![Screenshot 2024-01-11 at 3 27 38 PM](https://github.com/microsoft/vscode/assets/54879025/c153c665-4265-49c6-9c9d-84f48c632dc0)
