### PR TITLE
Close webview view when extension host restart

### DIFF
--- a/src/vs/workbench/contrib/webviewView/browser/webviewViewPane.ts
+++ b/src/vs/workbench/contrib/webviewView/browser/webviewViewPane.ts
@@ -235,10 +235,14 @@ export class WebviewViewPane extends ViewPane {
 					this._activated = false;
 					this._webview.clear();
 					this._webviewDisposables.clear();
+					webviewView.close();
 				},
 
 				show: (preserveFocus) => {
 					this.viewService.openView(this.id, !preserveFocus);
+				},
+				close: () => {
+					this.viewService.closeView(this.id);
 				}
 			};
 

--- a/src/vs/workbench/contrib/webviewView/browser/webviewViewService.ts
+++ b/src/vs/workbench/contrib/webviewView/browser/webviewViewService.ts
@@ -57,6 +57,8 @@ export interface WebviewView {
 	 * Force the webview view to show.
 	 */
 	show(preserveFocus: boolean): void;
+
+	close(): void;
 }
 
 /**


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
Close #188257 

There will be no `WebviewViewProvider` after the extension host restart. They will need to `registerWebviewViewProvider` again to show the webview again.

Not sure if it is an ideal fix. Any feedback could be helpful, thanks in advance.

![demo](https://github.com/user-attachments/assets/2f64331e-ddba-469b-9e1d-401a940b2a2c)
