### PR TITLE
fix: restore VSCODE_CWD fix when resolving current working directory

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -6,6 +6,13 @@
 //@ts-check
 'use strict';
 
+// Delete `VSCODE_CWD` very early. We have seen
+// reports where `code .` would use the wrong
+// current working directory due to our variable
+// somehow escaping to the parent shell
+// (https://github.com/microsoft/vscode/issues/126399)
+delete process.env['VSCODE_CWD'];
+
 // ESM-comment-begin
 const bootstrap = require('./bootstrap');
 const bootstrapNode = require('./bootstrap-node');
@@ -24,13 +31,6 @@ const product = require('./bootstrap-meta').product;
 //
 // const __dirname = path.dirname(fileURLToPath(import.meta.url));
 // ESM-uncomment-end
-
-// Delete `VSCODE_CWD` very early. We have seen
-// reports where `code .` would use the wrong
-// current working directory due to our variable
-// somehow escaping to the parent shell
-// (https://github.com/microsoft/vscode/issues/126399)
-delete process.env['VSCODE_CWD'];
 
 async function start() {
 


### PR DESCRIPTION
Regressed in https://github.com/microsoft/vscode/commit/16654e61265ca89e53612bb7a61f89f4e99aeb3c#diff-a3751a8ca1ab5bdf5d4bb6b4c3861d9a81205bc01b080e57301090b6e8b34165

/cc @bpasero 