### PR TITLE
Fixing type serialization issue with `HoverWithId` interface

### DIFF
--- a/src/vs/editor/common/languages.ts
+++ b/src/vs/editor/common/languages.ts
@@ -190,17 +190,17 @@ export interface HoverProvider<THover = Hover> {
 	 * position will be merged by the editor. A hover can have a range which defaults
 	 * to the word range at the position when omitted.
 	 */
-	provideHover(model: model.ITextModel, position: Position, token: CancellationToken, context?: HoverContext<THover>): ProviderResult<Hover>;
+	provideHover(model: model.ITextModel, position: Position, token: CancellationToken, context?: HoverContext<THover>): ProviderResult<THover>;
 }
 
 export interface HoverContext<THover = Hover> {
 	/**
-	 * Hover verbosity context
+	 * Hover verbosity request
 	 */
-	hoverVerbosityContext?: HoverVerbosityContext<THover>;
+	verbosityRequest?: HoverVerbosityRequest<THover>;
 }
 
-export interface HoverVerbosityContext<THover = Hover> {
+export interface HoverVerbosityRequest<THover = Hover> {
 	/**
 	 * Whether to increase or decrease the hover's verbosity
 	 */

--- a/src/vs/editor/common/languages.ts
+++ b/src/vs/editor/common/languages.ts
@@ -195,13 +195,20 @@ export interface HoverProvider<THover = Hover> {
 
 export interface HoverContext<THover = Hover> {
 	/**
+	 * Hover verbosity context
+	 */
+	hoverVerbosityContext?: HoverVerbosityContext<THover>;
+}
+
+export interface HoverVerbosityContext<THover = Hover> {
+	/**
 	 * Whether to increase or decrease the hover's verbosity
 	 */
-	action?: HoverVerbosityAction;
+	action: HoverVerbosityAction;
 	/**
 	 * The previous hover for the same position
 	 */
-	previousHover?: THover;
+	previousHover: THover;
 }
 
 export enum HoverVerbosityAction {

--- a/src/vs/editor/contrib/hover/browser/markdownHoverParticipant.ts
+++ b/src/vs/editor/contrib/hover/browser/markdownHoverParticipant.ts
@@ -352,7 +352,7 @@ class MarkdownRenderedHoverParts extends Disposable {
 		const hoverPosition = hoverRenderedPart.hoverSource.hoverPosition;
 		const hoverProvider = hoverRenderedPart.hoverSource.hoverProvider;
 		const hover = hoverRenderedPart.hoverSource.hover;
-		const hoverContext: HoverContext = { hoverVerbosityContext: { action, previousHover: hover } };
+		const hoverContext: HoverContext = { verbosityRequest: { action, previousHover: hover } };
 
 		let newHover: Hover | null | undefined;
 		try {

--- a/src/vs/editor/contrib/hover/browser/markdownHoverParticipant.ts
+++ b/src/vs/editor/contrib/hover/browser/markdownHoverParticipant.ts
@@ -352,7 +352,7 @@ class MarkdownRenderedHoverParts extends Disposable {
 		const hoverPosition = hoverRenderedPart.hoverSource.hoverPosition;
 		const hoverProvider = hoverRenderedPart.hoverSource.hoverProvider;
 		const hover = hoverRenderedPart.hoverSource.hover;
-		const hoverContext: HoverContext = { action, previousHover: hover };
+		const hoverContext: HoverContext = { hoverVerbosityContext: { action, previousHover: hover } };
 
 		let newHover: Hover | null | undefined;
 		try {

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -6852,17 +6852,17 @@ declare namespace monaco.languages {
 		 * position will be merged by the editor. A hover can have a range which defaults
 		 * to the word range at the position when omitted.
 		 */
-		provideHover(model: editor.ITextModel, position: Position, token: CancellationToken, context?: HoverContext<THover>): ProviderResult<Hover>;
+		provideHover(model: editor.ITextModel, position: Position, token: CancellationToken, context?: HoverContext<THover>): ProviderResult<THover>;
 	}
 
 	export interface HoverContext<THover = Hover> {
 		/**
-		 * Hover verbosity context
+		 * Hover verbosity request
 		 */
-		hoverVerbosityContext?: HoverVerbosityContext<THover>;
+		verbosityRequest?: HoverVerbosityRequest<THover>;
 	}
 
-	export interface HoverVerbosityContext<THover = Hover> {
+	export interface HoverVerbosityRequest<THover = Hover> {
 		/**
 		 * Whether to increase or decrease the hover's verbosity
 		 */

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -6857,13 +6857,20 @@ declare namespace monaco.languages {
 
 	export interface HoverContext<THover = Hover> {
 		/**
+		 * Hover verbosity context
+		 */
+		hoverVerbosityContext?: HoverVerbosityContext<THover>;
+	}
+
+	export interface HoverVerbosityContext<THover = Hover> {
+		/**
 		 * Whether to increase or decrease the hover's verbosity
 		 */
-		action?: HoverVerbosityAction;
+		action: HoverVerbosityAction;
 		/**
 		 * The previous hover for the same position
 		 */
-		previousHover?: THover;
+		previousHover: THover;
 	}
 
 	export enum HoverVerbosityAction {

--- a/src/vs/workbench/api/browser/mainThreadLanguageFeatures.ts
+++ b/src/vs/workbench/api/browser/mainThreadLanguageFeatures.ts
@@ -259,9 +259,9 @@ export class MainThreadLanguageFeatures extends Disposable implements MainThread
 		this._registrations.set(handle, this._languageFeaturesService.hoverProvider.register(selector, <languages.HoverProvider<HoverWithId>>{
 			provideHover: async (model: ITextModel, position: EditorPosition, token: CancellationToken, context?: languages.HoverContext<HoverWithId>): Promise<HoverWithId | undefined> => {
 				const serializedContext: languages.HoverContext<{ id: number }> = {
-					hoverVerbosityContext: context?.hoverVerbosityContext ? {
-						action: context.hoverVerbosityContext.action,
-						previousHover: { id: context.hoverVerbosityContext.previousHover.id }
+					verbosityRequest: context?.verbosityRequest ? {
+						action: context.verbosityRequest.action,
+						previousHover: { id: context.verbosityRequest.previousHover.id }
 					} : undefined,
 				};
 				const hover = await this._proxy.$provideHover(handle, model.uri, position, serializedContext, token);

--- a/src/vs/workbench/api/browser/mainThreadLanguageFeatures.ts
+++ b/src/vs/workbench/api/browser/mainThreadLanguageFeatures.ts
@@ -256,9 +256,15 @@ export class MainThreadLanguageFeatures extends Disposable implements MainThread
 			this._proxy.$releaseHover(handle, hoverId);
 		});
 		*/
-		this._registrations.set(handle, this._languageFeaturesService.hoverProvider.register(selector, <languages.HoverProvider>{
-			provideHover: async (model: ITextModel, position: EditorPosition, token: CancellationToken, context?: languages.HoverContext<{ id: number }>): Promise<HoverWithId | undefined> => {
-				const hover = await this._proxy.$provideHover(handle, model.uri, position, context, token);
+		this._registrations.set(handle, this._languageFeaturesService.hoverProvider.register(selector, <languages.HoverProvider<HoverWithId>>{
+			provideHover: async (model: ITextModel, position: EditorPosition, token: CancellationToken, context?: languages.HoverContext<HoverWithId>): Promise<HoverWithId | undefined> => {
+				const serializedContext: languages.HoverContext<{ id: number }> = {
+					hoverVerbosityContext: context?.hoverVerbosityContext ? {
+						action: context.hoverVerbosityContext.action,
+						previousHover: { id: context.hoverVerbosityContext.previousHover.id }
+					} : undefined,
+				};
+				const hover = await this._proxy.$provideHover(handle, model.uri, position, serializedContext, token);
 				// hoverFinalizationRegistry.register(hover, hover.id);
 				return hover;
 			}

--- a/src/vs/workbench/api/common/extHostLanguageFeatures.ts
+++ b/src/vs/workbench/api/common/extHostLanguageFeatures.ts
@@ -271,13 +271,13 @@ class HoverAdapter {
 		const pos = typeConvert.Position.to(position);
 
 		let value: vscode.Hover | null | undefined;
-		if (context && context.hoverVerbosityContext) {
-			const previousHoverId = context.hoverVerbosityContext.previousHover.id;
+		if (context && context.verbosityRequest) {
+			const previousHoverId = context.verbosityRequest.previousHover.id;
 			const previousHover = this._hoverMap.get(previousHoverId);
 			if (!previousHover) {
 				throw new Error(`Hover with id ${previousHoverId} not found`);
 			}
-			const hoverContext: vscode.HoverContext = { action: context.hoverVerbosityContext.action, previousHover };
+			const hoverContext: vscode.HoverContext = { action: context.verbosityRequest.action, previousHover };
 			value = await this._provider.provideHover(doc, pos, token, hoverContext);
 		} else {
 			value = await this._provider.provideHover(doc, pos, token);

--- a/src/vs/workbench/api/common/extHostLanguageFeatures.ts
+++ b/src/vs/workbench/api/common/extHostLanguageFeatures.ts
@@ -271,13 +271,13 @@ class HoverAdapter {
 		const pos = typeConvert.Position.to(position);
 
 		let value: vscode.Hover | null | undefined;
-		if (context && context.previousHover !== undefined && context.action !== undefined) {
-			const previousHoverId = context.previousHover.id;
+		if (context && context.hoverVerbosityContext) {
+			const previousHoverId = context.hoverVerbosityContext.previousHover.id;
 			const previousHover = this._hoverMap.get(previousHoverId);
 			if (!previousHover) {
 				throw new Error(`Hover with id ${previousHoverId} not found`);
 			}
-			const hoverContext: vscode.HoverContext = { action: context.action, previousHover };
+			const hoverContext: vscode.HoverContext = { action: context.hoverVerbosityContext.action, previousHover };
 			value = await this._provider.provideHover(doc, pos, token, hoverContext);
 		} else {
 			value = await this._provider.provideHover(doc, pos, token);


### PR DESCRIPTION
Introducing also the `verbosityRequest` field in the internal API. 