### PR TITLE
debt - reduce large `workbench.statusbar.hidden` state

### DIFF
--- a/src/vs/workbench/browser/parts/statusbar/statusbarModel.ts
+++ b/src/vs/workbench/browser/parts/statusbar/statusbarModel.ts
@@ -48,7 +48,7 @@ export class StatusbarViewModel extends Disposable {
 		if (hiddenRaw) {
 			try {
 				const hiddenArray: string[] = JSON.parse(hiddenRaw);
-				this.hidden = new Set(hiddenArray);
+				this.hidden = new Set(hiddenArray.filter(entry => !entry.startsWith('status.workspaceTrust.'))); // TODO@bpasero remove this migration eventually
 			} catch (error) {
 				// ignore parsing errors
 			}


### PR DESCRIPTION
fyi @sandy081 @sbatten this will drop the large amount of `status.workspaceTrust.` entries now that we have a single one called `status.workspaceTrust`