### PR TITLE
Track where completions apply to better

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminal.suggest.contribution.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminal.suggest.contribution.ts
@@ -166,7 +166,6 @@ class TerminalSuggestContribution extends DisposableStore implements ITerminalCo
 				this._instance.focus();
 				this._instance.sendText(text, false);
 			}));
-			this.add(this._instance.onDidSendText(() => this._addon.value?.hideSuggestWidget()));
 		}
 	}
 }

--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalSuggestAddon.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalSuggestAddon.ts
@@ -285,8 +285,6 @@ export class SuggestAddon extends Disposable implements ITerminalAddon, ISuggest
 
 		// Hide the widget if the latest character was a space
 		if (this._currentPromptInputState.cursorIndex > 1 && this._currentPromptInputState.value.at(this._currentPromptInputState.cursorIndex - 1) === ' ') {
-			this._preventCompletionsRequest = false;
-			this._allowCompletionsRequestTask.cancel();
 			this.hideSuggestWidget(true);
 			return;
 		}
@@ -294,8 +292,6 @@ export class SuggestAddon extends Disposable implements ITerminalAddon, ISuggest
 		// Hide the widget if the cursor moves to the left of the initial position as the
 		// completions are no longer valid
 		if (this._currentPromptInputState.cursorIndex < this._initialPromptInputState.cursorIndex) {
-			this._preventCompletionsRequest = false;
-			this._allowCompletionsRequestTask.cancel();
 			this.hideSuggestWidget(true);
 			return;
 		}
@@ -321,7 +317,6 @@ export class SuggestAddon extends Disposable implements ITerminalAddon, ISuggest
 		if (!dimensions.width || !dimensions.height) {
 			return;
 		}
-		// TODO: What do frozen and auto do?
 		const xtermBox = this._screen!.getBoundingClientRect();
 		this._suggestWidget.showSuggestions(0, false, false, {
 			left: xtermBox.left + this._terminal.buffer.active.cursorX * dimensions.width,

--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalSuggestAddon.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalSuggestAddon.ts
@@ -135,7 +135,7 @@ export class SuggestAddon extends Disposable implements ITerminalAddon, ISuggest
 	static requestEnableCodeCompletionsSequence = '\x1b[24~h'; // F12,h
 
 	private _preventCompletionsRequest: boolean = false;
-	private _allowCompletionsRequestTask = new RunOnceScheduler(() => this._preventCompletionsRequest = false, 500);
+	private _allowCompletionsRequestTask = new RunOnceScheduler(() => this._preventCompletionsRequest = false, 50);
 
 	private readonly _onBell = this._register(new Emitter<void>());
 	readonly onBell = this._onBell.event;

--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalSuggestAddon.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalSuggestAddon.ts
@@ -298,12 +298,11 @@ export class SuggestAddon extends Disposable implements ITerminalAddon, ISuggest
 
 		if (this._terminalSuggestWidgetVisibleContextKey.get()) {
 			this._cursorIndexDelta = this._currentPromptInputState.cursorIndex - this._initialPromptInputState.cursorIndex;
-			// let leadingLineContent = this._leadingLineContent + this._currentPromptInputState.value.substring(this._leadingLineContent.length, this._leadingLineContent.length + this._cursorIndexDelta);
-			let leadingLineContent = this._currentPromptInputState.value.substring(this._replacementIndex, this._replacementIndex + this._replacementLength + this._cursorIndexDelta);
+			let normalizedLeadingLineContent = this._currentPromptInputState.value.substring(this._replacementIndex, this._replacementIndex + this._replacementLength + this._cursorIndexDelta);
 			if (this._isFilteringDirectories) {
-				leadingLineContent = normalizePathSeparator(leadingLineContent, this._pathSeparator);
+				normalizedLeadingLineContent = normalizePathSeparator(normalizedLeadingLineContent, this._pathSeparator);
 			}
-			const lineContext = new LineContext(leadingLineContent, this._cursorIndexDelta);
+			const lineContext = new LineContext(normalizedLeadingLineContent, this._cursorIndexDelta);
 			this._suggestWidget.setLineContext(lineContext);
 		}
 
@@ -398,7 +397,7 @@ export class SuggestAddon extends Disposable implements ITerminalAddon, ISuggest
 
 		this._cursorIndexDelta = this._currentPromptInputState.cursorIndex - this._initialPromptInputState.cursorIndex;
 
-		let leadingLineContent = this._leadingLineContent;
+		let normalizedLeadingLineContent = this._leadingLineContent;
 		// If there is a single directory in the completions:
 		// - `\` and `/` are normalized such that either can be used
 		// - Using `\` or `/` will request new completions. It's important that this only occurs
@@ -408,9 +407,9 @@ export class SuggestAddon extends Disposable implements ITerminalAddon, ISuggest
 		if (this._isFilteringDirectories) {
 			const firstDir = completions.find(e => e.completion.isDirectory);
 			this._pathSeparator = firstDir?.completion.label.match(/(?<sep>[\\\/])/)?.groups?.sep ?? sep;
-			leadingLineContent = normalizePathSeparator(leadingLineContent, this._pathSeparator);
+			normalizedLeadingLineContent = normalizePathSeparator(normalizedLeadingLineContent, this._pathSeparator);
 		}
-		const lineContext = new LineContext(leadingLineContent, this._cursorIndexDelta);
+		const lineContext = new LineContext(normalizedLeadingLineContent, this._cursorIndexDelta);
 		const model = new SimpleCompletionModel(completions, lineContext, replacementIndex, replacementLength);
 		this._handleCompletionModel(model);
 	}


### PR DESCRIPTION
- ~~Prevent quick successive completion requests~~ (this caused more problems)
- Use ~~initial prompt state~~ replacementIndex+replacementLength instead of current for initial line context. The source of this is pwsh and tells us exactly where the completions were requested
- Set cursorIndexDelta in the initial completion state

Fixes #224683

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
