### PR TITLE
Tunnel: Extend port mapping lookup also for querystring

### DIFF
--- a/src/vs/platform/tunnel/common/tunnel.ts
+++ b/src/vs/platform/tunnel/common/tunnel.ts
@@ -141,18 +141,31 @@ export interface ITunnelService {
 	isPortPrivileged(port: number): boolean;
 }
 
-export function extractLocalHostUriMetaDataForPortMapping(uri: URI): { address: string; port: number } | undefined {
+export function extractLocalHostUriMetaDataForPortMapping(uri: URI, { checkQuery = true } = {}): { address: string; port: number } | undefined {
 	if (uri.scheme !== 'http' && uri.scheme !== 'https') {
 		return undefined;
 	}
 	const localhostMatch = /^(localhost|127\.0\.0\.1|0\.0\.0\.0):(\d+)$/.exec(uri.authority);
-	if (!localhostMatch) {
+	if (localhostMatch) {
+		return {
+			address: localhostMatch[1],
+			port: +localhostMatch[2],
+		};
+	}
+	if (!uri.query || !checkQuery) {
 		return undefined;
 	}
-	return {
-		address: localhostMatch[1],
-		port: +localhostMatch[2],
-	};
+	const keyvalues = uri.query.split('&');
+	for (const keyvalue of keyvalues) {
+		const value = keyvalue.split('=')[1];
+		if (/^https?:/.exec(value)) {
+			const result = extractLocalHostUriMetaDataForPortMapping(URI.parse(value));
+			if (result) {
+				return result;
+			}
+		}
+	}
+	return undefined;
 }
 
 export const LOCALHOST_ADDRESSES = ['localhost', '127.0.0.1', '0:0:0:0:0:0:0:1', '::1'];

--- a/src/vs/platform/tunnel/test/common/tunnel.test.ts
+++ b/src/vs/platform/tunnel/test/common/tunnel.test.ts
@@ -1,0 +1,44 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import * as assert from 'assert';
+import { URI } from 'vs/base/common/uri';
+import { extractLocalHostUriMetaDataForPortMapping } from 'vs/platform/tunnel/common/tunnel';
+import { ensureNoDisposablesAreLeakedInTestSuite } from 'vs/base/test/common/utils';
+
+
+suite('Tunnel', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	function portMappingDoTest(res: { address: string; port: number } | undefined, expectedAddress?: string, expectedPort?: number) {
+		assert.strictEqual(!expectedAddress, !res);
+		assert.strictEqual(res?.address, expectedAddress);
+		assert.strictEqual(res?.port, expectedPort);
+	}
+
+	function portMappingTest(uri: string, expectedAddress?: string, expectedPort?: number) {
+		for (const checkQuery of [true, false]) {
+			portMappingDoTest(extractLocalHostUriMetaDataForPortMapping(URI.parse(uri), { checkQuery }), expectedAddress, expectedPort);
+		}
+	}
+
+	function portMappingTestQuery(uri: string, expectedAddress?: string, expectedPort?: number) {
+		portMappingDoTest(extractLocalHostUriMetaDataForPortMapping(URI.parse(uri)), expectedAddress, expectedPort);
+		portMappingDoTest(extractLocalHostUriMetaDataForPortMapping(URI.parse(uri), { checkQuery: false }), undefined, undefined);
+	}
+
+	test('portMapping', () => {
+		portMappingTest('file:///foo.bar/baz');
+		portMappingTest('http://foo.bar:1234');
+		portMappingTest('http://localhost:8080', 'localhost', 8080);
+		portMappingTest('https://localhost:443', 'localhost', 443);
+		portMappingTest('http://127.0.0.1:3456', '127.0.0.1', 3456);
+		portMappingTest('http://0.0.0.0:7654', '0.0.0.0', 7654);
+		portMappingTest('http://localhost:8080/path?foo=bar', 'localhost', 8080);
+		portMappingTest('http://localhost:8080/path?foo=http%3A%2F%2Flocalhost%3A8081', 'localhost', 8080);
+		portMappingTestQuery('http://foo.bar/path?url=http%3A%2F%2Flocalhost%3A8081', 'localhost', 8081);
+		portMappingTestQuery('http://foo.bar/path?url=http%3A%2F%2Flocalhost%3A8081&url2=http%3A%2F%2Flocalhost%3A8082', 'localhost', 8081);
+		portMappingTestQuery('http://foo.bar/path?url=http%3A%2F%2Fmicrosoft.com%2Fbad&url2=http%3A%2F%2Flocalhost%3A8081', 'localhost', 8081);
+	});
+});

--- a/src/vs/platform/webview/common/webviewPortMapping.ts
+++ b/src/vs/platform/webview/common/webviewPortMapping.ts
@@ -29,7 +29,7 @@ export class WebviewPortMappingManager implements IDisposable {
 
 	public async getRedirect(resolveAuthority: IAddress | null | undefined, url: string): Promise<string | undefined> {
 		const uri = URI.parse(url);
-		const requestLocalHostInfo = extractLocalHostUriMetaDataForPortMapping(uri);
+		const requestLocalHostInfo = extractLocalHostUriMetaDataForPortMapping(uri, { checkQuery: false });
 		if (!requestLocalHostInfo) {
 			return undefined;
 		}


### PR DESCRIPTION
When running az login, the URL has localhost in redirect_uri query param. This should trigger automatic port mapping.

Improve localhost port mapping to cover this case as well.

- Fixes #203869