### PR TITLE
Fix detection of libstdc++ with multiple installed

### DIFF
--- a/resources/server/bin/helpers/check-requirements-linux.sh
+++ b/resources/server/bin/helpers/check-requirements-linux.sh
@@ -56,7 +56,8 @@ elif [ -f /sbin/ldconfig ]; then
     libstdcpp_paths=$(/sbin/ldconfig -p | grep 'libstdc++.so.6')
 
     if [ "$(echo "$libstdcpp_paths" | wc -l)" -gt 1 ]; then
-        libstdcpp_path=$(echo "$libstdcpp_paths" | grep "$LDCONFIG_ARCH" | awk '{print $NF}' | head -n1)
+        # More than one found: Filter with architecte and use last
+	libstdcpp_path=$(echo "$libstdcpp_paths" | grep "$LDCONFIG_ARCH" | awk '{print $NF}' | sort -r | head -n 1)
     else
         libstdcpp_path=$(echo "$libstdcpp_paths" | awk '{print $NF}')
     fi


### PR DESCRIPTION
With more than one result in libstdcpp_path readlink fails. Reverse sort results and take first to hopefully use newest.
Fixes microsoft#203967

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
