### PR TITLE
Use NotebookOptions for statusbar instead of viewmodel options

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/contrib/editorStatusBar/editorStatusBar.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/editorStatusBar/editorStatusBar.ts
@@ -303,9 +303,11 @@ export class NotebookIndentationStatus extends Disposable implements IWorkbenchC
 			this._accessor.clear();
 			return;
 		}
-		const indentSize = cellOptions?.indentSize;
-		const tabSize = cellOptions?.tabSize;
-		const insertSpaces = cellOptions?.insertSpaces;
+
+		const cellEditorOverridesRaw = editor.notebookOptions.getDisplayOptions().editorOptionsCustomizations;
+		const indentSize = cellEditorOverridesRaw['editor.indentSize'] ?? cellOptions?.indentSize;
+		const insertSpaces = cellEditorOverridesRaw['editor.insertSpaces'] ?? cellOptions?.tabSize;
+		const tabSize = cellEditorOverridesRaw['editor.tabSize'] ?? cellOptions?.insertSpaces;
 
 		const width = typeof indentSize === 'number' ? indentSize : tabSize;
 

--- a/src/vs/workbench/contrib/notebook/browser/controller/notebookIndentationActions.ts
+++ b/src/vs/workbench/contrib/notebook/browser/controller/notebookIndentationActions.ts
@@ -24,7 +24,7 @@ export class NotebookIndentUsingTabs extends Action2 {
 
 	constructor() {
 		super({
-			id: NotebookIndentUsingSpaces.ID,
+			id: NotebookIndentUsingTabs.ID,
 			title: nls.localize('indentUsingTabs', "Indent Using Tabs"),
 			precondition: undefined,
 		});
@@ -56,7 +56,7 @@ export class NotebookChangeTabDisplaySize extends Action2 {
 
 	constructor() {
 		super({
-			id: NotebookIndentUsingSpaces.ID,
+			id: NotebookChangeTabDisplaySize.ID,
 			title: nls.localize('changeTabDisplaySize', "Change Tab Display Size"),
 			precondition: undefined,
 		});
@@ -72,7 +72,7 @@ export class NotebookIndentationToSpacesAction extends Action2 {
 
 	constructor() {
 		super({
-			id: NotebookIndentUsingSpaces.ID,
+			id: NotebookIndentationToSpacesAction.ID,
 			title: nls.localize('convertIndentationToSpaces', "Convert Indentation to Spaces"),
 			precondition: undefined,
 		});
@@ -80,7 +80,6 @@ export class NotebookIndentationToSpacesAction extends Action2 {
 
 	override run(accessor: ServicesAccessor, ...args: any[]): void {
 		convertNotebookIndentation(accessor, true);
-
 	}
 }
 
@@ -89,7 +88,7 @@ export class NotebookIndentationToTabsAction extends Action2 {
 
 	constructor() {
 		super({
-			id: NotebookIndentUsingSpaces.ID,
+			id: NotebookIndentationToTabsAction.ID,
 			title: nls.localize('convertIndentationToTabs', "Convert Indentation to Tabs"),
 			precondition: undefined,
 		});
@@ -194,8 +193,7 @@ function convertNotebookIndentation(accessor: ServicesAccessor, tabsToSpaces: bo
 
 			bulkEditService.apply(edits, { label: nls.localize('convertIndentation', "Convert Indentation"), code: 'undoredo.convertIndentation', });
 
-		})).then((notebookEdits) => {
-
+		})).then(() => {
 			// store the initial values of the configuration
 			const initialConfig = configurationService.getValue(NotebookSetting.cellEditorOptionsCustomizations) as any;
 			const initialIndentSize = initialConfig['editor.indentSize'];
@@ -255,3 +253,7 @@ function getIndentationEditOperations(model: ITextModel, tabSize: number, tabsTo
 }
 
 registerAction2(NotebookIndentUsingSpaces);
+registerAction2(NotebookIndentUsingTabs);
+registerAction2(NotebookChangeTabDisplaySize);
+registerAction2(NotebookIndentationToSpacesAction);
+registerAction2(NotebookIndentationToTabsAction);


### PR DESCRIPTION
Fixes: #108675, #205739

Solves the statusbar entry not updating with the new setting override created by the change view and convert file commands within the quickpick. 

Might also need to create an issue for cellEditorOptions, as some of the onDidChange events seem to be firing in a relatively circular manner.