### PR TITLE
Updated AutoSave Duration Default to 200MS

### DIFF
--- a/src/vs/workbench/contrib/files/browser/files.contribution.ts
+++ b/src/vs/workbench/contrib/files/browser/files.contribution.ts
@@ -273,7 +273,7 @@ configurationRegistry.registerConfiguration({
 		},
 		'files.autoSaveDelay': {
 			'type': 'number',
-			'default': 1000,
+			'default': 200,
 			'minimum': 0,
 			'markdownDescription': nls.localize({ comment: ['This is the description for a setting. Values surrounded by single quotes are not to be translated.'], key: 'autoSaveDelay' }, "Controls the delay in milliseconds after which an editor with unsaved changes is saved automatically. Only applies when `#files.autoSave#` is set to `{0}`.", AutoSaveConfiguration.AFTER_DELAY),
 			scope: ConfigurationScope.LANGUAGE_OVERRIDABLE


### PR DESCRIPTION
# Updated the autosave default duration to 200MS instead of 1000MS

Sometimes developers find it very annoying when the default autosave duration is 1 seconds (1000ms) as the VS-Code default.