### PR TITLE
Add license for deviceid

### DIFF
--- a/cglicenses.json
+++ b/cglicenses.json
@@ -131,6 +131,19 @@
 		]
 	},
 	{
+		// Reason: NPM package does not include repository URL https://github.com/microsoft/vscode-deviceid/issues/12
+		"name": "@vscode/deviceid",
+		"fullLicenseText": [
+			"MIT License",
+			"",
+			"Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the \"Software\"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:",
+			"",
+			"The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.",
+			"",
+			"THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE."
+		]
+	},
+	{
 		// Reason: Missing license file
 		"name": "@tokenizer/token",
 		"fullLicenseText": [


### PR DESCRIPTION
Add license to cglicenses.json due the NPM package not including the repository URL: https://github.com/microsoft/vscode-deviceid/issues/12