### PR TITLE
Improve creation of text models for chat code blocks

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatListRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatListRenderer.ts
@@ -21,7 +21,7 @@ import { Codicon } from 'vs/base/common/codicons';
 import { Emitter, Event } from 'vs/base/common/event';
 import { FuzzyScore } from 'vs/base/common/filters';
 import { IMarkdownString, MarkdownString } from 'vs/base/common/htmlContent';
-import { Disposable, DisposableStore, IDisposable, toDisposable } from 'vs/base/common/lifecycle';
+import { Disposable, DisposableStore, IDisposable, IReference, toDisposable } from 'vs/base/common/lifecycle';
 import { ResourceMap } from 'vs/base/common/map';
 import { marked } from 'vs/base/common/marked/marked';
 import { FileAccess, Schemas, matchesSomeScheme } from 'vs/base/common/network';
@@ -30,10 +30,9 @@ import { basename } from 'vs/base/common/path';
 import { equalsIgnoreCase } from 'vs/base/common/strings';
 import { ThemeIcon } from 'vs/base/common/themables';
 import { URI } from 'vs/base/common/uri';
-import { ICodeEditor } from 'vs/editor/browser/editorBrowser';
-import { ICodeEditorService } from 'vs/editor/browser/services/codeEditorService';
 import { IMarkdownRenderResult, MarkdownRenderer } from 'vs/editor/browser/widget/markdownRenderer/browser/markdownRenderer';
 import { Range } from 'vs/editor/common/core/range';
+import { IResolvedTextEditorModel, ITextModelService } from 'vs/editor/common/services/resolverService';
 import { localize } from 'vs/nls';
 import { IMenuEntryActionViewItemOptions, MenuEntryActionViewItem } from 'vs/platform/actions/browser/menuEntryActionViewItem';
 import { MenuWorkbenchToolBar } from 'vs/platform/actions/browser/toolbar';
@@ -41,7 +40,6 @@ import { MenuId, MenuItemAction } from 'vs/platform/actions/common/actions';
 import { ICommandService } from 'vs/platform/commands/common/commands';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
-import { ITextResourceEditorInput } from 'vs/platform/editor/common/editor';
 import { FileKind, FileType } from 'vs/platform/files/common/files';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { ServiceCollection } from 'vs/platform/instantiation/common/serviceCollection';
@@ -56,9 +54,9 @@ import { AccessibilityVerbositySettingId } from 'vs/workbench/contrib/accessibil
 import { IAccessibleViewService } from 'vs/workbench/contrib/accessibility/browser/accessibleView';
 import { ChatTreeItem, IChatCodeBlockInfo, IChatFileTreeInfo } from 'vs/workbench/contrib/chat/browser/chat';
 import { ChatFollowups } from 'vs/workbench/contrib/chat/browser/chatFollowups';
-import { ChatMarkdownDecorationsRenderer, annotateSpecialMarkdownContent, extractVulnerabilitiesFromText } from 'vs/workbench/contrib/chat/browser/chatMarkdownDecorationsRenderer';
+import { ChatMarkdownDecorationsRenderer, IMarkdownVulnerability, annotateSpecialMarkdownContent, extractVulnerabilitiesFromText } from 'vs/workbench/contrib/chat/browser/chatMarkdownDecorationsRenderer';
 import { ChatEditorOptions } from 'vs/workbench/contrib/chat/browser/chatOptions';
-import { ChatCodeBlockContentProvider, ICodeBlockData, ICodeBlockPart, LocalFileCodeBlockPart, SimpleCodeBlockPart, localFileLanguageId, parseLocalFileData } from 'vs/workbench/contrib/chat/browser/codeBlockPart';
+import { ChatCodeBlockContentProvider, CodeBlockPart, ICodeBlockData, ICodeBlockPart, localFileLanguageId, parseLocalFileData } from 'vs/workbench/contrib/chat/browser/codeBlockPart';
 import { IChatAgentMetadata } from 'vs/workbench/contrib/chat/common/chatAgents';
 import { CONTEXT_CHAT_RESPONSE_SUPPORT_ISSUE_REPORTING, CONTEXT_REQUEST, CONTEXT_RESPONSE, CONTEXT_RESPONSE_FILTERED, CONTEXT_RESPONSE_VOTE } from 'vs/workbench/contrib/chat/common/chatContextKeys';
 import { IChatProgressRenderableResponseContent } from 'vs/workbench/contrib/chat/common/chatModel';
