### PR TITLE
Fix scrolling misalignment issue with find box

### DIFF
--- a/src/vs/workbench/browser/parts/editor/textEditor.ts
+++ b/src/vs/workbench/browser/parts/editor/textEditor.ts
@@ -267,7 +267,8 @@ export abstract class AbstractTextEditor<T extends IEditorViewState> extends Abs
 		}
 
 		return {
-			scrollTop: editor.getScrollTop(),
+			// The top position can vary depending on the view zones (find widget for example)
+			scrollTop: editor.getScrollTop() - editor.getTopForLineNumber(1),
 			scrollLeft: editor.getScrollLeft(),
 		};
 	}


### PR DESCRIPTION
This pull request fixes the scrolling misalignment issue that occurs when the search/find widget is opened in VSCode Insiders. The issue was caused by the top position of the editor being affected by view zones, resulting in misalignment. The fix adjusts the top position calculation to ensure proper alignment. Fixes #208538.