### PR TITLE
Drop custom property from Jupyter Nb metadata

### DIFF
--- a/extensions/ipynb/src/common.ts
+++ b/extensions/ipynb/src/common.ts
@@ -67,5 +67,5 @@ export interface CellMetadata {
 }
 
 export function useCustomPropertyInMetadata() {
-	return !workspace.getConfiguration('jupyter', undefined).get<boolean>('experimental.dropCustomMetadata', false);
+	return !workspace.getConfiguration('jupyter', undefined).get<boolean>('experimental.dropCustomMetadata', true);
 }


### PR DESCRIPTION
For #205637

This pull request removes the custom property from Jupyter Notebook metadata. The `useCustomPropertyInMetadata` function now returns `true` instead of `false` for the `experimental.dropCustomMetadata` configuration option.