### PR TITLE
Render hovers over context views

### DIFF
--- a/src/vs/base/browser/ui/contextview/contextview.ts
+++ b/src/vs/base/browser/ui/contextview/contextview.ts
@@ -60,6 +60,9 @@ export interface IDelegate {
 	canRelayout?: boolean; // default: true
 	onDOMEvent?(e: Event, activeElement: HTMLElement): void;
 	onHide?(data?: unknown): void;
+
+	// context views with higher layers are rendered over contet views with lower layers
+	layer?: number; // Default: 0
 }
 
 export interface IContextViewProvider {
@@ -222,7 +225,7 @@ export class ContextView extends Disposable {
 		this.view.className = 'context-view';
 		this.view.style.top = '0px';
 		this.view.style.left = '0px';
-		this.view.style.zIndex = '2575';
+		this.view.style.zIndex = `${2575 + (delegate.layer ?? 0)}`;
 		this.view.style.position = this.useFixedPosition ? 'fixed' : 'absolute';
 		DOM.show(this.view);
 

--- a/src/vs/editor/browser/services/hoverService/hoverService.ts
+++ b/src/vs/editor/browser/services/hoverService/hoverService.ts
@@ -194,6 +194,9 @@ function getHoverOptionsIdentity(options: IHoverOptions | undefined): IHoverOpti
 
 class HoverContextViewDelegate implements IDelegate {
 
+	// Render over all other context views
+	public readonly layer = 1;
+
 	get anchorPosition() {
 		return this._hover.anchor;
 	}

--- a/src/vs/platform/contextview/browser/contextView.ts
+++ b/src/vs/platform/contextview/browser/contextView.ts
@@ -43,6 +43,9 @@ export interface IContextViewDelegate {
 	focus?(): void;
 	anchorAlignment?: AnchorAlignment;
 	anchorAxisAlignment?: AnchorAxisAlignment;
+
+	// context views with higher layers are rendered over contet views with lower layers
+	layer?: number; // Default: 0
 }
 
 export const IContextMenuService = createDecorator<IContextMenuService>('contextMenuService');


### PR DESCRIPTION
This PR introduces a layering system for context views. Context views with higher layers are now rendered over context views with lower layers. This change primarily affects the rendering of hovers, ensuring they are displayed above all other context views.