### PR TITLE
make preview options non optional

### DIFF
--- a/src/vs/workbench/services/search/common/search.ts
+++ b/src/vs/workbench/services/search/common/search.ts
@@ -853,3 +853,8 @@ export function excludeToGlobPattern(excludesForFolder: { baseUri?: URI | undefi
 			} : pattern;
 	}));
 }
+
+export const DEFAULT_TEXT_SEARCH_PREVIEW_OPTIONS = {
+	matchLines: 100,
+	charsPerLine: 10000
+};

--- a/src/vs/workbench/services/search/common/searchExtConversionTypes.ts
+++ b/src/vs/workbench/services/search/common/searchExtConversionTypes.ts
@@ -12,6 +12,7 @@ import { asArray, coalesce } from 'vs/base/common/arrays';
 import { CancellationToken } from 'vs/base/common/cancellation';
 import { URI } from 'vs/base/common/uri';
 import { IProgress } from 'vs/platform/progress/common/progress';
+import { DEFAULT_TEXT_SEARCH_PREVIEW_OPTIONS } from 'vs/workbench/services/search/common/search';
 import { Range, FileSearchProviderNew, FileSearchProviderOptions, ProviderResult, TextSearchCompleteNew, TextSearchContextNew, TextSearchMatchNew, TextSearchProviderNew, TextSearchProviderOptions, TextSearchQueryNew, TextSearchResultNew, AITextSearchProviderNew, TextSearchCompleteMessage } from 'vs/workbench/services/search/common/searchExtTypes';
 
 // old types that are retained for backward compatibility
