### PR TITLE
Finalize markdown update links on paste setting

### DIFF
--- a/extensions/markdown-language-features/package.json
+++ b/extensions/markdown-language-features/package.json
@@ -708,14 +708,11 @@
             "%configuration.markdown.preferredMdPathExtensionStyle.removeExtension%"
           ]
         },
-        "markdown.experimental.updateLinksOnPaste": {
+        "markdown.editor.updateLinksOnPaste.enabled": {
           "type": "boolean",
-          "default": false,
-          "markdownDescription": "%configuration.markdown.experimental.updateLinksOnPaste%",
+          "markdownDescription": "%configuration.markdown.editor.updateLinksOnPaste.enabled%",
           "scope": "resource",
-          "tags": [
-            "experimental"
-          ]
+          "default": true
         }
       }
     },

--- a/extensions/markdown-language-features/package.nls.json
+++ b/extensions/markdown-language-features/package.nls.json
@@ -91,6 +91,6 @@
 	"configuration.markdown.preferredMdPathExtensionStyle.removeExtension": "Prefer removing the file extension. For example, path completions to a file named `file.md` will insert `file` without the `.md`.",
 	"configuration.markdown.editor.filePaste.videoSnippet": "Snippet used when adding videos to Markdown. This snippet can use the following variables:\n- `${src}` — The resolved path of the video file.\n- `${title}` — The title used for the video. A snippet placeholder will automatically be created for this variable.",
 	"configuration.markdown.editor.filePaste.audioSnippet": "Snippet used when adding audio to Markdown. This snippet can use the following variables:\n- `${src}` — The resolved path of the audio  file.\n- `${title}` — The title used for the audio. A snippet placeholder will automatically be created for this variable.",
-	"configuration.markdown.experimental.updateLinksOnPaste": "Enable/disable automatic updating of links in text that is copied and pasted from one Markdown editor to another.",
+	"configuration.markdown.editor.updateLinksOnPaste.enabled": "Enable/disable updating of links in text that is copied and pasted from one Markdown editor to another.",
 	"workspaceTrust": "Required for loading styles configured in the workspace."
 }


### PR DESCRIPTION
Fixes #209318

Enables this new feature by default (but as an option, not the default way to paste)

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
