### PR TITLE
remove overrides of getActionsContext on viewpanecontainer

### DIFF
--- a/src/vs/workbench/browser/parts/views/viewPaneContainer.ts
+++ b/src/vs/workbench/browser/parts/views/viewPaneContainer.ts
@@ -593,6 +593,9 @@ export class ViewPaneContainer extends Component implements IViewPaneContainer {
 	}
 
 	getActionsContext(): unknown {
+		if (this.isViewMergedWithContainer()) {
+			return this.panes[0].getActionsContext();
+		}
 		return undefined;
 	}
 

--- a/src/vs/workbench/contrib/scm/browser/scmViewPaneContainer.ts
+++ b/src/vs/workbench/contrib/scm/browser/scmViewPaneContainer.ts
@@ -6,7 +6,7 @@
 import 'vs/css!./media/scm';
 import { localize } from 'vs/nls';
 import { ITelemetryService } from 'vs/platform/telemetry/common/telemetry';
-import { ISCMViewService, VIEWLET_ID } from 'vs/workbench/contrib/scm/common/scm';
+import { VIEWLET_ID } from 'vs/workbench/contrib/scm/common/scm';
 import { IInstantiationService } from 'vs/platform/instantiation/common/instantiation';
 import { IContextMenuService } from 'vs/platform/contextview/browser/contextView';
 import { IThemeService } from 'vs/platform/theme/common/themeService';
@@ -21,7 +21,6 @@ import { ViewPaneContainer } from 'vs/workbench/browser/parts/views/viewPaneCont
 export class SCMViewPaneContainer extends ViewPaneContainer {
 
 	constructor(
-		@ISCMViewService private readonly scmViewService: ISCMViewService,
 		@IWorkbenchLayoutService layoutService: IWorkbenchLayoutService,
 		@ITelemetryService telemetryService: ITelemetryService,
 		@IInstantiationService instantiationService: IInstantiationService,
@@ -47,10 +46,6 @@ export class SCMViewPaneContainer extends ViewPaneContainer {
 
 	override getTitle(): string {
 		return localize('source control', "Source Control");
-	}
-
-	override getActionsContext(): unknown {
-		return this.scmViewService.visibleRepositories.length === 1 ? this.scmViewService.visibleRepositories[0].provider : undefined;
 	}
 
 }


### PR DESCRIPTION
Fixes an issue where a single view title toolbar is being displayed in the view pane container toolbar area and the context is undefined.

Motivation for this change:
- View Pane Containers cannot really have an identity that contains toolbar actions and context with moveable views. They act purely as pre-defined containers for a specific set of views, but the user can change that. Actions and context should be tied to the views.
- The only use case of defining a context in the view pane container was SCM. The same context was defined on the SCM view which will get set properly now if it is being merged with the container as well as if it is moved to a different container.

Run/Debug is still a rule breaker here by having actions, but it doesn't use the context.