### PR TITLE
fix: remove enter as a keybinding for accepting a terminal suggestion

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminal.suggest.contribution.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminal.suggest.contribution.ts
@@ -152,9 +152,8 @@ registerActiveInstanceAction({
 	f1: false,
 	precondition: ContextKeyExpr.and(ContextKeyExpr.or(TerminalContextKeys.processSupported, TerminalContextKeys.terminalHasBeenCreated), TerminalContextKeys.focus, TerminalContextKeys.isOpen, TerminalContextKeys.suggestWidgetVisible),
 	keybinding: {
-		primary: KeyCode.Enter,
-		secondary: [KeyCode.Tab],
-		// Enter is bound to other workbench keybindings that this needs to beat
+		// Tab is bound to other workbench keybindings that this needs to beat
+		primary: KeyCode.Tab,
 		weight: KeybindingWeight.WorkbenchContrib + 1
 	},
 	run: (activeInstance) => TerminalSuggestContribution.get(activeInstance)?.addon?.acceptSelectedSuggestion()


### PR DESCRIPTION
Fixes #212450. I think `enter` shouldn't be a keybinding for accepting a suggestion since suggestions can appear without request. If a user always had to trigger completions, I think it would be fine to leave as is