### PR TITLE
Make overview ruler border consistently colored

### DIFF
--- a/src/vs/editor/browser/viewParts/overviewRuler/decorationsOverviewRuler.ts
+++ b/src/vs/editor/browser/viewParts/overviewRuler/decorationsOverviewRuler.ts
@@ -512,9 +512,7 @@ export class DecorationsOverviewRuler extends ViewPart {
 			canvasCtx.strokeStyle = this._settings.borderColor;
 			canvasCtx.moveTo(0, 0);
 			canvasCtx.lineTo(0, canvasHeight);
-			canvasCtx.stroke();
-
-			canvasCtx.moveTo(0, 0);
+			canvasCtx.moveTo(1, 0);
 			canvasCtx.lineTo(canvasWidth, 0);
 			canvasCtx.stroke();
 		}


### PR DESCRIPTION
Fixes #221724

cc @daviddossett 

## Dark Modern

Before

![image](https://github.com/user-attachments/assets/7cd1bfb0-420b-4ade-9eac-aaec4e66274a)


![image](https://github.com/user-attachments/assets/0c2995b3-653e-4bb0-8a77-c0b9e6c370d3)

After

![image](https://github.com/user-attachments/assets/d34869ee-18dd-4a27-89f0-433d3e4f0b94)

![image](https://github.com/user-attachments/assets/cf682793-28c7-4de1-a0a9-8c9821cd282c)

## Dark+

Before

![image](https://github.com/user-attachments/assets/ae44b0c2-6bec-4d9d-a767-c974a30acdff)
![image](https://github.com/user-attachments/assets/fa2e1757-fca6-4a01-9695-f0701dd1f4f1)

After

![image](https://github.com/user-attachments/assets/58bea094-1bcc-42b5-9c79-1cdf2222acf3)
![image](https://github.com/user-attachments/assets/894b346d-928a-478d-9e10-72eb4985af4f)
