### PR TITLE
fix: fire `onDidChangeContentHeight` when attaching context

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
@@ -347,7 +347,11 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		}
 	}
 
-	attachContext(contentReferences: IChatRequestVariableEntry[]): void {
+	attachContext(overwrite: boolean, ...contentReferences: IChatRequestVariableEntry[]): void {
+		if (overwrite) {
+			this._attachedContext.clear();
+		}
+
 		if (contentReferences.length > 0) {
 			for (const reference of contentReferences) {
 				this._attachedContext.add(reference);
@@ -489,6 +493,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 	}
 
 	private initAttachedContext(container: HTMLElement) {
+		const oldHeight = container.offsetHeight;
 		dom.clearNode(container);
 		this.attachedContextDisposables.clear();
 		dom.setVisibility(Boolean(this.attachedContext.size), this.attachedContextContainer);
@@ -547,6 +552,10 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 			});
 			this.attachedContextDisposables.add(disp);
 		});
+
+		if (oldHeight !== container.offsetHeight) {
+			this._onDidChangeHeight.fire();
+		}
 	}
 
 	async renderFollowups(items: IChatFollowup[] | undefined, response: IChatResponseViewModel | undefined): Promise<void> {

--- a/src/vs/workbench/contrib/chat/browser/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatWidget.ts
@@ -792,14 +792,7 @@ export class ChatWidget extends Disposable implements IChatWidget {
 
 
 	setContext(overwrite: boolean, ...contentReferences: IChatRequestVariableEntry[]) {
-		if (overwrite) {
-			this.inputPart.clearContext();
-		}
-		this.inputPart.attachContext(contentReferences);
-
-		if (this.bodyDimension) {
-			this.layout(this.bodyDimension.height, this.bodyDimension.width);
-		}
+		this.inputPart.attachContext(overwrite, ...contentReferences);
 	}
 
 	getCodeBlockInfosForResponse(response: IChatResponseViewModel): IChatCodeBlockInfo[] {

--- a/src/vs/workbench/contrib/chat/browser/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/media/chat.css
@@ -534,6 +534,7 @@
 .interactive-session .chat-attached-context .chat-attached-context-attachment .monaco-icon-label .monaco-button.codicon.codicon-close,
 .interactive-session .chat-attached-context .chat-attached-context-attachment .monaco-button.codicon.codicon-close {
 	color: var(--vscode-descriptionForeground);
+	cursor: pointer;
 }
 
 .interactive-session .chat-attached-context .chat-attached-context-attachment .monaco-icon-label .codicon {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
Fix https://github.com/microsoft/vscode/issues/221385

Also use `cursor: pointer` for clear button