### PR TITLE
enable easy configuration of unassigned keybindings for extension contributed accessibility help dialogs

### DIFF
--- a/src/vs/platform/accessibility/browser/accessibleView.ts
+++ b/src/vs/platform/accessibility/browser/accessibleView.ts
@@ -119,7 +119,7 @@ export interface IAccessibleViewService {
 	 */
 	getOpenAriaHint(verbositySettingKey: string): string | null;
 	getCodeBlockContext(): ICodeBlockActionContext | undefined;
-	showKeybindingsQuickPick(): Promise<void>;
+	showKeybindingsQuickPick(): void;
 }
 
 

--- a/src/vs/platform/accessibility/browser/accessibleView.ts
+++ b/src/vs/platform/accessibility/browser/accessibleView.ts
@@ -8,6 +8,7 @@ import { IKeyboardEvent } from 'vs/platform/keybinding/common/keybinding';
 import { IPickerQuickAccessItem } from 'vs/platform/quickinput/browser/pickerQuickAccess';
 import { Event } from 'vs/base/common/event';
 import { IAction } from 'vs/base/common/actions';
+import { IQuickPickItem } from 'vs/platform/quickinput/common/quickInput';
 
 export const IAccessibleViewService = createDecorator<IAccessibleViewService>('accessibleViewService');
 
@@ -60,6 +61,11 @@ export interface IAccessibleViewOptions {
 	 * If this provider might want to request to be shown again, provide an ID.
 	 */
 	id?: AccessibleViewProviderId;
+
+	/**
+	 * Keybinding items to configure
+	 */
+	configureKeybindingItems?: IQuickPickItem[];
 }
 
 
@@ -113,6 +119,7 @@ export interface IAccessibleViewService {
 	 */
 	getOpenAriaHint(verbositySettingKey: string): string | null;
 	getCodeBlockContext(): ICodeBlockActionContext | undefined;
+	showKeybindingsQuickPick(): Promise<void>;
 }
 
 

--- a/src/vs/platform/accessibility/browser/accessibleView.ts
+++ b/src/vs/platform/accessibility/browser/accessibleView.ts
@@ -119,7 +119,7 @@ export interface IAccessibleViewService {
 	 */
 	getOpenAriaHint(verbositySettingKey: string): string | null;
 	getCodeBlockContext(): ICodeBlockActionContext | undefined;
-	showKeybindingsQuickPick(): void;
+	configureKeybindings(): void;
 }
 
 

--- a/src/vs/workbench/api/browser/viewsExtensionPoint.ts
+++ b/src/vs/workbench/api/browser/viewsExtensionPoint.ts
@@ -173,7 +173,7 @@ const viewDescriptor: IJSONSchema = {
 		},
 		accessibilityHelpContent: {
 			type: 'string',
-			markdownDescription: localize('vscode.extension.contributes.view.accessibilityHelpContent', "When the accessibility help dialog is invoked in this view, this content will be presented to the user as a markdown string. Keybindings will be resolved when provided in the format of <keybinding:commandId>. If there is no keybinding, that will be indicated with a link to configure one.")
+			markdownDescription: localize('vscode.extension.contributes.view.accessibilityHelpContent', "When the accessibility help dialog is invoked in this view, this content will be presented to the user as a markdown string. Keybindings will be resolved when provided in the format of <keybinding:commandId>. If there is no keybinding, that will be indicated and this command will be included in a quickpick for easy configuration.")
 		}
 	}
 };

--- a/src/vs/workbench/contrib/accessibility/browser/accessibleView.ts
+++ b/src/vs/workbench/contrib/accessibility/browser/accessibleView.ts
@@ -38,7 +38,7 @@ import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 import { ResultKind } from 'vs/platform/keybinding/common/keybindingResolver';
 import { ILayoutService } from 'vs/platform/layout/browser/layoutService';
 import { IOpenerService } from 'vs/platform/opener/common/opener';
