### PR TITLE
code actions on save for autosave `afterDelay`

### DIFF
--- a/src/vs/editor/contrib/codeAction/browser/codeActionContributions.ts
+++ b/src/vs/editor/contrib/codeAction/browser/codeActionContributions.ts
@@ -45,3 +45,15 @@ Registry.as<IConfigurationRegistry>(Extensions.Configuration).registerConfigurat
 		},
 	}
 });
+
+Registry.as<IConfigurationRegistry>(Extensions.Configuration).registerConfiguration({
+	...editorConfigurationBaseNode,
+	properties: {
+		'editor.codeActions.triggerOnFocusChange': {
+			type: 'boolean',
+			scope: ConfigurationScope.LANGUAGE_OVERRIDABLE,
+			markdownDescription: nls.localize('triggerOnFocusChange', 'Enable triggering {0} when {1} is set to `afterDelay`. Code Actions must be set to `always` to be triggered for window and focus changes.', '`#editor.codeActionsOnSave#`', '`#files.autoSave#`'),
+			default: false,
+		},
+	}
+});

--- a/src/vs/editor/contrib/codeAction/browser/codeActionContributions.ts
+++ b/src/vs/editor/contrib/codeAction/browser/codeActionContributions.ts
@@ -52,7 +52,7 @@ Registry.as<IConfigurationRegistry>(Extensions.Configuration).registerConfigurat
 		'editor.codeActions.triggerOnFocusChange': {
 			type: 'boolean',
 			scope: ConfigurationScope.LANGUAGE_OVERRIDABLE,
-			markdownDescription: nls.localize('triggerOnFocusChange', 'Enable triggering {0} when {1} is set to `afterDelay`. Code Actions must be set to `always` to be triggered for window and focus changes.', '`#editor.codeActionsOnSave#`', '`#files.autoSave#`'),
+			markdownDescription: nls.localize('triggerOnFocusChange', 'Enable triggering {0} when {1} is set to {2}. Code Actions must be set to {3} to be triggered for window and focus changes.', '`#editor.codeActionsOnSave#`', '`#files.autoSave#`', '`afterDelay`', '`always`'),
 			default: false,
 		},
 	}

--- a/src/vs/workbench/contrib/codeEditor/browser/outline/documentSymbolsTree.ts
+++ b/src/vs/workbench/contrib/codeEditor/browser/outline/documentSymbolsTree.ts
@@ -3,27 +3,27 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import 'vs/css!./documentSymbolsTree';
-import 'vs/editor/contrib/symbolIcons/browser/symbolIcons'; // The codicon symbol colors are defined here and must be loaded to get colors
 import * as dom from 'vs/base/browser/dom';
 import { HighlightedLabel } from 'vs/base/browser/ui/highlightedlabel/highlightedLabel';
-import { IIdentityProvider, IKeyboardNavigationLabelProvider, IListVirtualDelegate } from 'vs/base/browser/ui/list/list';
-import { ITreeNode, ITreeRenderer, ITreeFilter } from 'vs/base/browser/ui/tree/tree';
-import { createMatches, FuzzyScore } from 'vs/base/common/filters';
-import { Range } from 'vs/editor/common/core/range';
-import { SymbolKind, SymbolKinds, SymbolTag, getAriaLabelForSymbol, symbolKindNames } from 'vs/editor/common/languages';
-import { OutlineElement, OutlineGroup, OutlineModel } from 'vs/editor/contrib/documentSymbols/browser/outlineModel';
-import { localize } from 'vs/nls';
 import { IconLabel, IIconLabelValueOptions } from 'vs/base/browser/ui/iconLabel/iconLabel';
+import { IIdentityProvider, IKeyboardNavigationLabelProvider, IListVirtualDelegate } from 'vs/base/browser/ui/list/list';
+import { IListAccessibilityProvider } from 'vs/base/browser/ui/list/listWidget';
+import { ITreeFilter, ITreeNode, ITreeRenderer } from 'vs/base/browser/ui/tree/tree';
+import { mainWindow } from 'vs/base/browser/window';
+import { createMatches, FuzzyScore } from 'vs/base/common/filters';
+import { ThemeIcon } from 'vs/base/common/themables';
+import 'vs/css!./documentSymbolsTree';
+import { Range } from 'vs/editor/common/core/range';
+import { getAriaLabelForSymbol, SymbolKind, symbolKindNames, SymbolKinds, SymbolTag } from 'vs/editor/common/languages';
+import { ITextResourceConfigurationService } from 'vs/editor/common/services/textResourceConfiguration';
+import { OutlineElement, OutlineGroup, OutlineModel } from 'vs/editor/contrib/documentSymbols/browser/outlineModel';
+import 'vs/editor/contrib/symbolIcons/browser/symbolIcons'; // The codicon symbol colors are defined here and must be loaded to get colors
+import { localize } from 'vs/nls';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { MarkerSeverity } from 'vs/platform/markers/common/markers';
-import { IThemeService } from 'vs/platform/theme/common/themeService';
 import { listErrorForeground, listWarningForeground } from 'vs/platform/theme/common/colorRegistry';
