### PR TITLE
Update treesitter parsing with text buffer chunk api

### DIFF
--- a/src/vs/editor/browser/services/treeSitter/treeSitterParserService.ts
+++ b/src/vs/editor/browser/services/treeSitter/treeSitterParserService.ts
@@ -14,7 +14,6 @@ import { IFileService } from 'vs/platform/files/common/files';
 import { IModelContentChangedEvent, IModelLanguageChangedEvent } from 'vs/editor/common/textModelEvents';
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 import { ILogService } from 'vs/platform/log/common/log';
-import { Range } from 'vs/editor/common/core/range';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { setTimeout0 } from 'vs/base/common/platform';
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Introduced a new `getNearChunk` api to get the minimal text after `index` offset. Adopted this in branch https://github.com/microsoft/vscode/tree/alexr00/gettingStartedWithTreeSitter and I can see the perf difference for editing

_Before_

<img width="602" alt="image" src="https://github.com/user-attachments/assets/230bfa14-bfdb-4819-b92e-18ada2165c36">


_After_

<img width="589" alt="image" src="https://github.com/user-attachments/assets/f9c1759f-edb5-4178-95f2-8a33d35686e1">

---


@alexr00 I tried to adopt this change in https://github.com/microsoft/vscode/pull/213565 but I didn't see the incremental parsing, even a single type will trigger the whole document to be re-parsed (from index: 0). We can catch up and see what's going on and what else you potentially need from the text buffer side.
