### PR TITLE
Fix tsc -p ./src, remove no-default-lib

### DIFF
--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -44,7 +44,6 @@
 		"./vs/code/electron-sandbox/processExplorer/processExplorer.js",
 		"./vs/code/electron-sandbox/workbench/workbench.js",
 		"./vs/workbench/contrib/issue/electron-sandbox/issueReporter.js",
-		"./vs/workbench/contrib/webview/browser/pre/service-worker.js",
 		"./typings",
 		"./vs/**/*.ts",
 		"vscode-dts/vscode.proposed.*.d.ts",

--- a/src/vs/workbench/contrib/webview/browser/pre/service-worker.js
+++ b/src/vs/workbench/contrib/webview/browser/pre/service-worker.js
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 // @ts-check
 
-/// <reference no-default-lib="true"/>
 /// <reference lib="webworker" />
 
 const sw = /** @type {ServiceWorkerGlobalScope} */ (/** @type {any} */ (self));


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

#216566 added this file to `tsconfig` such that `tsc -p ./src` compiles it, but it contained a `no-default-lib` directive. This directive is not supposed to be used except specifically in the case of "I'm writing my own alternative `lib.d.ts` and need to tell TypeScript to use it instead" (see https://www.typescriptlang.org/docs/handbook/triple-slash-directives.html#-reference-no-default-libtrue). Having it breaks the standard library definitions. So, remove that.

This makes the lib errors go away, but then you hit https://github.com/microsoft/TypeScript/issues/20595 as tsconfig includes DOM which cannot be used with WebWorker. So, remove the file from tsconfig again too.

cc @jrieken @bpasero  