### PR TITLE
chore: increase compile job timeout

### DIFF
--- a/build/azure-pipelines/product-build.yml
+++ b/build/azure-pipelines/product-build.yml
@@ -197,6 +197,7 @@ extends:
       - stage: Compile
         jobs:
           - job: Compile
+            timeoutInMinutes: 90
             pool:
               name: 1es-ubuntu-20.04-x64
               os: linux


### PR DESCRIPTION
The CodeQL finalize task is also resulting in timeouts sometimes occurring within the Compile job of the VS Code build pipeline.