### PR TITLE
cli: add --server-base-path flag to `code serve-web` command

### DIFF
--- a/cli/src/commands/args.rs
+++ b/cli/src/commands/args.rs
@@ -210,6 +210,9 @@ pub struct ServeWebArgs {
 	/// If set, the user accepts the server license terms and the server will be started without a user prompt.
 	#[clap(long)]
 	pub accept_server_license_terms: bool,
+	/// Specifies the path under which the web UI and the code server is provided.
+	#[clap(long)]
+	pub server_base_path: Option<String>,
 	/// Specifies the directory that server data is kept in.
 	#[clap(long)]
 	pub server_data_dir: Option<String>,

--- a/cli/src/commands/serve_web.rs
+++ b/cli/src/commands/serve_web.rs
@@ -127,7 +127,7 @@ pub async fn serve_web(ctx: CommandContext, mut args: ServeWebArgs) -> Result<i3
 		if let Some(base) = args.server_base_path {
 			if !base.starts_with('/') {
 				listening.push('/');
-                        }
+			}
 			listening.push_str(&base);
 		}
 		if let Some(ct) = args.connection_token {
@@ -696,7 +696,7 @@ impl ConnectionManager {
 		// License agreement already checked by the `server_web` function.
 		cmd.args(["--accept-server-license-terms"]);
 
-		if let Some(a) = &args.args.server_base_path{
+		if let Some(a) = &args.args.server_base_path {
 			cmd.arg("--server-base-path");
 			cmd.arg(a);
 		}

--- a/cli/src/commands/serve_web.rs
+++ b/cli/src/commands/serve_web.rs
@@ -125,8 +125,8 @@ pub async fn serve_web(ctx: CommandContext, mut args: ServeWebArgs) -> Result<i3
 
 		let mut listening = format!("Web UI available at http://{}", addr);
 		if let Some(base) = args.server_base_path {
-			if !base.starts_with("/") {
-				listening.push_str("/");
+			if !base.starts_with('/') {
+				listening.push('/');
                         }
 			listening.push_str(&base);
 		}

--- a/cli/src/commands/serve_web.rs
+++ b/cli/src/commands/serve_web.rs
@@ -124,6 +124,12 @@ pub async fn serve_web(ctx: CommandContext, mut args: ServeWebArgs) -> Result<i3
 		let builder = Server::try_bind(&addr).map_err(CodeError::CouldNotListenOnInterface)?;
 
 		let mut listening = format!("Web UI available at http://{}", addr);
+		if let Some(base) = args.server_base_path {
+			if !base.starts_with("/") {
+				listening.push_str("/");
+                        }
+			listening.push_str(&base);
+		}
 		if let Some(ct) = args.connection_token {
 			listening.push_str(&format!("?tkn={}", ct));
 		}
@@ -690,6 +696,10 @@ impl ConnectionManager {
 		// License agreement already checked by the `server_web` function.
 		cmd.args(["--accept-server-license-terms"]);
 
+		if let Some(a) = &args.args.server_base_path{
+			cmd.arg("--server-base-path");
+			cmd.arg(a);
+		}
 		if let Some(a) = &args.args.server_data_dir {
 			cmd.arg("--server-data-dir");
 			cmd.arg(a);


### PR DESCRIPTION
Expose the `--server-base-path` option in `code serve-web` command

Companion to https://github.com/microsoft/vscode/pull/202491

To test if it works, build the cli with these environment variables:
```
export VSCODE_CLI_QUALITY=insiders
export VSCODE_CLI_UPDATE_URL=https://update.code.visualstudio.com
export VSCODE_CLI_TUNNEL_SERVER_QUALITIES='{"insider":{"serverApplicationName":"code-server-insiders"}}'
```

Start the server on `/abc`:
```
./target/debug/code serve-web --server-base-path /abc 

Web UI available at http://127.0.0.1:8000/abc?tkn=67a8ca19-b8a3-4502-ae0f-172c60638aa7
```

The option will be available in `code serve-web --help`:
```
$ ./target/debug/code serve-web --help
Runs a local web version of Code - OSS

Usage: code serve-web [OPTIONS]

Options:
      --host <HOST>
          Host to listen on, defaults to 'localhost'
      --socket-path <SOCKET_PATH>

      --port <PORT>
          Port to listen on. If 0 is passed a random free port is picked [default: 8000]                                           
      --connection-token <CONNECTION_TOKEN>
          A secret that must be included with all requests
      --connection-token-file <CONNECTION_TOKEN_FILE>
          A file containing a secret that must be included with all requests                                                       
      --without-connection-token
          Run without a connection token. Only use this if the connection is secured by other means                                
      --accept-server-license-terms
          If set, the user accepts the server license terms and the server will be started without a user prompt                   
      --server-base-path <SERVER_BASE_PATH>
          Specifies the path under which the web UI and the code server is provided                                                
      --server-data-dir <SERVER_DATA_DIR>
          Specifies the directory that server data is kept in
      --user-data-dir <USER_DATA_DIR>
          Specifies the directory that user data is kept in. Can be used to open multiple distinct instances of Code               
      --extensions-dir <EXTENSIONS_DIR>
          Set the root path for extensions
  -h, --help
          Print help

GLOBAL OPTIONS:
      --cli-data-dir <CLI_DATA_DIR>  Directory where CLI metadata should be stored [env: VSCODE_CLI_DATA_DIR=]                     
      --verbose                      Print verbose output (implies --wait)                                                         
      --log <level>                  Log level to use [possible values: trace, debug, info, warn, error, critical, off]
```