### PR TITLE
feature: add import map files for tests

### DIFF
--- a/src/vs/base/parts/sandbox/electron-sandbox/preload.js
+++ b/src/vs/base/parts/sandbox/electron-sandbox/preload.js
@@ -333,4 +333,9 @@
 		// @ts-ignore
 		window.vscode = globals;
 	}
+	const isTest = !process.contextIsolated
+	if (isTest) {
+		// @ts-ignore
+		window.testGlobalRequire = require
+	}
 }());

--- a/test/unit/browser/import-map/amdx.js
+++ b/test/unit/browser/import-map/amdx.js
@@ -1,0 +1,47 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+export const root = new URL('../../../../', import.meta.url).toString().slice(0, -1)
+
+const getResult = defineCall => {
+	if (typeof defineCall.callback === 'function') {
+		return defineCall.callback([])
+	}
+	return defineCall.callback
+}
+
+export const importAmdModule = async (absolutePath) => {
+	const defineCalls = []
+	globalThis.define = (id, dependencies, callback) => {
+		if (typeof id !== 'string') {
+			callback = dependencies
+			dependencies = id
+			id = null
+		}
+		if (typeof dependencies !== 'object' || !Array.isArray(dependencies)) {
+			callback = dependencies
+			dependencies = null
+		}
+		defineCalls.push({
+			id, dependencies, callback
+		})
+	}
+
+	globalThis.define.amd = true;
+	globalThis.exports = Object.create(null)
+	await import(absolutePath)
+	if (Object.keys(globalThis.exports).length > 0) {
+		return globalThis.exports
+	}
+	if (defineCalls.length === 0) {
+		throw new Error('no module was defined')
+	}
+	const defineCall = defineCalls.pop()
+	if (Array.isArray(defineCall.dependencies) && defineCall.dependencies.length > 0) {
+		throw new Error(`dependencies are not supported`)
+	}
+	const result = getResult(defineCall)
+	return result
+}

--- a/test/unit/browser/import-map/assert.js
+++ b/test/unit/browser/import-map/assert.js
@@ -1,0 +1,15 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import { importAmdModule, root } from './amdx.js'
+
+const module = await importAmdModule(
+	`${root}/test/unit/assert.js`,
+)
+
+const { AssertionError, deepEqual, deepStrictEqual, doesNotReject, doesNotThrow, equal, fail, ifError, notDeepEqual, notDeepStrictEqual, ok, rejects, strictEqual, throws, notStrictEqual, notEqual } = module
+
+export { AssertionError, deepEqual, deepStrictEqual, doesNotReject, doesNotThrow, equal, fail, ifError, notDeepEqual, notDeepStrictEqual, ok, rejects, strictEqual, throws, notStrictEqual, notEqual }
+
+export default module

--- a/test/unit/browser/import-map/jschardet.js
+++ b/test/unit/browser/import-map/jschardet.js
@@ -1,0 +1,11 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import { importAmdModule, root } from './amdx.js'
+
+const module = await importAmdModule(
+	`${root}/node_modules/jschardet/dist/jschardet.min.js`,
+)
+
+export default module

--- a/test/unit/browser/import-map/sinon-test.js
+++ b/test/unit/browser/import-map/sinon-test.js
@@ -1,0 +1,11 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import { importAmdModule, root } from './amdx.js'
+
+const module = await importAmdModule(
+	`${root}/node_modules/sinon-test/dist/sinon-test.js`,
+)
+
+export default module

--- a/test/unit/browser/import-map/sinon.js
+++ b/test/unit/browser/import-map/sinon.js
@@ -1,0 +1,15 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import { importAmdModule, root } from './amdx.js'
+
+const module = await importAmdModule(
+	`${root}/node_modules/sinon/pkg/sinon.js`,
+)
+
+const { addBehaviour, createSandbox, assert, clock, requests, server, match, spy, defaultConfig, expectation, stub, mock, fake, useFakeTimers, useFakeXMLHttpRequest, useFakeServer, restore, reset, resetHistory, sandbox, resetBehaviour, setFormatter, usingPromise, verify, verifyAndRestore, replace, replaceGetter, replaceSetter, createStubInstance } = module
+
+export { addBehaviour, assert, clock, createSandbox, createStubInstance, defaultConfig, expectation, fake, match, mock, replace, replaceGetter, replaceSetter, requests, reset, resetBehaviour, resetHistory, restore, sandbox, server, setFormatter, spy, stub, useFakeServer, useFakeTimers, useFakeXMLHttpRequest, usingPromise, verify, verifyAndRestore }
+
+export default module

