### PR TITLE
Add classes for chat response parts

### DIFF
--- a/src/vs/workbench/api/common/extHost.api.impl.ts
+++ b/src/vs/workbench/api/common/extHost.api.impl.ts
@@ -1639,7 +1639,13 @@ export function createApiFactoryAndRegisterActors(accessor: ServicesAccessor): I
 			ThreadFocus: extHostTypes.ThreadFocus,
 			RelatedInformationType: extHostTypes.RelatedInformationType,
 			SpeechToTextStatus: extHostTypes.SpeechToTextStatus,
-			KeywordRecognitionStatus: extHostTypes.KeywordRecognitionStatus
+			KeywordRecognitionStatus: extHostTypes.KeywordRecognitionStatus,
+			ChatResponseTextPart: extHostTypes.ChatResponseTextPart,
+			ChatResponseMarkdownPart: extHostTypes.ChatResponseMarkdownPart,
+			ChatResponseFilesPart: extHostTypes.ChatResponseFilesPart,
+			ChatResponseAnchorPart: extHostTypes.ChatResponseAnchorPart,
+			ChatResponseProgressPart: extHostTypes.ChatResponseProgressPart,
+			ChatResponseReferencePart: extHostTypes.ChatResponseReferencePart,
 		};
 	};
 }

--- a/src/vs/workbench/api/common/extHostChatAgents2.ts
+++ b/src/vs/workbench/api/common/extHostChatAgents2.ts
@@ -73,50 +73,44 @@ class ChatAgentResponseStream {
 			};
 
 			this._apiObject = {
-				markdown(value) {
-					throwIfDone(this.markdown);
-					_report({
-						kind: 'markdownContent',
-						content: typeConvert.MarkdownString.from(value)
-					});
-					return this;
-				},
 				text(value) {
 					throwIfDone(this.text);
 					this.markdown(new MarkdownString().appendText(value));
 					return this;
 				},
+				markdown(value) {
+					throwIfDone(this.markdown);
+					const part = new extHostTypes.ChatResponseMarkdownPart(value);
+					const dto = typeConvert.ChatResponseMarkdownPart.to(part);
+					_report(dto);
+					return this;
+				},
 				files(value) {
 					throwIfDone(this.files);
-					_report({
-						kind: 'treeData',
-						treeData: value
-					});
+					const part = new extHostTypes.ChatResponseFilesPart(value);
+					const dto = typeConvert.ChatResponseFilesPart.to(part);
+					_report(dto);
 					return this;
 				},
 				anchor(value, title?: string) {
 					throwIfDone(this.anchor);
-					_report({
-						kind: 'inlineReference',
-						name: title,
-						inlineReference: !URI.isUri(value) ? typeConvert.Location.from(<vscode.Location>value) : value
-					});
+					const part = new extHostTypes.ChatResponseAnchorPart(value, title);
+					const dto = typeConvert.ChatResponseAnchorPart.to(part);
+					_report(dto);
 					return this;
 				},
 				progress(value) {
 					throwIfDone(this.progress);
-					_report({
-						kind: 'progressMessage',
-						content: new MarkdownString(value)
-					});
+					const part = new extHostTypes.ChatResponseProgressPart(value);
+					const dto = typeConvert.ChatResponseProgressPart.to(part);
+					_report(dto);
 					return this;
 				},
 				reference(value) {
 					throwIfDone(this.reference);
-					_report({
-						kind: 'reference',
-						reference: !URI.isUri(value) ? typeConvert.Location.from(<vscode.Location>value) : value
-					});
+					const part = new extHostTypes.ChatResponseReferencePart(value);
+					const dto = typeConvert.ChatResponseReferencePart.to(part);
+					_report(dto);
 					return this;
 				},
 				report(progress) {

--- a/src/vs/workbench/api/common/extHostChatAgents2.ts
+++ b/src/vs/workbench/api/common/extHostChatAgents2.ts
@@ -73,7 +73,7 @@ class ChatAgentResponseStream {
 			};
 
 			this._apiObject = {
-				markdown(value, meta) {
+				markdown(value) {
 					throwIfDone(this.markdown);
 					_report({
 						kind: 'markdownContent',
@@ -81,12 +81,12 @@ class ChatAgentResponseStream {
 					});
 					return this;
 				},
-				text(value, meta) {
+				text(value) {
 					throwIfDone(this.text);
-					this.markdown(new MarkdownString().appendText(value), meta);
+					this.markdown(new MarkdownString().appendText(value));
 					return this;
 				},
-				files(value, meta) {
+				files(value) {
 					throwIfDone(this.files);
 					_report({
 						kind: 'treeData',
@@ -94,11 +94,11 @@ class ChatAgentResponseStream {
 					});
 					return this;
 				},
-				anchor(value, meta) {
+				anchor(value, title?: string) {
 					throwIfDone(this.anchor);
 					_report({
 						kind: 'inlineReference',
-						name: meta?.title,
+						name: title,
 						inlineReference: !URI.isUri(value) ? typeConvert.Location.from(<vscode.Location>value) : value
 					});
 					return this;

--- a/src/vs/workbench/api/common/extHostTypes.ts
+++ b/src/vs/workbench/api/common/extHostTypes.ts
@@ -4212,8 +4212,8 @@ export class ChatResponseTextPart {
 }
 
 export class ChatResponseMarkdownPart {
-	value: string | MarkdownString;
-	constructor(value: string | MarkdownString) {
+	value: string | vscode.MarkdownString;
+	constructor(value: string | vscode.MarkdownString) {
 		this.value = value;
 	}
 }
@@ -4227,8 +4227,10 @@ export class ChatResponseFilesPart {
 
 export class ChatResponseAnchorPart {
 	value: vscode.Uri | vscode.Location | vscode.SymbolInformation;
-	constructor(value: vscode.Uri | vscode.Location | vscode.SymbolInformation) {
+	title?: string;
+	constructor(value: vscode.Uri | vscode.Location | vscode.SymbolInformation, title?: string) {
 		this.value = value;
+		this.title = title;
 	}
 }
 

--- a/src/vs/workbench/api/common/extHostTypes.ts
+++ b/src/vs/workbench/api/common/extHostTypes.ts
@@ -4203,6 +4203,50 @@ export enum ChatAgentResultFeedbackKind {
 	Helpful = 1,
 }
 
+
+export class ChatResponseTextPart {
+	value: string;
+	constructor(value: string) {
+		this.value = value;
+	}
+}
+
+export class ChatResponseMarkdownPart {
+	value: string | MarkdownString;
+	constructor(value: string | MarkdownString) {
+		this.value = value;
+	}
+}
+
+export class ChatResponseFilesPart {
+	value: vscode.ChatAgentFileTreeData;
+	constructor(value: vscode.ChatAgentFileTreeData) {
+		this.value = value;
+	}
+}
+
+export class ChatResponseAnchorPart {
+	value: vscode.Uri | vscode.Location | vscode.SymbolInformation;
+	constructor(value: vscode.Uri | vscode.Location | vscode.SymbolInformation) {
+		this.value = value;
+	}
+}
+
+export class ChatResponseProgressPart {
+	value: string;
+	constructor(value: string) {
+		this.value = value;
+	}
+}
+
+export class ChatResponseReferencePart {
+	value: vscode.Uri | vscode.Location;
+	constructor(value: vscode.Uri | vscode.Location) {
+		this.value = value;
+	}
+}
+
+
 //#endregion
 
 //#region ai

--- a/src/vscode-dts/vscode.proposed.chatAgents2.d.ts
+++ b/src/vscode-dts/vscode.proposed.chatAgents2.d.ts
@@ -17,7 +17,7 @@ declare module 'vscode' {
 		/**
 		 * The content that was received from the chat agent. Only the progress parts that represent actual content (not metadata) are represented.
 		 */
-		response: ChatAgentContentProgress[];
+		response: (ChatAgentContentProgress | ChatResponseTextPart | ChatResponseMarkdownPart | ChatResponseFilesPart | ChatResponseAnchorPart)[];
 
 		/**
 		 * The result that was received from the chat agent.
@@ -277,24 +277,15 @@ declare module 'vscode' {
 		variables: Record<string, ChatVariableValue[]>;
 	}
 
-	export interface ChatAgentResponseItemMetadata {
-		title: string;
-		// annotations: any[]; // future OffsetbasedAnnotation and Annotation
-	}
-
 	export interface ChatAgentResponseStream {
 
-		// RENDERED
+		text(value: string): ChatAgentResponseStream;
 
-		text(value: string, meta?: ChatAgentResponseItemMetadata): ChatAgentResponseStream;
+		markdown(value: string | MarkdownString): ChatAgentResponseStream;
 
-		markdown(value: string | MarkdownString, meta?: ChatAgentResponseItemMetadata): ChatAgentResponseStream;
+		files(value: ChatAgentFileTreeData): ChatAgentResponseStream;
 
-		files(value: ChatAgentFileTreeData, meta?: ChatAgentResponseItemMetadata): ChatAgentResponseStream;
-
-		anchor(value: Uri | Location, meta?: ChatAgentResponseItemMetadata): ChatAgentResponseStream;
-
-		// META
+		anchor(value: Uri | Location, title?: string): ChatAgentResponseStream;
 
 		// TODO@API this influences the rendering, it inserts new lines which is likely a bug
 		progress(value: string): ChatAgentResponseStream;
@@ -308,6 +299,47 @@ declare module 'vscode' {
 		 */
 		report(value: ChatAgentProgress): void;
 	}
+
+	// TODO@API
+	// support ChatResponseCommandPart
+	// support ChatResponseTextEditPart
+	// support ChatResponseCodeReferencePart
+
+	// TODO@API should the name suffix differentiate between rendered items (XYZPart)
+	// and metadata like XYZItem
+	export class ChatResponseTextPart {
+		value: string;
+		constructor(value: string);
+	}
+
+	export class ChatResponseMarkdownPart {
+		value: string | MarkdownString;
+		constructor(value: string | MarkdownString);
+	}
+
+	export class ChatResponseFilesPart {
+		value: ChatAgentFileTreeData;
+		constructor(value: ChatAgentFileTreeData);
+	}
+
+	export class ChatResponseAnchorPart {
+		value: Uri | Location | SymbolInformation;
+		title?: string;
+		constructor(value: Uri | Location | SymbolInformation, title?: string);
+	}
+
+	export class ChatResponseProgressPart {
+		value: string;
+		constructor(value: string);
+	}
+
+	export class ChatResponseReferencePart {
+		value: Uri | Location;
+		constructor(value: Uri | Location);
+	}
+
+	export type ChatResponsePart = ChatResponseTextPart | ChatResponseMarkdownPart | ChatResponseFilesPart | ChatResponseAnchorPart
+		| ChatResponseProgressPart | ChatResponseReferencePart;
 
 	/**
 	 * @deprecated use ChatAgentResponseStream instead


### PR DESCRIPTION
This pull request adds new classes for different types of chat response parts, such as text, markdown, files, anchor, progress, and reference. These classes will be used to represent the content received from the chat agent in a more structured way.