### PR TITLE
Revert "Remove latest-release-monitor-workflow"

### DIFF
--- a/.github/workflows/latest-release-monitor.yml
+++ b/.github/workflows/latest-release-monitor.yml
@@ -1,0 +1,36 @@
+name: Latest Release Monitor
+
+permissions:
+  id-token: write
+  contents: read
+
+on:
+  schedule:
+    - cron: 0/5 * * * *
+  repository_dispatch:
+    types: [trigger-latest-release-monitor]
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    environment: main
+    steps:
+      - uses: azure/login@v2
+        with:
+          client-id: ${{ vars.AZURE_CLIENT_ID }}
+          tenant-id: ${{ vars.AZURE_TENANT_ID }}
+          allow-no-subscriptions: true
+      - name: Checkout Actions
+        uses: actions/checkout@v4
+        with:
+          repository: "microsoft/vscode-github-triage-actions"
+          path: ./actions
+          ref: stable
+      - name: Install Actions
+        run: npm install --production --prefix ./actions
+      - name: Install Storage Module
+        run: npm install @azure/storage-blob@12.1.1
+      - name: Run Latest Release Monitor
+        uses: ./actions/latest-release-monitor
+        with:
+          token: ${{secrets.VSCODE_ISSUE_TRIAGE_BOT_PAT}}


### PR DESCRIPTION
Temporarily Reverts microsoft/vscode#222246 till github app permissions are restored.