### PR TITLE
Export ILocalizedString in nls.mock.ts

### DIFF
--- a/src/vs/nls.mock.ts
+++ b/src/vs/nls.mock.ts
@@ -8,7 +8,7 @@ export interface ILocalizeInfo {
 	comment: string[];
 }
 
-interface ILocalizedString {
+export interface ILocalizedString {
 	original: string;
 	value: string;
 }


### PR DESCRIPTION
`ILocalizedString` was exported in https://github.com/microsoft/vscode/commit/90f37e5ee25a2d16cad446b38766609aa74b244f#diff-ffc5ec6b53c5b0571dc77297b4aa72ebbba65eb8c8992f42f0c32905fa3eff1d

In order to be able to stub in the mock, we should export it in nls.mock.ts too.