### PR TITLE
Enable go to definition in chat code blocks

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatListRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatListRenderer.ts
@@ -24,12 +24,14 @@ import { IMarkdownString, MarkdownString } from 'vs/base/common/htmlContent';
 import { Disposable, DisposableStore, IDisposable, toDisposable } from 'vs/base/common/lifecycle';
 import { ResourceMap } from 'vs/base/common/map';
 import { marked } from 'vs/base/common/marked/marked';
-import { FileAccess } from 'vs/base/common/network';
+import { FileAccess, Schemas } from 'vs/base/common/network';
 import { clamp } from 'vs/base/common/numbers';
 import { basename } from 'vs/base/common/path';
 import { equalsIgnoreCase } from 'vs/base/common/strings';
 import { ThemeIcon } from 'vs/base/common/themables';
 import { URI } from 'vs/base/common/uri';
+import { ICodeEditor } from 'vs/editor/browser/editorBrowser';
+import { ICodeEditorService } from 'vs/editor/browser/services/codeEditorService';
 import { IMarkdownRenderResult, MarkdownRenderer } from 'vs/editor/browser/widget/markdownRenderer/browser/markdownRenderer';
 import { Range } from 'vs/editor/common/core/range';
 import { localize } from 'vs/nls';
@@ -39,6 +41,7 @@ import { MenuId, MenuItemAction } from 'vs/platform/actions/common/actions';
 import { ICommandService } from 'vs/platform/commands/common/commands';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
+import { ITextResourceEditorInput } from 'vs/platform/editor/common/editor';
 import { FileKind, FileType } from 'vs/platform/files/common/files';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { ServiceCollection } from 'vs/platform/instantiation/common/serviceCollection';
@@ -55,7 +58,7 @@ import { ChatTreeItem, IChatCodeBlockInfo, IChatFileTreeInfo } from 'vs/workbenc
 import { ChatFollowups } from 'vs/workbench/contrib/chat/browser/chatFollowups';
 import { ChatMarkdownDecorationsRenderer, annotateSpecialMarkdownContent, extractVulnerabilitiesFromText } from 'vs/workbench/contrib/chat/browser/chatMarkdownDecorationsRenderer';
 import { ChatEditorOptions } from 'vs/workbench/contrib/chat/browser/chatOptions';
-import { ICodeBlockData, ICodeBlockPart, LocalFileCodeBlockPart, SimpleCodeBlockPart, localFileLanguageId, parseLocalFileData } from 'vs/workbench/contrib/chat/browser/codeBlockPart';
+import { ChatCodeBlockContentProvider, ICodeBlockData, ICodeBlockPart, LocalFileCodeBlockPart, SimpleCodeBlockPart, localFileLanguageId, parseLocalFileData } from 'vs/workbench/contrib/chat/browser/codeBlockPart';
 import { IChatAgentMetadata } from 'vs/workbench/contrib/chat/common/chatAgents';
 import { CONTEXT_CHAT_RESPONSE_SUPPORT_ISSUE_REPORTING, CONTEXT_REQUEST, CONTEXT_RESPONSE, CONTEXT_RESPONSE_FILTERED, CONTEXT_RESPONSE_VOTE } from 'vs/workbench/contrib/chat/common/chatContextKeys';
 import { IChatProgressRenderableResponseContent } from 'vs/workbench/contrib/chat/common/chatModel';
@@ -141,6 +144,7 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 		@IContextKeyService private readonly contextKeyService: IContextKeyService,
 		@IChatService private readonly chatService: IChatService,
 		@IEditorService private readonly editorService: IEditorService,
