### PR TITLE
Don't clear chat disposables too early while progressive rendering

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatListRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatListRenderer.ts
@@ -684,7 +684,6 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 				disposables.clear();
 				this.basicRenderElement(renderableResponse, element, index, templateData);
 			} else if (!isFullyRendered) {
-				disposables.clear();
 				this.renderContentReferencesIfNeeded(element, templateData, disposables);
 				let hasRenderedOneMarkdownBlock = false;
 				partsToRender.forEach((partToRender, index) => {


### PR DESCRIPTION
This clear() is wrong because this loop is incrementally updating content, not rerendering everything. Deleting is also not quite right because we are technically leaking when things get rerendered. But that is only the case while in the middle of streaming content, and things will always be fixed up when the response is done loading. Got another change on the plan for June which will fix all of this in a more complete way.
Fix #212853

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
