### PR TITLE
ensure chat response isn't too verbose

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatAccessibilityService.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatAccessibilityService.ts
@@ -11,6 +11,7 @@ import { AccessibilityProgressSignalScheduler } from 'vs/platform/accessibilityS
 import { IChatAccessibilityService } from 'vs/workbench/contrib/chat/browser/chat';
 import { IChatResponseViewModel } from 'vs/workbench/contrib/chat/common/chatViewModel';
 import { renderStringAsPlaintext } from 'vs/base/browser/markdownRenderer';
+import { MarkdownString } from 'vs/base/common/htmlContent';
 
 const CHAT_RESPONSE_PENDING_ALLOWANCE_MS = 4000;
 export class ChatAccessibilityService extends Disposable implements IChatAccessibilityService {
@@ -39,7 +40,8 @@ export class ChatAccessibilityService extends Disposable implements IChatAccessi
 			return;
 		}
 		const errorDetails = isPanelChat && response.errorDetails ? ` ${response.errorDetails.message}` : '';
-		status(renderStringAsPlaintext(responseContent) + errorDetails);
+		const plainTextResponse = renderStringAsPlaintext(new MarkdownString(responseContent));
+		status(plainTextResponse + errorDetails);
 	}
 }
 


### PR DESCRIPTION
The string is only parsed as plain text if it's a `MarkdownString`

fix #212788