### PR TITLE
fix: memory leak in extension tabs

### DIFF
--- a/src/vs/workbench/contrib/extensions/browser/extensionFeaturesTab.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionFeaturesTab.ts
@@ -178,10 +178,10 @@ export class ExtensionFeaturesTab extends Themable {
 			return;
 		}
 
-		const splitView = new SplitView<number>(this.domNode, {
+		const splitView = this._register(new SplitView<number>(this.domNode, {
 			orientation: Orientation.HORIZONTAL,
 			proportionalLayout: true
-		});
+		}));
 		this.layoutParticipants.push({
 			layout: (height: number, width: number) => {
 				splitView.el.style.height = `${height - 14}px`;
@@ -190,7 +190,7 @@ export class ExtensionFeaturesTab extends Themable {
 		});
 
 		const featuresListContainer = $('.features-list-container');
-		const list = this.createFeaturesList(featuresListContainer);
+		const list = this._register(this.createFeaturesList(featuresListContainer));
 		list.splice(0, list.length, features);
 
 		const featureViewContainer = $('.feature-view-container');


### PR DESCRIPTION
## Summary

This fixes an event listener memory leak in the extension detail view tabs component. When switching between the "Details", "Features" and "Changelog" tabs, the number of event listeners increases each time.

![tabs](https://github.com/microsoft/vscode/assets/23744935/8aa289a7-c416-468f-9927-687befe06e59) 


## Before

The number of event listeners grows linearly to more than 20000:

![before](https://github.com/microsoft/vscode/assets/23744935/ce577d8c-e342-426d-aeb0-654d7d39d2f5)




## After

The number of event listeners stays constant at 2723:

![after](https://github.com/microsoft/vscode/assets/23744935/4419ced9-b76f-4ac2-b615-2c6958295a07)