### PR TITLE
Dictated text goes off screen when using voice commands. (fix #205783)

### DIFF
--- a/src/vs/workbench/contrib/codeEditor/browser/dictation/editorDictation.ts
+++ b/src/vs/workbench/contrib/codeEditor/browser/dictation/editorDictation.ts
@@ -199,10 +199,11 @@ export class EditorDictation extends Disposable implements IEditorContribution {
 				previewStart = assertIsDefined(this.editor.getPosition());
 			}
 
+			const endPosition = new Position(previewStart.lineNumber, previewStart.column + text.length);
 			this.editor.executeEdits(EditorDictation.ID, [
 				EditOperation.replace(Range.fromPositions(previewStart, previewStart.with(undefined, previewStart.column + lastReplaceTextLength)), text)
 			], [
-				Selection.fromPositions(new Position(previewStart.lineNumber, previewStart.column + text.length))
+				Selection.fromPositions(endPosition)
 			]);
 
 			if (isPreview) {
@@ -225,6 +226,7 @@ export class EditorDictation extends Disposable implements IEditorContribution {
 				lastReplaceTextLength = 0;
 			}
 
+			this.editor.revealPositionInCenterIfOutsideViewport(endPosition);
 			this.widget.layout();
 		};
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
