### PR TITLE
Bump msal-node and fix a bad contrast ratio

### DIFF
--- a/extensions/microsoft-authentication/package.json
+++ b/extensions/microsoft-authentication/package.json
@@ -126,7 +126,7 @@
   },
   "dependencies": {
     "@azure/ms-rest-azure-env": "^2.0.0",
-    "@azure/msal-node": "^2.12.0",
+    "@azure/msal-node": "^2.13.0",
     "@vscode/extension-telemetry": "^0.9.0",
     "vscode-tas-client": "^0.1.84"
   },

--- a/extensions/microsoft-authentication/src/node/loopbackTemplate.ts
+++ b/extensions/microsoft-authentication/src/node/loopbackTemplate.ts
@@ -69,7 +69,7 @@ export const loopbackTemplate = `
 		}
 
 		.error-text {
-			color: red;
+			color: salmon;
 			font-size: 1rem;
 		}
 

--- a/extensions/microsoft-authentication/yarn.lock
+++ b/extensions/microsoft-authentication/yarn.lock
@@ -7,17 +7,17 @@
   resolved "https://registry.yarnpkg.com/@azure/ms-rest-azure-env/-/ms-rest-azure-env-2.0.0.tgz#45809f89763a480924e21d3c620cd40866771625"
   integrity sha512-dG76W7ElfLi+fbTjnZVGj+M9e0BIEJmRxU6fHaUQ12bZBe8EJKYb2GV50YWNaP2uJiVQ5+7nXEVj1VN1UQtaEw==
 
-"@azure/msal-common@14.14.0":
-  version "14.14.0"
-  resolved "https://registry.yarnpkg.com/@azure/msal-common/-/msal-common-14.14.0.tgz#31a015070d5864ebcf9ebb988fcbc5c5536f22d1"
-  integrity sha512-OxcOk9H1/1fktHh6//VCORgSNJc2dCQObTm6JNmL824Z6iZSO6eFo/Bttxe0hETn9B+cr7gDouTQtsRq3YPuSQ==
+"@azure/msal-common@14.14.1":
+  version "14.14.1"
+  resolved "https://registry.yarnpkg.com/@azure/msal-common/-/msal-common-14.14.1.tgz#62e4569518d2c52e7de1f460d40ab919ca66b99b"
+  integrity sha512-2Q3tqNz/PZLfSr8BvcHZVpRRfSn4MjGSqjj9J+HlBsmbf1Uu4P0WeXnemjTJwwx9KrmplsrN3UkZ/LPOR720rw==
 
-"@azure/msal-node@^2.12.0":
-  version "2.12.0"
-  resolved "https://registry.yarnpkg.com/@azure/msal-node/-/msal-node-2.12.0.tgz#57ee6b6011a320046d72dc0828fec46278f2ab2c"
-  integrity sha512-jmk5Im5KujRA2AcyCb0awA3buV8niSrwXZs+NBJWIvxOz76RvNlusGIqi43A0h45BPUy93Qb+CPdpJn82NFTIg==
+"@azure/msal-node@^2.13.0":
+  version "2.13.0"
+  resolved "https://registry.yarnpkg.com/@azure/msal-node/-/msal-node-2.13.0.tgz#007ffffa84e4f91f00f816b980740837ce6626fe"
+  integrity sha512-DhP97ycs7qlCVzzzWGzJiwAFyFj5okno74E4FUZ61oCLfKh4IxA1kxirqzrWuYZWpBe9HVPL6GA4NvmlEOBN5Q==
   dependencies:
-    "@azure/msal-common" "14.14.0"
+    "@azure/msal-common" "14.14.1"
     jsonwebtoken "^9.0.0"
     uuid "^8.3.0"
 


### PR DESCRIPTION
Bumps MSAL-node which contains [my fix](https://github.com/AzureAD/microsoft-authentication-library-for-js/pull/7247) that will actually show our error template.

Also fixes an A11y contrast issue with said error template.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
ref https://github.com/microsoft/vscode/issues/229415