### PR TITLE
Webviews: Avoids triggering new chrome scrollbar behavior

### DIFF
--- a/src/vs/workbench/contrib/webview/browser/pre/index-no-csp.html
+++ b/src/vs/workbench/contrib/webview/browser/pre/index-no-csp.html
@@ -85,8 +85,10 @@
 		const defaultStyles = document.createElement('style');
 		defaultStyles.id = '_defaultStyles';
 		defaultStyles.textContent = `
-			html {
-				scrollbar-color: var(--vscode-scrollbarSlider-background) var(--vscode-editor-background);
+			@supports not selector(::-webkit-scrollbar) {
+				html {
+					scrollbar-color: var(--vscode-scrollbarSlider-background) var(--vscode-editor-background);
+				}
 			}
 
 			body {

--- a/src/vs/workbench/contrib/webview/browser/pre/index.html
+++ b/src/vs/workbench/contrib/webview/browser/pre/index.html
@@ -88,8 +88,10 @@
 		const defaultStyles = document.createElement('style');
 		defaultStyles.id = '_defaultStyles';
 		defaultStyles.textContent = `
-			html {
-				scrollbar-color: var(--vscode-scrollbarSlider-background) var(--vscode-editor-background);
+			@supports not selector(::-webkit-scrollbar) {	
+				html {
+					scrollbar-color: var(--vscode-scrollbarSlider-background) var(--vscode-editor-background);
+				}
 			}
 
 			body {


### PR DESCRIPTION
Fixes #213045

Avoids triggering new Chrome 121 scrollbar behavior that if `scrollbar-color` or `scrollbar-width` are used then the `::-webkit-scrollbar*` props are ignored.