### PR TITLE
Reverting PR #219099 and removing onMouseLeave event on the hover controller 

### DIFF
--- a/src/vs/editor/browser/controller/mouseHandler.ts
+++ b/src/vs/editor/browser/controller/mouseHandler.ts
@@ -24,7 +24,6 @@ import { MouseWheelClassifier } from 'vs/base/browser/ui/scrollbar/scrollableEle
 
 export interface IPointerHandlerHelper {
 	viewDomNode: HTMLElement;
-	overflowWidgetsDomNode: HTMLElement | null;
 	linesContentDomNode: HTMLElement;
 	viewLinesDomNode: HTMLElement;
 
@@ -63,8 +62,6 @@ export class MouseHandler extends ViewEventHandler {
 	private lastMouseLeaveTime: number;
 	private _height: number;
 	private _mouseLeaveMonitor: IDisposable | null = null;
-	private _mouseOnOverflowWidgetsDomNode: boolean = false;
-	private _mouseOnViewDomNode: boolean = false;
 
 	constructor(context: ViewContext, viewController: ViewController, viewHelper: IPointerHandlerHelper) {
 		super();
@@ -79,7 +76,7 @@ export class MouseHandler extends ViewEventHandler {
 			this.viewController,
 			this.viewHelper,
 			this.mouseTargetFactory,
-			(e, testEventTarget) => this._createMouseTargetForView(e, testEventTarget),
+			(e, testEventTarget) => this._createMouseTarget(e, testEventTarget),
 			(e) => this._getMouseColumn(e)
 		));
 
@@ -91,8 +88,7 @@ export class MouseHandler extends ViewEventHandler {
 		this._register(mouseEvents.onContextMenu(this.viewHelper.viewDomNode, (e) => this._onContextMenu(e, true)));
 
 		this._register(mouseEvents.onMouseMove(this.viewHelper.viewDomNode, (e) => {
-			this._mouseOnViewDomNode = true;
-			this._onMouseMoveOverView(e);
+			this._onMouseMove(e);
 
 			// See https://github.com/microsoft/vscode/issues/138789
 			// When moving the mouse really quickly, the browser sometimes forgets to
@@ -105,12 +101,7 @@ export class MouseHandler extends ViewEventHandler {
 				this._mouseLeaveMonitor = dom.addDisposableListener(this.viewHelper.viewDomNode.ownerDocument, 'mousemove', (e) => {
 					if (!this.viewHelper.viewDomNode.contains(e.target as Node | null)) {
 						// went outside the editor!
-						this._mouseOnViewDomNode = false;
-						setTimeout(() => {
-							if (!this._mouseOnOverflowWidgetsDomNode) {
-								this._onMouseLeave(new EditorMouseEvent(e, false, this.viewHelper.viewDomNode));
-							}
-						}, 0);
+						this._onMouseLeave(new EditorMouseEvent(e, false, this.viewHelper.viewDomNode));
 					}
 				});
 			}
@@ -118,32 +109,7 @@ export class MouseHandler extends ViewEventHandler {
 
 		this._register(mouseEvents.onMouseUp(this.viewHelper.viewDomNode, (e) => this._onMouseUp(e)));
 
-		this._register(mouseEvents.onMouseLeave(this.viewHelper.viewDomNode, (e) => {
-			this._mouseOnViewDomNode = false;
-			setTimeout(() => {
-				if (!this._mouseOnOverflowWidgetsDomNode) {
-					this._onMouseLeave(e);
-				}
-			}, 0);
-		}));
-
-		const overflowWidgetsDomNode = this.viewHelper.overflowWidgetsDomNode;
-		if (overflowWidgetsDomNode) {
-			this._register(mouseEvents.onMouseMove(overflowWidgetsDomNode, (e) => {
-				this._mouseOnOverflowWidgetsDomNode = true;
-				this._mouseLeaveMonitor?.dispose();
-				this._mouseLeaveMonitor = null;
-				this._onMouseMoveOverOverflowWidgetsDomNode(e);
-			}));
-			this._register(mouseEvents.onMouseLeave(overflowWidgetsDomNode, (e) => {
-				this._mouseOnOverflowWidgetsDomNode = false;
-				setTimeout(() => {
-					if (!this._mouseOnViewDomNode) {
-						this._onMouseLeave(e);
-					}
-				}, 0);
-			}));
-		}
+		this._register(mouseEvents.onMouseLeave(this.viewHelper.viewDomNode, (e) => this._onMouseLeave(e)));
 
 		// `pointerdown` events can't be used to determine if there's a double click, or triple click
 		// because their `e.detail` is always 0.
@@ -268,10 +234,10 @@ export class MouseHandler extends ViewEventHandler {
 		}
 
 		const relativePos = createCoordinatesRelativeToEditor(this.viewHelper.viewDomNode, editorPos, pos);
-		return this.mouseTargetFactory.createMouseTargetForView(this.viewHelper.getLastRenderData(), editorPos, pos, relativePos, null);
+		return this.mouseTargetFactory.createMouseTarget(this.viewHelper.getLastRenderData(), editorPos, pos, relativePos, null);
 	}
 
-	protected _createMouseTargetForView(e: EditorMouseEvent, testEventTarget: boolean): IMouseTarget {
+	protected _createMouseTarget(e: EditorMouseEvent, testEventTarget: boolean): IMouseTarget {
 		let target = e.target;
 		if (!this.viewHelper.viewDomNode.contains(target)) {
 			const shadowRoot = dom.getShadowRoot(this.viewHelper.viewDomNode);
@@ -281,11 +247,7 @@ export class MouseHandler extends ViewEventHandler {
 				);
 			}
 		}
-		return this.mouseTargetFactory.createMouseTargetForView(this.viewHelper.getLastRenderData(), e.editorPos, e.pos, e.relativePos, testEventTarget ? target : null);
-	}
-
-	private _createMouseTargetForOverflowWidgetsDomNode(e: EditorMouseEvent): IMouseTarget {
-		return this.mouseTargetFactory.createMouseTargetForOverflowWidgetsDomNode(this.viewHelper.getLastRenderData(), e.editorPos, e.pos, e.relativePos, e.target);
+		return this.mouseTargetFactory.createMouseTarget(this.viewHelper.getLastRenderData(), e.editorPos, e.pos, e.relativePos, testEventTarget ? target : null);
 	}
 
 	private _getMouseColumn(e: EditorMouseEvent): number {
@@ -295,30 +257,11 @@ export class MouseHandler extends ViewEventHandler {
 	protected _onContextMenu(e: EditorMouseEvent, testEventTarget: boolean): void {
 		this.viewController.emitContextMenu({
 			event: e,
-			target: this._createMouseTargetForView(e, testEventTarget)
+			target: this._createMouseTarget(e, testEventTarget)
 		});
 	}
 
-	protected _onMouseMoveOverView(e: EditorMouseEvent): void {
-		this._onMouseMove(e, this._createMouseTargetForView(e, true));
-	}
-
-	private _onMouseMoveOverOverflowWidgetsDomNode(e: EditorMouseEvent): void {
-		this._onMouseMove(e, this._createMouseTargetForOverflowWidgetsDomNode(e));
-	}
-
-	private _onMouseMove(e: EditorMouseEvent, target: IMouseTarget): void {
-		const shouldIgnoreMouseMoveEvent = this._shouldIgnoreMouseMoveEvent(e);
-		if (shouldIgnoreMouseMoveEvent) {
-			return undefined;
-		}
-		this.viewController.emitMouseMove({
-			event: e,
-			target
-		});
-	}
-
-	private _shouldIgnoreMouseMoveEvent(e: EditorMouseEvent): boolean {
+	protected _onMouseMove(e: EditorMouseEvent): void {
 		const targetIsWidget = this.mouseTargetFactory.mouseTargetIsWidget(e);
 		if (!targetIsWidget) {
 			e.preventDefault();
@@ -326,14 +269,17 @@ export class MouseHandler extends ViewEventHandler {
 
 		if (this._mouseDownOperation.isActive()) {
 			// In selection/drag operation
-			return true;
+			return;
 		}
 		const actualMouseMoveTime = e.timestamp;
 		if (actualMouseMoveTime < this.lastMouseLeaveTime) {
 			// Due to throttling, this event occurred before the mouse left the editor, therefore ignore it.
-			return true;
+			return;
 		}
-		return false;
+		this.viewController.emitMouseMove({
+			event: e,
+			target: this._createMouseTarget(e, true)
+		});
 	}
 
 	protected _onMouseLeave(e: EditorMouseEvent): void {
@@ -351,12 +297,12 @@ export class MouseHandler extends ViewEventHandler {
 	protected _onMouseUp(e: EditorMouseEvent): void {
 		this.viewController.emitMouseUp({
 			event: e,
-			target: this._createMouseTargetForView(e, true)
+			target: this._createMouseTarget(e, true)
 		});
 	}
 
 	protected _onMouseDown(e: EditorMouseEvent, pointerId: number): void {
-		const t = this._createMouseTargetForView(e, true);
+		const t = this._createMouseTarget(e, true);
 
 		const targetIsContent = (t.type === MouseTargetType.CONTENT_TEXT || t.type === MouseTargetType.CONTENT_EMPTY);
 		const targetIsGutter = (t.type === MouseTargetType.GUTTER_GLYPH_MARGIN || t.type === MouseTargetType.GUTTER_LINE_NUMBERS || t.type === MouseTargetType.GUTTER_LINE_DECORATIONS);
@@ -795,7 +741,7 @@ class TopBottomDragScrollingOperation extends Disposable {
 			const horizontalScrollbarHeight = this._context.configuration.options.get(EditorOption.layoutInfo).horizontalScrollbarHeight;
 			const pos = new PageCoordinates(this._mouseEvent.pos.x, editorPos.y + editorPos.height - horizontalScrollbarHeight - 0.1);
 			const relativePos = createCoordinatesRelativeToEditor(this._viewHelper.viewDomNode, editorPos, pos);
-			mouseTarget = this._mouseTargetFactory.createMouseTargetForView(this._viewHelper.getLastRenderData(), editorPos, pos, relativePos, null);
+			mouseTarget = this._mouseTargetFactory.createMouseTarget(this._viewHelper.getLastRenderData(), editorPos, pos, relativePos, null);
 		}
 		if (!mouseTarget.position || mouseTarget.position.lineNumber !== edgeLineNumber) {
 			if (this._position.outsidePosition === 'above') {

--- a/src/vs/editor/browser/controller/pointerHandler.ts
+++ b/src/vs/editor/browser/controller/pointerHandler.ts
@@ -47,7 +47,7 @@ export class PointerEventHandler extends MouseHandler {
 		// PonterEvents
 		const pointerEvents = new EditorPointerEventFactory(this.viewHelper.viewDomNode);
 
-		this._register(pointerEvents.onPointerMove(this.viewHelper.viewDomNode, (e) => this._onMouseMoveOverView(e)));
+		this._register(pointerEvents.onPointerMove(this.viewHelper.viewDomNode, (e) => this._onMouseMove(e)));
 		this._register(pointerEvents.onPointerUp(this.viewHelper.viewDomNode, (e) => this._onMouseUp(e)));
 		this._register(pointerEvents.onPointerLeave(this.viewHelper.viewDomNode, (e) => this._onMouseLeave(e)));
 		this._register(pointerEvents.onPointerDown(this.viewHelper.viewDomNode, (e, pointerId) => this._onMouseDown(e, pointerId)));
@@ -73,7 +73,7 @@ export class PointerEventHandler extends MouseHandler {
 	}
 
 	private _dispatchGesture(event: GestureEvent, inSelectionMode: boolean): void {
-		const target = this._createMouseTargetForView(new EditorMouseEvent(event, false, this.viewHelper.viewDomNode), false);
+		const target = this._createMouseTarget(new EditorMouseEvent(event, false, this.viewHelper.viewDomNode), false);
 		if (target.position) {
 			this.viewController.dispatchMouse({
 				position: target.position,
@@ -119,7 +119,7 @@ class TouchHandler extends MouseHandler {
 
 		this.viewHelper.focusTextArea();
 
-		const target = this._createMouseTargetForView(new EditorMouseEvent(event, false, this.viewHelper.viewDomNode), false);
+		const target = this._createMouseTarget(new EditorMouseEvent(event, false, this.viewHelper.viewDomNode), false);
 
 		if (target.position) {
 			// Send the tap event also to the <textarea> (for input purposes)

--- a/src/vs/editor/browser/view.ts
+++ b/src/vs/editor/browser/view.ts
@@ -97,7 +97,6 @@ export class View extends ViewEventHandler {
 	private readonly _linesContent: FastDomNode<HTMLElement>;
 	public readonly domNode: FastDomNode<HTMLElement>;
 	private readonly _overflowGuardContainer: FastDomNode<HTMLElement>;
-	private readonly _overflowWidgetsDomNode: HTMLElement | null;
 
 	// Actual mutable state
 	private _shouldRecomputeGlyphMarginLanes: boolean = false;
@@ -115,7 +114,6 @@ export class View extends ViewEventHandler {
 		super();
 		this._selections = [new Selection(1, 1, 1, 1)];
 		this._renderAnimationFrame = null;
-		this._overflowWidgetsDomNode = overflowWidgetsDomNode ?? null;
 
 		const viewController = new ViewController(configuration, model, userInputEvents, commandDelegate);
 
@@ -280,7 +278,6 @@ export class View extends ViewEventHandler {
 	private _createPointerHandlerHelper(): IPointerHandlerHelper {
 		return {
 			viewDomNode: this.domNode.domNode,
-			overflowWidgetsDomNode: this._overflowWidgetsDomNode,
 			linesContentDomNode: this._linesContent.domNode,
 			viewLinesDomNode: this._viewLines.getDomNode().domNode,
 

--- a/src/vs/editor/contrib/hover/browser/hoverAccessibleViews.ts
+++ b/src/vs/editor/contrib/hover/browser/hoverAccessibleViews.ts
@@ -91,7 +91,7 @@ abstract class BaseHoverAccessibleViewProvider extends Disposable implements IAc
 		if (!this._hoverController) {
 			return;
 		}
-		this._hoverController.shouldKeepOpenOnEditorMouseMoveOrLeave = true;
+		this._hoverController.shouldKeepOpenOnEditorMouseMove = true;
 		this._focusedHoverPartIndex = this._hoverController.focusedHoverPartIndex();
 		this._register(this._hoverController.onHoverContentsChanged(() => {
 			this._onDidChangeContent.fire();
@@ -108,7 +108,7 @@ abstract class BaseHoverAccessibleViewProvider extends Disposable implements IAc
 			this._hoverController.focusHoverPartWithIndex(this._focusedHoverPartIndex);
 		}
 		this._focusedHoverPartIndex = -1;
-		this._hoverController.shouldKeepOpenOnEditorMouseMoveOrLeave = false;
+		this._hoverController.shouldKeepOpenOnEditorMouseMove = false;
 	}
 
 	provideContentAtIndex(focusedHoverIndex: number, includeVerbosityActions: boolean): string {

--- a/src/vs/editor/contrib/hover/browser/hoverController.ts
+++ b/src/vs/editor/contrib/hover/browser/hoverController.ts
@@ -53,7 +53,7 @@ export class HoverController extends Disposable implements IEditorContribution {
 
 	public static readonly ID = 'editor.contrib.hover';
 
-	public shouldKeepOpenOnEditorMouseMoveOrLeave: boolean = false;
+	public shouldKeepOpenOnEditorMouseMove: boolean = false;
 
 	private readonly _listenersStore = new DisposableStore();
 
@@ -112,7 +112,6 @@ export class HoverController extends Disposable implements IEditorContribution {
 			this._listenersStore.add(this._editor.onKeyDown((e: IKeyboardEvent) => this._onKeyDown(e)));
 		}
 
-		this._listenersStore.add(this._editor.onMouseLeave((e) => this._onEditorMouseLeave(e)));
 		this._listenersStore.add(this._editor.onDidChangeModel(() => {
 			this._cancelScheduler();
 			this._hideWidgets();
@@ -179,23 +178,6 @@ export class HoverController extends Disposable implements IEditorContribution {
 		this._hoverState.mouseDown = false;
 	}
 
-	private _onEditorMouseLeave(mouseEvent: IPartialEditorMouseEvent): void {
-		if (this.shouldKeepOpenOnEditorMouseMoveOrLeave) {
-			return;
-		}
-
-		this._cancelScheduler();
-
-		const shouldNotHideCurrentHoverWidget = this._shouldNotHideCurrentHoverWidget(mouseEvent);
-		if (shouldNotHideCurrentHoverWidget) {
-			return;
-		}
-		if (_sticky) {
-			return;
-		}
-		this._hideWidgets();
-	}
-
 	private _shouldNotRecomputeCurrentHoverWidget(mouseEvent: IEditorMouseEvent): boolean {
 
 		const isHoverSticky = this._hoverSettings.sticky;
@@ -232,7 +214,7 @@ export class HoverController extends Disposable implements IEditorContribution {
 	}
 
 	private _onEditorMouseMove(mouseEvent: IEditorMouseEvent): void {
-		if (this.shouldKeepOpenOnEditorMouseMoveOrLeave) {
+		if (this.shouldKeepOpenOnEditorMouseMove) {
 			return;
 		}
 


### PR DESCRIPTION
fixes https://github.com/microsoft/vscode/issues/224391

Reverting PR #219099 and removing onMouseLeave event on the hover controller

The issue with this change is that if the mouse is on a hover and then leaves the editor, the hover does not disappear. To make the hover disappear you need to mouse on the editor outside of the hover.

cc @alexdima 