### PR TITLE
Revert "do not implicitly add `onTaskType:x` activation events for ex…

### DIFF
--- a/src/vs/workbench/contrib/tasks/common/taskDefinitionRegistry.ts
+++ b/src/vs/workbench/contrib/tasks/common/taskDefinitionRegistry.ts
@@ -83,6 +83,13 @@ namespace Configuration {
 
 const taskDefinitionsExtPoint = ExtensionsRegistry.registerExtensionPoint<Configuration.ITaskDefinition[]>({
 	extensionPoint: 'taskDefinitions',
+	activationEventsGenerator: (contributions: Configuration.ITaskDefinition[], result: { push(item: string): void }) => {
+		for (const task of contributions) {
+			if (task.type) {
+				result.push(`onTaskType:${task.type}`);
+			}
+		}
+	},
 	jsonSchema: {
 		description: nls.localize('TaskDefinitionExtPoint', 'Contributes task kinds'),
 		type: 'array',


### PR DESCRIPTION
I have to revert this fix once again because we need to activate all task providing extensions when debugging as otherwise, a `preLaunchTask` might not be found. A user can set their `preLaunchTask` to be anything. 

Similarly, build tasks can be set programmatically, using the `TaskGroup` API property. Thus, when the build task command is run, we need to activate all extensions that contribute tasks.

In order to minimize the number of extension activations, we encourage people to set the `type` property for their `preLaunchTask`. 
