### PR TITLE
Add outline data source classes + unit testing

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/contrib/outline/notebookOutline.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/outline/notebookOutline.ts
@@ -33,7 +33,7 @@ import { NotebookCellOutlineProvider } from 'vs/workbench/contrib/notebook/brows
 import { CellKind, NotebookSetting } from 'vs/workbench/contrib/notebook/common/notebookCommon';
 import { IEditorService, SIDE_GROUP } from 'vs/workbench/services/editor/common/editorService';
 import { LifecyclePhase } from 'vs/workbench/services/lifecycle/common/lifecycle';
-import { IOutline, IOutlineComparator, IOutlineCreator, IOutlineListConfig, IOutlineService, IQuickPickDataSource, IQuickPickOutlineElement, OutlineChangeEvent, OutlineConfigCollapseItemsValues, OutlineConfigKeys, OutlineTarget } from 'vs/workbench/services/outline/browser/outline';
+import { IBreadcrumbsDataSource, IOutline, IOutlineComparator, IOutlineCreator, IOutlineListConfig, IOutlineService, IQuickPickDataSource, IQuickPickOutlineElement, OutlineChangeEvent, OutlineConfigCollapseItemsValues, OutlineConfigKeys, OutlineTarget } from 'vs/workbench/services/outline/browser/outline';
 import { OutlineEntry } from 'vs/workbench/contrib/notebook/browser/viewModel/OutlineEntry';
 import { CancellationToken } from 'vs/base/common/cancellation';
 import { IModelDeltaDecoration } from 'vs/editor/common/model';
@@ -332,6 +332,53 @@ class NotebookQuickPickProvider implements IQuickPickDataSource<OutlineEntry> {
 	}
 }
 
+class NotebookOutlinePaneProvider implements IDataSource<NotebookCellOutline, OutlineEntry> {
+	constructor(
+		private _getEntries: () => OutlineEntry[],
+		@IConfigurationService private readonly _configurationService: IConfigurationService,
+	) { }
+
+	*getChildren(element: NotebookCellOutline | OutlineEntry): Iterable<OutlineEntry> {
+		const showCodeCells = this._configurationService.getValue<boolean>(NotebookSetting.outlineShowCodeCells);
+		const showCodeCellSymbols = this._configurationService.getValue<boolean>(NotebookSetting.outlineShowCodeCellSymbols);
+		const showMarkdownHeadersOnly = this._configurationService.getValue<boolean>(NotebookSetting.outlineShowMarkdownHeadersOnly);
+
+		for (const entry of element instanceof NotebookCellOutline ? (this._getEntries()) : element.children) {
+			if (entry.cell.cellKind === CellKind.Markup) {
+				if (!showMarkdownHeadersOnly) {
+					yield entry;
+				} else if (entry.level < NotebookOutlineConstants.NonHeaderOutlineLevel) {
+					yield entry;
+				}
+
+			} else if (showCodeCells && entry.cell.cellKind === CellKind.Code) {
+				if (showCodeCellSymbols) {
+					yield entry;
+				} else if (entry.level === NotebookOutlineConstants.NonHeaderOutlineLevel) {
+					yield entry;
+				}
+			}
+		}
+	}
+}
+
+class NotebookBreadcrumbsProvider implements IBreadcrumbsDataSource<OutlineEntry> {
+	constructor(
+		private _getActiveElement: () => OutlineEntry | undefined,
+		// @IConfigurationService private readonly _configurationService: IConfigurationService, // TODO: @Yoyokrazy will need this service once we start filtering entries at this layer
+	) { }
+
+	getBreadcrumbElements(): readonly OutlineEntry[] {
+		const result: OutlineEntry[] = [];
+		let candidate = this._getActiveElement();
+		while (candidate) {
+			result.unshift(candidate);
+			candidate = candidate.parent;
+		}
+		return result;
+	}
+}
+
 class NotebookComparator implements IOutlineComparator<OutlineEntry> {
 
 	private readonly _collator = new DOM.WindowIdleValue<Intl.Collator>(mainWindow, () => new Intl.Collator(undefined, { numeric: true }));
@@ -400,11 +447,6 @@ export class NotebookCellOutline implements IOutline<OutlineEntry> {
 		}));
 
 		installSelectionListener();
-		const treeDataSource: IDataSource<this, OutlineEntry> = {
-			getChildren: parent => {
-				return this.getChildren(parent, _configurationService);
-			}
-		};
 		const delegate = new NotebookOutlineVirtualDelegate();
 		const renderers = [instantiationService.createInstance(NotebookOutlineRenderer, this._editor.getControl(), _target)];
 		const comparator = new NotebookComparator();
