### PR TITLE
telemetry for lightbulb and move to code actions

### DIFF
--- a/src/vs/editor/contrib/codeAction/browser/codeAction.ts
+++ b/src/vs/editor/contrib/codeAction/browser/codeAction.ts
@@ -273,7 +273,7 @@ export async function applyCodeAction(
 		codeActionKind: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The kind (refactor, quickfix) of the applied code action' };
 		codeActionIsPreferred: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Was the code action marked as being a preferred action?' };
 		reason: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The kind of action used to trigger apply code action.' };
-		owner: 'mjbvz';
+		owner: 'justschen';
 		comment: 'Event used to gain insights into which code actions are being triggered';
 	};
 

--- a/src/vs/editor/contrib/codeAction/browser/codeActionController.ts
+++ b/src/vs/editor/contrib/codeAction/browser/codeActionController.ts
@@ -40,6 +40,7 @@ import { CodeActionAutoApply, CodeActionFilter, CodeActionItem, CodeActionKind, 
 import { CodeActionModel, CodeActionsState } from 'vs/editor/contrib/codeAction/browser/codeActionModel';
 import { HierarchicalKind } from 'vs/base/common/hierarchicalKind';
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
+import { filter } from 'vs/base/common/objects';
 
 
 interface IActionShowOptions {
@@ -109,24 +110,23 @@ export class CodeActionController extends Disposable implements IEditorContribut
 	private async showCodeActionsFromLightbulb(actions: CodeActionSet, at: IAnchor | IPosition): Promise<void> {
 
 		// Telemetry for showing code actions here. only log on `showLightbulb`. Shows us how often it was clicked.
-		if (actions.validActions.length <= 2) {
-			type ShowCodeActionListEvent = {
-				codeActionListLength: number;
-				codeActions: string[];
-			};
+		type ShowCodeActionListEvent = {
+			codeActionListLength: number;
+			codeActions: string[];
+		};
 
-			type ShowListEventClassification = {
-				codeActionListLength: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The length of the code action list from the lightbulb widget.' };
-				codeActions: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The title of code actions in this menu.' };
-				owner: 'justschen';
-				comment: 'Event used to gain insights into what code actions are being shown';
-			};
+		type ShowListEventClassification = {
+			codeActionListLength: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The length of the code action list from the lightbulb widget.' };
+			codeActions: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The title of code actions in this menu.' };
+			owner: 'justschen';
+			comment: 'Event used to gain insights into what code actions are being shown';
+		};
 
-			this._telemetryService.publicLog2<ShowCodeActionListEvent, ShowListEventClassification>('codeAction.showCodeActionsFromLightbulb', {
-				codeActionListLength: actions.validActions.length,
-				codeActions: actions.validActions.map(action => action.action.title),
-			});
-		}
+		this._telemetryService.publicLog2<ShowCodeActionListEvent, ShowListEventClassification>('codeAction.showCodeActionsFromLightbulb', {
+			codeActionListLength: actions.validActions.length,
+			codeActions: actions.validActions.map(action => action.action.title),
+		});
+
 
 		if (actions.allAIFixes && actions.validActions.length === 1) {
 			const actionItem = actions.validActions[0];

--- a/src/vs/editor/contrib/codeAction/browser/codeActionController.ts
+++ b/src/vs/editor/contrib/codeAction/browser/codeActionController.ts
@@ -109,7 +109,7 @@ export class CodeActionController extends Disposable implements IEditorContribut
 
 	private async showCodeActionsFromLightbulb(actions: CodeActionSet, at: IAnchor | IPosition): Promise<void> {
 
-		// Telemetry for showing code actions here. only log on `showLightbulb`. Shows us how often it was clicked.
+		// Telemetry for showing code actions from lightbulb. Shows us how often it was clicked.
 		type ShowCodeActionListEvent = {
 			codeActionListLength: number;
 			codeActions: string[];

--- a/src/vs/editor/contrib/codeAction/browser/codeActionController.ts
+++ b/src/vs/editor/contrib/codeAction/browser/codeActionController.ts
@@ -109,19 +109,24 @@ export class CodeActionController extends Disposable implements IEditorContribut
 	private async showCodeActionsFromLightbulb(actions: CodeActionSet, at: IAnchor | IPosition): Promise<void> {
 
 		// Telemetry for showing code actions here. only log on `showLightbulb`. Shows us how often it was clicked.
-		type ShowCodeActionListEvent = {
-			codeActionListLength: number;
-		};
+		if (actions.validActions.length <= 2) {
+			type ShowCodeActionListEvent = {
+				codeActionListLength: number;
+				codeActions: string[];
+			};
 
-		type ShowListEventClassification = {
-			codeActionListLength: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The length of the code action list from the lightbulb widget.' };
-			owner: 'justschen';
-			comment: 'Event used to gain insights into how many valid code actions are being shown';
-		};
+			type ShowListEventClassification = {
+				codeActionListLength: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The length of the code action list from the lightbulb widget.' };
+				codeActions: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The title of code actions in this menu.' };
+				owner: 'justschen';
+				comment: 'Event used to gain insights into what code actions are being shown';
+			};
 
-		this._telemetryService.publicLog2<ShowCodeActionListEvent, ShowListEventClassification>('codeAction.showCodeActionsFromLightbulb', {
-			codeActionListLength: actions.validActions.length,
-		});
+			this._telemetryService.publicLog2<ShowCodeActionListEvent, ShowListEventClassification>('codeAction.showCodeActionsFromLightbulb', {
+				codeActionListLength: actions.validActions.length,
+				codeActions: actions.validActions.map(action => action.action.title),
+			});
+		}
 
 		if (actions.allAIFixes && actions.validActions.length === 1) {
 			const actionItem = actions.validActions[0];

--- a/src/vs/editor/contrib/codeAction/browser/codeActionController.ts
+++ b/src/vs/editor/contrib/codeAction/browser/codeActionController.ts
@@ -39,6 +39,7 @@ import { registerThemingParticipant } from 'vs/platform/theme/common/themeServic
 import { CodeActionAutoApply, CodeActionFilter, CodeActionItem, CodeActionKind, CodeActionSet, CodeActionTrigger, CodeActionTriggerSource } from 'vs/editor/contrib/codeAction/common/types';
 import { CodeActionModel, CodeActionsState } from 'vs/editor/contrib/codeAction/browser/codeActionModel';
 import { HierarchicalKind } from 'vs/base/common/hierarchicalKind';
+import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 
 
 interface IActionShowOptions {
@@ -79,6 +80,7 @@ export class CodeActionController extends Disposable implements IEditorContribut
 		@IConfigurationService private readonly _configurationService: IConfigurationService,
 		@IActionWidgetService private readonly _actionWidgetService: IActionWidgetService,
 		@IInstantiationService private readonly _instantiationService: IInstantiationService,
+		@ITelemetryService private readonly _telemetryService: ITelemetryService
 	) {
 		super();
 
@@ -105,6 +107,22 @@ export class CodeActionController extends Disposable implements IEditorContribut
 	}
 
 	private async showCodeActionsFromLightbulb(actions: CodeActionSet, at: IAnchor | IPosition): Promise<void> {
+
+		// Telemetry for showing code actions here. only log on `showLightbulb`. Shows us how often it was clicked.
+		type ShowCodeActionListEvent = {
+			codeActionListLength: number;
+		};
+
+		type ShowListEventClassification = {
+			codeActionListLength: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The length of the code action list from the lightbulb widget.' };
+			owner: 'justschen';
+			comment: 'Event used to gain insights into how many valid code actions are being shown';
+		};
+
+		this._telemetryService.publicLog2<ShowCodeActionListEvent, ShowListEventClassification>('codeAction.showCodeActionsFromLightbulb', {
+			codeActionListLength: actions.validActions.length,
+		});
+
 		if (actions.allAIFixes && actions.validActions.length === 1) {
 			const actionItem = actions.validActions[0];
 			const command = actionItem.action.command;
@@ -280,13 +298,32 @@ export class CodeActionController extends Disposable implements IEditorContribut
 
 		const delegate: IActionListDelegate<CodeActionItem> = {
 			onSelect: async (action: CodeActionItem, preview?: boolean) => {
-				this._applyCodeAction(action, /* retrigger */ true, !!preview, ApplyCodeActionReason.FromCodeActions);
-				this._actionWidgetService.hide();
+				this._applyCodeAction(action, /* retrigger */ true, !!preview, options.fromLightbulb ? ApplyCodeActionReason.FromAILightbulb : ApplyCodeActionReason.FromCodeActions);
+				this._actionWidgetService.hide(false);
 				currentDecorations.clear();
 			},
-			onHide: () => {
+			onHide: (didCancel?) => {
 				this._editor?.focus();
 				currentDecorations.clear();
+				// Telemetry for showing code actions here. only log on `showLightbulb`. Logs when code action list is quit out.
+				if (options.fromLightbulb && didCancel !== undefined) {
+					type ShowCodeActionListEvent = {
+						codeActionListLength: number;
+						didCancel: boolean;
+					};
+
+					type ShowListEventClassification = {
+						codeActionListLength: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The length of the code action list when quit out. Can be from any code action menu.' };
+						didCancel: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Whether the code action was cancelled or selected.' };
+						owner: 'justschen';
+						comment: 'Event used to gain insights into how many valid code actions are being shown';
+					};
+
+					this._telemetryService.publicLog2<ShowCodeActionListEvent, ShowListEventClassification>('codeAction.showCodeActionList.onHide', {
+						codeActionListLength: actions.validActions.length,
+						didCancel: didCancel,
+					});
+				}
 			},
 			onHover: async (action: CodeActionItem, token: CancellationToken) => {
 				if (token.isCancellationRequested) {

--- a/src/vs/editor/contrib/codeAction/browser/codeActionController.ts
+++ b/src/vs/editor/contrib/codeAction/browser/codeActionController.ts
@@ -40,7 +40,6 @@ import { CodeActionAutoApply, CodeActionFilter, CodeActionItem, CodeActionKind, 
 import { CodeActionModel, CodeActionsState } from 'vs/editor/contrib/codeAction/browser/codeActionModel';
 import { HierarchicalKind } from 'vs/base/common/hierarchicalKind';
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
-import { filter } from 'vs/base/common/objects';
 
 
 interface IActionShowOptions {
@@ -113,11 +112,13 @@ export class CodeActionController extends Disposable implements IEditorContribut
 		type ShowCodeActionListEvent = {
 			codeActionListLength: number;
 			codeActions: string[];
+			codeActionProviders: string[];
 		};
 
 		type ShowListEventClassification = {
 			codeActionListLength: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The length of the code action list from the lightbulb widget.' };
 			codeActions: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The title of code actions in this menu.' };
+			codeActionProviders: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The title of code actions in this menu.' };
 			owner: 'justschen';
 			comment: 'Event used to gain insights into what code actions are being shown';
 		};
@@ -125,6 +126,7 @@ export class CodeActionController extends Disposable implements IEditorContribut
 		this._telemetryService.publicLog2<ShowCodeActionListEvent, ShowListEventClassification>('codeAction.showCodeActionsFromLightbulb', {
 			codeActionListLength: actions.validActions.length,
 			codeActions: actions.validActions.map(action => action.action.title),
+			codeActionProviders: actions.validActions.map(action => action.provider?.displayName ?? ''),
 		});
 
 

--- a/src/vs/editor/contrib/codeAction/browser/codeActionController.ts
+++ b/src/vs/editor/contrib/codeAction/browser/codeActionController.ts
@@ -118,7 +118,7 @@ export class CodeActionController extends Disposable implements IEditorContribut
 		type ShowListEventClassification = {
 			codeActionListLength: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The length of the code action list from the lightbulb widget.' };
 			codeActions: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The title of code actions in this menu.' };
-			codeActionProviders: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The title of code actions in this menu.' };
+			codeActionProviders: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The provider of code actions in this menu.' };
 			owner: 'justschen';
 			comment: 'Event used to gain insights into what code actions are being shown';
 		};

--- a/src/vs/editor/contrib/codeAction/browser/lightBulbWidget.ts
+++ b/src/vs/editor/contrib/codeAction/browser/lightBulbWidget.ts
@@ -7,6 +7,7 @@ import * as dom from 'vs/base/browser/dom';
 import { Gesture } from 'vs/base/browser/touch';
 import { Codicon } from 'vs/base/common/codicons';
 import { Emitter, Event } from 'vs/base/common/event';
+import { HierarchicalKind } from 'vs/base/common/hierarchicalKind';
 import { Disposable } from 'vs/base/common/lifecycle';
 import { ThemeIcon } from 'vs/base/common/themables';
 import 'vs/css!./lightBulbWidget';
@@ -15,10 +16,11 @@ import { EditorOption } from 'vs/editor/common/config/editorOptions';
 import { IPosition } from 'vs/editor/common/core/position';
 import { computeIndentLevel } from 'vs/editor/common/model/utils';
 import { autoFixCommandId, quickFixCommandId } from 'vs/editor/contrib/codeAction/browser/codeAction';
-import type { CodeActionSet, CodeActionTrigger } from 'vs/editor/contrib/codeAction/common/types';
+import { CodeActionKind, type CodeActionSet, type CodeActionTrigger } from 'vs/editor/contrib/codeAction/common/types';
 import * as nls from 'vs/nls';
 import { ICommandService } from 'vs/platform/commands/common/commands';
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
+import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 
 namespace LightBulbState {
 
@@ -64,6 +66,7 @@ export class LightBulbWidget extends Disposable implements IContentWidget {
 		private readonly _editor: ICodeEditor,
 		@IKeybindingService private readonly _keybindingService: IKeybindingService,
 		@ICommandService commandService: ICommandService,
+		@ITelemetryService private readonly _telemetryService: ITelemetryService,
 	) {
 		super();
 
@@ -189,6 +192,33 @@ export class LightBulbWidget extends Disposable implements IContentWidget {
 			position: { lineNumber: effectiveLineNumber, column: effectiveColumnNumber },
 			preference: LightBulbWidget._posPref
 		});
+
+		const validActions = actions.validActions;
+		if (validActions.length === 1) {
+			const actionKind = actions.validActions[0].action.kind;
+			if (actionKind) {
+				const hierarchicalKind = new HierarchicalKind(actionKind);
+				if (CodeActionKind.RefactorMove.contains(hierarchicalKind)) {
+					// Telemetry for showing code actions here. only log on `showLightbulb`. Logs when code action list is quit out.
+
+					type ShowCodeActionListEvent = {
+						codeActionListLength: number;
+					};
+
+					type ShowListEventClassification = {
+						codeActionListLength: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The length of the code action list when quit out. Can be from any code action menu.' };
+						owner: 'justschen';
+						comment: 'Event used to gain insights into how often the lightbulb only contains one code action, namely the move to code action. ';
+					};
+
+					this._telemetryService.publicLog2<ShowCodeActionListEvent, ShowListEventClassification>('lightbulbWidget.moveToCodeActions', {
+						codeActionListLength: validActions.length,
+					});
+
+				}
+			}
+		}
+
 		this._editor.layoutContentWidget(this);
 	}
 

--- a/src/vs/editor/contrib/codeAction/browser/lightBulbWidget.ts
+++ b/src/vs/editor/contrib/codeAction/browser/lightBulbWidget.ts
@@ -7,7 +7,6 @@ import * as dom from 'vs/base/browser/dom';
 import { Gesture } from 'vs/base/browser/touch';
 import { Codicon } from 'vs/base/common/codicons';
 import { Emitter, Event } from 'vs/base/common/event';
-import { HierarchicalKind } from 'vs/base/common/hierarchicalKind';
 import { Disposable } from 'vs/base/common/lifecycle';
 import { ThemeIcon } from 'vs/base/common/themables';
 import 'vs/css!./lightBulbWidget';
@@ -16,11 +15,10 @@ import { EditorOption } from 'vs/editor/common/config/editorOptions';
 import { IPosition } from 'vs/editor/common/core/position';
 import { computeIndentLevel } from 'vs/editor/common/model/utils';
 import { autoFixCommandId, quickFixCommandId } from 'vs/editor/contrib/codeAction/browser/codeAction';
-import { CodeActionKind, type CodeActionSet, type CodeActionTrigger } from 'vs/editor/contrib/codeAction/common/types';
+import { type CodeActionSet, type CodeActionTrigger } from 'vs/editor/contrib/codeAction/common/types';
 import * as nls from 'vs/nls';
 import { ICommandService } from 'vs/platform/commands/common/commands';
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
-import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 
 namespace LightBulbState {
 
@@ -65,8 +63,7 @@ export class LightBulbWidget extends Disposable implements IContentWidget {
 	constructor(
 		private readonly _editor: ICodeEditor,
 		@IKeybindingService private readonly _keybindingService: IKeybindingService,
-		@ICommandService commandService: ICommandService,
-		@ITelemetryService private readonly _telemetryService: ITelemetryService,
+		@ICommandService commandService: ICommandService
 	) {
 		super();
 
@@ -192,32 +189,6 @@ export class LightBulbWidget extends Disposable implements IContentWidget {
 			position: { lineNumber: effectiveLineNumber, column: effectiveColumnNumber },
 			preference: LightBulbWidget._posPref
 		});
-
-		const validActions = actions.validActions;
-		if (validActions.length === 1) {
-			const actionKind = actions.validActions[0].action.kind;
-			if (actionKind) {
-				const hierarchicalKind = new HierarchicalKind(actionKind);
-				if (CodeActionKind.RefactorMove.contains(hierarchicalKind)) {
-					// Telemetry for showing code actions here. only log on `showLightbulb`. Logs when code action list is quit out.
-
-					type ShowCodeActionListEvent = {
-						codeActionListLength: number;
-					};
-
-					type ShowListEventClassification = {
-						codeActionListLength: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The length of the code action list when quit out. Can be from any code action menu.' };
-						owner: 'justschen';
-						comment: 'Event used to gain insights into how often the lightbulb only contains one code action, namely the move to code action. ';
-					};
-
-					this._telemetryService.publicLog2<ShowCodeActionListEvent, ShowListEventClassification>('lightbulbWidget.moveToCodeActions', {
-						codeActionListLength: validActions.length,
-					});
-
-				}
-			}
-		}
 
 		this._editor.layoutContentWidget(this);
 	}

--- a/src/vs/editor/contrib/codeAction/browser/lightBulbWidget.ts
+++ b/src/vs/editor/contrib/codeAction/browser/lightBulbWidget.ts
@@ -15,7 +15,7 @@ import { EditorOption } from 'vs/editor/common/config/editorOptions';
 import { IPosition } from 'vs/editor/common/core/position';
 import { computeIndentLevel } from 'vs/editor/common/model/utils';
 import { autoFixCommandId, quickFixCommandId } from 'vs/editor/contrib/codeAction/browser/codeAction';
-import { type CodeActionSet, type CodeActionTrigger } from 'vs/editor/contrib/codeAction/common/types';
+import type { CodeActionSet, CodeActionTrigger } from 'vs/editor/contrib/codeAction/common/types';
 import * as nls from 'vs/nls';
 import { ICommandService } from 'vs/platform/commands/common/commands';
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
@@ -63,7 +63,7 @@ export class LightBulbWidget extends Disposable implements IContentWidget {
 	constructor(
 		private readonly _editor: ICodeEditor,
 		@IKeybindingService private readonly _keybindingService: IKeybindingService,
-		@ICommandService commandService: ICommandService
+		@ICommandService commandService: ICommandService,
 	) {
 		super();
 
@@ -189,7 +189,6 @@ export class LightBulbWidget extends Disposable implements IContentWidget {
 			position: { lineNumber: effectiveLineNumber, column: effectiveColumnNumber },
 			preference: LightBulbWidget._posPref
 		});
-
 		this._editor.layoutContentWidget(this);
 	}
 

--- a/src/vs/platform/actionWidget/browser/actionWidget.ts
+++ b/src/vs/platform/actionWidget/browser/actionWidget.ts
@@ -36,7 +36,7 @@ export interface IActionWidgetService {
 
 	show<T>(user: string, supportsPreview: boolean, items: readonly IActionListItem<T>[], delegate: IActionListDelegate<T>, anchor: IAnchor, container: HTMLElement | undefined, actionBarActions?: readonly IAction[]): void;
 
-	hide(): void;
+	hide(didCancel?: boolean): void;
 
 	readonly isVisible: boolean;
 }
@@ -87,8 +87,8 @@ class ActionWidgetService extends Disposable implements IActionWidgetService {
 		this._list?.value?.focusNext();
 	}
 
-	hide() {
-		this._list.value?.hide();
+	hide(didCancel?: boolean) {
+		this._list.value?.hide(didCancel);
 		this._list.clear();
 	}
 
@@ -139,7 +139,7 @@ class ActionWidgetService extends Disposable implements IActionWidgetService {
 		widget.style.width = `${width}px`;
 
 		const focusTracker = renderDisposables.add(dom.trackFocus(element));
-		renderDisposables.add(focusTracker.onDidBlur(() => this.hide()));
+		renderDisposables.add(focusTracker.onDidBlur(() => this.hide(true)));
 
 		return renderDisposables;
 	}
@@ -179,7 +179,7 @@ registerAction2(class extends Action2 {
 	}
 
 	run(accessor: ServicesAccessor): void {
-		accessor.get(IActionWidgetService).hide();
+		accessor.get(IActionWidgetService).hide(true);
 	}
 });
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

tracking:
- when code action menu is closed (when source is lightbulb). whether it was cancelled or selected
- when lightbulb widget is clicked on, how many code actions there are in that menu, which code actions they are, and their respective providers.

already tracking:
- code actions applied. we can check how often `move to...` code actions are called, and the `codeActionReason` which is where the code action came from.

related: https://github.com/microsoft/vscode/issues/204047, https://github.com/microsoft/vscode/issues/202767
