### PR TITLE
CommentController.activeCommentThread seems to be the raw object instead of a proxy

### DIFF
--- a/src/vs/workbench/api/common/extHostComments.ts
+++ b/src/vs/workbench/api/common/extHostComments.ts
@@ -641,11 +641,11 @@ export function createExtHostComments(mainContext: IMainContext, commands: ExtHo
 			return this._activeComment;
 		}
 
-		private _activeThread: vscode.CommentThread2 | undefined;
+		private _activeThread: ExtHostCommentThread | undefined;
 
 		get activeCommentThread(): vscode.CommentThread2 | undefined {
 			checkProposedApiEnabled(this._extension, 'activeComment');
-			return this._activeThread;
+			return this._activeThread?.value;
 		}
 
 		private _localDisposables: types.Disposable[];


### PR DESCRIPTION
Fixes #223025