### PR TITLE
Remove getSessions API in favor of getAccounts

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadAuthentication.ts
+++ b/src/vs/workbench/api/browser/mainThreadAuthentication.ts
@@ -260,18 +260,6 @@ export class MainThreadAuthentication extends Disposable implements MainThreadAu
 		return session;
 	}
 
-	async $getSessions(providerId: string, scopes: readonly string[], extensionId: string, extensionName: string): Promise<AuthenticationSession[]> {
-		const sessions = await this.authenticationService.getSessions(providerId, [...scopes], undefined, true);
-		const accessibleSessions = sessions.filter(s => this.authenticationAccessService.isAccessAllowed(providerId, s.account.label, extensionId));
-		if (accessibleSessions.length) {
-			this.sendProviderUsageTelemetry(extensionId, providerId);
-			for (const session of accessibleSessions) {
-				this.authenticationUsageService.addAccountUsage(providerId, session.account.label, extensionId, extensionName);
-			}
-		}
-		return accessibleSessions;
-	}
-
 	async $getAccounts(providerId: string): Promise<ReadonlyArray<AuthenticationSessionAccount>> {
 		const sessions = await this.authenticationService.getSessions(providerId);
 		const accounts = new Array<AuthenticationSessionAccount>();

--- a/src/vs/workbench/api/common/extHost.api.impl.ts
+++ b/src/vs/workbench/api/common/extHost.api.impl.ts
@@ -294,10 +294,6 @@ export function createApiFactoryAndRegisterActors(accessor: ServicesAccessor): I
 				}
 				return extHostAuthentication.getSession(extension, providerId, scopes, options as any);
 			},
-			getSessions(providerId: string, scopes: readonly string[]) {
-				checkProposedApiEnabled(extension, 'authGetSessions');
-				return extHostAuthentication.getSessions(extension, providerId, scopes);
-			},
 			getAccounts(providerId: string) {
 				checkProposedApiEnabled(extension, 'authGetSessions');
 				return extHostAuthentication.getAccounts(providerId);

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -162,7 +162,6 @@ export interface MainThreadAuthenticationShape extends IDisposable {
 	$ensureProvider(id: string): Promise<void>;
 	$sendDidChangeSessions(providerId: string, event: AuthenticationSessionsChangeEvent): void;
 	$getSession(providerId: string, scopes: readonly string[], extensionId: string, extensionName: string, options: { createIfNone?: boolean; forceNewSession?: boolean | AuthenticationForceNewSessionOptions; clearSessionPreference?: boolean }): Promise<AuthenticationSession | undefined>;
-	$getSessions(providerId: string, scopes: readonly string[], extensionId: string, extensionName: string): Promise<AuthenticationSession[]>;
 	$getAccounts(providerId: string): Promise<ReadonlyArray<AuthenticationSessionAccount>>;
 	$removeSession(providerId: string, sessionId: string): Promise<void>;
 }

--- a/src/vs/workbench/api/common/extHostAuthentication.ts
+++ b/src/vs/workbench/api/common/extHostAuthentication.ts
@@ -32,7 +32,6 @@ export class ExtHostAuthentication implements ExtHostAuthenticationShape {
 	readonly onDidChangeSessions: Event<vscode.AuthenticationSessionsChangeEvent> = this._onDidChangeSessions.event;
 
 	private _getSessionTaskSingler = new TaskSingler<vscode.AuthenticationSession | undefined>();
-	private _getSessionsTaskSingler = new TaskSingler<ReadonlyArray<vscode.AuthenticationSession>>();
 
 	constructor(
 		@IExtHostRpcService extHostRpc: IExtHostRpcService
@@ -51,16 +50,6 @@ export class ExtHostAuthentication implements ExtHostAuthenticationShape {
 			await this._proxy.$ensureProvider(providerId);
 			const extensionName = requestingExtension.displayName || requestingExtension.name;
 			return this._proxy.$getSession(providerId, scopes, extensionId, extensionName, options);
-		});
-	}
-
-	async getSessions(requestingExtension: IExtensionDescription, providerId: string, scopes: readonly string[]): Promise<ReadonlyArray<vscode.AuthenticationSession>> {
-		const extensionId = ExtensionIdentifier.toKey(requestingExtension.identifier);
-		const sortedScopes = [...scopes].sort().join(' ');
-		return await this._getSessionsTaskSingler.getOrCreate(`${extensionId} ${sortedScopes}`, async () => {
-			await this._proxy.$ensureProvider(providerId);
-			const extensionName = requestingExtension.displayName || requestingExtension.name;
-			return this._proxy.$getSessions(providerId, scopes, extensionId, extensionName);
 		});
 	}
 

--- a/src/vscode-dts/vscode.proposed.authGetSessions.d.ts
+++ b/src/vscode-dts/vscode.proposed.authGetSessions.d.ts
@@ -67,23 +67,4 @@ declare module 'vscode' {
 		 */
 		createSession(scopes: readonly string[], options: AuthenticationProviderSessionOptions): Thenable<AuthenticationSession>;
 	}
-
-	// THE BELOW IS THE OLD PROPOSAL WHICH WILL BE REMOVED BUT KEPT UNTIL THE NEW PROPOSAL IS ADOPTED BY ALL PARTIES
-
-	export namespace authentication {
-		/**
-		 * Get all authentication sessions matching the desired scopes that this extension has access to. In order to request access,
-		 * use {@link getSession}. To request an additional account, specify {@link AuthenticationGetSessionOptions.clearSessionPreference}
-		 * and {@link AuthenticationGetSessionOptions.createIfNone} together.
-		 *
-		 * Currently, there are only two authentication providers that are contributed from built in extensions
-		 * to the editor that implement GitHub and Microsoft authentication: their providerId's are 'github' and 'microsoft'.
-		 *
-		 * @param providerId The id of the provider to use
-		 * @param scopes A list of scopes representing the permissions requested. These are dependent on the authentication provider
-		 * @returns A thenable that resolves to a readonly array of authentication sessions.
-		 * @deprecated Use {@link getAccounts} instead.
-		 */
-		export function getSessions(providerId: string, scopes: readonly string[]): Thenable<readonly AuthenticationSession[]>;
-	}
 }


### PR DESCRIPTION
Azure folks (the only ones using this proposed API) have not depended on getSessions yet so it's safe to delete.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
