### PR TITLE
Adopt `localize2` in a few more places

### DIFF
--- a/src/vs/editor/contrib/colorPicker/browser/standaloneColorPickerActions.ts
+++ b/src/vs/editor/contrib/colorPicker/browser/standaloneColorPickerActions.ts
@@ -6,7 +6,7 @@
 import { ICodeEditor } from 'vs/editor/browser/editorBrowser';
 import { EditorAction, EditorAction2, ServicesAccessor, registerEditorAction } from 'vs/editor/browser/editorExtensions';
 import { KeyCode } from 'vs/base/common/keyCodes';
-import { localize } from 'vs/nls';
+import { localize, localize2 } from 'vs/nls';
 import { KeybindingWeight } from 'vs/platform/keybinding/common/keybindingsRegistry';
 import { StandaloneColorPickerController } from 'vs/editor/contrib/colorPicker/browser/standaloneColorPickerWidget';
 import { EditorContextKeys } from 'vs/editor/common/editorContextKeys';
@@ -18,9 +18,8 @@ export class ShowOrFocusStandaloneColorPicker extends EditorAction2 {
 		super({
 			id: 'editor.action.showOrFocusStandaloneColorPicker',
 			title: {
-				value: localize('showOrFocusStandaloneColorPicker', "Show or Focus Standalone Color Picker"),
+				...localize2('showOrFocusStandaloneColorPicker', "Show or Focus Standalone Color Picker"),
 				mnemonicTitle: localize({ key: 'mishowOrFocusStandaloneColorPicker', comment: ['&& denotes a mnemonic'] }, "&&Show or Focus Standalone Color Picker"),
-				original: 'Show or Focus Standalone Color Picker',
 			},
 			precondition: undefined,
 			menu: [

--- a/src/vs/editor/contrib/gotoSymbol/browser/goToCommands.ts
+++ b/src/vs/editor/contrib/gotoSymbol/browser/goToCommands.ts
@@ -283,9 +283,8 @@ registerAction2(class GoToDefinitionAction extends DefinitionAction {
 		}, {
 			id: GoToDefinitionAction.id,
 			title: {
-				value: nls.localize('actions.goToDecl.label', "Go to Definition"),
-				original: 'Go to Definition',
-				mnemonicTitle: nls.localize({ key: 'miGotoDefinition', comment: ['&& denotes a mnemonic'] }, "Go to &&Definition")
+				...nls.localize2('actions.goToDecl.label', "Go to Definition"),
+				mnemonicTitle: nls.localize({ key: 'miGotoDefinition', comment: ['&& denotes a mnemonic'] }, "Go to &&Definition"),
 			},
 			precondition: ContextKeyExpr.and(
 				EditorContextKeys.hasDefinitionProvider,
@@ -413,9 +412,8 @@ registerAction2(class GoToDeclarationAction extends DeclarationAction {
 		}, {
 			id: GoToDeclarationAction.id,
 			title: {
-				value: nls.localize('actions.goToDeclaration.label', "Go to Declaration"),
-				original: 'Go to Declaration',
-				mnemonicTitle: nls.localize({ key: 'miGotoDeclaration', comment: ['&& denotes a mnemonic'] }, "Go to &&Declaration")
+				...nls.localize2('actions.goToDeclaration.label', "Go to Declaration"),
+				mnemonicTitle: nls.localize({ key: 'miGotoDeclaration', comment: ['&& denotes a mnemonic'] }, "Go to &&Declaration"),
 			},
 			precondition: ContextKeyExpr.and(
 				EditorContextKeys.hasDeclarationProvider,
@@ -501,9 +499,8 @@ registerAction2(class GoToTypeDefinitionAction extends TypeDefinitionAction {
 		}, {
 			id: GoToTypeDefinitionAction.ID,
 			title: {
-				value: nls.localize('actions.goToTypeDefinition.label', "Go to Type Definition"),
-				original: 'Go to Type Definition',
-				mnemonicTitle: nls.localize({ key: 'miGotoTypeDefinition', comment: ['&& denotes a mnemonic'] }, "Go to &&Type Definition")
+				...nls.localize2('actions.goToTypeDefinition.label', "Go to Type Definition"),
+				mnemonicTitle: nls.localize({ key: 'miGotoTypeDefinition', comment: ['&& denotes a mnemonic'] }, "Go to &&Type Definition"),
 			},
 			precondition: ContextKeyExpr.and(
 				EditorContextKeys.hasTypeDefinitionProvider,
@@ -590,9 +587,8 @@ registerAction2(class GoToImplementationAction extends ImplementationAction {
 		}, {
 			id: GoToImplementationAction.ID,
 			title: {
-				value: nls.localize('actions.goToImplementation.label', "Go to Implementations"),
-				original: 'Go to Implementations',
-				mnemonicTitle: nls.localize({ key: 'miGotoImplementation', comment: ['&& denotes a mnemonic'] }, "Go to &&Implementations")
+				...nls.localize2('actions.goToImplementation.label', "Go to Implementations"),
+				mnemonicTitle: nls.localize({ key: 'miGotoImplementation', comment: ['&& denotes a mnemonic'] }, "Go to &&Implementations"),
 			},
 			precondition: ContextKeyExpr.and(
 				EditorContextKeys.hasImplementationProvider,
@@ -678,9 +674,8 @@ registerAction2(class GoToReferencesAction extends ReferencesAction {
 		}, {
 			id: 'editor.action.goToReferences',
 			title: {
-				value: nls.localize('goToReferences.label', "Go to References"),
-				original: 'Go to References',
-				mnemonicTitle: nls.localize({ key: 'miGotoReference', comment: ['&& denotes a mnemonic'] }, "Go to &&References")
+				...nls.localize2('goToReferences.label', "Go to References"),
+				mnemonicTitle: nls.localize({ key: 'miGotoReference', comment: ['&& denotes a mnemonic'] }, "Go to &&References"),
 			},
 			precondition: ContextKeyExpr.and(
 				EditorContextKeys.hasReferenceProvider,

--- a/src/vs/editor/contrib/stickyScroll/browser/stickyScrollActions.ts
+++ b/src/vs/editor/contrib/stickyScroll/browser/stickyScrollActions.ts
@@ -21,9 +21,8 @@ export class ToggleStickyScroll extends Action2 {
 		super({
 			id: 'editor.action.toggleStickyScroll',
 			title: {
-				value: localize('toggleEditorStickyScroll', "Toggle Editor Sticky Scroll"),
+				...localize2('toggleEditorStickyScroll', "Toggle Editor Sticky Scroll"),
 				mnemonicTitle: localize({ key: 'mitoggleStickyScroll', comment: ['&& denotes a mnemonic'] }, "&&Toggle Editor Sticky Scroll"),
-				original: 'Toggle Editor Sticky Scroll',
 			},
 			category: Categories.View,
 			toggled: {
@@ -54,9 +53,8 @@ export class FocusStickyScroll extends EditorAction2 {
 		super({
 			id: 'editor.action.focusStickyScroll',
 			title: {
-				value: localize('focusStickyScroll', "Focus Sticky Scroll"),
+				...localize2('focusStickyScroll', "Focus Sticky Scroll"),
 				mnemonicTitle: localize({ key: 'mifocusStickyScroll', comment: ['&& denotes a mnemonic'] }, "&&Focus Sticky Scroll"),
-				original: 'Focus Sticky Scroll',
 			},
 			precondition: ContextKeyExpr.and(ContextKeyExpr.has('config.editor.stickyScroll.enabled'), EditorContextKeys.stickyScrollVisible),
 			menu: [

--- a/src/vs/editor/contrib/toggleTabFocusMode/browser/toggleTabFocusMode.ts
+++ b/src/vs/editor/contrib/toggleTabFocusMode/browser/toggleTabFocusMode.ts
@@ -17,7 +17,7 @@ export class ToggleTabFocusModeAction extends Action2 {
 	constructor() {
 		super({
 			id: ToggleTabFocusModeAction.ID,
-			title: { value: nls.localize({ key: 'toggle.tabMovesFocus', comment: ['Turn on/off use of tab key for moving focus around VS Code'] }, 'Toggle Tab Key Moves Focus'), original: 'Toggle Tab Key Moves Focus' },
+			title: nls.localize2({ key: 'toggle.tabMovesFocus', comment: ['Turn on/off use of tab key for moving focus around VS Code'] }, 'Toggle Tab Key Moves Focus'),
 			precondition: undefined,
 			keybinding: {
 				primary: KeyMod.CtrlCmd | KeyCode.KeyM,

--- a/src/vs/platform/action/common/actionCommonCategories.ts
+++ b/src/vs/platform/action/common/actionCommonCategories.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { localize, localize2 } from 'vs/nls';
+import { localize2 } from 'vs/nls';
 
 export const Categories = Object.freeze({
 	View: localize2('view', 'View'),
@@ -11,5 +11,5 @@ export const Categories = Object.freeze({
 	Test: localize2('test', 'Test'),
 	File: localize2('file', 'File'),
 	Preferences: localize2('preferences', 'Preferences'),
-	Developer: { value: localize({ key: 'developer', comment: ['A developer on Code itself or someone diagnosing issues in Code'] }, "Developer"), original: 'Developer' }
+	Developer: localize2({ key: 'developer', comment: ['A developer on Code itself or someone diagnosing issues in Code'] }, "Developer"),
 });

--- a/src/vs/platform/extensionManagement/common/extensionManagement.ts
+++ b/src/vs/platform/extensionManagement/common/extensionManagement.ts
@@ -9,7 +9,7 @@ import { Event } from 'vs/base/common/event';
 import { IPager } from 'vs/base/common/paging';
 import { Platform } from 'vs/base/common/platform';
 import { URI } from 'vs/base/common/uri';
-import { localize, localize2 } from 'vs/nls';
+import { localize2 } from 'vs/nls';
 import { ExtensionType, IExtension, IExtensionManifest, TargetPlatform } from 'vs/platform/extensions/common/extensions';
 import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
 
@@ -545,6 +545,5 @@ export interface IExtensionTipsService {
 	getOtherExecutableBasedTips(): Promise<IExecutableBasedExtensionTip[]>;
 }
 
-export const ExtensionsLabel = localize('extensions', "Extensions");
-export const ExtensionsLocalizedLabel = { value: ExtensionsLabel, original: 'Extensions' };
+export const ExtensionsLocalizedLabel = localize2('extensions', "Extensions");
 export const PreferencesLocalizedLabel = localize2('preferences', 'Preferences');

--- a/src/vs/workbench/browser/actions/developerActions.ts
+++ b/src/vs/workbench/browser/actions/developerActions.ts
@@ -396,7 +396,7 @@ class LogStorageAction extends Action2 {
 	constructor() {
 		super({
 			id: 'workbench.action.logStorage',
-			title: { value: localize({ key: 'logStorage', comment: ['A developer only action to log the contents of the storage for the current window.'] }, "Log Storage Database Contents"), original: 'Log Storage Database Contents' },
+			title: localize2({ key: 'logStorage', comment: ['A developer only action to log the contents of the storage for the current window.'] }, "Log Storage Database Contents"),
 			category: Categories.Developer,
 			f1: true
 		});
@@ -417,7 +417,7 @@ class LogWorkingCopiesAction extends Action2 {
 	constructor() {
 		super({
 			id: 'workbench.action.logWorkingCopies',
-			title: { value: localize({ key: 'logWorkingCopies', comment: ['A developer only action to log the working copies that exist.'] }, "Log Working Copies"), original: 'Log Working Copies' },
+			title: localize2({ key: 'logWorkingCopies', comment: ['A developer only action to log the working copies that exist.'] }, "Log Working Copies"),
 			category: Categories.Developer,
 			f1: true
 		});

--- a/src/vs/workbench/browser/actions/helpActions.ts
+++ b/src/vs/workbench/browser/actions/helpActions.ts
@@ -25,9 +25,8 @@ class KeybindingsReferenceAction extends Action2 {
 		super({
 			id: KeybindingsReferenceAction.ID,
 			title: {
-				value: localize('keybindingsReference', "Keyboard Shortcuts Reference"),
+				...localize2('keybindingsReference', "Keyboard Shortcuts Reference"),
 				mnemonicTitle: localize({ key: 'miKeyboardShortcuts', comment: ['&& denotes a mnemonic'] }, "&&Keyboard Shortcuts Reference"),
-				original: 'Keyboard Shortcuts Reference'
 			},
 			category: Categories.Help,
 			f1: true,
@@ -64,9 +63,8 @@ class OpenIntroductoryVideosUrlAction extends Action2 {
 		super({
 			id: OpenIntroductoryVideosUrlAction.ID,
 			title: {
-				value: localize('openVideoTutorialsUrl', "Video Tutorials"),
+				...localize2('openVideoTutorialsUrl', "Video Tutorials"),
 				mnemonicTitle: localize({ key: 'miVideoTutorials', comment: ['&& denotes a mnemonic'] }, "&&Video Tutorials"),
-				original: 'Video Tutorials'
 			},
 			category: Categories.Help,
 			f1: true,
@@ -97,9 +95,8 @@ class OpenTipsAndTricksUrlAction extends Action2 {
 		super({
 			id: OpenTipsAndTricksUrlAction.ID,
 			title: {
-				value: localize('openTipsAndTricksUrl', "Tips and Tricks"),
+				...localize2('openTipsAndTricksUrl', "Tips and Tricks"),
 				mnemonicTitle: localize({ key: 'miTipsAndTricks', comment: ['&& denotes a mnemonic'] }, "Tips and Tri&&cks"),
-				original: 'Tips and Tricks'
 			},
 			category: Categories.Help,
 			f1: true,
@@ -130,9 +127,8 @@ class OpenDocumentationUrlAction extends Action2 {
 		super({
 			id: OpenDocumentationUrlAction.ID,
 			title: {
-				value: localize('openDocumentationUrl', "Documentation"),
+				...localize2('openDocumentationUrl', "Documentation"),
 				mnemonicTitle: localize({ key: 'miDocumentation', comment: ['&& denotes a mnemonic'] }, "&&Documentation"),
-				original: 'Documentation'
 			},
 			category: Categories.Help,
 			f1: true,
@@ -186,9 +182,8 @@ class OpenYouTubeUrlAction extends Action2 {
 		super({
 			id: OpenYouTubeUrlAction.ID,
 			title: {
-				value: localize('openYouTubeUrl', "Join Us on YouTube"),
+				...localize2('openYouTubeUrl', "Join Us on YouTube"),
 				mnemonicTitle: localize({ key: 'miYouTube', comment: ['&& denotes a mnemonic'] }, "&&Join Us on YouTube"),
-				original: 'Join Us on YouTube'
 			},
 			category: Categories.Help,
 			f1: true,
@@ -219,9 +214,8 @@ class OpenRequestFeatureUrlAction extends Action2 {
 		super({
 			id: OpenRequestFeatureUrlAction.ID,
 			title: {
-				value: localize('openUserVoiceUrl', "Search Feature Requests"),
+				...localize2('openUserVoiceUrl', "Search Feature Requests"),
 				mnemonicTitle: localize({ key: 'miUserVoice', comment: ['&& denotes a mnemonic'] }, "&&Search Feature Requests"),
-				original: 'Search Feature Requests'
 			},
 			category: Categories.Help,
 			f1: true,
@@ -252,9 +246,8 @@ class OpenLicenseUrlAction extends Action2 {
 		super({
 			id: OpenLicenseUrlAction.ID,
 			title: {
-				value: localize('openLicenseUrl', "View License"),
+				...localize2('openLicenseUrl', "View License"),
 				mnemonicTitle: localize({ key: 'miLicense', comment: ['&& denotes a mnemonic'] }, "View &&License"),
-				original: 'View License'
 			},
 			category: Categories.Help,
 			f1: true,
@@ -291,9 +284,8 @@ class OpenPrivacyStatementUrlAction extends Action2 {
 		super({
 			id: OpenPrivacyStatementUrlAction.ID,
 			title: {
-				value: localize('openPrivacyStatement', "Privacy Statement"),
+				...localize2('openPrivacyStatement', "Privacy Statement"),
 				mnemonicTitle: localize({ key: 'miPrivacyStatement', comment: ['&& denotes a mnemonic'] }, "Privac&&y Statement"),
-				original: 'Privacy Statement'
 			},
 			category: Categories.Help,
 			f1: true,

--- a/src/vs/workbench/browser/actions/layoutActions.ts
+++ b/src/vs/workbench/browser/actions/layoutActions.ts
@@ -81,9 +81,8 @@ registerAction2(class extends Action2 {
 		super({
 			id: 'workbench.action.toggleCenteredLayout',
 			title: {
-				value: localize('toggleCenteredLayout', "Toggle Centered Layout"),
+				...localize2('toggleCenteredLayout', "Toggle Centered Layout"),
 				mnemonicTitle: localize({ key: 'miToggleCenteredLayout', comment: ['&& denotes a mnemonic'] }, "&&Centered Layout"),
-				original: 'Toggle Centered Layout'
 			},
 			precondition: IsAuxiliaryWindowFocusedContext.toNegated(),
 			category: Categories.View,
@@ -285,9 +284,8 @@ registerAction2(class extends Action2 {
 		super({
 			id: 'workbench.action.toggleEditorVisibility',
 			title: {
-				value: localize('toggleEditor', "Toggle Editor Area Visibility"),
+				...localize2('toggleEditor', "Toggle Editor Area Visibility"),
 				mnemonicTitle: localize({ key: 'miShowEditorArea', comment: ['&& denotes a mnemonic'] }, "Show &&Editor Area"),
-				original: 'Toggle Editor Area Visibility'
 			},
 			category: Categories.View,
 			f1: true,
@@ -418,9 +416,8 @@ export class ToggleStatusbarVisibilityAction extends Action2 {
 		super({
 			id: ToggleStatusbarVisibilityAction.ID,
 			title: {
-				value: localize('toggleStatusbar', "Toggle Status Bar Visibility"),
+				...localize2('toggleStatusbar', "Toggle Status Bar Visibility"),
 				mnemonicTitle: localize({ key: 'miStatusbar', comment: ['&& denotes a mnemonic'] }, "S&&tatus Bar"),
-				original: 'Toggle Status Bar Visibility'
 			},
 			category: Categories.View,
 			f1: true,
@@ -703,9 +700,8 @@ registerAction2(class extends Action2 {
 		super({
 			id: 'workbench.action.toggleZenMode',
 			title: {
-				value: localize('toggleZenMode', "Toggle Zen Mode"),
+				...localize2('toggleZenMode', "Toggle Zen Mode"),
 				mnemonicTitle: localize({ key: 'miToggleZenMode', comment: ['&& denotes a mnemonic'] }, "Zen Mode"),
-				original: 'Toggle Zen Mode'
 			},
 			precondition: IsAuxiliaryWindowFocusedContext.toNegated(),
 			category: Categories.View,
@@ -751,9 +747,8 @@ if (isWindows || isLinux || isWeb) {
 			super({
 				id: 'workbench.action.toggleMenuBar',
 				title: {
-					value: localize('toggleMenuBar', "Toggle Menu Bar"),
+					...localize2('toggleMenuBar', "Toggle Menu Bar"),
 					mnemonicTitle: localize({ key: 'miMenuBar', comment: ['&& denotes a mnemonic'] }, "Menu &&Bar"),
-					original: 'Toggle Menu Bar'
 				},
 				category: Categories.View,
 				f1: true,

--- a/src/vs/workbench/browser/actions/listCommands.ts
+++ b/src/vs/workbench/browser/actions/listCommands.ts
@@ -21,7 +21,7 @@ import { AbstractTree, TreeFindMatchType, TreeFindMode } from 'vs/base/browser/u
 import { isActiveElement } from 'vs/base/browser/dom';
 import { Action2, registerAction2 } from 'vs/platform/actions/common/actions';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
-import { localize } from 'vs/nls';
+import { localize, localize2 } from 'vs/nls';
 
 function ensureDOMFocus(widget: ListWidget | undefined): void {
 	// it can happen that one of the commands is executed while
@@ -913,9 +913,8 @@ registerAction2(class ToggleStickyScroll extends Action2 {
 		super({
 			id: 'tree.toggleStickyScroll',
 			title: {
-				value: localize('toggleTreeStickyScroll', "Toggle Tree Sticky Scroll"),
+				...localize2('toggleTreeStickyScroll', "Toggle Tree Sticky Scroll"),
 				mnemonicTitle: localize({ key: 'mitoggleTreeStickyScroll', comment: ['&& denotes a mnemonic'] }, "&&Toggle Tree Sticky Scroll"),
-				original: 'Toggle Tree Sticky Scroll',
 			},
 			category: 'View',
 			f1: true

--- a/src/vs/workbench/browser/actions/windowActions.ts
+++ b/src/vs/workbench/browser/actions/windowActions.ts
@@ -237,9 +237,8 @@ export class OpenRecentAction extends BaseOpenRecentAction {
 		super({
 			id: OpenRecentAction.ID,
 			title: {
-				value: localize('openRecent', "Open Recent..."),
+				...localize2('openRecent', "Open Recent..."),
 				mnemonicTitle: localize({ key: 'miMore', comment: ['&& denotes a mnemonic'] }, "&&More..."),
-				original: 'Open Recent...'
 			},
 			category: Categories.File,
 			f1: true,
@@ -283,9 +282,8 @@ class ToggleFullScreenAction extends Action2 {
 		super({
 			id: 'workbench.action.toggleFullScreen',
 			title: {
-				value: localize('toggleFullScreen', "Toggle Full Screen"),
+				...localize2('toggleFullScreen', "Toggle Full Screen"),
 				mnemonicTitle: localize({ key: 'miToggleFullScreen', comment: ['&& denotes a mnemonic'] }, "&&Full Screen"),
-				original: 'Toggle Full Screen'
 			},
 			category: Categories.View,
 			f1: true,
@@ -344,9 +342,8 @@ class ShowAboutDialogAction extends Action2 {
 		super({
 			id: 'workbench.action.showAboutDialog',
 			title: {
-				value: localize('about', "About"),
+				...localize2('about', "About"),
 				mnemonicTitle: localize({ key: 'miAbout', comment: ['&& denotes a mnemonic'] }, "&&About"),
-				original: 'About'
 			},
 			category: Categories.Help,
 			f1: true,
@@ -372,9 +369,8 @@ class NewWindowAction extends Action2 {
 		super({
 			id: 'workbench.action.newWindow',
 			title: {
-				value: localize('newWindow', "New Window"),
+				...localize2('newWindow', "New Window"),
 				mnemonicTitle: localize({ key: 'miNewWindow', comment: ['&& denotes a mnemonic'] }, "New &&Window"),
-				original: 'New Window'
 			},
 			f1: true,
 			keybinding: {

--- a/src/vs/workbench/browser/parts/activitybar/activitybarPart.ts
+++ b/src/vs/workbench/browser/parts/activitybar/activitybarPart.ts
@@ -380,8 +380,7 @@ registerAction2(class extends Action2 {
 		super({
 			id: 'workbench.action.activityBarLocation.side',
 			title: {
-				value: localize('positionActivityBarSide', 'Move Activity Bar to Side'),
-				original: 'Move Activity Bar to Side',
+				...localize2('positionActivityBarSide', 'Move Activity Bar to Side'),
 				mnemonicTitle: localize({ key: 'miSideActivityBar', comment: ['&& denotes a mnemonic'] }, "&&Side"),
 			},
 			shortTitle: localize('side', "Side"),
@@ -407,8 +406,7 @@ registerAction2(class extends Action2 {
 		super({
 			id: 'workbench.action.activityBarLocation.top',
 			title: {
-				value: localize('positionActivityBarTop', 'Move Activity Bar to Top'),
-				original: 'Move Activity Bar to Top',
+				...localize2('positionActivityBarTop', 'Move Activity Bar to Top'),
 				mnemonicTitle: localize({ key: 'miTopActivityBar', comment: ['&& denotes a mnemonic'] }, "&&Top"),
 			},
 			shortTitle: localize('top', "Top"),
@@ -434,8 +432,7 @@ registerAction2(class extends Action2 {
 		super({
 			id: 'workbench.action.activityBarLocation.hide',
 			title: {
-				value: localize('hideActivityBar', 'Hide Activity Bar'),
-				original: 'Hide Activity Bar',
+				...localize2('hideActivityBar', 'Hide Activity Bar'),
 				mnemonicTitle: localize({ key: 'miHideActivityBar', comment: ['&& denotes a mnemonic'] }, "&&Hidden"),
 			},
 			shortTitle: localize('hide', "Hidden"),

--- a/src/vs/workbench/browser/parts/auxiliarybar/auxiliaryBarActions.ts
+++ b/src/vs/workbench/browser/parts/auxiliarybar/auxiliaryBarActions.ts
@@ -26,12 +26,12 @@ const auxiliaryBarLeftOffIcon = registerIcon('auxiliarybar-left-off-layout-icon'
 export class ToggleAuxiliaryBarAction extends Action2 {
 
 	static readonly ID = 'workbench.action.toggleAuxiliaryBar';
-	static readonly LABEL = localize('toggleAuxiliaryBar', "Toggle Secondary Side Bar Visibility");
+	static readonly LABEL = localize2('toggleAuxiliaryBar', "Toggle Secondary Side Bar Visibility");
 
 	constructor() {
 		super({
 			id: ToggleAuxiliaryBarAction.ID,
-			title: { value: ToggleAuxiliaryBarAction.LABEL, original: 'Toggle Secondary Side Bar Visibility' },
+			title: ToggleAuxiliaryBarAction.LABEL,
 			toggled: {
 				condition: AuxiliaryBarVisibleContext,
 				title: localize('secondary sidebar', "Secondary Side Bar"),
@@ -70,13 +70,12 @@ registerAction2(ToggleAuxiliaryBarAction);
 registerAction2(class FocusAuxiliaryBarAction extends Action2 {
 
 	static readonly ID = 'workbench.action.focusAuxiliaryBar';
-	static readonly LABEL = localize('focusAuxiliaryBar', "Focus into Secondary Side Bar");
-
+	static readonly LABEL = localize2('focusAuxiliaryBar', "Focus into Secondary Side Bar");
 
 	constructor() {
 		super({
 			id: FocusAuxiliaryBarAction.ID,
-			title: { value: FocusAuxiliaryBarAction.LABEL, original: 'Focus into Secondary Side Bar' },
+			title: FocusAuxiliaryBarAction.LABEL,
 			category: Categories.View,
 			f1: true,
 		});

--- a/src/vs/workbench/browser/parts/banner/bannerPart.ts
+++ b/src/vs/workbench/browser/parts/banner/bannerPart.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import 'vs/css!./media/bannerpart';
-import { localize } from 'vs/nls';
+import { localize2 } from 'vs/nls';
 import { $, addDisposableListener, append, asCSSUrl, clearNode, EventType } from 'vs/base/browser/dom';
 import { ActionBar } from 'vs/base/browser/ui/actionbar/actionbar';
 import { InstantiationType, registerSingleton } from 'vs/platform/instantiation/common/extensions';
@@ -285,12 +285,12 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 class FocusBannerAction extends Action2 {
 
 	static readonly ID = 'workbench.action.focusBanner';
-	static readonly LABEL = localize('focusBanner', "Focus Banner");
+	static readonly LABEL = localize2('focusBanner', "Focus Banner");
 
 	constructor() {
 		super({
 			id: FocusBannerAction.ID,
-			title: { value: FocusBannerAction.LABEL, original: 'Focus Banner' },
+			title: FocusBannerAction.LABEL,
 			category: Categories.View,
 			f1: true
 		});

--- a/src/vs/workbench/browser/parts/editor/breadcrumbsControl.ts
+++ b/src/vs/workbench/browser/parts/editor/breadcrumbsControl.ts
@@ -598,9 +598,8 @@ registerAction2(class ToggleBreadcrumb extends Action2 {
 		super({
 			id: 'breadcrumbs.toggle',
 			title: {
-				value: localize('cmd.toggle', "Toggle Breadcrumbs"),
+				...localize2('cmd.toggle', "Toggle Breadcrumbs"),
 				mnemonicTitle: localize({ key: 'miBreadcrumbs', comment: ['&& denotes a mnemonic'] }, "Toggle &&Breadcrumbs"),
-				original: 'Toggle Breadcrumbs',
 			},
 			category: Categories.View,
 			toggled: {

--- a/src/vs/workbench/browser/parts/editor/editor.contribution.ts
+++ b/src/vs/workbench/browser/parts/editor/editor.contribution.ts
@@ -679,8 +679,7 @@ MenuRegistry.appendMenuItem(MenuId.MenubarLayoutMenu, {
 	command: {
 		id: SPLIT_EDITOR_UP,
 		title: {
-			original: 'Split Up',
-			value: localize('miSplitEditorUpWithoutMnemonic', "Split Up"),
+			...localize2('miSplitEditorUpWithoutMnemonic', "Split Up"),
 			mnemonicTitle: localize({ key: 'miSplitEditorUp', comment: ['&& denotes a mnemonic'] }, "Split &&Up"),
 		}
 	},
@@ -692,9 +691,8 @@ MenuRegistry.appendMenuItem(MenuId.MenubarLayoutMenu, {
 	command: {
 		id: SPLIT_EDITOR_DOWN,
 		title: {
-			original: 'Split Down',
-			value: localize('miSplitEditorDownWithoutMnemonic', "Split Down"),
-			mnemonicTitle: localize({ key: 'miSplitEditorDown', comment: ['&& denotes a mnemonic'] }, "Split &&Down")
+			...localize2('miSplitEditorDownWithoutMnemonic', "Split Down"),
+			mnemonicTitle: localize({ key: 'miSplitEditorDown', comment: ['&& denotes a mnemonic'] }, "Split &&Down"),
 		}
 	},
 	order: 2
@@ -705,9 +703,8 @@ MenuRegistry.appendMenuItem(MenuId.MenubarLayoutMenu, {
 	command: {
 		id: SPLIT_EDITOR_LEFT,
 		title: {
-			original: 'Split Left',
-			value: localize('miSplitEditorLeftWithoutMnemonic', "Split Left"),
-			mnemonicTitle: localize({ key: 'miSplitEditorLeft', comment: ['&& denotes a mnemonic'] }, "Split &&Left")
+			...localize2('miSplitEditorLeftWithoutMnemonic', "Split Left"),
+			mnemonicTitle: localize({ key: 'miSplitEditorLeft', comment: ['&& denotes a mnemonic'] }, "Split &&Left"),
 		}
 	},
 	order: 3
@@ -718,9 +715,8 @@ MenuRegistry.appendMenuItem(MenuId.MenubarLayoutMenu, {
 	command: {
 		id: SPLIT_EDITOR_RIGHT,
 		title: {
-			original: 'Split Right',
-			value: localize('miSplitEditorRightWithoutMnemonic', "Split Right"),
-			mnemonicTitle: localize({ key: 'miSplitEditorRight', comment: ['&& denotes a mnemonic'] }, "Split &&Right")
+			...localize2('miSplitEditorRightWithoutMnemonic', "Split Right"),
+			mnemonicTitle: localize({ key: 'miSplitEditorRight', comment: ['&& denotes a mnemonic'] }, "Split &&Right"),
 		}
 	},
 	order: 4
@@ -731,9 +727,8 @@ MenuRegistry.appendMenuItem(MenuId.MenubarLayoutMenu, {
 	command: {
 		id: SPLIT_EDITOR_IN_GROUP,
 		title: {
-			original: 'Split in Group',
-			value: localize('miSplitEditorInGroupWithoutMnemonic', "Split in Group"),
-			mnemonicTitle: localize({ key: 'miSplitEditorInGroup', comment: ['&& denotes a mnemonic'] }, "Split in &&Group")
+			...localize2('miSplitEditorInGroupWithoutMnemonic', "Split in Group"),
+			mnemonicTitle: localize({ key: 'miSplitEditorInGroup', comment: ['&& denotes a mnemonic'] }, "Split in &&Group"),
 		}
 	},
 	when: ActiveEditorCanSplitInGroupContext,
@@ -745,9 +740,8 @@ MenuRegistry.appendMenuItem(MenuId.MenubarLayoutMenu, {
 	command: {
 		id: JOIN_EDITOR_IN_GROUP,
 		title: {
-			original: 'Join in Group',
-			value: localize('miJoinEditorInGroupWithoutMnemonic', "Join in Group"),
-			mnemonicTitle: localize({ key: 'miJoinEditorInGroup', comment: ['&& denotes a mnemonic'] }, "Join in &&Group")
+			...localize2('miJoinEditorInGroupWithoutMnemonic', "Join in Group"),
+			mnemonicTitle: localize({ key: 'miJoinEditorInGroup', comment: ['&& denotes a mnemonic'] }, "Join in &&Group"),
 		}
 	},
 	when: SideBySideEditorActiveContext,
@@ -759,9 +753,8 @@ MenuRegistry.appendMenuItem(MenuId.MenubarLayoutMenu, {
 	command: {
 		id: MOVE_EDITOR_INTO_NEW_WINDOW_COMMAND_ID,
 		title: {
-			original: 'Move Editor into New Window',
-			value: localize('moveEditorToNewWindow', "Move Editor into New Window"),
-			mnemonicTitle: localize({ key: 'miMoveEditorToNewWindow', comment: ['&& denotes a mnemonic'] }, "&&Move Editor into New Window")
+			...localize2('moveEditorToNewWindow', "Move Editor into New Window"),
+			mnemonicTitle: localize({ key: 'miMoveEditorToNewWindow', comment: ['&& denotes a mnemonic'] }, "&&Move Editor into New Window"),
 		}
 	},
 	order: 1
@@ -772,9 +765,8 @@ MenuRegistry.appendMenuItem(MenuId.MenubarLayoutMenu, {
 	command: {
 		id: COPY_EDITOR_INTO_NEW_WINDOW_COMMAND_ID,
 		title: {
-			original: 'Copy Editor into New Window',
-			value: localize('copyEditorToNewWindow', "Copy Editor into New Window"),
-			mnemonicTitle: localize({ key: 'miCopyEditorToNewWindow', comment: ['&& denotes a mnemonic'] }, "&&Copy Editor into New Window")
+			...localize2('copyEditorToNewWindow', "Copy Editor into New Window"),
+			mnemonicTitle: localize({ key: 'miCopyEditorToNewWindow', comment: ['&& denotes a mnemonic'] }, "&&Copy Editor into New Window"),
 		}
 	},
 	order: 2
@@ -785,9 +777,8 @@ MenuRegistry.appendMenuItem(MenuId.MenubarLayoutMenu, {
 	command: {
 		id: EditorLayoutSingleAction.ID,
 		title: {
-			original: 'Single',
-			value: localize('miSingleColumnEditorLayoutWithoutMnemonic', "Single"),
-			mnemonicTitle: localize({ key: 'miSingleColumnEditorLayout', comment: ['&& denotes a mnemonic'] }, "&&Single")
+			...localize2('miSingleColumnEditorLayoutWithoutMnemonic', "Single"),
+			mnemonicTitle: localize({ key: 'miSingleColumnEditorLayout', comment: ['&& denotes a mnemonic'] }, "&&Single"),
 		}
 	},
 	order: 1
@@ -798,9 +789,8 @@ MenuRegistry.appendMenuItem(MenuId.MenubarLayoutMenu, {
 	command: {
 		id: EditorLayoutTwoColumnsAction.ID,
 		title: {
-			original: 'Two Columns',
-			value: localize('miTwoColumnsEditorLayoutWithoutMnemonic', "Two Columns"),
-			mnemonicTitle: localize({ key: 'miTwoColumnsEditorLayout', comment: ['&& denotes a mnemonic'] }, "&&Two Columns")
+			...localize2('miTwoColumnsEditorLayoutWithoutMnemonic', "Two Columns"),
+			mnemonicTitle: localize({ key: 'miTwoColumnsEditorLayout', comment: ['&& denotes a mnemonic'] }, "&&Two Columns"),
 		}
 	},
 	order: 3
@@ -811,9 +801,8 @@ MenuRegistry.appendMenuItem(MenuId.MenubarLayoutMenu, {
 	command: {
 		id: EditorLayoutThreeColumnsAction.ID,
 		title: {
-			original: 'Three Columns',
-			value: localize('miThreeColumnsEditorLayoutWithoutMnemonic', "Three Columns"),
-			mnemonicTitle: localize({ key: 'miThreeColumnsEditorLayout', comment: ['&& denotes a mnemonic'] }, "T&&hree Columns")
+			...localize2('miThreeColumnsEditorLayoutWithoutMnemonic', "Three Columns"),
+			mnemonicTitle: localize({ key: 'miThreeColumnsEditorLayout', comment: ['&& denotes a mnemonic'] }, "T&&hree Columns"),
 		}
 	},
 	order: 4
@@ -824,9 +813,8 @@ MenuRegistry.appendMenuItem(MenuId.MenubarLayoutMenu, {
 	command: {
 		id: EditorLayoutTwoRowsAction.ID,
 		title: {
-			original: 'Two Rows',
-			value: localize('miTwoRowsEditorLayoutWithoutMnemonic', "Two Rows"),
-			mnemonicTitle: localize({ key: 'miTwoRowsEditorLayout', comment: ['&& denotes a mnemonic'] }, "T&&wo Rows")
+			...localize2('miTwoRowsEditorLayoutWithoutMnemonic', "Two Rows"),
+			mnemonicTitle: localize({ key: 'miTwoRowsEditorLayout', comment: ['&& denotes a mnemonic'] }, "T&&wo Rows"),
 		}
 	},
 	order: 5
@@ -837,9 +825,8 @@ MenuRegistry.appendMenuItem(MenuId.MenubarLayoutMenu, {
 	command: {
 		id: EditorLayoutThreeRowsAction.ID,
 		title: {
-			original: 'Three Rows',
-			value: localize('miThreeRowsEditorLayoutWithoutMnemonic', "Three Rows"),
-			mnemonicTitle: localize({ key: 'miThreeRowsEditorLayout', comment: ['&& denotes a mnemonic'] }, "Three &&Rows")
+			...localize2('miThreeRowsEditorLayoutWithoutMnemonic', "Three Rows"),
+			mnemonicTitle: localize({ key: 'miThreeRowsEditorLayout', comment: ['&& denotes a mnemonic'] }, "Three &&Rows"),
 		}
 	},
 	order: 6
@@ -850,9 +837,8 @@ MenuRegistry.appendMenuItem(MenuId.MenubarLayoutMenu, {
 	command: {
 		id: EditorLayoutTwoByTwoGridAction.ID,
 		title: {
-			original: 'Grid (2x2)',
-			value: localize('miTwoByTwoGridEditorLayoutWithoutMnemonic', "Grid (2x2)"),
-			mnemonicTitle: localize({ key: 'miTwoByTwoGridEditorLayout', comment: ['&& denotes a mnemonic'] }, "&&Grid (2x2)")
+			...localize2('miTwoByTwoGridEditorLayoutWithoutMnemonic', "Grid (2x2)"),
+			mnemonicTitle: localize({ key: 'miTwoByTwoGridEditorLayout', comment: ['&& denotes a mnemonic'] }, "&&Grid (2x2)"),
 		}
 	},
 	order: 7
@@ -863,9 +849,8 @@ MenuRegistry.appendMenuItem(MenuId.MenubarLayoutMenu, {
 	command: {
 		id: EditorLayoutTwoRowsRightAction.ID,
 		title: {
-			original: 'Two Rows Right',
-			value: localize('miTwoRowsRightEditorLayoutWithoutMnemonic', "Two Rows Right"),
-			mnemonicTitle: localize({ key: 'miTwoRowsRightEditorLayout', comment: ['&& denotes a mnemonic'] }, "Two R&&ows Right")
+			...localize2('miTwoRowsRightEditorLayoutWithoutMnemonic', "Two Rows Right"),
+			mnemonicTitle: localize({ key: 'miTwoRowsRightEditorLayout', comment: ['&& denotes a mnemonic'] }, "Two R&&ows Right"),
 		}
 	},
 	order: 8
@@ -876,9 +861,8 @@ MenuRegistry.appendMenuItem(MenuId.MenubarLayoutMenu, {
 	command: {
 		id: EditorLayoutTwoColumnsBottomAction.ID,
 		title: {
-			original: 'Two Columns Bottom',
-			value: localize('miTwoColumnsBottomEditorLayoutWithoutMnemonic', "Two Columns Bottom"),
-			mnemonicTitle: localize({ key: 'miTwoColumnsBottomEditorLayout', comment: ['&& denotes a mnemonic'] }, "Two &&Columns Bottom")
+			...localize2('miTwoColumnsBottomEditorLayoutWithoutMnemonic', "Two Columns Bottom"),
+			mnemonicTitle: localize({ key: 'miTwoColumnsBottomEditorLayout', comment: ['&& denotes a mnemonic'] }, "Two &&Columns Bottom"),
 		}
 	},
 	order: 9

--- a/src/vs/workbench/browser/parts/editor/editorActions.ts
+++ b/src/vs/workbench/browser/parts/editor/editorActions.ts
@@ -1380,7 +1380,10 @@ export class NavigateForwardAction extends Action2 {
 	constructor() {
 		super({
 			id: NavigateForwardAction.ID,
-			title: { value: localize('navigateForward', "Go Forward"), original: 'Go Forward', mnemonicTitle: localize({ key: 'miForward', comment: ['&& denotes a mnemonic'] }, "&&Forward") },
+			title: {
+				...localize2('navigateForward', "Go Forward"),
+				mnemonicTitle: localize({ key: 'miForward', comment: ['&& denotes a mnemonic'] }, "&&Forward")
+			},
 			f1: true,
 			icon: Codicon.arrowRight,
 			precondition: ContextKeyExpr.has('canNavigateForward'),
@@ -1412,7 +1415,10 @@ export class NavigateBackwardsAction extends Action2 {
 	constructor() {
 		super({
 			id: NavigateBackwardsAction.ID,
-			title: { value: localize('navigateBack', "Go Back"), original: 'Go Back', mnemonicTitle: localize({ key: 'miBack', comment: ['&& denotes a mnemonic'] }, "&&Back") },
+			title: {
+				...localize2('navigateBack', "Go Back"),
+				mnemonicTitle: localize({ key: 'miBack', comment: ['&& denotes a mnemonic'] }, "&&Back")
+			},
 			f1: true,
 			precondition: ContextKeyExpr.has('canNavigateBack'),
 			icon: Codicon.arrowLeft,
@@ -2530,9 +2536,8 @@ export class MoveEditorToNewWindowAction extends BaseMoveCopyEditorToNewWindowAc
 		super(
 			MOVE_EDITOR_INTO_NEW_WINDOW_COMMAND_ID,
 			{
-				value: localize('moveEditorToNewWindow', "Move Editor into New Window"),
+				...localize2('moveEditorToNewWindow', "Move Editor into New Window"),
 				mnemonicTitle: localize({ key: 'miMoveEditorToNewWindow', comment: ['&& denotes a mnemonic'] }, "&&Move Editor into New Window"),
-				original: 'Move Editor into New Window'
 			},
 			undefined,
 			true
@@ -2546,9 +2551,8 @@ export class CopyEditorToNewindowAction extends BaseMoveCopyEditorToNewWindowAct
 		super(
 			COPY_EDITOR_INTO_NEW_WINDOW_COMMAND_ID,
 			{
-				value: localize('copyEditorToNewWindow', "Copy Editor into New Window"),
+				...localize2('copyEditorToNewWindow', "Copy Editor into New Window"),
 				mnemonicTitle: localize({ key: 'miCopyEditorToNewWindow', comment: ['&& denotes a mnemonic'] }, "&&Copy Editor into New Window"),
-				original: 'Copy Editor into New Window'
 			},
 			{ primary: KeyChord(KeyMod.CtrlCmd | KeyCode.KeyK, KeyCode.KeyO), weight: KeybindingWeight.WorkbenchContrib },
 			false
@@ -2591,9 +2595,8 @@ export class MoveEditorGroupToNewWindowAction extends BaseMoveCopyEditorGroupToN
 		super(
 			MOVE_EDITOR_GROUP_INTO_NEW_WINDOW_COMMAND_ID,
 			{
-				value: localize('moveEditorGroupToNewWindow', "Move Editor Group into New Window"),
+				...localize2('moveEditorGroupToNewWindow', "Move Editor Group into New Window"),
 				mnemonicTitle: localize({ key: 'miMoveEditorGroupToNewWindow', comment: ['&& denotes a mnemonic'] }, "&&Move Editor Group into New Window"),
-				original: 'Move Editor Group into New Window'
 			},
 			true
 		);
@@ -2606,9 +2609,8 @@ export class CopyEditorGroupToNewWindowAction extends BaseMoveCopyEditorGroupToN
 		super(
 			COPY_EDITOR_GROUP_INTO_NEW_WINDOW_COMMAND_ID,
 			{
-				value: localize('copyEditorGroupToNewWindow', "Copy Editor Group into New Window"),
+				...localize2('copyEditorGroupToNewWindow', "Copy Editor Group into New Window"),
 				mnemonicTitle: localize({ key: 'miCopyEditorGroupToNewWindow', comment: ['&& denotes a mnemonic'] }, "&&Copy Editor Group into New Window"),
-				original: 'Copy Editor Group into New Window'
 			},
 			false
 		);
@@ -2621,9 +2623,8 @@ export class RestoreEditorsToMainWindowAction extends Action2 {
 		super({
 			id: 'workbench.action.restoreEditorsToMainWindow',
 			title: {
-				value: localize('restoreEditorsToMainWindow', "Restore Editors into Main Window"),
+				...localize2('restoreEditorsToMainWindow', "Restore Editors into Main Window"),
 				mnemonicTitle: localize({ key: 'miRestoreEditorsToMainWindow', comment: ['&& denotes a mnemonic'] }, "&&Restore Editors into Main Window"),
-				original: 'Restore Editors into Main Window'
 			},
 			f1: true,
 			precondition: IsAuxiliaryWindowFocusedContext,
@@ -2644,9 +2645,8 @@ export class NewEmptyEditorWindowAction extends Action2 {
 		super({
 			id: NEW_EMPTY_EDITOR_WINDOW_COMMAND_ID,
 			title: {
-				value: localize('newEmptyEditorWindow', "New Empty Editor Window"),
+				...localize2('newEmptyEditorWindow', "New Empty Editor Window"),
 				mnemonicTitle: localize({ key: 'miNewEmptyEditorWindow', comment: ['&& denotes a mnemonic'] }, "&&New Empty Editor Window"),
-				original: 'New Empty Editor Window'
 			},
 			f1: true,
 			category: Categories.View

--- a/src/vs/workbench/browser/parts/editor/editorCommands.ts
+++ b/src/vs/workbench/browser/parts/editor/editorCommands.ts
@@ -563,10 +563,7 @@ function registerDiffEditorCommands(): void {
 	MenuRegistry.appendMenuItem(MenuId.CommandPalette, {
 		command: {
 			id: TOGGLE_DIFF_SIDE_BY_SIDE,
-			title: {
-				value: localize('toggleInlineView', "Toggle Inline View"),
-				original: 'Compare: Toggle Inline View'
-			},
+			title: localize2('toggleInlineView', "Toggle Inline View"),
 			category: localize('compare', "Compare")
 		},
 		when: TextCompareEditorActiveContext
@@ -575,10 +572,7 @@ function registerDiffEditorCommands(): void {
 	MenuRegistry.appendMenuItem(MenuId.CommandPalette, {
 		command: {
 			id: DIFF_SWAP_SIDES,
-			title: {
-				value: localize('swapDiffSides', "Swap Left and Right Editor Side"),
-				original: 'Compare: Swap Left and Right Editor Side'
-			},
+			title: localize2('swapDiffSides', "Swap Left and Right Editor Side"),
 			category: localize('compare', "Compare")
 		},
 		when: TextCompareEditorActiveContext

--- a/src/vs/workbench/browser/parts/panel/panelActions.ts
+++ b/src/vs/workbench/browser/parts/panel/panelActions.ts
@@ -30,12 +30,12 @@ const panelOffIcon = registerIcon('panel-layout-icon-off', Codicon.layoutPanelOf
 export class TogglePanelAction extends Action2 {
 
 	static readonly ID = 'workbench.action.togglePanel';
-	static readonly LABEL = localize('togglePanelVisibility', "Toggle Panel Visibility");
+	static readonly LABEL = localize2('togglePanelVisibility', "Toggle Panel Visibility");
 
 	constructor() {
 		super({
 			id: TogglePanelAction.ID,
-			title: { value: TogglePanelAction.LABEL, original: 'Toggle Panel Visibility' },
+			title: TogglePanelAction.LABEL,
 			toggled: {
 				condition: PanelVisibleContext,
 				title: localize('toggle panel', "Panel"),

--- a/src/vs/workbench/contrib/chat/browser/actions/chatActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatActions.ts
@@ -250,7 +250,7 @@ export function getOpenChatEditorAction(id: string, label: string, when?: string
 		constructor() {
 			super({
 				id: `workbench.action.openChat.${id}`,
-				title: { value: localize('interactiveSession.open', "Open Editor ({0})", label), original: `Open Editor (${label})` },
+				title: localize2('interactiveSession.open', "Open Editor ({0})", label),
 				f1: true,
 				category: CHAT_CATEGORY,
 				precondition: ContextKeyExpr.deserialize(when)

--- a/src/vs/workbench/contrib/codeEditor/browser/quickaccess/gotoSymbolQuickAccess.ts
+++ b/src/vs/workbench/contrib/codeEditor/browser/quickaccess/gotoSymbolQuickAccess.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { localize } from 'vs/nls';
+import { localize, localize2 } from 'vs/nls';
 import { IKeyMods, IQuickPickSeparator, IQuickInputService, IQuickPick, ItemActivation } from 'vs/platform/quickinput/common/quickInput';
 import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
 import { IRange } from 'vs/editor/common/core/range';
@@ -244,9 +244,8 @@ class GotoSymbolAction extends Action2 {
 		super({
 			id: GotoSymbolAction.ID,
 			title: {
-				value: localize('gotoSymbol', "Go to Symbol in Editor..."),
+				...localize2('gotoSymbol', "Go to Symbol in Editor..."),
 				mnemonicTitle: localize({ key: 'miGotoSymbolInEditor', comment: ['&& denotes a mnemonic'] }, "Go to &&Symbol in Editor..."),
-				original: 'Go to Symbol in Editor...'
 			},
 			f1: true,
 			keybinding: {

--- a/src/vs/workbench/contrib/codeEditor/browser/toggleColumnSelection.ts
+++ b/src/vs/workbench/contrib/codeEditor/browser/toggleColumnSelection.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { localize } from 'vs/nls';
+import { localize, localize2 } from 'vs/nls';
 import { Action2, MenuId, registerAction2 } from 'vs/platform/actions/common/actions';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { ContextKeyExpr } from 'vs/platform/contextkey/common/contextkey';
@@ -23,9 +23,8 @@ export class ToggleColumnSelectionAction extends Action2 {
 		super({
 			id: ToggleColumnSelectionAction.ID,
 			title: {
-				value: localize('toggleColumnSelection', "Toggle Column Selection Mode"),
+				...localize2('toggleColumnSelection', "Toggle Column Selection Mode"),
 				mnemonicTitle: localize({ key: 'miColumnSelection', comment: ['&& denotes a mnemonic'] }, "Column &&Selection Mode"),
-				original: 'Toggle Column Selection Mode'
 			},
 			f1: true,
 			toggled: ContextKeyExpr.equals('config.editor.columnSelection', true),

--- a/src/vs/workbench/contrib/codeEditor/browser/toggleMinimap.ts
+++ b/src/vs/workbench/contrib/codeEditor/browser/toggleMinimap.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { localize } from 'vs/nls';
+import { localize, localize2 } from 'vs/nls';
 import { Action2, MenuId, registerAction2 } from 'vs/platform/actions/common/actions';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { ContextKeyExpr } from 'vs/platform/contextkey/common/contextkey';
@@ -18,9 +18,8 @@ export class ToggleMinimapAction extends Action2 {
 		super({
 			id: ToggleMinimapAction.ID,
 			title: {
-				value: localize('toggleMinimap', "Toggle Minimap"),
-				original: 'Toggle Minimap',
-				mnemonicTitle: localize({ key: 'miMinimap', comment: ['&& denotes a mnemonic'] }, "&&Minimap")
+				...localize2('toggleMinimap', "Toggle Minimap"),
+				mnemonicTitle: localize({ key: 'miMinimap', comment: ['&& denotes a mnemonic'] }, "&&Minimap"),
 			},
 			category: Categories.View,
 			f1: true,

--- a/src/vs/workbench/contrib/codeEditor/browser/toggleRenderControlCharacter.ts
+++ b/src/vs/workbench/contrib/codeEditor/browser/toggleRenderControlCharacter.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { localize } from 'vs/nls';
+import { localize, localize2 } from 'vs/nls';
 import { Action2, MenuId, registerAction2 } from 'vs/platform/actions/common/actions';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { ContextKeyExpr } from 'vs/platform/contextkey/common/contextkey';
@@ -18,9 +18,8 @@ export class ToggleRenderControlCharacterAction extends Action2 {
 		super({
 			id: ToggleRenderControlCharacterAction.ID,
 			title: {
-				value: localize('toggleRenderControlCharacters', "Toggle Control Characters"),
+				...localize2('toggleRenderControlCharacters', "Toggle Control Characters"),
 				mnemonicTitle: localize({ key: 'miToggleRenderControlCharacters', comment: ['&& denotes a mnemonic'] }, "Render &&Control Characters"),
-				original: 'Toggle Control Characters'
 			},
 			category: Categories.View,
 			f1: true,

--- a/src/vs/workbench/contrib/codeEditor/browser/toggleRenderWhitespace.ts
+++ b/src/vs/workbench/contrib/codeEditor/browser/toggleRenderWhitespace.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { localize } from 'vs/nls';
+import { localize, localize2 } from 'vs/nls';
 import { Action2, MenuId, registerAction2 } from 'vs/platform/actions/common/actions';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { ContextKeyExpr } from 'vs/platform/contextkey/common/contextkey';
@@ -18,9 +18,8 @@ class ToggleRenderWhitespaceAction extends Action2 {
 		super({
 			id: ToggleRenderWhitespaceAction.ID,
 			title: {
-				value: localize('toggleRenderWhitespace', "Toggle Render Whitespace"),
+				...localize2('toggleRenderWhitespace', "Toggle Render Whitespace"),
 				mnemonicTitle: localize({ key: 'miToggleRenderWhitespace', comment: ['&& denotes a mnemonic'] }, "&&Render Whitespace"),
-				original: 'Toggle Render Whitespace'
 			},
 			category: Categories.View,
 			f1: true,

--- a/src/vs/workbench/contrib/debug/browser/breakpointsView.ts
+++ b/src/vs/workbench/contrib/debug/browser/breakpointsView.ts
@@ -1343,9 +1343,8 @@ registerAction2(class extends Action2 {
 		super({
 			id: 'workbench.debug.viewlet.action.addFunctionBreakpointAction',
 			title: {
-				value: localize('addFunctionBreakpoint', "Add Function Breakpoint"),
-				original: 'Add Function Breakpoint',
-				mnemonicTitle: localize({ key: 'miFunctionBreakpoint', comment: ['&& denotes a mnemonic'] }, "&&Function Breakpoint...")
+				...localize2('addFunctionBreakpoint', "Add Function Breakpoint"),
+				mnemonicTitle: localize({ key: 'miFunctionBreakpoint', comment: ['&& denotes a mnemonic'] }, "&&Function Breakpoint..."),
 			},
 			f1: true,
 			icon: icons.watchExpressionsAddFuncBreakpoint,
@@ -1430,9 +1429,8 @@ registerAction2(class extends Action2 {
 		super({
 			id: 'workbench.debug.viewlet.action.removeAllBreakpoints',
 			title: {
-				original: 'Remove All Breakpoints',
-				value: localize('removeAllBreakpoints', "Remove All Breakpoints"),
-				mnemonicTitle: localize({ key: 'miRemoveAllBreakpoints', comment: ['&& denotes a mnemonic'] }, "Remove &&All Breakpoints")
+				...localize2('removeAllBreakpoints', "Remove All Breakpoints"),
+				mnemonicTitle: localize({ key: 'miRemoveAllBreakpoints', comment: ['&& denotes a mnemonic'] }, "Remove &&All Breakpoints"),
 			},
 			f1: true,
 			icon: icons.breakpointsRemoveAll,
@@ -1469,8 +1467,7 @@ registerAction2(class extends Action2 {
 		super({
 			id: 'workbench.debug.viewlet.action.enableAllBreakpoints',
 			title: {
-				original: 'Enable All Breakpoints',
-				value: localize('enableAllBreakpoints', "Enable All Breakpoints"),
+				...localize2('enableAllBreakpoints', "Enable All Breakpoints"),
 				mnemonicTitle: localize({ key: 'miEnableAllBreakpoints', comment: ['&& denotes a mnemonic'] }, "&&Enable All Breakpoints"),
 			},
 			f1: true,
@@ -1500,9 +1497,8 @@ registerAction2(class extends Action2 {
 		super({
 			id: 'workbench.debug.viewlet.action.disableAllBreakpoints',
 			title: {
-				original: 'Disable All Breakpoints',
-				value: localize('disableAllBreakpoints', "Disable All Breakpoints"),
-				mnemonicTitle: localize({ key: 'miDisableAllBreakpoints', comment: ['&& denotes a mnemonic'] }, "Disable A&&ll Breakpoints")
+				...localize2('disableAllBreakpoints', "Disable All Breakpoints"),
+				mnemonicTitle: localize({ key: 'miDisableAllBreakpoints', comment: ['&& denotes a mnemonic'] }, "Disable A&&ll Breakpoints"),
 			},
 			f1: true,
 			precondition: CONTEXT_DEBUGGERS_AVAILABLE,

--- a/src/vs/workbench/contrib/debug/browser/debugCommands.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugCommands.ts
@@ -74,7 +74,7 @@ export const CALLSTACK_BOTTOM_ID = 'workbench.action.debug.callStackBottom';
 export const CALLSTACK_UP_ID = 'workbench.action.debug.callStackUp';
 export const CALLSTACK_DOWN_ID = 'workbench.action.debug.callStackDown';
 
-export const DEBUG_COMMAND_CATEGORY: ILocalizedString = { original: 'Debug', value: nls.localize('debug', 'Debug') };
+export const DEBUG_COMMAND_CATEGORY: ILocalizedString = nls.localize2('debug', 'Debug');
 export const RESTART_LABEL = nls.localize2('restartDebug', "Restart");
 export const STEP_OVER_LABEL = nls.localize2('stepOverDebug', "Step Over");
 export const STEP_INTO_LABEL = nls.localize2('stepIntoDebug', "Step Into");

--- a/src/vs/workbench/contrib/debug/browser/debugEditorActions.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugEditorActions.ts
@@ -36,8 +36,7 @@ class ToggleBreakpointAction extends Action2 {
 		super({
 			id: 'editor.debug.action.toggleBreakpoint',
 			title: {
-				value: nls.localize('toggleBreakpointAction', "Debug: Toggle Breakpoint"),
-				original: 'Debug: Toggle Breakpoint',
+				...nls.localize2('toggleBreakpointAction', "Debug: Toggle Breakpoint"),
 				mnemonicTitle: nls.localize({ key: 'miToggleBreakpoint', comment: ['&& denotes a mnemonic'] }, "Toggle &&Breakpoint"),
 			},
 			precondition: CONTEXT_DEBUGGERS_AVAILABLE,
@@ -234,9 +233,8 @@ class OpenDisassemblyViewAction extends Action2 {
 		super({
 			id: OpenDisassemblyViewAction.ID,
 			title: {
-				value: nls.localize('openDisassemblyView', "Open Disassembly View"),
-				original: 'Open Disassembly View',
-				mnemonicTitle: nls.localize({ key: 'miDisassemblyView', comment: ['&& denotes a mnemonic'] }, "&&DisassemblyView")
+				...nls.localize2('openDisassemblyView', "Open Disassembly View"),
+				mnemonicTitle: nls.localize({ key: 'miDisassemblyView', comment: ['&& denotes a mnemonic'] }, "&&DisassemblyView"),
 			},
 			precondition: CONTEXT_FOCUSED_STACK_FRAME_HAS_INSTRUCTION_POINTER_REFERENCE,
 			menu: [
@@ -275,9 +273,8 @@ class ToggleDisassemblyViewSourceCodeAction extends Action2 {
 		super({
 			id: ToggleDisassemblyViewSourceCodeAction.ID,
 			title: {
-				value: nls.localize('toggleDisassemblyViewSourceCode', "Toggle Source Code in Disassembly View"),
-				original: 'Toggle Source Code in Disassembly View',
-				mnemonicTitle: nls.localize({ key: 'mitogglesource', comment: ['&& denotes a mnemonic'] }, "&&ToggleSource")
+				...nls.localize2('toggleDisassemblyViewSourceCode', "Toggle Source Code in Disassembly View"),
+				mnemonicTitle: nls.localize({ key: 'mitogglesource', comment: ['&& denotes a mnemonic'] }, "&&ToggleSource"),
 			},
 			f1: true,
 		});

--- a/src/vs/workbench/contrib/editSessions/common/editSessions.ts
+++ b/src/vs/workbench/contrib/editSessions/common/editSessions.ts
@@ -16,10 +16,7 @@ import { Event } from 'vs/base/common/event';
 import { StringSHA1 } from 'vs/base/common/hash';
 import { EditSessionsStoreClient } from 'vs/workbench/contrib/editSessions/common/editSessionsStorageClient';
 
-export const EDIT_SESSION_SYNC_CATEGORY: ILocalizedString = {
-	original: 'Cloud Changes',
-	value: localize('cloud changes', 'Cloud Changes')
-};
+export const EDIT_SESSION_SYNC_CATEGORY = localize2('cloud changes', 'Cloud Changes');
 
 export type SyncResource = 'editSessions' | 'workspaceState';
 

--- a/src/vs/workbench/contrib/extensions/browser/extensions.contribution.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensions.contribution.ts
@@ -1337,7 +1337,7 @@ class ExtensionsContributions extends Disposable implements IWorkbenchContributi
 
 		this.registerExtensionAction({
 			id: ToggleAutoUpdateForExtensionAction.ID,
-			title: { value: ToggleAutoUpdateForExtensionAction.LABEL, original: 'Auto Update' },
+			title: ToggleAutoUpdateForExtensionAction.LABEL,
 			category: ExtensionsLocalizedLabel,
 			menu: {
 				id: MenuId.ExtensionContext,
@@ -1502,7 +1502,7 @@ class ExtensionsContributions extends Disposable implements IWorkbenchContributi
 
 		this.registerExtensionAction({
 			id: 'workbench.extensions.action.toggleApplyToAllProfiles',
-			title: { value: localize('workbench.extensions.action.toggleApplyToAllProfiles', "Apply Extension to all Profiles"), original: `Apply Extension to all Profiles` },
+			title: localize2('workbench.extensions.action.toggleApplyToAllProfiles', "Apply Extension to all Profiles"),
 			toggled: ContextKeyExpr.has('isApplicationScopedExtension'),
 			menu: {
 				id: MenuId.ExtensionContext,
@@ -1520,7 +1520,7 @@ class ExtensionsContributions extends Disposable implements IWorkbenchContributi
 
 		this.registerExtensionAction({
 			id: TOGGLE_IGNORE_EXTENSION_ACTION_ID,
-			title: { value: localize('workbench.extensions.action.toggleIgnoreExtension', "Sync This Extension"), original: `Sync This Extension` },
+			title: localize2('workbench.extensions.action.toggleIgnoreExtension', "Sync This Extension"),
 			menu: {
 				id: MenuId.ExtensionContext,
 				group: '2_configure',
@@ -1537,7 +1537,7 @@ class ExtensionsContributions extends Disposable implements IWorkbenchContributi
 
 		this.registerExtensionAction({
 			id: 'workbench.extensions.action.ignoreRecommendation',
-			title: { value: localize('workbench.extensions.action.ignoreRecommendation', "Ignore Recommendation"), original: `Ignore Recommendation` },
+			title: localize2('workbench.extensions.action.ignoreRecommendation', "Ignore Recommendation"),
 			menu: {
 				id: MenuId.ExtensionContext,
 				group: '3_recommendations',
@@ -1549,7 +1549,7 @@ class ExtensionsContributions extends Disposable implements IWorkbenchContributi
 
 		this.registerExtensionAction({
 			id: 'workbench.extensions.action.undoIgnoredRecommendation',
-			title: { value: localize('workbench.extensions.action.undoIgnoredRecommendation', "Undo Ignored Recommendation"), original: `Undo Ignored Recommendation` },
+			title: localize2('workbench.extensions.action.undoIgnoredRecommendation', "Undo Ignored Recommendation"),
 			menu: {
 				id: MenuId.ExtensionContext,
 				group: '3_recommendations',
@@ -1561,7 +1561,7 @@ class ExtensionsContributions extends Disposable implements IWorkbenchContributi
 
 		this.registerExtensionAction({
 			id: 'workbench.extensions.action.addExtensionToWorkspaceRecommendations',
-			title: { value: localize('workbench.extensions.action.addExtensionToWorkspaceRecommendations', "Add to Workspace Recommendations"), original: `Add to Workspace Recommendations` },
+			title: localize2('workbench.extensions.action.addExtensionToWorkspaceRecommendations', "Add to Workspace Recommendations"),
 			menu: {
 				id: MenuId.ExtensionContext,
 				group: '3_recommendations',
@@ -1573,7 +1573,7 @@ class ExtensionsContributions extends Disposable implements IWorkbenchContributi
 
 		this.registerExtensionAction({
 			id: 'workbench.extensions.action.removeExtensionFromWorkspaceRecommendations',
-			title: { value: localize('workbench.extensions.action.removeExtensionFromWorkspaceRecommendations', "Remove from Workspace Recommendations"), original: `Remove from Workspace Recommendations` },
+			title: localize2('workbench.extensions.action.removeExtensionFromWorkspaceRecommendations', "Remove from Workspace Recommendations"),
 			menu: {
 				id: MenuId.ExtensionContext,
 				group: '3_recommendations',
@@ -1585,7 +1585,7 @@ class ExtensionsContributions extends Disposable implements IWorkbenchContributi
 
 		this.registerExtensionAction({
 			id: 'workbench.extensions.action.addToWorkspaceRecommendations',
-			title: { value: localize('workbench.extensions.action.addToWorkspaceRecommendations', "Add Extension to Workspace Recommendations"), original: `Add Extension to Workspace Recommendations` },
+			title: localize2('workbench.extensions.action.addToWorkspaceRecommendations', "Add Extension to Workspace Recommendations"),
 			category: localize('extensions', "Extensions"),
 			menu: {
 				id: MenuId.CommandPalette,
@@ -1608,7 +1608,7 @@ class ExtensionsContributions extends Disposable implements IWorkbenchContributi
 
 		this.registerExtensionAction({
 			id: 'workbench.extensions.action.addToWorkspaceFolderRecommendations',
-			title: { value: localize('workbench.extensions.action.addToWorkspaceFolderRecommendations', "Add Extension to Workspace Folder Recommendations"), original: `Add Extension to Workspace Folder Recommendations` },
+			title: localize2('workbench.extensions.action.addToWorkspaceFolderRecommendations', "Add Extension to Workspace Folder Recommendations"),
 			category: localize('extensions', "Extensions"),
 			menu: {
 				id: MenuId.CommandPalette,
@@ -1619,7 +1619,7 @@ class ExtensionsContributions extends Disposable implements IWorkbenchContributi
 
 		this.registerExtensionAction({
 			id: 'workbench.extensions.action.addToWorkspaceIgnoredRecommendations',
-			title: { value: localize('workbench.extensions.action.addToWorkspaceIgnoredRecommendations', "Add Extension to Workspace Ignored Recommendations"), original: `Add Extension to Workspace Ignored Recommendations` },
+			title: localize2('workbench.extensions.action.addToWorkspaceIgnoredRecommendations', "Add Extension to Workspace Ignored Recommendations"),
 			category: localize('extensions', "Extensions"),
 			menu: {
 				id: MenuId.CommandPalette,
@@ -1642,7 +1642,7 @@ class ExtensionsContributions extends Disposable implements IWorkbenchContributi
 
 		this.registerExtensionAction({
 			id: 'workbench.extensions.action.addToWorkspaceFolderIgnoredRecommendations',
-			title: { value: localize('workbench.extensions.action.addToWorkspaceFolderIgnoredRecommendations', "Add Extension to Workspace Folder Ignored Recommendations"), original: `Add Extension to Workspace Folder Ignored Recommendations` },
+			title: localize2('workbench.extensions.action.addToWorkspaceFolderIgnoredRecommendations', "Add Extension to Workspace Folder Ignored Recommendations"),
 			category: localize('extensions', "Extensions"),
 			menu: {
 				id: MenuId.CommandPalette,

--- a/src/vs/workbench/contrib/extensions/browser/extensionsActions.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsActions.ts
@@ -850,7 +850,7 @@ export class UpdateAction extends AbstractUpdateAction {
 export class ToggleAutoUpdateForExtensionAction extends ExtensionAction {
 
 	static readonly ID = 'workbench.extensions.action.toggleAutoUpdateForExtension';
-	static readonly LABEL = localize('enableAutoUpdateLabel', "Auto Update");
+	static readonly LABEL = localize2('enableAutoUpdateLabel', "Auto Update");
 
 	private static readonly EnabledClass = `${ExtensionAction.EXTENSION_ACTION_CLASS} auto-update`;
 	private static readonly DisabledClass = `${ToggleAutoUpdateForExtensionAction.EnabledClass} hide`;
@@ -862,7 +862,7 @@ export class ToggleAutoUpdateForExtensionAction extends ExtensionAction {
 		@IConfigurationService configurationService: IConfigurationService,
 
 	) {
-		super(ToggleAutoUpdateForExtensionAction.ID, ToggleAutoUpdateForExtensionAction.LABEL, ToggleAutoUpdateForExtensionAction.DisabledClass);
+		super(ToggleAutoUpdateForExtensionAction.ID, ToggleAutoUpdateForExtensionAction.LABEL.value, ToggleAutoUpdateForExtensionAction.DisabledClass);
 		this._register(configurationService.onDidChangeConfiguration(e => {
 			if (e.affectsConfiguration(AutoUpdateConfigurationKey)) {
 				this.update();

--- a/src/vs/workbench/contrib/extensions/browser/extensionsViewlet.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsViewlet.ts
@@ -84,7 +84,7 @@ const SearchDeprecatedExtensionsContext = new RawContextKey<boolean>('searchDepr
 export const RecommendedExtensionsContext = new RawContextKey<boolean>('recommendedExtensions', false);
 const SortByUpdateDateContext = new RawContextKey<boolean>('sortByUpdateDate', false);
 
-const REMOTE_CATEGORY: ILocalizedString = { value: localize({ key: 'remote', comment: ['Remote as in remote machine'] }, "Remote"), original: 'Remote' };
+const REMOTE_CATEGORY: ILocalizedString = localize2({ key: 'remote', comment: ['Remote as in remote machine'] }, "Remote");
 
 export class ExtensionsViewletViewsContribution implements IWorkbenchContribution {
 

--- a/src/vs/workbench/contrib/files/browser/views/openEditorsView.ts
+++ b/src/vs/workbench/contrib/files/browser/views/openEditorsView.ts
@@ -824,8 +824,7 @@ MenuRegistry.appendMenuItem(MenuId.MenubarLayoutMenu, {
 	command: {
 		id: toggleEditorGroupLayoutId,
 		title: {
-			original: 'Flip Layout',
-			value: nls.localize('miToggleEditorLayoutWithoutMnemonic', "Flip Layout"),
+			...nls.localize2('miToggleEditorLayoutWithoutMnemonic', "Flip Layout"),
 			mnemonicTitle: nls.localize({ key: 'miToggleEditorLayout', comment: ['&& denotes a mnemonic'] }, "Flip &&Layout")
 		}
 	},

--- a/src/vs/workbench/contrib/notebook/browser/contrib/troubleshoot/layout.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/troubleshoot/layout.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Disposable, DisposableStore, dispose, IDisposable } from 'vs/base/common/lifecycle';
-import { localize, localize2 } from 'vs/nls';
+import { localize2 } from 'vs/nls';
 import { Categories } from 'vs/platform/action/common/actionCommonCategories';
 import { Action2, registerAction2 } from 'vs/platform/actions/common/actions';
 import { ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
@@ -122,10 +122,7 @@ registerAction2(class extends Action2 {
 	constructor() {
 		super({
 			id: 'notebook.toggleLayoutTroubleshoot',
-			title: {
-				value: localize('workbench.notebook.toggleLayoutTroubleshoot', "Toggle Layout Troubleshoot"),
-				original: 'Toggle Notebook Layout Troubleshoot'
-			},
+			title: localize2('workbench.notebook.toggleLayoutTroubleshoot', "Toggle Layout Troubleshoot"),
 			category: Categories.Developer,
 			f1: true
 		});
@@ -173,10 +170,7 @@ registerAction2(class extends Action2 {
 	constructor() {
 		super({
 			id: 'notebook.clearNotebookEdtitorTypeCache',
-			title: {
-				value: localize('workbench.notebook.clearNotebookEdtitorTypeCache', "Clear Notebook Editor Type Cache"),
-				original: 'Clear Notebook Editor Cache'
-			},
+			title: localize2('workbench.notebook.clearNotebookEdtitorTypeCache', "Clear Notebook Editor Type Cache"),
 			category: Categories.Developer,
 			f1: true
 		});

--- a/src/vs/workbench/contrib/notebook/browser/controller/foldingController.ts
+++ b/src/vs/workbench/contrib/notebook/browser/controller/foldingController.ts
@@ -151,7 +151,7 @@ registerNotebookContribution(FoldingController.id, FoldingController);
 
 
 const NOTEBOOK_FOLD_COMMAND_LABEL = localize('fold.cell', "Fold Cell");
-const NOTEBOOK_UNFOLD_COMMAND_LABEL = localize('unfold.cell', "Unfold Cell");
+const NOTEBOOK_UNFOLD_COMMAND_LABEL = localize2('unfold.cell', "Unfold Cell");
 
 const FOLDING_COMMAND_ARGS: Pick<ICommandMetadata, 'args'> = {
 	args: [{
@@ -253,7 +253,7 @@ registerAction2(class extends Action2 {
 	constructor() {
 		super({
 			id: 'notebook.unfold',
-			title: { value: NOTEBOOK_UNFOLD_COMMAND_LABEL, original: 'Unfold Cell' },
+			title: NOTEBOOK_UNFOLD_COMMAND_LABEL,
 			category: NOTEBOOK_ACTIONS_CATEGORY,
 			keybinding: {
 				when: ContextKeyExpr.and(NOTEBOOK_EDITOR_FOCUSED, ContextKeyExpr.not(InputFocusedContextKey)),

--- a/src/vs/workbench/contrib/notebook/browser/view/cellParts/chat/cellChatActions.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/cellParts/chat/cellChatActions.ts
@@ -213,10 +213,7 @@ registerAction2(class extends NotebookCellAction {
 		super(
 			{
 				id: 'notebook.cell.chat.stop',
-				title: {
-					value: localize('notebook.cell.chat.stop', "Stop Request"),
-					original: 'Make Request'
-				},
+				title: localize2('notebook.cell.chat.stop', "Stop Request"),
 				icon: Codicon.debugStop,
 				menu: {
 					id: MENU_CELL_CHAT_INPUT,

--- a/src/vs/workbench/contrib/notebook/browser/viewParts/notebookEditorStickyScroll.ts
+++ b/src/vs/workbench/contrib/notebook/browser/viewParts/notebookEditorStickyScroll.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { localize } from 'vs/nls';
+import { localize, localize2 } from 'vs/nls';
 import * as DOM from 'vs/base/browser/dom';
 import { EventType as TouchEventType } from 'vs/base/browser/touch';
 import { StandardMouseEvent } from 'vs/base/browser/mouseEvent';
@@ -33,9 +33,8 @@ export class ToggleNotebookStickyScroll extends Action2 {
 		super({
 			id: 'notebook.action.toggleNotebookStickyScroll',
 			title: {
-				value: localize('toggleStickyScroll', "Toggle Notebook Sticky Scroll"),
+				...localize2('toggleStickyScroll', "Toggle Notebook Sticky Scroll"),
 				mnemonicTitle: localize({ key: 'mitoggleStickyScroll', comment: ['&& denotes a mnemonic'] }, "&&Toggle Notebook Sticky Scroll"),
-				original: 'Toggle Notebook Sticky Scroll',
 			},
 			category: Categories.View,
 			toggled: {

--- a/src/vs/workbench/contrib/preferences/browser/preferences.contribution.ts
+++ b/src/vs/workbench/contrib/preferences/browser/preferences.contribution.ts
@@ -192,9 +192,8 @@ class PreferencesActionsContribution extends Disposable implements IWorkbenchCon
 				super({
 					id: SETTINGS_COMMAND_OPEN_SETTINGS,
 					title: {
-						value: nls.localize('settings', "Settings"),
+						...nls.localize2('settings', "Settings"),
 						mnemonicTitle: nls.localize({ key: 'miOpenSettings', comment: ['&& denotes a mnemonic'] }, "&&Settings"),
-						original: 'Settings'
 					},
 					keybinding: {
 						weight: KeybindingWeight.WorkbenchContrib,
@@ -409,7 +408,7 @@ class PreferencesActionsContribution extends Disposable implements IWorkbenchCon
 			constructor() {
 				super({
 					id: '_workbench.action.openFolderSettings',
-					title: nls.localize2('openFolderSettings', "Open Folder Settings"),
+					title: nls.localize('openFolderSettings', "Open Folder Settings"),
 					category,
 					menu: {
 						id: MenuId.ExplorerContext,
@@ -480,12 +479,11 @@ class PreferencesActionsContribution extends Disposable implements IWorkbenchCon
 			.then(() => {
 				const remoteAuthority = this.environmentService.remoteAuthority;
 				const hostLabel = this.labelService.getHostLabel(Schemas.vscodeRemote, remoteAuthority) || remoteAuthority;
-				const label = nls.localize('openRemoteSettings', "Open Remote Settings ({0})", hostLabel);
 				registerAction2(class extends Action2 {
 					constructor() {
 						super({
 							id: 'workbench.action.openRemoteSettings',
-							title: { value: label, original: `Open Remote Settings (${hostLabel})` },
+							title: nls.localize2('openRemoteSettings', "Open Remote Settings ({0})", hostLabel),
 							category,
 							menu: {
 								id: MenuId.CommandPalette,
@@ -498,12 +496,11 @@ class PreferencesActionsContribution extends Disposable implements IWorkbenchCon
 						return accessor.get(IPreferencesService).openRemoteSettings(args);
 					}
 				});
-				const jsonLabel = nls.localize('openRemoteSettingsJSON', "Open Remote Settings (JSON) ({0})", hostLabel);
 				registerAction2(class extends Action2 {
 					constructor() {
 						super({
 							id: 'workbench.action.openRemoteSettingsFile',
-							title: { value: jsonLabel, original: `Open Remote Settings (JSON) (${hostLabel})` },
+							title: nls.localize2('openRemoteSettingsJSON', "Open Remote Settings (JSON) ({0})", hostLabel),
 							category,
 							menu: {
 								id: MenuId.CommandPalette,
@@ -830,7 +827,7 @@ class PreferencesActionsContribution extends Disposable implements IWorkbenchCon
 			constructor() {
 				super({
 					id: KEYBINDINGS_EDITOR_SHOW_DEFAULT_KEYBINDINGS,
-					title: { value: nls.localize('showDefaultKeybindings', "Show System Keybindings"), original: 'Show System Keyboard Shortcuts' },
+					title: nls.localize2('showDefaultKeybindings', "Show System Keybindings"),
 					menu: [
 						{
 							id: MenuId.EditorTitle,
@@ -851,7 +848,7 @@ class PreferencesActionsContribution extends Disposable implements IWorkbenchCon
 			constructor() {
 				super({
 					id: KEYBINDINGS_EDITOR_SHOW_EXTENSION_KEYBINDINGS,
-					title: { value: nls.localize('showExtensionKeybindings', "Show Extension Keybindings"), original: 'Show Extension Keyboard Shortcuts' },
+					title: nls.localize2('showExtensionKeybindings', "Show Extension Keybindings"),
 					menu: [
 						{
 							id: MenuId.EditorTitle,
@@ -872,7 +869,7 @@ class PreferencesActionsContribution extends Disposable implements IWorkbenchCon
 			constructor() {
 				super({
 					id: KEYBINDINGS_EDITOR_SHOW_USER_KEYBINDINGS,
-					title: { value: nls.localize('showUserKeybindings', "Show User Keybindings"), original: 'Show User Keyboard Shortcuts' },
+					title: nls.localize2('showUserKeybindings', "Show User Keybindings"),
 					menu: [
 						{
 							id: MenuId.EditorTitle,

--- a/src/vs/workbench/contrib/remoteTunnel/electron-sandbox/remoteTunnel.contribution.ts
+++ b/src/vs/workbench/contrib/remoteTunnel/electron-sandbox/remoteTunnel.contribution.ts
@@ -10,8 +10,7 @@ import { ITunnelApplicationConfig } from 'vs/base/common/product';
 import { joinPath } from 'vs/base/common/resources';
 import { isNumber, isObject, isString } from 'vs/base/common/types';
 import { URI } from 'vs/base/common/uri';
-import { localize } from 'vs/nls';
-import { ILocalizedString } from 'vs/platform/action/common/action';
+import { localize, localize2 } from 'vs/nls';
 import { Action2, MenuId, registerAction2 } from 'vs/platform/actions/common/actions';
 import { IClipboardService } from 'vs/platform/clipboard/common/clipboardService';
 import { ICommandService } from 'vs/platform/commands/common/commands';
@@ -37,10 +36,7 @@ import { LifecyclePhase } from 'vs/workbench/services/lifecycle/common/lifecycle
 import { IOutputService } from 'vs/workbench/services/output/common/output';
 import { IPreferencesService } from 'vs/workbench/services/preferences/common/preferences';
 
-export const REMOTE_TUNNEL_CATEGORY: ILocalizedString = {
-	original: 'Remote-Tunnels',
-	value: localize('remoteTunnel.category', 'Remote Tunnels')
-};
+export const REMOTE_TUNNEL_CATEGORY = localize2('remoteTunnel.category', 'Remote Tunnels');
 
 type CONTEXT_KEY_STATES = 'connected' | 'connecting' | 'disconnected';
 

--- a/src/vs/workbench/contrib/search/browser/searchActionsFind.ts
+++ b/src/vs/workbench/contrib/search/browser/searchActionsFind.ts
@@ -160,9 +160,8 @@ registerAction2(class FindInFilesAction extends Action2 {
 		super({
 			id: Constants.SearchCommandIds.FindInFilesActionId,
 			title: {
-				value: nls.localize('findInFiles', "Find in Files"),
+				...nls.localize2('findInFiles', "Find in Files"),
 				mnemonicTitle: nls.localize({ key: 'miFindInFiles', comment: ['&& denotes a mnemonic'] }, "Find &&in Files"),
-				original: 'Find in Files'
 			},
 			metadata: {
 				description: nls.localize('findInFiles.description', "Open a workspace search"),

--- a/src/vs/workbench/contrib/search/browser/searchActionsSymbol.ts
+++ b/src/vs/workbench/contrib/search/browser/searchActionsSymbol.ts
@@ -23,9 +23,8 @@ registerAction2(class ShowAllSymbolsAction extends Action2 {
 		super({
 			id: Constants.SearchCommandIds.ShowAllSymbolsActionId,
 			title: {
-				value: nls.localize('showTriggerActions', "Go to Symbol in Workspace..."),
-				original: 'Go to Symbol in Workspace...',
-				mnemonicTitle: nls.localize({ key: 'miGotoSymbolInWorkspace', comment: ['&& denotes a mnemonic'] }, "Go to Symbol in &&Workspace...")
+				...nls.localize2('showTriggerActions', "Go to Symbol in Workspace..."),
+				mnemonicTitle: nls.localize({ key: 'miGotoSymbolInWorkspace', comment: ['&& denotes a mnemonic'] }, "Go to Symbol in &&Workspace..."),
 			},
 			f1: true,
 			keybinding: {

--- a/src/vs/workbench/contrib/searchEditor/browser/searchEditor.contribution.ts
+++ b/src/vs/workbench/contrib/searchEditor/browser/searchEditor.contribution.ts
@@ -456,7 +456,7 @@ registerAction2(class extends Action2 {
 	constructor() {
 		super({
 			id: ToggleSearchEditorRegexCommandId,
-			title: { value: localize('searchEditor.action.toggleSearchEditorRegex', "Toggle Use Regular Expression"), original: 'Toggle Use Regular Expression"' },
+			title: localize2('searchEditor.action.toggleSearchEditorRegex', "Toggle Use Regular Expression"),
 			category,
 			f1: true,
 			precondition: SearchEditorConstants.InSearchEditor,
@@ -475,7 +475,7 @@ registerAction2(class extends Action2 {
 	constructor() {
 		super({
 			id: SearchEditorConstants.ToggleSearchEditorContextLinesCommandId,
-			title: { value: localize('searchEditor.action.toggleSearchEditorContextLines', "Toggle Context Lines"), original: 'Toggle Context Lines"' },
+			title: localize2('searchEditor.action.toggleSearchEditorContextLines', "Toggle Context Lines"),
 			category,
 			f1: true,
 			precondition: SearchEditorConstants.InSearchEditor,

--- a/src/vs/workbench/contrib/snippets/browser/commands/configureSnippets.ts
+++ b/src/vs/workbench/contrib/snippets/browser/commands/configureSnippets.ts
@@ -227,9 +227,8 @@ export class ConfigureSnippetsAction extends SnippetsAction {
 			id: 'workbench.action.openSnippets',
 			title: nls.localize2('openSnippet.label', "Configure User Snippets"),
 			shortTitle: {
-				value: nls.localize('userSnippets', "User Snippets"),
+				...nls.localize2('userSnippets', "User Snippets"),
 				mnemonicTitle: nls.localize({ key: 'miOpenSnippets', comment: ['&& denotes a mnemonic'] }, "User &&Snippets"),
-				original: 'User Snippets'
 			},
 			f1: true,
 			menu: [

--- a/src/vs/workbench/contrib/terminal/common/terminalStrings.ts
+++ b/src/vs/workbench/contrib/terminal/common/terminalStrings.ts
@@ -20,8 +20,7 @@ export const terminalStrings = {
 	focus: localize2('workbench.action.terminal.focus', "Focus Terminal"),
 	focusAndHideAccessibleBuffer: localize2('workbench.action.terminal.focusAndHideAccessibleBuffer', "Focus Terminal and Hide Accessible Buffer"),
 	kill: {
-		value: localize('killTerminal', "Kill Terminal"),
-		original: 'Kill Terminal',
+		...localize2('killTerminal', "Kill Terminal"),
 		short: localize('killTerminal.short', "Kill"),
 	},
 	moveToEditor: localize2('moveToEditor', "Move Terminal into Editor Area"),
@@ -30,8 +29,7 @@ export const terminalStrings = {
 	changeIcon: localize2('workbench.action.terminal.changeIcon', "Change Icon..."),
 	changeColor: localize2('workbench.action.terminal.changeColor', "Change Color..."),
 	split: {
-		value: localize('splitTerminal', "Split Terminal"),
-		original: 'Split Terminal',
+		...localize2('splitTerminal', "Split Terminal"),
 		short: localize('splitTerminal.short', "Split"),
 	},
 	unsplit: localize2('unsplitTerminal', "Unsplit Terminal"),

--- a/src/vs/workbench/contrib/testing/browser/testExplorerActions.ts
+++ b/src/vs/workbench/contrib/testing/browser/testExplorerActions.ts
@@ -77,7 +77,7 @@ const hasAnyTestProvider = ContextKeyGreaterExpr.create(TestingContextKeys.provi
 
 const LABEL_RUN_TESTS = localize2('runSelectedTests', "Run Tests");
 const LABEL_DEBUG_TESTS = localize2('debugSelectedTests', "Debug Tests");
-const LABEL_COVERAGE_TESTS = { value: localize('coverageSelectedTests', 'Run Tests with Coverage'), original: 'Run Tests withCoverage' };
+const LABEL_COVERAGE_TESTS = localize2('coverageSelectedTests', "Run Tests with Coverage");
 
 export class HideTestAction extends Action2 {
 	constructor() {
@@ -480,7 +480,7 @@ class StartContinuousRunAction extends Action2 {
 	constructor() {
 		super({
 			id: TestCommandId.StartContinousRun,
-			title: { value: localize('testing.startContinuous', "Start Continuous Run"), original: 'Enable Continuous Run' },
+			title: localize2('testing.startContinuous', "Start Continuous Run"),
 			category,
 			icon: icons.testingTurnContinuousRunOn,
 			menu: continuousMenus(false),

--- a/src/vs/workbench/contrib/update/browser/update.contribution.ts
+++ b/src/vs/workbench/contrib/update/browser/update.contribution.ts
@@ -38,9 +38,8 @@ export class ShowCurrentReleaseNotesAction extends Action2 {
 		super({
 			id: ShowCurrentReleaseNotesActionId,
 			title: {
-				value: localize('showReleaseNotes', "Show Release Notes"),
+				...localize2('showReleaseNotes', "Show Release Notes"),
 				mnemonicTitle: localize({ key: 'mshowReleaseNotes', comment: ['&& denotes a mnemonic'] }, "Show &&Release Notes"),
-				original: 'Show Release Notes'
 			},
 			category: { value: product.nameShort, original: product.nameShort },
 			f1: true,
@@ -148,10 +147,7 @@ class DownloadAction extends Action2 {
 	constructor() {
 		super({
 			id: DownloadAction.ID,
-			title: {
-				value: localize('openDownloadPage', "Download {0}", product.nameLong),
-				original: `Download ${product.downloadUrl}`
-			},
+			title: localize2('openDownloadPage', "Download {0}", product.nameLong),
 			precondition: ContextKeyExpr.and(IsWebContext, DOWNLOAD_URL), // Only show when running in a web browser and a download url is available
 			f1: true,
 			menu: [{

--- a/src/vs/workbench/contrib/userDataProfile/browser/userDataProfile.ts
+++ b/src/vs/workbench/contrib/userDataProfile/browser/userDataProfile.ts
@@ -189,10 +189,7 @@ export class UserDataProfilesWorkbenchContribution extends Disposable implements
 				const when = ContextKeyExpr.and(ContextKeyExpr.notEquals(CURRENT_PROFILE_CONTEXT.key, that.userDataProfilesService.defaultProfile.id), IS_CURRENT_PROFILE_TRANSIENT_CONTEXT.toNegated());
 				super({
 					id: `workbench.profiles.actions.editCurrentProfile`,
-					title: {
-						value: localize('edit profile', "Edit Profile..."),
-						original: `Edit Profile...`
-					},
+					title: localize2('edit profile', "Edit Profile..."),
 					precondition: when,
 					f1: true,
 					menu: [
@@ -217,10 +214,7 @@ export class UserDataProfilesWorkbenchContribution extends Disposable implements
 			constructor() {
 				super({
 					id,
-					title: {
-						value: localize('show profile contents', "Show Profile Contents"),
-						original: `Show Profile Contents`
-					},
+					title: localize2('show profile contents', "Show Profile Contents"),
 					category: PROFILES_CATEGORY,
 					menu: [
 						{
@@ -249,10 +243,7 @@ export class UserDataProfilesWorkbenchContribution extends Disposable implements
 			constructor() {
 				super({
 					id,
-					title: {
-						value: localize('export profile', "Export Profile..."),
-						original: `Export Profile (${that.userDataProfileService.currentProfile.name})...`
-					},
+					title: localize2('export profile', "Export Profile..."),
 					category: PROFILES_CATEGORY,
 					precondition: IS_PROFILE_EXPORT_IN_PROGRESS_CONTEXT.toNegated(),
 					menu: [
@@ -275,10 +266,7 @@ export class UserDataProfilesWorkbenchContribution extends Disposable implements
 		disposables.add(MenuRegistry.appendMenuItem(MenuId.MenubarShare, {
 			command: {
 				id,
-				title: {
-					value: localize('export profile in share', "Export Profile ({0})...", that.userDataProfileService.currentProfile.name),
-					original: `Export Profile (${that.userDataProfileService.currentProfile.name})...`
-				},
+				title: localize2('export profile in share', "Export Profile ({0})...", that.userDataProfileService.currentProfile.name),
 				precondition: PROFILES_ENABLEMENT_CONTEXT,
 			},
 		}));
@@ -381,10 +369,7 @@ export class UserDataProfilesWorkbenchContribution extends Disposable implements
 		disposables.add(MenuRegistry.appendMenuItem(MenuId.MenubarShare, {
 			command: {
 				id,
-				title: {
-					value: localize('import profile share', "Import Profile...",),
-					original: 'Import Profile...'
-				},
+				title: localize2('import profile share', "Import Profile..."),
 				precondition: PROFILES_ENABLEMENT_CONTEXT,
 			},
 		}));

--- a/src/vs/workbench/electron-sandbox/actions/windowActions.ts
+++ b/src/vs/workbench/electron-sandbox/actions/windowActions.ts
@@ -37,9 +37,8 @@ export class CloseWindowAction extends Action2 {
 		super({
 			id: CloseWindowAction.ID,
 			title: {
-				value: localize('closeWindow', "Close Window"),
+				...localize2('closeWindow', "Close Window"),
 				mnemonicTitle: localize({ key: 'miCloseWindow', comment: ['&& denotes a mnemonic'] }, "Clos&&e Window"),
-				original: 'Close Window'
 			},
 			f1: true,
 			keybinding: {
@@ -123,9 +122,8 @@ export class ZoomInAction extends BaseZoomAction {
 		super({
 			id: 'workbench.action.zoomIn',
 			title: {
-				value: localize('zoomIn', "Zoom In"),
+				...localize2('zoomIn', "Zoom In"),
 				mnemonicTitle: localize({ key: 'miZoomIn', comment: ['&& denotes a mnemonic'] }, "&&Zoom In"),
-				original: 'Zoom In'
 			},
 			category: Categories.View,
 			f1: true,
@@ -153,9 +151,8 @@ export class ZoomOutAction extends BaseZoomAction {
 		super({
 			id: 'workbench.action.zoomOut',
 			title: {
-				value: localize('zoomOut', "Zoom Out"),
+				...localize2('zoomOut', "Zoom Out"),
 				mnemonicTitle: localize({ key: 'miZoomOut', comment: ['&& denotes a mnemonic'] }, "&&Zoom Out"),
-				original: 'Zoom Out'
 			},
 			category: Categories.View,
 			f1: true,
@@ -187,9 +184,8 @@ export class ZoomResetAction extends BaseZoomAction {
 		super({
 			id: 'workbench.action.zoomReset',
 			title: {
-				value: localize('zoomReset', "Reset Zoom"),
+				...localize2('zoomReset', "Reset Zoom"),
 				mnemonicTitle: localize({ key: 'miZoomReset', comment: ['&& denotes a mnemonic'] }, "&&Reset Zoom"),
-				original: 'Reset Zoom'
 			},
 			category: Categories.View,
 			f1: true,

--- a/src/vs/workbench/services/views/browser/viewDescriptorService.ts
+++ b/src/vs/workbench/services/views/browser/viewDescriptorService.ts
@@ -18,7 +18,7 @@ import { generateUuid } from 'vs/base/common/uuid';
 import { IInstantiationService, ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
 import { getViewsStateStorageId, ViewContainerModel } from 'vs/workbench/services/views/common/viewContainerModel';
 import { registerAction2, Action2, MenuId } from 'vs/platform/actions/common/actions';
-import { localize } from 'vs/nls';
+import { localize, localize2 } from 'vs/nls';
 import { IStringDictionary } from 'vs/base/common/collections';
 import { ILogger, ILoggerService } from 'vs/platform/log/common/log';
 
@@ -839,10 +839,7 @@ export class ViewDescriptorService extends Disposable implements IViewDescriptor
 			constructor() {
 				super({
 					id: `${viewContainer.id}.resetViewContainerLocation`,
-					title: {
-						original: 'Reset Location',
-						value: localize('resetViewLocation', "Reset Location")
-					},
+					title: localize2('resetViewLocation', "Reset Location"),
 					menu: [{
 						id: MenuId.ViewContainerTitleContext,
 						when: ContextKeyExpr.or(

--- a/src/vs/workbench/services/views/browser/viewsService.ts
+++ b/src/vs/workbench/services/views/browser/viewsService.ts
@@ -12,7 +12,7 @@ import { ContextKeyExpr, IContextKey, IContextKeyService, RawContextKey } from '
 import { Event, Emitter } from 'vs/base/common/event';
 import { isString } from 'vs/base/common/types';
 import { MenuId, registerAction2, Action2, MenuRegistry } from 'vs/platform/actions/common/actions';
-import { localize } from 'vs/nls';
+import { localize, localize2 } from 'vs/nls';
 import { KeybindingWeight } from 'vs/platform/keybinding/common/keybindingsRegistry';
 import { InstantiationType, registerSingleton } from 'vs/platform/instantiation/common/extensions';
 import { IPaneComposite } from 'vs/workbench/common/panecomposite';
@@ -550,10 +550,7 @@ export class ViewsService extends Disposable implements IViewsService {
 			constructor() {
 				super({
 					id: `${viewDescriptor.id}.resetViewLocation`,
-					title: {
-						original: 'Reset Location',
-						value: localize('resetViewLocation', "Reset Location")
-					},
+					title: localize2('resetViewLocation', "Reset Location"),
 					menu: [{
 						id: MenuId.ViewTitleContext,
 						when: ContextKeyExpr.or(


### PR DESCRIPTION
This pass covers some more advanced cases my previous pass missed. Also caught a few instances where the original string was different from the actual localize string

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
