### PR TITLE
Inline chat fixes

### DIFF
--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatController.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatController.ts
@@ -741,7 +741,7 @@ export class InlineChatController implements IEditorContribution {
 		await responsePromise.p;
 		await progressiveEditsQueue.whenIdle();
 
-		if (response.isCanceled) {
+		if (response.result?.errorDetails) {
 			await this._session.undoChangesUntil(response.requestId);
 		}
 
@@ -758,7 +758,6 @@ export class InlineChatController implements IEditorContribution {
 
 		if (response.result?.errorDetails) {
 			//
-			await this._session.undoChangesUntil(response.requestId);
 
 		} else if (response.response.value.length === 0) {
 			// empty -> show message

--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatSession.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatSession.ts
@@ -360,27 +360,30 @@ export class HunkData {
 		// mirror textModelN changes to textModel0 execept for those that
 		// overlap with a hunk
 
-		type HunkRangePair = { rangeN: Range; range0: Range };
+		type HunkRangePair = { rangeN: Range; range0: Range; markAccepted: () => void };
 		const hunkRanges: HunkRangePair[] = [];
 
 		const ranges0: Range[] = [];
 
-		for (const { textModelNDecorations, textModel0Decorations, state } of this._data.values()) {
+		for (const entry of this._data.values()) {
 
-			if (state === HunkState.Pending) {
+			if (entry.state === HunkState.Pending) {
 				// pending means the hunk's changes aren't "sync'd" yet
-				for (let i = 1; i < textModelNDecorations.length; i++) {
-					const rangeN = this._textModelN.getDecorationRange(textModelNDecorations[i]);
-					const range0 = this._textModel0.getDecorationRange(textModel0Decorations[i]);
+				for (let i = 1; i < entry.textModelNDecorations.length; i++) {
+					const rangeN = this._textModelN.getDecorationRange(entry.textModelNDecorations[i]);
+					const range0 = this._textModel0.getDecorationRange(entry.textModel0Decorations[i]);
 					if (rangeN && range0) {
-						hunkRanges.push({ rangeN, range0 });
+						hunkRanges.push({
+							rangeN, range0,
+							markAccepted: () => entry.state = HunkState.Accepted
+						});
 					}
 				}
 
-			} else if (state === HunkState.Accepted) {
+			} else if (entry.state === HunkState.Accepted) {
 				// accepted means the hunk's changes are also in textModel0
-				for (let i = 1; i < textModel0Decorations.length; i++) {
-					const range = this._textModel0.getDecorationRange(textModel0Decorations[i]);
+				for (let i = 1; i < entry.textModel0Decorations.length; i++) {
+					const range = this._textModel0.getDecorationRange(entry.textModel0Decorations[i]);
 					if (range) {
 						ranges0.push(range);
 					}
@@ -399,16 +402,20 @@ export class HunkData {
 
 			let pendingChangesLen = 0;
 
-			for (const { rangeN, range0 } of hunkRanges) {
-				if (rangeN.getEndPosition().isBefore(Range.getStartPosition(change.range))) {
+			for (const entry of hunkRanges) {
+				if (entry.rangeN.getEndPosition().isBefore(Range.getStartPosition(change.range))) {
 					// pending hunk _before_ this change. When projecting into textModel0 we need to
 					// subtract that. Because diffing is relaxed it might include changes that are not
 					// actual insertions/deletions. Therefore we need to take the length of the original
 					// range into account.
-					pendingChangesLen += this._textModelN.getValueLengthInRange(rangeN);
-					pendingChangesLen -= this._textModel0.getValueLengthInRange(range0);
+					pendingChangesLen += this._textModelN.getValueLengthInRange(entry.rangeN);
+					pendingChangesLen -= this._textModel0.getValueLengthInRange(entry.range0);
 
-				} else if (Range.areIntersectingOrTouching(rangeN, change.range)) {
+				} else if (Range.areIntersectingOrTouching(entry.rangeN, change.range)) {
+					// an edit overlaps with a (pending) hunk. We take this as a signal
+					// to mark the hunk as accepted and to ignore the edit. The range of the hunk
+					// will be up-to-date because of decorations created for them
+					entry.markAccepted();
 					isOverlapping = true;
 					break;
 
@@ -447,24 +454,23 @@ export class HunkData {
 
 		diff ??= await this._editorWorkerService.computeDiff(this._textModel0.uri, this._textModelN.uri, { ignoreTrimWhitespace: false, maxComputationTimeMs: Number.MAX_SAFE_INTEGER, computeMoves: false }, 'advanced');
 
-		if (!diff || diff.changes.length === 0) {
-			// return new HunkData([], session);
-			return;
-		}
+		let mergedChanges: DetailedLineRangeMapping[] = [];
 
-		// merge changes neighboring changes
-		const mergedChanges = [diff.changes[0]];
-		for (let i = 1; i < diff.changes.length; i++) {
-			const lastChange = mergedChanges[mergedChanges.length - 1];
-			const thisChange = diff.changes[i];
-			if (thisChange.modified.startLineNumber - lastChange.modified.endLineNumberExclusive <= HunkData._HUNK_THRESHOLD) {
-				mergedChanges[mergedChanges.length - 1] = new DetailedLineRangeMapping(
-					lastChange.original.join(thisChange.original),
-					lastChange.modified.join(thisChange.modified),
-					(lastChange.innerChanges ?? []).concat(thisChange.innerChanges ?? [])
-				);
-			} else {
-				mergedChanges.push(thisChange);
+		if (diff && diff.changes.length > 0) {
+			// merge changes neighboring changes
+			mergedChanges = [diff.changes[0]];
+			for (let i = 1; i < diff.changes.length; i++) {
+				const lastChange = mergedChanges[mergedChanges.length - 1];
+				const thisChange = diff.changes[i];
+				if (thisChange.modified.startLineNumber - lastChange.modified.endLineNumberExclusive <= HunkData._HUNK_THRESHOLD) {
+					mergedChanges[mergedChanges.length - 1] = new DetailedLineRangeMapping(
+						lastChange.original.join(thisChange.original),
+						lastChange.modified.join(thisChange.modified),
+						(lastChange.innerChanges ?? []).concat(thisChange.innerChanges ?? [])
+					);
+				} else {
+					mergedChanges.push(thisChange);
+				}
 			}
 		}
 

--- a/src/vs/workbench/contrib/inlineChat/test/browser/__snapshots__/InlineChatSession_Apply_Code_s_preview_should_be_easier_to_undo_esc__7537.1.snap
+++ b/src/vs/workbench/contrib/inlineChat/test/browser/__snapshots__/InlineChatSession_Apply_Code_s_preview_should_be_easier_to_undo_esc__7537.1.snap
@@ -1,0 +1,13 @@
+export function fib(n) {
+	if (n <= 0) return 0;
+	if (n === 1) return 0;
+	if (n === 2) return 1;
+
+	let a = 0, b = 1, c;
+	for (let i = 3; i <= n; i++) {
+		c = a + b;
+		a = b;
+		b = c;
+	}
+	return b;
+}

--- a/src/vs/workbench/contrib/inlineChat/test/browser/__snapshots__/InlineChatSession_Apply_Code_s_preview_should_be_easier_to_undo_esc__7537.2.snap
+++ b/src/vs/workbench/contrib/inlineChat/test/browser/__snapshots__/InlineChatSession_Apply_Code_s_preview_should_be_easier_to_undo_esc__7537.2.snap
@@ -1,0 +1,6 @@
+export function fib(n) {
+	if (n <= 0) return 0;
+	if (n === 1) return 0;
+	if (n === 2) return 1;
+	return fib(n - 1) + fib(n - 2);
+}

--- a/src/vs/workbench/contrib/inlineChat/test/browser/inlineChatController.test.ts
+++ b/src/vs/workbench/contrib/inlineChat/test/browser/inlineChatController.test.ts
@@ -779,7 +779,7 @@ suite('InteractiveChatController', function () {
 
 	});
 
-	test('Stopping/cancelling a request should undo its changes', async function () {
+	test('Stopping/cancelling a request should NOT undo its changes', async function () {
 
 		model.setValue('World');
 
@@ -819,7 +819,7 @@ suite('InteractiveChatController', function () {
 		chatService.cancelCurrentRequestForSession(ctrl.chatWidget.viewModel!.model.sessionId);
 		assert.strictEqual(await p2, undefined);
 
-		assert.strictEqual(model.getValue(), 'World');
+		assert.strictEqual(model.getValue(), 'HelloWorld'); // CANCEL just stops the request and progressive typing but doesn't undo
 
 	});
 

--- a/src/vs/workbench/contrib/inlineChat/test/browser/inlineChatSession.test.ts
+++ b/src/vs/workbench/contrib/inlineChat/test/browser/inlineChatSession.test.ts
@@ -60,6 +60,8 @@ import { IWorkbenchAssignmentService } from 'vs/workbench/services/assignment/co
 import { NullWorkbenchAssignmentService } from 'vs/workbench/services/assignment/test/common/nullAssignmentService';
 import { ILanguageModelToolsService } from 'vs/workbench/contrib/chat/common/languageModelToolsService';
 import { MockLanguageModelToolsService } from 'vs/workbench/contrib/chat/test/common/mockLanguageModelToolsService';
+import { IChatRequestModel } from 'vs/workbench/contrib/chat/common/chatModel';
+import { assertSnapshot } from 'vs/base/test/common/snapshot';
 
 suite('InlineChatSession', function () {
 
@@ -487,4 +489,90 @@ suite('InlineChatSession', function () {
 
 		inlineChatSessionService.releaseSession(session);
 	});
+
+	test('Pressing Escape after inline chat errored with "response filtered" leaves document dirty #7764', async function () {
+
+		const origValue = `class Foo {
+	private onError(error: string): void {
+		if (/The request timed out|The network connection was lost/i.test(error)) {
+			return;
+		}
+
+		error = error.replace(/See https:\/\/github\.com\/Squirrel\/Squirrel\.Mac\/issues\/182 for more information/, 'This might mean the application was put on quarantine by macOS. See [this link](https://github.com/microsoft/vscode/issues/7426#issuecomment-425093469) for more information');
+
+		this.notificationService.notify({
+			severity: Severity.Error,
+			message: error,
+			source: nls.localize('update service', "Update Service"),
+		});
+	}
+}`;
+		model.setValue(origValue);
+
+		const session = await inlineChatSessionService.createSession(editor, { editMode: EditMode.Live }, CancellationToken.None);
+		assertType(session);
+
+		const fakeRequest = new class extends mock<IChatRequestModel>() {
+			override get id() { return 'one'; }
+		};
+		session.markModelVersion(fakeRequest);
+
+		assert.strictEqual(editor.getModel().getLineCount(), 15);
+
+		await makeEditAsAi([EditOperation.replace(new Range(7, 1, 7, Number.MAX_SAFE_INTEGER), `error = error.replace(
+			/See https:\/\/github\.com\/Squirrel\/Squirrel\.Mac\/issues\/182 for more information/,
+			'This might mean the application was put on quarantine by macOS. See [this link](https://github.com/microsoft/vscode/issues/7426#issuecomment-425093469) for more information'
+		);`)]);
+
+		assert.strictEqual(editor.getModel().getLineCount(), 18);
+
+		// called when a response errors out
+		await session.undoChangesUntil(fakeRequest.id);
+		await session.hunkData.recompute({ applied: 0, sha1: 'fakeSha1' }, undefined);
+
+		assert.strictEqual(editor.getModel().getValue(), origValue);
+
+		session.hunkData.discardAll(); // called when dimissing the session
+		assert.strictEqual(editor.getModel().getValue(), origValue);
+	});
+
+	test('Apply Code\'s preview should be easier to undo/esc #7537', async function () {
+		model.setValue(`export function fib(n) {
+	if (n <= 0) return 0;
+	if (n === 1) return 0;
+	if (n === 2) return 1;
+	return fib(n - 1) + fib(n - 2);
+}`);
+		const session = await inlineChatSessionService.createSession(editor, { editMode: EditMode.Live }, CancellationToken.None);
+		assertType(session);
+
+		await makeEditAsAi([EditOperation.replace(new Range(5, 1, 6, Number.MAX_SAFE_INTEGER), `
+	let a = 0, b = 1, c;
+	for (let i = 3; i <= n; i++) {
+		c = a + b;
+		a = b;
+		b = c;
+	}
+	return b;
+}`)]);
+
+		assert.strictEqual(session.hunkData.size, 1);
+		assert.strictEqual(session.hunkData.pending, 1);
+		assert.ok(session.hunkData.getInfo().every(d => d.getState() === HunkState.Pending));
+
+		await assertSnapshot(editor.getModel().getValue(), { name: '1' });
+
+		await model.undo();
+		await assertSnapshot(editor.getModel().getValue(), { name: '2' });
+
+		// overlapping edits (even UNDO) mark edits as accepted
+		assert.strictEqual(session.hunkData.size, 1);
+		assert.strictEqual(session.hunkData.pending, 0);
+		assert.ok(session.hunkData.getInfo().every(d => d.getState() === HunkState.Accepted));
+
+		// no further change when discarding
+		session.hunkData.discardAll(); // CANCEL
+		await assertSnapshot(editor.getModel().getValue(), { name: '2' });
+	});
+
 });


### PR DESCRIPTION
Only undo changes when an error happened and make sure it happens before recomputing hunks

Mark hunks with overlapping manual edits as accepted so that they don't get double applied or double rejected

Make sure `recompute` works correctly for diff to no-diff transition

- fixes https://github.com/microsoft/vscode-copilot/issues/7537
- fixes https://github.com/microsoft/vscode-copilot/issues/7719
- fixes https://github.com/microsoft/vscode-copilot/issues/7764