### PR TITLE
Experimental GitHub Multi-account support

### DIFF
--- a/extensions/github-authentication/package.json
+++ b/extensions/github-authentication/package.json
@@ -41,7 +41,7 @@
         "id": "github-enterprise"
       }
     ],
-    "configuration": {
+    "configuration": [{
       "title": "GitHub Enterprise Server Authentication Provider",
       "properties": {
         "github-enterprise.uri": {
@@ -49,7 +49,17 @@
           "description": "GitHub Enterprise Server URI"
         }
       }
+    },
+    {
+      "title": "GitHub Authentication",
+      "properties": {
+        "github.experimental.multipleAccounts": {
+          "type": "boolean",
+          "description": "Experimental support for multiple GitHub accounts"
+        }
+      }
     }
+  ]
   },
   "aiKey": "0c6ae279ed8443289764825290e4f9e2-1a736e7c-1324-4338-be46-fc2a58ae4d14-7255",
   "main": "./out/extension.js",

--- a/src/vs/workbench/api/browser/mainThreadAuthentication.ts
+++ b/src/vs/workbench/api/browser/mainThreadAuthentication.ts
@@ -261,15 +261,7 @@ export class MainThreadAuthentication extends Disposable implements MainThreadAu
 	}
 
 	async $getAccounts(providerId: string): Promise<ReadonlyArray<AuthenticationSessionAccount>> {
-		const sessions = await this.authenticationService.getSessions(providerId);
-		const accounts = new Array<AuthenticationSessionAccount>();
-		const seenAccounts = new Set<string>();
-		for (const session of sessions) {
-			if (!seenAccounts.has(session.account.label)) {
-				seenAccounts.add(session.account.label);
-				accounts.push(session.account);
-			}
-		}
+		const accounts = await this.authenticationService.getAccounts(providerId);
 		return accounts;
 	}
 

--- a/src/vs/workbench/services/authentication/browser/authenticationService.ts
+++ b/src/vs/workbench/services/authentication/browser/authenticationService.ts
@@ -164,6 +164,20 @@ export class AuthenticationService extends Disposable implements IAuthentication
 		throw new Error(`No authentication provider '${id}' is currently registered.`);
 	}
 
+	async getAccounts(id: string): Promise<ReadonlyArray<AuthenticationSessionAccount>> {
+		// TODO: Cache this
+		const sessions = await this.getSessions(id);
+		const accounts = new Array<AuthenticationSessionAccount>();
+		const seenAccounts = new Set<string>();
+		for (const session of sessions) {
+			if (!seenAccounts.has(session.account.label)) {
+				seenAccounts.add(session.account.label);
+				accounts.push(session.account);
+			}
+		}
+		return accounts;
+	}
+
 	async getSessions(id: string, scopes?: string[], account?: AuthenticationSessionAccount, activateImmediate: boolean = false): Promise<ReadonlyArray<AuthenticationSession>> {
 		const authProvider = this._authenticationProviders.get(id) || await this.tryActivateProvider(id, activateImmediate);
 		if (authProvider) {

--- a/src/vs/workbench/services/authentication/common/authentication.ts
+++ b/src/vs/workbench/services/authentication/common/authentication.ts
@@ -130,6 +130,13 @@ export interface IAuthenticationService {
 	getProvider(id: string): IAuthenticationProvider;
 
 	/**
+	 * Gets all accounts that are currently logged in across all sessions
+	 * @param id The id of the provider to ask for accounts
+	 * @returns A promise that resolves to an array of accounts
+	 */
+	getAccounts(id: string): Promise<ReadonlyArray<AuthenticationSessionAccount>>;
+
+	/**
 	 * Gets all sessions that satisfy the given scopes from the provider with the given id
 	 * @param id The id of the provider to ask for a session
 	 * @param scopes The scopes for the session


### PR DESCRIPTION
* Have select account picker include accounts that don't match requested scopes (this will run `createSession` for that chosen account)
* Implement multi-account GitHub support behind a setting

ref https://github.com/microsoft/vscode/issues/127967