### PR TITLE
Enable Ports view only when a port is forwarded if there's an onTunnel extension

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadTunnelService.ts
+++ b/src/vs/workbench/api/browser/mainThreadTunnelService.ts
@@ -56,12 +56,14 @@ export class MainThreadTunnelService extends Disposable implements MainThreadTun
 			this._register(this.remoteExplorerService.onEnabledPortsFeatures(() => this._proxy.$registerCandidateFinder(this.processFindingEnabled())));
 		}
 		this._register(this.configurationService.onDidChangeConfiguration(async (e) => {
-			if (e.affectsConfiguration(PORT_AUTO_FORWARD_SETTING) || e.affectsConfiguration(PORT_AUTO_SOURCE_SETTING)) {
+			if (this.remoteExplorerService.portsFeaturesEnabled && (e.affectsConfiguration(PORT_AUTO_FORWARD_SETTING) || e.affectsConfiguration(PORT_AUTO_SOURCE_SETTING))) {
 				return this._proxy.$registerCandidateFinder(this.processFindingEnabled());
 			}
 		}));
-		this._register(this.tunnelService.onAddedTunnelProvider(() => {
-			return this._proxy.$registerCandidateFinder(this.processFindingEnabled());
+		this._register(this.tunnelService.onAddedTunnelProvider(async () => {
+			if (this.remoteExplorerService.portsFeaturesEnabled) {
+				return this._proxy.$registerCandidateFinder(this.processFindingEnabled());
+			}
 		}));
 	}
 

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -1668,7 +1668,7 @@ export interface MainThreadTunnelServiceShape extends IDisposable {
 	$openTunnel(tunnelOptions: TunnelOptions, source: string | undefined): Promise<TunnelDto | undefined>;
 	$closeTunnel(remote: { host: string; port: number }): Promise<void>;
 	$getTunnels(): Promise<TunnelDescription[]>;
-	$setTunnelProvider(features?: TunnelProviderFeatures): Promise<void>;
+	$setTunnelProvider(features: TunnelProviderFeatures | undefined, enablePortsView: boolean): Promise<void>;
 	$setRemoteTunnelService(processId: number): Promise<void>;
 	$setCandidateFilter(): Promise<void>;
 	$onFoundNewCandidates(candidates: CandidatePort[]): Promise<void>;

--- a/src/vs/workbench/api/common/extHostTunnelService.ts
+++ b/src/vs/workbench/api/common/extHostTunnelService.ts
@@ -162,10 +162,10 @@ export class ExtHostTunnelService extends Disposable implements IExtHostTunnelSe
 			protocol: information.tunnelFeatures.protocol === undefined ? true : information.tunnelFeatures.protocol,
 		} : undefined;
 
-		this._proxy.$setTunnelProvider(tunnelFeatures);
+		this._proxy.$setTunnelProvider(tunnelFeatures, true);
 		return Promise.resolve(toDisposable(() => {
 			this._forwardPortProvider = undefined;
-			this._proxy.$setTunnelProvider(undefined);
+			this._proxy.$setTunnelProvider(undefined, false);
 		}));
 	}
 
@@ -214,7 +214,7 @@ export class ExtHostTunnelService extends Disposable implements IExtHostTunnelSe
 					protocol: true
 				} : undefined;
 
-				this._proxy.$setTunnelProvider(tunnelFeatures);
+				this._proxy.$setTunnelProvider(tunnelFeatures, !!provider.tunnelFactory);
 			}
 		} else {
 			this._forwardPortProvider = undefined;

--- a/src/vs/workbench/services/remote/common/tunnelModel.ts
+++ b/src/vs/workbench/services/remote/common/tunnelModel.ts
@@ -497,13 +497,13 @@ export class TunnelModel extends Disposable {
 				});
 			}
 			await this.storeForwarded();
+			this.checkExtensionActivationEvents();
 			this.remoteTunnels.set(key, tunnel);
 			this._onForwardPort.fire(this.forwarded.get(key)!);
 		}));
 		this._register(this.tunnelService.onTunnelClosed(address => {
 			return this.onTunnelClosed(address, TunnelCloseReason.Other);
 		}));
-		this.checkExtensionActivationEvents();
 	}
 
 	private extensionHasActivationEvent() {


### PR DESCRIPTION
Also, prevent candidate finder from running unless ports features are enabled

Fixes #222854
Fixes https://github.com/microsoft/vscode-remote-release/issues/10054