### PR TITLE
show preview label on code actions

### DIFF
--- a/src/vs/editor/contrib/codeAction/browser/codeActionController.ts
+++ b/src/vs/editor/contrib/codeAction/browser/codeActionController.ts
@@ -36,8 +36,9 @@ import { IEditorProgressService } from 'vs/platform/progress/common/progress';
 import { editorFindMatchHighlight, editorFindMatchHighlightBorder } from 'vs/platform/theme/common/colorRegistry';
 import { isHighContrast } from 'vs/platform/theme/common/theme';
 import { registerThemingParticipant } from 'vs/platform/theme/common/themeService';
-import { CodeActionAutoApply, CodeActionFilter, CodeActionItem, CodeActionSet, CodeActionTrigger, CodeActionTriggerSource } from '../common/types';
+import { CodeActionAutoApply, CodeActionFilter, CodeActionItem, CodeActionKind, CodeActionSet, CodeActionTrigger, CodeActionTriggerSource } from '../common/types';
 import { CodeActionModel, CodeActionsState } from './codeActionModel';
+import { HierarchicalKind } from 'vs/base/common/hierarchicalKind';
 
 
 interface IActionShowOptions {
@@ -291,7 +292,22 @@ export class CodeActionController extends Disposable implements IEditorContribut
 				if (token.isCancellationRequested) {
 					return;
 				}
-				return { canPreview: !!action.action.edit?.edits.length };
+
+				let canPreview = false;
+				const actionKind = action.action.kind;
+
+				if (actionKind) {
+					const hierarchicalKind = new HierarchicalKind(actionKind);
+					const refactorKinds = [
+						CodeActionKind.RefactorExtract,
+						CodeActionKind.RefactorInline,
+						CodeActionKind.RefactorRewrite
+					];
+
+					canPreview = refactorKinds.some(refactorKind => refactorKind.contains(hierarchicalKind));
+				}
+
+				return { canPreview: canPreview || !!action.action.edit?.edits.length };
 			},
 			onFocus: (action: CodeActionItem | undefined) => {
 				if (action && action.action) {

--- a/src/vs/editor/contrib/codeAction/browser/codeActionController.ts
+++ b/src/vs/editor/contrib/codeAction/browser/codeActionController.ts
@@ -36,8 +36,8 @@ import { IEditorProgressService } from 'vs/platform/progress/common/progress';
 import { editorFindMatchHighlight, editorFindMatchHighlightBorder } from 'vs/platform/theme/common/colorRegistry';
 import { isHighContrast } from 'vs/platform/theme/common/theme';
 import { registerThemingParticipant } from 'vs/platform/theme/common/themeService';
-import { CodeActionAutoApply, CodeActionFilter, CodeActionItem, CodeActionKind, CodeActionSet, CodeActionTrigger, CodeActionTriggerSource } from '../common/types';
-import { CodeActionModel, CodeActionsState } from './codeActionModel';
+import { CodeActionAutoApply, CodeActionFilter, CodeActionItem, CodeActionKind, CodeActionSet, CodeActionTrigger, CodeActionTriggerSource } from 'vs/editor/contrib/codeAction/common/types';
+import { CodeActionModel, CodeActionsState } from 'vs/editor/contrib/codeAction/browser/codeActionModel';
 import { HierarchicalKind } from 'vs/base/common/hierarchicalKind';
 
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

originally fixed via resolving the action, now statically pick which types of code actions show in cases where we don't know if edits are inbound or not. 