### PR TITLE
Use graceful-fs to buffer fs calls

### DIFF
--- a/build/gulpfile.js
+++ b/build/gulpfile.js
@@ -7,6 +7,13 @@
 
 // Increase max listeners for event emitters
 require('events').EventEmitter.defaultMaxListeners = 100;
+const { gracefulify } = require('graceful-fs');
+const fs = require('fs');
+try {
+	gracefulify(fs);
+} catch (e) {
+	logger.log(`Error enabling graceful-fs: ${e}`);
+}
 
 const gulp = require('gulp');
 const util = require('./lib/util');

--- a/build/package.json
+++ b/build/package.json
@@ -43,6 +43,7 @@
     "electron-osx-sign": "^0.4.16",
     "esbuild": "0.20.0",
     "extract-zip": "^2.0.1",
+    "graceful-fs": "^4.2.11",
     "gulp-merge-json": "^2.1.1",
     "gulp-shell": "^0.8.0",
     "jsonc-parser": "^2.3.0",

--- a/build/yarn.lock
+++ b/build/yarn.lock
@@ -1563,6 +1563,11 @@ graceful-fs@^4.1.6, graceful-fs@^4.2.0:
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.8.tgz#e412b8d33f5e006593cbd3cee6df9f2cebbe802a"
   integrity sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==
 
+graceful-fs@^4.2.11:
+  version "4.2.11"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.11.tgz#4183e4e8bf08bb6e05bbb2f7d2e0c8f712ca40e3"
+  integrity sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==
+
 "graceful-readlink@>= 1.0.0":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/graceful-readlink/-/graceful-readlink-1.0.1.tgz#4cafad76bc62f02fa039b2f94e9a3dd3a391a725"


### PR DESCRIPTION
Fixes `EMFILE: too many open files` thrown in the localization pipeline

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
