### PR TITLE
Remove padding from inline codespans in comment widget

### DIFF
--- a/src/vs/workbench/contrib/comments/browser/media/review.css
+++ b/src/vs/workbench/contrib/comments/browser/media/review.css
@@ -244,11 +244,6 @@
 	margin-top: 0;
 }
 
-.review-widget .body .comment-body code {
-	border-radius: 3px;
-	padding: 0 0.4em;
-}
-
 .review-widget .body .comment-body span {
 	white-space: pre;
 }


### PR DESCRIPTION
This pull request removes the unnecessary padding from inline codespans in the comment widget. The padding was causing extra space and looked incorrect. This change fixes issue #214038.