### PR TITLE
Fix broken highlights when clicking a previously selected symbol

### DIFF
--- a/src/vs/editor/contrib/wordHighlighter/browser/wordHighlighter.ts
+++ b/src/vs/editor/contrib/wordHighlighter/browser/wordHighlighter.ts
@@ -309,6 +309,11 @@ class WordHighlighter {
 
 			this._onPositionChanged(e);
 		}));
+		this.toUnhook.add(editor.onDidFocusEditorText((e) => {
+			if (!this.workerRequest) {
+				this._run();
+			}
+		}));
 		this.toUnhook.add(editor.onDidChangeModelContent((e) => {
 			this._stopAll();
 		}));
@@ -451,6 +456,7 @@ class WordHighlighter {
 
 			if (editorHighlighterContrib.wordHighlighter.decorations.length > 0) {
 				editorHighlighterContrib.wordHighlighter.decorations.clear();
+				editorHighlighterContrib.wordHighlighter.workerRequest = null;
 				editorHighlighterContrib.wordHighlighter._hasWordHighlights.set(false);
 			}
 		}
@@ -467,7 +473,7 @@ class WordHighlighter {
 		if (this.editor.hasTextFocus()) {
 			if (this.editor.getModel()?.uri.scheme !== Schemas.vscodeNotebookCell && WordHighlighter.query?.modelInfo?.model.uri.scheme !== Schemas.vscodeNotebookCell) { // clear query if focused non-nb editor
 				WordHighlighter.query = null;
-				this._run();
+				this._run(); // TODO: @Yoyokrazy -- investigate why we need a full rerun here. likely addressed a case/patch in the first iteration of this feature
 			} else { // remove modelInfo to account for nb cell being disposed
 				if (WordHighlighter.query?.modelInfo) {
 					WordHighlighter.query.modelInfo = null;
@@ -615,16 +621,18 @@ class WordHighlighter {
 	private _run(): void {
 
 		let workerRequestIsValid;
-		if (!this.editor.hasTextFocus()) { // no focus (new nb cell, etc)
-			if (WordHighlighter.query === null) {
-				// no previous query, nothing to highlight
+		const hasTextFocus = this.editor.hasTextFocus();
+
+		if (!hasTextFocus) { // new nb cell scrolled in, didChangeModel fires
+			if (!WordHighlighter.query) { // no previous query, nothing to highlight off of
 				return;
 			}
-		} else {
+		} else { // has text focus
 			const editorSelection = this.editor.getSelection();
 
 			// ignore multiline selection
 			if (!editorSelection || editorSelection.startLineNumber !== editorSelection.endLineNumber) {
+				WordHighlighter.query = null;
 				this._stopAll();
 				return;
 			}
@@ -686,20 +694,14 @@ class WordHighlighter {
 
 			const otherModelsToHighlight = this.getOtherModelsToHighlight(this.editor.getModel());
 
-			// 2 cases where we want to send the word
-			// a) there is no stored query model, but there is a word. This signals the editor that drove the highlight is disposed (cell out of viewport, etc)
-			// b) the queried model is not the current model. This signals that the editor that drove the highlight is still in the viewport, but we are highlighting a different cell
-			// otherwise, we send null in place of the word, and the model and selection are used to compute the word
-			// TODO: @Yoyokrazy -- investigate this logic for sendWord
-			const sendWord = (!WordHighlighter.query.modelInfo && WordHighlighter.query.word) ||
-				(WordHighlighter.query.modelInfo?.model.uri !== this.model.uri)
-				? true : false;
-
-			if (!WordHighlighter.query.modelInfo || (WordHighlighter.query.modelInfo.model.uri !== this.model.uri)) { // use this.model
-				this.workerRequest = this.computeWithModel(this.model, this.editor.getSelection(), sendWord ? WordHighlighter.query.word : null, otherModelsToHighlight);
-			} else { // use stored query model + selection
-				this.workerRequest = this.computeWithModel(WordHighlighter.query.modelInfo.model, WordHighlighter.query.modelInfo.selection, WordHighlighter.query.word, otherModelsToHighlight);
+			// when reaching here, there are two possible states.
+			// 		1) we have text focus, and a valid query was updated.
+			// 		2) we do not have text focus, and a valid query is cached.
+			// the query will ALWAYS have the correct data for the current highlight request, so it can always be passed to the workerRequest safely
+			if (!WordHighlighter.query.modelInfo || WordHighlighter.query.modelInfo.model.isDisposed()) {
+				return;
 			}
+			this.workerRequest = this.computeWithModel(WordHighlighter.query.modelInfo.model, WordHighlighter.query.modelInfo.selection, WordHighlighter.query.word, otherModelsToHighlight);
 
 			this.workerRequest?.result.then(data => {
 				if (myRequestId === this.workerRequestTokenId) {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fixes #199866

When an editor lost focus and the decorations were cleared, the worker request stayed live. This meant that if you click another editor and return to the same symbol you previously selected, the workerRequest would think that highlights are still present and don't need to be re-rendered.

Also a hard to find bug, if you select the EXACT same cursor position when you return to the editor, cursor position req does not fire and highlights are not computed at all.

Fix -- set worker req to null on focus loss, compute highlights on editor focus if !workerReq
also some misc logic streamlining in the last quarter of _run()