### PR TITLE
Make List / Tree Hovers Focusable

### DIFF
--- a/src/vs/base/browser/ui/hover/hover.ts
+++ b/src/vs/base/browser/ui/hover/hover.ts
@@ -43,6 +43,11 @@ export interface IHoverDelegate2 {
 
 	// TODO: Change hoverDelegate arg to exclude the actual delegate and instead use the new options
 	setupUpdatableHover(hoverDelegate: IHoverDelegate, htmlElement: HTMLElement, content: IUpdatableHoverContentOrFactory, options?: IUpdatableHoverOptions): IUpdatableHover;
+
+	/**
+	 * Shows the hover for the given element if one has been setup.
+	 */
+	triggerUpdatableHover(htmlElement: HTMLElement): void;
 }
 
 export interface IHoverWidget extends IDisposable {
@@ -246,6 +251,7 @@ export type IUpdatableHoverContentOrFactory = IUpdatableHoverContent | (() => IU
 export interface IUpdatableHoverOptions {
 	actions?: IHoverAction[];
 	linkHandler?(url: string): void;
+	trapFocus?: boolean;
 }
 
 export interface IUpdatableHover extends IDisposable {

--- a/src/vs/base/browser/ui/hover/hoverDelegate2.ts
+++ b/src/vs/base/browser/ui/hover/hoverDelegate2.ts
@@ -10,6 +10,7 @@ let baseHoverDelegate: IHoverDelegate2 = {
 	hideHover: () => undefined,
 	showAndFocusLastHover: () => undefined,
 	setupUpdatableHover: () => null!,
+	triggerUpdatableHover: () => undefined
 };
 
 /**

--- a/src/vs/editor/browser/services/hoverService/hoverService.ts
+++ b/src/vs/editor/browser/services/hoverService/hoverService.ts
@@ -62,7 +62,9 @@ export class HoverService extends Disposable implements IHoverService {
 		// HACK, remove this check when #189076 is fixed
 		if (!skipLastFocusedUpdate) {
 			if (trapFocus && activeElement) {
-				this._lastFocusedElementBeforeOpen = activeElement as HTMLElement;
+				if (!activeElement.classList.contains('monaco-hover')) {
+					this._lastFocusedElementBeforeOpen = activeElement as HTMLElement;
+				}
 			} else {
 				this._lastFocusedElementBeforeOpen = undefined;
 			}

--- a/src/vs/editor/browser/services/hoverService/updatableHoverWidget.ts
+++ b/src/vs/editor/browser/services/hoverService/updatableHoverWidget.ts
@@ -42,7 +42,7 @@ export class UpdatableHoverWidget implements IDisposable {
 
 			// show 'Loading' if no hover is up yet
 			if (!this._hoverWidget) {
-				this.show(localize('iconLabel.loading', "Loading..."), focus);
+				this.show(localize('iconLabel.loading', "Loading..."), focus, options);
 			}
 
 			// compute the content

--- a/src/vs/platform/hover/test/browser/nullHoverService.ts
+++ b/src/vs/platform/hover/test/browser/nullHoverService.ts
@@ -12,4 +12,5 @@ export const NullHoverService: IHoverService = {
 	showHover: () => undefined,
 	setupUpdatableHover: () => Disposable.None as any,
 	showAndFocusLastHover: () => undefined,
+	triggerUpdatableHover: () => undefined
 };

--- a/src/vs/workbench/contrib/extensions/browser/extensionsWidgets.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsWidgets.ts
@@ -553,7 +553,7 @@ export class ExtensionHoverWidget extends ExtensionWidget {
 		if (this.extension) {
 			this.hover.value = this.hoverService.setupUpdatableHover({
 				delay: this.configurationService.getValue<number>('workbench.hover.delay'),
-				showHover: (options) => {
+				showHover: (options, focus) => {
 					return this.hoverService.showHover({
 						...options,
 						additionalClasses: ['extension-hover'],
@@ -561,7 +561,10 @@ export class ExtensionHoverWidget extends ExtensionWidget {
 							hoverPosition: this.options.position(),
 							forcePosition: true,
 						},
-					});
+						persistence: {
+							hideOnKeyDown: true,
+						}
+					}, focus);
 				},
 				placement: 'element'
 			}, this.options.target, { markdown: () => Promise.resolve(this.getHoverMarkdown()), markdownNotSupportedFallback: undefined });


### PR DESCRIPTION
With the addition of support for triggering custom hovers in lists and trees using the `Ctrl K + Ctrl I` keybinding, this pull request makes the hovers focusable. Previously, it was not possible to set focus into the hover. This change allows users to interact with the hover content using keyboard navigation and after closing the hover, placing the focus back where it previously was.

fixes #211951

