### PR TITLE
Fix bug where ending drag on a menu item causes click in Firefox

### DIFF
--- a/src/vs/base/browser/ui/splitview/paneview.ts
+++ b/src/vs/base/browser/ui/splitview/paneview.ts
@@ -78,6 +78,8 @@ export abstract class Pane extends Disposable implements IView {
 	private readonly _onDidChangeExpansionState = this._register(new Emitter<boolean>());
 	readonly onDidChangeExpansionState: Event<boolean> = this._onDidChangeExpansionState.event;
 
+	private _canClick: boolean = true;
+
 	get ariaHeaderLabel(): string {
 		return this._ariaHeaderLabel;
 	}
@@ -271,11 +273,21 @@ export abstract class Pane extends Disposable implements IView {
 
 		[EventType.CLICK, TouchEventType.Tap].forEach(eventType => {
 			this._register(addDisposableListener(this.header, eventType, e => {
-				if (!e.defaultPrevented) {
+				if (!e.defaultPrevented && this._canClick) {
 					this.setExpanded(!this.isExpanded());
 				}
 			}));
 		});
+
+		if (isFirefox) {
+			this._canClick = false;
+			this._register(addDisposableListener(this.header, EventType.MOUSE_LEAVE, e => {
+				this._canClick = false;
+			}));
+			this._register(addDisposableListener(this.header, EventType.MOUSE_OVER, e => {
+				this._canClick = true;
+			}));
+		}
 
 		this.body = append(this.element, $('.pane-body'));
 

--- a/src/vs/platform/actions/browser/menuEntryActionViewItem.ts
+++ b/src/vs/platform/actions/browser/menuEntryActionViewItem.ts
@@ -200,6 +200,7 @@ export class MenuEntryActionViewItem extends ActionViewItem {
 
 			updateAltState();
 		}
+
 	}
 
 	protected override updateLabel(): void {

--- a/src/vs/workbench/browser/parts/compositeBarActions.ts
+++ b/src/vs/workbench/browser/parts/compositeBarActions.ts
@@ -27,6 +27,7 @@ import { HoverPosition } from 'vs/base/browser/ui/hover/hoverWidget';
 import { URI } from 'vs/base/common/uri';
 import { badgeBackground, badgeForeground, contrastBorder } from 'vs/platform/theme/common/colorRegistry';
 import type { IHoverWidget } from 'vs/base/browser/ui/hover/hover';
+import { isFirefox } from 'vs/base/common/platform';
 
 export interface ICompositeBar {
 
@@ -268,6 +269,17 @@ export class CompositeBarActionViewItem extends BaseActionViewItem {
 		append(container, $('.active-item-indicator'));
 
 		hide(this.badge);
+
+		// Prevent Firefox from triggering a click on mouse up from a draggable element - #180833
+		if (isFirefox && this.element) {
+			this._canClick = false;
+			this._register(addDisposableListener(this.element, EventType.MOUSE_OVER, e => {
+				this._canClick = true;
+			}));
+			this._register(addDisposableListener(this.element, EventType.MOUSE_LEAVE, e => {
+				this._canClick = false;
+			}));
+		}
 
 		this.update();
 		this.updateStyles();

--- a/src/vs/workbench/browser/parts/titlebar/commandCenterControl.ts
+++ b/src/vs/workbench/browser/parts/titlebar/commandCenterControl.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { isActiveDocument, reset } from 'vs/base/browser/dom';
+import { addDisposableListener, EventType, isActiveDocument, reset } from 'vs/base/browser/dom';
 import { BaseActionViewItem, IBaseActionViewItemOptions } from 'vs/base/browser/ui/actionbar/actionViewItems';
 import { getDefaultHoverDelegate } from 'vs/base/browser/ui/hover/hoverDelegateFactory';
 import { IHoverDelegate } from 'vs/base/browser/ui/hover/hoverDelegate';
@@ -22,6 +22,7 @@ import { IQuickInputService } from 'vs/platform/quickinput/common/quickInput';
 import { WindowTitle } from 'vs/workbench/browser/parts/titlebar/windowTitle';
 import { IEditorGroupsService } from 'vs/workbench/services/editor/common/editorGroupsService';
 import { IHoverService } from 'vs/platform/hover/browser/hover';
+import { isFirefox } from 'vs/base/common/platform';
 
 export class CommandCenterControl {
 
@@ -111,7 +112,6 @@ class CommandCenterCenterViewItem extends BaseActionViewItem {
 				groups.push([action]);
 			}
 		}
-
 
 		for (let i = 0; i < groups.length; i++) {
 			const group = groups[i];
@@ -213,6 +213,17 @@ class CommandCenterCenterViewItem extends BaseActionViewItem {
 				icon.style.opacity = '0.5';
 				container.appendChild(icon);
 			}
+		}
+
+		// prevent Firefox from triggering a click on mouse up from a draggable element
+		if (isFirefox && this.element) {
+			this._canClick = false;
+			this._register(addDisposableListener(this.element, EventType.MOUSE_OVER, e => {
+				this._canClick = true;
+			}));
+			this._register(addDisposableListener(this.element, EventType.MOUSE_LEAVE, e => {
+				this._canClick = false;
+			}));
 		}
 	}
 


### PR DESCRIPTION
Fixes #180833 

This PR fixes the bug where dragging and then releasing over a sidebar, status bar, or activity bar activates an unintended click in Firefox.

https://github.com/microsoft/vscode/assets/90876112/e1ea476c-61a7-4603-a254-22f7ae37143d

Fixes the following items
- Activity bar buttons
- Sidebar buttons
- Sidebar dropdowns
- Status bar buttons
- Command center control
- Layout controls toggle buttons

Does not fix the following
- Certain buttons within the 'Search' sidebar panel
- Command center control only when clicking in the center where the text is