### PR TITLE
Add recursive toggle

### DIFF
--- a/src/vs/editor/contrib/folding/browser/folding.ts
+++ b/src/vs/editor/contrib/folding/browser/folding.ts
@@ -809,6 +809,30 @@ class FoldRecursivelyAction extends FoldingAction<void> {
 	}
 }
 
+
+class ToggleFoldRecursivelyAction extends FoldingAction<void> {
+
+	constructor() {
+		super({
+			id: 'editor.toggleFoldRecursively',
+			label: nls.localize('toggleFoldRecursivelyAction.label', "Toggle Fold Recursively"),
+			alias: 'Toggle Fold Recursively',
+			precondition: CONTEXT_FOLDING_ENABLED,
+			kbOpts: {
+				kbExpr: EditorContextKeys.editorTextFocus,
+				primary: KeyChord(KeyMod.CtrlCmd | KeyCode.KeyK, KeyMod.CtrlCmd | KeyCode.KeyP),
+				weight: KeybindingWeight.EditorContrib
+			}
+		});
+	}
+
+	invoke(_foldingController: FoldingController, foldingModel: FoldingModel, editor: ICodeEditor): void {
+		const selectedLines = this.getSelectedLines(editor);
+		toggleCollapseState(foldingModel, Number.MAX_VALUE, selectedLines);
+	}
+}
+
+
 class FoldAllBlockCommentsAction extends FoldingAction<void> {
 
 	constructor() {
@@ -1189,6 +1213,7 @@ registerEditorAction(UnfoldAction);
 registerEditorAction(UnFoldRecursivelyAction);
 registerEditorAction(FoldAction);
 registerEditorAction(FoldRecursivelyAction);
+registerEditorAction(ToggleFoldRecursivelyAction);
 registerEditorAction(FoldAllAction);
 registerEditorAction(UnfoldAllAction);
 registerEditorAction(FoldAllBlockCommentsAction);

--- a/src/vs/editor/contrib/folding/browser/folding.ts
+++ b/src/vs/editor/contrib/folding/browser/folding.ts
@@ -820,7 +820,7 @@ class ToggleFoldRecursivelyAction extends FoldingAction<void> {
 			precondition: CONTEXT_FOLDING_ENABLED,
 			kbOpts: {
 				kbExpr: EditorContextKeys.editorTextFocus,
-				primary: KeyChord(KeyMod.CtrlCmd | KeyCode.KeyK, KeyMod.CtrlCmd | KeyCode.KeyP),
+				primary: KeyChord(KeyMod.CtrlCmd | KeyCode.KeyK, KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KeyL),
 				weight: KeybindingWeight.EditorContrib
 			}
 		});


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Feature: https://github.com/microsoft/vscode/issues/88915

This PR adds a recursive toggle fold command. There is already a fold, unfold and toggle fold command, but for recursive fold and unfold there is no recursive toggle fold command.

The command is accessible using shortcut `⌘K ⌘P`. I would have preferred using `⌘K ⌘O` since its less of a stretch for your fingers, but I felt this would be a bit confusing since there is already a command `⌘K ⌘0` related to folding. Happy to change it if there's any other suggestions.

Will create a PR into the vscode-docs repo as well to include this once reviewed.

