### PR TITLE
chore: pull in SDL scan as part of main build pipeline

### DIFF
--- a/build/azure-pipelines/product-build.yml
+++ b/build/azure-pipelines/product-build.yml
@@ -171,7 +171,7 @@ extends:
   parameters:
     sdl:
       tsa:
-        enabled: true
+        enabled: false
         config:
           codebaseName: 'devdiv_$(Build.Repository.Name)'
           serviceTreeID: '79c048b2-322f-4ed5-a1ea-252a1250e4b3'
@@ -181,6 +181,9 @@ extends:
           notificationAliases: ['monacotools@microsoft.com']
           validateToolOutput: None
           allTools: true
+      binskim:
+        analyzeTargetGlob: '$(Build.SourcesDirectory)/**.dll;$(Build.SourcesDirectory)/**.exe;$(Build.SourcesDirectory)/**.node'
+        symbolsPath: '$(agent.builddirectory)/scanbin/VSCode-win32-${{ parameters.VSCODE_ARCH }}/pdb'
       codeql:
         compiled:
           enabled: true

--- a/build/azure-pipelines/product-build.yml
+++ b/build/azure-pipelines/product-build.yml
@@ -315,6 +315,16 @@ extends:
                     VSCODE_QUALITY: ${{ variables.VSCODE_QUALITY }}
                     VSCODE_BUILD_WIN32_ARM64: ${{ parameters.VSCODE_BUILD_WIN32_ARM64 }}
 
+      - stage: CustomSDL
+        dependsOn: []
+        pool:
+          name: 1es-windows-2019-x64
+          os: windows
+          jobs:
+            - job: WindowsSDL
+              steps:
+                - template: build/azure-pipelines/sdl-scan.yml@self
+
       - ${{ if and(eq(parameters.VSCODE_COMPILE_ONLY, false), eq(variables['VSCODE_BUILD_STAGE_WINDOWS'], true)) }}:
         - stage: Windows
           dependsOn:

--- a/build/azure-pipelines/product-build.yml
+++ b/build/azure-pipelines/product-build.yml
@@ -322,6 +322,8 @@ extends:
           os: windows
           jobs:
             - job: WindowsSDL
+              variables:
+                - group: 'API Scan'
               steps:
                 - template: build/azure-pipelines/sdl-scan.yml@self
 

--- a/build/azure-pipelines/product-build.yml
+++ b/build/azure-pipelines/product-build.yml
@@ -182,7 +182,7 @@ extends:
           validateToolOutput: None
           allTools: true
       binskim:
-        analyzeTargetGlob: '$(Build.SourcesDirectory)/**.dll;$(Build.SourcesDirectory)/**.exe;$(Build.SourcesDirectory)/**.node'
+        analyzeTargetGlob: '$(agent.builddirectory)/scanbin/**.dll;$(agent.builddirectory)/scanbin/**.exe;$(agent.builddirectory)/scanbin/**.node'
         symbolsPath: '$(agent.builddirectory)/scanbin/VSCode-win32-x64/pdb'
       codeql:
         compiled:

--- a/build/azure-pipelines/product-build.yml
+++ b/build/azure-pipelines/product-build.yml
@@ -181,9 +181,6 @@ extends:
           notificationAliases: ['monacotools@microsoft.com']
           validateToolOutput: None
           allTools: true
-      binskim:
-        analyzeTargetGlob: '$(agent.builddirectory)/scanbin/**.dll;$(agent.builddirectory)/scanbin/**.exe;$(agent.builddirectory)/scanbin/**.node'
-        symbolsPath: '$(agent.builddirectory)/scanbin/VSCode-win32-x64/pdb'
       codeql:
         compiled:
           enabled: true

--- a/build/azure-pipelines/product-build.yml
+++ b/build/azure-pipelines/product-build.yml
@@ -320,12 +320,12 @@ extends:
         pool:
           name: 1es-windows-2019-x64
           os: windows
-          jobs:
-            - job: WindowsSDL
-              variables:
-                - group: 'API Scan'
-              steps:
-                - template: build/azure-pipelines/sdl-scan.yml@self
+        jobs:
+          - job: WindowsSDL
+            variables:
+              - group: 'API Scan'
+            steps:
+              - template: build/azure-pipelines/sdl-scan.yml@self
 
       - ${{ if and(eq(parameters.VSCODE_COMPILE_ONLY, false), eq(variables['VSCODE_BUILD_STAGE_WINDOWS'], true)) }}:
         - stage: Windows

--- a/build/azure-pipelines/product-build.yml
+++ b/build/azure-pipelines/product-build.yml
@@ -183,7 +183,7 @@ extends:
           allTools: true
       binskim:
         analyzeTargetGlob: '$(Build.SourcesDirectory)/**.dll;$(Build.SourcesDirectory)/**.exe;$(Build.SourcesDirectory)/**.node'
-        symbolsPath: '$(agent.builddirectory)/scanbin/VSCode-win32-${{ parameters.VSCODE_ARCH }}/pdb'
+        symbolsPath: '$(agent.builddirectory)/scanbin/VSCode-win32-x64/pdb'
       codeql:
         compiled:
           enabled: true

