### PR TITLE
Fix #209158. Add Copy Output and Open Output in Text Editor to Scrollable text output context menu.

### DIFF
--- a/extensions/ipynb/package.json
+++ b/extensions/ipynb/package.json
@@ -62,6 +62,11 @@
         "command": "notebook.cellOutput.copy",
         "title": "%copyCellOutput.title%",
         "category": "Notebook"
+      },
+      {
+        "command": "notebook.cellOutput.openInTextEditor",
+        "title": "%openCellOutput.title%",
+        "category": "Notebook"
       }
     ],
     "notebooks": [
@@ -108,12 +113,24 @@
         {
           "command": "notebook.cellOutput.copy",
           "when": "notebookCellHasOutputs"
+        },
+        {
+          "command": "notebook.cellOutput.openInTextEditor",
+          "when": "false"
         }
       ],
       "webview/context": [
         {
           "command": "notebook.cellOutput.copy",
           "when": "webviewId == 'notebook.output' && webviewSection == 'image'"
+        },
+        {
+          "command": "notebook.cellOutput.copy",
+          "when": "webviewId == 'notebook.output' && webviewSection == 'text'"
+        },
+        {
+          "command": "notebook.cellOutput.openInTextEditor",
+          "when": "webviewId == 'notebook.output' && webviewSection == 'text'"
         }
       ]
     }

--- a/extensions/ipynb/package.nls.json
+++ b/extensions/ipynb/package.nls.json
@@ -7,6 +7,7 @@
 	"openIpynbInNotebookEditor.title": "Open IPYNB File In Notebook Editor",
 	"cleanInvalidImageAttachment.title": "Clean Invalid Image Attachment Reference",
 	"copyCellOutput.title": "Copy Cell Output",
