### PR TITLE
Replace `removeChild` with `remove`

### DIFF
--- a/extensions/notebook-renderers/src/index.ts
+++ b/extensions/notebook-renderers/src/index.ts
@@ -11,7 +11,7 @@ import { formatStackTrace } from './stackTraceHelper';
 
 function clearContainer(container: HTMLElement) {
 	while (container.firstChild) {
-		container.removeChild(container.firstChild);
+		container.firstChild.remove();
 	}
 }
 
@@ -378,7 +378,7 @@ function renderStream(outputInfo: OutputWithAppend, outputElement: HTMLElement, 
 			contentParent = document.createElement('div');
 			contentParent.appendChild(newContent);
 			while (outputElement.firstChild) {
-				outputElement.removeChild(outputElement.firstChild);
+				outputElement.firstChild.remove();
 			}
 			outputElement.appendChild(contentParent);
 		}

--- a/src/vs/base/browser/dnd.ts
+++ b/src/vs/base/browser/dnd.ts
@@ -100,7 +100,7 @@ export function applyDragImage(event: DragEvent, label: string | null, clazz: st
 		event.dataTransfer.setDragImage(dragImage, -10, -10);
 
 		// Removes the element when the DND operation is done
-		setTimeout(() => ownerDocument.body.removeChild(dragImage), 0);
+		setTimeout(() => dragImage.remove(), 0);
 	}
 }
 

