### PR TITLE
Ability to use MSAL in the Desktop

### DIFF
--- a/extensions/microsoft-authentication/extension-browser.webpack.config.js
+++ b/extensions/microsoft-authentication/extension-browser.webpack.config.js
@@ -23,7 +23,8 @@ module.exports = withBrowserDefaults({
 	resolve: {
 		alias: {
 			'./node/authServer': path.resolve(__dirname, 'src/browser/authServer'),
-			'./node/buffer': path.resolve(__dirname, 'src/browser/buffer')
+			'./node/buffer': path.resolve(__dirname, 'src/browser/buffer'),
+			'./node/authProvider': path.resolve(__dirname, 'src/browser/authProvider'),
 		}
 	}
 });

--- a/extensions/microsoft-authentication/package.json
+++ b/extensions/microsoft-authentication/package.json
@@ -95,6 +95,16 @@
             ]
           }
         }
+      },
+      {
+        "title": "Microsoft",
+        "properties": {
+          "microsoft.useMsal": {
+            "type": "boolean",
+            "default": false,
+            "description": "%useMsal.description%"
+          }
+        }
       }
     ]
   },
@@ -117,6 +127,7 @@
   },
   "dependencies": {
     "@azure/ms-rest-azure-env": "^2.0.0",
+    "@azure/msal-node": "^2.12.0",
     "@vscode/extension-telemetry": "^0.9.0"
   },
   "repository": {

--- a/extensions/microsoft-authentication/package.nls.json
+++ b/extensions/microsoft-authentication/package.nls.json
@@ -3,6 +3,7 @@
 	"description": "Microsoft authentication provider",
 	"signIn": "Sign In",
 	"signOut": "Sign Out",
+	"useMsal.description": "Use the Microsoft Authentication Library (MSAL) to sign in with a Microsoft account.",
 	"microsoft-sovereign-cloud.environment.description": {
 		"message": "The Sovereign Cloud to use for authentication. If you select `custom`, you must also set the `#microsoft-sovereign-cloud.customEnvironment#` setting.",
 		"comment": [

--- a/extensions/microsoft-authentication/src/UriEventHandler.ts
+++ b/extensions/microsoft-authentication/src/UriEventHandler.ts
@@ -6,7 +6,14 @@
 import * as vscode from 'vscode';
 
 export class UriEventHandler extends vscode.EventEmitter<vscode.Uri> implements vscode.UriHandler {
-	public handleUri(uri: vscode.Uri) {
+	private _disposable = vscode.window.registerUriHandler(this);
+
+	handleUri(uri: vscode.Uri) {
 		this.fire(uri);
+	}
+
+	override dispose(): void {
+		super.dispose();
+		this._disposable.dispose();
 	}
 }

--- a/extensions/microsoft-authentication/src/browser/authProvider.ts
+++ b/extensions/microsoft-authentication/src/browser/authProvider.ts
@@ -1,0 +1,29 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { AuthenticationProvider, AuthenticationProviderAuthenticationSessionsChangeEvent, AuthenticationSession, EventEmitter } from 'vscode';
+
+export class MsalAuthProvider implements AuthenticationProvider {
+	private _onDidChangeSessions = new EventEmitter<AuthenticationProviderAuthenticationSessionsChangeEvent>();
+	onDidChangeSessions = this._onDidChangeSessions.event;
+
+	initialize(): Thenable<void> {
+		throw new Error('Method not implemented.');
+	}
+
+	getSessions(): Thenable<AuthenticationSession[]> {
+		throw new Error('Method not implemented.');
+	}
+	createSession(): Thenable<AuthenticationSession> {
+		throw new Error('Method not implemented.');
+	}
+	removeSession(): Thenable<void> {
+		throw new Error('Method not implemented.');
+	}
+
+	dispose() {
+		this._onDidChangeSessions.dispose();
+	}
+}

--- a/extensions/microsoft-authentication/src/common/async.ts
+++ b/extensions/microsoft-authentication/src/common/async.ts
@@ -3,7 +3,12 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { CancellationError, CancellationToken, Disposable } from 'vscode';
+import { CancellationError, CancellationToken, Disposable, Event, EventEmitter } from 'vscode';
+
+/**
+ * Can be passed into the Delayed to defer using a microtask
+ */
+export const MicrotaskDelay = Symbol('MicrotaskDelay');
 
 export class SequencerByKey<TKey> {
 
@@ -79,4 +84,474 @@ export function raceTimeoutError<T>(promise: Promise<T>, timeout: number): Promi
 
 export function raceCancellationAndTimeoutError<T>(promise: Promise<T>, token: CancellationToken, timeout: number): Promise<T> {
 	return raceCancellationError(raceTimeoutError(promise, timeout), token);
+}
+
+interface ILimitedTaskFactory<T> {
+	factory: () => Promise<T>;
+	c: (value: T | Promise<T>) => void;
+	e: (error?: unknown) => void;
+}
+
+export interface ILimiter<T> {
+
+	readonly size: number;
+
+	queue(factory: () => Promise<T>): Promise<T>;
+
+	clear(): void;
+}
+
+/**
+ * A helper to queue N promises and run them all with a max degree of parallelism. The helper
+ * ensures that at any time no more than M promises are running at the same time.
+ */
+export class Limiter<T> implements ILimiter<T> {
+
+	private _size = 0;
+	private _isDisposed = false;
+	private runningPromises: number;
+	private readonly maxDegreeOfParalellism: number;
+	private readonly outstandingPromises: ILimitedTaskFactory<T>[];
+	private readonly _onDrained: EventEmitter<void>;
+
+	constructor(maxDegreeOfParalellism: number) {
+		this.maxDegreeOfParalellism = maxDegreeOfParalellism;
+		this.outstandingPromises = [];
+		this.runningPromises = 0;
+		this._onDrained = new EventEmitter<void>();
+	}
+
+	/**
+	 *
+	 * @returns A promise that resolved when all work is done (onDrained) or when
+	 * there is nothing to do
+	 */
+	whenIdle(): Promise<void> {
+		return this.size > 0
+			? toPromise(this.onDrained)
+			: Promise.resolve();
+	}
+
+	get onDrained(): Event<void> {
+		return this._onDrained.event;
+	}
+
+	get size(): number {
+		return this._size;
+	}
+
+	queue(factory: () => Promise<T>): Promise<T> {
+		if (this._isDisposed) {
+			throw new Error('Object has been disposed');
+		}
+		this._size++;
+
+		return new Promise<T>((c, e) => {
+			this.outstandingPromises.push({ factory, c, e });
+			this.consume();
+		});
+	}
+
+	private consume(): void {
+		while (this.outstandingPromises.length && this.runningPromises < this.maxDegreeOfParalellism) {
+			const iLimitedTask = this.outstandingPromises.shift()!;
+			this.runningPromises++;
+
+			const promise = iLimitedTask.factory();
+			promise.then(iLimitedTask.c, iLimitedTask.e);
+			promise.then(() => this.consumed(), () => this.consumed());
+		}
+	}
+
+	private consumed(): void {
+		if (this._isDisposed) {
+			return;
+		}
+		this.runningPromises--;
+		if (--this._size === 0) {
+			this._onDrained.fire();
+		}
+
+		if (this.outstandingPromises.length > 0) {
+			this.consume();
+		}
+	}
+
+	clear(): void {
+		if (this._isDisposed) {
+			throw new Error('Object has been disposed');
+		}
+		this.outstandingPromises.length = 0;
+		this._size = this.runningPromises;
+	}
+
+	dispose(): void {
+		this._isDisposed = true;
+		this.outstandingPromises.length = 0; // stop further processing
+		this._size = 0;
+		this._onDrained.dispose();
+	}
+}
+
+
+interface IScheduledLater extends Disposable {
+	isTriggered(): boolean;
+}
+
+const timeoutDeferred = (timeout: number, fn: () => void): IScheduledLater => {
+	let scheduled = true;
+	const handle = setTimeout(() => {
+		scheduled = false;
+		fn();
+	}, timeout);
+	return {
+		isTriggered: () => scheduled,
+		dispose: () => {
+			clearTimeout(handle);
+			scheduled = false;
+		},
+	};
+};
+
+const microtaskDeferred = (fn: () => void): IScheduledLater => {
+	let scheduled = true;
+	queueMicrotask(() => {
+		if (scheduled) {
+			scheduled = false;
+			fn();
+		}
+	});
+
+	return {
+		isTriggered: () => scheduled,
+		dispose: () => { scheduled = false; },
+	};
+};
+
+/**
+ * A helper to delay (debounce) execution of a task that is being requested often.
+ *
+ * Following the throttler, now imagine the mail man wants to optimize the number of
+ * trips proactively. The trip itself can be long, so he decides not to make the trip
+ * as soon as a letter is submitted. Instead he waits a while, in case more
+ * letters are submitted. After said waiting period, if no letters were submitted, he
+ * decides to make the trip. Imagine that N more letters were submitted after the first
+ * one, all within a short period of time between each other. Even though N+1
+ * submissions occurred, only 1 delivery was made.
+ *
+ * The delayer offers this behavior via the trigger() method, into which both the task
+ * to be executed and the waiting period (delay) must be passed in as arguments. Following
+ * the example:
+ *
+ * 		const delayer = new Delayer(WAITING_PERIOD);
+ * 		const letters = [];
+ *
+ * 		function letterReceived(l) {
+ * 			letters.push(l);
+ * 			delayer.trigger(() => { return makeTheTrip(); });
+ * 		}
+ */
+export class Delayer<T> implements Disposable {
+
+	private deferred: IScheduledLater | null;
+	private completionPromise: Promise<any> | null;
+	private doResolve: ((value?: any | Promise<any>) => void) | null;
+	private doReject: ((err: any) => void) | null;
+	private task: (() => T | Promise<T>) | null;
+
+	constructor(public defaultDelay: number | typeof MicrotaskDelay) {
+		this.deferred = null;
+		this.completionPromise = null;
+		this.doResolve = null;
+		this.doReject = null;
+		this.task = null;
+	}
+
+	trigger(task: () => T | Promise<T>, delay = this.defaultDelay): Promise<T> {
+		this.task = task;
+		this.cancelTimeout();
+
+		if (!this.completionPromise) {
+			this.completionPromise = new Promise((resolve, reject) => {
+				this.doResolve = resolve;
+				this.doReject = reject;
+			}).then(() => {
+				this.completionPromise = null;
+				this.doResolve = null;
+				if (this.task) {
+					const task = this.task;
+					this.task = null;
+					return task();
+				}
+				return undefined;
+			});
+		}
+
+		const fn = () => {
+			this.deferred = null;
+			this.doResolve?.(null);
+		};
+
+		this.deferred = delay === MicrotaskDelay ? microtaskDeferred(fn) : timeoutDeferred(delay, fn);
+
+		return this.completionPromise;
+	}
+
+	isTriggered(): boolean {
+		return !!this.deferred?.isTriggered();
+	}
+
+	cancel(): void {
+		this.cancelTimeout();
+
+		if (this.completionPromise) {
+			this.doReject?.(new CancellationError());
+			this.completionPromise = null;
+		}
+	}
+
+	private cancelTimeout(): void {
+		this.deferred?.dispose();
+		this.deferred = null;
+	}
+
+	dispose(): void {
+		this.cancel();
+	}
+}
+
+/**
+ * A helper to prevent accumulation of sequential async tasks.
+ *
+ * Imagine a mail man with the sole task of delivering letters. As soon as
+ * a letter submitted for delivery, he drives to the destination, delivers it
+ * and returns to his base. Imagine that during the trip, N more letters were submitted.
+ * When the mail man returns, he picks those N letters and delivers them all in a
+ * single trip. Even though N+1 submissions occurred, only 2 deliveries were made.
+ *
+ * The throttler implements this via the queue() method, by providing it a task
+ * factory. Following the example:
+ *
+ * 		const throttler = new Throttler();
+ * 		const letters = [];
+ *
+ * 		function deliver() {
+ * 			const lettersToDeliver = letters;
+ * 			letters = [];
+ * 			return makeTheTrip(lettersToDeliver);
+ * 		}
+ *
+ * 		function onLetterReceived(l) {
+ * 			letters.push(l);
+ * 			throttler.queue(deliver);
+ * 		}
+ */
+export class Throttler implements Disposable {
+
+	private activePromise: Promise<any> | null;
+	private queuedPromise: Promise<any> | null;
+	private queuedPromiseFactory: (() => Promise<any>) | null;
+
+	private isDisposed = false;
+
+	constructor() {
+		this.activePromise = null;
+		this.queuedPromise = null;
+		this.queuedPromiseFactory = null;
+	}
+
+	queue<T>(promiseFactory: () => Promise<T>): Promise<T> {
+		if (this.isDisposed) {
+			return Promise.reject(new Error('Throttler is disposed'));
+		}
+
+		if (this.activePromise) {
+			this.queuedPromiseFactory = promiseFactory;
+
+			if (!this.queuedPromise) {
+				const onComplete = () => {
+					this.queuedPromise = null;
+
+					if (this.isDisposed) {
+						return;
+					}
+
+					const result = this.queue(this.queuedPromiseFactory!);
+					this.queuedPromiseFactory = null;
+
+					return result;
+				};
+
+				this.queuedPromise = new Promise(resolve => {
+					this.activePromise!.then(onComplete, onComplete).then(resolve);
+				});
+			}
+
+			return new Promise((resolve, reject) => {
+				this.queuedPromise!.then(resolve, reject);
+			});
+		}
+
+		this.activePromise = promiseFactory();
+
+		return new Promise((resolve, reject) => {
+			this.activePromise!.then((result: T) => {
+				this.activePromise = null;
+				resolve(result);
+			}, (err: unknown) => {
+				this.activePromise = null;
+				reject(err);
+			});
+		});
+	}
+
+	dispose(): void {
+		this.isDisposed = true;
+	}
+}
+
+/**
+ * A helper to delay execution of a task that is being requested often, while
+ * preventing accumulation of consecutive executions, while the task runs.
+ *
+ * The mail man is clever and waits for a certain amount of time, before going
+ * out to deliver letters. While the mail man is going out, more letters arrive
+ * and can only be delivered once he is back. Once he is back the mail man will
+ * do one more trip to deliver the letters that have accumulated while he was out.
+ */
+export class ThrottledDelayer<T> {
+
+	private delayer: Delayer<Promise<T>>;
+	private throttler: Throttler;
+
+	constructor(defaultDelay: number) {
+		this.delayer = new Delayer(defaultDelay);
+		this.throttler = new Throttler();
+	}
+
+	trigger(promiseFactory: () => Promise<T>, delay?: number): Promise<T> {
+		return this.delayer.trigger(() => this.throttler.queue(promiseFactory), delay) as unknown as Promise<T>;
+	}
+
+	isTriggered(): boolean {
+		return this.delayer.isTriggered();
+	}
+
+	cancel(): void {
+		this.delayer.cancel();
+	}
+
+	dispose(): void {
+		this.delayer.dispose();
+		this.throttler.dispose();
+	}
+}
+
+/**
+ * A queue is handles one promise at a time and guarantees that at any time only one promise is executing.
+ */
+export class Queue<T> extends Limiter<T> {
+
+	constructor() {
+		super(1);
+	}
+}
+
+/**
+ * Given an event, returns another event which only fires once.
+ *
+ * @param event The event source for the new event.
+ */
+export function once<T>(event: Event<T>): Event<T> {
+	return (listener, thisArgs = null, disposables?) => {
+		// we need this, in case the event fires during the listener call
+		let didFire = false;
+		let result: Disposable | undefined = undefined;
+		result = event(e => {
+			if (didFire) {
+				return;
+			} else if (result) {
+				result.dispose();
+			} else {
+				didFire = true;
+			}
+
+			return listener.call(thisArgs, e);
+		}, null, disposables);
+
+		if (didFire) {
+			result.dispose();
+		}
+
+		return result;
+	};
+}
+
+/**
+ * Creates a promise out of an event, using the {@link Event.once} helper.
+ */
+export function toPromise<T>(event: Event<T>): Promise<T> {
+	return new Promise(resolve => once(event)(resolve));
+}
+
+export type ValueCallback<T = unknown> = (value: T | Promise<T>) => void;
+
+const enum DeferredOutcome {
+	Resolved,
+	Rejected
+}
+
+/**
+ * Creates a promise whose resolution or rejection can be controlled imperatively.
+ */
+export class DeferredPromise<T> {
+
+	private completeCallback!: ValueCallback<T>;
+	private errorCallback!: (err: unknown) => void;
+	private outcome?: { outcome: DeferredOutcome.Rejected; value: any } | { outcome: DeferredOutcome.Resolved; value: T };
+
+	public get isRejected() {
+		return this.outcome?.outcome === DeferredOutcome.Rejected;
+	}
+
+	public get isResolved() {
+		return this.outcome?.outcome === DeferredOutcome.Resolved;
+	}
+
+	public get isSettled() {
+		return !!this.outcome;
+	}
+
+	public get value() {
+		return this.outcome?.outcome === DeferredOutcome.Resolved ? this.outcome?.value : undefined;
+	}
+
+	public readonly p: Promise<T>;
+
+	constructor() {
+		this.p = new Promise<T>((c, e) => {
+			this.completeCallback = c;
+			this.errorCallback = e;
+		});
+	}
+
+	public complete(value: T) {
+		return new Promise<void>(resolve => {
+			this.completeCallback(value);
+			this.outcome = { outcome: DeferredOutcome.Resolved, value };
+			resolve();
+		});
+	}
+
+	public error(err: unknown) {
+		return new Promise<void>(resolve => {
+			this.errorCallback(err);
+			this.outcome = { outcome: DeferredOutcome.Rejected, value: err };
+			resolve();
+		});
+	}
+
+	public cancel() {
+		return this.error(new CancellationError());
+	}
 }

--- a/extensions/microsoft-authentication/src/common/cachePlugin.ts
+++ b/extensions/microsoft-authentication/src/common/cachePlugin.ts
@@ -1,0 +1,55 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { ICachePlugin, TokenCacheContext } from '@azure/msal-node';
+import { Disposable, EventEmitter, SecretStorage } from 'vscode';
+
+export class SecretStorageCachePlugin implements ICachePlugin {
+	private readonly _onDidChange: EventEmitter<void> = new EventEmitter<void>();
+	readonly onDidChange = this._onDidChange.event;
+
+	private _disposable: Disposable;
+
+	private _value: string | undefined;
+
+	constructor(
+		private readonly _secretStorage: SecretStorage,
+		private readonly _key: string
+	) {
+		this._disposable = Disposable.from(
+			this._onDidChange,
+			this._registerChangeHandler()
+		);
+	}
+
+	private _registerChangeHandler() {
+		return this._secretStorage.onDidChange(e => {
+			if (e.key === this._key) {
+				this._onDidChange.fire();
+			}
+		});
+	}
+
+	async beforeCacheAccess(tokenCacheContext: TokenCacheContext): Promise<void> {
+		const data = await this._secretStorage.get(this._key);
+		this._value = data;
+		if (data) {
+			tokenCacheContext.tokenCache.deserialize(data);
+		}
+	}
+
+	async afterCacheAccess(tokenCacheContext: TokenCacheContext): Promise<void> {
+		if (tokenCacheContext.cacheHasChanged) {
+			const value = tokenCacheContext.tokenCache.serialize();
+			if (value !== this._value) {
+				await this._secretStorage.store(this._key, value);
+			}
+		}
+	}
+
+	dispose() {
+		this._disposable.dispose();
+	}
+}

--- a/extensions/microsoft-authentication/src/common/loggerOptions.ts
+++ b/extensions/microsoft-authentication/src/common/loggerOptions.ts
@@ -1,0 +1,61 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { LogLevel as MsalLogLevel } from '@azure/msal-node';
+import { env, LogLevel, LogOutputChannel } from 'vscode';
+
+export class MsalLoggerOptions {
+	piiLoggingEnabled = false;
+
+	constructor(private readonly _output: LogOutputChannel) { }
+
+	get logLevel(): MsalLogLevel {
+		return this._toMsalLogLevel(env.logLevel);
+	}
+
+	loggerCallback(level: MsalLogLevel, message: string, containsPii: boolean): void {
+		if (containsPii) {
+			return;
+		}
+
+		switch (level) {
+			case MsalLogLevel.Error:
+				this._output.error(message);
+				return;
+			case MsalLogLevel.Warning:
+				this._output.warn(message);
+				return;
+			case MsalLogLevel.Info:
+				this._output.info(message);
+				return;
+			case MsalLogLevel.Verbose:
+				this._output.debug(message);
+				return;
+			case MsalLogLevel.Trace:
+				this._output.trace(message);
+				return;
+			default:
+				this._output.info(message);
+				return;
+		}
+	}
+
+	private _toMsalLogLevel(logLevel: LogLevel): MsalLogLevel {
+		switch (logLevel) {
+			case LogLevel.Trace:
+				return MsalLogLevel.Trace;
+			case LogLevel.Debug:
+				return MsalLogLevel.Verbose;
+			case LogLevel.Info:
+				return MsalLogLevel.Info;
+			case LogLevel.Warning:
+				return MsalLogLevel.Warning;
+			case LogLevel.Error:
+				return MsalLogLevel.Error;
+			default:
+				return MsalLogLevel.Info;
+		}
+	}
+}

--- a/extensions/microsoft-authentication/src/common/loopbackClientAndOpener.ts
+++ b/extensions/microsoft-authentication/src/common/loopbackClientAndOpener.ts
@@ -1,0 +1,51 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import type { ILoopbackClient, ServerAuthorizationCodeResponse } from '@azure/msal-node';
+import type { UriEventHandler } from '../UriEventHandler';
+import { env, Uri } from 'vscode';
+import { toPromise } from './async';
+
+export interface ILoopbackClientAndOpener extends ILoopbackClient {
+	openBrowser(url: string): Promise<void>;
+}
+
+export class UriHandlerLoopbackClient implements ILoopbackClientAndOpener {
+	constructor(
+		private readonly _uriHandler: UriEventHandler,
+		private readonly _redirectUri: string
+	) { }
+
+	async listenForAuthCode(successTemplate?: string, errorTemplate?: string): Promise<ServerAuthorizationCodeResponse> {
+		console.log(successTemplate, errorTemplate);
+		const url = await toPromise(this._uriHandler.event);
+		const result = new URL(url.toString(true));
+
+		return {
+			code: result.searchParams.get('code') ?? undefined,
+			state: result.searchParams.get('state') ?? undefined,
+			error: result.searchParams.get('error') ?? undefined,
+			error_description: result.searchParams.get('error_description') ?? undefined,
+			error_uri: result.searchParams.get('error_uri') ?? undefined,
+		};
+	}
+
+	getRedirectUri(): string {
+		// We always return the constant redirect URL because
+		// it will handle redirecting back to the extension
+		return this._redirectUri;
+	}
+
+	closeServer(): void {
+		// No-op
+	}
+
+	async openBrowser(url: string): Promise<void> {
+		const callbackUri = await env.asExternalUri(Uri.parse(`${env.uriScheme}://vscode.microsoft-authentication`));
+
+		const uri = Uri.parse(url + `&state=${encodeURI(callbackUri.toString(true))}`);
+		await env.openExternal(uri);
+	}
+}

--- a/extensions/microsoft-authentication/src/common/publicClientCache.ts
+++ b/extensions/microsoft-authentication/src/common/publicClientCache.ts
@@ -1,0 +1,21 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import type { AccountInfo, AuthenticationResult, InteractiveRequest, SilentFlowRequest } from '@azure/msal-node';
+import type { Disposable, Event } from 'vscode';
+
+export interface ICachedPublicClientApplication extends Disposable {
+	initialize(): Promise<void>;
+	acquireTokenSilent(request: SilentFlowRequest): Promise<AuthenticationResult>;
+	acquireTokenInteractive(request: InteractiveRequest): Promise<AuthenticationResult>;
+	removeAccount(account: AccountInfo): Promise<void>;
+	accounts: AccountInfo[];
+	clientId: string;
+	authority: string;
+}
+
+export interface ICachedPublicClientApplicationManager {
+	getOrCreate(clientId: string, authority: string): Promise<ICachedPublicClientApplication>;
+	getAll(): ICachedPublicClientApplication[];
+}

--- a/extensions/microsoft-authentication/src/common/telemetryReporter.ts
+++ b/extensions/microsoft-authentication/src/common/telemetryReporter.ts
@@ -1,0 +1,110 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import TelemetryReporter from '@vscode/extension-telemetry';
+
+export const enum MicrosoftAccountType {
+	AAD = 'aad',
+	MSA = 'msa',
+	Unknown = 'unknown'
+}
+
+export class MicrosoftAuthenticationTelemetryReporter {
+	protected _telemetryReporter: TelemetryReporter;
+	constructor(aiKey: string) {
+		this._telemetryReporter = new TelemetryReporter(aiKey);
+	}
+
+	sendLoginEvent(scopes: readonly string[]): void {
+		/* __GDPR__
+			"login" : {
+				"owner": "TylerLeonhardt",
+				"comment": "Used to determine the usage of the Microsoft Auth Provider.",
+				"scopes": { "classification": "PublicNonPersonalData", "purpose": "FeatureInsight", "comment": "Used to determine what scope combinations are being requested." }
+			}
+		*/
+		this._telemetryReporter.sendTelemetryEvent('login', {
+			// Get rid of guids from telemetry.
+			scopes: JSON.stringify(this._scrubGuids(scopes)),
+		});
+	}
+	sendLoginFailedEvent(): void {
+		/* __GDPR__
+			"loginFailed" : { "owner": "TylerLeonhardt", "comment": "Used to determine how often users run into issues with the login flow." }
+		*/
+		this._telemetryReporter.sendTelemetryEvent('loginFailed');
+	}
+	sendLogoutEvent(): void {
+		/* __GDPR__
+			"logout" : { "owner": "TylerLeonhardt", "comment": "Used to determine how often users log out." }
+		*/
+		this._telemetryReporter.sendTelemetryEvent('logout');
+	}
+	sendLogoutFailedEvent(): void {
+		/* __GDPR__
+			"logoutFailed" : { "owner": "TylerLeonhardt", "comment": "Used to determine how often fail to log out." }
+		*/
+		this._telemetryReporter.sendTelemetryEvent('logoutFailed');
+	}
+	/**
+	 * Sends an event for an account type available at startup.
+	 * @param scopes The scopes for the session
+	 * @param accountType The account type for the session
+	 * @todo Remove the scopes since we really don't care about them.
+	 */
+	sendAccountEvent(scopes: string[], accountType: MicrosoftAccountType): void {
+		/* __GDPR__
+			"login" : {
+				"owner": "TylerLeonhardt",
+				"comment": "Used to determine the usage of the Microsoft Auth Provider.",
+				"scopes": { "classification": "PublicNonPersonalData", "purpose": "FeatureInsight", "comment": "Used to determine what scope combinations are being requested." },
+				"accountType": { "classification": "PublicNonPersonalData", "purpose": "FeatureInsight", "comment": "Used to determine what account types are being used." }
+			}
+		*/
+		this._telemetryReporter.sendTelemetryEvent('account', {
+			// Get rid of guids from telemetry.
+			scopes: JSON.stringify(this._scrubGuids(scopes)),
+			accountType
+		});
+	}
+
+	protected _scrubGuids(scopes: readonly string[]): string[] {
+		return scopes.map(s => s.replace(/[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}/i, '{guid}'));
+	}
+}
+
+export class MicrosoftSovereignCloudAuthenticationTelemetryReporter extends MicrosoftAuthenticationTelemetryReporter {
+	override sendLoginEvent(scopes: string[]): void {
+		/* __GDPR__
+			"loginMicrosoftSovereignCloud" : {
+				"owner": "TylerLeonhardt",
+				"comment": "Used to determine the usage of the Microsoft Auth Provider.",
+				"scopes": { "classification": "PublicNonPersonalData", "purpose": "FeatureInsight", "comment": "Used to determine what scope combinations are being requested." }
+			}
+		*/
+		this._telemetryReporter.sendTelemetryEvent('loginMicrosoftSovereignCloud', {
+			// Get rid of guids from telemetry.
+			scopes: JSON.stringify(this._scrubGuids(scopes)),
+		});
+	}
+	override sendLoginFailedEvent(): void {
+		/* __GDPR__
+			"loginMicrosoftSovereignCloudFailed" : { "owner": "TylerLeonhardt", "comment": "Used to determine how often users run into issues with the login flow." }
+		*/
+		this._telemetryReporter.sendTelemetryEvent('loginMicrosoftSovereignCloudFailed');
+	}
+	override sendLogoutEvent(): void {
+		/* __GDPR__
+			"logoutMicrosoftSovereignCloud" : { "owner": "TylerLeonhardt", "comment": "Used to determine how often users log out." }
+		*/
+		this._telemetryReporter.sendTelemetryEvent('logoutMicrosoftSovereignCloud');
+	}
+	override sendLogoutFailedEvent(): void {
+		/* __GDPR__
+			"logoutMicrosoftSovereignCloudFailed" : { "owner": "TylerLeonhardt", "comment": "Used to determine how often fail to log out." }
+		*/
+		this._telemetryReporter.sendTelemetryEvent('logoutMicrosoftSovereignCloudFailed');
+	}
+}

--- a/extensions/microsoft-authentication/src/extension.ts
+++ b/extensions/microsoft-authentication/src/extension.ts
@@ -3,179 +3,45 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as vscode from 'vscode';
-import { Environment, EnvironmentParameters } from '@azure/ms-rest-azure-env';
-import { AzureActiveDirectoryService, IStoredSession } from './AADHelper';
-import { BetterTokenStorage } from './betterSecretStorage';
-import { UriEventHandler } from './UriEventHandler';
-import TelemetryReporter from '@vscode/extension-telemetry';
+import { commands, ExtensionContext, l10n, window, workspace } from 'vscode';
+import * as extensionV1 from './extensionV1';
+import * as extensionV2 from './extensionV2';
 
-async function initMicrosoftSovereignCloudAuthProvider(context: vscode.ExtensionContext, telemetryReporter: TelemetryReporter, uriHandler: UriEventHandler, tokenStorage: BetterTokenStorage<IStoredSession>): Promise<vscode.Disposable | undefined> {
-	const environment = vscode.workspace.getConfiguration('microsoft-sovereign-cloud').get<string | undefined>('environment');
-	let authProviderName: string | undefined;
-	if (!environment) {
-		return undefined;
-	}
+const config = workspace.getConfiguration('microsoft');
+const useMsal = config.get<boolean>('useMsal', false);
 
-	if (environment === 'custom') {
-		const customEnv = vscode.workspace.getConfiguration('microsoft-sovereign-cloud').get<EnvironmentParameters>('customEnvironment');
-		if (!customEnv) {
-			const res = await vscode.window.showErrorMessage(vscode.l10n.t('You must also specify a custom environment in order to use the custom environment auth provider.'), vscode.l10n.t('Open settings'));
-			if (res) {
-				await vscode.commands.executeCommand('workbench.action.openSettingsJson', 'microsoft-sovereign-cloud.customEnvironment');
-			}
-			return undefined;
+export async function activate(context: ExtensionContext) {
+	context.subscriptions.push(workspace.onDidChangeConfiguration(async e => {
+		if (!e.affectsConfiguration('microsoft.useMsal') && useMsal === config.get<boolean>('useMsal', false)) {
+			return;
 		}
-		try {
-			Environment.add(customEnv);
-		} catch (e) {
-			const res = await vscode.window.showErrorMessage(vscode.l10n.t('Error validating custom environment setting: {0}', e.message), vscode.l10n.t('Open settings'));
-			if (res) {
-				await vscode.commands.executeCommand('workbench.action.openSettings', 'microsoft-sovereign-cloud.customEnvironment');
-			}
-			return undefined;
-		}
-		authProviderName = customEnv.name;
-	} else {
-		authProviderName = environment;
-	}
 
-	const env = Environment.get(authProviderName);
-	if (!env) {
-		const res = await vscode.window.showErrorMessage(vscode.l10n.t('The environment `{0}` is not a valid environment.', authProviderName), vscode.l10n.t('Open settings'));
-		return undefined;
-	}
+		const reload = l10n.t('Reload');
+		const result = await window.showInformationMessage(
+			'Reload required',
+			{
+				modal: true,
+				detail: l10n.t('Microsoft Account configuration has been changed.'),
+			},
+			reload
+		);
 
-	const aadService = new AzureActiveDirectoryService(
-		vscode.window.createOutputChannel(vscode.l10n.t('Microsoft Sovereign Cloud Authentication'), { log: true }),
-		context,
-		uriHandler,
-		tokenStorage,
-		telemetryReporter,
-		env);
-	await aadService.initialize();
-
-	const disposable = vscode.authentication.registerAuthenticationProvider('microsoft-sovereign-cloud', authProviderName, {
-		onDidChangeSessions: aadService.onDidChangeSessions,
-		getSessions: (scopes: string[]) => aadService.getSessions(scopes),
-		createSession: async (scopes: string[]) => {
-			try {
-				/* __GDPR__
-					"login" : {
-						"owner": "TylerLeonhardt",
-						"comment": "Used to determine the usage of the Microsoft Sovereign Cloud Auth Provider.",
-						"scopes": { "classification": "PublicNonPersonalData", "purpose": "FeatureInsight", "comment": "Used to determine what scope combinations are being requested." }
-					}
-				*/
-				telemetryReporter.sendTelemetryEvent('loginMicrosoftSovereignCloud', {
-					// Get rid of guids from telemetry.
-					scopes: JSON.stringify(scopes.map(s => s.replace(/[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}/i, '{guid}'))),
-				});
-
-				return await aadService.createSession(scopes);
-			} catch (e) {
-				/* __GDPR__
-					"loginFailed" : { "owner": "TylerLeonhardt", "comment": "Used to determine how often users run into issues with the login flow." }
-				*/
-				telemetryReporter.sendTelemetryEvent('loginMicrosoftSovereignCloudFailed');
-
-				throw e;
-			}
-		},
-		removeSession: async (id: string) => {
-			try {
-				/* __GDPR__
-					"logout" : { "owner": "TylerLeonhardt", "comment": "Used to determine how often users log out." }
-				*/
-				telemetryReporter.sendTelemetryEvent('logoutMicrosoftSovereignCloud');
-
-				await aadService.removeSessionById(id);
-			} catch (e) {
-				/* __GDPR__
-					"logoutFailed" : { "owner": "TylerLeonhardt", "comment": "Used to determine how often fail to log out." }
-				*/
-				telemetryReporter.sendTelemetryEvent('logoutMicrosoftSovereignCloudFailed');
-			}
-		}
-	}, { supportsMultipleAccounts: true });
-
-	context.subscriptions.push(disposable);
-	return disposable;
-}
-
-export async function activate(context: vscode.ExtensionContext) {
-	const aiKey: string = context.extension.packageJSON.aiKey;
-	const telemetryReporter = new TelemetryReporter(aiKey);
-
-	const uriHandler = new UriEventHandler();
-	context.subscriptions.push(uriHandler);
-	context.subscriptions.push(vscode.window.registerUriHandler(uriHandler));
-	const betterSecretStorage = new BetterTokenStorage<IStoredSession>('microsoft.login.keylist', context);
-
-	const loginService = new AzureActiveDirectoryService(
-		vscode.window.createOutputChannel(vscode.l10n.t('Microsoft Authentication'), { log: true }),
-		context,
-		uriHandler,
-		betterSecretStorage,
-		telemetryReporter,
-		Environment.AzureCloud);
-	await loginService.initialize();
-
-	context.subscriptions.push(vscode.authentication.registerAuthenticationProvider('microsoft', 'Microsoft', {
-		onDidChangeSessions: loginService.onDidChangeSessions,
-		getSessions: (scopes: string[], options?: vscode.AuthenticationProviderSessionOptions) => loginService.getSessions(scopes, options?.account),
-		createSession: async (scopes: string[], options?: vscode.AuthenticationProviderSessionOptions) => {
-			try {
-				/* __GDPR__
-					"login" : {
-						"owner": "TylerLeonhardt",
-						"comment": "Used to determine the usage of the Microsoft Auth Provider.",
-						"scopes": { "classification": "PublicNonPersonalData", "purpose": "FeatureInsight", "comment": "Used to determine what scope combinations are being requested." }
-					}
-				*/
-				telemetryReporter.sendTelemetryEvent('login', {
-					// Get rid of guids from telemetry.
-					scopes: JSON.stringify(scopes.map(s => s.replace(/[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}/i, '{guid}'))),
-				});
-
-				return await loginService.createSession(scopes, options?.account);
-			} catch (e) {
-				/* __GDPR__
-					"loginFailed" : { "owner": "TylerLeonhardt", "comment": "Used to determine how often users run into issues with the login flow." }
-				*/
-				telemetryReporter.sendTelemetryEvent('loginFailed');
-
-				throw e;
-			}
-		},
-		removeSession: async (id: string) => {
-			try {
-				/* __GDPR__
-					"logout" : { "owner": "TylerLeonhardt", "comment": "Used to determine how often users log out." }
-				*/
-				telemetryReporter.sendTelemetryEvent('logout');
-
-				await loginService.removeSessionById(id);
-			} catch (e) {
-				/* __GDPR__
-					"logoutFailed" : { "owner": "TylerLeonhardt", "comment": "Used to determine how often fail to log out." }
-				*/
-				telemetryReporter.sendTelemetryEvent('logoutFailed');
-			}
-		}
-	}, { supportsMultipleAccounts: true }));
-
-	let microsoftSovereignCloudAuthProviderDisposable = await initMicrosoftSovereignCloudAuthProvider(context, telemetryReporter, uriHandler, betterSecretStorage);
-
-	context.subscriptions.push(vscode.workspace.onDidChangeConfiguration(async e => {
-		if (e.affectsConfiguration('microsoft-sovereign-cloud')) {
-			microsoftSovereignCloudAuthProviderDisposable?.dispose();
-			microsoftSovereignCloudAuthProviderDisposable = await initMicrosoftSovereignCloudAuthProvider(context, telemetryReporter, uriHandler, betterSecretStorage);
+		if (result === reload) {
+			commands.executeCommand('workbench.action.reloadWindow');
 		}
 	}));
-
-	return;
+	// Only activate the new extension if we are not running in a browser environment
+	if (useMsal && typeof navigator === 'undefined') {
+		await extensionV2.activate(context);
+	} else {
+		await extensionV1.activate(context);
+	}
 }
 
-// this method is called when your extension is deactivated
-export function deactivate() { }
+export function deactivate() {
+	if (useMsal) {
+		extensionV2.deactivate();
+	} else {
+		extensionV1.deactivate();
+	}
+}

--- a/extensions/microsoft-authentication/src/extensionV1.ts
+++ b/extensions/microsoft-authentication/src/extensionV1.ts
@@ -1,0 +1,180 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+import { Environment, EnvironmentParameters } from '@azure/ms-rest-azure-env';
+import { AzureActiveDirectoryService, IStoredSession } from './AADHelper';
+import { BetterTokenStorage } from './betterSecretStorage';
+import { UriEventHandler } from './UriEventHandler';
+import TelemetryReporter from '@vscode/extension-telemetry';
+
+async function initMicrosoftSovereignCloudAuthProvider(context: vscode.ExtensionContext, telemetryReporter: TelemetryReporter, uriHandler: UriEventHandler, tokenStorage: BetterTokenStorage<IStoredSession>): Promise<vscode.Disposable | undefined> {
+	const environment = vscode.workspace.getConfiguration('microsoft-sovereign-cloud').get<string | undefined>('environment');
+	let authProviderName: string | undefined;
+	if (!environment) {
+		return undefined;
+	}
+
+	if (environment === 'custom') {
+		const customEnv = vscode.workspace.getConfiguration('microsoft-sovereign-cloud').get<EnvironmentParameters>('customEnvironment');
+		if (!customEnv) {
+			const res = await vscode.window.showErrorMessage(vscode.l10n.t('You must also specify a custom environment in order to use the custom environment auth provider.'), vscode.l10n.t('Open settings'));
+			if (res) {
+				await vscode.commands.executeCommand('workbench.action.openSettingsJson', 'microsoft-sovereign-cloud.customEnvironment');
+			}
+			return undefined;
+		}
+		try {
+			Environment.add(customEnv);
+		} catch (e) {
+			const res = await vscode.window.showErrorMessage(vscode.l10n.t('Error validating custom environment setting: {0}', e.message), vscode.l10n.t('Open settings'));
+			if (res) {
+				await vscode.commands.executeCommand('workbench.action.openSettings', 'microsoft-sovereign-cloud.customEnvironment');
+			}
+			return undefined;
+		}
+		authProviderName = customEnv.name;
+	} else {
+		authProviderName = environment;
+	}
+
+	const env = Environment.get(authProviderName);
+	if (!env) {
+		const res = await vscode.window.showErrorMessage(vscode.l10n.t('The environment `{0}` is not a valid environment.', authProviderName), vscode.l10n.t('Open settings'));
+		return undefined;
+	}
+
+	const aadService = new AzureActiveDirectoryService(
+		vscode.window.createOutputChannel(vscode.l10n.t('Microsoft Sovereign Cloud Authentication'), { log: true }),
+		context,
+		uriHandler,
+		tokenStorage,
+		telemetryReporter,
+		env);
+	await aadService.initialize();
+
+	const disposable = vscode.authentication.registerAuthenticationProvider('microsoft-sovereign-cloud', authProviderName, {
+		onDidChangeSessions: aadService.onDidChangeSessions,
+		getSessions: (scopes: string[]) => aadService.getSessions(scopes),
+		createSession: async (scopes: string[]) => {
+			try {
+				/* __GDPR__
+					"login" : {
+						"owner": "TylerLeonhardt",
+						"comment": "Used to determine the usage of the Microsoft Sovereign Cloud Auth Provider.",
+						"scopes": { "classification": "PublicNonPersonalData", "purpose": "FeatureInsight", "comment": "Used to determine what scope combinations are being requested." }
+					}
+				*/
+				telemetryReporter.sendTelemetryEvent('loginMicrosoftSovereignCloud', {
+					// Get rid of guids from telemetry.
+					scopes: JSON.stringify(scopes.map(s => s.replace(/[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}/i, '{guid}'))),
+				});
+
+				return await aadService.createSession(scopes);
+			} catch (e) {
+				/* __GDPR__
+					"loginFailed" : { "owner": "TylerLeonhardt", "comment": "Used to determine how often users run into issues with the login flow." }
+				*/
+				telemetryReporter.sendTelemetryEvent('loginMicrosoftSovereignCloudFailed');
+
+				throw e;
+			}
+		},
+		removeSession: async (id: string) => {
+			try {
+				/* __GDPR__
+					"logout" : { "owner": "TylerLeonhardt", "comment": "Used to determine how often users log out." }
+				*/
+				telemetryReporter.sendTelemetryEvent('logoutMicrosoftSovereignCloud');
+
+				await aadService.removeSessionById(id);
+			} catch (e) {
+				/* __GDPR__
+					"logoutFailed" : { "owner": "TylerLeonhardt", "comment": "Used to determine how often fail to log out." }
+				*/
+				telemetryReporter.sendTelemetryEvent('logoutMicrosoftSovereignCloudFailed');
+			}
+		}
+	}, { supportsMultipleAccounts: true });
+
+	context.subscriptions.push(disposable);
+	return disposable;
+}
+
+export async function activate(context: vscode.ExtensionContext) {
+	const aiKey: string = context.extension.packageJSON.aiKey;
+	const telemetryReporter = new TelemetryReporter(aiKey);
+
+	const uriHandler = new UriEventHandler();
+	context.subscriptions.push(uriHandler);
+	const betterSecretStorage = new BetterTokenStorage<IStoredSession>('microsoft.login.keylist', context);
+
+	const loginService = new AzureActiveDirectoryService(
+		vscode.window.createOutputChannel(vscode.l10n.t('Microsoft Authentication'), { log: true }),
+		context,
+		uriHandler,
+		betterSecretStorage,
+		telemetryReporter,
+		Environment.AzureCloud);
+	await loginService.initialize();
+
+	context.subscriptions.push(vscode.authentication.registerAuthenticationProvider('microsoft', 'Microsoft', {
+		onDidChangeSessions: loginService.onDidChangeSessions,
+		getSessions: (scopes: string[], options?: vscode.AuthenticationProviderSessionOptions) => loginService.getSessions(scopes, options?.account),
+		createSession: async (scopes: string[], options?: vscode.AuthenticationProviderSessionOptions) => {
+			try {
+				/* __GDPR__
+					"login" : {
+						"owner": "TylerLeonhardt",
+						"comment": "Used to determine the usage of the Microsoft Auth Provider.",
+						"scopes": { "classification": "PublicNonPersonalData", "purpose": "FeatureInsight", "comment": "Used to determine what scope combinations are being requested." }
+					}
+				*/
+				telemetryReporter.sendTelemetryEvent('login', {
+					// Get rid of guids from telemetry.
+					scopes: JSON.stringify(scopes.map(s => s.replace(/[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}/i, '{guid}'))),
+				});
+
+				return await loginService.createSession(scopes, options?.account);
+			} catch (e) {
+				/* __GDPR__
+					"loginFailed" : { "owner": "TylerLeonhardt", "comment": "Used to determine how often users run into issues with the login flow." }
+				*/
+				telemetryReporter.sendTelemetryEvent('loginFailed');
+
+				throw e;
+			}
+		},
+		removeSession: async (id: string) => {
+			try {
+				/* __GDPR__
+					"logout" : { "owner": "TylerLeonhardt", "comment": "Used to determine how often users log out." }
+				*/
+				telemetryReporter.sendTelemetryEvent('logout');
+
+				await loginService.removeSessionById(id);
+			} catch (e) {
+				/* __GDPR__
+					"logoutFailed" : { "owner": "TylerLeonhardt", "comment": "Used to determine how often fail to log out." }
+				*/
+				telemetryReporter.sendTelemetryEvent('logoutFailed');
+			}
+		}
+	}, { supportsMultipleAccounts: true }));
+
+	let microsoftSovereignCloudAuthProviderDisposable = await initMicrosoftSovereignCloudAuthProvider(context, telemetryReporter, uriHandler, betterSecretStorage);
+
+	context.subscriptions.push(vscode.workspace.onDidChangeConfiguration(async e => {
+		if (e.affectsConfiguration('microsoft-sovereign-cloud')) {
+			microsoftSovereignCloudAuthProviderDisposable?.dispose();
+			microsoftSovereignCloudAuthProviderDisposable = await initMicrosoftSovereignCloudAuthProvider(context, telemetryReporter, uriHandler, betterSecretStorage);
+		}
+	}));
+
+	return;
+}
+
+// this method is called when your extension is deactivated
+export function deactivate() { }

--- a/extensions/microsoft-authentication/src/extensionV2.ts
+++ b/extensions/microsoft-authentication/src/extensionV2.ts
@@ -1,0 +1,97 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Environment, EnvironmentParameters } from '@azure/ms-rest-azure-env';
+import Logger from './logger';
+import { MsalAuthProvider } from './node/authProvider';
+import { UriEventHandler } from './UriEventHandler';
+import { authentication, commands, ExtensionContext, l10n, window, workspace, Disposable } from 'vscode';
+import { MicrosoftAuthenticationTelemetryReporter, MicrosoftSovereignCloudAuthenticationTelemetryReporter } from './common/telemetryReporter';
+
+async function initMicrosoftSovereignCloudAuthProvider(
+	context: ExtensionContext,
+	uriHandler: UriEventHandler
+): Promise<Disposable | undefined> {
+	const environment = workspace.getConfiguration('microsoft-sovereign-cloud').get<string | undefined>('environment');
+	let authProviderName: string | undefined;
+	if (!environment) {
+		return undefined;
+	}
+
+	if (environment === 'custom') {
+		const customEnv = workspace.getConfiguration('microsoft-sovereign-cloud').get<EnvironmentParameters>('customEnvironment');
+		if (!customEnv) {
+			const res = await window.showErrorMessage(l10n.t('You must also specify a custom environment in order to use the custom environment auth provider.'), l10n.t('Open settings'));
+			if (res) {
+				await commands.executeCommand('workbench.action.openSettingsJson', 'microsoft-sovereign-cloud.customEnvironment');
+			}
+			return undefined;
+		}
+		try {
+			Environment.add(customEnv);
+		} catch (e) {
+			const res = await window.showErrorMessage(l10n.t('Error validating custom environment setting: {0}', e.message), l10n.t('Open settings'));
+			if (res) {
+				await commands.executeCommand('workbench.action.openSettings', 'microsoft-sovereign-cloud.customEnvironment');
+			}
+			return undefined;
+		}
+		authProviderName = customEnv.name;
+	} else {
+		authProviderName = environment;
+	}
+
+	const env = Environment.get(authProviderName);
+	if (!env) {
+		await window.showErrorMessage(l10n.t('The environment `{0}` is not a valid environment.', authProviderName), l10n.t('Open settings'));
+		return undefined;
+	}
+
+	const authProvider = new MsalAuthProvider(
+		context,
+		new MicrosoftSovereignCloudAuthenticationTelemetryReporter(context.extension.packageJSON.aiKey),
+		window.createOutputChannel(l10n.t('Microsoft Sovereign Cloud Authentication'), { log: true }),
+		uriHandler,
+		env
+	);
+	await authProvider.initialize();
+	const disposable = authentication.registerAuthenticationProvider(
+		'microsoft-sovereign-cloud',
+		authProviderName,
+		authProvider,
+		{ supportsMultipleAccounts: true }
+	);
+	context.subscriptions.push(disposable);
+	return disposable;
+}
+
+export async function activate(context: ExtensionContext) {
+	const uriHandler = new UriEventHandler();
+	context.subscriptions.push(uriHandler);
+	const authProvider = new MsalAuthProvider(
+		context,
+		new MicrosoftAuthenticationTelemetryReporter(context.extension.packageJSON.aiKey),
+		Logger,
+		uriHandler
+	);
+	await authProvider.initialize();
+	context.subscriptions.push(authentication.registerAuthenticationProvider(
+		'microsoft',
+		'Microsoft',
+		authProvider,
+		{ supportsMultipleAccounts: true }
+	));
+
+	let microsoftSovereignCloudAuthProviderDisposable = await initMicrosoftSovereignCloudAuthProvider(context, uriHandler);
+
+	context.subscriptions.push(workspace.onDidChangeConfiguration(async e => {
+		if (e.affectsConfiguration('microsoft-sovereign-cloud')) {
+			microsoftSovereignCloudAuthProviderDisposable?.dispose();
+			microsoftSovereignCloudAuthProviderDisposable = await initMicrosoftSovereignCloudAuthProvider(context, uriHandler);
+		}
+	}));
+}
+
+export function deactivate() { }

--- a/extensions/microsoft-authentication/src/node/authProvider.ts
+++ b/extensions/microsoft-authentication/src/node/authProvider.ts
@@ -1,0 +1,301 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import { AccountInfo, AuthenticationResult } from '@azure/msal-node';
+import { AuthenticationGetSessionOptions, AuthenticationProvider, AuthenticationProviderAuthenticationSessionsChangeEvent, AuthenticationSession, AuthenticationSessionAccountInformation, CancellationError, env, EventEmitter, ExtensionContext, l10n, LogOutputChannel, Memento, SecretStorage, Uri, window } from 'vscode';
+import { Environment } from '@azure/ms-rest-azure-env';
+import { CachedPublicClientApplicationManager } from './publicClientCache';
+import { UriHandlerLoopbackClient } from '../common/loopbackClientAndOpener';
+import { UriEventHandler } from '../UriEventHandler';
+import { ICachedPublicClientApplication } from '../common/publicClientCache';
+import { MicrosoftAccountType, MicrosoftAuthenticationTelemetryReporter } from '../common/telemetryReporter';
+import { loopbackTemplate } from './loopbackTemplate';
+import { Delayer } from '../common/async';
+
+const redirectUri = 'https://vscode.dev/redirect';
+const DEFAULT_CLIENT_ID = 'aebc6443-996d-45c2-90f0-388ff96faa56';
+const DEFAULT_TENANT = 'organizations';
+const MSA_TID = '9188040d-6c67-4c5b-b112-36a304b66dad';
+const MSA_PASSTHRU_TID = 'f8cdef31-a31e-4b4a-93e4-5f571e91255a';
+
+export class MsalAuthProvider implements AuthenticationProvider {
+
+	private readonly _disposables: { dispose(): void }[];
+	private readonly _publicClientManager: CachedPublicClientApplicationManager;
+	private readonly _refreshDelayer = new DelayerByKey<void>();
+
+	/**
+	 * Event to signal a change in authentication sessions for this provider.
+	 */
+	private readonly _onDidChangeSessionsEmitter = new EventEmitter<AuthenticationProviderAuthenticationSessionsChangeEvent>();
+
+	/**
+	 * Event to signal a change in authentication sessions for this provider.
+	 *
+	 * NOTE: This event is handled differently in the Microsoft auth provider than "typical" auth providers. Normally,
+	 * this event would fire when the provider's sessions change... which are tied to a specific list of scopes. However,
+	 * since Microsoft identity doesn't care too much about scopes (you can mint a new token from an existing token),
+	 * we just fire this event whenever the account list changes... so essentially there is one session per account.
+	 *
+	 * This is not quite how the API should be used... but this event really is just for signaling that the account list
+	 * has changed.
+	 */
+	onDidChangeSessions = this._onDidChangeSessionsEmitter.event;
+
+	constructor(
+		context: ExtensionContext,
+		private readonly _telemetryReporter: MicrosoftAuthenticationTelemetryReporter,
+		private readonly _logger: LogOutputChannel,
+		private readonly _uriHandler: UriEventHandler,
+		private readonly _env: Environment = Environment.AzureCloud
+	) {
+		this._disposables = context.subscriptions;
+		this._publicClientManager = new CachedPublicClientApplicationManager(
+			context.globalState,
+			context.secrets,
+			this._logger,
+			(e) => this._handleAccountChange(e)
+		);
+		this._disposables.push(this._publicClientManager);
+		this._disposables.push(this._onDidChangeSessionsEmitter);
+
+	}
+
+	async initialize(): Promise<void> {
+		await this._publicClientManager.initialize();
+
+		// Send telemetry for existing accounts
+		for (const cachedPca of this._publicClientManager.getAll()) {
+			for (const account of cachedPca.accounts) {
+				if (!account.idTokenClaims?.tid) {
+					continue;
+				}
+				const tid = account.idTokenClaims.tid;
+				const type = tid === MSA_TID || tid === MSA_PASSTHRU_TID ? MicrosoftAccountType.MSA : MicrosoftAccountType.AAD;
+				this._telemetryReporter.sendAccountEvent([], type);
+			}
+		}
+	}
+
+	/**
+	 * See {@link onDidChangeSessions} for more information on how this is used.
+	 * @param param0 Event that contains the added and removed accounts
+	 */
+	private _handleAccountChange({ added, deleted }: { added: AccountInfo[]; deleted: AccountInfo[] }) {
+		const process = (a: AccountInfo) => ({
+			// This shouldn't be needed
+			accessToken: '1234',
+			id: a.homeAccountId,
+			scopes: [],
+			account: {
+				id: a.homeAccountId,
+				label: a.username
+			},
+			idToken: a.idToken,
+		});
+		this._onDidChangeSessionsEmitter.fire({ added: added.map(process), changed: [], removed: deleted.map(process) });
+	}
+
+	async getSessions(scopes: string[] | undefined, options?: AuthenticationGetSessionOptions): Promise<AuthenticationSession[]> {
+		this._logger.info('[getSessions]', scopes ?? 'all', 'starting');
+		const modifiedScopes = scopes ? [...scopes] : [];
+		const clientId = this.getClientId(modifiedScopes);
+		const tenant = this.getTenantId(modifiedScopes);
+		this._addCommonScopes(modifiedScopes);
+		if (!scopes) {
+			const allSessions: AuthenticationSession[] = [];
+			for (const cachedPca of this._publicClientManager.getAll()) {
+				const sessions = await this.getAllSessionsForPca(cachedPca, modifiedScopes, modifiedScopes, options?.account);
+				allSessions.push(...sessions);
+			}
+			return allSessions;
+		}
+
+		const cachedPca = await this.getOrCreatePublicClientApplication(clientId, tenant);
+		const sessions = await this.getAllSessionsForPca(cachedPca, scopes, modifiedScopes.filter(s => !s.startsWith('VSCODE_'), options?.account));
+		this._logger.info(`[getSessions] returned ${sessions.length} sessions`);
+		return sessions;
+
+	}
+
+	async createSession(scopes: readonly string[]): Promise<AuthenticationSession> {
+		this._logger.info('[createSession]', scopes, 'starting');
+		const modifiedScopes = scopes ? [...scopes] : [];
+		const clientId = this.getClientId(modifiedScopes);
+		const tenant = this.getTenantId(modifiedScopes);
+		this._addCommonScopes(modifiedScopes);
+
+		const cachedPca = await this.getOrCreatePublicClientApplication(clientId, tenant);
+		let result: AuthenticationResult;
+		try {
+			result = await cachedPca.acquireTokenInteractive({
+				openBrowser: async (url: string) => { await env.openExternal(Uri.parse(url)); },
+				scopes: modifiedScopes,
+				successTemplate: loopbackTemplate,
+				// TODO: This is currently not working (the loopback client closes before this is rendered).
+				// There is an issue opened on MSAL Node to fix this. We should workaround this by re-implementing the Loopback client.
+				// errorTemplate: loopbackTemplate
+			});
+			this.setupRefresh(cachedPca, result, scopes);
+		} catch (e) {
+			if (e instanceof CancellationError) {
+				const yes = l10n.t('Yes');
+				const result = await window.showErrorMessage(
+					l10n.t('Having trouble logging in?'),
+					{
+						modal: true,
+						detail: l10n.t('Would you like to try a different way to sign in to your Microsoft account? ({0})', 'protocol handler')
+					},
+					yes
+				);
+				if (!result) {
+					this._telemetryReporter.sendLoginFailedEvent();
+					throw e;
+				}
+			}
+			const loopbackClient = new UriHandlerLoopbackClient(this._uriHandler, redirectUri);
+			try {
+				result = await cachedPca.acquireTokenInteractive({
+					openBrowser: (url: string) => loopbackClient.openBrowser(url),
+					scopes: modifiedScopes,
+					loopbackClient
+				});
+				this.setupRefresh(cachedPca, result, scopes);
+			} catch (e) {
+				this._telemetryReporter.sendLoginFailedEvent();
+				throw e;
+			}
+		}
+
+		const session = this.toAuthenticationSession(result, scopes);
+		this._telemetryReporter.sendLoginEvent(session.scopes);
+		this._logger.info('[createSession]', scopes, 'returned session');
+		return session;
+	}
+
+	async removeSession(sessionId: string): Promise<void> {
+		this._logger.info('[removeSession]', sessionId, 'starting');
+		for (const cachedPca of this._publicClientManager.getAll()) {
+			const accounts = cachedPca.accounts;
+			for (const account of accounts) {
+				if (account.homeAccountId === sessionId) {
+					this._telemetryReporter.sendLogoutEvent();
+					try {
+						await cachedPca.removeAccount(account);
+					} catch (e) {
+						this._telemetryReporter.sendLogoutFailedEvent();
+						throw e;
+					}
+					this._logger.info('[removeSession]', sessionId, 'removed session');
+					return;
+				}
+			}
+		}
+		this._logger.info('[removeSession]', sessionId, 'session not found');
+	}
+
+	private async getOrCreatePublicClientApplication(clientId: string, tenant: string): Promise<ICachedPublicClientApplication> {
+		const authority = new URL(tenant, this._env.activeDirectoryEndpointUrl).toString();
+		return await this._publicClientManager.getOrCreate(clientId, authority);
+	}
+
+	private _addCommonScopes(scopes: string[]) {
+		if (!scopes.includes('openid')) {
+			scopes.push('openid');
+		}
+		if (!scopes.includes('email')) {
+			scopes.push('email');
+		}
+		if (!scopes.includes('profile')) {
+			scopes.push('profile');
+		}
+		if (!scopes.includes('offline_access')) {
+			scopes.push('offline_access');
+		}
+		return scopes;
+	}
+
+	private async getAllSessionsForPca(
+		cachedPca: ICachedPublicClientApplication,
+		originalScopes: readonly string[],
+		scopesToSend: string[],
+		accountFilter?: AuthenticationSessionAccountInformation
+	): Promise<AuthenticationSession[]> {
+		const accounts = accountFilter
+			? cachedPca.accounts.filter(a => a.homeAccountId === accountFilter.id)
+			: cachedPca.accounts;
+		const sessions: AuthenticationSession[] = [];
+		for (const account of accounts) {
+			const result = await cachedPca.acquireTokenSilent({ account, scopes: scopesToSend, redirectUri });
+			this.setupRefresh(cachedPca, result, originalScopes);
+			sessions.push(this.toAuthenticationSession(result, originalScopes));
+		}
+		return sessions;
+	}
+
+	private setupRefresh(cachedPca: ICachedPublicClientApplication, result: AuthenticationResult, originalScopes: readonly string[]) {
+		const on = result.refreshOn || result.expiresOn;
+		if (!result.account || !on) {
+			return;
+		}
+
+		const account = result.account;
+		const scopes = result.scopes;
+		const timeToRefresh = on.getTime() - Date.now() - 5 * 60 * 1000; // 5 minutes before expiry
+		const key = JSON.stringify({ accountId: account.homeAccountId, scopes });
+		this._refreshDelayer.trigger(key, async () => {
+			const result = await cachedPca.acquireTokenSilent({ account, scopes, redirectUri, forceRefresh: true });
+			this._onDidChangeSessionsEmitter.fire({ added: [], changed: [this.toAuthenticationSession(result, originalScopes)], removed: [] });
+		}, timeToRefresh > 0 ? timeToRefresh : 0);
+	}
+
+	//#region scope parsers
+
+	private getClientId(scopes: string[]) {
+		return scopes.reduce<string | undefined>((prev, current) => {
+			if (current.startsWith('VSCODE_CLIENT_ID:')) {
+				return current.split('VSCODE_CLIENT_ID:')[1];
+			}
+			return prev;
+		}, undefined) ?? DEFAULT_CLIENT_ID;
+	}
+
+	private getTenantId(scopes: string[]) {
+		return scopes.reduce<string | undefined>((prev, current) => {
+			if (current.startsWith('VSCODE_TENANT:')) {
+				return current.split('VSCODE_TENANT:')[1];
+			}
+			return prev;
+		}, undefined) ?? DEFAULT_TENANT;
+	}
+
+	//#endregion
+
+	private toAuthenticationSession(result: AuthenticationResult, scopes: readonly string[]): AuthenticationSession & { idToken: string } {
+		return {
+			accessToken: result.accessToken,
+			idToken: result.idToken,
+			id: result.account?.homeAccountId ?? result.uniqueId,
+			account: {
+				id: result.account?.homeAccountId ?? result.uniqueId,
+				label: result.account?.username ?? 'Unknown',
+			},
+			scopes
+		};
+	}
+}
+
+class DelayerByKey<T> {
+	private _delayers = new Map<string, Delayer<T>>();
+
+	trigger(key: string, fn: () => Promise<T>, delay: number): Promise<T> {
+		let delayer = this._delayers.get(key);
+		if (!delayer) {
+			delayer = new Delayer<T>(delay);
+			this._delayers.set(key, delayer);
+		}
+
+		return delayer.trigger(fn, delay);
+	}
+}

--- a/extensions/microsoft-authentication/src/node/loopbackTemplate.ts
+++ b/extensions/microsoft-authentication/src/node/loopbackTemplate.ts
@@ -1,0 +1,138 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+export const loopbackTemplate = `
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+	<meta charset="utf-8" />
+	<title>Microsoft Account - Sign In</title>
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<style>
+		html {
+			height: 100%;
+		}
+
+		body {
+			box-sizing: border-box;
+			min-height: 100%;
+			margin: 0;
+			padding: 15px 30px;
+			display: flex;
+			flex-direction: column;
+			color: white;
+			font-family: "Segoe UI","Helvetica Neue","Helvetica",Arial,sans-serif;
+			background-color: #2C2C32;
+		}
+
+		.branding {
+			background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAJYAAACWCAYAAAA8AXHiAAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAAAhGVYSWZNTQAqAAAACAAFARIAAwAAAAEAAQAAARoABQAAAAEAAABKARsABQAAAAEAAABSASgAAwAAAAEAAgAAh2kABAAAAAEAAABaAAAAAAAAAEgAAAABAAAASAAAAAEAA6ABAAMAAAABAAEAAKACAAQAAAABAAAAlqADAAQAAAABAAAAlgAAAADkcSUjAAAACXBIWXMAAAsTAAALEwEAmpwYAAABWWlUWHRYTUw6Y29tLmFkb2JlLnhtcAAAAAAAPHg6eG1wbWV0YSB4bWxuczp4PSJhZG9iZTpuczptZXRhLyIgeDp4bXB0az0iWE1QIENvcmUgNS40LjAiPgogICA8cmRmOlJERiB4bWxuczpyZGY9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkvMDIvMjItcmRmLXN5bnRheC1ucyMiPgogICAgICA8cmRmOkRlc2NyaXB0aW9uIHJkZjphYm91dD0iIgogICAgICAgICAgICB4bWxuczp0aWZmPSJodHRwOi8vbnMuYWRvYmUuY29tL3RpZmYvMS4wLyI+CiAgICAgICAgIDx0aWZmOk9yaWVudGF0aW9uPjE8L3RpZmY6T3JpZW50YXRpb24+CiAgICAgIDwvcmRmOkRlc2NyaXB0aW9uPgogICA8L3JkZjpSREY+CjwveDp4bXBtZXRhPgpMwidZAAAxaElEQVR4Ae19CbgdRbXu6j2cecoECTIkICCGzAg+7qeQ9544QFQgiXpVEJTEe59ALsbMwE5AMZCQELgKeSoqDlyiQogCSUAC6FNCQhIwQMALCbNMGc68p37/v7prnz47++yzzzl76OCu851d3dXV1VXVf69atWqtVZaUg397IPJwSCKT46zgx16wh+19XSYnO6PjE7H4MDuZ7BSxXhQJ/On5KTWbTSMm3bYlvHXmJNxj2SatFLFVioeWn5lDDwAgMvOU2NG/3DMo2h691rLtr4bqBtVX1NVJRUOVBIIiyYSI3RkXO9q5NZmU5S98tu7XpmQF2AwAzCoNwMrAMm/CT3HkrgqJTI/KwodOD4ZDa5MVdUPtfe+KxONKiSob6+SIE46XqsYGK5FIBoLVtQEJiSRaWp+xktaNuzpqfirTLcBOZNJtdnjrDCk6wMrA8hOgWJcZoFSrT4nJogfPESu4Dv8AVLTTEqsC9MkSDHB2NIYfkZGnjJOqpiZQrkTCAmWyKqtDgXBAEs0tLyZtWRl7953/u/uiUR0sVgH2xuKERCJJnhc6lIFV6B7OuXyAJrIpqDzVlQ99TUKVt0scAEomQaXskBAONlEFrgpvLdkZk6r6Wjn6IxMx2qVeY0IsSVrhqnCgMiiJA62v4a5Vkmz/4a7PDWtmVXSIfGMSAGYVFGCpGvGh5VCiHohEAiJXi77sKx+eLZU1N0hHCyuTAJCCDqCAKIUCYxv4AcY6YnL0qeOkZuhQSeoo6b5OG+AC4ZJQRThQFQbAWt7Bvf8ZSNg3P3deA8ZUF2AzADCrMAArA4u9XMoQsQMp6nHlH5dKdcMcad+fJGVCCKRAxfMU1XKB1dYpI8acKI0jj5FkDNSti3LpzSgjCQQmrFA4HKiuIMAO2EnrtkBb+8pdXxr2OjOd+bAd2vQ2cro8mXPjwH/LwBp4H/a/hLvuCsr06cpky6KHfiK1jRdJ235M80ClABMtmMMfKJQDNB4j1VCstg4ZcTKANWpkZmCxAJZiABYIhgO1VRwi21HGj63OxI27pje9xGz5BlgZWOzVUgSPjEqufOheqWmcIq37YwBCWKsDDGlQULnAUh6L4CLFAh/fCmCNOSE7sNxi3IilxiUQCAdrayR+oCWBcn4q0eSy56c2PMc80+6yg2t4MEAKVgYWO7HYwcz8Ig9XSTz5kNQ0nC7tB6KoBmZ+bnAZdaVUhIMHVDxWQtQCYI3thWKZ8rrHLICiCwCslmIKFGn/GoPm9S+cW7ddswJgZw4Ta9NkC/n6HsrA6nufDewOV/Ap8x8cggHvMUztTpLO5igkCV2g4hMIJI3dY56mqBdwgXOlWP0DlhbNkhVgtoQDELza7Z1iJ2J3J2P2DX8/r+Evmsm2A2dukkBfAYbZSDkUrQco+IQ0XeY9eKwEraekovYkzP4OBhUrlGLEXYB1q6QnzXPYLUtuJ5SLcei1k62tMYDKDtTWnRusrf5/J9zbcv9xa5snc9aooLJti3xYbsVy1lEOxekBI01f8NBECVnbJVx1hHS2YSrnGf4y1SQTwAyYTJzpvr6lAWA2AWYlW1vidrQjGait/VS4pvaPx9/bvOn43+4/GwCzDcAoC0P+rKNd1ot9q1s5d489YIa/BQ9+Ap/yAxKsgJSJ8gGXUc94I1BD4Og/j91zDodYGFTmvf88VsYnpiWSt7ICNXWcoQoo2uNJ217298/X/8bky7ZcVKZYppcKE0OaDg0FDn9XPfwFCYc3YEYGUEUpTQeFUNTgyZniDBUyfJdecu9hVJjAYS+YbGuJ8z9QXXNaqL5uzQlrm3d88O79X+Ujt860MIu17ExDZJliFealkMJYMn1NQNZATnXlQ9+ScPXNEm3H02zKrZQK9PpoxQ5+PBJ3pVwqbkBJpFhjPiSNx47sWY7V60Nyy4BaQDQhdqCyJgRWX5LNLbuA8xUfaKz7sTtEkkhhMuBoU5QpVm792rdclKbzkyWoFj64WCrrAKo2SNMxhukSjb4CvoZe/pGBebyfP88ZTNx14KQX6BdV4McQSna2JZItLXGrsurEUEPdra8daPnv43934CIy+Qoqth2hDKx8v4hpkKbrAi++3AUbf4AlmqukvTmuiytgWfr3OBdg/bs533cpwMDgJ6BFEQtUVB4dGlz/kxPuab5TH8S2A1z9bGi+6/o+KY/8FKkUw6KH/ktqm/4Ngk8y6UHltvVCH39IrQx1SsXmoI9l5Tc72xS2Y50AWGtnaEjdF46/p3mtPuJqqmOUQ356YMZtYai8xITrfzsGb4Dg8392W6IZ8FOygImXslwe8KOzF0Dti2D8vZbO0KC6z37wdwfm/d2yvu8dvbPfXr7acw8YcULkrw0Sa34EoBovHZCmq3Jez7dlvwKkGMCoqIHn+E8tQtse5n1UwZn37HXVq0nOeO14sj0Ws44tD4U59FjWLEaaPue+IyXWskMqa11QUfCZQgaK6OtxhqeaIkpInjLUyiRBjJKMhRrrqkOh5IXlodB0S3/ilDR9/cngyx+RcOVg6WjtXZqe67OUUqVnJroQsgu+nTzF/oXUlsIUTIk/WaZY/e18A6r5D34MXbkV0vTBEoVKZ1Zpen8flv2+FCHLnq0YV4N2Zwcwb48pU6z+dDfVXiKnRKGh8HksJt+tIp44penZlmj68yBzD6DjRQ8pmQbwWR4u2aSau0oQg2JRT9EaUqZYfep9vEaKFGhFs2DDN6Si8m594Yk4RQyF+0gVMRlgwyTzb9qRIZu51C02+Uzc7WLaSS55eIvJh1WHwnVGWt0O+VM1eFgMg4dIXBY8OF+qar8HlRd0JciHRRutEoXUy/Q836R5kjIemnwmzpjJTcwlD7O6+crAytaZ5ppK013B5/wNy6W6/goIPkmlMBD1V5puCu8h5gs66GV6E7zHPZRRsmSrgOS7ZI3K84O9Bg/zN/wcuulfVYMHZ+3Mw+Hk+bmmuHT8pPgrZki/aG4qfVymWNneAfmp6Y5TDpm34T6s+306v9L0bA/ntSzAMZdK45qht4qXKVaPPeTM/GISWVcjnZV/xPB3mho8WL1ofPZY4AAuGHmWAZMpKv3cpPsgLlOsTC/BLNHMXn+YRAOPglE/ERoK3a1oMt1XrDQdDsne4YEEl/kv1vOzPcetUxlY6Z3kLNFEZdGG42Gk/hh00w9Xg4fedNPTy8n7OdBjgKRl+5RcudUqy7G8ADDS9DkPnApQbYNjjsOlsz1/SzTeZ/V2bKiQiZk/HUvp572VWcTrfaNYVLddvTUkgyYl5Rk2c1NARtRbUkIHX3nrKyNNn/fgp6BCcL8E0DUxuHShNL3ULzBFqVCR1KwwlZi3LshnQbkDizMkS61i2dkmqDa2zMQpr7tuDc3FQyOmNH0TtD4hTZ97/1ckFLxDEniBCbpvUZMofzQjHdzp5/6oZaoWuQHLMLOrXmgQO34hvugzUMJgfMnvIH5I9rXfgRfTJpqv9P4vU63r7cAYPESmx2X+A7NgQLoCtn68q7BLNL3VK3U9DT1pp6lsPjzoBVj8mqFWSzOfW549B7ZwP4W67RB1fgm7ACh24T84DZTsKlm2/WKZOX499Z1l512OdYoPG5yqkho8qBAoIXMf+K5UNiyAch4axbdXwiWaVAU9BwZQqdHPJCAPD82/55aSHbp17BlY/JrXQLVmOoa/VTtnSqjqVuFI2LI3itkJmX6nCLrICVceIRVVD8iNTy2RK6yrtVGGypWshVke7Bg8kCqJzF2/Gk45LoGMynEf5HGPl6WEIl/yAIlPTjstcmWyP86tW+ZZoWvCo65sbvrblVLVcCuGCFtiUb6MCjQshH/oOquAtQJMbgKzp6TUD7lKVjy9Ua57bJAaaUZ2dnd0kb1KxblKXtAYPMxd/zss0VwibTB4sEGlaF7sl8AXZP61TjhxX1qqirYO2alTPx0c3JHetbGbdq6SmqZLpXUfAEUnAo7NWA8NYLNjkFBXQJj4NpxkTpMrJj6ixgXPTLNTXut6uLkoyTR4WD0zpg5kB7+3EbrpZ6g0veQyqh5abyTuRBSP1dsM8iYwnMBTn91ph4afdKw0jDrWtqForq+oh6KKmWyDoegOLO/MbuXOO6V20BekdS9ngRwyu+ftsaZ2DPIfmI8je7Rtvlwx9vuatdRDo/FJNe/3gzDZg8FD3RjH4KE/SzTsinTy0WOH9OFCWrl8hD4GPwZYSSj/wmzBqm2y7Ff23H7cZ856Lzxk6LfjLc30nFw69R1PKwmsrqGQL57iAg6DK3c+CCadoOIyhnoh8dzXy6EVhvvohMQ7bQyN18mNf1sHUURdSYdGCj6pnDd349H4RmDwUD0AULH5hQBVT+WaZwF0YEYkGA5KKGRZrfsWyS++fHGgtvofYEpArArjpLaXl93jZYd5N9SE4oTkM5vAd0yQln1k0vvLI/HLsZXa1TbCX7n1nNyw43z5zujHBZ7iVLhaYHfQqRYbafrcB8ZhDHkEk5BG6YD7oP63LVV04Q8AKhIxGuZjsAOVBZtx4C1JJKYmb/78Y/r8aKLKrsYR1A0NBAtfryxPcIkuPPbajjeUVTuOhBcUfM11E6Aa4iy4sqb9/4fPJVCvNrhADFd+QCqr/irLd8zSCYFjht3zjDRLvft0SakwdniYd/+ZuG+LhMKNKk03fj77VFiJMiuDjnGwuoG860a4ED1RAKojbttSwxrB7zYGHuc1MS55AF4IGUjLIUO46RksuNp/lYpqmC/Bw1x+mVln1mhB07Ju6AoMjf8iL738FTy3UzhrjIzm8/IfyKjTfdCc+6bC1eYa/Z7jMcfggS33BsPamDjTtfQ0c55eFtO95XiPzT0m5jUGU0Z6XhvyQ3g6ViXVtr2LZeWUiOZH2044YVL0dT3x5w8oFhys2rIeqiEwX2rPN6hMqx0n+G37YuDdpsqoY56V67eNV1DphCHSxeuZO/obU/7GMjn7m/PANyFNX6MC3XiCzvgpJjk4mDQTe3P0lMb0TNd4rzfde+wt1+TzXk8d66gWxUYC8P4f2yvtLWfJjQAV9e7JA7NtPg8haTzsPzD7GyUt72GbMqksYH35PWJoxDBbUTUK85ptsvypb8q3x96mz/TOSPtbCTV4wGvlJGTu+kWwSr7GFwYPfWoP51RoA4e+1n2PSqdMlZs/97aKSCKngOJGUvDrXiyTDQnsfqX4Z7bOCqc6DsHwNRcnYGjsgJQbHVE3+FZZ/vQdcC7u7CGDnar6XQUtI+L4aJpz/01gdK8BTwL5Gx9Egwd2vJ//teUY+kIBsCRBgGqpLPvMGXLzZxxQcVbrNCCti5wFBCfRL+2juMGW0QoseAzRd8D30O2fzUlP6+nc5DWxN583jUMSCm2Dw/y6QV+R007aKUu3nqRrkpxMcDjrS6BQ10jT59z/K6luvAyg4syPQ6wLqr4UWIq8Nih5NYe+Vuk48FmAap72Az8YB1Q9VwrdfNA3w9wm3RybOD2d5yakX2N6+nWTZtLNPeYc17lXC10yp93NcxM8uU1Sj7HJa2JvRm+aHjueelsh1qiqOREzx7/Jsh0X6mSC7gY5NOYSyKRz2xC24zv3rccQ8iXsRYOv2/ECnEsRpc2jQ19ch77Ols0ST5woy6as06GPn5f5YLJV0tu1Jp83zRybuKc83uvm2Bt7jzOVwTTmwT9dGu6ERS+TvDSV58UKFViH5EaNAfB6PwXftVofTD6J4oJsQaXpYGRnr6+V79y/GUs0ZykPR9/lbgN9G7NdNjeoDGLoqw2h3jfJDWefJiumvJbaszBX0VTf6Hu2Hs3bNQwT1m+kgiIRiB1KFSxYZFNLghoGdYMvkRuf3iHXbzlOxQUEV6ahcZorTZ/1wAjoiO3AyzkFwx+c8XORHKjiv5+DLRz6sA8h9nZuOzBdbvjMLK1uLkOfn9vl1g3A2r8CM8I9mEFV4qU4MiXvOzHH3th7zIK85+nH5rynfCYdW2ugnJBK/Ctrx0qw6hm5fvsXFFwcGimxN4HS9DUQfH573YfwPTwFg4fjpJM7PKjmhcnlV3Bx1ucOfe07xI6dJDees0Y4pNPFRy5DX1cLfXsUkCtOxxZjyU/Br9M+fEFUiekClwFFeszmpKeZc+8102xeM9dNbPJ5z538FbrkEghWQOZ1pyx7apUmczcqUi/VTQeoZq37H3g9T8J90FDpgMGDoVR8kLdMf1EuZ8ivqgthdWO1LPv0eFn22ZecoY+yKX+syjivYWC/kLxjFjYba3k37RwHbYQ/gU85qgDS977WMgyhZhL1SGJovFSWPf1ReIs7T2aOe1ULunTt2Vgp+L0EQcSiEF1YWDqiSoluDwKGg++HE0vDexhwmfO+1iYv+S0ubVHUksTQ9zVZfvYdWqzK71SU0L+nOFIv517vB9W/0gZ+l9vHkOSCtyIluHz0yxK1x0GV5GmdoeCVDfwpAyqBogJ82Zg1Vtd/RIKBF8B7nSUX/OJf4drz90qVYjHOBimecKgUY90ShOfuMaJU8B6nEgt+gFePpZlqLCBH25/DBzNaQUVAkXfMhwEK21Wath3ceW5d+PIkxSTPH7tXmk+eiOn6I1Dwo2ZDqcHF2nHxNY79jaskWLleRh33S2irQqVQfVIFHSDh3XHWrpQJLdPGeWMee/9ZbFECJkSY7VbVYcWh+eey7AmAaspz+iETUO4uDgOuSUkpcebad8mKuGCrZFlnh2fKsr/9FtP/86TNVfSDWkbmIoqQylljPEaib0lTExaGwra8/lpQosB9GE1QIOEqPxPW0tSUMa9pwEnqnIkmk3s5/1EUCo8V0E0TiBJmyvJzVusj2Mfs6/d5cCiWaSS/IkqxGWaffD70qWBoMIgyIcq4Uq9Irxfzx3myA5t43JKamoCMHClSXw+aSlkoMpihzwyFhKFJ1/vdPE5ZXdfy3Q5oTqFI6E5BRTvW8SK2lx+voNKPNgLWA338TxC6A4sNphRbjSkw/s8+eaa07fsurFhI2dhhfF2lDWTQoaggQVTpA0eJHHY4XiPOwetrDVNgwrnqiBtApRDl5DOtYP78BQ5vAlCFsSxzl7zcClHClB2iyoYAVARrmf8koWso9DZYFfHwdX0Y9oHTRy/CrOxt8AkrIZJALjpcpm51Xl+I9+m9H3MU05UQxEOHiVRXibwO7SRSrwoOjahbgJkQWE0e8oVztmji9Fkj0wcWMPRVVKiKTtuBy+XGsx0xiVKqyYXlVdlG/vshuN2YGVisoH5dnLWoOOImyJPeAc/wC3QcGGa4xnUMLErfFFaltk5k5CiRN94QaW4GuCBrVPGDCyRvLfkC2Hj+6zEO9Nh9MzzOOWhm3hhXteGOlldBTc/HssxmxzrpGbsYQ182omua21OT3FZrFzBPT+e85u0ak8+km3OVxOGkZ2DxDn7iEXQaxREzx/4SDD1M6m3sEAqO2ewQakrU/O6Pvije7p5785hrvGSu89jk8V7PlMdcN/eS0pih8UgMje++LfI2qoklOLXUZkt1wOcDkFfv1x8cI874Vkw+VgCB2RlMHXmsRejegwGIZ8JYjlon1rtfkhUXtOrQNx1C3CIFVstbtfTHZrtm8qbnST9nvkxp6enMw/+DeSzmTA86Y4Qa8eyT16NHT8UMrRVGCWTqM89uTA3MU7zlmWtMM9fT09Lzm3zmHhOn0vGWafJPkAw9TOQoAIygUb8eyJxi6HE9xXchnflT/ywUQctkunPaleY552HStZgJhi3M+uZBNgVVF4CKSzOR4oGKVTG457FfQm7AYm2pm04d9dknPwFqMB4znjexvkjtg6J9mVk7jUBiIPWqw2zxmFGC2SNqh+oRPBnB5QJIQcRjPXDKMYBzzry/zARVH7Q9EXsL1uEfx1rfUkdZ8dBQG/Y2plDHuQOLNTDgumL03/Gmxkln6y61fPYLuFhHMzSGgfkjj3aYezL1pGgMBjA8V+rlUjoDKr3uZE3l7zoFakHLqDbc0bIRVk0nyopzHtO1Pi4eF8ukras+vj3qG7DYDIKLPNd3xr0lweYJ4C0ehx2iX6T0TkcTXAZIFEccBYBxFqgyL2QheMyQmKJkSNc0FpGJenHoCwWx3hfAWl8EVOosWXnuPh36etPwZJH/ZKEX5r2H3lCeC7PFKyzunv1Ruf6pP0BK/xnIvEAaqFvFt1jqgCpw0OLQWN8gMhLKjG+8JtIK/1ecNbKGJGLpNeU9BCbTnWOagsZgMQOFRGiAWPHpECVsVIuZnR+Gh8PpmflM3F6UwDawnvz3S0Bd+k6xTOW5eG10pOaMPRuLxXCuTyl90hkuTL6Sx0AIlxXDIKpHjRQZMsShXPTa56VcqSHQTdcXBbJnQ2BWSWPR1kelDUPfcoBKVXci9vtFd6oQr6j/wGJtqCNFjUeGOWMuxBLQcixekwriO/KRLwHv0Hj4CPBeRzqgov0qAaT8Fqps+C4m2kkYY0BmEa4KghIvlZXnnCG3nveWZ+hT6LHp5XBwD/RvKPSWo0wrZkMMc6zZGBbfgT+t66DRyY6nkagDPM1Qwh+Ci4FDYwMWsisprcfQ2IGhkYw+KRazONloLIq1vvZWiFa+BJP2dchgybQ1MBYt8dCnjfD/z8AolmkfZ0NXA0JcvpgDt0Wdzd/Al45XFODSD4dG/wQCjOCiAcnRI0WaBrtMPb8D12KmAgvIHa2bpS3+IQUVhz6G94nasLalwD8Dp1imgo5ukSulH/NjuQGUywrdA78JQch7yGLmB8TmeQONCS6CbPgRWDSGu5Z/vAF+CkNfTS1mfXtXya1TL9dHqCXQIaLmwm/DBFJe7znT09PMuYl7upfXGdLLc1K7/7p58/+yOWNUccTYtVhS+QgsaPaBcPE5BJd/gndoHDTYlpHHBeB36oC89drZCirObA8VixkltmldmwkE6Wnm3MSmiEzn6Wkmb3rMfPjPP7D4oK3u0/78Z5FX9jhMsVq551o79/5iRDo0gomvAs818liR8ad1PXVa12H5qA89AKqVf2BxrYwCw5lrPieHD31C2jub5OUXk2CCAw7L5UNwcUxMQKHLCjTAKvsPct2Om5Bkq24aqW859LkH8ggsDB1k3uli59/v/jqMYO9Rvj2AmWFHR0BefglMMhza0LKGMzD/hQDUgRyj2fpBl8l12zdL5K9HpuwBVHTvv0r7tUb5AZb6bVoMYEFL8lv3zINu0o/AsBM9CTCMWAbBHCEOATXB1Y7pvU4WcZk5/PXfZTRLy6Cq6ufke09+VsHFehq1bb++TR/Va+CzQjK4EXe/5MvWLoerSeyXDPdBAVCwpOvFlxQqRHBhJrZnt7M4TOU8MzPzUYe4VaG4gS6FatGetfK97ddjaJyLa47RrB+NIQh8PwTOClGXgVEsgsrIdi5f+zOs+l8Bwahj7UuzJz5E//mDgDVcPX9lt8iB/Y7euj+HRdbWMZqNtiakfvAc8F2PSmTHYV1Do7aE+UobONf2C6jYE6gL33b/gUV+KgWqdX+AT6oLoOnARWhnhwcDKM669JhPRSCPxf/XXhHZS01PHPuqZ7SW5of9E3CNZj8mVbJLrtl+loIr4oojTM4Sxn7CFbuB9enfUKhakpNj8h93VUuyGvsl130UVilw323R94MTCCg9YYygp7hI1RQaOpB6vQEDCA6H1PrkOp03v97kgx/HnpL6V1CbqWgCv7hevrttsSy0Ilq7EgtQ2Wump33QW6kq9B1YpiMvvW8YhJ+PqdO0Ds9+yYoj/Ojam56kHqYHmgRwMaZFzVtvOuAaNtzBlR/B5bSAGqPYGAFbi9QPuVq+t+NfJJqcJpEJ+4QuLrlDWjmkeqBvQ6HZ4eGydcdLAO6DKqpPhI4SVZOp6OeARYHhAsekKZjwo8OiJ+Z16kbRAOLNV3nm5NElO5RhyvJLTHea3MiJ/iRq6v+3VFjPy7VPflxBxRmj2mNqK/7pf3IHltnh4fJ7P4IZ3zZoUg6Hdxp+pQ6oTFfqEOieKKBwzDh17AKLwyH/mR/meLJ/L7QN9jhDIvdB9CtTr0qMNneIiKEPhmH7lEfku9vnOoa+WIw3C9amP4oR+/AbzA1Y7Cxanlz++08CCI9DRbcWPgnIqGeWSnvBpR0L8JiYh/qPH+bTf6RREa8FNoFcAqKtoJ/B5bQFewZhO7141IaD3u9DJLFOZu+o1VUHP26np3Uu3k8vwDLSdCzRzFr7ZciiHgAQsPwBuyobfEW2LyVFokxjCCIee8BkQMV02v8RXNSPenk3zOYxwhpBKm/LFkw9TB6eDySY+03MsjIeu3I6qmTXYM+gwfYuWbLlNLULoHZtUYdGVtD8pzc+vfLefOnXvPem5zN5M6V3v9YzsChNp2Ibpemz7p0l4dpfqOeUJFSPnQ0wvTXo4ViR5FxLgYqnBlxpMTuGSnc02SK4OqBST3AZIwfTnvTYeUL3fk3P05dzlsf8DOa+no45a6QzXe4ZFKr6APjOv8o12y4v6p5BWlHvj6m0idMrb/Jma6S5Zu5Nvyc9vft5ZmDpEk3E0em+7N5rIX1eIdFWzGyVq6bgKfdAqmSCF1wpapUJXHgEh8NXXoILoBa/C1JN6+CyqBOUPI7t9AatxKzxLrn0vkp1bPdPODQeDCxdook4QqVZa2/D7GchZDjcL5mwQH7zFfQh5p0KKjc2YPOCy0vF+Koo5+KzXtkNfwz7HHBpAp/r2wALJdSNGyPUNE6DEuGzsuTJcY49JgTKzpYsvq18PivWHVjdpOlrfwvd9RmuM/787Jes4HIB6QUaW6Tgw4+Czb1IqTyZ+NdeFtn3btKR0pMZ85GhxsFvg5V39wyqHgWB6na5ZutMZSnoaIV9XKrQn2+yP/egfV2NNNJ0xjXDN0ql2S8Z0vR8BgLHK0pgxV0cOY/xnDAflU8tGIu+9aYzWRgCt0UJOF9znMH1bVjOZzt6L8vZM4h9zD2Drt3+LxIf97WUz9d8LWSbBYtcAZBrPm/7+noP8jsUS5XzoEc16+4mqR6+RSrqzkjtl8xCc/lnRUw+7zHTTEgde8Bz0LCIzLys/5oPFjPwkxCQDnn+2bPgYO1fwSTjOrh6G4Ya5pn+jDE0grpS5lXb9FUJP7VTIls+5Kw1gnL5wrDXvJz8xpj1oYFUzrt83dGSCMAZf81Y8FQHO+Pv7bkp0CCj95j3mZdujhl7yZSCCyDSYZCXcBzACwnAKLYGxqLxts2QPxwvd39zo8w/+ddQGDxHqR73Rwa3rMX59kc3RjBD44cw690JvusCHRqppVrKobGAfeaIEy5feyImfNg2pOooSNO7lmgK+GAt2lArnihxYkyAYeijAUYl9pjpaF4lt00/TX70lVfVWJSqwgvH/AE5T8eQ2AEzMw7n7jpdOqJxJWPIlC/XtPQCM92XMQ/ccbt7BtU1/QwiidWai+Kc96H6c0C+xh1W7fWQvzTBNVHxQGX6vhu4lGphjxnsLCrJKDZvmp4yw1KLGVBW9RsBd0oLxv4FIJyAOr+NZRXkx7ZsGviie/tnxvQ8uablcl9PecBv2VDj0D2DBl0i127bLpEnjtU26VIQBNLvkxCQ+v1XQJfqGHxNUEjHGthBHZ7eSQU4d7qTbChcLtLbMPaYSdgnyQ/Py7zHjHGntGDscxhaMHS3/re6asy0XYvBi/eFsQnpwdsscy0930DymHsdvha7fWEhu7J2HDZAfxYAm+bsSYih0fjDMHXoT2yeZervPc+WxmeZ6+bYe6+pS7Y0Nw+1PKfiq+dp1wzRFFC8OA5+Co72MfS1H1gtt5w7Xn54/otZ95gx7pTmjH5T4vvGw2nHFvVbZcDFupsO8B6bjjPXTOxtqzfNHDP2BpPONHOcLY+5tysvvdeg3dgzqKr+Llmy/SbNYvYMMvlzibvK7A4M3ptep2xpJq8pL/3ZmdLT09xzzgpH61INfSyYTMWMsYCDWV4Iin5JqDVfAFDN1PbopAJrlNmCDos2BI+TW2Th2FMByg3ujhrZ78tWZlGvweWTs2cQttNrugx81+MQS3xAh0blu3IbGv04ftIqJTOqC93BxtF+pTrafw6mYqNl1bl36CyJ03AytbkE406JM6xF4z8Jge6vAK6wTgDcvWNzKaaEefhxO0NjVd2pON4li7dOUXDx3ZC37CUwmwnmdZrYpDP2ppljE5t86efp96XnY34TzDFjSh//Bv/kvAYd4aIFGFzgj3vMdGCPmSHbR8stU59z/E4BUI4fiNwr43WntHDcl8G/rJJqgIu+rfwtpfe2EbNG1zKouv5eiWxbqv1Au4JeZo0GDObFegvNdC1bPnNvT/eZdJOPsTfNlM09oddgys7ruVEI5hxIsDj0VYKfAwFvb54Jby4XYg3NWeoYiMtFvgCqqZDaLRp/OcB1JZakKOci3YLDD1Ta7/9JWgbBRq6TlkGD5sjiJx+V2X/2n2VQDu8/IC17V2L42A1xA/z64KUXKujQR5eL2F4tFn0RBHI8+KnVOvSpNkWOQ1+2+tGdEgP5s0Xjr8WOW/8GgS9oozqOKCZFzlbL7NccXjfoWAY1fEzqq3fJVds+4YhZImARXF9k3lL89MGwXqhPQH56UQcsts6CuOE93ahR5UF5rimXXshhco+Z9pY1MrTzJLn5vB3gHypSi7PejhrIsUqzAVLKha4afytEF1NVpyug6hLFocoDqT/vdWR7mDU2O5ZBVdUb5KqtEYey4+Pxqj87n9JAn5i/+wkdBGdJZ9WUFyCQxA6rHS/hCyfDxSWd/AwdOuurgHYEFNw7sMfMLZ+frmrOpCrc17lQgcMqeZNF434LmdhkDDHc8zAEgB8iM0b2P3eOhWVQtD0J58FXy5VPbpBZ25oo83r++TfyqxyQ5/fgLOlwEfrm818Vq3U8KNc2LEI74BrYwwBNDH0sK9b5GmZ9p4FKrdJZTr6Gvt7qZ6T0V47ZBHP5SRCr7JMwpfQ+B5f71euXzaGRE522/di0oP4TUpvcJXM3f/z1mUdAhxvB5jDvv+BUiovQpCA3f+WADN1xCuRJD6oEnIx2/4KjdVCFPWY6WtZJdcuJcvO5m3XoUyZbFQn7V3Jf7zJS+oVjnsIEcTx2Z31FKqAtQUGqUmXi32f/rJjWCY1lHeFgCb/caTYGqnsY+OFHAnO3LGJXBMIWWBkeaU498MOPUyVTE4LLyI++dc+vAa4vYvji0EGpfPe85p70mGAM0CoCIR6dJ/953lI99patCUX+4bBICjbvsUFwB/kIpPRj8KL44fhzSCGgGBh3Axn41aQdsGqHWPZbr99+zLgT3gsNGvrtROuBBF5QrzIvLbPQP6jzwWDxOvr41t2rAK5LIWvijIp5s5FdKi9j6KvlUsVbYECnQpTwmA59o6fZUHArPZtJptfwXv8IboT68Bk6xPgRXClg4cALLvZiEjIVKDraiXBo2PB6qR9xmG1z59kMr7PQGMpYPup7MFCcocqRB91y7mUA1VVYLOVyDypuPCBrS1EmYwam47OiFL2zZSPoG4Y+BVWFOg7xA6hYTYKKlJOU66oJZ0rr/rtTS0CHgpReuxs/jmVQCPywI0JxztlC34SDKZapGgWN02H+RaB963ffxHreDzGzwteC3bNtBSTvZZOgkIehjzxkLBqRH5y7WIswWqmmPD/FNIfnFsUMS7bDYKRxBgSqFEVwKOm5T5i/WKELROxl/W7R06RW+g+KJXZnTIYdNVzqh9ONBprjVUEqVj0zPQd1660TIZB7GIaXkAv9+2+mADy3Y2gcgoVTp6E0dCCgOg5g1pe8WH4wbQNkLQHhHjMEpJ8DBY0RvjK8osg27HvduACCYjNcH0zJi90W1Ayd7DyVkbGtzAiswwAsfBeHELCchhnqM+OuRqkIXoD2noEL8LxvvY3GPCTh2B2yYnq7sx3ITH75bo84t/v210uVl2ybBf5wBfhDNAvrpqXeUUN70O1Gwt0w8OnAOhIUa8ShCiwio7dZXW/X/YsuUOVNDlVevA1uBCp+4Qz5HPd1NlyamucCrA53KDykgcXu5Rc+c3VI9g5KymhspE3m//UR2FptBumw+3mV5j0M+KlGHBHZ+ikM7/dj32sMP7EYKBcFqsUP2YCFncu681igWLQcTx8KWUZPzE62awNtLcru6bEDLfrQvJ+m8CpQ3X4q3tzD0PqogXYt5XjFB1cmYPXIvPtvKCw9k+onCBopfWT8ZkjksLzV+aYadqSk9KgsX3gx/k2/pD/LpPs8LgMr/QUZXfprJ2Bh3sK+123P6/JWIVWK0utgzg2ozPkhNL6UgWVemjemAJU8VwT7XjcMHQ8h8eNqqFEIlaKeyB9ngb0FD/ByyN1baXm9fgh9A3ltd26FRWysnVqcHWJW/OR9kNJ/GoLU4vBcBilGzGBil8/iAhkFpEMpIPXhrLBMsbJBzBhqKLAmcjN17HsNXXpHjdu8+mwl9P9apk9eKRR+0p9szvU6HlnK2G1xGVi9vXqvoUZk4oUA140w8KW2B2hGARfWDThYP++x1tckmNjNo9dK/ONWKdN3UeKa+fTxRtecC+pXbZkPcH0PqsPU5GdX5v8DZakMZgg0cZrkXYfC4Yf7bkkn/x3idMf775eAigBEXGFYcgo3U79EQtXQ7cSCKXX6CxIMunoo3KUOPVwtaXIZWH3qfi5Yu4YakQk/go3A51XafUi4U+pTQweWGSpIZWD1pwtVrwtS+iUT1ko8/nFVJaKtZKENNQyFMnF/6l7Ye2wrCIc62GukDKz+drSR0l8z6TG4s5yIPXbew9BIXXqKI7oYbgOCvsbeepl7vWneY/JfDMqH4bhEMRj2hAXjZxCsp8vAcl5J/34NuK4av1OsTpjPte+GQa5jqNG/ErvuUjDhVbmY6bqQ6cgFU6ZLRUyzEdRnbFIeKANroB1vloAiH31VAlEsAbVsd6T0/bZw8tQoJ1Qhvy8m99ysPZxs2d8mVujnZWB5XmO/D7kEREONyEcPyMkTTsEuFX+ERir2boRdZSGDUrVCPqAPZYMFCNbX84Yluy+qe7MMrD70XdasxlCDAtVrJv4vWP+sgadkDIsElzI9uN0gIdfYPNGlXOnFmMsljdFeLNAHmxorE/v33bv7oqalaK4/rWhL2k8DeThFEcaf1ZKJ0+HY4wegXOS5YAuI31zx5OJI8cib9L5UImpojgdS2QHfS0DFrFA4GKxrrEjs3/9fuy8e9DktdbFaQgz4AeUCvD2g5nOuO6VrJv0fDItL4E4JogjVsOUScm7BYMfEB93FC+b/oIuFTEiAcMYx+wsGahvDyVjnq4nmfReDUn1RH6pGKlayPBQW4hUYO0qamV0z8WpYMV0KhUH0tY4Q+ZfSG/AZnBUmTuDTiFsVNcFgbWPIjna8YLfun1H38uvHgVLdnvJN5rbdF9OJQrxbn5RJf1Yw1IDqzZVPfhEbiP5aN1BLUkG9F0MNBQt+UiBxj71rhdCaHno07QoLt1YIgGA7M9BbGC1zM5Bk+4GnwUIt3XNxw69cKixnPmyHNk121Yvcji9TrMIiEEtA6HAqDV4z8U5I6T+hzmyD3GW9Hx5vCDIGAzZzrIn5/eFwhxITVlVdKFBVF7Q7W59IdLSev/viprF7vt74S4JqEtsFlKWDijUpU6z8vo+eS0sZamyBlN7aBEONejXUsGCoYQDjvVvT8GNAZGaEXoqVUvTLH8VS/snCnmvVDQFa/tjR1sdsO3AdwHS/Wz0LgAptnTmJZkGZaq7ZysDyvsxCHxtwLdoxCiPMn2AgewQc2mb2eJMJWAQV0xHzlXZpkA4YWCiNQ5kdCtQ0WuCf4NmscwOmsd/f8/VBD2u3gDKduUmCmahTpm4rAytTrxQyLWW/uGUoKNejMNQ4CTr13cFF8GggenDgpVY89wLr6BHgsQ7DOjidTff5dbI0DnlhAEqSHdjNNh5fiw3Llu75+pC/IB0q2aqoAHcE3XkovZblp881yVJW+VKuPWDcKV36QqU0qJT+dPiN6AIXX7cGHPA4G7COGiF1AFaffDfQsw55KMsCoBok2bqfT7sTz7l+zzcGbdNHc+uVZzZh8jGZwOtzKAOrz12Wpxu8LgkWbr0XUvopEKimGWp4gEUJmAGZl2L1DVgsAYAKhAO19ZJs3o9j+Zkkg8v3XFL/rLaM9frwmbZulj6AppaBNYDOG/CtpApcAmJYuPUnMNS4SNr2gmO2HP/0TDdgMjEBRmDxkjLvOVEs3pWA92hQqDpJtuxrR7k/hl/AFS9f3PQirolAZCBvI9XURxP7/1MGVv/7Lj93upJqLWzh1qWQ0s/pcqdECT6umKGQxwAV05R5j9L8C8A6vMehUAFlBcNhq7oGgNp/wLKTt8bDVatevbDmNT6TIoOtg15MpvyFMTEPoQysPHTigIugTzG5Gowy9OoXPPEdMPTXwykwAUVqxi2KFUwKMgUWKRYYpWhchn/wGGCxAU5BkLWLeQegrATW8cJWVTUB9Q6YqlsqrI4f/P3iEW+zvpNus8Nb3wAVM6sEA25E9wLKwOreHyU8gycf405pwdavwZ3S7ZIAP5+EOyUbUvoUuFxQxeLY76FSjjj+WC+giK6kFa4IWxVVYMr3vQ5ErgzG965+ceZxyqErhXpjUsEAZTqwDCzTE36JzYxx/tZzYFS2DkpzdMHZiRcF7866L5DjFhJE7IhRx8CNfi135COg7EBFdQig4izvJSwdLU80t/7k1SuOamfTCk2h0ruvDKz0HvHDuRGkLtx2OpistXZlw1C7+T2w3xBWwV9yuKpKhh0xApuIYJ+gZDJgVdUGaMQAQD0HfN2w59Wmnxu5kwOoxaBQEfJbRQtlYBWtq/v4IJdyjbx9b1Pzu3uvxXB4QbCmqT4MnqmiBgYL4Mq4aZ7diQleLPokhKM37P5G453mKTrkzcCyi6OuY5KLFpeBVbSu7seDPLKuCffZw5rfjU6OJ2LjIQyFm2S7E2B7MRBI/OmlbwzdbEpXQPWyjmfyFjL+/4JPu45FLkyEAAAAAElFTkSuQmCC');
+			background-size: 24px;
+			background-repeat: no-repeat;
+			background-position: left center;
+			padding-left: 36px;
+			font-size: 20px;
+			letter-spacing: -0.04rem;
+			font-weight: 400;
+			color: white;
+			text-decoration: none;
+		}
+
+		.message-container {
+			flex-grow: 1;
+			display: flex;
+			align-items: center;
+			justify-content: center;
+			margin: 0 30px;
+		}
+
+		.message {
+			font-weight: 300;
+			font-size: 1.4rem;
+		}
+
+		body.error .message {
+			display: none;
+		}
+
+		body.error .error-message {
+			display: block;
+		}
+
+		.error-message {
+			display: none;
+			font-weight: 300;
+			font-size: 1.3rem;
+		}
+
+		.error-text {
+			color: red;
+			font-size: 1rem;
+		}
+
+		@font-face {
+			font-family: 'Segoe UI';
+			src: url("https://c.s-microsoft.com/static/fonts/segoe-ui/west-european/light/latest.eot"),url("https://c.s-microsoft.com/static/fonts/segoe-ui/west-european/light/latest.eot?#iefix") format("embedded-opentype");
+			src: local("Segoe UI Light"),url("https://c.s-microsoft.com/static/fonts/segoe-ui/west-european/light/latest.woff2") format("woff2"),url("https://c.s-microsoft.com/static/fonts/segoe-ui/west-european/light/latest.woff") format("woff"),url("https://c.s-microsoft.com/static/fonts/segoe-ui/west-european/light/latest.ttf") format("truetype"),url("https://c.s-microsoft.com/static/fonts/segoe-ui/west-european/light/latest.svg#web") format("svg");
+			font-weight: 200
+		}
+
+		@font-face {
+			font-family: 'Segoe UI';
+			src: url("https://c.s-microsoft.com/static/fonts/segoe-ui/west-european/semilight/latest.eot"),url("https://c.s-microsoft.com/static/fonts/segoe-ui/west-european/semilight/latest.eot?#iefix") format("embedded-opentype");
+			src: local("Segoe UI Semilight"),url("https://c.s-microsoft.com/static/fonts/segoe-ui/west-european/semilight/latest.woff2") format("woff2"),url("https://c.s-microsoft.com/static/fonts/segoe-ui/west-european/semilight/latest.woff") format("woff"),url("https://c.s-microsoft.com/static/fonts/segoe-ui/west-european/semilight/latest.ttf") format("truetype"),url("https://c.s-microsoft.com/static/fonts/segoe-ui/west-european/semilight/latest.svg#web") format("svg");
+			font-weight: 300
+		}
+
+		@font-face {
+			font-family: 'Segoe UI';
+			src: url("https://c.s-microsoft.com/static/fonts/segoe-ui/west-european/normal/latest.eot"),url("https://c.s-microsoft.com/static/fonts/segoe-ui/west-european/normal/latest.eot?#iefix") format("embedded-opentype");
+			src: local("Segoe UI"),url("https://c.s-microsoft.com/static/fonts/segoe-ui/west-european/normal/latest.woff2") format("woff"),url("https://c.s-microsoft.com/static/fonts/segoe-ui/west-european/normal/latest.woff") format("woff"),url("https://c.s-microsoft.com/static/fonts/segoe-ui/west-european/normal/latest.ttf") format("truetype"),url("https://c.s-microsoft.com/static/fonts/segoe-ui/west-european/normal/latest.svg#web") format("svg");
+			font-weight: 400
+		}
+
+		@font-face {
+			font-family: 'Segoe UI';
+			src: url("https://c.s-microsoft.com/static/fonts/segoe-ui/west-european/semibold/latest.eot"),url("https://c.s-microsoft.com/static/fonts/segoe-ui/west-european/semibold/latest.eot?#iefix") format("embedded-opentype");
+			src: local("Segoe UI Semibold"),url("https://c.s-microsoft.com/static/fonts/segoe-ui/west-european/semibold/latest.woff2") format("woff"),url("https://c.s-microsoft.com/static/fonts/segoe-ui/west-european/semibold/latest.woff") format("woff"),url("https://c.s-microsoft.com/static/fonts/segoe-ui/west-european/semibold/latest.ttf") format("truetype"),url("https://c.s-microsoft.com/static/fonts/segoe-ui/west-european/semibold/latest.svg#web") format("svg");
+			font-weight: 600
+		}
+
+		@font-face {
+			font-family: 'Segoe UI';
+			src: url("https://c.s-microsoft.com/static/fonts/segoe-ui/west-european/bold/latest.eot"),url("https://c.s-microsoft.com/static/fonts/segoe-ui/west-european/bold/latest.eot?#iefix") format("embedded-opentype");
+			src: local("Segoe UI Bold"),url("https://c.s-microsoft.com/static/fonts/segoe-ui/west-european/bold/latest.woff2") format("woff"),url("https://c.s-microsoft.com/static/fonts/segoe-ui/west-european/bold/latest.woff") format("woff"),url("https://c.s-microsoft.com/static/fonts/segoe-ui/west-european/bold/latest.ttf") format("truetype"),url("https://c.s-microsoft.com/static/fonts/segoe-ui/west-european/bold/latest.svg#web") format("svg");
+			font-weight: 700
+		}
+	</style>
+</head>
+
+<body>
+	<a class="branding" href="https://code.visualstudio.com/">
+		Visual Studio Code
+	</a>
+	<div class="message-container">
+		<div class="message">
+			You are signed in now and can close this page.
+		</div>
+		<div class="error-message">
+			An error occurred while signing in:
+			<div class="error-text"></div>
+		</div>
+	</div>
+	<script>
+		var search = window.location.search;
+		var error = (/[?&^]error=([^&]+)/.exec(search) || [])[1];
+		if (error) {
+			document.querySelector('.error-text')
+				.textContent = decodeURIComponent(error);
+			document.querySelector('body')
+				.classList.add('error');
+		}
+	</script>
+</body>
+
+</html>
+`;

--- a/extensions/microsoft-authentication/src/node/publicClientCache.ts
+++ b/extensions/microsoft-authentication/src/node/publicClientCache.ts
@@ -1,0 +1,235 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { AccountInfo, AuthenticationResult, Configuration, InteractiveRequest, PublicClientApplication, SilentFlowRequest } from '@azure/msal-node';
+import { SecretStorageCachePlugin } from '../common/cachePlugin';
+import { SecretStorage, LogOutputChannel, Disposable, SecretStorageChangeEvent, EventEmitter, Memento, window, ProgressLocation, l10n } from 'vscode';
+import { MsalLoggerOptions } from '../common/loggerOptions';
+import { ICachedPublicClientApplication, ICachedPublicClientApplicationManager } from '../common/publicClientCache';
+import { raceCancellationAndTimeoutError } from '../common/async';
+
+export interface IPublicClientApplicationInfo {
+	clientId: string;
+	authority: string;
+}
+
+const _keyPrefix = 'pca:';
+
+export class CachedPublicClientApplicationManager implements ICachedPublicClientApplicationManager {
+	// The key is the clientId and authority stringified
+	private readonly _pcas = new Map<string, CachedPublicClientApplication>();
+
+	private _initialized = false;
+	private _disposable: Disposable;
+
+	constructor(
+		private readonly _globalMemento: Memento,
+		private readonly _secretStorage: SecretStorage,
+		private readonly _logger: LogOutputChannel,
+		private readonly _accountChangeHandler: (e: { added: AccountInfo[]; deleted: AccountInfo[] }) => void
+	) {
+		this._disposable = _secretStorage.onDidChange(e => this._handleSecretStorageChange(e));
+	}
+
+	async initialize() {
+		this._logger.debug('Initializing PublicClientApplicationManager');
+		const keys = await this._secretStorage.get('publicClientApplications');
+		if (!keys) {
+			this._initialized = true;
+			return;
+		}
+
+		const promises = new Array<Promise<ICachedPublicClientApplication>>();
+		try {
+			for (const key of JSON.parse(keys) as string[]) {
+				try {
+					const { clientId, authority } = JSON.parse(key) as IPublicClientApplicationInfo;
+					// Load the PCA in memory
+					promises.push(this.getOrCreate(clientId, authority));
+				} catch (e) {
+					// ignore
+				}
+			}
+		} catch (e) {
+			// data is corrupted
+			this._logger.error('Error initializing PublicClientApplicationManager:', e);
+			await this._secretStorage.delete('publicClientApplications');
+		}
+
+		// TODO: should we do anything for when this fails?
+		await Promise.allSettled(promises);
+		this._logger.debug('PublicClientApplicationManager initialized');
+		this._initialized = true;
+	}
+
+	dispose() {
+		this._disposable.dispose();
+		Disposable.from(...this._pcas.values()).dispose();
+	}
+
+	async getOrCreate(clientId: string, authority: string): Promise<ICachedPublicClientApplication> {
+		if (!this._initialized) {
+			throw new Error('PublicClientApplicationManager not initialized');
+		}
+
+		// Use the clientId and authority as the key
+		const pcasKey = JSON.stringify({ clientId, authority });
+		let pca = this._pcas.get(pcasKey);
+		if (pca) {
+			this._logger.debug(clientId, authority, 'PublicClientApplicationManager cache hit');
+			return pca;
+		}
+
+		this._logger.debug(clientId, authority, 'PublicClientApplicationManager cache miss, creating new PCA...');
+		pca = new CachedPublicClientApplication(clientId, authority, this._globalMemento, this._secretStorage, this._accountChangeHandler, this._logger);
+		this._pcas.set(pcasKey, pca);
+		await pca.initialize();
+		await this._storePublicClientApplications();
+		this._logger.debug(clientId, authority, 'PublicClientApplicationManager PCA created');
+		return pca;
+	}
+
+	getAll(): ICachedPublicClientApplication[] {
+		if (!this._initialized) {
+			throw new Error('PublicClientApplicationManager not initialized');
+		}
+		return Array.from(this._pcas.values());
+	}
+
+	private async _handleSecretStorageChange(e: SecretStorageChangeEvent) {
+		if (!e.key.startsWith(_keyPrefix)) {
+			return;
+		}
+
+		this._logger.debug('PublicClientApplicationManager secret storage change:', e.key);
+		const result = await this._secretStorage.get(e.key);
+		const pcasKey = e.key.split(_keyPrefix)[1];
+
+		// If the cache was deleted, or the PCA has zero accounts left, remove the PCA
+		if (!result || this._pcas.get(pcasKey)?.accounts.length === 0) {
+			this._logger.debug('PublicClientApplicationManager removing PCA:', pcasKey);
+			this._pcas.delete(pcasKey);
+			await this._storePublicClientApplications();
+			this._logger.debug('PublicClientApplicationManager PCA removed:', pcasKey);
+			return;
+		}
+
+		// Load the PCA in memory if it's not already loaded
+		const { clientId, authority } = JSON.parse(pcasKey) as IPublicClientApplicationInfo;
+		this._logger.debug('PublicClientApplicationManager loading PCA:', pcasKey);
+		await this.getOrCreate(clientId, authority);
+		this._logger.debug('PublicClientApplicationManager PCA loaded:', pcasKey);
+	}
+
+	private async _storePublicClientApplications() {
+		await this._secretStorage.store(
+			'publicClientApplications',
+			JSON.stringify(Array.from(this._pcas.keys()))
+		);
+	}
+}
+
+class CachedPublicClientApplication implements ICachedPublicClientApplication {
+	private _pca: PublicClientApplication;
+
+	private _accounts: AccountInfo[] = [];
+	private readonly _disposable: Disposable;
+
+	private readonly _loggerOptions = new MsalLoggerOptions(this._logger);
+	private readonly _secretStorageCachePlugin = new SecretStorageCachePlugin(
+		this._secretStorage,
+		// Include the prefix in the key so we can easily identify it later
+		`${_keyPrefix}${JSON.stringify({ clientId: this._clientId, authority: this._authority })}`
+	);
+	private readonly _config: Configuration = {
+		auth: { clientId: this._clientId, authority: this._authority },
+		system: {
+			loggerOptions: {
+				loggerCallback: (level, message, containsPii) => this._loggerOptions.loggerCallback(level, message, containsPii),
+			}
+		},
+		cache: {
+			cachePlugin: this._secretStorageCachePlugin
+		}
+	};
+
+	private _lastCreated: Date;
+
+	constructor(
+		private readonly _clientId: string,
+		private readonly _authority: string,
+		private readonly _globalMemento: Memento,
+		private readonly _secretStorage: SecretStorage,
+		private readonly _accountChangeHandler: (e: { added: AccountInfo[]; deleted: AccountInfo[] }) => void,
+		private readonly _logger: LogOutputChannel
+	) {
+		this._pca = new PublicClientApplication(this._config);
+		this._lastCreated = new Date();
+		this._disposable = this._registerOnSecretStorageChanged();
+	}
+
+	get accounts(): AccountInfo[] { return this._accounts; }
+	get clientId(): string { return this._clientId; }
+	get authority(): string { return this._authority; }
+
+	initialize(): Promise<void> {
+		return this._update();
+	}
+
+	dispose(): void {
+		this._disposable.dispose();
+	}
+
+	acquireTokenSilent(request: SilentFlowRequest): Promise<AuthenticationResult> {
+		return this._pca.acquireTokenSilent(request);
+	}
+
+	async acquireTokenInteractive(request: InteractiveRequest): Promise<AuthenticationResult> {
+		return await window.withProgress(
+			{
+				location: ProgressLocation.Notification,
+				cancellable: true,
+				title: l10n.t('Signing in to Microsoft...')
+			},
+			(_process, token) => raceCancellationAndTimeoutError(this._pca.acquireTokenInteractive(request), token, 1000 * 60 * 5), // 5 minutes
+		);
+	}
+
+	removeAccount(account: AccountInfo): Promise<void> {
+		this._globalMemento.update(`lastRemoval:${this._clientId}:${this._authority}`, new Date());
+		return this._pca.getTokenCache().removeAccount(account);
+	}
+
+	private _registerOnSecretStorageChanged() {
+		return this._secretStorageCachePlugin.onDidChange(() => this._update());
+	}
+
+	private async _update() {
+		const before = this._accounts;
+		this._logger.debug(this._clientId, this._authority, 'CachedPublicClientApplication update before:', before.length);
+		// Dates are stored as strings in the memento
+		const lastRemovalDate = this._globalMemento.get<string>(`lastRemoval:${this._clientId}:${this._authority}`);
+		if (lastRemovalDate && this._lastCreated && Date.parse(lastRemovalDate) > this._lastCreated.getTime()) {
+			this._logger.debug(this._clientId, this._authority, 'CachedPublicClientApplication removal detected... recreating PCA...');
+			this._pca = new PublicClientApplication(this._config);
+			this._lastCreated = new Date();
+		}
+
+		const after = await this._pca.getAllAccounts();
+		this._accounts = after;
+		this._logger.debug(this._clientId, this._authority, 'CachedPublicClientApplication update after:', after.length);
+
+		const beforeSet = new Set(before.map(b => b.homeAccountId));
+		const afterSet = new Set(after.map(a => a.homeAccountId));
+
+		const added = after.filter(a => !beforeSet.has(a.homeAccountId));
+		const deleted = before.filter(b => !afterSet.has(b.homeAccountId));
+		if (added.length > 0 || deleted.length > 0) {
+			this._accountChangeHandler({ added, deleted });
+			this._logger.debug(this._clientId, this._authority, 'CachedPublicClientApplication accounts changed. added, deleted:', added.length, deleted.length);
+		}
+		this._logger.debug(this._clientId, this._authority, 'CachedPublicClientApplication update complete');
+	}
+}

--- a/extensions/microsoft-authentication/src/node/publicClientCache.ts
+++ b/extensions/microsoft-authentication/src/node/publicClientCache.ts
@@ -155,6 +155,12 @@ class CachedPublicClientApplication implements ICachedPublicClientApplication {
 		}
 	};
 
+	/**
+	 * We keep track of the last time an account was removed so we can recreate the PCA if we detect that an account was removed.
+	 * This is due to MSAL-node not providing a way to detect when an account is removed from the cache. An internal issue has been
+	 * filed to track this. If MSAL-node ever provides a way to detect this or handle this better in the Persistant Cache Plugin,
+	 * we can remove this logic.
+	 */
 	private _lastCreated: Date;
 
 	constructor(

--- a/extensions/microsoft-authentication/yarn.lock
+++ b/extensions/microsoft-authentication/yarn.lock
@@ -7,6 +7,20 @@
   resolved "https://registry.yarnpkg.com/@azure/ms-rest-azure-env/-/ms-rest-azure-env-2.0.0.tgz#45809f89763a480924e21d3c620cd40866771625"
   integrity sha512-dG76W7ElfLi+fbTjnZVGj+M9e0BIEJmRxU6fHaUQ12bZBe8EJKYb2GV50YWNaP2uJiVQ5+7nXEVj1VN1UQtaEw==
 
+"@azure/msal-common@14.14.0":
+  version "14.14.0"
+  resolved "https://registry.yarnpkg.com/@azure/msal-common/-/msal-common-14.14.0.tgz#31a015070d5864ebcf9ebb988fcbc5c5536f22d1"
+  integrity sha512-OxcOk9H1/1fktHh6//VCORgSNJc2dCQObTm6JNmL824Z6iZSO6eFo/Bttxe0hETn9B+cr7gDouTQtsRq3YPuSQ==
+
+"@azure/msal-node@^2.12.0":
+  version "2.12.0"
+  resolved "https://registry.yarnpkg.com/@azure/msal-node/-/msal-node-2.12.0.tgz#57ee6b6011a320046d72dc0828fec46278f2ab2c"
+  integrity sha512-jmk5Im5KujRA2AcyCb0awA3buV8niSrwXZs+NBJWIvxOz76RvNlusGIqi43A0h45BPUy93Qb+CPdpJn82NFTIg==
+  dependencies:
+    "@azure/msal-common" "14.14.0"
+    jsonwebtoken "^9.0.0"
+    uuid "^8.3.0"
+
 "@microsoft/1ds-core-js@4.0.3", "@microsoft/1ds-core-js@^4.0.3":
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/@microsoft/1ds-core-js/-/1ds-core-js-4.0.3.tgz#c8a92c623745a9595e06558a866658480c33bdf9"
@@ -153,6 +167,11 @@ asynckit@^0.4.0:
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
   integrity sha1-x57Zf380y48robyXkLzDZkdLS3k=
 
+buffer-equal-constant-time@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz#f8e71132f7ffe6e01a5c9697a4c6f3e48d5cc819"
+  integrity sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==
+
 combined-stream@^1.0.8:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
@@ -165,6 +184,13 @@ delayed-stream@~1.0.0:
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
   integrity sha1-3zrhmayt+31ECqrgsp4icrJOxhk=
 
+ecdsa-sig-formatter@1.0.11:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz#ae0f0fa2d85045ef14a817daa3ce9acd0489e5bf"
+  integrity sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==
+  dependencies:
+    safe-buffer "^5.0.1"
+
 form-data@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-3.0.0.tgz#31b7e39c85f1355b7139ee0c647cf0de7f83c682"
@@ -173,6 +199,74 @@ form-data@^3.0.0:
     asynckit "^0.4.0"
     combined-stream "^1.0.8"
     mime-types "^2.1.12"
+
+jsonwebtoken@^9.0.0:
+  version "9.0.2"
+  resolved "https://registry.yarnpkg.com/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz#65ff91f4abef1784697d40952bb1998c504caaf3"
+  integrity sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==
+  dependencies:
+    jws "^3.2.2"
+    lodash.includes "^4.3.0"
+    lodash.isboolean "^3.0.3"
+    lodash.isinteger "^4.0.4"
+    lodash.isnumber "^3.0.3"
+    lodash.isplainobject "^4.0.6"
+    lodash.isstring "^4.0.1"
+    lodash.once "^4.0.0"
+    ms "^2.1.1"
+    semver "^7.5.4"
+
+jwa@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/jwa/-/jwa-1.4.1.tgz#743c32985cb9e98655530d53641b66c8645b039a"
+  integrity sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==
+  dependencies:
+    buffer-equal-constant-time "1.0.1"
+    ecdsa-sig-formatter "1.0.11"
+    safe-buffer "^5.0.1"
+
+jws@^3.2.2:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/jws/-/jws-3.2.2.tgz#001099f3639468c9414000e99995fa52fb478304"
+  integrity sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==
+  dependencies:
+    jwa "^1.4.1"
+    safe-buffer "^5.0.1"
+
+lodash.includes@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/lodash.includes/-/lodash.includes-4.3.0.tgz#60bb98a87cb923c68ca1e51325483314849f553f"
+  integrity sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==
+
+lodash.isboolean@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz#6c2e171db2a257cd96802fd43b01b20d5f5870f6"
+  integrity sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==
+
+lodash.isinteger@^4.0.4:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz#619c0af3d03f8b04c31f5882840b77b11cd68343"
+  integrity sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==
+
+lodash.isnumber@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz#3ce76810c5928d03352301ac287317f11c0b1ffc"
+  integrity sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==
+
+lodash.isplainobject@^4.0.6:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
+  integrity sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==
+
+lodash.isstring@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/lodash.isstring/-/lodash.isstring-4.0.1.tgz#d527dfb5456eca7cc9bb95d5daeaf88ba54a5451"
+  integrity sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==
+
+lodash.once@^4.0.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.once/-/lodash.once-4.1.1.tgz#0dd3971213c7c56df880977d504c88fb471a97ac"
+  integrity sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==
 
 mime-db@1.44.0:
   version "1.44.0"
@@ -186,7 +280,27 @@ mime-types@^2.1.12:
   dependencies:
     mime-db "1.44.0"
 
+ms@^2.1.1:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
+  integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
+
+safe-buffer@^5.0.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
+  integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
+
+semver@^7.5.4:
+  version "7.6.2"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.6.2.tgz#1e3b34759f896e8f14d6134732ce798aeb0c6e13"
+  integrity sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==
+
 undici-types@~5.26.4:
   version "5.26.5"
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-5.26.5.tgz#bcd539893d00b56e964fd2657a4866b221a65617"
   integrity sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==
+
+uuid@^8.3.0:
+  version "8.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
+  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This adds a new setting `microsoft.useMsal` to be used to enable the Microsoft Authentication Library (MSAL) for signing in with a Microsoft account. In the next month or so, this will be the default... but since it's such a large change (practically re-implementing the entire extension) we have a setting to gate it. I implemented this in such a way that when we are ready to make it the default, we can simply remove the setting and `extensionV1` code without having to do much else.

Known issues and workarounds (already opened issues internally):
* MSAL-node doesn't handle a scenario where 2 processes use the same persisted cache... this caused issues when one process (window of VS Code) would sign out of an account - the sign out would not be reflected in the other process (window of VS Code). **To work around this**, we use globalStorage to write a `lastRemoval:...` which, when that date is later than the creation date, we simply re-create the MSAL object. This is funky, but it works nicely.
* MSAL-node's "reads" actually write to the persisted storage. **This doesn't need a workaround**, but it does mean the extension is doing more than it needs to do because it has to handle these "writes" that are writing the same thing to the persisted storage.
* MSAL-node's default behavior does not render an error in the user's browser when an error was detected in the sign in flow. **There is not a workaround in this PR but I will include a workaround for this in a followup**


Next steps:
* Implement the workaround for that last issues
* Add tests to this extension (none exist today)

NOTE: Currently, this change does not work in the web worker extension host. While I was able to get MSAL-node to work in the web worker extension host, it required a lot of browserifying that needs more attention. Ironing this out is a next _next_ step, I'd say.
ref https://github.com/microsoft/vscode/issues/229415