### PR TITLE
Fix participant publisher showing "undefined" after reload

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/chatExecuteActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatExecuteActions.ts
@@ -157,6 +157,10 @@ export class CancelAction extends Action2 {
 				id: MenuId.ChatExecute,
 				when: CONTEXT_CHAT_REQUEST_IN_PROGRESS,
 				group: 'navigation',
+			},
+			keybinding: {
+				weight: KeybindingWeight.WorkbenchContrib,
+				primary: KeyMod.CtrlCmd | KeyCode.Escape,
 			}
 		});
 	}

--- a/src/vs/workbench/contrib/chat/browser/actions/chatExecuteActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatExecuteActions.ts
@@ -157,10 +157,6 @@ export class CancelAction extends Action2 {
 				id: MenuId.ChatExecute,
 				when: CONTEXT_CHAT_REQUEST_IN_PROGRESS,
 				group: 'navigation',
-			},
-			keybinding: {
-				weight: KeybindingWeight.WorkbenchContrib,
-				primary: KeyMod.CtrlCmd | KeyCode.Escape,
 			}
 		});
 	}

--- a/src/vs/workbench/contrib/chat/common/chatModel.ts
+++ b/src/vs/workbench/contrib/chat/common/chatModel.ts
@@ -821,20 +821,7 @@ export class ChatModel extends Disposable implements IChatModel {
 					followups: r.response?.followups,
 					isCanceled: r.response?.isCanceled,
 					vote: r.response?.vote,
-					agent: r.response?.agent ?
-						// May actually be the full IChatAgent instance, just take the data props. slashCommands don't matter here.
-						{
-							id: r.response.agent.id,
-							name: r.response.agent.name,
-							description: r.response.agent.description,
-							extensionId: r.response.agent.extensionId,
-							metadata: r.response.agent.metadata,
-							slashCommands: [],
-							locations: r.response.agent.locations,
-							isDefault: r.response.agent.isDefault,
-							extensionPublisher: r.response.agent.extensionPublisher
-						}
-						: undefined,
+					agent: r.response?.agent,
 					slashCommand: r.response?.slashCommand,
 					usedContext: r.response?.usedContext,
 					contentReferences: r.response?.contentReferences

--- a/src/vs/workbench/contrib/chat/common/chatParserTypes.ts
+++ b/src/vs/workbench/contrib/chat/common/chatParserTypes.ts
@@ -81,23 +81,6 @@ export class ChatRequestAgentPart implements IParsedChatRequestPart {
 	get promptText(): string {
 		return '';
 	}
-
-	/**
-	 * Don't stringify all the agent methods, just data.
-	 */
-	toJSON(): any {
-		return {
-			kind: this.kind,
-			range: this.range,
-			editorRange: this.editorRange,
-			agent: {
-				id: this.agent.id,
-				name: this.agent.name,
-				description: this.agent.description,
-				metadata: this.agent.metadata
-			}
-		};
-	}
 }
 
 /**

--- a/src/vs/workbench/contrib/chat/test/common/__snapshots__/ChatService_can_deserialize.0.snap
+++ b/src/vs/workbench/contrib/chat/test/common/__snapshots__/ChatService_can_deserialize.0.snap
@@ -11,7 +11,6 @@
         text: "@ChatProviderWithUsedContext test request",
         parts: [
           {
-            kind: "agent",
             range: {
               start: 0,
               endExclusive: 28
@@ -23,11 +22,18 @@
               endColumn: 29
             },
             agent: {
-              id: "ChatProviderWithUsedContext",
               name: "ChatProviderWithUsedContext",
-              description: undefined,
-              metadata: {  }
-            }
+              id: "ChatProviderWithUsedContext",
+              extensionId: {
+                value: "nullExtensionDescription",
+                _lower: "nullextensiondescription"
+              },
+              extensionPublisher: "",
+              locations: [ "panel" ],
+              metadata: {  },
+              slashCommands: [  ]
+            },
+            kind: "agent"
           },
           {
             range: {
@@ -52,18 +58,16 @@
       isCanceled: false,
       vote: undefined,
       agent: {
-        id: "ChatProviderWithUsedContext",
         name: "ChatProviderWithUsedContext",
-        description: undefined,
+        id: "ChatProviderWithUsedContext",
         extensionId: {
           value: "nullExtensionDescription",
           _lower: "nullextensiondescription"
         },
-        metadata: {  },
-        slashCommands: [  ],
+        extensionPublisher: "",
         locations: [ "panel" ],
-        isDefault: undefined,
-        extensionPublisher: ""
+        metadata: {  },
+        slashCommands: [  ]
       },
       slashCommand: undefined,
       usedContext: {

--- a/src/vs/workbench/contrib/chat/test/common/__snapshots__/ChatService_can_serialize.1.snap
+++ b/src/vs/workbench/contrib/chat/test/common/__snapshots__/ChatService_can_serialize.1.snap
@@ -10,7 +10,6 @@
       message: {
         parts: [
           {
-            kind: "agent",
             range: {
               start: 0,
               endExclusive: 28
@@ -22,14 +21,21 @@
               endColumn: 29
             },
             agent: {
-              id: "ChatProviderWithUsedContext",
               name: "ChatProviderWithUsedContext",
-              description: undefined,
+              id: "ChatProviderWithUsedContext",
+              extensionId: {
+                value: "nullExtensionDescription",
+                _lower: "nullextensiondescription"
+              },
+              extensionPublisher: "",
+              locations: [ "panel" ],
               metadata: {
                 requester: { name: "test" },
                 fullName: "test"
-              }
-            }
+              },
+              slashCommands: [  ]
+            },
+            kind: "agent"
           },
           {
             range: {
@@ -55,21 +61,19 @@
       isCanceled: false,
       vote: undefined,
       agent: {
-        id: "ChatProviderWithUsedContext",
         name: "ChatProviderWithUsedContext",
-        description: undefined,
+        id: "ChatProviderWithUsedContext",
         extensionId: {
           value: "nullExtensionDescription",
           _lower: "nullextensiondescription"
         },
+        extensionPublisher: "",
+        locations: [ "panel" ],
         metadata: {
           requester: { name: "test" },
           fullName: "test"
         },
-        slashCommands: [  ],
-        locations: [ "panel" ],
-        isDefault: undefined,
-        extensionPublisher: ""
+        slashCommands: [  ]
       },
       slashCommand: undefined,
       usedContext: {

--- a/src/vs/workbench/contrib/chat/test/common/chatService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/chatService.test.ts
@@ -163,7 +163,7 @@ suite('ChatService', () => {
 
 			await response.responseCompletePromise;
 
-			serializedChatData = chatModel1.toJSON();
+			serializedChatData = JSON.parse(JSON.stringify(chatModel1));
 		}
 
 		// try deserializing the state into a new service


### PR DESCRIPTION
Tried to only store agent ID instead of full agent details in the exported session, but it requires making the ChatModel creation async, or slowing down revealing the persisted chat content, and I don't want to do that.