### PR TITLE
Less hovers with pointers

### DIFF
--- a/src/vs/workbench/browser/parts/editor/breadcrumbsControl.ts
+++ b/src/vs/workbench/browser/parts/editor/breadcrumbsControl.ts
@@ -230,7 +230,7 @@ export class BreadcrumbsControl {
 		this._ckBreadcrumbsVisible = BreadcrumbsControl.CK_BreadcrumbsVisible.bindTo(this._contextKeyService);
 		this._ckBreadcrumbsActive = BreadcrumbsControl.CK_BreadcrumbsActive.bindTo(this._contextKeyService);
 
-		this._hoverDelegate = getDefaultHoverDelegate('element');
+		this._hoverDelegate = getDefaultHoverDelegate('mouse');
 
 		this._disposables.add(breadcrumbsService.register(this._editorGroup.id, this._widget));
 		this.hide();

--- a/src/vs/workbench/browser/parts/editor/editorTabsControl.ts
+++ b/src/vs/workbench/browser/parts/editor/editorTabsControl.ts
@@ -164,7 +164,7 @@ export abstract class EditorTabsControl extends Themable implements IEditorTabsC
 
 		this.renderDropdownAsChildElement = false;
 
-		this.tabsHoverDelegate = getDefaultHoverDelegate('element');
+		this.tabsHoverDelegate = getDefaultHoverDelegate('mouse');
 
 		this.create(parent);
 	}


### PR DESCRIPTION
This PR changes the hover delegate from 'element' to 'mouse' in both BreadcrumbsControl and EditorTabsControl classes. 