### PR TITLE
Don't throw for $updateAgent failure

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadChatAgents2.ts
+++ b/src/vs/workbench/api/browser/mainThreadChatAgents2.ts
@@ -199,7 +199,8 @@ export class MainThreadChatAgents2 extends Disposable implements MainThreadChatA
 	$updateAgent(handle: number, metadataUpdate: IExtensionChatAgentMetadata): void {
 		const data = this._agents.get(handle);
 		if (!data) {
-			throw new Error(`No agent with handle ${handle} registered`);
+			this._logService.error(`MainThreadChatAgents2#$updateAgent: No agent with handle ${handle} registered`);
+			return;
 		}
 		data.hasFollowups = metadataUpdate.hasFollowups;
 		this._chatAgentService.updateAgent(data.id, revive(metadataUpdate));


### PR DESCRIPTION
Fix #214157

This can happen after something else went wrong, and the exception doesn't go back to the extension or anywhere helpful besides error telemetry.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
