### PR TITLE
Update behavior of files.candidateGuessEncodings so the last entry is…

### DIFF
--- a/src/vs/workbench/services/textfile/common/encoding.ts
+++ b/src/vs/workbench/services/textfile/common/encoding.ts
@@ -346,14 +346,12 @@ async function guessEncodingByBuffer(buffer: VSBuffer, candidateGuessEncodings?:
 
 	let guessed = jschardet.detect(binaryString, candidateGuessEncodings ? { detectEncodings: candidateGuessEncodings } : undefined);
 
-	if (!candidateGuessEncodingsFallback && (!guessed || !guessed.encoding)) {
-		return null;
-	}
-
-	if (candidateGuessEncodingsFallback !== null) {
+	if (!guessed || !guessed.encoding) {
+		if (!candidateGuessEncodingsFallback) {
+			return null;
+		}
 		guessed = { encoding: candidateGuessEncodingsFallback, confidence: 0.99 };
 	}
-
 
 	const enc = guessed.encoding.toLowerCase();
 	if (0 <= IGNORE_ENCODINGS.indexOf(enc)) {


### PR DESCRIPTION
### Pull Request: Update `files.candidateGuessEncodings` Behavior

This pull request modifies the behavior of `files.candidateGuessEncodings` so that the last entry is used as a fallback when the encoding cannot be determined.

#### Current Implementation

The current implementation falls back to the `files.encoding` setting when the encoding cannot be detected.

#### Issue Identified

As identified by @peminator [here](https://github.com/microsoft/vscode/pull/208550#issuecomment-2151790237), if the encoding of a file cannot be detected for any reason, it defaults to `utf8` as set via `files.encoding`. However, this behavior might not always be desired.

#### Proposed Change

This change makes it so that the last entry in the `files.candidateGuessEncodings` array is used as the fallback encoding when detection fails. This approach is more intuitive and flexible, allowing for a customizable fallback option.

---

### Summary of Changes

- **Current Behavior:** Fallback to `files.encoding` when encoding cannot be detected.
- **New Behavior:** Fallback to the last entry in `files.candidateGuessEncodings` array.

### Reasoning

- **Flexibility:** Allows for a customizable fallback option.
- **Intuitiveness:** Aligns the behavior with user expectations for encoding fallback.

---