### PR TITLE
Regression: adding back hover widget CSS that had been removed

### DIFF
--- a/src/vs/base/browser/ui/hover/hoverWidget.css
+++ b/src/vs/base/browser/ui/hover/hoverWidget.css
@@ -171,11 +171,6 @@
 	display: inline-block;
 }
 
-.monaco-hover-content {
-	padding-right: 2px;
-	box-sizing: border-box;
-}
-
 .monaco-hover-content .action-container a {
 	-webkit-user-select: none;
 	user-select: none;

--- a/src/vs/base/browser/ui/hover/hoverWidget.css
+++ b/src/vs/base/browser/ui/hover/hoverWidget.css
@@ -171,6 +171,11 @@
 	display: inline-block;
 }
 
+.monaco-hover-content {
+	padding-right: 2px;
+	box-sizing: border-box;
+}
+
 .monaco-hover-content .action-container a {
 	-webkit-user-select: none;
 	user-select: none;

--- a/src/vs/base/browser/ui/hover/hoverWidget.ts
+++ b/src/vs/base/browser/ui/hover/hoverWidget.ts
@@ -21,6 +21,7 @@ export class HoverWidget extends Disposable {
 
 	public readonly containerDomNode: HTMLElement;
 	public readonly contentsDomNode: HTMLElement;
+	public readonly scrollableDomNode: HTMLElement;
 	public readonly scrollbar: DomScrollableElement;
 
 	constructor() {
@@ -37,7 +38,8 @@ export class HoverWidget extends Disposable {
 		this.scrollbar = this._register(new DomScrollableElement(this.contentsDomNode, {
 			consumeMouseWheelIfScrollbarIsNeeded: true
 		}));
-		this.containerDomNode.appendChild(this.scrollbar.getDomNode());
+		this.scrollableDomNode = this.scrollbar.getDomNode();
+		this.containerDomNode.appendChild(this.scrollableDomNode);
 	}
 
 	public onContentsChanged(): void {

--- a/src/vs/editor/contrib/hover/browser/contentHoverWidget.ts
+++ b/src/vs/editor/contrib/hover/browser/contentHoverWidget.ts
@@ -107,6 +107,11 @@ export class ContentHoverWidget extends ResizableContentWidget {
 		container.style.height = transformedHeight;
 	}
 
+	private _setScrollableDomNodeDimensions(width: number | string, height: number | string): void {
+		const scrollableDomNode = this._hover.scrollableDomNode;
+		return ContentHoverWidget._applyDimensions(scrollableDomNode, width, height);
+	}
+
 	private _setContentsDomNodeDimensions(width: number | string, height: number | string): void {
 		const contentsDomNode = this._hover.contentsDomNode;
 		return ContentHoverWidget._applyDimensions(contentsDomNode, width, height);
@@ -118,8 +123,11 @@ export class ContentHoverWidget extends ResizableContentWidget {
 	}
 
 	private _setHoverWidgetDimensions(width: number | string, height: number | string): void {
+		const modifiedWidth = typeof width === 'number' ? width : width; // + 2
+		const modifiedHeight = typeof height === 'number' ? height : height; // + 2
 		this._setContentsDomNodeDimensions(width, height);
-		this._setContainerDomNodeDimensions(width, height);
+		this._setScrollableDomNodeDimensions(modifiedWidth, modifiedHeight);
+		this._setContainerDomNodeDimensions(modifiedWidth, modifiedHeight);
 		this._layoutContentWidget();
 	}
 
@@ -133,6 +141,7 @@ export class ContentHoverWidget extends ResizableContentWidget {
 	private _setHoverWidgetMaxDimensions(width: number | string, height: number | string): void {
 		ContentHoverWidget._applyMaxDimensions(this._hover.contentsDomNode, width, height);
 		ContentHoverWidget._applyMaxDimensions(this._hover.containerDomNode, width, height);
+		ContentHoverWidget._applyMaxDimensions(this._hover.scrollableDomNode, width, height);
 		this._hover.containerDomNode.style.setProperty('--vscode-hover-maxWidth', typeof width === 'number' ? `${width}px` : width);
 		this._layoutContentWidget();
 	}
@@ -209,7 +218,7 @@ export class ContentHoverWidget extends ResizableContentWidget {
 		const initialWidth = (
 			typeof this._contentWidth === 'undefined'
 				? 0
-				: this._contentWidth - 2 // - 2 for the borders
+				: this._contentWidth // remove maybe
 		);
 
 		if (overflowing || this._hover.containerDomNode.clientWidth < initialWidth) {
@@ -217,7 +226,7 @@ export class ContentHoverWidget extends ResizableContentWidget {
 			const horizontalPadding = 14;
 			return bodyBoxWidth - horizontalPadding;
 		} else {
-			return this._hover.containerDomNode.clientWidth + 2;
+			return this._hover.containerDomNode.clientWidth; // remove maybe
 		}
 	}
 

--- a/src/vs/editor/contrib/hover/browser/hover.css
+++ b/src/vs/editor/contrib/hover/browser/hover.css
@@ -10,8 +10,16 @@
 .monaco-editor .monaco-hover {
 	color: var(--vscode-editorHoverWidget-foreground);
 	background-color: var(--vscode-editorHoverWidget-background);
-	border: 1px solid var(--vscode-editorHoverWidget-border);
-	border-radius: 3px;
+	outline: 1px solid var(--vscode-editorHoverWidget-border);
+}
+
+.monaco-editor .monaco-hover .monaco-scrollable-element {
+	/* box-sizing: border-box; */
+}
+
+.monaco-editor .monaco-hover-content {
+	/* box-sizing: border-box; */
+	/* padding: 1px 1px 1px 1px; */
 }
 
 .monaco-editor .monaco-hover a {
@@ -24,6 +32,13 @@
 
 .monaco-editor .monaco-hover .hover-row {
 	display: flex;
+	box-sizing: border-box;
+	border: 1px solid transparent;
+	/* margin: 1px 1px 1px 1px; */
+}
+
+.monaco-editor .monaco-hover .hover-row:focus {
+	border: 1px solid var(--vscode-focusBorder);
 }
 
 .monaco-editor .monaco-hover .hover-row .hover-row-contents {

--- a/src/vs/editor/contrib/hover/browser/hoverController.ts
+++ b/src/vs/editor/contrib/hover/browser/hoverController.ts
@@ -27,7 +27,7 @@ import { Emitter } from 'vs/base/common/event';
 
 // sticky hover widget which doesn't disappear on focus out and such
 const _sticky = false
-	// || Boolean("true") // done "weirdly" so that a lint warning prevents you from pushing this
+	|| Boolean("true") // done "weirdly" so that a lint warning prevents you from pushing this
 	;
 
 interface IHoverSettings {


### PR DESCRIPTION
The PR that was merged yesterday https://github.com/microsoft/vscode/pull/213700 has caused the inner right hover border to no longer be visible when it is focused. This PR adds the CSS back for the padding-right, but omits the padding-bottom. 