### PR TITLE
Fixes potential range out of bounds bug.

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/codeBlockPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/codeBlockPart.ts
@@ -54,12 +54,12 @@ import { ILabelService } from 'vs/platform/label/common/label';
 import { renderFormattedText } from 'vs/base/browser/formattedTextRenderer';
 import { IOpenerService } from 'vs/platform/opener/common/opener';
 import { IChatResponseModel, IChatTextEditGroup } from 'vs/workbench/contrib/chat/common/chatModel';
-import { EditOperation, ISingleEditOperation } from 'vs/editor/common/core/editOperation';
 import { TextEdit } from 'vs/editor/common/languages';
 import { ICodeEditorService } from 'vs/editor/browser/services/codeEditorService';
 import { isEqual } from 'vs/base/common/resources';
 import { DefaultModelSHA1Computer } from 'vs/editor/common/services/modelService';
 import { IDialogService } from 'vs/platform/dialogs/common/dialogs';
+import { TextModelText } from 'vs/editor/common/model/textModelText';
 
 const $ = dom.$;
 
@@ -820,12 +820,8 @@ export class DefaultChatTextEditor {
 			return 0;
 		}
 
-		const edits: ISingleEditOperation[] = [];
-		for (const item of diff.changes2) {
-			const range = item.original.toExclusiveRange();
-			const newText = model.modified.getValueInRange(item.modified.toExclusiveRange());
-			edits.push(EditOperation.replace(range, newText));
-		}
+		const modified = new TextModelText(model.modified);
+		const edits = diff.changes2.map(i => i.toRangeMapping().toTextEdit(modified).toSingleEditOperation());
 
 		model.original.pushStackElement();
 		model.original.pushEditOperations(null, edits, () => null);


### PR DESCRIPTION
There could be an original line range `[3, 3)` for a document that has 2 lines. That line range would mean that some lines are appended to the document - in which case `toExclusiveRange` would create a range with start and end positions outside the valid document range. This either throws or causes buggy behavior.

`toRangeMapping` converts the line range mapping to a range mapping and considers these edge-cases. The range mapping then has a method to convert the mapping to an edit.
At some point, I want to remove `toExclusiveRange` - for now, I marked it as deprecated.
Instead, `toInclusiveRange` should be used, which can return null in case of an empty line range (which cannot really be represented by a normal range).