### PR TITLE
ci: disable nodejsmirror for merge check

### DIFF
--- a/build/azure-pipelines/distro-build.yml
+++ b/build/azure-pipelines/distro-build.yml
@@ -11,5 +11,5 @@ steps:
     inputs:
       versionSource: fromFile
       versionFilePath: .nvmrc
-      nodejsMirror: https://github.com/joaomoreno/node-mirror/releases/download
+      #nodejsMirror: https://github.com/joaomoreno/node-mirror/releases/download
   - template: ./distro/download-distro.yml@self


### PR DESCRIPTION
Will be reverted once https://github.com/joaomoreno/node-mirror/pull/1 is merged.

Addresses https://dev.azure.com/monacotools/Monaco/_build/results?buildId=282912&view=results