### PR TITLE
Making API `editorHoverVerbosityLevel` use `verbosityLevel` instead of `action`

### DIFF
--- a/src/vs/editor/common/languages.ts
+++ b/src/vs/editor/common/languages.ts
@@ -202,9 +202,9 @@ export interface HoverContext<THover = Hover> {
 
 export interface HoverVerbosityRequest<THover = Hover> {
 	/**
-	 * Whether to increase or decrease the hover's verbosity
+	 * The delta by which to increase/decrease the hover verbosity level
 	 */
-	action: HoverVerbosityAction;
+	verbosityDelta: number;
 	/**
 	 * The previous hover for the same position
 	 */

--- a/src/vs/editor/contrib/hover/browser/markdownHoverParticipant.ts
+++ b/src/vs/editor/contrib/hover/browser/markdownHoverParticipant.ts
@@ -5,7 +5,7 @@
 
 import * as dom from 'vs/base/browser/dom';
 import { asArray, compareBy, numberComparator } from 'vs/base/common/arrays';
-import { CancellationToken } from 'vs/base/common/cancellation';
+import { CancellationToken, CancellationTokenSource } from 'vs/base/common/cancellation';
 import { IMarkdownString, isEmptyMarkdownString, MarkdownString } from 'vs/base/common/htmlContent';
 import { Disposable, DisposableStore, IDisposable, toDisposable } from 'vs/base/common/lifecycle';
 import { MarkdownRenderer } from 'vs/editor/browser/widget/markdownRenderer/browser/markdownRenderer';
@@ -212,6 +212,7 @@ class MarkdownRenderedHoverParts extends Disposable {
 
 	private _renderedHoverParts: RenderedHoverPart[];
 	private _hoverFocusInfo: FocusedHoverInfo = { hoverPartIndex: -1, focusRemains: false };
+	private _ongoingHoverOperations: Map<HoverProvider, { verbosityDelta: number; tokenSource: CancellationTokenSource }> = new Map();
 
 	constructor(
 		hoverParts: MarkdownHover[], // we own!
@@ -351,31 +352,44 @@ class MarkdownRenderedHoverParts extends Disposable {
 		if (!hoverRenderedPart || !hoverRenderedPart.hoverSource?.supportsVerbosityAction(action)) {
 			return;
 		}
-		const hoverPosition = hoverRenderedPart.hoverSource.hoverPosition;
-		const hoverProvider = hoverRenderedPart.hoverSource.hoverProvider;
-		const hover = hoverRenderedPart.hoverSource.hover;
-		const hoverContext: HoverContext = { verbosityRequest: { action, previousHover: hover } };
-
-		let newHover: Hover | null | undefined;
-		try {
-			newHover = await Promise.resolve(hoverProvider.provideHover(model, hoverPosition, CancellationToken.None, hoverContext));
-		} catch (e) {
-			onUnexpectedExternalError(e);
-		}
+		const hoverSource = hoverRenderedPart.hoverSource;
+		const newHover = await this._fetchHover(hoverSource, model, action);
 		if (!newHover) {
 			return;
 		}
-
-		const hoverSource = new HoverSource(newHover, hoverProvider, hoverPosition);
-		const renderedHoverPart = this._renderHoverPart(
+		const newHoverSource = new HoverSource(newHover, hoverSource.hoverProvider, hoverSource.hoverPosition);
+		const newHoverRenderedPart = this._renderHoverPart(
 			hoverFocusedPartIndex,
 			newHover.contents,
-			hoverSource,
+			newHoverSource,
 			this._onFinishedRendering
 		);
-		this._replaceRenderedHoverPartAtIndex(hoverFocusedPartIndex, renderedHoverPart);
+		this._replaceRenderedHoverPartAtIndex(hoverFocusedPartIndex, newHoverRenderedPart);
 		this._focusOnHoverPartWithIndex(hoverFocusedPartIndex);
 		this._onFinishedRendering();
+	}
+
+	private async _fetchHover(hoverSource: HoverSource, model: ITextModel, action: HoverVerbosityAction): Promise<Hover | null | undefined> {
+		let verbosityDelta = action === HoverVerbosityAction.Increase ? 1 : -1;
+		const provider = hoverSource.hoverProvider;
+		const doesOngoingOperationExist = this._ongoingHoverOperations.has(provider);
+		if (doesOngoingOperationExist) {
+			const ongoingOperation = this._ongoingHoverOperations.get(provider)!;
+			ongoingOperation.tokenSource.cancel();
+			verbosityDelta += ongoingOperation.verbosityDelta;
+		}
+		const tokenSource = new CancellationTokenSource();
+		this._ongoingHoverOperations.set(provider, { verbosityDelta, tokenSource });
+		const context: HoverContext = { verbosityRequest: { verbosityDelta, previousHover: hoverSource.hover } };
+		let hover: Hover | null | undefined;
+		try {
+			hover = await Promise.resolve(provider.provideHover(model, hoverSource.hoverPosition, tokenSource.token, context));
+		} catch (e) {
+			onUnexpectedExternalError(e);
+		}
+		tokenSource.dispose();
+		this._ongoingHoverOperations.delete(provider);
+		return hover;
 	}
 
 	private _replaceRenderedHoverPartAtIndex(index: number, renderedHoverPart: RenderedHoverPart): void {

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -6885,9 +6885,9 @@ declare namespace monaco.languages {
 
 	export interface HoverVerbosityRequest<THover = Hover> {
 		/**
-		 * Whether to increase or decrease the hover's verbosity
+		 * The delta by which to increase/decrease the hover verbosity level
 		 */
-		action: HoverVerbosityAction;
+		verbosityDelta: number;
 		/**
 		 * The previous hover for the same position
 		 */

--- a/src/vs/workbench/api/browser/mainThreadLanguageFeatures.ts
+++ b/src/vs/workbench/api/browser/mainThreadLanguageFeatures.ts
@@ -260,7 +260,7 @@ export class MainThreadLanguageFeatures extends Disposable implements MainThread
 			provideHover: async (model: ITextModel, position: EditorPosition, token: CancellationToken, context?: languages.HoverContext<HoverWithId>): Promise<HoverWithId | undefined> => {
 				const serializedContext: languages.HoverContext<{ id: number }> = {
 					verbosityRequest: context?.verbosityRequest ? {
-						action: context.verbosityRequest.action,
+						verbosityDelta: context.verbosityRequest.verbosityDelta,
 						previousHover: { id: context.verbosityRequest.previousHover.id }
 					} : undefined,
 				};

--- a/src/vs/workbench/api/common/extHostLanguageFeatures.ts
+++ b/src/vs/workbench/api/common/extHostLanguageFeatures.ts
@@ -277,7 +277,7 @@ class HoverAdapter {
 			if (!previousHover) {
 				throw new Error(`Hover with id ${previousHoverId} not found`);
 			}
-			const hoverContext: vscode.HoverContext = { action: context.verbosityRequest.action, previousHover };
+			const hoverContext: vscode.HoverContext = { verbosityDelta: context.verbosityRequest.verbosityDelta, previousHover };
 			value = await this._provider.provideHover(doc, pos, token, hoverContext);
 		} else {
 			value = await this._provider.provideHover(doc, pos, token);

--- a/src/vscode-dts/vscode.proposed.editorHoverVerbosityLevel.d.ts
+++ b/src/vscode-dts/vscode.proposed.editorHoverVerbosityLevel.d.ts
@@ -33,9 +33,9 @@ declare module 'vscode' {
 	export interface HoverContext {
 
 		/**
-		 * Whether to increase or decrease the hover's verbosity
+		 * The delta by which to increase/decrease the hover verbosity level
 		 */
-		readonly action?: HoverVerbosityAction;
+		readonly verbosityDelta?: number;
 
 		/**
 		 * The previous hover sent for the same position


### PR DESCRIPTION
fixes https://github.com/microsoft/vscode/issues/211153

This change has been done in order to allow the user to jump to a higher verbosity request instead of having to wait for the current one to finish. 

The following shows the proposed change. There is a two second timeout when providing the hover content. Clicking twice the `+` icon ultimately retrieves the content for a hover request for verbosity level 2 instead of 1.

https://github.com/microsoft/vscode/assets/61460952/eaa106fa-7cc2-4433-99b6-761f026c49c7

