### PR TITLE
change default  ouputWindowToggleScroll   when  outputWindow  is  focused and clicked  ,  because  the  scroll lock button is changed each time the output window is opened

### DIFF
--- a/src/vs/workbench/contrib/output/browser/outputServices.ts
+++ b/src/vs/workbench/contrib/output/browser/outputServices.ts
@@ -28,7 +28,7 @@ const OUTPUT_ACTIVE_CHANNEL_KEY = 'output.activechannel';
 
 class OutputChannel extends Disposable implements IOutputChannel {
 
-	scrollLock: boolean = false;
+	scrollLock: boolean = true;
 	readonly model: IOutputChannelModel;
 	readonly id: string;
 	readonly label: string;

--- a/src/vs/workbench/services/output/common/output.ts
+++ b/src/vs/workbench/services/output/common/output.ts
@@ -49,7 +49,7 @@ export const CONTEXT_ACTIVE_OUTPUT_LEVEL = new RawContextKey<string>('activeLogO
 
 export const CONTEXT_ACTIVE_OUTPUT_LEVEL_IS_DEFAULT = new RawContextKey<boolean>('activeLogOutput.levelIsDefault', false);
 
-export const CONTEXT_OUTPUT_SCROLL_LOCK = new RawContextKey<boolean>(`outputView.scrollLock`, false);
+export const CONTEXT_OUTPUT_SCROLL_LOCK = new RawContextKey<boolean>(`outputView.scrollLock`, true);
 
 export const IOutputService = createDecorator<IOutputService>('outputService');
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

![图片](https://github.com/user-attachments/assets/201ecf72-3cfd-4630-a1d8-f7018c1e70f5)
