### PR TITLE
eng: fix missing rustup command in build

### DIFF
--- a/build/azure-pipelines/cli/cli-compile-and-publish.yml
+++ b/build/azure-pipelines/cli/cli-compile-and-publish.yml
@@ -29,7 +29,7 @@ steps:
         displayName: Set product.json path
 
   - ${{ if parameters.VSCODE_CHECK_ONLY }}:
-    - script: rustup component add clippy && cargo clippy --target ${{ parameters.VSCODE_CLI_TARGET }} --bin=code
+    - script: cargo clippy --target ${{ parameters.VSCODE_CLI_TARGET }} --bin=code
       displayName: Lint ${{ parameters.VSCODE_CLI_TARGET }}
       workingDirectory: $(Build.SourcesDirectory)/cli
       env:

--- a/build/azure-pipelines/cli/install-rust-posix.yml
+++ b/build/azure-pipelines/cli/install-rust-posix.yml
@@ -33,6 +33,7 @@ steps:
       set -e
       rustup default $RUSTUP_TOOLCHAIN
       rustup update $RUSTUP_TOOLCHAIN
+      rustup component add clippy
     env:
       RUSTUP_TOOLCHAIN: ${{ parameters.channel }}
     displayName: "Set Rust version"

--- a/build/azure-pipelines/cli/test.yml
+++ b/build/azure-pipelines/cli/test.yml
@@ -1,7 +1,7 @@
 steps:
   - template: ./install-rust-posix.yml
 
-  - script: rustup component add clippy && cargo clippy -- -D warnings
+  - script: cargo clippy -- -D warnings
     workingDirectory: cli
     displayName: Clippy lint
 


### PR DESCRIPTION
Only call rustup when explicitly installing

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
