### PR TITLE
fix: dispose template data disposables in source column renderer

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/keybindingsEditor.ts
+++ b/src/vs/workbench/contrib/preferences/browser/keybindingsEditor.ts
@@ -1055,7 +1055,7 @@ class SourceColumnRenderer implements ITableRenderer<IKeybindingItemEntry, ISour
 	}
 
 	renderElement(keybindingItemEntry: IKeybindingItemEntry, index: number, templateData: ISourceColumnTemplateData, height: number | undefined): void {
-
+		templateData.disposables.clear();
 		if (isString(keybindingItemEntry.keybindingItem.source)) {
 			templateData.extensionContainer.classList.add('hide');
 			templateData.sourceLabel.element.classList.remove('hide');


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
Fixes #202455 

For testing:
1. Open the keybindings editor 
2. Close the keybindings editor
3. Repeat a opening and closing the keybindings editor a few times
4. The total event listener count should increment at the start, but then should stop incrementing (on my computer it grows from 968 to 1740 but stops at 1740 event listeners)


### Test output

```json
{
  "eventListenerCount": {
    "before": 1740,
    "after": 1740
  },
  "isLeak": false
}
```