### PR TITLE
 Add `windowOptions` to xtermTerminal to allow `ESC [18t` to work

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/xterm/xtermTerminal.ts
+++ b/src/vs/workbench/contrib/terminal/browser/xterm/xtermTerminal.ts
@@ -235,6 +235,11 @@ export class XtermTerminal extends Disposable implements IXtermTerminal, IDetach
 			overviewRulerWidth: 10,
 			ignoreBracketedPasteMode: config.ignoreBracketedPasteMode,
 			rescaleOverlappingGlyphs: config.rescaleOverlappingGlyphs,
+			windowOptions: {
+				getWinSizePixels: true,
+				getCellSizePixels: true,
+				getWinSizeChars: true,
+			},
 		}));
 		this._updateSmoothScrolling();
 		this._core = (this.raw as any)._core as IXtermCore;


### PR DESCRIPTION
Fixes #209309 by allowing the three supported `windowOptions` query targets in xterm.js.

Test:

1. Open a new terminal
2. Type `echo -e "\x1b[18t"`
3. Look for the printed escape codes
