### PR TITLE
Handle empty edits for TS paste

### DIFF
--- a/extensions/typescript-language-features/src/languageFeatures/copyPaste.ts
+++ b/extensions/typescript-language-features/src/languageFeatures/copyPaste.ts
@@ -106,7 +106,7 @@ class DocumentPasteProvider implements vscode.DocumentPasteEditProvider {
 			pasteLocations: ranges.map(typeConverters.Range.toTextSpan),
 			copiedFrom
 		}, token));
-		if (response.type !== 'response' || !response.body || token.isCancellationRequested) {
+		if (response.type !== 'response' || !response.body?.edits.length || token.isCancellationRequested) {
 			return;
 		}
 


### PR DESCRIPTION
Should use default paste in this case. Talking with TS if this should be handled differently from the server but worth adding the workaround for now
