### PR TITLE
Add file extensions for C++20 module interface units

### DIFF
--- a/extensions/cpp/package.json
+++ b/extensions/cpp/package.json
@@ -30,9 +30,13 @@
         "id": "cpp",
         "extensions": [
           ".cpp",
+          ".cppm",
           ".cc",
+          ".ccm",
           ".cxx",
+          ".cxxm",
           ".c++",
+          ".c++m",
           ".hpp",
           ".hh",
           ".hxx",


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Since C++20 introduced modules, some new file extensions are introduced alongside. For some of the new extensions, please refer to https://stackoverflow.com/a/76422027/20143641.

This PR adds the functionality for VS Code to automatically recognize source files with such extensions as C++ source files.

To test the changes, simply create a new file with extension:
- `cppm`
- `ccm`
- `c++m`
- `cxxm`

via  VS Code file explorer and observe that C++ is automatically detected as the language.

This PR doesn't seem to resolve any issues.