### PR TITLE
Disable web TS type acquisition

### DIFF
--- a/extensions/typescript-language-features/package.json
+++ b/extensions/typescript-language-features/package.json
@@ -1284,13 +1284,13 @@
         },
         "typescript.tsserver.web.projectWideIntellisense.suppressSemanticErrors": {
           "type": "boolean",
-          "default": false,
+          "default": true,
           "description": "%configuration.tsserver.web.projectWideIntellisense.suppressSemanticErrors%",
           "scope": "window"
         },
         "typescript.tsserver.web.typeAcquisition.enabled": {
           "type": "boolean",
-          "default": true,
+          "default": false,
           "description": "%configuration.tsserver.web.typeAcquisition.enabled%",
           "scope": "window"
         },

--- a/extensions/typescript-language-features/src/configuration/configuration.ts
+++ b/extensions/typescript-language-features/src/configuration/configuration.ts
@@ -261,10 +261,10 @@ export abstract class BaseServiceConfigurationProvider implements ServiceConfigu
 	}
 
 	private readWebProjectWideIntellisenseSuppressSemanticErrors(configuration: vscode.WorkspaceConfiguration): boolean {
-		return configuration.get<boolean>('typescript.tsserver.web.projectWideIntellisense.suppressSemanticErrors', false);
+		return configuration.get<boolean>('typescript.tsserver.web.projectWideIntellisense.suppressSemanticErrors', true);
 	}
 
 	private readWebTypeAcquisition(configuration: vscode.WorkspaceConfiguration): boolean {
-		return configuration.get<boolean>('typescript.tsserver.web.typeAcquisition.enabled', true);
+		return configuration.get<boolean>('typescript.tsserver.web.typeAcquisition.enabled', false);
 	}
 }


### PR DESCRIPTION
We're waiting on some perf improvement for upstream types installer before turning this on everywhere

Will be re-enable in insiders 