### PR TITLE
Fix double registration of menu on web

### DIFF
--- a/src/vs/workbench/browser/parts/sidebar/sidebarPart.ts
+++ b/src/vs/workbench/browser/parts/sidebar/sidebarPart.ts
@@ -112,13 +112,19 @@ export class SidebarPart extends AbstractPaneCompositePart {
 	}
 
 	private onDidChangeActivityBarLocation(): void {
+		this.acitivityBarPart.hide();
+
 		this.updateCompositeBar();
 
 		const id = this.getActiveComposite()?.getId();
 		if (id) {
 			this.onTitleAreaUpdate(id);
 		}
-		this.updateActivityBarVisiblity();
+
+		if (this.shouldShowActivityBar()) {
+			this.acitivityBarPart.show();
+		}
+
 		this.rememberActivityBarVisiblePosition();
 	}
 
@@ -230,14 +236,6 @@ export class SidebarPart extends AbstractPaneCompositePart {
 			case ActivityBarPosition.TOP: return ActivityBarPosition.TOP;
 			case ActivityBarPosition.BOTTOM: return ActivityBarPosition.BOTTOM;
 			default: return ActivityBarPosition.DEFAULT;
-		}
-	}
-
-	private updateActivityBarVisiblity(): void {
-		if (this.shouldShowActivityBar()) {
-			this.acitivityBarPart.show();
-		} else {
-			this.acitivityBarPart.hide();
 		}
 	}
 


### PR DESCRIPTION
This PR addresses an issue where the menu was being registered twice on the web. The changes ensure that the activity bar visibility is updated correctly, preventing the double registration of the menu.
#118692