### PR TITLE
Use correct colors for highlights

### DIFF
--- a/src/vs/platform/quickinput/browser/media/quickInput.css
+++ b/src/vs/platform/quickinput/browser/media/quickInput.css
@@ -263,11 +263,16 @@
 	overflow: hidden;
 }
 
-.quick-input-list .monaco-highlighted-label .highlight {
+/* preserve list-like styling instead of tree-like styling */
+.quick-input-list .monaco-list .monaco-list-row .monaco-highlighted-label .highlight {
 	font-weight: bold;
-	/* preserve list-like styling instead of tree-like styling */
+	background-color: unset;
+	color: var(--vscode-list-highlightForeground) !important;
+}
+
+/* preserve list-like styling instead of tree-like styling */
+.quick-input-list .monaco-list .monaco-list-row.focused .monaco-highlighted-label .highlight {
 	color: var(--vscode-list-focusHighlightForeground) !important;
-	background-color: transparent;
 }
 
 .quick-input-list .quick-input-list-entry .quick-input-list-separator {


### PR DESCRIPTION
I didn't realize there were 2 colors. This makes sure they're set correctly.

<img width="536" alt="image" src="https://github.com/microsoft/vscode/assets/2644648/62600488-efb1-45f2-b4da-e41fb84da4f3">

Fixes https://github.com/microsoft/vscode/issues/208213

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
