### PR TITLE
set tab focus when editable widget focused

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/codeBlockPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/codeBlockPart.ts
@@ -44,6 +44,7 @@ import { MenuPreventer } from 'vs/workbench/contrib/codeEditor/browser/menuPreve
 import { SelectionClipboardContributionID } from 'vs/workbench/contrib/codeEditor/browser/selectionClipboard';
 import { getSimpleEditorOptions } from 'vs/workbench/contrib/codeEditor/browser/simpleEditorOptions';
 import { IMarkdownVulnerability } from '../common/annotations';
+import { TabFocus } from 'vs/editor/browser/config/tabFocus';
 
 const $ = dom.$;
 
@@ -334,6 +335,10 @@ export class CodeBlockPart extends Disposable {
 		await this.updateEditor(data);
 
 		this.layout(width);
+		if (editable) {
+			this._register(this.editor.onDidFocusEditorWidget(() => TabFocus.setTabFocusMode(true)));
+			this._register(this.editor.onDidBlurEditorWidget(() => TabFocus.setTabFocusMode(false)));
+		}
 		this.editor.updateOptions({ ariaLabel: localize('chat.codeBlockLabel', "Code block {0}", data.codeBlockIndex + 1), readOnly: !editable });
 
 		if (data.hideToolbar) {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
fixes https://github.com/microsoft/vscode-copilot/issues/4740

https://github.com/microsoft/vscode/assets/29464607/8f131620-e93d-42b1-80c8-edcfe1d07233

