### PR TITLE
Fix a few double disposable registrations

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/preferencesWidgets.ts
+++ b/src/vs/workbench/contrib/preferences/browser/preferencesWidgets.ts
@@ -437,8 +437,7 @@ export class SearchWidget extends Widget {
 
 	protected createInputBox(parent: HTMLElement): HistoryInputBox {
 		const showHistoryHint = () => showHistoryKeybindingHint(this.keybindingService);
-		const box = this._register(new ContextScopedHistoryInputBox(parent, this.contextViewService, { ...this.options, showHistoryHint }, this.contextKeyService));
-		return box;
+		return new ContextScopedHistoryInputBox(parent, this.contextViewService, { ...this.options, showHistoryHint }, this.contextKeyService);
 	}
 
 	showMessage(message: string): void {

--- a/src/vs/workbench/contrib/testing/browser/testingOutputPeek.ts
+++ b/src/vs/workbench/contrib/testing/browser/testingOutputPeek.ts
@@ -92,18 +92,18 @@ export class TestingPeekOpener extends Disposable implements ITestingPeekOpener 
 	private lastUri?: TestUriWithDocument;
 
 	/** @inheritdoc */
-	public readonly historyVisible = MutableObservableValue.stored(this._register(new StoredValue<boolean>({
+	public readonly historyVisible = this._register(MutableObservableValue.stored(new StoredValue<boolean>({
 		key: 'testHistoryVisibleInPeek',
 		scope: StorageScope.PROFILE,
 		target: StorageTarget.USER,
-	}, this.storageService)), false);
+	}, this.storageService), false));
 
 	/** @inheritdoc */
-	public readonly callStackVisible = MutableObservableValue.stored(this._register(new StoredValue<boolean>({
+	public readonly callStackVisible = this._register(MutableObservableValue.stored(new StoredValue<boolean>({
 		key: 'testCallStackVisible',
 		scope: StorageScope.PROFILE,
 		target: StorageTarget.USER,
-	}, this.storageService)), true);
+	}, this.storageService), true));
 
 	constructor(
 		@IConfigurationService private readonly configuration: IConfigurationService,

--- a/src/vs/workbench/contrib/testing/common/testExclusions.ts
+++ b/src/vs/workbench/contrib/testing/common/testExclusions.ts
@@ -13,7 +13,7 @@ import { InternalTestItem } from 'vs/workbench/contrib/testing/common/testTypes'
 
 export class TestExclusions extends Disposable {
 	private readonly excluded = this._register(
-		MutableObservableValue.stored(this._register(new StoredValue<ReadonlySet<string>>({
+		MutableObservableValue.stored(new StoredValue<ReadonlySet<string>>({
 			key: 'excludedTestItems',
 			scope: StorageScope.WORKSPACE,
 			target: StorageTarget.MACHINE,
@@ -21,7 +21,7 @@ export class TestExclusions extends Disposable {
 				deserialize: v => new Set(JSON.parse(v)),
 				serialize: v => JSON.stringify([...v])
 			},
-		}, this.storageService)), new Set())
+		}, this.storageService), new Set())
 	);
 
 	constructor(@IStorageService private readonly storageService: IStorageService) {

--- a/src/vs/workbench/contrib/testing/common/testServiceImpl.ts
+++ b/src/vs/workbench/contrib/testing/common/testServiceImpl.ts
@@ -82,11 +82,11 @@ export class TestService extends Disposable implements ITestService {
 	/**
 	 * @inheritdoc
 	 */
-	public readonly showInlineOutput = MutableObservableValue.stored(this._register(new StoredValue<boolean>({
+	public readonly showInlineOutput = this._register(MutableObservableValue.stored(new StoredValue<boolean>({
 		key: 'inlineTestOutputVisible',
 		scope: StorageScope.WORKSPACE,
 		target: StorageTarget.USER
-	}, this.storage)), true);
+	}, this.storage), true));
 
 	constructor(
 		@IContextKeyService contextKeyService: IContextKeyService,


### PR DESCRIPTION
These values are being registered on a disposable store more than once. I think some of the instances in tests are actually leaking the `MutableObservableValue` too since it's not registered

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
