### PR TITLE
fix: tsserver no longer crashes when log path includes spaces

### DIFF
--- a/extensions/typescript-language-features/src/tsServer/spawner.ts
+++ b/extensions/typescript-language-features/src/tsServer/spawner.ts
@@ -234,7 +234,7 @@ export class TypeScriptServerSpawner {
 					tsServerLog = { type: 'file', uri: logFilePath };
 
 					args.push('--logVerbosity', TsServerLogLevel.toString(configuration.tsServerLogLevel));
-					args.push('--logFile', logFilePath.fsPath);
+					args.push('--logFile', `"${logFilePath.fsPath}"`);
 				}
 			}
 		}
@@ -242,7 +242,7 @@ export class TypeScriptServerSpawner {
 		if (configuration.enableTsServerTracing && !isWeb()) {
 			tsServerTraceDirectory = this._logDirectoryProvider.getNewLogDirectory();
 			if (tsServerTraceDirectory) {
-				args.push('--traceDirectory', tsServerTraceDirectory.fsPath);
+				args.push('--traceDirectory', `"${tsServerTraceDirectory.fsPath}"`);
 			}
 		}
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Guarantees that the log and trace filepaths passed into tsserver are wrapped in double quotes. Fixes https://github.com/microsoft/vscode/issues/204678

Today on macOS the default log path will be something like `/Users/xxx/Library/Application Support/Code/logs/20240207T135733/window4/exthost/vscode.typescript-language-features/tsserver-log-2o1bl4/tsserver.log` - note it's in a folder named `Application Support`. 

When we don't wrap the path in double quotes then bash interprets the log path as being `/Users/xxx/Library/Application`, with the remaining part of the args just being extra stuff that the server command gets confused about.

I don't _think_ we need to worry about the `logFilePath.fsPath` value already having double quotes in it since it's already a processed filepath with escapes in place for unexpected characters, but I'd be happy to add more protection against extra double quotes if that's something folks are concerned about.

