### PR TITLE
Indent next line when arrow function arrow followed by whitespace

### DIFF
--- a/extensions/typescript-basics/language-configuration.json
+++ b/extensions/typescript-basics/language-configuration.json
@@ -139,7 +139,7 @@
 			"pattern": "^(\\t|[ ])*[ ]\\*[^/]*\\*/\\s*$|^(\\t|[ ])*[ ]\\*/\\s*$|^(\\t|[ ])*\\*([ ]([^\\*]|\\*(?!/))*)?$"
 		},
 		"indentNextLinePattern": {
-			"pattern": "^\\s*(var|const|let)\\s+\\w+\\s*=\\s*\\(.*\\)\\s*=>\\s*$"
+			"pattern": "^.*=>\\s*$"
 		}
 	},
 	"onEnterRules": [

--- a/extensions/typescript-basics/language-configuration.json
+++ b/extensions/typescript-basics/language-configuration.json
@@ -137,6 +137,9 @@
 		// e.g.  * ...| or */| or *-----*/|
 		"unIndentedLinePattern": {
 			"pattern": "^(\\t|[ ])*[ ]\\*[^/]*\\*/\\s*$|^(\\t|[ ])*[ ]\\*/\\s*$|^(\\t|[ ])*\\*([ ]([^\\*]|\\*(?!/))*)?$"
+		},
+		"indentNextLinePattern": {
+			"pattern": "^\\s*(var|const|let)\\s+\\w+\\s*=\\s*\\(.*\\)\\s*=>\\s*$"
 		}
 	},
 	"onEnterRules": [

--- a/src/vs/editor/contrib/indentation/test/browser/indentation.test.ts
+++ b/src/vs/editor/contrib/indentation/test/browser/indentation.test.ts
@@ -548,14 +548,36 @@ suite('`Full` Auto Indent On Type - TypeScript/JavaScript', () => {
 		disposables.add(model);
 
 		withTestCodeEditor(model, { autoIndent: "full" }, (editor, viewModel, instantiationService) => {
-
 			registerLanguage(instantiationService, languageId, Language.TypeScript, disposables);
-
 			viewModel.type('const add1 = (n) =>');
 			viewModel.type("\n", 'keyboard');
 			assert.strictEqual(model.getValue(), [
 				'const add1 = (n) =>',
 				'    ',
+			].join('\n'));
+		});
+	});
+
+	test('issue #208215: indent after arrow function 2', () => {
+
+		// https://github.com/microsoft/vscode/issues/208215
+
+		const model = createTextModel([
+			'const array = [1, 2, 3, 4, 5];',
+			'array.map(',
+			'    v =>',
+		].join('\n'), languageId, {});
+		disposables.add(model);
+
+		withTestCodeEditor(model, { autoIndent: "full" }, (editor, viewModel, instantiationService) => {
+			registerLanguage(instantiationService, languageId, Language.TypeScript, disposables);
+			editor.setSelection(new Selection(3, 9, 3, 9));
+			viewModel.type("\n", 'keyboard');
+			assert.strictEqual(model.getValue(), [
+				'const array = [1, 2, 3, 4, 5];',
+				'array.map(',
+				'    v =>',
+				'        '
 			].join('\n'));
 		});
 	});

--- a/src/vs/editor/contrib/indentation/test/browser/indentation.test.ts
+++ b/src/vs/editor/contrib/indentation/test/browser/indentation.test.ts
@@ -538,14 +538,9 @@ suite('`Full` Auto Indent On Type - TypeScript/JavaScript', () => {
 
 	ensureNoDisposablesAreLeakedInTestSuite();
 
-	// Test added so there is at least one non-ignored test in this suite
-	test('temporary test', () => {
-		assert.ok(true);
-	});
-
 	// Failing tests from issues...
 
-	test.skip('issue #208215: indent after arrow function', () => {
+	test('issue #208215: indent after arrow function', () => {
 
 		// https://github.com/microsoft/vscode/issues/208215
 		// consider the regex: /^\s*(var|const|let)\s+\w+\s*=\s*\(.*\)\s*=>\s*$/
@@ -566,7 +561,7 @@ suite('`Full` Auto Indent On Type - TypeScript/JavaScript', () => {
 		});
 	});
 
-	test.skip('issue #208215: outdented after semicolon detected after arrow function', () => {
+	test('issue #208215: outdented after semicolon detected after arrow function', () => {
 
 		// Notes: we want to outdent after having detected a semi-colon which marks the end of the line, but only when we have detected an arrow function
 		// We could use one outdent pattern corresponding per indent pattern, and not a generic outdent and indent pattern

--- a/src/vs/editor/contrib/indentation/test/browser/indentation.test.ts
+++ b/src/vs/editor/contrib/indentation/test/browser/indentation.test.ts
@@ -543,7 +543,6 @@ suite('`Full` Auto Indent On Type - TypeScript/JavaScript', () => {
 	test('issue #208215: indent after arrow function', () => {
 
 		// https://github.com/microsoft/vscode/issues/208215
-		// consider the regex: /^\s*(var|const|let)\s+\w+\s*=\s*\(.*\)\s*=>\s*$/
 
 		const model = createTextModel("", languageId, {});
 		disposables.add(model);
@@ -563,8 +562,6 @@ suite('`Full` Auto Indent On Type - TypeScript/JavaScript', () => {
 
 	test('issue #208215: outdented after semicolon detected after arrow function', () => {
 
-		// Notes: we want to outdent after having detected a semi-colon which marks the end of the line, but only when we have detected an arrow function
-		// We could use one outdent pattern corresponding per indent pattern, and not a generic outdent and indent pattern
 
 		const model = createTextModel([
 			'const add1 = (n) =>',

--- a/src/vs/editor/contrib/indentation/test/browser/indentation.test.ts
+++ b/src/vs/editor/contrib/indentation/test/browser/indentation.test.ts
@@ -560,30 +560,7 @@ suite('`Full` Auto Indent On Type - TypeScript/JavaScript', () => {
 		});
 	});
 
-	test('issue #208215: outdented after semicolon detected after arrow function', () => {
-
-
-		const model = createTextModel([
-			'const add1 = (n) =>',
-			'    console.log("hi");',
-		].join('\n'), languageId, {});
-		disposables.add(model);
-
-		withTestCodeEditor(model, { autoIndent: "full" }, (editor, viewModel, instantiationService) => {
-
-			registerLanguage(instantiationService, languageId, Language.TypeScript, disposables);
-
-			editor.setSelection(new Selection(2, 24, 2, 24));
-			viewModel.type("\n", 'keyboard');
-			assert.strictEqual(model.getValue(), [
-				'const add1 = (n) =>',
-				'    console.log("hi");',
-				'',
-			].join('\n'));
-		});
-	});
-
-	test.skip('issue #116843: indent after arrow function', () => {
+	test('issue #116843: indent after arrow function', () => {
 
 		// https://github.com/microsoft/vscode/issues/116843
 

--- a/src/vs/editor/test/common/modes/supports/javascriptIndentationRules.ts
+++ b/src/vs/editor/test/common/modes/supports/javascriptIndentationRules.ts
@@ -7,5 +7,6 @@ export const javascriptIndentationRules = {
 	decreaseIndentPattern: /^((?!.*?\/\*).*\*\/)?\s*[\}\]].*$/,
 	increaseIndentPattern: /^((?!\/\/).)*(\{([^}"'`]*|(\t|[ ])*\/\/.*)|\([^)"'`]*|\[[^\]"'`]*)$/,
 	// e.g.  * ...| or */| or *-----*/|
-	unIndentedLinePattern: /^(\t|[ ])*[ ]\*[^/]*\*\/\s*$|^(\t|[ ])*[ ]\*\/\s*$|^(\t|[ ])*[ ]\*([ ]([^\*]|\*(?!\/))*)?$/
+	unIndentedLinePattern: /^(\t|[ ])*[ ]\*[^/]*\*\/\s*$|^(\t|[ ])*[ ]\*\/\s*$|^(\t|[ ])*[ ]\*([ ]([^\*]|\*(?!\/))*)?$/,
+	indentNextLinePattern: /^\s*(var|const|let)\s+\w+\s*=\s*\(.*\)\s*=>\s*$/,
 };

--- a/src/vs/editor/test/common/modes/supports/javascriptIndentationRules.ts
+++ b/src/vs/editor/test/common/modes/supports/javascriptIndentationRules.ts
@@ -8,5 +8,5 @@ export const javascriptIndentationRules = {
 	increaseIndentPattern: /^((?!\/\/).)*(\{([^}"'`]*|(\t|[ ])*\/\/.*)|\([^)"'`]*|\[[^\]"'`]*)$/,
 	// e.g.  * ...| or */| or *-----*/|
 	unIndentedLinePattern: /^(\t|[ ])*[ ]\*[^/]*\*\/\s*$|^(\t|[ ])*[ ]\*\/\s*$|^(\t|[ ])*[ ]\*([ ]([^\*]|\*(?!\/))*)?$/,
-	indentNextLinePattern: /^\s*(var|const|let)\s+\w+\s*=\s*\(.*\)\s*=>\s*$/,
+	indentNextLinePattern: /^.*=>\s*$/,
 };


### PR DESCRIPTION
Indenting the code when an arrow function is encountered where the arrow is followed by whitespace only (so no brace).

Fixes https://github.com/microsoft/vscode/issues/208215

https://github.com/microsoft/vscode/assets/61460952/fcd179ab-7e30-42c4-8e50-5feb27e40ce8

