### PR TITLE
Revert smaller badge size due to progress indicator

### DIFF
--- a/src/vs/workbench/browser/parts/media/paneCompositePart.css
+++ b/src/vs/workbench/browser/parts/media/paneCompositePart.css
@@ -225,9 +225,9 @@
 	right: 0px;
 	font-size: 9px;
 	font-weight: 600;
-	min-width: 12px;
-	height: 12px;
-	line-height: 12px;
+	min-width: 13px;
+	height: 13px;
+	line-height: 13px;
 	padding: 0 2px;
 	border-radius: 16px;
 	text-align: center;


### PR DESCRIPTION
This pull request reverts the changes made to the badge size in order to accommodate the progress indicator. The previous size was causing alignment issues, so the badge size has been reverted back to its original dimensions.