### PR TITLE
use better message in help dialog for unassigned kb in help dialog, provide configure assigned kb command, clean up code

### DIFF
--- a/src/vs/platform/accessibility/browser/accessibleView.ts
+++ b/src/vs/platform/accessibility/browser/accessibleView.ts
@@ -69,6 +69,11 @@ export interface IAccessibleViewOptions {
 	 * Keybinding items to configure
 	 */
 	configureKeybindingItems?: IQuickPickItem[];
+
+	/**
+	 * Keybinding items that are already configured
+	 */
+	configuredKeybindingItems?: IQuickPickItem[];
 }
 
 
@@ -123,7 +128,7 @@ export interface IAccessibleViewService {
 	 */
 	getOpenAriaHint(verbositySettingKey: string): string | null;
 	getCodeBlockContext(): ICodeBlockActionContext | undefined;
-	configureKeybindings(): void;
+	configureKeybindings(unassigned: boolean): void;
 	openHelpLink(): void;
 }
 

--- a/src/vs/workbench/contrib/accessibility/browser/accessibleView.ts
+++ b/src/vs/workbench/contrib/accessibility/browser/accessibleView.ts
@@ -502,8 +502,13 @@ export class AccessibleView extends Disposable {
 		const verbose = this._verbosityEnabled();
 		const readMoreLink = provider.options.readMoreUrl ? localize("openDoc", "\n\nOpen a browser window with more information related to accessibility<keybinding:{0}>.", AccessibilityCommandId.AccessibilityHelpOpenHelpLink) : '';
 		let disableHelpHint = '';
-		if (provider instanceof AccessibleContentProvider && provider.options.type === AccessibleViewType.Help && verbose) {
-			disableHelpHint = this._getDisableVerbosityHint();
+		let configureKbHint = '';
+		if (provider instanceof AccessibleContentProvider && provider.options.type === AccessibleViewType.Help) {
+			if (verbose) {
+				disableHelpHint = this._getDisableVerbosityHint();
+			}
+
+			configureKbHint = this._getConfigureUnassignedKbHint();
 		}
 		const accessibilitySupport = this._accessibilityService.isScreenReaderOptimized();
 		let message = '';
@@ -524,7 +529,7 @@ export class AccessibleView extends Disposable {
 		const exitThisDialogHint = verbose && !provider.options.position ? localize('exit', '\n\nExit this dialog (Escape).') : '';
 		let content = updatedContent ?? provider.provideContent();
 		if (provider.options.type === AccessibleViewType.Help) {
-			const resolvedContent = resolveContentAndKeybindingItems(this._keybindingService, content + readMoreLink + disableHelpHint + exitThisDialogHint);
+			const resolvedContent = resolveContentAndKeybindingItems(this._keybindingService, content + configureKbHint + readMoreLink + disableHelpHint + exitThisDialogHint);
 			if (resolvedContent) {
 				content = resolvedContent.content.value;
 				if (resolvedContent.configureKeybindingItems) {
@@ -779,6 +784,12 @@ export class AccessibleView extends Disposable {
 			return;
 		}
 		return localize('goToSymbolHint', 'Go to a symbol<keybinding:{0}>.', AccessibilityCommandId.GoToSymbol);
+	}
+
+	private _getConfigureUnassignedKbHint(): string {
+		const configureKb = this._keybindingService.lookupKeybinding(AccessibilityCommandId.AccessibilityHelpConfigureKeybindings)?.getAriaLabel();
+		const keybindingToConfigureQuickPick = configureKb ? '(' + configureKb + ')' : 'by assigning a keybinding to the command Accessibility Help Configure Keybindings.';
+		return localize('configureKb', 'Configure keybinings for commands that lack them {0}', keybindingToConfigureQuickPick);
 	}
 }
 

--- a/src/vs/workbench/contrib/accessibility/browser/accessibleViewActions.ts
+++ b/src/vs/workbench/contrib/accessibility/browser/accessibleViewActions.ts
@@ -62,7 +62,6 @@ class AccessibleViewNextCodeBlockAction extends Action2 {
 				mac: { primary: KeyMod.CtrlCmd | KeyMod.Alt | KeyCode.PageDown, },
 				weight: KeybindingWeight.WorkbenchContrib,
 			},
-			// to 
 			icon: Codicon.arrowRight,
 			menu:
 			{
@@ -242,10 +241,28 @@ class AccessibilityHelpConfigureKeybindingsAction extends Action2 {
 		});
 	}
 	async run(accessor: ServicesAccessor): Promise<void> {
-		await accessor.get(IAccessibleViewService).configureKeybindings();
+		await accessor.get(IAccessibleViewService).configureKeybindings(true);
 	}
 }
 registerAction2(AccessibilityHelpConfigureKeybindingsAction);
+
+class AccessibilityHelpConfigureAssignedKeybindingsAction extends Action2 {
+	constructor() {
+		super({
+			id: AccessibilityCommandId.AccessibilityHelpConfigureAssignedKeybindings,
+			precondition: ContextKeyExpr.and(accessibilityHelpIsShown),
+			keybinding: {
+				primary: KeyMod.Alt | KeyCode.KeyA,
+				weight: KeybindingWeight.WorkbenchContrib
+			},
+			title: localize('editor.action.accessibilityHelpConfigureAssignedKeybindings', "Accessibility Help Configure Assigned Keybindings")
+		});
+	}
+	async run(accessor: ServicesAccessor): Promise<void> {
+		await accessor.get(IAccessibleViewService).configureKeybindings(false);
+	}
+}
+registerAction2(AccessibilityHelpConfigureAssignedKeybindingsAction);
 
 
 class AccessibilityHelpOpenHelpLinkAction extends Action2 {

--- a/src/vs/workbench/contrib/accessibility/browser/accessibleViewKeybindingResolver.ts
+++ b/src/vs/workbench/contrib/accessibility/browser/accessibleViewKeybindingResolver.ts
@@ -7,11 +7,12 @@ import { MarkdownString } from 'vs/base/common/htmlContent';
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 import { IPickerQuickAccessItem } from 'vs/platform/quickinput/browser/pickerQuickAccess';
 
-export function resolveContentAndKeybindingItems(keybindingService: IKeybindingService, value?: string): { content: MarkdownString; configureKeybindingItems: IPickerQuickAccessItem[] | undefined } | undefined {
+export function resolveContentAndKeybindingItems(keybindingService: IKeybindingService, value?: string): { content: MarkdownString; configureKeybindingItems: IPickerQuickAccessItem[] | undefined; configuredKeybindingItems: IPickerQuickAccessItem[] | undefined } | undefined {
 	if (!value) {
 		return;
 	}
 	const configureKeybindingItems: IPickerQuickAccessItem[] = [];
+	const configuredKeybindingItems: IPickerQuickAccessItem[] = [];
 	const matches = value.matchAll(/\<keybinding:(?<commandId>.*)\>/gm);
 	for (const match of [...matches]) {
 		const commandId = match?.groups?.commandId;
@@ -26,12 +27,16 @@ export function resolveContentAndKeybindingItems(keybindingService: IKeybindingS
 				});
 			} else {
 				kbLabel = ' (' + keybinding + ')';
+				configuredKeybindingItems.push({
+					label: commandId,
+					id: commandId
+				});
 			}
 			value = value.replace(match[0], kbLabel);
 		}
 	}
 	const content = new MarkdownString(value);
 	content.isTrusted = true;
-	return { content, configureKeybindingItems: configureKeybindingItems.length ? configureKeybindingItems : undefined };
+	return { content, configureKeybindingItems: configureKeybindingItems.length ? configureKeybindingItems : undefined, configuredKeybindingItems: configuredKeybindingItems.length ? configuredKeybindingItems : undefined };
 }
 

--- a/src/vs/workbench/contrib/accessibility/browser/accessibleViewKeybindingResolver.ts
+++ b/src/vs/workbench/contrib/accessibility/browser/accessibleViewKeybindingResolver.ts
@@ -6,7 +6,6 @@
 import { MarkdownString } from 'vs/base/common/htmlContent';
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 import { IPickerQuickAccessItem } from 'vs/platform/quickinput/browser/pickerQuickAccess';
-import { AccessibilityCommandId } from 'vs/workbench/contrib/accessibility/common/accessibilityCommands';
 
 export function resolveContentAndKeybindingItems(keybindingService: IKeybindingService, value?: string): { content: MarkdownString; configureKeybindingItems: IPickerQuickAccessItem[] | undefined } | undefined {
 	if (!value) {
@@ -20,9 +19,7 @@ export function resolveContentAndKeybindingItems(keybindingService: IKeybindingS
 		if (match?.length && commandId) {
 			const keybinding = keybindingService.lookupKeybinding(commandId)?.getAriaLabel();
 			if (!keybinding) {
-				const configureKb = keybindingService.lookupKeybinding(AccessibilityCommandId.AccessibilityHelpConfigureKeybindings)?.getAriaLabel();
-				const keybindingToConfigureQuickPick = configureKb ? '(' + configureKb + ')' : 'by assigning a keybinding to the command Accessibility Help Configure Keybindings.';
-				kbLabel = `, configure a keybinding ` + keybindingToConfigureQuickPick;
+				kbLabel = ` (unassigned keybinding)`;
 				configureKeybindingItems.push({
 					label: commandId,
 					id: commandId

--- a/src/vs/workbench/contrib/accessibility/common/accessibilityCommands.ts
+++ b/src/vs/workbench/contrib/accessibility/common/accessibilityCommands.ts
@@ -14,5 +14,6 @@ export const enum AccessibilityCommandId {
 	NextCodeBlock = 'editor.action.accessibleViewNextCodeBlock',
 	PreviousCodeBlock = 'editor.action.accessibleViewPreviousCodeBlock',
 	AccessibilityHelpConfigureKeybindings = 'editor.action.accessibilityHelpConfigureKeybindings',
+	AccessibilityHelpConfigureAssignedKeybindings = 'editor.action.accessibilityHelpConfigureAssignedKeybindings',
 	AccessibilityHelpOpenHelpLink = 'editor.action.accessibilityHelpOpenHelpLink',
 }


### PR DESCRIPTION
1. Moves the hint on how to configure unassigned keybindings from after the command's name in the help content to the end of the help dialog. This change makes the help dialog text more grammatically correct and understandable and aligns with how we describe commands with keybindings IE `command name (keybinding)`. The hint is now displayed at the bottom of the dialog, where @jooyoungseo says users are more likely to find it if they scan quickly until the bottom. fixes #213415
Before: `The Create New Terminal (With Profile) command, configure a keybinding (Option+K) allows for easy terminal creation using a specific profile.`
After: `The Create New Terminal (With Profile) command (unassigned keybinding) allows for easy terminal creation using a specific profile.`
At the bottom:
`Configure keybindings for commands that lack them (Option+K).`
3. Adds a new action and corresponding hint to the accessibility help dialog to configure already assigned keybindings. Users can now access this action from the help dialog, which complements the existing action to configure unassigned keybindings. This addition was requested by @jooyoungseo and is intended to provide users with an easier way to configure keybindings. Before, they would have to select and copy the command name, go to the settings editor, and often search among many matches for the one of interest. Now, they can access the action directly from the help dialog. Separating the unassigned vs assigned keybindings makes sense as the former is higher priority. fixes #213414
4. Cleans up the code by extracting smaller parts into helper functions. Specifically, the updating and enriching of help dialog content has now been extracted from the `_render` function. This change makes the code more readable and maintainable by separating the concerns of rendering the dialog content and updating it with additional hints. 
