### PR TITLE
testing: avoid large hovers in test coverage, show inline counts instead

### DIFF
--- a/build/lib/stylelint/vscode-known-variables.json
+++ b/build/lib/stylelint/vscode-known-variables.json
@@ -683,6 +683,8 @@
 		"--vscode-terminalStickyScroll-background",
 		"--vscode-terminalStickyScrollHover-background",
 		"--vscode-testing-coverage-lineHeight",
+		"--vscode-testing-coverCountBadgeBackground",
+		"--vscode-testing-coverCountBadgeForeground",
 		"--vscode-testing-coveredBackground",
 		"--vscode-testing-coveredBorder",
 		"--vscode-testing-coveredGutterBackground",

--- a/src/vs/platform/theme/common/colorRegistry.ts
+++ b/src/vs/platform/theme/common/colorRegistry.ts
@@ -3,13 +3,13 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { assertNever } from 'vs/base/common/assert';
 import { RunOnceScheduler } from 'vs/base/common/async';
 import { Color, RGBA } from 'vs/base/common/color';
 import { Emitter, Event } from 'vs/base/common/event';
 import { IJSONSchema, IJSONSchemaMap } from 'vs/base/common/jsonSchema';
-import { assertNever } from 'vs/base/common/assert';
 import * as nls from 'vs/nls';
-import { Extensions as JSONExtensions, IJSONContributionRegistry } from 'vs/platform/jsonschemas/common/jsonContributionRegistry';
+import { IJSONContributionRegistry, Extensions as JSONExtensions } from 'vs/platform/jsonschemas/common/jsonContributionRegistry';
 import * as platform from 'vs/platform/registry/common/platform';
 import { IColorTheme } from 'vs/platform/theme/common/themeService';
 

--- a/src/vs/workbench/contrib/testing/browser/media/testing.css
+++ b/src/vs/workbench/contrib/testing/browser/media/testing.css
@@ -147,7 +147,7 @@
 
 .test-explorer .computed-state.retired,
 .testing-run-glyph.retired {
-	opacity: 0.7  !important;
+	opacity: 0.7 !important;
 }
 
 .test-explorer .test-is-hidden {
@@ -171,11 +171,7 @@
 	flex-grow: 1;
 }
 
-.monaco-workbench
-	.test-explorer
-	.monaco-action-bar
-	.action-item
-	> .action-label {
+.monaco-workbench .test-explorer .monaco-action-bar .action-item > .action-label {
 	padding: 1px 2px;
 	margin-right: 2px;
 }
@@ -358,6 +354,7 @@
 .monaco-editor .testing-inline-message-severity-0 {
 	color: var(--vscode-testing-message-error-decorationForeground) !important;
 }
+
 .monaco-editor .testing-inline-message-severity-1 {
 	color: var(--vscode-testing-message-info-decorationForeground) !important;
 }
@@ -411,8 +408,10 @@
 .explorer-item-with-test-coverage .explorer-item {
 	flex-grow: 1;
 }
+
 .explorer-item-with-test-coverage .monaco-icon-label::after {
-	margin-right: 12px; /* slightly reduce because the bars handle the scrollbar margin */
+	margin-right: 12px;
+	/* slightly reduce because the bars handle the scrollbar margin */
 }
 
 /** -- coverage decorations  */
@@ -447,14 +446,13 @@
 
 .coverage-deco-gutter.coverage-deco-miss.coverage-deco-hit::before {
 	background-image: linear-gradient(45deg,
-		var(--vscode-testing-coveredGutterBackground) 25%,
-		var(--vscode-testing-uncoveredGutterBackground) 25%,
-		var(--vscode-testing-uncoveredGutterBackground) 50%,
-		var(--vscode-testing-coveredGutterBackground) 50%,
-		75%,
-		var(--vscode-testing-uncoveredGutterBackground) 75%,
-		var(--vscode-testing-uncoveredGutterBackground) 100%
-	);
+			var(--vscode-testing-coveredGutterBackground) 25%,
+			var(--vscode-testing-uncoveredGutterBackground) 25%,
+			var(--vscode-testing-uncoveredGutterBackground) 50%,
+			var(--vscode-testing-coveredGutterBackground) 50%,
+			75%,
+			var(--vscode-testing-uncoveredGutterBackground) 75%,
+			var(--vscode-testing-uncoveredGutterBackground) 100%);
 	background-size: 6px 6px;
 	background-color: transparent;
 }
