### PR TITLE
fix: add disposable to elementDisposables instead of templateDisposables in renderElement function in SettingEnumRenderer

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
@@ -1698,7 +1698,7 @@ export class SettingEnumRenderer extends AbstractSettingRenderer implements ITre
 		const enumDescriptionsAreMarkdown = dataElement.setting.enumDescriptionsAreMarkdown;
 
 		const disposables = new DisposableStore();
-		template.toDispose.add(disposables);
+		template.elementDisposables.add(disposables);
 
 		let createdDefault = false;
 		if (!settingEnum.includes(dataElement.defaultValue)) {


### PR DESCRIPTION
Helps with #216649 

In SettingEnumRenderer, the `renderElement` function calls the `renderValue` function, whichs adds disposables to the template disposables instead of the element disposables. 

It seems the disposables in `renderValue` should always be added to `elementDisposables`:

| function name | disposables |
|--|--|
| renderTemplate | template disposables|
| renderElement | element disposables | 
| renderValue | element disposables |