### PR TITLE
resolve accessibility help dialog kbs in `accessibleViewService`

### DIFF
--- a/src/vs/editor/common/standaloneStrings.ts
+++ b/src/vs/editor/common/standaloneStrings.ts
@@ -18,19 +18,14 @@ export namespace AccessibilityHelpNLS {
 	export const auto_off = nls.localize("auto_off", "The application is configured to never be optimized for usage with a Screen Reader.");
 	export const screenReaderModeEnabled = nls.localize("screenReaderModeEnabled", "Screen Reader Optimized Mode enabled.");
 	export const screenReaderModeDisabled = nls.localize("screenReaderModeDisabled", "Screen Reader Optimized Mode disabled.");
-	export const tabFocusModeOnMsg = nls.localize("tabFocusModeOnMsg", "Pressing Tab in the current editor will move focus to the next focusable element. Toggle this behavior {0}.");
-	export const tabFocusModeOnMsgNoKb = nls.localize("tabFocusModeOnMsgNoKb", "Pressing Tab in the current editor will move focus to the next focusable element. The command {0} is currently not triggerable by a keybinding.");
-	export const stickScrollKb = nls.localize("stickScrollKb", "Focus Sticky Scroll ({0}) to focus the currently nested scopes.");
-	export const stickScrollNoKb = nls.localize("stickScrollNoKb", "Focus Sticky Scroll to focus the currently nested scopes. It is currently not triggerable by a keybinding.");
-	export const tabFocusModeOffMsg = nls.localize("tabFocusModeOffMsg", "Pressing Tab in the current editor will insert the tab character. Toggle this behavior {0}.");
-	export const tabFocusModeOffMsgNoKb = nls.localize("tabFocusModeOffMsgNoKb", "Pressing Tab in the current editor will insert the tab character. The command {0} is currently not triggerable by a keybinding.");
+	export const tabFocusModeOnMsg = nls.localize("tabFocusModeOnMsg", "Pressing Tab in the current editor will move focus to the next focusable element. Toggle this behavior<keybinding:editor.action.toggleTabFocusMode>");
+	export const tabFocusModeOffMsg = nls.localize("tabFocusModeOffMsg", "Pressing Tab in the current editor will insert the tab character. Toggle this behavior<keybinding:editor.action.toggleTabFocusMode>");
+	export const stickScroll = nls.localize("stickScrollKb", "Focus Sticky Scroll<keybinding:editor.action.focusStickyScroll> to focus the currently nested scopes.");
 	export const showAccessibilityHelpAction = nls.localize("showAccessibilityHelpAction", "Show Accessibility Help");
 	export const listSignalSounds = nls.localize("listSignalSoundsCommand", "Run the command: List Signal Sounds for an overview of all sounds and their current status.");
 	export const listAlerts = nls.localize("listAnnouncementsCommand", "Run the command: List Signal Announcements for an overview of announcements and their current status.");
-	export const quickChat = nls.localize("quickChatCommand", "Toggle quick chat ({0}) to open or close a chat session.");
-	export const quickChatNoKb = nls.localize("quickChatCommandNoKb", "Toggle quick chat is not currently triggerable by a keybinding.");
-	export const startInlineChat = nls.localize("startInlineChatCommand", "Start inline chat ({0}) to create an in editor chat session.");
-	export const startInlineChatNoKb = nls.localize("startInlineChatCommandNoKb", "The command: Start inline chat is not currentlyt riggerable by a keybinding.");
+	export const quickChat = nls.localize("quickChatCommand", "Toggle quick chat<keybinding:workbench.action.quickchat.toggle> to open or close a chat session.",);
+	export const startInlineChat = nls.localize("startInlineChatCommand", "Start inline chat<keybinding:inlineChat.start> to create an in editor chat session.");
 }
 
 export namespace InspectTokensNLS {

--- a/src/vs/workbench/contrib/accessibility/browser/accessibleView.ts
+++ b/src/vs/workbench/contrib/accessibility/browser/accessibleView.ts
@@ -41,6 +41,7 @@ import { IOpenerService } from 'vs/platform/opener/common/opener';
 import { IQuickInputService, IQuickPick, IQuickPickItem } from 'vs/platform/quickinput/common/quickInput';
 import { IStorageService, StorageScope, StorageTarget } from 'vs/platform/storage/common/storage';
 import { AccessibilityVerbositySettingId, AccessibilityWorkbenchSettingId, accessibilityHelpIsShown, accessibleViewContainsCodeBlocks, accessibleViewCurrentProviderId, accessibleViewGoToSymbolSupported, accessibleViewInCodeBlock, accessibleViewIsShown, accessibleViewOnLastLine, accessibleViewSupportsNavigation, accessibleViewVerbosityEnabled } from 'vs/workbench/contrib/accessibility/browser/accessibilityConfiguration';
+import { resolveContentAndKeybindingItems } from 'vs/workbench/contrib/accessibility/browser/accessibleViewKeybindingResolver';
 import { AccessibilityCommandId } from 'vs/workbench/contrib/accessibility/common/accessibilityCommands';
 import { IChatCodeBlockContextProviderService } from 'vs/workbench/contrib/chat/browser/chat';
 import { ICodeBlockActionContext } from 'vs/workbench/contrib/chat/browser/codeBlockPart';
@@ -491,7 +492,17 @@ export class AccessibleView extends Disposable {
 			}
 		}
 		const exitThisDialogHint = verbose && !provider.options.position ? localize('exit', '\n\nExit this dialog (Escape).') : '';
-		const newContent = message + provider.provideContent() + readMoreLink + disableHelpHint + exitThisDialogHint;
+		let content = provider.provideContent();
+		if (provider.options.type === AccessibleViewType.Help) {
+			const resolvedContent = resolveContentAndKeybindingItems(this._keybindingService, content);
+			if (resolvedContent) {
+				content = resolvedContent.content.value;
+				if (resolvedContent.configureKeybindingItems) {
+					provider.options.configureKeybindingItems = resolvedContent.configureKeybindingItems;
+				}
+			}
+		}
+		const newContent = message + content + readMoreLink + disableHelpHint + exitThisDialogHint;
 		this.calculateCodeBlocks(newContent);
 		this._currentContent = newContent;
 		this._updateContextKeys(provider, true);

