### PR TITLE
Polish items for tree-based quick pick

### DIFF
--- a/src/vs/platform/quickinput/browser/media/quickInput.css
+++ b/src/vs/platform/quickinput/browser/media/quickInput.css
@@ -163,6 +163,9 @@
 	overflow: hidden;
 	max-height: calc(20 * 22px);
 	padding-bottom: 5px;
+	/* match border radius of quick input widget */
+	border-top-left-radius: 5px;
+	border-top-right-radius: 5px;
 }
 
 .quick-input-list .quick-input-list-entry {
@@ -263,6 +266,9 @@
 
 .quick-input-list .monaco-highlighted-label .highlight {
 	font-weight: bold;
+	/* preserve list-like styling instead of tree-like styling */
+	color: var(--vscode-list-focusHighlightForeground) !important;
+	background-color: transparent;
 }
 
 .quick-input-list .quick-input-list-entry .quick-input-list-separator {
@@ -298,7 +304,8 @@
 
 .quick-input-list .quick-input-list-entry .quick-input-list-entry-action-bar .action-label.always-visible,
 .quick-input-list .quick-input-list-entry:hover .quick-input-list-entry-action-bar .action-label,
-.quick-input-list .monaco-list-row.focused .quick-input-list-entry-action-bar .action-label {
+.quick-input-list .monaco-list-row.focused .quick-input-list-entry-action-bar .action-label,
+.quick-input-list .monaco-list-row.passive-focused .quick-input-list-entry-action-bar .action-label {
 	display: flex;
 }
 
@@ -320,9 +327,4 @@
 /* Hide border when the item becomes the sticky one */
 .quick-input-list .monaco-tree-sticky-row .quick-input-list-entry.quick-input-list-separator-as-item.quick-input-list-separator-border {
 	border-top-style: none;
-}
-
-/* TODO: This seems to be the best way to do this... is there a better way? */
-.quick-input-list .monaco-tl-twistie {
-	display: none !important;
 }

--- a/src/vs/platform/quickinput/browser/quickInputTree.ts
+++ b/src/vs/platform/quickinput/browser/quickInputTree.ts
@@ -469,6 +469,11 @@ class QuickInputListRenderer implements ITreeRenderer<IQuickPickElement, void, I
 			data.entry.classList.remove('has-actions');
 		}
 	}
+	renderTwistie(element: IQuickPickElement, twistieElement: HTMLElement): boolean {
+		// Force the twistie to be hidden
+		twistieElement.setAttribute('style', 'display:none !important');
+		return false;
+	}
 	disposeElement?(_element: ITreeNode<IQuickPickElement, void>, _index: number, data: IQuickInputItemTemplateData): void {
 		data.toDisposeElement.clear();
 		data.actionBar.clear();
@@ -663,6 +668,7 @@ export class QuickInputTree extends Disposable {
 		this._registerOnElementChecked();
 		this._registerOnContextMenu();
 		this._registerHoverListeners();
+		this._registerSelectionChangeListener();
 	}
 
 	private _registerOnKeyDown() {
@@ -773,6 +779,21 @@ export class QuickInputTree extends Disposable {
 				return;
 			}
 			delayer.cancel();
+		}));
+	}
+
+	private _registerSelectionChangeListener() {
+		// When the user selects a separator, the separator will move to the top and focus will be
+		// set to the first element after the separator.
+		this._register(this._tree.onDidChangeSelection(e => {
+			const elementsWithoutSeparators = e.elements.filter((e): e is QuickPickItemElement => e instanceof QuickPickItemElement);
+			if (elementsWithoutSeparators.length !== e.elements.length) {
+				if (e.elements.length === 1 && e.elements[0] instanceof QuickPickSeparatorElement) {
+					this._tree.setFocus([e.elements[0].children[0]]);
+					this._tree.reveal(e.elements[0], 0);
+				}
+				this._tree.setSelection(elementsWithoutSeparators);
+			}
 		}));
 	}
 


### PR DESCRIPTION
* Make sure action bar is visible in sticky (change needed after https://github.com/microsoft/vscode/issues/207657)
* Go back to list style of highlights (https://github.com/microsoft/vscode/issues/207744)
* When you click on a separator, we scroll it up to the top of the list and focus the first item
* Hide the twistie is a programmatic way instead

Fixes https://github.com/microsoft/vscode/issues/207744
Fixes https://github.com/microsoft/vscode/issues/207190
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
