### PR TITLE
Register treeview hover delegate

### DIFF
--- a/src/vs/workbench/browser/parts/views/treeView.ts
+++ b/src/vs/workbench/browser/parts/views/treeView.ts
@@ -1106,7 +1106,7 @@ class TreeRenderer extends Disposable implements ITreeRenderer<ITreeItem, FuzzyS
 		@IInstantiationService instantiationService: IInstantiationService,
 	) {
 		super();
-		this._hoverDelegate = instantiationService.createInstance(WorkbenchHoverDelegate, 'mouse', false, { persistence: undefined /* use default persistence behaviour */ });
+		this._hoverDelegate = this._register(instantiationService.createInstance(WorkbenchHoverDelegate, 'mouse', false, { persistence: undefined /* use default persistence behaviour */ }));
 		this._register(this.themeService.onDidFileIconThemeChange(() => this.rerender()));
 		this._register(this.themeService.onDidColorThemeChange(() => this.rerender()));
 		this._register(checkboxStateHandler.onDidChangeCheckboxState(items => {


### PR DESCRIPTION
Previously, the treeview hover delegate was not registered. This PR ensures that the treeview hover delegate is registered.

#206090