### PR TITLE
Revealing a view causes VS Code to steal focus (fix #205766)

### DIFF
--- a/src/vs/base/browser/dom.ts
+++ b/src/vs/base/browser/dom.ts
@@ -921,10 +921,23 @@ export function getActiveWindow(): CodeWindow {
 	return (document.defaultView?.window ?? mainWindow) as CodeWindow;
 }
 
-export function focusWindow(element: Node): void {
+export function focusWindow(element: Node, options?: { force: boolean }): void {
 	const window = getWindow(element);
-	if (!window.document.hasFocus()) {
+
+	// Force: always focus the element window
+	if (options?.force) {
 		window.focus();
+	}
+
+	// Not forced: only focus the element window if another
+	// window in the same workspace group has focus (when auxiliary
+	// windows are opened).
+	// This prevents stealing focus from another workspace window.
+	else {
+		const activeWindow = getActiveWindow();
+		if (activeWindow.document.hasFocus() && activeWindow !== window) {
+			window.focus();
+		}
 	}
 }
 

--- a/src/vs/workbench/browser/window.ts
+++ b/src/vs/workbench/browser/window.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { isSafari, setFullscreen } from 'vs/base/browser/browser';
-import { addDisposableListener, EventHelper, EventType, getActiveWindow, getWindow, getWindowById, getWindows, getWindowsCount, windowOpenNoOpener, windowOpenPopup, windowOpenWithSuccess } from 'vs/base/browser/dom';
+import { addDisposableListener, EventHelper, EventType, focusWindow, getWindowById, getWindows, getWindowsCount, windowOpenNoOpener, windowOpenPopup, windowOpenWithSuccess } from 'vs/base/browser/dom';
 import { DomEmitter } from 'vs/base/browser/event';
 import { HidDeviceData, requestHidDevice, requestSerialPort, requestUsbDevice, SerialPortData, UsbDeviceData } from 'vs/base/browser/deviceAccess';
 import { timeout } from 'vs/base/common/async';
@@ -56,16 +56,8 @@ export abstract class BaseWindow extends Disposable {
 
 		targetWindow.HTMLElement.prototype.focus = function (this: HTMLElement, options?: FocusOptions | undefined): void {
 
-			// If the active focused window is not the same as the
-			// window of the element to focus, make sure to focus
-			// that window first before focusing the element.
-			const activeWindow = getActiveWindow();
-			if (activeWindow.document.hasFocus()) {
-				const elementWindow = getWindow(this);
-				if (activeWindow !== elementWindow) {
-					elementWindow.focus();
-				}
-			}
+			// Ensure elements window is focused
+			focusWindow(this);
 
 			// Pass to original focus() method
 			originalFocus.apply(this, [options]);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
