### PR TITLE
Ensure that cursor state change is always emitted upon restoring state

### DIFF
--- a/src/vs/editor/browser/viewParts/overviewRuler/decorationsOverviewRuler.ts
+++ b/src/vs/editor/browser/viewParts/overviewRuler/decorationsOverviewRuler.ts
@@ -249,7 +249,7 @@ export class DecorationsOverviewRuler extends ViewPart {
 			}
 		});
 
-		this._cursorPositions = [];
+		this._cursorPositions = [new Position(1, 1)];
 	}
 
 	public override dispose(): void {

--- a/src/vs/editor/common/cursor/cursor.ts
+++ b/src/vs/editor/common/cursor/cursor.ts
@@ -394,7 +394,7 @@ export class CursorsController extends Disposable {
 
 	private _emitStateChangedIfNecessary(eventsCollector: ViewModelEventsCollector, source: string | null | undefined, reason: CursorChangeReason, oldState: CursorModelState | null, reachedMaxCursorCount: boolean): boolean {
 		const newState = CursorModelState.from(this._model, this);
-		if (newState.equals(oldState) && source !== 'restoreState') {
+		if (newState.equals(oldState)) {
 			return false;
 		}
 

--- a/src/vs/editor/common/cursor/cursor.ts
+++ b/src/vs/editor/common/cursor/cursor.ts
@@ -394,7 +394,7 @@ export class CursorsController extends Disposable {
 
 	private _emitStateChangedIfNecessary(eventsCollector: ViewModelEventsCollector, source: string | null | undefined, reason: CursorChangeReason, oldState: CursorModelState | null, reachedMaxCursorCount: boolean): boolean {
 		const newState = CursorModelState.from(this._model, this);
-		if (newState.equals(oldState)) {
+		if (newState.equals(oldState) && source !== 'restoreState') {
 			return false;
 		}
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fixes #203345

It seems that the distinction between cases where the scrollbar background appears and where it does not lies in whether [onCursorStateChanged](https://github.com/microsoft/vscode/blob/b0d1f894c38a163ac23e400d41c800decede6117/src/vs/editor/browser/viewParts/overviewRuler/decorationsOverviewRuler.ts#L298) is called or not. When a file is opened, [restoreCursorState](https://github.com/microsoft/vscode/blob/b0d1f894c38a163ac23e400d41c800decede6117/src/vs/editor/common/viewModel/viewModelImpl.ts#L1033) fires events that initialize the cursor state, and [_emitStateChangedIfNecessary](https://github.com/microsoft/vscode/blob/b0d1f894c38a163ac23e400d41c800decede6117/src/vs/editor/common/cursor/cursor.ts#L395) determines whether the `CursorStateChangedEvent` should be fired by comparing the previous and current cursor states. However, it appears that the default value for the cursor position in a newly opened view is (1,1), which results in the `CursorStateChangedEvent` not being fired if the cursor position after restoration is also (1,1) – the cursor positioned before the first character on the first line. Without this event, certain parts of [DecorationsOverviewRuler](https://github.com/microsoft/vscode/blob/b0d1f894c38a163ac23e400d41c800decede6117/src/vs/editor/browser/viewParts/overviewRuler/decorationsOverviewRuler.ts) do not initialize properly, leading to the problem I linked above.

To address this, I've ensured that cursor events are emitted if they were caused by the `restoreState`.