### PR TITLE
reduce impact of memory leaks related to editor (second try)

### DIFF
--- a/src/vs/editor/browser/controller/textAreaHandler.ts
+++ b/src/vs/editor/browser/controller/textAreaHandler.ts
@@ -487,6 +487,11 @@ export class TextAreaHandler extends ViewPart {
 		super.dispose();
 	}
 
+	public override disposeDomNodes(): void {
+		this.textArea.domNode.remove();
+		this.textAreaCover.domNode.remove();
+	}
+
 	private _getAndroidWordAtPosition(position: Position): [string, number] {
 		const ANDROID_WORD_SEPARATORS = '`~!@#$%^&*()-=+[{]}\\|;:",.<>/?';
 		const lineContent = this._context.viewModel.getLineContent(position.lineNumber);

--- a/src/vs/editor/browser/view/viewOverlays.ts
+++ b/src/vs/editor/browser/view/viewOverlays.ts
@@ -63,6 +63,10 @@ export class ViewOverlays extends ViewPart implements IVisibleLinesHost<ViewOver
 		this._dynamicOverlays = [];
 	}
 
+	override disposeDomNodes(): void {
+		this.domNode.domNode.remove();
+	}
+
 	public getDomNode(): FastDomNode<HTMLElement> {
 		return this.domNode;
 	}

--- a/src/vs/editor/browser/view/viewPart.ts
+++ b/src/vs/editor/browser/view/viewPart.ts
@@ -27,6 +27,17 @@ export abstract class ViewPart extends ViewEventHandler {
 	public abstract prepareRender(ctx: RenderingContext): void;
 	public abstract render(ctx: RestrictedRenderingContext): void;
 
+
+	/**
+	 * Dispose dom nodes to reduce the impact of detached
+	 * dom node memory leaks. E.g when a memory leak occurs
+	 * in a child component of the editor (e.g. Minimap,
+	 * GlyphMarginWidgets,...) the editor dom (linked to
+	 * the child dom) should not be leaked as well.
+	 *
+	 * See also https://github.com/microsoft/vscode/pull/221499
+	 *
+	 */
 	public abstract disposeDomNodes(): void;
 }
 

