### PR TITLE
reset code action state for lightbulb widget and auto triggers

### DIFF
--- a/src/vs/editor/contrib/codeAction/browser/codeActionModel.ts
+++ b/src/vs/editor/contrib/codeAction/browser/codeActionModel.ts
@@ -334,6 +334,11 @@ export class CodeActionModel extends Disposable {
 				// Do not trigger state if current state is manual and incoming state is automatic
 				if (!isManualToAutoTransition) {
 					this.setState(newState);
+				} else {
+					// Reset the new state after getting code actions back.
+					setTimeout(() => {
+						this.setState(newState);
+					}, 500);
 				}
 			}, undefined);
 			this._codeActionOracle.value.trigger({ type: CodeActionTriggerType.Auto, triggerAction: CodeActionTriggerSource.Default });


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

fixes https://github.com/microsoft/vscode/issues/210817

in a previous PR, we introduced a 500ms wait for code actions in certain scenarios (quickly typed -> triggered). this ensures that after triggering, we reset the code action state to an "default" state. 