### PR TITLE
cli: determine archive type based on filename instead of path

### DIFF
--- a/cli/src/util/zipper.rs
+++ b/cli/src/util/zipper.rs
@@ -44,15 +44,12 @@ fn should_skip_first_segment(archive: &mut ZipArchive<File>) -> bool {
 	archive.len() > 1 // prefix removal is invalid if there's only a single file
 }
 
-pub fn unzip_file<T>(path: &Path, parent_path: &Path, mut reporter: T) -> Result<(), WrappedError>
+pub fn unzip_file<T>(file: File, parent_path: &Path, mut reporter: T) -> Result<(), WrappedError>
 where
 	T: ReportCopyProgress,
 {
-	let file = fs::File::open(path)
-		.map_err(|e| wrap(e, format!("unable to open file {}", path.display())))?;
-
-	let mut archive = zip::ZipArchive::new(file)
-		.map_err(|e| wrap(e, format!("failed to open zip archive {}", path.display())))?;
+	let mut archive =
+		zip::ZipArchive::new(file).map_err(|e| wrap(e, "failed to open zip archive"))?;
 
 	let skip_segments_no = usize::from(should_skip_first_segment(&mut archive));
 	let report_progress_every = archive.len() / 20;


### PR DESCRIPTION
Refs #219632

Seems like PRSS sometimes(?) doesn't return the full archive name in the response. I don't reproduce this, but others consistently do. This PR removes the dependency on the URL path and instead checks for the gzip magic number in the first two bytes of the archive to figure out what to do.
