### PR TITLE
Use OS separator when injecting ../ completion

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/media/shellIntegration.ps1
+++ b/src/vs/workbench/contrib/terminal/browser/media/shellIntegration.ps1
@@ -388,9 +388,9 @@ function Send-Completions {
 			if ($completions.CompletionMatches.Count -gt 0 -and $completions.CompletionMatches.Where({ $_.ResultType -eq 3 -or $_.ResultType -eq 4 })) {
 				# Add `../ relative to the top completion
 				$firstCompletion = $completions.CompletionMatches[0]
-				if ($firstCompletion.CompletionText.StartsWith('../')) {
-					if ($completionPrefix -match '(\.\.\/)+') {
-						$parentDir = "$($matches[0])../"
+				if ($firstCompletion.CompletionText.StartsWith("..$([System.IO.Path]::DirectorySeparatorChar)")) {
+					if ($completionPrefix -match "(\.\.$([System.IO.Path]::DirectorySeparatorChar))+") {
+						$parentDir = "$($matches[0])..$([System.IO.Path]::DirectorySeparatorChar)"
 						$currentPath = Split-Path -Parent $firstCompletion.ToolTip
 						try {
 							$parentDirPath = Split-Path -Parent $currentPath


### PR DESCRIPTION
This should fix the issue on Windows, it was working fine on macOS.

Fixes #222237

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
