### PR TITLE
Add the ability to use shell:true for DebugAdapterExecutable

### DIFF
--- a/src/vs/workbench/contrib/debug/common/debug.ts
+++ b/src/vs/workbench/contrib/debug/common/debug.ts
@@ -875,6 +875,7 @@ export interface IDebugAdapterFactory extends ITerminalLauncher {
 export interface IDebugAdapterExecutableOptions {
 	cwd?: string;
 	env?: { [key: string]: string };
+	shell?: string | boolean;
 }
 
 export interface IDebugAdapterExecutable {

--- a/src/vs/workbench/contrib/debug/node/debugAdapter.ts
+++ b/src/vs/workbench/contrib/debug/node/debugAdapter.ts
@@ -248,10 +248,6 @@ export class ExecutableDebugAdapter extends StreamDebugAdapter {
 				this._onError.fire(error);
 			});
 
-			this.serverProcess.stderr!.on('data', data => {
-				console.log(data);
-			});
-
 			this.serverProcess.stderr!.resume();
 
 			// finally connect to the DA

--- a/src/vs/workbench/contrib/debug/node/debugAdapter.ts
+++ b/src/vs/workbench/contrib/debug/node/debugAdapter.ts
@@ -223,11 +223,10 @@ export class ExecutableDebugAdapter extends StreamDebugAdapter {
 				}
 			} else {
 				const spawnOptions: cp.SpawnOptions = {
-					env: env
+					cwd: options.cwd,
+					env: env,
+					shell: options.shell,
 				};
-				if (options.cwd) {
-					spawnOptions.cwd = options.cwd;
-				}
 				this.serverProcess = cp.spawn(command, args, spawnOptions);
 			}
 
@@ -247,6 +246,10 @@ export class ExecutableDebugAdapter extends StreamDebugAdapter {
 
 			this.serverProcess.stdin!.on('error', error => {
 				this._onError.fire(error);
+			});
+
+			this.serverProcess.stderr!.on('data', data => {
+				console.log(data);
 			});
 
 			this.serverProcess.stderr!.resume();

--- a/src/vscode-dts/vscode.d.ts
+++ b/src/vscode-dts/vscode.d.ts
@@ -15864,6 +15864,13 @@ declare module 'vscode' {
 		 * The current working directory for the executed debug adapter.
 		 */
 		cwd?: string;
+
+		/**
+		 * If true, runs command inside of a shell. A different shell can be specified as a string.
+		 *
+		 * The path to the parent executable may need escaping and quoting when executing in a shell.
+		 */
+		shell?: string | boolean;
 	}
 
 	/**


### PR DESCRIPTION
The current insiders version of VS Code includes a new version of NodeJS that fails to spawn `.bat` files when `shell: true` is not set:

https://nodejs.org/en/blog/vulnerability/april-2024-security-releases-2

> It is important to note that there has been a breaking change for Windows users who utilize `child_process.spawn` and `child_process.spawnSync`. Node.js will now error with `EINVAL` if a `.bat` or `.cmd` file is passed to `child_process.spawn` and `child_process.spawnSync` without the `shell` option set.

The `DebugAdapterExecutable` class does not currently allow extensions to set `shell: true` when describing how their debug adapter should be launched. This PR adds support for passing `shell? string | boolean` through.

Without this fix, the Flutter debug adapter does not launch (it gets an `EINVAL` error). With this fix, it launches successfully.

Fixes https://github.com/microsoft/vscode/issues/224184

I don't know if there's a way to add automated tests for this, so if that is required please provide pointers. Thanks!
