### PR TITLE
Add support for `no_proxy` in RequestService

### DIFF
--- a/src/vs/platform/request/common/request.ts
+++ b/src/vs/platform/request/common/request.ts
@@ -150,6 +150,12 @@ function registerProxyConfigurations(scope: ConfigurationScope): void {
 				description: localize('strictSSL', "Controls whether the proxy server certificate should be verified against the list of supplied CAs."),
 				restricted: true
 			},
+			'http.noProxy': {
+				type: 'array',
+				default: [],
+				description: localize('noProxy', "List of hosts which should not use a proxy and are queried directly."),
+				restricted: true
+			},
 			'http.proxyKerberosServicePrincipal': {
 				type: 'string',
 				markdownDescription: localize('proxyKerberosServicePrincipal', "Overrides the principal service name for Kerberos authentication with the HTTP proxy. A default based on the proxy hostname is used when this is not set."),

--- a/src/vs/platform/request/node/requestService.ts
+++ b/src/vs/platform/request/node/requestService.ts
@@ -25,6 +25,7 @@ interface IHTTPConfiguration {
 	proxy?: string;
 	proxyStrictSSL?: boolean;
 	proxyAuthorization?: string;
+	noProxy?: string[];
 }
 
 export interface IRawRequestFunction {
@@ -48,6 +49,7 @@ export class RequestService extends AbstractRequestService implements IRequestSe
 
 	private proxyUrl?: string;
 	private strictSSL: boolean | undefined;
+	private noProxy: string[] = [];
 	private authorization?: string;
 	private shellEnvErrorLogged?: boolean;
 
@@ -72,10 +74,11 @@ export class RequestService extends AbstractRequestService implements IRequestSe
 		this.proxyUrl = config?.proxy;
 		this.strictSSL = !!config?.proxyStrictSSL;
 		this.authorization = config?.proxyAuthorization;
+		this.noProxy = config?.noProxy || [];
 	}
 
 	async request(options: NodeRequestOptions, token: CancellationToken): Promise<IRequestContext> {
-		const { proxyUrl, strictSSL } = this;
+		const { proxyUrl, strictSSL, noProxy } = this;
 
 		let shellEnv: typeof process.env | undefined = undefined;
 		try {
@@ -91,7 +94,7 @@ export class RequestService extends AbstractRequestService implements IRequestSe
 			...process.env,
 			...shellEnv
 		};
-		const agent = options.agent ? options.agent : await getProxyAgent(options.url || '', env, { proxyUrl, strictSSL });
+		const agent = options.agent ? options.agent : await getProxyAgent(options.url || '', env, { proxyUrl, strictSSL, noProxy });
 
 		options.agent = agent;
 		options.strictSSL = strictSSL;

--- a/src/vs/platform/request/test/node/proxy.test.ts
+++ b/src/vs/platform/request/test/node/proxy.test.ts
@@ -11,8 +11,10 @@ import { ensureNoDisposablesAreLeakedInTestSuite } from 'vs/base/test/common/uti
 
 suite("proxy support", () => {
 	const urlWithDomain = parseUrl("https://example.com/some/path");
+	const urlWithDomainAndPort = parseUrl("https://example.com:80/some/path");
 	const urlWithSubdomain = parseUrl("https://internal.example.com/some/path");
 	const urlWithIPv4 = parseUrl("https://127.0.0.1/some/path");
+	const urlWithIPv4AndPort = parseUrl("https://127.0.0.1:80/some/path");
 	const urlWithIPv6 = parseUrl("https://[::1]/some/path");
 
 	test("returns true if no denylists are provided", () => {
@@ -46,11 +48,22 @@ suite("proxy support", () => {
 		assert.strictEqual(urlMatchDenyList(urlWithSubdomain, ['.otherexample.com']), false);
 	});
 
+	test("match hostname with ports", () => {
+		assert.strictEqual(urlMatchDenyList(urlWithDomainAndPort, ['example.com:80']), true);
+		assert.strictEqual(urlMatchDenyList(urlWithDomainAndPort, ['otherexample.com:80']), false);
+		assert.strictEqual(urlMatchDenyList(urlWithDomainAndPort, ['example.com:70']), false);
+	});
+
 	test("match IP addresses", () => {
 		assert.strictEqual(urlMatchDenyList(urlWithIPv4, ['example.com']), false);
 		assert.strictEqual(urlMatchDenyList(urlWithIPv6, ['example.com']), false);
 		assert.strictEqual(urlMatchDenyList(urlWithIPv4, ['127.0.0.1']), true);
 		assert.strictEqual(urlMatchDenyList(urlWithIPv6, ['::1']), true);
+	});
+
+	test("match IP addresses with port", () => {
+		assert.strictEqual(urlMatchDenyList(urlWithIPv4AndPort, ['127.0.0.1:80']), true);
+		assert.strictEqual(urlMatchDenyList(urlWithIPv4AndPort, ['127.0.0.1:70']), false);
 	});
 
 	test("match IP addresses with range deny list", () => {

--- a/src/vs/platform/request/test/node/proxy.test.ts
+++ b/src/vs/platform/request/test/node/proxy.test.ts
@@ -1,0 +1,64 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { parse as parseUrl } from 'url';
+import { shouldProxyUrl, urlMatchDenyList } from 'vs/platform/request/node/proxy';
+import { ensureNoDisposablesAreLeakedInTestSuite } from 'vs/base/test/common/utils';
+
+
+suite("proxy support", () => {
+	const urlWithDomain = parseUrl("https://example.com/some/path");
+	const urlWithSubdomain = parseUrl("https://internal.example.com/some/path");
+	const urlWithIPv4 = parseUrl("https://127.0.0.1/some/path");
+	const urlWithIPv6 = parseUrl("https://[::1]/some/path");
+
+	test("returns true if no denylists are provided", () => {
+		assert.strictEqual(shouldProxyUrl(urlWithDomain, [], {}), true);
+	});
+
+	test("gives precedence to direct config value rather than environment", () => {
+		assert.strictEqual(shouldProxyUrl(urlWithDomain, ["otherexample.com"], { no_proxy: "example.com" }), true);
+		assert.strictEqual(shouldProxyUrl(urlWithDomain, ["example.com"], { no_proxy: "otherexample.com" }), false);
+	});
+
+	test("match wildcard", () => {
+		assert.strictEqual(urlMatchDenyList(urlWithDomain, ['*']), true);
+		assert.strictEqual(urlMatchDenyList(urlWithSubdomain, ['*']), true);
+		assert.strictEqual(urlMatchDenyList(urlWithIPv4, ['*']), true);
+		assert.strictEqual(urlMatchDenyList(urlWithIPv6, ['*']), true);
+	});
+
+	test("match direct hostname", () => {
+		assert.strictEqual(urlMatchDenyList(urlWithDomain, ['example.com']), true);
+		assert.strictEqual(urlMatchDenyList(urlWithDomain, ['otherexample.com']), false);
+		// Technically the following are a suffix match but it's a known behavior in the ecosystem
+		assert.strictEqual(urlMatchDenyList(urlWithDomain, ['.example.com']), true);
+		assert.strictEqual(urlMatchDenyList(urlWithDomain, ['.otherexample.com']), false);
+	});
+
+	test("match hostname suffixes", () => {
+		assert.strictEqual(urlMatchDenyList(urlWithSubdomain, ['example.com']), true);
+		assert.strictEqual(urlMatchDenyList(urlWithSubdomain, ['.example.com']), true);
+		assert.strictEqual(urlMatchDenyList(urlWithSubdomain, ['otherexample.com']), false);
+		assert.strictEqual(urlMatchDenyList(urlWithSubdomain, ['.otherexample.com']), false);
+	});
+
+	test("match IP addresses", () => {
+		assert.strictEqual(urlMatchDenyList(urlWithIPv4, ['example.com']), false);
+		assert.strictEqual(urlMatchDenyList(urlWithIPv6, ['example.com']), false);
+		assert.strictEqual(urlMatchDenyList(urlWithIPv4, ['127.0.0.1']), true);
+		assert.strictEqual(urlMatchDenyList(urlWithIPv6, ['::1']), true);
+	});
+
+	test("match IP addresses with range deny list", () => {
+		assert.strictEqual(urlMatchDenyList(urlWithIPv4, ['127.0.0.0/8']), true);
+		assert.strictEqual(urlMatchDenyList(urlWithIPv4, ['10.0.0.0/8']), false);
+		assert.strictEqual(urlMatchDenyList(urlWithIPv6, ['::0/64']), true);
+		assert.strictEqual(urlMatchDenyList(urlWithIPv6, ['100::0/64']), false);
+	});
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+});


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
In the same way that the environment variable `http_proxy` and `https_proxy` are supported, also add support for the final piece of the puzzle which is `no_proxy` (with the same approach of allowing both a configuration option and the environment to be read).

Since there is no one true way to process the content of the `no_proxy` value, I tried to follow the most compatible approach as outlined in https://about.gitlab.com/blog/2021/01/27/we-need-to-talk-no-proxy/. See also the man pages of tools like [`curl`](https://linux.die.net/man/1/curl#:~:text=%2D%2Dnoproxy%20%3Cno%2Dproxy%2Dlist%3E) or [`wget`](https://www.gnu.org/software/wget/manual/html_node/Proxies.html#:~:text=same%20URL.-,no_proxy,-This%20variable%20should) for examples.

The PR supports the following options:
- simple wildcard allow with `*`
- equality matching of both hostnames and IP addresses (v4 + v6)
- suffix matching for hostnames
- IP (v4 & v6) range matching (using node's builtin [BlockList](https://nodejs.org/api/net.html#class-netblocklist) class)

Tests were added.