### PR TITLE
Add `"packageManager"` field in `package.json` for corepack

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "perf": "node scripts/code-perf.js",
     "update-build-ts-version": "yarn add typescript@next && tsc -p ./build/tsconfig.build.json"
   },
+  "packageManager": "yarn@1.22.22",
   "dependencies": {
     "@microsoft/1ds-core-js": "^3.2.13",
     "@microsoft/1ds-post-js": "^3.2.13",


### PR DESCRIPTION
For developers with [Corepack](https://nodejs.org/docs/latest-v20.x/api/corepack.html) enabled, the `"packageManager"` field in `package.json` will be used by Corepack to automatically determine which version of the package manager should be used for the current project.

https://nodejs.org/docs/latest-v20.x/api/packages.html#packagemanager

## Background

When developers with Corepack enabled run the `yarn` command, the `"packageManager"` field in the root `package.json` will be automatically added with the following message shown:

```
! The local project doesn't define a 'packageManager' field. Corepack will now add one referencing yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e.
! For more details about this field, consult the documentation at https://nodejs.org/api/packages.html#packagemanager

1.22.22
```

...while this might not be ideal since it'll make the git working tree dirty.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
