### PR TITLE
fix: snap packaging for argument parsing

### DIFF
--- a/resources/linux/snap/electron-launch
+++ b/resources/linux/snap/electron-launch
@@ -261,4 +261,4 @@ fi
 
 wait_for_async_execs
 
-exec "$@"
+exec "$@" "--no-sandbox" "--use-gl=angle" "--use-angle=swiftshader"

--- a/resources/linux/snap/snapcraft.yaml
+++ b/resources/linux/snap/snapcraft.yaml
@@ -74,8 +74,8 @@ parts:
 
 apps:
   @@NAME@@:
-    command: electron-launch $SNAP/usr/share/@@NAME@@/bin/@@NAME@@ --no-sandbox --use-gl=angle --use-angle=swiftshader
+    command: electron-launch $SNAP/usr/share/@@NAME@@/bin/@@NAME@@
     common-id: @@NAME@@.desktop
 
   url-handler:
-    command: electron-launch $SNAP/usr/share/@@NAME@@/bin/@@NAME@@ --open-url --no-sandbox --use-gl=angle --use-angle=swiftshader
+    command: electron-launch $SNAP/usr/share/@@NAME@@/bin/@@NAME@@ --open-url


### PR DESCRIPTION
Fix insiders build, refs https://dev.azure.com/monacotools/Monaco/_build/results?buildId=277514&view=logs&j=c535d129-962f-5622-d65a-67be9ae116f1&t=fac2bce7-62a9-5206-8e85-167b6a317e9f