### PR TITLE
Support buttons in separators in Quick Access

### DIFF
--- a/src/vs/platform/quickinput/browser/pickerQuickAccess.ts
+++ b/src/vs/platform/quickinput/browser/pickerQuickAccess.ts
@@ -6,7 +6,7 @@
 import { timeout } from 'vs/base/common/async';
 import { CancellationToken, CancellationTokenSource } from 'vs/base/common/cancellation';
 import { Disposable, DisposableStore, IDisposable, MutableDisposable } from 'vs/base/common/lifecycle';
-import { IKeyMods, IQuickPickDidAcceptEvent, IQuickPickSeparator, IQuickPick, IQuickPickItem } from 'vs/platform/quickinput/common/quickInput';
+import { IKeyMods, IQuickPickDidAcceptEvent, IQuickPickSeparator, IQuickPick, IQuickPickItem, IQuickInputButton } from 'vs/platform/quickinput/common/quickInput';
 import { IQuickAccessProvider, IQuickAccessProviderRunOptions } from 'vs/platform/quickinput/common/quickAccess';
 import { isFunction } from 'vs/base/common/types';
 
@@ -44,6 +44,22 @@ export interface IPickerQuickAccessItem extends IQuickPickItem {
 	*/
 	accept?(keyMods: IKeyMods, event: IQuickPickDidAcceptEvent): void;
 
+	/**
+	 * A method that will be executed when a button of the pick item was
+	 * clicked on.
+	 *
+	 * @param buttonIndex index of the button of the item that
+	 * was clicked.
+	 *
+	 * @param the state of modifier keys when the button was triggered.
+	 *
+	 * @returns a value that indicates what should happen after the trigger
+	 * which can be a `Promise` for long running operations.
+	 */
+	trigger?(buttonIndex: number, keyMods: IKeyMods): TriggerAction | Promise<TriggerAction>;
+}
+
+export interface IPickerQuickAccessSeparator extends IQuickPickSeparator {
 	/**
 	 * A method that will be executed when a button of the pick item was
 	 * clicked on.
@@ -320,47 +336,52 @@ export abstract class PickerQuickAccessProvider<T extends IPickerQuickAccessItem
 			}
 		}));
 
-		// Trigger the pick with button index if button triggered
-		disposables.add(picker.onDidTriggerItemButton(async ({ button, item }) => {
-			if (typeof item.trigger === 'function') {
-				const buttonIndex = item.buttons?.indexOf(button) ?? -1;
-				if (buttonIndex >= 0) {
-					const result = item.trigger(buttonIndex, picker.keyMods);
-					const action = (typeof result === 'number') ? result : await result;
+		const buttonTrigger = async (button: IQuickInputButton, item: T | IPickerQuickAccessSeparator) => {
+			if (!item.trigger) {
+				return;
+			}
 
-					if (token.isCancellationRequested) {
-						return;
-					}
+			const buttonIndex = item.buttons?.indexOf(button) ?? -1;
+			if (buttonIndex >= 0) {
+				const result = item.trigger(buttonIndex, picker.keyMods);
+				const action = (typeof result === 'number') ? result : await result;
 
-					switch (action) {
-						case TriggerAction.NO_ACTION:
-							break;
-						case TriggerAction.CLOSE_PICKER:
-							picker.hide();
-							break;
-						case TriggerAction.REFRESH_PICKER:
-							updatePickerItems();
-							break;
-						case TriggerAction.REMOVE_ITEM: {
-							const index = picker.items.indexOf(item);
-							if (index !== -1) {
-								const items = picker.items.slice();
-								const removed = items.splice(index, 1);
-								const activeItems = picker.activeItems.filter(activeItem => activeItem !== removed[0]);
-								const keepScrollPositionBefore = picker.keepScrollPosition;
-								picker.keepScrollPosition = true;
-								picker.items = items;
-								if (activeItems) {
-									picker.activeItems = activeItems;
-								}
-								picker.keepScrollPosition = keepScrollPositionBefore;
+				if (token.isCancellationRequested) {
+					return;
+				}
+
+				switch (action) {
+					case TriggerAction.NO_ACTION:
+						break;
+					case TriggerAction.CLOSE_PICKER:
+						picker.hide();
+						break;
+					case TriggerAction.REFRESH_PICKER:
+						updatePickerItems();
+						break;
+					case TriggerAction.REMOVE_ITEM: {
+						const index = picker.items.indexOf(item);
+						if (index !== -1) {
+							const items = picker.items.slice();
+							const removed = items.splice(index, 1);
+							const activeItems = picker.activeItems.filter(activeItem => activeItem !== removed[0]);
+							const keepScrollPositionBefore = picker.keepScrollPosition;
+							picker.keepScrollPosition = true;
+							picker.items = items;
+							if (activeItems) {
+								picker.activeItems = activeItems;
 							}
-							break;
+							picker.keepScrollPosition = keepScrollPositionBefore;
 						}
+						break;
 					}
 				}
 			}
-		}));
+		};
+
+		// Trigger the pick with button index if button triggered
+		disposables.add(picker.onDidTriggerItemButton(({ button, item }) => buttonTrigger(button, item)));
+		disposables.add(picker.onDidTriggerSeparatorButton(({ button, separator }) => buttonTrigger(button, separator)));
 
 		return disposables;
 	}

--- a/src/vs/platform/quickinput/browser/pickerQuickAccess.ts
+++ b/src/vs/platform/quickinput/browser/pickerQuickAccess.ts
@@ -337,7 +337,7 @@ export abstract class PickerQuickAccessProvider<T extends IPickerQuickAccessItem
 		}));
 
 		const buttonTrigger = async (button: IQuickInputButton, item: T | IPickerQuickAccessSeparator) => {
-			if (!item.trigger) {
+			if (typeof item.trigger !== 'function') {
 				return;
 			}
 

--- a/src/vs/workbench/contrib/search/browser/quickTextSearch/textSearchQuickAccess.ts
+++ b/src/vs/workbench/contrib/search/browser/quickTextSearch/textSearchQuickAccess.ts
@@ -15,7 +15,7 @@ import { ITextEditorSelection } from 'vs/platform/editor/common/editor';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { ILabelService } from 'vs/platform/label/common/label';
 import { WorkbenchCompressibleObjectTree, getSelectionKeyboardEvent } from 'vs/platform/list/browser/listService';
-import { FastAndSlowPicks, IPickerQuickAccessItem, IPickerQuickAccessSeparator, PickerQuickAccessProvider, Picks, TriggerAction } from 'vs/platform/quickinput/browser/pickerQuickAccess';
+import { FastAndSlowPicks, IPickerQuickAccessItem, PickerQuickAccessProvider, Picks, TriggerAction } from 'vs/platform/quickinput/browser/pickerQuickAccess';
 import { DefaultQuickAccessFilterValue, IQuickAccessProviderRunOptions } from 'vs/platform/quickinput/common/quickAccess';
 import { IKeyMods, IQuickPick, IQuickPickItem, IQuickPickSeparator, QuickInputHideReason } from 'vs/platform/quickinput/common/quickInput';
 import { IWorkspaceContextService, IWorkspaceFolder } from 'vs/platform/workspace/common/workspace';
@@ -221,7 +221,7 @@ export class TextSearchQuickAccess extends PickerQuickAccessProvider<ITextSearch
 		matches = matches.sort(searchComparer);
 
 		const files = matches.length > limit ? matches.slice(0, limit) : matches;
-		const picks: Array<ITextSearchQuickAccessItem | IPickerQuickAccessSeparator> = [];
+		const picks: Array<ITextSearchQuickAccessItem | IQuickPickSeparator> = [];
 
 		for (let fileIndex = 0; fileIndex < matches.length; fileIndex++) {
 			if (fileIndex === limit) {
@@ -254,11 +254,6 @@ export class TextSearchQuickAccess extends PickerQuickAccessProvider<ITextSearch
 					iconClass: ThemeIcon.asClassName(searchOpenInFileIcon),
 					tooltip: localize('QuickSearchOpenInFile', "Open File")
 				}],
-				trigger: (): TriggerAction => {
-					// halp andrea
-					this.moveToSearchViewlet(fileMatch);
-					return TriggerAction.CLOSE_PICKER;
-				},
 			});
 
 			const results: Match[] = fileMatch.matches() ?? [];

--- a/src/vs/workbench/contrib/search/browser/quickTextSearch/textSearchQuickAccess.ts
+++ b/src/vs/workbench/contrib/search/browser/quickTextSearch/textSearchQuickAccess.ts
@@ -15,7 +15,7 @@ import { ITextEditorSelection } from 'vs/platform/editor/common/editor';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { ILabelService } from 'vs/platform/label/common/label';
 import { WorkbenchCompressibleObjectTree, getSelectionKeyboardEvent } from 'vs/platform/list/browser/listService';
-import { FastAndSlowPicks, IPickerQuickAccessItem, PickerQuickAccessProvider, Picks, TriggerAction } from 'vs/platform/quickinput/browser/pickerQuickAccess';
+import { FastAndSlowPicks, IPickerQuickAccessItem, IPickerQuickAccessSeparator, PickerQuickAccessProvider, Picks, TriggerAction } from 'vs/platform/quickinput/browser/pickerQuickAccess';
 import { DefaultQuickAccessFilterValue, IQuickAccessProviderRunOptions } from 'vs/platform/quickinput/common/quickAccess';
 import { IKeyMods, IQuickPick, IQuickPickItem, IQuickPickSeparator, QuickInputHideReason } from 'vs/platform/quickinput/common/quickInput';
 import { IWorkspaceContextService, IWorkspaceFolder } from 'vs/platform/workspace/common/workspace';
@@ -221,7 +221,7 @@ export class TextSearchQuickAccess extends PickerQuickAccessProvider<ITextSearch
 		matches = matches.sort(searchComparer);
 
 		const files = matches.length > limit ? matches.slice(0, limit) : matches;
-		const picks: Array<ITextSearchQuickAccessItem | IQuickPickSeparator> = [];
+		const picks: Array<ITextSearchQuickAccessItem | IPickerQuickAccessSeparator> = [];
 
 		for (let fileIndex = 0; fileIndex < matches.length; fileIndex++) {
 			if (fileIndex === limit) {
@@ -254,6 +254,11 @@ export class TextSearchQuickAccess extends PickerQuickAccessProvider<ITextSearch
 					iconClass: ThemeIcon.asClassName(searchOpenInFileIcon),
 					tooltip: localize('QuickSearchOpenInFile', "Open File")
 				}],
+				trigger: (): TriggerAction => {
+					// halp andrea
+					this.moveToSearchViewlet(fileMatch);
+					return TriggerAction.CLOSE_PICKER;
+				},
 			});
 
 			const results: Match[] = fileMatch.matches() ?? [];


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

separators can have buttons, but we didn't light this up in Quick Access. Since QuickTextSearch is taking advantage of this, this needs to be lit up.