### PR TITLE
Reconnect orphaned webviews after extension host restart/crash

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadWebviewPanels.ts
+++ b/src/vs/workbench/api/browser/mainThreadWebviewPanels.ts
@@ -137,6 +137,10 @@ export class MainThreadWebviewPanels extends Disposable implements extHostProtoc
 
 	public get webviewInputs(): Iterable<WebviewInput> { return this._webviewInputs; }
 
+	public isWebviewInputRegistered(input: WebviewInput): boolean {
+		return this._webviewInputs.getHandleForInput(input) !== undefined;
+	}
+
 	public addWebviewInput(handle: extHostProtocol.WebviewHandle, input: WebviewInput, options: { serializeBuffersForPostMessage: boolean }): void {
 		this._webviewInputs.add(handle, input);
 		this._mainThreadWebviews.addWebview(handle, input.webview, options);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Basically when the extension re-registers the webview provider and we detect an open webview editor that isn't registered in `MainThreadWebviewPanels` and is not dirty, we "reconnect" to it, by reinitialized it. Handling a dirty one is left for later consideration, as in that case, reinitializing it will likely lead to data loss AFAIK? Though maybe not, depending on if the state is saved on VS Code's renderer side in the model or elsewhere and if this is enough to restore it correctly.

Part of #225410 #84142 and likely other duplicates or other PR proposing a solution, continues from #225985, so you will also see the commits from it until it is merged or I rebase this branch.