### PR TITLE
Align terminal initial hint styles with the editor

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/chat/browser/media/terminalInitialHint.css
+++ b/src/vs/workbench/contrib/terminalContrib/chat/browser/media/terminalInitialHint.css
@@ -7,5 +7,10 @@
 	color: var(--vscode-input-placeholderForeground);
 }
 .monaco-workbench .pane-body.integrated-terminal .terminal-initial-hint a {
-	color: var(--vscode-textLink-foreground)
+	color: var(--vscode-textLink-foreground);
+}
+
+.monaco-workbench .pane-body.integrated-terminal .terminal-initial-hint a,
+.monaco-workbench .pane-body.integrated-terminal .terminal-initial-hint .detail {
+	font-style: italic;
 }

--- a/src/vs/workbench/contrib/terminalContrib/chat/browser/media/terminalInitialHint.css
+++ b/src/vs/workbench/contrib/terminalContrib/chat/browser/media/terminalInitialHint.css
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-.monaco-workbench .pane-body.integrated-terminal .contentWidgets .terminal-initial-hint {
+.monaco-workbench .pane-body.integrated-terminal .terminal-initial-hint {
 	color: var(--vscode-input-placeholderForeground);
 }
 .monaco-workbench .pane-body.integrated-terminal .terminal-initial-hint a {

--- a/src/vs/workbench/contrib/terminalContrib/chat/browser/terminal.initialHint.contribution.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chat/browser/terminal.initialHint.contribution.ts
@@ -247,7 +247,7 @@ class TerminalInitialHintWidget extends Disposable {
 			}
 		};
 
-		const hintElement = $('terminal-initial-hint');
+		const hintElement = $('div.terminal-initial-hint');
 		hintElement.style.display = 'block';
 
 		const keybindingHint = this.keybindingService.lookupKeybinding(TerminalChatCommandId.Start);

--- a/src/vs/workbench/contrib/terminalContrib/chat/browser/terminal.initialHint.contribution.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chat/browser/terminal.initialHint.contribution.ts
@@ -275,8 +275,7 @@ class TerminalInitialHintWidget extends Disposable {
 			hintElement.appendChild(after);
 
 			const typeToDismiss = localize('hintTextDismiss', 'Start typing to dismiss.');
-			const textHint2 = $('span', undefined, typeToDismiss);
-			textHint2.style.fontStyle = 'italic';
+			const textHint2 = $('span.detail', undefined, typeToDismiss);
 			hintElement.appendChild(textHint2);
 
 			ariaLabel = actionPart.concat(typeToDismiss);


### PR DESCRIPTION
![image](https://github.com/microsoft/vscode/assets/2193314/9552433c-27f5-469c-b53f-fcf070834c9b)

Fixes #213647