### PR TITLE
Fix shellIntegration tests on mac

### DIFF
--- a/extensions/vscode-api-tests/src/singlefolder-tests/terminal.shellIntegration.test.ts
+++ b/extensions/vscode-api-tests/src/singlefolder-tests/terminal.shellIntegration.test.ts
@@ -39,7 +39,9 @@ import { assertNoRpc } from '../utils';
 					});
 				}
 			}));
-			const terminal = window.createTerminal();
+			const terminal = platform() === 'win32'
+				? window.createTerminal()
+				: window.createTerminal({ shellPath: '/bin/bash' });
 			terminal.show();
 		});
 	}

--- a/src/vs/workbench/contrib/terminal/browser/media/shellIntegration-bash.sh
+++ b/src/vs/workbench/contrib/terminal/browser/media/shellIntegration-bash.sh
@@ -170,7 +170,12 @@ builtin printf "\e]633;P;ContinuationPrompt=$(echo "$PS2" | sed 's/\x1b/\\\\x1b/
 __vsc_report_prompt() {
 	# Expand the original PS1 similarly to how bash would normally
 	# See https://stackoverflow.com/a/37137981 for technique
-	__vsc_prompt=${__vsc_original_PS1}
+	if ((BASH_VERSINFO[0] >= 4)); then
+		__vsc_prompt=${__vsc_original_PS1@P}
+	else
+		__vsc_prompt=${__vsc_original_PS1}
+	fi
+
 	__vsc_prompt="$(builtin printf "%s" "${__vsc_prompt//[$'\001'$'\002']}")"
 	builtin printf "\e]633;P;Prompt=%s\a" "$(__vsc_escape_value "${__vsc_prompt}")"
 }

--- a/src/vs/workbench/contrib/terminal/browser/media/shellIntegration-bash.sh
+++ b/src/vs/workbench/contrib/terminal/browser/media/shellIntegration-bash.sh
@@ -170,7 +170,7 @@ builtin printf "\e]633;P;ContinuationPrompt=$(echo "$PS2" | sed 's/\x1b/\\\\x1b/
 __vsc_report_prompt() {
 	# Expand the original PS1 similarly to how bash would normally
 	# See https://stackoverflow.com/a/37137981 for technique
-	__vsc_prompt=${__vsc_original_PS1@P}
+	__vsc_prompt=${__vsc_original_PS1}
 	__vsc_prompt="$(builtin printf "%s" "${__vsc_prompt//[$'\001'$'\002']}")"
 	builtin printf "\e]633;P;Prompt=%s\a" "$(__vsc_escape_value "${__vsc_prompt}")"
 }
@@ -238,9 +238,9 @@ __vsc_update_prompt() {
 __vsc_precmd() {
 	__vsc_command_complete "$__vsc_status"
 	__vsc_current_command=""
-	__vsc_update_prompt
 	__vsc_report_prompt
 	__vsc_first_prompt=1
+	__vsc_update_prompt
 }
 
 __vsc_preexec() {


### PR DESCRIPTION
Problems:

- zsh may pause on launch on an update prompt during tests which breaks everything
- @P doesn't work in old bash shipped with macOS
- Execution read included function calls from bash script

cc @cpendery 