### PR TITLE
fix: disable core text font matching on macOS

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -324,8 +324,9 @@ function configureCommandlineSwitchesSync(cliArgs) {
 	app.commandLine.appendSwitch('disable-features', featuresToDisable);
 
 	// Blink features to configure.
+	// `FontMatchingCTMigration` - Siwtch font matching on macOS to Appkit (Refs https://github.com/microsoft/vscode/issues/224496#issuecomment-2270418470).
 	const blinkFeaturesToDisable =
-		`${app.commandLine.getSwitchValue('disable-blink-features')}`;
+		`FontMatchingCTMigration,${app.commandLine.getSwitchValue('disable-blink-features')}`;
 	app.commandLine.appendSwitch('disable-blink-features', blinkFeaturesToDisable);
 
 	// Support JS Flags


### PR DESCRIPTION
Refs https://github.com/microsoft/vscode/issues/224496