### PR TITLE
Fixes #218254

### DIFF
--- a/src/vs/workbench/contrib/webview/browser/webviewElement.ts
+++ b/src/vs/workbench/contrib/webview/browser/webviewElement.ts
@@ -265,6 +265,7 @@ export class WebviewElement extends Disposable implements IWebview, WebviewFindD
 					y: elementBox.y + data.clientY
 				})
 			});
+			this._send('set-context-menu-visible', { visible: true });
 		}));
 
 		this._register(this.on('load-resource', async (entry) => {
@@ -294,7 +295,6 @@ export class WebviewElement extends Disposable implements IWebview, WebviewFindD
 		this._register(Event.runAndSubscribe(webviewThemeDataProvider.onThemeDataChanged, () => this.style()));
 		this._register(_accessibilityService.onDidChangeReducedMotion(() => this.style()));
 		this._register(_accessibilityService.onDidChangeScreenReaderOptimized(() => this.style()));
-		this._register(contextMenuService.onDidShowContextMenu(() => this._send('set-context-menu-visible', { visible: true })));
 		this._register(contextMenuService.onDidHideContextMenu(() => this._send('set-context-menu-visible', { visible: false })));
 
 		this._confirmBeforeClose = configurationService.getValue<string>('window.confirmBeforeClose');


### PR DESCRIPTION
Fixes #218254 

onDidShowContextMenu fires for every webview even though only one webview has the context menu visible, hence removed the onDidShow listener, sending the set-context-menu-visible event to the html on did-context-menu event so that the context-menu-visible class gets applied only to the webview that actually has the context menu visible

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
