### PR TITLE
Merge Editor: fix a bug in `LineRange.join(other)`

### DIFF
--- a/src/vs/workbench/contrib/mergeEditor/browser/model/lineRange.ts
+++ b/src/vs/workbench/contrib/mergeEditor/browser/model/lineRange.ts
@@ -40,7 +40,7 @@ export class LineRange {
 	}
 
 	public join(other: LineRange): LineRange {
-		return new LineRange(Math.min(this.startLineNumber, other.startLineNumber), Math.max(this.endLineNumberExclusive, other.endLineNumberExclusive) - this.startLineNumber);
+		return LineRange.fromLineNumbers(Math.min(this.startLineNumber, other.startLineNumber), Math.max(this.endLineNumberExclusive, other.endLineNumberExclusive));
 	}
 
 	public get endLineNumberExclusive(): number {


### PR DESCRIPTION
It looks like there is a significant bug lurking in the `LineRange.join(other)` method.

When `other.startLineNumber` < `this.startLineNumber`, the line count of the resulting line range should be
```ts
Math.max(this.endLineNumberExclusive, other.endLineNumberExclusive) - other.startLineNumber
```
rather than
```ts
Math.max(this.endLineNumberExclusive, other.endLineNumberExclusive) - this.startLineNumber
```