### PR TITLE
Settings URL handling - "Open Current File as Release Notes" command not working

### DIFF
--- a/src/vs/workbench/contrib/update/browser/releaseNotesEditor.ts
+++ b/src/vs/workbench/contrib/update/browser/releaseNotesEditor.ts
@@ -204,7 +204,7 @@ export class ReleaseNotesManager {
 				throw new Error('Failed to fetch release notes');
 			}
 
-			if (!text || !/^#\s/.test(text)) { // release notes always starts with `#` followed by whitespace
+			if (!text || (!/^#\s/.test(text) && !useCurrentFile)) { // release notes always starts with `#` followed by whitespace, except when using the current file
 				throw new Error('Invalid release notes');
 			}
 


### PR DESCRIPTION
Fixes #223291