### PR TITLE
Fix broken chat layout after reloading window

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadChatAgents2.ts
+++ b/src/vs/workbench/api/browser/mainThreadChatAgents2.ts
@@ -138,7 +138,8 @@ export class MainThreadChatAgents2 extends Disposable implements MainThreadChatA
 					description: dynamicProps.description,
 					extensionId: extension,
 					extensionDisplayName: extensionDescription?.displayName ?? extension.value,
-					extensionPublisher: extensionDescription?.publisherDisplayName ?? extension.value,
+					extensionPublisherId: extensionDescription?.publisher ?? '', // extensionDescription _should_ be present at this point, since this extension is active and registering agents
+					extensionPublisherDisplayName: extensionDescription?.publisherDisplayName,
 					metadata: revive(metadata),
 					slashCommands: [],
 					locations: [ChatAgentLocation.Panel] // TODO all dynamic participants are panel only?

--- a/src/vs/workbench/contrib/chat/browser/chatAgentHover.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatAgentHover.ts
@@ -108,7 +108,7 @@ export class ChatAgentHover extends Disposable {
 
 		this.name.textContent = `@${agent.name}`;
 		this.extensionName.textContent = agent.extensionDisplayName;
-		this.publisherName.textContent = agent.extensionPublisher;
+		this.publisherName.textContent = agent.extensionPublisherDisplayName ?? agent.extensionPublisherId;
 
 		const description = agent.description && !agent.description.endsWith('.') ?
 			`${agent.description}. ` :

--- a/src/vs/workbench/contrib/chat/browser/chatMarkdownDecorationsRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatMarkdownDecorationsRenderer.ts
@@ -42,7 +42,7 @@ export class ChatMarkdownDecorationsRenderer {
 				let text = part.text;
 				const isDupe = this.chatAgentService.getAgentsByName(part.agent.name).length > 1;
 				if (isDupe) {
-					text += ` (${part.agent.extensionPublisher})`;
+					text += ` (${part.agent.extensionPublisherDisplayName})`;
 				}
 
 				result += `[${text}](${agentRefUrl}?${encodeURIComponent(part.agent.id)})`;

--- a/src/vs/workbench/contrib/chat/browser/chatParticipantContributions.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatParticipantContributions.ts
@@ -202,7 +202,8 @@ export class ChatExtensionPointHandler implements IWorkbenchContribution {
 						providerDescriptor.id,
 						{
 							extensionId: extension.description.identifier,
-							extensionPublisher: extension.description.publisherDisplayName ?? extension.description.publisher, // May not be present in OSS
+							extensionPublisherDisplayName: extension.description.publisherDisplayName ?? extension.description.publisher, // May not be present in OSS
+							extensionPublisherId: extension.description.publisher,
 							extensionDisplayName: extension.description.displayName ?? extension.description.name,
 							id: providerDescriptor.id,
 							description: providerDescriptor.description,

--- a/src/vs/workbench/contrib/chat/browser/contrib/chatInputEditorContrib.ts
+++ b/src/vs/workbench/contrib/chat/browser/contrib/chatInputEditorContrib.ts
@@ -213,7 +213,7 @@ class InputEditorDecorations extends Disposable {
 		const textDecorations: IDecorationOptions[] | undefined = [];
 		if (agentPart) {
 			const isDupe = !!this.chatAgentService.getAgents().find(other => other.name === agentPart.agent.name && other.id !== agentPart.agent.id);
-			const publisher = isDupe ? `(${agentPart.agent.extensionPublisher}) ` : '';
+			const publisher = isDupe ? `(${agentPart.agent.extensionPublisherDisplayName}) ` : '';
 			const agentHover = `${publisher}${agentPart.agent.description}`;
 			textDecorations.push({ range: agentPart.editorRange, hoverMessage: new MarkdownString(agentHover) });
 			if (agentSubcommandPart) {
@@ -361,7 +361,7 @@ class AgentCompletions extends Disposable {
 						return <CompletionItem>{
 							// Leading space is important because detail has no space at the start by design
 							label: isDupe ?
-								{ label: withAt, description: a.description, detail: ` (${a.extensionPublisher})` } :
+								{ label: withAt, description: a.description, detail: ` (${a.extensionPublisherDisplayName})` } :
 								withAt,
 							insertText: `${withAt} `,
 							detail: a.description,
@@ -452,7 +452,7 @@ class AgentCompletions extends Disposable {
 
 						return {
 							label: isDupe ?
-								{ label: agentLabel, description: agent.description, detail: ` (${agent.extensionPublisher})` } :
+								{ label: agentLabel, description: agent.description, detail: ` (${agent.extensionPublisherDisplayName})` } :
 								agentLabel,
 							detail,
 							filterText: `${chatSubcommandLeader}${agent.name}`,

--- a/src/vs/workbench/contrib/chat/common/chatAgents.ts
+++ b/src/vs/workbench/contrib/chat/common/chatAgents.ts
@@ -59,7 +59,8 @@ export interface IChatAgentData {
 	name: string;
 	description?: string;
 	extensionId: ExtensionIdentifier;
-	extensionPublisher: string;
+	extensionPublisherId: string;
+	extensionPublisherDisplayName?: string;
 	extensionDisplayName: string;
 	/** The agent invoked when no agent is specified */
 	isDefault?: boolean;
@@ -325,7 +326,8 @@ export class MergedChatAgent implements IChatAgent {
 	get name(): string { return this.data.name ?? ''; }
 	get description(): string { return this.data.description ?? ''; }
 	get extensionId(): ExtensionIdentifier { return this.data.extensionId; }
-	get extensionPublisher(): string { return this.data.extensionPublisher; }
+	get extensionPublisherId(): string { return this.data.extensionPublisherId; }
+	get extensionPublisherDisplayName() { return this.data.extensionPublisherDisplayName; }
 	get extensionDisplayName(): string { return this.data.extensionDisplayName; }
 	get isDefault(): boolean | undefined { return this.data.isDefault; }
 	get metadata(): IChatAgentMetadata { return this.data.metadata; }
@@ -445,7 +447,7 @@ export class ChatAgentNameService implements IChatAgentNameService {
 				return true;
 			}
 
-			return allowList.some(id => equalsIgnoreCase(id, id.includes('.') ? chatAgentData.extensionId.value : chatAgentData.extensionPublisher));
+			return allowList.some(id => equalsIgnoreCase(id, id.includes('.') ? chatAgentData.extensionId.value : chatAgentData.extensionPublisherId));
 		});
 	}
 

--- a/src/vs/workbench/contrib/chat/common/chatModel.ts
+++ b/src/vs/workbench/contrib/chat/common/chatModel.ts
@@ -672,6 +672,16 @@ export class ChatModel extends Disposable implements IChatModel {
 				...(raw as any),
 				name: (raw as any).id,
 			};
+
+		// Fill in required fields that may be missing from old data
+		if (!('extensionPublisherId' in agent)) {
+			agent.extensionPublisherId = agent.extensionPublisher ?? '';
+		}
+
+		if (!('extensionDisplayName' in agent)) {
+			agent.extensionDisplayName = '';
+		}
+
 		return revive(agent);
 	}
 
@@ -847,7 +857,7 @@ export class ChatModel extends Disposable implements IChatModel {
 					followups: r.response?.followups,
 					isCanceled: r.response?.isCanceled,
 					vote: r.response?.vote,
-					agent: r.response?.agent,
+					agent: r.response?.agent ? { ...r.response.agent } : undefined,
 					slashCommand: r.response?.slashCommand,
 					usedContext: r.response?.usedContext,
 					contentReferences: r.response?.contentReferences

--- a/src/vs/workbench/contrib/chat/test/common/__snapshots__/ChatRequestParser_agent_and_subcommand_after_newline.0.snap
+++ b/src/vs/workbench/contrib/chat/test/common/__snapshots__/ChatRequestParser_agent_and_subcommand_after_newline.0.snap
@@ -32,8 +32,9 @@
           value: "nullExtensionDescription",
           _lower: "nullextensiondescription"
         },
-        extensionPublisher: "",
+        extensionPublisherDisplayName: "",
         extensionDisplayName: "",
+        extensionPublisherId: "",
         locations: [ "panel" ],
         metadata: {  },
         slashCommands: [

--- a/src/vs/workbench/contrib/chat/test/common/__snapshots__/ChatRequestParser_agent_and_subcommand_with_leading_whitespace.0.snap
+++ b/src/vs/workbench/contrib/chat/test/common/__snapshots__/ChatRequestParser_agent_and_subcommand_with_leading_whitespace.0.snap
@@ -32,8 +32,9 @@
           value: "nullExtensionDescription",
           _lower: "nullextensiondescription"
         },
-        extensionPublisher: "",
+        extensionPublisherDisplayName: "",
         extensionDisplayName: "",
+        extensionPublisherId: "",
         locations: [ "panel" ],
         metadata: {  },
         slashCommands: [

--- a/src/vs/workbench/contrib/chat/test/common/__snapshots__/ChatRequestParser_agent_with_question_mark.0.snap
+++ b/src/vs/workbench/contrib/chat/test/common/__snapshots__/ChatRequestParser_agent_with_question_mark.0.snap
@@ -18,8 +18,9 @@
           value: "nullExtensionDescription",
           _lower: "nullextensiondescription"
         },
-        extensionPublisher: "",
+        extensionPublisherDisplayName: "",
         extensionDisplayName: "",
+        extensionPublisherId: "",
         locations: [ "panel" ],
         metadata: {  },
         slashCommands: [

--- a/src/vs/workbench/contrib/chat/test/common/__snapshots__/ChatRequestParser_agent_with_subcommand_after_text.0.snap
+++ b/src/vs/workbench/contrib/chat/test/common/__snapshots__/ChatRequestParser_agent_with_subcommand_after_text.0.snap
@@ -18,8 +18,9 @@
           value: "nullExtensionDescription",
           _lower: "nullextensiondescription"
         },
-        extensionPublisher: "",
+        extensionPublisherDisplayName: "",
         extensionDisplayName: "",
+        extensionPublisherId: "",
         locations: [ "panel" ],
         metadata: {  },
         slashCommands: [

--- a/src/vs/workbench/contrib/chat/test/common/__snapshots__/ChatRequestParser_agents__subCommand.0.snap
+++ b/src/vs/workbench/contrib/chat/test/common/__snapshots__/ChatRequestParser_agents__subCommand.0.snap
@@ -18,8 +18,9 @@
           value: "nullExtensionDescription",
           _lower: "nullextensiondescription"
         },
-        extensionPublisher: "",
+        extensionPublisherDisplayName: "",
         extensionDisplayName: "",
+        extensionPublisherId: "",
         locations: [ "panel" ],
         metadata: {  },
         slashCommands: [

--- a/src/vs/workbench/contrib/chat/test/common/__snapshots__/ChatRequestParser_agents_and_variables_and_multiline.0.snap
+++ b/src/vs/workbench/contrib/chat/test/common/__snapshots__/ChatRequestParser_agents_and_variables_and_multiline.0.snap
@@ -18,8 +18,9 @@
           value: "nullExtensionDescription",
           _lower: "nullextensiondescription"
         },
-        extensionPublisher: "",
+        extensionPublisherDisplayName: "",
         extensionDisplayName: "",
+        extensionPublisherId: "",
         locations: [ "panel" ],
         metadata: {  },
         slashCommands: [

--- a/src/vs/workbench/contrib/chat/test/common/__snapshots__/ChatRequestParser_agents_and_variables_and_multiline__part2.0.snap
+++ b/src/vs/workbench/contrib/chat/test/common/__snapshots__/ChatRequestParser_agents_and_variables_and_multiline__part2.0.snap
@@ -18,8 +18,9 @@
           value: "nullExtensionDescription",
           _lower: "nullextensiondescription"
         },
-        extensionPublisher: "",
+        extensionPublisherDisplayName: "",
         extensionDisplayName: "",
+        extensionPublisherId: "",
         locations: [ "panel" ],
         metadata: {  },
         slashCommands: [

--- a/src/vs/workbench/contrib/chat/test/common/__snapshots__/ChatService_can_deserialize.0.snap
+++ b/src/vs/workbench/contrib/chat/test/common/__snapshots__/ChatService_can_deserialize.0.snap
@@ -28,6 +28,7 @@
                 value: "nullExtensionDescription",
                 _lower: "nullextensiondescription"
               },
+              extensionPublisherId: "",
               extensionPublisherDisplayName: "",
               extensionDisplayName: "",
               locations: [ "panel" ],
@@ -65,12 +66,12 @@
           value: "nullExtensionDescription",
           _lower: "nullextensiondescription"
         },
+        extensionPublisherId: "",
         extensionPublisherDisplayName: "",
         extensionDisplayName: "",
         locations: [ "panel" ],
         metadata: {  },
-        slashCommands: [  ],
-        extensionPublisherId: ""
+        slashCommands: [  ]
       },
       slashCommand: undefined,
       usedContext: {

--- a/src/vs/workbench/contrib/chat/test/common/__snapshots__/ChatService_can_deserialize.0.snap
+++ b/src/vs/workbench/contrib/chat/test/common/__snapshots__/ChatService_can_deserialize.0.snap
@@ -28,7 +28,7 @@
                 value: "nullExtensionDescription",
                 _lower: "nullextensiondescription"
               },
-              extensionPublisher: "",
+              extensionPublisherDisplayName: "",
               extensionDisplayName: "",
               locations: [ "panel" ],
               metadata: {  },
@@ -65,11 +65,12 @@
           value: "nullExtensionDescription",
           _lower: "nullextensiondescription"
         },
-        extensionPublisher: "",
+        extensionPublisherDisplayName: "",
         extensionDisplayName: "",
         locations: [ "panel" ],
         metadata: {  },
-        slashCommands: [  ]
+        slashCommands: [  ],
+        extensionPublisherId: ""
       },
       slashCommand: undefined,
       usedContext: {

--- a/src/vs/workbench/contrib/chat/test/common/__snapshots__/ChatService_can_serialize.1.snap
+++ b/src/vs/workbench/contrib/chat/test/common/__snapshots__/ChatService_can_serialize.1.snap
@@ -27,6 +27,7 @@
                 value: "nullExtensionDescription",
                 _lower: "nullextensiondescription"
               },
+              extensionPublisherId: "",
               extensionPublisherDisplayName: "",
               extensionDisplayName: "",
               locations: [ "panel" ],
@@ -68,6 +69,7 @@
           value: "nullExtensionDescription",
           _lower: "nullextensiondescription"
         },
+        extensionPublisherId: "",
         extensionPublisherDisplayName: "",
         extensionDisplayName: "",
         locations: [ "panel" ],

--- a/src/vs/workbench/contrib/chat/test/common/__snapshots__/ChatService_can_serialize.1.snap
+++ b/src/vs/workbench/contrib/chat/test/common/__snapshots__/ChatService_can_serialize.1.snap
@@ -27,7 +27,7 @@
                 value: "nullExtensionDescription",
                 _lower: "nullextensiondescription"
               },
-              extensionPublisher: "",
+              extensionPublisherDisplayName: "",
               extensionDisplayName: "",
               locations: [ "panel" ],
               metadata: {
@@ -68,7 +68,7 @@
           value: "nullExtensionDescription",
           _lower: "nullextensiondescription"
         },
-        extensionPublisher: "",
+        extensionPublisherDisplayName: "",
         extensionDisplayName: "",
         locations: [ "panel" ],
         metadata: {

--- a/src/vs/workbench/contrib/chat/test/common/chatRequestParser.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/chatRequestParser.test.ts
@@ -115,7 +115,7 @@ suite('ChatRequestParser', () => {
 	});
 
 	const getAgentWithSlashCommands = (slashCommands: IChatAgentCommand[]) => {
-		return { id: 'agent', name: 'agent', extensionId: nullExtensionDescription.identifier, extensionPublisher: '', extensionDisplayName: '', locations: [ChatAgentLocation.Panel], metadata: {}, slashCommands } satisfies IChatAgentData;
+		return { id: 'agent', name: 'agent', extensionId: nullExtensionDescription.identifier, extensionPublisherDisplayName: '', extensionDisplayName: '', extensionPublisherId: '', locations: [ChatAgentLocation.Panel], metadata: {}, slashCommands } satisfies IChatAgentData;
 	};
 
 	test('agent with subcommand after text', async () => {

--- a/src/vs/workbench/contrib/chat/test/common/chatService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/chatService.test.ts
@@ -35,7 +35,8 @@ const chatAgentWithUsedContext: IChatAgent = {
 	id: chatAgentWithUsedContextId,
 	name: chatAgentWithUsedContextId,
 	extensionId: nullExtensionDescription.identifier,
-	extensionPublisher: '',
+	extensionPublisherDisplayName: '',
+	extensionPublisherId: '',
 	extensionDisplayName: '',
 	locations: [ChatAgentLocation.Panel],
 	metadata: {},
@@ -91,8 +92,8 @@ suite('ChatService', () => {
 				return {};
 			},
 		} satisfies IChatAgentImplementation;
-		testDisposables.add(chatAgentService.registerAgent('testAgent', { name: 'testAgent', id: 'testAgent', isDefault: true, extensionId: nullExtensionDescription.identifier, extensionPublisher: '', extensionDisplayName: '', locations: [ChatAgentLocation.Panel], metadata: {}, slashCommands: [] }));
-		testDisposables.add(chatAgentService.registerAgent(chatAgentWithUsedContextId, { name: chatAgentWithUsedContextId, id: chatAgentWithUsedContextId, extensionId: nullExtensionDescription.identifier, extensionPublisher: '', extensionDisplayName: '', locations: [ChatAgentLocation.Panel], metadata: {}, slashCommands: [] }));
+		testDisposables.add(chatAgentService.registerAgent('testAgent', { name: 'testAgent', id: 'testAgent', isDefault: true, extensionId: nullExtensionDescription.identifier, extensionPublisherId: '', extensionPublisherDisplayName: '', extensionDisplayName: '', locations: [ChatAgentLocation.Panel], metadata: {}, slashCommands: [] }));
+		testDisposables.add(chatAgentService.registerAgent(chatAgentWithUsedContextId, { name: chatAgentWithUsedContextId, id: chatAgentWithUsedContextId, extensionId: nullExtensionDescription.identifier, extensionPublisherId: '', extensionPublisherDisplayName: '', extensionDisplayName: '', locations: [ChatAgentLocation.Panel], metadata: {}, slashCommands: [] }));
 		testDisposables.add(chatAgentService.registerAgentImplementation('testAgent', agent));
 		chatAgentService.updateAgent('testAgent', { requester: { name: 'test' }, fullName: 'test' });
 	});

--- a/src/vs/workbench/contrib/chat/test/common/voiceChat.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/voiceChat.test.ts
@@ -29,6 +29,7 @@ suite('VoiceChat', () => {
 		extensionId: ExtensionIdentifier = nullExtensionDescription.identifier;
 		extensionPublisher = '';
 		extensionDisplayName = '';
+		extensionPublisherId = '';
 		locations: ChatAgentLocation[] = [ChatAgentLocation.Panel];
 		public readonly name: string;
 		constructor(readonly id: string, readonly slashCommands: IChatAgentCommand[]) {

--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatSessionServiceImpl.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatSessionServiceImpl.ts
@@ -318,8 +318,9 @@ export class InlineChatSessionServiceImpl implements IInlineChatSessionService {
 				id: _bridgeAgentId,
 				name: 'editor',
 				extensionId: nullExtensionDescription.identifier,
-				extensionPublisher: '',
+				extensionPublisherDisplayName: '',
 				extensionDisplayName: '',
+				extensionPublisherId: '',
 				isDefault: true,
 				locations: [ChatAgentLocation.Editor],
 				get slashCommands(): IChatAgentCommand[] {

--- a/src/vs/workbench/contrib/inlineChat/test/browser/inlineChatController.test.ts
+++ b/src/vs/workbench/contrib/inlineChat/test/browser/inlineChatController.test.ts
@@ -180,8 +180,9 @@ suite('InteractiveChatController', function () {
 
 		store.add(chatAgentService.registerDynamicAgent({
 			extensionId: nullExtensionDescription.identifier,
-			extensionPublisher: '',
+			extensionPublisherDisplayName: '',
 			extensionDisplayName: '',
+			extensionPublisherId: '',
 			id: 'testAgent',
 			name: 'testAgent',
 			isDefault: true,

--- a/src/vs/workbench/contrib/inlineChat/test/browser/inlineChatSession.test.ts
+++ b/src/vs/workbench/contrib/inlineChat/test/browser/inlineChatSession.test.ts
@@ -127,8 +127,9 @@ suite('InlineChatSession', function () {
 
 		instaService.get(IChatAgentService).registerDynamicAgent({
 			extensionId: nullExtensionDescription.identifier,
-			extensionPublisher: '',
+			extensionPublisherDisplayName: '',
 			extensionDisplayName: '',
+			extensionPublisherId: '',
 			id: 'testAgent',
 			name: 'testAgent',
 			isDefault: true,


### PR DESCRIPTION
Added a new property to the chat agent, but then it's missing from older rehydrated chat models.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
