### PR TITLE
Fix exponential runtime in service instantiation

### DIFF
--- a/src/vs/platform/instantiation/common/instantiationService.ts
+++ b/src/vs/platform/instantiation/common/instantiationService.ts
@@ -220,7 +220,9 @@ export class InstantiationService implements IInstantiationService {
 		while (stack.length) {
 			const item = stack.pop()!;
 
-			if (seen.has(String(item.id))) continue;
+			if (seen.has(String(item.id))) {
+				continue;
+			}
 			seen.add(String(item.id));
 
 			graph.lookupOrInsertNode(item);

--- a/src/vs/platform/instantiation/common/instantiationService.ts
+++ b/src/vs/platform/instantiation/common/instantiationService.ts
@@ -216,8 +216,13 @@ export class InstantiationService implements IInstantiationService {
 
 		let cycleCount = 0;
 		const stack = [{ id, desc, _trace }];
+		const seen = new Set<string>();
 		while (stack.length) {
 			const item = stack.pop()!;
+
+			if (seen.has(String(item.id))) continue;
+			seen.add(String(item.id));
+
 			graph.lookupOrInsertNode(item);
 
 			// a weak but working heuristic for cycle checks


### PR DESCRIPTION
Typically, service instantiation is quick. A DFS of sorts is used to explore and instantiate dependencies. This commit fixes a bug in the DFS.

When a service is instantiated, its dependencies are iterated over. If an instance is found, nothing more needs to be done with that dependency and iteration continues. If an instance isn't found i.e. the dependency has not yet been instantiated, a service "descriptor" is retrieved instead. The descriptor contains enough information to instantiate the dependency including dependencies the descriptor may have. All recursive descriptors are retrieved then instantiated according to the constructed DAG after retrieval.

The bug is in not keeping track of which descriptors have already been seen. Thus, service `a` with dependency on `b` and `c` and service `b` with dependency on `c` means that this iteration will examine `c` twice (if it's a descriptor). It is then simple to construct a dependency graph like `a->b, a->c, b->c, b->d, c->d, c->e, d->e, d->f`, etc. which can be seen to have Fibonacci and thus exponential complexity.

In practice this is not encountered often since a dependency that's an instance cuts short any further problems its dependency tree could have introduced. Besides correctness, this fix will avoid lost time from people needing to debug why the cycle heuristic is encountered for a service which 1. isn't a cycle and 2. shouldn't have a huge dependency graph.