### PR TITLE
testing: initial attributable test coverage API

### DIFF
--- a/src/vs/base/common/assert.ts
+++ b/src/vs/base/common/assert.ts
@@ -29,9 +29,9 @@ export function assertNever(value: never, message = 'Unreachable'): never {
 	throw new Error(message);
 }
 
-export function assert(condition: boolean): void {
+export function assert(condition: boolean, message = 'unexpected state'): asserts condition {
 	if (!condition) {
-		throw new BugIndicatingError('Assertion Failed');
+		throw new BugIndicatingError(`Assertion Failed: ${message}`);
 	}
 }
 

--- a/src/vs/base/common/prefixTree.ts
+++ b/src/vs/base/common/prefixTree.ts
@@ -46,6 +46,11 @@ export class WellDefinedPrefixTree<V> {
 		this.opNode(key, n => n._value = mutate(n._value === unset ? undefined : n._value));
 	}
 
+	/** Mutates nodes along the path in the prefix tree. */
+	mutatePath(key: Iterable<string>, mutate: (node: IPrefixTreeNode<V>) => void): void {
+		this.opNode(key, () => { }, n => mutate(n));
+	}
+
 	/** Deletes a node from the prefix tree, returning the value it contained. */
 	delete(key: Iterable<string>): V | undefined {
 		const path = this.getPathToKey(key);

--- a/src/vs/workbench/api/common/extHost.api.impl.ts
+++ b/src/vs/workbench/api/common/extHost.api.impl.ts
@@ -1683,6 +1683,7 @@ export function createApiFactoryAndRegisterActors(accessor: ServicesAccessor): I
 			DataTransferItem: extHostTypes.DataTransferItem,
 			TestCoverageCount: extHostTypes.TestCoverageCount,
 			FileCoverage: extHostTypes.FileCoverage,
+			FileCoverage2: extHostTypes.FileCoverage,
 			StatementCoverage: extHostTypes.StatementCoverage,
 			BranchCoverage: extHostTypes.BranchCoverage,
 			DeclarationCoverage: extHostTypes.DeclarationCoverage,

--- a/src/vs/workbench/api/common/extHostTypeConverters.ts
+++ b/src/vs/workbench/api/common/extHostTypeConverters.ts
@@ -2052,7 +2052,7 @@ export namespace TestCoverage {
 		}
 	}
 
-	export function fromFile(id: string, coverage: vscode.FileCoverage): IFileCoverage.Serialized {
+	export function fromFile(controllerId: string, id: string, coverage: vscode.FileCoverage): IFileCoverage.Serialized {
 		types.validateTestCoverageCount(coverage.statementCoverage);
 		types.validateTestCoverageCount(coverage.branchCoverage);
 		types.validateTestCoverageCount(coverage.declarationCoverage);
@@ -2063,6 +2063,8 @@ export namespace TestCoverage {
 			statement: fromCoverageCount(coverage.statementCoverage),
 			branch: coverage.branchCoverage && fromCoverageCount(coverage.branchCoverage),
 			declaration: coverage.declarationCoverage && fromCoverageCount(coverage.declarationCoverage),
+			testId: coverage instanceof types.FileCoverage && coverage.testItem ?
+				TestId.fromExtHostTestItem(coverage.testItem, controllerId).toString() : undefined,
 		};
 	}
 }

--- a/src/vs/workbench/api/common/extHostTypes.ts
+++ b/src/vs/workbench/api/common/extHostTypes.ts
@@ -4119,6 +4119,7 @@ export class FileCoverage implements vscode.FileCoverage {
 		public statementCoverage: vscode.TestCoverageCount,
 		public branchCoverage?: vscode.TestCoverageCount,
 		public declarationCoverage?: vscode.TestCoverageCount,
+		public testItem?: vscode.TestItem,
 	) {
 	}
 }

--- a/src/vs/workbench/api/test/browser/extHostTesting.test.ts
+++ b/src/vs/workbench/api/test/browser/extHostTesting.test.ts
@@ -14,7 +14,7 @@ import { URI } from 'vs/base/common/uri';
 import { mock, mockObject, MockObject } from 'vs/base/test/common/mock';
 import { ensureNoDisposablesAreLeakedInTestSuite } from 'vs/base/test/common/utils';
 import * as editorRange from 'vs/editor/common/core/range';
