### PR TITLE
dont include icon in notebook symbol filter

### DIFF
--- a/src/vs/workbench/contrib/codeEditor/browser/quickaccess/gotoSymbolQuickAccess.ts
+++ b/src/vs/workbench/contrib/codeEditor/browser/quickaccess/gotoSymbolQuickAccess.ts
@@ -195,19 +195,22 @@ export class GotoSymbolQuickAccessProvider extends AbstractGotoSymbolQuickAccess
 						item.highlights = undefined;
 						return true;
 					}
-					const labelWithoutIcons = stripIcons(item.label);
-					const score = fuzzyScore(picker.value, picker.value.toLowerCase(), 1 /*@-character*/,
-						labelWithoutIcons, labelWithoutIcons.toLowerCase(), 0,
+
+					const trimmedQuery = picker.value.substring(AbstractGotoSymbolQuickAccessProvider.PREFIX.length).trim();
+					const parsedLabel = parseLabelWithIcons(item.label);
+					const score = fuzzyScore(trimmedQuery, trimmedQuery.toLowerCase(), 0,
+						parsedLabel.text, parsedLabel.text.toLowerCase(), 0,
 						{ firstMatchCanBeWeak: true, boostFullMatch: true });
+
 					if (!score) {
 						return false;
 					}
 
 					item.score = score[1];
-					const matches = matchesFuzzyIconAware(picker.value.substring(1).trim(), parseLabelWithIcons(item.label)) ?? undefined;
-					item.highlights = { label: matches };
+					item.highlights = { label: matchesFuzzyIconAware(trimmedQuery, parsedLabel) ?? undefined };
 					return true;
 				});
+
 				if (filteredItems.length === 0) {
 					const label = localize('empty', 'No matching entries');
 					picker.items = [{ label, index: -1, kind: SymbolKind.String }];

--- a/src/vs/workbench/contrib/codeEditor/browser/quickaccess/gotoSymbolQuickAccess.ts
+++ b/src/vs/workbench/contrib/codeEditor/browser/quickaccess/gotoSymbolQuickAccess.ts
@@ -33,7 +33,7 @@ import { IOutlineModelService } from 'vs/editor/contrib/documentSymbols/browser/
 import { ILanguageFeaturesService } from 'vs/editor/common/services/languageFeatures';
 import { ContextKeyExpr } from 'vs/platform/contextkey/common/contextkey';
 import { accessibilityHelpIsShown, accessibleViewIsShown } from 'vs/workbench/contrib/accessibility/browser/accessibilityConfiguration';
-import { matchesFuzzyIconAware, parseLabelWithIcons, stripIcons } from 'vs/base/common/iconLabels';
+import { matchesFuzzyIconAware, parseLabelWithIcons } from 'vs/base/common/iconLabels';
 
 export class GotoSymbolQuickAccessProvider extends AbstractGotoSymbolQuickAccessProvider {
 

--- a/src/vs/workbench/contrib/notebook/browser/viewModel/notebookOutlineEntryFactory.ts
+++ b/src/vs/workbench/contrib/notebook/browser/viewModel/notebookOutlineEntryFactory.ts
@@ -105,6 +105,7 @@ type documentSymbol = ReturnType<outlineModel['getTopLevelSymbols']>[number];
 
 function createOutlineEntries(symbols: documentSymbol[], level: number): entryDesc[] {
 	const entries: entryDesc[] = [];
+
 	symbols.forEach(symbol => {
 		entries.push({ name: symbol.name, range: symbol.range, level, kind: symbol.kind });
 		if (symbol.children) {

--- a/src/vs/workbench/contrib/notebook/browser/viewModel/notebookOutlineEntryFactory.ts
+++ b/src/vs/workbench/contrib/notebook/browser/viewModel/notebookOutlineEntryFactory.ts
@@ -105,7 +105,6 @@ type documentSymbol = ReturnType<outlineModel['getTopLevelSymbols']>[number];
 
 function createOutlineEntries(symbols: documentSymbol[], level: number): entryDesc[] {
 	const entries: entryDesc[] = [];
-
 	symbols.forEach(symbol => {
 		entries.push({ name: symbol.name, range: symbol.range, level, kind: symbol.kind });
 		if (symbol.children) {


### PR DESCRIPTION
fix https://github.com/microsoft/vscode/issues/194215

I believe this will only apply to notebooks, since NotebookOutline has the only implementation for `IQuickPickDataSource.getQuickPickElements` and text editor goto symbol filtering is implemented [here](https://insiders.vscode.dev/github/microsoft/vscode/blob/main/src/vs/editor/contrib/quickAccess/browser/gotoSymbolQuickAccess.ts#L221)

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
