### PR TITLE
additions to suggest telemetry

### DIFF
--- a/src/vs/editor/contrib/suggest/browser/suggestController.ts
+++ b/src/vs/editor/contrib/suggest/browser/suggestController.ts
@@ -548,7 +548,6 @@ export class SuggestController implements IEditorContribution {
 			resolveDuration: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'How long resolving took to finish' };
 			commandDuration: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'How long a completion item command took' };
 			additionalEditsAsync: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'Info about asynchronously applying additional edits' };
-
 		};
 
 		this._telemetryService.publicLog2<AcceptedSuggestion, AcceptedSuggestionClassification>('suggest.acceptedSuggestion', {
@@ -582,16 +581,8 @@ export class SuggestController implements IEditorContribution {
 
 		const hasDuplicates = hasOtherInstances(completionItems, selectedLabel, index);
 
-		let firstIndex = -1;
-
 		// If duplicate, find first duplicate in the list
-		if (hasDuplicates) {
-			for (const completion of completionItems) {
-				if (completion.textLabel === selectedLabel && firstIndex === -1) {
-					firstIndex = completionItems.indexOf(completion);
-				}
-			}
-		}
+		const firstIndex = hasDuplicates ? completionItems.findIndex((completion) => completion.textLabel === selectedLabel) : -1;
 
 		// Log telemetry only when duplicate found and index is not -1
 		if (firstIndex !== -1) {

--- a/src/vs/editor/contrib/suggest/browser/suggestController.ts
+++ b/src/vs/editor/contrib/suggest/browser/suggestController.ts
@@ -533,7 +533,7 @@ export class SuggestController implements IEditorContribution {
 				labelMap.set(label, [i]);
 			}
 		}
-		// Check if there are any duplicates for the selectedLabel
+
 		const firstIndexArray = labelMap.get(item.textLabel);
 		const hasDuplicates = firstIndexArray && firstIndexArray.length > 1;
 		const firstIndex = hasDuplicates ? firstIndexArray[0] : -1;

--- a/src/vs/editor/contrib/suggest/browser/suggestController.ts
+++ b/src/vs/editor/contrib/suggest/browser/suggestController.ts
@@ -257,7 +257,6 @@ export class SuggestController implements IEditorContribution {
 			if (index === -1) {
 				index = 0;
 			}
-
 			if (this.model.state === State.Idle) {
 				// selecting an item can "pump" out selection/cursor change events
 				// which can cancel suggest halfway through this function. therefore


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

ref https://github.com/microsoft/vscode/pull/225001

- we don't really care about the label anymore + it might be PII so we are removing
- we care more when there are multiple suggestions that have the same label - which one do users click? the first? second? third?
- this adds a separate telemetry event which captures the `index` of the selected suggestion, as well as the `firstIndex` which is the first instance that chosen label shows up. the `kind` may also be interesting to see (although we know the sort order prioritizes local first, etc, we can maybe see in the telemetry in cases the first one is not selected, what type _is_ selected)
- We only send this event when there are multiple suggestions with the same label as the selected one. 


example:
<img width="481" alt="Screenshot 2024-08-13 at 11 24 51 PM" src="https://github.com/user-attachments/assets/0b1918e6-03cb-4bbf-bbfc-cfa73ae53bb4">
here if we select that Item, we log the first index as 2, but the chosen index as 3

TLDR: we want to see that when there are multiple labels that are the same, are people choosing the first one in the sorted list of completions