### PR TITLE
fix: added when condition for `cmd+n`

### DIFF
--- a/src/vs/workbench/browser/parts/editor/editor.contribution.ts
+++ b/src/vs/workbench/browser/parts/editor/editor.contribution.ts
@@ -1013,7 +1013,8 @@ MenuRegistry.appendMenuItem(MenuId.MenubarSwitchGroupMenu, {
 		id: 'workbench.action.focusSecondEditorGroup',
 		title: localize({ key: 'miFocusSecondGroup', comment: ['&& denotes a mnemonic'] }, "Group &&2")
 	},
-	order: 2
+	order: 2,
+	when: MultipleEditorGroupsContext
 });
 
 MenuRegistry.appendMenuItem(MenuId.MenubarSwitchGroupMenu, {
@@ -1023,7 +1024,8 @@ MenuRegistry.appendMenuItem(MenuId.MenubarSwitchGroupMenu, {
 		title: localize({ key: 'miFocusThirdGroup', comment: ['&& denotes a mnemonic'] }, "Group &&3"),
 		precondition: MultipleEditorGroupsContext
 	},
-	order: 3
+	order: 3,
+	when: MultipleEditorGroupsContext
 });
 
 MenuRegistry.appendMenuItem(MenuId.MenubarSwitchGroupMenu, {
@@ -1033,7 +1035,8 @@ MenuRegistry.appendMenuItem(MenuId.MenubarSwitchGroupMenu, {
 		title: localize({ key: 'miFocusFourthGroup', comment: ['&& denotes a mnemonic'] }, "Group &&4"),
 		precondition: MultipleEditorGroupsContext
 	},
-	order: 4
+	order: 4,
+	when: MultipleEditorGroupsContext
 });
 
 MenuRegistry.appendMenuItem(MenuId.MenubarSwitchGroupMenu, {
@@ -1043,7 +1046,8 @@ MenuRegistry.appendMenuItem(MenuId.MenubarSwitchGroupMenu, {
 		title: localize({ key: 'miFocusFifthGroup', comment: ['&& denotes a mnemonic'] }, "Group &&5"),
 		precondition: MultipleEditorGroupsContext
 	},
-	order: 5
+	order: 5,
+	when: MultipleEditorGroupsContext
 });
 
 MenuRegistry.appendMenuItem(MenuId.MenubarSwitchGroupMenu, {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
Currently, `cmd+n` commands like `workbench.action.focusSecondEditorGroup` have no `when` condition, which causes vscode to open empty editor groups, this PR addresses this issue by adding the `multipleEditorGroups` when condition to these commands.