### PR TITLE
A followup to #171066 fixing zsh and fish shells implementations

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/media/fish_xdg_data/fish/vendor_conf.d/shellIntegration.fish
+++ b/src/vs/workbench/contrib/terminal/browser/media/fish_xdg_data/fish/vendor_conf.d/shellIntegration.fish
@@ -24,7 +24,7 @@ set --global VSCODE_SHELL_INTEGRATION 1
 
 # Apply any explicit path prefix (see #99878)
 if status --is-login; and set -q VSCODE_PATH_PREFIX
-	set -gx PATH "$VSCODE_PATH_PREFIX:$PATH"
+	set -gx PATH "$VSCODE_PATH_PREFIX$PATH"
 end
 set -e VSCODE_PATH_PREFIX
 

--- a/src/vs/workbench/contrib/terminal/browser/media/fish_xdg_data/fish/vendor_conf.d/shellIntegration.fish
+++ b/src/vs/workbench/contrib/terminal/browser/media/fish_xdg_data/fish/vendor_conf.d/shellIntegration.fish
@@ -24,7 +24,7 @@ set --global VSCODE_SHELL_INTEGRATION 1
 
 # Apply any explicit path prefix (see #99878)
 if status --is-login; and set -q VSCODE_PATH_PREFIX
-	fish_add_path -p $VSCODE_PATH_PREFIX
+	set -gx PATH "$VSCODE_PATH_PREFIX:$PATH"
 end
 set -e VSCODE_PATH_PREFIX
 

--- a/src/vs/workbench/contrib/terminal/browser/media/shellIntegration-bash.sh
+++ b/src/vs/workbench/contrib/terminal/browser/media/shellIntegration-bash.sh
@@ -34,7 +34,7 @@ if [ "$VSCODE_INJECTION" == "1" ]; then
 
 		# Apply any explicit path prefix (see #99878)
 		if [ -n "${VSCODE_PATH_PREFIX:-}" ]; then
-			export PATH=$VSCODE_PATH_PREFIX$PATH
+			export PATH="$VSCODE_PATH_PREFIX:$PATH"
 			builtin unset VSCODE_PATH_PREFIX
 		fi
 	fi

--- a/src/vs/workbench/contrib/terminal/browser/media/shellIntegration-bash.sh
+++ b/src/vs/workbench/contrib/terminal/browser/media/shellIntegration-bash.sh
@@ -34,7 +34,7 @@ if [ "$VSCODE_INJECTION" == "1" ]; then
 
 		# Apply any explicit path prefix (see #99878)
 		if [ -n "${VSCODE_PATH_PREFIX:-}" ]; then
-			export PATH="$VSCODE_PATH_PREFIX:$PATH"
+			export PATH="$VSCODE_PATH_PREFIX$PATH"
 			builtin unset VSCODE_PATH_PREFIX
 		fi
 	fi

--- a/src/vs/workbench/contrib/terminal/browser/media/shellIntegration-profile.zsh
+++ b/src/vs/workbench/contrib/terminal/browser/media/shellIntegration-profile.zsh
@@ -12,7 +12,7 @@ if [[ $options[norcs] = off && -o "login" ]]; then
 
 	# Apply any explicit path prefix (see #99878)
 	if (( ${+VSCODE_PATH_PREFIX} )); then
-		export PATH="$VSCODE_PATH_PREFIX:$PATH"
+		export PATH="$VSCODE_PATH_PREFIX$PATH"
 	fi
 	builtin unset VSCODE_PATH_PREFIX
 fi

--- a/src/vs/workbench/contrib/terminal/browser/media/shellIntegration-profile.zsh
+++ b/src/vs/workbench/contrib/terminal/browser/media/shellIntegration-profile.zsh
@@ -2,15 +2,17 @@
 #   Copyright (c) Microsoft Corporation. All rights reserved.
 #   Licensed under the MIT License. See License.txt in the project root for license information.
 # ---------------------------------------------------------------------------------------------
-if [[ $options[norcs] = off && -o "login" &&  -f $USER_ZDOTDIR/.zprofile ]]; then
-	VSCODE_ZDOTDIR=$ZDOTDIR
-	ZDOTDIR=$USER_ZDOTDIR
-	. $USER_ZDOTDIR/.zprofile
-	ZDOTDIR=$VSCODE_ZDOTDIR
+if [[ $options[norcs] = off && -o "login" ]]; then
+	if [[ -f $USER_ZDOTDIR/.zprofile ]]; then
+		VSCODE_ZDOTDIR=$ZDOTDIR
+		ZDOTDIR=$USER_ZDOTDIR
+		. $USER_ZDOTDIR/.zprofile
+		ZDOTDIR=$VSCODE_ZDOTDIR
+	fi
 
 	# Apply any explicit path prefix (see #99878)
 	if (( ${+VSCODE_PATH_PREFIX} )); then
-		export PATH=$VSCODE_PATH_PREFIX$PATH
+		export PATH="$VSCODE_PATH_PREFIX:$PATH"
 	fi
 	builtin unset VSCODE_PATH_PREFIX
 fi


### PR DESCRIPTION
#171066 introduced a fix for applying PATH prefix on macOS login shells that resolved #99878. However it had little issues for each shell implementation.
This PR contains the following fixes:

`bash` fix:
 - Add missing quotes to avoid path interpretation

`zsh` fix:
 - Add missing quotes to avoid path interpretation
 - Move patching outside of `.zprofile` check as clean macOS install doesn't include this file, nevertheless PATH patching should still happen

 `fish` fix:
 - use `set -gx PATH` instead of `fish_add_path` as the latter has no effect on updating the path if entries already exist in it. Which is the case for some extensions, like [`vscode-micromamba`](https://github.com/mamba-org/vscode-micromamba) which modify process environment and after login shell rc processing path entries end up in the end.