### PR TITLE
Exclude product.overrides from hygiene

### DIFF
--- a/build/filters.js
+++ b/build/filters.js
@@ -81,6 +81,7 @@ module.exports.indentationFilter = [
 	'!resources/linux/snap/electron-launch',
 	'!build/ext.js',
 	'!build/npm/gyp/patches/gyp_spectre_mitigation_support.patch',
+	'!product.overrides.json',
 
 	// except specific folders
 	'!test/automation/out/**',


### PR DESCRIPTION
This shows up if you try running `hygiene` locally

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