--- a/test/unit/browser/import-map/vscode-iconv-lite-umd.js
+++ b/test/unit/browser/import-map/vscode-iconv-lite-umd.js
@@ -1,0 +1,11 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import { importAmdModule, root } from './amdx.js'
+
+const module = await importAmdModule(
+	`${root}/node_modules/@vscode/iconv-lite-umd/lib/iconv-lite-umd.js`,
+)
+
+export default module

--- a/test/unit/browser/import-map/xterm-headless.js
+++ b/test/unit/browser/import-map/xterm-headless.js
@@ -1,0 +1,11 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import { importAmdModule, root } from './amdx.js'
+
+const module = await importAmdModule(
+	`${root}/node_modules/@xterm/headless/lib-headless/xterm-headless.js`,
+)
+
+export default module

--- a/test/unit/browser/import-map/xterm.js
+++ b/test/unit/browser/import-map/xterm.js
@@ -1,0 +1,11 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import { importAmdModule, root } from './amdx.js'
+
+const module = await importAmdModule(
+	`${root}/node_modules/@xterm/xterm/lib/xterm.js`,
+)
+
+export default module

--- a/test/unit/browser/renderer.html
+++ b/test/unit/browser/renderer.html
@@ -8,6 +8,19 @@
 
 <body>
 	<div id="mocha"></div>
+	<script type="importmap">
+		{
+			"imports": {
+				"assert": "./import-map/assert.js",
+				"sinon": "./import-map/sinon.js",
+				"sinon-test": "./import-map/sinon-test.js",
+				"@xterm/xterm": "./import-map/xterm.js",
+				"@xterm/headless": "./import-map/xterm-headless.js",
+				"@vscode/iconv-lite-umd": "./import-map/vscode-iconv-lite-umd.js",
+				"jschardet": "./import-map/jschardet.js"
+			}
+		}
+	</script>
 	<script src="../../../node_modules/mocha/mocha.js"></script>
 	<script>
 		// !!! DO NOT CHANGE !!!

--- a/test/unit/electron/import-map/assert.js
+++ b/test/unit/electron/import-map/assert.js
@@ -1,0 +1,12 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { testGlobals } from './testGlobals.js';
+
+const { strictEqual, deepEqual, deepStrictEqual, ok, notStrictEqual, fail, notEqual, throws, notDeepStrictEqual, equal } = testGlobals['assert'];
+
+export { strictEqual, deepEqual, deepStrictEqual, ok, notStrictEqual, fail, notEqual, throws, notDeepStrictEqual, equal };
+
+export default testGlobals.assert;

--- a/test/unit/electron/import-map/child_process.js
+++ b/test/unit/electron/import-map/child_process.js
@@ -1,0 +1,10 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { testGlobals } from './testGlobals.js';
+
+const { fork, exec, spawn, execSync } = testGlobals['child_process'];
+
+export { fork, exec, spawn, execSync };

--- a/test/unit/electron/import-map/cookie.js
+++ b/test/unit/electron/import-map/cookie.js
@@ -1,0 +1,8 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { testGlobals } from './testGlobals.js';
+
+export default testGlobals.cookie;

--- a/test/unit/electron/import-map/crypto.js
+++ b/test/unit/electron/import-map/crypto.js
@@ -1,0 +1,10 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { testGlobals } from './testGlobals.js';
+
+const { createHash, randomBytes } = testGlobals.crypto;
+
+export { createHash, randomBytes };

--- a/test/unit/electron/import-map/electron.js
+++ b/test/unit/electron/import-map/electron.js
@@ -1,0 +1,10 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { testGlobals } from './testGlobals.js';
+
+const { ipcMain, screen, BrowserWindow, app, nativeTheme, dialog } = testGlobals.electron;
+
+export { ipcMain, screen, BrowserWindow, app, nativeTheme, dialog };

