### PR TITLE
changed issueReporterCommand types and bug fix

### DIFF
--- a/src/vs/code/electron-sandbox/issue/issueReporterPage.ts
+++ b/src/vs/code/electron-sandbox/issue/issueReporterPage.ts
@@ -93,7 +93,7 @@ export default (): string => `
 				<span id="ext-loading" hidden></span>
 				<span class="ext-parens" hidden>(</span><a href="#" class="showInfo" id="extension-id">${escape(localize('show', "show"))}</a><span class="ext-parens" hidden>)</span>
 			</label>
-			<pre class="block-info" id="extension-data" placeholder="${escape(localize('extensionData', "Extension does not have additional data to include."))}">
+			<pre class="block-info" id="extension-data" placeholder="${escape(localize('extensionData', "Extension does not have additional data to include."))}" style="white-space: pre-wrap;">
 				<!-- To be dynamically filled -->
 			</pre>
 		</div>

--- a/src/vs/code/electron-sandbox/issue/issueReporterService.ts
+++ b/src/vs/code/electron-sandbox/issue/issueReporterService.ts
@@ -15,6 +15,7 @@ import { Disposable } from 'vs/base/common/lifecycle';
 import { isLinuxSnap, isMacintosh } from 'vs/base/common/platform';
 import { escape } from 'vs/base/common/strings';
 import { ThemeIcon } from 'vs/base/common/themables';
+import { URI } from 'vs/base/common/uri';
 import { IssueReporterModel, IssueReporterData as IssueReporterModelData } from 'vs/code/electron-sandbox/issue/issueReporterModel';
 import { localize } from 'vs/nls';
 import { isRemoteDiagnosticError } from 'vs/platform/diagnostics/common/diagnostics';
@@ -249,7 +250,8 @@ export class IssueReporter extends Disposable {
 	private async updateIssueReporterUri(extension: IssueReporterExtensionData): Promise<void> {
 		try {
 			if (extension.command?.uri) {
-				extension.bugsUrl = extension.command.uri;
+				const uri = URI.revive(extension.command.uri);
+				extension.bugsUrl = uri.toString();
 			} else {
 				const uri = await this.issueMainService.$getIssueReporterUri(extension.id);
 				extension.bugsUrl = uri.toString(true);
@@ -958,7 +960,8 @@ export class IssueReporter extends Disposable {
 		}
 
 		if (selectedExtension?.command?.uri) {
-			issueUrl = selectedExtension.command.uri;
+			const uri = URI.revive(selectedExtension.command.uri);
+			issueUrl = uri.toString();
 		}
 
 		const gitHubDetails = this.parseGitHubUrl(issueUrl);

--- a/src/vs/platform/issue/common/issue.ts
+++ b/src/vs/platform/issue/common/issue.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { URI } from 'vs/base/common/uri';
+import { URI, UriComponents } from 'vs/base/common/uri';
 import { ISandboxConfiguration } from 'vs/base/parts/sandbox/common/sandboxTypes';
 import { PerformanceInfo, SystemInfo } from 'vs/platform/diagnostics/common/diagnostics';
 import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
@@ -60,7 +60,7 @@ export interface IssueReporterExtensionData {
 	command?: {
 		data?: string;
 		template?: string;
-		uri?: string;
+		uri?: UriComponents;
 	};
 }
 
@@ -78,7 +78,7 @@ export interface IssueReporterData extends WindowData {
 	command?: {
 		data?: string;
 		template?: string;
-		uri?: string;
+		uri?: UriComponents;
 	};
 }
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

fixes https://github.com/microsoft/vscode/issues/203229 and https://github.com/microsoft/vscode/issues/203249

changed type to UriCompenent.

shape of command may look like this, now that uri is a `UriComponent`:
``` typescript

	vscode.commands.executeCommand('workbench.action.openIssueReporter', {
		extensionId: 'ms-python.python',
		issueTitle: 'title here',
		command: {
			template: template,
			data: data,
			uri: Uri.parse('https://github.com/microsoft/vscode-copilot-release').toJSON(),
		}
	});
}
```