### PR TITLE
Tunnel: Extend port mapping lookup also for querystring (take 2)

### DIFF
--- a/src/vs/platform/tunnel/common/tunnel.ts
+++ b/src/vs/platform/tunnel/common/tunnel.ts
@@ -155,6 +155,23 @@ export function extractLocalHostUriMetaDataForPortMapping(uri: URI): { address: 
 	};
 }
 
+export function extractQueryLocalHostUriMetaDataForPortMapping(uri: URI): { address: string; port: number } | undefined {
+	if (uri.scheme !== 'http' && uri.scheme !== 'https' || !uri.query) {
+		return undefined;
+	}
+	const keyvalues = uri.query.split('&');
+	for (const keyvalue of keyvalues) {
+		const value = keyvalue.split('=')[1];
+		if (/^https?:/.exec(value)) {
+			const result = extractLocalHostUriMetaDataForPortMapping(URI.parse(value));
+			if (result) {
+				return result;
+			}
+		}
+	}
+	return undefined;
+}
+
 export const LOCALHOST_ADDRESSES = ['localhost', '127.0.0.1', '0:0:0:0:0:0:0:1', '::1'];
 export function isLocalhost(host: string): boolean {
 	return LOCALHOST_ADDRESSES.indexOf(host) >= 0;

--- a/src/vs/platform/tunnel/test/common/tunnel.test.ts
+++ b/src/vs/platform/tunnel/test/common/tunnel.test.ts
@@ -1,0 +1,37 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import * as assert from 'assert';
+import { URI } from 'vs/base/common/uri';
+import { extractLocalHostUriMetaDataForPortMapping } from 'vs/platform/tunnel/common/tunnel';
+import { ensureNoDisposablesAreLeakedInTestSuite } from 'vs/base/test/common/utils';
+
+
+suite('Tunnel', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	function portMappingDoTest(uri: string,
+		expectedAddress?: string,
+		expectedPort?: number) {
+		const res = extractLocalHostUriMetaDataForPortMapping(URI.parse(uri));
+		assert.strictEqual(!expectedAddress, !res);
+		assert.strictEqual(res?.address, expectedAddress);
+		assert.strictEqual(res?.port, expectedPort);
+	}
+
+	function portMappingTest(uri: string, expectedAddress?: string, expectedPort?: number) {
+		portMappingDoTest(uri, expectedAddress, expectedPort);
+	}
+
+	test('portMapping', () => {
+		portMappingTest('file:///foo.bar/baz');
+		portMappingTest('http://foo.bar:1234');
+		portMappingTest('http://localhost:8080', 'localhost', 8080);
+		portMappingTest('https://localhost:443', 'localhost', 443);
+		portMappingTest('http://127.0.0.1:3456', '127.0.0.1', 3456);
+		portMappingTest('http://0.0.0.0:7654', '0.0.0.0', 7654);
+		portMappingTest('http://localhost:8080/path?foo=bar', 'localhost', 8080);
+		portMappingTest('http://localhost:8080/path?foo=http%3A%2F%2Flocalhost%3A8081', 'localhost', 8080);
+	});
+});

--- a/src/vs/workbench/electron-sandbox/window.ts
+++ b/src/vs/workbench/electron-sandbox/window.ts
@@ -46,7 +46,7 @@ import { IOpenerService, IResolvedExternalUri, OpenOptions } from 'vs/platform/o
 import { Schemas } from 'vs/base/common/network';
 import { INativeHostService } from 'vs/platform/native/common/native';
 import { posix } from 'vs/base/common/path';
-import { ITunnelService, RemoteTunnel, extractLocalHostUriMetaDataForPortMapping } from 'vs/platform/tunnel/common/tunnel';
+import { ITunnelService, RemoteTunnel, extractLocalHostUriMetaDataForPortMapping, extractQueryLocalHostUriMetaDataForPortMapping } from 'vs/platform/tunnel/common/tunnel';
 import { IWorkbenchLayoutService, Parts, positionFromString, Position } from 'vs/workbench/services/layout/browser/layoutService';
 import { IWorkingCopyService } from 'vs/workbench/services/workingCopy/common/workingCopyService';
 import { WorkingCopyCapabilities } from 'vs/workbench/services/workingCopy/common/workingCopy';
