### PR TITLE
Git - do not invoke post commit commands when calling commit through the git extension api

### DIFF
--- a/extensions/git/src/api/api1.ts
+++ b/extensions/git/src/api/api1.ts
@@ -257,7 +257,7 @@ export class ApiRepository implements Repository {
 	}
 
 	commit(message: string, opts?: CommitOptions): Promise<void> {
-		return this.repository.commit(message, opts);
+		return this.repository.commit(message, { ...opts, postCommitCommand: null });
 	}
 
 	merge(ref: string): Promise<void> {


### PR DESCRIPTION
Fixes #205358