### PR TITLE
Fix leak/exception and links becoming bricked within the terminal

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/links/browser/terminal.links.contribution.ts
+++ b/src/vs/workbench/contrib/terminalContrib/links/browser/terminal.links.contribution.ts
@@ -66,15 +66,15 @@ class TerminalLinkContribution extends DisposableStore implements ITerminalContr
 		// Attach the link provider(s) to the instance and listen for changes
 		if (!isDetachedTerminalInstance(this._instance)) {
 			for (const linkProvider of this._terminalLinkProviderService.linkProviders) {
-				this._linkManager.registerExternalLinkProvider(linkProvider.provideLinks.bind(linkProvider, this._instance));
+				linkManager.registerExternalLinkProvider(linkProvider.provideLinks.bind(linkProvider, this._instance));
 			}
-			this._linkManager.add(this._terminalLinkProviderService.onDidAddLinkProvider(e => {
+			linkManager.add(this._terminalLinkProviderService.onDidAddLinkProvider(e => {
 				linkManager.registerExternalLinkProvider(e.provideLinks.bind(e, this._instance as ITerminalInstance));
 			}));
 		}
 
 		// TODO: Currently only a single link provider is supported; the one registered by the ext host
-		this._linkManager.add(this._terminalLinkProviderService.onDidRemoveLinkProvider(e => {
+		linkManager.add(this._terminalLinkProviderService.onDidRemoveLinkProvider(e => {
 			linkManager.dispose();
 			this.xtermReady(xterm);
 		}));

--- a/src/vs/workbench/contrib/terminalContrib/links/browser/terminal.links.contribution.ts
+++ b/src/vs/workbench/contrib/terminalContrib/links/browser/terminal.links.contribution.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { Event } from 'vs/base/common/event';
 import { KeyCode, KeyMod } from 'vs/base/common/keyCodes';
 import { DisposableStore } from 'vs/base/common/lifecycle';
 import { localize2 } from 'vs/nls';
@@ -50,27 +51,30 @@ class TerminalLinkContribution extends DisposableStore implements ITerminalContr
 	}
 
 	xtermReady(xterm: IXtermTerminal & { raw: RawXtermTerminal }): void {
-		const linkManager = this._instantiationService.createInstance(TerminalLinkManager, xterm.raw, this._processManager, this._instance.capabilities, this._linkResolver);
+		const linkManager = this._linkManager = this.add(this._instantiationService.createInstance(TerminalLinkManager, xterm.raw, this._processManager, this._instance.capabilities, this._linkResolver));
+
+		// Set widget manager
 		if (isTerminalProcessManager(this._processManager)) {
-			this._processManager.onProcessReady(() => {
+			const disposable = this.add(Event.once(this._processManager.onProcessReady)(() => {
 				linkManager.setWidgetManager(this._widgetManager);
-			});
+				this.delete(disposable);
+			}));
 		} else {
 			linkManager.setWidgetManager(this._widgetManager);
 		}
-		this._linkManager = this.add(linkManager);
 
 		// Attach the link provider(s) to the instance and listen for changes
 		if (!isDetachedTerminalInstance(this._instance)) {
 			for (const linkProvider of this._terminalLinkProviderService.linkProviders) {
 				this._linkManager.registerExternalLinkProvider(linkProvider.provideLinks.bind(linkProvider, this._instance));
 			}
-			this.add(this._terminalLinkProviderService.onDidAddLinkProvider(e => {
+			this._linkManager.add(this._terminalLinkProviderService.onDidAddLinkProvider(e => {
 				linkManager.registerExternalLinkProvider(e.provideLinks.bind(e, this._instance as ITerminalInstance));
 			}));
 		}
+
 		// TODO: Currently only a single link provider is supported; the one registered by the ext host
-		this.add(this._terminalLinkProviderService.onDidRemoveLinkProvider(e => {
+		this._linkManager.add(this._terminalLinkProviderService.onDidRemoveLinkProvider(e => {
 			linkManager.dispose();
 			this.xtermReady(xterm);
 		}));

--- a/src/vs/workbench/contrib/terminalContrib/links/browser/terminalLinkDetectorAdapter.ts
+++ b/src/vs/workbench/contrib/terminalContrib/links/browser/terminalLinkDetectorAdapter.ts
@@ -76,7 +76,7 @@ export class TerminalLinkDetectorAdapter extends Disposable implements ILinkProv
 		// Cap the maximum context on either side of the line being provided, by taking the context
 		// around the line being provided for this ensures the line the pointer is on will have
 		// links provided.
-		const maxLineContext = Math.max(this._detector.maxLinkLength / this._detector.xterm.cols);
+		const maxLineContext = Math.max(this._detector.maxLinkLength, this._detector.xterm.cols);
 		const minStartLine = Math.max(startLine - maxLineContext, 0);
 		const maxEndLine = Math.min(endLine + maxLineContext, this._detector.xterm.buffer.active.length);
 

--- a/src/vs/workbench/contrib/terminalContrib/links/browser/terminalLinkManager.ts
+++ b/src/vs/workbench/contrib/terminalContrib/links/browser/terminalLinkManager.ts
@@ -91,6 +91,8 @@ export class TerminalLinkManager extends DisposableStore {
 		let activeHoverDisposable: IDisposable | undefined;
 		let activeTooltipScheduler: RunOnceScheduler | undefined;
 		this.add(toDisposable(() => {
+			this._clearLinkProviders();
+			dispose(this._externalLinkProviders);
 			activeHoverDisposable?.dispose();
 			activeTooltipScheduler?.dispose();
 		}));

--- a/src/vs/workbench/contrib/terminalContrib/links/browser/terminalLinkManager.ts
+++ b/src/vs/workbench/contrib/terminalContrib/links/browser/terminalLinkManager.ts
@@ -352,7 +352,11 @@ export class TerminalLinkManager extends DisposableStore {
 		}
 	}
 
-	registerExternalLinkProvider(provideLinks: OmitFirstArg<ITerminalExternalLinkProvider['provideLinks']>): IDisposable {
+	registerExternalLinkProvider(provideLinks: OmitFirstArg<ITerminalExternalLinkProvider['provideLinks']>): void {
+		// Avoid any leaks in case this is already disposed
+		if (this.isDisposed) {
+			return;
+		}
 		// Clear and re-register the standard link providers so they are a lower priority than the new one
 		this._clearLinkProviders();
 		const detectorId = `extension-${this._externalLinkProviders.length}`;
@@ -360,7 +364,6 @@ export class TerminalLinkManager extends DisposableStore {
 		const newLinkProvider = this._xterm.registerLinkProvider(wrappedLinkProvider);
 		this._externalLinkProviders.push(newLinkProvider);
 		this._registerStandardLinkProviders();
-		return newLinkProvider;
 	}
 
 	protected _isLinkActivationModifierDown(event: MouseEvent): boolean {

--- a/src/vs/workbench/contrib/terminalContrib/links/browser/terminalLinkResolver.ts
+++ b/src/vs/workbench/contrib/terminalContrib/links/browser/terminalLinkResolver.ts
@@ -15,8 +15,6 @@ import { ITerminalBackend } from 'vs/platform/terminal/common/terminal';
 import { mainWindow } from 'vs/base/browser/window';
 
 export class TerminalLinkResolver implements ITerminalLinkResolver {
-	declare _serviceBrand: undefined;
-
 	// Link cache could be shared across all terminals, but that could lead to weird results when
 	// both local and remote terminals are present
 	private readonly _resolvedLinkCaches: Map<string, LinkCache> = new Map();

--- a/src/vs/workbench/contrib/terminalContrib/links/test/browser/terminalLinkManager.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/links/test/browser/terminalLinkManager.test.ts
@@ -99,6 +99,14 @@ suite('TerminalLinkManager', () => {
 		} as Partial<ITerminalCapabilityStore> as any, instantiationService.createInstance(TerminalLinkResolver)));
 	});
 
+	suite('registerExternalLinkProvider', () => {
+		test('should not leak disposables if the link manager is already disposed', () => {
+			linkManager.registerExternalLinkProvider(async () => undefined);
+			linkManager.dispose();
+			linkManager.registerExternalLinkProvider(async () => undefined);
+		});
+	});
+
 	suite('getLinks and open recent link', () => {
 		test('should return no links', async () => {
 			const links = await linkManager.getLinks();


### PR DESCRIPTION
This PR fixes the long standing issue where links suddenly break in the terminal (#184046) as well as a few leak issues, one of which could trigger an exception which would likely cause other problems.

I reproduced the primary issue by using the following code on the exthost side to simulate an extension registering and disposing a single link provider:

```ts
let i = 0;
setInterval(() => {
	const id = ++i;
	console.log(`LINKS: register new (${id})`);
	const d = this.registerLinkProvider({
		handleTerminalLink(link) {
			return null!;
		},
		provideTerminalLinks(context, token) {
			return [];
		},
	});
	setTimeout(() => {
		console.log(`LINKS: dispose old (${id})`);
		d.dispose();
	}, 5000);
}, 10000);
```

This is why the issue was so hard to reproduce in OSS since it happened when extensions did something that was somewhat unexpected. After putting this in place it became clear that the problem was related to the clunky re-creation of `TerminalLinkManager` when the extension host disposes of all of its link providers here:

https://github.com/microsoft/vscode/blob/ef40932ae9d63f86aa6e863f59921797a7e7f73e/src/vs/workbench/contrib/terminalContrib/links/browser/terminal.links.contribution.ts#L73-L76

Going deeper I found that xterm.js is holding onto disposed link adapters that were registered here:

https://github.com/microsoft/vscode/blob/ef40932ae9d63f86aa6e863f59921797a7e7f73e/src/vs/workbench/contrib/terminalContrib/links/browser/terminalLinkManager.ts#L351

https://github.com/microsoft/vscode/blob/ef40932ae9d63f86aa6e863f59921797a7e7f73e/src/vs/workbench/contrib/terminalContrib/links/browser/terminalLinkManager.ts#L360

So that fix was a matter of correctly disposing them when the link manager was replaced.

The `TerminalLinkManager` disposal is still in place and I noticed that when that happens it causes links to disappear, so it could be related to another issue where link underlines flicker. This is deferred though as this PR is complicated enough and that would need a new upstream API.

Fixes #184046
Fixes #203437