### PR TITLE
Leverage AuthenticationProviders for gating Language Model Access

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadChatProvider.ts
+++ b/src/vs/workbench/api/browser/mainThreadChatProvider.ts
@@ -4,7 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { CancellationToken } from 'vs/base/common/cancellation';
-import { DisposableMap, DisposableStore } from 'vs/base/common/lifecycle';
+import { Emitter, Event } from 'vs/base/common/event';
+import { DisposableMap, DisposableStore, IDisposable, toDisposable } from 'vs/base/common/lifecycle';
 import { localize } from 'vs/nls';
 import { ExtensionIdentifier } from 'vs/platform/extensions/common/extensions';
 import { ILogService } from 'vs/platform/log/common/log';
@@ -12,8 +13,10 @@ import { IProgress, Progress } from 'vs/platform/progress/common/progress';
 import { Registry } from 'vs/platform/registry/common/platform';
 import { ExtHostChatProviderShape, ExtHostContext, MainContext, MainThreadChatProviderShape } from 'vs/workbench/api/common/extHost.protocol';
 import { IChatResponseProviderMetadata, IChatResponseFragment, IChatProviderService, IChatMessage } from 'vs/workbench/contrib/chat/common/chatProvider';
+import { AuthenticationSession, AuthenticationSessionsChangeEvent, IAuthenticationProvider, IAuthenticationProviderCreateSessionOptions, IAuthenticationService, INTERNAL_AUTH_PROVIDER_PREFIX } from 'vs/workbench/services/authentication/common/authentication';
 import { Extensions, IExtensionFeaturesManagementService, IExtensionFeaturesRegistry } from 'vs/workbench/services/extensionManagement/common/extensionFeatures';
 import { IExtHostContext, extHostNamedCustomer } from 'vs/workbench/services/extensions/common/extHostCustomers';
+import { IExtensionService } from 'vs/workbench/services/extensions/common/extensions';
 
 @extHostNamedCustomer(MainContext.MainThreadChatProvider)
 export class MainThreadChatProvider implements MainThreadChatProviderShape {
@@ -28,6 +31,8 @@ export class MainThreadChatProvider implements MainThreadChatProviderShape {
 		@IChatProviderService private readonly _chatProviderService: IChatProviderService,
 		@IExtensionFeaturesManagementService private readonly _extensionFeaturesManagementService: IExtensionFeaturesManagementService,
 		@ILogService private readonly _logService: ILogService,
+		@IAuthenticationService private readonly _authenticationService: IAuthenticationService,
+		@IExtensionService private readonly _extensionService: IExtensionService
 	) {
 		this._proxy = extHostContext.getProxy(ExtHostContext.ExtHostChatProvider);
 
@@ -54,6 +59,7 @@ export class MainThreadChatProvider implements MainThreadChatProviderShape {
 				}
 			}
 		}));
