### PR TITLE
Fixing incorrect colorization of tokens in sticky scroll

### DIFF
--- a/src/vs/editor/contrib/stickyScroll/browser/stickyScrollWidget.ts
+++ b/src/vs/editor/contrib/stickyScroll/browser/stickyScrollWidget.ts
@@ -127,7 +127,9 @@ export class StickyScrollWidget extends Disposable implements IOverlayWidget {
 	}
 
 	setState(_state: StickyScrollWidgetState | undefined, foldingModel: FoldingModel | null, _rebuildFromLine?: number): void {
-		if ((!this._previousState && !_state) || (this._previousState && this._previousState.equals(_state))) {
+		if (typeof _rebuildFromLine === 'undefined' &&
+			((!this._previousState && !_state) || (this._previousState && this._previousState.equals(_state)))
+		) {
 			return;
 		}
 		const isWidgetHeightZero = this._isWidgetHeightZero(_state);

--- a/src/vs/editor/contrib/stickyScroll/browser/stickyScrollWidget.ts
+++ b/src/vs/editor/contrib/stickyScroll/browser/stickyScrollWidget.ts
@@ -127,7 +127,7 @@ export class StickyScrollWidget extends Disposable implements IOverlayWidget {
 	}
 
 	setState(_state: StickyScrollWidgetState | undefined, foldingModel: FoldingModel | null, _rebuildFromLine?: number): void {
-		if (typeof _rebuildFromLine === 'undefined' &&
+		if (_rebuildFromLine === undefined &&
 			((!this._previousState && !_state) || (this._previousState && this._previousState.equals(_state)))
 		) {
 			return;


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/201727

The issue was due to an early return which should only happen when variable _rebuildFromLine is undefined. In essence when _rebuildFromLine is a number, this should force the rebuild of sticky scroll even if the previous state is equal to the current state.