### PR TITLE
Avoid auto-reindentation when pasting text with only whitespace characters

### DIFF
--- a/src/vs/editor/common/languages/autoIndent.ts
+++ b/src/vs/editor/common/languages/autoIndent.ts
@@ -239,6 +239,9 @@ export function getGoodIndentForLine(
 
 	const processedIndentRulesSupport = new ProcessedIndentRulesSupport(virtualModel, indentRulesSupport, languageConfigurationService);
 	const indent = getInheritIndentForLine(autoIndent, virtualModel, lineNumber, undefined, languageConfigurationService);
+	console.log('getGoodIndentForLine');
+	console.log('lineNumber', lineNumber);
+	console.log('indent : ', indent);
 
 	if (indent) {
 		const inheritLine = indent.line;
@@ -277,7 +280,8 @@ export function getGoodIndentForLine(
 					if (enterResult.appendText) {
 						indentation += enterResult.appendText;
 					}
-
+					console.log('return 1');
+					console.log('indentation.length : ', indentation.length);
 					return strings.getLeadingWhitespace(indentation);
 				}
 			}
@@ -285,18 +289,23 @@ export function getGoodIndentForLine(
 
 		if (processedIndentRulesSupport.shouldDecrease(lineNumber)) {
 			if (indent.action === IndentAction.Indent) {
+				console.log('return 2');
 				return indent.indentation;
 			} else {
+				console.log('return 3');
 				return indentConverter.unshiftIndent(indent.indentation);
 			}
 		} else {
 			if (indent.action === IndentAction.Indent) {
+				console.log('return 4');
 				return indentConverter.shiftIndent(indent.indentation);
 			} else {
+				console.log('return 5');
 				return indent.indentation;
 			}
 		}
 	}
+	console.log('return 6');
 	return null;
 }
 

--- a/src/vs/editor/common/languages/autoIndent.ts
+++ b/src/vs/editor/common/languages/autoIndent.ts
@@ -239,9 +239,6 @@ export function getGoodIndentForLine(
 
 	const processedIndentRulesSupport = new ProcessedIndentRulesSupport(virtualModel, indentRulesSupport, languageConfigurationService);
 	const indent = getInheritIndentForLine(autoIndent, virtualModel, lineNumber, undefined, languageConfigurationService);
-	console.log('getGoodIndentForLine');
-	console.log('lineNumber', lineNumber);
-	console.log('indent : ', indent);
 
 	if (indent) {
 		const inheritLine = indent.line;
@@ -280,8 +277,7 @@ export function getGoodIndentForLine(
 					if (enterResult.appendText) {
 						indentation += enterResult.appendText;
 					}
-					console.log('return 1');
-					console.log('indentation.length : ', indentation.length);
+
 					return strings.getLeadingWhitespace(indentation);
 				}
 			}
@@ -289,23 +285,18 @@ export function getGoodIndentForLine(
 
 		if (processedIndentRulesSupport.shouldDecrease(lineNumber)) {
 			if (indent.action === IndentAction.Indent) {
-				console.log('return 2');
 				return indent.indentation;
 			} else {
-				console.log('return 3');
 				return indentConverter.unshiftIndent(indent.indentation);
 			}
 		} else {
 			if (indent.action === IndentAction.Indent) {
-				console.log('return 4');
 				return indentConverter.shiftIndent(indent.indentation);
 			} else {
-				console.log('return 5');
 				return indent.indentation;
 			}
 		}
 	}
-	console.log('return 6');
 	return null;
 }
 

--- a/src/vs/editor/contrib/indentation/browser/indentation.ts
+++ b/src/vs/editor/contrib/indentation/browser/indentation.ts
@@ -418,6 +418,14 @@ export class AutoIndentOnPaste implements IEditorContribution {
 		if (!model) {
 			return;
 		}
+		// TODO: also need to understand how autoindentation works when not pasting at the beginning of the line, but in the middle
+		// but could say that when the pasted text is only whitespaces, then should never reindent
+		// why when pasted in the middle of the text, no reindentation happens?
+
+		const containsOnlyWhitespace = this.rangeContainsOnlyWhitespaceCharacters(model, range);
+		if (containsOnlyWhitespace) {
+			return;
+		}
 		if (isStartOrEndInString(model, range)) {
 			return;
 		}
@@ -446,14 +454,19 @@ export class AutoIndentOnPaste implements IEditorContribution {
 			}
 			break;
 		}
