### PR TITLE
render chat responses as plaintext in accessible view

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatResponseAccessibleView.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatResponseAccessibleView.ts
@@ -3,7 +3,8 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { IMarkdownString } from 'vs/base/common/htmlContent';
+import { renderMarkdownAsPlaintext } from 'vs/base/browser/markdownRenderer';
+import { IMarkdownString, MarkdownString } from 'vs/base/common/htmlContent';
 import { ICodeEditorService } from 'vs/editor/browser/services/codeEditorService';
 import { AccessibleViewProviderId, AccessibleViewType } from 'vs/platform/accessibility/browser/accessibleView';
 import { alertAccessibleViewFocusChange, IAccessibleViewImplentation } from 'vs/platform/accessibility/browser/accessibleViewRegistry';
@@ -71,7 +72,7 @@ export class ChatResponseAccessibleView implements IAccessibleViewImplentation {
 			return {
 				id: AccessibleViewProviderId.Chat,
 				verbositySettingKey: AccessibilityVerbositySettingId.Chat,
-				provideContent(): string { return responseContent!; },
+				provideContent(): string { return renderMarkdownAsPlaintext(new MarkdownString(responseContent)); },
 				onClose() {
 					verifiedWidget.reveal(focusedItem);
 					if (chatInputFocused) {


### PR DESCRIPTION
Links should be navigated to and accessed in the chat response element, not in the accessible view. Thus, it makes sense to remove them as it's just added noise.

Before:
![Screenshot 2024-05-20 at 12 30 33 PM](https://github.com/microsoft/vscode/assets/29464607/1254d84f-4dc9-4d35-9b42-b81e707d6477)

After:
![Screenshot 2024-05-20 at 12 25 12 PM](https://github.com/microsoft/vscode/assets/29464607/6f0346b9-5621-44ac-a985-f711a5db552e)

fix #213074