### PR TITLE
Use new `getDocumentFormattingEditsWithSelectedProvider` for Notebook formatting

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/contrib/format/formatting.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/format/formatting.ts
@@ -14,7 +14,7 @@ import { EditorContextKeys } from 'vs/editor/common/editorContextKeys';
 import { IEditorWorkerService } from 'vs/editor/common/services/editorWorker';
 import { ILanguageFeaturesService } from 'vs/editor/common/services/languageFeatures';
 import { ITextModelService } from 'vs/editor/common/services/resolverService';
-import { FormattingMode, formatDocumentWithSelectedProvider, getDocumentFormattingEditsUntilResult } from 'vs/editor/contrib/format/browser/format';
+import { FormattingMode, formatDocumentWithSelectedProvider, getDocumentFormattingEditsWithSelectedProvider } from 'vs/editor/contrib/format/browser/format';
 import { Action2, MenuId, registerAction2 } from 'vs/platform/actions/common/actions';
 import { ContextKeyExpr } from 'vs/platform/contextkey/common/contextkey';
 import { IInstantiationService, ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
@@ -78,11 +78,11 @@ registerAction2(class extends Action2 {
 
 				const model = ref.object.textEditorModel;
 
-				const formatEdits = await getDocumentFormattingEditsUntilResult(
+				const formatEdits = await getDocumentFormattingEditsWithSelectedProvider(
 					editorWorkerService,
 					languageFeaturesService,
 					model,
-					model.getOptions(),
+					FormattingMode.Explicit,
 					CancellationToken.None
 				);
 
@@ -177,12 +177,11 @@ class FormatOnCellExecutionParticipant implements ICellExecutionParticipant {
 
 				const model = ref.object.textEditorModel;
 
-				// todo: eventually support cancellation. potential leak if cell deleted mid execution
-				const formatEdits = await getDocumentFormattingEditsUntilResult(
+				const formatEdits = await getDocumentFormattingEditsWithSelectedProvider(
 					this.editorWorkerService,
 					this.languageFeaturesService,
 					model,
-					model.getOptions(),
+					FormattingMode.Silent,
 					CancellationToken.None
 				);
 

--- a/src/vs/workbench/contrib/notebook/browser/contrib/saveParticipants/saveParticipants.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/saveParticipants/saveParticipants.ts
@@ -20,7 +20,7 @@ import { ILanguageFeaturesService } from 'vs/editor/common/services/languageFeat
 import { ITextModelService } from 'vs/editor/common/services/resolverService';
 import { ApplyCodeActionReason, applyCodeAction, getCodeActions } from 'vs/editor/contrib/codeAction/browser/codeAction';
 import { CodeActionKind, CodeActionTriggerSource } from 'vs/editor/contrib/codeAction/common/types';
-import { getDocumentFormattingEditsUntilResult } from 'vs/editor/contrib/format/browser/format';
+import { FormattingMode, getDocumentFormattingEditsWithSelectedProvider } from 'vs/editor/contrib/format/browser/format';
 import { SnippetController2 } from 'vs/editor/contrib/snippet/browser/snippetController2';
 import { localize } from 'vs/nls';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
@@ -73,11 +73,11 @@ class FormatOnSaveParticipant implements IStoredFileWorkingCopySaveParticipant {
 
 				const model = ref.object.textEditorModel;
 
-				const formatEdits = await getDocumentFormattingEditsUntilResult(
+				const formatEdits = await getDocumentFormattingEditsWithSelectedProvider(
 					this.editorWorkerService,
 					this.languageFeaturesService,
 					model,
-					model.getOptions(),
+					FormattingMode.Silent,
 					token
 				);
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fixes: #212124, #196050

Only use selected provider for formatting, fixes bug where users set a default formatter which returns nothing, then still see other formatters returning edits

