### PR TITLE
fix: use different package name for legacy servers

### DIFF
--- a/build/azure-pipelines/linux/product-build-linux-legacy-server.yml
+++ b/build/azure-pipelines/linux/product-build-linux-legacy-server.yml
@@ -171,7 +171,7 @@ steps:
       export VSCODE_NODE_GLIBC="-glibc-2.17"
       yarn gulp vscode-reh-linux-$(VSCODE_ARCH)-min-ci
       mv ../vscode-reh-linux-$(VSCODE_ARCH) ../vscode-server-linux-$(VSCODE_ARCH) # TODO@joaomoreno
-      ARCHIVE_PATH=".build/linux/server/vscode-server-linux-$(VSCODE_ARCH).tar.gz"
+      ARCHIVE_PATH=".build/linux/server/legacy-vscode-server-linux-$(VSCODE_ARCH).tar.gz"
       mkdir -p $(dirname $ARCHIVE_PATH)
       tar --owner=0 --group=0 -czf $ARCHIVE_PATH -C .. vscode-server-linux-$(VSCODE_ARCH)
       echo "##vso[task.setvariable variable=LEGACY_SERVER_PATH]$ARCHIVE_PATH"
@@ -184,7 +184,7 @@ steps:
       export VSCODE_NODE_GLIBC="-glibc-2.17"
       yarn gulp vscode-reh-web-linux-$(VSCODE_ARCH)-min-ci
       mv ../vscode-reh-web-linux-$(VSCODE_ARCH) ../vscode-server-linux-$(VSCODE_ARCH)-web # TODO@joaomoreno
-      ARCHIVE_PATH=".build/linux/web/vscode-server-linux-$(VSCODE_ARCH)-web.tar.gz"
+      ARCHIVE_PATH=".build/linux/web/legacy-vscode-server-linux-$(VSCODE_ARCH)-web.tar.gz"
       mkdir -p $(dirname $ARCHIVE_PATH)
       tar --owner=0 --group=0 -czf $ARCHIVE_PATH -C .. vscode-server-linux-$(VSCODE_ARCH)-web
       echo "##vso[task.setvariable variable=LEGACY_WEB_PATH]$ARCHIVE_PATH"


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-remote-release/issues/9670

Hash mismatch because asset got only published once while asset properties were published separately due to different platform keys.

```
2024-03-19T06:10:51.2369384Z [vscode_legacy_server_linux_arm64_archive-unsigned] Successfully provisioned insider/7c51753f7ce936a7aeb84ac881818c35c5a9ab8d/vscode-server-linux-arm64.tar.gz
2024-03-19T06:10:51.2420926Z [vscode_legacy_server_linux_arm64_archive-unsigned] Creating asset... {"platform":"legacy-server-linux-arm64","type":"archive-unsigned","url":"https://vscode.download.prss.microsoft.com/dbazure/download/insider/7c51753f7ce936a7aeb84ac881818c35c5a9ab8d/vscode-server-linux-arm64.tar.gz","hash":"b0bd1fea58548fcf79cc7c2d1d022d3ed8ac55e3","sha256hash":"985f4f660f6b0489c9ff8abb4cae7285dcc979851a28271be77179541a50f6e2","size":56796831,"supportsFastUpdate":true}


2024-03-19T06:13:15.8999269Z [vscode_server_linux_arm64_archive-unsigned] Already released and provisioned: https://vscode.download.prss.microsoft.com/dbazure/download/insider/7c51753f7ce936a7aeb84ac881818c35c5a9ab8d/vscode-server-linux-arm64.tar.gz
2024-03-19T06:13:15.9001557Z [vscode_server_linux_arm64_archive-unsigned] Creating asset... {"platform":"server-linux-arm64","type":"archive-unsigned","url":"https://vscode.download.prss.microsoft.com/dbazure/download/insider/7c51753f7ce936a7aeb84ac881818c35c5a9ab8d/vscode-server-linux-arm64.tar.gz","hash":"d809faf9252f10851dc43b1f9d47357974d357ef","sha256hash":"90da1bd498f3a94d4dea7f18a1676cf98225594bbefe8dadb5118c5ee47f7a4a","size":56652853,"supportsFastUpdate":true}
```