### PR TITLE
feature: use declare enum instead of declare const enum for typescrip…

### DIFF
--- a/src/typings/require.d.ts
+++ b/src/typings/require.d.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-declare const enum LoaderEventType {
+declare enum LoaderEventType {
 	LoaderAvailable = 1,
 
 	BeginLoadingScript = 10,


### PR DESCRIPTION
…t isolated modules

Part of https://github.com/microsoft/vscode/issues/212835


For testing, I enabled isolatedModules in src/tsconfig.json and checked that no error is shown anymore in `amd.ts` and `perfviewEditor.ts`.