### PR TITLE
Fixes #209614

### DIFF
--- a/src/vs/editor/browser/widget/codeEditor/editor.css
+++ b/src/vs/editor/browser/widget/codeEditor/editor.css
@@ -61,10 +61,6 @@
 	width: 100%;
 }
 
-.monaco-editor .view-overlays > div > div, .monaco-editor .margin-view-overlays > div > div {
-	bottom: 0;
-}
-
 /*
 .monaco-editor .auto-closed-character {
 	opacity: 0.3;


### PR DESCRIPTION
Fixes #209614
don't set bottom 0 for overlays, as height 100% already aligns the bottom, but takes care of borders.