### PR TITLE
switch default interactive.execute keybinding

### DIFF
--- a/src/vs/workbench/contrib/interactive/browser/interactive.contribution.ts
+++ b/src/vs/workbench/contrib/interactive/browser/interactive.contribution.ts
@@ -816,7 +816,7 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).regis
 		},
 		['interactiveWindow.executeWithShiftEnter']: {
 			type: 'boolean',
-			default: true,
+			default: false,
 			markdownDescription: localize('interactiveWindow.executeWithShiftEnter', "Execute the interactive window (REPL) input box with shift+enter, so that enter can be used to create a newline.")
 		}
 	}


### PR DESCRIPTION
fix https://github.com/microsoft/vscode/issues/213858

the migration from https://github.com/microsoft/vscode-jupyter/pull/15714 should keep jupyter users' behavior the same by manually adjusting that setting when an IW is opened through the jupyter extension
