### PR TITLE
fix: remove temp dir if extension is installed by another source

### DIFF
--- a/src/vs/platform/extensionManagement/node/extensionManagementService.ts
+++ b/src/vs/platform/extensionManagement/node/extensionManagementService.ts
@@ -602,6 +602,7 @@ export class ExtensionsScanner extends Disposable {
 				} catch (error) {
 					if (error.code === 'ENOTEMPTY') {
 						this.logService.info(`Rename failed because extension was installed by another source. So ignoring renaming.`, extensionKey.id);
+						try { await this.fileService.del(tempLocation, { recursive: true }); } catch (e) { /* ignore */ }
 					} else {
 						this.logService.info(`Rename failed because of ${getErrorMessage(error)}. Deleted from extracted location`, tempLocation);
 						throw error;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

In current implementation, if an extension was installed by another source, then the extracted temp folder would not be deleted, causing lots of temporary folders left on my machine.

<img width="401" alt="image" src="https://github.com/microsoft/vscode/assets/8667822/9d60e536-c917-43f2-9c79-8e1af08d594e">


This PR fixed this issue by removing the temp directory on `ENOTEMPTY`.
