### PR TITLE
Fix issue with clicking between active tabs

### DIFF
--- a/src/vs/workbench/browser/parts/editor/multiEditorTabsControl.ts
+++ b/src/vs/workbench/browser/parts/editor/multiEditorTabsControl.ts
@@ -684,13 +684,17 @@ export class MultiEditorTabsControl extends EditorTabsControl {
 		this.layout(this.dimensions, { forceRevealActiveTab: true });
 	}
 
+	private previousSelectedCount = 0;
 	updateEditorSelections(): void {
-		// Only update if the active editor is the same as before
-		// if the active editor is different, the update
-		// will happen from an open editor call.
-		const drawnActiveEditor = this.activeTabLabel?.editor;
-		const newActiveEditor = this.tabsModel.activeEditor;
-		if (drawnActiveEditor && newActiveEditor && !drawnActiveEditor.matches(newActiveEditor)) {
+		// We only need to redraw from here when a selection got removed
+		// otherwise it will be handled by the open editor change event.
+		// Checking count is currently enough but might require checking
+		// each editor in the future if selection is changed programatically.
+		const newSelectedCount = this.tabsModel.selectedEditors.length;
+		const previousSelectedCount = this.previousSelectedCount;
+		this.previousSelectedCount = newSelectedCount;
+
+		if (newSelectedCount >= previousSelectedCount) {
 			return;
 		}
 
@@ -1649,7 +1653,7 @@ export class MultiEditorTabsControl extends EditorTabsControl {
 	private redrawTabSelectedActiveAndDirty(isGroupActive: boolean, editor: EditorInput, tabContainer: HTMLElement, tabActionBar: ActionBar): void {
 		const isTabActive = this.tabsModel.isActive(editor);
 		const hasModifiedBorderTop = this.doRedrawTabDirty(isGroupActive, isTabActive, editor, tabContainer);
-
+		console.log('redrawTabSelectedActiveAndDirty', editor.getName());
 		this.doRedrawTabActive(isGroupActive, !hasModifiedBorderTop, editor, tabContainer, tabActionBar);
 	}
 

--- a/src/vs/workbench/browser/parts/editor/multiEditorTabsControl.ts
+++ b/src/vs/workbench/browser/parts/editor/multiEditorTabsControl.ts
@@ -685,6 +685,15 @@ export class MultiEditorTabsControl extends EditorTabsControl {
 	}
 
 	updateEditorSelections(): void {
+		// Only update if the active editor is the same as before
+		// if the active editor is different, the update
+		// will happen from an open editor call.
+		const drawnActiveEditor = this.activeTabLabel?.editor;
+		const newActiveEditor = this.tabsModel.activeEditor;
+		if (drawnActiveEditor && newActiveEditor && !drawnActiveEditor.matches(newActiveEditor)) {
+			return;
+		}
+
 		this.forEachTab((editor, tabIndex, tabContainer, tabLabelWidget, tabLabel, tabActionBar) => {
 			this.redrawTabSelectedActiveAndDirty(this.groupsView.activeGroup === this.groupView, editor, tabContainer, tabActionBar);
 		});

--- a/src/vs/workbench/browser/parts/editor/multiEditorTabsControl.ts
+++ b/src/vs/workbench/browser/parts/editor/multiEditorTabsControl.ts
@@ -1653,7 +1653,7 @@ export class MultiEditorTabsControl extends EditorTabsControl {
 	private redrawTabSelectedActiveAndDirty(isGroupActive: boolean, editor: EditorInput, tabContainer: HTMLElement, tabActionBar: ActionBar): void {
 		const isTabActive = this.tabsModel.isActive(editor);
 		const hasModifiedBorderTop = this.doRedrawTabDirty(isGroupActive, isTabActive, editor, tabContainer);
-		console.log('redrawTabSelectedActiveAndDirty', editor.getName());
+
 		this.doRedrawTabActive(isGroupActive, !hasModifiedBorderTop, editor, tabContainer, tabActionBar);
 	}
 

--- a/src/vs/workbench/browser/parts/editor/multiRowEditorTabsControl.ts
+++ b/src/vs/workbench/browser/parts/editor/multiRowEditorTabsControl.ts
@@ -20,6 +20,9 @@ export class MultiRowEditorControl extends Disposable implements IEditorTabsCont
 	private readonly stickyEditorTabsControl: IEditorTabsControl;
 	private readonly unstickyEditorTabsControl: IEditorTabsControl;
 
+	private previousSelectedStickyCount = 0;
+	private previousSelectedUnstickyCount = 0;
+
 	constructor(
 		private readonly parent: HTMLElement,
 		editorPartsView: IEditorPartsView,
@@ -164,8 +167,22 @@ export class MultiRowEditorControl extends Disposable implements IEditorTabsCont
 	}
 
 	updateEditorSelections(): void {
-		this.stickyEditorTabsControl.updateEditorSelections();
-		this.unstickyEditorTabsControl.updateEditorSelections();
+		const selectedEditors = this.groupView.selectedEditors;
+		const selectedStickyCount = selectedEditors.filter(e => this.model.isSticky(e)).length;
+		const selectedUnstickyCount = selectedEditors.filter(e => !this.model.isSticky(e)).length;
+
+		// If the selection length did not change then avoid updating the tabs
+		// as there will be an open editor action that will
+		// trigger a refresh of the tabs to reflect the new active editor
+		if (selectedStickyCount !== this.previousSelectedStickyCount) {
+			this.stickyEditorTabsControl.updateEditorSelections();
+		}
+		if (selectedUnstickyCount !== this.previousSelectedUnstickyCount) {
+			this.unstickyEditorTabsControl.updateEditorSelections();
+		}
+
+		this.previousSelectedStickyCount = selectedStickyCount;
+		this.previousSelectedUnstickyCount = selectedUnstickyCount;
 	}
 
 	updateEditorLabel(editor: EditorInput): void {

--- a/src/vs/workbench/browser/parts/editor/multiRowEditorTabsControl.ts
+++ b/src/vs/workbench/browser/parts/editor/multiRowEditorTabsControl.ts
@@ -20,9 +20,6 @@ export class MultiRowEditorControl extends Disposable implements IEditorTabsCont
 	private readonly stickyEditorTabsControl: IEditorTabsControl;
 	private readonly unstickyEditorTabsControl: IEditorTabsControl;
 
-	private previousSelectedStickyCount = 0;
-	private previousSelectedUnstickyCount = 0;
-
 	constructor(
 		private readonly parent: HTMLElement,
 		editorPartsView: IEditorPartsView,
@@ -167,22 +164,8 @@ export class MultiRowEditorControl extends Disposable implements IEditorTabsCont
 	}
 
 	updateEditorSelections(): void {
-		const selectedEditors = this.groupView.selectedEditors;
-		const selectedStickyCount = selectedEditors.filter(e => this.model.isSticky(e)).length;
-		const selectedUnstickyCount = selectedEditors.filter(e => !this.model.isSticky(e)).length;
-
-		// If the selection length did not change then avoid updating the tabs
-		// as there will be an open editor action that will
-		// trigger a refresh of the tabs to reflect the new active editor
-		if (selectedStickyCount !== this.previousSelectedStickyCount) {
-			this.stickyEditorTabsControl.updateEditorSelections();
-		}
-		if (selectedUnstickyCount !== this.previousSelectedUnstickyCount) {
-			this.unstickyEditorTabsControl.updateEditorSelections();
-		}
-
-		this.previousSelectedStickyCount = selectedStickyCount;
-		this.previousSelectedUnstickyCount = selectedUnstickyCount;
+		this.stickyEditorTabsControl.updateEditorSelections();
+		this.unstickyEditorTabsControl.updateEditorSelections();
 	}
 
 	updateEditorLabel(editor: EditorInput): void {

--- a/src/vs/workbench/common/editor/filteredEditorGroupModel.ts
+++ b/src/vs/workbench/common/editor/filteredEditorGroupModel.ts
@@ -36,7 +36,7 @@ abstract class FilteredEditorGroupModel extends Disposable implements IReadonlyE
 
 	get activeEditor(): EditorInput | null { return this.model.activeEditor && this.filter(this.model.activeEditor) ? this.model.activeEditor : null; }
 	get previewEditor(): EditorInput | null { return this.model.previewEditor && this.filter(this.model.previewEditor) ? this.model.previewEditor : null; }
-	get selectedEditors(): EditorInput[] { throw new Error('Filtered Editor Group Model should not be used for selectedEditors'); }
+	get selectedEditors(): EditorInput[] { return this.model.selectedEditors.filter(e => this.filter(e)); }
 
 	isPinned(editorOrIndex: EditorInput | number): boolean { return this.model.isPinned(editorOrIndex); }
 	isTransient(editorOrIndex: EditorInput | number): boolean { return this.model.isTransient(editorOrIndex); }


### PR DESCRIPTION
Previously, when clicking between active tabs, the `redrawTabSelectedActiveAndDirty` function was being called multiple times, resulting in unnecessary redraws. This pull request fixes the issue by adding a check to only update the tabs if the active editor is the same as before. If the active editor is different, the update will happen from an open editor call.

Fixes #213160