### PR TITLE
Move notebook status bar back to after restore (fix #224256)

### DIFF
--- a/src/vs/workbench/browser/parts/editor/editorPart.ts
+++ b/src/vs/workbench/browser/parts/editor/editorPart.ts
@@ -134,6 +134,9 @@ export class EditorPart extends Part implements IEditorPart, IEditorGroupsView {
 	private readonly _onDidChangeEditorPartOptions = this._register(new Emitter<IEditorPartOptionsChangeEvent>());
 	readonly onDidChangeEditorPartOptions = this._onDidChangeEditorPartOptions.event;
 
+	private readonly _onWillDispose = this._register(new Emitter<void>());
+	readonly onWillDispose = this._onWillDispose.event;
+
 	//#endregion
 
 	private readonly workspaceMemento = this.getMemento(StorageScope.WORKSPACE, StorageTarget.USER);
@@ -1466,6 +1469,9 @@ export class EditorPart extends Part implements IEditorPart, IEditorGroupsView {
 	}
 
 	override dispose(): void {
+
+		// Event
+		this._onWillDispose.fire();
 
 		// Forward to all groups
 		this.disposeGroups();

--- a/src/vs/workbench/browser/parts/editor/editorParts.ts
+++ b/src/vs/workbench/browser/parts/editor/editorParts.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { localize } from 'vs/nls';
-import { EditorGroupLayout, GroupDirection, GroupLocation, GroupOrientation, GroupsArrangement, GroupsOrder, IAuxiliaryEditorPart, IAuxiliaryEditorPartCreateEvent, IEditorGroupContextKeyProvider, IEditorDropTargetDelegate, IEditorGroupsService, IEditorSideGroup, IEditorWorkingSet, IFindGroupScope, IMergeGroupOptions, IEditorWorkingSetOptions } from 'vs/workbench/services/editor/common/editorGroupsService';
+import { EditorGroupLayout, GroupDirection, GroupLocation, GroupOrientation, GroupsArrangement, GroupsOrder, IAuxiliaryEditorPart, IAuxiliaryEditorPartCreateEvent, IEditorGroupContextKeyProvider, IEditorDropTargetDelegate, IEditorGroupsService, IEditorSideGroup, IEditorWorkingSet, IFindGroupScope, IMergeGroupOptions, IEditorWorkingSetOptions, IEditorPart } from 'vs/workbench/services/editor/common/editorGroupsService';
 import { Emitter } from 'vs/base/common/event';
 import { DisposableMap, DisposableStore, IDisposable, toDisposable } from 'vs/base/common/lifecycle';
 import { GroupIdentifier } from 'vs/workbench/common/editor';
@@ -22,6 +22,8 @@ import { IAuxiliaryWindowOpenOptions, IAuxiliaryWindowService } from 'vs/workben
 import { generateUuid } from 'vs/base/common/uuid';
 import { ContextKeyValue, IContextKey, IContextKeyService, RawContextKey } from 'vs/platform/contextkey/common/contextkey';
 import { isHTMLElement } from 'vs/base/browser/dom';
+import { ServiceCollection } from 'vs/platform/instantiation/common/serviceCollection';
+import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
 
 interface IEditorPartsUIState {
 	readonly auxiliary: IAuxiliaryEditorPartState[];
@@ -70,6 +72,28 @@ export class EditorParts extends MultiWindowParts<EditorPart> implements IEditor
 		return this.instantiationService.createInstance(MainEditorPart, this);
 	}
 
+	//#region Scoped Instantiation Services
+
+	private readonly mapPartToInstantiationService = new Map<number /* window ID */, IInstantiationService>();
+
+	getScopedInstantiationService(part: IEditorPart): IInstantiationService {
+		if (part === this.mainPart) {
+			if (!this.mapPartToInstantiationService.has(part.windowId)) {
+				this.instantiationService.invokeFunction(accessor => {
+					const editorService = accessor.get(IEditorService); // using `invokeFunction` to get hold of `IEditorService` lazily
+
+					this.mapPartToInstantiationService.set(part.windowId, this._register(this.instantiationService.createChild(new ServiceCollection(
+						[IEditorService, editorService.createScoped('main', this._store)]
+					))));
+				});
+			}
+		}
+
+		return this.mapPartToInstantiationService.get(part.windowId) ?? this.instantiationService;
+	}
+
+	//#endregion
+
 	//#region Auxiliary Editor Parts
 
 	private readonly _onDidCreateAuxiliaryEditorPart = this._register(new Emitter<IAuxiliaryEditorPartCreateEvent>());
@@ -77,6 +101,10 @@ export class EditorParts extends MultiWindowParts<EditorPart> implements IEditor
 
 	async createAuxiliaryEditorPart(options?: IAuxiliaryEditorPartOpenOptions): Promise<IAuxiliaryEditorPart> {
 		const { part, instantiationService, disposables } = await this.instantiationService.createInstance(AuxiliaryEditorPart, this).create(this.getGroupsLabel(this._parts.size), options);
+
+		// Keep instantiation service
+		this.mapPartToInstantiationService.set(part.windowId, instantiationService);
+		disposables.add(toDisposable(() => this.mapPartToInstantiationService.delete(part.windowId)));
 
 		// Events
 		this._onDidAddGroup.fire(part.activeGroup);

--- a/src/vs/workbench/browser/parts/editor/editorParts.ts
+++ b/src/vs/workbench/browser/parts/editor/editorParts.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { localize } from 'vs/nls';
-import { EditorGroupLayout, GroupDirection, GroupLocation, GroupOrientation, GroupsArrangement, GroupsOrder, IAuxiliaryEditorPart, IAuxiliaryEditorPartCreateEvent, IEditorGroupContextKeyProvider, IEditorDropTargetDelegate, IEditorGroupsService, IEditorSideGroup, IEditorWorkingSet, IFindGroupScope, IMergeGroupOptions, IEditorWorkingSetOptions, IEditorPart } from 'vs/workbench/services/editor/common/editorGroupsService';
+import { EditorGroupLayout, GroupDirection, GroupLocation, GroupOrientation, GroupsArrangement, GroupsOrder, IAuxiliaryEditorPart, IEditorGroupContextKeyProvider, IEditorDropTargetDelegate, IEditorGroupsService, IEditorSideGroup, IEditorWorkingSet, IFindGroupScope, IMergeGroupOptions, IEditorWorkingSetOptions, IEditorPart } from 'vs/workbench/services/editor/common/editorGroupsService';
 import { Emitter } from 'vs/base/common/event';
 import { DisposableMap, DisposableStore, IDisposable, toDisposable } from 'vs/base/common/lifecycle';
 import { GroupIdentifier } from 'vs/workbench/common/editor';
@@ -96,7 +96,7 @@ export class EditorParts extends MultiWindowParts<EditorPart> implements IEditor
 
 	//#region Auxiliary Editor Parts
 
-	private readonly _onDidCreateAuxiliaryEditorPart = this._register(new Emitter<IAuxiliaryEditorPartCreateEvent>());
+	private readonly _onDidCreateAuxiliaryEditorPart = this._register(new Emitter<IAuxiliaryEditorPart>());
 	readonly onDidCreateAuxiliaryEditorPart = this._onDidCreateAuxiliaryEditorPart.event;
 
 	async createAuxiliaryEditorPart(options?: IAuxiliaryEditorPartOpenOptions): Promise<IAuxiliaryEditorPart> {
@@ -109,8 +109,7 @@ export class EditorParts extends MultiWindowParts<EditorPart> implements IEditor
 		// Events
 		this._onDidAddGroup.fire(part.activeGroup);
 
-		const eventDisposables = disposables.add(new DisposableStore());
-		this._onDidCreateAuxiliaryEditorPart.fire({ part, instantiationService, disposables: eventDisposables });
+		this._onDidCreateAuxiliaryEditorPart.fire(part);
 
 		return part;
 	}

--- a/src/vs/workbench/browser/parts/editor/editorStatus.ts
+++ b/src/vs/workbench/browser/parts/editor/editorStatus.ts
@@ -892,7 +892,7 @@ export class EditorStatusContribution extends Disposable implements IWorkbenchCo
 			this.createEditorStatus(part);
 		}
 
-		this._register(editorGroupService.onDidCreateAuxiliaryEditorPart(({ part }) => this.createEditorStatus(part)));
+		this._register(editorGroupService.onDidCreateAuxiliaryEditorPart(part => this.createEditorStatus(part)));
 	}
 
 	private createEditorStatus(part: IEditorPart): void {

--- a/src/vs/workbench/browser/parts/editor/editorStatus.ts
+++ b/src/vs/workbench/browser/parts/editor/editorStatus.ts
@@ -55,9 +55,7 @@ import { ServicesAccessor } from 'vs/editor/browser/editorExtensions';
 import { KeybindingWeight } from 'vs/platform/keybinding/common/keybindingsRegistry';
 import { KeyChord, KeyCode, KeyMod } from 'vs/base/common/keyCodes';
 import { TabFocus } from 'vs/editor/browser/config/tabFocus';
-import { mainWindow } from 'vs/base/browser/window';
-import { IEditorGroupsService } from 'vs/workbench/services/editor/common/editorGroupsService';
-import { ServiceCollection } from 'vs/platform/instantiation/common/serviceCollection';
+import { IEditorGroupsService, IEditorPart } from 'vs/workbench/services/editor/common/editorGroupsService';
 
 class SideBySideEditorEncodingSupport implements IEncodingSupport {
 	constructor(private primary: IEncodingSupport, private secondary: IEncodingSupport) { }
@@ -886,22 +884,23 @@ export class EditorStatusContribution extends Disposable implements IWorkbenchCo
 	static readonly ID = 'workbench.contrib.editorStatus';
 
 	constructor(
-		@IInstantiationService instantiationService: IInstantiationService,
-		@IEditorGroupsService editorGroupService: IEditorGroupsService,
-		@IEditorService editorService: IEditorService
+		@IEditorGroupsService private readonly editorGroupService: IEditorGroupsService,
 	) {
 		super();
 
-		// Main Editor Status
-		const mainInstantiationService = this._register(instantiationService.createChild(new ServiceCollection(
-			[IEditorService, editorService.createScoped('main', this._store)]
-		)));
-		this._register(mainInstantiationService.createInstance(EditorStatus, mainWindow.vscodeWindowId));
+		for (const part of editorGroupService.parts) {
+			this.createEditorStatus(part);
+		}
 
-		// Auxiliary Editor Status
-		this._register(editorGroupService.onDidCreateAuxiliaryEditorPart(({ part, instantiationService, disposables }) => {
-			disposables.add(instantiationService.createInstance(EditorStatus, part.windowId));
-		}));
+		this._register(editorGroupService.onDidCreateAuxiliaryEditorPart(({ part }) => this.createEditorStatus(part)));
+	}
+
+	private createEditorStatus(part: IEditorPart): void {
+		const disposables = new DisposableStore();
+		Event.once(part.onWillDispose)(() => disposables.dispose());
+
+		const scopedInstantiationService = this.editorGroupService.getScopedInstantiationService(part);
+		disposables.add(scopedInstantiationService.createInstance(EditorStatus, part.windowId));
 	}
 }
 

--- a/src/vs/workbench/contrib/languageStatus/browser/languageStatus.contribution.ts
+++ b/src/vs/workbench/contrib/languageStatus/browser/languageStatus.contribution.ts
@@ -73,7 +73,7 @@ class LanguageStatusContribution extends Disposable implements IWorkbenchContrib
 			this.createLanguageStatus(part);
 		}
 
-		this._register(editorGroupService.onDidCreateAuxiliaryEditorPart(({ part }) => this.createLanguageStatus(part)));
+		this._register(editorGroupService.onDidCreateAuxiliaryEditorPart(part => this.createLanguageStatus(part)));
 	}
 
 	private createLanguageStatus(part: IEditorPart): void {

--- a/src/vs/workbench/contrib/languageStatus/browser/languageStatus.contribution.ts
+++ b/src/vs/workbench/contrib/languageStatus/browser/languageStatus.contribution.ts
@@ -28,12 +28,12 @@ import { IStorageService, StorageScope, StorageTarget } from 'vs/platform/storag
 import { equals } from 'vs/base/common/arrays';
 import { URI } from 'vs/base/common/uri';
 import { Action2, registerAction2 } from 'vs/platform/actions/common/actions';
-import { IInstantiationService, ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
+import { ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
 import { Categories } from 'vs/platform/action/common/actionCommonCategories';
 import { IAccessibilityInformation } from 'vs/platform/accessibility/common/accessibility';
-import { IEditorGroupsService } from 'vs/workbench/services/editor/common/editorGroupsService';
-import { ServiceCollection } from 'vs/platform/instantiation/common/serviceCollection';
+import { IEditorGroupsService, IEditorPart } from 'vs/workbench/services/editor/common/editorGroupsService';
 import { IHoverService, nativeHoverDelegate } from 'vs/platform/hover/browser/hover';
+import { Event } from 'vs/base/common/event';
 
 class LanguageStatusViewModel {
 
@@ -65,22 +65,23 @@ class StoredCounter {
 class LanguageStatusContribution extends Disposable implements IWorkbenchContribution {
 
 	constructor(
-		@IInstantiationService instantiationService: IInstantiationService,
-		@IEditorGroupsService editorGroupService: IEditorGroupsService,
-		@IEditorService editorService: IEditorService
+		@IEditorGroupsService private readonly editorGroupService: IEditorGroupsService,
 	) {
 		super();
 
-		// --- main language status
-		const mainInstantiationService = this._register(instantiationService.createChild(new ServiceCollection(
-			[IEditorService, editorService.createScoped('main', this._store)]
-		)));
-		this._register(mainInstantiationService.createInstance(LanguageStatus));
+		for (const part of editorGroupService.parts) {
+			this.createLanguageStatus(part);
+		}
 
-		// --- auxiliary language status
-		this._register(editorGroupService.onDidCreateAuxiliaryEditorPart(({ instantiationService, disposables }) => {
-			disposables.add(instantiationService.createInstance(LanguageStatus));
-		}));
+		this._register(editorGroupService.onDidCreateAuxiliaryEditorPart(({ part }) => this.createLanguageStatus(part)));
+	}
+
+	private createLanguageStatus(part: IEditorPart): void {
+		const disposables = new DisposableStore();
+		Event.once(part.onWillDispose)(() => disposables.dispose());
+
+		const scopedInstantiationService = this.editorGroupService.getScopedInstantiationService(part);
+		disposables.add(scopedInstantiationService.createInstance(LanguageStatus));
 	}
 }
 

--- a/src/vs/workbench/contrib/notebook/browser/contrib/editorStatusBar/editorStatusBar.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/editorStatusBar/editorStatusBar.ts
@@ -20,8 +20,8 @@ import { NotebookCellsChangeType } from 'vs/workbench/contrib/notebook/common/no
 import { INotebookKernel, INotebookKernelService } from 'vs/workbench/contrib/notebook/common/notebookKernelService';
 import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
 import { IStatusbarEntry, IStatusbarEntryAccessor, IStatusbarService, StatusbarAlignment } from 'vs/workbench/services/statusbar/browser/statusbar';
-import { IEditorGroupsService } from 'vs/workbench/services/editor/common/editorGroupsService';
-import { ServiceCollection } from 'vs/platform/instantiation/common/serviceCollection';
+import { IEditorGroupsService, IEditorPart } from 'vs/workbench/services/editor/common/editorGroupsService';
+import { Event } from 'vs/base/common/event';
 
 class ImplictKernelSelector implements IDisposable {
 
@@ -340,28 +340,26 @@ export class NotebookEditorStatusContribution extends Disposable implements IWor
 	static readonly ID = 'notebook.contrib.editorStatus';
 
 	constructor(
-		@IInstantiationService instantiationService: IInstantiationService,
-		@IEditorGroupsService editorGroupService: IEditorGroupsService,
-		@IEditorService editorService: IEditorService
+		@IEditorGroupsService private readonly editorGroupService: IEditorGroupsService
 	) {
 		super();
 
-		// Main Editor Status
-		const mainInstantiationService = instantiationService.createChild(new ServiceCollection(
-			[IEditorService, editorService.createScoped('main', this._store)]
-		));
-		this._register(mainInstantiationService.createInstance(KernelStatus));
-		this._register(mainInstantiationService.createInstance(ActiveCellStatus));
-		this._register(mainInstantiationService.createInstance(NotebookIndentationStatus));
+		for (const part of editorGroupService.parts) {
+			this.createNotebookStatus(part);
+		}
 
-		// Auxiliary Editor Status
-		this._register(editorGroupService.onDidCreateAuxiliaryEditorPart(({ part, instantiationService, disposables }) => {
-			disposables.add(instantiationService.createInstance(KernelStatus));
-			disposables.add(instantiationService.createInstance(ActiveCellStatus));
-			disposables.add(instantiationService.createInstance(NotebookIndentationStatus));
-		}));
+		this._register(editorGroupService.onDidCreateAuxiliaryEditorPart(({ part }) => this.createNotebookStatus(part)));
+	}
+
+	private createNotebookStatus(part: IEditorPart): void {
+		const disposables = new DisposableStore();
+		Event.once(part.onWillDispose)(() => disposables.dispose());
+
+		const scopedInstantiationService = this.editorGroupService.getScopedInstantiationService(part);
+		disposables.add(scopedInstantiationService.createInstance(KernelStatus));
+		disposables.add(scopedInstantiationService.createInstance(ActiveCellStatus));
+		disposables.add(scopedInstantiationService.createInstance(NotebookIndentationStatus));
 	}
 }
 
-
-registerWorkbenchContribution2(NotebookEditorStatusContribution.ID, NotebookEditorStatusContribution, WorkbenchPhase.BlockRestore);
+registerWorkbenchContribution2(NotebookEditorStatusContribution.ID, NotebookEditorStatusContribution, WorkbenchPhase.AfterRestored);

--- a/src/vs/workbench/contrib/notebook/browser/contrib/editorStatusBar/editorStatusBar.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/editorStatusBar/editorStatusBar.ts
@@ -348,7 +348,7 @@ export class NotebookEditorStatusContribution extends Disposable implements IWor
 			this.createNotebookStatus(part);
 		}
 
-		this._register(editorGroupService.onDidCreateAuxiliaryEditorPart(({ part }) => this.createNotebookStatus(part)));
+		this._register(editorGroupService.onDidCreateAuxiliaryEditorPart(part => this.createNotebookStatus(part)));
 	}
 
 	private createNotebookStatus(part: IEditorPart): void {

--- a/src/vs/workbench/electron-sandbox/window.ts
+++ b/src/vs/workbench/electron-sandbox/window.ts
@@ -377,7 +377,7 @@ export class NativeWindow extends BaseWindow {
 			this.createWindowZoomStatusEntry(part);
 		}
 
-		this._register(this.editorGroupService.onDidCreateAuxiliaryEditorPart(({ part }) => this.createWindowZoomStatusEntry(part)));
+		this._register(this.editorGroupService.onDidCreateAuxiliaryEditorPart(part => this.createWindowZoomStatusEntry(part)));
 
 		// Listen to visible editor changes (debounced in case a new editor opens immediately after)
 		this._register(Event.debounce(this.editorService.onDidVisibleEditorsChange, () => undefined, 0, undefined, undefined, undefined, this._store)(() => this.maybeCloseWindow()));
@@ -394,7 +394,7 @@ export class NativeWindow extends BaseWindow {
 				this.handleRepresentedFilename(part);
 			}
 
-			this._register(this.editorGroupService.onDidCreateAuxiliaryEditorPart(({ part }) => this.handleRepresentedFilename(part)));
+			this._register(this.editorGroupService.onDidCreateAuxiliaryEditorPart(part => this.handleRepresentedFilename(part)));
 		}
 
 		// Maximize/Restore on doubleclick (for macOS custom title)

--- a/src/vs/workbench/electron-sandbox/window.ts
+++ b/src/vs/workbench/electron-sandbox/window.ts
@@ -54,7 +54,7 @@ import { IFilesConfigurationService } from 'vs/workbench/services/filesConfigura
 import { Event } from 'vs/base/common/event';
 import { IRemoteAuthorityResolverService } from 'vs/platform/remote/common/remoteAuthorityResolver';
 import { IAddressProvider, IAddress } from 'vs/platform/remote/common/remoteAgentConnection';
-import { IEditorGroupsService } from 'vs/workbench/services/editor/common/editorGroupsService';
+import { IEditorGroupsService, IEditorPart } from 'vs/workbench/services/editor/common/editorGroupsService';
 import { IDialogService } from 'vs/platform/dialogs/common/dialogs';
 import { AuthInfo } from 'vs/base/parts/sandbox/electron-sandbox/electronTypes';
 import { ILogService } from 'vs/platform/log/common/log';
@@ -89,8 +89,6 @@ export class NativeWindow extends BaseWindow {
 	private pendingFoldersToAdd: URI[] = [];
 
 	private isDocumentedEdited = false;
-
-	private readonly mainPartEditorService: IEditorService;
 
 	constructor(
 		@IEditorService private readonly editorService: IEditorService,
@@ -132,8 +130,6 @@ export class NativeWindow extends BaseWindow {
 		@IHostService hostService: IHostService
 	) {
 		super(mainWindow, undefined, hostService, nativeEnvironmentService);
-
-		this.mainPartEditorService = editorService.createScoped('main', this._store);
 
 		this.registerListeners();
 		this.create();
@@ -377,9 +373,11 @@ export class NativeWindow extends BaseWindow {
 
 		this._register(onDidChangeZoomLevel(targetWindowId => this.handleOnDidChangeZoomLevel(targetWindowId)));
 
-		this._register(this.editorGroupService.onDidCreateAuxiliaryEditorPart(({ instantiationService, disposables, part }) => {
-			this.createWindowZoomStatusEntry(instantiationService, part.windowId, disposables);
-		}));
+		for (const part of this.editorGroupService.parts) {
+			this.createWindowZoomStatusEntry(part);
+		}
+
+		this._register(this.editorGroupService.onDidCreateAuxiliaryEditorPart(({ part }) => this.createWindowZoomStatusEntry(part)));
 
 		// Listen to visible editor changes (debounced in case a new editor opens immediately after)
 		this._register(Event.debounce(this.editorService.onDidVisibleEditorsChange, () => undefined, 0, undefined, undefined, undefined, this._store)(() => this.maybeCloseWindow()));
@@ -390,26 +388,13 @@ export class NativeWindow extends BaseWindow {
 			this.trackClosedWaitFiles(filesToWait.waitMarkerFileUri, coalesce(filesToWait.paths.map(path => path.fileUri)));
 		}
 
-		// macOS OS integration
+		// macOS OS integration: represented file name
 		if (isMacintosh) {
-			const updateRepresentedFilename = (editorService: IEditorService, targetWindowId: number | undefined) => {
-				const file = EditorResourceAccessor.getOriginalUri(editorService.activeEditor, { supportSideBySide: SideBySideEditor.PRIMARY, filterByScheme: Schemas.file });
+			for (const part of this.editorGroupService.parts) {
+				this.handleRepresentedFilename(part);
+			}
 
-				// Represented Filename
-				this.nativeHostService.setRepresentedFilename(file?.fsPath ?? '', { targetWindowId });
-
-				// Custom title menu (main window only currently)
-				if (typeof targetWindowId !== 'number') {
-					this.provideCustomTitleContextMenu(file?.fsPath);
-				}
-			};
-
-			this._register(this.mainPartEditorService.onDidActiveEditorChange(() => updateRepresentedFilename(this.mainPartEditorService, undefined)));
-
-			this._register(this.editorGroupService.onDidCreateAuxiliaryEditorPart(({ part, disposables }) => {
-				const auxiliaryEditorService = this.editorService.createScoped(part, disposables);
-				disposables.add(auxiliaryEditorService.onDidActiveEditorChange(() => updateRepresentedFilename(auxiliaryEditorService, part.windowId)));
-			}));
+			this._register(this.editorGroupService.onDidCreateAuxiliaryEditorPart(({ part }) => this.handleRepresentedFilename(part)));
 		}
 
 		// Maximize/Restore on doubleclick (for macOS custom title)
@@ -454,6 +439,26 @@ export class NativeWindow extends BaseWindow {
 		this._register(this.lifecycleService.onBeforeShutdown(e => this.onBeforeShutdown(e)));
 		this._register(this.lifecycleService.onBeforeShutdownError(e => this.onBeforeShutdownError(e)));
 		this._register(this.lifecycleService.onWillShutdown(e => this.onWillShutdown(e)));
+	}
+
+	private handleRepresentedFilename(part: IEditorPart): void {
+		const disposables = new DisposableStore();
+		Event.once(part.onWillDispose)(() => disposables.dispose());
+
+		const scopedEditorService = this.editorGroupService.getScopedInstantiationService(part).invokeFunction(accessor => accessor.get(IEditorService));
+		disposables.add(scopedEditorService.onDidActiveEditorChange(() => this.updateRepresentedFilename(scopedEditorService, part.windowId)));
+	}
+
+	private updateRepresentedFilename(editorService: IEditorService, targetWindowId: number): void {
+		const file = EditorResourceAccessor.getOriginalUri(editorService.activeEditor, { supportSideBySide: SideBySideEditor.PRIMARY, filterByScheme: Schemas.file });
+
+		// Represented Filename
+		this.nativeHostService.setRepresentedFilename(file?.fsPath ?? '', { targetWindowId });
+
+		// Custom title menu (main window only currently)
+		if (targetWindowId === mainWindow.vscodeWindowId) {
+			this.provideCustomTitleContextMenu(file?.fsPath);
+		}
 	}
 
 	//#region Window Lifecycle
@@ -646,8 +651,8 @@ export class NativeWindow extends BaseWindow {
 		// Clear old menu
 		this.customTitleContextMenuDisposable.clear();
 
-		// Provide new menu if a file is opened and we are on a custom title
-		if (!filePath || !hasNativeTitlebar(this.configurationService)) {
+		// Only provide a menu when we have a file path and custom titlebar
+		if (!filePath || hasNativeTitlebar(this.configurationService)) {
 			return;
 		}
 
@@ -693,11 +698,6 @@ export class NativeWindow extends BaseWindow {
 
 		// Touchbar menu (if enabled)
 		this.updateTouchbarMenu();
-
-		// Zoom status
-		for (const { window, disposables } of getWindows()) {
-			this.createWindowZoomStatusEntry(this.instantiationService, window.vscodeWindowId, disposables);
-		}
 
 		// Smoke Test Driver
 		if (this.environmentService.enableSmokeTestDriver) {
@@ -1105,11 +1105,15 @@ export class NativeWindow extends BaseWindow {
 		}
 	}
 
-	private createWindowZoomStatusEntry(instantiationService: IInstantiationService, targetWindowId: number, disposables: DisposableStore): void {
-		this.mapWindowIdToZoomStatusEntry.set(targetWindowId, disposables.add(instantiationService.createInstance(ZoomStatusEntry)));
-		disposables.add(toDisposable(() => this.mapWindowIdToZoomStatusEntry.delete(targetWindowId)));
+	private createWindowZoomStatusEntry(part: IEditorPart): void {
+		const disposables = new DisposableStore();
+		Event.once(part.onWillDispose)(() => disposables.dispose());
 
-		this.updateWindowZoomStatusEntry(targetWindowId);
+		const scopedInstantiationService = this.editorGroupService.getScopedInstantiationService(part);
+		this.mapWindowIdToZoomStatusEntry.set(part.windowId, disposables.add(scopedInstantiationService.createInstance(ZoomStatusEntry)));
+		disposables.add(toDisposable(() => this.mapWindowIdToZoomStatusEntry.delete(part.windowId)));
+
+		this.updateWindowZoomStatusEntry(part.windowId);
 	}
 
 	private updateWindowZoomStatusEntry(targetWindowId: number): void {
@@ -1177,7 +1181,7 @@ class ZoomStatusEntry extends Disposable {
 	updateZoomEntry(visibleOrText: false | string, targetWindowId: number): void {
 		if (typeof visibleOrText === 'string') {
 			if (!this.disposable.value) {
-				this.createZoomEntry(targetWindowId, visibleOrText);
+				this.createZoomEntry(visibleOrText);
 			}
 
 			this.updateZoomLevelLabel(targetWindowId);
@@ -1186,7 +1190,7 @@ class ZoomStatusEntry extends Disposable {
 		}
 	}
 
-	private createZoomEntry(targetWindowId: number, visibleOrText: string) {
+	private createZoomEntry(visibleOrText: string): void {
 		const disposables = new DisposableStore();
 		this.disposable.value = disposables;
 

--- a/src/vs/workbench/services/editor/common/editorGroupsService.ts
+++ b/src/vs/workbench/services/editor/common/editorGroupsService.ts
@@ -439,6 +439,11 @@ export interface IEditorPart extends IEditorGroupsContainer {
 	readonly onDidScroll: Event<void>;
 
 	/**
+	 * An event for when the editor part is disposed.
+	 */
+	readonly onWillDispose: Event<void>;
+
+	/**
 	 * The identifier of the window the editor part is contained in.
 	 */
 	readonly windowId: number;
@@ -560,6 +565,14 @@ export interface IEditorGroupsService extends IEditorGroupsContainer {
 	 * in there at the optional position and size on screen.
 	 */
 	createAuxiliaryEditorPart(options?: { bounds?: Partial<IRectangle> }): Promise<IAuxiliaryEditorPart>;
+
+	/**
+	 * Returns the instantiation service that is scoped to the
+	 * provided editor part. Use this method when building UI
+	 * that contributes to auxiliary editor parts to ensure the
+	 * UI is scoped to that part.
+	 */
+	getScopedInstantiationService(part: IEditorPart): IInstantiationService;
 
 	/**
 	 * Save a new editor working set from the currently opened

--- a/src/vs/workbench/services/editor/common/editorGroupsService.ts
+++ b/src/vs/workbench/services/editor/common/editorGroupsService.ts
@@ -485,12 +485,6 @@ export interface IAuxiliaryEditorPart extends IEditorPart {
 	close(): boolean;
 }
 
-export interface IAuxiliaryEditorPartCreateEvent {
-	readonly part: IAuxiliaryEditorPart;
-	readonly instantiationService: IInstantiationService;
-	readonly disposables: DisposableStore;
-}
-
 export interface IEditorWorkingSet {
 	readonly id: string;
 	readonly name: string;
@@ -528,7 +522,7 @@ export interface IEditorGroupsService extends IEditorGroupsContainer {
 	/**
 	 * An event for when a new auxiliary editor part is created.
 	 */
-	readonly onDidCreateAuxiliaryEditorPart: Event<IAuxiliaryEditorPartCreateEvent>;
+	readonly onDidCreateAuxiliaryEditorPart: Event<IAuxiliaryEditorPart>;
 
 	/**
 	 * Provides access to the main window editor part.

--- a/src/vs/workbench/test/browser/workbenchTestServices.ts
+++ b/src/vs/workbench/test/browser/workbenchTestServices.ts
@@ -836,6 +836,7 @@ export class TestEditorGroupsService implements IEditorGroupsService {
 	onDidLayout: Event<IDimension> = Event.None;
 	onDidChangeEditorPartOptions = Event.None;
 	onDidScroll = Event.None;
+	onWillDispose = Event.None;
 
 	orientation = GroupOrientation.HORIZONTAL;
 	isReady = true;
@@ -879,6 +880,7 @@ export class TestEditorGroupsService implements IEditorGroupsService {
 	isLayoutCentered(): boolean { return false; }
 	createEditorDropTarget(container: HTMLElement, delegate: IEditorDropTargetDelegate): IDisposable { return Disposable.None; }
 	registerContextKeyProvider<T extends ContextKeyValue>(_provider: IEditorGroupContextKeyProvider<T>): IDisposable { throw new Error('not implemented'); }
+	getScopedInstantiationService(part: IEditorPart): IInstantiationService { throw new Error('Method not implemented.'); }
 
 	partOptions!: IEditorPartOptions;
 	enforcePartOptions(options: IEditorPartOptions): IDisposable { return Disposable.None; }
@@ -1849,6 +1851,10 @@ export class TestEditorPart extends MainEditorPart implements IEditorGroupsServi
 	}
 
 	createAuxiliaryEditorPart(): Promise<IAuxiliaryEditorPart> {
+		throw new Error('Method not implemented.');
+	}
+
+	getScopedInstantiationService(part: IEditorPart): IInstantiationService {
 		throw new Error('Method not implemented.');
 	}
 

--- a/src/vs/workbench/test/browser/workbenchTestServices.ts
+++ b/src/vs/workbench/test/browser/workbenchTestServices.ts
@@ -52,7 +52,7 @@ import { IExtensionService } from 'vs/workbench/services/extensions/common/exten
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 import { IDecorationsService, IResourceDecorationChangeEvent, IDecoration, IDecorationData, IDecorationsProvider } from 'vs/workbench/services/decorations/common/decorations';
 import { IDisposable, toDisposable, Disposable, DisposableStore } from 'vs/base/common/lifecycle';
-import { IEditorGroupsService, IEditorGroup, GroupsOrder, GroupsArrangement, GroupDirection, IMergeGroupOptions, IEditorReplacement, IFindGroupScope, EditorGroupLayout, ICloseEditorOptions, GroupOrientation, ICloseAllEditorsOptions, ICloseEditorsFilter, IEditorDropTargetDelegate, IEditorPart, IAuxiliaryEditorPart, IEditorGroupsContainer, IAuxiliaryEditorPartCreateEvent, IEditorWorkingSet, IEditorGroupContextKeyProvider, IEditorWorkingSetOptions } from 'vs/workbench/services/editor/common/editorGroupsService';
+import { IEditorGroupsService, IEditorGroup, GroupsOrder, GroupsArrangement, GroupDirection, IMergeGroupOptions, IEditorReplacement, IFindGroupScope, EditorGroupLayout, ICloseEditorOptions, GroupOrientation, ICloseAllEditorsOptions, ICloseEditorsFilter, IEditorDropTargetDelegate, IEditorPart, IAuxiliaryEditorPart, IEditorGroupsContainer, IEditorWorkingSet, IEditorGroupContextKeyProvider, IEditorWorkingSetOptions } from 'vs/workbench/services/editor/common/editorGroupsService';
 import { IEditorService, ISaveEditorsOptions, IRevertAllEditorsOptions, PreferredGroup, IEditorsChangeEvent, ISaveEditorsResult } from 'vs/workbench/services/editor/common/editorService';
 import { ICodeEditorService } from 'vs/editor/browser/services/codeEditorService';
 import { IEditorPaneRegistry, EditorPaneDescriptor } from 'vs/workbench/browser/editor';
@@ -823,7 +823,7 @@ export class TestEditorGroupsService implements IEditorGroupsService {
 
 	windowId = mainWindow.vscodeWindowId;
 
-	onDidCreateAuxiliaryEditorPart: Event<IAuxiliaryEditorPartCreateEvent> = Event.None;
+	onDidCreateAuxiliaryEditorPart: Event<IAuxiliaryEditorPart> = Event.None;
 	onDidChangeActiveGroup: Event<IEditorGroup> = Event.None;
 	onDidActivateGroup: Event<IEditorGroup> = Event.None;
 	onDidAddGroup: Event<IEditorGroup> = Event.None;
@@ -1828,7 +1828,7 @@ export class TestEditorPart extends MainEditorPart implements IEditorGroupsServi
 	readonly mainPart = this;
 	readonly parts: readonly IEditorPart[] = [this];
 
-	readonly onDidCreateAuxiliaryEditorPart: Event<IAuxiliaryEditorPartCreateEvent> = Event.None;
+	readonly onDidCreateAuxiliaryEditorPart: Event<IAuxiliaryEditorPart> = Event.None;
 
 	testSaveState(): void {
 		return super.saveState();


### PR DESCRIPTION
fyi @rebornix , this adds a new method to editor group service to get the scoped instantiation service for a part and thus we can create notebook status bars on startup by iterating over all parts.