### PR TITLE
Fixes #211083 - change position of terminal icon picker

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminalIconPicker.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalIconPicker.ts
@@ -52,15 +52,17 @@ export class TerminalIconPicker extends Disposable {
 
 	async pickIcons(instanceId: number): Promise<ThemeIcon | undefined> {
 		const doc: HTMLDocument = getActiveDocument();
-		let pos = HoverPosition.BELOW;
+
+		// get the single terminal tab
+		const defaultTab = doc.getElementsByClassName('single-terminal-tab')[0] as HTMLElement;
+
 		// By default the target is either the position of the terminal or the window position
-		let target = doc.getElementById('terminal-uri-icon') ?? doc.body;
+		let target = defaultTab ?? doc.body;
 
 		// Target the exact tab
 		const terminalTab = doc.getElementById(`terminal-tab-instance-${instanceId}`);
 		if (terminalTab) {
 			target = terminalTab;
-			pos = HoverPosition.LEFT;
 		}
 
 		const dimension = new Dimension(486, 260);
@@ -74,7 +76,7 @@ export class TerminalIconPicker extends Disposable {
 				content: this._iconSelectBox.domNode,
 				target: target ?? doc.body,
 				position: {
-					hoverPosition: pos,
+					hoverPosition: HoverPosition.LEFT,
 				},
 				persistence: {
 					sticky: true,

--- a/src/vs/workbench/contrib/terminal/browser/terminalIconPicker.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalIconPicker.ts
@@ -51,11 +51,18 @@ export class TerminalIconPicker extends Disposable {
 	}
 
 	async pickIcons(instanceId: number): Promise<ThemeIcon | undefined> {
-		let target = getActiveDocument().body;
-		const terminalTab = getActiveDocument().getElementById(`terminal-tab-instance-${instanceId}`);
+		const doc: HTMLDocument = getActiveDocument();
+		let pos = HoverPosition.BELOW;
+		// By default the target is either the position of the terminal or the window position
+		let target = doc.getElementById('terminal-uri-icon') ?? doc.body;
+
+		// Target the exact tab
+		const terminalTab = doc.getElementById(`terminal-tab-instance-${instanceId}`);
 		if (terminalTab) {
 			target = terminalTab;
+			pos = HoverPosition.LEFT;
 		}
+
 		const dimension = new Dimension(486, 260);
 		return new Promise<ThemeIcon | undefined>(resolve => {
 			this._register(this._iconSelectBox.onDidSelect(e => {
@@ -65,9 +72,9 @@ export class TerminalIconPicker extends Disposable {
 			this._iconSelectBox.clearInput();
 			const hoverWidget = this._hoverService.showHover({
 				content: this._iconSelectBox.domNode,
-				target: target,
+				target: target ?? doc.body,
 				position: {
-					hoverPosition: HoverPosition.LEFT,
+					hoverPosition: pos,
 				},
 				persistence: {
 					sticky: true,

--- a/src/vs/workbench/contrib/terminal/browser/terminalIconPicker.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalIconPicker.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Dimension, getActiveDocument } from 'vs/base/browser/dom';
+import { Dimension, getActiveDocument, getActiveWindow } from 'vs/base/browser/dom';
 import { HoverPosition } from 'vs/base/browser/ui/hover/hoverWidget';
 import { codiconsLibrary } from 'vs/base/common/codiconsLibrary';
 import { Lazy } from 'vs/base/common/lazy';
@@ -50,7 +50,12 @@ export class TerminalIconPicker extends Disposable {
 		});
 	}
 
-	async pickIcons(): Promise<ThemeIcon | undefined> {
+	async pickIcons(instanceId: number): Promise<ThemeIcon | undefined> {
+		let target = getActiveDocument().body;
+		const terminalTab = getActiveDocument().getElementById(`terminal-tab-instance-${instanceId}`);
+		if (terminalTab) {
+			target = terminalTab;
+		}
 		const dimension = new Dimension(486, 260);
 		return new Promise<ThemeIcon | undefined>(resolve => {
 			this._register(this._iconSelectBox.onDidSelect(e => {
@@ -60,9 +65,9 @@ export class TerminalIconPicker extends Disposable {
 			this._iconSelectBox.clearInput();
 			const hoverWidget = this._hoverService.showHover({
 				content: this._iconSelectBox.domNode,
-				target: getActiveDocument().body,
+				target: target,
 				position: {
-					hoverPosition: HoverPosition.BELOW,
+					hoverPosition: HoverPosition.LEFT,
 				},
 				persistence: {
 					sticky: true,
@@ -76,6 +81,10 @@ export class TerminalIconPicker extends Disposable {
 			}
 			this._iconSelectBox.layout(dimension);
 			this._iconSelectBox.focus();
+
+			setTimeout(() => {
+				getActiveWindow().dispatchEvent(new Event('resize'));
+			}, 10);
 		});
 	}
 }

--- a/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
@@ -2203,7 +2203,7 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 			return icon;
 		}
 		const iconPicker = this._scopedInstantiationService.createInstance(TerminalIconPicker);
-		const pickedIcon = await iconPicker.pickIcons();
+		const pickedIcon = await iconPicker.pickIcons(this.instanceId);
 		iconPicker.dispose();
 		if (!pickedIcon) {
 			return undefined;

--- a/src/vs/workbench/contrib/terminal/browser/terminalTabsList.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalTabsList.ts
@@ -319,7 +319,7 @@ class TerminalTabsRenderer implements IListRenderer<ITerminalInstance, ITerminal
 
 		template.element.classList.toggle('has-text', hasText);
 		template.element.classList.toggle('is-active', this._terminalGroupService.activeInstance === instance);
-
+		template.element.setAttribute('id', `terminal-tab-instance-${instance.instanceId}`);
 		let prefix: string = '';
 		if (group.terminalInstances.length > 1) {
 			const terminalIndex = group.terminalInstances.indexOf(instance);


### PR DESCRIPTION
Per #211083, the position of both the terminal colour picker and the icon picker had to be moved closer to the terminal tab.
I took over PR #212174, which was left without its requested changes being addressed. I would give all the credit to @albarv340 for their work on the first part.

## Icon picker placement

<p align="center">
    <a>
        <img src="https://github.com/microsoft/vscode/assets/37577669/6de42509-144e-41f5-86f9-1fd2525b578b" height="265"/>
    </a>
<a>
        <img src="https://github.com/microsoft/vscode/assets/37577669/8dbf7aed-61e4-4a3d-b66a-6d9b978d8f6a" height="265"/> 
    </a>
</p>

#### Additional context
On the initial PR, the icon picker was only positioned correctly when there was more than one terminal tab (as shown in the screenshot on the right). However, the default position remained at the top of the window.

## ~Colour picker~

<p align="center">
    <a>
        <img src="https://github.com/microsoft/vscode/assets/37577669/cfc62fcb-792f-4bbc-8b87-76a23a0a70fd" height="265"/>
    </a>
<a>
        <img src="https://github.com/microsoft/vscode/assets/37577669/4faf3240-e66b-4c4f-95ba-5a436c71cc5b" height="265"/> 
    </a>
</p>

#### Additional context
~As I told @Tyriar on the [issue](https://github.com/microsoft/vscode/issues/211083), the colour picker used a `quickPicker, ' which was harder to modify without risking impacting other elements relying on the same class. So, I created it from scratch, similar to the icon picker. Let me know if you'd rather I use another method.~