### PR TITLE
fix: memory leak in code editor widget

### DIFF
--- a/src/vs/editor/browser/widget/codeEditorContributions.ts
+++ b/src/vs/editor/browser/widget/codeEditorContributions.ts
@@ -5,7 +5,7 @@
 
 import { getWindow, runWhenWindowIdle } from 'vs/base/browser/dom';
 import { onUnexpectedError } from 'vs/base/common/errors';
-import { Disposable, DisposableMap } from 'vs/base/common/lifecycle';
+import { Disposable, DisposableMap, IDisposable } from 'vs/base/common/lifecycle';
 import { ICodeEditor } from 'vs/editor/browser/editorBrowser';
 import { EditorContributionInstantiation, IEditorContributionDescription } from 'vs/editor/browser/editorExtensions';
 import { IEditorContribution } from 'vs/editor/common/editorCommon';
@@ -111,10 +111,10 @@ export class CodeEditorContributions extends Disposable {
 		this._instantiateSome(EditorContributionInstantiation.BeforeFirstInteraction);
 	}
 
-	public onAfterModelAttached(): void {
-		this._register(runWhenWindowIdle(getWindow(this._editor?.getDomNode()), () => {
+	public onAfterModelAttached(): IDisposable {
+		return runWhenWindowIdle(getWindow(this._editor?.getDomNode()), () => {
 			this._instantiateSome(EditorContributionInstantiation.AfterFirstRender);
-		}, 50));
+		}, 50);
 	}
 
 	private _instantiateSome(instantiation: EditorContributionInstantiation): void {

--- a/src/vs/editor/browser/widget/codeEditorWidget.ts
+++ b/src/vs/editor/browser/widget/codeEditorWidget.ts
@@ -242,6 +242,7 @@ export class CodeEditorWidget extends Disposable implements editorBrowser.ICodeE
 	private readonly _overflowWidgetsDomNode: HTMLElement | undefined;
 	private readonly _id: number;
 	private readonly _configuration: IEditorConfiguration;
+	private _contributionsDisposable: IDisposable | undefined;
 
 	protected readonly _actions = new Map<string, editorCommon.IEditorAction>();
 
@@ -523,7 +524,7 @@ export class CodeEditorWidget extends Disposable implements editorBrowser.ICodeE
 		this._onDidChangeModel.fire(e);
 		this._postDetachModelCleanup(detachedModel);
 
-		this._contributions.onAfterModelAttached();
+		this._contributionsDisposable = this._contributions.onAfterModelAttached();
 	}
 
 	private _removeDecorationTypes(): void {
@@ -1871,6 +1872,8 @@ export class CodeEditorWidget extends Disposable implements editorBrowser.ICodeE
 	}
 
 	private _detachModel(): ITextModel | null {
+		this._contributionsDisposable?.dispose();
+		this._contributionsDisposable = undefined;
 		if (!this._modelData) {
 			return null;
 		}
@@ -1887,7 +1890,6 @@ export class CodeEditorWidget extends Disposable implements editorBrowser.ICodeE
 		if (this._bannerDomNode && this._domElement.contains(this._bannerDomNode)) {
 			this._domElement.removeChild(this._bannerDomNode);
 		}
-
 		return model;
 	}
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
fixes #205485

Running the same test script as in the issue (opening and closing an editor 1997 times) now results in 0 additional `CodeEditorContributions._register` disposables being registered.