### PR TITLE
fix: bundling error makes terminal suggestions fail

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalSuggestAddon.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalSuggestAddon.ts
@@ -296,7 +296,8 @@ export class SuggestAddon extends Disposable implements ITerminalAddon, ISuggest
 		// TODO: What do frozen and auto do?
 		const xtermBox = this._screen!.getBoundingClientRect();
 		const panelBox = this._panel!.offsetParent!.getBoundingClientRect();
-		suggestWidget.showSuggestions(model, 0, false, false, {
+		suggestWidget.setCompletionModel(model);
+		suggestWidget.showSuggestions(0, false, false, {
 			left: (xtermBox.left - panelBox.left) + this._terminal.buffer.active.cursorX * dimensions.width,
 			top: (xtermBox.top - panelBox.top) + this._terminal.buffer.active.cursorY * dimensions.height,
 			height: dimensions.height
@@ -467,7 +468,8 @@ export class SuggestAddon extends Disposable implements ITerminalAddon, ISuggest
 			// TODO: What do frozen and auto do?
 			const xtermBox = this._screen!.getBoundingClientRect();
 			const panelBox = this._panel!.offsetParent!.getBoundingClientRect();
-			this._suggestWidget?.showSuggestions((this._suggestWidget as any)._completionModel, 0, false, false, {
+
+			this._suggestWidget?.showSuggestions(0, false, false, {
 				left: (xtermBox.left - panelBox.left) + (this._terminal.buffer.active.cursorX + handledCursorDelta) * dimensions.width,
 				top: (xtermBox.top - panelBox.top) + this._terminal.buffer.active.cursorY * dimensions.height,
 				height: dimensions.height

--- a/src/vs/workbench/services/suggest/browser/simpleSuggestWidget.ts
+++ b/src/vs/workbench/services/suggest/browser/simpleSuggestWidget.ts
@@ -222,7 +222,7 @@ export class SimpleSuggestWidget implements IDisposable {
 			return;
 		}
 
-		const visibleCount = this._completionModel?.items.length;
+		const visibleCount = this._completionModel?.items.length ?? 0;
 		const isEmpty = visibleCount === 0;
 		// this._ctxSuggestWidgetMultipleSuggestions.set(visibleCount > 1);
 

--- a/src/vs/workbench/services/suggest/browser/simpleSuggestWidget.ts
+++ b/src/vs/workbench/services/suggest/browser/simpleSuggestWidget.ts
@@ -204,7 +204,11 @@ export class SimpleSuggestWidget implements IDisposable {
 
 	private _cursorPosition?: { top: number; left: number; height: number };
 
-	showSuggestions(completionModel: SimpleCompletionModel, selectionIndex: number, isFrozen: boolean, isAuto: boolean, cursorPosition: { top: number; left: number; height: number }): void {
+	setCompletionModel(completionModel: SimpleCompletionModel) {
+		this._completionModel = completionModel;
+	}
+
+	showSuggestions(selectionIndex: number, isFrozen: boolean, isAuto: boolean, cursorPosition: { top: number; left: number; height: number }): void {
 		this._cursorPosition = cursorPosition;
 
 		// this._contentWidget.setPosition(this.editor.getPosition());
@@ -213,16 +217,12 @@ export class SimpleSuggestWidget implements IDisposable {
 		// this._currentSuggestionDetails?.cancel();
 		// this._currentSuggestionDetails = undefined;
 
-		if (this._completionModel !== completionModel) {
-			this._completionModel = completionModel;
-		}
-
 		if (isFrozen && this._state !== State.Empty && this._state !== State.Hidden) {
 			this._setState(State.Frozen);
 			return;
 		}
 
-		const visibleCount = this._completionModel.items.length;
+		const visibleCount = this._completionModel?.items.length;
 		const isEmpty = visibleCount === 0;
 		// this._ctxSuggestWidgetMultipleSuggestions.set(visibleCount > 1);
 
@@ -241,7 +241,7 @@ export class SimpleSuggestWidget implements IDisposable {
 		// this._onDidFocus.pause();
 		// this._onDidSelect.pause();
 		try {
-			this._list.splice(0, this._list.length, this._completionModel.items);
+			this._list.splice(0, this._list.length, this._completionModel?.items ?? []);
 			this._setState(isFrozen ? State.Frozen : State.Open);
 			this._list.reveal(selectionIndex, 0);
 			this._list.setFocus([selectionIndex]);


### PR DESCRIPTION
There is an issue with the bundling / build process for VSCode Insiders that introduces an undefined reference bug to the SimpleSuggestWidget show below.

https://github.com/microsoft/vscode/assets/35637443/9d41ac1a-a8c9-4290-a62c-e8b236fb0f41

As you can see in the code snippets below and their bundled counterparts, the second bundled image of calling `showSuggestions` uses the variable `this.h._completionModel`, but it should be `this.h.b` as seen in the first bundled image. This results in the value being undefined and causing the suggestions to error out.  This PR removes the passing of a private variable to the widget and instead exposes a set method for the `CompletionModel` which should fix this issue in the build.

> I'm not sure how to test this as it was working fine in the development environment, but removing the private access seems like it would fix the issue.

 
### Update the widget's model
#### Code
https://github.com/microsoft/vscode/blob/17e86debf73ddba21e315c642d518765ba9e5b2a/src/vs/workbench/services/suggest/browser/simpleSuggestWidget.ts#L207-L218
#### Bundled Code
![bundleBundled](https://github.com/microsoft/vscode/assets/35637443/4c18d22e-6c57-46ef-8964-482d8fa89a78)

### Call showSuggestions
#### Code
https://github.com/microsoft/vscode/blob/17e86debf73ddba21e315c642d518765ba9e5b2a/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalSuggestAddon.ts#L470-L474
#### Bundled Code
![bundleCallsite](https://github.com/microsoft/vscode/assets/35637443/b0aa0032-0013-4ba6-bfaf-4c0f8b487174)

Part of #154662