### PR TITLE
Monokai Dimmed theme: LESS syntax highlighting colors very different in v1.86.0

### DIFF
--- a/extensions/theme-monokai-dimmed/themes/dimmed-monokai-color-theme.json
+++ b/extensions/theme-monokai-dimmed/themes/dimmed-monokai-color-theme.json
@@ -366,7 +366,7 @@
 		},
 		{
 			"name": "CSS ID",
-			"scope": "meta.selector.css entity.other.attribute-name.id",
+			"scope": "meta.selector entity.other.attribute-name.id",
 			"settings": {
 				"fontStyle": "",
 				"foreground": "#9872A2"
@@ -374,7 +374,7 @@
 		},
 		{
 			"name": "CSS Property Name",
-			"scope": "support.type.property-name.css",
+			"scope": "support.type.property-name",
 			"settings": {
 				"fontStyle": "",
 				"foreground": "#676867"
@@ -382,7 +382,7 @@
 		},
 		{
 			"name": "CSS Property Value",
-			"scope": "meta.property-group support.constant.property-value.css, meta.property-value support.constant.property-value.css",
+			"scope": "meta.property-group support.constant.property-value, meta.property-value support.constant.property-value",
 			"settings": {
 				"fontStyle": "",
 				"foreground": "#C7444A"


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/204509

1.84:
![image](https://github.com/microsoft/vscode/assets/6461412/84b324f0-c677-4f4f-91f2-97b5d7c4655d)

after fix:
![image](https://github.com/microsoft/vscode/assets/6461412/acee0163-eae8-4270-a6da-3e6419897b02)


Note there are still minor differences (e.g. the color functions `lighten`) but that's because of the new less grammar.
It now classifies these as functions, which IMO is correct. Before: property values.