--- a/src/vs/editor/browser/view/viewPart.ts
+++ b/src/vs/editor/browser/view/viewPart.ts
@@ -12,6 +12,7 @@ export abstract class ViewPart extends ViewEventHandler {
 
 	_context: ViewContext;
 
+
 	constructor(context: ViewContext) {
 		super();
 		this._context = context;
@@ -25,6 +26,8 @@ export abstract class ViewPart extends ViewEventHandler {
 
 	public abstract prepareRender(ctx: RenderingContext): void;
 	public abstract render(ctx: RestrictedRenderingContext): void;
+
+	public abstract disposeDomNodes(): void;
 }
 
 export const enum PartFingerprint {

--- a/src/vs/editor/browser/viewParts/blockDecorations/blockDecorations.ts
+++ b/src/vs/editor/browser/viewParts/blockDecorations/blockDecorations.ts
@@ -55,6 +55,10 @@ export class BlockDecorations extends ViewPart {
 		super.dispose();
 	}
 
+	public override disposeDomNodes(): void {
+		this.domNode.domNode.remove();
+	}
+
 	// --- begin event handlers
 
 	public override onConfigurationChanged(e: viewEvents.ViewConfigurationChangedEvent): boolean {

--- a/src/vs/editor/browser/viewParts/contentWidgets/contentWidgets.ts
+++ b/src/vs/editor/browser/viewParts/contentWidgets/contentWidgets.ts
@@ -46,6 +46,11 @@ export class ViewContentWidgets extends ViewPart {
 		this._widgets = {};
 	}
 
+
+	public override disposeDomNodes(): void {
+		this.domNode.domNode.remove();
+	}
+
 	// --- begin event handlers
 
 	public override onConfigurationChanged(e: viewEvents.ViewConfigurationChangedEvent): boolean {

--- a/src/vs/editor/browser/viewParts/editorScrollbar/editorScrollbar.ts
+++ b/src/vs/editor/browser/viewParts/editorScrollbar/editorScrollbar.ts
@@ -103,6 +103,10 @@ export class EditorScrollbar extends ViewPart {
 		super.dispose();
 	}
 
+	public override disposeDomNodes(): void {
+		this.scrollbarDomNode.domNode.remove();
+	}
+
 	private _setLayout(): void {
 		const options = this._context.configuration.options;
 		const layoutInfo = options.get(EditorOption.layoutInfo);

--- a/src/vs/editor/browser/viewParts/glyphMargin/glyphMargin.ts
+++ b/src/vs/editor/browser/viewParts/glyphMargin/glyphMargin.ts
@@ -162,6 +162,10 @@ export class GlyphMarginWidgets extends ViewPart {
 		super.dispose();
 	}
 
+	override disposeDomNodes(): void {
+		this.domNode.domNode.remove();
+	}
+
 	public getWidgets(): IWidgetData[] {
 		return Object.values(this._widgets);
 	}

--- a/src/vs/editor/browser/viewParts/lines/viewLines.ts
+++ b/src/vs/editor/browser/viewParts/lines/viewLines.ts
@@ -169,6 +169,10 @@ export class ViewLines extends ViewPart implements IVisibleLinesHost<ViewLine>, 
 		super.dispose();
 	}
 
+	public override disposeDomNodes(): void {
+		this.domNode.domNode.remove();
+	}
+
 	public getDomNode(): FastDomNode<HTMLElement> {
 		return this.domNode;
 	}

--- a/src/vs/editor/browser/viewParts/margin/margin.ts
+++ b/src/vs/editor/browser/viewParts/margin/margin.ts
@@ -50,6 +50,10 @@ export class Margin extends ViewPart {
 		super.dispose();
 	}
 
+	public override disposeDomNodes(): void {
+		this._domNode.domNode.remove();
+	}
+
 	public getDomNode(): FastDomNode<HTMLElement> {
 		return this._domNode;
 	}

--- a/src/vs/editor/browser/viewParts/minimap/minimap.ts
+++ b/src/vs/editor/browser/viewParts/minimap/minimap.ts
@@ -840,6 +840,10 @@ export class Minimap extends ViewPart implements IMinimapModel {
 		super.dispose();
 	}
 
+	public override disposeDomNodes(): void {
+		this._actual.getDomNode().domNode.remove();
+	}
+
 	public getDomNode(): FastDomNode<HTMLElement> {
 		return this._actual.getDomNode();
 	}
@@ -2192,4 +2196,3 @@ class ContiguousLineMap<T> {
 		return this._values[lineNumber - this._startLineNumber];
 	}
 }
-

--- a/src/vs/editor/browser/viewParts/overlayWidgets/overlayWidgets.ts
+++ b/src/vs/editor/browser/viewParts/overlayWidgets/overlayWidgets.ts
@@ -67,6 +67,10 @@ export class ViewOverlayWidgets extends ViewPart {
 		this._widgets = {};
 	}
 
+	public override disposeDomNodes(): void {
+		this._domNode.domNode.remove();
+	}
+
 	public getDomNode(): FastDomNode<HTMLElement> {
 		return this._domNode;
 	}

--- a/src/vs/editor/browser/viewParts/overviewRuler/decorationsOverviewRuler.ts
+++ b/src/vs/editor/browser/viewParts/overviewRuler/decorationsOverviewRuler.ts
@@ -270,6 +270,10 @@ export class DecorationsOverviewRuler extends ViewPart {
 		this._tokensColorTrackerListener.dispose();
 	}
 
+	public override disposeDomNodes(): void {
+		this._domNode.domNode.remove();
+	}
+
 	private _updateSettings(renderNow: boolean): boolean {
 		const newSettings = new Settings(this._context.configuration, this._context.theme);
 		if (this._settings && this._settings.equals(newSettings)) {

--- a/src/vs/editor/browser/viewParts/rulers/rulers.ts
+++ b/src/vs/editor/browser/viewParts/rulers/rulers.ts
@@ -34,6 +34,10 @@ export class Rulers extends ViewPart {
 		super.dispose();
 	}
 
+	public override disposeDomNodes(): void {
+		this.domNode.domNode.remove();
+	}
+
 	// --- begin event handlers
 
 	public override onConfigurationChanged(e: viewEvents.ViewConfigurationChangedEvent): boolean {

--- a/src/vs/editor/browser/viewParts/scrollDecoration/scrollDecoration.ts
+++ b/src/vs/editor/browser/viewParts/scrollDecoration/scrollDecoration.ts
@@ -39,6 +39,10 @@ export class ScrollDecorationViewPart extends ViewPart {
 		super.dispose();
 	}
 
+	public override disposeDomNodes(): void {
+		this._domNode.domNode.remove();
+	}
+
 	private _updateShouldShow(): boolean {
 		const newShouldShow = (this._useShadows && this._scrollTop > 0);
 		if (this._shouldShow !== newShouldShow) {

--- a/src/vs/editor/browser/viewParts/viewCursors/viewCursors.ts
+++ b/src/vs/editor/browser/viewParts/viewCursors/viewCursors.ts
@@ -87,6 +87,10 @@ export class ViewCursors extends ViewPart {
 		this._cursorFlatBlinkInterval.dispose();
 	}
 
+	public override disposeDomNodes(): void {
+		this._domNode.domNode.remove();
+	}
+
 	public getDomNode(): FastDomNode<HTMLElement> {
 		return this._domNode;
 	}

--- a/src/vs/editor/browser/viewParts/viewZones/viewZones.ts
+++ b/src/vs/editor/browser/viewParts/viewZones/viewZones.ts
@@ -72,6 +72,10 @@ export class ViewZones extends ViewPart {
 		this._zones = {};
 	}
 
+	public override disposeDomNodes(): void {
+		this.domNode.domNode.remove();
+	}
+
 	// ---- begin view event handlers
 
 	private _recomputeWhitespacesProps(): boolean {

--- a/src/vs/editor/browser/viewParts/viewZones/viewZones.ts
+++ b/src/vs/editor/browser/viewParts/viewZones/viewZones.ts
@@ -74,6 +74,7 @@ export class ViewZones extends ViewPart {
 
 	public override disposeDomNodes(): void {
 		this.domNode.domNode.remove();
+		this.marginDomNode.domNode.remove();
 	}
 
 	// ---- begin view event handlers


### PR DESCRIPTION
Same as #219297, but this time with a different implementation. 

---

## Different Implementation

From @hediet:

> It turns out, that many contributions put their root dom element into the view (e.g. by registered an overlay widget), which then would have been cleared recursively when the view gets disposed (e.g. when someone does editor.setModel(null)).
This then explodes when the contribution puts its root dom element into the new view (when a new model is attached), as the dom element is still empty.
> I think the editor should remove all the widgets from the view dom node when the view is destroyed.

Following this idea, I implemented an abstract `disposeDomNodes` function for the `ViewPart` class. Each subclass implements this method, removing it's attached dom node(s) from the editor. 

Example: 

```ts
// textAreaHandler.ts
public override disposeDomNodes(): void {
	this.textArea.domNode.remove();
	this.textAreaCover.domNode.remove();
}
```

## Number of Canvas Elements (before)

The number of when canvas elements when opening editors grows linearly to ~3400: 

![canvas-count](https://github.com/microsoft/vscode/assets/23744935/25fbe6d3-200a-4055-b5d7-7907d88fb945)

## Number of Canvas Elements (after)

The number of canvas elements stays constant at ~9:

![canvas-count](https://github.com/microsoft/vscode/assets/23744935/06d84e11-7fd8-4e3d-9d82-a8bd8f6092d2)


## Testing the editor

Make sure the editor still works expected (including find, hover, definition, minimap, breadcrumbs, breakpoints, ...) 