-import { IQuickInputService } from 'vs/platform/quickinput/common/quickInput';
+import { IQuickInputService, IQuickPick, IQuickPickItem } from 'vs/platform/quickinput/common/quickInput';
 import { IStorageService, StorageScope, StorageTarget } from 'vs/platform/storage/common/storage';
 import { AccessibilityVerbositySettingId, AccessibilityWorkbenchSettingId, accessibilityHelpIsShown, accessibleViewContainsCodeBlocks, accessibleViewCurrentProviderId, accessibleViewGoToSymbolSupported, accessibleViewInCodeBlock, accessibleViewIsShown, accessibleViewOnLastLine, accessibleViewSupportsNavigation, accessibleViewVerbosityEnabled } from 'vs/workbench/contrib/accessibility/browser/accessibilityConfiguration';
 import { AccessibilityCommandId } from 'vs/workbench/contrib/accessibility/common/accessibilityCommands';
@@ -362,12 +362,13 @@ export class AccessibleView extends Disposable {
 		return symbols.length ? symbols : undefined;
 	}
 
-	async showKeybindingsQuickPick(): Promise<void> {
+	showKeybindingsQuickPick(): void {
 		const items = this._currentProvider?.options?.configureKeybindingItems;
 		if (!items) {
 			return;
 		}
-		const quickPick = this._register(this._quickInputService.createQuickPick());
+		const quickPick: IQuickPick<IQuickPickItem> = this._quickInputService.createQuickPick();
+		this._register(quickPick);
 		quickPick.items = items;
 		quickPick.title = localize('keybindings', 'Configure keybindings');
 		quickPick.placeholder = localize('selectKeybinding', 'Select a commandId to configure a keybinding for it');
@@ -377,7 +378,9 @@ export class AccessibleView extends Disposable {
 			if (item) {
 				await this._commandService.executeCommand('workbench.action.openGlobalKeybindings', item.id);
 			}
+			quickPick.dispose();
 		});
+		quickPick.onDidHide(() => quickPick.dispose());
 	}
 
 	private _convertTokensToSymbols(tokens: marked.TokensList, symbols: IAccessibleViewSymbol[]): void {
@@ -769,8 +772,8 @@ export class AccessibleViewService extends Disposable implements IAccessibleView
 		}
 		this._accessibleView.show(provider, undefined, undefined, position);
 	}
