### PR TITLE
fix: allowTrailingCommas in JSON by default

### DIFF
--- a/extensions/json-language-features/server/src/jsonServer.ts
+++ b/extensions/json-language-features/server/src/jsonServer.ts
@@ -323,6 +323,7 @@ export function startServer(connection: Connection, runtime: RuntimeEnvironment)
 		const languageSettings = {
 			validate: validateEnabled,
 			allowComments: true,
+			allowTrailingCommas: true,
 			schemas: new Array<SchemaConfiguration>()
 		};
 		if (schemaAssociations) {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fixes #202422

As, we're allowing comments by default in JSON file, we can also allow trailing commas.
More reasons on why we're doing this change, can be found in the linked issue.
