### PR TITLE
fix #214424

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/debugService.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugService.ts
@@ -204,8 +204,8 @@ export class DebugService implements IDebugService {
 
 		this.disposables.add(extensionService.onWillStop(evt => {
 			evt.veto(
-				this.stopSession(undefined).then(() => false),
-				nls.localize('stoppingDebug', 'Stopping debug sessions...'),
+				this.model.getSessions().length > 0,
+				nls.localize('active debub session', 'An active debug session is running.'),
 			);
 		}));
 

--- a/src/vs/workbench/contrib/debug/browser/debugService.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugService.ts
@@ -205,7 +205,7 @@ export class DebugService implements IDebugService {
 		this.disposables.add(extensionService.onWillStop(evt => {
 			evt.veto(
 				this.model.getSessions().length > 0,
-				nls.localize('active debub session', 'An active debug session is running.'),
+				nls.localize('active debug session', 'A debug session is still running.'),
 			);
 		}));
 

--- a/src/vs/workbench/contrib/extensions/common/extensions.ts
+++ b/src/vs/workbench/contrib/extensions/common/extensions.ts
@@ -163,6 +163,7 @@ export const ConfigurationKey = 'extensions';
 export const AutoUpdateConfigurationKey = 'extensions.autoUpdate';
 export const AutoCheckUpdatesConfigurationKey = 'extensions.autoCheckUpdates';
 export const CloseExtensionDetailsOnViewChangeKey = 'extensions.closeExtensionDetailsOnViewChange';
+export const AutoRestartConfigurationKey = 'extensions.autoRestart';
 
 export type AutoUpdateConfigurationValue = boolean | 'onlyEnabledExtensions' | 'onlySelectedExtensions';
 

--- a/src/vs/workbench/services/extensions/common/abstractExtensionService.ts
+++ b/src/vs/workbench/services/extensions/common/abstractExtensionService.ts
@@ -704,11 +704,10 @@ export abstract class AbstractExtensionService extends Disposable implements IEx
 		if (!veto) {
 			this._doStopExtensionHosts();
 		} else {
-			const vetoReasonsArray = Array.from(vetoReasons);
-
-			this._logService.warn(`Extension host was not stopped because of veto (stop reason: ${reason}, veto reason: ${vetoReasonsArray.join(', ')})`);
-
 			if (!auto) {
+				const vetoReasonsArray = Array.from(vetoReasons);
+
+				this._logService.warn(`Extension host was not stopped because of veto (stop reason: ${reason}, veto reason: ${vetoReasonsArray.join(', ')})`);
 				await this._dialogService.warn(
 					nls.localize('extensionStopVetoMessage', "The following operation was blocked: {0}", reason),
 					vetoReasonsArray.length === 1 ?

--- a/src/vs/workbench/services/extensions/common/abstractExtensionService.ts
+++ b/src/vs/workbench/services/extensions/common/abstractExtensionService.ts
@@ -653,8 +653,8 @@ export abstract class AbstractExtensionService extends Disposable implements IEx
 
 	//#region Stopping / Starting / Restarting
 
-	public stopExtensionHosts(reason: string): Promise<boolean> {
-		return this._doStopExtensionHostsWithVeto(reason);
+	public stopExtensionHosts(reason: string, auto?: boolean): Promise<boolean> {
+		return this._doStopExtensionHostsWithVeto(reason, auto);
 	}
 
 	protected _doStopExtensionHosts(): void {
@@ -675,7 +675,7 @@ export abstract class AbstractExtensionService extends Disposable implements IEx
 		}
 	}
 
-	private async _doStopExtensionHostsWithVeto(reason: string): Promise<boolean> {
+	private async _doStopExtensionHostsWithVeto(reason: string, auto?: boolean): Promise<boolean> {
 		const vetos: (boolean | Promise<boolean>)[] = [];
 		const vetoReasons = new Set<string>();
 
@@ -708,12 +708,15 @@ export abstract class AbstractExtensionService extends Disposable implements IEx
 
 			this._logService.warn(`Extension host was not stopped because of veto (stop reason: ${reason}, veto reason: ${vetoReasonsArray.join(', ')})`);
 
-			await this._dialogService.warn(
-				nls.localize('extensionStopVetoMessage', "The following operation was blocked: {0}", reason),
-				vetoReasonsArray.length === 1 ?
-					nls.localize('extensionStopVetoDetailsOne', "The reason for blocking the operation: {0}", vetoReasonsArray[0]) :
-					nls.localize('extensionStopVetoDetailsMany', "The reasons for blocking the operation:\n- {0}", vetoReasonsArray.join('\n -')),
-			);
+			if (!auto) {
+				await this._dialogService.warn(
+					nls.localize('extensionStopVetoMessage', "The following operation was blocked: {0}", reason),
+					vetoReasonsArray.length === 1 ?
+						nls.localize('extensionStopVetoDetailsOne', "The reason for blocking the operation: {0}", vetoReasonsArray[0]) :
+						nls.localize('extensionStopVetoDetailsMany', "The reasons for blocking the operation:\n- {0}", vetoReasonsArray.join('\n -')),
+				);
+			}
+
 		}
 
 		return !veto;

--- a/src/vs/workbench/services/extensions/common/extensions.ts
+++ b/src/vs/workbench/services/extensions/common/extensions.ts
@@ -513,10 +513,12 @@ export interface IExtensionService {
 	 * @param reason a human readable reason for stopping the extension hosts. This maybe
 	 * can be presented to the user when showing dialogs.
 	 *
+	 * @param auto indicates if the operation was triggered by an automatic action
+	 *
 	 * @returns a promise that resolves to `true` if the extension hosts were stopped, `false`
 	 * if the operation was vetoed by listeners of the `onWillStop` event.
 	 */
-	stopExtensionHosts(reason: string): Promise<boolean>;
+	stopExtensionHosts(reason: string, auto?: boolean): Promise<boolean>;
 
 	/**
 	 * Starts the extension hosts. If updates are provided, the extension hosts are started with the given updates.


### PR DESCRIPTION
- Added a setting to auto restart extensions following updates when window is not focused. This is enabled by default in insiders.
- Changed Debug behavior to always veto if there are active sessions. I believe debug should show a veto dialog instead of silently stopping the sessions
- Added `auto` parameter to not to show veto dialog if restarting extensions is an automatic operation.