### PR TITLE
Remove Sticky Scroll focus outline and background in settings editor

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/media/settingsEditor2.css
+++ b/src/vs/workbench/contrib/preferences/browser/media/settingsEditor2.css
@@ -196,6 +196,10 @@
 	background-color: var(--vscode-settings-focusedRowBackground);
 }
 
+.settings-editor > .settings-body .settings-tree-container .monaco-tree-sticky-container .monaco-list-row.focused .settings-row-inner-container {
+	background-color: unset; /* Remove Sticky Scroll focus */
+}
+
 .settings-editor > .settings-body .settings-tree-container .monaco-list-row:not(.focused) .settings-row-inner-container:hover {
 	background-color: var(--vscode-settings-rowHoverBackground);
 }
@@ -203,6 +207,10 @@
 .settings-editor > .settings-body .settings-tree-container .monaco-list:focus-within .monaco-list-row.focused .setting-item-contents,
 .settings-editor > .settings-body .settings-tree-container .monaco-list:focus-within .monaco-list-row.focused .settings-group-title-label {
 	outline: 1px solid var(--vscode-settings-focusedRowBorder);
+}
+
+.settings-editor > .settings-body .settings-tree-container .monaco-list:focus-within .monaco-tree-sticky-container .monaco-list-row.focused .settings-group-title-label {
+	outline: none; /* Remove Sticky Scroll focus */
 }
 
 .settings-editor > .settings-body .settings-tree-container .settings-editor-tree > .monaco-scrollable-element > .shadow.top {


### PR DESCRIPTION
This PR removes the focus outline and background in the settings editor. The changes specifically target the sticky scroll focus within the settings tree container. 