### PR TITLE
Don't hide activity actions at top

### DIFF
--- a/src/vs/platform/actions/browser/menuEntryActionViewItem.ts
+++ b/src/vs/platform/actions/browser/menuEntryActionViewItem.ts
@@ -45,7 +45,8 @@ export function createAndFillInActionBarActions(
 	target: IAction[] | { primary: IAction[]; secondary: IAction[] },
 	primaryGroup?: string | ((actionGroup: string) => boolean),
 	shouldInlineSubmenu?: (action: SubmenuAction, group: string, groupSize: number) => boolean,
-	useSeparatorsInPrimaryActions?: boolean): void {
+	useSeparatorsInPrimaryActions?: boolean
+): void {
 	const groups = menu.getActions(options);
 	const isPrimaryAction = typeof primaryGroup === 'string' ? (actionGroup: string) => actionGroup === primaryGroup : primaryGroup;
 

--- a/src/vs/workbench/browser/parts/titlebar/titlebarActions.ts
+++ b/src/vs/workbench/browser/parts/titlebar/titlebarActions.ts
@@ -235,28 +235,6 @@ registerAction2(class ToggleEditorActions extends Action2 {
 	}
 });
 
-registerAction2(class ToggleActivityBarActions extends Action2 {
-	static readonly settingsID = `workbench.activityBar.location`;
-	constructor() {
-
-		super({
-			id: `toggle.${ToggleActivityBarActions.settingsID}`,
-			title: localize('toggle.activityBarActions', 'Activity Bar Actions'),
-			toggled: ContextKeyExpr.equals(`config.${ToggleActivityBarActions.settingsID}`, 'top'),
-			menu: [
-				{ id: MenuId.TitleBarContext, order: 4, when: ContextKeyExpr.notEquals(`config.${ToggleActivityBarActions.settingsID}`, 'side'), group: '2_config' },
-				{ id: MenuId.TitleBarTitleContext, order: 4, when: ContextKeyExpr.notEquals(`config.${ToggleActivityBarActions.settingsID}`, 'side'), group: '2_config' }
-			]
-		});
-	}
-
-	run(accessor: ServicesAccessor, ...args: any[]): void {
-		const configService = accessor.get(IConfigurationService);
-		const oldLocation = configService.getValue<string>(ToggleActivityBarActions.settingsID);
-		configService.updateValue(ToggleActivityBarActions.settingsID, oldLocation === 'top' ? 'hidden' : 'top');
-	}
-});
-
 // --- Toolbar actions --- //
 
 export const ACCOUNTS_ACTIVITY_TILE_ACTION: IAction = {


### PR DESCRIPTION
This PR removes the hiding of activity bar actions at the top. The changes ensure that the activity bar actions remain visible and accessible for better user experience.