### PR TITLE
chore: polish APIScan and BinSkim scans

### DIFF
--- a/build/azure-pipelines/product-build.yml
+++ b/build/azure-pipelines/product-build.yml
@@ -329,6 +329,7 @@ extends:
               steps:
                 - template: build/azure-pipelines/win32/sdl-scan-win32.yml@self
                   parameters:
+                    VSCODE_ARCH: x64
                     VSCODE_QUALITY: ${{ variables.VSCODE_QUALITY }}
 
       - ${{ if and(eq(parameters.VSCODE_COMPILE_ONLY, false), eq(variables['VSCODE_BUILD_STAGE_WINDOWS'], true)) }}:

--- a/build/azure-pipelines/product-build.yml
+++ b/build/azure-pipelines/product-build.yml
@@ -316,17 +316,20 @@ extends:
                       VSCODE_QUALITY: ${{ variables.VSCODE_QUALITY }}
                       VSCODE_BUILD_WIN32_ARM64: ${{ parameters.VSCODE_BUILD_WIN32_ARM64 }}
 
-      - stage: CustomSDL
-        dependsOn: []
-        pool:
-          name: 1es-windows-2019-x64
-          os: windows
-        jobs:
-          - job: WindowsSDL
-            variables:
-              - group: 'API Scan'
-            steps:
-              - template: build/azure-pipelines/sdl-scan.yml@self
+      - ${{ if and(eq(variables['VSCODE_CIBUILD'], false), eq(parameters.VSCODE_COMPILE_ONLY, false), eq(parameters.VSCODE_STEP_ON_IT, false)) }}:
+        - stage: CustomSDL
+          dependsOn: []
+          pool:
+            name: 1es-windows-2019-x64
+            os: windows
+          jobs:
+            - job: WindowsSDL
+              variables:
+                - group: 'API Scan'
+              steps:
+                - template: build/azure-pipelines/win32/sdl-scan-win32.yml@self
+                  parameters:
+                    VSCODE_QUALITY: ${{ variables.VSCODE_QUALITY }}
 
       - ${{ if and(eq(parameters.VSCODE_COMPILE_ONLY, false), eq(variables['VSCODE_BUILD_STAGE_WINDOWS'], true)) }}:
         - stage: Windows

--- a/build/azure-pipelines/product-build.yml
+++ b/build/azure-pipelines/product-build.yml
@@ -316,7 +316,7 @@ extends:
                       VSCODE_QUALITY: ${{ variables.VSCODE_QUALITY }}
                       VSCODE_BUILD_WIN32_ARM64: ${{ parameters.VSCODE_BUILD_WIN32_ARM64 }}
 
-      - ${{ if and(eq(variables['VSCODE_CIBUILD'], false), eq(parameters.VSCODE_COMPILE_ONLY, false), eq(parameters.VSCODE_STEP_ON_IT, false)) }}:
+      - ${{ if and(eq(variables['VSCODE_CIBUILD'], false), eq(parameters.VSCODE_COMPILE_ONLY, false)) }}:
         - stage: CustomSDL
           dependsOn: []
           pool:

--- a/build/azure-pipelines/win32/sdl-scan-win32.yml
+++ b/build/azure-pipelines/win32/sdl-scan-win32.yml
@@ -9,6 +9,9 @@ parameters:
   - name: VSCODE_ARCH
     type: string
     default: x64
+  - name: VSCODE_QUALITY
+    type: string
+    default: stable
 
 steps:
   - task: NodeTool@0
@@ -17,7 +20,7 @@ steps:
       versionFilePath: .nvmrc
       nodejsMirror: https://github.com/joaomoreno/node-mirror/releases/download
 
-  - template: ./distro/download-distro.yml
+  - template: ./distro/download-distro.yml@self
 
   - task: AzureKeyVault@1
     displayName: "Azure Key Vault: Get Secrets"
@@ -25,6 +28,10 @@ steps:
       azureSubscription: "vscode-builds-subscription"
       KeyVaultName: vscode-build-secrets
       SecretsFilter: "github-distro-mixin-password"
+
+  - powershell: node build/setup-npm-registry.js $env:NPM_REGISTRY
+    condition: and(succeeded(), ne(variables['NPM_REGISTRY'], 'none'))
+    displayName: Setup NPM Registry
 
   - powershell: |
       . build/azure-pipelines/win32/exec.ps1
@@ -44,22 +51,12 @@ steps:
     condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'), ne('${{ parameters.NPM_REGISTRY }}', 'none'))
     displayName: Setup NPM Authentication
 
