### PR TITLE
Track focusout of NB cell outputs

### DIFF
--- a/extensions/ipynb/src/notebookAttachmentCleaner.ts
+++ b/extensions/ipynb/src/notebookAttachmentCleaner.ts
@@ -103,7 +103,9 @@ export class AttachmentCleaner implements vscode.CodeActionProvider {
 							notebookEdits.push(metadataEdit);
 						}
 					}
-
+					if (!notebookEdits.length) {
+						return;
+					}
 					const workspaceEdit = new vscode.WorkspaceEdit();
 					workspaceEdit.set(e.notebook.uri, notebookEdits);
 
@@ -229,7 +231,7 @@ export class AttachmentCleaner implements vscode.CodeActionProvider {
 
 		this.updateDiagnostics(cell.document.uri, diagnostics);
 
-		if (cell.index > -1 && !objectEquals(markdownAttachmentsInUse, cell.metadata.attachments)) {
+		if (cell.index > -1 && !objectEquals(markdownAttachmentsInUse || {}, cell.metadata.attachments || {})) {
 			const updateMetadata: { [key: string]: any } = deepClone(cell.metadata);
 			if (Object.keys(markdownAttachmentsInUse).length === 0) {
 				updateMetadata.attachments = undefined;

--- a/src/vs/workbench/contrib/notebook/browser/contrib/clipboard/notebookClipboard.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/clipboard/notebookClipboard.ts
@@ -59,6 +59,11 @@ function getFocusedWebviewDelegate(accessor: ServicesAccessor): IWebview | undef
 		_log(loggerService, '[Revive Webview] Notebook editor backlayer webview is not focused, bypass');
 		return;
 	}
+	// If none of the outputs have focus, then webview is not focused
+	const view = editor.getViewModel();
+	if (view && view.viewCells.every(cell => !cell.outputIsFocused && !cell.outputIsHovered)) {
+		return;
+	}
 
 	const webview = editor.getInnerWebview();
 	_log(loggerService, '[Revive Webview] Notebook editor backlayer webview is focused');

--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewPreloads.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewPreloads.ts
@@ -159,10 +159,36 @@ async function webviewPreloads(ctx: PreloadContext) {
 				}
 			};
 		};
+	function getOutputContainer(event: FocusEvent | MouseEvent) {
+		for (const node of event.composedPath()) {
+			if (node instanceof HTMLElement && node.classList.contains('output')) {
+				return {
+					id: node.id
+				};
+			}
+		}
+		return;
+	}
+	let lastFocusedOutput: { id: string } | undefined = undefined;
+	const handleOutputFocusOut = (event: FocusEvent) => {
+		const outputFocus = event && getOutputContainer(event);
+		if (!outputFocus) {
+			return;
+		}
+		// Possible we're tabbing through the elements of the same output.
+		// Lets see if focus is set back to the same output.
+		lastFocusedOutput = undefined;
+		setTimeout(() => {
+			if (lastFocusedOutput?.id === outputFocus.id) {
+				return;
+			}
+			postNotebookMessage<webviewMessages.IOutputBlurMessage>('outputBlur', outputFocus);
+		}, 0);
+	};
 
 	// check if an input element is focused within the output element
-	const checkOutputInputFocus = () => {
-
+	const checkOutputInputFocus = (e: FocusEvent) => {
+		lastFocusedOutput = getOutputContainer(e);
 		const activeElement = window.document.activeElement;
 		if (!activeElement) {
 			return;
@@ -182,16 +208,7 @@ async function webviewPreloads(ctx: PreloadContext) {
 			return;
 		}
 
-		let outputFocus: { id: string } | undefined = undefined;
-		for (const node of event.composedPath()) {
-			if (node instanceof HTMLElement && node.classList.contains('output')) {
-				outputFocus = {
-					id: node.id
-				};
-				break;
-			}
-		}
-
+		const outputFocus = lastFocusedOutput = getOutputContainer(event);
 		for (const node of event.composedPath()) {
 			if (node instanceof HTMLAnchorElement && node.href) {
 				if (node.href.startsWith('blob:')) {
@@ -277,6 +294,7 @@ async function webviewPreloads(ctx: PreloadContext) {
 
 	window.document.body.addEventListener('click', handleInnerClick);
 	window.document.body.addEventListener('focusin', checkOutputInputFocus);
+	window.document.body.addEventListener('focusout', handleOutputFocusOut);
 
 	interface RendererContext extends rendererApi.RendererContext<unknown> {
 		readonly onDidChangeSettings: Event<RenderOptions>;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
Fixes #205028

Clicking any whitespace in the notebook that isn't part of the output will now be treated as the notebook editor.
