### PR TITLE
contribute standard interactive execute keybindings from core

### DIFF
--- a/src/vs/workbench/contrib/interactive/browser/interactive.contribution.ts
+++ b/src/vs/workbench/contrib/interactive/browser/interactive.contribution.ts
@@ -434,7 +434,21 @@ registerAction2(class extends Action2 {
 			id: 'interactive.execute',
 			title: localize2('interactive.execute', 'Execute Code'),
 			category: interactiveWindowCategory,
-			keybinding: {
+			keybinding: [{
+				when: ContextKeyExpr.and(
+					ContextKeyExpr.equals('activeEditor', 'workbench.editor.interactive'),
+					ContextKeyExpr.equals('config.interactiveWindow.executeWithShiftEnter', true)
+				),
+				primary: KeyMod.Shift | KeyCode.Enter,
+				weight: NOTEBOOK_EDITOR_WIDGET_ACTION_WEIGHT
+			}, {
+				when: ContextKeyExpr.and(
+					ContextKeyExpr.equals('activeEditor', 'workbench.editor.interactive'),
+					ContextKeyExpr.equals('config.interactiveWindow.executeWithShiftEnter', false)
+				),
+				primary: KeyCode.Enter,
+				weight: NOTEBOOK_EDITOR_WIDGET_ACTION_WEIGHT
+			}, {
 				// when: NOTEBOOK_CELL_LIST_FOCUSED,
 				when: ContextKeyExpr.equals('activeEditor', 'workbench.editor.interactive'),
 				primary: KeyMod.WinCtrl | KeyCode.Enter,
@@ -442,7 +456,7 @@ registerAction2(class extends Action2 {
 					primary: KeyMod.CtrlCmd | KeyCode.Enter
 				},
 				weight: NOTEBOOK_EDITOR_WIDGET_ACTION_WEIGHT
-			},
+			}],
 			menu: [
 				{
 					id: MenuId.InteractiveInputExecute
@@ -807,6 +821,19 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).regis
 			type: 'boolean',
 			default: false,
 			markdownDescription: localize('interactiveWindow.promptToSaveOnClose', "Prompt to save the interactive window when it is closed. Only new interactive windows will be affected by this setting change.")
+		}
+	}
+});
+
+Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).registerConfiguration({
+	id: 'interactiveWindow',
+	order: 100,
+	type: 'object',
+	'properties': {
+		['executeWithShiftEnter']: {
+			type: 'boolean',
+			default: true,
+			markdownDescription: localize('interactiveWindow.executeWithShiftEnter', "Execute the interactive window (REPL) input box with shift+enter, so that enter can be used to create a newline.")
 		}
 	}
 });


### PR DESCRIPTION
https://github.com/microsoft/vscode/issues/212051

this will keep the keybinding as shift+enter, but we can switch the default once the keybinding is removed from jupyter with https://github.com/microsoft/vscode-jupyter/pull/15679.