### PR TITLE
Revive `TimelineChangeEvent.uri` if passed in `TimelineProvider.onDidChange` event

### DIFF
--- a/src/vs/workbench/contrib/timeline/browser/timelinePane.ts
+++ b/src/vs/workbench/contrib/timeline/browser/timelinePane.ts
@@ -418,7 +418,7 @@ export class TimelinePane extends ViewPane {
 	}
 
 	private onTimelineChanged(e: TimelineChangeEvent) {
-		if (e?.uri === undefined || this.uriIdentityService.extUri.isEqual(e.uri, this.uri)) {
+		if (e?.uri === undefined || this.uriIdentityService.extUri.isEqual(URI.revive(e.uri), this.uri)) {
 			const timeline = this.timelinesBySource.get(e.id);
 			if (timeline === undefined) {
 				return;


### PR DESCRIPTION
When building a `TimelineProvider` extension using this proposed API I discovered that an `onDidChange` event failed if a uri was specified. This PR fixes the problem.