### PR TITLE
Closed notebook search blocks text search

### DIFF
--- a/src/vs/workbench/contrib/search/browser/notebookSearch/notebookSearchService.ts
+++ b/src/vs/workbench/contrib/search/browser/notebookSearch/notebookSearchService.ts
@@ -117,22 +117,21 @@ export class NotebookSearchService implements INotebookSearchService {
 	}
 
 	private async doesFileExist(includes: string[], folderQueries: IFolderQuery<URI>[], token: CancellationToken): Promise<boolean> {
-		const promises: Promise<void>[] = includes.map(async includePattern => {
+		const promises: Promise<boolean>[] = includes.map(async includePattern => {
 			const query = this.queryBuilder.file(folderQueries.map(e => e.folder), {
 				includePattern: includePattern.startsWith('/') ? includePattern : '**/' + includePattern, // todo: find cleaner way to ensure that globs match all appropriate filetypes
-				exists: true
+				exists: true,
+				onlyFileScheme: true,
 			});
 			return this.searchService.fileSearch(
 				query,
 				token
 			).then((ret) => {
-				if (!ret.limitHit) {
-					throw Error('File not found');
-				}
+				return !!ret.limitHit;
 			});
 		});
 
-		return Promise.any(promises).then(() => true).catch(() => false);
+		return Promise.any(promises);
 	}
 
 	private async getClosedNotebookResults(textQuery: ITextQuery, scannedFiles: ResourceSet, token: CancellationToken): Promise<IClosedNotebookSearchResults> {

--- a/src/vs/workbench/services/search/common/queryBuilder.ts
+++ b/src/vs/workbench/services/search/common/queryBuilder.ts
@@ -92,6 +92,7 @@ interface ICommonQueryBuilderOptions {
 	disregardSearchExcludeSettings?: boolean;
 	ignoreSymlinks?: boolean;
 	onlyOpenEditors?: boolean;
+	onlyFileScheme?: boolean;
 }
 
 export interface IFileQueryBuilderOptions extends ICommonQueryBuilderOptions {
@@ -259,7 +260,8 @@ export class QueryBuilder {
 			excludePattern: excludeSearchPathsInfo.pattern,
 			includePattern: includeSearchPathsInfo.pattern,
 			onlyOpenEditors: options.onlyOpenEditors,
-			maxResults: options.maxResults
+			maxResults: options.maxResults,
+			onlyFileScheme: options.onlyFileScheme
 		};
 
 		if (options.onlyOpenEditors) {

--- a/src/vs/workbench/services/search/common/search.ts
+++ b/src/vs/workbench/services/search/common/search.ts
@@ -100,6 +100,7 @@ export interface ICommonQueryProps<U extends UriComponents> {
 
 	maxResults?: number;
 	usingSearchPaths?: boolean;
+	onlyFileScheme?: boolean;
 }
 
 export interface IFileQueryProps<U extends UriComponents> extends ICommonQueryProps<U> {

--- a/src/vs/workbench/services/search/common/searchService.ts
+++ b/src/vs/workbench/services/search/common/searchService.ts
@@ -271,6 +271,9 @@ export class SearchService extends Disposable implements ISearchService {
 			return [];
 		}
 		await Promise.all([...fqs.keys()].map(async scheme => {
+			if (query.onlyFileScheme && scheme !== Schemas.file) {
+				return;
+			}
 			const schemeFQs = fqs.get(scheme)!;
 			let provider = this.getSearchProvider(query.type).get(scheme);
 


### PR DESCRIPTION
Fixes #226859

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
Added a parameter so that notebook search only happens on the default file scheme. That brings up the question of how we'll deal with extensions that use the findfiles API, but there are non-default schemes active in one of the roots. This should unblock the notebook search case though