### PR TITLE
Add ChatAgentResult2#metadata

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadChatAgents2.ts
+++ b/src/vs/workbench/api/browser/mainThreadChatAgents2.ts
@@ -61,7 +61,7 @@ export class MainThreadChatAgents2 extends Disposable implements MainThreadChatA
 						if (e.action.kind === 'vote') {
 							this._proxy.$acceptFeedback(handle, e.result ?? {}, e.action.direction);
 						} else {
-							this._proxy.$acceptAction(handle, e.sessionId, e.requestId, e);
+							this._proxy.$acceptAction(handle, e.result || {}, e);
 						}
 						break;
 					}

--- a/src/vs/workbench/api/browser/mainThreadChatAgents2.ts
+++ b/src/vs/workbench/api/browser/mainThreadChatAgents2.ts
@@ -59,7 +59,7 @@ export class MainThreadChatAgents2 extends Disposable implements MainThreadChatA
 				for (const [handle, agent] of this._agents) {
 					if (agent.name === e.agentId) {
 						if (e.action.kind === 'vote') {
-							this._proxy.$acceptFeedback(handle, e.sessionId, e.requestId, e.action.direction);
+							this._proxy.$acceptFeedback(handle, e.result ?? {}, e.action.direction);
 						} else {
 							this._proxy.$acceptAction(handle, e.sessionId, e.requestId, e);
 						}

--- a/src/vs/workbench/api/browser/mainThreadChatAgents2.ts
+++ b/src/vs/workbench/api/browser/mainThreadChatAgents2.ts
@@ -87,12 +87,12 @@ export class MainThreadChatAgents2 extends Disposable implements MainThreadChatA
 					this._pendingProgress.delete(request.requestId);
 				}
 			},
