### PR TITLE
# Add control for the indendation prefix

### DIFF
--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -4082,6 +4082,11 @@ export interface IInlineSuggestOptions {
 	 * Font family for inline suggestions.
 	 */
 	fontFamily?: string | 'default';
+
+	/**
+	 * Controls how indentation interacts with the full acceptance of inline suggest.
+	 */
+	suppressIndentationAcceptance?: boolean;
 }
 
 /**
@@ -4100,7 +4105,8 @@ class InlineEditorSuggest extends BaseEditorOption<EditorOption.inlineSuggest, I
 			showToolbar: 'onHover',
 			suppressSuggestions: false,
 			keepOnBlur: false,
-			fontFamily: 'default'
+			fontFamily: 'default',
+			suppressIndentationAcceptance: false,
 		};
 
 		super(
@@ -4132,6 +4138,11 @@ class InlineEditorSuggest extends BaseEditorOption<EditorOption.inlineSuggest, I
 					default: defaults.fontFamily,
 					description: nls.localize('inlineSuggest.fontFamily', "Controls the font family of the inline suggestions.")
 				},
+				'editor.inlineSuggest.suppressIndentationAcceptance': {
+					type: 'boolean',
+					default: defaults.suppressIndentationAcceptance,
+					description: nls.localize('inlineSuggest.suppressIndentationAcceptance', "Controls how indentation interacts with the full acceptance of inline suggest. If enabled, on full accept with inline suggestion prefixed by indentation, will accept the full available suggestion.")
+				}
 			}
 		);
 	}

--- a/src/vs/editor/contrib/inlineCompletions/browser/inlineCompletionContextKeys.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/inlineCompletionContextKeys.ts
@@ -10,6 +10,8 @@ import { InlineCompletionsModel } from 'vs/editor/contrib/inlineCompletions/brow
 import { RawContextKey, IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 import { Disposable } from 'vs/base/common/lifecycle';
 import { localize } from 'vs/nls';
+import { ICodeEditor } from 'vs/editor/browser/editorBrowser';
+import { EditorOption } from 'vs/editor/common/config/editorOptions';
 
 export class InlineCompletionContextKeys extends Disposable {
 	public static readonly inlineSuggestionVisible = new RawContextKey<boolean>('inlineSuggestionVisible', false, localize('inlineSuggestionVisible', "Whether an inline suggestion is visible"));
@@ -25,6 +27,7 @@ export class InlineCompletionContextKeys extends Disposable {
 	constructor(
 		private readonly contextKeyService: IContextKeyService,
 		private readonly model: IObservable<InlineCompletionsModel | undefined>,
+		private readonly editor: ICodeEditor,
 	) {
 		super();
 
@@ -44,6 +47,7 @@ export class InlineCompletionContextKeys extends Disposable {
 		this._register(autorun(reader => {
 			/** @description update context key: inlineCompletionSuggestsIndentation, inlineCompletionSuggestsIndentationLessThanTabSize */
 			const model = this.model.read(reader);
+			if(!this.editor.getOption(EditorOption.inlineSuggest).suppressIndentationAcceptance) return;
 
 			let startsWithIndentation = false;
 			let startsWithIndentationLessThanTabSize = true;

--- a/src/vs/editor/contrib/inlineCompletions/browser/inlineCompletionsController.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/inlineCompletionsController.ts
@@ -130,7 +130,7 @@ export class InlineCompletionsController extends Disposable {
 	) {
 		super();
 
-		this._register(new InlineCompletionContextKeys(this._contextKeyService, this.model));
+		this._register(new InlineCompletionContextKeys(this._contextKeyService, this.model, this.editor));
 
 		this._register(reactToChange(this._editorObs.onDidType, (_value, _changes) => {
 			if (this._enabled.get()) {

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -4555,6 +4555,10 @@ declare namespace monaco.editor {
 		 * Font family for inline suggestions.
 		 */
 		fontFamily?: string | 'default';
+		/**
+		 * Controls how indentation interacts with the full acceptance of inline suggest.
+		 */
+		suppressIndentationAcceptance?: boolean;
 	}
 
 	export interface IInlineEditOptions {


### PR DESCRIPTION
Adds setting to control whether Tab should accept indentation or the full completion when completion is prefixed by indentation.

closes [#206811](https://github.com/microsoft/vscode/issues/206811)