### PR TITLE
Fixes #223937

### DIFF
--- a/src/vs/editor/browser/widget/codeEditor/editor.css
+++ b/src/vs/editor/browser/widget/codeEditor/editor.css
@@ -23,6 +23,7 @@
 	-webkit-text-size-adjust: 100%;
 	color: var(--vscode-editor-foreground);
 	background-color: var(--vscode-editor-background);
+	overflow-wrap: initial;
 }
 .monaco-editor-background {
 	background-color: var(--vscode-editor-background);


### PR DESCRIPTION
Fixes #223937

Ideally we would just limit the effect of this rule:

https://github.com/microsoft/vscode/blob/699b8df2b158f84408395f52bdf784bcf054e906/src/vs/workbench/contrib/chat/browser/media/chat.css#L231

...but that would have unpredictable consequences and is a risky change.

`overflow-wrap: initial;` is much less risky, as everything inside the monaco editor has a more specific css selector if it overrides `overflow-wrap`. Of course this change also has its risks.
