### PR TITLE
feat: support dynamic variables in chat context picker

### DIFF
--- a/src/vs/platform/quickinput/common/quickAccess.ts
+++ b/src/vs/platform/quickinput/common/quickAccess.ts
@@ -60,7 +60,7 @@ export interface IQuickAccessOptions {
 	/**
 	 * Provider specific options for this particular showing of the
 	 * quick access.
-	*/
+	 */
 	readonly providerOptions?: IQuickAccessProviderRunOptions;
 
 	/**

--- a/src/vs/workbench/api/browser/mainThreadChatAgents2.ts
+++ b/src/vs/workbench/api/browser/mainThreadChatAgents2.ts
@@ -10,6 +10,7 @@ import { IMarkdownString } from 'vs/base/common/htmlContent';
 import { Disposable, DisposableMap, IDisposable } from 'vs/base/common/lifecycle';
 import { revive } from 'vs/base/common/marshalling';
 import { escapeRegExpCharacters } from 'vs/base/common/strings';
+import { ThemeIcon } from 'vs/base/common/themables';
 import { URI, UriComponents } from 'vs/base/common/uri';
 import { Position } from 'vs/editor/common/core/position';
 import { Range } from 'vs/editor/common/core/range';
@@ -73,6 +74,7 @@ export class MainThreadChatAgents2 extends Disposable implements MainThreadChatA
 
 	private readonly _agents = this._register(new DisposableMap<number, AgentData>());
 	private readonly _agentCompletionProviders = this._register(new DisposableMap<number, IDisposable>());
+	private readonly _agentIdsToCompletionProviders = this._register(new DisposableMap<string, IDisposable>);
 
 	private readonly _pendingProgress = new Map<string, (part: IChatProgress) => void>();
 	private readonly _proxy: ExtHostChatAgentsShape2;
@@ -233,7 +235,13 @@ export class MainThreadChatAgents2 extends Disposable implements MainThreadChatA
 		this._pendingProgress.get(requestId)?.(revivedProgress);
 	}
 
-	$registerAgentCompletionsProvider(handle: number, triggerCharacters: string[]): void {
+	$registerAgentCompletionsProvider(handle: number, id: string, triggerCharacters: string[]): void {
+		const provide = async (query: string, token: CancellationToken) => {
+			const completions = await this._proxy.$invokeCompletionProvider(handle, query, token);
+			return completions.map((c) => ({ ...c, icon: c.icon ? ThemeIcon.fromId(c.icon) : undefined }));
+		};
+		this._agentIdsToCompletionProviders.set(id, this._chatAgentService.registerAgentCompletionProvider(id, provide));
+
 		this._agentCompletionProviders.set(handle, this._languageFeaturesService.completionProvider.register({ scheme: ChatInputPart.INPUT_SCHEME, hasAccessToAllModels: true }, {
 			_debugDisplayName: 'chatAgentCompletions:' + handle,
 			triggerCharacters,
@@ -263,7 +271,7 @@ export class MainThreadChatAgents2 extends Disposable implements MainThreadChatA
 					return null;
 				}
 
-				const result = await this._proxy.$invokeCompletionProvider(handle, query, token);
+				const result = await provide(query, token);
 				const variableItems = result.map(v => {
 					const insertText = v.insertText ?? (typeof v.label === 'string' ? v.label : v.label.label);
 					const rangeAfterInsert = new Range(range.insert.startLineNumber, range.insert.startColumn, range.insert.endLineNumber, range.insert.startColumn + insertText.length);
@@ -285,8 +293,9 @@ export class MainThreadChatAgents2 extends Disposable implements MainThreadChatA
 		}));
 	}
 
-	$unregisterAgentCompletionsProvider(handle: number): void {
+	$unregisterAgentCompletionsProvider(handle: number, id: string): void {
 		this._agentCompletionProviders.deleteAndDispose(handle);
+		this._agentIdsToCompletionProviders.deleteAndDispose(id);
 	}
 }
 

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -1241,8 +1241,8 @@ export interface IDynamicChatAgentProps {
 
 export interface MainThreadChatAgentsShape2 extends IDisposable {
 	$registerAgent(handle: number, extension: ExtensionIdentifier, id: string, metadata: IExtensionChatAgentMetadata, dynamicProps: IDynamicChatAgentProps | undefined): void;
-	$registerAgentCompletionsProvider(handle: number, triggerCharacters: string[]): void;
-	$unregisterAgentCompletionsProvider(handle: number): void;
+	$registerAgentCompletionsProvider(handle: number, id: string, triggerCharacters: string[]): void;
+	$unregisterAgentCompletionsProvider(handle: number, id: string): void;
 	$updateAgent(handle: number, metadataUpdate: IExtensionChatAgentMetadata): void;
 	$unregisterAgent(handle: number): void;
 	$handleProgressChunk(requestId: string, chunk: IChatProgressDto, handle?: number): Promise<number | void>;
@@ -1252,6 +1252,8 @@ export interface MainThreadChatAgentsShape2 extends IDisposable {
 
 export interface IChatAgentCompletionItem {
 	id: string;
+	fullName?: string;
+	icon?: string;
 	insertText?: string;
 	label: string | languages.CompletionItemLabel;
 	value: IChatRequestVariableValueDto;

--- a/src/vs/workbench/api/common/extHostChatAgents2.ts
+++ b/src/vs/workbench/api/common/extHostChatAgents2.ts
@@ -677,9 +677,9 @@ class ExtHostChatAgent {
 						throw new Error('triggerCharacters are required');
 					}
 
-					that._proxy.$registerAgentCompletionsProvider(that._handle, v.triggerCharacters);
+					that._proxy.$registerAgentCompletionsProvider(that._handle, that.id, v.triggerCharacters);
 				} else {
-					that._proxy.$unregisterAgentCompletionsProvider(that._handle);
+					that._proxy.$unregisterAgentCompletionsProvider(that._handle, that.id);
 				}
 			},
 			get participantVariableProvider() {

--- a/src/vs/workbench/api/common/extHostTypeConverters.ts
+++ b/src/vs/workbench/api/common/extHostTypeConverters.ts
@@ -2590,6 +2590,8 @@ export namespace ChatAgentCompletionItem {
 		return {
 			id: item.id,
 			label: item.label,
+			fullName: item.fullName,
+			icon: item.icon?.id,
 			value: item.values[0].value,
 			insertText: item.insertText,
 			detail: item.detail,

--- a/src/vs/workbench/api/common/extHostTypes.ts
+++ b/src/vs/workbench/api/common/extHostTypes.ts
@@ -4272,6 +4272,8 @@ export enum ChatVariableLevel {
 export class ChatCompletionItem implements vscode.ChatCompletionItem {
 	id: string;
 	label: string | CompletionItemLabel;
+	fullName?: string | undefined;
+	icon?: vscode.ThemeIcon;
 	insertText?: string;
 	values: vscode.ChatVariableValue[];
 	detail?: string;

--- a/src/vs/workbench/contrib/chat/browser/actions/chatContextActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatContextActions.ts
@@ -3,22 +3,26 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { CancellationToken } from 'vs/base/common/cancellation';
 import { Codicon } from 'vs/base/common/codicons';
 import { KeyCode, KeyMod } from 'vs/base/common/keyCodes';
 import { Schemas } from 'vs/base/common/network';
 import { ThemeIcon } from 'vs/base/common/themables';
 import { URI } from 'vs/base/common/uri';
 import { ServicesAccessor } from 'vs/editor/browser/editorExtensions';
+import { Command } from 'vs/editor/common/languages';
 import { localize, localize2 } from 'vs/nls';
 import { Action2, MenuId, registerAction2 } from 'vs/platform/actions/common/actions';
+import { ICommandService } from 'vs/platform/commands/common/commands';
 import { KeybindingWeight } from 'vs/platform/keybinding/common/keybindingsRegistry';
 import { AnythingQuickAccessProviderRunOptions } from 'vs/platform/quickinput/common/quickAccess';
 import { IQuickInputService, IQuickPickItem, QuickPickItem } from 'vs/platform/quickinput/common/quickInput';
 import { CHAT_CATEGORY } from 'vs/workbench/contrib/chat/browser/actions/chatActions';
 import { IChatWidget, IChatWidgetService } from 'vs/workbench/contrib/chat/browser/chat';
 import { SelectAndInsertFileAction } from 'vs/workbench/contrib/chat/browser/contrib/chatDynamicVariables';
-import { ChatAgentLocation } from 'vs/workbench/contrib/chat/common/chatAgents';
+import { ChatAgentLocation, IChatAgentService } from 'vs/workbench/contrib/chat/common/chatAgents';
 import { CONTEXT_CHAT_LOCATION, CONTEXT_IN_CHAT_INPUT } from 'vs/workbench/contrib/chat/common/chatContextKeys';
+import { ChatRequestAgentPart } from 'vs/workbench/contrib/chat/common/chatParserTypes';
 import { IChatVariablesService } from 'vs/workbench/contrib/chat/common/chatVariables';
 import { AnythingQuickAccessProvider } from 'vs/workbench/contrib/search/browser/anythingQuickAccess';
 
@@ -56,20 +60,28 @@ class AttachContextAction extends Action2 {
 		});
 	}
 
-	private _attachContext(widget: IChatWidget, ...picks: IQuickPickItem[]) {
-		widget?.attachContext(...picks.map((p) => ({
-			fullName: p.label,
-			icon: 'icon' in p && ThemeIcon.isThemeIcon(p.icon) ? p.icon : undefined,
-			name: 'name' in p && typeof p.name === 'string' ? p.name : p.label,
-			value: 'resource' in p && URI.isUri(p.resource) ? p.resource : undefined,
-			id: 'id' in p && typeof p.id === 'string' ? p.id :
-				'resource' in p && URI.isUri(p.resource) ? `${SelectAndInsertFileAction.Name}:${p.resource.toString()}` : ''
-		})));
+	private async _attachContext(widget: IChatWidget, commandService: ICommandService, ...picks: any[]) {
+		const toAttach = [];
+		for (const pick of picks) {
+			if (pick && typeof pick === 'object' && 'command' in pick) {
+				const selection = await commandService.executeCommand(pick.command.id, ...(pick.command.arguments ?? []));
+				if (selection) {
+					const qualifiedName = `${typeof pick.value === 'string' && pick.value.startsWith('#') ? pick.value.slice(1) : ''}${selection}`;
+
+					toAttach.push({ ...pick, isDynamic: pick.isDynamic, value: pick.value, name: qualifiedName, fullName: `$(${pick.icon.id}) ${selection}` });
+				}
+			} else {
+				toAttach.push({ ...pick, fullName: pick.label });
+			}
+		}
+		widget?.attachContext(...toAttach);
 	}
 
 	override async run(accessor: ServicesAccessor, ...args: any[]): Promise<void> {
 		const quickInputService = accessor.get(IQuickInputService);
+		const chatAgentService = accessor.get(IChatAgentService);
 		const chatVariablesService = accessor.get(IChatVariablesService);
+		const commandService = accessor.get(ICommandService);
 		const widgetService = accessor.get(IChatWidgetService);
 		const context: { widget?: IChatWidget } | undefined = args[0];
 		const widget = context?.widget ?? widgetService.lastFocusedWidget;
@@ -77,11 +89,24 @@ class AttachContextAction extends Action2 {
 			return;
 		}
 
-		const quickPickItems: (QuickPickItem & { name?: string; icon?: ThemeIcon })[] = [];
+		const quickPickItems: (QuickPickItem & { isDynamic?: boolean; name?: string; icon?: ThemeIcon; command?: Command; value?: unknown })[] = [];
 		for (const variable of chatVariablesService.getVariables()) {
 			if (variable.fullName) {
 				quickPickItems.push({ label: `${variable.icon ? `$(${variable.icon.id}) ` : ''}${variable.fullName}`, name: variable.name, id: variable.id, icon: variable.icon });
 			}
+		}
+
+		if (widget.viewModel?.sessionId) {
+			const agentPart = widget.parsedInput.parts.find((part): part is ChatRequestAgentPart => part instanceof ChatRequestAgentPart);
+			if (agentPart) {
+				const completions = await chatAgentService.getAgentCompletionItems(agentPart.agent.id, '', CancellationToken.None);
+				for (const variable of completions) {
+					if (variable.fullName) {
+						quickPickItems.push({ label: `${variable.icon ? `$(${variable.icon.id}) ` : ''}${variable.fullName}`, id: variable.id, command: variable.command, icon: variable.icon, value: variable.value, isDynamic: true });
+					}
+				}
+			}
+
 		}
 
 		if (chatVariablesService.hasVariable(SelectAndInsertFileAction.Name)) {
@@ -93,7 +118,7 @@ class AttachContextAction extends Action2 {
 			placeholder: localize('chatContext.attach.placeholder', 'Search attachments'),
 			providerOptions: <AnythingQuickAccessProviderRunOptions>{
 				handleAccept: (item: IQuickPickItem) => {
-					this._attachContext(widget, item);
+					this._attachContext(widget, commandService, item);
 				},
 				additionPicks: quickPickItems,
 				includeSymbols: false,

--- a/src/vs/workbench/contrib/chat/browser/chatVariables.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatVariables.ts
@@ -75,6 +75,8 @@ export class ChatVariablesService implements IChatVariablesService {
 							resolvedVariables[i] = { id: data.data.id, modelDescription: data.data.modelDescription, name: attachment.name, range: attachment.range, value, references };
 						}
 					}).catch(onUnexpectedExternalError));
+				} else if (attachment.isDynamic) {
+					resolvedVariables[i] = { id: attachment.id, name: attachment.name, value: attachment.value };
 				}
 			});
 

--- a/src/vs/workbench/contrib/chat/common/chatAgents.ts
+++ b/src/vs/workbench/contrib/chat/common/chatAgents.ts
@@ -15,7 +15,7 @@ import { observableValue } from 'vs/base/common/observableInternal/base';
 import { equalsIgnoreCase } from 'vs/base/common/strings';
 import { ThemeIcon } from 'vs/base/common/themables';
 import { URI } from 'vs/base/common/uri';
-import { ProviderResult } from 'vs/editor/common/languages';
+import { Command, ProviderResult } from 'vs/editor/common/languages';
 import { ContextKeyExpr, IContextKey, IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 import { ExtensionIdentifier } from 'vs/platform/extensions/common/extensions';
 import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
@@ -145,6 +145,14 @@ interface IChatAgentEntry {
 	impl?: IChatAgentImplementation;
 }
 
+export interface IChatAgentCompletionItem {
+	id: string;
+	fullName?: string;
+	icon?: ThemeIcon;
+	value: unknown;
+	command?: Command;
+}
+
 export interface IChatAgentService {
 	_serviceBrand: undefined;
 	/**
@@ -154,6 +162,8 @@ export interface IChatAgentService {
 	registerAgent(id: string, data: IChatAgentData): IDisposable;
 	registerAgentImplementation(id: string, agent: IChatAgentImplementation): IDisposable;
 	registerDynamicAgent(data: IChatAgentData, agentImpl: IChatAgentImplementation): IDisposable;
+	registerAgentCompletionProvider(id: string, provider: (query: string, token: CancellationToken) => Promise<IChatAgentCompletionItem[]>): IDisposable;
+	getAgentCompletionItems(id: string, query: string, token: CancellationToken): Promise<IChatAgentCompletionItem[]>;
 	invokeAgent(agent: string, request: IChatAgentRequest, progress: (part: IChatProgress) => void, history: IChatAgentHistoryEntry[], token: CancellationToken): Promise<IChatAgentResult>;
 	getFollowups(id: string, request: IChatAgentRequest, result: IChatAgentResult, history: IChatAgentHistoryEntry[], token: CancellationToken): Promise<IChatFollowup[]>;
 	getAgent(id: string): IChatAgentData | undefined;
@@ -253,6 +263,19 @@ export class ChatAgentService implements IChatAgentService {
 			this._agents = this._agents.filter(a => a !== agent);
 			this._onDidChangeAgents.fire(undefined);
 		});
+	}
+
+	private _agentCompletionProviders = new Map<string, (query: string, token: CancellationToken) => Promise<IChatAgentCompletionItem[]>>();
+
+	registerAgentCompletionProvider(id: string, provider: (query: string, token: CancellationToken) => Promise<IChatAgentCompletionItem[]>) {
+		this._agentCompletionProviders.set(id, provider);
+		return {
+			dispose: () => { this._agentCompletionProviders.delete(id); }
+		};
+	}
+
+	async getAgentCompletionItems(id: string, query: string, token: CancellationToken) {
+		return await this._agentCompletionProviders.get(id)?.(query, token) ?? [];
 	}
 
 	updateAgent(id: string, updateMetadata: IChatAgentMetadata): void {

--- a/src/vs/workbench/contrib/chat/common/chatModel.ts
+++ b/src/vs/workbench/contrib/chat/common/chatModel.ts
@@ -32,6 +32,7 @@ export interface IChatRequestVariableEntry {
 	range?: IOffsetRange;
 	value: IChatRequestVariableValue;
 	references?: IChatContentReference[];
+	isDynamic?: boolean;
 }
 
 export interface IChatRequestVariableData {

--- a/src/vs/workbench/contrib/chat/common/chatVariables.ts
+++ b/src/vs/workbench/contrib/chat/common/chatVariables.ts
@@ -56,6 +56,9 @@ export interface IChatVariablesService {
 export interface IDynamicVariable {
 	range: IRange;
 	id: string;
+	fullName?: string;
+	icon?: ThemeIcon;
+	prefix?: string;
 	modelDescription?: string;
 	data: IChatRequestVariableValue;
 }

--- a/src/vs/workbench/contrib/chat/test/common/voiceChatService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/voiceChatService.test.ts
@@ -12,7 +12,7 @@ import { ensureNoDisposablesAreLeakedInTestSuite } from 'vs/base/test/common/uti
 import { ProviderResult } from 'vs/editor/common/languages';
 import { ExtensionIdentifier } from 'vs/platform/extensions/common/extensions';
 import { MockContextKeyService } from 'vs/platform/keybinding/test/common/mockKeybindingService';
-import { ChatAgentLocation, IChatAgent, IChatAgentCommand, IChatAgentData, IChatAgentHistoryEntry, IChatAgentImplementation, IChatAgentMetadata, IChatAgentRequest, IChatAgentResult, IChatAgentService } from 'vs/workbench/contrib/chat/common/chatAgents';
+import { ChatAgentLocation, IChatAgent, IChatAgentCommand, IChatAgentCompletionItem, IChatAgentData, IChatAgentHistoryEntry, IChatAgentImplementation, IChatAgentMetadata, IChatAgentRequest, IChatAgentResult, IChatAgentService } from 'vs/workbench/contrib/chat/common/chatAgents';
 import { IChatModel } from 'vs/workbench/contrib/chat/common/chatModel';
 import { IChatProgress, IChatFollowup } from 'vs/workbench/contrib/chat/common/chatService';
 import { IVoiceChatSessionOptions, IVoiceChatTextEvent, VoiceChatService } from 'vs/workbench/contrib/chat/common/voiceChatService';
@@ -68,6 +68,8 @@ suite('VoiceChat', () => {
 		getAgentsByName(name: string): IChatAgentData[] { throw new Error('Method not implemented.'); }
 		updateAgent(id: string, updateMetadata: IChatAgentMetadata): void { throw new Error('Method not implemented.'); }
 		getAgentByFullyQualifiedId(id: string): IChatAgentData | undefined { throw new Error('Method not implemented.'); }
+		registerAgentCompletionProvider(id: string, provider: (query: string, token: CancellationToken) => Promise<IChatAgentCompletionItem[]>): IDisposable { throw new Error('Method not implemented.'); }
+		getAgentCompletionItems(id: string, query: string, token: CancellationToken): Promise<IChatAgentCompletionItem[]> { throw new Error('Method not implemented.'); }
 	}
 
 	class TestSpeechService implements ISpeechService {

--- a/src/vscode-dts/vscode.proposed.chatParticipantAdditions.d.ts
+++ b/src/vscode-dts/vscode.proposed.chatParticipantAdditions.d.ts
@@ -206,6 +206,8 @@ declare module 'vscode' {
 		id: string;
 		label: string | CompletionItemLabel;
 		values: ChatVariableValue[];
+		fullName?: string;
+		icon?: ThemeIcon;
 		insertText?: string;
 		detail?: string;
 		documentation?: string | MarkdownString;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

As a first pass, this PR enables invoking agent-specific variable providers by ID, displaying them in the Attach Context picker, and passing them through to the extension in the `ChatRequest`. 

There'll be a followup PR to implement a quick access provider for `kb`, which will require us to transition away from `ChatCompletionItem.command` and towards a `provide()` async function or similar.

cc @roblourens