### PR TITLE
Fix for Sticky Scroll Focus Space Key Issue

### DIFF
--- a/src/vs/base/browser/ui/tree/abstractTree.ts
+++ b/src/vs/base/browser/ui/tree/abstractTree.ts
@@ -1767,8 +1767,10 @@ class StickyScrollFocus<T, TFilterData, TRef> extends Disposable {
 	private _domHasFocus: boolean = false;
 	private get domHasFocus(): boolean { return this._domHasFocus; }
 	private set domHasFocus(hasFocus: boolean) {
-		this._domHasFocus = hasFocus;
-		this._onDidChangeHasFocus.fire(hasFocus);
+		if (hasFocus !== this._domHasFocus) {
+			this._onDidChangeHasFocus.fire(hasFocus);
+			this._domHasFocus = hasFocus;
+		}
 	}
 
 	constructor(

--- a/src/vs/workbench/browser/actions/listCommands.ts
+++ b/src/vs/workbench/browser/actions/listCommands.ts
@@ -266,7 +266,7 @@ function revealFocusedStickyScroll(tree: ObjectTree<any, any> | DataTree<any, an
 	}
 
 	tree.reveal(focus[0]);
-	tree.domFocus();
+	tree.getHTMLElement().focus(); // domfocus() would focus stiky scroll dom and not the tree todo@benibenj
 	tree.setFocus(focus);
 	postRevealAction?.(focus[0]);
 }
@@ -718,7 +718,7 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 });
 
 KeybindingsRegistry.registerCommandAndKeybindingRule({
-	id: 'list.toggleExpand',
+	id: 'list.stickyScrolltoggleExpand',
 	weight: KeybindingWeight.WorkbenchContrib + 50, // priorities over file explorer
 	when: WorkbenchTreeStickyScrollFocused,
 	primary: KeyCode.Space,
@@ -729,7 +729,7 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 			return;
 		}
 
-		revealFocusedStickyScroll(widget, focus => widget.setSelection([focus]));
+		revealFocusedStickyScroll(widget);
 	}
 });
 


### PR DESCRIPTION
This PR addresses an issue with the sticky scroll focus where the 'Space' key was not functioning as expected. Changes include ensuring the focus state is updated only when it changes, focusing on the correct element, and updating the keybinding rule id for better clarity.

#202835