### PR TITLE
dispose actions after selection/application of code action

### DIFF
--- a/src/vs/editor/contrib/codeAction/browser/codeActionController.ts
+++ b/src/vs/editor/contrib/codeAction/browser/codeActionController.ts
@@ -112,7 +112,12 @@ export class CodeActionController extends Disposable implements IEditorContribut
 					command.arguments[0] = { ...command.arguments[0], autoSend: false };
 				}
 			}
-			await this._applyCodeAction(actionItem, false, false, ApplyCodeActionReason.FromAILightbulb);
+			try {
+				this._lightBulbWidget.value?.hide();
+				await this._applyCodeAction(actionItem, false, false, ApplyCodeActionReason.FromAILightbulb);
+			} finally {
+				actions.dispose();
+			}
 			return;
 		}
 		await this.showCodeActionList(actions, at, { includeDisabledActions: false, fromLightbulb: true });
@@ -279,7 +284,11 @@ export class CodeActionController extends Disposable implements IEditorContribut
 
 		const delegate: IActionListDelegate<CodeActionItem> = {
 			onSelect: async (action: CodeActionItem, preview?: boolean) => {
-				this._applyCodeAction(action, /* retrigger */ true, !!preview, ApplyCodeActionReason.FromCodeActions);
+				try {
+					await this._applyCodeAction(action, /* retrigger */ true, !!preview, ApplyCodeActionReason.FromCodeActions);
+				} finally {
+					actions.dispose();
+				}
 				this._actionWidgetService.hide();
 				currentDecorations.clear();
 			},


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

related https://github.com/microsoft/vscode/issues/203897

in addition to change from `showActionsFromLightbulb`, disposes actions after selection via refactorings/quick fixes