### PR TITLE
Original window regrabs focus when using QuickOpen to switch to other window (fix #203111) (#203676)

### DIFF
--- a/src/vs/platform/auxiliaryWindow/electron-main/auxiliaryWindow.ts
+++ b/src/vs/platform/auxiliaryWindow/electron-main/auxiliaryWindow.ts
@@ -4,11 +4,13 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { BrowserWindow, WebContents } from 'electron';
+import { isLinux, isWindows } from 'vs/base/common/platform';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { IEnvironmentMainService } from 'vs/platform/environment/electron-main/environmentMainService';
 import { ILifecycleMainService } from 'vs/platform/lifecycle/electron-main/lifecycleMainService';
 import { ILogService } from 'vs/platform/log/common/log';
 import { IStateService } from 'vs/platform/state/node/state';
+import { hasNativeTitlebar } from 'vs/platform/window/common/window';
 import { IBaseWindow } from 'vs/platform/window/electron-main/window';
 import { BaseWindow } from 'vs/platform/windows/electron-main/windowImpl';
 
@@ -61,6 +63,9 @@ export class AuxiliaryWindow extends BaseWindow implements IAuxiliaryWindow {
 
 			// Disable Menu
 			window.setMenu(null);
+			if ((isWindows || isLinux) && hasNativeTitlebar(this.configurationService)) {
+				window.setAutoHideMenuBar(true); // Fix for https://github.com/microsoft/vscode/issues/200615
+			}
 
 			// Lifecycle
 			this.lifecycleMainService.registerAuxWindow(this);

--- a/src/vs/platform/menubar/electron-main/menubar.ts
+++ b/src/vs/platform/menubar/electron-main/menubar.ts
@@ -379,6 +379,13 @@ export class Menubar {
 		// Setting the application menu sets it to all opened windows,
 		// but we currently do not support a menu in auxiliary windows,
 		// so we need to unset it there.
+		//
+		// This is a bit ugly but `setApplicationMenu()` has some nice
+		// behaviour we want:
+		// - on macOS it is required because menus are application set
+		// - we use `getApplicationMenu()` to access the current state
+		// - new windows immediately get the same menu when opening
+		//   reducing overall flicker for these
 
 		Menu.setApplicationMenu(menu);
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
