### PR TITLE
Fix terminal devmode decoration visibility

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/developer/browser/media/developer.css
+++ b/src/vs/workbench/contrib/terminalContrib/developer/browser/media/developer.css
@@ -5,10 +5,10 @@
 
 .monaco-workbench .xterm.dev-mode .xterm-sequence-decoration {
 	background-color: var(--vscode-terminal-background, var(--vscode-panel-background));
-	display: none !important;
+	visibility: hidden;
 }
 .monaco-workbench .xterm.dev-mode:hover .xterm-sequence-decoration {
-	display: block !important;
+	visibility: visible !important;
 }
 .monaco-workbench .xterm.dev-mode .xterm-sequence-decoration.left {
 	direction: rtl;


### PR DESCRIPTION
display: block was showing decorations that weren't meant to be as that property is managed by xterm.js

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
