### PR TITLE
Fix keyboard layout detection

### DIFF
--- a/src/vs/workbench/services/keybinding/browser/keyboardLayoutService.ts
+++ b/src/vs/workbench/services/keybinding/browser/keyboardLayoutService.ts
@@ -42,6 +42,7 @@ export class BrowserKeyboardMapperFactoryBase extends Disposable {
 	protected _keymapInfos: KeymapInfo[];
 	protected _mru: KeymapInfo[];
 	private _activeKeymapInfo: KeymapInfo | null;
+	private keyboardLayoutMapAllowed: boolean = (navigator as any).keyboard !== undefined;
 
 	get activeKeymap(): KeymapInfo | null {
 		return this._activeKeymapInfo;
@@ -394,7 +395,7 @@ export class BrowserKeyboardMapperFactoryBase extends Disposable {
 	}
 
 	private async _getBrowserKeyMapping(keyboardEvent?: IKeyboardEvent): Promise<IRawMixedKeyboardMapping | null> {
-		if ((navigator as any).keyboard) {
+		if (this.keyboardLayoutMapAllowed) {
 			try {
 				return await (navigator as any).keyboard.getLayoutMap().then((e: any) => {
 					const ret: IKeyboardMapping = {};
@@ -419,6 +420,7 @@ export class BrowserKeyboardMapperFactoryBase extends Disposable {
 				});
 			} catch {
 				// getLayoutMap can throw if invoked from a nested browsing context
+				this.keyboardLayoutMapAllowed = false;
 			}
 		}
 		if (keyboardEvent && !keyboardEvent.shiftKey && !keyboardEvent.altKey && !keyboardEvent.metaKey && !keyboardEvent.metaKey) {

--- a/src/vs/workbench/services/keybinding/browser/keyboardLayoutService.ts
+++ b/src/vs/workbench/services/keybinding/browser/keyboardLayoutService.ts
@@ -420,7 +420,8 @@ export class BrowserKeyboardMapperFactoryBase extends Disposable {
 			} catch {
 				// getLayoutMap can throw if invoked from a nested browsing context
 			}
-		} else if (keyboardEvent && !keyboardEvent.shiftKey && !keyboardEvent.altKey && !keyboardEvent.metaKey && !keyboardEvent.metaKey) {
+		}
+		if (keyboardEvent && !keyboardEvent.shiftKey && !keyboardEvent.altKey && !keyboardEvent.metaKey && !keyboardEvent.metaKey) {
 			const ret: IKeyboardMapping = {};
 			const standardKeyboardEvent = keyboardEvent as StandardKeyboardEvent;
 			ret[standardKeyboardEvent.browserEvent.code] = {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

On google chrome inside a cross origin Iframe (or an iframe without the `keyboard-map` permission), it currently doesn't fallbacks on the keyboard event to detect the layout map.

Also, the delay introduced by each failing call to `getLayoutMap` was making the fallback used too late and not working for the first time a key is used
