### PR TITLE
Dedent codeblocks in lists in chat

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/codeBlockPart.css
+++ b/src/vs/workbench/contrib/chat/browser/codeBlockPart.css
@@ -15,7 +15,7 @@
 .interactive-result-code-block .interactive-result-code-block-toolbar > .monaco-action-bar,
 .interactive-result-code-block .interactive-result-code-block-toolbar > .monaco-toolbar {
 	position: absolute;
-	top: -13px;
+	top: -15px;
 	height: 26px;
 	line-height: 26px;
 	background-color: var(--vscode-interactive-result-editor-background-color, var(--vscode-editor-background));

--- a/src/vs/workbench/contrib/chat/browser/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/media/chat.css
@@ -266,13 +266,41 @@
 	margin: 0;
 }
 
+/* #region list indent rules */
 .interactive-item-container .value .rendered-markdown ul {
+	/* Keep this in sync with the values for dedented codeblocks below */
 	padding-inline-start: 24px;
 }
 
 .interactive-item-container .value .rendered-markdown ol {
+	/* Keep this in sync with the values for dedented codeblocks below */
 	padding-inline-start: 28px;
 }
+
+/* NOTE- We want to dedent codeblocks in lists specifically to give them the full width. No more elegant way to do this, these values
+have to be updated for changes to the rules above, or to support more deeply nested lists. */
+.interactive-item-container .value .rendered-markdown ul .interactive-result-code-block {
+	margin-left: -24px;
+}
+
+.interactive-item-container .value .rendered-markdown ul ul .interactive-result-code-block {
+	margin-left: -48px;
+}
+
+.interactive-item-container .value .rendered-markdown ol .interactive-result-code-block {
+	margin-left: -28px;
+}
+
+.interactive-item-container .value .rendered-markdown ol ol .interactive-result-code-block {
+	margin-left: -56px;
+}
+
+.interactive-item-container .value .rendered-markdown ol ul .interactive-result-code-block,
+.interactive-item-container .value .rendered-markdown ul ol .interactive-result-code-block {
+	margin-left: -52px;
+}
+
+/* #endregion list indent rules */
 
 .interactive-item-container .value .rendered-markdown li {
 	line-height: 1.3rem;


### PR DESCRIPTION
Rather than make indented codeblocks narrower, I am just de-indenting them so that they get the full width in lists. Not an elegant solution but I think this works well.
Fix microsoft/vscode-copilot#6188

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
