### PR TITLE
Fix StableEditorBottomScrollState

### DIFF
--- a/src/vs/editor/browser/stableEditorScroll.ts
+++ b/src/vs/editor/browser/stableEditorScroll.ts
@@ -5,6 +5,7 @@
 
 import { ICodeEditor } from 'vs/editor/browser/editorBrowser';
 import { Position } from 'vs/editor/common/core/position';
+import { ScrollType } from 'vs/editor/common/editorCommon';
 
 export class StableEditorScrollState {
 
@@ -59,7 +60,7 @@ export class StableEditorScrollState {
 		}
 
 		const offset = editor.getTopForLineNumber(currentCursorPosition.lineNumber) - editor.getTopForLineNumber(this._cursorPosition.lineNumber);
-		editor.setScrollTop(editor.getScrollTop() + offset);
+		editor.setScrollTop(editor.getScrollTop() + offset, ScrollType.Immediate);
 	}
 }
 
@@ -78,7 +79,7 @@ export class StableEditorBottomScrollState {
 		if (visibleRanges.length > 0) {
 			visiblePosition = visibleRanges.at(-1)!.getEndPosition();
 			const visiblePositionScrollBottom = editor.getBottomForLineNumber(visiblePosition.lineNumber);
-			visiblePositionScrollDelta = (editor.getScrollTop() + editor.getLayoutInfo().height) - visiblePositionScrollBottom;
+			visiblePositionScrollDelta = visiblePositionScrollBottom - editor.getScrollTop();
 		}
 		return new StableEditorBottomScrollState(editor.getScrollTop(), editor.getContentHeight(), visiblePosition, visiblePositionScrollDelta);
 	}
@@ -99,7 +100,7 @@ export class StableEditorBottomScrollState {
 
 		if (this._visiblePosition) {
 			const visiblePositionScrollBottom = editor.getBottomForLineNumber(this._visiblePosition.lineNumber);
-			editor.setScrollTop(visiblePositionScrollBottom - (this._visiblePositionScrollDelta + editor.getLayoutInfo().height));
+			editor.setScrollTop(visiblePositionScrollBottom - this._visiblePositionScrollDelta, ScrollType.Immediate);
 		}
 	}
 }


### PR DESCRIPTION
I think this fixes `StableEditorBottomScrollState`

But the problem is not completely solved because:
* there is a call to `revealRangeNearTopIfOutsideViewport` somewhere in the view zone show code.
* (when doing "explain this") - when markdown streams in, the view zone grows but nobody calls `StableEditorBottomScrollState`
* (when doing "document this") - when edits stream in, I think the view zone grows and also there is a call to `revealRangeInCenterIfOutsideViewport`

I would continue by figuring out where the view zone changes its height and using `StableEditorBottomScrollState` there.