### PR TITLE
Fix two bugs in #214589 fixing #213535.

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/view/cellParts/cellComments.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/cellParts/cellComments.ts
@@ -27,7 +27,6 @@ export class CellComments extends CellContentPart {
 	constructor(
 		private readonly notebookEditor: INotebookEditorDelegate,
 		private readonly container: HTMLElement,
-
 		@IContextKeyService private readonly contextKeyService: IContextKeyService,
 		@IThemeService private readonly themeService: IThemeService,
 		@ICommentService private readonly commentService: ICommentService,

--- a/src/vs/workbench/contrib/notebook/browser/view/cellParts/cellComments.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/cellParts/cellComments.ts
@@ -108,7 +108,7 @@ export class CellComments extends CellContentPart {
 		if (this._commentThreadWidget.value) {
 			if (!info) {
 				this._commentThreadDisposables.clear();
-				this._commentThreadWidget.dispose();
+				this._commentThreadWidget.value = undefined;
 				this.currentElement.commentHeight = 0;
 				return;
 			}
@@ -154,7 +154,6 @@ export class CellComments extends CellContentPart {
 
 	override didRenderCell(element: ICellViewModel): void {
 		if (element.cellKind === CellKind.Code) {
-			this.currentElement = element as CodeCellViewModel;
 			this.initialize(element);
 			this._bindListeners();
 		}

--- a/src/vs/workbench/contrib/notebook/browser/view/cellParts/cellComments.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/cellParts/cellComments.ts
@@ -20,7 +20,7 @@ import { CellKind } from 'vs/workbench/contrib/notebook/common/notebookCommon';
 import { ICellRange } from 'vs/workbench/contrib/notebook/common/notebookRange';
 
 export class CellComments extends CellContentPart {
-	private readonly _commentThreadWidget = new MutableDisposable<CommentThreadWidget<ICellRange>>;
+	private readonly _commentThreadWidget: MutableDisposable<CommentThreadWidget<ICellRange>>;
 	private currentElement: CodeCellViewModel | undefined;
 	private readonly _commentThreadDisposables = this._register(new DisposableStore());
 
@@ -35,6 +35,8 @@ export class CellComments extends CellContentPart {
 	) {
 		super();
 		this.container.classList.add('review-widget');
+
+		this._register(this._commentThreadWidget = new MutableDisposable<CommentThreadWidget<ICellRange>>());
 
 		this._register(this.themeService.onDidColorThemeChange(this._applyTheme, this));
 		// TODO @rebornix onDidChangeLayout (font change)


### PR DESCRIPTION
1. We must not `dispose()` the `MutableDisposable` `this._commentThreadWidget` - as that disposes the MutableDisposable itself, and it cannot then later be reassigned to a new value. Instead, we need to assign `value=undefined`, which disposes the previous `value`, but keeps the `MutableDisposable` available to be reused later.
2. `initialize()` is a no-op if `this.currentElement` is already identical to the passed `element`, so we must not do that assignment before calling initialize - instead `initialize()` does the assignment after checking.

@rebornix or @alexr00, could you please take a look?

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
