### PR TITLE
Pick up editor action command descriptions

### DIFF
--- a/src/vs/editor/contrib/quickAccess/browser/commandsQuickAccess.ts
+++ b/src/vs/editor/contrib/quickAccess/browser/commandsQuickAccess.ts
@@ -5,6 +5,8 @@
 
 import { stripIcons } from 'vs/base/common/iconLabels';
 import { IEditor } from 'vs/editor/common/editorCommon';
+import { ILocalizedString } from 'vs/nls';
+import { isLocalizedString } from 'vs/platform/action/common/action';
 import { ICommandService } from 'vs/platform/commands/common/commands';
 import { IDialogService } from 'vs/platform/dialogs/common/dialogs';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
@@ -38,9 +40,18 @@ export abstract class AbstractEditorCommandsQuickAccessProvider extends Abstract
 
 		const editorCommandPicks: ICommandQuickPick[] = [];
 		for (const editorAction of activeTextEditorControl.getSupportedActions()) {
+			let commandDescription: undefined | ILocalizedString;
+			if (editorAction.metadata?.description) {
+				if (isLocalizedString(editorAction.metadata.description)) {
+					commandDescription = editorAction.metadata.description;
+				} else {
+					commandDescription = { original: editorAction.metadata.description, value: editorAction.metadata.description };
+				}
+			}
 			editorCommandPicks.push({
 				commandId: editorAction.id,
 				commandAlias: editorAction.alias,
+				commandDescription,
 				label: stripIcons(editorAction.label) || editorAction.id,
 			});
 		}


### PR DESCRIPTION
Continuation of https://github.com/microsoft/vscode/pull/193937 and https://github.com/microsoft/vscode/pull/197442

This adds the command descriptions of editor actions to the ICommandQuickPick results so that those results can be picked up by the "similar commands" feature.

Example:

I can add:
```
metadata: {
    description: nls.localize2('test', "xyz"),
}
```
to the [AddLineCommentAction](https://github.com/microsoft/vscode/blob/7d788e70b95c79718b565ff9e255858db4cc74b3/src/vs/editor/contrib/comment/browser/comment.ts#L105)... and then when I search "xyz" it'll show up.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
<img width="527" alt="image" src="https://github.com/microsoft/vscode/assets/2644648/0fb61f28-a691-48c2-a3f6-99768e27b01a">