@@ -496,4 +494,32 @@
 	border-radius: 2px;
 	font: normal normal normal calc(var(--vscode-testing-coverage-lineHeight) / 2)/1 codicon;
 	border: 1px solid;
+}
+
+.coverage-deco-inline-count {
+	position: relative;
+	background: var(--vscode-testing-coverCountBadgeBackground);
+	color: var(--vscode-testing-coverCountBadgeForeground);
+	font-size: 0.7em;
+	margin: 0 0.7em 0 0.4em;
+	padding: 0.2em 0 0.2em 0.2em;
+	/* display: inline-block; */
+	border-top-left-radius: 2px;
+	border-bottom-left-radius: 2px;
+}
+
+.coverage-deco-inline-count::after {
+	content: '';
+	display: block;
+	position: absolute;
+	left: 100%;
+	top: 0;
+	bottom: 0;
+	width: 0.5em;
+	background-image:
+		linear-gradient(to bottom left, transparent 50%, var(--vscode-testing-coverCountBadgeBackground) 0),
+		linear-gradient(to bottom right, var(--vscode-testing-coverCountBadgeBackground) 50%, transparent 0);
+	background-size: 100% 50%;
+	background-repeat: no-repeat;
+	background-position: top, bottom;
 }

--- a/src/vs/workbench/contrib/testing/browser/theme.ts
+++ b/src/vs/workbench/contrib/testing/browser/theme.ts
@@ -5,7 +5,7 @@
 
 import { Color, RGBA } from 'vs/base/common/color';
 import { localize } from 'vs/nls';
-import { chartsGreen, chartsRed, contrastBorder, diffInserted, diffRemoved, editorBackground, editorErrorForeground, editorForeground, editorInfoForeground, opaque, registerColor, transparent } from 'vs/platform/theme/common/colorRegistry';
+import { badgeBackground, badgeForeground, chartsGreen, chartsRed, contrastBorder, diffInserted, diffRemoved, editorBackground, editorErrorForeground, editorForeground, editorInfoForeground, opaque, registerColor, transparent } from 'vs/platform/theme/common/colorRegistry';
 import { registerThemingParticipant } from 'vs/platform/theme/common/themeService';
 import { TestMessageType, TestResultState } from 'vs/workbench/contrib/testing/common/testTypes';
 
@@ -134,6 +134,20 @@ export const testingUncoveredGutterBackground = registerColor('testing.uncovered
 	hcDark: chartsRed,
 	hcLight: chartsRed
 }, localize('testing.uncoveredGutterBackground', 'Gutter color of regions where code not covered.'));
+
+export const testingCoverCountBadgeBackground = registerColor('testing.coverCountBadgeBackground', {
+	dark: badgeBackground,
+	light: badgeBackground,
+	hcDark: badgeBackground,
+	hcLight: badgeBackground
+}, localize('testing.coverCountBadgeBackground', 'Background for the badge indicating execution count'));
+
+export const testingCoverCountBadgeForeground = registerColor('testing.coverCountBadgeForeground', {
+	dark: badgeForeground,
+	light: badgeForeground,
+	hcDark: badgeForeground,
+	hcLight: badgeForeground
+}, localize('testing.coverCountBadgeForeground', 'Foreground for the badge indicating execution count'));
 
 export const testMessageSeverityColors: {
 	[K in TestMessageType]: {


### PR DESCRIPTION
Closes #202600

I still have a hover to make the "toggle line coverage" action visible, not sure a better place to put that...

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