--- a/build/azure-pipelines/product-build.yml
+++ b/build/azure-pipelines/product-build.yml
@@ -171,7 +171,7 @@ extends:
   parameters:
     sdl:
       tsa:
-        enabled: false
+        enabled: true
         config:
           codebaseName: 'devdiv_$(Build.Repository.Name)'
           serviceTreeID: '79c048b2-322f-4ed5-a1ea-252a1250e4b3'

--- a/build/azure-pipelines/sdl-scan.yml
+++ b/build/azure-pipelines/sdl-scan.yml
@@ -6,22 +6,10 @@ parameters:
     displayName: "Custom NPM Registry"
     type: string
     default: "https://pkgs.dev.azure.com/monacotools/Monaco/_packaging/vscode/npm/registry/"
-  - name: SCAN_WINDOWS
-    displayName: "Scan Windows"
-    type: boolean
-    default: true
-  - name: SCAN_LINUX
-    displayName: "Scan Linux"
-    type: boolean
-    default: false
 
 variables:
   - name: NPM_REGISTRY
     value: ${{ parameters.NPM_REGISTRY }}
-  - name: SCAN_WINDOWS
-    value: ${{ eq(parameters.SCAN_WINDOWS, true) }}
-  - name: SCAN_LINUX
-    value: ${{ eq(parameters.SCAN_LINUX, true) }}
   - name: VSCODE_MIXIN_REPO
     value: microsoft/vscode-distro
   - name: skipComponentGovernanceDetection
@@ -30,27 +18,14 @@ variables:
     value: x64
   - name: VSCODE_ARCH
     value: x64
-  - name: Codeql.enabled
-    value: true
-  - name: Codeql.TSAEnabled
-    value: true
-  - name: Codeql.TSAOptionsPath
-    value: '$(Build.SourcesDirectory)\build\azure-pipelines\config\tsaoptions.json'
 
 stages:
   - stage: Windows
-    condition: eq(variables.SCAN_WINDOWS, 'true')
     pool: 1es-windows-2019-x64
     jobs:
       - job: WindowsJob
         timeoutInMinutes: 0
         steps:
-          - task: CredScan@3
-            continueOnError: true
-            inputs:
-              scanFolder: "$(Build.SourcesDirectory)"
-              outputFormat: "pre"
-
           - task: NodeTool@0
             inputs:
               versionSource: fromFile
@@ -91,9 +66,39 @@ stages:
             condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'), ne(variables['NPM_REGISTRY'], 'none'))
             displayName: Setup NPM Registry
 
-          - task: CodeQL3000Init@0
-            displayName: CodeQL Initialize
-            condition: eq(variables['Codeql.enabled'], 'True')
+          - pwsh: |
+              $includes = @'
+                {
+                  'target_defaults': {
+                    'conditions': [
+                      ['OS=="win"', {
+                        'msvs_configuration_attributes': {
+                          'SpectreMitigation': 'Spectre'
+                        },
+                        'msvs_settings': {
+                          'VCCLCompilerTool': {
+                            'AdditionalOptions': [
+                              '/Zi',
+                              '/FS'
+                            ],
+                          },
+                          'VCLinkerTool': {
+                            'AdditionalOptions': [
+                              '/profile'
+                            ]
+                          }
+                        }
+                      }]
+                    ]
+                  }
+                }
+              '@
+
+              if (!(Test-Path "~/.gyp")) {
+                mkdir "~/.gyp"
+              }
+              echo $includes > "~/.gyp/include.gypi"
+            displayName: Create include.gypi
 
           - powershell: |
               . build/azure-pipelines/win32/exec.ps1
@@ -124,20 +129,10 @@ stages:
           - powershell: yarn compile
             displayName: Compile
 
-          - task: CodeQL3000Finalize@0
-            displayName: CodeQL Finalize
-            condition: eq(variables['Codeql.enabled'], 'True')
-
           - powershell: yarn gulp "vscode-symbols-win32-$(VSCODE_ARCH)"
             env:
               GITHUB_TOKEN: "$(github-distro-mixin-password)"
             displayName: Download Symbols
-
-          - task: PSScriptAnalyzer@1
-            inputs:
-              Path: '$(Build.SourcesDirectory)'
-              Settings: required
-              Recurse: true
 
           - task: BinSkim@4
             inputs:
@@ -148,16 +143,27 @@ stages:
               AnalyzeTargetGlob: '$(agent.builddirectory)\scanbin\**.dll;$(agent.builddirectory)\scanbin\**.exe;$(agent.builddirectory)\scanbin\**.node'
               AnalyzeLocalSymbolDirectories: '$(agent.builddirectory)\scanbin\VSCode-win32-$(VSCODE_ARCH)\pdb'
 
-          - task: AntiMalware@4
+          - task: CopyFiles@2
+            displayName: 'Collect Symbols for API Scan'
             inputs:
