### PR TITLE
Get rid of 'slash command' from API

### DIFF
--- a/src/vs/workbench/api/common/extHostTypeConverters.ts
+++ b/src/vs/workbench/api/common/extHostTypeConverters.ts
@@ -2428,11 +2428,10 @@ export namespace ChatResponseProgress {
 }
 
 export namespace ChatAgentRequest {
-	export function to(request: IChatAgentRequest, slashCommand: vscode.ChatAgentSubCommand | undefined): vscode.ChatAgentRequest {
+	export function to(request: IChatAgentRequest): vscode.ChatAgentRequest {
 		return {
 			prompt: request.message,
 			variables: ChatVariable.objectTo(request.variables),
-			slashCommand,
 			subCommand: request.command,
 			agentId: request.agentId,
 		};

--- a/src/vs/workbench/contrib/chat/common/chatServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/chatServiceImpl.ts
@@ -542,7 +542,7 @@ export class ChatService extends Disposable implements IChatService {
 						agentId: agent.id,
 						message: variableData.message,
 						variables: variableData.variables,
-						command: agentSlashCommandPart?.command.name ?? '',
+						command: agentSlashCommandPart?.command.name,
 					};
 
 					const agentResult = await this.chatAgentService.invokeAgent(agent.id, requestProps, progressCallback, history, token);

--- a/src/vscode-dts/vscode.proposed.chatAgents2.d.ts
+++ b/src/vscode-dts/vscode.proposed.chatAgents2.d.ts
@@ -5,9 +5,23 @@
 
 declare module 'vscode' {
 
+	/**
+	 * One request/response pair in chat history.
+	 */
 	export interface ChatAgentHistoryEntry {
+		/**
+		 * The request that was sent to the chat agent.
+		 */
 		request: ChatAgentRequest;
+
+		/**
+		 * The content that was received from the chat agent. Only the progress parts that represent actual content (not metadata) are represented.
+		 */
 		response: ChatAgentContentProgress[];
+
+		/**
+		 * The result that was received from the chat agent.
+		 */
 		result: ChatAgentResult2;
 	}
 
@@ -251,13 +265,6 @@ declare module 'vscode' {
 		 * The ID of the chat agent to which this request was directed.
 		 */
 		agentId: string;
-
-		/**
-		 * The {@link ChatAgentSubCommand subCommand} that was selected for this request. It is guaranteed that the passed subCommand
-		 * is an instance that was previously returned from the {@link ChatAgentSubCommandProvider.provideSubCommands subCommand provider}.
-		 * @deprecated this will be replaced by `subCommand`
-		 */
-		slashCommand?: ChatAgentSubCommand;
 
 		/**
 		 * The name of the {@link ChatAgentSubCommand subCommand} that was selected for this request.


### PR DESCRIPTION
Also don't send an empty string for 'subCommand' when there is no slash command selected

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
