### PR TITLE
Activate configuration-editing extension when jsonc files are opened

### DIFF
--- a/extensions/configuration-editing/package.json
+++ b/extensions/configuration-editing/package.json
@@ -11,7 +11,9 @@
   "icon": "images/icon.png",
   "activationEvents": [
     "onProfile",
-    "onProfile:github"
+    "onProfile:github",
+    "onLanguage:json",
+    "onLanguage:jsonc"
   ],
   "enabledApiProposals": [
     "profileContentHandlers"


### PR DESCRIPTION
Fix #182700

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
