### PR TITLE
use menu contributions in issue reporter

### DIFF
--- a/extensions/git/package.json
+++ b/extensions/git/package.json
@@ -14,6 +14,7 @@
     "contribEditSessions",
     "contribEditorContentMenu",
     "contribMergeEditorMenus",
+    "contribIssueReporter",
     "contribMultiDiffEditorMenus",
     "contribSourceControlHistoryItemGroupMenu",
     "contribSourceControlHistoryItemMenu",

--- a/extensions/git/package.json
+++ b/extensions/git/package.json
@@ -14,7 +14,6 @@
     "contribEditSessions",
     "contribEditorContentMenu",
     "contribMergeEditorMenus",
-    "contribIssueReporter",
     "contribMultiDiffEditorMenus",
     "contribSourceControlHistoryItemGroupMenu",
     "contribSourceControlHistoryItemMenu",

--- a/src/vs/code/electron-sandbox/issue/issueReporterService.ts
+++ b/src/vs/code/electron-sandbox/issue/issueReporterService.ts
@@ -51,6 +51,7 @@ export class IssueReporter extends Disposable {
 	private hasBeenSubmitted = false;
 	private openReporter = false;
 	private loadingExtensionData = false;
+	private changeExtension = false;
 	private delayedSubmit = new Delayer<void>(300);
 	private readonly previewButton!: Button;
 
@@ -1193,6 +1194,7 @@ export class IssueReporter extends Disposable {
 			}
 
 			this.addEventListener('extension-selector', 'change', async (e: Event) => {
+				this.changeExtension = true;
 				this.clearExtensionData();
 				const selectedExtensionId = (<HTMLInputElement>e.target).value;
 				const extensions = this.issueReporterModel.getData().allExtensions;
@@ -1205,7 +1207,7 @@ export class IssueReporter extends Disposable {
 						iconElement.classList.add(...ThemeIcon.asClassNameArray(Codicon.loading), 'codicon-modifier-spin');
 						this.setLoading(iconElement);
 						const openReporterData = await this.sendReporterMenu(selectedExtension);
-						if (openReporterData) {
+						if (openReporterData && this.changeExtension) {
 							this.removeLoading(iconElement, true);
 							this.configuration.data = openReporterData;
 						} else {
@@ -1220,8 +1222,10 @@ export class IssueReporter extends Disposable {
 							selectedExtension.uri = undefined;
 						}
 					}
-					// repopulates the fields with the new data given the selected extension.
-					this.updateExtensionStatus(matches[0]);
+					if (this.changeExtension) {
+						// repopulates the fields with the new data given the selected extension.
+						this.updateExtensionStatus(matches[0]);
+					}
 				} else {
 					this.issueReporterModel.update({ selectedExtension: undefined });
 					this.clearSearchResults();
@@ -1229,6 +1233,7 @@ export class IssueReporter extends Disposable {
 					this.validateSelectedExtension();
 					this.updateExtensionStatus(matches[0]);
 				}
+				this.changeExtension = false;
 			});
 		}
 

--- a/src/vs/code/electron-sandbox/issue/issueReporterService.ts
+++ b/src/vs/code/electron-sandbox/issue/issueReporterService.ts
@@ -1246,6 +1246,7 @@ export class IssueReporter extends Disposable {
 
 	private clearExtensionData(): void {
 		this.issueReporterModel.update({ extensionData: undefined });
+		this.configuration.data.issueBody = undefined;
 		this.configuration.data.data = undefined;
 		this.configuration.data.uri = undefined;
 	}

--- a/src/vs/code/electron-sandbox/issue/issueReporterService.ts
+++ b/src/vs/code/electron-sandbox/issue/issueReporterService.ts
@@ -1192,14 +1192,16 @@ export class IssueReporter extends Disposable {
 						if (openReporterData) {
 							this.configuration.data = openReporterData;
 						} else {
-							// case when previous extension had command
+							// if not using command, should have no configuration data in fields we care about and check later.
 							this.configuration.data.issueBody = undefined;
 							this.configuration.data.data = undefined;
+							this.configuration.data.uri = undefined;
 
 							// case when previous extension was opened from normal openIssueReporter command
 							selectedExtension.data = undefined;
 							selectedExtension.uri = undefined;
 						}
+						// repopulates the fields with the new data given the selected extension.
 						this.updateExtensionStatus(selectedExtension);
 					}
 				} else {

--- a/src/vs/code/electron-sandbox/issue/issueReporterService.ts
+++ b/src/vs/code/electron-sandbox/issue/issueReporterService.ts
@@ -792,8 +792,6 @@ export class IssueReporter extends Disposable {
 		const descriptionTextArea = this.getElementById('description')!;
 		const extensionDataTextArea = this.getElementById('extension-data')!;
 
-		const extensionDropdown = this.getElementById('extension-selector')!;
-
 		// Hide all by default
 		hide(blockContainer);
 		hide(systemBlock);
@@ -846,13 +844,8 @@ export class IssueReporter extends Disposable {
 				if (this.openReporter) {
 					show(extensionDataBlock);
 				}
-			}, 250);
+			}, 100);
 		}
