### PR TITLE
Enable shell integration in hidden terminals

### DIFF
--- a/src/vs/platform/terminal/common/terminalEnvironment.ts
+++ b/src/vs/platform/terminal/common/terminalEnvironment.ts
@@ -66,5 +66,5 @@ export function sanitizeCwd(cwd: string): string {
  * @param slc The shell launch config to check.
  */
 export function shouldUseEnvironmentVariableCollection(slc: IShellLaunchConfig): boolean {
-	return !slc.strictEnv && !slc.hideFromUser;
+	return !slc.strictEnv;
 }

--- a/src/vs/platform/terminal/node/terminalEnvironment.ts
+++ b/src/vs/platform/terminal/node/terminalEnvironment.ts
@@ -112,12 +112,23 @@ export function getShellIntegrationInjection(
 	logService: ILogService,
 	productService: IProductService
 ): IShellIntegrationConfigInjection | undefined {
-	// Shell integration arg injection is disabled when:
+	// Conditionally disable shell integration arg injection
 	// - The global setting is disabled
 	// - There is no executable (not sure what script to run)
 	// - The terminal is used by a feature like tasks or debugging
 	const useWinpty = isWindows && (!options.windowsEnableConpty || getWindowsBuildNumber() < 18309);
-	if (!options.shellIntegration.enabled || !shellLaunchConfig.executable || (shellLaunchConfig.isFeatureTerminal && !shellLaunchConfig.forceShellIntegration) || shellLaunchConfig.hideFromUser || shellLaunchConfig.ignoreShellIntegration || useWinpty) {
+	if (
+		// The global setting is disabled
+		!options.shellIntegration.enabled ||
+		// There is no executable (so there's no way to determine how to inject)
+		!shellLaunchConfig.executable ||
+		// It's a feature terminal (tasks, debug), unless it's explicitly being forced
+		(shellLaunchConfig.isFeatureTerminal && !shellLaunchConfig.forceShellIntegration) ||
+		// The ignoreShellIntegration flag is passed (eg. relaunching without shell integration)
+		shellLaunchConfig.ignoreShellIntegration ||
+		// Winpty is unsupported
+		useWinpty
+	) {
 		return undefined;
 	}
 

--- a/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
@@ -721,7 +721,7 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 			throw new ErrorNoTelemetry('Terminal disposed of during xterm.js creation');
 		}
 
-		const disableShellIntegrationReporting = (this.shellLaunchConfig.hideFromUser || this.shellLaunchConfig.executable === undefined || this.shellType === undefined) || !shellIntegrationSupportedShellTypes.includes(this.shellType);
+		const disableShellIntegrationReporting = (this.shellLaunchConfig.executable === undefined || this.shellType === undefined) || !shellIntegrationSupportedShellTypes.includes(this.shellType);
 		const xterm = this._scopedInstantiationService.createInstance(
 			XtermTerminal,
 			Terminal,


### PR DESCRIPTION
As I understand it, hidden terminals were always exempty from shell integration because hidden terminals were thought of as private to an extension in a way, and also since they probably weren't going to be interacted with. Especially since the introduction of the environment variable collection API I think we should change this decision, not doing so will lead to weirdness for extensions where hidden ones (which may be shown later) aren't fully featured and get inconsistent envs.

Fixes #199611
Part of #197187

A `hideFromUser` terminal after showing:

<img width="688" alt="Screenshot 2024-03-18 at 11 54 23 AM" src="https://github.com/microsoft/vscode/assets/2193314/1d04dc87-21ce-4083-a021-f3c33d8b2d67">

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
