### PR TITLE
Update comment in extensionGalleryService.ts

### DIFF
--- a/src/vs/platform/extensionManagement/common/extensionGalleryService.ts
+++ b/src/vs/platform/extensionManagement/common/extensionGalleryService.ts
@@ -167,9 +167,8 @@ enum Flags {
 	IncludeLatestVersionOnly = 0x200,
 
 	/**
-	 * This flag switches the asset uri to use GetAssetByName instead of CDN
-	 * When this is used, values of base asset uri and base asset uri fallback are switched
-	 * When this is used, source of asset files are pointed to Gallery service always even if CDN is available
+	 * The Unpublished extension flag indicates that the extension can't be installed/downloaded.
+	 * Users who have installed such an extension can continue to use the extension.
 	 */
 	Unpublished = 0x1000,
 


### PR DESCRIPTION
See issue #205003

The comment associated with [this code](https://github.com/microsoft/vscode/blob/b2d46084e9900bc9c4818e5824288ebdc4bc4a23/src/vs/platform/extensionManagement/common/extensionGalleryService.ts#L169-L174) is incorrect:

```
	/**
	 * This flag switches the asset uri to use GetAssetByName instead of CDN
	 * When this is used, values of base asset uri and base asset uri fallback are switched
	 * When this is used, source of asset files are pointed to Gallery service always even if CDN is available
	 */
	Unpublished = 0x1000,
```

I suggest changing it to something like this:

```
	/**
	 * The Unpublished extension flag indicates that the extension can't be installed/downloaded.
	 * Users who have installed such an extension can continue to use the extension.
	 */
	Unpublished = 0x1000,
```