### PR TITLE
Fix smoke tests

### DIFF
--- a/test/automation/src/extensions.ts
+++ b/test/automation/src/extensions.ts
@@ -41,7 +41,7 @@ export class Extensions extends Viewlet {
 	}
 
 	async closeExtension(title: string): Promise<any> {
-		await this.code.waitAndClick(`.tabs-container div.tab[title="Extension: ${title}"] div.tab-actions a.action-label.codicon.codicon-close`);
+		await this.code.waitAndClick(`.tabs-container div.tab[aria-label="Extension: ${title}"] div.tab-actions a.action-label.codicon.codicon-close`);
 	}
 
 	async installExtension(id: string, waitUntilEnabled: boolean): Promise<void> {


### PR DESCRIPTION
This PR fixes the smoke tests by updating the selector used in the `closeExtension` method. The title attribute was replaced with the aria-label attribute to ensure the correct tab is selected and closed.