### PR TITLE
debug: refactor state of DebugModel

### DIFF
--- a/src/vs/platform/observable/common/platformObservableUtils.ts
+++ b/src/vs/platform/observable/common/platformObservableUtils.ts
@@ -3,11 +3,12 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { IDisposable } from 'vs/base/common/lifecycle';
-import { autorunOpts, IObservable, IReader } from 'vs/base/common/observable';
+import { DisposableStore, IDisposable, IReference, toDisposable } from 'vs/base/common/lifecycle';
+import { autorunOpts, IObservable, IReader, ISettableObservable, ITransaction, observableValue, transaction } from 'vs/base/common/observable';
 import { observableFromEventOpts } from 'vs/base/common/observableInternal/utils';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { ContextKeyValue, IContextKeyService, RawContextKey } from 'vs/platform/contextkey/common/contextkey';
+import { IStorageService, IStorageValueChangeEvent, StorageScope, StorageTarget } from 'vs/platform/storage/common/storage';
 
 /** Creates an observable update when a configuration key updates. */
 export function observableConfigValue<T>(key: string, defaultValue: T, configurationService: IConfigurationService): IObservable<T> {
@@ -29,3 +30,126 @@ export function bindContextKey<T extends ContextKeyValue>(key: RawContextKey<T>,
 	});
 }
 
+export interface IStoredValueSerialization<T> {
+	fromString(data: string): T;
+	toString(data: T): string;
+}
+
+export interface IStoredObservableOptions<T> {
+	key: string;
+	scope: StorageScope;
+	target: StorageTarget;
+	defaultValue: T;
+	/** If true, the state will not be transferred in 'continue on.' */
+	localOnly?: boolean;
+	/** If set, the data will always be considered 'dirty' and stored when requested. */
+	isMutableData?: boolean;
+	/**
+	 * Serialization options for the stored value if you desire something other
+	 * than the default JSON-stringify.
+	 */
+	serialization?: IStoredValueSerialization<T>;
+}
+
+const defaultSerialization: IStoredValueSerialization<any> = {
+	fromString: d => JSON.parse(d),
+	toString: d => JSON.stringify(d),
+};
+
+export const serializeMapAsObject: IStoredValueSerialization<Map<string, any>> = {
+	fromString: d => new Map(Object.entries(JSON.parse(d))),
+	toString: d => {
+		const obj = Object.create(null);
+		for (const [key, value] of d) {
+			obj[key] = value;
+		}
+		return JSON.stringify(obj);
+	},
+};
+
+
+/** Creates an observable that stores and retrieves its value using the storage service. */
+export function storedObservable<T>(
+	storageService: IStorageService,
+	{ key, scope, target, defaultValue, localOnly = false, isMutableData = false, serialization = defaultSerialization }: IStoredObservableOptions<T>,
+): IReference<ISettableObservable<T>> {
+	const store = new DisposableStore();
+	const defaultSerialized = serialization.toString(defaultValue);
+
+	const readFromStorage = (): T => {
+		const stored = storageService.get(key, scope, undefined);
+		return stored === undefined ? defaultValue : serialization.fromString(stored);
+	};
+
+	// "Continue Working On" transfers applicable state by default
+	// Ref: https://github.com/microsoft/vscode/issues/183449
+	if ((target === StorageTarget.USER || scope === StorageScope.WORKSPACE) && !localOnly) {
+		store.add(listenToStorageServiceChange(storageService, scope, (e, tx) => {
+			if (e.external) {
+				observable.set(readFromStorage(), tx);
+			}
+		}));
+	}
+
+	const observable = observableValue(key, readFromStorage());
+	let dirty = isMutableData;
+
+	store.add(storageService.onWillSaveState(() => {
+		if (dirty) {
+			const serialized = serialization.toString(observable.get());
+			if (serialized === defaultSerialized) {
+				storageService.remove(key, scope);
+			} else {
+				storageService.store(key, serialized, scope, target);
+			}
+			dirty = isMutableData;
+		}
+	}));
+
+	if (!isMutableData) {
+		observable.addObserver({
+			beginUpdate() { },
+			endUpdate() { },
+			handlePossibleChange() { },
+			handleChange() { dirty = true; }
+		});
+	}
+
+	return { object: observable, dispose: () => store.dispose() };
+}
+
+const globalStorageListeners = new WeakMap<IStorageService, Map<StorageScope, {
+	listeners: Set<(e: IStorageValueChangeEvent, tx: ITransaction) => void>;
+	dispose: IDisposable;
+}>>();
+
+function listenToStorageServiceChange(s: IStorageService, scope: StorageScope, callback: (e: IStorageValueChangeEvent, tx: ITransaction) => void): IDisposable {
+	let listenerMap = globalStorageListeners.get(s);
+	if (!listenerMap) {
+		listenerMap = new Map();
+		globalStorageListeners.set(s, listenerMap);
+	}
+
+	let record = listenerMap.get(scope);
+	if (!record) {
+		const store = new DisposableStore();
+		record = { listeners: new Set(), dispose: store };
+		store.add(s.onDidChangeValue(scope, undefined, store)((e) => {
+			transaction(tx => {
+				for (const listener of record!.listeners) {
+					listener(e, tx);
+				}
+			}, () => `storage update to ${e.key}`);
+		}));
+
+		listenerMap.set(scope, record);
+	}
+
+	record.listeners.add(callback);
+	return toDisposable(() => {
+		if (record.listeners.delete(callback) && record.listeners.size === 0) {
+			record.dispose.dispose();
+			listenerMap.delete(scope);
+		}
+	});
+}

