### PR TITLE
Lock subsequent hover verbosity requests during hover verbosity request

### DIFF
--- a/src/vs/editor/contrib/hover/browser/hover.css
+++ b/src/vs/editor/contrib/hover/browser/hover.css
@@ -39,6 +39,7 @@
 	padding-right: 5px;
 	justify-content: end;
 	border-right: 1px solid var(--vscode-editorHoverWidget-border);
+	width: 11px;
 }
 
 .monaco-editor .monaco-hover .hover-row .verbosity-actions .codicon {
@@ -52,6 +53,25 @@
 
 .monaco-editor .monaco-hover .hover-row .verbosity-actions .codicon.action-disabled {
 	opacity: 0.6;
+}
+
+.monaco-editor .monaco-hover .hover-row .verbosity-actions .codicon.action-visible {
+	display: block;
+}
+
+.monaco-editor .monaco-hover .hover-row .verbosity-actions .codicon.action-hidden {
+	display: none;
+}
+
+.monaco-editor .monaco-hover .hover-row .verbosity-actions .codicon.codicon-hover-spinner {
+	animation: spin 1500ms cubic-bezier(0.75, 0, 0.25, 1) infinite;
+	font-size: 9px;
+	padding-bottom: 11px;
+}
+
+@keyframes spin {
+	0% { transform: rotate(0deg); }
+	100% { transform: rotate(360deg); }
 }
 
 .monaco-editor .monaco-hover .hover-row .actions {

--- a/src/vs/editor/contrib/hover/browser/hover.css
+++ b/src/vs/editor/contrib/hover/browser/hover.css
@@ -46,11 +46,11 @@
 	font-size: 11px;
 }
 
-.monaco-editor .monaco-hover .hover-row .verbosity-actions .codicon.enabled {
+.monaco-editor .monaco-hover .hover-row .verbosity-actions .codicon.action-enabled {
 	color: var(--vscode-textLink-foreground);
 }
 
-.monaco-editor .monaco-hover .hover-row .verbosity-actions .codicon.disabled {
+.monaco-editor .monaco-hover .hover-row .verbosity-actions .codicon.action-disabled {
 	opacity: 0.6;
 }
 


### PR DESCRIPTION
fixes https://github.com/microsoft/vscode/issues/211157

Currently when a hover verbosity request is being processed, it is still possible to make a new hover verbosity request. The code in this PR changes this so that one is not possible to make a request while another request is still executing. A spinner is shown in the meantime.

https://github.com/microsoft/vscode/assets/61460952/aab098fd-0462-4024-a92d-ccdce375fe28