--- a/test/unit/electron/import-map/events.js
+++ b/test/unit/electron/import-map/events.js
@@ -1,0 +1,10 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { testGlobals } from './testGlobals.js';
+
+const { EventEmitter } = testGlobals.events;
+
+export { EventEmitter };

--- a/test/unit/electron/import-map/fs.js
+++ b/test/unit/electron/import-map/fs.js
@@ -1,0 +1,10 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { testGlobals } from './testGlobals.js';
+
+const { createWriteStream, existsSync, readFileSync, readdirSync, rmSync, writeFileSync, unwatchFile, watchFile, watch, readFile, mkdir, chmod, link, unlink, truncate, copyFile, read, access, open, rm, readdir, writeFile, constants, stat, mkdirSync, unlinkSync, fdatasync, statSync, accessSync, symlinkSync, openSync, createReadStream, realpathSync, lstatSync, promises, lstat, fdatasyncSync, closeSync, utimes, appendFile, close, symlink, readlink, rmdir, write, renameSync, rename, realpath } = testGlobals.fs;
+
+export { createWriteStream, existsSync, readFileSync, readdirSync, rmSync, writeFileSync, unwatchFile, watchFile, watch, readFile, mkdir, chmod, link, unlink, truncate, copyFile, read, access, open, rm, readdir, writeFile, constants, stat, mkdirSync, unlinkSync, fdatasync, statSync, accessSync, symlinkSync, openSync, createReadStream, realpathSync, lstatSync, promises, lstat, fdatasyncSync, closeSync, utimes, appendFile, close, symlink, readlink, rmdir, write, renameSync, rename, realpath };

--- a/test/unit/electron/import-map/graceful-fs.js
+++ b/test/unit/electron/import-map/graceful-fs.js
@@ -1,0 +1,8 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { testGlobals } from './testGlobals.js';
+
+export default testGlobals['graceful-fs'];

--- a/test/unit/electron/import-map/istanbul-lib-coverage.js
+++ b/test/unit/electron/import-map/istanbul-lib-coverage.js
@@ -1,0 +1,10 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { testGlobals } from './testGlobals.js';
+
+const { createCoverageMap } = testGlobals['istanbul-lib-coverage'];
+
+export { createCoverageMap };

--- a/test/unit/electron/import-map/istanbul-lib-instrument.js
+++ b/test/unit/electron/import-map/istanbul-lib-instrument.js
@@ -1,0 +1,10 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { testGlobals } from './testGlobals.js';
+
+const { createInstrumenter } = testGlobals['istanbul-lib-instrument'];
+
+export { createInstrumenter };

--- a/test/unit/electron/import-map/istanbul-lib-report.js
+++ b/test/unit/electron/import-map/istanbul-lib-report.js
@@ -1,0 +1,10 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { testGlobals } from './testGlobals.js';
+
+const { createContext } = testGlobals['istanbul-lib-report'];
+
+export { createContext };

--- a/test/unit/electron/import-map/istanbul-lib-source-maps.js
+++ b/test/unit/electron/import-map/istanbul-lib-source-maps.js
@@ -1,0 +1,10 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { testGlobals } from './testGlobals.js';
+
+const { createSourceMapStore } = testGlobals['istanbul-lib-source-maps'];
+
+export { createSourceMapStore };

--- a/test/unit/electron/import-map/istanbul-reports.js
+++ b/test/unit/electron/import-map/istanbul-reports.js
@@ -1,0 +1,10 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { testGlobals } from './testGlobals.js';
+
+const { create } = testGlobals['istanbul-reports'];
+
+export { create };

--- a/test/unit/electron/import-map/jschardet.js
+++ b/test/unit/electron/import-map/jschardet.js
@@ -1,0 +1,10 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { testGlobals } from './testGlobals.js';
+
+const { detect } = testGlobals.jschardet;
+
+export { detect };

--- a/test/unit/electron/import-map/kerberos.js
+++ b/test/unit/electron/import-map/kerberos.js
@@ -1,0 +1,10 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { testGlobals } from './testGlobals.js';
+
+const { initializeClient } = testGlobals.kerberos;
+
+export { initializeClient };

