### PR TITLE
Fix for automatic folderOpen tasks with Remote SSH extension

### DIFF
--- a/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
+++ b/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
@@ -231,6 +231,8 @@ export abstract class AbstractTaskService extends Disposable implements ITaskSer
 	public onDidChangeTaskSystemInfo: Event<void> = this._onDidChangeTaskSystemInfo.event;
 	private _onDidReconnectToTasks: Emitter<void> = new Emitter();
 	public onDidReconnectToTasks: Event<void> = this._onDidReconnectToTasks.event;
+	private _onDidChangeTaskConfig: Emitter<void> = new Emitter();
+	public onDidChangeTaskConfig: Event<void> = this._onDidChangeTaskConfig.event;
 	public get isReconnected(): boolean { return this._tasksReconnected; }
 
 	constructor(
@@ -289,7 +291,7 @@ export abstract class AbstractTaskService extends Disposable implements ITaskSer
 			this._updateSetup(folderSetup);
 			return this._updateWorkspaceTasks(TaskRunSource.FolderOpen);
 		}));
-		this._register(this._configurationService.onDidChangeConfiguration((e) => {
+		this._register(this._configurationService.onDidChangeConfiguration(async (e) => {
 			if (!e.affectsConfiguration('tasks') || (!this._taskSystem && !this._workspaceTasksPromise)) {
 				return;
 			}
@@ -306,7 +308,8 @@ export abstract class AbstractTaskService extends Disposable implements ITaskSer
 			}
 
 			this._setTaskLRUCacheLimit();
-			return this._updateWorkspaceTasks(TaskRunSource.ConfigurationChange);
+			await this._updateWorkspaceTasks(TaskRunSource.ConfigurationChange);
+			this._onDidChangeTaskConfig.fire();
 		}));
 		this._taskRunningState = TASK_RUNNING_STATE.bindTo(_contextKeyService);
 		this._onDidStateChange = this._register(new Emitter());

--- a/src/vs/workbench/contrib/tasks/browser/runAutomaticTasks.ts
+++ b/src/vs/workbench/contrib/tasks/browser/runAutomaticTasks.ts
@@ -50,9 +50,34 @@ export class RunAutomaticTasks extends Disposable implements IWorkbenchContribut
 			this._logService.trace('RunAutomaticTasks: Awaiting task system info.');
 			await Event.toPromise(Event.once(this._taskService.onDidChangeTaskSystemInfo));
 		}
-		const workspaceTasks = await this._taskService.getWorkspaceTasks(TaskRunSource.FolderOpen);
+		let workspaceTasks = await this._taskService.getWorkspaceTasks(TaskRunSource.FolderOpen);
 		this._logService.trace(`RunAutomaticTasks: Found ${workspaceTasks.size} automatic tasks`);
-		await this._runWithPermission(this._taskService, this._configurationService, workspaceTasks);
+
+		let autoTasks = this._findAutoTasks(this._taskService, workspaceTasks);
+		this._logService.trace(`RunAutomaticTasks: taskNames=${JSON.stringify(autoTasks.taskNames)}`);
+
+		// As seen in some cases with the Remote SSH extension, the tasks configuration is loaded after we have come
+		// to this point. Let's give it some extra time.
+		if (autoTasks.taskNames.length === 0) {
+			const updatedWithinTimeout = await Promise.race([
+				new Promise<boolean>((resolve) => {
+					Event.toPromise(Event.once(this._taskService.onDidChangeTaskConfig)).then(() => resolve(true));
+				}),
+				new Promise<boolean>((resolve) => {
+					const timer = setTimeout(() => { clearTimeout(timer); resolve(false); }, 10000);
+				})]);
+
+			if (!updatedWithinTimeout) {
+				this._logService.trace(`RunAutomaticTasks: waited some extra time, but no update of tasks configuration`);
+				return;
+			}
+
+			workspaceTasks = await this._taskService.getWorkspaceTasks(TaskRunSource.FolderOpen);
+			autoTasks = this._findAutoTasks(this._taskService, workspaceTasks);
+			this._logService.trace(`RunAutomaticTasks: updated taskNames=${JSON.stringify(autoTasks.taskNames)}`);
+		}
+
+		this._runWithPermission(this._taskService, this._configurationService, autoTasks.tasks, autoTasks.taskNames);
 	}
 
 	private _runTasks(taskService: ITaskService, tasks: Array<Task | Promise<Task | undefined>>) {
@@ -124,10 +149,7 @@ export class RunAutomaticTasks extends Disposable implements IWorkbenchContribut
 		return { tasks, taskNames, locations };
 	}
 
-	private async _runWithPermission(taskService: ITaskService, configurationService: IConfigurationService, workspaceTaskResult: Map<string, IWorkspaceFolderTaskResult>) {
-
-		const { tasks, taskNames } = this._findAutoTasks(taskService, workspaceTaskResult);
-
+	private async _runWithPermission(taskService: ITaskService, configurationService: IConfigurationService, tasks: (Task | Promise<Task | undefined>)[], taskNames: string[]) {
 		if (taskNames.length === 0) {
 			return;
 		}

--- a/src/vs/workbench/contrib/tasks/common/taskService.ts
+++ b/src/vs/workbench/contrib/tasks/common/taskService.ts
@@ -94,6 +94,7 @@ export interface ITaskService {
 
 	registerTaskSystem(scheme: string, taskSystemInfo: ITaskSystemInfo): void;
 	onDidChangeTaskSystemInfo: Event<void>;
+	onDidChangeTaskConfig: Event<void>;
 	readonly hasTaskSystemInfo: boolean;
 	registerSupportedExecutions(custom?: boolean, shell?: boolean, process?: boolean): void;
 


### PR DESCRIPTION
In some cases (very often for me), the task configuration is loaded after the RunAutomaticTasks class has searched through the configured tasks to see if there are any automatic tasks to run. Since this search is a one time action, it means that the automatic tasks aren't always run.

This fix works around this race condition by exposing an event (onDidChangeTaskConfig) on the ITaskService interface and letting the AbstractTaskService implementation fire this event when it reloads the task configuration. If the RunAutomaticTasks class encounters zero automatic tasks, it waits for up to 10 seconds for this new event to fire before giving up. If the task configuration is updated during this time, RunAutomaticTasks looks for automatic tasks once more in the updated task configuration.

Fixes #203639 