### PR TITLE
feature: use type only imports

### DIFF
--- a/src/vs/base/browser/ui/grid/grid.ts
+++ b/src/vs/base/browser/ui/grid/grid.ts
@@ -8,10 +8,9 @@ import { equals, tail2 as tail } from 'vs/base/common/arrays';
 import { Event } from 'vs/base/common/event';
 import { Disposable } from 'vs/base/common/lifecycle';
 import 'vs/css!./gridview';
-import { Box, GridView, IGridViewOptions, IGridViewStyles, IView as IGridViewView, IViewSize, orthogonal, Sizing as GridViewSizing, GridLocation } from './gridview';
+import { Box, GridView, type IGridViewOptions, type IGridViewStyles, type IView as IGridViewView, type IViewSize, orthogonal, Sizing as GridViewSizing, GridLocation } from './gridview';
 import type { SplitView, AutoSizing as SplitViewAutoSizing } from 'vs/base/browser/ui/splitview/splitview';
-
-export { IViewSize, LayoutPriority, Orientation, orthogonal } from './gridview';
+export { type IViewSize, LayoutPriority, Orientation, orthogonal } from './gridview';
 
 export const enum Direction {
 	Up,

--- a/src/vs/base/common/observable.ts
+++ b/src/vs/base/common/observable.ts
@@ -6,14 +6,14 @@
 // This is a facade for the observable implementation. Only import from here!
 
 export {
-	IObservable,
-	IObserver,
-	IReader,
-	ISettable,
-	ISettableObservable,
-	ITransaction,
-	IChangeContext,
-	IChangeTracker,
+	type IObservable,
+	type IObserver,
+	type IReader,
+	type ISettable,
+	type ISettableObservable,
+	type ITransaction,
+	type IChangeContext,
+	type IChangeTracker,
 	observableValue,
 	disposableObservableValue,
 	transaction,
@@ -34,7 +34,7 @@ export {
 	autorunWithStoreHandleChanges,
 } from 'vs/base/common/observableInternal/autorun';
 export {
-	IObservableSignal,
+	type IObservableSignal,
 	constObservable,
 	debouncedObservable,
 	derivedObservableWithCache,

--- a/src/vs/base/node/processes.ts
+++ b/src/vs/base/node/processes.ts
@@ -8,7 +8,7 @@ import { Stats } from 'fs';
 import * as path from 'vs/base/common/path';
 import * as Platform from 'vs/base/common/platform';
 import * as process from 'vs/base/common/process';
-import { CommandOptions, ForkOptions, Source, SuccessData, TerminateResponse, TerminateResponseCode } from 'vs/base/common/processes';
+import type { CommandOptions, ForkOptions, Source, SuccessData, TerminateResponse, TerminateResponseCode } from 'vs/base/common/processes';
 import * as Types from 'vs/base/common/types';
 import * as pfs from 'vs/base/node/pfs';
 export { CommandOptions, ForkOptions, SuccessData, Source, TerminateResponse, TerminateResponseCode };

--- a/src/vs/workbench/contrib/tasks/common/taskService.ts
+++ b/src/vs/workbench/contrib/tasks/common/taskService.ts
@@ -7,15 +7,15 @@ import * as nls from 'vs/nls';
 import { Action } from 'vs/base/common/actions';
 import { Event } from 'vs/base/common/event';
 import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
-import { IDisposable } from 'vs/base/common/lifecycle';
+import type { IDisposable } from 'vs/base/common/lifecycle';
 
 import { IWorkspaceFolder, IWorkspace } from 'vs/platform/workspace/common/workspace';
-import { Task, ContributedTask, CustomTask, ITaskSet, TaskSorter, ITaskEvent, ITaskIdentifier, ConfiguringTask, TaskRunSource } from 'vs/workbench/contrib/tasks/common/tasks';
-import { ITaskSummary, ITaskTerminateResponse, ITaskSystemInfo } from 'vs/workbench/contrib/tasks/common/taskSystem';
-import { IStringDictionary } from 'vs/base/common/collections';
+import type { Task, ContributedTask, CustomTask, ITaskSet, TaskSorter, ITaskEvent, ITaskIdentifier, ConfiguringTask, TaskRunSource } from 'vs/workbench/contrib/tasks/common/tasks';
+import type { ITaskSummary, ITaskTerminateResponse, ITaskSystemInfo } from 'vs/workbench/contrib/tasks/common/taskSystem';
+import type { IStringDictionary } from 'vs/base/common/collections';
 import { RawContextKey, ContextKeyExpr } from 'vs/platform/contextkey/common/contextkey';
 
-export { ITaskSummary, Task, ITaskTerminateResponse as TaskTerminateResponse };
+export type { ITaskSummary, Task, ITaskTerminateResponse as TaskTerminateResponse };
 
 export const CustomExecutionSupportedContext = new RawContextKey<boolean>('customExecutionSupported', false, nls.localize('tasks.customExecutionSupported', "Whether CustomExecution tasks are supported. Consider using in the when clause of a \'taskDefinition\' contribution."));
 export const ShellExecutionSupportedContext = new RawContextKey<boolean>('shellExecutionSupported', false, nls.localize('tasks.shellExecutionSupported', "Whether ShellExecution tasks are supported. Consider using in the when clause of a \'taskDefinition\' contribution."));


### PR DESCRIPTION
Helps a tiny bit with #160416. 

The type only imports are required for esm (similar to #186970). It seems these changes would be beneficial, keeping diff for the esm branch(es) smaller and should be relatively harmless.

I created an esm branch here https://github.com/SimonSiefke/vscode/pull/2. It's similar to https://github.com/microsoft/vscode/pull/166033 with some parts working but also many things not yet working. I'm thinking, perhaps some parts from my branch could be useful eventually, together with #166033. 

It seems it will take some more time, but I'd be happy to answer any questions! Thanks! :)
