### PR TITLE
fix: incorrect roles defined for settings switcher

### DIFF
--- a/src/vs/base/browser/ui/actionbar/actionViewItems.ts
+++ b/src/vs/base/browser/ui/actionbar/actionViewItems.ts
@@ -25,6 +25,7 @@ import { getBaseLayerHoverDelegate } from 'vs/base/browser/ui/hover/hoverDelegat
 export interface IBaseActionViewItemOptions {
 	draggable?: boolean;
 	isMenu?: boolean;
+	isTabList?: boolean;
 	useEventAsContext?: boolean;
 	hoverDelegate?: IHoverDelegate;
 }
@@ -313,12 +314,14 @@ export class ActionViewItem extends BaseActionViewItem {
 		this.updateChecked();
 	}
 
-	private getDefaultAriaRole(): 'presentation' | 'menuitem' | 'button' {
+	private getDefaultAriaRole(): 'presentation' | 'menuitem' | 'tab' | 'button' {
 		if (this._action.id === Separator.ID) {
 			return 'presentation'; // A separator is a presentation item
 		} else {
 			if (this.options.isMenu) {
 				return 'menuitem';
+			} else if (this.options.isTabList) {
+				return 'tab';
 			} else {
 				return 'button';
 			}
@@ -421,11 +424,15 @@ export class ActionViewItem extends BaseActionViewItem {
 		if (this.label) {
 			if (this.action.checked !== undefined) {
 				this.label.classList.toggle('checked', this.action.checked);
-				this.label.setAttribute('aria-checked', this.action.checked ? 'true' : 'false');
-				this.label.setAttribute('role', 'checkbox');
+				if (this.options.isTabList) {
+					this.label.setAttribute('aria-selected', this.action.checked ? 'true' : 'false');
+				} else {
+					this.label.setAttribute('aria-checked', this.action.checked ? 'true' : 'false');
+					this.label.setAttribute('role', 'checkbox');
+				}
 			} else {
 				this.label.classList.remove('checked');
-				this.label.removeAttribute('aria-checked');
+				this.label.removeAttribute(this.options.isTabList ? 'aria-selected' : 'aria-checked');
 				this.label.setAttribute('role', this.getDefaultAriaRole());
 			}
 		}

--- a/src/vs/base/browser/ui/actionbar/actionbar.ts
+++ b/src/vs/base/browser/ui/actionbar/actionbar.ts
@@ -357,7 +357,7 @@ export class ActionBar extends Disposable implements IActionRunner {
 
 			let item: IActionViewItem | undefined;
 
-			const viewItemOptions = { hoverDelegate: this._hoverDelegate, ...options };
+			const viewItemOptions: IActionViewItemOptions = { hoverDelegate: this._hoverDelegate, ...options, isTabList: this.options.ariaRole === 'tablist' };
 			if (this.options.actionViewItemProvider) {
 				item = this.options.actionViewItemProvider(action, viewItemOptions);
 			}

--- a/src/vs/workbench/contrib/preferences/browser/preferencesWidgets.ts
+++ b/src/vs/workbench/contrib/preferences/browser/preferencesWidgets.ts
@@ -261,6 +261,7 @@ export class SettingsTargetsWidget extends Widget {
 			orientation: ActionsOrientation.HORIZONTAL,
 			focusOnlyEnabledItems: true,
 			ariaLabel: localize('settingsSwitcherBarAriaLabel', "Settings Switcher"),
+			ariaRole: 'tablist',
 			actionViewItemProvider: (action: IAction, options: IActionViewItemOptions) => action.id === 'folderSettings' ? this.folderSettings : undefined
 		}));
 


### PR DESCRIPTION
Ref #214227

This PR corrects the roles of the Settings editor settings scope switcher from menuitem/checkbox to tablist/tab. One downside is that elements with tab roles are supposed to have matching elements with tabpanel roles. I plan to add that in a future PR.

Edit: elements with tab roles do not have to have matching elements with tabpanel roles, and both NVDA and Accessibility Insights for Windows don't seem to call out the aria-controls attribute and tabpanel role even when I add the aria-controls attribute to the tab and the tabpanel role to the Settings editor body div. I'll merge the changes as-is and add the new role if prompted. CC @meganrogge 

![NVDA showing new tab roles of settings scope switcher](https://github.com/user-attachments/assets/1b5c1d2f-a895-4a71-8b66-5cab243f5f9a)

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