@@ -504,13 +505,10 @@ export function newToOldPreviewOptions(options: {
 ): {
 	matchLines: number;
 	charsPerLine: number;
-} | undefined {
-	if (!options || (options.matchLines === undefined && options.charsPerLine === undefined)) {
-		return undefined;
-	}
+} {
 	return {
-		matchLines: options.matchLines ?? 100,
-		charsPerLine: options.charsPerLine ?? 10000
+		matchLines: options?.matchLines ?? DEFAULT_TEXT_SEARCH_PREVIEW_OPTIONS.matchLines,
+		charsPerLine: options?.charsPerLine ?? DEFAULT_TEXT_SEARCH_PREVIEW_OPTIONS.charsPerLine
 	};
 }
 

--- a/src/vs/workbench/services/search/common/searchExtTypes.ts
+++ b/src/vs/workbench/services/search/common/searchExtTypes.ts
@@ -183,25 +183,25 @@ export interface TextSearchProviderOptions {
 	/**
 	 * Options to specify the size of the result text preview.
 	 */
-	previewOptions?: {
+	previewOptions: {
 		/**
 		 * The maximum number of lines in the preview.
 		 * Only search providers that support multiline search will ever return more than one line in the match.
 		 * Defaults to 100.
 		 */
-		matchLines?: number;
+		matchLines: number;
 
 		/**
 		 * The maximum number of characters included per line.
 		 * Defaults to 10000.
 		 */
-		charsPerLine?: number;
+		charsPerLine: number;
 	};
 
 	/**
 	 * Exclude files larger than `maxFileSize` in bytes.
 	 */
-	maxFileSize?: number;
+	maxFileSize: number | undefined;
 
 
 	/**

--- a/src/vs/workbench/services/search/common/textSearchManager.ts
+++ b/src/vs/workbench/services/search/common/textSearchManager.ts
@@ -11,7 +11,7 @@ import * as path from 'vs/base/common/path';
 import * as resources from 'vs/base/common/resources';
 import { TernarySearchTree } from 'vs/base/common/ternarySearchTree';
 import { URI } from 'vs/base/common/uri';
-import { DEFAULT_MAX_SEARCH_RESULTS, hasSiblingPromiseFn, IAITextQuery, IExtendedExtensionSearchOptions, IFileMatch, IFolderQuery, excludeToGlobPattern, IPatternInfo, ISearchCompleteStats, ITextQuery, ITextSearchContext, ITextSearchMatch, ITextSearchResult, ITextSearchStats, QueryGlobTester, QueryType, resolvePatternsForProvider, ISearchRange } from 'vs/workbench/services/search/common/search';
+import { DEFAULT_MAX_SEARCH_RESULTS, hasSiblingPromiseFn, IAITextQuery, IExtendedExtensionSearchOptions, IFileMatch, IFolderQuery, excludeToGlobPattern, IPatternInfo, ISearchCompleteStats, ITextQuery, ITextSearchContext, ITextSearchMatch, ITextSearchResult, ITextSearchStats, QueryGlobTester, QueryType, resolvePatternsForProvider, ISearchRange, DEFAULT_TEXT_SEARCH_PREVIEW_OPTIONS } from 'vs/workbench/services/search/common/search';
 import { AITextSearchProviderNew, TextSearchCompleteNew, TextSearchMatchNew, TextSearchProviderFolderOptions, TextSearchProviderNew, TextSearchProviderOptions, TextSearchQueryNew, TextSearchResultNew } from 'vs/workbench/services/search/common/searchExtTypes';
 
 export interface IFileUtils {
@@ -162,7 +162,7 @@ export class TextSearchManager {
 			folderOptions,
 			maxFileSize: this.query.maxFileSize,
 			maxResults: this.query.maxResults ?? DEFAULT_MAX_SEARCH_RESULTS,
-			previewOptions: this.query.previewOptions,
+			previewOptions: this.query.previewOptions ?? DEFAULT_TEXT_SEARCH_PREVIEW_OPTIONS,
 			surroundingContext: this.query.surroundingContext ?? 0,
 		};
 		if ('usePCRE2' in this.query) {

--- a/src/vs/workbench/services/search/node/ripgrepTextSearchEngine.ts
+++ b/src/vs/workbench/services/search/node/ripgrepTextSearchEngine.ts
@@ -209,7 +209,7 @@ export class RipgrepParser extends EventEmitter {
 
 	private numResults = 0;
 
-	constructor(private maxResults: number, private root: URI, private previewOptions?: ITextSearchPreviewOptions) {
+	constructor(private maxResults: number, private root: URI, private previewOptions: ITextSearchPreviewOptions) {
 		super();
 		this.stringDecoder = new StringDecoder();
 	}

--- a/src/vs/workbench/services/search/test/node/ripgrepTextSearchEngineUtils.test.ts
+++ b/src/vs/workbench/services/search/test/node/ripgrepTextSearchEngineUtils.test.ts
@@ -10,6 +10,7 @@ import { fixRegexNewline, IRgMatch, IRgMessage, RipgrepParser, unicodeEscapesToP
 import { Range, TextSearchMatchNew, TextSearchQueryNew, TextSearchResultNew } from 'vs/workbench/services/search/common/searchExtTypes';
 import { ensureNoDisposablesAreLeakedInTestSuite } from 'vs/base/test/common/utils';
 import { RipgrepTextSearchOptions } from 'vs/workbench/services/search/common/searchExtTypesInternal';
+import { DEFAULT_TEXT_SEARCH_PREVIEW_OPTIONS } from 'vs/workbench/services/search/common/search';
 
 suite('RipgrepTextSearchEngine', () => {
 	ensureNoDisposablesAreLeakedInTestSuite();
@@ -106,7 +107,7 @@ suite('RipgrepTextSearchEngine', () => {
 		const TEST_FOLDER = URI.file('/foo/bar');
 
 		function testParser(inputData: string[], expectedResults: TextSearchResultNew[]): void {
-			const testParser = new RipgrepParser(1000, TEST_FOLDER);
+			const testParser = new RipgrepParser(1000, TEST_FOLDER, DEFAULT_TEXT_SEARCH_PREVIEW_OPTIONS);
 
 			const actualResults: TextSearchResultNew[] = [];
 			testParser.on('result', r => {

--- a/src/vscode-dts/vscode.proposed.textSearchProviderNew.d.ts
+++ b/src/vscode-dts/vscode.proposed.textSearchProviderNew.d.ts
@@ -113,25 +113,25 @@ declare module 'vscode' {
 		/**
 		 * Options to specify the size of the result text preview.
 		 */
-		previewOptions?: {
+		previewOptions: {
 			/**
 			 * The maximum number of lines in the preview.
 			 * Only search providers that support multiline search will ever return more than one line in the match.
-			 * Defaults to 100 in the default ripgrep search provider, but extension-contributed providers can enforce their own default.
+			 * Defaults to 100.
 			 */
-			matchLines?: number;
+			matchLines: number;
 
 			/**
 			 * The maximum number of characters included per line.
-			 * Defaults to 10000 in the default ripgrep search provider, but extension-contributed providers can enforce their own default.
+			 * Defaults to 10000.
 			 */
-			charsPerLine?: number;
+			charsPerLine: number;
 		};
 
 		/**
 		 * Exclude files larger than `maxFileSize` in bytes.
 		 */
-		maxFileSize?: number;
+		maxFileSize: number | undefined;
 
 		/**
 		 * Number of lines of context to include before and after each match.


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
For text search provider, remove optional args. Instead, make previewOptions defined and maxFileSize can be undefined (this is because we currently don't enforce a max file size with ripgrep)