+		dipsosables.add(this._registerAuthenticationProvider(identifier));
 		dipsosables.add(Registry.as<IExtensionFeaturesRegistry>(Extensions.ExtensionFeaturesRegistry).registerExtensionFeature({
 			id: `lm-${identifier}`,
 			label: localize('languageModels', "Language Model ({0})", `${identifier}-${metadata.model}`),
@@ -92,5 +98,101 @@ export class MainThreadChatProvider implements MainThreadChatProviderShape {
 		});
 
 		return task;
+	}
+
+	private _registerAuthenticationProvider(identifier: string): IDisposable {
+		const disposables = new DisposableStore();
+		// This needs to be done in both MainThread & ExtHost ChatProvider
+		const authProviderId = INTERNAL_AUTH_PROVIDER_PREFIX + identifier;
+		// This is what will be displayed in the UI and the account used for managing access via Auth UI
+		const authAccountId = identifier;
+		this._authenticationService.registerAuthenticationProvider(authProviderId, new LanguageModelAccessAuthProvider(authProviderId, authAccountId));
+		disposables.add(toDisposable(() => {
+			this._authenticationService.unregisterAuthenticationProvider(authProviderId);
+		}));
+		disposables.add(this._authenticationService.onDidChangeSessions(async (e) => {
+			if (e.providerId === authProviderId) {
+				if (e.event.removed?.length) {
+					const allowedExtensions = this._authenticationService.readAllowedExtensions(authProviderId, authAccountId);
+					const extensionsToUpdateAccess = [];
+					for (const allowed of allowedExtensions) {
+						const extension = await this._extensionService.getExtension(allowed.id);
+						this._authenticationService.updateAllowedExtension(authProviderId, authAccountId, allowed.id, allowed.name, false);
+						if (extension) {
+							extensionsToUpdateAccess.push({
+								extension: extension.identifier,
+								enabled: false
+							});
+						}
+					}
+					this._proxy.$updateAccesslist(extensionsToUpdateAccess);
+				}
+			}
+		}));
+		disposables.add(this._authenticationService.onDidChangeExtensionSessionAccess(async (e) => {
+			const allowedExtensions = this._authenticationService.readAllowedExtensions(authProviderId, authAccountId);
+			const accessList = [];
+			for (const allowedExtension of allowedExtensions) {
+				const extension = await this._extensionService.getExtension(allowedExtension.id);
+				if (extension) {
+					accessList.push({
+						extension: extension.identifier,
+						enabled: allowedExtension.allowed ?? true
+					});
+				}
+			}
+			this._proxy.$updateAccesslist(accessList);
+		}));
+		return disposables;
+	}
+}
+
+// The fake AuthenticationProvider that will be used to gate access to the Language Model. There will be one per provider.
+class LanguageModelAccessAuthProvider implements IAuthenticationProvider {
+	supportsMultipleAccounts = false;
+	label = 'Language Model';
+
+	// Important for updating the UI
+	private _onDidChangeSessions: Emitter<AuthenticationSessionsChangeEvent> = new Emitter<AuthenticationSessionsChangeEvent>();
+	onDidChangeSessions: Event<AuthenticationSessionsChangeEvent> = this._onDidChangeSessions.event;
+
+	private _session: AuthenticationSession | undefined;
+
+	constructor(readonly id: string, private readonly accountName: string) { }
+
+	async getSessions(scopes?: string[] | undefined): Promise<readonly AuthenticationSession[]> {
+		// If there are no scopes and no session that means no extension has requested a session yet
+		// and the user is simply opening the Account menu. In that case, we should not return any "sessions".
+		if (scopes === undefined && !this._session) {
+			return [];
+		}
+		if (this._session) {
+			return [this._session];
+		}
+		return [await this.createSession(scopes || [], {})];
+	}
+	async createSession(scopes: string[], options: IAuthenticationProviderCreateSessionOptions): Promise<AuthenticationSession> {
+		this._session = this._createFakeSession(scopes);
+		this._onDidChangeSessions.fire({ added: [this._session], changed: [], removed: [] });
+		return this._session;
+	}
+	removeSession(sessionId: string): Promise<void> {
+		if (this._session) {
+			this._onDidChangeSessions.fire({ added: [], changed: [], removed: [this._session!] });
+			this._session = undefined;
+		}
+		return Promise.resolve();
+	}
+
+	private _createFakeSession(scopes: string[]): AuthenticationSession {
+		return {
+			id: 'fake-session',
+			account: {
+				id: this.id,
+				label: this.accountName,
+			},
+			accessToken: 'fake-access-token',
+			scopes,
+		};
 	}
 }

--- a/src/vs/workbench/api/common/extHost.api.impl.ts
+++ b/src/vs/workbench/api/common/extHost.api.impl.ts
@@ -207,7 +207,7 @@ export function createApiFactoryAndRegisterActors(accessor: ServicesAccessor): I
 	const extHostProfileContentHandlers = rpcProtocol.set(ExtHostContext.ExtHostProfileContentHandlers, new ExtHostProfileContentHandlers(rpcProtocol));
 	rpcProtocol.set(ExtHostContext.ExtHostInteractive, new ExtHostInteractive(rpcProtocol, extHostNotebook, extHostDocumentsAndEditors, extHostCommands, extHostLogService));
 	const extHostInteractiveEditor = rpcProtocol.set(ExtHostContext.ExtHostInlineChat, new ExtHostInteractiveEditor(rpcProtocol, extHostCommands, extHostDocuments, extHostLogService));
-	const extHostChatProvider = rpcProtocol.set(ExtHostContext.ExtHostChatProvider, new ExtHostChatProvider(rpcProtocol, extHostLogService));
+	const extHostChatProvider = rpcProtocol.set(ExtHostContext.ExtHostChatProvider, new ExtHostChatProvider(rpcProtocol, extHostLogService, extHostAuthentication));
 	const extHostChatAgents2 = rpcProtocol.set(ExtHostContext.ExtHostChatAgents2, new ExtHostChatAgents2(rpcProtocol, extHostChatProvider, extHostLogService, extHostCommands));
 	const extHostChatVariables = rpcProtocol.set(ExtHostContext.ExtHostChatVariables, new ExtHostChatVariables(rpcProtocol));
 	const extHostChat = rpcProtocol.set(ExtHostContext.ExtHostChat, new ExtHostChat(rpcProtocol));
