### PR TITLE
Update editor actions on settings change

### DIFF
--- a/src/vs/workbench/browser/parts/editor/multiEditorTabsControl.ts
+++ b/src/vs/workbench/browser/parts/editor/multiEditorTabsControl.ts
@@ -732,6 +732,11 @@ export class MultiEditorTabsControl extends EditorTabsControl {
 			this.updateTabsScrollbarSizing();
 		}
 
+		// Update editor actions
+		if (oldOptions.alwaysShowEditorActions !== newOptions.alwaysShowEditorActions) {
+			this.updateEditorActionsToolbar();
+		}
+
 		// Update tabs sizing
 		if (
 			oldOptions.tabSizingFixedMinWidth !== newOptions.tabSizingFixedMinWidth ||


### PR DESCRIPTION
This pull request updates the editor actions toolbar when the "alwaysShowEditorActions" setting is changed. Previously, the toolbar was not being updated when this setting was modified. This PR ensures that the toolbar is always in sync with the current value of the setting.