### PR TITLE
Fixes bug to recognize multiline latex context that begins inline

### DIFF
--- a/extensions/markdown-math/syntaxes/md-math-block.tmLanguage.json
+++ b/extensions/markdown-math/syntaxes/md-math-block.tmLanguage.json
@@ -13,7 +13,7 @@
 		"double_dollar_math_block": {
 			"name": "markup.math.block.markdown",
 			"contentName": "meta.embedded.math.markdown",
-			"begin": "(?<=^\\s*)(\\${2})(?![^$]*\\${2})",
+			"begin": "(?:.*?)(\\${2})(?![^$]*\\${2})",
 			"beginCaptures": {
 				"1": {
 					"name": "punctuation.definition.math.begin.markdown"
@@ -48,7 +48,7 @@
 		"single_dollar_math_block": {
 			"name": "markup.math.block.markdown",
 			"contentName": "meta.embedded.math.markdown",
-			"begin": "(?<=^\\s*)(\\$)(?![^$]*\\$|\\d)",
+			"begin": "(?:.*?)(\\$)(?![^$]*\\$|\\d)",
 			"beginCaptures": {
 				"1": {
 					"name": "punctuation.definition.math.begin.markdown"


### PR DESCRIPTION
fixes #202450 
Syntax highlighting applied to multiline latex in Markdown editor.
Gifs attached showing before and after behavior.

![Bad-Gif](https://github.com/microsoft/vscode/assets/120818400/0c6a321f-272b-4eef-9bd1-09a95e120a74)
![GoodGif](https://github.com/microsoft/vscode/assets/120818400/c9db47b9-a9b0-4f3f-8e8c-b5c009f7363b)
