### PR TITLE
REPL/IW editor only using a notebook text model

### DIFF
--- a/extensions/ipynb/package.json
+++ b/extensions/ipynb/package.json
@@ -15,7 +15,8 @@
   ],
   "activationEvents": [
     "onNotebook:jupyter-notebook",
-    "onNotebookSerializer:interactive"
+    "onNotebookSerializer:interactive",
+    "onNotebookSerializer:repl"
   ],
   "extensionKind": [
     "workspace",

--- a/extensions/ipynb/src/ipynbMain.ts
+++ b/extensions/ipynb/src/ipynbMain.ts
@@ -66,6 +66,23 @@ export function activate(context: vscode.ExtensionContext) {
 		}
 	} as vscode.NotebookDocumentContentOptions));
 
+	context.subscriptions.push(vscode.workspace.registerNotebookSerializer('repl', serializer, {
+		transientOutputs: false,
+		transientCellMetadata: useCustomPropertyInMetadata() ? {
+			breakpointMargin: true,
+			custom: false,
+			attachments: false
+		} : {
+			breakpointMargin: true,
+			id: false,
+			metadata: false,
+			attachments: false
+		},
+		cellContentMetadata: {
+			attachments: true
+		}
+	} as vscode.NotebookDocumentContentOptions));
+
 	vscode.languages.registerCodeLensProvider({ pattern: '**/*.ipynb' }, {
 		provideCodeLenses: (document) => {
 			if (

--- a/extensions/ipynb/src/ipynbMain.ts
+++ b/extensions/ipynb/src/ipynbMain.ts
@@ -66,23 +66,6 @@ export function activate(context: vscode.ExtensionContext) {
 		}
 	} as vscode.NotebookDocumentContentOptions));
 
-	context.subscriptions.push(vscode.workspace.registerNotebookSerializer('repl', serializer, {
-		transientOutputs: false,
-		transientCellMetadata: useCustomPropertyInMetadata() ? {
-			breakpointMargin: true,
-			custom: false,
-			attachments: false
-		} : {
-			breakpointMargin: true,
-			id: false,
-			metadata: false,
-			attachments: false
-		},
-		cellContentMetadata: {
-			attachments: true
-		}
-	} as vscode.NotebookDocumentContentOptions));
-
 	vscode.languages.registerCodeLensProvider({ pattern: '**/*.ipynb' }, {
 		provideCodeLenses: (document) => {
 			if (

--- a/src/vs/platform/actions/common/actions.ts
+++ b/src/vs/platform/actions/common/actions.ts
@@ -171,6 +171,7 @@ export class MenuId {
 	static readonly InteractiveCellDelete = new MenuId('InteractiveCellDelete');
 	static readonly InteractiveCellExecute = new MenuId('InteractiveCellExecute');
 	static readonly InteractiveInputExecute = new MenuId('InteractiveInputExecute');
+	static readonly ReplInputExecute = new MenuId('ReplInputExecute');
 	static readonly IssueReporter = new MenuId('IssueReporter');
 	static readonly NotebookToolbar = new MenuId('NotebookToolbar');
 	static readonly NotebookStickyScrollContext = new MenuId('NotebookStickyScrollContext');

--- a/src/vs/workbench/api/common/extHostNotebook.ts
+++ b/src/vs/workbench/api/common/extHostNotebook.ts
@@ -36,7 +36,7 @@ import { IExtHostSearch } from 'vs/workbench/api/common/extHostSearch';
 import { CellSearchModel } from 'vs/workbench/contrib/search/common/cellSearchModel';
 import { INotebookCellMatchNoModel, INotebookFileMatchNoModel, IRawClosedNotebookFileMatch, genericCellMatchesToTextSearchMatches } from 'vs/workbench/contrib/search/common/searchNotebookHelpers';
 import { NotebookPriorityInfo } from 'vs/workbench/contrib/search/common/search';
-import { globMatchesResource } from 'vs/workbench/services/editor/common/editorResolverService';
+import { globMatchesResource, RegisteredEditorPriority } from 'vs/workbench/services/editor/common/editorResolverService';
 import { ILogService } from 'vs/platform/log/common/log';
 
 export class ExtHostNotebookController implements ExtHostNotebookShape {
@@ -163,7 +163,7 @@ export class ExtHostNotebookController implements ExtHostNotebookShape {
 			providerDisplayName: extension.displayName || extension.name,
 			displayName: registration.displayName,
 			filenamePattern: viewOptionsFilenamePattern,
-			exclusive: registration.exclusive || false
+			priority: registration.exclusive ? RegisteredEditorPriority.exclusive : undefined
 		};
 	}
 

--- a/src/vs/workbench/contrib/interactive/browser/interactive.contribution.ts
+++ b/src/vs/workbench/contrib/interactive/browser/interactive.contribution.ts
@@ -591,7 +591,7 @@ registerAction2(class extends Action2 {
 			title: localize2('interactive.history.previous', 'Previous value in history'),
 			category: interactiveWindowCategory,
 			f1: false,
-			keybinding: {
+			keybinding: [{
 				when: ContextKeyExpr.and(
 					ContextKeyExpr.equals('activeEditor', 'workbench.editor.interactive'),
 					INTERACTIVE_INPUT_CURSOR_BOUNDARY.notEqualsTo('bottom'),
@@ -600,7 +600,16 @@ registerAction2(class extends Action2 {
 				),
 				primary: KeyCode.UpArrow,
 				weight: KeybindingWeight.WorkbenchContrib
-			},
+			}, {
+				when: ContextKeyExpr.and(
+					ContextKeyExpr.equals('activeEditor', 'workbench.editor.repl'),
+					INTERACTIVE_INPUT_CURSOR_BOUNDARY.notEqualsTo('bottom'),
+					INTERACTIVE_INPUT_CURSOR_BOUNDARY.notEqualsTo('none'),
+					SuggestContext.Visible.toNegated()
+				),
+				primary: KeyCode.UpArrow,
+				weight: KeybindingWeight.WorkbenchContrib
+			}]
 		});
 	}
 
@@ -630,7 +639,7 @@ registerAction2(class extends Action2 {
 			title: localize2('interactive.history.next', 'Next value in history'),
 			category: interactiveWindowCategory,
 			f1: false,
-			keybinding: {
+			keybinding: [{
 				when: ContextKeyExpr.and(
 					ContextKeyExpr.equals('activeEditor', 'workbench.editor.interactive'),
 					INTERACTIVE_INPUT_CURSOR_BOUNDARY.notEqualsTo('top'),
@@ -639,7 +648,16 @@ registerAction2(class extends Action2 {
 				),
 				primary: KeyCode.DownArrow,
 				weight: KeybindingWeight.WorkbenchContrib
-			},
+			}, {
+				when: ContextKeyExpr.and(
+					ContextKeyExpr.equals('activeEditor', 'workbench.editor.repl'),
+					INTERACTIVE_INPUT_CURSOR_BOUNDARY.notEqualsTo('top'),
+					INTERACTIVE_INPUT_CURSOR_BOUNDARY.notEqualsTo('none'),
+					SuggestContext.Visible.toNegated()
+				),
+				primary: KeyCode.DownArrow,
+				weight: KeybindingWeight.WorkbenchContrib
+			}],
 		});
 	}
 

--- a/src/vs/workbench/contrib/interactive/browser/interactive.contribution.ts
+++ b/src/vs/workbench/contrib/interactive/browser/interactive.contribution.ts
@@ -51,7 +51,7 @@ import { NotebookEditorWidget } from 'vs/workbench/contrib/notebook/browser/note
 import * as icons from 'vs/workbench/contrib/notebook/browser/notebookIcons';
 import { INotebookEditorService } from 'vs/workbench/contrib/notebook/browser/services/notebookEditorService';
 import { CellEditType, CellKind, CellUri, INTERACTIVE_WINDOW_EDITOR_ID, NotebookSetting, NotebookWorkingCopyTypeIdentifier } from 'vs/workbench/contrib/notebook/common/notebookCommon';
-import { InteractiveWindowOpen } from 'vs/workbench/contrib/notebook/common/notebookContextKeys';
+import { INTERACTIVE_WINDOW_IS_ACTIVE_EDITOR, InteractiveWindowOpen } from 'vs/workbench/contrib/notebook/common/notebookContextKeys';
 import { INotebookKernelService } from 'vs/workbench/contrib/notebook/common/notebookKernelService';
 import { INotebookService } from 'vs/workbench/contrib/notebook/common/notebookService';
 import { columnToEditorGroup } from 'vs/workbench/services/editor/common/editorGroupColumn';
@@ -411,10 +411,10 @@ registerAction2(class extends Action2 {
 		logService.debug('Open new interactive window:', notebookUri.toString(), inputUri.toString());
 
 		if (id) {
-			const allKernels = kernelService.getMatchingKernel({ uri: notebookUri, viewType: 'interactive' }).all;
+			const allKernels = kernelService.getMatchingKernel({ uri: notebookUri, kernelType: 'interactive' }).all;
 			const preferredKernel = allKernels.find(kernel => kernel.id === id);
 			if (preferredKernel) {
-				kernelService.preselectKernelForNotebook(preferredKernel, { uri: notebookUri, viewType: 'interactive' });
+				kernelService.preselectKernelForNotebook(preferredKernel, { uri: notebookUri, kernelType: 'interactive' });
 			}
 		}
 
@@ -459,7 +459,8 @@ registerAction2(class extends Action2 {
 			}],
 			menu: [
 				{
-					id: MenuId.InteractiveInputExecute
+					id: MenuId.InteractiveInputExecute,
+					when: INTERACTIVE_WINDOW_IS_ACTIVE_EDITOR
 				}
 			],
 			icon: icons.executeIcon,

--- a/src/vs/workbench/contrib/interactive/browser/interactive.contribution.ts
+++ b/src/vs/workbench/contrib/interactive/browser/interactive.contribution.ts
@@ -51,7 +51,7 @@ import { NotebookEditorWidget } from 'vs/workbench/contrib/notebook/browser/note
 import * as icons from 'vs/workbench/contrib/notebook/browser/notebookIcons';
 import { INotebookEditorService } from 'vs/workbench/contrib/notebook/browser/services/notebookEditorService';
 import { CellEditType, CellKind, CellUri, INTERACTIVE_WINDOW_EDITOR_ID, NotebookSetting, NotebookWorkingCopyTypeIdentifier } from 'vs/workbench/contrib/notebook/common/notebookCommon';
-import { INTERACTIVE_WINDOW_IS_ACTIVE_EDITOR, InteractiveWindowOpen } from 'vs/workbench/contrib/notebook/common/notebookContextKeys';
+import { InteractiveWindowOpen } from 'vs/workbench/contrib/notebook/common/notebookContextKeys';
 import { INotebookKernelService } from 'vs/workbench/contrib/notebook/common/notebookKernelService';
 import { INotebookService } from 'vs/workbench/contrib/notebook/common/notebookService';
 import { columnToEditorGroup } from 'vs/workbench/services/editor/common/editorGroupColumn';
@@ -459,8 +459,7 @@ registerAction2(class extends Action2 {
 			}],
 			menu: [
 				{
-					id: MenuId.InteractiveInputExecute,
-					when: INTERACTIVE_WINDOW_IS_ACTIVE_EDITOR
+					id: MenuId.InteractiveInputExecute
 				}
 			],
 			icon: icons.executeIcon,

--- a/src/vs/workbench/contrib/interactive/browser/interactive.contribution.ts
+++ b/src/vs/workbench/contrib/interactive/browser/interactive.contribution.ts
@@ -411,10 +411,10 @@ registerAction2(class extends Action2 {
 		logService.debug('Open new interactive window:', notebookUri.toString(), inputUri.toString());
 
 		if (id) {
-			const allKernels = kernelService.getMatchingKernel({ uri: notebookUri, kernelType: 'interactive' }).all;
+			const allKernels = kernelService.getMatchingKernel({ uri: notebookUri, notebookType: 'interactive' }).all;
 			const preferredKernel = allKernels.find(kernel => kernel.id === id);
 			if (preferredKernel) {
-				kernelService.preselectKernelForNotebook(preferredKernel, { uri: notebookUri, kernelType: 'interactive' });
+				kernelService.preselectKernelForNotebook(preferredKernel, { uri: notebookUri, notebookType: 'interactive' });
 			}
 		}
 

--- a/src/vs/workbench/contrib/interactive/browser/interactive.contribution.ts
+++ b/src/vs/workbench/contrib/interactive/browser/interactive.contribution.ts
@@ -95,7 +95,7 @@ export class InteractiveDocumentContribution extends Disposable implements IWork
 				providerDisplayName: 'Interactive Notebook',
 				displayName: 'Interactive',
 				filenamePattern: ['*.interactive'],
-				exclusive: true
+				priority: RegisteredEditorPriority.exclusive
 			}));
 		}
 

--- a/src/vs/workbench/contrib/interactive/browser/interactive.contribution.ts
+++ b/src/vs/workbench/contrib/interactive/browser/interactive.contribution.ts
@@ -51,9 +51,12 @@ import { NotebookEditorWidget } from 'vs/workbench/contrib/notebook/browser/note
 import * as icons from 'vs/workbench/contrib/notebook/browser/notebookIcons';
 import { INotebookEditorService } from 'vs/workbench/contrib/notebook/browser/services/notebookEditorService';
 import { CellEditType, CellKind, CellUri, INTERACTIVE_WINDOW_EDITOR_ID, NotebookSetting, NotebookWorkingCopyTypeIdentifier } from 'vs/workbench/contrib/notebook/common/notebookCommon';
-import { InteractiveWindowOpen } from 'vs/workbench/contrib/notebook/common/notebookContextKeys';
+import { InteractiveWindowOpen, NOTEBOOK_CELL_LIST_FOCUSED, REPL_NOTEBOOK_IS_ACTIVE_EDITOR } from 'vs/workbench/contrib/notebook/common/notebookContextKeys';
 import { INotebookKernelService } from 'vs/workbench/contrib/notebook/common/notebookKernelService';
 import { INotebookService } from 'vs/workbench/contrib/notebook/common/notebookService';
+import { executeReplInput } from 'vs/workbench/contrib/replNotebook/browser/repl.contribution';
+import { ReplEditor } from 'vs/workbench/contrib/replNotebook/browser/replEditor';
+import { ReplEditorInput } from 'vs/workbench/contrib/replNotebook/browser/replEditorInput';
 import { columnToEditorGroup } from 'vs/workbench/services/editor/common/editorGroupColumn';
 import { IEditorGroupsService } from 'vs/workbench/services/editor/common/editorGroupsService';
 import { IEditorResolverService, RegisteredEditorPriority } from 'vs/workbench/services/editor/common/editorResolverService';
@@ -456,10 +459,20 @@ registerAction2(class extends Action2 {
 					primary: KeyMod.CtrlCmd | KeyCode.Enter
 				},
 				weight: NOTEBOOK_EDITOR_WIDGET_ACTION_WEIGHT
+			}, {
+				when: ContextKeyExpr.and(
+					REPL_NOTEBOOK_IS_ACTIVE_EDITOR,
+					NOTEBOOK_CELL_LIST_FOCUSED.toNegated()
+				),
+				primary: KeyMod.CtrlCmd | KeyCode.Enter,
+				weight: NOTEBOOK_EDITOR_WIDGET_ACTION_WEIGHT
 			}],
 			menu: [
 				{
 					id: MenuId.InteractiveInputExecute
+				},
+				{
+					id: MenuId.ReplInputExecute
 				}
 			],
 			icon: icons.executeIcon,
@@ -483,19 +496,27 @@ registerAction2(class extends Action2 {
 		const historyService = accessor.get(IInteractiveHistoryService);
 		const notebookEditorService = accessor.get(INotebookEditorService);
 		let editorControl: { notebookEditor: NotebookEditorWidget | undefined; codeEditor: CodeEditorWidget } | undefined;
+		let isReplEditor = false;
 		if (context) {
 			const resourceUri = URI.revive(context);
-			const editors = editorService.findEditors(resourceUri)
-				.filter(id => id.editor instanceof InteractiveEditorInput && id.editor.resource?.toString() === resourceUri.toString());
-			if (editors.length) {
-				const editorInput = editors[0].editor as InteractiveEditorInput;
-				const currentGroup = editors[0].groupId;
-				const editor = await editorService.openEditor(editorInput, currentGroup);
-				editorControl = editor?.getControl() as { notebookEditor: NotebookEditorWidget | undefined; codeEditor: CodeEditorWidget } | undefined;
+			const editors = editorService.findEditors(resourceUri);
+			for (const found of editors) {
+				if (found.editor.typeId === ReplEditorInput.ID || found.editor.typeId === InteractiveEditorInput.ID) {
+					const editor = await editorService.openEditor(found.editor, found.groupId);
+					editorControl = editor?.getControl() as { notebookEditor: NotebookEditorWidget | undefined; codeEditor: CodeEditorWidget } | undefined;
+					isReplEditor = found.editor.typeId === ReplEditorInput.ID;
+					break;
+				}
 			}
 		}
 		else {
+			const editor = editorService.activeEditorPane;
+			isReplEditor = editor instanceof ReplEditor;
 			editorControl = editorService.activeEditorPane?.getControl() as { notebookEditor: NotebookEditorWidget | undefined; codeEditor: CodeEditorWidget } | undefined;
+		}
+
+		if (editorControl && isReplEditor) {
+			executeReplInput(accessor, editorControl);
 		}
 
 		if (editorControl && editorControl.notebookEditor && editorControl.codeEditor) {

--- a/src/vs/workbench/contrib/interactive/browser/interactiveEditor.ts
+++ b/src/vs/workbench/contrib/interactive/browser/interactiveEditor.ts
@@ -163,7 +163,7 @@ export class InteractiveEditor extends EditorPane implements IEditorPaneWithScro
 				this._editorOptions = this._computeEditorOptions();
 			}
 		}));
-		this._notebookOptions = new NotebookOptions(this.window, configurationService, notebookExecutionStateService, codeEditorService, true, { cellToolbarInteraction: 'hover', globalToolbar: true, stickyScrollEnabled: false, dragAndDropEnabled: false });
+		this._notebookOptions = instantiationService.createInstance(NotebookOptions, this.window, true, { cellToolbarInteraction: 'hover', globalToolbar: true, stickyScrollEnabled: false, dragAndDropEnabled: false });
 		this._editorMemento = this.getEditorMemento<InteractiveEditorViewState>(editorGroupService, textResourceConfigurationService, INTERACTIVE_EDITOR_VIEW_STATE_PREFERENCE_KEY);
 
 		codeEditorService.registerDecorationType('interactive-decoration', DECORATION_KEY, {});

--- a/src/vs/workbench/contrib/notebook/browser/controller/apiActions.ts
+++ b/src/vs/workbench/contrib/notebook/browser/controller/apiActions.ts
@@ -64,7 +64,7 @@ CommandsRegistry.registerCommand('_resolveNotebookKernels', async (accessor, arg
 }[]> => {
 	const notebookKernelService = accessor.get(INotebookKernelService);
 	const uri = URI.revive(args.uri as UriComponents);
-	const kernels = notebookKernelService.getMatchingKernel({ uri, viewType: args.viewType });
+	const kernels = notebookKernelService.getMatchingKernel({ uri, kernelType: args.viewType });
 
 	return kernels.all.map(provider => ({
 		id: provider.id,

--- a/src/vs/workbench/contrib/notebook/browser/controller/apiActions.ts
+++ b/src/vs/workbench/contrib/notebook/browser/controller/apiActions.ts
@@ -64,7 +64,7 @@ CommandsRegistry.registerCommand('_resolveNotebookKernels', async (accessor, arg
 }[]> => {
 	const notebookKernelService = accessor.get(INotebookKernelService);
 	const uri = URI.revive(args.uri as UriComponents);
-	const kernels = notebookKernelService.getMatchingKernel({ uri, kernelType: args.viewType });
+	const kernels = notebookKernelService.getMatchingKernel({ uri, notebookType: args.viewType });
 
 	return kernels.all.map(provider => ({
 		id: provider.id,

--- a/src/vs/workbench/contrib/notebook/browser/diff/notebookDiffEditor.ts
+++ b/src/vs/workbench/contrib/notebook/browser/diff/notebookDiffEditor.ts
@@ -41,13 +41,11 @@ import { BackLayerWebView, INotebookDelegateForWebview } from 'vs/workbench/cont
 import { NotebookDiffEditorEventDispatcher, NotebookDiffLayoutChangedEvent } from 'vs/workbench/contrib/notebook/browser/diff/eventDispatcher';
 import { FontMeasurements } from 'vs/editor/browser/config/fontMeasurements';
 import { NotebookOptions } from 'vs/workbench/contrib/notebook/browser/notebookOptions';
-import { INotebookExecutionStateService } from 'vs/workbench/contrib/notebook/common/notebookExecutionStateService';
 import { NotebookLayoutInfo } from 'vs/workbench/contrib/notebook/browser/notebookViewEvents';
 import { IEditorOptions } from 'vs/platform/editor/common/editor';
 import { cellIndexesToRanges, cellRangesToIndexes } from 'vs/workbench/contrib/notebook/common/notebookRange';
 import { NotebookDiffOverviewRuler } from 'vs/workbench/contrib/notebook/browser/diff/notebookDiffOverviewRuler';
 import { registerZIndex, ZIndex } from 'vs/platform/layout/browser/zIndexRegistry';
-import { ICodeEditorService } from 'vs/editor/browser/services/codeEditorService';
 
 const $ = DOM.$;
 
@@ -151,11 +149,9 @@ export class NotebookTextDiffEditor extends EditorPane implements INotebookTextD
 		@IConfigurationService private readonly configurationService: IConfigurationService,
 		@ITelemetryService telemetryService: ITelemetryService,
 		@IStorageService storageService: IStorageService,
-		@INotebookExecutionStateService notebookExecutionStateService: INotebookExecutionStateService,
-		@ICodeEditorService codeEditorService: ICodeEditorService
 	) {
 		super(NotebookTextDiffEditor.ID, group, telemetryService, themeService, storageService);
-		this._notebookOptions = new NotebookOptions(this.window, this.configurationService, notebookExecutionStateService, codeEditorService, false);
+		this._notebookOptions = instantiationService.createInstance(NotebookOptions, this.window, false, undefined);
 		this._register(this._notebookOptions);
 		this._revealFirst = true;
 	}

--- a/src/vs/workbench/contrib/notebook/browser/notebook.contribution.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebook.contribution.ts
@@ -187,8 +187,8 @@ class NotebookDiffEditorSerializer implements IEditorSerializer {
 }
 type SerializedNotebookEditorData = { resource: URI; preferredResource: URI; viewType: string; options?: NotebookEditorInputOptions };
 class NotebookEditorSerializer implements IEditorSerializer {
-	canSerialize(): boolean {
-		return true;
+	canSerialize(input: EditorInput): boolean {
+		return input instanceof NotebookEditorInput && input.viewType === 'jupyter-notebook';
 	}
 	serialize(input: EditorInput): string {
 		assertType(input instanceof NotebookEditorInput);

--- a/src/vs/workbench/contrib/notebook/browser/notebook.contribution.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebook.contribution.ts
@@ -188,7 +188,7 @@ class NotebookDiffEditorSerializer implements IEditorSerializer {
 type SerializedNotebookEditorData = { resource: URI; preferredResource: URI; viewType: string; options?: NotebookEditorInputOptions };
 class NotebookEditorSerializer implements IEditorSerializer {
 	canSerialize(input: EditorInput): boolean {
-		return input instanceof NotebookEditorInput && input.viewType === 'jupyter-notebook';
+		return input.typeId === NotebookEditorInput.ID;
 	}
 	serialize(input: EditorInput): string {
 		assertType(input instanceof NotebookEditorInput);

--- a/src/vs/workbench/contrib/notebook/browser/notebook.contribution.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebook.contribution.ts
@@ -644,7 +644,7 @@ class SimpleNotebookWorkingCopyEditorHandler extends Disposable implements IWork
 
 	private handlesSync(workingCopy: IWorkingCopyIdentifier): string /* viewType */ | undefined {
 		const viewType = this._getViewType(workingCopy);
-		if (!viewType || viewType === 'interactive') {
+		if (!viewType || viewType === 'interactive' || extname(workingCopy.resource) === '.replNotebook') {
 			return undefined;
 		}
 

--- a/src/vs/workbench/contrib/notebook/browser/notebookBrowser.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookBrowser.ts
@@ -22,7 +22,7 @@ import { IEditorPane, IEditorPaneWithSelection } from 'vs/workbench/common/edito
 import { CellViewModelStateChangeEvent, NotebookCellStateChangedEvent, NotebookLayoutInfo } from 'vs/workbench/contrib/notebook/browser/notebookViewEvents';
 import { NotebookCellTextModel } from 'vs/workbench/contrib/notebook/common/model/notebookCellTextModel';
 import { NotebookTextModel } from 'vs/workbench/contrib/notebook/common/model/notebookTextModel';
-import { CellKind, ICellOutput, INotebookCellStatusBarItem, INotebookRendererInfo, INotebookSearchOptions, IOrderedMimeType, NotebookCellInternalMetadata, NotebookCellMetadata, NOTEBOOK_EDITOR_ID } from 'vs/workbench/contrib/notebook/common/notebookCommon';
+import { CellKind, ICellOutput, INotebookCellStatusBarItem, INotebookRendererInfo, INotebookSearchOptions, IOrderedMimeType, NotebookCellInternalMetadata, NotebookCellMetadata, NOTEBOOK_EDITOR_ID, REPL_EDITOR_ID } from 'vs/workbench/contrib/notebook/common/notebookCommon';
 import { isCompositeNotebookEditorInput } from 'vs/workbench/contrib/notebook/common/notebookEditorInput';
 import { INotebookKernel } from 'vs/workbench/contrib/notebook/common/notebookKernelService';
 import { NotebookOptions } from 'vs/workbench/contrib/notebook/browser/notebookOptions';
@@ -878,7 +878,9 @@ export function getNotebookEditorFromEditorPane(editorPane?: IEditorPane): INote
 
 	const input = editorPane.input;
 
-	if (input && isCompositeNotebookEditorInput(input)) {
+	const isInteractiveEditor = input && isCompositeNotebookEditorInput(input);
+
+	if (isInteractiveEditor || editorPane.getId() === REPL_EDITOR_ID) {
 		return (editorPane.getControl() as { notebookEditor: INotebookEditor | undefined } | undefined)?.notebookEditor;
 	}
 

--- a/src/vs/workbench/contrib/notebook/browser/notebookBrowser.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookBrowser.ts
@@ -448,7 +448,7 @@ export interface INotebookViewCellsUpdateEvent {
 
 export interface INotebookViewModel {
 	notebookDocument: NotebookTextModel;
-	viewCells: ICellViewModel[];
+	readonly viewCells: ICellViewModel[];
 	layoutInfo: NotebookLayoutInfo | null;
 	onDidChangeViewCells: Event<INotebookViewCellsUpdateEvent>;
 	onDidChangeSelection: Event<string>;

--- a/src/vs/workbench/contrib/notebook/browser/notebookBrowser.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookBrowser.ts
@@ -383,6 +383,7 @@ export interface INotebookEditorCreationOptions {
 	};
 	readonly options?: NotebookOptions;
 	readonly codeWindow?: CodeWindow;
+	readonly forRepl?: boolean;
 }
 
 export interface INotebookWebviewMessage {

--- a/src/vs/workbench/contrib/notebook/browser/notebookEditorSerializer.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookEditorSerializer.ts
@@ -1,0 +1,4 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/

--- a/src/vs/workbench/contrib/notebook/browser/notebookEditorSerializer.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookEditorSerializer.ts
@@ -1,4 +1,0 @@
-/*---------------------------------------------------------------------------------------------
- *  Copyright (c) Microsoft Corporation. All rights reserved.
- *  Licensed under the MIT License. See License.txt in the project root for license information.
- *--------------------------------------------------------------------------------------------*/

--- a/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
@@ -311,7 +311,12 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditorD
 		this.isEmbedded = creationOptions.isEmbedded ?? false;
 		this._readOnly = creationOptions.isReadOnly ?? false;
 
-		this._notebookOptions = creationOptions.options ?? new NotebookOptions(this.creationOptions?.codeWindow ?? mainWindow, this.configurationService, notebookExecutionStateService, codeEditorService, this._readOnly);
+		this._overlayContainer = document.createElement('div');
+		this.scopedContextKeyService = this._register(contextKeyService.createScoped(this._overlayContainer));
+		this.instantiationService = instantiationService.createChild(new ServiceCollection([IContextKeyService, this.scopedContextKeyService]));
+
+		this._notebookOptions = creationOptions.options ??
+			this.instantiationService.createInstance(NotebookOptions, this.creationOptions?.codeWindow ?? mainWindow, this._readOnly, undefined);
 		this._register(this._notebookOptions);
 		const eventDispatcher = this._register(new NotebookEventDispatcher());
 		this._viewContext = new ViewContext(
@@ -322,9 +327,6 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditorD
 			this._onDidChangeCellState.fire(e);
 		}));
 
-		this._overlayContainer = document.createElement('div');
-		this.scopedContextKeyService = this._register(contextKeyService.createScoped(this._overlayContainer));
-		this.instantiationService = this._register(instantiationService.createChild(new ServiceCollection([IContextKeyService, this.scopedContextKeyService])));
 
 		this._register(_notebookService.onDidChangeOutputRenderers(() => {
 			this._updateOutputRenderers();

--- a/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
@@ -99,7 +99,6 @@ import { NotebookStickyScroll } from 'vs/workbench/contrib/notebook/browser/view
 import { AccessibilityVerbositySettingId } from 'vs/workbench/contrib/accessibility/browser/accessibilityConfiguration';
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 import { PixelRatio } from 'vs/base/browser/pixelRatio';
-import { ICodeEditorService } from 'vs/editor/browser/services/codeEditorService';
 import { PreventDefaultContextMenuItemsContextKeyName } from 'vs/workbench/contrib/webview/browser/webview.contribution';
 import { NotebookAccessibilityProvider } from 'vs/workbench/contrib/notebook/browser/notebookAccessibilityProvider';
 
@@ -272,6 +271,7 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditorD
 
 	readonly isEmbedded: boolean;
 	private _readOnly: boolean;
+	private readonly _inRepl: boolean;
 
 	public readonly scopedContextKeyService: IContextKeyService;
 	private readonly instantiationService: IInstantiationService;
@@ -302,7 +302,6 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditorD
 		@IEditorProgressService private editorProgressService: IEditorProgressService,
 		@INotebookLoggingService private readonly logService: INotebookLoggingService,
 		@IKeybindingService private readonly keybindingService: IKeybindingService,
-		@ICodeEditorService codeEditorService: ICodeEditorService
 	) {
 		super();
 
@@ -310,10 +309,11 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditorD
 
 		this.isEmbedded = creationOptions.isEmbedded ?? false;
 		this._readOnly = creationOptions.isReadOnly ?? false;
+		this._inRepl = creationOptions.forRepl ?? false;
 
 		this._overlayContainer = document.createElement('div');
 		this.scopedContextKeyService = this._register(contextKeyService.createScoped(this._overlayContainer));
-		this.instantiationService = instantiationService.createChild(new ServiceCollection([IContextKeyService, this.scopedContextKeyService]));
+		this.instantiationService = this._register(instantiationService.createChild(new ServiceCollection([IContextKeyService, this.scopedContextKeyService])));
 
 		this._notebookOptions = creationOptions.options ??
 			this.instantiationService.createInstance(NotebookOptions, this.creationOptions?.codeWindow ?? mainWindow, this._readOnly, undefined);
@@ -1437,7 +1437,7 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditorD
 	private async _attachModel(textModel: NotebookTextModel, viewState: INotebookEditorViewState | undefined, perf?: NotebookPerfMarks) {
 		this._ensureWebview(this.getId(), textModel.viewType, textModel.uri);
 
-		this.viewModel = this.instantiationService.createInstance(NotebookViewModel, textModel.viewType, textModel, this._viewContext, this.getLayoutInfo(), { isReadOnly: this._readOnly });
+		this.viewModel = this.instantiationService.createInstance(NotebookViewModel, textModel.viewType, textModel, this._viewContext, this.getLayoutInfo(), { isReadOnly: this._readOnly, inRepl: this._inRepl });
 		this._viewContext.eventDispatcher.emit([new NotebookLayoutChangedEvent({ width: true, fontInfo: true }, this.getLayoutInfo())]);
 		this.notebookOptions.updateOptions(this._readOnly);
 

--- a/src/vs/workbench/contrib/notebook/browser/notebookOptions.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookOptions.ts
@@ -137,11 +137,11 @@ export class NotebookOptions extends Disposable {
 
 	constructor(
 		readonly targetWindow: CodeWindow,
-		private readonly configurationService: IConfigurationService,
-		private readonly notebookExecutionStateService: INotebookExecutionStateService,
-		private readonly codeEditorService: ICodeEditorService,
 		private isReadonly: boolean,
-		private readonly overrides?: { cellToolbarInteraction: string; globalToolbar: boolean; stickyScrollEnabled: boolean; dragAndDropEnabled: boolean }
+		private readonly overrides: { cellToolbarInteraction: string; globalToolbar: boolean; stickyScrollEnabled: boolean; dragAndDropEnabled: boolean } | undefined,
+		@IConfigurationService private readonly configurationService: IConfigurationService,
+		@INotebookExecutionStateService private readonly notebookExecutionStateService: INotebookExecutionStateService,
+		@ICodeEditorService private readonly codeEditorService: ICodeEditorService,
 	) {
 		super();
 		const showCellStatusBar = this.configurationService.getValue<ShowCellStatusBarType>(NotebookSetting.showCellStatusBar);

--- a/src/vs/workbench/contrib/notebook/browser/services/notebookKernelHistoryServiceImpl.ts
+++ b/src/vs/workbench/contrib/notebook/browser/services/notebookKernelHistoryServiceImpl.ts
@@ -48,7 +48,7 @@ export class NotebookKernelHistoryService extends Disposable implements INoteboo
 		// We will suggest the only kernel
 		const suggested = allAvailableKernels.all.length === 1 ? allAvailableKernels.all[0] : undefined;
 		this._notebookLoggingService.debug('History', `getMatchingKernels: ${allAvailableKernels.all.length} kernels available for ${notebook.uri.path}. Selected: ${allAvailableKernels.selected?.label}. Suggested: ${suggested?.label}`);
-		const mostRecentKernelIds = this._mostRecentKernelsMap[notebook.viewType] ? [...this._mostRecentKernelsMap[notebook.viewType].values()] : [];
+		const mostRecentKernelIds = this._mostRecentKernelsMap[notebook.kernelType] ? [...this._mostRecentKernelsMap[notebook.kernelType].values()] : [];
 		const all = mostRecentKernelIds.map(kernelId => allKernels.find(kernel => kernel.id === kernelId)).filter(kernel => !!kernel) as INotebookKernel[];
 		this._notebookLoggingService.debug('History', `mru: ${mostRecentKernelIds.length} kernels in history, ${all.length} registered already.`);
 

--- a/src/vs/workbench/contrib/notebook/browser/services/notebookKernelHistoryServiceImpl.ts
+++ b/src/vs/workbench/contrib/notebook/browser/services/notebookKernelHistoryServiceImpl.ts
@@ -48,7 +48,7 @@ export class NotebookKernelHistoryService extends Disposable implements INoteboo
 		// We will suggest the only kernel
 		const suggested = allAvailableKernels.all.length === 1 ? allAvailableKernels.all[0] : undefined;
 		this._notebookLoggingService.debug('History', `getMatchingKernels: ${allAvailableKernels.all.length} kernels available for ${notebook.uri.path}. Selected: ${allAvailableKernels.selected?.label}. Suggested: ${suggested?.label}`);
-		const mostRecentKernelIds = this._mostRecentKernelsMap[notebook.kernelType] ? [...this._mostRecentKernelsMap[notebook.kernelType].values()] : [];
+		const mostRecentKernelIds = this._mostRecentKernelsMap[notebook.notebookType] ? [...this._mostRecentKernelsMap[notebook.notebookType].values()] : [];
 		const all = mostRecentKernelIds.map(kernelId => allKernels.find(kernel => kernel.id === kernelId)).filter(kernel => !!kernel) as INotebookKernel[];
 		this._notebookLoggingService.debug('History', `mru: ${mostRecentKernelIds.length} kernels in history, ${all.length} registered already.`);
 

--- a/src/vs/workbench/contrib/notebook/browser/services/notebookKernelServiceImpl.ts
+++ b/src/vs/workbench/contrib/notebook/browser/services/notebookKernelServiceImpl.ts
@@ -37,12 +37,12 @@ class KernelInfo {
 
 class NotebookTextModelLikeId {
 	static str(k: INotebookTextModelLike): string {
-		return `${k.viewType}/${k.uri.toString()}`;
+		return `${k.kernelType}/${k.uri.toString()}`;
 	}
 	static obj(s: string): INotebookTextModelLike {
 		const idx = s.indexOf('/');
 		return {
-			viewType: s.substring(0, idx),
+			kernelType: s.substring(0, idx),
 			uri: URI.parse(s.substring(idx + 1))
 		};
 	}
@@ -178,7 +178,7 @@ export class NotebookKernelService extends Disposable implements INotebookKernel
 	private static _score(kernel: INotebookKernel, notebook: INotebookTextModelLike): number {
 		if (kernel.viewType === '*') {
 			return 5;
-		} else if (kernel.viewType === notebook.viewType) {
+		} else if (kernel.viewType === notebook.kernelType) {
 			return 10;
 		} else {
 			return 0;
@@ -343,7 +343,7 @@ export class NotebookKernelService extends Disposable implements INotebookKernel
 					const stateChangeListener = sourceAction.onDidChangeState(() => {
 						this._onDidChangeSourceActions.fire({
 							notebook: document.uri,
-							viewType: document.viewType,
+							viewType: document.kernelType,
 						});
 					});
 					sourceActions.push([sourceAction, stateChangeListener]);
@@ -351,7 +351,7 @@ export class NotebookKernelService extends Disposable implements INotebookKernel
 			});
 			info.actions = sourceActions;
 			this._kernelSources.set(id, info);
-			this._onDidChangeSourceActions.fire({ notebook: document.uri, viewType: document.viewType });
+			this._onDidChangeSourceActions.fire({ notebook: document.uri, viewType: document.kernelType });
 		};
 
 		this._kernelSourceActionsUpdates.get(id)?.dispose();
@@ -382,7 +382,7 @@ export class NotebookKernelService extends Disposable implements INotebookKernel
 	}
 
 	getKernelDetectionTasks(notebook: INotebookTextModelLike): INotebookKernelDetectionTask[] {
-		return this._kernelDetectionTasks.get(notebook.viewType) ?? [];
+		return this._kernelDetectionTasks.get(notebook.kernelType) ?? [];
 	}
 
 	registerKernelSourceActionProvider(viewType: string, provider: IKernelSourceActionProvider): IDisposable {
@@ -411,7 +411,7 @@ export class NotebookKernelService extends Disposable implements INotebookKernel
 	 * Get kernel source actions from providers
 	 */
 	getKernelSourceActions2(notebook: INotebookTextModelLike): Promise<INotebookKernelSourceAction[]> {
-		const viewType = notebook.viewType;
+		const viewType = notebook.kernelType;
 		const providers = this._kernelSourceActionProviders.get(viewType) ?? [];
 		const promises = providers.map(provider => provider.provideKernelSourceActions());
 		return Promise.all(promises).then(actions => {

--- a/src/vs/workbench/contrib/notebook/browser/services/notebookKernelServiceImpl.ts
+++ b/src/vs/workbench/contrib/notebook/browser/services/notebookKernelServiceImpl.ts
@@ -37,12 +37,12 @@ class KernelInfo {
 
 class NotebookTextModelLikeId {
 	static str(k: INotebookTextModelLike): string {
-		return `${k.kernelType}/${k.uri.toString()}`;
+		return `${k.notebookType}/${k.uri.toString()}`;
 	}
 	static obj(s: string): INotebookTextModelLike {
 		const idx = s.indexOf('/');
 		return {
-			kernelType: s.substring(0, idx),
+			notebookType: s.substring(0, idx),
 			uri: URI.parse(s.substring(idx + 1))
 		};
 	}
@@ -178,7 +178,7 @@ export class NotebookKernelService extends Disposable implements INotebookKernel
 	private static _score(kernel: INotebookKernel, notebook: INotebookTextModelLike): number {
 		if (kernel.viewType === '*') {
 			return 5;
-		} else if (kernel.viewType === notebook.kernelType) {
+		} else if (kernel.viewType === notebook.notebookType) {
 			return 10;
 		} else {
 			return 0;
@@ -343,7 +343,7 @@ export class NotebookKernelService extends Disposable implements INotebookKernel
 					const stateChangeListener = sourceAction.onDidChangeState(() => {
 						this._onDidChangeSourceActions.fire({
 							notebook: document.uri,
-							viewType: document.kernelType,
+							viewType: document.notebookType,
 						});
 					});
 					sourceActions.push([sourceAction, stateChangeListener]);
@@ -351,7 +351,7 @@ export class NotebookKernelService extends Disposable implements INotebookKernel
 			});
 			info.actions = sourceActions;
 			this._kernelSources.set(id, info);
-			this._onDidChangeSourceActions.fire({ notebook: document.uri, viewType: document.kernelType });
+			this._onDidChangeSourceActions.fire({ notebook: document.uri, viewType: document.notebookType });
 		};
 
 		this._kernelSourceActionsUpdates.get(id)?.dispose();
@@ -382,7 +382,7 @@ export class NotebookKernelService extends Disposable implements INotebookKernel
 	}
 
 	getKernelDetectionTasks(notebook: INotebookTextModelLike): INotebookKernelDetectionTask[] {
-		return this._kernelDetectionTasks.get(notebook.kernelType) ?? [];
+		return this._kernelDetectionTasks.get(notebook.notebookType) ?? [];
 	}
 
 	registerKernelSourceActionProvider(viewType: string, provider: IKernelSourceActionProvider): IDisposable {
@@ -411,7 +411,7 @@ export class NotebookKernelService extends Disposable implements INotebookKernel
 	 * Get kernel source actions from providers
 	 */
 	getKernelSourceActions2(notebook: INotebookTextModelLike): Promise<INotebookKernelSourceAction[]> {
-		const viewType = notebook.kernelType;
+		const viewType = notebook.notebookType;
 		const providers = this._kernelSourceActionProviders.get(viewType) ?? [];
 		const promises = providers.map(provider => provider.provideKernelSourceActions());
 		return Promise.all(promises).then(actions => {

--- a/src/vs/workbench/contrib/notebook/browser/services/notebookServiceImpl.ts
+++ b/src/vs/workbench/contrib/notebook/browser/services/notebookServiceImpl.ts
@@ -132,7 +132,6 @@ export class NotebookProviderInfoStore extends Disposable {
 					selectors: notebookContribution.selector || [],
 					priority: this._convertPriority(notebookContribution.priority),
 					providerDisplayName: extension.description.displayName ?? extension.description.identifier.value,
-					exclusive: false
 				}));
 			}
 		}
@@ -171,7 +170,7 @@ export class NotebookProviderInfoStore extends Disposable {
 				id: notebookProviderInfo.id,
 				label: notebookProviderInfo.displayName,
 				detail: notebookProviderInfo.providerDisplayName,
-				priority: notebookProviderInfo.exclusive ? RegisteredEditorPriority.exclusive : notebookProviderInfo.priority,
+				priority: notebookProviderInfo.priority,
 			};
 			const notebookEditorOptions = {
 				canHandleDiff: () => !!this._configurationService.getValue(NotebookSetting.textDiffEditorPreview) && !this._accessibilityService.isScreenReaderOptimized(),
@@ -639,8 +638,7 @@ export class NotebookService extends Disposable implements INotebookService {
 			id: viewType,
 			displayName: data.displayName,
 			providerDisplayName: data.providerDisplayName,
-			exclusive: data.exclusive,
-			priority: RegisteredEditorPriority.default,
+			priority: data.priority || RegisteredEditorPriority.default,
 			selectors: []
 		});
 

--- a/src/vs/workbench/contrib/notebook/browser/viewModel/notebookViewModelImpl.ts
+++ b/src/vs/workbench/contrib/notebook/browser/viewModel/notebookViewModelImpl.ts
@@ -113,10 +113,6 @@ export class NotebookViewModel extends Disposable implements EditorFoldingStateD
 		return this._viewCells;
 	}
 
-	set viewCells(_: ICellViewModel[]) {
-		throw new Error('NotebookViewModel.viewCells is readonly');
-	}
-
 	get length(): number {
 		return this._viewCells.length;
 	}
@@ -337,9 +333,10 @@ export class NotebookViewModel extends Disposable implements EditorFoldingStateD
 			this._onDidChangeSelection.fire(e);
 		}));
 
-		this._viewCells = this._notebook.cells.map(cell => {
-			return createCellViewModel(this._instantiationService, this, cell, this._viewContext);
-		});
+		for (const cell of this._notebook.cellsForView()) {
+			this._viewCells.push(createCellViewModel(this._instantiationService, this, cell, this._viewContext));
+		}
+
 
 		this._viewCells.forEach(cell => {
 			this._handleToViewCellMapping.set(cell.handle, cell);

--- a/src/vs/workbench/contrib/notebook/browser/viewModel/notebookViewModelImpl.ts
+++ b/src/vs/workbench/contrib/notebook/browser/viewModel/notebookViewModelImpl.ts
@@ -99,6 +99,7 @@ let MODEL_ID = 0;
 
 export interface NotebookViewModelOptions {
 	isReadOnly: boolean;
+	inRepl?: boolean;
 }
 
 export class NotebookViewModel extends Disposable implements EditorFoldingStateDelegate, INotebookViewModel {
@@ -108,6 +109,7 @@ export class NotebookViewModel extends Disposable implements EditorFoldingStateD
 	private readonly _onDidChangeOptions = this._register(new Emitter<void>());
 	get onDidChangeOptions(): Event<void> { return this._onDidChangeOptions.event; }
 	private _viewCells: CellViewModel[] = [];
+	private readonly replView: boolean;
 
 	get viewCells(): ICellViewModel[] {
 		return this._viewCells;
@@ -202,6 +204,7 @@ export class NotebookViewModel extends Disposable implements EditorFoldingStateD
 		MODEL_ID++;
 		this.id = '$notebookViewModel' + MODEL_ID;
 		this._instanceId = strings.singleLetterHash(MODEL_ID);
+		this.replView = !!this.options.inRepl;
 
 		const compute = (changes: NotebookCellTextModelSplice<ICell>[], synchronous: boolean) => {
 			const diffs = changes.map(splice => {
@@ -333,8 +336,10 @@ export class NotebookViewModel extends Disposable implements EditorFoldingStateD
 			this._onDidChangeSelection.fire(e);
 		}));
 
-		for (const cell of this._notebook.cellsForView()) {
-			this._viewCells.push(createCellViewModel(this._instantiationService, this, cell, this._viewContext));
+
+		const viewCellCount = this.replView ? this._notebook.cells.length - 1 : this._notebook.cells.length;
+		for (let i = 0; i < viewCellCount; i++) {
+			this._viewCells.push(createCellViewModel(this._instantiationService, this, this._notebook.cells[i], this._viewContext));
 		}
 
 

--- a/src/vs/workbench/contrib/notebook/common/model/notebookTextModel.ts
+++ b/src/vs/workbench/contrib/notebook/common/model/notebookTextModel.ts
@@ -207,6 +207,16 @@ export class NotebookTextModel extends Disposable implements INotebookTextModel 
 		return this._cells;
 	}
 
+	*cellsForView(): Iterable<NotebookCellTextModel> {
+		if (this.viewType === 'repl') {
+			for (let i = 0; i < this._cells.length - 1; i++) {
+				yield this._cells[i];
+			}
+		} else {
+			yield* this._cells;
+		}
+	}
+
 	get versionId() {
 		return this._versionId;
 	}

--- a/src/vs/workbench/contrib/notebook/common/model/notebookTextModel.ts
+++ b/src/vs/workbench/contrib/notebook/common/model/notebookTextModel.ts
@@ -215,6 +215,11 @@ export class NotebookTextModel extends Disposable implements INotebookTextModel 
 		return this._alternativeVersionId;
 	}
 
+	get kernelType() {
+		// the repl notebook type can handle all the same kernels as the jupyter notebook type
+		return this.viewType === 'repl' ? 'jupyter-notebook' : this.viewType;
+	}
+
 	constructor(
 		readonly viewType: string,
 		readonly uri: URI,

--- a/src/vs/workbench/contrib/notebook/common/model/notebookTextModel.ts
+++ b/src/vs/workbench/contrib/notebook/common/model/notebookTextModel.ts
@@ -225,7 +225,7 @@ export class NotebookTextModel extends Disposable implements INotebookTextModel 
 		return this._alternativeVersionId;
 	}
 
-	get kernelType() {
+	get notebookType() {
 		// the repl notebook type can handle all the same kernels as the jupyter notebook type
 		return this.viewType === 'repl' ? 'jupyter-notebook' : this.viewType;
 	}

--- a/src/vs/workbench/contrib/notebook/common/model/notebookTextModel.ts
+++ b/src/vs/workbench/contrib/notebook/common/model/notebookTextModel.ts
@@ -226,8 +226,7 @@ export class NotebookTextModel extends Disposable implements INotebookTextModel 
 	}
 
 	get notebookType() {
-		// the repl notebook type can handle all the same kernels as the jupyter notebook type
-		return this.viewType === 'repl' ? 'jupyter-notebook' : this.viewType;
+		return this.viewType;
 	}
 
 	constructor(

--- a/src/vs/workbench/contrib/notebook/common/model/notebookTextModel.ts
+++ b/src/vs/workbench/contrib/notebook/common/model/notebookTextModel.ts
@@ -207,16 +207,6 @@ export class NotebookTextModel extends Disposable implements INotebookTextModel 
 		return this._cells;
 	}
 
-	*cellsForView(): Iterable<NotebookCellTextModel> {
-		if (this.viewType === 'repl') {
-			for (let i = 0; i < this._cells.length - 1; i++) {
-				yield this._cells[i];
-			}
-		} else {
-			yield* this._cells;
-		}
-	}
-
 	get versionId() {
 		return this._versionId;
 	}

--- a/src/vs/workbench/contrib/notebook/common/notebookCommon.ts
+++ b/src/vs/workbench/contrib/notebook/common/notebookCommon.ts
@@ -37,6 +37,7 @@ import { ICellExecutionError } from 'vs/workbench/contrib/notebook/common/notebo
 export const NOTEBOOK_EDITOR_ID = 'workbench.editor.notebook';
 export const NOTEBOOK_DIFF_EDITOR_ID = 'workbench.editor.notebookTextDiffEditor';
 export const INTERACTIVE_WINDOW_EDITOR_ID = 'workbench.editor.interactive';
+export const REPL_EDITOR_ID = 'workbench.editor.repl';
 
 
 export enum CellKind {

--- a/src/vs/workbench/contrib/notebook/common/notebookCommon.ts
+++ b/src/vs/workbench/contrib/notebook/common/notebookCommon.ts
@@ -254,6 +254,7 @@ export interface ICell {
 }
 
 export interface INotebookTextModel {
+	readonly kernelType: string;
 	readonly viewType: string;
 	metadata: NotebookDocumentMetadata;
 	readonly transientOptions: TransientOptions;

--- a/src/vs/workbench/contrib/notebook/common/notebookCommon.ts
+++ b/src/vs/workbench/contrib/notebook/common/notebookCommon.ts
@@ -781,6 +781,11 @@ export interface INotebookLoadOptions {
 	readonly limits?: IFileReadLimits;
 }
 
+export type NotebookEditorModelCreationOptions = {
+	limits?: IFileReadLimits;
+	scratchpad?: boolean;
+};
+
 export interface IResolvedNotebookEditorModel extends INotebookEditorModel {
 	notebook: NotebookTextModel;
 }

--- a/src/vs/workbench/contrib/notebook/common/notebookCommon.ts
+++ b/src/vs/workbench/contrib/notebook/common/notebookCommon.ts
@@ -34,6 +34,7 @@ import { IFileReadLimits } from 'vs/platform/files/common/files';
 import { parse as parseUri, generate as generateUri } from 'vs/workbench/services/notebook/common/notebookDocumentService';
 import { ICellExecutionError } from 'vs/workbench/contrib/notebook/common/notebookExecutionStateService';
 import { INotebookTextModelLike } from 'vs/workbench/contrib/notebook/common/notebookKernelService';
+import { RegisteredEditorPriority } from 'vs/workbench/services/editor/common/editorResolverService';
 
 export const NOTEBOOK_EDITOR_ID = 'workbench.editor.notebook';
 export const NOTEBOOK_DIFF_EDITOR_ID = 'workbench.editor.notebookTextDiffEditor';
@@ -554,7 +555,7 @@ export interface INotebookContributionData {
 	providerDisplayName: string;
 	displayName: string;
 	filenamePattern: (string | glob.IRelativePattern | INotebookExclusiveDocumentFilter)[];
-	exclusive: boolean;
+	priority?: RegisteredEditorPriority;
 }
 
 

--- a/src/vs/workbench/contrib/notebook/common/notebookCommon.ts
+++ b/src/vs/workbench/contrib/notebook/common/notebookCommon.ts
@@ -33,6 +33,7 @@ import { IMarkdownString } from 'vs/base/common/htmlContent';
 import { IFileReadLimits } from 'vs/platform/files/common/files';
 import { parse as parseUri, generate as generateUri } from 'vs/workbench/services/notebook/common/notebookDocumentService';
 import { ICellExecutionError } from 'vs/workbench/contrib/notebook/common/notebookExecutionStateService';
+import { INotebookTextModelLike } from 'vs/workbench/contrib/notebook/common/notebookKernelService';
 
 export const NOTEBOOK_EDITOR_ID = 'workbench.editor.notebook';
 export const NOTEBOOK_DIFF_EDITOR_ID = 'workbench.editor.notebookTextDiffEditor';
@@ -253,8 +254,8 @@ export interface ICell {
 	onDidChangeInternalMetadata: Event<CellInternalMetadataChangedEvent>;
 }
 
-export interface INotebookTextModel {
-	readonly kernelType: string;
+export interface INotebookTextModel extends INotebookTextModelLike {
+	readonly notebookType: string;
 	readonly viewType: string;
 	metadata: NotebookDocumentMetadata;
 	readonly transientOptions: TransientOptions;

--- a/src/vs/workbench/contrib/notebook/common/notebookCommon.ts
+++ b/src/vs/workbench/contrib/notebook/common/notebookCommon.ts
@@ -41,6 +41,7 @@ export const NOTEBOOK_DIFF_EDITOR_ID = 'workbench.editor.notebookTextDiffEditor'
 export const INTERACTIVE_WINDOW_EDITOR_ID = 'workbench.editor.interactive';
 export const REPL_EDITOR_ID = 'workbench.editor.repl';
 
+export const EXECUTE_REPL_COMMAND_ID = 'replNotebook.input.execute';
 
 export enum CellKind {
 	Markup = 1,

--- a/src/vs/workbench/contrib/notebook/common/notebookContextKeys.ts
+++ b/src/vs/workbench/contrib/notebook/common/notebookContextKeys.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { ContextKeyExpr, RawContextKey } from 'vs/platform/contextkey/common/contextkey';
-import { INTERACTIVE_WINDOW_EDITOR_ID, NOTEBOOK_EDITOR_ID } from 'vs/workbench/contrib/notebook/common/notebookCommon';
+import { INTERACTIVE_WINDOW_EDITOR_ID, NOTEBOOK_EDITOR_ID, REPL_EDITOR_ID } from 'vs/workbench/contrib/notebook/common/notebookCommon';
 
 
 
@@ -16,6 +16,7 @@ export const InteractiveWindowOpen = new RawContextKey<boolean>('interactiveWind
 // Is Notebook
 export const NOTEBOOK_IS_ACTIVE_EDITOR = ContextKeyExpr.equals('activeEditor', NOTEBOOK_EDITOR_ID);
 export const INTERACTIVE_WINDOW_IS_ACTIVE_EDITOR = ContextKeyExpr.equals('activeEditor', INTERACTIVE_WINDOW_EDITOR_ID);
+export const REPL_NOTEBOOK_IS_ACTIVE_EDITOR = ContextKeyExpr.equals('activeEditor', REPL_EDITOR_ID);
 
 // Editor keys
 export const NOTEBOOK_EDITOR_FOCUSED = new RawContextKey<boolean>('notebookEditorFocused', false);

--- a/src/vs/workbench/contrib/notebook/common/notebookContextKeys.ts
+++ b/src/vs/workbench/contrib/notebook/common/notebookContextKeys.ts
@@ -19,9 +19,12 @@ export const INTERACTIVE_WINDOW_IS_ACTIVE_EDITOR = ContextKeyExpr.equals('active
 export const REPL_NOTEBOOK_IS_ACTIVE_EDITOR = ContextKeyExpr.equals('activeEditor', REPL_EDITOR_ID);
 
 // Editor keys
+// based on the focus of the notebook editor widget
 export const NOTEBOOK_EDITOR_FOCUSED = new RawContextKey<boolean>('notebookEditorFocused', false);
+// always true within the cell list html element
 export const NOTEBOOK_CELL_LIST_FOCUSED = new RawContextKey<boolean>('notebookCellListFocused', false);
 export const NOTEBOOK_OUTPUT_FOCUSED = new RawContextKey<boolean>('notebookOutputFocused', false);
+// an input html element within the output webview has focus
 export const NOTEBOOK_OUTPUT_INPUT_FOCUSED = new RawContextKey<boolean>('notebookOutputInputFocused', false);
 export const NOTEBOOK_EDITOR_EDITABLE = new RawContextKey<boolean>('notebookEditable', true);
 export const NOTEBOOK_HAS_RUNNING_CELL = new RawContextKey<boolean>('notebookHasRunningCell', false);

--- a/src/vs/workbench/contrib/notebook/common/notebookEditorInput.ts
+++ b/src/vs/workbench/contrib/notebook/common/notebookEditorInput.ts
@@ -53,7 +53,7 @@ export class NotebookEditorInput extends AbstractResourceEditorInput {
 
 	static readonly ID: string = 'workbench.input.notebook';
 
-	private _editorModelReference: IReference<IResolvedNotebookEditorModel> | null = null;
+	protected editorModelReference: IReference<IResolvedNotebookEditorModel> | null = null;
 	private _sideLoadedListener: IDisposable;
 	private _defaultDirtyState: boolean = false;
 
@@ -105,8 +105,8 @@ export class NotebookEditorInput extends AbstractResourceEditorInput {
 
 	override dispose() {
 		this._sideLoadedListener.dispose();
-		this._editorModelReference?.dispose();
-		this._editorModelReference = null;
+		this.editorModelReference?.dispose();
+		this.editorModelReference = null;
 		super.dispose();
 	}
 
@@ -125,8 +125,8 @@ export class NotebookEditorInput extends AbstractResourceEditorInput {
 			capabilities |= EditorInputCapabilities.Untitled;
 		}
 
-		if (this._editorModelReference) {
-			if (this._editorModelReference.object.isReadonly()) {
+		if (this.editorModelReference) {
+			if (this.editorModelReference.object.isReadonly()) {
 				capabilities |= EditorInputCapabilities.Readonly;
 			}
 		} else {
@@ -143,7 +143,7 @@ export class NotebookEditorInput extends AbstractResourceEditorInput {
 	}
 
 	override getDescription(verbosity = Verbosity.MEDIUM): string | undefined {
-		if (!this.hasCapability(EditorInputCapabilities.Untitled) || this._editorModelReference?.object.hasAssociatedFilePath()) {
+		if (!this.hasCapability(EditorInputCapabilities.Untitled) || this.editorModelReference?.object.hasAssociatedFilePath()) {
 			return super.getDescription(verbosity);
 		}
 
@@ -151,21 +151,21 @@ export class NotebookEditorInput extends AbstractResourceEditorInput {
 	}
 
 	override isReadonly(): boolean | IMarkdownString {
-		if (!this._editorModelReference) {
+		if (!this.editorModelReference) {
 			return this.filesConfigurationService.isReadonly(this.resource);
 		}
-		return this._editorModelReference.object.isReadonly();
+		return this.editorModelReference.object.isReadonly();
 	}
 
 	override isDirty() {
-		if (!this._editorModelReference) {
+		if (!this.editorModelReference) {
 			return this._defaultDirtyState;
 		}
-		return this._editorModelReference.object.isDirty();
+		return this.editorModelReference.object.isDirty();
 	}
 
 	override isSaving(): boolean {
-		const model = this._editorModelReference?.object;
+		const model = this.editorModelReference?.object;
 		if (!model || !model.isDirty() || model.hasErrorState || this.hasCapability(EditorInputCapabilities.Untitled)) {
 			return false; // require the model to be dirty, file-backed and not in an error state
 		}
@@ -175,12 +175,12 @@ export class NotebookEditorInput extends AbstractResourceEditorInput {
 	}
 
 	override async save(group: GroupIdentifier, options?: ISaveOptions): Promise<EditorInput | IUntypedEditorInput | undefined> {
-		if (this._editorModelReference) {
+		if (this.editorModelReference) {
 
 			if (this.hasCapability(EditorInputCapabilities.Untitled)) {
 				return this.saveAs(group, options);
 			} else {
-				await this._editorModelReference.object.save(options);
+				await this.editorModelReference.object.save(options);
 			}
 
 			return this;
@@ -190,7 +190,7 @@ export class NotebookEditorInput extends AbstractResourceEditorInput {
 	}
 
 	override async saveAs(group: GroupIdentifier, options?: ISaveOptions): Promise<IUntypedEditorInput | undefined> {
-		if (!this._editorModelReference) {
+		if (!this.editorModelReference) {
 			return undefined;
 		}
 
@@ -200,9 +200,9 @@ export class NotebookEditorInput extends AbstractResourceEditorInput {
 			return undefined;
 		}
 
-		const pathCandidate = this.hasCapability(EditorInputCapabilities.Untitled) ? await this._suggestName(provider, this.labelService.getUriBasenameLabel(this.resource)) : this._editorModelReference.object.resource;
+		const pathCandidate = this.hasCapability(EditorInputCapabilities.Untitled) ? await this._suggestName(provider, this.labelService.getUriBasenameLabel(this.resource)) : this.editorModelReference.object.resource;
 		let target: URI | undefined;
-		if (this._editorModelReference.object.hasAssociatedFilePath()) {
+		if (this.editorModelReference.object.hasAssociatedFilePath()) {
 			target = pathCandidate;
 		} else {
 			target = await this._fileDialogService.pickFileToSave(pathCandidate, options?.availableFileSystems);
@@ -231,7 +231,7 @@ export class NotebookEditorInput extends AbstractResourceEditorInput {
 			throw new Error(`File name ${target} is not supported by ${provider.providerDisplayName}.\n\nPlease make sure the file name matches following patterns:\n${patterns}`);
 		}
 
-		return await this._editorModelReference.object.saveAs(target);
+		return await this.editorModelReference.object.saveAs(target);
 	}
 
 	private async _suggestName(provider: NotebookProviderInfo, suggestedFilename: string) {
@@ -260,7 +260,7 @@ export class NotebookEditorInput extends AbstractResourceEditorInput {
 
 	// called when users rename a notebook document
 	override async rename(group: GroupIdentifier, target: URI): Promise<IMoveResult | undefined> {
-		if (this._editorModelReference) {
+		if (this.editorModelReference) {
 			return { editor: { resource: target }, options: { override: this.viewType } };
 
 		}
@@ -268,8 +268,8 @@ export class NotebookEditorInput extends AbstractResourceEditorInput {
 	}
 
 	override async revert(_group: GroupIdentifier, options?: IRevertOptions): Promise<void> {
-		if (this._editorModelReference && this._editorModelReference.object.isDirty()) {
-			await this._editorModelReference.object.revert(options);
+		if (this.editorModelReference && this.editorModelReference.object.isDirty()) {
+			await this.editorModelReference.object.revert(options);
 		}
 	}
 
@@ -284,42 +284,42 @@ export class NotebookEditorInput extends AbstractResourceEditorInput {
 		// "other" loading anymore
 		this._sideLoadedListener.dispose();
 
-		if (!this._editorModelReference) {
+		if (!this.editorModelReference) {
 			const ref = await this._notebookModelResolverService.resolve(this.resource, this.viewType, this.ensureLimits(_options));
-			if (this._editorModelReference) {
+			if (this.editorModelReference) {
 				// Re-entrant, double resolve happened. Dispose the addition references and proceed
 				// with the truth.
 				ref.dispose();
-				return (<IReference<IResolvedNotebookEditorModel>>this._editorModelReference).object;
+				return (<IReference<IResolvedNotebookEditorModel>>this.editorModelReference).object;
 			}
-			this._editorModelReference = ref;
+			this.editorModelReference = ref;
 			if (this.isDisposed()) {
-				this._editorModelReference.dispose();
-				this._editorModelReference = null;
+				this.editorModelReference.dispose();
+				this.editorModelReference = null;
 				return null;
 			}
-			this._register(this._editorModelReference.object.onDidChangeDirty(() => this._onDidChangeDirty.fire()));
-			this._register(this._editorModelReference.object.onDidChangeReadonly(() => this._onDidChangeCapabilities.fire()));
-			this._register(this._editorModelReference.object.onDidRevertUntitled(() => this.dispose()));
-			if (this._editorModelReference.object.isDirty()) {
+			this._register(this.editorModelReference.object.onDidChangeDirty(() => this._onDidChangeDirty.fire()));
+			this._register(this.editorModelReference.object.onDidChangeReadonly(() => this._onDidChangeCapabilities.fire()));
+			this._register(this.editorModelReference.object.onDidRevertUntitled(() => this.dispose()));
+			if (this.editorModelReference.object.isDirty()) {
 				this._onDidChangeDirty.fire();
 			}
 		} else {
-			this._editorModelReference.object.load({ limits: this.ensureLimits(_options) });
+			this.editorModelReference.object.load({ limits: this.ensureLimits(_options) });
 		}
 
 		if (this.options._backupId) {
-			const info = await this._notebookService.withNotebookDataProvider(this._editorModelReference.object.notebook.viewType);
+			const info = await this._notebookService.withNotebookDataProvider(this.editorModelReference.object.notebook.viewType);
 			if (!(info instanceof SimpleNotebookProviderInfo)) {
 				throw new Error('CANNOT open file notebook with this provider');
 			}
 
 			const data = await info.serializer.dataToNotebook(VSBuffer.fromString(JSON.stringify({ __webview_backup: this.options._backupId })));
-			this._editorModelReference.object.notebook.applyEdits([
+			this.editorModelReference.object.notebook.applyEdits([
 				{
 					editType: CellEditType.Replace,
 					index: 0,
-					count: this._editorModelReference.object.notebook.length,
+					count: this.editorModelReference.object.notebook.length,
 					cells: data.cells
 				}
 			], true, undefined, () => undefined, undefined, false);
@@ -331,7 +331,7 @@ export class NotebookEditorInput extends AbstractResourceEditorInput {
 			}
 		}
 
-		return this._editorModelReference.object;
+		return this.editorModelReference.object;
 	}
 
 	override toUntyped(): IResourceEditorInput {

--- a/src/vs/workbench/contrib/notebook/common/notebookEditorInput.ts
+++ b/src/vs/workbench/contrib/notebook/common/notebookEditorInput.ts
@@ -285,7 +285,8 @@ export class NotebookEditorInput extends AbstractResourceEditorInput {
 		this._sideLoadedListener.dispose();
 
 		if (!this.editorModelReference) {
-			const ref = await this._notebookModelResolverService.resolve(this.resource, this.viewType, this.ensureLimits(_options));
+			const scratchpad = this.capabilities & EditorInputCapabilities.Scratchpad ? true : false;
+			const ref = await this._notebookModelResolverService.resolve(this.resource, this.viewType, { limits: this.ensureLimits(_options), scratchpad });
 			if (this.editorModelReference) {
 				// Re-entrant, double resolve happened. Dispose the addition references and proceed
 				// with the truth.

--- a/src/vs/workbench/contrib/notebook/common/notebookEditorModelResolverService.ts
+++ b/src/vs/workbench/contrib/notebook/common/notebookEditorModelResolverService.ts
@@ -38,6 +38,8 @@ export interface IUntitledNotebookResource {
 	 * - they will not ask for a file path when saving but use the associated path
 	 */
 	untitledResource: URI | undefined;
+
+	scratchpad?: boolean;
 }
 
 export interface INotebookEditorModelResolverService {

--- a/src/vs/workbench/contrib/notebook/common/notebookEditorModelResolverService.ts
+++ b/src/vs/workbench/contrib/notebook/common/notebookEditorModelResolverService.ts
@@ -5,10 +5,9 @@
 
 import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
 import { URI } from 'vs/base/common/uri';
-import { IResolvedNotebookEditorModel } from 'vs/workbench/contrib/notebook/common/notebookCommon';
+import { IResolvedNotebookEditorModel, NotebookEditorModelCreationOptions } from 'vs/workbench/contrib/notebook/common/notebookCommon';
 import { IReference } from 'vs/base/common/lifecycle';
 import { Event, IWaitUntil } from 'vs/base/common/event';
-import { IFileReadLimits } from 'vs/platform/files/common/files';
 
 export const INotebookEditorModelResolverService = createDecorator<INotebookEditorModelResolverService>('INotebookModelResolverService');
 
@@ -38,8 +37,6 @@ export interface IUntitledNotebookResource {
 	 * - they will not ask for a file path when saving but use the associated path
 	 */
 	untitledResource: URI | undefined;
-
-	scratchpad?: boolean;
 }
 
 export interface INotebookEditorModelResolverService {
@@ -52,6 +49,6 @@ export interface INotebookEditorModelResolverService {
 
 	isDirty(resource: URI): boolean;
 
-	resolve(resource: URI, viewType?: string, limits?: IFileReadLimits): Promise<IReference<IResolvedNotebookEditorModel>>;
-	resolve(resource: IUntitledNotebookResource, viewType: string, limits?: IFileReadLimits): Promise<IReference<IResolvedNotebookEditorModel>>;
+	resolve(resource: URI, viewType?: string, creationOptions?: NotebookEditorModelCreationOptions): Promise<IReference<IResolvedNotebookEditorModel>>;
+	resolve(resource: IUntitledNotebookResource, viewType: string, creationOtions?: NotebookEditorModelCreationOptions): Promise<IReference<IResolvedNotebookEditorModel>>;
 }

--- a/src/vs/workbench/contrib/notebook/common/notebookEditorModelResolverServiceImpl.ts
+++ b/src/vs/workbench/contrib/notebook/common/notebookEditorModelResolverServiceImpl.ts
@@ -79,7 +79,8 @@ class NotebookModelReferenceCollection extends ReferenceCollection<Promise<IReso
 			);
 			this._workingCopyManagers.set(workingCopyTypeId, workingCopyManager);
 		}
-		const scratchPad = viewType === 'interactive' && this._configurationService.getValue<boolean>(NotebookSetting.InteractiveWindowPromptToSave) !== true;
+		const isScratchpadView = viewType === 'interactive' || viewType === 'repl';
+		const scratchPad = isScratchpadView && this._configurationService.getValue<boolean>(NotebookSetting.InteractiveWindowPromptToSave) !== true;
 		const model = this._instantiationService.createInstance(SimpleNotebookEditorModel, uri, hasAssociatedFilePath, viewType, workingCopyManager, scratchPad);
 		const result = await model.load({ limits });
 

--- a/src/vs/workbench/contrib/notebook/common/notebookEditorModelResolverServiceImpl.ts
+++ b/src/vs/workbench/contrib/notebook/common/notebookEditorModelResolverServiceImpl.ts
@@ -220,8 +220,9 @@ export class NotebookModelResolverServiceImpl implements INotebookEditorModelRes
 			} else {
 				await this._extensionService.whenInstalledExtensionsRegistered();
 				const providers = this._notebookService.getContributedNotebookTypes(resource);
-				const exclusiveProvider = providers.find(provider => provider.exclusive);
-				viewType = exclusiveProvider?.id || providers[0]?.id;
+				viewType = providers.find(provider => provider.priority === 'exclusive')?.id ??
+					providers.find(provider => provider.priority === 'default')?.id ??
+					providers[0]?.id;
 			}
 		}
 

--- a/src/vs/workbench/contrib/notebook/common/notebookEditorModelResolverServiceImpl.ts
+++ b/src/vs/workbench/contrib/notebook/common/notebookEditorModelResolverServiceImpl.ts
@@ -5,7 +5,7 @@
 
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { URI } from 'vs/base/common/uri';
-import { CellUri, IResolvedNotebookEditorModel, NotebookSetting, NotebookWorkingCopyTypeIdentifier } from 'vs/workbench/contrib/notebook/common/notebookCommon';
+import { CellUri, IResolvedNotebookEditorModel, NotebookEditorModelCreationOptions, NotebookSetting, NotebookWorkingCopyTypeIdentifier } from 'vs/workbench/contrib/notebook/common/notebookCommon';
 import { NotebookFileWorkingCopyModel, NotebookFileWorkingCopyModelFactory, SimpleNotebookEditorModel } from 'vs/workbench/contrib/notebook/common/notebookEditorModel';
 import { combinedDisposable, DisposableStore, dispose, IDisposable, IReference, ReferenceCollection, toDisposable } from 'vs/base/common/lifecycle';
 import { INotebookService } from 'vs/workbench/contrib/notebook/common/notebookService';
@@ -177,9 +177,9 @@ export class NotebookModelResolverServiceImpl implements INotebookEditorModelRes
 		return this._data.isDirty(resource);
 	}
 
-	async resolve(resource: URI, viewType?: string, limits?: IFileReadLimits): Promise<IReference<IResolvedNotebookEditorModel>>;
-	async resolve(resource: IUntitledNotebookResource, viewType: string, limits?: IFileReadLimits, isScratchpad?: boolean): Promise<IReference<IResolvedNotebookEditorModel>>;
-	async resolve(arg0: URI | IUntitledNotebookResource, viewType?: string, limits?: IFileReadLimits, isScratchpad?: boolean): Promise<IReference<IResolvedNotebookEditorModel>> {
+	async resolve(resource: URI, viewType?: string, options?: NotebookEditorModelCreationOptions): Promise<IReference<IResolvedNotebookEditorModel>>;
+	async resolve(resource: IUntitledNotebookResource, viewType: string, options: NotebookEditorModelCreationOptions): Promise<IReference<IResolvedNotebookEditorModel>>;
+	async resolve(arg0: URI | IUntitledNotebookResource, viewType?: string, options?: NotebookEditorModelCreationOptions): Promise<IReference<IResolvedNotebookEditorModel>> {
 		let resource: URI;
 		let hasAssociatedFilePath = false;
 		if (URI.isUri(arg0)) {
@@ -241,7 +241,7 @@ export class NotebookModelResolverServiceImpl implements INotebookEditorModelRes
 			}
 		}
 
-		const reference = this._data.acquire(resource.toString(), viewType, hasAssociatedFilePath, limits, isScratchpad);
+		const reference = this._data.acquire(resource.toString(), viewType, hasAssociatedFilePath, options?.limits, options?.scratchpad);
 		try {
 			const model = await reference.object;
 			return {

--- a/src/vs/workbench/contrib/notebook/common/notebookKernelService.ts
+++ b/src/vs/workbench/contrib/notebook/common/notebookKernelService.ts
@@ -106,7 +106,7 @@ export interface IKernelSourceActionProvider {
 	provideKernelSourceActions(): Promise<INotebookKernelSourceAction[]>;
 }
 
-export interface INotebookTextModelLike { uri: URI; viewType: string }
+export interface INotebookTextModelLike { uri: URI; kernelType: string }
 
 export const INotebookKernelService = createDecorator<INotebookKernelService>('INotebookKernelService');
 

--- a/src/vs/workbench/contrib/notebook/common/notebookKernelService.ts
+++ b/src/vs/workbench/contrib/notebook/common/notebookKernelService.ts
@@ -106,7 +106,7 @@ export interface IKernelSourceActionProvider {
 	provideKernelSourceActions(): Promise<INotebookKernelSourceAction[]>;
 }
 
-export interface INotebookTextModelLike { uri: URI; kernelType: string }
+export interface INotebookTextModelLike { uri: URI; notebookType: string }
 
 export const INotebookKernelService = createDecorator<INotebookKernelService>('INotebookKernelService');
 

--- a/src/vs/workbench/contrib/notebook/common/notebookProvider.ts
+++ b/src/vs/workbench/contrib/notebook/common/notebookProvider.ts
@@ -19,7 +19,6 @@ export interface NotebookEditorDescriptor {
 	readonly selectors: readonly { filenamePattern?: string; excludeFileNamePattern?: string }[];
 	readonly priority: RegisteredEditorPriority;
 	readonly providerDisplayName: string;
-	readonly exclusive: boolean;
 }
 
 export class NotebookProviderInfo {
@@ -29,7 +28,6 @@ export class NotebookProviderInfo {
 	readonly displayName: string;
 	readonly priority: RegisteredEditorPriority;
 	readonly providerDisplayName: string;
-	readonly exclusive: boolean;
 
 	private _selectors: NotebookSelector[];
 	get selectors() {
@@ -50,7 +48,6 @@ export class NotebookProviderInfo {
 		})) || [];
 		this.priority = descriptor.priority;
 		this.providerDisplayName = descriptor.providerDisplayName;
-		this.exclusive = descriptor.exclusive;
 		this._options = {
 			transientCellMetadata: {},
 			transientDocumentMetadata: {},

--- a/src/vs/workbench/contrib/notebook/test/browser/notebookKernelHistory.test.ts
+++ b/src/vs/workbench/contrib/notebook/test/browser/notebookKernelHistory.test.ts
@@ -102,14 +102,14 @@ suite('NotebookKernelHistoryService', () => {
 
 		const kernelHistoryService = disposables.add(instantiationService.createInstance(NotebookKernelHistoryService));
 
-		let info = kernelHistoryService.getKernels({ uri: u1, viewType: 'foo' });
+		let info = kernelHistoryService.getKernels({ uri: u1, kernelType: 'foo' });
 		assert.equal(info.all.length, 0);
 		assert.ok(!info.selected);
 
 		// update priorities for u1 notebook
 		kernelService.updateKernelNotebookAffinity(k2, u1, 2);
 
-		info = kernelHistoryService.getKernels({ uri: u1, viewType: 'foo' });
+		info = kernelHistoryService.getKernels({ uri: u1, kernelType: 'foo' });
 		assert.equal(info.all.length, 0);
 		// MRU only auto selects kernel if there is only one
 		assert.deepStrictEqual(info.selected, undefined);
@@ -158,12 +158,12 @@ suite('NotebookKernelHistoryService', () => {
 		});
 
 		const kernelHistoryService = disposables.add(instantiationService.createInstance(NotebookKernelHistoryService));
-		let info = kernelHistoryService.getKernels({ uri: u1, viewType: 'foo' });
+		let info = kernelHistoryService.getKernels({ uri: u1, kernelType: 'foo' });
 		assert.equal(info.all.length, 1);
 		assert.deepStrictEqual(info.selected, undefined);
 
 		kernelHistoryService.addMostRecentKernel(k3);
-		info = kernelHistoryService.getKernels({ uri: u1, viewType: 'foo' });
+		info = kernelHistoryService.getKernels({ uri: u1, kernelType: 'foo' });
 		assert.deepStrictEqual(info.all, [k3, k2]);
 	});
 });

--- a/src/vs/workbench/contrib/notebook/test/browser/notebookKernelHistory.test.ts
+++ b/src/vs/workbench/contrib/notebook/test/browser/notebookKernelHistory.test.ts
@@ -66,8 +66,8 @@ suite('NotebookKernelHistoryService', () => {
 
 		const u1 = URI.parse('foo:///one');
 
-		const k1 = new TestNotebookKernel({ label: 'z', viewType: 'foo' });
-		const k2 = new TestNotebookKernel({ label: 'a', viewType: 'foo' });
+		const k1 = new TestNotebookKernel({ label: 'z', notebookType: 'foo' });
+		const k2 = new TestNotebookKernel({ label: 'a', notebookType: 'foo' });
 
 		disposables.add(kernelService.registerKernel(k1));
 		disposables.add(kernelService.registerKernel(k2));
@@ -102,14 +102,14 @@ suite('NotebookKernelHistoryService', () => {
 
 		const kernelHistoryService = disposables.add(instantiationService.createInstance(NotebookKernelHistoryService));
 
-		let info = kernelHistoryService.getKernels({ uri: u1, kernelType: 'foo' });
+		let info = kernelHistoryService.getKernels({ uri: u1, notebookType: 'foo' });
 		assert.equal(info.all.length, 0);
 		assert.ok(!info.selected);
 
 		// update priorities for u1 notebook
 		kernelService.updateKernelNotebookAffinity(k2, u1, 2);
 
-		info = kernelHistoryService.getKernels({ uri: u1, kernelType: 'foo' });
+		info = kernelHistoryService.getKernels({ uri: u1, notebookType: 'foo' });
 		assert.equal(info.all.length, 0);
 		// MRU only auto selects kernel if there is only one
 		assert.deepStrictEqual(info.selected, undefined);
@@ -119,9 +119,9 @@ suite('NotebookKernelHistoryService', () => {
 
 		const u1 = URI.parse('foo:///one');
 
-		const k1 = new TestNotebookKernel({ label: 'z', viewType: 'foo' });
-		const k2 = new TestNotebookKernel({ label: 'a', viewType: 'foo' });
-		const k3 = new TestNotebookKernel({ label: 'b', viewType: 'foo' });
+		const k1 = new TestNotebookKernel({ label: 'z', notebookType: 'foo' });
+		const k2 = new TestNotebookKernel({ label: 'a', notebookType: 'foo' });
+		const k3 = new TestNotebookKernel({ label: 'b', notebookType: 'foo' });
 
 		disposables.add(kernelService.registerKernel(k1));
 		disposables.add(kernelService.registerKernel(k2));
@@ -158,12 +158,12 @@ suite('NotebookKernelHistoryService', () => {
 		});
 
 		const kernelHistoryService = disposables.add(instantiationService.createInstance(NotebookKernelHistoryService));
-		let info = kernelHistoryService.getKernels({ uri: u1, kernelType: 'foo' });
+		let info = kernelHistoryService.getKernels({ uri: u1, notebookType: 'foo' });
 		assert.equal(info.all.length, 1);
 		assert.deepStrictEqual(info.selected, undefined);
 
 		kernelHistoryService.addMostRecentKernel(k3);
-		info = kernelHistoryService.getKernels({ uri: u1, kernelType: 'foo' });
+		info = kernelHistoryService.getKernels({ uri: u1, notebookType: 'foo' });
 		assert.deepStrictEqual(info.all, [k3, k2]);
 	});
 });
@@ -190,9 +190,9 @@ class TestNotebookKernel implements INotebookKernel {
 		return AsyncIterableObject.EMPTY;
 	}
 
-	constructor(opts?: { languages?: string[]; label?: string; viewType?: string }) {
+	constructor(opts?: { languages?: string[]; label?: string; notebookType?: string }) {
 		this.supportedLanguages = opts?.languages ?? [PLAINTEXT_LANGUAGE_ID];
 		this.label = opts?.label ?? this.label;
-		this.viewType = opts?.viewType ?? this.viewType;
+		this.viewType = opts?.notebookType ?? this.viewType;
 	}
 }

--- a/src/vs/workbench/contrib/notebook/test/browser/notebookKernelService.test.ts
+++ b/src/vs/workbench/contrib/notebook/test/browser/notebookKernelService.test.ts
@@ -72,7 +72,7 @@ suite('NotebookKernelService', () => {
 		disposables.add(kernelService.registerKernel(k2));
 
 		// equal priorities -> sort by name
-		let info = kernelService.getMatchingKernel({ uri: u1, viewType: 'foo' });
+		let info = kernelService.getMatchingKernel({ uri: u1, kernelType: 'foo' });
 		assert.ok(info.all[0] === k2);
 		assert.ok(info.all[1] === k1);
 
@@ -81,18 +81,18 @@ suite('NotebookKernelService', () => {
 		kernelService.updateKernelNotebookAffinity(k2, u2, 1);
 
 		// updated
-		info = kernelService.getMatchingKernel({ uri: u1, viewType: 'foo' });
+		info = kernelService.getMatchingKernel({ uri: u1, kernelType: 'foo' });
 		assert.ok(info.all[0] === k2);
 		assert.ok(info.all[1] === k1);
 
 		// NOT updated
-		info = kernelService.getMatchingKernel({ uri: u2, viewType: 'foo' });
+		info = kernelService.getMatchingKernel({ uri: u2, kernelType: 'foo' });
 		assert.ok(info.all[0] === k2);
 		assert.ok(info.all[1] === k1);
 
 		// reset
 		kernelService.updateKernelNotebookAffinity(k2, u1, undefined);
-		info = kernelService.getMatchingKernel({ uri: u1, viewType: 'foo' });
+		info = kernelService.getMatchingKernel({ uri: u1, kernelType: 'foo' });
 		assert.ok(info.all[0] === k2);
 		assert.ok(info.all[1] === k1);
 	});
@@ -103,18 +103,18 @@ suite('NotebookKernelService', () => {
 		const kernel = new TestNotebookKernel();
 		disposables.add(kernelService.registerKernel(kernel));
 
-		let info = kernelService.getMatchingKernel({ uri: notebook, viewType: 'foo' });
+		let info = kernelService.getMatchingKernel({ uri: notebook, kernelType: 'foo' });
 		assert.strictEqual(info.all.length, 1);
 		assert.ok(info.all[0] === kernel);
 
 		const betterKernel = new TestNotebookKernel();
 		disposables.add(kernelService.registerKernel(betterKernel));
 
-		info = kernelService.getMatchingKernel({ uri: notebook, viewType: 'foo' });
+		info = kernelService.getMatchingKernel({ uri: notebook, kernelType: 'foo' });
 		assert.strictEqual(info.all.length, 2);
 
 		kernelService.updateKernelNotebookAffinity(betterKernel, notebook, 2);
-		info = kernelService.getMatchingKernel({ uri: notebook, viewType: 'foo' });
+		info = kernelService.getMatchingKernel({ uri: notebook, kernelType: 'foo' });
 		assert.strictEqual(info.all.length, 2);
 		assert.ok(info.all[0] === betterKernel);
 		assert.ok(info.all[1] === kernel);
@@ -123,8 +123,8 @@ suite('NotebookKernelService', () => {
 	test('onDidChangeSelectedNotebooks not fired on initial notebook open #121904', function () {
 
 		const uri = URI.parse('foo:///one');
-		const jupyter = { uri, viewType: 'jupyter' };
-		const dotnet = { uri, viewType: 'dotnet' };
+		const jupyter = { uri, viewType: 'jupyter', kernelType: 'jupyter' };
+		const dotnet = { uri, viewType: 'dotnet', kernelType: 'dotnet' };
 
 		const jupyterKernel = new TestNotebookKernel({ viewType: jupyter.viewType });
 		const dotnetKernel = new TestNotebookKernel({ viewType: dotnet.viewType });
@@ -144,8 +144,8 @@ suite('NotebookKernelService', () => {
 	test('onDidChangeSelectedNotebooks not fired on initial notebook open #121904, p2', async function () {
 
 		const uri = URI.parse('foo:///one');
-		const jupyter = { uri, viewType: 'jupyter' };
-		const dotnet = { uri, viewType: 'dotnet' };
+		const jupyter = { uri, viewType: 'jupyter', kernelType: 'jupyter' };
+		const dotnet = { uri, viewType: 'dotnet', kernelType: 'dotnet' };
 
 		const jupyterKernel = new TestNotebookKernel({ viewType: jupyter.viewType });
 		const dotnetKernel = new TestNotebookKernel({ viewType: dotnet.viewType });

--- a/src/vs/workbench/contrib/notebook/test/browser/notebookKernelService.test.ts
+++ b/src/vs/workbench/contrib/notebook/test/browser/notebookKernelService.test.ts
@@ -72,7 +72,7 @@ suite('NotebookKernelService', () => {
 		disposables.add(kernelService.registerKernel(k2));
 
 		// equal priorities -> sort by name
-		let info = kernelService.getMatchingKernel({ uri: u1, kernelType: 'foo' });
+		let info = kernelService.getMatchingKernel({ uri: u1, notebookType: 'foo' });
 		assert.ok(info.all[0] === k2);
 		assert.ok(info.all[1] === k1);
 
@@ -81,18 +81,18 @@ suite('NotebookKernelService', () => {
 		kernelService.updateKernelNotebookAffinity(k2, u2, 1);
 
 		// updated
-		info = kernelService.getMatchingKernel({ uri: u1, kernelType: 'foo' });
+		info = kernelService.getMatchingKernel({ uri: u1, notebookType: 'foo' });
 		assert.ok(info.all[0] === k2);
 		assert.ok(info.all[1] === k1);
 
 		// NOT updated
-		info = kernelService.getMatchingKernel({ uri: u2, kernelType: 'foo' });
+		info = kernelService.getMatchingKernel({ uri: u2, notebookType: 'foo' });
 		assert.ok(info.all[0] === k2);
 		assert.ok(info.all[1] === k1);
 
 		// reset
 		kernelService.updateKernelNotebookAffinity(k2, u1, undefined);
-		info = kernelService.getMatchingKernel({ uri: u1, kernelType: 'foo' });
+		info = kernelService.getMatchingKernel({ uri: u1, notebookType: 'foo' });
 		assert.ok(info.all[0] === k2);
 		assert.ok(info.all[1] === k1);
 	});
@@ -103,18 +103,18 @@ suite('NotebookKernelService', () => {
 		const kernel = new TestNotebookKernel();
 		disposables.add(kernelService.registerKernel(kernel));
 
-		let info = kernelService.getMatchingKernel({ uri: notebook, kernelType: 'foo' });
+		let info = kernelService.getMatchingKernel({ uri: notebook, notebookType: 'foo' });
 		assert.strictEqual(info.all.length, 1);
 		assert.ok(info.all[0] === kernel);
 
 		const betterKernel = new TestNotebookKernel();
 		disposables.add(kernelService.registerKernel(betterKernel));
 
-		info = kernelService.getMatchingKernel({ uri: notebook, kernelType: 'foo' });
+		info = kernelService.getMatchingKernel({ uri: notebook, notebookType: 'foo' });
 		assert.strictEqual(info.all.length, 2);
 
 		kernelService.updateKernelNotebookAffinity(betterKernel, notebook, 2);
-		info = kernelService.getMatchingKernel({ uri: notebook, kernelType: 'foo' });
+		info = kernelService.getMatchingKernel({ uri: notebook, notebookType: 'foo' });
 		assert.strictEqual(info.all.length, 2);
 		assert.ok(info.all[0] === betterKernel);
 		assert.ok(info.all[1] === kernel);
@@ -123,8 +123,8 @@ suite('NotebookKernelService', () => {
 	test('onDidChangeSelectedNotebooks not fired on initial notebook open #121904', function () {
 
 		const uri = URI.parse('foo:///one');
-		const jupyter = { uri, viewType: 'jupyter', kernelType: 'jupyter' };
-		const dotnet = { uri, viewType: 'dotnet', kernelType: 'dotnet' };
+		const jupyter = { uri, viewType: 'jupyter', notebookType: 'jupyter' };
+		const dotnet = { uri, viewType: 'dotnet', notebookType: 'dotnet' };
 
 		const jupyterKernel = new TestNotebookKernel({ viewType: jupyter.viewType });
 		const dotnetKernel = new TestNotebookKernel({ viewType: dotnet.viewType });
@@ -144,8 +144,8 @@ suite('NotebookKernelService', () => {
 	test('onDidChangeSelectedNotebooks not fired on initial notebook open #121904, p2', async function () {
 
 		const uri = URI.parse('foo:///one');
-		const jupyter = { uri, viewType: 'jupyter', kernelType: 'jupyter' };
-		const dotnet = { uri, viewType: 'dotnet', kernelType: 'dotnet' };
+		const jupyter = { uri, viewType: 'jupyter', notebookType: 'jupyter' };
+		const dotnet = { uri, viewType: 'dotnet', notebookType: 'dotnet' };
 
 		const jupyterKernel = new TestNotebookKernel({ viewType: jupyter.viewType });
 		const dotnetKernel = new TestNotebookKernel({ viewType: dotnet.viewType });

--- a/src/vs/workbench/contrib/notebook/test/browser/notebookServiceImpl.test.ts
+++ b/src/vs/workbench/contrib/notebook/test/browser/notebookServiceImpl.test.ts
@@ -56,7 +56,6 @@ suite('NotebookProviderInfoStore', function () {
 			displayName: 'foo',
 			selectors: [{ filenamePattern: '*.foo' }],
 			priority: RegisteredEditorPriority.default,
-			exclusive: false,
 			providerDisplayName: 'foo',
 		});
 		const barInfo = new NotebookProviderInfo({
@@ -65,7 +64,6 @@ suite('NotebookProviderInfoStore', function () {
 			displayName: 'bar',
 			selectors: [{ filenamePattern: '*.bar' }],
 			priority: RegisteredEditorPriority.default,
-			exclusive: false,
 			providerDisplayName: 'bar',
 		});
 

--- a/src/vs/workbench/contrib/notebook/test/browser/notebookViewModel.test.ts
+++ b/src/vs/workbench/contrib/notebook/test/browser/notebookViewModel.test.ts
@@ -66,7 +66,7 @@ suite('NotebookViewModel', () => {
 	test('ctor', function () {
 		const notebook = new NotebookTextModel('notebook', URI.parse('test'), [], {}, { transientCellMetadata: {}, transientDocumentMetadata: {}, transientOutputs: false, cellContentMetadata: {} }, undoRedoService, modelService, languageService, languageDetectionService);
 		const model = new NotebookEditorTestModel(notebook);
-		const options = new NotebookOptions(mainWindow, instantiationService.get(IConfigurationService), instantiationService.get(INotebookExecutionStateService), instantiationService.get(ICodeEditorService), false);
+		const options = new NotebookOptions(mainWindow, false, undefined, instantiationService.get(IConfigurationService), instantiationService.get(INotebookExecutionStateService), instantiationService.get(ICodeEditorService));
 		const eventDispatcher = new NotebookEventDispatcher();
 		const viewContext = new ViewContext(options, eventDispatcher, () => ({} as IBaseCellEditorOptions));
 		const viewModel = new NotebookViewModel('notebook', model.notebook, viewContext, null, { isReadOnly: false }, instantiationService, bulkEditService, undoRedoService, textModelService, notebookExecutionStateService);

--- a/src/vs/workbench/contrib/notebook/test/browser/testNotebookEditor.ts
+++ b/src/vs/workbench/contrib/notebook/test/browser/testNotebookEditor.ts
@@ -229,7 +229,7 @@ function _createTestNotebookEditor(instantiationService: TestInstantiationServic
 	}), {}, { transientCellMetadata: {}, transientDocumentMetadata: {}, cellContentMetadata: {}, transientOutputs: false }));
 
 	const model = disposables.add(new NotebookEditorTestModel(notebook));
-	const notebookOptions = disposables.add(new NotebookOptions(mainWindow, instantiationService.get(IConfigurationService), instantiationService.get(INotebookExecutionStateService), instantiationService.get(ICodeEditorService), false));
+	const notebookOptions = disposables.add(new NotebookOptions(mainWindow, false, undefined, instantiationService.get(IConfigurationService), instantiationService.get(INotebookExecutionStateService), instantiationService.get(ICodeEditorService)));
 	const baseCellEditorOptions = new class extends mock<IBaseCellEditorOptions>() { };
 	const viewContext = new ViewContext(notebookOptions, disposables.add(new NotebookEventDispatcher()), () => baseCellEditorOptions);
 	const viewModel: NotebookViewModel = disposables.add(instantiationService.createInstance(NotebookViewModel, viewType, model.notebook, viewContext, null, { isReadOnly: false }));
@@ -471,7 +471,7 @@ export function createNotebookCellList(instantiationService: TestInstantiationSe
 	};
 
 	const notebookOptions = !!viewContext ? viewContext.notebookOptions
-		: disposables.add(new NotebookOptions(mainWindow, instantiationService.get(IConfigurationService), instantiationService.get(INotebookExecutionStateService), instantiationService.get(ICodeEditorService), false));
+		: disposables.add(new NotebookOptions(mainWindow, false, undefined, instantiationService.get(IConfigurationService), instantiationService.get(INotebookExecutionStateService), instantiationService.get(ICodeEditorService)));
 	const cellList: NotebookCellList = disposables.add(instantiationService.createInstance(
 		NotebookCellList,
 		'NotebookCellList',

--- a/src/vs/workbench/contrib/replNotebook/browser/interactiveEditor.css
+++ b/src/vs/workbench/contrib/replNotebook/browser/interactiveEditor.css
@@ -1,0 +1,21 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+.interactive-editor .input-cell-container:focus-within .input-editor-container .monaco-editor {
+	outline: solid 1px var(--vscode-notebook-focusedCellBorder);
+}
+
+.interactive-editor .input-cell-container .input-editor-container .monaco-editor {
+	outline: solid 1px var(--vscode-notebook-inactiveFocusedCellBorder);
+}
+
+.interactive-editor .input-cell-container .input-focus-indicator {
+	top: 8px;
+}
+
+.interactive-editor .input-cell-container .monaco-editor-background,
+.interactive-editor .input-cell-container .margin-view-overlays {
+	background-color: var(--vscode-notebook-cellEditorBackground, var(--vscode-editor-background));
+}

--- a/src/vs/workbench/contrib/replNotebook/browser/media/interactive.css
+++ b/src/vs/workbench/contrib/replNotebook/browser/media/interactive.css
@@ -1,0 +1,36 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+.interactive-editor .input-cell-container {
+	box-sizing: border-box;
+}
+
+.interactive-editor .input-cell-container .input-focus-indicator {
+	position: absolute;
+	left: 0px;
+	height: 19px;
+}
+
+.interactive-editor .input-cell-container .input-focus-indicator::before {
+	border-left: 3px solid transparent;
+	border-radius: 2px;
+	margin-left: 4px;
+	content: "";
+	position: absolute;
+	width: 0px;
+	height: 100%;
+	z-index: 10;
+	left: 0px;
+	top: 0px;
+	height: 100%;
+}
+
+.interactive-editor .input-cell-container .run-button-container {
+	position: absolute;
+}
+
+.interactive-editor .input-cell-container .run-button-container .monaco-toolbar .actions-container {
+	justify-content: center;
+}

--- a/src/vs/workbench/contrib/replNotebook/browser/repl.contribution.ts
+++ b/src/vs/workbench/contrib/replNotebook/browser/repl.contribution.ts
@@ -66,12 +66,12 @@ class ReplEditorSerializer implements IEditorSerializer {
 		if (!data) {
 			return undefined;
 		}
-		const { resource, preferredResource, viewType, options } = data;
+		const { resource, viewType } = data;
 		if (!data || !URI.isUri(resource) || typeof viewType !== 'string') {
 			return undefined;
 		}
 
-		const input = NotebookEditorInput.getOrCreate(instantiationService, resource, preferredResource, viewType, options);
+		const input = instantiationService.createInstance(ReplEditorInput, resource);
 		return input;
 	}
 }

--- a/src/vs/workbench/contrib/replNotebook/browser/repl.contribution.ts
+++ b/src/vs/workbench/contrib/replNotebook/browser/repl.contribution.ts
@@ -124,8 +124,7 @@ export class ReplDocumentContribution extends Disposable implements IWorkbenchCo
 					ref.object.notebook.onWillDispose(() => {
 						ref.dispose();
 					});
-
-					return { editor: NotebookEditorInput.getOrCreate(this.instantiationService, ref.object.resource, undefined, 'repl'), options };
+					return { editor: this.instantiationService.createInstance(ReplEditorInput, resource!), options };
 				}
 			}
 		);
@@ -161,7 +160,7 @@ class ReplWindowWorkingCopyEditorHandler extends Disposable implements IWorkbenc
 	}
 
 	createEditor(workingCopy: IWorkingCopyIdentifier): EditorInput {
-		return this.instantiationService.createInstance(ReplEditorInput, workingCopy.resource, undefined, 'repl', {});
+		return this.instantiationService.createInstance(ReplEditorInput, workingCopy.resource);
 	}
 
 	private async _installHandler(): Promise<void> {

--- a/src/vs/workbench/contrib/replNotebook/browser/repl.contribution.ts
+++ b/src/vs/workbench/contrib/replNotebook/browser/repl.contribution.ts
@@ -52,7 +52,7 @@ import { InputFocusedContext } from 'vs/platform/contextkey/common/contextkeys';
 type SerializedNotebookEditorData = { resource: URI; preferredResource: URI; viewType: string; options?: NotebookEditorInputOptions };
 class ReplEditorSerializer implements IEditorSerializer {
 	canSerialize(input: EditorInput): boolean {
-		return input instanceof ReplEditorInput;
+		return input instanceof ReplEditorInput && input.viewType === 'repl';
 	}
 	serialize(input: EditorInput): string {
 		assertType(input instanceof ReplEditorInput);
@@ -123,7 +123,7 @@ export class ReplDocumentContribution extends Disposable implements IWorkbenchCo
 		editorResolverService.registerEditor(
 			`*.ipynb`,
 			{
-				id: 'repl-notebook',
+				id: 'repl',
 				label: 'repl Editor',
 				priority: RegisteredEditorPriority.option
 			},
@@ -211,7 +211,7 @@ registerAction2(class extends Action2 {
 
 	async run(accessor: ServicesAccessor) {
 		const resource = URI.from({ scheme: Schemas.untitled, path: 'repl.ipynb' });
-		const editorInput: IUntypedEditorInput = { resource, options: { override: 'repl-notebook' } };
+		const editorInput: IUntypedEditorInput = { resource, options: { override: 'repl' } };
 
 		const editorService = accessor.get(IEditorService);
 		await editorService.openEditor(editorInput, 1);
@@ -240,8 +240,7 @@ registerAction2(class extends Action2 {
 			}],
 			menu: [
 				{
-					id: MenuId.InteractiveInputExecute,
-					when: REPL_NOTEBOOK_IS_ACTIVE_EDITOR
+					id: MenuId.ReplInputExecute
 				}
 			],
 			icon: icons.executeIcon,

--- a/src/vs/workbench/contrib/replNotebook/browser/repl.contribution.ts
+++ b/src/vs/workbench/contrib/replNotebook/browser/repl.contribution.ts
@@ -1,0 +1,202 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { SyncDescriptor } from 'vs/platform/instantiation/common/descriptors';
+import { Registry } from 'vs/platform/registry/common/platform';
+import { EditorPaneDescriptor, IEditorPaneRegistry } from 'vs/workbench/browser/editor';
+import { EditorExtensions, IEditorFactoryRegistry, IEditorSerializer, IUntypedEditorInput } from 'vs/workbench/common/editor';
+// is one contrib allowed to import from another?
+import { parse } from 'vs/base/common/marshalling';
+import { assertType } from 'vs/base/common/types';
+import { URI } from 'vs/base/common/uri';
+import { IInstantiationService, ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
+import { EditorInput } from 'vs/workbench/common/editor/editorInput';
+import { NotebookWorkingCopyTypeIdentifier, REPL_EDITOR_ID } from 'vs/workbench/contrib/notebook/common/notebookCommon';
+import { NotebookEditorInput, NotebookEditorInputOptions } from 'vs/workbench/contrib/notebook/common/notebookEditorInput';
+import { ReplEditor } from 'vs/workbench/contrib/replNotebook/browser/replEditor';
+import { ReplEditorInput } from 'vs/workbench/contrib/replNotebook/browser/replEditorInput';
+import { Disposable } from 'vs/base/common/lifecycle';
+import { IWorkbenchContribution, registerWorkbenchContribution2, WorkbenchPhase } from 'vs/workbench/common/contributions';
+import { IExtensionService } from 'vs/workbench/services/extensions/common/extensions';
+import { IWorkingCopyIdentifier } from 'vs/workbench/services/workingCopy/common/workingCopy';
+import { IWorkingCopyEditorHandler, IWorkingCopyEditorService } from 'vs/workbench/services/workingCopy/common/workingCopyEditorService';
+import { extname, isEqual } from 'vs/base/common/resources';
+import { INotebookService } from 'vs/workbench/contrib/notebook/common/notebookService';
+import { localize, localize2 } from 'vs/nls';
+import { Action2, registerAction2 } from 'vs/platform/actions/common/actions';
+import { IEditorResolverService, RegisteredEditorPriority } from 'vs/workbench/services/editor/common/editorResolverService';
+import { Schemas } from 'vs/base/common/network';
+import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
+import { INotebookEditorModelResolverService } from 'vs/workbench/contrib/notebook/common/notebookEditorModelResolverService';
+
+type SerializedNotebookEditorData = { resource: URI; preferredResource: URI; viewType: string; options?: NotebookEditorInputOptions };
+class ReplEditorSerializer implements IEditorSerializer {
+	canSerialize(input: EditorInput): boolean {
+		return input instanceof ReplEditorInput;
+	}
+	serialize(input: EditorInput): string {
+		assertType(input instanceof ReplEditorInput);
+		const data: SerializedNotebookEditorData = {
+			resource: input.resource,
+			preferredResource: input.preferredResource,
+			viewType: input.viewType,
+			options: input.options
+		};
+		return JSON.stringify(data);
+	}
+	deserialize(instantiationService: IInstantiationService, raw: string) {
+		const data = <SerializedNotebookEditorData>parse(raw);
+		if (!data) {
+			return undefined;
+		}
+		const { resource, preferredResource, viewType, options } = data;
+		if (!data || !URI.isUri(resource) || typeof viewType !== 'string') {
+			return undefined;
+		}
+
+		const input = NotebookEditorInput.getOrCreate(instantiationService, resource, preferredResource, viewType, options);
+		return input;
+	}
+}
+
+Registry.as<IEditorPaneRegistry>(EditorExtensions.EditorPane).registerEditorPane(
+	EditorPaneDescriptor.create(
+		ReplEditor,
+		REPL_EDITOR_ID,
+		'REPL Editor'
+	),
+	[
+		new SyncDescriptor(ReplEditorInput)
+	]
+);
+
+Registry.as<IEditorFactoryRegistry>(EditorExtensions.EditorFactory).registerEditorSerializer(
+	ReplEditorInput.ID,
+	ReplEditorSerializer
+);
+
+export class ReplDocumentContribution extends Disposable implements IWorkbenchContribution {
+
+	static readonly ID = 'workbench.contrib.replDocument';
+
+	constructor(
+		@INotebookService notebookService: INotebookService,
+		@IEditorResolverService editorResolverService: IEditorResolverService,
+		@IEditorService editorService: IEditorService,
+		@INotebookEditorModelResolverService private readonly notebookEditorModelResolverService: INotebookEditorModelResolverService,
+		@IInstantiationService private readonly instantiationService: IInstantiationService
+	) {
+		super();
+
+		const info = notebookService.getContributedNotebookType('repl');
+
+		// We need to register with the notebook service to let it know about this editor contribution
+		if (!info) {
+			this._register(notebookService.registerContributedNotebookType('repl', {
+				providerDisplayName: 'REPL Notebook',
+				displayName: 'Repl Notebook',
+				filenamePattern: ['*.repl'],
+				exclusive: false
+			}));
+		}
+
+		editorResolverService.registerEditor(
+			`*.repl`,
+			{
+				id: 'repl',
+				label: 'repl Editor',
+				priority: RegisteredEditorPriority.default
+			},
+			{
+				canSupportResource: uri =>
+					(uri.scheme === Schemas.untitled && extname(uri) === '.repl') ||
+					(uri.scheme === Schemas.vscodeNotebookCell && extname(uri) === '.repl'),
+				singlePerResource: true
+			},
+			{
+				createUntitledEditorInput: async ({ resource, options }) => {
+					const ref = await this.notebookEditorModelResolverService.resolve({ untitledResource: resource }, 'repl');
+
+					// untitled notebooks are disposed when they get saved. we should not hold a reference
+					// to such a disposed notebook and therefore dispose the reference as well
+					ref.object.notebook.onWillDispose(() => {
+						ref.dispose();
+					});
+
+					return { editor: NotebookEditorInput.getOrCreate(this.instantiationService, ref.object.resource, undefined, 'repl'), options };
+				}
+			}
+		);
+	}
+}
+
+class ReplWindowWorkingCopyEditorHandler extends Disposable implements IWorkbenchContribution, IWorkingCopyEditorHandler {
+
+	static readonly ID = 'workbench.contrib.replWorkingCopyEditorHandler';
+
+	constructor(
+		@IInstantiationService private readonly instantiationService: IInstantiationService,
+		@IWorkingCopyEditorService private readonly workingCopyEditorService: IWorkingCopyEditorService,
+		@IExtensionService private readonly extensionService: IExtensionService,
+	) {
+		super();
+
+		this._installHandler();
+	}
+
+	handles(workingCopy: IWorkingCopyIdentifier): boolean {
+		const viewType = this._getViewType(workingCopy);
+		return !!viewType && viewType === 'repl';
+
+	}
+
+	isOpen(workingCopy: IWorkingCopyIdentifier, editor: EditorInput): boolean {
+		if (!this.handles(workingCopy)) {
+			return false;
+		}
+
+		return editor instanceof ReplEditorInput && isEqual(workingCopy.resource, editor.resource);
+	}
+
+	createEditor(workingCopy: IWorkingCopyIdentifier): EditorInput {
+		return this.instantiationService.createInstance(ReplEditorInput, workingCopy.resource, undefined, 'repl', {});
+	}
+
+	private async _installHandler(): Promise<void> {
+		await this.extensionService.whenInstalledExtensionsRegistered();
+
+		this._register(this.workingCopyEditorService.registerHandler(this));
+	}
+
+	private _getViewType(workingCopy: IWorkingCopyIdentifier): string | undefined {
+		return NotebookWorkingCopyTypeIdentifier.parse(workingCopy.typeId);
+	}
+}
+
+registerWorkbenchContribution2(ReplWindowWorkingCopyEditorHandler.ID, ReplWindowWorkingCopyEditorHandler, WorkbenchPhase.BlockRestore);
+registerWorkbenchContribution2(ReplDocumentContribution.ID, ReplDocumentContribution, WorkbenchPhase.BlockRestore);
+
+
+registerAction2(class extends Action2 {
+	constructor() {
+		super({
+			id: 'repl.open',
+			title: localize2('repl.open', 'Open REPL Editor'),
+			category: 'REPL',
+			metadata: {
+				description: localize('repl.open', 'Open REPL Editor'),
+			}
+
+		});
+	}
+
+	async run(accessor: ServicesAccessor) {
+		const resource = URI.from({ scheme: Schemas.untitled, path: 'repl.repl' });
+		const editorInput: IUntypedEditorInput = { resource, options: {} };
+
+		const editorService = accessor.get(IEditorService);
+		await editorService.openEditor(editorInput, 1);
+	}
+});

--- a/src/vs/workbench/contrib/replNotebook/browser/repl.contribution.ts
+++ b/src/vs/workbench/contrib/replNotebook/browser/repl.contribution.ts
@@ -115,7 +115,7 @@ export class ReplDocumentContribution extends Disposable implements IWorkbenchCo
 				providerDisplayName: 'REPL Notebook',
 				displayName: 'Repl Notebook',
 				filenamePattern: ['*.ipynb'],
-				exclusive: false
+				priority: RegisteredEditorPriority.option,
 			}));
 		}
 

--- a/src/vs/workbench/contrib/replNotebook/browser/repl.contribution.ts
+++ b/src/vs/workbench/contrib/replNotebook/browser/repl.contribution.ts
@@ -293,8 +293,9 @@ registerAction2(class extends Action2 {
 					return;
 				}
 
-				historyService.addToHistory(notebookDocument.uri, '');
+				historyService.addToHistory(notebookDocument.uri, value);
 				textModel.setValue('');
+				notebookDocument.cells[index].resetTextBuffer(textModel.getTextBuffer());
 
 				const collapseState = editorControl.notebookEditor.notebookOptions.getDisplayOptions().interactiveWindowCollapseCodeCells === 'fromEditor' ?
 					{

--- a/src/vs/workbench/contrib/replNotebook/browser/repl.contribution.ts
+++ b/src/vs/workbench/contrib/replNotebook/browser/repl.contribution.ts
@@ -46,8 +46,6 @@ import { NOTEBOOK_EDITOR_FOCUSED, REPL_NOTEBOOK_IS_ACTIVE_EDITOR } from 'vs/work
 import { EditOperation } from 'vs/editor/common/core/editOperation';
 import { EditorContextKeys } from 'vs/editor/common/editorContextKeys';
 import { InputFocusedContext } from 'vs/platform/contextkey/common/contextkeys';
-import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
-
 
 type SerializedNotebookEditorData = { resource: URI; preferredResource: URI; viewType: string; options?: NotebookEditorInputOptions };
 class ReplEditorSerializer implements IEditorSerializer {
@@ -195,247 +193,236 @@ class ReplWindowWorkingCopyEditorHandler extends Disposable implements IWorkbenc
 registerWorkbenchContribution2(ReplWindowWorkingCopyEditorHandler.ID, ReplWindowWorkingCopyEditorHandler, WorkbenchPhase.BlockRestore);
 registerWorkbenchContribution2(ReplDocumentContribution.ID, ReplDocumentContribution, WorkbenchPhase.BlockRestore);
 
-export class ReplActionsContribution extends Disposable implements IWorkbenchContribution {
 
-	constructor(@IConfigurationService configurationService: IConfigurationService) {
-		super();
-		if (configurationService.getValue('notebook.experimental.replView') === true) {
-			this._registerActions();
+registerAction2(class extends Action2 {
+	constructor() {
+		super({
+			id: 'replNotebook.open',
+			title: localize2('replNotebook.open', 'Open REPL Editor'),
+			category: 'REPL',
+			metadata: {
+				description: localize('replNotebook.open', 'Open REPL Editor'),
+			}
+		});
+	}
+
+	async run(accessor: ServicesAccessor) {
+		const resource = URI.from({ scheme: Schemas.untitled, path: 'repl.ipynb' });
+		const editorInput: IUntypedEditorInput = { resource, options: { override: 'repl' } };
+
+		const editorService = accessor.get(IEditorService);
+		await editorService.openEditor(editorInput, 1);
+	}
+});
+
+registerAction2(class extends Action2 {
+	constructor() {
+		super({
+			id: 'replNotebook.input.execute',
+			title: localize2('replNotebook.input.execute', 'Execute the input box contents'),
+			keybinding: [{
+				when: ContextKeyExpr.and(
+					REPL_NOTEBOOK_IS_ACTIVE_EDITOR,
+					ContextKeyExpr.equals('config.interactiveWindow.executeWithShiftEnter', true)
+				),
+				primary: KeyMod.Shift | KeyCode.Enter,
+				weight: NOTEBOOK_EDITOR_WIDGET_ACTION_WEIGHT
+			}, {
+				when: ContextKeyExpr.and(
+					REPL_NOTEBOOK_IS_ACTIVE_EDITOR,
+					ContextKeyExpr.equals('config.interactiveWindow.executeWithShiftEnter', false)
+				),
+				primary: KeyCode.Enter,
+				weight: NOTEBOOK_EDITOR_WIDGET_ACTION_WEIGHT
+			}],
+			menu: [
+				{
+					id: MenuId.ReplInputExecute
+				}
+			],
+			icon: icons.executeIcon,
+			f1: false,
+			metadata: {
+				description: 'Execute the Contents of the Input Box',
+				args: [
+					{
+						name: 'resource',
+						description: 'Interactive resource Uri',
+						isOptional: true
+					}
+				]
+			}
+		});
+	}
+
+	async run(accessor: ServicesAccessor, context?: UriComponents): Promise<void> {
+		const editorService = accessor.get(IEditorService);
+		const bulkEditService = accessor.get(IBulkEditService);
+		const historyService = accessor.get(IInteractiveHistoryService);
+		const notebookEditorService = accessor.get(INotebookEditorService);
+		let editorControl: { notebookEditor: NotebookEditorWidget | undefined; codeEditor: CodeEditorWidget } | undefined;
+		if (context) {
+			const resourceUri = URI.revive(context);
+			const editors = editorService.findEditors(resourceUri);
+			for (const found of editors) {
+				if (found.editor.typeId === ReplEditorInput.ID) {
+					const editor = await editorService.openEditor(found.editor, found.groupId);
+					editorControl = editor?.getControl() as { notebookEditor: NotebookEditorWidget | undefined; codeEditor: CodeEditorWidget } | undefined;
+					break;
+				}
+			}
+		}
+		else {
+			editorControl = editorService.activeEditorPane?.getControl() as { notebookEditor: NotebookEditorWidget | undefined; codeEditor: CodeEditorWidget } | undefined;
+		}
+
+		if (editorControl && editorControl.notebookEditor && editorControl.codeEditor) {
+			const notebookDocument = editorControl.notebookEditor.textModel;
+			const textModel = editorControl.codeEditor.getModel();
+			const activeKernel = editorControl.notebookEditor.activeKernel;
+			const language = activeKernel?.supportedLanguages[0] ?? PLAINTEXT_LANGUAGE_ID;
+
+			if (notebookDocument && textModel) {
+				const index = notebookDocument.length - 1;
+				const value = textModel.getValue();
+
+				if (isFalsyOrWhitespace(value)) {
+					return;
+				}
+
+				historyService.addToHistory(notebookDocument.uri, value);
+				textModel.setValue('');
+				notebookDocument.cells[index].resetTextBuffer(textModel.getTextBuffer());
+
+				const collapseState = editorControl.notebookEditor.notebookOptions.getDisplayOptions().interactiveWindowCollapseCodeCells === 'fromEditor' ?
+					{
+						inputCollapsed: false,
+						outputCollapsed: false
+					} :
+					undefined;
+
+				await bulkEditService.apply([
+					new ResourceNotebookCellEdit(notebookDocument.uri,
+						{
+							editType: CellEditType.Replace,
+							index: index,
+							count: 0,
+							cells: [{
+								cellKind: CellKind.Code,
+								mime: undefined,
+								language,
+								source: value,
+								outputs: [],
+								metadata: {},
+								collapseState
+							}]
+						}
+					)
+				]);
+
+				// reveal the cell into view first
+				const range = { start: index, end: index + 1 };
+				editorControl.notebookEditor.revealCellRangeInView(range);
+				await editorControl.notebookEditor.executeNotebookCells(editorControl.notebookEditor.getCellsInRange({ start: index, end: index + 1 }));
+
+				// update the selection and focus in the extension host model
+				const editor = notebookEditorService.getNotebookEditor(editorControl.notebookEditor.getId());
+				if (editor) {
+					editor.setSelections([range]);
+					editor.setFocus(range);
+				}
+			}
 		}
 	}
+});
 
-	private _registerActions(): void {
-		registerAction2(class extends Action2 {
-			constructor() {
-				super({
-					id: 'replNotebook.open',
-					title: localize2('repl.open', 'Open REPL Editor'),
-					category: 'REPL',
-					metadata: {
-						description: localize('repl.open', 'Open REPL Editor'),
-					}
-				});
-			}
-
-			async run(accessor: ServicesAccessor) {
-				const resource = URI.from({ scheme: Schemas.untitled, path: 'repl.ipynb' });
-				const editorInput: IUntypedEditorInput = { resource, options: { override: 'repl' } };
-
-				const editorService = accessor.get(IEditorService);
-				await editorService.openEditor(editorInput, 1);
-			}
-		});
-
-		registerAction2(class extends Action2 {
-			constructor() {
-				super({
-					id: 'replNotebook.input.execute',
-					title: localize2('replNotebook.input.execute', 'Execute the input box contents'),
-					keybinding: [{
-						when: ContextKeyExpr.and(
-							REPL_NOTEBOOK_IS_ACTIVE_EDITOR,
-							ContextKeyExpr.equals('config.interactiveWindow.executeWithShiftEnter', true)
-						),
-						primary: KeyMod.Shift | KeyCode.Enter,
-						weight: NOTEBOOK_EDITOR_WIDGET_ACTION_WEIGHT
-					}, {
-						when: ContextKeyExpr.and(
-							REPL_NOTEBOOK_IS_ACTIVE_EDITOR,
-							ContextKeyExpr.equals('config.interactiveWindow.executeWithShiftEnter', false)
-						),
-						primary: KeyCode.Enter,
-						weight: NOTEBOOK_EDITOR_WIDGET_ACTION_WEIGHT
-					}],
-					menu: [
-						{
-							id: MenuId.ReplInputExecute
-						}
-					],
-					icon: icons.executeIcon,
-					f1: false,
-					metadata: {
-						description: 'Execute the Contents of the Input Box',
-						args: [
-							{
-								name: 'resource',
-								description: 'Interactive resource Uri',
-								isOptional: true
-							}
-						]
-					}
-				});
-			}
-
-			async run(accessor: ServicesAccessor, context?: UriComponents): Promise<void> {
-				const editorService = accessor.get(IEditorService);
-				const bulkEditService = accessor.get(IBulkEditService);
-				const historyService = accessor.get(IInteractiveHistoryService);
-				const notebookEditorService = accessor.get(INotebookEditorService);
-				let editorControl: { notebookEditor: NotebookEditorWidget | undefined; codeEditor: CodeEditorWidget } | undefined;
-				if (context) {
-					const resourceUri = URI.revive(context);
-					const editors = editorService.findEditors(resourceUri);
-					for (const found of editors) {
-						if (found.editor.typeId === ReplEditorInput.ID) {
-							const editor = await editorService.openEditor(found.editor, found.groupId);
-							editorControl = editor?.getControl() as { notebookEditor: NotebookEditorWidget | undefined; codeEditor: CodeEditorWidget } | undefined;
-							break;
-						}
-					}
-				}
-				else {
-					editorControl = editorService.activeEditorPane?.getControl() as { notebookEditor: NotebookEditorWidget | undefined; codeEditor: CodeEditorWidget } | undefined;
-				}
-
-				if (editorControl && editorControl.notebookEditor && editorControl.codeEditor) {
-					const notebookDocument = editorControl.notebookEditor.textModel;
-					const textModel = editorControl.codeEditor.getModel();
-					const activeKernel = editorControl.notebookEditor.activeKernel;
-					const language = activeKernel?.supportedLanguages[0] ?? PLAINTEXT_LANGUAGE_ID;
-
-					if (notebookDocument && textModel) {
-						const index = notebookDocument.length - 1;
-						const value = textModel.getValue();
-
-						if (isFalsyOrWhitespace(value)) {
-							return;
-						}
-
-						historyService.addToHistory(notebookDocument.uri, value);
-						textModel.setValue('');
-						notebookDocument.cells[index].resetTextBuffer(textModel.getTextBuffer());
-
-						const collapseState = editorControl.notebookEditor.notebookOptions.getDisplayOptions().interactiveWindowCollapseCodeCells === 'fromEditor' ?
-							{
-								inputCollapsed: false,
-								outputCollapsed: false
-							} :
-							undefined;
-
-						await bulkEditService.apply([
-							new ResourceNotebookCellEdit(notebookDocument.uri,
-								{
-									editType: CellEditType.Replace,
-									index: index,
-									count: 0,
-									cells: [{
-										cellKind: CellKind.Code,
-										mime: undefined,
-										language,
-										source: value,
-										outputs: [],
-										metadata: {},
-										collapseState
-									}]
-								}
-							)
-						]);
-
-						// reveal the cell into view first
-						const range = { start: index, end: index + 1 };
-						editorControl.notebookEditor.revealCellRangeInView(range);
-						await editorControl.notebookEditor.executeNotebookCells(editorControl.notebookEditor.getCellsInRange({ start: index, end: index + 1 }));
-
-						// update the selection and focus in the extension host model
-						const editor = notebookEditorService.getNotebookEditor(editorControl.notebookEditor.getId());
-						if (editor) {
-							editor.setSelections([range]);
-							editor.setFocus(range);
-						}
-					}
-				}
-			}
-		});
-
-		registerAction2(class extends Action2 {
-			constructor() {
-				super({
-					id: 'replNotebook.input.clear',
-					title: localize2('replNotebook.input.clear', 'Clear the REPL input contents'),
-					f1: false,
-					keybinding: [{
-						when: ContextKeyExpr.and(
-							REPL_NOTEBOOK_IS_ACTIVE_EDITOR,
-							InputFocusedContext,
-							EditorContextKeys.writable,
-							EditorContextKeys.hasNonEmptySelection.toNegated(),
-						),
-						primary: KeyCode.Escape,
-						weight: NOTEBOOK_EDITOR_WIDGET_ACTION_WEIGHT
-					}]
-				});
-			}
-
-			async run(accessor: ServicesAccessor): Promise<void> {
-				const editorService = accessor.get(IEditorService);
-				const editorControl = editorService.activeEditorPane?.getControl() as { notebookEditor: NotebookEditorWidget | undefined; codeEditor: CodeEditorWidget } | undefined;
-
-				if (editorControl && editorControl.notebookEditor && editorControl.codeEditor) {
-					const notebookDocument = editorControl.notebookEditor.textModel;
-					const textModel = editorControl.codeEditor.getModel();
-					const range = editorControl.codeEditor.getModel()?.getFullModelRange();
-
-					if (notebookDocument && textModel && range) {
-						editorControl.codeEditor.executeEdits('', [EditOperation.replace(range, null)]);
-					}
-				}
-			}
-		});
-
-
-		registerAction2(class extends Action2 {
-			constructor() {
-				super({
-					id: 'replNotebook.input.focus',
-					title: localize2('interactive.input.focus', 'Focus Input Editor'),
-					keybinding: {
-						when: ContextKeyExpr.and(
-							REPL_NOTEBOOK_IS_ACTIVE_EDITOR,
-							NOTEBOOK_EDITOR_FOCUSED,
-						),
-						primary: KeyMod.CtrlCmd | KeyMod.Alt | KeyCode.DownArrow,
-						weight: NOTEBOOK_EDITOR_WIDGET_ACTION_WEIGHT
-					},
-				});
-			}
-
-			async run(accessor: ServicesAccessor): Promise<void> {
-				const editorService = accessor.get(IEditorService);
-				const editorControl = editorService.activeEditorPane?.getControl() as { notebookEditor: NotebookEditorWidget | undefined; codeEditor: CodeEditorWidget } | undefined;
-
-				if (editorControl && editorControl.notebookEditor && editorControl.codeEditor) {
-					editorService.activeEditorPane?.focus();
-				}
-			}
-		});
-
-		registerAction2(class extends Action2 {
-			constructor() {
-				super({
-					id: 'replNotebook.history.focus',
-					title: localize2('replNotebook.history.focus', 'Focus History'),
-					f1: false,
-					keybinding: {
-						when: ContextKeyExpr.and(
-							REPL_NOTEBOOK_IS_ACTIVE_EDITOR,
-							EditorContextKeys.textInputFocus,
-							NOTEBOOK_EDITOR_FOCUSED.toNegated()
-						),
-						primary: KeyMod.CtrlCmd | KeyMod.Alt | KeyCode.UpArrow,
-						weight: NOTEBOOK_EDITOR_WIDGET_ACTION_WEIGHT
-					},
-				});
-			}
-
-			async run(accessor: ServicesAccessor): Promise<void> {
-				const editorService = accessor.get(IEditorService);
-				const editorControl = editorService.activeEditorPane?.getControl() as { notebookEditor: NotebookEditorWidget | undefined; codeEditor: CodeEditorWidget; focusHistory: () => void } | undefined;
-
-				if (editorControl && editorControl.notebookEditor && editorControl.codeEditor) {
-					editorControl.notebookEditor.focus();
-				}
-			}
+registerAction2(class extends Action2 {
+	constructor() {
+		super({
+			id: 'replNotebook.input.clear',
+			title: localize2('replNotebook.input.clear', 'Clear the REPL input contents'),
+			f1: false,
+			keybinding: [{
+				when: ContextKeyExpr.and(
+					REPL_NOTEBOOK_IS_ACTIVE_EDITOR,
+					InputFocusedContext,
+					EditorContextKeys.writable,
+					EditorContextKeys.hasNonEmptySelection.toNegated(),
+				),
+				primary: KeyCode.Escape,
+				weight: NOTEBOOK_EDITOR_WIDGET_ACTION_WEIGHT
+			}]
 		});
 	}
-}
+
+	async run(accessor: ServicesAccessor): Promise<void> {
+		const editorService = accessor.get(IEditorService);
+		const editorControl = editorService.activeEditorPane?.getControl() as { notebookEditor: NotebookEditorWidget | undefined; codeEditor: CodeEditorWidget } | undefined;
+
+		if (editorControl && editorControl.notebookEditor && editorControl.codeEditor) {
+			const notebookDocument = editorControl.notebookEditor.textModel;
+			const textModel = editorControl.codeEditor.getModel();
+			const range = editorControl.codeEditor.getModel()?.getFullModelRange();
+
+			if (notebookDocument && textModel && range) {
+				editorControl.codeEditor.executeEdits('', [EditOperation.replace(range, null)]);
+			}
+		}
+	}
+});
+
+
+registerAction2(class extends Action2 {
+	constructor() {
+		super({
+			id: 'replNotebook.input.focus',
+			title: localize2('interactive.input.focus', 'Focus Input Editor'),
+			keybinding: {
+				when: ContextKeyExpr.and(
+					REPL_NOTEBOOK_IS_ACTIVE_EDITOR,
+					NOTEBOOK_EDITOR_FOCUSED,
+				),
+				primary: KeyMod.CtrlCmd | KeyMod.Alt | KeyCode.DownArrow,
+				weight: NOTEBOOK_EDITOR_WIDGET_ACTION_WEIGHT
+			},
+		});
+	}
+
+	async run(accessor: ServicesAccessor): Promise<void> {
+		const editorService = accessor.get(IEditorService);
+		const editorControl = editorService.activeEditorPane?.getControl() as { notebookEditor: NotebookEditorWidget | undefined; codeEditor: CodeEditorWidget } | undefined;
+
+		if (editorControl && editorControl.notebookEditor && editorControl.codeEditor) {
+			editorService.activeEditorPane?.focus();
+		}
+	}
+});
+
+registerAction2(class extends Action2 {
+	constructor() {
+		super({
+			id: 'replNotebook.history.focus',
+			title: localize2('replNotebook.history.focus', 'Focus History'),
+			f1: false,
+			keybinding: {
+				when: ContextKeyExpr.and(
+					REPL_NOTEBOOK_IS_ACTIVE_EDITOR,
+					EditorContextKeys.textInputFocus,
+					NOTEBOOK_EDITOR_FOCUSED.toNegated()
+				),
+				primary: KeyMod.CtrlCmd | KeyMod.Alt | KeyCode.UpArrow,
+				weight: NOTEBOOK_EDITOR_WIDGET_ACTION_WEIGHT
+			},
+		});
+	}
+
+	async run(accessor: ServicesAccessor): Promise<void> {
+		const editorService = accessor.get(IEditorService);
+		const editorControl = editorService.activeEditorPane?.getControl() as { notebookEditor: NotebookEditorWidget | undefined; codeEditor: CodeEditorWidget; focusHistory: () => void } | undefined;
+
+		if (editorControl && editorControl.notebookEditor && editorControl.codeEditor) {
+			editorControl.notebookEditor.focus();
+		}
+	}
+});
 

--- a/src/vs/workbench/contrib/replNotebook/browser/repl.contribution.ts
+++ b/src/vs/workbench/contrib/replNotebook/browser/repl.contribution.ts
@@ -116,7 +116,7 @@ export class ReplDocumentContribution extends Disposable implements IWorkbenchCo
 			{
 				createUntitledEditorInput: async ({ resource, options }) => {
 					const scratchpad = this.configurationService.getValue<boolean>(NotebookSetting.InteractiveWindowPromptToSave) !== true;
-					const ref = await this.notebookEditorModelResolverService.resolve({ untitledResource: resource, scratchpad }, 'jupyter-notebook');
+					const ref = await this.notebookEditorModelResolverService.resolve({ untitledResource: resource }, 'jupyter-notebook', { scratchpad });
 
 					// untitled notebooks are disposed when they get saved. we should not hold a reference
 					// to such a disposed notebook and therefore dispose the reference as well
@@ -146,7 +146,7 @@ class ReplWindowWorkingCopyEditorHandler extends Disposable implements IWorkbenc
 
 	handles(workingCopy: IWorkingCopyIdentifier): boolean {
 		const viewType = this._getViewType(workingCopy);
-		return !!viewType && viewType === 'repl';
+		return !!viewType && viewType === 'jupyter-notebook' && extname(workingCopy.resource) === '.replNotebook';
 
 	}
 

--- a/src/vs/workbench/contrib/replNotebook/browser/repl.contribution.ts
+++ b/src/vs/workbench/contrib/replNotebook/browser/repl.contribution.ts
@@ -266,13 +266,13 @@ registerAction2(class extends Action2 {
 		let editorControl: { notebookEditor: NotebookEditorWidget | undefined; codeEditor: CodeEditorWidget } | undefined;
 		if (context) {
 			const resourceUri = URI.revive(context);
-			const editors = editorService.findEditors(resourceUri)
-				.filter(id => id.editor instanceof InteractiveEditorInput && id.editor.resource?.toString() === resourceUri.toString());
-			if (editors.length) {
-				const editorInput = editors[0].editor as InteractiveEditorInput;
-				const currentGroup = editors[0].groupId;
-				const editor = await editorService.openEditor(editorInput, currentGroup);
-				editorControl = editor?.getControl() as { notebookEditor: NotebookEditorWidget | undefined; codeEditor: CodeEditorWidget } | undefined;
+			const editors = editorService.findEditors(resourceUri);
+			for (const found of editors) {
+				if (found.editor.typeId === ReplEditorInput.ID) {
+					const editor = await editorService.openEditor(found.editor, found.groupId);
+					editorControl = editor?.getControl() as { notebookEditor: NotebookEditorWidget | undefined; codeEditor: CodeEditorWidget } | undefined;
+					break;
+				}
 			}
 		}
 		else {

--- a/src/vs/workbench/contrib/replNotebook/browser/repl.contribution.ts
+++ b/src/vs/workbench/contrib/replNotebook/browser/repl.contribution.ts
@@ -197,12 +197,9 @@ registerWorkbenchContribution2(ReplDocumentContribution.ID, ReplDocumentContribu
 registerAction2(class extends Action2 {
 	constructor() {
 		super({
-			id: 'replNotebook.open',
-			title: localize2('replNotebook.open', 'Open REPL Editor'),
-			category: 'REPL',
-			metadata: {
-				description: localize('replNotebook.open', 'Open REPL Editor'),
-			}
+			id: 'repl.newRepl',
+			title: localize2('repl.editor.open', 'New REPL Editor'),
+			category: 'Create',
 		});
 	}
 
@@ -219,7 +216,7 @@ registerAction2(class extends Action2 {
 	constructor() {
 		super({
 			id: EXECUTE_REPL_COMMAND_ID,
-			title: localize2('replNotebook.input.execute', 'Execute the input box contents'),
+			title: localize2('repl.input.execute', 'Execute the input box contents'),
 			keybinding: [{
 				when: ContextKeyExpr.and(
 					REPL_NOTEBOOK_IS_ACTIVE_EDITOR,
@@ -250,17 +247,7 @@ registerAction2(class extends Action2 {
 				}
 			],
 			icon: icons.executeIcon,
-			f1: false,
-			metadata: {
-				description: 'Execute the Contents of the Input Box',
-				args: [
-					{
-						name: 'resource',
-						description: 'Interactive resource Uri',
-						isOptional: true
-					}
-				]
-			}
+			f1: false
 		});
 	}
 
@@ -348,7 +335,7 @@ registerAction2(class extends Action2 {
 registerAction2(class extends Action2 {
 	constructor() {
 		super({
-			id: 'replNotebook.input.clear',
+			id: 'repl.input.clear',
 			title: localize2('replNotebook.input.clear', 'Clear the REPL input contents'),
 			f1: false,
 			keybinding: [{
@@ -384,8 +371,8 @@ registerAction2(class extends Action2 {
 registerAction2(class extends Action2 {
 	constructor() {
 		super({
-			id: 'replNotebook.input.focus',
-			title: localize2('interactive.input.focus', 'Focus Input Editor'),
+			id: 'repl.input.focus',
+			title: localize2('interactive.input.focus', 'Focus into REPL Input'),
 			keybinding: {
 				when: ContextKeyExpr.and(
 					REPL_NOTEBOOK_IS_ACTIVE_EDITOR,
@@ -410,8 +397,8 @@ registerAction2(class extends Action2 {
 registerAction2(class extends Action2 {
 	constructor() {
 		super({
-			id: 'replNotebook.history.focus',
-			title: localize2('replNotebook.history.focus', 'Focus History'),
+			id: 'repl.history.focus',
+			title: localize2('repl.history.focus', 'Focus into REPL History'),
 			f1: false,
 			keybinding: {
 				when: ContextKeyExpr.and(

--- a/src/vs/workbench/contrib/replNotebook/browser/repl.contribution.ts
+++ b/src/vs/workbench/contrib/replNotebook/browser/repl.contribution.ts
@@ -51,7 +51,7 @@ import { InputFocusedContext } from 'vs/platform/contextkey/common/contextkeys';
 type SerializedNotebookEditorData = { resource: URI; preferredResource: URI; viewType: string; options?: NotebookEditorInputOptions };
 class ReplEditorSerializer implements IEditorSerializer {
 	canSerialize(input: EditorInput): boolean {
-		return input instanceof ReplEditorInput && input.viewType === 'repl';
+		return input.typeId === ReplEditorInput.ID;
 	}
 	serialize(input: EditorInput): string {
 		assertType(input instanceof ReplEditorInput);

--- a/src/vs/workbench/contrib/replNotebook/browser/repl.contribution.ts
+++ b/src/vs/workbench/contrib/replNotebook/browser/repl.contribution.ts
@@ -36,7 +36,6 @@ import { CodeEditorWidget } from 'vs/editor/browser/widget/codeEditor/codeEditor
 import { PLAINTEXT_LANGUAGE_ID } from 'vs/editor/common/languages/modesRegistry';
 import { ContextKeyExpr } from 'vs/platform/contextkey/common/contextkey';
 import { ResourceNotebookCellEdit } from 'vs/workbench/contrib/bulkEdit/browser/bulkCellEdits';
-import { InteractiveEditorInput } from 'vs/workbench/contrib/interactive/browser/interactiveEditorInput';
 import { IInteractiveHistoryService } from 'vs/workbench/contrib/interactive/browser/interactiveHistoryService';
 import { NOTEBOOK_EDITOR_WIDGET_ACTION_WEIGHT } from 'vs/workbench/contrib/notebook/browser/controller/coreActions';
 import { NotebookEditorWidget } from 'vs/workbench/contrib/notebook/browser/notebookEditorWidget';

--- a/src/vs/workbench/contrib/replNotebook/browser/repl.contribution.ts
+++ b/src/vs/workbench/contrib/replNotebook/browser/repl.contribution.ts
@@ -13,7 +13,7 @@ import { assertType } from 'vs/base/common/types';
 import { URI, UriComponents } from 'vs/base/common/uri';
 import { IInstantiationService, ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
 import { EditorInput } from 'vs/workbench/common/editor/editorInput';
-import { CellEditType, CellKind, NotebookWorkingCopyTypeIdentifier, REPL_EDITOR_ID } from 'vs/workbench/contrib/notebook/common/notebookCommon';
+import { CellEditType, CellKind, EXECUTE_REPL_COMMAND_ID, NotebookWorkingCopyTypeIdentifier, REPL_EDITOR_ID } from 'vs/workbench/contrib/notebook/common/notebookCommon';
 import { NotebookEditorInputOptions } from 'vs/workbench/contrib/notebook/common/notebookEditorInput';
 import { ReplEditor } from 'vs/workbench/contrib/replNotebook/browser/replEditor';
 import { ReplEditorInput } from 'vs/workbench/contrib/replNotebook/browser/replEditorInput';
@@ -42,7 +42,7 @@ import { NotebookEditorWidget } from 'vs/workbench/contrib/notebook/browser/note
 import { INotebookEditorService } from 'vs/workbench/contrib/notebook/browser/services/notebookEditorService';
 import { KeyCode, KeyMod } from 'vs/base/common/keyCodes';
 import * as icons from 'vs/workbench/contrib/notebook/browser/notebookIcons';
-import { NOTEBOOK_EDITOR_FOCUSED, REPL_NOTEBOOK_IS_ACTIVE_EDITOR } from 'vs/workbench/contrib/notebook/common/notebookContextKeys';
+import { NOTEBOOK_CELL_LIST_FOCUSED, REPL_NOTEBOOK_IS_ACTIVE_EDITOR } from 'vs/workbench/contrib/notebook/common/notebookContextKeys';
 import { EditOperation } from 'vs/editor/common/core/editOperation';
 import { EditorContextKeys } from 'vs/editor/common/editorContextKeys';
 import { InputFocusedContext } from 'vs/platform/contextkey/common/contextkeys';
@@ -218,21 +218,30 @@ registerAction2(class extends Action2 {
 registerAction2(class extends Action2 {
 	constructor() {
 		super({
-			id: 'replNotebook.input.execute',
+			id: EXECUTE_REPL_COMMAND_ID,
 			title: localize2('replNotebook.input.execute', 'Execute the input box contents'),
 			keybinding: [{
 				when: ContextKeyExpr.and(
 					REPL_NOTEBOOK_IS_ACTIVE_EDITOR,
-					ContextKeyExpr.equals('config.interactiveWindow.executeWithShiftEnter', true)
+					ContextKeyExpr.equals('config.interactiveWindow.executeWithShiftEnter', true),
+					NOTEBOOK_CELL_LIST_FOCUSED.toNegated()
 				),
 				primary: KeyMod.Shift | KeyCode.Enter,
 				weight: NOTEBOOK_EDITOR_WIDGET_ACTION_WEIGHT
 			}, {
 				when: ContextKeyExpr.and(
 					REPL_NOTEBOOK_IS_ACTIVE_EDITOR,
-					ContextKeyExpr.equals('config.interactiveWindow.executeWithShiftEnter', false)
+					ContextKeyExpr.equals('config.interactiveWindow.executeWithShiftEnter', false),
+					NOTEBOOK_CELL_LIST_FOCUSED.toNegated()
 				),
 				primary: KeyCode.Enter,
+				weight: NOTEBOOK_EDITOR_WIDGET_ACTION_WEIGHT
+			}, {
+				when: ContextKeyExpr.and(
+					REPL_NOTEBOOK_IS_ACTIVE_EDITOR,
+					NOTEBOOK_CELL_LIST_FOCUSED.toNegated()
+				),
+				primary: KeyMod.CtrlCmd | KeyCode.Enter,
 				weight: NOTEBOOK_EDITOR_WIDGET_ACTION_WEIGHT
 			}],
 			menu: [
@@ -380,7 +389,7 @@ registerAction2(class extends Action2 {
 			keybinding: {
 				when: ContextKeyExpr.and(
 					REPL_NOTEBOOK_IS_ACTIVE_EDITOR,
-					NOTEBOOK_EDITOR_FOCUSED,
+					NOTEBOOK_CELL_LIST_FOCUSED,
 				),
 				primary: KeyMod.CtrlCmd | KeyMod.Alt | KeyCode.DownArrow,
 				weight: NOTEBOOK_EDITOR_WIDGET_ACTION_WEIGHT
@@ -408,7 +417,7 @@ registerAction2(class extends Action2 {
 				when: ContextKeyExpr.and(
 					REPL_NOTEBOOK_IS_ACTIVE_EDITOR,
 					EditorContextKeys.textInputFocus,
-					NOTEBOOK_EDITOR_FOCUSED.toNegated()
+					NOTEBOOK_CELL_LIST_FOCUSED.toNegated()
 				),
 				primary: KeyMod.CtrlCmd | KeyMod.Alt | KeyCode.UpArrow,
 				weight: NOTEBOOK_EDITOR_WIDGET_ACTION_WEIGHT

--- a/src/vs/workbench/contrib/replNotebook/browser/replEditor.ts
+++ b/src/vs/workbench/contrib/replNotebook/browser/replEditor.ts
@@ -200,7 +200,7 @@ export class ReplEditor extends EditorPane implements IEditorPaneWithScrolling {
 	}
 
 	private _setupRunButtonToolbar(runButtonContainer: HTMLElement) {
-		const menu = this._register(this._menuService.createMenu(MenuId.InteractiveInputExecute, this._contextKeyService));
+		const menu = this._register(this._menuService.createMenu(MenuId.ReplInputExecute, this._contextKeyService));
 		this._runbuttonToolbar = this._register(new ToolBar(runButtonContainer, this._contextMenuService, {
 			getKeyBinding: action => this._keybindingService.lookupKeybinding(action.id),
 			actionViewItemProvider: (action, options) => {

--- a/src/vs/workbench/contrib/replNotebook/browser/replEditor.ts
+++ b/src/vs/workbench/contrib/replNotebook/browser/replEditor.ts
@@ -420,7 +420,7 @@ export class ReplEditor extends EditorPane implements IEditorPaneWithScrolling {
 		}
 
 		if (model === null) {
-			throw new Error('The Interactive Window model could not be resolved');
+			throw new Error('The Intertive Window model could not be resolved');
 		}
 
 		this._notebookWidget.value?.setParentContextKeyService(this._contextKeyService);
@@ -643,7 +643,7 @@ export class ReplEditor extends EditorPane implements IEditorPaneWithScrolling {
 		if (model?.getValueLength() === 0) {
 			const transparentForeground = resolveColorValue(editorForeground, this.themeService.getColorTheme())?.transparent(0.4);
 			const languageId = model.getLanguageId();
-			const keybinding = this._keybindingService.lookupKeybinding('interactive.execute', this._contextKeyService)?.getLabel();
+			const keybinding = this._keybindingService.lookupKeybinding('replNotebook.executeInput', this._contextKeyService)?.getLabel();
 			const text = nls.localize('interactiveInputPlaceHolder', "Type '{0}' code here and press {1} to run", languageId, keybinding ?? 'ctrl+enter');
 			decorations.push({
 				range: {

--- a/src/vs/workbench/contrib/replNotebook/browser/replEditor.ts
+++ b/src/vs/workbench/contrib/replNotebook/browser/replEditor.ts
@@ -99,7 +99,6 @@ export class ReplEditor extends EditorPane implements IEditorPaneWithScrolling {
 	private _menuService: IMenuService;
 	private _contextMenuService: IContextMenuService;
 	private _editorGroupService: IEditorGroupsService;
-	private _notebookExecutionStateService: INotebookExecutionStateService;
 	private _extensionService: IExtensionService;
 	private readonly _widgetDisposableStore: DisposableStore = this._register(new DisposableStore());
 	private _lastLayoutDimensions?: { readonly dimension: DOM.Dimension; readonly position: DOM.IDomPosition };
@@ -153,7 +152,6 @@ export class ReplEditor extends EditorPane implements IEditorPaneWithScrolling {
 		this._menuService = menuService;
 		this._contextMenuService = contextMenuService;
 		this._editorGroupService = editorGroupService;
-		this._notebookExecutionStateService = notebookExecutionStateService;
 		this._extensionService = extensionService;
 
 		this._editorOptions = this._computeEditorOptions();
@@ -162,12 +160,12 @@ export class ReplEditor extends EditorPane implements IEditorPaneWithScrolling {
 				this._editorOptions = this._computeEditorOptions();
 			}
 		}));
-		this._notebookOptions = new NotebookOptions(this.window, configurationService, notebookExecutionStateService, codeEditorService, true, { cellToolbarInteraction: 'hover', globalToolbar: true, stickyScrollEnabled: false, dragAndDropEnabled: false });
+		this._notebookOptions = instantiationService.createInstance(NotebookOptions, this.window, true, { cellToolbarInteraction: 'hover', globalToolbar: true, stickyScrollEnabled: false, dragAndDropEnabled: false });
 		this._editorMemento = this.getEditorMemento<InteractiveEditorViewState>(editorGroupService, textResourceConfigurationService, INTERACTIVE_EDITOR_VIEW_STATE_PREFERENCE_KEY);
 
 		codeEditorService.registerDecorationType('interactive-decoration', DECORATION_KEY, {});
 		this._register(this._keybindingService.onDidUpdateKeybindings(this._updateInputDecoration, this));
-		this._register(this._notebookExecutionStateService.onDidChangeExecution((e) => {
+		this._register(notebookExecutionStateService.onDidChangeExecution((e) => {
 			if (e.type === NotebookExecutionType.cell && isEqual(e.notebook, this._notebookWidget.value?.viewModel?.notebookDocument.uri)) {
 				const cell = this._notebookWidget.value?.getCellByHandle(e.cellHandle);
 				if (cell && e.changed?.state) {
@@ -420,7 +418,7 @@ export class ReplEditor extends EditorPane implements IEditorPaneWithScrolling {
 		}
 
 		if (model === null) {
-			throw new Error('The Intertive Window model could not be resolved');
+			throw new Error('The REPL model could not be resolved');
 		}
 
 		this._notebookWidget.value?.setParentContextKeyService(this._contextKeyService);

--- a/src/vs/workbench/contrib/replNotebook/browser/replEditor.ts
+++ b/src/vs/workbench/contrib/replNotebook/browser/replEditor.ts
@@ -1,0 +1,627 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as DOM from 'vs/base/browser/dom';
+import { IActionViewItem } from 'vs/base/browser/ui/actionbar/actionbar';
+import { IAction, toAction } from 'vs/base/common/actions';
+import { timeout } from 'vs/base/common/async';
+import { CancellationToken } from 'vs/base/common/cancellation';
+import { Emitter, Event } from 'vs/base/common/event';
+import { DisposableStore, MutableDisposable } from 'vs/base/common/lifecycle';
+import { extname } from 'vs/base/common/resources';
+import { generateUuid } from 'vs/base/common/uuid';
+import { ITextResourceConfigurationService } from 'vs/editor/common/services/textResourceConfiguration';
+import { localize } from 'vs/nls';
+import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
+import { ByteSize, FileOperationError, FileOperationResult, IFileService, TooLargeFileOperationError } from 'vs/platform/files/common/files';
+import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
+import { IStorageService } from 'vs/platform/storage/common/storage';
+import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
+import { IThemeService } from 'vs/platform/theme/common/themeService';
+import { EditorPane } from 'vs/workbench/browser/parts/editor/editorPane';
+import { DEFAULT_EDITOR_ASSOCIATION, EditorPaneSelectionChangeReason, EditorResourceAccessor, IEditorMemento, IEditorOpenContext, IEditorPaneScrollPosition, IEditorPaneSelectionChangeEvent, IEditorPaneWithScrolling, createEditorOpenError, createTooLargeFileError, isEditorOpenError } from 'vs/workbench/common/editor';
+import { EditorInput } from 'vs/workbench/common/editor/editorInput';
+import { SELECT_KERNEL_ID } from 'vs/workbench/contrib/notebook/browser/controller/coreActions';
+import { INotebookEditorOptions, INotebookEditorViewState } from 'vs/workbench/contrib/notebook/browser/notebookBrowser';
+import { IBorrowValue, INotebookEditorService } from 'vs/workbench/contrib/notebook/browser/services/notebookEditorService';
+import { NotebookEditorWidget } from 'vs/workbench/contrib/notebook/browser/notebookEditorWidget';
+import { NotebooKernelActionViewItem } from 'vs/workbench/contrib/notebook/browser/viewParts/notebookKernelView';
+import { NotebookTextModel } from 'vs/workbench/contrib/notebook/common/model/notebookTextModel';
+import { CellKind, NOTEBOOK_EDITOR_ID, NotebookWorkingCopyTypeIdentifier } from 'vs/workbench/contrib/notebook/common/notebookCommon';
+import { NotebookEditorInput } from 'vs/workbench/contrib/notebook/common/notebookEditorInput';
+import { NotebookPerfMarks } from 'vs/workbench/contrib/notebook/common/notebookPerformance';
+import { GroupsOrder, IEditorGroup, IEditorGroupsService } from 'vs/workbench/services/editor/common/editorGroupsService';
+import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
+import { IEditorProgressService } from 'vs/platform/progress/common/progress';
+import { InstallRecommendedExtensionAction } from 'vs/workbench/contrib/extensions/browser/extensionsActions';
+import { INotebookService } from 'vs/workbench/contrib/notebook/common/notebookService';
+import { IExtensionsWorkbenchService } from 'vs/workbench/contrib/extensions/common/extensions';
+import { EnablementState } from 'vs/workbench/services/extensionManagement/common/extensionManagement';
+import { IWorkingCopyBackupService } from 'vs/workbench/services/workingCopy/common/workingCopyBackup';
+import { streamToBuffer } from 'vs/base/common/buffer';
+import { ILogService } from 'vs/platform/log/common/log';
+import { INotebookEditorWorkerService } from 'vs/workbench/contrib/notebook/common/services/notebookWorkerService';
+import { IPreferencesService } from 'vs/workbench/services/preferences/common/preferences';
+import { IActionViewItemOptions } from 'vs/base/browser/ui/actionbar/actionViewItems';
+import { StopWatch } from 'vs/base/common/stopwatch';
+import { ReplEditorInput } from 'vs/workbench/contrib/replNotebook/browser/replEditorInput';
+
+const NOTEBOOK_EDITOR_VIEW_STATE_PREFERENCE_KEY = 'NotebookEditorViewState';
+
+export class ReplEditor extends EditorPane implements IEditorPaneWithScrolling {
+	static readonly ID: string = NOTEBOOK_EDITOR_ID;
+
+	private readonly _editorMemento: IEditorMemento<INotebookEditorViewState>;
+	private readonly _groupListener = this._register(new DisposableStore());
+	private readonly _widgetDisposableStore: DisposableStore = this._register(new DisposableStore());
+	private _widget: IBorrowValue<NotebookEditorWidget> = { value: undefined };
+	private _rootElement!: HTMLElement;
+	private _pagePosition?: { readonly dimension: DOM.Dimension; readonly position: DOM.IDomPosition };
+
+	private readonly _inputListener = this._register(new MutableDisposable());
+
+	// override onDidFocus and onDidBlur to be based on the NotebookEditorWidget element
+	private readonly _onDidFocusWidget = this._register(new Emitter<void>());
+	override get onDidFocus(): Event<void> { return this._onDidFocusWidget.event; }
+	private readonly _onDidBlurWidget = this._register(new Emitter<void>());
+	override get onDidBlur(): Event<void> { return this._onDidBlurWidget.event; }
+
+	private readonly _onDidChangeModel = this._register(new Emitter<void>());
+	readonly onDidChangeModel: Event<void> = this._onDidChangeModel.event;
+
+	private readonly _onDidChangeSelection = this._register(new Emitter<IEditorPaneSelectionChangeEvent>());
+	readonly onDidChangeSelection = this._onDidChangeSelection.event;
+
+	protected readonly _onDidChangeScroll = this._register(new Emitter<void>());
+	readonly onDidChangeScroll = this._onDidChangeScroll.event;
+
+	constructor(
+		group: IEditorGroup,
+		@ITelemetryService telemetryService: ITelemetryService,
+		@IThemeService themeService: IThemeService,
+		@IInstantiationService private readonly _instantiationService: IInstantiationService,
+		@IStorageService storageService: IStorageService,
+		@IEditorService private readonly _editorService: IEditorService,
+		@IEditorGroupsService private readonly _editorGroupService: IEditorGroupsService,
+		@INotebookEditorService private readonly _notebookWidgetService: INotebookEditorService,
+		@IContextKeyService private readonly _contextKeyService: IContextKeyService,
+		@IFileService private readonly _fileService: IFileService,
+		@ITextResourceConfigurationService configurationService: ITextResourceConfigurationService,
+		@IEditorProgressService private readonly _editorProgressService: IEditorProgressService,
+		@INotebookService private readonly _notebookService: INotebookService,
+		@IExtensionsWorkbenchService private readonly _extensionsWorkbenchService: IExtensionsWorkbenchService,
+		@IWorkingCopyBackupService private readonly _workingCopyBackupService: IWorkingCopyBackupService,
+		@ILogService private readonly logService: ILogService,
+		@INotebookEditorWorkerService private readonly _notebookEditorWorkerService: INotebookEditorWorkerService,
+		@IPreferencesService private readonly _preferencesService: IPreferencesService
+	) {
+		super(ReplEditor.ID, group, telemetryService, themeService, storageService);
+		this._editorMemento = this.getEditorMemento<INotebookEditorViewState>(_editorGroupService, configurationService, NOTEBOOK_EDITOR_VIEW_STATE_PREFERENCE_KEY);
+
+		this._register(this._fileService.onDidChangeFileSystemProviderCapabilities(e => this._onDidChangeFileSystemProvider(e.scheme)));
+		this._register(this._fileService.onDidChangeFileSystemProviderRegistrations(e => this._onDidChangeFileSystemProvider(e.scheme)));
+	}
+
+	private _onDidChangeFileSystemProvider(scheme: string): void {
+		if (this.input instanceof NotebookEditorInput && this.input.resource?.scheme === scheme) {
+			this._updateReadonly(this.input);
+		}
+	}
+
+	private _onDidChangeInputCapabilities(input: NotebookEditorInput): void {
+		if (this.input === input) {
+			this._updateReadonly(input);
+		}
+	}
+
+	private _updateReadonly(input: NotebookEditorInput): void {
+		this._widget.value?.setOptions({ isReadOnly: !!input.isReadonly() });
+	}
+
+	get textModel(): NotebookTextModel | undefined {
+		return this._widget.value?.textModel;
+	}
+
+	override get minimumWidth(): number { return 220; }
+	override get maximumWidth(): number { return Number.POSITIVE_INFINITY; }
+
+	// these setters need to exist because this extends from EditorPane
+	override set minimumWidth(value: number) { /*noop*/ }
+	override set maximumWidth(value: number) { /*noop*/ }
+
+	//#region Editor Core
+	override get scopedContextKeyService(): IContextKeyService | undefined {
+		return this._widget.value?.scopedContextKeyService;
+	}
+
+	protected createEditor(parent: HTMLElement): void {
+		this._rootElement = DOM.append(parent, DOM.$('.notebook-editor'));
+		this._rootElement.id = `notebook-editor-element-${generateUuid()}`;
+	}
+
+	override getActionViewItem(action: IAction, options: IActionViewItemOptions): IActionViewItem | undefined {
+		if (action.id === SELECT_KERNEL_ID) {
+			// this is being disposed by the consumer
+			return this._instantiationService.createInstance(NotebooKernelActionViewItem, action, this, options);
+		}
+		return undefined;
+	}
+
+	override getControl(): NotebookEditorWidget | undefined {
+		return this._widget.value;
+	}
+
+	override setVisible(visible: boolean): void {
+		super.setVisible(visible);
+		if (!visible) {
+			this._widget.value?.onWillHide();
+		}
+	}
+
+	protected override setEditorVisible(visible: boolean): void {
+		super.setEditorVisible(visible);
+		this._groupListener.clear();
+		this._groupListener.add(this.group.onWillCloseEditor(e => this._saveEditorViewState(e.editor)));
+		this._groupListener.add(this.group.onDidModelChange(() => {
+			if (this._editorGroupService.activeGroup !== this.group) {
+				this._widget?.value?.updateEditorFocus();
+			}
+		}));
+
+		if (!visible) {
+			this._saveEditorViewState(this.input);
+			if (this.input && this._widget.value) {
+				// the widget is not transfered to other editor inputs
+				this._widget.value.onWillHide();
+			}
+		}
+	}
+
+	override focus() {
+		super.focus();
+		this._widget.value?.focus();
+	}
+
+	override hasFocus(): boolean {
+		const value = this._widget.value;
+		if (!value) {
+			return false;
+		}
+
+		return !!value && (DOM.isAncestorOfActiveElement(value.getDomNode() || DOM.isAncestorOfActiveElement(value.getOverflowContainerDomNode())));
+	}
+
+	override async setInput(input: ReplEditorInput, options: INotebookEditorOptions | undefined, context: IEditorOpenContext, token: CancellationToken, noRetry?: boolean): Promise<void> {
+		try {
+			let perfMarksCaptured = false;
+			const fileOpenMonitor = timeout(10000);
+			fileOpenMonitor.then(() => {
+				perfMarksCaptured = true;
+				this._handlePerfMark(perf, input);
+			});
+
+			const perf = new NotebookPerfMarks();
+			perf.mark('startTime');
+
+			this._inputListener.value = input.onDidChangeCapabilities(() => this._onDidChangeInputCapabilities(input));
+
+			this._widgetDisposableStore.clear();
+
+			// there currently is a widget which we still own so
+			// we need to hide it before getting a new widget
+			this._widget.value?.onWillHide();
+
+			this._widget = <IBorrowValue<NotebookEditorWidget>>this._instantiationService.invokeFunction(this._notebookWidgetService.retrieveWidget, this.group, input, undefined, this._pagePosition?.dimension, this.window);
+
+			if (this._rootElement && this._widget.value!.getDomNode()) {
+				this._rootElement.setAttribute('aria-flowto', this._widget.value!.getDomNode().id || '');
+				DOM.setParentFlowTo(this._widget.value!.getDomNode(), this._rootElement);
+			}
+
+			this._widgetDisposableStore.add(this._widget.value!.onDidChangeModel(() => this._onDidChangeModel.fire()));
+			this._widgetDisposableStore.add(this._widget.value!.onDidChangeActiveCell(() => this._onDidChangeSelection.fire({ reason: EditorPaneSelectionChangeReason.USER })));
+
+			if (this._pagePosition) {
+				this._widget.value!.layout(this._pagePosition.dimension, this._rootElement, this._pagePosition.position);
+			}
+
+			// only now `setInput` and yield/await. this is AFTER the actual widget is ready. This is very important
+			// so that others synchronously receive a notebook editor with the correct widget being set
+			await super.setInput(input, options, context, token);
+			const model = await input.resolve(options, perf);
+			perf.mark('inputLoaded');
+
+			// Check for cancellation
+			if (token.isCancellationRequested) {
+				return undefined;
+			}
+
+			// The widget has been taken away again. This can happen when the tab has been closed while
+			// loading was in progress, in particular when open the same resource as different view type.
+			// When this happen, retry once
+			if (!this._widget.value) {
+				if (noRetry) {
+					return undefined;
+				}
+				return this.setInput(input, options, context, token, true);
+			}
+
+			if (model === null) {
+				const knownProvider = this._notebookService.getViewTypeProvider(input.viewType);
+
+				if (!knownProvider) {
+					throw new Error(localize('fail.noEditor', "Cannot open resource with notebook editor type '{0}', please check if you have the right extension installed and enabled.", input.viewType));
+				}
+
+				await this._extensionsWorkbenchService.whenInitialized;
+				const extensionInfo = this._extensionsWorkbenchService.local.find(e => e.identifier.id === knownProvider);
+
+				throw createEditorOpenError(new Error(localize('fail.noEditor.extensionMissing', "Cannot open resource with notebook editor type '{0}', please check if you have the right extension installed and enabled.", input.viewType)), [
+					toAction({
+						id: 'workbench.notebook.action.installOrEnableMissing', label:
+							extensionInfo
+								? localize('notebookOpenEnableMissingViewType', "Enable extension for '{0}'", input.viewType)
+								: localize('notebookOpenInstallMissingViewType', "Install extension for '{0}'", input.viewType)
+						, run: async () => {
+							const d = this._notebookService.onAddViewType(viewType => {
+								if (viewType === input.viewType) {
+									// serializer is registered, try to open again
+									this._editorService.openEditor({ resource: input.resource });
+									d.dispose();
+								}
+							});
+							const extensionInfo = this._extensionsWorkbenchService.local.find(e => e.identifier.id === knownProvider);
+
+							try {
+								if (extensionInfo) {
+									await this._extensionsWorkbenchService.setEnablement(extensionInfo, extensionInfo.enablementState === EnablementState.DisabledWorkspace ? EnablementState.EnabledWorkspace : EnablementState.EnabledGlobally);
+								} else {
+									await this._instantiationService.createInstance(InstallRecommendedExtensionAction, knownProvider).run();
+								}
+							} catch (ex) {
+								this.logService.error(`Failed to install or enable extension ${knownProvider}`, ex);
+								d.dispose();
+							}
+						}
+					}),
+					toAction({
+						id: 'workbench.notebook.action.openAsText', label: localize('notebookOpenAsText', "Open As Text"), run: async () => {
+							const backup = await this._workingCopyBackupService.resolve({ resource: input.resource, typeId: NotebookWorkingCopyTypeIdentifier.create(input.viewType) });
+							if (backup) {
+								// with a backup present, we must resort to opening the backup contents
+								// as untitled text file to not show the wrong data to the user
+								const contents = await streamToBuffer(backup.value);
+								this._editorService.openEditor({ resource: undefined, contents: contents.toString() });
+							} else {
+								// without a backup present, we can open the original resource
+								this._editorService.openEditor({ resource: input.resource, options: { override: DEFAULT_EDITOR_ASSOCIATION.id, pinned: true } });
+							}
+						}
+					})
+				], { allowDialog: true });
+
+			}
+
+			this._widgetDisposableStore.add(model.notebook.onDidChangeContent(() => this._onDidChangeSelection.fire({ reason: EditorPaneSelectionChangeReason.EDIT })));
+
+			const viewState = options?.viewState ?? this._loadNotebookEditorViewState(input);
+
+			// We might be moving the notebook widget between groups, and these services are tied to the group
+			this._widget.value.setParentContextKeyService(this._contextKeyService);
+			this._widget.value.setEditorProgressService(this._editorProgressService);
+
+			await this._widget.value.setModel(model.notebook, viewState, perf);
+			const isReadOnly = !!input.isReadonly();
+			await this._widget.value.setOptions({ ...options, isReadOnly });
+			this._widgetDisposableStore.add(this._widget.value.onDidFocusWidget(() => this._onDidFocusWidget.fire()));
+			this._widgetDisposableStore.add(this._widget.value.onDidBlurWidget(() => this._onDidBlurWidget.fire()));
+
+			this._widgetDisposableStore.add(this._editorGroupService.createEditorDropTarget(this._widget.value.getDomNode(), {
+				containsGroup: (group) => this.group.id === group.id
+			}));
+
+			this._widgetDisposableStore.add(this._widget.value.onDidScroll(() => { this._onDidChangeScroll.fire(); }));
+
+			perf.mark('editorLoaded');
+
+			fileOpenMonitor.cancel();
+			if (perfMarksCaptured) {
+				return;
+			}
+
+			this._handlePerfMark(perf, input, model.notebook);
+			this._handlePromptRecommendations(model.notebook);
+		} catch (e) {
+			this.logService.warn('NotebookEditorWidget#setInput failed', e);
+			if (isEditorOpenError(e)) {
+				throw e;
+			}
+
+			// Handle case where a file is too large to open without confirmation
+			if ((<FileOperationError>e).fileOperationResult === FileOperationResult.FILE_TOO_LARGE) {
+				let message: string;
+				if (e instanceof TooLargeFileOperationError) {
+					message = localize('notebookTooLargeForHeapErrorWithSize', "The notebook is not displayed in the notebook editor because it is very large ({0}).", ByteSize.formatSize(e.size));
+				} else {
+					message = localize('notebookTooLargeForHeapErrorWithoutSize', "The notebook is not displayed in the notebook editor because it is very large.");
+				}
+
+				throw createTooLargeFileError(this.group, input, options, message, this._preferencesService);
+			}
+
+			const error = createEditorOpenError(e instanceof Error ? e : new Error((e ? e.message : '')), [
+				toAction({
+					id: 'workbench.notebook.action.openInTextEditor', label: localize('notebookOpenInTextEditor', "Open in Text Editor"), run: async () => {
+						const activeEditorPane = this._editorService.activeEditorPane;
+						if (!activeEditorPane) {
+							return;
+						}
+
+						const activeEditorResource = EditorResourceAccessor.getCanonicalUri(activeEditorPane.input);
+						if (!activeEditorResource) {
+							return;
+						}
+
+						if (activeEditorResource.toString() === input.resource?.toString()) {
+							// Replace the current editor with the text editor
+							return this._editorService.openEditor({
+								resource: activeEditorResource,
+								options: {
+									override: DEFAULT_EDITOR_ASSOCIATION.id,
+									pinned: true // new file gets pinned by default
+								}
+							});
+						}
+
+						return;
+					}
+				})
+			], { allowDialog: true });
+
+			throw error;
+		}
+	}
+
+	private _handlePerfMark(perf: NotebookPerfMarks, input: NotebookEditorInput, notebook?: NotebookTextModel) {
+		const perfMarks = perf.value;
+
+		type WorkbenchNotebookOpenClassification = {
+			owner: 'rebornix';
+			comment: 'The notebook file open metrics. Used to get a better understanding of the performance of notebook file opening';
+			scheme: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'File system provider scheme for the notebook resource' };
+			ext: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'File extension for the notebook resource' };
+			viewType: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The view type of the notebook editor' };
+			extensionActivated: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Extension activation time for the resource opening' };
+			inputLoaded: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Editor Input loading time for the resource opening' };
+			webviewCommLoaded: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Webview initialization time for the resource opening' };
+			customMarkdownLoaded: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Custom markdown loading time for the resource opening' };
+			editorLoaded: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Overall editor loading time for the resource opening' };
+			codeCellCount: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Total number of code cell' };
+			mdCellCount: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Total number of markdown cell' };
+			outputCount: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Total number of cell outputs' };
+			outputBytes: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Total number of bytes for all outputs' };
+			codeLength: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Length of text in all code cells' };
+			markdownLength: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Length of text in all markdown cells' };
+			notebookStatsLoaded: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Time for generating the notebook level information for telemetry' };
+		};
+
+		type WorkbenchNotebookOpenEvent = {
+			scheme: string;
+			ext: string;
+			viewType: string;
+			extensionActivated: number;
+			inputLoaded: number;
+			webviewCommLoaded: number;
+			customMarkdownLoaded: number | undefined;
+			editorLoaded: number;
+			codeCellCount: number | undefined;
+			mdCellCount: number | undefined;
+			outputCount: number | undefined;
+			outputBytes: number | undefined;
+			codeLength: number | undefined;
+			markdownLength: number | undefined;
+			notebookStatsLoaded: number | undefined;
+		};
+
+		const startTime = perfMarks['startTime'];
+		const extensionActivated = perfMarks['extensionActivated'];
+		const inputLoaded = perfMarks['inputLoaded'];
+		const webviewCommLoaded = perfMarks['webviewCommLoaded'];
+		const customMarkdownLoaded = perfMarks['customMarkdownLoaded'];
+		const editorLoaded = perfMarks['editorLoaded'];
+
+		let extensionActivationTimespan = -1;
+		let inputLoadingTimespan = -1;
+		let webviewCommLoadingTimespan = -1;
+		let customMarkdownLoadingTimespan = -1;
+		let editorLoadingTimespan = -1;
+
+		if (startTime !== undefined && extensionActivated !== undefined) {
+			extensionActivationTimespan = extensionActivated - startTime;
+
+			if (inputLoaded !== undefined) {
+				inputLoadingTimespan = inputLoaded - extensionActivated;
+			}
+
+			if (webviewCommLoaded !== undefined) {
+				webviewCommLoadingTimespan = webviewCommLoaded - extensionActivated;
+
+			}
+
+			if (customMarkdownLoaded !== undefined) {
+				customMarkdownLoadingTimespan = customMarkdownLoaded - startTime;
+			}
+
+			if (editorLoaded !== undefined) {
+				editorLoadingTimespan = editorLoaded - startTime;
+			}
+		}
+
+		// Notebook information
+		let codeCellCount: number | undefined = undefined;
+		let mdCellCount: number | undefined = undefined;
+		let outputCount: number | undefined = undefined;
+		let outputBytes: number | undefined = undefined;
+		let codeLength: number | undefined = undefined;
+		let markdownLength: number | undefined = undefined;
+		let notebookStatsLoaded: number | undefined = undefined;
+		if (notebook) {
+			const stopWatch = new StopWatch();
+			for (const cell of notebook.cells) {
+				if (cell.cellKind === CellKind.Code) {
+					codeCellCount = (codeCellCount || 0) + 1;
+					codeLength = (codeLength || 0) + cell.getTextLength();
+					outputCount = (outputCount || 0) + cell.outputs.length;
+					outputBytes = (outputBytes || 0) + cell.outputs.reduce((prev, cur) => prev + cur.outputs.reduce((size, item) => size + item.data.byteLength, 0), 0);
+				} else {
+					mdCellCount = (mdCellCount || 0) + 1;
+					markdownLength = (codeLength || 0) + cell.getTextLength();
+				}
+			}
+			notebookStatsLoaded = stopWatch.elapsed();
+		}
+
+		this.logService.trace(`[NotebookEditor] open notebook perf ${notebook?.uri.toString() ?? ''} - extensionActivation: ${extensionActivationTimespan}, inputLoad: ${inputLoadingTimespan}, webviewComm: ${webviewCommLoadingTimespan}, customMarkdown: ${customMarkdownLoadingTimespan}, editorLoad: ${editorLoadingTimespan}`);
+
+		this.telemetryService.publicLog2<WorkbenchNotebookOpenEvent, WorkbenchNotebookOpenClassification>('notebook/editorOpenPerf', {
+			scheme: input.resource.scheme,
+			ext: extname(input.resource),
+			viewType: input.viewType,
+			extensionActivated: extensionActivationTimespan,
+			inputLoaded: inputLoadingTimespan,
+			webviewCommLoaded: webviewCommLoadingTimespan,
+			customMarkdownLoaded: customMarkdownLoadingTimespan,
+			editorLoaded: editorLoadingTimespan,
+			codeCellCount,
+			mdCellCount,
+			outputCount,
+			outputBytes,
+			codeLength,
+			markdownLength,
+			notebookStatsLoaded
+		});
+	}
+
+	private _handlePromptRecommendations(model: NotebookTextModel) {
+		this._notebookEditorWorkerService.canPromptRecommendation(model.uri).then(shouldPrompt => {
+			type WorkbenchNotebookShouldPromptRecommendationClassification = {
+				owner: 'rebornix';
+				comment: 'The notebook file metrics. Used to get a better understanding of if we should prompt for notebook extension recommendations';
+				shouldPrompt: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Should we prompt for notebook extension recommendations' };
+			};
+
+			type WorkbenchNotebookShouldPromptRecommendationEvent = {
+				shouldPrompt: boolean;
+			};
+
+			this.telemetryService.publicLog2<WorkbenchNotebookShouldPromptRecommendationEvent, WorkbenchNotebookShouldPromptRecommendationClassification>('notebook/shouldPromptRecommendation', {
+				shouldPrompt: shouldPrompt
+			});
+		});
+	}
+
+	override clearInput(): void {
+		this._inputListener.clear();
+
+		if (this._widget.value) {
+			this._saveEditorViewState(this.input);
+			this._widget.value.onWillHide();
+		}
+		super.clearInput();
+	}
+
+	override setOptions(options: INotebookEditorOptions | undefined): void {
+		this._widget.value?.setOptions(options);
+		super.setOptions(options);
+	}
+
+	protected override saveState(): void {
+		this._saveEditorViewState(this.input);
+		super.saveState();
+	}
+
+	override getViewState(): INotebookEditorViewState | undefined {
+		const input = this.input;
+		if (!(input instanceof NotebookEditorInput)) {
+			return undefined;
+		}
+
+		this._saveEditorViewState(input);
+		return this._loadNotebookEditorViewState(input);
+	}
+
+	getScrollPosition(): IEditorPaneScrollPosition {
+		const widget = this.getControl();
+		if (!widget) {
+			throw new Error('Notebook widget has not yet been initialized');
+		}
+
+		return {
+			scrollTop: widget.scrollTop,
+			scrollLeft: 0,
+		};
+	}
+
+	setScrollPosition(scrollPosition: IEditorPaneScrollPosition): void {
+		const editor = this.getControl();
+		if (!editor) {
+			throw new Error('Control has not yet been initialized');
+		}
+
+		editor.setScrollTop(scrollPosition.scrollTop);
+	}
+
+	private _saveEditorViewState(input: EditorInput | undefined): void {
+		if (this._widget.value && input instanceof NotebookEditorInput) {
+			if (this._widget.value.isDisposed) {
+				return;
+			}
+
+			const state = this._widget.value.getEditorViewState();
+			this._editorMemento.saveEditorState(this.group, input.resource, state);
+		}
+	}
+
+	private _loadNotebookEditorViewState(input: NotebookEditorInput): INotebookEditorViewState | undefined {
+		const result = this._editorMemento.loadEditorState(this.group, input.resource);
+		if (result) {
+			return result;
+		}
+		// when we don't have a view state for the group/input-tuple then we try to use an existing
+		// editor for the same resource.
+		for (const group of this._editorGroupService.getGroups(GroupsOrder.MOST_RECENTLY_ACTIVE)) {
+			if (group.activeEditorPane !== this && group.activeEditorPane instanceof ReplEditor && group.activeEditor?.matches(input)) {
+				return group.activeEditorPane._widget.value?.getEditorViewState();
+			}
+		}
+		return;
+	}
+
+	layout(dimension: DOM.Dimension, position: DOM.IDomPosition): void {
+		this._rootElement.classList.toggle('mid-width', dimension.width < 1000 && dimension.width >= 600);
+		this._rootElement.classList.toggle('narrow-width', dimension.width < 600);
+		this._pagePosition = { dimension, position };
+
+		if (!this._widget.value || !(this.input instanceof NotebookEditorInput)) {
+			return;
+		}
+
+		if (this.input.resource.toString() !== this.textModel?.uri.toString() && this._widget.value?.hasModel()) {
+			// input and widget mismatch
+			// this happens when
+			// 1. open document A, pin the document
+			// 2. open document B
+			// 3. close document B
+			// 4. a layout is triggered
+			return;
+		}
+
+		if (this.isVisible()) {
+			this._widget.value.layout(dimension, this._rootElement, position);
+		}
+	}
+
+	//#endregion
+}

--- a/src/vs/workbench/contrib/replNotebook/browser/replEditor.ts
+++ b/src/vs/workbench/contrib/replNotebook/browser/replEditor.ts
@@ -359,6 +359,7 @@ export class ReplEditor extends EditorPane implements IEditorPaneWithScrolling {
 		this._notebookWidget = <IBorrowValue<NotebookEditorWidget>>this._instantiationService.invokeFunction(this._notebookWidgetService.retrieveWidget, this.group, input, {
 			isEmbedded: true,
 			isReadOnly: true,
+			forRepl: true,
 			contributions: NotebookEditorExtensionsRegistry.getSomeEditorContributions([
 				ExecutionStateCellStatusBarContrib.id,
 				TimerCellStatusBarContrib.id,

--- a/src/vs/workbench/contrib/replNotebook/browser/replEditor.ts
+++ b/src/vs/workbench/contrib/replNotebook/browser/replEditor.ts
@@ -56,7 +56,7 @@ import { ICursorPositionChangedEvent } from 'vs/editor/common/cursorEvents';
 import { IExtensionService } from 'vs/workbench/services/extensions/common/extensions';
 import { isEqual } from 'vs/base/common/resources';
 import { NotebookFindContrib } from 'vs/workbench/contrib/notebook/browser/contrib/find/notebookFindWidget';
-import { REPL_EDITOR_ID } from 'vs/workbench/contrib/notebook/common/notebookCommon';
+import { EXECUTE_REPL_COMMAND_ID, REPL_EDITOR_ID } from 'vs/workbench/contrib/notebook/common/notebookCommon';
 import 'vs/css!./interactiveEditor';
 import { IEditorOptions } from 'vs/editor/common/config/editorOptions';
 import { deepClone } from 'vs/base/common/objects';
@@ -641,22 +641,27 @@ export class ReplEditor extends EditorPane implements IEditorPaneWithScrolling {
 		if (model?.getValueLength() === 0) {
 			const transparentForeground = resolveColorValue(editorForeground, this.themeService.getColorTheme())?.transparent(0.4);
 			const languageId = model.getLanguageId();
-			const keybinding = this._keybindingService.lookupKeybinding('replNotebook.executeInput', this._contextKeyService)?.getLabel();
-			const text = nls.localize('interactiveInputPlaceHolder', "Type '{0}' code here and press {1} to run", languageId, keybinding ?? 'ctrl+enter');
-			decorations.push({
-				range: {
-					startLineNumber: 0,
-					endLineNumber: 0,
-					startColumn: 0,
-					endColumn: 1
-				},
-				renderOptions: {
-					after: {
-						contentText: text,
-						color: transparentForeground ? transparentForeground.toString() : undefined
+			if (languageId !== 'plaintext') {
+				const keybinding = this._keybindingService.lookupKeybinding(EXECUTE_REPL_COMMAND_ID, this._contextKeyService)?.getLabel();
+				const text = keybinding ?
+					nls.localize('interactiveInputPlaceHolder', "Type '{0}' code here and press {1} to run", languageId, keybinding) :
+					nls.localize('interactiveInputPlaceHolderNoKeybinding', "Type '{0}' code here and click run", languageId);
+				decorations.push({
+					range: {
+						startLineNumber: 0,
+						endLineNumber: 0,
+						startColumn: 0,
+						endColumn: 1
+					},
+					renderOptions: {
+						after: {
+							contentText: text,
+							color: transparentForeground ? transparentForeground.toString() : undefined
+						}
 					}
-				}
-			});
+				});
+			}
+
 		}
 
 		this._codeEditorWidget.setDecorationsByType('interactive-decoration', DECORATION_KEY, decorations);

--- a/src/vs/workbench/contrib/replNotebook/browser/replEditorInput.ts
+++ b/src/vs/workbench/contrib/replNotebook/browser/replEditorInput.ts
@@ -1,0 +1,40 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { URI } from 'vs/base/common/uri';
+import { ITextResourceConfigurationService } from 'vs/editor/common/services/textResourceConfiguration';
+import { IFileDialogService } from 'vs/platform/dialogs/common/dialogs';
+import { IFileService } from 'vs/platform/files/common/files';
+import { ILabelService } from 'vs/platform/label/common/label';
+import { NotebookEditorInput, NotebookEditorInputOptions } from 'vs/workbench/contrib/notebook/common/notebookEditorInput';
+import { INotebookEditorModelResolverService } from 'vs/workbench/contrib/notebook/common/notebookEditorModelResolverService';
+import { INotebookService } from 'vs/workbench/contrib/notebook/common/notebookService';
+import { ICustomEditorLabelService } from 'vs/workbench/services/editor/common/customEditorLabelService';
+import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
+import { IExtensionService } from 'vs/workbench/services/extensions/common/extensions';
+import { IFilesConfigurationService } from 'vs/workbench/services/filesConfiguration/common/filesConfigurationService';
+
+export class ReplEditorInput extends NotebookEditorInput {
+	static override ID: string = 'workbench.editorinputs.replEditorInput';
+
+	constructor(
+		resource: URI,
+		preferredResource: URI | undefined,
+		viewType: string,
+		options: NotebookEditorInputOptions,
+		@INotebookService _notebookService: INotebookService,
+		@INotebookEditorModelResolverService _notebookModelResolverService: INotebookEditorModelResolverService,
+		@IFileDialogService _fileDialogService: IFileDialogService,
+		@ILabelService labelService: ILabelService,
+		@IFileService fileService: IFileService,
+		@IFilesConfigurationService filesConfigurationService: IFilesConfigurationService,
+		@IExtensionService extensionService: IExtensionService,
+		@IEditorService editorService: IEditorService,
+		@ITextResourceConfigurationService textResourceConfigurationService: ITextResourceConfigurationService,
+		@ICustomEditorLabelService customEditorLabelService: ICustomEditorLabelService
+	) {
+		super(resource, preferredResource, viewType, options, _notebookService, _notebookModelResolverService, _fileDialogService, labelService, fileService, filesConfigurationService, extensionService, editorService, textResourceConfigurationService, customEditorLabelService);
+	}
+}

--- a/src/vs/workbench/contrib/replNotebook/browser/replEditorInput.ts
+++ b/src/vs/workbench/contrib/replNotebook/browser/replEditorInput.ts
@@ -64,7 +64,6 @@ export class ReplEditorInput extends NotebookEditorInput {
 			return this.inputModelRef.object.textEditorModel;
 		}
 
-		// return BaseCellViewModel.resolveTextModel
 		const lastCell = notebook.cells[notebook.cells.length - 1];
 		this.inputModelRef = await this._textModelService.createModelReference(lastCell.uri);
 		return this.inputModelRef.object.textEditorModel;
@@ -73,8 +72,9 @@ export class ReplEditorInput extends NotebookEditorInput {
 	override dispose() {
 		if (!this.isDisposing) {
 			this.isDisposing = true;
-			this.editorModelReference?.object.revert({ soft: true });
 			super.dispose();
+			this.editorModelReference?.object.revert({ soft: true });
+			this.inputModelRef?.dispose();
 		}
 	}
 }

--- a/src/vs/workbench/contrib/replNotebook/browser/replEditorInput.ts
+++ b/src/vs/workbench/contrib/replNotebook/browser/replEditorInput.ts
@@ -3,12 +3,16 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { IReference } from 'vs/base/common/lifecycle';
 import { URI } from 'vs/base/common/uri';
+import { IResolvedTextEditorModel, ITextModelService } from 'vs/editor/common/services/resolverService';
 import { ITextResourceConfigurationService } from 'vs/editor/common/services/textResourceConfiguration';
 import { IFileDialogService } from 'vs/platform/dialogs/common/dialogs';
 import { IFileService } from 'vs/platform/files/common/files';
 import { ILabelService } from 'vs/platform/label/common/label';
-import { NotebookEditorInput, NotebookEditorInputOptions } from 'vs/workbench/contrib/notebook/common/notebookEditorInput';
+import { IInteractiveHistoryService } from 'vs/workbench/contrib/interactive/browser/interactiveHistoryService';
+import { NotebookTextModel } from 'vs/workbench/contrib/notebook/common/model/notebookTextModel';
+import { NotebookEditorInput } from 'vs/workbench/contrib/notebook/common/notebookEditorInput';
 import { INotebookEditorModelResolverService } from 'vs/workbench/contrib/notebook/common/notebookEditorModelResolverService';
 import { INotebookService } from 'vs/workbench/contrib/notebook/common/notebookService';
 import { ICustomEditorLabelService } from 'vs/workbench/services/editor/common/customEditorLabelService';
@@ -19,11 +23,10 @@ import { IFilesConfigurationService } from 'vs/workbench/services/filesConfigura
 export class ReplEditorInput extends NotebookEditorInput {
 	static override ID: string = 'workbench.editorinputs.replEditorInput';
 
+	private _inputModelRef: IReference<IResolvedTextEditorModel> | undefined;
+
 	constructor(
 		resource: URI,
-		preferredResource: URI | undefined,
-		viewType: string,
-		options: NotebookEditorInputOptions,
 		@INotebookService _notebookService: INotebookService,
 		@INotebookEditorModelResolverService _notebookModelResolverService: INotebookEditorModelResolverService,
 		@IFileDialogService _fileDialogService: IFileDialogService,
@@ -33,8 +36,21 @@ export class ReplEditorInput extends NotebookEditorInput {
 		@IExtensionService extensionService: IExtensionService,
 		@IEditorService editorService: IEditorService,
 		@ITextResourceConfigurationService textResourceConfigurationService: ITextResourceConfigurationService,
-		@ICustomEditorLabelService customEditorLabelService: ICustomEditorLabelService
+		@ICustomEditorLabelService customEditorLabelService: ICustomEditorLabelService,
+		@IInteractiveHistoryService public readonly historyService: IInteractiveHistoryService,
+		@ITextModelService private readonly _textModelService: ITextModelService
 	) {
-		super(resource, preferredResource, viewType, options, _notebookService, _notebookModelResolverService, _fileDialogService, labelService, fileService, filesConfigurationService, extensionService, editorService, textResourceConfigurationService, customEditorLabelService);
+		super(resource, undefined, 'repl', {}, _notebookService, _notebookModelResolverService, _fileDialogService, labelService, fileService, filesConfigurationService, extensionService, editorService, textResourceConfigurationService, customEditorLabelService);
+	}
+
+	async resolveInput(notebook: NotebookTextModel) {
+		if (this._inputModelRef) {
+			return this._inputModelRef.object.textEditorModel;
+		}
+
+		// return BaseCellViewModel.resolveTextModel
+		const lastCell = notebook.cells[notebook.cells.length - 1];
+		this._inputModelRef = await this._textModelService.createModelReference(lastCell.uri);
+		return this._inputModelRef.object.textEditorModel;
 	}
 }

--- a/src/vs/workbench/contrib/replNotebook/browser/replEditorInput.ts
+++ b/src/vs/workbench/contrib/replNotebook/browser/replEditorInput.ts
@@ -54,6 +54,10 @@ export class ReplEditorInput extends NotebookEditorInput {
 		return ReplEditorInput.ID;
 	}
 
+	override getName() {
+		return 'REPL';
+	}
+
 	override get capabilities() {
 		const capabilities = super.capabilities;
 		const scratchPad = this.isScratchpad ? EditorInputCapabilities.Scratchpad : 0;

--- a/src/vs/workbench/contrib/replNotebook/browser/replEditorInput.ts
+++ b/src/vs/workbench/contrib/replNotebook/browser/replEditorInput.ts
@@ -72,9 +72,9 @@ export class ReplEditorInput extends NotebookEditorInput {
 	override dispose() {
 		if (!this.isDisposing) {
 			this.isDisposing = true;
-			super.dispose();
 			this.editorModelReference?.object.revert({ soft: true });
 			this.inputModelRef?.dispose();
+			super.dispose();
 		}
 	}
 }

--- a/src/vs/workbench/contrib/replNotebook/browser/replEditorInput.ts
+++ b/src/vs/workbench/contrib/replNotebook/browser/replEditorInput.ts
@@ -50,6 +50,10 @@ export class ReplEditorInput extends NotebookEditorInput {
 		this.isScratchpad = configurationService.getValue<boolean>(NotebookSetting.InteractiveWindowPromptToSave) !== true;
 	}
 
+	override get typeId(): string {
+		return ReplEditorInput.ID;
+	}
+
 	override get capabilities() {
 		const capabilities = super.capabilities;
 		const scratchPad = this.isScratchpad ? EditorInputCapabilities.Scratchpad : 0;

--- a/src/vs/workbench/contrib/replNotebook/browser/replEditorInput.ts
+++ b/src/vs/workbench/contrib/replNotebook/browser/replEditorInput.ts
@@ -46,7 +46,7 @@ export class ReplEditorInput extends NotebookEditorInput {
 		@ITextModelService private readonly _textModelService: ITextModelService,
 		@IConfigurationService configurationService: IConfigurationService
 	) {
-		super(resource, undefined, 'repl', {}, _notebookService, _notebookModelResolverService, _fileDialogService, labelService, fileService, filesConfigurationService, extensionService, editorService, textResourceConfigurationService, customEditorLabelService);
+		super(resource, undefined, 'jupyter-notebook', {}, _notebookService, _notebookModelResolverService, _fileDialogService, labelService, fileService, filesConfigurationService, extensionService, editorService, textResourceConfigurationService, customEditorLabelService);
 		this.isScratchpad = configurationService.getValue<boolean>(NotebookSetting.InteractiveWindowPromptToSave) !== true;
 	}
 

--- a/src/vs/workbench/workbench.common.main.ts
+++ b/src/vs/workbench/workbench.common.main.ts
@@ -193,6 +193,9 @@ import 'vs/workbench/contrib/inlineChat/browser/inlineChat.contribution';
 // Interactive
 import 'vs/workbench/contrib/interactive/browser/interactive.contribution';
 
+// repl
+import 'vs/workbench/contrib/replNotebook/browser/repl.contribution';
+
 // Testing
 import 'vs/workbench/contrib/testing/browser/testing.contribution';
 


### PR DESCRIPTION
https://github.com/microsoft/vscode/issues/154983

- Introduce a new view type 'repl' for an alternative editor type for .ipynb files.
- notebookTextModel has a `cellsForView` method, where a repl model will return all but the final cell, which is used for the input box.
- `replEditorInput` is mostly copied from `interactiveEditorInput` with just the minimum modifications to get it working.

Currently, 'viewType' is commonly used to distinguish notebook types for serializers - we should probably disambiguate those two concepts so that the new repl viewtype can handle more than just notebook models for ipynb files, but this PR does not tackle that.