### PR TITLE
remove acronym which caused screen reader to announce incorrectly, fix typo

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/replAccessibilityHelp.ts
+++ b/src/vs/workbench/contrib/debug/browser/replAccessibilityHelp.ts
@@ -48,7 +48,7 @@ class ReplAccessibilityHelpProvider extends Disposable implements IAccessibleVie
 
 	public provideContent(): string {
 		return [
-			localize('repl.help', "The debug console is a REPL (Read-Eval-Print-Loop) that allows you to evaluate expressions and run commands and can be focused with{0}.", '<keybinding:workbench.panel.repl.view.focus>'),
+			localize('repl.help', "The debug console is a Read-Eval-Print-Loop that allows you to evaluate expressions and run commands and can be focused with{0}.", '<keybinding:workbench.panel.repl.view.focus>'),
 			localize('repl.output', "The debug console output can be navigated to from the input field with the Focus Previous Widget command{0}.", '<keybinding:widgetNavigation.focusPrevious>'),
 			localize('repl.input', "The debug console input can be navigated to from the output with the Focus Next Widget command{0}.", '<keybinding:widgetNavigation.focusNext>'),
 			localize('repl.history', "The debug console output history can be navigated with the up and down arrow keys."),

--- a/src/vs/workbench/contrib/debug/browser/runAndDebugAccessibilityHelp.ts
+++ b/src/vs/workbench/contrib/debug/browser/runAndDebugAccessibilityHelp.ts
@@ -72,7 +72,7 @@ class RunAndDebugAccessibilityHelpProvider extends Disposable implements IAccess
 			localize('debug.focusCallStack', "- Debug: Focus Call Stack View command{0} will focus the call stack view.", '<keybinding:workbench.debug.action.focusCallStackView>'),
 			localize('debug.focusVariables', "- Debug: Focus Variables View command{0} will focus the variables view.", '<keybinding:workbench.debug.action.focusVariablesView>'),
 			localize('debug.focusWatch', "- Debug: Focus Watch View command{0} will focus the watch view.", '<keybinding:workbench.debug.action.focusWatchView>'),
-			localize('debug.help', "The debug console is a Read-Eval-Print-Loop that allows you to evaluate expressions and run commands and can be focused with{0}.", '<keybinding:workbench.panel.repl.view.focus'),
+			localize('debug.help', "The debug console is a Read-Eval-Print-Loop that allows you to evaluate expressions and run commands and can be focused with{0}.", '<keybinding:workbench.panel.repl.view.focus>'),
 			localize('debug.watchSetting', "The setting {0} controls whether watch variable changes are announced.", 'accessibility.debugWatchVariableAnnouncements'),
 		].join('\n');
 	}

--- a/src/vs/workbench/contrib/debug/browser/runAndDebugAccessibilityHelp.ts
+++ b/src/vs/workbench/contrib/debug/browser/runAndDebugAccessibilityHelp.ts
@@ -72,7 +72,7 @@ class RunAndDebugAccessibilityHelpProvider extends Disposable implements IAccess
 			localize('debug.focusCallStack', "- Debug: Focus Call Stack View command{0} will focus the call stack view.", '<keybinding:workbench.debug.action.focusCallStackView>'),
 			localize('debug.focusVariables', "- Debug: Focus Variables View command{0} will focus the variables view.", '<keybinding:workbench.debug.action.focusVariablesView>'),
 			localize('debug.focusWatch', "- Debug: Focus Watch View command{0} will focus the watch view.", '<keybinding:workbench.debug.action.focusWatchView>'),
-			localize('debug.help', "The debug console is a REPL (Read-Eval-Print-Loop) that allows you to evaluate expressions and run commands and can be focused with{0}.", '<keybinding:workbench.panel.repl.view.focus'),
+			localize('debug.help', "The debug console is a Read-Eval-Print-Loop that allows you to evaluate expressions and run commands and can be focused with{0}.", '<keybinding:workbench.panel.repl.view.focus'),
 			localize('debug.watchSetting', "The setting {0} controls whether watch variable changes are announced.", 'accessibility.debugWatchVariableAnnouncements'),
 		].join('\n');
 	}


### PR DESCRIPTION
fixes #223350
fixes https://github.com/microsoft/vscode/issues/223379