### PR TITLE
Respect --disable-gpu command line option when terminal gpu acceleration set to auto

### DIFF
--- a/src/vs/code/electron-main/app.ts
+++ b/src/vs/code/electron-main/app.ts
@@ -32,7 +32,7 @@ import { BackupMainService } from 'vs/platform/backup/electron-main/backupMainSe
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { ElectronExtensionHostDebugBroadcastChannel } from 'vs/platform/debug/electron-main/extensionHostDebugIpc';
 import { IDiagnosticsService } from 'vs/platform/diagnostics/common/diagnostics';
-import { DiagnosticsMainService, IDiagnosticsMainService } from 'vs/platform/diagnostics/electron-main/diagnosticsMainService';
+import { DiagnosticsMainService } from 'vs/platform/diagnostics/electron-main/diagnosticsMainService';
 import { DialogMainService, IDialogMainService } from 'vs/platform/dialogs/electron-main/dialogMainService';
 import { IEncryptionMainService } from 'vs/platform/encryption/common/encryptionService';
 import { EncryptionMainService } from 'vs/platform/encryption/electron-main/encryptionMainService';
@@ -121,6 +121,8 @@ import { Lazy } from 'vs/base/common/lazy';
 import { IAuxiliaryWindowsMainService } from 'vs/platform/auxiliaryWindow/electron-main/auxiliaryWindows';
 import { AuxiliaryWindowsMainService } from 'vs/platform/auxiliaryWindow/electron-main/auxiliaryWindowsMainService';
 import { normalizeNFC } from 'vs/base/common/normalization';
