### PR TITLE
fix: contentWidgets position

### DIFF
--- a/src/vs/editor/browser/viewParts/contentWidgets/contentWidgets.ts
+++ b/src/vs/editor/browser/viewParts/contentWidgets/contentWidgets.ts
@@ -353,9 +353,8 @@ class Widget {
 
 		const domNodePosition = dom.getDomNodePagePosition(this._viewDomNode.domNode);
 		const elDocument = this._viewDomNode.domNode.ownerDocument;
-		const elWindow = elDocument.defaultView;
-		const absoluteAboveTop = domNodePosition.top + aboveTop - (elWindow?.scrollY ?? 0);
-		const absoluteBelowTop = domNodePosition.top + belowTop - (elWindow?.scrollY ?? 0);
+		const absoluteAboveTop = aboveTop - window.scrollY;
+		const absoluteBelowTop = belowTop - window.scrollY;
 
 		const windowSize = dom.getClientArea(elDocument.body);
 		const [left, absoluteAboveLeft] = this._layoutHorizontalSegmentInPage(windowSize, domNodePosition, anchor.left - ctx.scrollLeft + this._contentLeft, width);
@@ -377,7 +376,7 @@ class Widget {
 			};
 		}
 
-		return { fitsAbove, aboveTop, fitsBelow, belowTop, left };
+		return { fitsAbove, aboveTop: aboveTop < 0 ? belowTop : aboveTop, fitsBelow, belowTop, left };
 	}
 
 	private _prepareRenderWidgetAtExactPositionOverflowing(topLeft: Coordinate): Coordinate {

--- a/src/vs/editor/browser/viewParts/contentWidgets/contentWidgets.ts
+++ b/src/vs/editor/browser/viewParts/contentWidgets/contentWidgets.ts
@@ -353,8 +353,9 @@ class Widget {
 
 		const domNodePosition = dom.getDomNodePagePosition(this._viewDomNode.domNode);
 		const elDocument = this._viewDomNode.domNode.ownerDocument;
-		const absoluteAboveTop = aboveTop - window.scrollY;
-		const absoluteBelowTop = belowTop - window.scrollY;
+		const elWindow = elDocument.defaultView;
+		const absoluteAboveTop = aboveTop - (elWindow?.scrollY ?? 0);
+		const absoluteBelowTop = belowTop - (elWindow?.scrollY ?? 0);
 
 		const windowSize = dom.getClientArea(elDocument.body);
 		const [left, absoluteAboveLeft] = this._layoutHorizontalSegmentInPage(windowSize, domNodePosition, anchor.left - ctx.scrollLeft + this._contentLeft, width);


### PR DESCRIPTION
When the package editor div is set to overflow:hidden, the contentWidgets in the first and second rows will be covered.
<img width="1480" alt="monaco" src="https://github.com/microsoft/vscode/assets/11404470/2f6ec52d-a6ef-4679-b636-10e422273d1c">
https://microsoft.github.io/monaco-editor/playground.html?source=v0.47.0#XQAAAALLBQAAAAAAAABBqQkHQ5NjdVl7kv_fvV9qAMfxMYIuJLeSgI72lQPteCuQDwIsgwP15WM1yBCCe_-VVAaIcJQiPmX0A8Vi5EjAHl46Zdqv-M_rMnvoL1dgL753qpv8vAn66nLKt7B0-Ojj9L49y8hzq_AAuoIfR_hOYiNaUaP_vJwau9-Fhtu5t8F5PxwvjIDom-OWWWcxT8Vfvvk8F7LhuLrODqODUUsrOGHOFsWB_FT-cyydc4TPcVq9nNoW2aQK-75WwNFSQLSzECJv2WJOhEtA8-BCIUga6ic7eefk8AgdX8vytwCk9-7ZFH01FgNGV7glkWSfTZqG3r3ylCvDlA_Rb3CqTlxyC1vIre0Hy20b2pFWHQImHf4EOxJ3AmZhjrRw9CwSmpYMwXrJmOm5b7t0qf0h4mdV7VYfA-nLJNG7ggBKXIgqa4Y8GlpC-tSgvOYKQ7DCm3_EP0IRzlkhH4bC-PLQtLMYbfPoS_4VEME4omvWG2ukS-kAJoVXMQ8wsYVJP8MyOYShH3u4R3ThZk46kcZZ5glK9PJ4yCfIweJYAg4mZYqg9CjUeGF5jFzclP1wjK0FYDeCWKfbnLrIHeKWiYL6kyJ-u7dkmksfQgWZ2n6kVx8AVOGpoLnVr8R2KhBbvfG9mkTIsumUNcL_rNmNEaemZFRdxQ7C0r1_Wuq1KhEV1HvocQy6y2BTOC3y0c2-x21S__qwz9pQWk5RrcfwqEU7vbq8P4p5WQs3VnSN68S9lQMuYrLLPtIj-vvexDPagAdClEZ1dmBeo04_RoNYX_ZcP0W51AQVJoOyoaEgtaWZjubE273ZSJMI9YHdwLv5DT8RjnvXJm0ESOTTsv_0lAak

