### PR TITLE
Set role on lightbulb widget

### DIFF
--- a/src/vs/editor/contrib/codeAction/browser/lightBulbWidget.ts
+++ b/src/vs/editor/contrib/codeAction/browser/lightBulbWidget.ts
@@ -68,7 +68,7 @@ export class LightBulbWidget extends Disposable implements IContentWidget {
 		super();
 
 		this._domNode = dom.$('div.lightBulbWidget');
-
+		this._domNode.role = 'menu';
 		this._register(Gesture.ignoreTarget(this._domNode));
 
 		this._editor.addContentWidget(this);


### PR DESCRIPTION
`menu` since clicking on it opens up a list of options