### PR TITLE
Activity bar positioning at the top and bottom

### DIFF
--- a/src/vs/platform/actions/common/actions.ts
+++ b/src/vs/platform/actions/common/actions.ts
@@ -194,6 +194,7 @@ export class MenuId {
 	static readonly SidebarTitle = new MenuId('SidebarTitle');
 	static readonly PanelTitle = new MenuId('PanelTitle');
 	static readonly AuxiliaryBarTitle = new MenuId('AuxiliaryBarTitle');
+	static readonly AuxiliaryBarHeader = new MenuId('AuxiliaryBarHeader');
 	static readonly TerminalInstanceContext = new MenuId('TerminalInstanceContext');
 	static readonly TerminalEditorInstanceContext = new MenuId('TerminalEditorInstanceContext');
 	static readonly TerminalNewDropdownContext = new MenuId('TerminalNewDropdownContext');

--- a/src/vs/workbench/browser/layout.ts
+++ b/src/vs/workbench/browser/layout.ts
@@ -359,9 +359,15 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 				LegacyWorkbenchLayoutSettings.STATUSBAR_VISIBLE,
 			].some(setting => e.affectsConfiguration(setting))) {
 				// Show Custom TitleBar if actions moved to the titlebar
-				const activityBarMovedToTop = e.affectsConfiguration(LayoutSettings.ACTIVITY_BAR_LOCATION) && this.configurationService.getValue<ActivityBarPosition>(LayoutSettings.ACTIVITY_BAR_LOCATION) === ActivityBarPosition.TOP;
 				const editorActionsMovedToTitlebar = e.affectsConfiguration(LayoutSettings.EDITOR_ACTIONS_LOCATION) && this.configurationService.getValue<EditorActionsLocation>(LayoutSettings.EDITOR_ACTIONS_LOCATION) === EditorActionsLocation.TITLEBAR;
-				if (activityBarMovedToTop || editorActionsMovedToTitlebar) {
+
+				let activityBarMovedToTopOrBottom = false;
+				if (e.affectsConfiguration(LayoutSettings.ACTIVITY_BAR_LOCATION)) {
+					const activityBarPosition = this.configurationService.getValue<ActivityBarPosition>(LayoutSettings.ACTIVITY_BAR_LOCATION);
+					activityBarMovedToTopOrBottom = activityBarPosition === ActivityBarPosition.TOP || activityBarPosition === ActivityBarPosition.BOTTOM;
+				}
+
+				if (activityBarMovedToTopOrBottom || editorActionsMovedToTitlebar) {
 					if (this.configurationService.getValue<CustomTitleBarVisibility>(TitleBarSetting.CUSTOM_TITLE_BAR_VISIBILITY) === CustomTitleBarVisibility.NEVER) {
 						this.configurationService.updateValue(TitleBarSetting.CUSTOM_TITLE_BAR_VISIBILITY, CustomTitleBarVisibility.AUTO);
 					}

--- a/src/vs/workbench/browser/layout.ts
+++ b/src/vs/workbench/browser/layout.ts
@@ -2707,7 +2707,7 @@ class LayoutStateModel extends Disposable {
 		if (oldValue !== undefined) {
 			return !oldValue;
 		}
-		return this.configurationService.getValue(LayoutSettings.ACTIVITY_BAR_LOCATION) !== ActivityBarPosition.SIDE;
+		return this.configurationService.getValue(LayoutSettings.ACTIVITY_BAR_LOCATION) !== ActivityBarPosition.DEFAULT;
 	}
 
 	private setRuntimeValueAndFire<T extends StorageKeyType>(key: RuntimeStateKey<T>, value: T): void {

--- a/src/vs/workbench/browser/media/part.css
+++ b/src/vs/workbench/browser/media/part.css
@@ -22,18 +22,21 @@
 	z-index: 12;
 }
 
-.monaco-workbench .part > .title {
+.monaco-workbench .part > .title,
+.monaco-workbench .part > .footer {
 	display: none; /* Parts have to opt in to show title area */
 }
 
-.monaco-workbench .part > .title {
+.monaco-workbench .part > .title,
+.monaco-workbench .part > .footer {
 	height: 35px;
 	display: flex;
 	box-sizing: border-box;
 	overflow: hidden;
 }
 
-.monaco-workbench .part > .title {
+.monaco-workbench .part > .title,
+.monaco-workbench .part > .footer {
 	padding-left: 8px;
 	padding-right: 8px;
 }

--- a/src/vs/workbench/browser/media/part.css
+++ b/src/vs/workbench/browser/media/part.css
@@ -23,12 +23,12 @@
 }
 
 .monaco-workbench .part > .title,
-.monaco-workbench .part > .composite-bar-area {
-	display: none; /* Parts have to opt in to show  and composite bar area */
+.monaco-workbench .part > .header-or-footer {
+	display: none; /* Parts have to opt in to show area */
 }
 
 .monaco-workbench .part > .title,
-.monaco-workbench .part > .composite-bar-area {
+.monaco-workbench .part > .header-or-footer {
 	height: 35px;
 	display: flex;
 	box-sizing: border-box;
@@ -36,7 +36,7 @@
 }
 
 .monaco-workbench .part > .title,
-.monaco-workbench .part > .composite-bar-area {
+.monaco-workbench .part > .header-or-footer {
 	padding-left: 8px;
 	padding-right: 8px;
 }

--- a/src/vs/workbench/browser/media/part.css
+++ b/src/vs/workbench/browser/media/part.css
@@ -23,12 +23,12 @@
 }
 
 .monaco-workbench .part > .title,
-.monaco-workbench .part > .footer {
-	display: none; /* Parts have to opt in to show title area */
+.monaco-workbench .part > .composite-bar-area {
+	display: none; /* Parts have to opt in to show  and composite bar area */
 }
 
 .monaco-workbench .part > .title,
-.monaco-workbench .part > .footer {
+.monaco-workbench .part > .composite-bar-area {
 	height: 35px;
 	display: flex;
 	box-sizing: border-box;
@@ -36,7 +36,7 @@
 }
 
 .monaco-workbench .part > .title,
-.monaco-workbench .part > .footer {
+.monaco-workbench .part > .composite-bar-area {
 	padding-left: 8px;
 	padding-right: 8px;
 }

--- a/src/vs/workbench/browser/parts/activitybar/activitybarPart.ts
+++ b/src/vs/workbench/browser/parts/activitybar/activitybarPart.ts
@@ -388,7 +388,7 @@ registerAction2(class extends Action2 {
 			toggled: ContextKeyExpr.equals(`config.${LayoutSettings.ACTIVITY_BAR_LOCATION}`, ActivityBarPosition.SIDE),
 			menu: [{
 				id: MenuId.ActivityBarPositionMenu,
-				order: 1
+				order: 2
 			}, {
 				id: MenuId.CommandPalette,
 				when: ContextKeyExpr.notEquals(`config.${LayoutSettings.ACTIVITY_BAR_LOCATION}`, ActivityBarPosition.SIDE),
@@ -414,7 +414,7 @@ registerAction2(class extends Action2 {
 			toggled: ContextKeyExpr.equals(`config.${LayoutSettings.ACTIVITY_BAR_LOCATION}`, ActivityBarPosition.TOP),
 			menu: [{
 				id: MenuId.ActivityBarPositionMenu,
-				order: 2
+				order: 1
 			}, {
 				id: MenuId.CommandPalette,
 				when: ContextKeyExpr.notEquals(`config.${LayoutSettings.ACTIVITY_BAR_LOCATION}`, ActivityBarPosition.TOP),
@@ -424,6 +424,32 @@ registerAction2(class extends Action2 {
 	run(accessor: ServicesAccessor): void {
 		const configurationService = accessor.get(IConfigurationService);
 		configurationService.updateValue(LayoutSettings.ACTIVITY_BAR_LOCATION, ActivityBarPosition.TOP);
+	}
+});
+
+registerAction2(class extends Action2 {
+	constructor() {
+		super({
+			id: 'workbench.action.activityBarLocation.bottom',
+			title: {
+				...localize2('positionActivityBarBottom', 'Move Activity Bar to Bottom'),
+				mnemonicTitle: localize({ key: 'miBottomActivityBar', comment: ['&& denotes a mnemonic'] }, "&&Bottom"),
+			},
+			shortTitle: localize('bottom', "Bottom"),
+			category: Categories.View,
+			toggled: ContextKeyExpr.equals(`config.${LayoutSettings.ACTIVITY_BAR_LOCATION}`, ActivityBarPosition.BOTTOM),
+			menu: [{
+				id: MenuId.ActivityBarPositionMenu,
+				order: 3
+			}, {
+				id: MenuId.CommandPalette,
+				when: ContextKeyExpr.notEquals(`config.${LayoutSettings.ACTIVITY_BAR_LOCATION}`, ActivityBarPosition.BOTTOM),
+			}]
+		});
+	}
+	run(accessor: ServicesAccessor): void {
+		const configurationService = accessor.get(IConfigurationService);
+		configurationService.updateValue(LayoutSettings.ACTIVITY_BAR_LOCATION, ActivityBarPosition.BOTTOM);
 	}
 });
 
@@ -440,7 +466,7 @@ registerAction2(class extends Action2 {
 			toggled: ContextKeyExpr.equals(`config.${LayoutSettings.ACTIVITY_BAR_LOCATION}`, ActivityBarPosition.HIDDEN),
 			menu: [{
 				id: MenuId.ActivityBarPositionMenu,
-				order: 3
+				order: 4
 			}, {
 				id: MenuId.CommandPalette,
 				when: ContextKeyExpr.notEquals(`config.${LayoutSettings.ACTIVITY_BAR_LOCATION}`, ActivityBarPosition.HIDDEN),

--- a/src/vs/workbench/browser/parts/activitybar/activitybarPart.ts
+++ b/src/vs/workbench/browser/parts/activitybar/activitybarPart.ts
@@ -378,26 +378,26 @@ export class ActivityBarCompositeBar extends PaneCompositeBar {
 registerAction2(class extends Action2 {
 	constructor() {
 		super({
-			id: 'workbench.action.activityBarLocation.side',
+			id: 'workbench.action.activityBarLocation.default',
 			title: {
-				...localize2('positionActivityBarSide', 'Move Activity Bar to Side'),
-				mnemonicTitle: localize({ key: 'miSideActivityBar', comment: ['&& denotes a mnemonic'] }, "&&Side"),
+				...localize2('positionActivityBarDefault', 'Move Activity Bar to Side'),
+				mnemonicTitle: localize({ key: 'miDefaultActivityBar', comment: ['&& denotes a mnemonic'] }, "&&Default"),
 			},
-			shortTitle: localize('side', "Side"),
+			shortTitle: localize('default', "Default"),
 			category: Categories.View,
-			toggled: ContextKeyExpr.equals(`config.${LayoutSettings.ACTIVITY_BAR_LOCATION}`, ActivityBarPosition.SIDE),
+			toggled: ContextKeyExpr.equals(`config.${LayoutSettings.ACTIVITY_BAR_LOCATION}`, ActivityBarPosition.DEFAULT),
 			menu: [{
 				id: MenuId.ActivityBarPositionMenu,
 				order: 2
 			}, {
 				id: MenuId.CommandPalette,
-				when: ContextKeyExpr.notEquals(`config.${LayoutSettings.ACTIVITY_BAR_LOCATION}`, ActivityBarPosition.SIDE),
+				when: ContextKeyExpr.notEquals(`config.${LayoutSettings.ACTIVITY_BAR_LOCATION}`, ActivityBarPosition.DEFAULT),
 			}]
 		});
 	}
 	run(accessor: ServicesAccessor): void {
 		const configurationService = accessor.get(IConfigurationService);
-		configurationService.updateValue(LayoutSettings.ACTIVITY_BAR_LOCATION, ActivityBarPosition.SIDE);
+		configurationService.updateValue(LayoutSettings.ACTIVITY_BAR_LOCATION, ActivityBarPosition.DEFAULT);
 	}
 });
 

--- a/src/vs/workbench/browser/parts/auxiliarybar/auxiliaryBarPart.ts
+++ b/src/vs/workbench/browser/parts/auxiliarybar/auxiliaryBarPart.ts
@@ -206,11 +206,11 @@ export class AuxiliaryBarPart extends AbstractPaneCompositePart {
 	protected getCompositeBarPosition(): CompositeBarPosition {
 		const activityBarPosition = this.configurationService.getValue<ActivityBarPosition>(LayoutSettings.ACTIVITY_BAR_LOCATION);
 		switch (activityBarPosition) {
+			case ActivityBarPosition.TOP: return CompositeBarPosition.TOP;
 			case ActivityBarPosition.BOTTOM: return CompositeBarPosition.BOTTOM;
 			case ActivityBarPosition.HIDDEN: return CompositeBarPosition.TITLE;
-			case ActivityBarPosition.SIDE: return CompositeBarPosition.TITLE;
-			case ActivityBarPosition.TOP:
-			default: return CompositeBarPosition.TOP;
+			case ActivityBarPosition.DEFAULT: return CompositeBarPosition.TITLE;
+			default: return CompositeBarPosition.TITLE;
 		}
 	}
 

--- a/src/vs/workbench/browser/parts/auxiliarybar/media/auxiliaryBarPart.css
+++ b/src/vs/workbench/browser/parts/auxiliarybar/media/auxiliaryBarPart.css
@@ -14,6 +14,22 @@
 	background-color: var(--vscode-sideBar-background);
 }
 
+.monaco-workbench .part.auxiliarybar .title-actions .actions-container {
+	justify-content: flex-end;
+}
+
+.monaco-workbench .part.auxiliarybar .title-actions .action-item {
+	margin-right: 4px;
+}
+
+.monaco-workbench .part.auxiliarybar > .title > .title-label {
+	flex: 1;
+}
+
+.monaco-workbench .part.auxiliarybar > .title > .title-label h2 {
+	text-transform: uppercase;
+}
+
 .monaco-workbench .part.auxiliarybar > .title > .composite-bar-container {
 	flex: 1;
 }
@@ -37,7 +53,7 @@
 	outline: var(--vscode-contrastActiveBorder, unset) dashed 1px !important;
 }
 
-.monaco-workbench .auxiliarybar.part.pane-composite-part > .composite.title.has-composite-bar > .title-actions {
+.monaco-workbench .auxiliarybar.part.pane-composite-part > .composite.title > .title-actions {
 	flex: inherit;
 }
 

--- a/src/vs/workbench/browser/parts/compositePart.ts
+++ b/src/vs/workbench/browser/parts/compositePart.ts
@@ -438,12 +438,8 @@ export abstract class CompositePart<T extends Composite> extends Part {
 		};
 	}
 
-	protected override createFooterArea(parent: HTMLElement): HTMLElement {
-		const footerArea = append(parent, $('.composite'));
-		footerArea.classList.add('footer');
-
-		hide(footerArea);
-		return footerArea;
+	protected createCompositeBarArea(): HTMLElement {
+		return $('.composite.composite-bar-area');
 	}
 
 	override updateStyles(): void {

--- a/src/vs/workbench/browser/parts/compositePart.ts
+++ b/src/vs/workbench/browser/parts/compositePart.ts
@@ -438,7 +438,7 @@ export abstract class CompositePart<T extends Composite> extends Part {
 		};
 	}
 
-	protected createCompositeBarArea(): HTMLElement {
+	protected createHeaderFooterCompositeBarArea(): HTMLElement {
 		return $('.composite.composite-bar-area');
 	}
 

--- a/src/vs/workbench/browser/parts/compositePart.ts
+++ b/src/vs/workbench/browser/parts/compositePart.ts
@@ -70,7 +70,7 @@ export abstract class CompositePart<T extends Composite> extends Part {
 	private activeComposite: Composite | undefined;
 	private lastActiveCompositeId: string;
 	private readonly instantiatedCompositeItems = new Map<string, CompositeItem>();
-	private titleLabel: ICompositeTitleLabel | undefined;
+	protected titleLabel: ICompositeTitleLabel | undefined;
 	private progressBar: ProgressBar | undefined;
 	private contentAreaSize: Dimension | undefined;
 	private readonly actionsListener = this._register(new MutableDisposable());
@@ -438,8 +438,12 @@ export abstract class CompositePart<T extends Composite> extends Part {
 		};
 	}
 
-	protected createHeaderFooterCompositeBarArea(): HTMLElement {
-		return $('.composite.composite-bar-area');
+	protected createHeaderArea(): HTMLElement {
+		return $('.composite');
+	}
+
+	protected createFooterArea(): HTMLElement {
+		return $('.composite');
 	}
 
 	override updateStyles(): void {

--- a/src/vs/workbench/browser/parts/compositePart.ts
+++ b/src/vs/workbench/browser/parts/compositePart.ts
@@ -438,6 +438,14 @@ export abstract class CompositePart<T extends Composite> extends Part {
 		};
 	}
 
+	protected override createFooterArea(parent: HTMLElement): HTMLElement {
+		const footerArea = append(parent, $('.composite'));
+		footerArea.classList.add('footer');
+
+		hide(footerArea);
+		return footerArea;
+	}
+
 	override updateStyles(): void {
 		super.updateStyles();
 

--- a/src/vs/workbench/browser/parts/media/compositepart.css
+++ b/src/vs/workbench/browser/parts/media/compositepart.css
@@ -7,6 +7,7 @@
 	height: 100%;
 }
 
+.monaco-workbench .part > .composite.footer,
 .monaco-workbench .part > .composite.title {
 	display: flex;
 }

--- a/src/vs/workbench/browser/parts/media/compositepart.css
+++ b/src/vs/workbench/browser/parts/media/compositepart.css
@@ -7,7 +7,7 @@
 	height: 100%;
 }
 
-.monaco-workbench .part > .composite.composite-bar-area,
+.monaco-workbench .part > .composite.header-or-footer,
 .monaco-workbench .part > .composite.title {
 	display: flex;
 }

--- a/src/vs/workbench/browser/parts/media/compositepart.css
+++ b/src/vs/workbench/browser/parts/media/compositepart.css
@@ -7,7 +7,7 @@
 	height: 100%;
 }
 
-.monaco-workbench .part > .composite.footer,
+.monaco-workbench .part > .composite.composite-bar-area,
 .monaco-workbench .part > .composite.title {
 	display: flex;
 }

--- a/src/vs/workbench/browser/parts/media/paneCompositePart.css
+++ b/src/vs/workbench/browser/parts/media/paneCompositePart.css
@@ -30,7 +30,7 @@
 }
 
 .monaco-workbench .pane-composite-part > .header-or-footer .composite-bar-container {
-	width: 100%;
+	flex: 1;
 }
 
 .monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-label.codicon-more,

--- a/src/vs/workbench/browser/parts/media/paneCompositePart.css
+++ b/src/vs/workbench/browser/parts/media/paneCompositePart.css
@@ -20,11 +20,17 @@
 	display: none;
 }
 
-.monaco-workbench .pane-composite-part > .title > .composite-bar-container {
+.monaco-workbench .pane-composite-part > .footer{
+	border-top: 1px solid var(--vscode-sideBarSectionHeader-border);
+}
+
+.monaco-workbench .pane-composite-part > .title > .composite-bar-container,
+.monaco-workbench .pane-composite-part > .footer > .composite-bar-container {
 	display: flex;
 }
 
-.monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-label.codicon-more {
+.monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-label.codicon-more,
+.monaco-workbench .pane-composite-part > .footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-label.codicon-more {
 	display: flex;
 	align-items: center;
 	justify-content: center;
@@ -33,12 +39,14 @@
 	color: inherit !important;
 }
 
-.monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar {
+.monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar,
+.monaco-workbench .pane-composite-part > .footer > .composite-bar-container > .composite-bar > .monaco-action-bar {
 	line-height: 27px; /* matches panel titles in settings */
 	height: 35px;
 }
 
-.monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item {
+.monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item,
+.monaco-workbench .pane-composite-part > .footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item {
 	text-transform: uppercase;
 	padding-left: 10px;
 	padding-right: 10px;
@@ -48,22 +56,27 @@
 	display: flex;
 }
 
-.monaco-workbench .pane-composite-part > .title > .composite-bar-container >.composite-bar > .monaco-action-bar .action-item.icon {
+.monaco-workbench .pane-composite-part > .title > .composite-bar-container >.composite-bar > .monaco-action-bar .action-item.icon,
+.monaco-workbench .pane-composite-part > .footer > .composite-bar-container >.composite-bar > .monaco-action-bar .action-item.icon {
 	height: 24px;
 	padding: 0 5px;
 }
 
-.monaco-workbench .pane-composite-part > .title > .composite-bar-container >.composite-bar .monaco-action-bar .action-label.codicon {
+.monaco-workbench .pane-composite-part > .title > .composite-bar-container >.composite-bar .monaco-action-bar .action-label.codicon,
+.monaco-workbench .pane-composite-part > .footer > .composite-bar-container >.composite-bar .monaco-action-bar .action-label.codicon {
 	font-size: 18px;
 }
 
-.monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon .action-label:not(.codicon) {
+.monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon .action-label:not(.codicon),
+.monaco-workbench .pane-composite-part > .footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon .action-label:not(.codicon) {
 	width: 16px;
 	height: 16px;
 }
 
 .monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item::before,
-.monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item::after {
+.monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item::after,
+.monaco-workbench .pane-composite-part > .footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item::before,
+.monaco-workbench .pane-composite-part > .footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item::after {
 	content: '';
 	width: 2px;
 	height: 24px;
@@ -77,26 +90,33 @@
 }
 
 .monaco-workbench .pane-composite-part > .title > .composite-bar-container.dragged-over > .composite-bar > .monaco-action-bar .action-item::before,
-.monaco-workbench .pane-composite-part > .title > .composite-bar-container.dragged-over > .composite-bar > .monaco-action-bar .action-item::after {
+.monaco-workbench .pane-composite-part > .title > .composite-bar-container.dragged-over > .composite-bar > .monaco-action-bar .action-item::after,
+.monaco-workbench .pane-composite-part > .footer > .composite-bar-container.dragged-over > .composite-bar > .monaco-action-bar .action-item::before,
+.monaco-workbench .pane-composite-part > .footer > .composite-bar-container.dragged-over > .composite-bar > .monaco-action-bar .action-item::after {
 	display: block;
 }
 
-.monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item::before {
+.monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item::before,
+.monaco-workbench .pane-composite-part > .footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item::before {
 	left: 1px;
 	margin-left: -2px;
 }
 
-.monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item::after {
+.monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item::after,
+.monaco-workbench .pane-composite-part > .footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item::after {
 	right: 1px;
 	margin-right: -2px;
 }
 
-.monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:first-of-type::before {
+
+.monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:first-of-type::before,
+.monaco-workbench .pane-composite-part > .footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:first-of-type::before {
 	left: 2px;
 	margin-left: -2px;
 }
 
-.monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:last-of-type::after {
+.monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:last-of-type::after,
+.monaco-workbench .pane-composite-part > .footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:last-of-type::after {
 	right: 2px;
 	margin-right: -2px;
 }
@@ -104,7 +124,11 @@
 .monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.right::before,
 .monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.left::after,
 .monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.left::before,
-.monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.right::after {
+.monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.right::after,
+.monaco-workbench .pane-composite-part > .footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.right::before,
+.monaco-workbench .pane-composite-part > .footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.left::after,
+.monaco-workbench .pane-composite-part > .footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.left::before,
+.monaco-workbench .pane-composite-part > .footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.right::after {
 	transition-delay: 0s;
 }
 
@@ -112,39 +136,52 @@
 .monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.left::before,
 .monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:last-of-type.right::after,
 .monaco-workbench .pane-composite-part > .title > .composite-bar-container.dragged-over-head  > .composite-bar > .monaco-action-bar .action-item:first-of-type::before,
-.monaco-workbench .pane-composite-part > .title > .composite-bar-container.dragged-over-tail > .composite-bar > .monaco-action-bar .action-item:last-of-type::after {
+.monaco-workbench .pane-composite-part > .title > .composite-bar-container.dragged-over-tail > .composite-bar > .monaco-action-bar .action-item:last-of-type::after,
+.monaco-workbench .pane-composite-part > .footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.right + .action-item::before,
+.monaco-workbench .pane-composite-part > .footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.left::before,
+.monaco-workbench .pane-composite-part > .footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:last-of-type.right::after,
+.monaco-workbench .pane-composite-part > .footer > .composite-bar-container.dragged-over-head  > .composite-bar > .monaco-action-bar .action-item:first-of-type::before,
+.monaco-workbench .pane-composite-part > .footer > .composite-bar-container.dragged-over-tail > .composite-bar > .monaco-action-bar .action-item:last-of-type::after {
 	opacity: 1;
 }
 
-.monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item .action-label {
+.monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item .action-label,
+.monaco-workbench .pane-composite-part > .footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item .action-label {
 	margin-right: 0;
 	padding: 2px;
 }
 
-.monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item .action-label {
+.monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item .action-label,
+.monaco-workbench .pane-composite-part > .footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item .action-label {
 	border-radius: 0;
 }
 
 .monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:not(.icon) .action-label,
-.monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon .action-label.codicon {
+.monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon .action-label.codicon,
+.monaco-workbench .pane-composite-part > .footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:not(.icon) .action-label,
+.monaco-workbench .pane-composite-part > .footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon .action-label.codicon {
 	background: none !important;
 }
 
-.monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.checked .action-label {
+.monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.checked .action-label,
+.monaco-workbench .pane-composite-part > .footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.checked .action-label {
 	margin-right: 0;
 }
 
-.monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .badge {
+.monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .badge,
+.monaco-workbench .pane-composite-part > .footer > .composite-bar-container > .composite-bar > .monaco-action-bar .badge {
 	margin-left: 8px;
 	display: flex;
 	align-items: center;
 }
 
-.monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon .badge {
+.monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon .badge,
+.monaco-workbench .pane-composite-part > .footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon .badge {
 	margin-left: 0px;
 }
 
-.monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .badge .badge-content {
+.monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .badge .badge-content,
+.monaco-workbench .pane-composite-part > .footer > .composite-bar-container > .composite-bar > .monaco-action-bar .badge .badge-content {
 	padding: 3px 5px;
 	border-radius: 11px;
 	font-size: 11px;
@@ -158,7 +195,8 @@
 	position: relative;
 }
 
-.monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon .badge.compact {
+.monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon .badge.compact,
+.monaco-workbench .pane-composite-part > .footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon .badge.compact {
 	position: absolute;
 	top: 0;
 	bottom: 0;
@@ -170,7 +208,8 @@
 	z-index: 2;
 }
 
-.monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon .badge.compact .badge-content {
+.monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon .badge.compact .badge-content,
+.monaco-workbench .pane-composite-part > .footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon .badge.compact .badge-content {
 	position: absolute;
 	top: 11px;
 	right: 0px;
@@ -184,7 +223,8 @@
 	text-align: center;
 }
 
-.monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon .badge.compact.progress-badge .badge-content::before {
+.monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon .badge.compact.progress-badge .badge-content::before,
+.monaco-workbench .pane-composite-part > .footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon .badge.compact.progress-badge .badge-content::before {
 	mask-size: 11px;
 	-webkit-mask-size: 11px;
 	top: 3px;
@@ -192,7 +232,8 @@
 }
 
 /* active item indicator */
-.monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item .active-item-indicator {
+.monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item .active-item-indicator,
+.monaco-workbench .pane-composite-part > .footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item .active-item-indicator {
 	position: absolute;
 	z-index: 1;
 	bottom: 0;
@@ -201,20 +242,24 @@
 	height: 100%;
 }
 
-.monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item .active-item-indicator {
+.monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item .active-item-indicator,
+.monaco-workbench .pane-composite-part > .footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item .active-item-indicator {
 	top: -4px;
 	left: 10px;
 	width: calc(100% - 20px);
 }
 
-.monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon .active-item-indicator {
+.monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon .active-item-indicator,
+.monaco-workbench .pane-composite-part > .footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon .active-item-indicator {
 	top: 1px;
 	left: 2px;
 	width: calc(100% - 4px);
 }
 
 .monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.checked .active-item-indicator:before,
-.monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:focus .active-item-indicator:before {
+.monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:focus .active-item-indicator:before,
+.monaco-workbench .pane-composite-part > .footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.checked .active-item-indicator:before,
+.monaco-workbench .pane-composite-part > .footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:focus .active-item-indicator:before {
 	content: "";
 	position: absolute;
 	z-index: 1;
@@ -225,20 +270,25 @@
 	border-top-style: solid;
 }
 
-.monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.clicked:not(.checked):focus .active-item-indicator:before {
+.monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.clicked:not(.checked):focus .active-item-indicator:before,
+.monaco-workbench .pane-composite-part > .footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.clicked:not(.checked):focus .active-item-indicator:before {
 	border-top-color: transparent !important; /* hides border on clicked state */
 }
 
-.monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:focus .active-item-indicator:before {
+.monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:focus .active-item-indicator:before,
+.monaco-workbench .pane-composite-part > .footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:focus .active-item-indicator:before {
 	border-top-color: var(--vscode-focusBorder) !important;
 }
 
 .monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.checked .action-label,
-.monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:hover .action-label {
+.monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:hover .action-label,
+.monaco-workbench .pane-composite-part > .footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.checked .action-label,
+.monaco-workbench .pane-composite-part > .footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:hover .action-label {
 	outline: var(--vscode-contrastActiveBorder, unset) solid 1px !important;
 }
 
-.monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:not(.checked):hover .action-label {
+.monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:not(.checked):hover .action-label,
+.monaco-workbench .pane-composite-part > .footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:not(.checked):hover .action-label {
 	outline: var(--vscode-contrastActiveBorder, unset) dashed 1px !important;
 }
 

--- a/src/vs/workbench/browser/parts/media/paneCompositePart.css
+++ b/src/vs/workbench/browser/parts/media/paneCompositePart.css
@@ -29,6 +29,10 @@
 	display: flex;
 }
 
+.monaco-workbench .pane-composite-part > .header-or-footer .composite-bar-container {
+	width: 100%;
+}
+
 .monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-label.codicon-more,
 .monaco-workbench .pane-composite-part > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-label.codicon-more {
 	display: flex;

--- a/src/vs/workbench/browser/parts/media/paneCompositePart.css
+++ b/src/vs/workbench/browser/parts/media/paneCompositePart.css
@@ -20,10 +20,9 @@
 	display: none;
 }
 
-.monaco-workbench .pane-composite-part > .header-or-footer.bottom {
+.monaco-workbench .pane-composite-part > .header-or-footer.footer {
 	border-top: 1px solid var(--vscode-sideBarSectionHeader-border);
 }
-
 
 .monaco-workbench .pane-composite-part > .title > .composite-bar-container,
 .monaco-workbench .pane-composite-part > .header-or-footer > .composite-bar-container {

--- a/src/vs/workbench/browser/parts/media/paneCompositePart.css
+++ b/src/vs/workbench/browser/parts/media/paneCompositePart.css
@@ -20,17 +20,18 @@
 	display: none;
 }
 
-.monaco-workbench .pane-composite-part > .footer{
+.monaco-workbench .pane-composite-part > .composite-bar-area.bottom {
 	border-top: 1px solid var(--vscode-sideBarSectionHeader-border);
 }
 
+
 .monaco-workbench .pane-composite-part > .title > .composite-bar-container,
-.monaco-workbench .pane-composite-part > .footer > .composite-bar-container {
+.monaco-workbench .pane-composite-part > .composite-bar-area > .composite-bar-container {
 	display: flex;
 }
 
 .monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-label.codicon-more,
-.monaco-workbench .pane-composite-part > .footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-label.codicon-more {
+.monaco-workbench .pane-composite-part > .composite-bar-area > .composite-bar-container > .composite-bar > .monaco-action-bar .action-label.codicon-more {
 	display: flex;
 	align-items: center;
 	justify-content: center;
@@ -40,13 +41,13 @@
 }
 
 .monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar,
-.monaco-workbench .pane-composite-part > .footer > .composite-bar-container > .composite-bar > .monaco-action-bar {
+.monaco-workbench .pane-composite-part > .composite-bar-area > .composite-bar-container > .composite-bar > .monaco-action-bar {
 	line-height: 27px; /* matches panel titles in settings */
 	height: 35px;
 }
 
 .monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item,
-.monaco-workbench .pane-composite-part > .footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item {
+.monaco-workbench .pane-composite-part > .composite-bar-area > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item {
 	text-transform: uppercase;
 	padding-left: 10px;
 	padding-right: 10px;
@@ -57,26 +58,26 @@
 }
 
 .monaco-workbench .pane-composite-part > .title > .composite-bar-container >.composite-bar > .monaco-action-bar .action-item.icon,
-.monaco-workbench .pane-composite-part > .footer > .composite-bar-container >.composite-bar > .monaco-action-bar .action-item.icon {
+.monaco-workbench .pane-composite-part > .composite-bar-area > .composite-bar-container >.composite-bar > .monaco-action-bar .action-item.icon {
 	height: 24px;
 	padding: 0 5px;
 }
 
 .monaco-workbench .pane-composite-part > .title > .composite-bar-container >.composite-bar .monaco-action-bar .action-label.codicon,
-.monaco-workbench .pane-composite-part > .footer > .composite-bar-container >.composite-bar .monaco-action-bar .action-label.codicon {
+.monaco-workbench .pane-composite-part > .composite-bar-area > .composite-bar-container >.composite-bar .monaco-action-bar .action-label.codicon {
 	font-size: 18px;
 }
 
 .monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon .action-label:not(.codicon),
-.monaco-workbench .pane-composite-part > .footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon .action-label:not(.codicon) {
+.monaco-workbench .pane-composite-part > .composite-bar-area > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon .action-label:not(.codicon) {
 	width: 16px;
 	height: 16px;
 }
 
 .monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item::before,
 .monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item::after,
-.monaco-workbench .pane-composite-part > .footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item::before,
-.monaco-workbench .pane-composite-part > .footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item::after {
+.monaco-workbench .pane-composite-part > .composite-bar-area > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item::before,
+.monaco-workbench .pane-composite-part > .composite-bar-area > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item::after {
 	content: '';
 	width: 2px;
 	height: 24px;
@@ -91,32 +92,32 @@
 
 .monaco-workbench .pane-composite-part > .title > .composite-bar-container.dragged-over > .composite-bar > .monaco-action-bar .action-item::before,
 .monaco-workbench .pane-composite-part > .title > .composite-bar-container.dragged-over > .composite-bar > .monaco-action-bar .action-item::after,
-.monaco-workbench .pane-composite-part > .footer > .composite-bar-container.dragged-over > .composite-bar > .monaco-action-bar .action-item::before,
-.monaco-workbench .pane-composite-part > .footer > .composite-bar-container.dragged-over > .composite-bar > .monaco-action-bar .action-item::after {
+.monaco-workbench .pane-composite-part > .composite-bar-area > .composite-bar-container.dragged-over > .composite-bar > .monaco-action-bar .action-item::before,
+.monaco-workbench .pane-composite-part > .composite-bar-area > .composite-bar-container.dragged-over > .composite-bar > .monaco-action-bar .action-item::after {
 	display: block;
 }
 
 .monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item::before,
-.monaco-workbench .pane-composite-part > .footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item::before {
+.monaco-workbench .pane-composite-part > .composite-bar-area > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item::before {
 	left: 1px;
 	margin-left: -2px;
 }
 
 .monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item::after,
-.monaco-workbench .pane-composite-part > .footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item::after {
+.monaco-workbench .pane-composite-part > .composite-bar-area > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item::after {
 	right: 1px;
 	margin-right: -2px;
 }
 
 
 .monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:first-of-type::before,
-.monaco-workbench .pane-composite-part > .footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:first-of-type::before {
+.monaco-workbench .pane-composite-part > .composite-bar-area > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:first-of-type::before {
 	left: 2px;
 	margin-left: -2px;
 }
 
 .monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:last-of-type::after,
-.monaco-workbench .pane-composite-part > .footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:last-of-type::after {
+.monaco-workbench .pane-composite-part > .composite-bar-area > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:last-of-type::after {
 	right: 2px;
 	margin-right: -2px;
 }
@@ -125,10 +126,10 @@
 .monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.left::after,
 .monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.left::before,
 .monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.right::after,
-.monaco-workbench .pane-composite-part > .footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.right::before,
-.monaco-workbench .pane-composite-part > .footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.left::after,
-.monaco-workbench .pane-composite-part > .footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.left::before,
-.monaco-workbench .pane-composite-part > .footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.right::after {
+.monaco-workbench .pane-composite-part > .composite-bar-area > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.right::before,
+.monaco-workbench .pane-composite-part > .composite-bar-area > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.left::after,
+.monaco-workbench .pane-composite-part > .composite-bar-area > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.left::before,
+.monaco-workbench .pane-composite-part > .composite-bar-area > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.right::after {
 	transition-delay: 0s;
 }
 
@@ -137,51 +138,51 @@
 .monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:last-of-type.right::after,
 .monaco-workbench .pane-composite-part > .title > .composite-bar-container.dragged-over-head  > .composite-bar > .monaco-action-bar .action-item:first-of-type::before,
 .monaco-workbench .pane-composite-part > .title > .composite-bar-container.dragged-over-tail > .composite-bar > .monaco-action-bar .action-item:last-of-type::after,
-.monaco-workbench .pane-composite-part > .footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.right + .action-item::before,
-.monaco-workbench .pane-composite-part > .footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.left::before,
-.monaco-workbench .pane-composite-part > .footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:last-of-type.right::after,
-.monaco-workbench .pane-composite-part > .footer > .composite-bar-container.dragged-over-head  > .composite-bar > .monaco-action-bar .action-item:first-of-type::before,
-.monaco-workbench .pane-composite-part > .footer > .composite-bar-container.dragged-over-tail > .composite-bar > .monaco-action-bar .action-item:last-of-type::after {
+.monaco-workbench .pane-composite-part > .composite-bar-area > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.right + .action-item::before,
+.monaco-workbench .pane-composite-part > .composite-bar-area > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.left::before,
+.monaco-workbench .pane-composite-part > .composite-bar-area > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:last-of-type.right::after,
+.monaco-workbench .pane-composite-part > .composite-bar-area > .composite-bar-container.dragged-over-head  > .composite-bar > .monaco-action-bar .action-item:first-of-type::before,
+.monaco-workbench .pane-composite-part > .composite-bar-area > .composite-bar-container.dragged-over-tail > .composite-bar > .monaco-action-bar .action-item:last-of-type::after {
 	opacity: 1;
 }
 
 .monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item .action-label,
-.monaco-workbench .pane-composite-part > .footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item .action-label {
+.monaco-workbench .pane-composite-part > .composite-bar-area > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item .action-label {
 	margin-right: 0;
 	padding: 2px;
 }
 
 .monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item .action-label,
-.monaco-workbench .pane-composite-part > .footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item .action-label {
+.monaco-workbench .pane-composite-part > .composite-bar-area > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item .action-label {
 	border-radius: 0;
 }
 
 .monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:not(.icon) .action-label,
 .monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon .action-label.codicon,
-.monaco-workbench .pane-composite-part > .footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:not(.icon) .action-label,
-.monaco-workbench .pane-composite-part > .footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon .action-label.codicon {
+.monaco-workbench .pane-composite-part > .composite-bar-area > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:not(.icon) .action-label,
+.monaco-workbench .pane-composite-part > .composite-bar-area > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon .action-label.codicon {
 	background: none !important;
 }
 
 .monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.checked .action-label,
-.monaco-workbench .pane-composite-part > .footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.checked .action-label {
+.monaco-workbench .pane-composite-part > .composite-bar-area > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.checked .action-label {
 	margin-right: 0;
 }
 
 .monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .badge,
-.monaco-workbench .pane-composite-part > .footer > .composite-bar-container > .composite-bar > .monaco-action-bar .badge {
+.monaco-workbench .pane-composite-part > .composite-bar-area > .composite-bar-container > .composite-bar > .monaco-action-bar .badge {
 	margin-left: 8px;
 	display: flex;
 	align-items: center;
 }
 
 .monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon .badge,
-.monaco-workbench .pane-composite-part > .footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon .badge {
+.monaco-workbench .pane-composite-part > .composite-bar-area > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon .badge {
 	margin-left: 0px;
 }
 
 .monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .badge .badge-content,
-.monaco-workbench .pane-composite-part > .footer > .composite-bar-container > .composite-bar > .monaco-action-bar .badge .badge-content {
+.monaco-workbench .pane-composite-part > .composite-bar-area > .composite-bar-container > .composite-bar > .monaco-action-bar .badge .badge-content {
 	padding: 3px 5px;
 	border-radius: 11px;
 	font-size: 11px;
@@ -196,7 +197,7 @@
 }
 
 .monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon .badge.compact,
-.monaco-workbench .pane-composite-part > .footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon .badge.compact {
+.monaco-workbench .pane-composite-part > .composite-bar-area > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon .badge.compact {
 	position: absolute;
 	top: 0;
 	bottom: 0;
@@ -209,7 +210,7 @@
 }
 
 .monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon .badge.compact .badge-content,
-.monaco-workbench .pane-composite-part > .footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon .badge.compact .badge-content {
+.monaco-workbench .pane-composite-part > .composite-bar-area > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon .badge.compact .badge-content {
 	position: absolute;
 	top: 11px;
 	right: 0px;
@@ -224,7 +225,7 @@
 }
 
 .monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon .badge.compact.progress-badge .badge-content::before,
-.monaco-workbench .pane-composite-part > .footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon .badge.compact.progress-badge .badge-content::before {
+.monaco-workbench .pane-composite-part > .composite-bar-area > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon .badge.compact.progress-badge .badge-content::before {
 	mask-size: 11px;
 	-webkit-mask-size: 11px;
 	top: 3px;
@@ -233,7 +234,7 @@
 
 /* active item indicator */
 .monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item .active-item-indicator,
-.monaco-workbench .pane-composite-part > .footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item .active-item-indicator {
+.monaco-workbench .pane-composite-part > .composite-bar-area > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item .active-item-indicator {
 	position: absolute;
 	z-index: 1;
 	bottom: 0;
@@ -243,14 +244,14 @@
 }
 
 .monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item .active-item-indicator,
-.monaco-workbench .pane-composite-part > .footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item .active-item-indicator {
+.monaco-workbench .pane-composite-part > .composite-bar-area > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item .active-item-indicator {
 	top: -4px;
 	left: 10px;
 	width: calc(100% - 20px);
 }
 
 .monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon .active-item-indicator,
-.monaco-workbench .pane-composite-part > .footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon .active-item-indicator {
+.monaco-workbench .pane-composite-part > .composite-bar-area > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon .active-item-indicator {
 	top: 1px;
 	left: 2px;
 	width: calc(100% - 4px);
@@ -258,8 +259,8 @@
 
 .monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.checked .active-item-indicator:before,
 .monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:focus .active-item-indicator:before,
-.monaco-workbench .pane-composite-part > .footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.checked .active-item-indicator:before,
-.monaco-workbench .pane-composite-part > .footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:focus .active-item-indicator:before {
+.monaco-workbench .pane-composite-part > .composite-bar-area > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.checked .active-item-indicator:before,
+.monaco-workbench .pane-composite-part > .composite-bar-area > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:focus .active-item-indicator:before {
 	content: "";
 	position: absolute;
 	z-index: 1;
@@ -271,24 +272,24 @@
 }
 
 .monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.clicked:not(.checked):focus .active-item-indicator:before,
-.monaco-workbench .pane-composite-part > .footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.clicked:not(.checked):focus .active-item-indicator:before {
+.monaco-workbench .pane-composite-part > .composite-bar-area > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.clicked:not(.checked):focus .active-item-indicator:before {
 	border-top-color: transparent !important; /* hides border on clicked state */
 }
 
 .monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:focus .active-item-indicator:before,
-.monaco-workbench .pane-composite-part > .footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:focus .active-item-indicator:before {
+.monaco-workbench .pane-composite-part > .composite-bar-area > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:focus .active-item-indicator:before {
 	border-top-color: var(--vscode-focusBorder) !important;
 }
 
 .monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.checked .action-label,
 .monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:hover .action-label,
-.monaco-workbench .pane-composite-part > .footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.checked .action-label,
-.monaco-workbench .pane-composite-part > .footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:hover .action-label {
+.monaco-workbench .pane-composite-part > .composite-bar-area > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.checked .action-label,
+.monaco-workbench .pane-composite-part > .composite-bar-area > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:hover .action-label {
 	outline: var(--vscode-contrastActiveBorder, unset) solid 1px !important;
 }
 
 .monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:not(.checked):hover .action-label,
-.monaco-workbench .pane-composite-part > .footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:not(.checked):hover .action-label {
+.monaco-workbench .pane-composite-part > .composite-bar-area > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:not(.checked):hover .action-label {
 	outline: var(--vscode-contrastActiveBorder, unset) dashed 1px !important;
 }
 

--- a/src/vs/workbench/browser/parts/media/paneCompositePart.css
+++ b/src/vs/workbench/browser/parts/media/paneCompositePart.css
@@ -20,18 +20,18 @@
 	display: none;
 }
 
-.monaco-workbench .pane-composite-part > .composite-bar-area.bottom {
+.monaco-workbench .pane-composite-part > .header-or-footer.bottom {
 	border-top: 1px solid var(--vscode-sideBarSectionHeader-border);
 }
 
 
 .monaco-workbench .pane-composite-part > .title > .composite-bar-container,
-.monaco-workbench .pane-composite-part > .composite-bar-area > .composite-bar-container {
+.monaco-workbench .pane-composite-part > .header-or-footer > .composite-bar-container {
 	display: flex;
 }
 
 .monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-label.codicon-more,
-.monaco-workbench .pane-composite-part > .composite-bar-area > .composite-bar-container > .composite-bar > .monaco-action-bar .action-label.codicon-more {
+.monaco-workbench .pane-composite-part > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-label.codicon-more {
 	display: flex;
 	align-items: center;
 	justify-content: center;
@@ -41,13 +41,13 @@
 }
 
 .monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar,
-.monaco-workbench .pane-composite-part > .composite-bar-area > .composite-bar-container > .composite-bar > .monaco-action-bar {
+.monaco-workbench .pane-composite-part > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar {
 	line-height: 27px; /* matches panel titles in settings */
 	height: 35px;
 }
 
 .monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item,
-.monaco-workbench .pane-composite-part > .composite-bar-area > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item {
+.monaco-workbench .pane-composite-part > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item {
 	text-transform: uppercase;
 	padding-left: 10px;
 	padding-right: 10px;
@@ -58,26 +58,26 @@
 }
 
 .monaco-workbench .pane-composite-part > .title > .composite-bar-container >.composite-bar > .monaco-action-bar .action-item.icon,
-.monaco-workbench .pane-composite-part > .composite-bar-area > .composite-bar-container >.composite-bar > .monaco-action-bar .action-item.icon {
+.monaco-workbench .pane-composite-part > .header-or-footer > .composite-bar-container >.composite-bar > .monaco-action-bar .action-item.icon {
 	height: 24px;
 	padding: 0 5px;
 }
 
 .monaco-workbench .pane-composite-part > .title > .composite-bar-container >.composite-bar .monaco-action-bar .action-label.codicon,
-.monaco-workbench .pane-composite-part > .composite-bar-area > .composite-bar-container >.composite-bar .monaco-action-bar .action-label.codicon {
+.monaco-workbench .pane-composite-part > .header-or-footer > .composite-bar-container >.composite-bar .monaco-action-bar .action-label.codicon {
 	font-size: 18px;
 }
 
 .monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon .action-label:not(.codicon),
-.monaco-workbench .pane-composite-part > .composite-bar-area > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon .action-label:not(.codicon) {
+.monaco-workbench .pane-composite-part > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon .action-label:not(.codicon) {
 	width: 16px;
 	height: 16px;
 }
 
 .monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item::before,
 .monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item::after,
-.monaco-workbench .pane-composite-part > .composite-bar-area > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item::before,
-.monaco-workbench .pane-composite-part > .composite-bar-area > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item::after {
+.monaco-workbench .pane-composite-part > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item::before,
+.monaco-workbench .pane-composite-part > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item::after {
 	content: '';
 	width: 2px;
 	height: 24px;
@@ -92,32 +92,32 @@
 
 .monaco-workbench .pane-composite-part > .title > .composite-bar-container.dragged-over > .composite-bar > .monaco-action-bar .action-item::before,
 .monaco-workbench .pane-composite-part > .title > .composite-bar-container.dragged-over > .composite-bar > .monaco-action-bar .action-item::after,
-.monaco-workbench .pane-composite-part > .composite-bar-area > .composite-bar-container.dragged-over > .composite-bar > .monaco-action-bar .action-item::before,
-.monaco-workbench .pane-composite-part > .composite-bar-area > .composite-bar-container.dragged-over > .composite-bar > .monaco-action-bar .action-item::after {
+.monaco-workbench .pane-composite-part > .header-or-footer > .composite-bar-container.dragged-over > .composite-bar > .monaco-action-bar .action-item::before,
+.monaco-workbench .pane-composite-part > .header-or-footer > .composite-bar-container.dragged-over > .composite-bar > .monaco-action-bar .action-item::after {
 	display: block;
 }
 
 .monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item::before,
-.monaco-workbench .pane-composite-part > .composite-bar-area > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item::before {
+.monaco-workbench .pane-composite-part > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item::before {
 	left: 1px;
 	margin-left: -2px;
 }
 
 .monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item::after,
-.monaco-workbench .pane-composite-part > .composite-bar-area > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item::after {
+.monaco-workbench .pane-composite-part > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item::after {
 	right: 1px;
 	margin-right: -2px;
 }
 
 
 .monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:first-of-type::before,
-.monaco-workbench .pane-composite-part > .composite-bar-area > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:first-of-type::before {
+.monaco-workbench .pane-composite-part > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:first-of-type::before {
 	left: 2px;
 	margin-left: -2px;
 }
 
 .monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:last-of-type::after,
-.monaco-workbench .pane-composite-part > .composite-bar-area > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:last-of-type::after {
+.monaco-workbench .pane-composite-part > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:last-of-type::after {
 	right: 2px;
 	margin-right: -2px;
 }
@@ -126,10 +126,10 @@
 .monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.left::after,
 .monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.left::before,
 .monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.right::after,
-.monaco-workbench .pane-composite-part > .composite-bar-area > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.right::before,
-.monaco-workbench .pane-composite-part > .composite-bar-area > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.left::after,
-.monaco-workbench .pane-composite-part > .composite-bar-area > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.left::before,
-.monaco-workbench .pane-composite-part > .composite-bar-area > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.right::after {
+.monaco-workbench .pane-composite-part > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.right::before,
+.monaco-workbench .pane-composite-part > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.left::after,
+.monaco-workbench .pane-composite-part > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.left::before,
+.monaco-workbench .pane-composite-part > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.right::after {
 	transition-delay: 0s;
 }
 
@@ -138,51 +138,51 @@
 .monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:last-of-type.right::after,
 .monaco-workbench .pane-composite-part > .title > .composite-bar-container.dragged-over-head  > .composite-bar > .monaco-action-bar .action-item:first-of-type::before,
 .monaco-workbench .pane-composite-part > .title > .composite-bar-container.dragged-over-tail > .composite-bar > .monaco-action-bar .action-item:last-of-type::after,
-.monaco-workbench .pane-composite-part > .composite-bar-area > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.right + .action-item::before,
-.monaco-workbench .pane-composite-part > .composite-bar-area > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.left::before,
-.monaco-workbench .pane-composite-part > .composite-bar-area > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:last-of-type.right::after,
-.monaco-workbench .pane-composite-part > .composite-bar-area > .composite-bar-container.dragged-over-head  > .composite-bar > .monaco-action-bar .action-item:first-of-type::before,
-.monaco-workbench .pane-composite-part > .composite-bar-area > .composite-bar-container.dragged-over-tail > .composite-bar > .monaco-action-bar .action-item:last-of-type::after {
+.monaco-workbench .pane-composite-part > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.right + .action-item::before,
+.monaco-workbench .pane-composite-part > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.left::before,
+.monaco-workbench .pane-composite-part > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:last-of-type.right::after,
+.monaco-workbench .pane-composite-part > .header-or-footer > .composite-bar-container.dragged-over-head  > .composite-bar > .monaco-action-bar .action-item:first-of-type::before,
+.monaco-workbench .pane-composite-part > .header-or-footer > .composite-bar-container.dragged-over-tail > .composite-bar > .monaco-action-bar .action-item:last-of-type::after {
 	opacity: 1;
 }
 
 .monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item .action-label,
-.monaco-workbench .pane-composite-part > .composite-bar-area > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item .action-label {
+.monaco-workbench .pane-composite-part > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item .action-label {
 	margin-right: 0;
 	padding: 2px;
 }
 
 .monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item .action-label,
-.monaco-workbench .pane-composite-part > .composite-bar-area > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item .action-label {
+.monaco-workbench .pane-composite-part > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item .action-label {
 	border-radius: 0;
 }
 
 .monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:not(.icon) .action-label,
 .monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon .action-label.codicon,
-.monaco-workbench .pane-composite-part > .composite-bar-area > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:not(.icon) .action-label,
-.monaco-workbench .pane-composite-part > .composite-bar-area > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon .action-label.codicon {
+.monaco-workbench .pane-composite-part > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:not(.icon) .action-label,
+.monaco-workbench .pane-composite-part > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon .action-label.codicon {
 	background: none !important;
 }
 
 .monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.checked .action-label,
-.monaco-workbench .pane-composite-part > .composite-bar-area > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.checked .action-label {
+.monaco-workbench .pane-composite-part > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.checked .action-label {
 	margin-right: 0;
 }
 
 .monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .badge,
-.monaco-workbench .pane-composite-part > .composite-bar-area > .composite-bar-container > .composite-bar > .monaco-action-bar .badge {
+.monaco-workbench .pane-composite-part > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .badge {
 	margin-left: 8px;
 	display: flex;
 	align-items: center;
 }
 
 .monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon .badge,
-.monaco-workbench .pane-composite-part > .composite-bar-area > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon .badge {
+.monaco-workbench .pane-composite-part > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon .badge {
 	margin-left: 0px;
 }
 
 .monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .badge .badge-content,
-.monaco-workbench .pane-composite-part > .composite-bar-area > .composite-bar-container > .composite-bar > .monaco-action-bar .badge .badge-content {
+.monaco-workbench .pane-composite-part > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .badge .badge-content {
 	padding: 3px 5px;
 	border-radius: 11px;
 	font-size: 11px;
@@ -197,7 +197,7 @@
 }
 
 .monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon .badge.compact,
-.monaco-workbench .pane-composite-part > .composite-bar-area > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon .badge.compact {
+.monaco-workbench .pane-composite-part > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon .badge.compact {
 	position: absolute;
 	top: 0;
 	bottom: 0;
@@ -210,7 +210,7 @@
 }
 
 .monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon .badge.compact .badge-content,
-.monaco-workbench .pane-composite-part > .composite-bar-area > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon .badge.compact .badge-content {
+.monaco-workbench .pane-composite-part > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon .badge.compact .badge-content {
 	position: absolute;
 	top: 11px;
 	right: 0px;
@@ -225,7 +225,7 @@
 }
 
 .monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon .badge.compact.progress-badge .badge-content::before,
-.monaco-workbench .pane-composite-part > .composite-bar-area > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon .badge.compact.progress-badge .badge-content::before {
+.monaco-workbench .pane-composite-part > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon .badge.compact.progress-badge .badge-content::before {
 	mask-size: 11px;
 	-webkit-mask-size: 11px;
 	top: 3px;
@@ -234,7 +234,7 @@
 
 /* active item indicator */
 .monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item .active-item-indicator,
-.monaco-workbench .pane-composite-part > .composite-bar-area > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item .active-item-indicator {
+.monaco-workbench .pane-composite-part > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item .active-item-indicator {
 	position: absolute;
 	z-index: 1;
 	bottom: 0;
@@ -244,14 +244,14 @@
 }
 
 .monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item .active-item-indicator,
-.monaco-workbench .pane-composite-part > .composite-bar-area > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item .active-item-indicator {
+.monaco-workbench .pane-composite-part > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item .active-item-indicator {
 	top: -4px;
 	left: 10px;
 	width: calc(100% - 20px);
 }
 
 .monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon .active-item-indicator,
-.monaco-workbench .pane-composite-part > .composite-bar-area > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon .active-item-indicator {
+.monaco-workbench .pane-composite-part > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.icon .active-item-indicator {
 	top: 1px;
 	left: 2px;
 	width: calc(100% - 4px);
@@ -259,8 +259,8 @@
 
 .monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.checked .active-item-indicator:before,
 .monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:focus .active-item-indicator:before,
-.monaco-workbench .pane-composite-part > .composite-bar-area > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.checked .active-item-indicator:before,
-.monaco-workbench .pane-composite-part > .composite-bar-area > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:focus .active-item-indicator:before {
+.monaco-workbench .pane-composite-part > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.checked .active-item-indicator:before,
+.monaco-workbench .pane-composite-part > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:focus .active-item-indicator:before {
 	content: "";
 	position: absolute;
 	z-index: 1;
@@ -272,24 +272,24 @@
 }
 
 .monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.clicked:not(.checked):focus .active-item-indicator:before,
-.monaco-workbench .pane-composite-part > .composite-bar-area > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.clicked:not(.checked):focus .active-item-indicator:before {
+.monaco-workbench .pane-composite-part > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.clicked:not(.checked):focus .active-item-indicator:before {
 	border-top-color: transparent !important; /* hides border on clicked state */
 }
 
 .monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:focus .active-item-indicator:before,
-.monaco-workbench .pane-composite-part > .composite-bar-area > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:focus .active-item-indicator:before {
+.monaco-workbench .pane-composite-part > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:focus .active-item-indicator:before {
 	border-top-color: var(--vscode-focusBorder) !important;
 }
 
 .monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.checked .action-label,
 .monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:hover .action-label,
-.monaco-workbench .pane-composite-part > .composite-bar-area > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.checked .action-label,
-.monaco-workbench .pane-composite-part > .composite-bar-area > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:hover .action-label {
+.monaco-workbench .pane-composite-part > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item.checked .action-label,
+.monaco-workbench .pane-composite-part > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:hover .action-label {
 	outline: var(--vscode-contrastActiveBorder, unset) solid 1px !important;
 }
 
 .monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:not(.checked):hover .action-label,
-.monaco-workbench .pane-composite-part > .composite-bar-area > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:not(.checked):hover .action-label {
+.monaco-workbench .pane-composite-part > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:not(.checked):hover .action-label {
 	outline: var(--vscode-contrastActiveBorder, unset) dashed 1px !important;
 }
 

--- a/src/vs/workbench/browser/parts/panel/panelActions.ts
+++ b/src/vs/workbench/browser/parts/panel/panelActions.ts
@@ -8,7 +8,7 @@ import { localize, localize2 } from 'vs/nls';
 import { KeyMod, KeyCode } from 'vs/base/common/keyCodes';
 import { MenuId, MenuRegistry, registerAction2, Action2, IAction2Options } from 'vs/platform/actions/common/actions';
 import { Categories } from 'vs/platform/action/common/actionCommonCategories';
-import { IWorkbenchLayoutService, PanelAlignment, Parts, Position, positionToString } from 'vs/workbench/services/layout/browser/layoutService';
+import { ActivityBarPosition, IWorkbenchLayoutService, LayoutSettings, PanelAlignment, Parts, Position, positionToString } from 'vs/workbench/services/layout/browser/layoutService';
 import { AuxiliaryBarVisibleContext, PanelAlignmentContext, PanelMaximizedContext, PanelPositionContext, PanelVisibleContext } from 'vs/workbench/common/contextkeys';
 import { ContextKeyExpr, ContextKeyExpression } from 'vs/platform/contextkey/common/contextkey';
 import { Codicon } from 'vs/base/common/codicons';
@@ -349,7 +349,12 @@ registerAction2(class extends Action2 {
 			}, {
 				id: MenuId.AuxiliaryBarTitle,
 				group: 'navigation',
-				order: 2
+				order: 2,
+				when: ContextKeyExpr.notEquals(`config.${LayoutSettings.ACTIVITY_BAR_LOCATION}`, ActivityBarPosition.TOP)
+			}, {
+				id: MenuId.AuxiliaryBarHeader,
+				group: 'navigation',
+				when: ContextKeyExpr.equals(`config.${LayoutSettings.ACTIVITY_BAR_LOCATION}`, ActivityBarPosition.TOP)
 			}]
 		});
 	}

--- a/src/vs/workbench/browser/parts/panel/panelPart.ts
+++ b/src/vs/workbench/browser/parts/panel/panelPart.ts
@@ -175,8 +175,12 @@ export class PanelPart extends AbstractPaneCompositePart {
 		super.layout(dimensions.width, dimensions.height, top, left);
 	}
 
-	protected shouldShowCompositeBar(): boolean {
+	protected shouldShowTitleCompositeBar(): boolean {
 		return true;
+	}
+
+	protected shouldShowFooterCompositeBar(): boolean {
+		return false;
 	}
 
 	toJSON(): object {

--- a/src/vs/workbench/browser/parts/panel/panelPart.ts
+++ b/src/vs/workbench/browser/parts/panel/panelPart.ts
@@ -25,7 +25,7 @@ import { IExtensionService } from 'vs/workbench/services/extensions/common/exten
 import { IViewDescriptorService } from 'vs/workbench/common/views';
 import { HoverPosition } from 'vs/base/browser/ui/hover/hoverWidget';
 import { IMenuService, MenuId } from 'vs/platform/actions/common/actions';
-import { AbstractPaneCompositePart } from 'vs/workbench/browser/parts/paneCompositePart';
+import { AbstractPaneCompositePart, CompositeBarPosition } from 'vs/workbench/browser/parts/paneCompositePart';
 import { ICommandService } from 'vs/platform/commands/common/commands';
 import { createAndFillInContextMenuActions } from 'vs/platform/actions/browser/menuEntryActionViewItem';
 import { IPaneCompositeBarOptions } from 'vs/workbench/browser/parts/paneCompositeBar';
@@ -175,12 +175,12 @@ export class PanelPart extends AbstractPaneCompositePart {
 		super.layout(dimensions.width, dimensions.height, top, left);
 	}
 
-	protected shouldShowTitleCompositeBar(): boolean {
+	protected override shouldShowCompositeBar(): boolean {
 		return true;
 	}
 
-	protected shouldShowFooterCompositeBar(): boolean {
-		return false;
+	protected getCompositeBarPosition(): CompositeBarPosition {
+		return CompositeBarPosition.TITLE;
 	}
 
 	toJSON(): object {

--- a/src/vs/workbench/browser/parts/sidebar/sidebarPart.ts
+++ b/src/vs/workbench/browser/parts/sidebar/sidebarPart.ts
@@ -212,7 +212,7 @@ export class SidebarPart extends AbstractPaneCompositePart {
 			case ActivityBarPosition.TOP: return CompositeBarPosition.TOP;
 			case ActivityBarPosition.BOTTOM: return CompositeBarPosition.BOTTOM;
 			case ActivityBarPosition.HIDDEN:
-			case ActivityBarPosition.SIDE:
+			case ActivityBarPosition.DEFAULT: // noop
 			default: return CompositeBarPosition.TITLE;
 		}
 	}
@@ -227,9 +227,9 @@ export class SidebarPart extends AbstractPaneCompositePart {
 	private getRememberedActivityBarVisiblePosition(): ActivityBarPosition {
 		const activityBarPosition = this.storageService.get(LayoutSettings.ACTIVITY_BAR_LOCATION, StorageScope.PROFILE);
 		switch (activityBarPosition) {
-			case ActivityBarPosition.SIDE: return ActivityBarPosition.SIDE;
+			case ActivityBarPosition.TOP: return ActivityBarPosition.TOP;
 			case ActivityBarPosition.BOTTOM: return ActivityBarPosition.BOTTOM;
-			default: return ActivityBarPosition.TOP;
+			default: return ActivityBarPosition.DEFAULT;
 		}
 	}
 

--- a/src/vs/workbench/browser/parts/sidebar/sidebarPart.ts
+++ b/src/vs/workbench/browser/parts/sidebar/sidebarPart.ts
@@ -80,7 +80,7 @@ export class SidebarPart extends AbstractPaneCompositePart {
 	) {
 		super(
 			Parts.SIDEBAR_PART,
-			{ hasTitle: true, borderWidth: () => (this.getColor(SIDE_BAR_BORDER) || this.getColor(contrastBorder)) ? 1 : 0 },
+			{ hasTitle: true, hasFooter: () => this.shouldShowFooterCompositeBar(), borderWidth: () => (this.getColor(SIDE_BAR_BORDER) || this.getColor(contrastBorder)) ? 1 : 0 },
 			SidebarPart.activeViewletSettingsKey,
 			ActiveViewletContext.bindTo(contextKeyService),
 			SidebarFocusContext.bindTo(contextKeyService),
@@ -112,7 +112,10 @@ export class SidebarPart extends AbstractPaneCompositePart {
 	}
 
 	private onDidChangeActivityBarLocation(): void {
+		this.removeCompositeBar();
 		this.updateTitleArea();
+		this.updateFooterArea();
+
 		const id = this.getActiveComposite()?.getId();
 		if (id) {
 			this.onTitleAreaUpdate(id);
@@ -153,7 +156,7 @@ export class SidebarPart extends AbstractPaneCompositePart {
 		return this.layoutService.getSideBarPosition() === SideBarPosition.LEFT ? AnchorAlignment.LEFT : AnchorAlignment.RIGHT;
 	}
 
-	protected override createCompisteBar(): ActivityBarCompositeBar {
+	protected override createCompositeBar(): ActivityBarCompositeBar {
 		return this.instantiationService.createInstance(ActivityBarCompositeBar, this.getCompositeBarOptions(), this.partId, this, false);
 	}
 
@@ -167,7 +170,7 @@ export class SidebarPart extends AbstractPaneCompositePart {
 			orientation: ActionsOrientation.HORIZONTAL,
 			recomputeSizes: true,
 			activityHoverOptions: {
-				position: () => HoverPosition.BELOW,
+				position: () => this.shouldShowFooterCompositeBar() ? HoverPosition.ABOVE : HoverPosition.BELOW,
 			},
 			fillExtraContextMenuActions: actions => {
 				const viewsSubmenuAction = this.getViewsSubmenuAction();
@@ -194,7 +197,16 @@ export class SidebarPart extends AbstractPaneCompositePart {
 	}
 
 	protected shouldShowCompositeBar(): boolean {
+		const activityBarPosition = this.configurationService.getValue<ActivityBarPosition>(LayoutSettings.ACTIVITY_BAR_LOCATION);
+		return activityBarPosition === ActivityBarPosition.TOP || activityBarPosition === ActivityBarPosition.BOTTOM;
+	}
+
+	protected shouldShowTitleCompositeBar(): boolean {
 		return this.configurationService.getValue(LayoutSettings.ACTIVITY_BAR_LOCATION) === ActivityBarPosition.TOP;
+	}
+
+	protected shouldShowFooterCompositeBar(): boolean {
+		return this.configurationService.getValue(LayoutSettings.ACTIVITY_BAR_LOCATION) === ActivityBarPosition.BOTTOM;
 	}
 
 	private shouldShowActivityBar(): boolean {
@@ -215,6 +227,7 @@ export class SidebarPart extends AbstractPaneCompositePart {
 		const activityBarPosition = this.storageService.get(LayoutSettings.ACTIVITY_BAR_LOCATION, StorageScope.PROFILE);
 		switch (activityBarPosition) {
 			case ActivityBarPosition.SIDE: return ActivityBarPosition.SIDE;
+			case ActivityBarPosition.BOTTOM: return ActivityBarPosition.BOTTOM;
 			default: return ActivityBarPosition.TOP;
 		}
 	}

--- a/src/vs/workbench/browser/parts/titlebar/titlebarActions.ts
+++ b/src/vs/workbench/browser/parts/titlebar/titlebarActions.ts
@@ -116,7 +116,8 @@ class ToggleCustomTitleBar extends Action2 {
 								ContextKeyExpr.equals('config.workbench.layoutControl.enabled', false),
 								ContextKeyExpr.equals('config.window.commandCenter', false),
 								ContextKeyExpr.notEquals('config.workbench.editor.editorActionsLocation', 'titleBar'),
-								ContextKeyExpr.notEquals('config.workbench.activityBar.location', 'top')
+								ContextKeyExpr.notEquals('config.workbench.activityBar.location', 'top'),
+								ContextKeyExpr.notEquals('config.workbench.activityBar.location', 'bottom')
 							)?.negate()
 						),
 						IsMainWindowFullscreenContext

--- a/src/vs/workbench/browser/parts/titlebar/titlebarPart.ts
+++ b/src/vs/workbench/browser/parts/titlebar/titlebarPart.ts
@@ -728,7 +728,8 @@ export class BrowserTitlebarPart extends Part implements ITitlebarPart {
 	}
 
 	private get activityActionsEnabled(): boolean {
-		return !this.isAuxiliary && this.configurationService.getValue<ActivityBarPosition>(LayoutSettings.ACTIVITY_BAR_LOCATION) === ActivityBarPosition.TOP;
+		const activityBarPosition = this.configurationService.getValue<ActivityBarPosition>(LayoutSettings.ACTIVITY_BAR_LOCATION);
+		return !this.isAuxiliary && (activityBarPosition === ActivityBarPosition.TOP || activityBarPosition === ActivityBarPosition.BOTTOM);
 	}
 
 	get hasZoomableElements(): boolean {

--- a/src/vs/workbench/browser/parts/views/viewPaneContainer.ts
+++ b/src/vs/workbench/browser/parts/views/viewPaneContainer.ts
@@ -20,7 +20,7 @@ import * as nls from 'vs/nls';
 import { createActionViewItem } from 'vs/platform/actions/browser/menuEntryActionViewItem';
 import { Action2, IAction2Options, IMenuService, ISubmenuItem, MenuId, MenuRegistry, registerAction2 } from 'vs/platform/actions/common/actions';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
-import { ContextKeyExpr, IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
+import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 import { IContextMenuService } from 'vs/platform/contextview/browser/contextView';
 import { IInstantiationService, ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
 import { KeybindingWeight } from 'vs/platform/keybinding/common/keybindingsRegistry';
@@ -39,7 +39,7 @@ import { IAddedViewDescriptorRef, ICustomViewDescriptor, IView, IViewContainerMo
 import { IViewsService } from 'vs/workbench/services/views/common/viewsService';
 import { FocusedViewContext } from 'vs/workbench/common/contextkeys';
 import { IExtensionService } from 'vs/workbench/services/extensions/common/extensions';
-import { ActivityBarPosition, IWorkbenchLayoutService, LayoutSettings, Parts, Position } from 'vs/workbench/services/layout/browser/layoutService';
+import { IWorkbenchLayoutService, LayoutSettings, Position } from 'vs/workbench/services/layout/browser/layoutService';
 import { IBaseActionViewItemOptions } from 'vs/base/browser/ui/actionbar/actionViewItems';
 
 export const ViewsSubMenu = new MenuId('Views');
@@ -47,7 +47,6 @@ MenuRegistry.appendMenuItem(MenuId.ViewContainerTitle, <ISubmenuItem>{
 	submenu: ViewsSubMenu,
 	title: nls.localize('views', "Views"),
 	order: 1,
-	when: ContextKeyExpr.and(ContextKeyExpr.equals('viewContainerLocation', ViewContainerLocationToString(ViewContainerLocation.Sidebar)), ContextKeyExpr.notEquals(`config.${LayoutSettings.ACTIVITY_BAR_LOCATION}`, ActivityBarPosition.TOP)),
 });
 
 export interface IViewPaneContainerOptions extends IPaneViewOptions {
@@ -1091,11 +1090,6 @@ export class ViewPaneContainer extends Component implements IViewPaneContainer {
 	}
 
 	isViewMergedWithContainer(): boolean {
-		const location = this.viewDescriptorService.getViewContainerLocation(this.viewContainer);
-		// Do not merge views in side bar when activity bar is on top because the view title is not shown
-		if (location === ViewContainerLocation.Sidebar && !this.layoutService.isVisible(Parts.ACTIVITYBAR_PART) && this.configurationService.getValue(LayoutSettings.ACTIVITY_BAR_LOCATION) === ActivityBarPosition.TOP) {
-			return false;
-		}
 		if (!(this.options.mergeViewWithContainerWhenSingleView && this.paneItems.length === 1)) {
 			return false;
 		}

--- a/src/vs/workbench/browser/workbench.contribution.ts
+++ b/src/vs/workbench/browser/workbench.contribution.ts
@@ -499,12 +499,12 @@ const registry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Con
 				'type': 'string',
 				'enum': ['side', 'top', 'bottom', 'hidden'],
 				'default': 'side',
-				'markdownDescription': localize({ comment: ['This is the description for a setting'], key: 'activityBarLocation' }, "Controls the location of the Activity Bar. It can either show to the `side` or `top` of the Primary Side Bar or `hidden`."),
+				'markdownDescription': localize({ comment: ['This is the description for a setting'], key: 'activityBarLocation' }, "Controls the location of the Activity Bar. It can either show to the `side` or `top` / `bottom` of the Primary and Secondary Side Bar or `hidden`."),
 				'enumDescriptions': [
-					localize('workbench.activityBar.location.side', "Show the Activity Bar to the side of the Primary Side Bar."),
-					localize('workbench.activityBar.location.top', "Show the Activity Bar on top of the Primary Side Bar."),
-					localize('workbench.activityBar.location.bottom', "Show the Activity Bar at the bottom of the Primary Side Bar."),
-					localize('workbench.activityBar.location.hide', "Hide the Activity Bar.")
+					localize('workbench.activityBar.location.side', "Show the Activity Bar of the Primary Side Bar on the side."),
+					localize('workbench.activityBar.location.top', "Show the Activity Bar on top of the Primary and Secondary Side Bar."),
+					localize('workbench.activityBar.location.bottom', "Show the Activity Bar at the bottom of the Primary and Secondary Side Bar."),
+					localize('workbench.activityBar.location.hide', "Hide the Activity Bar in the Primary and Secondary Side Bar.")
 				],
 			},
 			'workbench.activityBar.iconClickBehavior': {

--- a/src/vs/workbench/browser/workbench.contribution.ts
+++ b/src/vs/workbench/browser/workbench.contribution.ts
@@ -497,11 +497,11 @@ const registry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Con
 			},
 			[LayoutSettings.ACTIVITY_BAR_LOCATION]: {
 				'type': 'string',
-				'enum': ['side', 'top', 'bottom', 'hidden'],
-				'default': 'side',
-				'markdownDescription': localize({ comment: ['This is the description for a setting'], key: 'activityBarLocation' }, "Controls the location of the Activity Bar. It can either show to the `side` or `top` / `bottom` of the Primary and Secondary Side Bar or `hidden`."),
+				'enum': ['default', 'top', 'bottom', 'hidden'],
+				'default': 'default',
+				'markdownDescription': localize({ comment: ['This is the description for a setting'], key: 'activityBarLocation' }, "Controls the location of the Activity Bar. It can either show to the `default` or `top` / `bottom` of the Primary and Secondary Side Bar or `hidden`."),
 				'enumDescriptions': [
-					localize('workbench.activityBar.location.side', "Show the Activity Bar of the Primary Side Bar on the side."),
+					localize('workbench.activityBar.location.default', "Show the Activity Bar of the Primary Side Bar on the side."),
 					localize('workbench.activityBar.location.top', "Show the Activity Bar on top of the Primary and Secondary Side Bar."),
 					localize('workbench.activityBar.location.bottom', "Show the Activity Bar at the bottom of the Primary and Secondary Side Bar."),
 					localize('workbench.activityBar.location.hide', "Hide the Activity Bar in the Primary and Secondary Side Bar.")
@@ -808,6 +808,17 @@ Registry.as<IConfigurationMigrationRegistry>(Extensions.ConfigurationMigration)
 				result.push([LayoutSettings.ACTIVITY_BAR_LOCATION, { value: ActivityBarPosition.HIDDEN }]);
 			}
 			return result;
+		}
+	}]);
+
+Registry.as<IConfigurationMigrationRegistry>(Extensions.ConfigurationMigration)
+	.registerConfigurationMigrations([{
+		key: LayoutSettings.ACTIVITY_BAR_LOCATION, migrateFn: (value: any) => {
+			const results: ConfigurationKeyValuePairs = [];
+			if (value === 'side') {
+				results.push([LayoutSettings.ACTIVITY_BAR_LOCATION, { value: ActivityBarPosition.DEFAULT }]);
+			}
+			return results;
 		}
 	}]);
 

--- a/src/vs/workbench/browser/workbench.contribution.ts
+++ b/src/vs/workbench/browser/workbench.contribution.ts
@@ -497,12 +497,13 @@ const registry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Con
 			},
 			[LayoutSettings.ACTIVITY_BAR_LOCATION]: {
 				'type': 'string',
-				'enum': ['side', 'top', 'hidden'],
+				'enum': ['side', 'top', 'bottom', 'hidden'],
 				'default': 'side',
 				'markdownDescription': localize({ comment: ['This is the description for a setting'], key: 'activityBarLocation' }, "Controls the location of the Activity Bar. It can either show to the `side` or `top` of the Primary Side Bar or `hidden`."),
 				'enumDescriptions': [
 					localize('workbench.activityBar.location.side', "Show the Activity Bar to the side of the Primary Side Bar."),
 					localize('workbench.activityBar.location.top', "Show the Activity Bar on top of the Primary Side Bar."),
+					localize('workbench.activityBar.location.bottom', "Show the Activity Bar at the bottom of the Primary Side Bar."),
 					localize('workbench.activityBar.location.hide', "Hide the Activity Bar.")
 				],
 			},

--- a/src/vs/workbench/services/layout/browser/layoutService.ts
+++ b/src/vs/workbench/services/layout/browser/layoutService.ts
@@ -50,6 +50,7 @@ export const enum LayoutSettings {
 export const enum ActivityBarPosition {
 	SIDE = 'side',
 	TOP = 'top',
+	BOTTOM = 'bottom',
 	HIDDEN = 'hidden'
 }
 
@@ -371,7 +372,8 @@ function isTitleBarEmpty(configurationService: IConfigurationService): boolean {
 	}
 
 	// with the activity bar on top, we should always show
-	if (configurationService.getValue(LayoutSettings.ACTIVITY_BAR_LOCATION) === ActivityBarPosition.TOP) {
+	const activityBarPosition = configurationService.getValue<ActivityBarPosition>(LayoutSettings.ACTIVITY_BAR_LOCATION);
+	if (activityBarPosition === ActivityBarPosition.TOP || activityBarPosition === ActivityBarPosition.BOTTOM) {
 		return false;
 	}
 

--- a/src/vs/workbench/services/layout/browser/layoutService.ts
+++ b/src/vs/workbench/services/layout/browser/layoutService.ts
@@ -48,7 +48,7 @@ export const enum LayoutSettings {
 }
 
 export const enum ActivityBarPosition {
-	SIDE = 'side',
+	DEFAULT = 'default',
 	TOP = 'top',
 	BOTTOM = 'bottom',
 	HIDDEN = 'hidden'


### PR DESCRIPTION
This PR adds a footer area to composite parts and enables the positioning of the activity bar at the bottom. This change enhances the flexibility of the UI layout by allowing users to place the activity bar at the bottom of the screen if desired.

fixes #118692
fixes #195262
fixes #195132
fixes #197216

// cc @bpasero changes in `part.ts`