### PR TITLE
Fix commit character list

### DIFF
--- a/extensions/typescript-language-features/src/languageFeatures/completions.ts
+++ b/extensions/typescript-language-features/src/languageFeatures/completions.ts
@@ -504,9 +504,10 @@ class MyCompletionItem extends vscode.CompletionItem {
 	private static getCommitCharacters(
 		context: CompletionContext,
 		entry: Proto.CompletionEntry,
-		defaultCommitCharacters: readonly string[] | undefined): string[] | undefined {
+		defaultCommitCharacters: readonly string[] | undefined,
+	): string[] | undefined {
 		// @ts-expect-error until TS 5.6
-		let commitCharacters = entry.commitCharacters ?? defaultCommitCharacters;
+		let commitCharacters = (entry.commitCharacters as string[] | undefined) ?? (defaultCommitCharacters ? Array.from(defaultCommitCharacters) : undefined);
 		if (commitCharacters) {
 			if (context.enableCallCompletions
 				&& !context.isNewIdentifierLocation
@@ -781,7 +782,7 @@ class TypeScriptCompletionItemProvider implements vscode.CompletionItemProvider<
 		const entries = response.body.entries;
 		const metadata = response.metadata;
 		// @ts-expect-error until TS 5.6
-		const defaultCommitCharacters = response.body.defaultCommitCharacters;
+		const defaultCommitCharacters: readonly string[] | undefined = Object.freeze(response.body.defaultCommitCharacters);
 
 		if (response.body.optionalReplacementSpan) {
 			optionalReplacementRange = typeConverters.Range.fromTextSpan(response.body.optionalReplacementSpan);


### PR DESCRIPTION
We were modifying the default commit character array, which ended up making it thousands of elements long

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
