### PR TITLE
fix: fix microsoft#214741 declare vscode capbility on linux properly

### DIFF
--- a/resources/linux/code.desktop
+++ b/resources/linux/code.desktop
@@ -8,7 +8,7 @@ Type=Application
 StartupNotify=false
 StartupWMClass=@@NAME_SHORT@@
 Categories=TextEditor;Development;IDE;
-MimeType=application/x-@@NAME@@-workspace;
+MimeType=application/x-@@NAME@@-workspace;text/plain;
 Actions=new-empty-window;
 Keywords=vscode;
 


### PR DESCRIPTION
VS Code is a versatile text editor, and it's essential to properly declare its capabilities. Not only were plain text files be recognized as text/plain, but also coding files like .go, .php, .py, etc., which are a primary focus of VS Code. We definitely need VS Code to appear in the candidate list when opening these files.

Any discussions/suggestions are welcomed.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
