### PR TITLE
Fix Activity Bar Icon Clickability in Fullscreen

### DIFF
--- a/src/vs/workbench/browser/parts/media/paneCompositePart.css
+++ b/src/vs/workbench/browser/parts/media/paneCompositePart.css
@@ -66,7 +66,7 @@
 
 .monaco-workbench .pane-composite-part > .title > .composite-bar-container >.composite-bar > .monaco-action-bar .action-item.icon,
 .monaco-workbench .pane-composite-part > .header-or-footer > .composite-bar-container >.composite-bar > .monaco-action-bar .action-item.icon {
-	height: 24px;
+	height: 35px; /* matches height of composite container */
 	padding: 0 5px;
 }
 


### PR DESCRIPTION
This PR addresses the issue where the top/bottom of the activity bar icon was not clickable in fullscreen mode. The CSS has been updated to match the height of the composite container, improving the clickability of the icon.

Fixes #204688