### PR TITLE
De-select output for `focus cell container` commands

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
@@ -2367,8 +2367,9 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditorD
 			return;
 		}
 
+		cell.focusedOutputId = undefined;
+
 		if (focusItem === 'editor') {
-			cell.focusedOutputId = undefined;
 			this.focusElement(cell);
 			this._list.focusView();
 
@@ -2424,10 +2425,9 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditorD
 			const itemDOM = this._list.domElementOfElement(cell);
 			if (itemDOM && itemDOM.ownerDocument.activeElement && itemDOM.contains(itemDOM.ownerDocument.activeElement)) {
 				(itemDOM.ownerDocument.activeElement as HTMLElement).blur();
-			} else if (cell.focusedOutputId) {
-				this._webview?.blurOutput(cell.focusedOutputId);
-				cell.focusedOutputId = undefined;
 			}
+
+			this._webview?.blurOutput();
 
 			cell.updateEditState(CellEditState.Preview, 'focusNotebookCell');
 			cell.focusMode = CellFocusMode.Container;

--- a/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
@@ -2367,9 +2367,8 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditorD
 			return;
 		}
 
-		cell.focusedOutputId = undefined;
-
 		if (focusItem === 'editor') {
+			cell.focusedOutputId = undefined;
 			this.focusElement(cell);
 			this._list.focusView();
 
@@ -2425,6 +2424,9 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditorD
 			const itemDOM = this._list.domElementOfElement(cell);
 			if (itemDOM && itemDOM.ownerDocument.activeElement && itemDOM.contains(itemDOM.ownerDocument.activeElement)) {
 				(itemDOM.ownerDocument.activeElement as HTMLElement).blur();
+			} else if (cell.focusedOutputId) {
+				this._webview?.blurOutput(cell.focusedOutputId);
+				cell.focusedOutputId = undefined;
 			}
 
 			cell.updateEditState(CellEditState.Preview, 'focusNotebookCell');

--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView.ts
@@ -1729,6 +1729,17 @@ export class BackLayerWebView<T extends ICommonCellInfo> extends Themable {
 		});
 	}
 
+	blurOutput(outputId: string) {
+		if (this._disposed) {
+			return;
+		}
+
+		this._sendMessageToWebview({
+			type: 'blur-output',
+			outputId
+		});
+	}
+
 	async find(query: string, options: { wholeWord?: boolean; caseSensitive?: boolean; includeMarkup: boolean; includeOutput: boolean; shouldGetSearchPreviewInfo: boolean; ownerID: string }): Promise<IFindMatch[]> {
 		if (query === '') {
 			this._sendMessageToWebview({

--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView.ts
@@ -1729,14 +1729,13 @@ export class BackLayerWebView<T extends ICommonCellInfo> extends Themable {
 		});
 	}
 
-	blurOutput(outputId: string) {
+	blurOutput() {
 		if (this._disposed) {
 			return;
 		}
 
 		this._sendMessageToWebview({
-			type: 'blur-output',
-			outputId
+			type: 'blur-output'
 		});
 	}
 

--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewMessages.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewMessages.ts
@@ -69,7 +69,7 @@ export interface IScrollAckMessage extends BaseToWebviewMessage {
 	readonly version: number;
 }
 
-export interface IBlurOutputMessage extends BaseToWebviewMessage {
+export interface IFocusEditorMessage extends BaseToWebviewMessage {
 	readonly type: 'focus-editor';
 	readonly cellId: string;
 	readonly focusNext?: boolean;
@@ -260,6 +260,11 @@ export interface IFocusOutputMessage {
 	readonly type: 'focus-output';
 	readonly cellOrOutputId: string;
 	readonly alternateId?: string;
+}
+
+export interface IBlurOutputMessage {
+	readonly type: 'blur-output';
+	readonly outputId: string;
 }
 
 export interface IAckOutputHeight {
@@ -494,7 +499,7 @@ export type FromWebviewMessage = WebviewInitialized |
 	IScrollToRevealMessage |
 	IWheelMessage |
 	IScrollAckMessage |
-	IBlurOutputMessage |
+	IFocusEditorMessage |
 	ICustomKernelMessage |
 	ICustomRendererMessage |
 	IClickedDataUrlMessage |
@@ -520,6 +525,7 @@ export type FromWebviewMessage = WebviewInitialized |
 
 export type ToWebviewMessage = IClearMessage |
 	IFocusOutputMessage |
+	IBlurOutputMessage |
 	IAckOutputHeightMessage |
 	ICreationRequestMessage |
 	IViewScrollTopRequestMessage |

--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewMessages.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewMessages.ts
@@ -264,7 +264,6 @@ export interface IFocusOutputMessage {
 
 export interface IBlurOutputMessage {
 	readonly type: 'blur-output';
-	readonly outputId: string;
 }
 
 export interface IAckOutputHeight {

--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewPreloads.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewPreloads.ts
@@ -271,6 +271,19 @@ async function webviewPreloads(ctx: PreloadContext) {
 			postNotebookMessage<webviewMessages.IOutputFocusMessage>('outputFocus', outputFocus);
 		}
 	};
+
+	const blurOutput = (outputId: string) => {
+		const cellOutputContainer = window.document.getElementById(outputId);
+		if (!cellOutputContainer) {
+			return;
+		}
+		const selection = cellOutputContainer.getSelection();
+		if (!selection) {
+			return;
+		}
+		selection.removeAllRanges();
+	};
+
 	const selectOutputContents = (cellOrOutputId: string) => {
 		const selection = window.getSelection();
 		if (!selection) {
@@ -689,7 +702,7 @@ async function webviewPreloads(ctx: PreloadContext) {
 		element.id = `focus-sink-${cellId}`;
 		element.tabIndex = 0;
 		element.addEventListener('focus', () => {
-			postNotebookMessage<webviewMessages.IBlurOutputMessage>('focus-editor', {
+			postNotebookMessage<webviewMessages.IFocusEditorMessage>('focus-editor', {
 				cellId: cellId,
 				focusNext
 			});
@@ -1731,6 +1744,9 @@ async function webviewPreloads(ctx: PreloadContext) {
 			}
 			case 'focus-output':
 				focusFirstFocusableOrContainerInOutput(event.data.cellOrOutputId, event.data.alternateId);
+				break;
+			case 'blur-output':
+				blurOutput(event.data.outputId);
 				break;
 			case 'select-output-contents':
 				selectOutputContents(event.data.cellOrOutputId);

--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewPreloads.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewPreloads.ts
@@ -272,12 +272,8 @@ async function webviewPreloads(ctx: PreloadContext) {
 		}
 	};
 
-	const blurOutput = (outputId: string) => {
-		const cellOutputContainer = window.document.getElementById(outputId);
-		if (!cellOutputContainer) {
-			return;
-		}
-		const selection = cellOutputContainer.getSelection();
+	const blurOutput = () => {
+		const selection = window.getSelection();
 		if (!selection) {
 			return;
 		}
@@ -1746,7 +1742,7 @@ async function webviewPreloads(ctx: PreloadContext) {
 				focusFirstFocusableOrContainerInOutput(event.data.cellOrOutputId, event.data.alternateId);
 				break;
 			case 'blur-output':
-				blurOutput(event.data.outputId);
+				blurOutput();
 				break;
 			case 'select-output-contents':
 				selectOutputContents(event.data.cellOrOutputId);


### PR DESCRIPTION
fix https://github.com/microsoft/vscode-jupyter/issues/15424

pressing `esc` should de-select the output text if any is selected.