### PR TITLE
debug/variables: autofill input from an LRU

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/debugTaskRunner.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugTaskRunner.ts
@@ -3,35 +3,29 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as nls from 'vs/nls';
+import { Action } from 'vs/base/common/actions';
+import { disposableTimeout } from 'vs/base/common/async';
+import { CancellationToken, CancellationTokenSource } from 'vs/base/common/cancellation';
+import { createErrorWithActions } from 'vs/base/common/errorMessage';
+import { Emitter, Event } from 'vs/base/common/event';
+import { DisposableStore, IDisposable } from 'vs/base/common/lifecycle';
 import severity from 'vs/base/common/severity';
-import { Event } from 'vs/base/common/event';
-import { Markers } from 'vs/workbench/contrib/markers/common/markers';
-import { ITaskService, ITaskSummary } from 'vs/workbench/contrib/tasks/common/taskService';
+import * as nls from 'vs/nls';
+import { ICommandService } from 'vs/platform/commands/common/commands';
 import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
-import { IWorkspaceFolder, IWorkspace } from 'vs/platform/workspace/common/workspace';
-import { ITaskEvent, TaskEventKind, ITaskIdentifier, Task } from 'vs/workbench/contrib/tasks/common/tasks';
 import { IDialogService } from 'vs/platform/dialogs/common/dialogs';
 import { IMarkerService, MarkerSeverity } from 'vs/platform/markers/common/markers';
-import { IDebugConfiguration } from 'vs/workbench/contrib/debug/common/debug';
-import { IViewsService } from 'vs/workbench/services/views/common/viewsService';
+import { IProgressService, ProgressLocation } from 'vs/platform/progress/common/progress';
 import { IStorageService, StorageScope, StorageTarget } from 'vs/platform/storage/common/storage';
-import { createErrorWithActions } from 'vs/base/common/errorMessage';
-import { Action } from 'vs/base/common/actions';
+import { IWorkspace, IWorkspaceFolder } from 'vs/platform/workspace/common/workspace';
 import { DEBUG_CONFIGURE_COMMAND_ID, DEBUG_CONFIGURE_LABEL } from 'vs/workbench/contrib/debug/browser/debugCommands';
-import { ICommandService } from 'vs/platform/commands/common/commands';
+import { IDebugConfiguration } from 'vs/workbench/contrib/debug/common/debug';
+import { Markers } from 'vs/workbench/contrib/markers/common/markers';
+import { ConfiguringTask, CustomTask, ITaskEvent, ITaskIdentifier, Task, TaskEventKind } from 'vs/workbench/contrib/tasks/common/tasks';
+import { ITaskService, ITaskSummary } from 'vs/workbench/contrib/tasks/common/taskService';
+import { IViewsService } from 'vs/workbench/services/views/common/viewsService';
 
