### PR TITLE
Fix cell selection state bugs

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/controller/coreActions.ts
+++ b/src/vs/workbench/contrib/notebook/browser/controller/coreActions.ts
@@ -250,12 +250,14 @@ export abstract class NotebookMultiCellAction extends Action2 {
 		// no parsed args, try handle active editor
 		const editor = getEditorFromArgsOrActivePane(accessor);
 		if (editor) {
+			const selectedCellRange: ICellRange[] = editor.getSelections().length === 0 ? [editor.getFocus()] : editor.getSelections();
+
 			telemetryService.publicLog2<WorkbenchActionExecutedEvent, WorkbenchActionExecutedClassification>('workbenchActionExecuted', { id: this.desc.id, from: from });
 
 			return this.runWithContext(accessor, {
 				ui: false,
 				notebookEditor: editor,
-				selectedCells: cellRangeToViewCells(editor, editor.getSelections())
+				selectedCells: cellRangeToViewCells(editor, selectedCellRange)
 			});
 		}
 	}

--- a/src/vs/workbench/contrib/notebook/browser/controller/editActions.ts
+++ b/src/vs/workbench/contrib/notebook/browser/controller/editActions.ts
@@ -634,10 +634,8 @@ registerAction2(class CommentSelectedCellsAction extends NotebookMultiCellAction
 			keybinding: {
 				when: ContextKeyExpr.and(
 					NOTEBOOK_EDITOR_FOCUSED,
-					NOTEBOOK_CELL_LIST_FOCUSED,
-					ContextKeyExpr.not(InputFocusedContextKey),
 					NOTEBOOK_EDITOR_EDITABLE,
-					NOTEBOOK_CELL_EDITABLE
+					ContextKeyExpr.not(InputFocusedContextKey),
 				),
 				primary: KeyMod.CtrlCmd | KeyCode.Slash,
 				weight: KeybindingWeight.WorkbenchContrib
@@ -657,6 +655,7 @@ registerAction2(class CommentSelectedCellsAction extends NotebookMultiCellAction
 			}
 		});
 
+
 		selectedCellEditors.forEach(editor => {
 			if (!editor.hasModel()) {
 				return;
@@ -666,6 +665,8 @@ registerAction2(class CommentSelectedCellsAction extends NotebookMultiCellAction
 			const commands: ICommand[] = [];
 			const modelOptions = model.getOptions();
 			const commentsOptions = editor.getOption(EditorOption.comments);
+
+			const selection = editor.getSelection();
 
 			commands.push(new LineCommentCommand(
 				languageConfigurationService,
@@ -680,6 +681,8 @@ registerAction2(class CommentSelectedCellsAction extends NotebookMultiCellAction
 			editor.pushUndoStop();
 			editor.executeCommands(COMMENT_SELECTED_CELLS_ID, commands);
 			editor.pushUndoStop();
+
+			editor.setSelection(selection);
 		});
 	}
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fixes: #223343, #223345

Patch was made in `coreActions.ts` to address the bug relating to hitting escape and the command no longer working. 

Bug is upstream in the cell list, when escape is hit, the editor loses the cell selection, however retains focus. Therefore, the selectedCells are not passed into the context of this action. Now, the selectedCells are determined by checking the selection, and if empty, taking the focus of the editor.