### PR TITLE
Revert "Merge pull request #209136 from cpendery/fix/improve-marker-p…

### DIFF
--- a/src/vs/platform/terminal/common/capabilities/capabilities.ts
+++ b/src/vs/platform/terminal/common/capabilities/capabilities.ts
@@ -182,7 +182,6 @@ export interface ICommandDetectionCapability {
 	readonly onCurrentCommandInvalidated: Event<ICommandInvalidationRequest>;
 	setContinuationPrompt(value: string): void;
 	setCwd(value: string): void;
-	setPromptHeight(value: number): void;
 	setIsWindowsPty(value: boolean): void;
 	setIsCommandStorageDisabled(): void;
 	/**

--- a/src/vs/platform/terminal/common/capabilities/commandDetection/terminalCommand.ts
+++ b/src/vs/platform/terminal/common/capabilities/commandDetection/terminalCommand.ts
@@ -213,7 +213,6 @@ export class TerminalCommand implements ITerminalCommand {
 
 export interface ICurrentPartialCommand {
 	promptStartMarker?: IMarker;
-	promptHeight?: number;
 
 	commandStartMarker?: IMarker;
 	commandStartX?: number;
@@ -245,23 +244,12 @@ export interface ICurrentPartialCommand {
 	 */
 	isInvalid?: boolean;
 
-	/**
-	 * Whether the command start marker has been adjusted on Windows.
-	 */
-	isAdjusted?: boolean;
-
-	/**
-	 * Whether the command start marker adjustment has been attempt on new terminal input.
-	 */
-	isInputAdjusted?: boolean;
-
 	getPromptRowCount(): number;
 	getCommandRowCount(): number;
 }
 
 export class PartialTerminalCommand implements ICurrentPartialCommand {
 	promptStartMarker?: IMarker;
-	promptHeight?: number;
 
 	commandStartMarker?: IMarker;
 	commandStartX?: number;

--- a/src/vs/platform/terminal/common/capabilities/commandDetectionCapability.ts
+++ b/src/vs/platform/terminal/common/capabilities/commandDetectionCapability.ts
@@ -154,7 +154,6 @@ export class CommandDetectionCapability extends Disposable implements ICommandDe
 		};
 		this._register(this._terminal.onResize(e => this._handleResize(e)));
 		this._register(this._terminal.onCursorMove(() => this._handleCursorMove()));
-		this._register(this._terminal.onData(() => this._handleInput()));
 	}
 
 	private _handleResize(e: { cols: number; rows: number }) {
@@ -206,10 +205,6 @@ export class CommandDetectionCapability extends Disposable implements ICommandDe
 
 	setCwd(value: string) {
 		this._cwd = value;
-	}
-
-	setPromptHeight(value: number) {
-		this._currentCommand.promptHeight = value;
 	}
 
 	setIsWindowsPty(value: boolean) {
@@ -283,10 +278,6 @@ export class CommandDetectionCapability extends Disposable implements ICommandDe
 		}
 
 		return undefined;
-	}
-
-	private _handleInput(): void {
-		this._ptyHeuristics.value.handleInput();
 	}
 
 	handlePromptStart(options?: IHandleCommandOptions): void {
@@ -508,8 +499,6 @@ class UnixPtyHeuristics extends Disposable {
 		}));
 	}
 
-	handleInput() { }
-
 	handleCommandStart(options?: IHandleCommandOptions) {
 		this._hooks.commitCommandFinished();
 
@@ -663,28 +652,6 @@ class WindowsPtyHeuristics extends Disposable {
 		}
 	}
 
