### PR TITLE
Remove close secondary side bar action when activity bar is at the top

### DIFF
--- a/src/vs/workbench/browser/parts/auxiliarybar/auxiliaryBarPart.ts
+++ b/src/vs/workbench/browser/parts/auxiliarybar/auxiliaryBarPart.ts
@@ -240,14 +240,6 @@ export class AuxiliaryBarPart extends AbstractPaneCompositePart {
 		return headerArea;
 	}
 
-	protected override getToolbarWidth(): number {
-		if (this.getCompositeBarPosition() === CompositeBarPosition.TOP) {
-			return 22;
-		}
-
-		return super.getToolbarWidth();
-	}
-
 	private headerActionViewItemProvider(action: IAction, options: IActionViewItemOptions): IActionViewItem | undefined {
 		if (action.id === ToggleAuxiliaryBarAction.ID) {
 			return this.instantiationService.createInstance(ActionViewItem, undefined, action, options);

--- a/src/vs/workbench/browser/parts/panel/panelActions.ts
+++ b/src/vs/workbench/browser/parts/panel/panelActions.ts
@@ -353,10 +353,6 @@ registerAction2(class extends Action2 {
 				group: 'navigation',
 				order: 2,
 				when: ContextKeyExpr.notEquals(`config.${LayoutSettings.ACTIVITY_BAR_LOCATION}`, ActivityBarPosition.TOP)
-			}, {
-				id: MenuId.AuxiliaryBarHeader,
-				group: 'navigation',
-				when: ContextKeyExpr.equals(`config.${LayoutSettings.ACTIVITY_BAR_LOCATION}`, ActivityBarPosition.TOP)
 			}]
 		});
 	}


### PR DESCRIPTION
This pull request removes the close secondary side bar action when the activity bar is positioned at the top. This change ensures a consistent user experience when the activity bar is at the top and removes unnecessary clutter from the UI.

fixes [#221129](https://github.com/microsoft/vscode/issues/221129)