-              InputType: Basic
-              ScanType: CustomScan
-              FileDirPath: '$(Build.SourcesDirectory)'
-              EnableServices: true
-              SupportLogOnError: false
-              TreatSignatureUpdateFailureAs: 'Warning'
-              SignatureFreshness: 'OneDay'
-              TreatStaleSignatureAs: 'Error'
+              SourceFolder: $(Agent.BuildDirectory)
+              Contents: 'scanbin\**\*.pdb'
+              TargetFolder: '$(agent.builddirectory)\symbols'
+              flattenFolders: true
+            condition: succeeded()
+
+          - task: APIScan@2
+            inputs:
+              softwareFolder: $(agent.builddirectory)\scanbin
+              softwareName: 'vscode-client'
+              softwareVersionNum: '1'
+              symbolsFolder: 'SRV*http://symweb;$(agent.builddirectory)\symbols'
+              isLargeApp: false
+              toolVersion: 'Latest'
+            displayName: Run ApiScan
+            condition: succeeded()
+            env:
+              AzureServicesAuthConnectionString: $(apiscan-connectionstring)
 
           - task: PublishSecurityAnalysisLogs@3
             inputs:
@@ -170,127 +176,3 @@ stages:
             inputs:
               GdnPublishTsaOnboard: true
               GdnPublishTsaConfigFile: '$(Build.SourcesDirectory)\build\azure-pipelines\config\tsaoptions.json'
-
-  - stage: Linux
-    dependsOn: []
-    condition: eq(variables.SCAN_LINUX, 'true')
-    pool:
-      vmImage: "Ubuntu-18.04"
-    jobs:
-      - job: LinuxJob
-        steps:
-          - task: CredScan@2
-            inputs:
-              toolMajorVersion: "V2"
-          - task: NodeTool@0
-            inputs:
-              versionSource: fromFile
-              versionFilePath: .nvmrc
-              nodejsMirror: https://github.com/joaomoreno/node-mirror/releases/download
-
-          - template: ./distro/download-distro.yml
-
-          - task: AzureKeyVault@1
-            displayName: "Azure Key Vault: Get Secrets"
-            inputs:
-              azureSubscription: "vscode-builds-subscription"
-              KeyVaultName: vscode-build-secrets
-              SecretsFilter: "github-distro-mixin-password"
-
-          - script: |
-              set -e
-              npm config set registry "$NPM_REGISTRY" --location=project
-              # npm >v7 deprecated the `always-auth` config option, refs npm/cli@72a7eeb
-              # following is a workaround for yarn to send authorization header
-              # for GET requests to the registry.
-              echo "always-auth=true" >> .npmrc
-              yarn config set registry "$NPM_REGISTRY"
-            condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'), ne(variables['NPM_REGISTRY'], 'none'))
-            displayName: Setup NPM & Yarn
-
-          - task: npmAuthenticate@0
-            inputs:
-              workingFile: .npmrc
-            condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'), ne(variables['NPM_REGISTRY'], 'none'))
-            displayName: Setup NPM Authentication
-
-          - script: node build/setup-npm-registry.js $NPM_REGISTRY
-            condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'), ne(variables['NPM_REGISTRY'], 'none'))
-            displayName: Setup NPM Registry
-
-          - script: |
-              set -e
-              for i in {1..5}; do # try 5 times
-                yarn --cwd build --frozen-lockfile --check-files && break
-                if [ $i -eq 3 ]; then
-                  echo "Yarn failed too many times" >&2
-                  exit 1
-                fi
-                echo "Yarn failed $i, trying again..."
-              done
-            displayName: Install build dependencies
-
-          - script: |
-              set -e
-              export npm_config_arch=$(NPM_ARCH)
-
-              if [ -z "$CC" ] || [ -z "$CXX" ]; then
-                # Download clang based on chromium revision used by vscode
-                curl -s https://raw.githubusercontent.com/chromium/chromium/96.0.4664.110/tools/clang/scripts/update.py | python - --output-dir=$PWD/.build/CR_Clang --host-os=linux
-                # Download libcxx headers and objects from upstream electron releases
-                DEBUG=libcxx-fetcher \
-                VSCODE_LIBCXX_OBJECTS_DIR=$PWD/.build/libcxx-objects \
-                VSCODE_LIBCXX_HEADERS_DIR=$PWD/.build/libcxx_headers  \
-                VSCODE_LIBCXXABI_HEADERS_DIR=$PWD/.build/libcxxabi_headers \
-                VSCODE_ARCH="$(NPM_ARCH)" \
-                node build/linux/libcxx-fetcher.js
-                # Set compiler toolchain
-                export CC=$PWD/.build/CR_Clang/bin/clang
-                export CXX=$PWD/.build/CR_Clang/bin/clang++
-                export CXXFLAGS="-std=c++17 -nostdinc++ -D__NO_INLINE__ -I$PWD/.build/libcxx_headers -isystem$PWD/.build/libcxx_headers/include -isystem$PWD/.build/libcxxabi_headers/include -fPIC -flto=thin -fsplit-lto-unit -D_LIBCPP_ABI_NAMESPACE=Cr"
-                export LDFLAGS="-stdlib=libc++ -fuse-ld=lld -flto=thin -fsplit-lto-unit -L$PWD/.build/libcxx-objects -lc++abi"
-                export VSCODE_REMOTE_CC=$(which gcc)
-                export VSCODE_REMOTE_CXX=$(which g++)
-              fi
-
-              for i in {1..5}; do # try 5 times
-                yarn --frozen-lockfile --check-files && break
-                if [ $i -eq 3 ]; then
-                  echo "Yarn failed too many times" >&2
-                  exit 1
-                fi
-                echo "Yarn failed $i, trying again..."
-              done
-            env:
-              PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
-              GITHUB_TOKEN: "$(github-distro-mixin-password)"
-            displayName: Install dependencies
-
-          - script: yarn --frozen-lockfile --check-files
-            workingDirectory: .build/distro/npm
-            env:
-              npm_config_arch: $(NPM_ARCH)
-            displayName: Install distro node modules
-
-          - script: node build/azure-pipelines/distro/mixin-npm
-            displayName: Mixin distro node modules
-
-          - script: node build/azure-pipelines/distro/mixin-quality
-            displayName: Mixin distro quality
-            env:
-              VSCODE_QUALITY: stable
-
-          - script: yarn gulp vscode-symbols-linux-$(VSCODE_ARCH)
-            env:
-              GITHUB_TOKEN: "$(github-distro-mixin-password)"
-            displayName: Build
-
-          - task: BinSkim@3
-            inputs:
-              toolVersion: Latest
-              InputType: CommandLine
-              arguments: analyze $(agent.builddirectory)\scanbin\exe\*.* --recurse --local-symbol-directories $(agent.builddirectory)\scanbin\VSCode-linux-$(VSCODE_ARCH)\pdb
-
-          - task: TSAUpload@2
-            inputs:
-              GdnPublishTsaConfigFile: '$(Build.SourceDirectory)\build\azure-pipelines\config\tsaoptions.json'