--- a/test/unit/electron/import-map/minimatch.js
+++ b/test/unit/electron/import-map/minimatch.js
@@ -1,0 +1,8 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { testGlobals } from './testGlobals.js';
+
+export default testGlobals['minimatch'];

--- a/test/unit/electron/import-map/minimist.js
+++ b/test/unit/electron/import-map/minimist.js
@@ -1,0 +1,8 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { testGlobals } from './testGlobals.js';
+
+export default testGlobals.minimist;

--- a/test/unit/electron/import-map/mocha.js
+++ b/test/unit/electron/import-map/mocha.js
@@ -1,0 +1,10 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { testGlobals } from './testGlobals.js';
+
+const { beforeEach, afterEach, setup, suite, timeout, grep, reporter, run, Suite } = testGlobals.mocha;
+
+export { beforeEach, afterEach, setup, suite, timeout, grep, reporter, run, Suite };

--- a/test/unit/electron/import-map/native-is-elevated.js
+++ b/test/unit/electron/import-map/native-is-elevated.js
@@ -1,0 +1,8 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { testGlobals } from './testGlobals.js';
+
+export default testGlobals['native-is-elevated'];

--- a/test/unit/electron/import-map/native-keymap.js
+++ b/test/unit/electron/import-map/native-keymap.js
@@ -1,0 +1,10 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { testGlobals } from './testGlobals.js';
+
+const { getCurrentKeyboardLayout } = testGlobals['native-keymap'];
+
+export { getCurrentKeyboardLayout };

--- a/test/unit/electron/import-map/native-watchdog.js
+++ b/test/unit/electron/import-map/native-watchdog.js
@@ -1,0 +1,10 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { testGlobals } from './testGlobals.js';
+
+const { start } = testGlobals['native-watchdog'];
+
+export { start };

--- a/test/unit/electron/import-map/net.js
+++ b/test/unit/electron/import-map/net.js
@@ -1,0 +1,10 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { testGlobals } from './testGlobals.js';
+
+const { createServer, createConnection, connect, Socket } = testGlobals.net;
+
+export { connect, createConnection, createServer, Socket };

--- a/test/unit/electron/import-map/os.js
+++ b/test/unit/electron/import-map/os.js
@@ -1,0 +1,10 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { testGlobals } from './testGlobals.js';
+
+const { tmpdir, networkInterfaces, homedir, userInfo, release, hostname } = testGlobals.os;
+
+export { homedir, hostname, networkInterfaces, release, tmpdir, userInfo };

--- a/test/unit/electron/import-map/parcel-watcher.js
+++ b/test/unit/electron/import-map/parcel-watcher.js
@@ -1,0 +1,12 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { testGlobals } from './testGlobals.js';
+
+const { subscribe, writeSnapshot, getEventsSince } = testGlobals['@parcel/watcher'];
+
+export { getEventsSince, subscribe, writeSnapshot };
+
+export default testGlobals.parcelWatcher;

--- a/test/unit/electron/import-map/path.js
+++ b/test/unit/electron/import-map/path.js
@@ -1,0 +1,10 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { testGlobals } from './testGlobals.js';
+
+const { join, resolve, dirname, isAbsolute, normalize, relative, basename, extname, format, parse, toNamedspacedPath, sep, delimiter } = testGlobals.path;
+
+export { basename, delimiter, dirname, extname, format, isAbsolute, join, normalize, parse, relative, resolve, sep, toNamedspacedPath };

--- a/test/unit/electron/import-map/sinon-test.js
+++ b/test/unit/electron/import-map/sinon-test.js
@@ -1,0 +1,8 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { testGlobals } from './testGlobals.js';
+
+export default testGlobals['sinon-test'];

--- a/test/unit/electron/import-map/sinon.js
+++ b/test/unit/electron/import-map/sinon.js
@@ -1,0 +1,12 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { testGlobals } from './testGlobals.js';
+
+const { stub, createSandbox, sandbox, useFakeTimers, spy, restore, createStubInstance, expectation, clock, defaultConfig, addBehaviour, setFormatter, assert, mock } = testGlobals.sinon;
+
+export { addBehaviour, assert, clock, createSandbox, createStubInstance, defaultConfig, expectation, mock, restore, sandbox, setFormatter, spy, stub, useFakeTimers };
+
+export default testGlobals.sinon;

