### PR TITLE
Candidate: Fix stuck highlighting when `"editor.occurrencesHighlight": "off"`

### DIFF
--- a/src/vs/editor/contrib/wordHighlighter/browser/wordHighlighter.ts
+++ b/src/vs/editor/contrib/wordHighlighter/browser/wordHighlighter.ts
@@ -310,6 +310,11 @@ class WordHighlighter {
 			this._onPositionChanged(e);
 		}));
 		this.toUnhook.add(editor.onDidFocusEditorText((e) => {
+			if (this.occurrencesHighlight === 'off') {
+				// Early exit if nothing needs to be done
+				return;
+			}
+
 			if (!this.workerRequest) {
 				this._run();
 			}


### PR DESCRIPTION
Re: #206486

During debt, stuck highlighting was fixed by altering the lifecycle of the workerRequest that tracked occurrence highlights. 

Part of this fix included listening to `editor.onDidFocusEditorText`, and running a highlight request if there was no workerRequest already. This bypassed the check for `if (this.occurrencesHighlight === 'off')` and therefore would trigger highlights when the setting was disabled. 

Moving your cursor around would not fix the problem as those would trigger `editor.onDidChangeCursorPosition` and that flow correctly had the early exit if the setting was disabled. 

PR to main (#206557) has been merged. 