### PR TITLE
Fix an issue where defaultLinesDiffComputer does not pass in the timeout variable

### DIFF
--- a/src/vs/editor/common/diff/defaultLinesDiffComputer/defaultLinesDiffComputer.ts
+++ b/src/vs/editor/common/diff/defaultLinesDiffComputer/defaultLinesDiffComputer.ts
@@ -80,7 +80,8 @@ export class DefaultLinesDiffComputer implements ILinesDiffComputer {
 
 			return this.myersDiffingAlgorithm.compute(
 				sequence1,
-				sequence2
+				sequence2,
+				timeout
 			);
 		})();
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
Fixes https://github.com/microsoft/vscode/issues/213034

This caller is missing to pass in the timeout variable.
Otherwise it won't respect the `maxComputationTimeMs` option that was passed in in `computeDiff`

The definition of the `myersDiffingAlgorithm.compute` looks like this 
```
compute(seq1: ISequence, seq2: ISequence, timeout: ITimeout = InfiniteTimeout.instance)
```