### PR TITLE
Enable json language support for `code-snippets` files

### DIFF
--- a/extensions/json-language-features/client/src/languageParticipants.ts
+++ b/extensions/json-language-features/client/src/languageParticipants.ts
@@ -40,8 +40,10 @@ export function getLanguageParticipants(): LanguageParticipants {
 		languages = new Set();
 		languages.add('json');
 		languages.add('jsonc');
+		languages.add('snippets');
 		comments = new Set();
 		comments.add('jsonc');
+		comments.add('snippets');
 
 		for (const extension of extensions.allAcrossExtensionHosts) {
 			const jsonLanguageParticipants = extension.packageJSON?.contributes?.jsonLanguageParticipants as LanguageParticipantContribution[];

--- a/extensions/json-language-features/package.json
+++ b/extensions/json-language-features/package.json
@@ -15,7 +15,8 @@
   "icon": "icons/json.png",
   "activationEvents": [
     "onLanguage:json",
-    "onLanguage:jsonc"
+    "onLanguage:jsonc",
+    "onLanguage:snippets"
   ],
   "main": "./client/out/node/jsonClientMain",
   "browser": "./client/dist/browser/jsonClientMain",

--- a/extensions/json/package.json
+++ b/extensions/json/package.json
@@ -8,6 +8,11 @@
   "engines": {
     "vscode": "0.10.x"
   },
+  "extensionDependencies": [
+    "vscode.json-language-features"
+  ],
+  "activationEvents": [],
+  "main": "",
   "scripts": {
     "update-grammar": "node ./build/update-grammars.js"
   },
@@ -114,6 +119,11 @@
         "language": "snippets",
         "scopeName": "source.json.comments.snippets",
         "path": "./syntaxes/snippets.tmLanguage.json"
+      }
+    ],
+    "jsonLanguageParticipants": [
+      {
+        "languageId": "snippets"
       }
     ]
   },

--- a/extensions/json/package.json
+++ b/extensions/json/package.json
@@ -8,11 +8,6 @@
   "engines": {
     "vscode": "0.10.x"
   },
-  "extensionDependencies": [
-    "vscode.json-language-features"
-  ],
-  "activationEvents": [],
-  "main": "",
   "scripts": {
     "update-grammar": "node ./build/update-grammars.js"
   },
@@ -119,11 +114,6 @@
         "language": "snippets",
         "scopeName": "source.json.comments.snippets",
         "path": "./syntaxes/snippets.tmLanguage.json"
-      }
-    ],
-    "jsonLanguageParticipants": [
-      {
-        "languageId": "snippets"
       }
     ]
   },


### PR DESCRIPTION
Re-enables the `json-language-features` extension on `snippet` files
after it was broken with https://github.com/microsoft/vscode/issues/189176

Fixes #203206

uses the new `jsonLanguageParticipants` feature from https://github.com/microsoft/vscode/pull/198583

`"main": ""` is required because `"extensionDependencies": [ "vscode.json-language-features" ]` does **not** start the `json-language-features` extension without it

`"activationEvents": []` is there because when [publishing](https://code.visualstudio.com/api/working-with-extensions/publishing-extension) an extension it is required when `"main"` is present
`Manifest needs the 'activationEvents' property, given it has a 'main' property.`