### PR TITLE
Fix accidental dedent for `in` and `when` dedent in Ruby comments

### DIFF
--- a/extensions/ruby/language-configuration.json
+++ b/extensions/ruby/language-configuration.json
@@ -26,6 +26,6 @@
 	],
 	"indentationRules": {
 		"increaseIndentPattern": "^\\s*((begin|class|(private|protected)\\s+def|def|else|elsif|ensure|for|if|module|rescue|unless|until|when|in|while|case)|([^#]*\\sdo\\b)|([^#]*=\\s*(case|if|unless)))\\b([^#\\{;]|(\"|'|\/).*\\4)*(#.*)?$",
-		"decreaseIndentPattern": "^\\s*([}\\]]([,)]?\\s*(#|$)|\\.[a-zA-Z_]\\w*\\b)|(end|rescue|ensure|else|elsif)\\b)|((in|when)\\s)"
+		"decreaseIndentPattern": "^\\s*([}\\]]([,)]?\\s*(#|$)|\\.[a-zA-Z_]\\w*\\b)|(end|rescue|ensure|else|elsif)\\b|(in|when)\\s)"
 	}
 }

--- a/src/vs/editor/contrib/indentation/test/browser/indentation.test.ts
+++ b/src/vs/editor/contrib/indentation/test/browser/indentation.test.ts
@@ -373,16 +373,23 @@ suite('Editor Contrib - Auto Dedent On Type', () => {
 					['(', ')']
 				],
 				indentationRules: {
-					decreaseIndentPattern: /\s*([}\]]([,)]?\s*(#|$)|\.[a-zA-Z_]\w*\b)|(end|rescue|ensure|else|elsif)\b)|((in|when)\s)/,
+					decreaseIndentPattern: /^\s*([}\]]([,)]?\s*(#|$)|\.[a-zA-Z_]\w*\b)|(end|rescue|ensure|else|elsif)\b|(in|when)\s)/,
 					increaseIndentPattern: /^\s*((begin|class|(private|protected)\s+def|def|else|elsif|ensure|for|if|module|rescue|unless|until|when|in|while|case)|([^#]*\sdo\b)|([^#]*=\s*(case|if|unless)))\b([^#\{;]|(\"|'|\/).*\4)*(#.*)?$/,
 				},
 			});
+
 			viewModel.model.setValue("");
 			viewModel.type("def foo\n        i");
 			viewModel.type("n", 'keyboard');
 			assert.strictEqual(model.getValue(), "def foo\n        in");
 			viewModel.type(" ", 'keyboard');
 			assert.strictEqual(model.getValue(), "def foo\nin ");
+
+			viewModel.model.setValue("");
+			viewModel.type("  # in");
+			assert.strictEqual(model.getValue(), "  # in");
+			viewModel.type(" ", 'keyboard');
+			assert.strictEqual(model.getValue(), "  # in ");
 			improvedLanguageModel.dispose();
 		});
 	});


### PR DESCRIPTION
I was testing the changes from https://github.com/microsoft/vscode/pull/205397 in Insiders and I noticed that the code was incorrectly being dedented when typing `in` or `when` in comments.

We got the parenthesis balance incorrect in the regex. The regex has three outer groups for an or condition and we closed the group incorrectly, which made the last part of the regex skip the `\s*` part (which verifies that only blank spaces are in the front of the string).

This PR fixes the bug by properly balancing the parenthesis. The tests was also missing the `^` anchor, which I added to match the language configuration.

cc @rebornix  