-	/**
-	 * Attempt to adjust the command start marker when input is handled for the first time.
-	 */
-	handleInput() {
-		const currentY = this._terminal.buffer.active.baseY + this._terminal.buffer.active.cursorY;
-
-		const hasWrappingInPrompt = Array.from({ length: (this._capability.currentCommand.promptHeight ?? 0) + 1 }, (_, i) => currentY - i).find(y => this._terminal.buffer.active.getLine(y)?.isWrapped) !== undefined;
-		const hasActiveCommand = this._capability.currentCommand.commandStartX !== undefined && this._capability.currentCommand.commandExecutedX === undefined;
-		const hasAdjusted = this._capability.currentCommand.isAdjusted === true || this._capability.currentCommand.isInputAdjusted === true;
-
-		if (!hasActiveCommand || hasAdjusted || hasWrappingInPrompt) {
-			return;
-		}
-		this._capability.currentCommand.isInputAdjusted = true;
-		this._logService.debug('CommandDetectionCapability#handleInput attempting start marker adjustment');
-
-		this._tryAdjustCommandStartMarkerScannedLineCount = 0;
-		this._tryAdjustCommandStartMarkerPollCount = 0;
-		this._tryAdjustCommandStartMarkerScheduler = new RunOnceScheduler(() => this._tryAdjustCommandStartMarker(this._terminal.registerMarker(0)!), AdjustCommandStartMarkerConstants.Interval);
-		this._tryAdjustCommandStartMarkerScheduler.schedule();
-	}
-
 	handleCommandStart() {
 		this._capability.currentCommand.commandStartX = this._terminal.buffer.active.cursorX;
 
@@ -746,24 +713,21 @@ class WindowsPtyHeuristics extends Disposable {
 				if (prompt) {
 					const adjustedPrompt = typeof prompt === 'string' ? prompt : prompt.prompt;
 					this._capability.currentCommand.commandStartMarker = this._terminal.registerMarker(0)!;
-
-					// Adjust the prompt start marker to the command start marker
-					this._logService.debug('CommandDetectionCapability#_tryAdjustCommandStartMarker adjusted promptStart', `${this._capability.currentCommand.promptStartMarker?.line} -> ${this._capability.currentCommand.commandStartMarker.line}`);
-					this._capability.currentCommand.promptStartMarker?.dispose();
-					this._capability.currentCommand.promptStartMarker = cloneMarker(this._terminal, this._capability.currentCommand.commandStartMarker, -((this._capability.currentCommand.promptHeight ?? 1) - 1));
-
-					// Adjust the last command if it's not in the same position as the following
-					// prompt start marker
-					const lastCommand = this._capability.commands.at(-1);
-					if (lastCommand && this._capability.currentCommand.commandStartMarker.line !== lastCommand.endMarker?.line) {
-						lastCommand.endMarker?.dispose();
-						lastCommand.endMarker = cloneMarker(this._terminal, this._capability.currentCommand.commandStartMarker, -((this._capability.currentCommand.promptHeight ?? 1) - 1));
+					if (typeof prompt === 'object' && prompt.likelySingleLine) {
+						this._logService.debug('CommandDetectionCapability#_tryAdjustCommandStartMarker adjusted promptStart', `${this._capability.currentCommand.promptStartMarker?.line} -> ${this._capability.currentCommand.commandStartMarker.line}`);
+						this._capability.currentCommand.promptStartMarker?.dispose();
+						this._capability.currentCommand.promptStartMarker = cloneMarker(this._terminal, this._capability.currentCommand.commandStartMarker);
+						// Adjust the last command if it's not in the same position as the following
+						// prompt start marker
+						const lastCommand = this._capability.commands.at(-1);
+						if (lastCommand && this._capability.currentCommand.commandStartMarker.line !== lastCommand.endMarker?.line) {
+							lastCommand.endMarker?.dispose();
+							lastCommand.endMarker = cloneMarker(this._terminal, this._capability.currentCommand.commandStartMarker);
+						}
 					}
-
 					// use the regex to set the position as it's possible input has occurred
 					this._capability.currentCommand.commandStartX = adjustedPrompt.length;
 					this._logService.debug('CommandDetectionCapability#_tryAdjustCommandStartMarker adjusted commandStart', `${start.line} -> ${this._capability.currentCommand.commandStartMarker.line}:${this._capability.currentCommand.commandStartX}`);
-					this._capability.currentCommand.isAdjusted = true;
 					this._flushPendingHandleCommandStartTask();
 					return;
 				}
@@ -1085,7 +1049,5 @@ function getXtermLineContent(buffer: IBuffer, lineStart: number, lineEnd: number
 }
 
 function cloneMarker(xterm: Terminal, marker: IXtermMarker, offset: number = 0): IXtermMarker | undefined {
-	const cursorY = xterm.buffer.active.baseY + xterm.buffer.active.cursorY;
-	const cursorYOffset = marker.line - cursorY + offset;
-	return xterm.registerMarker((cursorY + cursorYOffset) < 0 ? -cursorY : cursorYOffset);
+	return xterm.registerMarker(marker.line - (xterm.buffer.active.baseY + xterm.buffer.active.cursorY) + offset);
 }

--- a/src/vs/platform/terminal/common/xterm/shellIntegrationAddon.ts
+++ b/src/vs/platform/terminal/common/xterm/shellIntegrationAddon.ts
@@ -403,10 +403,6 @@ export class ShellIntegrationAddon extends Disposable implements IShellIntegrati
 						this.capabilities.get(TerminalCapability.CommandDetection)?.setIsCommandStorageDisabled();
 						return true;
 					}
-					case 'PromptHeight': {
-						this.capabilities.get(TerminalCapability.CommandDetection)?.setPromptHeight(parseInt(value));
-						return true;
-					}
 				}
 			}
 			case VSCodeOscPt.SetMark: {

--- a/src/vs/workbench/contrib/terminal/browser/media/shellIntegration-bash.sh
+++ b/src/vs/workbench/contrib/terminal/browser/media/shellIntegration-bash.sh
@@ -182,11 +182,6 @@ __vsc_update_cwd() {
 	builtin printf '\e]633;P;Cwd=%s\a' "$(__vsc_escape_value "$__vsc_cwd")"
 }
 
-__vsc_update_prompt_height() {
-	__vsc_prompt_height="$(("$(builtin printf "%s" "${PS1@P}" | wc -l)" + 1))"
-	builtin printf '\e]633;P;PromptHeight=%s\a' "$(__vsc_escape_value "$__vsc_prompt_height")"
-}
-
 __vsc_command_output_start() {
 	builtin printf '\e]633;E;%s;%s\a' "$(__vsc_escape_value "${__vsc_current_command}")" $__vsc_nonce
 	builtin printf '\e]633;C\a'
@@ -234,7 +229,6 @@ __vsc_precmd() {
 	__vsc_command_complete "$__vsc_status"
 	__vsc_current_command=""
 	__vsc_update_prompt
-	__vsc_update_prompt_height
 	__vsc_first_prompt=1
 }
 

--- a/src/vs/workbench/contrib/terminal/browser/media/shellIntegration.ps1
+++ b/src/vs/workbench/contrib/terminal/browser/media/shellIntegration.ps1
@@ -52,12 +52,17 @@ if ($env:VSCODE_ENV_APPEND) {
 function Global:__VSCode-Escape-Value([string]$value) {
 	# NOTE: In PowerShell v6.1+, this can be written `$value -replace '…', { … }` instead of `[regex]::Replace`.
 	# Replace any non-alphanumeric characters.
-	[regex]::Replace($value, "[$([char]0x1b)\\\n;]", { param($match)
+	$Result = [regex]::Replace($value, '[\\\n;]', { param($match)
 			# Encode the (ascii) matches as `\x<hex>`
 			-Join (
 				[System.Text.Encoding]::UTF8.GetBytes($match.Value) | ForEach-Object { '\x{0:x2}' -f $_ }
 			)
 		})
+	# `e is only availabel in pwsh 6+
+	if ($PSVersionTable.PSVersion.Major -lt 6) {
+		$Result = $Result -replace "`e", '\x1b'
+	}
+	$Result
 }
 
 function Global:Prompt() {
@@ -90,13 +95,7 @@ function Global:Prompt() {
 		Write-Error "failure" -ea ignore
 	}
 	# Run the original prompt
-	$OriginalPrompt += $Global:__VSCodeOriginalPrompt.Invoke()
-	$Result += $OriginalPrompt
-
-	# Prompt height
-	# OSC 633 ; <Property>=<Value> ST
-	$Result += "$([char]0x1b)]633;P;PromptHeight=$(__VSCode-Escape-Value ($OriginalPrompt -Split '\n').Count)`a"
-
+	$Result += $Global:__VSCodeOriginalPrompt.Invoke()
 	# Write command started
 	$Result += "$([char]0x1b)]633;B`a"
 	$Global:__LastHistoryId = $LastHistoryEntry.Id


### PR DESCRIPTION
…lacements"

@cpendery this broke the build unfortunately, we need to tweak it

macOS Smoke tests:

```
  3 failing

  1) VSCode Smoke Tests (Electron)
       Terminal
         Terminal Shell Integration
           Process-based tests
             Decorations
               Should show default icons
                 Success:
     Error: Timeout: get elements '.terminal-command-decoration.codicon-terminal-decoration-success' after 20 seconds.
      at Code.poll (/Users/runner/work/1/s/test/automation/out/code.js:204:23)
      at async Code.waitForElements (/Users/runner/work/1/s/test/automation/out/code.js:160:16)
      at async Terminal.assertCommandDecorations (/Users/runner/work/1/s/test/automation/out/terminal.js:238:13)
      at async Context.<anonymous> (out/areas/terminal/terminal-shellIntegration.test.js:44:25)

  2) VSCode Smoke Tests (Electron)
       Terminal
         Terminal Shell Integration
           Process-based tests
             Decorations
               Should show default icons
                 Error:
     Error: Timeout: get elements '.terminal-command-decoration.codicon-terminal-decoration-error' after 20 seconds.
      at Code.poll (/Users/runner/work/1/s/test/automation/out/code.js:204:23)
      at async Code.waitForElements (/Users/runner/work/1/s/test/automation/out/code.js:160:16)
      at async Terminal.assertCommandDecorations (/Users/runner/work/1/s/test/automation/out/terminal.js:240:13)
      at async Context.<anonymous> (out/areas/terminal/terminal-shellIntegration.test.js:49:25)

  3) VSCode Smoke Tests (Electron)
       Terminal
         Terminal Shell Integration
           Process-based tests
             Decorations
               terminal.integrated.shellIntegration.decorationsEnabled should determine gutter and overview ruler decoration visibility
                 "before each" hook for "never":
     Error: Timeout: get elements '.terminal-command-decoration.codicon-terminal-decoration-success' after 20 seconds.
      at Code.poll (/Users/runner/work/1/s/test/automation/out/code.js:204:23)
      at async Code.waitForElements (/Users/runner/work/1/s/test/automation/out/code.js:160:16)
      at async Terminal.assertCommandDecorations (/Users/runner/work/1/s/test/automation/out/terminal.js:238:13)
      at async Context.<anonymous> (out/areas/terminal/terminal-shellIntegration.test.js:60:25)
```

macOS Integration tests:

```
8 failing
  1) vscode API - Terminal.shellIntegration
       execution events should fire in order when a command runs:
     Error: Timeout of 60000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves. (/Users/runner/work/1/s/extensions/vscode-api-tests/out/singlefolder-tests/terminal.shellIntegration.test.js)
      at listOnTimeout (node:internal/timers:569:17)
      at processTimers (node:internal/timers:512:7)

  2) vscode API - Terminal.shellIntegration
       end execution event should report zero exit code for successful commands:
     Error: Timeout of 60000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves. (/Users/runner/work/1/s/extensions/vscode-api-tests/out/singlefolder-tests/terminal.shellIntegration.test.js)
      at listOnTimeout (node:internal/timers:569:17)
      at processTimers (node:internal/timers:512:7)

  3) vscode API - Terminal.shellIntegration
       end execution event should report non-zero exit code for failed commands:
     Error: Timeout of 60000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves. (/Users/runner/work/1/s/extensions/vscode-api-tests/out/singlefolder-tests/terminal.shellIntegration.test.js)
      at listOnTimeout (node:internal/timers:569:17)
      at processTimers (node:internal/timers:512:7)

  4) vscode API - Terminal.shellIntegration
       TerminalShellExecution.read iterables should be available between the start and end execution events:
     Error: Timeout of 60000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves. (/Users/runner/work/1/s/extensions/vscode-api-tests/out/singlefolder-tests/terminal.shellIntegration.test.js)
      at listOnTimeout (node:internal/timers:569:17)
      at processTimers (node:internal/timers:512:7)

  5) vscode API - Terminal.shellIntegration
       TerminalShellExecution.read events should fire with contents of command:
     Error: Timeout of 60000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves. (/Users/runner/work/1/s/extensions/vscode-api-tests/out/singlefolder-tests/terminal.shellIntegration.test.js)
      at listOnTimeout (node:internal/timers:569:17)
      at processTimers (node:internal/timers:512:7)

  6) vscode API - Terminal.shellIntegration
```