### PR TITLE
Fix comment not expanding

### DIFF
--- a/src/vs/workbench/contrib/comments/browser/commentThreadZoneWidget.ts
+++ b/src/vs/workbench/contrib/comments/browser/commentThreadZoneWidget.ts
@@ -150,7 +150,6 @@ export class ReviewZoneWidget extends ZoneWidget implements ICommentThreadWidget
 
 		this._initialCollapsibleState = _pendingComment ? languages.CommentThreadCollapsibleState.Expanded : _commentThread.initialCollapsibleState;
 		_commentThread.initialCollapsibleState = this._initialCollapsibleState;
-		this._isExpanded = this._initialCollapsibleState === languages.CommentThreadCollapsibleState.Expanded;
 		this._commentThreadDisposables = [];
 		this.create();
 
@@ -439,7 +438,7 @@ export class ReviewZoneWidget extends ZoneWidget implements ICommentThreadWidget
 	}
 
 	_refresh(dimensions: dom.Dimension) {
-		if (dimensions.height === 0 && dimensions.width === 0) {
+		if ((this._isExpanded === undefined) && (dimensions.height === 0) && (dimensions.width === 0)) {
 			this.commentThread.collapsibleState = languages.CommentThreadCollapsibleState.Collapsed;
 			return;
 		}


### PR DESCRIPTION
Fixes #213974

`_refresh` is called when the comment is toggled to show using the comment bar. However, in some cases the dimensions that get passed in to the body are 0,0. If this happens, then the comment will end up being immediately collapsed again, leaving the expanded state out of sync and resulting thin the comment getting "stuck" collapsed.

In this repro, the comment in question does in fact start out with no content in the body, which is why the dimensions that get passed in are 0,0. 

The fix is to have an initial state (`_expanded === undefined`) which we can use to determin if we should actually set the comment to `collapsed` in `_refresh`.