### PR TITLE
Restrict copy/paste with imports to TS 5.6+

### DIFF
--- a/extensions/typescript-language-features/package.nls.json
+++ b/extensions/typescript-language-features/package.nls.json
@@ -219,7 +219,7 @@
 	"configuration.tsserver.web.projectWideIntellisense.suppressSemanticErrors": "Suppresses semantic errors on web even when project wide IntelliSense is enabled. This is always on when project wide IntelliSense is not enabled or available. See `#typescript.tsserver.web.projectWideIntellisense.enabled#`",
 	"configuration.tsserver.web.typeAcquisition.enabled": "Enable/disable package acquisition on the web. This enables IntelliSense for imported packages. Requires `#typescript.tsserver.web.projectWideIntellisense.enabled#`. Currently not supported for Safari.",
 	"configuration.tsserver.nodePath": "Run TS Server on a custom Node installation. This can be a path to a Node executable, or 'node' if you want VS Code to detect a Node installation.",
-	"configuration.updateImportsOnPaste": "Automatically update imports when pasting code. Requires TypeScript 5.5+.",
+	"configuration.updateImportsOnPaste": "Automatically update imports when pasting code. Requires TypeScript 5.6+.",
 	"walkthroughs.nodejsWelcome.title": "Get started with JavaScript and Node.js",
 	"walkthroughs.nodejsWelcome.description": "Make the most of Visual Studio Code's first-class JavaScript experience.",
 	"walkthroughs.nodejsWelcome.downloadNode.forMacOrWindows.title": "Install Node.js",

--- a/extensions/typescript-language-features/src/languageFeatures/copyPaste.ts
+++ b/extensions/typescript-language-features/src/languageFeatures/copyPaste.ts
@@ -61,7 +61,7 @@ class DocumentPasteProvider implements vscode.DocumentPasteEditProvider {
 		token: vscode.CancellationToken,
 	): Promise<vscode.DocumentPasteEdit[] | undefined> {
 		const config = vscode.workspace.getConfiguration(this._modeId, document.uri);
-		if (!config.get('experimental.updateImportsOnPaste')) {
+		if (!config.get('experimental.updateImportsOnPaste', false)) {
 			return;
 		}
 
@@ -91,6 +91,10 @@ class DocumentPasteProvider implements vscode.DocumentPasteEditProvider {
 			if (copyFile) {
 				copiedFrom = { file: copyFile, spans };
 			}
+		}
+
+		if (copiedFrom?.file === file) {
+			return;
 		}
 
 		const response = await this._client.execute('getPasteEdits', {
@@ -126,7 +130,7 @@ class DocumentPasteProvider implements vscode.DocumentPasteEditProvider {
 export function register(selector: DocumentSelector, language: LanguageDescription, client: ITypeScriptServiceClient) {
 	return conditionalRegistration([
 		requireSomeCapability(client, ClientCapability.Semantic),
-		requireMinVersion(client, API.v550),
+		requireMinVersion(client, API.v560),
 	], () => {
 		return vscode.languages.registerDocumentPasteEditProvider(selector.semantic, new DocumentPasteProvider(language.id, client), {
 			providedPasteEditKinds: [DocumentPasteProvider.kind],

--- a/extensions/typescript-language-features/src/tsServer/api.ts
+++ b/extensions/typescript-language-features/src/tsServer/api.ts
@@ -38,6 +38,7 @@ export class API {
 	public static readonly v544 = API.fromSimpleString('5.4.4');
 	public static readonly v540 = API.fromSimpleString('5.4.0');
 	public static readonly v550 = API.fromSimpleString('5.5.0');
+	public static readonly v560 = API.fromSimpleString('5.6.0');
 
 	public static fromVersionString(versionString: string): API {
 		let version = semver.valid(versionString);


### PR DESCRIPTION
Also skips when the copied file is the same as the paste file

