### PR TITLE
quick pick: a11y workaround

### DIFF
--- a/src/vs/platform/quickinput/test/browser/quickinput.test.ts
+++ b/src/vs/platform/quickinput/test/browser/quickinput.test.ts
@@ -32,6 +32,8 @@ import { ContextKeyService } from 'vs/platform/contextkey/browser/contextKeyServ
 import { NoMatchingKb } from 'vs/platform/keybinding/common/keybindingResolver';
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 import { ContextViewService } from 'vs/platform/contextview/browser/contextViewService';
+import { IAccessibilityService } from 'vs/platform/accessibility/common/accessibility';
+import { TestAccessibilityService } from 'vs/platform/accessibility/test/common/testAccessibilityService';
 
 // Sets up an `onShow` listener to allow us to wait until the quick pick is shown (useful when triggering an `accept()` right after launching a quick pick)
 // kick this off before you launch the picker and then await the promise returned after you launch the picker.
@@ -62,6 +64,7 @@ suite('QuickInput', () => { // https://github.com/microsoft/vscode/issues/147543
 		// Stub the services the quick input controller needs to function
 		instantiationService.stub(IThemeService, new TestThemeService());
 		instantiationService.stub(IConfigurationService, new TestConfigurationService());
+		instantiationService.stub(IAccessibilityService, new TestAccessibilityService());
 		instantiationService.stub(IListService, store.add(new ListService()));
 		instantiationService.stub(ILayoutService, { activeContainer: fixture, onDidLayoutContainer: Event.None } as any);
 		instantiationService.stub(IContextViewService, store.add(instantiationService.createInstance(ContextViewService)));


### PR DESCRIPTION
Fixes #211976

Unfortunately A11Y in browsers is both brittle and cumbersome. This PR removes and adds the currently focused tree node DOM node from its parent to nudge NVDA to read what we want it to read. It's hard to accomplish this in any other way without compromising performance, we're limited by the ARIA "api".