### PR TITLE
fix: memory leak in SelectBoxList

### DIFF
--- a/src/vs/base/browser/ui/selectBox/selectBoxCustom.ts
+++ b/src/vs/base/browser/ui/selectBox/selectBoxCustom.ts
@@ -730,7 +730,7 @@ export class SelectBoxList extends Disposable implements ISelectBoxDelegate, ILi
 
 		this.listRenderer = new SelectListRenderer();
 
-		this.selectList = new List('SelectBoxCustom', this.selectDropDownListContainer, this, [this.listRenderer], {
+		this.selectList = this._register(new List('SelectBoxCustom', this.selectDropDownListContainer, this, [this.listRenderer], {
 			useShadows: false,
 			verticalScrollMode: ScrollbarVisibility.Visible,
 			keyboardSupport: false,
@@ -756,7 +756,7 @@ export class SelectBoxList extends Disposable implements ISelectBoxDelegate, ILi
 				getRole: () => isMacintosh ? '' : 'option',
 				getWidgetRole: () => 'listbox'
 			}
-		});
+		}));
 		if (this.selectBoxOptions.ariaLabel) {
 			this.selectList.ariaLabel = this.selectBoxOptions.ariaLabel;
 		}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fixes a memory leak in `SelectBoxList` by registering `this.selectList` to the disposable store. 

## Event listeners (before)

When opening and closing the select box in the output view 97 times, the number of event listeners increases by 194 or 388:

```json
{
  "eventListenersWithStackTrace": [
    {
      "type": "click",
      "description": "(e) => this.emitter.fire(e)",
      "objectId": "7028190583252114818.4.54457",
      "stack": [
        "listener (vscode/out/vs/base/browser/event.js:13:23)",
        "Object.onWillAddFirstListener (vscode/out/vs/base/browser/event.js:16:55)",
        "_event (vscode/out/vs/base/common/event.js:856:60)",
        "vscode/out/vs/base/common/event.js:102:73",
        "Object.onWillAddFirstListener (vscode/out/vs/base/common/event.js:155:32)",
        "_event (vscode/out/vs/base/common/event.js:856:60)",
        "vscode/out/vs/base/common/event.js:133:95",
        "Array.map (<anonymous>)",
        "vscode/out/vs/base/common/event.js:133:82",
        "new MouseController (vscode/out/vs/base/browser/ui/list/listWidget.js:573:86)",
        "List.createMouseController (vscode/out/vs/base/browser/ui/list/listWidget.js:1195:20)",
        "new List (vscode/out/vs/base/browser/ui/list/listWidget.js:1180:41)",
        "SelectBoxList.createSelectList (vscode/out/vs/base/browser/ui/selectBox/selectBoxCustom.js:576:31)",
        "SelectBoxList.showSelectDropDown (vscode/out/vs/base/browser/ui/selectBox/selectBoxCustom.js:354:18)",
        "HTMLSelectElement.<anonymous> (vscode/out/vs/base/browser/ui/selectBox/selectBoxCustom.js:166:26)"
      ],
      "count": 388,
      "originalStack": ["vscode/src/vs/base/browser/event.ts:40:14"],
      "originalName": null
    },
    {
      "type": "keydown",
      "description": "(e) => this.emitter.fire(e)",
      "objectId": "7028190583252114818.4.54455",
      "stack": [
        "listener (vscode/out/vs/base/browser/event.js:13:23)",
        "Object.onWillAddFirstListener (vscode/out/vs/base/browser/event.js:16:55)",
        "_event (vscode/out/vs/base/common/event.js:856:60)",
        "fn (vscode/out/vs/base/common/event.js:396:24)",
        "fn (vscode/out/vs/base/common/event.js:396:24)",
        "new DOMFocusController (vscode/out/vs/base/browser/ui/list/listWidget.js:513:13)",
        "new List (vscode/out/vs/base/browser/ui/list/listWidget.js:1170:34)",
        "SelectBoxList.createSelectList (vscode/out/vs/base/browser/ui/selectBox/selectBoxCustom.js:576:31)",
        "SelectBoxList.showSelectDropDown (vscode/out/vs/base/browser/ui/selectBox/selectBoxCustom.js:354:18)",
        "HTMLSelectElement.<anonymous> (vscode/out/vs/base/browser/ui/selectBox/selectBoxCustom.js:166:26)"
      ],
      "count": 194,
      "originalStack": ["vscode/src/vs/base/browser/event.ts:40:14"],
      "originalName": null
    },
    {
      "type": "auxclick",
      "description": "(e) => this.emitter.fire(e)",
      "objectId": "7028190583252114818.4.54459",
      "stack": [
        "listener (vscode/out/vs/base/browser/event.js:13:23)",
        "Object.onWillAddFirstListener (vscode/out/vs/base/browser/event.js:16:55)",
        "_event (vscode/out/vs/base/common/event.js:856:60)",
        "vscode/out/vs/base/common/event.js:102:73",
        "Object.onWillAddFirstListener (vscode/out/vs/base/common/event.js:155:32)",
        "_event (vscode/out/vs/base/common/event.js:856:60)",
        "vscode/out/vs/base/common/event.js:121:73",
        "Object.onWillAddFirstListener (vscode/out/vs/base/common/event.js:155:32)",
        "_event (vscode/out/vs/base/common/event.js:856:60)",
        "vscode/out/vs/base/common/event.js:133:95",
        "Array.map (<anonymous>)",
        "vscode/out/vs/base/common/event.js:133:82",
        "new MouseController (vscode/out/vs/base/browser/ui/list/listWidget.js:573:86)",
        "List.createMouseController (vscode/out/vs/base/browser/ui/list/listWidget.js:1195:20)",
        "new List (vscode/out/vs/base/browser/ui/list/listWidget.js:1180:41)",
        "SelectBoxList.createSelectList (vscode/out/vs/base/browser/ui/selectBox/selectBoxCustom.js:576:31)",
        "SelectBoxList.showSelectDropDown (vscode/out/vs/base/browser/ui/selectBox/selectBoxCustom.js:354:18)",
        "HTMLSelectElement.<anonymous> (vscode/out/vs/base/browser/ui/selectBox/selectBoxCustom.js:166:26)"
      ],
      "count": 194,
      "originalStack": ["vscode/src/vs/base/browser/event.ts:40:14"],
      "originalName": null
    }
  ]
}
```

