### PR TITLE
Remove token types String, Comment and Regex from line before determining if there should be indentation or not

### DIFF
--- a/extensions/javascript/javascript-language-configuration.json
+++ b/extensions/javascript/javascript-language-configuration.json
@@ -111,10 +111,10 @@
 	},
 	"indentationRules": {
 		"decreaseIndentPattern": {
-			"pattern": "^((?!.*?/\\*).*\\*\/)?\\s*[\\}\\]\\)].*$"
+			"pattern": "^\\s*[\\}\\]\\)].*$"
 		},
 		"increaseIndentPattern": {
-			"pattern": "^((?!//).)*(\\{([^}\"'`/]*|(\\t|[ ])*//.*)|\\([^)\"'`/]*|\\[[^\\]\"'`/]*)$"
+			"pattern": "^.*(\\{[^}]*|\\([^)]*|\\[[^\\]]*)$"
 		},
 		// e.g.  * ...| or */| or *-----*/|
 		"unIndentedLinePattern": {

--- a/extensions/typescript-basics/language-configuration.json
+++ b/extensions/typescript-basics/language-configuration.json
@@ -129,10 +129,10 @@
 	},
 	"indentationRules": {
 		"decreaseIndentPattern": {
-			"pattern": "^((?!.*?/\\*).*\\*\/)?\\s*[\\}\\]\\)].*$"
+			"pattern": "^\\s*[\\}\\]\\)].*$"
 		},
 		"increaseIndentPattern": {
-			"pattern": "^((?!//).)*(\\{([^}\"'`/]*|(\\t|[ ])*//.*)|\\([^)\"'`/]*|\\[[^\\]\"'`/]*)$"
+			"pattern": "^.*(\\{[^}]*|\\([^)]*|\\[[^\\]]*)$"
 		},
 		// e.g.  * ...| or */| or *-----*/|
 		"unIndentedLinePattern": {


### PR DESCRIPTION
It has been noticed that the regex indentation patterns try to account for comments and strings containing braces that could mislead the regex pattern in determining whether indentation should happen. This PR aims to strip the analyzed string from its comments, strings and regexes before applying the indentation rules. This also simplifies the indentation regex patterns.