### PR TITLE
disable corepack auto pin feature when executing npm view

### DIFF
--- a/extensions/npm/src/features/packageJSONContribution.ts
+++ b/extensions/npm/src/features/packageJSONContribution.ts
@@ -287,7 +287,11 @@ export class PackageJSONContribution implements IJSONContribution {
 		return new Promise((resolve, _reject) => {
 			const args = ['view', '--json', '--', pack, 'description', 'dist-tags.latest', 'homepage', 'version', 'time'];
 			const cwd = resource && resource.scheme === 'file' ? dirname(resource.fsPath) : undefined;
-			cp.execFile(npmCommandPath, args, { cwd }, (error, stdout) => {
+
+			// corepack npm wrapper would automatically update package.json, which is surprising.
+			// disable that behavior.
+			const env = { COREPACK_ENABLE_AUTO_PIN: "0" };
+			cp.execFile(npmCommandPath, args, { cwd, env }, (error, stdout) => {
 				if (!error) {
 					try {
 						const content = JSON.parse(stdout);

--- a/extensions/npm/src/features/packageJSONContribution.ts
+++ b/extensions/npm/src/features/packageJSONContribution.ts
@@ -290,7 +290,10 @@ export class PackageJSONContribution implements IJSONContribution {
 
 			// corepack npm wrapper would automatically update package.json, which is surprising.
 			// disable that behavior.
-			const env = { COREPACK_ENABLE_AUTO_PIN: "0" };
+			// COREPACK_ENABLE_AUTO_PIN disables the package.json overwrite, and
+			// COREPACK_ENABLE_PROJECT_SPEC makes the npm view command succeed even if packageManager specified
+			//  a package manager other than npm.
+			const env = { COREPACK_ENABLE_AUTO_PIN: "0", COREPACK_ENABLE_PROJECT_SPEC: "0" };
 			cp.execFile(npmCommandPath, args, { cwd, env }, (error, stdout) => {
 				if (!error) {
 					try {

--- a/extensions/npm/src/features/packageJSONContribution.ts
+++ b/extensions/npm/src/features/packageJSONContribution.ts
@@ -288,11 +288,10 @@ export class PackageJSONContribution implements IJSONContribution {
 			const args = ['view', '--json', '--', pack, 'description', 'dist-tags.latest', 'homepage', 'version', 'time'];
 			const cwd = resource && resource.scheme === 'file' ? dirname(resource.fsPath) : undefined;
 
-			// corepack npm wrapper would automatically update package.json, which is surprising.
-			// disable that behavior.
+			// corepack npm wrapper would automatically update package.json. disable that behavior.
 			// COREPACK_ENABLE_AUTO_PIN disables the package.json overwrite, and
-			// COREPACK_ENABLE_PROJECT_SPEC makes the npm view command succeed even if packageManager specified
-			//  a package manager other than npm.
+			// COREPACK_ENABLE_PROJECT_SPEC makes the npm view command succeed
+			//   even if packageManager specified a package manager other than npm.
 			const env = { COREPACK_ENABLE_AUTO_PIN: "0", COREPACK_ENABLE_PROJECT_SPEC: "0" };
 			cp.execFile(npmCommandPath, args, { cwd, env }, (error, stdout) => {
 				if (!error) {


### PR DESCRIPTION
fixes #210556
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

the bundled plugin "npm" attempts to fetch the package versions with command "npm view --json" each time a user hovers on a package in package.json.

https://github.com/microsoft/vscode/blob/main/extensions/npm/src/features/packageJSONContribution.ts#L286-L290

however with a corepack installation (e.g. brew install corepack), the default behavior of the wrapped npm binary would try to pin the current package manager version to the package.json of the current project.

It's surprising behavior, since the action is triggered by vscode, and no obvious way to find out what's behind the vscode action, disabling the feature entirely would be reasonable since npm extension only wants the package information