### PR TITLE
shellscript: Register .eclass extension as shell-like

### DIFF
--- a/extensions/shellscript/package.json
+++ b/extensions/shellscript/package.json
@@ -34,6 +34,7 @@
           ".bash_profile",
           ".bash_login",
           ".ebuild",
+          ".eclass",
           ".profile",
           ".bash_logout",
           ".xprofile",


### PR DESCRIPTION
Gentoo provides a framework to define modular code that can be reused between ebuilds and packages; the file extension for Gentoo eclasses should be registered as shell-like syntax in addition to ebuilds.

https://wiki.gentoo.org/wiki/Eclass
