### PR TITLE
Enable `typescript.enablePromptUseWorkspaceTsdk` in repo

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -171,4 +171,5 @@
 	"css.format.spaceAroundSelectorSeparator": true,
 	"inlineChat.mode": "live",
 	"testing.defaultGutterClickAction": "contextMenu",
+	"typescript.enablePromptUseWorkspaceTsdk": true,
 }


### PR DESCRIPTION
This will prompt users to switch to the workspace version on first open of the workspace

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
