### PR TITLE
Fix Scroll Lock Issue in Active Editor

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
@@ -1025,9 +1025,8 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditorD
 		}));
 
 		this._register(this._list.onDidScroll((e) => {
-			this._onDidScroll.fire();
-
 			if (e.scrollTop !== e.oldScrollTop) {
+				this._onDidScroll.fire();
 				this.clearActiveCellWidgets();
 			}
 		}));


### PR DESCRIPTION
This PR addresses the issue where the active editor could not scroll when scroll locking was enabled and the notebook in the side editor was scrolled down. 

@rebornix I changed the notebook widget to only fire a scroll event if there actually was scrolling. If you think this could cause a problem we should at least forward the the `scrollEvent` from the list so that the consumer of the event can figure out if there actually has been scrolling.

Fixes #207818