### PR TITLE
adjust cell inserts beyond repl input cell

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/viewModel/notebookViewModelImpl.ts
+++ b/src/vs/workbench/contrib/notebook/browser/viewModel/notebookViewModelImpl.ts
@@ -205,6 +205,9 @@ export class NotebookViewModel extends Disposable implements EditorFoldingStateD
 		this.id = '$notebookViewModel' + MODEL_ID;
 		this._instanceId = strings.singleLetterHash(MODEL_ID);
 		this.replView = !!this.options.inRepl;
+		if (this.replView) {
+			_notebook.onOpenedInRepl();
+		}
 
 		const compute = (changes: NotebookCellTextModelSplice<ICell>[], synchronous: boolean) => {
 			const diffs = changes.map(splice => {


### PR DESCRIPTION
https://github.com/microsoft/vscode/issues/154983

I don't see an easy way to add an `appendCell` edit to the API since all edits require a range and are built without a notebook document. This will just adjust the index if the client accidentally passes an index that would put the cell beyond the input box.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
