### PR TITLE
[typescript-language-features] fix diagnostics telemetry property name

### DIFF
--- a/extensions/typescript-language-features/src/typescriptServiceClient.ts
+++ b/extensions/typescript-language-features/src/typescriptServiceClient.ts
@@ -1068,7 +1068,7 @@ export default class TypeScriptServiceClient extends Disposable implements IType
 							const resource = this.toResource(fileData.file);
 							return {
 								...fileData,
-								lineCount: this.bufferSyncSupport.lineCount(resource),
+								fileLineCount: this.bufferSyncSupport.lineCount(resource),
 							};
 						})
 					);


### PR DESCRIPTION
Fixes a bug in #220127 where telemetry wasn't including the file line count due to wrong property name.