### PR TITLE
Pass full function breakpoint options from plugin

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadDebugService.ts
+++ b/src/vs/workbench/api/browser/mainThreadDebugService.ts
@@ -223,7 +223,14 @@ export class MainThreadDebugService implements MainThreadDebugServiceShape, IDeb
 				}));
 				this.debugService.addBreakpoints(uri.revive(dto.uri), rawbps);
 			} else if (dto.type === 'function') {
-				this.debugService.addFunctionBreakpoint(dto.functionName, dto.id, dto.mode);
+				this.debugService.addFunctionBreakpoint({
+					name: dto.functionName,
+					mode: dto.mode,
+					condition: dto.condition,
+					hitCondition: dto.hitCondition,
+					enabled: dto.enabled,
+					logMessage: dto.logMessage
+				}, dto.id);
 			} else if (dto.type === 'data') {
 				this.debugService.addDataBreakpoint({
 					description: dto.label,

--- a/src/vs/workbench/contrib/debug/browser/debugService.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugService.ts
@@ -1073,8 +1073,14 @@ export class DebugService implements IDebugService {
 		return this.sendAllBreakpoints();
 	}
 
-	addFunctionBreakpoint(opts?: IFunctionBreakpointOptions, id?: string): void {
+	async addFunctionBreakpoint(opts?: IFunctionBreakpointOptions, id?: string): Promise<void> {
 		this.model.addFunctionBreakpoint(opts ?? { name: '' }, id);
+		// If opts not provided, sending the breakpoint is handled by a later to call to `updateFunctionBreakpoint`
+		if (opts) {
+			this.debugStorage.storeBreakpoints(this.model);
+			await this.sendFunctionBreakpoints();
+			this.debugStorage.storeBreakpoints(this.model);
+		}
 	}
 
 	async updateFunctionBreakpoint(id: string, update: { name?: string; hitCondition?: string; condition?: string }): Promise<void> {

--- a/src/vs/workbench/contrib/debug/browser/debugService.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugService.ts
@@ -42,7 +42,7 @@ import { DebugSession } from 'vs/workbench/contrib/debug/browser/debugSession';
 import { DebugTaskRunner, TaskRunResult } from 'vs/workbench/contrib/debug/browser/debugTaskRunner';
 import { CALLSTACK_VIEW_ID, CONTEXT_BREAKPOINTS_EXIST, CONTEXT_DEBUG_STATE, CONTEXT_DEBUG_TYPE, CONTEXT_DEBUG_UX, CONTEXT_DISASSEMBLY_VIEW_FOCUS, CONTEXT_HAS_DEBUGGED, CONTEXT_IN_DEBUG_MODE, DEBUG_MEMORY_SCHEME, DEBUG_SCHEME, IAdapterManager, IBreakpoint, IBreakpointData, IBreakpointUpdateData, ICompound, IConfig, IConfigurationManager, IDebugConfiguration, IDebugModel, IDebugService, IDebugSession, IDebugSessionOptions, IEnablement, IExceptionBreakpoint, IGlobalConfig, ILaunch, IStackFrame, IThread, IViewModel, REPL_VIEW_ID, State, VIEWLET_ID, debuggerDisabledMessage, getStateLabel } from 'vs/workbench/contrib/debug/common/debug';
 import { DebugCompoundRoot } from 'vs/workbench/contrib/debug/common/debugCompoundRoot';
-import { Breakpoint, DataBreakpoint, DebugModel, FunctionBreakpoint, IDataBreakpointOptions, IInstructionBreakpointOptions, InstructionBreakpoint } from 'vs/workbench/contrib/debug/common/debugModel';
+import { Breakpoint, DataBreakpoint, DebugModel, FunctionBreakpoint, IDataBreakpointOptions, IFunctionBreakpointOptions, IInstructionBreakpointOptions, InstructionBreakpoint } from 'vs/workbench/contrib/debug/common/debugModel';
 import { Source } from 'vs/workbench/contrib/debug/common/debugSource';
 import { DebugStorage } from 'vs/workbench/contrib/debug/common/debugStorage';
 import { DebugTelemetry } from 'vs/workbench/contrib/debug/common/debugTelemetry';
@@ -1073,8 +1073,8 @@ export class DebugService implements IDebugService {
 		return this.sendAllBreakpoints();
 	}
 
-	addFunctionBreakpoint(name?: string, id?: string, mode?: string): void {
-		this.model.addFunctionBreakpoint(name || '', id, mode);
+	addFunctionBreakpoint(opts?: IFunctionBreakpointOptions, id?: string): void {
+		this.model.addFunctionBreakpoint(opts ?? { name: '' }, id);
 	}
 
 	async updateFunctionBreakpoint(id: string, update: { name?: string; hitCondition?: string; condition?: string }): Promise<void> {

--- a/src/vs/workbench/contrib/debug/common/debug.ts
+++ b/src/vs/workbench/contrib/debug/common/debug.ts
@@ -24,7 +24,7 @@ import { ITelemetryEndpoint } from 'vs/platform/telemetry/common/telemetry';
 import { IWorkspaceFolder } from 'vs/platform/workspace/common/workspace';
 import { IEditorPane } from 'vs/workbench/common/editor';
 import { DebugCompoundRoot } from 'vs/workbench/contrib/debug/common/debugCompoundRoot';
-import { IDataBreakpointOptions, IInstructionBreakpointOptions } from 'vs/workbench/contrib/debug/common/debugModel';
+import { IDataBreakpointOptions, IFunctionBreakpointOptions, IInstructionBreakpointOptions } from 'vs/workbench/contrib/debug/common/debugModel';
 import { Source } from 'vs/workbench/contrib/debug/common/debugSource';
 import { ITaskIdentifier } from 'vs/workbench/contrib/tasks/common/tasks';
 import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
@@ -1150,7 +1150,7 @@ export interface IDebugService {
 	/**
 	 * Adds a new function breakpoint for the given name.
 	 */
-	addFunctionBreakpoint(name?: string, id?: string, mode?: string): void;
+	addFunctionBreakpoint(opts?: IFunctionBreakpointOptions, id?: string): void;
 
 	/**
 	 * Updates an already existing function breakpoint.

--- a/src/vs/workbench/contrib/debug/common/debugModel.ts
+++ b/src/vs/workbench/contrib/debug/common/debugModel.ts
@@ -1896,8 +1896,8 @@ export class DebugModel extends Disposable implements IDebugModel {
 		this._onDidChangeBreakpoints.fire({ changed: changed, sessionOnly: false });
 	}
 
-	addFunctionBreakpoint(functionName: string, id?: string, mode?: string): IFunctionBreakpoint {
-		const newFunctionBreakpoint = new FunctionBreakpoint({ name: functionName, mode }, id);
+	addFunctionBreakpoint(opts: IFunctionBreakpointOptions, id?: string): IFunctionBreakpoint {
+		const newFunctionBreakpoint = new FunctionBreakpoint(opts, id);
 		this.functionBreakpoints.push(newFunctionBreakpoint);
 		this._onDidChangeBreakpoints.fire({ added: [newFunctionBreakpoint], sessionOnly: false });
 

--- a/src/vs/workbench/contrib/debug/test/browser/breakpoints.test.ts
+++ b/src/vs/workbench/contrib/debug/test/browser/breakpoints.test.ts
@@ -161,8 +161,8 @@ suite('Debug - Breakpoints', () => {
 	});
 
 	test('function breakpoints', () => {
-		model.addFunctionBreakpoint('foo', '1');
-		model.addFunctionBreakpoint('bar', '2');
+		model.addFunctionBreakpoint({ name: 'foo' }, '1');
+		model.addFunctionBreakpoint({ name: 'bar' }, '2');
 		model.updateFunctionBreakpoint('1', { name: 'fooUpdated' });
 		model.updateFunctionBreakpoint('2', { name: 'barUpdated' });
 
@@ -380,7 +380,7 @@ suite('Debug - Breakpoints', () => {
 		assert.strictEqual(result.message, 'Data Breakpoint');
 		assert.strictEqual(result.icon.id, 'debug-breakpoint-data');
 
-		const functionBreakpoint = model.addFunctionBreakpoint('foo', '1');
+		const functionBreakpoint = model.addFunctionBreakpoint({ name: 'foo' }, '1');
 		result = getBreakpointMessageAndIcon(State.Stopped, true, functionBreakpoint, ls, model);
 		assert.strictEqual(result.message, 'Function Breakpoint');
 		assert.strictEqual(result.icon.id, 'debug-breakpoint-function');


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fixes #211894 by modifying the chain of calls to create a new function breakpoint to accept the full range of configurable fields. This ensures that the inserted function breakpoint matches the specification provided by a plugin rather than ignoring a variety of fields.

While working on this, I noticed #209386, and I have added code to send well-formed function breakpoints at the time of their creation, so this also fixes #209386.