### PR TITLE
menus: fix descenders missing from context menu options

### DIFF
--- a/src/vs/base/browser/ui/menu/menu.ts
+++ b/src/vs/base/browser/ui/menu/menu.ts
@@ -1281,7 +1281,6 @@ ${formatRule(Codicon.menuSubmenu)}
 .monaco-menu .monaco-action-bar.vertical .keybinding {
 	font-size: inherit;
 	padding: 0 2em;
-	overflow: hidden;
 	max-height: 100%;
 }
 

--- a/src/vs/workbench/contrib/testing/browser/testingDecorations.ts
+++ b/src/vs/workbench/contrib/testing/browser/testingDecorations.ts
@@ -975,7 +975,13 @@ class MultiRunTestDecoration extends RunTestDecoration implements ITestDecoratio
 		let testSubmenus: IAction[] = testItems.map(({ currentLabel, testItem }) => {
 			const actions = this.getTestContextMenuActions(testItem.test, testItem.resultItem);
 			disposable.add(actions);
-			return new SubmenuAction(testItem.test.item.extId, stripIcons(currentLabel), actions.object);
+			let label = stripIcons(currentLabel);
+			const lf = label.indexOf('\n');
+			if (lf !== -1) {
+				label = label.slice(0, lf);
+			}
+
+			return new SubmenuAction(testItem.test.item.extId, label, actions.object);
 		});
 
 


### PR DESCRIPTION
Fixes #209621, apply the fix locally for testing instead

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
