### PR TITLE
Re #209154. Make execution count sticky.

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/notebookBrowser.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookBrowser.ts
@@ -499,6 +499,7 @@ export interface INotebookEditor {
 	readonly isDisposed: boolean;
 	readonly activeKernel: INotebookKernel | undefined;
 	readonly scrollTop: number;
+	readonly scrollBottom: number;
 	readonly scopedContextKeyService: IContextKeyService;
 	readonly activeCodeEditor: ICodeEditor | undefined;
 	readonly codeEditors: [ICellViewModel, ICodeEditor][];

--- a/src/vs/workbench/contrib/notebook/browser/view/cellParts/cellExecution.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/cellParts/cellExecution.ts
@@ -6,9 +6,11 @@
 import * as DOM from 'vs/base/browser/dom';
 import { disposableTimeout } from 'vs/base/common/async';
 import { DisposableStore } from 'vs/base/common/lifecycle';
+import { clamp } from 'vs/base/common/numbers';
 import { ICellViewModel, INotebookEditorDelegate } from 'vs/workbench/contrib/notebook/browser/notebookBrowser';
 import { CellViewModelStateChangeEvent } from 'vs/workbench/contrib/notebook/browser/notebookViewEvents';
 import { CellContentPart } from 'vs/workbench/contrib/notebook/browser/view/cellPart';
+import { CodeCellViewModel } from 'vs/workbench/contrib/notebook/browser/viewModel/codeCellViewModel';
 import { NotebookCellInternalMetadata } from 'vs/workbench/contrib/notebook/common/notebookCommon';
 import { INotebookExecutionStateService } from 'vs/workbench/contrib/notebook/common/notebookExecutionStateService';
 
@@ -38,6 +40,10 @@ export class CellExecutionPart extends CellContentPart {
 
 				this.updateExecutionOrder(this.currentCell.internalMetadata);
 			}
+		}));
+
+		this._register(this._notebookEditor.onDidScroll(() => {
+			this._updatePosition();
 		}));
 	}
 
@@ -74,12 +80,38 @@ export class CellExecutionPart extends CellContentPart {
 	}
 
 	override updateInternalLayoutNow(element: ICellViewModel): void {
-		if (element.isInputCollapsed) {
-			DOM.hide(this._executionOrderLabel);
-		} else {
-			DOM.show(this._executionOrderLabel);
-			const top = element.layoutInfo.editorHeight - 22 + element.layoutInfo.statusBarHeight;
-			this._executionOrderLabel.style.top = `${top}px`;
+		this._updatePosition();
+	}
+
+	private _updatePosition() {
+		if (this.currentCell) {
+			if (this.currentCell.isInputCollapsed) {
+				DOM.hide(this._executionOrderLabel);
+			} else {
+				DOM.show(this._executionOrderLabel);
+				let top = this.currentCell.layoutInfo.editorHeight - 22 + this.currentCell.layoutInfo.statusBarHeight;
+
+				if (this.currentCell instanceof CodeCellViewModel) {
+					const elementTop = this._notebookEditor.getAbsoluteTopOfElement(this.currentCell);
+					const editorBottom = elementTop + this.currentCell.layoutInfo.outputContainerOffset;
+					// another approach to avoid the flicker caused by sticky scroll is manually calculate the scrollBottom:
+					// const scrollBottom = this._notebookEditor.scrollTop + this._notebookEditor.getLayoutInfo().height - 26 - this._notebookEditor.getLayoutInfo().stickyHeight;
+					const scrollBottom = this._notebookEditor.scrollBottom;
+
+					const lineHeight = 22;
+					if (scrollBottom <= editorBottom) {
+						const offset = editorBottom - scrollBottom;
+						top -= offset;
+						top = clamp(
+							top,
+							lineHeight + 12, // line height + padding for single line
+							this.currentCell.layoutInfo.editorHeight - lineHeight + this.currentCell.layoutInfo.statusBarHeight
+						);
+					}
+				}
+
+				this._executionOrderLabel.style.top = `${top}px`;
+			}
 		}
 	}
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

To make the execution count sticky, in this PR we manually adjust the top of the execution count label element on notebook scroll.


https://github.com/user-attachments/assets/801a7c60-0158-4320-862f-0e55c91e2237


The main challenge here is it flickers when the notebook sticky scroll disappears as it will trigger layouts in two different animation frames: the sticky scroll element disappears in current frame and the notebook list view layouts in next frame, this leads to a misalignment of the execution count label briefly, which is visually annoying.

Thus in this PR we try to do these two layouts at the same time.