### PR TITLE
Limit the size of the dialog box and let the message overflow

### DIFF
--- a/src/vs/base/browser/ui/dialog/dialog.css
+++ b/src/vs/base/browser/ui/dialog/dialog.css
@@ -28,6 +28,7 @@
 	min-width: 500px;
 	max-width: 90vw;
 	min-height: 75px;
+	max-height: 90vh;
 	padding: 10px;
 	transform: translate3d(0px, 0px, 0px);
 }
@@ -87,6 +88,8 @@
 .monaco-dialog-box .dialog-message-row .dialog-message-container .dialog-message-detail {
 	line-height: 22px;
 	flex: 1; /* let the message always grow */
+	max-height: 70vh;
+	overflow: auto; /* show scrollbars if the message is too big */
 }
 
 .monaco-dialog-box .dialog-message-row .dialog-message-container .dialog-message a:focus {

--- a/src/vs/base/browser/ui/dialog/dialog.css
+++ b/src/vs/base/browser/ui/dialog/dialog.css
@@ -62,13 +62,14 @@
 .monaco-dialog-box .dialog-message-row .dialog-message-container {
 	display: flex;
 	flex-direction: column;
-	overflow: hidden;
+	overflow: auto; /* show scrollbars if the message is too big */
 	text-overflow: ellipsis;
 	padding-left: 24px;
 	user-select: text;
 	-webkit-user-select: text;
 	word-wrap: break-word; /* never overflow long words, but break to next line */
 	white-space: normal;
+	max-height: 70vh;
 }
 
 /** Dialog: Message */
@@ -88,8 +89,6 @@
 .monaco-dialog-box .dialog-message-row .dialog-message-container .dialog-message-detail {
 	line-height: 22px;
 	flex: 1; /* let the message always grow */
-	max-height: 70vh;
-	overflow: auto; /* show scrollbars if the message is too big */
 }
 
 .monaco-dialog-box .dialog-message-row .dialog-message-container .dialog-message a:focus {


### PR DESCRIPTION
In case the error message is too large the dialog box can be too big and not fit into the screen. Add a height limit for the details message and let it overflow with scrollbars.