### PR TITLE
allow input elements to handle keydown events

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewPreloads.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewPreloads.ts
@@ -357,7 +357,7 @@ async function webviewPreloads(ctx: PreloadContext) {
 		}
 		const activeElement = window.document.activeElement;
 		if (activeElement?.tagName === 'INPUT' || activeElement?.tagName === 'TEXTAREA') {
-			e.preventDefault(); // We will handle selection in editor code.
+			// The input element will handle this.
 			return;
 		}
 


### PR DESCRIPTION
fix https://github.com/microsoft/vscode/issues/209355

input and text area elements will handle and swallow keypress events correctly, so just let them handle those. Similar to what was done [here](https://github.com/microsoft/vscode/blob/aamunger/releasePort/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewPreloads.ts#L316)
