### PR TITLE
build: don't break yarn watch on css syntax error

### DIFF
--- a/build/lib/compilation.js
+++ b/build/lib/compilation.js
@@ -58,12 +58,12 @@ function createCompile(src, build, emitError, transpileOnly) {
         const isCSS = (f) => f.path.endsWith('.css') && !f.path.includes('fixtures');
         const noDeclarationsFilter = util.filter(data => !(/\.d\.ts$/.test(data.path)));
         const postcss = require('gulp-postcss');
-        const postcssNesting = require('postcss-nesting');
+        const postcssPipe = util.$if(isCSS, postcss([require('postcss-nesting')()]));
         const input = es.through();
         const output = input
             .pipe(util.$if(isUtf8Test, bom())) // this is required to preserve BOM in test files that loose it otherwise
             .pipe(util.$if(!build && isRuntimeJs, util.appendOwnPathSourceURL()))
-            .pipe(util.$if(isCSS, postcss([postcssNesting()])))
+            .pipe(postcssPipe.on('error', e => { reporter(e); postcssPipe.emit('end'); }))
             .pipe(tsFilter)
             .pipe(util.loadSourcemaps())
             .pipe(compilation(token))

--- a/build/lib/compilation.ts
+++ b/build/lib/compilation.ts
@@ -68,13 +68,13 @@ function createCompile(src: string, build: boolean, emitError: boolean, transpil
 		const noDeclarationsFilter = util.filter(data => !(/\.d\.ts$/.test(data.path)));
 
 		const postcss = require('gulp-postcss') as typeof import('gulp-postcss');
-		const postcssNesting = require('postcss-nesting');
+		const postcssPipe = util.$if(isCSS, postcss([require('postcss-nesting')()]));
 
 		const input = es.through();
 		const output = input
 			.pipe(util.$if(isUtf8Test, bom())) // this is required to preserve BOM in test files that loose it otherwise
 			.pipe(util.$if(!build && isRuntimeJs, util.appendOwnPathSourceURL()))
-			.pipe(util.$if(isCSS, postcss([postcssNesting()])))
+			.pipe(postcssPipe.on('error', e => { reporter(e); postcssPipe.emit('end'); }))
 			.pipe(tsFilter)
 			.pipe(util.loadSourcemaps())
 			.pipe(compilation(token))


### PR DESCRIPTION
This is a bit ugly. Normally we'd use gulp-plumber here, but plumber's monkey-patching doesn't reach into nested streams in ternary-stream.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
