### PR TITLE
inline chat layout fixes

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chat.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.ts
@@ -98,6 +98,7 @@ export interface IChatWidgetViewOptions {
 		inputSideToolbar?: MenuId;
 		telemetrySource?: string;
 	};
+	defaultElementHeight?: number;
 	editorOverflowWidgetsDomNode?: HTMLElement;
 }
 

--- a/src/vs/workbench/contrib/chat/browser/chatListRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatListRenderer.ts
@@ -1010,6 +1010,7 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 
 export class ChatListDelegate implements IListVirtualDelegate<ChatTreeItem> {
 	constructor(
+		private readonly defaultElementHeight: number,
 		@ILogService private readonly logService: ILogService
 	) { }
 
@@ -1023,7 +1024,7 @@ export class ChatListDelegate implements IListVirtualDelegate<ChatTreeItem> {
 
 	getHeight(element: ChatTreeItem): number {
 		const kind = isRequestVM(element) ? 'request' : 'response';
-		const height = ('currentRenderedHeight' in element ? element.currentRenderedHeight : undefined) ?? 200;
+		const height = ('currentRenderedHeight' in element ? element.currentRenderedHeight : undefined) ?? this.defaultElementHeight;
 		this._traceLayout('getHeight', `${kind}, height=${height}`);
 		return height;
 	}

--- a/src/vs/workbench/contrib/chat/browser/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatWidget.ts
@@ -396,7 +396,7 @@ export class ChatWidget extends Disposable implements IChatWidget {
 
 	private createList(listContainer: HTMLElement, options: IChatListItemRendererOptions): void {
 		const scopedInstantiationService = this.instantiationService.createChild(new ServiceCollection([IContextKeyService, this.contextKeyService]));
-		const delegate = scopedInstantiationService.createInstance(ChatListDelegate);
+		const delegate = scopedInstantiationService.createInstance(ChatListDelegate, this.viewOptions.defaultElementHeight ?? 200);
 		const rendererDelegate: IChatRendererDelegate = {
 			getListLength: () => this.tree.getNode(null).visibleChildrenCount,
 			onDidScroll: this.onDidScroll,

--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatContentWidget.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatContentWidget.ts
@@ -64,6 +64,7 @@ export class InlineChatContentWidget implements IContentWidget {
 			ChatAgentLocation.Editor,
 			{ resource: true },
 			{
+				defaultElementHeight: 32,
 				editorOverflowWidgetsDomNode: _editor.getOverflowWidgetsDomNode(),
 				renderStyle: 'compact',
 				renderInputOnTop: true,

--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatWidget.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatWidget.ts
@@ -189,10 +189,11 @@ export class InlineChatWidget {
 			location,
 			{ resource: true },
 			{
-				// TODO@jrieken support editable code blocks
+				defaultElementHeight: 32,
 				renderStyle: 'compact',
 				renderInputOnTop: true,
 				supportsFileReferences: true,
+				editorOverflowWidgetsDomNode: options.editorOverflowWidgetsDomNode,
 				editableCodeBlocks: options.editableCodeBlocks,
 				menus: {
 					executeToolbar: options.inputMenuId,

--- a/src/vs/workbench/contrib/inlineChat/browser/media/inlineChat.css
+++ b/src/vs/workbench/contrib/inlineChat/browser/media/inlineChat.css
@@ -50,11 +50,11 @@
 /* status */
 
 .monaco-workbench .inline-chat .status {
-	padding-top: 4px;
 	display: flex;
 	justify-content: space-between;
 	align-items: center;
 }
+
 
 .monaco-workbench .inline-chat .status .actions.hidden {
 	display: none;
@@ -64,7 +64,7 @@
 	overflow: hidden;
 	color: var(--vscode-descriptionForeground);
 	font-size: 11px;
-	align-self: baseline;
+	padding-top: 4px;
 	padding-left: 10px;
 	display: inline-flex;
 }
@@ -130,6 +130,7 @@
 
 .monaco-workbench .inline-chat .status .actions {
 	display: flex;
+	padding-top: 4px;
 }
 
 .monaco-workbench .inline-chat .status .actions > .monaco-button,


### PR DESCRIPTION
- allow to define default element height which fixes unexpected large inline chat on first render,
- properly set editor overflow widget