### PR TITLE
Support MSYS/Cygwin absolute path notation

### DIFF
--- a/src/vs/base/test/common/path.test.ts
+++ b/src/vs/base/test/common/path.test.ts
@@ -602,7 +602,7 @@ suite('Paths (Node Implementation)', () => {
 		assert.strictEqual(path.win32.normalize('a//b//.'), 'a\\b');
 		assert.strictEqual(path.win32.normalize('//server/share/dir/file.ext'),
 			'\\\\server\\share\\dir\\file.ext');
-		assert.strictEqual(path.win32.normalize('/a/b/c/../../../x/y/z'), '\\x\\y\\z');
+		assert.strictEqual(path.win32.normalize('/aa/b/c/../../../x/y/z'), '\\x\\y\\z');
 		assert.strictEqual(path.win32.normalize('C:'), 'C:.');
 		assert.strictEqual(path.win32.normalize('C:..\\abc'), 'C:..\\abc');
 		assert.strictEqual(path.win32.normalize('C:..\\..\\abc\\..\\def'),
@@ -634,6 +634,12 @@ suite('Paths (Node Implementation)', () => {
 
 		assert.strictEqual(path.posix.normalize('./fixtures///b/../b/c.js'),
 			'fixtures/b/c.js');
+		assert.strictEqual(path.win32.normalize('/c'), 'C:\\');
+		assert.strictEqual(path.win32.normalize('/c/'), 'C:\\');
+		assert.strictEqual(path.win32.normalize('/c/foo.txt'), 'C:\\foo.txt');
+		assert.strictEqual(path.win32.normalize('/cd/foo.txt'), '\\cd\\foo.txt');
+		assert.strictEqual(path.win32.normalize('/cygdrive/c/foo.txt'), 'C:\\foo.txt');
+		assert.strictEqual(path.win32.normalize('/cygdrive/cd/foo.txt'), '\\cygdrive\\cd\\foo.txt');
 		assert.strictEqual(path.posix.normalize('/foo/../../../bar'), '/bar');
 		assert.strictEqual(path.posix.normalize('a//b//../b'), 'a/b');
 		assert.strictEqual(path.posix.normalize('a//b//./c'), 'a/b/c');
@@ -678,6 +684,12 @@ suite('Paths (Node Implementation)', () => {
 		assert.strictEqual(path.win32.isAbsolute('c://'), true);
 		assert.strictEqual(path.win32.isAbsolute('C:/Users/'), true);
 		assert.strictEqual(path.win32.isAbsolute('C:\\Users\\'), true);
+		assert.strictEqual(path.win32.isAbsolute('/c/Users'), true);
+		assert.strictEqual(path.win32.isAbsolute('/c'), true);
+		assert.strictEqual(path.win32.isAbsolute('/c/'), true);
+		assert.strictEqual(path.win32.isAbsolute('/cygdrive/c/Users'), true);
+		assert.strictEqual(path.win32.isAbsolute('/cygdrive/c'), true);
+		assert.strictEqual(path.win32.isAbsolute('/cygdrive/c/'), true);
 		assert.strictEqual(path.win32.isAbsolute('C:cwd/another'), false);
 		assert.strictEqual(path.win32.isAbsolute('C:cwd\\another'), false);
 		assert.strictEqual(path.win32.isAbsolute('directory/directory'), false);

--- a/src/vs/workbench/contrib/debug/test/browser/debugSource.test.ts
+++ b/src/vs/workbench/contrib/debug/test/browser/debugSource.test.ts
@@ -53,7 +53,7 @@ suite('Debug - Source', () => {
 			assert.strictEqual(sessionId, expectedSessionId);
 		};
 
-		checkData(uri.file('a/b/c/d'), 'd', isWindows ? '\\a\\b\\c\\d' : '/a/b/c/d', undefined, undefined);
+		checkData(uri.file('aa/b/c/d'), 'd', isWindows ? '\\aa\\b\\c\\d' : '/aa/b/c/d', undefined, undefined);
 		checkData(uri.from({ scheme: 'file', path: '/my/path/test.js', query: 'ref=1&session=2' }), 'test.js', isWindows ? '\\my\\path\\test.js' : '/my/path/test.js', undefined, undefined);
 
 		checkData(uri.from({ scheme: 'http', authority: 'www.example.com', path: '/my/path' }), 'path', 'http://www.example.com/my/path', undefined, undefined);


### PR DESCRIPTION
For MSYS: /d/file is translated to D:\file
For Cygwin: /cygdrive/d/file is D:\file
