### PR TITLE
Introduce PromptInputModel that gives a more reliable and testable view of the current command line

### DIFF
--- a/src/vs/platform/terminal/common/capabilities/capabilities.ts
+++ b/src/vs/platform/terminal/common/capabilities/capabilities.ts
@@ -5,6 +5,7 @@
 
 import { Event } from 'vs/base/common/event';
 import { IDisposable } from 'vs/base/common/lifecycle';
+import type { IPromptInputModel } from 'vs/platform/terminal/common/capabilities/commandDetection/promptInputModel';
 import { ICurrentPartialCommand } from 'vs/platform/terminal/common/capabilities/commandDetection/terminalCommand';
 import { ITerminalOutputMatch, ITerminalOutputMatcher } from 'vs/platform/terminal/common/terminal';
 import { ReplayEntry } from 'vs/platform/terminal/common/terminalProcess';
@@ -161,6 +162,7 @@ export interface IBufferMarkCapability {
 
 export interface ICommandDetectionCapability {
 	readonly type: TerminalCapability.CommandDetection;
+	readonly promptInputModel: IPromptInputModel;
 	readonly commands: readonly ITerminalCommand[];
 	/** The command currently being executed, otherwise undefined. */
 	readonly executingCommand: string | undefined;

--- a/src/vs/platform/terminal/common/capabilities/capabilities.ts
+++ b/src/vs/platform/terminal/common/capabilities/capabilities.ts
@@ -178,6 +178,7 @@ export interface ICommandDetectionCapability {
 	readonly onCommandExecuted: Event<ITerminalCommand>;
 	readonly onCommandInvalidated: Event<ITerminalCommand[]>;
 	readonly onCurrentCommandInvalidated: Event<ICommandInvalidationRequest>;
+	setContinuationPrompt(value: string): void;
 	setCwd(value: string): void;
 	setIsWindowsPty(value: boolean): void;
 	setIsCommandStorageDisabled(): void;

--- a/src/vs/platform/terminal/common/capabilities/commandDetection/promptInputModel.ts
+++ b/src/vs/platform/terminal/common/capabilities/commandDetection/promptInputModel.ts
@@ -113,13 +113,14 @@ export class PromptInputModel extends Disposable implements IPromptInputModel {
 			return;
 		}
 
+		// Command start line
 		this._value = commandLine.substring(this._commandStartX);
 		this._cursorIndex = Math.max(buffer.cursorX - this._commandStartX, 0);
 
 		// IDEA: Reinforce knowledge of prompt to avoid incorrect commandStart
 		// IDEA: Detect ghost text based on SGR and cursor
 
-		// Add multi-lines
+		// From command start line to cursor line
 		const absoluteCursorY = buffer.baseY + buffer.cursorY;
 		for (let y = commandStartY + 1; y <= absoluteCursorY; y++) {
 			let lineText = buffer.getLine(y)?.translateToString(true);
@@ -140,13 +141,15 @@ export class PromptInputModel extends Disposable implements IPromptInputModel {
 			}
 		}
 
-		// Check lines below the cursor for continuations
+		// Below cursor line
 		for (let y = absoluteCursorY + 1; y < buffer.baseY + this._xterm.rows; y++) {
 			const lineText = buffer.getLine(y)?.translateToString(true);
-			if (lineText && this._lineContainsContinuationPrompt(lineText)) {
-				this._value += `\n${this._trimContinuationPrompt(lineText)}`;
-			} else {
-				break;
+			if (lineText) {
+				if (this._continuationPrompt === undefined || this._lineContainsContinuationPrompt(lineText)) {
+					this._value += `\n${this._trimContinuationPrompt(lineText)}`;
+				} else {
+					break;
+				}
 			}
 		}
 

--- a/src/vs/platform/terminal/common/capabilities/commandDetection/promptInputModel.ts
+++ b/src/vs/platform/terminal/common/capabilities/commandDetection/promptInputModel.ts
@@ -1,0 +1,136 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Emitter, type Event } from 'vs/base/common/event';
+import { Disposable } from 'vs/base/common/lifecycle';
+import { ILogService, LogLevel } from 'vs/platform/log/common/log';
+import type { ITerminalCommand } from 'vs/platform/terminal/common/capabilities/capabilities';
+
+// Importing types is safe in any layer
+// eslint-disable-next-line local/code-import-patterns
+import type { Terminal, IMarker } from '@xterm/headless';
+import { debounce } from 'vs/base/common/decorators';
+
+const enum PromptInputState {
+	Unknown,
+	Input,
+	Execute,
+}
+
+export interface IPromptInputModel {
+	readonly onDidStartInput: Event<void>;
+	readonly onDidChangeInput: Event<void>;
+	readonly onDidFinishInput: Event<void>;
+
+	readonly value: string;
+	readonly cursorIndex: number;
+}
+
+export class PromptInputModel extends Disposable implements IPromptInputModel {
+	private _state: PromptInputState = PromptInputState.Unknown;
+
+	private _commandStartMarker: IMarker | undefined;
+	private _commandStartX: number = 0;
+
+	private _value: string = '';
+	get value() { return this._value; }
+
+	private _cursorIndex: number = 0;
+	get cursorIndex() { return this._cursorIndex; }
+
+	private readonly _onDidStartInput = this._register(new Emitter<void>());
+	readonly onDidStartInput = this._onDidStartInput.event;
+	private readonly _onDidChangeInput = this._register(new Emitter<void>());
+	readonly onDidChangeInput = this._onDidChangeInput.event;
+	private readonly _onDidFinishInput = this._register(new Emitter<void>());
+	readonly onDidFinishInput = this._onDidFinishInput.event;
+
+	constructor(
+		private readonly _xterm: Terminal,
+		onCommandStart: Event<ITerminalCommand>,
+		onCommandExecuted: Event<ITerminalCommand>,
+		private readonly _logService: ILogService
+	) {
+		super();
+
+		this._register(this._xterm.onData(e => this._handleInput(e)));
+		this._register(this._xterm.onCursorMove(() => this._sync()));
+		// TODO: Listen to the xterm textarea focus event?
+
+		this._register(onCommandStart(e => this._handleCommandStart(e as { marker: IMarker })));
+		this._register(onCommandExecuted(() => this._handleCommandExecuted()));
+
+	}
+
+	private _handleCommandStart(command: { marker: IMarker }) {
+		if (this._state === PromptInputState.Input) {
+			return;
+		}
+
+		this._state = PromptInputState.Input;
+		this._commandStartMarker = command.marker;
+		this._commandStartX = this._xterm.buffer.active.cursorX;
+		console.log('commandStart', command.marker.line, this._commandStartX);
+		this._onDidStartInput.fire();
+	}
+
+	private _handleCommandExecuted() {
+		if (this._state === PromptInputState.Execute) {
+			return;
+		}
+
+		this._state = PromptInputState.Execute;
+		this._onDidFinishInput.fire();
+	}
+
+	private _handleInput(data: string) {
+		this._logService.trace(`PromptInputModel#_handleInput data=${data}`);
+		this._sync();
+	}
+
+	@debounce(50)
+	private _sync() {
+		if (this._state !== PromptInputState.Input) {
+			return;
+		}
+
+		const commandStartY = this._commandStartMarker?.line;
+		if (!commandStartY) {
+			return;
+		}
+
+		const buffer = this._xterm.buffer.active;
+		const commandLine = buffer.getLine(commandStartY)?.translateToString(true);
+		if (!commandLine) {
+			this._logService.trace(`PromptInputModel#_sync: no line`);
+			return;
+		}
+
+		// TODO: Support multi-line prompts
+
+		this._value = commandLine.substring(this._commandStartX);
+		this._cursorIndex = Math.max(buffer.cursorX - this._commandStartX, 0);
+
+		// Add multi-lines
+		const absoluteCursorY = buffer.baseY + buffer.cursorY;
+		for (let y = commandStartY + 1; y <= absoluteCursorY; y++) {
+			const text = buffer.getLine(y)?.translateToString(true);
+			if (text) {
+				this._value += `\n${text}`;
+				if (y === absoluteCursorY) {
+					// TODO: Detect continuation
+					// TODO: Wide/emoji length support
+					this._cursorIndex = Math.max(this._value.length - text.length + buffer.cursorX, 0);
+				}
+			}
+		}
+
+		if (this._logService.getLevel() === LogLevel.Trace) {
+			this._logService.trace(`PromptInputModel#_sync: Input="${this._value.substring(0, this._cursorIndex)}|${this.value.substring(this._cursorIndex)}"`);
+		}
+
+		this._onDidChangeInput.fire();
+	}
+}

--- a/src/vs/platform/terminal/common/capabilities/commandDetection/promptInputModel.ts
+++ b/src/vs/platform/terminal/common/capabilities/commandDetection/promptInputModel.ts
@@ -52,20 +52,18 @@ export class PromptInputModel extends Disposable implements IPromptInputModel {
 		private readonly _xterm: Terminal,
 		onCommandStart: Event<ITerminalCommand>,
 		onCommandExecuted: Event<ITerminalCommand>,
-		private readonly _logService: ILogService
+		@ILogService private readonly _logService: ILogService
 	) {
 		super();
 
 		this._register(this._xterm.onData(e => this._handleInput(e)));
 		this._register(this._xterm.onCursorMove(() => this._sync()));
-		// TODO: Listen to the xterm textarea focus event?
 
 		this._register(onCommandStart(e => this._handleCommandStart(e as { marker: IMarker })));
 		this._register(onCommandExecuted(() => this._handleCommandExecuted()));
 	}
 
 	setContinuationPrompt(value: string): void {
-		console.log('setContinuationPrompt', value);
 		this._continuationPrompt = value;
 	}
 
@@ -77,7 +75,6 @@ export class PromptInputModel extends Disposable implements IPromptInputModel {
 		this._state = PromptInputState.Input;
 		this._commandStartMarker = command.marker;
 		this._commandStartX = this._xterm.buffer.active.cursorX;
-		console.log('commandStart', command.marker.line, this._commandStartX);
 		this._onDidStartInput.fire();
 	}
 
@@ -91,7 +88,6 @@ export class PromptInputModel extends Disposable implements IPromptInputModel {
 	}
 
 	private _handleInput(data: string) {
-		this._logService.trace(`PromptInputModel#_handleInput data=${data}`);
 		this._sync();
 	}
 

--- a/src/vs/platform/terminal/common/capabilities/commandDetection/promptInputModel.ts
+++ b/src/vs/platform/terminal/common/capabilities/commandDetection/promptInputModel.ts
@@ -130,8 +130,20 @@ export class PromptInputModel extends Disposable implements IPromptInputModel {
 					// TODO: Detect continuation
 					//       For pwsh: (Get-PSReadLineOption).ContinuationPrompt
 					// TODO: Wide/emoji length support
-					this._cursorIndex = Math.max(this._value.length - lineText.length + buffer.cursorX, 0);
+					this._cursorIndex = Math.max(this._value.length - lineText.length - (this._continuationPrompt?.length ?? 0) + buffer.cursorX, 0);
 				}
+			}
+		}
+
+		// TODO: Check below the cursor for continuations
+		for (let y = absoluteCursorY + 1; y < buffer.baseY + this._xterm.rows; y++) {
+			let lineText = buffer.getLine(y)?.translateToString(true);
+			if (lineText) {
+				// TODO: Detect line continuation if it's not set
+				if (this._continuationPrompt && lineText.startsWith(this._continuationPrompt)) {
+					lineText = lineText.substring(this._continuationPrompt.length);
+				}
+				this._value += `\n${lineText}`;
 			}
 		}
 

--- a/src/vs/platform/terminal/common/capabilities/commandDetection/promptInputModel.ts
+++ b/src/vs/platform/terminal/common/capabilities/commandDetection/promptInputModel.ts
@@ -112,8 +112,6 @@ export class PromptInputModel extends Disposable implements IPromptInputModel {
 			return;
 		}
 
-		// TODO: Support multi-line prompts
-
 		this._value = commandLine.substring(this._commandStartX);
 		this._cursorIndex = Math.max(buffer.cursorX - this._commandStartX, 0);
 

--- a/src/vs/platform/terminal/common/capabilities/commandDetection/promptInputModel.ts
+++ b/src/vs/platform/terminal/common/capabilities/commandDetection/promptInputModel.ts
@@ -93,6 +93,10 @@ export class PromptInputModel extends Disposable implements IPromptInputModel {
 
 	@debounce(50)
 	private _sync() {
+		this._syncNow();
+	}
+
+	protected _syncNow() {
 		if (this._state !== PromptInputState.Input) {
 			return;
 		}

--- a/src/vs/platform/terminal/common/capabilities/commandDetection/promptInputModel.ts
+++ b/src/vs/platform/terminal/common/capabilities/commandDetection/promptInputModel.ts
@@ -26,8 +26,6 @@ export interface IPromptInputModel {
 
 	readonly value: string;
 	readonly cursorIndex: number;
-
-	setContinuationPrompt(value: string): void;
 }
 
 export class PromptInputModel extends Disposable implements IPromptInputModel {

--- a/src/vs/platform/terminal/common/capabilities/commandDetection/promptInputModel.ts
+++ b/src/vs/platform/terminal/common/capabilities/commandDetection/promptInputModel.ts
@@ -181,7 +181,7 @@ export class PromptInputModel extends Disposable implements IPromptInputModel {
 		if (!this._continuationPrompt || !lineText.startsWith(this._continuationPrompt)) {
 			return 0;
 		}
-		let buffer: string = '';
+		let buffer = '';
 		let x = 0;
 		while (buffer !== this._continuationPrompt) {
 			buffer += line.getCell(x++)!.getChars();

--- a/src/vs/platform/terminal/common/capabilities/commandDetectionCapability.ts
+++ b/src/vs/platform/terminal/common/capabilities/commandDetectionCapability.ts
@@ -199,6 +199,10 @@ export class CommandDetectionCapability extends Disposable implements ICommandDe
 		}
 	}
 
+	setContinuationPrompt(value: string): void {
+		this._promptInputModel.setContinuationPrompt(value);
+	}
+
 	setCwd(value: string) {
 		this._cwd = value;
 	}

--- a/src/vs/platform/terminal/common/capabilities/commandDetectionCapability.ts
+++ b/src/vs/platform/terminal/common/capabilities/commandDetectionCapability.ts
@@ -10,11 +10,12 @@ import { Disposable, MandatoryMutableDisposable, MutableDisposable } from 'vs/ba
 import { ILogService } from 'vs/platform/log/common/log';
 import { CommandInvalidationReason, ICommandDetectionCapability, ICommandInvalidationRequest, IHandleCommandOptions, ISerializedCommandDetectionCapability, ISerializedTerminalCommand, ITerminalCommand, IXtermMarker, TerminalCapability } from 'vs/platform/terminal/common/capabilities/capabilities';
 import { ITerminalOutputMatcher } from 'vs/platform/terminal/common/terminal';
+import { ICurrentPartialCommand, PartialTerminalCommand, TerminalCommand } from 'vs/platform/terminal/common/capabilities/commandDetection/terminalCommand';
+import { PromptInputModel, type IPromptInputModel } from 'vs/platform/terminal/common/capabilities/commandDetection/promptInputModel';
 
 // Importing types is safe in any layer
 // eslint-disable-next-line local/code-import-patterns
 import type { IBuffer, IDisposable, IMarker, Terminal } from '@xterm/headless';
-import { ICurrentPartialCommand, PartialTerminalCommand, TerminalCommand } from 'vs/platform/terminal/common/capabilities/commandDetection/terminalCommand';
 
 interface ITerminalDimensions {
 	cols: number;
@@ -23,6 +24,9 @@ interface ITerminalDimensions {
 
 export class CommandDetectionCapability extends Disposable implements ICommandDetectionCapability {
 	readonly type = TerminalCapability.CommandDetection;
+
+	private readonly _promptInputModel: PromptInputModel;
+	get promptInputModel(): IPromptInputModel { return this._promptInputModel; }
 
 	protected _commands: TerminalCommand[] = [];
 	private _cwd: string | undefined;
@@ -86,6 +90,8 @@ export class CommandDetectionCapability extends Disposable implements ICommandDe
 		@ILogService private readonly _logService: ILogService
 	) {
 		super();
+
+		this._promptInputModel = this._register(new PromptInputModel(this._terminal, this.onCommandStarted, this.onCommandFinished, this._logService));
 
 		// Pull command line from the buffer if it was not set explicitly
 		this._register(this.onCommandExecuted(command => {

--- a/src/vs/platform/terminal/common/xterm/shellIntegrationAddon.ts
+++ b/src/vs/platform/terminal/common/xterm/shellIntegrationAddon.ts
@@ -382,7 +382,12 @@ export class ShellIntegrationAddon extends Disposable implements IShellIntegrati
 				}
 				switch (key) {
 					case 'ContinuationPrompt': {
-						this._updateContinuationPrompt(value);
+						// Exclude escape sequences and values between \[ and \]
+						const sanitizedValue = (value
+							.replace(/\x1b\[[0-9;]*m/g, '')
+							.replace(/\\\[.*?\\\]/g, '')
+						);
+						this._updateContinuationPrompt(sanitizedValue);
 						return true;
 					}
 					case 'Cwd': {
@@ -411,8 +416,10 @@ export class ShellIntegrationAddon extends Disposable implements IShellIntegrati
 	}
 
 	private _updateContinuationPrompt(value: string) {
-		const commandDetection = this.capabilities.get(TerminalCapability.CommandDetection);
-		commandDetection?.setContinuationPrompt(value);
+		if (!this._terminal) {
+			return;
+		}
+		this._createOrGetCommandDetection(this._terminal).setContinuationPrompt(value);
 	}
 
 	private _updateCwd(value: string) {

--- a/src/vs/platform/terminal/common/xterm/shellIntegrationAddon.ts
+++ b/src/vs/platform/terminal/common/xterm/shellIntegrationAddon.ts
@@ -160,6 +160,8 @@ const enum VSCodeOscPt {
 	 * - `IsWindows` - Indicates whether the terminal is using a Windows backend like winpty or
 	 *   conpty. This may be used to enable additional heuristics as the positioning of the shell
 	 *   integration sequences are not guaranteed to be correct. Valid values: `True`, `False`.
+	 * - `ContinuationPrompt` - Reports the continuation prompt that is printed at the start of
+	 *   multi-line inputs.
 	 *
 	 * WARNING: Any other properties may be changed and are not guaranteed to work in the future.
 	 */
@@ -379,6 +381,10 @@ export class ShellIntegrationAddon extends Disposable implements IShellIntegrati
 					return true;
 				}
 				switch (key) {
+					case 'ContinuationPrompt': {
+						this._updateContinuationPrompt(value);
+						return true;
+					}
 					case 'Cwd': {
 						this._updateCwd(value);
 						return true;
@@ -402,6 +408,11 @@ export class ShellIntegrationAddon extends Disposable implements IShellIntegrati
 
 		// Unrecognized sequence
 		return false;
+	}
+
+	private _updateContinuationPrompt(value: string) {
+		const commandDetection = this.capabilities.get(TerminalCapability.CommandDetection);
+		commandDetection?.setContinuationPrompt(value);
 	}
 
 	private _updateCwd(value: string) {

--- a/src/vs/platform/terminal/test/common/capabilities/commandDetection/promptInputModel.test.ts
+++ b/src/vs/platform/terminal/test/common/capabilities/commandDetection/promptInputModel.test.ts
@@ -82,6 +82,84 @@ suite('PromptInputModel', () => {
 				promptInputModel.forceSync();
 				assertPromptInput('foo|');
 			});
+			test('input with accepted and run ghost text', async () => {
+				await replayEvents([
+					'[?25l[2J[m[H]0;C:\Program Files\WindowsApps\Microsoft.PowerShell_7.4.2.0_x64__8wekyb3d8bbwe\pwsh.exe[?25h',
+					'[?25l[K\r\n[K\r\n[K\r\n[K\r\n[K\r\n[K\r\n[K\r\n[K\r\n[K\r\n[K\r\n[K\r\n[K\r\n[K\r\n[K\r\n[K\r\n[K\r\n[K\r\n[K\r\n[K\r\n[K\r\n[K\r\n[K\r\n[K\r\n[K\r\n[K\r\n[K[H[?25h',
+					']633;P;IsWindows=True',
+					']633;P;ContinuationPrompt=\x1b[38\x3b5\x3b8m∙\x1b[0m ',
+					']633;A]633;P;Cwd=C:\x5cGithub\x5cmicrosoft\x5cvscode]633;B',
+					'[34m\r\n[38;2;17;17;17m[44m03:41:36 [34m[41m [38;2;17;17;17mvscode [31m[43m [38;2;17;17;17m tyriar/prompt_input_model [33m[46m [38;2;17;17;17m$ [36m[49m [mvia [32m[1m v18.18.2 \r\n❯[m ',
+				]);
+				promptInputModel.setContinuationPrompt('∙ ');
+				onCommandStart.fire({ marker: xterm.registerMarker() } as ITerminalCommand);
+				promptInputModel.forceSync();
+				assertPromptInput('|');
+
+				await replayEvents([
+					'[?25l[93me[97m[2m[3mcho "hello world"[3;4H[?25h',
+					'[m',
+				]);
+				promptInputModel.forceSync();
+				assertPromptInput('e|cho "hello world"');
+
+				await replayEvents([
+					'[?25l[93mec[97m[2m[3mho "hello world"[3;5H[?25h',
+					'[m',
+				]);
+				promptInputModel.forceSync();
+				assertPromptInput('ec|ho "hello world"');
+
+				await replayEvents([
+					'[?25l[93m[3;3Hech[97m[2m[3mo "hello world"[3;6H[?25h',
+					'[m',
+				]);
+				promptInputModel.forceSync();
+				assertPromptInput('ech|o "hello world"');
+
+				await replayEvents([
+					'[?25l[93m[3;3Hecho[97m[2m[3m "hello world"[3;7H[?25h',
+					'[m',
+				]);
+				promptInputModel.forceSync();
+				assertPromptInput('echo| "hello world"');
+
+				await replayEvents([
+					'[?25l[93m[3;3Hecho [97m[2m[3m"hello world"[3;8H[?25h',
+					'[m',
+				]);
+				promptInputModel.forceSync();
+				assertPromptInput('echo |"hello world"');
+
+				await replayEvents([
+					'[?25l[93m[3;3Hecho [36m"hello world"[?25h',
+					'[m',
+				]);
+				promptInputModel.forceSync();
+				assertPromptInput('echo "hello world"|');
+
+				await replayEvents([
+					']633;E;echo "hello world";ff464d39-bc80-4bae-9ead-b1cafc4adf6f]633;C',
+				]);
+				onCommandExecuted.fire(null!);
+				promptInputModel.forceSync();
+				assertPromptInput('echo "hello world"|');
+
+				await replayEvents([
+					'\r\n',
+					'hello world\r\n',
+				]);
+				promptInputModel.forceSync();
+				assertPromptInput('echo "hello world"|');
+
+				await replayEvents([
+					']633;D;0]633;A]633;P;Cwd=C:\x5cGithub\x5cmicrosoft\x5cvscode]633;B',
+					'[34m\r\n[38;2;17;17;17m[44m03:41:42 [34m[41m [38;2;17;17;17mvscode [31m[43m [38;2;17;17;17m tyriar/prompt_input_model [33m[46m [38;2;17;17;17m$ [36m[49m [mvia [32m[1m v18.18.2 \r\n❯[m ',
+				]);
+				onCommandStart.fire({ marker: xterm.registerMarker() } as ITerminalCommand);
+				promptInputModel.forceSync();
+				assertPromptInput('|');
+			});
 		});
 	});
 });

--- a/src/vs/platform/terminal/test/common/capabilities/commandDetection/promptInputModel.test.ts
+++ b/src/vs/platform/terminal/test/common/capabilities/commandDetection/promptInputModel.test.ts
@@ -4,13 +4,25 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { ensureNoDisposablesAreLeakedInTestSuite } from 'vs/base/test/common/utils';
-import type { PromptInputModel } from 'vs/platform/terminal/common/capabilities/commandDetection/promptInputModel';
+import { NullLogService } from 'vs/platform/log/common/log';
+import { PromptInputModel } from 'vs/platform/terminal/common/capabilities/commandDetection/promptInputModel';
+import { Emitter } from 'vs/base/common/event';
+import type { ITerminalCommand } from 'vs/platform/terminal/common/capabilities/capabilities';
+
+// eslint-disable-next-line local/code-import-patterns, local/code-amd-node-module
+import { Terminal } from '@xterm/headless';
 
 suite('RequestStore', () => {
 	const store = ensureNoDisposablesAreLeakedInTestSuite();
 	let promptInputModel: PromptInputModel;
+	let xterm: Terminal;
+	let onCommandStart: Emitter<ITerminalCommand>;
+	let onCommandExecuted: Emitter<ITerminalCommand>;
 
 	setup(() => {
-
+		xterm = new Terminal();
+		onCommandStart = new Emitter();
+		onCommandExecuted = new Emitter();
+		promptInputModel = store.add(new PromptInputModel(xterm, onCommandStart.event, onCommandExecuted.event, new NullLogService));
 	});
 });

--- a/src/vs/platform/terminal/test/common/capabilities/commandDetection/promptInputModel.test.ts
+++ b/src/vs/platform/terminal/test/common/capabilities/commandDetection/promptInputModel.test.ts
@@ -33,6 +33,11 @@ suite('PromptInputModel', () => {
 		promptInputModel = store.add(new TestPromptInputModel(xterm, onCommandStart.event, onCommandExecuted.event, new NullLogService));
 	});
 
+	// To "record a session" for these tests:
+	// - Enable debug logging
+	// - Open and clear Terminal output channel
+	// - Open terminal and perform the test
+	// - Extract all "parsing data" lines from the terminal
 	suite('recorded sessions', () => {
 		async function replayEvents(events: string[]) {
 			for (const e of events) {

--- a/src/vs/platform/terminal/test/common/capabilities/commandDetection/promptInputModel.test.ts
+++ b/src/vs/platform/terminal/test/common/capabilities/commandDetection/promptInputModel.test.ts
@@ -1,0 +1,15 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { ensureNoDisposablesAreLeakedInTestSuite } from 'vs/base/test/common/utils';
+
+suite('RequestStore', () => {
+	const store = ensureNoDisposablesAreLeakedInTestSuite();
+
+	setup(() => {
+		instantiationService = new TestInstantiationService();
+		instantiationService.stub(ILogService, new LogService(new ConsoleLogger()));
+	});
+});

--- a/src/vs/platform/terminal/test/common/capabilities/commandDetection/promptInputModel.test.ts
+++ b/src/vs/platform/terminal/test/common/capabilities/commandDetection/promptInputModel.test.ts
@@ -115,29 +115,29 @@ suite('PromptInputModel', () => {
 		fireCommandStart();
 		assertPromptInput('|');
 
-		await writePromise('안');
-		assertPromptInput('안|');
+		await writePromise('안영');
+		assertPromptInput('안영|');
 
-		await writePromise('\r\n영');
-		assertPromptInput('안\n영|');
+		await writePromise('\r\n컴퓨터');
+		assertPromptInput('안영\n컴퓨터|');
 
-		await writePromise('\r\n이');
-		assertPromptInput('안\n영\n이|');
+		await writePromise('\r\n사람');
+		assertPromptInput('안영\n컴퓨터\n사람|');
 
 		await writePromise('\x1b[G');
-		assertPromptInput('안\n영\n|이');
+		assertPromptInput('안영\n컴퓨터\n|사람');
 
 		await writePromise('\x1b[A');
-		assertPromptInput('안\n|영\n이');
+		assertPromptInput('안영\n|컴퓨터\n사람');
 
-		await writePromise('\x1b[C');
-		assertPromptInput('안\n영|\n이');
+		await writePromise('\x1b[4C');
+		assertPromptInput('안영\n컴퓨|터\n사람');
 
 		await writePromise('\x1b[1;4H');
-		assertPromptInput('안|\n영\n이');
+		assertPromptInput('안|영\n컴퓨터\n사람');
 
 		await writePromise('\x1b[D');
-		assertPromptInput('|안\n영\n이');
+		assertPromptInput('|안영\n컴퓨터\n사람');
 	});
 
 	test('emoji input', async () => {
@@ -145,29 +145,29 @@ suite('PromptInputModel', () => {
 		fireCommandStart();
 		assertPromptInput('|');
 
-		await writePromise('👋');
-		assertPromptInput('👋|');
+		await writePromise('✌️👍');
+		assertPromptInput('✌️👍|');
 
-		await writePromise('\r\n👍');
-		assertPromptInput('👋\n👍|');
+		await writePromise('\r\n😎😕😅');
+		assertPromptInput('✌️👍\n😎😕😅|');
 
-		await writePromise('\r\n✌️');
-		assertPromptInput('👋\n👍\n✌️|');
+		await writePromise('\r\n🤔🤷😩');
+		assertPromptInput('✌️👍\n😎😕😅\n🤔🤷😩|');
 
 		await writePromise('\x1b[G');
-		assertPromptInput('👋\n👍\n|✌️');
+		assertPromptInput('✌️👍\n😎😕😅\n|🤔🤷😩');
 
 		await writePromise('\x1b[A');
-		assertPromptInput('👋\n|👍\n✌️');
+		assertPromptInput('✌️👍\n|😎😕😅\n🤔🤷😩');
 
-		await writePromise('\x1b[C');
-		assertPromptInput('👋\n👍|\n✌️');
+		await writePromise('\x1b[2C');
+		assertPromptInput('✌️👍\n😎😕|😅\n🤔🤷😩');
 
 		await writePromise('\x1b[1;4H');
-		assertPromptInput('👋|\n👍\n✌️');
+		assertPromptInput('✌️|👍\n😎😕😅\n🤔🤷😩');
 
 		await writePromise('\x1b[D');
-		assertPromptInput('|👋\n👍\n✌️');
+		assertPromptInput('|✌️👍\n😎😕😅\n🤔🤷😩');
 	});
 
 	// To "record a session" for these tests:

--- a/src/vs/platform/terminal/test/common/capabilities/commandDetection/promptInputModel.test.ts
+++ b/src/vs/platform/terminal/test/common/capabilities/commandDetection/promptInputModel.test.ts
@@ -11,18 +11,61 @@ import type { ITerminalCommand } from 'vs/platform/terminal/common/capabilities/
 
 // eslint-disable-next-line local/code-import-patterns, local/code-amd-node-module
 import { Terminal } from '@xterm/headless';
+import { strictEqual } from 'assert';
 
-suite('RequestStore', () => {
+class TestPromptInputModel extends PromptInputModel {
+	forceSync() {
+		this._syncNow();
+	}
+}
+
+suite('PromptInputModel', () => {
 	const store = ensureNoDisposablesAreLeakedInTestSuite();
-	let promptInputModel: PromptInputModel;
+	let promptInputModel: TestPromptInputModel;
 	let xterm: Terminal;
 	let onCommandStart: Emitter<ITerminalCommand>;
 	let onCommandExecuted: Emitter<ITerminalCommand>;
 
 	setup(() => {
-		xterm = new Terminal();
+		xterm = new Terminal({ allowProposedApi: true });
 		onCommandStart = new Emitter();
 		onCommandExecuted = new Emitter();
-		promptInputModel = store.add(new PromptInputModel(xterm, onCommandStart.event, onCommandExecuted.event, new NullLogService));
+		promptInputModel = store.add(new TestPromptInputModel(xterm, onCommandStart.event, onCommandExecuted.event, new NullLogService));
+	});
+
+	suite('recorded sessions', () => {
+		async function replayEvents(events: string[]) {
+			for (const e of events) {
+				await new Promise<void>(r => xterm.write(e, r));
+			}
+		}
+
+		suite('Windows, pwsh 7.4.2, starship prompt', () => {
+			test('input with ignored ghost text', async () => {
+				await replayEvents([
+					'[?25l[2J[m[H]0;C:\Program Files\WindowsApps\Microsoft.PowerShell_7.4.2.0_x64__8wekyb3d8bbwe\pwsh.exe[?25h',
+					'[?25l[K\n\r[K\n\r[K\n\r[K\n\r[K\n\r[K\n\r[K\n\r[K\n\r[K\n\r[K\n\r[K\n\r[K\n\r[K\n\r[K\n\r[K\n\r[K\n\r[K\n\r[K\n\r[K\n\r[K\n\r[K\n\r[K\n\r[K\n\r[K\n\r[K\n\r[K[H[?25h',
+					']633;P;IsWindows=True',
+					']633;P;ContinuationPrompt=\x1b[38\x3b5\x3b8m∙\x1b[0m ',
+					']633;A]633;P;Cwd=C:\x5cGithub\x5cmicrosoft\x5cvscode]633;B',
+					'[34m\n\r[38;2;17;17;17m[44m03:13:47 [34m[41m [38;2;17;17;17mvscode [31m[43m [38;2;17;17;17m tyriar/prompt_input_model [33m[46m [38;2;17;17;17m$⇡ [36m[49m [mvia [32m[1m v18.18.2 \n\r❯[m ',
+				]);
+				onCommandStart.fire({ marker: xterm.registerMarker() } as ITerminalCommand);
+				promptInputModel.forceSync();
+				strictEqual(promptInputModel.value, '');
+
+				await replayEvents([
+					'[?25l[93mf[97m[2m[3makecommand[3;4H[?25h',
+					'[m',
+					'[93mfo[9X',
+					'[m',
+					'[?25l[93m[3;3Hfoo[?25h',
+					'[m',
+				]);
+				promptInputModel.forceSync();
+				strictEqual(promptInputModel.value, 'foo');
+				strictEqual(promptInputModel.cursorIndex, 3);
+			});
+		});
 	});
 });

--- a/src/vs/platform/terminal/test/common/capabilities/commandDetection/promptInputModel.test.ts
+++ b/src/vs/platform/terminal/test/common/capabilities/commandDetection/promptInputModel.test.ts
@@ -4,12 +4,13 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { ensureNoDisposablesAreLeakedInTestSuite } from 'vs/base/test/common/utils';
+import type { PromptInputModel } from 'vs/platform/terminal/common/capabilities/commandDetection/promptInputModel';
 
 suite('RequestStore', () => {
 	const store = ensureNoDisposablesAreLeakedInTestSuite();
+	let promptInputModel: PromptInputModel;
 
 	setup(() => {
-		instantiationService = new TestInstantiationService();
-		instantiationService.stub(ILogService, new LogService(new ConsoleLogger()));
+
 	});
 });

--- a/src/vs/platform/terminal/test/common/capabilities/commandDetection/promptInputModel.test.ts
+++ b/src/vs/platform/terminal/test/common/capabilities/commandDetection/promptInputModel.test.ts
@@ -185,7 +185,7 @@ suite('PromptInputModel', () => {
 		suite('Windows 11 (10.0.22621.3447), pwsh 7.4.2, starship prompt 1.10.2', () => {
 			test('input with ignored ghost text', async () => {
 				await replayEvents([
-					'[?25l[2J[m[H]0;C:\Program Files\WindowsApps\Microsoft.PowerShell_7.4.2.0_x64__8wekyb3d8bbwe\pwsh.exe[?25h',
+					'[?25l[2J[m[H]0;C:\\Program Files\\WindowsApps\\Microsoft.PowerShell_7.4.2.0_x64__8wekyb3d8bbwe\\pwsh.exe[?25h',
 					'[?25l[K\r\n[K\r\n[K\r\n[K\r\n[K\r\n[K\r\n[K\r\n[K\r\n[K\r\n[K\r\n[K\r\n[K\r\n[K\r\n[K\r\n[K\r\n[K\r\n[K\r\n[K\r\n[K\r\n[K\r\n[K\r\n[K\r\n[K\r\n[K\r\n[K\r\n[K[H[?25h',
 					']633;P;IsWindows=True',
 					']633;P;ContinuationPrompt=\x1b[38\x3b5\x3b8m∙\x1b[0m ',
@@ -207,7 +207,7 @@ suite('PromptInputModel', () => {
 			});
 			test('input with accepted and run ghost text', async () => {
 				await replayEvents([
-					'[?25l[2J[m[H]0;C:\Program Files\WindowsApps\Microsoft.PowerShell_7.4.2.0_x64__8wekyb3d8bbwe\pwsh.exe[?25h',
+					'[?25l[2J[m[H]0;C:\\Program Files\\WindowsApps\\Microsoft.PowerShell_7.4.2.0_x64__8wekyb3d8bbwe\\pwsh.exe[?25h',
 					'[?25l[K\r\n[K\r\n[K\r\n[K\r\n[K\r\n[K\r\n[K\r\n[K\r\n[K\r\n[K\r\n[K\r\n[K\r\n[K\r\n[K\r\n[K\r\n[K\r\n[K\r\n[K\r\n[K\r\n[K\r\n[K\r\n[K\r\n[K\r\n[K\r\n[K\r\n[K[H[?25h',
 					']633;P;IsWindows=True',
 					']633;P;ContinuationPrompt=\x1b[38\x3b5\x3b8m∙\x1b[0m ',

--- a/src/vs/platform/terminal/test/common/capabilities/commandDetection/promptInputModel.test.ts
+++ b/src/vs/platform/terminal/test/common/capabilities/commandDetection/promptInputModel.test.ts
@@ -19,7 +19,7 @@ class TestPromptInputModel extends PromptInputModel {
 	}
 }
 
-suite.only('PromptInputModel', () => {
+suite('PromptInputModel', () => {
 	const store = ensureNoDisposablesAreLeakedInTestSuite();
 	let promptInputModel: TestPromptInputModel;
 	let xterm: Terminal;
@@ -57,15 +57,15 @@ suite.only('PromptInputModel', () => {
 			strictEqual(promptInputModel.cursorIndex, cursorIndex,);
 		}
 
-		suite('Windows, pwsh 7.4.2, starship prompt', () => {
+		suite('Windows 11 (10.0.22621.3447), pwsh 7.4.2, starship prompt 1.10.2', () => {
 			test('input with ignored ghost text', async () => {
 				await replayEvents([
 					'[?25l[2J[m[H]0;C:\Program Files\WindowsApps\Microsoft.PowerShell_7.4.2.0_x64__8wekyb3d8bbwe\pwsh.exe[?25h',
-					'[?25l[K\n\r[K\n\r[K\n\r[K\n\r[K\n\r[K\n\r[K\n\r[K\n\r[K\n\r[K\n\r[K\n\r[K\n\r[K\n\r[K\n\r[K\n\r[K\n\r[K\n\r[K\n\r[K\n\r[K\n\r[K\n\r[K\n\r[K\n\r[K\n\r[K\n\r[K[H[?25h',
+					'[?25l[K\r\n[K\r\n[K\r\n[K\r\n[K\r\n[K\r\n[K\r\n[K\r\n[K\r\n[K\r\n[K\r\n[K\r\n[K\r\n[K\r\n[K\r\n[K\r\n[K\r\n[K\r\n[K\r\n[K\r\n[K\r\n[K\r\n[K\r\n[K\r\n[K\r\n[K[H[?25h',
 					']633;P;IsWindows=True',
 					']633;P;ContinuationPrompt=\x1b[38\x3b5\x3b8m∙\x1b[0m ',
 					']633;A]633;P;Cwd=C:\x5cGithub\x5cmicrosoft\x5cvscode]633;B',
-					'[34m\n\r[38;2;17;17;17m[44m03:13:47 [34m[41m [38;2;17;17;17mvscode [31m[43m [38;2;17;17;17m tyriar/prompt_input_model [33m[46m [38;2;17;17;17m$⇡ [36m[49m [mvia [32m[1m v18.18.2 \n\r❯[m ',
+					'[34m\r\n[38;2;17;17;17m[44m03:13:47 [34m[41m [38;2;17;17;17mvscode [31m[43m [38;2;17;17;17m tyriar/prompt_input_model [33m[46m [38;2;17;17;17m$⇡ [36m[49m [mvia [32m[1m v18.18.2 \r\n❯[m ',
 				]);
 				onCommandStart.fire({ marker: xterm.registerMarker() } as ITerminalCommand);
 				promptInputModel.forceSync();

--- a/src/vs/workbench/contrib/terminal/browser/media/shellIntegration-bash.sh
+++ b/src/vs/workbench/contrib/terminal/browser/media/shellIntegration-bash.sh
@@ -162,6 +162,9 @@ __vsc_current_command=""
 __vsc_nonce="$VSCODE_NONCE"
 unset VSCODE_NONCE
 
+# Report continuation prompt
+builtin printf "\e]633;P;ContinuationPrompt=$(echo "$PS2" | sed 's/\x1b/\\\\x1b/g')\a"
+
 __vsc_prompt_start() {
 	builtin printf '\e]633;A\a'
 }

--- a/src/vs/workbench/contrib/terminal/browser/media/shellIntegration.ps1
+++ b/src/vs/workbench/contrib/terminal/browser/media/shellIntegration.ps1
@@ -57,7 +57,7 @@ function Global:__VSCode-Escape-Value([string]$value) {
 			-Join (
 				[System.Text.Encoding]::UTF8.GetBytes($match.Value) | ForEach-Object { '\x{0:x2}' -f $_ }
 			)
-		})
+		}) -replace "`e", '\x1b'
 }
 
 function Global:Prompt() {

--- a/src/vs/workbench/contrib/terminal/browser/media/shellIntegration.ps1
+++ b/src/vs/workbench/contrib/terminal/browser/media/shellIntegration.ps1
@@ -135,6 +135,12 @@ else {
 	[Console]::Write("$([char]0x1b)]633;P;IsWindows=$IsWindows`a")
 }
 
+# Set ContinuationPrompt property
+$ContinuationPrompt = (Get-PSReadLineOption).ContinuationPrompt
+if ($ContinuationPrompt) {
+	[Console]::Write("$([char]0x1b)]633;P;ContinuationPrompt=$(__VSCode-Escape-Value $ContinuationPrompt)`a")
+}
+
 # Set always on key handlers which map to default VS Code keybindings
 function Set-MappedKeyHandler {
 	param ([string[]] $Chord, [string[]]$Sequence)

--- a/src/vs/workbench/contrib/terminalContrib/accessibility/browser/textAreaSyncAddon.ts
+++ b/src/vs/workbench/contrib/terminalContrib/accessibility/browser/textAreaSyncAddon.ts
@@ -99,6 +99,7 @@ export class TextAreaSyncAddon extends Disposable implements ITerminalAddon {
 		}
 		const buffer = this._terminal.buffer.active;
 		const lineNumber = currentCommand.commandStartMarker?.line;
+		this._logService.debug('line number?', lineNumber);
 		if (!lineNumber) {
 			return;
 		}
@@ -107,6 +108,7 @@ export class TextAreaSyncAddon extends Disposable implements ITerminalAddon {
 			this._logService.debug(`TextAreaSyncAddon#updateCommandAndCursor: no line`);
 			return;
 		}
+		// TODO: Support multi-line prompts
 		if (currentCommand.commandStartX !== undefined) {
 			this._currentCommand = commandLine.substring(currentCommand.commandStartX);
 			const cursorPosition = buffer.cursorX - currentCommand.commandStartX;

--- a/src/vs/workbench/contrib/terminalContrib/developer/browser/media/developer.css
+++ b/src/vs/workbench/contrib/terminalContrib/developer/browser/media/developer.css
@@ -3,28 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-.monaco-workbench .xterm.dev-mode .xterm-helper-textarea {
-	z-index: 36 !important;
-	opacity: 0.8 !important;
-	right: 0 !important;
-	left: initial !important;
-	width: 50% !important;
-	background-color: var(--vscode-terminal-background, var(--vscode-panel-background));
-	color: var(--vscode-terminal-foreground);
-	transform: translateY(-100%);
-}
-.monaco-workbench .xterm.dev-mode .xterm-helper-textarea:focus {
-	opacity: 0.8 !important;
-}
-.monaco-workbench .xterm.dev-mode .xterm-helpers {
-	/* This could maybe be done outside of .dev-mode, but I'm scared to break something */
-	left: 0;
-	right: 0;
-}
-.monaco-workbench .xterm.dev-mode .xterm-helper-textarea:hover {
-	opacity: 0.25 !important;
-}
-
 .monaco-workbench .xterm.dev-mode .xterm-sequence-decoration {
 	background-color: var(--vscode-terminal-background, var(--vscode-panel-background));
 	display: none !important;

--- a/src/vs/workbench/contrib/terminalContrib/developer/browser/terminal.developer.contribution.ts
+++ b/src/vs/workbench/contrib/terminalContrib/developer/browser/terminal.developer.contribution.ts
@@ -250,7 +250,7 @@ class DevModeContribution extends Disposable implements ITerminalContribution {
 				name: localize('terminalDevMode', 'Terminal Dev Mode'),
 				text: `$(terminal) ${promptInput.substring(0, promptInputModel.cursorIndex)}|${promptInput.substring(promptInputModel.cursorIndex)}`,
 				ariaLabel: localize('terminalDevMode', 'Terminal Dev Mode'),
-				kind: 'warning'
+				kind: 'prominent'
 			};
 			if (!this._statusbarEntryAccessor.value) {
 				this._statusbarEntryAccessor.value = this._statusbarService.addEntry(this._statusbarEntry, `terminal.promptInput.${this._instance.instanceId}`, StatusbarAlignment.LEFT);


### PR DESCRIPTION
This adds the new `PromptInputModel` class which has a more reliable and testable view of the current command line when shell integration is available. This adds reporting of the line continuation from pwsh and bash to improve these results.

This also removed the text area overlay feature in dev mode and replaced it with a status bar item that reflects the current prompt using `|` for the cursor and `⏎` for a new line:

![Recording 2024-04-18 at 08 03 13](https://github.com/microsoft/vscode/assets/2193314/faa7ebc7-d961-455b-bd11-a0419b0669e9)

Follow ups:

- https://github.com/microsoft/vscode/issues/210662
- https://github.com/microsoft/vscode/issues/210663

fyi @cpendery I plan on adopting this in the suggest widget which should make a lot of things easier 👍 