### PR TITLE
Use 'const' in vscode.d.ts to show that props are not assignable

### DIFF
--- a/src/vscode-dts/vscode.d.ts
+++ b/src/vscode-dts/vscode.d.ts
@@ -10346,12 +10346,12 @@ declare module 'vscode' {
 		 * that currently has focus or, when none has focus, the one that has changed
 		 * input most recently.
 		 */
-		export let activeTextEditor: TextEditor | undefined;
+		export const activeTextEditor: TextEditor | undefined;
 
 		/**
 		 * The currently visible editors or an empty array.
 		 */
-		export let visibleTextEditors: readonly TextEditor[];
+		export const visibleTextEditors: readonly TextEditor[];
 
 		/**
 		 * An {@link Event} which fires when the {@link window.activeTextEditor active editor}
@@ -11085,7 +11085,7 @@ declare module 'vscode' {
 		 * The currently active color theme as configured in the settings. The active
 		 * theme can be changed via the `workbench.colorTheme` setting.
 		 */
-		export let activeColorTheme: ColorTheme;
+		export const activeColorTheme: ColorTheme;
 
 		/**
 		 * An {@link Event} which fires when the active color theme is changed or has changes.
@@ -16263,18 +16263,18 @@ declare module 'vscode' {
 		 * represented by the debug action floating window or the one currently shown in the drop down menu of the debug action floating window.
 		 * If no debug session is active, the value is `undefined`.
 		 */
-		export let activeDebugSession: DebugSession | undefined;
+		export const activeDebugSession: DebugSession | undefined;
 
 		/**
 		 * The currently active {@link DebugConsole debug console}.
 		 * If no debug session is active, output sent to the debug console is not shown.
 		 */
-		export let activeDebugConsole: DebugConsole;
+		export const activeDebugConsole: DebugConsole;
 
 		/**
 		 * List of breakpoints.
 		 */
-		export let breakpoints: readonly Breakpoint[];
+		export const breakpoints: readonly Breakpoint[];
 
 		/**
 		 * An {@link Event} which fires when the {@link debug.activeDebugSession active debug session}


### PR DESCRIPTION
Fix #216555

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
