### PR TITLE
migrate `debug.autoExpandLazyVariables` to enum format, enable it by default for screen reader users

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/debug.contribution.ts
+++ b/src/vs/workbench/contrib/debug/browser/debug.contribution.ts
@@ -643,4 +643,3 @@ configurationRegistry.registerConfiguration({
 });
 
 AccessibleViewRegistry.register(new DebugAccessibleView());
-

--- a/src/vs/workbench/contrib/debug/browser/debug.contribution.ts
+++ b/src/vs/workbench/contrib/debug/browser/debug.contribution.ts
@@ -58,6 +58,7 @@ import { DisassemblyViewInput } from 'vs/workbench/contrib/debug/common/disassem
 import { COPY_NOTEBOOK_VARIABLE_VALUE_ID, COPY_NOTEBOOK_VARIABLE_VALUE_LABEL } from 'vs/workbench/contrib/notebook/browser/contrib/notebookVariables/notebookVariableCommands';
 import { launchSchemaId } from 'vs/workbench/services/configuration/common/configuration';
 import { LifecyclePhase } from 'vs/workbench/services/lifecycle/common/lifecycle';
+import './debugSettingMigration';
 
 const debugCategory = nls.localize('debugCategory', "Debug");
 registerColors();
@@ -618,9 +619,15 @@ configurationRegistry.registerConfiguration({
 			description: nls.localize('debug.disassemblyView.showSourceCode', "Show Source Code in Disassembly View.")
 		},
 		'debug.autoExpandLazyVariables': {
-			type: 'boolean',
-			default: false,
-			description: nls.localize('debug.autoExpandLazyVariables', "Automatically show values for variables that are lazily resolved by the debugger, such as getters.")
+			type: 'string',
+			enum: ['auto', 'on', 'off'],
+			default: 'auto',
+			enumDescriptions: [
+				nls.localize('debug.autoExpandLazyVariables.auto', "When in screen reader optimized mode, automatically expand lazy variables."),
+				nls.localize('debug.autoExpandLazyVariables.on', "Always automatically expand lazy variables."),
+				nls.localize('debug.autoExpandLazyVariables.off', "Never automatically expand lazy variables.")
+			],
+			description: nls.localize('debug.autoExpandLazyVariables', "Controls if variables, such as getters, are automatically resolved and expanded by the debugger.")
 		},
 		'debug.enableStatusBarColor': {
 			type: 'boolean',
@@ -636,3 +643,4 @@ configurationRegistry.registerConfiguration({
 });
 
 AccessibleViewRegistry.register(new DebugAccessibleView());
+

--- a/src/vs/workbench/contrib/debug/browser/debugSession.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugSession.ts
@@ -45,6 +45,7 @@ import { isDefined } from 'vs/base/common/types';
 import { ITestService } from 'vs/workbench/contrib/testing/common/testService';
 import { ITestResultService } from 'vs/workbench/contrib/testing/common/testResultService';
 import { LiveTestResult } from 'vs/workbench/contrib/testing/common/testResult';
+import { IAccessibilityService } from 'vs/platform/accessibility/common/accessibility';
 
 const TRIGGERED_BREAKPOINT_MAX_DELAY = 1500;
 
@@ -117,6 +118,7 @@ export class DebugSession implements IDebugSession, IDisposable {
 		@ILogService private readonly logService: ILogService,
 		@ITestService private readonly testService: ITestService,
 		@ITestResultService testResultService: ITestResultService,
+		@IAccessibilityService private readonly accessibilityService: IAccessibilityService,
 	) {
 		this._options = options || {};
 		this.parentSession = this._options.parentSession;
@@ -238,7 +240,9 @@ export class DebugSession implements IDebugSession, IDisposable {
 
 	get autoExpandLazyVariables(): boolean {
 		// This tiny helper avoids converting the entire debug model to use service injection
-		return this.configurationService.getValue<IDebugConfiguration>('debug').autoExpandLazyVariables;
+		const screenReaderOptimized = this.accessibilityService.isScreenReaderOptimized();
+		const value = this.configurationService.getValue<IDebugConfiguration>('debug').autoExpandLazyVariables;
+		return value === 'auto' && screenReaderOptimized || value === 'on';
 	}
 
 	setConfiguration(configuration: { resolved: IConfig; unresolved: IConfig | undefined }) {

--- a/src/vs/workbench/contrib/debug/browser/debugSettingMigration.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugSettingMigration.ts
@@ -1,0 +1,22 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import { Registry } from 'vs/platform/registry/common/platform';
+import { Extensions, IConfigurationMigrationRegistry } from 'vs/workbench/common/configuration';
+
+Registry.as<IConfigurationMigrationRegistry>(Extensions.ConfigurationMigration)
+	.registerConfigurationMigrations([{
+		key: 'debug.autoExpandLazyVariables',
+		migrateFn: (value: boolean) => {
+			let newValue: string | undefined;
+			if (value === true) {
+				newValue = 'on';
+			} else if (value === false) {
+				newValue = 'auto';
+			}
+			return [
+				['debug.autoExpandLazyVariables', { value: newValue }],
+			];
+		}
+	}]);

--- a/src/vs/workbench/contrib/debug/common/debug.ts
+++ b/src/vs/workbench/contrib/debug/common/debug.ts
@@ -792,7 +792,7 @@ export interface IDebugConfiguration {
 	disassemblyView: {
 		showSourceCode: boolean;
 	};
-	autoExpandLazyVariables: boolean;
+	autoExpandLazyVariables: 'auto' | 'off' | 'on';
 	enableStatusBarColor: boolean;
 	showVariableTypes: boolean;
 }

--- a/src/vs/workbench/contrib/debug/test/browser/callStack.test.ts
+++ b/src/vs/workbench/contrib/debug/test/browser/callStack.test.ts
@@ -10,6 +10,7 @@ import { Constants } from 'vs/base/common/uint';
 import { generateUuid } from 'vs/base/common/uuid';
 import { ensureNoDisposablesAreLeakedInTestSuite } from 'vs/base/test/common/utils';
 import { Range } from 'vs/editor/common/core/range';
+import { TestAccessibilityService } from 'vs/platform/accessibility/test/common/testAccessibilityService';
 import { TestConfigurationService } from 'vs/platform/configuration/test/common/testConfigurationService';
 import { TestInstantiationService } from 'vs/platform/instantiation/test/common/instantiationServiceMock';
 import { NullLogService } from 'vs/platform/log/common/log';
@@ -41,7 +42,7 @@ export function createTestSession(model: DebugModel, name = 'mockSession', optio
 				}
 			};
 		}
-	} as IDebugService, undefined!, undefined!, new TestConfigurationService({ debug: { console: { collapseIdenticalLines: true } } }), undefined!, mockWorkspaceContextService, undefined!, undefined!, undefined!, mockUriIdentityService, new TestInstantiationService(), undefined!, undefined!, new NullLogService(), undefined!, undefined!);
+	} as IDebugService, undefined!, undefined!, new TestConfigurationService({ debug: { console: { collapseIdenticalLines: true } } }), undefined!, mockWorkspaceContextService, undefined!, undefined!, undefined!, mockUriIdentityService, new TestInstantiationService(), undefined!, undefined!, new NullLogService(), undefined!, undefined!, new TestAccessibilityService());
 }
 
 function createTwoStackFrames(session: DebugSession): { firstStackFrame: StackFrame; secondStackFrame: StackFrame } {
@@ -445,7 +446,7 @@ suite('Debug - CallStack', () => {
 			override get state(): State {
 				return State.Stopped;
 			}
-		}(generateUuid(), { resolved: { name: 'stoppedSession', type: 'node', request: 'launch' }, unresolved: undefined }, undefined, model, undefined, undefined!, undefined!, undefined!, undefined!, undefined!, mockWorkspaceContextService, undefined!, undefined!, undefined!, mockUriIdentityService, new TestInstantiationService(), undefined!, undefined!, new NullLogService(), undefined!, undefined!);
+		}(generateUuid(), { resolved: { name: 'stoppedSession', type: 'node', request: 'launch' }, unresolved: undefined }, undefined, model, undefined, undefined!, undefined!, undefined!, undefined!, undefined!, mockWorkspaceContextService, undefined!, undefined!, undefined!, mockUriIdentityService, new TestInstantiationService(), undefined!, undefined!, new NullLogService(), undefined!, undefined!, new TestAccessibilityService());
 		disposables.add(session);
 
 		const runningSession = createTestSession(model);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
fix #221512

cc @roblourens 