### PR TITLE
css/json/html web: adopt LanguageClient API change

### DIFF
--- a/extensions/css-language-features/client/src/browser/cssClientMain.ts
+++ b/extensions/css-language-features/client/src/browser/cssClientMain.ts
@@ -8,13 +8,6 @@ import { BaseLanguageClient, LanguageClientOptions } from 'vscode-languageclient
 import { startClient, LanguageClientConstructor } from '../cssClient';
 import { LanguageClient } from 'vscode-languageclient/browser';
 
-declare const Worker: {
-	new(stringUrl: string): any;
-};
-declare const TextDecoder: {
-	new(encoding?: string): { decode(buffer: ArrayBuffer): string };
-};
-
 let client: BaseLanguageClient | undefined;
 
 // this method is called when vs code is activated
@@ -25,7 +18,7 @@ export async function activate(context: ExtensionContext) {
 		worker.postMessage({ i10lLocation: l10n.uri?.toString(false) ?? '' });
 
 		const newLanguageClient: LanguageClientConstructor = (id: string, name: string, clientOptions: LanguageClientOptions) => {
-			return new LanguageClient(id, name, clientOptions, worker);
+			return new LanguageClient(id, name, worker, clientOptions);
 		};
 
 		client = await startClient(context, newLanguageClient, { TextDecoder });

--- a/extensions/css-language-features/client/tsconfig.json
+++ b/extensions/css-language-features/client/tsconfig.json
@@ -1,7 +1,10 @@
 {
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
-		"outDir": "./out"
+		"outDir": "./out",
+		"lib": [
+			"webworker"
+		]
 	},
 	"include": [
 		"src/**/*",

--- a/extensions/html-language-features/client/src/browser/htmlClientMain.ts
+++ b/extensions/html-language-features/client/src/browser/htmlClientMain.ts
@@ -8,13 +8,6 @@ import { LanguageClientOptions } from 'vscode-languageclient';
 import { startClient, LanguageClientConstructor, AsyncDisposable } from '../htmlClient';
 import { LanguageClient } from 'vscode-languageclient/browser';
 
-declare const Worker: {
-	new(stringUrl: string): any;
-};
-declare const TextDecoder: {
-	new(encoding?: string): { decode(buffer: ArrayBuffer): string };
-};
-
 let client: AsyncDisposable | undefined;
 
 // this method is called when vs code is activated
@@ -25,7 +18,7 @@ export async function activate(context: ExtensionContext) {
 		worker.postMessage({ i10lLocation: l10n.uri?.toString(false) ?? '' });
 
 		const newLanguageClient: LanguageClientConstructor = (id: string, name: string, clientOptions: LanguageClientOptions) => {
-			return new LanguageClient(id, name, clientOptions, worker);
+			return new LanguageClient(id, name, worker, clientOptions);
 		};
 
 		const timer = {

--- a/extensions/html-language-features/client/tsconfig.json
+++ b/extensions/html-language-features/client/tsconfig.json
@@ -1,7 +1,10 @@
 {
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
-		"outDir": "./out"
+		"outDir": "./out",
+		"lib": [
+			"webworker"
+		]
 	},
 	"include": [
 		"src/**/*",

--- a/extensions/json-language-features/client/src/browser/jsonClientMain.ts
+++ b/extensions/json-language-features/client/src/browser/jsonClientMain.ts
@@ -8,12 +8,6 @@ import { LanguageClientOptions } from 'vscode-languageclient';
 import { startClient, LanguageClientConstructor, SchemaRequestService, AsyncDisposable, languageServerDescription } from '../jsonClient';
 import { LanguageClient } from 'vscode-languageclient/browser';
 
-declare const Worker: {
-	new(stringUrl: string): any;
-};
-
-declare function fetch(uri: string, options: any): any;
-
 let client: AsyncDisposable | undefined;
 
 // this method is called when vs code is activated
@@ -24,7 +18,7 @@ export async function activate(context: ExtensionContext) {
 		worker.postMessage({ i10lLocation: l10n.uri?.toString(false) ?? '' });
 
 		const newLanguageClient: LanguageClientConstructor = (id: string, name: string, clientOptions: LanguageClientOptions) => {
-			return new LanguageClient(id, name, clientOptions, worker);
+			return new LanguageClient(id, name, worker, clientOptions);
 		};
 
 		const schemaRequests: SchemaRequestService = {

--- a/extensions/json-language-features/client/tsconfig.json
+++ b/extensions/json-language-features/client/tsconfig.json
@@ -1,7 +1,10 @@
 {
 	"extends": "../../tsconfig.base.json",
 	"compilerOptions": {
-		"outDir": "./out"
+		"outDir": "./out",
+		"lib": [
+			"webworker"
+		]
 	},
 	"include": [
 		"src/**/*",


### PR DESCRIPTION
Adopts https://github.com/microsoft/vscode-languageserver-node/pull/1485/files

Causes http://insiders.vscode.dev/ to fail when opening a JSON/CSS/HTML file.

![image](https://github.com/user-attachments/assets/b26e7d46-51f8-4b3e-9185-bc336877fdd4)


```
[Extension Host] TypeError: e.addEventListener is not a function
	at new s (https://main.vscode-cdn.net/insider/b36286db80c68b7fdc6bfee2f55e0208c8833dfc/extensions/json-language-features/client/dist/browser/jsonClientMain.js#vscode-extension:3:3452)
	at a.createMessageTransportsFromWorker (https://main.vscode-cdn.net/insider/b36286db80c68b7fdc6bfee2f55e0208c8833dfc/extensions/json-language-features/client/dist/browser/jsonClientMain.js#vscode-extension:3:54992)
	at a.createMessageTransports (https://main.vscode-cdn.net/insider/b36286db80c68b7fdc6bfee2f55e0208c8833dfc/extensions/json-language-features/client/dist/browser/jsonClientMain.js#vscode-extension:3:54893)
	at a.createConnection (https://main.vscode-cdn.net/insider/b36286db80c68b7fdc6bfee2f55e0208c8833dfc/extensions/json-language-features/client/dist/browser/jsonClientMain.js#vscode-extension:3:80777)
	at a.start (https://main.vscode-cdn.net/insider/b36286db80c68b7fdc6bfee2f55e0208c8833dfc/extensions/json-language-features/client/dist/browser/jsonClientMain.js#vscode-extension:3:71131)
	at S (https://main.vscode-cdn.net/insider/b36286db80c68b7fdc6bfee2f55e0208c8833dfc/extensions/json-language-features/client/dist/browser/jsonClientMain.js#vscode-extension:3:295061)
	at t.startClient (https://main.vscode-cdn.net/insider/b36286db80c68b7fdc6bfee2f55e0208c8833dfc/extensions/json-language-features/client/dist/browser/jsonClientMain.js#vscode-extension:3:289539)
	at e.activate (https://main.vscode-cdn.net/insider/b36286db80c68b7fdc6bfee2f55e0208c8833dfc/extensions/json-language-features/client/dist/browser/jsonClientMain.js#vscode-extension:3:354393)
	at Z.kb (../../../vs/workbench/api/worker/extensionHostWorker.js:107:13526)
	at Z.jb (../../../vs/workbench/api/worker/extensionHostWorker.js:107:13239)
	at eval (../../../vs/workbench/api/worker/extensionHostWorker.js:107:11244)
	at async n (../../../vs/workbench/api/worker/extensionHostWorker.js:96:6385)
	at async n.m (../../../vs/workbench/api/worker/extensionHostWorker.js:96:6348)
	at async n.l (../../../vs/workbench/api/worker/extensionHostWorker.js:96:5805)
```