### PR TITLE
Only one subscriber for kernels for onDidChangeSelectedNotebooks with separate tryAutoBindKernel

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadNotebookKernels.ts
+++ b/src/vs/workbench/api/browser/mainThreadNotebookKernels.ts
@@ -7,7 +7,7 @@ import { isNonEmptyArray } from 'vs/base/common/arrays';
 import { CancellationToken } from 'vs/base/common/cancellation';
 import { onUnexpectedError } from 'vs/base/common/errors';
 import { Emitter, Event } from 'vs/base/common/event';
-import { combinedDisposable, DisposableMap, DisposableStore, IDisposable, toDisposable } from 'vs/base/common/lifecycle';
+import { DisposableMap, DisposableStore, IDisposable, toDisposable } from 'vs/base/common/lifecycle';
 import { URI, UriComponents } from 'vs/base/common/uri';
 import { ILanguageService } from 'vs/editor/common/languages/language';
 import { ExtensionIdentifier } from 'vs/platform/extensions/common/extensions';
@@ -151,6 +151,16 @@ export class MainThreadNotebookKernels implements MainThreadNotebookKernelsShape
 				this._proxy.$cellExecutionChanged(e.notebook, e.cellHandle, e.changed?.state);
 			}
 		}));
+
+		this._disposables.add(this._notebookKernelService.onDidChangeSelectedNotebooks(e => {
+			for (const [handle, [kernel,]] of this._kernels) {
+				if (e.oldKernel === kernel.id) {
+					this._proxy.$acceptNotebookAssociation(handle, e.notebook, false);
+				} else if (e.newKernel === kernel.id) {
+					this._proxy.$acceptNotebookAssociation(handle, e.notebook, true);
+				}
+			}
+		}));
 	}
 
 	dispose(): void {
@@ -262,16 +272,10 @@ export class MainThreadNotebookKernels implements MainThreadNotebookKernelsShape
 			}
 		}(data, this._languageService);
 
-		const listener = this._notebookKernelService.onDidChangeSelectedNotebooks(e => {
-			if (e.oldKernel === kernel.id) {
-				this._proxy.$acceptNotebookAssociation(handle, e.notebook, false);
-			} else if (e.newKernel === kernel.id) {
-				this._proxy.$acceptNotebookAssociation(handle, e.notebook, true);
-			}
-		});
-
 		const registration = this._notebookKernelService.registerKernel(kernel);
-		this._kernels.set(handle, [kernel, combinedDisposable(listener, registration)]);
+		this._kernels.set(handle, [kernel, registration]);
+		// Only autobind *after* the kernel has already been added here
+		this._notebookKernelService.tryAutoBindKernel(kernel);
 	}
 
 	$updateKernel(handle: number, data: Partial<INotebookKernelDto2>): void {

--- a/src/vs/workbench/contrib/notebook/browser/services/notebookKernelServiceImpl.ts
+++ b/src/vs/workbench/contrib/notebook/browser/services/notebookKernelServiceImpl.ts
@@ -214,12 +214,6 @@ export class NotebookKernelService extends Disposable implements INotebookKernel
 		this._kernels.set(kernel.id, new KernelInfo(kernel));
 		this._onDidAddKernel.fire(kernel);
 
-		// auto associate the new kernel to existing notebooks it was
-		// associated to in the past.
-		for (const notebook of this._notebookService.getNotebookTextModels()) {
-			this._tryAutoBindNotebook(notebook, kernel);
-		}
-
 		return toDisposable(() => {
 			if (this._kernels.delete(kernel.id)) {
 				this._onDidRemoveKernel.fire(kernel);
@@ -230,6 +224,14 @@ export class NotebookKernelService extends Disposable implements INotebookKernel
 				}
 			}
 		});
+	}
+
+	tryAutoBindKernel(kernel: INotebookKernel): void {
+		// auto associate the new kernel to existing notebooks it was
+		// associated to in the past.
+		for (const notebook of this._notebookService.getNotebookTextModels()) {
+			this._tryAutoBindNotebook(notebook, kernel);
+		}
 	}
 
 	getMatchingKernel(notebook: INotebookTextModelLike): INotebookKernelMatchResult {

--- a/src/vs/workbench/contrib/notebook/common/notebookKernelService.ts
+++ b/src/vs/workbench/contrib/notebook/common/notebookKernelService.ts
@@ -119,6 +119,7 @@ export interface INotebookKernelService {
 	readonly onDidChangeNotebookAffinity: Event<void>;
 	readonly onDidNotebookVariablesUpdate: Event<URI>;
 	registerKernel(kernel: INotebookKernel): IDisposable;
+	tryAutoBindKernel(kernel: INotebookKernel): void;
 
 	getMatchingKernel(notebook: INotebookTextModelLike): INotebookKernelMatchResult;
 


### PR DESCRIPTION
This fixes the issue in https://github.com/microsoft/vscode/issues/204416 (and https://github.com/microsoft/vscode-jupyter/issues/15075).

The key difference between this PR and #204417 is that this PR does not have the issue in #207126. That issue was caused because of the `registerKernel()` call including `_tryAutoBindNotebook()` calls. In the #207126 case, the `_tryAutoBindNotebook()` would call `this._onDidChangeNotebookKernelBinding.fire()` which meant that the new singular`this._notebookKernelService.onDidChangeSelectedNotebooks()` listener would run in `mainThreadNotebookKernels.ts`. Since the kernel hadn't been added to `this._kernels` yet, the new kernel was not yet present when the listener ran, so it was missed.

To get around this, we perform the `_tryAutoBindNotebook()` calls explicitly via `tryAutoBindKernel()` after the kernel has been included in the `this._kernels` in `$addKernel()`.

This is the only usage of `registerKernel()` outside of tests. Based on current usages, the `_onDidAddKernel` in `registerKernel()` is safe to fire. Other `_tryAutoBindNotebook()` calls seem safe.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
