### PR TITLE
Enable notebook smoke test and capture memory leaks

### DIFF
--- a/build/azure-pipelines/linux/product-build-linux-test.yml
+++ b/build/azure-pipelines/linux/product-build-linux-test.yml
@@ -150,7 +150,7 @@ steps:
       - script: yarn --cwd test/smoke compile
         displayName: Compile smoke tests
 
-      - script: yarn gulp compile-extension:markdown-language-features compile-extension-media compile-extension:vscode-test-resolver
+      - script: yarn gulp compile-extension:markdown-language-features compile-extension:ipynb compile-extension-media compile-extension:vscode-test-resolver
         displayName: Build extensions for smoke tests
 
       - script: yarn gulp node

--- a/test/automation/src/application.ts
+++ b/test/automation/src/application.ts
@@ -6,6 +6,7 @@
 import { Workbench } from './workbench';
 import { Code, launch, LaunchOptions } from './code';
 import { Logger, measureAndLog } from './logger';
+import { Profiler } from './profiler';
 
 export const enum Quality {
 	Dev,
@@ -63,6 +64,10 @@ export class Application {
 		return this._userDataPath;
 	}
 
+	private _profiler: Profiler | undefined;
+
+	get profiler(): Profiler { return this._profiler!; }
+
 	async start(): Promise<void> {
 		await this._start();
 		await this.code.waitForElement('.explorer-folders-view');
@@ -110,6 +115,7 @@ export class Application {
 		});
 
 		this._workbench = new Workbench(this._code);
+		this._profiler = new Profiler(this.code);
 
 		return code;
 	}

