### PR TITLE
Fix Bash integration clobbering `$?` for PROMPT_COMMAND

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/media/shellIntegration-bash.sh
+++ b/src/vs/workbench/contrib/terminal/browser/media/shellIntegration-bash.sh
@@ -328,10 +328,10 @@ __vsc_restore_exit_code() {
 
 __vsc_prompt_cmd_original() {
 	__vsc_status="$?"
+	builtin local cmd
 	__vsc_restore_exit_code "${__vsc_status}"
 	# Evaluate the original PROMPT_COMMAND similarly to how bash would normally
 	# See https://unix.stackexchange.com/a/672843 for technique
-	builtin local cmd
 	for cmd in "${__vsc_original_prompt_command[@]}"; do
 		eval "${cmd:-}"
 	done


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fixes #221393, https://github.com/ohmybash/oh-my-bash/issues/595

### Problem

The exit status `$?` that the first command of `PROMPT_COMMAND` sees is broken by VSCode's Bash integration. It becomes always 0 (success) even when the previous command fails. This becomes a problem for a hook in `PROMPT_COMMAND` that updates the prompt content `PS1` based on the previous exit status. For example, this affects hooks that make the prompt green/red when the previous command succeeds/fails.

### Cause

This problem was introduced by PR #208364. The exit status is supposed to be restored by the line `__vsc_restore_exit_code "${__vsc_status}"`, but the culprit PR inserted `local cmd` after restoring the exit code. Then, `local cmd` again overwrites the exit status to 0, which `PROMPT_COMMAND` sees.

### Solution

The line `local cmd` should be performed before restoring the exit status.
