### PR TITLE
Allow specialized errors to trigger different messages for inline chat

### DIFF
--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatController.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatController.ts
@@ -278,7 +278,7 @@ export class InlineChatController implements IEditorContribution {
 		assertType(this._session === undefined);
 		assertType(this._editor.hasModel());
 
-		let session: Session | undefined = options.existingSession;
+		let session: Session | string | undefined = options.existingSession;
 
 
 		let initPosition: Position | undefined;
@@ -315,7 +315,7 @@ export class InlineChatController implements IEditorContribution {
 			msgListener.dispose();
 
 			if (createSessionCts.token.isCancellationRequested) {
-				if (session) {
+				if (session && typeof session !== 'string') {
 					this._inlineChatSessionService.releaseSession(session);
 				}
 				return State.CANCEL;
@@ -325,9 +325,9 @@ export class InlineChatController implements IEditorContribution {
 		delete options.initialRange;
 		delete options.existingSession;
 
-		if (!session) {
-			MessageController.get(this._editor)?.showMessage(localize('create.fail', "Failed to start editor chat"), widgetPosition);
-			this._log('Failed to start editor chat');
+		if (typeof session === 'string') {
+			MessageController.get(this._editor)?.showMessage(session, widgetPosition);
+			this._log(session);
 			return State.CANCEL;
 		}
 

--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatSessionService.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatSessionService.ts
@@ -43,7 +43,7 @@ export interface IInlineChatSessionService {
 	onDidStashSession: Event<IInlineChatSessionEvent>;
 	onDidEndSession: Event<IInlineChatSessionEndEvent>;
 
-	createSession(editor: IActiveCodeEditor, options: { editMode: EditMode; wholeRange?: IRange }, token: CancellationToken): Promise<Session | undefined>;
+	createSession(editor: IActiveCodeEditor, options: { editMode: EditMode; wholeRange?: IRange }, token: CancellationToken): Promise<Session | string>;
 
 	moveSession(session: Session, newEditor: ICodeEditor): void;
 

--- a/src/vs/workbench/contrib/inlineChat/test/browser/inlineChatSession.test.ts
+++ b/src/vs/workbench/contrib/inlineChat/test/browser/inlineChatSession.test.ts
@@ -37,12 +37,21 @@ import { EditMode, IInlineChatEditResponse, IInlineChatService, InlineChatRespon
 import { ITextFileService } from 'vs/workbench/services/textfile/common/textfiles';
 import { workbenchInstantiationService } from 'vs/workbench/test/browser/workbenchTestServices';
 import { CancellationToken } from 'vs/base/common/cancellation';
-import { assertType } from 'vs/base/common/types';
+import { assertType, isString } from 'vs/base/common/types';
 import { InlineChatServiceImpl } from 'vs/workbench/contrib/inlineChat/common/inlineChatServiceImpl';
 import { EditOperation } from 'vs/editor/common/core/editOperation';
 import { Position } from 'vs/editor/common/core/position';
 import { IEditorWorkerService } from 'vs/editor/common/services/editorWorker';
 import { TestWorkerService } from './testWorkerService';
+
+
+function assertIsSessionType(session: unknown): asserts session is Session {
+	assertType(session);
+	if (isString(session)) {
+		throw new Error('Expected session to be a Session');
+	}
+	return;
+}
 
 
 suite('ReplyResponse', function () {
@@ -166,7 +175,7 @@ suite('InlineChatSession', function () {
 
 	async function makeEditAsAi(edit: EditOperation | EditOperation[]) {
 		const session = inlineChatSessionService.getSession(editor, editor.getModel()!.uri);
-		assertType(session);
+		assertIsSessionType(session);
 		session.hunkData.ignoreTextModelNChanges = true;
 		try {
 			editor.executeEdits('test', Array.isArray(edit) ? edit : [edit]);
@@ -183,7 +192,7 @@ suite('InlineChatSession', function () {
 	test('Create, release', async function () {
 
 		const session = await inlineChatSessionService.createSession(editor, { editMode: EditMode.Live }, CancellationToken.None);
-		assertType(session);
+		assertIsSessionType(session);
 		inlineChatSessionService.releaseSession(session);
 	});
 
@@ -192,7 +201,7 @@ suite('InlineChatSession', function () {
 		const decorationCountThen = model.getAllDecorations().length;
 
 		const session = await inlineChatSessionService.createSession(editor, { editMode: EditMode.Live }, CancellationToken.None);
-		assertType(session);
+		assertIsSessionType(session);
 		assert.ok(session.textModelN === model);
 
 		await makeEditAsAi(EditOperation.insert(new Position(1, 1), 'AI_EDIT\n'));
@@ -218,7 +227,7 @@ suite('InlineChatSession', function () {
 	test('HunkData, accept', async function () {
 
 		const session = await inlineChatSessionService.createSession(editor, { editMode: EditMode.Live }, CancellationToken.None);
-		assertType(session);
+		assertIsSessionType(session);
 
 		await makeEditAsAi([EditOperation.insert(new Position(1, 1), 'AI_EDIT\n'), EditOperation.insert(new Position(10, 1), 'AI_EDIT\n')]);
 
@@ -239,7 +248,7 @@ suite('InlineChatSession', function () {
 	test('HunkData, reject', async function () {
 
 		const session = await inlineChatSessionService.createSession(editor, { editMode: EditMode.Live }, CancellationToken.None);
-		assertType(session);
+		assertIsSessionType(session);
 
 		await makeEditAsAi([EditOperation.insert(new Position(1, 1), 'AI_EDIT\n'), EditOperation.insert(new Position(10, 1), 'AI_EDIT\n')]);
 
@@ -262,7 +271,7 @@ suite('InlineChatSession', function () {
 		model.setValue('one\ntwo\nthree\nfour\nfive\nsix\nseven\neight\nnine\nten\neleven\ntwelwe\nthirteen\nfourteen\nfifteen\nsixteen\nseventeen\neighteen\nnineteen\n');
 
 		const session = await inlineChatSessionService.createSession(editor, { editMode: EditMode.Live }, CancellationToken.None);
-		assertType(session);
+		assertIsSessionType(session);
 
 		assert.ok(session.textModel0.equalsTextBuffer(session.textModelN.getTextBuffer()));
 
@@ -311,7 +320,7 @@ suite('InlineChatSession', function () {
 		const lines = ['one', 'two', 'three'];
 		model.setValue(lines.join('\n'));
 		const session = await inlineChatSessionService.createSession(editor, { editMode: EditMode.Live }, CancellationToken.None);
-		assertType(session);
+		assertIsSessionType(session);
 
 		await makeEditAsAi([EditOperation.insert(new Position(3, 1), 'AI WAS HERE\n')]);
 		assert.strictEqual(session.textModelN.getValue(), ['one', 'two', 'AI WAS HERE', 'three'].join('\n'));
@@ -328,7 +337,7 @@ suite('InlineChatSession', function () {
 		model.setValue(lines.join('\n'));
 
 		const session = await inlineChatSessionService.createSession(editor, { editMode: EditMode.Live }, CancellationToken.None);
-		assertType(session);
+		assertIsSessionType(session);
 
 		await makeEditAsAi([EditOperation.insert(new Position(3, 1), 'AI_EDIT\n')]);
 
@@ -353,7 +362,7 @@ suite('InlineChatSession', function () {
 		const lines = ['one', 'two', 'three'];
 		model.setValue(lines.join('\n'));
 		const session = await inlineChatSessionService.createSession(editor, { editMode: EditMode.Live }, CancellationToken.None);
-		assertType(session);
+		assertIsSessionType(session);
 
 		await makeEditAsAi([EditOperation.insert(new Position(3, 1), 'AI WAS HERE\n')]);
 		assert.strictEqual(session.textModelN.getValue(), ['one', 'two', 'AI WAS HERE', 'three'].join('\n'));
@@ -369,7 +378,7 @@ suite('InlineChatSession', function () {
 		const lines = ['one', 'two', 'three'];
 		model.setValue(lines.join('\n'));
 		const session = await inlineChatSessionService.createSession(editor, { editMode: EditMode.Live }, CancellationToken.None);
-		assertType(session);
+		assertIsSessionType(session);
 
 		await makeEditAsAi([EditOperation.insert(new Position(3, 1), 'AI WAS HERE\n')]);
 		assert.strictEqual(session.textModelN.getValue(), ['one', 'two', 'AI WAS HERE', 'three'].join('\n'));
@@ -392,7 +401,7 @@ suite('InlineChatSession', function () {
 		model.setValue(lines.join('\n'));
 
 		const session = await inlineChatSessionService.createSession(editor, { editMode: EditMode.Live }, CancellationToken.None);
-		assertType(session);
+		assertIsSessionType(session);
 
 		await makeEditAsAi([EditOperation.insert(new Position(3, 1), 'AI_EDIT\n')]);
 
@@ -419,7 +428,7 @@ suite('InlineChatSession', function () {
 		model.setValue(lines.join('\n'));
 
 		const session = await inlineChatSessionService.createSession(editor, { editMode: EditMode.Live }, CancellationToken.None);
-		assertType(session);
+		assertIsSessionType(session);
 
 		await makeEditAsAi([EditOperation.insert(new Position(3, 1), 'AI_EDIT\n')]);
 

--- a/src/vs/workbench/contrib/notebook/browser/controller/chat/notebookChatController.ts
+++ b/src/vs/workbench/contrib/notebook/browser/controller/chat/notebookChatController.ts
@@ -715,7 +715,7 @@ export class NotebookChatController extends Disposable implements INotebookEdito
 			token
 		);
 
-		if (!session) {
+		if (!session || typeof session === 'string') {
 			return;
 		}
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

The typings get a bit weird here, so I'm not sure what the suggestion should be but I decided to switch `undefined` for a `string` where the `string` represents what message should be displayed in the message controller when session creation fails
