### PR TITLE
Sort @workspace /explain above @terminal /explain

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/contrib/chatInputCompletions.ts
+++ b/src/vs/workbench/contrib/chat/browser/contrib/chatInputCompletions.ts
@@ -203,6 +203,16 @@ class AgentCompletions extends Disposable {
 				const agents = this.chatAgentService.getAgents()
 					.filter(a => a.locations.includes(widget.location));
 
+				// When the input is only `/`, items are sorted by sortText.
+				// When typing, filterText is used to score and sort.
+				// The same list is refiltered/ranked while typing.
+				const getFilterText = (agent: IChatAgentData, command: string) => {
+					// This is hacking the filter algorithm to make @terminal /explain match worse than @workspace /explain by making its match index later in the string.
+					// When I type `/exp`, the workspace one should be sorted over the terminal one.
+					const dummyPrefix = agent.id === 'github.copilot.terminal' ? `0000` : ``;
+					return `${chatSubcommandLeader}${dummyPrefix}${agent.name}.${command}`;
+				};
+
 				const justAgents: CompletionItem[] = agents
 					.filter(a => !a.isDefault)
 					.map(agent => {
@@ -218,7 +228,7 @@ class AgentCompletions extends Disposable {
 							insertText: `${agentLabel} `,
 							range: new Range(1, 1, 1, 1),
 							kind: CompletionItemKind.Text,
-							sortText: `${chatSubcommandLeader}${agent.id}`,
+							sortText: `${chatSubcommandLeader}${agent.name}`,
 							command: { id: AssignSelectedAgentAction.ID, title: AssignSelectedAgentAction.ID, arguments: [{ agent, widget } satisfies AssignSelectedAgentActionArgs] },
 						};
 					});
@@ -230,13 +240,13 @@ class AgentCompletions extends Disposable {
 							const withSlash = `${chatSubcommandLeader}${c.name}`;
 							return {
 								label: { label: withSlash, description: agentLabel, detail: isDupe ? ` (${agent.publisherDisplayName})` : undefined },
-								filterText: `${chatSubcommandLeader}${agent.name}${c.name}`,
+								filterText: getFilterText(agent, c.name),
 								commitCharacters: [' '],
 								insertText: `${agentLabel} ${withSlash} `,
 								detail: `(${agentLabel}) ${c.description ?? ''}`,
 								range: new Range(1, 1, 1, 1),
 								kind: CompletionItemKind.Text, // The icons are disabled here anyway
-								sortText: `${chatSubcommandLeader}${agent.id}${c.name}`,
+								sortText: `${chatSubcommandLeader}${agent.name}${c.name}`,
 								command: { id: AssignSelectedAgentAction.ID, title: AssignSelectedAgentAction.ID, arguments: [{ agent, widget } satisfies AssignSelectedAgentActionArgs] },
 							} satisfies CompletionItem;
 						})))


### PR DESCRIPTION
Fix microsoft/vscode-copilot-release#1245

This is a bit of a hack but has some advantanges over adding an 'order' field to the chat participant or something like that. We can keep the order the same in other cases except for when the user is typing to filter the / list, then @terminal slash commands will be pushed down.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
