### PR TITLE
Revert "Remove check for validity"

### DIFF
--- a/.github/workflows/on-open.yml
+++ b/.github/workflows/on-open.yml
@@ -16,6 +16,11 @@ jobs:
       - name: Install Actions
         run: npm install --production --prefix ./actions
 
+      - name: Check for Validity
+        uses: ./actions/validity-checker
+        with:
+          token: ${{secrets.VSCODE_ISSUE_TRIAGE_BOT_PAT}}
+
       - name: Run CopyCat (VSCodeTriageBot/testissues)
         uses: ./actions/copycat
         with:

--- a/.github/workflows/on-reopen.yml
+++ b/.github/workflows/on-reopen.yml
@@ -1,0 +1,22 @@
+name: On Reopen
+on:
+  issues:
+    types: [reopened]
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Actions
+        uses: actions/checkout@v4
+        with:
+          repository: "microsoft/vscode-github-triage-actions"
+          ref: stable
+          path: ./actions
+      - name: Install Actions
+        run: npm install --production --prefix ./actions
+
+      - name: Check for Validity
+        uses: ./actions/validity-checker
+        with:
+          token: ${{secrets.VSCODE_ISSUE_TRIAGE_BOT_PAT}}


### PR DESCRIPTION
Reverts microsoft/vscode#216675

Going back to closing these on open. Accumulating these for triage once an hour causes clutter when going through our issues. We should label and filter these out on open and prevent them from clogging up our other pipelines.