### PR TITLE
chore - inline chat work

### DIFF
--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChat.contribution.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChat.contribution.ts
@@ -108,7 +108,6 @@ registerAction2(InlineChatActions.ToggleDiffForChange);
 registerAction2(InlineChatActions.AcceptChanges);
 
 registerAction2(InlineChatActions.ReportIssueAction);
-registerAction2(InlineChatActions.CopyRecordings);
 
 const workbenchContributionsRegistry = Registry.as<IWorkbenchContributionsRegistry>(WorkbenchExtensions.Workbench);
 workbenchContributionsRegistry.registerWorkbenchContribution(InlineChatNotebookContribution, LifecyclePhase.Restored);

--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatActions.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatActions.ts
@@ -14,15 +14,11 @@ import { InlineChatController, InlineChatRunOptions } from 'vs/workbench/contrib
 import { ACTION_ACCEPT_CHANGES, CTX_INLINE_CHAT_HAS_AGENT, CTX_INLINE_CHAT_HAS_STASHED_SESSION, CTX_INLINE_CHAT_FOCUSED, CTX_INLINE_CHAT_INNER_CURSOR_FIRST, CTX_INLINE_CHAT_INNER_CURSOR_LAST, CTX_INLINE_CHAT_VISIBLE, CTX_INLINE_CHAT_OUTER_CURSOR_POSITION, CTX_INLINE_CHAT_USER_DID_EDIT, CTX_INLINE_CHAT_DOCUMENT_CHANGED, CTX_INLINE_CHAT_EDIT_MODE, EditMode, MENU_INLINE_CHAT_WIDGET_STATUS, CTX_INLINE_CHAT_REQUEST_IN_PROGRESS, CTX_INLINE_CHAT_RESPONSE_TYPE, InlineChatResponseType, ACTION_REGENERATE_RESPONSE, MENU_INLINE_CHAT_CONTENT_STATUS, ACTION_VIEW_IN_CHAT, ACTION_TOGGLE_DIFF, CTX_INLINE_CHAT_CHANGE_HAS_DIFF, CTX_INLINE_CHAT_CHANGE_SHOWS_DIFF, MENU_INLINE_CHAT_ZONE, CTX_INLINE_CHAT_SUPPORT_REPORT_ISSUE, ACTION_REPORT_ISSUE } from 'vs/workbench/contrib/inlineChat/common/inlineChat';
 import { localize, localize2 } from 'vs/nls';
 import { Action2, IAction2Options } from 'vs/platform/actions/common/actions';
-import { IClipboardService } from 'vs/platform/clipboard/common/clipboardService';
 import { ContextKeyExpr } from 'vs/platform/contextkey/common/contextkey';
 import { IInstantiationService, ServicesAccessor } from 'vs/platform/instantiation/common/instantiation';
 import { KeybindingWeight } from 'vs/platform/keybinding/common/keybindingsRegistry';
-import { IQuickInputService, IQuickPickItem } from 'vs/platform/quickinput/common/quickInput';
 import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
 import { ICodeEditorService } from 'vs/editor/browser/services/codeEditorService';
-import { fromNow } from 'vs/base/common/date';
-import { IInlineChatSessionService, Recording } from './inlineChatSessionService';
 import { CONTEXT_ACCESSIBILITY_MODE_ENABLED } from 'vs/platform/accessibility/common/accessibility';
 import { CommandsRegistry } from 'vs/platform/commands/common/commands';
 import { registerIcon } from 'vs/platform/theme/common/iconRegistry';
