### PR TITLE
Fix: select first one if there are multiple `libstdc++`s

### DIFF
--- a/resources/server/bin/helpers/check-requirements-linux.sh
+++ b/resources/server/bin/helpers/check-requirements-linux.sh
@@ -53,7 +53,7 @@ if [ "$OS_ID" != "alpine" ]; then
         libstdcpp_paths=$(/sbin/ldconfig -p | grep 'libstdc++.so.6')
 
         if [ "$(echo "$libstdcpp_paths" | wc -l)" -gt 1 ]; then
-            libstdcpp_path=$(echo "$libstdcpp_paths" | grep "$LDCONFIG_ARCH" | awk '{print $NF}')
+            libstdcpp_path=$(echo "$libstdcpp_paths" | grep "$LDCONFIG_ARCH" | awk '{print $NF}' | head -n1)
         else
             libstdcpp_path=$(echo "$libstdcpp_paths" | awk '{print $NF}')
         fi


### PR DESCRIPTION
Since different versions of libstdc++ may exist, change to select the one version with higher priority.
fixes #205220
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
