### PR TITLE
Introduce a IWebviewUriService for webview resource URIs

### DIFF
--- a/src/vs/workbench/api/common/extHost.api.impl.ts
+++ b/src/vs/workbench/api/common/extHost.api.impl.ts
@@ -102,6 +102,7 @@ import { ExtHostWebviewViews } from 'vs/workbench/api/common/extHostWebviewView'
 import { IExtHostWindow } from 'vs/workbench/api/common/extHostWindow';
 import { IExtHostWorkspace } from 'vs/workbench/api/common/extHostWorkspace';
 import { DebugConfigurationProviderTriggerKind } from 'vs/workbench/contrib/debug/common/debug';
+import { IWebviewUriService } from 'vs/workbench/contrib/webview/common/webview';
 import { ExtensionDescriptionRegistry } from 'vs/workbench/services/extensions/common/extensionDescriptionRegistry';
 import { UIKind } from 'vs/workbench/services/extensions/common/extensionHostProtocol';
 import { checkProposedApiEnabled, isProposedApiEnabled } from 'vs/workbench/services/extensions/common/extensions';
@@ -143,6 +144,7 @@ export function createApiFactoryAndRegisterActors(accessor: ServicesAccessor): I
 	const extHostSecretState = accessor.get(IExtHostSecretState);
 	const extHostEditorTabs = accessor.get(IExtHostEditorTabs);
 	const extHostManagedSockets = accessor.get(IExtHostManagedSockets);
+	const webviewUriService = accessor.get(IWebviewUriService);
 
 	// register addressable instances
 	rpcProtocol.set(ExtHostContext.ExtHostFileSystemInfo, extHostFileSystemInfo);
@@ -177,12 +179,12 @@ export function createApiFactoryAndRegisterActors(accessor: ServicesAccessor): I
 	const extHostNotebook = rpcProtocol.set(ExtHostContext.ExtHostNotebook, new ExtHostNotebookController(rpcProtocol, extHostCommands, extHostDocumentsAndEditors, extHostDocuments, extHostConsumerFileSystem, extHostSearch));
 	const extHostNotebookDocuments = rpcProtocol.set(ExtHostContext.ExtHostNotebookDocuments, new ExtHostNotebookDocuments(extHostNotebook));
 	const extHostNotebookEditors = rpcProtocol.set(ExtHostContext.ExtHostNotebookEditors, new ExtHostNotebookEditors(extHostLogService, extHostNotebook));
-	const extHostNotebookKernels = rpcProtocol.set(ExtHostContext.ExtHostNotebookKernels, new ExtHostNotebookKernels(rpcProtocol, initData, extHostNotebook, extHostCommands, extHostLogService));
+	const extHostNotebookKernels = rpcProtocol.set(ExtHostContext.ExtHostNotebookKernels, new ExtHostNotebookKernels(rpcProtocol, initData, extHostNotebook, extHostCommands, extHostLogService, webviewUriService));
 	const extHostNotebookRenderers = rpcProtocol.set(ExtHostContext.ExtHostNotebookRenderers, new ExtHostNotebookRenderers(rpcProtocol, extHostNotebook));
 	const extHostNotebookDocumentSaveParticipant = rpcProtocol.set(ExtHostContext.ExtHostNotebookDocumentSaveParticipant, new ExtHostNotebookDocumentSaveParticipant(extHostLogService, extHostNotebook, rpcProtocol.getProxy(MainContext.MainThreadBulkEdits)));
 	const extHostEditors = rpcProtocol.set(ExtHostContext.ExtHostEditors, new ExtHostEditors(rpcProtocol, extHostDocumentsAndEditors));
 	const extHostTreeViews = rpcProtocol.set(ExtHostContext.ExtHostTreeViews, new ExtHostTreeViews(rpcProtocol.getProxy(MainContext.MainThreadTreeViews), extHostCommands, extHostLogService));
