### PR TITLE
Support preserving focused elements in list view.

### DIFF
--- a/src/vs/base/browser/ui/list/listWidget.ts
+++ b/src/vs/base/browser/ui/list/listWidget.ts
@@ -1038,6 +1038,7 @@ export interface IListOptionsUpdate extends IListViewOptionsUpdate {
 	readonly typeNavigationEnabled?: boolean;
 	readonly typeNavigationMode?: TypeNavigationMode;
 	readonly multipleSelectionSupport?: boolean;
+	readonly enablePreserveElements?: boolean;
 }
 
 export interface IListOptions<T> extends IListOptionsUpdate {
@@ -1067,6 +1068,7 @@ export interface IListOptions<T> extends IListOptionsUpdate {
 	readonly initialSize?: Dimension;
 	readonly paddingTop?: number;
 	readonly paddingBottom?: number;
+	readonly enablePreserveElements?: boolean;
 }
 
 export interface IListStyles {
@@ -1143,7 +1145,8 @@ const DefaultOptions: IListOptions<any> = {
 		onDragOver() { return false; },
 		drop() { },
 		dispose() { }
-	}
+	},
+	enablePreserveElements: false
 };
 
 // TODO@Joao: move these utils into a SortedArray class
@@ -1389,6 +1392,7 @@ export class List<T> implements ISpliceable<T>, IDisposable {
 	private keyboardController: KeyboardController<T> | undefined;
 	private mouseController: MouseController<T>;
 	private _ariaLabel: string = '';
+	private enablePreserveElements: boolean;
 
 	protected readonly disposables = new DisposableStore();
 
@@ -1537,6 +1541,8 @@ export class List<T> implements ISpliceable<T>, IDisposable {
 		if (this._options.multipleSelectionSupport !== false) {
 			this.view.domNode.setAttribute('aria-multiselectable', 'true');
 		}
+
+		this.enablePreserveElements = _options.enablePreserveElements ?? DefaultOptions.enablePreserveElements ?? false;
 	}
 
 	protected createListView(container: HTMLElement, virtualDelegate: IListVirtualDelegate<T>, renderers: IListRenderer<any, any>[], viewOptions: IListViewOptions<T>): IListView<T> {
@@ -1563,6 +1569,10 @@ export class List<T> implements ISpliceable<T>, IDisposable {
 		this.mouseController.updateOptions(optionsUpdate);
 		this.keyboardController?.updateOptions(optionsUpdate);
 		this.view.updateOptions(optionsUpdate);
+
+		if (optionsUpdate.enablePreserveElements !== undefined) {
+			this.enablePreserveElements = optionsUpdate.enablePreserveElements;
+		}
 	}
 
 	get options(): IListOptions<T> {
@@ -1734,6 +1744,10 @@ export class List<T> implements ISpliceable<T>, IDisposable {
 		}
 
 		this.focus.set(indexes, browserEvent);
+
+		if (this.enablePreserveElements) {
+			this.view.preserveElements(indexes);
+		}
 	}
 
 	focusNext(n = 1, loop = false, browserEvent?: UIEvent, filter?: (element: T) => boolean): void {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

An experiment for preserving focused element always in the list view even if it's scrolled out of the viewport so it won't be discarded and losing states (e.g., users have focus in an input box).
