### PR TITLE
rename 'insert at cursor' to 'apply in editor'

### DIFF
--- a/src/vs/editor/common/languages.ts
+++ b/src/vs/editor/common/languages.ts
@@ -2262,7 +2262,7 @@ export interface MappedEditsProvider {
 	 *
 	 * @param document The document to provide mapped edits for.
 	 * @param codeBlocks Code blocks that come from an LLM's reply.
-	 * 						"Insert at cursor" in the panel chat only sends one edit that the user clicks on, but inline chat can send multiple blocks and let the lang server decide what to do with them.
+	 * 						"Apply in Editor" in the panel chat only sends one edit that the user clicks on, but inline chat can send multiple blocks and let the lang server decide what to do with them.
 	 * @param context The context for providing mapped edits.
 	 * @param token A cancellation token.
 	 * @returns A provider result of text edits.

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -8065,7 +8065,7 @@ declare namespace monaco.languages {
 		 *
 		 * @param document The document to provide mapped edits for.
 		 * @param codeBlocks Code blocks that come from an LLM's reply.
-		 * 						"Insert at cursor" in the panel chat only sends one edit that the user clicks on, but inline chat can send multiple blocks and let the lang server decide what to do with them.
+		 * 						"Apply in Editor" in the panel chat only sends one edit that the user clicks on, but inline chat can send multiple blocks and let the lang server decide what to do with them.
 		 * @param context The context for providing mapped edits.
 		 * @param token A cancellation token.
 		 * @returns A provider result of text edits.

--- a/src/vs/workbench/contrib/chat/browser/actions/chatCodeblockActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatCodeblockActions.ts
@@ -184,7 +184,7 @@ export function registerChatCodeBlockActions() {
 		constructor() {
 			super({
 				id: 'workbench.action.chat.insertCodeBlock',
-				title: localize2('interactive.insertCodeBlock.label', "Insert at Cursor"),
+				title: localize2('interactive.insertCodeBlock.label', "Apply in Editor"),
 				precondition: CONTEXT_CHAT_ENABLED,
 				f1: true,
 				category: CHAT_CATEGORY,

--- a/src/vscode-dts/vscode.proposed.mappedEditsProvider.d.ts
+++ b/src/vscode-dts/vscode.proposed.mappedEditsProvider.d.ts
@@ -23,7 +23,7 @@ declare module 'vscode' {
 		 * Provide mapped edits for a given document.
 		 * @param document The document to provide mapped edits for.
 		 * @param codeBlocks Code blocks that come from an LLM's reply.
-		 * 						"Insert at cursor" in the panel chat only sends one edit that the user clicks on, but inline chat can send multiple blocks and let the lang server decide what to do with them.
+		 * 						"Apply in Editor" in the panel chat only sends one edit that the user clicks on, but inline chat can send multiple blocks and let the lang server decide what to do with them.
 		 * @param context The context for providing mapped edits.
 		 * @param token A cancellation token.
 		 * @returns A provider result of text edits.


### PR DESCRIPTION
The 'insert at cursor' command applies a code block in the currently open editor.
Depending on the active selection, this can be an insert or a replace. 

For that I decided to rename the command.

please speak up if you disagree
@roblourens @alexdima 