### PR TITLE
Save editor terminal instance cwd property

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminalEditorSerializer.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalEditorSerializer.ts
@@ -36,7 +36,7 @@ export class TerminalInputSerializer implements IEditorSerializer {
 			pid: instance.processId || 0,
 			title: instance.title,
 			titleSource: instance.titleSource,
-			cwd: '',
+			cwd: instance.cwd || '',
 			icon: instance.icon,
 			color: instance.color,
 			hasChildProcesses: instance.hasChildProcesses,


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
For [#226246](https://github.com/microsoft/vscode/pull/226246/files#diff-8aa9b8febd8098ffad7c9a14f89a3e594e042cbc93cfbdecfb6ab05d491e6ee2R1653)
While working on the PR, I found the instance from editor didn't persist the `cwd` property and after restore it will be `''`

Step to reproduce:
1. New terminal
2. Move terminal into editor area
3. cd any dir
4. Reload window
5. the `instance.cwd` is empty.