### PR TITLE
add a command to focus last terminal tab (#225831)

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminalCommands.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalCommands.ts
@@ -26,4 +26,16 @@ function registerOpenTerminalAtIndexCommands(): void {
 			}
 		});
 	}
+
+	KeybindingsRegistry.registerCommandAndKeybindingRule({
+		id: 'workbench.action.terminal.focusLast',
+		weight: KeybindingWeight.WorkbenchContrib,
+		when: undefined,
+		primary: 0,
+		handler: accessor => {
+			const terminalIndex = accessor.get(ITerminalGroupService).instances.length - 1;
+			accessor.get(ITerminalGroupService).setActiveInstanceByIndex(terminalIndex);
+			return accessor.get(ITerminalGroupService).showPanel(true);
+		}
+	});
 }

--- a/src/vs/workbench/contrib/terminal/common/terminal.ts
+++ b/src/vs/workbench/contrib/terminal/common/terminal.ts
@@ -565,6 +565,7 @@ export const DEFAULT_COMMANDS_TO_SKIP_SHELL: string[] = [
 	'workbench.action.terminal.focusAtIndex7',
 	'workbench.action.terminal.focusAtIndex8',
 	'workbench.action.terminal.focusAtIndex9',
+	'workbench.action.terminal.focusLast',
 	'workbench.action.focusSecondEditorGroup',
 	'workbench.action.focusThirdEditorGroup',
 	'workbench.action.focusFourthEditorGroup',


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
Fixes #225831.

This PR intends to add a new command `workbench.action.terminal.focusLast` to complete with `workbench.action.terminal.focusAtIndex${visibleIndex}`.

The new command allows user to focus the last terminal by index, similar to `workbench.action.lastEditorInGroup` which allows user to focus the last editor in an editor group.

To test the change, create several terminal tabs in the panel, assign a key binding to `workbench.action.terminal.focusLast`, and use that key binding to verify that last terminal tab can be focused.