### PR TITLE
Fix Drag n Drop behavior in Open Editors with multiple groups

### DIFF
--- a/src/vs/base/browser/ui/list/listView.ts
+++ b/src/vs/base/browser/ui/list/listView.ts
@@ -1221,7 +1221,7 @@ export class ListView<T> implements IListView<T> {
 		feedback = distinct(feedback).filter(i => i >= -1 && i < this.length).sort((a, b) => a - b);
 		feedback = feedback[0] === -1 ? [-1] : feedback;
 
-		const dragOverEffectPosition = typeof result !== 'boolean' && result.effect && result.effect.position ? result.effect.position : ListDragOverEffectPosition.Over;
+		let dragOverEffectPosition = typeof result !== 'boolean' && result.effect && result.effect.position ? result.effect.position : ListDragOverEffectPosition.Over;
 
 		if (equalsDragFeedback(this.currentDragFeedback, feedback) && this.currentDragFeedbackPosition === dragOverEffectPosition) {
 			return true;
@@ -1242,6 +1242,15 @@ export class ListView<T> implements IListView<T> {
 
 			if (feedback.length > 1 && dragOverEffectPosition !== ListDragOverEffectPosition.Over) {
 				throw new Error('Can\'t use multiple feedbacks with position different than \'over\'');
+			}
+
+			// Make sure there is no flicker when moving between two items
+			// Always use the before feedback if possible
+			if (dragOverEffectPosition === ListDragOverEffectPosition.After) {
+				if (feedback[0] < this.length - 1) {
+					feedback[0] += 1;
+					dragOverEffectPosition = ListDragOverEffectPosition.Before;
+				}
 			}
 
 			for (const index of feedback) {

--- a/src/vs/base/browser/ui/list/listWidget.ts
+++ b/src/vs/base/browser/ui/list/listWidget.ts
@@ -979,14 +979,13 @@ export class DefaultStyleController implements IStyleController {
 		if (styles.listDropBetweenBackground) {
 			content.push(`
 			.monaco-list${suffix} .monaco-list-rows.drop-target-before .monaco-list-row:first-child::before,
-			.monaco-list${suffix} .monaco-list-row.drop-target-after + .monaco-list-row::before,
 			.monaco-list${suffix} .monaco-list-row.drop-target-before::before {
 				content: ""; position: absolute; top: 0px; left: 0px; width: 100%; height: 1px;
 				background-color: ${styles.listDropBetweenBackground};
 			}`);
 			content.push(`
 			.monaco-list${suffix} .monaco-list-rows.drop-target-after .monaco-list-row:last-child::after,
-			.monaco-list${suffix} .monaco-list-row:last-child.drop-target-after::after {
+			.monaco-list${suffix} .monaco-list-row.drop-target-after::after {
 				content: ""; position: absolute; bottom: 0px; left: 0px; width: 100%; height: 1px;
 				background-color: ${styles.listDropBetweenBackground};
 			}`);


### PR DESCRIPTION
This PR addresses the issue where the drag and drop functionality in Open Editors was not working as expected when there were multiple groups. The changes ensure that the drop feedback is correctly shown in the second group when dragging the last item in the first group. Additionally, the feedback shifts to the correct position of the dragged item when it is dragged further down on to the top of Group 2. On drop, the item now correctly moves to Group 1.

Fixes #203179