### PR TITLE
dispose saved text model with wrong view type

### DIFF
--- a/src/vs/workbench/contrib/interactive/browser/interactiveEditorInput.ts
+++ b/src/vs/workbench/contrib/interactive/browser/interactiveEditorInput.ts
@@ -209,7 +209,11 @@ export class InteractiveEditorInput extends EditorInput implements ICompositeNot
 			return undefined; // save cancelled
 		}
 
-		return await this._editorModelReference.saveAs(target);
+		const saved = await this._editorModelReference.saveAs(target);
+		if (saved && 'resource' in saved && saved.resource) {
+			this._notebookService.getNotebookTextModel(saved.resource)?.dispose();
+		}
+		return saved;
 	}
 
 	override matches(otherInput: EditorInput | IUntypedEditorInput): boolean {


### PR DESCRIPTION
fix https://github.com/microsoft/vscode/issues/208016

as mentioned [in this comment](https://insiders.vscode.dev/github/microsoft/vscode/blob/main/src/vs/workbench/contrib/notebook/common/notebookEditorModel.ts#L173-L174), when we `save as` on a notebook model, we leave the newly created model orphaned, to be picked up by the editor that is about to be created with the new resource.
In the case of saving an interactive window, we are saving the model with the `interactive` viewtype, since the model factory in the interactive working copy has that viewtype, but the new editor will open with the `notebook` viewtype.

We can fix this by just disposing the new model that we create, and the editor will resolve another model with the correct viewtype.