### PR TITLE
Add Python Prompt detection hint

### DIFF
--- a/src/vs/platform/terminal/common/capabilities/commandDetectionCapability.ts
+++ b/src/vs/platform/terminal/common/capabilities/commandDetectionCapability.ts
@@ -903,6 +903,15 @@ class WindowsPtyHeuristics extends Disposable {
 			}
 		}
 
+		// Python Prompt
+		const pythonPrompt = lineText.match(/^(?<prompt>>>> )/g)?.groups?.prompt;
+		if (pythonPrompt) {
+			return {
+				prompt: pythonPrompt,
+				likelySingleLine: true
+			};
+		}
+
 		// Command Prompt
 		const cmdMatch = lineText.match(/^(?<prompt>(\(.+\)\s)?(?:[A-Z]:\\.*>))/);
 		return cmdMatch?.groups?.prompt ? {


### PR DESCRIPTION
Adding Python Prompt to commandDetectionCapability.ts as it may help with solving decoration issues on Windows pwsh folks using Python REPL. 

Related: https://github.com/microsoft/vscode-python/issues/22535