### PR TITLE
fix issue with terminal chat input focus

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/chat/browser/terminalChatActions.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chat/browser/terminalChatActions.ts
@@ -100,7 +100,8 @@ registerActiveXtermAction({
 	title: localize2('focusTerminalInput', 'Focus Terminal Input'),
 	keybinding: {
 		primary: KeyMod.CtrlCmd | KeyCode.UpArrow,
-		when: TerminalChatContextKeys.focused,
+		secondary: [KeyMod.CtrlCmd | KeyCode.KeyI],
+		when: ContextKeyExpr.and(TerminalChatContextKeys.focused, CTX_INLINE_CHAT_FOCUSED.toNegated()),
 		weight: KeybindingWeight.WorkbenchContrib,
 	},
 	f1: true,


### PR DESCRIPTION
Before, invoking `ctrlCmd+i` with focus on the terminal chat response would focus the panel chat input. 

Now, it focuses the terminal chat input. 

It preserves the behavior of voice start so that when a user is in the terminal chat input, using `ctrlCmd+i` will start voice chat.

fixes https://github.com/microsoft/vscode-copilot/issues/4754

I tested this, but would be good if you could also @Tyriar 