### PR TITLE
additional lightbulb telemetry for insiders

### DIFF
--- a/src/vs/editor/contrib/codeAction/browser/lightBulbWidget.ts
+++ b/src/vs/editor/contrib/codeAction/browser/lightBulbWidget.ts
@@ -7,6 +7,7 @@ import * as dom from 'vs/base/browser/dom';
 import { Gesture } from 'vs/base/browser/touch';
 import { Codicon } from 'vs/base/common/codicons';
 import { Emitter, Event } from 'vs/base/common/event';
+import { HierarchicalKind } from 'vs/base/common/hierarchicalKind';
 import { Disposable } from 'vs/base/common/lifecycle';
 import { ThemeIcon } from 'vs/base/common/themables';
 import 'vs/css!./lightBulbWidget';
@@ -15,10 +16,11 @@ import { EditorOption } from 'vs/editor/common/config/editorOptions';
 import { IPosition } from 'vs/editor/common/core/position';
 import { computeIndentLevel } from 'vs/editor/common/model/utils';
 import { autoFixCommandId, quickFixCommandId } from 'vs/editor/contrib/codeAction/browser/codeAction';
-import type { CodeActionSet, CodeActionTrigger } from 'vs/editor/contrib/codeAction/common/types';
+import { CodeActionKind, type CodeActionSet, type CodeActionTrigger } from 'vs/editor/contrib/codeAction/common/types';
 import * as nls from 'vs/nls';
 import { ICommandService } from 'vs/platform/commands/common/commands';
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
+import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 
 namespace LightBulbState {
 
@@ -64,11 +66,12 @@ export class LightBulbWidget extends Disposable implements IContentWidget {
 		private readonly _editor: ICodeEditor,
 		@IKeybindingService private readonly _keybindingService: IKeybindingService,
 		@ICommandService commandService: ICommandService,
+		@ITelemetryService private readonly _telemetryService: ITelemetryService,
 	) {
 		super();
 
 		this._domNode = dom.$('div.lightBulbWidget');
-		this._domNode.role = 'listbox';
+		this._domNode.role = 'menu';
 		this._register(Gesture.ignoreTarget(this._domNode));
 
 		this._editor.addContentWidget(this);
@@ -189,6 +192,33 @@ export class LightBulbWidget extends Disposable implements IContentWidget {
 			position: { lineNumber: effectiveLineNumber, column: effectiveColumnNumber },
 			preference: LightBulbWidget._posPref
 		});
+
+		const validActions = actions.validActions;
+		const actionKind = actions.validActions[0].action.kind;
+		if (validActions.length !== 1 || !actionKind) {
+			this._editor.layoutContentWidget(this);
+			return;
+		}
+
+		const hierarchicalKind = new HierarchicalKind(actionKind);
+
+		if (CodeActionKind.RefactorMove.contains(hierarchicalKind)) {
+			// Telemetry for showing code actions here. only log on `showLightbulb`. Logs when code action list is quit out.
+			type ShowCodeActionListEvent = {
+				codeActionListLength: number;
+			};
+
+			type ShowListEventClassification = {
+				codeActionListLength: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The length of the code action list when quit out. Can be from any code action menu.' };
+				owner: 'justschen';
+				comment: 'Event used to gain insights into how often the lightbulb only contains one code action, namely the move to code action. ';
+			};
+
+			this._telemetryService.publicLog2<ShowCodeActionListEvent, ShowListEventClassification>('lightbulbWidget.moveToCodeActions', {
+				codeActionListLength: validActions.length,
+			});
+		}
+
 		this._editor.layoutContentWidget(this);
 	}
 

--- a/src/vs/editor/contrib/codeAction/browser/lightBulbWidget.ts
+++ b/src/vs/editor/contrib/codeAction/browser/lightBulbWidget.ts
@@ -16,7 +16,7 @@ import { EditorOption } from 'vs/editor/common/config/editorOptions';
 import { IPosition } from 'vs/editor/common/core/position';
 import { computeIndentLevel } from 'vs/editor/common/model/utils';
 import { autoFixCommandId, quickFixCommandId } from 'vs/editor/contrib/codeAction/browser/codeAction';
-import { CodeActionKind, type CodeActionSet, type CodeActionTrigger } from 'vs/editor/contrib/codeAction/common/types';
+import { CodeActionKind, CodeActionSet, CodeActionTrigger } from 'vs/editor/contrib/codeAction/common/types';
 import * as nls from 'vs/nls';
 import { ICommandService } from 'vs/platform/commands/common/commands';
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
@@ -71,7 +71,7 @@ export class LightBulbWidget extends Disposable implements IContentWidget {
 		super();
 
 		this._domNode = dom.$('div.lightBulbWidget');
-		this._domNode.role = 'menu';
+		this._domNode.role = 'listbox';
 		this._register(Gesture.ignoreTarget(this._domNode));
 
 		this._editor.addContentWidget(this);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

telemetry when lightbulb shows up and only contains a single code action (which is a `move` type code action). 

cc. @isidorn @aiday-mar 