### PR TITLE
Round off notification focus outlines

### DIFF
--- a/src/vs/workbench/browser/parts/notifications/media/notificationsCenter.css
+++ b/src/vs/workbench/browser/parts/notifications/media/notificationsCenter.css
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-.monaco-workbench > .notifications-center {
+ .monaco-workbench > .notifications-center {
 	position: absolute;
 	z-index: 1000;
 	right: 8px;
@@ -44,14 +44,12 @@
 	justify-content: flex-end;
 }
 
-.monaco-workbench > .notifications-center .notifications-list-container .monaco-list-row[data-last-element="false"] > .notification-list-item {
+.monaco-workbench > .notifications-center .notifications-list-container .monaco-list-row:not(:last-child) > .notification-list-item {
 	border-bottom: 1px solid var(--vscode-notifications-border);
 }
 
-.monaco-workbench > .notifications-center .notifications-list-container,
-.monaco-workbench > .notifications-center .notifications-list-container .monaco-scrollable-element,
-.monaco-workbench > .notifications-center .notifications-list-container .notification-list-item {
-	border-radius: 0;
+.monaco-workbench > .notifications-center .notifications-list-container .monaco-list-row:last-child {
+	border-radius: 0px 0px 4px 4px; /* adopt the border radius at the end of the notifications center */
 }
 
 /* Icons */

--- a/src/vs/workbench/browser/parts/notifications/media/notificationsCenter.css
+++ b/src/vs/workbench/browser/parts/notifications/media/notificationsCenter.css
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
- .monaco-workbench > .notifications-center {
+.monaco-workbench > .notifications-center {
 	position: absolute;
 	z-index: 1000;
 	right: 8px;

--- a/src/vs/workbench/browser/parts/notifications/media/notificationsList.css
+++ b/src/vs/workbench/browser/parts/notifications/media/notificationsList.css
@@ -9,7 +9,6 @@
 	color: var(--vscode-notifications-foreground);
 	background: var(--vscode-notifications-background);
 	outline-color: var(--vscode-contrastBorder);
-	border-radius: inherit;
 }
 
 .monaco-workbench .notifications-list-container .notification-list-item {
@@ -19,7 +18,6 @@
 	padding: 10px 5px;
 	height: 100%;
 	box-sizing: border-box;
-	border-radius: 4px;
 }
 
 .monaco-workbench .notifications-list-container .notification-offset-helper {
@@ -27,20 +25,6 @@
 	position: absolute;
 	line-height: 22px;
 	word-wrap: break-word; /* never overflow long words, but break to next line */
-}
-
-.monaco-workbench .notifications-list-container .monaco-scrollable-element {
-	border-radius: 4px;
-}
-
-/** Notification: List Row */
-
-.monaco-workbench .notifications-toasts.visible .notifications-list-container .monaco-list-row.focused {
-	border-radius: 4px;
-}
-
-.monaco-workbench .notifications-center.visible .notifications-list-container .monaco-list-row.focused:last-child {
-	border-radius: 0px 0px 4px 4px;
 }
 
 /** Notification: Main Row */

--- a/src/vs/workbench/browser/parts/notifications/media/notificationsList.css
+++ b/src/vs/workbench/browser/parts/notifications/media/notificationsList.css
@@ -33,6 +33,16 @@
 	border-radius: 4px;
 }
 
+/** Notification: List Row */
+
+.monaco-workbench .notifications-toasts.visible .notifications-list-container .monaco-list-row.focused {
+	border-radius: 4px;
+}
+
+.monaco-workbench .notifications-center.visible .notifications-list-container .monaco-list-row.focused:last-child {
+	border-radius: 0px 0px 4px 4px;
+}
+
 /** Notification: Main Row */
 
 .monaco-workbench .notifications-list-container .notification-list-item > .notification-list-item-main-row {

--- a/src/vs/workbench/browser/parts/notifications/media/notificationsToasts.css
+++ b/src/vs/workbench/browser/parts/notifications/media/notificationsToasts.css
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-.monaco-workbench > .notifications-toasts {
+ .monaco-workbench > .notifications-toasts {
 	position: absolute;
 	z-index: 1000;
 	right: 3px;
@@ -30,6 +30,13 @@
 	transform: translate3d(0px, 100%, 0px); /* move the notification 50px to the bottom (to prevent bleed through) */
 	opacity: 0; /*  fade the toast in */
 	transition:	transform 300ms ease-out, opacity 300ms ease-out;
+}
+
+.monaco-workbench > .notifications-toasts .notifications-list-container,
+.monaco-workbench > .notifications-toasts .notification-toast-container > .notification-toast,
+.monaco-workbench > .notifications-toasts .notification-toast-container > .notification-toast .monaco-scrollable-element,
+.monaco-workbench > .notifications-toasts .notification-toast-container > .notification-toast .monaco-list:not(.element-focused):focus:before,
+.monaco-workbench > .notifications-toasts .notification-toast-container > .notification-toast .monaco-list-row {
 	border-radius: 4px;
 }
 

--- a/src/vs/workbench/browser/parts/notifications/media/notificationsToasts.css
+++ b/src/vs/workbench/browser/parts/notifications/media/notificationsToasts.css
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
- .monaco-workbench > .notifications-toasts {
+.monaco-workbench > .notifications-toasts {
 	position: absolute;
 	z-index: 1000;
 	right: 3px;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fixes https://github.com/microsoft/vscode/issues/225750

| Before | After |
| -- | -- |
|  <img width="463" alt="toast-focus-before" src="https://github.com/user-attachments/assets/9f710ffb-f75c-48cf-aecd-087f9281d1a6">|  <img width="462" alt="toast-focus" src="https://github.com/user-attachments/assets/7ece60e5-9098-43ef-9528-ce5890b0085d">|
|  <img width="464" alt="notifications-focus-before" src="https://github.com/user-attachments/assets/e0aa185e-36b1-4b3b-b9b1-cd5c928d5c7d">|  <img width="466" alt="notifications-focus" src="https://github.com/user-attachments/assets/bd0a32d4-7197-4d53-9143-4ff90e7e6e25">|

When a notification is focused (either on its own in a toast, or in the notification list), the outline box around it can get cut off at the edges.

This PR rounds off all corners in the case of a toast - or just the bottom for the last item in the notification list - so the outline should be fully visible.