### PR TITLE
Resize terminal horizontal and vertical separately

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
@@ -1844,58 +1844,72 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 		}
 	}
 
-	@debounce(50)
-	private async _resize(): Promise<void> {
-		this._resizeNow(false);
-	}
+	private async _resize(immediate?: boolean): Promise<void> {
+		if (!this.xterm) {
+			return;
+		}
 
-	private async _resizeNow(immediate: boolean): Promise<void> {
 		let cols = this.cols;
 		let rows = this.rows;
 
-		if (this.xterm) {
-			// Only apply these settings when the terminal is visible so that
-			// the characters are measured correctly.
-			if (this._isVisible && this._layoutSettingsChanged) {
-				const font = this.xterm.getFont();
-				const config = this._terminalConfigurationService.config;
-				this.xterm.raw.options.letterSpacing = font.letterSpacing;
-				this.xterm.raw.options.lineHeight = font.lineHeight;
-				this.xterm.raw.options.fontSize = font.fontSize;
-				this.xterm.raw.options.fontFamily = font.fontFamily;
-				this.xterm.raw.options.fontWeight = config.fontWeight;
-				this.xterm.raw.options.fontWeightBold = config.fontWeightBold;
+		// Only apply these settings when the terminal is visible so that
+		// the characters are measured correctly.
+		if (this._isVisible && this._layoutSettingsChanged) {
+			const font = this.xterm.getFont();
+			const config = this._terminalConfigurationService.config;
+			this.xterm.raw.options.letterSpacing = font.letterSpacing;
+			this.xterm.raw.options.lineHeight = font.lineHeight;
+			this.xterm.raw.options.fontSize = font.fontSize;
+			this.xterm.raw.options.fontFamily = font.fontFamily;
+			this.xterm.raw.options.fontWeight = config.fontWeight;
+			this.xterm.raw.options.fontWeightBold = config.fontWeightBold;
 
-				// Any of the above setting changes could have changed the dimensions of the
-				// terminal, re-evaluate now.
-				this._initDimensions();
-				cols = this.cols;
-				rows = this.rows;
+			// Any of the above setting changes could have changed the dimensions of the
+			// terminal, re-evaluate now.
+			this._initDimensions();
+			cols = this.cols;
+			rows = this.rows;
 
-				this._layoutSettingsChanged = false;
-			}
-
-			if (isNaN(cols) || isNaN(rows)) {
-				return;
-			}
-
-			if (cols !== this.xterm.raw.cols || rows !== this.xterm.raw.rows) {
-				if (this._fixedRows || this._fixedCols) {
-					await this._updateProperty(ProcessPropertyType.FixedDimensions, { cols: this._fixedCols, rows: this._fixedRows });
-				}
-				this._onDimensionsChanged.fire();
-			}
-
-			this.xterm.raw.resize(cols, rows);
-			TerminalInstance._lastKnownGridDimensions = { cols, rows };
+			this._layoutSettingsChanged = false;
 		}
+
+		if (isNaN(cols) || isNaN(rows)) {
+			return;
+		}
+
+		if (cols !== this.xterm.raw.cols || rows !== this.xterm.raw.rows) {
+			if (this._fixedRows || this._fixedCols) {
+				await this._updateProperty(ProcessPropertyType.FixedDimensions, { cols: this._fixedCols, rows: this._fixedRows });
+			}
+			this._onDimensionsChanged.fire();
+		}
+
+		TerminalInstance._lastKnownGridDimensions = { cols, rows };
 
 		if (immediate) {
-			// do not await, call setDimensions synchronously
-			this._processManager.setDimensions(cols, rows, true);
+			this.xterm.raw.resize(cols, rows);
+			await this._updatePtyDimensions(this.xterm.raw);
 		} else {
-			await this._processManager.setDimensions(cols, rows);
+			// Update dimensions independently as vertical resize is cheap but horizontal resize is
+			// expensive due to reflow.
+			this._resizeVertically(this.xterm.raw, rows);
+			this._resizeHorizontally(this.xterm.raw, cols);
 		}
+	}
+
+	private async _resizeVertically(rawXterm: XTermTerminal, rows: number): Promise<void> {
+		rawXterm.resize(rawXterm.cols, rows);
+		await this._updatePtyDimensions(rawXterm);
+	}
+
+	@debounce(50)
+	private async _resizeHorizontally(rawXterm: XTermTerminal, cols: number): Promise<void> {
+		rawXterm.resize(cols, rawXterm.rows);
+		await this._updatePtyDimensions(rawXterm);
+	}
+
+	private async _updatePtyDimensions(rawXterm: XTermTerminal): Promise<void> {
+		await this._processManager.setDimensions(rawXterm.cols, rawXterm.rows);
 	}
 
 	setShellType(shellType: TerminalShellType | undefined) {
@@ -1977,7 +1991,7 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 		}
 		this._dimensionsOverride = dimensions;
 		if (immediate) {
-			this._resizeNow(true);
+			this._resize(true);
 		} else {
 			this._resize();
 		}


### PR DESCRIPTION
This allows vertical resizes to feel much smoother as the only reason resize was being debounced to begin with was that reflow is slow, only horizontal reflow is slow though so this should be fine.

Part of #216810

---

![Recording 2024-06-21 at 09 28 17](https://github.com/user-attachments/assets/fd1b3c05-85b0-4ba4-ab01-a03d62521242)
