### PR TITLE
fix(git): filter out fork username when checking out branch

### DIFF
--- a/extensions/git/package.json
+++ b/extensions/git/package.json
@@ -25,6 +25,7 @@
     "editSessionIdentityProvider",
     "quickDiffProvider",
     "quickPickSortByLabel",
+    "quickPickFilterPattern",
     "scmActionButton",
     "scmHistoryProvider",
     "scmMultiDiffEditor",

--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -2501,6 +2501,9 @@ export class CommandCenter {
 
 		const disposables: Disposable[] = [];
 		const quickPick = window.createQuickPick();
+		// GitHub PRs have a copy button for their head branch. If it's a fork, it contains the username as a prefix, e.g.
+		// `username:branchname`. This filters the first part out.
+		quickPick.filterPattern = /[^:]*$/;
 		quickPick.busy = true;
 		quickPick.sortByLabel = false;
 		quickPick.placeholder = opts?.detached

--- a/extensions/git/tsconfig.json
+++ b/extensions/git/tsconfig.json
@@ -12,6 +12,7 @@
 		"../../src/vscode-dts/vscode.d.ts",
 		"../../src/vscode-dts/vscode.proposed.diffCommand.d.ts",
 		"../../src/vscode-dts/vscode.proposed.quickPickSortByLabel.d.ts",
+		"../../src/vscode-dts/vscode.proposed.quickPickFilterPattern.d.ts",
 		"../../src/vscode-dts/vscode.proposed.scmActionButton.d.ts",
 		"../../src/vscode-dts/vscode.proposed.scmHistoryProvider.d.ts",
 		"../../src/vscode-dts/vscode.proposed.scmSelectedProvider.d.ts",

--- a/src/vs/platform/quickinput/browser/quickInput.ts
+++ b/src/vs/platform/quickinput/browser/quickInput.ts
@@ -533,6 +533,7 @@ export class QuickPick<T extends IQuickPickItem> extends QuickInput implements I
 	private _hideInput: boolean | undefined;
 	private _hideCountBadge: boolean | undefined;
 	private _hideCheckAll: boolean | undefined;
+	private _filterPattern: RegExp | undefined;
 
 	get quickNavigate() {
 		return this._quickNavigate;
@@ -567,7 +568,12 @@ export class QuickPick<T extends IQuickPickItem> extends QuickInput implements I
 		}
 	}
 
-	filterValue = (value: string) => value;
+	filterValue = (value: string): string => {
+		if (this.filterPattern) {
+			return value.match(this.filterPattern)?.[0] ?? '';
+		}
+		return value;
+	};
 
 	set ariaLabel(ariaLabel: string | undefined) {
 		this._ariaLabel = ariaLabel;
@@ -671,6 +677,15 @@ export class QuickPick<T extends IQuickPickItem> extends QuickInput implements I
 
 	set sortByLabel(sortByLabel: boolean) {
 		this._sortByLabel = sortByLabel;
+		this.update();
+	}
+
+	get filterPattern() {
+		return this._filterPattern;
+	}
+
+	set filterPattern(pattern: RegExp | undefined) {
+		this._filterPattern = pattern;
 		this.update();
 	}
 

--- a/src/vs/workbench/api/browser/mainThreadQuickOpen.ts
+++ b/src/vs/workbench/api/browser/mainThreadQuickOpen.ts
@@ -202,6 +202,8 @@ export class MainThreadQuickOpen implements MainThreadQuickOpenShape {
 
 					return button;
 				});
+			} else if (param === 'filterPattern') {
+				(input as any)[param] = params[param] && new RegExp(params[param].source, params[param].flags);
 			} else {
 				(input as any)[param] = params[param];
 			}

--- a/src/vs/workbench/api/common/extHostQuickOpen.ts
+++ b/src/vs/workbench/api/common/extHostQuickOpen.ts
@@ -539,6 +539,7 @@ export function createExtHostQuickOpen(mainContext: IMainContext, workspace: IEx
 		private _matchOnDescription = true;
 		private _matchOnDetail = true;
 		private _sortByLabel = true;
+		private _filterPattern: RegExp | undefined;
 		private _keepScrollPosition = false;
 		private _activeItems: T[] = [];
 		private readonly _onDidChangeActiveEmitter = new Emitter<T[]>();
@@ -642,6 +643,20 @@ export function createExtHostQuickOpen(mainContext: IMainContext, workspace: IEx
 		set sortByLabel(sortByLabel: boolean) {
 			this._sortByLabel = sortByLabel;
 			this.update({ sortByLabel });
+		}
+
+		get filterPattern() {
+			return this._filterPattern;
+		}
+
+		set filterPattern(filterPattern: RegExp | undefined) {
+			this._filterPattern = filterPattern;
+			this.update({
+				filterPattern: filterPattern && {
+					source: filterPattern.source,
+					flags: filterPattern.flags
+				}
+			});
 		}
 
 		get keepScrollPosition() {

--- a/src/vs/workbench/services/extensions/common/extensionsApiProposals.ts
+++ b/src/vs/workbench/services/extensions/common/extensionsApiProposals.ts
@@ -92,6 +92,7 @@ export const allApiProposals = Object.freeze({
 	portsAttributes: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.portsAttributes.d.ts',
 	profileContentHandlers: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.profileContentHandlers.d.ts',
 	quickDiffProvider: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.quickDiffProvider.d.ts',
+	quickPickFilterPattern: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.quickPickFilterPattern.d.ts',
 	quickPickItemTooltip: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.quickPickItemTooltip.d.ts',
 	quickPickSortByLabel: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.quickPickSortByLabel.d.ts',
 	resolvers: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.resolvers.d.ts',

--- a/src/vscode-dts/vscode.proposed.quickPickFilterPattern.d.ts
+++ b/src/vscode-dts/vscode.proposed.quickPickFilterPattern.d.ts
@@ -1,0 +1,16 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+declare module 'vscode' {
+
+	// https://github.com/microsoft/vscode/issues/201012
+
+	export interface QuickPick<T extends QuickPickItem> extends QuickInput {
+		/**
+		 * An optional RegExp pattern which is applied on the value when filtering the items.
+		 */
+		filterPattern?: RegExp;
+	}
+}


### PR DESCRIPTION
Motivation: GitHub PRs have a copy button for their head branch. If it's a fork, it contains the username as a prefix, e.g. `username:branchname`. This PR will filter the first part out. (`:` as a character is not allowed as a branch name).

This required me to introduce a new proposed API to the QuickPick element, allowing it to use a regular expression pattern to filter its items. Implementing a callback based approach like it was already implemented on the actual widget seems not great, due to the async nature of the extension host -> main process communication.

Whats the best way of covering it with tests?

Thats the button:

<img width="698" alt="image" src="https://github.com/microsoft/vscode/assets/17984549/869d84bc-fe81-4245-a4f3-aa913a1a2724">

Fixes https://github.com/microsoft/vscode/issues/201012