### PR TITLE
One auth provider per-extension

### DIFF
--- a/src/vs/workbench/api/common/extHost.api.impl.ts
+++ b/src/vs/workbench/api/common/extHost.api.impl.ts
@@ -1395,7 +1395,7 @@ export function createApiFactoryAndRegisterActors(accessor: ServicesAccessor): I
 		const chat: typeof vscode.chat = {
 			registerChatResponseProvider(id: string, provider: vscode.ChatResponseProvider, metadata: vscode.ChatResponseProviderMetadata) {
 				checkProposedApiEnabled(extension, 'chatProvider');
-				return extHostChatProvider.registerLanguageModel(extension.identifier, id, provider, metadata);
+				return extHostChatProvider.registerLanguageModel(extension, id, provider, metadata);
 			},
 			requestLanguageModelAccess(id, options) {
 				checkProposedApiEnabled(extension, 'chatRequestAccess');

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -1184,6 +1184,7 @@ export interface MainThreadChatProviderShape extends IDisposable {
 export interface ExtHostChatProviderShape {
 	$updateLanguageModels(data: { added?: string[]; removed?: string[] }): void;
 	$updateAccesslist(data: { extension: ExtensionIdentifier; enabled: boolean }[]): void;
+	$updateModelAccesslist(data: { from: ExtensionIdentifier; to: ExtensionIdentifier; enabled: boolean }[]): void;
 	$provideLanguageModelResponse(handle: number, requestId: number, from: ExtensionIdentifier, messages: IChatMessage[], options: { [name: string]: any }, token: CancellationToken): Promise<any>;
 	$handleResponseFragment(requestId: number, chunk: IChatResponseFragment): Promise<void>;
 }

--- a/src/vs/workbench/api/common/extHostChatProvider.ts
+++ b/src/vs/workbench/api/common/extHostChatProvider.ts
@@ -11,7 +11,7 @@ import * as typeConvert from 'vs/workbench/api/common/extHostTypeConverters';
 import type * as vscode from 'vscode';
 import { Progress } from 'vs/platform/progress/common/progress';
 import { IChatMessage, IChatResponseFragment } from 'vs/workbench/contrib/chat/common/chatProvider';
-import { ExtensionIdentifier, ExtensionIdentifierMap, ExtensionIdentifierSet, IRelaxedExtensionDescription } from 'vs/platform/extensions/common/extensions';
+import { ExtensionIdentifier, ExtensionIdentifierMap, ExtensionIdentifierSet, IExtensionDescription } from 'vs/platform/extensions/common/extensions';
 import { AsyncIterableSource } from 'vs/base/common/async';
 import { Emitter, Event } from 'vs/base/common/event';
 import { ExtHostAuthentication } from 'vs/workbench/api/common/extHostAuthentication';
@@ -91,12 +91,14 @@ export class ExtHostChatProvider implements ExtHostChatProviderShape {
 
 	private readonly _proxy: MainThreadChatProviderShape;
 	private readonly _onDidChangeAccess = new Emitter<ExtensionIdentifierSet>();
+	private readonly _onDidChangeModelAccess = new Emitter<{ from: ExtensionIdentifier; to: ExtensionIdentifier }>();
 	private readonly _onDidChangeProviders = new Emitter<vscode.LanguageModelChangeEvent>();
 	readonly onDidChangeProviders = this._onDidChangeProviders.event;
 
 	private readonly _languageModels = new Map<number, LanguageModelData>();
 	private readonly _languageModelIds = new Set<string>(); // these are ALL models, not just the one in this EH
 	private readonly _accesslist = new ExtensionIdentifierMap<boolean>();
+	private readonly _modelAccessList = new ExtensionIdentifierMap<ExtensionIdentifierSet>();
 	private readonly _pendingRequest = new Map<number, { languageModelId: string; res: LanguageModelRequest }>();
 
 
@@ -113,11 +115,22 @@ export class ExtHostChatProvider implements ExtHostChatProviderShape {
 		this._onDidChangeProviders.dispose();
 	}
 
-	registerLanguageModel(extension: ExtensionIdentifier, identifier: string, provider: vscode.ChatResponseProvider, metadata: vscode.ChatResponseProviderMetadata): IDisposable {
+	registerLanguageModel(extension: IExtensionDescription, identifier: string, provider: vscode.ChatResponseProvider, metadata: vscode.ChatResponseProviderMetadata): IDisposable {
 
 		const handle = ExtHostChatProvider._idPool++;
-		this._languageModels.set(handle, { extension, provider });
-		this._proxy.$registerProvider(handle, identifier, { extension, model: metadata.name ?? '' });
+		this._languageModels.set(handle, { extension: extension.identifier, provider });
+		let auth;
+		if (metadata.auth) {
+			auth = {
+				providerLabel: extension.displayName || extension.name,
+				accountLabel: typeof metadata.auth === 'object' ? metadata.auth.label : undefined
+			};
+		}
+		this._proxy.$registerProvider(handle, identifier, {
+			extension: extension.identifier,
+			model: metadata.name ?? '',
+			auth
+		});
 
 		return toDisposable(() => {
 			this._languageModels.delete(handle);
@@ -190,7 +203,26 @@ export class ExtHostChatProvider implements ExtHostChatProviderShape {
 		this._onDidChangeAccess.fire(updated);
 	}
 
-	async requestLanguageModelAccess(extension: Readonly<IRelaxedExtensionDescription>, languageModelId: string, options?: vscode.LanguageModelAccessOptions): Promise<vscode.LanguageModelAccess> {
+	$updateModelAccesslist(data: { from: ExtensionIdentifier; to: ExtensionIdentifier; enabled: boolean }[]): void {
+		const updated = new Array<{ from: ExtensionIdentifier; to: ExtensionIdentifier }>();
+		for (const { from, to, enabled } of data) {
+			const set = this._modelAccessList.get(from) ?? new ExtensionIdentifierSet();
+			const oldValue = set.has(to);
+			if (oldValue !== enabled) {
+				if (enabled) {
+					set.add(to);
+				} else {
+					set.delete(to);
+				}
+				this._modelAccessList.set(from, set);
+				const newItem = { from, to };
+				updated.push(newItem);
+				this._onDidChangeModelAccess.fire(newItem);
+			}
+		}
+	}
+
+	async requestLanguageModelAccess(extension: IExtensionDescription, languageModelId: string, options?: vscode.LanguageModelAccessOptions): Promise<vscode.LanguageModelAccess> {
 		const from = extension.identifier;
 		// check if the extension is in the access list and allowed to make chat requests
 		if (this._accesslist.get(from) === false) {
@@ -206,7 +238,10 @@ export class ExtHostChatProvider implements ExtHostChatProviderShape {
 			}
 			throw new Error(`Language model '${languageModelId}' NOT found`);
 		}
-		await this._checkAuthAccess(extension, languageModelId, justification);
+
+		if (metadata.auth) {
+			await this._checkAuthAccess(extension, { identifier: metadata.extension, displayName: metadata.auth?.providerLabel }, justification);
+		}
 
 		const that = this;
 
@@ -215,15 +250,18 @@ export class ExtHostChatProvider implements ExtHostChatProviderShape {
 				return metadata.model;
 			},
 			get isRevoked() {
-				return !that._accesslist.get(from) || !that._languageModelIds.has(languageModelId);
+				return !that._accesslist.get(from)
+					|| (metadata.auth && !that._modelAccessList.get(from)?.has(metadata.extension))
+					|| !that._languageModelIds.has(languageModelId);
 			},
 			get onDidChangeAccess() {
 				const onDidChangeAccess = Event.filter(that._onDidChangeAccess.event, set => set.has(from));
 				const onDidRemoveLM = Event.filter(that._onDidChangeProviders.event, e => e.removed.includes(languageModelId));
-				return Event.signal(Event.any(onDidChangeAccess, onDidRemoveLM));
+				const onDidChangeModelAccess = Event.filter(that._onDidChangeModelAccess.event, e => ExtensionIdentifier.equals(e.from, from) && ExtensionIdentifier.equals(e.to, metadata.extension));
+				return Event.signal(Event.any(onDidChangeAccess, onDidRemoveLM, onDidChangeModelAccess));
 			},
 			makeChatRequest(messages, options, token) {
-				if (!that._accesslist.get(from)) {
+				if (!that._accesslist.get(from) || (metadata.auth && !that._modelAccessList.get(from)?.has(metadata.extension))) {
 					throw new Error('Access to chat has been revoked');
 				}
 				if (!that._languageModelIds.has(languageModelId)) {
@@ -253,20 +291,22 @@ export class ExtHostChatProvider implements ExtHostChatProviderShape {
 	}
 
 	// BIG HACK: Using AuthenticationProviders to check access to Language Models
-	private async _checkAuthAccess(from: Readonly<IRelaxedExtensionDescription>, languageModelId: string, detail?: string): Promise<void> {
+	private async _checkAuthAccess(from: IExtensionDescription, to: { identifier: ExtensionIdentifier; displayName: string }, detail?: string): Promise<void> {
 		// This needs to be done in both MainThread & ExtHost ChatProvider
-		const providerId = INTERNAL_AUTH_PROVIDER_PREFIX + languageModelId;
+		const providerId = INTERNAL_AUTH_PROVIDER_PREFIX + to.identifier.value;
 		const session = await this._extHostAuthentication.getSession(from, providerId, [], { silent: true });
 		if (!session) {
 			try {
 				await this._extHostAuthentication.getSession(from, providerId, [], {
 					forceNewSession: {
-						detail: detail ?? localize('chatAccess', "To allow access to the '{0}' language model", languageModelId),
+						detail: detail ?? localize('chatAccess', "To allow access to the language models provided by {0}", to.displayName),
 					}
 				});
 			} catch (err) {
-				throw new Error('Access to language model has not been granted');
+				throw new Error('Access to language models has not been granted');
 			}
 		}
+
+		this.$updateModelAccesslist([{ from: from.identifier, to: to.identifier, enabled: true }]);
 	}
 }

--- a/src/vs/workbench/contrib/chat/common/chatProvider.ts
+++ b/src/vs/workbench/contrib/chat/common/chatProvider.ts
@@ -30,6 +30,10 @@ export interface IChatResponseProviderMetadata {
 	readonly extension: ExtensionIdentifier;
 	readonly model: string;
 	readonly description?: string;
+	readonly auth?: {
+		readonly providerLabel: string;
+		readonly accountLabel?: string;
+	};
 }
 
 export interface IChatResponseProvider {

--- a/src/vscode-dts/vscode.proposed.chatProvider.d.ts
+++ b/src/vscode-dts/vscode.proposed.chatProvider.d.ts
@@ -26,6 +26,13 @@ declare module 'vscode' {
 		 */
 		// TODO@API rename to model
 		name: string;
+
+		/**
+		 * When present, this gates the use of `requestLanguageModelAccess` behind an authorization flow where
+		 * the user must approve of another extension accessing the models contributed by this extension.
+		 * Additionally, the extension can provide a label that will be shown in the UI.
+		 */
+		auth?: true | { label: string };
 	}
 
 	export namespace chat {


### PR DESCRIPTION
This way we don't complicate the user's experience who doesn't need to know anything about models.

![image](https://github.com/microsoft/vscode/assets/2644648/fdfab3c7-78d1-44c4-a7ae-6d48cc3a08dd)
![image](https://github.com/microsoft/vscode/assets/2644648/4812b960-a570-4cb2-8577-72ada38fd808)

Additionally, this gives the extension the ability to specify the label that is shown in the account menu
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
ref https://github.com/microsoft/vscode/issues/205389