### PR TITLE
Collapse multiple expression lines into one in Variable panel.

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/media/debug.contribution.css
+++ b/src/vs/workbench/contrib/debug/browser/media/debug.contribution.css
@@ -89,7 +89,6 @@
 	overflow: hidden;
 	text-overflow: ellipsis;
 	font-family: var(--monaco-monospace-font);
-	white-space: pre;
 }
 
 .monaco-workbench.mac .debug-pane .monaco-list-row .expression,

--- a/src/vs/workbench/contrib/debug/browser/media/debugViewlet.css
+++ b/src/vs/workbench/contrib/debug/browser/media/debugViewlet.css
@@ -228,7 +228,6 @@
 .debug-pane .monaco-list-row .expression .value {
 	height: 22px;
 	overflow: hidden;
-	white-space: pre;
 	text-overflow: ellipsis;
 }
 


### PR DESCRIPTION
As far as I can tell, `.debug-hover-widget` never has ancestors `.monaco-list-row .expression`, so that should not actually be affected (and should probably be removed). I am also not sure why there are two rules for this in two separate files  right next to each other, maybe that can be cleaned up, too.

Fixes #212167.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