--- a/src/vs/workbench/contrib/debug/common/debug.ts
+++ b/src/vs/workbench/contrib/debug/common/debug.ts
@@ -759,9 +759,9 @@ export interface IDebugModel extends ITreeElement {
  * An event describing a change to the set of [breakpoints](#debug.Breakpoint).
  */
 export interface IBreakpointsChangeEvent {
-	added?: Array<IBreakpoint | IFunctionBreakpoint | IDataBreakpoint | IInstructionBreakpoint>;
-	removed?: Array<IBreakpoint | IFunctionBreakpoint | IDataBreakpoint | IInstructionBreakpoint>;
-	changed?: Array<IBreakpoint | IFunctionBreakpoint | IDataBreakpoint | IInstructionBreakpoint>;
+	added?: ReadonlyArray<IBreakpoint | IFunctionBreakpoint | IDataBreakpoint | IInstructionBreakpoint>;
+	removed?: ReadonlyArray<IBreakpoint | IFunctionBreakpoint | IDataBreakpoint | IInstructionBreakpoint>;
+	changed?: ReadonlyArray<IBreakpoint | IFunctionBreakpoint | IDataBreakpoint | IInstructionBreakpoint>;
 	sessionOnly: boolean;
 }
 

--- a/src/vs/workbench/contrib/debug/common/debugStorage.ts
+++ b/src/vs/workbench/contrib/debug/common/debugStorage.ts
@@ -4,12 +4,12 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Disposable } from 'vs/base/common/lifecycle';
-import { observableValue } from 'vs/base/common/observable';
 import { URI } from 'vs/base/common/uri';
 import { ILogService } from 'vs/platform/log/common/log';
+import { serializeMapAsObject, storedObservable } from 'vs/platform/observable/common/platformObservableUtils';
 import { IStorageService, StorageScope, StorageTarget } from 'vs/platform/storage/common/storage';
 import { IUriIdentityService } from 'vs/platform/uriIdentity/common/uriIdentity';
-import { IDebugModel, IEvaluate, IExpression } from 'vs/workbench/contrib/debug/common/debug';
+import { IEvaluate, IExpression } from 'vs/workbench/contrib/debug/common/debug';
 import { Breakpoint, DataBreakpoint, ExceptionBreakpoint, Expression, FunctionBreakpoint } from 'vs/workbench/contrib/debug/common/debugModel';
 import { ITextFileService } from 'vs/workbench/services/textfile/common/textfiles';
 
@@ -22,145 +22,155 @@ const DEBUG_CHOSEN_ENVIRONMENTS_KEY = 'debug.chosenenvironment';
 const DEBUG_UX_STATE_KEY = 'debug.uxstate';
 
 export class DebugStorage extends Disposable {
-	public readonly breakpoints = observableValue(this, this.loadBreakpoints());
-	public readonly functionBreakpoints = observableValue(this, this.loadFunctionBreakpoints());
-	public readonly exceptionBreakpoints = observableValue(this, this.loadExceptionBreakpoints());
-	public readonly dataBreakpoints = observableValue(this, this.loadDataBreakpoints());
-	public readonly watchExpressions = observableValue(this, this.loadWatchExpressions());
+	public chosenEnvironments = this._register(createChosenEnvironmentsObservable(this.storageService)).object;
+	public breakpoints = this._register(createBreakpointsObservable(this.storageService, this.textFileService, this.uriIdentityService, this.logService)).object;
+	public functionBreakpoints = this._register(createFunctionBreakpointsObservable(this.storageService)).object;
+	public exceptionBreakpoints = this._register(createExceptionBreakpointsObservable(this.storageService)).object;
+	public dataBreakpoints = this._register(createDataBreakpointsObservable(this.storageService)).object;
+	public watchExpressions = this._register(createWatchExpressionObservable(this.storageService)).object;
+	public debugUX = this._register(createDebugUXObservable(this.storageService)).object;
 
 	constructor(
 		@IStorageService private readonly storageService: IStorageService,
 		@ITextFileService private readonly textFileService: ITextFileService,
 		@IUriIdentityService private readonly uriIdentityService: IUriIdentityService,
-		@ILogService private readonly logService: ILogService
+		@ILogService private readonly logService: ILogService,
 	) {
 		super();
-
-		this._register(storageService.onDidChangeValue(StorageScope.WORKSPACE, undefined, this._store)(e => {
-			if (e.external) {
-				switch (e.key) {
-					case DEBUG_BREAKPOINTS_KEY:
-						return this.breakpoints.set(this.loadBreakpoints(), undefined);
-					case DEBUG_FUNCTION_BREAKPOINTS_KEY:
-						return this.functionBreakpoints.set(this.loadFunctionBreakpoints(), undefined);
-					case DEBUG_EXCEPTION_BREAKPOINTS_KEY:
-						return this.exceptionBreakpoints.set(this.loadExceptionBreakpoints(), undefined);
-					case DEBUG_DATA_BREAKPOINTS_KEY:
-						return this.dataBreakpoints.set(this.loadDataBreakpoints(), undefined);
-					case DEBUG_WATCH_EXPRESSIONS_KEY:
-						return this.watchExpressions.set(this.loadWatchExpressions(), undefined);
-				}
-			}
-		}));
 	}
+}
 
-	loadDebugUxState(): 'simple' | 'default' {
-		return this.storageService.get(DEBUG_UX_STATE_KEY, StorageScope.WORKSPACE, 'default') as 'simple' | 'default';
-	}
+const createWatchExpressionObservable = (s: IStorageService) => storedObservable<readonly Expression[]>(s, {
+	key: DEBUG_WATCH_EXPRESSIONS_KEY,
+	scope: StorageScope.WORKSPACE,
+	target: StorageTarget.MACHINE,
+	defaultValue: [],
+	isMutableData: true,
+	serialization: {
+		fromString: loadWatchExpressions,
+		toString: storeWatchExpressions,
+	},
+});
+const createBreakpointsObservable = (s: IStorageService, textFileService: ITextFileService, uriIdentityService: IUriIdentityService, logService: ILogService) => storedObservable<readonly Breakpoint[]>(s, {
+	key: DEBUG_BREAKPOINTS_KEY,
+	scope: StorageScope.WORKSPACE,
+	target: StorageTarget.MACHINE,
+	defaultValue: [],
+	isMutableData: true,
+	serialization: {
+		fromString: (s) => loadBreakpoints(s, textFileService, uriIdentityService, logService),
+		toString: JSON.stringify,
+	},
+});
 
-	storeDebugUxState(value: 'simple' | 'default'): void {
-		this.storageService.store(DEBUG_UX_STATE_KEY, value, StorageScope.WORKSPACE, StorageTarget.MACHINE);
-	}
+const createFunctionBreakpointsObservable = (s: IStorageService) => storedObservable<readonly FunctionBreakpoint[]>(s, {
+	key: DEBUG_FUNCTION_BREAKPOINTS_KEY,
+	scope: StorageScope.WORKSPACE,
+	target: StorageTarget.MACHINE,
+	defaultValue: [],
+	isMutableData: true,
+	serialization: {
+		fromString: loadFunctionBreakpoints,
+		toString: JSON.stringify,
+	},
+});
 
-	private loadBreakpoints(): Breakpoint[] {
-		let result: Breakpoint[] | undefined;
-		try {
-			result = JSON.parse(this.storageService.get(DEBUG_BREAKPOINTS_KEY, StorageScope.WORKSPACE, '[]')).map((breakpoint: ReturnType<Breakpoint['toJSON']>) => {
-				breakpoint.uri = URI.revive(breakpoint.uri);
-				return new Breakpoint(breakpoint, this.textFileService, this.uriIdentityService, this.logService, breakpoint.id);
-			});
-		} catch (e) { }
+const createExceptionBreakpointsObservable = (s: IStorageService) => storedObservable<readonly ExceptionBreakpoint[]>(s, {
+	key: DEBUG_EXCEPTION_BREAKPOINTS_KEY,
+	scope: StorageScope.WORKSPACE,
+	target: StorageTarget.MACHINE,
+	defaultValue: [],
+	isMutableData: true,
+	serialization: {
+		fromString: loadExceptionBreakpoints,
+		toString: JSON.stringify,
+	},
+});
 
-		return result || [];
-	}
+const createDataBreakpointsObservable = (s: IStorageService) => storedObservable<readonly DataBreakpoint[]>(s, {
+	key: DEBUG_DATA_BREAKPOINTS_KEY,
+	scope: StorageScope.WORKSPACE,
+	target: StorageTarget.MACHINE,
+	defaultValue: [],
+	isMutableData: true,
+	serialization: {
+		fromString: loadDataBreakpoints,
+		toString: JSON.stringify,
+	},
+});
 
-	private loadFunctionBreakpoints(): FunctionBreakpoint[] {
-		let result: FunctionBreakpoint[] | undefined;
-		try {
-			result = JSON.parse(this.storageService.get(DEBUG_FUNCTION_BREAKPOINTS_KEY, StorageScope.WORKSPACE, '[]')).map((fb: ReturnType<FunctionBreakpoint['toJSON']>) => {
-				return new FunctionBreakpoint(fb, fb.id);
-			});
-		} catch (e) { }
+const createChosenEnvironmentsObservable = (s: IStorageService) => storedObservable<ReadonlyMap<string, string>>(s, {
+	key: DEBUG_CHOSEN_ENVIRONMENTS_KEY,
+	scope: StorageScope.WORKSPACE,
+	target: StorageTarget.MACHINE,
+	defaultValue: new Map(),
+	serialization: serializeMapAsObject,
+});
 
-		return result || [];
-	}
+const createDebugUXObservable = (s: IStorageService) => storedObservable<'simple' | 'default'>(s, {
+	key: DEBUG_UX_STATE_KEY,
+	scope: StorageScope.WORKSPACE,
+	target: StorageTarget.MACHINE,
+	defaultValue: 'default',
+	serialization: { fromString: a => a as 'simple' | 'default', toString: a => a },
+});
 
-	private loadExceptionBreakpoints(): ExceptionBreakpoint[] {
-		let result: ExceptionBreakpoint[] | undefined;
-		try {
-			result = JSON.parse(this.storageService.get(DEBUG_EXCEPTION_BREAKPOINTS_KEY, StorageScope.WORKSPACE, '[]')).map((exBreakpoint: ReturnType<ExceptionBreakpoint['toJSON']>) => {
-				return new ExceptionBreakpoint(exBreakpoint, exBreakpoint.id);
-			});
-		} catch (e) { }
+function loadBreakpoints(input: string, textFileService: ITextFileService, uriIdentityService: IUriIdentityService, logService: ILogService): Breakpoint[] {
+	let result: Breakpoint[] | undefined;
+	try {
+		result = JSON.parse(input).map((breakpoint: ReturnType<Breakpoint['toJSON']>) => {
+			breakpoint.uri = URI.revive(breakpoint.uri);
+			return new Breakpoint(breakpoint, textFileService, uriIdentityService, logService, breakpoint.id);
+		});
+	} catch (e) { }
 
-		return result || [];
-	}
+	return result || [];
+}
 
-	private loadDataBreakpoints(): DataBreakpoint[] {
-		let result: DataBreakpoint[] | undefined;
-		try {
-			result = JSON.parse(this.storageService.get(DEBUG_DATA_BREAKPOINTS_KEY, StorageScope.WORKSPACE, '[]')).map((dbp: ReturnType<DataBreakpoint['toJSON']>) => {
-				return new DataBreakpoint(dbp, dbp.id);
-			});
-		} catch (e) { }
+function loadFunctionBreakpoints(input: string): FunctionBreakpoint[] {
+	let result: FunctionBreakpoint[] | undefined;
+	try {
+		result = JSON.parse(input).map((fb: ReturnType<FunctionBreakpoint['toJSON']>) => {
+			return new FunctionBreakpoint(fb, fb.id);
+		});
+	} catch (e) { }
 
-		return result || [];
-	}
+	return result || [];
+}
 
-	private loadWatchExpressions(): Expression[] {
-		let result: Expression[] | undefined;
-		try {
-			result = JSON.parse(this.storageService.get(DEBUG_WATCH_EXPRESSIONS_KEY, StorageScope.WORKSPACE, '[]')).map((watchStoredData: { name: string; id: string }) => {
-				return new Expression(watchStoredData.name, watchStoredData.id);
-			});
-		} catch (e) { }
+function loadExceptionBreakpoints(input: string): ExceptionBreakpoint[] {
+	let result: ExceptionBreakpoint[] | undefined;
+	try {
+		result = JSON.parse(input).map((exBreakpoint: ReturnType<ExceptionBreakpoint['toJSON']>) => {
+			return new ExceptionBreakpoint(exBreakpoint, exBreakpoint.id);
+		});
+	} catch (e) { }
 
-		return result || [];
-	}
+	return result || [];
+}
 
-	loadChosenEnvironments(): { [key: string]: string } {
-		return JSON.parse(this.storageService.get(DEBUG_CHOSEN_ENVIRONMENTS_KEY, StorageScope.WORKSPACE, '{}'));
-	}
+function loadDataBreakpoints(input: string): DataBreakpoint[] {
+	let result: DataBreakpoint[] | undefined;
+	try {
+		result = JSON.parse(input).map((dbp: ReturnType<DataBreakpoint['toJSON']>) => {
+			return new DataBreakpoint(dbp, dbp.id);
+		});
+	} catch (e) { }
 
-	storeChosenEnvironments(environments: { [key: string]: string }): void {
-		this.storageService.store(DEBUG_CHOSEN_ENVIRONMENTS_KEY, JSON.stringify(environments), StorageScope.WORKSPACE, StorageTarget.MACHINE);
-	}
+	return result || [];
+}
 
-	storeWatchExpressions(watchExpressions: (IExpression & IEvaluate)[]): void {
-		if (watchExpressions.length) {
-			this.storageService.store(DEBUG_WATCH_EXPRESSIONS_KEY, JSON.stringify(watchExpressions.map(we => ({ name: we.name, id: we.getId() }))), StorageScope.WORKSPACE, StorageTarget.MACHINE);
-		} else {
-			this.storageService.remove(DEBUG_WATCH_EXPRESSIONS_KEY, StorageScope.WORKSPACE);
-		}
-	}
+function loadWatchExpressions(input: string): Expression[] {
+	let result: Expression[] | undefined;
+	try {
+		result = JSON.parse(input).map((watchStoredData: { name: string; id: string }) => {
+			return new Expression(watchStoredData.name, watchStoredData.id);
+		});
+	} catch (e) { }
 
-	storeBreakpoints(debugModel: IDebugModel): void {
-		const breakpoints = debugModel.getBreakpoints();
-		if (breakpoints.length) {
-			this.storageService.store(DEBUG_BREAKPOINTS_KEY, JSON.stringify(breakpoints), StorageScope.WORKSPACE, StorageTarget.MACHINE);
-		} else {
-			this.storageService.remove(DEBUG_BREAKPOINTS_KEY, StorageScope.WORKSPACE);
-		}
+	return result || [];
+}
 
-		const functionBreakpoints = debugModel.getFunctionBreakpoints();
-		if (functionBreakpoints.length) {
-			this.storageService.store(DEBUG_FUNCTION_BREAKPOINTS_KEY, JSON.stringify(functionBreakpoints), StorageScope.WORKSPACE, StorageTarget.MACHINE);
-		} else {
-			this.storageService.remove(DEBUG_FUNCTION_BREAKPOINTS_KEY, StorageScope.WORKSPACE);
-		}
-
-		const dataBreakpoints = debugModel.getDataBreakpoints().filter(dbp => dbp.canPersist);
-		if (dataBreakpoints.length) {
-			this.storageService.store(DEBUG_DATA_BREAKPOINTS_KEY, JSON.stringify(dataBreakpoints), StorageScope.WORKSPACE, StorageTarget.MACHINE);
-		} else {
-			this.storageService.remove(DEBUG_DATA_BREAKPOINTS_KEY, StorageScope.WORKSPACE);
-		}
-
-		const exceptionBreakpoints = debugModel.getExceptionBreakpoints();
-		if (exceptionBreakpoints.length) {
-			this.storageService.store(DEBUG_EXCEPTION_BREAKPOINTS_KEY, JSON.stringify(exceptionBreakpoints), StorageScope.WORKSPACE, StorageTarget.MACHINE);
-		} else {
-			this.storageService.remove(DEBUG_EXCEPTION_BREAKPOINTS_KEY, StorageScope.WORKSPACE);
-		}
-	}
+function storeWatchExpressions(watchExpressions: readonly (IExpression & IEvaluate)[]): string {
+	return JSON.stringify(watchExpressions.map(we => ({ name: we.name, id: we.getId() })));
 }

--- a/src/vs/workbench/contrib/debug/test/browser/breakpoints.test.ts
+++ b/src/vs/workbench/contrib/debug/test/browser/breakpoints.test.ts
@@ -87,7 +87,7 @@ suite('Debug - Breakpoints', () => {
 		addBreakpointsAndCheckEvents(model, modelUri, [{ lineNumber: 5, enabled: true }, { lineNumber: 10, enabled: false }]);
 		addBreakpointsAndCheckEvents(model, modelUri, [{ lineNumber: 12, enabled: true, condition: 'fake condition' }]);
 		assert.strictEqual(model.getBreakpoints().length, 3);
-		const bp = model.getBreakpoints().pop();
+		const bp = model.getBreakpoints().slice().pop();
 		if (bp) {
 			model.removeBreakpoints([bp]);
 		}
@@ -457,7 +457,7 @@ suite('Debug - Breakpoints', () => {
 		];
 
 		addBreakpointsAndCheckEvents(model1, modelUri, first);
-		debugStorage1.storeBreakpoints(model1);
+		storage1.flush();
 		const stored = storage1.get('debug.breakpoint', StorageScope.WORKSPACE);
 
 		// 2. hydrate a new model and ensure external breakpoints get applied

--- a/src/vs/workbench/contrib/debug/test/browser/watch.test.ts
+++ b/src/vs/workbench/contrib/debug/test/browser/watch.test.ts
@@ -10,7 +10,7 @@ import { createMockDebugModel } from 'vs/workbench/contrib/debug/test/browser/mo
 
 // Expressions
 
-function assertWatchExpressions(watchExpressions: Expression[], expectedName: string) {
+function assertWatchExpressions(watchExpressions: readonly Expression[], expectedName: string) {
 	assert.strictEqual(watchExpressions.length, 2);
 	watchExpressions.forEach(we => {
 		assert.strictEqual(we.available, false);


### PR DESCRIPTION
This adds a new observable utility `storedObservable` and adopts it in
DebugStorage, where we use it to present a single Observable interface
for its various state. Where previously it only used observables
internally, now it's exposed and we use that as the point of truth for
the various types that debug stores instead of separate arrays which
require manual saving.

The downside of this is that because debug types are mutable, we have
an `isMutableData` flag to tell the observable to just save state
whenever it's asked to be the storage service. However, in exchange we
no longer eagerly save this state during user interactions.

I did a little ugliness in `listenToStorageServiceChange` to try to get
all state updates in a single transaction, but I'm good removing that
if we don't think it's useful.

cc @hediet

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
