### PR TITLE
Fix for 'Can't compress when there are no elements to compress' error

### DIFF
--- a/src/vs/base/browser/ui/tree/objectTree.ts
+++ b/src/vs/base/browser/ui/tree/objectTree.ts
@@ -189,6 +189,10 @@ class CompressibleStickyScrollDelegate<T, TFilterData> implements IStickyScrollD
 
 	private compressStickyNodes(stickyNodes: StickyScrollNode<T, TFilterData>[]): StickyScrollNode<T, TFilterData> {
 
+		if (stickyNodes.length === 0) {
+			throw new Error('Can\'t compress empty sticky nodes');
+		}
+
 		if (!this.modelProvider().isCompressionEnabled()) {
 			return stickyNodes[0];
 		}
@@ -206,11 +210,7 @@ class CompressibleStickyScrollDelegate<T, TFilterData> implements IStickyScrollD
 			}
 		}
 
-		if (elements.length === 0) {
-			throw new Error('Can\'t compress when there are no elements to compress');
-		}
-
-		if (elements.length === 1) {
+		if (elements.length < 2) {
 			return stickyNodes[0];
 		}
 


### PR DESCRIPTION
This PR addresses the issue where an error was thrown when trying to compress an empty list of elements. The fix involves adding a check to ensure that there are at least two elements before attempting to compress. This prevents the error from being thrown when the list of elements is empty or contains only one element.

Fixes #202800