### PR TITLE
debug: fix hover disappearing 'too quickly'

### DIFF
--- a/src/vs/base/common/numbers.ts
+++ b/src/vs/base/common/numbers.ts
@@ -69,3 +69,30 @@ export class SlidingWindowAverage {
 		return this._val;
 	}
 }
+
+/** Returns whether the point is within the triangle formed by the following 6 x/y point pairs */
+export function isPointWithinTriangle(
+	x: number, y: number,
+	ax: number, ay: number,
+	bx: number, by: number,
+	cx: number, cy: number
+) {
+	const v0x = cx - ax;
+	const v0y = cy - ay;
+	const v1x = bx - ax;
+	const v1y = by - ay;
+	const v2x = x - ax;
+	const v2y = y - ay;
+
+	const dot00 = v0x * v0x + v0y * v0y;
+	const dot01 = v0x * v1x + v0y * v1y;
+	const dot02 = v0x * v2x + v0y * v2y;
+	const dot11 = v1x * v1x + v1y * v1y;
+	const dot12 = v1x * v2x + v1y * v2y;
+
+	const invDenom = 1 / (dot00 * dot11 - dot01 * dot01);
+	const u = (dot11 * dot02 - dot01 * dot12) * invDenom;
+	const v = (dot00 * dot12 - dot01 * dot02) * invDenom;
+
+	return u >= 0 && v >= 0 && u + v < 1;
+}

--- a/src/vs/base/test/common/numbers.test.ts
+++ b/src/vs/base/test/common/numbers.test.ts
@@ -1,0 +1,27 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { isPointWithinTriangle } from 'vs/base/common/numbers';
+import { ensureNoDisposablesAreLeakedInTestSuite } from 'vs/base/test/common/utils';
+
+suite('isPointWithinTriangle', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	test('should return true if the point is within the triangle', () => {
+		const result = isPointWithinTriangle(0.25, 0.25, 0, 0, 1, 0, 0, 1);
+		assert.ok(result);
+	});
+
+	test('should return false if the point is outside the triangle', () => {
+		const result = isPointWithinTriangle(2, 2, 0, 0, 1, 0, 0, 1);
+		assert.ok(!result);
+	});
+
+	test('should return true if the point is on the edge of the triangle', () => {
+		const result = isPointWithinTriangle(0.5, 0, 0, 0, 1, 0, 0, 1);
+		assert.ok(result);
+	});
+});

--- a/src/vs/workbench/contrib/debug/browser/debugEditorContribution.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugEditorContribution.ts
@@ -6,6 +6,7 @@
 import { addDisposableListener, isKeyboardEvent } from 'vs/base/browser/dom';
 import { DomEmitter } from 'vs/base/browser/event';
 import { IKeyboardEvent, StandardKeyboardEvent } from 'vs/base/browser/keyboardEvent';
+import { IMouseEvent } from 'vs/base/browser/mouseEvent';
 import { distinct } from 'vs/base/common/arrays';
 import { RunOnceScheduler } from 'vs/base/common/async';
 import { CancellationToken, CancellationTokenSource } from 'vs/base/common/cancellation';
@@ -208,7 +209,7 @@ export class DebugEditorContribution implements IDebugEditorContribution {
 
 	private toDispose: IDisposable[];
 	private hoverWidget: DebugHoverWidget;
-	private hoverPosition: Position | null = null;
+	private hoverPosition?: { position: Position; event: IMouseEvent };
 	private mouseDown = false;
 	private exceptionWidgetVisible: IContextKey<boolean>;
 	private gutterIsHovered = false;
@@ -341,7 +342,7 @@ export class DebugEditorContribution implements IDebugEditorContribution {
 
 				if (debugHoverWasVisible && this.hoverPosition) {
 					// If the debug hover was visible immediately show the editor hover for the alt transition to be smooth
-					this.showEditorHover(this.hoverPosition, false);
+					this.showEditorHover(this.hoverPosition.position, false);
 				}
 
 				const onKeyUp = new DomEmitter(ownerDocument, 'keyup');
@@ -361,14 +362,14 @@ export class DebugEditorContribution implements IDebugEditorContribution {
 		});
 	}
 
