### PR TITLE
Git - use first commit as common ancestor if the repository has not been published to a remote

### DIFF
--- a/extensions/git/src/api/git.d.ts
+++ b/extensions/git/src/api/git.d.ts
@@ -146,6 +146,7 @@ export interface LogOptions {
 	readonly shortStats?: boolean;
 	readonly author?: string;
 	readonly refNames?: string[];
+	readonly maxParents?: number;
 }
 
 export interface CommitOptions {

--- a/extensions/git/src/git.ts
+++ b/extensions/git/src/git.ts
@@ -1165,6 +1165,10 @@ export class Repository {
 			args.push(`--author="${options.author}"`);
 		}
 
+		if (typeof options?.maxParents === 'number') {
+			args.push(`--max-parents=${options.maxParents}`);
+		}
+
 		if (options?.refNames) {
 			args.push('--topo-order');
 			args.push('--decorate=full');

--- a/extensions/git/src/historyProvider.ts
+++ b/extensions/git/src/historyProvider.ts
@@ -274,7 +274,11 @@ export class GitHistoryProvider implements SourceControlHistoryProvider, FileDec
 					return ancestor;
 				}
 
-				// TODO@lszomoru - Return first commit
+				// First commit
+				const commits = await this.repository.log({ maxParents: 0, refNames: ['HEAD'] });
+				if (commits.length > 0) {
+					return commits[0].hash;
+				}
 			} else if (historyItemGroupIds.length > 1) {
 				const ancestor = await this.repository.getMergeBase(historyItemGroupIds[0], historyItemGroupIds[1], ...historyItemGroupIds.slice(2));
 				return ancestor;


### PR DESCRIPTION
Fixes #223475