### PR TITLE
Changing default for ShowLightbulbIconMode to On

### DIFF
--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -2760,7 +2760,7 @@ export type EditorLightbulbOptions = Readonly<Required<IEditorLightbulbOptions>>
 class EditorLightbulb extends BaseEditorOption<EditorOption.lightbulb, IEditorLightbulbOptions, EditorLightbulbOptions> {
 
 	constructor() {
-		const defaults: EditorLightbulbOptions = { enabled: ShowLightbulbIconMode.OnCode };
+		const defaults: EditorLightbulbOptions = { enabled: ShowLightbulbIconMode.On };
 		super(
 			EditorOption.lightbulb, 'lightbulb', defaults,
 			{


### PR DESCRIPTION
Based on the experiment we ran, we decided to  set the default to On.
