### PR TITLE
chore: increase compile job timeout (#209497)

### DIFF
--- a/build/azure-pipelines/product-build.yml
+++ b/build/azure-pipelines/product-build.yml
@@ -197,6 +197,7 @@ extends:
       - stage: Compile
         jobs:
           - job: Compile
+            timeoutInMinutes: 90
             pool:
               name: 1es-ubuntu-20.04-x64
               os: linux


### PR DESCRIPTION
I noticed that the Compile job also times out more often these days.
I previously merged in a timeout increase, but it was only for the Linux x64 release job.