### PR TITLE
Improve rendering of inline chat anchors

### DIFF
--- a/src/vs/editor/browser/widget/markdownRenderer/browser/markdownRenderer.ts
+++ b/src/vs/editor/browser/widget/markdownRenderer/browser/markdownRenderer.ts
@@ -105,10 +105,14 @@ export class MarkdownRenderer {
 			},
 			asyncRenderCallback: () => this._onDidRenderAsync.fire(),
 			actionHandler: {
-				callback: (link) => openLinkFromMarkdown(this._openerService, link, markdown.isTrusted),
+				callback: (link) => this.openMarkdownLink(link, markdown),
 				disposables: disposables
 			}
 		};
+	}
+
+	protected async openMarkdownLink(link: string, markdown: IMarkdownString) {
+		await openLinkFromMarkdown(this._openerService, link, markdown.isTrusted);
 	}
 }
 

--- a/src/vs/workbench/contrib/chat/browser/chatMarkdownDecorationsRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatMarkdownDecorationsRenderer.ts
@@ -161,7 +161,7 @@ export class ChatMarkdownDecorationsRenderer {
 						this.renderResourceWidget(a.textContent!, args, store),
 						a);
 				} else if (href.startsWith(contentRefUrl)) {
-					this.renderFileWidget(href, a);
+					this.renderFileWidget(href, a, store);
 				} else if (href.startsWith('command:')) {
 					this.injectKeybindingHint(a, href, this.keybindingService);
 				}
@@ -226,7 +226,7 @@ export class ChatMarkdownDecorationsRenderer {
 		return container;
 	}
 
-	private renderFileWidget(href: string, a: HTMLAnchorElement): void {
+	private renderFileWidget(href: string, a: HTMLAnchorElement, store: DisposableStore): void {
 		// TODO this can be a nicer FileLabel widget with an icon. Do a simple link for now.
 		const fullUri = URI.parse(href);
 		let location: Location | { uri: URI; range: undefined };
@@ -246,9 +246,12 @@ export class ChatMarkdownDecorationsRenderer {
 		a.setAttribute('data-href', location.uri.with({ fragment }).toString());
 
 		const label = this.labelService.getUriLabel(location.uri, { relative: true });
-		a.title = location.range ?
+		a.replaceChildren(dom.$('code', undefined, label));
+
+		const title = location.range ?
 			`${label}#${location.range.startLineNumber}-${location.range.endLineNumber}` :
 			label;
+		store.add(this.hoverService.setupManagedHover(getDefaultHoverDelegate('element'), a, title));
 	}
 
 

--- a/src/vs/workbench/contrib/chat/browser/chatMarkdownRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatMarkdownRenderer.ts
@@ -7,10 +7,14 @@ import { MarkdownRenderOptions, MarkedOptions } from '../../../../base/browser/m
 import { getDefaultHoverDelegate } from '../../../../base/browser/ui/hover/hoverDelegateFactory.js';
 import { IMarkdownString } from '../../../../base/common/htmlContent.js';
 import { DisposableStore } from '../../../../base/common/lifecycle.js';
+import { URI } from '../../../../base/common/uri.js';
 import { IMarkdownRendererOptions, IMarkdownRenderResult, MarkdownRenderer } from '../../../../editor/browser/widget/markdownRenderer/browser/markdownRenderer.js';
 import { ILanguageService } from '../../../../editor/common/languages/language.js';
+import { ICommandService } from '../../../../platform/commands/common/commands.js';
+import { IFileService } from '../../../../platform/files/common/files.js';
 import { IHoverService } from '../../../../platform/hover/browser/hover.js';
 import { IOpenerService } from '../../../../platform/opener/common/opener.js';
+import { REVEAL_IN_EXPLORER_COMMAND_ID } from '../../files/browser/fileConstants.js';
 import { ITrustedDomainService } from '../../url/browser/trustedDomainService.js';
 
 const allowedHtmlTags = [
@@ -60,6 +64,8 @@ export class ChatMarkdownRenderer extends MarkdownRenderer {
 		@IOpenerService openerService: IOpenerService,
 		@ITrustedDomainService private readonly trustedDomainService: ITrustedDomainService,
 		@IHoverService private readonly hoverService: IHoverService,
+		@IFileService private readonly fileService: IFileService,
+		@ICommandService private readonly commandService: ICommandService,
 	) {
 		super(options ?? {}, languageService, openerService);
 	}
@@ -104,5 +110,18 @@ export class ChatMarkdownRenderer extends MarkdownRenderer {
 				store.dispose();
 			}
 		};
+	}
+
+	protected override async openMarkdownLink(link: string, markdown: IMarkdownString) {
+		try {
+			const uri = URI.parse(link);
+			if ((await this.fileService.stat(uri)).isDirectory) {
+				return this.commandService.executeCommand(REVEAL_IN_EXPLORER_COMMAND_ID, uri);
+			}
+		} catch {
+			// noop
+		}
+
+		return super.openMarkdownLink(link, markdown);
 	}
 }


### PR DESCRIPTION
Fixes #226375

- Render as inline code
- Fix hover title to show the full paths
- Make inline links to directories reveal the dir. Currently they open an invalid editor

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
