### PR TITLE
refactor: move `ChatResponseWarningPart` to `chatParticipantAdditions` API proposal

### DIFF
--- a/src/vscode-dts/vscode.proposed.chatParticipant.d.ts
+++ b/src/vscode-dts/vscode.proposed.chatParticipant.d.ts
@@ -352,15 +352,6 @@ declare module 'vscode' {
 		reference(value: Uri | Location | { variableName: string; value?: Uri | Location }, iconPath?: ThemeIcon | { light: Uri; dark: Uri }): ChatResponseStream;
 
 		/**
-		 * Push a warning to this stream. Short-hand for
-		 * `push(new ChatResponseWarningPart(message))`.
-		 *
-		 * @param message A warning message
-		 * @returns This stream.
-		 */
-		warning(message: string | MarkdownString): ChatResponseStream;
-
-		/**
 		 * Pushes a part to this stream.
 		 *
 		 * @param part A response part, rendered or metadata
@@ -410,16 +401,11 @@ declare module 'vscode' {
 		constructor(value: Command);
 	}
 
-	export class ChatResponseWarningPart {
-		value: MarkdownString;
-		constructor(value: string | MarkdownString);
-	}
-
 	/**
 	 * Represents the different chat response types.
 	 */
 	export type ChatResponsePart = ChatResponseMarkdownPart | ChatResponseFileTreePart | ChatResponseAnchorPart
-		| ChatResponseProgressPart | ChatResponseReferencePart | ChatResponseCommandButtonPart | ChatResponseWarningPart;
+		| ChatResponseProgressPart | ChatResponseReferencePart | ChatResponseCommandButtonPart;
 
 
 	export namespace chat {

--- a/src/vscode-dts/vscode.proposed.chatParticipantAdditions.d.ts
+++ b/src/vscode-dts/vscode.proposed.chatParticipantAdditions.d.ts
@@ -102,11 +102,25 @@ declare module 'vscode' {
 		constructor(uri: Uri, edits: TextEdit | TextEdit[]);
 	}
 
+	export class ChatResponseWarningPart {
+		value: MarkdownString;
+		constructor(value: string | MarkdownString);
+	}
+
 	export interface ChatResponseStream {
 		textEdit(target: Uri, edits: TextEdit | TextEdit[]): ChatResponseStream;
 		markdownWithVulnerabilities(value: string | MarkdownString, vulnerabilities: ChatVulnerability[]): ChatResponseStream;
 		detectedParticipant(participant: string, command?: ChatCommand): ChatResponseStream;
-		push(part: ChatResponsePart | ChatResponseTextEditPart | ChatResponseDetectedParticipantPart): ChatResponseStream;
+		push(part: ChatResponsePart | ChatResponseTextEditPart | ChatResponseDetectedParticipantPart | ChatResponseWarningPart): ChatResponseStream;
+		/**
+		 * Push a warning to this stream. Short-hand for
+		 * `push(new ChatResponseWarningPart(message))`.
+		 *
+		 * @param message A warning message
+		 * @returns This stream.
+		 */
+		warning(message: string | MarkdownString): ChatResponseStream;
+
 	}
 
 	// TODO@API fit this into the stream


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

@roblourens should the URI-based [`ChatResponseReferencePart.iconPath`](https://github.com/microsoft/vscode/blob/ac7985feb5d941b829f883e56a22c142b016fafa/src/vscode-dts/vscode.proposed.chatParticipant.d.ts#L395) change be moved to `chatParticipantAdditions` too?
