### PR TITLE
Remove dummy value in favor of empty collection

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/media/GitTabExpansion.psm1
+++ b/src/vs/workbench/contrib/terminal/browser/media/GitTabExpansion.psm1
@@ -546,9 +546,8 @@ function GitTabExpansionInternal($lastBlock, $GitStatus = $null) {
 
 		# Handles git checkout|switch <ref>
 		"^(?:checkout|switch).* (?<ref>\S*)$" {
-			# Return a dummy value to prevent file path completion from happening
 			if ($lastBlock -match "-b\s[^\s]*$") {
-				'~'
+				$null # Force zero results
 			} else {
 				[System.Management.Automation.CompletionResult]::new('.', '.', 'ParameterName', "Discard changes in working directory")
 				gitBranches $matches['ref'] $true | ConvertTo-VscodeCompletion -Type 'branch'
@@ -653,7 +652,12 @@ Microsoft.PowerShell.Core\Register-ArgumentCompleter -CommandName $cmdNames -Nat
 	$textToComplete = $commandAst.ToString().PadRight($padLength, ' ').Substring(0, $padLength)
 
 	WriteTabExpLog "Expand: command: '$($commandAst.Extent.Text)', padded: '$textToComplete', padlen: $padLength"
-	Expand-GitCommand $textToComplete
+	$result = Expand-GitCommand $textToComplete
+	if ($null -eq $result) {
+		,@()
+	} else {
+		$result
+	}
 }
 
 

--- a/src/vs/workbench/contrib/terminal/browser/media/shellIntegration.ps1
+++ b/src/vs/workbench/contrib/terminal/browser/media/shellIntegration.ps1
@@ -369,8 +369,19 @@ function Send-Completions {
 		}
 
 		# Get completions using TabExpansion2
-		$completions = TabExpansion2 -inputScript $completionPrefix -cursorColumn $cursorIndex
-		if ($null -ne $completions.CompletionMatches) {
+		$completions = $null
+		try
+		{
+			$completions = TabExpansion2 -inputScript $completionPrefix -cursorColumn $cursorIndex
+		}
+		catch
+		{
+			# TabExpansion2 may throw when there are no completions, in this case return an empty
+			# list to prevent falling back to file path completions
+		}
+		if ($null -eq $completions -or $null -eq $completions.CompletionMatches) {
+			$result += ";0;$($completionPrefix.Length);$($completionPrefix.Length);[]"
+		} else {
 			$result += ";$($completions.ReplacementIndex);$($completions.ReplacementLength + $prefixCursorDelta);$($cursorIndex - $prefixCursorDelta);"
 			$json = [System.Collections.ArrayList]@($completions.CompletionMatches)
 			# Relative directory completions


### PR DESCRIPTION
This is the right way to handle zero completions, instead of using a dummy ~ value
