### PR TITLE
Monokai Dimmed theme: json syntax highlighting colors very different in v1.88.0

### DIFF
--- a/extensions/theme-monokai-dimmed/themes/dimmed-monokai-color-theme.json
+++ b/extensions/theme-monokai-dimmed/themes/dimmed-monokai-color-theme.json
@@ -374,7 +374,7 @@
 		},
 		{
 			"name": "CSS Property Name",
-			"scope": "support.type.property-name",
+			"scope": "source.css support.type.property-name",
 			"settings": {
 				"fontStyle": "",
 				"foreground": "#676867"


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/209713