### PR TITLE
Don't merge a view with a titleDescription (fix #166000)

### DIFF
--- a/src/vs/workbench/browser/parts/views/viewPaneContainer.ts
+++ b/src/vs/workbench/browser/parts/views/viewPaneContainer.ts
@@ -1100,6 +1100,10 @@ export class ViewPaneContainer extends Component implements IViewPaneContainer {
 		if (!(this.options.mergeViewWithContainerWhenSingleView && this.paneItems.length === 1)) {
 			return false;
 		}
+		if (this.paneItems[0].pane.titleDescription) {
+			// Don't merge a view with a titleDescription. See #166000
+			return false;
+		}
 		if (!this.areExtensionsReady) {
 			if (this.visibleViewsCountFromCache === undefined) {
 				return this.paneItems[0].pane.isExpanded();


### PR DESCRIPTION
This PR fixes #166000

That Timeline view issue is a specific instance of the underlying cause, which is that a view which merges its header to the view container header because it is the only view in the container then has nowhere to show its titleDescription.

This PR solves the problem by preventing merging when titleDescription is set non-empty.