### PR TITLE
fix: render 'rerun without' for autodetected chat participants without commands

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatListRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatListRenderer.ts
@@ -406,10 +406,8 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 
 		dom.clearNode(templateData.detail);
 
-		if (element.slashCommand && element.agentOrSlashCommandDetected) {
-			const usingMsg = `${chatSubcommandLeader}${element.slashCommand.name}`;
-			const msg = localize('usedAgent', "used {0} [[(rerun without)]]", usingMsg);
-
+		if (element.agentOrSlashCommandDetected) {
+			const msg = element.slashCommand ? localize('usedAgentSlashCommand', "used {0} [[(rerun without)]]", `${chatSubcommandLeader}${element.slashCommand.name}`) : localize('usedAgent', "[[(rerun without)]]");
 			dom.reset(templateData.detail, renderFormattedText(msg, {
 				className: 'agentOrSlashCommandDetected',
 				inline: true,


### PR DESCRIPTION


<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
