### PR TITLE
Disable VS Code file watching for yarn pnp

### DIFF
--- a/extensions/typescript-language-features/src/tsServer/api.ts
+++ b/extensions/typescript-language-features/src/tsServer/api.ts
@@ -80,4 +80,8 @@ export class API {
 	public lt(other: API): boolean {
 		return !this.gte(other);
 	}
+
+	public isYarnPnp(): boolean {
+		return this.fullVersionString.includes('-sdk');
+	}
 }

--- a/extensions/typescript-language-features/src/tsServer/spawner.ts
+++ b/extensions/typescript-language-features/src/tsServer/spawner.ts
@@ -271,7 +271,11 @@ export class TypeScriptServerSpawner {
 
 		args.push('--noGetErrOnBackgroundUpdate');
 
-		if (apiVersion.gte(API.v544) && configuration.useVsCodeWatcher) {
+		if (
+			apiVersion.gte(API.v544)
+			&& configuration.useVsCodeWatcher
+			&& !apiVersion.isYarnPnp() // Disable for yarn pnp as it currently breaks with the VS Code watcher
+		) {
 			args.push('--canUseWatchEvents');
 		}
 


### PR DESCRIPTION
cc @bpasero 

Also warns users when TS Server crashes with a patched Yarn PnP version as this is a very common source of crashes