### PR TITLE
Update panel and auxiliary bar action titles

### DIFF
--- a/src/vs/workbench/browser/parts/panel/panelActions.ts
+++ b/src/vs/workbench/browser/parts/panel/panelActions.ts
@@ -318,7 +318,7 @@ registerAction2(class extends Action2 {
 	constructor() {
 		super({
 			id: 'workbench.action.closePanel',
-			title: localize2('closePanel', 'Close Panel'),
+			title: localize2('closePanel', 'Hide Panel'),
 			category: Categories.View,
 			icon: closeIcon,
 			menu: [{
@@ -340,7 +340,7 @@ registerAction2(class extends Action2 {
 	constructor() {
 		super({
 			id: 'workbench.action.closeAuxiliaryBar',
-			title: localize2('closeSecondarySideBar', 'Close Secondary Side Bar'),
+			title: localize2('closeSecondarySideBar', 'Hide Secondary Side Bar'),
 			category: Categories.View,
 			icon: closeIcon,
 			menu: [{


### PR DESCRIPTION
Rename "Close" verb to "Hide" to prevent confusion that the panel contents could be lost. Same for the secondary side bar. Closes #203184.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
