### PR TITLE
override pgup pgdown for SR users

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/contrib/navigation/arrow.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/navigation/arrow.ts
@@ -22,7 +22,7 @@ import { CTX_NOTEBOOK_CHAT_OUTER_FOCUS_POSITION } from 'vs/workbench/contrib/not
 import { INotebookActionContext, INotebookCellActionContext, NotebookAction, NotebookCellAction, NOTEBOOK_EDITOR_WIDGET_ACTION_WEIGHT, findTargetCellEditor } from 'vs/workbench/contrib/notebook/browser/controller/coreActions';
 import { CellEditState } from 'vs/workbench/contrib/notebook/browser/notebookBrowser';
 import { CellKind, NOTEBOOK_EDITOR_CURSOR_BOUNDARY } from 'vs/workbench/contrib/notebook/common/notebookCommon';
-import { NOTEBOOK_CELL_HAS_OUTPUTS, NOTEBOOK_CELL_MARKDOWN_EDIT_MODE, NOTEBOOK_CELL_TYPE, NOTEBOOK_CURSOR_NAVIGATION_MODE, NOTEBOOK_EDITOR_FOCUSED, NOTEBOOK_OUTPUT_INPUT_FOCUSED, NOTEBOOK_OUTPUT_FOCUSED } from 'vs/workbench/contrib/notebook/common/notebookContextKeys';
+import { NOTEBOOK_CELL_HAS_OUTPUTS, NOTEBOOK_CELL_MARKDOWN_EDIT_MODE, NOTEBOOK_CELL_TYPE, NOTEBOOK_CURSOR_NAVIGATION_MODE, NOTEBOOK_EDITOR_FOCUSED, NOTEBOOK_OUTPUT_INPUT_FOCUSED, NOTEBOOK_OUTPUT_FOCUSED, NOTEBOOK_CELL_EDITOR_FOCUSED } from 'vs/workbench/contrib/notebook/common/notebookContextKeys';
 
 const NOTEBOOK_FOCUS_TOP = 'notebook.focusTop';
 const NOTEBOOK_FOCUS_BOTTOM = 'notebook.focusBottom';
@@ -104,10 +104,10 @@ registerAction2(class FocusNextCellAction extends NotebookCellAction {
 					weight: KeybindingWeight.WorkbenchContrib
 				},
 				{
-					when: NOTEBOOK_EDITOR_FOCUSED,
-					primary: KeyMod.CtrlCmd | KeyMod.Alt | KeyCode.PageDown,
-					mac: { primary: KeyMod.CtrlCmd | KeyMod.Alt | KeyCode.PageDown, },
-					weight: KeybindingWeight.WorkbenchContrib
+					when: ContextKeyExpr.and(NOTEBOOK_CELL_EDITOR_FOCUSED, CONTEXT_ACCESSIBILITY_MODE_ENABLED),
+					primary: KeyMod.CtrlCmd | KeyCode.PageDown,
+					mac: { primary: KeyMod.WinCtrl | KeyCode.PageUp, },
+					weight: KeybindingWeight.WorkbenchContrib + 1
 				},
 			]
 		});
@@ -180,10 +180,10 @@ registerAction2(class FocusPreviousCellAction extends NotebookCellAction {
 					weight: KeybindingWeight.WorkbenchContrib, // markdown keybinding, focus on list: higher weight to override list.focusDown
 				},
 				{
-					when: NOTEBOOK_EDITOR_FOCUSED,
-					primary: KeyMod.CtrlCmd | KeyMod.Alt | KeyCode.PageUp,
-					mac: { primary: KeyMod.CtrlCmd | KeyMod.Alt | KeyCode.PageUp },
-					weight: KeybindingWeight.WorkbenchContrib
+					when: ContextKeyExpr.and(NOTEBOOK_CELL_EDITOR_FOCUSED, CONTEXT_ACCESSIBILITY_MODE_ENABLED),
+					primary: KeyMod.CtrlCmd | KeyCode.PageUp,
+					mac: { primary: KeyMod.WinCtrl | KeyCode.PageUp, },
+					weight: KeybindingWeight.WorkbenchContrib + 1
 				},
 			],
 		});


### PR DESCRIPTION
fix https://github.com/microsoft/vscode/issues/215578

Just modifying the current keybinding instead of adding a new one since ctrl+alt+pageup/down was added for SR users, but ended up being a poor binding choice for those particular users.

 
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
