### PR TITLE
chore: increase timeout of Linux x64 job

### DIFF
--- a/build/azure-pipelines/product-build.yml
+++ b/build/azure-pipelines/product-build.yml
@@ -455,6 +455,7 @@ extends:
 
             - ${{ if and(eq(variables['VSCODE_CIBUILD'], false), eq(parameters.VSCODE_BUILD_LINUX, true)) }}:
               - job: Linuxx64
+                timeoutInMinutes: 90
                 variables:
                   VSCODE_ARCH: x64
                   NPM_ARCH: x64


### PR DESCRIPTION
The Linux x64 job in particular times out often on the CodeQL Finalize task.
This PR increases the timeout to 90 minutes, because it seems like the job does finish, just not in under an hour.