### PR TITLE
revert early disposal of code actions

### DIFF
--- a/src/vs/editor/contrib/codeAction/browser/codeActionController.ts
+++ b/src/vs/editor/contrib/codeAction/browser/codeActionController.ts
@@ -112,12 +112,7 @@ export class CodeActionController extends Disposable implements IEditorContribut
 					command.arguments[0] = { ...command.arguments[0], autoSend: false };
 				}
 			}
-			try {
-				this._lightBulbWidget.value?.hide();
-				await this._applyCodeAction(actionItem, false, false, ApplyCodeActionReason.FromAILightbulb);
-			} finally {
-				actions.dispose();
-			}
+			await this._applyCodeAction(actionItem, false, false, ApplyCodeActionReason.FromAILightbulb);
 			return;
 		}
 		await this.showCodeActionList(actions, at, { includeDisabledActions: false, fromLightbulb: true });
@@ -284,11 +279,7 @@ export class CodeActionController extends Disposable implements IEditorContribut
 
 		const delegate: IActionListDelegate<CodeActionItem> = {
 			onSelect: async (action: CodeActionItem, preview?: boolean) => {
-				try {
-					await this._applyCodeAction(action, /* retrigger */ true, !!preview, ApplyCodeActionReason.FromCodeActions);
-				} finally {
-					actions.dispose();
-				}
+				this._applyCodeAction(action, /* retrigger */ true, !!preview, ApplyCodeActionReason.FromCodeActions);
 				this._actionWidgetService.hide();
 				currentDecorations.clear();
 			},


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

fixes: https://github.com/microsoft/vscode/issues/205498 and https://github.com/microsoft/vscode/issues/204606
reverts: https://github.com/microsoft/vscode/pull/203936
related and reopening: https://github.com/microsoft/vscode/issues/203897

looks like the previous fix disposes of actions prematurely. I suspect that code actions that do additional things like opening the quick pick are disposed early even tho technically the action is still running. Reverting for now.

cc. @aeschli 
