### PR TITLE
Add action label and keybindings for the editor hover status bar in the editor hover accessible view/help

### DIFF
--- a/src/vs/base/browser/ui/hover/hoverWidget.ts
+++ b/src/vs/base/browser/ui/hover/hoverWidget.ts
@@ -50,11 +50,17 @@ export class HoverAction extends Disposable {
 		return new HoverAction(parent, actionOptions, keybindingLabel);
 	}
 
+	public readonly actionLabel: string;
+	public readonly actionKeybindingLabel: string | null;
+
 	private readonly actionContainer: HTMLElement;
 	private readonly action: HTMLElement;
 
 	private constructor(parent: HTMLElement, actionOptions: { label: string; iconClass?: string; run: (target: HTMLElement) => void; commandId: string }, keybindingLabel: string | null) {
 		super();
+
+		this.actionLabel = actionOptions.label;
+		this.actionKeybindingLabel = keybindingLabel;
 
 		this.actionContainer = dom.append(parent, $('div.action-container'));
 		this.actionContainer.setAttribute('tabindex', '0');

--- a/src/vs/editor/contrib/hover/browser/contentHoverRendered.ts
+++ b/src/vs/editor/contrib/hover/browser/contentHoverRendered.ts
@@ -21,6 +21,7 @@ import { ColorHoverParticipant } from 'vs/editor/contrib/colorPicker/browser/col
 import { localize } from 'vs/nls';
 import { InlayHintsHover } from 'vs/editor/contrib/inlayHints/browser/inlayHintsHover';
 import { BugIndicatingError } from 'vs/base/common/errors';
+import { HoverAction } from 'vs/base/browser/ui/hover/hoverWidget';
 
 export class RenderedContentHover extends Disposable {
 
@@ -175,6 +176,10 @@ interface IRenderedContentStatusBar {
 	 * The HTML element containing the hover status bar.
 	 */
 	hoverElement: HTMLElement;
+	/**
+	 * The actions of the hover status bar.
+	 */
+	actions: HoverAction[];
 }
 
 type IRenderedContentHoverPartOrStatusBar = IRenderedContentHoverPart | IRenderedContentStatusBar;
@@ -187,6 +192,10 @@ class RenderedStatusBar implements IDisposable {
 
 	get hoverElement(): HTMLElement {
 		return this._statusBar.hoverElement;
+	}
+
+	get actions(): HoverAction[] {
+		return this._statusBar.actions;
 	}
 
 	dispose() {
@@ -270,6 +279,7 @@ class RenderedContentHoverParts extends Disposable {
 			this._renderedParts.push({
 				type: 'statusBar',
 				hoverElement: renderedStatusBar.hoverElement,
+				actions: renderedStatusBar.actions,
 			});
 		}
 		return toDisposable(() => { disposables.dispose(); });
@@ -332,7 +342,16 @@ class RenderedContentHoverParts extends Disposable {
 			return '';
 		}
 		if (renderedPart.type === 'statusBar') {
-			return localize('hoverAccessibilityStatusBar', "This is a hover status bar.");
+			const statusBarDescription = [localize('hoverAccessibilityStatusBar', "This is a hover status bar.")];
+			for (const action of renderedPart.actions) {
+				const keybinding = action.actionKeybindingLabel;
+				if (keybinding) {
+					statusBarDescription.push(localize('hoverAccessibilityStatusBarActionWithKeybinding', "It has an action with label {0} and keybinding {1}.", action.actionLabel, keybinding));
+				} else {
+					statusBarDescription.push(localize('hoverAccessibilityStatusBarActionWithoutKeybinding', "It has an action with label {0}.", action.actionLabel));
+				}
+			}
+			return statusBarDescription.join('\n');
 		}
 		return renderedPart.participant.getAccessibleContent(renderedPart.hoverPart);
 	}

--- a/src/vs/editor/contrib/hover/browser/contentHoverStatusBar.ts
+++ b/src/vs/editor/contrib/hover/browser/contentHoverStatusBar.ts
@@ -13,6 +13,8 @@ const $ = dom.$;
 export class EditorHoverStatusBar extends Disposable implements IEditorHoverStatusBar {
 
 	public readonly hoverElement: HTMLElement;
+	public readonly actions: HoverAction[] = [];
+
 	private readonly actionsElement: HTMLElement;
 	private _hasContent: boolean = false;
 
@@ -39,7 +41,9 @@ export class EditorHoverStatusBar extends Disposable implements IEditorHoverStat
 		const keybinding = this._keybindingService.lookupKeybinding(actionOptions.commandId);
 		const keybindingLabel = keybinding ? keybinding.getLabel() : null;
 		this._hasContent = true;
-		return this._register(HoverAction.render(this.actionsElement, actionOptions, keybindingLabel));
+		const action = this._register(HoverAction.render(this.actionsElement, actionOptions, keybindingLabel));
+		this.actions.push(action);
+		return action;
 	}
 
 	public append(element: HTMLElement): HTMLElement {


### PR DESCRIPTION
fixes https://github.com/microsoft/vscode/issues/217975

Add action label and keybindings for the editor hover status bar in the editor hover accessible view/help

![Screenshot 2024-06-26 at 11 38 58](https://github.com/microsoft/vscode/assets/61460952/c1aff9e1-577c-4b82-8e8f-be9e7d965583)