### PR TITLE
Only set new activeEntry if entry is not filtered out

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/viewModel/notebookOutlineProvider.ts
+++ b/src/vs/workbench/contrib/notebook/browser/viewModel/notebookOutlineProvider.ts
@@ -263,7 +263,21 @@ export class NotebookCellOutlineProvider {
 				}
 			}
 		}
-		if (newActive !== this._activeEntry) {
+
+		// @Yoyokrazy - Make sure the new active entry isn't part of the filtered exclusions
+		const showCodeCells = this._configurationService.getValue<boolean>(NotebookSetting.outlineShowCodeCells);
+		const showCodeCellSymbols = this._configurationService.getValue<boolean>(NotebookSetting.outlineShowCodeCellSymbols);
+		const showMarkdownHeadersOnly = this._configurationService.getValue<boolean>(NotebookSetting.outlineShowMarkdownHeadersOnly);
+
+		// check the three outline filtering conditions
+		// if any are true, newActive should NOT be set to this._activeEntry and the event should NOT fire
+		if (
+			(newActive !== this._activeEntry) && !(
+				(showMarkdownHeadersOnly && newActive?.cell.cellKind === CellKind.Markup && newActive?.level === 7) || 	// show headers only + cell is mkdn + is level 7 (no header)
+				(showCodeCells && newActive?.cell.cellKind === CellKind.Code) ||										// show code cells   + cell is code
+				(showCodeCellSymbols && newActive?.cell.cellKind === CellKind.Code && newActive?.level > 7)				// show code symbols + cell is code + has level > 7 (nb symbol levels)
+			)
+		) {
 			this._activeEntry = newActive;
 			this._onDidChange.fire({ affectOnlyActiveElement: true });
 		}

--- a/src/vs/workbench/contrib/notebook/browser/viewModel/notebookOutlineProvider.ts
+++ b/src/vs/workbench/contrib/notebook/browser/viewModel/notebookOutlineProvider.ts
@@ -274,8 +274,8 @@ export class NotebookCellOutlineProvider {
 		if (
 			(newActive !== this._activeEntry) && !(
 				(showMarkdownHeadersOnly && newActive?.cell.cellKind === CellKind.Markup && newActive?.level === 7) || 	// show headers only + cell is mkdn + is level 7 (no header)
-				(showCodeCells && newActive?.cell.cellKind === CellKind.Code) ||										// show code cells   + cell is code
-				(showCodeCellSymbols && newActive?.cell.cellKind === CellKind.Code && newActive?.level > 7)				// show code symbols + cell is code + has level > 7 (nb symbol levels)
+				(!showCodeCells && newActive?.cell.cellKind === CellKind.Code) ||										// show code cells   + cell is code
+				(!showCodeCellSymbols && newActive?.cell.cellKind === CellKind.Code && newActive?.level > 7)			// show code symbols + cell is code + has level > 7 (nb symbol levels)
 			)
 		) {
 			this._activeEntry = newActive;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fixes: #208923

cc @jrieken / @rebornix 

When outline view was set to `follow cursor`, the treeview will try to highlight the active entry in the outline view. After the latest iteration, users are now able to exclude a variety of cell types from the view. This filtering logic was shifted to the treeview's `getChildren` call in order to preserve the outline model for other computations (namely nb sticky scroll).

Easiest example is if the user excludes code cells (the default behavior), and then clicks a code cell. The treeview will attempt to highlight the entry, but as the cell was filtered out, there would be an error as the entry cannot be found. This breaks the outline view entirely, and the treeview cannot recover. Ideally this wouldn't force a reload, but this PR ensures that a notebook entry exclusion error will not break the view state.