### PR TITLE
Fixing hover is more sticky than before

### DIFF
--- a/src/vs/editor/contrib/hover/browser/contentHoverController2.ts
+++ b/src/vs/editor/contrib/hover/browser/contentHoverController2.ts
@@ -92,7 +92,7 @@ export class ContentHoverController extends Disposable implements IEditorContrib
 		this._hoverSettings = {
 			enabled: hoverOpts.enabled,
 			sticky: hoverOpts.sticky,
-			hidingDelay: hoverOpts.delay
+			hidingDelay: hoverOpts.hidingDelay
 		};
 
 		if (hoverOpts.enabled) {

--- a/src/vs/editor/contrib/hover/browser/marginHoverController.ts
+++ b/src/vs/editor/contrib/hover/browser/marginHoverController.ts
@@ -77,7 +77,7 @@ export class MarginHoverController extends Disposable implements IEditorContribu
 		this._hoverSettings = {
 			enabled: hoverOpts.enabled,
 			sticky: hoverOpts.sticky,
-			hidingDelay: hoverOpts.delay
+			hidingDelay: hoverOpts.hidingDelay
 		};
 
 		if (hoverOpts.enabled) {


### PR DESCRIPTION
Fixing hover is more sticky than before

fixes https://github.com/microsoft/vscode/issues/221607

The issue was happenning because the hiding delay was initialized to the showing delay. 

fix found by [MohenjoDaro](https://github.com/MohenjoDaro)