### PR TITLE
add missing editor encodings supported in the terminal and by iconv-lite

### DIFF
--- a/src/vs/workbench/services/textfile/common/encoding.ts
+++ b/src/vs/workbench/services/textfile/common/encoding.ts
@@ -765,6 +765,31 @@ export const SUPPORTED_ENCODINGS: EncodingsMap = {
 		labelLong: 'Western European DOS (CP 850)',
 		labelShort: 'CP 850',
 		order: 47
+	},
+	cp855: {
+		labelLong: 'Cyrillic (Russian) DOS (CP 855)',
+		labelShort: 'CP 855',
+		order: 48
+	},
+	cp857: {
+		labelLong: 'Turkish DOS (CP 857)',
+		labelShort: 'CP 857',
+		order: 49
+	},
+	cp860: {
+		labelLong: 'Portuguese DOS (CP 860)',
+		labelShort: 'CP 860',
+		order: 50
+	},
+	cp861: {
+		labelLong: 'Icelandic DOS (CP 861)',
+		labelShort: 'CP 861',
+		order: 51
+	},
+	cp869: {
+		labelLong: 'Modern Greek DOS (CP 869)',
+		labelShort: 'CP 869',
+		order: 52
 	}
 };
 


### PR DESCRIPTION
follow-up to 0d53acc, partially fixing #71591

Used the [iconv-lite supported encoding list](https://github.com/ashtuchkin/iconv-lite/wiki/Supported-Encodings) and the terminal settings `windowsTerminalEncodings` https://github.com/microsoft/vscode/blob/9b2e9634aa7cca984acd9d408bb4342cb1613aca/src/vs/base/node/terminalEncoding.ts#L12-L26 to add encodings that vscode already supports in the terminal but not in the file encodings.

Note that there are more supported single-byte encodings in iconv-lite that could be added to both the terminal list and the file encodings.

Verification: verify you can pick the encoding and save files with that encoding.