### PR TITLE
Revert Locker schedule to run once a day

### DIFF
--- a/.github/workflows/locker.yml
+++ b/.github/workflows/locker.yml
@@ -1,7 +1,7 @@
 name: Locker
 on:
   schedule:
-    - cron: 20 * * * * # run on the 20th minute of every hour
+    - cron: 20 23 * * * # 4:20pm Redmond
   repository_dispatch:
     types: [trigger-locker]
 


### PR DESCRIPTION
We're all caught up with the backlog of lockers that need to be cleaned. We can revert the Locker schedule to run once a day. 