### PR TITLE
Fix color picker command title

### DIFF
--- a/src/vs/editor/contrib/colorPicker/browser/standaloneColorPickerActions.ts
+++ b/src/vs/editor/contrib/colorPicker/browser/standaloneColorPickerActions.ts
@@ -18,13 +18,16 @@ export class ShowOrFocusStandaloneColorPicker extends EditorAction2 {
 		super({
 			id: 'editor.action.showOrFocusStandaloneColorPicker',
 			title: {
-				...localize2('showOrFocusStandaloneColorPicker', "Show or focus a standalone color picker which uses the default color provider. It displays hex/rgb/hsl colors."),
+				...localize2('showOrFocusStandaloneColorPicker', "Show or Focus Standalone Color Picker"),
 				mnemonicTitle: localize({ key: 'mishowOrFocusStandaloneColorPicker', comment: ['&& denotes a mnemonic'] }, "&&Show or Focus Standalone Color Picker"),
 			},
 			precondition: undefined,
 			menu: [
 				{ id: MenuId.CommandPalette },
-			]
+			],
+			metadata: {
+				description: localize2('showOrFocusStandaloneColorPickerDescription', "Show or focus a standalone color picker which uses the default color provider. It displays hex/rgb/hsl colors."),
+			}
 		});
 	}
 	runEditorCommand(_accessor: ServicesAccessor, editor: ICodeEditor) {


### PR DESCRIPTION
#209612 incorrectly changed the title to a description rather than adding a description.

<img width="579" alt="image" src="https://github.com/microsoft/vscode/assets/191085/a024e3ec-5335-4012-86f8-7e6a15d0f272">

Move the description to the description and revert the editor title to what it was previously.