### PR TITLE
re-enable terminal chat hint by default, fix bug

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/chat/browser/terminal.initialHint.contribution.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chat/browser/terminal.initialHint.contribution.ts
@@ -102,7 +102,8 @@ export class TerminalInitialHintContribution extends Disposable implements ITerm
 
 	private _createHint(): void {
 		const instance = this._instance instanceof TerminalInstance ? this._instance : undefined;
-		if (!instance || !this._xterm || this._hintWidget || instance?.capabilities.get(TerminalCapability.CommandDetection)?.hasInput) {
+		const commandDetectionCapability = instance?.capabilities.get(TerminalCapability.CommandDetection);
+		if (!instance || !this._xterm || this._hintWidget || !commandDetectionCapability || !commandDetectionCapability?.hasInput) {
 			return;
 		}
 
@@ -130,6 +131,16 @@ export class TerminalInitialHintContribution extends Disposable implements ITerm
 			this._decoration?.dispose();
 			this._addon?.dispose();
 		}));
+
+		const inputModel = commandDetectionCapability.promptInputModel;
+		if (inputModel) {
+			this._register(inputModel.onDidChangeInput(() => {
+				if (inputModel.value) {
+					this._decoration?.dispose();
+					this._addon?.dispose();
+				}
+			}));
+		}
 
 		if (!this._decoration) {
 			return;

--- a/src/vs/workbench/contrib/terminalContrib/chat/common/terminalInitialHintConfiguration.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chat/common/terminalInitialHintConfiguration.ts
@@ -16,6 +16,6 @@ export const terminalInitialHintConfiguration: IStringDictionary<IConfigurationP
 		restricted: true,
 		markdownDescription: localize('terminal.integrated.initialHint', "Controls if the first terminal without input will show a hint about available actions when it is focused."),
 		type: 'boolean',
-		default: false
+		default: true
 	}
 };


### PR DESCRIPTION
Some configs/startup scripts add to the prompt after our `promptStarted` has already completed. 

We now dispose of the hint when that happens so it doesn't look buggy. There's no way to wait for these scripts before showing the hint AFAICT and would be buggy/flaky to attempt to do so. 

fix #212221