## Event listeners (after)

The number of event listeners stays basically constant:

```json
{
  "eventListenersWithStackTrace": [
    {
      "type": "blur",
      "description": "(e)=>{\n                        this.onDOMEvent(e, false);\n                    }",
      "objectId": "-6731368636718759049.4.37375",
      "sourceMaps": [""],
      "stack": [
        "listener (vscode/out/vs/base/browser/ui/contextview/contextview.js:210:106)",
        "new DomListener (vscode/out/vs/base/browser/dom.js:516:24)",
        "addDisposableListener (vscode/out/vs/base/browser/dom.js:528:16)",
        "Object.addStandardDisposableListener (vscode/out/vs/base/browser/dom.js:547:16)",
        "vscode/out/vs/base/browser/ui/contextview/contextview.js:211:54",
        "Array.forEach (<anonymous>)",
        "ContextView.setContainer (vscode/out/vs/base/browser/ui/contextview/contextview.js:210:46)",
        "ContextViewService.showContextView (vscode/out/vs/platform/contextview/browser/contextViewService.js:59:30)",
        "SelectBoxList.showSelectDropDown (vscode/out/vs/base/browser/ui/selectBox/selectBoxCustom.js:360:38)",
        "HTMLSelectElement.<anonymous> (vscode/out/vs/base/browser/ui/selectBox/selectBoxCustom.js:192:26)"
      ],
      "count": 2
    },
    {
      "type": "-monaco-gesturesend",
      "description": "(e)=>{\n                e.preventDefault();\n                e.stopPropagation();\n                this._gestureInProgress = false;\n                this._slider.toggleClassName('active', false);\n            }",
      "objectId": "-6731368636718759049.4.37363",
      "sourceMaps": [""],
      "stack": [
        "listener (vscode/out/vs/editor/browser/viewParts/minimap/minimap.js:928:123)",
        "new DomListener (vscode/out/vs/base/browser/dom.js:516:24)",
        "addDisposableListener (vscode/out/vs/base/browser/dom.js:528:16)",
        "Object.addStandardDisposableListener (vscode/out/vs/base/browser/dom.js:547:16)",
        "new InnerMinimap (vscode/out/vs/editor/browser/viewParts/minimap/minimap.js:929:49)",
        "new Minimap (vscode/out/vs/editor/browser/viewParts/minimap/minimap.js:569:28)",
        "new View (vscode/out/vs/editor/browser/view.js:174:29)",
        "CodeEditorWidget._createView (vscode/out/vs/editor/browser/widget/codeEditor/codeEditorWidget.js:1545:26)",
        "CodeEditorWidget._attachModel (vscode/out/vs/editor/browser/widget/codeEditor/codeEditorWidget.js:1442:46)",
        "CodeEditorWidget.setModel (vscode/out/vs/editor/browser/widget/codeEditor/codeEditorWidget.js:457:22)",
        "OutputEditor.setInput (vscode/out/vs/workbench/browser/parts/editor/textResourceEditor.js:70:21)",
        "async OutputEditor.setInput (vscode/out/vs/workbench/contrib/output/browser/outputView.js:258:13)"
      ],
      "count": 1
    },
    {
      "type": "-monaco-gesturechange",
      "description": "(e)=>{\n                e.preventDefault();\n                e.stopPropagation();\n                if (this._lastRenderData && this._gestureInProgress) {\n                    this.scrollDueToTouchEvent(e);\n                }\n            }",
      "objectId": "-6731368636718759049.4.37361",
      "sourceMaps": [""],
      "stack": [
        "listener (vscode/out/vs/editor/browser/viewParts/minimap/minimap.js:919:119)",
        "new DomListener (vscode/out/vs/base/browser/dom.js:516:24)",
        "Object.addDisposableListener (vscode/out/vs/base/browser/dom.js:528:16)",
        "new InnerMinimap (vscode/out/vs/editor/browser/viewParts/minimap/minimap.js:920:50)",
        "new Minimap (vscode/out/vs/editor/browser/viewParts/minimap/minimap.js:569:28)",
        "new View (vscode/out/vs/editor/browser/view.js:174:29)",
        "CodeEditorWidget._createView (vscode/out/vs/editor/browser/widget/codeEditor/codeEditorWidget.js:1545:26)",
        "CodeEditorWidget._attachModel (vscode/out/vs/editor/browser/widget/codeEditor/codeEditorWidget.js:1442:46)",
        "CodeEditorWidget.setModel (vscode/out/vs/editor/browser/widget/codeEditor/codeEditorWidget.js:457:22)",
        "OutputEditor.setInput (vscode/out/vs/workbench/browser/parts/editor/textResourceEditor.js:70:21)",
        "async OutputEditor.setInput (vscode/out/vs/workbench/contrib/output/browser/outputView.js:258:13)"
      ],
      "count": 1
    }
  ]
}

```
