### PR TITLE
Fix HC textPreformat colors

### DIFF
--- a/src/vs/platform/theme/common/colors/baseColors.ts
+++ b/src/vs/platform/theme/common/colors/baseColors.ts
@@ -65,7 +65,7 @@ export const textSeparatorForeground = registerColor('textSeparator.foreground',
 // ------ text preformat
 
 export const textPreformatForeground = registerColor('textPreformat.foreground',
-	{ light: '#A31515', dark: '#D7BA7D', hcDark: '#FFFFFF', hcLight: '#000000' },
+	{ light: '#A31515', dark: '#D7BA7D', hcDark: '#000000', hcLight: '#FFFFFF' },
 	nls.localize('textPreformatForeground', "Foreground color for preformatted text segments."));
 
 export const textPreformatBackground = registerColor('textPreformat.background',

--- a/src/vs/workbench/contrib/welcomeWalkthrough/browser/media/walkThroughPart.css
+++ b/src/vs/workbench/contrib/welcomeWalkthrough/browser/media/walkThroughPart.css
@@ -153,6 +153,8 @@
 .monaco-workbench .part.editor > .content .walkThroughContent code,
 .monaco-workbench .part.editor > .content .walkThroughContent .shortcut {
 	color: var(--vscode-textPreformat-foreground);
+	background-color: var(--vscode-textPreformat-background);
+	border-radius: 3px;
 }
 
 .monaco-workbench .part.editor > .content .walkThroughContent .monaco-editor {


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/214412

I originally reversed these colors in https://github.com/microsoft/vscode/pull/213698 to address an issue with invisible shortcuts in the editor playground. 

Seems like `textPreformat.foreground` needs to be used with `textPreformat.background` to be visible.