### PR TITLE
Fixes #223410. Re-layouts the diff editor when `decorationsLeft` changes.

### DIFF
--- a/src/vs/editor/browser/observableCodeEditor.ts
+++ b/src/vs/editor/browser/observableCodeEditor.ts
@@ -191,6 +191,7 @@ export class ObservableCodeEditor extends Disposable {
 
 	public readonly layoutInfo = observableFromEvent(this.editor.onDidLayoutChange, () => this.editor.getLayoutInfo());
 	public readonly layoutInfoContentLeft = this.layoutInfo.map(l => l.contentLeft);
+	public readonly layoutInfoDecorationsLeft = this.layoutInfo.map(l => l.decorationsLeft);
 
 	public readonly contentWidth = observableFromEvent(this.editor.onDidContentSizeChange, () => this.editor.getContentWidth());
 

--- a/src/vs/editor/browser/widget/diffEditor/components/diffEditorEditors.ts
+++ b/src/vs/editor/browser/widget/diffEditor/components/diffEditorEditors.ts
@@ -30,7 +30,10 @@ export class DiffEditorEditors extends Disposable {
 	public readonly modifiedScrollTop = observableFromEvent(this, this.modified.onDidScrollChange, () => /** @description modified.getScrollTop */ this.modified.getScrollTop());
 	public readonly modifiedScrollHeight = observableFromEvent(this, this.modified.onDidScrollChange, () => /** @description modified.getScrollHeight */ this.modified.getScrollHeight());
 
-	public readonly modifiedModel = observableCodeEditor(this.modified).model;
+	public readonly modifiedObs = observableCodeEditor(this.modified);
+	public readonly originalObs = observableCodeEditor(this.original);
+
+	public readonly modifiedModel = this.modifiedObs.model;
 
 	public readonly modifiedSelections = observableFromEvent(this, this.modified.onDidChangeCursorSelection, () => this.modified.getSelections() ?? []);
 	public readonly modifiedCursor = derivedOpts({ owner: this, equalsFn: Position.equals }, reader => this.modifiedSelections.read(reader)[0]?.getPosition() ?? new Position(1, 1));

--- a/src/vs/editor/browser/widget/diffEditor/diffEditorWidget.ts
+++ b/src/vs/editor/browser/widget/diffEditor/diffEditorWidget.ts
@@ -390,7 +390,7 @@ export class DiffEditorWidget extends DelegatingEditor implements IDiffEditor {
 			if (shouldHideOriginalLineNumbers) {
 				originalWidth = 0;
 			} else {
-				originalWidth = Math.max(5, this._editors.original.getLayoutInfo().decorationsLeft);
+				originalWidth = Math.max(5, this._editors.originalObs.layoutInfoDecorationsLeft.read(reader));
 			}
 
 			modifiedLeft = gutterWidth + originalWidth;


### PR DESCRIPTION
Fixes #223410