### PR TITLE
Chat Agent API updates

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadChatAgents2.ts
+++ b/src/vs/workbench/api/browser/mainThreadChatAgents2.ts
@@ -13,6 +13,7 @@ import { getWordAtText } from 'vs/editor/common/core/wordHelper';
 import { CompletionContext, CompletionItem, CompletionItemKind, CompletionList } from 'vs/editor/common/languages';
 import { ITextModel } from 'vs/editor/common/model';
 import { ILanguageFeaturesService } from 'vs/editor/common/services/languageFeatures';
+import { ExtensionIdentifier } from 'vs/platform/extensions/common/extensions';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { ExtHostChatAgentsShape2, ExtHostContext, IChatProgressDto, IExtensionChatAgentMetadata, MainContext, MainThreadChatAgentsShape2 } from 'vs/workbench/api/common/extHost.protocol';
 import { IChatWidgetService } from 'vs/workbench/contrib/chat/browser/chat';
@@ -74,10 +75,11 @@ export class MainThreadChatAgents2 extends Disposable implements MainThreadChatA
 		this._agents.deleteAndDispose(handle);
 	}
 
-	$registerAgent(handle: number, name: string, metadata: IExtensionChatAgentMetadata): void {
+	$registerAgent(handle: number, extension: ExtensionIdentifier, name: string, metadata: IExtensionChatAgentMetadata): void {
 		let lastSlashCommands: IChatAgentCommand[] | undefined;
 		const d = this._chatAgentService.registerAgent({
 			id: name,
+			extensionId: extension,
 			metadata: revive(metadata),
 			invoke: async (request, progress, history, token) => {
 				this._pendingProgress.set(request.requestId, progress);

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -1195,7 +1195,7 @@ export interface IExtensionChatAgentMetadata extends Dto<IChatAgentMetadata> {
 }
 
 export interface MainThreadChatAgentsShape2 extends IDisposable {
-	$registerAgent(handle: number, name: string, metadata: IExtensionChatAgentMetadata): void;
+	$registerAgent(handle: number, extension: ExtensionIdentifier, name: string, metadata: IExtensionChatAgentMetadata): void;
 	$registerAgentCompletionsProvider(handle: number, triggerCharacters: string[]): void;
 	$unregisterAgentCompletionsProvider(handle: number): void;
 	$updateAgent(handle: number, metadataUpdate: IExtensionChatAgentMetadata): void;

--- a/src/vs/workbench/api/common/extHostChatAgents2.ts
+++ b/src/vs/workbench/api/common/extHostChatAgents2.ts
@@ -176,7 +176,7 @@ export class ExtHostChatAgents2 implements ExtHostChatAgentsShape2 {
 		const agent = new ExtHostChatAgent(extension, name, this._proxy, handle, handler);
 		this._agents.set(handle, agent);
 
-		this._proxy.$registerAgent(handle, name, {});
+		this._proxy.$registerAgent(handle, extension.identifier, name, {});
 		return agent.apiAgent;
 	}
 
@@ -239,11 +239,11 @@ export class ExtHostChatAgents2 implements ExtHostChatAgentsShape2 {
 				{ ...ehResult, metadata: undefined };
 
 			// REQUEST turn
-			res.push(new extHostTypes.ChatAgentRequestTurn(h.request.message, h.request.agentId, h.request.command, h.request.variables2.variables.map(typeConvert.ChatAgentResolvedVariable.to)));
+			res.push(new extHostTypes.ChatAgentRequestTurn(h.request.message, h.request.command, h.request.variables2.variables.map(typeConvert.ChatAgentResolvedVariable.to), { extensionId: '', agentId: h.request.agentId }));
 
 			// RESPONSE turn
 			const parts = coalesce(h.response.map(r => typeConvert.ChatResponsePart.from(r, this.commands.converter)));
-			res.push(new extHostTypes.ChatAgentResponseTurn(parts, result, h.request.agentId));
+			res.push(new extHostTypes.ChatAgentResponseTurn(parts, result, { extensionId: '', agentId: h.request.agentId }));
 		}
 
 		return res;

--- a/src/vs/workbench/api/common/extHostChatAgents2.ts
+++ b/src/vs/workbench/api/common/extHostChatAgents2.ts
@@ -197,11 +197,10 @@ export class ExtHostChatAgents2 implements ExtHostChatAgentsShape2 {
 
 		const stream = new ChatAgentResponseStream(agent.extension, request, this._proxy, this._logService, this.commands.converter, sessionDisposables);
 		try {
-			const convertedHistory = await this.prepareHistory(request, context);
-			const convertedHistory2 = await this.prepareHistoryTurns(request, context);
+			const convertedHistory = await this.prepareHistoryTurns(request, context);
 			const task = agent.invoke(
 				typeConvert.ChatAgentRequest.to(request),
-				{ history: convertedHistory, history2: convertedHistory2 },
+				{ history: convertedHistory, history2: convertedHistory },
 				stream.apiObject,
 				token
 			);
@@ -227,21 +226,6 @@ export class ExtHostChatAgents2 implements ExtHostChatAgentsShape2 {
 			stream.close();
 			this._extHostChatProvider.$updateAccesslist([{ extension: agent.extension.identifier, enabled: false }]);
 		}
-	}
-
-	private async prepareHistory(request: IChatAgentRequest, context: { history: IChatAgentHistoryEntryDto[] }): Promise<vscode.ChatAgentHistoryEntry[]> {
-		return coalesce(await Promise.all(context.history
-			.map(async h => {
-				const ehResult = typeConvert.ChatAgentResult.to(h.result);
-				const result: vscode.ChatAgentResult2 = request.agentId === h.request.agentId ?
-					ehResult :
-					{ ...ehResult, metadata: undefined };
-				return {
-					request: typeConvert.ChatAgentRequest.to(h.request),
-					response: coalesce(h.response.map(r => typeConvert.ChatResponsePart.from(r, this.commands.converter))),
-					result,
-				} satisfies vscode.ChatAgentHistoryEntry;
-			})));
 	}
 
 	private async prepareHistoryTurns(request: IChatAgentRequest, context: { history: IChatAgentHistoryEntryDto[] }): Promise<(vscode.ChatAgentRequestTurn | vscode.ChatAgentResponseTurn)[]> {

--- a/src/vs/workbench/api/common/extHostTypes.ts
+++ b/src/vs/workbench/api/common/extHostTypes.ts
@@ -4258,20 +4258,28 @@ export class ChatResponseReferencePart {
 
 
 export class ChatAgentRequestTurn implements vscode.ChatAgentRequestTurn {
+	agentId: string;
 	constructor(
 		readonly prompt: string,
-		readonly agentId: string,
 		readonly command: string | undefined,
 		readonly variables: vscode.ChatAgentResolvedVariable[],
-	) { }
+		readonly agent: { extensionId: string; agentId: string },
+	) {
+		this.agentId = agent.agentId;
+	}
 }
 
 export class ChatAgentResponseTurn implements vscode.ChatAgentResponseTurn {
+
+	agentId: string;
+
 	constructor(
 		readonly response: ReadonlyArray<ChatResponseTextPart | ChatResponseMarkdownPart | ChatResponseFileTreePart | ChatResponseAnchorPart | ChatResponseCommandButtonPart>,
 		readonly result: vscode.ChatAgentResult2,
-		readonly agentId: string,
-	) { }
+		readonly agent: { extensionId: string; agentId: string }
+	) {
+		this.agentId = agent.agentId;
+	}
 }
 
 //#endregion

--- a/src/vs/workbench/contrib/chat/common/chatAgents.ts
+++ b/src/vs/workbench/contrib/chat/common/chatAgents.ts
@@ -11,6 +11,7 @@ import { Disposable, IDisposable, toDisposable } from 'vs/base/common/lifecycle'
 import { ThemeIcon } from 'vs/base/common/themables';
 import { URI } from 'vs/base/common/uri';
 import { ProviderResult } from 'vs/editor/common/languages';
+import { ExtensionIdentifier } from 'vs/platform/extensions/common/extensions';
 import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
 import { IChatProgressResponseContent, IChatRequestVariableData2 } from 'vs/workbench/contrib/chat/common/chatModel';
 import { IChatFollowup, IChatProgress, IChatResponseErrorDetails } from 'vs/workbench/contrib/chat/common/chatService';
@@ -26,6 +27,7 @@ export interface IChatAgentHistoryEntry {
 
 export interface IChatAgentData {
 	id: string;
+	extensionId: ExtensionIdentifier;
 	metadata: IChatAgentMetadata;
 }
 

--- a/src/vs/workbench/contrib/chat/common/chatModel.ts
+++ b/src/vs/workbench/contrib/chat/common/chatModel.ts
@@ -788,7 +788,7 @@ export class ChatModel extends Disposable implements IChatModel {
 					followups: r.response?.followups,
 					isCanceled: r.response?.isCanceled,
 					vote: r.response?.vote,
-					agent: r.response?.agent ? { id: r.response.agent.id, metadata: r.response.agent.metadata } : undefined, // May actually be the full IChatAgent instance, just take the data props
+					agent: r.response?.agent ? { id: r.response.agent.id, extensionId: r.response.agent.extensionId, metadata: r.response.agent.metadata } : undefined, // May actually be the full IChatAgent instance, just take the data props
 					slashCommand: r.response?.slashCommand,
 					usedContext: r.response?.usedContext,
 					contentReferences: r.response?.contentReferences

--- a/src/vs/workbench/contrib/chat/test/common/__snapshots__/Chat_can_deserialize.0.snap
+++ b/src/vs/workbench/contrib/chat/test/common/__snapshots__/Chat_can_deserialize.0.snap
@@ -53,6 +53,10 @@
       vote: undefined,
       agent: {
         id: "ChatProviderWithUsedContext",
+        extensionId: {
+          value: "nullExtensionDescription",
+          _lower: "nullextensiondescription"
+        },
         metadata: {  }
       },
       slashCommand: undefined,

--- a/src/vs/workbench/contrib/chat/test/common/__snapshots__/Chat_can_serialize.1.snap
+++ b/src/vs/workbench/contrib/chat/test/common/__snapshots__/Chat_can_serialize.1.snap
@@ -53,6 +53,10 @@
       vote: undefined,
       agent: {
         id: "ChatProviderWithUsedContext",
+        extensionId: {
+          value: "nullExtensionDescription",
+          _lower: "nullextensiondescription"
+        },
         metadata: {  }
       },
       slashCommand: undefined,

--- a/src/vs/workbench/contrib/chat/test/common/chatService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/chatService.test.ts
@@ -29,7 +29,7 @@ import { ChatService } from 'vs/workbench/contrib/chat/common/chatServiceImpl';
 import { ChatSlashCommandService, IChatSlashCommandService } from 'vs/workbench/contrib/chat/common/chatSlashCommands';
 import { IChatVariablesService } from 'vs/workbench/contrib/chat/common/chatVariables';
 import { MockChatVariablesService } from 'vs/workbench/contrib/chat/test/common/mockChatVariables';
-import { IExtensionService } from 'vs/workbench/services/extensions/common/extensions';
+import { IExtensionService, nullExtensionDescription } from 'vs/workbench/services/extensions/common/extensions';
 import { TestContextService, TestExtensionService, TestStorageService } from 'vs/workbench/test/common/workbenchTestServices';
 
 class SimpleTestProvider extends Disposable implements IChatProvider {
@@ -57,6 +57,7 @@ class SimpleTestProvider extends Disposable implements IChatProvider {
 const chatAgentWithUsedContextId = 'ChatProviderWithUsedContext';
 const chatAgentWithUsedContext: IChatAgent = {
 	id: chatAgentWithUsedContextId,
+	extensionId: nullExtensionDescription.identifier,
 	metadata: {},
 	async provideSlashCommands(token) {
 		return [];
@@ -109,6 +110,7 @@ suite('Chat', () => {
 
 		const agent = {
 			id: 'testAgent',
+			extensionId: nullExtensionDescription.identifier,
 			metadata: { isDefault: true },
 			async invoke(request, progress, history, token) {
 				return {};

--- a/src/vs/workbench/contrib/chat/test/common/voiceChat.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/voiceChat.test.ts
@@ -10,10 +10,12 @@ import { IMarkdownString } from 'vs/base/common/htmlContent';
 import { DisposableStore, IDisposable } from 'vs/base/common/lifecycle';
 import { ensureNoDisposablesAreLeakedInTestSuite } from 'vs/base/test/common/utils';
 import { ProviderResult } from 'vs/editor/common/languages';
+import { ExtensionIdentifier } from 'vs/platform/extensions/common/extensions';
 import { IChatAgent, IChatAgentCommand, IChatAgentHistoryEntry, IChatAgentMetadata, IChatAgentRequest, IChatAgentResult, IChatAgentService } from 'vs/workbench/contrib/chat/common/chatAgents';
 import { IChatProgress, IChatFollowup } from 'vs/workbench/contrib/chat/common/chatService';
 import { IVoiceChatSessionOptions, IVoiceChatTextEvent, VoiceChatService } from 'vs/workbench/contrib/chat/common/voiceChat';
 import { ISpeechProvider, ISpeechService, ISpeechToTextEvent, ISpeechToTextSession, KeywordRecognitionStatus, SpeechToTextStatus } from 'vs/workbench/contrib/speech/common/speechService';
+import { nullExtensionDescription } from 'vs/workbench/services/extensions/common/extensions';
 
 suite('VoiceChat', () => {
 
@@ -22,6 +24,9 @@ suite('VoiceChat', () => {
 	}
 
 	class TestChatAgent implements IChatAgent {
+
+		extensionId: ExtensionIdentifier = nullExtensionDescription.identifier;
+
 		constructor(readonly id: string, readonly lastSlashCommands: IChatAgentCommand[]) { }
 		invoke(request: IChatAgentRequest, progress: (part: IChatProgress) => void, history: IChatAgentHistoryEntry[], token: CancellationToken): Promise<IChatAgentResult> { throw new Error('Method not implemented.'); }
 		provideSlashCommands(token: CancellationToken): Promise<IChatAgentCommand[]> { throw new Error('Method not implemented.'); }

--- a/src/vscode-dts/vscode.proposed.chatAgents2.d.ts
+++ b/src/vscode-dts/vscode.proposed.chatAgents2.d.ts
@@ -38,12 +38,15 @@ declare module 'vscode' {
 		 */
 		readonly prompt: string;
 
+		// TODO@API NAME agent
+		// TODO@API TYPE {agent:string, extension:string}
+		/** @deprecated */
+		readonly agentId: string;
+
 		/**
 		 * The ID of the chat agent to which this request was directed.
 		 */
-		// TODO@API NAME agent
-		// TODO@API TYPE {agent:string, extension:string}
-		readonly agentId: string;
+		readonly agent: { extensionId: string; agentId: string };
 
 		/**
 		 * The name of the {@link ChatAgentCommand command} that was selected for this request.
@@ -56,7 +59,7 @@ declare module 'vscode' {
 		// TODO@API is this needed?
 		readonly variables: ChatAgentResolvedVariable[];
 
-		private constructor(prompt: string, agentId: string, command: string | undefined, variables: ChatAgentResolvedVariable[],);
+		private constructor(prompt: string, command: string | undefined, variables: ChatAgentResolvedVariable[], agent: { extensionId: string; agentId: string });
 	}
 
 	// TODO@API name: Turn?
@@ -72,9 +75,12 @@ declare module 'vscode' {
 		 */
 		readonly result: ChatAgentResult2;
 
+		/** @deprecated */
 		readonly agentId: string;
 
-		private constructor(response: ReadonlyArray<ChatResponseTextPart | ChatResponseMarkdownPart | ChatResponseFileTreePart | ChatResponseAnchorPart | ChatResponseCommandButtonPart>, result: ChatAgentResult2, agentId: string);
+		readonly agent: { extensionId: string; agentId: string };
+
+		private constructor(response: ReadonlyArray<ChatResponseTextPart | ChatResponseMarkdownPart | ChatResponseFileTreePart | ChatResponseAnchorPart | ChatResponseCommandButtonPart>, result: ChatAgentResult2, agentId: { extensionId: string; agentId: string });
 	}
 
 	export interface ChatAgentContext {

--- a/src/vscode-dts/vscode.proposed.chatAgents2.d.ts
+++ b/src/vscode-dts/vscode.proposed.chatAgents2.d.ts
@@ -79,16 +79,13 @@ declare module 'vscode' {
 
 	export interface ChatAgentContext {
 		/**
-		 * @deprecated
-		 */
-		history: ChatAgentHistoryEntry[];
-
-		// location:
-
-		/**
 		 * All of the chat messages so far in the current chat session.
 		 */
-		// TODO@API name: histroy
+		readonly history: ReadonlyArray<ChatAgentRequestTurn | ChatAgentResponseTurn>;
+
+		/**
+		 * @deprecated, use histroy
+		 */
 		readonly history2: ReadonlyArray<ChatAgentRequestTurn | ChatAgentResponseTurn>;
 	}
 


### PR DESCRIPTION
This pull request fixes several issues in the Chat Agent API. It includes the following changes:

- Updated `ChatAgentContext#history` to be an array of turns.

- Added agent info (agent and extension id) to `ChatAgentResponseTurn` and `ChatAgentRequestTurn`.

 #199908