### PR TITLE
translate to a 1-based location for the marker service

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/contrib/cellDiagnostics/cellDiagnostics.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/cellDiagnostics/cellDiagnostics.ts
@@ -91,7 +91,10 @@ export class CellDiagnostics extends Disposable {
 		return {
 			severity: 8,
 			message: message,
-			...location,
+			startLineNumber: location.startLineNumber + 1,
+			startColumn: location.startColumn + 1,
+			endLineNumber: location.endLineNumber + 1,
+			endColumn: location.endColumn + 1,
 			source: 'Cell Execution Error'
 		};
 	}


### PR DESCRIPTION
https://github.com/microsoft/vscode-copilot/issues/4136

code markers are off by 1, but the ranges are correct when used against the Languages.Diagnostic API, so they should probably be translated here.