### PR TITLE
enable move to previous cell command when screen reader enabled

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/contrib/navigation/arrow.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/navigation/arrow.ts
@@ -18,7 +18,6 @@ import { ServicesAccessor } from 'vs/platform/instantiation/common/instantiation
 import { KeybindingWeight } from 'vs/platform/keybinding/common/keybindingsRegistry';
 import { Registry } from 'vs/platform/registry/common/platform';
 import { InlineChatController } from 'vs/workbench/contrib/inlineChat/browser/inlineChatController';
-import { CTX_INLINE_CHAT_FOCUSED, CTX_INLINE_CHAT_INNER_CURSOR_LAST } from 'vs/workbench/contrib/inlineChat/common/inlineChat';
 import { INotebookActionContext, INotebookCellActionContext, NotebookAction, NotebookCellAction, NOTEBOOK_EDITOR_WIDGET_ACTION_WEIGHT, findTargetCellEditor } from 'vs/workbench/contrib/notebook/browser/controller/coreActions';
 import { CellEditState } from 'vs/workbench/contrib/notebook/browser/notebookBrowser';
 import { CellKind, NOTEBOOK_EDITOR_CURSOR_BOUNDARY } from 'vs/workbench/contrib/notebook/common/notebookCommon';
@@ -77,39 +76,6 @@ registerAction2(class FocusNextCellAction extends NotebookCellAction {
 					primary: KeyMod.CtrlCmd | KeyCode.DownArrow,
 					mac: { primary: KeyMod.WinCtrl | KeyMod.CtrlCmd | KeyCode.DownArrow, },
 					weight: KeybindingWeight.WorkbenchContrib
-				},
-				{
-					when: ContextKeyExpr.and(
-						NOTEBOOK_EDITOR_FOCUSED,
-						CONTEXT_ACCESSIBILITY_MODE_ENABLED.negate(),
-						ContextKeyExpr.equals('config.notebook.navigation.allowNavigateToSurroundingCells', true),
-						ContextKeyExpr.and(
-							ContextKeyExpr.has(InputFocusedContextKey),
-							NOTEBOOK_EDITOR_CURSOR_BOUNDARY.notEqualsTo('top'),
-							NOTEBOOK_EDITOR_CURSOR_BOUNDARY.notEqualsTo('none'),
-						),
-						CTX_INLINE_CHAT_FOCUSED,
-						CTX_INLINE_CHAT_INNER_CURSOR_LAST,
-						EditorContextKeys.isEmbeddedDiffEditor.negate()
-					),
-					primary: KeyCode.DownArrow,
-					weight: KeybindingWeight.EditorCore
-				},
-				{
-					when: ContextKeyExpr.and(
-						NOTEBOOK_EDITOR_FOCUSED,
-						CONTEXT_ACCESSIBILITY_MODE_ENABLED.negate(),
-						ContextKeyExpr.equals('config.notebook.navigation.allowNavigateToSurroundingCells', true),
-						ContextKeyExpr.and(
-							NOTEBOOK_CELL_TYPE.isEqualTo('markup'),
-							NOTEBOOK_CELL_MARKDOWN_EDIT_MODE.isEqualTo(false),
-							NOTEBOOK_CURSOR_NAVIGATION_MODE),
-						CTX_INLINE_CHAT_FOCUSED,
-						CTX_INLINE_CHAT_INNER_CURSOR_LAST,
-						EditorContextKeys.isEmbeddedDiffEditor.negate()
-					),
-					primary: KeyCode.DownArrow,
-					weight: KeybindingWeight.EditorCore
 				},
 				{
 					when: NOTEBOOK_EDITOR_FOCUSED,

--- a/src/vs/workbench/contrib/notebook/browser/contrib/navigation/arrow.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/navigation/arrow.ts
@@ -121,7 +121,6 @@ registerAction2(class FocusPreviousCellAction extends NotebookCellAction {
 		super({
 			id: NOTEBOOK_FOCUS_PREVIOUS_EDITOR,
 			title: localize('cursorMoveUp', 'Focus Previous Cell Editor'),
-			precondition: CONTEXT_ACCESSIBILITY_MODE_ENABLED.negate(),
 			keybinding: [
 				{
 					when: ContextKeyExpr.and(


### PR DESCRIPTION
ctrl+alt+pageup was added specifically for accessibility mode, but the pre-condition was preventing it from working.

also
fix https://github.com/microsoft/vscode/issues/194753

removing extra bindings because:
- move up has these keybindings but move down doesn't 
- down arrow is already bound to get next command in this context, so it doesn't actually affect anything
