### PR TITLE
Fix markdown links not rendered as links while the link is incomplete

### DIFF
--- a/src/vs/base/browser/markdownRenderer.ts
+++ b/src/vs/base/browser/markdownRenderer.ts
@@ -809,7 +809,7 @@ function completeLinkTargetArg(tokens: marked.Token): marked.Token {
 }
 
 function completeLinkText(tokens: marked.Token): marked.Token {
-	return completeWithString(tokens, '](about:blank)');
+	return completeWithString(tokens, '](https://microsoft.com)');
 }
 
 function completeDoublestar(tokens: marked.Token): marked.Token {

--- a/src/vs/base/test/browser/markdownRenderer.test.ts
+++ b/src/vs/base/test/browser/markdownRenderer.test.ts
@@ -660,7 +660,7 @@ const y = 2;
 				const tokens = marked.lexer(incomplete);
 				const newTokens = fillInIncompleteTokens(tokens);
 
-				const completeTokens = marked.lexer(incomplete + '](about:blank)');
+				const completeTokens = marked.lexer(incomplete + '](https://microsoft.com)');
 				assert.deepStrictEqual(newTokens, completeTokens);
 			});
 
@@ -680,7 +680,7 @@ const y = 2;
 				const tokens = marked.lexer(incomplete);
 				const newTokens = fillInIncompleteTokens(tokens);
 
-				const completeTokens = marked.lexer(incomplete + '\`](about:blank)');
+				const completeTokens = marked.lexer(incomplete + '\`](https://microsoft.com)');
 				assert.deepStrictEqual(newTokens, completeTokens);
 			});
 		});
@@ -772,7 +772,7 @@ const y = 2;
 				const tokens = marked.lexer(incomplete);
 				const newTokens = fillInIncompleteTokens(tokens);
 
-				const completeTokens = marked.lexer(incomplete + '](about:blank)');
+				const completeTokens = marked.lexer(incomplete + '](https://microsoft.com)');
 				assert.deepStrictEqual(newTokens, completeTokens);
 			});
 
@@ -844,7 +844,7 @@ const y = 2;
 				const tokens = marked.lexer(incomplete);
 				const newTokens = fillInIncompleteTokens(tokens);
 
-				const completeTokens = marked.lexer(incomplete + '`](about:blank)');
+				const completeTokens = marked.lexer(incomplete + '`](https://microsoft.com)');
 				assert.deepStrictEqual(newTokens, completeTokens);
 			});
 
@@ -853,7 +853,7 @@ const y = 2;
 				const tokens = marked.lexer(incomplete);
 				const newTokens = fillInIncompleteTokens(tokens);
 
-				const completeTokens = marked.lexer(incomplete + '**](about:blank)');
+				const completeTokens = marked.lexer(incomplete + '**](https://microsoft.com)');
 				assert.deepStrictEqual(newTokens, completeTokens);
 			});
 
@@ -871,7 +871,7 @@ const y = 2;
 				const tokens = marked.lexer(incomplete);
 				const newTokens = fillInIncompleteTokens(tokens);
 
-				const completeTokens = marked.lexer(incomplete + '](about:blank)');
+				const completeTokens = marked.lexer(incomplete + '](https://microsoft.com)');
 				assert.deepStrictEqual(newTokens, completeTokens);
 			});
 


### PR DESCRIPTION
Because about:blank isn't recognized as a valid url by the markdown renderer

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
