### PR TITLE
Add `audioCues.terminalCommandSucceded` (issue #178989)

### DIFF
--- a/src/vs/platform/audioCues/browser/audioCueService.ts
+++ b/src/vs/platform/audioCues/browser/audioCueService.ts
@@ -344,6 +344,7 @@ export const enum AccessibilityAlertSettingId {
 	TerminalQuickFix = 'accessibility.alert.terminalQuickFix',
 	TerminalBell = 'accessibility.alert.terminalBell',
 	TerminalCommandFailed = 'accessibility.alert.terminalCommandFailed',
+	TerminalCommandSucceded = 'accessibility.alert.terminalCommandSucceded',
 	TaskCompleted = 'accessibility.alert.taskCompleted',
 	TaskFailed = 'accessibility.alert.taskFailed',
 	ChatRequestSent = 'accessibility.alert.chatRequestSent',
@@ -461,6 +462,14 @@ export class AudioCue {
 		settingsKey: 'audioCues.terminalCommandFailed',
 		alertSettingsKey: AccessibilityAlertSettingId.TerminalCommandFailed,
 		alertMessage: localize('audioCues.terminalCommandFailed.alertMessage', 'Command Failed')
+	});
+
+	public static readonly terminalCommandSucceded = AudioCue.register({
+		name: localize('audioCues.terminalCommandSucceded', 'Terminal Command Succeded'),
+		sound: Sound.error,
+		settingsKey: 'audioCues.terminalCommandSucceded',
+		alertSettingsKey: AccessibilityAlertSettingId.TerminalCommandSucceded,
+		alertMessage: localize('audioCues.terminalCommandSucceded.alertMessage', 'Command Succeded')
 	});
 
 	public static readonly terminalBell = AudioCue.register({

--- a/src/vs/platform/audioCues/browser/audioCueService.ts
+++ b/src/vs/platform/audioCues/browser/audioCueService.ts
@@ -466,7 +466,7 @@ export class AudioCue {
 
 	public static readonly terminalCommandSucceded = AudioCue.register({
 		name: localize('audioCues.terminalCommandSucceded', 'Terminal Command Succeded'),
-		sound: Sound.error,
+		sound: Sound.terminalBell,
 		settingsKey: 'audioCues.terminalCommandSucceded',
 		alertSettingsKey: AccessibilityAlertSettingId.TerminalCommandSucceded,
 		alertMessage: localize('audioCues.terminalCommandSucceded.alertMessage', 'Command Succeded')

--- a/src/vs/workbench/contrib/accessibility/browser/accessibilityConfiguration.ts
+++ b/src/vs/workbench/contrib/accessibility/browser/accessibilityConfiguration.ts
@@ -200,6 +200,12 @@ const configuration: IConfigurationNode = {
 			'default': true,
 			tags: ['accessibility']
 		},
+		[AccessibilityAlertSettingId.TerminalCommandSucceded]: {
+			'markdownDescription': localize('alert.terminalCommandSucceded', "Alerts when a terminal command succeeds (zero exit code). Also see {0}.", '`#audioCues.terminalCommandSucceded#`'),
+			'type': 'boolean',
+			'default': true,
+			tags: ['accessibility']
+		},
 		[AccessibilityAlertSettingId.TaskFailed]: {
 			'markdownDescription': localize('alert.taskFailed', "Alerts when a task fails (non-zero exit code). Also see {0}.", '`#audioCues.taskFailed#`'),
 			'type': 'boolean',

--- a/src/vs/workbench/contrib/audioCues/browser/audioCues.contribution.ts
+++ b/src/vs/workbench/contrib/audioCues/browser/audioCues.contribution.ts
@@ -93,6 +93,10 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).regis
 			'description': localize('audioCues.terminalCommandFailed', "Plays a sound when a terminal command fails (non-zero exit code)."),
 			...audioCueFeatureBase,
 		},
+		'audioCues.terminalCommandSucceded': {
+			'description': localize('audioCues.terminalCommandSucceded', "Plays a sound when a terminal command succeeds (zero exit code)."),
+			...audioCueFeatureBase,
+		},
 		'audioCues.terminalQuickFix': {
 			'description': localize('audioCues.terminalQuickFix', "Plays a sound when terminal Quick Fixes are available."),
 			...audioCueFeatureBase,

--- a/src/vs/workbench/contrib/terminal/browser/xterm/decorationAddon.ts
+++ b/src/vs/workbench/contrib/terminal/browser/xterm/decorationAddon.ts
@@ -220,6 +220,8 @@ export class DecorationAddon extends Disposable implements ITerminalAddon {
 			this.registerCommandDecoration(command);
 			if (command.exitCode) {
 				this._audioCueService.playAudioCue(AudioCue.terminalCommandFailed);
+			} else {
+				this._audioCueService.playAudioCue(AudioCue.terminalCommandSucceded);
 			}
 		}));
 		// Command invalidated


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Corresponds to https://github.com/microsoft/vscode/issues/178989 in Feature request.

This PR adds the ability to play a sound when a terminal command finishes with a `0` exit code, which is a useful feature for both multitasking and accessibility, like its similar, already existing, setting `audioCues.terminalCommandFailed`, which was added at PR https://github.com/microsoft/vscode/pull/174621

I'm using the `terminalBell.mp3` sound because it feels the most succeed to me. It's also very similar to other OS terminal bells (on MacOS, when pressing `Ctrl+G` on the terminal you will hear it)

 I think it is ok to use this in 2 different places because they are very well differentiated.
