### PR TITLE
Allow running behind proxy

### DIFF
--- a/src/vs/server/node/remoteExtensionHostAgentServer.ts
+++ b/src/vs/server/node/remoteExtensionHostAgentServer.ts
@@ -69,6 +69,7 @@ class RemoteExtensionHostAgentServer extends Disposable implements IServerAPI {
 	private readonly _webClientServer: WebClientServer | null;
 	private readonly _webEndpointOriginChecker = WebEndpointOriginChecker.create(this._productService);
 
+	private readonly _serverBasePath: string | undefined;
 	private readonly _serverRootPath: string;
 
 	private shutdownTimer: NodeJS.Timeout | undefined;
@@ -86,7 +87,12 @@ class RemoteExtensionHostAgentServer extends Disposable implements IServerAPI {
 	) {
 		super();
 
-		this._serverRootPath = getServerRootPath(_productService, serverBasePath);
+		if (serverBasePath !== undefined && serverBasePath.charCodeAt(serverBasePath.length - 1) === CharCode.Slash) {
+			// Remove trailing slash from base path
+			serverBasePath = serverBasePath.substring(0, serverBasePath.length - 1);
+		}
+		this._serverBasePath = serverBasePath;
+		this._serverRootPath = getServerRootPath(_productService, undefined); // handle base path explicitly
 		this._extHostConnections = Object.create(null);
 		this._managementConnections = Object.create(null);
 		this._allReconnectionTokens = new Set<string>();
@@ -117,6 +123,12 @@ class RemoteExtensionHostAgentServer extends Disposable implements IServerAPI {
 			return serveError(req, res, 400, `Bad request.`);
 		}
 
+		// Serve from both '/' and serverBasePath
+		if (this._serverBasePath !== undefined && pathname.startsWith(this._serverBasePath)) {
+			pathname = pathname.substring(this._serverBasePath.length) || '/';
+			// from now on treat parsedUrl as if it was without serverBasePath
+			parsedUrl.pathname = pathname;
+		}
 		// for now accept all paths, with or without server root path
 		if (pathname.startsWith(this._serverRootPath) && pathname.charCodeAt(this._serverRootPath.length) === CharCode.Slash) {
 			pathname = pathname.substring(this._serverRootPath.length);

--- a/src/vs/server/node/webClientServer.ts
+++ b/src/vs/server/node/webClientServer.ts
@@ -277,14 +277,27 @@ export class WebClientServer {
 			return Array.isArray(val) ? val[0] : val;
 		};
 
+		const replacePort = (host: string, port: string) => {
+			const index = host?.indexOf(':');
+			if (index !== -1) {
+				host = host?.substring(0, index);
+			}
+			host += `:${port}`;
+			return host;
+		};
+
 		const useTestResolver = (!this._environmentService.isBuilt && this._environmentService.args['use-test-resolver']);
-		const remoteAuthority = (
+		let remoteAuthority = (
 			useTestResolver
 				? 'test+test'
 				: (getFirstHeader('x-original-host') || getFirstHeader('x-forwarded-host') || req.headers.host)
 		);
 		if (!remoteAuthority) {
 			return serveError(req, res, 400, `Bad request.`);
+		}
+		const forwardedPort = getFirstHeader('x-forwarded-port');
+		if (forwardedPort) {
+			remoteAuthority = replacePort(remoteAuthority, forwardedPort);
 		}
 
 		function asJSON(value: unknown): string {

--- a/src/vs/server/node/webClientServer.ts
+++ b/src/vs/server/node/webClientServer.ts
@@ -299,9 +299,10 @@ export class WebClientServer {
 		}
 
 		// Prefix routes with basePath for clients
-		const staticRoute = posix.join(this._basePath, this._staticRoute);
-		const callbackRoute = posix.join(this._basePath, this._callbackRoute);
-		const webExtensionRoute = posix.join(this._basePath, this._webExtensionRoute);
+		const basePath = getFirstHeader('x-forwarded-prefix') || this._basePath;
+		const staticRoute = posix.join(basePath, this._staticRoute);
+		const callbackRoute = posix.join(basePath, this._callbackRoute);
+		const webExtensionRoute = posix.join(basePath, this._webExtensionRoute);
 
 		const resolveWorkspaceURI = (defaultLocation?: string) => defaultLocation && URI.file(path.resolve(defaultLocation)).with({ scheme: Schemas.vscodeRemote, authority: remoteAuthority });
 
@@ -334,7 +335,7 @@ export class WebClientServer {
 
 		const workbenchWebConfiguration = {
 			remoteAuthority,
-			serverBasePath: this._basePath,
+			serverBasePath: basePath,
 			_wrapWebWorkerExtHostInIframe,
 			developmentOptions: { enableSmokeTestDriver: this._environmentService.args['enable-smoke-test-driver'] ? true : undefined, logLevel: this._logService.getLevel() },
 			settingsSyncOptions: !this._environmentService.isBuilt && this._environmentService.args['enable-sync'] ? { enabled: true } : undefined,


### PR DESCRIPTION
See #210399 for the motivation.

Commits:
- Serve from `/` and basePath
- Honor `X-Forwarded-Prefix` header
- Honor `X-Forwarded-Port` header

Test procedure:
- Compile via `yarn compile`
- Run `scripts/code-server.sh`
- Run an nginx proxy with the following config:
    ```nginx
    server {
        listen 8080;
        listen [::]:8080;
    
        location /some/path/ {
            proxy_pass http://localhost:9888/;
            proxy_set_header Host $host;
            proxy_set_header Upgrade $http_upgrade;
            proxy_set_header Connection $http_connection;
            proxy_set_header X-Forwarded-Host $host;
            proxy_set_header X-Forwarded-Port $server_port;
            proxy_set_header X-Forwarded-Prefix "/some/path";
        }
    }
    ```
- Access VSCode on http://localhost:8080/some/path

Fixes #210399, #225706