### PR TITLE
Implements dryRun for workbench.extensions.action.debugExtensionHost

### DIFF
--- a/src/vs/workbench/contrib/extensions/electron-sandbox/debugExtensionHostAction.ts
+++ b/src/vs/workbench/contrib/extensions/electron-sandbox/debugExtensionHostAction.ts
@@ -28,8 +28,7 @@ export class DebugExtensionHostAction extends Action {
 		super(DebugExtensionHostAction.ID, DebugExtensionHostAction.LABEL, DebugExtensionHostAction.CSS_CLASS);
 	}
 
-	override async run(): Promise<any> {
-
+	override async run(args: unknown): Promise<any> {
 		const inspectPorts = await this._extensionService.getInspectPorts(ExtensionHostKind.LocalProcess, false);
 		if (inspectPorts.length === 0) {
 			const res = await this._dialogService.confirm({
@@ -49,11 +48,15 @@ export class DebugExtensionHostAction extends Action {
 			console.warn(`There are multiple extension hosts available for debugging. Picking the first one...`);
 		}
 
-		return this._debugService.startDebugging(undefined, {
-			type: 'node',
-			name: nls.localize('debugExtensionHost.launch.name', "Attach Extension Host"),
-			request: 'attach',
-			port: inspectPorts[0].port,
-		});
+		if (args !== undefined && (args as any)[0].dryRun) {
+			return { inspectPorts };
+		} else {
+			return this._debugService.startDebugging(undefined, {
+				type: 'node',
+				name: nls.localize('debugExtensionHost.launch.name', "Attach Extension Host"),
+				request: 'attach',
+				port: inspectPorts[0].port,
+			});
+		}
 	}
 }

--- a/src/vs/workbench/contrib/extensions/electron-sandbox/extensions.contribution.ts
+++ b/src/vs/workbench/contrib/extensions/electron-sandbox/extensions.contribution.ts
@@ -77,9 +77,9 @@ workbenchRegistry.registerWorkbenchContribution(ExtensionsAutoProfiler, Lifecycl
 workbenchRegistry.registerWorkbenchContribution(RemoteExtensionsInitializerContribution, LifecyclePhase.Restored);
 // Register Commands
 
-CommandsRegistry.registerCommand(DebugExtensionHostAction.ID, (accessor: ServicesAccessor) => {
+CommandsRegistry.registerCommand(DebugExtensionHostAction.ID, (accessor: ServicesAccessor, ...args) => {
 	const instantiationService = accessor.get(IInstantiationService);
-	instantiationService.createInstance(DebugExtensionHostAction).run();
+	return instantiationService.createInstance(DebugExtensionHostAction).run(args);
 });
 
 CommandsRegistry.registerCommand(StartExtensionHostProfileAction.ID, (accessor: ServicesAccessor) => {


### PR DESCRIPTION
This allows extensions to build on top of this command.