### PR TITLE
Show icon in panel title

### DIFF
--- a/src/vs/workbench/browser/parts/paneCompositePart.ts
+++ b/src/vs/workbench/browser/parts/paneCompositePart.ts
@@ -344,14 +344,14 @@ export abstract class AbstractPaneCompositePart extends CompositePart<PaneCompos
 		return titleLabel;
 	}
 
-	protected updateCompositeBar(): void {
+	protected updateCompositeBar(updateCompositeBarOption: boolean = false): void {
 		const wasCompositeBarVisible = this.compositeBarPosition !== undefined;
 		const isCompositeBarVisible = this.shouldShowCompositeBar();
 		const previousPosition = this.compositeBarPosition;
 		const newPosition = isCompositeBarVisible ? this.getCompositeBarPosition() : undefined;
 
-		// Only update if the visibility or position has changed
-		if (previousPosition === newPosition) {
+		// Only update if the visibility or position has changed or if the composite bar options should be updated
+		if (!updateCompositeBarOption && previousPosition === newPosition) {
 			return;
 		}
 
@@ -401,6 +401,10 @@ export abstract class AbstractPaneCompositePart extends CompositePart<PaneCompos
 		}
 
 		this.compositeBarPosition = newPosition;
+
+		if (updateCompositeBarOption) {
+			this.layoutCompositeBar();
+		}
 	}
 
 	protected override createHeaderArea(): HTMLElement {

--- a/src/vs/workbench/browser/parts/panel/panelPart.ts
+++ b/src/vs/workbench/browser/parts/panel/panelPart.ts
@@ -30,6 +30,7 @@ import { ICommandService } from '../../../../platform/commands/common/commands.j
 import { createAndFillInContextMenuActions } from '../../../../platform/actions/browser/menuEntryActionViewItem.js';
 import { IPaneCompositeBarOptions } from '../paneCompositeBar.js';
 import { IHoverService } from '../../../../platform/hover/browser/hover.js';
+import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 
 export class PanelPart extends AbstractPaneCompositePart {
 
@@ -79,6 +80,7 @@ export class PanelPart extends AbstractPaneCompositePart {
 		@IExtensionService extensionService: IExtensionService,
 		@ICommandService private commandService: ICommandService,
 		@IMenuService menuService: IMenuService,
+		@IConfigurationService private configurationService: IConfigurationService
 	) {
 		super(
 			Parts.PANEL_PART,
@@ -102,6 +104,12 @@ export class PanelPart extends AbstractPaneCompositePart {
 			extensionService,
 			menuService,
 		);
+
+		this._register(this.configurationService.onDidChangeConfiguration(e => {
+			if (e.affectsConfiguration('workbench.panel.showLabel')) {
+				this.updateCompositeBar(true);
+			}
+		}));
 	}
 
 	override updateStyles(): void {
@@ -126,7 +134,7 @@ export class PanelPart extends AbstractPaneCompositePart {
 			pinnedViewContainersKey: 'workbench.panel.pinnedPanels',
 			placeholderViewContainersKey: 'workbench.panel.placeholderPanels',
 			viewContainersWorkspaceStateKey: 'workbench.panel.viewContainersWorkspaceState',
-			icon: false,
+			icon: !this.configurationService.getValue('workbench.panel.showLabel'),
 			orientation: ActionsOrientation.HORIZONTAL,
 			recomputeSizes: true,
 			activityHoverOptions: {

--- a/src/vs/workbench/browser/workbench.contribution.ts
+++ b/src/vs/workbench/browser/workbench.contribution.ts
@@ -514,6 +514,11 @@ const registry = Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Con
 				'default': 'left',
 				'description': localize('sideBarLocation', "Controls the location of the primary side bar and activity bar. They can either show on the left or right of the workbench. The secondary side bar will show on the opposite side of the workbench.")
 			},
+			'workbench.panel.showLabel': {
+				'type': 'boolean',
+				'default': true,
+				'description': localize('panelShowLabel', "Controls whether activity items in the panel title are shown as label or icon."),
+			},
 			'workbench.panel.defaultLocation': {
 				'type': 'string',
 				'enum': ['left', 'bottom', 'top', 'right'],


### PR DESCRIPTION
`workbench.panel.showLabel` is added to control whether activity items in the panel title are shown as a label or an icon.

closes #227076