### PR TITLE
fix: deprecate unity-launch flag

### DIFF
--- a/resources/linux/code.desktop
+++ b/resources/linux/code.desktop
@@ -2,7 +2,7 @@
 Name=@@NAME_LONG@@
 Comment=Code Editing. Redefined.
 GenericName=Text Editor
-Exec=@@EXEC@@ --unity-launch %F
+Exec=@@EXEC@@ %F
 Icon=@@ICON@@
 Type=Application
 StartupNotify=false

--- a/src/vs/code/electron-main/app.ts
+++ b/src/vs/code/electron-main/app.ts
@@ -1356,7 +1356,7 @@ export class CodeApplication extends Disposable {
 		return windowsMainService.open({
 			context,
 			cli: args,
-			forceNewWindow: args['new-window'] || (!hasCliArgs && args['unity-launch']),
+			forceNewWindow: args['new-window'],
 			diffMode: args.diff,
 			mergeMode: args.merge,
 			noRecentEntry,

--- a/src/vs/platform/environment/common/argv.ts
+++ b/src/vs/platform/environment/common/argv.ts
@@ -38,7 +38,6 @@ export interface NativeParsedArgs {
 	add?: boolean;
 	goto?: boolean;
 	'new-window'?: boolean;
-	'unity-launch'?: boolean; // Always open a new window, except if opening the first window or opening a file or folder as part of the launch.
 	'reuse-window'?: boolean;
 	locale?: string;
 	'user-data-dir'?: string;

--- a/src/vs/platform/environment/node/argv.ts
+++ b/src/vs/platform/environment/node/argv.ts
@@ -157,7 +157,6 @@ export const OPTIONS: OptionDescriptions<Required<NativeParsedArgs>> = {
 	'crash-reporter-directory': { type: 'string' },
 	'crash-reporter-id': { type: 'string' },
 	'skip-add-to-recently-opened': { type: 'boolean' },
-	'unity-launch': { type: 'boolean' },
 	'open-url': { type: 'boolean' },
 	'file-write': { type: 'boolean' },
 	'file-chmod': { type: 'boolean' },

--- a/src/vs/platform/launch/electron-main/launchMainService.ts
+++ b/src/vs/platform/launch/electron-main/launchMainService.ts
@@ -147,7 +147,7 @@ export class LaunchMainService implements ILaunchMainService {
 			let openNewWindow = false;
 
 			// Force new window
-			if (args['new-window'] || args['unity-launch'] || baseConfig.forceProfile || baseConfig.forceTempProfile) {
+			if (args['new-window'] || baseConfig.forceProfile || baseConfig.forceTempProfile) {
 				openNewWindow = true;
 			}
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fixes https://github.com/microsoft/vscode/issues/202545

This PR removes mentions of the unity-launch flag.
I have tested the deb and rpm with a custom dev build and found no issues when opening from the launcher with left click or ctrl+left click.

- [x] Test opening from the dock with ctrl+left click versus opening a terminal from the dock with ctrl+left click
  - [x] Ubuntu deb&mdash;both terminal and Insiders open a new instance
  - [x] Ubuntu snap&mdash;both terminal and Insiders open a new instance
  - [x] Fedora rpm&mdash;both terminal and Insiders open a new instance
- [x] Test opening from the launcher with ctrl+left click versus opening a terminal from the launcher with ctrl+left click
  - [x] Ubuntu deb&mdash;both terminal and Insiders open a new instance
  - [x] Ubuntu snap&mdash;both terminal and Insiders open a new instance
  - [x] Fedora rpm&mdash;both terminal and Insiders open a new instance in the background
 
- [x] Test opening from the dock with shift+left click versus opening a terminal from the dock with shift+left click
  - [x] Ubuntu deb&mdash;both terminal and Insiders open a new instance
  - [x] Ubuntu snap&mdash;both terminal and Insiders open a new instance
  - [x] Fedora rpm&mdash;both terminal and Insiders go to existing instance
- [x] Test opening from the launcher with shift+left click versus opening a terminal from the launcher with shift+left click
  - [x] Ubuntu deb&mdash;both terminal and Insiders go to existing instance
  - [x] Ubuntu snap&mdash;both terminal and Insiders go to existing instance
  - [x] Fedora rpm&mdash;both terminal and Insiders go to existing instance

