### PR TITLE
make `live` the default mode for inline chat, remove the `livePreview` setting but not (yet) the implementation

### DIFF
--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatController.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatController.ts
@@ -347,15 +347,15 @@ export class InlineChatController implements IEditorContribution {
 
 		// create a new strategy
 		switch (session.editMode) {
-			case EditMode.Live:
-				this._strategy = this._instaService.createInstance(LiveStrategy, session, this._editor, this._zone.value);
-				break;
 			case EditMode.Preview:
 				this._strategy = this._instaService.createInstance(PreviewStrategy, session, this._editor, this._zone.value);
 				break;
 			case EditMode.LivePreview:
-			default:
 				this._strategy = this._instaService.createInstance(LivePreviewStrategy, session, this._editor, this._zone.value);
+				break;
+			case EditMode.Live:
+			default:
+				this._strategy = this._instaService.createInstance(LiveStrategy, session, this._editor, this._zone.value);
 				break;
 		}
 

--- a/src/vs/workbench/contrib/inlineChat/common/inlineChat.ts
+++ b/src/vs/workbench/contrib/inlineChat/common/inlineChat.ts
@@ -193,8 +193,9 @@ export const overviewRulerInlineChatDiffRemoved = registerColor('editorOverviewR
 
 export const enum EditMode {
 	Live = 'live',
+	Preview = 'preview',
+	/** @deprecated */
 	LivePreview = 'livePreview',
-	Preview = 'preview'
 }
 
 Registry.as<IConfigurationMigrationRegistry>(ExtensionsMigration.ConfigurationMigration).registerConfigurationMigrations(
@@ -217,13 +218,12 @@ Registry.as<IConfigurationRegistry>(Extensions.Configuration).registerConfigurat
 	properties: {
 		[InlineChatConfigKeys.Mode]: {
 			description: localize('mode', "Configure if changes crafted with inline chat are applied directly to the document or are previewed first."),
-			default: EditMode.LivePreview,
+			default: EditMode.Live,
 			type: 'string',
-			enum: [EditMode.LivePreview, EditMode.Preview, EditMode.Live],
+			enum: [EditMode.Live, EditMode.Preview],
 			markdownEnumDescriptions: [
-				localize('mode.livePreview', "Changes are applied directly to the document and are highlighted visually via inline or side-by-side diffs. Ending a session will keep the changes."),
-				localize('mode.preview', "Changes are previewed only and need to be accepted via the apply button. Ending a session will discard the changes."),
 				localize('mode.live', "Changes are applied directly to the document, can be highlighted via inline diffs, and accepted/discarded by hunks. Ending a session will keep the changes."),
+				localize('mode.preview', "Changes are previewed only and need to be accepted via the apply button. Ending a session will discard the changes."),
 			],
 			tags: ['experimental']
 		},

--- a/src/vs/workbench/contrib/notebook/browser/view/cellParts/chat/cellChatController.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/cellParts/chat/cellChatController.ts
@@ -270,7 +270,7 @@ export class NotebookCellChatController extends Disposable {
 
 		const session = await this._inlineChatSessionService.createSession(
 			editor,
-			{ editMode: EditMode.LivePreview },
+			{ editMode: EditMode.Live },
 			token
 		);
 


### PR DESCRIPTION
https://github.com/microsoft/vscode/issues/204368