### PR TITLE
`visibleTextEditorControls` in the editor service doesn't return all visible text editor controls (fix #211357)

### DIFF
--- a/src/vs/workbench/contrib/scm/browser/dirtydiffDecorator.ts
+++ b/src/vs/workbench/contrib/scm/browser/dirtydiffDecorator.ts
@@ -58,10 +58,6 @@ import { AccessibilitySignal, IAccessibilitySignalService } from 'vs/platform/ac
 import { IAccessibilityService } from 'vs/platform/accessibility/common/accessibility';
 import { IQuickDiffService, QuickDiff } from 'vs/workbench/contrib/scm/common/quickDiff';
 import { IQuickDiffSelectItem, SwitchQuickDiffBaseAction, SwitchQuickDiffViewItem } from 'vs/workbench/contrib/scm/browser/dirtyDiffSwitcher';
-import { TextDiffEditor } from 'vs/workbench/browser/parts/editor/textDiffEditor';
-import { IEditorControl } from 'vs/workbench/common/editor';
-import { TextFileEditor } from 'vs/workbench/contrib/files/browser/editors/textFileEditor';
-import { SideBySideEditor } from 'vs/workbench/browser/parts/editor/sideBySideEditor';
 
 class DiffActionRunner extends ActionRunner {
 
@@ -1653,28 +1649,8 @@ export class DirtyDiffWorkbenchController extends Disposable implements ext.IWor
 		this.enabled = false;
 	}
 
