### PR TITLE
fix surround with naming for the command palette

### DIFF
--- a/src/vs/workbench/contrib/snippets/browser/commands/surroundWithSnippet.ts
+++ b/src/vs/workbench/contrib/snippets/browser/commands/surroundWithSnippet.ts
@@ -32,8 +32,8 @@ export class SurroundWithSnippetEditorAction extends SnippetEditorAction {
 	static readonly options = {
 		id: 'editor.action.surroundWithSnippet',
 		title: {
-			value: localize('label', 'More...'),
-			original: 'More...'
+			value: localize('label', 'Surround With Snippet...'),
+			original: 'Surround With Snippet...'
 		}
 	};
 

--- a/src/vs/workbench/contrib/snippets/browser/snippetCodeActionProvider.ts
+++ b/src/vs/workbench/contrib/snippets/browser/snippetCodeActionProvider.ts
@@ -25,7 +25,7 @@ class SurroundWithSnippetCodeActionProvider implements CodeActionProvider {
 
 	private static readonly _overflowCommandCodeAction: CodeAction = {
 		kind: CodeActionKind.SurroundWith.value,
-		title: SurroundWithSnippetEditorAction.options.title.value,
+		title: localize('more', "More..."),
 		command: {
 			id: SurroundWithSnippetEditorAction.options.id,
 			title: SurroundWithSnippetEditorAction.options.title.value,


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

fixes candidate https://github.com/microsoft/vscode/issues/204506

main PR: https://github.com/microsoft/vscode/pull/204587

(slightly differing from main PR due to changes to `localize2` https://github.com/microsoft/vscode/commit/777ea450a1307db0ae27a6b83fa45f14339f7316)