### PR TITLE
testing: improvements to test results tree

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadTesting.ts
+++ b/src/vs/workbench/api/browser/mainThreadTesting.ts
@@ -50,8 +50,8 @@ export class MainThreadTesting extends Disposable implements MainThreadTestingSh
 			getTestsRelatedToCode: (uri, position, token) => this.proxy.$getTestsRelatedToCode(uri, position, token),
 		}));
 
-		this._register(this.testService.onDidCancelTestRun(({ runId }) => {
-			this.proxy.$cancelExtensionTestRun(runId);
+		this._register(this.testService.onDidCancelTestRun(({ runId, taskId }) => {
+			this.proxy.$cancelExtensionTestRun(runId, taskId);
 		}));
 
 		this._register(Event.debounce(testProfiles.onDidChange, (_last, e) => e)(() => {

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -2731,7 +2731,7 @@ export const enum ExtHostTestingResource {
 export interface ExtHostTestingShape {
 	$runControllerTests(req: IStartControllerTests[], token: CancellationToken): Promise<{ error?: string }[]>;
 	$startContinuousRun(req: ICallProfileRunHandler[], token: CancellationToken): Promise<{ error?: string }[]>;
-	$cancelExtensionTestRun(runId: string | undefined): void;
+	$cancelExtensionTestRun(runId: string | undefined, taskId: string | undefined): void;
 	/** Handles a diff of tests, as a result of a subscribeToDiffs() call */
 	$acceptDiff(diff: TestsDiffOp.Serialized[]): void;
 	/** Expands a test item's children, by the given number of levels. */

--- a/src/vs/workbench/api/common/extHostTesting.ts
+++ b/src/vs/workbench/api/common/extHostTesting.ts
@@ -506,11 +506,11 @@ export class ExtHostTesting extends Disposable implements ExtHostTestingShape {
 	/**
 	 * Cancels an ongoing test run.
 	 */
-	public $cancelExtensionTestRun(runId: string | undefined) {
+	public $cancelExtensionTestRun(runId: string | undefined, taskId: string | undefined) {
 		if (runId === undefined) {
 			this.runTracker.cancelAllRuns();
 		} else {
-			this.runTracker.cancelRunById(runId);
+			this.runTracker.cancelRunById(runId, taskId);
 		}
 	}
 
@@ -599,7 +599,7 @@ const enum TestRunTrackerState {
 class TestRunTracker extends Disposable {
 	private state = TestRunTrackerState.Running;
 	private running = 0;
-	private readonly tasks = new Map</* task ID */string, { run: vscode.TestRun }>();
+	private readonly tasks = new Map</* task ID */string, { cts: CancellationTokenSource; run: vscode.TestRun }>();
 	private readonly sharedTestIds = new Set<string>();
 	private readonly cts: CancellationTokenSource;
 	private readonly endEmitter = this._register(new Emitter<void>());
@@ -659,8 +659,10 @@ class TestRunTracker extends Disposable {
 	}
 
 	/** Requests cancellation of the run. On the second call, forces cancellation. */
-	public cancel() {
-		if (this.state === TestRunTrackerState.Running) {
+	public cancel(taskId?: string) {
+		if (taskId) {
+			this.tasks.get(taskId)?.cts.cancel();
+		} else if (this.state === TestRunTrackerState.Running) {
 			this.cts.cancel();
 			this.state = TestRunTrackerState.Cancelling;
 		} else if (this.state === TestRunTrackerState.Cancelling) {
@@ -731,13 +733,15 @@ class TestRunTracker extends Disposable {
 		};
 
 		let ended = false;
+		// tasks are alive for as long as the tracker is alive, so simple this._register is fine:
+		const cts = this._register(new CancellationTokenSource(this.cts.token));
 
 		// one-off map used to associate test items with incrementing IDs in `addCoverage`.
 		// There's no need to include their entire ID, we just want to make sure they're
 		// stable and unique. Normal map is okay since TestRun lifetimes are limited.
 		const run: vscode.TestRun = {
 			isPersisted: this.dto.isPersisted,
-			token: this.cts.token,
+			token: cts.token,
 			name,
 			onDidDispose: this.onDidDispose,
 			addCoverage: (coverage) => {
@@ -815,8 +819,13 @@ class TestRunTracker extends Disposable {
 		};
 
 		this.running++;
-		this.tasks.set(taskId, { run });
-		this.proxy.$startedTestRunTask(runId, { id: taskId, ctrlId: this.dto.controllerId, name, running: true });
+		this.tasks.set(taskId, { run, cts });
+		this.proxy.$startedTestRunTask(runId, {
+			id: taskId,
+			ctrlId: this.dto.controllerId,
+			name: name || this.extension.displayName || this.extension.identifier.value,
+			running: true,
+		});
 
 		return run;
 	}
@@ -921,8 +930,8 @@ export class TestRunCoordinator {
 	/**
 	 * Cancels an existing test run via its cancellation token.
 	 */
-	public cancelRunById(runId: string) {
-		this.trackedById.get(runId)?.cancel();
+	public cancelRunById(runId: string, taskId?: string) {
+		this.trackedById.get(runId)?.cancel(taskId);
 	}
 
 	/**

--- a/src/vs/workbench/contrib/testing/browser/testExplorerActions.ts
+++ b/src/vs/workbench/contrib/testing/browser/testExplorerActions.ts
@@ -707,7 +707,7 @@ export class CancelTestRunAction extends Action2 {
 				weight: KeybindingWeight.WorkbenchContrib,
 				primary: KeyChord(KeyMod.CtrlCmd | KeyCode.Semicolon, KeyMod.CtrlCmd | KeyCode.KeyX),
 			},
-			menu: {
+			menu: [{
 				id: MenuId.ViewTitle,
 				order: ActionOrder.Run,
 				group: 'navigation',
@@ -715,19 +715,23 @@ export class CancelTestRunAction extends Action2 {
 					ContextKeyExpr.equals('view', Testing.ExplorerViewId),
 					ContextKeyExpr.equals(TestingContextKeys.isRunning.serialize(), true),
 				)
-			}
+			}]
 		});
 	}
 
 	/**
 	 * @override
 	 */
-	public async run(accessor: ServicesAccessor) {
+	public async run(accessor: ServicesAccessor, resultId?: string, taskId?: string) {
 		const resultService = accessor.get(ITestResultService);
 		const testService = accessor.get(ITestService);
-		for (const run of resultService.results) {
-			if (!run.completedAt) {
-				testService.cancelTestRun(run.id);
+		if (resultId) {
+			testService.cancelTestRun(resultId, taskId);
+		} else {
+			for (const run of resultService.results) {
+				if (!run.completedAt) {
+					testService.cancelTestRun(run.id);
+				}
 			}
 		}
 	}

--- a/src/vs/workbench/contrib/testing/browser/testResultsView/testResultsTree.ts
+++ b/src/vs/workbench/contrib/testing/browser/testResultsView/testResultsTree.ts
@@ -32,12 +32,13 @@ import { IContextMenuService } from 'vs/platform/contextview/browser/contextView
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { WorkbenchCompressibleObjectTree } from 'vs/platform/list/browser/listService';
 import { IProgressService } from 'vs/platform/progress/common/progress';
+import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
 import { widgetClose } from 'vs/platform/theme/common/iconRegistry';
 import { getTestItemContextOverlay } from 'vs/workbench/contrib/testing/browser/explorerProjections/testItemContextOverlay';
 import * as icons from 'vs/workbench/contrib/testing/browser/icons';
 import { renderTestMessageAsText } from 'vs/workbench/contrib/testing/browser/testMessageColorizer';
-import { TestOutputSubject, InspectSubject, TaskSubject, MessageSubject, mapFindTestMessage, getMessageArgs } from 'vs/workbench/contrib/testing/browser/testResultsView/testResultsSubject';
-import { Testing } from 'vs/workbench/contrib/testing/common/constants';
+import { InspectSubject, MessageSubject, TaskSubject, TestOutputSubject, getMessageArgs, mapFindTestMessage } from 'vs/workbench/contrib/testing/browser/testResultsView/testResultsSubject';
+import { TestCommandId, Testing } from 'vs/workbench/contrib/testing/common/constants';
 import { ITestCoverageService } from 'vs/workbench/contrib/testing/common/testCoverageService';
 import { ITestExplorerFilterState } from 'vs/workbench/contrib/testing/common/testExplorerFilterState';
 import { ITestProfileService } from 'vs/workbench/contrib/testing/common/testProfileService';
@@ -121,7 +122,19 @@ class CoverageElement implements ITreeElement {
 	) {
 		this.onDidChange = Event.fromObservableLight(coverageService.selected);
 	}
+}
 
+class OlderResultsElement implements ITreeElement {
+	public readonly type = 'older';
+	public readonly context: undefined;
+	public readonly id = `older-${this.n}`;
+	public readonly onDidChange = Event.None;
+	public readonly label: string;
+
+	constructor(private readonly n: number) {
+		this.label = localize('nOlderResults', '{0} older results', n);
+
+	}
 }
 
 class TestCaseElement implements ITreeElement {
@@ -173,7 +186,7 @@ class TaskElement implements ITreeElement {
 	public readonly changeEmitter = new Emitter<void>();
 	public readonly onDidChange = this.changeEmitter.event;
 	public readonly type = 'task';
-	public readonly context: string;
+	public readonly context: { resultId: string; taskId: string };
 	public readonly id: string;
 	public readonly label: string;
 	public readonly itemsCache = new CreationCache<TestCaseElement>();
@@ -185,8 +198,8 @@ class TaskElement implements ITreeElement {
 	constructor(public readonly results: ITestResult, public readonly task: ITestRunTaskResults, public readonly index: number) {
 		this.id = `${results.id}/${index}`;
 		this.task = results.tasks[index];
-		this.context = String(index);
-		this.label = this.task.name ?? localize('testUnnamedTask', 'Unnamed Task');
+		this.context = { resultId: results.id, taskId: this.task.id };
+		this.label = this.task.name;
 	}
 }
 
@@ -248,7 +261,7 @@ class TestMessageElement implements ITreeElement {
 	}
 }
 
-type TreeElement = TestResultElement | TestCaseElement | TestMessageElement | TaskElement | CoverageElement;
+type TreeElement = TestResultElement | TestCaseElement | TestMessageElement | TaskElement | CoverageElement | OlderResultsElement;
 
 export class OutputPeekTree extends Disposable {
 	private disposed = false;
@@ -268,6 +281,7 @@ export class OutputPeekTree extends Disposable {
 		@ITestExplorerFilterState explorerFilter: ITestExplorerFilterState,
 		@ITestCoverageService coverageService: ITestCoverageService,
 		@IProgressService progressService: IProgressService,
+		@ITelemetryService telemetryService: ITelemetryService,
 	) {
 		super();
 
@@ -312,6 +326,7 @@ export class OutputPeekTree extends Disposable {
 		)) as WorkbenchCompressibleObjectTree<TreeElement, FuzzyScore>;
 
 		const cc = new CreationCache<TreeElement>();
+
 		const getTaskChildren = (taskElem: TaskElement): Iterable<ICompressedTreeElement<TreeElement>> => {
 			const { results, index, itemsCache, task } = taskElem;
 			const tests = Iterable.filter(results.tests, test => test.tasks[index].state >= TestResultState.Running || test.tasks[index].messages.length > 0);
@@ -345,7 +360,7 @@ export class OutputPeekTree extends Disposable {
 				.filter(isDefined);
 		};
 
-		const getResultChildren = (result: ITestResult): Iterable<ICompressedTreeElement<TreeElement>> => {
+		const getResultChildren = (result: ITestResult): ICompressedTreeElement<TreeElement>[] => {
 			return result.tasks.map((task, taskIndex) => {
 				const taskElem = cc.getOrCreate(task, () => new TaskElement(result, task, taskIndex));
 				return ({
@@ -357,16 +372,42 @@ export class OutputPeekTree extends Disposable {
 			});
 		};
 
-		const getRootChildren = () => results.results.map(result => {
-			const element = cc.getOrCreate(result, () => new TestResultElement(result));
-			return {
-				element,
-				incompressible: true,
-				collapsible: true,
-				collapsed: this.tree.hasElement(element) ? this.tree.isCollapsed(element) : true,
-				children: getResultChildren(result)
-			};
-		});
+		const getRootChildren = (): Iterable<ICompressedTreeElement<TreeElement>> => {
+			let children: ICompressedTreeElement<TreeElement>[] = [];
+
+			const older = [];
+
+			for (const result of results.results) {
+				if (!children.length && result.tasks.length) {
+					children = getResultChildren(result);
+				} else if (children) {
+					const element = cc.getOrCreate(result, () => new TestResultElement(result));
+					older.push({
+						element,
+						incompressible: true,
+						collapsible: true,
+						collapsed: this.tree.hasElement(element) ? this.tree.isCollapsed(element) : true,
+						children: getResultChildren(result)
+					});
+				}
+			}
+
+			if (!children.length) {
+				return older;
+			}
+
+			if (older.length) {
+				children.push({
+					element: new OlderResultsElement(older.length),
+					incompressible: true,
+					collapsible: true,
+					collapsed: true,
+					children: older,
+				});
+			}
+
+			return children;
+		};
 
 		// Queued result updates to prevent spamming CPU when lots of tests are
 		// completing and messaging quickly (#142514)
@@ -388,15 +429,12 @@ export class OutputPeekTree extends Disposable {
 		};
 
 		const attachToResults = (result: LiveTestResult) => {
-			const resultNode = cc.get(result)! as TestResultElement;
 			const disposable = new DisposableStore();
 			disposable.add(result.onNewTask(i => {
+				this.tree.setChildren(null, getRootChildren(), { diffIdentityProvider });
+
 				if (result.tasks.length === 1) {
 					this.requestReveal.fire(new TaskSubject(result, 0)); // reveal the first task in new runs
-				}
-
-				if (this.tree.hasElement(resultNode)) {
-					this.tree.setChildren(resultNode, getResultChildren(result), { diffIdentityProvider });
 				}
 
 				// note: tasks are bounded and their lifetime is equivalent to that of
@@ -407,6 +445,7 @@ export class OutputPeekTree extends Disposable {
 					queueTaskChildrenUpdate(cc.get(task) as TaskElement);
 				}));
 			}));
+
 			disposable.add(result.onEndTask(index => {
 				(cc.get(result.tasks[index]) as TaskElement | undefined)?.changeEmitter.fire();
 			}));
@@ -432,11 +471,9 @@ export class OutputPeekTree extends Disposable {
 			}));
 
 			disposable.add(result.onComplete(() => {
-				resultNode.changeEmitter.fire();
+				(cc.get(result) as TestResultElement | undefined)?.changeEmitter.fire();
 				disposable.dispose();
 			}));
-
-			return resultNode;
 		};
 
 		this._register(results.onResultsChanged(e => {
@@ -449,18 +486,10 @@ export class OutputPeekTree extends Disposable {
 
 			if ('completed' in e) {
 				(cc.get(e.completed) as TestResultElement | undefined)?.changeEmitter.fire();
-				return;
-			}
-
-			this.tree.setChildren(null, getRootChildren(), { diffIdentityProvider });
-
-			// done after setChildren intentionally so that the ResultElement exists in the cache.
-			if ('started' in e) {
-				for (const child of this.tree.getNode(null).children) {
-					this.tree.collapse(child.element, false);
-				}
-
-				this.tree.expand(attachToResults(e.started), true);
+			} else if ('started' in e) {
+				attachToResults(e.started);
+			} else {
+				this.tree.setChildren(null, getRootChildren(), { diffIdentityProvider });
 			}
 		}));
 
@@ -544,6 +573,16 @@ export class OutputPeekTree extends Disposable {
 
 
 		this._register(this.tree.onContextMenu(e => this.onContextMenu(e)));
+
+		this._register(this.tree.onDidChangeCollapseState(e => {
+			if (e.node.element instanceof OlderResultsElement && !e.node.collapsed) {
+				telemetryService.publicLog2<{}, {
+					owner: 'connor4312';
+					// we're considering removing or depromoting this feature because we don't think it's used:
+					comment: 'Records that test history was used';
+				}>('testing.expandOlderResults');
+			}
+		}));
 
 		this.tree.setChildren(null, getRootChildren());
 		for (const result of results.results) {
@@ -708,6 +747,15 @@ class TreeActionsProvider {
 				undefined,
 				() => this.requestReveal.fire(new TaskSubject(element.results, element.index)),
 			));
+			if (element.task.running) {
+				primary.push(new Action(
+					'testing.outputPeek.cancel',
+					localize('testing.cancelRun', 'Cancel Test Run'),
+					ThemeIcon.asClassName(icons.testingCancelIcon),
+					undefined,
+					() => this.commandService.executeCommand(TestCommandId.CancelTestRunAction, element.results.id, element.task.id),
+				));
+			}
 		}
 
 		if (element instanceof TestResultElement) {

--- a/src/vs/workbench/contrib/testing/common/testResult.ts
+++ b/src/vs/workbench/contrib/testing/common/testResult.ts
@@ -675,7 +675,7 @@ export class HydratedTestResult implements ITestResult {
 		this.completedAt = serialized.completedAt;
 		this.tasks = serialized.tasks.map((task, i) => ({
 			id: task.id,
-			name: task.name,
+			name: task.name || localize('testUnnamedTask', 'Unnamed Task'),
 			ctrlId: task.ctrlId,
 			running: false,
 			coverage: observableValue(this, undefined),

--- a/src/vs/workbench/contrib/testing/common/testService.ts
+++ b/src/vs/workbench/contrib/testing/common/testService.ts
@@ -311,7 +311,7 @@ export interface ITestService {
 	 * Fires when the user requests to cancel a test run -- or all runs, if no
 	 * runId is given.
 	 */
-	readonly onDidCancelTestRun: Event<{ runId: string | undefined }>;
+	readonly onDidCancelTestRun: Event<{ runId: string | undefined; taskId: string | undefined }>;
 
 	/**
 	 * Event that fires when the excluded tests change.
@@ -392,7 +392,7 @@ export interface ITestService {
 	/**
 	 * Cancels an ongoing test run by its ID, or all runs if no ID is given.
 	 */
-	cancelTestRun(runId?: string): void;
+	cancelTestRun(runId?: string, taskId?: string): void;
 
 	/**
 	 * Publishes a test diff for a controller.

--- a/src/vs/workbench/contrib/testing/common/testServiceImpl.ts
+++ b/src/vs/workbench/contrib/testing/common/testServiceImpl.ts
@@ -41,7 +41,7 @@ export class TestService extends Disposable implements ITestService {
 	private testControllers = observableValue<ReadonlyMap<string, IMainThreadTestController>>('testControllers', new Map<string, IMainThreadTestController>());
 	private testExtHosts = new Set<IMainThreadTestHostProxy>();
 
-	private readonly cancelExtensionTestRunEmitter = new Emitter<{ runId: string | undefined }>();
+	private readonly cancelExtensionTestRunEmitter = new Emitter<{ runId: string | undefined; taskId: string | undefined }>();
 	private readonly willProcessDiffEmitter = new Emitter<TestsDiff>();
 	private readonly didProcessDiffEmitter = new Emitter<TestsDiff>();
 	private readonly testRefreshCancellations = new Set<CancellationTokenSource>();
@@ -133,14 +133,14 @@ export class TestService extends Disposable implements ITestService {
 	/**
 	 * @inheritdoc
 	 */
-	public cancelTestRun(runId?: string) {
-		this.cancelExtensionTestRunEmitter.fire({ runId });
+	public cancelTestRun(runId?: string, taskId?: string) {
+		this.cancelExtensionTestRunEmitter.fire({ runId, taskId });
 
 		if (runId === undefined) {
 			for (const runCts of this.uiRunningTests.values()) {
 				runCts.cancel();
 			}
-		} else {
+		} else if (!taskId) {
 			this.uiRunningTests.get(runId)?.cancel();
 		}
 	}

--- a/src/vs/workbench/contrib/testing/common/testTypes.ts
+++ b/src/vs/workbench/contrib/testing/common/testTypes.ts
@@ -332,7 +332,7 @@ export namespace ITestTaskState {
 
 export interface ITestRunTask {
 	id: string;
-	name: string | undefined;
+	name: string;
 	running: boolean;
 	ctrlId: string;
 }

--- a/src/vs/workbench/contrib/testing/test/common/testResultService.test.ts
+++ b/src/vs/workbench/contrib/testing/test/common/testResultService.test.ts
@@ -66,7 +66,7 @@ suite('Workbench - Test Results Service', () => {
 		));
 
 		ds.add(r.onChange(e => changed.add(e)));
-		r.addTask({ id: 't', name: undefined, running: true, ctrlId: 'ctrl' });
+		r.addTask({ id: 't', name: 'n', running: true, ctrlId: 'ctrl' });
 
 		tests = ds.add(testStubs.nested());
 		const cts = ds.add(new CancellationTokenSource());

--- a/src/vs/workbench/contrib/testing/test/common/testResultStorage.test.ts
+++ b/src/vs/workbench/contrib/testing/test/common/testResultStorage.test.ts
@@ -28,7 +28,7 @@ suite('Workbench - Test Result Storage', () => {
 			NullTelemetryService,
 		));
 
-		t.addTask({ id: taskName, name: undefined, running: true, ctrlId: 'ctrlId' });
+		t.addTask({ id: taskName, name: 'n', running: true, ctrlId: 'ctrlId' });
 		const tests = ds.add(testStubs.nested());
 		tests.expand(tests.root.id, Infinity);
 		t.addTestChainToRun('ctrlId', [


### PR DESCRIPTION
- Only show an entry when the first task is created (Fixes #223550)
- Hide past results in an "X more" entry and see if people use it
- Add some more lifecycle controls on the task items

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
