### PR TITLE
debug: support location references for variable values

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/exceptionWidget.ts
+++ b/src/vs/workbench/contrib/debug/browser/exceptionWidget.ts
@@ -15,7 +15,7 @@ import { ThemeIcon } from 'vs/base/common/themables';
 import { Color } from 'vs/base/common/color';
 import { registerColor } from 'vs/platform/theme/common/colorRegistry';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
-import { LinkDetector } from 'vs/workbench/contrib/debug/browser/linkDetector';
+import { DebugLinkHoverBehavior, LinkDetector } from 'vs/workbench/contrib/debug/browser/linkDetector';
 import { EditorOption } from 'vs/editor/common/config/editorOptions';
 import { ActionBar } from 'vs/base/browser/ui/actionbar/actionbar';
 import { Action } from 'vs/base/common/actions';
@@ -98,7 +98,7 @@ export class ExceptionWidget extends ZoneWidget {
 		if (this.exceptionInfo.details && this.exceptionInfo.details.stackTrace) {
 			const stackTrace = $('.stack-trace');
 			const linkDetector = this.instantiationService.createInstance(LinkDetector);
-			const linkedStackTrace = linkDetector.linkify(this.exceptionInfo.details.stackTrace, true, this.debugSession ? this.debugSession.root : undefined);
+			const linkedStackTrace = linkDetector.linkify(this.exceptionInfo.details.stackTrace, true, this.debugSession ? this.debugSession.root : undefined, undefined, { type: DebugLinkHoverBehavior.Rich, store: this._disposables });
 			stackTrace.appendChild(linkedStackTrace);
 			dom.append(container, stackTrace);
 			ariaLabel += ', ' + this.exceptionInfo.details.stackTrace;

--- a/src/vs/workbench/contrib/debug/browser/linkDetector.ts
+++ b/src/vs/workbench/contrib/debug/browser/linkDetector.ts
@@ -3,22 +3,26 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { getWindow } from 'vs/base/browser/dom';
+import { StandardKeyboardEvent } from 'vs/base/browser/keyboardEvent';
+import { getDefaultHoverDelegate } from 'vs/base/browser/ui/hover/hoverDelegateFactory';
+import { KeyCode } from 'vs/base/common/keyCodes';
+import { DisposableStore } from 'vs/base/common/lifecycle';
 import { Schemas } from 'vs/base/common/network';
 import * as osPath from 'vs/base/common/path';
 import * as platform from 'vs/base/common/platform';
 import { URI } from 'vs/base/common/uri';
+import { localize } from 'vs/nls';
+import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
 import { IFileService } from 'vs/platform/files/common/files';
+import { IHoverService } from 'vs/platform/hover/browser/hover';
 import { IOpenerService } from 'vs/platform/opener/common/opener';
+import { ITunnelService } from 'vs/platform/tunnel/common/tunnel';
 import { IWorkspaceFolder } from 'vs/platform/workspace/common/workspace';
+import { IDebugSession } from 'vs/workbench/contrib/debug/common/debug';
 import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
 import { IWorkbenchEnvironmentService } from 'vs/workbench/services/environment/common/environmentService';
 import { IPathService } from 'vs/workbench/services/path/common/pathService';
-import { StandardKeyboardEvent } from 'vs/base/browser/keyboardEvent';
-import { KeyCode } from 'vs/base/common/keyCodes';
-import { localize } from 'vs/nls';
-import { ITunnelService } from 'vs/platform/tunnel/common/tunnel';
-import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
-import { getWindow } from 'vs/base/browser/dom';
 
 const CONTROL_CODES = '\\u0000-\\u0020\\u007f-\\u009f';
 const WEB_LINK_REGEX = new RegExp('(?:[a-zA-Z][a-zA-Z0-9+.-]{2,}:\\/\\/|data:|www\\.)[^\\s' + CONTROL_CODES + '"]{2,}[^\\s' + CONTROL_CODES + '"\')}\\],:;.!?]', 'ug');
@@ -40,6 +44,22 @@ type LinkPart = {
 	captures: string[];
 };
 
+export const enum DebugLinkHoverBehavior {
+	/** A nice workbench hover */
+	Rich,
+	/**
+	 * Basic browser hover
+	 * @deprecated Consumers should adopt `rich` by propagating disposables appropriately
+	 */
+	Basic,
+	/** No hover */
+	None
+}
+
+/** Store implies HoverBehavior=rich */
+export type DebugLinkHoverBehaviorTypeData = { type: DebugLinkHoverBehavior.None | DebugLinkHoverBehavior.Basic }
+	| { type: DebugLinkHoverBehavior.Rich; store: DisposableStore };
+
 export class LinkDetector {
 	constructor(
 		@IEditorService private readonly editorService: IEditorService,
@@ -48,7 +68,8 @@ export class LinkDetector {
 		@IPathService private readonly pathService: IPathService,
 		@ITunnelService private readonly tunnelService: ITunnelService,
 		@IWorkbenchEnvironmentService private readonly environmentService: IWorkbenchEnvironmentService,
-		@IConfigurationService private readonly configurationService: IConfigurationService
+		@IConfigurationService private readonly configurationService: IConfigurationService,
+		@IHoverService private readonly hoverService: IHoverService,
 	) {
 		// noop
 	}
@@ -59,8 +80,10 @@ export class LinkDetector {
 	 * 'onclick' event is attached to all anchored links that opens them in the editor.
 	 * When splitLines is true, each line of the text, even if it contains no links, is wrapped in a <span>
 	 * and added as a child of the returned <span>.
+	 * If a `hoverBehavior` is passed, hovers may be added using the workbench hover service.
+	 * This should be preferred for new code where hovers are desirable.
 	 */
-	linkify(text: string, splitLines?: boolean, workspaceFolder?: IWorkspaceFolder, includeFulltext?: boolean): HTMLElement {
+	linkify(text: string, splitLines?: boolean, workspaceFolder?: IWorkspaceFolder, includeFulltext?: boolean, hoverBehavior?: DebugLinkHoverBehaviorTypeData): HTMLElement {
 		if (splitLines) {
 			const lines = text.split('\n');
 			for (let i = 0; i < lines.length - 1; i++) {
@@ -88,13 +111,13 @@ export class LinkDetector {
 						container.appendChild(document.createTextNode(part.value));
 						break;
 					case 'web':
-						container.appendChild(this.createWebLink(includeFulltext ? text : undefined, part.value));
+						container.appendChild(this.createWebLink(includeFulltext ? text : undefined, part.value, hoverBehavior));
 						break;
 					case 'path': {
 						const path = part.captures[0];
 						const lineNumber = part.captures[1] ? Number(part.captures[1]) : 0;
 						const columnNumber = part.captures[2] ? Number(part.captures[2]) : 0;
-						container.appendChild(this.createPathLink(includeFulltext ? text : undefined, part.value, path, lineNumber, columnNumber, workspaceFolder));
+						container.appendChild(this.createPathLink(includeFulltext ? text : undefined, part.value, path, lineNumber, columnNumber, workspaceFolder, hoverBehavior));
 						break;
 					}
 				}
@@ -105,7 +128,32 @@ export class LinkDetector {
 		return container;
 	}
 
-	private createWebLink(fulltext: string | undefined, url: string): Node {
+	/**
+	 * Linkifies a location reference.
+	 */
+	linkifyLocation(text: string, locationReference: number, session: IDebugSession, hoverBehavior?: DebugLinkHoverBehaviorTypeData) {
+		const link = this.createLink(text);
+		this.decorateLink(link, undefined, text, hoverBehavior, async (preserveFocus: boolean) => {
+			const location = await session.resolveLocationReference(locationReference);
+
+			await this.editorService.openEditor({
+				resource: location.source.uri,
+				options: {
+					preserveFocus,
+					selection: {
+						startLineNumber: location.line,
+						startColumn: location.column,
+						endLineNumber: location.endLine,
+						endColumn: location.endColumn,
+					},
+				},
+			});
+		});
+
+		return link;
+	}
+
+	private createWebLink(fulltext: string | undefined, url: string, hoverBehavior?: DebugLinkHoverBehaviorTypeData): Node {
 		const link = this.createLink(url);
 
 		let uri = URI.parse(url);
@@ -119,7 +167,7 @@ export class LinkDetector {
 			});
 		}
 
-		this.decorateLink(link, uri, fulltext, async () => {
+		this.decorateLink(link, uri, fulltext, hoverBehavior, async () => {
 
 			if (uri.scheme === Schemas.file) {
 				// Just using fsPath here is unsafe: https://github.com/microsoft/vscode/issues/109076
@@ -149,7 +197,7 @@ export class LinkDetector {
 		return link;
 	}
 
-	private createPathLink(fulltext: string | undefined, text: string, path: string, lineNumber: number, columnNumber: number, workspaceFolder: IWorkspaceFolder | undefined): Node {
+	private createPathLink(fulltext: string | undefined, text: string, path: string, lineNumber: number, columnNumber: number, workspaceFolder: IWorkspaceFolder | undefined, hoverBehavior?: DebugLinkHoverBehaviorTypeData): Node {
 		if (path[0] === '/' && path[1] === '/') {
 			// Most likely a url part which did not match, for example ftp://path.
 			return document.createTextNode(text);
@@ -162,7 +210,7 @@ export class LinkDetector {
 			}
 			const uri = workspaceFolder.toResource(path);
 			const link = this.createLink(text);
-			this.decorateLink(link, uri, fulltext, (preserveFocus: boolean) => this.editorService.openEditor({ resource: uri, options: { ...options, preserveFocus } }));
+			this.decorateLink(link, uri, fulltext, hoverBehavior, (preserveFocus: boolean) => this.editorService.openEditor({ resource: uri, options: { ...options, preserveFocus } }));
 			return link;
 		}
 
@@ -180,7 +228,7 @@ export class LinkDetector {
 			if (stat.isDirectory) {
 				return;
 			}
-			this.decorateLink(link, uri, fulltext, (preserveFocus: boolean) => this.editorService.openEditor({ resource: uri, options: { ...options, preserveFocus } }));
+			this.decorateLink(link, uri, fulltext, hoverBehavior, (preserveFocus: boolean) => this.editorService.openEditor({ resource: uri, options: { ...options, preserveFocus } }));
 		}).catch(() => {
 			// If the uri can not be resolved we should not spam the console with error, remain quite #86587
 		});
@@ -193,12 +241,19 @@ export class LinkDetector {
 		return link;
 	}
 
-	private decorateLink(link: HTMLElement, uri: URI, fulltext: string | undefined, onClick: (preserveFocus: boolean) => void) {
+	private decorateLink(link: HTMLElement, uri: URI | undefined, fulltext: string | undefined, hoverBehavior: DebugLinkHoverBehaviorTypeData | undefined, onClick: (preserveFocus: boolean) => void) {
 		link.classList.add('link');
-		const followLink = this.tunnelService.canTunnel(uri) ? localize('followForwardedLink', "follow link using forwarded port") : localize('followLink', "follow link");
-		link.title = fulltext
+		const followLink = uri && this.tunnelService.canTunnel(uri) ? localize('followForwardedLink', "follow link using forwarded port") : localize('followLink', "follow link");
+		const title = link.ariaLabel = fulltext
 			? (platform.isMacintosh ? localize('fileLinkWithPathMac', "Cmd + click to {0}\n{1}", followLink, fulltext) : localize('fileLinkWithPath', "Ctrl + click to {0}\n{1}", followLink, fulltext))
 			: (platform.isMacintosh ? localize('fileLinkMac', "Cmd + click to {0}", followLink) : localize('fileLink', "Ctrl + click to {0}", followLink));
+
+		if (hoverBehavior?.type === DebugLinkHoverBehavior.Rich) {
+			hoverBehavior.store.add(this.hoverService.setupManagedHover(getDefaultHoverDelegate('element'), link, title));
+		} else if (hoverBehavior?.type !== DebugLinkHoverBehavior.None) {
+			link.title = title;
+		}
+
 		link.onmousemove = (event) => { link.classList.toggle('pointer', platform.isMacintosh ? event.metaKey : event.ctrlKey); };
 		link.onmouseleave = () => link.classList.remove('pointer');
 		link.onclick = (event) => {

--- a/src/vs/workbench/contrib/debug/browser/rawDebugSession.ts
+++ b/src/vs/workbench/contrib/debug/browser/rawDebugSession.ts
@@ -484,6 +484,10 @@ export class RawDebugSession implements IDisposable {
 		return this.send<DebugProtocol.SourceResponse>('source', args);
 	}
 
+	locations(args: DebugProtocol.LocationsArguments): Promise<DebugProtocol.LocationsResponse | undefined> {
+		return this.send<DebugProtocol.LocationsResponse>('locations', args);
+	}
+
 	loadedSources(args: DebugProtocol.LoadedSourcesArguments): Promise<DebugProtocol.LoadedSourcesResponse | undefined> {
 		if (this.capabilities.supportsLoadedSourcesRequest) {
 			return this.send<DebugProtocol.LoadedSourcesResponse>('loadedSources', args);

--- a/src/vs/workbench/contrib/debug/browser/replViewer.ts
+++ b/src/vs/workbench/contrib/debug/browser/replViewer.ts
@@ -12,7 +12,7 @@ import { CachedListVirtualDelegate } from 'vs/base/browser/ui/list/list';
 import { IListAccessibilityProvider } from 'vs/base/browser/ui/list/listWidget';
 import { IAsyncDataSource, ITreeNode, ITreeRenderer } from 'vs/base/browser/ui/tree/tree';
 import { createMatches, FuzzyScore } from 'vs/base/common/filters';
-import { Disposable, IDisposable } from 'vs/base/common/lifecycle';
+import { Disposable, DisposableStore, IDisposable } from 'vs/base/common/lifecycle';
 import { basename } from 'vs/base/common/path';
 import severity from 'vs/base/common/severity';
 import { ThemeIcon } from 'vs/base/common/themables';
@@ -47,6 +47,7 @@ interface IReplGroupTemplateData {
 
 interface IReplEvaluationResultTemplateData {
 	value: HTMLElement;
+	elementStore: DisposableStore;
 }
 
 interface IOutputReplElementTemplateData {
@@ -65,6 +66,7 @@ interface IRawObjectReplTemplateData {
 	name: HTMLElement;
 	value: HTMLElement;
 	label: HighlightedLabel;
+	elementStore: DisposableStore;
 }
 
 export class ReplEvaluationInputsRenderer implements ITreeRenderer<ReplEvaluationInput, FuzzyScore, IReplEvaluationInputTemplateData> {
@@ -141,19 +143,21 @@ export class ReplEvaluationResultsRenderer implements ITreeRenderer<ReplEvaluati
 		const output = dom.append(container, $('.evaluation-result.expression'));
 		const value = dom.append(output, $('span.value'));
 
-		return { value };
+		return { value, elementStore: new DisposableStore() };
 	}
 
 	renderElement(element: ITreeNode<ReplEvaluationResult | Variable, FuzzyScore>, index: number, templateData: IReplEvaluationResultTemplateData): void {
+		templateData.elementStore.clear();
 		const expression = element.element;
-		renderExpressionValue(expression, templateData.value, {
+		renderExpressionValue(templateData.elementStore, expression, templateData.value, {
 			colorize: true,
-			linkDetector: this.linkDetector
+			hover: false,
+			linkDetector: this.linkDetector,
 		}, this.hoverService);
 	}
 
 	disposeTemplate(templateData: IReplEvaluationResultTemplateData): void {
-		// noop
+		templateData.elementStore.dispose();
 	}
 }
 
@@ -245,7 +249,7 @@ export class ReplVariablesRenderer extends AbstractExpressionsRenderer<IExpressi
 		const isReplVariable = expression instanceof ReplVariableElement;
 		if (isReplVariable || !expression.name) {
 			data.label.set('');
-			renderExpressionValue(isReplVariable ? expression.expression : expression, data.value, { colorize: true, linkDetector: this.linkDetector }, this.hoverService);
+			renderExpressionValue(data.elementDisposable, isReplVariable ? expression.expression : expression, data.value, { colorize: true, linkDetector: this.linkDetector }, this.hoverService);
 			data.expression.classList.remove('nested-variable');
 		} else {
 			renderVariable(data.elementDisposable, this.commandService, this.hoverService, expression as Variable, data, true, highlights, this.linkDetector);
@@ -278,10 +282,12 @@ export class ReplRawObjectsRenderer implements ITreeRenderer<RawObjectReplElemen
 		const label = new HighlightedLabel(name);
 		const value = dom.append(expression, $('span.value'));
 
-		return { container, expression, name, label, value };
+		return { container, expression, name, label, value, elementStore: new DisposableStore() };
 	}
 
 	renderElement(node: ITreeNode<RawObjectReplElement, FuzzyScore>, index: number, templateData: IRawObjectReplTemplateData): void {
+		templateData.elementStore.clear();
+
 		// key
 		const element = node.element;
 		templateData.label.set(element.name ? `${element.name}:` : '', createMatches(node.filterData));
@@ -292,12 +298,14 @@ export class ReplRawObjectsRenderer implements ITreeRenderer<RawObjectReplElemen
 		}
 
 		// value
-		renderExpressionValue(element.value, templateData.value, {
-			linkDetector: this.linkDetector
+		renderExpressionValue(templateData.elementStore, element.value, templateData.value, {
+			linkDetector: this.linkDetector,
+			hover: false,
 		}, this.hoverService);
 	}
 
 	disposeTemplate(templateData: IRawObjectReplTemplateData): void {
+		templateData.elementStore.dispose();
 		templateData.label.dispose();
 	}
 }

--- a/src/vs/workbench/contrib/debug/browser/replViewer.ts
+++ b/src/vs/workbench/contrib/debug/browser/replViewer.ts
@@ -249,7 +249,7 @@ export class ReplVariablesRenderer extends AbstractExpressionsRenderer<IExpressi
 		const isReplVariable = expression instanceof ReplVariableElement;
 		if (isReplVariable || !expression.name) {
 			data.label.set('');
-			renderExpressionValue(data.elementDisposable, isReplVariable ? expression.expression : expression, data.value, { colorize: true, linkDetector: this.linkDetector }, this.hoverService);
+			renderExpressionValue(data.elementDisposable, isReplVariable ? expression.expression : expression, data.value, { colorize: true, linkDetector: this.linkDetector, hover: false }, this.hoverService);
 			data.expression.classList.remove('nested-variable');
 		} else {
 			renderVariable(data.elementDisposable, this.commandService, this.hoverService, expression as Variable, data, true, highlights, this.linkDetector);

--- a/src/vs/workbench/contrib/debug/browser/variablesView.ts
+++ b/src/vs/workbench/contrib/debug/browser/variablesView.ts
@@ -461,10 +461,9 @@ export class VisualizedVariableRenderer extends AbstractExpressionsRenderer {
 			text += ':';
 		}
 		data.label.set(text, highlights, viz.name);
-		renderExpressionValue(viz, data.value, {
+		renderExpressionValue(data.elementDisposable, viz, data.value, {
 			showChanged: false,
 			maxValueLength: 1024,
-			hover: data.elementDisposable,
 			colorize: true,
 			linkDetector: this.linkDetector
 		}, this.hoverService);

--- a/src/vs/workbench/contrib/debug/browser/watchExpressionsView.ts
+++ b/src/vs/workbench/contrib/debug/browser/watchExpressionsView.ts
@@ -87,8 +87,8 @@ export class WatchExpressionsView extends ViewPane {
 		container.classList.add('debug-watch');
 		const treeContainer = renderViewTree(container);
 
-		const expressionsRenderer = this.instantiationService.createInstance(WatchExpressionsRenderer);
 		const linkDetector = this.instantiationService.createInstance(LinkDetector);
+		const expressionsRenderer = this.instantiationService.createInstance(WatchExpressionsRenderer, linkDetector);
 		this.tree = <WorkbenchAsyncDataTree<IDebugService | IExpression, IExpression, FuzzyScore>>this.instantiationService.createInstance(WorkbenchAsyncDataTree, 'WatchExpressions', treeContainer, new WatchExpressionsDelegate(),
 			[
 				expressionsRenderer,
@@ -279,6 +279,7 @@ export class WatchExpressionsRenderer extends AbstractExpressionsRenderer {
 	static readonly ID = 'watchexpression';
 
 	constructor(
+		private readonly linkDetector: LinkDetector,
 		@IMenuService private readonly menuService: IMenuService,
 		@IContextKeyService private readonly contextKeyService: IContextKeyService,
 		@IDebugService debugService: IDebugService,
@@ -329,10 +330,10 @@ export class WatchExpressionsRenderer extends AbstractExpressionsRenderer {
 		}
 
 		data.label.set(text, highlights, title);
-		renderExpressionValue(expression, data.value, {
+		renderExpressionValue(data.elementDisposable, expression, data.value, {
 			showChanged: true,
 			maxValueLength: MAX_VALUE_RENDER_LENGTH_IN_VIEWLET,
-			hover: data.elementDisposable,
+			linkDetector: this.linkDetector,
 			colorize: true
 		}, this.hoverService);
 	}

--- a/src/vs/workbench/contrib/debug/common/debug.ts
+++ b/src/vs/workbench/contrib/debug/common/debug.ts
@@ -352,6 +352,13 @@ export interface IDebugEvaluatePosition {
 	source: DebugProtocol.Source;
 }
 
+export interface IDebugLocationReferenced {
+	line: number;
+	column: number;
+	endLine?: number;
+	endColumn?: number;
+	source: Source;
+}
 
 export interface IDebugSession extends ITreeElement {
 
@@ -432,6 +439,7 @@ export interface IDebugSession extends ITreeElement {
 	sendExceptionBreakpoints(exbpts: IExceptionBreakpoint[]): Promise<void>;
 	breakpointsLocations(uri: uri, lineNumber: number): Promise<IPosition[]>;
 	getDebugProtocolBreakpoint(breakpointId: string): DebugProtocol.Breakpoint | undefined;
+	resolveLocationReference(locationReference: number): Promise<IDebugLocationReferenced>;
 
 	stackTrace(threadId: number, startFrame: number, levels: number, token: CancellationToken): Promise<DebugProtocol.StackTraceResponse | undefined>;
 	exceptionInfo(threadId: number): Promise<IExceptionInfo | undefined>;

--- a/src/vs/workbench/contrib/debug/common/debugModel.ts
+++ b/src/vs/workbench/contrib/debug/common/debugModel.ts
@@ -54,7 +54,8 @@ export class ExpressionContainer implements IExpressionContainer {
 		public indexedVariables: number | undefined = 0,
 		public memoryReference: string | undefined = undefined,
 		private startOfVariables: number | undefined = 0,
-		public presentationHint: DebugProtocol.VariablePresentationHint | undefined = undefined
+		public presentationHint: DebugProtocol.VariablePresentationHint | undefined = undefined,
+		public valueLocationReference: number | undefined = undefined,
 	) { }
 
 	get reference(): number | undefined {
@@ -83,6 +84,7 @@ export class ExpressionContainer implements IExpressionContainer {
 		this.indexedVariables = dummyVar.indexedVariables;
 		this.memoryReference = dummyVar.memoryReference;
 		this.presentationHint = dummyVar.presentationHint;
+		this.valueLocationReference = dummyVar.valueLocationReference;
 		// Also call overridden method to adopt subclass props
 		this.adoptLazyResponse(dummyVar);
 	}
@@ -162,7 +164,7 @@ export class ExpressionContainer implements IExpressionContainer {
 					const count = nameCount.get(v.name) || 0;
 					const idDuplicationIndex = count > 0 ? count.toString() : '';
 					nameCount.set(v.name, count + 1);
-					return new Variable(this.session, this.threadId, this, v.variablesReference, v.name, v.evaluateName, v.value, v.namedVariables, v.indexedVariables, v.memoryReference, v.presentationHint, v.type, v.__vscodeVariableMenuContext, true, 0, idDuplicationIndex);
+					return new Variable(this.session, this.threadId, this, v.variablesReference, v.name, v.evaluateName, v.value, v.namedVariables, v.indexedVariables, v.memoryReference, v.presentationHint, v.type, v.__vscodeVariableMenuContext, true, 0, idDuplicationIndex, v.declarationLocationReference, v.valueLocationReference);
 				}
 				return new Variable(this.session, this.threadId, this, 0, '', undefined, nls.localize('invalidVariableAttributes', "Invalid variable attributes"), 0, 0, undefined, { kind: 'virtual' }, undefined, undefined, false);
 			});
@@ -220,6 +222,7 @@ export class ExpressionContainer implements IExpressionContainer {
 				this.memoryReference = response.body.memoryReference;
 				this.type = response.body.type || this.type;
 				this.presentationHint = response.body.presentationHint;
+				this.valueLocationReference = response.body.valueLocationReference;
 
 				if (!keepLazyVars && response.body.presentationHint?.lazy) {
 					await this.evaluateLazy();
@@ -355,8 +358,10 @@ export class Variable extends ExpressionContainer implements IExpression {
 		public readonly available = true,
 		startOfVariables = 0,
 		idDuplicationIndex = '',
+		public readonly declarationLocationReference: number | undefined = undefined,
+		valueLocationReference: number | undefined = undefined,
 	) {
-		super(session, threadId, reference, `variable:${parent.getId()}:${name}:${idDuplicationIndex}`, namedVariables, indexedVariables, memoryReference, startOfVariables, presentationHint);
+		super(session, threadId, reference, `variable:${parent.getId()}:${name}:${idDuplicationIndex}`, namedVariables, indexedVariables, memoryReference, startOfVariables, presentationHint, valueLocationReference);
 		this.value = value || '';
 		this.type = type;
 	}

--- a/src/vs/workbench/contrib/debug/test/browser/baseDebugView.test.ts
+++ b/src/vs/workbench/contrib/debug/test/browser/baseDebugView.test.ts
@@ -109,37 +109,38 @@ suite('Debug - Base Debug View', () => {
 
 	test('render expression value', () => {
 		let container = $('.container');
-		renderExpressionValue('render \n me', container, {}, NullHoverService);
+		const store = disposables.add(new DisposableStore());
+		renderExpressionValue(store, 'render \n me', container, {}, NullHoverService);
 		assert.strictEqual(container.className, 'value');
 		assert.strictEqual(container.textContent, 'render \n me');
 
 		const expression = new Expression('console');
 		expression.value = 'Object';
 		container = $('.container');
-		renderExpressionValue(expression, container, { colorize: true }, NullHoverService);
+		renderExpressionValue(store, expression, container, { colorize: true }, NullHoverService);
 		assert.strictEqual(container.className, 'value unavailable error');
 
 		expression.available = true;
 		expression.value = '"string value"';
 		container = $('.container');
-		renderExpressionValue(expression, container, { colorize: true, linkDetector }, NullHoverService);
+		renderExpressionValue(store, expression, container, { colorize: true, linkDetector }, NullHoverService);
 		assert.strictEqual(container.className, 'value string');
 		assert.strictEqual(container.textContent, '"string value"');
 
 		expression.type = 'boolean';
 		container = $('.container');
-		renderExpressionValue(expression, container, { colorize: true }, NullHoverService);
+		renderExpressionValue(store, expression, container, { colorize: true }, NullHoverService);
 		assert.strictEqual(container.className, 'value boolean');
 		assert.strictEqual(container.textContent, expression.value);
 
 		expression.value = 'this is a long string';
 		container = $('.container');
-		renderExpressionValue(expression, container, { colorize: true, maxValueLength: 4, linkDetector }, NullHoverService);
+		renderExpressionValue(store, expression, container, { colorize: true, maxValueLength: 4, linkDetector }, NullHoverService);
 		assert.strictEqual(container.textContent, 'this...');
 
 		expression.value = isWindows ? 'C:\\foo.js:5' : '/foo.js:5';
 		container = $('.container');
-		renderExpressionValue(expression, container, { colorize: true, linkDetector }, NullHoverService);
+		renderExpressionValue(store, expression, container, { colorize: true, linkDetector }, NullHoverService);
 		assert.ok(container.querySelector('a'));
 		assert.strictEqual(container.querySelector('a')!.textContent, expression.value);
 	});

--- a/src/vs/workbench/contrib/debug/test/browser/watchExpressionView.test.ts
+++ b/src/vs/workbench/contrib/debug/test/browser/watchExpressionView.test.ts
@@ -97,7 +97,7 @@ suite('Debug - Watch Debug View', () => {
 			}
 		});
 		instantiationService.stub(IConfigurationService, configurationService);
-		watchExpressionsRenderer = instantiationService.createInstance(WatchExpressionsRenderer);
+		watchExpressionsRenderer = instantiationService.createInstance(WatchExpressionsRenderer, null as any);
 		assertWatchVariable(disposables, watchExpressionsRenderer, true);
 	});
 
@@ -108,7 +108,7 @@ suite('Debug - Watch Debug View', () => {
 			}
 		});
 		instantiationService.stub(IConfigurationService, configurationService);
-		watchExpressionsRenderer = instantiationService.createInstance(WatchExpressionsRenderer);
+		watchExpressionsRenderer = instantiationService.createInstance(WatchExpressionsRenderer, null as any);
 		assertWatchVariable(disposables, watchExpressionsRenderer, false);
 	});
 });

--- a/src/vs/workbench/contrib/debug/test/common/mockDebug.ts
+++ b/src/vs/workbench/contrib/debug/test/common/mockDebug.ts
@@ -13,7 +13,7 @@ import { NullLogService } from 'vs/platform/log/common/log';
 import { IStorageService } from 'vs/platform/storage/common/storage';
 import { IWorkspaceFolder } from 'vs/platform/workspace/common/workspace';
 import { AbstractDebugAdapter } from 'vs/workbench/contrib/debug/common/abstractDebugAdapter';
-import { AdapterEndEvent, IAdapterManager, IBreakpoint, IBreakpointData, IBreakpointUpdateData, IConfig, IConfigurationManager, IDataBreakpoint, IDataBreakpointInfoResponse, IDebugModel, IDebugService, IDebugSession, IDebugSessionOptions, IDebugger, IExceptionBreakpoint, IExceptionInfo, IFunctionBreakpoint, IInstructionBreakpoint, ILaunch, IMemoryRegion, INewReplElementData, IRawModelUpdate, IRawStoppedDetails, IReplElement, IStackFrame, IThread, IViewModel, LoadedSourceEvent, State } from 'vs/workbench/contrib/debug/common/debug';
+import { AdapterEndEvent, IAdapterManager, IBreakpoint, IBreakpointData, IBreakpointUpdateData, IConfig, IConfigurationManager, IDataBreakpoint, IDataBreakpointInfoResponse, IDebugLocationReferenced, IDebugModel, IDebugService, IDebugSession, IDebugSessionOptions, IDebugger, IExceptionBreakpoint, IExceptionInfo, IFunctionBreakpoint, IInstructionBreakpoint, ILaunch, IMemoryRegion, INewReplElementData, IRawModelUpdate, IRawStoppedDetails, IReplElement, IStackFrame, IThread, IViewModel, LoadedSourceEvent, State } from 'vs/workbench/contrib/debug/common/debug';
 import { DebugCompoundRoot } from 'vs/workbench/contrib/debug/common/debugCompoundRoot';
 import { IInstructionBreakpointOptions } from 'vs/workbench/contrib/debug/common/debugModel';
 import { Source } from 'vs/workbench/contrib/debug/common/debugSource';
@@ -449,6 +449,9 @@ export class MockSession implements IDebugSession {
 		throw new Error('Method not implemented.');
 	}
 	goto(threadId: number, targetId: number): Promise<DebugProtocol.GotoResponse> {
+		throw new Error('Method not implemented.');
+	}
+	resolveLocationReference(locationReference: number): Promise<IDebugLocationReferenced> {
 		throw new Error('Method not implemented.');
 	}
 }

--- a/src/vs/workbench/contrib/notebook/browser/contrib/notebookVariables/notebookVariablesTree.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/notebookVariables/notebookVariablesTree.ts
@@ -66,10 +66,9 @@ export class NotebookVariableRenderer implements ITreeRenderer<INotebookVariable
 		data.name.textContent = text;
 		data.name.title = element.element.type ?? '';
 
-		renderExpressionValue(element.element, data.value, {
+		renderExpressionValue(data.elementDisposables, element.element, data.value, {
 			colorize: true,
-			hover: data.elementDisposables,
-			maxValueLength: MAX_VALUE_RENDER_LENGTH_IN_VIEWLET
+			maxValueLength: MAX_VALUE_RENDER_LENGTH_IN_VIEWLET,
 		}, this._hoverService);
 	}
 


### PR DESCRIPTION
Adopts https://github.com/microsoft/debug-adapter-protocol/issues/343

Also tackles some debt around debug linkification, resolving an issue
where links had native hovers that conflicted with the rich hovers added
a few iterations ago. It still uses native hovers for links in some
contexts (plain text output in the debug console) because we don't pass
through element disposables there, but it uses workbench hovers when
there's not another rich hover being used (rich debug console output).

![](https://memes.peet.io/img/24-08-8aacba27-0903-4313-b7f6-6b3bbbff6970.png)

Closes #225425

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
