### PR TITLE
Allow building Code OSS behind a proxy

### DIFF
--- a/build/lib/fetch.js
+++ b/build/lib/fetch.js
@@ -13,6 +13,8 @@ const log = require("fancy-log");
 const ansiColors = require("ansi-colors");
 const crypto = require("crypto");
 const through2 = require("through2");
+const undici = require("undici");
+const process = require("process");
 function fetchUrls(urls, options) {
     if (options === undefined) {
         options = {};
@@ -43,6 +45,10 @@ async function fetchUrl(url, options, retries = 10, retryDelay = 1000) {
         const controller = new AbortController();
         const timeout = setTimeout(() => controller.abort(), 30 * 1000);
         try {
+            if (process.env.https_proxy) {
+                const dispatcher = new undici.ProxyAgent({ uri: process.env.https_proxy });
+                undici.setGlobalDispatcher(dispatcher);
+            }
             const response = await fetch(url, {
                 ...options.nodeFetchOptions,
                 signal: controller.signal /* Typings issue with lib.dom.d.ts */

--- a/build/lib/fetch.ts
+++ b/build/lib/fetch.ts
@@ -9,6 +9,8 @@ import * as log from 'fancy-log';
 import * as ansiColors from 'ansi-colors';
 import * as crypto from 'crypto';
 import * as through2 from 'through2';
+import * as undici from 'undici';
+import * as process from 'process';
 import { Stream } from 'stream';
 
 export interface IFetchOptions {
@@ -52,6 +54,10 @@ export async function fetchUrl(url: string, options: IFetchOptions, retries = 10
 		const controller = new AbortController();
 		const timeout = setTimeout(() => controller.abort(), 30 * 1000);
 		try {
+			if (process.env.https_proxy) {
+				const dispatcher = new undici.ProxyAgent({ uri: process.env.https_proxy });
+				undici.setGlobalDispatcher(dispatcher);
+			}
 			const response = await fetch(url, {
 				...options.nodeFetchOptions,
 				signal: controller.signal as any /* Typings issue with lib.dom.d.ts */

--- a/build/package.json
+++ b/build/package.json
@@ -53,6 +53,7 @@
     "ternary-stream": "^3.0.0",
     "through2": "^4.0.2",
     "tmp": "^0.2.1",
+    "undici": "^6.19.7",
     "vscode-universal-bundler": "^0.1.2",
     "workerpool": "^6.4.0",
     "yauzl": "^2.10.0"

--- a/build/yarn.lock
+++ b/build/yarn.lock
@@ -2664,6 +2664,11 @@ undici-types@~5.26.4:
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-5.26.5.tgz#bcd539893d00b56e964fd2657a4866b221a65617"
   integrity sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==
 
+undici@^6.19.7:
+  version "6.19.7"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-6.19.7.tgz#7d4cf26dc689838aa8b6753a3c5c4288fc1e0216"
+  integrity sha512-HR3W/bMGPSr90i8AAp2C4DM3wChFdJPLrWYpIS++LxS8K+W535qftjt+4MyjNYHeWabMj1nvtmLIi7l++iq91A==
+
 universal-user-agent@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/universal-user-agent/-/universal-user-agent-6.0.0.tgz#3381f8503b251c0d9cd21bc1de939ec9df5480ee"


### PR DESCRIPTION
Allows users behind a proxy to build `Code - OSS` from source.

The following edit to the wiki would also help people behind a proxy, even if it depends on `Electron` more than on `Code - OSS`. (Feel free to reword it as english is not my native language)

___
``````
diff --git a/How-to-Contribute.md b/How-to-Contribute.md           
index 19fb4bc..195cc87 100644         
--- a/How-to-Contribute.md
+++ b/How-to-Contribute.md
@@ -110,6 +110,11 @@ cd vscode
 yarn
 ```
  
+<ul>
+<em>If you are behind a proxy, first ensure that the <code>https_proxy</code> environment variable is set, and then run the following commands: <br /><ul
><code>yarn config set https-proxy $https_proxy<br />yarn config set proxy $https_proxy<br />GLOBAL_AGENT_HTTPS_PROXY=$https_proxy ELECTRON_GET_USE_PROXY=
true yarn</code>.</ul><br />Other commands will remain the same</em>
+
+</ul>
+
 Then you have two options:
  
 - If you want to build from inside VS Code, you can open the `vscode` folder and start the build task with <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>B</kbd> 
(<kbd>CMD</kbd>+<kbd>Shift</kbd>+<kbd>B</kbd> on macOS). The build task will stay running in the background even if you close VS Code. If you happen to cl
ose VS Code and open it again, just resume the build by pressing <kbd>Ctrl</kbd>+<kbd>Shift</kbd>+<kbd>B</kbd> (<kbd>CMD</kbd>+<kbd>Shift</kbd>+<kbd>B</kb
d>) again. You can kill it by running the `Kill Build VS Code` task or pressing <kbd>Ctrl</kbd>+<kbd>D</kbd> in the task terminal.
``````