+		@ICodeEditorService codeEditorService: ICodeEditorService,
 		@IThemeService private readonly themeService: IThemeService,
 	) {
 		super();
@@ -149,6 +153,27 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 		this._editorPool = this._register(this.instantiationService.createInstance(EditorPool, this.editorOptions, overflowWidgetsDomNode));
 		this._treePool = this._register(this.instantiationService.createInstance(TreePool, this._onDidChangeVisibility.event));
 		this._contentReferencesListPool = this._register(this.instantiationService.createInstance(ContentReferencesListPool, this._onDidChangeVisibility.event));
+
+		this._register(this.instantiationService.createInstance(ChatCodeBlockContentProvider));
+
+		this._register(codeEditorService.registerCodeEditorOpenHandler(async (input: ITextResourceEditorInput, _source: ICodeEditor | null, _sideBySide?: boolean): Promise<ICodeEditor | null> => {
+			if (input.resource.scheme !== Schemas.vscodeChatCodeBlock) {
+				return null;
+			}
+			const block = this._editorPool.find(input.resource);
+			if (!block) {
+				return null;
+			}
+			if (input.options?.selection) {
+				block.editor.setSelection({
+					startLineNumber: input.options.selection.startLineNumber,
+					startColumn: input.options.selection.startColumn,
+					endLineNumber: input.options.selection.startLineNumber ?? input.options.selection.endLineNumber,
+					endColumn: input.options.selection.startColumn ?? input.options.selection.endColumn
+				});
+			}
+			return block.editor;
+		}));
 
 		this._usedReferencesEnabled = configService.getValue('chat.experimental.usedReferences') ?? true;
 		this._register(configService.onDidChangeConfiguration(e => {
@@ -1073,6 +1098,10 @@ class EditorPool extends Disposable {
 
 	get(data: ICodeBlockData): IDisposableReference<ICodeBlockPart> {
 		return this.getFromPool(data.type === 'localFile' ? this._localFileEditorPool : this._simpleEditorPool);
+	}
+
+	find(resource: URI): SimpleCodeBlockPart | undefined {
+		return Array.from(this._simpleEditorPool.inUse).find(part => part.uri?.toString() === resource.toString());
 	}
 
 	private getFromPool(pool: ResourcePool<ICodeBlockPart>): IDisposableReference<ICodeBlockPart> {

--- a/src/vs/workbench/contrib/chat/browser/codeBlockPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/codeBlockPart.ts
@@ -358,6 +358,7 @@ export class SimpleCodeBlockPart extends BaseCodeBlockPart<ISimpleCodeBlockData>
 		this._uri = URI.from({ scheme: Schemas.vscodeChatCodeBlock, path: generateUuid() });
 		this.textModel = textModelService.createModelReference(this._uri).then(ref => {
 			this.editor.setModel(ref.object.textEditorModel);
+			this._register(ref);
 			return ref.object.textEditorModel;
 		});
 

--- a/src/vs/workbench/contrib/chat/browser/codeBlockPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/codeBlockPart.ts
@@ -20,7 +20,7 @@ import { ILanguageService } from 'vs/editor/common/languages/language';
 import { PLAINTEXT_LANGUAGE_ID } from 'vs/editor/common/languages/modesRegistry';
 import { EndOfLinePreference, ITextModel } from 'vs/editor/common/model';
 import { IModelService } from 'vs/editor/common/services/model';
-import { IResolvedTextEditorModel, ITextModelService } from 'vs/editor/common/services/resolverService';
+import { IResolvedTextEditorModel, ITextModelContentProvider, ITextModelService } from 'vs/editor/common/services/resolverService';
 import { BracketMatchingController } from 'vs/editor/contrib/bracketMatching/browser/bracketMatching';
 import { ContextMenuController } from 'vs/editor/contrib/contextmenu/browser/contextmenu';
 import { ViewportSemanticTokensContribution } from 'vs/editor/contrib/semanticTokens/browser/viewportSemanticTokens';
@@ -41,7 +41,8 @@ import { IChatResponseViewModel, isResponseVM } from 'vs/workbench/contrib/chat/
 import { MenuPreventer } from 'vs/workbench/contrib/codeEditor/browser/menuPreventer';
 import { SelectionClipboardContributionID } from 'vs/workbench/contrib/codeEditor/browser/selectionClipboard';
 import { getSimpleEditorOptions } from 'vs/workbench/contrib/codeEditor/browser/simpleEditorOptions';
-import { IEditorConstructionOptions } from 'vs/editor/browser/config/editorConfiguration';
+import { GotoDefinitionAtPositionEditorContribution } from 'vs/editor/contrib/gotoSymbol/browser/link/goToDefinitionAtPosition';
+import { HoverController } from 'vs/editor/contrib/hover/browser/hover';
 
 const $ = dom.$;
 
@@ -128,7 +129,7 @@ abstract class BaseCodeBlockPart<Data extends ICodeBlockData> extends Disposable
 	protected readonly _onDidChangeContentHeight = this._register(new Emitter<void>());
 	public readonly onDidChangeContentHeight = this._onDidChangeContentHeight.event;
 
-	protected readonly editor: CodeEditorWidget;
+	public readonly editor: CodeEditorWidget;
 	protected readonly toolbar: MenuWorkbenchToolBar;
 	private readonly contextKeyService: IContextKeyService;
 
@@ -300,13 +301,17 @@ export class SimpleCodeBlockPart extends BaseCodeBlockPart<ISimpleCodeBlockData>
 
 	private currentCodeBlockData: ISimpleCodeBlockData | undefined;
 
-	private readonly textModel: ITextModel;
+	private readonly textModel: Promise<ITextModel>;
+
+	private readonly _uri: URI;
+
 	constructor(
 		options: ChatEditorOptions,
 		menuId: MenuId,
 		@IInstantiationService instantiationService: IInstantiationService,
 		@IContextKeyService contextKeyService: IContextKeyService,
 		@IModelService modelService: IModelService,
+		@ITextModelService textModelService: ITextModelService,
 		@IConfigurationService configurationService: IConfigurationService,
 		@IAccessibilityService accessibilityService: IAccessibilityService,
 		@ILanguageService private readonly languageService: ILanguageService,
@@ -326,8 +331,11 @@ export class SimpleCodeBlockPart extends BaseCodeBlockPart<ISimpleCodeBlockData>
 			buttonSeparator: undefined,
 			supportIcons: true
 		});
-		this.textModel = this._register(this.modelService.createModel('', null, undefined, true));
-		this.editor.setModel(this.textModel);
+		this._uri = URI.from({ scheme: Schemas.vscodeChatCodeBlock, path: generateUuid() });
+		this.textModel = textModelService.createModelReference(this._uri).then(ref => {
+			this.editor.setModel(ref.object.textEditorModel);
+			return ref.object.textEditorModel;
+		});
 
 		this.vulnsListElement = dom.append(vulnsContainer, $('ul.interactive-result-vulns-list'));
 
@@ -342,7 +350,7 @@ export class SimpleCodeBlockPart extends BaseCodeBlockPart<ISimpleCodeBlockData>
 	}
 
 	get uri(): URI {
-		return this.textModel.uri;
+		return this._uri;
 	}
 
 	protected override createEditor(instantiationService: IInstantiationService, parent: HTMLElement, options: Readonly<IEditorConstructionOptions>): CodeEditorWidget {
@@ -357,6 +365,8 @@ export class SimpleCodeBlockPart extends BaseCodeBlockPart<ISimpleCodeBlockData>
 				ViewportSemanticTokensContribution.ID,
 				BracketMatchingController.ID,
 				SmartSelectController.ID,
+				HoverController.ID,
+				GotoDefinitionAtPositionEditorContribution.ID,
 			])
 		}));
 	}