-	async showKeybindingsQuickPick(): Promise<void> {
-		await this._accessibleView?.showKeybindingsQuickPick();
+	showKeybindingsQuickPick(): void {
+		this._accessibleView?.showKeybindingsQuickPick();
 	}
 	showLastProvider(id: AccessibleViewProviderId): void {
 		this._accessibleView?.showLastProvider(id);

--- a/src/vs/workbench/contrib/accessibility/browser/accessibleView.ts
+++ b/src/vs/workbench/contrib/accessibility/browser/accessibleView.ts
@@ -362,7 +362,7 @@ export class AccessibleView extends Disposable {
 		return symbols.length ? symbols : undefined;
 	}
 
-	showKeybindingsQuickPick(): void {
+	configureKeybindings(): void {
 		const items = this._currentProvider?.options?.configureKeybindingItems;
 		if (!items) {
 			return;
@@ -772,8 +772,8 @@ export class AccessibleViewService extends Disposable implements IAccessibleView
 		}
 		this._accessibleView.show(provider, undefined, undefined, position);
 	}
-	showKeybindingsQuickPick(): void {
-		this._accessibleView?.showKeybindingsQuickPick();
+	configureKeybindings(): void {
+		this._accessibleView?.configureKeybindings();
 	}
 	showLastProvider(id: AccessibleViewProviderId): void {
 		this._accessibleView?.showLastProvider(id);

--- a/src/vs/workbench/contrib/accessibility/browser/accessibleView.ts
+++ b/src/vs/workbench/contrib/accessibility/browser/accessibleView.ts
@@ -369,6 +369,7 @@ export class AccessibleView extends Disposable {
 		}
 		const quickPick = this._register(this._quickInputService.createQuickPick());
 		quickPick.items = items;
+		quickPick.title = localize('keybindings', 'Configure keybindings');
 		quickPick.placeholder = localize('selectKeybinding', 'Select a commandId to configure a keybinding for it');
 		quickPick.show();
 		quickPick.onDidAccept(async () => {

--- a/src/vs/workbench/contrib/accessibility/browser/accessibleView.ts
+++ b/src/vs/workbench/contrib/accessibility/browser/accessibleView.ts
@@ -367,8 +367,9 @@ export class AccessibleView extends Disposable {
 		if (!items) {
 			return;
 		}
-		const quickPick = this._quickInputService.createQuickPick();
+		const quickPick = this._register(this._quickInputService.createQuickPick());
 		quickPick.items = items;
+		quickPick.placeholder = localize('selectKeybinding', 'Select a commandId to configure a keybinding for it');
 		quickPick.show();
 		quickPick.onDidAccept(async () => {
 			const item = quickPick.selectedItems[0];

--- a/src/vs/workbench/contrib/accessibility/browser/accessibleView.ts
+++ b/src/vs/workbench/contrib/accessibility/browser/accessibleView.ts
@@ -38,7 +38,7 @@ import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 import { ResultKind } from 'vs/platform/keybinding/common/keybindingResolver';
 import { ILayoutService } from 'vs/platform/layout/browser/layoutService';
 import { IOpenerService } from 'vs/platform/opener/common/opener';
-import { IQuickInputService, IQuickPickItem } from 'vs/platform/quickinput/common/quickInput';
+import { IQuickInputService } from 'vs/platform/quickinput/common/quickInput';
 import { IStorageService, StorageScope, StorageTarget } from 'vs/platform/storage/common/storage';
 import { AccessibilityVerbositySettingId, AccessibilityWorkbenchSettingId, accessibilityHelpIsShown, accessibleViewContainsCodeBlocks, accessibleViewCurrentProviderId, accessibleViewGoToSymbolSupported, accessibleViewInCodeBlock, accessibleViewIsShown, accessibleViewOnLastLine, accessibleViewSupportsNavigation, accessibleViewVerbosityEnabled } from 'vs/workbench/contrib/accessibility/browser/accessibilityConfiguration';
 import { AccessibilityCommandId } from 'vs/workbench/contrib/accessibility/common/accessibilityCommands';
@@ -367,11 +367,15 @@ export class AccessibleView extends Disposable {
 		if (!items) {
 			return;
 		}
-		const result: IQuickPickItem[] | undefined = await this._quickInputService.pick(items);
-		if (result?.[0]) {
-			await this._commandService.executeCommand('workbench.action.openGlobalKeybindings', result[0].id);
-		}
-		return;
+		const quickPick = this._quickInputService.createQuickPick();
+		quickPick.items = items;
+		quickPick.show();
+		quickPick.onDidAccept(async () => {
+			const item = quickPick.selectedItems[0];
+			if (item) {
+				await this._commandService.executeCommand('workbench.action.openGlobalKeybindings', item.id);
+			}
+		});
 	}
 
 	private _convertTokensToSymbols(tokens: marked.TokensList, symbols: IAccessibleViewSymbol[]): void {

--- a/src/vs/workbench/contrib/accessibility/browser/accessibleView.ts
+++ b/src/vs/workbench/contrib/accessibility/browser/accessibleView.ts
@@ -371,7 +371,7 @@ export class AccessibleView extends Disposable {
 		this._register(quickPick);
 		quickPick.items = items;
 		quickPick.title = localize('keybindings', 'Configure keybindings');
-		quickPick.placeholder = localize('selectKeybinding', 'Select a commandId to configure a keybinding for it');
+		quickPick.placeholder = localize('selectKeybinding', 'Select a command ID to configure a keybinding for it');
 		quickPick.show();
 		quickPick.onDidAccept(async () => {
 			const item = quickPick.selectedItems[0];

--- a/src/vs/workbench/contrib/accessibility/browser/accessibleView.ts
+++ b/src/vs/workbench/contrib/accessibility/browser/accessibleView.ts
@@ -644,7 +644,7 @@ export class AccessibleView extends Disposable {
 		if (!lastProvider) {
 			return;
 		}
-		//TODO:@meganrogge add command to open configure keybindings when there are some commands with no keybindings
+
 		const accessibleViewHelpProvider = {
 			id: lastProvider.id,
 			provideContent: () => lastProvider.options.customHelp ? lastProvider?.options.customHelp() : this._getAccessibleViewHelpDialogContent(this._goToSymbolsSupported()),

--- a/src/vs/workbench/contrib/accessibility/browser/accessibleViewActions.ts
+++ b/src/vs/workbench/contrib/accessibility/browser/accessibleViewActions.ts
@@ -228,6 +228,24 @@ class AccessibleViewDisableHintAction extends Action2 {
 }
 registerAction2(AccessibleViewDisableHintAction);
 
+class AccessibilityHelpConfigureKeybindingsAction extends Action2 {
+	constructor() {
+		super({
+			id: AccessibilityCommandId.AccessibilityHelpConfigureKeybindings,
+			precondition: ContextKeyExpr.and(accessibilityHelpIsShown),
+			keybinding: {
+				primary: KeyMod.Alt | KeyCode.F7,
+				weight: KeybindingWeight.WorkbenchContrib
+			},
+			title: localize('editor.action.accessibilityHelpConfigureKeybindings', "Accessibility Help Configure Keybindings")
+		});
+	}
+	async run(accessor: ServicesAccessor): Promise<void> {
+		await accessor.get(IAccessibleViewService).showKeybindingsQuickPick();
+	}
+}
+registerAction2(AccessibilityHelpConfigureKeybindingsAction);
+
 class AccessibleViewAcceptInlineCompletionAction extends Action2 {
 	constructor() {
 		super({
@@ -267,3 +285,4 @@ class AccessibleViewAcceptInlineCompletionAction extends Action2 {
 	}
 }
 registerAction2(AccessibleViewAcceptInlineCompletionAction);
+

--- a/src/vs/workbench/contrib/accessibility/browser/accessibleViewActions.ts
+++ b/src/vs/workbench/contrib/accessibility/browser/accessibleViewActions.ts
@@ -234,7 +234,7 @@ class AccessibilityHelpConfigureKeybindingsAction extends Action2 {
 			id: AccessibilityCommandId.AccessibilityHelpConfigureKeybindings,
 			precondition: ContextKeyExpr.and(accessibilityHelpIsShown),
 			keybinding: {
-				primary: KeyMod.Alt | KeyCode.F7,
+				primary: KeyMod.Alt | KeyCode.KeyK,
 				weight: KeybindingWeight.WorkbenchContrib
 			},
 			title: localize('editor.action.accessibilityHelpConfigureKeybindings', "Accessibility Help Configure Keybindings")

--- a/src/vs/workbench/contrib/accessibility/browser/accessibleViewActions.ts
+++ b/src/vs/workbench/contrib/accessibility/browser/accessibleViewActions.ts
@@ -241,7 +241,7 @@ class AccessibilityHelpConfigureKeybindingsAction extends Action2 {
 		});
 	}
 	async run(accessor: ServicesAccessor): Promise<void> {
-		await accessor.get(IAccessibleViewService).showKeybindingsQuickPick();
+		await accessor.get(IAccessibleViewService).configureKeybindings();
 	}
 }
 registerAction2(AccessibilityHelpConfigureKeybindingsAction);

--- a/src/vs/workbench/contrib/accessibility/browser/extensionAccesibilityHelp.contribution.ts
+++ b/src/vs/workbench/contrib/accessibility/browser/extensionAccesibilityHelp.contribution.ts
@@ -5,14 +5,15 @@
 
 import { MarkdownString } from 'vs/base/common/htmlContent';
 import { DisposableMap, IDisposable, DisposableStore, Disposable } from 'vs/base/common/lifecycle';
-import { URI } from 'vs/base/common/uri';
 import { AccessibleViewType, ExtensionContentProvider } from 'vs/platform/accessibility/browser/accessibleView';
 import { AccessibleViewRegistry } from 'vs/platform/accessibility/browser/accessibleViewRegistry';
 import { ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
+import { IPickerQuickAccessItem } from 'vs/platform/quickinput/browser/pickerQuickAccess';
 import { Registry } from 'vs/platform/registry/common/platform';
 import { FocusedViewContext } from 'vs/workbench/common/contextkeys';
 import { IViewsRegistry, Extensions, IViewDescriptor } from 'vs/workbench/common/views';
+import { AccessibilityCommandId } from 'vs/workbench/contrib/accessibility/common/accessibilityCommands';
 import { IViewsService } from 'vs/workbench/services/views/common/viewsService';
 
 export class ExtensionAccessibilityHelpDialogContribution extends Disposable {
@@ -54,9 +55,9 @@ function registerAccessibilityHelpAction(keybindingService: IKeybindingService, 
 			const viewsService = accessor.get(IViewsService);
 			return new ExtensionContentProvider(
 				viewDescriptor.id,
-				{ type: AccessibleViewType.Help },
-				() => helpContent.value,
-				() => viewsService.openView(viewDescriptor.id, true)
+				{ type: AccessibleViewType.Help, configureKeybindingItems: helpContent.configureKeybindingItems },
+				() => helpContent.value.value,
+				() => viewsService.openView(viewDescriptor.id, true),
 			);
 		}
 	}));
@@ -68,27 +69,33 @@ function registerAccessibilityHelpAction(keybindingService: IKeybindingService, 
 	return disposableStore;
 }
 
-function resolveExtensionHelpContent(keybindingService: IKeybindingService, content?: MarkdownString): MarkdownString | undefined {
+function resolveExtensionHelpContent(keybindingService: IKeybindingService, content?: MarkdownString): { value: MarkdownString; configureKeybindingItems: IPickerQuickAccessItem[] | undefined } | undefined {
 	if (!content) {
 		return;
 	}
+	const configureKeybindingItems: IPickerQuickAccessItem[] = [];
 	let resolvedContent = typeof content === 'string' ? content : content.value;
 	const matches = resolvedContent.matchAll(/\<keybinding:(?<commandId>.*)\>/gm);
 	for (const match of [...matches]) {
 		const commandId = match?.groups?.commandId;
+		let kbLabel;
 		if (match?.length && commandId) {
 			const keybinding = keybindingService.lookupKeybinding(commandId)?.getAriaLabel();
-			let kbLabel = keybinding;
-			if (!kbLabel) {
-				const args = URI.parse(`command:workbench.action.openGlobalKeybindings?${encodeURIComponent(JSON.stringify(commandId))}`);
-				kbLabel = ` [Configure a keybinding](${args})`;
+			if (!keybinding) {
+				const configureKb = keybindingService.lookupKeybinding(AccessibilityCommandId.AccessibilityHelpConfigureKeybindings)?.getAriaLabel();
+				const keybindingToConfigureQuickPick = configureKb ? '(' + configureKb + ')' : 'by assigning a keybinding to the command accessibility.openQuickPick.';
+				kbLabel = `, configure a keybinding ` + keybindingToConfigureQuickPick;
+				configureKeybindingItems.push({
+					label: commandId,
+					id: commandId
+				});
 			} else {
 				kbLabel = ' (' + keybinding + ')';
 			}
 			resolvedContent = resolvedContent.replace(match[0], kbLabel);
 		}
 	}
-	const result = new MarkdownString(resolvedContent);
-	result.isTrusted = true;
-	return result;
+	const value = new MarkdownString(resolvedContent);
+	value.isTrusted = true;
+	return { value, configureKeybindingItems: configureKeybindingItems.length ? configureKeybindingItems : undefined };
 }

--- a/src/vs/workbench/contrib/accessibility/browser/extensionAccesibilityHelp.contribution.ts
+++ b/src/vs/workbench/contrib/accessibility/browser/extensionAccesibilityHelp.contribution.ts
@@ -99,3 +99,4 @@ function resolveExtensionHelpContent(keybindingService: IKeybindingService, cont
 	value.isTrusted = true;
 	return { value, configureKeybindingItems: configureKeybindingItems.length ? configureKeybindingItems : undefined };
 }
+

--- a/src/vs/workbench/contrib/accessibility/common/accessibilityCommands.ts
+++ b/src/vs/workbench/contrib/accessibility/common/accessibilityCommands.ts
@@ -12,5 +12,6 @@ export const enum AccessibilityCommandId {
 	ShowPrevious = 'editor.action.accessibleViewPrevious',
 	AccessibleViewAcceptInlineCompletion = 'editor.action.accessibleViewAcceptInlineCompletion',
 	NextCodeBlock = 'editor.action.accessibleViewNextCodeBlock',
-	PreviousCodeBlock = 'editor.action.accessibleViewPreviousCodeBlock'
+	PreviousCodeBlock = 'editor.action.accessibleViewPreviousCodeBlock',
+	AccessibilityHelpConfigureKeybindings = 'editor.action.accessibilityHelpConfigureKeybindings',
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
fixes #210665

The parsing/keybinding resolution will move into the `AccessibleViewService` or a helper class when I next work on #210695. This is just a step in that direction.

https://github.com/microsoft/vscode/assets/29464607/825e1232-0117-49de-b394-f163f665f877


