### PR TITLE
Fixes #191390

### DIFF
--- a/src/vs/base/common/uri.ts
+++ b/src/vs/base/common/uri.ts
@@ -413,6 +413,10 @@ export class URI implements UriComponents {
 			return result;
 		}
 	}
+
+	[Symbol.for('debug.description')]() {
+		return `URI(${this.toString()})`;
+	}
 }
 
 export interface UriComponents {

--- a/src/vs/workbench/api/common/extHostDocumentData.ts
+++ b/src/vs/workbench/api/common/extHostDocumentData.ts
@@ -76,6 +76,9 @@ export class ExtHostDocumentData extends MirrorTextModel {
 				validateRange(ran) { return that._validateRange(ran); },
 				validatePosition(pos) { return that._validatePosition(pos); },
 				getWordRangeAtPosition(pos, regexp?) { return that._getWordRangeAtPosition(pos, regexp); },
+				[Symbol.for('debug.description')]() {
+					return `TextDocument(${that._uri.toString()})`;
+				}
 			};
 		}
 		return Object.freeze(this._document);

--- a/src/vs/workbench/api/common/extHostNotebookDocument.ts
+++ b/src/vs/workbench/api/common/extHostNotebookDocument.ts
@@ -211,6 +211,9 @@ export class ExtHostNotebookDocument {
 				},
 				save() {
 					return that._save();
+				},
+				[Symbol.for('debug.description')]() {
+					return `NotebookDocument(${this.uri.toString()})`;
 				}
 			};
 			this._notebook = Object.freeze(apiObject);

--- a/src/vs/workbench/api/common/extHostNotebookEditor.ts
+++ b/src/vs/workbench/api/common/extHostNotebookEditor.ts
@@ -71,6 +71,9 @@ export class ExtHostNotebookEditor {
 				get viewColumn() {
 					return that._viewColumn;
 				},
+				[Symbol.for('debug.description')]() {
+					return `NotebookEditor(${this.notebook.uri.toString()})`;
+				}
 			};
 
 			ExtHostNotebookEditor.apiEditorsToExtHost.set(this._editor, this);

--- a/src/vs/workbench/api/common/extHostTextEditor.ts
+++ b/src/vs/workbench/api/common/extHostTextEditor.ts
@@ -11,7 +11,7 @@ import { IRange } from 'vs/editor/common/core/range';
 import { ISingleEditOperation } from 'vs/editor/common/core/editOperation';
 import { IResolvedTextEditorConfiguration, ITextEditorConfigurationUpdate, MainThreadTextEditorsShape } from 'vs/workbench/api/common/extHost.protocol';
 import * as TypeConverters from 'vs/workbench/api/common/extHostTypeConverters';
-import { EndOfLine, Position, Range, Selection, SnippetString, TextEditorLineNumbersStyle, TextEditorRevealType } from 'vs/workbench/api/common/extHostTypes';
+import { EndOfLine, getDebugDescriptionOfSelection, Position, Range, Selection, SnippetString, TextEditorLineNumbersStyle, TextEditorRevealType } from 'vs/workbench/api/common/extHostTypes';
 import type * as vscode from 'vscode';
 import { ILogService } from 'vs/platform/log/common/log';
 import { Lazy } from 'vs/base/common/lazy';
@@ -566,6 +566,9 @@ export class ExtHostTextEditor {
 			},
 			hide() {
 				_proxy.$tryHideEditor(id);
+			},
+			[Symbol.for('debug.description')]() {
+				return `TextEditor(${this.document.uri.toString()}, ${this.selections.map(s => getDebugDescriptionOfSelection(s)).join(', ')})`;
 			}
 		});
 	}

--- a/src/vs/workbench/api/common/extHostTextEditor.ts
+++ b/src/vs/workbench/api/common/extHostTextEditor.ts
@@ -11,7 +11,7 @@ import { IRange } from 'vs/editor/common/core/range';
 import { ISingleEditOperation } from 'vs/editor/common/core/editOperation';
 import { IResolvedTextEditorConfiguration, ITextEditorConfigurationUpdate, MainThreadTextEditorsShape } from 'vs/workbench/api/common/extHost.protocol';
 import * as TypeConverters from 'vs/workbench/api/common/extHostTypeConverters';
-import { EndOfLine, getDebugDescriptionOfSelection, Position, Range, Selection, SnippetString, TextEditorLineNumbersStyle, TextEditorRevealType } from 'vs/workbench/api/common/extHostTypes';
+import { EndOfLine, Position, Range, Selection, SnippetString, TextEditorLineNumbersStyle, TextEditorRevealType } from 'vs/workbench/api/common/extHostTypes';
 import type * as vscode from 'vscode';
 import { ILogService } from 'vs/platform/log/common/log';
 import { Lazy } from 'vs/base/common/lazy';
