### PR TITLE
Fix #160621. Do no steal escape when focus is in input.

### DIFF
--- a/src/vs/editor/contrib/gotoSymbol/browser/peek/referencesController.ts
+++ b/src/vs/editor/contrib/gotoSymbol/browser/peek/referencesController.ts
@@ -27,6 +27,8 @@ import { INotificationService } from 'vs/platform/notification/common/notificati
 import { IStorageService, StorageScope, StorageTarget } from 'vs/platform/storage/common/storage';
 import { OneReference, ReferencesModel } from '../referencesModel';
 import { LayoutData, ReferenceWidget } from './referencesWidget';
+import { EditorContextKeys } from 'vs/editor/common/editorContextKeys';
+import { InputFocusedContext } from 'vs/platform/contextkey/common/contextkeys';
 
 export const ctxReferenceSearchVisible = new RawContextKey<boolean>('referenceSearchVisible', false, nls.localize('referenceSearchVisible', "Whether reference peek is visible, like 'Peek References' or 'Peek Definition'"));
 
@@ -367,7 +369,14 @@ KeybindingsRegistry.registerKeybindingRule({
 	weight: KeybindingWeight.WorkbenchContrib + 50,
 	primary: KeyCode.Escape,
 	secondary: [KeyMod.Shift | KeyCode.Escape],
-	when: ContextKeyExpr.and(ctxReferenceSearchVisible, ContextKeyExpr.not('config.editor.stablePeek'))
+	when: ContextKeyExpr.and(
+		ctxReferenceSearchVisible,
+		ContextKeyExpr.not('config.editor.stablePeek'),
+		ContextKeyExpr.or(
+			EditorContextKeys.editorTextFocus,
+			InputFocusedContext.negate()
+		)
+	)
 });
 
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
