### PR TITLE
Fix a syntax error in xml extension

### DIFF
--- a/extensions/xml/syntaxes/xml.tmLanguage.json
+++ b/extensions/xml/syntaxes/xml.tmLanguage.json
@@ -356,10 +356,10 @@
 					"captures": {
 						"0": {
 							"name": "punctuation.definition.comment.xml"
-						},
-						"end": "--%>",
-						"name": "comment.block.xml"
-					}
+						}
+					},
+					"end": "--%>",
+					"name": "comment.block.xml"
 				},
 				{
 					"begin": "<!--",


### PR DESCRIPTION
Corrected the syntax for handling `<%-- some comments --%>` comments in XML files.
- Fixed misplaced 'end' and 'name' keys in comment captures.
