### PR TITLE
remove important! on style

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/backLayerWebView.ts
@@ -436,7 +436,7 @@ export class BackLayerWebView<T extends ICommonCellInfo> extends Themable {
 					}
 
 					table, thead, tr, th, td, tbody {
-						border: none !important;
+						border: none;
 						border-color: transparent;
 						border-spacing: 0;
 						border-collapse: collapse;


### PR DESCRIPTION
fix https://github.com/microsoft/vscode/issues/210462

There is a slight change in the padding of a dataframe in the output if the border is removed entirely, but I couldn't find any differences by removing important. The initial introduction of this style didn't have any explanation.