--- a/src/vs/workbench/contrib/accessibility/browser/accessibleViewKeybindingResolver.ts
+++ b/src/vs/workbench/contrib/accessibility/browser/accessibleViewKeybindingResolver.ts
@@ -1,0 +1,40 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { MarkdownString } from 'vs/base/common/htmlContent';
+import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
+import { IPickerQuickAccessItem } from 'vs/platform/quickinput/browser/pickerQuickAccess';
+import { AccessibilityCommandId } from 'vs/workbench/contrib/accessibility/common/accessibilityCommands';
+
+export function resolveContentAndKeybindingItems(keybindingService: IKeybindingService, value?: string): { content: MarkdownString; configureKeybindingItems: IPickerQuickAccessItem[] | undefined } | undefined {
+	if (!value) {
+		return;
+	}
+	const configureKeybindingItems: IPickerQuickAccessItem[] = [];
+	const matches = value.matchAll(/\<keybinding:(?<commandId>.*)\>/gm);
+	for (const match of [...matches]) {
+		const commandId = match?.groups?.commandId;
+		let kbLabel;
+		if (match?.length && commandId) {
+			const keybinding = keybindingService.lookupKeybinding(commandId)?.getAriaLabel();
+			if (!keybinding) {
+				const configureKb = keybindingService.lookupKeybinding(AccessibilityCommandId.AccessibilityHelpConfigureKeybindings)?.getAriaLabel();
+				const keybindingToConfigureQuickPick = configureKb ? '(' + configureKb + ')' : 'by assigning a keybinding to the command Accessibility Help Configure Keybindings.';
+				kbLabel = `, configure a keybinding ` + keybindingToConfigureQuickPick;
+				configureKeybindingItems.push({
+					label: commandId,
+					id: commandId
+				});
+			} else {
+				kbLabel = ' (' + keybinding + ')';
+			}
+			value = value.replace(match[0], kbLabel);
+		}
+	}
+	const content = new MarkdownString(value);
+	content.isTrusted = true;
+	return { content, configureKeybindingItems: configureKeybindingItems.length ? configureKeybindingItems : undefined };
+}
+

--- a/src/vs/workbench/contrib/accessibility/browser/editorAccessibilityHelp.ts
+++ b/src/vs/workbench/contrib/accessibility/browser/editorAccessibilityHelp.ts
@@ -8,12 +8,10 @@ import { ICodeEditor } from 'vs/editor/browser/editorBrowser';
 import { ICodeEditorService } from 'vs/editor/browser/services/codeEditorService';
 import { EditorOption } from 'vs/editor/common/config/editorOptions';
 import { AccessibilityHelpNLS } from 'vs/editor/common/standaloneStrings';
-import { ToggleTabFocusModeAction } from 'vs/editor/contrib/toggleTabFocusMode/browser/toggleTabFocusMode';
 import { ICommandService } from 'vs/platform/commands/common/commands';
 import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
-import { descriptionForCommand } from 'vs/workbench/contrib/accessibility/browser/accessibleViewContributions';
 import { AccessibilityHelpAction } from 'vs/workbench/contrib/accessibility/browser/accessibleViewActions';
 import { CONTEXT_CHAT_ENABLED } from 'vs/workbench/contrib/chat/common/chatContextKeys';
 import { CommentAccessibilityHelpNLS } from 'vs/workbench/contrib/comments/browser/commentsAccessibility';
@@ -87,13 +85,13 @@ class EditorAccessibilityHelpProvider implements IAccessibleViewContentProvider 
 		}
 
 		if (options.get(EditorOption.stickyScroll).enabled) {
-			content.push(descriptionForCommand('editor.action.focusStickyScroll', AccessibilityHelpNLS.stickScrollKb, AccessibilityHelpNLS.stickScrollNoKb, this._keybindingService));
+			content.push(AccessibilityHelpNLS.stickScroll);
 		}
 
 		if (options.get(EditorOption.tabFocusMode)) {
-			content.push(descriptionForCommand(ToggleTabFocusModeAction.ID, AccessibilityHelpNLS.tabFocusModeOnMsg, AccessibilityHelpNLS.tabFocusModeOnMsgNoKb, this._keybindingService));
+			content.push(AccessibilityHelpNLS.tabFocusModeOnMsg);
 		} else {
-			content.push(descriptionForCommand(ToggleTabFocusModeAction.ID, AccessibilityHelpNLS.tabFocusModeOffMsg, AccessibilityHelpNLS.tabFocusModeOffMsgNoKb, this._keybindingService));
+			content.push(AccessibilityHelpNLS.tabFocusModeOffMsg);
 		}
 		return content.join('\n\n');
 	}
@@ -102,17 +100,14 @@ class EditorAccessibilityHelpProvider implements IAccessibleViewContentProvider 
 export function getCommentCommandInfo(keybindingService: IKeybindingService, contextKeyService: IContextKeyService, editor: ICodeEditor): string | undefined {
 	const editorContext = contextKeyService.getContext(editor.getDomNode()!);
 	if (editorContext.getValue<boolean>(CommentContextKeys.activeEditorHasCommentingRange.key)) {
-		return [CommentAccessibilityHelpNLS.intro, CommentAccessibilityHelpNLS.addComment, CommentAccessibilityHelpNLS.nextCommentThreadKb, CommentAccessibilityHelpNLS.previousCommentThreadKb, CommentAccessibilityHelpNLS.nextRange, CommentAccessibilityHelpNLS.previousRange].join('\n');
+		return [CommentAccessibilityHelpNLS.intro, CommentAccessibilityHelpNLS.addComment, CommentAccessibilityHelpNLS.nextCommentThread, CommentAccessibilityHelpNLS.previousCommentThread, CommentAccessibilityHelpNLS.nextRange, CommentAccessibilityHelpNLS.previousRange].join('\n');
 	}
 	return;
 }
 
 export function getChatCommandInfo(keybindingService: IKeybindingService, contextKeyService: IContextKeyService): string | undefined {
 	if (CONTEXT_CHAT_ENABLED.getValue(contextKeyService)) {
-		const commentCommandInfo: string[] = [];
-		commentCommandInfo.push(descriptionForCommand('workbench.action.quickchat.toggle', AccessibilityHelpNLS.quickChat, AccessibilityHelpNLS.quickChatNoKb, keybindingService));
-		commentCommandInfo.push(descriptionForCommand('inlineChat.start', AccessibilityHelpNLS.startInlineChat, AccessibilityHelpNLS.startInlineChatNoKb, keybindingService));
-		return commentCommandInfo.join('\n');
+		return [AccessibilityHelpNLS.quickChat, AccessibilityHelpNLS.startInlineChat].join('\n');
 	}
 	return;
 }

