### PR TITLE
fix: skip glibc requirements check on nixos

### DIFF
--- a/resources/server/bin/helpers/check-requirements-linux.sh
+++ b/resources/server/bin/helpers/check-requirements-linux.sh
@@ -10,6 +10,13 @@ ARCH=$(uname -m)
 found_required_glibc=0
 found_required_glibcxx=0
 
+# Extract the ID value from /etc/os-release
+OS_ID="$(cat /etc/os-release | grep -Eo 'ID=([^"]+)' | sed 's/ID=//')"
+if [ "$OS_ID" = "nixos" ]; then
+  echo "Warning: NixOS detected, skipping GLIBC check"
+  exit 0
+fi
+
 # Based on https://github.com/bminor/glibc/blob/520b1df08de68a3de328b65a25b86300a7ddf512/elf/cache.c#L162-L245
 case $ARCH in
 	x86_64) LDCONFIG_ARCH="x86-64";;


### PR DESCRIPTION
It is not possible to identify the path to `libstdc++` and `libc` on this OS using the usual methods.

Fixes https://github.com/microsoft/vscode/issues/202728