@@ -822,8 +822,29 @@ export class NativeWindow extends BaseWindow {
 	}
 
 	async resolveExternalUri(uri: URI, options?: OpenOptions): Promise<IResolvedExternalUri | undefined> {
+		let queryTunnel: RemoteTunnel | string | undefined;
 		if (options?.allowTunneling) {
 			const portMappingRequest = extractLocalHostUriMetaDataForPortMapping(uri);
+			const queryPortMapping = extractQueryLocalHostUriMetaDataForPortMapping(uri);
+			if (queryPortMapping) {
+				queryTunnel = await this.openTunnel(queryPortMapping.address, queryPortMapping.port);
+				if (queryTunnel && (typeof queryTunnel !== 'string')) {
+					// If the tunnel was mapped to a different port, dispose it, because some services
+					// validate the port number in the query string.
+					if (queryTunnel.tunnelRemotePort !== queryPortMapping.port) {
+						queryTunnel.dispose();
+						queryTunnel = undefined;
+					} else {
+						if (!portMappingRequest) {
+							const tunnel = queryTunnel;
+							return {
+								resolved: uri,
+								dispose: () => tunnel.dispose()
+							};
+						}
+					}
+				}
+			}
 			if (portMappingRequest) {
 				const tunnel = await this.openTunnel(portMappingRequest.address, portMappingRequest.port);
 				if (tunnel && (typeof tunnel !== 'string')) {
@@ -831,7 +852,12 @@ export class NativeWindow extends BaseWindow {
 					const resolved = addressAsUri.scheme.startsWith(uri.scheme) ? addressAsUri : uri.with({ authority: tunnel.localAddress });
 					return {
 						resolved,
-						dispose: () => tunnel.dispose(),
+						dispose() {
+							tunnel.dispose();
+							if (queryTunnel && (typeof queryTunnel !== 'string')) {
+								queryTunnel.dispose();
+							}
+						}
 					};
 				}
 			}

--- a/src/vs/workbench/electron-sandbox/window.ts
+++ b/src/vs/workbench/electron-sandbox/window.ts
@@ -42,11 +42,11 @@ import { coalesce } from 'vs/base/common/arrays';
 import { ConfigurationTarget, IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { IStorageService, StorageScope, StorageTarget } from 'vs/platform/storage/common/storage';
 import { assertIsDefined } from 'vs/base/common/types';
-import { IOpenerService, OpenOptions } from 'vs/platform/opener/common/opener';
+import { IOpenerService, IResolvedExternalUri, OpenOptions } from 'vs/platform/opener/common/opener';
 import { Schemas } from 'vs/base/common/network';
 import { INativeHostService } from 'vs/platform/native/common/native';
 import { posix } from 'vs/base/common/path';
-import { ITunnelService, extractLocalHostUriMetaDataForPortMapping } from 'vs/platform/tunnel/common/tunnel';
+import { ITunnelService, RemoteTunnel, extractLocalHostUriMetaDataForPortMapping } from 'vs/platform/tunnel/common/tunnel';
 import { IWorkbenchLayoutService, Parts, positionFromString, Position } from 'vs/workbench/services/layout/browser/layoutService';
 import { IWorkingCopyService } from 'vs/workbench/services/workingCopy/common/workingCopyService';
 import { WorkingCopyCapabilities } from 'vs/workbench/services/workingCopy/common/workingCopy';
@@ -807,6 +807,53 @@ export class NativeWindow extends BaseWindow {
 		});
 	}
 
+	private async openTunnel(address: string, port: number): Promise<RemoteTunnel | string | undefined> {
+		const remoteAuthority = this.environmentService.remoteAuthority;
+		const addressProvider: IAddressProvider | undefined = remoteAuthority ? {
+			getAddress: async (): Promise<IAddress> => {
+				return (await this.remoteAuthorityResolverService.resolveAuthority(remoteAuthority)).authority;
+			}
+		} : undefined;
+		const tunnel = await this.tunnelService.getExistingTunnel(address, port);
+		if (!tunnel || (typeof tunnel === 'string')) {
+			return this.tunnelService.openTunnel(addressProvider, address, port);
+		}
+		return tunnel;
+	}
+
+	async resolveExternalUri(uri: URI, options?: OpenOptions): Promise<IResolvedExternalUri | undefined> {
+		if (options?.allowTunneling) {
+			const portMappingRequest = extractLocalHostUriMetaDataForPortMapping(uri);
+			if (portMappingRequest) {
+				const tunnel = await this.openTunnel(portMappingRequest.address, portMappingRequest.port);
+				if (tunnel && (typeof tunnel !== 'string')) {
+					const addressAsUri = URI.parse(tunnel.localAddress);
+					const resolved = addressAsUri.scheme.startsWith(uri.scheme) ? addressAsUri : uri.with({ authority: tunnel.localAddress });
+					return {
+						resolved,
+						dispose: () => tunnel.dispose(),
+					};
+				}
+			}
+		}
+
+		if (!options?.openExternal) {
+			const canHandleResource = await this.fileService.canHandleResource(uri);
+			if (canHandleResource) {
+				return {
+					resolved: URI.from({
+						scheme: this.productService.urlProtocol,
+						path: 'workspace',
+						query: uri.toString()
+					}),
+					dispose() { }
+				};
+			}
+		}
+
+		return undefined;
+	}
+
 	private setupOpenHandlers(): void {
 
 		// Handle external open() calls
@@ -828,46 +875,7 @@ export class NativeWindow extends BaseWindow {
 		// Register external URI resolver
 		this.openerService.registerExternalUriResolver({
 			resolveExternalUri: async (uri: URI, options?: OpenOptions) => {
-				if (options?.allowTunneling) {
-					const portMappingRequest = extractLocalHostUriMetaDataForPortMapping(uri);
-					if (portMappingRequest) {
-						const remoteAuthority = this.environmentService.remoteAuthority;
-						const addressProvider: IAddressProvider | undefined = remoteAuthority ? {
-							getAddress: async (): Promise<IAddress> => {
-								return (await this.remoteAuthorityResolverService.resolveAuthority(remoteAuthority)).authority;
-							}
-						} : undefined;
-						let tunnel = await this.tunnelService.getExistingTunnel(portMappingRequest.address, portMappingRequest.port);
-						if (!tunnel || (typeof tunnel === 'string')) {
-							tunnel = await this.tunnelService.openTunnel(addressProvider, portMappingRequest.address, portMappingRequest.port);
-						}
-						if (tunnel && (typeof tunnel !== 'string')) {
-							const constTunnel = tunnel;
-							const addressAsUri = URI.parse(constTunnel.localAddress);
-							const resolved = addressAsUri.scheme.startsWith(uri.scheme) ? addressAsUri : uri.with({ authority: constTunnel.localAddress });
-							return {
-								resolved,
-								dispose: () => constTunnel.dispose(),
-							};
-						}
-					}
-				}
-
-				if (!options?.openExternal) {
-					const canHandleResource = await this.fileService.canHandleResource(uri);
-					if (canHandleResource) {
-						return {
-							resolved: URI.from({
-								scheme: this.productService.urlProtocol,
-								path: 'workspace',
-								query: uri.toString()
-							}),
-							dispose() { }
-						};
-					}
-				}
-
-				return undefined;
+				return this.resolveExternalUri(uri, options);
 			}
 		});
 	}

--- a/src/vs/workbench/test/electron-sandbox/resolveExternal.test.ts
+++ b/src/vs/workbench/test/electron-sandbox/resolveExternal.test.ts
@@ -1,0 +1,71 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import * as assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from 'vs/base/test/common/utils';
+import { NativeWindow } from 'vs/workbench/electron-sandbox/window';
+import { RemoteTunnel } from 'vs/platform/tunnel/common/tunnel';
+import { URI } from 'vs/base/common/uri';
+
+type PortMap = Record<number, number>;
+
+class TunnelMock {
+	private assignedPorts: PortMap = {};
+
+	reset(ports: PortMap) {
+		this.assignedPorts = ports;
+	}
+
+	openTunnel(_address: string, port: number): Promise<RemoteTunnel | string | undefined> {
+		if (!this.assignedPorts[port]) {
+			return Promise.reject(new Error('Unexpected tunnel request'));
+		}
+		const res: RemoteTunnel = {
+			localAddress: `localhost:${this.assignedPorts[port]}`,
+			tunnelRemoteHost: '4.3.2.1',
+			tunnelRemotePort: this.assignedPorts[port],
+			privacy: '',
+			dispose: () => {
+				return Promise.resolve();
+			}
+		};
+		delete this.assignedPorts[port];
+		return Promise.resolve(res);
+	}
+
+	validate() {
+		assert(Object.keys(this.assignedPorts).length === 0, 'Expected tunnel to be used');
+	}
+}
+
+suite('NativeWindow:resolveExternal', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+	const tunnelMock = new TunnelMock();
+
+	async function doTest(uri: string, ports: PortMap = {}, expectedUri?: string) {
+		tunnelMock.reset(ports);
+		const res = await NativeWindow.prototype.resolveExternalUri.call(tunnelMock, URI.parse(uri), {
+			allowTunneling: true,
+			openExternal: true
+		});
+		assert.strictEqual(!expectedUri, !res, `Expected URI ${expectedUri} but got ${res}`);
+		if (expectedUri && res) {
+			assert.strictEqual(res.resolved.toString(), URI.parse(expectedUri).toString());
+		}
+		tunnelMock.validate();
+	}
+	test('invalid', async () => {
+		await doTest('file:///foo.bar/baz');
+		await doTest('http://foo.bar/path');
+	});
+	test('simple', async () => {
+		await doTest('http://localhost:1234/path', { 1234: 1234 }, 'http://localhost:1234/path');
+	});
+	test('all interfaces', async () => {
+		await doTest('http://0.0.0.0:1234/path', { 1234: 1234 }, 'http://localhost:1234/path');
+	});
+	test('changed port', async () => {
+		await doTest('http://localhost:1234/path', { 1234: 1235 }, 'http://localhost:1235/path');
+	});
+});


### PR DESCRIPTION
When running az login, the URL has localhost in redirect_uri query param. This should trigger automatic port mapping.

Improve localhost port mapping to cover this case as well.

This is a revised and tested version of #203908 which was reverted in #205370.

Fixes #203869.