### PR TITLE
updated config to electron 29 and ES2020 for modern JS

### DIFF
--- a/build/tsconfig.build.json
+++ b/build/tsconfig.build.json
@@ -1,15 +1,29 @@
 {
-	"extends": "./tsconfig.json",
-	"compilerOptions": {
-		"allowJs": false,
-		"checkJs": false,
-		"noEmit": false,
-		"skipLibCheck": true
-	},
-	"include": [
-		"**/*.ts"
-	],
-	"exclude": [
-		"lib/eslint-plugin-vscode/**/*"
-	]
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "allowJs": false,
+        "checkJs": false,
+        "noEmit": false,
+        "skipLibCheck": true,
+        "target": "ES2020",
+        "module": "commonjs",
+        "lib": ["ES2020", "DOM"],
+        "strict": true,
+        "noImplicitAny": true,
+        "moduleResolution": "node",
+        "outDir": "./dist",
+        "baseUrl": ".",
+        "paths": {
+            "*": ["node_modules/*"]
+        },
+        "types": ["node", "electron"]
+    },
+    "include": [
+        "**/*.ts"
+    ],
+    "exclude": [
+        "lib/eslint-plugin-vscode/**/*",
+        "node_modules",
+        "dist"
+    ]
 }


### PR DESCRIPTION
Updated to be with electron 29, and added additional support for modern JS features, added node and electron types, and .dist outdir.