### PR TITLE
testing: exploratory UI for followup actions

### DIFF
--- a/.vscode/extensions/vscode-selfhost-test-provider/src/extension.ts
+++ b/.vscode/extensions/vscode-selfhost-test-provider/src/extension.ts
@@ -25,7 +25,7 @@ const TEST_FILE_PATTERN = 'src/vs/**/*.{test,integrationTest}.ts';
 
 const getWorkspaceFolderForTestFile = (uri: vscode.Uri) =>
 	(uri.path.endsWith('.test.ts') || uri.path.endsWith('.integrationTest.ts')) &&
-	uri.path.includes('/src/vs/')
+		uri.path.includes('/src/vs/')
 		? vscode.workspace.getWorkspaceFolder(uri)
 		: undefined;
 
@@ -40,6 +40,18 @@ type FileChangeEvent = { uri: vscode.Uri; removed: boolean };
 export async function activate(context: vscode.ExtensionContext) {
 	const ctrl = vscode.tests.createTestController('selfhost-test-controller', 'VS Code Tests');
 	const fileChangedEmitter = new vscode.EventEmitter<FileChangeEvent>();
+
+	// todo@connor4312: tidy this up and make it work
+	// context.subscriptions.push(vscode.tests.registerTestFollowupProvider({
+	// 	async provideFollowup(result, test, taskIndex, messageIndex, token) {
+	// 		await new Promise(r => setTimeout(r, 2000));
+	// 		return [{
+	// 			title: '$(sparkle) Ask copilot for help',
+	// 			command: 'asdf'
+	// 		}];
+	// 	},
+	// }));
+
 
 	ctrl.resolveHandler = async test => {
 		if (!test) {
@@ -62,7 +74,7 @@ export async function activate(context: vscode.ExtensionContext) {
 	});
 
 	const createRunHandler = (
-		runnerCtor: { new (folder: vscode.WorkspaceFolder): VSCodeTestRunner },
+		runnerCtor: { new(folder: vscode.WorkspaceFolder): VSCodeTestRunner },
 		kind: vscode.TestRunProfileKind,
 		args: string[] = []
 	) => {

--- a/.vscode/extensions/vscode-selfhost-test-provider/src/failingDeepStrictEqualAssertFixer.ts
+++ b/.vscode/extensions/vscode-selfhost-test-provider/src/failingDeepStrictEqualAssertFixer.ts
@@ -71,8 +71,6 @@ export class FailingDeepStrictEqualAssertFixer {
 				},
 			})
 		);
