### PR TITLE
Pick up latest Markdown language service

### DIFF
--- a/extensions/markdown-language-features/server/package.json
+++ b/extensions/markdown-language-features/server/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vscode-markdown-languageserver",
   "description": "Markdown language server",
-  "version": "0.5.0-alpha.5",
+  "version": "0.5.0-alpha.6",
   "author": "Microsoft Corporation",
   "license": "MIT",
   "engines": {
@@ -18,7 +18,7 @@
     "vscode-languageserver": "^8.1.0",
     "vscode-languageserver-textdocument": "^1.0.8",
     "vscode-languageserver-types": "^3.17.3",
-    "vscode-markdown-languageservice": "^0.5.0-alpha.5",
+    "vscode-markdown-languageservice": "^0.5.0-alpha.6",
     "vscode-uri": "^3.0.7"
   },
   "devDependencies": {

--- a/extensions/markdown-language-features/server/src/protocol.ts
+++ b/extensions/markdown-language-features/server/src/protocol.ts
@@ -8,7 +8,7 @@ import type * as lsp from 'vscode-languageserver-types';
 import type * as md from 'vscode-markdown-languageservice';
 
 //#region From server
-export const parse = new RequestType<{ uri: string }, md.Token[], any>('markdown/parse');
+export const parse = new RequestType<{ uri: string; text?: string }, md.Token[], any>('markdown/parse');
 
 export const fs_readFile = new RequestType<{ uri: string }, number[], any>('markdown/fs/readFile');
 export const fs_readDirectory = new RequestType<{ uri: string }, [string, { isDirectory: boolean }][], any>('markdown/fs/readDirectory');

--- a/extensions/markdown-language-features/server/src/server.ts
+++ b/extensions/markdown-language-features/server/src/server.ts
@@ -29,7 +29,13 @@ export async function startVsCodeServer(connection: Connection) {
 		slugifier = md.githubSlugifier;
 
 		tokenize(document: md.ITextDocument): Promise<md.Token[]> {
-			return connection.sendRequest(protocol.parse, { uri: document.uri.toString() });
+			return connection.sendRequest(protocol.parse, {
+				uri: document.uri,
+
+				// Clients won't be able to read temp documents.
+				// Send along the full text for parsing.
+				text: document.version < 0 ? document.getText() : undefined
+			});
 		}
 	};
 

--- a/extensions/markdown-language-features/server/yarn.lock
+++ b/extensions/markdown-language-features/server/yarn.lock
@@ -151,10 +151,10 @@ vscode-languageserver@^8.1.0:
   dependencies:
     vscode-languageserver-protocol "3.17.3"
 
-vscode-markdown-languageservice@^0.5.0-alpha.5:
-  version "0.5.0-alpha.5"
-  resolved "https://registry.yarnpkg.com/vscode-markdown-languageservice/-/vscode-markdown-languageservice-0.5.0-alpha.5.tgz#d4c5a4b7ab8d03a9dbbdf64ce51862686ca05cf8"
-  integrity sha512-yu2TbIj2alrgh7JAzGQS4YadSBX4MDT7UjgrT4BQvtGfXOPC4G76llP4iZpkDWPBvAXywxnMZ9eZ3N15f81InA==
+vscode-markdown-languageservice@^0.5.0-alpha.6:
+  version "0.5.0-alpha.6"
+  resolved "https://registry.yarnpkg.com/vscode-markdown-languageservice/-/vscode-markdown-languageservice-0.5.0-alpha.6.tgz#3aa5fc94fea3d5d7f0cd970e64348e2791643dc0"
+  integrity sha512-mA1JCA7aHHSek5gr8Yv7C3esEPo2hRrgxmoZUDRro+pnwbdsJuRaWOKWtCWxejRUVVVhc/5yTK2X64Jx9OCmFQ==
   dependencies:
     "@vscode/l10n" "^0.0.10"
     node-html-parser "^6.1.5"

--- a/extensions/markdown-language-features/src/client/protocol.ts
+++ b/extensions/markdown-language-features/src/client/protocol.ts
@@ -16,7 +16,7 @@ export type ResolvedDocumentLinkTarget =
 	| { readonly kind: 'external'; readonly uri: vscode.Uri };
 
 //#region From server
-export const parse = new RequestType<{ uri: string }, Token[], any>('markdown/parse');
+export const parse = new RequestType<{ uri: string; text?: string }, Token[], any>('markdown/parse');
 
 export const fs_readFile = new RequestType<{ uri: string }, number[], any>('markdown/fs/readFile');
 export const fs_readDirectory = new RequestType<{ uri: string }, [string, { isDirectory: boolean }][], any>('markdown/fs/readDirectory');

--- a/extensions/markdown-language-features/src/markdownEngine.ts
+++ b/extensions/markdown-language-features/src/markdownEngine.ts
@@ -55,7 +55,7 @@ class TokenCache {
 	public tryGetCached(document: ITextDocument, config: MarkdownItConfig): Token[] | undefined {
 		if (this._cachedDocument
 			&& this._cachedDocument.uri.toString() === document.uri.toString()
-			&& this._cachedDocument.version === document.version
+			&& document.version >= 0 && this._cachedDocument.version === document.version
 			&& this._cachedDocument.config.breaks === config.breaks
 			&& this._cachedDocument.config.linkify === config.linkify
 		) {


### PR DESCRIPTION
Fixes #211389

This fixes an important issue where temporary documents were being cached by the markdown parser

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