@@ -1399,7 +1399,7 @@ export function createApiFactoryAndRegisterActors(accessor: ServicesAccessor): I
 			},
 			requestLanguageModelAccess(id, options) {
 				checkProposedApiEnabled(extension, 'chatRequestAccess');
-				return extHostChatProvider.requestLanguageModelAccess(extension.identifier, id, options);
+				return extHostChatProvider.requestLanguageModelAccess(extension, id, options);
 			},
 			get languageModels() {
 				checkProposedApiEnabled(extension, 'chatRequestAccess');

--- a/src/vs/workbench/api/common/extHostAuthentication.ts
+++ b/src/vs/workbench/api/common/extHostAuthentication.ts
@@ -8,6 +8,7 @@ import { Emitter, Event } from 'vs/base/common/event';
 import { IMainContext, MainContext, MainThreadAuthenticationShape, ExtHostAuthenticationShape } from 'vs/workbench/api/common/extHost.protocol';
 import { Disposable } from 'vs/workbench/api/common/extHostTypes';
 import { IExtensionDescription, ExtensionIdentifier } from 'vs/platform/extensions/common/extensions';
+import { INTERNAL_AUTH_PROVIDER_PREFIX } from 'vs/workbench/services/authentication/common/authentication';
 
 interface ProviderWithMetadata {
 	label: string;
@@ -106,7 +107,10 @@ export class ExtHostAuthentication implements ExtHostAuthenticationShape {
 	}
 
 	$onDidChangeAuthenticationSessions(id: string, label: string) {
-		this._onDidChangeSessions.fire({ provider: { id, label } });
+		// Don't fire events for the internal auth providers
+		if (!id.startsWith(INTERNAL_AUTH_PROVIDER_PREFIX)) {
+			this._onDidChangeSessions.fire({ provider: { id, label } });
+		}
 		return Promise.resolve();
 	}
 }

--- a/src/vs/workbench/services/authentication/common/authentication.ts
+++ b/src/vs/workbench/services/authentication/common/authentication.ts
@@ -5,6 +5,11 @@
 import { Event } from 'vs/base/common/event';
 import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
 
+/**
+ * Use this if you don't want the onDidChangeSessions event to fire in the extension host
+ */
+export const INTERNAL_AUTH_PROVIDER_PREFIX = '__';
+
 export interface AuthenticationSessionAccount {
 	label: string;
 	id: string;
@@ -34,6 +39,20 @@ export interface IAuthenticationCreateSessionOptions {
 	activateImmediate?: boolean;
 }
 
+export interface AllowedExtension {
+	id: string;
+	name: string;
+	/**
+	 * If true or undefined, the extension is allowed to use the account
+	 * If false, the extension is not allowed to use the account
+	 * TODO: undefined shouldn't be a valid value, but it is for now
+	 */
+	allowed?: boolean;
+	lastUsed?: number;
+	// If true, this comes from the product.json
+	trusted?: boolean;
+}
+
 export const IAuthenticationService = createDecorator<IAuthenticationService>('IAuthenticationService');
 
 export interface IAuthenticationService {
@@ -58,6 +77,7 @@ export interface IAuthenticationService {
 	readonly onDidUnregisterAuthenticationProvider: Event<AuthenticationProviderInformation>;
 
 	readonly onDidChangeSessions: Event<{ providerId: string; label: string; event: AuthenticationSessionsChangeEvent }>;
+	readonly onDidChangeExtensionSessionAccess: Event<{ providerId: string; accountName: string }>;
 
 	// TODO completely remove this property
 	declaredProviders: AuthenticationProviderInformation[];
@@ -70,6 +90,7 @@ export interface IAuthenticationService {
 	removeSession(providerId: string, sessionId: string): Promise<void>;
 
 	manageTrustedExtensionsForAccount(providerId: string, accountName: string): Promise<void>;
+	readAllowedExtensions(providerId: string, accountName: string): AllowedExtension[];
 	removeAccountSessions(providerId: string, accountName: string, sessions: AuthenticationSession[]): Promise<void>;
 }
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
This is a pragmatic approach to gating language model access using familiar UI.

Since we already have the Auth Stack which has a concept of "Managing Trusted Extensions" we can initially use that for gating La
nguage Model Access so that when an extension asks for Language Model Access, they have to see a dialog first.

This auth provider is an implementation detail of a Language Model and neither the extension author nor the user need to know anything about it.

The user can use familiar UI for managing trusted extensions:
![image](https://github.com/microsoft/vscode/assets/2644648/adb21b3e-92cc-40bd-ae6f-4ab6f59fb0ca)
![image](https://github.com/microsoft/vscode/assets/2644648/19bfcec5-154c-4ba1-a645-07c782ad6f08)
![image](https://github.com/microsoft/vscode/assets/2644648/88936aa3-4072-4731-aff5-22739641da8e)

fixes https://github.com/microsoft/vscode/issues/205389