### PR TITLE
Provide project/file name in TypeScript loading indicator

### DIFF
--- a/extensions/typescript-language-features/src/typescriptServiceClient.ts
+++ b/extensions/typescript-language-features/src/typescriptServiceClient.ts
@@ -1344,17 +1344,7 @@ class ServerInitializingIndicator extends Disposable {
 		// the incoming project loading task is.
 		this.reset();
 
-		// `projectName` is typically an absolute file path to the tsconfig.json file.
-		// We'll try to find the first path suited to form a more suitable
-		// display name for the progress indicator.
-		let projectDisplayName = projectName;
-		for (const folder of vscode.workspace.workspaceFolders ?? empty) {
-			if (projectName.startsWith(folder.uri.fsPath)) {
-				projectDisplayName = path.relative(folder.uri.fsPath, projectName);
-				break;
-			}
-		}
-
+		const projectDisplayName = vscode.workspace.asRelativePath(projectName);
 		vscode.window.withProgress({
 			location: vscode.ProgressLocation.Window,
 			title: vscode.l10n.t("Initializing project '{0}'", projectDisplayName),

--- a/extensions/typescript-language-features/src/typescriptServiceClient.ts
+++ b/extensions/typescript-language-features/src/typescriptServiceClient.ts
@@ -30,7 +30,6 @@ import { TypeScriptVersionManager } from './tsServer/versionManager';
 import { ITypeScriptVersionProvider, TypeScriptVersion } from './tsServer/versionProvider';
 import { ClientCapabilities, ClientCapability, ExecConfig, ITypeScriptServiceClient, ServerResponse, TypeScriptRequests } from './typescriptService';
 import { Disposable, DisposableStore, disposeAll } from './utils/dispose';
-import { empty } from './utils/arrays';
 import { hash } from './utils/hash';
 import { isWeb, isWebAndHasSharedArrayBuffers } from './utils/platform';
 

--- a/extensions/typescript-language-features/src/typescriptServiceClient.ts
+++ b/extensions/typescript-language-features/src/typescriptServiceClient.ts
@@ -30,6 +30,7 @@ import { TypeScriptVersionManager } from './tsServer/versionManager';
 import { ITypeScriptVersionProvider, TypeScriptVersion } from './tsServer/versionProvider';
 import { ClientCapabilities, ClientCapability, ExecConfig, ITypeScriptServiceClient, ServerResponse, TypeScriptRequests } from './typescriptService';
 import { Disposable, DisposableStore, disposeAll } from './utils/dispose';
+import { empty } from './utils/arrays';
 import { hash } from './utils/hash';
 import { isWeb, isWebAndHasSharedArrayBuffers } from './utils/platform';
 
@@ -902,9 +903,14 @@ export default class TypeScriptServiceClient extends Disposable implements IType
 
 		if (command === 'updateOpen') {
 			// If update open has completed, consider that the project has loaded
-			Promise.all(executions).then(() => {
+			const updateOpenTask = Promise.all(executions).then(() => {
 				this.loadingIndicator.reset();
 			});
+
+			const updateOpenArgs = (args as Proto.UpdateOpenRequestArgs);
+			if (updateOpenArgs.openFiles?.length === 1) {
+				this.loadingIndicator.startedLoadingFile(updateOpenArgs.openFiles[0].file, updateOpenTask);
+			}
 		}
 
 		return executions[0]!;
@@ -1321,7 +1327,7 @@ function getDiagnosticsKind(event: Proto.Event) {
 
 class ServerInitializingIndicator extends Disposable {
 
-	private _task?: { project: string | undefined; resolve: () => void };
+	private _task?: { project: string; resolve: () => void };
 
 	public reset(): void {
 		if (this._task) {
@@ -1333,20 +1339,40 @@ class ServerInitializingIndicator extends Disposable {
 	/**
 	 * Signal that a project has started loading.
 	 */
-	public startedLoadingProject(projectName: string | undefined): void {
+	public startedLoadingProject(projectName: string): void {
 		// TS projects are loaded sequentially. Cancel existing task because it should always be resolved before
 		// the incoming project loading task is.
 		this.reset();
 
+		// `projectName` is typically an absolute file path to the tsconfig.json file.
+		// We'll try to find the first path suited to form a more suitable
+		// display name for the progress indicator.
+		let projectDisplayName = projectName;
+		for (const folder of vscode.workspace.workspaceFolders ?? empty) {
+			if (projectName.startsWith(folder.uri.fsPath)) {
+				projectDisplayName = path.relative(folder.uri.fsPath, projectName);
+				break;
+			}
+		}
+
 		vscode.window.withProgress({
 			location: vscode.ProgressLocation.Window,
-			title: vscode.l10n.t("Initializing JS/TS language features"),
+			title: vscode.l10n.t("Initializing project '{0}'", projectDisplayName),
 		}, () => new Promise<void>(resolve => {
 			this._task = { project: projectName, resolve };
 		}));
 	}
 
-	public finishedLoadingProject(projectName: string | undefined): void {
+	public startedLoadingFile(fileName: string, task: Promise<unknown>): void {
+		if (!this._task) {
+			vscode.window.withProgress({
+				location: vscode.ProgressLocation.Window,
+				title: vscode.l10n.t("Analyzing '{0}' and its dependencies", path.basename(fileName)),
+			}, () => task);
+		}
+	}
+
+	public finishedLoadingProject(projectName: string): void {
 		if (this._task && this._task.project === projectName) {
 			this._task.resolve();
 			this._task = undefined;


### PR DESCRIPTION
# Existing Behavior

Today, when the TypeScript extension receives a `projectLoadingStart` event, VS Code displays the text 

> Initializing JS/TS language features

in the status bar as a progress indicator.

This is helpful, but it has some limitations:

1. It doesn't specify *which* project we're waiting on.
2. The progress indicator doesn't show up until a project starts loading, meaning files belonging to an inferred project won't trigger any indicator.

# New Behavior

With this change, the TypeScript extension will do a few new things:

1. When a project starts loading, the indicator will instead say

   > Initializing project '...'
1. When a single file is opened, the indicator will now say

   > Analyzing '...' and its dependencies

The current PR hasn't done this, but when multiple files are opened, we can probably say

> Analyzing opened JS/TS files