### PR TITLE
fix task bug

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -198,7 +198,13 @@
 			"windows": {
 				"command": ".\\scripts\\code-server.bat"
 			},
-			"args": ["--no-launch", "--connection-token", "dev-token", "--port", "8080"],
+			"args": [
+				"--no-launch",
+				"--connection-token",
+				"dev-token",
+				"--port",
+				"8080"
+			],
 			"label": "Run code server",
 			"isBackground": true,
 			"problemMatcher": {
@@ -220,7 +226,12 @@
 			"windows": {
 				"command": ".\\scripts\\code-web.bat"
 			},
-			"args": ["--port", "8080", "--browser", "none"],
+			"args": [
+				"--port",
+				"8080",
+				"--browser",
+				"none"
+			],
 			"label": "Run code web",
 			"isBackground": true,
 			"problemMatcher": {
@@ -268,7 +279,6 @@
 			"detail": "node_modules/tsec/bin/tsec -p src/tsconfig.json --noEmit"
 		},
 		{
-			// Used for monaco editor playground launch config
 			"label": "Launch Http Server",
 			"type": "shell",
 			"command": "node_modules/.bin/ts-node -T ./scripts/playground-server",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -198,13 +198,7 @@
 			"windows": {
 				"command": ".\\scripts\\code-server.bat"
 			},
-			"args": [
-				"--no-launch",
-				"--connection-token",
-				"dev-token",
-				"--port",
-				"8080"
-			],
+			"args": ["--no-launch", "--connection-token", "dev-token", "--port", "8080"],
 			"label": "Run code server",
 			"isBackground": true,
 			"problemMatcher": {
@@ -226,12 +220,7 @@
 			"windows": {
 				"command": ".\\scripts\\code-web.bat"
 			},
-			"args": [
-				"--port",
-				"8080",
-				"--browser",
-				"none"
-			],
+			"args": ["--port", "8080", "--browser", "none"],
 			"label": "Run code web",
 			"isBackground": true,
 			"problemMatcher": {
@@ -279,6 +268,7 @@
 			"detail": "node_modules/tsec/bin/tsec -p src/tsconfig.json --noEmit"
 		},
 		{
+			// Used for monaco editor playground launch config
 			"label": "Launch Http Server",
 			"type": "shell",
 			"command": "node_modules/.bin/ts-node -T ./scripts/playground-server",

--- a/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
+++ b/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
@@ -3053,18 +3053,12 @@ export abstract class AbstractTaskService extends Disposable implements ITaskSer
 				groupTasks = await this._findWorkspaceTasksInGroup(taskGroup, true);
 			}
 
-			switch (groupTasks.length) {
-				case 0:
-					// No tasks found, prompt to configure
-					configure.apply(this);
-					break;
-				case 1:
-					// A single default task was returned, just run it directly
-					return resolveTaskAndRun(groupTasks[0]);
-				default:
-					// Multiple default tasks returned, show the quickPicker
-					return handleMultipleTasks(false);
+			if (groupTasks.length === 1) {
+				// A single default task was returned, just run it directly
+				return resolveTaskAndRun(groupTasks[0]);
 			}
+			// Multiple default tasks returned, show the quickPicker
+			return handleMultipleTasks(false);
 		})();
 		this._progressService.withProgress(options, () => promise);
 	}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
I'd changed the behavior such that when no default build task was found, it would prompt you to configure that. Instead, we should just show all build tasks and allow it to run. 

A user can still run `configure default build task` if they want to do so.

fixes [#209953](https://github.com/microsoft/vscode/issues/209953)