-import { ExtensionIdentifier } from 'vs/platform/extensions/common/extensions';
+import { ExtensionIdentifier, IRelaxedExtensionDescription } from 'vs/platform/extensions/common/extensions';
 import { NullLogService } from 'vs/platform/log/common/log';
 import { MainThreadTestingShape } from 'vs/workbench/api/common/extHost.protocol';
 import { ExtHostCommands } from 'vs/workbench/api/common/extHostCommands';
@@ -637,6 +637,7 @@ suite('ExtHost Testing', () => {
 		let req: TestRunRequest;
 
 		let dto: TestRunDto;
+		const ext: IRelaxedExtensionDescription = {} as any;
 
 		teardown(() => {
 			for (const { id } of c.trackers) {
@@ -671,11 +672,11 @@ suite('ExtHost Testing', () => {
 		});
 
 		test('tracks a run started from a main thread request', () => {
-			const tracker = ds.add(c.prepareForMainThreadTestRun(req, dto, configuration, cts.token));
+			const tracker = ds.add(c.prepareForMainThreadTestRun(ext, req, dto, configuration, cts.token));
 			assert.strictEqual(tracker.hasRunningTasks, false);
 
-			const task1 = c.createTestRun('ctrl', single, req, 'run1', true);
-			const task2 = c.createTestRun('ctrl', single, req, 'run2', true);
+			const task1 = c.createTestRun(ext, 'ctrl', single, req, 'run1', true);
+			const task2 = c.createTestRun(ext, 'ctrl', single, req, 'run2', true);
 			assert.strictEqual(proxy.$startedExtensionTestRun.called, false);
 			assert.strictEqual(tracker.hasRunningTasks, true);
 
@@ -696,8 +697,8 @@ suite('ExtHost Testing', () => {
 		test('run cancel force ends after a timeout', () => {
 			const clock = sinon.useFakeTimers();
 			try {
-				const tracker = ds.add(c.prepareForMainThreadTestRun(req, dto, configuration, cts.token));
-				const task = c.createTestRun('ctrl', single, req, 'run1', true);
+				const tracker = ds.add(c.prepareForMainThreadTestRun(ext, req, dto, configuration, cts.token));
+				const task = c.createTestRun(ext, 'ctrl', single, req, 'run1', true);
 				const onEnded = sinon.stub();
 				ds.add(tracker.onEnd(onEnded));
 
@@ -721,8 +722,8 @@ suite('ExtHost Testing', () => {
 		});
 
 		test('run cancel force ends on second cancellation request', () => {
-			const tracker = ds.add(c.prepareForMainThreadTestRun(req, dto, configuration, cts.token));
-			const task = c.createTestRun('ctrl', single, req, 'run1', true);
+			const tracker = ds.add(c.prepareForMainThreadTestRun(ext, req, dto, configuration, cts.token));
+			const task = c.createTestRun(ext, 'ctrl', single, req, 'run1', true);
 			const onEnded = sinon.stub();
 			ds.add(tracker.onEnd(onEnded));
 
@@ -740,7 +741,7 @@ suite('ExtHost Testing', () => {
 		});
 
 		test('tracks a run started from an extension request', () => {
-			const task1 = c.createTestRun('ctrl', single, req, 'hello world', false);
+			const task1 = c.createTestRun(ext, 'ctrl', single, req, 'hello world', false);
 
 			const tracker = Iterable.first(c.trackers)!;
 			assert.strictEqual(tracker.hasRunningTasks, true);
@@ -757,8 +758,8 @@ suite('ExtHost Testing', () => {
 				}]
 			]);
 
-			const task2 = c.createTestRun('ctrl', single, req, 'run2', true);
-			const task3Detached = c.createTestRun('ctrl', single, { ...req }, 'task3Detached', true);
+			const task2 = c.createTestRun(ext, 'ctrl', single, req, 'run2', true);
+			const task3Detached = c.createTestRun(ext, 'ctrl', single, { ...req }, 'task3Detached', true);
 
 			task1.end();
 			assert.strictEqual(proxy.$finishedExtensionTestRun.called, false);
@@ -772,7 +773,7 @@ suite('ExtHost Testing', () => {
 		});
 
 		test('adds tests to run smartly', () => {
-			const task1 = c.createTestRun('ctrlId', single, req, 'hello world', false);
+			const task1 = c.createTestRun(ext, 'ctrlId', single, req, 'hello world', false);
 			const tracker = Iterable.first(c.trackers)!;
 			const expectedArgs: unknown[][] = [];
 			assert.deepStrictEqual(proxy.$addTestsToRun.args, expectedArgs);
@@ -811,7 +812,7 @@ suite('ExtHost Testing', () => {
 			const test2 = new TestItemImpl('ctrlId', 'id-d', 'test d', URI.file('/testd.txt'));
 			test1.range = test2.range = new Range(new Position(0, 0), new Position(1, 0));
 			single.root.children.replace([test1, test2]);
-			const task = c.createTestRun('ctrlId', single, req, 'hello world', false);
+			const task = c.createTestRun(ext, 'ctrlId', single, req, 'hello world', false);
 
 			const message1 = new TestMessage('some message');
 			message1.location = new Location(URI.file('/a.txt'), new Position(0, 0));
@@ -852,7 +853,7 @@ suite('ExtHost Testing', () => {
 		});
 
 		test('guards calls after runs are ended', () => {
-			const task = c.createTestRun('ctrl', single, req, 'hello world', false);
+			const task = c.createTestRun(ext, 'ctrl', single, req, 'hello world', false);
 			task.end();
 
 			task.failed(single.root, new TestMessage('some message'));
@@ -864,7 +865,7 @@ suite('ExtHost Testing', () => {
 		});
 
 		test('excludes tests outside tree or explicitly excluded', () => {
-			const task = c.createTestRun('ctrlId', single, {
+			const task = c.createTestRun(ext, 'ctrlId', single, {
 				profile: configuration,
 				include: [single.root.children.get('id-a')!],
 				exclude: [single.root.children.get('id-a')!.children.get('id-aa')!],
@@ -894,7 +895,7 @@ suite('ExtHost Testing', () => {
 			const childB = new TestItemImpl('ctrlId', 'id-child', 'child', undefined);
 			testB!.children.replace([childB]);
 
-			const task1 = c.createTestRun('ctrl', single, new TestRunRequestImpl(), 'hello world', false);
+			const task1 = c.createTestRun(ext, 'ctrl', single, new TestRunRequestImpl(), 'hello world', false);
 			const tracker = Iterable.first(c.trackers)!;
 
 			task1.passed(childA);

--- a/src/vs/workbench/contrib/testing/common/testTypes.ts
+++ b/src/vs/workbench/contrib/testing/common/testTypes.ts
@@ -559,6 +559,7 @@ export namespace ICoverageCount {
 export interface IFileCoverage {
 	id: string;
 	uri: URI;
+	testId?: TestId;
 	statement: ICoverageCount;
 	branch?: ICoverageCount;
 	declaration?: ICoverageCount;
@@ -568,6 +569,7 @@ export namespace IFileCoverage {
 	export interface Serialized {
 		id: string;
 		uri: UriComponents;
+		testId: string | undefined;
 		statement: ICoverageCount;
 		branch?: ICoverageCount;
 		declaration?: ICoverageCount;
@@ -578,6 +580,7 @@ export namespace IFileCoverage {
 		statement: original.statement,
 		branch: original.branch,
 		declaration: original.declaration,
+		testId: original.testId?.toString(),
 		uri: original.uri.toJSON(),
 	});
 
@@ -586,7 +589,15 @@ export namespace IFileCoverage {
 		statement: serialized.statement,
 		branch: serialized.branch,
 		declaration: serialized.declaration,
+		testId: serialized.testId ? TestId.fromString(serialized.testId) : undefined,
 		uri: uriIdentity.asCanonicalUri(URI.revive(serialized.uri)),
+	});
+
+	export const empty = (id: string, uri: URI): IFileCoverage => ({
+		id,
+		uri,
+		testId: undefined,
+		statement: ICoverageCount.empty(),
 	});
 }
 

--- a/src/vs/workbench/contrib/testing/test/common/testCoverage.test.ts
+++ b/src/vs/workbench/contrib/testing/test/common/testCoverage.test.ts
@@ -1,0 +1,194 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { SinonSandbox, createSandbox } from 'sinon';
+import { Iterable } from 'vs/base/common/iterator';
+import { URI } from 'vs/base/common/uri';
+import { ensureNoDisposablesAreLeakedInTestSuite } from 'vs/base/test/common/utils';
+import { onObservableChange } from 'vs/workbench/contrib/testing/common/observableUtils';
+import { ICoverageAccessor, TestCoverage } from 'vs/workbench/contrib/testing/common/testCoverage';
+import { TestId } from 'vs/workbench/contrib/testing/common/testId';
+import { IFileCoverage } from 'vs/workbench/contrib/testing/common/testTypes';
+
+suite('TestCoverage', () => {
+	let sandbox: SinonSandbox;
+	let coverageAccessor: ICoverageAccessor;
+	let testCoverage: TestCoverage;
+
+	const ds = ensureNoDisposablesAreLeakedInTestSuite();
+
+	setup(() => {
+		sandbox = createSandbox();
+		coverageAccessor = {
+			getCoverageDetails: sandbox.stub().resolves([]),
+		};
+		testCoverage = new TestCoverage('taskId', { extUri: { ignorePathCasing: () => true } } as any, coverageAccessor);
+	});
+
+	teardown(() => {
+		sandbox.restore();
+	});
+
+	function addTests() {
+		const raw1: IFileCoverage = {
+			id: '1',
+			uri: URI.file('/path/to/file'),
+			statement: { covered: 10, total: 20 },
+			branch: { covered: 5, total: 10 },
+			declaration: { covered: 2, total: 5 },
+		};
+
+		testCoverage.append(raw1, undefined);
+
+		const raw2: IFileCoverage = {
+			id: '1',
+			uri: URI.file('/path/to/file2'),
+			statement: { covered: 5, total: 10 },
+			branch: { covered: 1, total: 5 },
+		};
+
+		testCoverage.append(raw2, undefined);
+
+		return { raw1, raw2 };
+	}
+
+	test('should look up file coverage', async () => {
+		const { raw1 } = addTests();
+
+		const fileCoverage = testCoverage.getUri(raw1.uri);
+		assert.equal(fileCoverage?.id, raw1.id);
+		assert.deepEqual(fileCoverage?.statement, raw1.statement);
+		assert.deepEqual(fileCoverage?.branch, raw1.branch);
+		assert.deepEqual(fileCoverage?.declaration, raw1.declaration);
+		assert.strictEqual(fileCoverage?.existsInExtHost, true);
+
+		assert.strictEqual(testCoverage.getComputedForUri(raw1.uri), testCoverage.getUri(raw1.uri));
+		assert.strictEqual(testCoverage.getComputedForUri(URI.file('/path/to/x')), undefined);
+		assert.strictEqual(testCoverage.getUri(URI.file('/path/to/x')), undefined);
+	});
+
+	test('should compute coverage for directories', async () => {
+		const { raw1 } = addTests();
+		const dirCoverage = testCoverage.getComputedForUri(URI.file('/path/to'));
+		assert.deepEqual(dirCoverage?.statement, { covered: 15, total: 30 });
+		assert.deepEqual(dirCoverage?.branch, { covered: 6, total: 15 });
+		assert.deepEqual(dirCoverage?.declaration, raw1.declaration);
+		assert.strictEqual(dirCoverage?.existsInExtHost, false);
+	});
+
+	test('should incrementally diff updates to existing files', async () => {
+		addTests();
+
+		const raw3: IFileCoverage = {
+			id: '1',
+			uri: URI.file('/path/to/file'),
+			statement: { covered: 12, total: 24 },
+			branch: { covered: 7, total: 10 },
+			declaration: { covered: 2, total: 5 },
+		};
+
+		testCoverage.append(raw3, undefined);
+
+		const fileCoverage = testCoverage.getUri(raw3.uri);
+		assert.deepEqual(fileCoverage?.statement, raw3.statement);
+		assert.deepEqual(fileCoverage?.branch, raw3.branch);
+		assert.deepEqual(fileCoverage?.declaration, raw3.declaration);
+
+		const dirCoverage = testCoverage.getComputedForUri(URI.file('/path/to'));
+		assert.deepEqual(dirCoverage?.statement, { covered: 17, total: 34 });
+		assert.deepEqual(dirCoverage?.branch, { covered: 8, total: 15 });
+		assert.deepEqual(dirCoverage?.declaration, raw3.declaration);
+	});
+
+	test('should emit changes', async () => {
+		const changes: string[][] = [];
+		ds.add(onObservableChange(testCoverage.didAddCoverage, value =>
+			changes.push(value.map(v => v.value!.uri.toString()))));
+
+		addTests();
+
+		assert.deepStrictEqual(changes, [
+			[
+				"file:///",
+				"file:///",
+				"file:///",
+				"file:///path",
+				"file:///path/to",
+				"file:///path/to/file",
+			],
+			[
+				"file:///",
+				"file:///",
+				"file:///",
+				"file:///path",
+				"file:///path/to",
+				"file:///path/to/file2",
+			],
+		]);
+	});
+
+	test('adds per-test data to files', async () => {
+		const { raw1 } = addTests();
+
+		const raw3: IFileCoverage = {
+			id: '1',
+			testId: TestId.fromString('my-test'),
+			uri: URI.file('/path/to/file'),
+			statement: { covered: 12, total: 24 },
+			branch: { covered: 7, total: 10 },
+			declaration: { covered: 2, total: 5 },
+		};
+		testCoverage.append(raw3, undefined);
+
+		const fileCoverage = testCoverage.getUri(raw1.uri);
+		assert.strictEqual(fileCoverage?.perTestData?.size, 1);
+
+		const perTestCoverage = Iterable.first(fileCoverage!.perTestData!.values());
+		assert.deepStrictEqual(perTestCoverage?.statement, raw3.statement);
+		assert.deepStrictEqual(perTestCoverage?.branch, raw3.branch);
+		assert.deepStrictEqual(perTestCoverage?.declaration, raw3.declaration);
+
+		// should be unchanged:
+		assert.deepEqual(fileCoverage?.statement, { covered: 10, total: 20 });
+		assert.deepEqual(fileCoverage?.existsInExtHost, true);
+		const dirCoverage = testCoverage.getComputedForUri(URI.file('/path/to'));
+		assert.deepEqual(dirCoverage?.statement, { covered: 15, total: 30 });
+	});
+
+	test('works if per-test data is added first', async () => {
+		const raw3: IFileCoverage = {
+			id: '1',
+			testId: TestId.fromString('my-test'),
+			uri: URI.file('/path/to/file'),
+			statement: { covered: 12, total: 24 },
+			branch: { covered: 7, total: 10 },
+			declaration: { covered: 2, total: 5 },
+		};
+		testCoverage.append(raw3, undefined);
+
+		const fileCoverage = testCoverage.getUri(raw3.uri);
+		assert.deepEqual(fileCoverage?.existsInExtHost, false);
+
+		addTests();
+
+		assert.strictEqual(fileCoverage?.perTestData?.size, 1);
+		const perTestCoverage = Iterable.first(fileCoverage!.perTestData!.values());
+		assert.deepStrictEqual(perTestCoverage?.statement, raw3.statement);
+		assert.deepStrictEqual(perTestCoverage?.branch, raw3.branch);
+		assert.deepStrictEqual(perTestCoverage?.declaration, raw3.declaration);
+
+		// should be the expected values:
+		assert.deepEqual(fileCoverage?.statement, { covered: 10, total: 20 });
+		assert.deepEqual(fileCoverage?.existsInExtHost, true);
+		const dirCoverage = testCoverage.getComputedForUri(URI.file('/path/to'));
+		assert.deepEqual(dirCoverage?.statement, { covered: 15, total: 30 });
+	});
+});

--- a/src/vs/workbench/services/extensions/common/extensionsApiProposals.ts
+++ b/src/vs/workbench/services/extensions/common/extensionsApiProposals.ts
@@ -9,6 +9,7 @@ export const allApiProposals = Object.freeze({
 	activeComment: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.activeComment.d.ts',
 	aiRelatedInformation: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.aiRelatedInformation.d.ts',
 	aiTextSearchProvider: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.aiTextSearchProvider.d.ts',
+	attributableCoverage: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.attributableCoverage.d.ts',
 	authGetSessions: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.authGetSessions.d.ts',
 	authLearnMore: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.authLearnMore.d.ts',
 	authSession: 'https://raw.githubusercontent.com/microsoft/vscode/main/src/vscode-dts/vscode.proposed.authSession.d.ts',

--- a/src/vscode-dts/vscode.proposed.attributableCoverage.d.ts
+++ b/src/vscode-dts/vscode.proposed.attributableCoverage.d.ts
@@ -1,0 +1,28 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+declare module 'vscode' {
+	export class FileCoverage2 extends FileCoverage {
+		/**
+		 * Test {@link TestItem} this file coverage is generated from. If undefined,
+		 * the editor will assume the coverage is the overall summary coverage for
+		 * the entire file.
+		 *
+		 * If per-test coverage is available, an extension should append multiple
+		 * `FileCoverage` instances with this property set for each test item. It
+		 * must also append a `FileCoverage` instance without this property set to
+		 * represent the overall coverage of the file.
+		 */
+		testItem?: TestItem;
+
+		constructor(
+			uri: Uri,
+			statementCoverage: TestCoverageCount,
+			branchCoverage?: TestCoverageCount,
+			declarationCoverage?: TestCoverageCount,
+			testItem?: TestItem,
+		);
+	}
+}


### PR DESCRIPTION
This implements the data flow for attributable test coverage. Todo for tomorrow is to support this in our test runner (probably making module to generate per-test coverage for generic JS tests) and then building some UX for it.

Refs #212196

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
