### PR TITLE
Couple of styling updates to quick pick

### DIFF
--- a/src/vs/platform/quickinput/browser/media/quickInput.css
+++ b/src/vs/platform/quickinput/browser/media/quickInput.css
@@ -59,7 +59,7 @@
 
 .quick-input-header {
 	display: flex;
-	padding: 8px 6px 6px 6px;
+	padding: 8px 6px 2px 6px;
 }
 
 .quick-input-widget.hidden-input .quick-input-header {
@@ -323,10 +323,19 @@
 	background: none;
 }
 
-/* Quick input separators as full-row item */
 .quick-input-list .quick-input-list-separator-as-item {
-	font-weight: 600;
+	padding: 4px 6px;
 	font-size: 12px;
+}
+
+/* Quick input separators as full-row item */
+.quick-input-list .quick-input-list-separator-as-item .label-name {
+	font-weight: 600;
+}
+
+.quick-input-list .quick-input-list-separator-as-item .label-description {
+	/* Override default description opacity so we don't have a contrast ratio issue. */
+	opacity: 1 !important;
 }
 
 /* Hide border when the item becomes the sticky one */

--- a/src/vs/platform/quickinput/browser/quickInputTree.ts
+++ b/src/vs/platform/quickinput/browser/quickInputTree.ts
@@ -277,9 +277,8 @@ class QuickPickSeparatorElement extends BaseQuickPickItemElement {
 class QuickInputItemDelegate implements IListVirtualDelegate<IQuickPickElement> {
 	getHeight(element: IQuickPickElement): number {
 
-		if (!element.item) {
-			// must be a separator
-			return 24;
+		if (element instanceof QuickPickSeparatorElement) {
+			return 30;
 		}
 		return element.saneDetail ? 44 : 22;
 	}


### PR DESCRIPTION
1. Separator descriptions no longer include opacity so that contrast ratio is satisfied
2. The separators are now a little taller so that they stand out compared to regular items

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
<img width="518" alt="image" src="https://github.com/microsoft/vscode/assets/2644648/87ece85c-27f3-47dd-ac52-16ed825ca873">
