### PR TITLE
Fix #206511: Shortcuts now visit the correct search entry after editing

### DIFF
--- a/src/vs/workbench/contrib/search/browser/searchView.ts
+++ b/src/vs/workbench/contrib/search/browser/searchView.ts
@@ -722,8 +722,42 @@ export class SearchView extends ViewPane {
 		return this.refreshTree(event);
 	}
 
+	private reselectAfterRefreshTree(beforePreviousSelection: RenderableMatch | null): void {
+		// Selection exists -> no need to reselect as what caused the tree to refresh didn't change the selected match
+		if (this.tree.selectionSize > 0 || !beforePreviousSelection) {
+			return;
+		}
+
+		// Go to the first element of the tree
+		const iterator = this.tree.navigate();
+		let current = iterator.first();
+		// Look for the element before the previous selection in the tree
+		while (!!current) {
+			if (current.id() === beforePreviousSelection.id()) {
+				this.tree.setSelection([current]);
+				this.tree.setFocus([current]);
+				this.tree.reveal(current);
+			}
+			current = iterator.next();
+		}
+	}
+
 	refreshTree(event?: IChangeEvent): void {
 		const collapseResults = this.searchConfig.collapseResults;
+
+		// Get the selection before the refresh
+		const [previous] = this.tree.getSelection();
+		const navigator = this.tree.navigate(previous);
+		let beforePrevious = navigator.previous();
+		// Expand until beforePrevious is a Match
+		while (beforePrevious && !(beforePrevious instanceof Match)) {
+			if (this.tree.isCollapsed(beforePrevious)) {
+				this.tree.expand(beforePrevious);
+			}
+
+			beforePrevious = navigator.previous();
+		}
+
 		if (!event || event.added || event.removed) {
 			// Refresh whole tree
 			if (this.searchConfig.sortOrder === SearchSortOrder.Modified) {
@@ -746,6 +780,7 @@ export class SearchView extends ViewPane {
 				});
 			}
 		}
