### PR TITLE
Open File... selection is first file rather than last / In quick input move active item to the very first item in the list rather than the very last

### DIFF
--- a/src/vs/base/browser/ui/list/listWidget.ts
+++ b/src/vs/base/browser/ui/list/listWidget.ts
@@ -1868,7 +1868,7 @@ export class List<T> implements ISpliceable<T>, IDisposable {
 		return this.getFocus().map(i => this.view.element(i));
 	}
 
-	reveal(index: number, relativeTop?: number, paddingTop: number = 0, applyRelativeTopOnlyIfNotVisible: boolean = false): void {
+	reveal(index: number, relativeTop?: number, paddingTop: number = 0): void {
 		if (index < 0 || index >= this.length) {
 			throw new ListError(this.user, `Invalid index ${index}`);
 		}
@@ -1878,20 +1878,9 @@ export class List<T> implements ISpliceable<T>, IDisposable {
 		const elementHeight = this.view.elementHeight(index);
 
 		if (isNumber(relativeTop)) {
-			let applyRelativeTop: boolean;
-			if (applyRelativeTopOnlyIfNotVisible) {
-				const viewItemBottom = elementTop + elementHeight;
-				const scrollBottom = scrollTop + this.view.renderHeight;
-
-				applyRelativeTop = elementTop < scrollTop + paddingTop || viewItemBottom >= scrollBottom;
-			} else {
-				applyRelativeTop = true;
-			}
-			if (applyRelativeTop) {
-				// y = mx + b
-				const m = elementHeight - this.view.renderHeight + paddingTop;
-				this.view.setScrollTop(m * clamp(relativeTop, 0, 1) + elementTop - paddingTop);
-			}
+			// y = mx + b
+			const m = elementHeight - this.view.renderHeight + paddingTop;
+			this.view.setScrollTop(m * clamp(relativeTop, 0, 1) + elementTop - paddingTop);
 		} else {
 			const viewItemBottom = elementTop + elementHeight;
 			const scrollBottom = scrollTop + this.view.renderHeight;

--- a/src/vs/base/browser/ui/list/listWidget.ts
+++ b/src/vs/base/browser/ui/list/listWidget.ts
@@ -1868,7 +1868,7 @@ export class List<T> implements ISpliceable<T>, IDisposable {
 		return this.getFocus().map(i => this.view.element(i));
 	}
 
-	reveal(index: number, relativeTop?: number, paddingTop: number = 0): void {
+	reveal(index: number, relativeTop?: number, paddingTop: number = 0, applyRelativeTopOnlyIfNotVisible: boolean = false): void {
 		if (index < 0 || index >= this.length) {
 			throw new ListError(this.user, `Invalid index ${index}`);
 		}
@@ -1878,9 +1878,20 @@ export class List<T> implements ISpliceable<T>, IDisposable {
 		const elementHeight = this.view.elementHeight(index);
 
 		if (isNumber(relativeTop)) {
-			// y = mx + b
-			const m = elementHeight - this.view.renderHeight + paddingTop;
-			this.view.setScrollTop(m * clamp(relativeTop, 0, 1) + elementTop - paddingTop);
+			let applyRelativeTop: boolean;
+			if (applyRelativeTopOnlyIfNotVisible) {
+				const viewItemBottom = elementTop + elementHeight;
+				const scrollBottom = scrollTop + this.view.renderHeight;
+
+				applyRelativeTop = elementTop < scrollTop + paddingTop || viewItemBottom >= scrollBottom;
+			} else {
+				applyRelativeTop = true;
+			}
+			if (applyRelativeTop) {
+				// y = mx + b
+				const m = elementHeight - this.view.renderHeight + paddingTop;
+				this.view.setScrollTop(m * clamp(relativeTop, 0, 1) + elementTop - paddingTop);
+			}
 		} else {
 			const viewItemBottom = elementTop + elementHeight;
 			const scrollBottom = scrollTop + this.view.renderHeight;

--- a/src/vs/platform/quickinput/browser/quickInputList.ts
+++ b/src/vs/platform/quickinput/browser/quickInputList.ts
@@ -741,7 +741,11 @@ export class QuickInputList {
 		if (items.length > 0) {
 			const focused = this.list.getFocus()[0];
 			if (typeof focused === 'number') {
-				this.list.reveal(focused, 0, 0, true);
+				if (this.list.firstVisibleIndex <= focused && focused <= this.list.lastVisibleIndex) {
+					this.list.reveal(focused);
+				} else {
+					this.list.reveal(focused, 0);
+				}
 			}
 		}
 	}

--- a/src/vs/platform/quickinput/browser/quickInputList.ts
+++ b/src/vs/platform/quickinput/browser/quickInputList.ts
@@ -741,7 +741,7 @@ export class QuickInputList {
 		if (items.length > 0) {
 			const focused = this.list.getFocus()[0];
 			if (typeof focused === 'number') {
-				this.list.reveal(focused);
+				this.list.reveal(focused, 0, 0, true);
 			}
 		}
 	}


### PR DESCRIPTION
This is inspired by #202367. This doesn't fix it completely as no fuzzy search is working, though at least it makes it easier to reveal stuff in all lists inside VS Code as now if the item was not visible it will appear at the top rather than at the very bottom.

See video for the new behaviour:
https://github.com/microsoft/vscode/assets/9883873/eca0a3e3-2e1c-4339-b8da-72d45816e96f

