### PR TITLE
Improve refresh and scope handling

### DIFF
--- a/extensions/microsoft-authentication/src/common/scopeData.ts
+++ b/extensions/microsoft-authentication/src/common/scopeData.ts
@@ -1,0 +1,78 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+const DEFAULT_CLIENT_ID = 'aebc6443-996d-45c2-90f0-388ff96faa56';
+const DEFAULT_TENANT = 'organizations';
+
+export class ScopeData {
+
+	/**
+	 * The full list of scopes including:
+	 * * the original scopes passed to the constructor
+	 * * internal VS Code scopes (e.g. `VSCODE_CLIENT_ID:...`)
+	 * * the default scopes (`openid`, `email`, `profile`, `offline_access`)
+	 */
+	readonly allScopes: string[];
+
+	/**
+	 * The full list of scopes as a space-separated string. For logging.
+	 */
+	readonly scopeStr: string;
+
+	/**
+	 * The list of scopes to send to the token endpoint. This is the same as `scopes` but without the internal VS Code scopes.
+	 */
+	readonly scopesToSend: string[];
+
+	/**
+	 * The client ID to use for the token request. This is the value of the `VSCODE_CLIENT_ID:...` scope if present, otherwise the default client ID.
+	 */
+	readonly clientId: string;
+
+	/**
+	 * The tenant ID to use for the token request. This is the value of the `VSCODE_TENANT:...` scope if present, otherwise the default tenant ID.
+	 */
+	readonly tenant: string;
+
+	constructor(readonly originalScopes: readonly string[] = []) {
+		const modifiedScopes = [...originalScopes];
+		if (!modifiedScopes.includes('openid')) {
+			modifiedScopes.push('openid');
+		}
+		if (!modifiedScopes.includes('email')) {
+			modifiedScopes.push('email');
+		}
+		if (!modifiedScopes.includes('profile')) {
+			modifiedScopes.push('profile');
+		}
+		if (!modifiedScopes.includes('offline_access')) {
+			modifiedScopes.push('offline_access');
+		}
+		modifiedScopes.sort();
+		this.allScopes = modifiedScopes;
+		this.scopeStr = modifiedScopes.join(' ');
+		this.scopesToSend = this.originalScopes.filter(s => !s.startsWith('VSCODE_'));
+		this.clientId = this.getClientId(this.allScopes);
+		this.tenant = this.getTenantId(this.allScopes);
+	}
+
+	private getClientId(scopes: string[]) {
+		return scopes.reduce<string | undefined>((prev, current) => {
+			if (current.startsWith('VSCODE_CLIENT_ID:')) {
+				return current.split('VSCODE_CLIENT_ID:')[1];
+			}
+			return prev;
+		}, undefined) ?? DEFAULT_CLIENT_ID;
+	}
+
+	private getTenantId(scopes: string[]) {
+		return scopes.reduce<string | undefined>((prev, current) => {
+			if (current.startsWith('VSCODE_TENANT:')) {
+				return current.split('VSCODE_TENANT:')[1];
+			}
+			return prev;
+		}, undefined) ?? DEFAULT_TENANT;
+	}
+}

--- a/extensions/microsoft-authentication/src/common/test/scopeData.test.ts
+++ b/extensions/microsoft-authentication/src/common/test/scopeData.test.ts
@@ -1,0 +1,54 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { ScopeData } from '../scopeData';
+
+suite('ScopeData', () => {
+	test('should include default scopes if not present', () => {
+		const scopeData = new ScopeData(['custom_scope']);
+		assert.deepStrictEqual(scopeData.allScopes, ['custom_scope', 'email', 'offline_access', 'openid', 'profile']);
+	});
+
+	test('should not duplicate default scopes if already present', () => {
+		const scopeData = new ScopeData(['openid', 'email', 'profile', 'offline_access']);
+		assert.deepStrictEqual(scopeData.allScopes, ['email', 'offline_access', 'openid', 'profile']);
+	});
+
+	test('should sort the scopes alphabetically', () => {
+		const scopeData = new ScopeData(['profile', 'email', 'openid', 'offline_access']);
+		assert.deepStrictEqual(scopeData.allScopes, ['email', 'offline_access', 'openid', 'profile']);
+	});
+
+	test('should create a space-separated string of all scopes', () => {
+		const scopeData = new ScopeData(['custom_scope']);
+		assert.strictEqual(scopeData.scopeStr, 'custom_scope email offline_access openid profile');
+	});
+
+	test('should filter out internal VS Code scopes for scopesToSend', () => {
+		const scopeData = new ScopeData(['custom_scope', 'VSCODE_CLIENT_ID:some_id']);
+		assert.deepStrictEqual(scopeData.scopesToSend, ['custom_scope']);
+	});
+
+	test('should use the default client ID if no VSCODE_CLIENT_ID scope is present', () => {
+		const scopeData = new ScopeData(['custom_scope']);
+		assert.strictEqual(scopeData.clientId, 'aebc6443-996d-45c2-90f0-388ff96faa56');
+	});
+
+	test('should use the VSCODE_CLIENT_ID scope if present', () => {
+		const scopeData = new ScopeData(['custom_scope', 'VSCODE_CLIENT_ID:some_id']);
+		assert.strictEqual(scopeData.clientId, 'some_id');
+	});
+
+	test('should use the default tenant ID if no VSCODE_TENANT scope is present', () => {
+		const scopeData = new ScopeData(['custom_scope']);
+		assert.strictEqual(scopeData.tenant, 'organizations');
+	});
+
+	test('should use the VSCODE_TENANT scope if present', () => {
+		const scopeData = new ScopeData(['custom_scope', 'VSCODE_TENANT:some_tenant']);
+		assert.strictEqual(scopeData.tenant, 'some_tenant');
+	});
+});


### PR DESCRIPTION
* Moves the `setupRefresh` stuff into the CachedPublicClientApp simplifying things a bit
* Uses a ScopeData class to handle all scope operations fixing an issue where we were passing in the wrong array into the `acquireTokenInteractive`

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
ref https://github.com/microsoft/vscode/issues/229415