### PR TITLE
Fix cursor position after splitting window

### DIFF
--- a/src/vs/workbench/contrib/scm/browser/dirtydiffDecorator.ts
+++ b/src/vs/workbench/contrib/scm/browser/dirtydiffDecorator.ts
@@ -280,9 +280,9 @@ class DirtyDiffWidget extends PeekViewWidget {
 		this._actionbarWidget!.context = [diffEditorModel.modified.uri, providerSpecificChanges, contextIndex];
 		if (usePosition) {
 			this.show(position, height);
+			this.editor.setPosition(position);
+			this.editor.focus();
 		}
-		this.editor.setPosition(position);
-		this.editor.focus();
 	}
 
 	private renderTitle(label: string): void {


### PR DESCRIPTION
This pull request fixes the issue where the cursor is not in the correct position after splitting the window with the quick diff open and editing.

Fixes #203969