-	private getVisibleEditorControls(): IEditorControl[] {
-		const controls: IEditorControl[] = [];
-		const addControl = (control: IEditorControl | undefined) => {
-			if (control) {
-				controls.push(control);
-			}
-		};
-
-		for (const editorPane of this.editorService.visibleEditorPanes) {
-			if (editorPane instanceof TextDiffEditor || editorPane instanceof TextFileEditor) {
-				addControl(editorPane.getControl());
-			} else if (editorPane instanceof SideBySideEditor) {
-				addControl(editorPane.getPrimaryEditorPane()?.getControl());
-				addControl(editorPane.getSecondaryEditorPane()?.getControl());
-			}
-		}
-		return controls;
-	}
-
 	private onEditorsChanged(): void {
-		const visibleControls = this.getVisibleEditorControls();
-		for (const editor of visibleControls) {
+		for (const editor of this.editorService.visibleTextEditorControls) {
 			if (isCodeEditor(editor)) {
 				const textModel = editor.getModel();
 				const controller = DirtyDiffController.get(editor);
@@ -1700,7 +1676,7 @@ export class DirtyDiffWorkbenchController extends Disposable implements ext.IWor
 
 		for (const [uri, item] of this.items) {
 			for (const editorId of item.keys()) {
-				if (!this.getVisibleEditorControls().find(editor => isCodeEditor(editor) && editor.getModel()?.uri.toString() === uri.toString() && editor.getId() === editorId)) {
+				if (!this.editorService.visibleTextEditorControls.find(editor => isCodeEditor(editor) && editor.getModel()?.uri.toString() === uri.toString() && editor.getId() === editorId)) {
 					if (item.has(editorId)) {
 						const dirtyDiffItem = item.get(editorId);
 						dirtyDiffItem?.dispose();

--- a/src/vs/workbench/services/editor/browser/editorService.ts
+++ b/src/vs/workbench/services/editor/browser/editorService.ts
@@ -5,7 +5,7 @@
 
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { IResourceEditorInput, IEditorOptions, EditorActivation, IResourceEditorInputIdentifier, ITextResourceEditorInput } from 'vs/platform/editor/common/editor';
-import { SideBySideEditor, IEditorPane, GroupIdentifier, IUntitledTextResourceEditorInput, IResourceDiffEditorInput, EditorInputWithOptions, isEditorInputWithOptions, IEditorIdentifier, IEditorCloseEvent, ITextDiffEditorPane, IRevertOptions, SaveReason, EditorsOrder, IWorkbenchEditorConfiguration, EditorResourceAccessor, IVisibleEditorPane, EditorInputCapabilities, isResourceDiffEditorInput, IUntypedEditorInput, isResourceEditorInput, isEditorInput, isEditorInputWithOptionsAndGroup, IFindEditorOptions, isResourceMergeEditorInput, IEditorWillOpenEvent } from 'vs/workbench/common/editor';
+import { SideBySideEditor, IEditorPane, GroupIdentifier, IUntitledTextResourceEditorInput, IResourceDiffEditorInput, EditorInputWithOptions, isEditorInputWithOptions, IEditorIdentifier, IEditorCloseEvent, ITextDiffEditorPane, IRevertOptions, SaveReason, EditorsOrder, IWorkbenchEditorConfiguration, EditorResourceAccessor, IVisibleEditorPane, EditorInputCapabilities, isResourceDiffEditorInput, IUntypedEditorInput, isResourceEditorInput, isEditorInput, isEditorInputWithOptionsAndGroup, IFindEditorOptions, isResourceMergeEditorInput, IEditorWillOpenEvent, IEditorControl } from 'vs/workbench/common/editor';
 import { EditorInput } from 'vs/workbench/common/editor/editorInput';
 import { SideBySideEditorInput } from 'vs/workbench/common/editor/sideBySideEditorInput';
 import { ResourceMap, ResourceSet } from 'vs/base/common/map';
@@ -14,6 +14,7 @@ import { Event, Emitter } from 'vs/base/common/event';
 import { URI } from 'vs/base/common/uri';
 import { joinPath } from 'vs/base/common/resources';
 import { DiffEditorInput } from 'vs/workbench/common/editor/diffEditorInput';
+import { SideBySideEditor as SideBySideEditorPane } from 'vs/workbench/browser/parts/editor/sideBySideEditor';
 import { IEditorGroupsService, IEditorGroup, GroupsOrder, IEditorReplacement, isEditorReplacement, ICloseEditorOptions, IEditorGroupsContainer } from 'vs/workbench/services/editor/common/editorGroupsService';
 import { IUntypedEditorReplacement, IEditorService, ISaveEditorsOptions, ISaveAllEditorsOptions, IRevertAllEditorsOptions, IBaseSaveRevertAllEditorOptions, IOpenEditorsOptions, PreferredGroup, isPreferredGroup, IEditorsChangeEvent, ISaveEditorsResult } from 'vs/workbench/services/editor/common/editorService';
 import { IConfigurationChangeEvent, IConfigurationService } from 'vs/platform/configuration/common/configuration';
@@ -491,9 +492,18 @@ export class EditorService extends Disposable implements EditorServiceImpl {
 	get visibleTextEditorControls(): Array<ICodeEditor | IDiffEditor> {
 		const visibleTextEditorControls: Array<ICodeEditor | IDiffEditor> = [];
 		for (const visibleEditorPane of this.visibleEditorPanes) {
-			const control = visibleEditorPane.getControl();
-			if (isCodeEditor(control) || isDiffEditor(control)) {
-				visibleTextEditorControls.push(control);
+			const controls: Array<IEditorControl | undefined> = [];
+			if (visibleEditorPane instanceof SideBySideEditorPane) {
+				controls.push(visibleEditorPane.getPrimaryEditorPane()?.getControl());
+				controls.push(visibleEditorPane.getSecondaryEditorPane()?.getControl());
+			} else {
+				controls.push(visibleEditorPane.getControl());
+			}
+
+			for (const control of controls) {
+				if (isCodeEditor(control) || isDiffEditor(control)) {
+					visibleTextEditorControls.push(control);
+				}
 			}
 		}
 

--- a/src/vs/workbench/services/editor/common/editorService.ts
+++ b/src/vs/workbench/services/editor/common/editorService.ts
@@ -207,6 +207,9 @@ export interface IEditorService {
 	/**
 	 * All text editor widgets that are currently visible across all editor groups. A text editor
 	 * widget is either a text or a diff editor.
+	 *
+	 * This property supports side-by-side editors as well, by returning both sides if they are
+	 * text editor widgets.
 	 */
 	readonly visibleTextEditorControls: readonly (IEditor | IDiffEditor)[];
 


### PR DESCRIPTION
@alexr00 this is a revert of your changes with the intent that the editor service considers them now, could you check?