### PR TITLE
Revert "Don't merge a view with a titleDescription (fix #166000) (#214010)"

### DIFF
--- a/src/vs/workbench/browser/parts/views/viewPaneContainer.ts
+++ b/src/vs/workbench/browser/parts/views/viewPaneContainer.ts
@@ -1100,10 +1100,6 @@ export class ViewPaneContainer extends Component implements IViewPaneContainer {
 		if (!(this.options.mergeViewWithContainerWhenSingleView && this.paneItems.length === 1)) {
 			return false;
 		}
-		if (this.paneItems[0].pane.titleDescription) {
-			// Don't merge a view with a titleDescription. See #166000
-			return false;
-		}
 		if (!this.areExtensionsReady) {
 			if (this.visibleViewsCountFromCache === undefined) {
 				return this.paneItems[0].pane.isExpanded();


### PR DESCRIPTION
This reverts commit af1bd0264a4430575b16abf6f15fefbe497434dc.

fixes #214769