### PR TITLE
Fix #163943. Preserve focused editor if focused cell is scrolled out of viewport.

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/notebookBrowser.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookBrowser.ts
@@ -488,6 +488,7 @@ export interface INotebookEditor {
 	readonly onDidScroll: Event<void>;
 	readonly onDidChangeLayout: Event<void>;
 	readonly onDidChangeActiveCell: Event<void>;
+	readonly onDidChangeActiveEditor: Event<INotebookEditor>;
 	readonly onDidChangeActiveKernel: Event<void>;
 	readonly onMouseUp: Event<INotebookEditorMouseEvent>;
 	readonly onMouseDown: Event<INotebookEditorMouseEvent>;

--- a/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
+++ b/src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts
@@ -102,6 +102,7 @@ import { PixelRatio } from 'vs/base/browser/pixelRatio';
 import { PreventDefaultContextMenuItemsContextKeyName } from 'vs/workbench/contrib/webview/browser/webview.contribution';
 import { NotebookAccessibilityProvider } from 'vs/workbench/contrib/notebook/browser/notebookAccessibilityProvider';
 import { NotebookHorizontalTracker } from 'vs/workbench/contrib/notebook/browser/viewParts/notebookHorizontalTracker';
+import { NotebookCellEditorPool } from 'vs/workbench/contrib/notebook/browser/view/notebookCellEditorPool';
 
 const $ = DOM.$;
 
@@ -202,6 +203,7 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditorD
 	private _dndController: CellDragAndDropController | null = null;
 	private _listTopCellToolbar: ListTopCellToolbar | null = null;
 	private _renderedEditors: Map<ICellViewModel, ICodeEditor> = new Map();
+	private _editorPool!: NotebookCellEditorPool;
 	private _viewContext: ViewContext;
 	private _notebookViewModel: NotebookViewModel | undefined;
 	private readonly _localStore: DisposableStore = this._register(new DisposableStore());
@@ -917,11 +919,11 @@ export class NotebookEditorWidget extends Disposable implements INotebookEditorD
 
 	private _createCellList(): void {
 		this._body.classList.add('cell-list-container');
-
 		this._dndController = this._register(new CellDragAndDropController(this, this._body));
 		const getScopedContextKeyService = (container: HTMLElement) => this._list.contextKeyService.createScoped(container);
+		this._editorPool = this._register(this.instantiationService.createInstance(NotebookCellEditorPool, this, getScopedContextKeyService));
 		const renderers = [
-			this.instantiationService.createInstance(CodeCellRenderer, this, this._renderedEditors, this._dndController, getScopedContextKeyService),
+			this.instantiationService.createInstance(CodeCellRenderer, this, this._renderedEditors, this._editorPool, this._dndController, getScopedContextKeyService),
 			this.instantiationService.createInstance(MarkupCellRenderer, this, this._dndController, this._renderedEditors, getScopedContextKeyService),
 		];
 

--- a/src/vs/workbench/contrib/notebook/browser/view/notebookCellEditorPool.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/notebookCellEditorPool.ts
@@ -1,0 +1,136 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as DOM from 'vs/base/browser/dom';
+import { CancelablePromise, createCancelablePromise } from 'vs/base/common/async';
+import { Disposable, DisposableStore, MutableDisposable } from 'vs/base/common/lifecycle';
+import { CodeEditorWidget } from 'vs/editor/browser/widget/codeEditor/codeEditorWidget';
+import { EditorContextKeys } from 'vs/editor/common/editorContextKeys';
+import { ITextModelService } from 'vs/editor/common/services/resolverService';
+import { IConfigurationService } from 'vs/platform/configuration/common/configuration';
+import { IContextKeyService, IScopedContextKeyService } from 'vs/platform/contextkey/common/contextkey';
+import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
+import { ServiceCollection } from 'vs/platform/instantiation/common/serviceCollection';
+import { CellFocusMode, ICellViewModel, INotebookEditorDelegate } from 'vs/workbench/contrib/notebook/browser/notebookBrowser';
+import { CellEditorOptions } from 'vs/workbench/contrib/notebook/browser/view/cellParts/cellEditorOptions';
+
+export class NotebookCellEditorPool extends Disposable {
+	private readonly _focusedEditorDOM: HTMLElement;
+	private readonly _editorDisposable = this._register(new MutableDisposable());
+	private _editorContextKeyService!: IScopedContextKeyService;
+	private _editor!: CodeEditorWidget;
+	private _focusEditorCancellablePromise: CancelablePromise<void> | undefined;
+	private _isInitialized = false;
+	private _isDisposed = false;
+
+	constructor(
+		readonly notebookEditor: INotebookEditorDelegate,
+		private readonly contextKeyServiceProvider: (container: HTMLElement) => IScopedContextKeyService,
+		@ITextModelService private readonly textModelService: ITextModelService,
+		@IConfigurationService private readonly _configurationService: IConfigurationService,
+		@IInstantiationService private readonly _instantiationService: IInstantiationService,
+	) {
+		super();
+
+		this._focusedEditorDOM = this.notebookEditor.getDomNode().appendChild(DOM.$('.cell-editor-part-cache'));
+		this._focusedEditorDOM.style.position = 'absolute';
+		this._focusedEditorDOM.style.top = '-50000px';
+		this._focusedEditorDOM.style.width = '1px';
+		this._focusedEditorDOM.style.height = '1px';
+	}
+
+	private _initializeEditor(cell: ICellViewModel) {
+		this._editorContextKeyService = this._register(this.contextKeyServiceProvider(this._focusedEditorDOM));
+
+		const editorContainer = DOM.prepend(this._focusedEditorDOM, DOM.$('.cell-editor-container'));
+		const editorInstaService = this._register(this._instantiationService.createChild(new ServiceCollection([IContextKeyService, this._editorContextKeyService])));
+		EditorContextKeys.inCompositeEditor.bindTo(this._editorContextKeyService).set(true);
+		const editorOptions = new CellEditorOptions(this.notebookEditor.getBaseCellEditorOptions(cell.language), this.notebookEditor.notebookOptions, this._configurationService);
+
+		this._editor = this._register(editorInstaService.createInstance(CodeEditorWidget, editorContainer, {
+			...editorOptions.getDefaultValue(),
+			dimension: {
+				width: 0,
+				height: 0
+			},
+			scrollbar: {
+				vertical: 'hidden',
+				horizontal: 'auto',
+				handleMouseWheel: false,
+				useShadows: false,
+			},
+		}, {
+			contributions: this.notebookEditor.creationOptions.cellEditorContributions
+		}));
+
+		this._isInitialized = true;
+	}
+
+	preserveFocusedEditor(cell: ICellViewModel): void {
+		if (!this._isInitialized) {
+			this._initializeEditor(cell);
+		}
+
+		this._editorDisposable.clear();
+		this._focusEditorCancellablePromise?.cancel();
+
+		this._focusEditorCancellablePromise = createCancelablePromise(async token => {
+			const ref = await this.textModelService.createModelReference(cell.uri);
+
+			if (this._isDisposed || token.isCancellationRequested) {
+				ref.dispose();
+				return;
+			}
+
+			const editorDisposable = new DisposableStore();
+
+			this._editor.setModel(ref.object.textEditorModel);
+			this._editor.setSelections(cell.getSelections());
+			this._editor.focus();
+
+			const _update = () => {
+				const editorSelections = this._editor.getSelections();
+				if (editorSelections) {
+					cell.setSelections(editorSelections);
+				}
+
+				this.notebookEditor.revealInView(cell);
+				this._editor.setModel(null);
+				ref.dispose();
+			};
+
+			editorDisposable.add(this._editor.onDidChangeModelContent((e) => {
+				_update();
+			}));
+
+			editorDisposable.add(this._editor.onDidChangeCursorSelection(e => {
+				if (e.source === 'keyboard' || e.source === 'mouse') {
+					_update();
+				}
+			}));
+
+			editorDisposable.add(this.notebookEditor.onDidChangeActiveEditor(() => {
+				const latestActiveCell = this.notebookEditor.getActiveCell();
+
+				if (latestActiveCell !== cell || latestActiveCell.focusMode !== CellFocusMode.Editor) {
+					// focus moves to another cell or cell container
+					// we should stop preserving the editor
+					this._editorDisposable.clear();
+					this._editor.setModel(null);
+					ref.dispose();
+				}
+			}));
+
+			this._editorDisposable.value = editorDisposable;
+		});
+	}
+
+	override dispose() {
+		this._isDisposed = true;
+		this._focusEditorCancellablePromise?.cancel();
+
+		super.dispose();
+	}
+}

--- a/src/vs/workbench/contrib/notebook/browser/view/notebookCellEditorPool.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/notebookCellEditorPool.ts
@@ -85,7 +85,7 @@ export class NotebookCellEditorPool extends Disposable {
 			}
 
 			const editorDisposable = new DisposableStore();
-
+			editorDisposable.add(ref);
 			this._editor.setModel(ref.object.textEditorModel);
 			this._editor.setSelections(cell.getSelections());
 			this._editor.focus();

--- a/src/vs/workbench/contrib/notebook/browser/view/renderers/cellRenderer.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/renderers/cellRenderer.ts
@@ -50,6 +50,7 @@ import { MarkupCellViewModel } from 'vs/workbench/contrib/notebook/browser/viewM
 import { CellViewModel } from 'vs/workbench/contrib/notebook/browser/viewModel/notebookViewModelImpl';
 import { CellKind } from 'vs/workbench/contrib/notebook/common/notebookCommon';
 import { INotebookExecutionStateService } from 'vs/workbench/contrib/notebook/common/notebookExecutionStateService';
+import { NotebookCellEditorPool } from 'vs/workbench/contrib/notebook/browser/view/notebookCellEditorPool';
 
 const $ = DOM.$;
 
@@ -239,6 +240,7 @@ export class CodeCellRenderer extends AbstractCellRenderer implements IListRende
 	constructor(
 		notebookEditor: INotebookEditorDelegate,
 		private renderedEditors: Map<ICellViewModel, ICodeEditor>,
+		private editorPool: NotebookCellEditorPool,
 		dndController: CellDragAndDropController,
 		contextKeyServiceProvider: (container: HTMLElement) => IScopedContextKeyService,
 		@IConfigurationService configurationService: IConfigurationService,
@@ -382,7 +384,7 @@ export class CodeCellRenderer extends AbstractCellRenderer implements IListRende
 		templateData.outputContainer.domNode.innerText = '';
 		templateData.outputContainer.domNode.appendChild(templateData.cellOutputCollapsedContainer);
 
-		templateData.elementDisposables.add(templateData.instantiationService.createInstance(CodeCell, this.notebookEditor, element, templateData));
+		templateData.elementDisposables.add(templateData.instantiationService.createInstance(CodeCell, this.notebookEditor, element, templateData, this.editorPool));
 		this.renderedEditors.set(element, templateData.editor);
 	}
 


### PR DESCRIPTION
Fixes issue #163943. The pull request includes the following commits:

1. Fix #163943. Preserve focused editor if focused cell is scrolled out of viewport.

2. fix memory leak

The pull request contains the following file changes:

- `src/vs/workbench/contrib/notebook/browser/notebookBrowser.ts`

- `src/vs/workbench/contrib/notebook/browser/view/renderers/cellRenderer.ts`

- `src/vs/workbench/contrib/notebook/browser/notebookEditorWidget.ts`

- `src/vs/workbench/contrib/notebook/browser/view/cellParts/codeCell.ts`

