### PR TITLE
fix: `merge.toggleActiveConflict` as shortcuts

### DIFF
--- a/src/vs/workbench/contrib/mergeEditor/browser/view/viewModel.ts
+++ b/src/vs/workbench/contrib/mergeEditor/browser/view/viewModel.ts
@@ -193,6 +193,7 @@ export class MergeEditorViewModel extends Disposable {
 	): void {
 		this.manuallySetActiveModifiedBaseRange.set({ range: baseRange, counter: this.counter++ }, tx);
 		this.model.setState(baseRange, state, inputNumber, tx);
+		this.lastFocusedEditor.clearCache(tx);
 	}
 
 	private goToConflict(getModifiedBaseRange: (editor: CodeEditorView, curLineNumber: number) => ModifiedBaseRange | undefined): void {


### PR DESCRIPTION
When Merge Editor's actions are assigned to keyboard like this:

```json
[
    {
        "key": "ctrl+g a",
        "command": "merge.toggleActiveConflictInput1",
        "when": "isMergeEditor"
    },
    {
        "key": "ctrl+g b",
        "command": "merge.toggleActiveConflictInput2",
        "when": "isMergeEditor"
    },
    {
        "key": "ctrl+g ctrl+a",
        "command": "merge.acceptAllInput1",
        "when": "isMergeEditor"
    },
    {
        "key": "ctrl+g ctrl+b",
        "command": "merge.acceptAllInput2",
        "when": "isMergeEditor"
    },
]
```

Any of such action changes the state of the merged editor so diff range becomes locked, i.e. even if a cursor is moved to another diff range the actions target the locked one. If focus is changed the merge editor returns to a normal state. This behavior is only reproducible if all the actions are performed with keyboard because mouse clicking and calling the actions from the command pallette changes the focus and everything works correctly.

Fixes #225319

[merge-editor-fix-after.webm](https://github.com/user-attachments/assets/b2614112-754b-4c72-8429-b1c424aa2a73)


<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
