### PR TITLE
Fix duplicate links where description is falsey

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/links/browser/terminalLinkQuickpick.ts
+++ b/src/vs/workbench/contrib/terminalContrib/links/browser/terminalLinkQuickpick.ts
@@ -221,12 +221,10 @@ export class TerminalLinkQuickpick extends DisposableStore {
 					}
 
 					// Skip the link if it's a duplicate URI + line/col
-					if (description) {
-						if (linkUriKeys.has(label + '|' + description)) {
-							continue;
-						}
-						linkUriKeys.add(label + '|' + description);
+					if (linkUriKeys.has(label + '|' + (description ?? ''))) {
+						continue;
 					}
+					linkUriKeys.add(label + '|' + (description ?? ''));
 				}
 
 				picks.push({ label, link, description });


### PR DESCRIPTION
Fixes #206124

<img width="299" alt="Screenshot 2024-03-26 at 11 51 13 AM" src="https://github.com/microsoft/vscode/assets/2193314/24092618-249d-4a41-b818-d771bf4b0eb1">
<img width="620" alt="Screenshot 2024-03-26 at 11 51 23 AM" src="https://github.com/microsoft/vscode/assets/2193314/9de19ce9-675e-43de-9733-c2c780d08ad4">
