### PR TITLE
get the editor from the context for cases that its not the focused editor

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/controller/cellOutputActions.ts
+++ b/src/vs/workbench/contrib/notebook/browser/controller/cellOutputActions.ts
@@ -33,9 +33,15 @@ registerAction2(class CopyCellOutputAction extends Action2 {
 		});
 	}
 
+	private getNoteboookEditor(editorService: IEditorService, outputContext: INotebookOutputActionContext | { outputViewModel: ICellOutputViewModel } | undefined): INotebookEditor | undefined {
+		if (outputContext && 'notebookEditor' in outputContext) {
+			return outputContext.notebookEditor;
+		}
+		return getNotebookEditorFromEditorPane(editorService.activeEditorPane);
+	}
+
 	async run(accessor: ServicesAccessor, outputContext: INotebookOutputActionContext | { outputViewModel: ICellOutputViewModel } | undefined): Promise<void> {
-		const editorService = accessor.get(IEditorService);
-		const notebookEditor = getNotebookEditorFromEditorPane(editorService.activeEditorPane);
+		const notebookEditor = this.getNoteboookEditor(accessor.get(IEditorService), outputContext);
 
 		if (!notebookEditor) {
 			return;

--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewPreloads.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewPreloads.ts
@@ -1598,31 +1598,24 @@ async function webviewPreloads(ctx: PreloadContext) {
 
 			if (image) {
 				const imageToCopy = image;
-				async function copyImage(retries: number) {
-					await navigator.clipboard.write([new ClipboardItem({
-						'image/png': new Promise((resolve) => {
-							const canvas = document.createElement('canvas');
-							canvas.width = imageToCopy.naturalWidth;
-							canvas.height = imageToCopy.naturalHeight;
-							const context = canvas.getContext('2d');
-							context!.drawImage(imageToCopy, 0, 0);
+				await navigator.clipboard.write([new ClipboardItem({
+					'image/png': new Promise((resolve) => {
+						const canvas = document.createElement('canvas');
+						canvas.width = imageToCopy.naturalWidth;
+						canvas.height = imageToCopy.naturalHeight;
+						const context = canvas.getContext('2d');
+						context!.drawImage(imageToCopy, 0, 0);
 
-							canvas.toBlob((blob) => {
-								if (blob) {
-									resolve(blob);
-								} else if (retries > 0) {
-									setTimeout(() => { copyImage(retries - 1); }, 20);
-									return;
-								} else {
-									console.error('No blob data to write to clipboard');
-								}
-								canvas.remove();
-							}, 'image/png');
-						})
-					})]);
-				}
-
-				copyImage(retries);
+						canvas.toBlob((blob) => {
+							if (blob) {
+								resolve(blob);
+							} else {
+								console.error('No blob data to write to clipboard');
+							}
+							canvas.remove();
+						}, 'image/png');
+					})
+				})]);
 			} else {
 				console.error('Could not find image element to copy for output with id', outputId);
 			}


### PR DESCRIPTION
fix https://github.com/microsoft/vscode/issues/205462

- you can select an option from the output menu without giving the editor focus, but the editor is in the context in that case.
- also allow more time for retrying for focus to reduce some flakiness.