### PR TITLE
Remove xterm canvas renderer from fallback logic

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/xterm-private.d.ts
+++ b/src/vs/workbench/contrib/terminal/browser/xterm-private.d.ts
@@ -40,9 +40,7 @@ export interface IXtermCore {
 			}
 		},
 		_renderer: {
-			value?: {
-				_renderLayers?: any[];
-			}
+			value?: unknown;
 		};
 		_handleIntersectionChange: any;
 	};

--- a/src/vs/workbench/contrib/terminal/common/terminalStorageKeys.ts
+++ b/src/vs/workbench/contrib/terminal/common/terminalStorageKeys.ts
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 export const enum TerminalStorageKeys {
-	NeverMeasureRenderTime = 'terminal.integrated.neverMeasureRenderTime',
 	SuggestedRendererType = 'terminal.integrated.suggestedRendererType',
 	TabsListWidthHorizontal = 'tabs-list-width-horizontal',
 	TabsListWidthVertical = 'tabs-list-width-vertical',


### PR DESCRIPTION
This simplifies things a lot, the plan is to remove the canvas renderer completely from VS Code if all goes well (#209276).

Fixes #209275

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
