### PR TITLE
remove giant unused context key

### DIFF
--- a/extensions/ipynb/src/ipynbMain.ts
+++ b/extensions/ipynb/src/ipynbMain.ts
@@ -117,13 +117,6 @@ export function activate(context: vscode.ExtensionContext) {
 		context.subscriptions.push(cleaner);
 	}
 
-	// Update new file contribution
-	vscode.extensions.onDidChange(() => {
-		vscode.commands.executeCommand('setContext', 'jupyterEnabled', vscode.extensions.getExtension('ms-toolsai.jupyter'));
-	});
-	vscode.commands.executeCommand('setContext', 'jupyterEnabled', vscode.extensions.getExtension('ms-toolsai.jupyter'));
-
-
 	return {
 		get dropCustomMetadata() {
 			return !useCustomPropertyInMetadata();


### PR DESCRIPTION
fix https://github.com/microsoft/vscode/issues/214503

there are no usages of the key in vscode, and the [PR that introduced it](https://github.com/microsoft/vscode/commit/4b17d05668b39a92725d67d7a90df070898edf92) doesn't have other references to it