### PR TITLE
Fix focusResult of Search Editor

### DIFF
--- a/src/vs/workbench/contrib/search/browser/search.contribution.ts
+++ b/src/vs/workbench/contrib/search/browser/search.contribution.ts
@@ -329,6 +329,11 @@ configurationRegistry.registerConfiguration({
 			default: 1,
 			markdownDescription: nls.localize('search.searchEditor.defaultNumberOfContextLines', "The default number of surrounding context lines to use when creating new Search Editors. If using `#search.searchEditor.reusePriorSearchConfiguration#`, this can be set to `null` (empty) to use the prior Search Editor's configuration.")
 		},
+		'search.searchEditor.focusResultsOnSearch': {
+			type: 'boolean',
+			default: false,
+			markdownDescription: nls.localize('search.searchEditor.focusResultsOnSearch', "When a search is triggered, focus the Search Editor results instead of the Search Editor input.")
+		},
 		'search.sortOrder': {
 			type: 'string',
 			enum: [SearchSortOrder.Default, SearchSortOrder.FileNames, SearchSortOrder.Type, SearchSortOrder.Modified, SearchSortOrder.CountDescending, SearchSortOrder.CountAscending],

--- a/src/vs/workbench/contrib/searchEditor/browser/searchEditor.ts
+++ b/src/vs/workbench/contrib/searchEditor/browser/searchEditor.ts
@@ -483,6 +483,15 @@ export class SearchEditor extends AbstractTextCodeEditor<SearchEditorViewState> 
 	}
 
 	async triggerSearch(_options?: { resetCursor?: boolean; delay?: number; focusResults?: boolean }) {
+		const focusResults = this.searchConfig.searchEditor.focusResultsOnSearch;
+
+		// If _options don't define focusResult field, then use the setting
+		if (_options === undefined) {
+			_options = { focusResults: focusResults };
+		} else if (_options.focusResults === undefined) {
+			_options.focusResults = focusResults;
+		}
+
 		const options = { resetCursor: true, delay: 0, ..._options };
 
 		if (!this.pauseSearching) {

--- a/src/vs/workbench/contrib/searchEditor/browser/searchEditorActions.ts
+++ b/src/vs/workbench/contrib/searchEditor/browser/searchEditorActions.ts
@@ -219,6 +219,6 @@ export const createEditorFromSearchResult =
 		} else {
 			const input = instantiationService.invokeFunction(getOrMakeSearchEditorInput, { from: 'rawData', resultsContents: '', config: { ...config, contextLines } });
 			const editor = await editorService.openEditor(input, { pinned: true }) as SearchEditor;
-			editor.triggerSearch({ focusResults: true });
+			editor.triggerSearch();
 		}
 	};

--- a/src/vs/workbench/services/search/common/search.ts
+++ b/src/vs/workbench/services/search/common/search.ts
@@ -430,6 +430,7 @@ export interface ISearchConfigurationProperties {
 		singleClickBehaviour: 'default' | 'peekDefinition';
 		reusePriorSearchConfiguration: boolean;
 		defaultNumberOfContextLines: number | null;
+		focusResultsOnSearch: boolean;
 		experimental: {};
 	};
 	sortOrder: SearchSortOrder;


### PR DESCRIPTION
~The customized value of focusResult was not used if the search editor was opened from the search view. If focusResult is set to false let's ensure that the search editor input is focused instead.~

~Fixed my keybinding:~
```
	{
		"key": "ctrl+shift+f",
		"command": "search.action.openEditor",
		"args": {
			"focusResults": false,
			"resetCursor": false,
			"triggerSearch": true,
		      },
	},
```

Adding the focusResults option to Search Editor options will allow to have a consistent behavior no matter where the triggerSearch has been fired from. If focusResults is set to false, let's ensure that the search editor input is focused.
    
Use cases that used to focus the Search Editor results instead of its input and were not configurable:
- If the Search Editor has been opened from the search view ("Open in editor" button).
~- If a Peek Definition window was open inside the Search Editor results, then at the widget closure, after the next search task has been completed, the focus was moved from the Search Editor input to its results.~

Fixes https://github.com/microsoft/vscode/issues/214369