@@ -419,47 +461,14 @@ export class NotebookCellOutline implements IOutline<OutlineEntry> {
 		};
 
 		this.config = {
-			breadcrumbsDataSource: {
-				getBreadcrumbElements: () => {
-					const result: OutlineEntry[] = [];
-					let candidate = this.activeElement;
-					while (candidate) {
-						result.unshift(candidate);
-						candidate = candidate.parent;
-					}
-					return result;
-				}
-			},
-			quickPickDataSource: instantiationService.createInstance(NotebookQuickPickProvider, () => (this._outlineProviderReference?.object?.entries ?? [])),
-			treeDataSource,
+			treeDataSource: instantiationService.createInstance(NotebookOutlinePaneProvider, () => (this.entries ?? [])),
+			quickPickDataSource: instantiationService.createInstance(NotebookQuickPickProvider, () => (this.entries ?? [])),
+			breadcrumbsDataSource: instantiationService.createInstance(NotebookBreadcrumbsProvider, () => (this.activeElement)),
 			delegate,
 			renderers,
 			comparator,
 			options
 		};
-	}
-
-	*getChildren(parent: OutlineEntry | NotebookCellOutline, configurationService: IConfigurationService): Iterable<OutlineEntry> {
-		const showCodeCells = configurationService.getValue<boolean>(NotebookSetting.outlineShowCodeCells);
-		const showCodeCellSymbols = configurationService.getValue<boolean>(NotebookSetting.outlineShowCodeCellSymbols);
-		const showMarkdownHeadersOnly = configurationService.getValue<boolean>(NotebookSetting.outlineShowMarkdownHeadersOnly);
-
-		for (const entry of parent instanceof NotebookCellOutline ? (this._outlineProviderReference?.object?.entries ?? []) : parent.children) {
-			if (entry.cell.cellKind === CellKind.Markup) {
-				if (!showMarkdownHeadersOnly) {
-					yield entry;
-				} else if (entry.level < NotebookOutlineConstants.NonHeaderOutlineLevel) {
-					yield entry;
-				}
-
-			} else if (showCodeCells && entry.cell.cellKind === CellKind.Code) {
-				if (showCodeCellSymbols) {
-					yield entry;
-				} else if (entry.level === NotebookOutlineConstants.NonHeaderOutlineLevel) {
-					yield entry;
-				}
-			}
-		}
 	}
 
 	async setFullSymbols(cancelToken: CancellationToken) {

--- a/src/vs/workbench/contrib/notebook/browser/contrib/outline/notebookOutline.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/outline/notebookOutline.ts
@@ -284,7 +284,7 @@ class NotebookOutlineVirtualDelegate implements IListVirtualDelegate<OutlineEntr
 	}
 }
 
