### PR TITLE
allow tab focus to move to changes/staged changes, providing number of changed files to screen reader users

### DIFF
--- a/src/vs/workbench/contrib/scm/browser/scmViewPane.ts
+++ b/src/vs/workbench/contrib/scm/browser/scmViewPane.ts
@@ -462,6 +462,7 @@ class ResourceGroupRenderer implements ICompressibleTreeRenderer<ISCMResourceGro
 		(container.parentElement!.parentElement!.querySelector('.monaco-tl-twistie')! as HTMLElement).classList.add('force-twistie');
 
 		const element = append(container, $('.resource-group'));
+		element.tabIndex = 0;
 		const name = append(element, $('.name'));
 		const actionsContainer = append(element, $('.actions'));
 		const actionBar = new ActionBar(actionsContainer, { actionViewItemProvider: this.actionViewItemProvider });
@@ -1014,6 +1015,7 @@ class HistoryItemChangeRenderer implements ICompressibleTreeRenderer<SCMHistoryI
 	renderTemplate(container: HTMLElement): HistoryItemChangeTemplate {
 		const element = append(container, $('.change'));
 		const name = append(element, $('.name'));
+		name.tabIndex = 0;
 		const fileLabel = this.labels.create(name, { supportDescriptionHighlights: true, supportHighlights: true });
 		const decorationIcon = append(element, $('.decoration-icon'));
 

--- a/src/vs/workbench/contrib/scm/browser/scmViewPane.ts
+++ b/src/vs/workbench/contrib/scm/browser/scmViewPane.ts
@@ -1015,7 +1015,6 @@ class HistoryItemChangeRenderer implements ICompressibleTreeRenderer<SCMHistoryI
 	renderTemplate(container: HTMLElement): HistoryItemChangeTemplate {
 		const element = append(container, $('.change'));
 		const name = append(element, $('.name'));
-		name.tabIndex = 0;
 		const fileLabel = this.labels.create(name, { supportDescriptionHighlights: true, supportHighlights: true });
 		const decorationIcon = append(element, $('.decoration-icon'));
 


### PR DESCRIPTION
Part of #203577

This way, the screen reader user can hear the number of changed/staged files immediately.

@lszomoru , JooYoung also requested commands to focus the changed/staged change trees. Could you pls provide a code pointer to do this and I can look into it? 🙏🏼 

https://github.com/microsoft/vscode/assets/29464607/bd972387-8486-4134-88c0-c7d519c216e9

