### PR TITLE
Remove select unique filtering in git completions

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/media/GitTabExpansion.psm1
+++ b/src/vs/workbench/contrib/terminal/browser/media/GitTabExpansion.psm1
@@ -546,15 +546,9 @@ function GitTabExpansionInternal($lastBlock, $GitStatus = $null) {
 
 		# Handles git checkout|switch <ref>
 		"^(?:checkout|switch).* (?<ref>\S*)$" {
-			& {
-				& {
-					gitBranches $matches['ref'] $true
-					gitRemoteUniqueBranches $matches['ref']
-					# Return only unique branches (to eliminate duplicates where the branch exists locally and on the remote)
-				} | Select-Object -Unique | ConvertTo-VscodeCompletion -Type 'branch'
-
-				gitTags $matches['ref'] | Select-Object -Unique | ConvertTo-VscodeCompletion -Type 'tag'
-			}
+			gitBranches $matches['ref'] $true | ConvertTo-VscodeCompletion -Type 'branch'
+			gitRemoteUniqueBranches $matches['ref'] | ConvertTo-VscodeCompletion -Type 'branch'
+			gitTags $matches['ref'] | ConvertTo-VscodeCompletion -Type 'tag'
 		}
 
 		# Handles git worktree add <path> <ref>


### PR DESCRIPTION
This was taking a lot of time, if we do end up actually needing the unique check we should probably do it on the client side in TS.

Fixes #224690

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
