### PR TITLE
use `savedFrom` to participate in the right resource when doing save-as or when saving an untitled file

### DIFF
--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatSavingServiceImpl.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatSavingServiceImpl.ts
@@ -105,13 +105,13 @@ export class InlineChatSavingServiceImpl implements IInlineChatSavingService {
 		const queue = new Queue<void>();
 
 		const d1 = this._textFileService.files.addSaveParticipant({
-			participate: (model, context, progress, token) => {
-				return queue.queue(() => this._participate(model.textEditorModel?.uri, context.reason, progress, token));
+			participate: (model, ctx, progress, token) => {
+				return queue.queue(() => this._participate(ctx.savedFrom ?? model.textEditorModel?.uri, ctx.reason, progress, token));
 			}
 		});
 		const d2 = this._workingCopyFileService.addSaveParticipant({
-			participate: (workingCopy, env, progress, token) => {
-				return queue.queue(() => this._participate(workingCopy.resource, env.reason, progress, token));
+			participate: (workingCopy, ctx, progress, token) => {
+				return queue.queue(() => this._participate(ctx.savedFrom ?? workingCopy.resource, ctx.reason, progress, token));
 			}
 		});
 		this._saveParticipant.value = combinedDisposable(d1, d2, queue);


### PR DESCRIPTION
fixes https://github.com/microsoft/vscode-copilot/issues/3690