### PR TITLE
Fix bad accessor use in reveal in explorer

### DIFF
--- a/src/vs/workbench/contrib/files/browser/fileCommands.ts
+++ b/src/vs/workbench/contrib/files/browser/fileCommands.ts
@@ -315,6 +315,7 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 CommandsRegistry.registerCommand({
 	id: REVEAL_IN_EXPLORER_COMMAND_ID,
 	handler: async (accessor, resource: URI | object) => {
+		const explorerService = accessor.get(IExplorerService);
 		const viewService = accessor.get(IViewsService);
 		const contextService = accessor.get(IWorkspaceContextService);
 		const uri = getResourceForCommand(accessor, resource);
@@ -327,7 +328,6 @@ CommandsRegistry.registerCommand({
 				// Fixes #197268
 				explorerView.autoReveal = false;
 				explorerView.setExpanded(true);
-				const explorerService = accessor.get(IExplorerService);
 				await explorerService.select(uri, 'force');
 				explorerView.focus();
 				explorerView.autoReveal = oldAutoReveal;


### PR DESCRIPTION
Fixes #221818
Caused by 8605691877fdefb35e043ea2a11f1f311bb5ad16

@benibenj you can't use an accessor after an await. You might have introduced other cases
cc @lramos15 

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
