### PR TITLE
Prevent F1 from opening browser help in webviews

### DIFF
--- a/src/vs/workbench/contrib/webview/browser/pre/index-no-csp.html
+++ b/src/vs/workbench/contrib/webview/browser/pre/index-no-csp.html
@@ -596,7 +596,7 @@
 				} else {
 					return; // let the browser handle this
 				}
-			} else if (!onElectron && (isCloseTab(e) || isNewWindow(e) || isHelp(e))) {
+			} else if (!onElectron && (isCloseTab(e) || isNewWindow(e) || isHelp(e) || isRefresh(e))) {
 				// Prevent Ctrl+W closing window / Ctrl+N opening new window in PWA.
 				// (No effect in a regular browser tab.)
 				e.preventDefault();
@@ -708,6 +708,15 @@
 		function isHelp(e) {
 			// 112: keyCode of "F1"
 			return e.keyCode === 112;
+		}
+
+		/**
+		 * @param {KeyboardEvent} e
+		 * @return {boolean}
+		 */
+		function isRefresh(e) {
+			// 116: keyCode of "F5"
+			return e.keyCode === 116;
 		}
 
 		let isHandlingScroll = false;

--- a/src/vs/workbench/contrib/webview/browser/pre/index-no-csp.html
+++ b/src/vs/workbench/contrib/webview/browser/pre/index-no-csp.html
@@ -596,7 +596,7 @@
 				} else {
 					return; // let the browser handle this
 				}
-			} else if (!onElectron && (isCloseTab(e) || isNewWindow(e))) {
+			} else if (!onElectron && (isCloseTab(e) || isNewWindow(e) || isHelp(e))) {
 				// Prevent Ctrl+W closing window / Ctrl+N opening new window in PWA.
 				// (No effect in a regular browser tab.)
 				e.preventDefault();
@@ -699,6 +699,15 @@
 			const hasMeta = e.ctrlKey || e.metaKey;
 			// 78: keyCode of "N"
 			return hasMeta && e.keyCode === 78;
+		}
+
+		/**
+		 * @param {KeyboardEvent} e
+		 * @return {boolean}
+		 */
+		function isHelp(e) {
+			// 112: keyCode of "F1"
+			return e.keyCode === 112;
 		}
 
 		let isHandlingScroll = false;

--- a/src/vs/workbench/contrib/webview/browser/pre/index.html
+++ b/src/vs/workbench/contrib/webview/browser/pre/index.html
@@ -597,7 +597,7 @@
 				} else {
 					return; // let the browser handle this
 				}
-			} else if (!onElectron && (isCloseTab(e) || isNewWindow(e) || isHelp(e))) {
+			} else if (!onElectron && (isCloseTab(e) || isNewWindow(e) || isHelp(e) || isRefresh(e))) {
 				// Prevent Ctrl+W closing window / Ctrl+N opening new window in PWA.
 				// (No effect in a regular browser tab.)
 				e.preventDefault();
@@ -709,6 +709,15 @@
 		function isHelp(e) {
 			// 112: keyCode of "F1"
 			return e.keyCode === 112;
+		}
+
+		/**
+		 * @param {KeyboardEvent} e
+		 * @return {boolean}
+		 */
+		function isRefresh(e) {
+			// 116: keyCode of "F5"
+			return e.keyCode === 116;
 		}
 
 		let isHandlingScroll = false;

--- a/src/vs/workbench/contrib/webview/browser/pre/index.html
+++ b/src/vs/workbench/contrib/webview/browser/pre/index.html
@@ -597,7 +597,7 @@
 				} else {
 					return; // let the browser handle this
 				}
-			} else if (!onElectron && (isCloseTab(e) || isNewWindow(e))) {
+			} else if (!onElectron && (isCloseTab(e) || isNewWindow(e) || isHelp(e))) {
 				// Prevent Ctrl+W closing window / Ctrl+N opening new window in PWA.
 				// (No effect in a regular browser tab.)
 				e.preventDefault();
@@ -700,6 +700,15 @@
 			const hasMeta = e.ctrlKey || e.metaKey;
 			// 78: keyCode of "N"
 			return hasMeta && e.keyCode === 78;
+		}
+
+		/**
+		 * @param {KeyboardEvent} e
+		 * @return {boolean}
+		 */
+		function isHelp(e) {
+			// 112: keyCode of "F1"
+			return e.keyCode === 112;
 		}
 
 		let isHandlingScroll = false;

--- a/src/vs/workbench/contrib/webview/browser/pre/index.html
+++ b/src/vs/workbench/contrib/webview/browser/pre/index.html
@@ -5,7 +5,7 @@
 	<meta charset="UTF-8">
 
 	<meta http-equiv="Content-Security-Policy"
-		content="default-src 'none'; script-src 'sha256-frEVWVmmI4TWHGHXZaCTWqGQI9jv+i8hv+sOa87Gqlc=' 'self'; frame-src 'self'; style-src 'unsafe-inline';">
+		content="default-src 'none'; script-src 'sha256-MbYFw/X6HjRtVlnfFTL3ylPDt3RsDzWrYVjfrzKJbMA=' 'self'; frame-src 'self'; style-src 'unsafe-inline';">
 
 	<!-- Disable pinch zooming -->
 	<meta name="viewport"


### PR DESCRIPTION
This fixes #162166 and #174569

When in VS Code (web) pressing F1 does not trigger the browser help normally, but it does when in a webview.

Preventing this just requires us to call preventDefault on the event, the same as for ctrl+w and ctrl+n.