### PR TITLE
Make sure any status bar item created by extension has meaningful id

### DIFF
--- a/src/vs/workbench/api/common/extHostStatusBar.ts
+++ b/src/vs/workbench/api/common/extHostStatusBar.ts
@@ -63,9 +63,8 @@ export class ExtHostStatusBarEntry implements vscode.StatusBarItem {
 		this.#proxy = proxy;
 		this.#commands = commands;
 
-		id = id ?? 'status';
-		if (id && extension) {
-			this._entryId = asStatusBarItemIdentifier(extension.identifier, id);
+		if (extension) {
+			this._entryId = id ? asStatusBarItemIdentifier(extension.identifier, id) : extension.identifier;
 			// if new item already exists mark it as visible and copy properties
 			// this can only happen when an item was contributed by an extension
 			const item = staticItems.get(this._entryId);

--- a/src/vs/workbench/api/common/extHostStatusBar.ts
+++ b/src/vs/workbench/api/common/extHostStatusBar.ts
@@ -64,7 +64,7 @@ export class ExtHostStatusBarEntry implements vscode.StatusBarItem {
 		this.#commands = commands;
 
 		if (extension) {
-			this._entryId = id ? asStatusBarItemIdentifier(extension.identifier, id) : extension.identifier;
+			this._entryId = id ? asStatusBarItemIdentifier(extension.identifier, id) : extension.identifier.value;
 			// if new item already exists mark it as visible and copy properties
 			// this can only happen when an item was contributed by an extension
 			const item = staticItems.get(this._entryId);

--- a/src/vs/workbench/api/common/extHostStatusBar.ts
+++ b/src/vs/workbench/api/common/extHostStatusBar.ts
@@ -63,6 +63,7 @@ export class ExtHostStatusBarEntry implements vscode.StatusBarItem {
 		this.#proxy = proxy;
 		this.#commands = commands;
 
+		id = id ?? 'status';
 		if (id && extension) {
 			this._entryId = asStatusBarItemIdentifier(extension.identifier, id);
 			// if new item already exists mark it as visible and copy properties


### PR DESCRIPTION
If an extension does not specify the id of the status bar item, it still makes sense to generate the identifier that includes extension id. Otherwise, in case of multiple extension hosts, it is possibile that during the initialization, different extension hosts may generate the same sequential id and one of the status bar items will not be visible.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
