### PR TITLE
Fix config provider issues during restart

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/debugService.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugService.ts
@@ -796,8 +796,6 @@ export class DebugService implements IDebugService {
 		if (launch) {
 			unresolved = launch.getConfiguration(session.configuration.name);
 			if (unresolved && !equals(unresolved, session.unresolvedConfiguration)) {
-				// Take the type from the session since the debug extension might overwrite it #21316
-				unresolved.type = session.configuration.type;
 				unresolved.noDebug = session.configuration.noDebug;
 				needsToSubstitute = true;
 			}
@@ -811,7 +809,7 @@ export class DebugService implements IDebugService {
 			if (resolvedByProviders) {
 				resolved = await this.substituteVariables(launch, resolvedByProviders);
 				if (resolved && !initCancellationToken.token.isCancellationRequested) {
-					resolved = await this.configurationManager.resolveDebugConfigurationWithSubstitutedVariables(launch && launch.workspace ? launch.workspace.uri : undefined, unresolved.type, resolved, initCancellationToken.token);
+					resolved = await this.configurationManager.resolveDebugConfigurationWithSubstitutedVariables(launch && launch.workspace ? launch.workspace.uri : undefined, resolved.type, resolved, initCancellationToken.token);
 				}
 			} else {
 				resolved = resolvedByProviders;


### PR DESCRIPTION
- Taking the resolved debug type from the previous run may cause us to skip the correct config provider
- Need to use the correct resolved type for the call to `resolveDebugConfigurationWithSubstitutedVariables`
Fix #212985

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