--- a/src/vs/workbench/contrib/accessibility/browser/editorAccessibilityHelp.ts
+++ b/src/vs/workbench/contrib/accessibility/browser/editorAccessibilityHelp.ts
@@ -17,7 +17,6 @@ import { descriptionForCommand } from 'vs/workbench/contrib/accessibility/browse
 import { AccessibilityHelpAction } from 'vs/workbench/contrib/accessibility/browser/accessibleViewActions';
 import { CONTEXT_CHAT_ENABLED } from 'vs/workbench/contrib/chat/common/chatContextKeys';
 import { CommentAccessibilityHelpNLS } from 'vs/workbench/contrib/comments/browser/commentsAccessibility';
-import { CommentCommandId } from 'vs/workbench/contrib/comments/common/commentCommandIds';
 import { CommentContextKeys } from 'vs/workbench/contrib/comments/common/commentContextKeys';
 import { NEW_UNTITLED_FILE_COMMAND_ID } from 'vs/workbench/contrib/files/browser/fileConstants';
 import { IAccessibleViewService, IAccessibleViewContentProvider, AccessibleViewProviderId, IAccessibleViewOptions, AccessibleViewType } from 'vs/platform/accessibility/browser/accessibleView';
@@ -103,14 +102,7 @@ class EditorAccessibilityHelpProvider implements IAccessibleViewContentProvider 
 export function getCommentCommandInfo(keybindingService: IKeybindingService, contextKeyService: IContextKeyService, editor: ICodeEditor): string | undefined {
 	const editorContext = contextKeyService.getContext(editor.getDomNode()!);
 	if (editorContext.getValue<boolean>(CommentContextKeys.activeEditorHasCommentingRange.key)) {
-		const commentCommandInfo: string[] = [];
-		commentCommandInfo.push(CommentAccessibilityHelpNLS.intro);
-		commentCommandInfo.push(descriptionForCommand(CommentCommandId.Add, CommentAccessibilityHelpNLS.addComment, CommentAccessibilityHelpNLS.addCommentNoKb, keybindingService));
-		commentCommandInfo.push(descriptionForCommand(CommentCommandId.NextThread, CommentAccessibilityHelpNLS.nextCommentThreadKb, CommentAccessibilityHelpNLS.nextCommentThreadNoKb, keybindingService));
-		commentCommandInfo.push(descriptionForCommand(CommentCommandId.PreviousThread, CommentAccessibilityHelpNLS.previousCommentThreadKb, CommentAccessibilityHelpNLS.previousCommentThreadNoKb, keybindingService));
-		commentCommandInfo.push(descriptionForCommand(CommentCommandId.NextRange, CommentAccessibilityHelpNLS.nextRange, CommentAccessibilityHelpNLS.nextRangeNoKb, keybindingService));
-		commentCommandInfo.push(descriptionForCommand(CommentCommandId.PreviousRange, CommentAccessibilityHelpNLS.previousRange, CommentAccessibilityHelpNLS.previousRangeNoKb, keybindingService));
-		return commentCommandInfo.join('\n');
+		return [CommentAccessibilityHelpNLS.intro, CommentAccessibilityHelpNLS.addComment, CommentAccessibilityHelpNLS.nextCommentThreadKb, CommentAccessibilityHelpNLS.previousCommentThreadKb, CommentAccessibilityHelpNLS.nextRange, CommentAccessibilityHelpNLS.previousRange].join('\n');
 	}
 	return;
 }

--- a/src/vs/workbench/contrib/accessibility/browser/extensionAccesibilityHelp.contribution.ts
+++ b/src/vs/workbench/contrib/accessibility/browser/extensionAccesibilityHelp.contribution.ts
@@ -3,17 +3,14 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { MarkdownString } from 'vs/base/common/htmlContent';
 import { DisposableMap, IDisposable, DisposableStore, Disposable } from 'vs/base/common/lifecycle';
+import { ServicesAccessor } from 'vs/editor/browser/editorExtensions';
 import { AccessibleViewType, ExtensionContentProvider } from 'vs/platform/accessibility/browser/accessibleView';
 import { AccessibleViewRegistry } from 'vs/platform/accessibility/browser/accessibleViewRegistry';
