### PR TITLE
Ensure target window is connected

### DIFF
--- a/src/vs/platform/native/electron-main/nativeHostMainService.ts
+++ b/src/vs/platform/native/electron-main/nativeHostMainService.ts
@@ -847,12 +847,17 @@ export class NativeHostMainService extends Disposable implements INativeHostMain
 		return this.auxiliaryWindowsMainService.getWindowById(windowId);
 	}
 
-	private getTargetWindow(fallbackWindowId: number | undefined): ICodeWindow | IAuxiliaryWindow | undefined {
-		let window = this.instantiationService.invokeFunction(getFocusedOrLastActiveWindow);
-		if (!window) {
-			window = this.windowById(fallbackWindowId);
+	private getTargetWindow(windowId: number | undefined): ICodeWindow | IAuxiliaryWindow | undefined {
+		const candidateWindowId = this.instantiationService.invokeFunction(getFocusedOrLastActiveWindow)?.id;
+		const candidateAuxiliaryWindow = this.auxiliaryWindowById(candidateWindowId);
+
+		// We have an auxiliary window as candidate but we can only
+		// return it if it is parented to the requesting window
+		if (candidateAuxiliaryWindow?.parentId === windowId) {
+			return candidateAuxiliaryWindow;
 		}
 
-		return window;
+		// In all other cases, fallback to the requesting window
+		return this.codeWindowById(windowId);
 	}
 }


### PR DESCRIPTION
fix https://github.com/microsoft/vscode/issues/201686

When using aux windows, it makes sense to put stuff like modal dialogs in the window the user is focusing on. When you have multiple projects open, the window you're focusing on may not be related to the project that's surfacing the prompt, so we check that the focused window is connected.

Right now we just check for direct parents / children. We could dig around to find all of the given window id's relatives, but I'm not sure that's necessary. In the cases I've seen the hierarchy is only ever two deep, but there may be deeper hierarchies I haven't encountered. In those cases we'd fall back to surfacing the prompt in the given window id.

We could maybe dig around for all windows connected to the given window id and surface the propmt in whichever window was last active, but I didn't want to prematurely complicate things.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
