### PR TITLE
Check detected link suffix when opening search links

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/links/browser/links.ts
+++ b/src/vs/workbench/contrib/terminalContrib/links/browser/links.ts
@@ -84,6 +84,11 @@ export interface ITerminalSimpleLink {
 	uri?: URI;
 
 	/**
+	 * An optional full line to be used for context when resolving.
+	 */
+	contextLine?: string;
+
+	/**
 	 * The location or selection range of the link.
 	 */
 	selection?: ITextEditorSelection;

--- a/src/vs/workbench/contrib/terminalContrib/links/browser/terminalWordLinkDetector.ts
+++ b/src/vs/workbench/contrib/terminalContrib/links/browser/terminalWordLinkDetector.ts
@@ -103,7 +103,8 @@ export class TerminalWordLinkDetector extends Disposable implements ITerminalLin
 			links.push({
 				text: word.text,
 				bufferRange,
-				type: TerminalBuiltinLinkType.Search
+				type: TerminalBuiltinLinkType.Search,
+				contextLine: text
 			});
 		}
 


### PR DESCRIPTION
This pulls in some of the smarts from verified links into search links by detecting links with suffixes, seeing if it matches and then using the suffix when opening the quick pick. This allows opening the link `foo` on the line `'foo', line 10` and it will open a search for `foo:10`.

Fixes #190847
Fixes #201632

![image](https://github.com/microsoft/vscode/assets/2193314/da15acd1-c575-4039-a61d-d974cb8926dc)
