### PR TITLE
Sort `Developer: Open Log File...` quickpick and add extension IDs (fix #205170)

### DIFF
--- a/src/vs/workbench/contrib/output/browser/output.contribution.ts
+++ b/src/vs/workbench/contrib/output/browser/output.contribution.ts
@@ -409,7 +409,8 @@ class OutputContribution extends Disposable implements IWorkbenchContribution {
 				const fileConfigurationService = accessor.get(IFilesConfigurationService);
 
 				const entries: IOutputChannelQuickPickItem[] = outputService.getChannelDescriptors().filter(c => c.file && c.log)
-					.map(channel => (<IOutputChannelQuickPickItem>{ id: channel.id, label: channel.label, channel }));
+					.sort((a, b) => a.label.localeCompare(b.label))
+					.map(channel => (<IOutputChannelQuickPickItem>{ id: channel.id, label: channel.label, description: channel.extensionId, channel }));
 
 				const argName = args && typeof args === 'string' ? args : undefined;
 				let entry: IOutputChannelQuickPickItem | undefined;


### PR DESCRIPTION
This PR fixes #205170

![image](https://github.com/microsoft/vscode/assets/6726799/3d7c5c08-cdd0-48ac-9bd1-7a1811856506)

Before the change it was:

![image](https://github.com/microsoft/vscode/assets/6726799/2e0da9c4-fc27-425b-a788-28fbb8c8b5b0)

