### PR TITLE
Making same changes to JavaScript language configuration file as for TypeScript

### DIFF
--- a/extensions/javascript/javascript-language-configuration.json
+++ b/extensions/javascript/javascript-language-configuration.json
@@ -119,6 +119,9 @@
 		// e.g.  * ...| or */| or *-----*/|
 		"unIndentedLinePattern": {
 			"pattern": "^(\\t|[ ])*[ ]\\*[^/]*\\*/\\s*$|^(\\t|[ ])*[ ]\\*/\\s*$|^(\\t|[ ])*[ ]\\*([ ]([^\\*]|\\*(?!/))*)?$"
+		},
+		"indentNextLinePattern": {
+			"pattern": "^((.*=>\\s*)|((.*[^\\w]+|\\s*)(if|while|for)\\s*\\(.*\\)\\s*))$"
 		}
 	},
 	"onEnterRules": [
@@ -197,6 +200,33 @@
 			"action": {
 				"indent": "outdent"
 			}
-		}
+		},
+		// Indent when pressing enter from inside ()
+		{
+			"beforeText": "^.*\\([^\\)]*$",
+			"afterText": "^\\s*\\).*$",
+			"action": {
+				"indent": "indentOutdent",
+				"appendText": "\t",
+			}
+		},
+		// Indent when pressing enter from inside {}
+		{
+			"beforeText": "^.*\\{[^\\}]*$",
+			"afterText": "^\\s*\\}.*$",
+			"action": {
+				"indent": "indentOutdent",
+				"appendText": "\t",
+			}
+		},
+		// Indent when pressing enter from inside []
+		{
+			"beforeText": "^.*\\[[^\\]]*$",
+			"afterText": "^\\s*\\].*$",
+			"action": {
+				"indent": "indentOutdent",
+				"appendText": "\t",
+			}
+		},
 	]
 }


### PR DESCRIPTION
Three PRs have been made to improve the indentation in TypeScript files as follows:

- https://github.com/microsoft/vscode/pull/208291
- https://github.com/microsoft/vscode/pull/208287
- https://github.com/microsoft/vscode/pull/208319

The same changes were not made to the JavaScript language configuration file although they should have been made because the language configuration files are quasi identical. This PR aims to address this.

In relation to https://github.com/microsoft/vscode/issues/43244