### PR TITLE
Fix width overflow in rename suggestions

### DIFF
--- a/src/vs/editor/contrib/rename/browser/renameInputField.ts
+++ b/src/vs/editor/contrib/rename/browser/renameInputField.ts
@@ -515,7 +515,6 @@ class CandidatesView {
 	public layout({ height, width }: { height: number; width: number }): void {
 		this._availableHeight = height;
 		this._minimumWidth = width;
-		this._listContainer.style.width = `${this._minimumWidth}px`;
 	}
 
 	public setCandidates(candidates: NewSymbolName[]): void {


### PR DESCRIPTION
This PR addresses an issue where the width of rename suggestions was overflowing. The fix involves removing the line that sets the width of the list container in the `renameInputField.ts` file. This ensures that the width of the rename suggestions does not exceed the available space.