### PR TITLE
chore: add diagnostics to integration test runs

### DIFF
--- a/build/azure-pipelines/win32/product-build-win32-test.yml
+++ b/build/azure-pipelines/win32/product-build-win32-test.yml
@@ -72,6 +72,11 @@ steps:
         }
       displayName: Build integration tests
 
+    - powershell: .\build\azure-pipelines\win32\listprocesses.bat
+      displayName: Diagnostics before integration test runs
+      continueOnError: true
+      condition: succeededOrFailed()
+
     - ${{ if eq(parameters.VSCODE_QUALITY, 'oss') }}:
       - powershell: .\scripts\test-integration.bat --tfs "Integration Tests"
         displayName: Run integration tests (Electron)
@@ -120,6 +125,11 @@ steps:
           exec { .\scripts\test-remote-integration.bat }
         displayName: Run integration tests (Remote)
         timeoutInMinutes: 20
+
+      - powershell: .\build\azure-pipelines\win32\listprocesses.bat
+        displayName: Diagnostics after integration test runs
+        continueOnError: true
+        condition: succeededOrFailed()
 
   - ${{ if eq(parameters.VSCODE_RUN_SMOKE_TESTS, true) }}:
     - powershell: .\build\azure-pipelines\win32\listprocesses.bat


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

CredScan seems to occasionally interfere with release build integration tests. I'm adding these steps to give us more diagnostics output if it happens again.