### PR TITLE
Window title use execution path.

### DIFF
--- a/src/vs/platform/externalTerminal/node/externalTerminalService.ts
+++ b/src/vs/platform/externalTerminal/node/externalTerminalService.ts
@@ -56,8 +56,9 @@ export class WindowsExternalTerminalService extends ExternalTerminalService impl
 		const cmdArgs = ['/c', 'start', '/wait'];
 		if (exec.indexOf(' ') >= 0) {
 			// The "" argument is the window title. Without this, exec doesn't work when the path
-			// contains spaces
-			cmdArgs.push('""');
+			// contains spaces. #6590
+			// Title is Execution Path. #220129
+			cmdArgs.push(exec);
 		}
 		cmdArgs.push(exec);
 		// Add starting directory parameter for Windows Terminal (see #90734)


### PR DESCRIPTION
fix #220129
Unable to reproduce #6590,the problem is somewhat similar to #60806. 
To be conservative, use the execution path to assign a title. 
I feel that removing it is also possible.
![11](https://github.com/microsoft/vscode/assets/48614781/de2850d4-ab38-4c8c-b0b5-18780b6bdffd)