-  - powershell: |
-      . build/azure-pipelines/win32/exec.ps1
-      $ErrorActionPreference = "Stop"
-      exec { node build/setup-npm-registry.js "${{ parameters.NPM_REGISTRY }}" }
-    condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'), ne('${{ parameters.NPM_REGISTRY }}', 'none'))
-    displayName: Setup NPM Registry
-
   - pwsh: |
       $includes = @'
         {
           'target_defaults': {
             'conditions': [
               ['OS=="win"', {
-                'msvs_configuration_attributes': {
-                  'SpectreMitigation': 'Spectre'
-                },
                 'msvs_settings': {
                   'VCCLCompilerTool': {
                     'AdditionalOptions': [
@@ -91,9 +88,10 @@ steps:
       $ErrorActionPreference = "Stop"
       retry { exec { yarn --frozen-lockfile --check-files } }
     env:
+      npm_config_arch: $(VSCODE_ARCH)
+      CHILD_CONCURRENCY: 1
       PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
       GITHUB_TOKEN: "$(github-distro-mixin-password)"
-      CHILD_CONCURRENCY: 1
     displayName: Install dependencies
 
   - script: node build/azure-pipelines/distro/mixin-npm
@@ -102,15 +100,29 @@ steps:
   - script: node build/azure-pipelines/distro/mixin-quality
     displayName: Mixin distro quality
     env:
-      VSCODE_QUALITY: stable
+      VSCODE_QUALITY: ${{ parameters.VSCODE_QUALITY }}
 
   - powershell: yarn compile
     displayName: Compile
+
+  - powershell: |
+      Get-ChildItem '$(Agent.BuildDirectory)\scanbin' -Recurse -Filter "*.exe"
+      Get-ChildItem '$(Agent.BuildDirectory)\scanbin' -Recurse -Filter "*.dll"
+      Get-ChildItem '$(Agent.BuildDirectory)\scanbin' -Recurse -Filter "*.node"
+      Get-ChildItem '$(Agent.BuildDirectory)\scanbin' -Recurse -Filter "*.pdb"
+    displayName: List files
 
   - powershell: yarn gulp "vscode-symbols-win32-${{ parameters.VSCODE_ARCH }}"
     env:
       GITHUB_TOKEN: "$(github-distro-mixin-password)"
     displayName: Download Symbols
+
+  - powershell: |
+      Get-ChildItem '$(Agent.BuildDirectory)\scanbin' -Recurse -Filter "*.exe"
+      Get-ChildItem '$(Agent.BuildDirectory)\scanbin' -Recurse -Filter "*.dll"
+      Get-ChildItem '$(Agent.BuildDirectory)\scanbin' -Recurse -Filter "*.node"
+      Get-ChildItem '$(Agent.BuildDirectory)\scanbin' -Recurse -Filter "*.pdb"
+    displayName: List files again
 
   - task: BinSkim@4
     inputs:
@@ -118,15 +130,15 @@ steps:
       Function: "analyze"
       TargetPattern: "guardianGlob"
       AnalyzeIgnorePdbLoadError: true
-      AnalyzeTargetGlob: '$(agent.builddirectory)\scanbin\**.dll;$(agent.builddirectory)\scanbin\**.exe;$(agent.builddirectory)\scanbin\**.node'
-      AnalyzeLocalSymbolDirectories: '$(agent.builddirectory)\scanbin\VSCode-win32-${{ parameters.VSCODE_ARCH }}\pdb'
+      AnalyzeTargetGlob: '$(Agent.BuildDirectory)\scanbin\**.dll;$(Agent.BuildDirectory)\scanbin\**.exe;$(Agent.BuildDirectory)\scanbin\**.node'
+      AnalyzeLocalSymbolDirectories: '$(Agent.BuildDirectory)\scanbin\VSCode-win32-${{ parameters.VSCODE_ARCH }}\pdb'
 
   - task: CopyFiles@2
     displayName: 'Collect Symbols for API Scan'
     inputs:
       SourceFolder: $(Agent.BuildDirectory)
       Contents: 'scanbin\**\*.pdb'
-      TargetFolder: '$(agent.builddirectory)\symbols'
+      TargetFolder: '$(Agent.BuildDirectory)\symbols'
       flattenFolders: true
     condition: succeeded()
 

--- a/build/azure-pipelines/win32/sdl-scan-win32.yml
+++ b/build/azure-pipelines/win32/sdl-scan-win32.yml
@@ -20,7 +20,7 @@ steps:
       versionFilePath: .nvmrc
       nodejsMirror: https://github.com/joaomoreno/node-mirror/releases/download
 
-  - template: ./distro/download-distro.yml@self
+  - template: ../distro/download-distro.yml@self
 
   - task: AzureKeyVault@1
     displayName: "Azure Key Vault: Get Secrets"

--- a/build/azure-pipelines/win32/sdl-scan-win32.yml
+++ b/build/azure-pipelines/win32/sdl-scan-win32.yml
@@ -1,8 +1,4 @@
 parameters:
-  - name: NPM_REGISTRY
-    displayName: "Custom NPM Registry"
-    type: string
-    default: "https://pkgs.dev.azure.com/monacotools/Monaco/_packaging/vscode/npm/registry/"
   - name: NPM_ARCH
     type: string
     default: x64
@@ -19,6 +15,11 @@ steps:
       versionSource: fromFile
       versionFilePath: .nvmrc
       nodejsMirror: https://github.com/joaomoreno/node-mirror/releases/download
+
+  - task: UsePythonVersion@0
+    inputs:
+      versionSpec: "3.x"
+      addToPath: true
 
   - template: ../distro/download-distro.yml@self
 

--- a/build/azure-pipelines/win32/sdl-scan-win32.yml
+++ b/build/azure-pipelines/win32/sdl-scan-win32.yml
@@ -89,7 +89,7 @@ steps:
       $ErrorActionPreference = "Stop"
       retry { exec { yarn --frozen-lockfile --check-files } }
     env:
-      npm_config_arch: $(VSCODE_ARCH)
+      npm_config_arch: ${{ parameters.VSCODE_ARCH }}
       CHILD_CONCURRENCY: 1
       ELECTRON_SKIP_BINARY_DOWNLOAD: 1
       PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1

--- a/build/azure-pipelines/win32/sdl-scan-win32.yml
+++ b/build/azure-pipelines/win32/sdl-scan-win32.yml
@@ -108,10 +108,10 @@ steps:
     displayName: Compile
 
   - powershell: |
-      Get-ChildItem '$(Agent.BuildDirectory)\scanbin' -Recurse -Filter "*.exe"
-      Get-ChildItem '$(Agent.BuildDirectory)\scanbin' -Recurse -Filter "*.dll"
-      Get-ChildItem '$(Agent.BuildDirectory)\scanbin' -Recurse -Filter "*.node"
-      Get-ChildItem '$(Agent.BuildDirectory)\scanbin' -Recurse -Filter "*.pdb"
+      Get-ChildItem '$(Build.SourcesDirectory)' -Recurse -Filter "*.exe"
+      Get-ChildItem '$(Build.SourcesDirectory)' -Recurse -Filter "*.dll"
+      Get-ChildItem '$(Build.SourcesDirectory)' -Recurse -Filter "*.node"
+      Get-ChildItem '$(Build.SourcesDirectory)' -Recurse -Filter "*.pdb"
     displayName: List files
 
   - powershell: yarn gulp "vscode-symbols-win32-${{ parameters.VSCODE_ARCH }}"

--- a/build/azure-pipelines/win32/sdl-scan-win32.yml
+++ b/build/azure-pipelines/win32/sdl-scan-win32.yml
@@ -38,13 +38,13 @@ steps:
       # for GET requests to the registry.
       exec { Add-Content -Path .npmrc -Value "always-auth=true" }
       exec { yarn config set registry "$env:NPM_REGISTRY" }
-    condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'), ne(variables['NPM_REGISTRY'], 'none'))
+    condition: and(succeeded(), ne(variables['NPM_REGISTRY'], 'none'))
     displayName: Setup NPM & Yarn
 
   - task: npmAuthenticate@0
     inputs:
       workingFile: .npmrc
-    condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'), ne(variables['NPM_REGISTRY'], 'none'))
+    condition: and(succeeded(), ne(variables['NPM_REGISTRY'], 'none'))
     displayName: Setup NPM Authentication
 
   - pwsh: |

--- a/build/azure-pipelines/win32/sdl-scan-win32.yml
+++ b/build/azure-pipelines/win32/sdl-scan-win32.yml
@@ -47,12 +47,17 @@ steps:
     condition: and(succeeded(), ne(variables['NPM_REGISTRY'], 'none'))
     displayName: Setup NPM Authentication
 
+  # Remove msvs_configuration_attributes once kerberos 2.1.2-alpha.0 or newer is available.
+  # Ref https://github.com/mongodb-js/kerberos/pull/187.
   - pwsh: |
       $includes = @'
         {
           'target_defaults': {
             'conditions': [
               ['OS=="win"', {
+                'msvs_configuration_attributes': {
+                  'SpectreMitigation': 'Spectre'
+                },
                 'msvs_settings': {
                   'VCCLCompilerTool': {
                     'AdditionalOptions': [

--- a/build/azure-pipelines/win32/sdl-scan-win32.yml
+++ b/build/azure-pipelines/win32/sdl-scan-win32.yml
@@ -1,13 +1,8 @@
 parameters:
-  - name: NPM_ARCH
-    type: string
-    default: x64
   - name: VSCODE_ARCH
     type: string
-    default: x64
   - name: VSCODE_QUALITY
     type: string
-    default: stable
 
 steps:
   - task: NodeTool@0

--- a/build/azure-pipelines/win32/sdl-scan-win32.yml
+++ b/build/azure-pipelines/win32/sdl-scan-win32.yml
@@ -37,19 +37,19 @@ steps:
   - powershell: |
       . build/azure-pipelines/win32/exec.ps1
       $ErrorActionPreference = "Stop"
-      exec { npm config set registry "${{ parameters.NPM_REGISTRY }}" --location=project }
+      exec { npm config set registry "$env:NPM_REGISTRY" --location=project }
       # npm >v7 deprecated the `always-auth` config option, refs npm/cli@72a7eeb
       # following is a workaround for yarn to send authorization header
       # for GET requests to the registry.
       exec { Add-Content -Path .npmrc -Value "always-auth=true" }
-      exec { yarn config set registry "${{ parameters.NPM_REGISTRY }}" }
-    condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'), ne('${{ parameters.NPM_REGISTRY }}', 'none'))
+      exec { yarn config set registry "$env:NPM_REGISTRY" }
+    condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'), ne(variables['NPM_REGISTRY'], 'none'))
     displayName: Setup NPM & Yarn
 
   - task: npmAuthenticate@0
     inputs:
       workingFile: .npmrc
-    condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'), ne('${{ parameters.NPM_REGISTRY }}', 'none'))
+    condition: and(succeeded(), ne(variables.NODE_MODULES_RESTORED, 'true'), ne(variables['NPM_REGISTRY'], 'none'))
     displayName: Setup NPM Authentication
 
   - pwsh: |

--- a/build/azure-pipelines/win32/sdl-scan-win32.yml
+++ b/build/azure-pipelines/win32/sdl-scan-win32.yml
@@ -91,6 +91,7 @@ steps:
     env:
       npm_config_arch: $(VSCODE_ARCH)
       CHILD_CONCURRENCY: 1
+      ELECTRON_SKIP_BINARY_DOWNLOAD: 1
       PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
       GITHUB_TOKEN: "$(github-distro-mixin-password)"
     displayName: Install dependencies

--- a/build/azure-pipelines/win32/sdl-scan-win32.yml
+++ b/build/azure-pipelines/win32/sdl-scan-win32.yml
@@ -146,10 +146,10 @@ steps:
 
   - task: APIScan@2
     inputs:
-      softwareFolder: $(agent.builddirectory)\scanbin
+      softwareFolder: $(Agent.BuildDirectory)\scanbin
       softwareName: 'vscode-client'
       softwareVersionNum: '1'
-      symbolsFolder: 'srv*https://symweb.azurefd.net;$(agent.builddirectory)\symbols'
+      symbolsFolder: 'srv*https://symweb.azurefd.net;$(Agent.BuildDirectory)\symbols'
       isLargeApp: false
       toolVersion: 'Latest'
       azureSubscription: 'vscode-apiscan'

--- a/build/azure-pipelines/win32/sdl-scan-win32.yml
+++ b/build/azure-pipelines/win32/sdl-scan-win32.yml
@@ -47,17 +47,12 @@ steps:
     condition: and(succeeded(), ne(variables['NPM_REGISTRY'], 'none'))
     displayName: Setup NPM Authentication
 
-  # Remove msvs_configuration_attributes once kerberos 2.1.2-alpha.0 or newer is available.
-  # Ref https://github.com/mongodb-js/kerberos/pull/187.
   - pwsh: |
       $includes = @'
         {
           'target_defaults': {
             'conditions': [
               ['OS=="win"', {
-                'msvs_configuration_attributes': {
-                  'SpectreMitigation': 'Spectre'
-                },
                 'msvs_settings': {
                   'VCCLCompilerTool': {
                     'AdditionalOptions': [


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Instead of integrating the CustomSDL stage into the Windows build, I believe it saves both pipeline run time and engineering time to keep the stage where it currently is. With the current stage, some compile steps are repeated, but they run in parallel to the rest of the pipeline. Because CustomSDL is isolated from the rest of the build, it also lowers the risk of accidentally publishing the product with symbols.

Pre-requisites before merging this PR:
- [x] Confirm whether electron.exe qualifies to be scanned, or whether we need to bring in Code.exe from a separate build process and scan that instead. @deepak1556 @rzhao271

