### PR TITLE
Update preference markers on profile change

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/preferencesRenderers.ts
+++ b/src/vs/workbench/contrib/preferences/browser/preferencesRenderers.ts
@@ -500,6 +500,7 @@ class UnsupportedSettingsRenderer extends Disposable implements languages.CodeAc
 		this._register(this.editor.getModel()!.onDidChangeContent(() => this.delayedRender()));
 		this._register(Event.filter(this.configurationService.onDidChangeConfiguration, e => e.source === ConfigurationTarget.DEFAULT)(() => this.delayedRender()));
 		this._register(languageFeaturesService.codeActionProvider.register({ pattern: settingsEditorModel.uri.path }, this));
+		this._register(userDataProfileService.onDidChangeCurrentProfile(() => this.delayedRender()));
 	}
 
 	private delayedRender(): void {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

When the profile change, we need to recompute the markers because it relies on the currentProfile for the `defaultProfileSettingWhileNonDefaultActive` marker

Most of the time, changing the profile already triggers the render via the configuration change but not everytime