### PR TITLE
Fix bad spacing in /help

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -265,7 +265,7 @@ class ChatSlashStaticSlashCommandsContribution extends Disposable {
 						return `\t* [\`${chatSubcommandLeader}${c.name}\`](command:${SubmitAction.ID}?${urlSafeArg}) - ${c.description}`;
 					}).join('\n');
 
-					return agentLine + '\n' + commandText;
+					return (agentLine + '\n' + commandText).trim();
 				}))).join('\n');
 			progress.report({ content: new MarkdownString(agentText, { isTrusted: { enabledCommands: [SubmitAction.ID] } }), kind: 'markdownContent' });
 			if (defaultAgent?.metadata.helpTextPostfix) {


### PR DESCRIPTION
This turns out to be from rendering paragraphs inside the list items because there are extra newlines between bulletpoints

<img width="431" alt="image" src="https://github.com/microsoft/vscode/assets/323878/a46acdc4-3039-46ec-877c-3ac055dcf238">
