### PR TITLE
reload file icon theme when language configuration changes

### DIFF
--- a/src/vs/workbench/services/themes/browser/workbenchThemeService.ts
+++ b/src/vs/workbench/services/themes/browser/workbenchThemeService.ts
@@ -116,7 +116,7 @@ export class WorkbenchThemeService implements IWorkbenchThemeService {
 		@ILogService private readonly logService: ILogService,
 		@IHostColorSchemeService private readonly hostColorService: IHostColorSchemeService,
 		@IUserDataInitializationService private readonly userDataInitializationService: IUserDataInitializationService,
-		@ILanguageService languageService: ILanguageService
+		@ILanguageService private readonly languageService: ILanguageService
 	) {
 		this.container = layoutService.mainContainer;
 		this.settings = new ThemeConfiguration(configurationService);
@@ -378,6 +378,7 @@ export class WorkbenchThemeService implements IWorkbenchThemeService {
 				await this.setProductIconTheme(DEFAULT_PRODUCT_ICON_THEME_ID, 'auto');
 			}
 		});
+		this.languageService.onDidChange(() => this.reloadCurrentFileIconTheme());
 
 		return Promise.all([this.getColorThemes(), this.getFileIconThemes(), this.getProductIconThemes()]).then(([ct, fit, pit]) => {
 			updateColorThemeConfigurationSchemas(ct);


### PR DESCRIPTION
language configurations can contain a default icon. Therefore, the file icon theme needs to reload when the configuration changes