### PR TITLE
If the setting value is the same, do nothing

### DIFF
--- a/extensions/github-authentication/src/github.ts
+++ b/extensions/github-authentication/src/github.ts
@@ -142,6 +142,10 @@ export class GitHubAuthenticationProvider implements vscode.AuthenticationProvid
 			this.context.secrets.onDidChange(() => this.checkForUpdates()),
 			vscode.workspace.onDidChangeConfiguration(async e => {
 				if (e.affectsConfiguration('github.experimental.multipleAccounts')) {
+					const newValue = vscode.workspace.getConfiguration('github.experimental').get<boolean>('multipleAccounts', false);
+					if (newValue === this._supportsMultipleAccounts) {
+						return;
+					}
 					const result = await vscode.window.showInformationMessage(vscode.l10n.t('Please reload the window to apply the new setting.'), { modal: true }, vscode.l10n.t('Reload Window'));
 					if (result) {
 						vscode.commands.executeCommand('workbench.action.reloadWindow');


### PR DESCRIPTION
It seems like this event fires in Codespaces... my _guess_ is that Codespaces basically overwrites all the settings from settings sync which causes this event to fire.

It's surprising to me that this event fires even though the value hasn't changed.

I can't repro this with the test resolver, and I also cant have Codespaces use Code - OSS, so we'll just have to see how this goes.

This _should_ do the trick though.

Fixes https://github.com/microsoft/vscode/issues/223508

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
