### PR TITLE
Fix typo in editor.action.startDebugTextMate title

### DIFF
--- a/src/vs/workbench/contrib/codeEditor/electron-sandbox/startDebugTextMate.ts
+++ b/src/vs/workbench/contrib/codeEditor/electron-sandbox/startDebugTextMate.ts
@@ -29,7 +29,7 @@ class StartDebugTextMate extends Action2 {
 	constructor() {
 		super({
 			id: 'editor.action.startDebugTextMate',
-			title: nls.localize2('startDebugTextMate', "Start Text Mate Syntax Grammar Logging"),
+			title: nls.localize2('startDebugTextMate', "Start TextMate Syntax Grammar Logging"),
 			category: Categories.Developer,
 			f1: true
 		});


### PR DESCRIPTION
TextMate is one word.

Sorry for the tiny PR but as a switcher from TextMate to VS Code it makes me a little bit sad every time I invoke this in the UI, and I just found out PRs fixing errors in translatable strings are apparently welcomed.