### PR TITLE
improve fix for debug find focus jumping

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/repl.ts
+++ b/src/vs/workbench/contrib/debug/browser/repl.ts
@@ -237,9 +237,7 @@ export class Repl extends FilterViewPane implements IHistoryNavigationWidget {
 			this.filter.filterQuery = this.filterWidget.getFilterText();
 			if (this.tree) {
 				this.tree.refilter();
-				if (!this.findIsOpen || this.filterWidget.hasFocus()) {
-					revealLastElement(this.tree);
-				}
+				revealLastElement(this.tree);
 			}
 		}));
 	}
@@ -681,6 +679,10 @@ export class Repl extends FilterViewPane implements IHistoryNavigationWidget {
 			});
 
 		this._register(tree.onDidChangeContentHeight(() => {
+			if (this.findIsOpen && !this.replInput.hasTextFocus()) {
+				// Focus is in the find widget, don't scroll to the bottom
+				return;
+			}
 			if (tree.scrollHeight !== this.previousTreeScrollHeight) {
 				// Due to rounding, the scrollTop + renderHeight will not exactly match the scrollHeight.
 				// Consider the tree to be scrolled all the way down if it is within 2px of the bottom.


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
reverts https://github.com/microsoft/vscode/pull/225297 and actually fixes the bug 

`revealLastElement` was called when the content height changed after a `find` input change and we don't want that. 

That happens because it gets fired on `rerender` https://github.com/microsoft/vscode/blob/e757c5d8675fa691804288634090db212700da72/src/vs/base/browser/ui/list/listView.ts#L1489 

which happens `onScroll`, which we do to focus a find result

https://github.com/microsoft/vscode/blob/e757c5d8675fa691804288634090db212700da72/src/vs/base/browser/ui/list/listView.ts#L1110

With my former PR, I was not reproducing the bug properly, so thought it was fixed 🤦🏼‍♀️ . Now, I've added a check to only call `revealLastElement` when the `find` input is not focused.

<img width="1036" alt="Screenshot 2024-08-09 at 4 04 48 PM" src="https://github.com/user-attachments/assets/562a92c7-20ff-4a00-8af5-8f897ac02532">


