### PR TITLE
debt - ensure `partOptions` are accessible only from service

### DIFF
--- a/src/vs/workbench/browser/parts/editor/editorsObserver.ts
+++ b/src/vs/workbench/browser/parts/editor/editorsObserver.ts
@@ -97,7 +97,7 @@ export class EditorsObserver extends Disposable {
 
 	private registerListeners(): void {
 		this._register(this.editorGroupsContainer.onDidAddGroup(group => this.onGroupAdded(group)));
-		this._register(this.editorGroupsContainer.onDidChangeEditorPartOptions(e => this.onDidChangeEditorPartOptions(e)));
+		this._register(this.editorGroupService.onDidChangeEditorPartOptions(e => this.onDidChangeEditorPartOptions(e)));
 		this._register(this.storageService.onWillSaveState(() => this.saveState()));
 	}
 
@@ -310,17 +310,17 @@ export class EditorsObserver extends Disposable {
 
 	private async ensureOpenedEditorsLimit(exclude: IEditorIdentifier | undefined, groupId?: GroupIdentifier): Promise<void> {
 		if (
-			!this.editorGroupsContainer.partOptions.limit?.enabled ||
-			typeof this.editorGroupsContainer.partOptions.limit.value !== 'number' ||
-			this.editorGroupsContainer.partOptions.limit.value <= 0
+			!this.editorGroupService.partOptions.limit?.enabled ||
+			typeof this.editorGroupService.partOptions.limit.value !== 'number' ||
+			this.editorGroupService.partOptions.limit.value <= 0
 		) {
 			return; // return early if not enabled or invalid
 		}
 
-		const limit = this.editorGroupsContainer.partOptions.limit.value;
+		const limit = this.editorGroupService.partOptions.limit.value;
 
 		// In editor group
-		if (this.editorGroupsContainer.partOptions.limit?.perEditorGroup) {
+		if (this.editorGroupService.partOptions.limit?.perEditorGroup) {
 
 			// For specific editor groups
 			if (typeof groupId === 'number') {
@@ -349,7 +349,7 @@ export class EditorsObserver extends Disposable {
 		// Check for `excludeDirty` setting and apply it by excluding
 		// any recent editor that is dirty from the opened editors limit
 		let mostRecentEditorsCountingForLimit: IEditorIdentifier[];
-		if (this.editorGroupsContainer.partOptions.limit?.excludeDirty) {
+		if (this.editorGroupService.partOptions.limit?.excludeDirty) {
 			mostRecentEditorsCountingForLimit = mostRecentEditors.filter(({ editor }) => {
 				if ((editor.isDirty() && !editor.isSaving()) || editor.hasCapability(EditorInputCapabilities.Scratchpad)) {
 					return false; // not dirty editors (unless in the process of saving) or scratchpads

--- a/src/vs/workbench/browser/parts/titlebar/titlebarPart.ts
+++ b/src/vs/workbench/browser/parts/titlebar/titlebarPart.ts
@@ -701,10 +701,10 @@ export class BrowserTitlebarPart extends Part implements ITitlebarPart {
 	}
 
 	private get editorActionsEnabled(): boolean {
-		return this.editorGroupsContainer.partOptions.editorActionsLocation === 'titleBar' ||
+		return this.editorGroupService.partOptions.editorActionsLocation === 'titleBar' ||
 			(
-				this.editorGroupsContainer.partOptions.editorActionsLocation === 'default' &&
-				this.editorGroupsContainer.partOptions.showTabs === 'none'
+				this.editorGroupService.partOptions.editorActionsLocation === 'default' &&
+				this.editorGroupService.partOptions.showTabs === 'none'
 			);
 	}
 

--- a/src/vs/workbench/services/editor/common/editorGroupsService.ts
+++ b/src/vs/workbench/services/editor/common/editorGroupsService.ts
@@ -411,16 +411,6 @@ export interface IEditorGroupsContainer {
 	copyGroup(group: IEditorGroup | GroupIdentifier, location: IEditorGroup | GroupIdentifier, direction: GroupDirection): IEditorGroup;
 
 	/**
-	 * Access the options of the editor part.
-	 */
-	readonly partOptions: IEditorPartOptions;
-
-	/**
-	 * An event that notifies when editor part options change.
-	 */
-	readonly onDidChangeEditorPartOptions: Event<IEditorPartOptionsChangeEvent>;
-
-	/**
 	 * Allows to register a drag and drop target for editors
 	 * on the provided `container`.
 	 */
@@ -525,6 +515,16 @@ export interface IEditorGroupsService extends IEditorGroupsContainer {
 	 * Get the editor part that is rooted in the provided container.
 	 */
 	getPart(container: unknown /* HTMLElement */): IEditorPart;
+
+	/**
+	 * Access the options of the editor part.
+	 */
+	readonly partOptions: IEditorPartOptions;
+
+	/**
+	 * An event that notifies when editor part options change.
+	 */
+	readonly onDidChangeEditorPartOptions: Event<IEditorPartOptionsChangeEvent>;
 
 	/**
 	 * Opens a new window with a full editor part instantiated


### PR DESCRIPTION
Otherwise we have a potential timing problem before the options propagate down to the floating windows.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
