### PR TITLE
move start actions back to /browser/, inline command id strings

### DIFF
--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChat.contribution.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChat.contribution.ts
@@ -20,6 +20,10 @@ import { IInlineChatSavingService } from 'vs/workbench/contrib/inlineChat/browse
 import { IInlineChatSessionService } from 'vs/workbench/contrib/inlineChat/browser/inlineChatSessionService';
 import { InlineChatSessionServiceImpl } from 'vs/workbench/contrib/inlineChat/browser/inlineChatSessionServiceImpl';
 
+import { StartSessionAction, HoldToSpeak } from '../browser/inlineChatActions2';
+registerAction2(StartSessionAction);
+registerAction2(HoldToSpeak);
+
 
 // --- browser
 

--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatActions2.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatActions2.ts
@@ -10,12 +10,11 @@ import { ServicesAccessor } from 'vs/platform/instantiation/common/instantiation
 import { KeybindingWeight } from 'vs/platform/keybinding/common/keybindingsRegistry';
 import { InlineChatController, InlineChatRunOptions } from 'vs/workbench/contrib/inlineChat/browser/inlineChatController';
 import { AbstractInlineChatAction } from 'vs/workbench/contrib/inlineChat/browser/inlineChatActions';
-import { LOCALIZED_START_INLINE_CHAT_STRING, START_INLINE_CHAT } from '../browser/inlineChatActions';
+import { LOCALIZED_START_INLINE_CHAT_STRING, START_INLINE_CHAT } from './inlineChatActions';
 import { disposableTimeout } from 'vs/base/common/async';
 import { EditorContextKeys } from 'vs/editor/common/editorContextKeys';
 import { ICommandService } from 'vs/platform/commands/common/commands';
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
-import { StartVoiceChatAction, StopListeningAction } from 'vs/workbench/contrib/chat/electron-sandbox/actions/voiceChatActions';
 import { IChatExecuteActionContext } from 'vs/workbench/contrib/chat/browser/actions/chatExecuteActions';
 import { CTX_INLINE_CHAT_HAS_PROVIDER, CTX_INLINE_CHAT_VISIBLE, InlineChatConfigKeys } from 'vs/workbench/contrib/inlineChat/common/inlineChat';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
@@ -96,13 +95,13 @@ function holdForSpeech(accessor: ServicesAccessor, ctrl: InlineChatController | 
 	let listening = false;
 	const handle = disposableTimeout(() => {
 		// start VOICE input
-		commandService.executeCommand(StartVoiceChatAction.ID, { voice: { disableTimeout: true } } satisfies IChatExecuteActionContext);
+		commandService.executeCommand('workbench.action.chat.startVoiceChat', { voice: { disableTimeout: true } } satisfies IChatExecuteActionContext);
 		listening = true;
 	}, 250);
 
 	holdMode.finally(() => {
 		if (listening) {
-			commandService.executeCommand(StopListeningAction.ID).finally(() => {
+			commandService.executeCommand('workbench.action.chat.stopListening').finally(() => {
 				ctrl!.acceptInput();
 			});
 		}

--- a/src/vs/workbench/contrib/inlineChat/electron-sandbox/inlineChat.contribution.ts
+++ b/src/vs/workbench/contrib/inlineChat/electron-sandbox/inlineChat.contribution.ts
@@ -6,12 +6,7 @@
 import { EditorContributionInstantiation, registerEditorContribution } from 'vs/editor/browser/editorExtensions';
 import { registerAction2 } from 'vs/platform/actions/common/actions';
 import { CancelAction, InlineChatQuickVoice, StartAction, StopAction } from 'vs/workbench/contrib/inlineChat/electron-sandbox/inlineChatQuickVoice';
-import { StartSessionAction, HoldToSpeak } from './inlineChatActions';
 
-// start and hold for voice
-
-registerAction2(StartSessionAction);
-registerAction2(HoldToSpeak);
 
 // quick voice
 


### PR DESCRIPTION
Inline strings of commands, candidate special fix for https://github.com/microsoft/vscode-copilot/issues/3857