### PR TITLE
Fix potential race creating JS/TS temp dir

### DIFF
--- a/extensions/typescript-language-features/src/extension.ts
+++ b/extensions/typescript-language-features/src/extension.ts
@@ -88,5 +88,5 @@ export function activate(
 }
 
 export function deactivate() {
-	fs.rmSync(temp.getInstanceTempDir(), { recursive: true, force: true });
+	fs.rmSync(temp.instanceTempDir.value, { recursive: true, force: true });
 }


### PR DESCRIPTION
Fixes #203335

Switches to use `fs.mkdirSync` recursive to avoid the extra checks