### PR TITLE
Reenable chat test

### DIFF
--- a/extensions/vscode-api-tests/package.json
+++ b/extensions/vscode-api-tests/package.json
@@ -7,7 +7,6 @@
   "enabledApiProposals": [
     "authSession",
     "chatAgents2",
-    "chatVariables",
     "contribViewsRemote",
     "contribStatusBarItems",
     "createFileSystemWatcher",

--- a/extensions/vscode-api-tests/src/singlefolder-tests/chat.test.ts
+++ b/extensions/vscode-api-tests/src/singlefolder-tests/chat.test.ts
@@ -8,7 +8,7 @@ import 'mocha';
 import { CancellationToken, chat, ChatAgentRequest, ChatVariableLevel, Disposable, interactive, InteractiveSession, ProviderResult } from 'vscode';
 import { assertNoRpc, closeAllEditors, DeferredPromise, disposeAll } from '../utils';
 
-suite.skip('chat', () => {
+suite('chat', () => {
 
 	let disposables: Disposable[] = [];
 	setup(() => {
@@ -48,9 +48,9 @@ suite.skip('chat', () => {
 	test('agent and slash command', async () => {
 		const deferred = getDeferredForRequest();
 		interactive.sendInteractiveRequestToProvider('provider', { message: '@agent /hello friend' });
-		const lastResult = await deferred.p;
-		assert.deepStrictEqual(lastResult.slashCommand, { name: 'hello', description: 'Hello' });
-		assert.strictEqual(lastResult.prompt, 'friend');
+		const request = await deferred.p;
+		assert.deepStrictEqual(request.subCommand, 'hello');
+		assert.strictEqual(request.prompt, 'friend');
 	});
 
 	test('agent and variable', async () => {
@@ -62,8 +62,8 @@ suite.skip('chat', () => {
 
 		const deferred = getDeferredForRequest();
 		interactive.sendInteractiveRequestToProvider('provider', { message: '@agent hi #myVar' });
-		const lastResult = await deferred.p;
-		assert.strictEqual(lastResult.prompt, 'hi [#myVar](values:myVar)');
-		assert.strictEqual(lastResult.variables['myVar'][0].value, 'myValue');
+		const request = await deferred.p;
+		assert.strictEqual(request.prompt, 'hi [#myVar](values:myVar)');
+		assert.strictEqual(request.variables['myVar'][0].value, 'myValue');
 	});
 });


### PR DESCRIPTION
I think this isn't an issue with the test- every time it fails, we see "The Web Worker Extension Host did not start in 60s". The chat tests are the first tests, and so they just time out due to being affected by the slow startup. That EH timeout issue looks old.
Fix #203429

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
