### PR TITLE
Fix copy action being stolen by terminal chat

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/chat/browser/terminalChatController.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chat/browser/terminalChatController.ts
@@ -115,11 +115,7 @@ export class TerminalChatController extends Disposable implements ITerminalContr
 		}
 		this._register(this._chatCodeBlockContextProviderService.registerProvider({
 			getCodeBlockContext: (editor) => {
-				const chatWidget = this.chatWidget;
-				if (!chatWidget) {
-					return;
-				}
-				if (!editor) {
+				if (!editor || !this._chatWidget?.hasValue || !this.hasFocus()) {
 					return;
 				}
 				return {


### PR DESCRIPTION
What was happening here is chatWidget was called which would initialize the terminal chat widget, so I switched that to check whether the lazy value exists and added a hasFocus check for good measure.

Fixes #208413
