### PR TITLE
type based coloring

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/baseDebugView.ts
+++ b/src/vs/workbench/contrib/debug/browser/baseDebugView.ts
@@ -19,7 +19,7 @@ import { localize } from 'vs/nls';
 import { IContextViewService } from 'vs/platform/contextview/browser/contextView';
 import { defaultInputBoxStyles } from 'vs/platform/theme/browser/defaultStyles';
 import { LinkDetector } from 'vs/workbench/contrib/debug/browser/linkDetector';
-import { IDebugService, IExpression, IExpressionContainer } from 'vs/workbench/contrib/debug/common/debug';
+import { IDebugService, IExpression, IExpressionValue } from 'vs/workbench/contrib/debug/common/debug';
 import { Expression, ExpressionContainer, Variable } from 'vs/workbench/contrib/debug/common/debugModel';
 import { ReplEvaluationResult } from 'vs/workbench/contrib/debug/common/replModel';
 
@@ -51,7 +51,7 @@ export function renderViewTree(container: HTMLElement): HTMLElement {
 	return treeContainer;
 }
 
-export function renderExpressionValue(expressionOrValue: IExpressionContainer | string, container: HTMLElement, options: IRenderValueOptions): void {
+export function renderExpressionValue(expressionOrValue: IExpressionValue | string, container: HTMLElement, options: IRenderValueOptions): void {
 	let value = typeof expressionOrValue === 'string' ? expressionOrValue : expressionOrValue.value;
 
 	// remove stale classes

--- a/src/vs/workbench/contrib/debug/browser/baseDebugView.ts
+++ b/src/vs/workbench/contrib/debug/browser/baseDebugView.ts
@@ -63,7 +63,7 @@ export function renderExpressionValue(expressionOrValue: IExpressionValue | stri
 			container.classList.add('error');
 		}
 	} else {
-		if ((expressionOrValue instanceof ExpressionContainer) && options.showChanged && expressionOrValue.valueChanged && value !== Expression.DEFAULT_VALUE) {
+		if (typeof expressionOrValue !== 'string' && options.showChanged && expressionOrValue.valueChanged && value !== Expression.DEFAULT_VALUE) {
 			// value changed color has priority over other colors.
 			container.className = 'value changed';
 			expressionOrValue.valueChanged = false;

--- a/src/vs/workbench/contrib/debug/common/debug.ts
+++ b/src/vs/workbench/contrib/debug/common/debug.ts
@@ -148,14 +148,17 @@ export interface IReplElementSource {
 	readonly column: number;
 }
 
-export interface IExpressionContainer extends ITreeElement {
+export interface IExpressionValue {
+	readonly value: string;
+	readonly type?: string;
+}
+
+export interface IExpressionContainer extends ITreeElement, IExpressionValue {
 	readonly hasChildren: boolean;
 	evaluateLazy(): Promise<void>;
 	getChildren(): Promise<IExpression[]>;
 	readonly reference?: number;
 	readonly memoryReference?: string;
-	readonly value: string;
-	readonly type?: string;
 	valueChanged?: boolean;
 	readonly presentationHint?: DebugProtocol.VariablePresentationHint | undefined;
 }

--- a/src/vs/workbench/contrib/debug/common/debug.ts
+++ b/src/vs/workbench/contrib/debug/common/debug.ts
@@ -151,6 +151,7 @@ export interface IReplElementSource {
 export interface IExpressionValue {
 	readonly value: string;
 	readonly type?: string;
+	valueChanged?: boolean;
 }
 
 export interface IExpressionContainer extends ITreeElement, IExpressionValue {
@@ -159,7 +160,6 @@ export interface IExpressionContainer extends ITreeElement, IExpressionValue {
 	getChildren(): Promise<IExpression[]>;
 	readonly reference?: number;
 	readonly memoryReference?: string;
-	valueChanged?: boolean;
 	readonly presentationHint?: DebugProtocol.VariablePresentationHint | undefined;
 }
 

--- a/src/vs/workbench/contrib/notebook/browser/contrib/notebookVariables/notebookVariablesTree.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/notebookVariables/notebookVariablesTree.ts
@@ -14,6 +14,7 @@ import { renderExpressionValue } from 'vs/workbench/contrib/debug/browser/baseDe
 import { INotebookVariableElement } from 'vs/workbench/contrib/notebook/browser/contrib/notebookVariables/notebookVariablesDataSource';
 
 const $ = dom.$;
+const MAX_VALUE_RENDER_LENGTH_IN_VIEWLET = 1024;
 
 export class NotebookVariablesTree extends WorkbenchObjectTree<INotebookVariableElement> { }
 
@@ -56,7 +57,11 @@ export class NotebookVariableRenderer implements ITreeRenderer<INotebookVariable
 		const text = element.element.value.trim() !== '' ? `${element.element.name}:` : element.element.name;
 		data.name.textContent = text;
 
-		renderExpressionValue(element.element.value, data.value, { colorize: true, showHover: true });
+		renderExpressionValue(element.element, data.value, {
+			colorize: true,
+			showHover: true,
+			maxValueLength: MAX_VALUE_RENDER_LENGTH_IN_VIEWLET
+		});
 	}
 
 	disposeTemplate(): void {


### PR DESCRIPTION
https://github.com/microsoft/vscode/issues/165445

Making further use of the debug view's expression renderer.
Split out the relevant parts of the ExpressionContainer to avoid needing to create dummy properties.