### PR TITLE
Settings deep-linking issues when extensions update

### DIFF
--- a/src/vs/workbench/services/preferences/browser/preferencesService.ts
+++ b/src/vs/workbench/services/preferences/browser/preferencesService.ts
@@ -6,7 +6,7 @@
 import { getErrorMessage } from 'vs/base/common/errors';
 import { Emitter } from 'vs/base/common/event';
 import { parse } from 'vs/base/common/json';
-import { Disposable } from 'vs/base/common/lifecycle';
+import { Disposable, IDisposable, MutableDisposable } from 'vs/base/common/lifecycle';
 import * as network from 'vs/base/common/network';
 import { URI } from 'vs/base/common/uri';
 import { CoreEditingCommands } from 'vs/editor/browser/coreCommands';
@@ -595,10 +595,11 @@ export class PreferencesService extends Disposable implements IPreferencesServic
 	getSetting(settingId: string): ISetting | undefined {
 		if (!this._settingsGroups) {
 			const defaultSettings = this.getDefaultSettings(ConfigurationTarget.USER);
-			const defaultsChangedDisposable = this._register(defaultSettings.onDidChange(() => {
+			const defaultsChangedDisposable: MutableDisposable<IDisposable> = this._register(new MutableDisposable());
+			defaultsChangedDisposable.value = defaultSettings.onDidChange(() => {
 				this._settingsGroups = undefined;
-				defaultsChangedDisposable.dispose();
-			}));
+				defaultsChangedDisposable.clear();
+			});
 			this._settingsGroups = defaultSettings.getSettingsGroups();
 		}
 

--- a/src/vs/workbench/services/preferences/browser/preferencesService.ts
+++ b/src/vs/workbench/services/preferences/browser/preferencesService.ts
@@ -67,8 +67,6 @@ export class PreferencesService extends Disposable implements IPreferencesServic
 	private readonly _requestedDefaultSettings = new ResourceSet();
 
 	private _settingsGroups: ISettingsGroup[] | undefined = undefined;
-	private _defaultSettings: DefaultSettings | undefined = undefined;
-
 
 	constructor(
 		@IEditorService private readonly editorService: IEditorService,
@@ -441,14 +439,14 @@ export class PreferencesService extends Disposable implements IPreferencesServic
 
 	private getDefaultSettings(target: ConfigurationTarget): DefaultSettings {
 		if (target === ConfigurationTarget.WORKSPACE) {
-			this._defaultWorkspaceSettingsContentModel ??= this._register(new DefaultSettings(this.getMostCommonlyUsedSettings(), target));
+			this._defaultWorkspaceSettingsContentModel ??= this._register(new DefaultSettings(this.getMostCommonlyUsedSettings(), target, this.configurationService));
 			return this._defaultWorkspaceSettingsContentModel;
 		}
 		if (target === ConfigurationTarget.WORKSPACE_FOLDER) {
-			this._defaultFolderSettingsContentModel ??= this._register(new DefaultSettings(this.getMostCommonlyUsedSettings(), target));
+			this._defaultFolderSettingsContentModel ??= this._register(new DefaultSettings(this.getMostCommonlyUsedSettings(), target, this.configurationService));
 			return this._defaultFolderSettingsContentModel;
 		}
-		this._defaultUserSettingsContentModel ??= this._register(new DefaultSettings(this.getMostCommonlyUsedSettings(), target));
+		this._defaultUserSettingsContentModel ??= this._register(new DefaultSettings(this.getMostCommonlyUsedSettings(), target, this.configurationService));
 		return this._defaultUserSettingsContentModel;
 	}
 
@@ -594,16 +592,14 @@ export class PreferencesService extends Disposable implements IPreferencesServic
 		return position;
 	}
 
-	private get defaultSettings(): DefaultSettings {
-		if (!this._defaultSettings) {
-			this._defaultSettings = new DefaultSettings([], ConfigurationTarget.USER);
-		}
-		return this._defaultSettings;
-	}
-
 	getSetting(settingId: string): ISetting | undefined {
 		if (!this._settingsGroups) {
-			this._settingsGroups = this.defaultSettings.getSettingsGroups();
+			const defaultSettings = this.getDefaultSettings(ConfigurationTarget.USER);
+			const defaultsChangedDisposable = this._register(defaultSettings.onDidChange(() => {
+				this._settingsGroups = undefined;
+				defaultsChangedDisposable.dispose();
+			}));
+			this._settingsGroups = defaultSettings.getSettingsGroups();
 		}
 
 		for (const group of this._settingsGroups) {
@@ -632,11 +628,10 @@ export class PreferencesService extends Disposable implements IPreferencesServic
 
 		const openSettingsOptions: IOpenSettingsOptions = {};
 		const settingInfo = uri.path.split('/').filter(part => !!part);
-		if ((settingInfo.length === 0) || !this.getSetting(settingInfo[0])) {
-			return false;
+		if ((settingInfo.length > 0) && this.getSetting(settingInfo[0])) {
+			openSettingsOptions.query = settingInfo[0];
 		}
 
-		openSettingsOptions.query = settingInfo[0];
 		this.openSettings(openSettingsOptions);
 		return true;
 	}


### PR DESCRIPTION
Fixes #223389
- Fixes not opening the settings editor with no query
- Fixes not updating the cached defaults when extensions change them
    - Fixes the `DefaultSettings` `onDidChange` never firing due to the `fire` getting deleted in https://github.com/microsoft/vscode/pull/221136/files#diff-537b4dce91b9254cc9fd3e2982fc235b33373aaeda34b928e6546256295c1730L142