### PR TITLE
fix #219977

### DIFF
--- a/src/vs/platform/configuration/test/common/configurationRegistry.test.ts
+++ b/src/vs/platform/configuration/test/common/configurationRegistry.test.ts
@@ -31,6 +31,24 @@ suite('ConfigurationRegistry', () => {
 		assert.deepStrictEqual(configurationRegistry.getConfigurationProperties()['[lang]'].default, { a: 2, c: 3 });
 	});
 
+	test('configuration override defaults - prevent overriding default value', async () => {
+		configurationRegistry.registerConfiguration({
+			'id': '_test_default',
+			'type': 'object',
+			'properties': {
+				'config.preventDefaultValueOverride': {
+					'type': 'object',
+					default: { a: 0 },
+					'disallowConfigurationDefault': true
+				}
+			}
+		});
+
+		configurationRegistry.registerDefaultConfigurations([{ overrides: { 'config.preventDefaultValueOverride': { a: 1, b: 2 } } }]);
+
+		assert.deepStrictEqual(configurationRegistry.getConfigurationProperties()['config.preventDefaultValueOverride'].default, { a: 0 });
+	});
+
 	test('configuration override defaults - merges defaults', async () => {
 		configurationRegistry.registerDefaultConfigurations([{ overrides: { '[lang]': { a: 1, b: 2 } } }]);
 		configurationRegistry.registerDefaultConfigurations([{ overrides: { '[lang]': { a: 2, c: 3 } } }]);
@@ -91,8 +109,8 @@ suite('ConfigurationRegistry', () => {
 			}
 		});
 
-		const overrides1 = [{ overrides: { 'config': { a: 1, b: 2 } }, source: 'source1' }];
-		const overrides2 = [{ overrides: { 'config': { a: 2, c: 3 } }, source: 'source2' }];
+		const overrides1 = [{ overrides: { 'config': { a: 1, b: 2 } }, source: { id: 'source1', displayName: 'source1' } }];
+		const overrides2 = [{ overrides: { 'config': { a: 2, c: 3 } }, source: { id: 'source2', displayName: 'source2' } }];
 
 		configurationRegistry.registerDefaultConfigurations(overrides1);
 		configurationRegistry.registerDefaultConfigurations(overrides2);

--- a/src/vs/platform/configuration/test/common/configurations.test.ts
+++ b/src/vs/platform/configuration/test/common/configurations.test.ts
@@ -386,7 +386,7 @@ suite('DefaultConfiguration', () => {
 					}
 				}
 			},
-			source: 'source1'
+			source: { id: 'source1', displayName: 'source1' }
 		};
 
 		const node2 = {
@@ -398,7 +398,7 @@ suite('DefaultConfiguration', () => {
 					}
 				}
 			},
-			source: 'source2'
+			source: { id: 'source2', displayName: 'source2' }
 		};
 		configurationRegistry.registerDefaultConfigurations([node1]);
 		configurationRegistry.registerDefaultConfigurations([node2]);

--- a/src/vs/workbench/api/common/configurationExtensionPoint.ts
+++ b/src/vs/workbench/api/common/configurationExtensionPoint.ts
@@ -160,11 +160,17 @@ defaultConfigurationExtPoint.setHandler((extensions, { added, removed }) => {
 		const addedDefaultConfigurations = added.map<IConfigurationDefaults>(extension => {
 			const overrides: IStringDictionary<any> = objects.deepClone(extension.value);
 			for (const key of Object.keys(overrides)) {
+				const registeredPropertyScheme = registeredProperties[key];
+				if (registeredPropertyScheme?.disallowConfigurationDefault) {
+					extension.collector.warn(nls.localize('config.property.preventDefaultConfiguration.warning', "Cannot register configuration defaults for '{0}'. This setting does not allow contributing configuration defaults.", key));
+					delete overrides[key];
+					continue;
+				}
 				if (!OVERRIDE_PROPERTY_REGEX.test(key)) {
-					const registeredPropertyScheme = registeredProperties[key];
 					if (registeredPropertyScheme?.scope && !allowedScopes.includes(registeredPropertyScheme.scope)) {
 						extension.collector.warn(nls.localize('config.property.defaultConfiguration.warning', "Cannot register configuration defaults for '{0}'. Only defaults for machine-overridable, window, resource and language overridable scoped settings are supported.", key));
 						delete overrides[key];
+						continue;
 					}
 				}
 			}

--- a/src/vs/workbench/contrib/debug/browser/debug.contribution.ts
+++ b/src/vs/workbench/contrib/debug/browser/debug.contribution.ts
@@ -560,7 +560,8 @@ configurationRegistry.registerConfiguration({
 			type: 'object',
 			description: nls.localize({ comment: ['This is the description for a setting'], key: 'launch' }, "Global debug launch configuration. Should be used as an alternative to 'launch.json' that is shared across workspaces."),
 			default: { configurations: [], compounds: [] },
-			$ref: launchSchemaId
+			$ref: launchSchemaId,
+			disallowConfigurationDefault: true
 		},
 		'debug.focusWindowOnBreak': {
 			type: 'boolean',

--- a/src/vs/workbench/services/configuration/browser/configurationService.ts
+++ b/src/vs/workbench/services/configuration/browser/configurationService.ts
@@ -1260,9 +1260,9 @@ class RegisterConfigurationSchemasContribution extends Disposable implements IWo
 			type: 'object',
 			description: localize('configurationDefaults.description', 'Contribute defaults for configurations'),
 			properties: Object.assign({},
-				machineOverridableSettings.properties,
-				windowSettings.properties,
-				resourceSettings.properties
+				this.filterDefaultOverridableProperties(machineOverridableSettings.properties),
+				this.filterDefaultOverridableProperties(windowSettings.properties),
+				this.filterDefaultOverridableProperties(resourceSettings.properties)
 			),
 			patternProperties: {
 				[OVERRIDE_PROPERTY_PATTERN]: {
@@ -1311,6 +1311,16 @@ class RegisterConfigurationSchemasContribution extends Disposable implements IWo
 		const result: IStringDictionary<IConfigurationPropertySchema> = {};
 		Object.entries(properties).forEach(([key, value]) => {
 			if (!value.restricted) {
+				result[key] = value;
+			}
+		});
+		return result;
+	}
+
+	private filterDefaultOverridableProperties(properties: IStringDictionary<IConfigurationPropertySchema>): IStringDictionary<IConfigurationPropertySchema> {
+		const result: IStringDictionary<IConfigurationPropertySchema> = {};
+		Object.entries(properties).forEach(([key, value]) => {
+			if (!value.disallowConfigurationDefault) {
 				result[key] = value;
 			}
 		});
@@ -1365,7 +1375,7 @@ class UpdateExperimentalSettingsDefaults extends Disposable implements IWorkbenc
 			} catch (error) {/*ignore */ }
 		}
 		if (Object.keys(overrides).length) {
-			this.configurationRegistry.registerDefaultConfigurations([{ overrides, source: localize('experimental', "Experiments") }]);
+			this.configurationRegistry.registerDefaultConfigurations([{ overrides }]);
 		}
 	}
 }


### PR DESCRIPTION
fix #219977

Provided a metadata property for configuration to define if the setting should allow contributing configuration defaults or not

```
	/**
	 * Disallow extensions to contribute configuration default value for this setting.
	 */
	disallowConfigurationDefault?: boolean;
``` 

And adopted `launch` to use this.

cc @connor4312 