### PR TITLE
gettingStarted: make themeService protected (again)

### DIFF
--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts
@@ -174,7 +174,7 @@ export class GettingStartedPage extends EditorPane {
 		@ILanguageService private readonly languageService: ILanguageService,
 		@IFileService private readonly fileService: IFileService,
 		@IOpenerService private readonly openerService: IOpenerService,
-		@IWorkbenchThemeService public override readonly themeService: IWorkbenchThemeService,
+		@IWorkbenchThemeService protected override readonly themeService: IWorkbenchThemeService,
 		@IStorageService private storageService: IStorageService,
 		@IExtensionService private readonly extensionService: IExtensionService,
 		@IInstantiationService private readonly instantiationService: IInstantiationService,


### PR DESCRIPTION
Fix for:
```
[13:29:19] [mangler] Done collecting. Classes: 7580. Exported symbols: 9178
[core-ci                 ] [13:29:23] [mangler] WARN: 'themeService' from /mnt/vss/_work/1/s/src/vs/platform/theme/common/themeService.ts:178 became PUBLIC because of: /mnt/vss/_work/1/s/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts:177
[core-ci                 ] [13:29:23] [mangler] ERROR: Protected fields have been made PUBLIC. This hurts minification and is therefore not allowed. Review the WARN messages further above
[core-ci                 ] [13:29:23] Starting compilation...
[core-ci                 ] [13:29:23] 'core-ci' errored after 47 s
[core-ci                 ] [13:29:23] Error: Protected fields have been made PUBLIC. This hurts minification and is therefore not allowed. Review the WARN messages further above
```