### PR TITLE
Fix drag and drop behavior for empty activity bar in title/top

### DIFF
--- a/src/vs/workbench/browser/parts/activitybar/activitybarPart.ts
+++ b/src/vs/workbench/browser/parts/activitybar/activitybarPart.ts
@@ -37,6 +37,7 @@ import { IViewDescriptorService, ViewContainerLocation, ViewContainerLocationToS
 import { IPaneCompositePartService } from '../../../services/panecomposite/browser/panecomposite.js';
 import { IExtensionService } from '../../../services/extensions/common/extensions.js';
 import { IWorkbenchEnvironmentService } from '../../../services/environment/common/environmentService.js';
+import { IViewsService } from '../../../services/views/common/viewsService.js';
 
 export class ActivitybarPart extends Part {
 
@@ -205,6 +206,7 @@ export class ActivityBarCompositeBar extends PaneCompositeBar {
 		@IStorageService storageService: IStorageService,
 		@IExtensionService extensionService: IExtensionService,
 		@IViewDescriptorService viewDescriptorService: IViewDescriptorService,
+		@IViewsService viewService: IViewsService,
 		@IContextKeyService contextKeyService: IContextKeyService,
 		@IWorkbenchEnvironmentService environmentService: IWorkbenchEnvironmentService,
 		@IConfigurationService private readonly configurationService: IConfigurationService,
@@ -217,7 +219,7 @@ export class ActivityBarCompositeBar extends PaneCompositeBar {
 				options.fillExtraContextMenuActions(actions, e);
 				this.fillContextMenuActions(actions, e);
 			}
-		}, part, paneCompositePart, instantiationService, storageService, extensionService, viewDescriptorService, contextKeyService, environmentService, layoutService);
+		}, part, paneCompositePart, instantiationService, storageService, extensionService, viewDescriptorService, viewService, contextKeyService, environmentService, layoutService);
 
 		if (showGlobalActivities) {
 			this.globalCompositeBar = this._register(instantiationService.createInstance(GlobalCompositeBar, () => this.getContextMenuActions(), (theme: IColorTheme) => this.options.colors(theme), this.options.activityHoverOptions));

--- a/src/vs/workbench/browser/parts/compositeBar.ts
+++ b/src/vs/workbench/browser/parts/compositeBar.ts
@@ -19,7 +19,7 @@ import { Emitter } from '../../../base/common/event.js';
 import { ViewContainerLocation, IViewDescriptorService } from '../../common/views.js';
 import { IPaneComposite } from '../../common/panecomposite.js';
 import { IComposite } from '../../common/composite.js';
-import { CompositeDragAndDropData, CompositeDragAndDropObserver, IDraggedCompositeData, ICompositeDragAndDrop, Before2D, toggleDropEffect } from '../dnd.js';
+import { CompositeDragAndDropData, CompositeDragAndDropObserver, IDraggedCompositeData, ICompositeDragAndDrop, Before2D, toggleDropEffect, ICompositeDragAndDropObserverCallbacks } from '../dnd.js';
 import { Gesture, EventType as TouchEventType, GestureEvent } from '../../../base/browser/touch.js';
 
 export interface ICompositeBarItem {
@@ -152,6 +152,78 @@ export interface ICompositeBarOptions {
 	readonly getDefaultCompositeId: () => string | undefined;
 }
 
+class CompositeBarDndCallbacks implements ICompositeDragAndDropObserverCallbacks {
+
+	private insertDropBefore: Before2D | undefined = undefined;
+
+	constructor(
+		private readonly compositeBarContainer: HTMLElement,
+		private readonly actionBarContainer: HTMLElement,
+		private readonly compositeBarModel: CompositeBarModel,
+		private readonly dndHandler: ICompositeDragAndDrop,
+		private readonly orientation: ActionsOrientation,
+	) { }
+
+	onDragOver(e: IDraggedCompositeData) {
+
+		// don't add feedback if this is over the composite bar actions or there are no actions
+		const visibleItems = this.compositeBarModel.visibleItems;
+		if (!visibleItems.length || (e.eventData.target && isAncestor(e.eventData.target as HTMLElement, this.actionBarContainer))) {
+			this.insertDropBefore = this.updateFromDragging(this.compositeBarContainer, false, false, true);
+			return;
+		}
+
+		const insertAtFront = this.insertAtFront(this.actionBarContainer, e.eventData);
+		const target = insertAtFront ? visibleItems[0] : visibleItems[visibleItems.length - 1];
+		const validDropTarget = this.dndHandler.onDragOver(e.dragAndDropData, target.id, e.eventData);
+		toggleDropEffect(e.eventData.dataTransfer, 'move', validDropTarget);
+		this.insertDropBefore = this.updateFromDragging(this.compositeBarContainer, validDropTarget, insertAtFront, true);
+	}
+
+	onDragLeave(e: IDraggedCompositeData) {
+		this.insertDropBefore = this.updateFromDragging(this.compositeBarContainer, false, false, false);
+	}
+
+	onDragEnd(e: IDraggedCompositeData) {
+		this.insertDropBefore = this.updateFromDragging(this.compositeBarContainer, false, false, false);
+	}
+
+	onDrop(e: IDraggedCompositeData) {
+		const visibleItems = this.compositeBarModel.visibleItems;
+		let targetId = undefined;
+		if (visibleItems.length) {
+			targetId = this.insertAtFront(this.actionBarContainer, e.eventData) ? visibleItems[0].id : visibleItems[visibleItems.length - 1].id;
+		}
+		this.dndHandler.drop(e.dragAndDropData, targetId, e.eventData, this.insertDropBefore);
+		this.insertDropBefore = this.updateFromDragging(this.compositeBarContainer, false, false, false);
+	}
+
+	private insertAtFront(element: HTMLElement, event: DragEvent): boolean {
+		const rect = element.getBoundingClientRect();
+		const posX = event.clientX;
+		const posY = event.clientY;
+
+		switch (this.orientation) {
+			case ActionsOrientation.HORIZONTAL:
+				return posX < rect.left;
+			case ActionsOrientation.VERTICAL:
+				return posY < rect.top;
+		}
+	}
+
+	private updateFromDragging(element: HTMLElement, showFeedback: boolean, front: boolean, isDragging: boolean): Before2D | undefined {
+		element.classList.toggle('dragged-over', isDragging);
+		element.classList.toggle('dragged-over-head', showFeedback && front);
+		element.classList.toggle('dragged-over-tail', showFeedback && !front);
+
+		if (!showFeedback) {
+			return undefined;
+		}
+
+		return { verticallyBefore: front, horizontallyBefore: front };
+	}
+}
+
 export class CompositeBar extends Widget implements ICompositeBar {
 
 	private readonly _onDidChange = this._register(new Emitter<void>());
@@ -232,66 +304,10 @@ export class CompositeBar extends Widget implements ICompositeBar {
 		this._register(addDisposableListener(parent, TouchEventType.Contextmenu, e => this.showContextMenu(getWindow(parent), e)));
 
 		// Register a drop target on the whole bar to prevent forbidden feedback
-		let insertDropBefore: Before2D | undefined = undefined;
-		this._register(CompositeDragAndDropObserver.INSTANCE.registerTarget(parent, {
-			onDragOver: (e: IDraggedCompositeData) => {
-
-				// don't add feedback if this is over the composite bar actions or there are no actions
-				const visibleItems = this.getVisibleComposites();
-				if (!visibleItems.length || (e.eventData.target && isAncestor(e.eventData.target as HTMLElement, actionBarDiv))) {
-					insertDropBefore = this.updateFromDragging(parent, false, false, true);
-					return;
-				}
-
-				const insertAtFront = this.insertAtFront(actionBarDiv, e.eventData);
-				const target = insertAtFront ? visibleItems[0] : visibleItems[visibleItems.length - 1];
-				const validDropTarget = this.options.dndHandler.onDragOver(e.dragAndDropData, target.id, e.eventData);
-				toggleDropEffect(e.eventData.dataTransfer, 'move', validDropTarget);
-				insertDropBefore = this.updateFromDragging(parent, validDropTarget, insertAtFront, true);
-			},
-			onDragLeave: (e: IDraggedCompositeData) => {
-				insertDropBefore = this.updateFromDragging(parent, false, false, false);
-			},
-			onDragEnd: (e: IDraggedCompositeData) => {
-				insertDropBefore = this.updateFromDragging(parent, false, false, false);
-			},
-			onDrop: (e: IDraggedCompositeData) => {
-				const visibleItems = this.getVisibleComposites();
-				let targetId = undefined;
-				if (visibleItems.length) {
-					targetId = this.insertAtFront(actionBarDiv, e.eventData) ? visibleItems[0].id : visibleItems[visibleItems.length - 1].id;
-				}
-				this.options.dndHandler.drop(e.dragAndDropData, targetId, e.eventData, insertDropBefore);
-				insertDropBefore = this.updateFromDragging(parent, false, false, false);
-			}
-		}));
+		const dndCallback = new CompositeBarDndCallbacks(parent, actionBarDiv, this.model, this.options.dndHandler, this.options.orientation);
+		this._register(CompositeDragAndDropObserver.INSTANCE.registerTarget(parent, dndCallback));
 
 		return actionBarDiv;
-	}
-
-	private insertAtFront(element: HTMLElement, event: DragEvent): boolean {
-		const rect = element.getBoundingClientRect();
-		const posX = event.clientX;
-		const posY = event.clientY;
-
-		switch (this.options.orientation) {
-			case ActionsOrientation.HORIZONTAL:
-				return posX < rect.left;
-			case ActionsOrientation.VERTICAL:
-				return posY < rect.top;
-		}
-	}
-
-	private updateFromDragging(element: HTMLElement, showFeedback: boolean, front: boolean, isDragging: boolean): Before2D | undefined {
-		element.classList.toggle('dragged-over', isDragging);
-		element.classList.toggle('dragged-over-head', showFeedback && front);
-		element.classList.toggle('dragged-over-tail', showFeedback && !front);
-
-		if (!showFeedback) {
-			return undefined;
-		}
-
-		return { verticallyBefore: front, horizontallyBefore: front };
 	}
 
 	focus(index?: number): void {

--- a/src/vs/workbench/browser/parts/compositeBar.ts
+++ b/src/vs/workbench/browser/parts/compositeBar.ts
@@ -14,7 +14,7 @@ import { StandardMouseEvent } from '../../../base/browser/mouseEvent.js';
 import { IContextMenuService } from '../../../platform/contextview/browser/contextView.js';
 import { Widget } from '../../../base/browser/ui/widget.js';
 import { isUndefinedOrNull } from '../../../base/common/types.js';
-import { IColorTheme, IThemeService } from '../../../platform/theme/common/themeService.js';
+import { IColorTheme } from '../../../platform/theme/common/themeService.js';
 import { Emitter } from '../../../base/common/event.js';
 import { ViewContainerLocation, IViewDescriptorService } from '../../common/views.js';
 import { IPaneComposite } from '../../common/panecomposite.js';
@@ -173,7 +173,6 @@ export class CompositeBar extends Widget implements ICompositeBar {
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
 		@IContextMenuService private readonly contextMenuService: IContextMenuService,
 		@IViewDescriptorService private readonly viewDescriptorService: IViewDescriptorService,
-		@IThemeService private readonly themeService: IThemeService
 	) {
 		super();
 
@@ -238,29 +237,23 @@ export class CompositeBar extends Widget implements ICompositeBar {
 			onDragOver: (e: IDraggedCompositeData) => {
 
 				// don't add feedback if this is over the composite bar actions or there are no actions
-				if ((e.eventData.target && isAncestor(e.eventData.target as HTMLElement, actionBarDiv))) {
-					insertDropBefore = this.updateFromDragging(parent, false, true);
+				const visibleItems = this.getVisibleComposites();
+				if (!visibleItems.length || (e.eventData.target && isAncestor(e.eventData.target as HTMLElement, actionBarDiv))) {
+					insertDropBefore = this.updateFromDragging(parent, false, false, true);
 					return;
 				}
 
-				const visibleItems = this.getVisibleComposites();
-				let targetId = undefined;
-				let hoverPosition: 'over' | 'before' | 'after' = 'over';
-				if (visibleItems.length) {
-					const insertAtFront = this.insertAtFront(actionBarDiv, e.eventData);
-					hoverPosition = insertAtFront ? 'before' : 'after';
-					targetId = insertAtFront ? visibleItems[0].id : visibleItems[visibleItems.length - 1].id;
-				}
-
-				const validDropTarget = this.options.dndHandler.onDragOver(e.dragAndDropData, targetId, e.eventData);
+				const insertAtFront = this.insertAtFront(actionBarDiv, e.eventData);
+				const target = insertAtFront ? visibleItems[0] : visibleItems[visibleItems.length - 1];
+				const validDropTarget = this.options.dndHandler.onDragOver(e.dragAndDropData, target.id, e.eventData);
 				toggleDropEffect(e.eventData.dataTransfer, 'move', validDropTarget);
-				insertDropBefore = this.updateFromDragging(parent, validDropTarget, true, hoverPosition);
+				insertDropBefore = this.updateFromDragging(parent, validDropTarget, insertAtFront, true);
 			},
 			onDragLeave: (e: IDraggedCompositeData) => {
-				insertDropBefore = this.updateFromDragging(parent, false);
+				insertDropBefore = this.updateFromDragging(parent, false, false, false);
 			},
 			onDragEnd: (e: IDraggedCompositeData) => {
-				insertDropBefore = this.updateFromDragging(parent, false);
+				insertDropBefore = this.updateFromDragging(parent, false, false, false);
 			},
 			onDrop: (e: IDraggedCompositeData) => {
 				const visibleItems = this.getVisibleComposites();
@@ -269,20 +262,11 @@ export class CompositeBar extends Widget implements ICompositeBar {
 					targetId = this.insertAtFront(actionBarDiv, e.eventData) ? visibleItems[0].id : visibleItems[visibleItems.length - 1].id;
 				}
 				this.options.dndHandler.drop(e.dragAndDropData, targetId, e.eventData, insertDropBefore);
-				insertDropBefore = this.updateFromDragging(parent, false);
+				insertDropBefore = this.updateFromDragging(parent, false, false, false);
 			}
 		}));
 
-		this.updateStyles();
-		this._register(this.themeService.onDidColorThemeChange(() => this.updateStyles()));
-
 		return actionBarDiv;
-	}
-
-	private updateStyles(): void {
-		const theme = this.themeService.getColorTheme();
-		const colors = this.options.colors(theme);
-		this.compositeSwitcherBar?.domNode.style.setProperty('--insert-border-color', colors.dragAndDropBorder ? colors.dragAndDropBorder.toString() : '');
 	}
 
 	private insertAtFront(element: HTMLElement, event: DragEvent): boolean {
@@ -298,21 +282,16 @@ export class CompositeBar extends Widget implements ICompositeBar {
 		}
 	}
 
-	private updateFromDragging(element: HTMLElement, showFeedback: false, isDragging?: boolean): Before2D | undefined;
-	private updateFromDragging(element: HTMLElement, showFeedback: boolean, isDragging: boolean, position: 'before' | 'after' | 'over'): Before2D | undefined;
-	private updateFromDragging(element: HTMLElement, showFeedback: boolean, isDragging: boolean = false, position: 'before' | 'after' | 'over' = 'after'): Before2D | undefined {
-		console.log('updateFromDragging', showFeedback, position, isDragging);
-
+	private updateFromDragging(element: HTMLElement, showFeedback: boolean, front: boolean, isDragging: boolean): Before2D | undefined {
 		element.classList.toggle('dragged-over', isDragging);
-		element.classList.toggle('dragged-over-head', showFeedback && position === 'before');
-		element.classList.toggle('dragged-over-tail', showFeedback && position === 'after');
-		element.classList.toggle('dragged-over-over', showFeedback && position === 'over');
+		element.classList.toggle('dragged-over-head', showFeedback && front);
+		element.classList.toggle('dragged-over-tail', showFeedback && !front);
 
 		if (!showFeedback) {
 			return undefined;
 		}
 
-		return { verticallyBefore: position === 'before', horizontallyBefore: position === 'before' };
+		return { verticallyBefore: front, horizontallyBefore: front };
 	}
 
 	focus(index?: number): void {

--- a/src/vs/workbench/browser/parts/media/paneCompositePart.css
+++ b/src/vs/workbench/browser/parts/media/paneCompositePart.css
@@ -83,8 +83,10 @@
 	height: 16px;
 }
 
+.monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar::before,
 .monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item::before,
 .monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item::after,
+.monaco-workbench .pane-composite-part > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar::before,
 .monaco-workbench .pane-composite-part > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item::before,
 .monaco-workbench .pane-composite-part > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item::after {
 	content: '';
@@ -99,8 +101,15 @@
 	transition-delay: 100ms;
 }
 
+.monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar::before,
+.monaco-workbench .pane-composite-part > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar::before {
+	top: 5px;
+}
+
+.monaco-workbench .pane-composite-part > .title > .composite-bar-container.dragged-over > .composite-bar > .monaco-action-bar::before,
 .monaco-workbench .pane-composite-part > .title > .composite-bar-container.dragged-over > .composite-bar > .monaco-action-bar .action-item::before,
 .monaco-workbench .pane-composite-part > .title > .composite-bar-container.dragged-over > .composite-bar > .monaco-action-bar .action-item::after,
+.monaco-workbench .pane-composite-part > .header-or-footer > .composite-bar-container.dragged-over > .composite-bar > .monaco-action-bar::before,
 .monaco-workbench .pane-composite-part > .header-or-footer > .composite-bar-container.dragged-over > .composite-bar > .monaco-action-bar .action-item::before,
 .monaco-workbench .pane-composite-part > .header-or-footer > .composite-bar-container.dragged-over > .composite-bar > .monaco-action-bar .action-item::after {
 	display: block;
@@ -152,6 +161,11 @@
 .monaco-workbench .pane-composite-part > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:last-of-type.right::after,
 .monaco-workbench .pane-composite-part > .header-or-footer > .composite-bar-container.dragged-over-head  > .composite-bar > .monaco-action-bar .action-item:first-of-type::before,
 .monaco-workbench .pane-composite-part > .header-or-footer > .composite-bar-container.dragged-over-tail > .composite-bar > .monaco-action-bar .action-item:last-of-type::after {
+	opacity: 1;
+}
+
+.monaco-workbench .pane-composite-part > .header-or-footer > .composite-bar-container.dragged-over-over > .composite-bar > .monaco-action-bar::before,
+.monaco-workbench .pane-composite-part > .title > .composite-bar-container.dragged-over-over > .composite-bar > .monaco-action-bar::before {
 	opacity: 1;
 }
 

--- a/src/vs/workbench/browser/parts/media/paneCompositePart.css
+++ b/src/vs/workbench/browser/parts/media/paneCompositePart.css
@@ -83,10 +83,8 @@
 	height: 16px;
 }
 
-.monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar::before,
 .monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item::before,
 .monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item::after,
-.monaco-workbench .pane-composite-part > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar::before,
 .monaco-workbench .pane-composite-part > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item::before,
 .monaco-workbench .pane-composite-part > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item::after {
 	content: '';
@@ -101,15 +99,8 @@
 	transition-delay: 100ms;
 }
 
-.monaco-workbench .pane-composite-part > .title > .composite-bar-container > .composite-bar > .monaco-action-bar::before,
-.monaco-workbench .pane-composite-part > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar::before {
-	top: 5px;
-}
-
-.monaco-workbench .pane-composite-part > .title > .composite-bar-container.dragged-over > .composite-bar > .monaco-action-bar::before,
 .monaco-workbench .pane-composite-part > .title > .composite-bar-container.dragged-over > .composite-bar > .monaco-action-bar .action-item::before,
 .monaco-workbench .pane-composite-part > .title > .composite-bar-container.dragged-over > .composite-bar > .monaco-action-bar .action-item::after,
-.monaco-workbench .pane-composite-part > .header-or-footer > .composite-bar-container.dragged-over > .composite-bar > .monaco-action-bar::before,
 .monaco-workbench .pane-composite-part > .header-or-footer > .composite-bar-container.dragged-over > .composite-bar > .monaco-action-bar .action-item::before,
 .monaco-workbench .pane-composite-part > .header-or-footer > .composite-bar-container.dragged-over > .composite-bar > .monaco-action-bar .action-item::after {
 	display: block;
@@ -161,11 +152,6 @@
 .monaco-workbench .pane-composite-part > .header-or-footer > .composite-bar-container > .composite-bar > .monaco-action-bar .action-item:last-of-type.right::after,
 .monaco-workbench .pane-composite-part > .header-or-footer > .composite-bar-container.dragged-over-head  > .composite-bar > .monaco-action-bar .action-item:first-of-type::before,
 .monaco-workbench .pane-composite-part > .header-or-footer > .composite-bar-container.dragged-over-tail > .composite-bar > .monaco-action-bar .action-item:last-of-type::after {
-	opacity: 1;
-}
-
-.monaco-workbench .pane-composite-part > .header-or-footer > .composite-bar-container.dragged-over-over > .composite-bar > .monaco-action-bar::before,
-.monaco-workbench .pane-composite-part > .title > .composite-bar-container.dragged-over-over > .composite-bar > .monaco-action-bar::before {
 	opacity: 1;
 }
 

--- a/src/vs/workbench/browser/parts/paneCompositeBar.ts
+++ b/src/vs/workbench/browser/parts/paneCompositeBar.ts
@@ -29,6 +29,7 @@ import { GestureEvent } from '../../../base/browser/touch.js';
 import { IPaneCompositePart } from './paneCompositePart.js';
 import { ITelemetryService } from '../../../platform/telemetry/common/telemetry.js';
 import { IConfigurationService } from '../../../platform/configuration/common/configuration.js';
+import { IViewsService } from '../../services/views/common/viewsService.js';
 
 interface IPlaceholderViewContainer {
 	readonly id: string;
@@ -102,6 +103,7 @@ export class PaneCompositeBar extends Disposable {
 		@IStorageService private readonly storageService: IStorageService,
 		@IExtensionService private readonly extensionService: IExtensionService,
 		@IViewDescriptorService private readonly viewDescriptorService: IViewDescriptorService,
+		@IViewsService private readonly viewService: IViewsService,
 		@IContextKeyService protected readonly contextKeyService: IContextKeyService,
 		@IWorkbenchEnvironmentService private readonly environmentService: IWorkbenchEnvironmentService,
 		@IWorkbenchLayoutService protected readonly layoutService: IWorkbenchLayoutService,
@@ -383,7 +385,7 @@ export class PaneCompositeBar extends Disposable {
 
 		if (viewContainer) {
 			if (viewContainer.hideIfEmpty) {
-				if (this.viewDescriptorService.getViewContainerModel(viewContainer).activeViewDescriptors.length > 0) {
+				if (this.viewService.isViewContainerActive(viewContainerId)) {
 					return false;
 				}
 			} else {

--- a/src/vs/workbench/browser/parts/paneCompositePart.ts
+++ b/src/vs/workbench/browser/parts/paneCompositePart.ts
@@ -268,7 +268,7 @@ export abstract class AbstractPaneCompositePart extends CompositePart<PaneCompos
 		this.emptyPaneMessageElement.appendChild(messageElement);
 		parent.appendChild(this.emptyPaneMessageElement);
 
-		this._register(CompositeDragAndDropObserver.INSTANCE.registerTarget(this.emptyPaneMessageElement, {
+		this._register(CompositeDragAndDropObserver.INSTANCE.registerTarget(this.element, {
 			onDragOver: (e) => {
 				EventHelper.stop(e.eventData, true);
 				if (this.paneCompositeBar.value) {

--- a/src/vs/workbench/services/views/common/viewsService.ts
+++ b/src/vs/workbench/services/views/common/viewsService.ts
@@ -17,6 +17,7 @@ export interface IViewsService {
 	// View Container APIs
 	readonly onDidChangeViewContainerVisibility: Event<{ id: string; visible: boolean; location: ViewContainerLocation }>;
 	isViewContainerVisible(id: string): boolean;
+	isViewContainerActive(id: string): boolean;
 	openViewContainer(id: string, focus?: boolean): Promise<IPaneComposite | null>;
 	closeViewContainer(id: string): void;
 	getVisibleViewContainer(location: ViewContainerLocation): ViewContainer | null;

--- a/src/vs/workbench/test/browser/workbenchTestServices.ts
+++ b/src/vs/workbench/test/browser/workbenchTestServices.ts
@@ -795,6 +795,7 @@ export class TestViewsService implements IViewsService {
 
 	onDidChangeViewContainerVisibility = new Emitter<{ id: string; visible: boolean; location: ViewContainerLocation }>().event;
 	isViewContainerVisible(id: string): boolean { return true; }
+	isViewContainerActive(id: string): boolean { return true; }
 	getVisibleViewContainer(): ViewContainer | null { return null; }
 	openViewContainer(id: string, focus?: boolean): Promise<IPaneComposite | null> { return Promise.resolve(null); }
 	closeViewContainer(id: string): void { }


### PR DESCRIPTION
This pull request fixes the issue #196359 where dragging and dropping a view on an empty activity bar would not allow dropping it.