### PR TITLE
Focus into Side Bar commands don't focus the sidebar if the sidebar wasn't already visible (fix #193737)

### DIFF
--- a/src/vs/workbench/browser/parts/sidebar/sidebarActions.ts
+++ b/src/vs/workbench/browser/parts/sidebar/sidebarActions.ts
@@ -37,7 +37,6 @@ export class FocusSideBarAction extends Action2 {
 		// Show side bar
 		if (!layoutService.isVisible(Parts.SIDEBAR_PART)) {
 			layoutService.setPartHidden(false, Parts.SIDEBAR_PART);
-			return;
 		}
 
 		// Focus into active viewlet


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
