### PR TITLE
Support http proxies for build/lib/fetch to allow vscode compilation when behind enterprise egress restrictions

### DIFF
--- a/build/lib/fetch.js
+++ b/build/lib/fetch.js
@@ -11,6 +11,8 @@ const log = require("fancy-log");
 const ansiColors = require("ansi-colors");
 const crypto = require("crypto");
 const through2 = require("through2");
+const process_1 = require("process");
+const undici_1 = require("undici");
 function fetchUrls(urls, options) {
     if (options === undefined) {
         options = {};
@@ -33,6 +35,12 @@ function fetchUrls(urls, options) {
 exports.fetchUrls = fetchUrls;
 async function fetchUrl(url, options, retries = 10, retryDelay = 1000) {
     const verbose = !!options.verbose ?? (!!process.env['CI'] || !!process.env['BUILD_ARTIFACTSTAGINGDIRECTORY']);
+    // Proxy setup
+    let agent;
+    const proxyUrl = process_1.env['https_proxy'] || process_1.env['http_proxy'] || '';
+    if (proxyUrl !== '') {
+        agent = new undici_1.ProxyAgent(proxyUrl);
+    }
     try {
         let startTime = 0;
         if (verbose) {
@@ -42,8 +50,9 @@ async function fetchUrl(url, options, retries = 10, retryDelay = 1000) {
         const controller = new AbortController();
         const timeout = setTimeout(() => controller.abort(), 30 * 1000);
         try {
-            const response = await fetch(url, {
+            const response = await (0, undici_1.fetch)(url, {
                 ...options.nodeFetchOptions,
+                dispatcher: agent,
                 signal: controller.signal /* Typings issue with lib.dom.d.ts */
             });
             if (verbose) {

--- a/build/package.json
+++ b/build/package.json
@@ -53,6 +53,7 @@
     "ternary-stream": "^3.0.0",
     "through2": "^4.0.2",
     "tmp": "^0.2.1",
+    "undici": "^6.6.2",
     "vscode-universal-bundler": "^0.0.2",
     "workerpool": "^6.4.0",
     "yauzl": "^2.10.0"

--- a/build/yarn.lock
+++ b/build/yarn.lock
@@ -353,6 +353,11 @@
   resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.20.0.tgz#2efddf82828aac85e64cef62482af61c29561bee"
   integrity sha512-NgJnesu1RtWihtTtXGFMU5YSE6JyyHPMxCwBZK7a6/8d31GuSo9l0Ss7w1Jw5QnKUawG6UEehs883kcXf5fYwg==
 
+"@fastify/busboy@^2.0.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@fastify/busboy/-/busboy-2.1.0.tgz#0709e9f4cb252351c609c6e6d8d6779a8d25edff"
+  integrity sha512-+KpH+QxZU7O4675t3mnkQKcZZg56u+K/Ct2K+N2AZYNVK8kyeo/bI18tI8aPm3tvNNRyTWfj6s5tnGNlcbQRsA==
+
 "@malept/cross-spawn-promise@^1.1.0":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@malept/cross-spawn-promise/-/cross-spawn-promise-1.1.1.tgz#504af200af6b98e198bce768bc1730c6936ae01d"
@@ -2656,6 +2661,13 @@ undici-types@~5.26.4:
   version "5.26.5"
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-5.26.5.tgz#bcd539893d00b56e964fd2657a4866b221a65617"
   integrity sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==
+
+undici@^6.6.2:
+  version "6.6.2"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-6.6.2.tgz#8dce5ae54e8a3bc7140c2b2a0972b5fde9a88efb"
+  integrity sha512-vSqvUE5skSxQJ5sztTZ/CdeJb1Wq0Hf44hlYMciqHghvz+K88U0l7D6u1VsndoFgskDcnU+nG3gYmMzJVzd9Qg==
+  dependencies:
+    "@fastify/busboy" "^2.0.0"
 
 universal-user-agent@^6.0.0:
   version "6.0.0"


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
Add support for http proxies to `build/lib/fetch`. This allows one to fully compile vscode when behind company proxies.

While a bunch of other code in the repository or in dependencies (like [ripgrep](https://github.com/microsoft/vscode-ripgrep)) uses things like [https-proxy-agent](https://www.npmjs.com/package/https-proxy-agent), the fetch utility in the build folder did not have that same support causing build failures (e.g. when the process start to download built-in extensions).

Since this fetch utility actually started using the `fetch` method instead of the more classic Node HTTP stack, this PR adds support for http proxies in this case by using [the recommended variant](https://undici.nodejs.org/#/docs/api/ProxyAgent) from the underlying library used by Node's fetch [undici](https://undici.nodejs.org/).

Note that unfortunately the bundled copy of undici Node uses to expose `fetch` as a global doesn't have the proper typing for `RequestInit` and specifically lacks the additional `dispatcher` property which lets us set the proxy dispatcher. As a result it seemed cleaner to clearly require undici directly and simply use its builtin types.