### PR TITLE
[toggleAutoSave]: Toggle Auto save doesn't go back to the selected mode (fix: #211538)

### DIFF
--- a/src/vs/workbench/contrib/files/test/browser/editorAutoSave.test.ts
+++ b/src/vs/workbench/contrib/files/test/browser/editorAutoSave.test.ts
@@ -21,7 +21,7 @@ import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 import { MockContextKeyService } from 'vs/platform/keybinding/test/common/mockKeybindingService';
 import { DEFAULT_EDITOR_ASSOCIATION } from 'vs/workbench/common/editor';
 import { TestWorkspace } from 'vs/platform/workspace/test/common/testWorkspace';
-import { TestContextService, TestMarkerService } from 'vs/workbench/test/common/workbenchTestServices';
+import { TestContextService, TestMarkerService, TestStorageService } from 'vs/workbench/test/common/workbenchTestServices';
 import { UriIdentityService } from 'vs/platform/uriIdentity/common/uriIdentityService';
 import { IAccessibilitySignalService } from 'vs/platform/accessibilitySignal/browser/accessibilitySignalService';
 
@@ -55,7 +55,8 @@ suite('EditorAutoSave', () => {
 			disposables.add(new UriIdentityService(disposables.add(new TestFileService()))),
 			disposables.add(new TestFileService()),
 			new TestMarkerService(),
-			new TestTextResourceConfigurationService(configurationService)
+			new TestTextResourceConfigurationService(configurationService),
+			disposables.add(new TestStorageService())
 		)));
 
 		const part = await createEditorPart(instantiationService, disposables);

--- a/src/vs/workbench/contrib/files/test/browser/textFileEditorTracker.test.ts
+++ b/src/vs/workbench/contrib/files/test/browser/textFileEditorTracker.test.ts
@@ -27,7 +27,7 @@ import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 import { FILE_EDITOR_INPUT_ID } from 'vs/workbench/contrib/files/common/files';
 import { DEFAULT_EDITOR_ASSOCIATION } from 'vs/workbench/common/editor';
 import { TestWorkspace } from 'vs/platform/workspace/test/common/testWorkspace';
-import { TestContextService, TestMarkerService } from 'vs/workbench/test/common/workbenchTestServices';
+import { TestContextService, TestMarkerService, TestStorageService } from 'vs/workbench/test/common/workbenchTestServices';
 import { UriIdentityService } from 'vs/platform/uriIdentity/common/uriIdentityService';
 
 suite('Files - TextFileEditorTracker', () => {
@@ -72,7 +72,8 @@ suite('Files - TextFileEditorTracker', () => {
 			disposables.add(new UriIdentityService(fileService)),
 			fileService,
 			new TestMarkerService(),
-			new TestTextResourceConfigurationService(configurationService)
+			new TestTextResourceConfigurationService(configurationService),
+			disposables.add(new TestStorageService())
 		)));
 
 		const part = await createEditorPart(instantiationService, disposables);

--- a/src/vs/workbench/services/workingCopy/test/electron-sandbox/workingCopyBackupTracker.test.ts
+++ b/src/vs/workbench/services/workingCopy/test/electron-sandbox/workingCopyBackupTracker.test.ts
@@ -35,7 +35,7 @@ import { IEnvironmentService } from 'vs/platform/environment/common/environment'
 import { TestWorkspace, Workspace } from 'vs/platform/workspace/test/common/testWorkspace';
 import { IProgressService } from 'vs/platform/progress/common/progress';
 import { IWorkingCopyEditorService } from 'vs/workbench/services/workingCopy/common/workingCopyEditorService';
-import { TestContextService, TestMarkerService, TestWorkingCopy } from 'vs/workbench/test/common/workbenchTestServices';
+import { TestContextService, TestMarkerService, TestStorageService, TestWorkingCopy } from 'vs/workbench/test/common/workbenchTestServices';
 import { CancellationToken } from 'vs/base/common/cancellation';
 import { IWorkingCopyBackup, WorkingCopyCapabilities } from 'vs/workbench/services/workingCopy/common/workingCopy';
 import { Event, Emitter } from 'vs/base/common/event';
@@ -160,7 +160,8 @@ suite('WorkingCopyBackupTracker (native)', function () {
 			disposables.add(new UriIdentityService(disposables.add(new TestFileService()))),
 			disposables.add(new TestFileService()),
 			new TestMarkerService(),
-			new TestTextResourceConfigurationService(configurationService)
+			new TestTextResourceConfigurationService(configurationService),
+			disposables.add(new TestStorageService())
 		)));
 
 		const part = await createEditorPart(instantiationService, disposables);


### PR DESCRIPTION

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Solve issue: https://github.com/microsoft/vscode/issues/211538

- Did use the StorageService to save the value. And use it from there.
- By introducing the StorageService, i had to update the TestStorageService constructs in 2 other tests files


## For Tests

No tests were implemented for the whole toggle functionality (my changes, and the changes before). 
- I wanted to implement a unit test for it. But i couldn't figure out how to execute a command giving the context in https://github.com/MohamedLamineAllal/vscode/blob/f3d3c69532d74b0dc267dcb9670c98eb0b516915/src/vs/workbench/contrib/files/test/browser/editorAutoSave.test.ts#L102
- If you can point me to how i should go about it. I will add the tests.

Otherwise, i did test the changes of this PR. And it does fix well the problem. Also all tests are passing.

