### PR TITLE
Shell integration: Fix PS2 prompt reporting

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/media/shellIntegration-bash.sh
+++ b/src/vs/workbench/contrib/terminal/browser/media/shellIntegration-bash.sh
@@ -163,7 +163,7 @@ __vsc_nonce="$VSCODE_NONCE"
 unset VSCODE_NONCE
 
 # Report continuation prompt
-builtin printf "\e]633;P;ContinuationPrompt=$(echo "$PS2" | sed 's/\x1b/\\\\x1b/g')\a"
+builtin printf "\e]633;P;ContinuationPrompt=%s\a" "$(echo "$PS2" | sed 's/\x1b/\\\\x1b/g')"
 
 __vsc_report_prompt() {
 	# Expand the original PS1 similarly to how bash would normally


### PR DESCRIPTION
Currently shellIntegration-bash attempts to handle raw ESCs within the `PS2` continuation prompt by converting them to backslash-escapes... but then it feeds those backslash-escapes to `printf` which immediately converts them back.

And in most cases, just like PS1, the PS2 will have `\e` backslash-escaped form anyway – which still leads to the same problem of printf translating them back to raw ESC.

For example, if PS2 is set to:

    PS2="\[\e[0;1;30m\]...\[\e[m\] "

(with Bash strings keeping the `\[` and `\e` as literal text), then the printf results in the output:

    <U+001B>]633;P;ContinuationPrompt=\[<U+001B>[0;1;30m\]...\[<U+001B>[m\] <U+0007>

With this change, it should result in the expected:

    <U+001B>]633;P;ContinuationPrompt=\[\e[0;1;30m\]...\[\e[m\] \a<U+0007>

(Yes, I noticed __vsc_report_prompt() just a few lines below which does everything differently with PS1 – I'm pretty sure the same code should be handling both prompts identically, but I'm not sufficiently familiar with the code to attempt unifying them just yet.)

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
