### PR TITLE
Clear Activity Bar icon badge correctly (fix #210640)

### DIFF
--- a/src/vs/workbench/browser/parts/views/treeView.ts
+++ b/src/vs/workbench/browser/parts/views/treeView.ts
@@ -453,6 +453,8 @@ abstract class AbstractTreeView extends Disposable implements ITreeView {
 				priority: 50
 			};
 			this._activity.value = this.activityService.showViewActivity(this.id, activity);
+		} else {
+			this._activity.clear();
 		}
 	}
 


### PR DESCRIPTION
This PR fixes #210640

When an extension sets a TreeView.badge and subsequently clears it by setting it `undefined`, remove the badge from the Activity Bar icon.