### PR TITLE
Turns on asyncTokenization by default. Fixes #225794

### DIFF
--- a/src/vs/editor/common/config/editorConfigurationSchema.ts
+++ b/src/vs/editor/common/config/editorConfigurationSchema.ts
@@ -94,7 +94,7 @@ const editorConfiguration: IConfigurationNode = {
 		},
 		'editor.experimental.asyncTokenization': {
 			type: 'boolean',
-			default: false,
+			default: true,
 			description: nls.localize('editor.experimental.asyncTokenization', "Controls whether the tokenization should happen asynchronously on a web worker."),
 			tags: ['experimental'],
 		},


### PR DESCRIPTION
Fixes #225794

(See https://exp.microsoft.com/a/feature/229db5b0-4e1e-4aea-9bd7-eba106e4c1b7?workspaceId=dbd12384-5001-4e90-a863-526321eaf233&group=/vscodeexpws)