### PR TITLE
Fix statusbar actions

### DIFF
--- a/src/vs/workbench/contrib/scm/browser/util.ts
+++ b/src/vs/workbench/contrib/scm/browser/util.ts
@@ -150,7 +150,7 @@ export class StatusBarAction extends Action {
 class StatusBarActionViewItem extends ActionViewItem {
 
 	constructor(action: StatusBarAction, options: IBaseActionViewItemOptions) {
-		super(null, action, options);
+		super(null, action, { ...options, icon: false, label: true });
 	}
 
 	protected override updateLabel(): void {


### PR DESCRIPTION
This PR addresses the issue with statusbar actions. The `StatusBarActionViewItem` constructor has been updated to ensure the correct options are passed. 
Fix #205361