### PR TITLE
Misc cleanup in QuickInputTree

### DIFF
--- a/src/vs/platform/quickinput/browser/quickInputController.ts
+++ b/src/vs/platform/quickinput/browser/quickInputController.ts
@@ -275,7 +275,7 @@ export class QuickInputController extends Disposable {
 						} else {
 							selectors.push('input[type=text]');
 						}
-						if (this.getUI().list.isDisplayed()) {
+						if (this.getUI().list.displayed) {
 							selectors.push('.monaco-list');
 						}
 						// focus links if there are any
@@ -614,7 +614,7 @@ export class QuickInputController extends Disposable {
 		ui.customButtonContainer.style.display = visibilities.customButton ? '' : 'none';
 		ui.message.style.display = visibilities.message ? '' : 'none';
 		ui.progressBar.getContainer().style.display = visibilities.progressBar ? '' : 'none';
-		ui.list.display(!!visibilities.list);
+		ui.list.displayed = !!visibilities.list;
 		ui.container.classList.toggle('show-checkboxes', !!visibilities.checkBox);
 		ui.container.classList.toggle('hidden-input', !visibilities.inputBox && !visibilities.description);
 		this.updateLayout(); // TODO
@@ -683,7 +683,7 @@ export class QuickInputController extends Disposable {
 	}
 
 	navigate(next: boolean, quickNavigate?: IQuickNavigateConfiguration) {
-		if (this.isVisible() && this.getUI().list.isDisplayed()) {
+		if (this.isVisible() && this.getUI().list.displayed) {
 			this.getUI().list.focus(next ? QuickPickFocus.Next : QuickPickFocus.Previous);
 			if (quickNavigate && this.controller instanceof QuickPick) {
 				this.controller.quickNavigate = quickNavigate;


### PR DESCRIPTION
* dispose some Event.maps
* remove a bunch of dead code (functions that are no longer used)
* stylistic changes
* have `QuickPickFocus.Second`, `QuickPickFocus.Last`, `QuickPickFocus.NextSeparator` use the tree itself instead of `this._itemElements`

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
