### PR TITLE
fix `terminalLinkQuickPick` and `decorationAddon` disposable leaks

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/xterm/decorationAddon.ts
+++ b/src/vs/workbench/contrib/terminal/browser/xterm/decorationAddon.ts
@@ -468,7 +468,7 @@ export class DecorationAddon extends Disposable implements ITerminalAddon {
 	}
 
 	private _showToggleVisibilityQuickPick() {
-		const quickPick = this._quickInputService.createQuickPick();
+		const quickPick = this._register(this._quickInputService.createQuickPick());
 		quickPick.hideInput = true;
 		quickPick.hideCheckAll = true;
 		quickPick.canSelectMany = true;
@@ -493,7 +493,7 @@ export class DecorationAddon extends Disposable implements ITerminalAddon {
 			}
 		}
 		quickPick.selectedItems = selectedItems;
-		quickPick.onDidChangeSelection(async e => {
+		this._register(quickPick.onDidChangeSelection(async e => {
 			let newValue: 'both' | 'gutter' | 'overviewRuler' | 'never' = 'never';
 			if (e.includes(gutterIcon)) {
 				if (e.includes(overviewRulerIcon)) {
@@ -505,7 +505,7 @@ export class DecorationAddon extends Disposable implements ITerminalAddon {
 				newValue = 'overviewRuler';
 			}
 			await this._configurationService.updateValue(TerminalSettingId.ShellIntegrationDecorationsEnabled, newValue);
-		});
+		}));
 		quickPick.ok = false;
 		quickPick.show();
 	}

--- a/src/vs/workbench/contrib/terminalContrib/links/browser/terminalLinkQuickpick.ts
+++ b/src/vs/workbench/contrib/terminalContrib/links/browser/terminalLinkQuickpick.ts
@@ -76,6 +76,8 @@ export class TerminalLinkQuickpick extends DisposableStore {
 
 		// Create and show quick pick
 		const pick = this._quickInputService.createQuickPick<IQuickPickItem | ITerminalLinkQuickPickItem>({ useSeparators: true });
+		const disposables = new DisposableStore();
+		disposables.add(pick);
 		pick.items = picks;
 		pick.placeholder = localize('terminal.integrated.openDetectedLink', "Select the link to open, type to filter all links");
 		pick.sortByLabel = false;
@@ -87,7 +89,6 @@ export class TerminalLinkQuickpick extends DisposableStore {
 		// Show all results only when filtering begins, this is done so the quick pick will show up
 		// ASAP with only the viewport entries.
 		let accepted = false;
-		const disposables = new DisposableStore();
 		if (!usingAllLinks) {
 			disposables.add(Event.once(pick.onDidChangeValue)(async () => {
 				const allLinks = await links.all;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
fixes [#225385](https://github.com/microsoft/vscode/issues/225385)