### PR TITLE
Offset terminal when inline chat appears to ensure cursor is visible

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/chat/browser/terminalChatController.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chat/browser/terminalChatController.ts
@@ -149,7 +149,7 @@ export class TerminalChatController extends Disposable implements ITerminalContr
 
 	xtermReady(xterm: IXtermTerminal & { raw: RawXtermTerminal }): void {
 		this._chatWidget = new Lazy(() => {
-			const chatWidget = this._register(this._instantiationService.createInstance(TerminalChatWidget, this._instance.domElement!, this._instance));
+			const chatWidget = this._register(this._instantiationService.createInstance(TerminalChatWidget, this._instance.domElement!, this._instance, xterm));
 			this._register(chatWidget.focusTracker.onDidFocus(() => {
 				TerminalChatController.activeChatWidget = this;
 				if (!isDetachedTerminalInstance(this._instance)) {

--- a/src/vs/workbench/contrib/terminalContrib/stickyScroll/browser/terminalStickyScrollContribution.ts
+++ b/src/vs/workbench/contrib/terminalContrib/stickyScroll/browser/terminalStickyScrollContribution.ts
@@ -60,6 +60,14 @@ export class TerminalStickyScrollContribution extends Disposable implements ITer
 		this._refreshState();
 	}
 
+	hideLock() {
+		this._overlay.value?.lockHide();
+	}
+
+	hideUnlock() {
+		this._overlay.value?.unlockHide();
+	}
+
 	private _refreshState(): void {
 		if (this._overlay.value) {
 			this._tryDisable();

--- a/src/vs/workbench/contrib/terminalContrib/stickyScroll/browser/terminalStickyScrollOverlay.ts
+++ b/src/vs/workbench/contrib/terminalContrib/stickyScroll/browser/terminalStickyScrollOverlay.ts
@@ -129,6 +129,14 @@ export class TerminalStickyScrollOverlay extends Disposable {
 		});
 	}
 
+	lockHide() {
+		this._element?.classList.add('lock-hide');
+	}
+
+	unlockHide() {
+		this._element?.classList.remove('lock-hide');
+	}
+
 	private _setState(state: OverlayState) {
 		if (this._state === state) {
 			return;


### PR DESCRIPTION
This will overlay the terminal inline chat widget on top of the terminal the same as previously where the cursor would be visible. If it would not be visible, the terminal wrapper element is now shifted upwards to ensure it's visible. This comes with a couple of downsides:

- The very top of the terminal cannot be accessed as overflow is clipped by the view.
- The chat may overlap content if there is any below the cursor, which is an unlikely edge case.

This isn't as good as a zone widget-like system in xterm.js could be, but that is quite the undertaking and complicates the renderer code quite a bit. So this is a good compromise.

Fixes microsoft/vscode-copilot#4720

![Recording 2024-04-12 at 07 00 17](https://github.com/microsoft/vscode/assets/2193314/7710fc8f-b43d-4077-b1d4-94da9a3506cf)
