### PR TITLE
add telemetry for clicking on sparkle

### DIFF
--- a/src/vs/editor/contrib/codeAction/browser/codeAction.ts
+++ b/src/vs/editor/contrib/codeAction/browser/codeAction.ts
@@ -245,7 +245,8 @@ function getDocumentationFromProvider(
 export enum ApplyCodeActionReason {
 	OnSave = 'onSave',
 	FromProblemsView = 'fromProblemsView',
-	FromCodeActions = 'fromCodeActions'
+	FromCodeActions = 'fromCodeActions',
+	FromAILightbulb = 'fromAILightbulb' // direct invocation when clicking on the AI lightbulb
 }
 
 export async function applyCodeAction(

--- a/src/vs/editor/contrib/codeAction/browser/lightBulbWidget.ts
+++ b/src/vs/editor/contrib/codeAction/browser/lightBulbWidget.ts
@@ -86,22 +86,6 @@ export class LightBulbWidget extends Disposable implements IContentWidget {
 				return;
 			}
 
-			if (
-				this.state.actions.allAIFixes
-				&& this.state.actions.validActions.length === 1
-			) {
-				const action = this.state.actions.validActions[0].action;
-				const id = action.command?.id;
-				if (id) {
-					let args = action.command?.arguments;
-					if (id === 'inlineChat.start' && args && args.length === 1) {
-						args = [{ ...args[0], autoSend: false }];
-					}
-					commandService.executeCommand(id, ...(args || []));
-					e.preventDefault();
-					return;
-				}
-			}
 			// Make sure that focus / cursor location is not lost when clicking widget icon
 			this._editor.focus();
 			e.preventDefault();


### PR DESCRIPTION
For #203678

From https://github.com/microsoft/vscode/pull/202989#issuecomment-1913804337

There's currently no telemetry to detect that a user opened inline chat by clicking on a sparkle (AI light bulb)

The PR adds that info to the telemetry event that we use to see which code action got applied.
