### PR TITLE
get the serializer from the notebook service each time

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/services/notebookServiceImpl.ts
+++ b/src/vs/workbench/contrib/notebook/browser/services/notebookServiceImpl.ts
@@ -697,6 +697,14 @@ export class NotebookService extends Disposable implements INotebookService {
 		return result;
 	}
 
+	tryGetDataProviderSync(viewType: string): SimpleNotebookProviderInfo | undefined {
+		const selected = this.notebookProviderInfoStore.get(viewType);
+		if (!selected) {
+			return undefined;
+		}
+		return this._notebookProviders.get(selected.id);
+	}
+
 
 	private _persistMementos(): void {
 		this._memento.saveMemento();

--- a/src/vs/workbench/contrib/notebook/common/notebookEditorModelResolverServiceImpl.ts
+++ b/src/vs/workbench/contrib/notebook/common/notebookEditorModelResolverServiceImpl.ts
@@ -70,7 +70,7 @@ class NotebookModelReferenceCollection extends ReferenceCollection<Promise<IReso
 		const workingCopyTypeId = NotebookWorkingCopyTypeIdentifier.create(viewType);
 		let workingCopyManager = this._workingCopyManagers.get(workingCopyTypeId);
 		if (!workingCopyManager) {
-			const factory = new NotebookFileWorkingCopyModelFactory(viewType, this._notebookService, this._configurationService, this._telemetryService);
+			const factory = new NotebookFileWorkingCopyModelFactory(viewType, this._notebookService, this._configurationService, this._telemetryService, this._logService);
 			workingCopyManager = <IFileWorkingCopyManager<NotebookFileWorkingCopyModel, NotebookFileWorkingCopyModel>><any>this._instantiationService.createInstance(
 				FileWorkingCopyManager,
 				workingCopyTypeId,

--- a/src/vs/workbench/contrib/notebook/common/notebookService.ts
+++ b/src/vs/workbench/contrib/notebook/common/notebookService.ts
@@ -65,6 +65,7 @@ export interface INotebookService {
 
 	registerNotebookSerializer(viewType: string, extensionData: NotebookExtensionDescription, serializer: INotebookSerializer): IDisposable;
 	withNotebookDataProvider(viewType: string): Promise<SimpleNotebookProviderInfo>;
+	tryGetDataProviderSync(viewType: string): SimpleNotebookProviderInfo | undefined;
 
 	getOutputMimeTypeInfo(textModel: NotebookTextModel, kernelProvides: readonly string[] | undefined, output: IOutputDto): readonly IOrderedMimeType[];
 

--- a/src/vs/workbench/contrib/notebook/test/browser/notebookEditorModel.test.ts
+++ b/src/vs/workbench/contrib/notebook/test/browser/notebookEditorModel.test.ts
@@ -15,6 +15,7 @@ import { TestConfigurationService } from 'vs/platform/configuration/test/common/
 import { ExtensionIdentifier } from 'vs/platform/extensions/common/extensions';
 import { IFileStatWithMetadata } from 'vs/platform/files/common/files';
 import { TestInstantiationService } from 'vs/platform/instantiation/test/common/instantiationServiceMock';
+import { ILogService } from 'vs/platform/log/common/log';
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 import { NotebookTextModel } from 'vs/workbench/contrib/notebook/common/model/notebookTextModel';
 import { CellKind, IOutputDto, NotebookData, NotebookSetting, TransientOptions } from 'vs/workbench/contrib/notebook/common/notebookCommon';
@@ -29,6 +30,7 @@ suite('NotebookFileWorkingCopyModel', function () {
 	let instantiationService: TestInstantiationService;
 	const configurationService = new TestConfigurationService();
 	const telemetryService = new class extends mock<ITelemetryService>() { };
+	const logservice = new class extends mock<ILogService>() { };
 
 	teardown(() => disposables.dispose());
 
@@ -65,7 +67,8 @@ suite('NotebookFileWorkingCopyModel', function () {
 					}
 				),
 				configurationService,
-				telemetryService
+				telemetryService,
+				logservice
 			));
 
 			await model.snapshot(SnapshotContext.Save, CancellationToken.None);
@@ -88,7 +91,8 @@ suite('NotebookFileWorkingCopyModel', function () {
 					}
 				),
 				configurationService,
-				telemetryService
+				telemetryService,
+				logservice
 			));
 			await model.snapshot(SnapshotContext.Save, CancellationToken.None);
 			assert.strictEqual(callCount, 1);
@@ -123,7 +127,8 @@ suite('NotebookFileWorkingCopyModel', function () {
 					}
 				),
 				configurationService,
-				telemetryService
+				telemetryService,
+				logservice
 			));
 
 			await model.snapshot(SnapshotContext.Save, CancellationToken.None);
@@ -147,6 +152,7 @@ suite('NotebookFileWorkingCopyModel', function () {
 				),
 				configurationService,
 				telemetryService,
+				logservice
 
 			));
 			await model.snapshot(SnapshotContext.Save, CancellationToken.None);
@@ -181,7 +187,8 @@ suite('NotebookFileWorkingCopyModel', function () {
 					}
 				),
 				configurationService,
-				telemetryService
+				telemetryService,
+				logservice
 			));
 
 			await model.snapshot(SnapshotContext.Save, CancellationToken.None);
@@ -204,7 +211,8 @@ suite('NotebookFileWorkingCopyModel', function () {
 					}
 				),
 				configurationService,
-				telemetryService
+				telemetryService,
+				logservice
 			));
 			await model.snapshot(SnapshotContext.Save, CancellationToken.None);
 			assert.strictEqual(callCount, 1);
@@ -239,7 +247,8 @@ suite('NotebookFileWorkingCopyModel', function () {
 				}
 			),
 			configurationService,
-			telemetryService
+			telemetryService,
+			logservice
 		));
 
 		try {
@@ -282,7 +291,8 @@ suite('NotebookFileWorkingCopyModel', function () {
 			notebook,
 			notebookService,
 			configurationService,
-			telemetryService
+			telemetryService,
+			logservice
 		));
 
 		// the save method should not be set if the serializer is not yet resolved


### PR DESCRIPTION
fix https://github.com/microsoft/vscode-jupyter/issues/15698

if the EH restarts, the serializer proxy object is no longer valid, so we need to retrieve the latest object from the notebook service each time