### PR TITLE
respect `waitOnExit` behavior

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
@@ -1160,7 +1160,7 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 	}
 
 	override dispose(reason?: TerminalExitReason): void {
-		if (this.shellLaunchConfig.type === 'Task' && reason === TerminalExitReason.Process && this._exitCode !== 0) {
+		if (this.shellLaunchConfig.type === 'Task' && reason === TerminalExitReason.Process && this._exitCode !== 0 && !this.shellLaunchConfig.waitOnExit) {
 			return;
 		}
 		if (this.isDisposed) {


### PR DESCRIPTION
If it's a `waitOnExit` terminal, no need to do this new behavior, respect the old behavior where a key press closes the terminal. 

follow up to https://github.com/microsoft/vscode/issues/224418#issuecomment-2271293199