### PR TITLE
Support setting keyboard shortcut from Action Item Context Menu

### DIFF
--- a/src/vs/platform/actions/browser/toolbar.ts
+++ b/src/vs/platform/actions/browser/toolbar.ts
@@ -212,26 +212,31 @@ export class WorkbenchToolBar extends ToolBar {
 					}
 				}
 
+				const primaryActions = [];
+
+				if (action instanceof MenuItemAction && action.menuKeybinding) {
+					primaryActions.push(action.menuKeybinding);
+				}
+
 				// add "hide foo" actions
-				let hideAction: IAction;
 				if (!noHide && (action instanceof MenuItemAction || action instanceof SubmenuItemAction)) {
 					if (!action.hideActions) {
 						// no context menu for MenuItemAction instances that support no hiding
 						// those are fake actions and need to be cleaned up
 						return;
 					}
-					hideAction = action.hideActions.hide;
+					primaryActions.push(action.hideActions.hide);
 
 				} else {
-					hideAction = toAction({
+					primaryActions.push(toAction({
 						id: 'label',
 						label: localize('hide', "Hide"),
 						enabled: false,
 						run() { }
-					});
+					}));
 				}
 
-				const actions = Separator.join([hideAction], toggleActions);
+				const actions = Separator.join(primaryActions, toggleActions);
 
 				// add "Reset Menu" action
 				if (this._options?.resetMenu && !menuIds) {

--- a/src/vs/platform/actions/common/actions.ts
+++ b/src/vs/platform/actions/common/actions.ts
@@ -479,6 +479,7 @@ export class MenuItemAction implements IAction {
 		alt: ICommandAction | undefined,
 		options: IMenuActionOptions | undefined,
 		readonly hideActions: IMenuItemHide | undefined,
+		readonly menuKeybinding: IAction | undefined,
 		@IContextKeyService contextKeyService: IContextKeyService,
 		@ICommandService private _commandService: ICommandService
 	) {
@@ -513,7 +514,7 @@ export class MenuItemAction implements IAction {
 		}
 
 		this.item = item;
-		this.alt = alt ? new MenuItemAction(alt, undefined, options, hideActions, contextKeyService, _commandService) : undefined;
+		this.alt = alt ? new MenuItemAction(alt, undefined, options, hideActions, undefined, contextKeyService, _commandService) : undefined;
 		this._options = options;
 		this.class = icon && ThemeIcon.asClassName(icon);
 

--- a/src/vs/platform/quickinput/browser/commandsQuickAccess.ts
+++ b/src/vs/platform/quickinput/browser/commandsQuickAccess.ts
@@ -28,6 +28,7 @@ import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 
 export interface ICommandQuickPick extends IPickerQuickAccessItem {
 	readonly commandId: string;
+	readonly commandWhen?: string;
 	readonly commandAlias?: string;
 	readonly commandDescription?: ILocalizedString;
 	tfIdfScore?: number;

--- a/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
@@ -374,7 +374,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 			actionViewItemProvider: (action, options) => {
 				if (this.location === ChatAgentLocation.Panel) {
 					if ((action.id === SubmitAction.ID || action.id === CancelAction.ID) && action instanceof MenuItemAction) {
-						const dropdownAction = this.instantiationService.createInstance(MenuItemAction, { id: 'chat.moreExecuteActions', title: localize('notebook.moreExecuteActionsLabel', "More..."), icon: Codicon.chevronDown }, undefined, undefined, undefined);
+						const dropdownAction = this.instantiationService.createInstance(MenuItemAction, { id: 'chat.moreExecuteActions', title: localize('notebook.moreExecuteActionsLabel', "More..."), icon: Codicon.chevronDown }, undefined, undefined, undefined, undefined);
 						return this.instantiationService.createInstance(ChatSubmitDropdownActionItem, action, dropdownAction);
 					}
 				}

--- a/src/vs/workbench/contrib/quickaccess/browser/commandsQuickAccess.ts
+++ b/src/vs/workbench/contrib/quickaccess/browser/commandsQuickAccess.ts
@@ -37,6 +37,7 @@ import { CommandInformationResult, IAiRelatedInformationService, RelatedInformat
 import { IEditorGroupsService } from 'vs/workbench/services/editor/common/editorGroupsService';
 import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
 import { IExtensionService } from 'vs/workbench/services/extensions/common/extensions';
+import { createKeybindingCommandQuery } from 'vs/workbench/services/preferences/browser/keybindingsEditorModel';
 import { IPreferencesService } from 'vs/workbench/services/preferences/common/preferences';
 
 export class CommandsQuickAccessProvider extends AbstractEditorCommandsQuickAccessProvider {
@@ -132,7 +133,7 @@ export class CommandsQuickAccessProvider extends AbstractEditorCommandsQuickAcce
 				tooltip: localize('configure keybinding', "Configure Keybinding"),
 			}],
 			trigger: (): TriggerAction => {
-				this.preferencesService.openGlobalKeybindingSettings(false, { query: `@command:${picks.commandId}` });
+				this.preferencesService.openGlobalKeybindingSettings(false, { query: createKeybindingCommandQuery(picks.commandId, picks.commandWhen) });
 				return TriggerAction.CLOSE_PICKER;
 			},
 		}));
@@ -243,6 +244,7 @@ export class CommandsQuickAccessProvider extends AbstractEditorCommandsQuickAcce
 				: { value: metadataDescription, original: metadataDescription };
 			globalCommandPicks.push({
 				commandId: action.item.id,
+				commandWhen: action.item.precondition?.serialize(),
 				commandAlias,
 				label: stripIcons(label),
 				commandDescription,

--- a/src/vs/workbench/contrib/scm/browser/scmViewPane.ts
+++ b/src/vs/workbench/contrib/scm/browser/scmViewPane.ts
@@ -2029,7 +2029,7 @@ class SCMInputWidgetToolbar extends WorkbenchToolBar {
 			id: SCMInputWidgetCommandId.CancelAction,
 			title: localize('scmInputCancelAction', "Cancel"),
 			icon: Codicon.debugStop,
-		}, undefined, undefined, undefined, contextKeyService, commandService);
+		}, undefined, undefined, undefined, undefined, contextKeyService, commandService);
 	}
 
 	public setInput(input: ISCMInput): void {

--- a/src/vs/workbench/contrib/testing/browser/testingExplorerView.ts
+++ b/src/vs/workbench/contrib/testing/browser/testingExplorerView.ts
@@ -395,7 +395,7 @@ export class TestingExplorerView extends ViewPane {
 			icon: group === TestRunProfileBitset.Run
 				? icons.testingRunAllIcon
 				: icons.testingDebugAllIcon,
-		}, undefined, undefined, undefined);
+		}, undefined, undefined, undefined, undefined);
 
 		const dropdownAction = new Action('selectRunConfig', 'Select Configuration...', 'codicon-chevron-down', true);
 
@@ -485,7 +485,7 @@ class ResultSummaryView extends Disposable {
 			{ ...new ReRunLastRun().desc, icon: icons.testingRerunIcon },
 			{ ...new DebugLastRun().desc, icon: icons.testingDebugIcon },
 			{},
-			undefined,
+			undefined, undefined
 		), { icon: true, label: false });
 
 		this.render();


### PR DESCRIPTION
This pull request adds support for setting keyboard shortcuts from the Action Item Context Menu. The context menu now includes an entry for configuring the commands keybinding. This allows users to easily configure the keyboard shortcut for each action item.
Fixes #208221