### PR TITLE
fix: do not show activity bar's focus border on click

### DIFF
--- a/src/vs/workbench/browser/parts/activitybar/media/activityaction.css
+++ b/src/vs/workbench/browser/parts/activitybar/media/activityaction.css
@@ -104,7 +104,8 @@
 	display: none;
 }
 
-.monaco-workbench .activitybar > .content :not(.monaco-menu) > .monaco-action-bar .action-item.clicked:focus:before {
+.monaco-workbench .activitybar > .content :not(.monaco-menu) > .monaco-action-bar .action-item.clicked:focus:before,
+.monaco-workbench .activitybar > .content :not(.monaco-menu) > .monaco-action-bar .action-item.clicked:focus .active-item-indicator::before {
 	border-left: none !important; /* no focus feedback when using mouse */
 }
 


### PR DESCRIPTION
## Related issue

Close #217834

## Overview

This will hide the active item indicator of activity bar when using a mouse to click on it. With this change, the flickering border won't happen anymore.

The way to test it is the same as in the related issue:

- First, to observe the problem, "activityBar.activeBorder" should be transparent. Otherwise, make sure "focusBorder" color is different from "activityBar.activeBorder".
- Simple click on the explorer icon in the activity bar, the flickering border will not appear this time.