### PR TITLE
Add validation for empty pattern in custom editor labels

### DIFF
--- a/src/vs/workbench/browser/workbench.contribution.ts
+++ b/src/vs/workbench/browser/workbench.contribution.ts
@@ -109,6 +109,8 @@ const registry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Con
 				{
 					type: 'string',
 					markdownDescription: localize('workbench.editor.label.template', "The template which should be rendered when the pattern mtches. May include the variables ${dirname}, ${filename} and ${extname}."),
+					minLength: 1,
+					pattern: '.*[a-zA-Z0-9].*'
 				},
 				'default': {}
 			},

--- a/src/vs/workbench/services/editor/common/customEditorLabelService.ts
+++ b/src/vs/workbench/services/editor/common/customEditorLabelService.ts
@@ -74,11 +74,16 @@ export class CustomEditorLabelService extends Disposable implements ICustomEdito
 		this.enabled = this.configurationService.getValue<boolean>(CustomEditorLabelService.SETTING_ID_ENABLED);
 	}
 
+	private _templateRegexValidation: RegExp = /[a-zA-Z0-9]/;
 	private storeCustomPatterns(): void {
 		this.patterns = [];
 		const customLabelPatterns = this.configurationService.getValue<ICustomEditorLabelObject>(CustomEditorLabelService.SETTING_ID_PATTERNS);
 		for (const pattern in customLabelPatterns) {
 			const template = customLabelPatterns[pattern];
+
+			if (!this._templateRegexValidation.test(template)) {
+				continue;
+			}
 
 			const isAbsolutePath = isAbsolute(pattern);
 			const parsedPattern = parseGlob(pattern);


### PR DESCRIPTION
This PR adds a validation check for empty patterns in custom editor labels. Now, the system will ignore any pattern that does not contain at least one alphanumeric character. This prevents the creation of items with empty file names, addressing the issue raised during testing.

Fixes #208723