-import { ITextResourceConfigurationService } from 'vs/editor/common/services/textResourceConfiguration';
-import { IListAccessibilityProvider } from 'vs/base/browser/ui/list/listWidget';
+import { IThemeService } from 'vs/platform/theme/common/themeService';
 import { IOutlineComparator, OutlineConfigKeys, OutlineTarget } from 'vs/workbench/services/outline/browser/outline';
-import { ThemeIcon } from 'vs/base/common/themables';
-import { mainWindow } from 'vs/base/browser/window';
 
 export type DocumentSymbolItem = OutlineGroup | OutlineElement;
 

--- a/src/vs/workbench/contrib/codeEditor/browser/outline/documentSymbolsTree.ts
+++ b/src/vs/workbench/contrib/codeEditor/browser/outline/documentSymbolsTree.ts
@@ -3,27 +3,27 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import 'vs/css!./documentSymbolsTree';
+import 'vs/editor/contrib/symbolIcons/browser/symbolIcons'; // The codicon symbol colors are defined here and must be loaded to get colors
 import * as dom from 'vs/base/browser/dom';
 import { HighlightedLabel } from 'vs/base/browser/ui/highlightedlabel/highlightedLabel';
-import { IconLabel, IIconLabelValueOptions } from 'vs/base/browser/ui/iconLabel/iconLabel';
 import { IIdentityProvider, IKeyboardNavigationLabelProvider, IListVirtualDelegate } from 'vs/base/browser/ui/list/list';
-import { IListAccessibilityProvider } from 'vs/base/browser/ui/list/listWidget';
-import { ITreeFilter, ITreeNode, ITreeRenderer } from 'vs/base/browser/ui/tree/tree';
-import { mainWindow } from 'vs/base/browser/window';
+import { ITreeNode, ITreeRenderer, ITreeFilter } from 'vs/base/browser/ui/tree/tree';
 import { createMatches, FuzzyScore } from 'vs/base/common/filters';
-import { ThemeIcon } from 'vs/base/common/themables';
-import 'vs/css!./documentSymbolsTree';
 import { Range } from 'vs/editor/common/core/range';
-import { getAriaLabelForSymbol, SymbolKind, symbolKindNames, SymbolKinds, SymbolTag } from 'vs/editor/common/languages';
-import { ITextResourceConfigurationService } from 'vs/editor/common/services/textResourceConfiguration';
+import { SymbolKind, SymbolKinds, SymbolTag, getAriaLabelForSymbol, symbolKindNames } from 'vs/editor/common/languages';
 import { OutlineElement, OutlineGroup, OutlineModel } from 'vs/editor/contrib/documentSymbols/browser/outlineModel';
-import 'vs/editor/contrib/symbolIcons/browser/symbolIcons'; // The codicon symbol colors are defined here and must be loaded to get colors
 import { localize } from 'vs/nls';
+import { IconLabel, IIconLabelValueOptions } from 'vs/base/browser/ui/iconLabel/iconLabel';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { MarkerSeverity } from 'vs/platform/markers/common/markers';
-import { listErrorForeground, listWarningForeground } from 'vs/platform/theme/common/colorRegistry';
 import { IThemeService } from 'vs/platform/theme/common/themeService';
+import { listErrorForeground, listWarningForeground } from 'vs/platform/theme/common/colorRegistry';
+import { ITextResourceConfigurationService } from 'vs/editor/common/services/textResourceConfiguration';
+import { IListAccessibilityProvider } from 'vs/base/browser/ui/list/listWidget';
 import { IOutlineComparator, OutlineConfigKeys, OutlineTarget } from 'vs/workbench/services/outline/browser/outline';
+import { ThemeIcon } from 'vs/base/common/themables';
+import { mainWindow } from 'vs/base/browser/window';
 
 export type DocumentSymbolItem = OutlineGroup | OutlineElement;
 

