### PR TITLE
Fix memory leak in comments browser

### DIFF
--- a/src/vs/workbench/contrib/comments/browser/commentNode.ts
+++ b/src/vs/workbench/contrib/comments/browser/commentNode.ts
@@ -766,6 +766,11 @@ export class CommentNode<T extends IRange | ICellRange> extends Disposable {
 			}, 3000);
 		}
 	}
+
+	override dispose(): void {
+		this._commentEditorDisposables.forEach(dispose => dispose.dispose());
+		super.dispose();
+	}
 }
 
 function fillInActions(groups: [string, Array<MenuItemAction | SubmenuItemAction>][], target: IAction[] | { primary: IAction[]; secondary: IAction[] }, useAlternativeActions: boolean, isPrimaryGroup: (group: string) => boolean = group => group === 'navigation'): void {

--- a/src/vs/workbench/contrib/comments/browser/commentNode.ts
+++ b/src/vs/workbench/contrib/comments/browser/commentNode.ts
@@ -8,7 +8,7 @@ import * as dom from 'vs/base/browser/dom';
 import * as languages from 'vs/editor/common/languages';
 import { ActionsOrientation, ActionBar } from 'vs/base/browser/ui/actionbar/actionbar';
 import { Action, IActionRunner, IAction, Separator, ActionRunner } from 'vs/base/common/actions';
-import { Disposable, IDisposable } from 'vs/base/common/lifecycle';
+import { Disposable, IDisposable, dispose } from 'vs/base/common/lifecycle';
 import { URI } from 'vs/base/common/uri';
 import { ITextModel } from 'vs/editor/common/model';
 import { IModelService } from 'vs/editor/common/services/model';
@@ -576,12 +576,10 @@ export class CommentNode<T extends IRange | ICellRange> extends Disposable {
 
 		this._commentEditorModel?.dispose();
 
-		this._commentEditorDisposables.forEach(dispose => dispose.dispose());
+		dispose(this._commentEditorDisposables);
 		this._commentEditorDisposables = [];
-		if (this._commentEditor) {
-			this._commentEditor.dispose();
-			this._commentEditor = null;
-		}
+		this._commentEditor?.dispose();
+		this._commentEditor = null;
 
 		this._commentEditContainer!.remove();
 	}
@@ -768,8 +766,8 @@ export class CommentNode<T extends IRange | ICellRange> extends Disposable {
 	}
 
 	override dispose(): void {
-		this._commentEditorDisposables.forEach(dispose => dispose.dispose());
 		super.dispose();
+		dispose(this._commentEditorDisposables);
 	}
 }
 

--- a/src/vs/workbench/contrib/comments/browser/commentReply.ts
+++ b/src/vs/workbench/contrib/comments/browser/commentReply.ts
@@ -369,4 +369,8 @@ export class CommentReply<T extends IRange | ICellRange> extends Disposable {
 		});
 	}
 
+	override dispose(): void {
+		this._commentThreadDisposables.forEach(dispose => dispose.dispose());
+		super.dispose();
+	}
 }

--- a/src/vs/workbench/contrib/comments/browser/commentReply.ts
+++ b/src/vs/workbench/contrib/comments/browser/commentReply.ts
@@ -6,7 +6,7 @@
 import * as dom from 'vs/base/browser/dom';
 import { MOUSE_CURSOR_TEXT_CSS_CLASS_NAME } from 'vs/base/browser/ui/mouseCursor/mouseCursor';
 import { IAction } from 'vs/base/common/actions';
-import { Disposable, IDisposable } from 'vs/base/common/lifecycle';
+import { Disposable, IDisposable, dispose } from 'vs/base/common/lifecycle';
 import { MarshalledId } from 'vs/base/common/marshallingIds';
 import { URI } from 'vs/base/common/uri';
 import { generateUuid } from 'vs/base/common/uuid';
@@ -370,7 +370,7 @@ export class CommentReply<T extends IRange | ICellRange> extends Disposable {
 	}
 
 	override dispose(): void {
-		this._commentThreadDisposables.forEach(dispose => dispose.dispose());
 		super.dispose();
+		dispose(this._commentThreadDisposables);
 	}
 }

--- a/src/vs/workbench/contrib/comments/browser/commentThreadWidget.ts
+++ b/src/vs/workbench/contrib/comments/browser/commentThreadWidget.ts
@@ -260,8 +260,8 @@ export class CommentThreadWidget<T extends IRange | ICellRange = IRange> extends
 	}
 
 	override dispose() {
-		dispose(this._commentThreadDisposables);
 		super.dispose();
+		dispose(this._commentThreadDisposables);
 		this.updateCurrentThread(false, false);
 	}
 

--- a/src/vs/workbench/contrib/comments/browser/commentThreadWidget.ts
+++ b/src/vs/workbench/contrib/comments/browser/commentThreadWidget.ts
@@ -260,6 +260,7 @@ export class CommentThreadWidget<T extends IRange | ICellRange = IRange> extends
 	}
 
 	override dispose() {
+		dispose(this._commentThreadDisposables);
 		super.dispose();
 		this.updateCurrentThread(false, false);
 	}


### PR DESCRIPTION
The disposable objects stored in `_commentThreadDisposables` and `_commentEditorDisposables` are not disposed when the parent object is being disposed, leading to a memory leak.