### PR TITLE
fix windows terminal hint not showing up

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/chat/browser/terminal.initialHint.contribution.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chat/browser/terminal.initialHint.contribution.ts
@@ -108,7 +108,7 @@ export class TerminalInitialHintContribution extends Disposable implements ITerm
 	private _createHint(): void {
 		const instance = this._instance instanceof TerminalInstance ? this._instance : undefined;
 		const commandDetectionCapability = instance?.capabilities.get(TerminalCapability.CommandDetection);
-		if (!instance || !this._xterm || this._hintWidget || !commandDetectionCapability || commandDetectionCapability?.hasInput || instance.reconnectionProperties) {
+		if (!instance || !this._xterm || this._hintWidget || !commandDetectionCapability || commandDetectionCapability.promptInputModel.value || instance.reconnectionProperties) {
 			return;
 		}
 


### PR DESCRIPTION
fix #213693

use `promptInputModel` instead of `hasInput` as it's more accurate

![image](https://github.com/microsoft/vscode/assets/29464607/26c33434-2076-4427-a5d1-a3b99642be0f)