--- a/src/vs/workbench/contrib/codeEditor/browser/saveParticipants.ts
+++ b/src/vs/workbench/contrib/codeEditor/browser/saveParticipants.ts
@@ -291,13 +291,11 @@ class CodeActionOnSaveParticipant implements ITextFileSaveParticipant {
 	private async triggerCodeActionsCommand() {
 		if (this.configurationService.getValue<boolean>('editor.codeActions.triggerOnFocusChange') && this.configurationService.getValue<string>('files.autoSave') === 'afterDelay') {
 			const model = this.codeEditorService.getActiveCodeEditor()?.getModel();
-
 			if (!model) {
-				return;
+				return undefined;
 			}
 
 			const settingsOverrides = { overrideIdentifier: model.getLanguageId(), resource: model.uri };
-
 			const setting = this.configurationService.getValue<{ [kind: string]: string | boolean } | string[]>('editor.codeActionsOnSave', settingsOverrides);
 
 			if (!setting) {
@@ -311,14 +309,14 @@ class CodeActionOnSaveParticipant implements ITextFileSaveParticipant {
 			const settingItems: string[] = Object.keys(setting).filter(x => setting[x] && setting[x] === 'always' && CodeActionKind.Source.contains(new HierarchicalKind(x)));
 
 			const cancellationTokenSource = new CancellationTokenSource();
-			const token = cancellationTokenSource.token;
 
 			const codeActionKindList = [];
 			for (const item of settingItems) {
 				codeActionKindList.push(new HierarchicalKind(item));
 			}
 
-			await this.applyOnSaveActions(model, codeActionKindList, [], Progress.None, token);
+			// run code actions based on what is found from setting === 'always', no exclusions.
+			await this.applyOnSaveActions(model, codeActionKindList, [], Progress.None, cancellationTokenSource.token);
 		}
 	}
 

--- a/src/vs/workbench/contrib/codeEditor/browser/saveParticipants.ts
+++ b/src/vs/workbench/contrib/codeEditor/browser/saveParticipants.ts
@@ -269,7 +269,7 @@ class FormatOnSaveParticipant implements ITextFileSaveParticipant {
 	}
 }
 
-class CodeActionOnSaveParticipant implements ITextFileSaveParticipant {
+class CodeActionOnSaveParticipant extends Disposable implements ITextFileSaveParticipant {
 
 	constructor(
 		@IConfigurationService private readonly configurationService: IConfigurationService,
@@ -279,13 +279,10 @@ class CodeActionOnSaveParticipant implements ITextFileSaveParticipant {
 		@IEditorService private readonly editorService: IEditorService,
 		@ICodeEditorService private readonly codeEditorService: ICodeEditorService,
 	) {
-		this.hostService.onDidChangeFocus(async () => {
-			this.triggerCodeActionsCommand();
-		});
+		super();
 
-		this.editorService.onDidActiveEditorChange(async () => {
-			this.triggerCodeActionsCommand();
-		});
+		this._register(this.hostService.onDidChangeFocus(() => { this.triggerCodeActionsCommand(); }));
+		this._register(this.editorService.onDidActiveEditorChange(() => { this.triggerCodeActionsCommand(); }));
 	}
 
 	private async triggerCodeActionsCommand() {

--- a/src/vs/workbench/contrib/codeEditor/browser/saveParticipants.ts
+++ b/src/vs/workbench/contrib/codeEditor/browser/saveParticipants.ts
@@ -17,17 +17,15 @@ import { Selection } from 'vs/editor/common/core/selection';
 import { CodeActionProvider, CodeActionTriggerType } from 'vs/editor/common/languages';
 import { ITextModel } from 'vs/editor/common/model';
 import { ILanguageFeaturesService } from 'vs/editor/common/services/languageFeatures';
-import { IModelService } from 'vs/editor/common/services/model';
 import { ApplyCodeActionReason, applyCodeAction, getCodeActions } from 'vs/editor/contrib/codeAction/browser/codeAction';
 import { CodeActionKind, CodeActionTriggerSource } from 'vs/editor/contrib/codeAction/common/types';
 import { FormattingMode, formatDocumentRangesWithSelectedProvider, formatDocumentWithSelectedProvider } from 'vs/editor/contrib/format/browser/format';
 import { SnippetController2 } from 'vs/editor/contrib/snippet/browser/snippetController2';
 import { localize } from 'vs/nls';
-import { ICommandService } from 'vs/platform/commands/common/commands';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { ExtensionIdentifier } from 'vs/platform/extensions/common/extensions';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
-import { IProgress, IProgressService, IProgressStep, Progress } from 'vs/platform/progress/common/progress';
+import { IProgress, IProgressStep, Progress } from 'vs/platform/progress/common/progress';
 import { Registry } from 'vs/platform/registry/common/platform';
 import { IWorkbenchContribution, IWorkbenchContributionsRegistry, Extensions as WorkbenchContributionsExtensions } from 'vs/workbench/common/contributions';
 import { SaveReason } from 'vs/workbench/common/editor';
@@ -279,11 +277,7 @@ class CodeActionOnSaveParticipant implements ITextFileSaveParticipant {
 		@ILanguageFeaturesService private readonly languageFeaturesService: ILanguageFeaturesService,
 		@IHostService private readonly hostService: IHostService,
 		@IEditorService private readonly editorService: IEditorService,
-		@ICommandService private readonly commandService: ICommandService,
-		@IModelService private readonly modelService: IModelService,
 		@ICodeEditorService private readonly codeEditorService: ICodeEditorService,
-		@IProgressService private readonly progressService: IProgressService,
-
 	) {
 		this.hostService.onDidChangeFocus(async () => {
 			this.triggerCodeActionsCommand();


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
ref: https://github.com/microsoft/vscode/issues/200881

This will trigger code actions for organize imports when the following conditions are applied:
- file auto save is set to `afterDelay`
- editor code actions (`source.organizeImports`) is set to `always`
- setting: `editor.codeActions.triggerOnFocusChange` is `true` (default is false)

note: will still be triggered when `afterDelay` is on and we manually trigger a safe (same as current behavior) 

TLDR: we match the behavior of `onFocusChange` or `onWindowChange` save styles when code actions are `always` and our save style is `afterDelay`

