### PR TITLE
testing: a second, better take on the call stack view for tests

### DIFF
--- a/src/vs/platform/actions/common/actions.ts
+++ b/src/vs/platform/actions/common/actions.ts
@@ -60,6 +60,7 @@ export class MenuId {
 	static readonly DebugWatchContext = new MenuId('DebugWatchContext');
 	static readonly DebugToolBar = new MenuId('DebugToolBar');
 	static readonly DebugToolBarStop = new MenuId('DebugToolBarStop');
+	static readonly DebugCallStackToolbar = new MenuId('DebugCallStackToolbar');
 	static readonly EditorContext = new MenuId('EditorContext');
 	static readonly SimpleEditorContext = new MenuId('SimpleEditorContext');
 	static readonly EditorContent = new MenuId('EditorContent');

--- a/src/vs/workbench/contrib/debug/browser/callStackEditorContribution.ts
+++ b/src/vs/workbench/contrib/debug/browser/callStackEditorContribution.ts
@@ -48,18 +48,27 @@ const FOCUSED_STACK_FRAME_MARGIN: IModelDecorationOptions = {
 		color: themeColorFromId(focusedStackFrameColor)
 	}
 };
-const TOP_STACK_FRAME_DECORATION: IModelDecorationOptions = {
+export const TOP_STACK_FRAME_DECORATION: IModelDecorationOptions = {
 	description: 'top-stack-frame-decoration',
 	isWholeLine: true,
 	className: 'debug-top-stack-frame-line',
 	stickiness
 };
-const FOCUSED_STACK_FRAME_DECORATION: IModelDecorationOptions = {
+export const FOCUSED_STACK_FRAME_DECORATION: IModelDecorationOptions = {
 	description: 'focused-stack-frame-decoration',
 	isWholeLine: true,
 	className: 'debug-focused-stack-frame-line',
 	stickiness
 };
+
+export const makeStackFrameColumnDecoration = (noCharactersBefore: boolean): IModelDecorationOptions => ({
+	description: 'top-stack-frame-inline-decoration',
+	before: {
+		content: '\uEB8B',
+		inlineClassName: noCharactersBefore ? 'debug-top-stack-frame-column start-of-line' : 'debug-top-stack-frame-column',
+		inlineClassNameAffectsLetterSpacing: true
+	},
+});
 
 export function createDecorationsForStackFrame(stackFrame: IStackFrame, isFocusedSession: boolean, noCharactersBefore: boolean): IModelDeltaDecoration[] {
 	// only show decorations for the currently focused thread.
@@ -85,14 +94,7 @@ export function createDecorationsForStackFrame(stackFrame: IStackFrame, isFocuse
 
 		if (stackFrame.range.startColumn > 1) {
 			result.push({
-				options: {
-					description: 'top-stack-frame-inline-decoration',
-					before: {
-						content: '\uEB8B',
-						inlineClassName: noCharactersBefore ? 'debug-top-stack-frame-column start-of-line' : 'debug-top-stack-frame-column',
-						inlineClassNameAffectsLetterSpacing: true
-					},
-				},
+				options: makeStackFrameColumnDecoration(noCharactersBefore),
 				range: columnUntilEOLRange
 			});
 		}

--- a/src/vs/workbench/contrib/debug/browser/callStackWidget.ts
+++ b/src/vs/workbench/contrib/debug/browser/callStackWidget.ts
@@ -1,0 +1,517 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as dom from 'vs/base/browser/dom';
+import { Button } from 'vs/base/browser/ui/button/button';
+import { IListRenderer, IListVirtualDelegate } from 'vs/base/browser/ui/list/list';
+import { IListAccessibilityProvider } from 'vs/base/browser/ui/list/listWidget';
+import { assertNever } from 'vs/base/common/assert';
+import { CancellationToken, CancellationTokenSource } from 'vs/base/common/cancellation';
+import { Codicon } from 'vs/base/common/codicons';
+import { Emitter, Event } from 'vs/base/common/event';
+import { Disposable, DisposableStore, toDisposable } from 'vs/base/common/lifecycle';
+import { autorun, derived, IObservable, ISettableObservable, observableValue } from 'vs/base/common/observable';
+import { Constants } from 'vs/base/common/uint';
+import { URI } from 'vs/base/common/uri';
+import 'vs/css!./media/callStackWidget';
+import { ICodeEditor } from 'vs/editor/browser/editorBrowser';
+import { CodeEditorWidget } from 'vs/editor/browser/widget/codeEditor/codeEditorWidget';
+import { EmbeddedCodeEditorWidget } from 'vs/editor/browser/widget/codeEditor/embeddedCodeEditorWidget';
+import { IEditorOptions } from 'vs/editor/common/config/editorOptions';
+import { Range } from 'vs/editor/common/core/range';
+import { Location } from 'vs/editor/common/languages';
+import { ITextModelService } from 'vs/editor/common/services/resolverService';
+import { localize, localize2 } from 'vs/nls';
+import { createActionViewItem } from 'vs/platform/actions/browser/menuEntryActionViewItem';
+import { MenuWorkbenchToolBar } from 'vs/platform/actions/browser/toolbar';
+import { Action2, MenuId, registerAction2 } from 'vs/platform/actions/common/actions';
+import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
+import { TextEditorSelectionRevealType } from 'vs/platform/editor/common/editor';
+import { IInstantiationService, ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
+import { ILabelService } from 'vs/platform/label/common/label';
+import { WorkbenchList } from 'vs/platform/list/browser/listService';
+import { INotificationService } from 'vs/platform/notification/common/notification';
+import { defaultButtonStyles } from 'vs/platform/theme/browser/defaultStyles';
+import { ResourceLabel } from 'vs/workbench/browser/labels';
+import { makeStackFrameColumnDecoration, TOP_STACK_FRAME_DECORATION } from 'vs/workbench/contrib/debug/browser/callStackEditorContribution';
+import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
+
+
+export class CallStackFrame {
+	constructor(
+		public readonly name: string,
+		public readonly source?: URI,
+		public readonly line = 1,
+		public readonly column = 1,
+	) { }
+}
+
+export class SkippedCallFrames {
+	constructor(
+		public readonly label: string,
+		public readonly load: (token: CancellationToken) => Promise<AnyStackFrame[]>,
+	) { }
+}
+
+export type AnyStackFrame = SkippedCallFrames | CallStackFrame;
+
+class WrappedCallStackFrame extends CallStackFrame {
+	public readonly editorHeight: ISettableObservable<number>;
+	public readonly collapsed = observableValue('WrappedCallStackFrame.collapsed', false);
+	public readonly height: IObservable<number>;
+
+	constructor(original: CallStackFrame, defaultLineHeight: number) {
+		super(original.name, original.source, original.line, original.column);
+		// the actual height will be updated when the editor is rendered, but
+		// estimate it initially to make sure the scroll is approximately correct
+		this.editorHeight = observableValue('WrappedCallStackFrame.editorHeight', defaultLineHeight * (LINES_AROUND * 2 + 1));
+		this.height = derived(reader => {
+			return this.collapsed.read(reader) ? HEADER_HEIGHT : HEADER_HEIGHT + this.editorHeight.read(reader);
+		});
+	}
+}
+
+type ListItem = WrappedCallStackFrame | SkippedCallFrames;
+
+const WIDGET_CLASS_NAME = 'multiCallStackWidget';
+
+/**
+ * A reusable widget that displays a call stack as a series of editors. Note
+ * that this both used in debug's exception widget as well as in the testing
+ * call stack view.
+ */
+export class CallStackWidget extends Disposable {
+	private readonly list: WorkbenchList<ListItem>;
+	private readonly layoutEmitter = this._register(new Emitter<void>());
+	private readonly currentFramesDs = this._register(new DisposableStore());
+	private cts?: CancellationTokenSource;
+
+	constructor(
+		container: HTMLElement,
+		containingEditor: ICodeEditor | undefined,
+		@IInstantiationService instantiationService: IInstantiationService,
+		@IConfigurationService private readonly configurationService: IConfigurationService,
+	) {
+		super();
+
+		container.classList.add(WIDGET_CLASS_NAME);
+		this._register(toDisposable(() => container.classList.remove(WIDGET_CLASS_NAME)));
+
+		this.list = this._register(instantiationService.createInstance(
+			WorkbenchList,
+			'TestResultStackWidget',
+			container,
+			new StackDelegate(),
+			[
+				instantiationService.createInstance(FrameCodeRenderer, containingEditor, this.layoutEmitter.event),
+				instantiationService.createInstance(MissingCodeRenderer),
+				instantiationService.createInstance(SkippedRenderer, (i) => this.loadFrame(i)),
+			],
+			{
+				horizontalScrolling: false,
+				multipleSelectionSupport: false,
+				accessibilityProvider: instantiationService.createInstance(StackAccessibilityProvider),
+			}
+		) as WorkbenchList<ListItem>);
+	}
+
+	/** Replaces the call frames display in the view. */
+	public setFrames(frames: AnyStackFrame[]): void {
+		// cancel any existing load
+		this.currentFramesDs.clear();
+		this.cts = new CancellationTokenSource();
+		this._register(toDisposable(() => this.cts!.dispose(true)));
+
+		this.list.splice(0, this.list.length, this.mapFrames(frames));
+	}
+
+	public layout(height?: number, width?: number): void {
+		this.list.layout(height, width);
+		this.layoutEmitter.fire();
+	}
+
+	private async loadFrame(replacing: SkippedCallFrames): Promise<void> {
+		if (!this.cts) {
+			return;
+		}
+
+		const frames = await replacing.load(this.cts.token);
+		if (this.cts.token.isCancellationRequested) {
+			return;
+		}
+
+		const index = this.list.indexOf(replacing);
+		this.list.splice(index, 1, this.mapFrames(frames));
+	}
+
+	private mapFrames(frames: AnyStackFrame[]): ListItem[] {
+		const result: ListItem[] = [];
+		const defaultLineHeight = this.configurationService.getValue<number>('editor.lineHeight');
+		for (const frame of frames) {
+			if (!(frame instanceof CallStackFrame)) {
+				result.push(frame);
+				continue;
+			}
+
+			const wrapped = new WrappedCallStackFrame(frame, defaultLineHeight);
+			result.push(wrapped);
+
+			this.currentFramesDs.add(autorun(reader => {
+				const height = wrapped.height.read(reader);
+				const idx = this.list.indexOf(wrapped);
+				if (idx !== -1) {
+					this.list.updateElementHeight(idx, height);
+				}
+			}));
+		}
+
+		return result;
+	}
+}
+
+class StackAccessibilityProvider implements IListAccessibilityProvider<ListItem> {
+	constructor(@ILabelService private readonly labelService: ILabelService) { }
+
+	getAriaLabel(e: ListItem): string | IObservable<string> | null {
+		if (e instanceof SkippedCallFrames) {
+			return e.label;
+		}
+
+		if (e instanceof CallStackFrame) {
+			if (e.source && e.line) {
+				return localize({
+					comment: ['{0} is an extension-defined label, then line number and filename'],
+					key: 'stackTraceLabel',
+				}, '{0}, line {1} in {2}', e.name, e.line, this.labelService.getUriLabel(e.source, { relative: true }));
+			}
+
+			return e.name;
+		}
+
+		assertNever(e);
+	}
+	getWidgetAriaLabel(): string {
+		return localize('stackTrace', 'Stack Trace');
+	}
+}
+
+class StackDelegate implements IListVirtualDelegate<ListItem> {
+	getHeight(element: ListItem): number {
+		if (element instanceof CallStackFrame) {
+			return element.height.get();
+		}
+		if (element instanceof SkippedCallFrames) {
+			return 50;
+		}
+
+		assertNever(element);
+	}
+
+	getTemplateId(element: ListItem): string {
+		if (element instanceof CallStackFrame) {
+			return element.source ? FrameCodeRenderer.templateId : MissingCodeRenderer.templateId;
+		}
+		if (element instanceof SkippedCallFrames) {
+			return SkippedRenderer.templateId;
+		}
+
+		assertNever(element);
+	}
+}
+
+interface IStackTemplateData {
+	container: HTMLElement;
+	editor: CodeEditorWidget;
+	label: ResourceLabel;
+	elements: ReturnType<typeof makeFrameElements>;
+	decorations: string[];
+	collapse: Button;
+	toolbar: MenuWorkbenchToolBar;
+	elementStore: DisposableStore;
+	templateStore: DisposableStore;
+}
+
+const editorOptions: IEditorOptions = {
+	scrollBeyondLastLine: false,
+	scrollbar: {
+		vertical: 'hidden',
+		horizontal: 'auto',
+		handleMouseWheel: false,
+		useShadows: false,
+	},
+	glyphMargin: false,
+	overviewRulerLanes: 0,
+	fixedOverflowWidgets: true,
+	overviewRulerBorder: false,
+	stickyScroll: { enabled: false },
+	minimap: { enabled: false },
+	readOnly: true,
+	wordWrap: 'off',
+};
+
+const makeFrameElements = () => dom.h('div.multiCallStackFrame', [
+	dom.h('div.header@header', [
+		dom.h('div.collapse-button@collapseButton'),
+		dom.h('div.title.show-file-icons@title'),
+		dom.h('div.actions@actions'),
+	]),
+
+	dom.h('div.editorParent', [
+		dom.h('div.editorContainer@editor'),
+	])
+]);
+
+const HEADER_HEIGHT = 40;
+const LINES_AROUND = 3;
+
+/** Renderer for a normal stack frame where code is available. */
+class FrameCodeRenderer implements IListRenderer<ListItem, IStackTemplateData> {
+	public static readonly templateId = 'f';
+
+	public readonly templateId = FrameCodeRenderer.templateId;
+
+	constructor(
+		private readonly containingEditor: ICodeEditor | undefined,
+		private readonly onLayout: Event<void>,
+		@ITextModelService private readonly modelService: ITextModelService,
+		@IInstantiationService private readonly instantiationService: IInstantiationService,
+	) { }
+
+	renderTemplate(container: HTMLElement): IStackTemplateData {
+		const containingEditor = this.containingEditor;
+		const elements = makeFrameElements();
+		container.appendChild(elements.root);
+
+		const templateStore = new DisposableStore();
+		templateStore.add(toDisposable(() => dom.clearNode(elements.root)));
+
+		const editor = containingEditor
+			? this.instantiationService.createInstance(
+				EmbeddedCodeEditorWidget,
+				elements.editor,
+				editorOptions,
+				{},
+				containingEditor,
+			)
+			: this.instantiationService.createInstance(
+				CodeEditorWidget,
+				elements.editor,
+				editorOptions,
+				{},
+			);
+
+		templateStore.add(editor);
+
+		const label = templateStore.add(this.instantiationService.createInstance(ResourceLabel, elements.title, {}));
+
+		const toolbar = templateStore.add(this.instantiationService.createInstance(MenuWorkbenchToolBar, elements.actions, MenuId.DebugCallStackToolbar, {
+			menuOptions: { shouldForwardArgs: true },
+			actionViewItemProvider: (action, options) => createActionViewItem(this.instantiationService, action, options),
+		}));
+
+		const collapse = templateStore.add(new Button(elements.collapseButton, {}));
+
+		return {
+			editor,
+			container,
+			decorations: [],
+			elements,
+			label,
+			toolbar,
+			collapse,
+			elementStore: templateStore.add(new DisposableStore()),
+			templateStore,
+		};
+	}
+
+	renderElement(element: ListItem, index: number, template: IStackTemplateData, height: number | undefined): void {
+		const { elementStore, editor } = template;
+		elementStore.clear();
+
+		const item = element as WrappedCallStackFrame;
+		const uri = item.source!;
+
+		this.setupCollapseButton(item, template);
+		this.setupEditorLayout(item, template);
+		template.label.element.setFile(uri);
+
+		const cts = new CancellationTokenSource();
+		elementStore.add(toDisposable(() => cts.dispose(true)));
+		this.modelService.createModelReference(uri).then(reference => {
+			if (cts.token.isCancellationRequested) {
+				return reference.dispose();
+			}
+
+			elementStore.add(reference);
+			editor.setModel(reference.object.textEditorModel);
+			this.setupEditorAfterModel(item, template);
+		});
+	}
+
+	private setupEditorLayout(item: WrappedCallStackFrame, { elementStore, container, editor }: IStackTemplateData) {
+		const layout = (height = item.editorHeight.get()) =>
+			editor.layout({ width: container.clientWidth, height });
+		elementStore.add(this.onLayout(() => layout()));
+		elementStore.add(autorun(reader => layout(item.editorHeight.read(reader))));
+	}
+
+	private setupCollapseButton(item: WrappedCallStackFrame, { elementStore, elements, collapse, editor }: IStackTemplateData) {
+		elementStore.add(autorun(reader => {
+			collapse.element.className = '';
+			collapse.icon = item.collapsed.read(reader) ? Codicon.chevronRight : Codicon.chevronDown;
+			elements.root.classList.toggle('collapsed', item.collapsed.get());
+		}));
+		elementStore.add(collapse.onDidClick(() => {
+			item.collapsed.set(!item.collapsed.get(), undefined);
+		}));
+	}
+
+	private setupEditorAfterModel(item: WrappedCallStackFrame, template: IStackTemplateData): void {
+		const range = Range.fromPositions({
+			column: item.column ?? 1,
+			lineNumber: item.line ?? 1,
+		});
+
+		template.toolbar.context = { uri: item.source, range };
+
+		template.editor.setHiddenAreas([
+			Range.fromPositions({ lineNumber: 1, column: 1 }, { lineNumber: range.startLineNumber - LINES_AROUND, column: 1 }),
+			Range.fromPositions({ lineNumber: range.startLineNumber + LINES_AROUND, column: 1 }, { lineNumber: Constants.MAX_SAFE_SMALL_INTEGER, column: 1 }),
+		]);
+
+		template.editor.revealRangeInCenter(range);
+
+		const updateEditorHeight = () => {
+			item.editorHeight.set(template.editor.getScrollHeight(), undefined);
+		};
+
+		template.elementStore.add(template.editor.onDidContentSizeChange(updateEditorHeight));
+		updateEditorHeight();
+
+		template.editor.changeDecorations(accessor => {
+			for (const d of template.decorations) {
+				accessor.removeDecoration(d);
+			}
+			template.decorations.length = 0;
+
+			const beforeRange = range.setStartPosition(range.startLineNumber, 1);
+			const hasCharactersBefore = !!template.editor.getModel()?.getValueInRange(beforeRange).trim();
+			const decoRange = range.setEndPosition(range.startLineNumber, Constants.MAX_SAFE_SMALL_INTEGER);
+
+			template.decorations.push(accessor.addDecoration(
+				decoRange,
+				makeStackFrameColumnDecoration(!hasCharactersBefore),
+			));
+			template.decorations.push(accessor.addDecoration(
+				decoRange,
+				TOP_STACK_FRAME_DECORATION,
+			));
+		});
+	}
+
+	disposeElement(element: ListItem, index: number, templateData: IStackTemplateData, height: number | undefined): void {
+		templateData.elementStore.clear();
+	}
+
+	disposeTemplate(templateData: IStackTemplateData): void {
+		templateData.templateStore.dispose();
+	}
+}
+
+interface IMissingTemplateData {
+	container: HTMLElement;
+}
+
+/** Renderer for a call frame that's missing a URI */
+class MissingCodeRenderer implements IListRenderer<ListItem, IMissingTemplateData> {
+	public static readonly templateId = 'm';
+	public readonly templateId = MissingCodeRenderer.templateId;
+
+	renderTemplate(container: HTMLElement): IMissingTemplateData {
+		return { container };
+	}
+
+	renderElement(element: ListItem, index: number, templateData: IMissingTemplateData, height: number | undefined): void {
+		templateData.container.innerText = (element as CallStackFrame).name;
+	}
+
+	disposeTemplate(templateData: IMissingTemplateData): void {
+		dom.clearNode(templateData.container);
+	}
+}
+
+interface ISkippedTemplateData {
+	button: Button;
+	current?: SkippedCallFrames;
+	store: DisposableStore;
+}
+
+/** Renderer for a button to load more call frames */
+class SkippedRenderer implements IListRenderer<ListItem, ISkippedTemplateData> {
+	public static readonly templateId = 's';
+	public readonly templateId = SkippedRenderer.templateId;
+
+	constructor(
+		private readonly loadFrames: (fromItem: SkippedCallFrames) => Promise<void>,
+		@INotificationService private readonly notificationService: INotificationService,
+	) { }
+
+	renderTemplate(container: HTMLElement): ISkippedTemplateData {
+		const store = new DisposableStore();
+		const button = new Button(container, { title: '', ...defaultButtonStyles });
+		const data: ISkippedTemplateData = { button, store };
+
+		store.add(button);
+		store.add(button.onDidClick(() => {
+			if (!data.current || !button.enabled) {
+				return;
+			}
+
+			button.enabled = false;
+			this.loadFrames(data.current).catch(e => {
+				this.notificationService.error(localize('failedToLoadFrames', 'Failed to load stack frames: {0}', e.message));
+			});
+		}));
+
+		return data;
+	}
+
+	renderElement(element: ListItem, index: number, templateData: ISkippedTemplateData, height: number | undefined): void {
+		const cast = element as SkippedCallFrames;
+		templateData.button.enabled = true;
+		templateData.button.label = cast.label;
+		templateData.current = cast;
+	}
+
+	disposeTemplate(templateData: ISkippedTemplateData): void {
+		templateData.store.dispose();
+	}
+}
+
+registerAction2(class extends Action2 {
+	constructor() {
+		super({
+			id: 'callStackWidget.goToFile',
+			title: localize2('goToFile', 'Open File'),
+			icon: Codicon.goToFile,
+			menu: {
+				id: MenuId.DebugCallStackToolbar,
+				order: 22,
+				group: 'navigation',
+			},
+		});
+	}
+
+	async run(accessor: ServicesAccessor, { uri, range }: Location): Promise<void> {
+		const editorService = accessor.get(IEditorService);
+		await editorService.openEditor({
+			resource: uri,
+			options: {
+				selection: range,
+				selectionRevealType: TextEditorSelectionRevealType.CenterIfOutsideViewport,
+			},
+		});
+	}
+});

--- a/src/vs/workbench/contrib/debug/browser/media/callStackWidget.css
+++ b/src/vs/workbench/contrib/debug/browser/media/callStackWidget.css
@@ -1,0 +1,40 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+.multiCallStackFrame {
+	margin-bottom: 8px;
+
+	.header {
+		display: flex;
+		align-items: center;
+		height: 32px;
+		background: var(--vscode-multiDiffEditor-headerBackground);
+		border-top: 1px solid var(--vscode-multiDiffEditor-border);
+		color: var(--vscode-foreground);
+		padding: 0 5px;
+	}
+
+	.title {
+		flex-grow: 1;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	&.collapsed {
+		.header {
+			border-bottom: 1px solid var(--vscode-multiDiffEditor-border);
+		}
+
+		.editorParent {
+			display: none;
+		}
+	}
+
+	.editorParent {
+		padding-left: 3px;
+		background: var(--vscode-editor-background);
+	}
+}

--- a/src/vs/workbench/contrib/testing/browser/media/testing.css
+++ b/src/vs/workbench/contrib/testing/browser/media/testing.css
@@ -225,6 +225,23 @@
 	box-sizing: border-box;
 }
 
+.test-output-peek-view {
+	display: flex;
+	align-items: stretch;
+
+	.test-output-stack-toggle {
+		&.visible {
+			display: none;
+		}
+
+		a {
+			padding: 2px;
+			height: 100%;
+			cursor: pointer;
+		}
+	}
+}
+
 .monaco-editor .zone-widget.test-output-peek .monaco-editor .monaco-editor-background,
 .monaco-editor .zone-widget.test-output-peek .monaco-editor .inputarea.ime-input,
 .monaco-editor .zone-widget.test-output-peek .test-output-peek-message-container {
@@ -315,44 +332,6 @@
 
 .test-output-call-stack {
 	height: 100%;
-
-	.monaco-list-row {
-		padding: 0 3px 0 8px;
-		display: flex;
-		gap: 3px;
-
-		.location, .label {
-			white-space: nowrap;
-		}
-
-		.label {
-			flex-grow: 1;
-		}
-
-		.location {
-			/*Use direction so the source shows elipses on the left*/
-			direction: rtl;
-			overflow: hidden;
-			text-overflow: ellipsis;
-			font-size: 0.9em;
-		}
-
-		&.no-source .label {
-			opacity: 0.7;
-		}
-
-		&:hover {
-			.label {
-				overflow: hidden;
-				text-overflow: ellipsis;
-			}
-
-			.location {
-				overflow: visible;
-				text-overflow: unset;
-			}
-		}
-	}
 }
 
 /** -- filter  */

--- a/src/vs/workbench/contrib/testing/browser/testResultsView/testMessageStack.ts
+++ b/src/vs/workbench/contrib/testing/browser/testResultsView/testMessageStack.ts
@@ -4,61 +4,34 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as dom from 'vs/base/browser/dom';
-import { IListRenderer, IListVirtualDelegate } from 'vs/base/browser/ui/list/list';
 import { Emitter } from 'vs/base/common/event';
-import { Disposable, IDisposable } from 'vs/base/common/lifecycle';
-import { Range } from 'vs/editor/common/core/range';
-import { localize } from 'vs/nls';
+import { Disposable } from 'vs/base/common/lifecycle';
+import { ICodeEditor } from 'vs/editor/browser/editorBrowser';
 import { MenuId } from 'vs/platform/actions/common/actions';
 import { IContextMenuService } from 'vs/platform/contextview/browser/contextView';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
-import { ILabelService } from 'vs/platform/label/common/label';
-import { WorkbenchList } from 'vs/platform/list/browser/listService';
+import { CallStackFrame, CallStackWidget } from 'vs/workbench/contrib/debug/browser/callStackWidget';
 import { ITestMessageStackFrame } from 'vs/workbench/contrib/testing/common/testTypes';
-import { IEditorService, SIDE_GROUP } from 'vs/workbench/services/editor/common/editorService';
-
-const stackItemDelegate: IListVirtualDelegate<void> = {
-	getHeight: () => 22,
-	getTemplateId: () => 's',
-};
 
 export class TestResultStackWidget extends Disposable {
-	private readonly list: WorkbenchList<ITestMessageStackFrame>;
+	private readonly widget: CallStackWidget;
 	private readonly changeStackFrameEmitter = this._register(new Emitter<ITestMessageStackFrame>());
 
 	public readonly onDidChangeStackFrame = this.changeStackFrameEmitter.event;
 
 	constructor(
 		private readonly container: HTMLElement,
+		containingEditor: ICodeEditor | undefined,
 		@IInstantiationService instantiationService: IInstantiationService,
-		@ILabelService labelService: ILabelService,
 		@IContextMenuService contextMenuService: IContextMenuService
 	) {
 		super();
 
-		this.list = this._register(instantiationService.createInstance(
-			WorkbenchList,
-			'TestResultStackWidget',
+		this.widget = this._register(instantiationService.createInstance(
+			CallStackWidget,
 			container,
-			stackItemDelegate,
-			[instantiationService.createInstance(StackRenderer)],
-			{
-				multipleSelectionSupport: false,
-				accessibilityProvider: {
-					getWidgetAriaLabel: () => localize('testStackTrace', 'Test stack trace'),
-					getAriaLabel: (e: ITestMessageStackFrame) => e.position && e.uri ? localize({
-						comment: ['{0} is an extension-defined label, then line number and filename'],
-						key: 'stackTraceLabel',
-					}, '{0}, line {1} in {2}', e.label, e.position.lineNumber, labelService.getUriLabel(e.uri, { relative: true })) : e.label,
-				}
-			}
-		) as WorkbenchList<ITestMessageStackFrame>);
-
-		this._register(this.list.onDidChangeSelection(e => {
-			if (e.elements.length) {
-				this.changeStackFrameEmitter.fire(e.elements[0]);
-			}
-		}));
+			containingEditor,
+		));
 
 		this._register(dom.addDisposableListener(container, dom.EventType.CONTEXT_MENU, e => {
 			contextMenuService.showContextMenu({
@@ -69,84 +42,15 @@ export class TestResultStackWidget extends Disposable {
 	}
 
 	public update(stack: ITestMessageStackFrame[], selection?: ITestMessageStackFrame) {
-		this.list.splice(0, this.list.length, stack);
-		this.list.layout();
-
-		const i = selection && stack.indexOf(selection);
-		if (i && i !== -1) {
-			this.list.setSelection([i]);
-			this.list.setFocus([i]);
-			// selection is triggered actioning on the call stack from a different
-			// editor, ensure the stack item is still focused in this editor
-			this.list.domFocus();
-		}
+		this.widget.setFrames(stack.map(frame => new CallStackFrame(
+			frame.label,
+			frame.uri,
+			frame.position?.lineNumber,
+			frame.position?.column,
+		)));
 	}
 
 	public layout(height?: number, width?: number) {
-		this.list.layout(height ?? this.container.clientHeight, width);
+		this.widget.layout(height ?? this.container.clientHeight, width);
 	}
 }
-
-interface ITemplateData {
-	container: HTMLElement;
-	label: HTMLElement;
-	location: HTMLElement;
-	current?: ITestMessageStackFrame;
-	disposable: IDisposable;
-}
-
-class StackRenderer implements IListRenderer<ITestMessageStackFrame, ITemplateData> {
-	public readonly templateId = 's';
-
-	constructor(
-		@ILabelService private readonly labelService: ILabelService,
-		@IEditorService private readonly openerService: IEditorService,
-	) { }
-
-	renderTemplate(container: HTMLElement): ITemplateData {
-		const label = dom.$('.label');
-		const location = dom.$('.location');
-		container.appendChild(label);
-		container.appendChild(location);
-		const data: ITemplateData = {
-			container,
-			label,
-			location,
-			disposable: dom.addDisposableListener(container, dom.EventType.CLICK, e => {
-				if (e.ctrlKey || e.metaKey) {
-					if (data.current?.uri) {
-						this.openerService.openEditor({
-							resource: data.current.uri,
-							options: {
-								selection: data.current.position ? Range.fromPositions(data.current.position) : undefined,
-							}
-						}, SIDE_GROUP);
-						e.preventDefault();
-						e.stopPropagation();
-					}
-				}
-			}),
-		};
-
-		return data;
-	}
-
-	renderElement(element: ITestMessageStackFrame, index: number, templateData: ITemplateData, height: number | undefined): void {
-		templateData.label.innerText = element.label;
-		templateData.current = element;
-		templateData.container.classList.toggle('no-source', !element.uri);
-
-		if (element.uri) {
-			templateData.location.innerText = this.labelService.getUriBasenameLabel(element.uri);
-			templateData.location.title = this.labelService.getUriLabel(element.uri, { relative: true });
-			if (element.position) {
-				templateData.location.innerText += `:${element.position.lineNumber}:${element.position.column}`;
-			}
-		}
-	}
-
-	disposeTemplate(templateData: ITemplateData): void {
-		templateData.disposable.dispose();
-	}
-}
-

--- a/src/vs/workbench/contrib/testing/browser/testing.contribution.ts
+++ b/src/vs/workbench/contrib/testing/browser/testing.contribution.ts
@@ -25,7 +25,7 @@ import { testingResultsIcon, testingViewIcon } from 'vs/workbench/contrib/testin
 import { TestCoverageView } from 'vs/workbench/contrib/testing/browser/testCoverageView';
 import { TestingDecorationService, TestingDecorations } from 'vs/workbench/contrib/testing/browser/testingDecorations';
 import { TestingExplorerView } from 'vs/workbench/contrib/testing/browser/testingExplorerView';
-import { CloseTestPeek, GoToNextMessageAction, GoToPreviousMessageAction, OpenMessageInEditorAction, TestResultsView, TestingOutputPeekController, TestingPeekOpener, ToggleCallStackAction, ToggleTestingPeekHistory } from 'vs/workbench/contrib/testing/browser/testingOutputPeek';
+import { CloseTestPeek, GoToNextMessageAction, GoToPreviousMessageAction, OpenMessageInEditorAction, TestResultsView, TestingOutputPeekController, TestingPeekOpener, ToggleTestingPeekHistory } from 'vs/workbench/contrib/testing/browser/testingOutputPeek';
 import { TestingProgressTrigger } from 'vs/workbench/contrib/testing/browser/testingProgressUiService';
 import { TestingViewPaneContainer } from 'vs/workbench/contrib/testing/browser/testingViewPaneContainer';
 import { testingConfiguration } from 'vs/workbench/contrib/testing/common/configuration';
@@ -136,7 +136,6 @@ registerAction2(GoToPreviousMessageAction);
 registerAction2(GoToNextMessageAction);
 registerAction2(CloseTestPeek);
 registerAction2(ToggleTestingPeekHistory);
-registerAction2(ToggleCallStackAction);
 
 Registry.as<IWorkbenchContributionsRegistry>(WorkbenchExtensions.Workbench).registerWorkbenchContribution(TestingContentProvider, LifecyclePhase.Restored);
 Registry.as<IWorkbenchContributionsRegistry>(WorkbenchExtensions.Workbench).registerWorkbenchContribution(TestingPeekOpener, LifecyclePhase.Eventually);

--- a/src/vs/workbench/contrib/testing/browser/testingOutputPeek.ts
+++ b/src/vs/workbench/contrib/testing/browser/testingOutputPeek.ts
@@ -21,7 +21,7 @@ import { EditorAction2 } from 'vs/editor/browser/editorExtensions';
 import { ICodeEditorService } from 'vs/editor/browser/services/codeEditorService';
 import { EmbeddedCodeEditorWidget } from 'vs/editor/browser/widget/codeEditor/embeddedCodeEditorWidget';
 import { EmbeddedDiffEditorWidget } from 'vs/editor/browser/widget/diffEditor/embeddedDiffEditorWidget';
-import { IPosition, Position } from 'vs/editor/common/core/position';
+import { Position } from 'vs/editor/common/core/position';
 import { Range } from 'vs/editor/common/core/range';
 import { IEditor, IEditorContribution, ScrollType } from 'vs/editor/common/editorCommon';
 import { EditorContextKeys } from 'vs/editor/common/editorContextKeys';
@@ -52,7 +52,7 @@ import { IViewPaneOptions, ViewPane } from 'vs/workbench/browser/parts/views/vie
 import { IViewDescriptorService } from 'vs/workbench/common/views';
 import { renderTestMessageAsText } from 'vs/workbench/contrib/testing/browser/testMessageColorizer';
 import { InspectSubject, MessageSubject, TaskSubject, TestOutputSubject, mapFindTestMessage } from 'vs/workbench/contrib/testing/browser/testResultsView/testResultsSubject';
-import { ITestResultsViewContentUiState, TestResultsViewContent } from 'vs/workbench/contrib/testing/browser/testResultsView/testResultsViewContent';
+import { TestResultsViewContent } from 'vs/workbench/contrib/testing/browser/testResultsView/testResultsViewContent';
 import { testingMessagePeekBorder, testingPeekBorder, testingPeekHeaderBackground, testingPeekMessageHeaderBackground } from 'vs/workbench/contrib/testing/browser/theme';
 import { AutoOpenPeekViewWhen, TestingConfigKeys, getTestingConfiguration } from 'vs/workbench/contrib/testing/common/configuration';
 import { Testing } from 'vs/workbench/contrib/testing/common/constants';
@@ -61,7 +61,7 @@ import { StoredValue } from 'vs/workbench/contrib/testing/common/storedValue';
 import { ITestResult, TestResultItemChange, TestResultItemChangeReason, resultItemParents } from 'vs/workbench/contrib/testing/common/testResult';
 import { ITestResultService, ResultChangeEvent } from 'vs/workbench/contrib/testing/common/testResultService';
 import { ITestService } from 'vs/workbench/contrib/testing/common/testService';
-import { IRichLocation, ITestMessage, ITestMessageStackFrame, TestMessageType, TestResultItem } from 'vs/workbench/contrib/testing/common/testTypes';
+import { IRichLocation, ITestMessage, TestMessageType, TestResultItem } from 'vs/workbench/contrib/testing/common/testTypes';
 import { TestingContextKeys } from 'vs/workbench/contrib/testing/common/testingContextKeys';
 import { IShowResultOptions, ITestingPeekOpener } from 'vs/workbench/contrib/testing/common/testingPeekOpener';
 import { isFailedState } from 'vs/workbench/contrib/testing/common/testingStates';
@@ -114,16 +114,9 @@ export class TestingPeekOpener extends Disposable implements ITestingPeekOpener 
 		@IViewsService private readonly viewsService: IViewsService,
 		@ICommandService private readonly commandService: ICommandService,
 		@INotificationService private readonly notificationService: INotificationService,
-		@IContextKeyService contextKeyService: IContextKeyService,
 	) {
 		super();
 		this._register(testResults.onTestChanged(this.openPeekOnFailure, this));
-
-		const callStackVisibleKey = TestingContextKeys.showCallStackInPeek.bindTo(contextKeyService);
-		this._register(this.callStackVisible.onDidChange(() => {
-			callStackVisibleKey.set(this.callStackVisible.value);
-		}));
-		callStackVisibleKey.set(this.callStackVisible.value);
 	}
 
 	/** @inheritdoc */
@@ -464,7 +457,7 @@ export class TestingOutputPeekController extends Disposable implements IEditorCo
 	/**
 	 * Shows a peek for the existing inspect subject.
 	 */
-	public async showSubject(subject: InspectSubject, frame?: ITestMessageStackFrame, uiState?: ITestResultsViewContentUiState) {
+	private async showSubject(subject: InspectSubject) {
 		if (!this.peek.value) {
 			this.peek.value = this.instantiationService.createInstance(TestResultsPeek, this.editor);
 			this.peek.value.onDidClose(() => {
@@ -480,7 +473,7 @@ export class TestingOutputPeekController extends Disposable implements IEditorCo
 			alert(renderTestMessageAsText(subject.message.message));
 		}
 
-		this.peek.value.setModel(subject, frame, uiState);
+		this.peek.value.setModel(subject);
 	}
 
 	public async openAndShow(uri: URI) {
@@ -707,59 +700,9 @@ class TestResultsPeek extends PeekViewWidget {
 			this._disposables.add(this.content.onClose(() => {
 				TestingOutputPeekController.get(this.editor)?.removePeek();
 			}));
-
-			this._disposables.add(this.content.onDidChangeStackFrame(sf => {
-				if (!sf.uri) {
-					return;
-				}
-
-				if (this.uriIdentityService.extUri.isEqual(sf.uri, this.editor.getModel()?.uri)) {
-					if (sf.position) {
-						this.changePositionTo(sf.position);
-					}
-					return;
-				}
-
-				const current = this.current;
-				const uiState = this.content.uiState;
-				this.codeEditorService.openCodeEditor(
-					{
-						resource: sf.uri,
-						options: {
-							preserveFocus: true,
-							selection: sf.position ? Range.fromPositions(sf.position) : undefined,
-							transient: true,
-						}
-					},
-					this.editor,
-				).then(newEditor => {
-					if (!newEditor || !current) {
-						return;
-					}
-
-					TestingOutputPeekController.get(newEditor)?.showSubject(current, sf, uiState);
-				});
-			}));
 		}
 
 		super._fillContainer(container);
-	}
-
-	/** Moves the peek to a new position in the current editor, maintaining its position on the screen */
-	private changePositionTo(position: IPosition) {
-		const currentPosition = this.position;
-		if (!currentPosition) {
-			this.show(position, TestResultsPeek.lastHeightInLines || 10);
-			return;
-		}
-
-		const currentPositionViewOffset = this.editor.getScrolledVisiblePosition(currentPosition);
-		this.updatePositionAndHeight(position);
-
-		if (currentPositionViewOffset) {
-			const newPosition = this.editor.getTopForPosition(position.lineNumber, position.column);
-			this.editor.setScrollTop(newPosition - currentPositionViewOffset?.top);
-		}
 	}
 
 	protected override _fillHead(container: HTMLElement): void {
@@ -793,35 +736,35 @@ class TestResultsPeek extends PeekViewWidget {
 	/**
 	 * Updates the test to be shown.
 	 */
-	public setModel(subject: InspectSubject, frame?: ITestMessageStackFrame, uiState?: ITestResultsViewContentUiState): Promise<void> {
+	public setModel(subject: InspectSubject): Promise<void> {
 		if (subject instanceof TaskSubject || subject instanceof TestOutputSubject) {
 			this.current = subject;
-			return this.showInPlace(subject, frame, uiState);
+			return this.showInPlace(subject);
 		}
 
 		const message = subject.message;
 		const previous = this.current;
-		const revealLocation = frame?.position || subject.revealLocation?.range.getStartPosition();
+		const revealLocation = subject.revealLocation?.range.getStartPosition();
 		if (!revealLocation && !previous) {
 			return Promise.resolve();
 		}
 
 		this.current = subject;
 		if (!revealLocation) {
-			return this.showInPlace(subject, frame, uiState);
+			return this.showInPlace(subject);
 		}
 
 		this.show(revealLocation, TestResultsPeek.lastHeightInLines || hintMessagePeekHeight(message));
 		this.editor.revealRangeNearTopIfOutsideViewport(Range.fromPositions(revealLocation), ScrollType.Smooth);
 
-		return this.showInPlace(subject, frame, uiState);
+		return this.showInPlace(subject);
 	}
 
 	/**
 	 * Shows a message in-place without showing or changing the peek location.
 	 * This is mostly used if peeking a message without a location.
 	 */
-	public async showInPlace(subject: InspectSubject, frame?: ITestMessageStackFrame, uiState?: ITestResultsViewContentUiState) {
+	public async showInPlace(subject: InspectSubject) {
 		if (subject instanceof MessageSubject) {
 			const message = subject.message;
 			this.setTitle(firstLine(renderTestMessageAsText(message.message)), stripIcons(subject.test.label));
@@ -829,7 +772,7 @@ class TestResultsPeek extends PeekViewWidget {
 			this.setTitle(localize('testOutputTitle', 'Test Output'));
 		}
 		this.applyTheme();
-		await this.content.reveal({ subject, frame, preserveFocus: false, uiState });
+		await this.content.reveal({ subject, preserveFocus: false });
 	}
 
 	protected override _relayout(newHeightInLines: number): void {
@@ -874,7 +817,7 @@ export class TestResultsView extends ViewPane {
 		@ITelemetryService telemetryService: ITelemetryService,
 		@IHoverService hoverService: IHoverService,
 		@ITestResultService private readonly resultService: ITestResultService,
-		@IEditorService private readonly editorService: IEditorService,
+
 	) {
 		super(options, keybindingService, contextMenuService, configurationService, contextKeyService, viewDescriptorService, instantiationService, openerService, themeService, telemetryService, hoverService);
 	}
@@ -912,17 +855,6 @@ export class TestResultsView extends ViewPane {
 		const content = this.content.value;
 		content.fillBody(container);
 		this._register(content.onDidRequestReveal(subject => content.reveal({ preserveFocus: true, subject })));
-		this._register(content.onDidChangeStackFrame(sf => {
-			if (sf.uri) {
-				this.editorService.openEditor({
-					resource: sf.uri,
-					options: {
-						preserveFocus: true,
-						selection: sf.position ? Range.fromPositions(sf.position) : undefined,
-					}
-				});
-			}
-		}));
 
 		const [lastResult] = this.resultService.results;
 		if (lastResult && lastResult.tasks.length) {
@@ -1134,37 +1066,5 @@ export class ToggleTestingPeekHistory extends Action2 {
 	public override run(accessor: ServicesAccessor) {
 		const opener = accessor.get(ITestingPeekOpener);
 		opener.historyVisible.value = !opener.historyVisible.value;
-	}
-}
-
-export class ToggleCallStackAction extends Action2 {
-	public static readonly ID = 'testing.toggleCallStack';
-	constructor() {
-		super({
-			id: ToggleCallStackAction.ID,
-			title: localize2('testing.toggleCallStack', 'Show Call Stack in Peek'),
-			metadata: {
-				description: localize2('testing.toggleCallStack.description', 'Shows or hides the history of test runs in the peek view')
-			},
-			icon: Codicon.debugLineByLine,
-			toggled: TestingContextKeys.showCallStackInPeek,
-			category: Categories.Test,
-			menu: [{
-				id: MenuId.TestCallStackContext,
-			}, {
-				id: MenuId.ViewTitle,
-				when: ContextKeyExpr.equals('view', Testing.ResultsViewId)
-			}, {
-				id: MenuId.TestPeekTitle,
-				group: 'navigation',
-				when: ContextKeyExpr.not(TestingContextKeys.showCallStackInPeek.key),
-				order: 4,
-			}],
-		});
-	}
-
-	public override run(accessor: ServicesAccessor) {
-		const opener = accessor.get(ITestingPeekOpener);
-		opener.callStackVisible.value = !opener.callStackVisible.value;
 	}
 }

--- a/src/vs/workbench/contrib/testing/common/testingContextKeys.ts
+++ b/src/vs/workbench/contrib/testing/common/testingContextKeys.ts
@@ -26,7 +26,6 @@ export namespace TestingContextKeys {
 	export const isCoverageFilteredToTest = new RawContextKey('testing.isCoverageFilteredToTest', false, { type: 'boolean', description: localize('testing.isCoverageFilteredToTest', 'Indicates whether coverage has been filterd to a single test') });
 	export const coverageToolbarEnabled = new RawContextKey('testing.coverageToolbarEnabled', true, { type: 'boolean', description: localize('testing.coverageToolbarEnabled', 'Indicates whether the coverage toolbar is enabled') });
 	export const inlineCoverageEnabled = new RawContextKey('testing.inlineCoverageEnabled', false, { type: 'boolean', description: localize('testing.inlineCoverageEnabled', 'Indicates whether inline coverage is shown') });
-	export const showCallStackInPeek = new RawContextKey<boolean>('testing.showCallStackInPeek', true, { type: 'boolean', description: localize('testing.showCallStackInPeek', 'Whether to show the failure call stack in the testing peek') });
 
 	export const capabilityToContextKey: { [K in TestRunProfileBitset]: RawContextKey<boolean> } = {
 		[TestRunProfileBitset.Run]: hasRunnableTests,


### PR DESCRIPTION
This borrows some ideas (though no code, yet) from the multi diff
view to show call frame context inline. I think it still needs a little
polish, but I really like the concept. I also designed it as a reusable
component that I plan to use to enhance the debug exception widget.

<img width="824" alt="image" src="https://github.com/user-attachments/assets/4d3c7110-2931-464f-984d-d4a8d042d0c2">
