### PR TITLE
fix: entry not always listed in Settings editor

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
@@ -1388,6 +1388,7 @@ export class SettingsEditor2 extends EditorPane {
 						displayName: extension.displayName,
 					}
 				};
+				groups.push(additionalGroup);
 				additionalGroups.push(additionalGroup);
 				setAdditionalGroups = true;
 			}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
Entries from settingsEditorRecommendedExtensions sometimes don't show up under the Settings editor table of contents.

I have confirmed that adding the entry under both the `groups` and `additionalGroups` variables doesn't cause a breakage.