### PR TITLE
Reset shell-type context when the type is unknown

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminalService.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalService.ts
@@ -208,7 +208,7 @@ export class TerminalService extends Disposable implements ITerminalService {
 			}
 			if (instance?.shellType) {
 				this._terminalShellTypeContextKey.set(instance.shellType.toString());
-			} else if (!instance) {
+			} else if (!instance || !(instance.shellType)) {
 				this._terminalShellTypeContextKey.reset();
 			}
 		}));

--- a/src/vs/workbench/contrib/terminal/common/terminalContextKey.ts
+++ b/src/vs/workbench/contrib/terminal/common/terminalContextKey.ts
@@ -81,8 +81,8 @@ export namespace TerminalContextKeys {
 	/** Whether the mouse is within the terminal tabs list. */
 	export const tabsMouse = new RawContextKey<boolean>(TerminalContextKeyStrings.TabsMouse, false, true);
 
-	/** The shell type of the active terminal, this is set to the last known value when no terminals exist. */
-	export const shellType = new RawContextKey<string>(TerminalContextKeyStrings.ShellType, undefined, { type: 'string', description: localize('terminalShellTypeContextKey', "The shell type of the active terminal, this is set to the last known value when no terminals exist.") });
+	/** The shell type of the active terminal, this is set if the type can be detected. */
+	export const shellType = new RawContextKey<string>(TerminalContextKeyStrings.ShellType, undefined, { type: 'string', description: localize('terminalShellTypeContextKey', "The shell type of the active terminal, this is set if the type can be detected.") });
 
 	/** Whether the terminal's alt buffer is active. */
 	export const altBufferActive = new RawContextKey<boolean>(TerminalContextKeyStrings.AltBufferActive, false, localize('terminalAltBufferActive', "Whether the terminal's alt buffer is active."));


### PR DESCRIPTION
## Motivation

To provide robust usage upon shell type context, only set shell-type context key if we can tell the type of the shell.

Also update the description of the context to reflect this change.

This modification resolve #191650.

Since that the semantic of the context key is also changed, the translation should also be updated.
But I'm not sure about the work flow regarding this.

## How to Test

(This PR can only be verified since that `terminalShellType` context key is only supported when the host environment is Windows.)

Prepare a shell profile that the shell type is undefined.

```diff
--- a/src/vs/platform/terminal/node/windowsShellHelper.ts
+++ b/src/vs/platform/terminal/node/windowsShellHelper.ts
@@ -136,7 +136,7 @@ export class WindowsShellHelper extends Disposable implements IWindowsShellHelpe
        getShellType(executable: string): TerminalShellType | undefined {
                switch (executable.toLowerCase()) {
                        case 'cmd.exe':
-                               return WindowsShellType.CommandPrompt;
+                               return undefined;
                        case 'powershell.exe':
                        case 'pwsh.exe':
                                return WindowsShellType.PowerShell;
```

Open a shell, inspect the context key `terminalShellType` is set correctly.

Open another shell that do not support shell-type,
inspect again to check that the context key `terminalShellType` is disappeared.

(Also change between two opened shells to validate the behavior)