+	"openCellOutput.title": "Open Cell Output in Text Editor",
 	"markdownAttachmentRenderer.displayName": {
 		"message": "Markdown-It ipynb Cell Attachment renderer",
 		"comment": [

--- a/extensions/notebook-renderers/src/ansi.ts
+++ b/extensions/notebook-renderers/src/ansi.ts
@@ -8,9 +8,14 @@ import { ansiColorIdentifiers } from './colorMap';
 import { LinkOptions, linkify } from './linkify';
 
 
-export function handleANSIOutput(text: string, linkOptions: LinkOptions): HTMLSpanElement {
+export function handleANSIOutput(text: string, linkOptions: LinkOptions, outputId: string): HTMLSpanElement {
 
 	const root: HTMLSpanElement = document.createElement('span');
+	root.setAttribute('data-vscode-context', JSON.stringify({
+		webviewSection: 'text',
+		outputId: outputId,
+		'preventDefaultContextMenuItems': true
+	}));
 	const textLength: number = text.length;
 
 	let styleNames: string[] = [];

--- a/extensions/notebook-renderers/src/ansi.ts
+++ b/extensions/notebook-renderers/src/ansi.ts
@@ -8,14 +8,9 @@ import { ansiColorIdentifiers } from './colorMap';
 import { LinkOptions, linkify } from './linkify';
 
 
-export function handleANSIOutput(text: string, linkOptions: LinkOptions, outputId: string): HTMLSpanElement {
+export function handleANSIOutput(text: string, linkOptions: LinkOptions): HTMLSpanElement {
 
 	const root: HTMLSpanElement = document.createElement('span');
-	root.setAttribute('data-vscode-context', JSON.stringify({
-		webviewSection: 'text',
-		outputId: outputId,
-		'preventDefaultContextMenuItems': true
-	}));
 	const textLength: number = text.length;
 
 	let styleNames: string[] = [];

--- a/extensions/notebook-renderers/src/textHelper.ts
+++ b/extensions/notebook-renderers/src/textHelper.ts
@@ -71,22 +71,27 @@ function generateNestedViewAllElement(outputId: string) {
 
 function truncatedArrayOfString(id: string, buffer: string[], linesLimit: number, linkOptions: LinkOptions) {
 	const container = document.createElement('div');
+	container.setAttribute('data-vscode-context', JSON.stringify({
+		webviewSection: 'text',
+		outputId: id,
+		'preventDefaultContextMenuItems': true
+	}));
 	const lineCount = buffer.length;
 
 	if (lineCount <= linesLimit) {
-		const spanElement = handleANSIOutput(buffer.join('\n'), linkOptions, id);
+		const spanElement = handleANSIOutput(buffer.join('\n'), linkOptions);
 		container.appendChild(spanElement);
 		return container;
 	}
 
-	container.appendChild(handleANSIOutput(buffer.slice(0, linesLimit - 5).join('\n'), linkOptions, id));
+	container.appendChild(handleANSIOutput(buffer.slice(0, linesLimit - 5).join('\n'), linkOptions));
 
 	// truncated piece
 	const elipses = document.createElement('div');
 	elipses.innerText = '...';
 	container.appendChild(elipses);
 
-	container.appendChild(handleANSIOutput(buffer.slice(lineCount - 5).join('\n'), linkOptions, id));
+	container.appendChild(handleANSIOutput(buffer.slice(lineCount - 5).join('\n'), linkOptions));
 
 	container.appendChild(generateViewMoreElement(id));
 
@@ -95,11 +100,16 @@ function truncatedArrayOfString(id: string, buffer: string[], linesLimit: number
 
 function scrollableArrayOfString(id: string, buffer: string[], linkOptions: LinkOptions) {
 	const element = document.createElement('div');
+	element.setAttribute('data-vscode-context', JSON.stringify({
+		webviewSection: 'text',
+		outputId: id,
+		'preventDefaultContextMenuItems': true
+	}));
 	if (buffer.length > softScrollableLineLimit) {
 		element.appendChild(generateNestedViewAllElement(id));
 	}
 
-	element.appendChild(handleANSIOutput(buffer.slice(-1 * softScrollableLineLimit).join('\n'), linkOptions, id));
+	element.appendChild(handleANSIOutput(buffer.slice(-1 * softScrollableLineLimit).join('\n'), linkOptions));
 
 	return element;
 }
@@ -118,7 +128,7 @@ function appendScrollableOutput(element: HTMLElement, id: string, appended: stri
 		return false;
 	}
 	else {
-		element.appendChild(handleANSIOutput(buffer.join('\n'), linkOptions, id));
+		element.appendChild(handleANSIOutput(buffer.join('\n'), linkOptions));
 		outputLengths[id] = appendedLength;
 	}
 	return true;

--- a/extensions/notebook-renderers/src/textHelper.ts
+++ b/extensions/notebook-renderers/src/textHelper.ts
@@ -74,19 +74,19 @@ function truncatedArrayOfString(id: string, buffer: string[], linesLimit: number
 	const lineCount = buffer.length;
 
 	if (lineCount <= linesLimit) {
-		const spanElement = handleANSIOutput(buffer.join('\n'), linkOptions);
+		const spanElement = handleANSIOutput(buffer.join('\n'), linkOptions, id);
 		container.appendChild(spanElement);
 		return container;
 	}
 
-	container.appendChild(handleANSIOutput(buffer.slice(0, linesLimit - 5).join('\n'), linkOptions));
+	container.appendChild(handleANSIOutput(buffer.slice(0, linesLimit - 5).join('\n'), linkOptions, id));
 
 	// truncated piece
 	const elipses = document.createElement('div');
 	elipses.innerText = '...';
 	container.appendChild(elipses);
 
-	container.appendChild(handleANSIOutput(buffer.slice(lineCount - 5).join('\n'), linkOptions));
+	container.appendChild(handleANSIOutput(buffer.slice(lineCount - 5).join('\n'), linkOptions, id));
 
 	container.appendChild(generateViewMoreElement(id));
 
@@ -99,7 +99,7 @@ function scrollableArrayOfString(id: string, buffer: string[], linkOptions: Link
 		element.appendChild(generateNestedViewAllElement(id));
 	}
 
-	element.appendChild(handleANSIOutput(buffer.slice(-1 * softScrollableLineLimit).join('\n'), linkOptions));
+	element.appendChild(handleANSIOutput(buffer.slice(-1 * softScrollableLineLimit).join('\n'), linkOptions, id));
 
 	return element;
 }
@@ -118,7 +118,7 @@ function appendScrollableOutput(element: HTMLElement, id: string, appended: stri
 		return false;
 	}
 	else {
-		element.appendChild(handleANSIOutput(buffer.join('\n'), linkOptions));
+		element.appendChild(handleANSIOutput(buffer.join('\n'), linkOptions, id));
 		outputLengths[id] = appendedLength;
 	}
 	return true;

--- a/src/vs/workbench/contrib/notebook/browser/controller/cellOutputActions.ts
+++ b/src/vs/workbench/contrib/notebook/browser/controller/cellOutputActions.ts
@@ -108,7 +108,7 @@ function getOutputViewModelFromId(outputId: string, notebookEditor: INotebookEdi
 
 export const OPEN_OUTPUT_COMMAND_ID = 'notebook.cellOutput.openInTextEditor';
 
-registerAction2(class CopyCellOutputAction extends Action2 {
+registerAction2(class OpenCellOutputInEditorAction extends Action2 {
 	constructor() {
 		super({
 			id: OPEN_OUTPUT_COMMAND_ID,

--- a/src/vs/workbench/contrib/notebook/browser/controller/cellOutputActions.ts
+++ b/src/vs/workbench/contrib/notebook/browser/controller/cellOutputActions.ts
@@ -7,6 +7,7 @@ import { ServicesAccessor } from 'vs/editor/browser/editorExtensions';
 import { localize } from 'vs/nls';
 import { Action2, MenuId, registerAction2 } from 'vs/platform/actions/common/actions';
 import { IClipboardService } from 'vs/platform/clipboard/common/clipboardService';
+import { IOpenerService } from 'vs/platform/opener/common/opener';
 import { INotebookOutputActionContext, NOTEBOOK_ACTIONS_CATEGORY } from 'vs/workbench/contrib/notebook/browser/controller/coreActions';
 import { NOTEBOOK_CELL_HAS_OUTPUTS } from 'vs/workbench/contrib/notebook/common/notebookContextKeys';
 import * as icons from 'vs/workbench/contrib/notebook/browser/notebookIcons';
@@ -14,7 +15,7 @@ import { ILogService } from 'vs/platform/log/common/log';
 import { copyCellOutput } from 'vs/workbench/contrib/notebook/browser/contrib/clipboard/cellOutputClipboard';
 import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
 import { ICellOutputViewModel, ICellViewModel, INotebookEditor, getNotebookEditorFromEditorPane } from 'vs/workbench/contrib/notebook/browser/notebookBrowser';
-import { CellKind } from 'vs/workbench/contrib/notebook/common/notebookCommon';
+import { CellKind, CellUri } from 'vs/workbench/contrib/notebook/common/notebookCommon';
 import { CodeCellViewModel } from 'vs/workbench/contrib/notebook/browser/viewModel/codeCellViewModel';
 
 export const COPY_OUTPUT_COMMAND_ID = 'notebook.cellOutput.copy';
@@ -104,3 +105,45 @@ function getOutputViewModelFromId(outputId: string, notebookEditor: INotebookEdi
 
 	return undefined;
 }
+
+export const OPEN_OUTPUT_COMMAND_ID = 'notebook.cellOutput.openInTextEditor';
+
+registerAction2(class CopyCellOutputAction extends Action2 {
+	constructor() {
+		super({
+			id: OPEN_OUTPUT_COMMAND_ID,
+			title: localize('notebookActions.openOutputInEditor', "Open Cell Output in Text Editor"),
+			f1: false,
+			category: NOTEBOOK_ACTIONS_CATEGORY,
+			icon: icons.copyIcon,
+		});
+	}
+
+	private getNoteboookEditor(editorService: IEditorService, outputContext: INotebookOutputActionContext | { outputViewModel: ICellOutputViewModel } | undefined): INotebookEditor | undefined {
+		if (outputContext && 'notebookEditor' in outputContext) {
+			return outputContext.notebookEditor;
+		}
+		return getNotebookEditorFromEditorPane(editorService.activeEditorPane);
+	}
+
+	async run(accessor: ServicesAccessor, outputContext: INotebookOutputActionContext | { outputViewModel: ICellOutputViewModel } | undefined): Promise<void> {
+		const notebookEditor = this.getNoteboookEditor(accessor.get(IEditorService), outputContext);
+
+		if (!notebookEditor) {
+			return;
+		}
+
+		let outputViewModel: ICellOutputViewModel | undefined;
+		if (outputContext && 'outputId' in outputContext && typeof outputContext.outputId === 'string') {
+			outputViewModel = getOutputViewModelFromId(outputContext.outputId, notebookEditor);
+		} else if (outputContext && 'outputViewModel' in outputContext) {
+			outputViewModel = outputContext.outputViewModel;
+		}
+
+		const openerService = accessor.get(IOpenerService);
+
+		if (outputViewModel?.model.outputId && notebookEditor.textModel?.uri) {
+			openerService.open(CellUri.generateCellOutputUri(notebookEditor.textModel.uri, outputViewModel.model.outputId));
+		}
+	}
+});


### PR DESCRIPTION
Adding copy and open output actions to the context menu for scrollable output, so users can easily view the full output with mouse.

<img width="741" alt="image" src="https://github.com/user-attachments/assets/b9b3359a-0e82-471e-83d5-1278afba5675">
