### PR TITLE
Expose comments input as text document

### DIFF
--- a/src/vs/base/common/network.ts
+++ b/src/vs/base/common/network.ts
@@ -116,7 +116,7 @@ export namespace Schemas {
 	/**
 	 * Scheme used for input box for creating comments.
 	 */
-	export const commentsInput = 'vscode-comments-input';
+	export const commentsInput = 'comment';
 
 	/**
 	 * Scheme used for special rendering of settings in the release notes

--- a/src/vs/base/common/network.ts
+++ b/src/vs/base/common/network.ts
@@ -114,6 +114,11 @@ export namespace Schemas {
 	export const vscodeSourceControl = 'vscode-scm';
 
 	/**
+	 * Scheme used for input box for creating comments.
+	 */
+	export const commentsInput = 'vscode-comments-input';
+
+	/**
 	 * Scheme used for special rendering of settings in the release notes
 	 */
 	export const codeSetting = 'code-setting';

--- a/src/vs/platform/markers/common/markerService.ts
+++ b/src/vs/platform/markers/common/markerService.ts
@@ -18,7 +18,6 @@ export const unsupportedSchemas = new Set([
 	Schemas.walkThrough,
 	Schemas.walkThroughSnippet,
 	Schemas.vscodeChatCodeBlock,
-	Schemas.commentsInput,
 ]);
 
 class DoubleResourceMap<V> {

--- a/src/vs/platform/markers/common/markerService.ts
+++ b/src/vs/platform/markers/common/markerService.ts
@@ -12,7 +12,14 @@ import { Schemas } from 'vs/base/common/network';
 import { URI } from 'vs/base/common/uri';
 import { IMarker, IMarkerData, IMarkerService, IResourceMarker, MarkerSeverity, MarkerStatistics } from './markers';
 
-export const unsupportedSchemas = new Set([Schemas.inMemory, Schemas.vscodeSourceControl, Schemas.walkThrough, Schemas.walkThroughSnippet, Schemas.vscodeChatCodeBlock]);
+export const unsupportedSchemas = new Set([
+	Schemas.inMemory,
+	Schemas.vscodeSourceControl,
+	Schemas.walkThrough,
+	Schemas.walkThroughSnippet,
+	Schemas.vscodeChatCodeBlock,
+	Schemas.commentsInput,
+]);
 
 class DoubleResourceMap<V> {
 

--- a/src/vs/workbench/contrib/comments/browser/commentNode.ts
+++ b/src/vs/workbench/contrib/comments/browser/commentNode.ts
@@ -8,11 +8,8 @@ import * as dom from 'vs/base/browser/dom';
 import * as languages from 'vs/editor/common/languages';
 import { ActionsOrientation, ActionBar } from 'vs/base/browser/ui/actionbar/actionbar';
 import { Action, IActionRunner, IAction, Separator, ActionRunner } from 'vs/base/common/actions';
-import { Disposable, IDisposable, dispose } from 'vs/base/common/lifecycle';
+import { Disposable, IDisposable, IReference, dispose } from 'vs/base/common/lifecycle';
 import { URI, UriComponents } from 'vs/base/common/uri';
-import { ITextModel } from 'vs/editor/common/model';
-import { IModelService } from 'vs/editor/common/services/model';
-import { ILanguageService } from 'vs/editor/common/languages/language';
 import { MarkdownRenderer } from 'vs/editor/browser/widget/markdownRenderer/browser/markdownRenderer';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { ICommentService } from 'vs/workbench/contrib/comments/browser/commentService';
@@ -45,13 +42,14 @@ import { Scrollable, ScrollbarVisibility } from 'vs/base/common/scrollable';
 import { SmoothScrollableElement } from 'vs/base/browser/ui/scrollbar/scrollableElement';
 import { DomEmitter } from 'vs/base/browser/event';
 import { CommentContextKeys } from 'vs/workbench/contrib/comments/common/commentContextKeys';
-import { FileAccess } from 'vs/base/common/network';
+import { FileAccess, Schemas } from 'vs/base/common/network';
 import { COMMENTS_SECTION, ICommentsConfiguration } from 'vs/workbench/contrib/comments/common/commentsConfiguration';
 import { StandardMouseEvent } from 'vs/base/browser/mouseEvent';
 import { IAccessibilityService } from 'vs/platform/accessibility/common/accessibility';
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 import { MarshalledCommentThread } from 'vs/workbench/common/comments';
 import { IHoverService } from 'vs/platform/hover/browser/hover';
+import { IResolvedTextEditorModel, ITextModelService } from 'vs/editor/common/services/resolverService';
 
 class CommentsActionRunner extends ActionRunner {
 	protected override async runAction(action: IAction, context: any[]): Promise<void> {
@@ -75,7 +73,7 @@ export class CommentNode<T extends IRange | ICellRange> extends Disposable {
 	private _reactionActionsContainer?: HTMLElement;
 	private _commentEditor: SimpleCommentEditor | null = null;
 	private _commentEditorDisposables: IDisposable[] = [];
-	private _commentEditorModel: ITextModel | null = null;
+	private _commentEditorModel: IReference<IResolvedTextEditorModel> | null = null;
 	private _editorHeight = MIN_EDITOR_HEIGHT;
 
 	private _isPendingLabel!: HTMLElement;
@@ -112,15 +110,14 @@ export class CommentNode<T extends IRange | ICellRange> extends Disposable {
 		private markdownRenderer: MarkdownRenderer,
 		@IInstantiationService private instantiationService: IInstantiationService,
 		@ICommentService private commentService: ICommentService,
-		@IModelService private modelService: IModelService,
-		@ILanguageService private languageService: ILanguageService,
 		@INotificationService private notificationService: INotificationService,
 		@IContextMenuService private contextMenuService: IContextMenuService,
 		@IContextKeyService contextKeyService: IContextKeyService,
 		@IConfigurationService private configurationService: IConfigurationService,
 		@IHoverService private hoverService: IHoverService,
 		@IAccessibilityService private accessibilityService: IAccessibilityService,
-		@IKeybindingService private keybindingService: IKeybindingService
+		@IKeybindingService private keybindingService: IKeybindingService,
+		@ITextModelService private readonly textModelService: ITextModelService,
 	) {
 		super();
 
@@ -494,13 +491,18 @@ export class CommentNode<T extends IRange | ICellRange> extends Disposable {
 		return (typeof this.comment.body === 'string') ? this.comment.body : this.comment.body.value;
 	}
 
-	private createCommentEditor(editContainer: HTMLElement): void {
+	private async createCommentEditor(editContainer: HTMLElement): Promise<void> {
 		const container = dom.append(editContainer, dom.$('.edit-textarea'));
 		this._commentEditor = this.instantiationService.createInstance(SimpleCommentEditor, container, SimpleCommentEditor.getEditorOptions(this.configurationService), this._contextKeyService, this.parentThread);
-		const resource = URI.parse(`comment:commentinput-${this.comment.uniqueIdInThread}-${Date.now()}.md`);
-		this._commentEditorModel = this.modelService.createModel('', this.languageService.createByFilepathOrFirstLine(resource), resource, false);
 
-		this._commentEditor.setModel(this._commentEditorModel);
+		const resource = URI.from({
+			scheme: Schemas.commentsInput,
+			path: `/commentinput-${this.comment.uniqueIdInThread}-${Date.now()}.md`
+		});
+		const modelRef = await this.textModelService.createModelReference(resource);
+		this._commentEditorModel = modelRef;
+
+		this._commentEditor.setModel(this._commentEditorModel.object.textEditorModel);
 		this._commentEditor.setValue(this.pendingEdit ?? this.commentBodyValue);
 		this.pendingEdit = undefined;
 		this._commentEditor.layout({ width: container.clientWidth - 14, height: this._editorHeight });
@@ -511,8 +513,8 @@ export class CommentNode<T extends IRange | ICellRange> extends Disposable {
 			this._commentEditor!.focus();
 		});
 
-		const lastLine = this._commentEditorModel.getLineCount();
-		const lastColumn = this._commentEditorModel.getLineLength(lastLine) + 1;
+		const lastLine = this._commentEditorModel.object.textEditorModel.getLineCount();
+		const lastColumn = this._commentEditorModel.object.textEditorModel.getLineLength(lastLine) + 1;
 		this._commentEditor.setSelection(new Selection(lastLine, lastColumn, lastLine, lastColumn));
 
 		const commentThread = this.commentThread;
@@ -547,7 +549,7 @@ export class CommentNode<T extends IRange | ICellRange> extends Disposable {
 
 		this.calculateEditorHeight();
 
-		this._register((this._commentEditorModel.onDidChangeContent(() => {
+		this._register((this._commentEditorModel.object.textEditorModel.onDidChangeContent(() => {
 			if (this._commentEditor && this.calculateEditorHeight()) {
 				this._commentEditor.layout({ height: this._editorHeight, width: this._commentEditor.getLayoutInfo().width });
 				this._commentEditor.render(true);
@@ -604,7 +606,7 @@ export class CommentNode<T extends IRange | ICellRange> extends Disposable {
 		this._scrollableElement.setScrollDimensions({ width, scrollWidth, height, scrollHeight });
 	}
 
-	public switchToEditMode() {
+	public async switchToEditMode() {
 		if (this.isEditing) {
 			return;
 		}
@@ -612,7 +614,7 @@ export class CommentNode<T extends IRange | ICellRange> extends Disposable {
 		this.isEditing = true;
 		this._body.classList.add('hidden');
 		this._commentEditContainer = dom.append(this._commentDetailsContainer, dom.$('.edit-container'));
-		this.createCommentEditor(this._commentEditContainer);
+		await this.createCommentEditor(this._commentEditContainer);
 
 		const formActions = dom.append(this._commentEditContainer, dom.$('.form-actions'));
 		const otherActions = dom.append(formActions, dom.$('.other-actions'));
@@ -705,7 +707,7 @@ export class CommentNode<T extends IRange | ICellRange> extends Disposable {
 		}));
 	}
 
-	update(newComment: languages.Comment) {
+	async update(newComment: languages.Comment) {
 
 		if (newComment.body !== this.comment.body) {
 			this.updateCommentBody(newComment.body);
@@ -721,7 +723,7 @@ export class CommentNode<T extends IRange | ICellRange> extends Disposable {
 
 		if (isChangingMode) {
 			if (newComment.mode === languages.CommentMode.Editing) {
-				this.switchToEditMode();
+				await this.switchToEditMode();
 			} else {
 				this.removeCommentEditor();
 			}

--- a/src/vs/workbench/contrib/comments/browser/commentReply.ts
+++ b/src/vs/workbench/contrib/comments/browser/commentReply.ts
@@ -4,22 +4,24 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as dom from 'vs/base/browser/dom';
+import { getDefaultHoverDelegate } from 'vs/base/browser/ui/hover/hoverDelegateFactory';
 import { MOUSE_CURSOR_TEXT_CSS_CLASS_NAME } from 'vs/base/browser/ui/mouseCursor/mouseCursor';
 import { IAction } from 'vs/base/common/actions';
 import { Disposable, IDisposable, dispose } from 'vs/base/common/lifecycle';
 import { MarshalledId } from 'vs/base/common/marshallingIds';
+import { Schemas } from 'vs/base/common/network';
 import { URI } from 'vs/base/common/uri';
 import { generateUuid } from 'vs/base/common/uuid';
 import { ICodeEditor } from 'vs/editor/browser/editorBrowser';
 import { IRange } from 'vs/editor/common/core/range';
 import * as languages from 'vs/editor/common/languages';
-import { ILanguageService } from 'vs/editor/common/languages/language';
 import { ITextModel } from 'vs/editor/common/model';
-import { IModelService } from 'vs/editor/common/services/model';
+import { ITextModelService } from 'vs/editor/common/services/resolverService';
 import * as nls from 'vs/nls';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { IContextKey, IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
+import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 import { editorForeground, resolveColorValue } from 'vs/platform/theme/common/colorRegistry';
 import { IThemeService } from 'vs/platform/theme/common/themeService';
 import { CommentFormActions } from 'vs/workbench/contrib/comments/browser/commentFormActions';
@@ -29,11 +31,8 @@ import { CommentContextKeys } from 'vs/workbench/contrib/comments/common/comment
 import { ICommentThreadWidget } from 'vs/workbench/contrib/comments/common/commentThreadWidget';
 import { ICellRange } from 'vs/workbench/contrib/notebook/common/notebookRange';
 import { LayoutableEditor, MIN_EDITOR_HEIGHT, SimpleCommentEditor, calculateEditorHeight } from './simpleCommentEditor';
-import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
-import { getDefaultHoverDelegate } from 'vs/base/browser/ui/hover/hoverDelegateFactory';
 import { IHoverService } from 'vs/platform/hover/browser/hover';
 
-const COMMENT_SCHEME = 'comment';
 let INMEM_MODEL_ID = 0;
 export const COMMENTEDITOR_DECORATION_KEY = 'commenteditordecoration';
 
@@ -42,8 +41,8 @@ export class CommentReply<T extends IRange | ICellRange> extends Disposable {
 	form: HTMLElement;
 	commentEditorIsEmpty: IContextKey<boolean>;
 	private _error!: HTMLElement;
-	private _formActions: HTMLElement | null;
-	private _editorActions: HTMLElement | null;
+	private readonly _formActions: HTMLElement;
+	private readonly _editorActions: HTMLElement;
 	private _commentThreadDisposables: IDisposable[] = [];
 	private _commentFormActions!: CommentFormActions;
 	private _commentEditorActions!: CommentFormActions;
@@ -63,12 +62,11 @@ export class CommentReply<T extends IRange | ICellRange> extends Disposable {
 		private _parentThread: ICommentThreadWidget,
 		private _actionRunDelegate: (() => void) | null,
 		@ICommentService private commentService: ICommentService,
-		@ILanguageService private languageService: ILanguageService,
-		@IModelService private modelService: IModelService,
 		@IThemeService private themeService: IThemeService,
 		@IConfigurationService configurationService: IConfigurationService,
 		@IKeybindingService private keybindingService: IKeybindingService,
 		@IHoverService private hoverService: IHoverService,
+		@ITextModelService private readonly textModelService: ITextModelService
 	) {
 		super();
 
@@ -77,6 +75,13 @@ export class CommentReply<T extends IRange | ICellRange> extends Disposable {
 		this.commentEditorIsEmpty = CommentContextKeys.commentIsEmpty.bindTo(this._contextKeyService);
 		this.commentEditorIsEmpty.set(!this._pendingComment);
 
+		const formActions = dom.append(this.form, dom.$('.form-actions'));
+		this._formActions = dom.append(formActions, dom.$('.other-actions'));
+		this._editorActions = dom.append(formActions, dom.$('.editor-actions'));
+		this.initialize();
+	}
+
+	async initialize() {
 		const hasExistingComments = this._commentThread.comments && this._commentThread.comments.length > 0;
 		const modeId = generateUuid() + '-' + (hasExistingComments ? this._commentThread.threadId : ++INMEM_MODEL_ID);
 		const params = JSON.stringify({
@@ -84,25 +89,30 @@ export class CommentReply<T extends IRange | ICellRange> extends Disposable {
 			commentThreadId: this._commentThread.threadId
 		});
 
-		let resource = URI.parse(`${COMMENT_SCHEME}://${this._commentThread.extensionId}/commentinput-${modeId}.md?${params}`); // TODO. Remove params once extensions adopt authority.
-		const commentController = this.commentService.getCommentController(owner);
+		let resource = URI.from({
+			scheme: Schemas.commentsInput,
+			path: `/${this._commentThread.extensionId}/commentinput-${modeId}.md?${params}` // TODO. Remove params once extensions adopt authority.
+		});
+		const commentController = this.commentService.getCommentController(this.owner);
 		if (commentController) {
 			resource = resource.with({ authority: commentController.id });
 		}
 
-		const model = this.modelService.createModel(this._pendingComment || '', this.languageService.createByFilepathOrFirstLine(resource), resource, false);
+		const model = await this.textModelService.createModelReference(resource);
+		model.object.textEditorModel.setValue(this._pendingComment || '');
+
 		this._register(model);
-		this.commentEditor.setModel(model);
+		this.commentEditor.setModel(model.object.textEditorModel);
 		this.calculateEditorHeight();
 
-		this._register((model.onDidChangeContent(() => {
+		this._register(model.object.textEditorModel.onDidChangeContent(() => {
 			this.setCommentEditorDecorations();
 			this.commentEditorIsEmpty?.set(!this.commentEditor.getValue());
 			if (this.calculateEditorHeight()) {
 				this.commentEditor.layout({ height: this._editorHeight, width: this.commentEditor.getLayoutInfo().width });
 				this.commentEditor.render(true);
 			}
-		})));
+		}));
 
 		this.createTextModelListener(this.commentEditor, this.form);
 
@@ -115,11 +125,8 @@ export class CommentReply<T extends IRange | ICellRange> extends Disposable {
 			this.expandReplyArea();
 		}
 		this._error = dom.append(this.form, dom.$('.validation-error.hidden'));
-		const formActions = dom.append(this.form, dom.$('.form-actions'));
-		this._formActions = dom.append(formActions, dom.$('.other-actions'));
-		this.createCommentWidgetFormActions(this._formActions, model);
-		this._editorActions = dom.append(formActions, dom.$('.editor-actions'));
-		this.createCommentWidgetEditorActions(this._editorActions, model);
+		this.createCommentWidgetFormActions(this._formActions, model.object.textEditorModel);
+		this.createCommentWidgetEditorActions(this._editorActions, model.object.textEditorModel);
 	}
 
 	private calculateEditorHeight(): boolean {

--- a/src/vs/workbench/contrib/comments/browser/commentReply.ts
+++ b/src/vs/workbench/contrib/comments/browser/commentReply.ts
@@ -41,8 +41,8 @@ export class CommentReply<T extends IRange | ICellRange> extends Disposable {
 	form: HTMLElement;
 	commentEditorIsEmpty: IContextKey<boolean>;
 	private _error!: HTMLElement;
-	private readonly _formActions: HTMLElement;
-	private readonly _editorActions: HTMLElement;
+	private _formActions!: HTMLElement;
+	private _editorActions!: HTMLElement;
 	private _commentThreadDisposables: IDisposable[] = [];
 	private _commentFormActions!: CommentFormActions;
 	private _commentEditorActions!: CommentFormActions;
@@ -75,9 +75,6 @@ export class CommentReply<T extends IRange | ICellRange> extends Disposable {
 		this.commentEditorIsEmpty = CommentContextKeys.commentIsEmpty.bindTo(this._contextKeyService);
 		this.commentEditorIsEmpty.set(!this._pendingComment);
 
-		const formActions = dom.append(this.form, dom.$('.form-actions'));
-		this._formActions = dom.append(formActions, dom.$('.other-actions'));
-		this._editorActions = dom.append(formActions, dom.$('.editor-actions'));
 		this.initialize();
 	}
 
@@ -125,7 +122,10 @@ export class CommentReply<T extends IRange | ICellRange> extends Disposable {
 			this.expandReplyArea();
 		}
 		this._error = dom.append(this.form, dom.$('.validation-error.hidden'));
+		const formActions = dom.append(this.form, dom.$('.form-actions'));
+		this._formActions = dom.append(formActions, dom.$('.other-actions'));
 		this.createCommentWidgetFormActions(this._formActions, model.object.textEditorModel);
+		this._editorActions = dom.append(formActions, dom.$('.editor-actions'));
 		this.createCommentWidgetEditorActions(this._editorActions, model.object.textEditorModel);
 	}
 

--- a/src/vs/workbench/contrib/comments/browser/commentThreadBody.ts
+++ b/src/vs/workbench/contrib/comments/browser/commentThreadBody.ts
@@ -70,7 +70,7 @@ export class CommentThreadBody<T extends IRange | ICellRange = IRange> extends D
 		this._commentsElement.focus();
 	}
 
-	display() {
+	async display() {
 		this._commentsElement = dom.append(this.container, dom.$('div.comments-container'));
 		this._commentsElement.setAttribute('role', 'presentation');
 		this._commentsElement.tabIndex = 0;
@@ -98,7 +98,7 @@ export class CommentThreadBody<T extends IRange | ICellRange = IRange> extends D
 				this._commentElements.push(newCommentNode);
 				this._commentsElement.appendChild(newCommentNode.domNode);
 				if (comment.mode === languages.CommentMode.Editing) {
-					newCommentNode.switchToEditMode();
+					await newCommentNode.switchToEditMode();
 				}
 			}
 		}
@@ -156,7 +156,7 @@ export class CommentThreadBody<T extends IRange | ICellRange = IRange> extends D
 		return;
 	}
 
-	updateCommentThread(commentThread: languages.CommentThread<T>, preserveFocus: boolean) {
+	async updateCommentThread(commentThread: languages.CommentThread<T>, preserveFocus: boolean) {
 		const oldCommentsLen = this._commentElements.length;
 		const newCommentsLen = commentThread.comments ? commentThread.comments.length : 0;
 
@@ -207,7 +207,7 @@ export class CommentThreadBody<T extends IRange | ICellRange = IRange> extends D
 				}
 
 				if (currentComment.mode === languages.CommentMode.Editing) {
-					newElement.switchToEditMode();
+					await newElement.switchToEditMode();
 					newCommentsInEditMode.push(newElement);
 				}
 			}

--- a/src/vs/workbench/contrib/comments/browser/commentThreadWidget.ts
+++ b/src/vs/workbench/contrib/comments/browser/commentThreadWidget.ts
@@ -205,7 +205,7 @@ export class CommentThreadWidget<T extends IRange | ICellRange = IRange> extends
 		}, true));
 	}
 
-	updateCommentThread(commentThread: languages.CommentThread<T>) {
+	async updateCommentThread(commentThread: languages.CommentThread<T>) {
 		const shouldCollapse = (this._commentThread.collapsibleState === languages.CommentThreadCollapsibleState.Expanded) && (this._commentThreadState === languages.CommentThreadState.Unresolved)
 			&& (commentThread.state === languages.CommentThreadState.Resolved);
 		this._commentThreadState = commentThread.state;
@@ -214,7 +214,7 @@ export class CommentThreadWidget<T extends IRange | ICellRange = IRange> extends
 		this._commentThreadDisposables = [];
 		this._bindCommentThreadListeners();
 
-		this._body.updateCommentThread(commentThread, this._commentReply?.isCommentEditorFocused() ?? false);
+		await this._body.updateCommentThread(commentThread, this._commentReply?.isCommentEditorFocused() ?? false);
 		this._threadIsEmpty.set(!this._body.length);
 		this._header.updateCommentThread(commentThread);
 		this._commentReply?.updateCommentThread(commentThread);
@@ -230,11 +230,11 @@ export class CommentThreadWidget<T extends IRange | ICellRange = IRange> extends
 		}
 	}
 
-	display(lineHeight: number) {
+	async display(lineHeight: number) {
 		const headHeight = Math.max(23, Math.ceil(lineHeight * 1.2)); // 23 is the value of `Math.ceil(lineHeight * 1.2)` with the default editor font size
 		this._header.updateHeight(headHeight);
 
-		this._body.display();
+		await this._body.display();
 
 		// create comment thread only when it supports reply
 		if (this._commentThread.canReply) {

--- a/src/vs/workbench/contrib/comments/browser/commentThreadZoneWidget.ts
+++ b/src/vs/workbench/contrib/comments/browser/commentThreadZoneWidget.ts
@@ -328,7 +328,7 @@ export class ReviewZoneWidget extends ZoneWidget implements ICommentThreadWidget
 			this.bindCommentThreadListeners();
 		}
 
-		this._commentThreadWidget.updateCommentThread(commentThread);
+		await this._commentThreadWidget.updateCommentThread(commentThread);
 
 		// Move comment glyph widget and show position if the line has changed.
 		const lineNumber = this._commentThread.range?.endLineNumber ?? 1;
@@ -356,13 +356,13 @@ export class ReviewZoneWidget extends ZoneWidget implements ICommentThreadWidget
 		this._commentThreadWidget.layout(widthInPixel);
 	}
 
-	display(range: IRange | undefined) {
+	async display(range: IRange | undefined) {
 		if (range) {
 			this._commentGlyph = new CommentGlyphWidget(this.editor, range?.endLineNumber ?? -1);
 			this._commentGlyph.setThreadState(this._commentThread.state);
 		}
 
-		this._commentThreadWidget.display(this.editor.getOption(EditorOption.lineHeight));
+		await this._commentThreadWidget.display(this.editor.getOption(EditorOption.lineHeight));
 		this._disposables.add(this._commentThreadWidget.onDidResize(dimension => {
 			this._refresh(dimension);
 		}));

--- a/src/vs/workbench/contrib/comments/browser/commentsController.ts
+++ b/src/vs/workbench/contrib/comments/browser/commentsController.ts
@@ -495,10 +495,10 @@ export class CommentController implements IEditorContribution {
 		this.globalToDispose.add(this.commentService.onDidSetDataProvider(_ => this.beginComputeAndHandleEditorChange()));
 		this.globalToDispose.add(this.commentService.onDidUpdateCommentingRanges(_ => this.beginComputeAndHandleEditorChange()));
 
-		this.globalToDispose.add(this.commentService.onDidSetResourceCommentInfos(e => {
+		this.globalToDispose.add(this.commentService.onDidSetResourceCommentInfos(async e => {
 			const editorURI = this.editor && this.editor.hasModel() && this.editor.getModel().uri;
 			if (editorURI && editorURI.toString() === e.resource.toString()) {
-				this.setComments(e.commentInfos.filter(commentInfo => commentInfo !== null));
+				await this.setComments(e.commentInfos.filter(commentInfo => commentInfo !== null));
 			}
 		}));
 
@@ -646,8 +646,8 @@ export class CommentController implements IEditorContribution {
 			return Promise.resolve([]);
 		});
 
-		return this._computePromise.then(commentInfos => {
-			this.setComments(coalesce(commentInfos));
+		return this._computePromise.then(async commentInfos => {
+			await this.setComments(coalesce(commentInfos));
 			this._computePromise = null;
 		}, error => console.log(error));
 	}
@@ -940,7 +940,7 @@ export class CommentController implements IEditorContribution {
 				const pendingCommentText = (this._pendingNewCommentCache[e.uniqueOwner] && this._pendingNewCommentCache[e.uniqueOwner][thread.threadId])
 					?? continueOnCommentText;
 				const pendingEdits = this._pendingEditsCache[e.uniqueOwner] && this._pendingEditsCache[e.uniqueOwner][thread.threadId];
-				this.displayCommentThread(e.uniqueOwner, thread, pendingCommentText, pendingEdits);
+				await this.displayCommentThread(e.uniqueOwner, thread, pendingCommentText, pendingEdits);
 				this._commentInfos.filter(info => info.uniqueOwner === e.uniqueOwner)[0].threads.push(thread);
 				this.tryUpdateReservedSpace();
 			}
@@ -1021,7 +1021,7 @@ export class CommentController implements IEditorContribution {
 		return undefined;
 	}
 
-	private displayCommentThread(uniqueOwner: string, thread: languages.CommentThread, pendingComment: string | undefined, pendingEdits: { [key: number]: string } | undefined): void {
+	private async displayCommentThread(uniqueOwner: string, thread: languages.CommentThread, pendingComment: string | undefined, pendingEdits: { [key: number]: string } | undefined): Promise<void> {
 		const editor = this.editor?.getModel();
 		if (!editor) {
 			return;
@@ -1035,7 +1035,7 @@ export class CommentController implements IEditorContribution {
 			continueOnCommentReply = this.commentService.removeContinueOnComment({ uniqueOwner, uri: editor.uri, range: thread.range, isReply: true });
 		}
 		const zoneWidget = this.instantiationService.createInstance(ReviewZoneWidget, this.editor, uniqueOwner, thread, pendingComment ?? continueOnCommentReply?.body, pendingEdits);
-		zoneWidget.display(thread.range);
+		await zoneWidget.display(thread.range);
 		this._commentWidgets.push(zoneWidget);
 		this.openCommentsView(thread);
 	}
@@ -1296,7 +1296,7 @@ export class CommentController implements IEditorContribution {
 		}
 	}
 
-	private setComments(commentInfos: ICommentInfo[]): void {
+	private async setComments(commentInfos: ICommentInfo[]): Promise<void> {
 		if (!this.editor || !this.commentService.isCommentingEnabled) {
 			return;
 		}
@@ -1307,7 +1307,7 @@ export class CommentController implements IEditorContribution {
 		this.removeCommentWidgetsAndStoreCache();
 
 		let hasCommentingRanges = false;
-		this._commentInfos.forEach(info => {
+		for (const info of this._commentInfos) {
 			if (!hasCommentingRanges && (info.commentingRanges.ranges.length > 0 || info.commentingRanges.fileComments)) {
 				hasCommentingRanges = true;
 			}
@@ -1315,7 +1315,7 @@ export class CommentController implements IEditorContribution {
 			const providerCacheStore = this._pendingNewCommentCache[info.uniqueOwner];
 			const providerEditsCacheStore = this._pendingEditsCache[info.uniqueOwner];
 			info.threads = info.threads.filter(thread => !thread.isDisposed);
-			info.threads.forEach(thread => {
+			for (const thread of info.threads) {
 				let pendingComment: string | undefined = undefined;
 				if (providerCacheStore) {
 					pendingComment = providerCacheStore[thread.threadId];
@@ -1326,12 +1326,12 @@ export class CommentController implements IEditorContribution {
 					pendingEdits = providerEditsCacheStore[thread.threadId];
 				}
 
-				this.displayCommentThread(info.uniqueOwner, thread, pendingComment, pendingEdits);
-			});
+				await this.displayCommentThread(info.uniqueOwner, thread, pendingComment, pendingEdits);
+			}
 			for (const thread of info.pendingCommentThreads ?? []) {
 				this.resumePendingComment(this.editor!.getModel()!.uri, thread);
 			}
-		});
+		}
 
 		this._commentingRangeDecorator.update(this.editor, this._commentInfos);
 		this._commentThreadRangeDecorator.update(this.editor, this._commentInfos);

--- a/src/vs/workbench/contrib/comments/browser/commentsEditorContribution.ts
+++ b/src/vs/workbench/contrib/comments/browser/commentsEditorContribution.ts
@@ -25,8 +25,11 @@ import { CONTEXT_ACCESSIBILITY_MODE_ENABLED } from 'vs/platform/accessibility/co
 import { ContextKeyExpr } from 'vs/platform/contextkey/common/contextkey';
 import { accessibilityHelpIsShown, accessibleViewCurrentProviderId, AccessibleViewProviderId } from 'vs/workbench/contrib/accessibility/browser/accessibilityConfiguration';
 import { CommentCommandId } from 'vs/workbench/contrib/comments/common/commentCommandIds';
+import { registerWorkbenchContribution2, WorkbenchPhase } from 'vs/workbench/common/contributions';
+import { CommentsInputContentProvider } from 'vs/workbench/contrib/comments/browser/commentsInputContentProvider';
 
 registerEditorContribution(ID, CommentController, EditorContributionInstantiation.AfterFirstRender);
+registerWorkbenchContribution2(CommentsInputContentProvider.ID, CommentsInputContentProvider, WorkbenchPhase.BlockRestore);
 
 KeybindingsRegistry.registerCommandAndKeybindingRule({
 	id: CommentCommandId.NextThread,

--- a/src/vs/workbench/contrib/comments/browser/commentsInputContentProvider.ts
+++ b/src/vs/workbench/contrib/comments/browser/commentsInputContentProvider.ts
@@ -1,0 +1,32 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Disposable } from 'vs/base/common/lifecycle';
+import { Schemas } from 'vs/base/common/network';
+import { URI } from 'vs/base/common/uri';
+import { IEditorContribution } from 'vs/editor/common/editorCommon';
+import { ILanguageService } from 'vs/editor/common/languages/language';
+import { ITextModel } from 'vs/editor/common/model';
+import { IModelService } from 'vs/editor/common/services/model';
+import { ITextModelContentProvider, ITextModelService } from 'vs/editor/common/services/resolverService';
+
+export class CommentsInputContentProvider extends Disposable implements ITextModelContentProvider, IEditorContribution {
+
+	public static readonly ID = 'comments.input.contentProvider';
+
+	constructor(
+		@ITextModelService textModelService: ITextModelService,
+		@IModelService private readonly _modelService: IModelService,
+		@ILanguageService private readonly _languageService: ILanguageService,
+	) {
+		super();
+		this._register(textModelService.registerTextModelContentProvider(Schemas.commentsInput, this));
+	}
+
+	async provideTextContent(resource: URI): Promise<ITextModel | null> {
+		const existing = this._modelService.getModel(resource);
+		return existing ?? this._modelService.createModel('', this._languageService.createById('markdown'), resource);
+	}
+}

--- a/src/vs/workbench/contrib/comments/browser/media/review.css
+++ b/src/vs/workbench/contrib/comments/browser/media/review.css
@@ -386,7 +386,7 @@
 	margin-right: 12px;
 }
 
-.review-widget .body .comment-form .monaco-text-button,
+.review-widget .body .comment-form .form-actions .monaco-text-button,
 .review-widget .body .edit-container .monaco-text-button {
 	width: auto;
 	padding: 4px 10px;

--- a/src/vs/workbench/contrib/comments/browser/simpleCommentEditor.ts
+++ b/src/vs/workbench/contrib/comments/browser/simpleCommentEditor.ts
@@ -28,6 +28,14 @@ import { ILanguageFeaturesService } from 'vs/editor/common/services/languageFeat
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { ICodeEditor } from 'vs/editor/browser/editorBrowser';
 import { clamp } from 'vs/base/common/numbers';
+import { CopyPasteController } from 'vs/editor/contrib/dropOrPasteInto/browser/copyPasteController';
+import { CodeActionController } from 'vs/editor/contrib/codeAction/browser/codeActionController';
+import { DropIntoEditorController } from 'vs/editor/contrib/dropOrPasteInto/browser/dropIntoEditorController';
+import { HoverController } from 'vs/editor/contrib/hover/browser/hover';
+import { InlineCompletionsController } from 'vs/editor/contrib/inlineCompletions/browser/inlineCompletionsController';
+import { LinkDetector } from 'vs/editor/contrib/links/browser/links';
+import { MessageController } from 'vs/editor/contrib/message/browser/messageController';
+import { SelectionClipboardContributionID } from 'vs/workbench/contrib/codeEditor/browser/selectionClipboard';
 
 export const ctxCommentEditorFocused = new RawContextKey<boolean>('commentEditorFocused', false);
 export const MIN_EDITOR_HEIGHT = 5 * 18;
@@ -63,7 +71,17 @@ export class SimpleCommentEditor extends CodeEditorWidget {
 				{ id: SuggestController.ID, ctor: SuggestController, instantiation: EditorContributionInstantiation.Eager },
 				{ id: SnippetController2.ID, ctor: SnippetController2, instantiation: EditorContributionInstantiation.Lazy },
 				{ id: TabCompletionController.ID, ctor: TabCompletionController, instantiation: EditorContributionInstantiation.Eager }, // eager because it needs to define a context key
-				{ id: EditorDictation.ID, ctor: EditorDictation, instantiation: EditorContributionInstantiation.Lazy }
+				{ id: EditorDictation.ID, ctor: EditorDictation, instantiation: EditorContributionInstantiation.Lazy },
+				...EditorExtensionsRegistry.getSomeEditorContributions([
+					CopyPasteController.ID,
+					DropIntoEditorController.ID,
+					LinkDetector.ID,
+					MessageController.ID,
+					HoverController.ID,
+					SelectionClipboardContributionID,
+					InlineCompletionsController.ID,
+					CodeActionController.ID,
+				])
 			]
 		};
 
@@ -113,6 +131,7 @@ export class SimpleCommentEditor extends CodeEditorWidget {
 			minimap: {
 				enabled: false
 			},
+			dropIntoEditor: { enabled: true },
 			autoClosingBrackets: configurationService.getValue('editor.autoClosingBrackets'),
 			quickSuggestions: false,
 			accessibilitySupport: configurationService.getValue<'auto' | 'off' | 'on'>('editor.accessibilitySupport'),

--- a/src/vs/workbench/contrib/notebook/browser/view/cellParts/cellComments.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/cellParts/cellComments.ts
@@ -53,11 +53,11 @@ export class CellComments extends CellContentPart {
 		const info = await this._getCommentThreadForCell(element);
 
 		if (info) {
-			this._createCommentTheadWidget(info.owner, info.thread);
+			await this._createCommentTheadWidget(info.owner, info.thread);
 		}
 	}
 
-	private _createCommentTheadWidget(owner: string, commentThread: languages.CommentThread<ICellRange>) {
+	private async _createCommentTheadWidget(owner: string, commentThread: languages.CommentThread<ICellRange>) {
 		this._commentThreadWidget?.dispose();
 		this.commentTheadDisposables.clear();
 		this._commentThreadWidget = this.instantiationService.createInstance(
@@ -84,7 +84,7 @@ export class CellComments extends CellContentPart {
 
 		const layoutInfo = this.notebookEditor.getLayoutInfo();
 
-		this._commentThreadWidget.display(layoutInfo.fontInfo.lineHeight);
+		await this._commentThreadWidget.display(layoutInfo.fontInfo.lineHeight);
 		this._applyTheme();
 
 		this.commentTheadDisposables.add(this._commentThreadWidget.onDidResize(() => {
@@ -99,7 +99,7 @@ export class CellComments extends CellContentPart {
 			if (this.currentElement) {
 				const info = await this._getCommentThreadForCell(this.currentElement);
 				if (!this._commentThreadWidget && info) {
-					this._createCommentTheadWidget(info.owner, info.thread);
+					await this._createCommentTheadWidget(info.owner, info.thread);
 					const layoutInfo = (this.currentElement as CodeCellViewModel).layoutInfo;
 					this.container.style.top = `${layoutInfo.outputContainerOffset + layoutInfo.outputTotalHeight}px`;
 					this.currentElement.commentHeight = this._calculateCommentThreadHeight(this._commentThreadWidget!.getDimensions().height);
@@ -117,7 +117,7 @@ export class CellComments extends CellContentPart {
 						return;
 					}
 
-					this._commentThreadWidget.updateCommentThread(info.thread);
+					await this._commentThreadWidget.updateCommentThread(info.thread);
 					this.currentElement.commentHeight = this._calculateCommentThreadHeight(this._commentThreadWidget.getDimensions().height);
 				}
 			}


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/209610
For #209508

Exposes comment input editors as text documents that extensions can see. Enables a few features in them too such as 'paste as' and 'drop into'

Will need polishing but this should get most of the basics working 