### PR TITLE
Added setting for notebook cell markdown lineheight

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/notebook.contribution.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebook.contribution.ts
@@ -941,6 +941,12 @@ configurationRegistry.registerConfiguration({
 			default: 0,
 			tags: ['notebookLayout']
 		},
+		[NotebookSetting.markdownLineHeight]: {
+			markdownDescription: nls.localize('notebook.markdown.lineHeight', "Controls the line height in pixels of markdown cells in notebooks. When set to {0}, {1} will be used", '`0`', '`normal`'),
+			type: 'number',
+			default: 0,
+			tags: ['notebookLayout']
+		},
 		[NotebookSetting.cellEditorOptionsCustomizations]: editorOptionsCustomizationSchema,
 		[NotebookSetting.interactiveWindowCollapseCodeCells]: {
 			markdownDescription: nls.localize('notebook.interactiveWindow.collapseCodeCells', "Controls whether code cells in the interactive window are collapsed by default."),

--- a/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
@@ -366,6 +366,7 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditorD
 				|| e.dragAndDropEnabled
 				|| e.fontSize
 				|| e.markupFontSize
+				|| e.markdownLineHeight
 				|| e.fontFamily
 				|| e.insertToolbarAlignment
 				|| e.outputFontSize

--- a/src/vs/workbench/contrib/notebook/browser/notebookOptions.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookOptions.ts
@@ -47,6 +47,7 @@ export interface NotebookDisplayOptions { // TODO @Yoyokrazy rename to a more ge
 	outputFontFamily: string;
 	outputLineHeight: number;
 	markupFontSize: number;
+	markdownLineHeight: number;
 	editorOptionsCustomizations: Partial<{
 		'editor.indentSize': 'tabSize' | number;
 		'editor.tabSize': number;
@@ -96,6 +97,7 @@ export interface NotebookOptionsChangeEvent {
 	readonly fontSize?: boolean;
 	readonly outputFontSize?: boolean;
 	readonly markupFontSize?: boolean;
+	readonly markdownLineHeight?: boolean;
 	readonly fontFamily?: boolean;
 	readonly outputFontFamily?: boolean;
 	readonly editorOptionsCustomizations?: boolean;
@@ -159,6 +161,7 @@ export class NotebookOptions extends Disposable {
 		// const { bottomToolbarGap, bottomToolbarHeight } = this._computeBottomToolbarDimensions(compactView, insertToolbarPosition, insertToolbarAlignment);
 		const fontSize = this.configurationService.getValue<number>('editor.fontSize');
 		const markupFontSize = this.configurationService.getValue<number>(NotebookSetting.markupFontSize);
+		const markdownLineHeight = this.configurationService.getValue<number>(NotebookSetting.markdownLineHeight);
 		let editorOptionsCustomizations = this.configurationService.getValue<Partial<{
 			'editor.indentSize': 'tabSize' | number;
 			'editor.tabSize': number;
@@ -246,6 +249,7 @@ export class NotebookOptions extends Disposable {
 			outputFontFamily,
 			outputLineHeight,
 			markupFontSize,
+			markdownLineHeight,
 			editorOptionsCustomizations,
 			focusIndicatorGap: 3,
 			interactiveWindowCollapseCodeCells,
@@ -411,6 +415,7 @@ export class NotebookOptions extends Disposable {
 		const fontSize = e.affectsConfiguration('editor.fontSize');
 		const outputFontSize = e.affectsConfiguration(NotebookSetting.outputFontSize);
 		const markupFontSize = e.affectsConfiguration(NotebookSetting.markupFontSize);
+		const markdownLineHeight = e.affectsConfiguration(NotebookSetting.markdownLineHeight);
 		const fontFamily = e.affectsConfiguration('editor.fontFamily');
 		const outputFontFamily = e.affectsConfiguration(NotebookSetting.outputFontFamily);
 		const editorOptionsCustomizations = e.affectsConfiguration(NotebookSetting.cellEditorOptionsCustomizations);
@@ -439,6 +444,7 @@ export class NotebookOptions extends Disposable {
 			&& !fontSize
 			&& !outputFontSize
 			&& !markupFontSize
+			&& !markdownLineHeight
 			&& !fontFamily
 			&& !outputFontFamily
 			&& !editorOptionsCustomizations
@@ -525,6 +531,10 @@ export class NotebookOptions extends Disposable {
 			configuration.markupFontSize = this.configurationService.getValue<number>(NotebookSetting.markupFontSize);
 		}
 
+		if (markdownLineHeight) {
+			configuration.markdownLineHeight = this.configurationService.getValue<number>(NotebookSetting.markdownLineHeight);
+		}
+
 		if (outputFontFamily) {
 			configuration.outputFontFamily = this.configurationService.getValue<string>(NotebookSetting.outputFontFamily);
 		}
@@ -579,6 +589,7 @@ export class NotebookOptions extends Disposable {
 			fontSize,
 			outputFontSize,
 			markupFontSize,
+			markdownLineHeight,
 			fontFamily,
 			outputFontFamily,
 			editorOptionsCustomizations,
@@ -796,6 +807,7 @@ export class NotebookOptions extends Disposable {
 			outputFontSize: this._layoutConfiguration.outputFontSize,
 			outputFontFamily: this._layoutConfiguration.outputFontFamily,
 			markupFontSize: this._layoutConfiguration.markupFontSize,
+			markdownLineHeight: this._layoutConfiguration.markdownLineHeight,
 			outputLineHeight: this._layoutConfiguration.outputLineHeight,
 			outputScrolling: this._layoutConfiguration.outputScrolling,
 			outputWordWrap: this._layoutConfiguration.outputWordWrap,
@@ -819,6 +831,7 @@ export class NotebookOptions extends Disposable {
 			outputFontSize: this._layoutConfiguration.outputFontSize,
 			outputFontFamily: this._layoutConfiguration.outputFontFamily,
 			markupFontSize: this._layoutConfiguration.markupFontSize,
+			markdownLineHeight: this._layoutConfiguration.markdownLineHeight,
 			outputLineHeight: this._layoutConfiguration.outputLineHeight,
 			outputScrolling: this._layoutConfiguration.outputScrolling,
 			outputWordWrap: this._layoutConfiguration.outputWordWrap,

--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView.ts
@@ -114,6 +114,7 @@ interface BacklayerWebviewOptions {
 	readonly fontFamily: string;
 	readonly outputFontFamily: string;
 	readonly markupFontSize: number;
+	readonly markdownLineHeight: number;
 	readonly outputLineHeight: number;
 	readonly outputScrolling: boolean;
 	readonly outputWordWrap: boolean;
@@ -266,6 +267,7 @@ export class BackLayerWebView<T extends ICommonCellInfo> extends Themable {
 			'notebook-output-node-left-padding': `${this.options.outputNodeLeftPadding}px`,
 			'notebook-markdown-min-height': `${this.options.previewNodePadding * 2}px`,
 			'notebook-markup-font-size': typeof this.options.markupFontSize === 'number' && this.options.markupFontSize > 0 ? `${this.options.markupFontSize}px` : `calc(${this.options.fontSize}px * 1.2)`,
+			'notebook-markdown-line-height': typeof this.options.markdownLineHeight === 'number' && this.options.markdownLineHeight > 0 ? `${this.options.markdownLineHeight}px` : `normal`,
 			'notebook-cell-output-font-size': `${this.options.outputFontSize || this.options.fontSize}px`,
 			'notebook-cell-output-line-height': `${this.options.outputLineHeight}px`,
 			'notebook-cell-output-max-height': `${this.options.outputLineHeight * this.options.outputLineLimit}px`,
@@ -366,6 +368,7 @@ export class BackLayerWebView<T extends ICommonCellInfo> extends Themable {
 						white-space: initial;
 
 						font-size: var(--notebook-markup-font-size);
+						line-height: var(--notebook-markdown-line-height);
 						color: var(--theme-ui-foreground);
 					}
 

--- a/src/vs/workbench/contrib/notebook/common/notebookCommon.ts
+++ b/src/vs/workbench/contrib/notebook/common/notebookCommon.ts
@@ -932,6 +932,7 @@ export const NotebookSetting = {
 	openGettingStarted: 'notebook.experimental.openGettingStarted',
 	globalToolbarShowLabel: 'notebook.globalToolbarShowLabel',
 	markupFontSize: 'notebook.markup.fontSize',
+	markdownLineHeight: 'notebook.markdown.lineHeight',
 	interactiveWindowCollapseCodeCells: 'interactiveWindow.collapseCellInputCode',
 	outputScrollingDeprecated: 'notebook.experimental.outputScrolling',
 	outputScrolling: 'notebook.output.scrolling',


### PR DESCRIPTION
New feature for issue: #193857
____________________________

A new setting, `notebook.markdown.lineHeight`, is added in this PR. The custom value this variable is set to will be the value used by `'line-height'` in the inline stylesheet for the html markup used to render notebook markdown cells. By default, `notebook.markdown.lineHeight` will be set to `normal`. This feature only affects the markdown cells in Jupyter notebooks.

**Examples**

`"notebook.markdown.lineHeight": 25`
<img width="1728" alt="Screenshot 2024-05-12 at 12 43 19 AM" src="https://github.com/microsoft/vscode/assets/86983871/fa69ccd5-09a2-48e9-bb7b-e3dec0a8c12f">


`"notebook.markdown.lineHeight": 25`,
    `"notebook.markup.fontSize": 10`
<img width="1728" alt="Screenshot 2024-05-12 at 12 45 00 AM" src="https://github.com/microsoft/vscode/assets/86983871/51080e01-d437-4368-aa04-7d387a9de0bd">

`"notebook.markup.fontSize": 35`
<img width="1728" alt="Screenshot 2024-05-12 at 12 47 14 AM" src="https://github.com/microsoft/vscode/assets/86983871/c22a8857-ceec-4982-8802-a200f8bdf3a9">

**Invalid value**
<img width="1728" alt="Screenshot 2024-05-12 at 12 56 27 AM" src="https://github.com/microsoft/vscode/assets/86983871/f515cfef-a101-4379-8d9a-52f3e865c507">


**All default settings**
<img width="1728" alt="Screenshot 2024-05-12 at 12 51 19 AM" src="https://github.com/microsoft/vscode/assets/86983871/e87b48ef-13d4-4f3d-b453-81bc6d44a916">
