### PR TITLE
Move registering env contributed auth providers to the service

### DIFF
--- a/src/vs/workbench/contrib/authentication/browser/authentication.contribution.ts
+++ b/src/vs/workbench/contrib/authentication/browser/authentication.contribution.ts
@@ -123,6 +123,10 @@ export class AuthenticationContribution extends Disposable implements IWorkbench
 		this._register(codeExchangeProxyCommand);
 		this._register(extensionFeature);
 
+		// Clear the placeholder menu item if there are already providers registered.
+		if (_authenticationService.getProviderIds().length) {
+			this._clearPlaceholderMenuItem();
+		}
 		this._registerHandlers();
 		this._registerAuthenticationExtentionPointHandler();
 		this._registerEnvContributedAuthenticationProviders();
@@ -172,8 +176,7 @@ export class AuthenticationContribution extends Disposable implements IWorkbench
 
 	private _registerHandlers(): void {
 		this._register(this._authenticationService.onDidRegisterAuthenticationProvider(_e => {
-			this._placeholderMenuItem?.dispose();
-			this._placeholderMenuItem = undefined;
+			this._clearPlaceholderMenuItem();
 		}));
 		this._register(this._authenticationService.onDidUnregisterAuthenticationProvider(_e => {
 			if (!this._authenticationService.getProviderIds().length) {
@@ -191,6 +194,11 @@ export class AuthenticationContribution extends Disposable implements IWorkbench
 	private _registerActions(): void {
 		this._register(registerAction2(SignOutOfAccountAction));
 		this._register(registerAction2(ManageTrustedExtensionsForAccountAction));
+	}
+
+	private _clearPlaceholderMenuItem(): void {
+		this._placeholderMenuItem?.dispose();
+		this._placeholderMenuItem = undefined;
 	}
 }
 

--- a/src/vs/workbench/services/authentication/test/browser/authenticationService.test.ts
+++ b/src/vs/workbench/services/authentication/test/browser/authenticationService.test.ts
@@ -9,6 +9,7 @@ import { ensureNoDisposablesAreLeakedInTestSuite } from 'vs/base/test/common/uti
 import { AuthenticationAccessService } from 'vs/workbench/services/authentication/browser/authenticationAccessService';
 import { AuthenticationService } from 'vs/workbench/services/authentication/browser/authenticationService';
 import { AuthenticationProviderInformation, AuthenticationSessionsChangeEvent, IAuthenticationProvider } from 'vs/workbench/services/authentication/common/authentication';
+import { TestEnvironmentService } from 'vs/workbench/test/browser/workbenchTestServices';
 import { TestExtensionService, TestProductService, TestStorageService } from 'vs/workbench/test/common/workbenchTestServices';
 
 function createSession() {
@@ -36,7 +37,7 @@ suite('AuthenticationService', () => {
 	setup(() => {
 		const storageService = disposables.add(new TestStorageService());
 		const authenticationAccessService = disposables.add(new AuthenticationAccessService(storageService, TestProductService));
-		authenticationService = disposables.add(new AuthenticationService(new TestExtensionService(), authenticationAccessService));
+		authenticationService = disposables.add(new AuthenticationService(new TestExtensionService(), authenticationAccessService, TestEnvironmentService));
 	});
 
 	teardown(() => {


### PR DESCRIPTION
This prevents a race condition where an extension was being activated before the contribution was running.

Since the contribution has other stuff that doesn't need to run early, I removed what does and moved it into the service. I think this make a lot more sense because upon service creation, it should already register auth providers that are already available.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
