### PR TITLE
testing: update coverage from UX feedback

### DIFF
--- a/src/vs/workbench/contrib/testing/browser/media/testing.css
+++ b/src/vs/workbench/contrib/testing/browser/media/testing.css
@@ -363,6 +363,10 @@
 
 /** -- coverage  */
 
+.coverage-view-is-filtered > .pane-header > .actions {
+	display: block !important;
+}
+
 .test-coverage-list-item {
 	display: flex;
 	align-items: center;

--- a/src/vs/workbench/contrib/testing/common/constants.ts
+++ b/src/vs/workbench/contrib/testing/common/constants.ts
@@ -66,6 +66,7 @@ export const enum TestCommandId {
 	CoverageClear = 'testing.coverage.close',
 	CoverageCurrentFile = 'testing.coverageCurrentFile',
 	CoverageFilterToTest = 'testing.coverageFilterToTest',
+	CoverageFilterToTestInEditor = 'testing.coverageFilterToTestInEditor',
 	CoverageLastRun = 'testing.coverageLastRun',
 	CoverageSelectedAction = 'testing.coverageSelected',
 	CoverageToggleToolbar = 'testing.coverageToggleToolbar',

--- a/src/vs/workbench/contrib/testing/common/testCoverage.ts
+++ b/src/vs/workbench/contrib/testing/common/testCoverage.ts
@@ -131,20 +131,7 @@ export class TestCoverage {
 					if (chain.length === canonical.length) {
 						node.value = fileData;
 					} else {
-						node.value ??= new ComputedFileCoverage({
-							id: String(incId++),
-							uri: this.treePathToUri(canonical.slice(0, chain.length)),
-							statement: { covered: 0, total: 0 },
-						}, fileData.fromResult);
-
-						for (const kind of ['statement', 'branch', 'declaration'] as const) {
-							const count = fileData[kind];
-							if (count) {
-								const cc = (node.value[kind] ??= { covered: 0, total: 0 });
-								cc.covered += count.covered;
-								cc.total += count.total;
-							}
-						}
+						node.value ??= new BypassedFileCoverage(this.treePathToUri(canonical.slice(0, chain.length)), fileData.fromResult);
 					}
 				});
 			}
@@ -235,6 +222,15 @@ export abstract class AbstractFileCoverage {
  * extension.
  */
 export class ComputedFileCoverage extends AbstractFileCoverage { }
+
+/**
+ * A virtual node that doesn't have any added coverage info.
+ */
+export class BypassedFileCoverage extends ComputedFileCoverage {
+	constructor(uri: URI, result: LiveTestResult) {
+		super({ id: String(incId++), uri, statement: { covered: 0, total: 0 } }, result);
+	}
+}
 
 export class FileCoverage extends AbstractFileCoverage {
 	private _details?: Promise<CoverageDetails[]>;

--- a/src/vs/workbench/contrib/testing/common/testCoverageService.ts
+++ b/src/vs/workbench/contrib/testing/common/testCoverageService.ts
@@ -80,6 +80,12 @@ export class TestCoverageService extends Disposable implements ITestCoverageServ
 			reader => !!this.selected.read(reader)?.perTestCoverageIDs.size,
 		));
 
+		this._register(bindContextKey(
+			TestingContextKeys.isCoverageFilteredToTest,
+			contextKeyService,
+			reader => !!this.filterToTest.read(reader),
+		));
+
 		this._register(resultService.onResultsChanged(evt => {
 			if ('completed' in evt) {
 				const coverage = evt.completed.tasks.find(t => t.coverage.get());

--- a/src/vs/workbench/contrib/testing/common/testingContextKeys.ts
+++ b/src/vs/workbench/contrib/testing/common/testingContextKeys.ts
@@ -23,6 +23,7 @@ export namespace TestingContextKeys {
 	export const activeEditorHasTests = new RawContextKey('testing.activeEditorHasTests', false, { type: 'boolean', description: localize('testing.activeEditorHasTests', 'Indicates whether any tests are present in the current editor') });
 	export const isTestCoverageOpen = new RawContextKey('testing.isTestCoverageOpen', false, { type: 'boolean', description: localize('testing.isTestCoverageOpen', 'Indicates whether a test coverage report is open') });
 	export const hasPerTestCoverage = new RawContextKey('testing.hasPerTestCoverage', false, { type: 'boolean', description: localize('testing.hasPerTestCoverage', 'Indicates whether per-test coverage is available') });
+	export const isCoverageFilteredToTest = new RawContextKey('testing.isCoverageFilteredToTest', false, { type: 'boolean', description: localize('testing.isCoverageFilteredToTest', 'Indicates whether coverage has been filterd to a single test') });
 	export const coverageToolbarEnabled = new RawContextKey('testing.coverageToolbarEnabled', true, { type: 'boolean', description: localize('testing.coverageToolbarEnabled', 'Indicates whether the coverage toolbar is enabled') });
 
 	export const capabilityToContextKey: { [K in TestRunProfileBitset]: RawContextKey<boolean> } = {


### PR DESCRIPTION
- Have coverage actions in the editor title by default
- Coverage actions move into the toolbar when the toolbar is toggled on
- Use a view action in the Test Coverage view for filtering data
- Don't show %'s on directories in the Test Coverage view when filtered

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
