### PR TITLE
api: some slight lmtools polish

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadLanguageModelTools.ts
+++ b/src/vs/workbench/api/browser/mainThreadLanguageModelTools.ts
@@ -5,9 +5,8 @@
 
 import { CancellationToken } from 'vs/base/common/cancellation';
 import { Disposable, DisposableMap } from 'vs/base/common/lifecycle';
-import { ExtHostLanguageModelToolsShape, ExtHostContext, MainContext, MainThreadLanguageModelToolsShape } from 'vs/workbench/api/common/extHost.protocol';
-import { IChatMessage } from 'vs/workbench/contrib/chat/common/languageModels';
-import { IToolData, ILanguageModelToolsService, IToolResult, IToolInvokation, CountTokensCallback } from 'vs/workbench/contrib/chat/common/languageModelToolsService';
+import { ExtHostContext, ExtHostLanguageModelToolsShape, MainContext, MainThreadLanguageModelToolsShape } from 'vs/workbench/api/common/extHost.protocol';
+import { CountTokensCallback, ILanguageModelToolsService, IToolData, IToolInvocation, IToolResult } from 'vs/workbench/contrib/chat/common/languageModelToolsService';
 import { IExtHostContext, extHostNamedCustomer } from 'vs/workbench/services/extensions/common/extHostCustomers';
 
 @extHostNamedCustomer(MainContext.MainThreadLanguageModelTools)
@@ -31,18 +30,18 @@ export class MainThreadLanguageModelTools extends Disposable implements MainThre
 		return Array.from(this._languageModelToolsService.getTools());
 	}
 
