### PR TITLE
Fix a typo in product.json

### DIFF
--- a/product.json
+++ b/product.json
@@ -21,7 +21,7 @@
 	"win32x64UserAppId": "{{CC6B787D-37A0-49E8-AE24-8559A032BE0C}",
 	"win32arm64UserAppId": "{{3AEBF0C8-F733-4AD4-BADE-FDB816D53D7B}",
 	"win32AppUserModelId": "Microsoft.CodeOSS",
-	"win32ShellNameShort": "C&ode - OSS",
+	"win32ShellNameShort": "Code - OSS",
 	"win32TunnelServiceMutex": "vscodeoss-tunnelservice",
 	"win32TunnelMutex": "vscodeoss-tunnel",
 	"darwinBundleIdentifier": "com.visualstudio.code.oss",


### PR DESCRIPTION
This changes `C&ode - OSS` to `Code - OSS`.

I don’t know what this is for, but it looks like a typo.