### PR TITLE
Set focus back to the editor hover part on escape from the accessible view/help

### DIFF
--- a/src/vs/editor/contrib/hover/browser/contentHoverController.ts
+++ b/src/vs/editor/contrib/hover/browser/contentHoverController.ts
@@ -321,6 +321,10 @@ export class ContentHoverController extends Disposable implements IHoverWidget {
 		this._contentHoverWidget.focus();
 	}
 
+	public focusHoverPartWithIndex(index: number): void {
+		this._renderedContentHover?.focusHoverPartWithIndex(index);
+	}
+
 	public scrollUp(): void {
 		this._contentHoverWidget.scrollUp();
 	}

--- a/src/vs/editor/contrib/hover/browser/contentHoverRendered.ts
+++ b/src/vs/editor/contrib/hover/browser/contentHoverRendered.ts
@@ -76,6 +76,10 @@ export class RenderedContentHover extends Disposable {
 		return this._renderedHoverParts.focusedHoverPartIndex;
 	}
 
+	public focusHoverPartWithIndex(index: number): void {
+		this._renderedHoverParts.focusHoverPartWithIndex(index);
+	}
+
 	public getAccessibleWidgetContent(): string {
 		return this._renderedHoverParts.getAccessibleContent();
 	}
@@ -316,6 +320,13 @@ class RenderedContentHoverParts extends Disposable {
 			this._markdownHoverParticipant = markdownHoverParticipant as MarkdownHoverParticipant;
 		}
 		this._colorHoverParticipant = participants.find(p => p instanceof ColorHoverParticipant);
+	}
+
+	public focusHoverPartWithIndex(index: number): void {
+		if (index < 0 || index >= this._renderedParts.length) {
+			return;
+		}
+		this._renderedParts[index].hoverElement.focus();
 	}
 
 	public getAccessibleContent(): string {

--- a/src/vs/editor/contrib/hover/browser/hoverAccessibleViews.ts
+++ b/src/vs/editor/contrib/hover/browser/hoverAccessibleViews.ts
@@ -117,8 +117,12 @@ abstract class BaseHoverAccessibleViewProvider extends Disposable implements IAc
 		if (!this._hoverController) {
 			return;
 		}
+		if (this._focusedHoverPartIndex === -1) {
+			this._hoverController.focus();
+		} else {
+			this._hoverController.focusHoverPartWithIndex(this._focusedHoverPartIndex);
+		}
 		this._focusedHoverPartIndex = -1;
-		this._hoverController.focus();
 		this._hoverController.shouldKeepOpenOnEditorMouseMoveOrLeave = false;
 		this.dispose();
 	}

--- a/src/vs/editor/contrib/hover/browser/hoverController.ts
+++ b/src/vs/editor/contrib/hover/browser/hoverController.ts
@@ -433,6 +433,10 @@ export class HoverController extends Disposable implements IEditorContribution {
 		this._contentWidget?.focus();
 	}
 
+	public focusHoverPartWithIndex(index: number): void {
+		this._contentWidget?.focusHoverPartWithIndex(index);
+	}
+
 	public scrollUp(): void {
 		this._contentWidget?.scrollUp();
 	}


### PR DESCRIPTION
fixes https://github.com/microsoft/vscode/issues/218217

Previously when pressing escape from the accessible view/help, focus would be moved to the full hover, even if a sub-part was foused. Now focus is moved back to the hover part if it was previously focused.