### PR TITLE
Close webview when extension host restart

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadWebviewPanels.ts
+++ b/src/vs/workbench/api/browser/mainThreadWebviewPanels.ts
@@ -90,6 +90,15 @@ export class MainThreadWebviewPanels extends Disposable implements extHostProtoc
 
 	private readonly webviewOriginStore: ExtensionKeyedWebviewOriginStore;
 
+	public override dispose(): void {
+		for (const webview of this._webviewInputs) {
+			if (typeof webview.group === 'number' && webview.webview.options.autoCloseWhenDispose) {
+				this._editorService.closeEditor({ editor: webview, groupId: webview.group });
+			}
+		}
+		super.dispose();
+	}
+
 	constructor(
 		context: IExtHostContext,
 		private readonly _mainThreadWebviews: MainThreadWebviews,
@@ -365,5 +374,6 @@ function reviveWebviewOptions(panelOptions: extHostProtocol.IWebviewPanelOptions
 	return {
 		enableFindWidget: panelOptions.enableFindWidget,
 		retainContextWhenHidden: panelOptions.retainContextWhenHidden,
+		autoCloseWhenDispose: panelOptions.autoCloseWhenDispose,
 	};
 }

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -866,6 +866,7 @@ export interface IWebviewContentOptions {
 export interface IWebviewPanelOptions {
 	readonly enableFindWidget?: boolean;
 	readonly retainContextWhenHidden?: boolean;
+	readonly autoCloseWhenDispose?: boolean;
 }
 
 export interface CustomTextEditorCapabilities {

--- a/src/vs/workbench/api/common/extHostWebviewPanels.ts
+++ b/src/vs/workbench/api/common/extHostWebviewPanels.ts
@@ -327,5 +327,6 @@ function serializeWebviewPanelOptions(options: vscode.WebviewPanelOptions): extH
 	return {
 		enableFindWidget: options.enableFindWidget,
 		retainContextWhenHidden: options.retainContextWhenHidden,
+		autoCloseWhenDispose: options.autoCloseWhenDispose,
 	};
 }

--- a/src/vs/workbench/contrib/webview/browser/webview.ts
+++ b/src/vs/workbench/contrib/webview/browser/webview.ts
@@ -103,6 +103,7 @@ export interface WebviewOptions {
 
 	readonly tryRestoreScrollPosition?: boolean;
 	readonly retainContextWhenHidden?: boolean;
+	readonly autoCloseWhenDispose?: boolean;
 	transformCssVariables?(styles: WebviewStyles): WebviewStyles;
 }
 

--- a/src/vscode-dts/vscode.d.ts
+++ b/src/vscode-dts/vscode.d.ts
@@ -9662,6 +9662,11 @@ declare module 'vscode' {
 		 * your panel's context cannot be quickly saved and restored.
 		 */
 		readonly retainContextWhenHidden?: boolean;
+
+		/**
+		 * Whether the webview panel is automatically closed when it is disposed.
+		 */
+		readonly autoCloseWhenDispose?: boolean;
 	}
 
 	/**


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
Close #70656 

Not all webviews require an extension to live in the background.

Instead of all the panels being closed when disposed, introduce a new option in `WebviewPanelOptions` that can close webview editor when the extension host restart.

```js
panel = vscode.window.createWebviewPanel(
    'catCoding',
    'Cat Coding with auto close',
    vscode.ViewColumn.One,
    {
	    autoCloseWhenDispose: true
    } 
);
```

![demo](https://github.com/user-attachments/assets/c4cef809-a614-4e15-ad48-1c987efb00dd)


