### PR TITLE
Support call stacks in test failures

### DIFF
--- a/src/vs/base/common/arrays.ts
+++ b/src/vs/base/common/arrays.ts
@@ -885,3 +885,18 @@ export class Permutation {
 		return new Permutation(inverseIndexMap);
 	}
 }
+
+/**
+ * Asynchronous variant of `Array.find()`, returning the first element in
+ * the array for which the predicate returns true.
+ *
+ * This implementation does not bail early and waits for all promises to
+ * resolve before returning.
+ */
+export async function findAsync<T>(array: readonly T[], predicate: (element: T, index: number) => Promise<boolean>): Promise<T | undefined> {
+	const results = await Promise.all(array.map(
+		async (element, index) => ({ element, ok: await predicate(element, index) })
+	));
+
+	return results.find(r => r.ok)?.element;
+}

--- a/src/vs/platform/actions/common/actions.ts
+++ b/src/vs/platform/actions/common/actions.ts
@@ -144,7 +144,6 @@ export class MenuId {
 	static readonly TestMessageContent = new MenuId('TestMessageContent');
 	static readonly TestPeekElement = new MenuId('TestPeekElement');
 	static readonly TestPeekTitle = new MenuId('TestPeekTitle');
-	static readonly TestCallStackContext = new MenuId('TestCallStackContext');
 	static readonly TouchBarContext = new MenuId('TouchBarContext');
 	static readonly TitleBarContext = new MenuId('TitleBarContext');
 	static readonly TitleBarTitleContext = new MenuId('TitleBarTitleContext');

--- a/src/vs/platform/actions/common/actions.ts
+++ b/src/vs/platform/actions/common/actions.ts
@@ -60,6 +60,7 @@ export class MenuId {
 	static readonly DebugWatchContext = new MenuId('DebugWatchContext');
 	static readonly DebugToolBar = new MenuId('DebugToolBar');
 	static readonly DebugToolBarStop = new MenuId('DebugToolBarStop');
+	static readonly DebugCallStackToolbar = new MenuId('DebugCallStackToolbar');
 	static readonly EditorContext = new MenuId('EditorContext');
 	static readonly SimpleEditorContext = new MenuId('SimpleEditorContext');
 	static readonly EditorContent = new MenuId('EditorContent');

--- a/src/vs/platform/actions/common/actions.ts
+++ b/src/vs/platform/actions/common/actions.ts
@@ -144,6 +144,7 @@ export class MenuId {
 	static readonly TestMessageContent = new MenuId('TestMessageContent');
 	static readonly TestPeekElement = new MenuId('TestPeekElement');
 	static readonly TestPeekTitle = new MenuId('TestPeekTitle');
+	static readonly TestCallStack = new MenuId('TestCallStack');
 	static readonly TouchBarContext = new MenuId('TouchBarContext');
 	static readonly TitleBarContext = new MenuId('TitleBarContext');
 	static readonly TitleBarTitleContext = new MenuId('TitleBarTitleContext');

--- a/src/vs/workbench/api/common/extHostTesting.ts
+++ b/src/vs/workbench/api/common/extHostTesting.ts
@@ -738,7 +738,7 @@ class TestRunTracker extends Disposable {
 
 		this.running++;
 		this.tasks.set(taskId, { run });
-		this.proxy.$startedTestRunTask(runId, { id: taskId, name, running: true });
+		this.proxy.$startedTestRunTask(runId, { id: taskId, ctrlId: this.dto.controllerId, name, running: true });
 
 		return run;
 	}

--- a/src/vs/workbench/contrib/debug/browser/callStackEditorContribution.ts
+++ b/src/vs/workbench/contrib/debug/browser/callStackEditorContribution.ts
@@ -48,18 +48,27 @@ const FOCUSED_STACK_FRAME_MARGIN: IModelDecorationOptions = {
 		color: themeColorFromId(focusedStackFrameColor)
 	}
 };
-const TOP_STACK_FRAME_DECORATION: IModelDecorationOptions = {
+export const TOP_STACK_FRAME_DECORATION: IModelDecorationOptions = {
 	description: 'top-stack-frame-decoration',
 	isWholeLine: true,
 	className: 'debug-top-stack-frame-line',
 	stickiness
 };
-const FOCUSED_STACK_FRAME_DECORATION: IModelDecorationOptions = {
+export const FOCUSED_STACK_FRAME_DECORATION: IModelDecorationOptions = {
 	description: 'focused-stack-frame-decoration',
 	isWholeLine: true,
 	className: 'debug-focused-stack-frame-line',
 	stickiness
 };
+
+export const makeStackFrameColumnDecoration = (noCharactersBefore: boolean): IModelDecorationOptions => ({
+	description: 'top-stack-frame-inline-decoration',
+	before: {
+		content: '\uEB8B',
+		inlineClassName: noCharactersBefore ? 'debug-top-stack-frame-column start-of-line' : 'debug-top-stack-frame-column',
+		inlineClassNameAffectsLetterSpacing: true
+	},
+});
 
 export function createDecorationsForStackFrame(stackFrame: IStackFrame, isFocusedSession: boolean, noCharactersBefore: boolean): IModelDeltaDecoration[] {
 	// only show decorations for the currently focused thread.
@@ -85,14 +94,7 @@ export function createDecorationsForStackFrame(stackFrame: IStackFrame, isFocuse
 
 		if (stackFrame.range.startColumn > 1) {
 			result.push({
-				options: {
-					description: 'top-stack-frame-inline-decoration',
-					before: {
-						content: '\uEB8B',
-						inlineClassName: noCharactersBefore ? 'debug-top-stack-frame-column start-of-line' : 'debug-top-stack-frame-column',
-						inlineClassNameAffectsLetterSpacing: true
-					},
-				},
+				options: makeStackFrameColumnDecoration(noCharactersBefore),
 				range: columnUntilEOLRange
 			});
 		}

--- a/src/vs/workbench/contrib/debug/browser/callStackWidget.ts
+++ b/src/vs/workbench/contrib/debug/browser/callStackWidget.ts
@@ -21,7 +21,7 @@ import 'vs/css!./media/callStackWidget';
 import { ICodeEditor } from 'vs/editor/browser/editorBrowser';
 import { CodeEditorWidget } from 'vs/editor/browser/widget/codeEditor/codeEditorWidget';
 import { EmbeddedCodeEditorWidget } from 'vs/editor/browser/widget/codeEditor/embeddedCodeEditorWidget';
-import { IEditorOptions } from 'vs/editor/common/config/editorOptions';
+import { EditorOption, IEditorOptions } from 'vs/editor/common/config/editorOptions';
 import { Range } from 'vs/editor/common/core/range';
 import { ScrollType } from 'vs/editor/common/editorCommon';
 import { Location } from 'vs/editor/common/languages';
@@ -287,7 +287,7 @@ const makeFrameElements = () => dom.h('div.multiCallStackFrame', [
 	])
 ]);
 
-const HEADER_HEIGHT = 40;
+const HEADER_HEIGHT = 32;
 
 interface IAbstractFrameRendererTemplateData {
 	container: HTMLElement;
@@ -391,14 +391,14 @@ class FrameCodeRenderer extends AbstractFrameRenderer<IStackTemplateData> {
 				EmbeddedCodeEditorWidget,
 				data.elements.editor,
 				editorOptions,
-				{},
+				{ isSimpleWidget: true },
 				this.containingEditor,
 			)
 			: this.instantiationService.createInstance(
 				CodeEditorWidget,
 				data.elements.editor,
 				editorOptions,
-				{},
+				{ isSimpleWidget: true },
 			);
 
 		data.templateStore.add(editor);
@@ -479,7 +479,7 @@ class FrameCodeRenderer extends AbstractFrameRenderer<IStackTemplateData> {
 
 	private revealEditor(item: WrappedCallStackFrame, editor: CodeEditorWidget, height = item.editorHeight.get()) {
 		const top = editor.getTopForPosition(item.line ?? 1, item.column ?? 1);
-		editor.setScrollTop(top - height / 2, ScrollType.Immediate);
+		editor.setScrollTop(top - (height - editor.getOption(EditorOption.lineHeight)) / 2, ScrollType.Immediate);
 	}
 }
 

--- a/src/vs/workbench/contrib/debug/browser/callStackWidget.ts
+++ b/src/vs/workbench/contrib/debug/browser/callStackWidget.ts
@@ -11,16 +11,19 @@ import { assertNever } from 'vs/base/common/assert';
 import { CancellationToken, CancellationTokenSource } from 'vs/base/common/cancellation';
 import { Codicon } from 'vs/base/common/codicons';
 import { Emitter, Event } from 'vs/base/common/event';
-import { Disposable, DisposableStore, toDisposable } from 'vs/base/common/lifecycle';
-import { autorun, derived, IObservable, observableValue } from 'vs/base/common/observable';
+import { Disposable, DisposableStore, IDisposable, toDisposable } from 'vs/base/common/lifecycle';
+import { autorun, autorunWithStore, derived, IObservable, ISettableObservable, observableValue } from 'vs/base/common/observable';
+import { ThemeIcon } from 'vs/base/common/themables';
 import { Constants } from 'vs/base/common/uint';
 import { URI } from 'vs/base/common/uri';
+import { generateUuid } from 'vs/base/common/uuid';
 import 'vs/css!./media/callStackWidget';
 import { ICodeEditor } from 'vs/editor/browser/editorBrowser';
 import { CodeEditorWidget } from 'vs/editor/browser/widget/codeEditor/codeEditorWidget';
 import { EmbeddedCodeEditorWidget } from 'vs/editor/browser/widget/codeEditor/embeddedCodeEditorWidget';
 import { IEditorOptions } from 'vs/editor/common/config/editorOptions';
 import { Range } from 'vs/editor/common/core/range';
+import { ScrollType } from 'vs/editor/common/editorCommon';
 import { Location } from 'vs/editor/common/languages';
 import { ITextModelService } from 'vs/editor/common/services/resolverService';
 import { localize, localize2 } from 'vs/nls';
@@ -54,9 +57,23 @@ export class SkippedCallFrames {
 	) { }
 }
 
-export type AnyStackFrame = SkippedCallFrames | CallStackFrame;
+export abstract class CustomStackFrame {
+	public readonly showHeader = observableValue('CustomStackFrame.showHeader', true);
+	public abstract readonly height: IObservable<number>;
+	public abstract readonly label: string;
+	public icon?: ThemeIcon;
+	public abstract render(container: HTMLElement): IDisposable;
+	public renderActions?(container: HTMLElement): IDisposable;
+}
 
-class WrappedCallStackFrame extends CallStackFrame {
+export type AnyStackFrame = SkippedCallFrames | CallStackFrame | CustomStackFrame;
+
+interface IFrameLikeItem {
+	readonly collapsed: ISettableObservable<boolean>;
+	readonly height: IObservable<number>;
+}
+
+class WrappedCallStackFrame extends CallStackFrame implements IFrameLikeItem {
 	public readonly editorHeight = observableValue('WrappedCallStackFrame.height', 100);
 	public readonly collapsed = observableValue('WrappedCallStackFrame.collapsed', false);
 
@@ -69,7 +86,18 @@ class WrappedCallStackFrame extends CallStackFrame {
 	}
 }
 
-type ListItem = WrappedCallStackFrame | SkippedCallFrames;
+class WrappedCustomStackFrame implements IFrameLikeItem {
+	public readonly collapsed = observableValue('WrappedCallStackFrame.collapsed', false);
+
+	public readonly height = derived(reader => {
+		const headerHeight = this.original.showHeader.read(reader) ? HEADER_HEIGHT : 0;
+		return this.collapsed.read(reader) ? headerHeight : headerHeight + this.original.height.read(reader);
+	});
+
+	constructor(public readonly original: CustomStackFrame) { }
+}
+
+type ListItem = WrappedCallStackFrame | SkippedCallFrames | WrappedCustomStackFrame;
 
 const WIDGET_CLASS_NAME = 'multiCallStackWidget';
 
@@ -102,10 +130,13 @@ export class CallStackWidget extends Disposable {
 			[
 				instantiationService.createInstance(FrameCodeRenderer, containingEditor, this.layoutEmitter.event),
 				instantiationService.createInstance(MissingCodeRenderer),
+				instantiationService.createInstance(CustomRenderer),
 				instantiationService.createInstance(SkippedRenderer, (i) => this.loadFrame(i)),
 			],
 			{
 				multipleSelectionSupport: false,
+				mouseSupport: false,
+				keyboardSupport: false,
 				accessibilityProvider: instantiationService.createInstance(StackAccessibilityProvider),
 			}
 		) as WorkbenchList<ListItem>);
@@ -143,12 +174,13 @@ export class CallStackWidget extends Disposable {
 	private mapFrames(frames: AnyStackFrame[]): ListItem[] {
 		const result: ListItem[] = [];
 		for (const frame of frames) {
-			if (!(frame instanceof CallStackFrame)) {
+			if (frame instanceof SkippedCallFrames) {
 				result.push(frame);
 				continue;
 			}
 
-			const wrapped = new WrappedCallStackFrame(frame);
+			const wrapped = frame instanceof CustomStackFrame
+				? new WrappedCustomStackFrame(frame) : new WrappedCallStackFrame(frame);
 			result.push(wrapped);
 
 			this.currentFramesDs.add(autorun(reader => {
@@ -172,6 +204,10 @@ class StackAccessibilityProvider implements IListAccessibilityProvider<ListItem>
 			return e.label;
 		}
 
+		if (e instanceof WrappedCustomStackFrame) {
+			return e.original.label;
+		}
+
 		if (e instanceof CallStackFrame) {
 			if (e.source && e.line) {
 				return localize({
@@ -192,7 +228,7 @@ class StackAccessibilityProvider implements IListAccessibilityProvider<ListItem>
 
 class StackDelegate implements IListVirtualDelegate<ListItem> {
 	getHeight(element: ListItem): number {
-		if (element instanceof CallStackFrame) {
+		if (element instanceof CallStackFrame || element instanceof WrappedCustomStackFrame) {
 			return element.height.get();
 		}
 		if (element instanceof SkippedCallFrames) {
@@ -209,21 +245,17 @@ class StackDelegate implements IListVirtualDelegate<ListItem> {
 		if (element instanceof SkippedCallFrames) {
 			return SkippedRenderer.templateId;
 		}
+		if (element instanceof WrappedCustomStackFrame) {
+			return CustomRenderer.templateId;
+		}
 
 		assertNever(element);
 	}
 }
 
-interface IStackTemplateData {
-	container: HTMLElement;
+interface IStackTemplateData extends IAbstractFrameRendererTemplateData {
 	editor: CodeEditorWidget;
-	label: ResourceLabel;
-	elements: ReturnType<typeof makeFrameElements>;
-	decorations: string[];
-	collapse: Button;
 	toolbar: MenuWorkbenchToolBar;
-	elementStore: DisposableStore;
-	templateStore: DisposableStore;
 }
 
 const editorOptions: IEditorOptions = {
@@ -234,13 +266,13 @@ const editorOptions: IEditorOptions = {
 		handleMouseWheel: false,
 		useShadows: false,
 	},
-	glyphMargin: false,
 	overviewRulerLanes: 0,
 	fixedOverflowWidgets: true,
 	overviewRulerBorder: false,
 	stickyScroll: { enabled: false },
 	minimap: { enabled: false },
 	readOnly: true,
+	automaticLayout: false,
 };
 
 const makeFrameElements = () => dom.h('div.multiCallStackFrame', [
@@ -257,8 +289,89 @@ const makeFrameElements = () => dom.h('div.multiCallStackFrame', [
 
 const HEADER_HEIGHT = 40;
 
+interface IAbstractFrameRendererTemplateData {
+	container: HTMLElement;
+	label: ResourceLabel;
+	elements: ReturnType<typeof makeFrameElements>;
+	decorations: string[];
+	collapse: Button;
+	elementStore: DisposableStore;
+	templateStore: DisposableStore;
+}
+
+abstract class AbstractFrameRenderer<T extends IAbstractFrameRendererTemplateData> implements IListRenderer<ListItem, T> {
+	public abstract templateId: string;
+
+	constructor(
+		@IInstantiationService protected readonly instantiationService: IInstantiationService,
+	) { }
+
+	renderTemplate(container: HTMLElement): T {
+		const elements = makeFrameElements();
+		container.appendChild(elements.root);
+
+
+		const templateStore = new DisposableStore();
+		container.classList.add('multiCallStackFrameContainer');
+		templateStore.add(toDisposable(() => {
+			container.classList.remove('multiCallStackFrameContainer');
+			elements.root.remove();
+		}));
+
+		const label = templateStore.add(this.instantiationService.createInstance(ResourceLabel, elements.title, {}));
+
+		const collapse = templateStore.add(new Button(elements.collapseButton, {}));
+
+		const contentId = generateUuid();
+		elements.editor.id = contentId;
+		elements.editor.role = 'region';
+		elements.collapseButton.setAttribute('aria-controls', contentId);
+
+		return this.finishRenderTemplate({
+			container,
+			decorations: [],
+			elements,
+			label,
+			collapse,
+			elementStore: templateStore.add(new DisposableStore()),
+			templateStore,
+		});
+	}
+
+	protected abstract finishRenderTemplate(data: IAbstractFrameRendererTemplateData): T;
+
+	renderElement(element: ListItem, index: number, template: T, height: number | undefined): void {
+		const { elementStore } = template;
+		elementStore.clear();
+		const item = element as IFrameLikeItem;
+
+		this.setupCollapseButton(item, template);
+	}
+
+	private setupCollapseButton(item: IFrameLikeItem, { elementStore, elements, collapse }: T) {
+		elementStore.add(autorun(reader => {
+			collapse.element.className = '';
+			const collapsed = item.collapsed.read(reader);
+			collapse.icon = collapsed ? Codicon.chevronRight : Codicon.chevronDown;
+			collapse.element.ariaExpanded = String(!collapsed);
+			elements.root.classList.toggle('collapsed', collapsed);
+		}));
+		elementStore.add(collapse.onDidClick(() => {
+			item.collapsed.set(!item.collapsed.get(), undefined);
+		}));
+	}
+
+	disposeElement(element: ListItem, index: number, templateData: T, height: number | undefined): void {
+		templateData.elementStore.clear();
+	}
+
+	disposeTemplate(templateData: T): void {
+		templateData.templateStore.dispose();
+	}
+}
+
 /** Renderer for a normal stack frame where code is available. */
-class FrameCodeRenderer implements IListRenderer<ListItem, IStackTemplateData> {
+class FrameCodeRenderer extends AbstractFrameRenderer<IStackTemplateData> {
 	public static readonly templateId = 'f';
 
 	public readonly templateId = FrameCodeRenderer.templateId;
@@ -267,64 +380,46 @@ class FrameCodeRenderer implements IListRenderer<ListItem, IStackTemplateData> {
 		private readonly containingEditor: ICodeEditor | undefined,
 		private readonly onLayout: Event<void>,
 		@ITextModelService private readonly modelService: ITextModelService,
-		@IInstantiationService private readonly instantiationService: IInstantiationService,
-	) { }
+		@IInstantiationService instantiationService: IInstantiationService,
+	) {
+		super(instantiationService);
+	}
 
-	renderTemplate(container: HTMLElement): IStackTemplateData {
-		const containingEditor = this.containingEditor;
-		const elements = makeFrameElements();
-		container.appendChild(elements.root);
-
-		const templateStore = new DisposableStore();
-		templateStore.add(toDisposable(() => dom.clearNode(elements.root)));
-
-		const editor = containingEditor
+	protected override finishRenderTemplate(data: IAbstractFrameRendererTemplateData): IStackTemplateData {
+		const editor = this.containingEditor
 			? this.instantiationService.createInstance(
 				EmbeddedCodeEditorWidget,
-				elements.editor,
+				data.elements.editor,
 				editorOptions,
 				{},
-				containingEditor,
+				this.containingEditor,
 			)
 			: this.instantiationService.createInstance(
 				CodeEditorWidget,
-				elements.editor,
+				data.elements.editor,
 				editorOptions,
 				{},
 			);
 
-		templateStore.add(editor);
+		data.templateStore.add(editor);
 
-		const label = templateStore.add(this.instantiationService.createInstance(ResourceLabel, elements.title, {}));
 
-		const toolbar = templateStore.add(this.instantiationService.createInstance(MenuWorkbenchToolBar, elements.actions, MenuId.DebugCallStackToolbar, {
+		const toolbar = data.templateStore.add(this.instantiationService.createInstance(MenuWorkbenchToolBar, data.elements.actions, MenuId.DebugCallStackToolbar, {
 			menuOptions: { shouldForwardArgs: true },
 			actionViewItemProvider: (action, options) => createActionViewItem(this.instantiationService, action, options),
 		}));
 
-		const collapse = templateStore.add(new Button(elements.collapseButton, {}));
-
-		return {
-			editor,
-			container,
-			decorations: [],
-			elements,
-			label,
-			toolbar,
-			collapse,
-			elementStore: templateStore.add(new DisposableStore()),
-			templateStore,
-		};
+		return { ...data, editor, toolbar };
 	}
 
-	renderElement(element: ListItem, index: number, template: IStackTemplateData, height: number | undefined): void {
+	override renderElement(element: ListItem, index: number, template: IStackTemplateData, height: number | undefined): void {
+		super.renderElement(element, index, template, height);
+
 		const { elementStore, editor } = template;
-		elementStore.clear();
 
 		const item = element as WrappedCallStackFrame;
 		const uri = item.source!;
 
-		this.setupCollapseButton(item, template);
 		this.setupEditorLayout(item, template);
 		template.label.element.setFile(uri);
 
@@ -342,26 +437,16 @@ class FrameCodeRenderer implements IListRenderer<ListItem, IStackTemplateData> {
 	}
 
 	private setupEditorLayout(item: WrappedCallStackFrame, { elementStore, container, editor }: IStackTemplateData) {
-		const layout = () => editor.layout({
-			width: container.clientWidth,
-			height: item.editorHeight.get(),
-		});
+		const layout = () => {
+			const height = item.editorHeight.get();
+			editor.layout({ width: container.clientWidth, height });
+			this.revealEditor(item, editor, height);
+		};
 		elementStore.add(this.onLayout(layout));
 		layout();
 	}
 
-	private setupCollapseButton(item: WrappedCallStackFrame, { elementStore, elements, collapse, editor }: IStackTemplateData) {
-		elementStore.add(autorun(reader => {
-			collapse.element.className = '';
-			collapse.icon = item.collapsed.read(reader) ? Codicon.chevronRight : Codicon.chevronDown;
-			elements.root.classList.toggle('collapsed', item.collapsed.get());
-		}));
-		elementStore.add(collapse.onDidClick(() => {
-			item.collapsed.set(!item.collapsed.get(), undefined);
-		}));
-	}
-
-	private setupEditorAfterModel(item: CallStackFrame, template: IStackTemplateData): void {
+	private setupEditorAfterModel(item: WrappedCallStackFrame, template: IStackTemplateData): void {
 		const range = Range.fromPositions({
 			column: item.column ?? 1,
 			lineNumber: item.line ?? 1,
@@ -369,21 +454,7 @@ class FrameCodeRenderer implements IListRenderer<ListItem, IStackTemplateData> {
 
 		template.toolbar.context = { uri: item.source, range };
 
-		template.editor.changeViewZones(vz => {
-			vz.addZone({
-				afterLineNumber: 0,
-				heightInLines: range.startLineNumber - 3,
-				domNode: document.createElement('div'),
-				showInHiddenAreas: true,
-			});
-			// vz.addZone({
-			// 	afterLineNumber: range.startLineNumber + 2,
-			// 	heightInLines: Constants.MAX_SAFE_SMALL_INTEGER,
-			// 	domNode: document.createElement('div'),
-			// });
-		});
-
-		template.editor.revealRangeInCenter(range);
+		this.revealEditor(item, template.editor);
 
 		template.editor.changeDecorations(accessor => {
 			for (const d of template.decorations) {
@@ -406,12 +477,9 @@ class FrameCodeRenderer implements IListRenderer<ListItem, IStackTemplateData> {
 		});
 	}
 
-	disposeElement(element: ListItem, index: number, templateData: IStackTemplateData, height: number | undefined): void {
-		templateData.elementStore.clear();
-	}
-
-	disposeTemplate(templateData: IStackTemplateData): void {
-		templateData.templateStore.dispose();
+	private revealEditor(item: WrappedCallStackFrame, editor: CodeEditorWidget, height = item.editorHeight.get()) {
+		const top = editor.getTopForPosition(item.line ?? 1, item.column ?? 1);
+		editor.setScrollTop(top - height / 2, ScrollType.Immediate);
 	}
 }
 
@@ -434,6 +502,44 @@ class MissingCodeRenderer implements IListRenderer<ListItem, IMissingTemplateDat
 
 	disposeTemplate(templateData: IMissingTemplateData): void {
 		dom.clearNode(templateData.container);
+	}
+}
+
+interface IMissingTemplateData {
+	container: HTMLElement;
+}
+
+/** Renderer for a call frame that's missing a URI */
+class CustomRenderer extends AbstractFrameRenderer<IAbstractFrameRendererTemplateData> {
+	public static readonly templateId = 'c';
+	public readonly templateId = CustomRenderer.templateId;
+
+	protected override finishRenderTemplate(data: IAbstractFrameRendererTemplateData): IAbstractFrameRendererTemplateData {
+		return data;
+	}
+
+	override renderElement(element: ListItem, index: number, template: IAbstractFrameRendererTemplateData, height: number | undefined): void {
+		super.renderElement(element, index, template, height);
+
+		const item = element as WrappedCustomStackFrame;
+		const { elementStore, container, label } = template;
+
+		label.element.setResource({ name: item.original.label }, { icon: item.original.icon });
+
+		elementStore.add(autorun(reader => {
+			template.elements.header.style.display = item.original.showHeader.read(reader) ? '' : 'none';
+		}));
+
+		elementStore.add(autorunWithStore((reader, store) => {
+			if (!item.collapsed.read(reader)) {
+				store.add(item.original.render(container));
+			}
+		}));
+
+		const actions = item.original.renderActions?.(template.elements.actions);
+		if (actions) {
+			elementStore.add(actions);
+		}
 	}
 }
 

--- a/src/vs/workbench/contrib/debug/browser/callStackWidget.ts
+++ b/src/vs/workbench/contrib/debug/browser/callStackWidget.ts
@@ -1,0 +1,512 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as dom from 'vs/base/browser/dom';
+import { Button } from 'vs/base/browser/ui/button/button';
+import { IListRenderer, IListVirtualDelegate } from 'vs/base/browser/ui/list/list';
+import { IListAccessibilityProvider } from 'vs/base/browser/ui/list/listWidget';
+import { assertNever } from 'vs/base/common/assert';
+import { CancellationToken, CancellationTokenSource } from 'vs/base/common/cancellation';
+import { Codicon } from 'vs/base/common/codicons';
+import { Emitter, Event } from 'vs/base/common/event';
+import { Disposable, DisposableStore, toDisposable } from 'vs/base/common/lifecycle';
+import { autorun, derived, IObservable, observableValue } from 'vs/base/common/observable';
+import { Constants } from 'vs/base/common/uint';
+import { URI } from 'vs/base/common/uri';
+import 'vs/css!./media/callStackWidget';
+import { ICodeEditor } from 'vs/editor/browser/editorBrowser';
+import { CodeEditorWidget } from 'vs/editor/browser/widget/codeEditor/codeEditorWidget';
+import { EmbeddedCodeEditorWidget } from 'vs/editor/browser/widget/codeEditor/embeddedCodeEditorWidget';
+import { IEditorOptions } from 'vs/editor/common/config/editorOptions';
+import { Range } from 'vs/editor/common/core/range';
+import { Location } from 'vs/editor/common/languages';
+import { ITextModelService } from 'vs/editor/common/services/resolverService';
+import { localize, localize2 } from 'vs/nls';
+import { createActionViewItem } from 'vs/platform/actions/browser/menuEntryActionViewItem';
+import { MenuWorkbenchToolBar } from 'vs/platform/actions/browser/toolbar';
+import { Action2, MenuId, registerAction2 } from 'vs/platform/actions/common/actions';
+import { TextEditorSelectionRevealType } from 'vs/platform/editor/common/editor';
+import { IInstantiationService, ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
+import { ILabelService } from 'vs/platform/label/common/label';
+import { WorkbenchList } from 'vs/platform/list/browser/listService';
+import { INotificationService } from 'vs/platform/notification/common/notification';
+import { defaultButtonStyles } from 'vs/platform/theme/browser/defaultStyles';
+import { ResourceLabel } from 'vs/workbench/browser/labels';
+import { makeStackFrameColumnDecoration, TOP_STACK_FRAME_DECORATION } from 'vs/workbench/contrib/debug/browser/callStackEditorContribution';
+import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
+
+
+export class CallStackFrame {
+	constructor(
+		public readonly name: string,
+		public readonly source?: URI,
+		public readonly line = 1,
+		public readonly column = 1,
+	) { }
+}
+
+export class SkippedCallFrames {
+	constructor(
+		public readonly label: string,
+		public readonly load: (token: CancellationToken) => Promise<AnyStackFrame[]>,
+	) { }
+}
+
+export type AnyStackFrame = SkippedCallFrames | CallStackFrame;
+
+class WrappedCallStackFrame extends CallStackFrame {
+	public readonly editorHeight = observableValue('WrappedCallStackFrame.height', 100);
+	public readonly collapsed = observableValue('WrappedCallStackFrame.collapsed', false);
+
+	public readonly height = derived(reader => {
+		return this.collapsed.read(reader) ? HEADER_HEIGHT : HEADER_HEIGHT + this.editorHeight.read(reader);
+	});
+
+	constructor(original: CallStackFrame) {
+		super(original.name, original.source, original.line, original.column);
+	}
+}
+
+type ListItem = WrappedCallStackFrame | SkippedCallFrames;
+
+const WIDGET_CLASS_NAME = 'multiCallStackWidget';
+
+/**
+ * A reusable widget that displays a call stack as a series of editors. Note
+ * that this both used in debug's exception widget as well as in the testing
+ * call stack view.
+ */
+export class CallStackWidget extends Disposable {
+	private readonly list: WorkbenchList<ListItem>;
+	private readonly layoutEmitter = this._register(new Emitter<void>());
+	private readonly currentFramesDs = this._register(new DisposableStore());
+	private cts?: CancellationTokenSource;
+
+	constructor(
+		container: HTMLElement,
+		containingEditor: ICodeEditor | undefined,
+		@IInstantiationService instantiationService: IInstantiationService,
+	) {
+		super();
+
+		container.classList.add(WIDGET_CLASS_NAME);
+		this._register(toDisposable(() => container.classList.remove(WIDGET_CLASS_NAME)));
+
+		this.list = this._register(instantiationService.createInstance(
+			WorkbenchList,
+			'TestResultStackWidget',
+			container,
+			new StackDelegate(),
+			[
+				instantiationService.createInstance(FrameCodeRenderer, containingEditor, this.layoutEmitter.event),
+				instantiationService.createInstance(MissingCodeRenderer),
+				instantiationService.createInstance(SkippedRenderer, (i) => this.loadFrame(i)),
+			],
+			{
+				multipleSelectionSupport: false,
+				accessibilityProvider: instantiationService.createInstance(StackAccessibilityProvider),
+			}
+		) as WorkbenchList<ListItem>);
+	}
+
+	/** Replaces the call frames display in the view. */
+	public setFrames(frames: AnyStackFrame[]): void {
+		// cancel any existing load
+		this.currentFramesDs.clear();
+		this.cts = new CancellationTokenSource();
+		this._register(toDisposable(() => this.cts!.dispose(true)));
+
+		this.list.splice(0, this.list.length, this.mapFrames(frames));
+	}
+
+	public layout(height?: number, width?: number): void {
+		this.list.layout(height, width);
+		this.layoutEmitter.fire();
+	}
+
+	private async loadFrame(replacing: SkippedCallFrames): Promise<void> {
+		if (!this.cts) {
+			return;
+		}
+
+		const frames = await replacing.load(this.cts.token);
+		if (this.cts.token.isCancellationRequested) {
+			return;
+		}
+
+		const index = this.list.indexOf(replacing);
+		this.list.splice(index, 1, this.mapFrames(frames));
+	}
+
+	private mapFrames(frames: AnyStackFrame[]): ListItem[] {
+		const result: ListItem[] = [];
+		for (const frame of frames) {
+			if (!(frame instanceof CallStackFrame)) {
+				result.push(frame);
+				continue;
+			}
+
+			const wrapped = new WrappedCallStackFrame(frame);
+			result.push(wrapped);
+
+			this.currentFramesDs.add(autorun(reader => {
+				const height = wrapped.height.read(reader);
+				const idx = this.list.indexOf(wrapped);
+				if (idx !== -1) {
+					this.list.updateElementHeight(idx, height);
+				}
+			}));
+		}
+
+		return result;
+	}
+}
+
+class StackAccessibilityProvider implements IListAccessibilityProvider<ListItem> {
+	constructor(@ILabelService private readonly labelService: ILabelService) { }
+
+	getAriaLabel(e: ListItem): string | IObservable<string> | null {
+		if (e instanceof SkippedCallFrames) {
+			return e.label;
+		}
+
+		if (e instanceof CallStackFrame) {
+			if (e.source && e.line) {
+				return localize({
+					comment: ['{0} is an extension-defined label, then line number and filename'],
+					key: 'stackTraceLabel',
+				}, '{0}, line {1} in {2}', e.name, e.line, this.labelService.getUriLabel(e.source, { relative: true }));
+			}
+
+			return e.name;
+		}
+
+		assertNever(e);
+	}
+	getWidgetAriaLabel(): string {
+		return localize('stackTrace', 'Stack Trace');
+	}
+}
+
+class StackDelegate implements IListVirtualDelegate<ListItem> {
+	getHeight(element: ListItem): number {
+		if (element instanceof CallStackFrame) {
+			return element.height.get();
+		}
+		if (element instanceof SkippedCallFrames) {
+			return 50;
+		}
+
+		assertNever(element);
+	}
+
+	getTemplateId(element: ListItem): string {
+		if (element instanceof CallStackFrame) {
+			return element.source ? FrameCodeRenderer.templateId : MissingCodeRenderer.templateId;
+		}
+		if (element instanceof SkippedCallFrames) {
+			return SkippedRenderer.templateId;
+		}
+
+		assertNever(element);
+	}
+}
+
+interface IStackTemplateData {
+	container: HTMLElement;
+	editor: CodeEditorWidget;
+	label: ResourceLabel;
+	elements: ReturnType<typeof makeFrameElements>;
+	decorations: string[];
+	collapse: Button;
+	toolbar: MenuWorkbenchToolBar;
+	elementStore: DisposableStore;
+	templateStore: DisposableStore;
+}
+
+const editorOptions: IEditorOptions = {
+	scrollBeyondLastLine: false,
+	scrollbar: {
+		vertical: 'hidden',
+		horizontal: 'hidden',
+		handleMouseWheel: false,
+		useShadows: false,
+	},
+	glyphMargin: false,
+	overviewRulerLanes: 0,
+	fixedOverflowWidgets: true,
+	overviewRulerBorder: false,
+	stickyScroll: { enabled: false },
+	minimap: { enabled: false },
+	readOnly: true,
+};
+
+const makeFrameElements = () => dom.h('div.multiCallStackFrame', [
+	dom.h('div.header@header', [
+		dom.h('div.collapse-button@collapseButton'),
+		dom.h('div.title.show-file-icons@title'),
+		dom.h('div.actions@actions'),
+	]),
+
+	dom.h('div.editorParent', [
+		dom.h('div.editorContainer@editor'),
+	])
+]);
+
+const HEADER_HEIGHT = 40;
+
+/** Renderer for a normal stack frame where code is available. */
+class FrameCodeRenderer implements IListRenderer<ListItem, IStackTemplateData> {
+	public static readonly templateId = 'f';
+
+	public readonly templateId = FrameCodeRenderer.templateId;
+
+	constructor(
+		private readonly containingEditor: ICodeEditor | undefined,
+		private readonly onLayout: Event<void>,
+		@ITextModelService private readonly modelService: ITextModelService,
+		@IInstantiationService private readonly instantiationService: IInstantiationService,
+	) { }
+
+	renderTemplate(container: HTMLElement): IStackTemplateData {
+		const containingEditor = this.containingEditor;
+		const elements = makeFrameElements();
+		container.appendChild(elements.root);
+
+		const templateStore = new DisposableStore();
+		templateStore.add(toDisposable(() => dom.clearNode(elements.root)));
+
+		const editor = containingEditor
+			? this.instantiationService.createInstance(
+				EmbeddedCodeEditorWidget,
+				elements.editor,
+				editorOptions,
+				{},
+				containingEditor,
+			)
+			: this.instantiationService.createInstance(
+				CodeEditorWidget,
+				elements.editor,
+				editorOptions,
+				{},
+			);
+
+		templateStore.add(editor);
+
+		const label = templateStore.add(this.instantiationService.createInstance(ResourceLabel, elements.title, {}));
+
+		const toolbar = templateStore.add(this.instantiationService.createInstance(MenuWorkbenchToolBar, elements.actions, MenuId.DebugCallStackToolbar, {
+			menuOptions: { shouldForwardArgs: true },
+			actionViewItemProvider: (action, options) => createActionViewItem(this.instantiationService, action, options),
+		}));
+
+		const collapse = templateStore.add(new Button(elements.collapseButton, {}));
+
+		return {
+			editor,
+			container,
+			decorations: [],
+			elements,
+			label,
+			toolbar,
+			collapse,
+			elementStore: templateStore.add(new DisposableStore()),
+			templateStore,
+		};
+	}
+
+	renderElement(element: ListItem, index: number, template: IStackTemplateData, height: number | undefined): void {
+		const { elementStore, editor } = template;
+		elementStore.clear();
+
+		const item = element as WrappedCallStackFrame;
+		const uri = item.source!;
+
+		this.setupCollapseButton(item, template);
+		this.setupEditorLayout(item, template);
+		template.label.element.setFile(uri);
+
+		const cts = new CancellationTokenSource();
+		elementStore.add(toDisposable(() => cts.dispose(true)));
+		this.modelService.createModelReference(uri).then(reference => {
+			if (cts.token.isCancellationRequested) {
+				return reference.dispose();
+			}
+
+			elementStore.add(reference);
+			editor.setModel(reference.object.textEditorModel);
+			this.setupEditorAfterModel(item, template);
+		});
+	}
+
+	private setupEditorLayout(item: WrappedCallStackFrame, { elementStore, container, editor }: IStackTemplateData) {
+		const layout = () => editor.layout({
+			width: container.clientWidth,
+			height: item.editorHeight.get(),
+		});
+		elementStore.add(this.onLayout(layout));
+		layout();
+	}
+
+	private setupCollapseButton(item: WrappedCallStackFrame, { elementStore, elements, collapse, editor }: IStackTemplateData) {
+		elementStore.add(autorun(reader => {
+			collapse.element.className = '';
+			collapse.icon = item.collapsed.read(reader) ? Codicon.chevronRight : Codicon.chevronDown;
+			elements.root.classList.toggle('collapsed', item.collapsed.get());
+		}));
+		elementStore.add(collapse.onDidClick(() => {
+			item.collapsed.set(!item.collapsed.get(), undefined);
+		}));
+	}
+
+	private setupEditorAfterModel(item: CallStackFrame, template: IStackTemplateData): void {
+		const range = Range.fromPositions({
+			column: item.column ?? 1,
+			lineNumber: item.line ?? 1,
+		});
+
+		template.toolbar.context = { uri: item.source, range };
+
+		template.editor.changeViewZones(vz => {
+			vz.addZone({
+				afterLineNumber: 0,
+				heightInLines: range.startLineNumber - 3,
+				domNode: document.createElement('div'),
+				showInHiddenAreas: true,
+			});
+			// vz.addZone({
+			// 	afterLineNumber: range.startLineNumber + 2,
+			// 	heightInLines: Constants.MAX_SAFE_SMALL_INTEGER,
+			// 	domNode: document.createElement('div'),
+			// });
+		});
+
+		template.editor.revealRangeInCenter(range);
+
+		template.editor.changeDecorations(accessor => {
+			for (const d of template.decorations) {
+				accessor.removeDecoration(d);
+			}
+			template.decorations.length = 0;
+
+			const beforeRange = range.setStartPosition(range.startLineNumber, 1);
+			const hasCharactersBefore = !!template.editor.getModel()?.getValueInRange(beforeRange).trim();
+			const decoRange = range.setEndPosition(range.startLineNumber, Constants.MAX_SAFE_SMALL_INTEGER);
+
+			template.decorations.push(accessor.addDecoration(
+				decoRange,
+				makeStackFrameColumnDecoration(!hasCharactersBefore),
+			));
+			template.decorations.push(accessor.addDecoration(
+				decoRange,
+				TOP_STACK_FRAME_DECORATION,
+			));
+		});
+	}
+
+	disposeElement(element: ListItem, index: number, templateData: IStackTemplateData, height: number | undefined): void {
+		templateData.elementStore.clear();
+	}
+
+	disposeTemplate(templateData: IStackTemplateData): void {
+		templateData.templateStore.dispose();
+	}
+}
+
+interface IMissingTemplateData {
+	container: HTMLElement;
+}
+
+/** Renderer for a call frame that's missing a URI */
+class MissingCodeRenderer implements IListRenderer<ListItem, IMissingTemplateData> {
+	public static readonly templateId = 'm';
+	public readonly templateId = MissingCodeRenderer.templateId;
+
+	renderTemplate(container: HTMLElement): IMissingTemplateData {
+		return { container };
+	}
+
+	renderElement(element: ListItem, index: number, templateData: IMissingTemplateData, height: number | undefined): void {
+		templateData.container.innerText = (element as CallStackFrame).name;
+	}
+
+	disposeTemplate(templateData: IMissingTemplateData): void {
+		dom.clearNode(templateData.container);
+	}
+}
+
+interface ISkippedTemplateData {
+	button: Button;
+	current?: SkippedCallFrames;
+	store: DisposableStore;
+}
+
+/** Renderer for a button to load more call frames */
+class SkippedRenderer implements IListRenderer<ListItem, ISkippedTemplateData> {
+	public static readonly templateId = 's';
+	public readonly templateId = SkippedRenderer.templateId;
+
+	constructor(
+		private readonly loadFrames: (fromItem: SkippedCallFrames) => Promise<void>,
+		@INotificationService private readonly notificationService: INotificationService,
+	) { }
+
+	renderTemplate(container: HTMLElement): ISkippedTemplateData {
+		const store = new DisposableStore();
+		const button = new Button(container, { title: '', ...defaultButtonStyles });
+		const data: ISkippedTemplateData = { button, store };
+
+		store.add(button);
+		store.add(button.onDidClick(() => {
+			if (!data.current || !button.enabled) {
+				return;
+			}
+
+			button.enabled = false;
+			this.loadFrames(data.current).catch(e => {
+				this.notificationService.error(localize('failedToLoadFrames', 'Failed to load stack frames: {0}', e.message));
+			});
+		}));
+
+		return data;
+	}
+
+	renderElement(element: ListItem, index: number, templateData: ISkippedTemplateData, height: number | undefined): void {
+		const cast = element as SkippedCallFrames;
+		templateData.button.enabled = true;
+		templateData.button.label = cast.label;
+		templateData.current = cast;
+	}
+
+	disposeTemplate(templateData: ISkippedTemplateData): void {
+		templateData.store.dispose();
+	}
+}
+
+registerAction2(class extends Action2 {
+	constructor() {
+		super({
+			id: 'callStackWidget.goToFile',
+			title: localize2('goToFile', 'Open File'),
+			icon: Codicon.goToFile,
+			menu: {
+				id: MenuId.DebugCallStackToolbar,
+				order: 22,
+				group: 'navigation',
+			},
+		});
+	}
+
+	async run(accessor: ServicesAccessor, { uri, range }: Location): Promise<void> {
+		const editorService = accessor.get(IEditorService);
+		await editorService.openEditor({
+			resource: uri,
+			options: {
+				selection: range,
+				selectionRevealType: TextEditorSelectionRevealType.CenterIfOutsideViewport,
+			},
+		});
+	}
+});

--- a/src/vs/workbench/contrib/debug/browser/media/callStackWidget.css
+++ b/src/vs/workbench/contrib/debug/browser/media/callStackWidget.css
@@ -1,0 +1,28 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+.multiCallStackFrame {
+	.header {
+		display: flex;
+		align-items: center;
+		height: 32px;
+		margin-top: 8px;
+		background: var(--vscode-multiDiffEditor-headerBackground);
+		border-top: 1px solid var(--vscode-multiDiffEditor-border);
+		color: var(--vscode-foreground);
+		padding: 0 5px;
+	}
+
+	.title {
+		flex-grow: 1;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	&.collapsed .header {
+		border-bottom: 1px solid var(--vscode-multiDiffEditor-border);
+	}
+}

--- a/src/vs/workbench/contrib/debug/browser/media/callStackWidget.css
+++ b/src/vs/workbench/contrib/debug/browser/media/callStackWidget.css
@@ -19,6 +19,10 @@
 		overflow: hidden;
 		text-overflow: ellipsis;
 		white-space: nowrap;
+
+		&[role="link"] {
+			cursor: pointer;
+		}
 	}
 
 	&.collapsed {
@@ -36,6 +40,9 @@
 	}
 
 	.actions {
+		display: flex;
+		align-items: center;
+		gap: 8px;
 		margin-right: 12px;
 	}
 }

--- a/src/vs/workbench/contrib/debug/browser/media/callStackWidget.css
+++ b/src/vs/workbench/contrib/debug/browser/media/callStackWidget.css
@@ -8,7 +8,6 @@
 		display: flex;
 		align-items: center;
 		height: 32px;
-		margin-top: 8px;
 		background: var(--vscode-multiDiffEditor-headerBackground);
 		border-top: 1px solid var(--vscode-multiDiffEditor-border);
 		color: var(--vscode-foreground);
@@ -42,10 +41,6 @@
 }
 
 .multiCallStackWidget {
-	.monaco-list-row[data-index="0"] .multiCallStackFrame .header {
-		margin-top: 0;
-	}
-
 	.multiCallStackFrameContainer {
 		background: none !important;
 	}

--- a/src/vs/workbench/contrib/debug/browser/media/callStackWidget.css
+++ b/src/vs/workbench/contrib/debug/browser/media/callStackWidget.css
@@ -22,7 +22,31 @@
 		white-space: nowrap;
 	}
 
-	&.collapsed .header {
-		border-bottom: 1px solid var(--vscode-multiDiffEditor-border);
+	&.collapsed {
+		.header {
+			border-bottom: 1px solid var(--vscode-multiDiffEditor-border);
+		}
+
+		.editorParent {
+			display: none;
+		}
+	}
+
+	.collapse-button {
+		cursor: pointer;
+	}
+
+	.actions {
+		margin-right: 12px;
+	}
+}
+
+.multiCallStackWidget {
+	.monaco-list-row[data-index="0"] .multiCallStackFrame .header {
+		margin-top: 0;
+	}
+
+	.multiCallStackFrameContainer {
+		background: none !important;
 	}
 }

--- a/src/vs/workbench/contrib/testing/browser/icons.ts
+++ b/src/vs/workbench/contrib/testing/browser/icons.ts
@@ -71,8 +71,8 @@ registerThemingParticipant((theme, collector) => {
 	}
 
 	collector.addRule(`
-		.monaco-editor ${ThemeIcon.asCSSSelector(testingRunIcon)},
-		.monaco-editor ${ThemeIcon.asCSSSelector(testingRunAllIcon)} {
+		.monaco-editor .glyph-margin-widgets ${ThemeIcon.asCSSSelector(testingRunIcon)},
+		.monaco-editor .glyph-margin-widgets ${ThemeIcon.asCSSSelector(testingRunAllIcon)} {
 			color: ${theme.getColor(testingColorRunAction)};
 		}
 	`);

--- a/src/vs/workbench/contrib/testing/browser/media/testing.css
+++ b/src/vs/workbench/contrib/testing/browser/media/testing.css
@@ -235,6 +235,15 @@
 	background-color: var(--vscode-peekViewEditorGutter-background);
 }
 
+.test-output-primary-scrollable,
+.test-output-primary-container {
+	height: 100%;
+}
+
+.test-output-primary-container {
+	margin: 0 20px;
+}
+
 .test-output-peek-message-container {
 	overflow: hidden;
 }
@@ -268,15 +277,9 @@
 }
 
 .testing-followup-action {
-	position: absolute;
-	top: 100%;
-	left: 22px;
-	right: 22px;
-	margin-top: -25px;
 	line-height: 25px;
 	overflow: hidden;
 	pointer-events: none;
-	background: linear-gradient(transparent, var(--vscode-peekViewEditor-background) 50%);
 	display: flex;
 	align-items: center;
 	gap: 14px;

--- a/src/vs/workbench/contrib/testing/browser/media/testing.css
+++ b/src/vs/workbench/contrib/testing/browser/media/testing.css
@@ -315,44 +315,6 @@
 
 .test-output-call-stack {
 	height: 100%;
-
-	.monaco-list-row {
-		padding: 0 3px 0 8px;
-		display: flex;
-		gap: 3px;
-
-		.location, .label {
-			white-space: nowrap;
-		}
-
-		.label {
-			flex-grow: 1;
-		}
-
-		.location {
-			/*Use direction so the source shows elipses on the left*/
-			direction: rtl;
-			overflow: hidden;
-			text-overflow: ellipsis;
-			font-size: 0.9em;
-		}
-
-		&.no-source .label {
-			opacity: 0.7;
-		}
-
-		&:hover {
-			.label {
-				overflow: hidden;
-				text-overflow: ellipsis;
-			}
-
-			.location {
-				overflow: visible;
-				text-overflow: unset;
-			}
-		}
-	}
 }
 
 /** -- filter  */

--- a/src/vs/workbench/contrib/testing/browser/media/testing.css
+++ b/src/vs/workbench/contrib/testing/browser/media/testing.css
@@ -235,15 +235,6 @@
 	background-color: var(--vscode-peekViewEditorGutter-background);
 }
 
-.test-output-primary-scrollable,
-.test-output-primary-container {
-	height: 100%;
-}
-
-.test-output-primary-container {
-	margin: 0 20px;
-}
-
 .test-output-peek-message-container {
 	overflow: hidden;
 }

--- a/src/vs/workbench/contrib/testing/browser/testExplorerActions.ts
+++ b/src/vs/workbench/contrib/testing/browser/testExplorerActions.ts
@@ -1028,7 +1028,7 @@ abstract class ExecuteTestAtCursor extends Action2 {
 		// whose range is equal to the closest one, we run them all.
 		await showDiscoveringWhile(progressService, (async () => {
 			for await (const test of testsInFile(testService, uriIdentityService, model.uri)) {
-				if (!test.item.range || !(profileService.capabilitiesForTest(test) & this.group)) {
+				if (!test.item.range || !(profileService.capabilitiesForTest(test.item) & this.group)) {
 					continue;
 				}
 

--- a/src/vs/workbench/contrib/testing/browser/testResultsView/testMessageStack.ts
+++ b/src/vs/workbench/contrib/testing/browser/testResultsView/testMessageStack.ts
@@ -3,14 +3,11 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as dom from 'vs/base/browser/dom';
 import { Emitter } from 'vs/base/common/event';
 import { Disposable } from 'vs/base/common/lifecycle';
 import { ICodeEditor } from 'vs/editor/browser/editorBrowser';
-import { MenuId } from 'vs/platform/actions/common/actions';
-import { IContextMenuService } from 'vs/platform/contextview/browser/contextView';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
-import { CallStackFrame, CallStackWidget } from 'vs/workbench/contrib/debug/browser/callStackWidget';
+import { AnyStackFrame, CallStackFrame, CallStackWidget } from 'vs/workbench/contrib/debug/browser/callStackWidget';
 import { ITestMessageStackFrame } from 'vs/workbench/contrib/testing/common/testTypes';
 
 export class TestResultStackWidget extends Disposable {
@@ -23,7 +20,6 @@ export class TestResultStackWidget extends Disposable {
 		private readonly container: HTMLElement,
 		containingEditor: ICodeEditor | undefined,
 		@IInstantiationService instantiationService: IInstantiationService,
-		@IContextMenuService contextMenuService: IContextMenuService
 	) {
 		super();
 
@@ -32,22 +28,15 @@ export class TestResultStackWidget extends Disposable {
 			container,
 			containingEditor,
 		));
-
-		this._register(dom.addDisposableListener(container, dom.EventType.CONTEXT_MENU, e => {
-			contextMenuService.showContextMenu({
-				getAnchor: () => ({ x: e.x, y: e.y }),
-				menuId: MenuId.TestCallStackContext
-			});
-		}));
 	}
 
-	public update(stack: ITestMessageStackFrame[], selection?: ITestMessageStackFrame) {
-		this.widget.setFrames(stack.map(frame => new CallStackFrame(
+	public update(messageFrame: AnyStackFrame, stack: ITestMessageStackFrame[]) {
+		this.widget.setFrames([messageFrame, ...stack.map(frame => new CallStackFrame(
 			frame.label,
 			frame.uri,
 			frame.position?.lineNumber,
 			frame.position?.column,
-		)));
+		))]);
 	}
 
 	public layout(height?: number, width?: number) {

--- a/src/vs/workbench/contrib/testing/browser/testResultsView/testMessageStack.ts
+++ b/src/vs/workbench/contrib/testing/browser/testResultsView/testMessageStack.ts
@@ -4,61 +4,34 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as dom from 'vs/base/browser/dom';
-import { IListRenderer, IListVirtualDelegate } from 'vs/base/browser/ui/list/list';
 import { Emitter } from 'vs/base/common/event';
-import { Disposable, IDisposable } from 'vs/base/common/lifecycle';
-import { Range } from 'vs/editor/common/core/range';
-import { localize } from 'vs/nls';
+import { Disposable } from 'vs/base/common/lifecycle';
+import { ICodeEditor } from 'vs/editor/browser/editorBrowser';
 import { MenuId } from 'vs/platform/actions/common/actions';
 import { IContextMenuService } from 'vs/platform/contextview/browser/contextView';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
-import { ILabelService } from 'vs/platform/label/common/label';
-import { WorkbenchList } from 'vs/platform/list/browser/listService';
+import { CallStackFrame, CallStackWidget } from 'vs/workbench/contrib/debug/browser/callStackWidget';
 import { ITestMessageStackFrame } from 'vs/workbench/contrib/testing/common/testTypes';
-import { IEditorService, SIDE_GROUP } from 'vs/workbench/services/editor/common/editorService';
-
-const stackItemDelegate: IListVirtualDelegate<void> = {
-	getHeight: () => 22,
-	getTemplateId: () => 's',
-};
 
 export class TestResultStackWidget extends Disposable {
-	private readonly list: WorkbenchList<ITestMessageStackFrame>;
+	private readonly widget: CallStackWidget;
 	private readonly changeStackFrameEmitter = this._register(new Emitter<ITestMessageStackFrame>());
 
 	public readonly onDidChangeStackFrame = this.changeStackFrameEmitter.event;
 
 	constructor(
 		private readonly container: HTMLElement,
+		containingEditor: ICodeEditor | undefined,
 		@IInstantiationService instantiationService: IInstantiationService,
-		@ILabelService labelService: ILabelService,
 		@IContextMenuService contextMenuService: IContextMenuService
 	) {
 		super();
 
-		this.list = this._register(instantiationService.createInstance(
-			WorkbenchList,
-			'TestResultStackWidget',
+		this.widget = this._register(instantiationService.createInstance(
+			CallStackWidget,
 			container,
-			stackItemDelegate,
-			[instantiationService.createInstance(StackRenderer)],
-			{
-				multipleSelectionSupport: false,
-				accessibilityProvider: {
-					getWidgetAriaLabel: () => localize('testStackTrace', 'Test stack trace'),
-					getAriaLabel: (e: ITestMessageStackFrame) => e.position && e.uri ? localize({
-						comment: ['{0} is an extension-defined label, then line number and filename'],
-						key: 'stackTraceLabel',
-					}, '{0}, line {1} in {2}', e.label, e.position.lineNumber, labelService.getUriLabel(e.uri, { relative: true })) : e.label,
-				}
-			}
-		) as WorkbenchList<ITestMessageStackFrame>);
-
-		this._register(this.list.onDidChangeSelection(e => {
-			if (e.elements.length) {
-				this.changeStackFrameEmitter.fire(e.elements[0]);
-			}
-		}));
+			containingEditor,
+		));
 
 		this._register(dom.addDisposableListener(container, dom.EventType.CONTEXT_MENU, e => {
 			contextMenuService.showContextMenu({
@@ -69,84 +42,15 @@ export class TestResultStackWidget extends Disposable {
 	}
 
 	public update(stack: ITestMessageStackFrame[], selection?: ITestMessageStackFrame) {
-		this.list.splice(0, this.list.length, stack);
-		this.list.layout();
-
-		const i = selection && stack.indexOf(selection);
-		if (i && i !== -1) {
-			this.list.setSelection([i]);
-			this.list.setFocus([i]);
-			// selection is triggered actioning on the call stack from a different
-			// editor, ensure the stack item is still focused in this editor
-			this.list.domFocus();
-		}
+		this.widget.setFrames(stack.map(frame => new CallStackFrame(
+			frame.label,
+			frame.uri,
+			frame.position?.lineNumber,
+			frame.position?.column,
+		)));
 	}
 
 	public layout(height?: number, width?: number) {
-		this.list.layout(height ?? this.container.clientHeight, width);
+		this.widget.layout(height ?? this.container.clientHeight, width);
 	}
 }
-
-interface ITemplateData {
-	container: HTMLElement;
-	label: HTMLElement;
-	location: HTMLElement;
-	current?: ITestMessageStackFrame;
-	disposable: IDisposable;
-}
-
-class StackRenderer implements IListRenderer<ITestMessageStackFrame, ITemplateData> {
-	public readonly templateId = 's';
-
-	constructor(
-		@ILabelService private readonly labelService: ILabelService,
-		@IEditorService private readonly openerService: IEditorService,
-	) { }
-
-	renderTemplate(container: HTMLElement): ITemplateData {
-		const label = dom.$('.label');
-		const location = dom.$('.location');
-		container.appendChild(label);
-		container.appendChild(location);
-		const data: ITemplateData = {
-			container,
-			label,
-			location,
-			disposable: dom.addDisposableListener(container, dom.EventType.CLICK, e => {
-				if (e.ctrlKey || e.metaKey) {
-					if (data.current?.uri) {
-						this.openerService.openEditor({
-							resource: data.current.uri,
-							options: {
-								selection: data.current.position ? Range.fromPositions(data.current.position) : undefined,
-							}
-						}, SIDE_GROUP);
-						e.preventDefault();
-						e.stopPropagation();
-					}
-				}
-			}),
-		};
-
-		return data;
-	}
-
-	renderElement(element: ITestMessageStackFrame, index: number, templateData: ITemplateData, height: number | undefined): void {
-		templateData.label.innerText = element.label;
-		templateData.current = element;
-		templateData.container.classList.toggle('no-source', !element.uri);
-
-		if (element.uri) {
-			templateData.location.innerText = this.labelService.getUriBasenameLabel(element.uri);
-			templateData.location.title = this.labelService.getUriLabel(element.uri, { relative: true });
-			if (element.position) {
-				templateData.location.innerText += `:${element.position.lineNumber}:${element.position.column}`;
-			}
-		}
-	}
-
-	disposeTemplate(templateData: ITemplateData): void {
-		templateData.disposable.dispose();
-	}
-}
-

--- a/src/vs/workbench/contrib/testing/browser/testResultsView/testResultsOutput.ts
+++ b/src/vs/workbench/contrib/testing/browser/testResultsView/testResultsOutput.ts
@@ -4,10 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as dom from 'vs/base/browser/dom';
-import { DomScrollableElement } from 'vs/base/browser/ui/scrollbar/scrollableElement';
 import { Delayer } from 'vs/base/common/async';
 import { VSBuffer } from 'vs/base/common/buffer';
-import { IMarkdownString } from 'vs/base/common/htmlContent';
+import { Event } from 'vs/base/common/event';
 import { Iterable } from 'vs/base/common/iterator';
 import { Lazy } from 'vs/base/common/lazy';
 import { Disposable, IDisposable, IReference, MutableDisposable, combinedDisposable, toDisposable } from 'vs/base/common/lifecycle';
@@ -62,10 +61,11 @@ class SimpleDiffEditorModel extends EditorModel {
 
 
 export interface IPeekOutputRenderer extends IDisposable {
+	onDidContentSizeChange?: Event<void>;
 	/** Updates the displayed test. Should clear if it cannot display the test. */
-	update(subject: InspectSubject): void;
-	/** Recalculate content layout. */
-	layout(dimension: dom.IDimension): void;
+	update(subject: InspectSubject): Promise<boolean>;
+	/** Recalculate content layout. Returns the height it should be rendered at. */
+	layout(dimension: dom.IDimension): number | undefined;
 	/** Dispose the content provider. */
 	dispose(): void;
 }
@@ -78,17 +78,17 @@ const commonEditorOptions: IEditorOptions = {
 	scrollbar: {
 		verticalScrollbarSize: 14,
 		horizontal: 'auto',
-		useShadows: true,
+		useShadows: false,
 		verticalHasArrows: false,
 		horizontalHasArrows: false,
 		alwaysConsumeMouseWheel: false
 	},
+	overviewRulerLanes: 0,
 	fixedOverflowWidgets: true,
 	readOnly: true,
-	minimap: {
-		enabled: false
-	},
-	wordWrap: 'on',
+	stickyScroll: { enabled: false },
+	minimap: { enabled: false },
+	automaticLayout: false,
 };
 
 const diffEditorOptions: IDiffEditorConstructionOptions = {
@@ -110,6 +110,10 @@ export class DiffContentProvider extends Disposable implements IPeekOutputRender
 	private readonly model = this._register(new MutableDisposable());
 	private dimension?: dom.IDimension;
 
+	public get onDidContentSizeChange() {
+		return this.widget.value?.onDidContentSizeChange || Event.None;
+	}
+
 	constructor(
 		private readonly editor: ICodeEditor | undefined,
 		private readonly container: HTMLElement,
@@ -121,11 +125,13 @@ export class DiffContentProvider extends Disposable implements IPeekOutputRender
 
 	public async update(subject: InspectSubject) {
 		if (!(subject instanceof MessageSubject)) {
-			return this.clear();
+			this.clear();
+			return false;
 		}
 		const message = subject.message;
 		if (!ITestMessage.isDiffable(message)) {
-			return this.clear();
+			this.clear();
+			return false;
 		}
 
 		const [original, modified] = await Promise.all([
@@ -157,6 +163,8 @@ export class DiffContentProvider extends Disposable implements IPeekOutputRender
 		this.widget.value.updateOptions(this.getOptions(
 			isMultiline(message.expected) || isMultiline(message.actual)
 		));
+
+		return true;
 	}
 
 	private clear() {
@@ -166,7 +174,15 @@ export class DiffContentProvider extends Disposable implements IPeekOutputRender
 
 	public layout(dimensions: dom.IDimension) {
 		this.dimension = dimensions;
-		this.widget.value?.layout(dimensions);
+		const editor = this.widget.value;
+		if (!editor) {
+			return;
+		}
+
+		editor.layout(dimensions);
+		const height = Math.min(1000, Math.max(editor.getOriginalEditor().getContentHeight(), editor.getModifiedEditor().getContentHeight()));
+		editor.layout({ height, width: dimensions.width });
+		return height;
 	}
 
 	protected getOptions(isMultiline: boolean): IDiffEditorOptions {
@@ -176,72 +192,55 @@ export class DiffContentProvider extends Disposable implements IPeekOutputRender
 	}
 }
 
-class ScrollableMarkdownMessage extends Disposable {
-	private readonly scrollable: DomScrollableElement;
-	private readonly element: HTMLElement;
-
-	constructor(container: HTMLElement, markdown: MarkdownRenderer, message: IMarkdownString) {
-		super();
-
-		const rendered = this._register(markdown.render(message, {}));
-		rendered.element.style.height = '100%';
-		rendered.element.style.userSelect = 'text';
-		container.appendChild(rendered.element);
-		this.element = rendered.element;
-
-		this.scrollable = this._register(new DomScrollableElement(rendered.element, {
-			className: 'preview-text',
-		}));
-		container.appendChild(this.scrollable.getDomNode());
-
-		this._register(toDisposable(() => {
-			this.scrollable.getDomNode().remove();
-		}));
-
-		this.scrollable.scanDomNode();
-	}
-
-	public layout(height: number, width: number) {
-		// Remove padding of `.monaco-editor .zone-widget.test-output-peek .preview-text`
-		this.scrollable.setScrollDimensions({
-			width: width - 32,
-			height: height - 16,
-			scrollWidth: this.element.scrollWidth,
-			scrollHeight: this.element.scrollHeight
-		});
-	}
-}
 
 export class MarkdownTestMessagePeek extends Disposable implements IPeekOutputRenderer {
 	private readonly markdown = new Lazy(
 		() => this._register(this.instantiationService.createInstance(MarkdownRenderer, {})),
 	);
 
-	private readonly textPreview = this._register(new MutableDisposable<ScrollableMarkdownMessage>());
+	private element?: HTMLElement;
 
 	constructor(private readonly container: HTMLElement, @IInstantiationService private readonly instantiationService: IInstantiationService) {
 		super();
+		this._register(toDisposable(() => this.clear()));
 	}
 
-	public update(subject: InspectSubject): void {
+	public async update(subject: InspectSubject) {
 		if (!(subject instanceof MessageSubject)) {
-			return this.textPreview.clear();
+			this.clear();
+			return false;
 		}
 
 		const message = subject.message;
 		if (ITestMessage.isDiffable(message) || typeof message.message === 'string') {
-			return this.textPreview.clear();
+			this.clear();
+			return false;
 		}
 
-		this.textPreview.value = new ScrollableMarkdownMessage(
-			this.container,
-			this.markdown.value,
-			message.message as IMarkdownString,
-		);
+
+		const rendered = this._register(this.markdown.value.render(message.message, {}));
+		rendered.element.style.height = '100%';
+		rendered.element.style.userSelect = 'text';
+		rendered.element.classList.add('preview-text');
+		this.container.appendChild(rendered.element);
+		this.element = rendered.element;
+		return true;
 	}
 
-	public layout(dimension: dom.IDimension): void {
-		this.textPreview.value?.layout(dimension.height, dimension.width);
+	public layout(dimension: dom.IDimension): number | undefined {
+		if (!this.element) {
+			return undefined;
+		}
+
+		this.element.style.width = `${dimension.width}px`;
+		return this.element.clientHeight;
+	}
+
+	private clear() {
+		if (this.element) {
+			this.element.remove();
+			this.element = undefined;
+		}
 	}
 }
 
@@ -250,6 +249,10 @@ export class PlainTextMessagePeek extends Disposable implements IPeekOutputRende
 	private readonly widget = this._register(new MutableDisposable<CodeEditorWidget>());
 	private readonly model = this._register(new MutableDisposable());
 	private dimension?: dom.IDimension;
+
+	public get onDidContentSizeChange() {
+		return this.widget.value?.onDidContentSizeChange || Event.None;
+	}
 
 	constructor(
 		private readonly editor: ICodeEditor | undefined,
@@ -260,14 +263,16 @@ export class PlainTextMessagePeek extends Disposable implements IPeekOutputRende
 		super();
 	}
 
-	public async update(subject: InspectSubject) {
+	public async update(subject: InspectSubject): Promise<boolean> {
 		if (!(subject instanceof MessageSubject)) {
-			return this.clear();
+			this.clear();
+			return false;
 		}
 
 		const message = subject.message;
 		if (ITestMessage.isDiffable(message) || message.type === TestMessageType.Output || typeof message.message !== 'string') {
-			return this.clear();
+			this.clear();
+			return false;
 		}
 
 		const modelRef = this.model.value = await this.modelService.createModelReference(subject.messageUri);
@@ -293,6 +298,7 @@ export class PlainTextMessagePeek extends Disposable implements IPeekOutputRende
 		this.widget.value.setModel(modelRef.object.textEditorModel);
 		this.widget.value.updateOptions(commonEditorOptions);
 		this.widgetDecorations.value = colorizeTestMessageInEditor(message.message, this.widget.value);
+		return true;
 	}
 
 	private clear() {
@@ -303,7 +309,15 @@ export class PlainTextMessagePeek extends Disposable implements IPeekOutputRende
 
 	public layout(dimensions: dom.IDimension) {
 		this.dimension = dimensions;
-		this.widget.value?.layout(dimensions);
+		const editor = this.widget.value;
+		if (!editor) {
+			return;
+		}
+
+		editor.layout(dimensions);
+		const height = editor.getContentHeight();
+		editor.layout({ height, width: dimensions.width });
+		return height;
 	}
 }
 
@@ -372,7 +386,7 @@ export class TerminalMessagePeek extends Disposable implements IPeekOutputRender
 		});
 	}
 
-	public async update(subject: InspectSubject) {
+	public async update(subject: InspectSubject): Promise<boolean> {
 		this.outputDataListener.clear();
 		if (subject instanceof TaskSubject) {
 			await this.updateForTaskSubject(subject);
@@ -380,7 +394,10 @@ export class TerminalMessagePeek extends Disposable implements IPeekOutputRender
 			await this.updateForTestSubject(subject);
 		} else {
 			this.clear();
+			return false;
 		}
+
+		return true;
 	}
 
 	private async updateForTestSubject(subject: TestOutputSubject | MessageSubject) {
@@ -525,7 +542,10 @@ export class TerminalMessagePeek extends Disposable implements IPeekOutputRender
 		this.dimensions = dimensions;
 		if (this.terminal.value) {
 			this.layoutTerminal(this.terminal.value, dimensions.width, dimensions.height);
+			return dimensions.height;
 		}
+
+		return undefined;
 	}
 
 	private layoutTerminal(

--- a/src/vs/workbench/contrib/testing/browser/testResultsView/testResultsTree.ts
+++ b/src/vs/workbench/contrib/testing/browser/testResultsView/testResultsTree.ts
@@ -689,7 +689,7 @@ class TreeActionsProvider {
 
 	public provideActionBar(element: ITreeElement) {
 		const test = element instanceof TestCaseElement ? element.test : undefined;
-		const capabilities = test ? this.testProfileService.capabilitiesForTest(test) : 0;
+		const capabilities = test ? this.testProfileService.capabilitiesForTest(test.item) : 0;
 
 		const contextKeys: [string, unknown][] = [
 			['peek', Testing.OutputPeekContributionId],

--- a/src/vs/workbench/contrib/testing/browser/testResultsView/testResultsViewContent.ts
+++ b/src/vs/workbench/contrib/testing/browser/testResultsView/testResultsViewContent.ts
@@ -7,11 +7,13 @@ import * as dom from 'vs/base/browser/dom';
 import { StandardKeyboardEvent } from 'vs/base/browser/keyboardEvent';
 import { renderLabelWithIcons } from 'vs/base/browser/ui/iconLabel/iconLabels';
 import { Orientation, Sizing, SplitView } from 'vs/base/browser/ui/splitview/splitview';
+import { findAsync } from 'vs/base/common/arrays';
 import { Limiter } from 'vs/base/common/async';
 import { CancellationTokenSource } from 'vs/base/common/cancellation';
 import { Emitter, Event, Relay } from 'vs/base/common/event';
 import { KeyCode } from 'vs/base/common/keyCodes';
-import { Disposable, DisposableStore, MutableDisposable, toDisposable } from 'vs/base/common/lifecycle';
+import { Disposable, DisposableStore, IDisposable, toDisposable } from 'vs/base/common/lifecycle';
+import { observableValue } from 'vs/base/common/observable';
 import 'vs/css!./testResultsViewContent';
 import { ICodeEditor } from 'vs/editor/browser/editorBrowser';
 import { ITextModelService } from 'vs/editor/common/services/resolverService';
@@ -22,26 +24,56 @@ import { IContextKey, IContextKeyService } from 'vs/platform/contextkey/common/c
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { ServiceCollection } from 'vs/platform/instantiation/common/serviceCollection';
 import { IQuickInputService } from 'vs/platform/quickinput/common/quickInput';
+import { CustomStackFrame } from 'vs/workbench/contrib/debug/browser/callStackWidget';
+import * as icons from 'vs/workbench/contrib/testing/browser/icons';
 import { TestResultStackWidget } from 'vs/workbench/contrib/testing/browser/testResultsView/testMessageStack';
 import { DiffContentProvider, IPeekOutputRenderer, MarkdownTestMessagePeek, PlainTextMessagePeek, TerminalMessagePeek } from 'vs/workbench/contrib/testing/browser/testResultsView/testResultsOutput';
-import { InspectSubject, MessageSubject, equalsSubject } from 'vs/workbench/contrib/testing/browser/testResultsView/testResultsSubject';
+import { InspectSubject, MessageSubject, TestOutputSubject, equalsSubject } from 'vs/workbench/contrib/testing/browser/testResultsView/testResultsSubject';
 import { OutputPeekTree } from 'vs/workbench/contrib/testing/browser/testResultsView/testResultsTree';
 import { IObservableValue } from 'vs/workbench/contrib/testing/common/observableValue';
 import { LiveTestResult } from 'vs/workbench/contrib/testing/common/testResult';
 import { ITestFollowup, ITestService } from 'vs/workbench/contrib/testing/common/testService';
 import { ITestMessageStackFrame } from 'vs/workbench/contrib/testing/common/testTypes';
 import { TestingContextKeys } from 'vs/workbench/contrib/testing/common/testingContextKeys';
-import { ITestingPeekOpener } from 'vs/workbench/contrib/testing/common/testingPeekOpener';
 
 const enum SubView {
-	CallStack = 0,
-	Diff = 1,
-	History = 2,
+	Diff = 0,
+	History = 1,
 }
 
 /** UI state that can be saved/restored, used to give a nice experience when switching stack frames */
 export interface ITestResultsViewContentUiState {
 	splitViewWidths: number[];
+}
+
+class MessageStackFrame extends CustomStackFrame {
+	public override height = observableValue('MessageStackFrame.height', 100);
+	public override label: string;
+	public override icon = icons.testingViewIcon;
+
+	constructor(
+		private readonly message: HTMLElement,
+		private readonly followup: FollowupActionWidget,
+		subject: InspectSubject,
+	) {
+		super();
+
+		this.label = subject instanceof MessageSubject
+			? subject.test.label
+			: subject instanceof TestOutputSubject
+				? subject.test.item.label
+				: subject.result.name;
+	}
+
+	public override render(container: HTMLElement): IDisposable {
+		container.appendChild(this.message);
+		return toDisposable(() => this.message.remove());
+	}
+
+	public override renderActions(container: HTMLElement): IDisposable {
+		container.appendChild(this.followup.domNode);
+		return toDisposable(() => this.followup.domNode.remove());
+	}
 }
 
 export class TestResultsViewContent extends Disposable {
@@ -50,13 +82,14 @@ export class TestResultsViewContent extends Disposable {
 	private readonly didReveal = this._register(new Emitter<{ subject: InspectSubject; preserveFocus: boolean }>());
 	private readonly currentSubjectStore = this._register(new DisposableStore());
 	private readonly onCloseEmitter = this._register(new Relay<void>());
-	private readonly onDidChangeStackFrameEmitter = this._register(new Relay<ITestMessageStackFrame>());
 	private followupWidget!: FollowupActionWidget;
 	private messageContextKeyService!: IContextKeyService;
 	private contextKeyTestMessage!: IContextKey<string>;
 	private contextKeyResultOutdated!: IContextKey<boolean>;
-	private callStackEl!: HTMLElement;
-	private readonly callStackWidget = this._register(new MutableDisposable<TestResultStackWidget>());
+	private stackContainer!: HTMLElement;
+	private callStackWidget!: TestResultStackWidget;
+	private currentTopFrame?: MessageStackFrame;
+	private isDoingLayoutUpdate?: boolean;
 
 	private dimension?: dom.Dimension;
 	private splitView!: SplitView;
@@ -70,7 +103,6 @@ export class TestResultsViewContent extends Disposable {
 	public onDidRequestReveal!: Event<InspectSubject>;
 
 	public readonly onClose = this.onCloseEmitter.event;
-	public readonly onDidChangeStackFrame = this.onDidChangeStackFrameEmitter.event;
 
 	public get uiState(): ITestResultsViewContentUiState {
 		return {
@@ -91,7 +123,6 @@ export class TestResultsViewContent extends Disposable {
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
 		@ITextModelService protected readonly modelService: ITextModelService,
 		@IContextKeyService private readonly contextKeyService: IContextKeyService,
-		@ITestingPeekOpener private readonly peekOpener: ITestingPeekOpener,
 	) {
 		super();
 	}
@@ -99,12 +130,14 @@ export class TestResultsViewContent extends Disposable {
 	public fillBody(containerElement: HTMLElement): void {
 		const initialSpitWidth = TestResultsViewContent.lastSplitWidth;
 		this.splitView = new SplitView(containerElement, { orientation: Orientation.HORIZONTAL });
-		this.callStackEl = dom.append(containerElement, dom.$('.test-output-call-stack'));
 
 		const { historyVisible, showRevealLocationOnMessages } = this.options;
 		const isInPeekView = this.editor !== undefined;
-		const messageContainer = this.messageContainer = dom.append(containerElement, dom.$('.test-output-peek-message-container'));
-		this.followupWidget = this._register(this.instantiationService.createInstance(FollowupActionWidget, messageContainer, this.editor));
+
+		const messageContainer = this.messageContainer = dom.$('.test-output-peek-message-container');
+		this.stackContainer = dom.append(containerElement, dom.$('.test-output-call-stack-container'));
+		this.callStackWidget = this._register(this.instantiationService.createInstance(TestResultStackWidget, this.stackContainer, this.editor));
+		this.followupWidget = this._register(this.instantiationService.createInstance(FollowupActionWidget, this.editor));
 		this.onCloseEmitter.input = this.followupWidget.onClose;
 
 		this.contentProviders = [
@@ -113,12 +146,6 @@ export class TestResultsViewContent extends Disposable {
 			this._register(this.instantiationService.createInstance(TerminalMessagePeek, messageContainer, isInPeekView)),
 			this._register(this.instantiationService.createInstance(PlainTextMessagePeek, this.editor, messageContainer)),
 		];
-
-		this._register(this.peekOpener.callStackVisible.onDidChange(() => {
-			if (this.current) {
-				this.updateVisiblityOfStackView(this.current);
-			}
-		}));
 
 		this.messageContextKeyService = this._register(this.contextKeyService.createScoped(containerElement));
 		this.contextKeyTestMessage = TestingContextKeys.testMessageContext.bindTo(this.messageContextKeyService);
@@ -136,15 +163,15 @@ export class TestResultsViewContent extends Disposable {
 
 		this.splitView.addView({
 			onDidChange: Event.None,
-			element: messageContainer,
+			element: this.stackContainer,
 			minimumSize: 200,
 			maximumSize: Number.MAX_VALUE,
 			layout: width => {
 				TestResultsViewContent.lastSplitWidth = width;
+
 				if (this.dimension) {
-					for (const provider of this.contentProviders) {
-						provider.layout({ height: this.dimension.height, width });
-					}
+					this.callStackWidget?.layout(this.dimension.height, width);
+					this.layoutContentWidgets(this.dimension, width);
 				}
 			},
 		}, Sizing.Distribute);
@@ -162,9 +189,9 @@ export class TestResultsViewContent extends Disposable {
 		}, Sizing.Distribute);
 
 
-		this.splitView.setViewVisible(this.viewIndex(SubView.History), historyVisible.value);
+		this.splitView.setViewVisible(SubView.History, historyVisible.value);
 		this._register(historyVisible.onDidChange(visible => {
-			this.splitView.setViewVisible(this.viewIndex(SubView.History), visible);
+			this.splitView.setViewVisible(SubView.History, visible);
 		}));
 
 		if (initialSpitWidth) {
@@ -179,8 +206,6 @@ export class TestResultsViewContent extends Disposable {
 	public reveal(opts: {
 		subject: InspectSubject;
 		preserveFocus: boolean;
-		frame?: ITestMessageStackFrame;
-		uiState?: ITestResultsViewContentUiState;
 	}) {
 		this.didReveal.fire(opts);
 
@@ -190,49 +215,48 @@ export class TestResultsViewContent extends Disposable {
 
 		this.current = opts.subject;
 		return this.contentProvidersUpdateLimiter.queue(async () => {
-			await Promise.all(this.contentProviders.map(p => p.update(opts.subject)));
-			this.followupWidget.show(opts.subject);
 			this.currentSubjectStore.clear();
-			this.updateVisiblityOfStackView(opts.subject, opts.frame);
-			this.populateFloatingClick(opts.subject);
+			const callFrames = (opts.subject instanceof MessageSubject && opts.subject.stack) || [];
+			const topFrame = await this.prepareTopFrame(opts.subject, callFrames);
+			this.callStackWidget.update(topFrame, callFrames);
 
-			if (opts.uiState) {
-				opts.uiState.splitViewWidths.forEach((width, i) => this.splitView.resizeView(i, width));
-			}
+			this.followupWidget.show(opts.subject);
+			this.populateFloatingClick(opts.subject);
 		});
 	}
 
-	private updateVisiblityOfStackView(subject: InspectSubject, frame?: ITestMessageStackFrame) {
-		const stack = this.peekOpener.callStackVisible.value && subject instanceof MessageSubject && subject.stack;
+	private async prepareTopFrame(subject: InspectSubject, callFrames: ITestMessageStackFrame[]) {
+		const topFrame = this.currentTopFrame = new MessageStackFrame(this.messageContainer, this.followupWidget, subject);
+		topFrame.showHeader.set(callFrames.length > 0, undefined);
 
-		if (stack) {
-			if (!this.callStackWidget.value) {
-				const widget = this.callStackWidget.value = this.instantiationService.createInstance(TestResultStackWidget, this.callStackEl, this.editor);
-				this.splitView.addView({
-					onDidChange: Event.None,
-					element: this.callStackEl,
-					minimumSize: 100,
-					maximumSize: Number.MAX_VALUE,
-					layout: width => widget.layout(undefined, width),
-				}, 150, 0);
-				this.onDidChangeStackFrameEmitter.input = widget.onDidChangeStackFrame;
+		const provider = await findAsync(this.contentProviders, p => p.update(subject));
+		if (provider) {
+			if (this.dimension) {
+				topFrame.height.set(provider.layout(this.dimension)!, undefined);
 			}
-
-			this.callStackWidget.value.update(stack, frame);
-		} else if (this.callStackWidget.value) {
-			this.splitView.removeView(0);
-			this.onDidChangeStackFrameEmitter.input = Event.None;
-			this.callStackWidget.clear();
+			if (provider.onDidContentSizeChange) {
+				this.currentSubjectStore.add(provider.onDidContentSizeChange(() => {
+					if (this.dimension && !this.isDoingLayoutUpdate) {
+						this.isDoingLayoutUpdate = true;
+						topFrame.height.set(provider.layout(this.dimension)!, undefined);
+						this.isDoingLayoutUpdate = false;
+					}
+				}));
+			}
 		}
+
+		return topFrame;
 	}
 
-	private viewIndex(subView: SubView) {
-		// the call stack view is index 0, if it's not visible then all indicies are shifted by one
-		if (!this.callStackWidget.value) {
-			return subView - 1;
+	private layoutContentWidgets(dimension: dom.Dimension, width = this.splitView.getViewSize(SubView.Diff)) {
+		this.isDoingLayoutUpdate = true;
+		for (const provider of this.contentProviders) {
+			const frameHeight = provider.layout({ height: dimension.height, width });
+			if (frameHeight) {
+				this.currentTopFrame?.height.set(frameHeight, undefined);
+			}
 		}
-
-		return subView;
+		this.isDoingLayoutUpdate = false;
 	}
 
 	private populateFloatingClick(subject: InspectSubject) {
@@ -285,8 +309,11 @@ class FollowupActionWidget extends Disposable {
 	private readonly onCloseEmitter = this._register(new Emitter<void>());
 	public readonly onClose = this.onCloseEmitter.event;
 
+	public get domNode() {
+		return this.el.root;
+	}
+
 	constructor(
-		private readonly container: HTMLElement,
 		private readonly editor: ICodeEditor | undefined,
 		@ITestService private readonly testService: ITestService,
 		@IQuickInputService private readonly quickInput: IQuickInputService,
@@ -333,7 +360,6 @@ class FollowupActionWidget extends Disposable {
 			this.el.root.appendChild(this.makeMoreLink(followups.followups));
 		}
 
-		this.container.appendChild(this.el.root);
 		this.visibleStore.add(toDisposable(() => {
 			this.el.root.remove();
 		}));

--- a/src/vs/workbench/contrib/testing/browser/testResultsView/testResultsViewContent.ts
+++ b/src/vs/workbench/contrib/testing/browser/testResultsView/testResultsViewContent.ts
@@ -207,7 +207,7 @@ export class TestResultsViewContent extends Disposable {
 
 		if (stack) {
 			if (!this.callStackWidget.value) {
-				const widget = this.callStackWidget.value = this.instantiationService.createInstance(TestResultStackWidget, this.callStackEl);
+				const widget = this.callStackWidget.value = this.instantiationService.createInstance(TestResultStackWidget, this.callStackEl, this.editor);
 				this.splitView.addView({
 					onDidChange: Event.None,
 					element: this.callStackEl,

--- a/src/vs/workbench/contrib/testing/browser/testing.contribution.ts
+++ b/src/vs/workbench/contrib/testing/browser/testing.contribution.ts
@@ -25,7 +25,7 @@ import { testingResultsIcon, testingViewIcon } from 'vs/workbench/contrib/testin
 import { TestCoverageView } from 'vs/workbench/contrib/testing/browser/testCoverageView';
 import { TestingDecorationService, TestingDecorations } from 'vs/workbench/contrib/testing/browser/testingDecorations';
 import { TestingExplorerView } from 'vs/workbench/contrib/testing/browser/testingExplorerView';
-import { CloseTestPeek, GoToNextMessageAction, GoToPreviousMessageAction, OpenMessageInEditorAction, TestResultsView, TestingOutputPeekController, TestingPeekOpener, ToggleCallStackAction, ToggleTestingPeekHistory } from 'vs/workbench/contrib/testing/browser/testingOutputPeek';
+import { CloseTestPeek, GoToNextMessageAction, GoToPreviousMessageAction, OpenMessageInEditorAction, TestResultsView, TestingOutputPeekController, TestingPeekOpener, ToggleTestingPeekHistory } from 'vs/workbench/contrib/testing/browser/testingOutputPeek';
 import { TestingProgressTrigger } from 'vs/workbench/contrib/testing/browser/testingProgressUiService';
 import { TestingViewPaneContainer } from 'vs/workbench/contrib/testing/browser/testingViewPaneContainer';
 import { testingConfiguration } from 'vs/workbench/contrib/testing/common/configuration';
@@ -136,7 +136,6 @@ registerAction2(GoToPreviousMessageAction);
 registerAction2(GoToNextMessageAction);
 registerAction2(CloseTestPeek);
 registerAction2(ToggleTestingPeekHistory);
-registerAction2(ToggleCallStackAction);
 
 Registry.as<IWorkbenchContributionsRegistry>(WorkbenchExtensions.Workbench).registerWorkbenchContribution(TestingContentProvider, LifecyclePhase.Restored);
 Registry.as<IWorkbenchContributionsRegistry>(WorkbenchExtensions.Workbench).registerWorkbenchContribution(TestingPeekOpener, LifecyclePhase.Eventually);

--- a/src/vs/workbench/contrib/testing/browser/testingDecorations.ts
+++ b/src/vs/workbench/contrib/testing/browser/testingDecorations.ts
@@ -835,7 +835,7 @@ abstract class RunTestDecoration {
 	 */
 	protected getTestContextMenuActions(test: InternalTestItem, resultItem?: TestResultItem): IReference<IAction[]> {
 		const testActions: IAction[] = [];
-		const capabilities = this.testProfileService.capabilitiesForTest(test);
+		const capabilities = this.testProfileService.capabilitiesForTest(test.item);
 
 		[
 			{ bitset: TestRunProfileBitset.Run, label: localize('run test', 'Run Test') },
@@ -927,7 +927,7 @@ class MultiRunTestDecoration extends RunTestDecoration implements ITestDecoratio
 			{ bitset: TestRunProfileBitset.Coverage, label: localize('run all test with coverage', 'Run All Tests with Coverage') },
 			{ bitset: TestRunProfileBitset.Debug, label: localize('debug all test', 'Debug All Tests') },
 		].forEach(({ bitset, label }, i) => {
-			const canRun = this.tests.some(({ test }) => this.testProfileService.capabilitiesForTest(test) & bitset);
+			const canRun = this.tests.some(({ test }) => this.testProfileService.capabilitiesForTest(test.item) & bitset);
 			if (canRun) {
 				allActions.push(new Action(`testing.gutter.run${i}`, label, undefined, undefined, () => this.runWith(bitset)));
 			}

--- a/src/vs/workbench/contrib/testing/browser/testingExplorerView.ts
+++ b/src/vs/workbench/contrib/testing/browser/testingExplorerView.ts
@@ -1537,7 +1537,7 @@ const getActionableElementActions = (
 	element: TestItemTreeElement,
 ) => {
 	const test = element instanceof TestItemTreeElement ? element.test : undefined;
-	const contextKeys: [string, unknown][] = getTestItemContextOverlay(test, test ? profiles.capabilitiesForTest(test) : 0);
+	const contextKeys: [string, unknown][] = getTestItemContextOverlay(test, test ? profiles.capabilitiesForTest(test.item) : 0);
 	contextKeys.push(['view', Testing.ExplorerViewId]);
 	if (test) {
 		const ctrl = testService.getTestController(test.controllerId);

--- a/src/vs/workbench/contrib/testing/common/testItemCollection.ts
+++ b/src/vs/workbench/contrib/testing/common/testItemCollection.ts
@@ -533,6 +533,7 @@ export class TestItemCollection<T extends ITestItemLike> extends Disposable {
 		if (levels < 0) {
 			return;
 		}
+		throw new Error('test');
 
 		const expandRequests: Promise<void>[] = [];
 		for (const [_, child] of this.options.getChildren(internal.actual)) {

--- a/src/vs/workbench/contrib/testing/common/testItemCollection.ts
+++ b/src/vs/workbench/contrib/testing/common/testItemCollection.ts
@@ -533,7 +533,6 @@ export class TestItemCollection<T extends ITestItemLike> extends Disposable {
 		if (levels < 0) {
 			return;
 		}
-		throw new Error('test');
 
 		const expandRequests: Promise<void>[] = [];
 		for (const [_, child] of this.options.getChildren(internal.actual)) {

--- a/src/vs/workbench/contrib/testing/common/testProfileService.ts
+++ b/src/vs/workbench/contrib/testing/common/testProfileService.ts
@@ -13,7 +13,7 @@ import { IStorageService, StorageScope, StorageTarget } from 'vs/platform/storag
 import { StoredValue } from 'vs/workbench/contrib/testing/common/storedValue';
 import { TestId } from 'vs/workbench/contrib/testing/common/testId';
 import { IMainThreadTestController } from 'vs/workbench/contrib/testing/common/testService';
-import { ITestRunProfile, InternalTestItem, TestRunProfileBitset, testRunProfileBitsetList } from 'vs/workbench/contrib/testing/common/testTypes';
+import { ITestItem, ITestRunProfile, InternalTestItem, TestRunProfileBitset, testRunProfileBitsetList } from 'vs/workbench/contrib/testing/common/testTypes';
 import { TestingContextKeys } from 'vs/workbench/contrib/testing/common/testingContextKeys';
 
 export const ITestProfileService = createDecorator<ITestProfileService>('testProfileService');
@@ -47,7 +47,7 @@ export interface ITestProfileService {
 	 * there's any usable profiles available for those groups.
 	 * @returns a bitset to use with {@link TestRunProfileBitset}
 	 */
-	capabilitiesForTest(test: InternalTestItem): number;
+	capabilitiesForTest(test: ITestItem): number;
 
 	/**
 	 * Configures a test profile.
@@ -226,15 +226,15 @@ export class TestProfileService extends Disposable implements ITestProfileServic
 	}
 
 	/** @inheritdoc */
-	public capabilitiesForTest(test: InternalTestItem) {
-		const ctrl = this.controllerProfiles.get(test.controllerId);
+	public capabilitiesForTest(test: ITestItem) {
+		const ctrl = this.controllerProfiles.get(TestId.root(test.extId));
 		if (!ctrl) {
 			return 0;
 		}
 
 		let capabilities = 0;
 		for (const profile of ctrl.profiles) {
-			if (!profile.tag || test.item.tags.includes(profile.tag)) {
+			if (!profile.tag || test.tags.includes(profile.tag)) {
 				capabilities |= capabilities & profile.group ? TestRunProfileBitset.HasNonDefaultProfile : profile.group;
 			}
 		}

--- a/src/vs/workbench/contrib/testing/common/testResult.ts
+++ b/src/vs/workbench/contrib/testing/common/testResult.ts
@@ -607,7 +607,7 @@ export class LiveTestResult extends Disposable implements ITestResult {
 	private readonly doSerialize = new Lazy((): ISerializedTestResults => ({
 		id: this.id,
 		completedAt: this.completedAt!,
-		tasks: this.tasks.map(t => ({ id: t.id, name: t.name })),
+		tasks: this.tasks.map(t => ({ id: t.id, name: t.name, ctrlId: t.ctrlId })),
 		name: this.name,
 		request: this.request,
 		items: [...this.testById.values()].map(TestResultItem.serializeWithoutMessages),
@@ -616,7 +616,7 @@ export class LiveTestResult extends Disposable implements ITestResult {
 	private readonly doSerializeWithMessages = new Lazy((): ISerializedTestResults => ({
 		id: this.id,
 		completedAt: this.completedAt!,
-		tasks: this.tasks.map(t => ({ id: t.id, name: t.name })),
+		tasks: this.tasks.map(t => ({ id: t.id, name: t.name, ctrlId: t.ctrlId })),
 		name: this.name,
 		request: this.request,
 		items: [...this.testById.values()].map(TestResultItem.serialize),
@@ -676,6 +676,7 @@ export class HydratedTestResult implements ITestResult {
 		this.tasks = serialized.tasks.map((task, i) => ({
 			id: task.id,
 			name: task.name,
+			ctrlId: task.ctrlId,
 			running: false,
 			coverage: observableValue(this, undefined),
 			output: emptyRawOutput,

--- a/src/vs/workbench/contrib/testing/common/testTypes.ts
+++ b/src/vs/workbench/contrib/testing/common/testTypes.ts
@@ -329,6 +329,7 @@ export interface ITestRunTask {
 	id: string;
 	name: string | undefined;
 	running: boolean;
+	ctrlId: string;
 }
 
 export interface ITestTag {
@@ -579,7 +580,7 @@ export interface ISerializedTestResults {
 	/** Subset of test result items */
 	items: TestResultItem.Serialized[];
 	/** Tasks involved in the run. */
-	tasks: { id: string; name: string | undefined }[];
+	tasks: { id: string; name: string | undefined; ctrlId: string }[];
 	/** Human-readable name of the test run. */
 	name: string;
 	/** Test trigger informaton */

--- a/src/vs/workbench/contrib/testing/common/testingContextKeys.ts
+++ b/src/vs/workbench/contrib/testing/common/testingContextKeys.ts
@@ -26,7 +26,6 @@ export namespace TestingContextKeys {
 	export const isCoverageFilteredToTest = new RawContextKey('testing.isCoverageFilteredToTest', false, { type: 'boolean', description: localize('testing.isCoverageFilteredToTest', 'Indicates whether coverage has been filterd to a single test') });
 	export const coverageToolbarEnabled = new RawContextKey('testing.coverageToolbarEnabled', true, { type: 'boolean', description: localize('testing.coverageToolbarEnabled', 'Indicates whether the coverage toolbar is enabled') });
 	export const inlineCoverageEnabled = new RawContextKey('testing.inlineCoverageEnabled', false, { type: 'boolean', description: localize('testing.inlineCoverageEnabled', 'Indicates whether inline coverage is shown') });
-	export const showCallStackInPeek = new RawContextKey<boolean>('testing.showCallStackInPeek', true, { type: 'boolean', description: localize('testing.showCallStackInPeek', 'Whether to show the failure call stack in the testing peek') });
 
 	export const capabilityToContextKey: { [K in TestRunProfileBitset]: RawContextKey<boolean> } = {
 		[TestRunProfileBitset.Run]: hasRunnableTests,

--- a/src/vs/workbench/contrib/testing/common/testingPeekOpener.ts
+++ b/src/vs/workbench/contrib/testing/common/testingPeekOpener.ts
@@ -24,9 +24,6 @@ export interface ITestingPeekOpener {
 	/** Whether test history should be shown in the results output. */
 	historyVisible: MutableObservableValue<boolean>;
 
-	/** Whether the test call stack should be shown in the results output. */
-	callStackVisible: MutableObservableValue<boolean>;
-
 	/**
 	 * Tries to peek the first test error, if the item is in a failed state.
 	 * @returns a boolean indicating whether a peek was opened

--- a/src/vs/workbench/contrib/testing/test/common/testResultService.test.ts
+++ b/src/vs/workbench/contrib/testing/test/common/testResultService.test.ts
@@ -66,7 +66,7 @@ suite('Workbench - Test Results Service', () => {
 		));
 
 		ds.add(r.onChange(e => changed.add(e)));
-		r.addTask({ id: 't', name: undefined, running: true });
+		r.addTask({ id: 't', name: undefined, running: true, ctrlId: 'ctrl' });
 
 		tests = ds.add(testStubs.nested());
 		const cts = ds.add(new CancellationTokenSource());
@@ -293,7 +293,7 @@ suite('Workbench - Test Results Service', () => {
 		} as IUriIdentityService, {
 			completedAt,
 			id: 'some-id',
-			tasks: [{ id: 't', name: undefined }],
+			tasks: [{ id: 't', name: undefined, ctrlId: 'ctrl' }],
 			name: 'hello world',
 			request: defaultOpts([]),
 			items: [{

--- a/src/vs/workbench/contrib/testing/test/common/testResultStorage.test.ts
+++ b/src/vs/workbench/contrib/testing/test/common/testResultStorage.test.ts
@@ -28,7 +28,7 @@ suite('Workbench - Test Result Storage', () => {
 			NullTelemetryService,
 		));
 
-		t.addTask({ id: taskName, name: undefined, running: true });
+		t.addTask({ id: taskName, name: undefined, running: true, ctrlId: 'ctrlId' });
 		const tests = ds.add(testStubs.nested());
 		tests.expand(tests.root.id, Infinity);
 		t.addTestChainToRun('ctrlId', [


### PR DESCRIPTION
This PR implements API and UI support for call stacks in test messages. For an extension who doesn't adopt the new API, nothing changes. When a call stack is available, you get a multi-editor view inspired by the multidiff view. This appears both in the peek and Test Results view. 

It is implemented in a way that the call stack itself is generic and can be reused by debug in the future, and it borrows some UI from debug land:

<img width="1305" alt="image" src="https://github.com/user-attachments/assets/1de539e4-55bf-4f3e-be24-c76727d95194">

The editors are readonly, `simple` monaco editors. There is never nested scrolling unless the test failure is >1000 lines, until that point the editor expands to fit its content. Clicking on either the title or "go to file" action brings the user to that location from the call stack. The top of the stack (the failure message) has quick actions to re-run the test or debug the test. A very handy flow is setting a breakpoint in the first call frame within the peek and hitting the "debug" button to quickly debug to that failure. Followup actions are shown (see the "fix with copilot" action in the screenshot)

Overall I'm really liking this UI. It does feel kind of heavy to be in a peek, but the utility is there.