### PR TITLE
Fix synchronization of scrolling event flooding

### DIFF
--- a/src/vs/workbench/contrib/scrollLocking/browser/scrollLocking.ts
+++ b/src/vs/workbench/contrib/scrollLocking/browser/scrollLocking.ts
@@ -12,6 +12,7 @@ import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 import { SideBySideEditor } from 'vs/workbench/browser/parts/editor/sideBySideEditor';
 import { IWorkbenchContribution } from 'vs/workbench/common/contributions';
 import { IEditorPane, IEditorPaneScrollPosition, isEditorPaneWithScrolling } from 'vs/workbench/common/editor';
+import { ReentrancyBarrier } from 'vs/workbench/contrib/mergeEditor/browser/utils';
 import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
 import { IStatusbarEntryAccessor, IStatusbarService, StatusbarAlignment } from 'vs/workbench/services/statusbar/browser/statusbar';
 
@@ -59,6 +60,9 @@ export class SyncScroll extends Disposable implements IWorkbenchContribution {
 		this.toggleStatusbarItem(this.isActive);
 	}
 
+	// makes sure that the onDidEditorPaneScroll is not called multiple times for the same event
+	private _reentrancyBarrier = new ReentrancyBarrier();
+
 	private trackVisiblePanes(): void {
 		this.paneDisposables.clear();
 		this.paneInitialScrollTop.clear();
@@ -70,7 +74,11 @@ export class SyncScroll extends Disposable implements IWorkbenchContribution {
 			}
 
 			this.paneInitialScrollTop.set(pane, pane.getScrollPosition());
-			this.paneDisposables.add(pane.onDidChangeScroll(() => this.onDidEditorPaneScroll(pane)));
+			this.paneDisposables.add(pane.onDidChangeScroll(() =>
+				this._reentrancyBarrier.runExclusively(() => {
+					this.onDidEditorPaneScroll(pane);
+				})
+			));
 		}
 	}
 


### PR DESCRIPTION
This pull request fixes the issue of synchronization scrolling event flooding that can cause the editors to crash or be stuck. The issue is caused by the order in which the events are triggered. The fix ensures that the onDidEditorPaneScroll event is not called multiple times for the same event, preventing flooding and potential crashes. Fixes #209020