@@ -568,7 +568,7 @@ export class ExtHostTextEditor {
 				_proxy.$tryHideEditor(id);
 			},
 			[Symbol.for('debug.description')]() {
-				return `TextEditor(${this.document.uri.toString()}, ${this.selections.map(s => getDebugDescriptionOfSelection(s)).join(', ')})`;
+				return `TextEditor(${this.document.uri.toString()})`;
 			}
 		});
 	}

--- a/src/vs/workbench/api/common/extHostTypes.ts
+++ b/src/vs/workbench/api/common/extHostTypes.ts
@@ -271,6 +271,10 @@ export class Position {
 	toJSON(): any {
 		return { line: this.line, character: this.character };
 	}
+
+	[Symbol.for('debug.description')]() {
+		return `(${this.line}:${this.character})`;
+	}
 }
 
 @es5ClassCompat
@@ -417,6 +421,10 @@ export class Range {
 	toJSON(): any {
 		return [this.start, this.end];
 	}
+
+	[Symbol.for('debug.description')]() {
+		return getDebugDescriptionOfRange(this);
+	}
 }
 
 @es5ClassCompat
@@ -483,6 +491,29 @@ export class Selection extends Range {
 			anchor: this.anchor
 		};
 	}
+
+
+	[Symbol.for('debug.description')]() {
+		return getDebugDescriptionOfSelection(this);
+	}
+}
+
+export function getDebugDescriptionOfRange(range: vscode.Range): string {
+	return range.isEmpty
+		? `[${range.start.line}:${range.start.character})`
+		: `[${range.start.line}:${range.start.character} -> ${range.end.line}:${range.end.character})`;
+}
+
+export function getDebugDescriptionOfSelection(selection: vscode.Selection): string {
+	let rangeStr = getDebugDescriptionOfRange(selection);
+	if (!selection.isEmpty) {
+		if (selection.active.isEqual(selection.start)) {
+			rangeStr = `|${rangeStr}`;
+		} else {
+			rangeStr = `${rangeStr}|`;
+		}
+	}
+	return rangeStr;
 }
 
 const validateConnectionToken = (connectionToken: string) => {

--- a/src/vs/workbench/contrib/chat/test/common/__snapshots__/ChatService_can_deserialize.0.snap
+++ b/src/vs/workbench/contrib/chat/test/common/__snapshots__/ChatService_can_deserialize.0.snap
@@ -77,15 +77,7 @@
       usedContext: {
         documents: [
           {
-            uri: {
-              scheme: "file",
-              authority: "",
-              path: "/test/path/to/file",
-              query: "",
-              fragment: "",
-              _formatted: null,
-              _fsPath: null
-            },
+            uri: URI(file:///test/path/to/file),
             version: 3,
             ranges: [
               {

--- a/src/vs/workbench/contrib/chat/test/common/__snapshots__/ChatService_can_serialize.1.snap
+++ b/src/vs/workbench/contrib/chat/test/common/__snapshots__/ChatService_can_serialize.1.snap
@@ -77,15 +77,7 @@
       usedContext: {
         documents: [
           {
-            uri: {
-              scheme: "file",
-              authority: "",
-              path: "/test/path/to/file",
-              query: "",
-              fragment: "",
-              _formatted: null,
-              _fsPath: null
-            },
+            uri: URI(file:///test/path/to/file),
             version: 3,
             ranges: [
               {

--- a/src/vs/workbench/contrib/chat/test/common/__snapshots__/Response_inline_reference.0.snap
+++ b/src/vs/workbench/contrib/chat/test/common/__snapshots__/Response_inline_reference.0.snap
@@ -9,15 +9,7 @@
     kind: "markdownContent"
   },
   {
-    inlineReference: {
-      scheme: "https",
-      authority: "microsoft.com",
-      path: "/",
-      query: "",
-      fragment: "",
-      _formatted: null,
-      _fsPath: null
-    },
+    inlineReference: URI(https://microsoft.com/),
     kind: "inlineReference"
   },
   {


### PR DESCRIPTION
Fixes #191390

Implements `debug.description` for:
* Ranges and Selections: `[10:0 -> 11:12)`
* Position: `(11:12)`
* TextDocument: `TextDocument(file://test.txt)`

These are very common objects and having a nice representation in the debugger makes debugging much more pleasant.

Prior art of formatting ranges:
* [TextSpan.ToString](https://learn.microsoft.com/en-us/dotnet/api/microsoft.codeanalysis.text.textspan.tostring?view=roslyn-dotnet-4.7.0): `[10..20)`
* [LinePositionSpan.ToString](https://learn.microsoft.com/en-us/dotnet/api/microsoft.codeanalysis.text.linepositionspan.tostring?view=roslyn-dotnet-4.7.0#microsoft-codeanalysis-text-linepositionspan-tostring): `(0,0)-(5,6)`
* VS Code: `[31,1 -> 31,1]` (which refers to columns and thus is a closed interval, wheres the extension host ranges refer to characters and don't include the character at `range.end`)

I think using half-open interval syntax might be more clear for advanced users, while `->` still makes it clear for people who don't know the half-open syntax.
