### PR TITLE
Use the builtin local command in shell integration scripts

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/media/shellIntegration-bash.sh
+++ b/src/vs/workbench/contrib/terminal/browser/media/shellIntegration-bash.sh
@@ -112,15 +112,15 @@ __vsc_escape_value() {
 	fi
 
 	# Process text byte by byte, not by codepoint.
-	local -r LC_ALL=C
-	local -r str="${1}"
-	local -ir len="${#str}"
+	builtin local -r LC_ALL=C
+	builtin local -r str="${1}"
+	builtin local -ir len="${#str}"
 
-	local -i i
-	local -i val
-	local byte
-	local token
-	local out=''
+	builtin local -i i
+	builtin local -i val
+	builtin local byte
+	builtin local token
+	builtin local out=''
 
 	for (( i=0; i < "${#str}"; ++i )); do
 		# Escape backslashes, semi-colons specially, then special ASCII chars below space (0x20).
@@ -326,7 +326,7 @@ __vsc_prompt_cmd_original() {
 	__vsc_restore_exit_code "${__vsc_status}"
 	# Evaluate the original PROMPT_COMMAND similarly to how bash would normally
 	# See https://unix.stackexchange.com/a/672843 for technique
-	local cmd
+	builtin local cmd
 	for cmd in "${__vsc_original_prompt_command[@]}"; do
 		eval "${cmd:-}"
 	done

--- a/src/vs/workbench/contrib/terminal/browser/media/shellIntegration-rc.zsh
+++ b/src/vs/workbench/contrib/terminal/browser/media/shellIntegration-rc.zsh
@@ -159,7 +159,7 @@ __vsc_update_prompt() {
 }
 
 __vsc_precmd() {
-	local __vsc_status="$?"
+	builtin local __vsc_status="$?"
 	if [ -z "${__vsc_in_command_execution-}" ]; then
 		# not in command execution
 		__vsc_command_output_start


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Sometimes people redefine `local` to something else, just like you could with other builtins. So in the shell integration scripts we should really use `builtin local` to avoid calling the redefined version.