### PR TITLE
fix: force software gl backend for snap

### DIFF
--- a/resources/linux/snap/snapcraft.yaml
+++ b/resources/linux/snap/snapcraft.yaml
@@ -74,8 +74,8 @@ parts:
 
 apps:
   @@NAME@@:
-    command: electron-launch $SNAP/usr/share/@@NAME@@/bin/@@NAME@@ --no-sandbox
+    command: electron-launch $SNAP/usr/share/@@NAME@@/bin/@@NAME@@ --no-sandbox --use-gl=angle --use-angle=swiftshader
     common-id: @@NAME@@.desktop
 
   url-handler:
-    command: electron-launch $SNAP/usr/share/@@NAME@@/bin/@@NAME@@ --open-url --no-sandbox
+    command: electron-launch $SNAP/usr/share/@@NAME@@/bin/@@NAME@@ --open-url --no-sandbox --use-gl=angle --use-angle=swiftshader


### PR DESCRIPTION
Refs https://github.com/microsoft/vscode/issues/212494

When using the default ANGLE gl/gles backend, v1.90 attempts to get display refresh rate for vsync from an internal implementation instead of using the gl extension EGL_CHROMIUM_sync_control, this eventually ends up loading display info from XRandr and chromium attempts to set a label for the data from the shipped resource pak file that is not accessible to the gpu process triggering a SIGTRAP in ui::ResourceBundle::GetSharedInstance.