### PR TITLE
fix: `yarn run gulp vscode-darwin-arm64` fails when run in the debug terminal

### DIFF
--- a/build/lib/extensions.js
+++ b/build/lib/extensions.js
@@ -482,9 +482,6 @@ async function esbuildExtensions(taskName, isWatch, scripts) {
                     return reject(error);
                 }
                 reporter(stderr, script);
-                if (stderr) {
-                    return reject();
-                }
                 return resolve();
             });
             proc.stdout.on('data', (data) => {

--- a/build/lib/extensions.ts
+++ b/build/lib/extensions.ts
@@ -563,9 +563,6 @@ async function esbuildExtensions(taskName: string, isWatch: boolean, scripts: { 
 					return reject(error);
 				}
 				reporter(stderr, script);
-				if (stderr) {
-					return reject();
-				}
 				return resolve();
 			});
 


### PR DESCRIPTION
>I think that block can just be removed safely since execFile with provide an error if the subprocess has a !=0 exit code

Fixes #221581

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
