### PR TITLE
defaults web issue report false and disable in Firefox

### DIFF
--- a/src/vs/workbench/contrib/issue/browser/issue.contribution.ts
+++ b/src/vs/workbench/contrib/issue/browser/issue.contribution.ts
@@ -40,7 +40,7 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration)
 		properties: {
 			'issueReporter.experimental.webReporter': {
 				type: 'boolean',
-				default: true,
+				default: false,
 				description: 'Enable experimental issue reporter for web.',
 			},
 		}

--- a/src/vs/workbench/contrib/issue/browser/issueService.ts
+++ b/src/vs/workbench/contrib/issue/browser/issueService.ts
@@ -49,7 +49,7 @@ export class BrowserIssueService implements IWorkbenchIssueService {
 	}
 
 	async openReporter(options: Partial<IssueReporterData>): Promise<void> {
-		// If web reporter setting is turned off, or if we are in Firefox, open the old GitHub issue reporter
+		// If web reporter setting is false, or if we are in Firefox, open the old GitHub issue reporter
 		if (!this.configurationService.getValue<boolean>('issueReporter.experimental.webReporter') || isFirefox) {
 			const extensionId = options.extensionId;
 			// If we don't have a extensionId, treat this as a Core issue

--- a/src/vs/workbench/contrib/issue/browser/issueService.ts
+++ b/src/vs/workbench/contrib/issue/browser/issueService.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as dom from 'vs/base/browser/dom';
-import { userAgent } from 'vs/base/common/platform';
+import { isFirefox, userAgent } from 'vs/base/common/platform';
 import { IExtensionDescription, ExtensionType } from 'vs/platform/extensions/common/extensions';
 import { normalizeGitHubUrl } from 'vs/platform/issue/common/issueReporterUtil';
 import { getZoomLevel } from 'vs/base/browser/browser';
@@ -49,7 +49,8 @@ export class BrowserIssueService implements IWorkbenchIssueService {
 	}
 
 	async openReporter(options: Partial<IssueReporterData>): Promise<void> {
-		if (!this.configurationService.getValue<boolean>('issueReporter.experimental.webReporter')) {
+		// If web reporter setting is turned off, or if we are in Firefox, open the old GitHub issue reporter
+		if (!this.configurationService.getValue<boolean>('issueReporter.experimental.webReporter') || isFirefox) {
 			const extensionId = options.extensionId;
 			// If we don't have a extensionId, treat this as a Core issue
 			if (!extensionId) {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

ref https://github.com/microsoft/vscode/issues/213645

enabled `issueReporter.experimental.webReporter` as true for insiders, but turning off for release.

also turning off web reporting for Firefox pending above issue