### PR TITLE
Check for newline instead of an arbitrary length for showing hover hint

### DIFF
--- a/src/vs/platform/quickinput/browser/quickInput.ts
+++ b/src/vs/platform/quickinput/browser/quickInput.ts
@@ -1283,7 +1283,7 @@ export class QuickInputHoverDelegate implements IHoverDelegate {
 				: typeof options.content === 'string'
 					? options.content
 					: options.content.value
-		).length > 20;
+		).includes('\n');
 		return this.hoverService.showHover({
 			...options,
 			persistence: {


### PR DESCRIPTION
This should show the hint less in scenarios where we don't need it.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