+		this.reselectAfterRefreshTree(beforePrevious);
 	}
 
 	private createResultIterator(collapseResults: ISearchConfigurationProperties['collapseResults']): Iterable<ICompressedTreeElement<RenderableMatch>> {

--- a/test/automation/src/search.ts
+++ b/test/automation/src/search.ts
@@ -126,6 +126,10 @@ export class Search extends Viewlet {
 		await this.code.waitForTextContent(`${VIEWLET} .messages`, undefined, text => text === '' || text.startsWith('Search was canceled before any results could be found'), retryCount);
 	}
 
+	async waitForSelectNextResult(): Promise<void> {
+		await this.code.dispatchKeybinding('F4');
+	}
+
 	private async waitForInputFocus(selector: string): Promise<void> {
 		let retries = 0;
 

--- a/test/automation/src/search.ts
+++ b/test/automation/src/search.ts
@@ -10,6 +10,7 @@ const VIEWLET = '.search-view';
 const INPUT = `${VIEWLET} .search-widget .search-container .monaco-inputbox textarea`;
 const INCLUDE_INPUT = `${VIEWLET} .query-details .file-types.includes .monaco-inputbox input`;
 const FILE_MATCH = (filename: string) => `${VIEWLET} .results .filematch[data-resource$="${filename}"]`;
+const SELECTED_MATCH = `${VIEWLET} .results .focused.selected .plain.match`;
 
 async function retry(setup: () => Promise<any>, attempt: () => Promise<any>) {
 	let count = 0;
@@ -81,6 +82,10 @@ export class Search extends Viewlet {
 		await this.code.waitAndClick(`${VIEWLET} .query-details.more .more`);
 	}
 
+	async matchWholeWord(): Promise<void> {
+		await this.code.waitAndClick(`${VIEWLET} .search-widget .search-container .codicon-whole-word`);
+	}
+
 	async removeFileMatch(filename: string, expectedText: string): Promise<void> {
 		const fileMatch = FILE_MATCH(filename);
 
@@ -126,8 +131,9 @@ export class Search extends Viewlet {
 		await this.code.waitForTextContent(`${VIEWLET} .messages`, undefined, text => text === '' || text.startsWith('Search was canceled before any results could be found'), retryCount);
 	}
 
-	async waitForSelectNextResult(): Promise<void> {
-		await this.code.dispatchKeybinding('F4');
+	async waitForSelectedMatchText(text: string, retryCount?: number): Promise<void> {
+		// Confirms that the current selected result contains the provided text
+		await this.code.waitForTextContent(SELECTED_MATCH, undefined, result => result.startsWith(text), retryCount);
 	}
 
 	private async waitForInputFocus(selector: string): Promise<void> {

--- a/test/smoke/src/areas/search/search.test.ts
+++ b/test/smoke/src/areas/search/search.test.ts
@@ -48,6 +48,32 @@ export function setup(logger: Logger) {
 			await app.workbench.search.removeFileMatch('app.js', '2 results in 2 files');
 		});
 
+		it('navigates search results & checks for correct selection after removal', async function () {
+			const app = this.app as Application;
+			await app.workbench.search.openSearchViewlet();
+			await app.workbench.search.searchFor('body');
+
+			// Go to the first result not in app.js
+			await app.workbench.search.waitForSelectNextResult();
+			await app.workbench.search.waitForSelectNextResult();
+			await app.workbench.search.waitForSelectNextResult();
+			await app.workbench.search.waitForSelectNextResult();
+			await app.workbench.search.waitForSelectNextResult();
+
+			// Delete the next result (only result in style.css)
+			await app.code.dispatchKeybinding('Backspace');
+
+			// Should go to the result in layout.pug
+			await app.workbench.search.waitForSelectNextResult();
+			// Delete the next result (only result in style.css)
+			await app.code.dispatchKeybinding('Backspace');
+			await app.code.dispatchKeybinding('escape');
+
+			// The only results left should be in app.js
+			await app.workbench.search.searchFor('body');
+			await app.workbench.search.waitForResultText('4 results in 1 file');
+		});
+
 		it.skip('replaces first search result with a replace term', async function () { // TODO@roblourens https://github.com/microsoft/vscode/issues/137195
 			const app = this.app as Application;
 

--- a/test/smoke/src/areas/search/search.test.ts
+++ b/test/smoke/src/areas/search/search.test.ts
@@ -48,30 +48,23 @@ export function setup(logger: Logger) {
 			await app.workbench.search.removeFileMatch('app.js', '2 results in 2 files');
 		});
 
-		it('navigates search results & checks for correct selection after removal', async function () {
+		it('#206511, navigates results & checks for correct selection after editing current result', async function () {
 			const app = this.app as Application;
 			await app.workbench.search.openSearchViewlet();
+			await app.workbench.search.matchWholeWord();
 			await app.workbench.search.searchFor('body');
+			await app.workbench.search.waitForResultText('3 results in 3 files');
 
-			// Go to the first result not in app.js
-			await app.workbench.search.waitForSelectNextResult();
-			await app.workbench.search.waitForSelectNextResult();
-			await app.workbench.search.waitForSelectNextResult();
-			await app.workbench.search.waitForSelectNextResult();
-			await app.workbench.search.waitForSelectNextResult();
-
-			// Delete the next result (only result in style.css)
-			await app.code.dispatchKeybinding('Backspace');
-
-			// Should go to the result in layout.pug
-			await app.workbench.search.waitForSelectNextResult();
-			// Delete the next result (only result in style.css)
-			await app.code.dispatchKeybinding('Backspace');
-			await app.code.dispatchKeybinding('escape');
-
-			// The only results left should be in app.js
-			await app.workbench.search.searchFor('body');
-			await app.workbench.search.waitForResultText('4 results in 1 file');
+			// Select second result ("body {" in style.css)
+			await app.code.dispatchKeybinding('F4');
+			await app.code.dispatchKeybinding('F4');
+			await app.workbench.search.waitForSelectedMatchText('body {');
+			// Replace the current selection so that it no longer matches the query
+			await app.workbench.editor.waitForTypeInEditor('style.css', 'ist');
+			await app.code.dispatchKeybinding('F4');
+			// Verify that the selection goes to the actual "next",
+			// instead of going back to the first result
+			await app.workbench.search.waitForSelectedMatchText('body');
 		});
 
 		it.skip('replaces first search result with a replace term', async function () { // TODO@roblourens https://github.com/microsoft/vscode/issues/137195


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/206511
Bug (previous behavior):
    Press Ctrl+Shift+F to perform a search.
    Press F4 a few times.
    Edit the selected result so it no longer matches the query.
	The active position in the search pane disappears.
    Press F4. Editor location jumps to the first found item.

Solution:
When the search results change, the tree in src/vs/workbench/contrib/search/browser/searchView.ts now correctly updates the selected result if it is no longer present. This is accomplished by keeping a reference to the Match immediately before the selection. If the tree's selection is deleted, we will find this reference and make this the new selection.

Testing:
This is tested via a smoke test, which attempts to perform deletions via the keyboard shortcuts in order to keep only the results in the first FileMatch.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
