### PR TITLE
fix: relayout editor when tab height change

### DIFF
--- a/src/vs/workbench/browser/parts/editor/multiEditorTabsControl.ts
+++ b/src/vs/workbench/browser/parts/editor/multiEditorTabsControl.ts
@@ -2011,6 +2011,7 @@ export class MultiEditorTabsControl extends EditorTabsControl {
 
 		// Reset dimensions if hidden
 		if (!this.visible && this.dimensions) {
+			this.groupView.relayout();
 			this.dimensions.used = undefined;
 		}
 	}


### PR DESCRIPTION
When i close last tab in the second row, the editor height is not recalculate.

https://github.com/microsoft/vscode/assets/50652358/59a7d3c7-2f76-4d73-8482-dbf9c6323a61

