### PR TITLE
Clarify custom title bar style setting description

### DIFF
--- a/src/vs/workbench/electron-sandbox/desktop.contribution.ts
+++ b/src/vs/workbench/electron-sandbox/desktop.contribution.ts
@@ -245,7 +245,7 @@ import { MAX_ZOOM_LEVEL, MIN_ZOOM_LEVEL } from 'vs/platform/window/electron-sand
 				],
 				'default': isLinux ? 'never' : 'auto',
 				'scope': ConfigurationScope.APPLICATION,
-				'description': localize('window.customTitleBarVisibility', "Adjust when the custom title bar should be shown."),
+				'markdownDescription': localize('window.customTitleBarVisibility', "Adjust when the custom title bar should be shown. The custom title bar can be hidden when in full screen mode with `windowed`. The custom title bar can only be hidden in none full screen mode with `never` when `#window.titleBarStyle#` is set to `native`."),
 			},
 			'window.dialogStyle': {
 				'type': 'string',


### PR DESCRIPTION
Updated the description for the custom title bar style setting to be more informative and less confusing for users, especially those on Mac. The new description clearly states the behavior of the custom title bar in different scenarios and its relation with the `#window.titleBarStyle#` setting.

Fixes #203290