### PR TITLE
Fix empty diff editor, leakage, and duplicated labels

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatListRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatListRenderer.ts
@@ -1071,7 +1071,8 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 					URI.from({ scheme: Schemas.vscodeChatCodeBlock, path: original.uri.path, query: generateUuid() }),
 					false
 				);
-				store.add(modified);
+				const modRef = await this.textModelService.createModelReference(modified.uri);
+				store.add(modRef);
 
 				const editGroups: ISingleEditOperation[][] = [];
 				if (isResponseVM(element)) {
@@ -1113,6 +1114,7 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 			element: ref.object.element,
 			dispose() {
 				store.dispose();
+				ref.dispose();
 			},
 		};
 	}

--- a/src/vs/workbench/contrib/chat/browser/codeBlockPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/codeBlockPart.ts
@@ -690,6 +690,7 @@ export class CodeCompareBlockPart extends Disposable {
 		this.layout(width);
 		this.diffEditor.updateOptions({ ariaLabel: localize('chat.compareCodeBlockLabel', "Code Edits") });
 
+		this.toolbar1.clear();
 		this.toolbar1.push(toAction({
 			label: basename(data.edit.uri),
 			tooltip: localize('chat.edit.tooltip', "Open '{0}'", this.labelService.getUriLabel(data.edit.uri, { relative: true })),


### PR DESCRIPTION
Store/dispose a reference to the RHS model of the compare editor instead of the model, make sure diff editors are released, fix repeated labels

fixes https://github.com/microsoft/vscode-copilot/issues/5885
fixes https://github.com/microsoft/vscode/issues/213992