### PR TITLE
Ensure new editing comment is focused when expanding a thread

### DIFF
--- a/src/vs/workbench/contrib/comments/browser/commentReply.ts
+++ b/src/vs/workbench/contrib/comments/browser/commentReply.ts
@@ -118,7 +118,7 @@ export class CommentReply<T extends IRange | ICellRange> extends Disposable {
 			this.expandReplyArea();
 		} else if (hasExistingComments) {
 			this.createReplyButton(this.commentEditor, this.form);
-		} else if (focus && (!this._commentThread.comments || this._commentThread.comments.length === 0)) {
+		} else if (focus && (this._commentThread.comments && this._commentThread.comments.length === 0)) {
 			this.expandReplyArea();
 		}
 		this._error = dom.append(this.form, dom.$('.validation-error.hidden'));

--- a/src/vs/workbench/contrib/comments/browser/commentThreadBody.ts
+++ b/src/vs/workbench/contrib/comments/browser/commentThreadBody.ts
@@ -70,6 +70,12 @@ export class CommentThreadBody<T extends IRange | ICellRange = IRange> extends D
 		this._commentsElement.focus();
 	}
 
+	ensureFocusIntoNewEditingComment() {
+		if (this._commentElements.length === 1 && this._commentElements[0].isEditing) {
+			this._commentElements[0].setFocus(true);
+		}
+	}
+
 	async display() {
 		this._commentsElement = dom.append(this.container, dom.$('div.comments-container'));
 		this._commentsElement.setAttribute('role', 'presentation');

--- a/src/vs/workbench/contrib/comments/browser/commentThreadWidget.ts
+++ b/src/vs/workbench/contrib/comments/browser/commentThreadWidget.ts
@@ -353,6 +353,10 @@ export class CommentThreadWidget<T extends IRange | ICellRange = IRange> extends
 		}
 	}
 
+	ensureFocusIntoNewEditingComment() {
+		this._body.ensureFocusIntoNewEditingComment();
+	}
+
 	focusCommentEditor() {
 		this._commentReply?.expandReplyAreaAndFocusCommentEditor();
 	}

--- a/src/vs/workbench/contrib/comments/browser/commentThreadZoneWidget.ts
+++ b/src/vs/workbench/contrib/comments/browser/commentThreadZoneWidget.ts
@@ -423,6 +423,7 @@ export class ReviewZoneWidget extends ZoneWidget implements ICommentThreadWidget
 		this._commentThreadDisposables.push(this._commentThread.onDidChangeCollapsibleState(state => {
 			if (state === languages.CommentThreadCollapsibleState.Expanded && !this._isExpanded) {
 				this.show(this.arrowPosition(this._commentThread.range), 2);
+				this._commentThreadWidget.ensureFocusIntoNewEditingComment();
 				return;
 			}
 

--- a/src/vs/workbench/contrib/comments/browser/commentsController.ts
+++ b/src/vs/workbench/contrib/comments/browser/commentsController.ts
@@ -869,8 +869,7 @@ export class CommentController implements IEditorContribution {
 		const pendingCommentText = (this._pendingNewCommentCache[uniqueOwner] && this._pendingNewCommentCache[uniqueOwner][thread.threadId])
 			?? continueOnCommentText;
 		const pendingEdits = this._pendingEditsCache[uniqueOwner] && this._pendingEditsCache[uniqueOwner][thread.threadId];
-		const isThreadTemplateOrEmpty = (thread.isTemplate || (!thread.comments || (thread.comments.length === 0)));
-		const shouldReveal = thread.canReply && isThreadTemplateOrEmpty && (!thread.editorId || (thread.editorId === editorId));
+		const shouldReveal = thread.canReply && thread.isTemplate && (!thread.comments || (thread.comments.length === 0)) && (!thread.editorId || (thread.editorId === editorId));
 		await this.displayCommentThread(uniqueOwner, thread, shouldReveal, pendingCommentText, pendingEdits);
 		this._commentInfos.filter(info => info.uniqueOwner === uniqueOwner)[0].threads.push(thread);
 		this.tryUpdateReservedSpace();


### PR DESCRIPTION
Fixes #223842

Caused by https://github.com/microsoft/vscode/issues/214661. 

I caused https://github.com/microsoft/vscode/issues/214661 when I fixed an issue when there are multiple text editors open with the same uri with comments. When I tried to fix https://github.com/microsoft/vscode/issues/214661 I made it so when extensions call `createCommentThread` and pass in `[]` for the comments, we always expand the reply editor, resulting in the bad behavior above.

I took a quick look, and it seems very common for extensions to pass in `[]` for the comments and then immediately set them. 

This change first reverts the bad change from https://github.com/microsoft/vscode/issues/214661.

Then, I"ve made a change that enables the scenario that https://github.com/microsoft/vscode/issues/214661 aimed to fix: A way for an extension to create acomment thead with the editor expanded and focused.