### PR TITLE
handle updates while outputs are collapsed

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
@@ -2830,7 +2830,7 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditorD
 
 	async updateOutput(cell: CodeCellViewModel, output: IInsetRenderOutput, offset: number): Promise<void> {
 		this._insetModifyQueueByOutputId.queue(output.source.model.outputId, async () => {
-			if (this._isDisposed || !this._webview) {
+			if (this._isDisposed || !this._webview || cell.isOutputCollapsed) {
 				return;
 			}
 

--- a/src/vs/workbench/contrib/notebook/browser/view/cellParts/cellOutput.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/cellParts/cellOutput.ts
@@ -183,7 +183,7 @@ class CellOutputElement extends Disposable {
 		const index = this.viewCell.outputsViewModels.indexOf(this.output);
 
 		if (this.viewCell.isOutputCollapsed || !this.notebookEditor.hasModel()) {
-			this.cellOutputContainer.unrenderedChanges();
+			this.cellOutputContainer.flagAsStale();
 			return undefined;
 		}
 
@@ -478,14 +478,10 @@ const enum CellOutputUpdateContext {
 
 export class CellOutputContainer extends CellContentPart {
 	private _outputEntries: OutputEntryViewHandler[] = [];
-	private _staleOutputs: boolean = false;
+	private _hasStaleOutputs: boolean = false;
 
 	get renderedOutputEntries() {
 		return this._outputEntries;
-	}
-
-	unrenderedChanges() {
-		this._staleOutputs = true;
 	}
 
 	constructor(
@@ -540,6 +536,13 @@ export class CellOutputContainer extends CellContentPart {
 		}
 	}
 
+	/**
+	 * Notify that an output may have been swapped out without the model getting rendered.
+	 */
+	flagAsStale() {
+		this._hasStaleOutputs = true;
+	}
+
 	private _doRender() {
 		if (this.viewCell.outputsViewModels.length > 0) {
 			if (this.viewCell.layoutInfo.outputTotalHeight !== 0) {
@@ -575,8 +578,8 @@ export class CellOutputContainer extends CellContentPart {
 	}
 
 	viewUpdateShowOutputs(initRendering: boolean): void {
-		if (this._staleOutputs) {
-			this._staleOutputs = false;
+		if (this._hasStaleOutputs) {
+			this._hasStaleOutputs = false;
 			this._outputEntries.forEach(entry => {
 				entry.element.rerender();
 			});

--- a/src/vs/workbench/contrib/notebook/browser/view/cellParts/cellOutput.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/cellParts/cellOutput.ts
@@ -183,6 +183,7 @@ class CellOutputElement extends Disposable {
 		const index = this.viewCell.outputsViewModels.indexOf(this.output);
 
 		if (this.viewCell.isOutputCollapsed || !this.notebookEditor.hasModel()) {
+			this.cellOutputContainer.unrenderedChanges();
 			return undefined;
 		}
 
@@ -477,9 +478,14 @@ const enum CellOutputUpdateContext {
 
 export class CellOutputContainer extends CellContentPart {
 	private _outputEntries: OutputEntryViewHandler[] = [];
+	private _staleOutputs: boolean = false;
 
 	get renderedOutputEntries() {
 		return this._outputEntries;
+	}
+
+	unrenderedChanges() {
+		this._staleOutputs = true;
 	}
 
 	constructor(
@@ -569,6 +575,13 @@ export class CellOutputContainer extends CellContentPart {
 	}
 
 	viewUpdateShowOutputs(initRendering: boolean): void {
+		if (this._staleOutputs) {
+			this._staleOutputs = false;
+			this._outputEntries.forEach(entry => {
+				entry.element.rerender();
+			});
+		}
+
 		for (let index = 0; index < this._outputEntries.length; index++) {
 			const viewHandler = this._outputEntries[index];
 			const outputEntry = viewHandler.element;


### PR DESCRIPTION
fix https://github.com/microsoft/vscode/issues/196304

this fixes two separate scenarios 
- when an output is simply updated for a single renderer - prevent the render from happening (#196304)
- when an output is replaced (switched mime types) - the CellOutputContainer needs to track that it's output entries are out of date and need to be recreated