### PR TITLE
Fix for Issue #208123: Missing NLS

### DIFF
--- a/src/vs/workbench/contrib/scrollLocking/browser/scrollLocking.ts
+++ b/src/vs/workbench/contrib/scrollLocking/browser/scrollLocking.ts
@@ -147,10 +147,10 @@ export class SyncScroll extends Disposable implements IWorkbenchContribution {
 		if (active) {
 			if (!this.statusBarEntry.value) {
 				this.statusBarEntry.value = this.statusbarService.addEntry({
-					name: 'Scrolling Locked',
-					text: 'Scrolling Locked',
-					tooltip: 'Lock Scrolling enabled',
-					ariaLabel: 'Scrolling Locked',
+					name: localize('mouseScrolllingLocked', 'Scrolling Locked'),
+					text: localize('mouseScrolllingLocked', 'Scrolling Locked'),
+					tooltip: localize('mouseLockScrollingEnabled', 'Lock Scrolling Enabled'),
+					ariaLabel: localize('mouseScrolllingLocked', 'Scrolling Locked'),
 					command: {
 						id: 'workbench.action.toggleLockedScrolling',
 						title: ''

--- a/src/vs/workbench/contrib/scrollLocking/browser/scrollLocking.ts
+++ b/src/vs/workbench/contrib/scrollLocking/browser/scrollLocking.ts
@@ -146,11 +146,13 @@ export class SyncScroll extends Disposable implements IWorkbenchContribution {
 	private toggleStatusbarItem(active: boolean): void {
 		if (active) {
 			if (!this.statusBarEntry.value) {
+				const text = localize('mouseScrolllingLocked', 'Scrolling Locked');
+				const tooltip = localize('mouseLockScrollingEnabled', 'Lock Scrolling Enabled');
 				this.statusBarEntry.value = this.statusbarService.addEntry({
-					name: localize('mouseScrolllingLocked', 'Scrolling Locked'),
-					text: localize('mouseScrolllingLocked', 'Scrolling Locked'),
-					tooltip: localize('mouseLockScrollingEnabled', 'Lock Scrolling Enabled'),
-					ariaLabel: localize('mouseScrolllingLocked', 'Scrolling Locked'),
+					name: text,
+					text,
+					tooltip,
+					ariaLabel: text,
 					command: {
 						id: 'workbench.action.toggleLockedScrolling',
 						title: ''


### PR DESCRIPTION
This PR addresses the missing NLS issue in the scrollLocking.ts file. The status bar entry for 'Scrolling Locked' has been localized to support multiple languages. This change enhances the user experience for non-English users.

Fixes #208123