### PR TITLE
fix off by one errors in debug accessible view navigation

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/debugAccessibleView.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugAccessibleView.ts
@@ -99,15 +99,12 @@ class DebugAccessibleViewProvider extends Disposable implements IAccessibleViewC
 		if (!dataSource) {
 			return;
 		}
-		let line = 0;
+		let line = 1;
 		const content: string[] = [];
 		for (const e of elements) {
 			content.push(e.toString().replace(/\n/g, ''));
 			this._elementPositionMap.set(e.getId(), new Position(line, 1));
 			line++;
-			if (e.sourceData) {
-				line++;
-			}
 			if (dataSource.hasChildren(e)) {
 				const childContent: string[] = [];
 				const children = await dataSource.getChildren(e);


### PR DESCRIPTION
cc @jooyoungseo, this should now work for elements and their children. we currently don't expand children of children in the accessible view, but this should be a good start. If that's something you think we should do, we can consider it in the future. I don't want to impact perf with this.

