### PR TITLE
disable `isolatedModules` because they prevent const enum inlining

### DIFF
--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -7,7 +7,7 @@
 		"sourceMap": false,
 		"allowJs": true,
 		"resolveJsonModule": true,
-		"isolatedModules": true,
+		"isolatedModules": false,
 		"outDir": "../out/vs",
 		"types": [
 			"mocha",


### PR DESCRIPTION
fixes https://github.com/microsoft/vscode/issues/227372