### PR TITLE
Fixing hover disappearance in editors that have `overflowingWidgetDomNode` set

### DIFF
--- a/src/vs/editor/contrib/hover/browser/contentHoverController.ts
+++ b/src/vs/editor/contrib/hover/browser/contentHoverController.ts
@@ -16,6 +16,7 @@ import { IInstantiationService } from 'vs/platform/instantiation/common/instanti
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 import { HoverVerbosityAction } from 'vs/editor/common/standalone/standaloneEnums';
 import { ContentHoverWidget } from 'vs/editor/contrib/hover/browser/contentHoverWidget';
+import { mousePositionWithinElement } from 'vs/editor/contrib/hover/browser/hoverUtils';
 import { ContentHoverComputer } from 'vs/editor/contrib/hover/browser/contentHoverComputer';
 import { HoverResult } from 'vs/editor/contrib/hover/browser/contentHoverTypes';
 import { Emitter } from 'vs/base/common/event';
@@ -69,10 +70,14 @@ export class ContentHoverController extends Disposable implements IHoverWidget {
 			const messages = (result.hasLoadingMessage ? this._addLoadingMessage(result.value) : result.value);
 			this._withResult(new HoverResult(this._computer.anchor, messages, result.isComplete));
 		}));
-		this._register(dom.addStandardDisposableListener(this._contentHoverWidget.getDomNode(), 'keydown', (e) => {
+		const contentHoverWidgetNode = this._contentHoverWidget.getDomNode();
+		this._register(dom.addStandardDisposableListener(contentHoverWidgetNode, 'keydown', (e) => {
 			if (e.equals(KeyCode.Escape)) {
 				this.hide();
 			}
+		}));
+		this._register(dom.addStandardDisposableListener(contentHoverWidgetNode, 'mouseleave', (e) => {
+			this._onMouseLeave(e);
 		}));
 		this._register(TokenizationRegistry.onDidChange(() => {
 			if (this._contentHoverWidget.position && this._currentResult) {
@@ -281,6 +286,18 @@ export class ContentHoverController extends Disposable implements IHoverWidget {
 		return anchorCandidates;
 	}
 
+	private _onMouseLeave(e: MouseEvent): void {
+		const editorDomNode = this._editor.getDomNode();
+		if (!editorDomNode) {
+			return undefined;
+		}
+		const isMouseWithinEditor = mousePositionWithinElement(editorDomNode, e.x, e.y);
+		if (isMouseWithinEditor) {
+			return undefined;
+		}
+		this.hide();
+	}
+
 	public startShowingAtRange(range: Range, mode: HoverStartMode, source: HoverStartSource, focus: boolean): void {
 		this._startShowingOrUpdateHover(new HoverRangeAnchor(0, range, undefined, undefined), mode, source, focus, null);
 	}
@@ -361,6 +378,10 @@ export class ContentHoverController extends Disposable implements IHoverWidget {
 		this._computer.anchor = null;
 		this._hoverOperation.cancel();
 		this._setCurrentResult(null);
+	}
+
+	public getDomNode(): HTMLElement {
+		return this._contentHoverWidget.getDomNode();
 	}
 
 	public get isColorPickerVisible(): boolean {

--- a/src/vs/editor/contrib/hover/browser/contentHoverController.ts
+++ b/src/vs/editor/contrib/hover/browser/contentHoverController.ts
@@ -16,11 +16,11 @@ import { IInstantiationService } from 'vs/platform/instantiation/common/instanti
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 import { HoverVerbosityAction } from 'vs/editor/common/standalone/standaloneEnums';
 import { ContentHoverWidget } from 'vs/editor/contrib/hover/browser/contentHoverWidget';
-import { mousePositionWithinElement } from 'vs/editor/contrib/hover/browser/hoverUtils';
 import { ContentHoverComputer } from 'vs/editor/contrib/hover/browser/contentHoverComputer';
 import { HoverResult } from 'vs/editor/contrib/hover/browser/contentHoverTypes';
 import { Emitter } from 'vs/base/common/event';
 import { RenderedContentHover } from 'vs/editor/contrib/hover/browser/contentHoverRendered';
+import { isMousePositionWithinElement } from 'vs/editor/contrib/hover/browser/hoverUtils';
 
 export class ContentHoverController extends Disposable implements IHoverWidget {
 
@@ -288,14 +288,10 @@ export class ContentHoverController extends Disposable implements IHoverWidget {
 
 	private _onMouseLeave(e: MouseEvent): void {
 		const editorDomNode = this._editor.getDomNode();
-		if (!editorDomNode) {
-			return undefined;
+		const isMousePositionOutsideOfEditor = !editorDomNode || !isMousePositionWithinElement(editorDomNode, e.x, e.y);
+		if (isMousePositionOutsideOfEditor) {
+			this.hide();
 		}
-		const isMouseWithinEditor = mousePositionWithinElement(editorDomNode, e.x, e.y);
-		if (isMouseWithinEditor) {
-			return undefined;
-		}
-		this.hide();
 	}
 
 	public startShowingAtRange(range: Range, mode: HoverStartMode, source: HoverStartSource, focus: boolean): void {

--- a/src/vs/editor/contrib/hover/browser/contentHoverWidget.ts
+++ b/src/vs/editor/contrib/hover/browser/contentHoverWidget.ts
@@ -7,7 +7,6 @@ import * as dom from 'vs/base/browser/dom';
 import { ContentWidgetPositionPreference, ICodeEditor, IContentWidgetPosition } from 'vs/editor/browser/editorBrowser';
 import { ConfigurationChangedEvent, EditorOption } from 'vs/editor/common/config/editorOptions';
 import { HoverStartSource } from 'vs/editor/contrib/hover/browser/hoverOperation';
-import { computeDistanceFromPointToRectangle } from 'vs/editor/contrib/hover/browser/hoverUtils';
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 import { ResizableContentWidget } from 'vs/editor/contrib/hover/browser/resizableContentWidget';
 import { IContextKey, IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
@@ -458,3 +457,10 @@ export class ContentHoverWidget extends ResizableContentWidget {
 	}
 }
 
+function computeDistanceFromPointToRectangle(pointX: number, pointY: number, left: number, top: number, width: number, height: number): number {
+	const x = (left + width / 2); // x center of rectangle
+	const y = (top + height / 2); // y center of rectangle
+	const dx = Math.max(Math.abs(pointX - x) - width / 2, 0);
+	const dy = Math.max(Math.abs(pointY - y) - height / 2, 0);
+	return Math.sqrt(dx * dx + dy * dy);
+}

--- a/src/vs/editor/contrib/hover/browser/contentHoverWidget.ts
+++ b/src/vs/editor/contrib/hover/browser/contentHoverWidget.ts
@@ -7,6 +7,7 @@ import * as dom from 'vs/base/browser/dom';
 import { ContentWidgetPositionPreference, ICodeEditor, IContentWidgetPosition } from 'vs/editor/browser/editorBrowser';
 import { ConfigurationChangedEvent, EditorOption } from 'vs/editor/common/config/editorOptions';
 import { HoverStartSource } from 'vs/editor/contrib/hover/browser/hoverOperation';
+import { computeDistanceFromPointToRectangle } from 'vs/editor/contrib/hover/browser/hoverUtils';
 import { IKeybindingService } from 'vs/platform/keybinding/common/keybinding';
 import { ResizableContentWidget } from 'vs/editor/contrib/hover/browser/resizableContentWidget';
 import { IContextKey, IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
@@ -457,10 +458,3 @@ export class ContentHoverWidget extends ResizableContentWidget {
 	}
 }
 
-function computeDistanceFromPointToRectangle(pointX: number, pointY: number, left: number, top: number, width: number, height: number): number {
-	const x = (left + width / 2); // x center of rectangle
-	const y = (top + height / 2); // y center of rectangle
-	const dx = Math.max(Math.abs(pointX - x) - width / 2, 0);
-	const dy = Math.max(Math.abs(pointY - y) - height / 2, 0);
-	return Math.sqrt(dx * dx + dy * dy);
-}

--- a/src/vs/editor/contrib/hover/browser/hoverController.ts
+++ b/src/vs/editor/contrib/hover/browser/hoverController.ts
@@ -7,7 +7,7 @@ import { DECREASE_HOVER_VERBOSITY_ACTION_ID, INCREASE_HOVER_VERBOSITY_ACTION_ID,
 import { IKeyboardEvent } from 'vs/base/browser/keyboardEvent';
 import { KeyCode } from 'vs/base/common/keyCodes';
 import { Disposable, DisposableStore } from 'vs/base/common/lifecycle';
-import { ICodeEditor, IEditorMouseEvent, IPartialEditorMouseEvent, MouseTargetType } from 'vs/editor/browser/editorBrowser';
+import { ICodeEditor, IEditorMouseEvent, IPartialEditorMouseEvent } from 'vs/editor/browser/editorBrowser';
 import { ConfigurationChangedEvent, EditorOption } from 'vs/editor/common/config/editorOptions';
 import { Range } from 'vs/editor/common/core/range';
 import { IEditorContribution, IScrollEvent } from 'vs/editor/common/editorCommon';
@@ -20,7 +20,6 @@ import { ResultKind } from 'vs/platform/keybinding/common/keybindingResolver';
 import { HoverVerbosityAction } from 'vs/editor/common/languages';
 import { RunOnceScheduler } from 'vs/base/common/async';
 import { isMousePositionWithinElement } from 'vs/editor/contrib/hover/browser/hoverUtils';
-import { ContentHoverWidget } from 'vs/editor/contrib/hover/browser/contentHoverWidget';
 import { ContentHoverController } from 'vs/editor/contrib/hover/browser/contentHoverController';
 import 'vs/css!./hover';
 import { MarginHoverWidget } from 'vs/editor/contrib/hover/browser/marginHoverWidget';
@@ -161,12 +160,6 @@ export class HoverController extends Disposable implements IEditorContribution {
 	}
 
 	private _isMouseOnMarginHoverWidget(mouseEvent: IPartialEditorMouseEvent): boolean {
-		const target = mouseEvent.target;
-		// TODO: potentially not needed check as we check mouse position below, kept for now
-		const isTargetMarginHoverWidget = target && (target.type === MouseTargetType.OVERLAY_WIDGET && target.detail === MarginHoverWidget.ID);
-		if (isTargetMarginHoverWidget) {
-			return true;
-		}
 		const marginHoverWidgetNode = this._glyphWidget?.getDomNode();
 		if (marginHoverWidgetNode) {
 			return isMousePositionWithinElement(marginHoverWidgetNode, mouseEvent.event.posx, mouseEvent.event.posy);
@@ -175,12 +168,6 @@ export class HoverController extends Disposable implements IEditorContribution {
 	}
 
 	private _isMouseOnContentHoverWidget(mouseEvent: IPartialEditorMouseEvent): boolean {
-		const target = mouseEvent.target;
-		// TODO: potentially not needed check as we check mouse position below, kept for now
-		const isTargetContentHoverWidget = target && (target.type === MouseTargetType.CONTENT_WIDGET && target.detail === ContentHoverWidget.ID);
-		if (isTargetContentHoverWidget) {
-			return true;
-		}
 		const contentWidgetNode = this._contentWidget?.getDomNode();
 		if (contentWidgetNode) {
 			return isMousePositionWithinElement(contentWidgetNode, mouseEvent.event.posx, mouseEvent.event.posy);

--- a/src/vs/editor/contrib/hover/browser/hoverUtils.ts
+++ b/src/vs/editor/contrib/hover/browser/hoverUtils.ts
@@ -5,15 +5,7 @@
 
 import * as dom from 'vs/base/browser/dom';
 
-export function computeDistanceFromPointToRectangle(pointX: number, pointY: number, left: number, top: number, width: number, height: number): number {
-	const x = (left + width / 2); // x center of rectangle
-	const y = (top + height / 2); // y center of rectangle
-	const dx = Math.max(Math.abs(pointX - x) - width / 2, 0);
-	const dy = Math.max(Math.abs(pointY - y) - height / 2, 0);
-	return Math.sqrt(dx * dx + dy * dy);
-}
-
-export function mousePositionWithinElement(element: HTMLElement, posx: number, posy: number): boolean {
+export function isMousePositionWithinElement(element: HTMLElement, posx: number, posy: number): boolean {
 	const elementRect = dom.getDomNodePagePosition(element);
 	if (posx < elementRect.left
 		|| posx > elementRect.left + elementRect.width

--- a/src/vs/editor/contrib/hover/browser/hoverUtils.ts
+++ b/src/vs/editor/contrib/hover/browser/hoverUtils.ts
@@ -1,0 +1,25 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as dom from 'vs/base/browser/dom';
+
+export function computeDistanceFromPointToRectangle(pointX: number, pointY: number, left: number, top: number, width: number, height: number): number {
+	const x = (left + width / 2); // x center of rectangle
+	const y = (top + height / 2); // y center of rectangle
+	const dx = Math.max(Math.abs(pointX - x) - width / 2, 0);
+	const dy = Math.max(Math.abs(pointY - y) - height / 2, 0);
+	return Math.sqrt(dx * dx + dy * dy);
+}
+
+export function mousePositionWithinElement(element: HTMLElement, posx: number, posy: number): boolean {
+	const elementRect = dom.getDomNodePagePosition(element);
+	if (posx < elementRect.left
+		|| posx > elementRect.left + elementRect.width
+		|| posy < elementRect.top
+		|| posy > elementRect.top + elementRect.height) {
+		return false;
+	}
+	return true;
+}

--- a/src/vs/editor/contrib/hover/browser/marginHoverWidget.ts
+++ b/src/vs/editor/contrib/hover/browser/marginHoverWidget.ts
@@ -14,6 +14,7 @@ import { IOpenerService } from 'vs/platform/opener/common/opener';
 import { HoverWidget } from 'vs/base/browser/ui/hover/hoverWidget';
 import { IHoverWidget } from 'vs/editor/contrib/hover/browser/hoverTypes';
 import { IHoverMessage, LaneOrLineNumber, MarginHoverComputer } from 'vs/editor/contrib/hover/browser/marginHoverComputer';
+import { mousePositionWithinElement } from 'vs/editor/contrib/hover/browser/hoverUtils';
 
 const $ = dom.$;
 
@@ -59,7 +60,9 @@ export class MarginHoverWidget extends Disposable implements IOverlayWidget, IHo
 				this._updateFont();
 			}
 		}));
-
+		this._register(dom.addStandardDisposableListener(this._hover.containerDomNode, 'mouseleave', (e) => {
+			this._onMouseLeave(e);
+		}));
 		this._editor.addOverlayWidget(this);
 	}
 
@@ -180,5 +183,17 @@ export class MarginHoverWidget extends Disposable implements IOverlayWidget, IHo
 		const left = editorLayout.glyphMarginLeft + editorLayout.glyphMarginWidth + (this._computer.lane === 'lineNo' ? editorLayout.lineNumbersWidth : 0);
 		this._hover.containerDomNode.style.left = `${left}px`;
 		this._hover.containerDomNode.style.top = `${Math.max(Math.round(top), 0)}px`;
+	}
+
+	private _onMouseLeave(e: MouseEvent): void {
+		const editorDomNode = this._editor.getDomNode();
+		if (!editorDomNode) {
+			return undefined;
+		}
+		const isMouseWithinEditor = mousePositionWithinElement(editorDomNode, e.x, e.y);
+		if (isMouseWithinEditor) {
+			return undefined;
+		}
+		this.hide();
 	}
 }

--- a/src/vs/editor/contrib/hover/browser/marginHoverWidget.ts
+++ b/src/vs/editor/contrib/hover/browser/marginHoverWidget.ts
@@ -14,7 +14,7 @@ import { IOpenerService } from 'vs/platform/opener/common/opener';
 import { HoverWidget } from 'vs/base/browser/ui/hover/hoverWidget';
 import { IHoverWidget } from 'vs/editor/contrib/hover/browser/hoverTypes';
 import { IHoverMessage, LaneOrLineNumber, MarginHoverComputer } from 'vs/editor/contrib/hover/browser/marginHoverComputer';
-import { mousePositionWithinElement } from 'vs/editor/contrib/hover/browser/hoverUtils';
+import { isMousePositionWithinElement } from 'vs/editor/contrib/hover/browser/hoverUtils';
 
 const $ = dom.$;
 
@@ -187,13 +187,9 @@ export class MarginHoverWidget extends Disposable implements IOverlayWidget, IHo
 
 	private _onMouseLeave(e: MouseEvent): void {
 		const editorDomNode = this._editor.getDomNode();
-		if (!editorDomNode) {
-			return undefined;
+		const isMousePositionOutsideOfEditor = !editorDomNode || !isMousePositionWithinElement(editorDomNode, e.x, e.y);
+		if (isMousePositionOutsideOfEditor) {
+			this.hide();
 		}
-		const isMouseWithinEditor = mousePositionWithinElement(editorDomNode, e.x, e.y);
-		if (isMouseWithinEditor) {
-			return undefined;
-		}
-		this.hide();
 	}
 }


### PR DESCRIPTION
fixes #224391

In editors where the overflowing widgets dom node is set, when the mouse moves outside of the view dom node, this fires the `mouseLeave` event and the hover is hidden. In order to fix this, in the `onMouseLeave` listener of the hover controller, we calculate the distance from the mouse position to the content (or margin) hover. If it is zero, then the hover is not hidden. When the mouse leaves the content (or margin) hover, it is found if the mouse position is within the bounding rectangle of the editor. If it is not, the hover is immediately hidden, otherwise the `onMouseMove` listener on the hover controller handles this event. 