### PR TITLE
Fix markdown light and dark mode when using high contrast themes

### DIFF
--- a/extensions/github/markdown.css
+++ b/extensions/github/markdown.css
@@ -4,6 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 .vscode-dark img[src$=\#gh-light-mode-only],
-.vscode-light img[src$=\#gh-dark-mode-only] {
+.vscode-light img[src$=\#gh-dark-mode-only],
+.vscode-high-contrast img[src$=\#gh-light-mode-only],
+.vscode-high-contrast-light img[src$=\#gh-dark-mode-only] {
 	display: none;
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fixes #203686

how to test:

1. Create a markdown document
2. Add an image with both a light and dark variant

```
![Diagram](diagram-dark.svg#gh-dark-mode-only)
![Diagram](diagram-light.svg#gh-light-mode-only)
```

3. Switch to a high-contrast theme
4. Check if both light and dark variants are displayed
