### PR TITLE
fix: requirements detection for alpine

### DIFF
--- a/resources/server/bin/helpers/check-requirements-linux.sh
+++ b/resources/server/bin/helpers/check-requirements-linux.sh
@@ -19,16 +19,17 @@ if [ -f "/tmp/vscode-skip-server-requirements-check" ]; then
 	exit 0
 fi
 
-BITNESS=$(getconf LONG_BIT)
 ARCH=$(uname -m)
 found_required_glibc=0
 found_required_glibcxx=0
 
 # Extract the ID value from /etc/os-release
-OS_ID="$(cat /etc/os-release | grep -Eo 'ID=([^"]+)' | sed -n '1s/ID=//p')"
-if [ "$OS_ID" = "nixos" ]; then
-  echo "Warning: NixOS detected, skipping GLIBC check"
-  exit 0
+if [ -f /etc/os-release ]; then
+    OS_ID="$(cat /etc/os-release | grep -Eo 'ID=([^"]+)' | sed -n '1s/ID=//p')"
+    if [ "$OS_ID" = "nixos" ]; then
+        echo "Warning: NixOS detected, skipping GLIBC check"
+        exit 0
+    fi
 fi
 
 # Based on https://github.com/bminor/glibc/blob/520b1df08de68a3de328b65a25b86300a7ddf512/elf/cache.c#L162-L245
@@ -36,6 +37,7 @@ case $ARCH in
 	x86_64) LDCONFIG_ARCH="x86-64";;
 	armv7l | armv8l) LDCONFIG_ARCH="hard-float";;
 	arm64 | aarch64)
+        BITNESS=$(getconf LONG_BIT)
 		if [ "$BITNESS" = "32" ]; then
 			# Can have 32-bit userland on 64-bit kernel
 			LDCONFIG_ARCH="hard-float"
@@ -45,23 +47,29 @@ case $ARCH in
 		;;
 esac
 
-if [ -f /usr/lib64/libstdc++.so.6 ]; then
-	# Typical path
-	libstdcpp_path='/usr/lib64/libstdc++.so.6'
-elif [ -f /usr/lib/libstdc++.so.6 ]; then
-	# Typical path
-	libstdcpp_path='/usr/lib/libstdc++.so.6'
-elif [ -f /sbin/ldconfig ]; then
-    # Look up path
-    libstdcpp_paths=$(/sbin/ldconfig -p | grep 'libstdc++.so.6')
+if [ "$OS_ID" != "alpine" ]; then
+    if [ -f /sbin/ldconfig ]; then
+        # Look up path
+        libstdcpp_paths=$(/sbin/ldconfig -p | grep 'libstdc++.so.6')
 
-    if [ "$(echo "$libstdcpp_paths" | wc -l)" -gt 1 ]; then
-        libstdcpp_path=$(echo "$libstdcpp_paths" | grep "$LDCONFIG_ARCH" | awk '{print $NF}' | head -n1)
-    else
-        libstdcpp_path=$(echo "$libstdcpp_paths" | awk '{print $NF}')
+        if [ "$(echo "$libstdcpp_paths" | wc -l)" -gt 1 ]; then
+            libstdcpp_path=$(echo "$libstdcpp_paths" | grep "$LDCONFIG_ARCH" | awk '{print $NF}' | head -n1)
+        else
+            libstdcpp_path=$(echo "$libstdcpp_paths" | awk '{print $NF}')
+        fi
     fi
-else
-	echo "Warning: Can't find libstdc++.so or ldconfig, can't verify libstdc++ version"
+fi
+
+if [ -z "$libstdcpp_path" ]; then
+    if [ -f /usr/lib/libstdc++.so.6 ]; then
+	    # Typical path
+	    libstdcpp_path='/usr/lib/libstdc++.so.6'
+    elif [ -f /usr/lib64/libstdc++.so.6 ]; then
+	    # Typical path
+	    libstdcpp_path='/usr/lib64/libstdc++.so.6'
+    else
+	    echo "Warning: Can't find libstdc++.so or ldconfig, can't verify libstdc++ version"
+    fi
 fi
 
 if [ -n "$libstdcpp_path" ]; then
@@ -78,14 +86,21 @@ if [ -n "$libstdcpp_path" ]; then
     fi
 fi
 
-if [ -z "$(ldd --version 2>&1 | grep 'musl libc')" ]; then
-    if [ -f /usr/lib64/libc.so.6 ]; then
-        # Typical path
-        libc_path='/usr/lib64/libc.so.6'
-    elif [ -f /usr/lib/libc.so.6 ]; then
-        # Typical path
-        libc_path='/usr/lib/libc.so.6'
-    elif [ -f /sbin/ldconfig ]; then
+if [ "$OS_ID" = "alpine" ]; then
+    MUSL_RTLDLIST="/lib/ld-musl-aarch64.so.1 /lib/ld-musl-x86_64.so.1"
+    for rtld in ${MUSL_RTLDLIST}; do
+        if [ -x $rtld ]; then
+            musl_version=$("$rtld" --version 2>&1 | grep "Version" | awk '{print $NF}')
+            break
+        fi
+    done
+    if [ "$(printf '%s\n' "1.2.3" "$musl_version" | sort -V | head -n1)" != "1.2.3" ]; then
+        echo "Error: Unsupported alpine distribution. Please refer to our supported distro section https://aka.ms/vscode-remote/linux for additional information."
+        exit 99
+    fi
+    found_required_glibc=1
+elif [ -z "$(ldd --version 2>&1 | grep 'musl libc')" ]; then
+    if [ -f /sbin/ldconfig ]; then
         # Look up path
         libc_paths=$(/sbin/ldconfig -p | grep 'libc.so.6')
 
@@ -94,6 +109,12 @@ if [ -z "$(ldd --version 2>&1 | grep 'musl libc')" ]; then
         else
             libc_path=$(echo "$libc_paths" | awk '{print $NF}')
         fi
+    elif [ -f /usr/lib/libc.so.6 ]; then
+        # Typical path
+        libc_path='/usr/lib/libc.so.6'
+    elif [ -f /usr/lib64/libc.so.6 ]; then
+        # Typical path
+        libc_path='/usr/lib64/libc.so.6'
     else
         echo "Warning: Can't find libc.so or ldconfig, can't verify libc version"
     fi
@@ -110,16 +131,7 @@ if [ -z "$(ldd --version 2>&1 | grep 'musl libc')" ]; then
         fi
     fi
 else
-    if [ "$OS_ID" = "alpine" ]; then
-        musl_version=$(ldd --version 2>&1 | grep "Version" | awk '{print $NF}')
-        if [ "$(printf '%s\n' "1.2.3" "$musl_version" | sort -V | head -n1)" != "1.2.3" ]; then
-            echo "Error: Unsupported alpine distribution. Please refer to our supported distro section https://aka.ms/vscode-remote/linux for additional information."
-            exit 99
-        fi
-    else
-        echo "Warning: musl detected, skipping GLIBC check"
-    fi
-
+    echo "Warning: musl detected, skipping GLIBC check"
     found_required_glibc=1
 fi
 


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-remote-release/issues/9499
Fixes https://github.com/microsoft/vscode/issues/204611

* `/etc/os-release` maybe not be available on certain distros
* scope bitness check only on arm architecture
* use dynamic loader in alpine scenario to identify musl version for cases where ldd can point to glibc sysroot
* Reorder path checks in other cases to use ldconfig cache first before fallbacks