-
-		if (fileOnExtension && this.loadingExtensionData) {
-			(extensionDropdown as HTMLSelectElement).disabled = true;
-		}
-
 
 		if (issueType === IssueType.Bug) {
 			if (!fileOnMarketplace) {
@@ -1207,7 +1200,7 @@ export class IssueReporter extends Disposable {
 				if (matches.length) {
 					this.issueReporterModel.update({ selectedExtension: matches[0] });
 					const selectedExtension = this.issueReporterModel.getData().selectedExtension;
-					if (selectedExtension) {
+					if (selectedExtension && !this.loadingExtensionData) {
 						const iconElement = document.createElement('span');
 						iconElement.classList.add(...ThemeIcon.asClassNameArray(Codicon.loading), 'codicon-modifier-spin');
 						this.setLoading(iconElement);
@@ -1226,13 +1219,15 @@ export class IssueReporter extends Disposable {
 							selectedExtension.data = undefined;
 							selectedExtension.uri = undefined;
 						}
-						// repopulates the fields with the new data given the selected extension.
-						this.updateExtensionStatus(selectedExtension);
 					}
+					// repopulates the fields with the new data given the selected extension.
+					this.updateExtensionStatus(matches[0]);
 				} else {
 					this.issueReporterModel.update({ selectedExtension: undefined });
 					this.clearSearchResults();
+					this.clearExtensionData();
 					this.validateSelectedExtension();
+					this.updateExtensionStatus(matches[0]);
 				}
 			});
 		}
@@ -1397,9 +1392,6 @@ export class IssueReporter extends Disposable {
 		const hideLoading = this.getElementById('ext-loading')!;
 		hide(hideLoading);
 		hideLoading.removeChild(element);
-
-		const extensionDropdown = this.getElementById('extension-selector')!;
-		(extensionDropdown as HTMLSelectElement).disabled = false;
 
 		this.renderBlocks();
 	}

--- a/src/vs/code/electron-sandbox/issue/issueReporterService.ts
+++ b/src/vs/code/electron-sandbox/issue/issueReporterService.ts
@@ -302,7 +302,6 @@ export class IssueReporter extends Disposable {
 	private async sendReporterMenu(extension: IssueReporterExtensionData): Promise<IssueReporterData | undefined> {
 		try {
 			const data = await this.issueMainService.$sendReporterMenu(extension.id, extension.name);
-			console.log('send reporter data: ', data);
 			return data;
 		} catch (e) {
 			console.error(e);
@@ -1185,7 +1184,6 @@ export class IssueReporter extends Disposable {
 					this.issueReporterModel.update({ selectedExtension: matches[0] });
 					const selectedExtension = this.issueReporterModel.getData().selectedExtension;
 					if (selectedExtension) {
-						console.log('reaching selected extension');
 						const iconElement = document.createElement('span');
 						iconElement.classList.add(...ThemeIcon.asClassNameArray(Codicon.loading), 'codicon-modifier-spin');
 						this.setLoading(iconElement);
@@ -1207,7 +1205,6 @@ export class IssueReporter extends Disposable {
 						this.updateExtensionStatus(selectedExtension);
 					}
 				} else {
-					console.log('not reaching selected extension');
 					this.issueReporterModel.update({ selectedExtension: undefined });
 					this.clearSearchResults();
 					this.validateSelectedExtension();

--- a/src/vs/code/electron-sandbox/issue/issueReporterService.ts
+++ b/src/vs/code/electron-sandbox/issue/issueReporterService.ts
@@ -302,6 +302,7 @@ export class IssueReporter extends Disposable {
 	private async sendReporterMenu(extension: IssueReporterExtensionData): Promise<IssueReporterData | undefined> {
 		try {
 			const data = await this.issueMainService.$sendReporterMenu(extension.id, extension.name);
+			console.log('send reporter data: ', data);
 			return data;
 		} catch (e) {
 			console.error(e);
@@ -1184,6 +1185,7 @@ export class IssueReporter extends Disposable {
 					this.issueReporterModel.update({ selectedExtension: matches[0] });
 					const selectedExtension = this.issueReporterModel.getData().selectedExtension;
 					if (selectedExtension) {
+						console.log('reaching selected extension');
 						const iconElement = document.createElement('span');
 						iconElement.classList.add(...ThemeIcon.asClassNameArray(Codicon.loading), 'codicon-modifier-spin');
 						this.setLoading(iconElement);
@@ -1205,6 +1207,7 @@ export class IssueReporter extends Disposable {
 						this.updateExtensionStatus(selectedExtension);
 					}
 				} else {
+					console.log('not reaching selected extension');
 					this.issueReporterModel.update({ selectedExtension: undefined });
 					this.clearSearchResults();
 					this.validateSelectedExtension();

--- a/src/vs/platform/actions/common/actions.ts
+++ b/src/vs/platform/actions/common/actions.ts
@@ -164,6 +164,7 @@ export class MenuId {
 	static readonly InteractiveCellDelete = new MenuId('InteractiveCellDelete');
 	static readonly InteractiveCellExecute = new MenuId('InteractiveCellExecute');
 	static readonly InteractiveInputExecute = new MenuId('InteractiveInputExecute');
+	static readonly IssueReporter = new MenuId('IssueReporter');
 	static readonly NotebookToolbar = new MenuId('NotebookToolbar');
 	static readonly NotebookStickyScrollContext = new MenuId('NotebookStickyScrollContext');
 	static readonly NotebookCellTitle = new MenuId('NotebookCellTitle');

--- a/src/vs/platform/issue/common/issue.ts
+++ b/src/vs/platform/issue/common/issue.ts
@@ -70,8 +70,8 @@ export interface IssueReporterData extends WindowData {
 	restrictedMode: boolean;
 	isUnsupported: boolean;
 	githubAccessToken: string;
-	readonly issueTitle?: string;
-	readonly issueBody?: string;
+	issueTitle?: string;
+	issueBody?: string;
 	data?: string;
 	uri?: UriComponents;
 }
@@ -138,5 +138,6 @@ export interface IIssueMainService {
 	$getIssueReporterData(extensionId: string): Promise<string>;
 	$getIssueReporterTemplate(extensionId: string): Promise<string>;
 	$getReporterStatus(extensionId: string, extensionName: string): Promise<boolean[]>;
+	$sendReporterMenu(extensionId: string, extensionName: string): Promise<IssueReporterData | undefined>;
 	$closeReporter(): Promise<void>;
 }

--- a/src/vs/platform/issue/electron-main/issueMainService.ts
+++ b/src/vs/platform/issue/electron-main/issueMainService.ts
@@ -179,7 +179,6 @@ export class IssueMainService implements IIssueMainService {
 
 				this.issueReporterWindow.on('close', () => {
 					this.issueReporterWindow = null;
-
 					issueReporterDisposables.dispose();
 				});
 
@@ -187,15 +186,14 @@ export class IssueMainService implements IIssueMainService {
 					if (this.issueReporterWindow) {
 						this.issueReporterWindow.close();
 						this.issueReporterWindow = null;
-
 						issueReporterDisposables.dispose();
 					}
 				});
 			}
 		}
 
-		if (this.issueReporterWindow) {
-			this.focusWindow(this.issueReporterWindow);
+		else if (this.issueReporterWindow) {
+			this.issueReporterWindow.focus();
 		}
 	}
 
@@ -453,6 +451,19 @@ export class IssueMainService implements IIssueMainService {
 			cts.cancel();
 		});
 		return (result ?? defaultResult) as boolean[];
+	}
+
+
+	async $sendReporterMenu(extensionId: string, extensionName: string): Promise<IssueReporterData | undefined> {
+		const window = this.issueReporterWindowCheck();
+		const replyChannel = `vscode:triggerReporterMenu`;
+		const cts = new CancellationTokenSource();
+		window.sendWhenReady(replyChannel, cts.token, { replyChannel, extensionId, extensionName });
+		const result = await raceTimeout(new Promise(resolve => validatedIpcMain.once('vscode:triggerReporterMenuResponse', (_: unknown, data: IssueReporterData | undefined) => resolve(data))), 2000, () => {
+			this.logService.error('Error: Extension timed out waiting for menu response');
+			cts.cancel();
+		});
+		return result as IssueReporterData | undefined;
 	}
 
 	async $closeReporter(): Promise<void> {

--- a/src/vs/platform/issue/electron-main/issueMainService.ts
+++ b/src/vs/platform/issue/electron-main/issueMainService.ts
@@ -459,7 +459,7 @@ export class IssueMainService implements IIssueMainService {
 		const replyChannel = `vscode:triggerReporterMenu`;
 		const cts = new CancellationTokenSource();
 		window.sendWhenReady(replyChannel, cts.token, { replyChannel, extensionId, extensionName });
-		const result = await raceTimeout(new Promise(resolve => validatedIpcMain.once('vscode:triggerReporterMenuResponse', (_: unknown, data: IssueReporterData | undefined) => resolve(data))), 2000, () => {
+		const result = await raceTimeout(new Promise(resolve => validatedIpcMain.once('vscode:triggerReporterMenuResponse', (_: unknown, data: IssueReporterData | undefined) => resolve(data))), 5000, () => {
 			this.logService.error('Error: Extension timed out waiting for menu response');
 			cts.cancel();
 		});

--- a/src/vs/platform/issue/electron-main/issueMainService.ts
+++ b/src/vs/platform/issue/electron-main/issueMainService.ts
@@ -193,7 +193,7 @@ export class IssueMainService implements IIssueMainService {
 		}
 
 		else if (this.issueReporterWindow) {
-			this.issueReporterWindow.focus();
+			this.focusWindow(this.issueReporterWindow);
 		}
 	}
 

--- a/src/vs/workbench/services/actions/common/menusExtensionPoint.ts
+++ b/src/vs/workbench/services/actions/common/menusExtensionPoint.ts
@@ -322,6 +322,12 @@ const apiMenus: IAPIMenu[] = [
 		description: localize('interactive.cell.title', "The contributed interactive cell title menu"),
 	},
 	{
+		key: 'issue/reporter',
+		id: MenuId.IssueReporter,
+		description: localize('issue.reporter', "The contributed issue reporter menu"),
+		// proposed: 'contribIssueReporter'
+	},
+	{
 		key: 'testing/item/context',
 		id: MenuId.TestItem,
 		description: localize('testing.item.context', "The contributed test item menu"),

--- a/src/vs/workbench/services/actions/common/menusExtensionPoint.ts
+++ b/src/vs/workbench/services/actions/common/menusExtensionPoint.ts
@@ -325,7 +325,7 @@ const apiMenus: IAPIMenu[] = [
 		key: 'issue/reporter',
 		id: MenuId.IssueReporter,
 		description: localize('issue.reporter', "The contributed issue reporter menu"),
-		// proposed: 'contribIssueReporter'
+		proposed: 'contribIssueReporter'
 	},
 	{
 		key: 'testing/item/context',

--- a/src/vs/workbench/services/extensions/common/extensionsApiProposals.ts
+++ b/src/vs/workbench/services/extensions/common/extensionsApiProposals.ts
@@ -27,6 +27,7 @@ export const allApiProposals = Object.freeze({
 	contribCommentThreadAdditionalMenu: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.contribCommentThreadAdditionalMenu.d.ts',
 	contribEditSessions: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.contribEditSessions.d.ts',
 	contribEditorContentMenu: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.contribEditorContentMenu.d.ts',
+	contribIssueReporter: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.contribIssueReporter.d.ts',
 	contribLabelFormatterWorkspaceTooltip: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.contribLabelFormatterWorkspaceTooltip.d.ts',
 	contribMenuBarHome: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.contribMenuBarHome.d.ts',
 	contribMergeEditorMenus: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.contribMergeEditorMenus.d.ts',

--- a/src/vs/workbench/services/issue/electron-sandbox/issueService.ts
+++ b/src/vs/workbench/services/issue/electron-sandbox/issueService.ts
@@ -28,6 +28,8 @@ import { IIntegrityService } from 'vs/workbench/services/integrity/common/integr
 import { ILogService } from 'vs/platform/log/common/log';
 import { IIssueDataProvider, IIssueUriRequestHandler, IWorkbenchIssueService } from 'vs/workbench/services/issue/common/issue';
 import { mainWindow } from 'vs/base/browser/window';
+import { IMenuService, MenuId } from 'vs/platform/actions/common/actions';
+import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 
 export class NativeIssueService implements IWorkbenchIssueService {
 	declare readonly _serviceBrand: undefined;
@@ -35,6 +37,8 @@ export class NativeIssueService implements IWorkbenchIssueService {
 	private readonly _handlers = new Map<string, IIssueUriRequestHandler>();
 	private readonly _providers = new Map<string, IIssueDataProvider>();
 	private readonly _activationEventReader = new ImplicitActivationAwareReader();
+	private issueReporterData!: IssueReporterData;
+	private foundExtension = false;
 
 	constructor(
 		@IIssueMainService private readonly issueMainService: IIssueMainService,
@@ -49,6 +53,8 @@ export class NativeIssueService implements IWorkbenchIssueService {
 		@IIntegrityService private readonly integrityService: IIntegrityService,
 		@IExtensionService private readonly extensionService: IExtensionService,
 		@ILogService private readonly logService: ILogService,
+		@IMenuService private readonly menuService: IMenuService,
+		@IContextKeyService private readonly contextKeyService: IContextKeyService
 	) {
 		ipcRenderer.on('vscode:triggerIssueUriRequestHandler', async (event: unknown, request: { replyChannel: string; extensionId: string }) => {
 			const result = await this.getIssueReporterUri(request.extensionId, CancellationToken.None);
@@ -81,6 +87,24 @@ export class NativeIssueService implements IWorkbenchIssueService {
 			}
 			const result = [this._providers.has(extensionId.toLowerCase()), this._handlers.has(extensionId.toLowerCase())];
 			ipcRenderer.send('vscode:triggerReporterStatusResponse', result);
+		});
+		ipcRenderer.on('vscode:triggerReporterMenu', async (event, arg) => {
+			const extensionId = arg.extensionId;
+
+			// creates menu from contributed
+			const menu = this.menuService.createMenu(MenuId.IssueReporter, this.contextKeyService);
+
+			// render menu and dispose
+			const actions = menu.getActions({ renderShortTitle: true }).flatMap(entry => entry[1]);
+			actions.forEach(action => {
+				if (action.item && 'source' in action.item && action.item.source?.id === extensionId) {
+					this.foundExtension = true;
+					action.run();
+				} else {
+					ipcRenderer.send('vscode:triggerReporterMenuResponse', undefined);
+				}
+			});
+			menu.dispose();
 		});
 	}
 
@@ -154,6 +178,11 @@ export class NativeIssueService implements IWorkbenchIssueService {
 			isUnsupported,
 			githubAccessToken
 		}, dataOverrides);
+
+		this.issueReporterData = issueReporterData;
+		if (this.foundExtension) {
+			ipcRenderer.send('vscode:triggerReporterMenuResponse', this.issueReporterData);
+		}
 		return this.issueMainService.openReporter(issueReporterData);
 	}
 

--- a/src/vs/workbench/services/issue/electron-sandbox/issueService.ts
+++ b/src/vs/workbench/services/issue/electron-sandbox/issueService.ts
@@ -177,8 +177,6 @@ export class NativeIssueService implements IWorkbenchIssueService {
 		}, dataOverrides);
 
 		if (this.foundExtension) {
-			console.log('found in open reporter');
-			console.log(issueReporterData);
 			ipcRenderer.send('vscode:triggerReporterMenuResponse', issueReporterData);
 		}
 		return this.issueMainService.openReporter(issueReporterData);

--- a/src/vs/workbench/services/issue/electron-sandbox/issueService.ts
+++ b/src/vs/workbench/services/issue/electron-sandbox/issueService.ts
@@ -37,7 +37,6 @@ export class NativeIssueService implements IWorkbenchIssueService {
 	private readonly _handlers = new Map<string, IIssueUriRequestHandler>();
 	private readonly _providers = new Map<string, IIssueDataProvider>();
 	private readonly _activationEventReader = new ImplicitActivationAwareReader();
-	private issueReporterData!: IssueReporterData;
 	private foundExtension = false;
 
 	constructor(
@@ -179,9 +178,8 @@ export class NativeIssueService implements IWorkbenchIssueService {
 			githubAccessToken
 		}, dataOverrides);
 
-		this.issueReporterData = issueReporterData;
 		if (this.foundExtension) {
-			ipcRenderer.send('vscode:triggerReporterMenuResponse', this.issueReporterData);
+			ipcRenderer.send('vscode:triggerReporterMenuResponse', issueReporterData);
 		}
 		return this.issueMainService.openReporter(issueReporterData);
 	}

--- a/src/vs/workbench/services/issue/electron-sandbox/issueService.ts
+++ b/src/vs/workbench/services/issue/electron-sandbox/issueService.ts
@@ -95,12 +95,10 @@ export class NativeIssueService implements IWorkbenchIssueService {
 
 			// render menu and dispose
 			const actions = menu.getActions({ renderShortTitle: true }).flatMap(entry => entry[1]);
-			actions.forEach(action => {
+			actions.forEach(async action => {
 				if (action.item && 'source' in action.item && action.item.source?.id === extensionId) {
 					this.foundExtension = true;
-					action.run();
-				} else {
-					ipcRenderer.send('vscode:triggerReporterMenuResponse', undefined);
+					await action.run();
 				}
 			});
 			menu.dispose();
@@ -179,6 +177,8 @@ export class NativeIssueService implements IWorkbenchIssueService {
 		}, dataOverrides);
 
 		if (this.foundExtension) {
+			console.log('found in open reporter');
+			console.log(issueReporterData);
 			ipcRenderer.send('vscode:triggerReporterMenuResponse', issueReporterData);
 		}
 		return this.issueMainService.openReporter(issueReporterData);

--- a/src/vs/workbench/services/issue/electron-sandbox/issueService.ts
+++ b/src/vs/workbench/services/issue/electron-sandbox/issueService.ts
@@ -100,7 +100,7 @@ export class NativeIssueService implements IWorkbenchIssueService {
 				actions.forEach(async action => {
 					try {
 						if (action.item && 'source' in action.item && action.item.source?.id === extensionId) {
-							this.extensionIdentifierSet.add(ExtensionIdentifier.toKey(extensionId));
+							this.extensionIdentifierSet.add(extensionId);
 							this.isRunning = true;
 							await action.run();
 						}
@@ -192,7 +192,7 @@ export class NativeIssueService implements IWorkbenchIssueService {
 			githubAccessToken
 		}, dataOverrides);
 
-		if (issueReporterData.extensionId && this.extensionIdentifierSet.has(ExtensionIdentifier.toKey(issueReporterData.extensionId))) {
+		if (issueReporterData.extensionId && this.extensionIdentifierSet.has(issueReporterData.extensionId)) {
 			ipcRenderer.send('vscode:triggerReporterMenuResponse', issueReporterData);
 			this.extensionIdentifierSet.delete(new ExtensionIdentifier(issueReporterData.extensionId));
 		}

--- a/src/vs/workbench/services/issue/electron-sandbox/issueService.ts
+++ b/src/vs/workbench/services/issue/electron-sandbox/issueService.ts
@@ -90,7 +90,6 @@ export class NativeIssueService implements IWorkbenchIssueService {
 		});
 		ipcRenderer.on('vscode:triggerReporterMenu', async (event, arg) => {
 			if (!this.isRunning) {
-				this.isRunning = true;
 				const extensionId = arg.extensionId;
 
 				// creates menu from contributed
@@ -102,6 +101,7 @@ export class NativeIssueService implements IWorkbenchIssueService {
 					try {
 						if (action.item && 'source' in action.item && action.item.source?.id === extensionId) {
 							this.foundExtension = true;
+							this.isRunning = true;
 							await action.run();
 						}
 					} catch (error) {

--- a/src/vscode-dts/vscode.proposed.contribIssueReporter.d.ts
+++ b/src/vscode-dts/vscode.proposed.contribIssueReporter.d.ts
@@ -1,0 +1,7 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// empty placeholder declaration for the `issue reporter`-submenu contribution point
+// https://github.com/microsoft/vscode/issues/196863


### PR DESCRIPTION
issue reporter changes:
- menu contribution point for extensions
- open issue reporter command interaction changes


![Recording 2024-02-15 at 08 06 28](https://github.com/microsoft/vscode/assets/54879025/89b0734e-9408-4e7a-acfc-136b006121d5)

for context:
- `reporter-command-two` and `reporter-command-double` are normal ones
- `reporter-command-delay` simulates a delay of 3 seconds (ie, if we have to wait to collect data).

