### PR TITLE
fix settings editor memory leak

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
@@ -355,7 +355,6 @@ export class SettingsEditor2 extends EditorPane {
 	}
 
 	override async setInput(input: SettingsEditor2Input, options: ISettingsEditorOptions | undefined, context: IEditorOpenContext, token: CancellationToken): Promise<void> {
-		this.inputChangeListener.clear();
 		this.inSettingsEditorContextKey.set(true);
 		await super.setInput(input, options, context, token);
 		if (!this.input) {

--- a/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
@@ -219,7 +219,7 @@ export class SettingsEditor2 extends EditorPane {
 
 	private installedExtensionIds: string[] = [];
 
-	private inputChangeListener: MutableDisposable<IDisposable>
+	private readonly inputChangeListener: MutableDisposable<IDisposable>;
 
 	constructor(
 		group: IEditorGroup,
@@ -291,7 +291,7 @@ export class SettingsEditor2 extends EditorPane {
 		if (ENABLE_LANGUAGE_FILTER && !SettingsEditor2.SUGGESTIONS.includes(`@${LANGUAGE_SETTING_TAG}`)) {
 			SettingsEditor2.SUGGESTIONS.push(`@${LANGUAGE_SETTING_TAG}`);
 		}
-		this.inputChangeListener = this._register(new MutableDisposable())
+		this.inputChangeListener = this._register(new MutableDisposable());
 	}
 
 	override get minimumWidth(): number { return SettingsEditor2.EDITOR_MIN_WIDTH; }
@@ -355,10 +355,9 @@ export class SettingsEditor2 extends EditorPane {
 	}
 
 	override async setInput(input: SettingsEditor2Input, options: ISettingsEditorOptions | undefined, context: IEditorOpenContext, token: CancellationToken): Promise<void> {
-		this.inputChangeListener.clear()
+		this.inputChangeListener.clear();
 		this.inSettingsEditorContextKey.set(true);
 		await super.setInput(input, options, context, token);
-		this.input?.onWillDispose
 		if (!this.input) {
 			return;
 		}

--- a/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
@@ -17,7 +17,7 @@ import { isCancellationError } from 'vs/base/common/errors';
 import { Emitter, Event } from 'vs/base/common/event';
 import { Iterable } from 'vs/base/common/iterator';
 import { KeyCode } from 'vs/base/common/keyCodes';
-import { Disposable, DisposableStore, dispose } from 'vs/base/common/lifecycle';
+import { Disposable, DisposableStore, dispose, type IDisposable, MutableDisposable } from 'vs/base/common/lifecycle';
 import * as platform from 'vs/base/common/platform';
 import { URI } from 'vs/base/common/uri';
 import 'vs/css!./media/settingsEditor2';
@@ -219,6 +219,8 @@ export class SettingsEditor2 extends EditorPane {
 
 	private installedExtensionIds: string[] = [];
 
+	private inputChangeListener: MutableDisposable<IDisposable>
+
 	constructor(
 		group: IEditorGroup,
 		@ITelemetryService telemetryService: ITelemetryService,
@@ -289,6 +291,7 @@ export class SettingsEditor2 extends EditorPane {
 		if (ENABLE_LANGUAGE_FILTER && !SettingsEditor2.SUGGESTIONS.includes(`@${LANGUAGE_SETTING_TAG}`)) {
 			SettingsEditor2.SUGGESTIONS.push(`@${LANGUAGE_SETTING_TAG}`);
 		}
+		this.inputChangeListener = this._register(new MutableDisposable())
 	}
 
 	override get minimumWidth(): number { return SettingsEditor2.EDITOR_MIN_WIDTH; }
@@ -352,8 +355,10 @@ export class SettingsEditor2 extends EditorPane {
 	}
 
 	override async setInput(input: SettingsEditor2Input, options: ISettingsEditorOptions | undefined, context: IEditorOpenContext, token: CancellationToken): Promise<void> {
+		this.inputChangeListener.clear()
 		this.inSettingsEditorContextKey.set(true);
 		await super.setInput(input, options, context, token);
+		this.input?.onWillDispose
 		if (!this.input) {
 			return;
 		}
@@ -382,9 +387,9 @@ export class SettingsEditor2 extends EditorPane {
 
 		// Don't block setInput on render (which can trigger an async search)
 		this.onConfigUpdate(undefined, true).then(() => {
-			this._register(input.onWillDispose(() => {
+			this.inputChangeListener.value = input.onWillDispose(() => {
 				this.searchWidget.setValue('');
-			}));
+			});
 
 			// Init TOC selection
 			this.updateTreeScrollSync();


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Helps with #216649


### Stack Trace

By measuring growing disposable stores, it showed this stack trace very often: 

```
SettingsEditor2._register (vscode/out/vs/base/common/lifecycle.js:393:32)\nvscode/out/vs/workbench/contrib/preferences/browser/settingsEditor2.js:264:22
```

```js
// settingsEditor2.js
this._register(input.onWillDispose(() => {
	this.searchWidget.setValue('');
}));
```

### Possible memory leak cause

It seems when all editors are closed, the last opened editor always remains. But when setting a new editor input, a `input.onWillDispose` listener is added to the `SettingsEditor2`. When opening the `SettingsEditor2` again, a new `input.onWillDispose` listener is added to the initial `SettingsEditor2`.


### Testing

For testing, I ran the same test script opening and closing the settings editor 197 times which showed that the number of `SettingsEditor2Input` instances was reduced from 197 to 2. 

