### PR TITLE
fix: update rpm release tag to el8

### DIFF
--- a/resources/linux/rpm/code.spec.template
+++ b/resources/linux/rpm/code.spec.template
@@ -1,6 +1,6 @@
 Name:     @@NAME@@
 Version:  @@VERSION@@
-Release:  @@RELEASE@@.el7
+Release:  @@RELEASE@@.el8
 Summary:  Code editing. Redefined.
 Group:    Development/Tools
 Vendor:   Microsoft Corporation


### PR DESCRIPTION
Upcoming release `1.86` has [updated glibc requirements](https://code.visualstudio.com/docs/supporting/faq#_can-i-run-vs-code-on-older-linux-distributions) which will break package install on el7 systems, updating the tag to signify that.

I would like to do something similar for debian packages but haven't found the way. Suggestions welcome!

/cc @rzhao271 