-
-		tests.testResults;
 	}
 
 	dispose() {
@@ -99,15 +97,15 @@ const formatJsonValue = (value: unknown) => {
 		context => (node: ts.Node) => {
 			const visitor = (node: ts.Node): ts.Node =>
 				ts.isPropertyAssignment(node) &&
-				ts.isStringLiteralLike(node.name) &&
-				identifierLikeRe.test(node.name.text)
+					ts.isStringLiteralLike(node.name) &&
+					identifierLikeRe.test(node.name.text)
 					? ts.factory.createPropertyAssignment(
-							ts.factory.createIdentifier(node.name.text),
-							ts.visitNode(node.initializer, visitor) as ts.Expression
-					  )
+						ts.factory.createIdentifier(node.name.text),
+						ts.visitNode(node.initializer, visitor) as ts.Expression
+					)
 					: ts.isStringLiteralLike(node) && node.text === '[undefined]'
-					? ts.factory.createIdentifier('undefined')
-					: ts.visitEachChild(node, visitor, context);
+						? ts.factory.createIdentifier('undefined')
+						: ts.visitEachChild(node, visitor, context);
 
 			return ts.visitNode(node, visitor);
 		},
@@ -190,7 +188,7 @@ class StrictEqualAssertion {
 		return undefined;
 	}
 
-	constructor(private readonly expression: ts.CallExpression) {}
+	constructor(private readonly expression: ts.CallExpression) { }
 
 	/** Gets the expected value */
 	public get expectedValue(): ts.Expression | undefined {

--- a/src/vs/workbench/api/browser/mainThreadTesting.ts
+++ b/src/vs/workbench/api/browser/mainThreadTesting.ts
@@ -18,13 +18,13 @@ import { TestId } from 'vs/workbench/contrib/testing/common/testId';
 import { ITestProfileService } from 'vs/workbench/contrib/testing/common/testProfileService';
 import { LiveTestResult } from 'vs/workbench/contrib/testing/common/testResult';
 import { ITestResultService } from 'vs/workbench/contrib/testing/common/testResultService';
-import { IMainThreadTestController, ITestRootProvider, ITestService } from 'vs/workbench/contrib/testing/common/testService';
+import { IMainThreadTestController, ITestService } from 'vs/workbench/contrib/testing/common/testService';
 import { CoverageDetails, ExtensionRunTestsRequest, IFileCoverage, ITestItem, ITestMessage, ITestRunProfile, ITestRunTask, ResolvedTestRunRequest, TestResultState, TestRunProfileBitset, TestsDiffOp } from 'vs/workbench/contrib/testing/common/testTypes';
 import { IExtHostContext, extHostNamedCustomer } from 'vs/workbench/services/extensions/common/extHostCustomers';
 import { ExtHostContext, ExtHostTestingShape, ILocationDto, ITestControllerPatch, MainContext, MainThreadTestingShape } from '../common/extHost.protocol';
 
 @extHostNamedCustomer(MainContext.MainThreadTesting)
-export class MainThreadTesting extends Disposable implements MainThreadTestingShape, ITestRootProvider {
+export class MainThreadTesting extends Disposable implements MainThreadTestingShape {
 	private readonly proxy: ExtHostTestingShape;
 	private readonly diffListener = this._register(new MutableDisposable());
 	private readonly testProviderRegistrations = new Map<string, {
@@ -233,6 +233,9 @@ export class MainThreadTesting extends Disposable implements MainThreadTestingSh
 			runTests: (reqs, token) => this.proxy.$runControllerTests(reqs, token),
 			startContinuousRun: (reqs, token) => this.proxy.$startContinuousRun(reqs, token),
 			expandTest: (testId, levels) => this.proxy.$expandTest(testId, isFinite(levels) ? levels : -1),
+			provideTestFollowups: (req, token) => this.proxy.$provideTestFollowups(req, token),
+			executeTestFollowup: id => this.proxy.$executeTestFollowup(id),
+			disposeTestFollowups: ids => this.proxy.$disposeTestFollowups(ids),
 		};
 
 		disposable.add(toDisposable(() => this.testProfiles.removeProfile(controllerId)));

--- a/src/vs/workbench/api/common/extHost.api.impl.ts
+++ b/src/vs/workbench/api/common/extHost.api.impl.ts
@@ -453,6 +453,10 @@ export function createApiFactoryAndRegisterActors(accessor: ServicesAccessor): I
 				checkProposedApiEnabled(extension, 'testObserver');
 				return extHostTesting.runTests(provider);
 			},
+			registerTestFollowupProvider(provider) {
+				checkProposedApiEnabled(extension, 'testObserver');
+				return extHostTesting.registerTestFollowupProvider(provider);
+			},
 			get onDidChangeTestResults() {
 				checkProposedApiEnabled(extension, 'testObserver');
 				return _asExtensionEvent(extHostTesting.onResultsChanged);

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -65,7 +65,7 @@ import { InputValidationType } from 'vs/workbench/contrib/scm/common/scm';
 import { IWorkspaceSymbol, NotebookPriorityInfo } from 'vs/workbench/contrib/search/common/search';
 import { IRawClosedNotebookFileMatch } from 'vs/workbench/contrib/search/common/searchNotebookHelpers';
 import { IKeywordRecognitionEvent, ISpeechProviderMetadata, ISpeechToTextEvent, ITextToSpeechEvent } from 'vs/workbench/contrib/speech/common/speechService';
-import { CoverageDetails, ExtensionRunTestsRequest, ICallProfileRunHandler, IFileCoverage, ISerializedTestResults, IStartControllerTests, ITestItem, ITestMessage, ITestRunProfile, ITestRunTask, ResolvedTestRunRequest, TestResultState, TestsDiffOp } from 'vs/workbench/contrib/testing/common/testTypes';
+import { CoverageDetails, ExtensionRunTestsRequest, ICallProfileRunHandler, IFileCoverage, ISerializedTestResults, IStartControllerTests, ITestItem, ITestMessage, ITestRunProfile, ITestRunTask, ResolvedTestRunRequest, TestMessageFollowupRequest, TestMessageFollowupResponse, TestResultState, TestsDiffOp } from 'vs/workbench/contrib/testing/common/testTypes';
 import { Timeline, TimelineChangeEvent, TimelineOptions, TimelineProviderDescriptor } from 'vs/workbench/contrib/timeline/common/timeline';
 import { TypeHierarchyItem } from 'vs/workbench/contrib/typeHierarchy/common/typeHierarchy';
 import { RelatedInformationResult, RelatedInformationType } from 'vs/workbench/services/aiRelatedInformation/common/aiRelatedInformation';
@@ -2703,8 +2703,6 @@ export interface ExtHostTestingShape {
 	$cancelExtensionTestRun(runId: string | undefined): void;
 	/** Handles a diff of tests, as a result of a subscribeToDiffs() call */
 	$acceptDiff(diff: TestsDiffOp.Serialized[]): void;
-	/** Publishes that a test run finished. */
-	$publishTestResults(results: ISerializedTestResults[]): void;
 	/** Expands a test item's children, by the given number of levels. */
 	$expandTest(testId: string, levels: number): Promise<void>;
 	/** Requests coverage details for a test run. Errors if not available. */
@@ -2719,6 +2717,17 @@ export interface ExtHostTestingShape {
 	$syncTests(): Promise<void>;
 	/** Sets the active test run profiles */
 	$setDefaultRunProfiles(profiles: Record</* controller id */string, /* profile id */ number[]>): void;
+
+	// --- test results:
+
+	/** Publishes that a test run finished. */
+	$publishTestResults(results: ISerializedTestResults[]): void;
+	/** Requests followup actions for a test (failure) message */
+	$provideTestFollowups(req: TestMessageFollowupRequest, token: CancellationToken): Promise<TestMessageFollowupResponse[]>;
+	/** Actions a followup actions for a test (failure) message */
+	$executeTestFollowup(id: number): Promise<void>;
+	/** Disposes followup actions for a test (failure) message */
+	$disposeTestFollowups(id: number[]): void;
 }
 
 export interface ExtHostLocalizationShape {

--- a/src/vs/workbench/contrib/testing/browser/media/testing.css
+++ b/src/vs/workbench/contrib/testing/browser/media/testing.css
@@ -267,6 +267,48 @@
 	cursor: pointer;
 }
 
+.testing-followup-action {
+	position: absolute;
+	top: 100%;
+	left: 22px;
+	right: 22px;
+	margin-top: -25px;
+	line-height: 25px;
+	overflow: hidden;
+	pointer-events: none;
+	background: linear-gradient(transparent, var(--vscode-peekViewEditor-background) 50%);
+
+	&.animated {
+		animation: fadeIn 150ms ease-out;
+	}
+
+	> a {
+		display: flex;
+		align-items: center;
+		gap: 4px;
+		cursor: pointer;
+		pointer-events: auto;
+		width: fit-content;
+
+		&, .codicon {
+			color: var(--vscode-textLink-foreground);
+		}
+
+		&:hover {
+			color: var(--vscode-textLink-activeForeground);
+		}
+
+		&[aria-disabled="true"] {
+			color: inherit;
+			cursor: default;
+
+			.codicon {
+				color: inherit;
+			}
+		}
+	}
+}
+
 /** -- filter  */
 .monaco-action-bar.testing-filter-action-bar {
 	flex-shrink: 0;

--- a/src/vs/workbench/contrib/testing/common/testService.ts
+++ b/src/vs/workbench/contrib/testing/common/testService.ts
@@ -12,7 +12,7 @@ import { URI } from 'vs/base/common/uri';
 import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
 import { IUriIdentityService } from 'vs/platform/uriIdentity/common/uriIdentity';
 import { IObservableValue, MutableObservableValue } from 'vs/workbench/contrib/testing/common/observableValue';
-import { AbstractIncrementalTestCollection, ICallProfileRunHandler, IncrementalTestCollectionItem, InternalTestItem, ITestItemContext, ResolvedTestRunRequest, IStartControllerTests, IStartControllerTestsResult, TestItemExpandState, TestRunProfileBitset, TestsDiff } from 'vs/workbench/contrib/testing/common/testTypes';
+import { AbstractIncrementalTestCollection, ICallProfileRunHandler, IncrementalTestCollectionItem, InternalTestItem, ITestItemContext, ResolvedTestRunRequest, IStartControllerTests, IStartControllerTestsResult, TestItemExpandState, TestRunProfileBitset, TestsDiff, TestMessageFollowupResponse, TestMessageFollowupRequest } from 'vs/workbench/contrib/testing/common/testTypes';
 import { TestExclusions } from 'vs/workbench/contrib/testing/common/testExclusions';
 import { TestId } from 'vs/workbench/contrib/testing/common/testId';
 import { ITestResult } from 'vs/workbench/contrib/testing/common/testResult';
@@ -29,6 +29,9 @@ export interface IMainThreadTestController {
 	expandTest(id: string, levels: number): Promise<void>;
 	startContinuousRun(request: ICallProfileRunHandler[], token: CancellationToken): Promise<IStartControllerTestsResult[]>;
 	runTests(request: IStartControllerTests[], token: CancellationToken): Promise<IStartControllerTestsResult[]>;
+	provideTestFollowups(req: TestMessageFollowupRequest, token: CancellationToken): Promise<TestMessageFollowupResponse[]>;
+	executeTestFollowup(id: number): Promise<void>;
+	disposeTestFollowups(ids: number[]): void;
 }
 
 export interface IMainThreadTestCollection extends AbstractIncrementalTestCollection<IncrementalTestCollectionItem> {
@@ -214,14 +217,6 @@ export const testsUnderUri = async function* (testService: ITestService, ident: 
 };
 
 /**
- * An instance of the RootProvider should be registered for each extension
- * host.
- */
-export interface ITestRootProvider {
-	// todo: nothing, yet
-}
-
-/**
  * A run request that expresses the intent of the request and allows the
  * test service to resolve the specifics of the group.
  */
@@ -234,6 +229,15 @@ export interface AmbiguousRunTestsRequest {
 	exclude?: InternalTestItem[];
 	/** Whether this was triggered from an auto run. */
 	continuous?: boolean;
+}
+
+export interface ITestFollowup {
+	message: string;
+	execute(): Promise<void>;
+}
+
+export interface ITestFollowups extends IDisposable {
+	followups: ITestFollowup[];
 }
 
 export interface ITestService {
@@ -303,6 +307,11 @@ export interface ITestService {
 	 * Requests that tests be executed.
 	 */
 	runResolvedTests(req: ResolvedTestRunRequest, token?: CancellationToken): Promise<ITestResult>;
+
+	/**
+	 * Provides followup actions for a test run.
+	 */
+	provideTestFollowups(req: TestMessageFollowupRequest, token: CancellationToken): Promise<ITestFollowups>;
 
 	/**
 	 * Ensures the test diff from the remote ext host is flushed and waits for

--- a/src/vs/workbench/contrib/testing/common/testServiceImpl.ts
+++ b/src/vs/workbench/contrib/testing/common/testServiceImpl.ts
@@ -27,8 +27,8 @@ import { TestingContextKeys } from 'vs/workbench/contrib/testing/common/testingC
 import { canUseProfileWithTest, ITestProfileService } from 'vs/workbench/contrib/testing/common/testProfileService';
 import { ITestResult } from 'vs/workbench/contrib/testing/common/testResult';
 import { ITestResultService } from 'vs/workbench/contrib/testing/common/testResultService';
-import { AmbiguousRunTestsRequest, IMainThreadTestController, ITestService } from 'vs/workbench/contrib/testing/common/testService';
-import { ResolvedTestRunRequest, TestDiffOpType, TestsDiff } from 'vs/workbench/contrib/testing/common/testTypes';
+import { AmbiguousRunTestsRequest, IMainThreadTestController, ITestFollowups, ITestService } from 'vs/workbench/contrib/testing/common/testService';
+import { ResolvedTestRunRequest, TestDiffOpType, TestMessageFollowupRequest, TestsDiff } from 'vs/workbench/contrib/testing/common/testTypes';
 import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
 
 export class TestService extends Disposable implements ITestService {
@@ -262,6 +262,32 @@ export class TestService extends Disposable implements ITestService {
 			this.uiRunningTests.delete(result.id);
 			result.markComplete();
 		}
+	}
+
+	/**
+	 * @inheritdoc
+	 */
+	public async provideTestFollowups(req: TestMessageFollowupRequest, token: CancellationToken): Promise<ITestFollowups> {
+		const reqs = await Promise.all([...this.testControllers.values()]
+			.map(async ctrl => ({ ctrl, followups: await ctrl.provideTestFollowups(req, token) })));
+
+		const followups: ITestFollowups = {
+			followups: reqs.flatMap(({ ctrl, followups }) => followups.map(f => ({
+				message: f.title,
+				execute: () => ctrl.executeTestFollowup(f.id)
+			}))),
+			dispose: () => {
+				for (const { ctrl, followups } of reqs) {
+					ctrl.disposeTestFollowups(followups.map(f => f.id));
+				}
+			}
+		};
+
+		if (token.isCancellationRequested) {
+			followups.dispose();
+		}
+
+		return followups;
 	}
 
 	/**

--- a/src/vs/workbench/contrib/testing/common/testTypes.ts
+++ b/src/vs/workbench/contrib/testing/common/testTypes.ts
@@ -474,6 +474,20 @@ export const applyTestItemUpdate = (internal: InternalTestItem | ITestItemUpdate
 	}
 };
 
+/** Request to an ext host to get followup messages for a test failure. */
+export interface TestMessageFollowupRequest {
+	resultId: string;
+	extId: string;
+	taskIndex: number;
+	messageIndex: number;
+}
+
+/** Request to an ext host to get followup messages for a test failure. */
+export interface TestMessageFollowupResponse {
+	id: number;
+	title: string;
+}
+
 /**
  * Test result item used in the main thread.
  */

--- a/src/vscode-dts/vscode.proposed.testObserver.d.ts
+++ b/src/vscode-dts/vscode.proposed.testObserver.d.ts
@@ -16,6 +16,11 @@ declare module 'vscode' {
 		export function runTests(run: TestRunRequest, token?: CancellationToken): Thenable<void>;
 
 		/**
+		 * Registers a provider that can provide follow-up actions for a test failure.
+		 */
+		export function registerTestFollowupProvider(provider: TestFollowupProvider): Disposable;
+
+		/**
 		 * Returns an observer that watches and can request tests.
 		 */
 		export function createTestObserver(): TestObserver;
@@ -29,6 +34,10 @@ declare module 'vscode' {
 		 * Event that fires when the {@link testResults} array is updated.
 		 */
 		export const onDidChangeTestResults: Event<void>;
+	}
+
+	export interface TestFollowupProvider {
+		provideFollowup(result: TestRunResult, test: TestResultSnapshot, taskIndex: number, messageIndex: number, token: CancellationToken): ProviderResult<Command[]>;
 	}
 
 	export interface TestObserver {


### PR DESCRIPTION
This adds an API that extensions can use to contribute 'followup'
actions around test messages. Here just a dummy hello world using
copilot, but extensions could have any action here, such as actions to
update snapshots if a test failed:

![](https://memes.peet.io/img/24-05-c1f3e073-a2da-4f16-a033-c8f7e5cd4864.png)

Implemented using a simple provider API.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
