### PR TITLE
Hover Delay Fix

### DIFF
--- a/src/vs/base/browser/ui/iconLabel/iconLabelHover.ts
+++ b/src/vs/base/browser/ui/iconLabel/iconLabelHover.ts
@@ -180,6 +180,7 @@ export function setupCustomHover(hoverDelegate: IHoverDelegate, htmlElement: HTM
 		}
 		if (hadHover) {
 			hoverDelegate.onDidHideHover?.();
+			hoverWidget = undefined;
 		}
 	};
 


### PR DESCRIPTION
This PR fixes an issue where the hover would often appear instantly, even when `workbench.hover.delay` was set to a large value. The hover widget is now properly undefined after hiding, ensuring that the delay is respected in all cases.

Fixes #205658