### PR TITLE
Add color item for sidebar title background

### DIFF
--- a/build/lib/stylelint/vscode-known-variables.json
+++ b/build/lib/stylelint/vscode-known-variables.json
@@ -565,6 +565,7 @@
 		"--vscode-sideBarSectionHeader-background",
 		"--vscode-sideBarSectionHeader-border",
 		"--vscode-sideBarSectionHeader-foreground",
+		"--vscode-sideBarTitle-background",
 		"--vscode-sideBarTitle-foreground",
 		"--vscode-sideBySideEditor-horizontalBorder",
 		"--vscode-sideBySideEditor-verticalBorder",

--- a/src/vs/workbench/browser/parts/auxiliarybar/media/auxiliaryBarPart.css
+++ b/src/vs/workbench/browser/parts/auxiliarybar/media/auxiliaryBarPart.css
@@ -22,6 +22,10 @@
 	margin-right: 4px;
 }
 
+.monaco-workbench .part.auxiliarybar > .title {
+	background-color: var(--vscode-sideBarTitle-background);
+}
+
 .monaco-workbench .part.auxiliarybar > .title > .title-label {
 	flex: 1;
 }

--- a/src/vs/workbench/browser/parts/sidebar/media/sidebarpart.css
+++ b/src/vs/workbench/browser/parts/sidebar/media/sidebarpart.css
@@ -16,6 +16,10 @@
 	margin-right: 4px;
 }
 
+.monaco-workbench .part.sidebar > .title {
+	background-color: var(--vscode-sideBarTitle-background);
+}
+
 .monaco-workbench .part.sidebar > .title > .title-label h2 {
 	text-transform: uppercase;
 }

--- a/src/vs/workbench/common/theme.ts
+++ b/src/vs/workbench/common/theme.ts
@@ -850,6 +850,13 @@ export const SIDE_BAR_BORDER = registerColor('sideBar.border', {
 	hcLight: contrastBorder
 }, localize('sideBarBorder', "Side bar border color on the side separating to the editor. The side bar is the container for views like explorer and search."));
 
+export const SIDE_BAR_TITLE_BACKGROUND = registerColor('sideBarTitle.background', {
+	dark: SIDE_BAR_BACKGROUND,
+	light: SIDE_BAR_BACKGROUND,
+	hcDark: SIDE_BAR_BACKGROUND,
+	hcLight: SIDE_BAR_BACKGROUND
+}, localize('sideBarTitleBackground', "Side bar title background color. The side bar is the container for views like explorer and search."));
+
 export const SIDE_BAR_TITLE_FOREGROUND = registerColor('sideBarTitle.foreground', {
 	dark: SIDE_BAR_FOREGROUND,
 	light: SIDE_BAR_FOREGROUND,


### PR DESCRIPTION
This pull request adds a new color item, `sideBarTitle.background`, for the background color of the sidebar title. This allows users to customize the color of the sidebar title separately from the sidebar background. The changes include adding the color item to the theme file and updating the CSS styles for the sidebar title. Fixes #209164.