### PR TITLE
Document 100k character markdown limitation

### DIFF
--- a/src/vscode-dts/vscode.d.ts
+++ b/src/vscode-dts/vscode.d.ts
@@ -18690,6 +18690,7 @@ declare module 'vscode' {
 		/**
 		 * Push a markdown part to this stream. Short-hand for
 		 * `push(new ChatResponseMarkdownPart(value))`.
+		 * Note: Only the first 100,000 characters per call will be rendered.
 		 *
 		 * @see {@link ChatResponseStream.push}
 		 * @param value A markdown string or a string that should be interpreted as markdown. The boolean form of {@link MarkdownString.isTrusted} is NOT supported.
@@ -18770,6 +18771,7 @@ declare module 'vscode' {
 
 		/**
 		 * Create a new ChatResponseMarkdownPart.
+		 * Note: Only the first 100,000 characters per ChatResponseMarkdownPart will be rendered.
 		 *
 		 * @param value A markdown string or a string that should be interpreted as markdown. The boolean form of {@link MarkdownString.isTrusted} is NOT supported.
 		 */


### PR DESCRIPTION
We have this restriction https://github.com/microsoft/vscode/blob/3d3e1b7e487a077f1a5d2bc5fb16d3278456cd8d/src/vs/base/browser/markdownRenderer.ts#L235-L237

Do you think we should just document it here, or try to do something else to work better with really long responses? I ran into this while trying to return images with long data URIs