### PR TITLE
Increase the length of the drop-down shadow of sticky scroll

### DIFF
--- a/src/vs/editor/contrib/stickyScroll/browser/stickyScroll.css
+++ b/src/vs/editor/contrib/stickyScroll/browser/stickyScroll.css
@@ -61,7 +61,7 @@
 
 .monaco-editor .sticky-widget {
 	width: 100%;
-	box-shadow: var(--vscode-editorStickyScroll-shadow) 0 3px 2px -2px;
+	box-shadow: var(--vscode-editorStickyScroll-shadow) 0 4px 2px -2px;
 	z-index: 4;
 	background-color: var(--vscode-editorStickyScroll-background);
 	right: initial !important;


### PR DESCRIPTION
Increase the length of the drop-down shadow of sticky scroll

In relation to https://github.com/microsoft/vscode/issues/215440