@@ -375,8 +385,8 @@ export class SimpleCodeBlockPart extends BaseCodeBlockPart<ISimpleCodeBlockData>
 		}
 	}
 
-	protected override updateEditor(data: ISimpleCodeBlockData): void {
-		this.editor.setModel(this.textModel);
+	protected override async updateEditor(data: ISimpleCodeBlockData): Promise<void> {
+		this.editor.setModel(await this.textModel);
 		const text = this.fixCodeText(data.text, data.languageId);
 		this.setText(text);
 
@@ -414,25 +424,26 @@ export class SimpleCodeBlockPart extends BaseCodeBlockPart<ISimpleCodeBlockData>
 		return text;
 	}
 
-	private setText(newText: string): void {
-		const currentText = this.textModel.getValue(EndOfLinePreference.LF);
+	private async setText(newText: string): Promise<void> {
+		const model = await this.textModel;
+		const currentText = model.getValue(EndOfLinePreference.LF);
 		if (newText === currentText) {
 			return;
 		}
 
 		if (newText.startsWith(currentText)) {
 			const text = newText.slice(currentText.length);
-			const lastLine = this.textModel.getLineCount();
-			const lastCol = this.textModel.getLineMaxColumn(lastLine);
-			this.textModel.applyEdits([{ range: new Range(lastLine, lastCol, lastLine, lastCol), text }]);
+			const lastLine = model.getLineCount();
+			const lastCol = model.getLineMaxColumn(lastLine);
+			model.applyEdits([{ range: new Range(lastLine, lastCol, lastLine, lastCol), text }]);
 		} else {
 			// console.log(`Failed to optimize setText`);
-			this.textModel.setValue(newText);
+			model.setValue(newText);
 		}
 	}
 
-	private setLanguage(vscodeLanguageId: string | undefined): void {
-		this.textModel.setLanguage(vscodeLanguageId ?? PLAINTEXT_LANGUAGE_ID);
+	private async setLanguage(vscodeLanguageId: string | undefined): Promise<void> {
+		(await this.textModel).setLanguage(vscodeLanguageId ?? PLAINTEXT_LANGUAGE_ID);
 	}
 }
 
@@ -501,5 +512,25 @@ export class LocalFileCodeBlockPart extends BaseCodeBlockPart<ILocalFileCodeBloc
 			element: data.element,
 			languageId: model.getLanguageId()
 		} satisfies ICodeBlockActionContext;
+	}
+}
+
+
+export class ChatCodeBlockContentProvider extends Disposable implements ITextModelContentProvider {
+
+	constructor(
+		@ITextModelService textModelService: ITextModelService,
+		@IModelService private readonly _modelService: IModelService,
+	) {
+		super();
+		this._register(textModelService.registerTextModelContentProvider(Schemas.vscodeChatCodeBlock, this));
+	}
+
+	async provideTextContent(resource: URI): Promise<ITextModel | null> {
+		const existing = this._modelService.getModel(resource);
+		if (existing) {
+			return existing;
+		}
+		return this._modelService.createModel('', null, resource);
 	}
 }


### PR DESCRIPTION
Hooks up code blocks to the `ITextModelService` so that link decorations work as well
