### PR TITLE
themes: Increase contrast of  inputs placeholder text

### DIFF
--- a/extensions/theme-defaults/themes/dark_modern.json
+++ b/extensions/theme-defaults/themes/dark_modern.json
@@ -49,7 +49,7 @@
 		"input.background": "#313131",
 		"input.border": "#3C3C3C",
 		"input.foreground": "#CCCCCC",
-		"input.placeholderForeground": "#818181",
+		"input.placeholderForeground": "#989898",
 		"inputOption.activeBackground": "#2489DB82",
 		"inputOption.activeBorder": "#2488DB",
 		"keybindingLabel.foreground": "#CCCCCC",

--- a/extensions/theme-defaults/themes/light_modern.json
+++ b/extensions/theme-defaults/themes/light_modern.json
@@ -51,7 +51,7 @@
 		"input.background": "#FFFFFF",
 		"input.border": "#CECECE",
 		"input.foreground": "#3B3B3B",
-		"input.placeholderForeground": "#868686",
+		"input.placeholderForeground": "#767676",
 		"inputOption.activeBackground": "#BED6ED",
 		"inputOption.activeBorder": "#005FB8",
 		"inputOption.activeForeground": "#000000",


### PR DESCRIPTION
Increases the contrast to > 4.5 in Dark/Light Modern themes.

Fixes #203656.
Fixes #203398.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
