### PR TITLE
Polish experience for completing files and folders in pwsh

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/media/shellIntegration.ps1
+++ b/src/vs/workbench/contrib/terminal/browser/media/shellIntegration.ps1
@@ -237,7 +237,13 @@ function Send-Completions {
 	else {
 		# Note that CompleteCommand isn't included here as it's expensive
 		$completions = $(
-			([System.Management.Automation.CompletionCompleters]::CompleteFilename($completionPrefix));
+			# Add trailing \ for directories so behavior aligns with TabExpansion2
+			[System.Management.Automation.CompletionCompleters]::CompleteFilename($completionPrefix) | ForEach-Object {
+				if ($_.ResultType -eq [System.Management.Automation.CompletionResultType]::ProviderContainer) {
+					[System.Management.Automation.CompletionResult]::new("$($_.CompletionText)\", "$($_.ListItemText)\", $_.ResultType, $_.ToolTip)
+				}
+				$_
+			}
 			([System.Management.Automation.CompletionCompleters]::CompleteVariable($completionPrefix));
 		)
 		if ($null -ne $completions) {

--- a/src/vs/workbench/contrib/terminal/browser/media/shellIntegration.ps1
+++ b/src/vs/workbench/contrib/terminal/browser/media/shellIntegration.ps1
@@ -240,7 +240,7 @@ function Send-Completions {
 			# Add trailing \ for directories so behavior aligns with TabExpansion2
 			[System.Management.Automation.CompletionCompleters]::CompleteFilename($completionPrefix) | ForEach-Object {
 				if ($_.ResultType -eq [System.Management.Automation.CompletionResultType]::ProviderContainer) {
-					[System.Management.Automation.CompletionResult]::new("$($_.CompletionText)\", "$($_.ListItemText)\", $_.ResultType, $_.ToolTip)
+					[System.Management.Automation.CompletionResult]::new($_.CompletionText + [System.IO.Path]::DirectorySeparatorChar, $_.ListItemText + [System.IO.Path]::DirectorySeparatorChar, $_.ResultType, $_.ToolTip)
 				}
 				$_
 			}

--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalSuggestAddon.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalSuggestAddon.ts
@@ -605,7 +605,8 @@ export function parseCompletionsFromShell(rawCompletions: PwshCompletion | PwshC
 		return [rawCompletions].map(e => (new SimpleCompletionItem({
 			label: e.CompletionText,
 			icon: pwshTypeToIconMap[e.ResultType],
-			detail: e.ToolTip
+			detail: e.ToolTip,
+			isFile: e.ResultType === 3,
 		})));
 	}
 	if (rawCompletions.length === 0) {
@@ -615,19 +616,22 @@ export function parseCompletionsFromShell(rawCompletions: PwshCompletion | PwshC
 		return [rawCompletions as CompressedPwshCompletion].map(e => (new SimpleCompletionItem({
 			label: e[0],
 			icon: pwshTypeToIconMap[e[1]],
-			detail: e[2]
+			detail: e[2],
+			isFile: e[1] === 3,
 		})));
 	}
 	if (Array.isArray(rawCompletions[0])) {
 		return (rawCompletions as CompressedPwshCompletion[]).map(e => (new SimpleCompletionItem({
 			label: e[0],
 			icon: pwshTypeToIconMap[e[1]],
-			detail: e[2]
+			detail: e[2],
+			isFile: e[1] === 3,
 		})));
 	}
 	return (rawCompletions as PwshCompletion[]).map(e => (new SimpleCompletionItem({
-		label: e.CompletionText, // e.ListItemText,
+		label: e.CompletionText,
 		icon: pwshTypeToIconMap[e.ResultType],
-		detail: e.ToolTip
+		detail: e.ToolTip,
+		isFile: e.ResultType === 3,
 	})));
 }

--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalSuggestAddon.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalSuggestAddon.ts
@@ -544,6 +544,11 @@ export class SuggestAddon extends Disposable implements ITerminalAddon, ISuggest
 			}
 		}
 
+		// For folders, allow the next completion request to get completions for that folder
+		if (completion.icon === Codicon.folder) {
+			this._lastAcceptedCompletionTimestamp = 0;
+		}
+
 		// Send the completion
 		this._onAcceptedCompletion.fire([
 			// Backspace (left) to remove all additional input

--- a/src/vs/workbench/services/suggest/browser/simpleCompletionItem.ts
+++ b/src/vs/workbench/services/suggest/browser/simpleCompletionItem.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { FuzzyScore } from 'vs/base/common/filters';
+import { isWindows } from 'vs/base/common/platform';
 import { ThemeIcon } from 'vs/base/common/themables';
 
 export interface ISimpleCompletion {
@@ -44,6 +45,9 @@ export class SimpleCompletionItem {
 		this.labelLow = this.completion.label.toLowerCase();
 		this.labelLowExcludeFileExt = this.labelLow;
 		if (completion.isFile) {
+			if (isWindows) {
+				this.labelLow = this.labelLow.replaceAll('/', '\\');
+			}
 			const extIndex = this.labelLow.lastIndexOf('.');
 			if (extIndex !== -1) {
 				this.labelLowExcludeFileExt = this.labelLow.substring(0, extIndex);

--- a/src/vs/workbench/services/suggest/browser/simpleCompletionItem.ts
+++ b/src/vs/workbench/services/suggest/browser/simpleCompletionItem.ts
@@ -19,11 +19,18 @@ export interface ISimpleCompletion {
 	 * The completion's detail which appears on the right of the list.
 	 */
 	detail?: string;
+	/**
+	 * Whether the completion is a file. Files with the same score will be sorted against each other
+	 * first by extension length and then certain extensions will get a boost based on the OS.
+	 */
+	isFile?: boolean;
 }
 
 export class SimpleCompletionItem {
 	// perf
 	readonly labelLow: string;
+	readonly labelLowExcludeFileExt: string;
+	readonly fileExtLow: string = '';
 
 	// sorting, filtering
 	score: FuzzyScore = FuzzyScore.Default;
@@ -35,5 +42,13 @@ export class SimpleCompletionItem {
 	) {
 		// ensure lower-variants (perf)
 		this.labelLow = this.completion.label.toLowerCase();
+		this.labelLowExcludeFileExt = this.labelLow;
+		if (completion.isFile) {
+			const extIndex = this.labelLow.lastIndexOf('.');
+			if (extIndex !== -1) {
+				this.labelLowExcludeFileExt = this.labelLow.substring(0, extIndex);
+				this.fileExtLow = this.labelLow.substring(extIndex + 1);
+			}
+		}
 	}
 }

--- a/src/vs/workbench/services/suggest/browser/simpleCompletionModel.ts
+++ b/src/vs/workbench/services/suggest/browser/simpleCompletionModel.ts
@@ -7,6 +7,7 @@ import { SimpleCompletionItem } from 'vs/workbench/services/suggest/browser/simp
 import { quickSelect } from 'vs/base/common/arrays';
 import { CharCode } from 'vs/base/common/charCode';
 import { FuzzyScore, fuzzyScore, fuzzyScoreGracefulAggressive, FuzzyScoreOptions, FuzzyScorer } from 'vs/base/common/filters';
+import { isWindows } from 'vs/base/common/platform';
 
 export interface ISimpleCompletionStats {
 	pLabelLen: number;
@@ -180,7 +181,29 @@ export class SimpleCompletionModel {
 			labelLengths.push(item.completion.label.length);
 		}
 
-		this._filteredItems = target.sort((a, b) => b.score[0] - a.score[0]);
+		this._filteredItems = target.sort((a, b) => {
+			// Sort first by the score
+			let score = b.score[0] - a.score[0];
+			if (score !== 0) {
+				return score;
+			}
+			// Sort files with the same score against each other specially
+			if (a.fileExtLow.length > 0 && b.fileExtLow.length > 0) {
+				// Then by label length ascending (excluding file extension if it's a file)
+				score = a.labelLowExcludeFileExt.length - b.labelLowExcludeFileExt.length;
+				if (score !== 0) {
+					return score;
+				}
+				// If they're files, boost extensions depending on the operating system
+				score = fileExtScore(b.fileExtLow) - fileExtScore(a.fileExtLow);
+				if (score !== 0) {
+					return score;
+				}
+				// Then by file extension length ascending
+				score = b.fileExtLow.length - a.fileExtLow.length;
+			}
+			return score;
+		});
 		this._refilterKind = Refilter.Nothing;
 
 		this._stats = {
@@ -189,4 +212,19 @@ export class SimpleCompletionModel {
 				: 0
 		};
 	}
+}
+
+// TODO: This should be based on the process OS, not the local OS
+const fileExtScores = new Map<string, number>(isWindows ? [
+	['ps1', 0.09],
+	['bat', 0.08],
+	['sh', -0.09]
+] : [
+	['ps1', 0.09],
+	['bat', 0.08],
+	['sh', 0.08],
+]);
+
+function fileExtScore(ext: string): number {
+	return fileExtScores.get(ext) || 0;
 }

--- a/src/vs/workbench/services/suggest/browser/simpleCompletionModel.ts
+++ b/src/vs/workbench/services/suggest/browser/simpleCompletionModel.ts
@@ -81,6 +81,7 @@ export class SimpleCompletionModel {
 		const labelLengths: number[] = [];
 
 		const { leadingLineContent, characterCountDelta } = this._lineContext;
+		const formattedLeadingLineContent = isWindows ? leadingLineContent.replaceAll('/', '\\') : leadingLineContent;
 		let word = '';
 		let wordLow = '';
 
@@ -111,7 +112,7 @@ export class SimpleCompletionModel {
 			const overwriteBefore = this.replacementLength; // item.position.column - item.editStart.column;
 			const wordLen = overwriteBefore + characterCountDelta; // - (item.position.column - this._column);
 			if (word.length !== wordLen) {
-				word = wordLen === 0 ? '' : leadingLineContent.slice(-wordLen);
+				word = wordLen === 0 ? '' : formattedLeadingLineContent.slice(-wordLen);
 				wordLow = word.toLowerCase();
 			}
 

--- a/src/vs/workbench/services/suggest/browser/simpleCompletionModel.ts
+++ b/src/vs/workbench/services/suggest/browser/simpleCompletionModel.ts
@@ -222,7 +222,7 @@ const fileExtScores = new Map<string, number>(isWindows ? [
 	['sh', -0.09]
 ] : [
 	['ps1', 0.09],
-	['bat', 0.08],
+	['bat', -0.08],
 	['sh', 0.08],
 ]);
 


### PR DESCRIPTION
Summary:

- Short files get a score boost
- File extensions get a score boost based on the OS (eg. .bat preferred on Windows)
- `/` is treated the same as `\` in filters on Windows
- A trailing `/` or `\` is added to completed folders

Fixes https://github.com/microsoft/vscode/issues/222228
Fixes https://github.com/microsoft/vscode/issues/222230
Fixes https://github.com/microsoft/vscode/issues/222227

![Recording 2024-07-19 at 12 23 19](https://github.com/user-attachments/assets/9514f133-a2d6-4f99-ab1b-3f6f0c684dce)
