### PR TITLE
stop AutoInstallerFs from thrashing forevermore and fix typings installer

### DIFF
--- a/extensions/typescript-language-features/web/src/fileWatcherManager.ts
+++ b/extensions/typescript-language-features/web/src/fileWatcherManager.ts
@@ -53,9 +53,9 @@ export class FileWatcherManager {
 		this.watchFiles.set(path, { callback, pollingInterval, options });
 		const watchIds = [++this.watchId];
 		this.watchPort.postMessage({ type: 'watchFile', uri: uri, id: watchIds[0] });
-		if (this.enabledExperimentalTypeAcquisition && looksLikeNodeModules(path)) {
+		if (this.enabledExperimentalTypeAcquisition && looksLikeNodeModules(path) && uri.scheme !== 'vscode-global-typings') {
 			watchIds.push(++this.watchId);
-			this.watchPort.postMessage({ type: 'watchFile', uri: mapUri(uri, 'vscode-node-modules'), id: watchIds[1] });
+			this.watchPort.postMessage({ type: 'watchFile', uri: mapUri(uri, 'vscode-global-typings'), id: watchIds[1] });
 		}
 		return {
 			close: () => {

--- a/extensions/typescript-language-features/web/src/typingsInstaller/typingsInstaller.ts
+++ b/extensions/typescript-language-features/web/src/typingsInstaller/typingsInstaller.ts
@@ -70,10 +70,12 @@ export class WebTypingsInstallerClient implements ts.server.ITypingsInstaller {
 				break;
 			case 'event::beginInstallTypes':
 			case 'event::endInstallTypes':
+			// TODO(@zkat): maybe do something with this?
+			case 'action::watchTypingLocations':
 				// Don't care.
 				break;
 			default:
-				throw new Error(`unexpected response: ${response}`);
+				throw new Error(`unexpected response: ${JSON.stringify(response)}`);
 		}
 	}
 


### PR DESCRIPTION
This gets the AutoInstallerFs and ATA working. Previously, it was thrashing like whoa, but now only a single package management operation is done at a time, and the thundering herd just waits for that one shared operation to complete, instead of queueing new ones.

The only thing I can't seem to get this to do is to re-install and refresh types/definitions when package.json changes or when a new dependency is imported. Not sure what's up with that, but I think that problem can be solved separately.

/cc @mattbierner 