### PR TITLE
Also disable `` ` `` as autoclosing pair

### DIFF
--- a/extensions/markdown-basics/language-configuration.json
+++ b/extensions/markdown-basics/language-configuration.json
@@ -42,10 +42,6 @@
 				"string"
 			]
 		},
-		{
-			"open": "`",
-			"close": "`"
-		},
 	],
 	"surroundingPairs": [
 		[


### PR DESCRIPTION
Fixes #192676

Not ideal but likely better than the current behavior that inserts extra backticks

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
