### PR TITLE
voice - allow dictation in SCM input and comments

### DIFF
--- a/src/vs/workbench/contrib/comments/browser/simpleCommentEditor.ts
+++ b/src/vs/workbench/contrib/comments/browser/simpleCommentEditor.ts
@@ -13,6 +13,7 @@ import { ICommandService } from 'vs/platform/commands/common/commands';
 
 // Allowed Editor Contributions:
 import { MenuPreventer } from 'vs/workbench/contrib/codeEditor/browser/menuPreventer';
+import { EditorDictation } from 'vs/workbench/contrib/codeEditor/browser/dictation/editorDictation';
 import { ContextMenuController } from 'vs/editor/contrib/contextmenu/browser/contextmenu';
 import { SuggestController } from 'vs/editor/contrib/suggest/browser/suggestController';
 import { SnippetController2 } from 'vs/editor/contrib/snippet/browser/snippetController2';
@@ -62,6 +63,7 @@ export class SimpleCommentEditor extends CodeEditorWidget {
 				{ id: SuggestController.ID, ctor: SuggestController, instantiation: EditorContributionInstantiation.Eager },
 				{ id: SnippetController2.ID, ctor: SnippetController2, instantiation: EditorContributionInstantiation.Lazy },
 				{ id: TabCompletionController.ID, ctor: TabCompletionController, instantiation: EditorContributionInstantiation.Eager }, // eager because it needs to define a context key
+				{ id: EditorDictation.ID, ctor: EditorDictation, instantiation: EditorContributionInstantiation.Lazy }
 			]
 		};
 

--- a/src/vs/workbench/contrib/scm/browser/scmViewPane.ts
+++ b/src/vs/workbench/contrib/scm/browser/scmViewPane.ts
@@ -51,6 +51,7 @@ import { IModelService } from 'vs/editor/common/services/model';
 import { EditorExtensionsRegistry } from 'vs/editor/browser/editorExtensions';
 import { MenuPreventer } from 'vs/workbench/contrib/codeEditor/browser/menuPreventer';
 import { SelectionClipboardContributionID } from 'vs/workbench/contrib/codeEditor/browser/selectionClipboard';
+import { EditorDictation } from 'vs/workbench/contrib/codeEditor/browser/dictation/editorDictation';
 import { ContextMenuController } from 'vs/editor/contrib/contextmenu/browser/contextmenu';
 import * as platform from 'vs/base/common/platform';
 import { compare, format } from 'vs/base/common/strings';
@@ -2444,7 +2445,8 @@ class SCMInputWidget {
 				SuggestController.ID,
 				InlineCompletionsController.ID,
 				CodeActionController.ID,
-				FormatOnType.ID
+				FormatOnType.ID,
+				EditorDictation.ID
 			])
 		};
 


### PR DESCRIPTION
//cc @lszomoru @alexr00 , this makes it that the editor dictation commands work in the SCM input field and comments so that you can use your voice to fill in text.

![Recording 2024-02-20 at 20 18 05](https://github.com/microsoft/vscode/assets/900690/7d9c624b-c4f3-409e-90d6-729856451e5f)

![Recording 2024-02-20 at 20 19 00](https://github.com/microsoft/vscode/assets/900690/a9f98d1a-5230-46c4-9f17-8a72b1271a83)
