### PR TITLE
Fix selection issue with filtered group models

### DIFF
--- a/src/vs/workbench/browser/parts/editor/multiEditorTabsControl.ts
+++ b/src/vs/workbench/browser/parts/editor/multiEditorTabsControl.ts
@@ -1288,24 +1288,24 @@ export class MultiEditorTabsControl extends EditorTabsControl {
 			throw new BugIndicatingError();
 		}
 
-		const anchorIndex = this.groupView.getIndexOfEditor(anchor);
-		if (anchorIndex === -1) {
+		const anchorEditorIndex = this.groupView.getIndexOfEditor(anchor);
+		if (anchorEditorIndex === -1) {
 			throw new BugIndicatingError();
 		}
 
 		let selection = this.groupView.selectedEditors;
 
 		// Unselect editors on other side of anchor in relation to the target
-		let currentIndex = anchorIndex;
-		while (currentIndex >= 0 && currentIndex <= this.groupView.count - 1) {
-			currentIndex = anchorIndex < editorIndex ? currentIndex - 1 : currentIndex + 1;
+		let currentEditorIndex = anchorEditorIndex;
+		while (currentEditorIndex >= 0 && currentEditorIndex <= this.groupView.count - 1) {
+			currentEditorIndex = anchorEditorIndex < editorIndex ? currentEditorIndex - 1 : currentEditorIndex + 1;
 
-			if (!this.tabsModel.isSelected(currentIndex)) {
+			const currentEditor = this.groupView.getEditorByIndex(currentEditorIndex);
+			if (!currentEditor) {
 				break;
 			}
 
-			const currentEditor = this.groupView.getEditorByIndex(currentIndex);
-			if (!currentEditor) {
+			if (!this.groupView.isSelected(currentEditor)) {
 				break;
 			}
 
@@ -1313,12 +1313,12 @@ export class MultiEditorTabsControl extends EditorTabsControl {
 		}
 
 		// Select editors between anchor and target
-		const fromIndex = anchorIndex < editorIndex ? anchorIndex : editorIndex;
-		const toIndex = anchorIndex < editorIndex ? editorIndex : anchorIndex;
+		const fromEditorIndex = anchorEditorIndex < editorIndex ? anchorEditorIndex : editorIndex;
+		const toEditorIndex = anchorEditorIndex < editorIndex ? editorIndex : anchorEditorIndex;
 
-		const editorsToSelect = this.groupView.getEditors(EditorsOrder.SEQUENTIAL).slice(fromIndex, toIndex + 1);
+		const editorsToSelect = this.groupView.getEditors(EditorsOrder.SEQUENTIAL).slice(fromEditorIndex, toEditorIndex + 1);
 		for (const editor of editorsToSelect) {
-			if (!this.tabsModel.isSelected(editor)) {
+			if (!this.groupView.isSelected(editor)) {
 				selection.push(editor);
 			}
 		}
@@ -1343,7 +1343,7 @@ export class MultiEditorTabsControl extends EditorTabsControl {
 			const recentEditors = this.groupView.getEditors(EditorsOrder.MOST_RECENTLY_ACTIVE);
 			for (let i = 1; i < recentEditors.length; i++) { // First one is the active editor
 				const recentEditor = recentEditors[i];
-				if (this.tabsModel.isSelected(recentEditor)) {
+				if (this.groupView.isSelected(recentEditor)) {
 					newActiveEditor = recentEditor;
 					break;
 				}

--- a/src/vs/workbench/common/editor/filteredEditorGroupModel.ts
+++ b/src/vs/workbench/common/editor/filteredEditorGroupModel.ts
@@ -36,7 +36,7 @@ abstract class FilteredEditorGroupModel extends Disposable implements IReadonlyE
 
 	get activeEditor(): EditorInput | null { return this.model.activeEditor && this.filter(this.model.activeEditor) ? this.model.activeEditor : null; }
 	get previewEditor(): EditorInput | null { return this.model.previewEditor && this.filter(this.model.previewEditor) ? this.model.previewEditor : null; }
-	get selectedEditors(): EditorInput[] { return this.model.selectedEditors.filter(e => this.filter(e)); }
+	get selectedEditors(): EditorInput[] { throw new Error('Filtered Editor Group Model should not be used for selectedEditors'); }
 
 	isPinned(editorOrIndex: EditorInput | number): boolean { return this.model.isPinned(editorOrIndex); }
 	isTransient(editorOrIndex: EditorInput | number): boolean { return this.model.isTransient(editorOrIndex); }


### PR DESCRIPTION
Since selection is always working across both rows, it should be invalid to use filtered group models when dealing with selection. This pull request fixes the issue by throwing an error when trying to access the `selectedEditors` property in the `FilteredEditorGroupModel`. This ensures that the filtered group model is not used for selection purposes. isSelected() however is still valid to use

Fixes #213163