### PR TITLE
Removing the on mouse leave listener in the hover controller

### DIFF
--- a/src/vs/editor/contrib/hover/browser/hoverAccessibleViews.ts
+++ b/src/vs/editor/contrib/hover/browser/hoverAccessibleViews.ts
@@ -91,7 +91,7 @@ abstract class BaseHoverAccessibleViewProvider extends Disposable implements IAc
 		if (!this._hoverController) {
 			return;
 		}
-		this._hoverController.shouldKeepOpenOnEditorMouseMoveOrLeave = true;
+		this._hoverController.shouldKeepOpenOnEditorMouseMove = true;
 		this._focusedHoverPartIndex = this._hoverController.focusedHoverPartIndex();
 		this._register(this._hoverController.onHoverContentsChanged(() => {
 			this._onDidChangeContent.fire();
@@ -108,7 +108,7 @@ abstract class BaseHoverAccessibleViewProvider extends Disposable implements IAc
 			this._hoverController.focusHoverPartWithIndex(this._focusedHoverPartIndex);
 		}
 		this._focusedHoverPartIndex = -1;
-		this._hoverController.shouldKeepOpenOnEditorMouseMoveOrLeave = false;
+		this._hoverController.shouldKeepOpenOnEditorMouseMove = false;
 	}
 
 	provideContentAtIndex(focusedHoverIndex: number, includeVerbosityActions: boolean): string {

--- a/src/vs/editor/contrib/hover/browser/hoverController.ts
+++ b/src/vs/editor/contrib/hover/browser/hoverController.ts
@@ -53,7 +53,7 @@ export class HoverController extends Disposable implements IEditorContribution {
 
 	public static readonly ID = 'editor.contrib.hover';
 
-	public shouldKeepOpenOnEditorMouseMoveOrLeave: boolean = false;
+	public shouldKeepOpenOnEditorMouseMove: boolean = false;
 
 	private readonly _listenersStore = new DisposableStore();
 
@@ -112,7 +112,6 @@ export class HoverController extends Disposable implements IEditorContribution {
 			this._listenersStore.add(this._editor.onKeyDown((e: IKeyboardEvent) => this._onKeyDown(e)));
 		}
 
-		this._listenersStore.add(this._editor.onMouseLeave((e) => this._onEditorMouseLeave(e)));
 		this._listenersStore.add(this._editor.onDidChangeModel(() => {
 			this._cancelScheduler();
 			this._hideWidgets();
@@ -179,23 +178,6 @@ export class HoverController extends Disposable implements IEditorContribution {
 		this._hoverState.mouseDown = false;
 	}
 
-	private _onEditorMouseLeave(mouseEvent: IPartialEditorMouseEvent): void {
-		if (this.shouldKeepOpenOnEditorMouseMoveOrLeave) {
-			return;
-		}
-
-		this._cancelScheduler();
-
-		const shouldNotHideCurrentHoverWidget = this._shouldNotHideCurrentHoverWidget(mouseEvent);
-		if (shouldNotHideCurrentHoverWidget) {
-			return;
-		}
-		if (_sticky) {
-			return;
-		}
-		this._hideWidgets();
-	}
-
 	private _shouldNotRecomputeCurrentHoverWidget(mouseEvent: IEditorMouseEvent): boolean {
 
 		const isHoverSticky = this._hoverSettings.sticky;
@@ -232,7 +214,7 @@ export class HoverController extends Disposable implements IEditorContribution {
 	}
 
 	private _onEditorMouseMove(mouseEvent: IEditorMouseEvent): void {
-		if (this.shouldKeepOpenOnEditorMouseMoveOrLeave) {
+		if (this.shouldKeepOpenOnEditorMouseMove) {
 			return;
 		}
 


### PR DESCRIPTION
fixes https://github.com/microsoft/vscode/issues/224391

In editors where the overflow widgets dom node is set, when the mouse moves outside of the view dom node, this fires the `mouseLeave` event and the hover is closed. To fix this, we have considered some fixes including firing an event when the mouse moves on the overflowing widgets dom node. This PR has been reverted because it has unforeseen consequences. Instead this PR removes the on `onMouseLeave` listener on the editor.