### PR TITLE
Fix editor command context extraction

### DIFF
--- a/src/vs/workbench/browser/parts/editor/editorCommands.ts
+++ b/src/vs/workbench/browser/parts/editor/editorCommands.ts
@@ -1412,7 +1412,7 @@ export function getEditorsFromContext(accessor: ServicesAccessor, resourceOrCont
 export function getCommandsContext(accessor: ServicesAccessor, resourceOrContext?: URI | IEditorCommandsContext, context?: IEditorCommandsContext): IEditorCommandsContext | undefined {
 	const isUri = URI.isUri(resourceOrContext);
 
-	const editorCommandsContext = isUri ? context : resourceOrContext;
+	const editorCommandsContext = isUri ? context : resourceOrContext ? resourceOrContext : context;
 	if (editorCommandsContext && typeof editorCommandsContext.groupId === 'number') {
 		return editorCommandsContext;
 	}


### PR DESCRIPTION
This pull request fixes the context extraction in the `getCommandsContext` function. 

fixes #212883