### PR TITLE
Show keybindings in comment button hovers

### DIFF
--- a/src/vs/workbench/contrib/comments/browser/commentFormActions.ts
+++ b/src/vs/workbench/contrib/comments/browser/commentFormActions.ts
@@ -7,6 +7,8 @@ import { Button } from 'vs/base/browser/ui/button/button';
 import { IAction } from 'vs/base/common/actions';
 import { DisposableStore, IDisposable } from 'vs/base/common/lifecycle';
 import { IMenu } from 'vs/platform/actions/common/actions';
+import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
+import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 import { defaultButtonStyles } from 'vs/platform/theme/browser/defaultStyles';
 
 export class CommentFormActions implements IDisposable {
@@ -15,6 +17,8 @@ export class CommentFormActions implements IDisposable {
 	private _actions: IAction[] = [];
 
 	constructor(
+		private readonly keybindingService: IKeybindingService,
+		private readonly contextKeyService: IContextKeyService,
 		private container: HTMLElement,
 		private actionHandler: (action: IAction) => void,
 		private readonly maxActions?: number
@@ -33,7 +37,9 @@ export class CommentFormActions implements IDisposable {
 
 			this._actions = actions;
 			for (const action of actions) {
-				const button = new Button(this.container, { secondary: !isPrimary, ...defaultButtonStyles });
+				const keybinding = this.keybindingService.lookupKeybinding(action.id, this.contextKeyService)?.getLabel() ?? undefined;
+				const title = keybinding ? `${action.label} (${keybinding})` : action.label;
+				const button = new Button(this.container, { secondary: !isPrimary, title, ...defaultButtonStyles });
 
 				isPrimary = false;
 				this._buttonElements.push(button.element);

--- a/src/vs/workbench/contrib/comments/browser/commentFormActions.ts
+++ b/src/vs/workbench/contrib/comments/browser/commentFormActions.ts
@@ -10,6 +10,7 @@ import { IMenu } from 'vs/platform/actions/common/actions';
 import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 import { defaultButtonStyles } from 'vs/platform/theme/browser/defaultStyles';
+import { CommentCommandId } from 'vs/workbench/contrib/comments/common/commentCommandIds';
 
 export class CommentFormActions implements IDisposable {
 	private _buttonElements: HTMLElement[] = [];
@@ -37,7 +38,10 @@ export class CommentFormActions implements IDisposable {
 
 			this._actions = actions;
 			for (const action of actions) {
-				const keybinding = this.keybindingService.lookupKeybinding(action.id, this.contextKeyService)?.getLabel() ?? undefined;
+				let keybinding = this.keybindingService.lookupKeybinding(action.id, this.contextKeyService)?.getLabel();
+				if (!keybinding && isPrimary) {
+					keybinding = this.keybindingService.lookupKeybinding(CommentCommandId.Submit, this.contextKeyService)?.getLabel();
+				}
 				const title = keybinding ? `${action.label} (${keybinding})` : action.label;
 				const button = new Button(this.container, { secondary: !isPrimary, title, ...defaultButtonStyles });
 

--- a/src/vs/workbench/contrib/comments/browser/commentNode.ts
+++ b/src/vs/workbench/contrib/comments/browser/commentNode.ts
@@ -49,6 +49,7 @@ import { FileAccess } from 'vs/base/common/network';
 import { COMMENTS_SECTION, ICommentsConfiguration } from 'vs/workbench/contrib/comments/common/commentsConfiguration';
 import { StandardMouseEvent } from 'vs/base/browser/mouseEvent';
 import { IAccessibilityService } from 'vs/platform/accessibility/common/accessibility';
+import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 
 class CommentsActionRunner extends ActionRunner {
 	protected override async runAction(action: IAction, context: any[]): Promise<void> {
@@ -114,7 +115,8 @@ export class CommentNode<T extends IRange | ICellRange> extends Disposable {
 		@IContextMenuService private contextMenuService: IContextMenuService,
 		@IContextKeyService contextKeyService: IContextKeyService,
 		@IConfigurationService private configurationService: IConfigurationService,
-		@IAccessibilityService private accessibilityService: IAccessibilityService
+		@IAccessibilityService private accessibilityService: IAccessibilityService,
+		@IKeybindingService private keybindingService: IKeybindingService
 	) {
 		super();
 
@@ -610,7 +612,7 @@ export class CommentNode<T extends IRange | ICellRange> extends Disposable {
 			this._commentFormActions?.setActions(menu);
 		}));
 
-		this._commentFormActions = new CommentFormActions(container, (action: IAction): void => {
+		this._commentFormActions = new CommentFormActions(this.keybindingService, this._contextKeyService, container, (action: IAction): void => {
 			const text = this._commentEditor!.getValue();
 
 			action.run({
@@ -636,7 +638,7 @@ export class CommentNode<T extends IRange | ICellRange> extends Disposable {
 			this._commentEditorActions?.setActions(menu);
 		}));
 
-		this._commentEditorActions = new CommentFormActions(container, (action: IAction): void => {
+		this._commentEditorActions = new CommentFormActions(this.keybindingService, this._contextKeyService, container, (action: IAction): void => {
 			const text = this._commentEditor!.getValue();
 
 			action.run({

--- a/src/vs/workbench/contrib/comments/browser/commentReply.ts
+++ b/src/vs/workbench/contrib/comments/browser/commentReply.ts
@@ -29,6 +29,7 @@ import { CommentContextKeys } from 'vs/workbench/contrib/comments/common/comment
 import { ICommentThreadWidget } from 'vs/workbench/contrib/comments/common/commentThreadWidget';
 import { ICellRange } from 'vs/workbench/contrib/notebook/common/notebookRange';
 import { LayoutableEditor, MIN_EDITOR_HEIGHT, SimpleCommentEditor, calculateEditorHeight } from './simpleCommentEditor';
+import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 
 const COMMENT_SCHEME = 'comment';
 let INMEM_MODEL_ID = 0;
@@ -63,7 +64,8 @@ export class CommentReply<T extends IRange | ICellRange> extends Disposable {
 		@ILanguageService private languageService: ILanguageService,
 		@IModelService private modelService: IModelService,
 		@IThemeService private themeService: IThemeService,
-		@IConfigurationService configurationService: IConfigurationService
+		@IConfigurationService configurationService: IConfigurationService,
+		@IKeybindingService private keybindingService: IKeybindingService
 	) {
 		super();
 
@@ -283,7 +285,7 @@ export class CommentReply<T extends IRange | ICellRange> extends Disposable {
 			this._commentFormActions.setActions(menu);
 		}));
 
-		this._commentFormActions = new CommentFormActions(container, async (action: IAction) => {
+		this._commentFormActions = new CommentFormActions(this.keybindingService, this._contextKeyService, container, async (action: IAction) => {
 			await this._actionRunDelegate?.();
 
 			await action.run({
@@ -306,7 +308,7 @@ export class CommentReply<T extends IRange | ICellRange> extends Disposable {
 			this._commentEditorActions.setActions(editorMenu);
 		}));
 
-		this._commentEditorActions = new CommentFormActions(container, async (action: IAction) => {
+		this._commentEditorActions = new CommentFormActions(this.keybindingService, this._contextKeyService, container, async (action: IAction) => {
 			this._actionRunDelegate?.();
 
 			action.run({

--- a/src/vs/workbench/contrib/comments/browser/commentThreadAdditionalActions.ts
+++ b/src/vs/workbench/contrib/comments/browser/commentThreadAdditionalActions.ts
@@ -15,6 +15,7 @@ import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 import { CommentFormActions } from 'vs/workbench/contrib/comments/browser/commentFormActions';
 import { CommentMenus } from 'vs/workbench/contrib/comments/browser/commentMenus';
 import { ICellRange } from 'vs/workbench/contrib/notebook/common/notebookRange';
+import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 
 export class CommentThreadAdditionalActions<T extends IRange | ICellRange> extends Disposable {
 	private _container: HTMLElement | null;
@@ -27,6 +28,7 @@ export class CommentThreadAdditionalActions<T extends IRange | ICellRange> exten
 		private _contextKeyService: IContextKeyService,
 		private _commentMenus: CommentMenus,
 		private _actionRunDelegate: (() => void) | null,
+		@IKeybindingService private _keybindingService: IKeybindingService,
 	) {
 		super();
 
@@ -78,7 +80,7 @@ export class CommentThreadAdditionalActions<T extends IRange | ICellRange> exten
 			this._enableDisableMenu(menu);
 		}));
 
-		this._commentFormActions = new CommentFormActions(container, async (action: IAction) => {
+		this._commentFormActions = new CommentFormActions(this._keybindingService, this._contextKeyService, container, async (action: IAction) => {
 			this._actionRunDelegate?.();
 
 			action.run({


### PR DESCRIPTION
This pull request adds the functionality to show keybindings in the comment button hovers. 