### PR TITLE
Improve typings of Quick Pick

### DIFF
--- a/src/vs/editor/contrib/quickAccess/browser/editorNavigationQuickAccess.ts
+++ b/src/vs/editor/contrib/quickAccess/browser/editorNavigationQuickAccess.ts
@@ -52,7 +52,7 @@ export abstract class AbstractEditorNavigationQuickAccessProvider implements IQu
 
 	//#region Provider methods
 
-	provide(picker: IQuickPick<IQuickPickItem>, token: CancellationToken, runOptions?: IQuickAccessProviderRunOptions): IDisposable {
+	provide(picker: IQuickPick<IQuickPickItem, { useSeparators: true }>, token: CancellationToken, runOptions?: IQuickAccessProviderRunOptions): IDisposable {
 		const disposables = new DisposableStore();
 
 		// Apply options if any
@@ -78,7 +78,7 @@ export abstract class AbstractEditorNavigationQuickAccessProvider implements IQu
 		return disposables;
 	}
 
-	private doProvide(picker: IQuickPick<IQuickPickItem>, token: CancellationToken, runOptions?: IQuickAccessProviderRunOptions): IDisposable {
+	private doProvide(picker: IQuickPick<IQuickPickItem, { useSeparators: true }>, token: CancellationToken, runOptions?: IQuickAccessProviderRunOptions): IDisposable {
 		const disposables = new DisposableStore();
 
 		// With text control
@@ -134,12 +134,12 @@ export abstract class AbstractEditorNavigationQuickAccessProvider implements IQu
 	/**
 	 * Subclasses to implement to provide picks for the picker when an editor is active.
 	 */
-	protected abstract provideWithTextEditor(context: IQuickAccessTextEditorContext, picker: IQuickPick<IQuickPickItem>, token: CancellationToken, runOptions?: IQuickAccessProviderRunOptions): IDisposable;
+	protected abstract provideWithTextEditor(context: IQuickAccessTextEditorContext, picker: IQuickPick<IQuickPickItem, { useSeparators: true }>, token: CancellationToken, runOptions?: IQuickAccessProviderRunOptions): IDisposable;
 
 	/**
 	 * Subclasses to implement to provide picks for the picker when no editor is active.
 	 */
-	protected abstract provideWithoutTextEditor(picker: IQuickPick<IQuickPickItem>, token: CancellationToken): IDisposable;
+	protected abstract provideWithoutTextEditor(picker: IQuickPick<IQuickPickItem, { useSeparators: true }>, token: CancellationToken): IDisposable;
 
 	protected gotoLocation({ editor }: IQuickAccessTextEditorContext, options: { range: IRange; keyMods: IKeyMods; forceSideBySide?: boolean; preserveFocus?: boolean }): void {
 		editor.setSelection(options.range, TextEditorSelectionSource.JUMP);

--- a/src/vs/editor/contrib/quickAccess/browser/gotoLineQuickAccess.ts
+++ b/src/vs/editor/contrib/quickAccess/browser/gotoLineQuickAccess.ts
@@ -24,7 +24,7 @@ export abstract class AbstractGotoLineQuickAccessProvider extends AbstractEditor
 		super({ canAcceptInBackground: true });
 	}
 
-	protected provideWithoutTextEditor(picker: IQuickPick<IGotoLineQuickPickItem>): IDisposable {
+	protected provideWithoutTextEditor(picker: IQuickPick<IGotoLineQuickPickItem, { useSeparators: true }>): IDisposable {
 		const label = localize('cannotRunGotoLine', "Open a text editor first to go to a line.");
 
 		picker.items = [{ label }];
@@ -33,7 +33,7 @@ export abstract class AbstractGotoLineQuickAccessProvider extends AbstractEditor
 		return Disposable.None;
 	}
 
-	protected provideWithTextEditor(context: IQuickAccessTextEditorContext, picker: IQuickPick<IGotoLineQuickPickItem>, token: CancellationToken): IDisposable {
+	protected provideWithTextEditor(context: IQuickAccessTextEditorContext, picker: IQuickPick<IGotoLineQuickPickItem, { useSeparators: true }>, token: CancellationToken): IDisposable {
 		const editor = context.editor;
 		const disposables = new DisposableStore();
 

--- a/src/vs/editor/contrib/quickAccess/browser/gotoSymbolQuickAccess.ts
+++ b/src/vs/editor/contrib/quickAccess/browser/gotoSymbolQuickAccess.ts
@@ -63,13 +63,13 @@ export abstract class AbstractGotoSymbolQuickAccessProvider extends AbstractEdit
 		this.options.canAcceptInBackground = true;
 	}
 
-	protected provideWithoutTextEditor(picker: IQuickPick<IGotoSymbolQuickPickItem>): IDisposable {
+	protected provideWithoutTextEditor(picker: IQuickPick<IGotoSymbolQuickPickItem, { useSeparators: true }>): IDisposable {
 		this.provideLabelPick(picker, localize('cannotRunGotoSymbolWithoutEditor', "To go to a symbol, first open a text editor with symbol information."));
 
 		return Disposable.None;
 	}
 
-	protected provideWithTextEditor(context: IQuickAccessTextEditorContext, picker: IQuickPick<IGotoSymbolQuickPickItem>, token: CancellationToken, runOptions?: IQuickAccessProviderRunOptions): IDisposable {
+	protected provideWithTextEditor(context: IQuickAccessTextEditorContext, picker: IQuickPick<IGotoSymbolQuickPickItem, { useSeparators: true }>, token: CancellationToken, runOptions?: IQuickAccessProviderRunOptions): IDisposable {
 		const editor = context.editor;
 		const model = this.getModel(editor);
 		if (!model) {
@@ -87,7 +87,7 @@ export abstract class AbstractGotoSymbolQuickAccessProvider extends AbstractEdit
 		return this.doProvideWithoutEditorSymbols(context, model, picker, token);
 	}
 
-	private doProvideWithoutEditorSymbols(context: IQuickAccessTextEditorContext, model: ITextModel, picker: IQuickPick<IGotoSymbolQuickPickItem>, token: CancellationToken): IDisposable {
+	private doProvideWithoutEditorSymbols(context: IQuickAccessTextEditorContext, model: ITextModel, picker: IQuickPick<IGotoSymbolQuickPickItem, { useSeparators: true }>, token: CancellationToken): IDisposable {
 		const disposables = new DisposableStore();
 
 		// Generic pick for not having any symbol information
@@ -110,7 +110,7 @@ export abstract class AbstractGotoSymbolQuickAccessProvider extends AbstractEdit
 		return disposables;
 	}
 
-	private provideLabelPick(picker: IQuickPick<IGotoSymbolQuickPickItem>, label: string): void {
+	private provideLabelPick(picker: IQuickPick<IGotoSymbolQuickPickItem, { useSeparators: true }>, label: string): void {
 		picker.items = [{ label, index: 0, kind: SymbolKind.String }];
 		picker.ariaLabel = label;
 	}
@@ -137,7 +137,7 @@ export abstract class AbstractGotoSymbolQuickAccessProvider extends AbstractEdit
 		return symbolProviderRegistryPromise.p;
 	}
 
-	private doProvideWithEditorSymbols(context: IQuickAccessTextEditorContext, model: ITextModel, picker: IQuickPick<IGotoSymbolQuickPickItem>, token: CancellationToken, runOptions?: IQuickAccessProviderRunOptions): IDisposable {
+	private doProvideWithEditorSymbols(context: IQuickAccessTextEditorContext, model: ITextModel, picker: IQuickPick<IGotoSymbolQuickPickItem, { useSeparators: true }>, token: CancellationToken, runOptions?: IQuickAccessProviderRunOptions): IDisposable {
 		const editor = context.editor;
 		const disposables = new DisposableStore();
 

--- a/src/vs/editor/standalone/browser/quickInput/standaloneQuickInputService.ts
+++ b/src/vs/editor/standalone/browser/quickInput/standaloneQuickInputService.ts
@@ -119,8 +119,10 @@ export class StandaloneQuickInputService implements IQuickInputService {
 		return this.activeService.input(options, token);
 	}
 
-	createQuickPick<T extends IQuickPickItem>(): IQuickPick<T> {
-		return this.activeService.createQuickPick();
+	createQuickPick<T extends IQuickPickItem>(options: { useSeparators: true }): IQuickPick<T, { useSeparators: true }>;
+	createQuickPick<T extends IQuickPickItem>(options?: { useSeparators: boolean }): IQuickPick<T, { useSeparators: false }>;
+	createQuickPick<T extends IQuickPickItem>(options: { useSeparators: boolean } = { useSeparators: false }): IQuickPick<T, { useSeparators: boolean }> {
+		return this.activeService.createQuickPick(options);
 	}
 
 	createInputBox(): IInputBox {

--- a/src/vs/platform/quickinput/browser/helpQuickAccess.ts
+++ b/src/vs/platform/quickinput/browser/helpQuickAccess.ts
@@ -25,7 +25,7 @@ export class HelpQuickAccessProvider implements IQuickAccessProvider {
 		@IKeybindingService private readonly keybindingService: IKeybindingService
 	) { }
 
-	provide(picker: IQuickPick<IHelpQuickAccessPickItem>): IDisposable {
+	provide(picker: IQuickPick<IHelpQuickAccessPickItem, { useSeparators: true }>): IDisposable {
 		const disposables = new DisposableStore();
 
 		// Open a picker with the selected value if picked

--- a/src/vs/platform/quickinput/browser/pickerQuickAccess.ts
+++ b/src/vs/platform/quickinput/browser/pickerQuickAccess.ts
@@ -133,7 +133,7 @@ export abstract class PickerQuickAccessProvider<T extends IPickerQuickAccessItem
 		super();
 	}
 
-	provide(picker: IQuickPick<T>, token: CancellationToken, runOptions?: IQuickAccessProviderRunOptions): IDisposable {
+	provide(picker: IQuickPick<T, { useSeparators: true }>, token: CancellationToken, runOptions?: IQuickAccessProviderRunOptions): IDisposable {
 		const disposables = new DisposableStore();
 
 		// Apply options if any

--- a/src/vs/platform/quickinput/browser/quickAccess.ts
+++ b/src/vs/platform/quickinput/browser/quickAccess.ts
@@ -20,7 +20,7 @@ export class QuickAccessController extends Disposable implements IQuickAccessCon
 	private readonly lastAcceptedPickerValues = new Map<IQuickAccessProviderDescriptor, string>();
 
 	private visibleQuickAccess: {
-		readonly picker: IQuickPick<IQuickPickItem>;
+		readonly picker: IQuickPick<IQuickPickItem, { useSeparators: true }>;
 		readonly descriptor: IQuickAccessProviderDescriptor | undefined;
 		readonly value: string;
 	} | undefined = undefined;
@@ -99,7 +99,7 @@ export class QuickAccessController extends Disposable implements IQuickAccessCon
 		// Create a picker for the provider to use with the initial value
 		// and adjust the filtering to exclude the prefix from filtering
 		const disposables = new DisposableStore();
-		const picker = disposables.add(this.quickInputService.createQuickPick());
+		const picker = disposables.add(this.quickInputService.createQuickPick({ useSeparators: true }));
 		picker.value = value;
 		this.adjustValueSelection(picker, descriptor, options);
 		picker.placeholder = options?.placeholder ?? descriptor?.placeholder;
@@ -163,7 +163,7 @@ export class QuickAccessController extends Disposable implements IQuickAccessCon
 		}
 	}
 
-	private adjustValueSelection(picker: IQuickPick<IQuickPickItem>, descriptor?: IQuickAccessProviderDescriptor, options?: IQuickAccessOptions): void {
+	private adjustValueSelection(picker: IQuickPick<IQuickPickItem, { useSeparators: true }>, descriptor?: IQuickAccessProviderDescriptor, options?: IQuickAccessOptions): void {
 		let valueSelection: [number, number];
 
 		// Preserve: just always put the cursor at the end
@@ -180,7 +180,7 @@ export class QuickAccessController extends Disposable implements IQuickAccessCon
 	}
 
 	private registerPickerListeners(
-		picker: IQuickPick<IQuickPickItem>,
+		picker: IQuickPick<IQuickPickItem, { useSeparators: true }>,
 		provider: IQuickAccessProvider | undefined,
 		descriptor: IQuickAccessProviderDescriptor | undefined,
 		value: string,

--- a/src/vs/platform/quickinput/browser/quickInput.ts
+++ b/src/vs/platform/quickinput/browser/quickInput.ts
@@ -527,7 +527,7 @@ abstract class QuickInput extends Disposable implements IQuickInput {
 	}
 }
 
-export class QuickPick<T extends IQuickPickItem> extends QuickInput implements IQuickPick<T> {
+export class QuickPick<T extends IQuickPickItem, O extends { useSeparators: boolean } = { useSeparators: false }> extends QuickInput implements IQuickPick<T, O> {
 
 	private static readonly DEFAULT_ARIA_LABEL = localize('quickInputBox.ariaLabel', "Type to narrow down results.");
 
@@ -538,7 +538,7 @@ export class QuickPick<T extends IQuickPickItem> extends QuickInput implements I
 	private readonly onWillAcceptEmitter = this._register(new Emitter<IQuickPickWillAcceptEvent>());
 	private readonly onDidAcceptEmitter = this._register(new Emitter<IQuickPickDidAcceptEvent>());
 	private readonly onDidCustomEmitter = this._register(new Emitter<void>());
-	private _items: Array<T | IQuickPickSeparator> = [];
+	private _items: O extends { useSeparators: true } ? Array<T | IQuickPickSeparator> : Array<T> = [];
 	private itemsUpdated = false;
 	private _canSelectMany = false;
 	private _canAcceptInBackground = false;
@@ -645,7 +645,7 @@ export class QuickPick<T extends IQuickPickItem> extends QuickInput implements I
 		this.ui.list.scrollTop = scrollTop;
 	}
 
-	set items(items: Array<T | IQuickPickSeparator>) {
+	set items(items: O extends { useSeparators: true } ? Array<T | IQuickPickSeparator> : Array<T>) {
 		this._items = items;
 		this.itemsUpdated = true;
 		this.update();

--- a/src/vs/platform/quickinput/browser/quickInputController.ts
+++ b/src/vs/platform/quickinput/browser/quickInputController.ts
@@ -374,7 +374,7 @@ export class QuickInputController extends Disposable {
 				resolve(undefined);
 				return;
 			}
-			const input = this.createQuickPick<T>();
+			const input = this.createQuickPick<T>({ useSeparators: true });
 			let activeItem: T | undefined;
 			const disposables = [
 				input,
@@ -545,9 +545,11 @@ export class QuickInputController extends Disposable {
 
 	backButton = backButton;
 
-	createQuickPick<T extends IQuickPickItem>(): IQuickPick<T> {
+	createQuickPick<T extends IQuickPickItem>(options: { useSeparators: true }): IQuickPick<T, { useSeparators: true }>;
+	createQuickPick<T extends IQuickPickItem>(options?: { useSeparators: boolean }): IQuickPick<T, { useSeparators: false }>;
+	createQuickPick<T extends IQuickPickItem>(options: { useSeparators: boolean } = { useSeparators: false }): IQuickPick<T, { useSeparators: boolean }> {
 		const ui = this.getUI(true);
-		return new QuickPick<T>(ui);
+		return new QuickPick<T, typeof options>(ui);
 	}
 
 	createInputBox(): IInputBox {

--- a/src/vs/platform/quickinput/browser/quickInputService.ts
+++ b/src/vs/platform/quickinput/browser/quickInputService.ts
@@ -157,8 +157,10 @@ export class QuickInputService extends Themable implements IQuickInputService {
 		return this.controller.input(options, token);
 	}
 
-	createQuickPick<T extends IQuickPickItem>(): IQuickPick<T> {
-		return this.controller.createQuickPick();
+	createQuickPick<T extends IQuickPickItem>(options: { useSeparators: true }): IQuickPick<T, { useSeparators: true }>;
+	createQuickPick<T extends IQuickPickItem>(options?: { useSeparators: boolean }): IQuickPick<T, { useSeparators: false }>;
+	createQuickPick<T extends IQuickPickItem>(options: { useSeparators: boolean } = { useSeparators: false }): IQuickPick<T, { useSeparators: boolean }> {
+		return this.controller.createQuickPick(options);
 	}
 
 	createInputBox(): IInputBox {

--- a/src/vs/platform/quickinput/browser/quickPickPin.ts
+++ b/src/vs/platform/quickinput/browser/quickPickPin.ts
@@ -18,7 +18,7 @@ const buttonClasses = [pinButtonClass, pinnedButtonClass];
  * be removed if @param filterDupliates has been provided. Pin and pinned button events trigger updates to the underlying storage.
  * Shows the quickpick once formatted.
  */
-export async function showWithPinnedItems(storageService: IStorageService, storageKey: string, quickPick: IQuickPick<IQuickPickItem>, filterDuplicates?: boolean): Promise<void> {
+export async function showWithPinnedItems(storageService: IStorageService, storageKey: string, quickPick: IQuickPick<IQuickPickItem, { useSeparators: true }>, filterDuplicates?: boolean): Promise<void> {
 	const itemsWithoutPinned = quickPick.items;
 	let itemsWithPinned = _formatPinnedItems(storageKey, quickPick, storageService, undefined, filterDuplicates);
 	quickPick.onDidTriggerItemButton(async buttonEvent => {
@@ -41,7 +41,7 @@ export async function showWithPinnedItems(storageService: IStorageService, stora
 	quickPick.show();
 }
 
-function _formatPinnedItems(storageKey: string, quickPick: IQuickPick<IQuickPickItem>, storageService: IStorageService, changedItem?: IQuickPickItem, filterDuplicates?: boolean): QuickPickItem[] {
+function _formatPinnedItems(storageKey: string, quickPick: IQuickPick<IQuickPickItem, { useSeparators: true }>, storageService: IStorageService, changedItem?: IQuickPickItem, filterDuplicates?: boolean): QuickPickItem[] {
 	const formattedItems: QuickPickItem[] = [];
 	let pinnedItems;
 	if (changedItem) {

--- a/src/vs/platform/quickinput/common/quickAccess.ts
+++ b/src/vs/platform/quickinput/common/quickAccess.ts
@@ -129,7 +129,7 @@ export interface IQuickAccessProvider {
 	 * @return a disposable that will automatically be disposed when the picker
 	 * closes or is replaced by another picker.
 	 */
-	provide(picker: IQuickPick<IQuickPickItem>, token: CancellationToken, options?: IQuickAccessProviderRunOptions): IDisposable;
+	provide(picker: IQuickPick<IQuickPickItem, { useSeparators: true }>, token: CancellationToken, options?: IQuickAccessProviderRunOptions): IDisposable;
 }
 
 export interface IQuickAccessProviderHelp {

--- a/src/vs/platform/quickinput/common/quickInput.ts
+++ b/src/vs/platform/quickinput/common/quickInput.ts
@@ -418,7 +418,7 @@ export enum QuickPickFocus {
 /**
  * Represents a quick pick control that allows the user to select an item from a list of options.
  */
-export interface IQuickPick<T extends IQuickPickItem> extends IQuickInput {
+export interface IQuickPick<T extends IQuickPickItem, O extends { useSeparators: boolean } = { useSeparators: false }> extends IQuickInput {
 
 	/**
 	 * The type of the quick input.
@@ -505,7 +505,7 @@ export interface IQuickPick<T extends IQuickPickItem> extends IQuickInput {
 	/**
 	 * The items to be displayed in the quick pick.
 	 */
-	items: ReadonlyArray<T | IQuickPickSeparator>;
+	items: O extends { useSeparators: true } ? ReadonlyArray<T | IQuickPickSeparator> : ReadonlyArray<T>;
 
 	/**
 	 * Whether multiple items can be selected. If so, checkboxes will be rendered.
@@ -871,7 +871,8 @@ export interface IQuickInputService {
 	/**
 	 * Provides raw access to the quick pick controller.
 	 */
-	createQuickPick<T extends IQuickPickItem>(): IQuickPick<T>;
+	createQuickPick<T extends IQuickPickItem>(options: { useSeparators: true }): IQuickPick<T, { useSeparators: true }>;
+	createQuickPick<T extends IQuickPickItem>(options?: { useSeparators: boolean }): IQuickPick<T, { useSeparators: false }>;
 
 	/**
 	 * Provides raw access to the input box controller.

--- a/src/vs/workbench/browser/actions/layoutActions.ts
+++ b/src/vs/workbench/browser/actions/layoutActions.ts
@@ -966,7 +966,7 @@ registerAction2(class extends Action2 {
 	}
 
 	private async getView(quickInputService: IQuickInputService, viewDescriptorService: IViewDescriptorService, paneCompositePartService: IPaneCompositePartService, viewId?: string): Promise<string> {
-		const quickPick = quickInputService.createQuickPick();
+		const quickPick = quickInputService.createQuickPick({ useSeparators: true });
 		quickPick.placeholder = localize('moveFocusedView.selectView', "Select a View to Move");
 		quickPick.items = this.getViewItems(viewDescriptorService, paneCompositePartService);
 		quickPick.selectedItems = quickPick.items.filter(item => (item as IQuickPickItem).id === viewId) as IQuickPickItem[];
@@ -1025,7 +1025,7 @@ class MoveFocusedViewAction extends Action2 {
 			return;
 		}
 
-		const quickPick = quickInputService.createQuickPick();
+		const quickPick = quickInputService.createQuickPick({ useSeparators: true });
 		quickPick.placeholder = localize('moveFocusedView.selectDestination', "Select a Destination for the View");
 		quickPick.title = localize({ key: 'moveFocusedView.title', comment: ['{0} indicates the title of the view the user has selected to move.'] }, "View: Move {0}", viewDescriptor.name.value);
 
@@ -1411,7 +1411,7 @@ for (const { active } of [...ToggleVisibilityActions, ...MoveSideBarActions, ...
 
 registerAction2(class CustomizeLayoutAction extends Action2 {
 
-	private _currentQuickPick?: IQuickPick<IQuickPickItem>;
+	private _currentQuickPick?: IQuickPick<IQuickPickItem, { useSeparators: true }>;
 
 	constructor() {
 		super({
@@ -1504,7 +1504,7 @@ registerAction2(class CustomizeLayoutAction extends Action2 {
 		const commandService = accessor.get(ICommandService);
 		const quickInputService = accessor.get(IQuickInputService);
 		const keybindingService = accessor.get(IKeybindingService);
-		const quickPick = quickInputService.createQuickPick();
+		const quickPick = quickInputService.createQuickPick({ useSeparators: true });
 
 		this._currentQuickPick = quickPick;
 		quickPick.items = this.getItems(contextKeyService, keybindingService);

--- a/src/vs/workbench/browser/parts/editor/editorQuickAccess.ts
+++ b/src/vs/workbench/browser/parts/editor/editorQuickAccess.ts
@@ -60,7 +60,7 @@ export abstract class BaseEditorQuickAccessProvider extends PickerQuickAccessPro
 		);
 	}
 
-	override provide(picker: IQuickPick<IEditorQuickPickItem>, token: CancellationToken): IDisposable {
+	override provide(picker: IQuickPick<IEditorQuickPickItem, { useSeparators: true }>, token: CancellationToken): IDisposable {
 
 		// Reset the pick state for this run
 		this.pickState.reset(!!picker.quickNavigate);

--- a/src/vs/workbench/contrib/authentication/browser/actions/manageTrustedExtensionsForAccountAction.ts
+++ b/src/vs/workbench/contrib/authentication/browser/actions/manageTrustedExtensionsForAccountAction.ts
@@ -113,7 +113,7 @@ export class ManageTrustedExtensionsForAccountAction extends Action2 {
 		}
 
 		const disposableStore = new DisposableStore();
-		const quickPick = disposableStore.add(quickInputService.createQuickPick<TrustedExtensionsQuickPickItem>());
+		const quickPick = disposableStore.add(quickInputService.createQuickPick<TrustedExtensionsQuickPickItem>({ useSeparators: true }));
 		quickPick.canSelectMany = true;
 		quickPick.customButton = true;
 		quickPick.customLabel = localize('manageTrustedExtensions.cancel', 'Cancel');

--- a/src/vs/workbench/contrib/codeEditor/browser/quickaccess/gotoSymbolQuickAccess.ts
+++ b/src/vs/workbench/contrib/codeEditor/browser/quickaccess/gotoSymbolQuickAccess.ts
@@ -123,7 +123,7 @@ export class GotoSymbolQuickAccessProvider extends AbstractGotoSymbolQuickAccess
 
 	//#endregion
 
-	protected override provideWithoutTextEditor(picker: IQuickPick<IGotoSymbolQuickPickItem>): IDisposable {
+	protected override provideWithoutTextEditor(picker: IQuickPick<IGotoSymbolQuickPickItem, { useSeparators: true }>): IDisposable {
 		if (this.canPickWithOutlineService()) {
 			return this.doGetOutlinePicks(picker);
 		}
@@ -134,7 +134,7 @@ export class GotoSymbolQuickAccessProvider extends AbstractGotoSymbolQuickAccess
 		return this.editorService.activeEditorPane ? this.outlineService.canCreateOutline(this.editorService.activeEditorPane) : false;
 	}
 
-	private doGetOutlinePicks(picker: IQuickPick<IGotoSymbolQuickPickItem>): IDisposable {
+	private doGetOutlinePicks(picker: IQuickPick<IGotoSymbolQuickPickItem, { useSeparators: true }>): IDisposable {
 		const pane = this.editorService.activeEditorPane;
 		if (!pane) {
 			return Disposable.None;

--- a/src/vs/workbench/contrib/debug/browser/debugSessionPicker.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugSessionPicker.ts
@@ -21,7 +21,7 @@ export async function showDebugSessionMenu(accessor: ServicesAccessor, selectAnd
 	const commandService = accessor.get(ICommandService);
 
 	const localDisposableStore = new DisposableStore();
-	const quickPick = quickInputService.createQuickPick<IPickerDebugItem>();
+	const quickPick = quickInputService.createQuickPick<IPickerDebugItem>({ useSeparators: true });
 	localDisposableStore.add(quickPick);
 	quickPick.matchOnLabel = quickPick.matchOnDescription = quickPick.matchOnDetail = quickPick.sortByLabel = false;
 	quickPick.placeholder = nls.localize('moveFocusedView.selectView', 'Search debug sessions by name');

--- a/src/vs/workbench/contrib/debug/common/loadedScriptsPicker.ts
+++ b/src/vs/workbench/contrib/debug/common/loadedScriptsPicker.ts
@@ -35,7 +35,7 @@ export async function showLoadedScriptMenu(accessor: ServicesAccessor) {
 	const labelService = accessor.get(ILabelService);
 
 	const localDisposableStore = new DisposableStore();
-	const quickPick = quickInputService.createQuickPick<IPickerDebugItem>();
+	const quickPick = quickInputService.createQuickPick<IPickerDebugItem>({ useSeparators: true });
 	localDisposableStore.add(quickPick);
 	quickPick.matchOnLabel = quickPick.matchOnDescription = quickPick.matchOnDetail = quickPick.sortByLabel = false;
 	quickPick.placeholder = nls.localize('moveFocusedView.selectView', "Search loaded scripts by name");

--- a/src/vs/workbench/contrib/editSessions/browser/editSessions.contribution.ts
+++ b/src/vs/workbench/contrib/editSessions/browser/editSessions.contribution.ts
@@ -960,7 +960,7 @@ export class EditSessionsContribution extends Disposable implements IWorkbenchCo
 	}
 
 	private async pickContinueEditSessionDestination(): Promise<string | undefined> {
-		const quickPick = this.quickInputService.createQuickPick<ContinueEditSessionItem>();
+		const quickPick = this.quickInputService.createQuickPick<ContinueEditSessionItem>({ useSeparators: true });
 
 		const workspaceContext = this.contextService.getWorkbenchState() === WorkbenchState.FOLDER
 			? this.contextService.getWorkspace().folders[0].name

--- a/src/vs/workbench/contrib/editSessions/browser/editSessionsStorageService.ts
+++ b/src/vs/workbench/contrib/editSessions/browser/editSessionsStorageService.ts
@@ -311,7 +311,7 @@ export class EditSessionsWorkbenchService extends Disposable implements IEditSes
 	 * Prompts the user to pick an authentication option for storing and getting edit sessions.
 	 */
 	private async getAccountPreference(reason: 'read' | 'write'): Promise<AuthenticationSession & { providerId: string } | undefined> {
-		const quickpick = this.quickInputService.createQuickPick<ExistingSession | AuthenticationProviderOption | IQuickPickItem>();
+		const quickpick = this.quickInputService.createQuickPick<ExistingSession | AuthenticationProviderOption | IQuickPickItem>({ useSeparators: true });
 		quickpick.ok = false;
 		quickpick.placeholder = reason === 'read' ? localize('choose account read placeholder', "Select an account to restore your working changes from the cloud") : localize('choose account placeholder', "Select an account to store your working changes in the cloud");
 		quickpick.ignoreFocusOut = true;

--- a/src/vs/workbench/contrib/localization/common/localizationsActions.ts
+++ b/src/vs/workbench/contrib/localization/common/localizationsActions.ts
@@ -37,7 +37,7 @@ export class ConfigureDisplayLanguageAction extends Action2 {
 
 		const installedLanguages = await languagePackService.getInstalledLanguages();
 
-		const qp = quickInputService.createQuickPick<ILanguagePackItem>();
+		const qp = quickInputService.createQuickPick<ILanguagePackItem>({ useSeparators: true });
 		qp.matchOnDescription = true;
 		qp.placeholder = localize('chooseLocale', "Select Display Language");
 

--- a/src/vs/workbench/contrib/logs/common/logsActions.ts
+++ b/src/vs/workbench/contrib/logs/common/logsActions.ts
@@ -75,7 +75,7 @@ export class SetLogLevelAction extends Action {
 
 		return new Promise((resolve, reject) => {
 			const disposables = new DisposableStore();
-			const quickPick = this.quickInputService.createQuickPick();
+			const quickPick = this.quickInputService.createQuickPick({ useSeparators: true });
 			quickPick.placeholder = nls.localize('selectlog', "Set Log Level");
 			quickPick.items = entries;
 			let selectedItem: IQuickPickItem | undefined;

--- a/src/vs/workbench/contrib/notebook/browser/view/cellParts/cellOutput.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/cellParts/cellOutput.ts
@@ -381,7 +381,7 @@ class CellOutputElement extends Disposable {
 			});
 		}
 
-		const picker = this.quickInputService.createQuickPick();
+		const picker = this.quickInputService.createQuickPick({ useSeparators: true });
 		picker.items = [
 			...items,
 			{ type: 'separator' },

--- a/src/vs/workbench/contrib/notebook/browser/viewParts/notebookKernelQuickPickStrategy.ts
+++ b/src/vs/workbench/contrib/notebook/browser/viewParts/notebookKernelQuickPickStrategy.ts
@@ -136,7 +136,7 @@ abstract class KernelPickerStrategyBase implements IKernelPickerStrategy {
 			return true;
 		}
 
-		const quickPick = this._quickInputService.createQuickPick<KernelQuickPickItem>();
+		const quickPick = this._quickInputService.createQuickPick<KernelQuickPickItem>({ useSeparators: true });
 		const quickPickItems = this._getKernelPickerQuickPickItems(notebook, matchResult, this._notebookKernelService, scopedContextKeyService);
 
 		if (quickPickItems.length === 1 && supportAutoRun(quickPickItems[0]) && !skipAutoRun) {
@@ -339,7 +339,7 @@ abstract class KernelPickerStrategyBase implements IKernelPickerStrategy {
 
 	private async _showInstallKernelExtensionRecommendation(
 		notebookTextModel: NotebookTextModel,
-		quickPick: IQuickPick<KernelQuickPickItem>,
+		quickPick: IQuickPick<KernelQuickPickItem, { useSeparators: true }>,
 		extensionWorkbenchService: IExtensionsWorkbenchService,
 		token: CancellationToken
 	) {
@@ -519,7 +519,7 @@ export class KernelPickerMRUStrategy extends KernelPickerStrategyBase {
 	private async displaySelectAnotherQuickPick(editor: IActiveNotebookEditor, kernelListEmpty: boolean): Promise<boolean> {
 		const notebook: NotebookTextModel = editor.textModel;
 		const disposables = new DisposableStore();
-		const quickPick = this._quickInputService.createQuickPick<KernelQuickPickItem>();
+		const quickPick = this._quickInputService.createQuickPick<KernelQuickPickItem>({ useSeparators: true });
 		const quickPickItem = await new Promise<KernelQuickPickItem | IQuickInputButton | undefined>(resolve => {
 			// select from kernel sources
 			quickPick.title = kernelListEmpty ? localize('select', "Select Kernel") : localize('selectAnotherKernel', "Select Another Kernel");
@@ -699,7 +699,7 @@ export class KernelPickerMRUStrategy extends KernelPickerStrategyBase {
 
 	private async _selectOneKernel(notebook: NotebookTextModel, source: string, kernels: INotebookKernel[]) {
 		const quickPickItems: QuickPickInput<KernelPick>[] = kernels.map(kernel => toKernelQuickPick(kernel, undefined));
-		const quickPick = this._quickInputService.createQuickPick<KernelQuickPickItem>();
+		const quickPick = this._quickInputService.createQuickPick<KernelQuickPickItem>({ useSeparators: true });
 		quickPick.items = quickPickItems;
 		quickPick.canSelectMany = false;
 

--- a/src/vs/workbench/contrib/remote/browser/remoteIndicator.ts
+++ b/src/vs/workbench/contrib/remote/browser/remoteIndicator.ts
@@ -778,7 +778,7 @@ export class RemoteStatusIndicator extends Disposable implements IWorkbenchContr
 			return items;
 		};
 
-		const quickPick = this.quickInputService.createQuickPick();
+		const quickPick = this.quickInputService.createQuickPick({ useSeparators: true });
 		quickPick.placeholder = nls.localize('remoteActions', "Select an option to open a Remote Window");
 		quickPick.items = computeItems();
 		quickPick.sortByLabel = false;

--- a/src/vs/workbench/contrib/remoteTunnel/electron-sandbox/remoteTunnel.contribution.ts
+++ b/src/vs/workbench/contrib/remoteTunnel/electron-sandbox/remoteTunnel.contribution.ts
@@ -363,7 +363,7 @@ export class RemoteTunnelWorkbenchContribution extends Disposable implements IWo
 
 	private async getAuthenticationSession(): Promise<ExistingSessionItem | undefined> {
 		const sessions = await this.getAllSessions();
-		const quickpick = this.quickInputService.createQuickPick<ExistingSessionItem | AuthenticationProviderOption | IQuickPickItem>();
+		const quickpick = this.quickInputService.createQuickPick<ExistingSessionItem | AuthenticationProviderOption | IQuickPickItem>({ useSeparators: true });
 		quickpick.ok = false;
 		quickpick.placeholder = localize('accountPreference.placeholder', "Sign in to an account to enable remote access");
 		quickpick.ignoreFocusOut = true;
@@ -750,7 +750,7 @@ export class RemoteTunnelWorkbenchContribution extends Disposable implements IWo
 
 		return new Promise<void>((c, e) => {
 			const disposables = new DisposableStore();
-			const quickPick = this.quickInputService.createQuickPick();
+			const quickPick = this.quickInputService.createQuickPick({ useSeparators: true });
 			quickPick.placeholder = localize('manage.placeholder', 'Select a command to invoke');
 			disposables.add(quickPick);
 			const items: Array<QuickPickItem> = [];

--- a/src/vs/workbench/contrib/search/browser/anythingQuickAccess.ts
+++ b/src/vs/workbench/contrib/search/browser/anythingQuickAccess.ts
@@ -87,7 +87,7 @@ export class AnythingQuickAccessProvider extends PickerQuickAccessProvider<IAnyt
 
 	private readonly pickState = this._register(new class extends Disposable {
 
-		picker: IQuickPick<IAnythingQuickPickItem> | undefined = undefined;
+		picker: IQuickPick<IAnythingQuickPickItem, { useSeparators: true }> | undefined = undefined;
 
 		editorViewState = this._register(this.instantiationService.createInstance(PickerEditorState));
 
@@ -109,7 +109,7 @@ export class AnythingQuickAccessProvider extends PickerQuickAccessProvider<IAnyt
 			super();
 		}
 
-		set(picker: IQuickPick<IAnythingQuickPickItem>): void {
+		set(picker: IQuickPick<IAnythingQuickPickItem, { useSeparators: true }>): void {
 
 			// Picker for this run
 			this.picker = picker;
@@ -188,7 +188,7 @@ export class AnythingQuickAccessProvider extends PickerQuickAccessProvider<IAnyt
 		};
 	}
 
-	override provide(picker: IQuickPick<IAnythingQuickPickItem>, token: CancellationToken, runOptions?: AnythingQuickAccessProviderRunOptions): IDisposable {
+	override provide(picker: IQuickPick<IAnythingQuickPickItem, { useSeparators: true }>, token: CancellationToken, runOptions?: AnythingQuickAccessProviderRunOptions): IDisposable {
 		const disposables = new DisposableStore();
 
 		// Update the pick state for this run

--- a/src/vs/workbench/contrib/search/browser/quickTextSearch/textSearchQuickAccess.ts
+++ b/src/vs/workbench/contrib/search/browser/quickTextSearch/textSearchQuickAccess.ts
@@ -100,7 +100,7 @@ export class TextSearchQuickAccess extends PickerQuickAccessProvider<ITextSearch
 		super.dispose();
 	}
 
-	override provide(picker: IQuickPick<ITextSearchQuickAccessItem>, token: CancellationToken, runOptions?: IQuickAccessProviderRunOptions): IDisposable {
+	override provide(picker: IQuickPick<ITextSearchQuickAccessItem, { useSeparators: true }>, token: CancellationToken, runOptions?: IQuickAccessProviderRunOptions): IDisposable {
 		const disposables = new DisposableStore();
 		if (TEXT_SEARCH_QUICK_ACCESS_PREFIX.length < picker.value.length) {
 			picker.valueSelection = [TEXT_SEARCH_QUICK_ACCESS_PREFIX.length, picker.value.length];

--- a/src/vs/workbench/contrib/snippets/browser/snippetPicker.ts
+++ b/src/vs/workbench/contrib/snippets/browser/snippetPicker.ts
@@ -77,7 +77,7 @@ export async function pickSnippet(accessor: ServicesAccessor, languageIdOrSnippe
 		return result;
 	};
 
-	const picker = quickInputService.createQuickPick<ISnippetPick>();
+	const picker = quickInputService.createQuickPick<ISnippetPick>({ useSeparators: true });
 	picker.placeholder = nls.localize('pick.placeholder', "Select a snippet");
 	picker.matchOnDetail = true;
 	picker.ignoreFocusOut = false;

--- a/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
+++ b/src/vs/workbench/contrib/tasks/browser/abstractTaskService.ts
@@ -55,7 +55,7 @@ import { getTemplates as getTaskTemplates } from 'vs/workbench/contrib/tasks/com
 import * as TaskConfig from '../common/taskConfiguration';
 import { TerminalTaskSystem } from './terminalTaskSystem';
 
-import { IQuickInputService, IQuickPick, IQuickPickItem, IQuickPickSeparator, QuickPickInput } from 'vs/platform/quickinput/common/quickInput';
+import { IQuickInputService, IQuickPickItem, IQuickPickSeparator, QuickPickInput } from 'vs/platform/quickinput/common/quickInput';
 
 import { IContextKey, IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 import { TaskDefinitionRegistry } from 'vs/workbench/contrib/tasks/common/taskDefinitionRegistry';
@@ -2738,7 +2738,7 @@ export abstract class AbstractTaskService extends Disposable implements ITaskSer
 			entries.push(additionalEntries[0]);
 		}
 
-		const picker: IQuickPick<ITaskQuickPickEntry> = this._quickInputService.createQuickPick();
+		const picker = this._quickInputService.createQuickPick<ITaskQuickPickEntry>({ useSeparators: true });
 		picker.placeholder = placeHolder;
 		picker.matchOnDescription = true;
 		if (name) {

--- a/src/vs/workbench/contrib/tasks/browser/taskQuickPick.ts
+++ b/src/vs/workbench/contrib/tasks/browser/taskQuickPick.ts
@@ -229,7 +229,7 @@ export class TaskQuickPick extends Disposable {
 	}
 
 	public async show(placeHolder: string, defaultEntry?: ITaskQuickPickEntry, startAtType?: string, name?: string): Promise<Task | undefined | null> {
-		const picker: IQuickPick<ITaskTwoLevelQuickPickEntry> = this._quickInputService.createQuickPick();
+		const picker = this._quickInputService.createQuickPick<ITaskTwoLevelQuickPickEntry>({ useSeparators: true });
 		picker.placeholder = placeHolder;
 		picker.matchOnDescription = true;
 		picker.ignoreFocusOut = false;
@@ -308,7 +308,7 @@ export class TaskQuickPick extends Disposable {
 
 
 
-	private async _doPickerFirstLevel(picker: IQuickPick<ITaskTwoLevelQuickPickEntry>, taskQuickPickEntries: QuickPickInput<ITaskTwoLevelQuickPickEntry>[]): Promise<Task | ConfiguringTask | string | null | undefined> {
+	private async _doPickerFirstLevel(picker: IQuickPick<ITaskTwoLevelQuickPickEntry, { useSeparators: true }>, taskQuickPickEntries: QuickPickInput<ITaskTwoLevelQuickPickEntry>[]): Promise<Task | ConfiguringTask | string | null | undefined> {
 		picker.items = taskQuickPickEntries;
 		showWithPinnedItems(this._storageService, runTaskStorageKey, picker, true);
 		const firstLevelPickerResult = await new Promise<ITaskTwoLevelQuickPickEntry | undefined | null>(resolve => {
@@ -319,7 +319,7 @@ export class TaskQuickPick extends Disposable {
 		return firstLevelPickerResult?.task;
 	}
 
-	public async doPickerSecondLevel(picker: IQuickPick<ITaskTwoLevelQuickPickEntry>, type: string, name?: string) {
+	public async doPickerSecondLevel(picker: IQuickPick<ITaskTwoLevelQuickPickEntry, { useSeparators: true }>, type: string, name?: string) {
 		picker.busy = true;
 		if (type === SHOW_ALL) {
 			const items = (await this._taskService.tasks()).filter(t => !t.configurationProperties.hide).sort((a, b) => this._sorter.compare(a, b)).map(task => this._createTaskEntry(task));

--- a/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
@@ -2264,7 +2264,7 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 		const showAllColorsItem = { label: 'Reset to default' };
 		items.push(showAllColorsItem);
 
-		const quickPick = this._quickInputService.createQuickPick();
+		const quickPick = this._quickInputService.createQuickPick({ useSeparators: true });
 		quickPick.items = items;
 		quickPick.matchOnDescription = true;
 		quickPick.placeholder = nls.localize('changeColor', 'Select a color for the terminal');

--- a/src/vs/workbench/contrib/terminal/browser/terminalRunRecentQuickPick.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalRunRecentQuickPick.ts
@@ -217,7 +217,7 @@ export async function showRunRecentQuickPick(
 		instantiationService.invokeFunction(showRunRecentQuickPick, instance, terminalInRunCommandPicker, type, fuzzySearchToggle.checked ? 'fuzzy' : 'contiguous', quickPick.value);
 	});
 	const outputProvider = instantiationService.createInstance(TerminalOutputProvider);
-	const quickPick = quickInputService.createQuickPick<Item | IQuickPickItem & { rawLabel: string }>();
+	const quickPick = quickInputService.createQuickPick<Item | IQuickPickItem & { rawLabel: string }>({ useSeparators: true });
 	const originalItems = items;
 	quickPick.items = [...originalItems];
 	quickPick.sortByLabel = false;

--- a/src/vs/workbench/contrib/terminalContrib/links/browser/terminalLinkQuickpick.ts
+++ b/src/vs/workbench/contrib/terminalContrib/links/browser/terminalLinkQuickpick.ts
@@ -75,7 +75,7 @@ export class TerminalLinkQuickpick extends DisposableStore {
 		}
 
 		// Create and show quick pick
-		const pick = this._quickInputService.createQuickPick<IQuickPickItem | ITerminalLinkQuickPickItem>();
+		const pick = this._quickInputService.createQuickPick<IQuickPickItem | ITerminalLinkQuickPickItem>({ useSeparators: true });
 		pick.items = picks;
 		pick.placeholder = localize('terminal.integrated.openDetectedLink', "Select the link to open, type to filter all links");
 		pick.sortByLabel = false;

--- a/src/vs/workbench/contrib/testing/browser/testExplorerActions.ts
+++ b/src/vs/workbench/contrib/testing/browser/testExplorerActions.ts
@@ -465,7 +465,7 @@ function selectContinuousRunProfiles(
 		}
 	}
 
-	const quickpick = quickInputService.createQuickPick<IQuickPickItem & { profile: ITestRunProfile }>();
+	const quickpick = quickInputService.createQuickPick<IQuickPickItem & { profile: ITestRunProfile }>({ useSeparators: true });
 	quickpick.title = localize('testing.selectContinuousProfiles', 'Select profiles to run when files change:');
 	quickpick.canSelectMany = true;
 	quickpick.items = qpItems;

--- a/src/vs/workbench/contrib/testing/browser/testingConfigurationUi.ts
+++ b/src/vs/workbench/contrib/testing/browser/testingConfigurationUi.ts
@@ -82,7 +82,7 @@ function buildPicker(accessor: ServicesAccessor, {
 		}
 	}
 
-	const quickpick = accessor.get(IQuickInputService).createQuickPick<IQuickPickItem & { profile: ITestRunProfile }>();
+	const quickpick = accessor.get(IQuickInputService).createQuickPick<IQuickPickItem & { profile: ITestRunProfile }>({ useSeparators: true });
 	quickpick.items = items;
 	quickpick.placeholder = placeholder;
 	return quickpick;

--- a/src/vs/workbench/contrib/themes/browser/themes.contribution.ts
+++ b/src/vs/workbench/contrib/themes/browser/themes.contribution.ts
@@ -291,7 +291,7 @@ interface InstalledThemesPickerOptions {
 	readonly title?: string;
 	readonly description?: string;
 	readonly toggles?: IQuickInputToggle[];
-	readonly onToggle?: (toggle: IQuickInputToggle, quickInput: IQuickPick<ThemeItem>) => Promise<void>;
+	readonly onToggle?: (toggle: IQuickInputToggle, quickInput: IQuickPick<ThemeItem, { useSeparators: boolean }>) => Promise<void>;
 }
 
 class InstalledThemesPicker {
@@ -343,7 +343,7 @@ class InstalledThemesPicker {
 				const disposables = new DisposableStore();
 
 				const autoFocusIndex = picks.findIndex(p => isItem(p) && p.id === activeItemId);
-				const quickpick = this.quickInputService.createQuickPick<ThemeItem>();
+				const quickpick = this.quickInputService.createQuickPick<ThemeItem>({ useSeparators: true });
 				quickpick.items = picks;
 				quickpick.title = this.options.title;
 				quickpick.description = this.options.description;

--- a/src/vs/workbench/contrib/userDataProfile/browser/userDataProfile.ts
+++ b/src/vs/workbench/contrib/userDataProfile/browser/userDataProfile.ts
@@ -522,7 +522,7 @@ export class UserDataProfilesWorkbenchContribution extends Disposable implements
 				const notificationService = accessor.get(INotificationService);
 
 				const disposables = new DisposableStore();
-				const quickPick = disposables.add(quickInputService.createQuickPick());
+				const quickPick = disposables.add(quickInputService.createQuickPick({ useSeparators: true }));
 				const profileTemplateQuickPickItems = await that.getProfileTemplatesQuickPickItems();
 
 				const updateQuickPickItems = (value?: string) => {

--- a/src/vs/workbench/contrib/userDataSync/browser/userDataSync.ts
+++ b/src/vs/workbench/contrib/userDataSync/browser/userDataSync.ts
@@ -904,7 +904,7 @@ export class UserDataSyncWorkbenchContribution extends Disposable implements IWo
 					const quickInputService = accessor.get(IQuickInputService);
 					const commandService = accessor.get(ICommandService);
 					const disposables = new DisposableStore();
-					const quickPick = quickInputService.createQuickPick();
+					const quickPick = quickInputService.createQuickPick({ useSeparators: true });
 					disposables.add(quickPick);
 					const items: Array<QuickPickItem> = [];
 					if (that.userDataSyncService.conflicts.length) {

--- a/src/vs/workbench/contrib/welcomeViews/common/newFile.contribution.ts
+++ b/src/vs/workbench/contrib/welcomeViews/common/newFile.contribution.ts
@@ -99,7 +99,7 @@ class NewFileTemplatesManager extends Disposable {
 		const { promise: resultPromise, resolve: resolveResult } = promiseWithResolvers<boolean>();
 
 		const disposables = new DisposableStore();
-		const qp = this.quickInputService.createQuickPick();
+		const qp = this.quickInputService.createQuickPick({ useSeparators: true });
 		qp.title = localize('newFileTitle', "New File...");
 		qp.placeholder = localize('newFilePlaceholder', "Select File Type or Enter File Name...");
 		qp.sortByLabel = false;

--- a/src/vs/workbench/services/editor/browser/editorResolverService.ts
+++ b/src/vs/workbench/services/editor/browser/editorResolverService.ts
@@ -716,7 +716,7 @@ export class EditorResolverService extends Disposable implements IEditorResolver
 		const editorPicks = this.mapEditorsToQuickPickEntry(resource, showDefaultPicker);
 
 		// Create the editor picker
-		const editorPicker = this.quickInputService.createQuickPick<IQuickPickItem>();
+		const editorPicker = this.quickInputService.createQuickPick<IQuickPickItem>({ useSeparators: true });
 		const placeHolderMessage = showDefaultPicker ?
 			localize('promptOpenWith.updateDefaultPlaceHolder', "Select new default editor for '{0}'", `*${extname(resource)}`) :
 			localize('promptOpenWith.placeHolder', "Select editor for '{0}'", basename(resource));

--- a/src/vs/workbench/services/userDataSync/browser/userDataSyncWorkbenchService.ts
+++ b/src/vs/workbench/services/userDataSync/browser/userDataSyncWorkbenchService.ts
@@ -577,7 +577,7 @@ export class UserDataSyncWorkbenchService extends Disposable implements IUserDat
 
 		let result: UserDataSyncAccount | IAuthenticationProvider | undefined;
 		const disposables: DisposableStore = new DisposableStore();
-		const quickPick = disposables.add(this.quickInputService.createQuickPick<AccountQuickPickItem>());
+		const quickPick = disposables.add(this.quickInputService.createQuickPick<AccountQuickPickItem>({ useSeparators: true }));
 
 		const promise = new Promise<UserDataSyncAccount | IAuthenticationProvider | undefined>(c => {
 			disposables.add(quickPick.onDidHide(() => {

--- a/src/vs/workbench/test/browser/quickAccess.test.ts
+++ b/src/vs/workbench/test/browser/quickAccess.test.ts
@@ -47,7 +47,7 @@ suite('QuickAccess', () => {
 
 		constructor(@IQuickInputService private readonly quickInputService: IQuickInputService, disposables: DisposableStore) { }
 
-		provide(picker: IQuickPick<IQuickPickItem>, token: CancellationToken): IDisposable {
+		provide(picker: IQuickPick<IQuickPickItem, { useSeparators: true }>, token: CancellationToken): IDisposable {
 			assert.ok(picker);
 			providerDefaultCalled = true;
 			token.onCancellationRequested(() => providerDefaultCanceled = true);
@@ -60,7 +60,7 @@ suite('QuickAccess', () => {
 	}
 
 	class TestProvider1 implements IQuickAccessProvider {
-		provide(picker: IQuickPick<IQuickPickItem>, token: CancellationToken): IDisposable {
+		provide(picker: IQuickPick<IQuickPickItem, { useSeparators: true }>, token: CancellationToken): IDisposable {
 			assert.ok(picker);
 			provider1Called = true;
 			token.onCancellationRequested(() => provider1Canceled = true);
@@ -70,7 +70,7 @@ suite('QuickAccess', () => {
 	}
 
 	class TestProvider2 implements IQuickAccessProvider {
-		provide(picker: IQuickPick<IQuickPickItem>, token: CancellationToken): IDisposable {
+		provide(picker: IQuickPick<IQuickPickItem, { useSeparators: true }>, token: CancellationToken): IDisposable {
 			assert.ok(picker);
 			provider2Called = true;
 			token.onCancellationRequested(() => provider2Canceled = true);
@@ -80,7 +80,7 @@ suite('QuickAccess', () => {
 	}
 
 	class TestProvider3 implements IQuickAccessProvider {
-		provide(picker: IQuickPick<IQuickPickItem>, token: CancellationToken): IDisposable {
+		provide(picker: IQuickPick<IQuickPickItem, { useSeparators: true }>, token: CancellationToken): IDisposable {
 			assert.ok(picker);
 			provider3Called = true;
 			token.onCancellationRequested(() => provider3Canceled = true);

--- a/src/vs/workbench/test/browser/workbenchTestServices.ts
+++ b/src/vs/workbench/test/browser/workbenchTestServices.ts
@@ -2102,7 +2102,7 @@ export class TestQuickInputService implements IQuickInputService {
 
 	async input(options?: IInputOptions, token?: CancellationToken): Promise<string> { return options ? 'resolved' + options.prompt : 'resolved'; }
 
-	createQuickPick<T extends IQuickPickItem>(): IQuickPick<T> { throw new Error('not implemented.'); }
+	createQuickPick<T extends IQuickPickItem>(): IQuickPick<T, { useSeparators: boolean }> { throw new Error('not implemented.'); }
 	createInputBox(): IInputBox { throw new Error('not implemented.'); }
 	createQuickWidget(): IQuickWidget { throw new Error('Method not implemented.'); }
 	focus(): void { throw new Error('not implemented.'); }


### PR DESCRIPTION
This changes the default behavior of the _Core API_ `quickInputService.createQuickPick()` to the following:

```ts
	createQuickPick<T extends IQuickPickItem>(options: { useSeparators: true }): IQuickPick<T, { useSeparators: true }>;
	createQuickPick<T extends IQuickPickItem>(options?: { useSeparators: boolean }): IQuickPick<T, { useSeparators: false }>;
```
This influences the `items` property of `IQuickPick` to the following:

```ts
export interface IQuickPick<T extends IQuickPickItem, O extends { useSeparators: boolean } = { useSeparators: false }> extends IQuickInput {
  // ...
  items: O extends { useSeparators: true } ? ReadonlyArray<T | IQuickPickSeparator> : ReadonlyArray<T>;
  // ...
}
```

We have many places where you see:
```
const items = qp.items as IQuickPickItem[];
// do something
```
Folks are just trying to use a QuickPick without separators. This change allows those who don't need separators to not need extra filters or ugly casts in order to treat `items` like an array of only items.

QuickAccess, since it's often passed in a `picker` already, is given one that always uses separators, but maybe wave 2 of this is having that be part of the registration of a QuickAccessProvider... but then again, pretty much every provider has separators.... so maybe it's not worth it...

Fixes https://github.com/microsoft/vscode/issues/201203

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
