### PR TITLE
Fix shell integration for append/prepend EnvironmentVariableCollection API

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/media/fish_xdg_data/fish/vendor_conf.d/shellIntegration.fish
+++ b/src/vs/workbench/contrib/terminal/browser/media/fish_xdg_data/fish/vendor_conf.d/shellIntegration.fish
@@ -39,7 +39,7 @@ function __vsc_apply_env_vars
 		set ITEMS (string split : $VSCODE_ENV_REPLACE)
 		for B in $ITEMS
 			set split (string split = $B)
-			set -gx "$split[1]" (echo -e "$split[2]")
+			set -gx "$split[1]" "$(echo -e "$split[2]")"
 		end
 		set -e VSCODE_ENV_REPLACE
 	end
@@ -47,7 +47,7 @@ function __vsc_apply_env_vars
 		set ITEMS (string split : $VSCODE_ENV_PREPEND)
 		for B in $ITEMS
 			set split (string split = $B)
-			set -gx "$split[1]" (echo -e "$split[2]")"$$split[1]" # avoid -p as it adds a space
+			set -gx "$split[1]" "$(echo -e "$split[2]"):$$split[1]" # avoid -p as it adds a space
 		end
 		set -e VSCODE_ENV_PREPEND
 	end
@@ -55,7 +55,7 @@ function __vsc_apply_env_vars
 		set ITEMS (string split : $VSCODE_ENV_APPEND)
 		for B in $ITEMS
 			set split (string split = $B)
-			set -gx "$split[1]" "$$split[1]"(echo -e "$split[2]") # avoid -a as it adds a space
+			set -gx "$split[1]" "$$split[1]:$(echo -e "$split[2]")" # avoid -a as it adds a space
 		end
 		set -e VSCODE_ENV_APPEND
 	end

--- a/src/vs/workbench/contrib/terminal/browser/media/shellIntegration-bash.sh
+++ b/src/vs/workbench/contrib/terminal/browser/media/shellIntegration-bash.sh
@@ -60,7 +60,7 @@ if [ -n "${VSCODE_ENV_PREPEND:-}" ]; then
 	for ITEM in "${ADDR[@]}"; do
 		VARNAME="$(echo $ITEM | cut -d "=" -f 1)"
 		VALUE="$(echo -e "$ITEM" | cut -d "=" -f 2-)"
-		export $VARNAME="$VALUE${!VARNAME}"
+		export $VARNAME="$VALUE:${!VARNAME}"
 	done
 	builtin unset VSCODE_ENV_PREPEND
 fi
@@ -69,7 +69,7 @@ if [ -n "${VSCODE_ENV_APPEND:-}" ]; then
 	for ITEM in "${ADDR[@]}"; do
 		VARNAME="$(echo $ITEM | cut -d "=" -f 1)"
 		VALUE="$(echo -e "$ITEM" | cut -d "=" -f 2-)"
-		export $VARNAME="${!VARNAME}$VALUE"
+		export $VARNAME="${!VARNAME}:$VALUE"
 	done
 	builtin unset VSCODE_ENV_APPEND
 fi

--- a/src/vs/workbench/contrib/terminal/browser/media/shellIntegration-rc.zsh
+++ b/src/vs/workbench/contrib/terminal/browser/media/shellIntegration-rc.zsh
@@ -45,7 +45,7 @@ if [ -n "${VSCODE_ENV_PREPEND:-}" ]; then
 	IFS=':' read -rA ADDR <<< "$VSCODE_ENV_PREPEND"
 	for ITEM in "${ADDR[@]}"; do
 		VARNAME="$(echo ${ITEM%%=*})"
-		export $VARNAME="$(echo -e ${ITEM#*=})${(P)VARNAME}"
+		export $VARNAME="$(echo -e ${ITEM#*=}):${(P)VARNAME}"
 	done
 	unset VSCODE_ENV_PREPEND
 fi
@@ -53,7 +53,7 @@ if [ -n "${VSCODE_ENV_APPEND:-}" ]; then
 	IFS=':' read -rA ADDR <<< "$VSCODE_ENV_APPEND"
 	for ITEM in "${ADDR[@]}"; do
 		VARNAME="$(echo ${ITEM%%=*})"
-		export $VARNAME="${(P)VARNAME}$(echo -e ${ITEM#*=})"
+		export $VARNAME="${(P)VARNAME}:$(echo -e ${ITEM#*=})"
 	done
 	unset VSCODE_ENV_APPEND
 fi


### PR DESCRIPTION
Add missing `:` separator in the variable setter for append and prepend for bash/zsh and fish. Withtout it last entry of first list and first entry of second list will merge into one string.

Add quotes around all the expression that eval into strings in fish integration, for safety sake.
