### PR TITLE
get request to show up in chat view

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/chat/browser/terminalChatController.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chat/browser/terminalChatController.ts
@@ -375,6 +375,7 @@ export class TerminalChatController extends Disposable implements ITerminalContr
 	reveal(): void {
 		this._chatWidget?.value.reveal();
 	}
+
 	async viewInChat(): Promise<void> {
 		const providerInfo = this._chatService.getProviderInfos()?.[0];
 		if (!providerInfo) {

--- a/src/vs/workbench/contrib/terminalContrib/chat/browser/terminalChatController.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chat/browser/terminalChatController.ts
@@ -375,34 +375,26 @@ export class TerminalChatController extends Disposable implements ITerminalContr
 	reveal(): void {
 		this._chatWidget?.value.reveal();
 	}
-
 	async viewInChat(): Promise<void> {
 		const providerInfo = this._chatService.getProviderInfos()?.[0];
 		if (!providerInfo) {
 			return;
 		}
-		const model = this._model.value;
 		const widget = await this._chatWidgetService.revealViewForProvider(providerInfo.id);
-		if (widget) {
-			if (widget.viewModel && model) {
-				for (const request of model.getRequests()) {
-					if (request.response?.response.value || request.response?.result) {
-						this._chatService.addCompleteRequest(widget.viewModel.sessionId,
-							request.message as IParsedChatRequest,
-							request.variableData,
-							{
-								message: request.response.response.value,
-								result: request.response.result,
-								followups: request.response.followups
-							});
-					}
-				}
-				widget.focusLastMessage();
-			} else if (!model) {
-				widget.focusInput();
-			}
-			this._chatWidget?.rawValue?.hide();
+		const request = this._currentRequest;
+		if (!widget || !request) {
+			return;
 		}
+		this._chatService.addCompleteRequest(widget!.viewModel!.sessionId,
+			request.message.text,
+			request.variableData,
+			{
+				message: request.response!.response.value,
+				result: request.response!.result,
+				followups: request.response!.followups
+			});
+		widget.focusLastMessage();
+		this._chatWidget?.rawValue?.hide();
 	}
 
 	// TODO: Move to register calls, don't override

--- a/src/vs/workbench/contrib/terminalContrib/chat/browser/terminalChatController.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chat/browser/terminalChatController.ts
@@ -383,7 +383,7 @@ export class TerminalChatController extends Disposable implements ITerminalContr
 		}
 		const widget = await this._chatWidgetService.revealViewForProvider(providerInfo.id);
 		const request = this._currentRequest;
-		if (!widget || !request) {
+		if (!widget || !request?.response) {
 			return;
 		}
 		this._chatService.addCompleteRequest(widget!.viewModel!.sessionId,


### PR DESCRIPTION
This took awhile 😓 . the issue was passing in the response as `IParsedChatRequest` meant it was getting parsed using the `parts: []` so resulted in the empty string. Instead, we now just pass in the string query.

The other changes are just simplifying the code because we cache the current request, so don't need to go looking for it in a convoluted way.

fixes https://github.com/microsoft/vscode-copilot/issues/4725