### PR TITLE
Spawn .bat/.cmd DebugAdapterExecutables with shell=true

### DIFF
--- a/src/vs/workbench/contrib/debug/node/debugAdapter.ts
+++ b/src/vs/workbench/contrib/debug/node/debugAdapter.ts
@@ -223,6 +223,7 @@ export class ExecutableDebugAdapter extends StreamDebugAdapter {
 				}
 			} else {
 				let spawnCommand = command;
+				let spawnArgs = args;
 				const spawnOptions: cp.SpawnOptions = {
 					env: env
 				};
@@ -233,9 +234,10 @@ export class ExecutableDebugAdapter extends StreamDebugAdapter {
 					// https://github.com/microsoft/vscode/issues/224184
 					spawnOptions.shell = true;
 					spawnCommand = `"${command}"`;
+					spawnArgs = args.map(a => `"${a}"`);
 				}
 
-				this.serverProcess = cp.spawn(spawnCommand, args, spawnOptions);
+				this.serverProcess = cp.spawn(spawnCommand, spawnArgs, spawnOptions);
 			}
 
 			this.serverProcess.on('error', err => {

--- a/src/vs/workbench/contrib/debug/node/debugAdapter.ts
+++ b/src/vs/workbench/contrib/debug/node/debugAdapter.ts
@@ -230,7 +230,7 @@ export class ExecutableDebugAdapter extends StreamDebugAdapter {
 				if (options.cwd) {
 					spawnOptions.cwd = options.cwd;
 				}
-				if (platform.isWindows && command.endsWith('.bat')) {
+				if (platform.isWindows && (command.endsWith('.bat') || command.endsWith('.cmd'))) {
 					// https://github.com/microsoft/vscode/issues/224184
 					spawnOptions.shell = true;
 					spawnCommand = `"${command}"`;

--- a/src/vs/workbench/contrib/debug/node/debugAdapter.ts
+++ b/src/vs/workbench/contrib/debug/node/debugAdapter.ts
@@ -235,7 +235,6 @@ export class ExecutableDebugAdapter extends StreamDebugAdapter {
 					spawnOptions.shell = true;
 					spawnCommand = `"${command}"`;
 					spawnArgs = args.map(a => {
-						a = a.replace(/\\/g, '\\\\'); // Escape existing \
 						a = a.replace(/"/g, '\\"'); // Escape existing double quotes with \
 						// Wrap in double quotes
 						return `"${a}"`;

--- a/src/vs/workbench/contrib/debug/node/debugAdapter.ts
+++ b/src/vs/workbench/contrib/debug/node/debugAdapter.ts
@@ -222,13 +222,20 @@ export class ExecutableDebugAdapter extends StreamDebugAdapter {
 					throw new Error(nls.localize('unableToLaunchDebugAdapterNoArgs', "Unable to launch debug adapter."));
 				}
 			} else {
+				let spawnCommand = command;
 				const spawnOptions: cp.SpawnOptions = {
 					env: env
 				};
 				if (options.cwd) {
 					spawnOptions.cwd = options.cwd;
 				}
-				this.serverProcess = cp.spawn(command, args, spawnOptions);
+				if (platform.isWindows && command.endsWith('.bat')) {
+					// https://github.com/microsoft/vscode/issues/224184
+					spawnOptions.shell = true;
+					spawnCommand = `"${command}"`;
+				}
+
+				this.serverProcess = cp.spawn(spawnCommand, args, spawnOptions);
 			}
 
 			this.serverProcess.on('error', err => {

--- a/src/vs/workbench/contrib/debug/node/debugAdapter.ts
+++ b/src/vs/workbench/contrib/debug/node/debugAdapter.ts
@@ -234,7 +234,12 @@ export class ExecutableDebugAdapter extends StreamDebugAdapter {
 					// https://github.com/microsoft/vscode/issues/224184
 					spawnOptions.shell = true;
 					spawnCommand = `"${command}"`;
-					spawnArgs = args.map(a => `"${a}"`);
+					spawnArgs = args.map(a => {
+						a = a.replace(/\\/g, '\\\\'); // Escape existing \
+						a = a.replace(/"/g, '\\"'); // Escape existing double quotes with \
+						// Wrap in double quotes
+						return `"${a}"`;
+					});
 				}
 
 				this.serverProcess = cp.spawn(spawnCommand, spawnArgs, spawnOptions);


### PR DESCRIPTION
Fix #224184

- Spawn can use powershell if the user has set COMSPEC to point at powershell, but I don't think this is that common?
- ~~I'm unsure about escaping the args, because I think that in the previous node version, they would have had to be escaped already, but I'll check~~
- In any case, the DAs that pass the if check would be broken anyway in this release.