### PR TITLE
editors - drop generic `options` parameter in editor input `resolve` method

### DIFF
--- a/src/vs/workbench/browser/parts/editor/binaryEditor.ts
+++ b/src/vs/workbench/browser/parts/editor/binaryEditor.ts
@@ -46,7 +46,7 @@ export abstract class BaseBinaryResourceEditor extends EditorPlaceholder {
 	}
 
 	protected async getContents(input: EditorInput, options: IEditorOptions): Promise<IEditorPlaceholderContents> {
-		const model = await input.resolve(options);
+		const model = await input.resolve();
 
 		// Assert Model instance
 		if (!(model instanceof BinaryEditorModel)) {

--- a/src/vs/workbench/browser/parts/editor/textDiffEditor.ts
+++ b/src/vs/workbench/browser/parts/editor/textDiffEditor.ts
@@ -106,7 +106,7 @@ export class TextDiffEditor extends AbstractTextEditor<IDiffEditorViewState> imp
 		await super.setInput(input, options, context, token);
 
 		try {
-			const resolvedModel = await input.resolve(options);
+			const resolvedModel = await input.resolve();
 
 			// Check for cancellation
 			if (token.isCancellationRequested) {

--- a/src/vs/workbench/browser/parts/editor/textResourceEditor.ts
+++ b/src/vs/workbench/browser/parts/editor/textResourceEditor.ts
@@ -53,7 +53,7 @@ export abstract class AbstractTextResourceEditor extends AbstractTextCodeEditor<
 
 		// Set input and resolve
 		await super.setInput(input, options, context, token);
-		const resolvedModel = await input.resolve(options);
+		const resolvedModel = await input.resolve();
 
 		// Check for cancellation
 		if (token.isCancellationRequested) {

--- a/src/vs/workbench/common/editor/diffEditorInput.ts
+++ b/src/vs/workbench/common/editor/diffEditorInput.ts
@@ -14,7 +14,7 @@ import { TextDiffEditorModel } from 'vs/workbench/common/editor/textDiffEditorMo
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
 import { shorten } from 'vs/base/common/labels';
-import { IEditorOptions, isResolvedEditorModel } from 'vs/platform/editor/common/editor';
+import { isResolvedEditorModel } from 'vs/platform/editor/common/editor';
 
 interface IDiffEditorInputLabels {
 	name: string;
@@ -171,13 +171,13 @@ export class DiffEditorInput extends SideBySideEditorInput implements IDiffEdito
 		}
 	}
 
-	override async resolve(options?: IEditorOptions): Promise<EditorModel> {
+	override async resolve(): Promise<EditorModel> {
 
 		// Create Model - we never reuse our cached model if refresh is true because we cannot
 		// decide for the inputs within if the cached model can be reused or not. There may be
 		// inputs that need to be loaded again and thus we always recreate the model and dispose
 		// the previous one - if any.
-		const resolvedModel = await this.createModel(options);
+		const resolvedModel = await this.createModel();
 		this.cachedModel?.dispose();
 
 		this.cachedModel = resolvedModel;
@@ -193,12 +193,12 @@ export class DiffEditorInput extends SideBySideEditorInput implements IDiffEdito
 		return editorPanes.find(editorPane => editorPane.typeId === TEXT_DIFF_EDITOR_ID);
 	}
 
-	private async createModel(options?: IEditorOptions): Promise<DiffEditorModel> {
+	private async createModel(): Promise<DiffEditorModel> {
 
 		// Join resolve call over two inputs and build diff editor model
 		const [originalEditorModel, modifiedEditorModel] = await Promise.all([
-			this.original.resolve(options),
-			this.modified.resolve(options)
+			this.original.resolve(),
+			this.modified.resolve()
 		]);
 
 		// If both are text models, return textdiffeditor model

--- a/src/vs/workbench/common/editor/editorInput.ts
+++ b/src/vs/workbench/common/editor/editorInput.ts
@@ -5,7 +5,6 @@
 
 import { Emitter } from 'vs/base/common/event';
 import { URI } from 'vs/base/common/uri';
-import { IEditorOptions } from 'vs/platform/editor/common/editor';
 import { firstOrDefault } from 'vs/base/common/arrays';
 import { EditorInputCapabilities, Verbosity, GroupIdentifier, ISaveOptions, IRevertOptions, IMoveResult, IEditorDescriptor, IEditorPane, IUntypedEditorInput, EditorResourceAccessor, AbstractEditorInput, isEditorInput, IEditorIdentifier } from 'vs/workbench/common/editor';
 import { isEqual } from 'vs/base/common/resources';
@@ -235,7 +234,7 @@ export abstract class EditorInput extends AbstractEditorInput {
 	 * The `options` parameter are passed down from the editor when the
 	 * input is resolved as part of it.
 	 */
-	async resolve(options?: IEditorOptions): Promise<IDisposable | null> {
+	async resolve(): Promise<IDisposable | null> {
 		return null;
 	}
 

--- a/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
@@ -355,7 +355,7 @@ export class SettingsEditor2 extends EditorPane {
 			return;
 		}
 
-		const model = await this.input.resolve(options);
+		const model = await this.input.resolve();
 		if (token.isCancellationRequested || !(model instanceof Settings2EditorModel)) {
 			return;
 		}

--- a/src/vs/workbench/contrib/webviewPanel/browser/webviewEditor.ts
+++ b/src/vs/workbench/contrib/webviewPanel/browser/webviewEditor.ts
@@ -154,7 +154,7 @@ export class WebviewEditor extends EditorPane {
 		}
 
 		await super.setInput(input, options, context, token);
-		await input.resolve(options);
+		await input.resolve();
 
 		if (token.isCancellationRequested || this._isDisposed) {
 			return;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
