### PR TITLE
Keep hover open when increase hover verbosity or decrease hover verbosity actions are triggered

### DIFF
--- a/src/vs/editor/contrib/hover/browser/hoverController.ts
+++ b/src/vs/editor/contrib/hover/browser/hoverController.ts
@@ -332,7 +332,7 @@ export class HoverController extends Disposable implements IEditorContribution {
 		// If the beginning of a multi-chord keybinding is pressed,
 		// or the command aims to focus the hover,
 		// set the variable to true, otherwise false
-		const mightTriggerFocus = (
+		const shouldKeepHoverVisible = (
 			resolvedKeyboardEvent.kind === ResultKind.MoreChordsNeeded ||
 			(resolvedKeyboardEvent.kind === ResultKind.KbFound
 				&& (resolvedKeyboardEvent.commandId === SHOW_OR_FOCUS_HOVER_ACTION_ID
@@ -347,7 +347,7 @@ export class HoverController extends Disposable implements IEditorContribution {
 			|| e.keyCode === KeyCode.Alt
 			|| e.keyCode === KeyCode.Meta
 			|| e.keyCode === KeyCode.Shift
-			|| mightTriggerFocus
+			|| shouldKeepHoverVisible
 		) {
 			// Do not hide hover when a modifier key is pressed
 			return;

--- a/src/vs/editor/contrib/hover/browser/hoverController.ts
+++ b/src/vs/editor/contrib/hover/browser/hoverController.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { SHOW_OR_FOCUS_HOVER_ACTION_ID } from 'vs/editor/contrib/hover/browser/hoverActionIds';
+import { DECREASE_HOVER_VERBOSITY_ACTION_ID, INCREASE_HOVER_VERBOSITY_ACTION_ID, SHOW_OR_FOCUS_HOVER_ACTION_ID } from 'vs/editor/contrib/hover/browser/hoverActionIds';
 import { IKeyboardEvent } from 'vs/base/browser/keyboardEvent';
 import { KeyCode } from 'vs/base/common/keyCodes';
 import { Disposable, DisposableStore } from 'vs/base/common/lifecycle';
@@ -335,7 +335,9 @@ export class HoverController extends Disposable implements IEditorContribution {
 		const mightTriggerFocus = (
 			resolvedKeyboardEvent.kind === ResultKind.MoreChordsNeeded ||
 			(resolvedKeyboardEvent.kind === ResultKind.KbFound
-				&& resolvedKeyboardEvent.commandId === SHOW_OR_FOCUS_HOVER_ACTION_ID
+				&& (resolvedKeyboardEvent.commandId === SHOW_OR_FOCUS_HOVER_ACTION_ID
+					|| resolvedKeyboardEvent.commandId === INCREASE_HOVER_VERBOSITY_ACTION_ID
+					|| resolvedKeyboardEvent.commandId === DECREASE_HOVER_VERBOSITY_ACTION_ID)
 				&& this._contentWidget?.isVisible
 			)
 		);


### PR DESCRIPTION
Adding a check that the increase hover verbosity actions are triggered in which case we want to keep the hover visible. 