### PR TITLE
Hide unmodified cells in nb diff view

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/diff/diffComponents.ts
+++ b/src/vs/workbench/contrib/notebook/browser/diff/diffComponents.ts
@@ -239,6 +239,8 @@ abstract class AbstractElementRenderer extends Disposable {
 	protected readonly _outputLocalDisposable = this._register(new DisposableStore());
 	protected _ignoreMetadata: boolean = false;
 	protected _ignoreOutputs: boolean = false;
+	protected _cellHeaderContainer!: HTMLElement;
+	protected _cellHeader!: PropertyHeader;
 	protected _metadataHeaderContainer!: HTMLElement;
 	protected _metadataHeader!: PropertyHeader;
 	protected _metadataInfoContainer!: HTMLElement;
@@ -321,6 +323,9 @@ abstract class AbstractElementRenderer extends Disposable {
 
 		this.styleContainer(this._diffEditorContainer);
 		this.updateSourceEditor();
+		if (this.cell.modified) {
+			this._register(this.cell.modified.textModel.onDidChangeContent(() => this._cellHeader.refresh()));
+		}
 
 		this._ignoreMetadata = this.configurationService.getValue('notebook.diff.ignoreMetadata');
 		if (this._ignoreMetadata) {
@@ -828,6 +833,7 @@ abstract class SingleSideDiffElement extends AbstractElementRenderer {
 	_disposeMetadata() {
 		this.cell.metadataStatusHeight = 0;
 		this.cell.metadataHeight = 0;
+		this.templateData.cellHeaderContainer.style.display = 'none';
 		this.templateData.metadataHeaderContainer.style.display = 'none';
 		this.templateData.metadataInfoContainer.style.display = 'none';
 		this._metadataEditor = undefined;
@@ -1221,7 +1227,6 @@ export class ModifiedElement extends AbstractElementRenderer {
 	private _editor?: DiffEditorWidget;
 	private _editorViewStateChanged: boolean;
 	private _editorContainer!: HTMLElement;
-	private _inputToolbarContainer!: HTMLElement;
 	protected _toolbar!: ToolBar;
 	protected _menu!: IMenu;
 
@@ -1491,63 +1496,100 @@ export class ModifiedElement extends AbstractElementRenderer {
 	}
 
 	updateSourceEditor(): void {
+		this._cellHeaderContainer = this.templateData.cellHeaderContainer;
+		this._cellHeaderContainer.style.display = 'flex';
+		this._cellHeaderContainer.innerText = '';
 		const modifiedCell = this.cell.modified;
-		const lineCount = modifiedCell.textModel.textBuffer.getLineCount();
-		const lineHeight = this.notebookEditor.getLayoutInfo().fontInfo.lineHeight || 17;
-
-		const editorHeight = this.cell.layoutInfo.editorHeight !== 0 ? this.cell.layoutInfo.editorHeight : lineCount * lineHeight + fixedEditorPadding.top + fixedEditorPadding.bottom;
 		this._editorContainer = this.templateData.editorContainer;
-		this._editor = this.templateData.sourceEditor;
-
 		this._editorContainer.classList.add('diff');
 
-		this._editor.layout({
-			width: this.notebookEditor.getLayoutInfo().width - 2 * DIFF_CELL_MARGIN,
-			height: editorHeight
-		});
-
-		this._editorContainer.style.height = `${editorHeight}px`;
-
-		this._register(this._editor.onDidContentSizeChange((e) => {
-			if (e.contentHeightChanged && this.cell.layoutInfo.editorHeight !== e.contentHeight) {
-				this.cell.editorHeight = e.contentHeight;
+		const renderSourceEditor = () => {
+			if (this.cell.cellFoldingState === PropertyFoldingState.Collapsed) {
+				this._editorContainer.style.display = 'none';
+				this.cell.editorHeight = 0;
+				return;
 			}
-		}));
 
-		this._initializeSourceDiffEditor();
-		const scopedContextKeyService = this.contextKeyService.createScoped(this.templateData.inputToolbarContainer);
+			const lineCount = modifiedCell.textModel.textBuffer.getLineCount();
+			const lineHeight = this.notebookEditor.getLayoutInfo().fontInfo.lineHeight || 17;
+			const editorHeight = this.cell.layoutInfo.editorHeight !== 0 ? this.cell.layoutInfo.editorHeight : (lineCount * lineHeight) + fixedEditorPadding.top + fixedEditorPadding.bottom;
+
+			this._editorContainer.style.height = `${editorHeight}px`;
+			this._editorContainer.style.display = 'block';
+
+			if (this._editor) {
+				const contentHeight = this._editor.getContentHeight();
+				if (contentHeight >= 0) {
+					this.cell.editorHeight = contentHeight;
+				}
+				return;
+			}
+
+			this._editor = this.templateData.sourceEditor;
+			this._editor.layout({
+				width: this.notebookEditor.getLayoutInfo().width - 2 * DIFF_CELL_MARGIN,
+				height: editorHeight
+			});
+			this._register(this._editor.onDidContentSizeChange((e) => {
+				if (this.cell.cellFoldingState === PropertyFoldingState.Expanded && e.contentHeightChanged && this.cell.layoutInfo.editorHeight !== e.contentHeight) {
+					this.cell.editorHeight = e.contentHeight;
+				}
+			}));
+			this._initializeSourceDiffEditor();
+		};
+
+		this._cellHeader = this._register(this.instantiationService.createInstance(
+			PropertyHeader,
+			this.cell,
+			this._cellHeaderContainer,
+			this.notebookEditor,
+			{
+				updateInfoRendering: () => renderSourceEditor(),
+				checkIfModified: (cell) => {
+					return cell.modified?.textModel.getValue() !== cell.original?.textModel.getValue() ? { reason: undefined } : false;
+				},
+				getFoldingState: (cell) => cell.cellFoldingState,
+				updateFoldingState: (cell, state) => cell.cellFoldingState = state,
+				unChangedLabel: 'Cell',
+				changedLabel: 'Cell changed',
+				prefix: 'cell',
+				menuId: MenuId.NotebookDiffCellInputTitle
+			}
+		));
+		this._cellHeader.buildHeader();
+		renderSourceEditor();
+
+		const scopedContextKeyService = this.contextKeyService.createScoped(this._cellHeaderContainer);
 		this._register(scopedContextKeyService);
 		const inputChanged = NOTEBOOK_DIFF_CELL_INPUT.bindTo(scopedContextKeyService);
+		inputChanged.set(this.cell.modified.textModel.getValue() !== this.cell.original.textModel.getValue());
 
-		this._inputToolbarContainer = this.templateData.inputToolbarContainer;
 		this._toolbar = this.templateData.toolbar;
 
 		this._toolbar.context = {
 			cell: this.cell
 		};
 
-		if (this.cell.modified.textModel.getValue() !== this.cell.original.textModel.getValue()) {
-			this._inputToolbarContainer.style.display = 'block';
-			inputChanged.set(true);
-		} else {
-			this._inputToolbarContainer.style.display = 'none';
-			inputChanged.set(false);
-		}
-
-		this._register(this.cell.modified.textModel.onDidChangeContent(() => {
-			if (this.cell.modified.textModel.getValue() !== this.cell.original.textModel.getValue()) {
-				this._inputToolbarContainer.style.display = 'block';
-				inputChanged.set(true);
-			} else {
-				this._inputToolbarContainer.style.display = 'none';
-				inputChanged.set(false);
-			}
-		}));
-
-		const menu = this.menuService.getMenuActions(MenuId.NotebookDiffCellInputTitle, scopedContextKeyService, { shouldForwardArgs: true });
 		const actions: IAction[] = [];
-		createAndFillInActionBarActions(menu, actions);
-		this._toolbar.setActions(actions);
+
+		const refreshToolbar = () => {
+			const hasChanges = this.cell.modified.textModel.getValue() !== this.cell.original.textModel.getValue();
+			inputChanged.set(hasChanges);
+
+			if (!actions.length) {
+				const menu = this.menuService.getMenuActions(MenuId.NotebookDiffCellInputTitle, scopedContextKeyService, { shouldForwardArgs: true });
+				createAndFillInActionBarActions(menu, actions);
+			}
+
+			if (hasChanges) {
+				this._toolbar.setActions(actions);
+			} else {
+				this._toolbar.setActions([]);
+			}
+		};
+
+		this._register(this.cell.modified.textModel.onDidChangeContent(() => refreshToolbar()));
+		refreshToolbar();
 	}
 
 	private async _initializeSourceDiffEditor() {
@@ -1597,17 +1639,17 @@ export class ModifiedElement extends AbstractElementRenderer {
 
 	layout(state: IDiffElementLayoutState) {
 		DOM.scheduleAtNextAnimationFrame(DOM.getWindow(this._diffEditorContainer), () => {
-			if (state.editorHeight) {
+			if (state.editorHeight && this._editor) {
 				this._editorContainer.style.height = `${this.cell.layoutInfo.editorHeight}px`;
-				this._editor!.layout({
+				this._editor.layout({
 					width: this._editor!.getViewWidth(),
 					height: this.cell.layoutInfo.editorHeight
 				});
 			}
 
-			if (state.outerWidth) {
+			if (state.outerWidth && this._editor) {
 				this._editorContainer.style.height = `${this.cell.layoutInfo.editorHeight}px`;
-				this._editor!.layout();
+				this._editor.layout();
 			}
 
 			if (state.metadataHeight || state.outerWidth) {

--- a/src/vs/workbench/contrib/notebook/browser/diff/diffElementViewModel.ts
+++ b/src/vs/workbench/contrib/notebook/browser/diff/diffElementViewModel.ts
@@ -34,6 +34,7 @@ interface ILayoutInfoDelta extends ILayoutInfoDelta0 {
 }
 
 export abstract class DiffElementViewModelBase extends Disposable {
+	public cellFoldingState: PropertyFoldingState;
 	public metadataFoldingState: PropertyFoldingState;
 	public outputFoldingState: PropertyFoldingState;
 	protected _layoutInfoEmitter = this._register(new Emitter<CellDiffViewModelLayoutChangeEvent>());
@@ -132,21 +133,24 @@ export abstract class DiffElementViewModelBase extends Disposable {
 	) {
 		super();
 		const editorHeight = this._estimateEditorHeight(initData.fontInfo);
+		const cellStatusHeight = 25;
 		this._layoutInfo = {
 			width: 0,
 			editorHeight: editorHeight,
 			editorMargin: 0,
 			metadataHeight: 0,
+			cellStatusHeight,
 			metadataStatusHeight: 25,
 			rawOutputHeight: 0,
 			outputTotalHeight: 0,
 			outputStatusHeight: 25,
 			outputMetadataHeight: 0,
 			bodyMargin: 32,
-			totalHeight: 82 + editorHeight,
+			totalHeight: 82 + cellStatusHeight + editorHeight,
 			layoutState: CellLayoutState.Uninitialized
 		};
 
+		this.cellFoldingState = modified?.textModel?.getValue() !== original?.textModel?.getValue() ? PropertyFoldingState.Expanded : PropertyFoldingState.Collapsed;
 		this.metadataFoldingState = PropertyFoldingState.Collapsed;
 		this.outputFoldingState = PropertyFoldingState.Collapsed;
 
@@ -185,6 +189,7 @@ export abstract class DiffElementViewModelBase extends Disposable {
 		const editorHeight = delta.editorHeight !== undefined ? delta.editorHeight : this._layoutInfo.editorHeight;
 		const editorMargin = delta.editorMargin !== undefined ? delta.editorMargin : this._layoutInfo.editorMargin;
 		const metadataHeight = delta.metadataHeight !== undefined ? delta.metadataHeight : this._layoutInfo.metadataHeight;
+		const cellStatusHeight = delta.cellStatusHeight !== undefined ? delta.cellStatusHeight : this._layoutInfo.cellStatusHeight;
 		const metadataStatusHeight = delta.metadataStatusHeight !== undefined ? delta.metadataStatusHeight : this._layoutInfo.metadataStatusHeight;
 		const rawOutputHeight = delta.rawOutputHeight !== undefined ? delta.rawOutputHeight : this._layoutInfo.rawOutputHeight;
 		const outputStatusHeight = delta.outputStatusHeight !== undefined ? delta.outputStatusHeight : this._layoutInfo.outputStatusHeight;
@@ -194,6 +199,7 @@ export abstract class DiffElementViewModelBase extends Disposable {
 
 		const totalHeight = editorHeight
 			+ editorMargin
+			+ cellStatusHeight
 			+ metadataHeight
 			+ metadataStatusHeight
 			+ outputHeight
@@ -205,6 +211,7 @@ export abstract class DiffElementViewModelBase extends Disposable {
 			editorHeight: editorHeight,
 			editorMargin: editorMargin,
 			metadataHeight: metadataHeight,
+			cellStatusHeight,
 			metadataStatusHeight: metadataStatusHeight,
 			outputTotalHeight: outputHeight,
 			outputStatusHeight: outputStatusHeight,
@@ -236,6 +243,11 @@ export abstract class DiffElementViewModelBase extends Disposable {
 
 		if (newLayout.metadataHeight !== this._layoutInfo.metadataHeight) {
 			changeEvent.metadataHeight = true;
+			somethingChanged = true;
+		}
+
+		if (newLayout.cellStatusHeight !== this._layoutInfo.cellStatusHeight) {
+			changeEvent.cellStatusHeight = true;
 			somethingChanged = true;
 		}
 
@@ -288,6 +300,7 @@ export abstract class DiffElementViewModelBase extends Disposable {
 		const totalHeight = editorHeight
 			+ this._layoutInfo.editorMargin
 			+ this._layoutInfo.metadataHeight
+			+ this._layoutInfo.cellStatusHeight
 			+ this._layoutInfo.metadataStatusHeight
 			+ this._layoutInfo.outputTotalHeight
 			+ this._layoutInfo.outputStatusHeight
@@ -410,6 +423,7 @@ export class SideBySideDiffElementViewModel extends DiffElementViewModelBase {
 		this.modified = modified;
 		this.type = type;
 
+		this.cellFoldingState = modified.textModel.getValue() !== original.textModel.getValue() ? PropertyFoldingState.Expanded : PropertyFoldingState.Collapsed;
 		this.metadataFoldingState = PropertyFoldingState.Collapsed;
 		this.outputFoldingState = PropertyFoldingState.Collapsed;
 
@@ -491,6 +505,7 @@ export class SideBySideDiffElementViewModel extends DiffElementViewModelBase {
 		return this._layoutInfo.editorHeight
 			+ this._layoutInfo.editorMargin
 			+ this._layoutInfo.metadataHeight
+			+ this._layoutInfo.cellStatusHeight
 			+ this._layoutInfo.metadataStatusHeight
 			+ this._layoutInfo.outputStatusHeight
 			+ this._layoutInfo.bodyMargin / 2
@@ -599,6 +614,7 @@ export class SingleSideDiffElementViewModel extends DiffElementViewModelBase {
 		return this._layoutInfo.editorHeight
 			+ this._layoutInfo.editorMargin
 			+ this._layoutInfo.metadataHeight
+			+ this._layoutInfo.cellStatusHeight
 			+ this._layoutInfo.metadataStatusHeight
 			+ this._layoutInfo.outputStatusHeight
 			+ this._layoutInfo.bodyMargin / 2

--- a/src/vs/workbench/contrib/notebook/browser/diff/notebookDiff.css
+++ b/src/vs/workbench/contrib/notebook/browser/diff/notebookDiff.css
@@ -99,6 +99,7 @@
 	width: 50%;
 }
 
+.notebook-text-diff-editor .cell-diff-editor-container .cell-header-container,
 .notebook-text-diff-editor .cell-diff-editor-container .output-header-container,
 .notebook-text-diff-editor .cell-diff-editor-container .metadata-header-container {
 	display: flex;
@@ -107,6 +108,7 @@
 	cursor: default;
 }
 
+.notebook-text-diff-editor .cell-diff-editor-container .cell-header-container .property-folding-indicator .codicon,
 .notebook-text-diff-editor .cell-diff-editor-container .output-header-container .property-folding-indicator .codicon,
 .notebook-text-diff-editor .cell-diff-editor-container .metadata-header-container .property-folding-indicator .codicon {
 	visibility: visible;
@@ -114,6 +116,7 @@
 	cursor: pointer;
 }
 
+.notebook-text-diff-editor .cell-diff-editor-container .cell-header-container,
 .notebook-text-diff-editor .cell-diff-editor-container .output-header-container,
 .notebook-text-diff-editor .cell-diff-editor-container .metadata-header-container {
 	display: flex;
@@ -121,22 +124,26 @@
 	align-items: center;
 }
 
+.notebook-text-diff-editor .cell-diff-editor-container .cell-header-container .property-toolbar,
 .notebook-text-diff-editor .cell-diff-editor-container .output-header-container .property-toolbar,
 .notebook-text-diff-editor .cell-diff-editor-container .metadata-header-container .property-toolbar {
 	margin-left: auto;
 }
 
+.notebook-text-diff-editor .cell-diff-editor-container .cell-header-container .property-status,
 .notebook-text-diff-editor .cell-diff-editor-container .output-header-container .property-status,
 .notebook-text-diff-editor .cell-diff-editor-container .metadata-header-container .property-status {
 	font-size: 12px;
 }
 
+.notebook-text-diff-editor .cell-diff-editor-container .cell-header-container .property-status span,
 .notebook-text-diff-editor .cell-diff-editor-container .output-header-container .property-status span,
 .notebook-text-diff-editor .cell-diff-editor-container .metadata-header-container .property-status span {
 	margin: 0 0 0 8px;
 	line-height: 21px;
 }
 
+.notebook-text-diff-editor .cell-diff-editor-container .cell-header-container .property-status span.property-description,
 .notebook-text-diff-editor .cell-diff-editor-container .output-header-container .property-status span.property-description,
 .notebook-text-diff-editor .cell-diff-editor-container .metadata-header-container .property-status span.property-description {
 	font-style: italic;

--- a/src/vs/workbench/contrib/notebook/browser/diff/notebookDiffEditor.ts
+++ b/src/vs/workbench/contrib/notebook/browser/diff/notebookDiffEditor.ts
@@ -334,6 +334,9 @@ export class NotebookTextDiffEditor extends EditorPane implements INotebookTextD
 
 		this._register(this._list.onMouseUp(e => {
 			if (e.element) {
+				if (typeof e.index === 'number') {
+					this._list.setFocus([e.index]);
+				}
 				this._onMouseUp.fire({ event: e.browserEvent, target: e.element });
 			}
 		}));

--- a/src/vs/workbench/contrib/notebook/browser/diff/notebookDiffEditorBrowser.ts
+++ b/src/vs/workbench/contrib/notebook/browser/diff/notebookDiffEditorBrowser.ts
@@ -72,6 +72,7 @@ export interface CellDiffSingleSideRenderTemplate extends CellDiffCommonRenderTe
 	readonly diffEditorContainer: HTMLElement;
 	readonly diagonalFill: HTMLElement;
 	readonly elementDisposables: DisposableStore;
+	readonly cellHeaderContainer: HTMLElement;
 	readonly sourceEditor: CodeEditorWidget;
 	readonly metadataHeaderContainer: HTMLElement;
 	readonly metadataInfoContainer: HTMLElement;
@@ -85,6 +86,7 @@ export interface CellDiffSideBySideRenderTemplate extends CellDiffCommonRenderTe
 	readonly body: HTMLElement;
 	readonly diffEditorContainer: HTMLElement;
 	readonly elementDisposables: DisposableStore;
+	readonly cellHeaderContainer: HTMLElement;
 	readonly sourceEditor: DiffEditorWidget;
 	readonly editorContainer: HTMLElement;
 	readonly inputToolbarContainer: HTMLElement;
@@ -101,6 +103,7 @@ export interface IDiffElementLayoutInfo {
 	editorHeight: number;
 	editorMargin: number;
 	metadataHeight: number;
+	cellStatusHeight: number;
 	metadataStatusHeight: number;
 	rawOutputHeight: number;
 	outputMetadataHeight: number;

--- a/src/vs/workbench/contrib/notebook/browser/diff/notebookDiffList.ts
+++ b/src/vs/workbench/contrib/notebook/browser/diff/notebookDiffList.ts
@@ -82,6 +82,7 @@ export class CellDiffSingleSideRenderer implements IListRenderer<SingleSideDiffE
 
 		const diagonalFill = DOM.append(body, DOM.$('.diagonal-fill'));
 
+		const cellHeaderContainer = DOM.append(diffEditorContainer, DOM.$('.cell-header-container'));
 		const sourceContainer = DOM.append(diffEditorContainer, DOM.$('.source-container'));
 		const editor = this._buildSourceEditor(sourceContainer);
 
@@ -102,6 +103,7 @@ export class CellDiffSingleSideRenderer implements IListRenderer<SingleSideDiffE
 			container,
 			diffEditorContainer,
 			diagonalFill,
+			cellHeaderContainer,
 			sourceEditor: editor,
 			metadataHeaderContainer,
 			metadataInfoContainer,
@@ -183,6 +185,7 @@ export class CellDiffSideBySideRenderer implements IListRenderer<SideBySideDiffE
 		const diffEditorContainer = DOM.$('.cell-diff-editor-container');
 		DOM.append(body, diffEditorContainer);
 
+		const cellHeaderContainer = DOM.append(diffEditorContainer, DOM.$('.cell-header-container'));
 		const sourceContainer = DOM.append(diffEditorContainer, DOM.$('.source-container'));
 		const { editor, editorContainer } = this._buildSourceEditor(sourceContainer);
 
@@ -216,6 +219,7 @@ export class CellDiffSideBySideRenderer implements IListRenderer<SideBySideDiffE
 			body,
 			container,
 			diffEditorContainer,
+			cellHeaderContainer,
 			sourceEditor: editor,
 			editorContainer,
 			inputToolbarContainer,


### PR DESCRIPTION
Fixes #174152

Unmodified cells are now hidden/collapsed by default (just as done with outputs and metadata).


![Screenshot 2024-08-06 at 14 45 15](https://github.com/user-attachments/assets/16b1e43e-6b01-4ccd-9b80-04632acc13a0)
