### PR TITLE
Change tree find keybinding to `ctrl+alt+f`

### DIFF
--- a/src/vs/workbench/browser/actions/listCommands.ts
+++ b/src/vs/workbench/browser/actions/listCommands.ts
@@ -805,7 +805,7 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 	id: 'list.find',
 	weight: KeybindingWeight.WorkbenchContrib,
 	when: ContextKeyExpr.and(RawWorkbenchListFocusContextKey, WorkbenchListSupportsFind),
-	primary: KeyMod.CtrlCmd | KeyCode.KeyF,
+	primary: KeyMod.CtrlCmd | KeyMod.Alt | KeyCode.KeyF,
 	secondary: [KeyCode.F3],
 	handler: (accessor) => {
 		const widget = accessor.get(IListService).lastFocusedList;


### PR DESCRIPTION
Update the keybinding for the find command in the tree view to use `ctrl+alt+f` instead of `ctrl+f`. This change provides a more intuitive and consistent keybinding for users.