### PR TITLE
chore: include d3dcompiler_47.dll in scan folder

### DIFF
--- a/build/gulpfile.scan.js
+++ b/build/gulpfile.scan.js
@@ -26,6 +26,9 @@ const BUILD_TARGETS = [
 	{ platform: 'linux', arch: 'arm64' },
 ];
 
+// The following files do not have PDBs downloaded for them during the download symbols process.
+const excludedCheckList = ['d3dcompiler_47.dll'];
+
 BUILD_TARGETS.forEach(buildTarget => {
 	const dashed = (/** @type {string | null} */ str) => (str ? `-${str}` : ``);
 	const platform = buildTarget.platform;
@@ -46,7 +49,6 @@ BUILD_TARGETS.forEach(buildTarget => {
 	if (platform === 'win32') {
 		tasks.push(
 			() => electron.dest(destinationPdb, { ...config, platform, arch: arch === 'armhf' ? 'arm' : arch, pdbs: true }),
-			// util.rimraf(path.join(destinationExe, 'd3dcompiler_47.dll')),
 			() => confirmPdbsExist(destinationExe, destinationPdb)
 		);
 	}
@@ -110,10 +112,13 @@ function nodeModules(destinationExe, destinationPdb, platform) {
 
 function confirmPdbsExist(destinationExe, destinationPdb) {
 	readdirSync(destinationExe).forEach(file => {
+		if (excludedCheckList.includes(file)) {
+			return;
+		}
+
 		if (file.endsWith('.dll') || file.endsWith('.exe')) {
 			const pdb = `${file}.pdb`;
-			// Known that d3dcompiler_47.dll does not have a pdb
-			if (!existsSync(path.join(destinationPdb, pdb)) && file !== 'd3dcompiler_47.dll') {
+			if (!existsSync(path.join(destinationPdb, pdb))) {
 				throw new Error(`Missing pdb file for ${file}. Tried searching for ${pdb} in ${destinationPdb}.`);
 			}
 		}

--- a/build/gulpfile.scan.js
+++ b/build/gulpfile.scan.js
@@ -46,7 +46,7 @@ BUILD_TARGETS.forEach(buildTarget => {
 	if (platform === 'win32') {
 		tasks.push(
 			() => electron.dest(destinationPdb, { ...config, platform, arch: arch === 'armhf' ? 'arm' : arch, pdbs: true }),
-			util.rimraf(path.join(destinationExe, 'd3dcompiler_47.dll')),
+			// util.rimraf(path.join(destinationExe, 'd3dcompiler_47.dll')),
 			() => confirmPdbsExist(destinationExe, destinationPdb)
 		);
 	}

--- a/build/gulpfile.scan.js
+++ b/build/gulpfile.scan.js
@@ -112,7 +112,8 @@ function confirmPdbsExist(destinationExe, destinationPdb) {
 	readdirSync(destinationExe).forEach(file => {
 		if (file.endsWith('.dll') || file.endsWith('.exe')) {
 			const pdb = `${file}.pdb`;
-			if (!existsSync(path.join(destinationPdb, pdb))) {
+			// Known that d3dcompiler_47.dll does not have a pdb
+			if (!existsSync(path.join(destinationPdb, pdb)) && file !== 'd3dcompiler_47.dll') {
 				throw new Error(`Missing pdb file for ${file}. Tried searching for ${pdb} in ${destinationPdb}.`);
 			}
 		}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
Includes the DLL for APIScan and BinSkim.
APIScan is able to scan the file and reports no errors.
BinSkim is not able to scan the file, but it is also unable to scan the other Electron DLLs. Luckily, BinSkim does not error out with this change.

Confirmation build: https://dev.azure.com/monacotools/Monaco/_build/results?buildId=288223&view=results
