### PR TITLE
Remove package.json schema descriptions

### DIFF
--- a/extensions/css-language-features/schemas/package.schema.json
+++ b/extensions/css-language-features/schemas/package.schema.json
@@ -1,6 +1,5 @@
 {
 	"$schema": "http://json-schema.org/draft-07/schema#",
-	"title": "CSS contributions to package.json",
 	"type": "object",
 	"properties": {
 		"contributes": {

--- a/extensions/html-language-features/schemas/package.schema.json
+++ b/extensions/html-language-features/schemas/package.schema.json
@@ -1,6 +1,5 @@
 {
 	"$schema": "http://json-schema.org/draft-07/schema#",
-	"title": "HTML contributions to package.json",
 	"type": "object",
 	"properties": {
 		"contributes": {

--- a/extensions/markdown-language-features/schemas/package.schema.json
+++ b/extensions/markdown-language-features/schemas/package.schema.json
@@ -1,6 +1,5 @@
 {
 	"$schema": "http://json-schema.org/draft-07/schema#",
-	"title": "Markdown contributions to package.json",
 	"type": "object",
 	"properties": {
 		"contributes": {

--- a/extensions/typescript-language-features/schemas/package.schema.json
+++ b/extensions/typescript-language-features/schemas/package.schema.json
@@ -1,6 +1,5 @@
 {
 	"$schema": "http://json-schema.org/draft-07/schema#",
-	"title": "TypeScript contributions to package.json",
 	"type": "object",
 	"properties": {
 		"contributes": {


### PR DESCRIPTION
These labels then show up when hovering on the opening bracket in a package.json (All package.json schemas are merged)
