### PR TITLE
Remove Identity Provider in Quick Pick Tree

### DIFF
--- a/extensions/vscode-api-tests/src/singlefolder-tests/quickInput.test.ts
+++ b/extensions/vscode-api-tests/src/singlefolder-tests/quickInput.test.ts
@@ -139,8 +139,8 @@ suite('vscode API - quick input', function () {
 		};
 
 		const quickPick = createQuickPick({
-			events: ['active', 'selection', 'accept', 'active', 'selection', 'accept', 'hide'],
-			activeItems: [['eins'], ['drei']],
+			events: ['active', 'selection', 'accept', 'active', 'active', 'selection', 'accept', 'hide'],
+			activeItems: [['eins'], [], ['drei']],
 			selectionItems: [['eins'], ['drei']],
 			acceptedItems: {
 				active: [['eins'], ['drei']],
@@ -253,6 +253,7 @@ suite('vscode API - quick input', function () {
 function createQuickPick(expected: QuickPickExpected, done: (err?: any) => void, record = false) {
 	const quickPick = window.createQuickPick();
 	let eventIndex = -1;
+	quickPick.ignoreFocusOut = true;
 	quickPick.onDidChangeActive(items => {
 		if (record) {
 			console.log(`active: [${items.map(item => item.label).join(', ')}]`);

--- a/extensions/vscode-api-tests/src/singlefolder-tests/quickInput.test.ts
+++ b/extensions/vscode-api-tests/src/singlefolder-tests/quickInput.test.ts
@@ -139,8 +139,8 @@ suite('vscode API - quick input', function () {
 		};
 
 		const quickPick = createQuickPick({
-			events: ['active', 'selection', 'accept', 'active', 'active', 'selection', 'accept', 'hide'],
-			activeItems: [['eins'], [], ['drei']],
+			events: ['active', 'selection', 'accept', 'active', 'selection', 'accept', 'hide'],
+			activeItems: [['eins'], ['drei']],
 			selectionItems: [['eins'], ['drei']],
 			acceptedItems: {
 				active: [['eins'], ['drei']],

--- a/extensions/vscode-api-tests/src/singlefolder-tests/quickInput.test.ts
+++ b/extensions/vscode-api-tests/src/singlefolder-tests/quickInput.test.ts
@@ -253,7 +253,6 @@ suite('vscode API - quick input', function () {
 function createQuickPick(expected: QuickPickExpected, done: (err?: any) => void, record = false) {
 	const quickPick = window.createQuickPick();
 	let eventIndex = -1;
-	quickPick.ignoreFocusOut = true;
 	quickPick.onDidChangeActive(items => {
 		if (record) {
 			console.log(`active: [${items.map(item => item.label).join(', ')}]`);

--- a/src/vs/platform/quickinput/browser/quickInput.ts
+++ b/src/vs/platform/quickinput/browser/quickInput.ts
@@ -1087,7 +1087,6 @@ export class QuickPick<T extends IQuickPickItem> extends QuickInput implements I
 		this.ui.list.sortByLabel = this.sortByLabel;
 		if (this.itemsUpdated) {
 			this.itemsUpdated = false;
-			const currentActiveItems = this._activeItems;
 			this._focusEventBufferer.bufferEvents(() => {
 				this.ui.list.setElements(this.items);
 				this.ui.list.filter(this.filterValue(this.ui.inputBox.value));
@@ -1096,15 +1095,6 @@ export class QuickPick<T extends IQuickPickItem> extends QuickInput implements I
 				this.ui.count.setCount(this.ui.list.getCheckedCount());
 				switch (this._itemActivation) {
 					case ItemActivation.NONE:
-						// Handle the case where we had active items (i.e. someone chose an item)
-						// but the initial item activation is set to none. Calling clearFocus will
-						// not trigger the onDidFocus event because when the tree receives new elements,
-						// it sets the focus to no elements. So we need to set & fire the active items
-						// accordingly to reflect the state change after setting the items.
-						if (currentActiveItems.length > 0) {
-							this._activeItems = [];
-							this.onDidChangeActiveEmitter.fire(this._activeItems);
-						}
 						this._itemActivation = ItemActivation.FIRST; // only valid once, then unset
 						break;
 					case ItemActivation.SECOND:

--- a/src/vs/platform/quickinput/browser/quickInput.ts
+++ b/src/vs/platform/quickinput/browser/quickInput.ts
@@ -17,7 +17,7 @@ import { IToggleStyles, Toggle } from 'vs/base/browser/ui/toggle/toggle';
 import { equals } from 'vs/base/common/arrays';
 import { TimeoutTimer } from 'vs/base/common/async';
 import { Codicon } from 'vs/base/common/codicons';
-import { Emitter, Event } from 'vs/base/common/event';
+import { Emitter, Event, EventBufferer } from 'vs/base/common/event';
 import { KeyCode } from 'vs/base/common/keyCodes';
 import { Disposable, DisposableStore } from 'vs/base/common/lifecycle';
 import { isIOS, isMacintosh } from 'vs/base/common/platform';
@@ -534,6 +534,7 @@ export class QuickPick<T extends IQuickPickItem> extends QuickInput implements I
 	private _hideInput: boolean | undefined;
 	private _hideCountBadge: boolean | undefined;
 	private _hideCheckAll: boolean | undefined;
+	private _focusEventBufferer = new EventBufferer();
 
 	get quickNavigate() {
 		return this._quickNavigate;
@@ -919,7 +920,11 @@ export class QuickPick<T extends IQuickPickItem> extends QuickInput implements I
 			this.visibleDisposables.add(this.ui.onDidCustom(() => {
 				this.onDidCustomEmitter.fire();
 			}));
-			this.visibleDisposables.add(this.ui.list.onDidChangeFocus(focusedItems => {
+			this.visibleDisposables.add(this._focusEventBufferer.wrapEvent(
+				this.ui.list.onDidChangeFocus,
+				// Only fire the last event
+				(_, e) => e
+			)(focusedItems => {
 				if (this.activeItemsUpdated) {
 					return; // Expect another event.
 				}
@@ -1083,36 +1088,38 @@ export class QuickPick<T extends IQuickPickItem> extends QuickInput implements I
 		if (this.itemsUpdated) {
 			this.itemsUpdated = false;
 			const currentActiveItems = this._activeItems;
-			this.ui.list.setElements(this.items);
-			this.ui.list.filter(this.filterValue(this.ui.inputBox.value));
-			this.ui.checkAll.checked = this.ui.list.getAllVisibleChecked();
-			this.ui.visibleCount.setCount(this.ui.list.getVisibleCount());
-			this.ui.count.setCount(this.ui.list.getCheckedCount());
-			switch (this._itemActivation) {
-				case ItemActivation.NONE:
-					// Handle the case where we had active items (i.e. someone chose an item)
-					// but the initial item activation is set to none. Calling clearFocus will
-					// not trigger the onDidFocus event because when the tree receives new elements,
-					// it sets the focus to no elements. So we need to set & fire the active items
-					// accordingly to reflect the state change after setting the items.
-					if (currentActiveItems.length > 0) {
-						this._activeItems = [];
-						this.onDidChangeActiveEmitter.fire(this._activeItems);
-					}
-					this._itemActivation = ItemActivation.FIRST; // only valid once, then unset
-					break;
-				case ItemActivation.SECOND:
-					this.ui.list.focus(QuickInputListFocus.Second);
-					this._itemActivation = ItemActivation.FIRST; // only valid once, then unset
-					break;
-				case ItemActivation.LAST:
-					this.ui.list.focus(QuickInputListFocus.Last);
-					this._itemActivation = ItemActivation.FIRST; // only valid once, then unset
-					break;
-				default:
-					this.trySelectFirst();
-					break;
-			}
+			this._focusEventBufferer.bufferEvents(() => {
+				this.ui.list.setElements(this.items);
+				this.ui.list.filter(this.filterValue(this.ui.inputBox.value));
+				this.ui.checkAll.checked = this.ui.list.getAllVisibleChecked();
+				this.ui.visibleCount.setCount(this.ui.list.getVisibleCount());
+				this.ui.count.setCount(this.ui.list.getCheckedCount());
+				switch (this._itemActivation) {
+					case ItemActivation.NONE:
+						// Handle the case where we had active items (i.e. someone chose an item)
+						// but the initial item activation is set to none. Calling clearFocus will
+						// not trigger the onDidFocus event because when the tree receives new elements,
+						// it sets the focus to no elements. So we need to set & fire the active items
+						// accordingly to reflect the state change after setting the items.
+						if (currentActiveItems.length > 0) {
+							this._activeItems = [];
+							this.onDidChangeActiveEmitter.fire(this._activeItems);
+						}
+						this._itemActivation = ItemActivation.FIRST; // only valid once, then unset
+						break;
+					case ItemActivation.SECOND:
+						this.ui.list.focus(QuickInputListFocus.Second);
+						this._itemActivation = ItemActivation.FIRST; // only valid once, then unset
+						break;
+					case ItemActivation.LAST:
+						this.ui.list.focus(QuickInputListFocus.Last);
+						this._itemActivation = ItemActivation.FIRST; // only valid once, then unset
+						break;
+					default:
+						this.trySelectFirst();
+						break;
+				}
+			});
 		}
 		if (this.ui.container.classList.contains('show-checkboxes') !== !!this.canSelectMany) {
 			if (this.canSelectMany) {

--- a/src/vs/platform/quickinput/browser/quickInputTree.ts
+++ b/src/vs/platform/quickinput/browser/quickInputTree.ts
@@ -741,25 +741,6 @@ export class QuickInputTree extends Disposable {
 				indent: 0,
 				horizontalScrolling: false,
 				allowNonCollapsibleParents: true,
-				identityProvider: {
-					getId: element => {
-						// always prefer item over separator because if item is defined, it must be the main item type
-						const mainItem = element.item || element.separator;
-						if (mainItem === undefined) {
-							return '';
-						}
-						// always prefer a defined id if one was specified and use "label + description + detail" as a fallback
-						if (mainItem.id !== undefined) {
-							return mainItem.id;
-						}
-						let id = `label:${mainItem.label}`;
-						id += `$$description:${mainItem.description}`;
-						if (mainItem.type !== 'separator') {
-							id += `$$detail:${mainItem.detail}`;
-						}
-						return id;
-					},
-				},
 				alwaysConsumeMouseWheel: true
 			}
 		));


### PR DESCRIPTION
When QP moved from a list to a tree the identity provider concept behaved differently. Post-move, things were getting/staying selected that shouldn't have been. See the below issues.

This is because the identity provider was, perhaps, working how you expect... treating certain items in the list as other items and thus causing them to be selected.

But as I think about this more, quick pick always operates under the model that the references of those items are really the "id"... so this PR removes the identity provider.

Still fixes https://github.com/microsoft/vscode/issues/209842

Fixes https://github.com/microsoft/vscode/issues/209848

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
