### PR TITLE
Move hover action ids into a separate file

### DIFF
--- a/src/vs/editor/contrib/hover/browser/hoverActionIds.ts
+++ b/src/vs/editor/contrib/hover/browser/hoverActionIds.ts
@@ -1,0 +1,15 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+export const SHOW_OR_FOCUS_HOVER_ACTION_ID = 'editor.action.showHover';
+export const SHOW_DEFINITION_PREVIEW_HOVER_ACTION_ID = 'editor.action.showDefinitionPreviewHover';
+export const SCROLL_UP_HOVER_ACTION_ID = 'editor.action.scrollUpHover';
+export const SCROLL_DOWN_HOVER_ACTION_ID = 'editor.action.scrollDownHover';
+export const SCROLL_LEFT_HOVER_ACTION_ID = 'editor.action.scrollLeftHover';
+export const SCROLL_RIGHT_HOVER_ACTION_ID = 'editor.action.scrollRightHover';
+export const PAGE_UP_HOVER_ACTION_ID = 'editor.action.pageUpHover';
+export const PAGE_DOWN_HOVER_ACTION_ID = 'editor.action.pageDownHover';
+export const GO_TO_TOP_HOVER_ACTION_ID = 'editor.action.goToTopHover';
+export const GO_TO_BOTTOM_HOVER_ACTION_ID = 'editor.action.goToBottomHover';

--- a/src/vs/editor/contrib/hover/browser/hoverActions.ts
+++ b/src/vs/editor/contrib/hover/browser/hoverActions.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { GO_TO_BOTTOM_HOVER_ACTION_ID, GO_TO_TOP_HOVER_ACTION_ID, PAGE_DOWN_HOVER_ACTION_ID, PAGE_UP_HOVER_ACTION_ID, SCROLL_DOWN_HOVER_ACTION_ID, SCROLL_LEFT_HOVER_ACTION_ID, SCROLL_RIGHT_HOVER_ACTION_ID, SCROLL_UP_HOVER_ACTION_ID, SHOW_DEFINITION_PREVIEW_HOVER_ACTION_ID, SHOW_OR_FOCUS_HOVER_ACTION_ID } from 'vs/editor/contrib/hover/browser/hoverActionIds';
 import { KeyChord, KeyCode, KeyMod } from 'vs/base/common/keyCodes';
 import { ICodeEditor } from 'vs/editor/browser/editorBrowser';
 import { EditorAction, ServicesAccessor } from 'vs/editor/browser/editorExtensions';
@@ -27,7 +28,7 @@ export class ShowOrFocusHoverAction extends EditorAction {
 
 	constructor() {
 		super({
-			id: 'editor.action.showHover',
+			id: SHOW_OR_FOCUS_HOVER_ACTION_ID,
 			label: nls.localize({
 				key: 'showOrFocusHover',
 				comment: [
@@ -109,7 +110,7 @@ export class ShowDefinitionPreviewHoverAction extends EditorAction {
 
 	constructor() {
 		super({
-			id: 'editor.action.showDefinitionPreviewHover',
+			id: SHOW_DEFINITION_PREVIEW_HOVER_ACTION_ID,
 			label: nls.localize({
 				key: 'showDefinitionPreviewHover',
 				comment: [
@@ -153,7 +154,7 @@ export class ScrollUpHoverAction extends EditorAction {
 
 	constructor() {
 		super({
-			id: 'editor.action.scrollUpHover',
+			id: SCROLL_UP_HOVER_ACTION_ID,
 			label: nls.localize({
 				key: 'scrollUpHover',
 				comment: [
@@ -186,7 +187,7 @@ export class ScrollDownHoverAction extends EditorAction {
 
 	constructor() {
 		super({
-			id: 'editor.action.scrollDownHover',
+			id: SCROLL_DOWN_HOVER_ACTION_ID,
 			label: nls.localize({
 				key: 'scrollDownHover',
 				comment: [
@@ -219,7 +220,7 @@ export class ScrollLeftHoverAction extends EditorAction {
 
 	constructor() {
 		super({
-			id: 'editor.action.scrollLeftHover',
+			id: SCROLL_LEFT_HOVER_ACTION_ID,
 			label: nls.localize({
 				key: 'scrollLeftHover',
 				comment: [
@@ -252,7 +253,7 @@ export class ScrollRightHoverAction extends EditorAction {
 
 	constructor() {
 		super({
-			id: 'editor.action.scrollRightHover',
+			id: SCROLL_RIGHT_HOVER_ACTION_ID,
 			label: nls.localize({
 				key: 'scrollRightHover',
 				comment: [
@@ -285,7 +286,7 @@ export class PageUpHoverAction extends EditorAction {
 
 	constructor() {
 		super({
-			id: 'editor.action.pageUpHover',
+			id: PAGE_UP_HOVER_ACTION_ID,
 			label: nls.localize({
 				key: 'pageUpHover',
 				comment: [
@@ -319,7 +320,7 @@ export class PageDownHoverAction extends EditorAction {
 
 	constructor() {
 		super({
-			id: 'editor.action.pageDownHover',
+			id: PAGE_DOWN_HOVER_ACTION_ID,
 			label: nls.localize({
 				key: 'pageDownHover',
 				comment: [
@@ -353,7 +354,7 @@ export class GoToTopHoverAction extends EditorAction {
 
 	constructor() {
 		super({
-			id: 'editor.action.goToTopHover',
+			id: GO_TO_TOP_HOVER_ACTION_ID,
 			label: nls.localize({
 				key: 'goToTopHover',
 				comment: [
@@ -388,7 +389,7 @@ export class GoToBottomHoverAction extends EditorAction {
 
 	constructor() {
 		super({
-			id: 'editor.action.goToBottomHover',
+			id: GO_TO_BOTTOM_HOVER_ACTION_ID,
 			label: nls.localize({
 				key: 'goToBottomHover',
 				comment: [

--- a/src/vs/editor/contrib/hover/browser/hoverController.ts
+++ b/src/vs/editor/contrib/hover/browser/hoverController.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { SHOW_OR_FOCUS_HOVER_ACTION_ID } from 'vs/editor/contrib/hover/browser/hoverActionIds';
 import { IKeyboardEvent } from 'vs/base/browser/keyboardEvent';
 import { KeyCode } from 'vs/base/common/keyCodes';
 import { Disposable, DisposableStore } from 'vs/base/common/lifecycle';
@@ -332,7 +333,7 @@ export class HoverController extends Disposable implements IEditorContribution {
 		const mightTriggerFocus = (
 			resolvedKeyboardEvent.kind === ResultKind.MoreChordsNeeded ||
 			(resolvedKeyboardEvent.kind === ResultKind.KbFound
-				&& resolvedKeyboardEvent.commandId === 'editor.action.showHover'
+				&& resolvedKeyboardEvent.commandId === SHOW_OR_FOCUS_HOVER_ACTION_ID
 				&& this._contentWidget?.isVisible
 			)
 		);


### PR DESCRIPTION
This pull request moves the hover action ids into a separate file for better organization and maintainability. The hover action ids are now defined in the file `hoverActionIds.ts`.