--- a/build/azure-pipelines/sdl-scan.yml
+++ b/build/azure-pipelines/sdl-scan.yml
@@ -1,23 +1,14 @@
-trigger: none
-pr: none
-
 parameters:
   - name: NPM_REGISTRY
     displayName: "Custom NPM Registry"
     type: string
     default: "https://pkgs.dev.azure.com/monacotools/Monaco/_packaging/vscode/npm/registry/"
-
-variables:
-  - name: NPM_REGISTRY
-    value: ${{ parameters.NPM_REGISTRY }}
-  - name: VSCODE_MIXIN_REPO
-    value: microsoft/vscode-distro
-  - name: skipComponentGovernanceDetection
-    value: true
   - name: NPM_ARCH
-    value: x64
+    type: string
+    default: x64
   - name: VSCODE_ARCH
-    value: x64
+    type: string
+    default: x64
 
 steps:
   - task: NodeTool@0
@@ -38,26 +29,26 @@ steps:
   - powershell: |
       . build/azure-pipelines/win32/exec.ps1
       $ErrorActionPreference = "Stop"
-      exec { npm config set registry "$env:NPM_REGISTRY" --location=project }
+      exec { npm config set registry "${{ parameters.NPM_REGISTRY }}" --location=project }
       # npm >v7 deprecated the `always-auth` config option, refs npm/cli@72a7eeb
       # following is a workaround for yarn to send authorization header
       # for GET requests to the registry.
       exec { Add-Content -Path .npmrc -Value "always-auth=true" }
-      exec { yarn config set registry "$env:NPM_REGISTRY" }
-    condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'), ne(variables['NPM_REGISTRY'], 'none'))
+      exec { yarn config set registry "${{ parameters.NPM_REGISTRY }}" }
+    condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'), ne(${{ parameters.NPM_REGISTRY }}, 'none'))
     displayName: Setup NPM & Yarn
 
   - task: npmAuthenticate@0
     inputs:
       workingFile: .npmrc
-    condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'), ne(variables['NPM_REGISTRY'], 'none'))
+    condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'), ne(${{ parameters.NPM_REGISTRY }}, 'none'))
     displayName: Setup NPM Authentication
 
   - powershell: |
       . build/azure-pipelines/win32/exec.ps1
       $ErrorActionPreference = "Stop"
-      exec { node build/setup-npm-registry.js $env:NPM_REGISTRY }
-    condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'), ne(variables['NPM_REGISTRY'], 'none'))
+      exec { node build/setup-npm-registry.js ${{ parameters.NPM_REGISTRY }} }
+    condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'), ne(${{ parameters.NPM_REGISTRY }}, 'none'))
     displayName: Setup NPM Registry
 
   - pwsh: |
@@ -104,7 +95,7 @@ steps:
       mkdir "$nodeGypDir"
       npm install node-gyp@10.0.1 -g --prefix "$nodeGypDir"
       $env:npm_config_node_gyp = "${nodeGypDir}/node_modules/node-gyp/bin/node-gyp.js"
-      $env:npm_config_arch = "$(NPM_ARCH)"
+      $env:npm_config_arch = "${{ parameters.NPM_ARCH }}"
       retry { exec { yarn --frozen-lockfile --check-files } }
     env:
       PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
@@ -123,7 +114,7 @@ steps:
   - powershell: yarn compile
     displayName: Compile
 
