### PR TITLE
Use node 20 in dev container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/devcontainers/typescript-node:18-bookworm
+FROM mcr.microsoft.com/devcontainers/typescript-node:20-bookworm
 
 ADD install-vscode.sh /root/
 RUN /root/install-vscode.sh


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fixes https://github.com/microsoft/vscode/issues/215432

| Before | After |
|--|--|
|![image](https://github.com/microsoft/vscode/assets/1149641/47d32716-3a97-4ef4-8690-b94b3de56287)|![image](https://github.com/microsoft/vscode/assets/1149641/ea377319-97a0-4d7e-b9ad-1dc1c96f134e)|

Running `yarn install` requires node 20, but our typescript dev container base image uses node 18.

This PR just updates it to `typescript-node:20-bookworm`

### Tests
I've run the following in my dev container, and it seems to work fine.
 - [x] ESLint (`yarn eslint`)
 - [x] Unit tests (`./scripts/test.sh`)
 - [x] Automated smoke tests (`yarn smoketest`)
 