-function once(match: (e: ITaskEvent) => boolean, event: Event<ITaskEvent>): Event<ITaskEvent> {
-	return (listener, thisArgs = null, disposables?) => {
-		const result = event(e => {
-			if (match(e)) {
-				result.dispose();
-				return listener.call(thisArgs, e);
-			}
-		}, null, disposables);
-		return result;
-	};
-}
+const onceFilter = (event: Event<ITaskEvent>, filter: (e: ITaskEvent) => boolean) => Event.once(Event.filter(event, filter));
 
 export const enum TaskRunResult {
 	Failure,
@@ -39,10 +33,17 @@ export const enum TaskRunResult {
 }
 
 const DEBUG_TASK_ERROR_CHOICE_KEY = 'debug.taskerrorchoice';
+const ABORT_LABEL = nls.localize('abort', "Abort");
+const DEBUG_ANYWAY_LABEL = nls.localize({ key: 'debugAnyway', comment: ['&& denotes a mnemonic'] }, "&&Debug Anyway");
+const DEBUG_ANYWAY_LABEL_NO_MEMO = nls.localize('debugAnywayNoMemo', "Debug Anyway");
 
-export class DebugTaskRunner {
+interface IRunnerTaskSummary extends ITaskSummary {
+	cancelled?: boolean;
+}
 
-	private canceled = false;
+export class DebugTaskRunner implements IDisposable {
+
+	private globalCancellation = new CancellationTokenSource();
 
 	constructor(
 		@ITaskService private readonly taskService: ITaskService,
@@ -51,18 +52,26 @@ export class DebugTaskRunner {
 		@IViewsService private readonly viewsService: IViewsService,
 		@IDialogService private readonly dialogService: IDialogService,
 		@IStorageService private readonly storageService: IStorageService,
-		@ICommandService private readonly commandService: ICommandService
+		@ICommandService private readonly commandService: ICommandService,
+		@IProgressService private readonly progressService: IProgressService,
 	) { }
 
 	cancel(): void {
-		this.canceled = true;
+		this.globalCancellation.dispose(true);
+		this.globalCancellation = new CancellationTokenSource();
 	}
 
-	async runTaskAndCheckErrors(root: IWorkspaceFolder | IWorkspace | undefined, taskId: string | ITaskIdentifier | undefined): Promise<TaskRunResult> {
+	public dispose(): void {
+		this.globalCancellation.dispose(true);
+	}
+
+	async runTaskAndCheckErrors(
+		root: IWorkspaceFolder | IWorkspace | undefined,
+		taskId: string | ITaskIdentifier | undefined,
+	): Promise<TaskRunResult> {
 		try {
-			this.canceled = false;
-			const taskSummary = await this.runTask(root, taskId);
-			if (this.canceled || (taskSummary && taskSummary.exitCode === undefined)) {
+			const taskSummary = await this.runTask(root, taskId, this.globalCancellation.token);
+			if (taskSummary && (taskSummary.exitCode === undefined || taskSummary.cancelled)) {
 				// User canceled, either debugging, or the prelaunch task
 				return TaskRunResult.Failure;
 			}
@@ -101,7 +110,7 @@ export class DebugTaskRunner {
 				message,
 				buttons: [
 					{
-						label: nls.localize({ key: 'debugAnyway', comment: ['&& denotes a mnemonic'] }, "&&Debug Anyway"),
+						label: DEBUG_ANYWAY_LABEL,
 						run: () => DebugChoice.DebugAnyway
 					},
 					{
@@ -110,7 +119,7 @@ export class DebugTaskRunner {
 					}
 				],
 				cancelButton: {
-					label: nls.localize('abort', "Abort"),
+					label: ABORT_LABEL,
 					run: () => DebugChoice.Cancel
 				},
 				checkbox: {
@@ -182,7 +191,7 @@ export class DebugTaskRunner {
 		}
 	}
 
-	async runTask(root: IWorkspace | IWorkspaceFolder | undefined, taskId: string | ITaskIdentifier | undefined): Promise<ITaskSummary | null> {
+	async runTask(root: IWorkspace | IWorkspaceFolder | undefined, taskId: string | ITaskIdentifier | undefined, token: CancellationToken): Promise<IRunnerTaskSummary | null> {
 		if (!taskId) {
 			return Promise.resolve(null);
 		}
@@ -200,23 +209,42 @@ export class DebugTaskRunner {
 
 		// If a task is missing the problem matcher the promise will never complete, so we need to have a workaround #35340
 		let taskStarted = false;
+		const store = new DisposableStore();
 		const getTaskKey = (t: Task) => t.getKey() ?? t.getMapKey();
 		const taskKey = getTaskKey(task);
-		const inactivePromise: Promise<ITaskSummary | null> = new Promise((c) => once(e => {
-			// When a task isBackground it will go inactive when it is safe to launch.
-			// But when a background task is terminated by the user, it will also fire an inactive event.
-			// This means that we will not get to see the real exit code from running the task (undefined when terminated by the user).
-			// Catch the ProcessEnded event here, which occurs before inactive, and capture the exit code to prevent this.
-			return (e.kind === TaskEventKind.Inactive
-				|| (e.kind === TaskEventKind.ProcessEnded && e.exitCode === undefined))
-				&& getTaskKey(e.__task) === taskKey;
-		}, this.taskService.onDidStateChange)(e => {
-			taskStarted = true;
-			c(e.kind === TaskEventKind.ProcessEnded ? { exitCode: e.exitCode } : null);
-		}));
+		const inactivePromise: Promise<ITaskSummary | null> = new Promise((resolve) => store.add(
+			onceFilter(this.taskService.onDidStateChange, e => {
+				// When a task isBackground it will go inactive when it is safe to launch.
+				// But when a background task is terminated by the user, it will also fire an inactive event.
+				// This means that we will not get to see the real exit code from running the task (undefined when terminated by the user).
+				// Catch the ProcessEnded event here, which occurs before inactive, and capture the exit code to prevent this.
+				return (e.kind === TaskEventKind.Inactive
+					|| (e.kind === TaskEventKind.ProcessEnded && e.exitCode === undefined))
+					&& getTaskKey(e.__task) === taskKey;
+			})(e => {
+				taskStarted = true;
+				resolve(e.kind === TaskEventKind.ProcessEnded ? { exitCode: e.exitCode } : null);
+			}),
+		));
 
-		const promise: Promise<ITaskSummary | null> = this.taskService.getActiveTasks().then(async (tasks): Promise<ITaskSummary | null> => {
+		store.add(
+			onceFilter(this.taskService.onDidStateChange, e => ((e.kind === TaskEventKind.Active) || (e.kind === TaskEventKind.DependsOnStarted)) && getTaskKey(e.__task) === taskKey
+			)(() => {
+				// Task is active, so everything seems to be fine, no need to prompt after 10 seconds
+				// Use case being a slow running task should not be prompted even though it takes more than 10 seconds
+				taskStarted = true;
+			})
+		);
+
+		const didAcquireInput = store.add(new Emitter<void>());
+		store.add(onceFilter(
+			this.taskService.onDidStateChange,
+			e => (e.kind === TaskEventKind.AcquiredInput) && getTaskKey(e.__task) === taskKey
+		)(() => didAcquireInput.fire()));
+
+		const taskDonePromise: Promise<ITaskSummary | null> = this.taskService.getActiveTasks().then(async (tasks): Promise<ITaskSummary | null> => {
 			if (tasks.find(t => getTaskKey(t) === taskKey)) {
+				didAcquireInput.fire();
 				// Check that the task isn't busy and if it is, wait for it
 				const busyTasks = await this.taskService.getBusyTasks();
 				if (busyTasks.find(t => getTaskKey(t) === taskKey)) {
@@ -226,11 +254,7 @@ export class DebugTaskRunner {
 				// task is already running and isn't busy - nothing to do.
 				return Promise.resolve(null);
 			}
-			once(e => ((e.kind === TaskEventKind.Active) || (e.kind === TaskEventKind.DependsOnStarted)) && getTaskKey(e.__task) === taskKey, this.taskService.onDidStateChange)(() => {
-				// Task is active, so everything seems to be fine, no need to prompt after 10 seconds
-				// Use case being a slow running task should not be prompted even though it takes more than 10 seconds
-				taskStarted = true;
-			});
+
 			const taskPromise = this.taskService.run(task);
 			if (task.configurationProperties.isBackground) {
 				return inactivePromise;
@@ -239,28 +263,59 @@ export class DebugTaskRunner {
 			return taskPromise.then(x => x ?? null);
 		});
 
-		return new Promise((c, e) => {
-			const waitForInput = new Promise<void>(resolve => once(e => (e.kind === TaskEventKind.AcquiredInput) && getTaskKey(e.__task) === taskKey, this.taskService.onDidStateChange)(() => {
-				resolve();
+		const result = new Promise<IRunnerTaskSummary | null>((resolve, reject) => {
+			taskDonePromise.then(result => {
+				taskStarted = true;
+				resolve(result);
+			}, error => reject(error));
+
+			store.add(token.onCancellationRequested(() => {
+				resolve({ exitCode: undefined, cancelled: true });
+				this.taskService.terminate(task).catch(() => { });
 			}));
 
-			promise.then(result => {
-				taskStarted = true;
-				c(result);
-			}, error => e(error));
-
-			waitForInput.then(() => {
+			// Start the timeouts once a terminal has been acquired
+			store.add(didAcquireInput.event(() => {
 				const waitTime = task.configurationProperties.isBackground ? 5000 : 10000;
 
-				setTimeout(() => {
+				// Error shown if there's a background task with no problem matcher that doesn't exit quickly
+				store.add(disposableTimeout(() => {
 					if (!taskStarted) {
-						const errorMessage = typeof taskId === 'string'
-							? nls.localize('taskNotTrackedWithTaskId', "The task '{0}' cannot be tracked. Make sure to have a problem matcher defined.", taskId)
-							: nls.localize('taskNotTracked', "The task '{0}' cannot be tracked. Make sure to have a problem matcher defined.", JSON.stringify(taskId));
-						e({ severity: severity.Error, message: errorMessage });
+						const errorMessage = nls.localize('taskNotTracked', "The task '{0}' has not exited and doesn't have a 'problemMatcher' defined. Make sure to define a problem matcher for watch tasks.", typeof taskId === 'string' ? taskId : JSON.stringify(taskId));
+						reject({ severity: severity.Error, message: errorMessage });
 					}
-				}, waitTime);
-			});
+				}, waitTime));
+
+				// Notification shown on any task taking a while to resolve
+				store.add(disposableTimeout(() => {
+					const message = nls.localize('runningTask', "Waiting for preLaunchTask '{0}'...", task.configurationProperties.name);
+					const buttons = [DEBUG_ANYWAY_LABEL_NO_MEMO, ABORT_LABEL];
+					const canConfigure = task instanceof CustomTask || task instanceof ConfiguringTask;
+					if (canConfigure) {
+						buttons.splice(1, 0, nls.localize('configureTask', "Configure Task"));
+					}
+
+					this.progressService.withProgress(
+						{ location: ProgressLocation.Notification, title: message, buttons },
+						() => result.catch(() => { }),
+						(choice) => {
+							if (choice === undefined) {
+								// no-op, keep waiting
+							} else if (choice === 0) { // debug anyway
+								resolve({ exitCode: 0 });
+							} else { // abort or configure
+								resolve({ exitCode: undefined, cancelled: true });
+								this.taskService.terminate(task).catch(() => { });
+								if (canConfigure && choice === 1) { // configure
+									this.taskService.openConfig(task as CustomTask);
+								}
+							}
+						}
+					);
+				}, 10_000));
+			}));
 		});
+
+		return result.finally(() => store.dispose());
 	}
 }

--- a/src/vs/workbench/contrib/debug/browser/debugTaskRunner.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugTaskRunner.ts
@@ -5,7 +5,7 @@
 
 import { Action } from 'vs/base/common/actions';
 import { disposableTimeout } from 'vs/base/common/async';
-import { CancellationToken, CancellationTokenSource } from 'vs/base/common/cancellation';
+import { CancellationTokenSource } from 'vs/base/common/cancellation';
 import { createErrorWithActions } from 'vs/base/common/errorMessage';
 import { Emitter, Event } from 'vs/base/common/event';
 import { DisposableStore, IDisposable } from 'vs/base/common/lifecycle';
@@ -191,7 +191,7 @@ export class DebugTaskRunner implements IDisposable {
 		}
 	}
 
-	async runTask(root: IWorkspace | IWorkspaceFolder | undefined, taskId: string | ITaskIdentifier | undefined, token: CancellationToken): Promise<IRunnerTaskSummary | null> {
+	async runTask(root: IWorkspace | IWorkspaceFolder | undefined, taskId: string | ITaskIdentifier | undefined, token = this.globalCancellation.token): Promise<IRunnerTaskSummary | null> {
 		if (!taskId) {
 			return Promise.resolve(null);
 		}

--- a/src/vs/workbench/services/configurationResolver/browser/baseConfigurationResolverService.ts
+++ b/src/vs/workbench/services/configurationResolver/browser/baseConfigurationResolverService.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 import { Queue } from 'vs/base/common/async';
 import { IStringDictionary } from 'vs/base/common/collections';
+import { LRUCache } from 'vs/base/common/map';
 import { Schemas } from 'vs/base/common/network';
 import { IProcessEnvironment } from 'vs/base/common/platform';
 import * as Types from 'vs/base/common/types';
@@ -14,6 +15,7 @@ import { ICommandService } from 'vs/platform/commands/common/commands';
 import { ConfigurationTarget, IConfigurationOverrides, IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { ILabelService } from 'vs/platform/label/common/label';
 import { IInputOptions, IPickOptions, IQuickInputService, IQuickPickItem } from 'vs/platform/quickinput/common/quickInput';
+import { IStorageService, StorageScope, StorageTarget } from 'vs/platform/storage/common/storage';
 import { IWorkspaceContextService, IWorkspaceFolder, WorkbenchState } from 'vs/platform/workspace/common/workspace';
 import { EditorResourceAccessor, SideBySideEditor } from 'vs/workbench/common/editor';
 import { ConfiguredInput } from 'vs/workbench/services/configurationResolver/common/configurationResolver';
@@ -21,6 +23,9 @@ import { AbstractVariableResolverService } from 'vs/workbench/services/configura
 import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
 import { IExtensionService } from 'vs/workbench/services/extensions/common/extensions';
 import { IPathService } from 'vs/workbench/services/path/common/pathService';
+
+const LAST_INPUT_STORAGE_KEY = 'configResolveInputLru';
+const LAST_INPUT_CACHE_SIZE = 5;
 
 export abstract class BaseConfigurationResolverService extends AbstractVariableResolverService {
 
@@ -42,6 +47,7 @@ export abstract class BaseConfigurationResolverService extends AbstractVariableR
 		private readonly labelService: ILabelService,
 		private readonly pathService: IPathService,
 		extensionService: IExtensionService,
+		private readonly storageService: IStorageService,
 	) {
 		super({
 			getFolderUri: (folderName: string): uri | undefined => {
@@ -214,7 +220,7 @@ export abstract class BaseConfigurationResolverService extends AbstractVariableR
 			switch (type) {
 
 				case 'input':
-					result = await this.showUserInput(name, inputs);
+					result = await this.showUserInput(section, name, inputs);
 					break;
 
 				case 'command': {
@@ -282,7 +288,7 @@ export abstract class BaseConfigurationResolverService extends AbstractVariableR
 	 * @param variable Name of the input variable.
 	 * @param inputInfos Information about each possible input variable.
 	 */
-	private showUserInput(variable: string, inputInfos: ConfiguredInput[]): Promise<string | undefined> {
+	private showUserInput(section: string | undefined, variable: string, inputInfos: ConfiguredInput[]): Promise<string | undefined> {
 
 		if (!inputInfos) {
 			return Promise.reject(new Error(nls.localize('inputVariable.noInputSection', "Variable '{0}' must be defined in an '{1}' section of the debug or task configuration.", variable, 'inputs')));
@@ -296,13 +302,17 @@ export abstract class BaseConfigurationResolverService extends AbstractVariableR
 				throw new Error(nls.localize('inputVariable.missingAttribute', "Input variable '{0}' is of type '{1}' and must include '{2}'.", variable, info.type, attrName));
 			};
 
+			const defaultValueMap = this.readInputLru();
+			const defaultValueKey = `${section}.${variable}`;
+			const previousPickedValue = defaultValueMap.get(defaultValueKey);
+
 			switch (info.type) {
 
 				case 'promptString': {
 					if (!Types.isString(info.description)) {
 						missingAttribute('description');
 					}
-					const inputOptions: IInputOptions = { prompt: info.description, ignoreFocusLost: true };
+					const inputOptions: IInputOptions = { prompt: info.description, ignoreFocusLost: true, value: previousPickedValue };
 					if (info.default) {
 						inputOptions.value = info.default;
 					}
@@ -310,6 +320,9 @@ export abstract class BaseConfigurationResolverService extends AbstractVariableR
 						inputOptions.password = info.password;
 					}
 					return this.userInputAccessQueue.queue(() => this.quickInputService.input(inputOptions)).then(resolvedInput => {
+						if (typeof resolvedInput === 'string') {
+							this.storeInputLru(defaultValueMap.set(defaultValueKey, resolvedInput));
+						}
 						return resolvedInput as string;
 					});
 				}
@@ -344,6 +357,8 @@ export abstract class BaseConfigurationResolverService extends AbstractVariableR
 						if (value === info.default) {
 							item.description = nls.localize('inputVariable.defaultInputValue', "(Default)");
 							picks.unshift(item);
+						} else if (!info.default && value === previousPickedValue) {
+							picks.unshift(item);
 						} else {
 							picks.push(item);
 						}
@@ -351,7 +366,9 @@ export abstract class BaseConfigurationResolverService extends AbstractVariableR
 					const pickOptions: IPickOptions<PickStringItem> = { placeHolder: info.description, matchOnDetail: true, ignoreFocusLost: true };
 					return this.userInputAccessQueue.queue(() => this.quickInputService.pick(picks, pickOptions, undefined)).then(resolvedInput => {
 						if (resolvedInput) {
-							return (resolvedInput as PickStringItem).value;
+							const value = (resolvedInput as PickStringItem).value;
+							this.storeInputLru(defaultValueMap.set(defaultValueKey, value));
+							return value;
 						}
 						return undefined;
 					});
@@ -374,5 +391,23 @@ export abstract class BaseConfigurationResolverService extends AbstractVariableR
 			}
 		}
 		return Promise.reject(new Error(nls.localize('inputVariable.undefinedVariable', "Undefined input variable '{0}' encountered. Remove or define '{0}' to continue.", variable)));
+	}
+
+	private storeInputLru(lru: LRUCache<string, string>): void {
+		this.storageService.store(LAST_INPUT_STORAGE_KEY, JSON.stringify(lru.toJSON()), StorageScope.WORKSPACE, StorageTarget.MACHINE);
+	}
+
+	private readInputLru(): LRUCache<string, string> {
+		const contents = this.storageService.get(LAST_INPUT_STORAGE_KEY, StorageScope.WORKSPACE);
+		const lru = new LRUCache<string, string>(LAST_INPUT_CACHE_SIZE);
+		try {
+			if (contents) {
+				lru.fromJSON(JSON.parse(contents));
+			}
+		} catch {
+			// ignored
+		}
+
+		return lru;
 	}
 }

--- a/src/vs/workbench/services/configurationResolver/browser/configurationResolverService.ts
+++ b/src/vs/workbench/services/configurationResolver/browser/configurationResolverService.ts
@@ -8,6 +8,7 @@ import { IConfigurationService } from 'vs/platform/configuration/common/configur
 import { InstantiationType, registerSingleton } from 'vs/platform/instantiation/common/extensions';
 import { ILabelService } from 'vs/platform/label/common/label';
 import { IQuickInputService } from 'vs/platform/quickinput/common/quickInput';
+import { IStorageService } from 'vs/platform/storage/common/storage';
 import { IWorkspaceContextService } from 'vs/platform/workspace/common/workspace';
 import { BaseConfigurationResolverService } from 'vs/workbench/services/configurationResolver/browser/baseConfigurationResolverService';
 import { IConfigurationResolverService } from 'vs/workbench/services/configurationResolver/common/configurationResolver';
@@ -26,10 +27,11 @@ export class ConfigurationResolverService extends BaseConfigurationResolverServi
 		@ILabelService labelService: ILabelService,
 		@IPathService pathService: IPathService,
 		@IExtensionService extensionService: IExtensionService,
+		@IStorageService storageService: IStorageService,
 	) {
 		super({ getAppRoot: () => undefined, getExecPath: () => undefined },
 			Promise.resolve(Object.create(null)), editorService, configurationService,
-			commandService, workspaceContextService, quickInputService, labelService, pathService, extensionService);
+			commandService, workspaceContextService, quickInputService, labelService, pathService, extensionService, storageService);
 	}
 }
 

--- a/src/vs/workbench/services/configurationResolver/electron-sandbox/configurationResolverService.ts
+++ b/src/vs/workbench/services/configurationResolver/electron-sandbox/configurationResolverService.ts
@@ -16,6 +16,7 @@ import { ILabelService } from 'vs/platform/label/common/label';
 import { IShellEnvironmentService } from 'vs/workbench/services/environment/electron-sandbox/shellEnvironmentService';
 import { IPathService } from 'vs/workbench/services/path/common/pathService';
 import { IExtensionService } from 'vs/workbench/services/extensions/common/extensions';
+import { IStorageService } from 'vs/platform/storage/common/storage';
 
 export class ConfigurationResolverService extends BaseConfigurationResolverService {
 
@@ -30,6 +31,7 @@ export class ConfigurationResolverService extends BaseConfigurationResolverServi
 		@IShellEnvironmentService shellEnvironmentService: IShellEnvironmentService,
 		@IPathService pathService: IPathService,
 		@IExtensionService extensionService: IExtensionService,
+		@IStorageService storageService: IStorageService,
 	) {
 		super({
 			getAppRoot: (): string | undefined => {
@@ -39,7 +41,7 @@ export class ConfigurationResolverService extends BaseConfigurationResolverServi
 				return environmentService.execPath;
 			},
 		}, shellEnvironmentService.getShellEnv(), editorService, configurationService, commandService,
-			workspaceContextService, quickInputService, labelService, pathService, extensionService);
+			workspaceContextService, quickInputService, labelService, pathService, extensionService, storageService);
 	}
 }
 

--- a/src/vs/workbench/services/configurationResolver/test/electron-sandbox/configurationResolverService.test.ts
+++ b/src/vs/workbench/services/configurationResolver/test/electron-sandbox/configurationResolverService.test.ts
@@ -27,7 +27,7 @@ import { IConfigurationResolverService } from 'vs/workbench/services/configurati
 import { IExtensionService } from 'vs/workbench/services/extensions/common/extensions';
 import { IPathService } from 'vs/workbench/services/path/common/pathService';
 import { TestEditorService, TestQuickInputService } from 'vs/workbench/test/browser/workbenchTestServices';
-import { TestContextService, TestExtensionService } from 'vs/workbench/test/common/workbenchTestServices';
+import { TestContextService, TestExtensionService, TestStorageService } from 'vs/workbench/test/common/workbenchTestServices';
 
 const mockLineNumber = 10;
 class TestEditorServiceWithActiveEditor extends TestEditorService {
@@ -84,7 +84,7 @@ suite('Configuration Resolver Service', () => {
 		extensionService = new TestExtensionService();
 		containingWorkspace = testWorkspace(URI.parse('file:///VSCode/workspaceLocation'));
 		workspace = containingWorkspace.folders[0];
-		configurationResolverService = new TestConfigurationResolverService(nullContext, Promise.resolve(envVariables), editorService, new MockInputsConfigurationService(), mockCommandService, new TestContextService(containingWorkspace), quickInputService, labelService, pathService, extensionService);
+		configurationResolverService = new TestConfigurationResolverService(nullContext, Promise.resolve(envVariables), editorService, new MockInputsConfigurationService(), mockCommandService, new TestContextService(containingWorkspace), quickInputService, labelService, pathService, extensionService, disposables.add(new TestStorageService()));
 	});
 
 	teardown(() => {
@@ -230,7 +230,7 @@ suite('Configuration Resolver Service', () => {
 			}
 		});
 
-		const service = new TestConfigurationResolverService(nullContext, Promise.resolve(envVariables), disposables.add(new TestEditorServiceWithActiveEditor()), configurationService, mockCommandService, new TestContextService(), quickInputService, labelService, pathService, extensionService);
+		const service = new TestConfigurationResolverService(nullContext, Promise.resolve(envVariables), disposables.add(new TestEditorServiceWithActiveEditor()), configurationService, mockCommandService, new TestContextService(), quickInputService, labelService, pathService, extensionService, disposables.add(new TestStorageService()));
 		assert.strictEqual(await service.resolveAsync(workspace, 'abc ${config:editor.fontFamily} xyz'), 'abc foo xyz');
 	});
 
@@ -241,7 +241,7 @@ suite('Configuration Resolver Service', () => {
 			}
 		});
 
-		const service = new TestConfigurationResolverService(nullContext, Promise.resolve(envVariables), disposables.add(new TestEditorServiceWithActiveEditor()), configurationService, mockCommandService, new TestContextService(), quickInputService, labelService, pathService, extensionService);
+		const service = new TestConfigurationResolverService(nullContext, Promise.resolve(envVariables), disposables.add(new TestEditorServiceWithActiveEditor()), configurationService, mockCommandService, new TestContextService(), quickInputService, labelService, pathService, extensionService, disposables.add(new TestStorageService()));
 		assert.strictEqual(await service.resolveAsync(undefined, 'abc ${config:editor.fontFamily} xyz'), 'abc foo xyz');
 	});
 
@@ -257,7 +257,7 @@ suite('Configuration Resolver Service', () => {
 			}
 		});
 
-		const service = new TestConfigurationResolverService(nullContext, Promise.resolve(envVariables), disposables.add(new TestEditorServiceWithActiveEditor()), configurationService, mockCommandService, new TestContextService(), quickInputService, labelService, pathService, extensionService);
+		const service = new TestConfigurationResolverService(nullContext, Promise.resolve(envVariables), disposables.add(new TestEditorServiceWithActiveEditor()), configurationService, mockCommandService, new TestContextService(), quickInputService, labelService, pathService, extensionService, disposables.add(new TestStorageService()));
 		assert.strictEqual(await service.resolveAsync(workspace, 'abc ${config:editor.fontFamily} ${config:terminal.integrated.fontFamily} xyz'), 'abc foo bar xyz');
 	});
 
@@ -273,7 +273,7 @@ suite('Configuration Resolver Service', () => {
 			}
 		});
 
-		const service = new TestConfigurationResolverService(nullContext, Promise.resolve(envVariables), disposables.add(new TestEditorServiceWithActiveEditor()), configurationService, mockCommandService, new TestContextService(), quickInputService, labelService, pathService, extensionService);
+		const service = new TestConfigurationResolverService(nullContext, Promise.resolve(envVariables), disposables.add(new TestEditorServiceWithActiveEditor()), configurationService, mockCommandService, new TestContextService(), quickInputService, labelService, pathService, extensionService, disposables.add(new TestStorageService()));
 		if (platform.isWindows) {
 			assert.strictEqual(await service.resolveAsync(workspace, 'abc ${config:editor.fontFamily} ${workspaceFolder} ${env:key1} xyz'), 'abc foo \\VSCode\\workspaceLocation Value for key1 xyz');
 		} else {
@@ -293,7 +293,7 @@ suite('Configuration Resolver Service', () => {
 			}
 		});
 
-		const service = new TestConfigurationResolverService(nullContext, Promise.resolve(envVariables), disposables.add(new TestEditorServiceWithActiveEditor()), configurationService, mockCommandService, new TestContextService(), quickInputService, labelService, pathService, extensionService);
+		const service = new TestConfigurationResolverService(nullContext, Promise.resolve(envVariables), disposables.add(new TestEditorServiceWithActiveEditor()), configurationService, mockCommandService, new TestContextService(), quickInputService, labelService, pathService, extensionService, disposables.add(new TestStorageService()));
 		if (platform.isWindows) {
 			assert.strictEqual(await service.resolveAsync(workspace, '${config:editor.fontFamily} ${config:terminal.integrated.fontFamily} ${workspaceFolder} - ${workspaceFolder} ${env:key1} - ${env:key2}'), 'foo bar \\VSCode\\workspaceLocation - \\VSCode\\workspaceLocation Value for key1 - Value for key2');
 		} else {
@@ -326,7 +326,7 @@ suite('Configuration Resolver Service', () => {
 			}
 		});
 
-		const service = new TestConfigurationResolverService(nullContext, Promise.resolve(envVariables), disposables.add(new TestEditorServiceWithActiveEditor()), configurationService, mockCommandService, new TestContextService(), quickInputService, labelService, pathService, extensionService);
+		const service = new TestConfigurationResolverService(nullContext, Promise.resolve(envVariables), disposables.add(new TestEditorServiceWithActiveEditor()), configurationService, mockCommandService, new TestContextService(), quickInputService, labelService, pathService, extensionService, disposables.add(new TestStorageService()));
 		assert.strictEqual(await service.resolveAsync(workspace, 'abc ${config:editor.fontFamily} ${config:editor.lineNumbers} ${config:editor.insertSpaces} xyz'), 'abc foo 123 false xyz');
 	});
 
@@ -335,7 +335,7 @@ suite('Configuration Resolver Service', () => {
 			editor: {}
 		});
 
-		const service = new TestConfigurationResolverService(nullContext, Promise.resolve(envVariables), disposables.add(new TestEditorServiceWithActiveEditor()), configurationService, mockCommandService, new TestContextService(), quickInputService, labelService, pathService, extensionService);
+		const service = new TestConfigurationResolverService(nullContext, Promise.resolve(envVariables), disposables.add(new TestEditorServiceWithActiveEditor()), configurationService, mockCommandService, new TestContextService(), quickInputService, labelService, pathService, extensionService, disposables.add(new TestStorageService()));
 		assert.strictEqual(await service.resolveAsync(workspace, 'abc ${unknownVariable} xyz'), 'abc ${unknownVariable} xyz');
 		assert.strictEqual(await service.resolveAsync(workspace, 'abc ${env:unknownVariable} xyz'), 'abc  xyz');
 	});
@@ -347,7 +347,7 @@ suite('Configuration Resolver Service', () => {
 			}
 		});
 
-		const service = new TestConfigurationResolverService(nullContext, Promise.resolve(envVariables), disposables.add(new TestEditorServiceWithActiveEditor()), configurationService, mockCommandService, new TestContextService(), quickInputService, labelService, pathService, extensionService);
+		const service = new TestConfigurationResolverService(nullContext, Promise.resolve(envVariables), disposables.add(new TestEditorServiceWithActiveEditor()), configurationService, mockCommandService, new TestContextService(), quickInputService, labelService, pathService, extensionService, disposables.add(new TestStorageService()));
 
 		assert.rejects(async () => await service.resolveAsync(workspace, 'abc ${env} xyz'));
 		assert.rejects(async () => await service.resolveAsync(workspace, 'abc ${env:} xyz'));


### PR DESCRIPTION
This keeps a small LRU in the config resolver and storage service to provide default values, when not otherwise specified, for inputs in e.g. debugging.

I added this after I was annoyed by having to keep autofilling the same ephemeral value in some debug configs earlier.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
