### PR TITLE
Disposing the hover disposables inside of the `_setCurrentResult` method of the contentHoverController

### DIFF
--- a/src/vs/editor/contrib/hover/browser/contentHoverTypes.ts
+++ b/src/vs/editor/contrib/hover/browser/contentHoverTypes.ts
@@ -3,7 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { DisposableStore } from 'vs/base/common/lifecycle';
 import { Position } from 'vs/editor/common/core/position';
 import { HoverStartSource } from 'vs/editor/contrib/hover/browser/hoverOperation';
 import { HoverAnchor, IEditorHoverColorPickerWidget, IHoverPart } from 'vs/editor/contrib/hover/browser/hoverTypes';
@@ -54,7 +53,6 @@ export class ContentHoverVisibleData {
 		public readonly preferAbove: boolean,
 		public readonly stoleFocus: boolean,
 		public readonly source: HoverStartSource,
-		public readonly isBeforeContent: boolean,
-		public readonly disposables: DisposableStore
+		public readonly isBeforeContent: boolean
 	) { }
 }

--- a/src/vs/editor/contrib/hover/browser/contentHoverWidget.ts
+++ b/src/vs/editor/contrib/hover/browser/contentHoverWidget.ts
@@ -92,7 +92,6 @@ export class ContentHoverWidget extends ResizableContentWidget {
 
 	public override dispose(): void {
 		super.dispose();
-		this._visibleData?.disposables.dispose();
 		this._editor.removeContentWidget(this);
 	}
 
@@ -265,7 +264,6 @@ export class ContentHoverWidget extends ResizableContentWidget {
 	}
 
 	private _setHoverData(hoverData: ContentHoverVisibleData | undefined): void {
-		this._visibleData?.disposables.dispose();
 		this._visibleData = hoverData;
 		this._hoverVisibleKey.set(!!hoverData);
 		this._hover.containerDomNode.classList.toggle('hidden', !hoverData);


### PR DESCRIPTION
Disposing the hover disposables inside of the `_setCurrentResult` method of the contentHoverController
Adding more consistency into the contentHoverController code.