### PR TITLE
Fixes 212240: Windows: node-gyp install fails with latest node.js

### DIFF
--- a/build/npm/postinstall.js
+++ b/build/npm/postinstall.js
@@ -36,6 +36,7 @@ function yarnInstall(dir, opts) {
 		...(opts ?? {}),
 		cwd: dir,
 		stdio: 'inherit',
+		shell: true
 	};
 
 	const raw = process.env['npm_config_argv'] || '{}';

--- a/build/npm/preinstall.js
+++ b/build/npm/preinstall.js
@@ -99,7 +99,8 @@ function installHeaders() {
 	const yarnResult = cp.spawnSync(yarn, ['install'], {
 		env: process.env,
 		cwd: path.join(__dirname, 'gyp'),
-		stdio: 'inherit'
+		stdio: 'inherit',
+		shell: true
 	});
 	if (yarnResult.error || yarnResult.status !== 0) {
 		console.error(`Installing node-gyp failed`);
@@ -111,7 +112,7 @@ function installHeaders() {
 	// file checked into our repository. So from that point it is save to construct the path
 	// to that executable
 	const node_gyp = path.join(__dirname, 'gyp', 'node_modules', '.bin', 'node-gyp.cmd');
-	const result = cp.execFileSync(node_gyp, ['list'], { encoding: 'utf8' });
+	const result = cp.execFileSync(node_gyp, ['list'], { encoding: 'utf8', shell: true });
 	const versions = new Set(result.split(/\n/g).filter(line => !line.startsWith('gyp info')).map(value => value));
 
 	const local = getHeaderInfo(path.join(__dirname, '..', '..', '.yarnrc'));
@@ -119,7 +120,7 @@ function installHeaders() {
 
 	if (local !== undefined && !versions.has(local.target)) {
 		// Both disturl and target come from a file checked into our repository
-		cp.execFileSync(node_gyp, ['install', '--dist-url', local.disturl, local.target]);
+		cp.execFileSync(node_gyp, ['install', '--dist-url', local.disturl, local.target], { shell: true });
 	}
 
 	// Avoid downloading headers for Windows arm64 till we move to Nodejs v19 in remote
@@ -136,7 +137,7 @@ function installHeaders() {
 		process.env['npm_config_arch'] !== "arm64" &&
 		process.arch !== "arm64") {
 		// Both disturl and target come from a file checked into our repository
-		cp.execFileSync(node_gyp, ['install', '--dist-url', remote.disturl, remote.target]);
+		cp.execFileSync(node_gyp, ['install', '--dist-url', remote.disturl, remote.target], { shell: true });
 	}
 }
 

--- a/extensions/package.json
+++ b/extensions/package.json
@@ -13,5 +13,8 @@
     "@parcel/watcher": "2.1.0",
     "esbuild": "0.20.0",
     "vscode-grammar-updater": "^1.1.0"
+  },
+  "resolutions": {
+    "node-gyp-build": "4.8.1"
   }
 }

--- a/extensions/yarn.lock
+++ b/extensions/yarn.lock
@@ -217,10 +217,10 @@ node-addon-api@^3.2.1:
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-3.2.1.tgz#81325e0a2117789c0128dab65e7e38f07ceba161"
   integrity sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==
 
-node-gyp-build@^4.3.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.3.0.tgz#9f256b03e5826150be39c764bf51e993946d71a3"
-  integrity sha512-iWjXZvmboq0ja1pUGULQBexmxq8CV4xBhX7VDOTbL7ZR4FOowwY/VOtRxBN/yKxmdGoIp4j5ysNT4u3S2pDQ3Q==
+node-gyp-build@4.8.1, node-gyp-build@^4.3.0:
+  version "4.8.1"
+  resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.8.1.tgz#976d3ad905e71b76086f4f0b0d3637fe79b6cda5"
+  integrity sha512-OSs33Z9yWr148JZcbZd5WiAXhh/n9z8TxQcdMhIOlpN9AhWpLfvVFO73+m77bBABQMaY9XSvIa+qk0jlI7Gcaw==
 
 picomatch@^2.3.1:
   version "2.3.1"

--- a/package.json
+++ b/package.json
@@ -216,6 +216,9 @@
     "xml2js": "^0.5.0",
     "yaserver": "^0.4.0"
   },
+  "resolutions": {
+    "node-gyp-build": "4.8.1"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/microsoft/vscode.git"

--- a/remote/package.json
+++ b/remote/package.json
@@ -35,5 +35,8 @@
     "vscode-textmate": "9.0.0",
     "yauzl": "^3.0.0",
     "yazl": "^2.4.3"
+  },
+  "resolutions": {
+    "node-gyp-build": "4.8.1"
   }
 }

--- a/remote/yarn.lock
+++ b/remote/yarn.lock
@@ -421,10 +421,10 @@ node-addon-api@^4.3.0:
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-4.3.0.tgz#52a1a0b475193e0928e98e0426a0d1254782b77f"
   integrity sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==
 
-node-gyp-build@^4.3.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.3.0.tgz#9f256b03e5826150be39c764bf51e993946d71a3"
-  integrity sha512-iWjXZvmboq0ja1pUGULQBexmxq8CV4xBhX7VDOTbL7ZR4FOowwY/VOtRxBN/yKxmdGoIp4j5ysNT4u3S2pDQ3Q==
+node-gyp-build@4.8.1, node-gyp-build@^4.3.0:
+  version "4.8.1"
+  resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.8.1.tgz#976d3ad905e71b76086f4f0b0d3637fe79b6cda5"
+  integrity sha512-OSs33Z9yWr148JZcbZd5WiAXhh/n9z8TxQcdMhIOlpN9AhWpLfvVFO73+m77bBABQMaY9XSvIa+qk0jlI7Gcaw==
 
 node-pty@1.1.0-beta11:
   version "1.1.0-beta11"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7266,10 +7266,10 @@ node-fetch@^2.6.0, node-fetch@^2.6.7:
   dependencies:
     whatwg-url "^5.0.0"
 
-node-gyp-build@^4.3.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.3.0.tgz#9f256b03e5826150be39c764bf51e993946d71a3"
-  integrity sha512-iWjXZvmboq0ja1pUGULQBexmxq8CV4xBhX7VDOTbL7ZR4FOowwY/VOtRxBN/yKxmdGoIp4j5ysNT4u3S2pDQ3Q==
+node-gyp-build@4.8.1, node-gyp-build@^4.3.0:
+  version "4.8.1"
+  resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.8.1.tgz#976d3ad905e71b76086f4f0b0d3637fe79b6cda5"
+  integrity sha512-OSs33Z9yWr148JZcbZd5WiAXhh/n9z8TxQcdMhIOlpN9AhWpLfvVFO73+m77bBABQMaY9XSvIa+qk0jlI7Gcaw==
 
 node-html-markdown@^1.3.0:
   version "1.3.0"


### PR DESCRIPTION

Make VS Code compile on Windows with NodeJS >=20.13.1