### PR TITLE
strings: make 'count' much faster

### DIFF
--- a/src/vs/base/common/strings.ts
+++ b/src/vs/base/common/strings.ts
@@ -90,15 +90,14 @@ export function escapeRegExpCharacters(value: string): string {
 }
 
 /**
- * Counts how often `character` occurs inside `value`.
+ * Counts how often `substr` occurs inside `value`.
  */
-export function count(value: string, character: string): number {
+export function count(value: string, substr: string): number {
 	let result = 0;
-	const ch = character.charCodeAt(0);
-	for (let i = value.length - 1; i >= 0; i--) {
-		if (value.charCodeAt(i) === ch) {
-			result++;
-		}
+	let index = value.indexOf(substr);
+	while (index !== -1) {
+		result++;
+		index = value.indexOf(substr, index + substr.length);
 	}
 	return result;
 }

--- a/src/vs/base/test/common/strings.test.ts
+++ b/src/vs/base/test/common/strings.test.ts
@@ -543,6 +543,16 @@ suite('Strings', () => {
 		assert.strictEqual(strings.removeAnsiEscapeCodesFromPrompt('\n\\[\u001b[01;34m\\]\\w\\[\u001b[00m\\]\n\\[\u001b[1;32m\\]> \\[\u001b[0m\\]'), '\n\\w\n> ');
 	});
 
+	test('count', () => {
+		assert.strictEqual(strings.count('hello world', 'o'), 2);
+		assert.strictEqual(strings.count('hello world', 'l'), 3);
+		assert.strictEqual(strings.count('hello world', 'z'), 0);
+		assert.strictEqual(strings.count('hello world', 'hello'), 1);
+		assert.strictEqual(strings.count('hello world', 'world'), 1);
+		assert.strictEqual(strings.count('hello world', 'hello world'), 1);
+		assert.strictEqual(strings.count('hello world', 'foo'), 0);
+	});
+
 	ensureNoDisposablesAreLeakedInTestSuite();
 });
 


### PR DESCRIPTION
I noticed in doing a fix in copilot that our 'count' function was glacially slow. This is significantly faster.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
