### PR TITLE
Improve extension `README` preview markdown codeblock language detection

### DIFF
--- a/src/vs/workbench/contrib/markdown/browser/markdownDocumentRenderer.ts
+++ b/src/vs/workbench/contrib/markdown/browser/markdownDocumentRenderer.ts
@@ -215,7 +215,7 @@ export async function renderMarkdownDocument(
 				return;
 			}
 
-			const languageId = languageService.getLanguageIdByLanguageName(lang);
+			const languageId = languageService.getLanguageIdByLanguageName(lang) ?? languageService.getLanguageIdByLanguageName(lang.split(/\s+|:|,|(?!^)\{|\?]/, 1)[0]);
 			const html = await tokenizeToString(languageService, code, languageId);
 			callback(null, `<code>${html}</code>`);
 		});


### PR DESCRIPTION
Fixes #205328

after attempting to match a language alias against the whole line (and failing)
it will fall back to attempting to match only the initial (whitespace separated) language name

the intention for this is for my [extension](https://marketplace.visualstudio.com/items?itemName=RedCMD.tmlanguage-syntax-highlighter)
`json textmate` is a subset of normal `json`
I wanted to put a codeblock in displaying some `json textmate` code
but if my extension isn't installed, I wanted it to default back to normal `json`
which is what Github and the builtin Markdown extension does
but the extension `README.md` preview does not

`lang.split(/\s+|:|,|(?!^)\{|\?]/, 1)[0]`
splits the language line once on one of the following symbols ` :,{?`
then returns the first section
(leading whitespace is already stripped from the lang line)