### PR TITLE
lm: prototype of returning elements from lm tools

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadLanguageModelTools.ts
+++ b/src/vs/workbench/api/browser/mainThreadLanguageModelTools.ts
@@ -5,8 +5,8 @@
 
 import { CancellationToken } from 'vs/base/common/cancellation';
 import { Disposable, DisposableMap } from 'vs/base/common/lifecycle';
-import { ExtHostLanguageModelToolsShape, ExtHostContext, MainContext, MainThreadLanguageModelToolsShape } from 'vs/workbench/api/common/extHost.protocol';
-import { IToolData, ILanguageModelToolsService, IToolResult } from 'vs/workbench/contrib/chat/common/languageModelToolsService';
+import { ExtHostContext, ExtHostLanguageModelToolsShape, MainContext, MainThreadLanguageModelToolsShape } from 'vs/workbench/api/common/extHost.protocol';
+import { ILanguageModelToolsService, IToolData, IToolInvokation, IToolPromptContext, IToolTsxPromptPiece } from 'vs/workbench/contrib/chat/common/languageModelToolsService';
 import { IExtHostContext, extHostNamedCustomer } from 'vs/workbench/services/extensions/common/extHostCustomers';
 
 @extHostNamedCustomer(MainContext.MainThreadLanguageModelTools)
@@ -29,8 +29,27 @@ export class MainThreadLanguageModelTools extends Disposable implements MainThre
 		return Array.from(this._languageModelToolsService.getTools());
 	}
 
