### PR TITLE
Fix stripping of some characters in markdown header folding

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/viewModel/foldingModel.ts
+++ b/src/vs/workbench/contrib/notebook/browser/viewModel/foldingModel.ts
@@ -317,7 +317,7 @@ export function* getMarkdownHeadersInCell(cellContent: string): Iterable<{ reado
 		if (token.type === 'heading') {
 			yield {
 				depth: token.depth,
-				text: renderMarkdownAsPlaintext({ value: token.text }).trim()
+				text: renderMarkdownAsPlaintext({ value: token.raw }).trim()
 			};
 		}
 	}


### PR DESCRIPTION
Fixes #147008

Makes sure the inner header text is not converted to a list and then stripped 