### PR TITLE
Implement new context key when quickinput is focused and use it for handling `ENTER` and `ESC`

### DIFF
--- a/src/vs/platform/quickinput/browser/quickInput.ts
+++ b/src/vs/platform/quickinput/browser/quickInput.ts
@@ -32,6 +32,11 @@ import { QuickInputList, QuickInputListFocus } from './quickInputList';
 import { quickInputButtonToAction, renderQuickInputDescription } from './quickInputUtils';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { IHoverOptions, IHoverService, WorkbenchHoverDelegate } from 'vs/platform/hover/browser/hover';
+import { ContextKeyExpr, RawContextKey } from 'vs/platform/contextkey/common/contextkey';
+
+export const inQuickInputContextKeyValue = 'inQuickInput';
+export const InQuickInputContextKey = new RawContextKey<boolean>(inQuickInputContextKeyValue, false, localize('inQuickInput', "Whether keyboard focus is inside the quick input control"));
+export const inQuickInputContext = ContextKeyExpr.has(inQuickInputContextKeyValue);
 
 export interface IQuickInputOptions {
 	idPrefix: string;

--- a/src/vs/platform/quickinput/browser/quickInputActions.ts
+++ b/src/vs/platform/quickinput/browser/quickInputActions.ts
@@ -1,0 +1,31 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { KeyCode, KeyMod } from 'vs/base/common/keyCodes';
+import { KeybindingWeight, KeybindingsRegistry } from 'vs/platform/keybinding/common/keybindingsRegistry';
+import { inQuickInputContext } from 'vs/platform/quickinput/browser/quickInput';
+import { IQuickInputService } from 'vs/platform/quickinput/common/quickInput';
+
+KeybindingsRegistry.registerCommandAndKeybindingRule({
+	id: 'workbench.action.quickInput.accept',
+	weight: KeybindingWeight.EditorCore,
+	when: inQuickInputContext,
+	primary: KeyCode.Enter,
+	handler: accessor => {
+		const quickInputService = accessor.get(IQuickInputService);
+		return quickInputService.accept();
+	}
+});
+
+KeybindingsRegistry.registerCommandAndKeybindingRule({
+	id: 'workbench.action.quickInput.cancel',
+	weight: KeybindingWeight.WorkbenchContrib,
+	when: inQuickInputContext,
+	primary: KeyCode.Escape, secondary: [KeyMod.Shift | KeyCode.Escape],
+	handler: accessor => {
+		const quickInputService = accessor.get(IQuickInputService);
+		return quickInputService.cancel();
+	}
+});

--- a/src/vs/platform/quickinput/browser/quickInputService.ts
+++ b/src/vs/platform/quickinput/browser/quickInputService.ts
@@ -98,7 +98,8 @@ export class QuickInputService extends Themable implements IQuickInputService {
 			...options
 		},
 			this.themeService,
-			this.layoutService
+			this.layoutService,
+			this.contextKeyService
 		));
 
 		controller.layout(host.activeContainerDimension, host.activeContainerOffset.quickPickTop);

--- a/src/vs/platform/quickinput/test/browser/quickinput.test.ts
+++ b/src/vs/platform/quickinput/test/browser/quickinput.test.ts
@@ -20,6 +20,7 @@ import { toDisposable } from 'vs/base/common/lifecycle';
 import { mainWindow } from 'vs/base/browser/window';
 import { QuickPick } from 'vs/platform/quickinput/browser/quickInput';
 import { IQuickPickItem } from 'vs/platform/quickinput/common/quickInput';
+import { MockContextKeyService } from 'vs/platform/keybinding/test/common/mockKeybindingService';
 
 // Sets up an `onShow` listener to allow us to wait until the quick pick is shown (useful when triggering an `accept()` right after launching a quick pick)
 // kick this off before you launch the picker and then await the promise returned after you launch the picker.
@@ -45,50 +46,53 @@ suite('QuickInput', () => { // https://github.com/microsoft/vscode/issues/147543
 		mainWindow.document.body.appendChild(fixture);
 		store.add(toDisposable(() => mainWindow.document.body.removeChild(fixture)));
 
-		controller = store.add(new QuickInputController({
-			container: fixture,
-			idPrefix: 'testQuickInput',
-			ignoreFocusOut() { return true; },
-			returnFocus() { },
-			backKeybindingLabel() { return undefined; },
-			setContextKey() { return undefined; },
-			linkOpenerDelegate(content) { },
-			createList: <T>(
-				user: string,
-				container: HTMLElement,
-				delegate: IListVirtualDelegate<T>,
-				renderers: IListRenderer<T, any>[],
-				options: IListOptions<T>,
-			) => new List<T>(user, container, delegate, renderers, options),
-			hoverDelegate: {
-				showHover(options, focus) {
-					return undefined;
+		controller = store.add(new QuickInputController(
+			{
+				container: fixture,
+				idPrefix: 'testQuickInput',
+				ignoreFocusOut() { return true; },
+				returnFocus() { },
+				backKeybindingLabel() { return undefined; },
+				setContextKey() { return undefined; },
+				linkOpenerDelegate(content) { },
+				createList: <T>(
+					user: string,
+					container: HTMLElement,
+					delegate: IListVirtualDelegate<T>,
+					renderers: IListRenderer<T, any>[],
+					options: IListOptions<T>,
+				) => new List<T>(user, container, delegate, renderers, options),
+				hoverDelegate: {
+					showHover(options, focus) {
+						return undefined;
+					},
+					delay: 200
 				},
-				delay: 200
-			},
-			styles: {
-				button: unthemedButtonStyles,
-				countBadge: unthemedCountStyles,
-				inputBox: unthemedInboxStyles,
-				toggle: unthemedToggleStyles,
-				keybindingLabel: unthemedKeybindingLabelOptions,
-				list: unthemedListStyles,
-				progressBar: unthemedProgressBarOptions,
-				widget: {
-					quickInputBackground: undefined,
-					quickInputForeground: undefined,
-					quickInputTitleBackground: undefined,
-					widgetBorder: undefined,
-					widgetShadow: undefined,
-				},
-				pickerGroup: {
-					pickerGroupBorder: undefined,
-					pickerGroupForeground: undefined,
+				styles: {
+					button: unthemedButtonStyles,
+					countBadge: unthemedCountStyles,
+					inputBox: unthemedInboxStyles,
+					toggle: unthemedToggleStyles,
+					keybindingLabel: unthemedKeybindingLabelOptions,
+					list: unthemedListStyles,
+					progressBar: unthemedProgressBarOptions,
+					widget: {
+						quickInputBackground: undefined,
+						quickInputForeground: undefined,
+						quickInputTitleBackground: undefined,
+						widgetBorder: undefined,
+						widgetShadow: undefined,
+					},
+					pickerGroup: {
+						pickerGroupBorder: undefined,
+						pickerGroupForeground: undefined,
+					}
 				}
-			}
-		},
+			},
 			new TestThemeService(),
-			{ activeContainer: fixture } as any));
+			{ activeContainer: fixture } as any,
+			new MockContextKeyService())
+		);
 
 		// initial layout
 		controller.layout({ height: 20, width: 40 }, 0);


### PR DESCRIPTION
Name says it all. If you wanna set accepting the quickpick with, for example, `TAB` instead you can do that now.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
a small part of https://github.com/microsoft/vscode/issues/98479