### PR TITLE
cli: fix tunnels not working on Windows

### DIFF
--- a/cli/src/tunnels/code_server.rs
+++ b/cli/src/tunnels/code_server.rs
@@ -479,7 +479,7 @@ impl<'a> ServerBuilder<'a> {
 			.arg("--enable-remote-auto-shutdown")
 			.arg(format!("--port={}", port));
 
-		let child = self.spawn_server_process(cmd)?;
+		let child = self.spawn_server_process(cmd).await?;
 		let log_file = self.get_logfile()?;
 		let plog = self.logger.prefixed(&log::new_code_server_prefix());
 
@@ -553,7 +553,7 @@ impl<'a> ServerBuilder<'a> {
 			.arg("--enable-remote-auto-shutdown")
 			.arg(format!("--socket-path={}", socket.display()));
 
-		let child = self.spawn_server_process(cmd)?;
+		let child = self.spawn_server_process(cmd).await?;
 		let log_file = self.get_logfile()?;
 		let plog = self.logger.prefixed(&log::new_code_server_prefix());
 
@@ -594,13 +594,13 @@ impl<'a> ServerBuilder<'a> {
 		let mut cmd = self.get_base_command();
 		cmd.args(args);
 
-		let child = self.spawn_server_process(cmd)?;
+		let child = self.spawn_server_process(cmd).await?;
 		let plog = self.logger.prefixed(&log::new_code_server_prefix());
 
 		Ok(monitor_server::<M, R>(child, None, plog, true))
 	}
 
-	fn spawn_server_process(&self, mut cmd: Command) -> Result<Child, AnyError> {
+	async fn spawn_server_process(&self, mut cmd: Command) -> Result<Child, AnyError> {
 		info!(self.logger, "Starting server...");
 
 		debug!(self.logger, "Starting server with command... {:?}", cmd);
@@ -615,7 +615,10 @@ impl<'a> ServerBuilder<'a> {
 		let cmd = cmd.creation_flags(
 			winapi::um::winbase::CREATE_NO_WINDOW
 				| winapi::um::winbase::CREATE_NEW_PROCESS_GROUP
-				| winapi::um::winbase::CREATE_BREAKAWAY_FROM_JOB,
+				| get_should_use_breakaway_from_job()
+					.await
+					.then_some(winapi::um::winbase::CREATE_BREAKAWAY_FROM_JOB)
+					.unwrap_or_default(),
 		);
 
 		let child = cmd
@@ -873,4 +876,14 @@ pub async fn download_cli_into_cache(
 			Err(CodeError::CorruptDownload("cli directory is empty").into())
 		}
 	}
+}
+
+#[cfg(target_os = "windows")]
+async fn get_should_use_breakaway_from_job() -> bool {
+	let mut cmd = Command::new("cmd");
+	cmd.creation_flags(
+		winapi::um::winbase::CREATE_NO_WINDOW | winapi::um::winbase::CREATE_BREAKAWAY_FROM_JOB,
+	);
+
+	cmd.args(["/C", "echo ok"]).output().await.is_ok()
 }


### PR DESCRIPTION
I made a change this past iteration to use `CREATE_BREAKAWAY_FROM_JOB`
in order to allow the code-server process to outlive SSH connections run
from the exec server.

However, it appears that this _can_ break things if it's run from a job
that doesn't have the JOB_OBJECT_LIMIT_BREAKAWAY_OK flag set. I'm not
a winapi expert, so this is a simple though perhaps inefficient change
to probe whether we can do this via an echo command before starting the
server.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
