### PR TITLE
do not implicitly add `onTaskType:x` activation events for extensions which contribute a task of type `x`

### DIFF
--- a/src/vs/workbench/contrib/tasks/common/taskDefinitionRegistry.ts
+++ b/src/vs/workbench/contrib/tasks/common/taskDefinitionRegistry.ts
@@ -83,13 +83,6 @@ namespace Configuration {
 
 const taskDefinitionsExtPoint = ExtensionsRegistry.registerExtensionPoint<Configuration.ITaskDefinition[]>({
 	extensionPoint: 'taskDefinitions',
-	activationEventsGenerator: (contributions: Configuration.ITaskDefinition[], result: { push(item: string): void }) => {
-		for (const task of contributions) {
-			if (task.type) {
-				result.push(`onTaskType:${task.type}`);
-			}
-		}
-	},
 	jsonSchema: {
 		description: nls.localize('TaskDefinitionExtPoint', 'Contributes task kinds'),
 		type: 'array',


### PR DESCRIPTION
fix #192043

see https://github.com/microsoft/vscode/issues/192043#issuecomment-2233904025
