### PR TITLE
Show 'File saved' not `Cell Metadata Updated`

### DIFF
--- a/src/vs/workbench/contrib/notebook/common/model/cellEdit.ts
+++ b/src/vs/workbench/contrib/notebook/common/model/cellEdit.ts
@@ -101,7 +101,7 @@ export class SpliceCellsEdit implements IResourceUndoRedoElement {
 export class CellMetadataEdit implements IResourceUndoRedoElement {
 	type: UndoRedoElementType.Resource = UndoRedoElementType.Resource;
 	label: string = 'Update Cell Metadata';
-	code: string = 'undoredo.notebooks.updateCellMetadata';
+	code: string = 'undoredo.textBufferEdit';
 	constructor(
 		public resource: URI,
 		readonly index: number,

--- a/src/vs/workbench/contrib/notebook/common/model/notebookTextModel.ts
+++ b/src/vs/workbench/contrib/notebook/common/model/notebookTextModel.ts
@@ -25,7 +25,9 @@ import { isDefined } from 'vs/base/common/types';
 class StackOperation implements IWorkspaceUndoRedoElement {
 	type: UndoRedoElementType.Workspace;
 
-	readonly code = 'undoredo.notebooks.stackOperation';
+	public get code() {
+		return this._operations.length === 1 ? this._operations[0].code : 'undoredo.notebooks.stackOperation';
+	}
 
 	private _operations: IUndoRedoElement[] = [];
 	private _beginSelectionState: ISelectionState | undefined = undefined;
@@ -799,7 +801,7 @@ export class NotebookTextModel extends Disposable implements INotebookTextModel 
 						return that.uri;
 					}
 					readonly label = 'Update Cell Metadata';
-					readonly code = 'undoredo.notebooks.updateCellMetadata';
+					readonly code = 'undoredo.textBufferEdit';
 					undo() {
 						that._updateNotebookCellMetadata(oldMetadata, false, beginSelectionState, undoRedoGroup);
 					}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
For https://github.com/microsoft/vscode/issues/207968

**Work around for better Notebook Timeline entries**
In notebooks when adding a cell, we (built in ipynb serializer extension) performs additional edits as a side effect of adding a cell
* As a result, we do not see the `Insert Cell` in Timeline as the last edit operations is `Update Cell Metadata`
* As `Cell Metadata Updated` is not a user friendly operation we would prefer to replace this label in favour of `File Saved` (as is done today for Text Buffer edits)

Looking at how this is done for text editor, we need to ensure the `code === 'undoredo.textBufferEdit'`

@bpasero 
Wanted to check if this simple work around is sufficient, or whether we should come up with a different strategy.

We want notebook edit operations to end up in the line `return undefined`, thats the code path that leads to `File Saved` in the timeline view.

```typescript
	private resolveSourceFromUndoRedo(e: IWorkingCopySaveEvent): SaveSource | undefined {
		const lastStackElement = this.undoRedoService.getLastElement(e.workingCopy.resource);
		if (lastStackElement) {
			if (lastStackElement.code === 'undoredo.textBufferEdit') {
				return undefined; // ignore any unspecific stack element that resulted just from typing
			}
```