### PR TITLE
Replace Object.prototype.hasOwnProperty.call with Object.hasOwn in ts-basics snippet

### DIFF
--- a/extensions/typescript-basics/snippets/typescript.code-snippets
+++ b/extensions/typescript-basics/snippets/typescript.code-snippets
@@ -152,7 +152,7 @@
 		"prefix": "forin",
 		"body": [
 			"for (const ${1:key} in ${2:object}) {",
-			"\tif (Object.prototype.hasOwnProperty.call(${2:object}, ${1:key})) {",
+			"\tif (Object.hasOwn(${2:object}, ${1:key})) {",
 			"\t\tconst ${3:element} = ${2:object}[${1:key}];",
 			"\t\t$TM_SELECTED_TEXT$0",
 			"\t}",


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
Simple change to use https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwn instead of `Object.prototype.hasOwnProperty.call`  

> Note: Object.hasOwn() is intended as a replacement for [Object.prototype.hasOwnProperty()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/hasOwnProperty).