### PR TITLE
Pressing F6 on Windows doesn't navigate to the secondary side bar (fix #171229)

### DIFF
--- a/src/vs/workbench/browser/actions/navigationActions.ts
+++ b/src/vs/workbench/browser/actions/navigationActions.ts
@@ -273,10 +273,13 @@ abstract class BaseFocusAction extends Action2 {
 					neighbour = next ? Parts.PANEL_PART : Parts.SIDEBAR_PART;
 					break;
 				case Parts.PANEL_PART:
-					neighbour = next ? Parts.STATUSBAR_PART : Parts.EDITOR_PART;
+					neighbour = next ? Parts.AUXILIARYBAR_PART : Parts.EDITOR_PART;
+					break;
+				case Parts.AUXILIARYBAR_PART:
+					neighbour = next ? Parts.STATUSBAR_PART : Parts.PANEL_PART;
 					break;
 				case Parts.STATUSBAR_PART:
-					neighbour = next ? Parts.ACTIVITYBAR_PART : Parts.PANEL_PART;
+					neighbour = next ? Parts.ACTIVITYBAR_PART : Parts.AUXILIARYBAR_PART;
 					break;
 				case Parts.ACTIVITYBAR_PART:
 					neighbour = next ? Parts.SIDEBAR_PART : Parts.STATUSBAR_PART;
@@ -306,6 +309,8 @@ abstract class BaseFocusAction extends Action2 {
 			currentlyFocusedPart = Parts.STATUSBAR_PART;
 		} else if (layoutService.hasFocus(Parts.SIDEBAR_PART)) {
 			currentlyFocusedPart = Parts.SIDEBAR_PART;
+		} else if (layoutService.hasFocus(Parts.AUXILIARYBAR_PART)) {
+			currentlyFocusedPart = Parts.AUXILIARYBAR_PART;
 		} else if (layoutService.hasFocus(Parts.PANEL_PART)) {
 			currentlyFocusedPart = Parts.PANEL_PART;
 		}

--- a/src/vs/workbench/browser/layout.ts
+++ b/src/vs/workbench/browser/layout.ts
@@ -1148,6 +1148,10 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 				this.paneCompositeService.getActivePaneComposite(ViewContainerLocation.Sidebar)?.focus();
 				break;
 			}
+			case Parts.AUXILIARYBAR_PART: {
+				this.paneCompositeService.getActivePaneComposite(ViewContainerLocation.AuxiliaryBar)?.focus();
+				break;
+			}
 			case Parts.ACTIVITYBAR_PART:
 				(this.getPart(Parts.SIDEBAR_PART) as SidebarPart).focusActivityBar();
 				break;

--- a/src/vs/workbench/browser/parts/paneCompositePart.ts
+++ b/src/vs/workbench/browser/parts/paneCompositePart.ts
@@ -526,7 +526,7 @@ export abstract class AbstractPaneCompositePart extends CompositePart<PaneCompos
 		this.hideActiveComposite();
 	}
 
-	protected focusComositeBar(): void {
+	protected focusCompositeBar(): void {
 		this.paneCompositeBar.value?.focus();
 	}
 

--- a/src/vs/workbench/browser/parts/sidebar/sidebarPart.ts
+++ b/src/vs/workbench/browser/parts/sidebar/sidebarPart.ts
@@ -257,7 +257,7 @@ export class SidebarPart extends AbstractPaneCompositePart {
 			this.onDidChangeActivityBarLocation();
 		}
 		if (this.shouldShowCompositeBar()) {
-			this.focusComositeBar();
+			this.focusCompositeBar();
 		} else {
 			if (!this.layoutService.isVisible(Parts.ACTIVITYBAR_PART)) {
 				this.layoutService.setPartHidden(false, Parts.ACTIVITYBAR_PART);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
