### PR TITLE
Move 'incorrect account' handling into core

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadAuthentication.ts
+++ b/src/vs/workbench/api/browser/mainThreadAuthentication.ts
@@ -19,6 +19,7 @@ import { IAuthenticationUsageService } from 'vs/workbench/services/authenticatio
 import { getAuthenticationProviderActivationEvent } from 'vs/workbench/services/authentication/browser/authenticationService';
 import { URI, UriComponents } from 'vs/base/common/uri';
 import { IOpenerService } from 'vs/platform/opener/common/opener';
+import { CancellationError } from 'vs/base/common/errors';
 
 interface AuthenticationForceNewSessionOptions {
 	detail?: string;
@@ -159,6 +160,31 @@ export class MainThreadAuthentication extends Disposable implements MainThreadAu
 		return result ?? false;
 	}
 
+	private async continueWithIncorrectAccountPrompt(chosenAccountLabel: string, requestedAccountLabel: string): Promise<boolean> {
+		const result = await this.dialogService.prompt({
+			message: nls.localize('incorrectAccount', "Incorrect account detected"),
+			detail: nls.localize('incorrectAccountDetail', "The chosen account, {0}, does not match the requested account, {1}.", chosenAccountLabel, requestedAccountLabel),
+			type: Severity.Warning,
+			cancelButton: true,
+			buttons: [
+				{
+					label: nls.localize('keep', 'Keep {0}', chosenAccountLabel),
+					run: () => chosenAccountLabel
+				},
+				{
+					label: nls.localize('loginWith', 'Login with {0}', requestedAccountLabel),
+					run: () => requestedAccountLabel
+				}
+			],
+		});
+
+		if (!result.result) {
+			throw new CancellationError();
+		}
+
+		return result.result === chosenAccountLabel;
+	}
+
 	private async doGetSession(providerId: string, scopes: string[], extensionId: string, extensionName: string, options: AuthenticationGetSessionOptions): Promise<AuthenticationSession | undefined> {
 		const sessions = await this.authenticationService.getSessions(providerId, scopes, options.account, true);
 		const provider = this.authenticationService.getProvider(providerId);
@@ -212,18 +238,25 @@ export class MainThreadAuthentication extends Disposable implements MainThreadAu
 				throw new Error('User did not consent to login.');
 			}
 
-			let session;
+			let session: AuthenticationSession;
 			if (sessions?.length && !options.forceNewSession) {
 				session = provider.supportsMultipleAccounts && !options.account
 					? await this.authenticationExtensionsService.selectSession(providerId, extensionId, extensionName, scopes, sessions)
 					: sessions[0];
 			} else {
-				let account: AuthenticationSessionAccount | undefined = options.account;
-				if (!account) {
+				let accountToCreate: AuthenticationSessionAccount | undefined = options.account;
+				if (!accountToCreate) {
 					const sessionIdToRecreate = this.authenticationExtensionsService.getSessionPreference(providerId, extensionId, scopes);
-					account = sessionIdToRecreate ? sessions.find(session => session.id === sessionIdToRecreate)?.account : undefined;
+					accountToCreate = sessionIdToRecreate ? sessions.find(session => session.id === sessionIdToRecreate)?.account : undefined;
 				}
-				session = await this.authenticationService.createSession(providerId, scopes, { activateImmediate: true, account });
+
+				do {
+					session = await this.authenticationService.createSession(providerId, scopes, { activateImmediate: true, account: accountToCreate });
+				} while (
+					accountToCreate
+					&& accountToCreate.label !== session.account.label
+					&& !await this.continueWithIncorrectAccountPrompt(session.account.label, accountToCreate.label)
+				);
 			}
 
 			this.authenticationAccessService.updateAllowedExtensions(providerId, session.account.label, [{ id: extensionId, name: extensionName, allowed: true }]);


### PR DESCRIPTION
So that all auth providers can take advantage of this logic. This basically will do a light enforcement that the account you signed in to matches the account that was requested (if it was specified).

This is needed for finalization.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
