### PR TITLE
Fix arguments for create `tsconfig`/`jsconfig`

### DIFF
--- a/extensions/typescript-language-features/src/ui/intellisenseStatus.ts
+++ b/extensions/typescript-language-features/src/ui/intellisenseStatus.ts
@@ -43,6 +43,8 @@ namespace IntellisenseState {
 	export type State = typeof None | Pending | Resolved | typeof SyntaxOnly;
 }
 
+type CreateOrOpenConfigCommandArgs = [root: vscode.Uri, projectType: ProjectType];
+
 export class IntellisenseStatus extends Disposable {
 
 	public readonly openOpenConfigCommandId = '_typescript.openConfig';
@@ -62,7 +64,7 @@ export class IntellisenseStatus extends Disposable {
 
 		commandManager.register({
 			id: this.openOpenConfigCommandId,
-			execute: async (root: vscode.Uri, projectType: ProjectType) => {
+			execute: async (...[root, projectType]: CreateOrOpenConfigCommandArgs) => {
 				if (this._state.type === IntellisenseState.Type.Resolved) {
 					await openProjectConfigOrPromptToCreate(projectType, this._client, root, this._state.configFile);
 				} else if (this._state.type === IntellisenseState.Type.Pending) {
@@ -72,7 +74,7 @@ export class IntellisenseStatus extends Disposable {
 		});
 		commandManager.register({
 			id: this.createOrOpenConfigCommandId,
-			execute: async (root: vscode.Uri, projectType: ProjectType) => {
+			execute: async (...[root, projectType]: CreateOrOpenConfigCommandArgs) => {
 				await openOrCreateConfig(this._client.apiVersion, projectType, root, this._client.configuration);
 			},
 		});
@@ -182,7 +184,7 @@ export class IntellisenseStatus extends Disposable {
 						title: this._state.projectType === ProjectType.TypeScript
 							? vscode.l10n.t("Configure tsconfig")
 							: vscode.l10n.t("Configure jsconfig"),
-						arguments: [rootPath],
+						arguments: [rootPath, this._state.projectType] satisfies CreateOrOpenConfigCommandArgs,
 					};
 				} else {
 					statusItem.text = vscode.workspace.asRelativePath(this._state.configFile);
@@ -190,7 +192,7 @@ export class IntellisenseStatus extends Disposable {
 					statusItem.command = {
 						command: this.openOpenConfigCommandId,
 						title: vscode.l10n.t("Open config file"),
-						arguments: [rootPath],
+						arguments: [rootPath, this._state.projectType] satisfies CreateOrOpenConfigCommandArgs,
 					};
 				}
 				break;


### PR DESCRIPTION
Fixes #224989

Adds typings too to prevent this again

