### PR TITLE
debt - avoid quick pick leaks

### DIFF
--- a/src/vs/workbench/browser/actions/layoutActions.ts
+++ b/src/vs/workbench/browser/actions/layoutActions.ts
@@ -966,13 +966,14 @@ registerAction2(class extends Action2 {
 	}
 
 	private async getView(quickInputService: IQuickInputService, viewDescriptorService: IViewDescriptorService, paneCompositePartService: IPaneCompositePartService, viewId?: string): Promise<string> {
-		const quickPick = quickInputService.createQuickPick({ useSeparators: true });
+		const disposables = new DisposableStore();
+		const quickPick = disposables.add(quickInputService.createQuickPick({ useSeparators: true }));
 		quickPick.placeholder = localize('moveFocusedView.selectView', "Select a View to Move");
 		quickPick.items = this.getViewItems(viewDescriptorService, paneCompositePartService);
 		quickPick.selectedItems = quickPick.items.filter(item => (item as IQuickPickItem).id === viewId) as IQuickPickItem[];
 
 		return new Promise((resolve, reject) => {
-			quickPick.onDidAccept(() => {
+			disposables.add(quickPick.onDidAccept(() => {
 				const viewId = quickPick.selectedItems[0];
 				if (viewId.id) {
 					resolve(viewId.id);
@@ -981,9 +982,12 @@ registerAction2(class extends Action2 {
 				}
 
 				quickPick.hide();
-			});
+			}));
 
-			quickPick.onDidHide(() => reject());
+			disposables.add(quickPick.onDidHide(() => {
+				disposables.dispose();
+				reject();
+			}));
 
 			quickPick.show();
 		});
@@ -1025,7 +1029,8 @@ class MoveFocusedViewAction extends Action2 {
 			return;
 		}
 
-		const quickPick = quickInputService.createQuickPick({ useSeparators: true });
+		const disposables = new DisposableStore();
+		const quickPick = disposables.add(quickInputService.createQuickPick({ useSeparators: true }));
 		quickPick.placeholder = localize('moveFocusedView.selectDestination', "Select a Destination for the View");
 		quickPick.title = localize({ key: 'moveFocusedView.title', comment: ['{0} indicates the title of the view the user has selected to move.'] }, "View: Move {0}", viewDescriptor.name.value);
 
@@ -1120,7 +1125,7 @@ class MoveFocusedViewAction extends Action2 {
 
 		quickPick.items = items;
 
-		quickPick.onDidAccept(() => {
+		disposables.add(quickPick.onDidAccept(() => {
 			const destination = quickPick.selectedItems[0];
 
 			if (destination.id === '_.panel.newcontainer') {
@@ -1138,7 +1143,9 @@ class MoveFocusedViewAction extends Action2 {
 			}
 
 			quickPick.hide();
-		});
+		}));
+
+		disposables.add(quickPick.onDidHide(() => disposables.dispose()));
 
 		quickPick.show();
 	}
@@ -1504,7 +1511,10 @@ registerAction2(class CustomizeLayoutAction extends Action2 {
 		const commandService = accessor.get(ICommandService);
 		const quickInputService = accessor.get(IQuickInputService);
 		const keybindingService = accessor.get(IKeybindingService);
-		const quickPick = quickInputService.createQuickPick({ useSeparators: true });
+
+		const disposables = new DisposableStore();
+
+		const quickPick = disposables.add(quickInputService.createQuickPick({ useSeparators: true }));
 
 		this._currentQuickPick = quickPick;
 		quickPick.items = this.getItems(contextKeyService, keybindingService);
@@ -1529,7 +1539,6 @@ registerAction2(class CustomizeLayoutAction extends Action2 {
 			closeButton
 		];
 
-		const disposables = new DisposableStore();
 		let selectedItem: CustomizeLayoutItem | undefined = undefined;
 		disposables.add(contextKeyService.onDidChangeContext(changeEvent => {
 			if (changeEvent.affectsSome(LayoutContextKeySet)) {
@@ -1542,21 +1551,21 @@ registerAction2(class CustomizeLayoutAction extends Action2 {
 			}
 		}));
 
-		quickPick.onDidAccept(event => {
+		disposables.add(quickPick.onDidAccept(event => {
 			if (quickPick.selectedItems.length) {
 				selectedItem = quickPick.selectedItems[0] as CustomizeLayoutItem;
 				commandService.executeCommand(selectedItem.id);
 			}
-		});
+		}));
 
-		quickPick.onDidTriggerItemButton(event => {
+		disposables.add(quickPick.onDidTriggerItemButton(event => {
 			if (event.item) {
 				selectedItem = event.item as CustomizeLayoutItem;
 				commandService.executeCommand(selectedItem.id);
 			}
-		});
+		}));
 
-		quickPick.onDidTriggerButton((button) => {
+		disposables.add(quickPick.onDidTriggerButton((button) => {
 			if (button === closeButton) {
 				quickPick.hide();
 			} else if (button === resetButton) {
@@ -1578,16 +1587,16 @@ registerAction2(class CustomizeLayoutAction extends Action2 {
 
 				commandService.executeCommand('workbench.action.alignPanelCenter');
 			}
-		});
+		}));
 
-		quickPick.onDidHide(() => {
+		disposables.add(quickPick.onDidHide(() => {
 			quickPick.dispose();
-		});
+		}));
 
-		quickPick.onDispose(() => {
+		disposables.add(quickPick.onDispose(() => {
 			this._currentQuickPick = undefined;
 			disposables.dispose();
-		});
+		}));
 
 		quickPick.show();
 	}

--- a/src/vs/workbench/browser/layout.ts
+++ b/src/vs/workbench/browser/layout.ts
@@ -634,7 +634,7 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 		// Layout Initialization State
 		const initialEditorsState = this.getInitialEditorsState();
 		if (initialEditorsState) {
-			this.logService.info('Initial editor state', initialEditorsState);
+			this.logService.trace('Initial editor state', initialEditorsState);
 		}
 		const initialLayoutState: ILayoutInitializationState = {
 			layout: {

--- a/src/vs/workbench/browser/parts/editor/editorAutoSave.ts
+++ b/src/vs/workbench/browser/parts/editor/editorAutoSave.ts
@@ -84,7 +84,7 @@ export class EditorAutoSave extends Disposable implements IWorkbenchContribution
 				) {
 					this.discardAutoSave(workingCopyResult.workingCopy);
 
-					this.logService.info(`[editor auto save] running auto save from condition change event`, workingCopyResult.workingCopy.resource.toString(), workingCopyResult.workingCopy.typeId);
+					this.logService.trace(`[editor auto save] running auto save from condition change event`, workingCopyResult.workingCopy.resource.toString(), workingCopyResult.workingCopy.typeId);
 					workingCopyResult.workingCopy.save({ reason: workingCopyResult.reason });
 				}
 			}
@@ -100,7 +100,7 @@ export class EditorAutoSave extends Disposable implements IWorkbenchContribution
 				) {
 					this.waitingOnConditionAutoSaveEditors.delete(resource);
 
-					this.logService.info(`[editor auto save] running auto save from condition change event with reason ${editorResult.reason}`);
+					this.logService.trace(`[editor auto save] running auto save from condition change event with reason ${editorResult.reason}`);
 					this.editorService.save(editorResult.editor, { reason: editorResult.reason });
 				}
 			}

--- a/src/vs/workbench/contrib/accessibility/browser/accessibleView.ts
+++ b/src/vs/workbench/contrib/accessibility/browser/accessibleView.ts
@@ -414,26 +414,26 @@ export class AccessibleView extends Disposable {
 		if (!items) {
 			return;
 		}
-		const quickPick: IQuickPick<IQuickPickItem> = this._quickInputService.createQuickPick();
-		this._register(quickPick);
+		const disposables = this._register(new DisposableStore());
+		const quickPick: IQuickPick<IQuickPickItem> = disposables.add(this._quickInputService.createQuickPick());
 		quickPick.items = items;
 		quickPick.title = localize('keybindings', 'Configure keybindings');
 		quickPick.placeholder = localize('selectKeybinding', 'Select a command ID to configure a keybinding for it');
 		quickPick.show();
-		quickPick.onDidAccept(async () => {
+		disposables.add(quickPick.onDidAccept(async () => {
 			const item = quickPick.selectedItems[0];
 			if (item) {
 				await this._commandService.executeCommand('workbench.action.openGlobalKeybindings', item.id);
 			}
 			quickPick.dispose();
-		});
-		quickPick.onDidHide(() => {
+		}));
+		disposables.add(quickPick.onDidHide(() => {
 			if (!quickPick.selectedItems.length && provider) {
 				this.show(provider);
 			}
-			quickPick.dispose();
+			disposables.dispose();
 			this._inQuickPick = false;
-		});
+		}));
 	}
 
 	private _convertTokensToSymbols(tokens: marked.TokensList, symbols: IAccessibleViewSymbol[]): void {
@@ -919,7 +919,8 @@ class AccessibleViewSymbolQuickPick {
 
 	}
 	show(provider: AccesibleViewContentProvider): void {
-		const quickPick = this._quickInputService.createQuickPick<IAccessibleViewSymbol>();
+		const disposables = new DisposableStore();
+		const quickPick = disposables.add(this._quickInputService.createQuickPick<IAccessibleViewSymbol>());
 		quickPick.placeholder = localize('accessibleViewSymbolQuickPickPlaceholder', "Type to search symbols");
 		quickPick.title = localize('accessibleViewSymbolQuickPickTitle', "Go to Symbol Accessible View");
 		const picks = [];
@@ -936,16 +937,17 @@ class AccessibleViewSymbolQuickPick {
 		quickPick.canSelectMany = false;
 		quickPick.items = symbols;
 		quickPick.show();
-		quickPick.onDidAccept(() => {
+		disposables.add(quickPick.onDidAccept(() => {
 			this._accessibleView.showSymbol(provider, quickPick.selectedItems[0]);
 			quickPick.hide();
-		});
-		quickPick.onDidHide(() => {
+		}));
+		disposables.add(quickPick.onDidHide(() => {
 			if (quickPick.selectedItems.length === 0) {
 				// this was escaped, so refocus the accessible view
 				this._accessibleView.show(provider);
 			}
-		});
+			disposables.dispose();
+		}));
 	}
 }
 

--- a/src/vs/workbench/contrib/accessibilitySignals/browser/commands.ts
+++ b/src/vs/workbench/contrib/accessibilitySignals/browser/commands.ts
@@ -13,6 +13,7 @@ import { IConfigurationService } from 'vs/platform/configuration/common/configur
 import { ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
 import { IQuickInputService, IQuickPickItem } from 'vs/platform/quickinput/common/quickInput';
 import { IPreferencesService } from 'vs/workbench/services/preferences/common/preferences';
+import { DisposableStore } from 'vs/base/common/lifecycle';
 
 export class ShowSignalSoundHelp extends Action2 {
 	static readonly ID = 'signals.sounds.help';
@@ -44,10 +45,11 @@ export class ShowSignalSoundHelp extends Action2 {
 				alwaysVisible: true
 			}] : []
 		})).sort((a, b) => a.label.localeCompare(b.label));
-		const qp = quickInputService.createQuickPick<IQuickPickItem & { signal: AccessibilitySignal }>();
+		const disposables = new DisposableStore();
+		const qp = disposables.add(quickInputService.createQuickPick<IQuickPickItem & { signal: AccessibilitySignal }>());
 		qp.items = items;
 		qp.selectedItems = items.filter(i => accessibilitySignalService.isSoundEnabled(i.signal) || userGestureSignals.includes(i.signal) && configurationService.getValue(i.signal.settingsKey + '.sound') !== 'never');
-		qp.onDidAccept(() => {
+		disposables.add(qp.onDidAccept(() => {
 			const enabledSounds = qp.selectedItems.map(i => i.signal);
 			const disabledSounds = qp.items.map(i => (i as any).signal).filter(i => !enabledSounds.includes(i));
 			for (const signal of enabledSounds) {
@@ -67,13 +69,14 @@ export class ShowSignalSoundHelp extends Action2 {
 				configurationService.updateValue(signal.settingsKey, value);
 			}
 			qp.hide();
-		});
-		qp.onDidTriggerItemButton(e => {
+		}));
+		disposables.add(qp.onDidTriggerItemButton(e => {
 			preferencesService.openUserSettings({ jsonEditor: true, revealSetting: { key: e.item.signal.settingsKey, edit: true } });
-		});
-		qp.onDidChangeActive(() => {
+		}));
+		disposables.add(qp.onDidChangeActive(() => {
 			accessibilitySignalService.playSound(qp.activeItems[0].signal.sound.getSound(true), true, AcknowledgeDocCommentsToken);
-		});
+		}));
+		disposables.add(qp.onDidHide(() => disposables.dispose()));
 		qp.placeholder = localize('sounds.help.placeholder', 'Select a sound to play and configure');
 		qp.canSelectMany = true;
 		await qp.show();
@@ -114,11 +117,12 @@ export class ShowAccessibilityAnnouncementHelp extends Action2 {
 				alwaysVisible: true,
 			}] : []
 		})).sort((a, b) => a.label.localeCompare(b.label));
-		const qp = quickInputService.createQuickPick<IQuickPickItem & { signal: AccessibilitySignal }>();
+		const disposables = new DisposableStore();
+		const qp = disposables.add(quickInputService.createQuickPick<IQuickPickItem & { signal: AccessibilitySignal }>());
 		qp.items = items;
 		qp.selectedItems = items.filter(i => accessibilitySignalService.isAnnouncementEnabled(i.signal) || userGestureSignals.includes(i.signal) && configurationService.getValue(i.signal.settingsKey + '.announcement') !== 'never');
 		const screenReaderOptimized = accessibilityService.isScreenReaderOptimized();
-		qp.onDidAccept(() => {
+		disposables.add(qp.onDidAccept(() => {
 			if (!screenReaderOptimized) {
 				// announcements are off by default when screen reader is not active
 				qp.hide();
@@ -139,10 +143,11 @@ export class ShowAccessibilityAnnouncementHelp extends Action2 {
 				configurationService.updateValue(signal.settingsKey, value);
 			}
 			qp.hide();
-		});
-		qp.onDidTriggerItemButton(e => {
+		}));
+		disposables.add(qp.onDidTriggerItemButton(e => {
 			preferencesService.openUserSettings({ jsonEditor: true, revealSetting: { key: e.item.signal.settingsKey, edit: true } });
-		});
+		}));
+		disposables.add(qp.onDidHide(() => disposables.dispose()));
 		qp.placeholder = screenReaderOptimized ? localize('announcement.help.placeholder', 'Select an announcement to configure') : localize('announcement.help.placeholder.disabled', 'Screen reader is not active, announcements are disabled by default.');
 		qp.canSelectMany = true;
 		await qp.show();

--- a/src/vs/workbench/contrib/debug/browser/debugCommands.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugCommands.ts
@@ -37,6 +37,7 @@ import { showDebugSessionMenu } from 'vs/workbench/contrib/debug/browser/debugSe
 import { TEXT_FILE_EDITOR_ID } from 'vs/workbench/contrib/files/common/files';
 import { ILocalizedString } from 'vs/platform/action/common/action';
 import { CONTEXT_IN_CHAT_SESSION } from 'vs/workbench/contrib/chat/common/chatContextKeys';
+import { DisposableStore } from 'vs/base/common/lifecycle';
 
 export const ADD_CONFIGURATION_ID = 'debug.addConfiguration';
 export const TOGGLE_INLINE_BREAKPOINT_ID = 'editor.debug.action.toggleInlineBreakpoint';
@@ -569,11 +570,12 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 			target: DebugProtocol.StepInTarget;
 		}
 
-		const qp = quickInputService.createQuickPick<ITargetItem>();
+		const disposables = new DisposableStore();
+		const qp = disposables.add(quickInputService.createQuickPick<ITargetItem>());
 		qp.busy = true;
 		qp.show();
 
-		qp.onDidChangeActive(([item]) => {
+		disposables.add(qp.onDidChangeActive(([item]) => {
 			if (codeEditor && item && item.target.line !== undefined) {
 				codeEditor.revealLineInCenterIfOutsideViewport(item.target.line);
 				codeEditor.setSelection({
@@ -583,15 +585,15 @@ KeybindingsRegistry.registerCommandAndKeybindingRule({
 					endColumn: item.target.endColumn || item.target.column || 1,
 				});
 			}
-		});
+		}));
 
-		qp.onDidAccept(() => {
+		disposables.add(qp.onDidAccept(() => {
 			if (qp.activeItems.length) {
 				session.stepIn(frame.thread.threadId, qp.activeItems[0].target.id);
 			}
-		});
+		}));
 
-		qp.onDidHide(() => qp.dispose());
+		disposables.add(qp.onDidHide(() => disposables.dispose()));
 
 		session.stepInTargets(frame.frameId).then(targets => {
 			qp.busy = false;

--- a/src/vs/workbench/contrib/localHistory/browser/localHistoryCommands.ts
+++ b/src/vs/workbench/contrib/localHistory/browser/localHistoryCommands.ts
@@ -343,10 +343,11 @@ registerAction2(class extends Action2 {
 		// Sort the resources by history to put more relevant entries
 		// to the top.
 
-		const resourcePicker = quickInputService.createQuickPick<IQuickPickItem & { resource: URI }>();
+		const resourcePickerDisposables = new DisposableStore();
+		const resourcePicker = resourcePickerDisposables.add(quickInputService.createQuickPick<IQuickPickItem & { resource: URI }>());
 
 		let cts = new CancellationTokenSource();
-		resourcePicker.onDidHide(() => cts.dispose(true));
+		resourcePickerDisposables.add(resourcePicker.onDidHide(() => cts.dispose(true)));
 
 		resourcePicker.busy = true;
 		resourcePicker.show();
@@ -375,7 +376,7 @@ registerAction2(class extends Action2 {
 		}));
 
 		await Event.toPromise(resourcePicker.onDidAccept);
-		resourcePicker.dispose();
+		resourcePickerDisposables.dispose();
 
 		const resource = firstOrDefault(resourcePicker.selectedItems)?.resource;
 		if (!resource) {
@@ -385,11 +386,11 @@ registerAction2(class extends Action2 {
 		// Show all entries for the picked resource in another picker
 		// and open the entry in the end that was selected by the user
 
-		const disposables = new DisposableStore();
-		const entryPicker = disposables.add(quickInputService.createQuickPick<IQuickPickItem & { entry: IWorkingCopyHistoryEntry }>());
+		const entryPickerDisposables = new DisposableStore();
+		const entryPicker = entryPickerDisposables.add(quickInputService.createQuickPick<IQuickPickItem & { entry: IWorkingCopyHistoryEntry }>());
 
 		cts = new CancellationTokenSource();
-		disposables.add(entryPicker.onDidHide(() => cts.dispose(true)));
+		entryPickerDisposables.add(entryPicker.onDidHide(() => cts.dispose(true)));
 
 		entryPicker.busy = true;
 		entryPicker.show();
@@ -407,9 +408,9 @@ registerAction2(class extends Action2 {
 			description: toLocalHistoryEntryDateLabel(entry.timestamp)
 		}));
 
-		disposables.add(entryPicker.onDidAccept(async e => {
+		entryPickerDisposables.add(entryPicker.onDidAccept(async e => {
 			if (!e.inBackground) {
-				disposables.dispose();
+				entryPickerDisposables.dispose();
 			}
 
 			const selectedItem = firstOrDefault(entryPicker.selectedItems);
@@ -452,18 +453,19 @@ registerAction2(class extends Action2 {
 
 		const { entry } = await findLocalHistoryEntry(workingCopyHistoryService, item);
 		if (entry) {
-			const inputBox = quickInputService.createInputBox();
+			const disposables = new DisposableStore();
+			const inputBox = disposables.add(quickInputService.createInputBox());
 			inputBox.title = localize('renameLocalHistoryEntryTitle', "Rename Local History Entry");
 			inputBox.ignoreFocusOut = true;
 			inputBox.placeholder = localize('renameLocalHistoryPlaceholder', "Enter the new name of the local history entry");
 			inputBox.value = SaveSourceRegistry.getSourceLabel(entry.source);
 			inputBox.show();
-			inputBox.onDidAccept(() => {
+			disposables.add(inputBox.onDidAccept(() => {
 				if (inputBox.value) {
 					workingCopyHistoryService.updateEntry(entry, { source: inputBox.value }, CancellationToken.None);
 				}
-				inputBox.dispose();
-			});
+				disposables.dispose();
+			}));
 		}
 	}
 });
@@ -575,19 +577,20 @@ registerAction2(class extends Action2 {
 			return; // only enable for selected schemes
 		}
 
-		const inputBox = quickInputService.createInputBox();
+		const disposables = new DisposableStore();
+		const inputBox = disposables.add(quickInputService.createInputBox());
 		inputBox.title = localize('createLocalHistoryEntryTitle', "Create Local History Entry");
 		inputBox.ignoreFocusOut = true;
 		inputBox.placeholder = localize('createLocalHistoryPlaceholder', "Enter the new name of the local history entry for '{0}'", labelService.getUriBasenameLabel(resource));
 		inputBox.show();
-		inputBox.onDidAccept(async () => {
+		disposables.add(inputBox.onDidAccept(async () => {
 			const entrySource = inputBox.value;
-			inputBox.dispose();
+			disposables.dispose();
 
 			if (entrySource) {
 				await workingCopyHistoryService.addEntry({ resource, source: inputBox.value }, CancellationToken.None);
 			}
-		});
+		}));
 	}
 });
 

--- a/src/vs/workbench/contrib/localization/common/localizationsActions.ts
+++ b/src/vs/workbench/contrib/localization/common/localizationsActions.ts
@@ -37,7 +37,8 @@ export class ConfigureDisplayLanguageAction extends Action2 {
 
 		const installedLanguages = await languagePackService.getInstalledLanguages();
 
-		const qp = quickInputService.createQuickPick<ILanguagePackItem>({ useSeparators: true });
+		const disposables = new DisposableStore();
+		const qp = disposables.add(quickInputService.createQuickPick<ILanguagePackItem>({ useSeparators: true }));
 		qp.matchOnDescription = true;
 		qp.placeholder = localize('chooseLocale', "Select Display Language");
 
@@ -46,7 +47,6 @@ export class ConfigureDisplayLanguageAction extends Action2 {
 			qp.items = items.concat(this.withMoreInfoButton(installedLanguages));
 		}
 
-		const disposables = new DisposableStore();
 		const source = new CancellationTokenSource();
 		disposables.add(qp.onDispose(() => {
 			source.cancel();

--- a/src/vs/workbench/contrib/logs/common/logsActions.ts
+++ b/src/vs/workbench/contrib/logs/common/logsActions.ts
@@ -75,7 +75,7 @@ export class SetLogLevelAction extends Action {
 
 		return new Promise((resolve, reject) => {
 			const disposables = new DisposableStore();
-			const quickPick = this.quickInputService.createQuickPick({ useSeparators: true });
+			const quickPick = disposables.add(this.quickInputService.createQuickPick({ useSeparators: true }));
 			quickPick.placeholder = nls.localize('selectlog', "Set Log Level");
 			quickPick.items = entries;
 			let selectedItem: IQuickPickItem | undefined;
@@ -108,7 +108,7 @@ export class SetLogLevelAction extends Action {
 
 		return new Promise((resolve, reject) => {
 			const disposables = new DisposableStore();
-			const quickPick = this.quickInputService.createQuickPick();
+			const quickPick = disposables.add(this.quickInputService.createQuickPick());
 			quickPick.placeholder = logChannel ? nls.localize('selectLogLevelFor', " {0}: Select log level", logChannel?.label) : nls.localize('selectLogLevel', "Select log level");
 			quickPick.items = entries;
 			quickPick.activeItems = entries.filter((entry) => entry.level === this.loggerService.getLogLevel());

--- a/src/vs/workbench/contrib/notebook/browser/controller/layoutActions.ts
+++ b/src/vs/workbench/contrib/notebook/browser/controller/layoutActions.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Codicon } from 'vs/base/common/codicons';
+import { DisposableStore } from 'vs/base/common/lifecycle';
 import { URI, UriComponents } from 'vs/base/common/uri';
 import { localize, localize2 } from 'vs/nls';
 import { Categories } from 'vs/platform/action/common/actionCommonCategories';
@@ -191,22 +192,23 @@ registerAction2(class SaveMimeTypeDisplayOrder extends Action2 {
 
 	run(accessor: ServicesAccessor) {
 		const service = accessor.get(INotebookService);
-		const qp = accessor.get(IQuickInputService).createQuickPick<IQuickPickItem & { target: ConfigurationTarget }>();
+		const disposables = new DisposableStore();
+		const qp = disposables.add(accessor.get(IQuickInputService).createQuickPick<IQuickPickItem & { target: ConfigurationTarget }>());
 		qp.placeholder = localize('notebook.placeholder', 'Settings file to save in');
 		qp.items = [
 			{ target: ConfigurationTarget.USER, label: localize('saveTarget.machine', 'User Settings') },
 			{ target: ConfigurationTarget.WORKSPACE, label: localize('saveTarget.workspace', 'Workspace Settings') },
 		];
 
-		qp.onDidAccept(() => {
+		disposables.add(qp.onDidAccept(() => {
 			const target = qp.selectedItems[0]?.target;
 			if (target !== undefined) {
 				service.saveMimeDisplayOrder(target);
 			}
 			qp.dispose();
-		});
+		}));
 
-		qp.onDidHide(() => qp.dispose());
+		disposables.add(qp.onDidHide(() => disposables.dispose()));
 
 		qp.show();
 	}

--- a/src/vs/workbench/contrib/notebook/browser/diff/diffElementOutputs.ts
+++ b/src/vs/workbench/contrib/notebook/browser/diff/diffElementOutputs.ts
@@ -155,7 +155,8 @@ export class OutputElement extends Disposable {
 			description: index === currIndex ? nls.localize('curruentActiveMimeType', "Currently Active") : undefined
 		}));
 
-		const picker = this._quickInputService.createQuickPick();
+		const disposables = new DisposableStore();
+		const picker = disposables.add(this._quickInputService.createQuickPick());
 		picker.items = items;
 		picker.activeItems = items.filter(item => !!item.picked);
 		picker.placeholder = items.length !== mimeTypes.length
@@ -163,10 +164,10 @@ export class OutputElement extends Disposable {
 			: nls.localize('promptChooseMimeType.placeHolder', "Select mimetype to render for current output");
 
 		const pick = await new Promise<number | undefined>(resolve => {
-			picker.onDidAccept(() => {
+			disposables.add(picker.onDidAccept(() => {
 				resolve(picker.selectedItems.length === 1 ? (picker.selectedItems[0] as IMimeTypeRenderer).index : undefined);
-				picker.dispose();
-			});
+				disposables.dispose();
+			}));
 			picker.show();
 		});
 

--- a/src/vs/workbench/contrib/notebook/browser/view/cellParts/cellOutput.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/cellParts/cellOutput.ts
@@ -381,7 +381,8 @@ class CellOutputElement extends Disposable {
 			});
 		}
 
-		const picker = this.quickInputService.createQuickPick({ useSeparators: true });
+		const disposables = new DisposableStore();
+		const picker = disposables.add(this.quickInputService.createQuickPick({ useSeparators: true }));
 		picker.items = [
 			...items,
 			{ type: 'separator' },
@@ -393,10 +394,10 @@ class CellOutputElement extends Disposable {
 			: nls.localize('promptChooseMimeType.placeHolder', "Select mimetype to render for current output");
 
 		const pick = await new Promise<IMimeTypeRenderer | undefined>(resolve => {
-			picker.onDidAccept(() => {
+			disposables.add(picker.onDidAccept(() => {
 				resolve(picker.selectedItems.length === 1 ? (picker.selectedItems[0] as IMimeTypeRenderer) : undefined);
-				picker.dispose();
-			});
+				disposables.dispose();
+			}));
 			picker.show();
 		});
 

--- a/src/vs/workbench/contrib/remote/browser/remote.ts
+++ b/src/vs/workbench/contrib/remote/browser/remote.ts
@@ -799,8 +799,8 @@ export class RemoteAgentConnectionStatusListener extends Disposable implements I
 		const connection = remoteAgentService.getConnection();
 		if (connection) {
 			let quickInputVisible = false;
-			quickInputService.onShow(() => quickInputVisible = true);
-			quickInputService.onHide(() => quickInputVisible = false);
+			this._register(quickInputService.onShow(() => quickInputVisible = true));
+			this._register(quickInputService.onHide(() => quickInputVisible = false));
 
 			let visibleProgress: VisibleProgress | null = null;
 			let reconnectWaitEvent: ReconnectionWaitEvent | null = null;

--- a/src/vs/workbench/contrib/remoteTunnel/electron-sandbox/remoteTunnel.contribution.ts
+++ b/src/vs/workbench/contrib/remoteTunnel/electron-sandbox/remoteTunnel.contribution.ts
@@ -363,19 +363,20 @@ export class RemoteTunnelWorkbenchContribution extends Disposable implements IWo
 
 	private async getAuthenticationSession(): Promise<ExistingSessionItem | undefined> {
 		const sessions = await this.getAllSessions();
-		const quickpick = this.quickInputService.createQuickPick<ExistingSessionItem | AuthenticationProviderOption | IQuickPickItem>({ useSeparators: true });
+		const disposables = new DisposableStore();
+		const quickpick = disposables.add(this.quickInputService.createQuickPick<ExistingSessionItem | AuthenticationProviderOption | IQuickPickItem>({ useSeparators: true }));
 		quickpick.ok = false;
 		quickpick.placeholder = localize('accountPreference.placeholder', "Sign in to an account to enable remote access");
 		quickpick.ignoreFocusOut = true;
 		quickpick.items = await this.createQuickpickItems(sessions);
 
 		return new Promise((resolve, reject) => {
-			quickpick.onDidHide((e) => {
+			disposables.add(quickpick.onDidHide((e) => {
 				resolve(undefined);
-				quickpick.dispose();
-			});
+				disposables.dispose();
+			}));
 
-			quickpick.onDidAccept(async (e) => {
+			disposables.add(quickpick.onDidAccept(async (e) => {
 				const selection = quickpick.selectedItems[0];
 				if ('provider' in selection) {
 					const session = await this.authenticationService.createSession(selection.provider.id, selection.provider.scopes);
@@ -386,7 +387,7 @@ export class RemoteTunnelWorkbenchContribution extends Disposable implements IWo
 					resolve(undefined);
 				}
 				quickpick.hide();
-			});
+			}));
 
 			quickpick.show();
 		});

--- a/src/vs/workbench/contrib/snippets/browser/snippetPicker.ts
+++ b/src/vs/workbench/contrib/snippets/browser/snippetPicker.ts
@@ -11,6 +11,7 @@ import { Codicon } from 'vs/base/common/codicons';
 import { ThemeIcon } from 'vs/base/common/themables';
 import { Event } from 'vs/base/common/event';
 import { ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
+import { DisposableStore } from 'vs/base/common/lifecycle';
 
 export async function pickSnippet(accessor: ServicesAccessor, languageIdOrSnippets: string | Snippet[]): Promise<Snippet | undefined> {
 
@@ -77,16 +78,17 @@ export async function pickSnippet(accessor: ServicesAccessor, languageIdOrSnippe
 		return result;
 	};
 
-	const picker = quickInputService.createQuickPick<ISnippetPick>({ useSeparators: true });
+	const disposables = new DisposableStore();
+	const picker = disposables.add(quickInputService.createQuickPick<ISnippetPick>({ useSeparators: true }));
 	picker.placeholder = nls.localize('pick.placeholder', "Select a snippet");
 	picker.matchOnDetail = true;
 	picker.ignoreFocusOut = false;
 	picker.keepScrollPosition = true;
-	picker.onDidTriggerItemButton(ctx => {
+	disposables.add(picker.onDidTriggerItemButton(ctx => {
 		const isEnabled = snippetService.isEnabled(ctx.item.snippet);
 		snippetService.updateEnablement(ctx.item.snippet, !isEnabled);
 		picker.items = makeSnippetPicks();
-	});
+	}));
 	picker.items = makeSnippetPicks();
 	if (!picker.items.length) {
 		picker.validationMessage = nls.localize('pick.noSnippetAvailable', "No snippet available");
@@ -96,6 +98,6 @@ export async function pickSnippet(accessor: ServicesAccessor, languageIdOrSnippe
 	// wait for an item to be picked or the picker to become hidden
 	await Promise.race([Event.toPromise(picker.onDidAccept), Event.toPromise(picker.onDidHide)]);
 	const result = picker.selectedItems[0]?.snippet;
-	picker.dispose();
+	disposables.dispose();
 	return result;
 }

--- a/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
@@ -2269,12 +2269,13 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 		const showAllColorsItem = { label: 'Reset to default' };
 		items.push(showAllColorsItem);
 
+		const disposables: IDisposable[] = [];
 		const quickPick = this._quickInputService.createQuickPick({ useSeparators: true });
+		disposables.push(quickPick);
 		quickPick.items = items;
 		quickPick.matchOnDescription = true;
 		quickPick.placeholder = nls.localize('changeColor', 'Select a color for the terminal');
 		quickPick.show();
-		const disposables: IDisposable[] = [];
 		const result = await new Promise<IQuickPickItem | undefined>(r => {
 			disposables.push(quickPick.onDidHide(() => r(undefined)));
 			disposables.push(quickPick.onDidAccept(() => r(quickPick.selectedItems[0])));

--- a/src/vs/workbench/contrib/testing/browser/testCoverageView.ts
+++ b/src/vs/workbench/contrib/testing/browser/testCoverageView.ts
@@ -698,13 +698,13 @@ registerAction2(class TestCoverageChangeSortingAction extends ViewAction<TestCov
 		quickInput.placeholder = localize('testing.coverageSortPlaceholder', 'Sort the Test Coverage view...');
 		quickInput.items = items;
 		quickInput.show();
-		quickInput.onDidHide(() => quickInput.dispose());
-		quickInput.onDidAccept(() => {
+		disposables.add(quickInput.onDidHide(() => disposables.dispose()));
+		disposables.add(quickInput.onDidAccept(() => {
 			const picked = quickInput.selectedItems[0]?.value;
 			if (picked !== undefined) {
 				view.sortOrder.set(picked, undefined);
 				quickInput.dispose();
 			}
-		});
+		}));
 	}
 });

--- a/src/vs/workbench/contrib/testing/browser/testExplorerActions.ts
+++ b/src/vs/workbench/contrib/testing/browser/testExplorerActions.ts
@@ -8,6 +8,7 @@ import { CancellationToken } from 'vs/base/common/cancellation';
 import { Codicon } from 'vs/base/common/codicons';
 import { Iterable } from 'vs/base/common/iterator';
 import { KeyChord, KeyCode, KeyMod } from 'vs/base/common/keyCodes';
+import { DisposableStore } from 'vs/base/common/lifecycle';
 import { isDefined } from 'vs/base/common/types';
 import { URI } from 'vs/base/common/uri';
 import { IActiveCodeEditor, ICodeEditor } from 'vs/editor/browser/editorBrowser';
@@ -465,22 +466,23 @@ function selectContinuousRunProfiles(
 		}
 	}
 
-	const quickpick = quickInputService.createQuickPick<IQuickPickItem & { profile: ITestRunProfile }>({ useSeparators: true });
+	const disposables = new DisposableStore();
+	const quickpick = disposables.add(quickInputService.createQuickPick<IQuickPickItem & { profile: ITestRunProfile }>({ useSeparators: true }));
 	quickpick.title = localize('testing.selectContinuousProfiles', 'Select profiles to run when files change:');
 	quickpick.canSelectMany = true;
 	quickpick.items = qpItems;
 	quickpick.selectedItems = selectedItems;
 	quickpick.show();
-	return new Promise((resolve, reject) => {
-		quickpick.onDidAccept(() => {
+	return new Promise(resolve => {
+		disposables.add(quickpick.onDidAccept(() => {
 			resolve(quickpick.selectedItems.map(i => i.profile));
-			quickpick.dispose();
-		});
+			disposables.dispose();
+		}));
 
-		quickpick.onDidHide(() => {
+		disposables.add(quickpick.onDidHide(() => {
 			resolve([]);
-			quickpick.dispose();
-		});
+			disposables.dispose();
+		}));
 	});
 }
 

--- a/src/vs/workbench/contrib/testing/browser/testingConfigurationUi.ts
+++ b/src/vs/workbench/contrib/testing/browser/testingConfigurationUi.ts
@@ -14,6 +14,7 @@ import { testingUpdateProfiles } from 'vs/workbench/contrib/testing/browser/icon
 import { testConfigurationGroupNames } from 'vs/workbench/contrib/testing/common/constants';
 import { InternalTestItem, ITestRunProfile, TestRunProfileBitset } from 'vs/workbench/contrib/testing/common/testTypes';
 import { canUseProfileWithTest, ITestProfileService } from 'vs/workbench/contrib/testing/common/testProfileService';
+import { DisposableStore } from 'vs/base/common/lifecycle';
 
 interface IConfigurationPickerOptions {
 	/** Placeholder text */
@@ -108,6 +109,9 @@ CommandsRegistry.registerCommand({
 			return;
 		}
 
+		const disposables = new DisposableStore();
+		disposables.add(quickpick);
+
 		quickpick.canSelectMany = true;
 		if (options.selected) {
 			quickpick.selectedItems = quickpick.items
@@ -116,16 +120,16 @@ CommandsRegistry.registerCommand({
 		}
 
 		const pick = await new Promise<ITestRunProfile[] | undefined>(resolve => {
-			quickpick.onDidAccept(() => {
+			disposables.add(quickpick.onDidAccept(() => {
 				const selected = quickpick.selectedItems as readonly { profile?: ITestRunProfile }[];
 				resolve(selected.map(s => s.profile).filter(isDefined));
-			});
-			quickpick.onDidHide(() => resolve(undefined));
-			quickpick.onDidTriggerItemButton(triggerButtonHandler(profileService, resolve));
+			}));
+			disposables.add(quickpick.onDidHide(() => resolve(undefined)));
+			disposables.add(quickpick.onDidTriggerItemButton(triggerButtonHandler(profileService, resolve)));
 			quickpick.show();
 		});
 
-		quickpick.dispose();
+		disposables.dispose();
 		return pick;
 	}
 });
@@ -139,14 +143,17 @@ CommandsRegistry.registerCommand({
 			return;
 		}
 
+		const disposables = new DisposableStore();
+		disposables.add(quickpick);
+
 		const pick = await new Promise<ITestRunProfile | undefined>(resolve => {
-			quickpick.onDidAccept(() => resolve((quickpick.selectedItems[0] as { profile?: ITestRunProfile })?.profile));
-			quickpick.onDidHide(() => resolve(undefined));
-			quickpick.onDidTriggerItemButton(triggerButtonHandler(profileService, resolve));
+			disposables.add(quickpick.onDidAccept(() => resolve((quickpick.selectedItems[0] as { profile?: ITestRunProfile })?.profile)));
+			disposables.add(quickpick.onDidHide(() => resolve(undefined)));
+			disposables.add(quickpick.onDidTriggerItemButton(triggerButtonHandler(profileService, resolve)));
 			quickpick.show();
 		});
 
-		quickpick.dispose();
+		disposables.dispose();
 		return pick;
 	}
 });

--- a/src/vs/workbench/contrib/testing/browser/testingDecorations.ts
+++ b/src/vs/workbench/contrib/testing/browser/testingDecorations.ts
@@ -1068,17 +1068,18 @@ class MultiRunTestDecoration extends RunTestDecoration implements ITestDecoratio
 
 	private async pickAndRun(testItems: IMultiRunTest[]) {
 		const doPick = <T extends IQuickPickItem>(items: T[], title: string) => new Promise<T | undefined>(resolve => {
-			const pick = this.quickInputService.createQuickPick<T>();
+			const disposables = new DisposableStore();
+			const pick = disposables.add(this.quickInputService.createQuickPick<T>());
 			pick.placeholder = title;
 			pick.items = items;
-			pick.onDidHide(() => {
+			disposables.add(pick.onDidHide(() => {
 				resolve(undefined);
-				pick.dispose();
-			});
-			pick.onDidAccept(() => {
+				disposables.dispose();
+			}));
+			disposables.add(pick.onDidAccept(() => {
 				resolve(pick.selectedItems[0]);
-				pick.dispose();
-			});
+				disposables.dispose();
+			}));
 			pick.show();
 		});
 

--- a/src/vs/workbench/services/authentication/browser/authenticationExtensionsService.ts
+++ b/src/vs/workbench/services/authentication/browser/authenticationExtensionsService.ts
@@ -274,10 +274,10 @@ export class AuthenticationExtensionsService extends Disposable implements IAuth
 			}));
 
 			disposables.add(quickPick.onDidHide(_ => {
-				disposables.dispose();
 				if (!quickPick.selectedItems[0]) {
 					reject('User did not consent to account access');
 				}
+				disposables.dispose();
 			}));
 
 			quickPick.show();

--- a/src/vs/workbench/services/authentication/browser/authenticationExtensionsService.ts
+++ b/src/vs/workbench/services/authentication/browser/authenticationExtensionsService.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Disposable, dispose, IDisposable, MutableDisposable } from 'vs/base/common/lifecycle';
+import { Disposable, DisposableStore, dispose, IDisposable, MutableDisposable } from 'vs/base/common/lifecycle';
 import * as nls from 'vs/nls';
 import { MenuId, MenuRegistry } from 'vs/platform/actions/common/actions';
 import { CommandsRegistry } from 'vs/platform/commands/common/commands';
@@ -220,7 +220,8 @@ export class AuthenticationExtensionsService extends Disposable implements IAuth
 		if (!allAccounts.length) {
 			throw new Error('No accounts available');
 		}
-		const quickPick = this.quickInputService.createQuickPick<{ label: string; session?: AuthenticationSession; account?: AuthenticationSessionAccount }>();
+		const disposables = new DisposableStore();
+		const quickPick = disposables.add(this.quickInputService.createQuickPick<{ label: string; session?: AuthenticationSession; account?: AuthenticationSessionAccount }>());
 		quickPick.ignoreFocusOut = true;
 		const items: { label: string; session?: AuthenticationSession; account?: AuthenticationSessionAccount }[] = availableSessions.map(session => {
 			return {
@@ -251,7 +252,7 @@ export class AuthenticationExtensionsService extends Disposable implements IAuth
 		quickPick.placeholder = nls.localize('getSessionPlateholder', "Select an account for '{0}' to use or Esc to cancel", extensionName);
 
 		return await new Promise((resolve, reject) => {
-			quickPick.onDidAccept(async _ => {
+			disposables.add(quickPick.onDidAccept(async _ => {
 				quickPick.dispose();
 				let session = quickPick.selectedItems[0].session;
 				if (!session) {
@@ -270,14 +271,14 @@ export class AuthenticationExtensionsService extends Disposable implements IAuth
 				this.removeAccessRequest(providerId, extensionId);
 
 				resolve(session);
-			});
+			}));
 
-			quickPick.onDidHide(_ => {
-				quickPick.dispose();
+			disposables.add(quickPick.onDidHide(_ => {
+				disposables.dispose();
 				if (!quickPick.selectedItems[0]) {
 					reject('User did not consent to account access');
 				}
-			});
+			}));
 
 			quickPick.show();
 		});

--- a/src/vs/workbench/services/userDataProfile/browser/userDataProfileImportExportService.ts
+++ b/src/vs/workbench/services/userDataProfile/browser/userDataProfileImportExportService.ts
@@ -393,7 +393,7 @@ export class UserDataProfileImportExportService extends Disposable implements IU
 		const extensions: IQuickPickItem & { id: ProfileResourceType } = { id: ProfileResourceType.Extensions, label: localize('extensions', "Extensions"), picked: !profile?.useDefaultFlags?.extensions };
 		const resources = [settings, keybindings, snippets, tasks, extensions];
 
-		const quickPick = this.quickInputService.createQuickPick();
+		const quickPick = disposables.add(this.quickInputService.createQuickPick());
 		quickPick.title = title;
 		quickPick.placeholder = localize('name placeholder', "Profile name");
 		quickPick.value = profile?.name ?? (isUserDataProfileTemplate(source) ? this.generateProfileName(source.name) : '');


### PR DESCRIPTION
For some reason, most uses of quick pick / input leak listeners 🤷 . Here I go over some, other that I felt are a bit more complex are covered in separate issues:
* https://github.com/microsoft/vscode/issues/225386
* https://github.com/microsoft/vscode/issues/225385
* https://github.com/microsoft/vscode/issues/225381
* https://github.com/microsoft/vscode/issues/225379

The strategy I applied here is to have a `DisposableStore` when creating quick picker or input that disposes on hide, assuming that is always the last event to fire, either when something is accepted or the input is cancelled.