--- a/test/automation/src/notebook.ts
+++ b/test/automation/src/notebook.ts
@@ -23,7 +23,6 @@ export class Notebook {
 
 		await this.code.waitForElement(activeRowSelector);
 		await this.focusFirstCell();
-		await this.waitForActiveCellEditorContents('code()');
 	}
 
 	async focusNextCell() {

--- a/test/automation/src/playwrightDriver.ts
+++ b/test/automation/src/playwrightDriver.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as playwright from '@playwright/test';
+import type { Protocol } from 'playwright-core/types/protocol';
 import { dirname, join } from 'path';
 import { promises } from 'fs';
 import { IWindowDriver } from './driver';
@@ -81,6 +82,48 @@ export class PlaywrightDriver {
 
 	async didFinishLoad(): Promise<void> {
 		await this.whenLoaded;
+	}
+
+	private _cdpSession: playwright.CDPSession | undefined;
+
+	async startCDP() {
+		if (this._cdpSession) {
+			return;
+		}
+
+		this._cdpSession = await this.page.context().newCDPSession(this.page);
+	}
+
+	async evaluate(options: Protocol.Runtime.evaluateParameters): Promise<Protocol.Runtime.evaluateReturnValue> {
+		if (!this._cdpSession) {
+			throw new Error('CDP not started');
+		}
+
+		return await this._cdpSession.send('Runtime.evaluate', options);
+	}
+
+	async queryObjects(parameters: Protocol.Runtime.queryObjectsParameters): Promise<Protocol.Runtime.queryObjectsReturnValue> {
+		if (!this._cdpSession) {
+			throw new Error('CDP not started');
+		}
+
+		return await this._cdpSession.send('Runtime.queryObjects', parameters);
+	}
+
+	async callFunctionOn(parameters: Protocol.Runtime.callFunctionOnParameters): Promise<Protocol.Runtime.callFunctionOnReturnValue> {
+		if (!this._cdpSession) {
+			throw new Error('CDP not started');
+		}
+
+		return await this._cdpSession.send('Runtime.callFunctionOn', parameters);
+	}
+
+	async getProperties(parameters: Protocol.Runtime.getPropertiesParameters): Promise<Protocol.Runtime.getPropertiesReturnValue> {
+		if (!this._cdpSession) {
+			throw new Error('CDP not started');
+		}
+
+		return await this._cdpSession.send('Runtime.getProperties', parameters);
 	}
 
 	private async takeScreenshot(name: string): Promise<void> {

--- a/test/automation/src/profiler.ts
+++ b/test/automation/src/profiler.ts
@@ -1,0 +1,224 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import type { Protocol } from 'playwright-core/types/protocol';
+import { Code } from './code';
+import { PlaywrightDriver } from './playwrightDriver';
+
+export class Profiler {
+	constructor(private readonly code: Code) {
+	}
+
+	async checkLeaks(className: string, fn: () => Promise<void>): Promise<void> {
+		await this.code.driver.startCDP();
+		const instancesBefore = await getInstances(this.code.driver);
+		const matchedInstances = instancesBefore.find(e => e.name !== undefined && e.name === className);
+		if (!matchedInstances) {
+			throw new Error(`${className} not found`);
+		}
+
+		const countBefore = matchedInstances.count;
+
+		await fn();
+
+		const instancesAfter = await getInstances(this.code.driver);
+		const matchedInstancesAfter = instancesAfter.find(e => e.name !== undefined && e.name === className);
+		if (!matchedInstancesAfter) {
+			throw new Error(`${className} not found`);
+		}
+
+		const countAfter = matchedInstancesAfter.count;
+		if (countAfter !== countBefore) {
+			throw new Error(`Leaked ${countAfter - countBefore} ${className}`);
+		}
+	}
+}
+
+function generateUuid() {
+	// use `randomValues` if possible
+	function getRandomValues(bucket: Uint8Array): Uint8Array {
+		for (let i = 0; i < bucket.length; i++) {
+			bucket[i] = Math.floor(Math.random() * 256);
+		}
+		return bucket;
+	}
+
+	// prep-work
+	const _data = new Uint8Array(16);
+	const _hex: string[] = [];
+	for (let i = 0; i < 256; i++) {
+		_hex.push(i.toString(16).padStart(2, '0'));
+	}
+
+	// get data
+	getRandomValues(_data);
+
+	// set version bits
+	_data[6] = (_data[6] & 0x0f) | 0x40;
+	_data[8] = (_data[8] & 0x3f) | 0x80;
+
+	// print as string
+	let i = 0;
+	let result = '';
+	result += _hex[_data[i++]];
+	result += _hex[_data[i++]];
+	result += _hex[_data[i++]];
+	result += _hex[_data[i++]];
+	result += '-';
+	result += _hex[_data[i++]];
+	result += _hex[_data[i++]];
+	result += '-';
+	result += _hex[_data[i++]];
+	result += _hex[_data[i++]];
+	result += '-';
+	result += _hex[_data[i++]];
+	result += _hex[_data[i++]];
+	result += '-';
+	result += _hex[_data[i++]];
+	result += _hex[_data[i++]];
+	result += _hex[_data[i++]];
+	result += _hex[_data[i++]];
+	result += _hex[_data[i++]];
+	result += _hex[_data[i++]];
+	return result;
+}
+
+
+
+/*---------------------------------------------------------------------------------------------
+ *  The MIT License (MIT)
+ *  Copyright (c) 2023-present, Simon Siefke
+ *
+ *  This code is derived from https://github.com/SimonSiefke/vscode-memory-leak-finder
+ *--------------------------------------------------------------------------------------------*/
+
+const getInstances = async (driver: PlaywrightDriver): Promise<Array<{ name: string; count: number }>> => {
+	const objectGroup = `og:${generateUuid()}`;
+	const prototypeDescriptor = await driver.evaluate({
+		expression: 'Object.prototype',
+		returnByValue: false,
+		objectGroup,
+	});
+	const objects = await driver.queryObjects({
+		prototypeObjectId: prototypeDescriptor.result.objectId!,
+		objectGroup,
+	});
+	const fnResult1 = await driver.callFunctionOn({
+		functionDeclaration: `function(){
+	const objects = this
+
+	const nativeConstructors = [
+		Object,
+		Array,
+		Function,
+		Set,
+		Map,
+		WeakMap,
+		WeakSet,
+		RegExp,
+		Node,
+		HTMLScriptElement,
+		DOMRectReadOnly,
+		DOMRect,
+		HTMLHtmlElement,
+		Node,
+		DOMTokenList,
+		HTMLUListElement,
+		HTMLStyleElement,
+		HTMLDivElement,
+		HTMLCollection,
+		FocusEvent,
+		Promise,
+		HTMLLinkElement,
+		HTMLLIElement,
+		HTMLAnchorElement,
+		HTMLSpanElement,
+		ArrayBuffer,
+		Uint16Array,
+		HTMLLabelElement,
+		TrustedTypePolicy,
+		Uint8Array,
+		Uint32Array,
+		HTMLHeadingElement,
+		MediaQueryList,
+		HTMLDocument,
+		TextDecoder,
+		TextEncoder,
+		HTMLInputElement,
+		HTMLCanvasElement,
+		HTMLIFrameElement,
+		Int32Array,
+		CSSStyleDeclaration
+	]
+
+	const isNativeConstructor = object => {
+		return nativeConstructors.includes(object.constructor) ||
+			object.constructor.name === 'AsyncFunction' ||
+			object.constructor.name === 'GeneratorFunction' ||
+			object.constructor.name === 'AsyncGeneratorFunction'
+	}
+
+	const isInstance = (object) => {
+		return object && !isNativeConstructor(object)
+	}
+
+	const instances = objects.filter(isInstance)
+	return instances
+}`,
+		objectId: objects.objects.objectId,
+		returnByValue: false,
+		objectGroup,
+	});
+
+	const fnResult2 = await getInstanceCountMap(driver, objectGroup, fnResult1.result);
+	const fnResult3 = await getInstanceCountArray(driver, objectGroup, fnResult2.result);
+	return fnResult3.result.value;
+};
+
+const getInstanceCountMap = async (driver: PlaywrightDriver, objectGroup: string, objects: Protocol.Runtime.RemoteObject) => {
+	const fnResult1 = await driver.callFunctionOn({
+		functionDeclaration: `function(){
+	const instances = this
+
+	const map = new Map()
+
+	for(const instance of instances){
+		if(map.has(instance.constructor)){
+			map.set(instance.constructor, map.get(instance.constructor) + 1)
+		} else {
+			map.set(instance.constructor, 1)
+		}
+	}
+	return map
+}`,
+		objectId: objects.objectId,
+		returnByValue: false,
+		objectGroup,
+	});
+
+	return fnResult1;
+};
+
+const getInstanceCountArray = async (driver: PlaywrightDriver, objectGroup: string, map: Protocol.Runtime.RemoteObject) => {
+	const fnResult1 = await driver.callFunctionOn({
+		functionDeclaration: `function(){
+	const map = this
+	const array = []
+
+	for(const [instanceConstructor, count] of map.entries()){
+		array.push({
+			name: instanceConstructor.name,
+			count,
+		})
+	}
+
+	return array
+}`,
+		objectId: map.objectId,
+		returnByValue: true,
+		objectGroup,
+	});
+	return fnResult1;
+};

--- a/test/smoke/src/areas/notebook/notebook.test.ts
+++ b/test/smoke/src/areas/notebook/notebook.test.ts
@@ -27,7 +27,7 @@ export function setup(logger: Logger) {
 
 		it('leaks check', async function () {
 			const app = this.app as Application;
-			await app.profiler.checkLeaks('NotebookTextModel', async () => {
+			await app.profiler.checkLeaks(['NotebookTextModel', 'NotebookCellTextModel'], async () => {
 				await app.workbench.notebook.openNotebook();
 				await app.workbench.quickaccess.runCommand('workbench.action.files.save');
 				await app.workbench.quickaccess.runCommand('workbench.action.closeActiveEditor');

--- a/test/smoke/src/areas/notebook/notebook.test.ts
+++ b/test/smoke/src/areas/notebook/notebook.test.ts
@@ -25,7 +25,7 @@ export function setup(logger: Logger) {
 			cp.execSync('git reset --hard HEAD --quiet', { cwd: app.workspacePathOrFolder });
 		});
 
-		it('check heap leaks', async function () {
+		it.skip('check heap leaks', async function () {
 			const app = this.app as Application;
 			await app.profiler.checkHeapLeaks(['NotebookTextModel', 'NotebookCellTextModel', 'NotebookEventDispatcher'], async () => {
 				await app.workbench.notebook.openNotebook();
@@ -36,7 +36,7 @@ export function setup(logger: Logger) {
 
 		it('check object leaks', async function () {
 			const app = this.app as Application;
-			await app.profiler.checkLeaks(['NotebookTextModel'], async () => {
+			await app.profiler.checkObjectLeaks(['NotebookTextModel', 'NotebookCellTextModel', 'NotebookEventDispatcher'], async () => {
 				await app.workbench.notebook.openNotebook();
 				await app.workbench.quickaccess.runCommand('workbench.action.files.save');
 				await app.workbench.quickaccess.runCommand('workbench.action.closeActiveEditor');

--- a/test/smoke/src/areas/notebook/notebook.test.ts
+++ b/test/smoke/src/areas/notebook/notebook.test.ts
@@ -25,7 +25,16 @@ export function setup(logger: Logger) {
 			cp.execSync('git reset --hard HEAD --quiet', { cwd: app.workspacePathOrFolder });
 		});
 
-		it('leaks check', async function () {
+		it('check heap leaks', async function () {
+			const app = this.app as Application;
+			await app.profiler.checkHeapLeaks(['NotebookTextModel', 'NotebookCellTextModel', 'NotebookEventDispatcher'], async () => {
+				await app.workbench.notebook.openNotebook();
+				await app.workbench.quickaccess.runCommand('workbench.action.files.save');
+				await app.workbench.quickaccess.runCommand('workbench.action.closeActiveEditor');
+			});
+		});
+
+		it('check object leaks', async function () {
 			const app = this.app as Application;
 			await app.profiler.checkLeaks(['NotebookTextModel'], async () => {
 				await app.workbench.notebook.openNotebook();

--- a/test/smoke/src/areas/notebook/notebook.test.ts
+++ b/test/smoke/src/areas/notebook/notebook.test.ts
@@ -27,7 +27,7 @@ export function setup(logger: Logger) {
 
 		it('leaks check', async function () {
 			const app = this.app as Application;
-			await app.profiler.checkLeaks(['NotebookTextModel', 'NotebookCellTextModel'], async () => {
+			await app.profiler.checkLeaks(['NotebookTextModel'], async () => {
 				await app.workbench.notebook.openNotebook();
 				await app.workbench.quickaccess.runCommand('workbench.action.files.save');
 				await app.workbench.quickaccess.runCommand('workbench.action.closeActiveEditor');

--- a/test/smoke/src/areas/notebook/notebook.test.ts
+++ b/test/smoke/src/areas/notebook/notebook.test.ts
@@ -8,7 +8,7 @@ import { Application, Logger } from '../../../../automation';
 import { installAllHandlers } from '../../utils';
 
 export function setup(logger: Logger) {
-	describe.skip('Notebooks', () => { // https://github.com/microsoft/vscode/issues/140575
+	describe('Notebooks', () => { // https://github.com/microsoft/vscode/issues/140575
 
 		// Shared before/after handling
 		installAllHandlers(logger);
@@ -25,7 +25,16 @@ export function setup(logger: Logger) {
 			cp.execSync('git reset --hard HEAD --quiet', { cwd: app.workspacePathOrFolder });
 		});
 
-		it('inserts/edits code cell', async function () {
+		it('leaks check', async function () {
+			const app = this.app as Application;
+			await app.profiler.checkLeaks('NotebookTextModel', async () => {
+				await app.workbench.notebook.openNotebook();
+				await app.workbench.quickaccess.runCommand('workbench.action.files.save');
+				await app.workbench.quickaccess.runCommand('workbench.action.closeActiveEditor');
+			});
+		});
+
+		it.skip('inserts/edits code cell', async function () {
 			const app = this.app as Application;
 			await app.workbench.notebook.openNotebook();
 			await app.workbench.notebook.focusNextCell();
@@ -34,7 +43,7 @@ export function setup(logger: Logger) {
 			await app.workbench.notebook.stopEditingCell();
 		});
 
-		it('inserts/edits markdown cell', async function () {
+		it.skip('inserts/edits markdown cell', async function () {
 			const app = this.app as Application;
 			await app.workbench.notebook.openNotebook();
 			await app.workbench.notebook.focusNextCell();


### PR DESCRIPTION
We have been manually measuring the memory usage of the notebook component in the dev tools to catch potential memory leaks, to avoid repeated manual work, this is an attempt to automate the process. We already use Playwright in our smoke test and it supports opening a cdp session to archive the same target as we do manually in dev tools. As we know, the smoke test is often flaky, so we'll try it in the notebook first, and if it's reliable enough, we can make this generic and use it in other components as well.

In this PR, I took two different approaches:

- I took a heap snapshot after a test run and analyzed the snapshot using @connor4312's [v8-heap-parser](https://github.com/microsoft/vscode-v8-heap-tools). It's very reliable and easy to extend, but relatively slow.
- Another approach is to list all objects as @SimonSiefke has done in [vscode-memory-leak-finder](https://github.com/SimonSiefke/vscode-memory-leak-finder) and compare the objects before and after. This is much faster, but I don't fully understand the output yet.
  - The script can list all non-native objects (inherited from `Object.prototype`). For example, at startup we get one `NotebookTextModel` and during a notebook test we will have 2 `NotebookTextModel` objects. After the notebook editor is closed, the `NotebookTextModel` object is disposed/gc'ed, we have one `NotebookTextModel` again (the class).
  - However, I'm not sure why we still have 2 `NotebookCellTextModel` instances after a successful test run, even though we don't get any zombie `NotebookCellTextModel` instances in the heap snapshot. I may be missing something obvious here, it would be great if @SimonSiefke can help.

I'm leaning towards the second approach if we can figure out a relaiable approach of detecting the leaks (like what @SimonSiefke did in all the memory leak issues).