### PR TITLE
Fix: GLIBCXX version detection bug in check-requirements-linux.sh (issue #204186)

### DIFF
--- a/resources/server/bin/helpers/check-requirements-linux.sh
+++ b/resources/server/bin/helpers/check-requirements-linux.sh
@@ -65,10 +65,10 @@ else
 fi
 
 if [ -n "$libstdcpp_path" ]; then
-        # Extracts the version number from the path, e.g. libstdc++.so.6.0.22 -> 6.0.22
-        # which is then compared based on the fact that release versioning and symbol versioning
-        # are aligned for libstdc++. Refs https://gcc.gnu.org/onlinedocs/libstdc++/manual/abi.html
-        # (i-e) GLIBCXX_3.4.<release> is provided by libstdc++.so.6.y.<release>
+# Extracts the version number from the path, e.g. libstdc++.so.6.0.22 -> 6.0.22
+# which is then compared based on the fact that release versioning and symbol versioning
+# are aligned for libstdc++. Refs https://gcc.gnu.org/onlinedocs/libstdc++/manual/abi.html
+# (i-e) GLIBCXX_3.4.<release> is provided by libstdc++.so.6.y.<release>
     libstdcpp_real_path=$(readlink -f "$libstdcpp_path")
     libstdcpp_version=$(strings "$libstdcpp_real_path" | grep -o 'GLIBCXX_[0-9]*\.[0-9]*\.[0-9]*' | sort -V | tail -1)
     libstdcpp_version_number=$(echo "$libstdcpp_version" | sed 's/GLIBCXX_//')

--- a/resources/server/bin/helpers/check-requirements-linux.sh
+++ b/resources/server/bin/helpers/check-requirements-linux.sh
@@ -68,7 +68,7 @@ if [ -n "$libstdcpp_path" ]; then
     libstdcpp_real_path=$(readlink -f "$libstdcpp_path")
     libstdcpp_version=$(strings "$libstdcpp_real_path" | grep -o 'GLIBCXX_[0-9]*\.[0-9]*\.[0-9]*' | sort -V | tail -1)
     libstdcpp_version_number=$(echo "$libstdcpp_version" | sed 's/GLIBCXX_//')
-    if [ "$(printf '%s\n' "3.4.25" "$libstdcpp_version_number" | sort -V | head -n1)" = "3.4.25" ]; then
+    if [ "$(printf '%s\n' "3.4.24" "$libstdcpp_version_number" | sort -V | head -n1)" = "3.4.24" ]; then
         found_required_glibcxx=1
     else
         echo "Warning: Missing GLIBCXX >= 3.4.25! from $libstdcpp_real_path"

--- a/resources/server/bin/helpers/check-requirements-linux.sh
+++ b/resources/server/bin/helpers/check-requirements-linux.sh
@@ -66,7 +66,7 @@ fi
 
 if [ -n "$libstdcpp_path" ]; then
     libstdcpp_real_path=$(readlink -f "$libstdcpp_path")
-    libstdcpp_version=$(strings "$libstdcpp_real_path" | grep -o 'GLIBCXX_[0-9]*\.[0-9]*\.[0-9]*' | sort -V | tail -1)
+	libstdcpp_version=$(grep -ao 'GLIBCXX_[0-9]*\.[0-9]*\.[0-9]*' "$libstdcpp_real_path" | sort -V | tail -1)
     libstdcpp_version_number=$(echo "$libstdcpp_version" | sed 's/GLIBCXX_//')
     if [ "$(printf '%s\n' "3.4.24" "$libstdcpp_version_number" | sort -V | head -n1)" = "3.4.24" ]; then
         found_required_glibcxx=1

--- a/resources/server/bin/helpers/check-requirements-linux.sh
+++ b/resources/server/bin/helpers/check-requirements-linux.sh
@@ -65,13 +65,14 @@ else
 fi
 
 if [ -n "$libstdcpp_path" ]; then
-	# Extracts the version number from the path, e.g. libstdc++.so.6.0.22 -> 6.0.22
-	# which is then compared based on the fact that release versioning and symbol versioning
-	# are aligned for libstdc++. Refs https://gcc.gnu.org/onlinedocs/libstdc++/manual/abi.html
-	# (i-e) GLIBCXX_3.4.<release> is provided by libstdc++.so.6.y.<release>
+        # Extracts the version number from the path, e.g. libstdc++.so.6.0.22 -> 6.0.22
+        # which is then compared based on the fact that release versioning and symbol versioning
+        # are aligned for libstdc++. Refs https://gcc.gnu.org/onlinedocs/libstdc++/manual/abi.html
+        # (i-e) GLIBCXX_3.4.<release> is provided by libstdc++.so.6.y.<release>
     libstdcpp_real_path=$(readlink -f "$libstdcpp_path")
-    libstdcpp_version=$(echo "$libstdcpp_real_path" | awk -F'\\.so\\.' '{print $NF}')
-    if [ "$(printf '%s\n' "6.0.25" "$libstdcpp_version" | sort -V | head -n1)" = "6.0.25" ]; then
+    libstdcpp_version=$(strings "$libstdcpp_real_path" | grep -o 'GLIBCXX_[0-9]*\.[0-9]*\.[0-9]*' | sort -V | tail -1)
+    libstdcpp_version_number=$(echo "$libstdcpp_version" | sed 's/GLIBCXX_//')
+    if [ "$(printf '%s\n' "3.4.25" "$libstdcpp_version_number" | sort -V | head -n1)" = "3.4.25" ]; then
         found_required_glibcxx=1
     else
         echo "Warning: Missing GLIBCXX >= 3.4.25! from $libstdcpp_real_path"

--- a/resources/server/bin/helpers/check-requirements-linux.sh
+++ b/resources/server/bin/helpers/check-requirements-linux.sh
@@ -57,11 +57,7 @@ if [ "$OS_ID" != "alpine" ]; then
         else
             libstdcpp_path=$(echo "$libstdcpp_paths" | awk '{print $NF}')
         fi
-    fi
-fi
-
-if [ -z "$libstdcpp_path" ]; then
-    if [ -f /usr/lib/libstdc++.so.6 ]; then
+    elif [ -f /usr/lib/libstdc++.so.6 ]; then
 	    # Typical path
 	    libstdcpp_path='/usr/lib/libstdc++.so.6'
     elif [ -f /usr/lib64/libstdc++.so.6 ]; then
@@ -70,19 +66,26 @@ if [ -z "$libstdcpp_path" ]; then
     else
 	    echo "Warning: Can't find libstdc++.so or ldconfig, can't verify libstdc++ version"
     fi
-fi
 
-while [ -n "$libstdcpp_path" ]; do
-    libstdcpp_path_line=$(echo "$libstdcpp_path" | head -n1)
-    libstdcpp_real_path=$(readlink -f "$libstdcpp_path_line")
-    libstdcpp_version=$(grep -ao 'GLIBCXX_[0-9]*\.[0-9]*\.[0-9]*' "$libstdcpp_real_path" | sort -V | tail -1)
-    libstdcpp_version_number=$(echo "$libstdcpp_version" | sed 's/GLIBCXX_//')
-    if [ "$(printf '%s\n' "3.4.24" "$libstdcpp_version_number" | sort -V | head -n1)" = "3.4.24" ]; then
-        found_required_glibcxx=1
-        break
-    fi
-    libstdcpp_path=$(echo "$libstdcpp_path" | tail -n +2)    # remove first line
-done
+    while [ -n "$libstdcpp_path" ]; do
+	    # Extracts the version number from the path, e.g. libstdc++.so.6.0.22 -> 6.0.22
+	    # which is then compared based on the fact that release versioning and symbol versioning
+	    # are aligned for libstdc++. Refs https://gcc.gnu.org/onlinedocs/libstdc++/manual/abi.html
+	    # (i-e) GLIBCXX_3.4.<release> is provided by libstdc++.so.6.y.<release>
+        libstdcpp_path_line=$(echo "$libstdcpp_path" | head -n1)
+        libstdcpp_real_path=$(readlink -f "$libstdcpp_path_line")
+        libstdcpp_version=$(grep -ao 'GLIBCXX_[0-9]*\.[0-9]*\.[0-9]*' "$libstdcpp_real_path" | sort -V | tail -1)
+        libstdcpp_version_number=$(echo "$libstdcpp_version" | sed 's/GLIBCXX_//')
+        if [ "$(printf '%s\n' "3.4.24" "$libstdcpp_version_number" | sort -V | head -n1)" = "3.4.24" ]; then
+            found_required_glibcxx=1
+            break
+        fi
+        libstdcpp_path=$(echo "$libstdcpp_path" | tail -n +2)    # remove first line
+    done
+else
+    echo "Warning: alpine distro detected, skipping GLIBCXX check"
+    found_required_glibcxx=1
+fi
 if [ "$found_required_glibcxx" = "0" ]; then
     echo "Warning: Missing GLIBCXX >= 3.4.25! from $libstdcpp_real_path"
 fi

--- a/resources/server/bin/helpers/check-requirements-linux.sh
+++ b/resources/server/bin/helpers/check-requirements-linux.sh
@@ -65,10 +65,6 @@ else
 fi
 
 if [ -n "$libstdcpp_path" ]; then
-# Extracts the version number from the path, e.g. libstdc++.so.6.0.22 -> 6.0.22
-# which is then compared based on the fact that release versioning and symbol versioning
-# are aligned for libstdc++. Refs https://gcc.gnu.org/onlinedocs/libstdc++/manual/abi.html
-# (i-e) GLIBCXX_3.4.<release> is provided by libstdc++.so.6.y.<release>
     libstdcpp_real_path=$(readlink -f "$libstdcpp_path")
     libstdcpp_version=$(strings "$libstdcpp_real_path" | grep -o 'GLIBCXX_[0-9]*\.[0-9]*\.[0-9]*' | sort -V | tail -1)
     libstdcpp_version_number=$(echo "$libstdcpp_version" | sed 's/GLIBCXX_//')


### PR DESCRIPTION
- Existing detection scripts simply use the `awk` command to record the version number in the `libstdc++.so` filename, 
- but in some specific versions of glibc++, the detailed version number is not indicated in the filename. 
  - Like the issue  #204186 , the OS version (Ubuntu 22.04) supports `GLIBCXX_3.4.25` but fails version checking because the filename is simply `libstdc++.so.6`, 
  - and we have reproduced this issue when connecting to the Ubuntu 22.04 server using ssh. 
- Instead of simply using the `awk` command to filter file names, we use a script to simulate the `strings /usr/lib/x86_64-linux-gnu/libstdc++.so.6 | grep GLIBCXX` operation, which reads the highest-supported version number of GLIBCXX, and determines whether the existing environment supports the minimum VSCode requirements. instead of simply filtering filenames with the `awk` command.
