### PR TITLE
Pass references on code block document as metadata

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatListRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatListRenderer.ts
@@ -870,8 +870,13 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 						return $('div');
 					}
 				} else {
+					if (!isRequestVM(element) && !isResponseVM(element)) {
+						console.error('Trying to render code block in welcome', element.id, index);
+						return $('div');
+					}
+
 					const sessionId = isResponseVM(element) || isRequestVM(element) ? element.sessionId : '';
-					const blockModel = this.codeBlockModelCollection.getOrCreate(sessionId, element.id, index);
+					const blockModel = this.codeBlockModelCollection.get(sessionId, element, index);
 					if (!blockModel) {
 						console.error('Trying to render code block without model', element.id, index);
 						return $('div');

--- a/src/vs/workbench/contrib/chat/common/chatViewModel.ts
+++ b/src/vs/workbench/contrib/chat/common/chatViewModel.ts
@@ -266,7 +266,7 @@ export class ChatViewModel extends Disposable implements IChatViewModel {
 		renderer.code = (value, languageId) => {
 			languageId ??= '';
 			const newText = this.fixCodeText(value, languageId);
-			const textModel = this.codeBlockModelCollection.getOrCreate(this._model.sessionId, model.id, codeBlockIndex++);
+			const textModel = this.codeBlockModelCollection.getOrCreate(this._model.sessionId, model, codeBlockIndex++);
 			textModel.then(ref => {
 				const model = ref.object.textEditorModel;
 				if (languageId) {


### PR DESCRIPTION
Pass along code block references in the fragment of code block documents

This allows extensions to look up the references for a given code block. We need this information to implement various IntelliSense features

cc @sbatten @roblourens 