### PR TITLE
fix: cwd not escaping when running wt.exe externally

### DIFF
--- a/src/vs/platform/externalTerminal/node/externalTerminalService.ts
+++ b/src/vs/platform/externalTerminal/node/externalTerminalService.ts
@@ -107,7 +107,7 @@ export class WindowsExternalTerminalService extends ExternalTerminalService impl
 				// prefer to use the window terminal to spawn if it's available instead
 				// of start, since that allows ctrl+c handling (#81322)
 				spawnExec = wt;
-				cmdArgs = ['-d', dir || '.', exec, '/c', command]; // default dir fixes #204039
+				cmdArgs = ['-d', '.', exec, '/c', command];
 			} else {
 				spawnExec = WindowsExternalTerminalService.CMD;
 				cmdArgs = ['/c', 'start', title, '/wait', exec, '/c', command];


### PR DESCRIPTION
We actually already set the cwd when spawning wt.exe, so we can use just
`.` to reference it and avoid dealing with escaping entirely.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
