### PR TITLE
fix: terminal suggestions to sort by fuzzy score

### DIFF
--- a/src/vs/workbench/services/suggest/browser/simpleCompletionItem.ts
+++ b/src/vs/workbench/services/suggest/browser/simpleCompletionItem.ts
@@ -27,7 +27,6 @@ export class SimpleCompletionItem {
 
 	// sorting, filtering
 	score: FuzzyScore = FuzzyScore.Default;
-	distance: number = 0;
 	idx?: number;
 	word?: string;
 

--- a/src/vs/workbench/services/suggest/browser/simpleCompletionModel.ts
+++ b/src/vs/workbench/services/suggest/browser/simpleCompletionModel.ts
@@ -174,8 +174,6 @@ export class SimpleCompletionModel {
 			}
 
 			item.idx = i;
-			// TODO: Word distance
-			item.distance = 1;//this._wordDistance.distance(item.position, item.completion);
 			target.push(item);
 
 			// update stats

--- a/src/vs/workbench/services/suggest/browser/simpleCompletionModel.ts
+++ b/src/vs/workbench/services/suggest/browser/simpleCompletionModel.ts
@@ -40,7 +40,7 @@ export class SimpleCompletionModel {
 		private readonly _items: SimpleCompletionItem[],
 		private _lineContext: LineContext,
 		readonly replacementIndex: number,
-		readonly replacementLength: number
+		readonly replacementLength: number,
 	) {
 	}
 
@@ -182,7 +182,7 @@ export class SimpleCompletionModel {
 			labelLengths.push(item.completion.label.length);
 		}
 
-		this._filteredItems = target; // target.sort(this._snippetCompareFn);
+		this._filteredItems = target.sort((a, b) => b.score[0] - a.score[0]);
 		this._refilterKind = Refilter.Nothing;
 
 		this._stats = {


### PR DESCRIPTION
Updates the terminal suggestion model to use the fuzzy matching scores for sorting.

### Before
![image](https://github.com/microsoft/vscode/assets/35637443/1bc8649a-b7eb-47a3-addc-e2872907ff12)
### After
![image](https://github.com/microsoft/vscode/assets/35637443/0c444f18-7244-477c-a6ba-2bf8e53b526a)

Part of #154662