### PR TITLE
Add stack trace to console warnings

### DIFF
--- a/src/vs/base/browser/ui/list/listView.ts
+++ b/src/vs/base/browser/ui/list/listView.ts
@@ -519,7 +519,7 @@ export class ListView<T> implements IListView<T> {
 
 		if (typeof size === 'undefined') {
 			if (!this.supportDynamicHeights) {
-				console.warn('Dynamic heights not supported');
+				console.warn('Dynamic heights not supported', new Error().stack);
 				return;
 			}
 
@@ -1519,7 +1519,7 @@ export class ListView<T> implements IListView<T> {
 			item.row.domNode.style.height = '';
 			item.size = item.row.domNode.offsetHeight;
 			if (item.size === 0 && !isAncestor(item.row.domNode, getWindow(item.row.domNode).document.body)) {
-				console.warn('Measuring item node that is not in DOM! Add ListView to the DOM before measuring row height!');
+				console.warn('Measuring item node that is not in DOM! Add ListView to the DOM before measuring row height!', new Error().stack);
 			}
 			item.lastDynamicHeightWidth = this.renderWidth;
 			return item.size - size;


### PR DESCRIPTION
This pull request adds a stack trace to the console warnings in the `ListView` class. This will provide more information about the location of the warning in the code, making it easier to debug and fix any issues. 

closes #225953