### PR TITLE
testing: simplify tests when actioning gutter items

### DIFF
--- a/src/vs/base/common/prefixTree.ts
+++ b/src/vs/base/common/prefixTree.ts
@@ -32,6 +32,11 @@ export class WellDefinedPrefixTree<V> {
 		return this.root.children?.values() || Iterable.empty();
 	}
 
+	/** Gets the top-level nodes of the tree */
+	public get entries(): Iterable<[string, IPrefixTreeNode<V>]> {
+		return this.root.children?.entries() || Iterable.empty();
+	}
+
 	/**
 	 * Inserts a new value in the prefix tree.
 	 * @param onNode - called for each node as we descend to the insertion point,

--- a/src/vs/workbench/contrib/testing/browser/testingDecorations.ts
+++ b/src/vs/workbench/contrib/testing/browser/testingDecorations.ts
@@ -47,7 +47,7 @@ import { TestId } from 'vs/workbench/contrib/testing/common/testId';
 import { ITestProfileService } from 'vs/workbench/contrib/testing/common/testProfileService';
 import { ITestResult, LiveTestResult } from 'vs/workbench/contrib/testing/common/testResult';
 import { ITestResultService } from 'vs/workbench/contrib/testing/common/testResultService';
-import { ITestService, getContextForTestItem, testsInFile } from 'vs/workbench/contrib/testing/common/testService';
+import { ITestService, getContextForTestItem, simplifyTestsToExecute, testsInFile } from 'vs/workbench/contrib/testing/common/testService';
 import { IRichLocation, ITestMessage, ITestRunProfile, IncrementalTestCollectionItem, InternalTestItem, TestDiffOpType, TestMessageType, TestResultItem, TestResultState, TestRunProfileBitset } from 'vs/workbench/contrib/testing/common/testTypes';
 import { ITestDecoration as IPublicTestDecoration, ITestingDecorationsService, TestDecorations } from 'vs/workbench/contrib/testing/common/testingDecorations';
 import { ITestingPeekOpener } from 'vs/workbench/contrib/testing/common/testingPeekOpener';
@@ -806,7 +806,7 @@ abstract class RunTestDecoration {
 
 	protected runWith(profile: TestRunProfileBitset) {
 		return this.testService.runTests({
-			tests: this.tests.map(({ test }) => test),
+			tests: simplifyTestsToExecute(this.testService.collection, this.tests.map(({ test }) => test)),
 			group: profile,
 		});
 	}

--- a/src/vs/workbench/contrib/testing/common/testId.ts
+++ b/src/vs/workbench/contrib/testing/common/testId.ts
@@ -105,7 +105,7 @@ export class TestId {
 	 * todo@connor4312: review usages of this to see if using the WellDefinedPrefixTree is better
 	 */
 	public static isChild(maybeParent: string, maybeChild: string) {
-		return maybeChild.startsWith(maybeParent) && maybeChild[maybeParent.length] === TestIdPathParts.Delimiter;
+		return maybeChild[maybeParent.length] === TestIdPathParts.Delimiter && maybeChild.startsWith(maybeParent);
 	}
 
 	/**

--- a/src/vs/workbench/contrib/testing/test/common/testService.test.ts
+++ b/src/vs/workbench/contrib/testing/test/common/testService.test.ts
@@ -1,0 +1,108 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { ensureNoDisposablesAreLeakedInTestSuite } from 'vs/base/test/common/utils';
+import { TestId } from 'vs/workbench/contrib/testing/common/testId';
+import { simplifyTestsToExecute } from 'vs/workbench/contrib/testing/common/testService';
+import { getInitializedMainTestCollection, makeSimpleStubTree } from 'vs/workbench/contrib/testing/test/common/testStubs';
+
+suite('Workbench - Test Service', () => {
+	ensureNoDisposablesAreLeakedInTestSuite();
+
+	suite('simplifyTestsToExecute', () => {
+		const tree1 = {
+			a: {
+				b1: {
+					c1: {
+						d: undefined
+					},
+					c2: {
+						d: undefined
+					},
+				},
+				b2: undefined,
+			}
+		} as const;
+
+		test('noop on single item', async () => {
+			const c = await getInitializedMainTestCollection(makeSimpleStubTree(tree1));
+
+			const t = simplifyTestsToExecute(c, [
+				c.getNodeById(new TestId(['ctrlId', 'a', 'b1']).toString())!
+			]);
+
+			assert.deepStrictEqual(t.map(t => t.item.extId.toString()), [
+				new TestId(['ctrlId', 'a', 'b1']).toString()
+			]);
+		});
+
+		test('goes to common root 1', async () => {
+			const c = await getInitializedMainTestCollection(makeSimpleStubTree(tree1));
+
+			const t = simplifyTestsToExecute(c, [
+				c.getNodeById(new TestId(['ctrlId', 'a', 'b1', 'c1', 'd']).toString())!,
+				c.getNodeById(new TestId(['ctrlId', 'a', 'b1', 'c2']).toString())!,
+			]);
+
+			assert.deepStrictEqual(t.map(t => t.item.extId.toString()), [
+				new TestId(['ctrlId', 'a', 'b1']).toString()
+			]);
+		});
+
+		test('goes to common root 2', async () => {
+			const c = await getInitializedMainTestCollection(makeSimpleStubTree(tree1));
+
+			const t = simplifyTestsToExecute(c, [
+				c.getNodeById(new TestId(['ctrlId', 'a', 'b1', 'c1']).toString())!,
+				c.getNodeById(new TestId(['ctrlId', 'a', 'b1']).toString())!,
+			]);
+
+			assert.deepStrictEqual(t.map(t => t.item.extId.toString()), [
+				new TestId(['ctrlId', 'a', 'b1']).toString()
+			]);
+		});
+
+		test('goes to common root 3', async () => {
+			const c = await getInitializedMainTestCollection(makeSimpleStubTree(tree1));
+
+			const t = simplifyTestsToExecute(c, [
+				c.getNodeById(new TestId(['ctrlId', 'a', 'b1', 'c1', 'd']).toString())!,
+				c.getNodeById(new TestId(['ctrlId', 'a', 'b1', 'c2']).toString())!,
+			]);
+
+			assert.deepStrictEqual(t.map(t => t.item.extId.toString()), [
+				new TestId(['ctrlId', 'a', 'b1']).toString()
+			]);
+		});
+
+		test('goes to common root 4', async () => {
+			const c = await getInitializedMainTestCollection(makeSimpleStubTree(tree1));
+
+			const t = simplifyTestsToExecute(c, [
+				c.getNodeById(new TestId(['ctrlId', 'a', 'b2']).toString())!,
+				c.getNodeById(new TestId(['ctrlId', 'a', 'b1']).toString())!,
+			]);
+
+			assert.deepStrictEqual(t.map(t => t.item.extId.toString()), [
+				new TestId(['ctrlId']).toString()
+			]);
+		});
+
+		test('no-op divergent trees', async () => {
+			const c = await getInitializedMainTestCollection(makeSimpleStubTree(tree1));
+
+			const t = simplifyTestsToExecute(c, [
+				c.getNodeById(new TestId(['ctrlId', 'a', 'b1', 'c2']).toString())!,
+				c.getNodeById(new TestId(['ctrlId', 'a', 'b2']).toString())!,
+			]);
+
+			assert.deepStrictEqual(t.map(t => t.item.extId.toString()), [
+				new TestId(['ctrlId', 'a', 'b1', 'c2']).toString(),
+				new TestId(['ctrlId', 'a', 'b2']).toString(),
+			]);
+		});
+	});
+});

--- a/src/vs/workbench/contrib/testing/test/common/testStubs.ts
+++ b/src/vs/workbench/contrib/testing/test/common/testStubs.ts
@@ -113,6 +113,26 @@ export const getInitializedMainTestCollection = async (singleUse = testStubs.nes
 	return c;
 };
 
+type StubTreeIds = Readonly<{ [id: string]: StubTreeIds | undefined }>;
+
+export const makeSimpleStubTree = (ids: StubTreeIds): TestTestCollection => {
+	const collection = new TestTestCollection();
+
+	const add = (parent: TestTestItem, children: StubTreeIds, path: readonly string[]) => {
+		for (const id of Object.keys(children)) {
+			const item = new TestTestItem(new TestId([...path, id]), id);
+			parent.children.add(item);
+			if (children[id]) {
+				add(item, children[id]!, [...path, id]);
+			}
+		}
+	};
+
+	add(collection.root, ids, ['ctrlId']);
+
+	return collection;
+};
+
 export const testStubs = {
 	nested: (idPrefix = 'id-') => {
 		const collection = new TestTestCollection();


### PR DESCRIPTION
This adds a function to "simplify" tests by preferring to pass parent
items rather than child items when running tests via test gutter
decorations, when all children have been included. For https://github.com/microsoft/vscode-python/issues/21151

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
