### PR TITLE
Change default nb sticky mode based on feedback

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/notebook.contribution.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebook.contribution.ts
@@ -886,7 +886,7 @@ configurationRegistry.registerConfiguration({
 				nls.localize('notebook.stickyScrollMode.flat', "Nested sticky lines appear flat."),
 				nls.localize('notebook.stickyScrollMode.indented', "Nested sticky lines appear indented."),
 			],
-			default: 'flat',
+			default: 'indented',
 			tags: ['notebookLayout']
 		},
 		[NotebookSetting.consolidatedOutputButton]: {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
Feedback likes indented, set that as default layout for nb sticky scroll