### PR TITLE
Fix null access

### DIFF
--- a/extensions/typescript-language-features/src/extension.browser.ts
+++ b/extensions/typescript-language-features/src/extension.browser.ts
@@ -118,7 +118,7 @@ async function startPreloadWorkspaceContentsIfNeeded(context: vscode.ExtensionCo
 		return;
 	}
 
-	const workspaceUri = vscode.workspace.workspaceFolders?.[0].uri;
+	const workspaceUri = vscode.workspace.workspaceFolders?.at(0)?.uri;
 	if (!workspaceUri || workspaceUri.scheme !== 'vscode-vfs' || !workspaceUri.authority.startsWith('github')) {
 		logger.info(`Skipped loading workspace contents for repository ${workspaceUri?.toString()}`);
 		return;


### PR DESCRIPTION
Prevents js/ts from loading on web if you don't open a workspace