### PR TITLE
feat(markdown-language-features): #208398 add avif as image extension

### DIFF
--- a/extensions/markdown-language-features/src/languageFeatures/copyFiles/shared.ts
+++ b/extensions/markdown-language-features/src/languageFeatures/copyFiles/shared.ts
@@ -20,6 +20,7 @@ enum MediaKind {
 
 export const mediaFileExtensions = new Map<string, MediaKind>([
 	// Images
+	['avif', MediaKind.Image],
 	['bmp', MediaKind.Image],
 	['gif', MediaKind.Image],
 	['ico', MediaKind.Image],

--- a/extensions/markdown-language-features/src/util/mimes.ts
+++ b/extensions/markdown-language-features/src/util/mimes.ts
@@ -9,6 +9,7 @@ export const Mime = {
 } as const;
 
 export const mediaMimes = new Set([
+	'image/avif',
 	'image/bmp',
 	'image/gif',
 	'image/jpeg',


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
Implements #208398.

Just adds .avif image extension to `Markdown Language Features` VSCode extension as per requested in the issue.
