### PR TITLE
improve & move debug console info up in help dialog

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/runAndDebugAccessibilityHelp.ts
+++ b/src/vs/workbench/contrib/debug/browser/runAndDebugAccessibilityHelp.ts
@@ -70,7 +70,7 @@ class RunAndDebugAccessibilityHelpProvider extends Disposable implements IAccess
 		return [
 			localize('debug.showRunAndDebug', "The Show Run and Debug view command{0} will open the current view.", '<keybinding:workbench.view.debug>'),
 			localize('debug.startDebugging', "The Debug: Start Debugging command{0} will start a debug session.", '<keybinding:workbench.action.debug.start>'),
-			localize('debug.help', "The debug console is a Read-Eval-Print-Loop that allows you to evaluate expressions and run commands and can be focused with{0}.", '<keybinding:workbench.panel.repl.view.focus>'),
+			localize('debug.help', "Access debug output and evaluate expressions in the debug console, which can be focused with{0}.", '<keybinding:workbench.panel.repl.view.focus>'),
 			AccessibilityHelpNLS.setBreakpoint,
 			AccessibilityHelpNLS.addToWatch,
 			localize('onceDebugging', "Once debugging, the following commands will be available:"),

--- a/src/vs/workbench/contrib/debug/browser/runAndDebugAccessibilityHelp.ts
+++ b/src/vs/workbench/contrib/debug/browser/runAndDebugAccessibilityHelp.ts
@@ -70,6 +70,7 @@ class RunAndDebugAccessibilityHelpProvider extends Disposable implements IAccess
 		return [
 			localize('debug.showRunAndDebug', "The Show Run and Debug view command{0} will open the current view.", '<keybinding:workbench.view.debug>'),
 			localize('debug.startDebugging', "The Debug: Start Debugging command{0} will start a debug session.", '<keybinding:workbench.action.debug.start>'),
+			localize('debug.help', "The debug console is a Read-Eval-Print-Loop that allows you to evaluate expressions and run commands and can be focused with{0}.", '<keybinding:workbench.panel.repl.view.focus>'),
 			AccessibilityHelpNLS.setBreakpoint,
 			AccessibilityHelpNLS.addToWatch,
 			localize('onceDebugging', "Once debugging, the following commands will be available:"),
@@ -84,7 +85,6 @@ class RunAndDebugAccessibilityHelpProvider extends Disposable implements IAccess
 			localize('debug.focusCallStack', "- Debug: Focus Call Stack View command{0} will focus the call stack view.", '<keybinding:workbench.debug.action.focusCallStackView>'),
 			localize('debug.focusVariables', "- Debug: Focus Variables View command{0} will focus the variables view.", '<keybinding:workbench.debug.action.focusVariablesView>'),
 			localize('debug.focusWatch', "- Debug: Focus Watch View command{0} will focus the watch view.", '<keybinding:workbench.debug.action.focusWatchView>'),
-			localize('debug.help', "The debug console is a Read-Eval-Print-Loop that allows you to evaluate expressions and run commands and can be focused with{0}.", '<keybinding:workbench.panel.repl.view.focus>'),
 			localize('debug.watchSetting', "The setting {0} controls whether watch variable changes are announced.", 'accessibility.debugWatchVariableAnnouncements'),
 		].join('\n');
 	}


### PR DESCRIPTION
We got feedback via the applause survey that SR users aren't sure how to access debug console output. 