### PR TITLE
ci: enable nodejsMirror

### DIFF
--- a/build/azure-pipelines/alpine/cli-build-alpine.yml
+++ b/build/azure-pipelines/alpine/cli-build-alpine.yml
@@ -16,7 +16,7 @@ steps:
     inputs:
       versionSource: fromFile
       versionFilePath: .nvmrc
-      #nodejsMirror: https://github.com/joaomoreno/node-mirror/releases/download
+      nodejsMirror: https://github.com/joaomoreno/node-mirror/releases/download
 
   - ${{ if ne(parameters.VSCODE_QUALITY, 'oss') }}:
     # Install yarn as the ARM64 build agent is using vanilla Ubuntu

--- a/build/azure-pipelines/darwin/cli-build-darwin.yml
+++ b/build/azure-pipelines/darwin/cli-build-darwin.yml
@@ -16,7 +16,7 @@ steps:
     inputs:
       versionSource: fromFile
       versionFilePath: .nvmrc
-      #nodejsMirror: https://github.com/joaomoreno/node-mirror/releases/download
+      nodejsMirror: https://github.com/joaomoreno/node-mirror/releases/download
 
   - ${{ if ne(parameters.VSCODE_QUALITY, 'oss') }}:
     - template: ../cli/cli-apply-patches.yml@self

--- a/build/azure-pipelines/darwin/product-build-darwin-cli-sign.yml
+++ b/build/azure-pipelines/darwin/product-build-darwin-cli-sign.yml
@@ -9,7 +9,7 @@ steps:
     inputs:
       versionSource: fromFile
       versionFilePath: .nvmrc
-      #nodejsMirror: https://github.com/joaomoreno/node-mirror/releases/download
+      nodejsMirror: https://github.com/joaomoreno/node-mirror/releases/download
 
   - script: node build/setup-npm-registry.js $NPM_REGISTRY build
     condition: and(succeeded(), ne(variables['NPM_REGISTRY'], 'none'))

--- a/build/azure-pipelines/darwin/product-build-darwin-sign.yml
+++ b/build/azure-pipelines/darwin/product-build-darwin-sign.yml
@@ -3,7 +3,7 @@ steps:
     inputs:
       versionSource: fromFile
       versionFilePath: .nvmrc
-      #nodejsMirror: https://github.com/joaomoreno/node-mirror/releases/download
+      nodejsMirror: https://github.com/joaomoreno/node-mirror/releases/download
 
   - task: UseDotNet@2
     inputs:

--- a/build/azure-pipelines/darwin/product-build-darwin-universal.yml
+++ b/build/azure-pipelines/darwin/product-build-darwin-universal.yml
@@ -3,7 +3,7 @@ steps:
     inputs:
       versionSource: fromFile
       versionFilePath: .nvmrc
-      #nodejsMirror: https://github.com/joaomoreno/node-mirror/releases/download
+      nodejsMirror: https://github.com/joaomoreno/node-mirror/releases/download
 
   - template: ../distro/download-distro.yml@self
 

--- a/build/azure-pipelines/darwin/product-build-darwin.yml
+++ b/build/azure-pipelines/darwin/product-build-darwin.yml
@@ -20,7 +20,7 @@ steps:
     inputs:
       versionSource: fromFile
       versionFilePath: .nvmrc
-      #nodejsMirror: https://github.com/joaomoreno/node-mirror/releases/download
+      nodejsMirror: https://github.com/joaomoreno/node-mirror/releases/download
 
   - ${{ if ne(parameters.VSCODE_QUALITY, 'oss') }}:
     - template: ../distro/download-distro.yml@self

--- a/build/azure-pipelines/distro-build.yml
+++ b/build/azure-pipelines/distro-build.yml
@@ -11,5 +11,5 @@ steps:
     inputs:
       versionSource: fromFile
       versionFilePath: .nvmrc
-      #nodejsMirror: https://github.com/joaomoreno/node-mirror/releases/download
+      nodejsMirror: https://github.com/joaomoreno/node-mirror/releases/download
   - template: ./distro/download-distro.yml@self


### PR DESCRIPTION
Mirror was disabled due to missing builds which is now addressed in https://github.com/joaomoreno/node-mirror