### PR TITLE
Fix: only add apt sources for users that want them (#22145)

### DIFF
--- a/build/gulpfile.vscode.linux.js
+++ b/build/gulpfile.vscode.linux.js
@@ -108,7 +108,11 @@ function prepareDebPackage(arch) {
 			.pipe(replace('@@NAME@@', product.applicationName))
 			.pipe(rename('DEBIAN/postinst'));
 
-		const all = es.merge(control, postinst, postrm, prerm, desktops, appdata, workspaceMime, icon, bash_completion, zsh_completion, code);
+		const templates = gulp.src('resources/linux/debian/templates.template', { base: '.' })
+			.pipe(replace('@@NAME@@', product.applicationName))
+			.pipe(rename('DEBIAN/templates'));
+
+		const all = es.merge(control, templates, postinst, postrm, prerm, desktops, appdata, workspaceMime, icon, bash_completion, zsh_completion, code);
 
 		return all.pipe(vfs.dest(destination));
 	};

--- a/resources/linux/debian/postinst.template
+++ b/resources/linux/debian/postinst.template
@@ -35,20 +35,46 @@ if [ "@@NAME@@" != "code-oss" ]; then
 	eval $(apt-config shell APT_TRUSTED_PARTS Dir::Etc::trustedparts/d)
 	CODE_TRUSTED_PART=${APT_TRUSTED_PARTS}microsoft.gpg
 
+	RET=true
+	if [ -e '/usr/share/debconf/confmodule' ]; then
+		. /usr/share/debconf/confmodule
+		db_get @@NAME@@/add-microsoft-repo || true
+	fi
+
 	# Install repository source list
 	WRITE_SOURCE=0
-	if [ ! -f $CODE_SOURCE_PART ] && [ ! -f /etc/rpi-issue ]; then
-		# Write source list if it does not exist and we're not running on Raspberry Pi OS
-		WRITE_SOURCE=1
-	elif grep -Eq "http:\/\/packages\.microsoft\.com\/repos\/vscode" $CODE_SOURCE_PART; then
+	if [ "$RET" = false ]; then
+		# The user does not want to add the microsoft repository
+		WRITE_SOURCE=0
+	elif grep -q "http://packages.microsoft.com/repos/vscode" $CODE_SOURCE_PART; then
 		# Migrate from old repository
+		WRITE_SOURCE=2
+	elif grep -q "http://packages.microsoft.com/repos/code" $CODE_SOURCE_PART; then
+		# Migrate from old repository
+		WRITE_SOURCE=2
+	elif apt-cache policy | grep -q "https://packages.microsoft.com/repos/code"; then
+		# Skip following checks if the repo is already known to apt
+		WRITE_SOURCE=0
+	elif [ ! -f $CODE_SOURCE_PART ] && [ ! -f /etc/rpi-issue ]; then
+		# Write source list if it does not exist and we're not running on Raspberry Pi OS
 		WRITE_SOURCE=1
 	elif grep -q "# disabled on upgrade to" $CODE_SOURCE_PART; then
 		# Write source list if it was disabled by OS upgrade
 		WRITE_SOURCE=1
 	fi
 
-	if [ "$WRITE_SOURCE" -eq "1" ]; then
+	if [ "$WRITE_SOURCE" -eq "1" ] && [ -e '/usr/share/debconf/confmodule' ]; then
+		# Ask the user whether to actually write the source list
+		db_input high @@NAME@@/add-microsoft-repo || true
+		db_go || true
+
+		db_get @@NAME@@/add-microsoft-repo
+		if [ "$RET" = false ]; then
+			WRITE_SOURCE=0
+		fi
+	fi
+
+	if [ "$WRITE_SOURCE" -ne "0" ]; then
 		echo "### THIS FILE IS AUTOMATICALLY CONFIGURED ###
 # You may comment out this entry, but any other modifications may be lost.
 deb [arch=amd64,arm64,armhf] https://packages.microsoft.com/repos/code stable main" > $CODE_SOURCE_PART

--- a/resources/linux/debian/postrm.template
+++ b/resources/linux/debian/postrm.template
@@ -14,3 +14,22 @@ fi
 if hash update-mime-database 2>/dev/null; then
 	update-mime-database /usr/share/mime
 fi
+
+RET=true
+if [ -e '/usr/share/debconf/confmodule' ]; then
+	. /usr/share/debconf/confmodule
+	db_get @@NAME@@/add-microsoft-repo || true
+fi
+if [ "$RET" = "true" ]; then
+	eval $(apt-config shell APT_SOURCE_PARTS Dir::Etc::sourceparts/d)
+	CODE_SOURCE_PART=${APT_SOURCE_PARTS}vscode.list
+	rm -f $CODE_SOURCE_PART
+
+	eval $(apt-config shell APT_TRUSTED_PARTS Dir::Etc::trustedparts/d)
+	CODE_TRUSTED_PART=${APT_TRUSTED_PARTS}microsoft.gpg
+	rm -f $CODE_TRUSTED_PART
+fi
+
+if [ "$1" = "purge" ] && [ -e '/usr/share/debconf/confmodule' ]; then
+	db_purge
+fi

--- a/resources/linux/debian/templates.template
+++ b/resources/linux/debian/templates.template
@@ -1,0 +1,6 @@
+Template: @@NAME@@/add-microsoft-repo
+Type: boolean
+Default: true
+Description: Add Microsoft apt repository for Visual Studio Code?
+ The installer would like to add the Microsoft repository and signing
+ key to update VS Code through apt.


### PR DESCRIPTION
Currently, vscode.list is added to /etc/apt/sources.d/ whenever it doesn't exist. With this patch, the new behaviour is as follows:

1. If the user already has the Microsoft source file installed for apt, sources won't be added
2. If the user sets debconf-set-selections to set code/add-microsoft-repo to false, the sources won't be added
3. If sources might be added, the script checks whether it makes sense to (over)write them (i.e. the file doesn't exist, is old or has been disabled during some OS upgrade)
4. If is makes sense and the code/add-microsoft-repo is not set, the user is asked to cofirm, whether they actually want Microsoft sources to be installed (setting code/add-microsoft-repo to the selected value)
5. Only if it makes sense and the user agrees, the sources are installed

This change will mostly affect new users or those reinstalling vscode. Personally, I feel like the whole approach of automatically adding the repo is very invasive, and would prefer that it not be done at all. However, with this change, it is up to the user whether they want it to be installed or not. Since the default is set to true, users that install vscode in noninteractive environments get the current behavior. Existing users will either be asked once or never (depending on whther step 4 above gets triggered). New users will be asked unless they make a decision ahead of time using debconf-set-selections.

With this, #22145 and duplicates should be sufficiently addressed.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
