### PR TITLE
Navigating via "Go to Symbol in Editor..." does not add those navigated locations to the cursor navigation histories. (fix #207484)

### DIFF
--- a/src/vs/editor/contrib/quickAccess/browser/editorNavigationQuickAccess.ts
+++ b/src/vs/editor/contrib/quickAccess/browser/editorNavigationQuickAccess.ts
@@ -16,6 +16,7 @@ import { IQuickAccessProvider } from 'vs/platform/quickinput/common/quickAccess'
 import { IKeyMods, IQuickPick, IQuickPickItem } from 'vs/platform/quickinput/common/quickInput';
 import { themeColorFromId } from 'vs/platform/theme/common/themeService';
 import { status } from 'vs/base/browser/ui/aria/aria';
+import { TextEditorSelectionSource } from 'vs/platform/editor/common/editor';
 
 interface IEditorLineDecoration {
 	readonly rangeHighlightId: string;
@@ -141,7 +142,7 @@ export abstract class AbstractEditorNavigationQuickAccessProvider implements IQu
 	protected abstract provideWithoutTextEditor(picker: IQuickPick<IQuickPickItem>, token: CancellationToken): IDisposable;
 
 	protected gotoLocation({ editor }: IQuickAccessTextEditorContext, options: { range: IRange; keyMods: IKeyMods; forceSideBySide?: boolean; preserveFocus?: boolean }): void {
-		editor.setSelection(options.range);
+		editor.setSelection(options.range, TextEditorSelectionSource.JUMP);
 		editor.revealRangeInCenter(options.range, ScrollType.Smooth);
 		if (!options.preserveFocus) {
 			editor.focus();


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
