### PR TITLE
fix: suggest widget persisting on completion acceptance

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalSuggestAddon.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalSuggestAddon.ts
@@ -425,9 +425,12 @@ export class SuggestAddon extends Disposable implements ITerminalAddon, ISuggest
 		}
 		// Right
 		if (data === '\x1b[C') {
-			handled = true;
-			this._cursorIndexDelta += 1;
-			handledCursorDelta++;
+			// If right requests beyond where the completion was requested (potentially accepting a shell completion), hide
+			if (this._additionalInput?.length !== this._cursorIndexDelta) {
+				handled = true;
+				this._cursorIndexDelta++;
+				handledCursorDelta++;
+			}
 		}
 		if (data.match(/^[a-z0-9]$/i)) {
 


### PR DESCRIPTION
### Before
https://github.com/microsoft/vscode/assets/35637443/4e2f9541-610e-4d47-ac1e-5a411fe92327
### After
https://github.com/microsoft/vscode/assets/35637443/2656b9d2-f2cd-44a6-9d3c-f563b290f0da

When accepting a shell completion, the suggest widget should hide.

Part of #154662





