### PR TITLE
Add missing space in CLI help text.

### DIFF
--- a/cli/src/commands/args.rs
+++ b/cli/src/commands/args.rs
@@ -13,7 +13,7 @@ const CLI_NAME: &str = concatcp!(constants::PRODUCT_NAME_LONG, " CLI");
 const HELP_COMMANDS: &str = concatcp!(
 	"Usage: ",
 	constants::APPLICATION_NAME,
-	" [options][paths...]
+	" [options] [paths...]
 
 To read output from another program, append '-' (e.g. 'echo Hello World | {name} -')"
 );


### PR DESCRIPTION
Before:

```
$ code --help
Visual Studio Code 1.92.0

Usage: code [options][paths...]
```

After:

```
$ code --help
Visual Studio Code 1.92.0

Usage: code [options] [paths...]
```