### PR TITLE
Add zsh and fish as valid shell code block languages

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/chatCodeblockActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatCodeblockActions.ts
@@ -382,8 +382,10 @@ export function registerChatCodeBlockActions() {
 	});
 
 	const shellLangIds = [
+		'fish',
 		'powershell',
-		'shellscript'
+		'shellscript',
+		'zsh'
 	];
 	registerAction2(class RunInTerminalAction extends ChatCodeBlockAction {
 		constructor() {


### PR DESCRIPTION
This will make the run in terminal button move out of the overflow menu

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
