### PR TITLE
Disable terminal initial hint when ctrl+i is triggered

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/chat/browser/terminal.initialHint.contribution.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chat/browser/terminal.initialHint.contribution.ts
@@ -261,6 +261,7 @@ class TerminalInitialHintWidget extends Disposable {
 		};
 		this.toDispose.add(this.commandService.onDidExecuteCommand(e => {
 			if (e.commandId === TerminalChatCommandId.Start) {
+				this._storageService.store(Constants.InitialHintHideStorageKey, true, StorageScope.APPLICATION, StorageTarget.USER);
 				this.dispose();
 			}
 		}));


### PR DESCRIPTION
Previously this would only happen when _clicked_.

Fixes #213820

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