-			provideFollowups: async (sessionId, token): Promise<IChatFollowup[]> => {
+			provideFollowups: async (result, token): Promise<IChatFollowup[]> => {
 				if (!this._agents.get(handle)?.hasFollowups) {
 					return [];
 				}
 
-				return this._proxy.$provideFollowups(handle, sessionId, token);
+				return this._proxy.$provideFollowups(handle, result, token);
 			},
 			get lastSlashCommands() {
 				return lastSlashCommands;

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -1223,7 +1223,7 @@ export interface ExtHostChatAgentsShape2 {
 	$provideSlashCommands(handle: number, token: CancellationToken): Promise<IChatAgentCommand[]>;
 	$provideFollowups(handle: number, sessionId: string, token: CancellationToken): Promise<IChatFollowup[]>;
 	$acceptFeedback(handle: number, result: IChatAgentResult, vote: InteractiveSessionVoteDirection, reportIssue?: boolean): void;
-	$acceptAction(handle: number, sessionId: string, requestId: string, action: IChatUserActionEvent): void;
+	$acceptAction(handle: number, result: IChatAgentResult, action: IChatUserActionEvent): void;
 	$invokeCompletionProvider(handle: number, query: string, token: CancellationToken): Promise<IChatAgentCompletionItem[]>;
 	$provideWelcomeMessage(handle: number, token: CancellationToken): Promise<(string | IMarkdownString)[] | undefined>;
 	$provideSampleQuestions(handle: number, token: CancellationToken): Promise<IChatFollowup[] | undefined>;

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -1222,7 +1222,7 @@ export interface ExtHostChatAgentsShape2 {
 	$invokeAgent(handle: number, request: IChatAgentRequest, context: { history: IChatAgentHistoryEntryDto[] }, token: CancellationToken): Promise<IChatAgentResult | undefined>;
 	$provideSlashCommands(handle: number, token: CancellationToken): Promise<IChatAgentCommand[]>;
 	$provideFollowups(handle: number, sessionId: string, token: CancellationToken): Promise<IChatFollowup[]>;
-	$acceptFeedback(handle: number, sessionId: string, requestId: string, vote: InteractiveSessionVoteDirection, reportIssue?: boolean): void;
+	$acceptFeedback(handle: number, result: IChatAgentResult, vote: InteractiveSessionVoteDirection, reportIssue?: boolean): void;
 	$acceptAction(handle: number, sessionId: string, requestId: string, action: IChatUserActionEvent): void;
 	$invokeCompletionProvider(handle: number, query: string, token: CancellationToken): Promise<IChatAgentCompletionItem[]>;
 	$provideWelcomeMessage(handle: number, token: CancellationToken): Promise<(string | IMarkdownString)[] | undefined>;

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -1221,7 +1221,7 @@ export type IChatAgentHistoryEntryDto = {
 export interface ExtHostChatAgentsShape2 {
 	$invokeAgent(handle: number, request: IChatAgentRequest, context: { history: IChatAgentHistoryEntryDto[] }, token: CancellationToken): Promise<IChatAgentResult | undefined>;
 	$provideSlashCommands(handle: number, token: CancellationToken): Promise<IChatAgentCommand[]>;
-	$provideFollowups(handle: number, sessionId: string, token: CancellationToken): Promise<IChatFollowup[]>;
+	$provideFollowups(handle: number, result: IChatAgentResult, token: CancellationToken): Promise<IChatFollowup[]>;
 	$acceptFeedback(handle: number, result: IChatAgentResult, vote: InteractiveSessionVoteDirection, reportIssue?: boolean): void;
 	$acceptAction(handle: number, result: IChatAgentResult, action: IChatUserActionEvent): void;
 	$invokeCompletionProvider(handle: number, query: string, token: CancellationToken): Promise<IChatAgentCompletionItem[]>;

--- a/src/vs/workbench/api/common/extHostChatAgents2.ts
+++ b/src/vs/workbench/api/common/extHostChatAgents2.ts
@@ -226,7 +226,7 @@ export class ExtHostChatAgents2 implements ExtHostChatAgentsShape2 {
 							JSON.stringify(result.metadata);
 						} catch (err) {
 							const msg = `result.metadata MUST be JSON.stringify-able. Got error: ${err.message}`;
-							this._logService.error(msg, agent.extension);
+							this._logService.error(`[${agent.extension.identifier.value}] [@${agent.id}] ${msg}`, agent.extension);
 							return { errorDetails: { message: msg }, timings: stream.timings };
 						}
 					}

--- a/src/vs/workbench/api/common/extHostTypeConverters.ts
+++ b/src/vs/workbench/api/common/extHostTypeConverters.ts
@@ -34,7 +34,7 @@ import * as extHostProtocol from 'vs/workbench/api/common/extHost.protocol';
 import { getPrivateApiFor } from 'vs/workbench/api/common/extHostTestingPrivateApi';
 import { DEFAULT_EDITOR_ASSOCIATION, SaveReason } from 'vs/workbench/common/editor';
 import { IViewBadge } from 'vs/workbench/common/views';
-import { IChatAgentRequest } from 'vs/workbench/contrib/chat/common/chatAgents';
+import { IChatAgentRequest, IChatAgentResult } from 'vs/workbench/contrib/chat/common/chatAgents';
 import * as chatProvider from 'vs/workbench/contrib/chat/common/chatProvider';
 import { IChatCommandButton, IChatContentInlineReference, IChatContentReference, IChatFollowup, IChatMarkdownContent, IChatProgressMessage, IChatTreeData } from 'vs/workbench/contrib/chat/common/chatService';
 import { IChatRequestVariableValue } from 'vs/workbench/contrib/chat/common/chatVariables';
@@ -2624,6 +2624,15 @@ export namespace ChatAgentCompletionItem {
 			insertText: item.insertText,
 			detail: item.detail,
 			documentation: item.documentation,
+		};
+	}
+}
+
+export namespace ChatAgentResult {
+	export function to(result: IChatAgentResult): vscode.ChatAgentResult2 {
+		return {
+			errorDetails: result.errorDetails,
+			metadata: result.metadata,
 		};
 	}
 }

--- a/src/vs/workbench/contrib/chat/browser/actions/chatCodeblockActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatCodeblockActions.ts
@@ -108,6 +108,7 @@ export function registerChatCodeBlockActions() {
 					agentId: context.element.agent?.id,
 					sessionId: context.element.sessionId,
 					requestId: context.element.requestId,
+					result: context.element.result,
 					action: {
 						kind: 'copy',
 						codeBlockIndex: context.codeBlockIndex,
@@ -151,6 +152,7 @@ export function registerChatCodeBlockActions() {
 			agentId: context.element.agent?.id,
 			sessionId: context.element.sessionId,
 			requestId: context.element.requestId,
+			result: context.element.result,
 			action: {
 				kind: 'copy',
 				codeBlockIndex: context.codeBlockIndex,
@@ -325,6 +327,7 @@ export function registerChatCodeBlockActions() {
 					agentId: context.element.agent?.id,
 					sessionId: context.element.sessionId,
 					requestId: context.element.requestId,
+					result: context.element.result,
 					action: {
 						kind: 'insert',
 						codeBlockIndex: context.codeBlockIndex,
@@ -370,6 +373,7 @@ export function registerChatCodeBlockActions() {
 					agentId: context.element.agent?.id,
 					sessionId: context.element.sessionId,
 					requestId: context.element.requestId,
+					result: context.element.result,
 					action: {
 						kind: 'insert',
 						codeBlockIndex: context.codeBlockIndex,
@@ -464,6 +468,7 @@ export function registerChatCodeBlockActions() {
 					agentId: context.element.agent?.id,
 					sessionId: context.element.sessionId,
 					requestId: context.element.requestId,
+					result: context.element.result,
 					action: {
 						kind: 'runInTerminal',
 						codeBlockIndex: context.codeBlockIndex,

--- a/src/vs/workbench/contrib/chat/browser/actions/chatTitleActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatTitleActions.ts
@@ -54,6 +54,7 @@ export function registerChatTitleActions() {
 				agentId: item.agent?.id,
 				sessionId: item.sessionId,
 				requestId: item.requestId,
+				result: item.result,
 				action: {
 					kind: 'vote',
 					direction: InteractiveSessionVoteDirection.Up,
@@ -93,6 +94,7 @@ export function registerChatTitleActions() {
 				agentId: item.agent?.id,
 				sessionId: item.sessionId,
 				requestId: item.requestId,
+				result: item.result,
 				action: {
 					kind: 'vote',
 					direction: InteractiveSessionVoteDirection.Down,
@@ -131,6 +133,7 @@ export function registerChatTitleActions() {
 				agentId: item.agent?.id,
 				sessionId: item.sessionId,
 				requestId: item.requestId,
+				result: item.result,
 				action: {
 					kind: 'bug'
 				}

--- a/src/vs/workbench/contrib/chat/browser/chatQuick.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatQuick.ts
@@ -289,13 +289,13 @@ class QuickChat extends Disposable {
 		}
 
 		for (const request of this.model.getRequests()) {
-			if (request.response?.response.value || request.response?.errorDetails) {
+			if (request.response?.response.value || request.response?.result) {
 				this.chatService.addCompleteRequest(widget.viewModel.sessionId,
 					request.message as IParsedChatRequest,
 					request.variableData,
 					{
 						message: request.response.response.value,
-						errorDetails: request.response.errorDetails,
+						result: request.response.result,
 						followups: request.response.followups
 					});
 			} else if (request.message) {

--- a/src/vs/workbench/contrib/chat/browser/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatWidget.ts
@@ -455,7 +455,8 @@ export class ChatWidget extends Disposable implements IChatWidget {
 				providerId: this.viewModel.providerId,
 				sessionId: this.viewModel.sessionId,
 				requestId: e.response.requestId,
-				agentId: e.response?.agent?.id,
+				agentId: e.response.agent?.id,
+				result: e.response.result,
 				action: {
 					kind: 'followUp',
 					followup: e.followup

--- a/src/vs/workbench/contrib/chat/common/chatAgents.ts
+++ b/src/vs/workbench/contrib/chat/common/chatAgents.ts
@@ -31,7 +31,7 @@ export interface IChatAgentData {
 
 export interface IChatAgent extends IChatAgentData {
 	invoke(request: IChatAgentRequest, progress: (part: IChatProgress) => void, history: IChatAgentHistoryEntry[], token: CancellationToken): Promise<IChatAgentResult>;
-	provideFollowups?(sessionId: string, token: CancellationToken): Promise<IChatFollowup[]>;
+	provideFollowups?(result: IChatAgentResult, token: CancellationToken): Promise<IChatFollowup[]>;
 	lastSlashCommands?: IChatAgentCommand[];
 	provideSlashCommands(token: CancellationToken): Promise<IChatAgentCommand[]>;
 	provideWelcomeMessage?(token: CancellationToken): ProviderResult<(string | IMarkdownString)[] | undefined>;
@@ -105,7 +105,7 @@ export interface IChatAgentService {
 	readonly onDidChangeAgents: Event<void>;
 	registerAgent(agent: IChatAgent): IDisposable;
 	invokeAgent(id: string, request: IChatAgentRequest, progress: (part: IChatProgress) => void, history: IChatAgentHistoryEntry[], token: CancellationToken): Promise<IChatAgentResult>;
-	getFollowups(id: string, sessionId: string, token: CancellationToken): Promise<IChatFollowup[]>;
+	getFollowups(id: string, result: IChatAgentResult, token: CancellationToken): Promise<IChatFollowup[]>;
 	getAgents(): Array<IChatAgent>;
 	getAgent(id: string): IChatAgent | undefined;
 	getDefaultAgent(): IChatAgent | undefined;
@@ -184,7 +184,7 @@ export class ChatAgentService extends Disposable implements IChatAgentService {
 		return await data.agent.invoke(request, progress, history, token);
 	}
 
-	async getFollowups(id: string, sessionId: string, token: CancellationToken): Promise<IChatFollowup[]> {
+	async getFollowups(id: string, result: IChatAgentResult, token: CancellationToken): Promise<IChatFollowup[]> {
 		const data = this._agents.get(id);
 		if (!data) {
 			throw new Error(`No agent with id ${id}`);
@@ -194,6 +194,6 @@ export class ChatAgentService extends Disposable implements IChatAgentService {
 			return [];
 		}
 
-		return data.agent.provideFollowups(sessionId, token);
+		return data.agent.provideFollowups(result, token);
 	}
 }

--- a/src/vs/workbench/contrib/chat/common/chatAgents.ts
+++ b/src/vs/workbench/contrib/chat/common/chatAgents.ts
@@ -89,13 +89,13 @@ export interface IChatAgentRequest {
 }
 
 export interface IChatAgentResult {
-	// delete, keep while people are still using the previous API
-	followUp?: IChatFollowup[];
 	errorDetails?: IChatResponseErrorDetails;
 	timings?: {
 		firstProgress?: number;
 		totalElapsed: number;
 	};
+	/** Extra properties that the agent can use to identify a result */
+	readonly metadata?: { readonly [key: string]: any };
 }
 
 export const IChatAgentService = createDecorator<IChatAgentService>('chatAgentService');

--- a/src/vs/workbench/contrib/chat/common/chatParserTypes.ts
+++ b/src/vs/workbench/contrib/chat/common/chatParserTypes.ts
@@ -78,6 +78,21 @@ export class ChatRequestAgentPart implements IParsedChatRequestPart {
 	get promptText(): string {
 		return '';
 	}
+
+	/**
+	 * Don't stringify all the agent methods, just data.
+	 */
+	toJSON(): any {
+		return {
+			kind: this.kind,
+			range: this.range,
+			editorRange: this.editorRange,
+			agent: {
+				id: this.agent.id,
+				metadata: this.agent.metadata
+			}
+		};
+	}
 }
 
 /**

--- a/src/vs/workbench/contrib/chat/common/chatService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService.ts
@@ -12,7 +12,7 @@ import { IRange, Range } from 'vs/editor/common/core/range';
 import { Command, Location, ProviderResult } from 'vs/editor/common/languages';
 import { FileType } from 'vs/platform/files/common/files';
 import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
-import { IChatAgentCommand, IChatAgentData } from 'vs/workbench/contrib/chat/common/chatAgents';
+import { IChatAgentCommand, IChatAgentData, IChatAgentResult } from 'vs/workbench/contrib/chat/common/chatAgents';
 import { ChatModel, IChatModel, IChatRequestVariableData, ISerializableChatData } from 'vs/workbench/contrib/chat/common/chatModel';
 import { IParsedChatRequest } from 'vs/workbench/contrib/chat/common/chatParserTypes';
 import { IChatRequestVariableValue } from 'vs/workbench/contrib/chat/common/chatVariables';
@@ -38,15 +38,6 @@ export interface IChatResponseErrorDetails {
 	responseIsIncomplete?: boolean;
 	responseIsFiltered?: boolean;
 	responseIsRedacted?: boolean;
-}
-
-export interface IChatResponse {
-	session: IChat;
-	errorDetails?: IChatResponseErrorDetails;
-	timings?: {
-		firstProgress?: number;
-		totalElapsed: number;
-	};
 }
 
 export interface IChatResponseProgressFileTreeData {
@@ -234,6 +225,7 @@ export interface IChatUserActionEvent {
 	agentId: string | undefined;
 	sessionId: string;
 	requestId: string;
+	result: IChatAgentResult | undefined;
 }
 
 export interface IChatDynamicRequest {
@@ -250,7 +242,7 @@ export interface IChatDynamicRequest {
 
 export interface IChatCompleteResponse {
 	message: string | ReadonlyArray<IChatProgress>;
-	errorDetails?: IChatResponseErrorDetails;
+	result?: IChatAgentResult;
 	followups?: IChatFollowup[];
 }
 

--- a/src/vs/workbench/contrib/chat/common/chatServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/chatServiceImpl.ts
@@ -20,13 +20,13 @@ import { Progress } from 'vs/platform/progress/common/progress';
 import { IStorageService, StorageScope, StorageTarget } from 'vs/platform/storage/common/storage';
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 import { IWorkspaceContextService } from 'vs/platform/workspace/common/workspace';
-import { IChatAgentCommand, IChatAgentData, IChatAgentHistoryEntry, IChatAgentRequest, IChatAgentService } from 'vs/workbench/contrib/chat/common/chatAgents';
+import { IChatAgentCommand, IChatAgentData, IChatAgentHistoryEntry, IChatAgentRequest, IChatAgentResult, IChatAgentService } from 'vs/workbench/contrib/chat/common/chatAgents';
 import { CONTEXT_PROVIDER_EXISTS } from 'vs/workbench/contrib/chat/common/chatContextKeys';
 import { ChatModel, ChatModelInitState, ChatRequestModel, ChatWelcomeMessageModel, IChatModel, IChatRequestVariableData, ISerializableChatData, ISerializableChatsData } from 'vs/workbench/contrib/chat/common/chatModel';
 import { ChatRequestAgentPart, ChatRequestAgentSubcommandPart, ChatRequestSlashCommandPart, IParsedChatRequest, getPromptText } from 'vs/workbench/contrib/chat/common/chatParserTypes';
 import { ChatMessageRole, IChatMessage } from 'vs/workbench/contrib/chat/common/chatProvider';
 import { ChatRequestParser } from 'vs/workbench/contrib/chat/common/chatRequestParser';
-import { ChatAgentCopyKind, IChat, IChatCompleteResponse, IChatDetail, IChatDynamicRequest, IChatFollowup, IChatProgress, IChatProvider, IChatProviderInfo, IChatResponse, IChatService, IChatTransferredSessionData, IChatUserActionEvent, InteractiveSessionVoteDirection } from 'vs/workbench/contrib/chat/common/chatService';
+import { ChatAgentCopyKind, IChat, IChatCompleteResponse, IChatDetail, IChatDynamicRequest, IChatFollowup, IChatProgress, IChatProvider, IChatProviderInfo, IChatService, IChatTransferredSessionData, IChatUserActionEvent, InteractiveSessionVoteDirection } from 'vs/workbench/contrib/chat/common/chatService';
 import { IChatSlashCommandService } from 'vs/workbench/contrib/chat/common/chatSlashCommands';
 import { IChatVariablesService } from 'vs/workbench/contrib/chat/common/chatVariables';
 import { IExtensionService } from 'vs/workbench/services/extensions/common/extensions';
@@ -516,7 +516,7 @@ export class ChatService extends Disposable implements IChatService {
 					this._onDidSubmitAgent.fire({ agent: agentPart.agent, slashCommand: agentSlashCommandPart.command, sessionId: model.sessionId });
 				}
 
-				let rawResponse: IChatResponse | null | undefined;
+				let rawResult: IChatAgentResult | null | undefined;
 				let agentOrCommandFollowups: Promise<IChatFollowup[] | undefined> | undefined = undefined;
 
 				const defaultAgent = this.chatAgentService.getDefaultAgent();
@@ -536,7 +536,7 @@ export class ChatService extends Disposable implements IChatService {
 							variables: request.variableData.variables,
 							command: request.response.slashCommand?.name
 						};
-						history.push({ request: historyRequest, response: request.response.response.value, result: { errorDetails: request.response.errorDetails } });
+						history.push({ request: historyRequest, response: request.response.response.value, result: request.response.result ?? {} });
 					}
 
 					const initVariableData: IChatRequestVariableData = { message: getPromptText(parsedRequest.parts), variables: {} };
@@ -554,13 +554,8 @@ export class ChatService extends Disposable implements IChatService {
 					};
 
 					const agentResult = await this.chatAgentService.invokeAgent(agent.id, requestProps, progressCallback, history, token);
-					rawResponse = {
-						session: model.session!,
-						errorDetails: agentResult.errorDetails,
-						timings: agentResult.timings
-					};
-					agentOrCommandFollowups = agentResult?.followUp ? Promise.resolve(agentResult.followUp) :
-						this.chatAgentService.getFollowups(agent.id, sessionId, CancellationToken.None);
+					rawResult = agentResult;
+					agentOrCommandFollowups = this.chatAgentService.getFollowups(agent.id, sessionId, CancellationToken.None);
 				} else if (commandPart && this.chatSlashCommandService.hasCommand(commandPart.slashCommand.command)) {
 					request = model.addRequest(parsedRequest, { message, variables: {} });
 					// contributed slash commands
@@ -577,7 +572,7 @@ export class ChatService extends Disposable implements IChatService {
 						progressCallback(p);
 					}), history, token);
 					agentOrCommandFollowups = Promise.resolve(commandResult?.followUp);
-					rawResponse = { session: model.session! };
+					rawResult = {};
 
 				} else {
 					throw new Error(`Cannot handle request`);
@@ -586,36 +581,36 @@ export class ChatService extends Disposable implements IChatService {
 				if (token.isCancellationRequested) {
 					return;
 				} else {
-					if (!rawResponse) {
+					if (!rawResult) {
 						this.trace('sendRequest', `Provider returned no response for session ${model.sessionId}`);
-						rawResponse = { session: model.session!, errorDetails: { message: localize('emptyResponse', "Provider returned null response") } };
+						rawResult = { errorDetails: { message: localize('emptyResponse', "Provider returned null response") } };
 					}
 
-					const result = rawResponse.errorDetails?.responseIsFiltered ? 'filtered' :
-						rawResponse.errorDetails && gotProgress ? 'errorWithOutput' :
-							rawResponse.errorDetails ? 'error' :
+					const result = rawResult.errorDetails?.responseIsFiltered ? 'filtered' :
+						rawResult.errorDetails && gotProgress ? 'errorWithOutput' :
+							rawResult.errorDetails ? 'error' :
 								'success';
 					this.telemetryService.publicLog2<ChatProviderInvokedEvent, ChatProviderInvokedClassification>('interactiveSessionProviderInvoked', {
 						providerId: provider.id,
-						timeToFirstProgress: rawResponse.timings?.firstProgress,
-						totalTime: rawResponse.timings?.totalElapsed,
+						timeToFirstProgress: rawResult.timings?.firstProgress,
+						totalTime: rawResult.timings?.totalElapsed,
 						result,
 						requestType,
 						agent: agentPart?.agent.id ?? '',
 						slashCommand: agentSlashCommandPart ? agentSlashCommandPart.command.name : commandPart?.slashCommand.command,
 						chatSessionId: model.sessionId
 					});
-					model.setResponse(request, rawResponse);
+					model.setResponse(request, rawResult);
 					this.trace('sendRequest', `Provider returned response for session ${model.sessionId}`);
 
 					// TODO refactor this or rethink the API https://github.com/microsoft/vscode-copilot/issues/593
 					if (agentOrCommandFollowups) {
 						agentOrCommandFollowups.then(followups => {
 							model.setFollowups(request, followups);
-							model.completeResponse(request, rawResponse?.errorDetails);
+							model.completeResponse(request);
 						});
 					} else {
-						model.completeResponse(request, rawResponse?.errorDetails);
+						model.completeResponse(request);
 					}
 				}
 			} finally {
@@ -674,14 +669,11 @@ export class ChatService extends Disposable implements IChatService {
 				model.acceptResponseProgress(request, part, true);
 			}
 		}
-		model.setResponse(request, {
-			session: model.session!,
-			errorDetails: response.errorDetails,
-		});
+		model.setResponse(request, response.result || {});
 		if (response.followups !== undefined) {
 			model.setFollowups(request, response.followups);
 		}
-		model.completeResponse(request, response.errorDetails);
+		model.completeResponse(request);
 	}
 
 	cancelCurrentRequestForSession(sessionId: string): void {

--- a/src/vs/workbench/contrib/chat/common/chatServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/common/chatServiceImpl.ts
@@ -555,7 +555,7 @@ export class ChatService extends Disposable implements IChatService {
 
 					const agentResult = await this.chatAgentService.invokeAgent(agent.id, requestProps, progressCallback, history, token);
 					rawResult = agentResult;
-					agentOrCommandFollowups = this.chatAgentService.getFollowups(agent.id, sessionId, CancellationToken.None);
+					agentOrCommandFollowups = this.chatAgentService.getFollowups(agent.id, agentResult, CancellationToken.None);
 				} else if (commandPart && this.chatSlashCommandService.hasCommand(commandPart.slashCommand.command)) {
 					request = model.addRequest(parsedRequest, { message, variables: {} });
 					// contributed slash commands

--- a/src/vs/workbench/contrib/chat/common/chatViewModel.ts
+++ b/src/vs/workbench/contrib/chat/common/chatViewModel.ts
@@ -339,6 +339,10 @@ export class ChatResponseViewModel extends Disposable implements IChatResponseVi
 		return this._model.result;
 	}
 
+	get errorDetails(): IChatResponseErrorDetails | undefined {
+		return this.result?.errorDetails;
+	}
+
 	get vote() {
 		return this._model.vote;
 	}

--- a/src/vs/workbench/contrib/chat/common/chatViewModel.ts
+++ b/src/vs/workbench/contrib/chat/common/chatViewModel.ts
@@ -8,7 +8,7 @@ import { Disposable } from 'vs/base/common/lifecycle';
 import { URI } from 'vs/base/common/uri';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { ILogService } from 'vs/platform/log/common/log';
-import { IChatAgentCommand, IChatAgentData } from 'vs/workbench/contrib/chat/common/chatAgents';
+import { IChatAgentCommand, IChatAgentData, IChatAgentResult } from 'vs/workbench/contrib/chat/common/chatAgents';
 import { ChatModelInitState, IChatModel, IChatRequestModel, IChatResponseModel, IChatWelcomeMessageContent, IResponse } from 'vs/workbench/contrib/chat/common/chatModel';
 import { IParsedChatRequest } from 'vs/workbench/contrib/chat/common/chatParserTypes';
 import { IChatContentReference, IChatProgressMessage, IChatFollowup, IChatResponseErrorDetails, IChatResponseProgressFileTreeData, IChatUsedContext, InteractiveSessionVoteDirection, IChatCommandButton } from 'vs/workbench/contrib/chat/common/chatService';
@@ -122,6 +122,7 @@ export interface IChatResponseViewModel {
 	readonly vote: InteractiveSessionVoteDirection | undefined;
 	readonly replyFollowups?: IChatFollowup[];
 	readonly errorDetails?: IChatResponseErrorDetails;
+	readonly result?: IChatAgentResult;
 	readonly contentUpdateTimings?: IChatLiveUpdateData;
 	renderData?: IChatResponseRenderData;
 	agentAvatarHasBeenRendered?: boolean;
@@ -203,7 +204,7 @@ export class ChatViewModel extends Disposable implements IChatViewModel {
 				if (typeof responseIdx === 'number' && responseIdx >= 0) {
 					const items = this._items.splice(responseIdx, 1);
 					const item = items[0];
-					if (isResponseVM(item)) {
+					if (item instanceof ChatResponseViewModel) {
 						item.dispose();
 					}
 				}
@@ -334,8 +335,8 @@ export class ChatResponseViewModel extends Disposable implements IChatResponseVi
 		return this._model.followups?.filter((f): f is IChatFollowup => f.kind === 'reply');
 	}
 
-	get errorDetails() {
-		return this._model.errorDetails;
+	get result() {
+		return this._model.result;
 	}
 
 	get vote() {

--- a/src/vs/workbench/contrib/chat/test/common/__snapshots__/Chat_can_deserialize.0.snap
+++ b/src/vs/workbench/contrib/chat/test/common/__snapshots__/Chat_can_deserialize.0.snap
@@ -10,6 +10,7 @@
         text: "@ChatProviderWithUsedContext test request",
         parts: [
           {
+            kind: "agent",
             range: {
               start: 0,
               endExclusive: 28
@@ -22,11 +23,8 @@
             },
             agent: {
               id: "ChatProviderWithUsedContext",
-              metadata: {  },
-              provideSlashCommands: [Function provideSlashCommands],
-              invoke: [Function invoke]
-            },
-            kind: "agent"
+              metadata: {  }
+            }
           },
           {
             range: {
@@ -49,8 +47,8 @@
         variables: {  }
       },
       response: [  ],
-      responseErrorDetails: undefined,
-      followups: [  ],
+      result: { metadata: { metadataKey: "value" } },
+      followups: undefined,
       isCanceled: false,
       vote: undefined,
       agent: {

--- a/src/vs/workbench/contrib/chat/test/common/__snapshots__/Chat_can_serialize.1.snap
+++ b/src/vs/workbench/contrib/chat/test/common/__snapshots__/Chat_can_serialize.1.snap
@@ -9,6 +9,7 @@
       message: {
         parts: [
           {
+            kind: "agent",
             range: {
               start: 0,
               endExclusive: 28
@@ -21,11 +22,8 @@
             },
             agent: {
               id: "ChatProviderWithUsedContext",
-              metadata: {  },
-              provideSlashCommands: [Function provideSlashCommands],
-              invoke: [Function invoke]
-            },
-            kind: "agent"
+              metadata: {  }
+            }
           },
           {
             range: {
@@ -49,7 +47,7 @@
         variables: {  }
       },
       response: [  ],
-      responseErrorDetails: undefined,
+      result: { metadata: { metadataKey: "value" } },
       followups: undefined,
       isCanceled: false,
       vote: undefined,

--- a/src/vs/workbench/contrib/chat/test/common/chatService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/chatService.test.ts
@@ -75,7 +75,10 @@ const chatAgentWithUsedContext: IChatAgent = {
 			kind: 'usedContext'
 		});
 
-		return {};
+		return { metadata: { metadataKey: 'value' } };
+	},
+	async provideFollowups(sessionId, token) {
+		return [{ kind: 'reply', message: 'Something else', tooltip: 'a tooltip' }];
 	},
 };
 
@@ -109,6 +112,9 @@ suite('Chat', () => {
 			metadata: { isDefault: true },
 			async invoke(request, progress, history, token) {
 				return {};
+			},
+			async provideSlashCommands(token) {
+				return [];
 			},
 		} as IChatAgent;
 		testDisposables.add(chatAgentService.registerAgent(agent));
@@ -224,6 +230,7 @@ suite('Chat', () => {
 
 		const response = await testService.sendRequest(model.sessionId, `@${chatAgentWithUsedContextId} test request`);
 		assert(response);
+		await response.responseCompletePromise;
 
 		assert.strictEqual(model.getRequests().length, 1);
 

--- a/src/vs/workbench/contrib/chat/test/common/voiceChat.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/voiceChat.test.ts
@@ -44,7 +44,7 @@ suite('VoiceChat', () => {
 		readonly onDidChangeAgents = Event.None;
 		registerAgent(agent: IChatAgent): IDisposable { throw new Error(); }
 		invokeAgent(id: string, request: IChatAgentRequest, progress: (part: IChatProgress) => void, history: IChatAgentHistoryEntry[], token: CancellationToken): Promise<IChatAgentResult> { throw new Error(); }
-		getFollowups(id: string, sessionId: string, token: CancellationToken): Promise<IChatFollowup[]> { throw new Error(); }
+		getFollowups(id: string, result: IChatAgentResult, token: CancellationToken): Promise<IChatFollowup[]> { throw new Error(); }
 		getAgents(): Array<IChatAgent> { return agents; }
 		getAgent(id: string): IChatAgent | undefined { throw new Error(); }
 		getDefaultAgent(): IChatAgent | undefined { throw new Error(); }

--- a/src/vscode-dts/vscode.proposed.chatAgents2.d.ts
+++ b/src/vscode-dts/vscode.proposed.chatAgents2.d.ts
@@ -110,12 +110,12 @@ declare module 'vscode' {
 	/**
 	 * Represents user feedback for a result.
 	 */
-	export interface ChatAgentResult2Feedback<TResult extends ChatAgentResult2> {
+	export interface ChatAgentResult2Feedback {
 		/**
 		 * This instance of ChatAgentResult2 is the same instance that was returned from the chat agent,
 		 * and it can be extended with arbitrary properties if needed.
 		 */
-		readonly result: TResult;
+		readonly result: ChatAgentResult2;
 
 		/**
 		 * The kind of feedback that was received.
@@ -197,16 +197,16 @@ declare module 'vscode' {
 	/**
 	 * Will be invoked once after each request to get suggested followup questions to show the user. The user can click the followup to send it to the chat.
 	 */
-	export interface ChatAgentFollowupProvider<TResult extends ChatAgentResult2> {
+	export interface ChatAgentFollowupProvider {
 		/**
 		 *
 		 * @param result The same instance of the result object that was returned by the chat agent, and it can be extended with arbitrary properties if needed.
 		 * @param token A cancellation token.
 		 */
-		provideFollowups(result: TResult, token: CancellationToken): ProviderResult<ChatAgentFollowup[]>;
+		provideFollowups(result: ChatAgentResult2, token: CancellationToken): ProviderResult<ChatAgentFollowup[]>;
 	}
 
-	export interface ChatAgent2<TResult extends ChatAgentResult2> {
+	export interface ChatAgent2 {
 
 		/**
 		 * The short name by which this agent is referred to in the UI, e.g `workspace`.
@@ -245,7 +245,7 @@ declare module 'vscode' {
 		/**
 		 * This provider will be called once after each request to retrieve suggested followup questions.
 		 */
-		followupProvider?: ChatAgentFollowupProvider<TResult>;
+		followupProvider?: ChatAgentFollowupProvider;
 
 
 		// TODO@API
@@ -269,7 +269,7 @@ declare module 'vscode' {
 		 * The passed {@link ChatAgentResult2Feedback.result result} is guaranteed to be the same instance that was
 		 * previously returned from this chat agent.
 		 */
-		onDidReceiveFeedback: Event<ChatAgentResult2Feedback<TResult>>;
+		onDidReceiveFeedback: Event<ChatAgentResult2Feedback>;
 
 		/**
 		 * Dispose this agent and free resources
@@ -580,7 +580,7 @@ declare module 'vscode' {
 		 * @param handler The reply-handler of the agent.
 		 * @returns A new chat agent
 		 */
-		export function createChatAgent<TResult extends ChatAgentResult2>(name: string, handler: ChatAgentHandler): ChatAgent2<TResult>;
+		export function createChatAgent(name: string, handler: ChatAgentHandler): ChatAgent2;
 
 		/**
 		 * Register a variable which can be used in a chat request to any agent.

--- a/src/vscode-dts/vscode.proposed.chatAgents2.d.ts
+++ b/src/vscode-dts/vscode.proposed.chatAgents2.d.ts
@@ -86,9 +86,10 @@ declare module 'vscode' {
 		 */
 		errorDetails?: ChatAgentErrorDetails;
 
-		// TODO@API
-		// add CATCH-all signature [name:string]: string|boolean|number instead of `T extends...`
-		// readonly metadata: { readonly [key: string]: any };
+		/**
+		 * Arbitrary metadata for this result. Can be anything but must be JSON-stringifyable.
+		 */
+		readonly metadata?: { readonly [key: string]: any };
 	}
 
 	/**

--- a/src/vscode-dts/vscode.proposed.chatAgents2Additions.d.ts
+++ b/src/vscode-dts/vscode.proposed.chatAgents2Additions.d.ts
@@ -77,7 +77,7 @@ declare module 'vscode' {
 		/**
 		 * Create a chat agent with the extended progress type
 		 */
-		export function createChatAgent<TResult extends ChatAgentResult2>(name: string, handler: ChatAgentExtendedHandler): ChatAgent2;
+		export function createChatAgent(name: string, handler: ChatAgentExtendedHandler): ChatAgent2;
 	}
 
 	/*

--- a/src/vscode-dts/vscode.proposed.chatAgents2Additions.d.ts
+++ b/src/vscode-dts/vscode.proposed.chatAgents2Additions.d.ts
@@ -5,7 +5,7 @@
 
 declare module 'vscode' {
 
-	export interface ChatAgent2<TResult extends ChatAgentResult2> {
+	export interface ChatAgent2 {
 		onDidPerformAction: Event<ChatAgentUserActionEvent>;
 		supportIssueReporting?: boolean;
 	}
@@ -50,7 +50,7 @@ declare module 'vscode' {
 		report(value: ChatAgentExtendedProgress): void;
 	};
 
-	export interface ChatAgent2<TResult extends ChatAgentResult2> {
+	export interface ChatAgent2 {
 		/**
 		 * Provide a set of variables that can only be used with this agent.
 		 */
@@ -77,7 +77,7 @@ declare module 'vscode' {
 		/**
 		 * Create a chat agent with the extended progress type
 		 */
-		export function createChatAgent<TResult extends ChatAgentResult2>(name: string, handler: ChatAgentExtendedHandler): ChatAgent2<TResult>;
+		export function createChatAgent<TResult extends ChatAgentResult2>(name: string, handler: ChatAgentExtendedHandler): ChatAgent2;
 	}
 
 	/*

--- a/src/vscode-dts/vscode.proposed.defaultChatAgent.d.ts
+++ b/src/vscode-dts/vscode.proposed.defaultChatAgent.d.ts
@@ -12,7 +12,7 @@ declare module 'vscode' {
 		provideSampleQuestions?(token: CancellationToken): ProviderResult<ChatAgentFollowup[]>;
 	}
 
-	export interface ChatAgent2<TResult extends ChatAgentResult2> {
+	export interface ChatAgent2 {
 		/**
 		 * When true, this agent is invoked by default when no other agent is being invoked
 		 */


### PR DESCRIPTION
Instead of returning the same Result instance back to the extension, we let them return some serializable metadata, and return that. This can include a sessionId or some other state.