+import { IDiagnosticsMainService } from 'vs/platform/diagnostics/common/diagnosticsMain';
+
 /**
  * The main VS Code application. There will only ever be one instance,
  * even if the user starts many instances (e.g. from the command line).
@@ -1118,8 +1120,9 @@ export class CodeApplication extends Disposable {
 		const launchChannel = ProxyChannel.fromService(accessor.get(ILaunchMainService), disposables, { disableMarshalling: true });
 		this.mainProcessNodeIpcServer.registerChannel('launch', launchChannel);
 
-		const diagnosticsChannel = ProxyChannel.fromService(accessor.get(IDiagnosticsMainService), disposables, { disableMarshalling: true });
-		this.mainProcessNodeIpcServer.registerChannel('diagnostics', diagnosticsChannel);
+		const diagnosticsMainChannel = ProxyChannel.fromService(accessor.get(IDiagnosticsMainService), disposables, { disableMarshalling: true });
+		this.mainProcessNodeIpcServer.registerChannel('diagnostics-main', diagnosticsMainChannel);
+		mainProcessElectronServer.registerChannel('diagnostics-main', diagnosticsMainChannel);
 
 		// Policies (main & shared process)
 		const policyChannel = disposables.add(new PolicyChannel(accessor.get(IPolicyService)));

--- a/src/vs/code/electron-main/main.ts
+++ b/src/vs/code/electron-main/main.ts
@@ -29,7 +29,6 @@ import { CodeApplication } from 'vs/code/electron-main/app';
 import { localize } from 'vs/nls';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { ConfigurationService } from 'vs/platform/configuration/common/configurationService';
-import { IDiagnosticsMainService } from 'vs/platform/diagnostics/electron-main/diagnosticsMainService';
 import { DiagnosticsService } from 'vs/platform/diagnostics/node/diagnosticsService';
 import { NativeParsedArgs } from 'vs/platform/environment/common/argv';
 import { EnvironmentMainService, IEnvironmentMainService } from 'vs/platform/environment/electron-main/environmentMainService';
@@ -72,6 +71,7 @@ import { massageMessageBoxOptions } from 'vs/platform/dialogs/common/dialogs';
 import { SaveStrategy, StateService } from 'vs/platform/state/node/stateService';
 import { FileUserDataProvider } from 'vs/platform/userData/common/fileUserDataProvider';
 import { addUNCHostToAllowlist, getUNCHost } from 'vs/base/node/unc';
+import { IDiagnosticsMainService } from 'vs/platform/diagnostics/common/diagnosticsMain';
 
 /**
  * The main VS Code entry point.
@@ -362,7 +362,7 @@ class CodeMain {
 			}
 
 			const otherInstanceLaunchMainService = ProxyChannel.toService<ILaunchMainService>(client.getChannel('launch'), { disableMarshalling: true });
-			const otherInstanceDiagnosticsMainService = ProxyChannel.toService<IDiagnosticsMainService>(client.getChannel('diagnostics'), { disableMarshalling: true });
+			const otherInstanceDiagnosticsMainService = ProxyChannel.toService<IDiagnosticsMainService>(client.getChannel('diagnostics-main'), { disableMarshalling: true });
 
 			// Process Info
 			if (environmentMainService.args.status) {

--- a/src/vs/platform/diagnostics/common/diagnostics.ts
+++ b/src/vs/platform/diagnostics/common/diagnostics.ts
@@ -148,5 +148,5 @@ export interface IMainProcessDiagnostics {
 	readonly windows: IWindowDiagnostics[];
 	readonly pidToNames: IProcessDiagnostics[];
 	readonly screenReader: boolean;
-	readonly gpuFeatureStatus: any;
+	readonly gpuFeatureStatus: Electron.GPUFeatureStatus;
 }

--- a/src/vs/platform/diagnostics/common/diagnosticsMain.ts
+++ b/src/vs/platform/diagnostics/common/diagnosticsMain.ts
@@ -1,0 +1,21 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IMainProcessDiagnostics, IRemoteDiagnosticError, IRemoteDiagnosticInfo } from 'vs/platform/diagnostics/common/diagnostics';
+import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
+
+export const ID = 'diagnosticsMainService';
+export const IDiagnosticsMainService = createDecorator<IDiagnosticsMainService>(ID);
+
+export interface IRemoteDiagnosticOptions {
+	includeProcesses?: boolean;
+	includeWorkspaceMetadata?: boolean;
+}
+
+export interface IDiagnosticsMainService {
+	readonly _serviceBrand: undefined;
+	getRemoteDiagnostics(options: IRemoteDiagnosticOptions): Promise<(IRemoteDiagnosticInfo | IRemoteDiagnosticError)[]>;
+	getMainDiagnostics(): Promise<IMainProcessDiagnostics>;
+}

--- a/src/vs/platform/diagnostics/electron-main/diagnosticsMainService.ts
+++ b/src/vs/platform/diagnostics/electron-main/diagnosticsMainService.ts
@@ -8,7 +8,6 @@ import { validatedIpcMain } from 'vs/base/parts/ipc/electron-main/ipcMain';
 import { CancellationToken } from 'vs/base/common/cancellation';
 import { URI } from 'vs/base/common/uri';
 import { IDiagnosticInfo, IDiagnosticInfoOptions, IMainProcessDiagnostics, IProcessDiagnostics, IRemoteDiagnosticError, IRemoteDiagnosticInfo, IWindowDiagnostics } from 'vs/platform/diagnostics/common/diagnostics';
-import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
 import { ICodeWindow } from 'vs/platform/window/electron-main/window';
 import { IWindowsMainService } from 'vs/platform/windows/electron-main/windows';
 import { isSingleFolderWorkspaceIdentifier, isWorkspaceIdentifier } from 'vs/platform/workspace/common/workspace';
@@ -16,20 +15,7 @@ import { IWorkspacesManagementMainService } from 'vs/platform/workspaces/electro
 import { assertIsDefined } from 'vs/base/common/types';
 import { ILogService } from 'vs/platform/log/common/log';
 import { UtilityProcess } from 'vs/platform/utilityProcess/electron-main/utilityProcess';
-
-export const ID = 'diagnosticsMainService';
-export const IDiagnosticsMainService = createDecorator<IDiagnosticsMainService>(ID);
-
-export interface IRemoteDiagnosticOptions {
-	includeProcesses?: boolean;
-	includeWorkspaceMetadata?: boolean;
-}
-
-export interface IDiagnosticsMainService {
-	readonly _serviceBrand: undefined;
-	getRemoteDiagnostics(options: IRemoteDiagnosticOptions): Promise<(IRemoteDiagnosticInfo | IRemoteDiagnosticError)[]>;
-	getMainDiagnostics(): Promise<IMainProcessDiagnostics>;
-}
+import { IDiagnosticsMainService, IRemoteDiagnosticOptions } from 'vs/platform/diagnostics/common/diagnosticsMain';
 
 export class DiagnosticsMainService implements IDiagnosticsMainService {
 

--- a/src/vs/platform/diagnostics/electron-sandbox/diagnosticsMainService.ts
+++ b/src/vs/platform/diagnostics/electron-sandbox/diagnosticsMainService.ts
@@ -1,0 +1,9 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { IDiagnosticsMainService } from 'vs/platform/diagnostics/common/diagnosticsMain';
+import { registerMainProcessRemoteService } from 'vs/platform/ipc/electron-sandbox/services';
+
+registerMainProcessRemoteService(IDiagnosticsMainService, 'diagnostics-main');

--- a/src/vs/platform/issue/electron-main/processMainService.ts
+++ b/src/vs/platform/issue/electron-main/processMainService.ts
@@ -12,7 +12,7 @@ import { listProcesses } from 'vs/base/node/ps';
 import { validatedIpcMain } from 'vs/base/parts/ipc/electron-main/ipcMain';
 import { localize } from 'vs/nls';
 import { IDiagnosticsService, isRemoteDiagnosticError, PerformanceInfo, SystemInfo } from 'vs/platform/diagnostics/common/diagnostics';
-import { IDiagnosticsMainService } from 'vs/platform/diagnostics/electron-main/diagnosticsMainService';
+import { IDiagnosticsMainService } from 'vs/platform/diagnostics/common/diagnosticsMain';
 import { IDialogMainService } from 'vs/platform/dialogs/electron-main/dialogMainService';
 import { IEnvironmentMainService } from 'vs/platform/environment/electron-main/environmentMainService';
 import { IProcessMainService, ProcessExplorerData, ProcessExplorerWindowConfiguration } from 'vs/platform/issue/common/issue';

--- a/src/vs/workbench/workbench.desktop.main.ts
+++ b/src/vs/workbench/workbench.desktop.main.ts
@@ -73,6 +73,7 @@ import 'vs/workbench/services/checksum/electron-sandbox/checksumService';
 import 'vs/platform/remote/electron-sandbox/sharedProcessTunnelService';
 import 'vs/workbench/services/tunnel/electron-sandbox/tunnelService';
 import 'vs/platform/diagnostics/electron-sandbox/diagnosticsService';
+import 'vs/platform/diagnostics/electron-sandbox/diagnosticsMainService';
 import 'vs/platform/profiling/electron-sandbox/profilingService';
 import 'vs/platform/telemetry/electron-sandbox/customEndpointTelemetryService';
 import 'vs/platform/remoteTunnel/electron-sandbox/remoteTunnelService';


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
Close #200696 

Base on [workbench/contrib/terminal/browser/xterm/xtermTerminal.ts#L685](https://github.com/microsoft/vscode/blob/main/src/vs/workbench/contrib/terminal/browser/xterm/xtermTerminal.ts#L685)

Checked webgl2 if enabled after invoke `getMainDiagnostics` from the [gpuFeatureStatus](https://www.electronjs.org/docs/latest/api/structures/gpu-feature-status) object.

Not sure if I need to do more checking with the `gpuFeatureStatus` object.

![pic](https://github.com/user-attachments/assets/e46f58e8-027b-459d-a081-ac07c5325e3d)


