### PR TITLE
Python error terminal output ⌘ + Click links erroneously treats filename as if it ends in a single quote ' (fix #206001)

### DIFF
--- a/src/vs/workbench/contrib/output/common/outputLinkComputer.ts
+++ b/src/vs/workbench/contrib/output/common/outputLinkComputer.ts
@@ -88,7 +88,7 @@ export class OutputLinkComputer {
 		}
 
 		for (const workspaceFolderVariant of workspaceFolderVariants) {
-			const validPathCharacterPattern = '[^\\s\\(\\):<>"]';
+			const validPathCharacterPattern = '[^\\s\\(\\):<>\'"]';
 			const validPathCharacterOrSpacePattern = `(?:${validPathCharacterPattern}| ${validPathCharacterPattern})`;
 			const pathPattern = `${validPathCharacterOrSpacePattern}+\\.${validPathCharacterPattern}+`;
 			const strictPathPattern = `${validPathCharacterPattern}+`;

--- a/src/vs/workbench/contrib/output/test/browser/outputLinkProvider.test.ts
+++ b/src/vs/workbench/contrib/output/test/browser/outputLinkProvider.test.ts
@@ -277,9 +277,9 @@ suite('OutputLinkProvider', () => {
 		line = toOSPath(' at \'C:\\Users\\someone\\AppData\\Local\\Temp\\_monacodata_9888\\workspaces\\mankala\\Game.ts\' in');
 		result = OutputLinkComputer.detectLinks(line, 1, patterns, contextService);
 		assert.strictEqual(result.length, 1);
-		assert.strictEqual(result[0].url, contextService.toResource('/Game.ts\'').toString());
+		assert.strictEqual(result[0].url, contextService.toResource('/Game.ts').toString());
 		assert.strictEqual(result[0].range.startColumn, 6);
-		assert.strictEqual(result[0].range.endColumn, 86);
+		assert.strictEqual(result[0].range.endColumn, 85);
 	});
 
 	test('OutputLinkProvider - #106847', function () {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
