### PR TITLE
Move cmd start escape to end of prompt

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/media/fish_xdg_data/fish/vendor_conf.d/shellIntegration.fish
+++ b/src/vs/workbench/contrib/terminal/browser/media/fish_xdg_data/fish/vendor_conf.d/shellIntegration.fish
@@ -173,11 +173,11 @@ function __init_vscode_shell_integration
 		function fish_mode_prompt
 			__vsc_fish_prompt_start
 			__vsc_fish_mode_prompt
-			__vsc_fish_cmd_start
 		end
 
 		function fish_prompt
 			__vsc_fish_prompt
+			__vsc_fish_cmd_start
 		end
 	else
 		# No fish_mode_prompt, so put everything in fish_prompt.


### PR DESCRIPTION
#185907 moves the cmd start escape to the end of the mode prompt, but since the mode prompt ‘appears to the left of the regular prompt’ that seems too early: declaring that the start of the cmd causes the rest of the prompt to be part of the command in the recent commands list.

<img width="1630" alt="Screenshot 2024-04-16 at 8 24 56 AM" src="https://github.com/microsoft/vscode/assets/191085/c9b3b896-1fc2-4403-8899-6896f642055d">

Moves `__vsc_fish_cmd_start` to the end of `fish_prompt` so the prompt is not part of the command. Tested that the prompt no longer appears in the recent commands and running the command from the recent list no longer tries to execute the prompt as the command.