### PR TITLE
Fix converting tree data

### DIFF
--- a/src/vs/workbench/api/common/extHostTypeConverters.ts
+++ b/src/vs/workbench/api/common/extHostTypeConverters.ts
@@ -2376,7 +2376,7 @@ export namespace ChatResponseFilesPart {
 		};
 	}
 	export function from(part: Dto<IChatTreeData>): vscode.ChatResponseFileTreePart {
-		const { treeData } = revive<IChatTreeData>(part.treeData);
+		const treeData = revive<extHostProtocol.IChatResponseProgressFileTreeData>(part.treeData);
 		function convert(items: extHostProtocol.IChatResponseProgressFileTreeData[]): vscode.ChatResponseFileTree[] {
 			return items.map(item => {
 				return {


### PR DESCRIPTION
This PR addresses an issue in the conversion of tree data in the `extHostTypeConverters.ts` file. The type of `treeData` has been corrected to `extHostProtocol.IChatResponseProgressFileTreeData` from `IChatTreeData` to ensure accurate conversion.