### PR TITLE
testing: rename coverage executionCount to executed, allow bool

### DIFF
--- a/src/vs/workbench/api/common/extHostTypeConverters.ts
+++ b/src/vs/workbench/api/common/extHostTypeConverters.ts
@@ -2003,18 +2003,18 @@ export namespace TestCoverage {
 	export function fromDetailed(coverage: vscode.DetailedCoverage): CoverageDetails.Serialized {
 		if ('branches' in coverage) {
 			return {
-				count: coverage.executionCount,
+				count: coverage.executed,
 				location: fromLocation(coverage.location),
 				type: DetailType.Statement,
 				branches: coverage.branches.length
-					? coverage.branches.map(b => ({ count: b.executionCount, location: b.location && fromLocation(b.location), label: b.label }))
+					? coverage.branches.map(b => ({ count: b.executed, location: b.location && fromLocation(b.location), label: b.label }))
 					: undefined,
 			};
 		} else {
 			return {
 				type: DetailType.Function,
 				name: coverage.name,
-				count: coverage.executionCount,
+				count: coverage.executed,
 				location: fromLocation(coverage.location),
 			};
 		}

--- a/src/vs/workbench/api/common/extHostTypes.ts
+++ b/src/vs/workbench/api/common/extHostTypes.ts
@@ -3975,15 +3975,15 @@ export class FileCoverage implements vscode.FileCoverage {
 		for (const detail of details) {
 			if ('branches' in detail) {
 				statements.total += 1;
-				statements.covered += detail.executionCount > 0 ? 1 : 0;
+				statements.covered += detail.executed ? 1 : 0;
 
 				for (const branch of detail.branches) {
 					branches.total += 1;
-					branches.covered += branch.executionCount > 0 ? 1 : 0;
+					branches.covered += branch.executed ? 1 : 0;
 				}
 			} else {
 				fn.total += 1;
-				fn.covered += detail.executionCount > 0 ? 1 : 0;
+				fn.covered += detail.executed ? 1 : 0;
 			}
 		}
 
@@ -4014,25 +4014,37 @@ export class FileCoverage implements vscode.FileCoverage {
 }
 
 export class StatementCoverage implements vscode.StatementCoverage {
+	// back compat until finalization:
+	get executionCount() { return +this.executed; }
+	set executionCount(n: number) { this.executed = n; }
+
 	constructor(
-		public executionCount: number,
+		public executed: number | boolean,
 		public location: Position | Range,
 		public branches: vscode.BranchCoverage[] = [],
 	) { }
 }
 
 export class BranchCoverage implements vscode.BranchCoverage {
+	// back compat until finalization:
+	get executionCount() { return +this.executed; }
+	set executionCount(n: number) { this.executed = n; }
+
 	constructor(
-		public executionCount: number,
+		public executed: number | boolean,
 		public location: Position | Range,
 		public label?: string,
 	) { }
 }
 
 export class FunctionCoverage implements vscode.FunctionCoverage {
+	// back compat until finalization:
+	get executionCount() { return +this.executed; }
+	set executionCount(n: number) { this.executed = n; }
+
 	constructor(
 		public readonly name: string,
-		public executionCount: number,
+		public executed: number | boolean,
 		public location: Position | Range,
 	) { }
 }

--- a/src/vs/workbench/contrib/testing/browser/codeCoverageDecorations.ts
+++ b/src/vs/workbench/contrib/testing/browser/codeCoverageDecorations.ts
@@ -264,7 +264,7 @@ export class CodeCoverageDecorations extends Disposable implements IEditorContri
 							};
 						} else {
 							target.className = `coverage-deco-inline ${cls}`;
-							if (primary) {
+							if (primary && typeof hits === 'number') {
 								target.before = countBadge(hits);
 							}
 						}
@@ -286,7 +286,7 @@ export class CodeCoverageDecorations extends Disposable implements IEditorContri
 					const applyHoverOptions = (target: IModelDecorationOptions) => {
 						target.className = `coverage-deco-inline ${cls}`;
 						target.hoverMessage = description;
-						if (primary) {
+						if (primary && typeof detail.count === 'number') {
 							target.before = countBadge(detail.count);
 						}
 					};
@@ -451,7 +451,7 @@ export class CoverageDetailsModel {
 			const text = wrapName(model.getValueInRange(tidyLocation(detail.location)).trim() || `<empty statement>`);
 			const str = new MarkdownString();
 			if (detail.branches?.length) {
-				const covered = detail.branches.filter(b => b.count > 0).length;
+				const covered = detail.branches.filter(b => !!b.count).length;
 				str.appendMarkdown(localize('coverage.branches', '{0} of {1} of branches in {2} were covered.', covered, detail.branches.length, text));
 			} else {
 				str.appendMarkdown(localize('coverage.codeExecutedCount', '{0} was executed {1} time(s).', text, detail.count));

--- a/src/vs/workbench/contrib/testing/browser/testCoverageView.ts
+++ b/src/vs/workbench/contrib/testing/browser/testCoverageView.ts
@@ -158,11 +158,11 @@ class FunctionCoverageNode {
 				continue;
 			}
 
-			statement.covered += detail.count > 0 ? 1 : 0;
+			statement.covered += detail.count ? 1 : 0;
 			statement.total++;
 			if (detail.branches) {
 				for (const { count } of detail.branches) {
-					branch.covered += count > 0 ? 1 : 0;
+					branch.covered += count ? 1 : 0;
 					branch.total++;
 				}
 			}
@@ -402,7 +402,7 @@ class Sorter implements ITreeSorter<CoverageTreeElement> {
 					const attrA = a.tpc;
 					const attrB = b.tpc;
 					return (attrA !== undefined && attrB !== undefined && attrB - attrA)
-						|| (b.hits - a.hits)
+						|| (+b.hits - +a.hits)
 						|| a.label.localeCompare(b.label);
 				}
 			}
@@ -522,7 +522,7 @@ class FunctionCoverageRenderer implements ICompressibleTreeRenderer<CoverageTree
 
 	/** @inheritdoc */
 	private doRender(element: FunctionCoverageNode, templateData: FunctionTemplateData, _filterData: FuzzyScore | undefined) {
-		const covered = element.hits > 0;
+		const covered = !!element.hits;
 		const icon = covered ? testingWasCovered : testingStatesToIcons.get(TestResultState.Unset);
 		templateData.container.classList.toggle('not-covered', !covered);
 		templateData.icon.className = `computed-state ${ThemeIcon.asClassName(icon!)}`;

--- a/src/vs/workbench/contrib/testing/common/testTypes.ts
+++ b/src/vs/workbench/contrib/testing/common/testTypes.ts
@@ -614,14 +614,14 @@ export namespace CoverageDetails {
 }
 
 export interface IBranchCoverage {
-	count: number;
+	count: number | boolean;
 	label?: string;
 	location?: Range | Position;
 }
 
 export namespace IBranchCoverage {
 	export interface Serialized {
-		count: number;
+		count: number | boolean;
 		label?: string;
 		location?: IRange | IPosition;
 	}
@@ -633,7 +633,7 @@ export namespace IBranchCoverage {
 export interface IFunctionCoverage {
 	type: DetailType.Function;
 	name: string;
-	count: number;
+	count: number | boolean;
 	location: Range | Position;
 }
 
@@ -641,7 +641,7 @@ export namespace IFunctionCoverage {
 	export interface Serialized {
 		type: DetailType.Function;
 		name: string;
-		count: number;
+		count: number | boolean;
 		location: IRange | IPosition;
 	}
 
@@ -651,7 +651,7 @@ export namespace IFunctionCoverage {
 
 export interface IStatementCoverage {
 	type: DetailType.Statement;
-	count: number;
+	count: number | boolean;
 	location: Range | Position;
 	branches?: IBranchCoverage[];
 }
@@ -659,7 +659,7 @@ export interface IStatementCoverage {
 export namespace IStatementCoverage {
 	export interface Serialized {
 		type: DetailType.Statement;
-		count: number;
+		count: number | boolean;
 		location: IRange | IPosition;
 		branches?: IBranchCoverage.Serialized[];
 	}

--- a/src/vscode-dts/vscode.proposed.testCoverage.d.ts
+++ b/src/vscode-dts/vscode.proposed.testCoverage.d.ts
@@ -129,10 +129,11 @@ declare module 'vscode' {
 	 */
 	export class StatementCoverage {
 		/**
-		 * The number of times this statement was executed. If zero, the
-		 * statement will be marked as un-covered.
+		 * The number of times this statement was executed, or a boolean indicating
+		 * whether it was executed if the exact count is unknown. If zero or false,
+		 * the statement will be marked as un-covered.
 		 */
-		executionCount: number;
+		executed: number | boolean;
 
 		/**
 		 * Statement location.
@@ -147,12 +148,13 @@ declare module 'vscode' {
 
 		/**
 		 * @param location The statement position.
-		 * @param executionCount The number of times this statement was
-		 * executed. If zero, the statement will be marked as un-covered.
+		 * @param executed The number of times this statement was executed, or a
+		 * boolean indicating  whether it was executed if the exact count is
+		 * unknown. If zero or false, the statement will be marked as un-covered.
 		 * @param branches Coverage from branches of this line.  If it's not a
 		 * conditional, this should be omitted.
 		 */
-		constructor(executionCount: number, location: Position | Range, branches?: BranchCoverage[]);
+		constructor(executed: number | boolean, location: Position | Range, branches?: BranchCoverage[]);
 	}
 
 	/**
@@ -160,10 +162,11 @@ declare module 'vscode' {
 	 */
 	export class BranchCoverage {
 		/**
-		 * The number of times this branch was executed. If zero, the
-		 * branch will be marked as un-covered.
+		 * The number of times this branch was executed, or a boolean indicating
+		 * whether it was executed if the exact count is unknown. If zero or false,
+		 * the branch will be marked as un-covered.
 		 */
-		executionCount: number;
+		executed: number | boolean;
 
 		/**
 		 * Branch location.
@@ -177,10 +180,12 @@ declare module 'vscode' {
 		label?: string;
 
 		/**
-		 * @param executionCount The number of times this branch was executed.
+		 * @param executed The number of times this branch was executed, or a
+		 * boolean indicating  whether it was executed if the exact count is
+		 * unknown. If zero or false, the branch will be marked as un-covered.
 		 * @param location The branch position.
 		 */
-		constructor(executionCount: number, location?: Position | Range, label?: string);
+		constructor(executed: number | boolean, location?: Position | Range, label?: string);
 	}
 
 	/**
@@ -193,10 +198,11 @@ declare module 'vscode' {
 		name: string;
 
 		/**
-		 * The number of times this function was executed. If zero, the
-		 * function will be marked as un-covered.
+		 * The number of times this function was executed, or a boolean indicating
+		 * whether it was executed if the exact count is unknown. If zero or false,
+		 * the function will be marked as un-covered.
 		 */
-		executionCount: number;
+		executed: number | boolean;
 
 		/**
 		 * Function location.
@@ -204,10 +210,12 @@ declare module 'vscode' {
 		location: Position | Range;
 
 		/**
-		 * @param executionCount The number of times this function was executed.
+		 * @param executed The number of times this function was executed, or a
+		 * boolean indicating  whether it was executed if the exact count is
+		 * unknown. If zero or false, the function will be marked as un-covered.
 		 * @param location The function position.
 		 */
-		constructor(name: string, executionCount: number, location: Position | Range);
+		constructor(name: string, executed: number | boolean, location: Position | Range);
 	}
 
 	export type DetailedCoverage = StatementCoverage | FunctionCoverage;


### PR DESCRIPTION
coverage.py does not provide execution count, only a boolean indicating
whether any given data was executed at all. Allow extensions to provide
boolean values for executions, and rename the properties to `executed`
rather than `executionCount`, so that we can handle this properly in the
UI and e.g. avoid showing incorrect count badges when the real count
is unknown.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
