### PR TITLE
Fixed #114425 prevent mime pollution on install

### DIFF
--- a/resources/linux/code.desktop
+++ b/resources/linux/code.desktop
@@ -8,7 +8,7 @@ Type=Application
 StartupNotify=false
 StartupWMClass=@@NAME_SHORT@@
 Categories=TextEditor;Development;IDE;
-MimeType=text/plain;inode/directory;application/x-@@NAME@@-workspace;
+MimeType=application/x-@@NAME@@-workspace;
 Actions=new-empty-window;
 Keywords=vscode;
 


### PR DESCRIPTION
This software is not a plain text editor, and it's definitely not a file manager. Advertising compatibility with such overrides default OS handlers on many distributions, unnecessarily.

