### PR TITLE
Add missing 'name' property to LanguageModelChatAssistantMessage

### DIFF
--- a/src/vs/workbench/api/common/extHostTypes.ts
+++ b/src/vs/workbench/api/common/extHostTypes.ts
@@ -4350,9 +4350,11 @@ export class LanguageModelChatUserMessage {
 
 export class LanguageModelChatAssistantMessage {
 	content: string;
+	name?: string;
 
-	constructor(content: string) {
+	constructor(content: string, name?: string) {
 		this.content = content;
+		this.name = name;
 	}
 }
 

--- a/src/vscode-dts/vscode.proposed.languageModels.d.ts
+++ b/src/vscode-dts/vscode.proposed.languageModels.d.ts
@@ -80,11 +80,17 @@ declare module 'vscode' {
 		content: string;
 
 		/**
+		 * The optional name of a user for this message.
+		 */
+		name: string | undefined;
+
+		/**
 		 * Create a new assistant message.
 		 *
 		 * @param content The content of the message.
+		 * @param name The optional name of a user for the message.
 		 */
-		constructor(content: string);
+		constructor(content: string, name?: string);
 	}
 
 	/**


### PR DESCRIPTION
<img width="402" alt="image" src="https://github.com/microsoft/vscode/assets/323878/b1730bd4-0e1e-473e-bea0-a2a8b7ddd6a7">
