### PR TITLE
Fix inoperative try/catch

### DIFF
--- a/src/vs/workbench/services/keybinding/browser/keyboardLayoutService.ts
+++ b/src/vs/workbench/services/keybinding/browser/keyboardLayoutService.ts
@@ -396,7 +396,7 @@ export class BrowserKeyboardMapperFactoryBase extends Disposable {
 	private async _getBrowserKeyMapping(keyboardEvent?: IKeyboardEvent): Promise<IRawMixedKeyboardMapping | null> {
 		if ((navigator as any).keyboard) {
 			try {
-				return (navigator as any).keyboard.getLayoutMap().then((e: any) => {
+				return await (navigator as any).keyboard.getLayoutMap().then((e: any) => {
 					const ret: IKeyboardMapping = {};
 					for (const key of e) {
 						ret[key[0]] = {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

There is a try/catch preventing errors `if invoked from a nested browsing context` but at least in lastest chrome, the method returns a rejected promise in that case and the try/catch does nothing leading to an uncaught error