### PR TITLE
Disable some share context menus in editor playground

### DIFF
--- a/extensions/github/package.json
+++ b/extensions/github/package.json
@@ -98,14 +98,14 @@
       "editor/context/share": [
         {
           "command": "github.copyVscodeDevLink",
-          "when": "github.hasGitHubRepo && resourceScheme != untitled && remoteName != 'codespaces'",
+          "when": "github.hasGitHubRepo && resourceScheme != untitled && !isInEmbeddedEditor && remoteName != 'codespaces'",
           "group": "0_vscode@0"
         }
       ],
       "explorer/context/share": [
         {
           "command": "github.copyVscodeDevLinkWithoutRange",
-          "when": "github.hasGitHubRepo && resourceScheme != untitled && remoteName != 'codespaces'",
+          "when": "github.hasGitHubRepo && resourceScheme != untitled && !isInEmbeddedEditor && remoteName != 'codespaces'",
           "group": "0_vscode@0"
         }
       ],


### PR DESCRIPTION
@joyceerhl I believe there are still some `share` and `copy as` menu items coming from the GitHub extension. Can you look into adopting this context key there too?

![Screenshot 2024-02-06 at 10 51 24 PM](https://github.com/microsoft/vscode/assets/12821956/b81fe101-ad12-47d7-a783-1b922cd24b88)


As context, I'm reusing this context key for code blocks inside of the chat widget. Those code blocks cannot be shared as GitHub links as they aren't part of the repo