### PR TITLE
Fix for incorrect file icon margins with compact pinned tabs and left tab action location

### DIFF
--- a/src/vs/workbench/browser/parts/editor/media/multieditortabscontrol.css
+++ b/src/vs/workbench/browser/parts/editor/media/multieditortabscontrol.css
@@ -228,7 +228,7 @@
 	pointer-events: none; /* prevents cursor flickering (fixes https://github.com/microsoft/vscode/issues/38753) */
 }
 
-.monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.tab-actions-left {
+.monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab.tab-actions-left:not(.sticky-compact) {
 	flex-direction: row-reverse;
 	padding-left: 0;
 	padding-right: 10px;


### PR DESCRIPTION
This PR addresses an issue where the file icon of pinned tabs was not centered and had incorrect padding when the Pinned Tab Sizing was set to compact and Tab Action Location was set to left. The CSS selector has been updated to exclude compact pinned tabs from the rule that was causing the issue.

Fixes #202505