### PR TITLE
Fix copyright statement

### DIFF
--- a/cglicenses.json
+++ b/cglicenses.json
@@ -134,6 +134,8 @@
 		// Reason: NPM package does not include repository URL https://github.com/microsoft/vscode-deviceid/issues/12
 		"name": "@vscode/deviceid",
 		"fullLicenseText": [
+			"Copyright (c) Microsoft Corporation.",
+			"",
 			"MIT License",
 			"",
 			"Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the \"Software\"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:",


### PR DESCRIPTION
This pull request fixes the copyright statement in the codebase. The previous statement was missing the copyright holder information. The new statement includes the copyright notice for Microsoft Corporation. This change ensures that the codebase complies with copyright requirements.