### PR TITLE
Adjust WordHighlighter to use `hasTextFocus()` instead of `hasWidgetFocus()`

### DIFF
--- a/src/vs/editor/contrib/wordHighlighter/browser/wordHighlighter.ts
+++ b/src/vs/editor/contrib/wordHighlighter/browser/wordHighlighter.ts
@@ -491,6 +491,7 @@ class WordHighlighter {
 
 	private _stopAll(): void {
 		// Remove any existing decorations
+		// TODO: @Yoyokrazy - this triggers as notebooks scroll, causing highlights to disappear momentarily.
 		this._removeAllDecorations();
 
 		// Cancel any renderDecorationsTimer
@@ -608,7 +609,7 @@ class WordHighlighter {
 	private _run(): void {
 
 		let workerRequestIsValid;
-		if (!this.editor.hasWidgetFocus()) { // no focus (new nb cell, etc)
+		if (!this.editor.hasTextFocus()) { // no focus (new nb cell, etc)
 			if (WordHighlighter.query === null) {
 				// no previous query, nothing to highlight
 				return;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fixes: #203752

Notebook cells being scrolled in held widget focus, causing highlights to be computed off selection of 1,1,1,1. Change condition to textFocus, which scrolled in cells never hold. This also brings a check for model data (performed within text focus, which potentially can help with reading from disposed models re: #201814 and #201824 but need to monitor error telem)
