### PR TITLE
Fixed to show files in deepest directory in search results

### DIFF
--- a/src/vs/workbench/contrib/search/browser/searchModel.ts
+++ b/src/vs/workbench/contrib/search/browser/searchModel.ts
@@ -1026,6 +1026,15 @@ export class FolderMatch extends Disposable {
 			}
 		}
 
+		// FolderMatch on a leaf node does not always run the for-loop of folderMatch because it does not have a FolderMatch as a child.
+		// Therefore, FileMatch is also searched to check for the existence of AIResults
+		const fileIterator = this.fileMatchesIterator();
+		for (const elem of fileIterator) {
+			if (elem.hasDownstreamNonAIResults()) {
+				return true;
+			}
+		}
+
 		return false;
 	}
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fix: https://github.com/microsoft/vscode/issues/206595

I have confirmed that it appears in the following way.

1. execute the following command in an empty directory
2. search for searchbox in Hello

```sh
 mkdir -p Foo/Bar
 echo Hello > Foo/foo
 echo Hello > Foo/hoge
 echo Hello > Foo/Bar/buz
```
