### PR TITLE
Keyboard Shortcut to Reset Bottom Pane to Original Position

### DIFF
--- a/src/vs/workbench/browser/actions/layoutActions.ts
+++ b/src/vs/workbench/browser/actions/layoutActions.ts
@@ -1145,6 +1145,28 @@ registerAction2(class extends Action2 {
 	}
 });
 
+// --- Reset Bottom Pane Size
+
+registerAction2(class extends Action2 {
+
+	constructor() {
+		super({
+			id: 'workbench.action.resetBottomPane',
+			title: localize2('resetBottomPane', 'Reset Bottom Pane Size'),
+			category: Categories.View,
+			f1: true,
+			keybinding: {
+				weight: KeybindingWeight.WorkbenchContrib,
+				primary: KeyChord(KeyMod.CtrlCmd | KeyCode.KeyK, KeyCode.KeyL)
+			},
+		});
+	}
+
+	run(accessor: ServicesAccessor): void {
+		return accessor.get(IWorkbenchLayoutService).resetBottomPane();
+	}
+});
+
 // --- Resize View
 
 abstract class BaseResizeViewAction extends Action2 {

--- a/src/vs/workbench/browser/layout.ts
+++ b/src/vs/workbench/browser/layout.ts
@@ -1463,6 +1463,8 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 		this.workbenchGrid.setViewVisible(this.statusBarPartView, !hidden);
 	}
 
+	resetBottomPane(): void { }
+
 	protected createWorkbenchLayout(): void {
 		const titleBar = this.getPart(Parts.TITLEBAR_PART);
 		const bannerPart = this.getPart(Parts.BANNER_PART);

--- a/src/vs/workbench/services/layout/browser/layoutService.ts
+++ b/src/vs/workbench/services/layout/browser/layoutService.ts
@@ -309,6 +309,11 @@ export interface IWorkbenchLayoutService extends ILayoutService {
 	 * Returns the next visible view part in a given direction in the main window.
 	 */
 	getVisibleNeighborPart(part: Parts, direction: Direction): Parts | undefined;
+
+	/**
+	 * Resets the size of the bottom pane.
+	 */
+	resetBottomPane(): void;
 }
 
 export function shouldShowCustomTitleBar(configurationService: IConfigurationService, window: Window, menuBarToggled?: boolean): boolean {

--- a/src/vs/workbench/test/browser/workbenchTestServices.ts
+++ b/src/vs/workbench/test/browser/workbenchTestServices.ts
@@ -660,6 +660,7 @@ export class TestLayoutService implements IWorkbenchLayoutService {
 	isWindowMaximized(targetWindow: Window) { return false; }
 	updateWindowMaximizedState(targetWindow: Window, maximized: boolean): void { }
 	getVisibleNeighborPart(part: Parts, direction: Direction): Parts | undefined { return undefined; }
+	resetBottomPane(): void { }
 	focus() { }
 }
 


### PR DESCRIPTION
Issue: (https://github.com/microsoft/vscode/issues/207928)

The proposed change implements a keyboard shortcut that allows the user to reset the bottom pane to its original location, rather than requiring them to double-click on the edge of the pane.

