### PR TITLE
Use hover statusbar for chat "view in marketplace" option

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatAgentHover.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatAgentHover.ts
@@ -29,12 +29,9 @@ export class ChatAgentHover extends Disposable {
 	private readonly publisherName: HTMLElement;
 	private readonly description: HTMLElement;
 
-	private currentAgent: IChatAgentData | undefined;
-
 	constructor(
 		@IChatAgentService private readonly chatAgentService: IChatAgentService,
 		@IExtensionsWorkbenchService private readonly extensionService: IExtensionsWorkbenchService,
-		@ICommandService private readonly commandService: ICommandService,
 		@IChatAgentNameService private readonly chatAgentNameService: IChatAgentNameService,
 	) {
 		super();
@@ -79,8 +76,6 @@ export class ChatAgentHover extends Disposable {
 
 	setAgent(id: string): void {
 		const agent = this.chatAgentService.getAgent(id)!;
-		this.currentAgent = agent;
-
 		if (agent.metadata.icon instanceof URI) {
 			const avatarIcon = dom.$<HTMLImageElement>('img.icon');
 			avatarIcon.src = FileAccess.uriToBrowserUri(agent.metadata.icon).toString(true);
@@ -135,5 +130,5 @@ export function getChatAgentHoverOptions(getAgent: () => IChatAgentData | undefi
 				},
 			}
 		]
-	}
+	};
 }

--- a/src/vs/workbench/contrib/chat/browser/chatAgentHover.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatAgentHover.ts
@@ -5,7 +5,7 @@
 
 import * as dom from 'vs/base/browser/dom';
 import { h } from 'vs/base/browser/dom';
-import { Button } from 'vs/base/browser/ui/button/button';
+import { IUpdatableHoverOptions } from 'vs/base/browser/ui/hover/hover';
 import { renderIcon } from 'vs/base/browser/ui/iconLabel/iconLabels';
 import { CancellationTokenSource } from 'vs/base/common/cancellation';
 import { Codicon } from 'vs/base/common/codicons';
@@ -55,7 +55,6 @@ export class ChatAgentHover extends Disposable {
 				]),
 				h('.chat-agent-hover-warning@warning'),
 				h('span.chat-agent-hover-description@description'),
-				h('span.chat-agent-hover-marketplace-button@button'),
 			]);
 		this.domNode = hoverElement.root;
 
@@ -76,25 +75,6 @@ export class ChatAgentHover extends Disposable {
 
 		hoverElement.warning.appendChild(renderIcon(Codicon.warning));
 		hoverElement.warning.appendChild(dom.$('span', undefined, localize('reservedName', "This chat extension is using a reserved name.")));
-
-		const label = localize('marketplaceLabel', "View in Marketplace") + '.';
-		const marketplaceButton = this._register(new Button(hoverElement.button, {
-			title: label,
-			buttonBackground: undefined,
-			buttonBorder: undefined,
-			buttonForeground: undefined,
-			buttonHoverBackground: undefined,
-			buttonSecondaryBackground: undefined,
-			buttonSecondaryForeground: undefined,
-			buttonSecondaryHoverBackground: undefined,
-			buttonSeparator: undefined,
-		}));
-		marketplaceButton.label = label;
-		this._register(marketplaceButton.onDidClick(() => {
-			if (this.currentAgent) {
-				this.commandService.executeCommand(showExtensionsWithIdsCommandId, [this.currentAgent.extensionId.value]);
-			}
-		}));
 	}
 
 	setAgent(id: string): void {
@@ -138,5 +118,22 @@ export class ChatAgentHover extends Disposable {
 				}
 			});
 		}
+	}
+}
+
+export function getChatAgentHoverOptions(getAgent: () => IChatAgentData | undefined, commandService: ICommandService): IUpdatableHoverOptions {
+	return {
+		actions: [
+			{
+				commandId: showExtensionsWithIdsCommandId,
+				label: localize('marketplaceLabel', "View in Marketplace"),
+				run: () => {
+					const agent = getAgent();
+					if (agent) {
+						commandService.executeCommand(showExtensionsWithIdsCommandId, [agent.extensionId.value]);
+					}
+				},
+			}
+		]
 	}
 }

--- a/src/vs/workbench/contrib/chat/browser/chatListRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatListRenderer.ts
@@ -58,7 +58,7 @@ import { ColorScheme } from 'vs/platform/theme/common/theme';
 import { IThemeService } from 'vs/platform/theme/common/themeService';
 import { IResourceLabel, ResourceLabels } from 'vs/workbench/browser/labels';
 import { ChatTreeItem, GeneratingPhrase, IChatCodeBlockInfo, IChatFileTreeInfo } from 'vs/workbench/contrib/chat/browser/chat';
-import { ChatAgentHover } from 'vs/workbench/contrib/chat/browser/chatAgentHover';
+import { ChatAgentHover, getChatAgentHoverOptions } from 'vs/workbench/contrib/chat/browser/chatAgentHover';
 import { ChatConfirmationWidget } from 'vs/workbench/contrib/chat/browser/chatConfirmationWidget';
 import { ChatFollowups } from 'vs/workbench/contrib/chat/browser/chatFollowups';
 import { ChatMarkdownDecorationsRenderer } from 'vs/workbench/contrib/chat/browser/chatMarkdownDecorationsRenderer';
@@ -78,6 +78,7 @@ import { ITrustedDomainService } from 'vs/workbench/contrib/url/browser/trustedD
 import { IMarkdownVulnerability, annotateSpecialMarkdownContent } from '../common/annotations';
 import { CodeBlockModelCollection } from '../common/codeBlockModelCollection';
 import { IChatListItemRendererOptions } from './chat';
+import { showExtensionsWithIdsCommandId } from 'vs/workbench/contrib/extensions/browser/extensionsActions';
 
 const $ = dom.$;
 
@@ -303,7 +304,7 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 			}
 
 			return undefined;
-		}));
+		}, getChatAgentHoverOptions(() => isResponseVM(template.currentElement) ? template.currentElement.agent : undefined, this.commandService)));
 
 		const template: IChatListItemTemplate = { avatarContainer, username, detail, referencesListContainer, value, rowContainer, elementDisposables, titleToolbar, templateDisposables, contextKeyService, agentHover };
 		return template;

--- a/src/vs/workbench/contrib/chat/browser/chatListRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatListRenderer.ts
@@ -78,7 +78,6 @@ import { ITrustedDomainService } from 'vs/workbench/contrib/url/browser/trustedD
 import { IMarkdownVulnerability, annotateSpecialMarkdownContent } from '../common/annotations';
 import { CodeBlockModelCollection } from '../common/codeBlockModelCollection';
 import { IChatListItemRendererOptions } from './chat';
-import { showExtensionsWithIdsCommandId } from 'vs/workbench/contrib/extensions/browser/extensionsActions';
 
 const $ = dom.$;
 

--- a/src/vs/workbench/contrib/chat/browser/media/chatAgentHover.css
+++ b/src/vs/workbench/contrib/chat/browser/media/chatAgentHover.css
@@ -76,15 +76,6 @@
 }
 
 .chat-agent-hover-description,
-.chat-agent-hover-marketplace-button .monaco-text-button,
 .chat-agent-hover-warning {
 	font-size: 13px;
-}
-
-.chat-agent-hover .chat-agent-hover-marketplace-button .monaco-text-button {
-	margin-left: 3px;
-	display: unset;
-	padding: unset;
-	border: unset;
-	line-height: unset;
 }


### PR DESCRIPTION
This PR includes a cleanup and an update to use the hover statusbar for the chat "view in marketplace" option. The changes remove the need for a separate button and streamline the user interface. 