--- a/test/unit/electron/import-map/stream.js
+++ b/test/unit/electron/import-map/stream.js
@@ -1,0 +1,10 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { testGlobals } from './testGlobals.js';
+
+const { Transform, Readable, Writable } = testGlobals.stream;
+
+export { Readable, Transform, Writable };

--- a/test/unit/electron/import-map/string_decoder.js
+++ b/test/unit/electron/import-map/string_decoder.js
@@ -1,0 +1,10 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { testGlobals } from './testGlobals.js';
+
+const { StringDecoder } = testGlobals['string_decoder'];
+
+export { StringDecoder };

--- a/test/unit/electron/import-map/testGlobals.js
+++ b/test/unit/electron/import-map/testGlobals.js
@@ -1,0 +1,71 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// @ts-ignore
+const { testGlobalRequire, testSetRun, testIpcRenderer } = globalThis;
+
+const modules = [
+	'@parcel/watcher',
+	'@vscode/ripgrep',
+	'@vscode/sqlite3',
+	'@vscode/windows-ca-certs',
+	'@vscode/windows-registry',
+	'@vscode/windows-process-tree',
+	'@xterm/headless',
+	'@xterm/xterm',
+	'assert',
+	'child_process',
+	'cookie',
+	'crypto',
+	'electron',
+	'events',
+	'fs',
+	'glob',
+	'graceful-fs',
+	'inspector',
+	'jschardet',
+	'kerberos',
+	'minimatch',
+	'minimist',
+	'mocha',
+	'native-is-elevated',
+	'native-keymap',
+	'native-watchdog',
+	'net',
+	'os',
+	'path',
+	'sinon-test',
+	'sinon',
+	'stream',
+	'string_decoder',
+	'url',
+	'util',
+	'vscode-regexpp',
+	'yauzl',
+	'zlib',
+	"istanbul-lib-coverage",
+	"istanbul-lib-instrument",
+	"istanbul-lib-report",
+	"istanbul-lib-source-maps",
+	"istanbul-reports",
+	"windows-foreground-love",
+]
+
+const createTestGlobals = () => {
+	const map = Object.create(null)
+	for (const module of modules) {
+		Object.defineProperty(map, module, {
+			get() {
+				return testGlobalRequire(module)
+			},
+		})
+	}
+	map.setRun = testSetRun
+	map.ipcRenderer = testIpcRenderer
+	return map
+}
+
+
+export const testGlobals = createTestGlobals()

--- a/test/unit/electron/import-map/testGlobals.js
+++ b/test/unit/electron/import-map/testGlobals.js
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 // @ts-ignore
-const { testGlobalRequire, testSetRun, testIpcRenderer } = globalThis;
+const { testGlobalRequire } = globalThis;
 
 const modules = [
 	'@parcel/watcher',
@@ -62,8 +62,6 @@ const createTestGlobals = () => {
 			},
 		})
 	}
-	map.setRun = testSetRun
-	map.ipcRenderer = testIpcRenderer
 	return map
 }
 

--- a/test/unit/electron/import-map/url.js
+++ b/test/unit/electron/import-map/url.js
@@ -1,0 +1,10 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { testGlobals } from './testGlobals.js';
+
+const { pathToFileURL, fileURLToPath } = testGlobals['url'];
+
+export { pathToFileURL, fileURLToPath };

--- a/test/unit/electron/import-map/util.js
+++ b/test/unit/electron/import-map/util.js
@@ -1,0 +1,10 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { testGlobals } from './testGlobals.js';
+
+const { promisify } = testGlobals.util;
+
+export { promisify };

--- a/test/unit/electron/import-map/vscode-regexpp.js
+++ b/test/unit/electron/import-map/vscode-regexpp.js
@@ -1,0 +1,10 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { testGlobals } from './testGlobals.js';
+
+const { RegExpParser, RegExpVisitor } = testGlobals['vscode-regexpp'];
+
+export { RegExpParser, RegExpVisitor };

