### PR TITLE
fix: escaping path correct for the right click "add to .gitignore" action when containing opening square brackets "["

### DIFF
--- a/extensions/git/src/repository.ts
+++ b/extensions/git/src/repository.ts
@@ -1958,7 +1958,7 @@ export class Repository implements Disposable {
 		return await this.run(Operation.Ignore, async () => {
 			const ignoreFile = `${this.repository.root}${path.sep}.gitignore`;
 			const textToAppend = files
-				.map(uri => relativePath(this.repository.root, uri.fsPath).replace(/\[/g, '\\[').replace(/\\/g, '/'))
+				.map(uri => relativePath(this.repository.root, uri.fsPath).replace(/\\/g, '/').replace(/\[/g, '\\['))
 				.join('\n');
 
 			const document = await new Promise(c => fs.exists(ignoreFile, c))

--- a/extensions/git/src/repository.ts
+++ b/extensions/git/src/repository.ts
@@ -1958,7 +1958,7 @@ export class Repository implements Disposable {
 		return await this.run(Operation.Ignore, async () => {
 			const ignoreFile = `${this.repository.root}${path.sep}.gitignore`;
 			const textToAppend = files
-				.map(uri => relativePath(this.repository.root, uri.fsPath).replace(/\\/g, '/'))
+				.map(uri => relativePath(this.repository.root, uri.fsPath).replace(/\\/g, '/').replace(/([\\{}|^$+?.()\[\]])/g, '\\$1'))
 				.join('\n');
 
 			const document = await new Promise(c => fs.exists(ignoreFile, c))

--- a/extensions/git/src/repository.ts
+++ b/extensions/git/src/repository.ts
@@ -1958,7 +1958,7 @@ export class Repository implements Disposable {
 		return await this.run(Operation.Ignore, async () => {
 			const ignoreFile = `${this.repository.root}${path.sep}.gitignore`;
 			const textToAppend = files
-				.map(uri => relativePath(this.repository.root, uri.fsPath).replace(/\\/g, '/').replace(/([\\{}|^$+?.()\[\]])/g, '\\$1'))
+				.map(uri => relativePath(this.repository.root, uri.fsPath).replace(/\[/g, '\\[').replace(/\\/g, '/'))
 				.join('\n');
 
 			const document = await new Promise(c => fs.exists(ignoreFile, c))


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
This PR closes #184898 

This bug affected me now for a long time and I finally decided to try to fix it myself as it does not seem as a really complex bug. 

# What's the current problem?
Currently, there is an issue with one of the context menu options. If you are in the shipped source control extension (git) in a repository and right-click a changed file, you can select "Add to .gitignore". This will append the selected file path to the .gitignore file.

This works for most special characters. The only issue seems to be when dealing with open square brackets ("["). Closing square brackets are not a problem, but the opening ones cause git to not recognize the file path correctly. This will result in the file not properly excluded from future commits.

I think it has something to do, with .gitignore beeing parsed with regex capabilities by git and therefore interpreting the opening squared bracket as the start of an expression. The closing square bracket can never be the start of an expression and therefore does not cause any issues.

# Solution
Opening square brackets have to be escaped properly. Escaping them will make git to recogine the path correctly in .gitignore. 
I just used the same method already used in the same line of code to also replace these opening square brackets with an opening escaped square bracket

# How to reproduce the initial issue
1. Create a new repository 
2. add a file containing a open square bracket in the name, e.g."File[Name.txt"
3. go into the source control panel on the left side
4. right-click the file and select "Add to .gitignore" 
5. You will see that the file will not be removed from the list of changed files but a entry is added to the .gitignore file

# How to test this PR
1. Create a new repository 
2. add a file containing a open square bracket in the name
3. go into the source control panel on the left side
4. right-click the file and select "Add to .gitignore" 
5. the file is removed from the changes list, as the .gitignore entry is now correctly escaped

I sanity checked this behavior with "git status" to make sure it's not a pure vscode quirk with the internal .gitignore recognition for changes.

It appears that there are currently no automatic tests regarding these code parts.

 Tested with git version 2.41.0.windows.1 on Windows 11