### PR TITLE
esm - run `removeGlobalNodeModuleLookupPaths` only in node.js (#226042)

### DIFF
--- a/src/bootstrap-fork.js
+++ b/src/bootstrap-fork.js
@@ -22,7 +22,7 @@ performance.mark('code/fork/start');
 // Crash reporter
 configureCrashReporter();
 
-// Remove global paths from the node module lookup (TODO@esm does this work in ESM?)
+// Remove global paths from the node module lookup (node.js only)
 bootstrapNode.removeGlobalNodeModuleLookupPaths();
 
 // Enable ASAR in our forked processes

--- a/src/bootstrap-node.js
+++ b/src/bootstrap-node.js
@@ -110,6 +110,12 @@ module.exports.devInjectNodeModuleLookupPath = function (injectPath) {
 };
 
 module.exports.removeGlobalNodeModuleLookupPaths = function () {
+	if (typeof process?.versions?.electron === 'string') {
+		return; // Electron disables global search paths in https://github.com/electron/electron/blob/3186c2f0efa92d275dc3d57b5a14a60ed3846b0e/shell/common/node_bindings.cc#L653
+	}
+
+	// TODO@esm this might not work anymore (https://github.com/microsoft/vscode/issues/226042)
+
 	const Module = require('module');
 	// @ts-ignore
 	const globalPaths = Module.globalPaths;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
