### PR TITLE
cli: fix port forward responses getting truncated

### DIFF
--- a/cli/src/tunnels/socket_signal.rs
+++ b/cli/src/tunnels/socket_signal.rs
@@ -255,7 +255,7 @@ where
 				Ok(flate2::Status::Ok | flate2::Status::BufError) => {
 					let processed_len = in_offset + (self.flate.total_in() - in_before) as usize;
 					let output_len = out_offset + (self.flate.total_out() - out_before) as usize;
-					if processed_len < contents.len() {
+					if processed_len < contents.len() || output_len == self.output.len() {
 						// If we filled the output buffer but there's more data to compress,
 						// extend the output buffer and keep compressing.
 						out_offset = output_len;


### PR DESCRIPTION
There was a bug in the compression loop where the compressor could
indicate that it processed all input, but was waiting for space in the
output buffer in order to send the data. We didn't handle this case so
data would just get stuck in the compressor and dropped when the 
connection closed.

A fix with more tweaks is found in #206464, but this change is
sufficient to resolve the issue for me.

Closes https://github.com/microsoft/vscode-remote-release/issues/9594

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
