### PR TITLE
joh/traditional mouse

### DIFF
--- a/build/lib/stylelint/vscode-known-variables.json
+++ b/build/lib/stylelint/vscode-known-variables.json
@@ -778,6 +778,8 @@
 		"--vscode-hover-whiteSpace",
 		"--vscode-inline-chat-cropped",
 		"--vscode-inline-chat-expanded",
+		"--vscode-inline-chat-quick-voice-height",
+		"--vscode-inline-chat-quick-voice-width",
 		"--vscode-interactive-session-foreground",
 		"--vscode-interactive-result-editor-background-color",
 		"--vscode-repl-font-family",

--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatController.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatController.ts
@@ -106,6 +106,7 @@ export class InlineChatController implements IEditorContribution {
 	private _historyCandidate: string = '';
 	private _historyUpdate: (prompt: string) => void;
 
+	private _isDisposed: boolean = false;
 	private readonly _store = new DisposableStore();
 	private readonly _zone: Lazy<InlineChatZoneWidget>;
 	private readonly _ctxHasActiveRequest: IContextKey<boolean>;
@@ -189,12 +190,15 @@ export class InlineChatController implements IEditorContribution {
 		};
 	}
 
-	dispose(): void {
-		if (this._session) {
-			this._inlineChatSessionService.releaseSession(this._session);
+	async dispose(): Promise<void> {
+		if (this._currentRun) {
+			this._messages.fire((this._session?.lastExchange
+				? Message.PAUSE_SESSION
+				: Message.CANCEL_SESSION)
+			);
 		}
-		this._strategy?.dispose();
 		this._store.dispose();
+		this._isDisposed = true;
 		this._log('DISPOSED controller');
 	}
 
@@ -262,7 +266,7 @@ export class InlineChatController implements IEditorContribution {
 
 	protected async _nextState(state: State, options: InlineChatRunOptions): Promise<void> {
 		let nextState: State | void = state;
-		while (nextState) {
+		while (nextState && !this._isDisposed) {
 			this._log('setState to ', nextState);
 			nextState = await this[nextState](options);
 		}
@@ -457,18 +461,18 @@ export class InlineChatController implements IEditorContribution {
 			store.dispose();
 		}
 
-		this._zone.value.widget.selectAll(false);
 
 		if (message & (Message.CANCEL_INPUT | Message.CANCEL_SESSION)) {
 			return State.CANCEL;
 		}
 
-		if (message & Message.ACCEPT_SESSION) {
-			return State.ACCEPT;
-		}
-
 		if (message & Message.PAUSE_SESSION) {
 			return State.PAUSE;
+		}
+
+		if (message & Message.ACCEPT_SESSION) {
+			this._zone.value.widget.selectAll(false);
+			return State.ACCEPT;
 		}
 
 		if (message & Message.RERUN_INPUT && this._session.lastExchange) {

--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatController.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatController.ts
@@ -190,7 +190,7 @@ export class InlineChatController implements IEditorContribution {
 		};
 	}
 
-	async dispose(): Promise<void> {
+	dispose(): void {
 		if (this._currentRun) {
 			this._messages.fire((this._session?.lastExchange
 				? Message.PAUSE_SESSION

--- a/src/vs/workbench/contrib/inlineChat/electron-sandbox/inlineChatQuickVoice.css
+++ b/src/vs/workbench/contrib/inlineChat/electron-sandbox/inlineChatQuickVoice.css
@@ -40,6 +40,10 @@
 	}
 }
 
-.monaco-editor .inline-chat-quick-voice .message.preview {
+.monaco-editor .inline-chat-quick-voice .preview {
 	opacity: .4;
+}
+
+.monaco-editor .inline-chat-quick-voice .message:not(:empty) {
+	margin-right: 0.4ch;
 }

--- a/src/vs/workbench/contrib/inlineChat/electron-sandbox/inlineChatQuickVoice.css
+++ b/src/vs/workbench/contrib/inlineChat/electron-sandbox/inlineChatQuickVoice.css
@@ -10,8 +10,10 @@
 	display: flex;
 	align-items: center;
 	box-shadow: 0 4px 8px var(--vscode-inlineChat-shadow);
-	white-space: nowrap;
 	z-index: 1000;
+	min-height: var(--vscode-inline-chat-quick-voice-height);
+	line-height: var(--vscode-inline-chat-quick-voice-height);
+	max-width: var(--vscode-inline-chat-quick-voice-width);
 }
 
 .monaco-editor .inline-chat-quick-voice .codicon.codicon-mic-filled {

--- a/src/vs/workbench/contrib/inlineChat/electron-sandbox/inlineChatQuickVoice.ts
+++ b/src/vs/workbench/contrib/inlineChat/electron-sandbox/inlineChatQuickVoice.ts
@@ -258,6 +258,7 @@ export class InlineChatQuickVoice implements IEditorContribution {
 			listener.dispose();
 			this._widget.hide();
 			this._ctxQuickChatInProgress.reset();
+			this._editor.focus();
 
 			if (!abort && message) {
 				InlineChatController.get(this._editor)?.run({ message, autoSend: true });

--- a/src/vs/workbench/contrib/inlineChat/electron-sandbox/inlineChatQuickVoice.ts
+++ b/src/vs/workbench/contrib/inlineChat/electron-sandbox/inlineChatQuickVoice.ts
@@ -107,6 +107,7 @@ export class CancelAction extends EditorAction2 {
 class QuickVoiceWidget implements IContentWidget {
 
 	readonly suppressMouseDown = true;
+	readonly allowEditorOverflow = true;
 
 	private readonly _domNode = document.createElement('div');
 	private readonly _elements = dom.h('.inline-chat-quick-voice@main', [
@@ -157,8 +158,10 @@ class QuickVoiceWidget implements IContentWidget {
 
 	beforeRender(): IDimension | null {
 		const lineHeight = this._editor.getOption(EditorOption.lineHeight);
-		this._elements.main.style.lineHeight = `${lineHeight}px`;
-		this._elements.main.style.height = `${lineHeight}px`;
+		const width = this._editor.getLayoutInfo().contentWidth * 0.7;
+
+		this._elements.main.style.setProperty('--vscode-inline-chat-quick-voice-height', `${lineHeight}px`);
+		this._elements.main.style.setProperty('--vscode-inline-chat-quick-voice-width', `${width}px`);
 		return null;
 	}
 


### PR DESCRIPTION
- focus editor back when quick voice ends
- fix https://github.com/microsoft/vscode-copilot/issues/315
- quick voice should wrap when getting too long
- render recognizing and recognized text differently
