### PR TITLE
Fix editor commands context

### DIFF
--- a/src/vs/workbench/browser/parts/editor/editorActions.ts
+++ b/src/vs/workbench/browser/parts/editor/editorActions.ts
@@ -1175,9 +1175,8 @@ export class ToggleMaximizeEditorGroupAction extends Action2 {
 		const editorGroupsService = accessor.get(IEditorGroupsService);
 
 		const resolvedContext = resolveCommandsContext(accessor, args);
-		const groupContext = resolvedContext.groupedEditors[0];
-		if (groupContext) {
-			editorGroupsService.toggleMaximizeGroup(groupContext.group);
+		if (!resolvedContext.groupedEditors.length) {
+			editorGroupsService.toggleMaximizeGroup(resolvedContext.groupedEditors[0].group);
 		}
 	}
 }
@@ -2546,21 +2545,21 @@ abstract class BaseMoveCopyEditorToNewWindowAction extends Action2 {
 	override async run(accessor: ServicesAccessor, ...args: unknown[]) {
 		const editorGroupService = accessor.get(IEditorGroupsService);
 		const resolvedContext = resolveCommandsContext(accessor, args);
-		const groupContext = resolvedContext.groupedEditors[0];
-		if (!groupContext) {
+		if (!resolvedContext.groupedEditors.length) {
 			return;
 		}
 
 		const auxiliaryEditorPart = await editorGroupService.createAuxiliaryEditorPart();
 
-		const sourceGroup = groupContext.group; // only single group supported for move/copy for now
+		// only single group supported for move/copy for now
+		const { group, editors } = resolvedContext.groupedEditors[0];
 		const options = { preserveFocus: resolvedContext.preserveFocus };
-		const sourceEditors = groupContext.editors.map(editor => ({ editor, options }));
+		const editorsWithOptions = editors.map(editor => ({ editor, options }));
 
 		if (this.move) {
-			sourceGroup.moveEditors(sourceEditors, auxiliaryEditorPart.activeGroup);
+			group.moveEditors(editorsWithOptions, auxiliaryEditorPart.activeGroup);
 		} else {
-			sourceGroup.copyEditors(sourceEditors, auxiliaryEditorPart.activeGroup);
+			group.copyEditors(editorsWithOptions, auxiliaryEditorPart.activeGroup);
 		}
 
 		auxiliaryEditorPart.activeGroup.focus();

--- a/src/vs/workbench/browser/parts/editor/editorActions.ts
+++ b/src/vs/workbench/browser/parts/editor/editorActions.ts
@@ -1175,7 +1175,7 @@ export class ToggleMaximizeEditorGroupAction extends Action2 {
 		const editorGroupsService = accessor.get(IEditorGroupsService);
 
 		const resolvedContext = resolveCommandsContext(accessor, args);
-		if (!resolvedContext.groupedEditors.length) {
+		if (resolvedContext.groupedEditors.length) {
 			editorGroupsService.toggleMaximizeGroup(resolvedContext.groupedEditors[0].group);
 		}
 	}

--- a/src/vs/workbench/browser/parts/editor/editorActions.ts
+++ b/src/vs/workbench/browser/parts/editor/editorActions.ts
@@ -13,7 +13,7 @@ import { IWorkbenchLayoutService, Parts } from 'vs/workbench/services/layout/bro
 import { GoFilter, IHistoryService } from 'vs/workbench/services/history/common/history';
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 import { ICommandService } from 'vs/platform/commands/common/commands';
-import { CLOSE_EDITOR_COMMAND_ID, MOVE_ACTIVE_EDITOR_COMMAND_ID, ActiveEditorMoveCopyArguments, SPLIT_EDITOR_LEFT, SPLIT_EDITOR_RIGHT, SPLIT_EDITOR_UP, SPLIT_EDITOR_DOWN, splitEditor, LAYOUT_EDITOR_GROUPS_COMMAND_ID, UNPIN_EDITOR_COMMAND_ID, COPY_ACTIVE_EDITOR_COMMAND_ID, SPLIT_EDITOR, resolveCommandsContext, getCommandsContext, TOGGLE_MAXIMIZE_EDITOR_GROUP, MOVE_EDITOR_INTO_NEW_WINDOW_COMMAND_ID, COPY_EDITOR_INTO_NEW_WINDOW_COMMAND_ID, MOVE_EDITOR_GROUP_INTO_NEW_WINDOW_COMMAND_ID, COPY_EDITOR_GROUP_INTO_NEW_WINDOW_COMMAND_ID, NEW_EMPTY_EDITOR_WINDOW_COMMAND_ID as NEW_EMPTY_EDITOR_WINDOW_COMMAND_ID, resolveEditorsContext, getEditorsContext } from 'vs/workbench/browser/parts/editor/editorCommands';
+import { CLOSE_EDITOR_COMMAND_ID, MOVE_ACTIVE_EDITOR_COMMAND_ID, ActiveEditorMoveCopyArguments, SPLIT_EDITOR_LEFT, SPLIT_EDITOR_RIGHT, SPLIT_EDITOR_UP, SPLIT_EDITOR_DOWN, splitEditor, LAYOUT_EDITOR_GROUPS_COMMAND_ID, UNPIN_EDITOR_COMMAND_ID, COPY_ACTIVE_EDITOR_COMMAND_ID, SPLIT_EDITOR, TOGGLE_MAXIMIZE_EDITOR_GROUP, MOVE_EDITOR_INTO_NEW_WINDOW_COMMAND_ID, COPY_EDITOR_INTO_NEW_WINDOW_COMMAND_ID, MOVE_EDITOR_GROUP_INTO_NEW_WINDOW_COMMAND_ID, COPY_EDITOR_GROUP_INTO_NEW_WINDOW_COMMAND_ID, NEW_EMPTY_EDITOR_WINDOW_COMMAND_ID as NEW_EMPTY_EDITOR_WINDOW_COMMAND_ID } from 'vs/workbench/browser/parts/editor/editorCommands';
 import { IEditorGroupsService, IEditorGroup, GroupsArrangement, GroupLocation, GroupDirection, preferredSideBySideGroupDirection, IFindGroupScope, GroupOrientation, EditorGroupLayout, GroupsOrder, MergeGroupMode } from 'vs/workbench/services/editor/common/editorGroupsService';
 import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
@@ -34,10 +34,10 @@ import { IKeybindingRule, KeybindingWeight } from 'vs/platform/keybinding/common
 import { ILogService } from 'vs/platform/log/common/log';
 import { Categories } from 'vs/platform/action/common/actionCommonCategories';
 import { ActiveEditorAvailableEditorIdsContext, ActiveEditorContext, ActiveEditorGroupEmptyContext, AuxiliaryBarVisibleContext, EditorPartMaximizedEditorGroupContext, EditorPartMultipleEditorGroupsContext, IsAuxiliaryWindowFocusedContext, MultipleEditorGroupsContext, SideBarVisibleContext } from 'vs/workbench/common/contextkeys';
-import { URI } from 'vs/base/common/uri';
 import { getActiveDocument } from 'vs/base/browser/dom';
 import { ICommandActionTitle } from 'vs/platform/action/common/action';
 import { IProgressService, ProgressLocation } from 'vs/platform/progress/common/progress';
+import { resolveCommandsContext } from 'vs/workbench/browser/parts/editor/editorCommandsContext';
 
 class ExecuteCommandAction extends Action2 {
 
@@ -62,12 +62,14 @@ abstract class AbstractSplitEditorAction extends Action2 {
 		return preferredSideBySideGroupDirection(configurationService);
 	}
 
-	override async run(accessor: ServicesAccessor, resourceOrContext?: URI | IEditorCommandsContext, context?: IEditorCommandsContext): Promise<void> {
+	override async run(accessor: ServicesAccessor, ...args: unknown[]): Promise<void> {
 		const editorGroupService = accessor.get(IEditorGroupsService);
 		const configurationService = accessor.get(IConfigurationService);
 
-		const commandContext = getCommandsContext(accessor, resourceOrContext, context);
-		splitEditor(editorGroupService, this.getDirection(configurationService), commandContext ? [commandContext] : undefined);
+		const direction = this.getDirection(configurationService);
+		const commandContext = resolveCommandsContext(accessor, args);
+
+		splitEditor(editorGroupService, direction, commandContext);
 	}
 }
 
@@ -1169,11 +1171,14 @@ export class ToggleMaximizeEditorGroupAction extends Action2 {
 		});
 	}
 
-	override async run(accessor: ServicesAccessor, resourceOrContext?: URI | IEditorCommandsContext, context?: IEditorCommandsContext): Promise<void> {
+	override async run(accessor: ServicesAccessor, ...args: unknown[]): Promise<void> {
 		const editorGroupsService = accessor.get(IEditorGroupsService);
 
-		const { group } = resolveCommandsContext(editorGroupsService, getCommandsContext(accessor, resourceOrContext, context));
-		editorGroupsService.toggleMaximizeGroup(group);
+		const resolvedContext = resolveCommandsContext(accessor, args);
+		const groupContext = resolvedContext.groupedEditors[0];
+		if (groupContext) {
+			editorGroupsService.toggleMaximizeGroup(groupContext.group);
+		}
 	}
 }
 
@@ -2538,17 +2543,20 @@ abstract class BaseMoveCopyEditorToNewWindowAction extends Action2 {
 		});
 	}
 
-	override async run(accessor: ServicesAccessor, resourceOrContext?: URI | IEditorCommandsContext, context?: IEditorCommandsContext) {
+	override async run(accessor: ServicesAccessor, ...args: unknown[]) {
 		const editorGroupService = accessor.get(IEditorGroupsService);
-		const editorsContext = resolveEditorsContext(getEditorsContext(accessor, resourceOrContext, context));
-		if (editorsContext.length === 0) {
+		const resolvedContext = resolveCommandsContext(accessor, args);
+		const groupContext = resolvedContext.groupedEditors[0];
+		if (!groupContext) {
 			return;
 		}
 
 		const auxiliaryEditorPart = await editorGroupService.createAuxiliaryEditorPart();
 
-		const sourceGroup = editorsContext[0].group; // only single group supported for move/copy for now
-		const sourceEditors = editorsContext.filter(({ group }) => group === sourceGroup);
+		const sourceGroup = groupContext.group; // only single group supported for move/copy for now
+		const options = { preserveFocus: resolvedContext.preserveFocus };
+		const sourceEditors = groupContext.editors.map(editor => ({ editor, options }));
+
 		if (this.move) {
 			sourceGroup.moveEditors(sourceEditors, auxiliaryEditorPart.activeGroup);
 		} else {

--- a/src/vs/workbench/browser/parts/editor/editorCommands.ts
+++ b/src/vs/workbench/browser/parts/editor/editorCommands.ts
@@ -3,13 +3,10 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { getActiveElement } from 'vs/base/browser/dom';
-import { List } from 'vs/base/browser/ui/list/listWidget';
-import { coalesce, distinct } from 'vs/base/common/arrays';
 import { IJSONSchema } from 'vs/base/common/jsonSchema';
 import { KeyChord, KeyCode, KeyMod } from 'vs/base/common/keyCodes';
 import { Schemas, matchesScheme } from 'vs/base/common/network';
-import { extname, isEqual } from 'vs/base/common/resources';
+import { extname } from 'vs/base/common/resources';
 import { isNumber, isObject, isString, isUndefined } from 'vs/base/common/types';
 import { URI, UriComponents } from 'vs/base/common/uri';
 import { isDiffEditor } from 'vs/editor/browser/editorBrowser';
@@ -23,7 +20,7 @@ import { ContextKeyExpr } from 'vs/platform/contextkey/common/contextkey';
 import { EditorResolution, IEditorOptions, IResourceEditorInput, ITextEditorOptions } from 'vs/platform/editor/common/editor';
 import { IInstantiationService, ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
 import { KeybindingWeight, KeybindingsRegistry } from 'vs/platform/keybinding/common/keybindingsRegistry';
-import { IListService, IOpenEvent } from 'vs/platform/list/browser/listService';
+import { IOpenEvent } from 'vs/platform/list/browser/listService';
 import { IOpenerService } from 'vs/platform/opener/common/opener';
 import { IQuickInputService } from 'vs/platform/quickinput/common/quickInput';
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
@@ -31,17 +28,18 @@ import { ActiveGroupEditorsByMostRecentlyUsedQuickAccess } from 'vs/workbench/br
 import { SideBySideEditor } from 'vs/workbench/browser/parts/editor/sideBySideEditor';
 import { TextDiffEditor } from 'vs/workbench/browser/parts/editor/textDiffEditor';
 import { ActiveEditorCanSplitInGroupContext, ActiveEditorGroupEmptyContext, ActiveEditorGroupLockedContext, ActiveEditorStickyContext, MultipleEditorGroupsContext, SideBySideEditorActiveContext, TextCompareEditorActiveContext } from 'vs/workbench/common/contextkeys';
-import { CloseDirection, EditorInputCapabilities, EditorsOrder, IEditorCommandsContext, IEditorIdentifier, IResourceDiffEditorInput, IUntitledTextResourceEditorInput, IVisibleEditorPane, isEditorCommandsContext, isEditorIdentifier, isEditorInputWithOptionsAndGroup } from 'vs/workbench/common/editor';
+import { CloseDirection, EditorInputCapabilities, EditorsOrder, IResourceDiffEditorInput, IUntitledTextResourceEditorInput, IVisibleEditorPane, isEditorInputWithOptionsAndGroup } from 'vs/workbench/common/editor';
 import { DiffEditorInput } from 'vs/workbench/common/editor/diffEditorInput';
 import { EditorInput } from 'vs/workbench/common/editor/editorInput';
 import { SideBySideEditorInput } from 'vs/workbench/common/editor/sideBySideEditorInput';
 import { EditorGroupColumn, columnToEditorGroup } from 'vs/workbench/services/editor/common/editorGroupColumn';
-import { EditorGroupLayout, GroupDirection, GroupLocation, GroupsOrder, IEditorGroup, IEditorGroupsService, IEditorReplacement, isEditorGroup, preferredSideBySideGroupDirection } from 'vs/workbench/services/editor/common/editorGroupsService';
+import { EditorGroupLayout, GroupDirection, GroupLocation, GroupsOrder, IEditorGroup, IEditorGroupsService, IEditorReplacement, preferredSideBySideGroupDirection } from 'vs/workbench/services/editor/common/editorGroupsService';
 import { IEditorResolverService } from 'vs/workbench/services/editor/common/editorResolverService';
 import { IEditorService, SIDE_GROUP } from 'vs/workbench/services/editor/common/editorService';
 import { IPathService } from 'vs/workbench/services/path/common/pathService';
 import { IUntitledTextEditorService } from 'vs/workbench/services/untitled/common/untitledTextEditorService';
 import { DIFF_FOCUS_OTHER_SIDE, DIFF_FOCUS_PRIMARY_SIDE, DIFF_FOCUS_SECONDARY_SIDE, DIFF_OPEN_SIDE, registerDiffEditorCommands } from './diffEditorCommands';
+import { IResolvedEditorCommandsContext, resolveCommandsContext } from 'vs/workbench/browser/parts/editor/editorCommandsContext';
 
 export const CLOSE_SAVED_EDITORS_COMMAND_ID = 'workbench.action.closeUnmodifiedEditors';
 export const CLOSE_EDITORS_IN_GROUP_COMMAND_ID = 'workbench.action.closeEditorsInGroup';
@@ -656,50 +654,26 @@ function registerFocusEditorGroupAtIndexCommands(): void {
 	}
 }
 
-export function splitEditor(editorGroupService: IEditorGroupsService, direction: GroupDirection, contexts?: IEditorCommandsContext[]): void {
-	let newGroup: IEditorGroup | undefined;
-	let sourceGroup: IEditorGroup | undefined;
+export function splitEditor(editorGroupService: IEditorGroupsService, direction: GroupDirection, resolvedContext: IResolvedEditorCommandsContext): void {
+	const groupContext = resolvedContext.groupedEditors[0];
+	if (!groupContext) {
+		return;
+	}
 
-	for (const context of contexts ?? [undefined]) {
-		let currentGroup: IEditorGroup | undefined;
+	// Only support splitting from one source group
+	const sourceGroup = groupContext.group;
+	const preserveFocus = resolvedContext.preserveFocus;
+	const newGroup = editorGroupService.addGroup(sourceGroup, direction);
 
-		if (context) {
-			currentGroup = editorGroupService.getGroup(context.groupId);
-		} else {
-			currentGroup = editorGroupService.activeGroup;
-		}
-
-		if (!currentGroup) {
-			continue;
-		}
-
-		if (!sourceGroup) {
-			sourceGroup = currentGroup;
-		} else if (sourceGroup.id !== currentGroup.id) {
-			continue; // Only support splitting from the same group
-		}
-
-		// Add group
-		if (!newGroup) {
-			newGroup = editorGroupService.addGroup(currentGroup, direction);
-		}
-
+	for (const editorToCopy of resolvedContext.groupedEditors[0].editors) {
 		// Split editor (if it can be split)
-		let editorToCopy: EditorInput | undefined;
-		if (context && typeof context.editorIndex === 'number') {
-			editorToCopy = currentGroup.getEditorByIndex(context.editorIndex);
-		} else {
-			editorToCopy = currentGroup.activeEditor ?? undefined;
-		}
-
-		// Copy the editor to the new group, else create an empty group
 		if (editorToCopy && !editorToCopy.hasCapability(EditorInputCapabilities.Singleton)) {
-			currentGroup.copyEditor(editorToCopy, newGroup, { preserveFocus: context?.preserveFocus });
+			sourceGroup.copyEditor(editorToCopy, newGroup, { preserveFocus });
 		}
 	}
 
 	// Focus
-	newGroup?.focus();
+	newGroup.focus();
 }
 
 function registerSplitEditorCommands() {
@@ -709,9 +683,9 @@ function registerSplitEditorCommands() {
 		{ id: SPLIT_EDITOR_LEFT, direction: GroupDirection.LEFT },
 		{ id: SPLIT_EDITOR_RIGHT, direction: GroupDirection.RIGHT }
 	].forEach(({ id, direction }) => {
-		CommandsRegistry.registerCommand(id, function (accessor, resourceOrContext?: URI | IEditorCommandsContext, context?: IEditorCommandsContext) {
-			const { editors } = getEditorsContext(accessor, resourceOrContext, context);
-			splitEditor(accessor.get(IEditorGroupsService), direction, editors);
+		CommandsRegistry.registerCommand(id, function (accessor, ...args) {
+			const resolvedContext = resolveCommandsContext(accessor, args);
+			splitEditor(accessor.get(IEditorGroupsService), direction, resolvedContext);
 		});
 	});
 }
@@ -721,14 +695,14 @@ function registerCloseEditorCommands() {
 	// A special handler for "Close Editor" depending on context
 	// - keybindining: do not close sticky editors, rather open the next non-sticky editor
 	// - menu: always close editor, even sticky ones
-	function closeEditorHandler(accessor: ServicesAccessor, forceCloseStickyEditors: boolean, resourceOrContext?: URI | IEditorCommandsContext, context?: IEditorCommandsContext): Promise<unknown> {
+	function closeEditorHandler(accessor: ServicesAccessor, forceCloseStickyEditors: boolean, ...args: unknown[]): Promise<unknown> {
 		const editorGroupsService = accessor.get(IEditorGroupsService);
 		const editorService = accessor.get(IEditorService);
 
 		let keepStickyEditors: boolean | undefined = undefined;
 		if (forceCloseStickyEditors) {
 			keepStickyEditors = false; // explicitly close sticky editors
-		} else if (resourceOrContext || context) {
+		} else if (args.length > 1) {
 			keepStickyEditors = false; // we have a context, as such this command was used e.g. from the tab context menu
 		} else {
 			keepStickyEditors = editorGroupsService.partOptions.preventPinnedEditorClose === 'keyboard' || editorGroupsService.partOptions.preventPinnedEditorClose === 'keyboardAndMouse'; // respect setting otherwise
@@ -756,17 +730,12 @@ function registerCloseEditorCommands() {
 		}
 
 		// With context: proceed to close editors as instructed
-		const { editors, groups } = getEditorsContext(accessor, resourceOrContext, context);
+		const resolvedContext = resolveCommandsContext(accessor, args);
+		const preserveFocus = resolvedContext.preserveFocus;
 
-		return Promise.all(groups.map(async group => {
-			if (group) {
-				const editorsToClose = coalesce(editors
-					.filter(editor => editor.groupId === group.id)
-					.map(editor => typeof editor.editorIndex === 'number' ? group.getEditorByIndex(editor.editorIndex) : group.activeEditor))
-					.filter(editor => !keepStickyEditors || !group.isSticky(editor));
-
-				await group.closeEditors(editorsToClose, { preserveFocus: context?.preserveFocus });
-			}
+		return Promise.all(resolvedContext.groupedEditors.map(async groupContext => {
+			const editorsToClose = groupContext.editors.filter(editor => !keepStickyEditors || !groupContext.group.isSticky(editor));
+			await groupContext.group.closeEditors(editorsToClose, { preserveFocus });
 		}));
 	}
 
@@ -776,13 +745,13 @@ function registerCloseEditorCommands() {
 		when: undefined,
 		primary: KeyMod.CtrlCmd | KeyCode.KeyW,
 		win: { primary: KeyMod.CtrlCmd | KeyCode.F4, secondary: [KeyMod.CtrlCmd | KeyCode.KeyW] },
-		handler: (accessor, resourceOrContext?: URI | IEditorCommandsContext, context?: IEditorCommandsContext) => {
-			return closeEditorHandler(accessor, false, resourceOrContext, context);
+		handler: (accessor, ...args: unknown[]) => {
+			return closeEditorHandler(accessor, false, args);
 		}
 	});
 
-	CommandsRegistry.registerCommand(CLOSE_PINNED_EDITOR_COMMAND_ID, (accessor, resourceOrContext?: URI | IEditorCommandsContext, context?: IEditorCommandsContext) => {
-		return closeEditorHandler(accessor, true /* force close pinned editors */, resourceOrContext, context);
+	CommandsRegistry.registerCommand(CLOSE_PINNED_EDITOR_COMMAND_ID, (accessor, ...args: unknown[]) => {
+		return closeEditorHandler(accessor, true /* force close pinned editors */, args);
 	});
 
 	KeybindingsRegistry.registerCommandAndKeybindingRule({
@@ -790,12 +759,10 @@ function registerCloseEditorCommands() {
 		weight: KeybindingWeight.WorkbenchContrib,
 		when: undefined,
 		primary: KeyChord(KeyMod.CtrlCmd | KeyCode.KeyK, KeyCode.KeyW),
-		handler: (accessor, resourceOrContext?: URI | IEditorCommandsContext, context?: IEditorCommandsContext) => {
-			return Promise.all(getEditorsContext(accessor, resourceOrContext, context).groups.map(async group => {
-				if (group) {
-					await group.closeAllEditors({ excludeSticky: true });
-					return;
-				}
+		handler: (accessor, ...args: unknown[]) => {
+			const resolvedContext = resolveCommandsContext(accessor, args);
+			return Promise.all(resolvedContext.groupedEditors.map(async groupContext => {
+				await groupContext.group.closeAllEditors({ excludeSticky: true });
 			}));
 		}
 	});
@@ -806,19 +773,12 @@ function registerCloseEditorCommands() {
 		when: ContextKeyExpr.and(ActiveEditorGroupEmptyContext, MultipleEditorGroupsContext),
 		primary: KeyMod.CtrlCmd | KeyCode.KeyW,
 		win: { primary: KeyMod.CtrlCmd | KeyCode.F4, secondary: [KeyMod.CtrlCmd | KeyCode.KeyW] },
-		handler: (accessor, resourceOrContext?: URI | IEditorCommandsContext, context?: IEditorCommandsContext) => {
+		handler: (accessor, ...args: unknown[]) => {
 			const editorGroupService = accessor.get(IEditorGroupsService);
-			const commandsContext = getCommandsContext(accessor, resourceOrContext, context);
+			const commandsContext = resolveCommandsContext(accessor, args);
 
-			let group: IEditorGroup | undefined;
-			if (commandsContext && typeof commandsContext.groupId === 'number') {
-				group = editorGroupService.getGroup(commandsContext.groupId);
-			} else {
-				group = editorGroupService.activeGroup;
-			}
-
-			if (group) {
-				editorGroupService.removeGroup(group);
+			if (commandsContext.groupedEditors.length) {
+				editorGroupService.removeGroup(commandsContext.groupedEditors[0].group);
 			}
 		}
 	});
@@ -828,11 +788,10 @@ function registerCloseEditorCommands() {
 		weight: KeybindingWeight.WorkbenchContrib,
 		when: undefined,
 		primary: KeyChord(KeyMod.CtrlCmd | KeyCode.KeyK, KeyCode.KeyU),
-		handler: (accessor, resourceOrContext?: URI | IEditorCommandsContext, context?: IEditorCommandsContext) => {
-			return Promise.all(getEditorsContext(accessor, resourceOrContext, context).groups.map(async group => {
-				if (group) {
-					await group.closeEditors({ savedOnly: true, excludeSticky: true }, { preserveFocus: context?.preserveFocus });
-				}
+		handler: (accessor, ...args: unknown[]) => {
+			const resolvedContext = resolveCommandsContext(accessor, args);
+			return Promise.all(resolvedContext.groupedEditors.map(async groupContext => {
+				await groupContext.group.closeEditors({ savedOnly: true, excludeSticky: true }, { preserveFocus: resolvedContext.preserveFocus });
 			}));
 		}
 	});
@@ -843,24 +802,19 @@ function registerCloseEditorCommands() {
 		when: undefined,
 		primary: undefined,
 		mac: { primary: KeyMod.CtrlCmd | KeyMod.Alt | KeyCode.KeyT },
-		handler: (accessor, resourceOrContext?: URI | IEditorCommandsContext, context?: IEditorCommandsContext) => {
-			const { editors, groups } = getEditorsContext(accessor, resourceOrContext, context);
-			return Promise.all(groups.map(async group => {
-				if (group) {
-					const editorsToKeep = editors
-						.filter(editor => editor.groupId === group.id)
-						.map(editor => typeof editor.editorIndex === 'number' ? group.getEditorByIndex(editor.editorIndex) : group.activeEditor);
+		handler: (accessor, ...args: unknown[]) => {
+			const resolvedContext = resolveCommandsContext(accessor, args);
 
-					const editorsToClose = group.getEditors(EditorsOrder.SEQUENTIAL, { excludeSticky: true }).filter(editor => !editorsToKeep.includes(editor));
+			return Promise.all(resolvedContext.groupedEditors.map(async groupContext => {
+				const editorsToClose = groupContext.group.getEditors(EditorsOrder.SEQUENTIAL, { excludeSticky: true }).filter(editor => !groupContext.editors.includes(editor));
 
-					for (const editorToKeep of editorsToKeep) {
-						if (editorToKeep) {
-							group.pinEditor(editorToKeep);
-						}
+				for (const editorToKeep of groupContext.editors) {
+					if (editorToKeep) {
+						groupContext.group.pinEditor(editorToKeep);
 					}
-
-					await group.closeEditors(editorsToClose, { preserveFocus: context?.preserveFocus });
 				}
+
+				await groupContext.group.closeEditors(editorsToClose, { preserveFocus: resolvedContext.preserveFocus });
 			}));
 		}
 	});
@@ -870,16 +824,15 @@ function registerCloseEditorCommands() {
 		weight: KeybindingWeight.WorkbenchContrib,
 		when: undefined,
 		primary: undefined,
-		handler: async (accessor, resourceOrContext?: URI | IEditorCommandsContext, context?: IEditorCommandsContext) => {
-			const editorGroupService = accessor.get(IEditorGroupsService);
-
-			const { group, editor } = resolveCommandsContext(editorGroupService, getCommandsContext(accessor, resourceOrContext, context));
-			if (group && editor) {
-				if (group.activeEditor) {
-					group.pinEditor(group.activeEditor);
+		handler: async (accessor, ...args: unknown[]) => {
+			const resolvedContext = resolveCommandsContext(accessor, args);
+			if (resolvedContext.groupedEditors.length) {
+				const groupContext = resolvedContext.groupedEditors[0];
+				if (groupContext.group.activeEditor) {
+					groupContext.group.pinEditor(groupContext.group.activeEditor);
 				}
 
-				await group.closeEditors({ direction: CloseDirection.RIGHT, except: editor, excludeSticky: true }, { preserveFocus: context?.preserveFocus });
+				await groupContext.group.closeEditors({ direction: CloseDirection.RIGHT, except: groupContext.editors[0], excludeSticky: true }, { preserveFocus: resolvedContext.preserveFocus });
 			}
 		}
 	});
@@ -889,62 +842,66 @@ function registerCloseEditorCommands() {
 		weight: KeybindingWeight.WorkbenchContrib,
 		when: undefined,
 		primary: undefined,
-		handler: async (accessor, resourceOrContext?: URI | IEditorCommandsContext, context?: IEditorCommandsContext) => {
+		handler: async (accessor, ...args: unknown[]) => {
 			const editorService = accessor.get(IEditorService);
 			const editorResolverService = accessor.get(IEditorResolverService);
 			const telemetryService = accessor.get(ITelemetryService);
 
-			const editorsAndGroup = resolveEditorsContext(getEditorsContext(accessor, resourceOrContext, context));
+			const resolvedContext = resolveCommandsContext(accessor, args);
 			const editorReplacements = new Map<IEditorGroup, IEditorReplacement[]>();
 
-			for (const { editor, group } of editorsAndGroup) {
-				const untypedEditor = editor.toUntyped();
-				if (!untypedEditor) {
-					return; // Resolver can only resolve untyped editors
+			for (const groupContext of resolvedContext.groupedEditors) {
+				const group = groupContext.group;
+
+				for (const editor of groupContext.editors) {
+					const untypedEditor = editor.toUntyped();
+					if (!untypedEditor) {
+						return; // Resolver can only resolve untyped editors
+					}
+
+					untypedEditor.options = { ...editorService.activeEditorPane?.options, override: EditorResolution.PICK };
+					const resolvedEditor = await editorResolverService.resolveEditor(untypedEditor, group);
+					if (!isEditorInputWithOptionsAndGroup(resolvedEditor)) {
+						return;
+					}
+
+					let editorReplacementsInGroup = editorReplacements.get(group);
+					if (!editorReplacementsInGroup) {
+						editorReplacementsInGroup = [];
+						editorReplacements.set(group, editorReplacementsInGroup);
+					}
+
+					editorReplacementsInGroup.push({
+						editor: editor,
+						replacement: resolvedEditor.editor,
+						forceReplaceDirty: editor.resource?.scheme === Schemas.untitled,
+						options: resolvedEditor.options
+					});
+
+					// Telemetry
+					type WorkbenchEditorReopenClassification = {
+						owner: 'rebornix';
+						comment: 'Identify how a document is reopened';
+						scheme: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'File system provider scheme for the resource' };
+						ext: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'File extension for the resource' };
+						from: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The editor view type the resource is switched from' };
+						to: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The editor view type the resource is switched to' };
+					};
+
+					type WorkbenchEditorReopenEvent = {
+						scheme: string;
+						ext: string;
+						from: string;
+						to: string;
+					};
+
+					telemetryService.publicLog2<WorkbenchEditorReopenEvent, WorkbenchEditorReopenClassification>('workbenchEditorReopen', {
+						scheme: editor.resource?.scheme ?? '',
+						ext: editor.resource ? extname(editor.resource) : '',
+						from: editor.editorId ?? '',
+						to: resolvedEditor.editor.editorId ?? ''
+					});
 				}
-
-				untypedEditor.options = { ...editorService.activeEditorPane?.options, override: EditorResolution.PICK };
-				const resolvedEditor = await editorResolverService.resolveEditor(untypedEditor, group);
-				if (!isEditorInputWithOptionsAndGroup(resolvedEditor)) {
-					return;
-				}
-
-				let editorReplacementsInGroup = editorReplacements.get(group);
-				if (!editorReplacementsInGroup) {
-					editorReplacementsInGroup = [];
-					editorReplacements.set(group, editorReplacementsInGroup);
-				}
-
-				editorReplacementsInGroup.push({
-					editor: editor,
-					replacement: resolvedEditor.editor,
-					forceReplaceDirty: editor.resource?.scheme === Schemas.untitled,
-					options: resolvedEditor.options
-				});
-
-				// Telemetry
-				type WorkbenchEditorReopenClassification = {
-					owner: 'rebornix';
-					comment: 'Identify how a document is reopened';
-					scheme: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'File system provider scheme for the resource' };
-					ext: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'File extension for the resource' };
-					from: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The editor view type the resource is switched from' };
-					to: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The editor view type the resource is switched to' };
-				};
-
-				type WorkbenchEditorReopenEvent = {
-					scheme: string;
-					ext: string;
-					from: string;
-					to: string;
-				};
-
-				telemetryService.publicLog2<WorkbenchEditorReopenEvent, WorkbenchEditorReopenClassification>('workbenchEditorReopen', {
-					scheme: editor.resource?.scheme ?? '',
-					ext: editor.resource ? extname(editor.resource) : '',
-					from: editor.editorId ?? '',
-					to: resolvedEditor.editor.editorId ?? ''
-				});
 			}
 
 			// Replace editor with resolved one and make active
@@ -955,15 +912,16 @@ function registerCloseEditorCommands() {
 		}
 	});
 
-	CommandsRegistry.registerCommand(CLOSE_EDITORS_AND_GROUP_COMMAND_ID, async (accessor: ServicesAccessor, resourceOrContext?: URI | IEditorCommandsContext, context?: IEditorCommandsContext) => {
+	CommandsRegistry.registerCommand(CLOSE_EDITORS_AND_GROUP_COMMAND_ID, async (accessor: ServicesAccessor, ...args: unknown[]) => {
 		const editorGroupService = accessor.get(IEditorGroupsService);
 
-		const { group } = resolveCommandsContext(editorGroupService, getCommandsContext(accessor, resourceOrContext, context));
-		if (group) {
-			await group.closeAllEditors();
+		const resolvedContext = resolveCommandsContext(accessor, args);
+		const groupContext = resolvedContext.groupedEditors[0];
+		if (groupContext) {
+			await groupContext.group.closeAllEditors();
 
-			if (group.count === 0 && editorGroupService.getGroup(group.id) /* could be gone by now */) {
-				editorGroupService.removeGroup(group); // only remove group if it is now empty
+			if (groupContext.group.count === 0 && editorGroupService.getGroup(groupContext.group.id) /* could be gone by now */) {
+				editorGroupService.removeGroup(groupContext.group); // only remove group if it is now empty
 			}
 		}
 	});
@@ -1002,16 +960,20 @@ function registerFocusEditorGroupWihoutWrapCommands(): void {
 
 function registerSplitEditorInGroupCommands(): void {
 
-	async function splitEditorInGroup(accessor: ServicesAccessor, resourceOrContext?: URI | IEditorCommandsContext, context?: IEditorCommandsContext): Promise<void> {
-		const editorGroupService = accessor.get(IEditorGroupsService);
+	async function splitEditorInGroup(accessor: ServicesAccessor, resolvedContext: IResolvedEditorCommandsContext): Promise<void> {
 		const instantiationService = accessor.get(IInstantiationService);
 
-		const { group, editor } = resolveCommandsContext(editorGroupService, getCommandsContext(accessor, resourceOrContext, context));
+		const groupContext = resolvedContext.groupedEditors[0];
+		if (!groupContext) {
+			return;
+		}
+
+		const editor = groupContext.editors[0];
 		if (!editor) {
 			return;
 		}
 
-		await group.replaceEditors([{
+		await groupContext.group.replaceEditors([{
 			editor,
 			replacement: instantiationService.createInstance(SideBySideEditorInput, undefined, undefined, editor, editor),
 			forceReplaceDirty: true
@@ -1033,15 +995,23 @@ function registerSplitEditorInGroupCommands(): void {
 				}
 			});
 		}
-		run(accessor: ServicesAccessor, resourceOrContext?: URI | IEditorCommandsContext, context?: IEditorCommandsContext): Promise<void> {
-			return splitEditorInGroup(accessor, resourceOrContext, context);
+		run(accessor: ServicesAccessor, ...args: unknown[]): Promise<void> {
+			return splitEditorInGroup(accessor, resolveCommandsContext(accessor, args));
 		}
 	});
 
-	async function joinEditorInGroup(accessor: ServicesAccessor, resourceOrContext?: URI | IEditorCommandsContext, context?: IEditorCommandsContext): Promise<void> {
-		const editorGroupService = accessor.get(IEditorGroupsService);
+	async function joinEditorInGroup(resolvedContext: IResolvedEditorCommandsContext): Promise<void> {
+		const groupContext = resolvedContext.groupedEditors[0];
+		if (!groupContext) {
+			return;
+		}
 
-		const { group, editor } = resolveCommandsContext(editorGroupService, getCommandsContext(accessor, resourceOrContext, context));
+		const group = groupContext.group;
+		const editor = groupContext.editors[0];
+		if (!editor) {
+			return;
+		}
+
 		if (!(editor instanceof SideBySideEditorInput)) {
 			return;
 		}
@@ -1079,8 +1049,8 @@ function registerSplitEditorInGroupCommands(): void {
 				}
 			});
 		}
-		run(accessor: ServicesAccessor, resourceOrContext?: URI | IEditorCommandsContext, context?: IEditorCommandsContext): Promise<void> {
-			return joinEditorInGroup(accessor, resourceOrContext, context);
+		run(accessor: ServicesAccessor, ...args: unknown[]): Promise<void> {
+			return joinEditorInGroup(resolveCommandsContext(accessor, args));
 		}
 	});
 
@@ -1094,14 +1064,22 @@ function registerSplitEditorInGroupCommands(): void {
 				f1: true
 			});
 		}
-		async run(accessor: ServicesAccessor, resourceOrContext?: URI | IEditorCommandsContext, context?: IEditorCommandsContext): Promise<void> {
-			const editorGroupService = accessor.get(IEditorGroupsService);
+		async run(accessor: ServicesAccessor, ...args: unknown[]): Promise<void> {
+			const resolvedContext = resolveCommandsContext(accessor, args);
+			const groupContext = resolvedContext.groupedEditors[0];
+			if (!groupContext) {
+				return;
+			}
 
-			const { editor } = resolveCommandsContext(editorGroupService, getCommandsContext(accessor, resourceOrContext, context));
+			const editor = groupContext.editors[0];
+			if (!editor) {
+				return;
+			}
+
 			if (editor instanceof SideBySideEditorInput) {
-				await joinEditorInGroup(accessor, resourceOrContext, context);
+				await joinEditorInGroup(resolvedContext);
 			} else if (editor) {
-				await splitEditorInGroup(accessor, resourceOrContext, context);
+				await splitEditorInGroup(accessor, resolvedContext);
 			}
 		}
 	});
@@ -1215,12 +1193,12 @@ function registerOtherEditorCommands(): void {
 		weight: KeybindingWeight.WorkbenchContrib,
 		when: undefined,
 		primary: KeyChord(KeyMod.CtrlCmd | KeyCode.KeyK, KeyCode.Enter),
-		handler: async (accessor, resourceOrContext?: URI | IEditorCommandsContext, context?: IEditorCommandsContext) => {
-			const editorGroupService = accessor.get(IEditorGroupsService);
-
-			const { group, editor } = resolveCommandsContext(editorGroupService, getCommandsContext(accessor, resourceOrContext, context));
-			if (group && editor) {
-				return group.pinEditor(editor);
+		handler: async (accessor, ...args: unknown[]) => {
+			const resolvedContext = resolveCommandsContext(accessor, args);
+			for (const groupContext of resolvedContext.groupedEditors) {
+				for (const editor of groupContext.editors) {
+					groupContext.group.pinEditor(editor);
+				}
 			}
 		}
 	});
@@ -1236,10 +1214,9 @@ function registerOtherEditorCommands(): void {
 		}
 	});
 
-	function setEditorGroupLock(accessor: ServicesAccessor, resourceOrContext?: URI | IEditorCommandsContext, context?: IEditorCommandsContext, locked?: boolean): void {
-		const editorGroupService = accessor.get(IEditorGroupsService);
-
-		const { group } = resolveCommandsContext(editorGroupService, getCommandsContext(accessor, resourceOrContext, context));
+	function setEditorGroupLock(accessor: ServicesAccessor, locked: boolean | undefined, ...args: unknown[]): void {
+		const resolvedContext = resolveCommandsContext(accessor, args);
+		const group = resolvedContext.groupedEditors[0]?.group;
 		group?.lock(locked ?? !group.isLocked);
 	}
 
@@ -1252,8 +1229,8 @@ function registerOtherEditorCommands(): void {
 				f1: true
 			});
 		}
-		async run(accessor: ServicesAccessor, resourceOrContext?: URI | IEditorCommandsContext, context?: IEditorCommandsContext): Promise<void> {
-			setEditorGroupLock(accessor, resourceOrContext, context);
+		async run(accessor: ServicesAccessor, ...args: unknown[]): Promise<void> {
+			setEditorGroupLock(accessor, undefined, ...args);
 		}
 	});
 
@@ -1267,8 +1244,8 @@ function registerOtherEditorCommands(): void {
 				f1: true
 			});
 		}
-		async run(accessor: ServicesAccessor, resourceOrContext?: URI | IEditorCommandsContext, context?: IEditorCommandsContext): Promise<void> {
-			setEditorGroupLock(accessor, resourceOrContext, context, true);
+		async run(accessor: ServicesAccessor, ...args: unknown[]): Promise<void> {
+			setEditorGroupLock(accessor, true, args);
 		}
 	});
 
@@ -1282,8 +1259,8 @@ function registerOtherEditorCommands(): void {
 				f1: true
 			});
 		}
-		async run(accessor: ServicesAccessor, resourceOrContext?: URI | IEditorCommandsContext, context?: IEditorCommandsContext): Promise<void> {
-			setEditorGroupLock(accessor, resourceOrContext, context, false);
+		async run(accessor: ServicesAccessor, ...args: unknown[]): Promise<void> {
+			setEditorGroupLock(accessor, false, args);
 		}
 	});
 
@@ -1292,9 +1269,12 @@ function registerOtherEditorCommands(): void {
 		weight: KeybindingWeight.WorkbenchContrib,
 		when: ActiveEditorStickyContext.toNegated(),
 		primary: KeyChord(KeyMod.CtrlCmd | KeyCode.KeyK, KeyMod.Shift | KeyCode.Enter),
-		handler: async (accessor, resourceOrContext?: URI | IEditorCommandsContext, context?: IEditorCommandsContext) => {
-			for (const { editor, group } of resolveEditorsContext(getEditorsContext(accessor, resourceOrContext, context))) {
-				group.stickEditor(editor);
+		handler: async (accessor, ...args: unknown[]) => {
+			const resolvedContext = resolveCommandsContext(accessor, args);
+			for (const groupContext of resolvedContext.groupedEditors) {
+				for (const editor of groupContext.editors) {
+					groupContext.group.stickEditor(editor);
+				}
 			}
 		}
 	});
@@ -1331,9 +1311,12 @@ function registerOtherEditorCommands(): void {
 		weight: KeybindingWeight.WorkbenchContrib,
 		when: ActiveEditorStickyContext,
 		primary: KeyChord(KeyMod.CtrlCmd | KeyCode.KeyK, KeyMod.Shift | KeyCode.Enter),
-		handler: async (accessor, resourceOrContext?: URI | IEditorCommandsContext, context?: IEditorCommandsContext) => {
-			for (const { editor, group } of resolveEditorsContext(getEditorsContext(accessor, resourceOrContext, context))) {
-				group.unstickEditor(editor);
+		handler: async (accessor, ...args: unknown[]) => {
+			const resolvedContext = resolveCommandsContext(accessor, args);
+			for (const groupContext of resolvedContext.groupedEditors) {
+				for (const editor of groupContext.editors) {
+					groupContext.group.unstickEditor(editor);
+				}
 			}
 		}
 	});
@@ -1343,145 +1326,19 @@ function registerOtherEditorCommands(): void {
 		weight: KeybindingWeight.WorkbenchContrib,
 		when: undefined,
 		primary: undefined,
-		handler: (accessor, resourceOrContext?: URI | IEditorCommandsContext, context?: IEditorCommandsContext) => {
+		handler: (accessor, ...args: unknown[]) => {
 			const editorGroupService = accessor.get(IEditorGroupsService);
 			const quickInputService = accessor.get(IQuickInputService);
 
-			const commandsContext = getCommandsContext(accessor, resourceOrContext, context);
-			if (commandsContext && typeof commandsContext.groupId === 'number') {
-				const group = editorGroupService.getGroup(commandsContext.groupId);
-				if (group) {
-					editorGroupService.activateGroup(group); // we need the group to be active
-				}
+			const commandsContext = resolveCommandsContext(accessor, args);
+			const group = commandsContext.groupedEditors[0]?.group;
+			if (group) {
+				editorGroupService.activateGroup(group); // we need the group to be active
 			}
 
 			return quickInputService.quickAccess.show(ActiveGroupEditorsByMostRecentlyUsedQuickAccess.PREFIX);
 		}
 	});
-}
-
-type EditorsContext = { editors: IEditorCommandsContext[]; groups: Array<IEditorGroup | undefined> };
-export function getEditorsContext(accessor: ServicesAccessor, resourceOrContext?: URI | IEditorCommandsContext, context?: IEditorCommandsContext): EditorsContext {
-	const editorGroupService = accessor.get(IEditorGroupsService);
-	const listService = accessor.get(IListService);
-
-	const editorContext = getMultiSelectedEditorContexts(getCommandsContext(accessor, resourceOrContext, context), listService, editorGroupService);
-
-	const activeGroup = editorGroupService.activeGroup;
-	if (editorContext.length === 0 && activeGroup.activeEditor) {
-		// add the active editor as fallback
-		editorContext.push({
-			groupId: activeGroup.id,
-			editorIndex: activeGroup.getIndexOfEditor(activeGroup.activeEditor)
-		});
-	}
-
-	return {
-		editors: editorContext,
-		groups: distinct(editorContext.map(context => context.groupId)).map(groupId => editorGroupService.getGroup(groupId))
-	};
-}
-
-export function resolveEditorsContext(context: EditorsContext): { editor: EditorInput; group: IEditorGroup }[] {
-	const { editors, groups } = context;
-
-	const editorsAndGroup = editors.map(e => {
-		if (e.editorIndex === undefined) {
-			return undefined;
-		}
-		const group = groups.find(group => group && group.id === e.groupId);
-		const editor = group?.getEditorByIndex(e.editorIndex);
-		if (!editor || !group) {
-			return undefined;
-		}
-		return { editor, group };
-	});
-
-	return coalesce(editorsAndGroup);
-}
-
-export function getCommandsContext(accessor: ServicesAccessor, resourceOrContext?: URI | IEditorCommandsContext, context?: IEditorCommandsContext): IEditorCommandsContext | undefined {
-	const isUri = URI.isUri(resourceOrContext);
-
-	const editorCommandsContext = isUri ? context : resourceOrContext ? resourceOrContext : context;
-	if (editorCommandsContext && isEditorCommandsContext(editorCommandsContext)) {
-		return editorCommandsContext;
-	}
-
-	if (isUri) {
-		const editorGroupService = accessor.get(IEditorGroupsService);
-		const editorGroup = editorGroupService.getGroups(GroupsOrder.MOST_RECENTLY_ACTIVE).find(group => isEqual(group.activeEditor?.resource, resourceOrContext));
-		if (editorGroup) {
-			return { groupId: editorGroup.index, editorIndex: editorGroup.getIndexOfEditor(editorGroup.activeEditor!) };
-		}
-	}
-
-	return undefined;
-}
-
-export function resolveCommandsContext(editorGroupService: IEditorGroupsService, context?: IEditorCommandsContext): { group: IEditorGroup; editor?: EditorInput } {
-
-	// Resolve from context
-	let group = context && typeof context.groupId === 'number' ? editorGroupService.getGroup(context.groupId) : undefined;
-	let editor = group && context && typeof context.editorIndex === 'number' ? group.getEditorByIndex(context.editorIndex) ?? undefined : undefined;
-
-	// Fallback to active group as needed
-	if (!group) {
-		group = editorGroupService.activeGroup;
-	}
-
-	// Fallback to active editor as needed
-	if (!editor) {
-		editor = group.activeEditor ?? undefined;
-	}
-
-	return { group, editor };
-}
-
-export function getMultiSelectedEditorContexts(editorContext: IEditorCommandsContext | undefined, listService: IListService, editorGroupService: IEditorGroupsService): IEditorCommandsContext[] {
-
-	// First check for a focused list to return the selected items from
-	const list = listService.lastFocusedList;
-	if (list instanceof List && list.getHTMLElement() === getActiveElement()) {
-		const elementToContext = (element: IEditorIdentifier | IEditorGroup) => {
-			if (isEditorGroup(element)) {
-				return { groupId: element.id, editorIndex: undefined };
-			}
-
-			const group = editorGroupService.getGroup(element.groupId);
-
-			return { groupId: element.groupId, editorIndex: group ? group.getIndexOfEditor(element.editor) : -1 };
-		};
-
-		const onlyEditorGroupAndEditor = (e: IEditorIdentifier | IEditorGroup) => isEditorGroup(e) || isEditorIdentifier(e);
-
-		const focusedElements: Array<IEditorIdentifier | IEditorGroup> = list.getFocusedElements().filter(onlyEditorGroupAndEditor);
-		const focus = editorContext ? editorContext : focusedElements.length ? focusedElements.map(elementToContext)[0] : undefined; // need to take into account when editor context is { group: group }
-
-		if (focus) {
-			const selection: Array<IEditorIdentifier | IEditorGroup> = list.getSelectedElements().filter(onlyEditorGroupAndEditor);
-
-			if (selection.length > 1) {
-				return selection.map(elementToContext);
-			}
-
-			return [focus];
-		}
-	}
-	// Check editors selected in the group (tabs)
-	else {
-		const group = editorContext ? editorGroupService.getGroup(editorContext.groupId) : editorGroupService.activeGroup;
-		const editor = editorContext && editorContext.editorIndex !== undefined ? group?.getEditorByIndex(editorContext.editorIndex) : group?.activeEditor;
-		// If the editor is selected, return all selected editors otherwise only use the editors context
-		if (group && editor) {
-			if (group.isSelected(editor)) {
-				return group.selectedEditors.map(se => ({ groupId: group.id, editorIndex: group.getIndexOfEditor(se) }));
-			}
-		}
-	}
-
-	// Otherwise go with passed in context
-	return !!editorContext ? [editorContext] : [];
 }
 
 export function setup(): void {

--- a/src/vs/workbench/browser/parts/editor/editorCommandsContext.ts
+++ b/src/vs/workbench/browser/parts/editor/editorCommandsContext.ts
@@ -85,19 +85,23 @@ function getCommandsContext(accessor: ServicesAccessor, commandArgs: unknown[]):
 }
 
 function moveCurrentEditorContextToFront(editorContext: IEditorCommandsContext, multiEditorContext: IEditorCommandsContext[]): IEditorCommandsContext[] {
+	if (multiEditorContext.length <= 1) {
+		return multiEditorContext;
+	}
+
 	const editorContextIndex = multiEditorContext.findIndex(context =>
 		context.groupId === editorContext.groupId &&
-		context.editorIndex === editorContext.editorIndex &&
-		context.preserveFocus === editorContext.preserveFocus
+		(editorContext.editorIndex === undefined || context.editorIndex === editorContext.editorIndex) &&
+		(editorContext.preserveFocus === undefined || context.preserveFocus === editorContext.preserveFocus)
 	);
 
-	if (editorContextIndex !== -1) {
-		multiEditorContext.splice(editorContextIndex, 1);
-	} else {
+	if (editorContextIndex === -1) {
 		throw new Error('Invalid multi select editor context');
 	}
 
-	multiEditorContext.unshift(editorContext);
+	const currentContext = multiEditorContext[editorContextIndex];
+	multiEditorContext.splice(editorContextIndex, 1);
+	multiEditorContext.unshift(currentContext);
 
 	return multiEditorContext;
 }

--- a/src/vs/workbench/browser/parts/editor/editorCommandsContext.ts
+++ b/src/vs/workbench/browser/parts/editor/editorCommandsContext.ts
@@ -91,17 +91,17 @@ function moveCurrentEditorContextToFront(editorContext: IEditorCommandsContext, 
 
 	const editorContextIndex = multiEditorContext.findIndex(context =>
 		context.groupId === editorContext.groupId &&
-		(editorContext.editorIndex === undefined || context.editorIndex === editorContext.editorIndex) &&
-		(editorContext.preserveFocus === undefined || context.preserveFocus === editorContext.preserveFocus)
+		context.editorIndex === editorContext.editorIndex
 	);
 
-	if (editorContextIndex === -1) {
-		throw new Error('Invalid multi select editor context');
+	if (editorContextIndex !== -1) {
+		multiEditorContext.splice(editorContextIndex, 1);
+		multiEditorContext.unshift(editorContext);
+	} else if (editorContext.editorIndex === undefined) {
+		multiEditorContext.unshift(editorContext);
+	} else {
+		throw new Error('Editor context not found in multi editor context');
 	}
-
-	const currentContext = multiEditorContext[editorContextIndex];
-	multiEditorContext.splice(editorContextIndex, 1);
-	multiEditorContext.unshift(currentContext);
 
 	return multiEditorContext;
 }

--- a/src/vs/workbench/browser/parts/editor/editorCommandsContext.ts
+++ b/src/vs/workbench/browser/parts/editor/editorCommandsContext.ts
@@ -14,11 +14,11 @@ import { IEditorGroup, IEditorGroupsService, isEditorGroup } from 'vs/workbench/
 import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
 
 export interface IResolvedEditorCommandsContext {
-	groupedEditors: {
-		group: IEditorGroup;
-		editors: EditorInput[];
+	readonly groupedEditors: {
+		readonly group: IEditorGroup;
+		readonly editors: EditorInput[];
 	}[];
-	preserveFocus: boolean;
+	readonly preserveFocus: boolean;
 }
 
 export function resolveCommandsContext(accessor: ServicesAccessor, commandArgs: unknown[]): IResolvedEditorCommandsContext {
@@ -133,7 +133,7 @@ function getEditorContextFromCommandArgs(accessor: ServicesAccessor, commandArgs
 	// If there is no context in the arguments, try to find the context from the focused list
 	// if the action was executed from a list
 	if (isListAcion) {
-		const list = listService.lastFocusedList as List<any>;
+		const list = listService.lastFocusedList as List<unknown>;
 		for (const focusedElement of list.getFocusedElements()) {
 			if (isGroupOrEditor(focusedElement)) {
 				return groupOrEditorToEditorContext(focusedElement, undefined, editorGroupsService);
@@ -150,7 +150,7 @@ function getMultiSelectContext(accessor: ServicesAccessor, editorContext: IEdito
 
 	// If the action was executed from a list, return all selected editors
 	if (isListAction) {
-		const list = listService.lastFocusedList as List<any>;
+		const list = listService.lastFocusedList as List<unknown>;
 		const selection = list.getSelectedElements().filter(isGroupOrEditor);
 
 		if (selection.length > 1) {
@@ -181,7 +181,7 @@ function groupOrEditorToEditorContext(element: IEditorIdentifier | IEditorGroup,
 	return { groupId: element.groupId, editorIndex: group ? group.getIndexOfEditor(element.editor) : -1, preserveFocus };
 }
 
-function isGroupOrEditor(element: any): element is IEditorIdentifier | IEditorGroup {
+function isGroupOrEditor(element: unknown): element is IEditorIdentifier | IEditorGroup {
 	return isEditorGroup(element) || isEditorIdentifier(element);
 }
 

--- a/src/vs/workbench/browser/parts/editor/editorCommandsContext.ts
+++ b/src/vs/workbench/browser/parts/editor/editorCommandsContext.ts
@@ -1,0 +1,196 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { getActiveElement } from 'vs/base/browser/dom';
+import { List } from 'vs/base/browser/ui/list/listWidget';
+import { URI } from 'vs/base/common/uri';
+import { ServicesAccessor } from 'vs/editor/browser/editorExtensions';
+import { IListService } from 'vs/platform/list/browser/listService';
+import { IEditorCommandsContext, isEditorCommandsContext, IEditorIdentifier, isEditorIdentifier } from 'vs/workbench/common/editor';
+import { EditorInput } from 'vs/workbench/common/editor/editorInput';
+import { IEditorGroup, IEditorGroupsService, isEditorGroup } from 'vs/workbench/services/editor/common/editorGroupsService';
+import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
+
+export interface IResolvedEditorCommandsContext {
+	groupedEditors: {
+		group: IEditorGroup;
+		editors: EditorInput[];
+	}[];
+	preserveFocus: boolean;
+}
+
+export function resolveCommandsContext(accessor: ServicesAccessor, commandArgs: unknown[]): IResolvedEditorCommandsContext {
+	const editorGroupsService = accessor.get(IEditorGroupsService);
+
+	const commandContext = getCommandsContext(accessor, commandArgs);
+	const preserveFocus = commandContext.length ? commandContext[0].preserveFocus || false : false;
+	const resolvedContext: IResolvedEditorCommandsContext = { groupedEditors: [], preserveFocus };
+
+	for (const editorContext of commandContext) {
+		const groupAndEditor = getEditorAndGroupFromContext(editorContext, editorGroupsService);
+		if (!groupAndEditor) {
+			continue;
+		}
+
+		const { group, editor } = groupAndEditor;
+
+		// Find group context if already added
+		let groupContext = undefined;
+		for (const targetGroupContext of resolvedContext.groupedEditors) {
+			if (targetGroupContext.group.id === group.id) {
+				groupContext = targetGroupContext;
+				break;
+			}
+		}
+
+		// Otherwise add new group context
+		if (!groupContext) {
+			groupContext = { group, editors: [] };
+			resolvedContext.groupedEditors.push(groupContext);
+		}
+
+		// Add editor to group context
+		if (editor) {
+			groupContext.editors.push(editor);
+		}
+	}
+
+	return resolvedContext;
+}
+
+function getCommandsContext(accessor: ServicesAccessor, commandArgs: unknown[]): IEditorCommandsContext[] {
+	// Figure out if command is executed from a list
+	const listService = accessor.get(IListService);
+	const list = listService.lastFocusedList;
+	let isListAction = list instanceof List && list.getHTMLElement() === getActiveElement();
+
+	// Get editor context for which the command was triggered
+	let editorContext = getEditorContextFromCommandArgs(accessor, commandArgs, isListAction);
+
+	// If the editor context can not be determind use the active editor
+	if (!editorContext) {
+		const editorGroupService = accessor.get(IEditorGroupsService);
+		const activeGroup = editorGroupService.activeGroup;
+		const activeEditor = activeGroup.activeEditor;
+		editorContext = { groupId: activeGroup.id, editorIndex: activeEditor ? activeGroup.getIndexOfEditor(activeEditor) : undefined };
+		isListAction = false;
+	}
+
+	const multiEditorContext = getMultiSelectContext(accessor, editorContext, isListAction);
+
+	// Make sure the command context is the first one in the list
+	return moveCurrentEditorContextToFront(editorContext, multiEditorContext);
+}
+
+function moveCurrentEditorContextToFront(editorContext: IEditorCommandsContext, multiEditorContext: IEditorCommandsContext[]): IEditorCommandsContext[] {
+	const editorContextIndex = multiEditorContext.findIndex(context =>
+		context.groupId === editorContext.groupId &&
+		context.editorIndex === editorContext.editorIndex &&
+		context.preserveFocus === editorContext.preserveFocus
+	);
+
+	if (editorContextIndex !== -1) {
+		multiEditorContext.splice(editorContextIndex, 1);
+	} else {
+		throw new Error('Invalid multi select editor context');
+	}
+
+	multiEditorContext.unshift(editorContext);
+
+	return multiEditorContext;
+}
+
+function getEditorContextFromCommandArgs(accessor: ServicesAccessor, commandArgs: unknown[], isListAcion: boolean): IEditorCommandsContext | undefined {
+	// We only know how to extraxt the command context from URI and IEditorCommandsContext arguments
+	const filteredArgs = commandArgs.filter(arg => isEditorCommandsContext(arg) || URI.isUri(arg));
+
+	// If the command arguments contain an editor context, use it
+	for (const arg of filteredArgs) {
+		if (isEditorCommandsContext(arg)) {
+			return arg;
+		}
+	}
+
+	const editorService = accessor.get(IEditorService);
+
+	// Otherwise, try to find the editor group by the URI of the resource
+	for (const uri of filteredArgs as URI[]) {
+		const editorIdentifiers = editorService.findEditors(uri);
+		if (editorIdentifiers.length) {
+			return editorIdentifiers[0];
+		}
+	}
+
+	const listService = accessor.get(IListService);
+	const editorGroupsService = accessor.get(IEditorGroupsService);
+
+	// If there is no context in the arguments, try to find the context from the focused list
+	// if the action was executed from a list
+	if (isListAcion) {
+		const list = listService.lastFocusedList as List<any>;
+		for (const focusedElement of list.getFocusedElements()) {
+			if (isGroupOrEditor(focusedElement)) {
+				return groupOrEditorToEditorContext(focusedElement, undefined, editorGroupsService);
+			}
+		}
+	}
+
+	return undefined;
+}
+
+function getMultiSelectContext(accessor: ServicesAccessor, editorContext: IEditorCommandsContext, isListAction: boolean): IEditorCommandsContext[] {
+	const listService = accessor.get(IListService);
+	const editorGroupsService = accessor.get(IEditorGroupsService);
+
+	// If the action was executed from a list, return all selected editors
+	if (isListAction) {
+		const list = listService.lastFocusedList as List<any>;
+		const selection = list.getSelectedElements().filter(isGroupOrEditor);
+
+		if (selection.length > 1) {
+			return selection.map(e => groupOrEditorToEditorContext(e, editorContext.preserveFocus, editorGroupsService));
+		}
+	}
+	// Check editors selected in the group (tabs)
+	else {
+		const group = editorGroupsService.getGroup(editorContext.groupId);
+		const editor = editorContext.editorIndex !== undefined ? group?.getEditorByIndex(editorContext.editorIndex) : group?.activeEditor;
+		// If the editor is selected, return all selected editors otherwise only use the editors context
+		if (group && editor && group.isSelected(editor)) {
+			return group.selectedEditors.map(editor => groupOrEditorToEditorContext({ editor, groupId: group.id }, editorContext.preserveFocus, editorGroupsService));
+		}
+	}
+
+	// Otherwise go with passed in context
+	return [editorContext];
+}
+
+function groupOrEditorToEditorContext(element: IEditorIdentifier | IEditorGroup, preserveFocus: boolean | undefined, editorGroupsService: IEditorGroupsService): IEditorCommandsContext {
+	if (isEditorGroup(element)) {
+		return { groupId: element.id, editorIndex: undefined, preserveFocus };
+	}
+
+	const group = editorGroupsService.getGroup(element.groupId);
+
+	return { groupId: element.groupId, editorIndex: group ? group.getIndexOfEditor(element.editor) : -1, preserveFocus };
+}
+
+function isGroupOrEditor(element: any): element is IEditorIdentifier | IEditorGroup {
+	return isEditorGroup(element) || isEditorIdentifier(element);
+}
+
+function getEditorAndGroupFromContext(commandContext: IEditorCommandsContext, editorGroupsService: IEditorGroupsService): { group: IEditorGroup; editor: EditorInput | undefined } | undefined {
+	const group = editorGroupsService.getGroup(commandContext.groupId);
+	if (!group) {
+		return undefined;
+	}
+
+	if (commandContext.editorIndex === undefined) {
+		return { group, editor: undefined };
+	}
+
+	const editor = group.getEditorByIndex(commandContext.editorIndex);
+	return { group, editor };
+}

--- a/src/vs/workbench/contrib/files/browser/fileCommands.ts
+++ b/src/vs/workbench/contrib/files/browser/fileCommands.ts
@@ -519,7 +519,7 @@ CommandsRegistry.registerCommand({
 		if (!resolvedContext.groupedEditors.length) {
 			groups = editorGroupService.getGroups(GroupsOrder.MOST_RECENTLY_ACTIVE);
 		} else {
-			groups = resolvedContext.groupedEditors.map(groupContext => groupContext.group);
+			groups = resolvedContext.groupedEditors.map(({ group }) => group);
 		}
 
 		return saveDirtyEditorsOfGroups(accessor, groups, { reason: SaveReason.EXPLICIT });

--- a/src/vs/workbench/contrib/files/browser/fileCommands.ts
+++ b/src/vs/workbench/contrib/files/browser/fileCommands.ts
@@ -25,7 +25,7 @@ import { isWeb, isWindows } from 'vs/base/common/platform';
 import { ITextModelService } from 'vs/editor/common/services/resolverService';
 import { getResourceForCommand, getMultiSelectedResources, getOpenEditorsViewMultiSelection, IExplorerService } from 'vs/workbench/contrib/files/browser/files';
 import { IWorkspaceEditingService } from 'vs/workbench/services/workspaces/common/workspaceEditing';
-import { getMultiSelectedEditorContexts } from 'vs/workbench/browser/parts/editor/editorCommands';
+import { resolveCommandsContext } from 'vs/workbench/browser/parts/editor/editorCommandsContext';
 import { Schemas } from 'vs/base/common/network';
 import { INotificationService, Severity } from 'vs/platform/notification/common/notification';
 import { EditorContextKeys } from 'vs/editor/common/editorContextKeys';
@@ -35,7 +35,6 @@ import { ILabelService } from 'vs/platform/label/common/label';
 import { basename, joinPath, isEqual } from 'vs/base/common/resources';
 import { IDisposable, dispose } from 'vs/base/common/lifecycle';
 import { IEnvironmentService } from 'vs/platform/environment/common/environment';
-import { coalesce } from 'vs/base/common/arrays';
 import { ICodeEditorService } from 'vs/editor/browser/services/codeEditorService';
 import { EmbeddedCodeEditorWidget } from 'vs/editor/browser/widget/codeEditor/embeddedCodeEditorWidget';
 import { ITextFileService } from 'vs/workbench/services/textfile/common/textfiles';
@@ -514,13 +513,13 @@ CommandsRegistry.registerCommand({
 	handler: (accessor, _: URI | object, editorContext: IEditorCommandsContext) => {
 		const editorGroupService = accessor.get(IEditorGroupsService);
 
-		const contexts = getMultiSelectedEditorContexts(editorContext, accessor.get(IListService), accessor.get(IEditorGroupsService));
+		const resolvedContext = resolveCommandsContext(accessor, [editorContext]);
 
 		let groups: readonly IEditorGroup[] | undefined = undefined;
-		if (!contexts.length) {
+		if (!resolvedContext.groupedEditors.length) {
 			groups = editorGroupService.getGroups(GroupsOrder.MOST_RECENTLY_ACTIVE);
 		} else {
-			groups = coalesce(contexts.map(context => editorGroupService.getGroup(context.groupId)));
+			groups = resolvedContext.groupedEditors.map(groupContext => groupContext.group);
 		}
 
 		return saveDirtyEditorsOfGroups(accessor, groups, { reason: SaveReason.EXPLICIT });

--- a/src/vs/workbench/contrib/multiDiffEditor/browser/actions.ts
+++ b/src/vs/workbench/contrib/multiDiffEditor/browser/actions.ts
@@ -11,12 +11,10 @@ import { localize2 } from 'vs/nls';
 import { Action2, MenuId } from 'vs/platform/actions/common/actions';
 import { ContextKeyExpr } from 'vs/platform/contextkey/common/contextkey';
 import { ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
-import { getCommandsContext, resolveCommandsContext } from 'vs/workbench/browser/parts/editor/editorCommands';
-import { IEditorCommandsContext } from 'vs/workbench/common/editor';
+import { resolveCommandsContext } from 'vs/workbench/browser/parts/editor/editorCommandsContext';
 import { TextFileEditor } from 'vs/workbench/contrib/files/browser/editors/textFileEditor';
 import { MultiDiffEditor } from 'vs/workbench/contrib/multiDiffEditor/browser/multiDiffEditor';
 import { MultiDiffEditorInput } from 'vs/workbench/contrib/multiDiffEditor/browser/multiDiffEditorInput';
-import { IEditorGroupsService } from 'vs/workbench/services/editor/common/editorGroupsService';
 import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
 
 export class GoToFileAction extends Action2 {
@@ -75,9 +73,15 @@ export class CollapseAllAction extends Action2 {
 		});
 	}
 
-	async run(accessor: ServicesAccessor, resourceOrContext?: URI | IEditorCommandsContext, context?: IEditorCommandsContext): Promise<void> {
-		const { editor } = resolveCommandsContext(accessor.get(IEditorGroupsService), getCommandsContext(accessor, resourceOrContext, context));
+	async run(accessor: ServicesAccessor, ...args: unknown[]): Promise<void> {
+		const resolvedContext = resolveCommandsContext(accessor, args);
 
+		const groupContext = resolvedContext.groupedEditors[0];
+		if (!groupContext) {
+			return;
+		}
+
+		const editor = groupContext.editors[0];
 		if (editor instanceof MultiDiffEditorInput) {
 			const viewModel = await editor.getViewModel();
 			viewModel.collapseAll();
@@ -102,9 +106,15 @@ export class ExpandAllAction extends Action2 {
 		});
 	}
 
-	async run(accessor: ServicesAccessor, resourceOrContext?: URI | IEditorCommandsContext, context?: IEditorCommandsContext): Promise<void> {
-		const { editor } = resolveCommandsContext(accessor.get(IEditorGroupsService), getCommandsContext(accessor, resourceOrContext, context));
+	async run(accessor: ServicesAccessor, ...args: unknown[]): Promise<void> {
+		const resolvedContext = resolveCommandsContext(accessor, args);
 
+		const groupContext = resolvedContext.groupedEditors[0];
+		if (!groupContext) {
+			return;
+		}
+
+		const editor = groupContext.editors[0];
 		if (editor instanceof MultiDiffEditorInput) {
 			const viewModel = await editor.getViewModel();
 			viewModel.expandAll();

--- a/src/vs/workbench/contrib/notebook/browser/controller/coreActions.ts
+++ b/src/vs/workbench/contrib/notebook/browser/controller/coreActions.ts
@@ -13,7 +13,7 @@ import { getNotebookEditorFromEditorPane, IActiveNotebookEditor, ICellViewModel,
 import { INTERACTIVE_WINDOW_IS_ACTIVE_EDITOR, NOTEBOOK_EDITOR_EDITABLE, NOTEBOOK_EDITOR_FOCUSED, NOTEBOOK_IS_ACTIVE_EDITOR, NOTEBOOK_KERNEL_COUNT, NOTEBOOK_KERNEL_SOURCE_COUNT } from 'vs/workbench/contrib/notebook/common/notebookContextKeys';
 import { ICellRange, isICellRange } from 'vs/workbench/contrib/notebook/common/notebookRange';
 import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
-import { IEditorCommandsContext } from 'vs/workbench/common/editor';
+import { isEditorCommandsContext } from 'vs/workbench/common/editor';
 import { INotebookEditorService } from 'vs/workbench/contrib/notebook/browser/services/notebookEditorService';
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 import { WorkbenchActionExecutedClassification, WorkbenchActionExecutedEvent } from 'vs/base/common/actions';
@@ -220,9 +220,6 @@ export abstract class NotebookMultiCellAction extends Action2 {
 	private isCellToolbarContext(context?: unknown): context is INotebookCellToolbarActionContext {
 		return !!context && !!(context as INotebookActionContext).notebookEditor && (context as any).$mid === MarshalledId.NotebookCellActionContext;
 	}
-	private isEditorContext(context?: unknown): boolean {
-		return !!context && (context as IEditorCommandsContext).groupId !== undefined;
-	}
 
 	/**
 	 * The action/command args are resolved in following order
@@ -233,7 +230,7 @@ export abstract class NotebookMultiCellAction extends Action2 {
 	async run(accessor: ServicesAccessor, ...additionalArgs: any[]): Promise<void> {
 		const context = additionalArgs[0];
 		const isFromCellToolbar = this.isCellToolbarContext(context);
-		const isFromEditorToolbar = this.isEditorContext(context);
+		const isFromEditorToolbar = isEditorCommandsContext(context);
 		const from = isFromCellToolbar ? 'cellToolbar' : (isFromEditorToolbar ? 'editorToolbar' : 'other');
 		const telemetryService = accessor.get(ITelemetryService);
 


### PR DESCRIPTION
All editor commands can use `resolveCommandsContext` to retrieve the editor groups and editors related to the commands context. The function returns a `IResolvedEditorCommandsContext` which groups editors together with their editor group.

I'm not really sure about the names I picked, open for other suggestions for:
- `resolveCommandsContext`
- `IResolvedEditorCommandsContext`
- `IResolvedEditorCommandsContext.groupedEditors`

fixes #213155