### PR TITLE
Fix PSScriptAnalyzer alerts

### DIFF
--- a/src/vs/workbench/contrib/terminal/common/scripts/shellIntegration.ps1
+++ b/src/vs/workbench/contrib/terminal/common/scripts/shellIntegration.ps1
@@ -170,10 +170,8 @@ function Set-MappedKeyHandler {
 	}
 }
 
-function Get-KeywordCompletionResult(
-	$Keyword,
-	$Description = $Keyword
-) {
+function Get-KeywordCompletionResult {
+	param ($Keyword, $Description = $Keyword)
 	[System.Management.Automation.CompletionResult]::new($Keyword, $Keyword, [System.Management.Automation.CompletionResultType]::Keyword, $Description)
 }
 


### PR DESCRIPTION
MissingEndCurlyBrace, MissingEndParenthesisInMethodCall and UnexpectedToken.

Fixes microsoft/vscode-internalbacklog#5021

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
