### PR TITLE
revealInExplorer: Only show open editors view if it's actually visible

### DIFF
--- a/src/vs/workbench/contrib/files/browser/fileCommands.ts
+++ b/src/vs/workbench/contrib/files/browser/fileCommands.ts
@@ -337,6 +337,8 @@ CommandsRegistry.registerCommand({
 				explorerView.autoReveal = oldAutoReveal;
 			}
 		} else {
+			// Do not reveal the open editors view if it's hidden explicitly
+			// See https://github.com/microsoft/vscode/issues/227378
 			const openEditorsView = viewService.getViewWithId(OpenEditorsView.ID);
 			if (openEditorsView) {
 				openEditorsView.setExpanded(true);

--- a/src/vs/workbench/contrib/files/browser/fileCommands.ts
+++ b/src/vs/workbench/contrib/files/browser/fileCommands.ts
@@ -337,7 +337,7 @@ CommandsRegistry.registerCommand({
 				explorerView.autoReveal = oldAutoReveal;
 			}
 		} else {
-			const openEditorsView = await viewService.openView(OpenEditorsView.ID, false);
+			const openEditorsView = viewService.getViewWithId(OpenEditorsView.ID);
 			if (openEditorsView) {
 				openEditorsView.setExpanded(true);
 				openEditorsView.focus();


### PR DESCRIPTION
Fixes #227378

This fixes my main issue with #227378, you can reopen that issue if you want to do the optional one that is a suggestion that doesn't bother me.