### PR TITLE
Extend Github Authentication to support seamless SSO

### DIFF
--- a/extensions/github-authentication/package.json
+++ b/extensions/github-authentication/package.json
@@ -43,7 +43,11 @@
       "properties": {
         "github-enterprise.uri": {
           "type": "string",
-          "description": "GitHub Enterprise Server URI"
+          "description": "GitHub Enterprise Server URI. Can't be used along with github-enterprise.sso-id"
+        },
+        "github-enterprise.sso-id": {
+          "type": "string",
+          "description": "GitHub Enterprise Name. Can't be used along with github-enterprise.uri"
         }
       }
     }

--- a/extensions/github-authentication/src/common/env.ts
+++ b/extensions/github-authentication/src/common/env.ts
@@ -3,7 +3,8 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 import { Uri } from 'vscode';
-import { AuthProviderType } from '../github';
+import { AuthProviderType, EnterpriseSettings } from '../github';
+import { GitHubTarget } from '../flows';
 
 const VALID_DESKTOP_CALLBACK_SCHEMES = [
 	'vscode',
@@ -26,13 +27,26 @@ export function isSupportedClient(uri: Uri): boolean {
 	);
 }
 
-export function isSupportedTarget(type: AuthProviderType, gheUri?: Uri): boolean {
+export function isSupportedTarget(type: AuthProviderType, enterpriseSettings?: EnterpriseSettings): boolean {
 	return (
-		type === AuthProviderType.github ||
-		isHostedGitHubEnterprise(gheUri!)
+		type === AuthProviderType.github || enterpriseSettings?.ssoId !== undefined ||
+		isHostedGitHubEnterprise(enterpriseSettings?.uri!)
 	);
 }
 
 export function isHostedGitHubEnterprise(uri: Uri): boolean {
 	return /\.ghe\.com$/.test(uri.authority);
+}
+
+export function getTarget(enterpriseSettings?: EnterpriseSettings): GitHubTarget {
+	if (!enterpriseSettings) {
+		return GitHubTarget.DotCom;
+	}
+
+	if (enterpriseSettings.uri) {
+		return isHostedGitHubEnterprise(enterpriseSettings.uri!) ? GitHubTarget.HostedEnterprise : GitHubTarget.Enterprise;
+	}
+
+	return GitHubTarget.EnterpriseSSO;
+
 }


### PR DESCRIPTION
# What does this do?

Updates the Device Code and URL sign-in flows to support specifying a SSO Tenant ID in Settings. 

If specified, the sign in flow redirects to `https://github.com/enterprises/<id>/sso` before sending back the user to the Oauth or Device Login flows. 

The logic validates that only one of URI and SSO ID are set during extension activation time. It also intends to keep the current behavior by giving priority to the URI setting if set. 

# Why is this needed?

This is useful as it allows organizations that manage settings for users to redirect them to the Enterprise SSO login flow. 
This way organizations can somewhat ensure that users sign in with their enterprise Github account when connecting from managed environments and limit their chances of using a personal account. 

# How to test?
Package the extension and verify that:

- User is able to set the new setting
- Setting both Enterprise URI and Enterprise SSO ID throws an error
- If Enterprise SSO ID is set then user is redirected to the SSO login page
   - User is able to login in the browser
   - User is redirected back to VS Code
   - Authentication extensions gets a valid session
- If Enterprise URI is set then the current behavior is preserved