### PR TITLE
check undefined, trackpad can send deltaYs of 0

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewPreloads.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewPreloads.ts
@@ -561,7 +561,7 @@ async function webviewPreloads(ctx: PreloadContext) {
 	let lastTimeScrolled: number | undefined;
 	function flagRecentlyScrolled(node: Element, deltaY?: number) {
 		scrolledElement = node;
-		if (!deltaY) {
+		if (deltaY === undefined) {
 			lastTimeScrolled = Date.now();
 			previousDelta = undefined;
 			node.setAttribute('recentlyScrolled', 'true');


### PR DESCRIPTION
fix https://github.com/microsoft/vscode/issues/208859

made the mistake of using a `!` check for undefined on a number type.
