### PR TITLE
fix: trim end of matched link

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/quickFix/browser/terminalQuickFixBuiltinActions.ts
+++ b/src/vs/workbench/contrib/terminalContrib/quickFix/browser/terminalQuickFixBuiltinActions.ts
@@ -238,7 +238,7 @@ export function gitCreatePr(): ITerminalQuickFixInternalOptions {
 		},
 		commandExitResult: 'success',
 		getQuickFixes: (matchResult: ITerminalCommandMatchResult) => {
-			const link = matchResult?.outputMatch?.regexMatch?.groups?.link;
+			const link = matchResult?.outputMatch?.regexMatch?.groups?.link?.trimEnd();
 			if (!link) {
 				return;
 			}


### PR DESCRIPTION
I still sometimes see additional encoded spaces ('%20' strings) at the end of the 
PR quick fix links, and noticed that the regex matches every character. Instead of modifying the regex, I added a trimEnd call.