### PR TITLE
splits up process explorer and issue reporter services

### DIFF
--- a/src/vs/code/electron-main/app.ts
+++ b/src/vs/code/electron-main/app.ts
@@ -1186,7 +1186,7 @@ export class CodeApplication extends Disposable {
 		const issueChannel = ProxyChannel.fromService(accessor.get(IIssueMainService), disposables);
 		mainProcessElectronServer.registerChannel('issue', issueChannel);
 
-		// Issues
+		// Process
 		const processChannel = ProxyChannel.fromService(accessor.get(IProcessMainService), disposables);
 		mainProcessElectronServer.registerChannel('process', processChannel);
 

--- a/src/vs/code/electron-main/app.ts
+++ b/src/vs/code/electron-main/app.ts
@@ -52,8 +52,9 @@ import { DiskFileSystemProvider } from 'vs/platform/files/node/diskFileSystemPro
 import { SyncDescriptor } from 'vs/platform/instantiation/common/descriptors';
 import { IInstantiationService, ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
 import { ServiceCollection } from 'vs/platform/instantiation/common/serviceCollection';
-import { IIssueMainService } from 'vs/platform/issue/common/issue';
+import { IIssueMainService, IProcessMainService } from 'vs/platform/issue/common/issue';
 import { IssueMainService } from 'vs/platform/issue/electron-main/issueMainService';
+import { ProcessMainService } from 'vs/platform/issue/electron-main/processMainService';
 import { IKeyboardLayoutMainService, KeyboardLayoutMainService } from 'vs/platform/keyboardLayout/electron-main/keyboardLayoutMainService';
 import { ILaunchMainService, LaunchMainService } from 'vs/platform/launch/electron-main/launchMainService';
 import { ILifecycleMainService, LifecycleMainPhase, ShutdownReason } from 'vs/platform/lifecycle/electron-main/lifecycleMainService';
@@ -121,7 +122,6 @@ import { Lazy } from 'vs/base/common/lazy';
 import { IAuxiliaryWindowsMainService } from 'vs/platform/auxiliaryWindow/electron-main/auxiliaryWindows';
 import { AuxiliaryWindowsMainService } from 'vs/platform/auxiliaryWindow/electron-main/auxiliaryWindowsMainService';
 import { normalizeNFC } from 'vs/base/common/normalization';
-
 /**
  * The main VS Code application. There will only ever be one instance,
  * even if the user starts many instances (e.g. from the command line).
@@ -1051,6 +1051,9 @@ export class CodeApplication extends Disposable {
 		// Issues
 		services.set(IIssueMainService, new SyncDescriptor(IssueMainService, [this.userEnv]));
 
+		// Process
+		services.set(IProcessMainService, new SyncDescriptor(ProcessMainService, [this.userEnv]));
+
 		// Encryption
 		services.set(IEncryptionMainService, new SyncDescriptor(EncryptionMainService));
 
@@ -1182,6 +1185,10 @@ export class CodeApplication extends Disposable {
 		// Issues
 		const issueChannel = ProxyChannel.fromService(accessor.get(IIssueMainService), disposables);
 		mainProcessElectronServer.registerChannel('issue', issueChannel);
+
+		// Issues
+		const processChannel = ProxyChannel.fromService(accessor.get(IProcessMainService), disposables);
+		mainProcessElectronServer.registerChannel('process', processChannel);
 
 		// Encryption
 		const encryptionChannel = ProxyChannel.fromService(accessor.get(IEncryptionMainService), disposables);

--- a/src/vs/platform/issue/common/issue.ts
+++ b/src/vs/platform/issue/common/issue.ts
@@ -127,18 +127,25 @@ export const IIssueMainService = createDecorator<IIssueMainService>('issueServic
 
 export interface IIssueMainService {
 	readonly _serviceBrand: undefined;
-	stopTracing(): Promise<void>;
-	openReporter(data: IssueReporterData): Promise<void>;
-	openProcessExplorer(data: ProcessExplorerData): Promise<void>;
-	getSystemStatus(): Promise<string>;
 
 	// Used by the issue reporter
-
-	$getSystemInfo(): Promise<SystemInfo>;
-	$getPerformanceInfo(): Promise<PerformanceInfo>;
+	openReporter(data: IssueReporterData): Promise<void>;
 	$reloadWithExtensionsDisabled(): Promise<void>;
 	$showConfirmCloseDialog(): Promise<void>;
 	$showClipboardDialog(): Promise<boolean>;
 	$sendReporterMenu(extensionId: string, extensionName: string): Promise<IssueReporterData | undefined>;
 	$closeReporter(): Promise<void>;
+}
+
+export const IProcessMainService = createDecorator<IProcessMainService>('processService');
+
+export interface IProcessMainService {
+	readonly _serviceBrand: undefined;
+	getSystemStatus(): Promise<string>;
+	stopTracing(): Promise<void>;
+	openProcessExplorer(data: ProcessExplorerData): Promise<void>;
+
+	// Used by the process explorer
+	$getSystemInfo(): Promise<SystemInfo>;
+	$getPerformanceInfo(): Promise<PerformanceInfo>;
 }

--- a/src/vs/platform/issue/electron-main/processMainService.ts
+++ b/src/vs/platform/issue/electron-main/processMainService.ts
@@ -3,26 +3,28 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { BrowserWindow, BrowserWindowConstructorOptions, Display, screen } from 'electron';
-import { arch, release, type } from 'os';
-import { raceTimeout } from 'vs/base/common/async';
-import { CancellationTokenSource } from 'vs/base/common/cancellation';
+import { BrowserWindow, BrowserWindowConstructorOptions, contentTracing, Display, IpcMainEvent, screen } from 'electron';
+import { randomPath } from 'vs/base/common/extpath';
 import { DisposableStore } from 'vs/base/common/lifecycle';
 import { FileAccess } from 'vs/base/common/network';
 import { IProcessEnvironment, isMacintosh } from 'vs/base/common/platform';
+import { listProcesses } from 'vs/base/node/ps';
 import { validatedIpcMain } from 'vs/base/parts/ipc/electron-main/ipcMain';
 import { localize } from 'vs/nls';
+import { IDiagnosticsService, isRemoteDiagnosticError, PerformanceInfo, SystemInfo } from 'vs/platform/diagnostics/common/diagnostics';
+import { IDiagnosticsMainService } from 'vs/platform/diagnostics/electron-main/diagnosticsMainService';
 import { IDialogMainService } from 'vs/platform/dialogs/electron-main/dialogMainService';
 import { IEnvironmentMainService } from 'vs/platform/environment/electron-main/environmentMainService';
-import { IIssueMainService, IssueReporterData, IssueReporterWindowConfiguration, ProcessExplorerData, ProcessExplorerWindowConfiguration } from 'vs/platform/issue/common/issue';
+import { IProcessMainService, ProcessExplorerData, ProcessExplorerWindowConfiguration } from 'vs/platform/issue/common/issue';
 import { ILogService } from 'vs/platform/log/common/log';
 import { INativeHostMainService } from 'vs/platform/native/electron-main/nativeHostMainService';
 import product from 'vs/platform/product/common/product';
+import { IProductService } from 'vs/platform/product/common/productService';
 import { IIPCObjectUrl, IProtocolMainService } from 'vs/platform/protocol/electron-main/protocol';
 import { IStateService } from 'vs/platform/state/node/state';
+import { UtilityProcess } from 'vs/platform/utilityProcess/electron-main/utilityProcess';
 import { zoomLevelToZoomFactor } from 'vs/platform/window/common/window';
-import { ICodeWindow, IWindowState } from 'vs/platform/window/electron-main/window';
-import { IWindowsMainService } from 'vs/platform/windows/electron-main/windows';
+import { IWindowState } from 'vs/platform/window/electron-main/window';
 
 const processExplorerWindowState = 'issue.processExplorerWindowState';
 
@@ -35,14 +37,11 @@ interface IBrowserWindowOptions {
 
 type IStrictWindowState = Required<Pick<IWindowState, 'x' | 'y' | 'width' | 'height'>>;
 
-export class IssueMainService implements IIssueMainService {
+export class ProcessMainService implements IProcessMainService {
 
 	declare readonly _serviceBrand: undefined;
 
 	private static readonly DEFAULT_BACKGROUND_COLOR = '#1E1E1E';
-
-	private issueReporterWindow: BrowserWindow | null = null;
-	private issueReporterParentWindow: BrowserWindow | null = null;
 
 	private processExplorerWindow: BrowserWindow | null = null;
 	private processExplorerParentWindow: BrowserWindow | null = null;
@@ -51,68 +50,83 @@ export class IssueMainService implements IIssueMainService {
 		private userEnv: IProcessEnvironment,
 		@IEnvironmentMainService private readonly environmentMainService: IEnvironmentMainService,
 		@ILogService private readonly logService: ILogService,
+		@IDiagnosticsService private readonly diagnosticsService: IDiagnosticsService,
+		@IDiagnosticsMainService private readonly diagnosticsMainService: IDiagnosticsMainService,
 		@IDialogMainService private readonly dialogMainService: IDialogMainService,
 		@INativeHostMainService private readonly nativeHostMainService: INativeHostMainService,
 		@IProtocolMainService private readonly protocolMainService: IProtocolMainService,
+		@IProductService private readonly productService: IProductService,
 		@IStateService private readonly stateService: IStateService,
-		@IWindowsMainService private readonly windowsMainService: IWindowsMainService,
-	) { }
+	) {
+		this.registerListeners();
+	}
 
-	//#region Used by renderer
+	//#region Register Listeners
 
-	async openReporter(data: IssueReporterData): Promise<void> {
-		if (!this.issueReporterWindow) {
-			this.issueReporterParentWindow = BrowserWindow.getFocusedWindow();
-			if (this.issueReporterParentWindow) {
-				const issueReporterDisposables = new DisposableStore();
+	private registerListeners(): void {
+		validatedIpcMain.on('vscode:listProcesses', async event => {
+			const processes = [];
 
-				const issueReporterWindowConfigUrl = issueReporterDisposables.add(this.protocolMainService.createIPCObjectUrl<IssueReporterWindowConfiguration>());
-				const position = this.getWindowPosition(this.issueReporterParentWindow, 700, 800);
+			try {
+				processes.push({ name: localize('local', "Local"), rootProcess: await listProcesses(process.pid) });
 
-				this.issueReporterWindow = this.createBrowserWindow(position, issueReporterWindowConfigUrl, {
-					backgroundColor: data.styles.backgroundColor,
-					title: localize('issueReporter', "Issue Reporter"),
-					zoomLevel: data.zoomLevel,
-					alwaysOnTop: false
-				}, 'issue-reporter');
-
-				// Store into config object URL
-				issueReporterWindowConfigUrl.update({
-					appRoot: this.environmentMainService.appRoot,
-					windowId: this.issueReporterWindow.id,
-					userEnv: this.userEnv,
-					data,
-					disableExtensions: !!this.environmentMainService.disableExtensions,
-					os: {
-						type: type(),
-						arch: arch(),
-						release: release(),
-					},
-					product
-				});
-
-				this.issueReporterWindow.loadURL(
-					FileAccess.asBrowserUri(`vs/workbench/contrib/issue/electron-sandbox/issueReporter${this.environmentMainService.isBuilt ? '' : '-dev'}.html`).toString(true)
-				);
-
-				this.issueReporterWindow.on('close', () => {
-					this.issueReporterWindow = null;
-					issueReporterDisposables.dispose();
-				});
-
-				this.issueReporterParentWindow.on('closed', () => {
-					if (this.issueReporterWindow) {
-						this.issueReporterWindow.close();
-						this.issueReporterWindow = null;
-						issueReporterDisposables.dispose();
+				const remoteDiagnostics = await this.diagnosticsMainService.getRemoteDiagnostics({ includeProcesses: true });
+				remoteDiagnostics.forEach(data => {
+					if (isRemoteDiagnosticError(data)) {
+						processes.push({
+							name: data.hostName,
+							rootProcess: data
+						});
+					} else {
+						if (data.processes) {
+							processes.push({
+								name: data.hostName,
+								rootProcess: data.processes
+							});
+						}
 					}
 				});
+			} catch (e) {
+				this.logService.error(`Listing processes failed: ${e}`);
 			}
-		}
 
-		else if (this.issueReporterWindow) {
-			this.focusWindow(this.issueReporterWindow);
-		}
+			this.safeSend(event, 'vscode:listProcessesResponse', processes);
+		});
+
+		validatedIpcMain.on('vscode:workbenchCommand', (_: unknown, commandInfo: { id: any; from: any; args: any }) => {
+			const { id, from, args } = commandInfo;
+
+			let parentWindow: BrowserWindow | null;
+			switch (from) {
+				case 'processExplorer':
+					parentWindow = this.processExplorerParentWindow;
+					break;
+				default:
+					// The issue reporter does not use this anymore.
+					throw new Error(`Unexpected command source: ${from}`);
+			}
+
+			parentWindow?.webContents.send('vscode:runAction', { id, from, args });
+		});
+
+		validatedIpcMain.on('vscode:closeProcessExplorer', event => {
+			this.processExplorerWindow?.close();
+		});
+
+		validatedIpcMain.on('vscode:pidToNameRequest', async event => {
+			const mainProcessInfo = await this.diagnosticsMainService.getMainDiagnostics();
+
+			const pidToNames: [number, string][] = [];
+			for (const window of mainProcessInfo.windows) {
+				pidToNames.push([window.pid, `window [${window.id}] (${window.title})`]);
+			}
+
+			for (const { pid, name } of UtilityProcess.getAll()) {
+				pidToNames.push([pid, name]);
+			}
+
+			this.safeSend(event, 'vscode:pidToNameResponse', pidToNames);
+		});
 	}
 
 	async openProcessExplorer(data: ProcessExplorerData): Promise<void> {
@@ -188,122 +202,12 @@ export class IssueMainService implements IIssueMainService {
 		}
 	}
 
-	//#endregion
-
-	//#region used by issue reporter window
-	async $reloadWithExtensionsDisabled(): Promise<void> {
-		if (this.issueReporterParentWindow) {
-			try {
-				await this.nativeHostMainService.reload(this.issueReporterParentWindow.id, { disableExtensions: true });
-			} catch (error) {
-				this.logService.error(error);
-			}
-		}
-	}
-
-	async $showConfirmCloseDialog(): Promise<void> {
-		if (this.issueReporterWindow) {
-			const { response } = await this.dialogMainService.showMessageBox({
-				type: 'warning',
-				message: localize('confirmCloseIssueReporter', "Your input will not be saved. Are you sure you want to close this window?"),
-				buttons: [
-					localize({ key: 'yes', comment: ['&& denotes a mnemonic'] }, "&&Yes"),
-					localize('cancel', "Cancel")
-				]
-			}, this.issueReporterWindow);
-
-			if (response === 0) {
-				if (this.issueReporterWindow) {
-					this.issueReporterWindow.destroy();
-					this.issueReporterWindow = null;
-				}
-			}
-		}
-	}
-
-	async $showClipboardDialog(): Promise<boolean> {
-		if (this.issueReporterWindow) {
-			const { response } = await this.dialogMainService.showMessageBox({
-				type: 'warning',
-				message: localize('issueReporterWriteToClipboard', "There is too much data to send to GitHub directly. The data will be copied to the clipboard, please paste it into the GitHub issue page that is opened."),
-				buttons: [
-					localize({ key: 'ok', comment: ['&& denotes a mnemonic'] }, "&&OK"),
-					localize('cancel', "Cancel")
-				]
-			}, this.issueReporterWindow);
-
-			return response === 0;
-		}
-
-		return false;
-	}
-
-	issueReporterWindowCheck(): ICodeWindow {
-		if (!this.issueReporterParentWindow) {
-			throw new Error('Issue reporter window not available');
-		}
-		const window = this.windowsMainService.getWindowById(this.issueReporterParentWindow.id);
-		if (!window) {
-			throw new Error('Window not found');
-		}
-		return window;
-	}
-
-	async $sendReporterMenu(extensionId: string, extensionName: string): Promise<IssueReporterData | undefined> {
-		const window = this.issueReporterWindowCheck();
-		const replyChannel = `vscode:triggerReporterMenu`;
-		const cts = new CancellationTokenSource();
-		window.sendWhenReady(replyChannel, cts.token, { replyChannel, extensionId, extensionName });
-		const result = await raceTimeout(new Promise(resolve => validatedIpcMain.once(`vscode:triggerReporterMenuResponse:${extensionId}`, (_: unknown, data: IssueReporterData | undefined) => resolve(data))), 5000, () => {
-			this.logService.error(`Error: Extension ${extensionId} timed out waiting for menu response`);
-			cts.cancel();
-		});
-		return result as IssueReporterData | undefined;
-	}
-
-	async $closeReporter(): Promise<void> {
-		this.issueReporterWindow?.close();
-	}
-
-	//#endregion
-
 	private focusWindow(window: BrowserWindow): void {
 		if (window.isMinimized()) {
 			window.restore();
 		}
 
 		window.focus();
-	}
-
-	private createBrowserWindow<T>(position: IWindowState, ipcObjectUrl: IIPCObjectUrl<T>, options: IBrowserWindowOptions, windowKind: string): BrowserWindow {
-		const window = new BrowserWindow({
-			fullscreen: false,
-			skipTaskbar: false,
-			resizable: true,
-			width: position.width,
-			height: position.height,
-			minWidth: 300,
-			minHeight: 200,
-			x: position.x,
-			y: position.y,
-			title: options.title,
-			backgroundColor: options.backgroundColor || IssueMainService.DEFAULT_BACKGROUND_COLOR,
-			webPreferences: {
-				preload: FileAccess.asFileUri('vs/base/parts/sandbox/electron-sandbox/preload.js').fsPath,
-				additionalArguments: [`--vscode-window-config=${ipcObjectUrl.resource.toString()}`],
-				v8CacheOptions: this.environmentMainService.useCodeCache ? 'bypassHeatCheck' : 'none',
-				enableWebSQL: false,
-				spellcheck: false,
-				zoomFactor: zoomLevelToZoomFactor(options.zoomLevel),
-				sandbox: true
-			},
-			alwaysOnTop: options.alwaysOnTop,
-			experimentalDarkMode: true
-		} as BrowserWindowConstructorOptions & { experimentalDarkMode: boolean });
-
-		window.setMenuBarVisibility(false);
-
-		return window;
 	}
 
 	private getWindowPosition(parentWindow: BrowserWindow, defaultWidth: number, defaultHeight: number): IStrictWindowState {
@@ -373,6 +277,88 @@ export class IssueMainService implements IIssueMainService {
 		}
 
 		return state;
+	}
+
+	async stopTracing(): Promise<void> {
+		if (!this.environmentMainService.args.trace) {
+			return; // requires tracing to be on
+		}
+
+		const path = await contentTracing.stopRecording(`${randomPath(this.environmentMainService.userHome.fsPath, this.productService.applicationName)}.trace.txt`);
+
+		// Inform user to report an issue
+		await this.dialogMainService.showMessageBox({
+			type: 'info',
+			message: localize('trace.message', "Successfully created the trace file"),
+			detail: localize('trace.detail', "Please create an issue and manually attach the following file:\n{0}", path),
+			buttons: [localize({ key: 'trace.ok', comment: ['&& denotes a mnemonic'] }, "&&OK")],
+		}, BrowserWindow.getFocusedWindow() ?? undefined);
+
+		// Show item in explorer
+		this.nativeHostMainService.showItemInFolder(undefined, path);
+	}
+
+	async getSystemStatus(): Promise<string> {
+		const [info, remoteData] = await Promise.all([this.diagnosticsMainService.getMainDiagnostics(), this.diagnosticsMainService.getRemoteDiagnostics({ includeProcesses: false, includeWorkspaceMetadata: false })]);
+		return this.diagnosticsService.getDiagnostics(info, remoteData);
+	}
+
+	async $getSystemInfo(): Promise<SystemInfo> {
+		const [info, remoteData] = await Promise.all([this.diagnosticsMainService.getMainDiagnostics(), this.diagnosticsMainService.getRemoteDiagnostics({ includeProcesses: false, includeWorkspaceMetadata: false })]);
+		const msg = await this.diagnosticsService.getSystemInfo(info, remoteData);
+		return msg;
+	}
+
+	async $getPerformanceInfo(): Promise<PerformanceInfo> {
+		try {
+			const [info, remoteData] = await Promise.all([this.diagnosticsMainService.getMainDiagnostics(), this.diagnosticsMainService.getRemoteDiagnostics({ includeProcesses: true, includeWorkspaceMetadata: true })]);
+			return await this.diagnosticsService.getPerformanceInfo(info, remoteData);
+		} catch (error) {
+			this.logService.warn('issueService#getPerformanceInfo ', error.message);
+
+			throw error;
+		}
+	}
+
+	private createBrowserWindow<T>(position: IWindowState, ipcObjectUrl: IIPCObjectUrl<T>, options: IBrowserWindowOptions, windowKind: string): BrowserWindow {
+		const window = new BrowserWindow({
+			fullscreen: false,
+			skipTaskbar: false,
+			resizable: true,
+			width: position.width,
+			height: position.height,
+			minWidth: 300,
+			minHeight: 200,
+			x: position.x,
+			y: position.y,
+			title: options.title,
+			backgroundColor: options.backgroundColor || ProcessMainService.DEFAULT_BACKGROUND_COLOR,
+			webPreferences: {
+				preload: FileAccess.asFileUri('vs/base/parts/sandbox/electron-sandbox/preload.js').fsPath,
+				additionalArguments: [`--vscode-window-config=${ipcObjectUrl.resource.toString()}`],
+				v8CacheOptions: this.environmentMainService.useCodeCache ? 'bypassHeatCheck' : 'none',
+				enableWebSQL: false,
+				spellcheck: false,
+				zoomFactor: zoomLevelToZoomFactor(options.zoomLevel),
+				sandbox: true
+			},
+			alwaysOnTop: options.alwaysOnTop,
+			experimentalDarkMode: true
+		} as BrowserWindowConstructorOptions & { experimentalDarkMode: boolean });
+
+		window.setMenuBarVisibility(false);
+
+		return window;
+	}
+
+	private safeSend(event: IpcMainEvent, channel: string, ...args: unknown[]): void {
+		if (!event.sender.isDestroyed()) {
+			event.sender.send(channel, ...args);
+		}
+	}
+
+	async closeProcessExplorer(): Promise<void> {
+		this.processExplorerWindow?.close();
 	}
 }
 

--- a/src/vs/workbench/contrib/issue/browser/issue.ts
+++ b/src/vs/workbench/contrib/issue/browser/issue.ts
@@ -240,26 +240,6 @@ export class BaseIssueReporterService extends Disposable {
 	}
 
 	public setEventHandlers(): void {
-		this.addEventListener('issue-type', 'change', (event: Event) => {
-			const issueType = parseInt((<HTMLInputElement>event.target).value);
-			this.issueReporterModel.update({ issueType: issueType });
-			if (issueType === IssueType.PerformanceIssue && !this.receivedPerformanceInfo) {
-				this.issueMainService.$getPerformanceInfo().then(info => {
-					this.updatePerformanceInfo(info as Partial<IssueReporterData>);
-				});
-			}
-
-			// Resets placeholder
-			const descriptionTextArea = <HTMLInputElement>this.getElementById('issue-title');
-			if (descriptionTextArea) {
-				descriptionTextArea.placeholder = localize('undefinedPlaceholder', "Please enter a title");
-			}
-
-			this.updatePreviewButtonState();
-			this.setSourceOptions();
-			this.render();
-		});
-
 		(['includeSystemInfo', 'includeProcessInfo', 'includeWorkspaceInfo', 'includeExtensions', 'includeExperiments', 'includeExtensionData'] as const).forEach(elementId => {
 			this.addEventListener(elementId, 'click', (event: Event) => {
 				event.stopPropagation();

--- a/src/vs/workbench/contrib/issue/browser/issueReporterService.ts
+++ b/src/vs/workbench/contrib/issue/browser/issueReporterService.ts
@@ -72,6 +72,20 @@ export class IssueWebReporter extends BaseIssueReporterService {
 
 	public override setEventHandlers(): void {
 		super.setEventHandlers();
+		this.addEventListener('issue-type', 'change', (event: Event) => {
+			const issueType = parseInt((<HTMLInputElement>event.target).value);
+			this.issueReporterModel.update({ issueType: issueType });
+
+			// Resets placeholder
+			const descriptionTextArea = <HTMLInputElement>this.getElementById('issue-title');
+			if (descriptionTextArea) {
+				descriptionTextArea.placeholder = localize('undefinedPlaceholder', "Please enter a title");
+			}
+
+			this.updatePreviewButtonState();
+			this.setSourceOptions();
+			this.render();
+		});
 		this.previewButton.onDidClick(async () => {
 			this.delayedSubmit.trigger(async () => {
 				this.createIssue();

--- a/src/vs/workbench/contrib/issue/common/issue.ts
+++ b/src/vs/workbench/contrib/issue/common/issue.ts
@@ -10,5 +10,12 @@ export const IWorkbenchIssueService = createDecorator<IWorkbenchIssueService>('w
 export interface IWorkbenchIssueService {
 	readonly _serviceBrand: undefined;
 	openReporter(dataOverrides?: Partial<IssueReporterData>): Promise<void>;
+}
+
+export const IWorkbenchProcessService = createDecorator<IWorkbenchProcessService>('workbenchProcessService');
+
+export interface IWorkbenchProcessService {
+	readonly _serviceBrand: undefined;
 	openProcessExplorer(): Promise<void>;
 }
+

--- a/src/vs/workbench/contrib/issue/electron-sandbox/issue.contribution.ts
+++ b/src/vs/workbench/contrib/issue/electron-sandbox/issue.contribution.ts
@@ -4,9 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { localize, localize2 } from 'vs/nls';
-import { MenuRegistry, MenuId, registerAction2, Action2 } from 'vs/platform/actions/common/actions';
-import { IWorkbenchIssueService, IWorkbenchProcessService } from 'vs/workbench/contrib/issue/common/issue';
-import { CommandsRegistry } from 'vs/platform/commands/common/commands';
+import { registerAction2, Action2 } from 'vs/platform/actions/common/actions';
+import { IWorkbenchIssueService } from 'vs/workbench/contrib/issue/common/issue';
 import { BaseIssueContribution } from 'vs/workbench/contrib/issue/common/issue.contribution';
 import { IProductService } from 'vs/platform/product/common/productService';
 import { Registry } from 'vs/platform/registry/common/platform';
@@ -14,20 +13,14 @@ import { Extensions, IWorkbenchContributionsRegistry } from 'vs/workbench/common
 import { LifecyclePhase } from 'vs/workbench/services/lifecycle/common/lifecycle';
 import { Categories } from 'vs/platform/action/common/actionCommonCategories';
 import { ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
-import { INativeEnvironmentService } from 'vs/platform/environment/common/environment';
-import { IDialogService } from 'vs/platform/dialogs/common/dialogs';
-import { INativeHostService } from 'vs/platform/native/common/native';
-import { IProgressService, ProgressLocation } from 'vs/platform/progress/common/progress';
-import { IProcessMainService, IssueType } from 'vs/platform/issue/common/issue';
+import { IssueType } from 'vs/platform/issue/common/issue';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { IDisposable } from 'vs/base/common/lifecycle';
 import { IQuickAccessRegistry, Extensions as QuickAccessExtensions } from 'vs/platform/quickinput/common/quickAccess';
 import { IssueQuickAccess } from 'vs/workbench/contrib/issue/browser/issueQuickAccess';
 import 'vs/workbench/contrib/issue/electron-sandbox/issueMainService';
 import 'vs/workbench/contrib/issue/electron-sandbox/issueService';
-import 'vs/workbench/contrib/issue/electron-sandbox/processService';
 import 'vs/workbench/contrib/issue/browser/issueTroubleshoot';
-
 
 //#region Issue Contribution
 
@@ -95,81 +88,3 @@ class ReportPerformanceIssueUsingReporterAction extends Action2 {
 }
 
 // #endregion
-
-// #region Commands
-
-class OpenProcessExplorer extends Action2 {
-
-	static readonly ID = 'workbench.action.openProcessExplorer';
-
-	constructor() {
-		super({
-			id: OpenProcessExplorer.ID,
-			title: localize2('openProcessExplorer', 'Open Process Explorer'),
-			category: Categories.Developer,
-			f1: true
-		});
-	}
-
-	override async run(accessor: ServicesAccessor): Promise<void> {
-		const processService = accessor.get(IWorkbenchProcessService);
-
-		return processService.openProcessExplorer();
-	}
-}
-registerAction2(OpenProcessExplorer);
-MenuRegistry.appendMenuItem(MenuId.MenubarHelpMenu, {
-	group: '5_tools',
-	command: {
-		id: OpenProcessExplorer.ID,
-		title: localize({ key: 'miOpenProcessExplorerer', comment: ['&& denotes a mnemonic'] }, "Open &&Process Explorer")
-	},
-	order: 2
-});
-
-class StopTracing extends Action2 {
-
-	static readonly ID = 'workbench.action.stopTracing';
-
-	constructor() {
-		super({
-			id: StopTracing.ID,
-			title: localize2('stopTracing', 'Stop Tracing'),
-			category: Categories.Developer,
-			f1: true
-		});
-	}
-
-	override async run(accessor: ServicesAccessor): Promise<void> {
-		const processService = accessor.get(IProcessMainService);
-		const environmentService = accessor.get(INativeEnvironmentService);
-		const dialogService = accessor.get(IDialogService);
-		const nativeHostService = accessor.get(INativeHostService);
-		const progressService = accessor.get(IProgressService);
-
-		if (!environmentService.args.trace) {
-			const { confirmed } = await dialogService.confirm({
-				message: localize('stopTracing.message', "Tracing requires to launch with a '--trace' argument"),
-				primaryButton: localize({ key: 'stopTracing.button', comment: ['&& denotes a mnemonic'] }, "&&Relaunch and Enable Tracing"),
-			});
-
-			if (confirmed) {
-				return nativeHostService.relaunch({ addArgs: ['--trace'] });
-			}
-		}
-
-		await progressService.withProgress({
-			location: ProgressLocation.Dialog,
-			title: localize('stopTracing.title', "Creating trace file..."),
-			cancellable: false,
-			detail: localize('stopTracing.detail', "This can take up to one minute to complete.")
-		}, () => processService.stopTracing());
-	}
-}
-registerAction2(StopTracing);
-
-CommandsRegistry.registerCommand('_issues.getSystemStatus', (accessor) => {
-	return accessor.get(IProcessMainService).getSystemStatus();
-});
-
-//#endregion

--- a/src/vs/workbench/contrib/issue/electron-sandbox/issue.contribution.ts
+++ b/src/vs/workbench/contrib/issue/electron-sandbox/issue.contribution.ts
@@ -5,7 +5,7 @@
 
 import { localize, localize2 } from 'vs/nls';
 import { MenuRegistry, MenuId, registerAction2, Action2 } from 'vs/platform/actions/common/actions';
-import { IWorkbenchIssueService } from 'vs/workbench/contrib/issue/common/issue';
+import { IWorkbenchIssueService, IWorkbenchProcessService } from 'vs/workbench/contrib/issue/common/issue';
 import { CommandsRegistry } from 'vs/platform/commands/common/commands';
 import { BaseIssueContribution } from 'vs/workbench/contrib/issue/common/issue.contribution';
 import { IProductService } from 'vs/platform/product/common/productService';
@@ -18,13 +18,14 @@ import { INativeEnvironmentService } from 'vs/platform/environment/common/enviro
 import { IDialogService } from 'vs/platform/dialogs/common/dialogs';
 import { INativeHostService } from 'vs/platform/native/common/native';
 import { IProgressService, ProgressLocation } from 'vs/platform/progress/common/progress';
-import { IIssueMainService, IssueType } from 'vs/platform/issue/common/issue';
+import { IProcessMainService, IssueType } from 'vs/platform/issue/common/issue';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { IDisposable } from 'vs/base/common/lifecycle';
 import { IQuickAccessRegistry, Extensions as QuickAccessExtensions } from 'vs/platform/quickinput/common/quickAccess';
 import { IssueQuickAccess } from 'vs/workbench/contrib/issue/browser/issueQuickAccess';
 import 'vs/workbench/contrib/issue/electron-sandbox/issueMainService';
 import 'vs/workbench/contrib/issue/electron-sandbox/issueService';
+import 'vs/workbench/contrib/issue/electron-sandbox/processService';
 import 'vs/workbench/contrib/issue/browser/issueTroubleshoot';
 
 
@@ -87,15 +88,15 @@ class ReportPerformanceIssueUsingReporterAction extends Action2 {
 	}
 
 	override async run(accessor: ServicesAccessor): Promise<void> {
-		const issueService = accessor.get(IWorkbenchIssueService);
+		const issueService = accessor.get(IWorkbenchIssueService); // later can just get IIssueFormService
 
 		return issueService.openReporter({ issueType: IssueType.PerformanceIssue });
 	}
 }
 
-//#endregion
+// #endregion
 
-//#region Commands
+// #region Commands
 
 class OpenProcessExplorer extends Action2 {
 
@@ -111,9 +112,9 @@ class OpenProcessExplorer extends Action2 {
 	}
 
 	override async run(accessor: ServicesAccessor): Promise<void> {
-		const issueService = accessor.get(IWorkbenchIssueService);
+		const processService = accessor.get(IWorkbenchProcessService);
 
-		return issueService.openProcessExplorer();
+		return processService.openProcessExplorer();
 	}
 }
 registerAction2(OpenProcessExplorer);
@@ -140,7 +141,7 @@ class StopTracing extends Action2 {
 	}
 
 	override async run(accessor: ServicesAccessor): Promise<void> {
-		const issueService = accessor.get(IIssueMainService);
+		const processService = accessor.get(IProcessMainService);
 		const environmentService = accessor.get(INativeEnvironmentService);
 		const dialogService = accessor.get(IDialogService);
 		const nativeHostService = accessor.get(INativeHostService);
@@ -162,12 +163,13 @@ class StopTracing extends Action2 {
 			title: localize('stopTracing.title', "Creating trace file..."),
 			cancellable: false,
 			detail: localize('stopTracing.detail', "This can take up to one minute to complete.")
-		}, () => issueService.stopTracing());
+		}, () => processService.stopTracing());
 	}
 }
 registerAction2(StopTracing);
 
 CommandsRegistry.registerCommand('_issues.getSystemStatus', (accessor) => {
-	return accessor.get(IIssueMainService).getSystemStatus();
+	return accessor.get(IProcessMainService).getSystemStatus();
 });
+
 //#endregion

--- a/src/vs/workbench/contrib/issue/electron-sandbox/issueMainService.ts
+++ b/src/vs/workbench/contrib/issue/electron-sandbox/issueMainService.ts
@@ -4,6 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { registerMainProcessRemoteService } from 'vs/platform/ipc/electron-sandbox/services';
-import { IIssueMainService } from 'vs/platform/issue/common/issue';
+import { IIssueMainService, IProcessMainService } from 'vs/platform/issue/common/issue';
 
 registerMainProcessRemoteService(IIssueMainService, 'issue');
+registerMainProcessRemoteService(IProcessMainService, 'process');
+

--- a/src/vs/workbench/contrib/issue/electron-sandbox/issueReporterMain.ts
+++ b/src/vs/workbench/contrib/issue/electron-sandbox/issueReporterMain.ts
@@ -15,11 +15,12 @@ import { ServiceCollection } from 'vs/platform/instantiation/common/serviceColle
 import { IMainProcessService } from 'vs/platform/ipc/common/mainProcessService';
 import { ElectronIPCMainProcessService } from 'vs/platform/ipc/electron-sandbox/mainProcessService';
 import { registerMainProcessRemoteService } from 'vs/platform/ipc/electron-sandbox/services';
-import { IIssueMainService, IssueReporterWindowConfiguration } from 'vs/platform/issue/common/issue';
+import { IIssueMainService, IProcessMainService, IssueReporterWindowConfiguration } from 'vs/platform/issue/common/issue';
 import { INativeHostService } from 'vs/platform/native/common/native';
 import { NativeHostService } from 'vs/platform/native/common/nativeHostService';
 import { IssueReporter2 } from 'vs/workbench/contrib/issue/electron-sandbox/issueReporterService2';
 import { mainWindow } from 'vs/base/browser/window';
+
 
 export function startup(configuration: IssueReporterWindowConfiguration) {
 	const platformClass = isWindows ? 'windows' : isLinux ? 'linux' : 'mac';
@@ -50,3 +51,4 @@ function initServices(windowId: number) {
 }
 
 registerMainProcessRemoteService(IIssueMainService, 'issue');
+registerMainProcessRemoteService(IProcessMainService, 'process');

--- a/src/vs/workbench/contrib/issue/electron-sandbox/issueReporterService.ts
+++ b/src/vs/workbench/contrib/issue/electron-sandbox/issueReporterService.ts
@@ -19,7 +19,7 @@ import { URI } from 'vs/base/common/uri';
 import { IssueReporterModel, IssueReporterData as IssueReporterModelData } from 'vs/workbench/contrib/issue/browser/issueReporterModel';
 import { localize } from 'vs/nls';
 import { isRemoteDiagnosticError } from 'vs/platform/diagnostics/common/diagnostics';
-import { IIssueMainService, IssueReporterData, IssueReporterExtensionData, IssueReporterStyles, IssueReporterWindowConfiguration, IssueType } from 'vs/platform/issue/common/issue';
+import { IIssueMainService, IProcessMainService, IssueReporterData, IssueReporterExtensionData, IssueReporterStyles, IssueReporterWindowConfiguration, IssueType } from 'vs/platform/issue/common/issue';
 import { normalizeGitHubUrl } from 'vs/platform/issue/common/issueReporterUtil';
 import { INativeHostService } from 'vs/platform/native/common/native';
 import { getIconsStyleSheet } from 'vs/platform/theme/browser/iconsStyleSheet';
@@ -59,7 +59,8 @@ export class IssueReporter extends Disposable {
 	constructor(
 		private readonly configuration: IssueReporterWindowConfiguration,
 		@INativeHostService private readonly nativeHostService: INativeHostService,
-		@IIssueMainService private readonly issueMainService: IIssueMainService
+		@IIssueMainService private readonly issueMainService: IIssueMainService,
+		@IProcessMainService private readonly processMainService: IProcessMainService
 	) {
 		super();
 		const targetExtension = configuration.data.extensionId ? configuration.data.enabledExtensions.find(extension => extension.id.toLocaleLowerCase() === configuration.data.extensionId?.toLocaleLowerCase()) : undefined;
@@ -107,7 +108,7 @@ export class IssueReporter extends Disposable {
 			}
 		}
 
-		this.issueMainService.$getSystemInfo().then(info => {
+		this.processMainService.$getSystemInfo().then(info => {
 			this.issueReporterModel.update({ systemInfo: info });
 			this.receivedSystemInfo = true;
 
@@ -115,7 +116,7 @@ export class IssueReporter extends Disposable {
 			this.updatePreviewButtonState();
 		});
 		if (configuration.data.issueType === IssueType.PerformanceIssue) {
-			this.issueMainService.$getPerformanceInfo().then(info => {
+			this.processMainService.$getPerformanceInfo().then(info => {
 				this.updatePerformanceInfo(info as Partial<IssueReporterData>);
 			});
 		}
@@ -286,7 +287,7 @@ export class IssueReporter extends Disposable {
 			const issueType = parseInt((<HTMLInputElement>event.target).value);
 			this.issueReporterModel.update({ issueType: issueType });
 			if (issueType === IssueType.PerformanceIssue && !this.receivedPerformanceInfo) {
-				this.issueMainService.$getPerformanceInfo().then(info => {
+				this.processMainService.$getPerformanceInfo().then(info => {
 					this.updatePerformanceInfo(info as Partial<IssueReporterData>);
 				});
 			}

--- a/src/vs/workbench/contrib/issue/electron-sandbox/issueReporterService2.ts
+++ b/src/vs/workbench/contrib/issue/electron-sandbox/issueReporterService2.ts
@@ -12,7 +12,7 @@ import { ThemeIcon } from 'vs/base/common/themables';
 import { URI } from 'vs/base/common/uri';
 import { localize } from 'vs/nls';
 import { isRemoteDiagnosticError } from 'vs/platform/diagnostics/common/diagnostics';
-import { IIssueMainService, IssueReporterData, IssueReporterExtensionData, IssueReporterWindowConfiguration, IssueType } from 'vs/platform/issue/common/issue';
+import { IIssueMainService, IProcessMainService, IssueReporterData, IssueReporterExtensionData, IssueReporterWindowConfiguration, IssueType } from 'vs/platform/issue/common/issue';
 import { INativeHostService } from 'vs/platform/native/common/native';
 import { applyZoom, zoomIn, zoomOut } from 'vs/platform/window/electron-sandbox/window';
 import { BaseIssueReporterService, hide, show } from 'vs/workbench/contrib/issue/browser/issue';
@@ -24,14 +24,17 @@ const MAX_URL_LENGTH = 7500;
 
 
 export class IssueReporter2 extends BaseIssueReporterService {
+	private readonly processMainService: IProcessMainService;
 	constructor(
 		private readonly configuration: IssueReporterWindowConfiguration,
 		@INativeHostService private readonly nativeHostService: INativeHostService,
-		@IIssueMainService issueMainService: IIssueMainService
+		@IIssueMainService issueMainService: IIssueMainService,
+		@IProcessMainService processMainService: IProcessMainService
 	) {
 		super(configuration.disableExtensions, configuration.data, configuration.os, configuration.product, mainWindow, false, issueMainService);
 
-		this.issueMainService.$getSystemInfo().then(info => {
+		this.processMainService = processMainService;
+		this.processMainService.$getSystemInfo().then(info => {
 			this.issueReporterModel.update({ systemInfo: info });
 			this.receivedSystemInfo = true;
 
@@ -39,7 +42,7 @@ export class IssueReporter2 extends BaseIssueReporterService {
 			this.updatePreviewButtonState();
 		});
 		if (configuration.data.issueType === IssueType.PerformanceIssue) {
-			this.issueMainService.$getPerformanceInfo().then(info => {
+			this.processMainService.$getPerformanceInfo().then(info => {
 				this.updatePerformanceInfo(info as Partial<IssueReporterData>);
 			});
 		}
@@ -80,6 +83,26 @@ export class IssueReporter2 extends BaseIssueReporterService {
 
 	public override setEventHandlers(): void {
 		super.setEventHandlers();
+
+		this.addEventListener('issue-type', 'change', (event: Event) => {
+			const issueType = parseInt((<HTMLInputElement>event.target).value);
+			this.issueReporterModel.update({ issueType: issueType });
+			if (issueType === IssueType.PerformanceIssue && !this.receivedPerformanceInfo) {
+				this.processMainService.$getPerformanceInfo().then(info => {
+					this.updatePerformanceInfo(info as Partial<IssueReporterData>);
+				});
+			}
+
+			// Resets placeholder
+			const descriptionTextArea = <HTMLInputElement>this.getElementById('issue-title');
+			if (descriptionTextArea) {
+				descriptionTextArea.placeholder = localize('undefinedPlaceholder', "Please enter a title");
+			}
+
+			this.updatePreviewButtonState();
+			this.setSourceOptions();
+			this.render();
+		});
 
 		// Keep all event listerns involving window and issue creation
 		this.previewButton.onDidClick(async () => {

--- a/src/vs/workbench/contrib/issue/electron-sandbox/issueService.ts
+++ b/src/vs/workbench/contrib/issue/electron-sandbox/issueService.ts
@@ -4,20 +4,17 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { getZoomLevel } from 'vs/base/browser/browser';
-import { platform } from 'vs/base/common/process';
 import { ipcRenderer } from 'vs/base/parts/sandbox/electron-sandbox/globals';
 import { IExtensionManagementService } from 'vs/platform/extensionManagement/common/extensionManagement';
 import { ExtensionIdentifier, ExtensionType, ExtensionIdentifierSet } from 'vs/platform/extensions/common/extensions';
 import { InstantiationType, registerSingleton } from 'vs/platform/instantiation/common/extensions';
-import { IIssueMainService, IssueReporterData, IssueReporterExtensionData, IssueReporterStyles, ProcessExplorerData } from 'vs/platform/issue/common/issue';
-import { IProductService } from 'vs/platform/product/common/productService';
-import { activeContrastBorder, buttonBackground, buttonForeground, buttonHoverBackground, editorBackground, editorForeground, foreground, inputActiveOptionBorder, inputBackground, inputBorder, inputForeground, inputValidationErrorBackground, inputValidationErrorBorder, inputValidationErrorForeground, listActiveSelectionBackground, listActiveSelectionForeground, listFocusBackground, listFocusForeground, listFocusOutline, listHoverBackground, listHoverForeground, scrollbarShadow, scrollbarSliderActiveBackground, scrollbarSliderBackground, scrollbarSliderHoverBackground, textLinkActiveForeground, textLinkForeground } from 'vs/platform/theme/common/colorRegistry';
+import { IIssueMainService, IssueReporterData, IssueReporterExtensionData, IssueReporterStyles } from 'vs/platform/issue/common/issue';
+import { buttonBackground, buttonForeground, buttonHoverBackground, foreground, inputActiveOptionBorder, inputBackground, inputBorder, inputForeground, inputValidationErrorBackground, inputValidationErrorBorder, inputValidationErrorForeground, scrollbarSliderActiveBackground, scrollbarSliderBackground, scrollbarSliderHoverBackground, textLinkActiveForeground, textLinkForeground } from 'vs/platform/theme/common/colorRegistry';
 import { IColorTheme, IThemeService } from 'vs/platform/theme/common/themeService';
 import { IWorkspaceTrustManagementService } from 'vs/platform/workspace/common/workspaceTrust';
 import { SIDE_BAR_BACKGROUND } from 'vs/workbench/common/theme';
 import { IWorkbenchAssignmentService } from 'vs/workbench/services/assignment/common/assignmentService';
 import { IAuthenticationService } from 'vs/workbench/services/authentication/common/authentication';
-import { INativeWorkbenchEnvironmentService } from 'vs/workbench/services/environment/electron-sandbox/environmentService';
 import { IWorkbenchExtensionEnablementService } from 'vs/workbench/services/extensionManagement/common/extensionManagement';
 import { IIntegrityService } from 'vs/workbench/services/integrity/common/integrity';
 import { IWorkbenchIssueService } from 'vs/workbench/contrib/issue/common/issue';
@@ -34,9 +31,7 @@ export class NativeIssueService implements IWorkbenchIssueService {
 		@IThemeService private readonly themeService: IThemeService,
 		@IExtensionManagementService private readonly extensionManagementService: IExtensionManagementService,
 		@IWorkbenchExtensionEnablementService private readonly extensionEnablementService: IWorkbenchExtensionEnablementService,
-		@INativeWorkbenchEnvironmentService private readonly environmentService: INativeWorkbenchEnvironmentService,
 		@IWorkspaceTrustManagementService private readonly workspaceTrustManagementService: IWorkspaceTrustManagementService,
-		@IProductService private readonly productService: IProductService,
 		@IWorkbenchAssignmentService private readonly experimentService: IWorkbenchAssignmentService,
 		@IAuthenticationService private readonly authenticationService: IAuthenticationService,
 		@IIntegrityService private readonly integrityService: IIntegrityService,
@@ -152,34 +147,6 @@ export class NativeIssueService implements IWorkbenchIssueService {
 		}
 		return this.issueMainService.openReporter(issueReporterData);
 	}
-
-	openProcessExplorer(): Promise<void> {
-		const theme = this.themeService.getColorTheme();
-		const data: ProcessExplorerData = {
-			pid: this.environmentService.mainPid,
-			zoomLevel: getZoomLevel(mainWindow),
-			styles: {
-				backgroundColor: getColor(theme, editorBackground),
-				color: getColor(theme, editorForeground),
-				listHoverBackground: getColor(theme, listHoverBackground),
-				listHoverForeground: getColor(theme, listHoverForeground),
-				listFocusBackground: getColor(theme, listFocusBackground),
-				listFocusForeground: getColor(theme, listFocusForeground),
-				listFocusOutline: getColor(theme, listFocusOutline),
-				listActiveSelectionBackground: getColor(theme, listActiveSelectionBackground),
-				listActiveSelectionForeground: getColor(theme, listActiveSelectionForeground),
-				listHoverOutline: getColor(theme, activeContrastBorder),
-				scrollbarShadowColor: getColor(theme, scrollbarShadow),
-				scrollbarSliderActiveBackgroundColor: getColor(theme, scrollbarSliderActiveBackground),
-				scrollbarSliderBackgroundColor: getColor(theme, scrollbarSliderBackground),
-				scrollbarSliderHoverBackgroundColor: getColor(theme, scrollbarSliderHoverBackground),
-			},
-			platform: platform,
-			applicationName: this.productService.applicationName
-		};
-		return this.issueMainService.openProcessExplorer(data);
-	}
-
 
 }
 

--- a/src/vs/workbench/contrib/issue/electron-sandbox/process.contribution.ts
+++ b/src/vs/workbench/contrib/issue/electron-sandbox/process.contribution.ts
@@ -1,0 +1,96 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { localize, localize2 } from 'vs/nls';
+import { MenuRegistry, MenuId, registerAction2, Action2 } from 'vs/platform/actions/common/actions';
+import { IWorkbenchProcessService } from 'vs/workbench/contrib/issue/common/issue';
+import { CommandsRegistry } from 'vs/platform/commands/common/commands';
+import { Categories } from 'vs/platform/action/common/actionCommonCategories';
+import { ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
+import { INativeEnvironmentService } from 'vs/platform/environment/common/environment';
+import { IDialogService } from 'vs/platform/dialogs/common/dialogs';
+import { INativeHostService } from 'vs/platform/native/common/native';
+import { IProgressService, ProgressLocation } from 'vs/platform/progress/common/progress';
+import { IProcessMainService } from 'vs/platform/issue/common/issue';
+import 'vs/workbench/contrib/issue/electron-sandbox/processService';
+import 'vs/workbench/contrib/issue/electron-sandbox/issueMainService';
+
+
+//#region Commands
+
+class OpenProcessExplorer extends Action2 {
+
+	static readonly ID = 'workbench.action.openProcessExplorer';
+
+	constructor() {
+		super({
+			id: OpenProcessExplorer.ID,
+			title: localize2('openProcessExplorer', 'Open Process Explorer'),
+			category: Categories.Developer,
+			f1: true
+		});
+	}
+
+	override async run(accessor: ServicesAccessor): Promise<void> {
+		const processService = accessor.get(IWorkbenchProcessService);
+
+		return processService.openProcessExplorer();
+	}
+}
+registerAction2(OpenProcessExplorer);
+MenuRegistry.appendMenuItem(MenuId.MenubarHelpMenu, {
+	group: '5_tools',
+	command: {
+		id: OpenProcessExplorer.ID,
+		title: localize({ key: 'miOpenProcessExplorerer', comment: ['&& denotes a mnemonic'] }, "Open &&Process Explorer")
+	},
+	order: 2
+});
+
+class StopTracing extends Action2 {
+
+	static readonly ID = 'workbench.action.stopTracing';
+
+	constructor() {
+		super({
+			id: StopTracing.ID,
+			title: localize2('stopTracing', 'Stop Tracing'),
+			category: Categories.Developer,
+			f1: true
+		});
+	}
+
+	override async run(accessor: ServicesAccessor): Promise<void> {
+		const processService = accessor.get(IProcessMainService);
+		const environmentService = accessor.get(INativeEnvironmentService);
+		const dialogService = accessor.get(IDialogService);
+		const nativeHostService = accessor.get(INativeHostService);
+		const progressService = accessor.get(IProgressService);
+
+		if (!environmentService.args.trace) {
+			const { confirmed } = await dialogService.confirm({
+				message: localize('stopTracing.message', "Tracing requires to launch with a '--trace' argument"),
+				primaryButton: localize({ key: 'stopTracing.button', comment: ['&& denotes a mnemonic'] }, "&&Relaunch and Enable Tracing"),
+			});
+
+			if (confirmed) {
+				return nativeHostService.relaunch({ addArgs: ['--trace'] });
+			}
+		}
+
+		await progressService.withProgress({
+			location: ProgressLocation.Dialog,
+			title: localize('stopTracing.title', "Creating trace file..."),
+			cancellable: false,
+			detail: localize('stopTracing.detail', "This can take up to one minute to complete.")
+		}, () => processService.stopTracing());
+	}
+}
+registerAction2(StopTracing);
+
+CommandsRegistry.registerCommand('_issues.getSystemStatus', (accessor) => {
+	return accessor.get(IProcessMainService).getSystemStatus();
+});
+//#endregion

--- a/src/vs/workbench/contrib/issue/electron-sandbox/processService.ts
+++ b/src/vs/workbench/contrib/issue/electron-sandbox/processService.ts
@@ -1,0 +1,62 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { getZoomLevel } from 'vs/base/browser/browser';
+import { platform } from 'vs/base/common/process';
+import { InstantiationType, registerSingleton } from 'vs/platform/instantiation/common/extensions';
+import { IProcessMainService, ProcessExplorerData } from 'vs/platform/issue/common/issue';
+import { IProductService } from 'vs/platform/product/common/productService';
+import { activeContrastBorder, editorBackground, editorForeground, listActiveSelectionBackground, listActiveSelectionForeground, listFocusBackground, listFocusForeground, listFocusOutline, listHoverBackground, listHoverForeground, scrollbarShadow, scrollbarSliderActiveBackground, scrollbarSliderBackground, scrollbarSliderHoverBackground } from 'vs/platform/theme/common/colorRegistry';
+import { IColorTheme, IThemeService } from 'vs/platform/theme/common/themeService';
+import { INativeWorkbenchEnvironmentService } from 'vs/workbench/services/environment/electron-sandbox/environmentService';
+import { IWorkbenchProcessService } from 'vs/workbench/contrib/issue/common/issue';
+import { mainWindow } from 'vs/base/browser/window';
+
+export class ProcessService implements IWorkbenchProcessService {
+	declare readonly _serviceBrand: undefined;
+
+	constructor(
+		@IProcessMainService private readonly processMainService: IProcessMainService,
+		@IThemeService private readonly themeService: IThemeService,
+		@INativeWorkbenchEnvironmentService private readonly environmentService: INativeWorkbenchEnvironmentService,
+		@IProductService private readonly productService: IProductService,
+	) { }
+
+	openProcessExplorer(): Promise<void> {
+		const theme = this.themeService.getColorTheme();
+		const data: ProcessExplorerData = {
+			pid: this.environmentService.mainPid,
+			zoomLevel: getZoomLevel(mainWindow),
+			styles: {
+				backgroundColor: getColor(theme, editorBackground),
+				color: getColor(theme, editorForeground),
+				listHoverBackground: getColor(theme, listHoverBackground),
+				listHoverForeground: getColor(theme, listHoverForeground),
+				listFocusBackground: getColor(theme, listFocusBackground),
+				listFocusForeground: getColor(theme, listFocusForeground),
+				listFocusOutline: getColor(theme, listFocusOutline),
+				listActiveSelectionBackground: getColor(theme, listActiveSelectionBackground),
+				listActiveSelectionForeground: getColor(theme, listActiveSelectionForeground),
+				listHoverOutline: getColor(theme, activeContrastBorder),
+				scrollbarShadowColor: getColor(theme, scrollbarShadow),
+				scrollbarSliderActiveBackgroundColor: getColor(theme, scrollbarSliderActiveBackground),
+				scrollbarSliderBackgroundColor: getColor(theme, scrollbarSliderBackground),
+				scrollbarSliderHoverBackgroundColor: getColor(theme, scrollbarSliderHoverBackground),
+			},
+			platform: platform,
+			applicationName: this.productService.applicationName
+		};
+		return this.processMainService.openProcessExplorer(data);
+	}
+
+
+}
+
+function getColor(theme: IColorTheme, key: string): string | undefined {
+	const color = theme.getColor(key);
+	return color ? color.toString() : undefined;
+}
+
+registerSingleton(IWorkbenchProcessService, ProcessService, InstantiationType.Delayed);

--- a/src/vs/workbench/workbench.desktop.main.ts
+++ b/src/vs/workbench/workbench.desktop.main.ts
@@ -118,8 +118,8 @@ import 'vs/workbench/contrib/extensions/electron-sandbox/extensions.contribution
 // Issues
 import 'vs/workbench/contrib/issue/electron-sandbox/issue.contribution';
 
-// // Process
-// import 'vs/workbench/contrib/issue/electron-sandbox/process.contribution';
+// Process
+import 'vs/workbench/contrib/issue/electron-sandbox/process.contribution';
 
 // Remote
 import 'vs/workbench/contrib/remote/electron-sandbox/remote.contribution';

--- a/src/vs/workbench/workbench.desktop.main.ts
+++ b/src/vs/workbench/workbench.desktop.main.ts
@@ -118,6 +118,9 @@ import 'vs/workbench/contrib/extensions/electron-sandbox/extensions.contribution
 // Issues
 import 'vs/workbench/contrib/issue/electron-sandbox/issue.contribution';
 
+// // Process
+// import 'vs/workbench/contrib/issue/electron-sandbox/process.contribution';
+
 // Remote
 import 'vs/workbench/contrib/remote/electron-sandbox/remote.contribution';
 

--- a/src/vs/workbench/workbench.web.main.ts
+++ b/src/vs/workbench/workbench.web.main.ts
@@ -156,8 +156,6 @@ import 'vs/workbench/contrib/tags/browser/workspaceTagsService';
 // Issues
 import 'vs/workbench/contrib/issue/browser/issue.contribution';
 
-// // Process
-// import 'vs/workbench/contrib/issue/browser/process.contribution';
 
 // Splash
 import 'vs/workbench/contrib/splash/browser/splash.contribution';

--- a/src/vs/workbench/workbench.web.main.ts
+++ b/src/vs/workbench/workbench.web.main.ts
@@ -156,6 +156,9 @@ import 'vs/workbench/contrib/tags/browser/workspaceTagsService';
 // Issues
 import 'vs/workbench/contrib/issue/browser/issue.contribution';
 
+// // Process
+// import 'vs/workbench/contrib/issue/browser/process.contribution';
+
 // Splash
 import 'vs/workbench/contrib/splash/browser/splash.contribution';
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

part 1 of ongoing effort for issue reporter + floating windows in electron: https://github.com/microsoft/vscode/issues/213332

this sets up the following schema (sorry it's not nice in draw.io):
![NEW (2)](https://github.com/microsoft/vscode/assets/54879025/a9527fdd-d543-4f55-963f-1633f65475b8)


vs. what we currently do:
![OLD](https://github.com/microsoft/vscode/assets/54879025/036e3cee-5bab-4076-a5ee-950423b21627)

This PR mainly does the following:
- Splits up the services (reporter stuff exclusively in reporter)
- does not move anything new into contrib, but we will eventually replace IIssueMainService with IIssueFormService in contrib. IssueMainService will also be turned into an IssueFormService (combining IssuMainService and NativeIssueservice), and we can remove the `IWorkebenchIssueService`

cc. @Tyriar for process explorer things i believe?


