### PR TITLE
Fix multi selected tab close behavior

### DIFF
--- a/src/vs/workbench/browser/parts/editor/editorActions.ts
+++ b/src/vs/workbench/browser/parts/editor/editorActions.ts
@@ -437,7 +437,7 @@ export class UnpinEditorAction extends Action {
 	}
 }
 
-export class CloseOneEditorAction extends Action {
+export class CloseEditorTabAction extends Action {
 
 	static readonly ID = 'workbench.action.closeActiveEditor';
 	static readonly LABEL = localize('closeOneEditor', "Close");
@@ -451,33 +451,28 @@ export class CloseOneEditorAction extends Action {
 	}
 
 	override async run(context?: IEditorCommandsContext): Promise<void> {
-		let group: IEditorGroup | undefined;
-		let editorIndex: number | undefined;
-		if (context) {
-			group = this.editorGroupService.getGroup(context.groupId);
-
-			if (group) {
-				editorIndex = context.editorIndex; // only allow editor at index if group is valid
-			}
-		}
-
+		const group = context ? this.editorGroupService.getGroup(context.groupId) : this.editorGroupService.activeGroup;
 		if (!group) {
-			group = this.editorGroupService.activeGroup;
-		}
-
-		// Close specific editor in group
-		if (typeof editorIndex === 'number') {
-			const editorAtIndex = group.getEditorByIndex(editorIndex);
-			if (editorAtIndex) {
-				await group.closeEditor(editorAtIndex, { preserveFocus: context?.preserveFocus });
-				return;
-			}
-		}
-
-		// Otherwise close active editor in group
-		if (group.activeEditor) {
-			await group.closeEditor(group.activeEditor, { preserveFocus: context?.preserveFocus });
+			// group mentioned in context does not exist
 			return;
+		}
+
+		const targetEditor = context?.editorIndex !== undefined ? group.getEditorByIndex(context.editorIndex) : group.activeEditor;
+		if (!targetEditor) {
+			// No editor open or editor at index does not exist
+			return;
+		}
+
+		const editors: EditorInput[] = [];
+		if (group.isSelected(targetEditor)) {
+			editors.push(...group.selectedEditors);
+		} else {
+			editors.push(targetEditor);
+		}
+
+		// Close specific editors in group
+		for (const editor of editors) {
+			await group.closeEditor(editor, { preserveFocus: context?.preserveFocus });
 		}
 	}
 }

--- a/src/vs/workbench/browser/parts/editor/multiEditorTabsControl.ts
+++ b/src/vs/workbench/browser/parts/editor/multiEditorTabsControl.ts
@@ -35,7 +35,7 @@ import { MergeGroupMode, IMergeGroupOptions } from 'vs/workbench/services/editor
 import { addDisposableListener, EventType, EventHelper, Dimension, scheduleAtNextAnimationFrame, findParentWithClass, clearNode, DragAndDropObserver, isMouseEvent, getWindow } from 'vs/base/browser/dom';
 import { localize } from 'vs/nls';
 import { IEditorGroupsView, EditorServiceImpl, IEditorGroupView, IInternalEditorOpenOptions, IEditorPartsView } from 'vs/workbench/browser/parts/editor/editor';
-import { CloseOneEditorAction, UnpinEditorAction } from 'vs/workbench/browser/parts/editor/editorActions';
+import { CloseEditorTabAction, UnpinEditorAction } from 'vs/workbench/browser/parts/editor/editorActions';
 import { assertAllDefined, assertIsDefined } from 'vs/base/common/types';
 import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
 import { basenameOrAuthority } from 'vs/base/common/resources';
@@ -111,7 +111,7 @@ export class MultiEditorTabsControl extends EditorTabsControl {
 	private tabsScrollbar: ScrollableElement | undefined;
 	private tabSizingFixedDisposables: DisposableStore | undefined;
 
-	private readonly closeEditorAction = this._register(this.instantiationService.createInstance(CloseOneEditorAction, CloseOneEditorAction.ID, CloseOneEditorAction.LABEL));
+	private readonly closeEditorAction = this._register(this.instantiationService.createInstance(CloseEditorTabAction, CloseEditorTabAction.ID, CloseEditorTabAction.LABEL));
 	private readonly unpinEditorAction = this._register(this.instantiationService.createInstance(UnpinEditorAction, UnpinEditorAction.ID, UnpinEditorAction.LABEL));
 
 	private readonly tabResourceLabels = this._register(this.instantiationService.createInstance(ResourceLabels, DEFAULT_LABELS_CONTAINER));


### PR DESCRIPTION
This pull request fixes the issue where pressing close in a multi-selected tab only closes the target editor tab instead of closing all selected tabs. The behavior has been updated to close all selected tabs when the close button is pressed.

Fixes #213620