### PR TITLE
Enable explorer pasting of files without paths

### DIFF
--- a/src/vs/workbench/contrib/files/browser/fileActions.ts
+++ b/src/vs/workbench/contrib/files/browser/fileActions.ts
@@ -59,6 +59,7 @@ import { KeybindingWeight } from 'vs/platform/keybinding/common/keybindingsRegis
 import { KeyChord, KeyCode, KeyMod } from 'vs/base/common/keyCodes';
 import { Categories } from 'vs/platform/action/common/actionCommonCategories';
 import { ILocalizedString } from 'vs/platform/action/common/action';
+import { VSBuffer } from 'vs/base/common/buffer';
 
 export const NEW_FILE_COMMAND_ID = 'explorer.newFile';
 export const NEW_FILE_LABEL = nls.localize('newFile', "New File...");
@@ -308,11 +309,11 @@ export async function findValidPasteFileTarget(
 	fileService: IFileService,
 	dialogService: IDialogService,
 	targetFolder: ExplorerItem,
-	fileToPaste: { resource: URI; isDirectory?: boolean; allowOverwrite: boolean },
+	fileToPaste: { resource: URI | string; isDirectory?: boolean; allowOverwrite: boolean },
 	incrementalNaming: 'simple' | 'smart' | 'disabled'
 ): Promise<URI | undefined> {
 
-	let name = resources.basenameOrAuthority(fileToPaste.resource);
+	let name = typeof fileToPaste.resource === 'string' ? fileToPaste.resource : resources.basenameOrAuthority(fileToPaste.resource);
 	let candidate = resources.joinPath(targetFolder.resource, name);
 
 	// In the disabled case we must ask if it's ok to overwrite the file if it exists
@@ -1098,11 +1099,11 @@ export const pasteFileHandler = async (accessor: ServicesAccessor, fileList?: Fi
 
 	const toPaste = await getFilesToPaste(fileList, clipboardService);
 
-	if (confirmPasteNative && toPaste?.length >= 1) {
-		const message = toPaste.length > 1 ?
-			nls.localize('confirmMultiPasteNative', "Are you sure you want to paste the following {0} items?", toPaste.length) :
-			nls.localize('confirmPasteNative', "Are you sure you want to paste '{0}'?", basename(toPaste[0].fsPath));
-		const detail = toPaste.length > 1 ? getFileNamesMessage(toPaste) : undefined;
+	if (confirmPasteNative && toPaste.files.length >= 1) {
+		const message = toPaste.files.length > 1 ?
+			nls.localize('confirmMultiPasteNative', "Are you sure you want to paste the following {0} items?", toPaste.files.length) :
+			nls.localize('confirmPasteNative', "Are you sure you want to paste '{0}'?", basename(toPaste.type === 'paths' ? toPaste.files[0].fsPath : toPaste.files[0].name));
+		const detail = toPaste.files.length > 1 ? getFileNamesMessage(toPaste.files.map(item => toPaste.type === 'paths' ? item.path : (item as File).name)) : undefined;
 		const confirmation = await dialogService.confirm({
 			message,
 			detail,
@@ -1131,67 +1132,94 @@ export const pasteFileHandler = async (accessor: ServicesAccessor, fileList?: Fi
 	}
 
 	try {
-		// Check if target is ancestor of pasted folder
-		const sourceTargetPairs = coalesce(await Promise.all(toPaste.map(async fileToPaste => {
+		let targets: URI[] = [];
 
-			if (element.resource.toString() !== fileToPaste.toString() && resources.isEqualOrParent(element.resource, fileToPaste)) {
-				throw new Error(nls.localize('fileIsAncestor', "File to paste is an ancestor of the destination folder"));
+		if (toPaste.type === 'paths') { // Pasting from files on disk
+
+			// Check if target is ancestor of pasted folder
+			const sourceTargetPairs = coalesce(await Promise.all(toPaste.files.map(async fileToPaste => {
+				if (element.resource.toString() !== fileToPaste.toString() && resources.isEqualOrParent(element.resource, fileToPaste)) {
+					throw new Error(nls.localize('fileIsAncestor', "File to paste is an ancestor of the destination folder"));
+				}
+				const fileToPasteStat = await fileService.stat(fileToPaste);
+
+				// Find target
+				let target: ExplorerItem;
+				if (uriIdentityService.extUri.isEqual(element.resource, fileToPaste)) {
+					target = element.parent!;
+				} else {
+					target = element.isDirectory ? element : element.parent!;
+				}
+
+				const targetFile = await findValidPasteFileTarget(
+					explorerService,
+					fileService,
+					dialogService,
+					target,
+					{ resource: fileToPaste, isDirectory: fileToPasteStat.isDirectory, allowOverwrite: pasteShouldMove || incrementalNaming === 'disabled' },
+					incrementalNaming
+				);
+
+				if (!targetFile) {
+					return undefined;
+				}
+
+				return { source: fileToPaste, target: targetFile };
+			})));
+
+			if (sourceTargetPairs.length >= 1) {
+				// Move/Copy File
+				if (pasteShouldMove) {
+					const resourceFileEdits = sourceTargetPairs.map(pair => new ResourceFileEdit(pair.source, pair.target, { overwrite: incrementalNaming === 'disabled' }));
+					const options = {
+						confirmBeforeUndo: configurationService.getValue<IFilesConfiguration>().explorer.confirmUndo === UndoConfirmLevel.Verbose,
+						progressLabel: sourceTargetPairs.length > 1 ? nls.localize({ key: 'movingBulkEdit', comment: ['Placeholder will be replaced by the number of files being moved'] }, "Moving {0} files", sourceTargetPairs.length)
+							: nls.localize({ key: 'movingFileBulkEdit', comment: ['Placeholder will be replaced by the name of the file moved.'] }, "Moving {0}", resources.basenameOrAuthority(sourceTargetPairs[0].target)),
+						undoLabel: sourceTargetPairs.length > 1 ? nls.localize({ key: 'moveBulkEdit', comment: ['Placeholder will be replaced by the number of files being moved'] }, "Move {0} files", sourceTargetPairs.length)
+							: nls.localize({ key: 'moveFileBulkEdit', comment: ['Placeholder will be replaced by the name of the file moved.'] }, "Move {0}", resources.basenameOrAuthority(sourceTargetPairs[0].target))
+					};
+					await explorerService.applyBulkEdit(resourceFileEdits, options);
+				} else {
+					const resourceFileEdits = sourceTargetPairs.map(pair => new ResourceFileEdit(pair.source, pair.target, { copy: true, overwrite: incrementalNaming === 'disabled' }));
+					await applyCopyResourceEdit(sourceTargetPairs.map(pair => pair.target), resourceFileEdits);
+				}
 			}
-			const fileToPasteStat = await fileService.stat(fileToPaste);
 
-			// Find target
-			let target: ExplorerItem;
-			if (uriIdentityService.extUri.isEqual(element.resource, fileToPaste)) {
-				target = element.parent!;
-			} else {
-				target = element.isDirectory ? element : element.parent!;
-			}
+			targets = sourceTargetPairs.map(pair => pair.target);
 
-			const targetFile = await findValidPasteFileTarget(
-				explorerService,
-				fileService,
-				dialogService,
-				target,
-				{ resource: fileToPaste, isDirectory: fileToPasteStat.isDirectory, allowOverwrite: pasteShouldMove || incrementalNaming === 'disabled' },
-				incrementalNaming
-			);
+		} else { // Pasting from file data
+			const targetAndEdits = coalesce(await Promise.all(toPaste.files.map(async file => {
+				const target = element.isDirectory ? element : element.parent!;
 
-			if (!targetFile) {
-				return undefined;
-			}
-
-			return { source: fileToPaste, target: targetFile };
-		})));
-
-		if (sourceTargetPairs.length >= 1) {
-			// Move/Copy File
-			if (pasteShouldMove) {
-				const resourceFileEdits = sourceTargetPairs.map(pair => new ResourceFileEdit(pair.source, pair.target, { overwrite: incrementalNaming === 'disabled' }));
-				const options = {
-					confirmBeforeUndo: configurationService.getValue<IFilesConfiguration>().explorer.confirmUndo === UndoConfirmLevel.Verbose,
-					progressLabel: sourceTargetPairs.length > 1 ? nls.localize({ key: 'movingBulkEdit', comment: ['Placeholder will be replaced by the number of files being moved'] }, "Moving {0} files", sourceTargetPairs.length)
-						: nls.localize({ key: 'movingFileBulkEdit', comment: ['Placeholder will be replaced by the name of the file moved.'] }, "Moving {0}", resources.basenameOrAuthority(sourceTargetPairs[0].target)),
-					undoLabel: sourceTargetPairs.length > 1 ? nls.localize({ key: 'moveBulkEdit', comment: ['Placeholder will be replaced by the number of files being moved'] }, "Move {0} files", sourceTargetPairs.length)
-						: nls.localize({ key: 'moveFileBulkEdit', comment: ['Placeholder will be replaced by the name of the file moved.'] }, "Move {0}", resources.basenameOrAuthority(sourceTargetPairs[0].target))
+				const targetFile = await findValidPasteFileTarget(
+					explorerService,
+					fileService,
+					dialogService,
+					target,
+					{ resource: file.name, isDirectory: false, allowOverwrite: pasteShouldMove || incrementalNaming === 'disabled' },
+					incrementalNaming
+				);
+				if (!targetFile) {
+					return;
+				}
+				return {
+					target: targetFile,
+					edit: new ResourceFileEdit(undefined, targetFile, {
+						overwrite: incrementalNaming === 'disabled',
+						contents: (async () => VSBuffer.wrap(new Uint8Array(await file.arrayBuffer())))(),
+					})
 				};
-				await explorerService.applyBulkEdit(resourceFileEdits, options);
-			} else {
-				const resourceFileEdits = sourceTargetPairs.map(pair => new ResourceFileEdit(pair.source, pair.target, { copy: true, overwrite: incrementalNaming === 'disabled' }));
-				const undoLevel = configurationService.getValue<IFilesConfiguration>().explorer.confirmUndo;
-				const options = {
-					confirmBeforeUndo: undoLevel === UndoConfirmLevel.Default || undoLevel === UndoConfirmLevel.Verbose,
-					progressLabel: sourceTargetPairs.length > 1 ? nls.localize({ key: 'copyingBulkEdit', comment: ['Placeholder will be replaced by the number of files being copied'] }, "Copying {0} files", sourceTargetPairs.length)
-						: nls.localize({ key: 'copyingFileBulkEdit', comment: ['Placeholder will be replaced by the name of the file copied.'] }, "Copying {0}", resources.basenameOrAuthority(sourceTargetPairs[0].target)),
-					undoLabel: sourceTargetPairs.length > 1 ? nls.localize({ key: 'copyBulkEdit', comment: ['Placeholder will be replaced by the number of files being copied'] }, "Paste {0} files", sourceTargetPairs.length)
-						: nls.localize({ key: 'copyFileBulkEdit', comment: ['Placeholder will be replaced by the name of the file copied.'] }, "Paste {0}", resources.basenameOrAuthority(sourceTargetPairs[0].target))
-				};
-				await explorerService.applyBulkEdit(resourceFileEdits, options);
-			}
+			})));
 
-			const pair = sourceTargetPairs[0];
-			await explorerService.select(pair.target);
-			if (sourceTargetPairs.length === 1) {
-				const item = explorerService.findClosest(pair.target);
+			await applyCopyResourceEdit(targetAndEdits.map(pair => pair.target), targetAndEdits.map(pair => pair.edit));
+			targets = targetAndEdits.map(pair => pair.target);
+		}
+
+		if (targets.length) {
+			const firstTarget = targets[0];
+			await explorerService.select(firstTarget);
+			if (targets.length === 1) {
+				const item = explorerService.findClosest(firstTarget);
 				if (item && !item.isDirectory) {
 					await editorService.openEditor({ resource: item.resource, options: { pinned: true, preserveFocus: true } });
 				}
@@ -1206,15 +1234,37 @@ export const pasteFileHandler = async (accessor: ServicesAccessor, fileList?: Fi
 			pasteShouldMove = false;
 		}
 	}
+
+	async function applyCopyResourceEdit(targets: readonly URI[], resourceFileEdits: ResourceFileEdit[]) {
+		const undoLevel = configurationService.getValue<IFilesConfiguration>().explorer.confirmUndo;
+		const options = {
+			confirmBeforeUndo: undoLevel === UndoConfirmLevel.Default || undoLevel === UndoConfirmLevel.Verbose,
+			progressLabel: targets.length > 1 ? nls.localize({ key: 'copyingBulkEdit', comment: ['Placeholder will be replaced by the number of files being copied'] }, "Copying {0} files", targets.length)
+				: nls.localize({ key: 'copyingFileBulkEdit', comment: ['Placeholder will be replaced by the name of the file copied.'] }, "Copying {0}", resources.basenameOrAuthority(targets[0])),
+			undoLabel: targets.length > 1 ? nls.localize({ key: 'copyBulkEdit', comment: ['Placeholder will be replaced by the number of files being copied'] }, "Paste {0} files", targets.length)
+				: nls.localize({ key: 'copyFileBulkEdit', comment: ['Placeholder will be replaced by the name of the file copied.'] }, "Paste {0}", resources.basenameOrAuthority(targets[0]))
+		};
+		await explorerService.applyBulkEdit(resourceFileEdits, options);
+	}
 };
 
-async function getFilesToPaste(fileList: FileList | undefined, clipboardService: IClipboardService): Promise<readonly URI[]> {
+type FilesToPaste =
+	| { type: 'paths'; files: URI[] }
+	| { type: 'data'; files: File[] };
+
+async function getFilesToPaste(fileList: FileList | undefined, clipboardService: IClipboardService): Promise<FilesToPaste> {
 	if (fileList && fileList.length > 0) {
-		// with a `fileList` we support natively pasting files from clipboard
-		return [...fileList].filter(file => !!file.path && isAbsolute(file.path)).map(file => URI.file(file.path));
+		// with a `fileList` we support natively pasting file from disk from clipboard
+		const resources = [...fileList].filter(file => !!file.path && isAbsolute(file.path)).map(file => URI.file(file.path));
+		if (resources.length) {
+			return { type: 'paths', files: resources, };
+		}
+
+		// Support pasting files that we can't read from disk
+		return { type: 'data', files: [...fileList].filter(file => !file.path) };
 	} else {
 		// otherwise we fallback to reading resources from our clipboard service
-		return resources.distinctParents(await clipboardService.readResources(), resource => resource);
+		return { type: 'paths', files: resources.distinctParents(await clipboardService.readResources(), resource => resource) };
 	}
 }
 


### PR DESCRIPTION
Fixes #204051

This lets you paste a file that does not have `.path` into the explorer. This enables:

- Pasting image data into the explorer to create an image
- Pasting files into the explorer on web



<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
