### PR TITLE
Fix Drag And Drop in Activity Bar

### DIFF
--- a/src/vs/workbench/browser/parts/compositeBar.ts
+++ b/src/vs/workbench/browser/parts/compositeBar.ts
@@ -37,6 +37,7 @@ export class CompositeDragAndDrop implements ICompositeDragAndDrop {
 	constructor(
 		private viewDescriptorService: IViewDescriptorService,
 		private targetContainerLocation: ViewContainerLocation,
+		private orientation: ActionsOrientation,
 		private openComposite: (id: string, focus?: boolean) => Promise<IPaneComposite | null>,
 		private moveComposite: (from: string, to: string, before?: Before2D) => void,
 		private getItems: () => ICompositeBarItem[]
@@ -93,7 +94,7 @@ export class CompositeDragAndDrop implements ICompositeDragAndDrop {
 		}
 
 		const items = this.getItems();
-		const before = this.targetContainerLocation === ViewContainerLocation.Panel ? before2d?.horizontallyBefore : before2d?.verticallyBefore;
+		const before = this.orientation === ActionsOrientation.HORIZONTAL ? before2d?.horizontallyBefore : before2d?.verticallyBefore;
 		return items.filter(item => item.visible).findIndex(item => item.id === targetId) + (before ? 0 : 1);
 	}
 

--- a/src/vs/workbench/browser/parts/paneCompositeBar.ts
+++ b/src/vs/workbench/browser/parts/paneCompositeBar.ts
@@ -111,7 +111,7 @@ export class PaneCompositeBar extends Disposable {
 			? ViewContainerLocation.Panel : paneCompositePart.partId === Parts.AUXILIARYBAR_PART
 				? ViewContainerLocation.AuxiliaryBar : ViewContainerLocation.Sidebar;
 
-		this.dndHandler = new CompositeDragAndDrop(this.viewDescriptorService, this.location,
+		this.dndHandler = new CompositeDragAndDrop(this.viewDescriptorService, this.location, this.options.orientation,
 			async (id: string, focus?: boolean) => { return await this.paneCompositePart.openPaneComposite(id, focus) ?? null; },
 			(from: string, to: string, before?: Before2D) => this.compositeBar.move(from, to, this.options.orientation === ActionsOrientation.VERTICAL ? before?.verticallyBefore : before?.horizontallyBefore),
 			() => this.compositeBar.getCompositeBarItems(),


### PR DESCRIPTION
This PR fixes the issue where the drag and drop functionality in the activity bar was incorrect when the activity bar was not in the side bar. The fix ensures that the correct orientation is considered when performing drag and drop operations.

Fixes #206878