### PR TITLE
Adding the `experimental` and the `FeatureInsight` tag to the editor sticky scroll enablement setting

### DIFF
--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -2817,7 +2817,8 @@ class EditorStickyScroll extends BaseEditorOption<EditorOption.stickyScroll, IEd
 				'editor.stickyScroll.enabled': {
 					type: 'boolean',
 					default: defaults.enabled,
-					description: nls.localize('editor.stickyScroll.enabled', "Shows the nested current scopes during the scroll at the top of the editor.")
+					description: nls.localize('editor.stickyScroll.enabled', "Shows the nested current scopes during the scroll at the top of the editor."),
+					tags: ['experimental', 'FeatureInsight']
 				},
 				'editor.stickyScroll.maxLineCount': {
 					type: 'number',


### PR DESCRIPTION
In relation to https://github.com/microsoft/vscode/issues/202655