### PR TITLE
Enable roaming of inflight chat requests

### DIFF
--- a/src/vs/base/common/lifecycle.ts
+++ b/src/vs/base/common/lifecycle.ts
@@ -777,6 +777,16 @@ export class DisposableMap<K, V extends IDisposable = IDisposable> implements ID
 		this._store.delete(key);
 	}
 
+	/**
+	 * Delete the value stored for `key` from this map but return it. The caller is
+	 * responsible for disposing of the value.
+	 */
+	deleteAndLeak(key: K): V | undefined {
+		const value = this._store.get(key);
+		this._store.delete(key);
+		return value;
+	}
+
 	keys(): IterableIterator<K> {
 		return this._store.keys();
 	}

--- a/src/vs/workbench/contrib/chat/common/chatService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService.ts
@@ -331,7 +331,7 @@ export interface IChatService {
 	sendRequest(sessionId: string, message: string, options?: IChatSendRequestOptions): Promise<IChatSendRequestData | undefined>;
 
 	resendRequest(request: IChatRequestModel, options?: IChatSendRequestOptions): Promise<void>;
-
+	adoptRequest(sessionId: string, request: IChatRequestModel): Promise<void>;
 	removeRequest(sessionid: string, requestId: string): Promise<void>;
 	cancelCurrentRequestForSession(sessionId: string): void;
 	clearSession(sessionId: string): void;

--- a/src/vs/workbench/contrib/chat/test/common/chatModel.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/chatModel.test.ts
@@ -121,6 +121,36 @@ suite('ChatModel', () => {
 		model.removeRequest(requests[0].id);
 		assert.strictEqual(model.getRequests().length, 0);
 	});
+
+	test('adoptRequest', async function () {
+		const model1 = testDisposables.add(instantiationService.createInstance(ChatModel, undefined, ChatAgentLocation.Editor));
+		const model2 = testDisposables.add(instantiationService.createInstance(ChatModel, undefined, ChatAgentLocation.Panel));
+
+		model1.startInitialize();
+		model1.initialize(undefined);
+
+		model2.startInitialize();
+		model2.initialize(undefined);
+
+		const text = 'hello';
+		const request1 = model1.addRequest({ text, parts: [new ChatRequestTextPart(new OffsetRange(0, text.length), new Range(1, text.length, 1, text.length), text)] }, { variables: [] }, 0);
+
+		assert.strictEqual(model1.getRequests().length, 1);
+		assert.strictEqual(model2.getRequests().length, 0);
+		assert.ok(request1.session === model1);
+		assert.ok(request1.response?.session === model1);
+
+		model2.adoptRequest(request1);
+
+		assert.strictEqual(model1.getRequests().length, 0);
+		assert.strictEqual(model2.getRequests().length, 1);
+		assert.ok(request1.session === model2);
+		assert.ok(request1.response?.session === model2);
+
+		model2.acceptResponseProgress(request1, { content: new MarkdownString('Hello'), kind: 'markdownContent' });
+
+		assert.strictEqual(request1.response.response.asString(), 'Hello');
+	});
 });
 
 suite('Response', () => {

--- a/src/vs/workbench/contrib/chat/test/common/mockChatService.ts
+++ b/src/vs/workbench/contrib/chat/test/common/mockChatService.ts
@@ -46,6 +46,9 @@ export class MockChatService implements IChatService {
 	resendRequest(request: IChatRequestModel, options?: IChatSendRequestOptions | undefined): Promise<void> {
 		throw new Error('Method not implemented.');
 	}
+	adoptRequest(sessionId: string, request: IChatRequestModel): Promise<void> {
+		throw new Error('Method not implemented.');
+	}
 	removeRequest(sessionid: string, requestId: string): Promise<void> {
 		throw new Error('Method not implemented.');
 	}

--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatActions.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatActions.ts
@@ -29,6 +29,7 @@ import { registerIcon } from 'vs/platform/theme/common/iconRegistry';
 import { IPreferencesService } from 'vs/workbench/services/preferences/common/preferences';
 import { ILogService } from 'vs/platform/log/common/log';
 import { IChatService } from 'vs/workbench/contrib/chat/common/chatService';
+import { CONTEXT_CHAT_REQUEST_IN_PROGRESS } from 'vs/workbench/contrib/chat/common/chatContextKeys';
 
 CommandsRegistry.registerCommandAlias('interactiveEditor.start', 'inlineChat.start');
 CommandsRegistry.registerCommandAlias('interactive.acceptChanges', ACTION_ACCEPT_CHANGES);
@@ -482,15 +483,14 @@ export class ViewInChatAction extends AbstractInlineChatAction {
 			icon: Codicon.commentDiscussion,
 			precondition: CTX_INLINE_CHAT_VISIBLE,
 			menu: {
-				id: MENU_INLINE_CHAT_WIDGET_STATUS,
-				when: CTX_INLINE_CHAT_RESPONSE_TYPES.isEqualTo(InlineChatResponseTypes.OnlyMessages),
-				group: '0_main',
-				order: 1
+				id: MENU_INLINE_CHAT_WIDGET,
+				group: 'navigation',
+				order: 5
 			}
 		});
 	}
-	override runInlineChatCommand(_accessor: ServicesAccessor, ctrl: InlineChatController, _editor: ICodeEditor, ..._args: any[]): void {
-		ctrl.viewInChat();
+	override runInlineChatCommand(_accessor: ServicesAccessor, ctrl: InlineChatController, _editor: ICodeEditor, ..._args: any[]) {
+		return ctrl.viewInChat();
 	}
 }
 
@@ -501,6 +501,7 @@ export class RerunAction extends AbstractInlineChatAction {
 			title: localize2('chat.rerun.label', "Rerun Request"),
 			f1: false,
 			icon: Codicon.refresh,
+			precondition: CONTEXT_CHAT_REQUEST_IN_PROGRESS.negate(),
 			menu: {
 				id: MENU_INLINE_CHAT_WIDGET_STATUS,
 				group: '0_main',

--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatSessionServiceImpl.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatSessionServiceImpl.ts
@@ -154,7 +154,6 @@ export class InlineChatSessionServiceImpl implements IInlineChatSessionService {
 				return {
 					command: agentCommand.name,
 					detail: agentCommand.description,
-					refer: agentCommand.name === 'explain' // TODO@jrieken @joyceerhl this should be cleaned up
 				} satisfies IInlineChatSlashCommand;
 			})
 		};

--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatZoneWidget.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatZoneWidget.ts
@@ -14,7 +14,7 @@ import { ZoneWidget } from 'vs/editor/contrib/zoneWidget/browser/zoneWidget';
 import { localize } from 'vs/nls';
 import { IContextKey, IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
-import { ACTION_ACCEPT_CHANGES, ACTION_REGENERATE_RESPONSE, ACTION_TOGGLE_DIFF, ACTION_VIEW_IN_CHAT, CTX_INLINE_CHAT_OUTER_CURSOR_POSITION, EditMode, InlineChatConfigKeys, MENU_INLINE_CHAT_WIDGET, MENU_INLINE_CHAT_WIDGET_STATUS } from 'vs/workbench/contrib/inlineChat/common/inlineChat';
+import { ACTION_ACCEPT_CHANGES, ACTION_REGENERATE_RESPONSE, ACTION_TOGGLE_DIFF, CTX_INLINE_CHAT_OUTER_CURSOR_POSITION, EditMode, InlineChatConfigKeys, MENU_INLINE_CHAT_WIDGET, MENU_INLINE_CHAT_WIDGET_STATUS } from 'vs/workbench/contrib/inlineChat/common/inlineChat';
 import { EditorBasedInlineChatWidget } from './inlineChatWidget';
 import { MenuId } from 'vs/platform/actions/common/actions';
 import { isEqual } from 'vs/base/common/resources';
@@ -53,9 +53,9 @@ export class InlineChatZoneWidget extends ZoneWidget {
 				menu: MENU_INLINE_CHAT_WIDGET_STATUS,
 				options: {
 					buttonConfigProvider: action => {
-						if (action.id === ACTION_REGENERATE_RESPONSE || action.id === ACTION_TOGGLE_DIFF) {
-							return { showIcon: true, showLabel: false, isSecondary: true };
-						} else if (action.id === ACTION_VIEW_IN_CHAT || action.id === ACTION_ACCEPT_CHANGES) {
+						if (new Set([ACTION_REGENERATE_RESPONSE, ACTION_TOGGLE_DIFF]).has(action.id)) {
+							return { isSecondary: true, showIcon: true, showLabel: false };
+						} else if (action.id === ACTION_ACCEPT_CHANGES) {
 							return { isSecondary: false };
 						} else {
 							return { isSecondary: true };

--- a/src/vs/workbench/contrib/inlineChat/common/inlineChat.ts
+++ b/src/vs/workbench/contrib/inlineChat/common/inlineChat.ts
@@ -23,8 +23,6 @@ import { ExtensionIdentifier } from 'vs/platform/extensions/common/extensions';
 export interface IInlineChatSlashCommand {
 	command: string;
 	detail?: string;
-	refer?: boolean;
-	executeImmediately?: boolean;
 }
 
 export interface IInlineChatSession {


### PR DESCRIPTION
This enables to remove the special handling for `/explain`

- fixes https://github.com/microsoft/vscode-copilot/issues/2192
- fixes https://github.com/microsoft/vscode/issues/208706 because inline chat now closes on "view in chat"
- fixes https://github.com/microsoft/vscode-copilot/issues/5288