### PR TITLE
Enable links to locations within comment editors

### DIFF
--- a/src/vs/workbench/contrib/comments/browser/commentsInputContentProvider.ts
+++ b/src/vs/workbench/contrib/comments/browser/commentsInputContentProvider.ts
@@ -6,11 +6,16 @@
 import { Disposable } from 'vs/base/common/lifecycle';
 import { Schemas } from 'vs/base/common/network';
 import { URI } from 'vs/base/common/uri';
-import { IEditorContribution } from 'vs/editor/common/editorCommon';
+import { ICodeEditor } from 'vs/editor/browser/editorBrowser';
+import { ICodeEditorService } from 'vs/editor/browser/services/codeEditorService';
+import { IEditorContribution, ScrollType } from 'vs/editor/common/editorCommon';
 import { ILanguageService } from 'vs/editor/common/languages/language';
 import { ITextModel } from 'vs/editor/common/model';
 import { IModelService } from 'vs/editor/common/services/model';
 import { ITextModelContentProvider, ITextModelService } from 'vs/editor/common/services/resolverService';
+import { ITextResourceEditorInput } from 'vs/platform/editor/common/editor';
+import { applyTextEditorOptions } from 'vs/workbench/common/editor/editorOptions';
+import { SimpleCommentEditor } from 'vs/workbench/contrib/comments/browser/simpleCommentEditor';
 
 export class CommentsInputContentProvider extends Disposable implements ITextModelContentProvider, IEditorContribution {
 
@@ -18,11 +23,27 @@ export class CommentsInputContentProvider extends Disposable implements ITextMod
 
 	constructor(
 		@ITextModelService textModelService: ITextModelService,
+		@ICodeEditorService codeEditorService: ICodeEditorService,
 		@IModelService private readonly _modelService: IModelService,
 		@ILanguageService private readonly _languageService: ILanguageService,
 	) {
 		super();
 		this._register(textModelService.registerTextModelContentProvider(Schemas.commentsInput, this));
+
+		this._register(codeEditorService.registerCodeEditorOpenHandler(async (input: ITextResourceEditorInput, editor: ICodeEditor | null, _sideBySide?: boolean): Promise<ICodeEditor | null> => {
+			if (!(editor instanceof SimpleCommentEditor)) {
+				return null;
+			}
+
+			if (editor.getModel()?.uri.toString() !== input.resource.toString()) {
+				return null;
+			}
+
+			if (input.options) {
+				applyTextEditorOptions(input.options, editor, ScrollType.Immediate);
+			}
+			return editor;
+		}));
 	}
 
 	async provideTextContent(resource: URI): Promise<ITextModel | null> {


### PR DESCRIPTION
Makes sure that if you write a comment such as:

```
[ref]

[ref]: http://example.com
```

Clicking on `ref` navigates to the definition instead of opening the comment contents in a new editor

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
