### PR TITLE
Fix Extra Padding Near Dropdown in Terminal

### DIFF
--- a/src/vs/workbench/browser/parts/media/paneCompositePart.css
+++ b/src/vs/workbench/browser/parts/media/paneCompositePart.css
@@ -9,7 +9,7 @@
 
 .monaco-workbench .pane-composite-part > .title.has-composite-bar > .title-actions .monaco-action-bar .action-item,
 .monaco-workbench .pane-composite-part > .title.has-composite-bar > .global-actions .monaco-action-bar .action-item {
-	padding-right: 4px; /* Use padding instead of margin for width computation to be correct #200515 */
+	margin-right: 4px;
 }
 
 .monaco-workbench .pane-composite-part > .title.has-composite-bar > .title-actions .monaco-action-bar .action-item .action-label {

--- a/src/vs/workbench/browser/parts/paneCompositePart.ts
+++ b/src/vs/workbench/browser/parts/paneCompositePart.ts
@@ -479,7 +479,11 @@ export abstract class AbstractPaneCompositePart extends CompositePart<PaneCompos
 		if (!activePane || !this.toolBar) {
 			return 0;
 		}
-		return this.toolBar.getItemsWidth() + 5 + (this.globalToolBar?.getItemsWidth() ?? 0); // 5px toolBar padding-left
+
+		// Each toolbar item has 4px margin in the panel toolbar
+		const toolBarWidth = this.toolBar.getItemsWidth() + this.toolBar.getItemsLength() * 4;
+		const globalToolBarWidth = this.globalToolBar ? this.globalToolBar.getItemsWidth() + this.globalToolBar.getItemsLength() * 4 : 0;
+		return 5 + toolBarWidth + globalToolBarWidth; // 5px toolBar padding-left
 	}
 
 	private onTitleAreaContextMenu(event: StandardMouseEvent): void {


### PR DESCRIPTION
This PR addresses the issue of extra padding to the right of the dropdown in the terminal for the insider release. The padding has been adjusted to match the stable release. This was achieved by modifying the padding and margin values in the relevant CSS and JavaScript files.

Fixes #202078