### PR TITLE
Fixes #198387

### DIFF
--- a/extensions/typescript-language-features/src/languageFeatures/codeLens/implementationsCodeLens.ts
+++ b/extensions/typescript-language-features/src/languageFeatures/codeLens/implementationsCodeLens.ts
@@ -90,6 +90,9 @@ export default class TypeScriptImplementationsCodeLensProvider extends TypeScrip
 		if (item.kind === PConst.Kind.method && parent && parent.kind === PConst.Kind.interface && vscode.workspace.getConfiguration(this.language.id).get<boolean>('implementationsCodeLens.showOnInterfaceMethods')) {
 			return getSymbolRange(document, item);
 		}
+		if (item.kind === PConst.Kind.method && parent && parent.kind === PConst.Kind.class && parent.kindModifiers.match(/\babstract\b/g) && vscode.workspace.getConfiguration(this.language.id).get<boolean>('implementationsCodeLens.showOnInterfaceMethods')) {
+			return getSymbolRange(document, item);
+		}
 		switch (item.kind) {
 			case PConst.Kind.interface:
 				return getSymbolRange(document, item);

--- a/extensions/typescript-language-features/src/languageFeatures/codeLens/implementationsCodeLens.ts
+++ b/extensions/typescript-language-features/src/languageFeatures/codeLens/implementationsCodeLens.ts
@@ -90,7 +90,7 @@ export default class TypeScriptImplementationsCodeLensProvider extends TypeScrip
 		if (item.kind === PConst.Kind.method && parent && parent.kind === PConst.Kind.interface && vscode.workspace.getConfiguration(this.language.id).get<boolean>('implementationsCodeLens.showOnInterfaceMethods')) {
 			return getSymbolRange(document, item);
 		}
-		if (item.kind === PConst.Kind.method && parent && parent.kind === PConst.Kind.class && parent.kindModifiers.match(/\babstract\b/g) && vscode.workspace.getConfiguration(this.language.id).get<boolean>('implementationsCodeLens.showOnInterfaceMethods')) {
+		if (item.kind === PConst.Kind.method && item.kindModifiers.match(/\boverride\b/g) && parent && parent.kind === PConst.Kind.class && parent.kindModifiers.match(/\babstract\b/g) && vscode.workspace.getConfiguration(this.language.id).get<boolean>('implementationsCodeLens.showOnInterfaceMethods')) {
 			return getSymbolRange(document, item);
 		}
 		switch (item.kind) {

--- a/extensions/typescript-language-features/src/languageFeatures/codeLens/implementationsCodeLens.ts
+++ b/extensions/typescript-language-features/src/languageFeatures/codeLens/implementationsCodeLens.ts
@@ -90,7 +90,7 @@ export default class TypeScriptImplementationsCodeLensProvider extends TypeScrip
 		if (item.kind === PConst.Kind.method && parent && parent.kind === PConst.Kind.interface && vscode.workspace.getConfiguration(this.language.id).get<boolean>('implementationsCodeLens.showOnInterfaceMethods')) {
 			return getSymbolRange(document, item);
 		}
-		if (item.kind === PConst.Kind.method && item.kindModifiers.match(/\boverride\b/g) && parent && parent.kind === PConst.Kind.class && parent.kindModifiers.match(/\babstract\b/g) && vscode.workspace.getConfiguration(this.language.id).get<boolean>('implementationsCodeLens.showOnInterfaceMethods')) {
+		if (item.kind === PConst.Kind.method && parent && parent.kind === PConst.Kind.class && parent.kindModifiers.match(/\babstract\b/g) && vscode.workspace.getConfiguration(this.language.id).get<boolean>('implementationsCodeLens.showOnInterfaceMethods')) {
 			return getSymbolRange(document, item);
 		}
 		switch (item.kind) {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
Fixes #198387  by adding implementation in code lens for overridden abstract class method. Test with 
```
abstract class A {
	foo() {
		console.log('foo from A')
	}
	bar() {
		console.log('bar from A')
	}
}

class B extends A {
	override foo() {
		console.log('foo from B')
	}
}

class C extends A {
	baz() {
		console.log('baz')
	}
}
```

Should see implementation 1 above line 2