-class NotebookQuickPickProvider implements IQuickPickDataSource<OutlineEntry> {
+export class NotebookQuickPickProvider implements IQuickPickDataSource<OutlineEntry> {
 
 	constructor(
 		private _getEntries: () => OutlineEntry[],
@@ -332,7 +332,7 @@ class NotebookQuickPickProvider implements IQuickPickDataSource<OutlineEntry> {
 	}
 }
 
-class NotebookOutlinePaneProvider implements IDataSource<NotebookCellOutline, OutlineEntry> {
+export class NotebookOutlinePaneProvider implements IDataSource<NotebookCellOutline, OutlineEntry> {
 	constructor(
 		private _getEntries: () => OutlineEntry[],
 		@IConfigurationService private readonly _configurationService: IConfigurationService,
@@ -343,7 +343,10 @@ class NotebookOutlinePaneProvider implements IDataSource<NotebookCellOutline, Ou
 		const showCodeCellSymbols = this._configurationService.getValue<boolean>(NotebookSetting.outlineShowCodeCellSymbols);
 		const showMarkdownHeadersOnly = this._configurationService.getValue<boolean>(NotebookSetting.outlineShowMarkdownHeadersOnly);
 
-		for (const entry of element instanceof NotebookCellOutline ? (this._getEntries()) : element.children) {
+		const isOutline = element instanceof NotebookCellOutline;
+		const entries = isOutline ? this._getEntries() : element.children;
+
+		for (const entry of entries) {
 			if (entry.cell.cellKind === CellKind.Markup) {
 				if (!showMarkdownHeadersOnly) {
 					yield entry;
@@ -362,7 +365,7 @@ class NotebookOutlinePaneProvider implements IDataSource<NotebookCellOutline, Ou
 	}
 }
 
-class NotebookBreadcrumbsProvider implements IBreadcrumbsDataSource<OutlineEntry> {
+export class NotebookBreadcrumbsProvider implements IBreadcrumbsDataSource<OutlineEntry> {
 	constructor(
 		private _getActiveElement: () => OutlineEntry | undefined,
 		// @IConfigurationService private readonly _configurationService: IConfigurationService, // TODO: @Yoyokrazy will need this service once we start filtering entries at this layer

--- a/src/vs/workbench/contrib/notebook/browser/contrib/outline/notebookOutline.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/outline/notebookOutline.ts
@@ -368,14 +368,17 @@ export class NotebookOutlinePaneProvider implements IDataSource<NotebookCellOutl
 export class NotebookBreadcrumbsProvider implements IBreadcrumbsDataSource<OutlineEntry> {
 	constructor(
 		private _getActiveElement: () => OutlineEntry | undefined,
-		// @IConfigurationService private readonly _configurationService: IConfigurationService, // TODO: @Yoyokrazy will need this service once we start filtering entries at this layer
+		@IConfigurationService private readonly _configurationService: IConfigurationService,
 	) { }
 
 	getBreadcrumbElements(): readonly OutlineEntry[] {
 		const result: OutlineEntry[] = [];
+		const showCodeCells = this._configurationService.getValue<boolean>(NotebookSetting.breadcrumbsShowCodeCells);
 		let candidate = this._getActiveElement();
 		while (candidate) {
-			result.unshift(candidate);
+			if (showCodeCells || candidate.cell.cellKind !== CellKind.Code) {
+				result.unshift(candidate);
+			}
 			candidate = candidate.parent;
 		}
 		return result;

--- a/src/vs/workbench/contrib/notebook/test/browser/contrib/notebookOutlineViewProviders.test.ts
+++ b/src/vs/workbench/contrib/notebook/test/browser/contrib/notebookOutlineViewProviders.test.ts
@@ -599,14 +599,14 @@ suite('Notebook Outline View Providers', function () {
 		}
 
 		// Generate raw outline
-		const outlineModel = new OutlineEntry(-1, -1, createCodeCellViewModel(), 'fakeRoot', false, false, undefined, undefined);
+		const outlineModel = new OutlineEntry(-1, -1, createMarkupCellViewModel(), 'fakeRoot', false, false, undefined, undefined);
 		for (const cell of cells) {
 			entryFactory.getOutlineEntries(cell, OutlineTarget.OutlinePane, 0).forEach(entry => outlineModel.addChild(entry));
 		}
 		const outlineTree = buildOutlineTree([...outlineModel.children]);
 
 		// Generate filtered outline (view model)
-		const breadcrumbsProvider = new NotebookBreadcrumbsProvider(() => [...outlineTree![0].children][1]);
+		const breadcrumbsProvider = new NotebookBreadcrumbsProvider(() => [...outlineTree![0].children][1], configurationService);
 		const results = breadcrumbsProvider.getBreadcrumbElements();
 
 		// Validate
@@ -622,7 +622,7 @@ suite('Notebook Outline View Providers', function () {
 		assert.equal(results[2].level, 7);
 	});
 
-	test.skip('Breadcrumbs 1: Code Cells Off ', async function () {
+	test('Breadcrumbs 1: Code Cells Off ', async function () {
 		await setOutlineViewConfiguration({
 			outlineShowMarkdownHeadersOnly: false,
 			outlineShowCodeCells: false,
@@ -650,14 +650,14 @@ suite('Notebook Outline View Providers', function () {
 		}
 
 		// Generate raw outline
-		const outlineModel = new OutlineEntry(-1, -1, createCodeCellViewModel(), 'fakeRoot', false, false, undefined, undefined);
+		const outlineModel = new OutlineEntry(-1, -1, createMarkupCellViewModel(), 'fakeRoot', false, false, undefined, undefined);
 		for (const cell of cells) {
 			entryFactory.getOutlineEntries(cell, OutlineTarget.OutlinePane, 0).forEach(entry => outlineModel.addChild(entry));
 		}
 		const outlineTree = buildOutlineTree([...outlineModel.children]);
 
 		// Generate filtered outline (view model)
-		const breadcrumbsProvider = new NotebookBreadcrumbsProvider(() => [...outlineTree![0].children][1]);
+		const breadcrumbsProvider = new NotebookBreadcrumbsProvider(() => [...outlineTree![0].children][1], configurationService);
 		const results = breadcrumbsProvider.getBreadcrumbElements();
 
 		// Validate

--- a/src/vs/workbench/contrib/notebook/test/browser/contrib/notebookOutlineViewProviders.test.ts
+++ b/src/vs/workbench/contrib/notebook/test/browser/contrib/notebookOutlineViewProviders.test.ts
@@ -1,0 +1,382 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { IDataSource } from 'vs/base/browser/ui/tree/tree';
+import { CancellationToken } from 'vs/base/common/cancellation';
+import { mock } from 'vs/base/test/common/mock';
+import { ensureNoDisposablesAreLeakedInTestSuite } from 'vs/base/test/common/utils';
+import { ITextModel } from 'vs/editor/common/model';
+import { IOutlineModelService, OutlineModel } from 'vs/editor/contrib/documentSymbols/browser/outlineModel';
+import { TestConfigurationService } from 'vs/platform/configuration/test/common/testConfigurationService';
+import { TestThemeService } from 'vs/platform/theme/test/common/testThemeService';
+import { NotebookCellOutline, NotebookOutlinePaneProvider, NotebookQuickPickProvider } from 'vs/workbench/contrib/notebook/browser/contrib/outline/notebookOutline';
+import { ICellViewModel } from 'vs/workbench/contrib/notebook/browser/notebookBrowser';
+import { NotebookOutlineEntryFactory } from 'vs/workbench/contrib/notebook/browser/viewModel/notebookOutlineEntryFactory';
+import { OutlineEntry } from 'vs/workbench/contrib/notebook/browser/viewModel/OutlineEntry';
+import { INotebookExecutionStateService } from 'vs/workbench/contrib/notebook/common/notebookExecutionStateService';
+import { textSymbol } from 'vs/workbench/contrib/notebook/test/browser/testNotebookEditor';
+import { OutlineTarget } from 'vs/workbench/services/outline/browser/outline';
+
+suite('Notebook Outline View Providers', function () {
+	// #region Setup
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	const configurationService = new TestConfigurationService();
+	const themeService = new TestThemeService();
+
+	const symbolsPerTextModel: Record<string, textSymbol[]> = {};
+	function setSymbolsForTextModel(symbols: textSymbol[], textmodelId = 'textId') {
+		symbolsPerTextModel[textmodelId] = symbols;
+	}
+
+	const executionService = new class extends mock<INotebookExecutionStateService>() {
+		override getCellExecution() { return undefined; }
+	};
+
+	class OutlineModelStub {
+		constructor(private textId: string) { }
+
+		getTopLevelSymbols() {
+			return symbolsPerTextModel[this.textId];
+		}
+	}
+	const outlineModelService = new class extends mock<IOutlineModelService>() {
+		override getOrCreate(model: ITextModel, arg1: any) {
+			const outline = new OutlineModelStub(model.id) as unknown as OutlineModel;
+			return Promise.resolve(outline);
+		}
+		override getDebounceValue(arg0: any) {
+			return 0;
+		}
+	};
+	// #endregion
+	// #region Helpers
+	function createCodeCellViewModel(version: number = 1, source = '# code', textmodelId = 'textId') {
+		return {
+			textBuffer: {
+				getLineCount() { return 0; }
+			},
+			getText() {
+				return source;
+			},
+			model: {
+				textModel: {
+					id: textmodelId,
+					getVersionId() { return version; }
+				}
+			},
+			resolveTextModel() {
+				return this.model.textModel as unknown;
+			},
+			cellKind: 2
+		} as ICellViewModel;
+	}
+
+	function createMarkupCellViewModel(version: number = 1, source = 'markup', textmodelId = 'textId', alternativeId = 1) {
+		return {
+			textBuffer: {
+				getLineCount() { return 0; }
+			},
+			getText() {
+				return source;
+			},
+			getAlternativeId() {
+				return alternativeId;
+			},
+			model: {
+				textModel: {
+					id: textmodelId,
+					getVersionId() { return version; }
+				}
+			},
+			resolveTextModel() {
+				return this.model.textModel as unknown;
+			},
+			cellKind: 1
+		} as ICellViewModel;
+	}
+
+	function flatten(element: NotebookCellOutline | OutlineEntry, dataSource: IDataSource<NotebookCellOutline, OutlineEntry>): OutlineEntry[] {
+		const elements: OutlineEntry[] = [];
+
+		const children = dataSource.getChildren(element);
+		for (const child of children) {
+			elements.push(child);
+			elements.push(...flatten(child, dataSource));
+		}
+
+		return elements;
+	}
+
+	/**
+	 * Set the configuration settings relevant to various outline views (OutlinePane, QuickPick, Breadcrumbs)
+	 *
+	 * @param outlineShowMarkdownHeadersOnly: boolean 	(notebook.outline.showMarkdownHeadersOnly)
+	 * @param outlineShowCodeCells: boolean 			(notebook.outline.showCodeCells)
+	 * @param outlineShowCodeCellSymbols: boolean 		(notebook.outline.showCodeCellSymbols)
+	 * @param quickPickShowAllSymbols: boolean 			(notebook.gotoSymbols.showAllSymbols)
+	 * @param breadcrumbsShowCodeCells: boolean 		(notebook.breadcrumbs.showCodeCells)
+	 */
+	async function setOutlineViewConfiguration(config: {
+		outlineShowMarkdownHeadersOnly: boolean;
+		outlineShowCodeCells: boolean;
+		outlineShowCodeCellSymbols: boolean;
+		quickPickShowAllSymbols: boolean;
+		breadcrumbsShowCodeCells: boolean;
+	}) {
+		await configurationService.setUserConfiguration('notebook.outline.showMarkdownHeadersOnly', config.outlineShowMarkdownHeadersOnly);
+		await configurationService.setUserConfiguration('notebook.outline.showCodeCells', config.outlineShowCodeCells);
+		await configurationService.setUserConfiguration('notebook.outline.showCodeCellSymbols', config.outlineShowCodeCellSymbols);
+		await configurationService.setUserConfiguration('notebook.gotoSymbols.showAllSymbols', config.quickPickShowAllSymbols);
+		await configurationService.setUserConfiguration('notebook.breadcrumbs.showCodeCells', config.breadcrumbsShowCodeCells);
+	}
+	// #endregion
+	// #region OutlinePane
+	test('OutlinePane 0: Default Settings (Headers Only ON, Code cells OFF, Symbols ON)', async function () {
+		await setOutlineViewConfiguration({
+			outlineShowMarkdownHeadersOnly: true,
+			outlineShowCodeCells: false,
+			outlineShowCodeCellSymbols: true,
+			quickPickShowAllSymbols: false,
+			breadcrumbsShowCodeCells: false
+		});
+
+		// Create models + symbols
+		const cells = [
+			createMarkupCellViewModel(1, '# h1', '$0', 0),
+			createMarkupCellViewModel(1, 'plaintext', '$1', 0),
+			createCodeCellViewModel(1, '# code cell 2', '$2'),
+			createCodeCellViewModel(1, '# code cell 3', '$3')
+		];
+		setSymbolsForTextModel([], '$0');
+		setSymbolsForTextModel([], '$1');
+		setSymbolsForTextModel([{ name: 'var2', range: {} }], '$2');
+		setSymbolsForTextModel([{ name: 'var3', range: {} }], '$3');
+
+		// Cache symbols
+		const entryFactory = new NotebookOutlineEntryFactory(executionService);
+		for (const cell of cells) {
+			await entryFactory.cacheSymbols(cell, outlineModelService, CancellationToken.None);
+		}
+
+		// Generate raw outline
+		const outlineModel = new OutlineEntry(-1, -1, createCodeCellViewModel(), 'fakeRoot', false, false, undefined, undefined);
+		for (const cell of cells) {
+			entryFactory.getOutlineEntries(cell, OutlineTarget.OutlinePane, 0).forEach(entry => outlineModel.addChild(entry));
+		}
+
+		// Generate filtered outline (view model)
+		const outlinePaneProvider = new NotebookOutlinePaneProvider(() => [], configurationService);
+		const results = flatten(outlineModel, outlinePaneProvider);
+
+		// Validate
+		assert.equal(results.length, 1);
+		assert.equal(results[0].label, 'h1');
+		assert.equal(results[0].level, 1);
+	});
+
+	test('OutlinePane 1: ALL Markdown', async function () {
+		await setOutlineViewConfiguration({
+			outlineShowMarkdownHeadersOnly: false,
+			outlineShowCodeCells: false,
+			outlineShowCodeCellSymbols: false,
+			quickPickShowAllSymbols: false,
+			breadcrumbsShowCodeCells: false
+		});
+
+		// Create models + symbols
+		const cells = [
+			createMarkupCellViewModel(1, '# h1', '$0', 0),
+			createMarkupCellViewModel(1, 'plaintext', '$1', 0),
+			createCodeCellViewModel(1, '# code cell 2', '$2'),
+			createCodeCellViewModel(1, '# code cell 3', '$3')
+		];
+		setSymbolsForTextModel([], '$0');
+		setSymbolsForTextModel([], '$1');
+		setSymbolsForTextModel([{ name: 'var2', range: {} }], '$2');
+		setSymbolsForTextModel([{ name: 'var3', range: {} }], '$3');
+
+		// Cache symbols
+		const entryFactory = new NotebookOutlineEntryFactory(executionService);
+		for (const cell of cells) {
+			await entryFactory.cacheSymbols(cell, outlineModelService, CancellationToken.None);
+		}
+
+		// Generate raw outline
+		const outlineModel = new OutlineEntry(-1, -1, createCodeCellViewModel(), 'fakeRoot', false, false, undefined, undefined);
+		for (const cell of cells) {
+			entryFactory.getOutlineEntries(cell, OutlineTarget.OutlinePane, 0).forEach(entry => outlineModel.addChild(entry));
+		}
+
+		// Generate filtered outline (view model)
+		const outlinePaneProvider = new NotebookOutlinePaneProvider(() => [], configurationService);
+		const results = flatten(outlineModel, outlinePaneProvider);
+
+		assert.equal(results.length, 2);
+
+		assert.equal(results[0].label, 'h1');
+		assert.equal(results[0].level, 1);
+
+		assert.equal(results[1].label, 'plaintext');
+		assert.equal(results[1].level, 7);
+	});
+
+	test('OutlinePane 2: Only Headers', async function () {
+		await setOutlineViewConfiguration({
+			outlineShowMarkdownHeadersOnly: true,
+			outlineShowCodeCells: false,
+			outlineShowCodeCellSymbols: false,
+			quickPickShowAllSymbols: false,
+			breadcrumbsShowCodeCells: false
+		});
+
+		// Create models + symbols
+		const cells = [
+			createMarkupCellViewModel(1, '# h1', '$0', 0),
+			createMarkupCellViewModel(1, 'plaintext', '$1', 0),
+			createCodeCellViewModel(1, '# code cell 2', '$2'),
+			createCodeCellViewModel(1, '# code cell 3', '$3')
+		];
+		setSymbolsForTextModel([], '$0');
+		setSymbolsForTextModel([], '$1');
+		setSymbolsForTextModel([{ name: 'var2', range: {} }], '$2');
+		setSymbolsForTextModel([{ name: 'var3', range: {} }], '$3');
+
+		// Cache symbols
+		const entryFactory = new NotebookOutlineEntryFactory(executionService);
+		for (const cell of cells) {
+			await entryFactory.cacheSymbols(cell, outlineModelService, CancellationToken.None);
+		}
+
+		// Generate raw outline
+		const outlineModel = new OutlineEntry(-1, -1, createCodeCellViewModel(), 'fakeRoot', false, false, undefined, undefined);
+		for (const cell of cells) {
+			entryFactory.getOutlineEntries(cell, OutlineTarget.OutlinePane, 0).forEach(entry => outlineModel.addChild(entry));
+		}
+
+		// Generate filtered outline (view model)
+		const outlinePaneProvider = new NotebookOutlinePaneProvider(() => [], configurationService);
+		const results = flatten(outlineModel, outlinePaneProvider);
+
+		assert.equal(results.length, 1);
+
+		assert.equal(results[0].label, 'h1');
+		assert.equal(results[0].level, 1);
+	});
+
+	test('OutlinePane 3: Only Headers + Code Cells', async function () {
+		await setOutlineViewConfiguration({
+			outlineShowMarkdownHeadersOnly: true,
+			outlineShowCodeCells: true,
+			outlineShowCodeCellSymbols: false,
+			quickPickShowAllSymbols: false,
+			breadcrumbsShowCodeCells: false
+		});
+
+		// Create models + symbols
+		const cells = [
+			createMarkupCellViewModel(1, '# h1', '$0', 0),
+			createMarkupCellViewModel(1, 'plaintext', '$1', 0),
+			createCodeCellViewModel(1, '# code cell 2', '$2'),
+			createCodeCellViewModel(1, '# code cell 3', '$3')
+		];
+		setSymbolsForTextModel([], '$0');
+		setSymbolsForTextModel([], '$1');
+		setSymbolsForTextModel([{ name: 'var2', range: {} }], '$2');
+		setSymbolsForTextModel([{ name: 'var3', range: {} }], '$3');
+
+		// Cache symbols
+		const entryFactory = new NotebookOutlineEntryFactory(executionService);
+		for (const cell of cells) {
+			await entryFactory.cacheSymbols(cell, outlineModelService, CancellationToken.None);
+		}
+
+		// Generate raw outline
+		const outlineModel = new OutlineEntry(-1, -1, createCodeCellViewModel(), 'fakeRoot', false, false, undefined, undefined);
+		for (const cell of cells) {
+			entryFactory.getOutlineEntries(cell, OutlineTarget.OutlinePane, 0).forEach(entry => outlineModel.addChild(entry));
+		}
+
+		// Generate filtered outline (view model)
+		const outlinePaneProvider = new NotebookOutlinePaneProvider(() => [], configurationService);
+		const results = flatten(outlineModel, outlinePaneProvider);
+
+		assert.equal(results.length, 3);
+
+		assert.equal(results[0].label, 'h1');
+		assert.equal(results[0].level, 1);
+
+		assert.equal(results[1].label, '# code cell 2');
+		assert.equal(results[1].level, 7);
+
+		assert.equal(results[2].label, '# code cell 3');
+		assert.equal(results[2].level, 7);
+	});
+
+	test('OutlinePane 4: Only Headers + Code Cells + Symbols', async function () {
+		await setOutlineViewConfiguration({
+			outlineShowMarkdownHeadersOnly: true,
+			outlineShowCodeCells: true,
+			outlineShowCodeCellSymbols: true,
+			quickPickShowAllSymbols: false,
+			breadcrumbsShowCodeCells: false
+		});
+
+		// Create models + symbols
+		const cells = [
+			createMarkupCellViewModel(1, '# h1', '$0', 0),
+			createMarkupCellViewModel(1, 'plaintext', '$1', 0),
+			createCodeCellViewModel(1, '# code cell 2', '$2'),
+			createCodeCellViewModel(1, '# code cell 3', '$3')
+		];
+		setSymbolsForTextModel([], '$0');
+		setSymbolsForTextModel([], '$1');
+		setSymbolsForTextModel([{ name: 'var2', range: {} }], '$2');
+		setSymbolsForTextModel([{ name: 'var3', range: {} }], '$3');
+
+		// Cache symbols
+		const entryFactory = new NotebookOutlineEntryFactory(executionService);
+		for (const cell of cells) {
+			await entryFactory.cacheSymbols(cell, outlineModelService, CancellationToken.None);
+		}
+
+		// Generate raw outline
+		const outlineModel = new OutlineEntry(-1, -1, createCodeCellViewModel(), 'fakeRoot', false, false, undefined, undefined);
+		for (const cell of cells) {
+			entryFactory.getOutlineEntries(cell, OutlineTarget.OutlinePane, 0).forEach(entry => outlineModel.addChild(entry));
+		}
+
+		// Generate filtered outline (view model)
+		const outlinePaneProvider = new NotebookOutlinePaneProvider(() => [], configurationService);
+		const results = flatten(outlineModel, outlinePaneProvider);
+
+		// validate
+		assert.equal(results.length, 5);
+
+		assert.equal(results[0].label, 'h1');
+		assert.equal(results[0].level, 1);
+
+		assert.equal(results[1].label, '# code cell 2');
+		assert.equal(results[1].level, 7);
+
+		assert.equal(results[2].label, 'var2');
+		assert.equal(results[2].level, 8);
+
+		assert.equal(results[3].label, '# code cell 3');
+		assert.equal(results[3].level, 7);
+
+		assert.equal(results[4].label, 'var3');
+		assert.equal(results[4].level, 8);
+	});
+
+	// #endregion
+	// #region QuickPick
+
+	// #endregion
+	// #region Breadcrumbs
+
+	// #endregion
+});

--- a/src/vs/workbench/contrib/notebook/test/browser/contrib/notebookSymbols.test.ts
+++ b/src/vs/workbench/contrib/notebook/test/browser/contrib/notebookSymbols.test.ts
@@ -12,14 +12,14 @@ import { IOutlineModelService, OutlineModel } from 'vs/editor/contrib/documentSy
 import { ICellViewModel } from 'vs/workbench/contrib/notebook/browser/notebookBrowser';
 import { NotebookOutlineEntryFactory } from 'vs/workbench/contrib/notebook/browser/viewModel/notebookOutlineEntryFactory';
 import { INotebookExecutionStateService } from 'vs/workbench/contrib/notebook/common/notebookExecutionStateService';
-import { textSymbol } from 'vs/workbench/contrib/notebook/test/browser/testNotebookEditor';
+import { MockDocumentSymbol } from 'vs/workbench/contrib/notebook/test/browser/testNotebookEditor';
 import { OutlineTarget } from 'vs/workbench/services/outline/browser/outline';
 
 suite('Notebook Symbols', function () {
 	ensureNoDisposablesAreLeakedInTestSuite();
 
-	const symbolsPerTextModel: Record<string, textSymbol[]> = {};
-	function setSymbolsForTextModel(symbols: textSymbol[], textmodelId = 'textId') {
+	const symbolsPerTextModel: Record<string, MockDocumentSymbol[]> = {};
+	function setSymbolsForTextModel(symbols: MockDocumentSymbol[], textmodelId = 'textId') {
 		symbolsPerTextModel[textmodelId] = symbols;
 	}
 

--- a/src/vs/workbench/contrib/notebook/test/browser/contrib/notebookSymbols.test.ts
+++ b/src/vs/workbench/contrib/notebook/test/browser/contrib/notebookSymbols.test.ts
@@ -12,12 +12,12 @@ import { IOutlineModelService, OutlineModel } from 'vs/editor/contrib/documentSy
 import { ICellViewModel } from 'vs/workbench/contrib/notebook/browser/notebookBrowser';
 import { NotebookOutlineEntryFactory } from 'vs/workbench/contrib/notebook/browser/viewModel/notebookOutlineEntryFactory';
 import { INotebookExecutionStateService } from 'vs/workbench/contrib/notebook/common/notebookExecutionStateService';
+import { textSymbol } from 'vs/workbench/contrib/notebook/test/browser/testNotebookEditor';
 import { OutlineTarget } from 'vs/workbench/services/outline/browser/outline';
 
 suite('Notebook Symbols', function () {
 	ensureNoDisposablesAreLeakedInTestSuite();
 
-	type textSymbol = { name: string; range: {}; children?: textSymbol[] };
 	const symbolsPerTextModel: Record<string, textSymbol[]> = {};
 	function setSymbolsForTextModel(symbols: textSymbol[], textmodelId = 'textId') {
 		symbolsPerTextModel[textmodelId] = symbols;

--- a/src/vs/workbench/contrib/notebook/test/browser/testNotebookEditor.ts
+++ b/src/vs/workbench/contrib/notebook/test/browser/testNotebookEditor.ts
@@ -427,7 +427,12 @@ export type MockNotebookCell = [
 	metadata?: NotebookCellMetadata,
 ];
 
-export type textSymbol = { name: string; range: {}; children?: textSymbol[] };
+export type MockDocumentSymbol = {
+	name: string;
+	range: {};
+	kind?: number;
+	children?: MockDocumentSymbol[];
+};
 
 export async function withTestNotebook<R = any>(cells: MockNotebookCell[], callback: (editor: IActiveTestNotebookEditorDelegate, viewModel: NotebookViewModel, disposables: DisposableStore, accessor: TestInstantiationService) => Promise<R> | R, accessor?: TestInstantiationService): Promise<R> {
 	const disposables: DisposableStore = new DisposableStore();

--- a/src/vs/workbench/contrib/notebook/test/browser/testNotebookEditor.ts
+++ b/src/vs/workbench/contrib/notebook/test/browser/testNotebookEditor.ts
@@ -217,7 +217,7 @@ export function setupInstantiationService(disposables: DisposableStore) {
 	return instantiationService;
 }
 
-function _createTestNotebookEditor(instantiationService: TestInstantiationService, disposables: DisposableStore, cells: [source: string, lang: string, kind: CellKind, output?: IOutputDto[], metadata?: NotebookCellMetadata][]): { editor: IActiveNotebookEditorDelegate; viewModel: NotebookViewModel } {
+function _createTestNotebookEditor(instantiationService: TestInstantiationService, disposables: DisposableStore, cells: MockNotebookCell[]): { editor: IActiveNotebookEditorDelegate; viewModel: NotebookViewModel } {
 
 	const viewType = 'notebook';
 	const notebook = disposables.add(instantiationService.createInstance(NotebookTextModel, viewType, URI.parse('test'), cells.map((cell): ICellDto2 => {
@@ -419,7 +419,17 @@ interface IActiveTestNotebookEditorDelegate extends IActiveNotebookEditorDelegat
 	visibleRanges: ICellRange[];
 }
 
-export async function withTestNotebook<R = any>(cells: [source: string, lang: string, kind: CellKind, output?: IOutputDto[], metadata?: NotebookCellMetadata][], callback: (editor: IActiveTestNotebookEditorDelegate, viewModel: NotebookViewModel, disposables: DisposableStore, accessor: TestInstantiationService) => Promise<R> | R, accessor?: TestInstantiationService): Promise<R> {
+export type MockNotebookCell = [
+	source: string,
+	lang: string,
+	kind: CellKind,
+	output?: IOutputDto[],
+	metadata?: NotebookCellMetadata,
+];
+
+export type textSymbol = { name: string; range: {}; children?: textSymbol[] };
+
+export async function withTestNotebook<R = any>(cells: MockNotebookCell[], callback: (editor: IActiveTestNotebookEditorDelegate, viewModel: NotebookViewModel, disposables: DisposableStore, accessor: TestInstantiationService) => Promise<R> | R, accessor?: TestInstantiationService): Promise<R> {
 	const disposables: DisposableStore = new DisposableStore();
 	const instantiationService = accessor ?? setupInstantiationService(disposables);
 	const notebookEditor = _createTestNotebookEditor(instantiationService, disposables, cells);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Resulting structure is that the `NotebookCellOutline` holds access to a single `NotebookCellOutlineProvider` by reference. This provider holds the most complete and detailed version of the outline, and filtering will be done in the provider classes that are created for the `NotebookCellOutline` (just an `IOutline<OutlineEntry>`) config data sources. 

Future work:
- Change event should be listened to in detail, only triggering a recompute as necessary
- Recompute will take parameters that represent what parts of the outline need a recompute based on filter settings
  - ex: model change is a code cell, filters have code cells off ==> no recompute. 
- Recompute and header generation will shift to a worker as it's the costliest step
- Re-work how `OutlineTarget` is used, right now will always be `outlinePane` due to the single provider design