### PR TITLE
Fix "Open Workspace Settings" when User Settings is open (fixes #148709)

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
@@ -484,8 +484,7 @@ export class SettingsEditor2 extends EditorPane {
 
 		const target: SettingsTarget | undefined = options.folderUri ?? recoveredViewState?.settingsTarget ?? <SettingsTarget | undefined>options.target;
 		if (target) {
-			this.settingsTargetsWidget.settingsTarget = target;
-			this.viewState.settingsTarget = target;
+			this.settingsTargetsWidget.updateTarget(target);
 		}
 	}
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fixes #148709 

`workbench.settings.editor` is at the default of `ui`

Open user settings

Modify a setting

Run command: "open workspace settings"

Before PR: the workspace tab is selected in the settings UI but the settings list still shows the user settings

After PR: the workspace tab is selected and the settings list shows the workspace settings