-  - powershell: yarn gulp "vscode-symbols-win32-$(VSCODE_ARCH)"
+  - powershell: yarn gulp "vscode-symbols-win32-${{ parameters.VSCODE_ARCH }}"
     env:
       GITHUB_TOKEN: "$(github-distro-mixin-password)"
     displayName: Download Symbols
@@ -135,7 +126,7 @@ steps:
       TargetPattern: "guardianGlob"
       AnalyzeIgnorePdbLoadError: true
       AnalyzeTargetGlob: '$(agent.builddirectory)\scanbin\**.dll;$(agent.builddirectory)\scanbin\**.exe;$(agent.builddirectory)\scanbin\**.node'
-      AnalyzeLocalSymbolDirectories: '$(agent.builddirectory)\scanbin\VSCode-win32-$(VSCODE_ARCH)\pdb'
+      AnalyzeLocalSymbolDirectories: '$(agent.builddirectory)\scanbin\VSCode-win32-${{ parameters.VSCODE_ARCH }}\pdb'
 
   - task: CopyFiles@2
     displayName: 'Collect Symbols for API Scan'

--- a/build/azure-pipelines/sdl-scan.yml
+++ b/build/azure-pipelines/sdl-scan.yml
@@ -19,160 +19,154 @@ variables:
   - name: VSCODE_ARCH
     value: x64
 
-stages:
-  - stage: Windows
-    pool: 1es-windows-2019-x64
-    jobs:
-      - job: WindowsJob
-        timeoutInMinutes: 0
-        steps:
-          - task: NodeTool@0
-            inputs:
-              versionSource: fromFile
-              versionFilePath: .nvmrc
-              nodejsMirror: https://github.com/joaomoreno/node-mirror/releases/download
+steps:
+  - task: NodeTool@0
+    inputs:
+      versionSource: fromFile
+      versionFilePath: .nvmrc
+      nodejsMirror: https://github.com/joaomoreno/node-mirror/releases/download
 
-          - template: ./distro/download-distro.yml
+  - template: ./distro/download-distro.yml
 
-          - task: AzureKeyVault@1
-            displayName: "Azure Key Vault: Get Secrets"
-            inputs:
-              azureSubscription: "vscode-builds-subscription"
-              KeyVaultName: vscode-build-secrets
-              SecretsFilter: "github-distro-mixin-password"
+  - task: AzureKeyVault@1
+    displayName: "Azure Key Vault: Get Secrets"
+    inputs:
+      azureSubscription: "vscode-builds-subscription"
+      KeyVaultName: vscode-build-secrets
+      SecretsFilter: "github-distro-mixin-password"
 
-          - powershell: |
-              . build/azure-pipelines/win32/exec.ps1
-              $ErrorActionPreference = "Stop"
-              exec { npm config set registry "$env:NPM_REGISTRY" --location=project }
-              # npm >v7 deprecated the `always-auth` config option, refs npm/cli@72a7eeb
-              # following is a workaround for yarn to send authorization header
-              # for GET requests to the registry.
-              exec { Add-Content -Path .npmrc -Value "always-auth=true" }
-              exec { yarn config set registry "$env:NPM_REGISTRY" }
-            condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'), ne(variables['NPM_REGISTRY'], 'none'))
-            displayName: Setup NPM & Yarn
+  - powershell: |
+      . build/azure-pipelines/win32/exec.ps1
+      $ErrorActionPreference = "Stop"
+      exec { npm config set registry "$env:NPM_REGISTRY" --location=project }
+      # npm >v7 deprecated the `always-auth` config option, refs npm/cli@72a7eeb
+      # following is a workaround for yarn to send authorization header
+      # for GET requests to the registry.
+      exec { Add-Content -Path .npmrc -Value "always-auth=true" }
+      exec { yarn config set registry "$env:NPM_REGISTRY" }
+    condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'), ne(variables['NPM_REGISTRY'], 'none'))
+    displayName: Setup NPM & Yarn
 
-          - task: npmAuthenticate@0
-            inputs:
-              workingFile: .npmrc
-            condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'), ne(variables['NPM_REGISTRY'], 'none'))
-            displayName: Setup NPM Authentication
+  - task: npmAuthenticate@0
+    inputs:
+      workingFile: .npmrc
+    condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'), ne(variables['NPM_REGISTRY'], 'none'))
+    displayName: Setup NPM Authentication
 
-          - powershell: |
-              . build/azure-pipelines/win32/exec.ps1
-              $ErrorActionPreference = "Stop"
-              exec { node build/setup-npm-registry.js $env:NPM_REGISTRY }
-            condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'), ne(variables['NPM_REGISTRY'], 'none'))
-            displayName: Setup NPM Registry
+  - powershell: |
+      . build/azure-pipelines/win32/exec.ps1
+      $ErrorActionPreference = "Stop"
+      exec { node build/setup-npm-registry.js $env:NPM_REGISTRY }
+    condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'), ne(variables['NPM_REGISTRY'], 'none'))
+    displayName: Setup NPM Registry
 
