### PR TITLE
activitybar: Use orange active highlight in dark HC theme

### DIFF
--- a/extensions/theme-defaults/themes/dark_modern.json
+++ b/extensions/theme-defaults/themes/dark_modern.json
@@ -49,7 +49,7 @@
 		"input.background": "#313131",
 		"input.border": "#3C3C3C",
 		"input.foreground": "#CCCCCC",
-		"input.placeholderForeground": "#818181",
+		"input.placeholderForeground": "#989898",
 		"inputOption.activeBackground": "#2489DB82",
 		"inputOption.activeBorder": "#2488DB",
 		"keybindingLabel.foreground": "#CCCCCC",

--- a/extensions/theme-defaults/themes/light_modern.json
+++ b/extensions/theme-defaults/themes/light_modern.json
@@ -51,7 +51,7 @@
 		"input.background": "#FFFFFF",
 		"input.border": "#CECECE",
 		"input.foreground": "#3B3B3B",
-		"input.placeholderForeground": "#868686",
+		"input.placeholderForeground": "#767676",
 		"inputOption.activeBackground": "#BED6ED",
 		"inputOption.activeBorder": "#005FB8",
 		"inputOption.activeForeground": "#000000",

--- a/src/vs/workbench/browser/parts/activitybar/media/activityaction.css
+++ b/src/vs/workbench/browser/parts/activitybar/media/activityaction.css
@@ -107,6 +107,11 @@
 	border-left: 2px solid;
 }
 
+.monaco-workbench.hc-black .activitybar > .content :not(.monaco-menu) > .monaco-action-bar .action-item.checked .active-item-indicator:before,
+.monaco-workbench.hc-black .activitybar > .content :not(.monaco-menu) > .monaco-action-bar .action-item:focus .active-item-indicator:before {
+	border-color: var(--vscode-focusBorder);
+}
+
 .monaco-workbench .activitybar > .content :not(.monaco-menu) > .monaco-action-bar .action-item.checked .active-item-indicator:before {
 	top: 0;
 	height: 100%;


### PR DESCRIPTION
before/after: 
<img width="307" alt="image" src="https://github.com/microsoft/vscode/assets/103326/b6d6294c-3405-4bb8-9156-dc04283b774f">

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
