### PR TITLE
Add Shell Type for Julia and Nushell

### DIFF
--- a/src/vs/platform/terminal/common/terminal.ts
+++ b/src/vs/platform/terminal/common/terminal.ts
@@ -142,8 +142,8 @@ export const enum PosixShellType {
 	Zsh = 'zsh',
 	Python = 'python',
 	Julia = 'julia'
-
 }
+
 export const enum WindowsShellType {
 	CommandPrompt = 'cmd',
 	PowerShell = 'pwsh',

--- a/src/vs/platform/terminal/common/terminal.ts
+++ b/src/vs/platform/terminal/common/terminal.ts
@@ -140,7 +140,9 @@ export const enum PosixShellType {
 	Csh = 'csh',
 	Ksh = 'ksh',
 	Zsh = 'zsh',
-	Python = 'python'
+	Python = 'python',
+	Julia = 'julia'
+
 }
 export const enum WindowsShellType {
 	CommandPrompt = 'cmd',

--- a/src/vs/platform/terminal/node/terminalProcess.ts
+++ b/src/vs/platform/terminal/node/terminalProcess.ts
@@ -70,6 +70,7 @@ const posixShellTypeMap = new Map<string, PosixShellType>([
 	['bash', PosixShellType.Bash],
 	['csh', PosixShellType.Csh],
 	['fish', PosixShellType.Fish],
+	['julia', PosixShellType.Julia],
 	['ksh', PosixShellType.Ksh],
 	['sh', PosixShellType.Sh],
 	['pwsh', PosixShellType.PowerShell],

--- a/src/vs/platform/terminal/node/terminalProcess.ts
+++ b/src/vs/platform/terminal/node/terminalProcess.ts
@@ -409,6 +409,9 @@ export class TerminalProcess extends Disposable implements ITerminalChildProcess
 
 		if (sanitizedTitle.toLowerCase().startsWith('python')) {
 			this._onDidChangeProperty.fire({ type: ProcessPropertyType.ShellType, value: PosixShellType.Python });
+		} else if (sanitizedTitle.includes('julia') || sanitizedTitle.includes('Julia')) {
+			// not getting picked up for some reason
+			this._onDidChangeProperty.fire({ type: ProcessPropertyType.ShellType, value: PosixShellType.Julia });
 		} else {
 			this._onDidChangeProperty.fire({ type: ProcessPropertyType.ShellType, value: posixShellTypeMap.get(sanitizedTitle) });
 		}


### PR DESCRIPTION
Adding shell type for Julia and Nushell, so the command history can be separated by each shell type. 