### PR TITLE
Avoid replacing a single character with ellipsis when rendering inline hints

### DIFF
--- a/src/vs/editor/contrib/inlayHints/browser/inlayHintsController.ts
+++ b/src/vs/editor/contrib/inlayHints/browser/inlayHintsController.ts
@@ -551,7 +551,10 @@ export class InlayHintsController implements IEditorContribution {
 				let tooLong = false;
 				const over = currentLineInfo.totalLen - InlayHintsController._MAX_LABEL_LEN;
 				if (over > 0) {
-					textlabel = textlabel.slice(0, -over) + '…';
+					// avoid replacing a single character with an ellipsis
+					if (over > 1) {
+						textlabel = textlabel.slice(0, -over) + '…';
+					}
 					tooLong = true;
 				}
 


### PR DESCRIPTION
This way we can avoid truncating this:
```
const result4: [string, string, ...number[]]
```
into this
```
const result4: [string, string, ...number[]…
```