### PR TITLE
Filter bash completion by current text

### DIFF
--- a/resources/completions/bash/code
+++ b/resources/completions/bash/code
@@ -20,7 +20,7 @@ _@@APPNAME@@()
 			return
 			;;
 		--locale)
-			COMPREPLY=( $( compgen -W 'de en en-US es fr it ja ko ru zh-CN zh-TW bg hu pt-br tr' ) )
+			COMPREPLY=( $( compgen -W 'de en en-US es fr it ja ko ru zh-CN zh-TW bg hu pt-br tr' -- "$cur" ) )
 			return
 			;;
 		--install-extension|--uninstall-extension)
@@ -28,7 +28,7 @@ _@@APPNAME@@()
 			return
 			;;
 		--log)
-			COMPREPLY=( $( compgen -W 'critical error warn info debug trace off' ) )
+			COMPREPLY=( $( compgen -W 'critical error warn info debug trace off' -- "$cur" ) )
 			return
 			;;
 		--folder-uri|--disable-extension)


### PR DESCRIPTION
compgen accepts an argument to filter the completions it generates by it, see the help: `If the optional WORD argument is supplied, matches against WORD are generated.` Before the change:
```
$ code --log criti<TAB>
critical  debug     error     info      off       trace     warn
```
After:
```
code --log crit<TAB>ical
```

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
