### PR TITLE
Fix incorrect typings in `OpenJsDocLinkCommand_Args`

### DIFF
--- a/extensions/typescript-language-features/src/commands/openJsDocLink.ts
+++ b/extensions/typescript-language-features/src/commands/openJsDocLink.ts
@@ -7,8 +7,17 @@ import * as vscode from 'vscode';
 import { Command } from './commandManager';
 
 export interface OpenJsDocLinkCommand_Args {
-	readonly file: vscode.Uri;
-	readonly position: vscode.Position;
+	readonly file: {
+		readonly scheme: string;
+		readonly authority?: string;
+		readonly path?: string;
+		readonly query?: string;
+		readonly fragment?: string;
+	};
+	readonly position: {
+		readonly line: number;
+		readonly character: number;
+	};
 }
 
 /**
@@ -21,8 +30,10 @@ export class OpenJsDocLinkCommand implements Command {
 	public readonly id = OpenJsDocLinkCommand.id;
 
 	public async execute(args: OpenJsDocLinkCommand_Args): Promise<void> {
+		const { line, character } = args.position;
+		const position = new vscode.Position(line, character);
 		await vscode.commands.executeCommand('vscode.open', vscode.Uri.from(args.file), <vscode.TextDocumentShowOptions>{
-			selection: new vscode.Range(args.position, args.position),
+			selection: new vscode.Range(position, position),
 		});
 	}
 }


### PR DESCRIPTION
Fixes an issue in `openJsDocLink` command due to incorrect typings in `OpenJsDocLinkCommand_Args`.

The `openJsDocLink` command currently declares the type of its `args` parameter as

```typescript
{
        readonly file: vscode.Uri;
        readonly position: vscode.Position;
}
```

However, the type of the actual argument given to the command is

```typescript
{
        readonly file: UriComponents;
        readonly position: { line: number; character: number; };
}
```

As a consequence, while the command does convert `args.file` to `vscode.Uri` via `vscode.Uri.from(args.file)`, it misses converting `args.position` to `vscode.Position`. This works *by accident* in VS Code, but causes an issue in Eclipse Theia (https://github.com/eclipse-theia/theia/issues/13568).

This PR fixes the typings in `OpenJsDocLinkCommand_Args` and adds the necessary conversion for `args.position`.