--- a/test/unit/electron/import-map/vscode-ripgrep.js
+++ b/test/unit/electron/import-map/vscode-ripgrep.js
@@ -1,0 +1,10 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { testGlobals } from './testGlobals.js';
+
+const { rgPath } = testGlobals['@vscode/ripgrep'];
+
+export { rgPath };

--- a/test/unit/electron/import-map/vscode-sqlite3.js
+++ b/test/unit/electron/import-map/vscode-sqlite3.js
@@ -1,0 +1,14 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { testGlobals } from './testGlobals.js';
+
+const { Database } = testGlobals['@vscode/sqlite3'];
+
+export { Database }
+
+export default {
+	Database
+};

--- a/test/unit/electron/import-map/vscode-windows-ca-certs.js
+++ b/test/unit/electron/import-map/vscode-windows-ca-certs.js
@@ -1,0 +1,10 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { testGlobals } from './testGlobals.js';
+
+const { Crypt32 } = testGlobals['@vscode/windows-ca-certs'];
+
+export { Crypt32 };

--- a/test/unit/electron/import-map/vscode-windows-process-tree.js
+++ b/test/unit/electron/import-map/vscode-windows-process-tree.js
@@ -1,0 +1,10 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { testGlobals } from './testGlobals.js';
+
+const { getProcessList, getProcessCpuUsage, getProcessTree } = testGlobals['@vscode/windows-process-tree'];
+
+export { getProcessList, getProcessCpuUsage, getProcessTree };

--- a/test/unit/electron/import-map/vscode-windows-registry.js
+++ b/test/unit/electron/import-map/vscode-windows-registry.js
@@ -1,0 +1,10 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { testGlobals } from './testGlobals.js';
+
+const { GetStringRegKey } = testGlobals['@vscode/windows-registry'];
+
+export { GetStringRegKey };

--- a/test/unit/electron/import-map/windows-foreground-love.js
+++ b/test/unit/electron/import-map/windows-foreground-love.js
@@ -1,0 +1,10 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { testGlobals } from './testGlobals.js';
+
+const { allowSetForegroundWindow } = testGlobals['windows-foreground-love'];
+
+export { allowSetForegroundWindow };

--- a/test/unit/electron/import-map/xterm-addon-canvas.js
+++ b/test/unit/electron/import-map/xterm-addon-canvas.js
@@ -1,0 +1,8 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { testGlobals } from './testGlobals.js';
+
+export default testGlobals['@xterm/addon-canvas'];

--- a/test/unit/electron/import-map/xterm-headless.js
+++ b/test/unit/electron/import-map/xterm-headless.js
@@ -1,0 +1,8 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { testGlobals } from './testGlobals.js';
+
+export default testGlobals['@xterm/headless'];

--- a/test/unit/electron/import-map/xterm.js
+++ b/test/unit/electron/import-map/xterm.js
@@ -1,0 +1,8 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { testGlobals } from './testGlobals.js';
+
+export default testGlobals['@xterm/xterm'];

--- a/test/unit/electron/import-map/yauzl.js
+++ b/test/unit/electron/import-map/yauzl.js
@@ -1,0 +1,10 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { testGlobals } from './testGlobals.js';
+
+const { open } = testGlobals.yauzl;
+
+export { open };

--- a/test/unit/electron/import-map/zlib.js
+++ b/test/unit/electron/import-map/zlib.js
@@ -1,0 +1,10 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { testGlobals } from './testGlobals.js';
+
+const { createDeflateRaw, createInflateRaw } = testGlobals.zlib
+
+export { createDeflateRaw, createInflateRaw };

--- a/test/unit/electron/renderer.html
+++ b/test/unit/electron/renderer.html
@@ -9,6 +9,57 @@
 <body>
 	<div id="mocha"></div>
 	<script src="../../../node_modules/mocha/mocha.js"></script>
