### PR TITLE
Fix memory leaks

### DIFF
--- a/src/vs/workbench/contrib/remote/browser/remoteExplorer.ts
+++ b/src/vs/workbench/contrib/remote/browser/remoteExplorer.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 import * as nls from 'vs/nls';
-import { Disposable, IDisposable } from 'vs/base/common/lifecycle';
+import { Disposable, IDisposable, MutableDisposable } from 'vs/base/common/lifecycle';
 import { IWorkbenchContribution } from 'vs/workbench/common/contributions';
 import { Extensions, IViewContainersRegistry, IViewsRegistry, ViewContainer, ViewContainerLocation } from 'vs/workbench/common/views';
 import { IRemoteExplorerService, PORT_AUTO_FALLBACK_SETTING, PORT_AUTO_FORWARD_SETTING, PORT_AUTO_SOURCE_SETTING, PORT_AUTO_SOURCE_SETTING_HYBRID, PORT_AUTO_SOURCE_SETTING_OUTPUT, PORT_AUTO_SOURCE_SETTING_PROCESS, TUNNEL_VIEW_CONTAINER_ID, TUNNEL_VIEW_ID } from 'vs/workbench/services/remote/common/remoteExplorerService';
@@ -41,8 +41,8 @@ import { IStorageService, StorageScope } from 'vs/platform/storage/common/storag
 export const VIEWLET_ID = 'workbench.view.remote';
 
 export class ForwardedPortsView extends Disposable implements IWorkbenchContribution {
-	private contextKeyListener?: IDisposable;
-	private _activityBadge?: IDisposable;
+	private readonly contextKeyListener = this._register(new MutableDisposable<IDisposable>());
+	private readonly activityBadge = this._register(new MutableDisposable<IDisposable>());
 	private entryAccessor: IStatusbarEntryAccessor | undefined;
 
 	constructor(
@@ -75,10 +75,7 @@ export class ForwardedPortsView extends Disposable implements IWorkbenchContribu
 	}
 
 	private async enableForwardedPortsView() {
-		if (this.contextKeyListener) {
-			this.contextKeyListener.dispose();
-			this.contextKeyListener = undefined;
-		}
+		this.contextKeyListener.clear();
 
 		const viewEnabled: boolean = !!forwardedPortsViewEnabled.getValue(this.contextKeyService);
 
@@ -91,7 +88,7 @@ export class ForwardedPortsView extends Disposable implements IWorkbenchContribu
 				viewsRegistry.registerViews([tunnelPanelDescriptor], viewContainer);
 			}
 		} else {
-			this.contextKeyListener = this.contextKeyService.onDidChangeContext(e => {
+			this.contextKeyListener.value = this.contextKeyService.onDidChangeContext(e => {
 				if (e.affectsSome(new Set(forwardedPortsViewEnabled.keys()))) {
 					this.enableForwardedPortsView();
 				}
@@ -119,9 +116,8 @@ export class ForwardedPortsView extends Disposable implements IWorkbenchContribu
 	}
 
 	private async updateActivityBadge() {
-		this._activityBadge?.dispose();
 		if (this.remoteExplorerService.tunnelModel.forwarded.size > 0) {
-			this._activityBadge = this.activityService.showViewActivity(TUNNEL_VIEW_ID, {
+			this.activityBadge.value = this.activityService.showViewActivity(TUNNEL_VIEW_ID, {
 				badge: new NumberBadge(this.remoteExplorerService.tunnelModel.forwarded.size, n => n === 1 ? nls.localize('1forwardedPort', "1 forwarded port") : nls.localize('nForwardedPorts', "{0} forwarded ports", n))
 			});
 		}

--- a/src/vs/workbench/contrib/webviewView/browser/webviewViewPane.ts
+++ b/src/vs/workbench/contrib/webviewView/browser/webviewViewPane.ts
@@ -57,7 +57,7 @@ export class WebviewViewPane extends ViewPane {
 	private setTitle: string | undefined;
 
 	private badge: IViewBadge | undefined;
-	private activity: IDisposable | undefined;
+	private readonly activity = this._register(new MutableDisposable<IDisposable>());
 
 	private readonly memento: Memento;
 	private readonly viewState: MementoObject;
@@ -256,18 +256,13 @@ export class WebviewViewPane extends ViewPane {
 			return;
 		}
 
-		if (this.activity) {
-			this.activity.dispose();
-			this.activity = undefined;
-		}
-
 		this.badge = badge;
 		if (badge) {
 			const activity = {
 				badge: new NumberBadge(badge.value, () => badge.tooltip),
 				priority: 150
 			};
-			this.activityService.showViewActivity(this.id, activity);
+			this.activity.value = this.activityService.showViewActivity(this.id, activity);
 		}
 	}
 


### PR DESCRIPTION
The activities in `treeView.ts` and `reportExplorer.ts` are not disposed when the parent object is disposed. Also fix the `contextKeyListener` disposable while we're here. The activity in `webviewViewPane.ts` is never disposed, because the return value is ignored.