### PR TITLE
Don't accidentally create InlineChatFileCreatePreviewWidget when hiding it

### DIFF
--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatController.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatController.ts
@@ -924,7 +924,7 @@ export class InlineChatController implements IEditorContribution {
 		this._ctxLastFeedbackKind.reset();
 		this._ctxSupportIssueReporting.reset();
 
-		this._zone.value.hide();
+		this._zone.rawValue?.hide();
 
 		// Return focus to the editor only if the current focus is within the editor widget
 		if (this._editor.hasWidgetFocus()) {

--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatStrategies.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatStrategies.ts
@@ -287,7 +287,7 @@ export class LivePreviewStrategy extends EditModeStrategy {
 		if (response.untitledTextModel && !response.untitledTextModel.isDisposed()) {
 			this._previewZone.value.showCreation(this._session.wholeRange.value.getStartPosition().delta(-1), response.untitledTextModel);
 		} else {
-			this._previewZone.value.hide();
+			this._previewZone.rawValue?.hide();
 		}
 
 		return this._updateDiffZones();
@@ -526,7 +526,7 @@ export class LiveStrategy extends EditModeStrategy {
 		if (response.untitledTextModel && !response.untitledTextModel.isDisposed()) {
 			this._previewZone.value.showCreation(this._session.wholeRange.value.getStartPosition().delta(-1), response.untitledTextModel);
 		} else {
-			this._previewZone.value.hide();
+			this._previewZone.rawValue?.hide();
 		}
 
 		this._progressiveEditingDecorations.clear();


### PR DESCRIPTION
Accessing `.value` causes the widget to be created. We don't need to do that on hide