### PR TITLE
feat: optimize check glibc version scripts

### DIFF
--- a/resources/server/bin/helpers/check-requirements-linux.sh
+++ b/resources/server/bin/helpers/check-requirements-linux.sh
@@ -133,7 +133,11 @@ elif [ -z "$(ldd --version 2>&1 | grep 'musl libc')" ]; then
 		# we instead use the version of the cached libc.so.6 file itself.
         libc_path_line=$(echo "$libc_path" | head -n1)
         libc_real_path=$(readlink -f "$libc_path_line")
-        libc_version=$(cat "$libc_real_path" | sed -n 's/.*release version \([0-9]\+\.[0-9]\+\).*/\1/p')
+        if command -v strings >/dev/null 2>&1; then
+            libc_version=$(strings "$libc_real_path" | grep "release version" | sed -n 's/.*release version \([0-9]\+\.[0-9]\+\).*/\1/p')
+        else
+            libc_version=$(cat "$libc_real_path" | sed -n 's/.*release version \([0-9]\+\.[0-9]\+\).*/\1/p')
+        fi
         if [ "$(printf '%s\n' "2.28" "$libc_version" | sort -V | head -n1)" = "2.28" ]; then
             found_required_glibc=1
             break


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
In centos7, using the `cat` command to check `glibc` version takes nearly 1 second
<img width="574" alt="image" src="https://github.com/microsoft/vscode/assets/13031838/909140f0-fd9c-4d7d-b193-0386863f8230">

but using the `strings` only tasks 18ms
<img width="570" alt="image" src="https://github.com/microsoft/vscode/assets/13031838/5df3f311-ae52-4f66-89fc-0395662338dd">

