### PR TITLE
Workaround low underscore in fonts by adjusting line height

### DIFF
--- a/src/vs/workbench/contrib/terminal/common/terminal.ts
+++ b/src/vs/workbench/contrib/terminal/common/terminal.ts
@@ -6,7 +6,7 @@
 import { Event } from 'vs/base/common/event';
 import { IDisposable } from 'vs/base/common/lifecycle';
 import { MarshalledId } from 'vs/base/common/marshallingIds';
-import { IProcessEnvironment, OperatingSystem } from 'vs/base/common/platform';
+import { IProcessEnvironment, isLinux, OperatingSystem } from 'vs/base/common/platform';
 import Severity from 'vs/base/common/severity';
 import { ThemeIcon } from 'vs/base/common/themables';
 import { URI } from 'vs/base/common/uri';
@@ -33,7 +33,12 @@ export const TERMINAL_CONFIG_SECTION = 'terminal.integrated';
 
 export const DEFAULT_LETTER_SPACING = 0;
 export const MINIMUM_LETTER_SPACING = -5;
-export const DEFAULT_LINE_HEIGHT = 1;
+// HACK: On Linux it's common for fonts to include an underline that is rendered lower than the
+// bottom of the cell which causes it to be cut off due to `overflow:hidden` in the DOM renderer.
+// See:
+// - https://github.com/microsoft/vscode/issues/211933
+// - https://github.com/xtermjs/xterm.js/issues/4067
+export const DEFAULT_LINE_HEIGHT = isLinux ? 1.1 : 1;
 
 export const MINIMUM_FONT_WEIGHT = 1;
 export const MAXIMUM_FONT_WEIGHT = 1000;

--- a/src/vs/workbench/contrib/terminal/test/browser/terminalConfigurationService.test.ts
+++ b/src/vs/workbench/contrib/terminal/test/browser/terminalConfigurationService.test.ts
@@ -6,6 +6,7 @@
 import { notStrictEqual, strictEqual } from 'assert';
 import { getActiveWindow } from 'vs/base/browser/dom';
 import { mainWindow } from 'vs/base/browser/window';
+import { isLinux } from 'vs/base/common/platform';
 import { ensureNoDisposablesAreLeakedInTestSuite } from 'vs/base/test/common/utils';
 import { EDITOR_FONT_DEFAULTS } from 'vs/editor/common/config/editorOptions';
 import { ConfigurationTarget, IConfigurationService } from 'vs/platform/configuration/common/configuration';
@@ -219,7 +220,7 @@ suite('Workbench - TerminalConfigurationService', () => {
 					}
 				}
 			});
-			strictEqual(terminalConfigurationService.getFont(getActiveWindow()).lineHeight, 1, 'editor.lineHeight should be 1 when terminal.integrated.lineHeight not set');
+			strictEqual(terminalConfigurationService.getFont(getActiveWindow()).lineHeight, isLinux ? 1.1 : 1, 'editor.lineHeight should be the default when terminal.integrated.lineHeight not set');
 		});
 	});
 


### PR DESCRIPTION
Part of #211933
