### PR TITLE
Clear out hijackable options in darwin/bin/code.sh

### DIFF
--- a/resources/darwin/bin/code.sh
+++ b/resources/darwin/bin/code.sh
@@ -31,5 +31,7 @@ fi
 CONTENTS="$APP_PATH/Contents"
 ELECTRON="$CONTENTS/MacOS/Electron"
 CLI="$CONTENTS/Resources/app/out/cli.js"
+unset NODE_OPTIONS
+unset NODE_REPL_EXTERNAL_MODULE
 ELECTRON_RUN_AS_NODE=1 "$ELECTRON" "$CLI" "$@"
 exit $?


### PR DESCRIPTION
Fixes #204005

Electron will log a warning when it is launched with these options, see https://github.com/electron/electron/pull/40770 for more context.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