--- a/src/vs/base/browser/dom.ts
+++ b/src/vs/base/browser/dom.ts
@@ -968,7 +968,7 @@ export function createStyleSheet(container: HTMLElement = mainWindow.document.he
 	container.appendChild(style);
 
 	if (disposableStore) {
-		disposableStore.add(toDisposable(() => container.removeChild(style)));
+		disposableStore.add(toDisposable(() => style.remove()));
 	}
 
 	// With <head> as container, the stylesheet becomes global and is tracked
@@ -1005,7 +1005,7 @@ function cloneGlobalStyleSheet(globalStylesheet: HTMLStyleElement, globalStylesh
 
 	const clone = globalStylesheet.cloneNode(true) as HTMLStyleElement;
 	targetWindow.document.head.appendChild(clone);
-	disposables.add(toDisposable(() => targetWindow.document.head.removeChild(clone)));
+	disposables.add(toDisposable(() => clone.remove()));
 
 	for (const rule of getDynamicStyleSheetRules(globalStylesheet)) {
 		clone.sheet?.insertRule(rule.cssText, clone.sheet?.cssRules.length);
@@ -1727,7 +1727,7 @@ export function triggerDownload(dataOrUri: Uint8Array | URI, name: string): void
 	anchor.click();
 
 	// Ensure to remove the element from DOM eventually
-	setTimeout(() => activeWindow.document.body.removeChild(anchor));
+	setTimeout(() => anchor.remove());
 }
 
 export function triggerUpload(): Promise<FileList | undefined> {
@@ -1750,7 +1750,7 @@ export function triggerUpload(): Promise<FileList | undefined> {
 		input.click();
 
 		// Ensure to remove the element from DOM eventually
-		setTimeout(() => activeWindow.document.body.removeChild(input));
+		setTimeout(() => input.remove());
 	});
 }
 

--- a/src/vs/base/browser/markdownRenderer.ts
+++ b/src/vs/base/browser/markdownRenderer.ts
@@ -427,7 +427,7 @@ function sanitizeRenderedMarkdown(
 			if (element.attributes.getNamedItem('type')?.value === 'checkbox') {
 				element.setAttribute('disabled', '');
 			} else if (!options.replaceWithPlaintext) {
-				element.parentElement?.removeChild(element);
+				element.remove();
 			}
 		}
 

--- a/src/vs/base/browser/ui/actionbar/actionbar.ts
+++ b/src/vs/base/browser/ui/actionbar/actionbar.ts
@@ -422,7 +422,7 @@ export class ActionBar extends Disposable implements IActionRunner {
 
 	pull(index: number): void {
 		if (index >= 0 && index < this.viewItems.length) {
-			this.actionsList.removeChild(this.actionsList.childNodes[index]);
+			this.actionsList.childNodes[index].remove();
 			this.viewItemDisposables.deleteAndDispose(this.viewItems[index]);
 			dispose(this.viewItems.splice(index, 1));
 			this.refreshRole();

--- a/src/vs/base/browser/ui/centered/centeredViewLayout.ts
+++ b/src/vs/base/browser/ui/centered/centeredViewLayout.ts
@@ -166,7 +166,7 @@ export class CenteredViewLayout implements IDisposable {
 		}
 
 		if (active) {
-			this.container.removeChild(this.view.element);
+			this.view.element.remove();
 			this.splitView = new SplitView(this.container, {
 				inverseAltBehavior: true,
 				orientation: Orientation.HORIZONTAL,
@@ -195,9 +195,7 @@ export class CenteredViewLayout implements IDisposable {
 
 			this.resizeSplitViews();
 		} else {
-			if (this.splitView) {
-				this.container.removeChild(this.splitView.el);
-			}
+			this.splitView?.el.remove();
 			this.splitViewDisposables.clear();
 			this.splitView?.dispose();
 			this.splitView = undefined;

--- a/src/vs/base/browser/ui/contextview/contextview.ts
+++ b/src/vs/base/browser/ui/contextview/contextview.ts
@@ -169,13 +169,11 @@ export class ContextView extends Disposable {
 		if (this.container) {
 			this.toDisposeOnSetContainer.dispose();
 
+			this.view.remove();
 			if (this.shadowRoot) {
-				this.shadowRoot.removeChild(this.view);
 				this.shadowRoot = null;
 				this.shadowRootHostElement?.remove();
 				this.shadowRootHostElement = null;
-			} else {
-				this.container.removeChild(this.view);
 			}
 
 			this.container = null;

--- a/src/vs/base/browser/ui/grid/gridview.ts
+++ b/src/vs/base/browser/ui/grid/gridview.ts
@@ -1063,7 +1063,7 @@ export class GridView implements IDisposable {
 		const oldRoot = this._root;
 
 		if (oldRoot) {
-			this.element.removeChild(oldRoot.element);
+			oldRoot.element.remove();
 			oldRoot.dispose();
 		}
 
@@ -1831,6 +1831,6 @@ export class GridView implements IDisposable {
 	dispose(): void {
 		this.onDidSashResetRelay.dispose();
 		this.root.dispose();
-		this.element.parentElement?.removeChild(this.element);
+		this.element.remove();
 	}
 }

--- a/src/vs/base/browser/ui/list/listView.ts
+++ b/src/vs/base/browser/ui/list/listView.ts
@@ -1158,7 +1158,7 @@ export class ListView<T> implements IListView<T> {
 			const container = getDragImageContainer(this.domNode);
 			container.appendChild(dragImage);
 			event.dataTransfer.setDragImage(dragImage, -10, -10);
-			setTimeout(() => container.removeChild(dragImage), 0);
+			setTimeout(() => dragImage.remove(), 0);
 		}
 
 		this.domNode.classList.add('dragging');
@@ -1542,7 +1542,7 @@ export class ListView<T> implements IListView<T> {
 		this.virtualDelegate.setDynamicHeight?.(item.element, item.size);
 
 		item.lastDynamicHeightWidth = this.renderWidth;
-		this.rowsContainer.removeChild(row.domNode);
+		row.domNode.remove();
 		this.cache.release(row);
 
 		return item.size - size;
@@ -1570,9 +1570,7 @@ export class ListView<T> implements IListView<T> {
 
 		this.items = [];
 
-		if (this.domNode && this.domNode.parentNode) {
-			this.domNode.parentNode.removeChild(this.domNode);
-		}
+		this.domNode?.remove();
 
 		this.dragOverAnimationDisposable?.dispose();
 		this.disposables.dispose();

--- a/src/vs/base/browser/ui/list/rowCache.ts
+++ b/src/vs/base/browser/ui/list/rowCache.ts
@@ -13,14 +13,6 @@ export interface IRow {
 	templateData: any;
 }
 
-function removeFromParent(element: HTMLElement): void {
-	try {
-		element.parentElement?.removeChild(element);
-	} catch (e) {
-		// this will throw if this happens due to a blur event, nasty business
-	}
-}
-
 export class RowCache<T> implements IDisposable {
 
 	private cache = new Map<string, IRow[]>();
@@ -104,7 +96,7 @@ export class RowCache<T> implements IDisposable {
 
 	private doRemoveNode(domNode: HTMLElement) {
 		domNode.classList.remove('scrolling');
-		removeFromParent(domNode);
+		domNode.remove();
 	}
 
 	private getTemplateCache(templateId: string): IRow[] {

--- a/src/vs/base/browser/ui/sash/sash.ts
+++ b/src/vs/base/browser/ui/sash/sash.ts
@@ -575,7 +575,7 @@ export class Sash extends Disposable {
 		const onPointerUp = (e: PointerEvent) => {
 			EventHelper.stop(e, false);
 
-			this.el.removeChild(style);
+			style.remove();
 
 			this.el.classList.remove('active');
 			this._onDidEnd.fire();

--- a/src/vs/base/browser/ui/selectBox/selectBoxCustom.ts
+++ b/src/vs/base/browser/ui/selectBox/selectBoxCustom.ts
@@ -520,12 +520,7 @@ export class SelectBoxList extends Disposable implements ISelectBoxDelegate, ILi
 		return {
 			dispose: () => {
 				// contextView will dispose itself if moving from one View to another
-				try {
-					container.removeChild(this.selectDropDownContainer); // remove to take out the CSS rules we add
-				}
-				catch (error) {
-					// Ignore, removed already by change of focus
-				}
+				this.selectDropDownContainer.remove(); // remove to take out the CSS rules we add
 			}
 		};
 	}
@@ -612,20 +607,20 @@ export class SelectBoxList extends Disposable implements ISelectBoxDelegate, ILi
 					&& this.options.length > maxVisibleOptionsBelow
 				) {
 					this._dropDownPosition = AnchorPosition.ABOVE;
-					this.selectDropDownContainer.removeChild(this.selectDropDownListContainer);
-					this.selectDropDownContainer.removeChild(this.selectionDetailsPane);
-					this.selectDropDownContainer.appendChild(this.selectionDetailsPane);
-					this.selectDropDownContainer.appendChild(this.selectDropDownListContainer);
+					this.selectDropDownListContainer.remove();
+					this.selectionDetailsPane.remove();
+					this.selectionDetailsPane.remove();
+					this.selectDropDownListContainer.remove();
 
 					this.selectionDetailsPane.classList.remove('border-top');
 					this.selectionDetailsPane.classList.add('border-bottom');
 
 				} else {
 					this._dropDownPosition = AnchorPosition.BELOW;
-					this.selectDropDownContainer.removeChild(this.selectDropDownListContainer);
-					this.selectDropDownContainer.removeChild(this.selectionDetailsPane);
-					this.selectDropDownContainer.appendChild(this.selectDropDownListContainer);
-					this.selectDropDownContainer.appendChild(this.selectionDetailsPane);
+					this.selectDropDownListContainer.remove();
+					this.selectionDetailsPane.remove();
+					this.selectDropDownListContainer.remove();
+					this.selectionDetailsPane.remove();
 
 					this.selectionDetailsPane.classList.remove('border-bottom');
 					this.selectionDetailsPane.classList.add('border-top');
@@ -879,7 +874,7 @@ export class SelectBoxList extends Disposable implements ISelectBoxDelegate, ILi
 
 				const tagName = child.tagName && child.tagName.toLowerCase();
 				if (tagName === 'img') {
-					element.removeChild(child);
+					child.remove();
 				} else {
 					cleanRenderedMarkdown(child);
 				}

--- a/src/vs/base/browser/ui/splitview/paneview.ts
+++ b/src/vs/base/browser/ui/splitview/paneview.ts
@@ -382,7 +382,7 @@ class PaneDraggable extends Disposable {
 
 		const dragImage = append(this.pane.element.ownerDocument.body, $('.monaco-drag-image', {}, this.pane.draggableElement.textContent || ''));
 		e.dataTransfer.setDragImage(dragImage, -10, -10);
-		setTimeout(() => this.pane.element.ownerDocument.body.removeChild(dragImage), 0);
+		setTimeout(() => dragImage.remove(), 0);
 
 		this.context.draggable = this;
 	}

--- a/src/vs/base/browser/ui/splitview/splitview.ts
+++ b/src/vs/base/browser/ui/splitview/splitview.ts
@@ -1127,7 +1127,7 @@ export class SplitView<TLayoutContext = undefined, TView extends IView<TLayoutCo
 			}
 
 			const onChangeDisposable = view.onDidChange(size => this.onViewChange(item, size));
-			const containerDisposable = toDisposable(() => this.viewContainer.removeChild(container));
+			const containerDisposable = toDisposable(() => container.remove());
 			const disposable = combinedDisposable(onChangeDisposable, containerDisposable);
 
 			let viewSize: ViewItemSize;

--- a/src/vs/base/browser/ui/tree/abstractTree.ts
+++ b/src/vs/base/browser/ui/tree/abstractTree.ts
@@ -796,7 +796,7 @@ class FindWidget<T, TFilterData> extends Disposable {
 		super();
 
 		container.appendChild(this.elements.root);
-		this._register(toDisposable(() => container.removeChild(this.elements.root)));
+		this._register(toDisposable(() => this.elements.root.remove()));
 
 		const styles = options?.styles ?? unthemedFindWidgetStyles;
 

--- a/src/vs/base/test/browser/progressBar.test.ts
+++ b/src/vs/base/test/browser/progressBar.test.ts
@@ -17,7 +17,7 @@ suite('ProgressBar', () => {
 	});
 
 	teardown(() => {
-		mainWindow.document.body.removeChild(fixture);
+		fixture.remove();
 	});
 
 	test('Progress Bar', function () {

--- a/src/vs/editor/browser/config/charWidthReader.ts
+++ b/src/vs/editor/browser/config/charWidthReader.ts
@@ -56,7 +56,7 @@ class DomCharWidthReader {
 		this._readFromDomElements();
 
 		// Remove the container from the DOM
-		this._container!.remove();
+		this._container?.remove();
 
 		this._container = null;
 		this._testElements = null;

--- a/src/vs/editor/browser/config/charWidthReader.ts
+++ b/src/vs/editor/browser/config/charWidthReader.ts
@@ -56,7 +56,7 @@ class DomCharWidthReader {
 		this._readFromDomElements();
 
 		// Remove the container from the DOM
-		targetWindow.document.body.removeChild(this._container!);
+		this._container!.remove();
 
 		this._container = null;
 		this._testElements = null;

--- a/src/vs/editor/browser/controller/textAreaHandler.ts
+++ b/src/vs/editor/browser/controller/textAreaHandler.ts
@@ -950,7 +950,7 @@ function measureText(targetDocument: Document, text: string, fontInfo: FontInfo,
 
 	const res = regularDomNode.offsetWidth;
 
-	targetDocument.body.removeChild(container);
+	container.remove();
 
 	return res;
 }

--- a/src/vs/editor/browser/services/abstractCodeEditorService.ts
+++ b/src/vs/editor/browser/services/abstractCodeEditorService.ts
@@ -341,7 +341,7 @@ class RefCountedStyleSheet {
 	public unref(): void {
 		this._refCount--;
 		if (this._refCount === 0) {
-			this._styleSheet.parentNode?.removeChild(this._styleSheet);
+			this._styleSheet.remove();
 			this._parent._removeEditorStyleSheets(this._editorId);
 		}
 	}

--- a/src/vs/editor/browser/view/domLineBreaksComputer.ts
+++ b/src/vs/editor/browser/view/domLineBreaksComputer.ts
@@ -184,7 +184,7 @@ function createLineBreaks(targetWindow: Window, requests: string[], fontInfo: Fo
 		result[i] = new ModelLineProjectionData(injectionOffsets, injectionOptions, breakOffsets, breakOffsetsVisibleColumn, wrappedTextIndentLength);
 	}
 
-	targetWindow.document.body.removeChild(containerDomNode);
+	containerDomNode.remove();
 	return result;
 }
 

--- a/src/vs/editor/browser/view/viewLayer.ts
+++ b/src/vs/editor/browser/view/viewLayer.ts
@@ -295,9 +295,7 @@ export class VisibleLinesCollection<T extends IVisibleLine> {
 			// Remove from DOM
 			for (let i = 0, len = deleted.length; i < len; i++) {
 				const lineDomNode = deleted[i].getDomNode();
-				if (lineDomNode) {
-					this.domNode.domNode.removeChild(lineDomNode);
-				}
+				lineDomNode?.remove();
 			}
 		}
 
@@ -310,9 +308,7 @@ export class VisibleLinesCollection<T extends IVisibleLine> {
 			// Remove from DOM
 			for (let i = 0, len = deleted.length; i < len; i++) {
 				const lineDomNode = deleted[i].getDomNode();
-				if (lineDomNode) {
-					this.domNode.domNode.removeChild(lineDomNode);
-				}
+				lineDomNode?.remove();
 			}
 		}
 
@@ -481,9 +477,7 @@ class ViewLayerRenderer<T extends IVisibleLine> {
 	private _removeLinesBefore(ctx: IRendererContext<T>, removeCount: number): void {
 		for (let i = 0; i < removeCount; i++) {
 			const lineDomNode = ctx.lines[i].getDomNode();
-			if (lineDomNode) {
-				this.domNode.removeChild(lineDomNode);
-			}
+			lineDomNode?.remove();
 		}
 		ctx.lines.splice(0, removeCount);
 	}
@@ -502,9 +496,7 @@ class ViewLayerRenderer<T extends IVisibleLine> {
 
 		for (let i = 0; i < removeCount; i++) {
 			const lineDomNode = ctx.lines[removeIndex + i].getDomNode();
-			if (lineDomNode) {
-				this.domNode.removeChild(lineDomNode);
-			}
+			lineDomNode?.remove();
 		}
 		ctx.lines.splice(removeIndex, removeCount);
 	}

--- a/src/vs/editor/browser/viewParts/contentWidgets/contentWidgets.ts
+++ b/src/vs/editor/browser/viewParts/contentWidgets/contentWidgets.ts
@@ -121,7 +121,7 @@ export class ViewContentWidgets extends ViewPart {
 			delete this._widgets[widgetId];
 
 			const domNode = myWidget.domNode.domNode;
-			domNode.parentNode!.removeChild(domNode);
+			domNode.remove();
 			domNode.removeAttribute('monaco-visible-content-widget');
 
 			this.setShouldRender();

--- a/src/vs/editor/browser/viewParts/glyphMargin/glyphMargin.ts
+++ b/src/vs/editor/browser/viewParts/glyphMargin/glyphMargin.ts
@@ -243,7 +243,7 @@ export class GlyphMarginWidgets extends ViewPart {
 			const domNode = widgetData.domNode.domNode;
 			delete this._widgets[widgetId];
 
-			domNode.parentNode?.removeChild(domNode);
+			domNode.remove();
 			this.setShouldRender();
 		}
 	}

--- a/src/vs/editor/browser/viewParts/viewZones/viewZones.ts
+++ b/src/vs/editor/browser/viewParts/viewZones/viewZones.ts
@@ -271,12 +271,12 @@ export class ViewZones extends ViewPart {
 
 			zone.domNode.removeAttribute('monaco-visible-view-zone');
 			zone.domNode.removeAttribute('monaco-view-zone');
-			zone.domNode.domNode.parentNode!.removeChild(zone.domNode.domNode);
+			zone.domNode.domNode.remove();
 
 			if (zone.marginDomNode) {
 				zone.marginDomNode.removeAttribute('monaco-visible-view-zone');
 				zone.marginDomNode.removeAttribute('monaco-view-zone');
-				zone.marginDomNode.domNode.parentNode!.removeChild(zone.marginDomNode.domNode);
+				zone.marginDomNode.domNode.remove();
 			}
 
 			this.setShouldRender();

--- a/src/vs/editor/browser/widget/codeEditor/codeEditorWidget.ts
+++ b/src/vs/editor/browser/widget/codeEditor/codeEditorWidget.ts
@@ -1613,7 +1613,7 @@ export class CodeEditorWidget extends Disposable implements editorBrowser.ICodeE
 
 	public setBanner(domNode: HTMLElement | null, domNodeHeight: number): void {
 		if (this._bannerDomNode && this._domElement.contains(this._bannerDomNode)) {
-			this._domElement.removeChild(this._bannerDomNode);
+			this._bannerDomNode.remove();
 		}
 
 		this._bannerDomNode = domNode;
@@ -1874,10 +1874,10 @@ export class CodeEditorWidget extends Disposable implements editorBrowser.ICodeE
 
 		this._domElement.removeAttribute('data-mode-id');
 		if (removeDomNode && this._domElement.contains(removeDomNode)) {
-			this._domElement.removeChild(removeDomNode);
+			removeDomNode.remove();
 		}
 		if (this._bannerDomNode && this._domElement.contains(this._bannerDomNode)) {
-			this._domElement.removeChild(this._bannerDomNode);
+			this._bannerDomNode.remove();
 		}
 		return model;
 	}

--- a/src/vs/editor/browser/widget/diffEditor/diffEditorWidget.ts
+++ b/src/vs/editor/browser/widget/diffEditor/diffEditorWidget.ts
@@ -111,7 +111,7 @@ export class DiffEditorWidget extends DelegatingEditor implements IDiffEditor {
 		this._contextKeyService.createKey('isInDiffEditor', true);
 
 		this._domElement.appendChild(this.elements.root);
-		this._register(toDisposable(() => this._domElement.removeChild(this.elements.root)));
+		this._register(toDisposable(() => this.elements.root.remove()));
 
 		this._rootSizeObserver = this._register(new ObservableElementSizeObserver(this.elements.root, options.dimension));
 		this._rootSizeObserver.setAutomaticLayout(options.automaticLayout ?? false);

--- a/src/vs/editor/browser/widget/diffEditor/utils.ts
+++ b/src/vs/editor/browser/widget/diffEditor/utils.ts
@@ -76,14 +76,14 @@ export function applyObservableDecorations(editor: ICodeEditor, decorations: IOb
 export function appendRemoveOnDispose(parent: HTMLElement, child: HTMLElement) {
 	parent.appendChild(child);
 	return toDisposable(() => {
-		parent.removeChild(child);
+		child.remove();
 	});
 }
 
 export function prependRemoveOnDispose(parent: HTMLElement, child: HTMLElement) {
 	parent.prepend(child);
 	return toDisposable(() => {
-		parent.removeChild(child);
+		child.remove();
 	});
 }
 

--- a/src/vs/editor/browser/widget/diffEditor/utils/editorGutter.ts
+++ b/src/vs/editor/browser/widget/diffEditor/utils/editorGutter.ts
@@ -136,7 +136,7 @@ export class EditorGutter<T extends IGutterItemInfo = IGutterItemInfo> extends D
 		for (const id of unusedIds) {
 			const view = this.views.get(id)!;
 			view.gutterItemView.dispose();
-			this._domNode.removeChild(view.domNode);
+			view.domNode.remove();
 			this.views.delete(id);
 		}
 	}

--- a/src/vs/editor/contrib/find/browser/findWidget.ts
+++ b/src/vs/editor/contrib/find/browser/findWidget.ts
@@ -410,9 +410,7 @@ export class FindWidget extends Widget implements IOverlayWidget, IVerticalSashL
 		}
 
 		// remove previous content
-		if (this._matchesCount.firstChild) {
-			this._matchesCount.removeChild(this._matchesCount.firstChild);
-		}
+		this._matchesCount.firstChild?.remove();
 
 		let label: string;
 		if (this._state.matchesCount > 0) {

--- a/src/vs/platform/actions/browser/floatingMenu.ts
+++ b/src/vs/platform/actions/browser/floatingMenu.ts
@@ -119,7 +119,7 @@ export class FloatingClickMenu extends AbstractFloatingClickMenu {
 		const w = this.instantiationService.createInstance(FloatingClickWidget, action.label);
 		const node = w.getDomNode();
 		this.options.container.appendChild(node);
-		disposable.add(toDisposable(() => this.options.container.removeChild(node)));
+		disposable.add(toDisposable(() => node.remove()));
 		return w;
 	}
 

--- a/src/vs/platform/clipboard/browser/clipboardService.ts
+++ b/src/vs/platform/clipboard/browser/clipboardService.ts
@@ -134,7 +134,7 @@ export class BrowserClipboardService extends Disposable implements IClipboardSer
 			activeElement.focus();
 		}
 
-		activeDocument.body.removeChild(textArea);
+		textArea.remove();
 	}
 
 	async readText(type?: string): Promise<string> {

--- a/src/vs/platform/quickinput/browser/quickInputTree.ts
+++ b/src/vs/platform/quickinput/browser/quickInputTree.ts
@@ -1125,7 +1125,7 @@ export class QuickInputTree extends Disposable {
 				const parent = focusedElement?.parentNode;
 				if (focusedElement && parent) {
 					const nextSibling = focusedElement.nextSibling;
-					parent.removeChild(focusedElement);
+					focusedElement.remove();
 					parent.insertBefore(focusedElement, nextSibling);
 				}
 			}, 0);

--- a/src/vs/platform/quickinput/test/browser/quickinput.test.ts
+++ b/src/vs/platform/quickinput/test/browser/quickinput.test.ts
@@ -57,7 +57,7 @@ suite('QuickInput', () => { // https://github.com/microsoft/vscode/issues/147543
 	setup(() => {
 		const fixture = document.createElement('div');
 		mainWindow.document.body.appendChild(fixture);
-		store.add(toDisposable(() => mainWindow.document.body.removeChild(fixture)));
+		store.add(toDisposable(() => fixture.remove()));
 
 		const instantiationService = new TestInstantiationService();
 

--- a/src/vs/workbench/browser/actions/developerActions.ts
+++ b/src/vs/workbench/browser/actions/developerActions.ts
@@ -63,7 +63,7 @@ class InspectContextKeysAction extends Action2 {
 		const hoverFeedback = document.createElement('div');
 		const activeDocument = getActiveDocument();
 		activeDocument.body.appendChild(hoverFeedback);
-		disposables.add(toDisposable(() => activeDocument.body.removeChild(hoverFeedback)));
+		disposables.add(toDisposable(() => hoverFeedback.remove()));
 
 		hoverFeedback.style.position = 'absolute';
 		hoverFeedback.style.pointerEvents = 'none';

--- a/src/vs/workbench/browser/parts/editor/editorDropTarget.ts
+++ b/src/vs/workbench/browser/parts/editor/editorDropTarget.ts
@@ -92,7 +92,7 @@ class DropOverlay extends Themable {
 		this.groupView.element.appendChild(container);
 		this.groupView.element.classList.add('dragged-over');
 		this._register(toDisposable(() => {
-			this.groupView.element.removeChild(container);
+			container.remove();
 			this.groupView.element.classList.remove('dragged-over');
 		}));
 

--- a/src/vs/workbench/browser/parts/editor/editorPanes.ts
+++ b/src/vs/workbench/browser/parts/editor/editorPanes.ts
@@ -466,7 +466,7 @@ export class EditorPanes extends Disposable {
 		// Remove editor pane from parent
 		const editorPaneContainer = this._activeEditorPane.getContainer();
 		if (editorPaneContainer) {
-			this.editorPanesParent.removeChild(editorPaneContainer);
+			editorPaneContainer.remove();
 			hide(editorPaneContainer);
 		}
 

--- a/src/vs/workbench/browser/parts/editor/sideBySideEditor.ts
+++ b/src/vs/workbench/browser/parts/editor/sideBySideEditor.ts
@@ -160,7 +160,7 @@ export class SideBySideEditor extends AbstractEditorWithViewState<ISideBySideEdi
 		// Clear old (if any) but remember ratio
 		const ratio = this.getSplitViewRatio();
 		if (this.splitview) {
-			container.removeChild(this.splitview.el);
+			this.splitview.el.remove();
 			this.splitviewDisposables.clear();
 		}
 

--- a/src/vs/workbench/browser/parts/notifications/notificationsToasts.ts
+++ b/src/vs/workbench/browser/parts/notifications/notificationsToasts.ts
@@ -602,7 +602,7 @@ export class NotificationsToasts extends Themable implements INotificationsToast
 		if (visible) {
 			notificationsToastsContainer.appendChild(toast.container);
 		} else {
-			notificationsToastsContainer.removeChild(toast.container);
+			toast.container.remove();
 		}
 
 		// Update visibility in model

--- a/src/vs/workbench/browser/parts/views/checkbox.ts
+++ b/src/vs/workbench/browser/parts/views/checkbox.ts
@@ -122,7 +122,7 @@ export class TreeItemCheckbox extends Disposable {
 	private removeCheckbox() {
 		const children = this.checkboxContainer.children;
 		for (const child of children) {
-			this.checkboxContainer.removeChild(child);
+			child.remove();
 		}
 	}
 }

--- a/src/vs/workbench/browser/parts/views/viewPaneContainer.ts
+++ b/src/vs/workbench/browser/parts/views/viewPaneContainer.ts
@@ -112,7 +112,7 @@ class ViewPaneDropOverlay extends Themable {
 		this.paneElement.appendChild(this.container);
 		this.paneElement.classList.add('dragged-over');
 		this._register(toDisposable(() => {
-			this.paneElement.removeChild(this.container);
+			this.container.remove();
 			this.paneElement.classList.remove('dragged-over');
 		}));
 

--- a/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
@@ -279,7 +279,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		}
 		// Remove the input editor from the DOM temporarily to prevent VoiceOver
 		// from reading the cleared text (the request) to the user.
-		this._inputEditorElement.removeChild(domNode);
+		domNode.remove();
 		this._inputEditor.setValue('');
 		this._inputEditorElement.appendChild(domNode);
 		this._inputEditor.focus();

--- a/src/vs/workbench/contrib/codeEditor/browser/find/simpleFindWidget.ts
+++ b/src/vs/workbench/contrib/codeEditor/browser/find/simpleFindWidget.ts
@@ -278,9 +278,7 @@ export abstract class SimpleFindWidget extends Widget implements IVerticalSashLa
 	override dispose() {
 		super.dispose();
 
-		if (this._domNode && this._domNode.parentElement) {
-			this._domNode.parentElement.removeChild(this._domNode);
-		}
+		this._domNode?.remove();
 	}
 
 	public isVisible(): boolean {

--- a/src/vs/workbench/contrib/comments/browser/commentThreadBody.ts
+++ b/src/vs/workbench/contrib/comments/browser/commentThreadBody.ts
@@ -181,7 +181,7 @@ export class CommentThreadBody<T extends IRange | ICellRange = IRange> extends D
 			this._commentDisposable.delete(commentToDelete);
 
 			this._commentElements.splice(commentElementsToDelIndex[i], 1);
-			this._commentsElement.removeChild(commentToDelete.domNode);
+			commentToDelete.domNode.remove();
 		}
 
 

--- a/src/vs/workbench/contrib/extensions/browser/extensionsWidgets.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsWidgets.ts
@@ -294,9 +294,7 @@ export class RecommendationWidget extends ExtensionWidget {
 	}
 
 	private clear(): void {
-		if (this.element) {
-			this.parent.removeChild(this.element);
-		}
+		this.element?.remove();
 		this.element = undefined;
 		this.disposables.clear();
 	}
@@ -330,9 +328,7 @@ export class PreReleaseBookmarkWidget extends ExtensionWidget {
 	}
 
 	private clear(): void {
-		if (this.element) {
-			this.parent.removeChild(this.element);
-		}
+		this.element?.remove();
 		this.element = undefined;
 		this.disposables.clear();
 	}
@@ -367,9 +363,7 @@ export class RemoteBadgeWidget extends ExtensionWidget {
 	}
 
 	private clear(): void {
-		if (this.remoteBadge.value) {
-			this.element.removeChild(this.remoteBadge.value.element);
-		}
+		this.remoteBadge.value?.element.remove();
 		this.remoteBadge.clear();
 	}
 

--- a/src/vs/workbench/contrib/issue/browser/issue.ts
+++ b/src/vs/workbench/contrib/issue/browser/issue.ts
@@ -1076,7 +1076,7 @@ export class BaseIssueReporterService extends Disposable {
 		const showLoading = this.getElementById('ext-loading')!;
 		show(showLoading);
 		while (showLoading.firstChild) {
-			showLoading.removeChild(showLoading.firstChild);
+			showLoading.firstChild.remove();
 		}
 		showLoading.append(element);
 
@@ -1097,7 +1097,7 @@ export class BaseIssueReporterService extends Disposable {
 		const hideLoading = this.getElementById('ext-loading')!;
 		hide(hideLoading);
 		if (hideLoading.firstChild) {
-			hideLoading.removeChild(element);
+			element.remove();
 		}
 		this.renderBlocks();
 	}
@@ -1202,5 +1202,3 @@ export function hide(el: Element | undefined | null) {
 export function show(el: Element | undefined | null) {
 	el?.classList.remove('hidden');
 }
-
-

--- a/src/vs/workbench/contrib/issue/electron-sandbox/issueReporterService.ts
+++ b/src/vs/workbench/contrib/issue/electron-sandbox/issueReporterService.ts
@@ -1356,7 +1356,7 @@ export class IssueReporter extends Disposable {
 		const showLoading = this.getElementById('ext-loading')!;
 		show(showLoading);
 		while (showLoading.firstChild) {
-			showLoading.removeChild(showLoading.firstChild);
+			showLoading.firstChild.remove();
 		}
 		showLoading.append(element);
 
@@ -1377,7 +1377,7 @@ export class IssueReporter extends Disposable {
 		const hideLoading = this.getElementById('ext-loading')!;
 		hide(hideLoading);
 		if (hideLoading.firstChild) {
-			hideLoading.removeChild(element);
+			element.remove();
 		}
 		this.renderBlocks();
 	}

--- a/src/vs/workbench/contrib/issue/electron-sandbox/issueReporterService2.ts
+++ b/src/vs/workbench/contrib/issue/electron-sandbox/issueReporterService2.ts
@@ -464,7 +464,7 @@ export class IssueReporter2 extends BaseIssueReporterService {
 		const showLoading = this.getElementById('ext-loading')!;
 		show(showLoading);
 		while (showLoading.firstChild) {
-			showLoading.removeChild(showLoading.firstChild);
+			showLoading.firstChild.remove();
 		}
 		showLoading.append(element);
 
@@ -485,7 +485,7 @@ export class IssueReporter2 extends BaseIssueReporterService {
 		const hideLoading = this.getElementById('ext-loading')!;
 		hide(hideLoading);
 		if (hideLoading.firstChild) {
-			hideLoading.removeChild(element);
+			element.remove();
 		}
 		this.renderBlocks();
 	}

--- a/src/vs/workbench/contrib/mergeEditor/browser/view/editorGutter.ts
+++ b/src/vs/workbench/contrib/mergeEditor/browser/view/editorGutter.ts
@@ -126,7 +126,7 @@ export class EditorGutter<T extends IGutterItemInfo = IGutterItemInfo> extends D
 		for (const id of unusedIds) {
 			const view = this.views.get(id)!;
 			view.gutterItemView.dispose();
-			this._domNode.removeChild(view.domNode);
+			view.domNode.remove();
 			this.views.delete(id);
 		}
 	}
@@ -154,4 +154,3 @@ export interface IGutterItemView<T extends IGutterItemInfo> extends IDisposable 
 	update(item: T): void;
 	layout(top: number, height: number, viewTop: number, viewHeight: number): void;
 }
-

--- a/src/vs/workbench/contrib/notebook/browser/contrib/find/notebookFindReplaceWidget.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/find/notebookFindReplaceWidget.ts
@@ -717,9 +717,7 @@ export abstract class SimpleFindReplaceWidget extends Widget {
 	override dispose() {
 		super.dispose();
 
-		if (this._domNode && this._domNode.parentElement) {
-			this._domNode.parentElement.removeChild(this._domNode);
-		}
+		this._domNode.remove();
 	}
 
 	public getDomNode() {

--- a/src/vs/workbench/contrib/notebook/browser/contrib/find/notebookFindWidget.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/find/notebookFindWidget.ts
@@ -348,9 +348,7 @@ class NotebookFindWidget extends SimpleFindReplaceWidget implements INotebookEdi
 		this._matchesCount.title = '';
 
 		// remove previous content
-		if (this._matchesCount.firstChild) {
-			this._matchesCount.removeChild(this._matchesCount.firstChild);
-		}
+		this._matchesCount.firstChild?.remove();
 
 		let label: string;
 

--- a/src/vs/workbench/contrib/notebook/browser/diff/diffElementOutputs.ts
+++ b/src/vs/workbench/contrib/notebook/browser/diff/diffElementOutputs.ts
@@ -181,7 +181,7 @@ export class OutputElement extends Disposable {
 			this.resizeListener.clear();
 			const element = this.domNode;
 			if (element) {
-				element.parentElement?.removeChild(element);
+				element.remove();
 				this._notebookEditor.removeInset(
 					this._diffElementViewModel,
 					this._nestedCell,
@@ -259,7 +259,7 @@ export class OutputContainer extends Disposable {
 				// already removed
 				removedKeys.push(key);
 				// remove element from DOM
-				this._outputContainer.removeChild(value.domNode);
+				value.domNode.remove();
 				this._editor.removeInset(this._diffElementViewModel, this._nestedCellViewModel, key, this._diffSide);
 			}
 		});

--- a/src/vs/workbench/contrib/notebook/browser/view/cellParts/cellDnd.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/cellParts/cellDnd.ts
@@ -335,7 +335,7 @@ export class CellDragAndDropController extends Disposable {
 			const dragImage = dragImageProvider();
 			cellRoot.parentElement!.appendChild(dragImage);
 			event.dataTransfer.setDragImage(dragImage, 0, 0);
-			setTimeout(() => cellRoot.parentElement!.removeChild(dragImage), 0); // Comment this out to debug drag image layout
+			setTimeout(() => dragImage.remove(), 0); // Comment this out to debug drag image layout
 		};
 		for (const dragHandle of dragHandles) {
 			templateData.templateDisposables.add(DOM.addDisposableListener(dragHandle, DOM.EventType.DRAG_START, onDragStart));

--- a/src/vs/workbench/contrib/notebook/browser/view/cellParts/cellOutput.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/cellParts/cellOutput.ts
@@ -95,7 +95,7 @@ class CellOutputElement extends Disposable {
 	}
 
 	detach() {
-		this.renderedOutputContainer?.parentElement?.removeChild(this.renderedOutputContainer);
+		this.renderedOutputContainer?.remove();
 
 		let count = 0;
 		if (this.innerContainer) {
@@ -110,7 +110,7 @@ class CellOutputElement extends Disposable {
 			}
 
 			if (count === 0) {
-				this.innerContainer.parentElement?.removeChild(this.innerContainer);
+				this.innerContainer.remove();
 			}
 		}
 
@@ -154,7 +154,7 @@ class CellOutputElement extends Disposable {
 			this._renderDisposableStore.clear();
 			const element = this.innerContainer;
 			if (element) {
-				element.parentElement?.removeChild(element);
+				element.remove();
 				this.notebookEditor.removeInset(this.output);
 			}
 
@@ -400,7 +400,7 @@ class CellOutputElement extends Disposable {
 		this._renderDisposableStore.clear();
 		const element = this.innerContainer;
 		if (element) {
-			element.parentElement?.removeChild(element);
+			element.remove();
 			this.notebookEditor.removeInset(viewModel);
 		}
 
@@ -807,5 +807,3 @@ const JUPYTER_RENDERER_MIMETYPES = [
 	'application/vnd.jupyter.widget-view+json',
 	'application/vnd.code.notebook.error'
 ];
-
-

--- a/src/vs/workbench/contrib/notebook/browser/view/cellParts/cellStatusPart.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/cellParts/cellStatusPart.ts
@@ -235,7 +235,7 @@ export class CellEditorStatusBar extends CellContentPart {
 			if (renderedItems.length > newItems.length) {
 				const deleted = renderedItems.splice(newItems.length, renderedItems.length - newItems.length);
 				for (const deletedItem of deleted) {
-					container.removeChild(deletedItem.container);
+					deletedItem.container.remove();
 					deletedItem.dispose();
 				}
 			}

--- a/src/vs/workbench/contrib/notebook/browser/view/cellParts/codeCell.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/cellParts/codeCell.ts
@@ -128,7 +128,7 @@ export class CodeCell extends Disposable {
 
 		const executionItemElement = DOM.append(this.templateData.cellInputCollapsedContainer, DOM.$('.collapsed-execution-icon'));
 		this._register(toDisposable(() => {
-			executionItemElement.parentElement?.removeChild(executionItemElement);
+			executionItemElement.remove();
 		}));
 		this._collapsedExecutionIcon = this._register(this.instantiationService.createInstance(CollapsedCodeCellExecutionIcon, this.notebookEditor, this.viewCell, executionItemElement));
 		this.updateForCollapseState();
@@ -496,7 +496,7 @@ export class CodeCell extends Disposable {
 		}
 
 		elements.forEach(element => {
-			element.parentElement?.removeChild(element);
+			element.remove();
 		});
 	}
 

--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewPreloads.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/webviewPreloads.ts
@@ -3069,7 +3069,7 @@ async function webviewPreloads(ctx: PreloadContext) {
 			});
 
 			if (this.dragOverlay) {
-				window.document.body.removeChild(this.dragOverlay);
+				this.dragOverlay.remove();
 				this.dragOverlay = undefined;
 			}
 

--- a/src/vs/workbench/contrib/notebook/browser/viewParts/notebookEditorToolbar.ts
+++ b/src/vs/workbench/contrib/notebook/browser/viewParts/notebookEditorToolbar.ts
@@ -416,7 +416,7 @@ export class NotebookEditorWorkbenchToolbar extends Disposable {
 				this._renderLabel = this._convertConfiguration(this.configurationService.getValue<RenderLabelWithFallback>(NotebookSetting.globalToolbarShowLabel));
 				this._updateStrategy();
 				const oldElement = this._notebookLeftToolbar.getElement();
-				oldElement.parentElement?.removeChild(oldElement);
+				oldElement.remove();
 				this._notebookLeftToolbar.dispose();
 
 				this._notebookLeftToolbar = this.instantiationService.createInstance(

--- a/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
@@ -2134,7 +2134,7 @@ function cleanRenderedMarkdown(element: Node): void {
 
 		const tagName = (<Element>child).tagName && (<Element>child).tagName.toLowerCase();
 		if (tagName === 'img') {
-			element.removeChild(child);
+			child.remove();
 		} else {
 			cleanRenderedMarkdown(child);
 		}

--- a/src/vs/workbench/contrib/preferences/browser/settingsWidgets.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsWidgets.ts
@@ -497,7 +497,7 @@ export class ListSettingWidget extends AbstractListSettingWidget<IListDataItem> 
 				const dragImage = this.getDragImage(item);
 				rowElement.ownerDocument.body.appendChild(dragImage);
 				ev.dataTransfer.setDragImage(dragImage, -10, -10);
-				setTimeout(() => rowElement.ownerDocument.body.removeChild(dragImage), 0);
+				setTimeout(() => dragImage.remove(), 0);
 			}
 		}));
 		this.listDisposables.add(DOM.addDisposableListener(rowElement, DOM.EventType.DRAG_OVER, (ev) => {

--- a/src/vs/workbench/contrib/splash/browser/partsSplash.ts
+++ b/src/vs/workbench/contrib/splash/browser/partsSplash.ts
@@ -110,8 +110,6 @@ export class PartsSplash {
 
 		// remove initial colors
 		const defaultStyles = mainWindow.document.head.getElementsByClassName('initialShellColors');
-		if (defaultStyles.length) {
-			mainWindow.document.head.removeChild(defaultStyles[0]);
-		}
+		defaultStyles?.[0].remove();
 	}
 }

--- a/src/vs/workbench/contrib/terminal/browser/terminalGroup.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalGroup.ts
@@ -177,7 +177,7 @@ class SplitPaneContainer extends Disposable {
 
 		// Remove old split view
 		while (this._container.children.length > 0) {
-			this._container.removeChild(this._container.children[0]);
+			this._container.children[0].remove();
 		}
 		this._splitViewDisposables.clear();
 		this._splitView.dispose();
@@ -288,7 +288,7 @@ export class TerminalGroup extends Disposable implements ITerminalGroup {
 		this._onPanelOrientationChanged.fire(this._terminalLocation === ViewContainerLocation.Panel && this._panelPosition === Position.BOTTOM ? Orientation.HORIZONTAL : Orientation.VERTICAL);
 		this._register(toDisposable(() => {
 			if (this._container && this._groupElement) {
-				this._container.removeChild(this._groupElement);
+				this._groupElement.remove();
 				this._groupElement = undefined;
 			}
 		}));

--- a/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
@@ -2296,9 +2296,7 @@ class TerminalInstanceDragAndDropController extends Disposable implements dom.ID
 	}
 
 	private _clearDropOverlay() {
-		if (this._dropOverlay && this._dropOverlay.parentElement) {
-			this._dropOverlay.parentElement.removeChild(this._dropOverlay);
-		}
+		this._dropOverlay?.remove();
 		this._dropOverlay = undefined;
 	}
 

--- a/src/vs/workbench/contrib/terminal/browser/terminalService.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalService.ts
@@ -1207,7 +1207,7 @@ class TerminalEditorStyle extends Themable {
 		super(_themeService);
 		this._registerListeners();
 		this._styleElement = dom.createStyleSheet(container);
-		this._register(toDisposable(() => container.removeChild(this._styleElement)));
+		this._register(toDisposable(() => this._styleElement.remove()));
 		this.updateStyles();
 	}
 

--- a/src/vs/workbench/contrib/terminal/browser/terminalTabbedView.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalTabbedView.ts
@@ -174,9 +174,7 @@ export class TerminalTabbedView extends Disposable {
 		} else {
 			if (this._splitView.length === 2 && !this._terminalTabsMouseContextKey.get()) {
 				this._splitView.removeView(this._tabTreeIndex);
-				if (this._plusButton) {
-					this._tabContainer.removeChild(this._plusButton);
-				}
+				this._plusButton?.remove();
 				this._removeSashListener();
 			}
 		}

--- a/src/vs/workbench/contrib/terminal/browser/terminalView.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalView.ts
@@ -585,7 +585,7 @@ class TerminalThemeIconStyle extends Themable {
 		super(_themeService);
 		this._registerListeners();
 		this._styleElement = dom.createStyleSheet(container);
-		this._register(toDisposable(() => container.removeChild(this._styleElement)));
+		this._register(toDisposable(() => this._styleElement.remove()));
 		this.updateStyles();
 	}
 

--- a/src/vs/workbench/contrib/terminal/browser/widgets/widgetManager.ts
+++ b/src/vs/workbench/contrib/terminal/browser/widgets/widgetManager.ts
@@ -19,8 +19,8 @@ export class TerminalWidgetManager implements IDisposable {
 	}
 
 	dispose(): void {
-		if (this._container && this._container.parentElement) {
-			this._container.parentElement.removeChild(this._container);
+		if (this._container) {
+			this._container.remove();
 			this._container = undefined;
 		}
 	}

--- a/src/vs/workbench/contrib/testing/browser/testCoverageBars.ts
+++ b/src/vs/workbench/contrib/testing/browser/testCoverageBars.ts
@@ -99,7 +99,7 @@ export class ManagedTestCoverageBars extends Disposable {
 
 		if (!this._coverage) {
 			const root = this.el.value.root;
-			ds.add(toDisposable(() => this.options.container.removeChild(root)));
+			ds.add(toDisposable(() => root.remove()));
 			this.options.container.appendChild(root);
 			ds.add(this.configurationService.onDidChangeConfiguration(c => {
 				if (!this._coverage) {

--- a/src/vs/workbench/contrib/testing/browser/testingExplorerView.ts
+++ b/src/vs/workbench/contrib/testing/browser/testingExplorerView.ts
@@ -500,7 +500,7 @@ class ResultSummaryView extends Disposable {
 		const { count, root, status, duration, rerun } = this.elements;
 		if (!results.length) {
 			if (this.elementsWereAttached) {
-				this.container.removeChild(root);
+				root.remove();
 				this.elementsWereAttached = false;
 			}
 			this.container.innerText = localize('noResults', 'No test results yet.');

--- a/src/vs/workbench/contrib/testing/browser/testingOutputPeek.ts
+++ b/src/vs/workbench/contrib/testing/browser/testingOutputPeek.ts
@@ -827,7 +827,7 @@ class FollowupActionWidget extends Disposable {
 
 		this.container.appendChild(this.el.root);
 		this.visibleStore.add(toDisposable(() => {
-			this.el.root.parentElement?.removeChild(this.el.root);
+			this.el.root.remove();
 		}));
 	}
 
@@ -1377,7 +1377,7 @@ class ScrollableMarkdownMessage extends Disposable {
 		container.appendChild(this.scrollable.getDomNode());
 
 		this._register(toDisposable(() => {
-			container.removeChild(this.scrollable.getDomNode());
+			this.scrollable.getDomNode().remove();
 		}));
 
 		this.scrollable.scanDomNode();

--- a/src/vs/workbench/contrib/webview/browser/pre/index-no-csp.html
+++ b/src/vs/workbench/contrib/webview/browser/pre/index-no-csp.html
@@ -973,7 +973,7 @@
 				const previousPendingFrame = getPendingFrame();
 				if (previousPendingFrame) {
 					previousPendingFrame.setAttribute('id', '');
-					document.body.removeChild(previousPendingFrame);
+					previousPendingFrame.remove();
 				}
 				if (!wasFirstLoad) {
 					pendingMessages = [];
@@ -1070,9 +1070,7 @@
 					if (newFrame && newFrame.contentDocument && newFrame.contentDocument === contentDocument) {
 						const wasFocused = document.hasFocus();
 						const oldActiveFrame = getActiveFrame();
-						if (oldActiveFrame) {
-							document.body.removeChild(oldActiveFrame);
-						}
+						oldActiveFrame?.remove();
 						// Styles may have changed since we created the element. Make sure we re-style
 						if (initialStyleVersion !== styleVersion) {
 							applyStyles(newFrame.contentDocument, newFrame.contentDocument.body);

--- a/src/vs/workbench/contrib/webview/browser/pre/index.html
+++ b/src/vs/workbench/contrib/webview/browser/pre/index.html
@@ -5,7 +5,7 @@
 	<meta charset="UTF-8">
 
 	<meta http-equiv="Content-Security-Policy"
-		content="default-src 'none'; script-src 'sha256-bQPwjO6bLiyf6v9eDVtAI67LrfonA1w49aFkRXBy4/g=' 'self'; frame-src 'self'; style-src 'unsafe-inline';">
+		content="default-src 'none'; script-src 'sha256-noHVLQsurkONXmA3fcuAmcZ8UPYm/db88mhm9gAXcvk=' 'self'; frame-src 'self'; style-src 'unsafe-inline';">
 
 	<!-- Disable pinch zooming -->
 	<meta name="viewport"

--- a/src/vs/workbench/contrib/webview/browser/pre/index.html
+++ b/src/vs/workbench/contrib/webview/browser/pre/index.html
@@ -974,7 +974,7 @@
 				const previousPendingFrame = getPendingFrame();
 				if (previousPendingFrame) {
 					previousPendingFrame.setAttribute('id', '');
-					document.body.removeChild(previousPendingFrame);
+					previousPendingFrame.remove();
 				}
 				if (!wasFirstLoad) {
 					pendingMessages = [];
@@ -1071,9 +1071,7 @@
 					if (newFrame && newFrame.contentDocument && newFrame.contentDocument === contentDocument) {
 						const wasFocused = document.hasFocus();
 						const oldActiveFrame = getActiveFrame();
-						if (oldActiveFrame) {
-							document.body.removeChild(oldActiveFrame);
-						}
+						oldActiveFrame?.remove();
 						// Styles may have changed since we created the element. Make sure we re-style
 						if (initialStyleVersion !== styleVersion) {
 							applyStyles(newFrame.contentDocument, newFrame.contentDocument.body);

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStarted.ts
@@ -1378,7 +1378,7 @@ export class GettingStartedPage extends EditorPane {
 	}
 
 	private buildMarkdownDescription(container: HTMLElement, text: LinkedText[]) {
-		while (container.firstChild) { container.removeChild(container.firstChild); }
+		while (container.firstChild) { container.firstChild.remove(); }
 
 		for (const linkedText of text) {
 			if (linkedText.nodes.length === 1 && typeof linkedText.nodes[0] !== 'string') {

--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStartedList.ts
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStartedList.ts
@@ -123,7 +123,7 @@ export class GettingStartedIndexList<T extends { id: string; when?: ContextKeyEx
 
 
 		while (this.list.firstChild) {
-			this.list.removeChild(this.list.firstChild);
+			this.list.firstChild.remove();
 		}
 
 		this.itemCount = limitedEntries.length;

--- a/src/vs/workbench/contrib/welcomeWalkthrough/browser/walkThroughPart.ts
+++ b/src/vs/workbench/contrib/welcomeWalkthrough/browser/walkThroughPart.ts
@@ -414,7 +414,7 @@ export class WalkThroughPart extends EditorPane {
 			const keybinding = command && this.keybindingService.lookupKeybinding(command);
 			const label = keybinding ? keybinding.getLabel() || '' : UNBOUND_COMMAND;
 			while (key.firstChild) {
-				key.removeChild(key.firstChild);
+				key.firstChild.remove();
 			}
 			key.appendChild(document.createTextNode(label));
 		});
@@ -433,7 +433,7 @@ export class WalkThroughPart extends EditorPane {
 		const keys = this.content.querySelectorAll('.multi-cursor-modifier');
 		Array.prototype.forEach.call(keys, (key: Element) => {
 			while (key.firstChild) {
-				key.removeChild(key.firstChild);
+				key.firstChild.remove();
 			}
 			key.appendChild(document.createTextNode(modifier));
 		});

--- a/src/vs/workbench/test/browser/part.test.ts
+++ b/src/vs/workbench/test/browser/part.test.ts
@@ -115,7 +115,7 @@ suite('Workbench parts', () => {
 	});
 
 	teardown(() => {
-		mainWindow.document.body.removeChild(fixture);
+		fixture.remove();
 		disposables.clear();
 	});
 


### PR DESCRIPTION
This replaces most uses of `parent.removeChild(child)` with `child.remove()`.

The two are almost equivalent. The only difference is that `parent.removeChild(child)` throws if the given node is not a child of the parent, whereas `child.remove()` never throws. There is no noticable performance difference. The only reason to use `removeChild` is to support Internet Explorer, but that’s no longer supported by Monaco editor.

I tested this in the Monaco playground, but not very thoroughly.