### PR TITLE
Adding the padding border back into `hover.css` file

### DIFF
--- a/src/vs/editor/contrib/hover/browser/hover.css
+++ b/src/vs/editor/contrib/hover/browser/hover.css
@@ -9,6 +9,7 @@
 
 .monaco-editor .monaco-hover-content {
 	padding-right: 2px;
+	padding-bottom: 2px;
 	box-sizing: border-box;
 }
 


### PR DESCRIPTION
Adding the padding border back into `hover.css` file