### PR TITLE
Properly escape values from Windows PowerShell SI

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/media/shellIntegration.ps1
+++ b/src/vs/workbench/contrib/terminal/browser/media/shellIntegration.ps1
@@ -52,12 +52,17 @@ if ($env:VSCODE_ENV_APPEND) {
 function Global:__VSCode-Escape-Value([string]$value) {
 	# NOTE: In PowerShell v6.1+, this can be written `$value -replace '…', { … }` instead of `[regex]::Replace`.
 	# Replace any non-alphanumeric characters.
-	[regex]::Replace($value, '[\\\n;]', { param($match)
+	$Result = [regex]::Replace($value, '[\\\n;]', { param($match)
 			# Encode the (ascii) matches as `\x<hex>`
 			-Join (
 				[System.Text.Encoding]::UTF8.GetBytes($match.Value) | ForEach-Object { '\x{0:x2}' -f $_ }
 			)
-		}) -replace "`e", '\x1b'
+		})
+	# `e is only availabel in pwsh 6+
+	if ($PSVersionTable.PSVersion.Major -lt 6) {
+		$Result = $Result -replace "`e", '\x1b'
+	}
+	$Result
 }
 
 function Global:Prompt() {


### PR DESCRIPTION
Fixes #210783
