### PR TITLE
Adopt new search query structure

### DIFF
--- a/src/vs/workbench/api/common/extHostSearch.ts
+++ b/src/vs/workbench/api/common/extHostSearch.ts
@@ -15,6 +15,7 @@ import { IRawFileQuery, ISearchCompleteStats, IFileQuery, IRawTextQuery, IRawQue
 import { URI, UriComponents } from 'vs/base/common/uri';
 import { TextSearchManager } from 'vs/workbench/services/search/common/textSearchManager';
 import { CancellationToken } from 'vs/base/common/cancellation';
+import { revive } from 'vs/base/common/marshalling';
 
 export interface IExtHostSearch extends ExtHostSearchShape {
 	registerTextSearchProvider(scheme: string, provider: vscode.TextSearchProvider): IDisposable;
@@ -171,8 +172,6 @@ export function reviveQuery<U extends IRawQuery>(rawQuery: U): U extends IRawTex
 }
 
 function reviveFolderQuery(rawFolderQuery: IFolderQuery<UriComponents>): IFolderQuery<URI> {
-	return {
-		...rawFolderQuery,
-		folder: URI.revive(rawFolderQuery.folder)
-	};
+	return revive(rawFolderQuery);
 }
+

--- a/src/vs/workbench/api/common/extHostWorkspace.ts
+++ b/src/vs/workbench/api/common/extHostWorkspace.ts
@@ -547,8 +547,7 @@ export class ExtHostWorkspace implements ExtHostWorkspaceShape, IExtHostWorkspac
 			fileEncoding: options.encoding,
 			maxResults: options.maxResults,
 			previewOptions,
-			afterContext: options.afterContext,
-			beforeContext: options.beforeContext,
+			surroundingContext: options.afterContext,
 
 			includePattern: includePattern,
 			excludePattern: excludePattern

--- a/src/vs/workbench/api/test/browser/mainThreadWorkspace.test.ts
+++ b/src/vs/workbench/api/test/browser/mainThreadWorkspace.test.ts
@@ -56,7 +56,7 @@ suite('MainThreadWorkspace', () => {
 			fileSearch(query: IFileQuery) {
 				assert.strictEqual(query.folderQueries.length, 1);
 				assert.strictEqual(query.folderQueries[0].disregardIgnoreFiles, true);
-				assert.deepStrictEqual(query.folderQueries[0].excludePattern, { 'filesExclude': true });
+				assert.deepStrictEqual(query.folderQueries[0].excludePattern?.pattern, { 'filesExclude': true });
 
 				return Promise.resolve({ results: [], messages: [] });
 			}

--- a/src/vs/workbench/api/test/node/extHostSearch.test.ts
+++ b/src/vs/workbench/api/test/node/extHostSearch.test.ts
@@ -339,7 +339,9 @@ suite('ExtHostSearch', () => {
 							'foo': true
 						},
 						excludePattern: {
-							'bar': true
+							pattern: {
+								'bar': true
+							}
 						}
 					},
 					{ folder: rootFolderB }
@@ -378,7 +380,9 @@ suite('ExtHostSearch', () => {
 							'*.jsx': true
 						},
 						excludePattern: {
-							'*.js': false
+							pattern: {
+								'*.js': false
+							}
 						}
 					}
 				]
@@ -496,15 +500,19 @@ suite('ExtHostSearch', () => {
 					{
 						folder: rootFolderA,
 						excludePattern: {
-							'folder/*.css': {
-								when: '$(basename).scss'
+							pattern: {
+								'folder/*.css': {
+									when: '$(basename).scss'
+								}
 							}
 						}
 					},
 					{
 						folder: rootFolderB,
 						excludePattern: {
-							'*.js': false
+							pattern: {
+								'*.js': false
+							}
 						}
 					}
 				]
@@ -877,7 +885,9 @@ suite('ExtHostSearch', () => {
 							'foo': true
 						},
 						excludePattern: {
-							'bar': true
+							pattern: {
+								'bar': true
+							}
 						}
 					},
 					{ folder: rootFolderB }
@@ -916,7 +926,9 @@ suite('ExtHostSearch', () => {
 							'*.jsx': true
 						},
 						excludePattern: {
-							'*.js': false
+							pattern: {
+								'*.js': false
+							}
 						}
 					}
 				]
@@ -1042,15 +1054,19 @@ suite('ExtHostSearch', () => {
 					{
 						folder: rootFolderA,
 						excludePattern: {
-							'folder/*.css': {
-								when: '$(basename).scss'
+							pattern: {
+								'folder/*.css': {
+									when: '$(basename).scss'
+								}
 							}
 						}
 					},
 					{
 						folder: rootFolderB,
 						excludePattern: {
-							'*.js': false
+							pattern: {
+								'*.js': false
+							}
 						}
 					}
 				]

--- a/src/vs/workbench/contrib/searchEditor/browser/searchEditor.ts
+++ b/src/vs/workbench/contrib/searchEditor/browser/searchEditor.ts
@@ -558,8 +558,7 @@ export class SearchEditor extends AbstractTextCodeEditor<SearchEditorViewState> 
 				matchLines: 1,
 				charsPerLine: 1000
 			},
-			afterContext: config.contextLines,
-			beforeContext: config.contextLines,
+			surroundingContext: config.contextLines,
 			isSmartCase: this.searchConfig.smartCase,
 			expandPatterns: true,
 			notebookSearchConfig: {

--- a/src/vs/workbench/services/search/common/fileSearchManager.ts
+++ b/src/vs/workbench/services/search/common/fileSearchManager.ts
@@ -10,7 +10,7 @@ import * as glob from 'vs/base/common/glob';
 import * as resources from 'vs/base/common/resources';
 import { StopWatch } from 'vs/base/common/stopwatch';
 import { URI } from 'vs/base/common/uri';
-import { IFileMatch, IFileSearchProviderStats, IFolderQuery, ISearchCompleteStats, IFileQuery, QueryGlobTester, resolvePatternsForProvider, hasSiblingFn } from 'vs/workbench/services/search/common/search';
+import { IFileMatch, IFileSearchProviderStats, IFolderQuery, ISearchCompleteStats, IFileQuery, QueryGlobTester, resolvePatternsForProvider, hasSiblingFn, excludeToGlobPattern } from 'vs/workbench/services/search/common/search';
 import { FileSearchProvider, FileSearchOptions } from 'vs/workbench/services/search/common/searchExtTypes';
 
 interface IInternalFileMatch {
@@ -164,11 +164,11 @@ class FileSearchEngine {
 
 	private getSearchOptionsForFolder(fq: IFolderQuery<URI>): FileSearchOptions {
 		const includes = resolvePatternsForProvider(this.config.includePattern, fq.includePattern);
-		const excludes = resolvePatternsForProvider(this.config.excludePattern, fq.excludePattern);
+		const excludes = excludeToGlobPattern(fq.excludePattern?.folder, resolvePatternsForProvider(this.config.excludePattern, fq.excludePattern?.pattern));
 
 		return {
 			folder: fq.folder,
-			excludes,
+			excludes: excludes.map(e => typeof (e) === 'string' ? e : e.pattern), // TODO- follow baseURI
 			includes,
 			useIgnoreFiles: !fq.disregardIgnoreFiles,
 			useGlobalIgnoreFiles: !fq.disregardGlobalIgnoreFiles,

--- a/src/vs/workbench/services/search/common/fileSearchManager.ts
+++ b/src/vs/workbench/services/search/common/fileSearchManager.ts
@@ -168,7 +168,7 @@ class FileSearchEngine {
 
 		return {
 			folder: fq.folder,
-			excludes: excludes.map(e => typeof (e) === 'string' ? e : e.pattern), // TODO- follow baseURI
+			excludes: excludes.map(e => typeof e === 'string' ? e : e.pattern), // TODO- follow baseURI
 			includes,
 			useIgnoreFiles: !fq.disregardIgnoreFiles,
 			useGlobalIgnoreFiles: !fq.disregardGlobalIgnoreFiles,

--- a/src/vs/workbench/services/search/common/getFileResults.ts
+++ b/src/vs/workbench/services/search/common/getFileResults.ts
@@ -11,8 +11,7 @@ export const getFileResults = (
 	bytes: Uint8Array,
 	pattern: RegExp,
 	options: {
-		beforeContext: number;
-		afterContext: number;
+		surroundingContext: number;
 		previewOptions: TextSearchPreviewOptions | undefined;
 		remainingResultQuota: number;
 	}
@@ -71,8 +70,8 @@ export const getFileResults = (
 				endLine++;
 			}
 
-			if (options.beforeContext) {
-				for (let contextLine = Math.max(0, startLine - options.beforeContext); contextLine < startLine; contextLine++) {
+			if (options.surroundingContext) {
+				for (let contextLine = Math.max(0, startLine - options.surroundingContext); contextLine < startLine; contextLine++) {
 					contextLinesNeeded.add(contextLine);
 				}
 			}
@@ -108,8 +107,8 @@ export const getFileResults = (
 			};
 			results.push(match);
 
-			if (options.afterContext) {
-				for (let contextLine = endLine + 1; contextLine <= Math.min(endLine + options.afterContext, lineRanges.length - 1); contextLine++) {
+			if (options.surroundingContext) {
+				for (let contextLine = endLine + 1; contextLine <= Math.min(endLine + options.surroundingContext, lineRanges.length - 1); contextLine++) {
 					contextLinesNeeded.add(contextLine);
 				}
 			}

--- a/src/vs/workbench/services/search/common/queryBuilder.ts
+++ b/src/vs/workbench/services/search/common/queryBuilder.ts
@@ -22,7 +22,7 @@ import { IUriIdentityService } from 'vs/platform/uriIdentity/common/uriIdentity'
 import { IWorkspaceContextService, IWorkspaceFolderData, toWorkspaceFolder, WorkbenchState } from 'vs/platform/workspace/common/workspace';
 import { IEditorGroupsService } from 'vs/workbench/services/editor/common/editorGroupsService';
 import { IPathService } from 'vs/workbench/services/path/common/pathService';
-import { getExcludes, ICommonQueryProps, IFileQuery, IFolderQuery, IPatternInfo, ISearchConfiguration, ITextQuery, ITextSearchPreviewOptions, pathIncludedInQuery, QueryType } from 'vs/workbench/services/search/common/search';
+import { ExcludeGlobPattern, getExcludes, ICommonQueryProps, IFileQuery, IFolderQuery, IPatternInfo, ISearchConfiguration, ITextQuery, ITextSearchPreviewOptions, pathIncludedInQuery, QueryType } from 'vs/workbench/services/search/common/search';
 
 /**
  * One folder to search and a glob expression that should be applied.
@@ -40,6 +40,17 @@ export interface ISearchPathPattern {
 	pattern?: glob.IExpression;
 }
 
+type ISearchPathPatternBuilder = string | string[];
+
+interface ISearchPatternBuilder {
+	uri?: uri;
+	pattern: ISearchPathPatternBuilder;
+}
+
+export function isISearchPatternBuilder(object: any): object is ISearchPatternBuilder {
+	return 'pattern' in object && (typeof object.pattern === 'string' || Array.isArray(object.pattern)) && (object.uri === undefined || URI.isUri(object.uri));
+}
+
 /**
  * A set of search paths and a set of glob expressions that should be applied.
  */
@@ -50,8 +61,8 @@ export interface ISearchPathsInfo {
 
 interface ICommonQueryBuilderOptions {
 	_reason?: string;
-	excludePattern?: string | string[];
-	includePattern?: string | string[];
+	excludePattern?: ISearchPatternBuilder | ISearchPathPatternBuilder;
+	includePattern?: ISearchPathPatternBuilder;
 	extraFileResources?: uri[];
 
 	/** Parse the special ./ syntax supported by the searchview, and expand foo to ** /foo */
@@ -79,8 +90,7 @@ export interface IFileQueryBuilderOptions extends ICommonQueryBuilderOptions {
 export interface ITextQueryBuilderOptions extends ICommonQueryBuilderOptions {
 	previewOptions?: ITextSearchPreviewOptions;
 	fileEncoding?: string;
-	beforeContext?: number;
-	afterContext?: number;
+	surroundingContext?: number;
 	isSmartCase?: boolean;
 	notebookSearchConfig?: {
 		includeMarkupInput: boolean;
@@ -98,7 +108,7 @@ export class QueryBuilder {
 		@IEditorGroupsService private readonly editorGroupsService: IEditorGroupsService,
 		@ILogService private readonly logService: ILogService,
 		@IPathService private readonly pathService: IPathService,
-		@IUriIdentityService protected readonly uriIdentityService: IUriIdentityService
+		@IUriIdentityService private readonly uriIdentityService: IUriIdentityService
 	) {
 	}
 
@@ -119,8 +129,7 @@ export class QueryBuilder {
 			previewOptions: options.previewOptions,
 			maxFileSize: options.maxFileSize,
 			usePCRE2: searchConfig.search.usePCRE2 || fallbackToPCRE || false,
-			beforeContext: options.beforeContext,
-			afterContext: options.afterContext,
+			surroundingContext: options.surroundingContext,
 			userDisabledExcludesAndIgnoreFiles: options.disregardExcludeSettings && options.disregardIgnoreFiles,
 
 		};
@@ -207,8 +216,9 @@ export class QueryBuilder {
 	}
 
 	private commonQuery(folderResources: (IWorkspaceFolderData | URI)[] = [], options: ICommonQueryBuilderOptions = {}): ICommonQueryProps<uri> {
+		const excludePattern = isISearchPatternBuilder(options.excludePattern) ? options.excludePattern.pattern : options.excludePattern;
 		const includeSearchPathsInfo: ISearchPathsInfo = this.handleIncludeExclude(options.includePattern, options.expandPatterns);
-		const excludeSearchPathsInfo: ISearchPathsInfo = this.handleIncludeExclude(options.excludePattern, options.expandPatterns);
+		const excludeSearchPathsInfo: ISearchPathsInfo = this.handleIncludeExclude(excludePattern, options.expandPatterns);
 
 		// Build folderQueries from searchPaths, if given, otherwise folderResources
 		const includeFolderName = folderResources.length > 1;
@@ -525,6 +535,12 @@ export class QueryBuilder {
 	private getFolderQueryForRoot(folder: (IWorkspaceFolderData | URI), options: ICommonQueryBuilderOptions, searchPathExcludes: ISearchPathsInfo, includeFolderName: boolean): IFolderQuery | null {
 		let thisFolderExcludeSearchPathPattern: glob.IExpression | undefined;
 		const folderUri = URI.isUri(folder) ? folder : folder.uri;
+
+		// only use exclude root if it is different from the folder root
+		const excludeRoot = isISearchPatternBuilder(options.excludePattern) ? options.excludePattern.uri : undefined;
+		const shouldUseExcludeRoot = (!excludeRoot || !(URI.isUri(folder) && this.uriIdentityService.extUri.isEqual(folder, excludeRoot)));
+		const excludeFolderRoot = shouldUseExcludeRoot ? excludeRoot : undefined;
+
 		if (searchPathExcludes.searchPaths) {
 			const thisFolderExcludeSearchPath = searchPathExcludes.searchPaths.filter(sp => isEqual(sp.searchPath, folderUri))[0];
 			if (thisFolderExcludeSearchPath && !thisFolderExcludeSearchPath.pattern) {
@@ -543,10 +559,16 @@ export class QueryBuilder {
 		};
 
 		const folderName = URI.isUri(folder) ? basename(folder) : folder.name;
+
+		const excludePatternRet = Object.keys(excludePattern).length > 0 ? {
+			folder: excludeFolderRoot,
+			pattern: excludePattern
+		} satisfies ExcludeGlobPattern : undefined;
+
 		return {
 			folder: folderUri,
 			folderName: includeFolderName ? folderName : undefined,
-			excludePattern: Object.keys(excludePattern).length > 0 ? excludePattern : undefined,
+			excludePattern: excludePatternRet,
 			fileEncoding: folderConfig.files && folderConfig.files.encoding,
 			disregardIgnoreFiles: typeof options.disregardIgnoreFiles === 'boolean' ? options.disregardIgnoreFiles : !folderConfig.search.useIgnoreFiles,
 			disregardGlobalIgnoreFiles: typeof options.disregardGlobalIgnoreFiles === 'boolean' ? options.disregardGlobalIgnoreFiles : !folderConfig.search.useGlobalIgnoreFiles,

--- a/src/vs/workbench/services/search/common/queryBuilder.ts
+++ b/src/vs/workbench/services/search/common/queryBuilder.ts
@@ -47,8 +47,8 @@ interface ISearchPatternBuilder {
 	pattern: ISearchPathPatternBuilder;
 }
 
-export function isISearchPatternBuilder(object: any): object is ISearchPatternBuilder {
-	return 'pattern' in object && (typeof object.pattern === 'string' || Array.isArray(object.pattern)) && (object.uri === undefined || URI.isUri(object.uri));
+export function isISearchPatternBuilder(object: ISearchPatternBuilder | ISearchPathPatternBuilder): object is ISearchPatternBuilder {
+	return (typeof object === 'object' && 'uri' in object && 'pattern' in object);
 }
 
 /**
@@ -216,7 +216,7 @@ export class QueryBuilder {
 	}
 
 	private commonQuery(folderResources: (IWorkspaceFolderData | URI)[] = [], options: ICommonQueryBuilderOptions = {}): ICommonQueryProps<uri> {
-		const excludePattern = isISearchPatternBuilder(options.excludePattern) ? options.excludePattern.pattern : options.excludePattern;
+		const excludePattern = options.excludePattern && isISearchPatternBuilder(options.excludePattern) ? options.excludePattern.pattern : options.excludePattern;
 		const includeSearchPathsInfo: ISearchPathsInfo = this.handleIncludeExclude(options.includePattern, options.expandPatterns);
 		const excludeSearchPathsInfo: ISearchPathsInfo = this.handleIncludeExclude(excludePattern, options.expandPatterns);
 
@@ -537,7 +537,7 @@ export class QueryBuilder {
 		const folderUri = URI.isUri(folder) ? folder : folder.uri;
 
 		// only use exclude root if it is different from the folder root
-		const excludeRoot = isISearchPatternBuilder(options.excludePattern) ? options.excludePattern.uri : undefined;
+		const excludeRoot = options.excludePattern && isISearchPatternBuilder(options.excludePattern) ? options.excludePattern.uri : undefined;
 		const shouldUseExcludeRoot = (!excludeRoot || !(URI.isUri(folder) && this.uriIdentityService.extUri.isEqual(folder, excludeRoot)));
 		const excludeFolderRoot = shouldUseExcludeRoot ? excludeRoot : undefined;
 

--- a/src/vs/workbench/services/search/common/searchExtTypes.ts
+++ b/src/vs/workbench/services/search/common/searchExtTypes.ts
@@ -58,7 +58,7 @@ export interface RelativePattern {
 	/**
 	 * A base file path to which this pattern will be matched against relatively.
 	 */
-	base: string;
+	baseUri: URI;
 
 	/**
 	 * A file glob pattern like `*.{ts,js}` that will be matched on file paths

--- a/src/vs/workbench/services/search/common/searchHelpers.ts
+++ b/src/vs/workbench/services/search/common/searchHelpers.ts
@@ -50,8 +50,8 @@ export function getTextSearchMatchWithModelContext(matches: ITextSearchMatch[], 
 	let prevLine = -1;
 	for (let i = 0; i < matches.length; i++) {
 		const { start: matchStartLine, end: matchEndLine } = getMatchStartEnd(matches[i]);
-		if (typeof query.beforeContext === 'number' && query.beforeContext > 0) {
-			const beforeContextStartLine = Math.max(prevLine + 1, matchStartLine - query.beforeContext);
+		if (typeof query.surroundingContext === 'number' && query.surroundingContext > 0) {
+			const beforeContextStartLine = Math.max(prevLine + 1, matchStartLine - query.surroundingContext);
 			for (let b = beforeContextStartLine; b < matchStartLine; b++) {
 				results.push({
 					text: model.getLineContent(b + 1),
@@ -64,8 +64,8 @@ export function getTextSearchMatchWithModelContext(matches: ITextSearchMatch[], 
 
 		const nextMatch = matches[i + 1];
 		const nextMatchStartLine = nextMatch ? getMatchStartEnd(nextMatch).start : Number.MAX_VALUE;
-		if (typeof query.afterContext === 'number' && query.afterContext > 0) {
-			const afterContextToLine = Math.min(nextMatchStartLine - 1, matchEndLine + query.afterContext, model.getLineCount() - 1);
+		if (typeof query.surroundingContext === 'number' && query.surroundingContext > 0) {
+			const afterContextToLine = Math.min(nextMatchStartLine - 1, matchEndLine + query.surroundingContext, model.getLineCount() - 1);
 			for (let a = matchEndLine + 1; a <= afterContextToLine; a++) {
 				results.push({
 					text: model.getLineContent(a + 1),

--- a/src/vs/workbench/services/search/node/fileSearch.ts
+++ b/src/vs/workbench/services/search/node/fileSearch.ts
@@ -82,7 +82,7 @@ export class FileWalker {
 		this.folderExcludePatterns = new Map<string, AbsoluteAndRelativeParsedExpression>();
 
 		config.folderQueries.forEach(folderQuery => {
-			const folderExcludeExpression: glob.IExpression = Object.assign({}, folderQuery.excludePattern || {}, this.config.excludePattern || {});
+			const folderExcludeExpression: glob.IExpression = Object.assign({}, folderQuery.excludePattern?.pattern || {}, this.config.excludePattern || {});
 
 			// Add excludes for other root folders
 			const fqPath = folderQuery.folder.fsPath;

--- a/src/vs/workbench/services/search/node/rawSearchService.ts
+++ b/src/vs/workbench/services/search/node/rawSearchService.ts
@@ -9,6 +9,7 @@ import { CancellationToken } from 'vs/base/common/cancellation';
 import { canceled } from 'vs/base/common/errors';
 import { Emitter, Event } from 'vs/base/common/event';
 import { compareItemsByFuzzyScore, FuzzyScorerCache, IItemAccessor, prepareQuery } from 'vs/base/common/fuzzyScorer';
+import { revive } from 'vs/base/common/marshalling';
 import { basename, dirname, join, sep } from 'vs/base/common/path';
 import { StopWatch } from 'vs/base/common/stopwatch';
 import { URI, UriComponents } from 'vs/base/common/uri';
@@ -443,8 +444,5 @@ function reviveQuery<U extends IRawQuery>(rawQuery: U): U extends IRawTextQuery 
 }
 
 function reviveFolderQuery(rawFolderQuery: IFolderQuery<UriComponents>): IFolderQuery<URI> {
-	return {
-		...rawFolderQuery,
-		folder: URI.revive(rawFolderQuery.folder)
-	};
+	return revive(rawFolderQuery);
 }

--- a/src/vs/workbench/services/search/test/browser/queryBuilder.test.ts
+++ b/src/vs/workbench/services/search/test/browser/queryBuilder.test.ts
@@ -212,9 +212,11 @@ suite('QueryBuilder', () => {
 				folderQueries: [{
 					folder: ROOT_1_URI,
 					excludePattern: {
-						'bar/**': true,
-						'foo/**': {
-							'when': '$(basename).ts'
+						pattern: {
+							'bar/**': true,
+							'foo/**': {
+								'when': '$(basename).ts'
+							}
 						}
 					}
 				}],
@@ -338,9 +340,12 @@ suite('QueryBuilder', () => {
 						'foo/**': true
 					},
 					excludePattern: {
-						'foo/**/*.js': true,
-						'bar/**': {
-							'when': '$(basename).ts'
+						pattern: {
+
+							'foo/**/*.js': true,
+							'bar/**': {
+								'when': '$(basename).ts'
+							}
 						}
 					}
 				}],
@@ -375,8 +380,8 @@ suite('QueryBuilder', () => {
 			{
 				contentPattern: PATTERN_INFO,
 				folderQueries: [
-					{ folder: ROOT_1_URI, excludePattern: patternsToIExpression('foo/**/*.js') },
-					{ folder: ROOT_2_URI, excludePattern: patternsToIExpression('bar') },
+					{ folder: ROOT_1_URI, excludePattern: makeExcludePatternFromPatterns('foo/**/*.js') },
+					{ folder: ROOT_2_URI, excludePattern: makeExcludePatternFromPatterns('bar') },
 					{ folder: ROOT_3_URI }
 				],
 				type: QueryType.Text
@@ -403,7 +408,7 @@ suite('QueryBuilder', () => {
 							'src/**': true
 						},
 						excludePattern: {
-							'bar': true
+							pattern: { 'bar': true }
 						},
 					}
 				],
@@ -460,7 +465,7 @@ suite('QueryBuilder', () => {
 				contentPattern: PATTERN_INFO,
 				folderQueries: [{
 					folder: ROOT_1_URI,
-					excludePattern: patternsToIExpression('bar', 'bar/**'),
+					excludePattern: makeExcludePatternFromPatterns('bar', 'bar/**'),
 				}],
 				type: QueryType.Text
 			});
@@ -478,7 +483,7 @@ suite('QueryBuilder', () => {
 				contentPattern: PATTERN_INFO,
 				folderQueries: [{
 					folder: ROOT_1_URI,
-					excludePattern: patternsToIExpression('bar/**/*.ts', 'bar/**/*.ts/**'),
+					excludePattern: makeExcludePatternFromPatterns('bar/**/*.ts', 'bar/**/*.ts/**'),
 				}],
 				type: QueryType.Text
 			});
@@ -496,7 +501,7 @@ suite('QueryBuilder', () => {
 				contentPattern: PATTERN_INFO,
 				folderQueries: [{
 					folder: ROOT_1_URI,
-					excludePattern: patternsToIExpression('bar/**/*.ts', 'bar/**/*.ts/**'),
+					excludePattern: makeExcludePatternFromPatterns('bar/**/*.ts', 'bar/**/*.ts/**'),
 				}],
 				type: QueryType.Text
 			});
@@ -1079,6 +1084,12 @@ suite('QueryBuilder', () => {
 		});
 	});
 });
+function makeExcludePatternFromPatterns(...patterns: string[]): {
+	pattern: IExpression;
+} | undefined {
+	const pattern = patternsToIExpression('foo/**/*.js');
+	return pattern ? { pattern } : undefined;
+}
 
 function assertEqualTextQueries(actual: ITextQuery, expected: ITextQuery): void {
 	expected = {
@@ -1098,7 +1109,7 @@ export function assertEqualQueries(actual: ITextQuery | IFileQuery, expected: IT
 	const folderQueryToCompareObject = (fq: IFolderQuery) => {
 		return {
 			path: fq.folder.fsPath,
-			excludePattern: normalizeExpression(fq.excludePattern),
+			excludePattern: normalizeExpression(fq.excludePattern?.pattern),
 			includePattern: normalizeExpression(fq.includePattern),
 			fileEncoding: fq.fileEncoding
 		};

--- a/src/vs/workbench/services/search/test/browser/queryBuilder.test.ts
+++ b/src/vs/workbench/services/search/test/browser/queryBuilder.test.ts
@@ -1087,7 +1087,7 @@ suite('QueryBuilder', () => {
 function makeExcludePatternFromPatterns(...patterns: string[]): {
 	pattern: IExpression;
 } | undefined {
-	const pattern = patternsToIExpression('foo/**/*.js');
+	const pattern = patternsToIExpression(...patterns);
 	return pattern ? { pattern } : undefined;
 }
 

--- a/src/vs/workbench/services/search/test/common/searchHelpers.test.ts
+++ b/src/vs/workbench/services/search/test/common/searchHelpers.test.ts
@@ -91,13 +91,12 @@ suite('SearchHelpers', () => {
 			}
 		} as ITextModel;
 
-		function getQuery(beforeContext?: number, afterContext?: number): ITextQuery {
+		function getQuery(surroundingContext?: number): ITextQuery {
 			return {
 				folderQueries: [],
 				type: QueryType.Text,
 				contentPattern: { pattern: 'test' },
-				beforeContext,
-				afterContext
+				surroundingContext,
 			};
 		}
 
@@ -122,7 +121,7 @@ suite('SearchHelpers', () => {
 				ranges: new Range(1, 0, 1, 10)
 			}];
 
-			assert.deepStrictEqual(getTextSearchMatchWithModelContext(matches, mockTextModel, getQuery(1, 2)), [
+			assert.deepStrictEqual(getTextSearchMatchWithModelContext(matches, mockTextModel, getQuery(1)), [
 				{
 					text: '1',
 					lineNumber: 1
@@ -131,10 +130,6 @@ suite('SearchHelpers', () => {
 				{
 					text: '3',
 					lineNumber: 3
-				},
-				{
-					text: '4',
-					lineNumber: 4
 				},
 			] satisfies ITextSearchResult[]);
 		});
@@ -156,7 +151,7 @@ suite('SearchHelpers', () => {
 					ranges: new Range(2, 0, 2, 10)
 				}];
 
-			assert.deepStrictEqual(getTextSearchMatchWithModelContext(matches, mockTextModel, getQuery(1, 2)), [
+			assert.deepStrictEqual(getTextSearchMatchWithModelContext(matches, mockTextModel, getQuery(1)), [
 				<ITextSearchContext>{
 					text: '1',
 					lineNumber: 1
@@ -165,10 +160,6 @@ suite('SearchHelpers', () => {
 				<ITextSearchContext>{
 					text: '4',
 					lineNumber: 4
-				},
-				<ITextSearchContext>{
-					text: '5',
-					lineNumber: 5
 				},
 			]);
 		});
@@ -190,15 +181,11 @@ suite('SearchHelpers', () => {
 					ranges: new Range(MOCK_LINE_COUNT - 1, 0, MOCK_LINE_COUNT - 1, 10)
 				}];
 
-			assert.deepStrictEqual(getTextSearchMatchWithModelContext(matches, mockTextModel, getQuery(1, 2)), [
+			assert.deepStrictEqual(getTextSearchMatchWithModelContext(matches, mockTextModel, getQuery(1)), [
 				matches[0],
 				<ITextSearchContext>{
 					text: '2',
 					lineNumber: 2
-				},
-				<ITextSearchContext>{
-					text: '3',
-					lineNumber: 3
 				},
 				<ITextSearchContext>{
 					text: '' + (MOCK_LINE_COUNT - 1),

--- a/src/vs/workbench/services/search/test/node/search.integrationTest.ts
+++ b/src/vs/workbench/services/search/test/node/search.integrationTest.ts
@@ -500,13 +500,15 @@ flakySuite('FileSearchEngine', () => {
 			{
 				folder: EXAMPLES_FIXTURES,
 				excludePattern: {
-					'**/anotherfile.txt': true
+					pattern: { '**/anotherfile.txt': true }
 				}
 			},
 			{
 				folder: MORE_FIXTURES,
 				excludePattern: {
-					'**/file.txt': true
+					pattern: {
+						'**/file.txt': true
+					}
 				}
 			}
 		];
@@ -755,7 +757,9 @@ flakySuite('FileWalker', () => {
 		const folderQueries: IFolderQuery[] = [
 			{
 				folder: URI.file(TEST_FIXTURES),
-				excludePattern: { '**/subfolder': true }
+				excludePattern: {
+					pattern: { '**/subfolder': true }
+				}
 			}
 		];
 

--- a/src/vs/workbench/services/search/test/node/textSearch.integrationTest.ts
+++ b/src/vs/workbench/services/search/test/node/textSearch.integrationTest.ts
@@ -291,7 +291,11 @@ flakySuite('TextSearch-integration', function () {
 		const config: ITextQuery = {
 			type: QueryType.Text,
 			folderQueries: [
-				{ folder: URI.file(EXAMPLES_FIXTURES), excludePattern: makeExpression('**/e*.js') },
+				{
+					folder: URI.file(EXAMPLES_FIXTURES), excludePattern: {
+						pattern: makeExpression('**/e*.js')
+					}
+				},
 				{ folder: URI.file(MORE_FIXTURES) }
 			],
 			contentPattern: { pattern: 'e' }
@@ -338,8 +342,7 @@ flakySuite('TextSearch-integration', function () {
 			type: QueryType.Text,
 			folderQueries: ROOT_FOLDER_QUERY,
 			contentPattern: { pattern: 'compiler.typeCheck();' },
-			beforeContext: 1,
-			afterContext: 2
+			surroundingContext: 1,
 		};
 
 		return doSearchTest(config, 4).then(results => {
@@ -349,8 +352,6 @@ flakySuite('TextSearch-integration', function () {
 			// assert.strictEqual((<ITextSearchMatch>results[1].results[0]).preview.text, '        compiler.typeCheck();\n'); // See https://github.com/BurntSushi/ripgrep/issues/1095
 			assert.strictEqual((<ITextSearchContext>results[2].results![0]).lineNumber, 26);
 			assert.strictEqual((<ITextSearchContext>results[2].results![0]).text, '        compiler.emit();');
-			assert.strictEqual((<ITextSearchContext>results[3].results![0]).lineNumber, 27);
-			assert.strictEqual((<ITextSearchContext>results[3].results![0]).text, '');
 		});
 	});
 

--- a/src/vs/workbench/services/search/test/node/textSearch.integrationTest.ts
+++ b/src/vs/workbench/services/search/test/node/textSearch.integrationTest.ts
@@ -345,8 +345,8 @@ flakySuite('TextSearch-integration', function () {
 			surroundingContext: 1,
 		};
 
-		return doSearchTest(config, 4).then(results => {
-			assert.strictEqual(results.length, 4);
+		return doSearchTest(config, 3).then(results => {
+			assert.strictEqual(results.length, 3);
 			assert.strictEqual((<ITextSearchContext>results[0].results![0]).lineNumber, 24);
 			assert.strictEqual((<ITextSearchContext>results[0].results![0]).text, '        compiler.addUnit(prog,"input.ts");');
 			// assert.strictEqual((<ITextSearchMatch>results[1].results[0]).preview.text, '        compiler.typeCheck();\n'); // See https://github.com/BurntSushi/ripgrep/issues/1095


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
Adopt new search query structure in preparation for new search API shapes. 

Pt 1 of trying to break down https://github.com/microsoft/vscode/pull/214041 into smaller PRs.

This will cause `beforeContext` to be ignored in the `findTextInFiles` API. This is because we will be using `surroundingContext` in the new API.