### PR TITLE
Allow transparency in sticky scroll overlay

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/stickyScroll/browser/terminalStickyScrollOverlay.ts
+++ b/src/vs/workbench/contrib/terminalContrib/stickyScroll/browser/terminalStickyScrollOverlay.ts
@@ -102,6 +102,7 @@ export class TerminalStickyScrollOverlay extends Disposable {
 			this._stickyScrollOverlay = this._register(new ctor({
 				rows: 1,
 				cols: this._xterm.raw.cols,
+				allowTransparency: true,
 				allowProposedApi: true,
 				...this._getOptions()
 			}));

--- a/src/vs/workbench/contrib/terminalContrib/stickyScroll/browser/terminalStickyScrollOverlay.ts
+++ b/src/vs/workbench/contrib/terminalContrib/stickyScroll/browser/terminalStickyScrollOverlay.ts
@@ -102,7 +102,6 @@ export class TerminalStickyScrollOverlay extends Disposable {
 			this._stickyScrollOverlay = this._register(new ctor({
 				rows: 1,
 				cols: this._xterm.raw.cols,
-				allowTransparency: true,
 				allowProposedApi: true,
 				...this._getOptions()
 			}));
@@ -447,6 +446,7 @@ export class TerminalStickyScrollOverlay extends Disposable {
 	private _getOptions(): ITerminalOptions {
 		const o = this._xterm.raw.options;
 		return {
+			allowTransparency: true,
 			cursorInactiveStyle: 'none',
 			scrollback: 0,
 			logLevel: 'off',


### PR DESCRIPTION
Fixes #208470

Example usage:

```
"terminalStickyScroll.background": "#1c2431c0",
```

![image](https://github.com/microsoft/vscode/assets/2193314/d4d99b19-0edc-498e-aff5-880e4d5755f9)
