### PR TITLE
variable view initialization

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/contrib/notebookVariables/notebookVariables.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/notebookVariables/notebookVariables.ts
@@ -20,8 +20,6 @@ import { getNotebookEditorFromEditorPane } from 'vs/workbench/contrib/notebook/b
 import { INotebookKernelService } from 'vs/workbench/contrib/notebook/common/notebookKernelService';
 import { IContextKey, IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 import { NOTEBOOK_VARIABLE_VIEW_ENABLED } from 'vs/workbench/contrib/notebook/browser/contrib/notebookVariables/notebookVariableContextKeys';
-import { NotebookEditorInput } from 'vs/workbench/contrib/notebook/common/notebookEditorInput';
-
 
 export class NotebookVariables extends Disposable implements IWorkbenchContribution {
 	private listeners: IDisposable[] = [];
@@ -41,11 +39,7 @@ export class NotebookVariables extends Disposable implements IWorkbenchContribut
 
 		this.viewEnabled = NOTEBOOK_VARIABLE_VIEW_ENABLED.bindTo(contextKeyService);
 
-		this.listeners.push(this.editorService.onDidEditorsChange((e) => {
-			if (e.event.editor instanceof NotebookEditorInput) {
-				this.handleInitEvent(true);
-			}
-		}));
+		this.listeners.push(this.editorService.onDidActiveEditorChange(() => this.handleInitEvent()));
 		this.listeners.push(this.notebookExecutionStateService.onDidChangeExecution((e) => this.handleInitEvent()));
 
 		this.configListener = configurationService.onDidChangeConfiguration((e) => this.handleConfigChange(e));
@@ -63,11 +57,9 @@ export class NotebookVariables extends Disposable implements IWorkbenchContribut
 		}
 	}
 
-	private handleInitEvent(isNotebook?: boolean) {
-		const notebookEditorActive = isNotebook ?? this.editorService.activeEditorPane?.getId() === 'workbench.editor.notebook';
-
+	private handleInitEvent() {
 		if (this.configurationService.getValue(NotebookSetting.notebookVariablesView)
-			&& notebookEditorActive) {
+			&& this.editorService.activeEditorPane?.getId() === 'workbench.editor.notebook') {
 
 			if (this.hasVariableProvider() && !this.initialized && this.initializeView()) {
 				this.viewEnabled.set(true);

--- a/src/vs/workbench/contrib/notebook/browser/contrib/notebookVariables/notebookVariablesView.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/notebookVariables/notebookVariablesView.ts
@@ -140,7 +140,7 @@ export class NotebookVariablesView extends ViewPane {
 	private setActiveNotebook() {
 		const current = this.activeNotebook;
 		const activeEditorPane = this.editorService.activeEditorPane;
-		if (activeEditorPane && activeEditorPane.getId() === 'workbench.editor.notebook') {
+		if (activeEditorPane?.getId() === 'workbench.editor.notebook') {
 			const notebookDocument = getNotebookEditorFromEditorPane(activeEditorPane)?.getViewModel()?.notebookDocument;
 			this.activeNotebook = notebookDocument;
 		}


### PR DESCRIPTION
fix https://github.com/microsoft/vscode/issues/205118

`onDidEditorsChange` fires before the `editorService.activeEditor` is updated, so it was checking if the previously active editor was a notebook