### PR TITLE
fix `problemMatcher` bug

### DIFF
--- a/src/vs/workbench/api/common/extHostTask.ts
+++ b/src/vs/workbench/api/common/extHostTask.ts
@@ -279,7 +279,7 @@ export namespace TaskDTO {
 			isBackground: value.isBackground,
 			group: TaskGroupDTO.from(value.group as vscode.TaskGroup),
 			presentationOptions: TaskPresentationOptionsDTO.from(value.presentationOptions),
-			problemMatchers: value.problemMatchers ? Array.isArray(value.problemMatchers) ? value.problemMatchers : [value.problemMatchers] : [],
+			problemMatchers: value.problemMatchers && Array.isArray(value.problemMatchers) ? value.problemMatchers : value.problemMatchers ? [value.problemMatchers] : [],
 			hasDefinedMatchers: (value as types.Task).hasDefinedMatchers,
 			runOptions: value.runOptions ? value.runOptions : { reevaluateOnRerun: true },
 			detail: value.detail

--- a/src/vs/workbench/api/common/extHostTask.ts
+++ b/src/vs/workbench/api/common/extHostTask.ts
@@ -279,7 +279,7 @@ export namespace TaskDTO {
 			isBackground: value.isBackground,
 			group: TaskGroupDTO.from(value.group as vscode.TaskGroup),
 			presentationOptions: TaskPresentationOptionsDTO.from(value.presentationOptions),
-			problemMatchers: value.problemMatchers && Array.isArray(value.problemMatchers) ? value.problemMatchers : value.problemMatchers ? [value.problemMatchers] : [],
+			problemMatchers: asArray(value.problemMatchers),
 			hasDefinedMatchers: (value as types.Task).hasDefinedMatchers,
 			runOptions: value.runOptions ? value.runOptions : { reevaluateOnRerun: true },
 			detail: value.detail
@@ -793,3 +793,13 @@ export class WorkerExtHostTask extends ExtHostTaskBase {
 }
 
 export const IExtHostTask = createDecorator<IExtHostTask>('IExtHostTask');
+
+function asArray(value: string | string[] | undefined): string[] {
+	if (value === undefined) {
+		return [];
+	}
+	if (Array.isArray(value)) {
+		return value;
+	}
+	return [value];
+}

--- a/src/vs/workbench/api/common/extHostTask.ts
+++ b/src/vs/workbench/api/common/extHostTask.ts
@@ -279,7 +279,7 @@ export namespace TaskDTO {
 			isBackground: value.isBackground,
 			group: TaskGroupDTO.from(value.group as vscode.TaskGroup),
 			presentationOptions: TaskPresentationOptionsDTO.from(value.presentationOptions),
-			problemMatchers: value.problemMatchers,
+			problemMatchers: value.problemMatchers ? Array.isArray(value.problemMatchers) ? value.problemMatchers : [value.problemMatchers] : [],
 			hasDefinedMatchers: (value as types.Task).hasDefinedMatchers,
 			runOptions: value.runOptions ? value.runOptions : { reevaluateOnRerun: true },
 			detail: value.detail

--- a/src/vscode-dts/vscode.d.ts
+++ b/src/vscode-dts/vscode.d.ts
@@ -8800,7 +8800,7 @@ declare module 'vscode' {
 		 * The problem matchers attached to the task. Defaults to an empty
 		 * array.
 		 */
-		problemMatchers: string | string[];
+		problemMatchers: string[];
 
 		/**
 		 * Run options for the task

--- a/src/vscode-dts/vscode.d.ts
+++ b/src/vscode-dts/vscode.d.ts
@@ -8800,7 +8800,7 @@ declare module 'vscode' {
 		 * The problem matchers attached to the task. Defaults to an empty
 		 * array.
 		 */
-		problemMatchers: string[];
+		problemMatchers: string | string[];
 
 		/**
 		 * Run options for the task


### PR DESCRIPTION
Fixes #225826

We define problem matchers as `string | string[]` here https://github.com/microsoft/vscode/blob/64c211389b557bb7a0cdd6130c03e737b35a09f9/src/vscode-dts/vscode.d.ts#L8731

But we define them here as `string []`
https://github.com/microsoft/vscode/blob/a0933df3cca6fbbf2936313fa01685df7fe40a99/src/vscode-dts/vscode.d.ts#L8803

Since consumers of the API might pass in a `string`, we need to handle that.

validated the fix here https://github.com/microsoft/vscode/issues/225826#issuecomment-2305998838