### PR TITLE
Add promiseWithResolvers shim

### DIFF
--- a/src/vs/base/common/async.ts
+++ b/src/vs/base/common/async.ts
@@ -137,6 +137,21 @@ export function asPromise<T>(callback: () => T | Thenable<T>): Promise<T> {
 	});
 }
 
+/**
+ * Creates and returns a new promise, plus its `resolve` and `reject` callbacks.
+ *
+ * Replace with standardized [`Promise.withResolvers`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/withResolvers) once it is supported
+ */
+export function promiseWithResolvers<T>(): { promise: Promise<T>; resolve: (value: T | PromiseLike<T>) => void; reject: (err?: any) => void } {
+	let resolve: (value: T | PromiseLike<T>) => void;
+	let reject: (reason?: any) => void;
+	const promise = new Promise<T>((res, rej) => {
+		resolve = res;
+		reject = rej;
+	});
+	return { promise, resolve: resolve!, reject: reject! };
+}
+
 export interface ITask<T> {
 	(): T;
 }
@@ -1467,13 +1482,7 @@ export class TaskSequentializer {
 		// so that we can return a promise that completes when the task has
 		// completed.
 		if (!this._queued) {
-			let promiseResolve: () => void;
-			let promiseReject: (error: Error) => void;
-			const promise = new Promise<void>((resolve, reject) => {
-				promiseResolve = resolve;
-				promiseReject = reject;
-			});
-
+			const { promise, resolve: promiseResolve, reject: promiseReject } = promiseWithResolvers<void>();
 			this._queued = {
 				run,
 				promise,

--- a/src/vs/editor/contrib/codeAction/test/browser/codeActionModel.test.ts
+++ b/src/vs/editor/contrib/codeAction/test/browser/codeActionModel.test.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as assert from 'assert';
+import { promiseWithResolvers } from 'vs/base/common/async';
 import { DisposableStore } from 'vs/base/common/lifecycle';
 import { assertType } from 'vs/base/common/types';
 import { URI } from 'vs/base/common/uri';
@@ -56,10 +57,8 @@ suite('CodeActionModel', () => {
 	});
 
 	test('Oracle -> marker added', async () => {
-		let done: () => void;
-		const donePromise = new Promise<void>(resolve => {
-			done = resolve;
-		});
+		const { promise: donePromise, resolve: done } = promiseWithResolvers<void>();
+
 		await runWithFakedTimers({ useFakeTimers: true }, () => {
 			const reg = registry.register(languageId, testProvider);
 			disposables.add(reg);
@@ -127,9 +126,7 @@ suite('CodeActionModel', () => {
 	});
 
 	test('Oracle -> should only auto trigger once for cursor and marker update right after each other', async () => {
-		let done: () => void;
-		const donePromise = new Promise<void>(resolve => { done = resolve; });
-
+		const { promise: donePromise, resolve: done } = promiseWithResolvers<void>();
 		await runWithFakedTimers({ useFakeTimers: true }, () => {
 			const reg = registry.register(languageId, testProvider);
 			disposables.add(reg);

--- a/src/vs/editor/contrib/parameterHints/test/browser/parameterHintsModel.test.ts
+++ b/src/vs/editor/contrib/parameterHints/test/browser/parameterHintsModel.test.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as assert from 'assert';
+import { promiseWithResolvers } from 'vs/base/common/async';
 import { CancellationToken } from 'vs/base/common/cancellation';
 import { DisposableStore } from 'vs/base/common/lifecycle';
 import { URI } from 'vs/base/common/uri';
@@ -76,8 +77,7 @@ suite('ParameterHintsModel', () => {
 	}
 
 	test('Provider should get trigger character on type', async () => {
-		let done: () => void;
-		const donePromise = new Promise<void>(resolve => { done = resolve; });
+		const { promise: donePromise, resolve: done } = promiseWithResolvers<void>();
 
 		const triggerChar = '(';
 
@@ -103,8 +103,7 @@ suite('ParameterHintsModel', () => {
 	});
 
 	test('Provider should be retriggered if already active', async () => {
-		let done: () => void;
-		const donePromise = new Promise<void>(resolve => { done = resolve; });
+		const { promise: donePromise, resolve: done } = promiseWithResolvers<void>();
 
 		const triggerChar = '(';
 
@@ -151,8 +150,7 @@ suite('ParameterHintsModel', () => {
 	});
 
 	test('Provider should not be retriggered if previous help is canceled first', async () => {
-		let done: () => void;
-		const donePromise = new Promise<void>(resolve => { done = resolve; });
+		const { promise: donePromise, resolve: done } = promiseWithResolvers<void>();
 
 		const triggerChar = '(';
 
@@ -199,8 +197,7 @@ suite('ParameterHintsModel', () => {
 	});
 
 	test('Provider should get last trigger character when triggered multiple times and only be invoked once', async () => {
-		let done: () => void;
-		const donePromise = new Promise<void>(resolve => { done = resolve; });
+		const { promise: donePromise, resolve: done } = promiseWithResolvers<void>();
 
 		const editor = createMockEditor('');
 		disposables.add(new ParameterHintsModel(editor, registry, 5));
@@ -242,8 +239,7 @@ suite('ParameterHintsModel', () => {
 	});
 
 	test('Provider should be retriggered if already active', async () => {
-		let done: () => void;
-		const donePromise = new Promise<void>(resolve => { done = resolve; });
+		const { promise: donePromise, resolve: done } = promiseWithResolvers<void>();
 
 		const editor = createMockEditor('');
 		disposables.add(new ParameterHintsModel(editor, registry, 5));
@@ -351,8 +347,7 @@ suite('ParameterHintsModel', () => {
 	});
 
 	test('Provider should be retriggered by retrigger character', async () => {
-		let done: () => void;
-		const donePromise = new Promise<void>(resolve => { done = resolve; });
+		const { promise: donePromise, resolve: done } = promiseWithResolvers<void>();
 
 		const triggerChar = 'a';
 		const retriggerChar = 'b';
@@ -521,8 +516,7 @@ suite('ParameterHintsModel', () => {
 	});
 
 	test('Retrigger while a pending resolve is still going on should preserve last active signature #96702', async () => {
-		let done: (r?: any) => void;
-		const donePromise = new Promise<void>(resolve => { done = resolve; });
+		const { promise: donePromise, resolve: done } = promiseWithResolvers<void>();
 
 		const editor = createMockEditor('');
 		const model = disposables.add(new ParameterHintsModel(editor, registry, 50));

--- a/src/vs/workbench/api/test/common/extHostExtensionActivator.test.ts
+++ b/src/vs/workbench/api/test/common/extHostExtensionActivator.test.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as assert from 'assert';
-import { timeout } from 'vs/base/common/async';
+import { promiseWithResolvers, timeout } from 'vs/base/common/async';
 import { URI } from 'vs/base/common/uri';
 import { ExtensionIdentifier, IExtensionDescription, IRelaxedExtensionDescription, TargetPlatform } from 'vs/platform/extensions/common/extensions';
 import { NullLogService } from 'vs/platform/log/common/log';
@@ -228,15 +228,12 @@ suite('ExtensionsActivator', () => {
 	}
 
 	class ExtensionActivationPromiseSource {
-		private _resolve!: (value: ActivatedExtension) => void;
-		private _reject!: (err: Error) => void;
+		private readonly _resolve: (value: ActivatedExtension) => void;
+		private readonly _reject: (err: Error) => void;
 		public readonly promise: Promise<ActivatedExtension>;
 
 		constructor() {
-			this.promise = new Promise<ActivatedExtension>((resolve, reject) => {
-				this._resolve = resolve;
-				this._reject = reject;
-			});
+			({ promise: this.promise, resolve: this._resolve, reject: this._reject } = promiseWithResolvers<ActivatedExtension>());
 		}
 
 		public resolve(): void {

--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewPreloads.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewPreloads.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import type * as DOM from 'vs/base/browser/window';
+import { promiseWithResolvers } from 'vs/base/common/async';
 import type { Event } from 'vs/base/common/event';
 import type { IDisposable } from 'vs/base/common/lifecycle';
 import type * as webviewMessages from 'vs/workbench/contrib/notebook/browser/view/renderers/webviewMessages';
@@ -800,12 +801,11 @@ async function webviewPreloads(ctx: PreloadContext) {
 		getOutputItem(outputId: string, mime: string) {
 			const requestId = this._requestPool++;
 
-			let resolve: ((x: webviewMessages.OutputItemEntry | undefined) => void) | undefined;
-			const p = new Promise<webviewMessages.OutputItemEntry | undefined>(r => resolve = r);
-			this._requests.set(requestId, { resolve: resolve! });
+			const { promise, resolve } = promiseWithResolvers<webviewMessages.OutputItemEntry | undefined>();
+			this._requests.set(requestId, { resolve });
 
 			postNotebookMessage<webviewMessages.IGetOutputItemMessage>('getOutputItem', { requestId, outputId, mime });
-			return p;
+			return promise;
 		}
 
 		resolveOutputItem(requestId: number, output: webviewMessages.OutputItemEntry | undefined) {
@@ -2254,12 +2254,8 @@ async function webviewPreloads(ctx: PreloadContext) {
 			this.id = id;
 			this._content = { value: content, version: 0, metadata: metadata };
 
-			let resolve: () => void;
-			let reject: () => void;
-			this.ready = new Promise<void>((res, rej) => {
-				resolve = res;
-				reject = rej;
-			});
+			const { promise, resolve, reject } = promiseWithResolvers<void>();
+			this.ready = promise;
 
 			let cachedData: { readonly version: number; readonly value: Uint8Array } | undefined;
 			this.outputItem = Object.freeze<ExtendedOutputItem>({

--- a/src/vs/workbench/contrib/terminal/browser/terminalInstanceService.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalInstanceService.ts
@@ -16,6 +16,7 @@ import { Emitter, Event } from 'vs/base/common/event';
 import { TerminalContextKeys } from 'vs/workbench/contrib/terminal/common/terminalContextKey';
 import { Registry } from 'vs/platform/registry/common/platform';
 import { IWorkbenchEnvironmentService } from 'vs/workbench/services/environment/common/environmentService';
+import { promiseWithResolvers } from 'vs/base/common/async';
 
 export class TerminalInstanceService extends Disposable implements ITerminalInstanceService {
 	declare _serviceBrand: undefined;
@@ -37,11 +38,9 @@ export class TerminalInstanceService extends Disposable implements ITerminalInst
 		this._terminalInRunCommandPicker = TerminalContextKeys.inTerminalRunCommandPicker.bindTo(this._contextKeyService);
 		this._configHelper = _instantiationService.createInstance(TerminalConfigHelper);
 
-
 		for (const remoteAuthority of [undefined, _environmentService.remoteAuthority]) {
-			let resolve: () => void;
-			const p = new Promise<void>(r => resolve = r);
-			this._backendRegistration.set(remoteAuthority, { promise: p, resolve: resolve! });
+			const { promise, resolve } = promiseWithResolvers<void>();
+			this._backendRegistration.set(remoteAuthority, { promise, resolve });
 		}
 	}
 

--- a/src/vs/workbench/contrib/webview/browser/webviewElement.ts
+++ b/src/vs/workbench/contrib/webview/browser/webviewElement.ts
@@ -6,7 +6,7 @@
 import { isFirefox } from 'vs/base/browser/browser';
 import { addDisposableListener, EventType, getActiveWindow } from 'vs/base/browser/dom';
 import { IMouseWheelEvent } from 'vs/base/browser/mouseEvent';
-import { ThrottledDelayer } from 'vs/base/common/async';
+import { promiseWithResolvers, ThrottledDelayer } from 'vs/base/common/async';
 import { streamToBuffer, VSBufferReadableStream } from 'vs/base/common/buffer';
 import { CancellationTokenSource } from 'vs/base/common/cancellation';
 import { Emitter, Event } from 'vs/base/common/event';
@@ -418,9 +418,8 @@ export class WebviewElement extends Disposable implements IWebview, WebviewFindD
 
 	private async _send<K extends keyof ToWebviewMessage>(channel: K, data: ToWebviewMessage[K], _createElement: Transferable[] = []): Promise<boolean> {
 		if (this._state.type === WebviewState.Type.Initializing) {
-			let resolve: (x: boolean) => void;
-			const promise = new Promise<boolean>(r => resolve = r);
-			this._state.pendingMessages.push({ channel, data, transferable: _createElement, resolve: resolve! });
+			const { promise, resolve } = promiseWithResolvers<boolean>();
+			this._state.pendingMessages.push({ channel, data, transferable: _createElement, resolve });
 			return promise;
 		} else {
 			return this.doPostMessage(channel, data, _createElement);

--- a/src/vs/workbench/contrib/webviewView/browser/webviewViewService.ts
+++ b/src/vs/workbench/contrib/webviewView/browser/webviewViewService.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { promiseWithResolvers } from 'vs/base/common/async';
 import { CancellationToken } from 'vs/base/common/cancellation';
 import { Emitter, Event } from 'vs/base/common/event';
 import { Disposable, IDisposable, toDisposable } from 'vs/base/common/lifecycle';
@@ -130,10 +131,9 @@ export class WebviewViewService extends Disposable implements IWebviewViewServic
 				throw new Error('View already awaiting revival');
 			}
 
-			let resolve: () => void;
-			const p = new Promise<void>(r => resolve = r);
-			this._awaitingRevival.set(viewType, { webview, resolve: resolve! });
-			return p;
+			const { promise, resolve } = promiseWithResolvers<void>();
+			this._awaitingRevival.set(viewType, { webview, resolve });
+			return promise;
 		}
 
 		return resolver.resolve(webview, cancellation);

--- a/src/vs/workbench/contrib/welcomeViews/common/newFile.contribution.ts
+++ b/src/vs/workbench/contrib/welcomeViews/common/newFile.contribution.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { promiseWithResolvers } from 'vs/base/common/async';
 import { KeyMod, KeyCode } from 'vs/base/common/keyCodes';
 import { Disposable, DisposableStore } from 'vs/base/common/lifecycle';
 import { assertIsDefined } from 'vs/base/common/types';
@@ -95,10 +96,7 @@ class NewFileTemplatesManager extends Disposable {
 	}
 
 	private async selectNewEntry(entries: NewFileItem[]): Promise<boolean> {
-		let resolveResult: (res: boolean) => void;
-		const resultPromise = new Promise<boolean>(resolve => {
-			resolveResult = resolve;
-		});
+		const { promise: resultPromise, resolve: resolveResult } = promiseWithResolvers<boolean>();
 
 		const disposables = new DisposableStore();
 		const qp = this.quickInputService.createQuickPick();

--- a/src/vs/workbench/services/extensions/common/extensionDescriptionRegistry.ts
+++ b/src/vs/workbench/services/extensions/common/extensionDescriptionRegistry.ts
@@ -7,6 +7,7 @@ import { ExtensionIdentifier, ExtensionIdentifierMap, ExtensionIdentifierSet, IE
 import { Emitter } from 'vs/base/common/event';
 import * as path from 'vs/base/common/path';
 import { Disposable, IDisposable, toDisposable } from 'vs/base/common/lifecycle';
+import { promiseWithResolvers } from 'vs/base/common/async';
 
 export class DeltaExtensionsResult {
 	constructor(
@@ -323,14 +324,14 @@ export class ExtensionDescriptionRegistryLock extends Disposable {
 
 class LockCustomer {
 	public readonly promise: Promise<IDisposable>;
-	private _resolve!: (value: IDisposable) => void;
+	private readonly _resolve: (value: IDisposable) => void;
 
 	constructor(
 		public readonly name: string
 	) {
-		this.promise = new Promise<IDisposable>((resolve, reject) => {
-			this._resolve = resolve;
-		});
+		const withResolvers = promiseWithResolvers<IDisposable>();
+		this.promise = withResolvers.promise;
+		this._resolve = withResolvers.resolve;
 	}
 
 	resolve(value: IDisposable): void {

--- a/src/vs/workbench/services/workspaces/common/workspaceTrust.ts
+++ b/src/vs/workbench/services/workspaces/common/workspaceTrust.ts
@@ -23,6 +23,7 @@ import { IUriIdentityService } from 'vs/platform/uriIdentity/common/uriIdentity'
 import { isEqualAuthority } from 'vs/base/common/resources';
 import { isWeb } from 'vs/base/common/platform';
 import { IFileService } from 'vs/platform/files/common/files';
+import { promiseWithResolvers } from 'vs/base/common/async';
 
 export const WORKSPACE_TRUST_ENABLED = 'security.workspace.trust.enabled';
 export const WORKSPACE_TRUST_STARTUP_PROMPT = 'security.workspace.trust.startupPrompt';
@@ -90,10 +91,10 @@ export class WorkspaceTrustManagementService extends Disposable implements IWork
 
 	private readonly storageKey = WORKSPACE_TRUST_STORAGE_KEY;
 
-	private _workspaceResolvedPromise: Promise<void>;
-	private _workspaceResolvedPromiseResolve!: () => void;
-	private _workspaceTrustInitializedPromise: Promise<void>;
-	private _workspaceTrustInitializedPromiseResolve!: () => void;
+	private readonly _workspaceResolvedPromise: Promise<void>;
+	private readonly _workspaceResolvedPromiseResolve: () => void;
+	private readonly _workspaceTrustInitializedPromise: Promise<void>;
+	private readonly _workspaceTrustInitializedPromiseResolve: () => void;
 
 	private readonly _onDidChangeTrust = this._register(new Emitter<boolean>());
 	readonly onDidChangeTrust = this._onDidChangeTrust.event;
@@ -127,12 +128,8 @@ export class WorkspaceTrustManagementService extends Disposable implements IWork
 		this._canonicalUrisResolved = false;
 		this._canonicalWorkspace = this.workspaceService.getWorkspace();
 
-		this._workspaceResolvedPromise = new Promise((resolve) => {
-			this._workspaceResolvedPromiseResolve = resolve;
-		});
-		this._workspaceTrustInitializedPromise = new Promise((resolve) => {
-			this._workspaceTrustInitializedPromiseResolve = resolve;
-		});
+		({ promise: this._workspaceResolvedPromise, resolve: this._workspaceResolvedPromiseResolve } = promiseWithResolvers());
+		({ promise: this._workspaceTrustInitializedPromise, resolve: this._workspaceTrustInitializedPromiseResolve } = promiseWithResolvers());
 
 		this._storedTrustState = new WorkspaceTrustMemento(isWeb && this.isEmptyWorkspace() ? undefined : this.storageService);
 		this._trustTransitionManager = this._register(new WorkspaceTrustTransitionManager());


### PR DESCRIPTION
Adds a shim for `Promise.withResolvers`. This is slightly reduces lines of code. More importantly it plays more nicely with TypeScript's type checking and lets us mark more vars const and properties readonly

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
