### PR TITLE
Fix missing class in inlinesuggest toolbar in Monaco-Editor causing CSS variables to be ineffective

### DIFF
--- a/src/vs/base/browser/ui/contextview/contextview.ts
+++ b/src/vs/base/browser/ui/contextview/contextview.ts
@@ -222,7 +222,7 @@ export class ContextView extends Disposable {
 
 		// Show static box
 		DOM.clearNode(this.view);
-		this.view.className = 'context-view';
+		this.view.className = 'context-view monaco-component';
 		this.view.style.top = '0px';
 		this.view.style.left = '0px';
 		this.view.style.zIndex = `${2575 + (delegate.layer ?? 0)}`;


### PR DESCRIPTION
This bug is about monaco-editor [issue](https://github.com/microsoft/monaco-editor/issues/3984).
I want to fix this bug in monaco-edtior project and I read its contribution guide and I find it builds from vscode,so I make a pr here.
**current monaco editor**（error style）：
![image](https://github.com/microsoft/vscode/assets/91405589/d9584c5d-ebd0-413a-bc13-31cd52b73360)
**my fix of monaco editor**（right style）
![image](https://github.com/microsoft/vscode/assets/91405589/99c1f4bd-b67a-496e-9d15-bd1c21e0f8c7)
**the reason of my fix**：
the action bar lose css color variables which are from other css class，so I add  a `monaco-component` class to the context-view element
![image](https://github.com/microsoft/vscode/assets/91405589/70b0c258-02c3-4729-9754-5b38d89b0456)
![image](https://github.com/microsoft/vscode/assets/91405589/ff9fdccb-24cf-4b52-8532-baf6f8cc195e)
**why vscode is ok**
vscode seems to use electron-menu and it dont need css style to make it looks right
<img width="842" alt="image" src="https://github.com/microsoft/vscode/assets/91405589/7961b670-4fd4-4c90-aaf3-855fcce83152">

