### PR TITLE
Introduce disablementMessage API proposal

### DIFF
--- a/src/vs/workbench/api/common/extHostInlineChat.ts
+++ b/src/vs/workbench/api/common/extHostInlineChat.ts
@@ -128,6 +128,7 @@ export class ExtHostInteractiveEditor implements ExtHostInlineChatShape {
 			id,
 			placeholder: session.placeholder,
 			input: session.input,
+			disablementMessage: session.disablementMessage,
 			slashCommands: session.slashCommands?.map(c => ({ command: c.command, detail: c.detail, refer: c.refer, executeImmediately: c.executeImmediately })),
 			wholeRange: typeConvert.Range.from(session.wholeRange),
 			message: session.message

--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatController.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatController.ts
@@ -48,6 +48,7 @@ import { CTX_INLINE_CHAT_DID_EDIT, CTX_INLINE_CHAT_HAS_ACTIVE_REQUEST, CTX_INLIN
 import { ICommandService } from 'vs/platform/commands/common/commands';
 import { StashedSession } from './inlineChatSession';
 import { IValidEditOperation } from 'vs/editor/common/model';
+import { MessageController } from 'vs/editor/contrib/message/browser/messageController';
 
 export const enum State {
 	CREATE_SESSION = 'CREATE_SESSION',
@@ -295,14 +296,11 @@ export class InlineChatController implements IEditorContribution {
 
 		let session: Session | undefined = options.existingSession;
 
-
 		let initPosition: Position | undefined;
 		if (options.position) {
 			initPosition = Position.lift(options.position).delta(-1);
 			delete options.position;
 		}
-
-		this._showWidget(true, initPosition);
 
 		this._updatePlaceholder();
 
@@ -344,6 +342,13 @@ export class InlineChatController implements IEditorContribution {
 			this._dialogService.info(localize('create.fail', "Failed to start editor chat"), localize('create.fail.detail', "Please consult the error log and try again later."));
 			return State.CANCEL;
 		}
+
+		if (session.session.disablementMessage) {
+			MessageController.get(this._editor)?.showMessage(session.session.disablementMessage, this._editor.getPosition());
+			return State.CANCEL;
+		}
+
+		this._showWidget(true, initPosition);
 
 		// create a new strategy
 		switch (session.editMode) {

--- a/src/vs/workbench/contrib/inlineChat/common/inlineChat.ts
+++ b/src/vs/workbench/contrib/inlineChat/common/inlineChat.ts
@@ -32,6 +32,7 @@ export interface IInlineChatSlashCommand {
 export interface IInlineChatSession {
 	id: number;
 	placeholder?: string;
+	disablementMessage?: string;
 	input?: string;
 	message?: string;
 	slashCommands?: IInlineChatSlashCommand[];

--- a/src/vscode-dts/vscode.proposed.interactive.d.ts
+++ b/src/vscode-dts/vscode.proposed.interactive.d.ts
@@ -20,6 +20,7 @@ declare module 'vscode' {
 	// todo@API make classes
 	export interface InteractiveEditorSession {
 		placeholder?: string;
+		disablementMessage?: string;
 		input?: string;
 		slashCommands?: InteractiveEditorSlashCommand[];
 		wholeRange?: Range;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Introduces a new concept of `disablementMessage` to the API. This can be used for disabling the inline chat widget and showing some UI. 

This unfortunately defers the widget showing until after we retrieve a session from the ExtHost but seemed more favored by the team than showing UX inside the inline chat widget.


![image](https://github.com/microsoft/vscode/assets/4544166/7b0a0d53-950c-4a74-861b-74d88d6c6293)
