### PR TITLE
Correctly highlight active line number when word wrap enabled

### DIFF
--- a/src/vs/editor/browser/viewParts/lineNumbers/lineNumbers.ts
+++ b/src/vs/editor/browser/viewParts/lineNumbers/lineNumbers.ts
@@ -33,6 +33,7 @@ export class LineNumbersOverlay extends DynamicViewOverlay {
 	private _lastCursorModelPosition: Position;
 	private _renderResult: string[] | null;
 	private _activeLineNumber: number;
+	protected _wordWrap!: boolean;
 
 	constructor(context: ViewContext) {
 		super();
@@ -56,6 +57,7 @@ export class LineNumbersOverlay extends DynamicViewOverlay {
 		const layoutInfo = options.get(EditorOption.layoutInfo);
 		this._lineNumbersLeft = layoutInfo.lineNumbersLeft;
 		this._lineNumbersWidth = layoutInfo.lineNumbersWidth;
+		this._wordWrap = layoutInfo.isViewportWrapping;
 	}
 
 	public override dispose(): void {
@@ -160,6 +162,9 @@ export class LineNumbersOverlay extends DynamicViewOverlay {
 
 		const lineCount = this._context.viewModel.getLineCount();
 		const output: string[] = [];
+		const coordinatesConverter = this._context.viewModel.coordinatesConverter;
+		const activeModelLineNumber = coordinatesConverter.convertViewPositionToModelPosition(new Position(this._activeLineNumber, 1)).lineNumber;
+
 		for (let lineNumber = visibleStartLineNumber; lineNumber <= visibleEndLineNumber; lineNumber++) {
 			const lineIndex = lineNumber - visibleStartLineNumber;
 
@@ -191,10 +196,9 @@ export class LineNumbersOverlay extends DynamicViewOverlay {
 					extraClassNames += ' dimmed-line-number';
 				}
 			}
-			if (lineNumber === this._activeLineNumber) {
+			if (lineNumber === this._activeLineNumber || (this._wordWrap && coordinatesConverter.convertViewPositionToModelPosition(new Position(lineNumber, 1)).lineNumber === activeModelLineNumber)) {
 				extraClassNames += ' active-line-number';
 			}
-
 
 			output[lineIndex] = (
 				`<div class="${LineNumbersOverlay.CLASS_NAME}${lineHeightClassName}${extraClassNames}" style="left:${this._lineNumbersLeft}px;width:${this._lineNumbersWidth}px;">${renderLineNumber}</div>`


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fixes #214937

Screenshot before (line number 3 not highlighted):

![before](https://github.com/user-attachments/assets/050bb972-afc0-40b0-9d26-c4aee3eb1804)

Screenshot after (line number 3 highlighted as expected):

![after](https://github.com/user-attachments/assets/0edeea26-6256-4f5e-816e-a32f5937c42c)
