### PR TITLE
Placing description into metadata-description instead of the title in Action2

### DIFF
--- a/src/vs/editor/contrib/stickyScroll/browser/stickyScrollActions.ts
+++ b/src/vs/editor/contrib/stickyScroll/browser/stickyScrollActions.ts
@@ -21,8 +21,11 @@ export class ToggleStickyScroll extends Action2 {
 		super({
 			id: 'editor.action.toggleStickyScroll',
 			title: {
-				...localize2('toggleEditorStickyScroll', "Toggle/enable the editor sticky scroll which shows the nested scopes at the top of the viewport."),
+				...localize2('toggleEditorStickyScroll', "Toggle Editor Sticky Scroll"),
 				mnemonicTitle: localize({ key: 'mitoggleStickyScroll', comment: ['&& denotes a mnemonic'] }, "&&Toggle Editor Sticky Scroll"),
+			},
+			metadata: {
+				description: localize2('toggleEditorStickyScroll.description', "Toggle/enable the editor sticky scroll which shows the nested scopes at the top of the viewport"),
 			},
 			category: Categories.View,
 			toggled: {


### PR DESCRIPTION
Currently the editor sticky scroll toggle command has a long phrase explaining what the command does. This phrase should be the in the description of the associated metadata object, not in the title field.