### PR TITLE
debug: fix closeReadonlyTabsOnEnd not working

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/debugService.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugService.ts
@@ -710,10 +710,7 @@ export class DebugService implements IDebugService {
 
 			if (this.configurationService.getValue<IDebugConfiguration>('debug').closeReadonlyTabsOnEnd) {
 				const editorsToClose = this.editorService.getEditors(EditorsOrder.SEQUENTIAL).filter(({ editor }) => {
-					if (editor.resource?.scheme === DEBUG_SCHEME) {
-						return editor.isReadonly() && session.getId() === Source.getEncodedDebugData(editor.resource).sessionId;
-					}
-					return false;
+					return editor.resource?.scheme === DEBUG_SCHEME && session.getId() === Source.getEncodedDebugData(editor.resource).sessionId;
 				});
 				this.editorService.closeEditors(editorsToClose);
 			}


### PR DESCRIPTION
The input itself is not readonly, the filesystem is, so this check
was always failing.

The entire `debug` scheme is readonly, so we don't need to try to
replace the check with anything else. This is pretty safe since this
code path is only hit when the new setting is enabled.

Closes #197949

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
