### PR TITLE
Close custom hover on escape

### DIFF
--- a/src/vs/platform/hover/browser/hover.ts
+++ b/src/vs/platform/hover/browser/hover.ts
@@ -4,11 +4,13 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
-import { Disposable, IDisposable } from 'vs/base/common/lifecycle';
+import { Disposable, DisposableStore, IDisposable } from 'vs/base/common/lifecycle';
 import { IMarkdownString } from 'vs/base/common/htmlContent';
 import { HoverPosition } from 'vs/base/browser/ui/hover/hoverWidget';
 import { IHoverDelegate, IHoverDelegateOptions, IHoverWidget } from 'vs/base/browser/ui/iconLabel/iconHoverDelegate';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
+import { addStandardDisposableListener } from 'vs/base/browser/dom';
+import { KeyCode } from 'vs/base/common/keyCodes';
 
 export const IHoverService = createDecorator<IHoverService>('hoverService');
 
@@ -245,6 +247,8 @@ export class WorkbenchHoverDelegate extends Disposable implements IHoverDelegate
 		return this._delay;
 	}
 
+	private hoverDisposables = this._register(new DisposableStore());
+
 	constructor(
 		public readonly placement: 'mouse' | 'element',
 		private readonly instantHover: boolean,
@@ -264,6 +268,18 @@ export class WorkbenchHoverDelegate extends Disposable implements IHoverDelegate
 
 	showHover(options: IHoverDelegateOptions, focus?: boolean): IHoverWidget | undefined {
 		const overrideOptions = typeof this.overrideOptions === 'function' ? this.overrideOptions(options, focus) : this.overrideOptions;
+
+		// close hover on escape
+		this.hoverDisposables.clear();
+		const targets = options.target instanceof HTMLElement ? [options.target] : options.target.targetElements;
+		for (const target of targets) {
+			this.hoverDisposables.add(addStandardDisposableListener(target, 'keydown', (e) => {
+				if (e.equals(KeyCode.Escape)) {
+					this.hoverService.hideHover();
+				}
+			}));
+		}
+
 		return this.hoverService.showHover({
 			...options,
 			persistence: {
@@ -278,6 +294,7 @@ export class WorkbenchHoverDelegate extends Disposable implements IHoverDelegate
 	}
 
 	onDidHideHover(): void {
+		this.hoverDisposables.clear();
 		if (this.instantHover) {
 			this.lastHoverHideTime = Date.now();
 		}


### PR DESCRIPTION
This PR introduces a feature to close the custom hover by pressing the escape key. 