### PR TITLE
Allow embedders to show an information message when workbench loads

### DIFF
--- a/src/vs/workbench/browser/web.api.ts
+++ b/src/vs/workbench/browser/web.api.ts
@@ -103,6 +103,16 @@ export interface IWorkbench {
 		 * `ExtensionTerminalOptions` in the extension API.
 		 */
 		createTerminal(options: IEmbedderTerminalOptions): Promise<void>;
+
+		/**
+		 * Show an information message to users. Optionally provide an array of items which will be presented as
+		 * clickable buttons.
+		 *
+		 * @param message The message to show.
+		 * @param items A set of items that will be rendered as actions in the message.
+		 * @returns A thenable that resolves to the selected item or `undefined` when being dismissed.
+		 */
+		showInformationMessage<T extends string>(message: string, ...items: T[]): Promise<T | undefined>;
 	};
 
 	workspace: {

--- a/src/vs/workbench/browser/web.factory.ts
+++ b/src/vs/workbench/browser/web.factory.ts
@@ -150,6 +150,11 @@ export namespace window {
 		const workbench = await workbenchPromise.p;
 		workbench.window.createTerminal(options);
 	}
+
+	export async function showInformationMessage<T extends string>(message: string, ...items: T[]): Promise<T | undefined> {
+		const workbench = await workbenchPromise.p;
+		return await workbench.window.showInformationMessage(message, ...items);
+	}
 }
 
 export namespace workspace {

--- a/src/vs/workbench/browser/web.main.ts
+++ b/src/vs/workbench/browser/web.main.ts
@@ -206,7 +206,7 @@ export class BrowserMain extends Disposable {
 				window: {
 					withProgress: (options, task) => progressService.withProgress(options, task),
 					createTerminal: async (options) => embedderTerminalService.createTerminal(options),
-					showInformationMessage: async (message, ...items) => showMessage(Severity.Info, message, ...items),
+					showInformationMessage: (message, ...items) => showMessage(Severity.Info, message, ...items),
 				},
 				workspace: {
 					didResolveRemoteAuthority: async () => {

--- a/src/vs/workbench/browser/web.main.ts
+++ b/src/vs/workbench/browser/web.main.ts
@@ -76,7 +76,7 @@ import { ILabelService } from 'vs/platform/label/common/label';
 import { UserDataProfileService } from 'vs/workbench/services/userDataProfile/common/userDataProfileService';
 import { IUserDataProfileService } from 'vs/workbench/services/userDataProfile/common/userDataProfile';
 import { BrowserUserDataProfilesService } from 'vs/platform/userDataProfile/browser/userDataProfile';
-import { timeout } from 'vs/base/common/async';
+import { DeferredPromise, timeout } from 'vs/base/common/async';
 import { windowLogId } from 'vs/workbench/services/log/common/logConstants';
 import { LogService } from 'vs/platform/log/common/logService';
 import { IRemoteSocketFactoryService, RemoteSocketFactoryService } from 'vs/platform/remote/common/remoteSocketFactoryService';
@@ -95,6 +95,7 @@ import { IEncryptionService } from 'vs/platform/encryption/common/encryptionServ
 import { ISecretStorageService } from 'vs/platform/secrets/common/secrets';
 import { TunnelSource } from 'vs/workbench/services/remote/common/tunnelModel';
 import { mainWindow } from 'vs/base/browser/window';
+import { INotificationService, Severity } from 'vs/platform/notification/common/notification';
 
 export class BrowserMain extends Disposable {
 
@@ -157,10 +158,26 @@ export class BrowserMain extends Disposable {
 			const labelService = accessor.get(ILabelService);
 			const embedderTerminalService = accessor.get(IEmbedderTerminalService);
 			const remoteAuthorityResolverService = accessor.get(IRemoteAuthorityResolverService);
+			const notificationService = accessor.get(INotificationService);
+
+			async function showMessage<T extends string>(severity: Severity, message: string, ...items: T[]): Promise<T | undefined> {
+				const choice = new DeferredPromise<T | undefined>();
+				const thing = notificationService.prompt(severity, message, items.map(item => ({
+					label: item,
+					run: () => choice.complete(item)
+				})));
+				const disposable = thing.onDidClose(() => {
+					choice.complete(undefined);
+					disposable.dispose();
+				});
+				const result = await choice.p;
+				thing.close();
+				return result;
+			}
 
 			let logger: DelayedLogChannel | undefined = undefined;
 
-			return {
+			return <IWorkbench>{
 				commands: {
 					executeCommand: (command, ...args) => commandService.executeCommand(command, ...args)
 				},
@@ -189,6 +206,7 @@ export class BrowserMain extends Disposable {
 				window: {
 					withProgress: (options, task) => progressService.withProgress(options, task),
 					createTerminal: async (options) => embedderTerminalService.createTerminal(options),
+					showInformationMessage: async (message, ...items) => showMessage(Severity.Info, message, ...items),
 				},
 				workspace: {
 					didResolveRemoteAuthority: async () => {

--- a/src/vs/workbench/browser/web.main.ts
+++ b/src/vs/workbench/browser/web.main.ts
@@ -162,16 +162,16 @@ export class BrowserMain extends Disposable {
 
 			async function showMessage<T extends string>(severity: Severity, message: string, ...items: T[]): Promise<T | undefined> {
 				const choice = new DeferredPromise<T | undefined>();
-				const thing = notificationService.prompt(severity, message, items.map(item => ({
+				const handle = notificationService.prompt(severity, message, items.map(item => ({
 					label: item,
 					run: () => choice.complete(item)
 				})));
-				const disposable = thing.onDidClose(() => {
+				const disposable = handle.onDidClose(() => {
 					choice.complete(undefined);
 					disposable.dispose();
 				});
 				const result = await choice.p;
-				thing.close();
+				handle.close();
 				return result;
 			}
 


### PR DESCRIPTION
Needed for MSAL adoption in vscode.dev

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
