### PR TITLE
Adopt `getAccounts` API in GitHub Authentication

### DIFF
--- a/extensions/github-authentication/package.json
+++ b/extensions/github-authentication/package.json
@@ -13,6 +13,9 @@
     "Other"
   ],
   "api": "none",
+  "enabledApiProposals": [
+    "authGetSessions"
+  ],
   "extensionKind": [
     "ui",
     "workspace"

--- a/extensions/github-authentication/src/flows.ts
+++ b/extensions/github-authentication/src/flows.ts
@@ -173,6 +173,8 @@ const allFlows: IFlow[] = [
 				]);
 				if (existingLogin) {
 					searchParams.append('login', existingLogin);
+				} else {
+					searchParams.append('prompt', 'select_account');
 				}
 
 				// The extra toString, parse is apparently needed for env.openExternal
@@ -240,6 +242,8 @@ const allFlows: IFlow[] = [
 				]);
 				if (existingLogin) {
 					searchParams.append('login', existingLogin);
+				} else {
+					searchParams.append('prompt', 'select_account');
 				}
 
 				const loginUrl = baseUri.with({

--- a/extensions/github-authentication/tsconfig.json
+++ b/extensions/github-authentication/tsconfig.json
@@ -12,6 +12,7 @@
 	},
 	"include": [
 		"src/**/*",
-		"../../src/vscode-dts/vscode.d.ts"
+		"../../src/vscode-dts/vscode.d.ts",
+		"../../src/vscode-dts/vscode.proposed.authGetSessions.d.ts"
 	]
 }

--- a/src/vs/workbench/api/browser/mainThreadAuthentication.ts
+++ b/src/vs/workbench/api/browser/mainThreadAuthentication.ts
@@ -174,21 +174,21 @@ export class MainThreadAuthentication extends Disposable implements MainThreadAu
 			throw new Error('Invalid combination of options. Please remove one of the following: createIfNone, silent');
 		}
 
+		if (options.clearSessionPreference) {
+			// Clearing the session preference is usually paired with createIfNone, so just remove the preference and
+			// defer to the rest of the logic in this function to choose the session.
+			this.authenticationExtensionsService.removeSessionPreference(providerId, extensionId, scopes);
+		}
+
 		// Check if the sessions we have are valid
 		if (!options.forceNewSession && sessions.length) {
 			if (provider.supportsMultipleAccounts) {
-				if (options.clearSessionPreference) {
-					// Clearing the session preference is usually paired with createIfNone, so just remove the preference and
-					// defer to the rest of the logic in this function to choose the session.
-					this.authenticationExtensionsService.removeSessionPreference(providerId, extensionId, scopes);
-				} else {
-					// If we have an existing session preference, use that. If not, we'll return any valid session at the end of this function.
-					const existingSessionPreference = this.authenticationExtensionsService.getSessionPreference(providerId, extensionId, scopes);
-					if (existingSessionPreference) {
-						const matchingSession = sessions.find(session => session.id === existingSessionPreference);
-						if (matchingSession && this.authenticationAccessService.isAccessAllowed(providerId, matchingSession.account.label, extensionId)) {
-							return matchingSession;
-						}
+				// If we have an existing session preference, use that. If not, we'll return any valid session at the end of this function.
+				const existingSessionPreference = this.authenticationExtensionsService.getSessionPreference(providerId, extensionId, scopes);
+				if (existingSessionPreference) {
+					const matchingSession = sessions.find(session => session.id === existingSessionPreference);
+					if (matchingSession && this.authenticationAccessService.isAccessAllowed(providerId, matchingSession.account.label, extensionId)) {
+						return matchingSession;
 					}
 				}
 			} else if (this.authenticationAccessService.isAccessAllowed(providerId, sessions[0].account.label, extensionId)) {


### PR DESCRIPTION
This allows the GitHub Auth provider to take in a account per this proposal:

https://github.com/microsoft/vscode/blob/417dddb83f3536479f88c40e1d78edf1136a5ae5/src/vscode-dts/vscode.proposed.authGetSessions.d.ts#L35-L69

Additionally, this makes an additional small change that allows `clearSessionPreference` to work in single-account auth providers.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
