### PR TITLE
chat: Use alternating request/response color

### DIFF
--- a/build/lib/stylelint/vscode-known-variables.json
+++ b/build/lib/stylelint/vscode-known-variables.json
@@ -44,6 +44,7 @@
 		"--vscode-chat-avatarBackground",
 		"--vscode-chat-avatarForeground",
 		"--vscode-chat-requestBorder",
+		"--vscode-chat-requestBackground",
 		"--vscode-chat-slashCommandBackground",
 		"--vscode-chat-slashCommandForeground",
 		"--vscode-chat-list-background",

--- a/src/vs/workbench/contrib/chat/browser/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/media/chat.css
@@ -221,6 +221,13 @@
 .interactive-request {
 	border-bottom: 1px solid var(--vscode-chat-requestBorder);
 	border-top: 1px solid var(--vscode-chat-requestBorder);
+	background-color: var(--vscode-chat-requestBackground);
+}
+
+.hc-black .interactive-request,
+.hc-light .interactive-request {
+	border-left: 3px solid var(--vscode-chat-requestBorder);
+	border-right: 3px solid var(--vscode-chat-requestBorder);
 }
 
 .interactive-item-container .value {

--- a/src/vs/workbench/contrib/chat/common/chatColors.ts
+++ b/src/vs/workbench/contrib/chat/common/chatColors.ts
@@ -5,12 +5,18 @@
 
 import { Color, RGBA } from 'vs/base/common/color';
 import { localize } from 'vs/nls';
-import { badgeBackground, badgeForeground, contrastBorder, foreground, registerColor } from 'vs/platform/theme/common/colorRegistry';
+import { badgeBackground, badgeForeground, contrastBorder, editorBackground, editorWidgetBackground, foreground, registerColor } from 'vs/platform/theme/common/colorRegistry';
 
 export const chatRequestBorder = registerColor(
 	'chat.requestBorder',
 	{ dark: new Color(new RGBA(255, 255, 255, 0.10)), light: new Color(new RGBA(0, 0, 0, 0.10)), hcDark: contrastBorder, hcLight: contrastBorder, },
 	localize('chat.requestBorder', 'The border color of a chat request.')
+);
+
+export const chatRequestBackground = registerColor(
+	'chat.requestBackground',
+	{ dark: editorBackground, light: editorBackground, hcDark: editorWidgetBackground, hcLight: null },
+	localize('chat.requestBackground', 'The background color of a chat request.')
 );
 
 export const chatSlashCommandBackground = registerColor(


### PR DESCRIPTION
dark: 
<img width="496" alt="image" src="https://github.com/microsoft/vscode/assets/103326/c9f8f336-5d2c-44e0-b38c-f57ca9d996df">

light:
<img width="493" alt="image" src="https://github.com/microsoft/vscode/assets/103326/93a4dbd2-cd34-4b29-b77e-7335ace7672c">

Dark HC:
<img width="497" alt="image" src="https://github.com/microsoft/vscode/assets/103326/3c27132b-3d39-4306-8e10-ff7211f4cb6d">

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

The HC themes now also have side borders to make the alternating rows more pronounced.
Light HC doesn't use a an alternating colour as the theme is completely flat.
Closes #200084.