### PR TITLE
Update language model metadata and add logging

### DIFF
--- a/src/vs/workbench/api/common/extHostLanguageModels.ts
+++ b/src/vs/workbench/api/common/extHostLanguageModels.ts
@@ -159,7 +159,8 @@ export class ExtHostLanguageModels implements ExtHostLanguageModelsShape {
 			name: metadata.name ?? '',
 			family: metadata.family ?? '',
 			version: metadata.version,
-			tokens: metadata.tokens,
+			maxInputTokens: metadata.maxInputTokens ?? metadata.tokens,
+			maxOutputTokens: metadata.maxOutputTokens ?? metadata.tokens,
 			auth,
 			targetExtensions: metadata.extensions
 		});
@@ -261,7 +262,8 @@ export class ExtHostLanguageModels implements ExtHostLanguageModelsShape {
 					family: data.metadata.family,
 					version: data.metadata.version,
 					name: data.metadata.name,
-					contextSize: data.metadata.tokens,
+					maxInputTokens: data.metadata.maxInputTokens,
+					maxOutputTokens: data.metadata.maxOutputTokens,
 					countTokens(text, token) {
 						if (!that._allLanguageModelData.has(identifier)) {
 							throw extHostTypes.LanguageModelError.NotFound(identifier);
@@ -281,10 +283,6 @@ export class ExtHostLanguageModels implements ExtHostLanguageModelsShape {
 			}
 
 			result.push(apiObject);
-		}
-
-		if (result.length === 0) {
-			return undefined;
 		}
 
 		return result;

--- a/src/vs/workbench/contrib/chat/common/languageModels.ts
+++ b/src/vs/workbench/contrib/chat/common/languageModels.ts
@@ -41,7 +41,8 @@ export interface ILanguageModelChatMetadata {
 	readonly vendor: string;
 	readonly version: string;
 	readonly family: string;
-	readonly tokens: number;
+	readonly maxInputTokens: number;
+	readonly maxOutputTokens: number;
 	readonly targetExtensions?: string[];
 
 	readonly auth?: {

--- a/src/vs/workbench/contrib/chat/common/languageModels.ts
+++ b/src/vs/workbench/contrib/chat/common/languageModels.ts
@@ -12,6 +12,7 @@ import { isFalsyOrWhitespace } from 'vs/base/common/strings';
 import { localize } from 'vs/nls';
 import { ExtensionIdentifier } from 'vs/platform/extensions/common/extensions';
 import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
+import { ILogService } from 'vs/platform/log/common/log';
 import { IProgress } from 'vs/platform/progress/common/progress';
 import { IExtensionService, isProposedApiEnabled } from 'vs/workbench/services/extensions/common/extensions';
 import { ExtensionsRegistry } from 'vs/workbench/services/extensions/common/extensionsRegistry';
@@ -139,6 +140,7 @@ export class LanguageModelsService implements ILanguageModelsService {
 
 	constructor(
 		@IExtensionService private readonly _extensionService: IExtensionService,
+		@ILogService private readonly _logService: ILogService,
 	) {
 
 		languageModelExtensionPoint.setHandler((extensions) => {
@@ -230,14 +232,17 @@ export class LanguageModelsService implements ILanguageModelsService {
 			}
 		}
 
+		this._logService.trace('[LM] selected language models', selector, result);
+
 		return result;
 	}
 
 	registerLanguageModelChat(identifier: string, provider: ILanguageModelChat): IDisposable {
+
+		this._logService.trace('[LM] registering language model chat', identifier, provider.metadata);
+
 		if (!this._vendors.has(provider.metadata.vendor)) {
-			// throw new Error(`Chat response provider uses UNKNOWN vendor ${provider.metadata.vendor}.`);
-			console.warn('USING UNKNOWN vendor', provider.metadata.vendor);
-			this._vendors.add(provider.metadata.vendor);
+			throw new Error(`Chat response provider uses UNKNOWN vendor ${provider.metadata.vendor}.`);
 		}
 		if (this._providers.has(identifier)) {
 			throw new Error(`Chat response provider with identifier ${identifier} is already registered.`);
@@ -247,6 +252,7 @@ export class LanguageModelsService implements ILanguageModelsService {
 		return toDisposable(() => {
 			if (this._providers.delete(identifier)) {
 				this._onDidChangeProviders.fire({ removed: [identifier] });
+				this._logService.trace('[LM] UNregistered language model chat', identifier, provider.metadata);
 			}
 		});
 	}

--- a/src/vscode-dts/vscode.proposed.chatProvider.d.ts
+++ b/src/vscode-dts/vscode.proposed.chatProvider.d.ts
@@ -44,6 +44,13 @@ declare module 'vscode' {
 		 */
 		readonly version: string;
 
+		readonly maxInputTokens: number;
+
+		readonly maxOutputTokens: number;
+
+		/**
+		 * @deprecated
+		 */
 		tokens: number;
 
 		/**

--- a/src/vscode-dts/vscode.proposed.languageModels.d.ts
+++ b/src/vscode-dts/vscode.proposed.languageModels.d.ts
@@ -133,11 +133,15 @@ declare module 'vscode' {
 		 */
 		readonly version: string;
 
-		// TODO@API
-		// max_prompt_tokens vs output_tokens vs context_size
-		// readonly inputTokens: number;
-		// readonly outputTokens: number;
-		readonly contextSize: number;
+		/**
+		 * The maximum number of tokens that can be sent to the model in a single request.
+		 */
+		readonly maxInputTokens: number;
+
+		/**
+		 * The maximum number of tokens that a model can generate in a single response.
+		 */
+		readonly maxOutputTokens: number;
 
 		/**
 		 * Make a chat request using a language model.
@@ -273,14 +277,25 @@ declare module 'vscode' {
 		 * Select chat models by a {@link LanguageModelChatSelector selector}. This can yield in multiple or no chat models and
 		 * extensions must handle these cases, esp. when no chat model exists, gracefully.
 		 *
-		 * *Note* that extensions can hold-on to the results returned by this function and use them later. However, whenever the
+		 * ```ts
+		 *
+		 * const models = await vscode.lm.selectChatModels({family: 'gpt-3.5-turbo'})!;
+		 * if (models.length > 0) {
+		 * 	const [first] = models;
+		 * 	const response = await first.sendRequest(...)
+		 * 	// ...
+		 * } else {
+		 * 	// NO chat models available
+		 * }
+		 * ```
+		 *
+		 * *Note* that extensions can hold-on to the results returned by this function and use them later. However, when the
 		 * {@link onDidChangeChatModels}-event is fired the list of chat models might have changed and extensions should re-query.
 		 *
 		 * @param selector A chat model selector. When omitted all chat models are returned.
-		 * @returns An array of chat models or `undefined` when no chat model was selected.
+		 * @returns An array of chat models, can be empty!
 		 */
-		// TODO@API no undefined but empty array
-		export function selectChatModels(selector?: LanguageModelChatSelector): Thenable<LanguageModelChat[] | undefined>;
+		export function selectChatModels(selector?: LanguageModelChatSelector): Thenable<LanguageModelChat[]>;
 	}
 
 	/**
@@ -296,9 +311,9 @@ declare module 'vscode' {
 		/**
 		 * Checks if a request can be made to a language model.
 		 *
-		 * *Note* that calling this function will not trigger a consent UI but just checks.
+		 * *Note* that calling this function will not trigger a consent UI but just checks for a persisted state.
 		 *
-		 * @param languageModelId A language model identifier, see {@link LanguageModelChat.id}
+		 * @param chat A language model chat object.
 		 * @return `true` if a request can be made, `false` if not, `undefined` if the language
 		 * model does not exist or consent hasn't been asked for.
 		 */


### PR DESCRIPTION
This pull request updates the language model metadata in the `ExtHostLanguageModels` and `LanguageModelsService` classes. It replaces the `contextSize` property with `maxInputTokens` and `maxOutputTokens` properties to better reflect the reality of the language model. Additionally, it adds logging when a language model chat is initiated, when it ends, and when a selection happens.