### PR TITLE
naive fix for #212408 

### DIFF
--- a/src/vs/workbench/services/dialogs/browser/simpleFileDialog.ts
+++ b/src/vs/workbench/services/dialogs/browser/simpleFileDialog.ts
@@ -832,7 +832,7 @@ export class SimpleFileDialog implements ISimpleFileDialog {
 			} else if (!statDirname.isDirectory) {
 				this.filePickBox.validationMessage = nls.localize('remoteFileDialog.validateNonexistentDir', 'Please enter a path that exists.');
 				return Promise.resolve(false);
-			} else if (statDirname.readonly || statDirname.locked) {
+			} else if ((statDirname.readonly && !this.isWindows) || statDirname.locked) {
 				this.filePickBox.validationMessage = nls.localize('remoteFileDialog.validateReadonlyFolder', 'This folder cannot be used as a save destination. Please choose another folder');
 				return Promise.resolve(false);
 			}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

A naive fix for #212408:
- added a simple `this.isWindows` check to [line 835 of `simpleFileDialog.ts`](https://github.com/microsoft/vscode/blob/ef54c4eb7bfd04bb0485cf9bc407b187b1be1799/src/vs/workbench/services/dialogs/browser/simpleFileDialog.ts#L835) 
  (based on [line 824](https://github.com/microsoft/vscode/blob/ef54c4eb7bfd04bb0485cf9bc407b187b1be1799/src/vs/workbench/services/dialogs/browser/simpleFileDialog.ts#L824) of the same file)

notes/toughts:
- the check is *naive* in it's current state: 
  it assumes the `this.isWindows` *also applies to the file service that provides the dirstat* (i haven't had the time to investigate how the services instantiated by the dialog are related in code)
  this IMO may require more work either in `simpleFileDialog` (like trying to `tocuh` the destination in a `Promise`, and returning that)  or the `fileService` (extra flags) 
  &rarr; **any comments, pointers, suggestions and help welcome!** - this being my first PR to the codebase
- thus, the condition on line 845 may need to be split into 'read-only' and 'locked' checks
- also, the localization message with the key `remoteFileDialog.validateReadonlyFolder` should be renamed `remoteFileDialog.validateLockedFolder` for correctness, while possibly altering  `remoteFileDialog.validateReadonlyFolder` or both to be more concise (if possible?)