### PR TITLE
Revert "reduce impact of memory leaks related to editor"

### DIFF
--- a/src/vs/base/browser/dom.ts
+++ b/src/vs/base/browser/dom.ts
@@ -129,16 +129,6 @@ export function clearNode(node: HTMLElement): void {
 	}
 }
 
-
-export function clearNodeRecursively(domNode: ChildNode) {
-	while (domNode.firstChild) {
-		const element = domNode.firstChild;
-		element.remove();
-		clearNodeRecursively(element);
-	}
-}
-
-
 class DomListener implements IDisposable {
 
 	private _handler: (e: any) => void;

--- a/src/vs/editor/browser/view.ts
+++ b/src/vs/editor/browser/view.ts
@@ -399,14 +399,6 @@ export class View extends ViewEventHandler {
 		}
 
 		super.dispose();
-
-		// See https://github.com/microsoft/vscode/pull/219297
-		// Reduces the impact of detached dom node memory leaks
-		// E.g when a memory leak occurs in a child component
-		// of the editor (e.g. Minimap, GlyphMarginWidgets,...)
-		// the editor dom (linked to the child dom) should not be
-		// leaked as well.
-		dom.clearNodeRecursively(this.domNode.domNode);
 	}
 
 	private _scheduleRender(): void {


### PR DESCRIPTION
Fixes #221356
Reverts https://github.com/microsoft/vscode/pull/219297

FYI @SimonSiefke 

This is a tricky bug. With https://github.com/microsoft/vscode/pull/219297, the view would recursively clear its root dom element at the end of disposing it, as not doing this seemed to have caused leaks.
It turns out, that many contributions put their root dom element into the view (e.g. by registered an overlay widget), which then would have been cleared recursively when the view gets disposed (e.g. when someone does editor.setModel(null)).
This then explodes when the contribution puts its root dom element into the new view (when a new model is attached), as the dom element is still empty.

I think the editor should remove all the widgets from the view dom node when the view is destroyed.