### PR TITLE
Complete walkthrough steps with commands after command execution

### DIFF
--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts
@@ -718,7 +718,7 @@ export class GettingStartedPage extends EditorPane {
 			stepElement.classList.add('expanded');
 			stepElement.setAttribute('aria-expanded', 'true');
 			this.buildMediaComponent(id);
-			this.gettingStartedService.progressStep(id);
+			this.gettingStartedService.progressByEvent('stepSelected:' + id);
 		} else {
 			this.editorInput.selectedStep = undefined;
 		}


### PR DESCRIPTION
We had previously changed this behavior so that all steps would complete immediately after open. This was done to alleviate https://github.com/microsoft/vscode/issues/166747

However, we noticed no significant changes in user behavior in walkthrough completions (from telemetry) and we still see drop-off after the first few steps. 
We have also seen this: https://github.com/microsoft/vscode/issues/176074  feedback from extension authors.