### PR TITLE
Trigger chat variable completion on word start

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/contrib/chatInputCompletions.ts
+++ b/src/vs/workbench/contrib/chat/browser/contrib/chatInputCompletions.ts
@@ -351,7 +351,7 @@ function computeCompletionRanges(model: ITextModel, position: Position, reg: Reg
 		return;
 	}
 	if (varWord && onlyOnWordStart) {
-		const wordBeforePositionColumn = position.column > 0 ? position.column - 1 : 0;
+		const wordBeforePositionColumn = varWord.startColumn > 0 ? varWord.startColumn - 1 : 0;
 		const wordBefore = model.getWordUntilPosition({ lineNumber: position.lineNumber, column: wordBeforePositionColumn });
 		if (wordBefore.word) {
 			// inside a word

--- a/src/vs/workbench/contrib/chat/browser/contrib/chatInputCompletions.ts
+++ b/src/vs/workbench/contrib/chat/browser/contrib/chatInputCompletions.ts
@@ -318,7 +318,7 @@ class BuiltinDynamicCompletions extends Disposable {
 					return null;
 				}
 
-				const range = computeCompletionRanges(model, position, BuiltinDynamicCompletions.VariableNameDef);
+				const range = computeCompletionRanges(model, position, BuiltinDynamicCompletions.VariableNameDef, true);
 				if (!range) {
 					return null;
 				}
@@ -344,11 +344,19 @@ class BuiltinDynamicCompletions extends Disposable {
 
 Registry.as<IWorkbenchContributionsRegistry>(WorkbenchExtensions.Workbench).registerWorkbenchContribution(BuiltinDynamicCompletions, LifecyclePhase.Eventually);
 
-function computeCompletionRanges(model: ITextModel, position: Position, reg: RegExp): { insert: Range; replace: Range; varWord: IWordAtPosition | null } | undefined {
+function computeCompletionRanges(model: ITextModel, position: Position, reg: RegExp, onlyOnWordStart = false): { insert: Range; replace: Range; varWord: IWordAtPosition | null } | undefined {
 	const varWord = getWordAtText(position.column, reg, model.getLineContent(position.lineNumber), 0);
 	if (!varWord && model.getWordUntilPosition(position).word) {
 		// inside a "normal" word
 		return;
+	}
+	if (varWord && onlyOnWordStart) {
+		const wordBeforePositionColumn = position.column > 0 ? position.column - 1 : 0;
+		const wordBefore = model.getWordUntilPosition({ lineNumber: position.lineNumber, column: wordBeforePositionColumn });
+		if (wordBefore.word) {
+			// inside a word
+			return;
+		}
 	}
 
 	let insert: Range;
@@ -394,7 +402,7 @@ class VariableCompletions extends Disposable {
 					return null;
 				}
 
-				const range = computeCompletionRanges(model, position, VariableCompletions.VariableNameDef);
+				const range = computeCompletionRanges(model, position, VariableCompletions.VariableNameDef, true);
 				if (!range) {
 					return null;
 				}

--- a/src/vs/workbench/contrib/chat/browser/contrib/chatInputCompletions.ts
+++ b/src/vs/workbench/contrib/chat/browser/contrib/chatInputCompletions.ts
@@ -351,8 +351,7 @@ function computeCompletionRanges(model: ITextModel, position: Position, reg: Reg
 		return;
 	}
 	if (varWord && onlyOnWordStart) {
-		const wordBeforePositionColumn = varWord.startColumn > 0 ? varWord.startColumn - 1 : 0;
-		const wordBefore = model.getWordUntilPosition({ lineNumber: position.lineNumber, column: wordBeforePositionColumn });
+		const wordBefore = model.getWordUntilPosition({ lineNumber: position.lineNumber, column: varWord.startColumn });
 		if (wordBefore.word) {
 			// inside a word
 			return;


### PR DESCRIPTION
closes #216757 

Added optional boolean parameter to `computeCompletionRanges` called `onlyOnWordStart`, which dictates to return the range only if the found `varWord` is at word start. 
Set it as true on chat input variable completion (`#`)