### PR TITLE
ELECTRON_RUN_AS_NODE is removed too late before bootstrap-amd.js redefines 'fs' (fix #225139)

### DIFF
--- a/src/server-cli.js
+++ b/src/server-cli.js
@@ -6,6 +6,10 @@
 // @ts-check
 'use strict';
 
+// Keep bootstrap-amd.js from redefining 'fs'.
+// TODO@esm this needs to be revisited in ESM
+delete process.env['ELECTRON_RUN_AS_NODE'];
+
 // ESM-comment-begin
 const path = require('path');
 const bootstrapNode = require('./bootstrap-node');
@@ -25,9 +29,6 @@ const product = require('./bootstrap-meta').product;
 // ESM-uncomment-end
 
 async function start() {
-
-	// Keep bootstrap-amd.js from redefining 'fs'.
-	delete process.env['ELECTRON_RUN_AS_NODE'];
 
 	// NLS
 	const nlsConfiguration = await resolveNLSConfiguration({ userLocale: 'en', osLocale: 'en', commit: product.commit, userDataPath: '', nlsMetadataPath: __dirname });

--- a/src/server-main.js
+++ b/src/server-main.js
@@ -11,6 +11,10 @@
  * @import { IServerAPI } from './vs/server/node/remoteExtensionHostAgentServer'
  */
 
+// Keep bootstrap-amd.js from redefining 'fs'.
+// TODO@esm this needs to be revisited in ESM
+delete process.env['ELECTRON_RUN_AS_NODE'];
+
 // ESM-comment-begin
 const path = require('path');
 const http = require('http');
@@ -279,7 +283,6 @@ async function findFreePort(host, start, end) {
  */
 function loadCode(nlsConfiguration) {
 	return new Promise((resolve, reject) => {
-		delete process.env['ELECTRON_RUN_AS_NODE']; // Keep bootstrap-amd.js from redefining 'fs'.
 
 		/** @type {INLSConfiguration} */
 		process.env['VSCODE_NLS_CONFIG'] = JSON.stringify(nlsConfiguration); // required for `bootstrap-amd` to pick up NLS messages


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
