### PR TITLE
Use instant hover for Radio buttons

### DIFF
--- a/src/vs/base/browser/ui/radio/radio.ts
+++ b/src/vs/base/browser/ui/radio/radio.ts
@@ -11,7 +11,7 @@ import { $ } from 'vs/base/browser/dom';
 import { IHoverDelegate } from 'vs/base/browser/ui/hover/hoverDelegate';
 import { Button } from 'vs/base/browser/ui/button/button';
 import { DisposableMap, DisposableStore } from 'vs/base/common/lifecycle';
-import { getDefaultHoverDelegate } from 'vs/base/browser/ui/hover/hoverDelegateFactory';
+import { createInstantHoverDelegate } from 'vs/base/browser/ui/hover/hoverDelegateFactory';
 
 export interface IRadioStyles {
 	readonly activeForeground?: string;
@@ -53,7 +53,7 @@ export class Radio extends Widget {
 	constructor(opts: IRadioOptions) {
 		super();
 
-		this.hoverDelegate = opts.hoverDelegate ?? getDefaultHoverDelegate('element');
+		this.hoverDelegate = opts.hoverDelegate ?? this._register(createInstantHoverDelegate());
 
 		this.domNode = $('.monaco-custom-radio');
 		this.domNode.setAttribute('role', 'radio');


### PR DESCRIPTION
Aligning the Radio Buttons Hover with the hover behaviour we have with other types of buttons and toolbars.

![Code_-_OSS_1bo1Gmdti2](https://github.com/user-attachments/assets/f144f039-665a-44c1-a71a-c63c0e357b9a)
