### PR TITLE
Fix some participant names being rendered incorrectly after reload

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -149,6 +149,7 @@ class ChatSlashStaticSlashCommandsContribution extends Disposable {
 		@ICommandService commandService: ICommandService,
 		@IChatAgentService chatAgentService: IChatAgentService,
 		@IChatVariablesService chatVariablesService: IChatVariablesService,
+		@IInstantiationService instantiationService: IInstantiationService,
 	) {
 		super();
 		this._store.add(slashCommandService.registerSlashCommand({
@@ -184,7 +185,8 @@ class ChatSlashStaticSlashCommandsContribution extends Disposable {
 				.filter(a => a.locations.includes(ChatAgentLocation.Panel))
 				.map(async a => {
 					const description = a.description ? `- ${a.description}` : '';
-					const agentLine = `- ${agentToMarkdown(a, true)} ${description}`;
+					const agentMarkdown = instantiationService.invokeFunction(accessor => agentToMarkdown(a, true, accessor));
+					const agentLine = `- ${agentMarkdown} ${description}`;
 					const commandText = a.slashCommands.map(c => {
 						const description = c.description ? `- ${c.description}` : '';
 						return `\t* ${agentSlashCommandToMarkdown(a, c)} ${description}`;

--- a/src/vs/workbench/contrib/chat/browser/chatMarkdownDecorationsRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatMarkdownDecorationsRenderer.ts
@@ -175,6 +175,7 @@ export class ChatMarkdownDecorationsRenderer {
 			container = this.renderResourceWidget(nameWithLeader, undefined);
 		}
 
+		const agent = this.chatAgentService.getAgent(args.agentId);
 		const hover: Lazy<ChatAgentHover> = new Lazy(() => store.add(this.instantiationService.createInstance(ChatAgentHover)));
 		store.add(this.hoverService.setupUpdatableHover(getDefaultHoverDelegate('element'), container, () => {
 			hover.value.setAgent(args.agentId);

--- a/src/vs/workbench/contrib/chat/browser/chatMarkdownDecorationsRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatMarkdownDecorationsRenderer.ts
@@ -12,7 +12,7 @@ import { revive } from 'vs/base/common/marshalling';
 import { URI } from 'vs/base/common/uri';
 import { Location } from 'vs/editor/common/languages';
 import { IHoverService } from 'vs/platform/hover/browser/hover';
-import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
+import { IInstantiationService, ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 import { ILabelService } from 'vs/platform/label/common/label';
 import { ILogService } from 'vs/platform/log/common/log';
@@ -34,13 +34,24 @@ const agentRefUrl = `http://_chatagent_`;
 /** For rendering agent decorations with hover */
 const agentSlashRefUrl = `http://_chatslash_`;
 
-export function agentToMarkdown(agent: IChatAgentData, isClickable: boolean): string {
-	const args: IAgentWidgetArgs = { agentId: agent.id, isClickable };
+export function agentToMarkdown(agent: IChatAgentData, isClickable: boolean, accessor: ServicesAccessor): string {
+	const chatAgentNameService = accessor.get(IChatAgentNameService);
+	const chatAgentService = accessor.get(IChatAgentService);
+
+	const isAllowed = chatAgentNameService.getAgentNameRestriction(agent).get();
+	let name = `${isAllowed ? agent.name : getFullyQualifiedId(agent)}`;
+	const isDupe = isAllowed && chatAgentService.getAgentsByName(agent.name).length > 1;
+	if (isDupe) {
+		name += ` (${agent.publisherDisplayName})`;
+	}
+
+	const args: IAgentWidgetArgs = { agentId: agent.id, name, isClickable };
 	return `[${agent.name}](${agentRefUrl}?${encodeURIComponent(JSON.stringify(args))})`;
 }
 
 interface IAgentWidgetArgs {
 	agentId: string;
+	name: string;
 	isClickable?: boolean;
 }
 
@@ -65,7 +76,6 @@ export class ChatMarkdownDecorationsRenderer {
 		@IHoverService private readonly hoverService: IHoverService,
 		@IChatService private readonly chatService: IChatService,
 		@IChatWidgetService private readonly chatWidgetService: IChatWidgetService,
-		@IChatAgentNameService private readonly chatAgentNameService: IChatAgentNameService,
 	) { }
 
 	convertParsedRequestToMarkdown(parsedRequest: IParsedChatRequest): string {
@@ -74,7 +84,7 @@ export class ChatMarkdownDecorationsRenderer {
 			if (part instanceof ChatRequestTextPart) {
 				result += part.text;
 			} else if (part instanceof ChatRequestAgentPart) {
-				result += agentToMarkdown(part.agent, false);
+				result += this.instantiationService.invokeFunction(accessor => agentToMarkdown(part.agent, false, accessor));
 			} else {
 				const uri = part instanceof ChatRequestDynamicVariablePart && part.data instanceof URI ?
 					part.data :
@@ -139,20 +149,7 @@ export class ChatMarkdownDecorationsRenderer {
 	}
 
 	private renderAgentWidget(args: IAgentWidgetArgs, store: DisposableStore): HTMLElement {
-		const agent = this.chatAgentService.getAgent(args.agentId);
-		let name: string;
-		if (agent) {
-			const isAllowed = this.chatAgentNameService.getAgentNameRestriction(agent).get();
-			name = `${chatAgentLeader}${isAllowed ? agent.name : getFullyQualifiedId(agent)}`;
-
-			const isDupe = isAllowed && this.chatAgentService.getAgentsByName(agent.name).length > 1;
-			if (isDupe) {
-				name += ` (${agent.publisherDisplayName})`;
-			}
-		} else {
-			name = args.agentId;
-		}
-
+		const nameWithLeader = `${chatAgentLeader}${args.name}`;
 		let container: HTMLElement;
 		if (args.isClickable) {
 			container = dom.$('span.chat-agent-widget');
@@ -161,8 +158,9 @@ export class ChatMarkdownDecorationsRenderer {
 				buttonForeground: asCssVariable(chatSlashCommandForeground),
 				buttonHoverBackground: undefined
 			}));
-			button.label = name;
+			button.label = nameWithLeader;
 			store.add(button.onDidClick(() => {
+				const agent = this.chatAgentService.getAgent(args.agentId);
 				const widget = this.chatWidgetService.lastFocusedWidget;
 				if (!widget || !agent) {
 					return;
@@ -171,7 +169,7 @@ export class ChatMarkdownDecorationsRenderer {
 				this.chatService.sendRequest(widget.viewModel!.sessionId, agent.metadata.sampleRequest ?? '', { location: widget.location, agentId: agent.id });
 			}));
 		} else {
-			container = this.renderResourceWidget(name, undefined);
+			container = this.renderResourceWidget(nameWithLeader, undefined);
 		}
 
 		store.add(this.hoverService.setupUpdatableHover(getDefaultHoverDelegate('element'), container, () => {

--- a/src/vs/workbench/contrib/chat/common/chatAgents.ts
+++ b/src/vs/workbench/contrib/chat/common/chatAgents.ts
@@ -335,6 +335,7 @@ export class MergedChatAgent implements IChatAgent {
 
 	get id(): string { return this.data.id; }
 	get name(): string { return this.data.name ?? ''; }
+	get fullName(): string { return this.data.fullName ?? ''; }
 	get description(): string { return this.data.description ?? ''; }
 	get extensionId(): ExtensionIdentifier { return this.data.extensionId; }
 	get extensionPublisherId(): string { return this.data.extensionPublisherId; }

--- a/src/vs/workbench/contrib/chat/common/chatModel.ts
+++ b/src/vs/workbench/contrib/chat/common/chatModel.ts
@@ -956,7 +956,7 @@ export class ChatWelcomeMessageModel implements IChatWelcomeMessageModel {
 	}
 
 	public get username(): string {
-		return this.chatAgentService.getDefaultAgent(ChatAgentLocation.Panel)?.fullName ?? '';
+		return this.chatAgentService.getContributedDefaultAgent(ChatAgentLocation.Panel)?.fullName ?? '';
 	}
 
 	public get avatarIcon(): ThemeIcon | undefined {


### PR DESCRIPTION
Compute the name using the real persisted IChatAgentData that we already have, instead of looking it up in the service that doesn't have that agent yet.
Ideally it would use both- this will still render the old details of agents after they are updated

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
