### PR TITLE
don't always consume mouse wheel

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatWidget.ts
@@ -455,6 +455,7 @@ export class ChatWidget extends Disposable implements IChatWidget {
 			{
 				identityProvider: { getId: (e: ChatTreeItem) => e.id },
 				horizontalScrolling: false,
+				alwaysConsumeMouseWheel: false,
 				supportDynamicHeights: true,
 				hideTwistiesOfChildlessElements: true,
 				accessibilityProvider: this.instantiationService.createInstance(ChatAccessibilityProvider),

--- a/src/vs/workbench/contrib/codeEditor/browser/simpleEditorOptions.ts
+++ b/src/vs/workbench/contrib/codeEditor/browser/simpleEditorOptions.ts
@@ -25,7 +25,8 @@ export function getSimpleEditorOptions(configurationService: IConfigurationServi
 		hideCursorInOverviewRuler: true,
 		selectionHighlight: false,
 		scrollbar: {
-			horizontal: 'hidden'
+			horizontal: 'hidden',
+			alwaysConsumeMouseWheel: false
 		},
 		lineDecorationsWidth: 0,
 		overviewRulerBorder: false,


### PR DESCRIPTION
for chat widget (list) and for chat input editor (actually all simple editor cases)