@@ -105,6 +103,7 @@ export interface IChatListItemRendererOptions {
 }
 
 export class ChatListItemRenderer extends Disposable implements ITreeRenderer<ChatTreeItem, FuzzyScore, IChatListItemTemplate> {
+
 	static readonly ID = 'item';
 
 	private readonly codeBlocksByResponseId = new Map<string, IChatCodeBlockInfo[]>();
@@ -133,46 +132,28 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 	private _usedReferencesEnabled = false;
 
 	constructor(
-		private readonly editorOptions: ChatEditorOptions,
+		editorOptions: ChatEditorOptions,
 		private readonly rendererOptions: IChatListItemRendererOptions,
 		private readonly delegate: IChatRendererDelegate,
-		overflowWidgetsDomNode: HTMLElement | undefined,
+		private readonly codeBlockModelCollection: CodeBlockModelCollection,
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
 		@IConfigurationService configService: IConfigurationService,
 		@ILogService private readonly logService: ILogService,
 		@IOpenerService private readonly openerService: IOpenerService,
 		@IContextKeyService private readonly contextKeyService: IContextKeyService,
-		@ICodeEditorService codeEditorService: ICodeEditorService,
 		@IThemeService private readonly themeService: IThemeService,
 		@ICommandService private readonly commandService: ICommandService,
+		@ITextModelService private readonly textModelService: ITextModelService,
 	) {
 		super();
+		this._editorPool = this._register(this.instantiationService.createInstance(EditorPool, editorOptions, delegate, undefined));
+
 		this.renderer = this._register(this.instantiationService.createInstance(MarkdownRenderer, {}));
 		this.markdownDecorationsRenderer = this.instantiationService.createInstance(ChatMarkdownDecorationsRenderer);
-		this._editorPool = this._register(this.instantiationService.createInstance(EditorPool, this.editorOptions, delegate, overflowWidgetsDomNode));
 		this._treePool = this._register(this.instantiationService.createInstance(TreePool, this._onDidChangeVisibility.event));
 		this._contentReferencesListPool = this._register(this.instantiationService.createInstance(ContentReferencesListPool, this._onDidChangeVisibility.event));
 
 		this._register(this.instantiationService.createInstance(ChatCodeBlockContentProvider));
-
-		this._register(codeEditorService.registerCodeEditorOpenHandler(async (input: ITextResourceEditorInput, _source: ICodeEditor | null, _sideBySide?: boolean): Promise<ICodeEditor | null> => {
-			if (input.resource.scheme !== Schemas.vscodeChatCodeBlock) {
-				return null;
-			}
-			const block = this._editorPool.find(input.resource);
-			if (!block) {
-				return null;
-			}
-			if (input.options?.selection) {
-				block.editor.setSelection({
-					startLineNumber: input.options.selection.startLineNumber,
-					startColumn: input.options.selection.startColumn,
-					endLineNumber: input.options.selection.startLineNumber ?? input.options.selection.endLineNumber,
-					endColumn: input.options.selection.startColumn ?? input.options.selection.endColumn
-				});
-			}
-			return block.editor;
-		}));
 
 		this._usedReferencesEnabled = configService.getValue('chat.experimental.usedReferences') ?? true;
 		this._register(configService.onDidChangeConfiguration(e => {
@@ -184,6 +165,10 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 
 	get templateId(): string {
 		return ChatListItemRenderer.ID;
+	}
+
+	editorsInUse() {
+		return this._editorPool.inUse();
 	}
 
 	private traceLayout(method: string, message: string) {
@@ -858,7 +843,6 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 
 	private renderMarkdown(markdown: IMarkdownString, element: ChatTreeItem, templateData: IChatListItemTemplate, fillInIncompleteTokens = false): IMarkdownRenderResult {
 		const disposables = new DisposableStore();
-		let codeBlockIndex = 0;
 
 		markdown = new MarkdownString(markdown.value, {
 			isTrusted: {
@@ -870,25 +854,33 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 		// We release editors in order so that it's more likely that the same editor will be assigned if this element is re-rendered right away, like it often is during progressive rendering
 		const orderedDisposablesList: IDisposable[] = [];
 		const codeblocks: IChatCodeBlockInfo[] = [];
+		let codeBlockIndex = 0;
 		const result = this.renderer.render(markdown, {
 			fillInIncompleteTokens,
 			codeBlockRendererSync: (languageId, text) => {
-				let data: ICodeBlockData;
+				const index = codeBlockIndex++;
+				let textModel: Promise<IReference<IResolvedTextEditorModel>>;
+				let range: Range | undefined;
+				let vulns: readonly IMarkdownVulnerability[] | undefined;
 				if (equalsIgnoreCase(languageId, localFileLanguageId)) {
 					try {
 						const parsedBody = parseLocalFileData(text);
-						data = { type: 'localFile', uri: parsedBody.uri, range: parsedBody.range && Range.lift(parsedBody.range), codeBlockIndex: codeBlockIndex++, element, hideToolbar: false, parentContextKeyService: templateData.contextKeyService };
+						range = parsedBody.range && Range.lift(parsedBody.range);
+						textModel = this.textModelService.createModelReference(parsedBody.uri);
 					} catch (e) {
-						console.error(e);
 						return $('div');
 					}
 				} else {
-					const vulns = extractVulnerabilitiesFromText(text);
-					const hideToolbar = isResponseVM(element) && element.errorDetails?.responseIsFiltered;
-					data = { type: 'code', languageId, text: vulns.newText, codeBlockIndex: codeBlockIndex++, element, hideToolbar, parentContextKeyService: templateData.contextKeyService, vulns: vulns.vulnerabilities };
+					// TODO: Creating the text models should be done in the model layer, not in the renderer
+					// The current approach means that only code blocks that have been rendered can be referenced
+					textModel = this.codeBlockModelCollection.getOrCreate(element, index);
+					const extractedVulns = extractVulnerabilitiesFromText(text);
+					vulns = extractedVulns.vulnerabilities;
+					textModel.then(ref => ref.object.textEditorModel.setValue(extractedVulns.newText));
 				}
 
-				const ref = this.renderCodeBlock(data);
+				const hideToolbar = isResponseVM(element) && element.errorDetails?.responseIsFiltered;
+				const ref = this.renderCodeBlock({ languageId, textModel, codeBlockIndex: index, element, range, hideToolbar, parentContextKeyService: templateData.contextKeyService, vulns });
 
 				// Attach this after updating text/layout of the editor, so it should only be fired when the size updates later (horizontal scrollbar, wrapping)
 				// not during a renderElement OR a progressive render (when we will be firing this event anyway at the end of the render)
@@ -899,15 +891,18 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 
 				if (isResponseVM(element)) {
 					const info: IChatCodeBlockInfo = {
-						codeBlockIndex: data.codeBlockIndex,
+						codeBlockIndex: index,
 						element,
 						focus() {
 							ref.object.focus();
 						}
 					};
 					codeblocks.push(info);
-					this.codeBlocksByEditorUri.set(ref.object.uri, info);
-					disposables.add(toDisposable(() => this.codeBlocksByEditorUri.delete(ref.object.uri)));
+					if (ref.object.uri) {
+						const uri = ref.object.uri;
+						this.codeBlocksByEditorUri.set(uri, info);
+						disposables.add(toDisposable(() => this.codeBlocksByEditorUri.delete(uri)));
+					}
 				}
 				orderedDisposablesList.push(ref);
 				return ref.object.element;
@@ -933,7 +928,7 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 	}
 
 	private renderCodeBlock(data: ICodeBlockData): IDisposableReference<ICodeBlockPart> {
-		const ref = this._editorPool.get(data);
+		const ref = this._editorPool.get();
 		const editorInfo = ref.object;
 		editorInfo.render(data, this._currentLayoutWidth);
 
@@ -1068,41 +1063,28 @@ interface IDisposableReference<T> extends IDisposable {
 	isStale: () => boolean;
 }
 
-class EditorPool extends Disposable {
+export class EditorPool extends Disposable {
 
-	private readonly _simpleEditorPool: ResourcePool<SimpleCodeBlockPart>;
-	private readonly _localFileEditorPool: ResourcePool<LocalFileCodeBlockPart>;
+	private readonly _pool: ResourcePool<CodeBlockPart>;
 
-	public *inUse(): Iterable<ICodeBlockPart> {
-		yield* this._simpleEditorPool.inUse;
-		yield* this._localFileEditorPool.inUse;
+	public inUse(): Iterable<ICodeBlockPart> {
+		return this._pool.inUse;
 	}
 
 	constructor(
-		private readonly options: ChatEditorOptions,
+		options: ChatEditorOptions,
 		delegate: IChatRendererDelegate,
 		overflowWidgetsDomNode: HTMLElement | undefined,
-		@IInstantiationService private readonly instantiationService: IInstantiationService,
+		@IInstantiationService instantiationService: IInstantiationService,
 	) {
 		super();
-		this._simpleEditorPool = this._register(new ResourcePool(() => {
-			return this.instantiationService.createInstance(SimpleCodeBlockPart, this.options, MenuId.ChatCodeBlock, delegate, overflowWidgetsDomNode);
-		}));
-		this._localFileEditorPool = this._register(new ResourcePool(() => {
-			return this.instantiationService.createInstance(LocalFileCodeBlockPart, this.options, MenuId.ChatCodeBlock, delegate, overflowWidgetsDomNode);
+		this._pool = this._register(new ResourcePool(() => {
+			return instantiationService.createInstance(CodeBlockPart, options, MenuId.ChatCodeBlock, delegate, overflowWidgetsDomNode);
 		}));
 	}
 
-	get(data: ICodeBlockData): IDisposableReference<ICodeBlockPart> {
-		return this.getFromPool(data.type === 'localFile' ? this._localFileEditorPool : this._simpleEditorPool);
-	}
-
-	find(resource: URI): SimpleCodeBlockPart | undefined {
-		return Array.from(this._simpleEditorPool.inUse).find(part => part.uri?.toString() === resource.toString());
-	}
-
-	private getFromPool(pool: ResourcePool<ICodeBlockPart>): IDisposableReference<ICodeBlockPart> {
-		const codeBlock = pool.get();
+	get(): IDisposableReference<ICodeBlockPart> {
+		const codeBlock = this._pool.get();
 		let stale = false;
 		return {
 			object: codeBlock,
@@ -1110,9 +1092,46 @@ class EditorPool extends Disposable {
 			dispose: () => {
 				codeBlock.reset();
 				stale = true;
-				pool.release(codeBlock);
+				this._pool.release(codeBlock);
 			}
 		};
+	}
+}
+
+export class CodeBlockModelCollection extends Disposable {
+
+	private readonly _models = new ResourceMap<Promise<IReference<IResolvedTextEditorModel>>>();
+
+	constructor(
+		@ITextModelService private readonly textModelService: ITextModelService,
+	) {
+		super();
+	}
+
+	public override dispose(): void {
+		super.dispose();
+		this.clear();
+	}
+
+	getOrCreate(element: ChatTreeItem, codeBlockIndex: number): Promise<IReference<IResolvedTextEditorModel>> {
+		const uri = this.getUri(element, codeBlockIndex);
+		const existing = this._models.get(uri);
+		if (existing) {
+			return existing;
+		}
+
+		const ref = this.textModelService.createModelReference(uri);
+		this._models.set(uri, ref);
+		return ref;
+	}
+
+	clear(): void {
+		this._models.forEach(async model => (await model).dispose());
+		this._models.clear();
+	}
+
+	private getUri(element: ChatTreeItem, index: number): URI {
+		return URI.from({ scheme: Schemas.vscodeChatCodeBlock, path: `/${element.id}/${index}` });
 	}
 }
 

--- a/src/vs/workbench/contrib/chat/browser/chatListRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatListRenderer.ts
@@ -104,7 +104,6 @@ export interface IChatListItemRendererOptions {
 }
 
 export class ChatListItemRenderer extends Disposable implements ITreeRenderer<ChatTreeItem, FuzzyScore, IChatListItemTemplate> {
-
 	static readonly ID = 'item';
 
 	private readonly codeBlocksByResponseId = new Map<string, IChatCodeBlockInfo[]>();
@@ -137,6 +136,7 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 		private readonly rendererOptions: IChatListItemRendererOptions,
 		private readonly delegate: IChatRendererDelegate,
 		private readonly codeBlockModelCollection: CodeBlockModelCollection,
+		overflowWidgetsDomNode: HTMLElement | undefined,
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
 		@IConfigurationService configService: IConfigurationService,
 		@ILogService private readonly logService: ILogService,
@@ -147,10 +147,10 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 		@ITextModelService private readonly textModelService: ITextModelService,
 	) {
 		super();
-		this._editorPool = this._register(this.instantiationService.createInstance(EditorPool, editorOptions, delegate, undefined));
 
 		this.renderer = this._register(this.instantiationService.createInstance(MarkdownRenderer, {}));
 		this.markdownDecorationsRenderer = this.instantiationService.createInstance(ChatMarkdownDecorationsRenderer);
+		this._editorPool = this._register(this.instantiationService.createInstance(EditorPool, editorOptions, delegate, overflowWidgetsDomNode));
 		this._treePool = this._register(this.instantiationService.createInstance(TreePool, this._onDidChangeVisibility.event));
 		this._contentReferencesListPool = this._register(this.instantiationService.createInstance(ContentReferencesListPool, this._onDidChangeVisibility.event));
 

--- a/src/vs/workbench/contrib/chat/browser/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatWidget.ts
@@ -5,37 +5,40 @@
 
 import * as dom from 'vs/base/browser/dom';
 import { ITreeContextMenuEvent, ITreeElement } from 'vs/base/browser/ui/tree/tree';
-import { disposableTimeout } from 'vs/base/common/async';
+import { disposableTimeout, timeout } from 'vs/base/common/async';
 import { toErrorMessage } from 'vs/base/common/errorMessage';
 import { Emitter } from 'vs/base/common/event';
 import { Disposable, DisposableStore, IDisposable, MutableDisposable, combinedDisposable, toDisposable } from 'vs/base/common/lifecycle';
+import { Schemas } from 'vs/base/common/network';
 import { isEqual } from 'vs/base/common/resources';
 import { isDefined } from 'vs/base/common/types';
 import { URI } from 'vs/base/common/uri';
 import 'vs/css!./media/chat';
 import { ICodeEditor } from 'vs/editor/browser/editorBrowser';
+import { ICodeEditorService } from 'vs/editor/browser/services/codeEditorService';
 import { MenuId } from 'vs/platform/actions/common/actions';
 import { IContextKey, IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 import { IContextMenuService } from 'vs/platform/contextview/browser/contextView';
+import { ITextResourceEditorInput } from 'vs/platform/editor/common/editor';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { ServiceCollection } from 'vs/platform/instantiation/common/serviceCollection';
 import { WorkbenchObjectTree } from 'vs/platform/list/browser/listService';
 import { ILogService } from 'vs/platform/log/common/log';
-import { IViewsService } from 'vs/workbench/services/views/common/viewsService';
+import { IThemeService } from 'vs/platform/theme/common/themeService';
 import { ChatTreeItem, IChatAccessibilityService, IChatCodeBlockInfo, IChatFileTreeInfo, IChatWidget, IChatWidgetService, IChatWidgetViewContext, IChatWidgetViewOptions } from 'vs/workbench/contrib/chat/browser/chat';
 import { ChatInputPart } from 'vs/workbench/contrib/chat/browser/chatInputPart';
-import { ChatAccessibilityProvider, ChatListDelegate, ChatListItemRenderer, IChatListItemRendererOptions, IChatRendererDelegate } from 'vs/workbench/contrib/chat/browser/chatListRenderer';
+import { ChatAccessibilityProvider, ChatListDelegate, ChatListItemRenderer, CodeBlockModelCollection, IChatListItemRendererOptions, IChatRendererDelegate } from 'vs/workbench/contrib/chat/browser/chatListRenderer';
 import { ChatEditorOptions } from 'vs/workbench/contrib/chat/browser/chatOptions';
 import { ChatViewPane } from 'vs/workbench/contrib/chat/browser/chatViewPane';
+import { IChatAgentCommand, IChatAgentData, IChatAgentService } from 'vs/workbench/contrib/chat/common/chatAgents';
 import { CONTEXT_CHAT_REQUEST_IN_PROGRESS, CONTEXT_IN_CHAT_SESSION, CONTEXT_RESPONSE_FILTERED } from 'vs/workbench/contrib/chat/common/chatContextKeys';
 import { IChatContributionService } from 'vs/workbench/contrib/chat/common/chatContributionService';
 import { ChatModelInitState, IChatModel } from 'vs/workbench/contrib/chat/common/chatModel';
-import { IChatFollowup, IChatService } from 'vs/workbench/contrib/chat/common/chatService';
-import { ChatViewModel, IChatResponseViewModel, isRequestVM, isResponseVM, isWelcomeVM } from 'vs/workbench/contrib/chat/common/chatViewModel';
-import { IThemeService } from 'vs/platform/theme/common/themeService';
 import { IParsedChatRequest, chatAgentLeader, chatSubcommandLeader } from 'vs/workbench/contrib/chat/common/chatParserTypes';
 import { ChatRequestParser } from 'vs/workbench/contrib/chat/common/chatRequestParser';
-import { IChatAgentCommand, IChatAgentData, IChatAgentService } from 'vs/workbench/contrib/chat/common/chatAgents';
+import { IChatFollowup, IChatService } from 'vs/workbench/contrib/chat/common/chatService';
+import { ChatViewModel, IChatResponseViewModel, isRequestVM, isResponseVM, isWelcomeVM } from 'vs/workbench/contrib/chat/common/chatViewModel';
+import { IViewsService } from 'vs/workbench/services/views/common/viewsService';
 
 const $ = dom.$;
 
@@ -98,6 +101,7 @@ export class ChatWidget extends Disposable implements IChatWidget {
 
 	private tree!: WorkbenchObjectTree<ChatTreeItem>;
 	private renderer!: ChatListItemRenderer;
+	private readonly _codeBlockModelCollection: CodeBlockModelCollection;
 
 	private inputPart!: ChatInputPart;
 	private editorOptions!: ChatEditorOptions;
@@ -109,6 +113,7 @@ export class ChatWidget extends Disposable implements IChatWidget {
 	private visibleChangeCount = 0;
 	private requestInProgress: IContextKey<boolean>;
 	private _visible = false;
+
 	public get visible() {
 		return this._visible;
 	}
@@ -122,6 +127,7 @@ export class ChatWidget extends Disposable implements IChatWidget {
 			return;
 		}
 
+		this._codeBlockModelCollection.clear();
 		this.viewModelDisposables.clear();
 
 		this._viewModel = viewModel;
@@ -158,13 +164,52 @@ export class ChatWidget extends Disposable implements IChatWidget {
 		@IChatAccessibilityService private readonly _chatAccessibilityService: IChatAccessibilityService,
 		@IInstantiationService private readonly _instantiationService: IInstantiationService,
 		@ILogService private readonly _logService: ILogService,
-		@IThemeService private readonly _themeService: IThemeService
+		@IThemeService private readonly _themeService: IThemeService,
+		@ICodeEditorService codeEditorService: ICodeEditorService,
 	) {
 		super();
 		CONTEXT_IN_CHAT_SESSION.bindTo(contextKeyService).set(true);
 		this.requestInProgress = CONTEXT_CHAT_REQUEST_IN_PROGRESS.bindTo(contextKeyService);
 
 		this._register((chatWidgetService as ChatWidgetService).register(this));
+
+		this._codeBlockModelCollection = this._register(instantiationService.createInstance(CodeBlockModelCollection));
+
+		this._register(codeEditorService.registerCodeEditorOpenHandler(async (input: ITextResourceEditorInput, _source: ICodeEditor | null, _sideBySide?: boolean): Promise<ICodeEditor | null> => {
+			if (input.resource.scheme !== Schemas.vscodeChatCodeBlock) {
+				return null;
+			}
+
+			const responseId = input.resource.path.split('/').at(1);
+			if (!responseId) {
+				return null;
+			}
+
+			const item = this.viewModel?.getItems().find(item => item.id === responseId);
+			if (!item) {
+				return null;
+			}
+
+			this.reveal(item);
+
+			await timeout(0); // wait for list to actually render
+
+			for (const editor of this.renderer.editorsInUse() ?? []) {
+				if (editor.uri?.toString() === input.resource.toString()) {
+					const inner = editor.editor;
+					if (input.options?.selection) {
+						inner.setSelection({
+							startLineNumber: input.options.selection.startLineNumber,
+							startColumn: input.options.selection.startColumn,
+							endLineNumber: input.options.selection.startLineNumber ?? input.options.selection.endLineNumber,
+							endColumn: input.options.selection.startColumn ?? input.options.selection.endColumn
+						});
+					}
+					return inner;
+				}
+			}
+			return null;
+		}));
 	}
 
 	get supportsFileReferences(): boolean {
@@ -340,7 +385,7 @@ export class ChatWidget extends Disposable implements IChatWidget {
 			this.editorOptions,
 			options,
 			rendererDelegate,
-			overflowWidgetsContainer,
+			this._codeBlockModelCollection,
 		));
 		this._register(this.renderer.onDidClickFollowup(item => {
 			// is this used anymore?
@@ -514,6 +559,10 @@ export class ChatWidget extends Disposable implements IChatWidget {
 				c.setInputState(viewState.inputState?.[c.id]);
 			}
 		});
+
+		// for (const message of this.viewModel.getItems()) {
+		// 	this._codeBlockModelCollection.createForMessage(message);
+		// }
 
 		if (this.tree) {
 			this.onDidChangeItems();

--- a/src/vs/workbench/contrib/chat/browser/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatWidget.ts
@@ -114,7 +114,6 @@ export class ChatWidget extends Disposable implements IChatWidget {
 	private visibleChangeCount = 0;
 	private requestInProgress: IContextKey<boolean>;
 	private _visible = false;
-
 	public get visible() {
 		return this._visible;
 	}
@@ -155,6 +154,7 @@ export class ChatWidget extends Disposable implements IChatWidget {
 		readonly viewContext: IChatWidgetViewContext,
 		private readonly viewOptions: IChatWidgetViewOptions,
 		private readonly styles: IChatWidgetStyles,
+		@ICodeEditorService codeEditorService: ICodeEditorService,
 		@IContextKeyService private readonly contextKeyService: IContextKeyService,
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
 		@IChatService private readonly chatService: IChatService,
@@ -165,7 +165,6 @@ export class ChatWidget extends Disposable implements IChatWidget {
 		@IInstantiationService private readonly _instantiationService: IInstantiationService,
 		@ILogService private readonly _logService: ILogService,
 		@IThemeService private readonly _themeService: IThemeService,
-		@ICodeEditorService codeEditorService: ICodeEditorService,
 	) {
 		super();
 		CONTEXT_IN_CHAT_SESSION.bindTo(contextKeyService).set(true);
@@ -386,6 +385,7 @@ export class ChatWidget extends Disposable implements IChatWidget {
 			options,
 			rendererDelegate,
 			this._codeBlockModelCollection,
+			overflowWidgetsContainer,
 		));
 		this._register(this.renderer.onDidClickFollowup(item => {
 			// is this used anymore?

--- a/src/vs/workbench/contrib/chat/browser/codeBlockPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/codeBlockPart.ts
@@ -9,10 +9,9 @@ import * as dom from 'vs/base/browser/dom';
 import { Button } from 'vs/base/browser/ui/button/button';
 import { Codicon } from 'vs/base/common/codicons';
 import { Emitter, Event } from 'vs/base/common/event';
-import { Disposable, IReference, MutableDisposable } from 'vs/base/common/lifecycle';
+import { Disposable, IReference } from 'vs/base/common/lifecycle';
 import { Schemas } from 'vs/base/common/network';
 import { URI, UriComponents } from 'vs/base/common/uri';
-import { generateUuid } from 'vs/base/common/uuid';
 import { IEditorConstructionOptions } from 'vs/editor/browser/config/editorConfiguration';
 import { EditorExtensionsRegistry } from 'vs/editor/browser/editorExtensions';
 import { CodeEditorWidget } from 'vs/editor/browser/widget/codeEditorWidget';
@@ -50,27 +49,19 @@ import { getSimpleEditorOptions } from 'vs/workbench/contrib/codeEditor/browser/
 
 const $ = dom.$;
 
-interface ICodeBlockDataCommon {
-	codeBlockIndex: number;
-	element: unknown;
-	parentContextKeyService?: IContextKeyService;
-	hideToolbar?: boolean;
-}
+export interface ICodeBlockData {
+	readonly codeBlockIndex: number;
+	readonly element: unknown;
 
-export interface ISimpleCodeBlockData extends ICodeBlockDataCommon {
-	type: 'code';
-	text: string;
-	languageId: string;
-	vulns?: IMarkdownVulnerability[];
-}
+	readonly textModel: Promise<IReference<IResolvedTextEditorModel>>;
+	readonly languageId: string;
 
-export interface ILocalFileCodeBlockData extends ICodeBlockDataCommon {
-	type: 'localFile';
-	uri: URI;
-	range?: Range;
-}
+	readonly vulns?: readonly IMarkdownVulnerability[];
+	readonly range?: Range;
 
-export type ICodeBlockData = ISimpleCodeBlockData | ILocalFileCodeBlockData;
+	readonly parentContextKeyService?: IContextKeyService;
+	readonly hideToolbar?: boolean;
+}
 
 /**
  * Special markdown code block language id used to render a local file.
@@ -118,19 +109,20 @@ export interface ICodeBlockActionContext {
 }
 
 
-export interface ICodeBlockPart<Data = ICodeBlockData> {
+export interface ICodeBlockPart {
+	readonly editor: CodeEditorWidget;
 	readonly onDidChangeContentHeight: Event<void>;
 	readonly element: HTMLElement;
-	readonly uri: URI;
+	readonly uri: URI | undefined;
 	layout(width: number): void;
-	render(data: Data, width: number): Promise<void>;
+	render(data: ICodeBlockData, width: number): Promise<void>;
 	focus(): void;
 	reset(): unknown;
 	dispose(): void;
 }
 
 const defaultCodeblockPadding = 10;
-abstract class BaseCodeBlockPart<Data extends ICodeBlockData> extends Disposable implements ICodeBlockPart<Data> {
+export class CodeBlockPart extends Disposable implements ICodeBlockPart {
 	protected readonly _onDidChangeContentHeight = this._register(new Emitter<void>());
 	public readonly onDidChangeContentHeight = this._onDidChangeContentHeight.event;
 
@@ -138,9 +130,12 @@ abstract class BaseCodeBlockPart<Data extends ICodeBlockData> extends Disposable
 	protected readonly toolbar: MenuWorkbenchToolBar;
 	private readonly contextKeyService: IContextKeyService;
 
-	abstract readonly uri: URI;
 	public readonly element: HTMLElement;
 
+	private readonly vulnsButton: Button;
+	private readonly vulnsListElement: HTMLElement;
+
+	private currentCodeBlockData: ICodeBlockData | undefined;
 	private currentScrollWidth = 0;
 
 	constructor(
@@ -152,7 +147,8 @@ abstract class BaseCodeBlockPart<Data extends ICodeBlockData> extends Disposable
 		@IContextKeyService contextKeyService: IContextKeyService,
 		@IModelService protected readonly modelService: IModelService,
 		@IConfigurationService private readonly configurationService: IConfigurationService,
-		@IAccessibilityService private readonly accessibilityService: IAccessibilityService
+		@IAccessibilityService private readonly accessibilityService: IAccessibilityService,
+		@ILanguageService private readonly languageService: ILanguageService,
 	) {
 		super();
 		this.element = $('.interactive-result-code-block');
@@ -186,6 +182,31 @@ abstract class BaseCodeBlockPart<Data extends ICodeBlockData> extends Disposable
 				shouldForwardArgs: true
 			}
 		}));
+
+		const vulnsContainer = dom.append(this.element, $('.interactive-result-vulns'));
+		const vulnsHeaderElement = dom.append(vulnsContainer, $('.interactive-result-vulns-header', undefined));
+		this.vulnsButton = new Button(vulnsHeaderElement, {
+			buttonBackground: undefined,
+			buttonBorder: undefined,
+			buttonForeground: undefined,
+			buttonHoverBackground: undefined,
+			buttonSecondaryBackground: undefined,
+			buttonSecondaryForeground: undefined,
+			buttonSecondaryHoverBackground: undefined,
+			buttonSeparator: undefined,
+			supportIcons: true
+		});
+
+		this.vulnsListElement = dom.append(vulnsContainer, $('ul.interactive-result-vulns-list'));
+
+		this.vulnsButton.onDidClick(() => {
+			const element = this.currentCodeBlockData!.element as IChatResponseViewModel;
+			element.vulnerabilitiesListExpanded = !element.vulnerabilitiesListExpanded;
+			this.vulnsButton.label = this.getVulnerabilitiesLabel();
+			this.element.classList.toggle('chat-vulnerabilities-collapsed', !element.vulnerabilitiesListExpanded);
+			this._onDidChangeContentHeight.fire();
+			// this.updateAriaLabel(collapseButton.element, referencesLabel, element.usedReferencesExpanded);
+		});
 
 		this._register(this.toolbar.onDidChangeDropdownVisibility(e => {
 			toolbarElement.classList.toggle('force-visibility', e);
@@ -229,7 +250,27 @@ abstract class BaseCodeBlockPart<Data extends ICodeBlockData> extends Disposable
 		}
 	}
 
-	protected abstract createEditor(instantiationService: IInstantiationService, parent: HTMLElement, options: Readonly<IEditorConstructionOptions>): CodeEditorWidget;
+	get uri(): URI | undefined {
+		return this.editor.getModel()?.uri;
+	}
+
+	private createEditor(instantiationService: IInstantiationService, parent: HTMLElement, options: Readonly<IEditorConstructionOptions>): CodeEditorWidget {
+		return this._register(instantiationService.createInstance(CodeEditorWidget, parent, options, {
+			isSimpleWidget: false,
+			contributions: EditorExtensionsRegistry.getSomeEditorContributions([
+				MenuPreventer.ID,
+				SelectionClipboardContributionID,
+				ContextMenuController.ID,
+
+				WordHighlighterContribution.ID,
+				ViewportSemanticTokensContribution.ID,
+				BracketMatchingController.ID,
+				SmartSelectController.ID,
+				HoverController.ID,
+				GotoDefinitionAtPositionEditorContribution.ID,
+			])
+		}));
+	}
 
 	focus(): void {
 		this.editor.focus();
@@ -277,17 +318,22 @@ abstract class BaseCodeBlockPart<Data extends ICodeBlockData> extends Disposable
 		this.updatePaddingForLayout();
 	}
 
-	protected getContentHeight() {
+	private getContentHeight() {
+		if (this.currentCodeBlockData?.range) {
+			const lineCount = this.currentCodeBlockData.range.endLineNumber - this.currentCodeBlockData.range.startLineNumber + 1;
+			const lineHeight = this.editor.getOption(EditorOption.lineHeight);
+			return lineCount * lineHeight;
+		}
 		return this.editor.getContentHeight();
 	}
 
-	async render(data: Data, width: number) {
+	async render(data: ICodeBlockData, width: number) {
 		if (data.parentContextKeyService) {
 			this.contextKeyService.updateParent(data.parentContextKeyService);
 		}
 
 		if (this.options.configuration.resultEditor.wordWrap === 'on') {
-			// Intialize the editor with the new proper width so that getContentHeight
+			// Initialize the editor with the new proper width so that getContentHeight
 			// will be computed correctly in the next call to layout()
 			this.layout(width);
 		}
@@ -302,102 +348,6 @@ abstract class BaseCodeBlockPart<Data extends ICodeBlockData> extends Disposable
 		} else {
 			dom.show(this.toolbar.getElement());
 		}
-	}
-
-	protected abstract updateEditor(data: Data): void | Promise<void>;
-
-	reset() {
-		this.clearWidgets();
-	}
-
-	private clearWidgets() {
-		HoverController.get(this.editor)?.hideContentHover();
-	}
-}
-
-
-export class SimpleCodeBlockPart extends BaseCodeBlockPart<ISimpleCodeBlockData> {
-
-	private readonly vulnsButton: Button;
-	private readonly vulnsListElement: HTMLElement;
-
-	private currentCodeBlockData: ISimpleCodeBlockData | undefined;
-
-	private readonly textModel: Promise<ITextModel>;
-
-	private readonly _uri: URI;
-
-	constructor(
-		options: ChatEditorOptions,
-		menuId: MenuId,
-		delegate: IChatRendererDelegate,
-		overflowWidgetsDomNode: HTMLElement | undefined,
-		@IInstantiationService instantiationService: IInstantiationService,
-		@IContextKeyService contextKeyService: IContextKeyService,
-		@IModelService modelService: IModelService,
-		@ITextModelService textModelService: ITextModelService,
-		@IConfigurationService configurationService: IConfigurationService,
-		@IAccessibilityService accessibilityService: IAccessibilityService,
-		@ILanguageService private readonly languageService: ILanguageService,
-	) {
-		super(options, menuId, delegate, overflowWidgetsDomNode, instantiationService, contextKeyService, modelService, configurationService, accessibilityService);
-
-		const vulnsContainer = dom.append(this.element, $('.interactive-result-vulns'));
-		const vulnsHeaderElement = dom.append(vulnsContainer, $('.interactive-result-vulns-header', undefined));
-		this.vulnsButton = new Button(vulnsHeaderElement, {
-			buttonBackground: undefined,
-			buttonBorder: undefined,
-			buttonForeground: undefined,
-			buttonHoverBackground: undefined,
-			buttonSecondaryBackground: undefined,
-			buttonSecondaryForeground: undefined,
-			buttonSecondaryHoverBackground: undefined,
-			buttonSeparator: undefined,
-			supportIcons: true
-		});
-		this._uri = URI.from({ scheme: Schemas.vscodeChatCodeBlock, path: generateUuid() });
-		this.textModel = textModelService.createModelReference(this._uri).then(ref => {
-			this.editor.setModel(ref.object.textEditorModel);
-			this._register(ref);
-			return ref.object.textEditorModel;
-		});
-
-		this.vulnsListElement = dom.append(vulnsContainer, $('ul.interactive-result-vulns-list'));
-
-		this.vulnsButton.onDidClick(() => {
-			const element = this.currentCodeBlockData!.element as IChatResponseViewModel;
-			element.vulnerabilitiesListExpanded = !element.vulnerabilitiesListExpanded;
-			this.vulnsButton.label = this.getVulnerabilitiesLabel();
-			this.element.classList.toggle('chat-vulnerabilities-collapsed', !element.vulnerabilitiesListExpanded);
-			this._onDidChangeContentHeight.fire();
-			// this.updateAriaLabel(collapseButton.element, referencesLabel, element.usedReferencesExpanded);
-		});
-	}
-
-	get uri(): URI {
-		return this._uri;
-	}
-
-	protected override createEditor(instantiationService: IInstantiationService, parent: HTMLElement, options: Readonly<IEditorConstructionOptions>): CodeEditorWidget {
-		return this._register(instantiationService.createInstance(CodeEditorWidget, parent, options, {
-			isSimpleWidget: false,
-			contributions: EditorExtensionsRegistry.getSomeEditorContributions([
-				MenuPreventer.ID,
-				SelectionClipboardContributionID,
-				ContextMenuController.ID,
-
-				WordHighlighterContribution.ID,
-				ViewportSemanticTokensContribution.ID,
-				BracketMatchingController.ID,
-				SmartSelectController.ID,
-				HoverController.ID,
-				GotoDefinitionAtPositionEditorContribution.ID,
-			])
-		}));
-	}
-
-	override async render(data: ISimpleCodeBlockData, width: number): Promise<void> {
-		await super.render(data, width);
 
 		if (data.vulns?.length && isResponseVM(data.element)) {
 			dom.clearNode(this.vulnsListElement);
@@ -410,20 +360,32 @@ export class SimpleCodeBlockPart extends BaseCodeBlockPart<ISimpleCodeBlockData>
 		}
 	}
 
-	protected override async updateEditor(data: ISimpleCodeBlockData): Promise<void> {
-		this.editor.setModel(await this.textModel);
-		const text = this.fixCodeText(data.text, data.languageId);
-		this.setText(text);
+	reset() {
+		this.clearWidgets();
+	}
 
-		const vscodeLanguageId = this.languageService.getLanguageIdByLanguageName(data.languageId) ?? undefined;
-		this.setLanguage(vscodeLanguageId);
-		data.languageId = vscodeLanguageId ?? 'plaintext';
+	private clearWidgets() {
+		HoverController.get(this.editor)?.hideContentHover();
+	}
+
+	private async updateEditor(data: ICodeBlockData): Promise<void> {
+		const textModel = (await data.textModel).object.textEditorModel;
+		this.editor.setModel(textModel);
+		const code = textModel.getValue();
+		const text = this.fixCodeText(code, data.languageId);
+		const vscodeLanguageId = this.languageService.getLanguageIdByLanguageName(data.languageId) ?? 'plaintext';
+		this.setTextAndLanguage(textModel, vscodeLanguageId, text);
+
+		if (data.range) {
+			this.editor.setSelection(data.range);
+			this.editor.revealRangeInCenter(data.range, ScrollType.Immediate);
+		}
 
 		this.toolbar.context = {
-			code: data.text,
+			code: textModel.getTextBuffer().getValueInRange(data.range ?? textModel.getFullModelRange(), EndOfLinePreference.TextDefined),
 			codeBlockIndex: data.codeBlockIndex,
 			element: data.element,
-			languageId: data.languageId
+			languageId: textModel.getLanguageId()
 		} satisfies ICodeBlockActionContext;
 	}
 
@@ -449,8 +411,9 @@ export class SimpleCodeBlockPart extends BaseCodeBlockPart<ISimpleCodeBlockData>
 		return text;
 	}
 
-	private async setText(newText: string): Promise<void> {
-		const model = await this.textModel;
+	private async setTextAndLanguage(model: ITextModel, vscodeLanguageId: string | undefined, newText: string): Promise<void> {
+		model.setLanguage(vscodeLanguageId ?? vscodeLanguageId ?? PLAINTEXT_LANGUAGE_ID);
+
 		const currentText = model.getValue(EndOfLinePreference.LF);
 		if (newText === currentText) {
 			return;
@@ -466,81 +429,7 @@ export class SimpleCodeBlockPart extends BaseCodeBlockPart<ISimpleCodeBlockData>
 			model.setValue(newText);
 		}
 	}
-
-	private async setLanguage(vscodeLanguageId: string | undefined): Promise<void> {
-		(await this.textModel).setLanguage(vscodeLanguageId ?? PLAINTEXT_LANGUAGE_ID);
-	}
 }
-
-export class LocalFileCodeBlockPart extends BaseCodeBlockPart<ILocalFileCodeBlockData> {
-
-	private readonly textModelReference = this._register(new MutableDisposable<IReference<IResolvedTextEditorModel>>());
-	private currentCodeBlockData?: ILocalFileCodeBlockData;
-
-	constructor(
-		options: ChatEditorOptions,
-		menuId: MenuId,
-		delegate: IChatRendererDelegate,
-		overflowWidgetsDomNode: HTMLElement | undefined,
-		@IInstantiationService instantiationService: IInstantiationService,
-		@IContextKeyService contextKeyService: IContextKeyService,
-		@IModelService modelService: IModelService,
-		@ITextModelService private readonly textModelService: ITextModelService,
-		@IConfigurationService configurationService: IConfigurationService,
-		@IAccessibilityService accessibilityService: IAccessibilityService
-	) {
-		super(options, menuId, delegate, overflowWidgetsDomNode, instantiationService, contextKeyService, modelService, configurationService, accessibilityService);
-	}
-
-	get uri(): URI {
-		return this.currentCodeBlockData!.uri;
-	}
-
-	protected override getContentHeight() {
-		if (this.currentCodeBlockData?.range) {
-			const lineCount = this.currentCodeBlockData.range.endLineNumber - this.currentCodeBlockData.range.startLineNumber + 1;
-			const lineHeight = this.editor.getOption(EditorOption.lineHeight);
-			return lineCount * lineHeight;
-		}
-		return super.getContentHeight();
-	}
-
-	protected override createEditor(instantiationService: IInstantiationService, parent: HTMLElement, options: Readonly<IEditorConstructionOptions>): CodeEditorWidget {
-		return this._register(instantiationService.createInstance(CodeEditorWidget, parent, {
-			...options,
-		}, {
-			// TODO: be more selective about contributions
-		}));
-	}
-
-	protected override async updateEditor(data: ILocalFileCodeBlockData): Promise<void> {
-		let model: ITextModel;
-		if (this.currentCodeBlockData?.uri.toString() === data.uri.toString()) {
-			this.currentCodeBlockData = data;
-			model = this.editor.getModel()!;
-		} else {
-			this.currentCodeBlockData = data;
-			const result = await this.textModelService.createModelReference(data.uri);
-			model = result.object.textEditorModel;
-			this.textModelReference.value = result;
-			this.editor.setModel(model);
-		}
-
-
-		if (data.range) {
-			this.editor.setSelection(data.range);
-			this.editor.revealRangeInCenter(data.range, ScrollType.Immediate);
-		}
-
-		this.toolbar.context = {
-			code: model.getTextBuffer().getValueInRange(data.range ?? model.getFullModelRange(), EndOfLinePreference.TextDefined),
-			codeBlockIndex: data.codeBlockIndex,
-			element: data.element,
-			languageId: model.getLanguageId()
-		} satisfies ICodeBlockActionContext;
-	}
-}
-
 
 export class ChatCodeBlockContentProvider extends Disposable implements ITextModelContentProvider {
 

--- a/src/vs/workbench/contrib/chat/common/codeBlockModelCollection.ts
+++ b/src/vs/workbench/contrib/chat/common/codeBlockModelCollection.ts
@@ -1,0 +1,53 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Disposable, IReference } from 'vs/base/common/lifecycle';
+import { ResourceMap } from 'vs/base/common/map';
+import { Schemas } from 'vs/base/common/network';
+import { URI } from 'vs/base/common/uri';
+import { IResolvedTextEditorModel, ITextModelService } from 'vs/editor/common/services/resolverService';
+
+
+export class CodeBlockModelCollection extends Disposable {
+
+	private readonly _models = new ResourceMap<Promise<IReference<IResolvedTextEditorModel>>>();
+
+	constructor(
+		@ITextModelService private readonly textModelService: ITextModelService
+	) {
+		super();
+	}
+
+	public override dispose(): void {
+		super.dispose();
+		this.clear();
+	}
+
+	get(responseId: string, codeBlockIndex: number): Promise<IReference<IResolvedTextEditorModel>> | undefined {
+		const uri = this.getUri(responseId, codeBlockIndex);
+		return this._models.get(uri);
+	}
+
+	getOrCreate(responseId: string, codeBlockIndex: number): Promise<IReference<IResolvedTextEditorModel>> {
+		const existing = this.get(responseId, codeBlockIndex);
+		if (existing) {
+			return existing;
+		}
+
+		const uri = this.getUri(responseId, codeBlockIndex);
+		const ref = this.textModelService.createModelReference(uri);
+		this._models.set(uri, ref);
+		return ref;
+	}
+
+	clear(): void {
+		this._models.forEach(async (model) => (await model).dispose());
+		this._models.clear();
+	}
+
+	private getUri(responseId: string, index: number): URI {
+		return URI.from({ scheme: Schemas.vscodeChatCodeBlock, path: `/${responseId}/${index}` });
+	}
+}

--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatWidget.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatWidget.ts
@@ -287,6 +287,7 @@ export class InlineChatWidget {
 
 		this._editorOptions = this._store.add(_instantiationService.createInstance(ChatEditorOptions, undefined, editorForeground, inputBackground, editorBackground));
 
+
 		// --- context keys
 
 		this._ctxMessageCropState = CTX_INLINE_CHAT_MESSAGE_CROP_STATE.bindTo(this._contextKeyService);
@@ -612,7 +613,7 @@ export class InlineChatWidget {
 			const viewModel = this._chatMessageDisposables.add(new ChatResponseViewModel(responseModel, this._logService));
 			const renderOptions: IChatListItemRendererOptions = { renderStyle: 'compact', noHeader: true, noPadding: true };
 			const chatRendererDelegate: IChatRendererDelegate = { getListLength() { return 1; } };
-			const renderer = this._chatMessageDisposables.add(this._instantiationService.createInstance(ChatListItemRenderer, this._editorOptions, renderOptions, chatRendererDelegate, this._codeBlockModelCollection));
+			const renderer = this._chatMessageDisposables.add(this._instantiationService.createInstance(ChatListItemRenderer, this._editorOptions, renderOptions, chatRendererDelegate, this._codeBlockModelCollection, undefined));
 			renderer.layout(this._elements.chatMessageContent.clientWidth - 4); // 2 for the padding used for the tab index border
 			this._chatMessageDisposables.add(this._onDidChangeLayout.event(() => {
 				renderer.layout(this._elements.chatMessageContent.clientWidth - 4);

--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatWidget.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatWidget.ts
@@ -55,7 +55,7 @@ import { AccessibilityVerbositySettingId } from 'vs/workbench/contrib/accessibil
 import { IAccessibleViewService } from 'vs/workbench/contrib/accessibility/browser/accessibleView';
 import { AccessibilityCommandId } from 'vs/workbench/contrib/accessibility/common/accessibilityCommands';
 import { ChatFollowups } from 'vs/workbench/contrib/chat/browser/chatFollowups';
-import { ChatListItemRenderer, IChatListItemRendererOptions, IChatRendererDelegate } from 'vs/workbench/contrib/chat/browser/chatListRenderer';
+import { ChatListItemRenderer, CodeBlockModelCollection, IChatListItemRendererOptions, IChatRendererDelegate } from 'vs/workbench/contrib/chat/browser/chatListRenderer';
 import { ChatEditorOptions } from 'vs/workbench/contrib/chat/browser/chatOptions';
 import { SlashCommandContentWidget } from 'vs/workbench/contrib/chat/browser/chatSlashCommandContentWidget';
 import { IChatAgentService } from 'vs/workbench/contrib/chat/common/chatAgents';
@@ -238,6 +238,7 @@ export class InlineChatWidget {
 	private _slashCommandUsedDisposables = this._store.add(new DisposableStore());
 
 	private _chatMessage: MarkdownString | undefined;
+	private readonly _codeBlockModelCollection: CodeBlockModelCollection;
 
 	constructor(
 		private readonly parentEditor: ICodeEditor,
@@ -284,7 +285,6 @@ export class InlineChatWidget {
 		this._inputEditor.setModel(this._inputModel);
 
 		this._editorOptions = this._store.add(_instantiationService.createInstance(ChatEditorOptions, undefined, editorForeground, inputBackground, editorBackground));
-
 
 		// --- context keys
 
@@ -444,6 +444,9 @@ export class InlineChatWidget {
 				this._elements.followUps.ariaLabel = this._accessibleViewService.getOpenAriaHint(AccessibilityVerbositySettingId.InlineChat);
 			}
 		}));
+
+		// Code block rendering
+		this._codeBlockModelCollection = this._store.add(this._instantiationService.createInstance(CodeBlockModelCollection));
 	}
 
 
@@ -608,7 +611,7 @@ export class InlineChatWidget {
 			const viewModel = this._chatMessageDisposables.add(new ChatResponseViewModel(responseModel, this._logService));
 			const renderOptions: IChatListItemRendererOptions = { renderStyle: 'compact', noHeader: true, noPadding: true };
 			const chatRendererDelegate: IChatRendererDelegate = { getListLength() { return 1; } };
-			const renderer = this._chatMessageDisposables.add(this._instantiationService.createInstance(ChatListItemRenderer, this._editorOptions, renderOptions, chatRendererDelegate, undefined));
+			const renderer = this._chatMessageDisposables.add(this._instantiationService.createInstance(ChatListItemRenderer, this._editorOptions, renderOptions, chatRendererDelegate, this._codeBlockModelCollection));
 			renderer.layout(this._elements.chatMessageContent.clientWidth - 4); // 2 for the padding used for the tab index border
 			this._chatMessageDisposables.add(this._onDidChangeLayout.event(() => {
 				renderer.layout(this._elements.chatMessageContent.clientWidth - 4);

--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatWidget.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatWidget.ts
@@ -55,12 +55,13 @@ import { AccessibilityVerbositySettingId } from 'vs/workbench/contrib/accessibil
 import { IAccessibleViewService } from 'vs/workbench/contrib/accessibility/browser/accessibleView';
 import { AccessibilityCommandId } from 'vs/workbench/contrib/accessibility/common/accessibilityCommands';
 import { ChatFollowups } from 'vs/workbench/contrib/chat/browser/chatFollowups';
-import { ChatListItemRenderer, CodeBlockModelCollection, IChatListItemRendererOptions, IChatRendererDelegate } from 'vs/workbench/contrib/chat/browser/chatListRenderer';
+import { ChatListItemRenderer, IChatListItemRendererOptions, IChatRendererDelegate } from 'vs/workbench/contrib/chat/browser/chatListRenderer';
 import { ChatEditorOptions } from 'vs/workbench/contrib/chat/browser/chatOptions';
 import { SlashCommandContentWidget } from 'vs/workbench/contrib/chat/browser/chatSlashCommandContentWidget';
 import { IChatAgentService } from 'vs/workbench/contrib/chat/common/chatAgents';
 import { ChatModel, ChatResponseModel } from 'vs/workbench/contrib/chat/common/chatModel';
 import { ChatResponseViewModel } from 'vs/workbench/contrib/chat/common/chatViewModel';
+import { CodeBlockModelCollection } from 'vs/workbench/contrib/chat/common/codeBlockModelCollection';
 import { ExpansionState, HunkData, HunkInformation, Session } from 'vs/workbench/contrib/inlineChat/browser/inlineChatSession';
 import { asRange, invertLineRange } from 'vs/workbench/contrib/inlineChat/browser/utils';
 import { ACTION_ACCEPT_CHANGES, ACTION_REGENERATE_RESPONSE, ACTION_VIEW_IN_CHAT, CTX_INLINE_CHAT_EMPTY, CTX_INLINE_CHAT_FOCUSED, CTX_INLINE_CHAT_INNER_CURSOR_END, CTX_INLINE_CHAT_INNER_CURSOR_FIRST, CTX_INLINE_CHAT_INNER_CURSOR_LAST, CTX_INLINE_CHAT_INNER_CURSOR_START, CTX_INLINE_CHAT_MESSAGE_CROP_STATE, CTX_INLINE_CHAT_OUTER_CURSOR_POSITION, CTX_INLINE_CHAT_RESPONSE_FOCUSED, CTX_INLINE_CHAT_VISIBLE, IInlineChatFollowup, IInlineChatSlashCommand, MENU_INLINE_CHAT_INPUT, MENU_INLINE_CHAT_WIDGET, MENU_INLINE_CHAT_WIDGET_FEEDBACK, MENU_INLINE_CHAT_WIDGET_MARKDOWN_MESSAGE, MENU_INLINE_CHAT_WIDGET_STATUS } from 'vs/workbench/contrib/inlineChat/common/inlineChat';


### PR DESCRIPTION
Refactors the chat code block logic to better support cross code blocks IntelliSense. Previously we only created text models for the visible editors in chat. With this new approach, we instead create a unique text model for each code block in the conversation. This allows us our IntelliSense features to work even if a code block is not visible in chat

Also uses this as a change to remove some duplicate I introduced to support local file editors in chat