+		console.log('range : ', range);
+		console.log('startLineNumber : ', startLineNumber);
+		console.log('range.endLineNumber : ', range.endLineNumber);
 
 		if (startLineNumber > range.endLineNumber) {
 			return;
 		}
 
 		let firstLineText = model.getLineContent(startLineNumber);
+		console.log('firstLineText : ', firstLineText);
 		if (!/\S/.test(firstLineText.substring(0, range.startColumn - 1))) {
 			const indentOfFirstLine = getGoodIndentForLine(autoIndent, model, model.getLanguageId(), startLineNumber, indentConverter, this._languageConfigurationService);
+			console.log('indentOfFirstLine.length : ', indentOfFirstLine?.length);
 
 			if (indentOfFirstLine !== null) {
 				const oldIndentation = strings.getLeadingWhitespace(firstLineText);
@@ -461,12 +474,17 @@ export class AutoIndentOnPaste implements IEditorContribution {
 				const oldSpaceCnt = indentUtils.getSpaceCnt(oldIndentation, tabSize);
 
 				if (newSpaceCnt !== oldSpaceCnt) {
+					console.log('newSpaceCnt : ', newSpaceCnt);
+					console.log('oldSpaceCnt : ', oldSpaceCnt);
+					console.log('tabSize : ', tabSize);
+					console.log('insertSpaces : ', insertSpaces);
 					const newIndent = indentUtils.generateIndent(newSpaceCnt, tabSize, insertSpaces);
+					console.log('push 1');
 					textEdits.push({
 						range: new Range(startLineNumber, 1, startLineNumber, oldIndentation.length + 1),
 						text: newIndent
 					});
-					firstLineText = newIndent + firstLineText.substr(oldIndentation.length);
+					firstLineText = newIndent + firstLineText.substring(oldIndentation.length);
 				} else {
 					const indentMetadata = getIndentMetadata(model, startLineNumber, this._languageConfigurationService);
 
@@ -528,6 +546,7 @@ export class AutoIndentOnPaste implements IEditorContribution {
 						const newIndent = indentUtils.generateIndent(newSpacesCnt, tabSize, insertSpaces);
 
 						if (newIndent !== originalIndent) {
+							console.log('push 2');
 							textEdits.push({
 								range: new Range(i, 1, i, originalIndent.length + 1),
 								text: newIndent
@@ -537,13 +556,38 @@ export class AutoIndentOnPaste implements IEditorContribution {
 				}
 			}
 		}
-
+		console.log('textEdits : ', textEdits);
 		if (textEdits.length > 0) {
 			this.editor.pushUndoStop();
 			const cmd = new AutoIndentOnPasteCommand(textEdits, this.editor.getSelection()!);
 			this.editor.executeCommand('autoIndentOnPaste', cmd);
 			this.editor.pushUndoStop();
 		}
+	}
+
+	// Is there a better way to find if a line contains only whitespace, other than doing this
+	// instead of trimming do a regex check that is maybe more efficient
+	private rangeContainsOnlyWhitespaceCharacters(model: ITextModel, range: Range): boolean {
+		let containsOnlyWhitespace: boolean = true;
+		if (range.startLineNumber === range.endLineNumber) {
+			const lineContent = model.getLineContent(range.startLineNumber);
+			const linePart = lineContent.substring(range.startColumn - 1, range.endColumn - 1);
+			containsOnlyWhitespace = linePart.trim().length === 0;
+		} else {
+			for (let i = range.startLineNumber; i <= range.endLineNumber; i++) {
+				const lineContent = model.getLineContent(i);
+				if (i === range.startLineNumber) {
+					const linePart = lineContent.substring(range.startColumn - 1);
+					containsOnlyWhitespace = linePart.trim().length === 0;
+				} else if (i === range.endLineNumber) {
+					const linePart = lineContent.substring(0, range.endColumn - 1);
+					containsOnlyWhitespace = linePart.trim().length === 0;
+				} else {
+					containsOnlyWhitespace = model.getLineFirstNonWhitespaceColumn(i) === 0;
+				}
+			}
+		}
+		return containsOnlyWhitespace;
 	}
 
 	private shouldIgnoreLine(model: ITextModel, lineNumber: number): boolean {


### PR DESCRIPTION
fixes https://github.com/microsoft/vscode/issues/213167

When one pastes only whitespace characters, this could be interpreted as an intended form of indentation. The indentation should not be adjusted in this case. 