-	$invokeTool(name: string, parameters: any, token: CancellationToken): Promise<IToolResult> {
+	$invokeTool(name: string, parameters: any, token: CancellationToken): Promise<IToolInvokation> {
 		return this._languageModelToolsService.invokeTool(name, parameters, token);
+	}
+
+	$freeToolInvokation(invokationId: string): void {
+		this._languageModelToolsService.freeToolInvokation(invokationId);
+	}
+
+	$invokeToolRender(callerId: string, invokationId: string, objectIdOrContentType: number | string, context: IToolPromptContext, token: CancellationToken | undefined): Promise<IToolTsxPromptPiece> {
+		return this._languageModelToolsService.invokeToolRender(
+			callerId,
+			invokationId,
+			objectIdOrContentType,
+			context,
+			token,
+			(input, token) => this._proxy.$invokeToolCountTokens(callerId, input, token)
+		);
+	}
+
+	$invokeToolCountTokens(callerId: string, input: string, token: CancellationToken | undefined): Promise<number> {
+		return this._languageModelToolsService.invokeToolCountTokens(callerId, input, token);
 	}
 
 	$registerTool(name: string): void {
@@ -39,6 +58,12 @@ export class MainThreadLanguageModelTools extends Disposable implements MainThre
 			{
 				invoke: async (parameters, token) => {
 					return await this._proxy.$invokeTool(name, parameters, token);
+				},
+				free: (invokationId) => {
+					this._proxy.$freeToolInvokation(invokationId);
+				},
+				render: (callerId, invokationId, objectIdOrContentType, context, token) => {
+					return this._proxy.$invokeToolRender(callerId, invokationId, objectIdOrContentType, context, token);
 				},
 			});
 		this._tools.set(name, disposable);

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -56,7 +56,7 @@ import { IChatProgressResponseContent } from 'vs/workbench/contrib/chat/common/c
 import { ChatAgentVoteDirection, IChatFollowup, IChatProgress, IChatResponseErrorDetails, IChatTask, IChatTaskDto, IChatUserActionEvent } from 'vs/workbench/contrib/chat/common/chatService';
 import { IChatRequestVariableValue, IChatVariableData, IChatVariableResolverProgress } from 'vs/workbench/contrib/chat/common/chatVariables';
 import { IChatMessage, IChatResponseFragment, ILanguageModelChatMetadata, ILanguageModelChatSelector, ILanguageModelsChangeEvent } from 'vs/workbench/contrib/chat/common/languageModels';
-import { IToolData, IToolDelta, IToolResult } from 'vs/workbench/contrib/chat/common/languageModelToolsService';
+import { IToolData, IToolDelta, IToolInvokation, IToolPromptContext, IToolTsxPromptPiece } from 'vs/workbench/contrib/chat/common/languageModelToolsService';
 import { DebugConfigurationProviderTriggerKind, IAdapterDescriptor, IConfig, IDebugSessionReplMode, IDebugTestRunReference, IDebugVisualization, IDebugVisualizationContext, IDebugVisualizationTreeItem, MainThreadDebugVisualization } from 'vs/workbench/contrib/debug/common/debug';
 import * as notebookCommon from 'vs/workbench/contrib/notebook/common/notebookCommon';
 import { CellExecutionUpdateType } from 'vs/workbench/contrib/notebook/common/notebookExecutionService';
@@ -1310,9 +1310,23 @@ export interface MainThreadChatVariablesShape extends IDisposable {
 
 export interface MainThreadLanguageModelToolsShape extends IDisposable {
 	$getTools(): Promise<Dto<IToolData>[]>;
-	$invokeTool(name: string, parameters: any, token: CancellationToken): Promise<IToolResult>;
+	$invokeTool(name: string, parameters: any, token: CancellationToken): Promise<IToolInvokation>;
 	$registerTool(id: string): void;
 	$unregisterTool(name: string): void;
+
+	/**
+	 * Invokes `render` on a tool's response or an element returns from a response previously.
+	 * @param callerId Caller ID for countToken lookups.
+	 * @param invokationId Tool invokation to address
+	 * @param objectIdOrContentType If a number, an ID of an existing invokation
+	 * object. If a string, an object from one of the content types.
+	 * @param context Context info to pass to `render()`
+	 */
+	$invokeToolRender(callerId: string, invokationId: string, objectIdOrContentType: number | string, context: IToolPromptContext, token: CancellationToken | undefined): Promise<IToolTsxPromptPiece>;
+	/** Frees data associated with a prior invokation. */
+	$freeToolInvokation(invokationId: string): void;
+	/** Counts tokens for a caller whos ID was passed to `invokeToolRender` */
+	$invokeToolCountTokens(callerId: string, input: string, token: CancellationToken | undefined): Promise<number>;
 }
 
 export type IChatRequestVariableValueDto = Dto<IChatRequestVariableValue>;
@@ -1323,7 +1337,11 @@ export interface ExtHostChatVariablesShape {
 
 export interface ExtHostLanguageModelToolsShape {
 	$acceptToolDelta(delta: IToolDelta): Promise<void>;
-	$invokeTool(id: string, parameters: any, token: CancellationToken): Promise<IToolResult>;
+	$invokeTool(id: string, parameters: any, token: CancellationToken): Promise<IToolInvokation>;
+
+	$invokeToolCountTokens(callerId: string, input: string, token: CancellationToken | undefined): Promise<number>;
+	$invokeToolRender(callerId: string, invokationId: string, objectIdOrContentType: number | string, context: IToolPromptContext, token: CancellationToken | undefined): Promise<IToolTsxPromptPiece>;
+	$freeToolInvokation(invokationId: string): void;
 }
 
 export interface MainThreadUrlsShape extends IDisposable {

--- a/src/vs/workbench/api/common/extHostLanguageModelTools.ts
+++ b/src/vs/workbench/api/common/extHostLanguageModelTools.ts
@@ -6,16 +6,29 @@
 import { CancellationToken } from 'vs/base/common/cancellation';
 import { IDisposable, toDisposable } from 'vs/base/common/lifecycle';
 import { revive } from 'vs/base/common/marshalling';
+import { generateUuid } from 'vs/base/common/uuid';
 import { IExtensionDescription } from 'vs/platform/extensions/common/extensions';
 import { ExtHostLanguageModelToolsShape, IMainContext, MainContext, MainThreadLanguageModelToolsShape } from 'vs/workbench/api/common/extHost.protocol';
 import * as typeConvert from 'vs/workbench/api/common/extHostTypeConverters';
-import { IToolData, IToolDelta, IToolResult } from 'vs/workbench/contrib/chat/common/languageModelToolsService';
+import { IsTsxElementToken, IToolData, IToolDelta, IToolInvokation, IToolPromptContext, IToolsTsxPromptElement, IToolTsxPromptPiece } from 'vs/workbench/contrib/chat/common/languageModelToolsService';
 import type * as vscode from 'vscode';
+
+let intermdiateIdCounter = 0;
 
 export class ExtHostLanguageModelTools implements ExtHostLanguageModelToolsShape {
 	/** A map of tools that were registered in this EH */
 	private readonly _registeredTools = new Map<string, { extension: IExtensionDescription; tool: vscode.LanguageModelTool }>();
 	private readonly _proxy: MainThreadLanguageModelToolsShape;
+	private readonly _invokationCallers = new Map<string, {
+		countTokens(text: string, token?: CancellationToken): Promise<number> | number;
+	}>();
+
+	private readonly _invokations = new Map<string, {
+		/** Tool result returned by the model */
+		result: vscode.LanguageModelToolResult;
+		/** Intermediate objects on which functions can be called. */
+		intermediates: Map<number, IToolTsxPromptPiece>;
+	}>();
 
 	/** A map of all known tools, from other EHs or registered in vscode core */
 	private readonly _allTools = new Map<string, IToolData>();
@@ -30,10 +43,21 @@ export class ExtHostLanguageModelTools implements ExtHostLanguageModelToolsShape
 		});
 	}
 
-	async invokeTool(name: string, parameters: any, token: CancellationToken): Promise<vscode.LanguageModelToolResult> {
+	async invokeTool(name: string, parameters: any, token: CancellationToken): Promise<vscode.LanguageModelToolResult & vscode.Disposable> {
 		// Making the round trip here because not all tools were necessarily registered in this EH
 		const result = await this._proxy.$invokeTool(name, parameters, token);
-		return typeConvert.LanguageModelToolResult.to(result);
+		for (const [key, value] of Object.entries(result.result)) {
+			if (typeConvert.LanguageModelToolResult.isPromptPieceLike(value) && typeof value.ctor === 'object') {
+				result.result[key] = {
+					...value,
+					ctor: this.makeProxiedTsxElement(result.id, key),
+				};
+			}
+		}
+
+		return typeConvert.LanguageModelToolResult.to(result, () => {
+			this._proxy.$freeToolInvokation(result.id);
+		});
 	}
 
 	async $acceptToolDelta(delta: IToolDelta): Promise<void> {
@@ -51,14 +75,69 @@ export class ExtHostLanguageModelTools implements ExtHostLanguageModelToolsShape
 			.map(tool => typeConvert.LanguageModelToolDescription.to(tool));
 	}
 
-	async $invokeTool(name: string, parameters: any, token: CancellationToken): Promise<IToolResult> {
+	$freeToolInvokation(invokationId: string): void {
+		this._invokations.delete(invokationId);
+	}
+
+	$invokeToolCountTokens(callerId: string, input: string): Promise<number> {
+		const caller = this._invokationCallers.get(callerId);
+		if (!caller) {
+			throw new Error(`Unknown caller ${callerId}`);
+		}
+
+		return Promise.resolve(caller.countTokens(input));
+	}
+
+	async $invokeToolRender(callerId: string, invokationId: string, objectIdOrContentType: number | string, context: IToolPromptContext): Promise<IToolTsxPromptPiece> {
+		const invokation = this._invokations.get(invokationId);
+		if (!invokation) {
+			throw new Error(`Unknown invokation ${invokationId}`);
+		}
+
+		const object: IToolTsxPromptPiece = typeof objectIdOrContentType === 'string'
+			? (invokation.result.hasOwnProperty(objectIdOrContentType) && invokation.result[objectIdOrContentType])
+			: invokation.intermediates.get(objectIdOrContentType);
+		if (!object || typeof object.ctor !== 'function') {
+			throw new Error(`Unknown object ${objectIdOrContentType}`);
+		}
+
+		function process(part: IToolTsxPromptPiece): IToolTsxPromptPiece {
+			let ctor = part.ctor;
+			if (typeof part.ctor === 'function') {
+				const id = ++intermdiateIdCounter;
+				invokation!.intermediates.set(id, part);
+				ctor = { [IsTsxElementToken]: id };
+			}
+
+			return {
+				...part,
+				ctor,
+				children: part.children.map((p): any => p && typeof p === 'object' ? process(p) : p),
+			};
+		}
+
+		const element = new object.ctor(object.props || {});
+
+		return process(await element.render({
+			...context,
+			countTokens: (text: string, token?: CancellationToken) => this._proxy.$invokeToolCountTokens(callerId, text, token),
+		}));
+	}
+
+	async $invokeTool(name: string, parameters: any, token: CancellationToken): Promise<IToolInvokation> {
 		const item = this._registeredTools.get(name);
 		if (!item) {
 			throw new Error(`Unknown tool ${name}`);
 		}
 
 		const extensionResult = await item.tool.invoke(parameters, token);
-		return typeConvert.LanguageModelToolResult.from(extensionResult);
+		const invokationId = generateUuid();
+		this._invokations.set(invokationId, {
+			result: extensionResult,
+			intermediates: new Map<number, any>(),
+		});
+
+		return typeConvert.LanguageModelToolResult.from(invokationId, extensionResult);
 	}
 
 	registerTool(extension: IExtensionDescription, name: string, tool: vscode.LanguageModelTool): IDisposable {
@@ -69,5 +148,42 @@ export class ExtHostLanguageModelTools implements ExtHostLanguageModelToolsShape
 			this._registeredTools.delete(name);
 			this._proxy.$unregisterTool(name);
 		});
+	}
+
+	private makeProxiedTsxElement(invokationId: string, objectIdOrContentType: string | number) {
+		const that = this;
+
+		return class implements IToolsTsxPromptElement {
+			constructor(_props: unknown) { }
+
+			async render(_state: unknown, sizing: {
+				readonly tokenBudget: number;
+				readonly endpoint: { modelMaxPromptTokens: number };
+				countTokens(text: string, token?: CancellationToken): Promise<number> | number;
+			}, token?: CancellationToken) {
+				const callerId = generateUuid();
+				that._invokationCallers.set(callerId, { countTokens: sizing.countTokens });
+				try {
+					const result = await that._proxy.$invokeToolRender(callerId, invokationId, objectIdOrContentType, {
+						endpoint: sizing.endpoint,
+						tokenBudget: sizing.tokenBudget,
+					}, token);
+
+					const process = (part: IToolTsxPromptPiece): IToolTsxPromptPiece => {
+						return {
+							...part,
+							ctor: typeof part.ctor === 'object' && IsTsxElementToken in part.ctor
+								? that.makeProxiedTsxElement(invokationId, part.ctor[IsTsxElementToken])
+								: part.ctor,
+							children: part.children.map((p): any => typeof p === 'object' && p ? process(p) : p),
+						};
+					};
+
+					return process(result);
+				} finally {
+					that._invokationCallers.delete(callerId);
+				}
+			}
+		};
 	}
 }

--- a/src/vs/workbench/contrib/chat/common/languageModelToolsService.ts
+++ b/src/vs/workbench/contrib/chat/common/languageModelToolsService.ts
@@ -33,6 +33,8 @@ interface IToolEntry {
  */
 export const IsTsxElementToken = '$$isTSXElement';
 
+export const IsFragmentMarker = '$$isFragment';
+
 export interface IToolPromptContext {
 	tokenBudget: number;
 	endpoint: { modelMaxPromptTokens: number };

--- a/src/vscode-dts/vscode.proposed.lmTools.d.ts
+++ b/src/vscode-dts/vscode.proposed.lmTools.d.ts
@@ -93,7 +93,7 @@ declare module 'vscode' {
 		 * Invoke a tool with the given parameters.
 		 * TODO@API Could request a set of contentTypes to be returned so they don't all need to be computed?
 		 */
-		export function invokeTool(name: string, parameters: Object, token: CancellationToken): Thenable<LanguageModelToolResult>;
+		export function invokeTool(name: string, parameters: Object, token: CancellationToken): Thenable<LanguageModelToolResult & Disposable>;
 	}
 
 	// Is the same as LanguageModelChatFunction now, but could have more details in the future


### PR DESCRIPTION
This prototypes the ability to return `{ myType: <SomeTsxElement />}`
from a language model tool with automatic consumption ability in a
caller. Still some bugs but it's getting there.

This necessarily makes `invokeTool` return a disposable, since now the
extension host need to retain the tool element so it can be called later.

I don't like this approach. It's complex and brings knowledge of TSX
into the extension host, in spite of only depending on the very minimal
TSX element with a `render` method. It also round trips every subsequent
render and token counting call through the extension host.

It would be nicer to have a way to pass the token counting function and
a budget to the tool and let it return some plain JSON-serializable
object that prompt-tsx understands. Token counting still round trips,
but it's less round trip. (And in the future maybe token counting can
be commoditized to avoid round trips.)

@roblourens @jrieken

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
