### PR TITLE
Feature Addition: added --empty argument for command code; addressing issue #207933

### DIFF
--- a/src/vs/code/node/cli.ts
+++ b/src/vs/code/node/cli.ts
@@ -36,7 +36,9 @@ function shouldSpawnCliProcess(argv: NativeParsedArgs): boolean {
 		|| !!argv['uninstall-extension']
 		|| !!argv['update-extensions']
 		|| !!argv['locate-extension']
-		|| !!argv['telemetry'];
+		|| !!argv['telemetry']
+		|| !!argv['empty']
+		|| argv._.length === 0; // Check if there are no arguments
 }
 
 interface IMainCli {
@@ -182,7 +184,7 @@ export async function main(argv: string[]): Promise<any> {
 	}
 
 	// Just Code
-	else {
+	else if (args.empty || args._.length === 0) {
 		const env: IProcessEnvironment = {
 			...process.env,
 			'ELECTRON_NO_ATTACH_CONSOLE': '1'

--- a/src/vs/platform/environment/common/argv.ts
+++ b/src/vs/platform/environment/common/argv.ts
@@ -30,6 +30,7 @@ export interface NativeParsedArgs {
 	help?: boolean;
 	version?: boolean;
 	telemetry?: boolean;
+	empty?: boolean;
 	status?: boolean;
 	wait?: boolean;
 	waitMarkerFilePath?: string;

--- a/src/vs/platform/environment/node/argv.ts
+++ b/src/vs/platform/environment/node/argv.ts
@@ -125,6 +125,8 @@ export const OPTIONS: OptionDescriptions<Required<NativeParsedArgs>> = {
 	'sandbox': { type: 'boolean' },
 	'telemetry': { type: 'boolean', cat: 't', description: localize('telemetry', "Shows all telemetry events which VS code collects.") },
 
+	'empty': { type: 'boolean' },
+
 	'remote': { type: 'string', allowEmptyValue: true },
 	'folder-uri': { type: 'string[]', cat: 'o', args: 'uri' },
 	'file-uri': { type: 'string[]', cat: 'o', args: 'uri' },


### PR DESCRIPTION
This pull request is for a feature addition addressing issue #207933. This concerns disabling the reopening of files on start, specifically through the command "code". The changes made add an extra argument to the command, labeled "--empty". Testing was done using the already existing test suite (locally and using Travis CI), which it passed. 
