### PR TITLE
Allow separators to have tooltips & descriptions

### DIFF
--- a/src/vs/platform/quickinput/browser/quickInputTree.ts
+++ b/src/vs/platform/quickinput/browser/quickInputTree.ts
@@ -110,6 +110,8 @@ class BaseQuickPickItemElement implements IQuickPickElement {
 				saneAriaLabel
 			};
 		});
+		this._saneDescription = mainItem.description;
+		this._saneTooltip = mainItem.tooltip;
 	}
 
 	// #region Lazy Getters
@@ -144,7 +146,7 @@ class BaseQuickPickItemElement implements IQuickPickElement {
 		this._hidden = value;
 	}
 
-	protected _saneDescription?: string;
+	private _saneDescription?: string;
 	get saneDescription() {
 		return this._saneDescription;
 	}
@@ -160,7 +162,7 @@ class BaseQuickPickItemElement implements IQuickPickElement {
 		this._saneDetail = value;
 	}
 
-	protected _saneTooltip?: string | IMarkdownString | HTMLElement;
+	private _saneTooltip?: string | IMarkdownString | HTMLElement;
 	get saneTooltip() {
 		return this._saneTooltip;
 	}
@@ -210,9 +212,7 @@ class QuickPickItemElement extends BaseQuickPickItemElement {
 			? Event.map(Event.filter<{ element: IQuickPickElement; checked: boolean }>(this._onChecked.event, e => e.element === this), e => e.checked)
 			: Event.None;
 
-		this._saneDescription = item.description;
 		this._saneDetail = item.detail;
-		this._saneTooltip = this.item.tooltip;
 		this._labelHighlights = item.highlights?.label;
 		this._descriptionHighlights = item.highlights?.description;
 		this._detailHighlights = item.highlights?.detail;

--- a/src/vs/platform/quickinput/common/quickInput.ts
+++ b/src/vs/platform/quickinput/common/quickInput.ts
@@ -57,6 +57,7 @@ export interface IQuickPickSeparator {
 	type: 'separator';
 	id?: string;
 	label?: string;
+	description?: string;
 	ariaLabel?: string;
 	buttons?: readonly IQuickInputButton[];
 	tooltip?: string | IMarkdownString;

--- a/src/vs/workbench/contrib/search/browser/quickTextSearch/textSearchQuickAccess.ts
+++ b/src/vs/workbench/contrib/search/browser/quickTextSearch/textSearchQuickAccess.ts
@@ -254,7 +254,7 @@ export class TextSearchQuickAccess extends PickerQuickAccessProvider<ITextSearch
 			picks.push({
 				label,
 				type: 'separator',
-				tooltip: description,
+				description,
 				buttons: [{
 					iconClass: ThemeIcon.asClassName(searchOpenInFileIcon),
 					tooltip: localize('QuickSearchOpenInFile', "Open File")


### PR DESCRIPTION
This allows the full-length separators to have tooltips and descriptions.

(They had support for tooltips already, but my refactoring to a tree broke that)

so really this just adds descriptions and fixes tooltips. Because of this, we now adopt the description in favor of the tooltip for QuickSearch

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
<img width="524" alt="image" src="https://github.com/microsoft/vscode/assets/2644648/cc50ef53-56a6-469e-ae4e-8cd81214cd18">

Fixes https://github.com/microsoft/vscode/issues/208118