### PR TITLE
Fix output vsbuffer transfer via workspace edit.

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadBulkEdits.ts
+++ b/src/vs/workbench/api/browser/mainThreadBulkEdits.ts
@@ -12,6 +12,7 @@ import { IUriIdentityService } from 'vs/platform/uriIdentity/common/uriIdentity'
 import { IWorkspaceEditDto, IWorkspaceFileEditDto, MainContext, MainThreadBulkEditsShape } from 'vs/workbench/api/common/extHost.protocol';
 import { ResourceNotebookCellEdit } from 'vs/workbench/contrib/bulkEdit/browser/bulkCellEdits';
 import { IExtHostContext, extHostNamedCustomer } from 'vs/workbench/services/extensions/common/extHostCustomers';
+import { SerializableObjectWithBuffers } from 'vs/workbench/services/extensions/common/proxyIdentifier';
 
 
 @extHostNamedCustomer(MainContext.MainThreadBulkEdits)
@@ -26,8 +27,8 @@ export class MainThreadBulkEdits implements MainThreadBulkEditsShape {
 
 	dispose(): void { }
 
-	$tryApplyWorkspaceEdit(dto: IWorkspaceEditDto, undoRedoGroupId?: number, isRefactoring?: boolean): Promise<boolean> {
-		const edits = reviveWorkspaceEditDto(dto, this._uriIdentService);
+	$tryApplyWorkspaceEdit(dto: SerializableObjectWithBuffers<IWorkspaceEditDto>, undoRedoGroupId?: number, isRefactoring?: boolean): Promise<boolean> {
+		const edits = reviveWorkspaceEditDto(dto.value, this._uriIdentService);
 		return this._bulkEditService.apply(edits, { undoRedoGroupId, respectAutoSaveConfig: isRefactoring }).then((res) => res.isApplied, err => {
 			this._logService.warn(`IGNORING workspace edit: ${err}`);
 			return false;

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -262,7 +262,7 @@ export interface ITextDocumentShowOptions {
 }
 
 export interface MainThreadBulkEditsShape extends IDisposable {
-	$tryApplyWorkspaceEdit(workspaceEditDto: IWorkspaceEditDto, undoRedoGroupId?: number, respectAutoSaveConfig?: boolean): Promise<boolean>;
+	$tryApplyWorkspaceEdit(workspaceEditDto: SerializableObjectWithBuffers<IWorkspaceEditDto>, undoRedoGroupId?: number, respectAutoSaveConfig?: boolean): Promise<boolean>;
 }
 
 export interface MainThreadTextEditorsShape extends IDisposable {

--- a/src/vs/workbench/api/common/extHostBulkEdits.ts
+++ b/src/vs/workbench/api/common/extHostBulkEdits.ts
@@ -8,6 +8,7 @@ import { MainContext, MainThreadBulkEditsShape } from 'vs/workbench/api/common/e
 import { ExtHostDocumentsAndEditors } from 'vs/workbench/api/common/extHostDocumentsAndEditors';
 import { IExtHostRpcService } from 'vs/workbench/api/common/extHostRpcService';
 import { WorkspaceEdit } from 'vs/workbench/api/common/extHostTypeConverters';
+import { SerializableObjectWithBuffers } from 'vs/workbench/services/extensions/common/proxyIdentifier';
 import type * as vscode from 'vscode';
 
 export class ExtHostBulkEdits {
@@ -28,7 +29,7 @@ export class ExtHostBulkEdits {
 	}
 
 	applyWorkspaceEdit(edit: vscode.WorkspaceEdit, extension: IExtensionDescription, metadata: vscode.WorkspaceEditMetadata | undefined): Promise<boolean> {
-		const dto = WorkspaceEdit.from(edit, this._versionInformationProvider);
+		const dto = new SerializableObjectWithBuffers(WorkspaceEdit.from(edit, this._versionInformationProvider));
 		return this._proxy.$tryApplyWorkspaceEdit(dto, undefined, metadata?.isRefactoring ?? false);
 	}
 }

--- a/src/vs/workbench/api/common/extHostDocumentSaveParticipant.ts
+++ b/src/vs/workbench/api/common/extHostDocumentSaveParticipant.ts
@@ -15,6 +15,7 @@ import type * as vscode from 'vscode';
 import { LinkedList } from 'vs/base/common/linkedList';
 import { ILogService } from 'vs/platform/log/common/log';
 import { IExtensionDescription } from 'vs/platform/extensions/common/extensions';
+import { SerializableObjectWithBuffers } from 'vs/workbench/services/extensions/common/proxyIdentifier';
 
 type Listener = [Function, any, IExtensionDescription];
 
@@ -165,7 +166,7 @@ export class ExtHostDocumentSaveParticipant implements ExtHostDocumentSavePartic
 			}
 
 			if (version === document.version) {
-				return this._mainThreadBulkEdits.$tryApplyWorkspaceEdit(dto);
+				return this._mainThreadBulkEdits.$tryApplyWorkspaceEdit(new SerializableObjectWithBuffers(dto));
 			}
 
 			return Promise.reject(new Error('concurrent_edits'));

--- a/src/vs/workbench/api/common/extHostNotebookDocumentSaveParticipant.ts
+++ b/src/vs/workbench/api/common/extHostNotebookDocumentSaveParticipant.ts
@@ -13,6 +13,7 @@ import { ExtHostNotebookController } from 'vs/workbench/api/common/extHostNotebo
 import { TextDocumentSaveReason, WorkspaceEdit as WorksapceEditConverter } from 'vs/workbench/api/common/extHostTypeConverters';
 import { WorkspaceEdit } from 'vs/workbench/api/common/extHostTypes';
 import { SaveReason } from 'vs/workbench/common/editor';
+import { SerializableObjectWithBuffers } from 'vs/workbench/services/extensions/common/proxyIdentifier';
 import { NotebookDocumentWillSaveEvent } from 'vscode';
 
 interface IExtensionListener<E> {
@@ -90,6 +91,6 @@ export class ExtHostNotebookDocumentSaveParticipant implements ExtHostNotebookDo
 			dto.edits = dto.edits.concat(edits);
 		}
 
-		return this._mainThreadBulkEdits.$tryApplyWorkspaceEdit(dto);
+		return this._mainThreadBulkEdits.$tryApplyWorkspaceEdit(new SerializableObjectWithBuffers(dto));
 	}
 }

--- a/src/vs/workbench/api/test/browser/extHostBulkEdits.test.ts
+++ b/src/vs/workbench/api/test/browser/extHostBulkEdits.test.ts
@@ -13,6 +13,7 @@ import { NullLogService } from 'vs/platform/log/common/log';
 import { ExtHostBulkEdits } from 'vs/workbench/api/common/extHostBulkEdits';
 import { nullExtensionDescription } from 'vs/workbench/services/extensions/common/extensions';
 import { ensureNoDisposablesAreLeakedInTestSuite } from 'vs/base/test/common/utils';
+import { SerializableObjectWithBuffers } from 'vs/workbench/services/extensions/common/proxyIdentifier';
 
 suite('ExtHostBulkEdits.applyWorkspaceEdit', () => {
 
@@ -25,8 +26,8 @@ suite('ExtHostBulkEdits.applyWorkspaceEdit', () => {
 
 		const rpcProtocol = new TestRPCProtocol();
 		rpcProtocol.set(MainContext.MainThreadBulkEdits, new class extends mock<MainThreadBulkEditsShape>() {
-			override $tryApplyWorkspaceEdit(_workspaceResourceEdits: IWorkspaceEditDto): Promise<boolean> {
-				workspaceResourceEdits = _workspaceResourceEdits;
+			override $tryApplyWorkspaceEdit(_workspaceResourceEdits: SerializableObjectWithBuffers<IWorkspaceEditDto>): Promise<boolean> {
+				workspaceResourceEdits = _workspaceResourceEdits.value;
 				return Promise.resolve(true);
 			}
 		});

--- a/src/vs/workbench/api/test/browser/extHostDocumentSaveParticipant.test.ts
+++ b/src/vs/workbench/api/test/browser/extHostDocumentSaveParticipant.test.ts
@@ -16,6 +16,7 @@ import { mock } from 'vs/base/test/common/mock';
 import { NullLogService } from 'vs/platform/log/common/log';
 import { nullExtensionDescription } from 'vs/workbench/services/extensions/common/extensions';
 import { ensureNoDisposablesAreLeakedInTestSuite } from 'vs/base/test/common/utils';
+import { SerializableObjectWithBuffers } from 'vs/workbench/services/extensions/common/proxyIdentifier';
 
 function timeout(n: number) {
 	return new Promise(resolve => setTimeout(resolve, n));
@@ -257,8 +258,8 @@ suite('ExtHostDocumentSaveParticipant', () => {
 
 		let dto: IWorkspaceEditDto;
 		const participant = new ExtHostDocumentSaveParticipant(nullLogService, documents, new class extends mock<MainThreadTextEditorsShape>() {
-			$tryApplyWorkspaceEdit(_edits: IWorkspaceEditDto) {
-				dto = _edits;
+			$tryApplyWorkspaceEdit(_edits: SerializableObjectWithBuffers<IWorkspaceEditDto>) {
+				dto = _edits.value;
 				return Promise.resolve(true);
 			}
 		});
@@ -281,8 +282,8 @@ suite('ExtHostDocumentSaveParticipant', () => {
 
 		let edits: IWorkspaceEditDto;
 		const participant = new ExtHostDocumentSaveParticipant(nullLogService, documents, new class extends mock<MainThreadTextEditorsShape>() {
-			$tryApplyWorkspaceEdit(_edits: IWorkspaceEditDto) {
-				edits = _edits;
+			$tryApplyWorkspaceEdit(_edits: SerializableObjectWithBuffers<IWorkspaceEditDto>) {
+				edits = _edits.value;
 				return Promise.resolve(true);
 			}
 		});
@@ -318,9 +319,9 @@ suite('ExtHostDocumentSaveParticipant', () => {
 	test('event delivery, two listeners -> two document states', () => {
 
 		const participant = new ExtHostDocumentSaveParticipant(nullLogService, documents, new class extends mock<MainThreadTextEditorsShape>() {
-			$tryApplyWorkspaceEdit(dto: IWorkspaceEditDto) {
+			$tryApplyWorkspaceEdit(dto: SerializableObjectWithBuffers<IWorkspaceEditDto>) {
 
-				for (const edit of dto.edits) {
+				for (const edit of dto.value.edits) {
 
 					const uri = URI.revive((<IWorkspaceTextEditDto>edit).resource);
 					const { text, range } = (<IWorkspaceTextEditDto>edit).textEdit;

--- a/src/vs/workbench/api/test/browser/mainThreadEditors.test.ts
+++ b/src/vs/workbench/api/test/browser/mainThreadEditors.test.ts
@@ -48,6 +48,7 @@ import { BulkEditService } from 'vs/workbench/contrib/bulkEdit/browser/bulkEditS
 import { IEditorGroupsService } from 'vs/workbench/services/editor/common/editorGroupsService';
 import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
 import { IWorkbenchEnvironmentService } from 'vs/workbench/services/environment/common/environmentService';
+import { SerializableObjectWithBuffers } from 'vs/workbench/services/extensions/common/proxyIdentifier';
 import { LabelService } from 'vs/workbench/services/label/common/labelService';
 import { ILifecycleService } from 'vs/workbench/services/lifecycle/common/lifecycle';
 import { IPaneCompositePartService } from 'vs/workbench/services/panecomposite/browser/panecomposite';
@@ -204,7 +205,7 @@ suite('MainThreadEditors', () => {
 		// Act as if the user edited the model
 		model.applyEdits([EditOperation.insert(new Position(0, 0), 'something')]);
 
-		return bulkEdits.$tryApplyWorkspaceEdit({ edits: [workspaceResourceEdit] }).then((result) => {
+		return bulkEdits.$tryApplyWorkspaceEdit(new SerializableObjectWithBuffers({ edits: [workspaceResourceEdit] })).then((result) => {
 			assert.strictEqual(result, false);
 		});
 	});
@@ -230,11 +231,11 @@ suite('MainThreadEditors', () => {
 			}
 		};
 
-		const p1 = bulkEdits.$tryApplyWorkspaceEdit({ edits: [workspaceResourceEdit1] }).then((result) => {
+		const p1 = bulkEdits.$tryApplyWorkspaceEdit(new SerializableObjectWithBuffers({ edits: [workspaceResourceEdit1] })).then((result) => {
 			// first edit request succeeds
 			assert.strictEqual(result, true);
 		});
-		const p2 = bulkEdits.$tryApplyWorkspaceEdit({ edits: [workspaceResourceEdit2] }).then((result) => {
+		const p2 = bulkEdits.$tryApplyWorkspaceEdit(new SerializableObjectWithBuffers({ edits: [workspaceResourceEdit2] })).then((result) => {
 			// second edit request fails
 			assert.strictEqual(result, false);
 		});
@@ -242,13 +243,13 @@ suite('MainThreadEditors', () => {
 	});
 
 	test(`applyWorkspaceEdit with only resource edit`, () => {
-		return bulkEdits.$tryApplyWorkspaceEdit({
+		return bulkEdits.$tryApplyWorkspaceEdit(new SerializableObjectWithBuffers({
 			edits: [
 				{ oldResource: resource, newResource: resource, options: undefined },
 				{ oldResource: undefined, newResource: resource, options: undefined },
 				{ oldResource: resource, newResource: undefined, options: undefined }
 			]
-		}).then((result) => {
+		})).then((result) => {
 			assert.strictEqual(result, true);
 			assert.strictEqual(movedResources.get(resource), resource);
 			assert.strictEqual(createdResources.has(resource), true);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

While playing Workspace Edit with notebooks, I found that when insert cells with outputs, outputs are always dropped. Turned out to be that we are not sending `VSBuffer` properly.

Notebook's execute handler will wrap the output updates with `SerializableObjectWithBuffers` to ensure that the buffers in outputs are serialized/deserialized correctly. 

https://github.com/microsoft/vscode/blob/39df90bb8aff05548cdd9d3eeee12e11b4193353/src/vs/workbench/api/common/extHostNotebookKernels.ts#L623 

Since we have notebook edits (which can contain output buffers) in `WorkspaceEdit`, we might want to do the same with `MainThreadBulkEditsShape#$tryApplyWorkspaceEdit`

cc @jrieken @mjbvz 