### PR TITLE
Command palette should return the "File: Compare New Untitled Text Files" command when I search for "diff" (fix #208897)

### DIFF
--- a/src/vs/workbench/contrib/files/browser/fileActions.contribution.ts
+++ b/src/vs/workbench/contrib/files/browser/fileActions.contribution.ts
@@ -246,7 +246,10 @@ appendToCommandPalette({
 appendToCommandPalette({
 	id: COMPARE_WITH_SAVED_COMMAND_ID,
 	title: nls.localize2('compareActiveWithSaved', "Compare Active File with Saved"),
-	category: Categories.File
+	category: Categories.File,
+	metadata: {
+		description: nls.localize2('compareActiveWithSavedMeta', "Opens a new diff editor to compare the active file with the version on disk.")
+	}
 });
 
 appendToCommandPalette({

--- a/src/vs/workbench/contrib/files/browser/fileActions.ts
+++ b/src/vs/workbench/contrib/files/browser/fileActions.ts
@@ -490,7 +490,10 @@ export class GlobalCompareResourcesAction extends Action2 {
 			title: GlobalCompareResourcesAction.LABEL,
 			f1: true,
 			category: Categories.File,
-			precondition: ActiveEditorContext
+			precondition: ActiveEditorContext,
+			metadata: {
+				description: nls.localize2('compareFileWithMeta', "Opens a picker to select a file to diff with the active editor.")
+			}
 		});
 	}
 
@@ -771,7 +774,10 @@ export class CompareNewUntitledTextFilesAction extends Action2 {
 			id: CompareNewUntitledTextFilesAction.ID,
 			title: CompareNewUntitledTextFilesAction.LABEL,
 			f1: true,
-			category: Categories.File
+			category: Categories.File,
+			metadata: {
+				description: nls.localize2('compareNewUntitledTextFilesMeta', "Opens a new diff editor with two untitled files.")
+			}
 		});
 	}
 
@@ -800,7 +806,10 @@ export class CompareWithClipboardAction extends Action2 {
 			title: CompareWithClipboardAction.LABEL,
 			f1: true,
 			category: Categories.File,
-			keybinding: { primary: KeyChord(KeyMod.CtrlCmd | KeyCode.KeyK, KeyCode.KeyC), weight: KeybindingWeight.WorkbenchContrib }
+			keybinding: { primary: KeyChord(KeyMod.CtrlCmd | KeyCode.KeyK, KeyCode.KeyC), weight: KeybindingWeight.WorkbenchContrib },
+			metadata: {
+				description: nls.localize2('compareWithClipboardMeta', "Opens a new diff editor to compare the active file with the contents of the clipboard.")
+			}
 		});
 	}
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
