### PR TITLE
Bug fix: check account id not session id

### DIFF
--- a/extensions/github-authentication/src/github.ts
+++ b/extensions/github-authentication/src/github.ts
@@ -304,11 +304,11 @@ export class GitHubAuthenticationProvider implements vscode.AuthenticationProvid
 			const session = await this.tokenToSession(token, scopes);
 			this.afterSessionLoad(session);
 
-			if (sessions.some(s => s.id !== session.id)) {
+			if (sessions.some(s => s.account.id !== session.account.id)) {
 				const otherAccountsIndexes = new Array<number>();
 				const otherAccountsLabels = new Set<string>();
 				for (let i = 0; i < sessions.length; i++) {
-					if (sessions[i].id !== session.id) {
+					if (sessions[i].account.id !== session.account.id) {
 						otherAccountsIndexes.push(i);
 						otherAccountsLabels.add(sessions[i].account.label);
 					}


### PR DESCRIPTION
This should be checking the account id not the session id... otherwise the user will get a modal every time they go through the login flow.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
