### PR TITLE
fix: fallback to strings for non-executable libc.so.6

### DIFF
--- a/resources/server/bin/helpers/check-requirements-linux.sh
+++ b/resources/server/bin/helpers/check-requirements-linux.sh
@@ -81,7 +81,13 @@ if [ -n "$(ldd --version | grep -v musl)" ]; then
 		# Rather than trusting the output of ldd --version (which is not always accurate)
 		# we instead use the version of the cached libc.so.6 file itself.
         libc_real_path=$(readlink -f "$libc_path")
-        libc_version=$($libc_real_path --version | sed -n 's/.*stable release version \([0-9]\+\.[0-9]\+\).*/\1/p')
+        if [ -x "$libc_real_path" ]; then
+            # get version from executable
+            libc_version=$($libc_real_path --version | sed -n 's/.*stable release version \([0-9]\+\.[0-9]\+\).*/\1/p')
+        else
+            # .so is not executable on this host; try getting from strings
+            libc_version=$(strings "$libc_real_path" | sed -n 's/.*stable release version \([0-9]\+\.[0-9]\+\).*/\1/p')
+        fi
         if [ "$(printf '%s\n' "2.28" "$libc_version" | sort -V | head -n1)" = "2.28" ]; then
             found_required_glibc=1
         else

--- a/resources/server/bin/helpers/check-requirements-linux.sh
+++ b/resources/server/bin/helpers/check-requirements-linux.sh
@@ -86,7 +86,7 @@ if [ -n "$(ldd --version | grep -v musl)" ]; then
             libc_version=$($libc_real_path --version | sed -n 's/.*stable release version \([0-9]\+\.[0-9]\+\).*/\1/p')
         else
             # .so is not executable on this host; try getting from strings
-            libc_version=$(strings "$libc_real_path" | sed -n 's/.*stable release version \([0-9]\+\.[0-9]\+\).*/\1/p')
+            libc_version=$(cat "$libc_real_path" | sed -n 's/.*stable release version \([0-9]\+\.[0-9]\+\).*/\1/p')
         fi
         if [ "$(printf '%s\n' "2.28" "$libc_version" | sort -V | head -n1)" = "2.28" ]; then
             found_required_glibc=1


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
This PR adds a fallback to `strings` on hosts where `libc.so.6` is not executable. I don't know if using `strings` is a robust solution, but it resolves the issue for me on WSL distro `Ubuntu-Preview`.

Fixes #202580