### PR TITLE
Fix layout issues in inline chat

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
@@ -530,6 +530,8 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 
 		const inputEditorHeight = Math.min(data.inputPartEditorHeight, height - data.followupsHeight - data.inputPartVerticalPadding);
 
+		this.followupsContainer.style.width = `${width}px`;
+
 		this._inputPartHeight = data.followupsHeight + inputEditorHeight + data.inputPartVerticalPadding + data.inputEditorBorder + data.implicitContextHeight;
 
 		const initialEditorScrollWidth = this._inputEditor.getScrollWidth();

--- a/src/vs/workbench/contrib/chat/browser/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/media/chat.css
@@ -555,6 +555,12 @@
 	display: block;
 	color: var(--vscode-textLink-foreground);
 	font-size: 12px;
+
+	/* clamp to max 3 lines */
+	display: -webkit-box;
+	-webkit-line-clamp: 3;
+	-webkit-box-orient: vertical;
+	overflow: hidden;
 }
 
 .interactive-session .interactive-input-part .interactive-input-followups .interactive-session-followups code {

--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatContentWidget.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatContentWidget.ts
@@ -137,7 +137,7 @@ export class InlineChatContentWidget implements IContentWidget {
 		const maxHeight = this._widget.input.inputEditor.getOption(EditorOption.lineHeight) * 5;
 		const inputEditorHeight = this._widget.contentHeight;
 
-		this._widget.layout(Math.min(maxHeight, inputEditorHeight), 360);
+		this._widget.layout(Math.min(maxHeight, inputEditorHeight), 390);
 
 		// const actualHeight = this._widget.inputPartHeight;
 		// return new dom.Dimension(width, actualHeight);


### PR DESCRIPTION
This pull request fixes layout issues in the inline chat feature. The user message was sometimes pushed down below the viewable space in the text entry box, and the chat would expand indefinitely as the user typed.

The changes in this pull request include:

- Clamping the follow-up height to three lines to prevent it from expanding excessively.

- Modifying the width of the follow-ups container to match the width of the chat input.

- Applying a CSS style to clamp the follow-up text to a maximum of three lines and hide overflow.

Fixes https://github.com/microsoft/vscode-copilot/issues/5522