### PR TITLE
fix wrong colors when editor findMatchForeground is not defined

### DIFF
--- a/src/vs/editor/contrib/find/browser/findWidget.css
+++ b/src/vs/editor/contrib/find/browser/findWidget.css
@@ -232,19 +232,11 @@
 	background-color: var(--vscode-editor-findMatchHighlightBackground);
 }
 
-.monaco-editor .findMatchInline {
-	color: var(--vscode-editor-findMatchHighlightForeground);
-}
-
 .monaco-editor .currentFindMatch {
 	background-color: var(--vscode-editor-findMatchBackground);
 	border: 2px solid var(--vscode-editor-findMatchBorder);
 	padding: 1px;
 	box-sizing: border-box;
-}
-
-.monaco-editor .currentFindMatchInline {
-	color: var(--vscode-editor-findMatchForeground);
 }
 
 .monaco-editor .findScope {

--- a/src/vs/editor/contrib/find/browser/findWidget.ts
+++ b/src/vs/editor/contrib/find/browser/findWidget.ts
@@ -35,7 +35,7 @@ import { IContextKey, IContextKeyService } from 'vs/platform/contextkey/common/c
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 import { INotificationService } from 'vs/platform/notification/common/notification';
 import { IStorageService, StorageScope, StorageTarget } from 'vs/platform/storage/common/storage';
-import { asCssVariable, contrastBorder, editorFindMatchHighlightBorder, editorFindRangeHighlightBorder, inputActiveOptionBackground, inputActiveOptionBorder, inputActiveOptionForeground } from 'vs/platform/theme/common/colorRegistry';
+import { asCssVariable, contrastBorder, editorFindMatchForeground, editorFindMatchHighlightBorder, editorFindMatchHighlightForeground, editorFindRangeHighlightBorder, inputActiveOptionBackground, inputActiveOptionBorder, inputActiveOptionForeground } from 'vs/platform/theme/common/colorRegistry';
 import { registerIcon, widgetClose } from 'vs/platform/theme/common/iconRegistry';
 import { IThemeService, registerThemingParticipant } from 'vs/platform/theme/common/themeService';
 import { ThemeIcon } from 'vs/base/common/themables';
@@ -1408,5 +1408,13 @@ registerThemingParticipant((theme, collector) => {
 	const hcBorder = theme.getColor(contrastBorder);
 	if (hcBorder) {
 		collector.addRule(`.monaco-editor .find-widget { border: 1px solid ${hcBorder}; }`);
+	}
+	const findMatchForeground = theme.getColor(editorFindMatchForeground);
+	if (findMatchForeground) {
+		collector.addRule(`.monaco-editor .findMatchInline { color: var(--vscode-editor-findMatchForeground); }`);
+	}
+	const findMatchHighlightForeground = theme.getColor(editorFindMatchHighlightForeground);
+	if (findMatchHighlightForeground) {
+		collector.addRule(`.monaco-editor .findMatchInline { color: var(--vscode-editor-findMatchHighlightForeground); }`);
 	}
 });

--- a/src/vs/editor/contrib/find/browser/findWidget.ts
+++ b/src/vs/editor/contrib/find/browser/findWidget.ts
@@ -1415,6 +1415,6 @@ registerThemingParticipant((theme, collector) => {
 	}
 	const findMatchHighlightForeground = theme.getColor(editorFindMatchHighlightForeground);
 	if (findMatchHighlightForeground) {
-		collector.addRule(`.monaco-editor .findMatchInline { color: var(--vscode-editor-findMatchHighlightForeground); }`);
+		collector.addRule(`.monaco-editor .currentFindMatchInline { color: var(--vscode-editor-findMatchHighlightForeground); }`);
 	}
 });

--- a/src/vs/editor/contrib/find/browser/findWidget.ts
+++ b/src/vs/editor/contrib/find/browser/findWidget.ts
@@ -1411,10 +1411,10 @@ registerThemingParticipant((theme, collector) => {
 	}
 	const findMatchForeground = theme.getColor(editorFindMatchForeground);
 	if (findMatchForeground) {
-		collector.addRule(`.monaco-editor .findMatchInline { color: var(--vscode-editor-findMatchForeground); }`);
+		collector.addRule(`.monaco-editor .findMatchInline { color: ${editorFindMatchForeground}; }`);
 	}
 	const findMatchHighlightForeground = theme.getColor(editorFindMatchHighlightForeground);
 	if (findMatchHighlightForeground) {
-		collector.addRule(`.monaco-editor .currentFindMatchInline { color: var(--vscode-editor-findMatchHighlightForeground); }`);
+		collector.addRule(`.monaco-editor .currentFindMatchInline { color: ${findMatchHighlightForeground}; }`);
 	}
 });

--- a/src/vs/editor/contrib/find/browser/findWidget.ts
+++ b/src/vs/editor/contrib/find/browser/findWidget.ts
@@ -1411,7 +1411,7 @@ registerThemingParticipant((theme, collector) => {
 	}
 	const findMatchForeground = theme.getColor(editorFindMatchForeground);
 	if (findMatchForeground) {
-		collector.addRule(`.monaco-editor .findMatchInline { color: ${editorFindMatchForeground}; }`);
+		collector.addRule(`.monaco-editor .findMatchInline { color: ${findMatchForeground}; }`);
 	}
 	const findMatchHighlightForeground = theme.getColor(editorFindMatchHighlightForeground);
 	if (findMatchHighlightForeground) {


### PR DESCRIPTION
fixes #29091 

When `editor.findMatchForeground` is not defined, it still overwrites the token colors. This PR changes the css to only enable the  `editorFindMatchForeground` css when `editor.findMatchForeground` is defined.

https://github.com/microsoft/vscode/assets/23744935/b250115f-0e8f-4095-9457-28a7171a5e95

