### PR TITLE
State `getWordRangeAtPosition` is used when `Diagnostic` range is empty

### DIFF
--- a/src/vscode-dts/vscode.d.ts
+++ b/src/vscode-dts/vscode.d.ts
@@ -6724,6 +6724,7 @@ declare module 'vscode' {
 
 		/**
 		 * The range to which this diagnostic applies.
+		 * When empty, the range of the {@link TextDocument.getWordRangeAtPosition current word} is used instead.
 		 */
 		range: Range;
 


### PR DESCRIPTION
Fix https://github.com/microsoft/vscode/issues/202909

tho I would prefer a way to disable `getWordRangeAtPosition` from being used in the first place
