### PR TITLE
fixing issue 226923: openning block comments more than closing comments cause sql …

### DIFF
--- a/extensions/sql/syntaxes/sql.tmLanguage.json
+++ b/extensions/sql/syntaxes/sql.tmLanguage.json
@@ -436,12 +436,7 @@
 				}
 			},
 			"end": "\\*/",
-			"name": "comment.block",
-			"patterns": [
-				{
-					"include": "#comment-block"
-				}
-			]
+			"name": "comment.block"
 		},
 		"regexps": {
 			"patterns": [


### PR DESCRIPTION
…sytnax error

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
There is one error of VSCode SQL syntax higlight, for example to open editor to chose sql syntax for below code 
``` use users;
/*
Here is level 1 comments
/* herere is level 2 comments

-- even more comments

*/

Select * from departs;
```
Here is the VSCode screenshot with incorrect SQL synatx
![2024-08-28 14_30_40-test_embeded_sql_script sql - vscode - Visual Studio Code](https://github.com/user-attachments/assets/b267c5c9-ff00-468f-b98c-d7bf168c8ec5)

