### PR TITLE
rm carriage returns from terminal buffer string in smoke test

### DIFF
--- a/test/smoke/src/areas/terminal/terminal-persistence.test.ts
+++ b/test/smoke/src/areas/terminal/terminal-persistence.test.ts
@@ -75,8 +75,8 @@ export function setup(options?: { skipSuite: boolean }) {
 				await terminal.assertTerminalGroups([
 					[{ name }]
 				]);
-				// There can be line wrapping, so remove newlines #216464
-				await terminal.waitForTerminalText(buffer => buffer.some(e => e.replaceAll('\n', '').includes('terminal_test_content')));
+				// There can be line wrapping, so remove newlines and carriage returns #216464
+				await terminal.waitForTerminalText(buffer => buffer.some(e => e.replaceAll(/[\r\n]/g, '').includes('terminal_test_content')));
 			});
 		});
 	});


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
fix #216464

failure still happened on windows because of `/r` I believe