### PR TITLE
Add single view pane container title support

### DIFF
--- a/src/vs/workbench/browser/parts/views/viewPane.ts
+++ b/src/vs/workbench/browser/parts/views/viewPane.ts
@@ -66,6 +66,8 @@ export interface IViewPaneOptions extends IPaneOptions {
 	readonly showActions?: ViewPaneShowActions;
 	readonly titleMenuId?: MenuId;
 	readonly donotForwardArgs?: boolean;
+	// The title of the container pane when it is merged with the view container
+	readonly singleViewPaneContainerTitle?: string;
 }
 
 export interface IFilterViewPaneOptions extends IViewPaneOptions {
@@ -333,6 +335,11 @@ export abstract class ViewPane extends Pane implements IView {
 		return this._titleDescription;
 	}
 
+	private _singleViewPaneContainerTitle: string | undefined;
+	public get singleViewPaneContainerTitle(): string | undefined {
+		return this._singleViewPaneContainerTitle;
+	}
+
 	readonly menuActions: CompositeMenuActions;
 
 	private progressBar!: ProgressBar;
@@ -369,6 +376,7 @@ export abstract class ViewPane extends Pane implements IView {
 		this.id = options.id;
 		this._title = options.title;
 		this._titleDescription = options.titleDescription;
+		this._singleViewPaneContainerTitle = options.singleViewPaneContainerTitle;
 		this.showActions = options.showActions ?? ViewPaneShowActions.Default;
 
 		this.scopedContextKeyService = this._register(contextKeyService.createScoped(this.element));

--- a/src/vs/workbench/browser/parts/views/viewPaneContainer.ts
+++ b/src/vs/workbench/browser/parts/views/viewPaneContainer.ts
@@ -559,10 +559,16 @@ export class ViewPaneContainer extends Component implements IViewPaneContainer {
 		const containerTitle = this.viewContainerModel.title;
 
 		if (this.isViewMergedWithContainer()) {
+			const singleViewPaneContainerTitle = this.paneItems[0].pane.singleViewPaneContainerTitle;
+			if (singleViewPaneContainerTitle) {
+				return singleViewPaneContainerTitle;
+			}
+
 			const paneItemTitle = this.paneItems[0].pane.title;
 			if (containerTitle === paneItemTitle) {
-				return this.paneItems[0].pane.title;
+				return paneItemTitle;
 			}
+
 			return paneItemTitle ? `${containerTitle}: ${paneItemTitle}` : containerTitle;
 		}
 
@@ -779,7 +785,8 @@ export class ViewPaneContainer extends Component implements IViewPaneContainer {
 					id: viewDescriptor.id,
 					title: viewDescriptor.name.value,
 					fromExtensionId: (viewDescriptor as Partial<ICustomViewDescriptor>).extensionId,
-					expanded: !collapsed
+					expanded: !collapsed,
+					singleViewPaneContainerTitle: viewDescriptor.singleViewPaneContainerTitle,
 				});
 
 			pane.render();

--- a/src/vs/workbench/common/views.ts
+++ b/src/vs/workbench/common/views.ts
@@ -284,6 +284,8 @@ export interface IViewDescriptor {
 
 	readonly containerTitle?: string;
 
+	readonly singleViewPaneContainerTitle?: string;
+
 	// Applies only to newly created views
 	readonly hideByDefault?: boolean;
 

--- a/src/vs/workbench/contrib/chat/browser/chatContributionServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContributionServiceImpl.ts
@@ -280,6 +280,7 @@ export class ChatExtensionPointHandler implements IWorkbenchContribution {
 			id: viewId,
 			containerIcon: this._viewContainer.icon,
 			containerTitle: this._viewContainer.title.value,
+			singleViewPaneContainerTitle: this._viewContainer.title.value,
 			name: { value: providerDescriptor.label, original: providerDescriptor.label },
 			canToggleVisibility: false,
 			canMoveView: true,


### PR DESCRIPTION
This PR introduces the `singleViewPaneContainerTitle` property to the `IViewPaneOptions` and `IViewDescriptor` interfaces. This allows for a custom title to be set for a container pane when it is merged with the view container. 
fixes https://github.com/microsoft/vscode-copilot/issues/4493