-	const extHostEditorInsets = rpcProtocol.set(ExtHostContext.ExtHostEditorInsets, new ExtHostEditorInsets(rpcProtocol.getProxy(MainContext.MainThreadEditorInsets), extHostEditors, initData.remote));
+	const extHostEditorInsets = rpcProtocol.set(ExtHostContext.ExtHostEditorInsets, new ExtHostEditorInsets(rpcProtocol.getProxy(MainContext.MainThreadEditorInsets), extHostEditors, initData.remote, webviewUriService));
 	const extHostDiagnostics = rpcProtocol.set(ExtHostContext.ExtHostDiagnostics, new ExtHostDiagnostics(rpcProtocol, extHostLogService, extHostFileSystemInfo, extHostDocumentsAndEditors));
 	const extHostLanguages = rpcProtocol.set(ExtHostContext.ExtHostLanguages, new ExtHostLanguages(rpcProtocol, extHostDocuments, extHostCommands.converter, uriTransformer));
 	const extHostLanguageFeatures = rpcProtocol.set(ExtHostContext.ExtHostLanguageFeatures, new ExtHostLanguageFeatures(rpcProtocol, uriTransformer, extHostDocuments, extHostCommands, extHostDiagnostics, extHostLogService, extHostApiDeprecation, extHostTelemetry));
@@ -198,7 +200,7 @@ export function createApiFactoryAndRegisterActors(accessor: ServicesAccessor): I
 	const extHostTheming = rpcProtocol.set(ExtHostContext.ExtHostTheming, new ExtHostTheming(rpcProtocol));
 	const extHostAuthentication = rpcProtocol.set(ExtHostContext.ExtHostAuthentication, new ExtHostAuthentication(rpcProtocol));
 	const extHostTimeline = rpcProtocol.set(ExtHostContext.ExtHostTimeline, new ExtHostTimeline(rpcProtocol, extHostCommands));
-	const extHostWebviews = rpcProtocol.set(ExtHostContext.ExtHostWebviews, new ExtHostWebviews(rpcProtocol, initData.remote, extHostWorkspace, extHostLogService, extHostApiDeprecation));
+	const extHostWebviews = rpcProtocol.set(ExtHostContext.ExtHostWebviews, new ExtHostWebviews(rpcProtocol, initData.remote, extHostWorkspace, extHostLogService, extHostApiDeprecation, webviewUriService));
 	const extHostWebviewPanels = rpcProtocol.set(ExtHostContext.ExtHostWebviewPanels, new ExtHostWebviewPanels(rpcProtocol, extHostWebviews, extHostWorkspace));
 	const extHostCustomEditors = rpcProtocol.set(ExtHostContext.ExtHostCustomEditors, new ExtHostCustomEditors(rpcProtocol, extHostDocuments, extensionStoragePaths, extHostWebviews, extHostWebviewPanels));
 	const extHostWebviewViews = rpcProtocol.set(ExtHostContext.ExtHostWebviewViews, new ExtHostWebviewViews(rpcProtocol, extHostWebviews));

--- a/src/vs/workbench/api/common/extHostCodeInsets.ts
+++ b/src/vs/workbench/api/common/extHostCodeInsets.ts
@@ -8,7 +8,7 @@ import { DisposableStore } from 'vs/base/common/lifecycle';
 import { IExtensionDescription } from 'vs/platform/extensions/common/extensions';
 import { ExtHostTextEditor } from 'vs/workbench/api/common/extHostTextEditor';
 import { ExtHostEditors } from 'vs/workbench/api/common/extHostTextEditors';
-import { asWebviewUri, webviewGenericCspSource, WebviewRemoteInfo } from 'vs/workbench/contrib/webview/common/webview';
+import { IWebviewUriService, WebviewRemoteInfo } from 'vs/workbench/contrib/webview/common/webview';
 import type * as vscode from 'vscode';
 import { ExtHostEditorInsetsShape, MainThreadEditorInsetsShape } from './extHost.protocol';
 
