### PR TITLE
reduce impact of memory leaks related to editor

### DIFF
--- a/src/vs/base/browser/dom.ts
+++ b/src/vs/base/browser/dom.ts
@@ -129,6 +129,16 @@ export function clearNode(node: HTMLElement): void {
 	}
 }
 
+
+export function clearNodeRecursively(domNode: ChildNode) {
+	while (domNode.firstChild) {
+		const element = domNode.firstChild;
+		element.remove();
+		clearNodeRecursively(element);
+	}
+}
+
+
 class DomListener implements IDisposable {
 
 	private _handler: (e: any) => void;

--- a/src/vs/editor/browser/view.ts
+++ b/src/vs/editor/browser/view.ts
@@ -399,6 +399,8 @@ export class View extends ViewEventHandler {
 		}
 
 		super.dispose();
+
+		dom.clearNodeRecursively(this.domNode.domNode);
 	}
 
 	private _scheduleRender(): void {

--- a/src/vs/editor/browser/view.ts
+++ b/src/vs/editor/browser/view.ts
@@ -400,6 +400,12 @@ export class View extends ViewEventHandler {
 
 		super.dispose();
 
+		// See https://github.com/microsoft/vscode/pull/219297
+		// Reduces the impact of detached dom node memory leaks
+		// E.g when a memory leak occurs in a child component
+		// of the editor (e.g. Minimap, GlyphMarginWidgets,...)
+		// the editor dom (linked to the child dom) should not be
+		// leaked as well.
 		dom.clearNodeRecursively(this.domNode.domNode);
 	}
 


### PR DESCRIPTION
Helps with #218077


## Changes

This PR changes the editor dispose function to recursively clear all child elements of the editor dom node.

DOM nodes hold strong references to parent node, sibling nodes and child nodes. When a memory leak occurs in a child component of the editor (e.g. `Minimap`, `GlyphMarginWidgets`, `TextAreaHandler`, ...)  the editor dom (linked to the child dom) is leaked as well.

By recursively clearing all editor child elements, only the child elements will be leaked. 

## Reducing impact of memory leaks

While this doesn't fix any memory leak, it reduces the impact of memory leaks related to the editor. For example, when opening an editor 197 times, the number of leaked dom nodes is much lower than before:

| Metric name | Before | After |
|-|-|-|
| detached canvas element count | ~800 | 0 |
| detached dom node count | 14307 | 937 |
| leaked object count | ~16400 | ~2000 |


## Making it easier to find the cause of editor memory leaks

With less leaked dom nodes, it could make it easier to find the cause of memory leaks related to the editor. For example, these are the detached dom nodes now when opening an editor 197 times:

```json
{
  "detachedDomNodes": {
    "after": [
      {
        "className": "HTMLDivElement",
        "description": "div.lines-content.monaco-editor-background",
        "count": 399
      },
      {
        "className": "HTMLDivElement",
        "description": "div.margin",
        "count": 399
      },
     {
        "className": "HTMLSpanElement",
        "description": "span.codicon.codicon-sync.codicon-modifier-spin",
        "count": 10
      },
      {
        "className": "HTMLDivElement",
        "description": "div.orthogonal-drag-handle.end",
        "count": 8
      },
      {
        "className": "HTMLDivElement",
        "description": "div.orthogonal-drag-handle.start",
        "count": 7
      },
      // ...
    ]
  }
}
```

It seems there is a memory leak related to the `editor background` and/or `editor margin` component. 


## Performance 

Clearing all dom nodes recursively has a performance overhead of ~1ms to ~1.8 ms on my machine. On the other hand, garbage collection could potentially be faster.

## Test Script for measuring canvas count 

```
git clone git@github.com:SimonSiefke/vscode-memory-leak-finder.git &&
cd vscode-memory-leak-finder &&
git checkout v5.53.0 &&
npm ci &&
VSCODE_PATH="yourPathLocalVscodeFolder/scripts/code.sh" node packages/cli/bin/test.js --cwd packages/e2e --only  editor.switch-between-tabs --check-leaks --measure-after --measure canvas-count --runs 17 &&
cat .vscode-memory-leak-finder-results/canvas-count/editor.switch-between-tabs.json 
```

## Test Script for measuring detached dom nodes 

```
git clone git@github.com:SimonSiefke/vscode-memory-leak-finder.git &&
cd vscode-memory-leak-finder &&
git checkout v5.53.0 &&
npm ci &&
VSCODE_PATH="yourPathLocalVscodeFolder/scripts/code.sh" node packages/cli/bin/test.js --cwd packages/e2e --only  editor.switch-between-tabs --check-leaks --measure-after --measure detached-dom-nodes --runs 17 &&
cat .vscode-memory-leak-finder-results/detached-dom-nodes/editor.switch-between-tabs.json 
```

## Test Results

The number of canvas elements now stays pretty much constant:

![canvas-count-2](https://github.com/microsoft/vscode/assets/23744935/931f5a32-ca8d-42d5-835e-107d75b24f23)
