### PR TITLE
Keyboard Shortcuts: allow editing when expression with double click

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/keybindingsEditor.ts
+++ b/src/vs/workbench/contrib/preferences/browser/keybindingsEditor.ts
@@ -536,7 +536,12 @@ export class KeybindingsEditor extends EditorPane implements IKeybindingsEditorP
 			}
 			const activeKeybindingEntry = this.activeKeybindingEntry;
 			if (activeKeybindingEntry) {
-				this.defineKeybinding(activeKeybindingEntry, false);
+				const target = e.browserEvent?.target;
+				if (DOM.isHTMLElement(target) && target.closest('.when')) {
+					this.defineWhenExpression(activeKeybindingEntry);
+				} else {
+					this.defineKeybinding(activeKeybindingEntry, false);
+				}
 			}
 		}));
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

In Keyboard Shortcuts, we can double click a line to edit the shortcut. Many times now I double clicked the when expression to edit that, but that wasn't the way. With this PR, if you double click on the when expression, you start editing that, rather than setting the keyboard shortcut.