### PR TITLE
POC for storing backup content on the FS from the EH

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadNotebook.ts
+++ b/src/vs/workbench/api/browser/mainThreadNotebook.ts
@@ -53,14 +53,14 @@ export class MainThreadNotebooks implements MainThreadNotebookShape {
 
 		disposables.add(this._notebookService.registerNotebookSerializer(viewType, extension, {
 			options,
-			dataToNotebook: async (data: VSBuffer): Promise<NotebookData> => {
+			dataToNotebook: async (data: VSBuffer, resource?: URI): Promise<NotebookData> => {
 				const sw = new StopWatch();
 				let result: NotebookData;
 				if (data.byteLength === 0 && viewType === 'interactive') {
 					// we don't want any starting cells for an empty interactive window.
 					result = NotebookDto.fromNotebookDataDto({ cells: [], metadata: {} });
 				} else {
-					const dto = await this._proxy.$dataToNotebook(handle, data, CancellationToken.None);
+					const dto = await this._proxy.$dataToNotebook(handle, data, resource, CancellationToken.None);
 					result = NotebookDto.fromNotebookDataDto(dto.value);
 				}
 				this._logService.trace(`[NotebookSerializer] dataToNotebook DONE after ${sw.elapsed()}ms`, {
@@ -69,9 +69,9 @@ export class MainThreadNotebooks implements MainThreadNotebookShape {
 				});
 				return result;
 			},
-			notebookToData: (data: NotebookData): Promise<VSBuffer> => {
+			notebookToData: (data: NotebookData, resource?: URI): Promise<VSBuffer> => {
 				const sw = new StopWatch();
-				const result = this._proxy.$notebookToData(handle, new SerializableObjectWithBuffers(NotebookDto.toNotebookDataDto(data)), CancellationToken.None);
+				const result = this._proxy.$notebookToData(handle, new SerializableObjectWithBuffers(NotebookDto.toNotebookDataDto(data)), resource, CancellationToken.None);
 				this._logService.trace(`[NotebookSerializer] notebookToData DONE after ${sw.elapsed()}`, {
 					viewType,
 					extensionId: extension.id.value,

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -2539,8 +2539,8 @@ export interface ExtHostNotebookShape extends ExtHostNotebookDocumentsAndEditors
 	$provideNotebookCellStatusBarItems(handle: number, uri: UriComponents, index: number, token: CancellationToken): Promise<INotebookCellStatusBarListDto | undefined>;
 	$releaseNotebookCellStatusBarItems(id: number): void;
 
-	$dataToNotebook(handle: number, data: VSBuffer, token: CancellationToken): Promise<SerializableObjectWithBuffers<NotebookDataDto>>;
-	$notebookToData(handle: number, data: SerializableObjectWithBuffers<NotebookDataDto>, token: CancellationToken): Promise<VSBuffer>;
+	$dataToNotebook(handle: number, data: VSBuffer, resource: URI | undefined, token: CancellationToken): Promise<SerializableObjectWithBuffers<NotebookDataDto>>;
+	$notebookToData(handle: number, data: SerializableObjectWithBuffers<NotebookDataDto>, resource: URI | undefined, token: CancellationToken): Promise<VSBuffer>;
 	$saveNotebook(handle: number, uri: UriComponents, versionId: number, options: files.IWriteFileOptions, token: CancellationToken): Promise<INotebookPartialFileStatsWithMetadata>;
 
 	$searchInNotebooks(handle: number, textQuery: search.ITextQuery, viewTypeFileTargets: NotebookPriorityInfo[], otherViewTypeFileTargets: NotebookPriorityInfo[], token: CancellationToken): Promise<{ results: IRawClosedNotebookFileMatch[]; limitHit: boolean }>;

--- a/src/vs/workbench/contrib/notebook/common/notebookEditorModel.ts
+++ b/src/vs/workbench/contrib/notebook/common/notebookEditorModel.ts
@@ -250,7 +250,7 @@ export class NotebookFileWorkingCopyModel extends Disposable implements IStoredF
 		return this._notebookModel;
 	}
 
-	async snapshot(token: CancellationToken): Promise<VSBufferReadableStream> {
+	async snapshot(token: CancellationToken, reason?: 'backup' | 'save'): Promise<VSBufferReadableStream> {
 		const serializer = await this.getNotebookSerializer();
 
 		const data: NotebookData = {
@@ -274,7 +274,7 @@ export class NotebookFileWorkingCopyModel extends Disposable implements IStoredF
 			data.cells.push(cellData);
 		}
 
-		const bytes = await serializer.notebookToData(data);
+		const bytes = await serializer.notebookToData(data, reason === 'backup' ? this._notebookModel.uri : undefined);
 		if (token.isCancellationRequested) {
 			throw new CancellationError();
 		}
@@ -327,7 +327,7 @@ export class NotebookFileWorkingCopyModelFactory implements IStoredFileWorkingCo
 		}
 
 		const bytes = await streamToBuffer(stream);
-		const data = await info.serializer.dataToNotebook(bytes);
+		const data = await info.serializer.dataToNotebook(bytes, resource);
 
 		if (token.isCancellationRequested) {
 			throw new CancellationError();

--- a/src/vs/workbench/contrib/notebook/common/notebookService.ts
+++ b/src/vs/workbench/contrib/notebook/common/notebookService.ts
@@ -31,8 +31,8 @@ export interface INotebookContentProvider {
 
 export interface INotebookSerializer {
 	options: TransientOptions;
-	dataToNotebook(data: VSBuffer): Promise<NotebookData>;
-	notebookToData(data: NotebookData): Promise<VSBuffer>;
+	dataToNotebook(data: VSBuffer, resource?: URI): Promise<NotebookData>;
+	notebookToData(data: NotebookData, resource?: URI): Promise<VSBuffer>;
 	save(uri: URI, versionId: number, options: IWriteFileOptions, token: CancellationToken): Promise<IFileStatWithMetadata>;
 	searchInNotebooks(textQuery: ITextQuery, token: CancellationToken, allPriorityInfo: Map<string, NotebookPriorityInfo[]>): Promise<{ results: INotebookFileMatchNoModel<URI>[]; limitHit: boolean }>;
 }

--- a/src/vs/workbench/services/workingCopy/common/fileWorkingCopy.ts
+++ b/src/vs/workbench/services/workingCopy/common/fileWorkingCopy.ts
@@ -74,7 +74,7 @@ export interface IFileWorkingCopyModel extends IDisposable {
 	 *
 	 * @param token support for cancellation
 	 */
-	snapshot(token: CancellationToken): Promise<VSBufferReadableStream>;
+	snapshot(token: CancellationToken, reason?: 'backup' | 'save'): Promise<VSBufferReadableStream>;
 
 	/**
 	 * Updates the model with the provided contents. The implementation should

--- a/src/vs/workbench/services/workingCopy/common/storedFileWorkingCopy.ts
+++ b/src/vs/workbench/services/workingCopy/common/storedFileWorkingCopy.ts
@@ -813,7 +813,7 @@ export class StoredFileWorkingCopy<M extends IStoredFileWorkingCopyModel> extend
 		// Fill in content if we are resolved
 		let content: VSBufferReadableStream | undefined = undefined;
 		if (this.isResolved()) {
-			content = await raceCancellation(this.model.snapshot(token), token);
+			content = await raceCancellation(this.model.snapshot(token, 'backup'), token);
 		}
 
 		return { meta, content };

--- a/src/vs/workbench/services/workingCopy/common/untitledFileWorkingCopy.ts
+++ b/src/vs/workbench/services/workingCopy/common/untitledFileWorkingCopy.ts
@@ -264,7 +264,7 @@ export class UntitledFileWorkingCopy<M extends IUntitledFileWorkingCopyModel> ex
 		// if any - to prevent backing up an unresolved working
 		// copy and loosing the initial value.
 		if (this.isResolved()) {
-			content = await raceCancellation(this.model.snapshot(token), token);
+			content = await raceCancellation(this.model.snapshot(token, 'backup'), token);
 		} else if (this.initialContents) {
 			content = this.initialContents.value;
 		}


### PR DESCRIPTION
This is just to show the possibility of writing backups in the EH so that the renderer process doesn't get blocked while writing large file content to disk for every backup. (https://github.com/microsoft/vscode/pull/209988 takes care of the auto-saves)

- The workingCopy class should probably just split out the backup code path as the `CustomEditorProvider` does, rather than adding a flag to `snapshot`
- Should the backup Tracker provide the location to write to? And also provide the pre-amble?
  - The model could either write the backup to that location if it knows how, or just return the content and let the backup service do it as usual


