### PR TITLE
Update menu selected state colors

### DIFF
--- a/extensions/theme-defaults/themes/dark_modern.json
+++ b/extensions/theme-defaults/themes/dark_modern.json
@@ -54,6 +54,7 @@
 		"inputOption.activeBorder": "#2488DB",
 		"keybindingLabel.foreground": "#CCCCCC",
 		"menu.background": "#1F1F1F",
+		"menu.selectionBackground": "#0078d4",
 		"notificationCenterHeader.background": "#1F1F1F",
 		"notificationCenterHeader.foreground": "#CCCCCC",
 		"notifications.background": "#1F1F1F",

--- a/extensions/theme-defaults/themes/light_modern.json
+++ b/extensions/theme-defaults/themes/light_modern.json
@@ -62,6 +62,8 @@
 		"list.hoverBackground": "#F2F2F2",
 		"list.focusAndSelectionOutline": "#005FB8",
 		"menu.border": "#CECECE",
+		"menu.selectionBackground": "#005FB8",
+		"menu.selectionForeground": "#ffffff",
 		"notebook.cellBorderColor": "#E5E5E5",
 		"notebook.selectedCellBackground": "#C8DDF150",
 		"notificationCenterHeader.background": "#FFFFFF",


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/203400

This change updates the selected background/foreground colors for custom menus in Dark Modern and Light Modern themes to ensure 3:1 contrast ratio with the menu background. Other lists, such as the command palette and explorer, don't have this same problem since their selected/focus state uses a border or icon to distinguish between the resting and selected state.

Note that menus use the same colors for hover and focused states, similar to macOS. Ideally we could decouple those in the future so that we could share hover styles across the basic list component and menus. For now, using the same color as `buttonBackground` yields 3:1 contrast with the background and >4.5:1 with the foreground text.

![CleanShot 2024-04-17 at 15 19 28@2x](https://github.com/microsoft/vscode/assets/25163139/38ba9286-5a1f-412b-897c-3ab231c1714c)
![CleanShot 2024-04-17 at 15 19 41@2x](https://github.com/microsoft/vscode/assets/25163139/15a6dfb1-b338-4834-99be-65079ab16b81)

## Other lists

![CleanShot 2024-04-17 at 15 24 12@2x](https://github.com/microsoft/vscode/assets/25163139/f766f374-1dc8-4906-b22d-ab1492d4b0c8)

![CleanShot 2024-04-17 at 15 24 23@2x](https://github.com/microsoft/vscode/assets/25163139/2665f138-57cf-4dae-bfcf-e04adab5be69)

