### PR TITLE
Never run cleared auxwindow timeouts

### DIFF
--- a/src/vs/workbench/browser/window.ts
+++ b/src/vs/workbench/browser/window.ts
@@ -133,9 +133,19 @@ export abstract class BaseWindow extends Disposable {
 					continue; // skip over hidden windows (but never over main window)
 				}
 
-				const handle = (window as any).vscodeOriginalSetTimeout.apply(this, [handlerFn, timeout, ...args]);
+				// we track didClear in case the browser does not properly clear the timeout
+				// this can happen for timeouts on unfocused windows
+				let didClear = false;
+
+				const handle = (window as any).vscodeOriginalSetTimeout.apply(this, [(...args: any[]) => {
+					if (didClear) {
+						return;
+					}
+					handlerFn(...args);
+				}, timeout, ...args]);
 
 				const timeoutDisposable = toDisposable(() => {
+					didClear = true;
 					(window as any).vscodeOriginalClearTimeout(handle);
 					timeoutDisposables.delete(timeoutDisposable);
 				});

--- a/src/vs/workbench/browser/window.ts
+++ b/src/vs/workbench/browser/window.ts
@@ -137,7 +137,7 @@ export abstract class BaseWindow extends Disposable {
 				// this can happen for timeouts on unfocused windows
 				let didClear = false;
 
-				const handle = (window as any).vscodeOriginalSetTimeout.apply(this, [(...args: any[]) => {
+				const handle = (window as any).vscodeOriginalSetTimeout.apply(this, [(...args: unknown[]) => {
 					if (didClear) {
 						return;
 					}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

The timeout attached to the aux-window is not always cleared even after calling `clearTimeout`.

This PR introduces a very simple fix that ensures that if `clearTimeout` has been called, then the handler associated with the timeout is never run.

## Background

When the user has at least one aux-window open, we attach any timeout to all windows to ensure that it runs. This means that we also need to clear the timeout from all windows. Unfortunately, it seems that in some circumstances, the timeout is *not* cleared from the aux window (while it is cleared from the main window), *despite `vscodeOriginalClearTimeout` being called on the aux window*. This causes a timeout that the calling code thought was cleared to still be called, which can result in bugs.

The proposed fix should have no negative consequences, and ensures that even if Electron is behaving in confusing ways, a cleared timeout will not run.


