### PR TITLE
Fix decoding of authority in webview

### DIFF
--- a/src/vs/workbench/contrib/webview/common/webview.ts
+++ b/src/vs/workbench/contrib/webview/common/webview.ts
@@ -74,5 +74,5 @@ function encodeAuthority(authority: string): string {
 }
 
 export function decodeAuthority(authority: string) {
-	return decodeURIComponent(authority.replace(/-([0-9a-f]{2})/g, (_, code) => String.fromCharCode(parseInt(code, 16))));
+	return decodeURIComponent(authority.replace(/-([0-9a-f]{4})/g, (_, code) => String.fromCharCode(parseInt(code, 16))));
 }

--- a/src/vs/workbench/contrib/webview/common/webview.ts
+++ b/src/vs/workbench/contrib/webview/common/webview.ts
@@ -74,5 +74,5 @@ function encodeAuthority(authority: string): string {
 }
 
 export function decodeAuthority(authority: string) {
-	return authority.replace(/-([0-9a-f]{4})/g, (_, code) => String.fromCharCode(parseInt(code, 16)));
+	return decodeURIComponent(authority.replace(/-([0-9a-f]{2})/g, (_, code) => String.fromCharCode(parseInt(code, 16))));
 }

--- a/src/vs/workbench/contrib/webview/test/common/webview.test.ts
+++ b/src/vs/workbench/contrib/webview/test/common/webview.test.ts
@@ -1,0 +1,27 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { decodeAuthority } from 'vs/workbench/contrib/webview/common/webview';
+import { ensureNoDisposablesAreLeakedInTestSuite } from 'vs/base/test/common/utils';
+
+suite('WebView', () => {
+	test('decodeAuthority', () => {
+		const encodedAuthority = 'https%3A%2F%2Fexample.com';
+		const expectedDecodedAuthority = 'https://example.com';
+
+		const actualDecodedAuthority = decodeAuthority(encodedAuthority);
+
+		assert.strictEqual(actualDecodedAuthority, expectedDecodedAuthority);
+	});
+
+	test('decodeAuthority should throw an error for invalid input', () => {
+		const invalidInput = 'not a valid input';
+
+		assert.throws(() => decodeAuthority(invalidInput));
+	});
+
+	ensureNoDisposablesAreLeakedInTestSuite();
+});

--- a/src/vs/workbench/contrib/webview/test/common/webview.test.ts
+++ b/src/vs/workbench/contrib/webview/test/common/webview.test.ts
@@ -8,6 +8,8 @@ import { decodeAuthority } from 'vs/workbench/contrib/webview/common/webview';
 import { ensureNoDisposablesAreLeakedInTestSuite } from 'vs/base/test/common/utils';
 
 suite('WebView', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
 	test('decodeAuthority', () => {
 		const encodedAuthority = 'https%3A%2F%2Fexample.com';
 		const expectedDecodedAuthority = 'https://example.com';
@@ -18,10 +20,6 @@ suite('WebView', () => {
 	});
 
 	test('decodeAuthority should throw an error for invalid input', () => {
-		const invalidInput = 'not a valid input';
-
-		assert.throws(() => decodeAuthority(invalidInput));
+		assert.rejects(async () => await decodeAuthority('not a valid input'));
 	});
-
-	ensureNoDisposablesAreLeakedInTestSuite();
 });


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Unmangles authority URL which is breaking PNG images.

Verification Steps:
1. Open Welcome.
2. Click Get Started with VS Code.
3. Images should load.

Fixes #209478 