### PR TITLE
Bumping up version to `1.86.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "code-oss-dev",
-  "version": "1.87.0",
+  "version": "1.88.0",
   "distro": "b314654a31bdba8cd2b0c7548e931916d03416bf",
   "author": {
     "name": "Microsoft Corporation"


### PR DESCRIPTION
Bumping up the version to `1.86.0` after the branching of the release branch from main