### PR TITLE
Refactor indentation.test.ts

### DIFF
--- a/src/vs/editor/contrib/indentation/test/browser/indentation.test.ts
+++ b/src/vs/editor/contrib/indentation/test/browser/indentation.test.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as assert from 'assert';
-import { DisposableStore } from 'vs/base/common/lifecycle';
+import { DisposableStore, IDisposable } from 'vs/base/common/lifecycle';
 import { ensureNoDisposablesAreLeakedInTestSuite } from 'vs/base/test/common/utils';
 import { ILanguageConfigurationService } from 'vs/editor/common/languages/languageConfigurationRegistry';
 import { createTextModel } from 'vs/editor/test/common/testTextModel';
@@ -25,15 +25,15 @@ import { cppBracketRules, goBracketRules, htmlBracketRules, latexBracketRules, l
 import { latexAutoClosingPairsRules } from 'vs/editor/test/common/modes/supports/autoClosingPairsRules';
 
 enum Language {
-	TypeScript,
-	Ruby,
-	PHP,
-	Go,
-	CPP,
-	HTML,
-	VB,
-	Latex,
-	Lua
+	TypeScript = 'ts-test',
+	Ruby = 'ruby-test',
+	PHP = 'php-test',
+	Go = 'go-test',
+	CPP = 'cpp-test',
+	HTML = 'html-test',
+	VB = 'vb-test',
+	Latex = 'latex-test',
+	Lua = 'lua-test'
 }
 
 function testIndentationToSpacesCommand(lines: string[], selection: Selection, tabSize: number, expectedLines: string[], expectedSelection: Selection): void {
@@ -44,18 +44,19 @@ function testIndentationToTabsCommand(lines: string[], selection: Selection, tab
 	testCommand(lines, null, selection, (accessor, sel) => new IndentationToTabsCommand(sel, tabSize), expectedLines, expectedSelection);
 }
 
-function registerLanguage(instantiationService: TestInstantiationService, languageId: string, language: Language, disposables: DisposableStore) {
+function registerLanguage(instantiationService: TestInstantiationService, language: Language): IDisposable {
+	const disposables = new DisposableStore();
 	const languageService = instantiationService.get(ILanguageService);
-	registerLanguageConfiguration(instantiationService, languageId, language, disposables);
-	disposables.add(languageService.registerLanguage({ id: languageId }));
+	disposables.add(registerLanguageConfiguration(instantiationService, language));
+	disposables.add(languageService.registerLanguage({ id: language }));
+	return disposables;
 }
 
-// TODO@aiday-mar read directly the configuration file
-function registerLanguageConfiguration(instantiationService: TestInstantiationService, languageId: string, language: Language, disposables: DisposableStore) {
+function registerLanguageConfiguration(instantiationService: TestInstantiationService, language: Language): IDisposable {
 	const languageConfigurationService = instantiationService.get(ILanguageConfigurationService);
 	switch (language) {
 		case Language.TypeScript:
-			disposables.add(languageConfigurationService.register(languageId, {
+			return languageConfigurationService.register(language, {
 				brackets: typescriptBracketRules,
 				comments: {
 					lineComment: '//',
@@ -63,62 +64,53 @@ function registerLanguageConfiguration(instantiationService: TestInstantiationSe
 				},
 				indentationRules: javascriptIndentationRules,
 				onEnterRules: javascriptOnEnterRules
-			}));
-			break;
+			});
 		case Language.Ruby:
-			disposables.add(languageConfigurationService.register(languageId, {
+			return languageConfigurationService.register(language, {
 				brackets: rubyBracketRules,
 				indentationRules: rubyIndentationRules,
-			}));
-			break;
+			});
 		case Language.PHP:
-			disposables.add(languageConfigurationService.register(languageId, {
+			return languageConfigurationService.register(language, {
 				brackets: phpBracketRules,
 				indentationRules: phpIndentationRules,
 				onEnterRules: phpOnEnterRules
-			}));
-			break;
+			});
 		case Language.Go:
-			disposables.add(languageConfigurationService.register(languageId, {
+			return languageConfigurationService.register(language, {
 				brackets: goBracketRules,
 				indentationRules: goIndentationRules
-			}));
-			break;
+			});
 		case Language.CPP:
-			disposables.add(languageConfigurationService.register(languageId, {
+			return languageConfigurationService.register(language, {
 				brackets: cppBracketRules,
 				onEnterRules: cppOnEnterRules
-			}));
-			break;
+			});
 		case Language.HTML:
-			disposables.add(languageConfigurationService.register(languageId, {
+			return languageConfigurationService.register(language, {
 				brackets: htmlBracketRules,
 				indentationRules: htmlIndentationRules,
 				onEnterRules: htmlOnEnterRules
-			}));
-			break;
+			});
 		case Language.VB:
-			disposables.add(languageConfigurationService.register(languageId, {
+			return languageConfigurationService.register(language, {
 				brackets: vbBracketRules,
-			}));
-			break;
+			});
 		case Language.Latex:
-			disposables.add(languageConfigurationService.register(languageId, {
+			return languageConfigurationService.register(language, {
 				brackets: latexBracketRules,
 				autoClosingPairs: latexAutoClosingPairsRules,
 				indentationRules: latexIndentationRules
-			}));
-			break;
+			});
 		case Language.Lua:
-			disposables.add(languageConfigurationService.register(languageId, {
+			return languageConfigurationService.register(language, {
 				brackets: luaBracketRules,
 				indentationRules: luaIndentationRules
-			}));
-			break;
+			});
 	}
 }
 
-function registerTokens(instantiationService: TestInstantiationService, tokens: { startIndex: number; value: number }[][], languageId: string, disposables: DisposableStore) {
+function registerTokens(instantiationService: TestInstantiationService, tokens: { startIndex: number; value: number }[][], languageId: string): IDisposable {
 	let lineIndex = 0;
 	const languageService = instantiationService.get(ILanguageService);
 	const tokenizationSupport: ITokenizationSupport = {
@@ -139,7 +131,7 @@ function registerTokens(instantiationService: TestInstantiationService, tokens: 
 			return new EncodedTokenizationResult(result, state);
 		}
 	};
-	disposables.add(TokenizationRegistry.register(languageId, tokenizationSupport));
+	return TokenizationRegistry.register(languageId, tokenizationSupport);
 }
 
 suite('Change Indentation to Spaces - TypeScript/Javascript', () => {
@@ -318,7 +310,7 @@ suite('Change Indentation to Tabs -  TypeScript/Javascript', () => {
 
 suite('Indent With Tab - TypeScript/JavaScript', () => {
 
-	const languageId = 'ts-test';
+	const languageId = Language.TypeScript;
 	let disposables: DisposableStore;
 
 	setup(() => {
@@ -348,7 +340,7 @@ suite('Indent With Tab - TypeScript/JavaScript', () => {
 
 		withTestCodeEditor(model, { autoIndent: "full" }, (editor, viewModel, instantiationService) => {
 
-			registerLanguage(instantiationService, languageId, Language.TypeScript, disposables);
+			disposables.add(registerLanguage(instantiationService, languageId));
 			editor.setSelection(new Selection(1, 1, 3, 5));
 			editor.executeCommands('editor.action.indentLines', TypeOperations.indent(viewModel.cursorConfig, editor.getModel(), editor.getSelections()));
 			assert.strictEqual(model.getValue(), [
@@ -374,7 +366,7 @@ suite('Indent With Tab - TypeScript/JavaScript', () => {
 
 		withTestCodeEditor(model, { autoIndent: "full" }, (editor, viewModel, instantiationService) => {
 
-			registerLanguage(instantiationService, languageId, Language.TypeScript, disposables);
+			disposables.add(registerLanguage(instantiationService, languageId));
 			editor.setSelection(new Selection(1, 1, 5, 2));
 			editor.executeCommands('editor.action.indentLines', TypeOperations.indent(viewModel.cursorConfig, editor.getModel(), editor.getSelections()));
 			assert.strictEqual(model.getValue(), [
@@ -390,7 +382,7 @@ suite('Indent With Tab - TypeScript/JavaScript', () => {
 
 suite('Auto Indent On Paste - TypeScript/JavaScript', () => {
 
-	const languageId = 'ts-test';
+	const languageId = Language.TypeScript;
 	let disposables: DisposableStore;
 
 	setup(() => {
@@ -442,8 +434,8 @@ suite('Auto Indent On Paste - TypeScript/JavaScript', () => {
 					{ startIndex: 15, value: 0 },
 				]
 			];
-			registerLanguage(instantiationService, languageId, Language.TypeScript, disposables);
-			registerTokens(instantiationService, tokens, languageId, disposables);
+			disposables.add(registerLanguage(instantiationService, languageId));
+			disposables.add(registerTokens(instantiationService, tokens, languageId));
 			const autoIndentOnPasteController = editor.registerAndInstantiateContribution(AutoIndentOnPaste.ID, AutoIndentOnPaste);
 			viewModel.paste(pasteText, true, undefined, 'keyboard');
 			autoIndentOnPasteController.trigger(new Range(1, 1, 4, 16));
@@ -473,7 +465,7 @@ suite('Auto Indent On Paste - TypeScript/JavaScript', () => {
 				'}'
 			].join('\n');
 
-			registerLanguage(instantiationService, languageId, Language.TypeScript, disposables);
+			disposables.add(registerLanguage(instantiationService, languageId));
 			const autoIndentOnPasteController = editor.registerAndInstantiateContribution(AutoIndentOnPaste.ID, AutoIndentOnPaste);
 			viewModel.paste(pasteText, true, undefined, 'keyboard');
 			autoIndentOnPasteController.trigger(new Range(1, 1, 11, 2));
@@ -492,7 +484,7 @@ suite('Auto Indent On Paste - TypeScript/JavaScript', () => {
 		disposables.add(model);
 
 		withTestCodeEditor(model, { autoIndent: 'full' }, (editor, viewModel, instantiationService) => {
-			registerLanguage(instantiationService, languageId, Language.TypeScript, disposables);
+			disposables.add(registerLanguage(instantiationService, languageId));
 			editor.setSelection(new Selection(2, 6, 2, 6));
 			const text = ', null';
 			viewModel.paste(text, true, undefined, 'keyboard');
@@ -520,7 +512,7 @@ suite('Auto Indent On Paste - TypeScript/JavaScript', () => {
 		disposables.add(model);
 
 		withTestCodeEditor(model, { autoIndent: 'full' }, (editor, viewModel, instantiationService) => {
-			registerLanguage(instantiationService, languageId, Language.TypeScript, disposables);
+			disposables.add(registerLanguage(instantiationService, languageId));
 			editor.setSelection(new Selection(5, 24, 5, 34));
 			const text = 'IMacLinuxKeyMapping';
 			viewModel.paste(text, true, undefined, 'keyboard');
@@ -545,7 +537,7 @@ suite('Auto Indent On Paste - TypeScript/JavaScript', () => {
 		disposables.add(model);
 
 		withTestCodeEditor(model, { autoIndent: 'full' }, (editor, viewModel, instantiationService) => {
-			registerLanguage(instantiationService, languageId, Language.TypeScript, disposables);
+			disposables.add(registerLanguage(instantiationService, languageId));
 			const text = [
 				'/*----------------',
 				' *  Copyright (c) ',
@@ -600,8 +592,8 @@ suite('Auto Indent On Paste - TypeScript/JavaScript', () => {
 					{ startIndex: 3, value: 0 },
 				]
 			];
-			registerLanguage(instantiationService, languageId, Language.TypeScript, disposables);
-			registerTokens(instantiationService, tokens, languageId, disposables);
+			disposables.add(registerLanguage(instantiationService, languageId));
+			disposables.add(registerTokens(instantiationService, tokens, languageId));
 			const autoIndentOnPasteController = editor.registerAndInstantiateContribution(AutoIndentOnPaste.ID, AutoIndentOnPaste);
 			viewModel.paste(text, true, undefined, 'keyboard');
 			autoIndentOnPasteController.trigger(new Range(1, 1, 4, 4));
@@ -628,7 +620,7 @@ suite('Auto Indent On Paste - TypeScript/JavaScript', () => {
 				'}',
 				''
 			].join('\n');
-			registerLanguage(instantiationService, languageId, Language.TypeScript, disposables);
+			disposables.add(registerLanguage(instantiationService, languageId));
 			const autoIndentOnPasteController = editor.registerAndInstantiateContribution(AutoIndentOnPaste.ID, AutoIndentOnPaste);
 			viewModel.paste(text, true, undefined, 'keyboard');
 			autoIndentOnPasteController.trigger(new Range(2, 1, 5, 1));
@@ -670,7 +662,7 @@ suite('Auto Indent On Paste - TypeScript/JavaScript', () => {
 				'}',
 				' '
 			].join('\n');
-			registerLanguage(instantiationService, languageId, Language.TypeScript, disposables);
+			disposables.add(registerLanguage(instantiationService, languageId));
 			const autoIndentOnPasteController = editor.registerAndInstantiateContribution(AutoIndentOnPaste.ID, AutoIndentOnPaste);
 			viewModel.paste(text, true, undefined, 'keyboard');
 			// todo@aiday-mar, make sure range is correct, and make test work as in real life
@@ -701,7 +693,7 @@ suite('Auto Indent On Paste - TypeScript/JavaScript', () => {
 				'return subsent;',
 				'}',
 			].join('\n');
-			registerLanguage(instantiationService, languageId, Language.TypeScript, disposables);
+			disposables.add(registerLanguage(instantiationService, languageId));
 			const autoIndentOnPasteController = editor.registerAndInstantiateContribution(AutoIndentOnPaste.ID, AutoIndentOnPaste);
 			viewModel.paste(text, true, undefined, 'keyboard');
 			// todo@aiday-mar, make sure range is correct, and make test work as in real life
@@ -733,15 +725,15 @@ suite('Auto Indent On Paste - TypeScript/JavaScript', () => {
 				[{ startIndex: 0, value: 0 }, { startIndex: 5, value: 0 }, { startIndex: 6, value: 0 }, { startIndex: 9, value: 0 }, { startIndex: 10, value: 0 }, { startIndex: 11, value: 0 }, { startIndex: 12, value: 0 }, { startIndex: 14, value: 0 }],
 				[{ startIndex: 0, value: 0 }, { startIndex: 1, value: 0 }]
 			];
-			registerLanguage(instantiationService, languageId, Language.TypeScript, disposables);
-			registerTokens(instantiationService, tokens, languageId, disposables);
+			disposables.add(registerLanguage(instantiationService, languageId));
+			disposables.add(registerTokens(instantiationService, tokens, languageId));
 
 			editor.setSelection(new Selection(2, 1, 2, 1));
 			const text = [
 				'// comment',
 				'const foo = 42',
 			].join('\n');
-			registerLanguage(instantiationService, languageId, Language.TypeScript, disposables);
+			disposables.add(registerLanguage(instantiationService, languageId));
 			const autoIndentOnPasteController = editor.registerAndInstantiateContribution(AutoIndentOnPaste.ID, AutoIndentOnPaste);
 			viewModel.paste(text, true, undefined, 'keyboard');
 			autoIndentOnPasteController.trigger(new Range(2, 1, 3, 15));
@@ -757,7 +749,7 @@ suite('Auto Indent On Paste - TypeScript/JavaScript', () => {
 
 suite('Auto Indent On Type - TypeScript/JavaScript', () => {
 
-	const languageId = "ts-test";
+	const languageId = Language.TypeScript;
 	let disposables: DisposableStore;
 
 	setup(() => {
@@ -780,7 +772,7 @@ suite('Auto Indent On Type - TypeScript/JavaScript', () => {
 		disposables.add(model);
 
 		withTestCodeEditor(model, { autoIndent: "full" }, (editor, viewModel, instantiationService) => {
-			registerLanguage(instantiationService, languageId, Language.TypeScript, disposables);
+			disposables.add(registerLanguage(instantiationService, languageId));
 			viewModel.type('const add1 = (n) =>');
 			viewModel.type("\n", 'keyboard');
 			assert.strictEqual(model.getValue(), [
@@ -802,7 +794,7 @@ suite('Auto Indent On Type - TypeScript/JavaScript', () => {
 		disposables.add(model);
 
 		withTestCodeEditor(model, { autoIndent: "full" }, (editor, viewModel, instantiationService) => {
-			registerLanguage(instantiationService, languageId, Language.TypeScript, disposables);
+			disposables.add(registerLanguage(instantiationService, languageId));
 			editor.setSelection(new Selection(3, 9, 3, 9));
 			viewModel.type("\n", 'keyboard');
 			assert.strictEqual(model.getValue(), [
@@ -823,7 +815,7 @@ suite('Auto Indent On Type - TypeScript/JavaScript', () => {
 
 		withTestCodeEditor(model, { autoIndent: "full" }, (editor, viewModel, instantiationService) => {
 
-			registerLanguage(instantiationService, languageId, Language.TypeScript, disposables);
+			disposables.add(registerLanguage(instantiationService, languageId));
 
 			viewModel.type([
 				'const add1 = (n) =>',
@@ -852,7 +844,7 @@ suite('Auto Indent On Type - TypeScript/JavaScript', () => {
 
 		withTestCodeEditor(model, { autoIndent: "full" }, (editor, viewModel, instantiationService) => {
 
-			registerLanguage(instantiationService, languageId, Language.TypeScript, disposables);
+			disposables.add(registerLanguage(instantiationService, languageId));
 			editor.setSelection(new Selection(3, 1, 3, 1));
 			viewModel.type('\n', 'keyboard');
 			assert.strictEqual(model.getValue(), [
@@ -882,7 +874,7 @@ suite('Auto Indent On Type - TypeScript/JavaScript', () => {
 		disposables.add(model);
 
 		withTestCodeEditor(model, { autoIndent: 'advanced' }, (editor, viewModel, instantiationService) => {
-			registerLanguage(instantiationService, languageId, Language.TypeScript, disposables);
+			disposables.add(registerLanguage(instantiationService, languageId));
 			editor.setSelection(new Selection(7, 6, 7, 6));
 			viewModel.type('\n', 'keyboard');
 			assert.strictEqual(model.getValue(),
@@ -913,7 +905,7 @@ suite('Auto Indent On Type - TypeScript/JavaScript', () => {
 		disposables.add(model);
 
 		withTestCodeEditor(model, { autoIndent: 'advanced' }, (editor, viewModel, instantiationService) => {
-			registerLanguage(instantiationService, languageId, Language.TypeScript, disposables);
+			disposables.add(registerLanguage(instantiationService, languageId));
 			editor.setSelection(new Selection(1, 4, 1, 4));
 			viewModel.type('\n', 'keyboard');
 			assert.strictEqual(model.getValue(),
@@ -939,7 +931,7 @@ suite('Auto Indent On Type - TypeScript/JavaScript', () => {
 		disposables.add(model);
 
 		withTestCodeEditor(model, { autoIndent: "full" }, (editor, viewModel, instantiationService) => {
-			registerLanguage(instantiationService, languageId, Language.TypeScript, disposables);
+			disposables.add(registerLanguage(instantiationService, languageId));
 			editor.setSelection(new Selection(2, 12, 2, 12));
 			viewModel.type("\n", 'keyboard');
 			assert.strictEqual(model.getValue(), [
@@ -964,7 +956,7 @@ suite('Auto Indent On Type - TypeScript/JavaScript', () => {
 
 		withTestCodeEditor(model, { autoIndent: "full" }, (editor, viewModel, instantiationService) => {
 
-			registerLanguage(instantiationService, languageId, Language.TypeScript, disposables);
+			disposables.add(registerLanguage(instantiationService, languageId));
 			editor.setSelection(new Selection(2, 19, 2, 19));
 			viewModel.type("\n", 'keyboard');
 			assert.strictEqual(model.getValue(), [
@@ -1001,7 +993,7 @@ suite('Auto Indent On Type - TypeScript/JavaScript', () => {
 
 		withTestCodeEditor(model, { autoIndent: "full" }, (editor, viewModel, instantiationService) => {
 
-			registerLanguage(instantiationService, languageId, Language.TypeScript, disposables);
+			disposables.add(registerLanguage(instantiationService, languageId));
 			editor.setSelection(new Selection(2, 23, 2, 23));
 			viewModel.type("\n", 'keyboard');
 			assert.strictEqual(model.getValue(), [
@@ -1027,7 +1019,7 @@ suite('Auto Indent On Type - TypeScript/JavaScript', () => {
 		disposables.add(model);
 
 		withTestCodeEditor(model, { autoIndent: "full" }, (editor, viewModel, instantiationService) => {
-			registerLanguage(instantiationService, languageId, Language.TypeScript, disposables);
+			disposables.add(registerLanguage(instantiationService, languageId));
 			editor.setSelection(new Selection(1, 14, 1, 14));
 			viewModel.type("\n", 'keyboard');
 			assert.strictEqual(model.getValue(), [
@@ -1051,7 +1043,7 @@ suite('Auto Indent On Type - TypeScript/JavaScript', () => {
 		disposables.add(model);
 
 		withTestCodeEditor(model, { autoIndent: "full" }, (editor, viewModel, instantiationService) => {
-			registerLanguage(instantiationService, languageId, Language.TypeScript, disposables);
+			disposables.add(registerLanguage(instantiationService, languageId));
 			editor.setSelection(new Selection(2, 7, 2, 7));
 			viewModel.type("\n", 'keyboard');
 			assert.strictEqual(model.getValue(), [
@@ -1075,7 +1067,7 @@ suite('Auto Indent On Type - TypeScript/JavaScript', () => {
 		disposables.add(model);
 
 		withTestCodeEditor(model, { autoIndent: "full" }, (editor, viewModel, instantiationService) => {
-			registerLanguage(instantiationService, languageId, Language.TypeScript, disposables);
+			disposables.add(registerLanguage(instantiationService, languageId));
 			editor.setSelection(new Selection(2, 7, 2, 7));
 			viewModel.type("\n", 'keyboard');
 			viewModel.type(".");
@@ -1100,7 +1092,7 @@ suite('Auto Indent On Type - TypeScript/JavaScript', () => {
 		disposables.add(model);
 
 		withTestCodeEditor(model, { autoIndent: "full" }, (editor, viewModel, instantiationService) => {
-			registerLanguage(instantiationService, languageId, Language.TypeScript, disposables);
+			disposables.add(registerLanguage(instantiationService, languageId));
 			editor.setSelection(new Selection(2, 24, 2, 24));
 			viewModel.type("\n", 'keyboard');
 			assert.strictEqual(model.getValue(), [
@@ -1126,7 +1118,7 @@ suite('Auto Indent On Type - TypeScript/JavaScript', () => {
 		disposables.add(model);
 
 		withTestCodeEditor(model, { autoIndent: "full" }, (editor, viewModel, instantiationService) => {
-			registerLanguage(instantiationService, languageId, Language.TypeScript, disposables);
+			disposables.add(registerLanguage(instantiationService, languageId));
 			editor.setSelection(new Selection(3, 5, 3, 5));
 			viewModel.type(".");
 			assert.strictEqual(model.getValue(), [
@@ -1150,7 +1142,7 @@ suite('Auto Indent On Type - TypeScript/JavaScript', () => {
 		disposables.add(model);
 
 		withTestCodeEditor(model, { autoIndent: "full" }, (editor, viewModel, instantiationService) => {
-			registerLanguage(instantiationService, languageId, Language.TypeScript, disposables);
+			disposables.add(registerLanguage(instantiationService, languageId));
 			editor.setSelection(new Selection(2, 25, 2, 25));
 			viewModel.type("\n", 'keyboard');
 			assert.strictEqual(model.getValue(), [
@@ -1171,7 +1163,7 @@ suite('Auto Indent On Type - TypeScript/JavaScript', () => {
 
 		withTestCodeEditor(model, { autoIndent: "full" }, (editor, viewModel, instantiationService) => {
 
-			registerLanguage(instantiationService, languageId, Language.TypeScript, disposables);
+			disposables.add(registerLanguage(instantiationService, languageId));
 
 			editor.setSelection(new Selection(1, 17, 1, 17));
 			viewModel.type("\n", 'keyboard');
@@ -1205,7 +1197,7 @@ suite('Auto Indent On Type - TypeScript/JavaScript', () => {
 
 		withTestCodeEditor(model, { autoIndent: "full" }, (editor, viewModel, instantiationService) => {
 
-			registerLanguage(instantiationService, languageId, Language.TypeScript, disposables);
+			disposables.add(registerLanguage(instantiationService, languageId));
 			editor.setSelection(new Selection(3, 14, 3, 14));
 			viewModel.type("\n", 'keyboard');
 			assert.strictEqual(model.getValue(), [
@@ -1233,7 +1225,7 @@ suite('Auto Indent On Type - TypeScript/JavaScript', () => {
 
 		withTestCodeEditor(model, { autoIndent: "full" }, (editor, viewModel, instantiationService) => {
 
-			registerLanguage(instantiationService, languageId, Language.TypeScript, disposables);
+			disposables.add(registerLanguage(instantiationService, languageId));
 			editor.setSelection(new Selection(4, 1, 4, 1));
 			viewModel.type("}", 'keyboard');
 			assert.strictEqual(model.getValue(), [
@@ -1257,7 +1249,7 @@ suite('Auto Indent On Type - TypeScript/JavaScript', () => {
 
 		withTestCodeEditor(model, { autoIndent: "full" }, (editor, viewModel, instantiationService) => {
 
-			registerLanguage(instantiationService, languageId, Language.TypeScript, disposables);
+			disposables.add(registerLanguage(instantiationService, languageId));
 			editor.setSelection(new Selection(2, 5, 2, 5));
 			viewModel.type("{}", 'keyboard');
 			assert.strictEqual(model.getValue(), [
@@ -1287,7 +1279,7 @@ suite('Auto Indent On Type - TypeScript/JavaScript', () => {
 		disposables.add(model);
 
 		withTestCodeEditor(model, { autoIndent: "keep" }, (editor, viewModel, instantiationService) => {
-			registerLanguage(instantiationService, languageId, Language.TypeScript, disposables);
+			disposables.add(registerLanguage(instantiationService, languageId));
 			editor.setSelection(new Selection(2, 5, 2, 5));
 			viewModel.type("}", 'keyboard');
 			assert.strictEqual(model.getValue(), [
@@ -1300,7 +1292,7 @@ suite('Auto Indent On Type - TypeScript/JavaScript', () => {
 
 suite('Auto Indent On Type - Ruby', () => {
 
-	const languageId = "ruby-test";
+	const languageId = Language.Ruby;
 	let disposables: DisposableStore;
 
 	setup(() => {
@@ -1322,7 +1314,7 @@ suite('Auto Indent On Type - Ruby', () => {
 
 		withTestCodeEditor(model, { autoIndent: "full" }, (editor, viewModel, instantiationService) => {
 
-			registerLanguage(instantiationService, languageId, Language.Ruby, disposables);
+			disposables.add(registerLanguage(instantiationService, languageId));
 
 			viewModel.type("def foo\n        i");
 			viewModel.type("n", 'keyboard');
@@ -1350,7 +1342,7 @@ suite('Auto Indent On Type - Ruby', () => {
 
 		withTestCodeEditor(model, { autoIndent: "full" }, (editor, viewModel, instantiationService) => {
 
-			registerLanguage(instantiationService, languageId, Language.Ruby, disposables);
+			disposables.add(registerLanguage(instantiationService, languageId));
 
 			viewModel.type("method('#foo') do");
 			viewModel.type("\n", 'keyboard');
@@ -1364,7 +1356,7 @@ suite('Auto Indent On Type - Ruby', () => {
 
 suite('Auto Indent On Type - PHP', () => {
 
-	const languageId = "php-test";
+	const languageId = Language.PHP;
 	let disposables: DisposableStore;
 
 	setup(() => {
@@ -1390,7 +1382,7 @@ suite('Auto Indent On Type - PHP', () => {
 
 		withTestCodeEditor(model, { autoIndent: "full" }, (editor, viewModel, instantiationService) => {
 
-			registerLanguage(instantiationService, languageId, Language.PHP, disposables);
+			disposables.add(registerLanguage(instantiationService, languageId));
 			editor.setSelection(new Selection(1, 54, 1, 54));
 			viewModel.type("\n", 'keyboard');
 			assert.strictEqual(model.getValue(), [
@@ -1403,7 +1395,7 @@ suite('Auto Indent On Type - PHP', () => {
 
 suite('Auto Indent On Paste - Go', () => {
 
-	const languageId = "go-test";
+	const languageId = Language.Go;
 	let disposables: DisposableStore;
 
 	setup(() => {
@@ -1433,7 +1425,7 @@ suite('Auto Indent On Paste - Go', () => {
 		disposables.add(model);
 
 		withTestCodeEditor(model, { autoIndent: "full" }, (editor, viewModel, instantiationService) => {
-			registerLanguage(instantiationService, languageId, Language.Go, disposables);
+			disposables.add(registerLanguage(instantiationService, languageId));
 			editor.setSelection(new Selection(3, 1, 3, 1));
 			const text = '  ';
 			const autoIndentOnPasteController = editor.registerAndInstantiateContribution(AutoIndentOnPaste.ID, AutoIndentOnPaste);
@@ -1451,7 +1443,7 @@ suite('Auto Indent On Paste - Go', () => {
 
 suite('Auto Indent On Type - CPP', () => {
 
-	const languageId = "cpp-test";
+	const languageId = Language.CPP;
 	let disposables: DisposableStore;
 
 	setup(() => {
@@ -1479,7 +1471,7 @@ suite('Auto Indent On Type - CPP', () => {
 		disposables.add(model);
 
 		withTestCodeEditor(model, { autoIndent: "full" }, (editor, viewModel, instantiationService) => {
-			registerLanguage(instantiationService, languageId, Language.CPP, disposables);
+			disposables.add(registerLanguage(instantiationService, languageId));
 			editor.setSelection(new Selection(2, 20, 2, 20));
 			viewModel.type("\n", 'keyboard');
 			assert.strictEqual(model.getValue(), [
@@ -1502,7 +1494,7 @@ suite('Auto Indent On Type - CPP', () => {
 		disposables.add(model);
 
 		withTestCodeEditor(model, { autoIndent: "full" }, (editor, viewModel, instantiationService) => {
-			registerLanguage(instantiationService, languageId, Language.CPP, disposables);
+			disposables.add(registerLanguage(instantiationService, languageId));
 			editor.setSelection(new Selection(1, 20, 1, 20));
 			viewModel.type("\n", 'keyboard');
 			assert.strictEqual(model.getValue(), [
@@ -1525,7 +1517,7 @@ suite('Auto Indent On Type - CPP', () => {
 
 		withTestCodeEditor(model, { autoIndent: "none" }, (editor, viewModel, instantiationService) => {
 
-			registerLanguage(instantiationService, languageId, Language.CPP, disposables);
+			disposables.add(registerLanguage(instantiationService, languageId));
 			editor.setSelection(new Selection(2, 3, 2, 3));
 			viewModel.type("}", 'keyboard');
 			assert.strictEqual(model.getValue(), [
@@ -1539,7 +1531,7 @@ suite('Auto Indent On Type - CPP', () => {
 
 suite('Auto Indent On Type - HTML', () => {
 
-	const languageId = "html-test";
+	const languageId = Language.HTML;
 	let disposables: DisposableStore;
 
 	setup(() => {
@@ -1568,7 +1560,7 @@ suite('Auto Indent On Type - HTML', () => {
 		disposables.add(model);
 
 		withTestCodeEditor(model, { autoIndent: "full" }, (editor, viewModel, instantiationService) => {
-			registerLanguage(instantiationService, languageId, Language.HTML, disposables);
+			disposables.add(registerLanguage(instantiationService, languageId));
 			editor.setSelection(new Selection(2, 48, 2, 48));
 			viewModel.type("\n", 'keyboard');
 			assert.strictEqual(model.getValue(), [
@@ -1583,7 +1575,7 @@ suite('Auto Indent On Type - HTML', () => {
 
 suite('Auto Indent On Type - Visual Basic', () => {
 
-	const languageId = "vb-test";
+	const languageId = Language.VB;
 	let disposables: DisposableStore;
 
 	setup(() => {
@@ -1612,7 +1604,7 @@ suite('Auto Indent On Type - Visual Basic', () => {
 		disposables.add(model);
 
 		withTestCodeEditor(model, { autoIndent: "full" }, (editor, viewModel, instantiationService) => {
-			registerLanguage(instantiationService, languageId, Language.VB, disposables);
+			disposables.add(registerLanguage(instantiationService, languageId));
 			editor.setSelection(new Selection(3, 10, 3, 10));
 			viewModel.type("f", 'keyboard');
 			assert.strictEqual(model.getValue(), [
@@ -1627,7 +1619,7 @@ suite('Auto Indent On Type - Visual Basic', () => {
 
 suite('Auto Indent On Type - Latex', () => {
 
-	const languageId = "latex-test";
+	const languageId = Language.Latex;
 	let disposables: DisposableStore;
 
 	setup(() => {
@@ -1655,7 +1647,7 @@ suite('Auto Indent On Type - Latex', () => {
 		disposables.add(model);
 
 		withTestCodeEditor(model, { autoIndent: "full" }, (editor, viewModel, instantiationService) => {
-			registerLanguage(instantiationService, languageId, Language.Latex, disposables);
+			disposables.add(registerLanguage(instantiationService, languageId));
 			editor.setSelection(new Selection(2, 9, 2, 9));
 			viewModel.type("{", 'keyboard');
 			assert.strictEqual(model.getValue(), [
@@ -1668,7 +1660,7 @@ suite('Auto Indent On Type - Latex', () => {
 
 suite('Auto Indent On Type - Lua', () => {
 
-	const languageId = "lua-test";
+	const languageId = Language.Lua;
 	let disposables: DisposableStore;
 
 	setup(() => {
@@ -1695,7 +1687,7 @@ suite('Auto Indent On Type - Lua', () => {
 		disposables.add(model);
 
 		withTestCodeEditor(model, { autoIndent: "full" }, (editor, viewModel, instantiationService) => {
-			registerLanguage(instantiationService, languageId, Language.Lua, disposables);
+			disposables.add(registerLanguage(instantiationService, languageId));
 			editor.setSelection(new Selection(1, 28, 1, 28));
 			viewModel.type("\n", 'keyboard');
 			assert.strictEqual(model.getValue(), [

--- a/src/vs/editor/contrib/indentation/test/browser/indentation.test.ts
+++ b/src/vs/editor/contrib/indentation/test/browser/indentation.test.ts
@@ -110,7 +110,7 @@ function registerLanguageConfiguration(instantiationService: TestInstantiationSe
 	}
 }
 
-function registerTokens(instantiationService: TestInstantiationService, tokens: { startIndex: number; value: number }[][], languageId: string): IDisposable {
+function registerTokenizationSupport(instantiationService: TestInstantiationService, tokens: { startIndex: number; value: number }[][], languageId: string): IDisposable {
 	let lineIndex = 0;
 	const languageService = instantiationService.get(ILanguageService);
 	const tokenizationSupport: ITokenizationSupport = {
@@ -435,7 +435,7 @@ suite('Auto Indent On Paste - TypeScript/JavaScript', () => {
 				]
 			];
 			disposables.add(registerLanguage(instantiationService, languageId));
-			disposables.add(registerTokens(instantiationService, tokens, languageId));
+			disposables.add(registerTokenizationSupport(instantiationService, tokens, languageId));
 			const autoIndentOnPasteController = editor.registerAndInstantiateContribution(AutoIndentOnPaste.ID, AutoIndentOnPaste);
 			viewModel.paste(pasteText, true, undefined, 'keyboard');
 			autoIndentOnPasteController.trigger(new Range(1, 1, 4, 16));
@@ -593,7 +593,7 @@ suite('Auto Indent On Paste - TypeScript/JavaScript', () => {
 				]
 			];
 			disposables.add(registerLanguage(instantiationService, languageId));
-			disposables.add(registerTokens(instantiationService, tokens, languageId));
+			disposables.add(registerTokenizationSupport(instantiationService, tokens, languageId));
 			const autoIndentOnPasteController = editor.registerAndInstantiateContribution(AutoIndentOnPaste.ID, AutoIndentOnPaste);
 			viewModel.paste(text, true, undefined, 'keyboard');
 			autoIndentOnPasteController.trigger(new Range(1, 1, 4, 4));
@@ -726,7 +726,7 @@ suite('Auto Indent On Paste - TypeScript/JavaScript', () => {
 				[{ startIndex: 0, value: 0 }, { startIndex: 1, value: 0 }]
 			];
 			disposables.add(registerLanguage(instantiationService, languageId));
-			disposables.add(registerTokens(instantiationService, tokens, languageId));
+			disposables.add(registerTokenizationSupport(instantiationService, tokens, languageId));
 
 			editor.setSelection(new Selection(2, 1, 2, 1));
 			const text = [


### PR DESCRIPTION
This PR is a refactoring PR. It contains two main changes:

- `registerLanguage` and `registerTokenizationSupport` now return IDisposables instead of taking a disposable store as a parameter
- The Language enum in the file is reused, in order to avoid having a language ID and a separate Language enum value in the calls to `registerLanguage` and `registerLanguageConfiguration`