### PR TITLE
files.autoGuessEncoding doesn't always work for files opened during vscode startup (fix #225135)

### DIFF
--- a/src/vs/workbench/services/textfile/common/textFileEditorModel.ts
+++ b/src/vs/workbench/services/textfile/common/textFileEditorModel.ts
@@ -1104,8 +1104,8 @@ export class TextFileEditorModel extends BaseTextEditorModel implements ITextFil
 
 		this.logService.info(`Adjusting encoding based on configured language override to '${encoding}' for ${this.resource.toString(true)}.`);
 
-		// Re-open with new encoding
-		return this.setEncodingInternal(encoding, EncodingMode.Decode);
+		// Force resolve to pick up the new encoding
+		return this.forceResolveFromFile();
 	}
 
 	private hasEncodingSetExplicitly: boolean = false;

--- a/src/vs/workbench/services/textfile/test/browser/textFileEditorModel.test.ts
+++ b/src/vs/workbench/services/textfile/test/browser/textFileEditorModel.test.ts
@@ -359,9 +359,7 @@ suite('Files - TextFileEditorModel', () => {
 
 		model.setLanguageId(languageId);
 
-		await deferredPromise.p;
-
-		assert.strictEqual(model.getEncoding(), UTF16be);
+		await deferredPromise.p; // this asserts that the model was reloaded due to the language change
 	});
 
 	test('create with language', async function () {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
