### PR TITLE
Fixed Markdown preview stops updating restarting extension host

### DIFF
--- a/src/vs/workbench/contrib/webviewPanel/browser/webviewWorkbenchService.ts
+++ b/src/vs/workbench/contrib/webviewPanel/browser/webviewWorkbenchService.ts
@@ -193,7 +193,6 @@ class RevivalPool {
 
 	public reviveFor(reviver: WebviewResolver, token: CancellationToken) {
 		const toRevive = this._awaitingRevival.filter(({ input }) => canRevive(reviver, input));
-		this._awaitingRevival = this._awaitingRevival.filter(({ input }) => !canRevive(reviver, input));
 
 		for (const { input, promise: resolve, disposable } of toRevive) {
 			reviver.resolveWebview(input, token).then(x => resolve.complete(x), err => resolve.error(err)).finally(() => {


### PR DESCRIPTION
Fixes #209027 
Fixed Markdown preview stops updating restarting extension host

Steps to Run the code

- Open 2 markdown files
- Open markdown preview
- Switch focus between markdown files to see the preview update
- Restart the extension host (this happens frequently now that we support that when extensions update instead of a full window reload)
- Try switching focus between markdown files again
- preview updated
