### PR TITLE
Enhanced Accessibility Signals with Advanced User and Modality-Specific Delays

### DIFF
--- a/src/vs/platform/accessibilitySignal/browser/accessibilitySignalService.ts
+++ b/src/vs/platform/accessibilitySignal/browser/accessibilitySignalService.ts
@@ -17,7 +17,7 @@ export const IAccessibilitySignalService = createDecorator<IAccessibilitySignalS
 
 export interface IAccessibilitySignalService {
 	readonly _serviceBrand: undefined;
-	playSignal(signal: AccessibilitySignal, options?: IAccessbilitySignalOptions): Promise<void>;
+	playSignal(signal: AccessibilitySignal, options?: IAccessibilitySignalOptions): Promise<void>;
 	playAccessibilitySignals(signals: (AccessibilitySignal | { signal: AccessibilitySignal; source: string })[]): Promise<void>;
 	isSoundEnabled(signal: AccessibilitySignal): boolean;
 	isAnnouncementEnabled(signal: AccessibilitySignal): boolean;
@@ -28,7 +28,7 @@ export interface IAccessibilitySignalService {
 	playSignalLoop(signal: AccessibilitySignal, milliseconds: number): IDisposable;
 }
 
-export interface IAccessbilitySignalOptions {
+export interface IAccessibilitySignalOptions {
 	allowManyInParallel?: boolean;
 	source?: string;
 	/**
@@ -56,10 +56,10 @@ export class AccessibilitySignalService extends Disposable implements IAccessibi
 		super();
 	}
 
-	public async playSignal(signal: AccessibilitySignal, options: IAccessbilitySignalOptions = {}): Promise<void> {
-		const announcementMessage = signal.announcementMessage;
-		if (this.isAnnouncementEnabled(signal, options.userGesture) && announcementMessage) {
-			this.accessibilityService.status(announcementMessage);
+	public async playSignal(signal: AccessibilitySignal, options: IAccessibilitySignalOptions = {}): Promise<void> {
+		const alertMessage = signal.announcementMessage;
+		if (this.isAnnouncementEnabled(signal, options.userGesture) && alertMessage) {
+			this.accessibilityService.status(alertMessage);
 		}
 
 		if (this.isSoundEnabled(signal, options.userGesture)) {

--- a/src/vs/workbench/contrib/accessibility/browser/accessibilityConfiguration.ts
+++ b/src/vs/workbench/contrib/accessibility/browser/accessibilityConfiguration.ts
@@ -100,6 +100,18 @@ const signalFeatureBase: IConfigurationPropertySchema = {
 		announcement: 'auto'
 	}
 };
+const signalDelayBase: IConfigurationPropertySchema = {
+	type: 'number',
+	minimum: 0,
+	maximum: 5000,
+	default: 0,
+	tags: ['accessibility'],
+};
+const signalFeatureDelaysBase: IConfigurationPropertySchema = {
+	type: 'object',
+	tags: ['accessibility'],
+	additionalProperties: false,
+};
 
 export const announcementFeatureBase: IConfigurationPropertySchema = {
 	'type': 'string',
@@ -279,6 +291,62 @@ const configuration: IConfigurationNode = {
 			'type': 'boolean',
 			'default': false,
 			tags: ['accessibility']
+		},
+		'accessibility.signals.lineFeatureDelays.critical': {
+			...signalFeatureDelaysBase,
+			'description': localize('accessibility.signals.lineFeatureDelays.critical', "Delays applied to accessibility signals when the active line has a critical feature (e.g. error, warning)."),
+			default: {
+				soundLineDelay: 0,
+				soundInlineDelay: 300,
+				announcementLineDelay: 300,
+				announcementInlineDelay: 600
+			},
+			'properties': {
+				'soundLineDelay': {
+					...signalDelayBase,
+					'description': localize('accessibility.signals.lineFeatureDelays.critical.soundLineDelay', "Delay for sounds when moving to a line with critical features."),
+				},
+				'soundInlineDelay': {
+					...signalDelayBase,
+					'description': localize('accessibility.signals.lineFeatureDelays.critical.soundInlineDelay', "Delay for sounds when moving within a line with critical features."),
+				},
+				'announcementLineDelay': {
+					...signalDelayBase,
+					'description': localize('accessibility.signals.lineFeatureDelays.critical.announcementLineDelay', "Delay for announcements when moving to a line with critical features."),
+				},
+				'announcementInlineDelay': {
+					...signalDelayBase,
+					'description': localize('accessibility.signals.lineFeatureDelays.critical.announcementInlineDelay', "Delay for announcements when moving within a line with critical features."),
+				},
+			},
+		},
+		'accessibility.signals.lineFeatureDelays.informational': {
+			...signalFeatureDelaysBase,
+			'description': localize('accessibility.signals.lineFeatureDelays.informational', "Delays applied to accessibility signals when the active line has an informational feature (e.g. breakpoint, folded area)."),
+			'default': {
+				soundLineDelay: 300,
+				soundInlineDelay: 600,
+				announcementLineDelay: 600,
+				announcementInlineDelay: 1200
+			},
+			'properties': {
+				'soundLineDelay': {
+					...signalDelayBase,
+					'description': localize('accessibility.signals.lineFeatureDelays.informational.soundLineDelay', "Delay for sounds when moving to a line with informational features."),
+				},
+				'soundInlineDelay': {
+					...signalDelayBase,
+					'description': localize('accessibility.signals.lineFeatureDelays.informational.soundInlineDelay', "Delay for sounds when moving within a line with informational features."),
+				},
+				'announcementLineDelay': {
+					...signalDelayBase,
+					'description': localize('accessibility.signals.lineFeatureDelays.informational.announcementLineDelay', "Delay for announcements when moving to a line with informational features."),
+				},
+				'announcementInlineDelay': {
+					...signalDelayBase,
+					'description': localize('accessibility.signals.lineFeatureDelays.informational.announcementInlineDelay', "Delay for announcements when moving within a line with informational features."),
+				},
+			},
 		},
 		'accessibility.signals.lineHasBreakpoint': {
 			...signalFeatureBase,

--- a/src/vs/workbench/contrib/accessibilitySignals/browser/accessibilitySignalLineFeatureContribution.ts
+++ b/src/vs/workbench/contrib/accessibilitySignals/browser/accessibilitySignalLineFeatureContribution.ts
@@ -12,7 +12,7 @@ import { Position } from 'vs/editor/common/core/position';
 import { CursorChangeReason } from 'vs/editor/common/cursorEvents';
 import { ITextModel } from 'vs/editor/common/model';
 import { FoldingController } from 'vs/editor/contrib/folding/browser/folding';
-import { AccessibilitySignal, IAccessibilitySignalService } from 'vs/platform/accessibilitySignal/browser/accessibilitySignalService';
+import { AccessibilitySignal, SignalModality, IAccessibilitySignalService } from 'vs/platform/accessibilitySignal/browser/accessibilitySignalService';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { IMarkerService, MarkerSeverity } from 'vs/platform/markers/common/markers';
@@ -41,6 +41,8 @@ export class SignalLineFeatureContribution
 		this.accessibilitySignalService.onAnnouncementEnabledChanged(cue),
 		() => this.accessibilitySignalService.isAnnouncementEnabled(cue)
 	));
+
+	private readonly modalities: SignalModality[] = [SignalModality.Sound, SignalModality.Announcement];
 
 	constructor(
 		@IEditorService private readonly editorService: IEditorService,
@@ -160,8 +162,12 @@ export class SignalLineFeatureContribution
 						newValue?.featureStates.get(feature) &&
 						(!lastValue?.featureStates?.get(feature) || newValue.lineNumber !== lastValue.lineNumber)
 				);
-
-				this.accessibilitySignalService.playAccessibilitySignals(newFeatures.map(f => f.signal));
+				if (newFeatures.length) {
+					const newSignals = newFeatures.map(f => f.signal);
+					for (const modality of this.modalities) {
+						this.accessibilitySignalService.playAccessibilitySignals(newSignals, modality);
+					}
+				}
 			})
 		);
 	}

--- a/src/vs/workbench/contrib/accessibilitySignals/browser/accessibilitySignalLineFeatureContribution.ts
+++ b/src/vs/workbench/contrib/accessibilitySignals/browser/accessibilitySignalLineFeatureContribution.ts
@@ -43,7 +43,7 @@ export class SignalLineFeatureContribution
 	));
 
 	private readonly modalities: SignalModality[] = [SignalModality.Sound, SignalModality.Announcement];
-	private pendingAccessibilitySignals: Map<SignalModality, NodeJS.Timeout | null> = new Map();
+	private pendingAccessibilitySignals: Map<SignalModality, any | null> = new Map();
 
 	private cancelAccessibilitySignals(modality: SignalModality) {
 		const pendingSignal = this.pendingAccessibilitySignals.get(modality);

--- a/src/vs/workbench/contrib/accessibilitySignals/browser/accessibilitySignalLineFeatureContribution.ts
+++ b/src/vs/workbench/contrib/accessibilitySignals/browser/accessibilitySignalLineFeatureContribution.ts
@@ -37,7 +37,7 @@ export class SignalLineFeatureContribution
 		() => this.accessibilitySignalService.isSoundEnabled(cue)
 	));
 
-	private readonly isAnnouncmentEnabledCahce = new CachedFunction<AccessibilitySignal, IObservable<boolean>>((cue) => observableFromEvent(
+	private readonly isAnnouncementEnabledCache = new CachedFunction<AccessibilitySignal, IObservable<boolean>>((cue) => observableFromEvent(
 		this.accessibilitySignalService.onAnnouncementEnabledChanged(cue),
 		() => this.accessibilitySignalService.isAnnouncementEnabled(cue)
 	));
@@ -52,7 +52,7 @@ export class SignalLineFeatureContribution
 
 		const someAccessibilitySignalIsEnabled = derived(
 			(reader) => /** @description someAccessibilitySignalFeatureIsEnabled */ this.features.some((feature) =>
-				this.isSoundEnabledCache.get(feature.signal).read(reader) || this.isAnnouncmentEnabledCahce.get(feature.signal).read(reader)
+				this.isSoundEnabledCache.get(feature.signal).read(reader) || this.isAnnouncementEnabledCache.get(feature.signal).read(reader)
 			)
 		);
 
@@ -121,7 +121,7 @@ export class SignalLineFeatureContribution
 			const isFeaturePresent = derivedOpts(
 				{ debugName: `isPresentInLine:${feature.signal.name}` },
 				(reader) => {
-					if (!this.isSoundEnabledCache.get(feature.signal).read(reader) && !this.isAnnouncmentEnabledCahce.get(feature.signal).read(reader)) {
+					if (!this.isSoundEnabledCache.get(feature.signal).read(reader) && !this.isAnnouncementEnabledCache.get(feature.signal).read(reader)) {
 						return false;
 					}
 					const position = debouncedPosition.read(reader);


### PR DESCRIPTION
fixes #204257

### Summary of the issue

The current accessibility signals implementation for "line features" (those that play while navigating code) has several issues that this PR aims to address:

1. **Accessibility signals disrupt the natural reading of the content**. Screen reader users hear sounds and announcements every time the cursor position changes. Although this behavior can be slightly mitigated by enabling the `accessibility.signals.debouncePositionChanges`' setting, it only introduces a short, non-configurable delay of 300 ms. This delay may be more or less useful for users who type quickly or are accustomed to reading content rapidly, but not for less advanced users or those who wish to navigate the content more slowly for better understanding or spell-checking. For instance, a variable named "user" containing a warning will be read character by character as "u warning s warning e warning r warning" unless the user moves very quickly to allow debouncing, making it difficult to comprehend the variable name. Additionally, a "warning" sound will play simultaneously, further complicating the speech synthesis understanding.
2. **The current implementation doesn't consider the distinct nature of audio and speech feedback**. Sound accessibility signals (formerly Audio Cues) play sound effects that are inherently different from speech and can even be played on a separate audio channel. Speech announcements, however, are played using ARIA live regions, and therefore cannot be separated/distinguished from the normal speech of the screen reader. This means that while sound signals playing simultaneously (or almost simultaneously) with normal reading might be less disruptive, speech signals will significantly interfere with code comprehension, especially when trying to carefully read the content within the line.
3. **Debouncing position changes creates synchronization issues**. The current debouncing implementation merely delays the moment when the features are detected for a specific position, so the detection (and its corresponding signals) will be played with a fixed delay of 300 ms after the position has changed, but the detection is still based on the original position. Therefore, if the cursor changes to a new position during this interval, it can happen that the pending detection fires a signal that will be played out of sync with the real, current position. For example, if the user is on a line with a breakpoint and moves quickly to another line without special features, the breakpoint sound and the corresponding announcement will be heard on the new line, out of sync with the trigger that originated the signal when the old position features were detected on the previous line.
4. **The current implementation doesn't allow different delays for different types of line features**. The feedback for "critical" features such as errors or warnings should be provided as quickly as possible (with enough delay to avoid interferences with reading), while "informational" features such as breakpoints or folded areas (which also apply to the full line and therefore will be read on every character), should have longer delays to allow reading the line in a more comfortable way.
5. **The current debouncing doesn't consider different navigation styles**. From a screen reader user's perspective, reading code consists of two distinct styles: quickly skimming from line to line to get an overall idea of the code, and carefully reading the contents of a line character by character or word by word, also paying attention to syntax and punctuation. These distinct styles require different delays for the feedback signals: while the "skimming" style requires shorter delays for immediate feedback, the "content" style will need longer delays to avoid interfering with the detailed reading.

### Enhanced Solution Strategy

This pull request significantly enhances the accessibility signals feature in VS Code, offering a more intuitive and user-focused experience. The final implementation effectively manages various signal modalities, including audio and speech, each with unique delays. These delays are further refined based on user navigation patterns, such as skimming through lines versus reading content within each line. This dual-level customization significantly improves the flexibility and adaptability of signal handling.

Key developments in this feature include:

1. **Modality Support**: The SignalModality enum type has been introduced, which enables the specification of desired modalities for each call to cater to their distinct nature. This foundational change allows for the separation and individual handling of different modalities, such as sound or speech, based on various conditions like triggers or settings. This separation is necessary to facilitate the rest of the additions in the pull request.
2. **Modality-Specific Delays**: Each signal modality can now have its own distinct delay. This enhancement allows for the nuanced handling of different modalities, catering to their unique requirements.
3. **Feature-Specific Delays**: A BaseLineFeature class was introduced that supports feature-specific delays. This update allows unique delays for different types of features, providing a more tailored user experience.
4. **User-Action Dependent Delays**: The system now adjusts delays based on user navigation behavior. When a user navigates within the same line, longer delays are applied to minimize interference with screen reader output. Conversely, shorter delays are implemented for line changes, providing timely feedback for users who are skimming through the program.
5. **User-Configurable Delays**: All delays are now adjustable, providing users the flexibility to fine-tune based on their reading speed or skill level.

These changes collectively provide a more responsive and user-centric accessibility signals feature in VS Code, enhancing the overall user experience.

### Testing the Feature

1. Open a test file containing code.
2. Enhance the test environment by adding breakpoints, folding code blocks, and intentionally introducing bugs to generate errors and/or warnings in the editor.
3. Navigate through the code in two distinct ways:
   a) Skim through the program by moving quickly between lines.
   b) Read the content of lines with features using the left/right arrow keys to navigate character by character (or word by word).
4. Adjust the `accessibility.signals.lineFeatureDelays.critical` and `accessibility.signals.lineFeatureDelays.informational` settings to modify the delays. Observe how these changes influence the user experience.

### Future work

The new methodology renders the `accessibility.signals.debouncePositionChanges` setting obsolete. Consequently, the debouncing code previously used in `accessibilitySignalLineFeatureContribution.ts` has been eliminated. This code was not only redundant but could also inadvertently prolong the new delays beyond their intended duration. While this setting is currently ineffective, it is being retained temporarily. It may serve as a universal switch for all future delay adjustments. If this approach is adopted, a renaming of the setting would be appropriate to reflect its broader role.
