### PR TITLE
Update notebook comment view in response to mutations

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/view/cellParts/cellComments.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/cellParts/cellComments.ts
@@ -110,10 +110,6 @@ export class CellComments extends CellContentPart {
 				this.currentElement.commentHeight = 0;
 				return;
 			}
-			if (this._commentThreadWidget.value.commentThread === info.thread) {
-				this.currentElement.commentHeight = this._calculateCommentThreadHeight(this._commentThreadWidget.value.getDimensions().height);
-				return;
-			}
 
 			await this._commentThreadWidget.value.updateCommentThread(info.thread);
 			this.currentElement.commentHeight = this._calculateCommentThreadHeight(this._commentThreadWidget.value.getDimensions().height);


### PR DESCRIPTION
Fixes Rendered notebook cell comments are not updated when the underlying data changes via the extension APIs #214248

This short circuiting makes it so that the comment is not updated. Not having this return early is consistent with the corresponding function in commentThreadZoneWidget.ts.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
