### PR TITLE
better lightbulb render scenarios

### DIFF
--- a/src/vs/editor/contrib/codeAction/browser/lightBulbWidget.ts
+++ b/src/vs/editor/contrib/codeAction/browser/lightBulbWidget.ts
@@ -18,7 +18,13 @@ import { autoFixCommandId, quickFixCommandId } from 'vs/editor/contrib/codeActio
 import { CodeActionSet, CodeActionTrigger } from 'vs/editor/contrib/codeAction/common/types';
 import * as nls from 'vs/nls';
 import { ICommandService } from 'vs/platform/commands/common/commands';
+
+
+
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
+
+
+
 
 namespace LightBulbState {
 
@@ -181,9 +187,17 @@ export class LightBulbWidget extends Disposable implements IContentWidget {
 			};
 
 			if (lineNumber > 1 && !isFolded(lineNumber - 1)) {
-				if (isLineEmptyOrIndented(lineNumber - 1) || lineNumber === model.getLineCount()) {
+				const lineCount = model.getLineCount();
+				const endLine = lineNumber === lineCount;
+				const prevLineEmptyOrIndented = lineNumber > 1 && isLineEmptyOrIndented(lineNumber - 1);
+				const nextLineEmptyOrIndented = !endLine && isLineEmptyOrIndented(lineNumber + 1);
+				const currLineEmptyOrIndented = isLineEmptyOrIndented(lineNumber);
+				const notEmpty = !nextLineEmptyOrIndented && !prevLineEmptyOrIndented;
+
+				// check above and below. if both are blocked, display lightbulb below.
+				if (prevLineEmptyOrIndented || endLine || (notEmpty && !currLineEmptyOrIndented)) {
 					effectiveLineNumber -= 1;
-				} else if (isLineEmptyOrIndented(lineNumber + 1)) {
+				} else if (nextLineEmptyOrIndented || (notEmpty && currLineEmptyOrIndented)) {
 					effectiveLineNumber += 1;
 				}
 			} else if ((lineNumber < model.getLineCount()) && !isFolded(lineNumber + 1)) {

--- a/src/vs/editor/contrib/codeAction/browser/lightBulbWidget.ts
+++ b/src/vs/editor/contrib/codeAction/browser/lightBulbWidget.ts
@@ -176,10 +176,6 @@ export class LightBulbWidget extends Disposable implements IContentWidget {
 
 			// Checks if line is empty or starts with any amount of whitespace
 			const isLineEmptyOrIndented = (lineNumber: number): boolean => {
-				const model = this._editor.getModel();
-				if (!model) {
-					return false;
-				}
 				const lineContent = model.getLineContent(lineNumber);
 				return /^\s*$|^\s+/.test(lineContent) || lineContent.length <= effectiveColumnNumber;
 			};

--- a/src/vs/editor/contrib/codeAction/browser/lightBulbWidget.ts
+++ b/src/vs/editor/contrib/codeAction/browser/lightBulbWidget.ts
@@ -18,13 +18,7 @@ import { autoFixCommandId, quickFixCommandId } from 'vs/editor/contrib/codeActio
 import { CodeActionSet, CodeActionTrigger } from 'vs/editor/contrib/codeAction/common/types';
 import * as nls from 'vs/nls';
 import { ICommandService } from 'vs/platform/commands/common/commands';
-
-
-
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
-
-
-
 
 namespace LightBulbState {
 

--- a/src/vs/editor/contrib/codeAction/browser/lightBulbWidget.ts
+++ b/src/vs/editor/contrib/codeAction/browser/lightBulbWidget.ts
@@ -173,9 +173,8 @@ export class LightBulbWidget extends Disposable implements IContentWidget {
 		let effectiveLineNumber = lineNumber;
 		let effectiveColumnNumber = 1;
 		if (!lineHasSpace) {
-			const currentContentEmpty = model.getLineContent(lineNumber).length <= effectiveColumnNumber;
-			if (lineNumber > 1 && !isFolded(lineNumber - 1) && !currentContentEmpty) {
-				if (model.getLineContent(lineNumber - 1).length <= effectiveColumnNumber) {
+			if (lineNumber > 1 && !isFolded(lineNumber - 1)) {
+				if (model.getLineContent(lineNumber - 1).length <= effectiveColumnNumber || lineNumber === model.getLineCount()) {
 					effectiveLineNumber -= 1;
 				} else if (model.getLineContent(lineNumber + 1).length <= effectiveColumnNumber) {
 					effectiveLineNumber += 1;
@@ -270,3 +269,11 @@ export class LightBulbWidget extends Disposable implements IContentWidget {
 		this._domNode.title = value;
 	}
 }
+
+
+
+
+console.log("");
+
+
+console.log();

--- a/src/vs/editor/contrib/codeAction/browser/lightBulbWidget.ts
+++ b/src/vs/editor/contrib/codeAction/browser/lightBulbWidget.ts
@@ -173,10 +173,21 @@ export class LightBulbWidget extends Disposable implements IContentWidget {
 		let effectiveLineNumber = lineNumber;
 		let effectiveColumnNumber = 1;
 		if (!lineHasSpace) {
+
+			// Checks if line is empty or starts with any amount of whitespace
+			const isLineEmptyOrIndented = (lineNumber: number): boolean => {
+				const model = this._editor.getModel();
+				if (!model) {
+					return false;
+				}
+				const lineContent = model.getLineContent(lineNumber);
+				return /^\s*$|^\s+/.test(lineContent) || lineContent.length <= effectiveColumnNumber;
+			};
+
 			if (lineNumber > 1 && !isFolded(lineNumber - 1)) {
-				if (model.getLineContent(lineNumber - 1).length <= effectiveColumnNumber || lineNumber === model.getLineCount()) {
+				if (isLineEmptyOrIndented(lineNumber - 1) || lineNumber === model.getLineCount()) {
 					effectiveLineNumber -= 1;
-				} else if (model.getLineContent(lineNumber + 1).length <= effectiveColumnNumber) {
+				} else if (isLineEmptyOrIndented(lineNumber + 1)) {
 					effectiveLineNumber += 1;
 				}
 			} else if ((lineNumber < model.getLineCount()) && !isFolded(lineNumber + 1)) {

--- a/src/vs/editor/contrib/codeAction/browser/lightBulbWidget.ts
+++ b/src/vs/editor/contrib/codeAction/browser/lightBulbWidget.ts
@@ -173,8 +173,13 @@ export class LightBulbWidget extends Disposable implements IContentWidget {
 		let effectiveLineNumber = lineNumber;
 		let effectiveColumnNumber = 1;
 		if (!lineHasSpace) {
-			if (lineNumber > 1 && !isFolded(lineNumber - 1)) {
-				effectiveLineNumber -= 1;
+			const currentContentEmpty = model.getLineContent(lineNumber).length <= effectiveColumnNumber;
+			if (lineNumber > 1 && !isFolded(lineNumber - 1) && !currentContentEmpty) {
+				if (model.getLineContent(lineNumber - 1).length <= effectiveColumnNumber) {
+					effectiveLineNumber -= 1;
+				} else if (model.getLineContent(lineNumber + 1).length <= effectiveColumnNumber) {
+					effectiveLineNumber += 1;
+				}
 			} else if ((lineNumber < model.getLineCount()) && !isFolded(lineNumber + 1)) {
 				effectiveLineNumber += 1;
 			} else if (column * fontInfo.spaceWidth < 22) {

--- a/src/vs/editor/contrib/codeAction/browser/lightBulbWidget.ts
+++ b/src/vs/editor/contrib/codeAction/browser/lightBulbWidget.ts
@@ -269,11 +269,3 @@ export class LightBulbWidget extends Disposable implements IContentWidget {
 		this._domNode.title = value;
 	}
 }
-
-
-
-
-console.log("");
-
-
-console.log();


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
fixes https://github.com/microsoft/vscode/issues/213807


https://github.com/microsoft/vscode/assets/54879025/6bc3a205-96a8-4169-a462-725260d84edb


https://github.com/microsoft/vscode/assets/54879025/da2d9668-844f-48a2-968b-e39a41d719ff



will show either above or below if we are clear to do so. we check above and below indentation and whitespace or empty lines and this way if there is space to show, we will never block text. basically will try `best case` placement.

cc. @aiday-mar 