### PR TITLE
fix: terminal suggestions should hide modal when no completions exist

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalSuggestAddon.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalSuggestAddon.ts
@@ -452,7 +452,7 @@ export class SuggestAddon extends Disposable implements ITerminalAddon, ISuggest
 			}
 
 			// Hide and clear model if there are no more items
-			if ((this._suggestWidget as any)._completionModel?.items.length === 0) {
+			if (!this._suggestWidget?.hasCompletions()) {
 				this._additionalInput = undefined;
 				this.hideSuggestWidget();
 				// TODO: Don't request every time; refine completions

--- a/src/vs/workbench/services/suggest/browser/simpleSuggestWidget.ts
+++ b/src/vs/workbench/services/suggest/browser/simpleSuggestWidget.ts
@@ -208,6 +208,10 @@ export class SimpleSuggestWidget implements IDisposable {
 		this._completionModel = completionModel;
 	}
 
+	hasCompletions(): boolean {
+		return this._completionModel?.items.length !== 0;
+	}
+
 	showSuggestions(selectionIndex: number, isFrozen: boolean, isAuto: boolean, cursorPosition: { top: number; left: number; height: number }): void {
 		this._cursorPosition = cursorPosition;
 


### PR DESCRIPTION
Fixes an issue similar to #208822 where the `any` access of the private variables don't work once bundled for insiders. It causes the empty modal to hang instead of hiding.


### Currently in Insiders
https://github.com/microsoft/vscode/assets/35637443/be0b5010-0260-4c26-9268-29e17fb160e9

Part of #154662