### PR TITLE
Make codelenses work after switching from webview editor (fix #198309)

### DIFF
--- a/src/vs/editor/contrib/codelens/browser/codelensController.ts
+++ b/src/vs/editor/contrib/codelens/browser/codelensController.ts
@@ -229,7 +229,7 @@ export class CodeLensContribution implements IEditorContribution {
 			this._resolveCodeLensesPromise?.cancel();
 			this._resolveCodeLensesPromise = undefined;
 		}));
-		this._localToDispose.add(this._editor.onDidFocusEditorWidget(() => {
+		this._localToDispose.add(this._editor.onDidFocusEditorText(() => {
 			scheduler.schedule();
 		}));
 		this._localToDispose.add(this._editor.onDidBlurEditorText(() => {


### PR DESCRIPTION
This PR fixes #198309

Repro:
1. Open a file whose contents produce codelenses.
2. Hover over codelens actions to check they highlight to show they are clickable
3. Open the settings editor.
4. Click back to tab of the file and observe that the codelens actions no longer highlight on hover :bug:
5. Activate a different window, then activate the VS Code one again. Observe that the codelens actions now work.

Issue may have been caused by https://github.com/microsoft/vscode/commit/04f02b504323d91a2eed9d827163b713a1a47859

