### PR TITLE
Render final line number for interval setting

### DIFF
--- a/src/vs/editor/browser/viewParts/lineNumbers/lineNumbers.ts
+++ b/src/vs/editor/browser/viewParts/lineNumbers/lineNumbers.ts
@@ -131,6 +131,10 @@ export class LineNumbersOverlay extends DynamicViewOverlay {
 			if (modelLineNumber % 10 === 0) {
 				return String(modelLineNumber);
 			}
+			const finalLineNumber = this._context.viewModel.getLineCount();
+			if (modelLineNumber === finalLineNumber) {
+				return String(modelLineNumber);
+			}
 			return '';
 		}
 


### PR DESCRIPTION
This will always render the final line number when `"editor.lineNumbers": "interval"` is set.

![finalLineNumber](https://github.com/microsoft/vscode/assets/15267120/289ee755-19d7-433c-a19c-b5d828513202)

This will close #207179
