### PR TITLE
Ignore links with text that equals the empty string

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/links/browser/terminalLinkParsing.ts
+++ b/src/vs/workbench/contrib/terminalContrib/links/browser/terminalLinkParsing.ts
@@ -277,6 +277,11 @@ function detectLinksViaSuffix(line: string): IParsedLink[] {
 				};
 				path = path.substring(prefix.text.length);
 
+				// Don't allow suffix links to be returned when the link itself is the empty string
+				if (path.trim().length === 0) {
+					continue;
+				}
+
 				// If there are multiple characters in the prefix, trim the prefix if the _first_
 				// suffix character is the same as the last prefix character. For example, for the
 				// text `echo "'foo' on line 1"`:

--- a/src/vs/workbench/contrib/terminalContrib/links/test/browser/terminalLinkParsing.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/links/test/browser/terminalLinkParsing.test.ts
@@ -706,5 +706,11 @@ suite('TerminalLinkParsing', () => {
 				});
 			}
 		});
+		suite('should ignore links with suffixes when the path itself is the empty string', () => {
+			deepStrictEqual(
+				detectLinks('""",1', OperatingSystem.Linux),
+				[] as IParsedLink[]
+			);
+		});
 	});
 });


### PR DESCRIPTION
fixes #206258
