### PR TITLE
Added mkdir -p /vscode-dev command to Dockerfile to address the "No file or directory" error during Docker build process.

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -7,8 +7,10 @@ RUN git config --system codespaces-theme.hide-status 1
 
 USER node
 RUN npm install -g node-gyp
+
 RUN YARN_CACHE="$(yarn cache dir)" && rm -rf "$YARN_CACHE" && ln -s /vscode-dev/yarn-cache "$YARN_CACHE"
 RUN echo 'export DISPLAY="${DISPLAY:-:1}"' | tee -a ~/.bashrc >> ~/.zshrc
 
 USER root
+RUN mkdir -p /vscode-dev
 CMD chown node:node /vscode-dev && sudo -u node mkdir -p /vscode-dev/yarn-cache && sleep inf


### PR DESCRIPTION
Changes Made:

    Included mkdir -p /vscode-dev command in the Dockerfile.

Details:
Previously, the Docker build process was failing due to the absence of the /vscode-dev directory. This addition ensures that the required directory is created, resolving the error and allowing the build process to complete successfully.