@@ -453,42 +449,6 @@ export class MoveToPreviousHunk extends AbstractInlineChatAction {
 
 	override runInlineChatCommand(accessor: ServicesAccessor, ctrl: InlineChatController, editor: ICodeEditor, ...args: any[]): void {
 		ctrl.moveHunk(false);
-	}
-}
-
-export class CopyRecordings extends AbstractInlineChatAction {
-
-	constructor() {
-		super({
-			id: 'inlineChat.copyRecordings',
-			f1: true,
-			title: localize2('copyRecordings', "(Developer) Write Exchange to Clipboard")
-		});
-	}
-
-	override async runInlineChatCommand(accessor: ServicesAccessor): Promise<void> {
-
-		const clipboardService = accessor.get(IClipboardService);
-		const quickPickService = accessor.get(IQuickInputService);
-		const ieSessionService = accessor.get(IInlineChatSessionService);
-
-		const recordings = ieSessionService.recordings().filter(r => r.exchanges.length > 0);
-		if (recordings.length === 0) {
-			return;
-		}
-
-		const picks: (IQuickPickItem & { rec: Recording })[] = recordings.map(rec => {
-			return {
-				rec,
-				label: localize('label', "'{0}' and {1} follow ups ({2})", rec.exchanges[0].prompt, rec.exchanges.length - 1, fromNow(rec.when, true)),
-				tooltip: rec.exchanges.map(ex => ex.prompt).join('\n'),
-			};
-		});
-
-		const pick = await quickPickService.pick(picks, { canPickMany: false });
-		if (pick) {
-			clipboardService.writeText(JSON.stringify(pick.rec, undefined, 2));
-		}
 	}
 }
 

--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatSession.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatSession.ts
@@ -5,22 +5,13 @@
 
 import { URI } from 'vs/base/common/uri';
 import { Emitter, Event } from 'vs/base/common/event';
-import { TextEdit } from 'vs/editor/common/languages';
 import { IIdentifiedSingleEditOperation, IModelDecorationOptions, IModelDeltaDecoration, ITextModel, IValidEditOperation, TrackedRangeStickiness } from 'vs/editor/common/model';
 import { EditMode, CTX_INLINE_CHAT_HAS_STASHED_SESSION } from 'vs/workbench/contrib/inlineChat/common/inlineChat';
 import { IRange, Range } from 'vs/editor/common/core/range';
 import { ModelDecorationOptions } from 'vs/editor/common/model/textModel';
-import { toErrorMessage } from 'vs/base/common/errorMessage';
-import { isCancellationError } from 'vs/base/common/errors';
 import { EditOperation, ISingleEditOperation } from 'vs/editor/common/core/editOperation';
 import { DetailedLineRangeMapping, LineRangeMapping, RangeMapping } from 'vs/editor/common/diff/rangeMapping';
-import { IUntitledTextEditorModel } from 'vs/workbench/services/untitled/common/untitledTextEditorModel';
-import { ITextFileService } from 'vs/workbench/services/textfile/common/textfiles';
-import { ILanguageService } from 'vs/editor/common/languages/language';
-import { ResourceMap } from 'vs/base/common/map';
-import { Schemas } from 'vs/base/common/network';
-import { isEqual } from 'vs/base/common/resources';
-import { IInlineChatSessionService, Recording } from './inlineChatSessionService';
+import { IInlineChatSessionService } from './inlineChatSessionService';
 import { LineRange } from 'vs/editor/common/core/lineRange';
 import { IEditorWorkerService } from 'vs/editor/common/services/editorWorker';
 import { coalesceInPlace } from 'vs/base/common/arrays';
@@ -30,7 +21,7 @@ import { DisposableStore, IDisposable } from 'vs/base/common/lifecycle';
 import { ICodeEditor } from 'vs/editor/browser/editorBrowser';
 import { IContextKey, IContextKeyService } from 'vs/platform/contextkey/common/contextkey';
 import { ILogService } from 'vs/platform/log/common/log';
-import { ChatModel, IChatRequestModel, IChatResponseModel, IChatTextEditGroupState } from 'vs/workbench/contrib/chat/common/chatModel';
+import { ChatModel, IChatRequestModel, IChatTextEditGroupState } from 'vs/workbench/contrib/chat/common/chatModel';
 import { ExtensionIdentifier } from 'vs/platform/extensions/common/extensions';
 import { IChatAgent } from 'vs/workbench/contrib/chat/common/chatAgents';
 import { IDocumentDiff } from 'vs/editor/common/diff/documentDiffProvider';
