### PR TITLE
vscode server: cope with multiple libc/libc++ installations

### DIFF
--- a/resources/server/bin/helpers/check-requirements-linux.sh
+++ b/resources/server/bin/helpers/check-requirements-linux.sh
@@ -56,7 +56,7 @@ elif [ -f /sbin/ldconfig ]; then
     libstdcpp_paths=$(/sbin/ldconfig -p | grep 'libstdc++.so.6')
 
     if [ "$(echo "$libstdcpp_paths" | wc -l)" -gt 1 ]; then
-        libstdcpp_path=$(echo "$libstdcpp_paths" | grep "$LDCONFIG_ARCH" | awk '{print $NF}')
+        libstdcpp_path=$(echo "$libstdcpp_paths" | grep "$LDCONFIG_ARCH" | awk '{print $NF}' | head -n1)
     else
         libstdcpp_path=$(echo "$libstdcpp_paths" | awk '{print $NF}')
     fi
@@ -90,7 +90,7 @@ if [ -z "$(ldd --version 2>&1 | grep 'musl libc')" ]; then
         libc_paths=$(/sbin/ldconfig -p | grep 'libc.so.6')
 
         if [ "$(echo "$libc_paths" | wc -l)" -gt 1 ]; then
-            libc_path=$(echo "$libc_paths" | grep "$LDCONFIG_ARCH" | awk '{print $NF}')
+            libc_path=$(echo "$libc_paths" | grep "$LDCONFIG_ARCH" | awk '{print $NF}' | head -n1)
         else
             libc_path=$(echo "$libc_paths" | awk '{print $NF}')
         fi


### PR DESCRIPTION
Allow running vscode remote server in environments where there are multiple libc or libc++ candidate paths. For determining the library version, use the first one reported in ldconfig -p.

For context, I'm running vscode server in a container with two libc packages: default one from `libc6:amd64` package, and another from `libc6-prof:amd64` (compiled with frame pointers) - both targeting x86:

```
# /sbin/ldconfig -p | grep libc.so.6
        libc.so.6 (libc6,x86-64, OS ABI: Linux 3.2.0) => /lib/libc6-prof/x86_64-linux-gnu/libc.so.6
        libc.so.6 (libc6,x86-64, OS ABI: Linux 3.2.0) => /lib/x86_64-linux-gnu/libc.so.6
        libc.so.6 (libc6, OS ABI: Linux 3.2.0) => /lib32/libc.so.6
```

Currently, the script fails silently. `$libc_path` contains two paths, and `readlink -f "$libc_path"` fails with exit code 1.
