### PR TITLE
Handle bad directory watch on web

### DIFF
--- a/extensions/typescript-language-features/web/src/serverHost.ts
+++ b/extensions/typescript-language-features/web/src/serverHost.ts
@@ -11,6 +11,7 @@ import { FileWatcherManager } from './fileWatcherManager';
 import { Logger } from './logging';
 import { PathMapper, looksLikeNodeModules, mapUri } from './pathMapper';
 import { findArgument, hasArgument } from './util/args';
+import { URI } from 'vscode-uri';
 
 type ServerHostWithImport = ts.server.ServerHost & { importPlugin(root: string, moduleName: string): Promise<ts.server.ModuleImportResult> };
 
@@ -349,7 +350,13 @@ function createServerHost(
 			return path;
 		}
 
-		let uri = pathMapper.toResource(path);
+		let uri: URI;
+		try {
+			uri = pathMapper.toResource(path);
+		} catch {
+			return path;
+		}
+
 		if (isNm) {
 			uri = mapUri(uri, 'vscode-node-modules');
 		}


### PR DESCRIPTION
Fix #221299

toResource throws here because we're tyring to watch directories outside of the workspace root. Should be fixed on TS side. Until them, adding a `catch`

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
