### PR TITLE
3 Changes to MSAL auth

### DIFF
--- a/extensions/microsoft-authentication/src/node/authProvider.ts
+++ b/extensions/microsoft-authentication/src/node/authProvider.ts
@@ -172,6 +172,7 @@ export class MsalAuthProvider implements AuthenticationProvider {
 		const session = this.toAuthenticationSession(result, scopeData.originalScopes);
 		this._telemetryReporter.sendLoginEvent(session.scopes);
 		this._logger.info('[createSession]', scopeData.scopeStr, 'returned session');
+		this._onDidChangeSessionsEmitter.fire({ added: [session], changed: [], removed: [] });
 		return session;
 	}
 


### PR DESCRIPTION
* Remove access token refreshing logic.
  * The calling pattern for an extension is that they should just always call `getSession` before doing something with it... and when they _call_ `getSession`, we call MSAL and MSAL will auto-refresh access tokens if they are expired or near expiry using the refresh tokens which have a much longer lifetime (access tokens expire after 1hr. Refresh tokens expire after 90 days).
* Have `createSession` fire an `onDidChangeSession` event so that the badge goes away if we are following the badge flow
* Improved logging messages

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fixes https://github.com/microsoft/vscode/issues/226488
ref https://github.com/microsoft/vscode/issues/229415