### PR TITLE
more copy SVG fixes

### DIFF
--- a/extensions/ipynb/package.json
+++ b/extensions/ipynb/package.json
@@ -113,7 +113,7 @@
       "webview/context": [
         {
           "command": "notebook.cellOutput.copy",
-          "when": "webviewId == 'notebook.output'"
+          "when": "webviewId == 'notebook.output' && webviewSection == 'image'"
         }
       ]
     }

--- a/src/vs/workbench/contrib/notebook/browser/controller/cellOutputActions.ts
+++ b/src/vs/workbench/contrib/notebook/browser/controller/cellOutputActions.ts
@@ -23,7 +23,7 @@ registerAction2(class CopyCellOutputAction extends Action2 {
 	constructor() {
 		super({
 			id: COPY_OUTPUT_COMMAND_ID,
-			title: localize('notebookActions.copyOutput', "Copy Output"),
+			title: localize('notebookActions.copyOutput', "Copy Cell Output"),
 			menu: {
 				id: MenuId.NotebookOutputToolbar,
 				when: NOTEBOOK_CELL_HAS_OUTPUTS

--- a/src/vs/workbench/contrib/notebook/browser/controller/cellOutputActions.ts
+++ b/src/vs/workbench/contrib/notebook/browser/controller/cellOutputActions.ts
@@ -42,7 +42,14 @@ registerAction2(class CopyCellOutputAction extends Action2 {
 		}
 
 		let outputViewModel: ICellOutputViewModel | undefined;
-		if (!outputContext) {
+		if (outputContext && 'outputId' in outputContext && typeof outputContext.outputId === 'string') {
+			outputViewModel = getOutputViewModelFromId(outputContext.outputId, notebookEditor);
+		} else if (outputContext && 'outputViewModel' in outputContext) {
+			outputViewModel = outputContext.outputViewModel;
+		}
+
+		if (!outputViewModel) {
+			// not able to find the output from the provided context, use the active cell
 			const activeCell = notebookEditor.getActiveCell();
 			if (!activeCell) {
 				return;
@@ -55,10 +62,6 @@ registerAction2(class CopyCellOutputAction extends Action2 {
 			} else {
 				outputViewModel = activeCell.outputsViewModels.find(output => output.pickedMimeType?.isTrusted);
 			}
-		} else if ('outputId' in outputContext && typeof outputContext.outputId === 'string') {
-			outputViewModel = getOutputViewModelFromId(outputContext.outputId, notebookEditor);
-		} else {
-			outputViewModel = outputContext.outputViewModel;
 		}
 
 		if (!outputViewModel) {

--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewPreloads.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewPreloads.ts
@@ -1400,7 +1400,9 @@ async function webviewPreloads(ctx: PreloadContext) {
 			let image = outputElement?.querySelector('img');
 
 			if (!image) {
-				const svgImage = outputElement?.querySelector('svg.output-image');
+				const svgImage = outputElement?.querySelector('svg.output-image') ??
+					outputElement?.querySelector('div.svgContainerStyle > svg');
+
 				if (svgImage) {
 					image = new Image();
 					image.src = 'data:image/svg+xml,' + encodeURIComponent(svgImage.outerHTML);


### PR DESCRIPTION
- fix the output menu wording to be consistent 
- account for how Jupyter extension renders SVGs
- account for context shape when coming from jupyter extension
- restrict the context menu to images (I mistakenly removed this restriction in the last change)