### PR TITLE
Fix #224437. Move cells command should read cell toolbar context.

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/controller/cellOperations.ts
+++ b/src/vs/workbench/contrib/notebook/browser/controller/cellOperations.ts
@@ -195,9 +195,17 @@ export async function moveCellRange(context: INotebookCellActionContext, directi
 		return;
 	}
 
-	const selections = editor.getSelections();
-	const modelRanges = expandCellRangesWithHiddenCells(editor, selections);
-	const range = modelRanges[0];
+	let range: ICellRange | undefined = undefined;
+
+	if (context.cell) {
+		const idx = editor.getCellIndex(context.cell);
+		range = { start: idx, end: idx + 1 };
+	} else {
+		const selections = editor.getSelections();
+		const modelRanges = expandCellRangesWithHiddenCells(editor, selections);
+		range = modelRanges[0];
+	}
+
 	if (!range || range.start === range.end) {
 		return;
 	}

--- a/src/vs/workbench/contrib/notebook/browser/controller/cellOperations.ts
+++ b/src/vs/workbench/contrib/notebook/browser/controller/cellOperations.ts
@@ -184,7 +184,7 @@ export function runDeleteAction(editor: IActiveNotebookEditor, cell: ICellViewMo
 	}
 }
 
-export async function moveCellRange(context: INotebookCellActionContext, direction: 'up' | 'down'): Promise<void> {
+export async function moveCellRange(context: INotebookActionContext, direction: 'up' | 'down'): Promise<void> {
 	if (!context.notebookEditor.hasModel()) {
 		return;
 	}

--- a/src/vs/workbench/contrib/notebook/test/browser/cellOperations.test.ts
+++ b/src/vs/workbench/contrib/notebook/test/browser/cellOperations.test.ts
@@ -48,7 +48,7 @@ suite('CellOperations', () => {
 			],
 			async (editor, viewModel) => {
 				viewModel.updateSelectionsState({ kind: SelectionStateType.Index, focus: { start: 1, end: 2 }, selections: [{ start: 0, end: 2 }] });
-				await moveCellRange({ notebookEditor: editor, cell: viewModel.cellAt(1)! }, 'down');
+				await moveCellRange({ notebookEditor: editor }, 'down');
 				assert.strictEqual(viewModel.cellAt(0)?.getText(), '# header b');
 				assert.strictEqual(viewModel.cellAt(1)?.getText(), '# header a');
 				assert.strictEqual(viewModel.cellAt(2)?.getText(), 'var b = 1;');
@@ -74,7 +74,7 @@ suite('CellOperations', () => {
 				editor.setHiddenAreas(viewModel.getHiddenRanges());
 
 				viewModel.updateSelectionsState({ kind: SelectionStateType.Index, focus: { start: 0, end: 1 }, selections: [{ start: 0, end: 1 }] });
-				await moveCellRange({ notebookEditor: editor, cell: viewModel.cellAt(1)! }, 'down');
+				await moveCellRange({ notebookEditor: editor }, 'down');
 				assert.strictEqual(viewModel.cellAt(0)?.getText(), '# header b');
 				assert.strictEqual(viewModel.cellAt(1)?.getText(), '# header a');
 				assert.strictEqual(viewModel.cellAt(2)?.getText(), 'var b = 1;');


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
