### PR TITLE
Updating the field `_maxStickyLines` inside of the constructor of sticky scroll

### DIFF
--- a/src/vs/editor/contrib/stickyScroll/browser/stickyScrollController.ts
+++ b/src/vs/editor/contrib/stickyScroll/browser/stickyScrollController.ts
@@ -85,6 +85,7 @@ export class StickyScrollController extends Disposable implements IEditorContrib
 		this._register(this._stickyLineCandidateProvider);
 
 		this._widgetState = new StickyScrollWidgetState([], [], 0);
+		this._onDidResize();
 		this._readConfiguration();
 		const stickyScrollDomNode = this._stickyScrollWidget.getDomNode();
 		this._register(this._editor.onDidChangeConfiguration(e => {

--- a/src/vs/editor/contrib/stickyScroll/test/browser/stickyScroll.test.ts
+++ b/src/vs/editor/contrib/stickyScroll/test/browser/stickyScroll.test.ts
@@ -137,7 +137,11 @@ suite('Sticky Scroll Tests', () => {
 					enabled: true,
 					maxLineCount: 5,
 					defaultModel: 'outlineModel'
-				}, serviceCollection: serviceCollection
+				},
+				envConfig: {
+					outerHeight: 500
+				},
+				serviceCollection: serviceCollection
 			}, async (editor, _viewModel, instantiationService) => {
 				const languageService = instantiationService.get(ILanguageFeaturesService);
 				const languageConfigurationService = instantiationService.get(ILanguageConfigurationService);
@@ -162,7 +166,11 @@ suite('Sticky Scroll Tests', () => {
 					enabled: true,
 					maxLineCount: 5,
 					defaultModel: 'outlineModel'
-				}, serviceCollection
+				},
+				envConfig: {
+					outerHeight: 500
+				},
+				serviceCollection
 			}, async (editor, _viewModel, instantiationService) => {
 
 				const stickyScrollController: StickyScrollController = editor.registerAndInstantiateContribution(StickyScrollController.ID, StickyScrollController);
@@ -211,7 +219,11 @@ suite('Sticky Scroll Tests', () => {
 					enabled: true,
 					maxLineCount: 5,
 					defaultModel: 'outlineModel'
-				}, serviceCollection
+				},
+				envConfig: {
+					outerHeight: 500
+				},
+				serviceCollection
 			}, async (editor, viewModel, instantiationService) => {
 
 				const stickyScrollController: StickyScrollController = editor.registerAndInstantiateContribution(StickyScrollController.ID, StickyScrollController);
@@ -305,7 +317,11 @@ suite('Sticky Scroll Tests', () => {
 					enabled: true,
 					maxLineCount: 5,
 					defaultModel: 'outlineModel'
-				}, serviceCollection
+				},
+				envConfig: {
+					outerHeight: 500
+				},
+				serviceCollection
 			}, async (editor, _viewModel, instantiationService) => {
 
 				const stickyScrollController: StickyScrollController = editor.registerAndInstantiateContribution(StickyScrollController.ID, StickyScrollController);

--- a/src/vs/editor/test/browser/config/testConfiguration.ts
+++ b/src/vs/editor/test/browser/config/testConfiguration.ts
@@ -4,25 +4,27 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { EditorConfiguration, IEnvConfiguration } from 'vs/editor/browser/config/editorConfiguration';
-import { EditorFontLigatures, EditorFontVariations, IEditorOptions } from 'vs/editor/common/config/editorOptions';
+import { EditorFontLigatures, EditorFontVariations } from 'vs/editor/common/config/editorOptions';
 import { BareFontInfo, FontInfo } from 'vs/editor/common/config/fontInfo';
+import { TestCodeEditorCreationOptions } from 'vs/editor/test/browser/testCodeEditor';
 import { AccessibilitySupport } from 'vs/platform/accessibility/common/accessibility';
 import { TestAccessibilityService } from 'vs/platform/accessibility/test/common/testAccessibilityService';
 
 export class TestConfiguration extends EditorConfiguration {
 
-	constructor(opts: IEditorOptions) {
+	constructor(opts: Readonly<TestCodeEditorCreationOptions>) {
 		super(false, opts, null, new TestAccessibilityService());
 	}
 
 	protected override _readEnvConfiguration(): IEnvConfiguration {
+		const envConfig = (this.getRawOptions() as TestCodeEditorCreationOptions).envConfig;
 		return {
-			extraEditorClassName: '',
-			outerWidth: 100,
-			outerHeight: 100,
-			emptySelectionClipboard: true,
-			pixelRatio: 1,
-			accessibilitySupport: AccessibilitySupport.Unknown
+			extraEditorClassName: envConfig?.extraEditorClassName ?? '',
+			outerWidth: envConfig?.outerWidth ?? 100,
+			outerHeight: envConfig?.outerHeight ?? 100,
+			emptySelectionClipboard: envConfig?.emptySelectionClipboard ?? true,
+			pixelRatio: envConfig?.pixelRatio ?? 1,
+			accessibilitySupport: envConfig?.accessibilitySupport ?? AccessibilitySupport.Unknown
 		};
 	}
 

--- a/src/vs/editor/test/browser/testCodeEditor.ts
+++ b/src/vs/editor/test/browser/testCodeEditor.ts
@@ -5,7 +5,7 @@
 
 import { DisposableStore, IDisposable, toDisposable } from 'vs/base/common/lifecycle';
 import { mock } from 'vs/base/test/common/mock';
-import { EditorConfiguration, IEditorConstructionOptions } from 'vs/editor/browser/config/editorConfiguration';
+import { EditorConfiguration } from 'vs/editor/browser/config/editorConfiguration';
 import { IActiveCodeEditor, ICodeEditor } from 'vs/editor/browser/editorBrowser';
 import { ICodeEditorService } from 'vs/editor/browser/services/codeEditorService';
 import { View } from 'vs/editor/browser/view';
@@ -30,7 +30,7 @@ import { TestLanguageConfigurationService } from 'vs/editor/test/common/modes/te
 import { TestEditorWorkerService } from 'vs/editor/test/common/services/testEditorWorkerService';
 import { TestTextResourcePropertiesService } from 'vs/editor/test/common/services/testTextResourcePropertiesService';
 import { instantiateTextModel } from 'vs/editor/test/common/testTextModel';
-import { IAccessibilityService } from 'vs/platform/accessibility/common/accessibility';
+import { AccessibilitySupport, IAccessibilityService } from 'vs/platform/accessibility/common/accessibility';
 import { TestAccessibilityService } from 'vs/platform/accessibility/test/common/testAccessibilityService';
 import { IClipboardService } from 'vs/platform/clipboard/common/clipboardService';
 import { TestClipboardService } from 'vs/platform/clipboard/test/common/testClipboardService';
@@ -68,7 +68,7 @@ export interface ITestCodeEditor extends IActiveCodeEditor {
 export class TestCodeEditor extends CodeEditorWidget implements ICodeEditor {
 
 	//#region testing overrides
-	protected override _createConfiguration(isSimpleWidget: boolean, options: Readonly<IEditorConstructionOptions>): EditorConfiguration {
+	protected override _createConfiguration(isSimpleWidget: boolean, options: Readonly<TestCodeEditorCreationOptions>): EditorConfiguration {
 		return new TestConfiguration(options);
 	}
 	protected override _createView(viewModel: ViewModel): [View, boolean] {
@@ -116,6 +116,10 @@ export interface TestCodeEditorCreationOptions extends editorOptions.IEditorOpti
 	 * Defaults to true.
 	 */
 	hasTextFocus?: boolean;
+	/**
+	 * Env configuration
+	 */
+	envConfig?: ITestEnvConfiguration;
 }
 
 export interface TestCodeEditorInstantiationOptions extends TestCodeEditorCreationOptions {
@@ -123,6 +127,15 @@ export interface TestCodeEditorInstantiationOptions extends TestCodeEditorCreati
 	 * Services to use.
 	 */
 	serviceCollection?: ServiceCollection;
+}
+
+export interface ITestEnvConfiguration {
+	extraEditorClassName?: string;
+	outerWidth?: number;
+	outerHeight?: number;
+	emptySelectionClipboard?: boolean;
+	pixelRatio?: number;
+	accessibilitySupport?: AccessibilitySupport;
 }
 
 export function withTestCodeEditor(text: ITextModel | string | string[] | ITextBufferFactory, options: TestCodeEditorInstantiationOptions, callback: (editor: ITestCodeEditor, viewModel: ViewModel, instantiationService: TestInstantiationService) => void): void {


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/201450

_note_: unsure about the usage of `getOptions` in the `_readEnvConfiguration` to access the raw options