### PR TITLE
Fix #215544. Fix notebook scoped instantiation service.

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/services/notebookEditorServiceImpl.ts
+++ b/src/vs/workbench/contrib/notebook/browser/services/notebookEditorServiceImpl.ts
@@ -19,6 +19,8 @@ import { URI } from 'vs/base/common/uri';
 import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
 import { IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 import { InteractiveWindowOpen } from 'vs/workbench/contrib/notebook/common/notebookContextKeys';
+import { ServiceCollection } from 'vs/platform/instantiation/common/serviceCollection';
+import { IEditorProgressService } from 'vs/platform/progress/common/progress';
 
 export class NotebookEditorWidgetService implements INotebookEditorService {
 
@@ -39,7 +41,8 @@ export class NotebookEditorWidgetService implements INotebookEditorService {
 	constructor(
 		@IEditorGroupsService private readonly editorGroupService: IEditorGroupsService,
 		@IEditorService editorService: IEditorService,
-		@IContextKeyService contextKeyService: IContextKeyService
+		@IContextKeyService contextKeyService: IContextKeyService,
+		@IInstantiationService private readonly instantiationService: IInstantiationService
 	) {
 
 		const groupListener = new Map<number, IDisposable[]>();
@@ -182,9 +185,13 @@ export class NotebookEditorWidgetService implements INotebookEditorService {
 
 		if (!value) {
 			// NEW widget
-			const instantiationService = accessor.get(IInstantiationService);
+			const editorGroupContextKeyService = accessor.get(IContextKeyService);
+			const editorGroupEditorProgressService = accessor.get(IEditorProgressService);
+			const notebookInstantiationService = this.instantiationService.createChild(new ServiceCollection(
+				[IContextKeyService, editorGroupContextKeyService],
+				[IEditorProgressService, editorGroupEditorProgressService]));
 			const ctorOptions = creationOptions ?? getDefaultNotebookCreationOptions();
-			const widget = instantiationService.createInstance(NotebookEditorWidget, {
+			const widget = notebookInstantiationService.createInstance(NotebookEditorWidget, {
 				...ctorOptions,
 				codeWindow: codeWindow ?? ctorOptions.codeWindow,
 			}, initialDimension);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

The notebook editor widget used the instantiation service from the editor group view. When moving the widget between editor groups, we will reparent the scoped context key service, so the menus are still working fine. However if the editor group where the instantiation service originally come from is closed, the instantiation service will also be disposed. This is a change from https://github.com/microsoft/vscode/pull/209421. Previously we will continue to use a dangling instantiation service which is never disposed in time.

The fix is ensuring that we are creating the child instatiation service from the workbench one instead of the editor group one. Thus our child service won't be disposed when an editor group is disposed. The contextx key service is still reparented when moving between editor groups.

![image](https://github.com/user-attachments/assets/f277e721-c462-4748-ba9c-aa299b866d25)
