### PR TITLE
Remove MultiRowEditorControl Hack and properly redraw tabs on restore

### DIFF
--- a/src/vs/workbench/browser/parts/editor/editorGroupView.ts
+++ b/src/vs/workbench/browser/parts/editor/editorGroupView.ts
@@ -568,8 +568,7 @@ export class EditorGroupView extends Themable implements IEditorGroupView {
 
 		// Show active editor (intentionally not using async to keep
 		// `restoreEditors` from executing in same stack)
-		return this.doShowEditor(activeEditor, { active: true, isNew: false /* restored */ }, options, internalOptions).then(() => {
-			this.titleControl.openEditors(this.editors);
+		const result = this.doShowEditor(activeEditor, { active: true, isNew: false /* restored */ }, options, internalOptions).then(() => {
 
 			// Set focused now if this is the active group and focus has
 			// not changed meanwhile. This prevents focus from being
@@ -580,6 +579,11 @@ export class EditorGroupView extends Themable implements IEditorGroupView {
 				this.focus();
 			}
 		});
+
+		// Restore editors in title control
+		this.titleControl.openEditors(this.editors);
+
+		return result;
 	}
 
 	//#region event handling

--- a/src/vs/workbench/browser/parts/editor/editorGroupView.ts
+++ b/src/vs/workbench/browser/parts/editor/editorGroupView.ts
@@ -560,7 +560,8 @@ export class EditorGroupView extends Themable implements IEditorGroupView {
 		options.preserveFocus = true;						// handle focus after editor is restored
 
 		const internalOptions: IInternalEditorOpenOptions = {
-			preserveWindowOrder: true						// handle window order after editor is restored
+			preserveWindowOrder: true,						// handle window order after editor is restored
+			skipTitleUpdate: true,							// update the title later for all editors at once
 		};
 
 		const activeElement = getActiveElement();
@@ -568,6 +569,7 @@ export class EditorGroupView extends Themable implements IEditorGroupView {
 		// Show active editor (intentionally not using async to keep
 		// `restoreEditors` from executing in same stack)
 		return this.doShowEditor(activeEditor, { active: true, isNew: false /* restored */ }, options, internalOptions).then(() => {
+			this.titleControl.openEditors(this.editors);
 
 			// Set focused now if this is the active group and focus has
 			// not changed meanwhile. This prevents focus from being

--- a/src/vs/workbench/browser/parts/editor/editorGroupView.ts
+++ b/src/vs/workbench/browser/parts/editor/editorGroupView.ts
@@ -835,7 +835,7 @@ export class EditorGroupView extends Themable implements IEditorGroupView {
 
 			// Ensure to show active editor if any
 			if (this.model.activeEditor) {
-				this.titleControl.openEditor(this.model.activeEditor);
+				this.titleControl.openEditors(this.model.getEditors(EditorsOrder.SEQUENTIAL));
 			}
 		}
 

--- a/src/vs/workbench/browser/parts/editor/multiEditorTabsControl.ts
+++ b/src/vs/workbench/browser/parts/editor/multiEditorTabsControl.ts
@@ -684,20 +684,7 @@ export class MultiEditorTabsControl extends EditorTabsControl {
 		this.layout(this.dimensions, { forceRevealActiveTab: true });
 	}
 
-	private previousSelectedCount = 0;
 	updateEditorSelections(): void {
-		// We only need to redraw from here when a selection got removed
-		// otherwise it will be handled by the open editor change event.
-		// Checking count is currently enough but might require checking
-		// each editor in the future if selection is changed programatically.
-		const newSelectedCount = this.tabsModel.selectedEditors.length;
-		const previousSelectedCount = this.previousSelectedCount;
-		this.previousSelectedCount = newSelectedCount;
-
-		if (newSelectedCount >= previousSelectedCount) {
-			return;
-		}
-
 		this.forEachTab((editor, tabIndex, tabContainer, tabLabelWidget, tabLabel, tabActionBar) => {
 			this.redrawTabSelectedActiveAndDirty(this.groupsView.activeGroup === this.groupView, editor, tabContainer, tabActionBar);
 		});

--- a/src/vs/workbench/browser/parts/editor/multiRowEditorTabsControl.ts
+++ b/src/vs/workbench/browser/parts/editor/multiRowEditorTabsControl.ts
@@ -64,7 +64,8 @@ export class MultiRowEditorControl extends Disposable implements IEditorTabsCont
 		const [editorTabController, otherTabController] = this.model.isSticky(editor) ? [this.stickyEditorTabsControl, this.unstickyEditorTabsControl] : [this.unstickyEditorTabsControl, this.stickyEditorTabsControl];
 		const didChange = editorTabController.openEditor(editor, options);
 		if (didChange) {
-			// HACK: To render all editor tabs on startup, otherwise only one row gets rendered
+			// We have to rerender both tab bars as the previous active tab could have moved between the two
+			// and we need to ensure that the active tab indicators have been removed from the previous active tab
 			otherTabController.openEditors([]);
 
 			this.handleOpenedEditors();

--- a/src/vs/workbench/browser/parts/editor/multiRowEditorTabsControl.ts
+++ b/src/vs/workbench/browser/parts/editor/multiRowEditorTabsControl.ts
@@ -61,8 +61,7 @@ export class MultiRowEditorControl extends Disposable implements IEditorTabsCont
 	}
 
 	openEditor(editor: EditorInput, options: IInternalEditorOpenOptions): boolean {
-		const editorTabController = this.model.isSticky(editor) ? this.stickyEditorTabsControl : this.unstickyEditorTabsControl;
-		const didChange = editorTabController.openEditor(editor, options);
+		const didChange = this.getEditorTabsController(editor).openEditor(editor, options);
 		if (didChange) {
 			this.handleOpenedEditors();
 		}

--- a/src/vs/workbench/browser/parts/editor/multiRowEditorTabsControl.ts
+++ b/src/vs/workbench/browser/parts/editor/multiRowEditorTabsControl.ts
@@ -61,13 +61,9 @@ export class MultiRowEditorControl extends Disposable implements IEditorTabsCont
 	}
 
 	openEditor(editor: EditorInput, options: IInternalEditorOpenOptions): boolean {
-		const [editorTabController, otherTabController] = this.model.isSticky(editor) ? [this.stickyEditorTabsControl, this.unstickyEditorTabsControl] : [this.unstickyEditorTabsControl, this.stickyEditorTabsControl];
+		const editorTabController = this.model.isSticky(editor) ? this.stickyEditorTabsControl : this.unstickyEditorTabsControl;
 		const didChange = editorTabController.openEditor(editor, options);
 		if (didChange) {
-			// We have to rerender both tab bars as the previous active tab could have moved between the two
-			// and we need to ensure that the active tab indicators have been removed from the previous active tab
-			otherTabController.openEditors([]);
-
 			this.handleOpenedEditors();
 		}
 		return didChange;


### PR DESCRIPTION
The comment in the MultiRowEditorControl class was misleading and has been updated to provide accurate information. 

#193690