-import { ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
-import { IPickerQuickAccessItem } from 'vs/platform/quickinput/browser/pickerQuickAccess';
 import { Registry } from 'vs/platform/registry/common/platform';
 import { FocusedViewContext } from 'vs/workbench/common/contextkeys';
 import { IViewsRegistry, Extensions, IViewDescriptor } from 'vs/workbench/common/views';
-import { AccessibilityCommandId } from 'vs/workbench/contrib/accessibility/common/accessibilityCommands';
 import { IViewsService } from 'vs/workbench/services/views/common/viewsService';
 
 export class ExtensionAccessibilityHelpDialogContribution extends Disposable {
@@ -42,9 +39,9 @@ export class ExtensionAccessibilityHelpDialogContribution extends Disposable {
 
 function registerAccessibilityHelpAction(keybindingService: IKeybindingService, viewDescriptor: IViewDescriptor): IDisposable {
 	const disposableStore = new DisposableStore();
-	const helpContent = resolveExtensionHelpContent(keybindingService, viewDescriptor.accessibilityHelpContent);
-	if (!helpContent) {
-		throw new Error('No help content for view');
+	const content = viewDescriptor.accessibilityHelpContent?.value;
+	if (!content) {
+		throw new Error('No content provided for the accessibility help dialog');
 	}
 	disposableStore.add(AccessibleViewRegistry.register({
 		priority: 95,
@@ -55,8 +52,8 @@ function registerAccessibilityHelpAction(keybindingService: IKeybindingService, 
 			const viewsService = accessor.get(IViewsService);
 			return new ExtensionContentProvider(
 				viewDescriptor.id,
-				{ type: AccessibleViewType.Help, configureKeybindingItems: helpContent.configureKeybindingItems },
-				() => helpContent.value.value,
+				{ type: AccessibleViewType.Help },
+				() => content,
 				() => viewsService.openView(viewDescriptor.id, true),
 			);
 		}
@@ -68,35 +65,3 @@ function registerAccessibilityHelpAction(keybindingService: IKeybindingService, 
 	}));
 	return disposableStore;
 }
-
-function resolveExtensionHelpContent(keybindingService: IKeybindingService, content?: MarkdownString): { value: MarkdownString; configureKeybindingItems: IPickerQuickAccessItem[] | undefined } | undefined {
-	if (!content) {
-		return;
-	}
-	const configureKeybindingItems: IPickerQuickAccessItem[] = [];
-	let resolvedContent = typeof content === 'string' ? content : content.value;
-	const matches = resolvedContent.matchAll(/\<keybinding:(?<commandId>.*)\>/gm);
-	for (const match of [...matches]) {
-		const commandId = match?.groups?.commandId;
-		let kbLabel;
-		if (match?.length && commandId) {
-			const keybinding = keybindingService.lookupKeybinding(commandId)?.getAriaLabel();
-			if (!keybinding) {
-				const configureKb = keybindingService.lookupKeybinding(AccessibilityCommandId.AccessibilityHelpConfigureKeybindings)?.getAriaLabel();
-				const keybindingToConfigureQuickPick = configureKb ? '(' + configureKb + ')' : 'by assigning a keybinding to the command accessibility.openQuickPick.';
-				kbLabel = `, configure a keybinding ` + keybindingToConfigureQuickPick;
-				configureKeybindingItems.push({
-					label: commandId,
-					id: commandId
-				});
-			} else {
-				kbLabel = ' (' + keybinding + ')';
-			}
-			resolvedContent = resolvedContent.replace(match[0], kbLabel);
-		}
-	}
-	const value = new MarkdownString(resolvedContent);
-	value.isTrusted = true;
-	return { value, configureKeybindingItems: configureKeybindingItems.length ? configureKeybindingItems : undefined };
-}
-

--- a/src/vs/workbench/contrib/chat/browser/actions/chatAccessibilityHelp.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatAccessibilityHelp.ts
@@ -4,8 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { localize } from 'vs/nls';
-import { format } from 'vs/base/common/strings';
-import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 import { ICodeEditor } from 'vs/editor/browser/editorBrowser';
 import { ServicesAccessor } from 'vs/editor/browser/editorExtensions';
 import { IChatWidgetService } from 'vs/workbench/contrib/chat/browser/chat';
@@ -29,47 +27,31 @@ export class ChatAccessibilityHelp implements IAccessibleViewImplentation {
 	}
 }
 
-export function getAccessibilityHelpText(accessor: ServicesAccessor, type: 'panelChat' | 'inlineChat'): string {
-	const keybindingService = accessor.get(IKeybindingService);
+export function getAccessibilityHelpText(type: 'panelChat' | 'inlineChat'): string {
 	const content = [];
-	const openAccessibleViewKeybinding = keybindingService.lookupKeybinding('editor.action.accessibleView')?.getAriaLabel();
 	if (type === 'panelChat') {
 		content.push(localize('chat.overview', 'The chat view is comprised of an input box and a request/response list. The input box is used to make requests and the list is used to display responses.'));
 		content.push(localize('chat.requestHistory', 'In the input box, use up and down arrows to navigate your request history. Edit input and use enter or the submit button to run a new request.'));
-		content.push(openAccessibleViewKeybinding ? localize('chat.inspectResponse', 'In the input box, inspect the last response in the accessible view {0}', openAccessibleViewKeybinding) : localize('chat.inspectResponseNoKb', 'With the input box focused, inspect the last response in the accessible view via the Open Accessible View command, which is currently not triggerable by a keybinding.'));
+		content.push(localize('chat.inspectResponse', 'In the input box, inspect the last response in the accessible view<keybinding:editor.action.accessibleView>'));
 		content.push(localize('chat.followUp', 'In the input box, navigate to the suggested follow up question (Shift+Tab) and press Enter to run it.'));
 		content.push(localize('chat.announcement', 'Chat responses will be announced as they come in. A response will indicate the number of code blocks, if any, and then the rest of the response.'));
-		content.push(descriptionForCommand('chat.action.focus', localize('workbench.action.chat.focus', 'To focus the chat request/response list, which can be navigated with up and down arrows, invoke the Focus Chat command ({0}).',), localize('workbench.action.chat.focusNoKb', 'To focus the chat request/response list, which can be navigated with up and down arrows, invoke The Focus Chat List command, which is currently not triggerable by a keybinding.'), keybindingService));
-		content.push(descriptionForCommand('workbench.action.chat.focusInput', localize('workbench.action.chat.focusInput', 'To focus the input box for chat requests, invoke the Focus Chat Input command ({0}).'), localize('workbench.action.interactiveSession.focusInputNoKb', 'To focus the input box for chat requests, invoke the Focus Chat Input command, which is currently not triggerable by a keybinding.'), keybindingService));
-		content.push(descriptionForCommand('workbench.action.chat.nextCodeBlock', localize('workbench.action.chat.nextCodeBlock', 'To focus the next code block within a response, invoke the Chat: Next Code Block command ({0}).'), localize('workbench.action.chat.nextCodeBlockNoKb', 'To focus the next code block within a response, invoke the Chat: Next Code Block command, which is currently not triggerable by a keybinding.'), keybindingService));
-		content.push(descriptionForCommand('workbench.action.chat.nextFileTree', localize('workbench.action.chat.nextFileTree', 'To focus the next file tree within a response, invoke the Chat: Next File Tree command ({0}).'), localize('workbench.action.chat.nextFileTreeNoKb', 'To focus the next file tree within a response, invoke the Chat: Next File Tree command, which is currently not triggerable by a keybinding.'), keybindingService));
-		content.push(descriptionForCommand('workbench.action.chat.clear', localize('workbench.action.chat.clear', 'To clear the request/response list, invoke the Chat Clear command ({0}).'), localize('workbench.action.chat.clearNoKb', 'To clear the request/response list, invoke the Chat Clear command, which is currently not triggerable by a keybinding.'), keybindingService));
+		content.push(localize('workbench.action.chat.focus', 'To focus the chat request/response list, which can be navigated with up and down arrows, invoke the Focus Chat command<keybinding:chat.action.focus>.'));
+		content.push(localize('workbench.action.chat.focusInput', 'To focus the input box for chat requests, invoke the Focus Chat Input command<keybinding:workbench.action.chat.focusInput>.'));
+		content.push(localize('workbench.action.chat.nextCodeBlock', 'To focus the next code block within a response, invoke the Chat: Next Code Block command<keybinding:workbench.action.chat.nextCodeBlock>.'));
+		content.push(localize('workbench.action.chat.nextFileTree', 'To focus the next file tree within a response, invoke the Chat: Next File Tree command<keybinding:workbench.action.chat.nextFileTree>.'));
+		content.push(localize('workbench.action.chat.clear', 'To clear the request/response list, invoke the Chat Clear command<keybinding:workbench.action.chat.clear>.'));
 	} else {
-		const startChatKeybinding = keybindingService.lookupKeybinding('inlineChat.start')?.getAriaLabel();
 		content.push(localize('inlineChat.overview', "Inline chat occurs within a code editor and takes into account the current selection. It is useful for making changes to the current editor. For example, fixing diagnostics, documenting or refactoring code. Keep in mind that AI generated code may be incorrect."));
-		content.push(localize('inlineChat.access', "It can be activated via code actions or directly using the command: Inline Chat: Start Inline Chat ({0}).", startChatKeybinding));
-		const upHistoryKeybinding = keybindingService.lookupKeybinding('inlineChat.previousFromHistory')?.getAriaLabel();
-		const downHistoryKeybinding = keybindingService.lookupKeybinding('inlineChat.nextFromHistory')?.getAriaLabel();
-		if (upHistoryKeybinding && downHistoryKeybinding) {
-			content.push(localize('inlineChat.requestHistory', 'In the input box, use {0} and {1} to navigate your request history. Edit input and use enter or the submit button to run a new request.', upHistoryKeybinding, downHistoryKeybinding));
-		}
-		content.push(openAccessibleViewKeybinding ? localize('inlineChat.inspectResponse', 'In the input box, inspect the response in the accessible view {0}.', openAccessibleViewKeybinding) : localize('inlineChat.inspectResponseNoKb', 'With the input box focused, inspect the response in the accessible view via the Open Accessible View command, which is currently not triggerable by a keybinding.'));
+		content.push(localize('inlineChat.access', "It can be activated via code actions or directly using the command: Inline Chat: Start Inline Chat<keybinding:inlineChat.start>."));
+		content.push(localize('inlineChat.requestHistory', 'In the input box, use<keybinding:inlineChat.previousFromHistory> and<keybinding:inlineChat.nextFromHistory> to navigate your request history. Edit input and use enter or the submit button to run a new request.'));
+		content.push(localize('inlineChat.inspectResponse', 'In the input box, inspect the response in the accessible viewview<keybinding:editor.action.accessibleView>'));
 		content.push(localize('inlineChat.contextActions', "Context menu actions may run a request prefixed with a /. Type / to discover such ready-made commands."));
 		content.push(localize('inlineChat.fix', "If a fix action is invoked, a response will indicate the problem with the current code. A diff editor will be rendered and can be reached by tabbing."));
-		const diffReviewKeybinding = keybindingService.lookupKeybinding(AccessibleDiffViewerNext.id)?.getAriaLabel();
-		content.push(diffReviewKeybinding ? localize('inlineChat.diff', "Once in the diff editor, enter review mode with ({0}). Use up and down arrows to navigate lines with the proposed changes.", diffReviewKeybinding) : localize('inlineChat.diffNoKb', "Tab again to enter the Diff editor with the changes and enter review mode with the Go to Next Difference Command. Use Up/DownArrow to navigate lines with the proposed changes."));
+		content.push(localize('inlineChat.diff', "Once in the diff editor, enter review mode with<keybinding:{0}>. Use up and down arrows to navigate lines with the proposed changes.", AccessibleDiffViewerNext.id));
 		content.push(localize('inlineChat.toolbar', "Use tab to reach conditional parts like commands, status, message responses and more."));
 	}
 	content.push(localize('chat.signals', "Accessibility Signals can be changed via settings with a prefix of signals.chat. By default, if a request takes more than 4 seconds, you will hear a sound indicating that progress is still occurring."));
 	return content.join('\n\n');
-}
-
-function descriptionForCommand(commandId: string, msg: string, noKbMsg: string, keybindingService: IKeybindingService): string {
-	const kb = keybindingService.lookupKeybinding(commandId);
-	if (kb) {
-		return format(msg, kb.getAriaLabel());
-	}
-	return format(noKbMsg, commandId);
 }
 
 export function getChatAccessibilityHelpProvider(accessor: ServicesAccessor, editor: ICodeEditor | undefined, type: 'panelChat' | 'inlineChat') {
@@ -86,7 +68,7 @@ export function getChatAccessibilityHelpProvider(accessor: ServicesAccessor, edi
 
 	const cachedPosition = inputEditor.getPosition();
 	inputEditor.getSupportedActions();
-	const helpText = getAccessibilityHelpText(accessor, type);
+	const helpText = getAccessibilityHelpText(type);
 	return {
 		id: type === 'panelChat' ? AccessibleViewProviderId.Chat : AccessibleViewProviderId.InlineChat,
 		verbositySettingKey: type === 'panelChat' ? AccessibilityVerbositySettingId.Chat : AccessibilityVerbositySettingId.InlineChat,

--- a/src/vs/workbench/contrib/comments/browser/commentsAccessibility.ts
+++ b/src/vs/workbench/contrib/comments/browser/commentsAccessibility.ts
@@ -16,13 +16,13 @@ import { IAccessibleViewImplentation } from 'vs/platform/accessibility/browser/a
 
 export namespace CommentAccessibilityHelpNLS {
 	export const intro = nls.localize('intro', "The editor contains commentable range(s). Some useful commands include:");
-	export const introWidget = nls.localize('introWidget', "This widget contains a text area, for composition of new comments, and actions, that can be tabbed to once tab moves focus mode has been enabled with the command Toggle Tab Key Moves Focus{0}", `<keybinding:${ToggleTabFocusModeAction.ID}>`);
+	export const tabFocus = nls.localize('introWidget', "This widget contains a text area, for composition of new comments, and actions, that can be tabbed to once tab moves focus mode has been enabled with the command Toggle Tab Key Moves Focus{0}", `<keybinding:${ToggleTabFocusModeAction.ID}>`);
 	export const commentCommands = nls.localize('commentCommands', "Some useful comment commands include:");
 	export const escape = nls.localize('escape', "- Dismiss Comment (Escape)");
 	export const nextRange = nls.localize('next', "- Go to Next Commenting Range{0}", `<keybinding:${CommentCommandId.NextRange}>`);
 	export const previousRange = nls.localize('previous', "- Go to Previous Commenting Range{0}", `<keybinding:${CommentCommandId.PreviousRange}>`);
-	export const nextCommentThreadKb = nls.localize('nextCommentThreadKb', "- Go to Next Comment Thread{0}", `<keybinding:${CommentCommandId.NextThread}>`);
-	export const previousCommentThreadKb = nls.localize('previousCommentThreadKb', "- Go to Previous Comment Thread{0}", `<keybinding:${CommentCommandId.PreviousThread}>`);
+	export const nextCommentThread = nls.localize('nextCommentThreadKb', "- Go to Next Comment Thread{0}", `<keybinding:${CommentCommandId.NextThread}>`);
+	export const previousCommentThread = nls.localize('previousCommentThreadKb', "- Go to Previous Comment Thread{0}", `<keybinding:${CommentCommandId.PreviousThread}>`);
 	export const addComment = nls.localize('addCommentNoKb', "- Add Comment on Current Selection{0}", `<keybinding:${CommentCommandId.Add}>`);
 	export const submitComment = nls.localize('submitComment', "- Submit Comment{0}", `<keybinding:${CommentCommandId.Submit}>`);
 }
@@ -33,7 +33,7 @@ export class CommentsAccessibilityHelpProvider implements IAccessibleViewContent
 	options: IAccessibleViewOptions = { type: AccessibleViewType.Help };
 	private _element: HTMLElement | undefined;
 	provideContent(): string {
-		return [CommentAccessibilityHelpNLS.introWidget, CommentAccessibilityHelpNLS.commentCommands, CommentAccessibilityHelpNLS.escape, CommentAccessibilityHelpNLS.addComment, CommentAccessibilityHelpNLS.submitComment, CommentAccessibilityHelpNLS.nextRange, CommentAccessibilityHelpNLS.previousRange].join('\n');
+		return [CommentAccessibilityHelpNLS.tabFocus, CommentAccessibilityHelpNLS.commentCommands, CommentAccessibilityHelpNLS.escape, CommentAccessibilityHelpNLS.addComment, CommentAccessibilityHelpNLS.submitComment, CommentAccessibilityHelpNLS.nextRange, CommentAccessibilityHelpNLS.previousRange].join('\n');
 	}
 	onClose(): void {
 		this._element?.focus();

--- a/src/vs/workbench/contrib/comments/browser/commentsAccessibility.ts
+++ b/src/vs/workbench/contrib/comments/browser/commentsAccessibility.ts
@@ -9,9 +9,6 @@ import { ctxCommentEditorFocused } from 'vs/workbench/contrib/comments/browser/s
 import { CommentContextKeys } from 'vs/workbench/contrib/comments/common/commentContextKeys';
 import * as nls from 'vs/nls';
 import { AccessibilityVerbositySettingId } from 'vs/workbench/contrib/accessibility/browser/accessibilityConfiguration';
-import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
-import * as strings from 'vs/base/common/strings';
-import { getActiveElement } from 'vs/base/browser/dom';
 import { CommentCommandId } from 'vs/workbench/contrib/comments/common/commentCommandIds';
 import { ToggleTabFocusModeAction } from 'vs/editor/contrib/toggleTabFocusMode/browser/toggleTabFocusMode';
 import { IAccessibleViewContentProvider, AccessibleViewProviderId, IAccessibleViewOptions, AccessibleViewType } from 'vs/platform/accessibility/browser/accessibleView';
@@ -19,22 +16,15 @@ import { IAccessibleViewImplentation } from 'vs/platform/accessibility/browser/a
 
 export namespace CommentAccessibilityHelpNLS {
 	export const intro = nls.localize('intro', "The editor contains commentable range(s). Some useful commands include:");
-	export const introWidget = nls.localize('introWidget', "This widget contains a text area, for composition of new comments, and actions, that can be tabbed to once tab moves focus mode has been enabled ({0}).");
-	export const introWidgetNoKb = nls.localize('introWidgetNoKb', "This widget contains a text area, for composition of new comments, and actions, that can be tabbed to once tab moves focus mode has been enabled with the command Toggle Tab Key Moves Focus, which is currently not triggerable via keybinding.");
+	export const introWidget = nls.localize('introWidget', "This widget contains a text area, for composition of new comments, and actions, that can be tabbed to once tab moves focus mode has been enabled with the command Toggle Tab Key Moves Focus{0}", `<keybinding:${ToggleTabFocusModeAction.ID}>`);
 	export const commentCommands = nls.localize('commentCommands', "Some useful comment commands include:");
 	export const escape = nls.localize('escape', "- Dismiss Comment (Escape)");
-	export const nextRange = nls.localize('next', "- Go to Next Commenting Range ({0})");
-	export const nextRangeNoKb = nls.localize('nextNoKb', "- Go to Next Commenting Range, which is currently not triggerable via keybinding.");
-	export const previousRange = nls.localize('previous', "- Go to Previous Commenting Range ({0})");
-	export const previousRangeNoKb = nls.localize('previousNoKb', "- Go to Previous Commenting Range, which is currently not triggerable via keybinding.");
-	export const nextCommentThreadKb = nls.localize('nextCommentThreadKb', "- Go to Next Comment Thread ({0})");
-	export const nextCommentThreadNoKb = nls.localize('nextCommentThreadNoKb', "- Go to Next Comment Thread, which is currently not triggerable via keybinding.");
-	export const previousCommentThreadKb = nls.localize('previousCommentThreadKb', "- Go to Previous Comment Thread ({0})");
-	export const previousCommentThreadNoKb = nls.localize('previousCommentThreadNoKb', "- Go to Previous Comment Thread, which is currently not triggerable via keybinding.");
-	export const addComment = nls.localize('addComment', "- Add Comment ({0})");
-	export const addCommentNoKb = nls.localize('addCommentNoKb', "- Add Comment on Current Selection, which is currently not triggerable via keybinding.");
-	export const submitComment = nls.localize('submitComment', "- Submit Comment ({0})");
-	export const submitCommentNoKb = nls.localize('submitCommentNoKb', "- Submit Comment, accessible via tabbing, as it's currently not triggerable with a keybinding.");
+	export const nextRange = nls.localize('next', "- Go to Next Commenting Range{0}", `<keybinding:${CommentCommandId.NextRange}>`);
+	export const previousRange = nls.localize('previous', "- Go to Previous Commenting Range{0}", `<keybinding:${CommentCommandId.PreviousRange}>`);
+	export const nextCommentThreadKb = nls.localize('nextCommentThreadKb', "- Go to Next Comment Thread{0}", `<keybinding:${CommentCommandId.NextThread}>`);
+	export const previousCommentThreadKb = nls.localize('previousCommentThreadKb', "- Go to Previous Comment Thread{0}", `<keybinding:${CommentCommandId.PreviousThread}>`);
+	export const addComment = nls.localize('addCommentNoKb', "- Add Comment on Current Selection{0}", `<keybinding:${CommentCommandId.Add}>`);
+	export const submitComment = nls.localize('submitComment', "- Submit Comment{0}", `<keybinding:${CommentCommandId.Submit}>`);
 }
 
 export class CommentsAccessibilityHelpProvider implements IAccessibleViewContentProvider {
@@ -42,29 +32,8 @@ export class CommentsAccessibilityHelpProvider implements IAccessibleViewContent
 	verbositySettingKey: AccessibilityVerbositySettingId = AccessibilityVerbositySettingId.Comments;
 	options: IAccessibleViewOptions = { type: AccessibleViewType.Help };
 	private _element: HTMLElement | undefined;
-	constructor(
-		@IKeybindingService private readonly _keybindingService: IKeybindingService
-	) {
-
-	}
-	private _descriptionForCommand(commandId: string, msg: string, noKbMsg: string): string {
-		const kb = this._keybindingService.lookupKeybinding(commandId);
-		if (kb) {
-			return strings.format(msg, kb.getAriaLabel());
-		}
-		return strings.format(noKbMsg, commandId);
-	}
 	provideContent(): string {
-		this._element = getActiveElement() as HTMLElement;
-		const content: string[] = [];
-		content.push(this._descriptionForCommand(ToggleTabFocusModeAction.ID, CommentAccessibilityHelpNLS.introWidget, CommentAccessibilityHelpNLS.introWidgetNoKb) + '\n');
-		content.push(CommentAccessibilityHelpNLS.commentCommands);
-		content.push(CommentAccessibilityHelpNLS.escape);
-		content.push(this._descriptionForCommand(CommentCommandId.Add, CommentAccessibilityHelpNLS.addComment, CommentAccessibilityHelpNLS.addCommentNoKb));
-		content.push(this._descriptionForCommand(CommentCommandId.Submit, CommentAccessibilityHelpNLS.submitComment, CommentAccessibilityHelpNLS.submitCommentNoKb));
-		content.push(this._descriptionForCommand(CommentCommandId.NextRange, CommentAccessibilityHelpNLS.nextRange, CommentAccessibilityHelpNLS.nextRangeNoKb));
-		content.push(this._descriptionForCommand(CommentCommandId.PreviousRange, CommentAccessibilityHelpNLS.previousRange, CommentAccessibilityHelpNLS.previousRangeNoKb));
-		return content.join('\n');
+		return [CommentAccessibilityHelpNLS.introWidget, CommentAccessibilityHelpNLS.commentCommands, CommentAccessibilityHelpNLS.escape, CommentAccessibilityHelpNLS.addComment, CommentAccessibilityHelpNLS.submitComment, CommentAccessibilityHelpNLS.nextRange, CommentAccessibilityHelpNLS.previousRange].join('\n');
 	}
 	onClose(): void {
 		this._element?.focus();

--- a/src/vs/workbench/contrib/notebook/browser/notebookAccessibilityHelp.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookAccessibilityHelp.ts
@@ -6,8 +6,6 @@ import { ServicesAccessor } from 'vs/platform/instantiation/common/instantiation
 import { IAccessibleViewImplentation } from 'vs/platform/accessibility/browser/accessibleViewRegistry';
 import { NOTEBOOK_IS_ACTIVE_EDITOR } from 'vs/workbench/contrib/notebook/common/notebookContextKeys';
 import { localize } from 'vs/nls';
-import { format } from 'vs/base/common/strings';
-import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 import { ICodeEditor } from 'vs/editor/browser/editorBrowser';
 import { AccessibleViewProviderId, AccessibleViewType } from 'vs/platform/accessibility/browser/accessibleView';
 import { AccessibilityVerbositySettingId } from 'vs/workbench/contrib/accessibility/browser/accessibilityConfiguration';
@@ -34,46 +32,23 @@ export class NotebookAccessibilityHelp implements IAccessibleViewImplentation {
 
 
 
-export function getAccessibilityHelpText(accessor: ServicesAccessor): string {
-	const keybindingService = accessor.get(IKeybindingService);
-	const content = [];
-	content.push(localize('notebook.overview', 'The notebook view is a collection of code and markdown cells. Code cells can be executed and will produce output directly below the cell.'));
-	content.push(descriptionForCommand('notebook.cell.edit',
-		localize('notebook.cell.edit', 'The Edit Cell command ({0}) will focus on the cell input.'),
-		localize('notebook.cell.editNoKb', 'The Edit Cell command will focus on the cell input and is currently not triggerable by a keybinding.'), keybindingService));
-	content.push(descriptionForCommand('notebook.cell.quitEdit',
-		localize('notebook.cell.quitEdit', 'The Quit Edit command ({0}) will set focus on the cell container. The default (Escape) key may need to be pressed twice first exit the virtual cursor if active.'),
-		localize('notebook.cell.quitEditNoKb', 'The Quit Edit command will set focus on the cell container and is currently not triggerable by a keybinding.'), keybindingService));
-	content.push(descriptionForCommand('notebook.cell.focusInOutput',
-		localize('notebook.cell.focusInOutput', 'The Focus Output command ({0}) will set focus in the cell\'s output.'),
-		localize('notebook.cell.focusInOutputNoKb', 'The Quit Edit command will set focus in the cell\'s output and is currently not triggerable by a keybinding.'), keybindingService));
-	content.push(descriptionForCommand('notebook.focusNextEditor',
-		localize('notebook.focusNextEditor', 'The Focus Next Cell Editor command ({0}) will set focus in the next cell\'s editor.'),
-		localize('notebook.focusNextEditorNoKb', 'The Focus Next Cell Editor command will set focus in the next cell\'s editor and is currently not triggerable by a keybinding.'), keybindingService));
-	content.push(descriptionForCommand('notebook.focusPreviousEditor',
-		localize('notebook.focusPreviousEditor', 'The Focus Previous Cell Editor command ({0}) will set focus in the previous cell\'s editor.'),
-		localize('notebook.focusPreviousEditorNoKb', 'The Focus Previous Cell Editor command will set focus in the previous cell\'s editor and is currently not triggerable by a keybinding.'), keybindingService));
-	content.push(localize('notebook.cellNavigation', 'The up and down arrows will also move focus between cells while focused on the outer cell container.'));
-	content.push(descriptionForCommand('notebook.cell.executeAndFocusContainer',
-		localize('notebook.cell.executeAndFocusContainer', 'The Execute Cell command ({0}) executes the cell that currently has focus.',),
-		localize('notebook.cell.executeAndFocusContainerNoKb', 'The Execute Cell command executes the cell that currently has focus and is currently not triggerable by a keybinding.'), keybindingService));
-	content.push(localize('notebook.cell.insertCodeCellBelowAndFocusContainer', 'The Insert Cell Above/Below commands will create new empty code cells'));
-	content.push(localize('notebook.changeCellType', 'The Change Cell to Code/Markdown commands are used to switch between cell types.'));
-
-
-	return content.join('\n\n');
-}
-
-function descriptionForCommand(commandId: string, msg: string, noKbMsg: string, keybindingService: IKeybindingService): string {
-	const kb = keybindingService.lookupKeybinding(commandId);
-	if (kb) {
-		return format(msg, kb.getAriaLabel());
-	}
-	return format(noKbMsg, commandId);
+export function getAccessibilityHelpText(): string {
+	return [
+		localize('notebook.overview', 'The notebook view is a collection of code and markdown cells. Code cells can be executed and will produce output directly below the cell.'),
+		localize('notebook.cell.edit', 'The Edit Cell command<keybinding:notebook.cell.edit> will focus on the cell input.'),
+		localize('notebook.cell.quitEdit', 'The Quit Edit command<keybinding:notebook.cell.quitEdit> will set focus on the cell container. The default (Escape) key may need to be pressed twice first exit the virtual cursor if active.'),
+		localize('notebook.cell.focusInOutput', 'The Focus Output command<keybinding:notebook.cell.focusInOutput> will set focus in the cell\'s output.'),
+		localize('notebook.focusNextEditor', 'The Focus Next Cell Editor command<keybinding:notebook.focusNextEditor> will set focus in the next cell\'s editor.'),
+		localize('notebook.focusPreviousEditor', 'The Focus Previous Cell Editor command<keybinding:notebook.focusPreviousEditor> will set focus in the previous cell\'s editor.'),
+		localize('notebook.cellNavigation', 'The up and down arrows will also move focus between cells while focused on the outer cell container.'),
+		localize('notebook.cell.executeAndFocusContainer', 'The Execute Cell command<keybinding:notebook.cell.executeAndFocusContainer> executes the cell that currently has focus.',),
+		localize('notebook.cell.insertCodeCellBelowAndFocusContainer', 'The Insert Cell Above/Below commands will create new empty code cells'),
+		localize('notebook.changeCellType', 'The Change Cell to Code/Markdown commands are used to switch between cell types.')
+	].join('\n\n');
 }
 
 export function runAccessibilityHelpAction(accessor: ServicesAccessor, editor: ICodeEditor | IVisibleEditorPane) {
-	const helpText = getAccessibilityHelpText(accessor);
+	const helpText = getAccessibilityHelpText();
 	return {
 		id: AccessibleViewProviderId.Notebook,
 		verbositySettingKey: AccessibilityVerbositySettingId.Notebook,


### PR DESCRIPTION
Adopted for the editor, comments, notebook, chat, and extension contributed accessibility help dialogs so far

part of [#210695](https://github.com/microsoft/vscode/issues/210695)

deferring terminal, diff editor, and other accessible views to a different PR