### PR TITLE
debug: pass environment via terminal API instead of command

### DIFF
--- a/src/vs/workbench/api/node/extHostDebugService.ts
+++ b/src/vs/workbench/api/node/extHostDebugService.ts
@@ -27,6 +27,7 @@ import { ExtensionDescriptionRegistry } from 'vs/workbench/services/extensions/c
 import type * as vscode from 'vscode';
 import { ExtHostConfigProvider, IExtHostConfiguration } from '../common/extHostConfiguration';
 import { IExtHostCommands } from 'vs/workbench/api/common/extHostCommands';
+import { createHash } from 'crypto';
 
 export class ExtHostDebugService extends ExtHostDebugServiceBase {
 
@@ -89,8 +90,8 @@ export class ExtHostDebugService extends ExtHostDebugServiceBase {
 
 			const terminalName = args.title || nls.localize('debug.terminal.title', "Debug Process");
 
-			const shellConfig = JSON.stringify({ shell, shellArgs });
-			let terminal = await this._integratedTerminalInstances.checkout(shellConfig, terminalName);
+			const termKey = createKeyForShell(shell, shellArgs, args);
+			let terminal = await this._integratedTerminalInstances.checkout(termKey, terminalName);
 
 			let cwdForPrepareCommand: string | undefined;
 			let giveShellTimeToInitialize = false;
@@ -102,6 +103,7 @@ export class ExtHostDebugService extends ExtHostDebugServiceBase {
 					cwd: args.cwd,
 					name: terminalName,
 					iconPath: new ThemeIcon('debug'),
+					env: args.env,
 				};
 				giveShellTimeToInitialize = true;
 				terminal = this._terminalService.createTerminalFromOptions(options, {
@@ -111,7 +113,7 @@ export class ExtHostDebugService extends ExtHostDebugServiceBase {
 					forceShellIntegration: true,
 					useShellEnvironment: true
 				});
-				this._integratedTerminalInstances.insert(terminal, shellConfig);
+				this._integratedTerminalInstances.insert(terminal, termKey);
 
 			} else {
 				cwdForPrepareCommand = args.cwd;
@@ -139,7 +141,7 @@ export class ExtHostDebugService extends ExtHostDebugServiceBase {
 				}
 			}
 
-			const command = prepareCommand(shell, args.args, !!args.argsCanBeInterpretedByShell, cwdForPrepareCommand, args.env);
+			const command = prepareCommand(shell, args.args, !!args.argsCanBeInterpretedByShell, cwdForPrepareCommand);
 			terminal.sendText(command);
 
 			// Mark terminal as unused when its session ends, see #112055
@@ -157,6 +159,14 @@ export class ExtHostDebugService extends ExtHostDebugServiceBase {
 		}
 		return super.$runInTerminal(args, sessionId);
 	}
+}
+
+/** Creates a key that determines how terminals get reused */
+function createKeyForShell(shell: string, shellArgs: string | string[], args: DebugProtocol.RunInTerminalRequestArguments) {
+	const hash = createHash('sha256');
+	hash.update(JSON.stringify({ shell, shellArgs }));
+	hash.update(JSON.stringify(Object.entries(args.env || {}).sort(([k1], [k2]) => k1.localeCompare(k2))));
+	return hash.digest('base64');
 }
 
 let externalTerminalService: IExternalTerminalService | undefined = undefined;

--- a/src/vs/workbench/contrib/debug/node/terminals.ts
+++ b/src/vs/workbench/contrib/debug/node/terminals.ts
@@ -56,7 +56,7 @@ export async function hasChildProcesses(processId: number | undefined): Promise<
 const enum ShellType { cmd, powershell, bash }
 
 
-export function prepareCommand(shell: string, args: string[], argsCanBeInterpretedByShell: boolean, cwd?: string, env?: { [key: string]: string | null }): string {
+export function prepareCommand(shell: string, args: string[], argsCanBeInterpretedByShell: boolean, cwd?: string): string {
 
 	shell = shell.trim().toLowerCase();
 
@@ -97,16 +97,6 @@ export function prepareCommand(shell: string, args: string[], argsCanBeInterpret
 				}
 				command += `cd ${quote(cwd)}; `;
 			}
-			if (env) {
-				for (const key in env) {
-					const value = env[key];
-					if (value === null) {
-						command += `Remove-Item env:${key}; `;
-					} else {
-						command += `\${env:${key}}='${value}'; `;
-					}
-				}
-			}
 			if (args.length > 0) {
 				const arg = args.shift()!;
 				const cmd = argsCanBeInterpretedByShell ? arg : quote(arg);
@@ -137,24 +127,9 @@ export function prepareCommand(shell: string, args: string[], argsCanBeInterpret
 				}
 				command += `cd ${quote(cwd)} && `;
 			}
-			if (env) {
-				command += 'cmd /C "';
-				for (const key in env) {
-					let value = env[key];
-					if (value === null) {
-						command += `set "${key}=" && `;
-					} else {
-						value = value.replace(/[&^|<>]/g, s => `^${s}`);
-						command += `set "${key}=${value}" && `;
-					}
-				}
-			}
 			for (const a of args) {
 				command += (a === '<' || a === '>' || argsCanBeInterpretedByShell) ? a : quote(a);
 				command += ' ';
-			}
-			if (env) {
-				command += '"';
 			}
 			break;
 
@@ -165,24 +140,8 @@ export function prepareCommand(shell: string, args: string[], argsCanBeInterpret
 				return s.length === 0 ? `""` : s;
 			};
 
-			const hardQuote = (s: string) => {
-				return /[^\w@%\/+=,.:^-]/.test(s) ? `'${s.replace(/'/g, '\'\\\'\'')}'` : s;
-			};
-
 			if (cwd) {
 				command += `cd ${quote(cwd)} ; `;
-			}
-			if (env) {
-				command += '/usr/bin/env';
-				for (const key in env) {
-					const value = env[key];
-					if (value === null) {
-						command += ` -u ${hardQuote(key)}`;
-					} else {
-						command += ` ${hardQuote(`${key}=${value}`)}`;
-					}
-				}
-				command += ' ';
 			}
 			for (const a of args) {
 				command += (a === '<' || a === '>' || argsCanBeInterpretedByShell) ? a : quote(a);


### PR DESCRIPTION
Fixes #198550. Don't prepend a big variable string, but pass `env` to the terminal when it's created (and make sure not to reuse terminals with a different env)

@Tyriar @roblourens this seems to work well, including overriding variables normally applied in dotfiles. I think debug's `env` just predates the ability to pass an `env` to the extension host terminal, but interested if you see any issues with this.