### PR TITLE
Pasting inside a floating window throws a clipboard access error in vscode.dev, even though paste works (fix #211774)

### DIFF
--- a/src/vs/platform/clipboard/browser/clipboardService.ts
+++ b/src/vs/platform/clipboard/browser/clipboardService.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { isSafari, isWebkitWebView } from 'vs/base/browser/browser';
-import { $, addDisposableListener, getActiveDocument, onDidRegisterWindow } from 'vs/base/browser/dom';
+import { $, addDisposableListener, getActiveDocument, getActiveWindow, onDidRegisterWindow } from 'vs/base/browser/dom';
 import { mainWindow } from 'vs/base/browser/window';
 import { DeferredPromise } from 'vs/base/common/async';
 import { Event } from 'vs/base/common/event';
@@ -66,7 +66,7 @@ export class BrowserClipboardService extends Disposable implements IClipboardSer
 			// This allows us to pass in a Promise that will either be cancelled by another event or
 			// resolved with the contents of the first call to this.writeText.
 			// see https://developer.mozilla.org/en-US/docs/Web/API/ClipboardItem/ClipboardItem#parameters
-			navigator.clipboard.write([new ClipboardItem({
+			getActiveWindow().navigator.clipboard.write([new ClipboardItem({
 				'text/plain': currentWritePromise.p,
 			})]).catch(async err => {
 				if (!(err instanceof Error) || err.name !== 'NotAllowedError' || !currentWritePromise.isRejected) {
@@ -106,7 +106,7 @@ export class BrowserClipboardService extends Disposable implements IClipboardSer
 		// as we have seen DOMExceptions in certain browsers
 		// due to security policies.
 		try {
-			return await navigator.clipboard.writeText(text);
+			return await getActiveWindow().navigator.clipboard.writeText(text);
 		} catch (error) {
 			console.error(error);
 		}
@@ -148,7 +148,7 @@ export class BrowserClipboardService extends Disposable implements IClipboardSer
 		// as we have seen DOMExceptions in certain browsers
 		// due to security policies.
 		try {
-			return await navigator.clipboard.readText();
+			return await getActiveWindow().navigator.clipboard.readText();
 		} catch (error) {
 			console.error(error);
 		}

--- a/src/vs/workbench/services/clipboard/browser/clipboardService.ts
+++ b/src/vs/workbench/services/clipboard/browser/clipboardService.ts
@@ -14,6 +14,7 @@ import { DisposableStore } from 'vs/base/common/lifecycle';
 import { IWorkbenchEnvironmentService } from 'vs/workbench/services/environment/common/environmentService';
 import { ILogService } from 'vs/platform/log/common/log';
 import { ILayoutService } from 'vs/platform/layout/browser/layoutService';
+import { getActiveWindow } from 'vs/base/browser/dom';
 
 export class BrowserClipboardService extends BaseBrowserClipboardService {
 
@@ -33,7 +34,7 @@ export class BrowserClipboardService extends BaseBrowserClipboardService {
 		}
 
 		try {
-			return await navigator.clipboard.readText();
+			return await getActiveWindow().navigator.clipboard.readText();
 		} catch (error) {
 			if (!!this.environmentService.extensionTestsLocationURI) {
 				return ''; // do not ask for input in tests (https://github.com/microsoft/vscode/issues/112264)


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