@@ -129,11 +120,10 @@ export class SessionWholeRange {
 export class Session {
 
 	private _isUnstashed: boolean = false;
-	private readonly _exchanges: SessionExchange[];
 	private readonly _startTime = new Date();
 	private readonly _teldata: TelemetryData;
 
-	readonly textModelNAltVersion: number;
+	private readonly _versionByRequest = new Map<string, number>();
 
 	constructor(
 		readonly editMode: EditMode,
@@ -153,9 +143,9 @@ export class Session {
 		readonly wholeRange: SessionWholeRange,
 		readonly hunkData: HunkData,
 		readonly chatModel: ChatModel,
-		exchanges?: SessionExchange[],
+		versionsByRequest?: [string, number][], // DEBT? this is needed when a chat model is "reused" for a new chat session
 	) {
-		this.textModelNAltVersion = textModelN.getAlternativeVersionId();
+
 		this._teldata = {
 			extension: ExtensionIdentifier.toKey(agent.extensionId),
 			startTime: this._startTime.toISOString(),
@@ -170,7 +160,9 @@ export class Session {
 			discardedHunks: 0,
 			responseTypes: ''
 		};
-		this._exchanges = exchanges ?? [];
+		if (versionsByRequest) {
+			this._versionByRequest = new Map(versionsByRequest);
+		}
 	}
 
 	get isUnstashed(): boolean {
@@ -182,40 +174,29 @@ export class Session {
 		this._isUnstashed = true;
 	}
 
-	addExchange(exchange: SessionExchange): void {
-		this._isUnstashed = false;
-		const newLen = this._exchanges.push(exchange);
-		this._teldata.rounds += `${newLen}|`;
-		// this._teldata.responseTypes += `${exchange.response instanceof ReplyResponse ? exchange.response.responseType : InlineChatResponseTypes.Empty}|`;
+	markModelVersion(request: IChatRequestModel) {
+		this._versionByRequest.set(request.id, this.textModelN.getAlternativeVersionId());
 	}
 
-	get exchanges(): SessionExchange[] {
-		return this._exchanges;
-	}
-
-	get lastExchange(): SessionExchange | undefined {
-		return this._exchanges[this._exchanges.length - 1];
+	get versionsByRequest() {
+		return Array.from(this._versionByRequest);
 	}
 
 	async undoChangesUntil(requestId: string): Promise<boolean> {
-		const idx = this._exchanges.findIndex(candidate => candidate.prompt.request.id === requestId);
-		if (idx < 0) {
+
+		const targetAltVersion = this._versionByRequest.get(requestId);
+		if (targetAltVersion === undefined) {
 			return false;
 		}
 		// undo till this point
 		this.hunkData.ignoreTextModelNChanges = true;
 		try {
-			const targetAltVersion = this._exchanges[idx].prompt.modelAltVersionId;
 			while (targetAltVersion < this.textModelN.getAlternativeVersionId() && this.textModelN.canUndo()) {
 				await this.textModelN.undo();
 			}
 		} finally {
 			this.hunkData.ignoreTextModelNChanges = false;
 		}
-		// TODO@jrieken cannot do this yet because some parts still rely on
-		// exchanges being around...
-		// // remove this and following exchanges
-		// this._exchanges.length = idx;
 		return true;
 	}
 
@@ -259,109 +240,8 @@ export class Session {
 		this._teldata.endTime = new Date().toISOString();
 		return this._teldata;
 	}
-
-	asRecording(): Recording {
-		const result: Recording = {
-			session: this.chatModel.sessionId,
-			when: this._startTime,
-			exchanges: []
-		};
-		for (const exchange of this._exchanges) {
-			const response = exchange.response;
-			if (response instanceof ReplyResponse) {
-				result.exchanges.push({ prompt: exchange.prompt.value, res: response.chatResponse });
-			}
-		}
-		return result;
-	}
 }
 
-
-export class SessionPrompt {
-
-	readonly value: string;
-
-	constructor(
-		readonly request: IChatRequestModel,
-		readonly modelAltVersionId: number,
-	) {
-		this.value = request.message.text;
-	}
-}
-
-export class SessionExchange {
-
-	constructor(
-		readonly prompt: SessionPrompt,
-		readonly response: ReplyResponse | EmptyResponse | ErrorResponse
-	) { }
-}
-
-export class EmptyResponse {
-
-}
-
-export class ErrorResponse {
-
-	readonly message: string;
-	readonly isCancellation: boolean;
-
-	constructor(
-		readonly error: any
-	) {
-		this.message = toErrorMessage(error, false);
-		this.isCancellation = isCancellationError(error);
-	}
-}
-
-export class ReplyResponse {
-
-	readonly untitledTextModel: IUntitledTextEditorModel | undefined;
-
-	constructor(
-		localUri: URI,
-		readonly chatRequest: IChatRequestModel,
-		readonly chatResponse: IChatResponseModel,
-		@ITextFileService private readonly _textFileService: ITextFileService,
-		@ILanguageService private readonly _languageService: ILanguageService,
-	) {
-
-		const editsMap = new ResourceMap<TextEdit[][]>();
-
-		for (const item of chatResponse.response.value) {
-			if (item.kind === 'textEditGroup') {
-				const array = editsMap.get(item.uri);
-				for (const group of item.edits) {
-					if (array) {
-						array.push(group);
-					} else {
-						editsMap.set(item.uri, [group]);
-					}
-				}
-			}
-		}
-
-		for (const [uri, edits] of editsMap) {
-
-			const flatEdits = edits.flat();
-			if (flatEdits.length === 0) {
-				editsMap.delete(uri);
-				continue;
-			}
-
-			const isLocalUri = isEqual(uri, localUri);
-			if (uri.scheme === Schemas.untitled && !isLocalUri && !this.untitledTextModel) { //TODO@jrieken the first untitled model WINS
-				const langSelection = this._languageService.createByFilepathOrFirstLine(uri, undefined);
-				const untitledTextModel = this._textFileService.untitled.create({
-					associatedResource: uri,
-					languageId: langSelection.languageId
-				});
-				this.untitledTextModel = untitledTextModel;
-				untitledTextModel.resolve();
-			}
-		}
-	}
-}
 
 export class StashedSession {
 

--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatSession.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatSession.ts
@@ -589,6 +589,8 @@ export class HunkData {
 
 		const hunks = mergedChanges.map(change => new RawHunk(change.original, change.modified, change.innerChanges ?? []));
 
+		editState.applied = hunks.length;
+
 		this._textModelN.changeDecorations(accessorN => {
 
 			this._textModel0.changeDecorations(accessor0 => {
@@ -691,6 +693,9 @@ export class HunkData {
 						const edits = this._discardEdits(item);
 						this._textModelN.pushEditOperations(null, edits, () => null);
 						data.state = HunkState.Rejected;
+						if (data.editState.applied > 0) {
+							data.editState.applied -= 1;
+						}
 					}
 				},
 				acceptChanges: () => {
@@ -707,7 +712,6 @@ export class HunkData {
 						}
 						this._textModel0.pushEditOperations(null, edits, () => null);
 						data.state = HunkState.Accepted;
-						data.editState.applied += 1;
 					}
 				}
 			};

--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatSessionService.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatSessionService.ts
@@ -10,16 +10,8 @@ import { IActiveCodeEditor, ICodeEditor } from 'vs/editor/browser/editorBrowser'
 import { IRange } from 'vs/editor/common/core/range';
 import { IValidEditOperation } from 'vs/editor/common/model';
 import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
-import { IChatResponseModel } from 'vs/workbench/contrib/chat/common/chatModel';
 import { EditMode } from 'vs/workbench/contrib/inlineChat/common/inlineChat';
 import { Session, StashedSession } from './inlineChatSession';
-
-
-export type Recording = {
-	when: Date;
-	session: string;
-	exchanges: { prompt: string; res: IChatResponseModel }[];
-};
 
 export interface ISessionKeyComputer {
 	getComparisonKey(editor: ICodeEditor, uri: URI): string;
@@ -57,9 +49,6 @@ export interface IInlineChatSessionService {
 	stashSession(session: Session, editor: ICodeEditor, undoCancelEdits: IValidEditOperation[]): StashedSession;
 
 	registerSessionKeyComputer(scheme: string, value: ISessionKeyComputer): IDisposable;
-
-	//
-	recordings(): readonly Recording[];
 
 	dispose(): void;
 }

--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatSessionServiceImpl.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatSessionServiceImpl.ts
@@ -3,7 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 import { CancellationToken } from 'vs/base/common/cancellation';
-import { CancellationError } from 'vs/base/common/errors';
 import { Emitter, Event } from 'vs/base/common/event';
 import { DisposableStore, IDisposable, MutableDisposable, toDisposable } from 'vs/base/common/lifecycle';
 import { Schemas } from 'vs/base/common/network';
@@ -26,8 +25,11 @@ import { IChatService } from 'vs/workbench/contrib/chat/common/chatService';
 import { CTX_INLINE_CHAT_HAS_AGENT, EditMode } from 'vs/workbench/contrib/inlineChat/common/inlineChat';
 import { IEditorService } from 'vs/workbench/services/editor/common/editorService';
 import { UntitledTextEditorInput } from 'vs/workbench/services/untitled/common/untitledTextEditorInput';
-import { EmptyResponse, ErrorResponse, HunkData, ReplyResponse, Session, SessionExchange, SessionPrompt, SessionWholeRange, StashedSession, TelemetryData, TelemetryDataClassification } from './inlineChatSession';
-import { IInlineChatSessionEndEvent, IInlineChatSessionEvent, IInlineChatSessionService, ISessionKeyComputer, Recording } from './inlineChatSessionService';
+import { HunkData, Session, SessionWholeRange, StashedSession, TelemetryData, TelemetryDataClassification } from './inlineChatSession';
+import { IInlineChatSessionEndEvent, IInlineChatSessionEvent, IInlineChatSessionService, ISessionKeyComputer } from './inlineChatSessionService';
+import { isEqual } from 'vs/base/common/resources';
+import { ILanguageService } from 'vs/editor/common/languages/language';
+import { ITextFileService } from 'vs/workbench/services/textfile/common/textfiles';
 
 
 type SessionData = {
@@ -65,8 +67,6 @@ export class InlineChatSessionServiceImpl implements IInlineChatSessionService {
 
 	private readonly _sessions = new Map<string, SessionData>();
 	private readonly _keyComputers = new Map<string, ISessionKeyComputer>();
-	private _recordings: Recording[] = [];
-
 
 	constructor(
 		@ITelemetryService private readonly _telemetryService: ITelemetryService,
@@ -76,6 +76,8 @@ export class InlineChatSessionServiceImpl implements IInlineChatSessionService {
 		@ILogService private readonly _logService: ILogService,
 		@IInstantiationService private readonly _instaService: IInstantiationService,
 		@IEditorService private readonly _editorService: IEditorService,
+		@ITextFileService private readonly _textFileService: ITextFileService,
+		@ILanguageService private readonly _languageService: ILanguageService,
 		@IChatService private readonly _chatService: IChatService,
 		@IChatAgentService private readonly _chatAgentService: IChatAgentService
 	) { }
@@ -126,8 +128,7 @@ export class InlineChatSessionServiceImpl implements IInlineChatSessionService {
 
 			const { response } = e.request;
 
-			const prompt = new SessionPrompt(e.request, session.textModelN.getAlternativeVersionId());
-
+			session.markModelVersion(e.request);
 			lastResponseListener.value = response.onDidChange(() => {
 
 				if (!response.isComplete) {
@@ -136,34 +137,22 @@ export class InlineChatSessionServiceImpl implements IInlineChatSessionService {
 
 				lastResponseListener.clear(); // ONCE
 
-				let inlineResponse: ErrorResponse | EmptyResponse | ReplyResponse;
-
-				// make an response from the ChatResponseModel
-				if (response.isCanceled) {
-					// error: cancelled
-					inlineResponse = new ErrorResponse(new CancellationError());
-				} else if (response.result?.errorDetails) {
-					// error: "real" error
-					inlineResponse = new ErrorResponse(new Error(response.result.errorDetails.message));
-				} else if (response.response.value.length === 0) {
-					// epmty response
-					inlineResponse = new EmptyResponse();
-				} else {
-					inlineResponse = this._instaService.createInstance(
-						ReplyResponse,
-						session.textModelN.uri,
-						e.request,
-						response
-					);
-				}
-
-				session.addExchange(new SessionExchange(prompt, inlineResponse));
-
-				if (inlineResponse instanceof ReplyResponse && inlineResponse.untitledTextModel) {
-					this._textModelService.createModelReference(inlineResponse.untitledTextModel.resource).then(ref => {
+				// special handling for untitled files
+				for (const part of response.response.value) {
+					if (part.kind !== 'textEditGroup' || part.uri.scheme !== Schemas.untitled || isEqual(part.uri, session.textModelN.uri)) {
+						continue;
+					}
+					const langSelection = this._languageService.createByFilepathOrFirstLine(part.uri, undefined);
+					const untitledTextModel = this._textFileService.untitled.create({
+						associatedResource: part.uri,
+						languageId: langSelection.languageId
+					});
+					untitledTextModel.resolve();
+					this._textModelService.createModelReference(part.uri).then(ref => {
 						store.add(ref);
 					});
 				}
+
 			});
 		}));
 
@@ -216,7 +205,7 @@ export class InlineChatSessionServiceImpl implements IInlineChatSessionService {
 			store.add(new SessionWholeRange(textModelN, wholeRange)),
 			store.add(new HunkData(this._editorWorkerService, textModel0, textModelN)),
 			chatModel,
-			options.session?.exchanges, // @ulugbekna: very hacky: we pass exchanges by reference because an exchange is added only on `addRequest` event from chat model which the migrated inline chat misses
+			options.session?.versionsByRequest,
 		);
 
 		// store: key -> session
@@ -279,7 +268,6 @@ export class InlineChatSessionServiceImpl implements IInlineChatSessionService {
 			return;
 		}
 
-		this._keepRecording(session);
 		this._telemetryService.publicLog2<TelemetryData, TelemetryDataClassification>('interactiveEditor/session', session.asTelemetryData());
 
 		const [key, value] = tuple;
@@ -291,7 +279,6 @@ export class InlineChatSessionServiceImpl implements IInlineChatSessionService {
 	}
 
 	stashSession(session: Session, editor: ICodeEditor, undoCancelEdits: IValidEditOperation[]): StashedSession {
-		this._keepRecording(session);
 		const result = this._instaService.createInstance(StashedSession, editor, session, undoCancelEdits);
 		this._onDidStashSession.fire({ editor, session });
 		this._logService.trace(`[IE] did STASH session for ${editor.getId()}, ${session.agent.extensionId}`);
@@ -323,19 +310,6 @@ export class InlineChatSessionServiceImpl implements IInlineChatSessionService {
 	registerSessionKeyComputer(scheme: string, value: ISessionKeyComputer): IDisposable {
 		this._keyComputers.set(scheme, value);
 		return toDisposable(() => this._keyComputers.delete(scheme));
-	}
-
-	// --- debug
-
-	private _keepRecording(session: Session) {
-		const newLen = this._recordings.unshift(session.asRecording());
-		if (newLen > 5) {
-			this._recordings.pop();
-		}
-	}
-
-	recordings(): readonly Recording[] {
-		return this._recordings;
 	}
 }
 

--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatWidget.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatWidget.ts
@@ -158,7 +158,7 @@ export class InlineChatWidget {
 						if (item.response.value.length === 0) {
 							return false;
 						}
-						return false;
+						return true;
 					}
 					return true;
 				},

--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatWidget.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatWidget.ts
@@ -145,10 +145,19 @@ export class InlineChatWidget {
 				supportsFileReferences: _configurationService.getValue(`chat.experimental.variables.${location.location}`) === true,
 				filter: item => {
 					if (isWelcomeVM(item)) {
+						// filter welcome messages
 						return false;
 					}
-					if (isResponseVM(item) && item.isComplete && item.response.value.length > 0 && item.response.value.every(item => item.kind === 'textEditGroup' && options.chatWidgetViewOptions?.rendererOptions?.renderTextEditsAsSummary?.(item.uri))) {
-						// filter responses that are just text edits (prevents the "Made Edits")
+					if (isResponseVM(item) && item.isComplete) {
+						// filter responses that
+						// - are just text edits(prevents the "Made Edits")
+						// - are all empty
+						if (item.response.value.length > 0 && item.response.value.every(item => item.kind === 'textEditGroup' && options.chatWidgetViewOptions?.rendererOptions?.renderTextEditsAsSummary?.(item.uri))) {
+							return false;
+						}
+						if (item.response.value.length === 0) {
+							return false;
+						}
 						return false;
 					}
 					return true;


### PR DESCRIPTION
* Support to start with a populated chat model, esp that has text edits for the current file
* Makes inline chat be entirely grounded in the chat model
* Removes the copy recordings command which never got used