@@ -21,7 +21,8 @@ export class ExtHostEditorInsets implements ExtHostEditorInsetsShape {
 	constructor(
 		private readonly _proxy: MainThreadEditorInsetsShape,
 		private readonly _editors: ExtHostEditors,
-		private readonly _remoteInfo: WebviewRemoteInfo
+		private readonly _remoteInfo: WebviewRemoteInfo,
+		@IWebviewUriService private readonly _webviewUriService: IWebviewUriService,
 	) {
 
 		// dispose editor inset whenever the hosting editor goes away
@@ -64,11 +65,11 @@ export class ExtHostEditorInsets implements ExtHostEditorInsetsShape {
 			private _options: vscode.WebviewOptions = Object.create(null);
 
 			asWebviewUri(resource: vscode.Uri): vscode.Uri {
-				return asWebviewUri(resource, that._remoteInfo);
+				return that._webviewUriService.asWebviewUri(resource, that._remoteInfo);
 			}
 
 			get cspSource(): string {
-				return webviewGenericCspSource;
+				return that._webviewUriService.cspSource;
 			}
 
 			set options(value: vscode.WebviewOptions) {

--- a/src/vs/workbench/api/common/extHostNotebookKernels.ts
+++ b/src/vs/workbench/api/common/extHostNotebookKernels.ts
@@ -19,7 +19,7 @@ import { ExtHostNotebookController } from 'vs/workbench/api/common/extHostNotebo
 import { ExtHostCell, ExtHostNotebookDocument } from 'vs/workbench/api/common/extHostNotebookDocument';
 import * as extHostTypeConverters from 'vs/workbench/api/common/extHostTypeConverters';
 import { NotebookCellExecutionState as ExtHostNotebookCellExecutionState, NotebookCellOutput, NotebookControllerAffinity2, NotebookVariablesRequestKind } from 'vs/workbench/api/common/extHostTypes';
-import { asWebviewUri } from 'vs/workbench/contrib/webview/common/webview';
+import { IWebviewUriService } from 'vs/workbench/contrib/webview/common/webview';
 import { INotebookKernelSourceAction, NotebookCellExecutionState } from 'vs/workbench/contrib/notebook/common/notebookCommon';
 import { CellExecutionUpdateType } from 'vs/workbench/contrib/notebook/common/notebookExecutionService';
 import { checkProposedApiEnabled } from 'vs/workbench/services/extensions/common/extensions';
@@ -64,6 +64,7 @@ export class ExtHostNotebookKernels implements ExtHostNotebookKernelsShape {
 		private readonly _extHostNotebook: ExtHostNotebookController,
 		private _commands: ExtHostCommands,
 		@ILogService private readonly _logService: ILogService,
+		@IWebviewUriService private readonly _webviewUriService: IWebviewUriService,
 	) {
 		this._proxy = mainContext.getProxy(MainContext.MainThreadNotebookKernels);
 
@@ -267,7 +268,7 @@ export class ExtHostNotebookKernels implements ExtHostNotebookKernelsShape {
 			},
 			asWebviewUri(uri: URI) {
 				checkProposedApiEnabled(extension, 'notebookMessaging');
-				return asWebviewUri(uri, that._initData.remote);
+				return that._webviewUriService.asWebviewUri(uri, that._initData.remote);
 			},
 		};
 

--- a/src/vs/workbench/api/common/extensionHostMain.ts
+++ b/src/vs/workbench/api/common/extensionHostMain.ts
@@ -23,6 +23,7 @@ import { IURITransformerService, URITransformerService } from 'vs/workbench/api/
 import { IExtHostExtensionService, IHostUtils } from 'vs/workbench/api/common/extHostExtensionService';
 import { IExtHostTelemetry } from 'vs/workbench/api/common/extHostTelemetry';
 import { Mutable } from 'vs/base/common/types';
+import { BaseWebviewUriService, IWebviewUriService } from 'vs/workbench/contrib/webview/common/webview';
 
 export interface IExitFn {
 	(code?: number): any;
@@ -158,6 +159,7 @@ export class ExtensionHostMain {
 		services.set(IExtHostRpcService, new ExtHostRpcService(this._rpcProtocol));
 		services.set(IURITransformerService, new URITransformerService(uriTransformer));
 		services.set(IHostUtils, hostUtils);
+		services.set(IWebviewUriService, new BaseWebviewUriService(initData.remote.resourceBaseHost));
 
 		const instaService: IInstantiationService = new InstantiationService(services, true);
 

--- a/src/vs/workbench/api/test/browser/extHostNotebookKernel.test.ts
+++ b/src/vs/workbench/api/test/browser/extHostNotebookKernel.test.ts
@@ -31,6 +31,7 @@ import { ExtHostFileSystemInfo } from 'vs/workbench/api/common/extHostFileSystem
 import { ensureNoDisposablesAreLeakedInTestSuite } from 'vs/base/test/common/utils';
 import { ExtHostSearch } from 'vs/workbench/api/common/extHostSearch';
 import { URITransformerService } from 'vs/workbench/api/common/extHostUriTransformerService';
+import { DefaultWebviewUriService } from 'vs/workbench/contrib/webview/common/webview';
 
 suite('NotebookKernel', function () {
 	let rpcProtocol: TestRPCProtocol;
@@ -152,7 +153,8 @@ suite('NotebookKernel', function () {
 			new class extends mock<IExtHostInitDataService>() { },
 			extHostNotebooks,
 			extHostCommands,
-			new NullLogService()
+			new NullLogService(),
+			new DefaultWebviewUriService(),
 		);
 	});
 

--- a/src/vs/workbench/api/test/browser/extHostTelemetry.test.ts
+++ b/src/vs/workbench/api/test/browser/extHostTelemetry.test.ts
@@ -50,7 +50,8 @@ suite('ExtHostTelemetry', function () {
 	const mockRemote = {
 		authority: 'test',
 		isRemote: false,
-		connectionData: null
+		connectionData: null,
+		resourceBaseHost: undefined,
 	};
 
 	const mockExtensionIdentifier: IExtensionDescription = {

--- a/src/vs/workbench/browser/web.api.ts
+++ b/src/vs/workbench/browser/web.api.ts
@@ -154,6 +154,13 @@ export interface IWorkbenchConstructionOptions {
 	readonly webviewEndpoint?: string;
 
 	/**
+	 * The base host from which resource URLs loaded in iframe content ("webview")
+	 * are created. The host in itself is never contacted directly as requests are
+	 * intercepted by a service worker however it has implication for CSP policies.
+	 */
+	readonly webviewResourceBaseHost?: string;
+
+	/**
 	 * A factory for web sockets.
 	 */
 	readonly webSocketFactory?: IWebSocketFactory;

--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView.ts
@@ -52,7 +52,7 @@ import { IScopedRendererMessaging } from 'vs/workbench/contrib/notebook/common/n
 import { INotebookService } from 'vs/workbench/contrib/notebook/common/notebookService';
 import { IWebviewElement, IWebviewService, WebviewContentPurpose, WebviewOriginStore } from 'vs/workbench/contrib/webview/browser/webview';
 import { WebviewWindowDragMonitor } from 'vs/workbench/contrib/webview/browser/webviewWindowDragMonitor';
-import { asWebviewUri, webviewGenericCspSource } from 'vs/workbench/contrib/webview/common/webview';
+import { IWebviewUriService } from 'vs/workbench/contrib/webview/common/webview';
 import { IEditorGroup, IEditorGroupsService } from 'vs/workbench/services/editor/common/editorGroupsService';
 import { IWorkbenchEnvironmentService } from 'vs/workbench/services/environment/common/environmentService';
 import { IPathService } from 'vs/workbench/services/path/common/pathService';
@@ -178,7 +178,8 @@ export class BackLayerWebView<T extends ICommonCellInfo> extends Themable {
 		@IPathService private readonly pathService: IPathService,
 		@INotebookLoggingService private readonly notebookLogService: INotebookLoggingService,
 		@IThemeService themeService: IThemeService,
-		@ITelemetryService private readonly telemetryService: ITelemetryService
+		@ITelemetryService private readonly telemetryService: ITelemetryService,
+		@IWebviewUriService private readonly webviewUriService: IWebviewUriService,
 	) {
 		super(themeService);
 
@@ -304,6 +305,7 @@ export class BackLayerWebView<T extends ICommonCellInfo> extends Themable {
 		const enableCsp = this.configurationService.getValue('notebook.experimental.enableCsp');
 		const currentHighlight = this.getColor(editorFindMatch);
 		const findMatchHighlight = this.getColor(editorFindMatchHighlight);
+		const webviewGenericCspSource = this.webviewUriService.cspSource;
 		return /* html */`
 		<html lang="en">
 			<head>
@@ -488,7 +490,7 @@ export class BackLayerWebView<T extends ICommonCellInfo> extends Themable {
 	}
 
 	private asWebviewUri(uri: URI, fromExtension: URI | undefined) {
-		return asWebviewUri(uri, fromExtension?.scheme === Schemas.vscodeRemote ? { isRemote: true, authority: fromExtension.authority } : undefined);
+		return this.webviewUriService.asWebviewUri(uri, fromExtension?.scheme === Schemas.vscodeRemote ? { isRemote: true, authority: fromExtension.authority } : undefined);
 	}
 
 	postKernelMessage(message: any) {

--- a/src/vs/workbench/contrib/webview/browser/webview.ts
+++ b/src/vs/workbench/contrib/webview/browser/webview.ts
@@ -18,6 +18,8 @@ import { createDecorator } from 'vs/platform/instantiation/common/instantiation'
 import { IStorageService, StorageScope, StorageTarget } from 'vs/platform/storage/common/storage';
 import { IWebviewPortMapping } from 'vs/platform/webview/common/webviewPortMapping';
 import { Memento, MementoObject } from 'vs/workbench/common/memento';
+import { BaseWebviewUriService } from 'vs/workbench/contrib/webview/common/webview';
+import { IBrowserWorkbenchEnvironmentService } from 'vs/workbench/services/environment/browser/environmentService';
 
 /**
  * Set when the find widget in a webview in a webview is visible.
@@ -387,5 +389,11 @@ export class ExtensionKeyedWebviewOriginStore {
 
 	public getOrigin(viewType: string, extId: ExtensionIdentifier): string {
 		return this._store.getOrigin(viewType, extId.value);
+	}
+}
+
+export class BrowserWebviewUriService extends BaseWebviewUriService {
+	constructor(@IBrowserWorkbenchEnvironmentService workbenchEnvironmentService: IBrowserWorkbenchEnvironmentService) {
+		super(workbenchEnvironmentService.webviewResourceBaseHost);
 	}
 }

--- a/src/vs/workbench/contrib/webview/browser/webview.web.contribution.ts
+++ b/src/vs/workbench/contrib/webview/browser/webview.web.contribution.ts
@@ -4,7 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { InstantiationType, registerSingleton } from 'vs/platform/instantiation/common/extensions';
-import { IWebviewService } from 'vs/workbench/contrib/webview/browser/webview';
+import { BrowserWebviewUriService, IWebviewService } from 'vs/workbench/contrib/webview/browser/webview';
 import { WebviewService } from './webviewService';
+import { IWebviewUriService } from 'vs/workbench/contrib/webview/common/webview';
 
 registerSingleton(IWebviewService, WebviewService, InstantiationType.Delayed);
+registerSingleton(IWebviewUriService, BrowserWebviewUriService, InstantiationType.Delayed);

--- a/src/vs/workbench/contrib/webview/browser/webviewElement.ts
+++ b/src/vs/workbench/contrib/webview/browser/webviewElement.ts
@@ -35,7 +35,7 @@ import { WebviewThemeDataProvider } from 'vs/workbench/contrib/webview/browser/t
 import { areWebviewContentOptionsEqual, IWebview, WebviewContentOptions, WebviewExtensionDescription, WebviewInitInfo, WebviewMessageReceivedEvent, WebviewOptions } from 'vs/workbench/contrib/webview/browser/webview';
 import { WebviewFindDelegate, WebviewFindWidget } from 'vs/workbench/contrib/webview/browser/webviewFindWidget';
 import { FromWebviewMessage, KeyEvent, ToWebviewMessage } from 'vs/workbench/contrib/webview/browser/webviewMessages';
-import { decodeAuthority, webviewGenericCspSource, webviewRootResourceAuthority } from 'vs/workbench/contrib/webview/common/webview';
+import { decodeAuthority, IWebviewUriService } from 'vs/workbench/contrib/webview/common/webview';
 import { IWorkbenchEnvironmentService } from 'vs/workbench/services/environment/common/environmentService';
 import { $window } from 'vs/base/browser/window';
 
@@ -154,6 +154,7 @@ export class WebviewElement extends Disposable implements IWebview, WebviewFindD
 		@ITunnelService private readonly _tunnelService: ITunnelService,
 		@IInstantiationService instantiationService: IInstantiationService,
 		@IAccessibilityService private readonly _accessibilityService: IAccessibilityService,
+		@IWebviewUriService private readonly _webviewUriService: IWebviewUriService,
 	) {
 		super();
 
@@ -459,7 +460,7 @@ export class WebviewElement extends Disposable implements IWebview, WebviewFindD
 			swVersion: String(this._expectedServiceWorkerVersion),
 			extensionId: extension?.id.value ?? '',
 			platform: this.platform,
-			'vscode-resource-base-authority': webviewRootResourceAuthority,
+			'vscode-resource-base-authority': this._webviewUriService.resourceAuthority,
 			parentOrigin: $window.origin,
 		};
 
@@ -648,7 +649,7 @@ export class WebviewElement extends Disposable implements IWebview, WebviewFindD
 				allowForms: this._content.options.allowForms ?? allowScripts, // For back compat, we allow forms by default when scripts are enabled
 			},
 			state: this._content.state,
-			cspSource: webviewGenericCspSource,
+			cspSource: this._webviewUriService.cspSource,
 			confirmBeforeClose: this._confirmBeforeClose,
 		});
 	}

--- a/src/vs/workbench/contrib/webview/electron-sandbox/webview.contribution.ts
+++ b/src/vs/workbench/contrib/webview/electron-sandbox/webview.contribution.ts
@@ -6,9 +6,11 @@
 import { registerAction2 } from 'vs/platform/actions/common/actions';
 import { InstantiationType, registerSingleton } from 'vs/platform/instantiation/common/extensions';
 import { IWebviewService } from 'vs/workbench/contrib/webview/browser/webview';
+import { IWebviewUriService, DefaultWebviewUriService } from 'vs/workbench/contrib/webview/common/webview';
 import * as webviewCommands from 'vs/workbench/contrib/webview/electron-sandbox/webviewCommands';
 import { ElectronWebviewService } from 'vs/workbench/contrib/webview/electron-sandbox/webviewService';
 
 registerSingleton(IWebviewService, ElectronWebviewService, InstantiationType.Delayed);
+registerSingleton(IWebviewUriService, DefaultWebviewUriService, InstantiationType.Delayed);
 
 registerAction2(webviewCommands.OpenWebviewDeveloperToolsAction);

--- a/src/vs/workbench/contrib/webview/electron-sandbox/webviewElement.ts
+++ b/src/vs/workbench/contrib/webview/electron-sandbox/webviewElement.ts
@@ -24,6 +24,7 @@ import { FindInFrameOptions, IWebviewManagerService } from 'vs/platform/webview/
 import { WebviewThemeDataProvider } from 'vs/workbench/contrib/webview/browser/themeing';
 import { WebviewInitInfo } from 'vs/workbench/contrib/webview/browser/webview';
 import { WebviewElement } from 'vs/workbench/contrib/webview/browser/webviewElement';
+import { IWebviewUriService } from 'vs/workbench/contrib/webview/common/webview';
 import { WindowIgnoreMenuShortcutsManager } from 'vs/workbench/contrib/webview/electron-sandbox/windowIgnoreMenuShortcutsManager';
 import { IWorkbenchEnvironmentService } from 'vs/workbench/services/environment/common/environmentService';
 
@@ -58,10 +59,11 @@ export class ElectronWebviewElement extends WebviewElement {
 		@INativeHostService private readonly _nativeHostService: INativeHostService,
 		@IInstantiationService instantiationService: IInstantiationService,
 		@IAccessibilityService accessibilityService: IAccessibilityService,
+		@IWebviewUriService webviewUriService: IWebviewUriService,
 	) {
 		super(initInfo, webviewThemeDataProvider,
 			configurationService, contextMenuService, notificationService, environmentService,
-			fileService, logService, remoteAuthorityResolverService, telemetryService, tunnelService, instantiationService, accessibilityService);
+			fileService, logService, remoteAuthorityResolverService, telemetryService, tunnelService, instantiationService, accessibilityService, webviewUriService);
 
 		this._webviewKeyboardHandler = new WindowIgnoreMenuShortcutsManager(configurationService, mainProcessService, _nativeHostService);
 

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts
@@ -70,6 +70,7 @@ import { IExtensionService } from 'vs/workbench/services/extensions/common/exten
 import { IHostService } from 'vs/workbench/services/host/browser/host';
 import { ThemeSettings } from 'vs/workbench/services/themes/common/workbenchThemeService';
 import { GettingStartedIndexList } from './gettingStartedList';
+import { IWebviewUriService } from 'vs/workbench/contrib/webview/common/webview';
 
 const SLIDE_TRANSITION_TIME_MS = 250;
 const configurationKey = 'workbench.startupEditor';
@@ -184,7 +185,8 @@ export class GettingStartedPage extends EditorPane {
 		@IHostService private readonly hostService: IHostService,
 		@IWebviewService private readonly webviewService: IWebviewService,
 		@IWorkspaceContextService private readonly workspaceContextService: IWorkspaceContextService,
-		@IAccessibilityService private readonly accessibilityService: IAccessibilityService) {
+		@IAccessibilityService private readonly accessibilityService: IAccessibilityService,
+		@IWebviewUriService private readonly webviewUriService: IWebviewUriService) {
 
 		super(GettingStartedPage.ID, telemetryService, themeService, storageService);
 
@@ -199,7 +201,7 @@ export class GettingStartedPage extends EditorPane {
 
 		this.categoriesSlideDisposables = this._register(new DisposableStore());
 
-		this.detailsRenderer = new GettingStartedDetailsRenderer(this.fileService, this.notificationService, this.extensionService, this.languageService);
+		this.detailsRenderer = new GettingStartedDetailsRenderer(this.fileService, this.notificationService, this.extensionService, this.languageService, this.webviewUriService);
 
 		this.contextService = this._register(contextService.createScoped(this.container));
 		inWelcomeContext.bindTo(this.contextService).set(true);

--- a/src/vs/workbench/contrib/welcomeGettingStarted/test/browser/gettingStartedMarkdownRenderer.test.ts
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/test/browser/gettingStartedMarkdownRenderer.test.ts
@@ -8,6 +8,7 @@ import { FileAccess } from 'vs/base/common/network';
 import { ensureNoDisposablesAreLeakedInTestSuite } from 'vs/base/test/common/utils';
 import { LanguageService } from 'vs/editor/common/services/languageService';
 import { TestNotificationService } from 'vs/platform/notification/test/common/testNotificationService';
+import { DefaultWebviewUriService } from 'vs/workbench/contrib/webview/common/webview';
 import { GettingStartedDetailsRenderer } from 'vs/workbench/contrib/welcomeGettingStarted/browser/gettingStartedDetailsRenderer';
 import { convertInternalMediaPathToFileURI } from 'vs/workbench/contrib/welcomeGettingStarted/browser/gettingStartedService';
 import { TestFileService } from 'vs/workbench/test/browser/workbenchTestServices';
@@ -21,7 +22,7 @@ suite('Getting Started Markdown Renderer', () => {
 	test('renders theme picker markdown with images', async () => {
 		const fileService = new TestFileService();
 		const languageService = new LanguageService();
-		const renderer = new GettingStartedDetailsRenderer(fileService, new TestNotificationService(), new TestExtensionService(), languageService);
+		const renderer = new GettingStartedDetailsRenderer(fileService, new TestNotificationService(), new TestExtensionService(), languageService, new DefaultWebviewUriService());
 		const mdPath = convertInternalMediaPathToFileURI('theme_picker').with({ query: JSON.stringify({ moduleId: 'vs/workbench/contrib/welcomeGettingStarted/common/media/theme_picker' }) });
 		const mdBase = FileAccess.asFileUri('vs/workbench/contrib/welcomeGettingStarted/common/media/');
 		const rendered = await renderer.renderMarkdown(mdPath, mdBase);

--- a/src/vs/workbench/services/environment/browser/environmentService.ts
+++ b/src/vs/workbench/services/environment/browser/environmentService.ts
@@ -37,6 +37,11 @@ export interface IBrowserWorkbenchEnvironmentService extends IWorkbenchEnvironme
 	 * Gets whether a resolver extension is expected for the environment.
 	 */
 	readonly expectsResolverExtension: boolean;
+
+	/**
+	 * The base host that gets used to construct resource URLs in webviews
+	 */
+	readonly webviewResourceBaseHost?: string;
 }
 
 export class BrowserWorkbenchEnvironmentService implements IBrowserWorkbenchEnvironmentService {
@@ -233,6 +238,11 @@ export class BrowserWorkbenchEnvironmentService implements IBrowserWorkbenchEnvi
 		return endpoint
 			.replace('{{commit}}', webviewExternalEndpointCommit ?? this.productService.commit ?? 'ef65ac1ba57f57f2a3961bfe94aa20481caca4c6')
 			.replace('{{quality}}', (webviewExternalEndpointCommit ? 'insider' : this.productService.quality) ?? 'insider');
+	}
+
+	@memoize
+	get webviewResourceBaseHost(): string {
+		return this.options.webviewResourceBaseHost || 'vscode-cdn.net';
 	}
 
 	@memoize

--- a/src/vs/workbench/services/extensions/browser/webWorkerExtensionHost.ts
+++ b/src/vs/workbench/services/extensions/browser/webWorkerExtensionHost.ts
@@ -320,7 +320,8 @@ export class WebWorkerExtensionHost extends Disposable implements IExtensionHost
 			remote: {
 				authority: this._environmentService.remoteAuthority,
 				connectionData: null,
-				isRemote: false
+				isRemote: false,
+				resourceBaseHost: this._environmentService.webviewResourceBaseHost,
 			},
 			uiKind: platform.isWeb ? UIKind.Web : UIKind.Desktop
 		};

--- a/src/vs/workbench/services/extensions/common/extensionHostProtocol.ts
+++ b/src/vs/workbench/services/extensions/common/extensionHostProtocol.ts
@@ -48,7 +48,7 @@ export interface IExtensionHostInitData {
 	loggers: UriDto<ILoggerResource>[];
 	logsLocation: URI;
 	autoStart: boolean;
-	remote: { isRemote: boolean; authority: string | undefined; connectionData: IRemoteConnectionData | null };
+	remote: { isRemote: boolean; authority: string | undefined; connectionData: IRemoteConnectionData | null; resourceBaseHost?: string };
 	consoleForward: { includeStack: boolean; logNative: boolean };
 	uiKind: UIKind;
 	messagePorts?: ReadonlyMap<string, MessagePortLike>;

--- a/src/vs/workbench/services/extensions/common/remoteExtensionHost.ts
+++ b/src/vs/workbench/services/extensions/common/remoteExtensionHost.ts
@@ -40,6 +40,7 @@ export interface IRemoteExtensionHostInitData {
 
 export interface IRemoteExtensionHostDataProvider {
 	readonly remoteAuthority: string;
+	readonly resourceBaseHost?: string;
 	getInitData(): Promise<IRemoteExtensionHostInitData>;
 }
 
@@ -233,7 +234,8 @@ export class RemoteExtensionHost extends Disposable implements IExtensionHost {
 			remote: {
 				isRemote: true,
 				authority: this._initDataProvider.remoteAuthority,
-				connectionData: remoteInitData.connectionData
+				connectionData: remoteInitData.connectionData,
+				resourceBaseHost: this._initDataProvider.resourceBaseHost,
 			},
 			consoleForward: {
 				includeStack: false,

--- a/src/vs/workbench/services/extensions/electron-sandbox/localProcessExtensionHost.ts
+++ b/src/vs/workbench/services/extensions/electron-sandbox/localProcessExtensionHost.ts
@@ -490,7 +490,8 @@ export class NativeLocalProcessExtensionHost implements IExtensionHost {
 			remote: {
 				authority: this._environmentService.remoteAuthority,
 				connectionData: null,
-				isRemote: false
+				isRemote: false,
+				resourceBaseHost: this._environmentService.webviewResourceBaseHost,
 			},
 			consoleForward: {
 				includeStack: !this._isExtensionDevTestFromCli && (this._isExtensionDevHost || !this._environmentService.isBuilt || this._productService.quality !== 'stable' || this._environmentService.verbose),


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
This PR introduces a new service `IWebviewUriService` whose role is to wrap the functionality previously offered by 3 constant exports: https://github.com/microsoft/vscode/blob/348e88dc0099fcedf9578013692ce6ca761f3501/src/vs/workbench/contrib/webview/common/webview.ts#L15-L25

Rather than use those hardcoded values, the new service provide the same functionality (aka wrapping resource URIs and returning a resource URI authority + CSP value) with the ability to modify the base host that's used rather than depend on the hardcoded `vscode-cdn.net`.

As the comment in the source explain, the domain is usually not very relevant because those resource URIs are never fetched from it. Rather a service worker is setup that intercepts the webview requests that follow this pattern and handle the actual retrieval as appropriate by interceding with the remote host.

Despite this service worker meddling, the domain is still important for one aspect: [Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP).

Since those requests are technically to a different origin, CSP policies have to be put in place to authorize them (CSP has no idea that they end up getting redirected). The webview base HTML does this with a `<meta http-equiv="Content-Security-Policy" />` type of tag however in our deployment of VSCode Web at Stripe we are required to put in place more stringent CSP policies by default that would not permit `vscode-cdn.net` to be part of the allowlist of domains for `connect-src` and the likes.

As a result, this changeset while pretty much no-op in the "common case" does allow this extensibility to happen for the case that matters aka when VSCode is served to a browser (and not while hosted in Electron) and lets embedder choose the  base endpoint they want by adding a new `IWorkbenchConstructionOptions` alongside the existing `webviewEndpoint` one.

On the PR itself, I have tested running the web server locally that with this new construction option I am able to correctly alter resource URLs such as the `pre.js` JS bundle used by the markdown extension:
<img width="1839" alt="Screenshot 2024-02-07 at 1 19 05 PM" src="https://github.com/microsoft/vscode/assets/79171530/f7c9307b-08b0-4dcc-85ce-3aa67ecc5203">

I also added one trivial unit test however I'm unsure if there is a good pattern for me to add a more in-depth test especially since this does have to cross over to the extension host side. Would appreciate any pointers in that space!