### PR TITLE
Make inline chat history logic reusable, implement history in terminal chat

### DIFF
--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatHistory.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatHistory.ts
@@ -1,0 +1,64 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IStorageService, StorageScope, StorageTarget } from 'vs/platform/storage/common/storage';
+
+export class InlineChatHistory {
+	private _promptHistory: string[] = [];
+	private _historyOffset: number = -1;
+	private _historyCandidate: string = '';
+
+	constructor(
+		private readonly _storageKey: string,
+		@IStorageService private readonly _storageService: IStorageService,
+	) {
+		this._promptHistory = JSON.parse(_storageService.get(this._storageKey, StorageScope.PROFILE, '[]'));
+	}
+
+	update(prompt: string): void {
+		const idx = this._promptHistory.indexOf(prompt);
+		if (idx >= 0) {
+			this._promptHistory.splice(idx, 1);
+		}
+		this._promptHistory.unshift(prompt);
+		this._historyOffset = -1;
+		this._historyCandidate = '';
+		this._storageService.store(this._storageKey, JSON.stringify(this._promptHistory), StorageScope.PROFILE, StorageTarget.USER);
+	}
+
+	clearCandidate() {
+		this._historyOffset = -1;
+		this._historyCandidate = '';
+	}
+
+	populateHistory(currentValue: string, up: boolean): undefined | string {
+		const len = this._promptHistory.length;
+		if (len === 0) {
+			return undefined;
+		}
+
+		if (this._historyOffset === -1) {
+			// remember the current value
+			this._historyCandidate = currentValue;
+		}
+
+		const newIdx = this._historyOffset + (up ? 1 : -1);
+		if (newIdx >= len) {
+			// reached the end
+			return undefined;
+		}
+
+		let entry: string;
+		if (newIdx < 0) {
+			entry = this._historyCandidate;
+			this._historyOffset = -1;
+		} else {
+			entry = this._promptHistory[newIdx];
+			this._historyOffset = newIdx;
+		}
+
+		return entry;
+	}
+}

--- a/src/vs/workbench/contrib/terminalContrib/chat/browser/terminalChat.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chat/browser/terminalChat.ts
@@ -21,6 +21,8 @@ export const enum TerminalChatCommandId {
 	RunCommand = 'workbench.action.terminal.chat.runCommand',
 	InsertCommand = 'workbench.action.terminal.chat.insertCommand',
 	ViewInChat = 'workbench.action.terminal.chat.viewInChat',
+	PreviousFromHistory = 'workbench.action.terminal.chat.previousFromHistory',
+	NextFromHistory = 'workbench.action.terminal.chat.nextFromHistory',
 }
 
 export const MENU_TERMINAL_CHAT_INPUT = MenuId.for('terminalChatInput');

--- a/src/vs/workbench/contrib/terminalContrib/chat/browser/terminalChatActions.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chat/browser/terminalChatActions.ts
@@ -40,7 +40,7 @@ registerActiveXtermAction({
 			return;
 		}
 		const contr = TerminalChatController.activeChatWidget || TerminalChatController.get(activeInstance);
-		contr?.chatWidget?.reveal();
+		contr?.reveal();
 	}
 });
 
@@ -368,3 +368,42 @@ registerActiveXtermAction({
 	}
 });
 
+registerActiveXtermAction({
+	id: TerminalChatCommandId.PreviousFromHistory,
+	title: localize2('previousFromHistory', 'Previous From History'),
+	precondition: ContextKeyExpr.and(
+		ContextKeyExpr.has(`config.${TerminalSettingId.ExperimentalInlineChat}`),
+		TerminalChatContextKeys.responseContainsCodeBlock.notEqualsTo(undefined)
+	),
+	keybinding: {
+		weight: KeybindingWeight.EditorCore + 10, // win against core_command
+		primary: KeyCode.UpArrow,
+	},
+	run: (_xterm, _accessor, activeInstance) => {
+		if (isDetachedTerminalInstance(activeInstance)) {
+			return;
+		}
+		const contr = TerminalChatController.activeChatWidget || TerminalChatController.get(activeInstance);
+		contr?.populateHistory(true);
+	}
+});
+
+registerActiveXtermAction({
+	id: TerminalChatCommandId.NextFromHistory,
+	title: localize2('nextFromHistory', 'Next From History'),
+	precondition: ContextKeyExpr.and(
+		ContextKeyExpr.has(`config.${TerminalSettingId.ExperimentalInlineChat}`),
+		TerminalChatContextKeys.responseContainsCodeBlock.notEqualsTo(undefined)
+	),
+	keybinding: {
+		weight: KeybindingWeight.EditorCore + 10, // win against core_command
+		primary: KeyCode.DownArrow,
+	},
+	run: (_xterm, _accessor, activeInstance) => {
+		if (isDetachedTerminalInstance(activeInstance)) {
+			return;
+		}
+		const contr = TerminalChatController.activeChatWidget || TerminalChatController.get(activeInstance);
+		contr?.populateHistory(false);
+	}
+});


### PR DESCRIPTION
Fixes microsoft/vscode-copilot#4261

Editor:

![Recording 2024-03-12 at 07 40 19](https://github.com/microsoft/vscode/assets/2193314/cf79ed43-3d82-4e73-ad69-4e9953cf7856)

Terminal:

![Recording 2024-03-12 at 07 40 52](https://github.com/microsoft/vscode/assets/2193314/09afc1b0-e7e5-4f22-bd69-a15fb6307ae6)
