### PR TITLE
Fix Goto Definition muli-line preview on single line file

### DIFF
--- a/src/vs/editor/contrib/gotoSymbol/browser/link/goToDefinitionAtPosition.ts
+++ b/src/vs/editor/contrib/gotoSymbol/browser/link/goToDefinitionAtPosition.ts
@@ -236,9 +236,10 @@ export class GotoDefinitionAtPositionEditorContribution implements IEditorContri
 
 	private stripIndentationFromPreviewRange(textEditorModel: ITextModel, startLineNumber: number, previewRange: IRange) {
 		const startIndent = textEditorModel.getLineFirstNonWhitespaceColumn(startLineNumber);
+		const maxLineNumber = Math.min(textEditorModel.getLineCount(), previewRange.endLineNumber);
 		let minIndent = startIndent;
 
-		for (let endLineNumber = startLineNumber + 1; endLineNumber < previewRange.endLineNumber; endLineNumber++) {
+		for (let endLineNumber = startLineNumber + 1; endLineNumber < maxLineNumber; endLineNumber++) {
 			const endIndent = textEditorModel.getLineFirstNonWhitespaceColumn(endLineNumber);
 			minIndent = Math.min(minIndent, endIndent);
 		}
@@ -260,7 +261,7 @@ export class GotoDefinitionAtPositionEditorContribution implements IEditorContri
 			}
 		}
 
-		return new Range(startLineNumber, 1, endLineNumber + 1, 1);
+		return new Range(startLineNumber, 1, Math.min(maxLineNumber, endLineNumber) + 1, 1);
 	}
 
 	private addDecoration(range: Range, hoverMessage: MarkdownString | undefined): void {


### PR DESCRIPTION
Fix https://github.com/microsoft/vscode/issues/205611

`stripIndentationFromPreviewRange()` wasn't checking if `previewRange.endLineNumber` goes over the end of the target file
https://github.com/microsoft/vscode/blob/d686f5f765f5c36ea11ac909309b6f1db0662de4/src/vs/editor/contrib/gotoSymbol/browser/link/goToDefinitionAtPosition.ts#L237-L248

`getPreviewRangeBasedOnIndentation()` was setting `endLineNumber` to 3 instead of 2 for single line files
https://github.com/microsoft/vscode/blob/d686f5f765f5c36ea11ac909309b6f1db0662de4/src/vs/editor/contrib/gotoSymbol/browser/link/goToDefinitionAtPosition.ts#L250-L264