### PR TITLE
Refresh git repository when a relevant subcommand is run in the terminal

### DIFF
--- a/extensions/git/package.json
+++ b/extensions/git/package.json
@@ -33,6 +33,7 @@
     "scmValidation",
     "tabInputMultiDiff",
     "tabInputTextMerge",
+    "terminalShellIntegration",
     "timeline"
   ],
   "categories": [

--- a/extensions/git/src/repository.ts
+++ b/extensions/git/src/repository.ts
@@ -974,7 +974,7 @@ export class Repository implements Disposable {
 		onDidChangeCountBadge(this.setCountBadge, this, this.disposables);
 		this.setCountBadge();
 
-		window.onDidEndTerminalShellExecution(e => {
+		this.disposables.push(window.onDidEndTerminalShellExecution(e => {
 			const [executable, subcommand, ..._args] = e.execution.commandLine.value.split(' ');
 			if (executable !== 'git' || !e.execution.cwd || !e.execution.cwd.path.startsWith(this.root)) {
 				return;
@@ -987,7 +987,7 @@ export class Repository implements Disposable {
 					}
 				}
 			}
-		});
+		}));
 	}
 
 	validateInput(text: string, _: number): SourceControlInputBoxValidation | undefined {

--- a/extensions/git/src/repository.ts
+++ b/extensions/git/src/repository.ts
@@ -975,11 +975,17 @@ export class Repository implements Disposable {
 		this.setCountBadge();
 
 		window.onDidEndTerminalShellExecution(e => {
-			if (!e.execution.commandLine.value.match(/^git\s?/) || !e.execution.cwd) {
+			const [executable, subcommand, ..._args] = e.execution.commandLine.value.split(' ');
+			if (executable !== 'git' || !e.execution.cwd || !e.execution.cwd.path.startsWith(this.root)) {
 				return;
 			}
-			if (e.exitCode === 0 && e.execution.cwd.path.startsWith(this.root)) {
-				this.refresh();
+			switch (subcommand) {
+				case 'fetch':
+				case 'pull': {
+					if (e.exitCode === 0) {
+						this.refresh();
+					}
+				}
 			}
 		});
 	}

--- a/extensions/git/src/repository.ts
+++ b/extensions/git/src/repository.ts
@@ -973,6 +973,15 @@ export class Repository implements Disposable {
 		const onDidChangeCountBadge = filterEvent(workspace.onDidChangeConfiguration, e => e.affectsConfiguration('git.countBadge', root));
 		onDidChangeCountBadge(this.setCountBadge, this, this.disposables);
 		this.setCountBadge();
+
+		window.onDidEndTerminalShellExecution(e => {
+			if (!e.execution.commandLine.value.match(/^git\s?/) || !e.execution.cwd) {
+				return;
+			}
+			if (e.exitCode === 0 && e.execution.cwd.path.startsWith(this.root)) {
+				this.refresh();
+			}
+		});
 	}
 
 	validateInput(text: string, _: number): SourceControlInputBoxValidation | undefined {

--- a/extensions/git/tsconfig.json
+++ b/extensions/git/tsconfig.json
@@ -20,6 +20,7 @@
 		"../../src/vscode-dts/vscode.proposed.scmTextDocument.d.ts",
 		"../../src/vscode-dts/vscode.proposed.tabInputMultiDiff.d.ts",
 		"../../src/vscode-dts/vscode.proposed.tabInputTextMerge.d.ts",
+		"../../src/vscode-dts/vscode.proposed.terminalShellIntegration.d.ts",
 		"../../src/vscode-dts/vscode.proposed.timeline.d.ts",
 		"../types/lib.textEncoder.d.ts"
 	]


### PR DESCRIPTION
Fixes #217244 

We could listen to a lot more things here, let me know how far we should go. I'm not sure if there are implications to calling `Repository.refresh` a bunch.

![Recording 2024-06-27 at 10 28 48](https://github.com/user-attachments/assets/c42f644b-52e2-4730-baee-bc0dd00f1d40)