-	async showHover(position: Position, focus: boolean): Promise<void> {
+	async showHover(position: Position, focus: boolean, mouseEvent?: IMouseEvent): Promise<void> {
 		// normally will already be set in `showHoverScheduler`, but public callers may hit this directly:
 		this.preventDefaultEditorHover();
 
 		const sf = this.debugService.getViewModel().focusedStackFrame;
 		const model = this.editor.getModel();
 		if (sf && model && this.uriIdentityService.extUri.isEqual(sf.source.uri, model.uri)) {
-			const result = await this.hoverWidget.showAt(position, focus);
+			const result = await this.hoverWidget.showAt(position, focus, mouseEvent);
 			if (result === ShowDebugHoverResult.NOT_AVAILABLE) {
 				// When no expression available fallback to editor hover
 				this.showEditorHover(position, focus);
@@ -438,7 +439,7 @@ export class DebugEditorContribution implements IDebugEditorContribution {
 	private get showHoverScheduler() {
 		const scheduler = new RunOnceScheduler(() => {
 			if (this.hoverPosition && !this.altPressed) {
-				this.showHover(this.hoverPosition, false);
+				this.showHover(this.hoverPosition.position, false, this.hoverPosition.event);
 			}
 		}, this.hoverDelay);
 		this.toDispose.push(scheduler);
@@ -493,8 +494,8 @@ export class DebugEditorContribution implements IDebugEditorContribution {
 		}
 
 		if (target.type === MouseTargetType.CONTENT_TEXT) {
-			if (target.position && !Position.equals(target.position, this.hoverPosition)) {
-				this.hoverPosition = target.position;
+			if (target.position && !Position.equals(target.position, this.hoverPosition?.position || null) && !this.hoverWidget.isInSafeTriangle(mouseEvent.event.posx, mouseEvent.event.posy)) {
+				this.hoverPosition = { position: target.position, event: mouseEvent.event };
 				// Disable the editor hover during the request to avoid flickering
 				this.preventDefaultEditorHover();
 				this.showHoverScheduler.schedule(this.hoverDelay);

--- a/src/vs/workbench/contrib/debug/browser/debugHover.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugHover.ts
@@ -5,6 +5,7 @@
 
 import * as dom from 'vs/base/browser/dom';
 import { IKeyboardEvent } from 'vs/base/browser/keyboardEvent';
+import { IMouseEvent } from 'vs/base/browser/mouseEvent';
 import { IListVirtualDelegate } from 'vs/base/browser/ui/list/list';
 import { IListAccessibilityProvider } from 'vs/base/browser/ui/list/listWidget';
 import { DomScrollableElement } from 'vs/base/browser/ui/scrollbar/scrollableElement';
@@ -83,6 +84,7 @@ export class DebugHoverWidget implements IContentWidget {
 	readonly allowEditorOverflow = true;
 
 	private _isVisible: boolean;
+	private safeTriangle?: dom.SafeTriangle;
 	private showCancellationSource?: CancellationTokenSource;
 	private domNode!: HTMLElement;
 	private tree!: AsyncDataTree<IExpression, IExpression, any>;
@@ -228,7 +230,15 @@ export class DebugHoverWidget implements IContentWidget {
 		return this.domNode;
 	}
 
-	async showAt(position: Position, focus: boolean): Promise<void | ShowDebugHoverResult> {
+	/**
+	 * Gets whether the given coordinates are in the safe triangle formed from
+	 * the position at which the hover was initiated.
+	 */
+	isInSafeTriangle(x: number, y: number) {
+		return this._isVisible && !!this.safeTriangle?.contains(x, y);
+	}
+
+	async showAt(position: Position, focus: boolean, mouseEvent?: IMouseEvent): Promise<void | ShowDebugHoverResult> {
 		this.showCancellationSource?.cancel();
 		const cancellationSource = this.showCancellationSource = new CancellationTokenSource();
 		const session = this.debugService.getViewModel().focusedSession;
@@ -269,7 +279,7 @@ export class DebugHoverWidget implements IContentWidget {
 			options: DebugHoverWidget._HOVER_HIGHLIGHT_DECORATION_OPTIONS
 		}]);
 
-		return this.doShow(result.range.getStartPosition(), expression, focus);
+		return this.doShow(result.range.getStartPosition(), expression, focus, mouseEvent);
 	}
 
 	private static readonly _HOVER_HIGHLIGHT_DECORATION_OPTIONS = ModelDecorationOptions.register({
@@ -277,7 +287,7 @@ export class DebugHoverWidget implements IContentWidget {
 		className: 'hoverHighlight'
 	});
 
-	private async doShow(position: Position, expression: IExpression, focus: boolean, forceValueHover = false): Promise<void> {
+	private async doShow(position: Position, expression: IExpression, focus: boolean, mouseEvent: IMouseEvent | undefined): Promise<void> {
 		if (!this.domNode) {
 			this.create();
 		}
@@ -285,7 +295,7 @@ export class DebugHoverWidget implements IContentWidget {
 		this.showAtPosition = position;
 		this._isVisible = true;
 
-		if (!expression.hasChildren || forceValueHover) {
+		if (!expression.hasChildren) {
 			this.complexValueContainer.hidden = true;
 			this.valueContainer.hidden = false;
 			renderExpressionValue(expression, this.valueContainer, {
@@ -312,6 +322,7 @@ export class DebugHoverWidget implements IContentWidget {
 		this.tree.scrollTop = 0;
 		this.tree.scrollLeft = 0;
 		this.complexValueContainer.hidden = false;
+		this.safeTriangle = mouseEvent && new dom.SafeTriangle(mouseEvent.posx, mouseEvent.posy, this.domNode);
 
 		if (focus) {
 			this.editor.render();


### PR DESCRIPTION
What was actually happening is that in the process of hovering into the
debug hover, another position was briefly hovered. No data was available
for this position, so the hover was hidden.

This PR implements "safe triangle" logic to avoid changing the hover position until the mouse moves in the safe triangle created by a displayed hover widget.

Fixes #211917

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
