### PR TITLE
Add command to trigger custom hover in Tree/List via keyboard

### DIFF
--- a/src/vs/editor/browser/services/hoverService/hoverService.ts
+++ b/src/vs/editor/browser/services/hoverService/hoverService.ts
@@ -216,6 +216,7 @@ export class HoverService extends Disposable implements IHoverService {
 				hoverDelegate.onDidHideHover?.();
 				hoverWidget = undefined;
 			}
+			htmlElement.removeAttribute('custom-hover-active');
 		};
 
 		const triggerShowHover = (delay: number, focus?: boolean, target?: IHoverDelegateTarget) => {
@@ -223,6 +224,7 @@ export class HoverService extends Disposable implements IHoverService {
 				if (!hoverWidget || hoverWidget.isDisposed) {
 					hoverWidget = new UpdatableHoverWidget(hoverDelegate, target || htmlElement, delay > 0);
 					await hoverWidget.update(typeof content === 'function' ? content() : content, focus, options);
+					htmlElement.setAttribute('custom-hover-active', 'true');
 				}
 			}, delay);
 		};

--- a/src/vs/workbench/api/browser/viewsExtensionPoint.ts
+++ b/src/vs/workbench/api/browser/viewsExtensionPoint.ts
@@ -292,6 +292,8 @@ class ViewsExtensionHandler implements IWorkbenchContribution {
 		this.handleAndRegisterCustomViewContainers();
 		this.handleAndRegisterCustomViews();
 
+		// Abstract tree has it's own implementation of triggering custom hover
+		// TreeView uses it's own implementation due to setting focus inside the (markdown)
 		let showTreeHoverCancellation = new CancellationTokenSource();
 		KeybindingsRegistry.registerCommandAndKeybindingRule({
 			id: 'workbench.action.showTreeHover',
@@ -332,7 +334,7 @@ class ViewsExtensionHandler implements IWorkbenchContribution {
 					}
 				}, true);
 			},
-			weight: KeybindingWeight.WorkbenchContrib,
+			weight: KeybindingWeight.WorkbenchContrib + 1,
 			primary: KeyChord(KeyMod.CtrlCmd | KeyCode.KeyK, KeyMod.CtrlCmd | KeyCode.KeyI),
 			when: ContextKeyExpr.and(RawCustomTreeViewContextKey, WorkbenchListFocusContextKey)
 		});

--- a/src/vs/workbench/browser/actions/listCommands.ts
+++ b/src/vs/workbench/browser/actions/listCommands.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { KeyMod, KeyCode } from 'vs/base/common/keyCodes';
+import { KeyMod, KeyCode, KeyChord } from 'vs/base/common/keyCodes';
 import { ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
 import { KeybindingsRegistry, KeybindingWeight } from 'vs/platform/keybinding/common/keybindingsRegistry';
 import { List } from 'vs/base/browser/ui/list/listWidget';
@@ -18,10 +18,11 @@ import { ITreeNode } from 'vs/base/browser/ui/tree/tree';
 import { CommandsRegistry } from 'vs/platform/commands/common/commands';
 import { Table } from 'vs/base/browser/ui/table/tableWidget';
 import { AbstractTree, TreeFindMatchType, TreeFindMode } from 'vs/base/browser/ui/tree/abstractTree';
-import { isActiveElement } from 'vs/base/browser/dom';
+import { EventType, getActiveWindow, isActiveElement } from 'vs/base/browser/dom';
 import { Action2, registerAction2 } from 'vs/platform/actions/common/actions';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { localize, localize2 } from 'vs/nls';
+import { IDisposable } from 'vs/base/common/lifecycle';
 
 function ensureDOMFocus(widget: ListWidget | undefined): void {
 	// it can happen that one of the commands is executed while
@@ -57,6 +58,10 @@ async function updateFocus(widget: WorkbenchListWidget, updateFocusFn: (widget: 
 async function navigate(widget: WorkbenchListWidget | undefined, updateFocusFn: (widget: WorkbenchListWidget) => void | Promise<void>): Promise<void> {
 	if (!widget) {
 		return;
+	}
+
+	if (activeHover) {
+		toggleCustomHover(activeHover, widget);
 	}
 
 	await updateFocus(widget, updateFocusFn);
@@ -693,6 +698,67 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 		}
 	}
 });
+
+KeybindingsRegistry.registerCommandAndKeybindingRule({
+	id: 'list.showHover',
+	weight: KeybindingWeight.WorkbenchContrib,
+	primary: KeyChord(KeyMod.CtrlCmd | KeyCode.KeyK, KeyMod.CtrlCmd | KeyCode.KeyI),
+	when: WorkbenchListFocusContextKey,
+	handler: async (accessor: ServicesAccessor, ...args: any[]) => {
+		const listService = accessor.get(IListService);
+		const lastFocusedList = listService.lastFocusedList;
+		if (!lastFocusedList) {
+			return;
+		}
+
+		// Check if a tree element is focused
+		const focus = lastFocusedList.getFocus();
+		if (!focus || (focus.length === 0)) {
+			return;
+		}
+
+		// As the tree does not know anything about the rendered DOM elements
+		// we have to traverse the dom to find the HTMLElements
+		const treeDOM = lastFocusedList.getHTMLElement();
+		const scrollableElement = treeDOM.querySelector('.monaco-scrollable-element');
+		const listRows = scrollableElement?.querySelector('.monaco-list-rows');
+		const focusedElement = listRows?.querySelector('.focused');
+		if (!focusedElement) {
+			return;
+		}
+
+		// Check if the focused element has a hover, otherwise find the first child with a hover
+		const elementWithHover = focusedElement.matches('[custom-hover="true"]') ? focusedElement : focusedElement.querySelector('[custom-hover="true"]');
+		if (!elementWithHover) {
+			return;
+		}
+
+		toggleCustomHover(elementWithHover as HTMLElement, lastFocusedList);
+	},
+});
+
+let activeHover: undefined | HTMLElement;
+let disposable: IDisposable | undefined;
+function toggleCustomHover(element: HTMLElement, list: WorkbenchListWidget) {
+	const show = !element.getAttribute('custom-hover-active');
+	const mouseEvent = new MouseEvent(show ? EventType.MOUSE_OVER : EventType.MOUSE_LEAVE, {
+		view: getActiveWindow(),
+		bubbles: true,
+		cancelable: true,
+	});
+	element.dispatchEvent(mouseEvent);
+
+	if (activeHover === element && !show) {
+		activeHover = undefined;
+		disposable?.dispose();
+		disposable = undefined;
+	} else {
+		activeHover = element;
+		disposable = list.onDidBlur(() => {
+			toggleCustomHover(element, list);
+		});
+	}
+}
 
 KeybindingsRegistry.registerCommandAndKeybindingRule({
 	id: 'list.toggleExpand',


### PR DESCRIPTION
This pull request adds a new command to trigger the custom hover in the Tree/List via the keyboard. Currently, there is no way to show the custom hover when navigating through the Tree/List using the keyboard. This fix ensures that the custom hover can be accessed and shown using the keyboard only. The custom hover is triggered by pressing the Ctrl+K, Ctrl+I key combination when the Tree/List has focus.

More details on the implementation here: https://github.com/microsoft/vscode/issues/209642#issuecomment-2092993808

// cc: @Tyriar 

Fixes #209642