### PR TITLE
add start chat, disable hint to terminal instance context menu

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminalMenus.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalMenus.ts
@@ -192,7 +192,7 @@ export function setupTerminalMenus(): void {
 						title: localize2('startChat', 'Copilot: Start in Terminal'),
 					},
 					group: '1_copilot@0',
-					order: 2
+					order: 1
 				}
 			},
 			{
@@ -202,7 +202,9 @@ export function setupTerminalMenus(): void {
 						id: TerminalCommandId.DisableInitialHint,
 						title: localize2('disableInitialHint', 'Disable Initial Hint'),
 					},
-					when: TerminalContextKeys.initialHintEnabled,
+					group: '1_copilot@0',
+					order: 2,
+					// when: ContextKeyExpr.and(TerminalContextKeys.initialHintEnabled),
 				}
 			}
 		]

--- a/src/vs/workbench/contrib/terminal/browser/terminalMenus.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalMenus.ts
@@ -184,6 +184,27 @@ export function setupTerminalMenus(): void {
 					order: 3
 				}
 			},
+			{
+				id: MenuId.TerminalInstanceContext,
+				item: {
+					command: {
+						id: 'workbench.action.terminal.chat.start',
+						title: localize2('startChat', 'Copilot: Start in Terminal'),
+					},
+					group: '1_copilot@0',
+					order: 2
+				}
+			},
+			{
+				id: MenuId.TerminalInstanceContext,
+				item: {
+					command: {
+						id: TerminalCommandId.DisableInitialHint,
+						title: localize2('disableInitialHint', 'Disable Initial Hint'),
+					},
+					when: TerminalContextKeys.initialHintEnabled,
+				}
+			}
 		]
 	);
 

--- a/src/vs/workbench/contrib/terminal/browser/terminalMenus.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalMenus.ts
@@ -188,23 +188,11 @@ export function setupTerminalMenus(): void {
 				id: MenuId.TerminalInstanceContext,
 				item: {
 					command: {
-						id: 'workbench.action.terminal.chat.start',
-						title: localize2('startChat', 'Copilot: Start in Terminal'),
-					},
-					group: '1_copilot@0',
-					order: 1
-				}
-			},
-			{
-				id: MenuId.TerminalInstanceContext,
-				item: {
-					command: {
 						id: TerminalCommandId.DisableInitialHint,
 						title: localize2('disableInitialHint', 'Disable Initial Hint'),
 					},
 					group: '1_copilot@0',
 					order: 2,
-					// when: ContextKeyExpr.and(TerminalContextKeys.initialHintEnabled),
 				}
 			}
 		]

--- a/src/vs/workbench/contrib/terminal/common/terminal.ts
+++ b/src/vs/workbench/contrib/terminal/common/terminal.ts
@@ -482,6 +482,7 @@ export const enum TerminalCommandId {
 	ShowEnvironmentContributions = 'workbench.action.terminal.showEnvironmentContributions',
 	StartVoice = 'workbench.action.terminal.startVoice',
 	StopVoice = 'workbench.action.terminal.stopVoice',
+	DisableInitialHint = 'workbench.action.terminal.disableInitialHint'
 }
 
 export const DEFAULT_COMMANDS_TO_SKIP_SHELL: string[] = [

--- a/src/vs/workbench/contrib/terminal/common/terminalContextKey.ts
+++ b/src/vs/workbench/contrib/terminal/common/terminalContextKey.ts
@@ -39,6 +39,7 @@ export const enum TerminalContextKeyStrings {
 	ShellType = 'terminalShellType',
 	InTerminalRunCommandPicker = 'inTerminalRunCommandPicker',
 	TerminalShellIntegrationEnabled = 'terminalShellIntegrationEnabled',
+	InitialHintEnabled = 'terminalInitialHintEnabled'
 }
 
 export namespace TerminalContextKeys {
@@ -158,4 +159,6 @@ export namespace TerminalContextKeys {
 			ContextKeyExpr.equals(`config.${TerminalSettingId.TabsShowActions}`, 'always')
 		)
 	);
+
+	export const initialHintEnabled = new RawContextKey<boolean>(TerminalContextKeyStrings.InitialHintEnabled, false, localize('terminalInitialHintEnabled', "Whether the terminal initial hint is enabled."));
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
fixes #213813 
fixes #213817

To do: 
- only include disable hint action in menu when widget is visible
- change context key to track that instead of when it's enabled
- ⚡ maybe just right click on the hint element to disable it
