### PR TITLE
chore: provide option to disable remote unsupported connection banner

### DIFF
--- a/src/vs/workbench/browser/parts/banner/bannerPart.ts
+++ b/src/vs/workbench/browser/parts/banner/bannerPart.ts
@@ -222,13 +222,12 @@ export class BannerPart extends Part implements IBannerService {
 		}
 
 		// Action
-		if (!item.disableCloseAction) {
-			const actionBarContainer = append(this.element, $('div.action-container'));
-			this.actionBar = this._register(new ActionBar(actionBarContainer));
-			const closeAction = this._register(new Action('banner.close', 'Close Banner', ThemeIcon.asClassName(widgetClose), true, () => this.close(item)));
-			this.actionBar.push(closeAction, { icon: true, label: false });
-			this.actionBar.setFocusable(false);
-		}
+		const actionBarContainer = append(this.element, $('div.action-container'));
+		this.actionBar = this._register(new ActionBar(actionBarContainer));
+		const label = item.closeLabel ?? 'Close Banner';
+		const closeAction = this._register(new Action('banner.close', label, ThemeIcon.asClassName(widgetClose), true, () => this.close(item)));
+		this.actionBar.push(closeAction, { icon: true, label: false });
+		this.actionBar.setFocusable(false);
 
 		this.setVisibility(true);
 		this.item = item;

--- a/src/vs/workbench/services/banner/browser/bannerService.ts
+++ b/src/vs/workbench/services/banner/browser/bannerService.ts
@@ -16,7 +16,7 @@ export interface IBannerItem {
 	readonly actions?: ILinkDescriptor[];
 	readonly ariaLabel?: string;
 	readonly onClose?: () => void;
-	readonly disableCloseAction?: boolean;
+	readonly closeLabel?: string;
 }
 
 export const IBannerService = createDecorator<IBannerService>('bannerService');


### PR DESCRIPTION
Refs https://github.com/microsoft/vscode/issues/204728

Allows dismissing the banner and persisting the choice until the next minor version update. Also, the choice is persisted per client rather than per remote authority.


https://github.com/microsoft/vscode/assets/964386/108adc6d-1585-4c15-bf65-706c868c355b

