### PR TITLE
Limit drop bail out to just http(s) uris

### DIFF
--- a/extensions/markdown-language-features/src/languageFeatures/copyFiles/dropOrPasteResource.ts
+++ b/extensions/markdown-language-features/src/languageFeatures/copyFiles/dropOrPasteResource.ts
@@ -156,9 +156,14 @@ class ResourcePasteOrDropProvider implements vscode.DocumentPasteEditProvider, v
 			return;
 		}
 
-		// Disable ourselves if there's also a text entry with the same content as our list,
+		// In some browsers, copying from the address bar sets both text/uri-list and text/plain.
+		// Disable ourselves if there's also a text entry with the same http(s) uri as our list,
 		// unless we are explicitly requested.
-		if (uriList.entries.length === 1 && !context?.only?.contains(ResourcePasteOrDropProvider.kind)) {
+		if (
+			uriList.entries.length === 1
+			&& (uriList.entries[0].uri.scheme === Schemes.http || uriList.entries[0].uri.scheme === Schemes.https)
+			&& !context?.only?.contains(ResourcePasteOrDropProvider.kind)
+		) {
 			const text = await dataTransfer.get(Mime.textPlain)?.asString();
 			if (token.isCancellationRequested) {
 				return;


### PR DESCRIPTION
Fixes #209239

The previous check was too broad and caused us to bail when pasting `file` uris. The specific case this code was trying to work around was copy/pasting from the browser address bar, which should almost always be a http or https uri

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
