### PR TITLE
Relocate nb stickyscroll toggle action, fix toggle verbage, more generic run section args

### DIFF
--- a/src/vs/workbench/browser/parts/editor/breadcrumbsControl.ts
+++ b/src/vs/workbench/browser/parts/editor/breadcrumbsControl.ts
@@ -611,7 +611,7 @@ registerAction2(class ToggleBreadcrumb extends Action2 {
 			category: Categories.View,
 			toggled: {
 				condition: ContextKeyExpr.equals('config.breadcrumbs.enabled', true),
-				title: localize('cmd.toggle2', "Breadcrumbs"),
+				title: localize('cmd.toggle2', "Toggle Breadcrumbs"),
 				mnemonicTitle: localize({ key: 'miBreadcrumbs2', comment: ['&& denotes a mnemonic'] }, "Toggle &&Breadcrumbs")
 			},
 			menu: [

--- a/src/vs/workbench/contrib/notebook/browser/controller/layoutActions.ts
+++ b/src/vs/workbench/contrib/notebook/browser/controller/layoutActions.ts
@@ -6,9 +6,10 @@
 import { Codicon } from 'vs/base/common/codicons';
 import { URI, UriComponents } from 'vs/base/common/uri';
 import { localize, localize2 } from 'vs/nls';
+import { Categories } from 'vs/platform/action/common/actionCommonCategories';
 import { Action2, MenuId, MenuRegistry, registerAction2 } from 'vs/platform/actions/common/actions';
 import { ICommandService } from 'vs/platform/commands/common/commands';
-import { ConfigurationTarget } from 'vs/platform/configuration/common/configuration';
+import { ConfigurationTarget, IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { ContextKeyExpr } from 'vs/platform/contextkey/common/contextkey';
 import { ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
 import { IQuickInputService, IQuickPickItem } from 'vs/platform/quickinput/common/quickInput';
@@ -240,5 +241,37 @@ registerAction2(class NotebookWebviewResetAction extends Action2 {
 
 			editor.getInnerWebview()?.reload();
 		}
+	}
+});
+
+registerAction2(class ToggleNotebookStickyScroll extends Action2 {
+	constructor() {
+		super({
+			id: 'notebook.action.toggleNotebookStickyScroll',
+			title: {
+				...localize2('toggleStickyScroll', "Toggle Notebook Sticky Scroll"),
+				mnemonicTitle: localize({ key: 'mitoggleNotebookStickyScroll', comment: ['&& denotes a mnemonic'] }, "&&Toggle Notebook Sticky Scroll"),
+			},
+			category: Categories.View,
+			toggled: {
+				condition: ContextKeyExpr.equals('config.notebook.stickyScroll.enabled', true),
+				title: localize('notebookStickyScroll', "Toggle Notebook Sticky Scroll"),
+				mnemonicTitle: localize({ key: 'mitoggleNotebookStickyScroll', comment: ['&& denotes a mnemonic'] }, "&&Toggle Notebook Sticky Scroll"),
+			},
+			menu: [
+				{ id: MenuId.CommandPalette },
+				{
+					id: MenuId.NotebookStickyScrollContext,
+					group: 'notebookView',
+					order: 2
+				}
+			]
+		});
+	}
+
+	override async run(accessor: ServicesAccessor): Promise<void> {
+		const configurationService = accessor.get(IConfigurationService);
+		const newValue = !configurationService.getValue('notebook.stickyScroll.enabled');
+		return configurationService.updateValue('notebook.stickyScroll.enabled', newValue);
 	}
 });


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Takes care of a couple nits:
- toggle nb sticky scroll is now in `layoutActions.ts`
- toggle verbage now says "Toggle *feature*" for both breadcrumbs and notebook stickyscroll
- more generic args for run section in stickyscroll