### PR TITLE
Disable api-test extension when running code.sh directly

### DIFF
--- a/scripts/code.bat
+++ b/scripts/code.bat
@@ -23,9 +23,16 @@ set VSCODE_CLI=1
 set ELECTRON_ENABLE_LOGGING=1
 set ELECTRON_ENABLE_STACK_DUMPING=1
 
+set DISABLE_TEST_EXTENSION="--disable-extension=vscode.vscode-api-tests"
+for %%A in (%*) do (
+	if "%%~A"=="--extensionTestsPath" (
+		set DISABLE_TEST_EXTENSION=""
+	)
+)
+
 :: Launch Code
 
-%CODE% . %*
+%CODE% . %DISABLE_TEST_EXTENSION% %*
 goto end
 
 :builtin

--- a/scripts/code.sh
+++ b/scripts/code.sh
@@ -42,8 +42,13 @@ function code() {
 	export ELECTRON_ENABLE_STACK_DUMPING=1
 	export ELECTRON_ENABLE_LOGGING=1
 
+	DISABLE_TEST_EXTENSION="--disable-extension=vscode.vscode-api-tests"
+	if [[ "$@" == *"--extensionTestsPath"* ]]; then
+		DISABLE_TEST_EXTENSION=""
+	fi
+
 	# Launch Code
-	exec "$CODE" . "$@"
+	exec "$CODE" . $DISABLE_TEST_EXTENSION "$@"
 }
 
 function code-wsl()


### PR DESCRIPTION
Need this because having the default chat participant from vscode-api-tests active when running OSS messes things up- there can only be one default participant and I can't find a reasonable way to handle having two. And I think people just don't expect to have all the api test contributions present when debugging OSS.