### PR TITLE
Making HoverContext fields readonly

### DIFF
--- a/src/vscode-dts/vscode.proposed.editorHoverVerbosityLevel.d.ts
+++ b/src/vscode-dts/vscode.proposed.editorHoverVerbosityLevel.d.ts
@@ -35,12 +35,12 @@ declare module 'vscode' {
 		/**
 		 * Whether to increase or decrease the hover's verbosity
 		 */
-		action?: HoverVerbosityAction;
+		readonly action?: HoverVerbosityAction;
 
 		/**
 		 * The previous hover sent for the same position
 		 */
-		previousHover?: Hover;
+		readonly previousHover?: Hover;
 	}
 
 	export enum HoverVerbosityAction {


### PR DESCRIPTION
In relation to https://github.com/microsoft/vscode/issues/211150

making HoverContext fields readonly
