### PR TITLE
closing out inline chat while speech is going does not stop audio (fix #213709)

### DIFF
--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatZoneWidget.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatZoneWidget.ts
@@ -147,6 +147,7 @@ export class InlineChatZoneWidget extends ZoneWidget {
 
 		super.show(position, this._computeHeightInLines());
 		this._setWidgetMargins(position);
+		this.widget.chatWidget.setVisible(true);
 		this.widget.focus();
 
 		scrollState.restore(this.editor);
@@ -209,6 +210,7 @@ export class InlineChatZoneWidget extends ZoneWidget {
 		this.container!.classList.remove('inside-selection');
 		this._ctxCursorPosition.reset();
 		this.widget.reset();
+		this.widget.chatWidget.setVisible(false);
 		super.hide();
 		aria.status(localize('inlineChatClosed', 'Closed inline chat widget'));
 	}


### PR DESCRIPTION
The voice integration to chat relies on the chat widget visibility events. 

When inline chat is used as zone widget, I noticed that the chat widget is not being told to be visible or not.

@jrieken I have added the calls but asking you to check if thats the right location to tell the chat widget. 