### PR TITLE
cli: skip integrity check when prereq skip flag is present (#203912)

### DIFF
--- a/cli/src/tunnels/code_server.rs
+++ b/cli/src/tunnels/code_server.rs
@@ -21,6 +21,7 @@ use crate::util::errors::{wrap, AnyError, CodeError, ExtensionInstallFailed, Wra
 use crate::util::http::{self, BoxedHttp};
 use crate::util::io::SilentCopyProgress;
 use crate::util::machine::process_exists;
+use crate::util::prereqs::skip_requirements_check;
 use crate::{debug, info, log, spanf, trace, warning};
 use lazy_static::lazy_static;
 use opentelemetry::KeyValue;
@@ -425,20 +426,24 @@ impl<'a> ServerBuilder<'a> {
 				let server_dir = target_dir.join(SERVER_FOLDER_NAME);
 				unzip_downloaded_release(&archive_path, &server_dir, SilentCopyProgress())?;
 
-				let output = capture_command_and_check_status(
-					server_dir
-						.join("bin")
-						.join(self.server_params.release.quality.server_entrypoint()),
-					&["--version"],
-				)
-				.await
-				.map_err(|e| wrap(e, "error checking server integrity"))?;
+				if !skip_requirements_check().await {
+					let output = capture_command_and_check_status(
+						server_dir
+							.join("bin")
+							.join(self.server_params.release.quality.server_entrypoint()),
+						&["--version"],
+					)
+					.await
+					.map_err(|e| wrap(e, "error checking server integrity"))?;
 
-				trace!(
-					self.logger,
-					"Server integrity verified, version: {}",
-					String::from_utf8_lossy(&output.stdout).replace('\n', " / ")
-				);
+					trace!(
+						self.logger,
+						"Server integrity verified, version: {}",
+						String::from_utf8_lossy(&output.stdout).replace('\n', " / ")
+					);
+				} else {
+					info!(self.logger, "Skipping server integrity check");
+				}
 
 				Ok(())
 			})


### PR DESCRIPTION
This change skips the "integrity verification" step where we run the VS Code CLI if the prerequisite-skip flag is present. This is needed for Amazon Linux where they patch our Node to work for older glibc's. Without this, we immediately discard the directory and try downloading the server again, which does not give them time to patch the binary.