### PR TITLE
aux editors - block `moveEditor` when unsupported

### DIFF
--- a/src/vs/workbench/browser/parts/editor/auxiliaryEditorPart.ts
+++ b/src/vs/workbench/browser/parts/editor/auxiliaryEditorPart.ts
@@ -5,7 +5,6 @@
 
 import { onDidChangeFullscreen } from 'vs/base/browser/browser';
 import { hide, show } from 'vs/base/browser/dom';
-import { mainWindow } from 'vs/base/browser/window';
 import { Emitter, Event } from 'vs/base/common/event';
 import { DisposableStore } from 'vs/base/common/lifecycle';
 import { isNative } from 'vs/base/common/platform';
@@ -175,12 +174,12 @@ export class AuxiliaryEditorPart {
 		disposables.add(auxiliaryWindow.onBeforeUnload(event => {
 			for (const group of editorPart.groups) {
 				for (const editor of group.editors) {
-					const canMove = editor.canMove(mainWindow.vscodeWindowId);
+					// Closing an auxiliary window with opened editors
+					// will move the editors to the main window. As such,
+					// we need to validate that we can move and otherwise
+					// prevent the window from closing.
+					const canMove = editor.canMove(group.id, this.editorPartsView.mainPart.activeGroup.id);
 					if (typeof canMove === 'string') {
-						// Closing an auxiliary window with opened editors
-						// will move the editors to the main window. As such,
-						// we need to validate that we can move and otherwise
-						// prevent the window from closing.
 						group.openEditor(editor);
 						event.veto(canMove);
 						break;

--- a/src/vs/workbench/common/editor/editorInput.ts
+++ b/src/vs/workbench/common/editor/editorInput.ts
@@ -289,16 +289,15 @@ export abstract class EditorInput extends AbstractEditorInput {
 	}
 
 	/**
-	 * Indicates if this editor can be moved to another window. By default
-	 * editors can freely be moved around windows. If an editor cannot be
+	 * Indicates if this editor can be moved to another group. By default
+	 * editors can freely be moved around groups. If an editor cannot be
 	 * moved, a message should be returned to show to the user.
 	 *
-	 * @param targetWindowId the target window to move the editor to.
-	 * @returns `true` if the editor can be moved to the target window, or
+	 * @returns `true` if the editor can be moved to the target group, or
 	 * a string with a message to show to the user if the editor cannot be
 	 * moved.
 	 */
-	canMove(targetWindowId: number): true | string {
+	canMove(sourceGroup: GroupIdentifier, targetGroup: GroupIdentifier): true | string {
 		return true;
 	}
 

--- a/src/vs/workbench/contrib/customEditor/browser/customEditorInput.ts
+++ b/src/vs/workbench/contrib/customEditor/browser/customEditorInput.ts
@@ -399,7 +399,7 @@ export class CustomEditorInput extends LazilyResolvedWebviewEditorInput {
 	}
 
 	public override claim(claimant: unknown, targetWindow: CodeWindow, scopedContextKeyService: IContextKeyService | undefined): void {
-		if (typeof this.canMove(targetWindow.vscodeWindowId) === 'string') {
+		if (typeof this.doCanMove(targetWindow.vscodeWindowId) === 'string') {
 			throw createEditorOpenError(localize('editorUnsupportedInWindow', "Unable to open the editor in this window, it contains modifications that can only be saved in the original window."), [
 				toAction({
 					id: 'openInOriginalWindow',
@@ -415,7 +415,19 @@ export class CustomEditorInput extends LazilyResolvedWebviewEditorInput {
 		return super.claim(claimant, targetWindow, scopedContextKeyService);
 	}
 
-	public override canMove(targetWindowId: number): true | string {
+	public override canMove(sourceGroup: GroupIdentifier, targetGroup: GroupIdentifier): true | string {
+		const resolvedTargetGroup = this.editorGroupsService.getGroup(targetGroup);
+		if (resolvedTargetGroup) {
+			const canMove = this.doCanMove(resolvedTargetGroup.windowId);
+			if (typeof canMove === 'string') {
+				return canMove;
+			}
+		}
+
+		return super.canMove(sourceGroup, targetGroup);
+	}
+
+	private doCanMove(targetWindowId: number): true | string {
 		if (this.isModified() && this._modelRef?.object.canHotExit === false) {
 			const sourceWindowId = getWindow(this.webview.container).vscodeWindowId;
 			if (sourceWindowId !== targetWindowId) {

--- a/src/vs/workbench/contrib/customEditor/browser/customEditorInput.ts
+++ b/src/vs/workbench/contrib/customEditor/browser/customEditorInput.ts
@@ -399,7 +399,7 @@ export class CustomEditorInput extends LazilyResolvedWebviewEditorInput {
 	}
 
 	public override claim(claimant: unknown, targetWindow: CodeWindow, scopedContextKeyService: IContextKeyService | undefined): void {
-		if (typeof this.doCanMove(targetWindow.vscodeWindowId) === 'string') {
+		if (this.doCanMove(targetWindow.vscodeWindowId) !== true) {
 			throw createEditorOpenError(localize('editorUnsupportedInWindow', "Unable to open the editor in this window, it contains modifications that can only be saved in the original window."), [
 				toAction({
 					id: 'openInOriginalWindow',

--- a/src/vs/workbench/contrib/customEditor/browser/customEditorInput.ts
+++ b/src/vs/workbench/contrib/customEditor/browser/customEditorInput.ts
@@ -438,7 +438,7 @@ export class CustomEditorInput extends LazilyResolvedWebviewEditorInput {
 				// into another window because that means, we potentally loose the modified
 				// state and thus trigger data loss.
 
-				return localize('editorCannotMove', "Unable to move the editor from this window, it contains modifications that can only be saved in the this window.");
+				return localize('editorCannotMove', "Unable to move the editor out of the window, it contains modifications that can only be saved in the this window.");
 			}
 		}
 

--- a/src/vs/workbench/services/auxiliaryWindow/electron-sandbox/auxiliaryWindowService.ts
+++ b/src/vs/workbench/services/auxiliaryWindow/electron-sandbox/auxiliaryWindowService.ts
@@ -30,7 +30,6 @@ type NativeCodeWindow = CodeWindow & {
 
 export class NativeAuxiliaryWindow extends AuxiliaryWindow {
 
-	private skipUnloadVeto = false;
 	private skipUnloadConfirmation = false;
 
 	constructor(
@@ -48,13 +47,9 @@ export class NativeAuxiliaryWindow extends AuxiliaryWindow {
 	}
 
 	protected override async handleVetoBeforeClose(e: BeforeUnloadEvent, veto: string): Promise<void> {
-		if (this.skipUnloadVeto) {
-			return;
-		}
-
 		this.preventUnload(e);
 
-		const { result } = await this.dialogService.prompt({
+		await this.dialogService.prompt({
 			type: 'error',
 			message: veto,
 			detail: localize('backupErrorDetails', "Try saving or reverting the editors with unsaved changes first and then try again."),
@@ -62,18 +57,9 @@ export class NativeAuxiliaryWindow extends AuxiliaryWindow {
 				{
 					label: localize({ key: 'ok', comment: ['&& denotes a mnemonic'] }, "&&OK"),
 					run: () => false // veto
-				},
-				{
-					label: localize('shutdownForceClose', "Close Anyway"),
-					run: () => true // no veto
 				}
-			],
+			]
 		});
-
-		if (result) {
-			this.skipUnloadVeto = true;
-			this.nativeHostService.closeWindow({ targetWindowId: this.window.vscodeWindowId });
-		}
 	}
 
 	protected override async confirmBeforeClose(e: BeforeUnloadEvent): Promise<void> {

--- a/src/vs/workbench/services/editor/browser/editorResolverService.ts
+++ b/src/vs/workbench/services/editor/browser/editorResolverService.ts
@@ -555,7 +555,10 @@ export class EditorResolverService extends Disposable implements IEditorResolver
 
 		// Move the editor already opened to the target group
 		if (targetGroup.id !== editorToUse.group.id) {
-			editorToUse.group.moveEditor(editorToUse.editor, targetGroup);
+			const moved = editorToUse.group.moveEditor(editorToUse.editor, targetGroup);
+			if (!moved) {
+				return;
+			}
 			return editorToUse.editor;
 		}
 		return;

--- a/src/vs/workbench/services/editor/common/editorGroupsService.ts
+++ b/src/vs/workbench/services/editor/common/editorGroupsService.ts
@@ -742,13 +742,17 @@ export interface IEditorGroup {
 
 	/**
 	 * Move an editor from this group either within this group or to another group.
+	 *
+	 * @returns whether the editor was moved or not.
 	 */
-	moveEditor(editor: EditorInput, target: IEditorGroup, options?: IEditorOptions): void;
+	moveEditor(editor: EditorInput, target: IEditorGroup, options?: IEditorOptions): boolean;
 
 	/**
 	 * Move editors from this group either within this group or to another group.
+	 *
+	 * @returns whether all editors were moved or not.
 	 */
-	moveEditors(editors: EditorInputWithOptions[], target: IEditorGroup): void;
+	moveEditors(editors: EditorInputWithOptions[], target: IEditorGroup): boolean;
 
 	/**
 	 * Copy an editor from this group to another group.

--- a/src/vs/workbench/services/editor/test/browser/editorGroupsService.test.ts
+++ b/src/vs/workbench/services/editor/test/browser/editorGroupsService.test.ts
@@ -1049,7 +1049,8 @@ suite('EditorGroupsService', () => {
 		assert.strictEqual(group.getEditorByIndex(0), inputInactive);
 		assert.strictEqual(group.getEditorByIndex(1), input);
 
-		group.moveEditors([{ editor: inputInactive, options: { index: 1 } }], group);
+		const res = group.moveEditors([{ editor: inputInactive, options: { index: 1 } }], group);
+		assert.strictEqual(res, true);
 		assert.strictEqual(moveEvents.length, 2);
 		assert.strictEqual((moveEvents[1] as IGroupEditorOpenEvent).editorIndex, 1);
 		assert.strictEqual((moveEvents[1] as IGroupEditorMoveEvent).oldEditorIndex, 0);
@@ -1557,15 +1558,18 @@ suite('EditorGroupsService', () => {
 		assert.strictEqual(leftFiredCount, 0);
 		assert.strictEqual(rightFiredCount, 0);
 
-		group.moveEditor(input, rightGroup);
+		let result = group.moveEditor(input, rightGroup);
+		assert.strictEqual(result, true);
 		assert.strictEqual(leftFiredCount, 1);
 		assert.strictEqual(rightFiredCount, 0);
 
-		group.moveEditor(inputInactive, rightGroup);
+		result = group.moveEditor(inputInactive, rightGroup);
+		assert.strictEqual(result, true);
 		assert.strictEqual(leftFiredCount, 2);
 		assert.strictEqual(rightFiredCount, 0);
 
-		rightGroup.moveEditor(inputInactive, group);
+		result = rightGroup.moveEditor(inputInactive, group);
+		assert.strictEqual(result, true);
 		assert.strictEqual(leftFiredCount, 2);
 		assert.strictEqual(rightFiredCount, 1);
 
@@ -1587,8 +1591,9 @@ suite('EditorGroupsService', () => {
 		await group.openEditors([{ editor: input, options: { pinned: true } }, { editor: inputInactive }, { editor: thirdInput }]);
 
 		input.setMoveDisabled('disabled');
-		group.moveEditor(input, rightGroup);
+		const result = group.moveEditor(input, rightGroup);
 
+		assert.strictEqual(result, false);
 		assert.strictEqual(group.count, 3);
 	});
 

--- a/src/vs/workbench/test/browser/workbenchTestServices.ts
+++ b/src/vs/workbench/test/browser/workbenchTestServices.ts
@@ -909,8 +909,8 @@ export class TestEditorGroupView implements IEditorGroupView {
 	isTransient(_editor: EditorInput): boolean { return false; }
 	isActive(_editor: EditorInput | IUntypedEditorInput): boolean { return false; }
 	contains(candidate: EditorInput | IUntypedEditorInput): boolean { return false; }
-	moveEditor(_editor: EditorInput, _target: IEditorGroup, _options?: IEditorOptions): void { }
-	moveEditors(_editors: EditorInputWithOptions[], _target: IEditorGroup): void { }
+	moveEditor(_editor: EditorInput, _target: IEditorGroup, _options?: IEditorOptions): boolean { return true; }
+	moveEditors(_editors: EditorInputWithOptions[], _target: IEditorGroup): boolean { return true; }
 	copyEditor(_editor: EditorInput, _target: IEditorGroup, _options?: IEditorOptions): void { }
 	copyEditors(_editors: EditorInputWithOptions[], _target: IEditorGroup): void { }
 	async closeEditor(_editor?: EditorInput, options?: ICloseEditorOptions): Promise<boolean> { return true; }
@@ -1768,11 +1768,11 @@ export class TestFileEditorInput extends EditorInput implements IFileEditorInput
 		this.moveDisabledReason = reason;
 	}
 
-	override canMove(targetWindowId: number): string | true {
+	override canMove(sourceGroup: GroupIdentifier, targetGroup: GroupIdentifier): string | true {
 		if (typeof this.moveDisabledReason === 'string') {
 			return this.moveDisabledReason;
 		}
-		return super.canMove(targetWindowId);
+		return super.canMove(sourceGroup, targetGroup);
 	}
 }
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
