### PR TITLE
Revert StableEditorScroll changes

### DIFF
--- a/src/vs/editor/browser/stableEditorScroll.ts
+++ b/src/vs/editor/browser/stableEditorScroll.ts
@@ -20,16 +20,6 @@ export class StableEditorScrollState {
 		const visibleRanges = editor.getVisibleRanges();
 		if (visibleRanges.length > 0) {
 			visiblePosition = visibleRanges[0].getStartPosition();
-
-			const cursorPos = editor.getPosition();
-			if (cursorPos) {
-				const isVisible = visibleRanges.some(range => range.containsPosition(cursorPos));
-				if (isVisible) {
-					// Keep cursor pos fixed if it is visible
-					visiblePosition = cursorPos;
-				}
-			}
-
 			const visiblePositionScrollTop = editor.getTopForPosition(visiblePosition.lineNumber, visiblePosition.column);
 			visiblePositionScrollDelta = editor.getScrollTop() - visiblePositionScrollTop;
 		}


### PR DESCRIPTION
Reverts microsoft/vscode#221031 which changed the behavior of the StableEditorScroll and caused unexpected behaviors in the diff editor and in the comments view.
Reopens #216824
Fixes #224275
Fixes #224263

fyi @hediet 