### PR TITLE
activity: require progress to be longer to count towards activity

### DIFF
--- a/src/vs/workbench/services/progress/browser/progressService.ts
+++ b/src/vs/workbench/services/progress/browser/progressService.ts
@@ -51,7 +51,7 @@ export class ProgressService extends Disposable implements IProgressService {
 		const { location } = options;
 
 		const task = async (progress: IProgress<IProgressStep>) => {
-			const activeLock = this.userActivityService.markActive();
+			const activeLock = this.userActivityService.markActive({ whenHeldFor: 15_000 });
 			try {
 				return await originalTask(progress);
 			} finally {

--- a/src/vs/workbench/services/userActivity/common/userActivityService.ts
+++ b/src/vs/workbench/services/userActivity/common/userActivityService.ts
@@ -3,12 +3,16 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { RunOnceScheduler, runWhenGlobalIdle } from 'vs/base/common/async';
+import { disposableTimeout, RunOnceScheduler, runWhenGlobalIdle } from 'vs/base/common/async';
 import { Emitter, Event } from 'vs/base/common/event';
-import { Disposable, IDisposable, toDisposable } from 'vs/base/common/lifecycle';
+import { Disposable, DisposableStore, IDisposable, toDisposable } from 'vs/base/common/lifecycle';
 import { InstantiationType, registerSingleton } from 'vs/platform/instantiation/common/extensions';
 import { IInstantiationService, createDecorator } from 'vs/platform/instantiation/common/instantiation';
 import { userActivityRegistry } from 'vs/workbench/services/userActivity/common/userActivityRegistry';
+
+export interface IMarkActiveOptions {
+	whenHeldFor?: number;
+}
 
 /**
  * Service that observes user activity in the window.
@@ -31,8 +35,10 @@ export interface IUserActivityService {
 	 * Multiple consumers call this method; the user will only be considered
 	 * inactive once all consumers have disposed of their Disposables.
 	 */
-	markActive(): IDisposable;
+	markActive(opts?: IMarkActiveOptions): IDisposable;
 }
+
+const MARK_INACTIVE_DEBOUNCE = 10_000;
 
 export const IUserActivityService = createDecorator<IUserActivityService>('IUserActivityService');
 
@@ -41,7 +47,7 @@ export class UserActivityService extends Disposable implements IUserActivityServ
 	private readonly markInactive = this._register(new RunOnceScheduler(() => {
 		this.isActive = false;
 		this.changeEmitter.fire(false);
-	}, 10_000));
+	}, MARK_INACTIVE_DEBOUNCE));
 
 	private readonly changeEmitter = this._register(new Emitter<boolean>);
 	private active = 0;
@@ -64,7 +70,13 @@ export class UserActivityService extends Disposable implements IUserActivityServ
 	}
 
 	/** @inheritdoc */
-	markActive(): IDisposable {
+	markActive(opts?: IMarkActiveOptions): IDisposable {
+		if (opts?.whenHeldFor) {
+			const store = new DisposableStore();
+			store.add(disposableTimeout(() => store.add(this.markActive()), opts.whenHeldFor));
+			return store;
+		}
+
 		if (++this.active === 1) {
 			this.isActive = true;
 			this.changeEmitter.fire(true);

--- a/src/vs/workbench/services/userActivity/test/common/userActivityService.test.ts
+++ b/src/vs/workbench/services/userActivity/test/common/userActivityService.test.ts
@@ -1,0 +1,74 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+
+import * as assert from 'assert';
+import * as sinon from 'sinon';
+import { ensureNoDisposablesAreLeakedInTestSuite } from 'vs/base/test/common/utils';
+import { TestInstantiationService } from 'vs/platform/instantiation/test/common/instantiationServiceMock';
+import { IMarkActiveOptions, IUserActivityService, UserActivityService } from 'vs/workbench/services/userActivity/common/userActivityService';
+
+const MARK_INACTIVE_DEBOUNCE = 10_000;
+
+suite('UserActivityService', () => {
+	let userActivityService: IUserActivityService;
+	let clock: sinon.SinonFakeTimers;
+
+	const ds = ensureNoDisposablesAreLeakedInTestSuite();
+
+	setup(() => {
+		clock = sinon.useFakeTimers();
+		userActivityService = ds.add(new UserActivityService(ds.add(new TestInstantiationService())));
+	});
+
+	teardown(() => {
+		clock.restore();
+	});
+
+	test('isActive should be true initially', () => {
+		assert.ok(userActivityService.isActive);
+	});
+
+	test('markActive should be inactive when all handles gone', () => {
+		const h1 = userActivityService.markActive();
+		const h2 = userActivityService.markActive();
+		assert.strictEqual(userActivityService.isActive, true);
+		h1.dispose();
+		assert.strictEqual(userActivityService.isActive, true);
+		h2.dispose();
+		clock.tick(MARK_INACTIVE_DEBOUNCE);
+		assert.strictEqual(userActivityService.isActive, false);
+	});
+
+	test('markActive sets active whenHeldFor', async () => {
+		userActivityService.markActive().dispose();
+		clock.tick(MARK_INACTIVE_DEBOUNCE);
+
+		const duration = 100; // milliseconds
+		const opts: IMarkActiveOptions = { whenHeldFor: duration };
+		const handle = userActivityService.markActive(opts);
+		assert.strictEqual(userActivityService.isActive, false);
+		clock.tick(duration - 1);
+		assert.strictEqual(userActivityService.isActive, false);
+		clock.tick(1);
+		assert.strictEqual(userActivityService.isActive, true);
+		handle.dispose();
+
+		clock.tick(MARK_INACTIVE_DEBOUNCE);
+		assert.strictEqual(userActivityService.isActive, false);
+	});
+
+	test('markActive whenHeldFor before triggers', async () => {
+		userActivityService.markActive().dispose();
+		clock.tick(MARK_INACTIVE_DEBOUNCE);
+
+		const duration = 100; // milliseconds
+		const opts: IMarkActiveOptions = { whenHeldFor: duration };
+		userActivityService.markActive(opts).dispose();
+		assert.strictEqual(userActivityService.isActive, false);
+		clock.tick(duration + MARK_INACTIVE_DEBOUNCE);
+		assert.strictEqual(userActivityService.isActive, false);
+	});
+});


### PR DESCRIPTION
Unfortunately we don't have a signal around progress for what's user initiated or not. This attempts to solve the problem in a different way by only counting long-running progress towards activity, such that the occasional background updates that Git does are unlikely to cause the state to change.

Fixes #221396

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