+	<script type="importmap">
+		{
+			"imports": {
+				"@parcel/watcher": "./import-map/parcel-watcher.js",
+				"@vscode/ripgrep": "./import-map/vscode-ripgrep.js",
+				"@vscode/sqlite3": "./import-map/vscode-sqlite3.js",
+				"@vscode/windows-ca-certs": "./import-map/vscode-windows-ca-certs.js",
+				"@vscode/windows-process-tree": "./import-map/vscode-windows-process-tree.js",
+				"@vscode/windows-registry": "./import-map/vscode-windows-registry.js",
+				"@xterm/addon-canvas": "./import-map/xterm-addon-canvas.js",
+				"@xterm/headless": "./import-map/xterm-headless.js",
+				"@xterm/xterm": "./import-map/xterm.js",
+				"assert": "./import-map/assert.js",
+				"child_process": "./import-map/child_process.js",
+				"cookie": "./import-map/cookie.js",
+				"crypto": "./import-map/crypto.js",
+				"electron": "./import-map/electron.js",
+				"events": "./import-map/events.js",
+				"fs": "./import-map/fs.js",
+				"graceful-fs": "./import-map/graceful-fs.js",
+				"istanbul-lib-coverage": "./import-map/istanbul-lib-coverage.js",
+				"istanbul-lib-instrument": "./import-map/istanbul-lib-instrument.js",
+				"istanbul-lib-report": "./import-map/istanbul-lib-report.js",
+				"istanbul-lib-source-maps": "./import-map/istanbul-lib-source-maps.js",
+				"istanbul-reports": "./import-map/istanbul-reports.js",
+				"jschardet": "./import-map/jschardet.js",
+				"kerberos": "./import-map/kerberos.js",
+				"minimatch": "./import-map/minimatch.js",
+				"minimist": "./import-map/minimist.js",
+				"mocha": "./import-map/mocha.js",
+				"native-is-elevated": "./import-map/native-is-elevated.js",
+				"native-keymap": "./import-map/native-keymap.js",
+				"native-watchdog": "./import-map/native-watchdog.js",
+				"net": "./import-map/net.js",
+				"node:os": "./import-map/os.js",
+				"node:path": "./import-map/path.js",
+				"os": "./import-map/os.js",
+				"path": "./import-map/path.js",
+				"sinon-test": "./import-map/sinon-test.js",
+				"sinon": "./import-map/sinon.js",
+				"stream": "./import-map/stream.js",
+				"string_decoder": "./import-map/string_decoder.js",
+				"url": "./import-map/url.js",
+				"util": "./import-map/util.js",
+				"vscode-regexpp": "./import-map/vscode-regexpp.js",
+				"windows-foreground-love": "./import-map/windows-foreground-love.js",
+				"yauzl": "./import-map/yauzl.js",
+				"zlib": "./import-map/zlib.js"
+			}
+		}
+	</script>
 
 	<script>
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Helps with #160416.

When migrating from AMD to ESM, it seems the tests would also need use ESM. Take for example this test file:

```js
// telemetryService.test.ts
import * as sinon from 'sinon';
import * as sinonTest from 'sinon-test';

const sinonTestFn = sinonTest(sinon);
```

When running this test in the browser, by default the paths `sinon` and `sinon-tests` can't be found. 

## Import Map

```html
<script type="importmap">
	{
		"imports": {
			"sinon": "./import-map/sinon.js",
			"sinon-test": "./import-map/sinon-test.js"
		}
	}
</script>
```

By using this import map, the paths of the imports are redirected to `import-map/sinon.js` and `import-map/sinon-test.js`. 

## Re-exports

The ESM file `import-map/sinon.js` file imports the `sinon` commonjs module and re-exports everything from it:

```js
// import-map/sinon.js
const module = await importAmdModule(`${root}/node_modules/sinon/pkg/sinon.js`)
const { addBehaviour, createSandbox, assert } = module
export { addBehaviour, createSandbox, assert }
export default module
```


## Additional information

- For now this change wouldn't really have an effect, as the tests are still using Commonjs/AMD. 

- The code for this has been extracted from #212727. There, the [units tests]( https://github.com/SimonSiefke/vscode/actions/runs/9131715443/job/25111532388?pr=2) have been passing on MacOS, Windows and Linux.

- Once the source files are using ESM, it seems this change would come in handy.

## Questions

- Perhaps would it make sense to add a script to automatically generate the `import-map/module.js` files?
- Perhaps change the folder names? E.g. in https://github.com/microsoft/vscode/pull/166033/files#diff-78e3fc4c704f8b601d5294d2c24253cd0f73c01c158ae43046746bed7cfdc9aa the folder is called `typings-esm`.
