### PR TITLE
Only rely on terminal backend for process support

### DIFF
--- a/src/vs/platform/terminal/common/terminal.ts
+++ b/src/vs/platform/terminal/common/terminal.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Event } from 'vs/base/common/event';
+import { Emitter, Event } from 'vs/base/common/event';
 import { IProcessEnvironment, OperatingSystem } from 'vs/base/common/platform';
 import { URI, UriComponents } from 'vs/base/common/uri';
 import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
@@ -1054,11 +1054,21 @@ function sanitizeRemoteAuthority(remoteAuthority: string | undefined) {
 	return remoteAuthority?.toLowerCase() ?? '';
 }
 
+export class TerminalBackendChangeEvent {
+	constructor(public readonly remoteAuthority: string | undefined) { }
+
+	public affects(remoteAuthority?: string): boolean {
+		return sanitizeRemoteAuthority(remoteAuthority) === this.remoteAuthority;
+	}
+}
+
 export interface ITerminalBackendRegistry {
 	/**
 	 * Gets all backends in the registry.
 	 */
 	backends: ReadonlyMap<string, ITerminalBackend>;
+
+	onDidChangeBackends: Event<TerminalBackendChangeEvent>;
 
 	/**
 	 * Registers a terminal backend for a remote authority.
@@ -1076,12 +1086,16 @@ class TerminalBackendRegistry implements ITerminalBackendRegistry {
 
 	get backends(): ReadonlyMap<string, ITerminalBackend> { return this._backends; }
 
+	private _onDidChangeBackends = new Emitter<TerminalBackendChangeEvent>();
+	readonly onDidChangeBackends: Event<TerminalBackendChangeEvent> = this._onDidChangeBackends.event;
+
 	registerTerminalBackend(backend: ITerminalBackend): void {
 		const key = sanitizeRemoteAuthority(backend.remoteAuthority);
 		if (this._backends.has(key)) {
 			throw new Error(`A terminal backend with remote authority '${key}' was already registered.`);
 		}
 		this._backends.set(key, backend);
+		this._onDidChangeBackends.fire(new TerminalBackendChangeEvent(key));
 	}
 
 	getTerminalBackend(remoteAuthority: string | undefined): ITerminalBackend | undefined {

--- a/src/vs/platform/terminal/common/terminal.ts
+++ b/src/vs/platform/terminal/common/terminal.ts
@@ -1049,6 +1049,11 @@ export const TerminalExtensions = {
 	Backend: 'workbench.contributions.terminal.processBackend'
 };
 
+function sanitizeRemoteAuthority(remoteAuthority: string | undefined) {
+	// Normalize the key to lowercase as the authority is case-insensitive
+	return remoteAuthority?.toLowerCase() ?? '';
+}
+
 export interface ITerminalBackendRegistry {
 	/**
 	 * Gets all backends in the registry.
@@ -1072,7 +1077,7 @@ class TerminalBackendRegistry implements ITerminalBackendRegistry {
 	get backends(): ReadonlyMap<string, ITerminalBackend> { return this._backends; }
 
 	registerTerminalBackend(backend: ITerminalBackend): void {
-		const key = this._sanitizeRemoteAuthority(backend.remoteAuthority);
+		const key = sanitizeRemoteAuthority(backend.remoteAuthority);
 		if (this._backends.has(key)) {
 			throw new Error(`A terminal backend with remote authority '${key}' was already registered.`);
 		}
@@ -1080,12 +1085,7 @@ class TerminalBackendRegistry implements ITerminalBackendRegistry {
 	}
 
 	getTerminalBackend(remoteAuthority: string | undefined): ITerminalBackend | undefined {
-		return this._backends.get(this._sanitizeRemoteAuthority(remoteAuthority));
-	}
-
-	private _sanitizeRemoteAuthority(remoteAuthority: string | undefined) {
-		// Normalize the key to lowercase as the authority is case-insensitive
-		return remoteAuthority?.toLowerCase() ?? '';
+		return this._backends.get(sanitizeRemoteAuthority(remoteAuthority));
 	}
 }
 Registry.add(TerminalExtensions.Backend, new TerminalBackendRegistry());

--- a/src/vs/workbench/contrib/terminal/browser/terminalService.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalService.ts
@@ -880,7 +880,7 @@ export class TerminalService extends Disposable implements ITerminalService {
 	}
 
 	registerProcessSupport(isSupported: boolean): void {
-		if (!isSupported) {
+		if (!isSupported || this._processSupportContextKey.get()) {
 			return;
 		}
 		this._processSupportContextKey.set(isSupported);

--- a/src/vs/workbench/contrib/terminal/browser/terminalService.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalService.ts
@@ -19,7 +19,7 @@ import { IContextKey, IContextKeyService } from 'vs/platform/contextkey/common/c
 import { IDialogService } from 'vs/platform/dialogs/common/dialogs';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { INotificationService } from 'vs/platform/notification/common/notification';
-import { ICreateContributedTerminalProfileOptions, IExtensionTerminalProfile, IPtyHostAttachTarget, IRawTerminalInstanceLayoutInfo, IRawTerminalTabLayoutInfo, IShellLaunchConfig, ITerminalBackend, ITerminalLaunchError, ITerminalLogService, ITerminalsLayoutInfo, ITerminalsLayoutInfoById, TerminalExitReason, TerminalLocation, TerminalLocationString, TitleEventSource } from 'vs/platform/terminal/common/terminal';
+import { ICreateContributedTerminalProfileOptions, IExtensionTerminalProfile, IPtyHostAttachTarget, IRawTerminalInstanceLayoutInfo, IRawTerminalTabLayoutInfo, IShellLaunchConfig, ITerminalBackend, ITerminalBackendRegistry, ITerminalLaunchError, ITerminalLogService, ITerminalsLayoutInfo, ITerminalsLayoutInfoById, TerminalExitReason, TerminalExtensions, TerminalLocation, TerminalLocationString, TitleEventSource } from 'vs/platform/terminal/common/terminal';
 import { formatMessageForTerminal } from 'vs/platform/terminal/common/terminalStrings';
 import { iconForeground } from 'vs/platform/theme/common/colorRegistry';
 import { getIconRegistry } from 'vs/platform/theme/common/iconRegistry';
@@ -53,6 +53,7 @@ import { TerminalCapabilityStore } from 'vs/platform/terminal/common/capabilitie
 import { ITimerService } from 'vs/workbench/services/timer/browser/timerService';
 import { mark } from 'vs/base/common/performance';
 import { DetachedTerminal } from 'vs/workbench/contrib/terminal/browser/detachedTerminal';
+import { Registry } from 'vs/platform/registry/common/platform';
 import { ITerminalCapabilityImplMap, TerminalCapability } from 'vs/platform/terminal/common/capabilities/capabilities';
 import { createInstanceCapabilityEventMultiplexer } from 'vs/workbench/contrib/terminal/browser/terminalEvents';
 import { mainWindow } from 'vs/base/browser/window';
@@ -216,7 +217,14 @@ export class TerminalService extends Disposable implements ITerminalService {
 		this._handleInstanceContextKeys();
 		this._terminalShellTypeContextKey = TerminalContextKeys.shellType.bindTo(this._contextKeyService);
 		this._processSupportContextKey = TerminalContextKeys.processSupported.bindTo(this._contextKeyService);
-		this._processSupportContextKey.set(!isWeb || this._remoteAgentService.getConnection() !== null);
+
+		const backendRegistry = Registry.as<ITerminalBackendRegistry>(TerminalExtensions.Backend);
+		this._processSupportContextKey.set(backendRegistry.getTerminalBackend(_remoteAgentService.getConnection()?.remoteAuthority) !== undefined);
+		this._register(backendRegistry.onDidChangeBackends((e) => {
+			if (e.affects(_remoteAgentService.getConnection()?.remoteAuthority)) {
+				this.registerProcessSupport(backendRegistry.getTerminalBackend(_remoteAgentService.getConnection()?.remoteAuthority) !== undefined);
+			}
+		}));
 		this._terminalHasBeenCreated = TerminalContextKeys.terminalHasBeenCreated.bindTo(this._contextKeyService);
 		this._terminalCountContextKey = TerminalContextKeys.count.bindTo(this._contextKeyService);
 		this._terminalEditorActive = TerminalContextKeys.terminalEditorActive.bindTo(this._contextKeyService);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Instead of checking `!isWeb || this._remoteAgentService.getConnection() !== null` to enable process support, directly check the registered terminal backend

There is no expected change or bugfix. it just makes it so if something else (in a fork) registers a terminal backend in a web environment, the process support will be enabled