### PR TITLE
Add `editor` to `chatParticipantExtensionPoint.locations` enum

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatContributionServiceImpl.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContributionServiceImpl.ts
@@ -147,7 +147,7 @@ const chatParticipantExtensionPoint = extensionsRegistry.ExtensionsRegistry.regi
 					default: ['panel'],
 					items: {
 						type: 'string',
-						enum: ['panel', 'terminal', 'notebook']
+						enum: ['panel', 'terminal', 'notebook', 'editor']
 					}
 
 				}


### PR DESCRIPTION
Fixes [#208890](https://github.com/microsoft/vscode/issues/208898)

Not sure this is an all-encompassing fix, as the auto-complete/suggestions for participants does not populate, but this allows users to `@participant` on inline chat.

We needed this for a chatParticipant extension we are currently working on that requires inline chat, so hopefully there is not too much more needed for this! If someone could point me towards getting the autocomplete to populate for applicable participants, I can include that as well.
