### PR TITLE
Document markdown debug server build path

### DIFF
--- a/extensions/markdown-language-features/src/extension.ts
+++ b/extensions/markdown-language-features/src/extension.ts
@@ -31,6 +31,8 @@ function startServer(context: vscode.ExtensionContext, parser: IMdParser): Promi
 
 	const serverModule = context.asAbsolutePath(
 		isDebugBuild
+			// For local non bundled version of vscode-markdown-languageserver
+			// ? './node_modules/vscode-markdown-languageserver/out/node/workerMain'
 			? './node_modules/vscode-markdown-languageserver/dist/node/workerMain'
 			: './dist/serverWorkerMain'
 	);


### PR DESCRIPTION
For debugging, we may want to load the non-bundled path. Only useful when using `yarn link` for local development so just adding as comment

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
