### PR TITLE
feat(web/lifecycleService): correct startupKind

### DIFF
--- a/src/vs/workbench/browser/layout.ts
+++ b/src/vs/workbench/browser/layout.ts
@@ -2611,7 +2611,7 @@ class LayoutStateModel extends Disposable {
 		LayoutStateKeys.GRID_SIZE.defaultValue = { height: workbenchDimensions.height, width: workbenchDimensions.width };
 		LayoutStateKeys.SIDEBAR_SIZE.defaultValue = Math.min(300, workbenchDimensions.width / 4);
 		LayoutStateKeys.AUXILIARYBAR_SIZE.defaultValue = Math.min(300, workbenchDimensions.width / 4);
-		LayoutStateKeys.PANEL_SIZE.defaultValue = (this.stateCache.get(LayoutStateKeys.PANEL_POSITION.name) ?? LayoutStateKeys.PANEL_POSITION.defaultValue) === 'bottom' ? workbenchDimensions.height / 3 : workbenchDimensions.width / 4;
+		LayoutStateKeys.PANEL_SIZE.defaultValue = (this.stateCache.get(LayoutStateKeys.PANEL_POSITION.name) ?? LayoutStateKeys.PANEL_POSITION.defaultValue) === Position.BOTTOM ? workbenchDimensions.height / 3 : workbenchDimensions.width / 4;
 		LayoutStateKeys.SIDEBAR_HIDDEN.defaultValue = this.contextService.getWorkbenchState() === WorkbenchState.EMPTY;
 
 		// Apply all defaults

--- a/src/vs/workbench/browser/layout.ts
+++ b/src/vs/workbench/browser/layout.ts
@@ -671,7 +671,7 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 
 			// Only restore last viewlet if window was reloaded or we are in development mode
 			let viewContainerToRestore: string | undefined;
-			if (!this.environmentService.isBuilt || lifecycleService.startupKind === StartupKind.ReloadedWindow || isWeb) {
+			if (!this.environmentService.isBuilt || lifecycleService.startupKind === StartupKind.ReloadedWindow) {
 				viewContainerToRestore = this.storageService.get(SidebarPart.activeViewletSettingsKey, StorageScope.WORKSPACE, this.viewDescriptorService.getDefaultViewContainer(ViewContainerLocation.Sidebar)?.id);
 			} else {
 				viewContainerToRestore = this.viewDescriptorService.getDefaultViewContainer(ViewContainerLocation.Sidebar)?.id;

--- a/src/vs/workbench/services/lifecycle/browser/lifecycleService.ts
+++ b/src/vs/workbench/services/lifecycle/browser/lifecycleService.ts
@@ -13,6 +13,7 @@ import { addDisposableListener, EventType } from 'vs/base/browser/dom';
 import { IStorageService, WillSaveStateReason } from 'vs/platform/storage/common/storage';
 import { CancellationToken } from 'vs/base/common/cancellation';
 import { mainWindow } from 'vs/base/browser/window';
+import { firstOrDefault } from 'vs/base/common/arrays';
 
 export class BrowserLifecycleService extends AbstractLifecycleService {
 
@@ -201,12 +202,13 @@ export class BrowserLifecycleService extends AbstractLifecycleService {
 		this.withExpectedShutdown({ disableShutdownHandling: true }, () => mainWindow.location.reload());
 	}
 
-	protected override resolveStartupKind(): StartupKind {
-		const timing = performance.getEntriesByType('navigation')[0] as PerformanceNavigationTiming | null;
-		let startupKind = super.resolveStartupKind();
-
-		if (timing?.type === 'reload' && startupKind === StartupKind.NewWindow) {
-			startupKind = StartupKind.ReloadedWindow;
+	protected override doResolveStartupKind(): StartupKind | undefined {
+		let startupKind = super.doResolveStartupKind();
+		if (typeof startupKind !== 'number') {
+			const timing = firstOrDefault(performance.getEntriesByType('navigation')) as PerformanceNavigationTiming | undefined;
+			if (timing?.type === 'reload') {
+				startupKind = StartupKind.ReloadedWindow;
+			}
 		}
 
 		return startupKind;

--- a/src/vs/workbench/services/lifecycle/browser/lifecycleService.ts
+++ b/src/vs/workbench/services/lifecycle/browser/lifecycleService.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ShutdownReason, ILifecycleService } from 'vs/workbench/services/lifecycle/common/lifecycle';
+import { ShutdownReason, ILifecycleService, StartupKind } from 'vs/workbench/services/lifecycle/common/lifecycle';
 import { ILogService } from 'vs/platform/log/common/log';
 import { AbstractLifecycleService } from 'vs/workbench/services/lifecycle/common/lifecycleService';
 import { localize } from 'vs/nls';
@@ -199,6 +199,17 @@ export class BrowserLifecycleService extends AbstractLifecycleService {
 		// Docs: https://web.dev/bfcache/#optimize-your-pages-for-bfcache
 		// Refs: https://github.com/microsoft/vscode/issues/136035
 		this.withExpectedShutdown({ disableShutdownHandling: true }, () => mainWindow.location.reload());
+	}
+
+	protected override resolveStartupKind(): StartupKind {
+		const timing = performance.getEntriesByType('navigation')[0] as PerformanceNavigationTiming | null;
+		let startupKind = super.resolveStartupKind();
+
+		if (timing?.type === 'reload' && startupKind === StartupKind.NewWindow) {
+			startupKind = StartupKind.ReloadedWindow;
+		}
+
+		return startupKind;
 	}
 }
 

--- a/src/vs/workbench/services/lifecycle/browser/lifecycleService.ts
+++ b/src/vs/workbench/services/lifecycle/browser/lifecycleService.ts
@@ -207,6 +207,7 @@ export class BrowserLifecycleService extends AbstractLifecycleService {
 		if (typeof startupKind !== 'number') {
 			const timing = firstOrDefault(performance.getEntriesByType('navigation')) as PerformanceNavigationTiming | undefined;
 			if (timing?.type === 'reload') {
+				// MDN: https://developer.mozilla.org/en-US/docs/Web/API/PerformanceNavigationTiming/type#value
 				startupKind = StartupKind.ReloadedWindow;
 			}
 		}

--- a/src/vs/workbench/services/lifecycle/common/lifecycleService.ts
+++ b/src/vs/workbench/services/lifecycle/common/lifecycleService.ts
@@ -51,6 +51,8 @@ export abstract class AbstractLifecycleService extends Disposable implements ILi
 		// Resolve startup kind
 		this._startupKind = this.resolveStartupKind();
 
+		this.logService.trace(`[lifecycle] starting up (startup kind: ${this._startupKind})`);
+
 		// Save shutdown reason to retrieve on next startup
 		this.storageService.onWillSaveState(e => {
 			if (e.reason === WillSaveStateReason.SHUTDOWN) {
@@ -59,7 +61,7 @@ export abstract class AbstractLifecycleService extends Disposable implements ILi
 		});
 	}
 
-	private resolveStartupKind(): StartupKind {
+	protected resolveStartupKind(): StartupKind {
 
 		// Retrieve and reset last shutdown reason
 		const lastShutdownReason = this.storageService.getNumber(AbstractLifecycleService.LAST_SHUTDOWN_REASON_KEY, StorageScope.WORKSPACE);
@@ -77,14 +79,6 @@ export abstract class AbstractLifecycleService extends Disposable implements ILi
 			default:
 				startupKind = StartupKind.NewWindow;
 		}
-
-		const timing = performance.getEntriesByType('navigation')[0] as PerformanceNavigationTiming;
-
-		if (timing.type === 'reload') {
-			startupKind = StartupKind.ReloadedWindow;
-		}
-
-		this.logService.trace(`[lifecycle] starting up (startup kind: ${startupKind})`);
 
 		return startupKind;
 	}

--- a/src/vs/workbench/services/lifecycle/common/lifecycleService.ts
+++ b/src/vs/workbench/services/lifecycle/common/lifecycleService.ts
@@ -60,10 +60,10 @@ export abstract class AbstractLifecycleService extends Disposable implements ILi
 	}
 
 	private resolveStartupKind(): StartupKind {
-		const startupKind = this.doResolveStartupKind();
+		const startupKind = this.doResolveStartupKind() ?? StartupKind.NewWindow;
 		this.logService.trace(`[lifecycle] starting up (startup kind: ${startupKind})`);
 
-		return startupKind ?? StartupKind.NewWindow;
+		return startupKind;
 	}
 
 	protected doResolveStartupKind(): StartupKind | undefined {

--- a/src/vs/workbench/services/lifecycle/common/lifecycleService.ts
+++ b/src/vs/workbench/services/lifecycle/common/lifecycleService.ts
@@ -78,6 +78,12 @@ export abstract class AbstractLifecycleService extends Disposable implements ILi
 				startupKind = StartupKind.NewWindow;
 		}
 
+		const timing = performance.getEntriesByType('navigation')[0] as PerformanceNavigationTiming;
+
+		if (timing.type === 'reload') {
+			startupKind = StartupKind.ReloadedWindow;
+		}
+
 		this.logService.trace(`[lifecycle] starting up (startup kind: ${startupKind})`);
 
 		return startupKind;


### PR DESCRIPTION
This PR fixes #206345 & #206296. 

Before the `startupKind` was only implemented for electron, but we can also do it on web (only found out cause chatgpt suggested). This makes the editor restoration logic better (and i'm sure other parts that use startupKind too)

-----
<a href="https://stackblitz.com/~/github.com/samdenty/vscode/tree/unexpected-mouse"><img src="https://developer.stackblitz.com/img/review_pr_small.svg" alt="Review PR in StackBlitz" align="left" width="103" height="20"></a> _Submitted with [StackBlitz](https://stackblitz.com/~/github.com/samdenty/vscode/tree/unexpected-mouse)._