### PR TITLE
Fix issue with settings not being respected in release notes

### DIFF
--- a/src/vs/workbench/contrib/markdown/browser/markdownSettingRenderer.ts
+++ b/src/vs/workbench/contrib/markdown/browser/markdownSettingRenderer.ts
@@ -14,9 +14,10 @@ import { IContextMenuService } from 'vs/platform/contextview/browser/contextView
 import { ActionViewItem } from 'vs/base/browser/ui/actionbar/actionViewItems';
 import { IAction } from 'vs/base/common/actions';
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
+import { IClipboardService } from 'vs/platform/clipboard/common/clipboardService';
 
-const codeSettingRegex = /^<code (codesetting)="([^\s"\:]+)(?::([^\s"]+))?">/;
-const codeFeatureRegex = /^<span (codefeature)="([^\s"\:]+)(?::([^\s"]+))?">/;
+const codeSettingRegex = /^<code (codesetting)="([^\s"\:]+)(?::([^"]+))?">/;
+const codeFeatureRegex = /^<span (codefeature)="([^\s"\:]+)(?::([^"]+))?">/;
 
 export class SimpleSettingRenderer {
 	private _defaultSettings: DefaultSettings;
@@ -28,7 +29,8 @@ export class SimpleSettingRenderer {
 		@IConfigurationService private readonly _configurationService: IConfigurationService,
 		@IContextMenuService private readonly _contextMenuService: IContextMenuService,
 		@IPreferencesService private readonly _preferencesService: IPreferencesService,
-		@ITelemetryService private readonly _telemetryService: ITelemetryService
+		@ITelemetryService private readonly _telemetryService: ITelemetryService,
+		@IClipboardService private readonly _clipboardService: IClipboardService
 	) {
 		this._defaultSettings = new DefaultSettings([], ConfigurationTarget.USER);
 	}
@@ -255,6 +257,17 @@ export class SimpleSettingRenderer {
 			label: viewInSettingsMessage,
 			run: () => {
 				return this._preferencesService.openApplicationSettings({ query: `@id:${settingId}` });
+			}
+		});
+
+		actions.push({
+			class: undefined,
+			enabled: true,
+			id: 'copySettingId',
+			tooltip: nls.localize('copySettingId', "Copy Setting ID"),
+			label: nls.localize('copySettingId', "Copy Setting ID"),
+			run: () => {
+				this._clipboardService.writeText(settingId);
 			}
 		});
 

--- a/src/vs/workbench/contrib/markdown/test/browser/markdownSettingRenderer.test.ts
+++ b/src/vs/workbench/contrib/markdown/test/browser/markdownSettingRenderer.test.ts
@@ -61,7 +61,7 @@ suite('Markdown Setting Renderer Test', () => {
 		preferencesService = <IPreferencesService>{};
 		contextMenuService = <IContextMenuService>{};
 		Registry.as<IConfigurationRegistry>(Extensions.Configuration).registerConfiguration(configuration);
-		settingRenderer = new SimpleSettingRenderer(configurationService, contextMenuService, preferencesService, { publicLog2: () => { } } as any);
+		settingRenderer = new SimpleSettingRenderer(configurationService, contextMenuService, preferencesService, { publicLog2: () => { } } as any, { writeText: async () => { } } as any);
 	});
 
 	suiteTeardown(() => {
@@ -82,7 +82,7 @@ suite('Markdown Setting Renderer Test', () => {
 	test('actions with no value', () => {
 		const uri = URI.parse(settingRenderer.settingToUriString('example.booleanSetting'));
 		const actions = settingRenderer.getActions(uri);
-		assert.strictEqual(actions?.length, 1);
+		assert.strictEqual(actions?.length, 2);
 		assert.strictEqual(actions[0].label, 'View "Example: Boolean Setting" in Settings');
 	});
 
@@ -91,7 +91,7 @@ suite('Markdown Setting Renderer Test', () => {
 		const uri = URI.parse(settingRenderer.settingToUriString('example.stringSetting', 'three'));
 
 		const verifyOriginalState = (actions: IAction[] | undefined): actions is IAction[] => {
-			assert.strictEqual(actions?.length, 2);
+			assert.strictEqual(actions?.length, 3);
 			assert.strictEqual(actions[0].label, 'Set "Example: String Setting" to "three"');
 			assert.strictEqual(actions[1].label, 'View in Settings');
 			assert.strictEqual(configurationService.getValue('example.stringSetting'), 'two');
@@ -104,9 +104,10 @@ suite('Markdown Setting Renderer Test', () => {
 			await actions[0].run();
 			assert.strictEqual(configurationService.getValue('example.stringSetting'), 'three');
 			const actionsUpdated = settingRenderer.getActions(uri);
-			assert.strictEqual(actionsUpdated?.length, 2);
+			assert.strictEqual(actionsUpdated?.length, 3);
 			assert.strictEqual(actionsUpdated[0].label, 'Restore value of "Example: String Setting"');
 			assert.strictEqual(actions[1].label, 'View in Settings');
+			assert.strictEqual(actions[2].label, 'Copy Setting ID');
 			assert.strictEqual(configurationService.getValue('example.stringSetting'), 'three');
 
 			// Restore the value


### PR DESCRIPTION
This pull request fixes an issue where settings with values separated were not being respected in the release notes. The issue was caused by a regex pattern that didn't correctly handle the separation of values. This PR updates the regex pattern to handle the separation of values correctly. Additionally, it adds a new action to copy the setting ID to the clipboard. This will make it easier for users to reference specific settings. Fixes #205678 and #205742.