### PR TITLE
Don't handle uncaught exceptions during quit

### DIFF
--- a/src/vs/code/electron-main/app.ts
+++ b/src/vs/code/electron-main/app.ts
@@ -359,6 +359,11 @@ export class CodeApplication extends Disposable {
 		// We handle uncaught exceptions here to prevent electron from opening a dialog to the user
 		setUnexpectedErrorHandler(error => this.onUnexpectedError(error));
 		process.on('uncaughtException', error => {
+			// Don't process the exception if exit is happening as it can cause the main process to
+			// hang while awaiting an IPC reply.
+			if (this.lifecycleMainService.quitRequested) {
+				return undefined;
+			}
 			if (!isSigPipeError(error)) {
 				onUnexpectedError(error);
 			}


### PR DESCRIPTION
This fixes a longstanding issue I've been seeing on macos where quitting Insiders will cause any Code - OSS instance to hang using 100% CPU and the only way to close it is by force killing it via the Activity Monitor

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
