### PR TITLE
Revert "debug: log progress in NamedPipeDebugAdapter tests (#170713)"

### DIFF
--- a/src/vs/workbench/contrib/debug/test/node/streamDebugAdapter.test.ts
+++ b/src/vs/workbench/contrib/debug/test/node/streamDebugAdapter.test.ts
@@ -49,23 +49,15 @@ suite('Debug - StreamDebugAdapter', () => {
 	ensureNoDisposablesAreLeakedInTestSuite();
 
 	test(`StreamDebugAdapter (NamedPipeDebugAdapter) can initialize a connection`, async () => {
-		// todo@connor4312: debug test failure that seems to only happen in CI.
-		// Even running this test on a loop on my machine for an hour doesn't hit failures :(
-		const progress: string[] = [];
-		const timeout = setTimeout(() => {
-			console.log('NamedPipeDebugAdapter test might fail. Progress:', progress.join(','));
-		}, 1000); // should usually finish is <10ms
 
 		const pipeName = crypto.randomBytes(10).toString('hex');
 		const pipePath = platform.isWindows ? join('\\\\.\\pipe\\', pipeName) : join(tmpdir(), pipeName);
-		progress.push(`listen on ${pipePath}`);
 		const server = await new Promise<net.Server>((resolve, reject) => {
 			const server = net.createServer(serverConnection);
 			server.once('listening', () => resolve(server));
 			server.once('error', reject);
 			server.listen(pipePath);
 		});
-		progress.push('server up');
 
 		const debugAdapter = new NamedPipeDebugAdapter({
 			type: 'pipeServer',
@@ -73,16 +65,12 @@ suite('Debug - StreamDebugAdapter', () => {
 		});
 		try {
 			await debugAdapter.startSession();
-			progress.push('started session');
 			const response: DebugProtocol.Response = await sendInitializeRequest(debugAdapter);
-			progress.push('got response');
 			assert.strictEqual(response.command, 'initialize');
 			assert.strictEqual(response.request_seq, 1);
 			assert.strictEqual(response.success, true, response.message);
 		} finally {
 			await debugAdapter.stopSession();
-			progress.push('stopped session');
-			clearTimeout(timeout);
 			server.close();
 			debugAdapter.dispose();
 		}


### PR DESCRIPTION
This reverts commit 32bb67bc16d442c55ad4f3a52ad0d7586d865406.

This test hasn't flaked in the last two years, and now the console logs
can cause a failure themselves if the test runs slowly.

Closes #209049

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
