### PR TITLE
fix run default build task command issues

### DIFF
--- a/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
+++ b/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
@@ -2948,7 +2948,7 @@ export abstract class AbstractTaskService extends Disposable implements ITaskSer
 	 */
 	private _getDefaultTasks(tasks: Task[], taskGlobsInList: boolean = false): Task[] {
 		const defaults: Task[] = [];
-		for (const task of tasks) {
+		for (const task of tasks.filter(t => !!t.configurationProperties.group)) {
 			// At this point (assuming taskGlobsInList is true) there are tasks with matching globs, so only put those in defaults
 			if (taskGlobsInList && typeof (task.configurationProperties.group as TaskGroup).isDefault === 'string') {
 				defaults.push(task);
@@ -3050,16 +3050,22 @@ export abstract class AbstractTaskService extends Disposable implements ITaskSer
 
 			// If no globs are found or matched fallback to checking for default tasks of the task group
 			if (!groupTasks.length) {
-				groupTasks = await this._findWorkspaceTasksInGroup(taskGroup, false);
+				groupTasks = await this._findWorkspaceTasksInGroup(taskGroup, true);
 			}
 
-			// A single default task was returned, just run it directly
-			if (groupTasks.length === 1) {
-				return resolveTaskAndRun(groupTasks[0]);
-			}
+			switch (groupTasks.length) {
+				case 0:
+					// No tasks found, prompt to configure
+					configure.apply(this);
+					break;
+				case 1:
+					// A single default task was returned, just run it directly
+					return resolveTaskAndRun(groupTasks[0]);
 
-			// Multiple default tasks returned, show the quickPicker
-			return handleMultipleTasks(false);
+				default:
+					// Multiple default tasks returned, show the quickPicker
+					return handleMultipleTasks(false);
+			}
 		})();
 		this._progressService.withProgress(options, () => promise);
 	}

--- a/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
+++ b/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
@@ -3061,7 +3061,6 @@ export abstract class AbstractTaskService extends Disposable implements ITaskSer
 				case 1:
 					// A single default task was returned, just run it directly
 					return resolveTaskAndRun(groupTasks[0]);
-
 				default:
 					// Multiple default tasks returned, show the quickPicker
 					return handleMultipleTasks(false);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
fix #184454

We were calling into `findWorkspaceTasksInGroup` with `isDefault:false` when it should be `true`. 

When just one task was found of the right `group`, it was getting run even when it lacked `isDefault`.

Now, we will prompt to configure if there are no default tasks found. 