### PR TITLE
Fix terminal `__vsc_first_prompt` errors with bash in `nounset` mode

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/media/shellIntegration-bash.sh
+++ b/src/vs/workbench/contrib/terminal/browser/media/shellIntegration-bash.sh
@@ -210,7 +210,7 @@ __vsc_update_cwd() {
 }
 
 __vsc_command_output_start() {
-	if [[ -z "$__vsc_first_prompt" ]]; then
+	if [[ -z "${__vsc_first_prompt-}" ]]; then
 		builtin return
 	fi
 	builtin printf '\e]633;E;%s;%s\a' "$(__vsc_escape_value "${__vsc_current_command}")" $__vsc_nonce
@@ -226,7 +226,7 @@ __vsc_continuation_end() {
 }
 
 __vsc_command_complete() {
-	if [[ -z "$__vsc_first_prompt" ]]; then
+	if [[ -z "${__vsc_first_prompt-}" ]]; then
 		builtin return
 	fi
 	if [ "$__vsc_current_command" = "" ]; then


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
