### PR TITLE
Introduce new inline chat error type for showing to the user

### DIFF
--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatSessionServiceImpl.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatSessionServiceImpl.ts
@@ -33,6 +33,14 @@ type SessionData = {
 	store: IDisposable;
 };
 
+export class InlineChatError extends Error {
+	static readonly code = 'InlineChatError';
+	constructor(message: string) {
+		super(message);
+		this.name = InlineChatError.code;
+	}
+}
+
 export class InlineChatSessionServiceImpl implements IInlineChatSessionService {
 
 	declare _serviceBrand: undefined;
@@ -92,7 +100,7 @@ export class InlineChatSessionServiceImpl implements IInlineChatSessionService {
 		} catch (error) {
 			this._logService.error('[IE] FAILED to prepare session', provider.debugName);
 			this._logService.error(error);
-			return undefined;
+			throw new InlineChatError((error as Error)?.message || 'Failed to prepare session');
 		}
 		if (!rawSession) {
 			this._logService.trace('[IE] NO session', provider.debugName);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Errors from the provider are now treated as `InlineChatError` which has its error message shown to the user