-          - pwsh: |
-              $includes = @'
-                {
-                  'target_defaults': {
-                    'conditions': [
-                      ['OS=="win"', {
-                        'msvs_configuration_attributes': {
-                          'SpectreMitigation': 'Spectre'
-                        },
-                        'msvs_settings': {
-                          'VCCLCompilerTool': {
-                            'AdditionalOptions': [
-                              '/Zi',
-                              '/FS'
-                            ],
-                          },
-                          'VCLinkerTool': {
-                            'AdditionalOptions': [
-                              '/profile'
-                            ]
-                          }
-                        }
-                      }]
+  - pwsh: |
+      $includes = @'
+        {
+          'target_defaults': {
+            'conditions': [
+              ['OS=="win"', {
+                'msvs_configuration_attributes': {
+                  'SpectreMitigation': 'Spectre'
+                },
+                'msvs_settings': {
+                  'VCCLCompilerTool': {
+                    'AdditionalOptions': [
+                      '/Zi',
+                      '/FS'
+                    ],
+                  },
+                  'VCLinkerTool': {
+                    'AdditionalOptions': [
+                      '/profile'
                     ]
                   }
                 }
-              '@
+              }]
+            ]
+          }
+        }
+      '@
 
-              if (!(Test-Path "~/.gyp")) {
-                mkdir "~/.gyp"
-              }
-              echo $includes > "~/.gyp/include.gypi"
-            displayName: Create include.gypi
+      if (!(Test-Path "~/.gyp")) {
+        mkdir "~/.gyp"
+      }
+      echo $includes > "~/.gyp/include.gypi"
+    displayName: Create include.gypi
 
-          - powershell: |
-              . build/azure-pipelines/win32/exec.ps1
-              . build/azure-pipelines/win32/retry.ps1
-              $ErrorActionPreference = "Stop"
-              # TODO: remove custom node-gyp when updating to Node v20,
-              # refs https://github.com/npm/cli/releases/tag/v10.2.3 which is available with Node >= 20.10.0
-              $nodeGypDir = "$(Agent.TempDirectory)/custom-packages"
-              mkdir "$nodeGypDir"
-              npm install node-gyp@10.0.1 -g --prefix "$nodeGypDir"
-              $env:npm_config_node_gyp = "${nodeGypDir}/node_modules/node-gyp/bin/node-gyp.js"
-              $env:npm_config_arch = "$(NPM_ARCH)"
-              retry { exec { yarn --frozen-lockfile --check-files } }
-            env:
-              PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
-              GITHUB_TOKEN: "$(github-distro-mixin-password)"
-              CHILD_CONCURRENCY: 1
-            displayName: Install dependencies
+  - powershell: |
+      . build/azure-pipelines/win32/exec.ps1
+      . build/azure-pipelines/win32/retry.ps1
+      $ErrorActionPreference = "Stop"
+      # TODO: remove custom node-gyp when updating to Node v20,
+      # refs https://github.com/npm/cli/releases/tag/v10.2.3 which is available with Node >= 20.10.0
+      $nodeGypDir = "$(Agent.TempDirectory)/custom-packages"
+      mkdir "$nodeGypDir"
+      npm install node-gyp@10.0.1 -g --prefix "$nodeGypDir"
+      $env:npm_config_node_gyp = "${nodeGypDir}/node_modules/node-gyp/bin/node-gyp.js"
+      $env:npm_config_arch = "$(NPM_ARCH)"
+      retry { exec { yarn --frozen-lockfile --check-files } }
+    env:
+      PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
+      GITHUB_TOKEN: "$(github-distro-mixin-password)"
+      CHILD_CONCURRENCY: 1
+    displayName: Install dependencies
 
-          - script: node build/azure-pipelines/distro/mixin-npm
-            displayName: Mixin distro node modules
+  - script: node build/azure-pipelines/distro/mixin-npm
+    displayName: Mixin distro node modules
 
-          - script: node build/azure-pipelines/distro/mixin-quality
-            displayName: Mixin distro quality
-            env:
-              VSCODE_QUALITY: stable
+  - script: node build/azure-pipelines/distro/mixin-quality
+    displayName: Mixin distro quality
+    env:
+      VSCODE_QUALITY: stable
 
-          - powershell: yarn compile
-            displayName: Compile
+  - powershell: yarn compile
+    displayName: Compile
 
-          - powershell: yarn gulp "vscode-symbols-win32-$(VSCODE_ARCH)"
-            env:
-              GITHUB_TOKEN: "$(github-distro-mixin-password)"
-            displayName: Download Symbols
+  - powershell: yarn gulp "vscode-symbols-win32-$(VSCODE_ARCH)"
+    env:
+      GITHUB_TOKEN: "$(github-distro-mixin-password)"
+    displayName: Download Symbols
 
-          - task: BinSkim@4
-            inputs:
-              InputType: "Basic"
-              Function: "analyze"
-              TargetPattern: "guardianGlob"
-              AnalyzeIgnorePdbLoadError: true
-              AnalyzeTargetGlob: '$(agent.builddirectory)\scanbin\**.dll;$(agent.builddirectory)\scanbin\**.exe;$(agent.builddirectory)\scanbin\**.node'
-              AnalyzeLocalSymbolDirectories: '$(agent.builddirectory)\scanbin\VSCode-win32-$(VSCODE_ARCH)\pdb'
+  - task: BinSkim@4
+    inputs:
+      InputType: "Basic"
+      Function: "analyze"
+      TargetPattern: "guardianGlob"
+      AnalyzeIgnorePdbLoadError: true
+      AnalyzeTargetGlob: '$(agent.builddirectory)\scanbin\**.dll;$(agent.builddirectory)\scanbin\**.exe;$(agent.builddirectory)\scanbin\**.node'
+      AnalyzeLocalSymbolDirectories: '$(agent.builddirectory)\scanbin\VSCode-win32-$(VSCODE_ARCH)\pdb'
 
-          - task: CopyFiles@2
-            displayName: 'Collect Symbols for API Scan'
-            inputs:
-              SourceFolder: $(Agent.BuildDirectory)
-              Contents: 'scanbin\**\*.pdb'
-              TargetFolder: '$(agent.builddirectory)\symbols'
-              flattenFolders: true
-            condition: succeeded()
+  - task: CopyFiles@2
+    displayName: 'Collect Symbols for API Scan'
+    inputs:
+      SourceFolder: $(Agent.BuildDirectory)
+      Contents: 'scanbin\**\*.pdb'
+      TargetFolder: '$(agent.builddirectory)\symbols'
+      flattenFolders: true
+    condition: succeeded()
 
-          - task: APIScan@2
-            inputs:
-              softwareFolder: $(agent.builddirectory)\scanbin
-              softwareName: 'vscode-client'
-              softwareVersionNum: '1'
-              symbolsFolder: 'SRV*http://symweb;$(agent.builddirectory)\symbols'
-              isLargeApp: false
-              toolVersion: 'Latest'
-            displayName: Run ApiScan
-            condition: succeeded()
-            env:
-              AzureServicesAuthConnectionString: $(apiscan-connectionstring)
+  - task: APIScan@2
+    inputs:
+      softwareFolder: $(agent.builddirectory)\scanbin
+      softwareName: 'vscode-client'
+      softwareVersionNum: '1'
+      symbolsFolder: 'SRV*http://symweb;$(agent.builddirectory)\symbols'
+      isLargeApp: false
+      toolVersion: 'Latest'
+    displayName: Run ApiScan
+    condition: succeeded()
+    env:
+      AzureServicesAuthConnectionString: $(apiscan-connectionstring)
 
-          - task: PublishSecurityAnalysisLogs@3
-            inputs:
-              ArtifactName: CodeAnalysisLogs
-              ArtifactType: Container
-              PublishProcessedResults: false
-              AllTools: true
+  - task: PublishSecurityAnalysisLogs@3
+    inputs:
+      ArtifactName: CodeAnalysisLogs
+      ArtifactType: Container
+      PublishProcessedResults: false
+      AllTools: true
 
-          - task: TSAUpload@2
-            inputs:
-              GdnPublishTsaOnboard: true
-              GdnPublishTsaConfigFile: '$(Build.SourcesDirectory)\build\azure-pipelines\config\tsaoptions.json'
+  - task: TSAUpload@2
+    inputs:
+      GdnPublishTsaOnboard: true
+      GdnPublishTsaConfigFile: '$(Build.SourcesDirectory)\build\azure-pipelines\config\tsaoptions.json'

--- a/build/azure-pipelines/sdl-scan.yml
+++ b/build/azure-pipelines/sdl-scan.yml
@@ -156,8 +156,3 @@ steps:
       ArtifactType: Container
       PublishProcessedResults: false
       AllTools: true
-
-  - task: TSAUpload@2
-    inputs:
-      GdnPublishTsaOnboard: true
-      GdnPublishTsaConfigFile: '$(Build.SourcesDirectory)\build\azure-pipelines\config\tsaoptions.json'

--- a/build/azure-pipelines/sdl-scan.yml
+++ b/build/azure-pipelines/sdl-scan.yml
@@ -35,20 +35,20 @@ steps:
       # for GET requests to the registry.
       exec { Add-Content -Path .npmrc -Value "always-auth=true" }
       exec { yarn config set registry "${{ parameters.NPM_REGISTRY }}" }
-    condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'), ne(${{ parameters.NPM_REGISTRY }}, 'none'))
+    condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'), ne('${{ parameters.NPM_REGISTRY }}', 'none'))
     displayName: Setup NPM & Yarn
 
   - task: npmAuthenticate@0
     inputs:
       workingFile: .npmrc
-    condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'), ne(${{ parameters.NPM_REGISTRY }}, 'none'))
+    condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'), ne('${{ parameters.NPM_REGISTRY }}', 'none'))
     displayName: Setup NPM Authentication
 
   - powershell: |
       . build/azure-pipelines/win32/exec.ps1
       $ErrorActionPreference = "Stop"
-      exec { node build/setup-npm-registry.js ${{ parameters.NPM_REGISTRY }} }
-    condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'), ne(${{ parameters.NPM_REGISTRY }}, 'none'))
+      exec { node build/setup-npm-registry.js "${{ parameters.NPM_REGISTRY }}" }
+    condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'), ne('${{ parameters.NPM_REGISTRY }}', 'none'))
     displayName: Setup NPM Registry
 
   - pwsh: |

--- a/build/azure-pipelines/sdl-scan.yml
+++ b/build/azure-pipelines/sdl-scan.yml
@@ -89,13 +89,6 @@ steps:
       . build/azure-pipelines/win32/exec.ps1
       . build/azure-pipelines/win32/retry.ps1
       $ErrorActionPreference = "Stop"
-      # TODO: remove custom node-gyp when updating to Node v20,
-      # refs https://github.com/npm/cli/releases/tag/v10.2.3 which is available with Node >= 20.10.0
-      $nodeGypDir = "$(Agent.TempDirectory)/custom-packages"
-      mkdir "$nodeGypDir"
-      npm install node-gyp@10.0.1 -g --prefix "$nodeGypDir"
-      $env:npm_config_node_gyp = "${nodeGypDir}/node_modules/node-gyp/bin/node-gyp.js"
-      $env:npm_config_arch = "${{ parameters.NPM_ARCH }}"
       retry { exec { yarn --frozen-lockfile --check-files } }
     env:
       PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1

--- a/build/azure-pipelines/win32/product-build-win32.yml
+++ b/build/azure-pipelines/win32/product-build-win32.yml
@@ -153,11 +153,6 @@ steps:
     - powershell: node build/azure-pipelines/distro/mixin-quality
       displayName: Mixin distro quality
 
-  - powershell: yarn gulp "vscode-symbols-win32-${{ parameters.VSCODE_ARCH }}"
-    env:
-      GITHUB_TOKEN: "$(github-distro-mixin-password)"
-    displayName: Download Symbols
-
   - template: ../common/install-builtin-extensions.yml@self
 
   - ${{ if and(ne(parameters.VSCODE_CIBUILD, true), ne(parameters.VSCODE_QUALITY, 'oss')) }}:

--- a/build/azure-pipelines/win32/product-build-win32.yml
+++ b/build/azure-pipelines/win32/product-build-win32.yml
@@ -90,6 +90,38 @@ steps:
     displayName: Setup NPM Authentication
 
   - powershell: |
+      $includes = @'
+        {
+          'target_defaults': {
+            'conditions': [
+              ['OS=="win"', {
+                'msvs_configuration_attributes': {
+                  'SpectreMitigation': 'Spectre'
+                },
+                'msvs_settings': {
+                  'VCCLCompilerTool': {
+                    'AdditionalOptions': [
+                      '/ZH:SHA_256'
+                    ],
+                  },
+                  'VCLinkerTool': {
+                    'AdditionalOptions': [
+                    ]
+                  }
+                }
+              }]
+            ]
+          }
+        }
+      '@
+
+      if (!(Test-Path "~/.gyp")) {
+        mkdir "~/.gyp"
+      }
+      echo $includes > "~/.gyp/include.gypi"
+    displayName: Create include.gypi
+
+  - powershell: |
       . build/azure-pipelines/win32/exec.ps1
       . build/azure-pipelines/win32/retry.ps1
       $ErrorActionPreference = "Stop"
@@ -120,6 +152,11 @@ steps:
   - ${{ if ne(parameters.VSCODE_QUALITY, 'oss') }}:
     - powershell: node build/azure-pipelines/distro/mixin-quality
       displayName: Mixin distro quality
+
+  - powershell: yarn gulp "vscode-symbols-win32-${{ parameters.VSCODE_ARCH }}"
+    env:
+      GITHUB_TOKEN: "$(github-distro-mixin-password)"
+    displayName: Download Symbols
 
   - template: ../common/install-builtin-extensions.yml@self
 

--- a/build/azure-pipelines/win32/product-build-win32.yml
+++ b/build/azure-pipelines/win32/product-build-win32.yml
@@ -90,38 +90,6 @@ steps:
     displayName: Setup NPM Authentication
 
   - powershell: |
-      $includes = @'
-        {
-          'target_defaults': {
-            'conditions': [
-              ['OS=="win"', {
-                'msvs_configuration_attributes': {
-                  'SpectreMitigation': 'Spectre'
-                },
-                'msvs_settings': {
-                  'VCCLCompilerTool': {
-                    'AdditionalOptions': [
-                      '/ZH:SHA_256'
-                    ],
-                  },
-                  'VCLinkerTool': {
-                    'AdditionalOptions': [
-                    ]
-                  }
-                }
-              }]
-            ]
-          }
-        }
-      '@
-
-      if (!(Test-Path "~/.gyp")) {
-        mkdir "~/.gyp"
-      }
-      echo $includes > "~/.gyp/include.gypi"
-    displayName: Create include.gypi
-
-  - powershell: |
       . build/azure-pipelines/win32/exec.ps1
       . build/azure-pipelines/win32/retry.ps1
       $ErrorActionPreference = "Stop"


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This PR pulls in the APIScan and BinSkim scans as a new stage to the main build pipeline. In turn, it removes the need for a separate SDL pipeline.

This PR is an intermediate solution; I believe that we'd optimally want the APIScan and BinSkim scans, and the configurations required for them, to be part of the Windows build pipeline.

Verification build: https://dev.azure.com/monacotools/Monaco/_build/results?buildId=278624&view=results