-	$invokeTool(dto: IToolInvokation, token: CancellationToken): Promise<IToolResult> {
+	$invokeTool(dto: IToolInvocation, token: CancellationToken): Promise<IToolResult> {
 		return this._languageModelToolsService.invokeTool(
 			dto,
-			(input, token) => this._proxy.$countTokensForInvokation(dto.callId, input, token),
+			(input, token) => this._proxy.$countTokensForInvocation(dto.callId, input, token),
 			token,
 		);
 	}
 
-	$countTokensForInvokation(callId: string, input: string | IChatMessage, token: CancellationToken): Promise<number> {
+	$countTokensForInvocation(callId: string, input: string, token: CancellationToken): Promise<number> {
 		const fn = this._countTokenCallbacks.get(callId);
 		if (!fn) {
-			throw new Error(`Tool invokation call ${callId} not found`);
+			throw new Error(`Tool invocation call ${callId} not found`);
 		}
 
 		return fn(input, token);

--- a/src/vs/workbench/api/common/extHost.api.impl.ts
+++ b/src/vs/workbench/api/common/extHost.api.impl.ts
@@ -1489,7 +1489,7 @@ export function createApiFactoryAndRegisterActors(accessor: ServicesAccessor): I
 				checkProposedApiEnabled(extension, 'lmTools');
 				return extHostLanguageModelTools.registerTool(extension, toolId, tool);
 			},
-			invokeTool(toolId: string, parameters: vscode.LanguageModelToolInvokationOptions, token: vscode.CancellationToken) {
+			invokeTool(toolId: string, parameters: vscode.LanguageModelToolInvocationOptions, token: vscode.CancellationToken) {
 				checkProposedApiEnabled(extension, 'lmTools');
 				return extHostLanguageModelTools.invokeTool(toolId, parameters, token);
 			},

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -56,7 +56,7 @@ import { IChatProgressResponseContent } from 'vs/workbench/contrib/chat/common/c
 import { ChatAgentVoteDirection, IChatFollowup, IChatProgress, IChatResponseErrorDetails, IChatTask, IChatTaskDto, IChatUserActionEvent } from 'vs/workbench/contrib/chat/common/chatService';
 import { IChatRequestVariableValue, IChatVariableData, IChatVariableResolverProgress } from 'vs/workbench/contrib/chat/common/chatVariables';
 import { IChatMessage, IChatResponseFragment, ILanguageModelChatMetadata, ILanguageModelChatSelector, ILanguageModelsChangeEvent } from 'vs/workbench/contrib/chat/common/languageModels';
-import { IToolData, IToolDelta, IToolInvokation, IToolResult } from 'vs/workbench/contrib/chat/common/languageModelToolsService';
+import { IToolData, IToolDelta, IToolInvocation, IToolResult } from 'vs/workbench/contrib/chat/common/languageModelToolsService';
 import { DebugConfigurationProviderTriggerKind, IAdapterDescriptor, IConfig, IDebugSessionReplMode, IDebugTestRunReference, IDebugVisualization, IDebugVisualizationContext, IDebugVisualizationTreeItem, MainThreadDebugVisualization } from 'vs/workbench/contrib/debug/common/debug';
 import * as notebookCommon from 'vs/workbench/contrib/notebook/common/notebookCommon';
 import { CellExecutionUpdateType } from 'vs/workbench/contrib/notebook/common/notebookExecutionService';
@@ -1313,8 +1313,8 @@ export interface MainThreadChatVariablesShape extends IDisposable {
 
 export interface MainThreadLanguageModelToolsShape extends IDisposable {
 	$getTools(): Promise<Dto<IToolData>[]>;
-	$invokeTool(dto: IToolInvokation, token: CancellationToken): Promise<IToolResult>;
-	$countTokensForInvokation(callId: string, input: string | IChatMessage, token: CancellationToken): Promise<number>;
+	$invokeTool(dto: IToolInvocation, token: CancellationToken): Promise<IToolResult>;
+	$countTokensForInvocation(callId: string, input: string, token: CancellationToken): Promise<number>;
 	$registerTool(id: string): void;
 	$unregisterTool(name: string): void;
 }
@@ -1327,8 +1327,8 @@ export interface ExtHostChatVariablesShape {
 
 export interface ExtHostLanguageModelToolsShape {
 	$acceptToolDelta(delta: IToolDelta): Promise<void>;
-	$invokeTool(dto: IToolInvokation, token: CancellationToken): Promise<IToolResult>;
-	$countTokensForInvokation(callId: string, input: string | IChatMessage, token: CancellationToken): Promise<number>;
+	$invokeTool(dto: IToolInvocation, token: CancellationToken): Promise<IToolResult>;
+	$countTokensForInvocation(callId: string, input: string, token: CancellationToken): Promise<number>;
 }
 
 export interface MainThreadUrlsShape extends IDisposable {

--- a/src/vs/workbench/contrib/chat/common/languageModelToolsService.ts
+++ b/src/vs/workbench/contrib/chat/common/languageModelToolsService.ts
@@ -11,7 +11,6 @@ import { IDisposable, toDisposable } from 'vs/base/common/lifecycle';
 import { ThemeIcon } from 'vs/base/common/themables';
 import { URI } from 'vs/base/common/uri';
 import { createDecorator } from 'vs/platform/instantiation/common/instantiation';
-import { IChatMessage } from 'vs/workbench/contrib/chat/common/languageModels';
 import { IExtensionService } from 'vs/workbench/services/extensions/common/extensions';
 
 export interface IToolData {
@@ -30,7 +29,7 @@ interface IToolEntry {
 	impl?: IToolImpl;
 }
 
-export interface IToolInvokation {
+export interface IToolInvocation {
 	callId: string;
 	toolId: string;
 	parameters: any;
@@ -43,7 +42,7 @@ export interface IToolResult {
 }
 
 export interface IToolImpl {
-	invoke(dto: IToolInvokation, countTokens: CountTokensCallback, token: CancellationToken): Promise<IToolResult>;
+	invoke(dto: IToolInvocation, countTokens: CountTokensCallback, token: CancellationToken): Promise<IToolResult>;
 }
 
 export const ILanguageModelToolsService = createDecorator<ILanguageModelToolsService>('ILanguageModelToolsService');
@@ -53,7 +52,7 @@ export interface IToolDelta {
 	removed?: string;
 }
 
-export type CountTokensCallback = (input: string | IChatMessage, token: CancellationToken) => Promise<number>;
+export type CountTokensCallback = (input: string, token: CancellationToken) => Promise<number>;
 
 export interface ILanguageModelToolsService {
 	_serviceBrand: undefined;
@@ -63,7 +62,7 @@ export interface ILanguageModelToolsService {
 	getTools(): Iterable<Readonly<IToolData>>;
 	getTool(id: string): IToolData | undefined;
 	getToolByName(name: string): IToolData | undefined;
-	invokeTool(dto: IToolInvokation, countTokens: CountTokensCallback, token: CancellationToken): Promise<IToolResult>;
+	invokeTool(dto: IToolInvocation, countTokens: CountTokensCallback, token: CancellationToken): Promise<IToolResult>;
 }
 
 export class LanguageModelToolsService implements ILanguageModelToolsService {
@@ -127,7 +126,7 @@ export class LanguageModelToolsService implements ILanguageModelToolsService {
 		return undefined;
 	}
 
-	async invokeTool(dto: IToolInvokation, countTokens: CountTokensCallback, token: CancellationToken): Promise<IToolResult> {
+	async invokeTool(dto: IToolInvocation, countTokens: CountTokensCallback, token: CancellationToken): Promise<IToolResult> {
 		let tool = this._tools.get(dto.toolId);
 		if (!tool) {
 			throw new Error(`Tool ${dto.toolId} was not contributed`);

--- a/src/vs/workbench/contrib/chat/test/common/mockLanguageModelToolsService.ts
+++ b/src/vs/workbench/contrib/chat/test/common/mockLanguageModelToolsService.ts
@@ -6,7 +6,7 @@
 import { CancellationToken } from 'vs/base/common/cancellation';
 import { Event } from 'vs/base/common/event';
 import { Disposable, IDisposable } from 'vs/base/common/lifecycle';
-import { CountTokensCallback, ILanguageModelToolsService, IToolData, IToolDelta, IToolImpl, IToolInvokation, IToolResult } from 'vs/workbench/contrib/chat/common/languageModelToolsService';
+import { CountTokensCallback, ILanguageModelToolsService, IToolData, IToolDelta, IToolImpl, IToolInvocation, IToolResult } from 'vs/workbench/contrib/chat/common/languageModelToolsService';
 
 export class MockLanguageModelToolsService implements ILanguageModelToolsService {
 	_serviceBrand: undefined;
@@ -35,7 +35,7 @@ export class MockLanguageModelToolsService implements ILanguageModelToolsService
 		return undefined;
 	}
 
-	async invokeTool(dto: IToolInvokation, countTokens: CountTokensCallback, token: CancellationToken): Promise<IToolResult> {
+	async invokeTool(dto: IToolInvocation, countTokens: CountTokensCallback, token: CancellationToken): Promise<IToolResult> {
 		return {
 			string: ''
 		};

--- a/src/vscode-dts/vscode.proposed.lmTools.d.ts
+++ b/src/vscode-dts/vscode.proposed.lmTools.d.ts
@@ -91,10 +91,10 @@ declare module 'vscode' {
 		 * Invoke a tool with the given parameters.
 		 * TODO@API Could request a set of contentTypes to be returned so they don't all need to be computed?
 		 */
-		export function invokeTool(id: string, options: LanguageModelToolInvokationOptions, token: CancellationToken): Thenable<LanguageModelToolResult>;
+		export function invokeTool(id: string, options: LanguageModelToolInvocationOptions, token: CancellationToken): Thenable<LanguageModelToolResult>;
 	}
 
-	export interface LanguageModelToolInvokationOptions {
+	export interface LanguageModelToolInvocationOptions {
 		/**
 		 * Parameters with which to invoke the tool.
 		 */
@@ -111,11 +111,11 @@ declare module 'vscode' {
 
 			/**
 			 * Count the number of tokens in a message using the model specific tokenizer-logic.
-			 * @param text A string or a message instance.
+			 * @param text A string.
 			 * @param token Optional cancellation token.  See {@link CancellationTokenSource} for how to create one.
 			 * @returns A thenable that resolves to the number of tokens.
 			 */
-			countTokens(text: string | LanguageModelChatMessage, token?: CancellationToken): Thenable<number>;
+			countTokens(text: string, token?: CancellationToken): Thenable<number>;
 		};
 	}
 
@@ -145,7 +145,7 @@ declare module 'vscode' {
 
 	export interface LanguageModelTool {
 		// TODO@API should it be LanguageModelToolResult | string?
-		invoke(options: LanguageModelToolInvokationOptions, token: CancellationToken): Thenable<LanguageModelToolResult>;
+		invoke(options: LanguageModelToolInvocationOptions, token: CancellationToken): Thenable<LanguageModelToolResult>;
 	}
 
 	export interface ChatLanguageModelToolReference {


### PR DESCRIPTION
- Have `countTokens` only take a string for now, since that's all that
  tool elements in tsx should currently omit (not chat messages with
  roles.) String counting is a much easier interface to satisfy.
- Joyce pointed out that it's "invocation" not "invokation", for reasons
  unfathomable to me. I will open an issue with the English language.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
