### PR TITLE
Revert "Allow search provider results to be outside of folder"

### DIFF
--- a/src/vs/workbench/api/test/node/extHostSearch.test.ts
+++ b/src/vs/workbench/api/test/node/extHostSearch.test.ts
@@ -702,25 +702,6 @@ suite('ExtHostSearch', () => {
 			const { results } = await runFileSearch(query);
 			compareURIs(results, reportedResults);
 		});
-
-		test('Works when provider returns files that are not in the original workspace', async () => {
-			const reportedResults = [
-				joinPath(rootFolderB, 'file1.ts'),
-				joinPath(rootFolderA, 'file2.ts'),
-				joinPath(rootFolderA, 'subfolder/file3.ts')
-			];
-
-			await registerTestFileSearchProvider({
-				provideFileSearchResults(query: vscode.FileSearchQuery, options: vscode.FileSearchOptions, token: vscode.CancellationToken): Promise<URI[]> {
-					return Promise.resolve(reportedResults);
-				}
-			});
-
-			const { results, stats } = await runFileSearch(getSimpleQuery());
-			assert(!stats.limitHit);
-			assert.strictEqual(results.length, 3);
-			compareURIs(results, reportedResults);
-		});
 	});
 
 	suite('Text:', () => {
@@ -1313,25 +1294,6 @@ suite('ExtHostSearch', () => {
 			};
 
 			const { results } = await runTextSearch(query);
-			assertResults(results, providedResults);
-		});
-
-
-		test('Works when provider returns files that are not in the original workspace', async () => {
-			const providedResults: vscode.TextSearchResult[] = [
-				makeTextResult(rootFolderB, 'file1.ts'),
-				makeTextResult(rootFolderA, 'file2.ts')
-			];
-
-			await registerTestTextSearchProvider({
-				provideTextSearchResults(query: vscode.TextSearchQuery, options: vscode.TextSearchOptions, progress: vscode.Progress<vscode.TextSearchResult>, token: vscode.CancellationToken): Promise<vscode.TextSearchComplete> {
-					providedResults.forEach(r => progress.report(r));
-					return Promise.resolve(null!);
-				}
-			});
-
-			const { results, stats } = await runTextSearch(getSimpleQuery('foo'));
-			assert(!stats.limitHit);
 			assertResults(results, providedResults);
 		});
 	});

--- a/src/vs/workbench/services/search/common/fileSearchManager.ts
+++ b/src/vs/workbench/services/search/common/fileSearchManager.ts
@@ -12,9 +12,9 @@ import { StopWatch } from '../../../../base/common/stopwatch.js';
 import { URI } from '../../../../base/common/uri.js';
 import { IFileMatch, IFileSearchProviderStats, IFolderQuery, ISearchCompleteStats, IFileQuery, QueryGlobTester, resolvePatternsForProvider, hasSiblingFn, excludeToGlobPattern, DEFAULT_MAX_SEARCH_RESULTS } from './search.js';
 import { FileSearchProviderFolderOptions, FileSearchProviderNew, FileSearchProviderOptions } from './searchExtTypes.js';
+import { TernarySearchTree } from '../../../../base/common/ternarySearchTree.js';
 import { Disposable } from '../../../../base/common/lifecycle.js';
 import { OldFileSearchProviderConverter } from './searchExtConversionTypes.js';
-import { ResourceMap } from '../../../../base/common/map.js';
 
 interface IInternalFileMatch {
 	base: URI;
@@ -126,7 +126,7 @@ class FileSearchEngine {
 		};
 
 
-		const folderMappings = new ResourceMap<FolderQueryInfo>();
+		const folderMappings: TernarySearchTree<URI, FolderQueryInfo> = TernarySearchTree.forUris<FolderQueryInfo>();
 		fqs.forEach(fq => {
 			const queryTester = new QueryGlobTester(this.config, fq);
 			const noSiblingsClauses = !queryTester.hasSiblingExcludeClauses();
@@ -153,9 +153,9 @@ class FileSearchEngine {
 
 
 			if (results) {
-				results.forEach(resultInfo => {
-					const result = resultInfo.result;
-					const fqFolderInfo = folderMappings.get(resultInfo.folder)!;
+				results.forEach(result => {
+
+					const fqFolderInfo = folderMappings.findSubstr(result)!;
 					const relativePath = path.posix.relative(fqFolderInfo.folder.path, result.path);
 
 					if (fqFolderInfo.noSiblingsClauses) {

--- a/src/vs/workbench/services/search/common/searchExtTypes.ts
+++ b/src/vs/workbench/services/search/common/searchExtTypes.ts
@@ -320,6 +320,41 @@ export class TextSearchContextNew {
  */
 export type TextSearchResultNew = TextSearchMatchNew | TextSearchContextNew;
 
+
+/**
+ * A FileSearchProvider provides search results for files in the given folder that match a query string. It can be invoked by quickaccess or other extensions.
+ *
+ * A FileSearchProvider is the more powerful of two ways to implement file search in VS Code. Use a FileSearchProvider if you wish to search within a folder for
+ * all files that match the user's query.
+ *
+ * The FileSearchProvider will be invoked on every keypress in quickaccess. When `workspace.findFiles` is called, it will be invoked with an empty query string,
+ * and in that case, every file in the folder should be returned.
+ */
+export interface FileSearchProviderNew {
+	/**
+	 * Provide the set of files that match a certain file path pattern.
+	 * @param query The parameters for this query.
+	 * @param options A set of options to consider while searching files.
+	 * @param progress A progress callback that must be invoked for all results.
+	 * @param token A cancellation token.
+	 */
+	provideFileSearchResults(pattern: string, options: FileSearchProviderOptions, token: CancellationToken): ProviderResult<URI[]>;
+}
+
+/**
+ * A TextSearchProvider provides search results for text results inside files in the workspace.
+ */
+export interface TextSearchProviderNew {
+	/**
+	 * Provide results that match the given text pattern.
+	 * @param query The parameters for this query.
+	 * @param options A set of options to consider while searching.
+	 * @param progress A progress callback that must be invoked for all results.
+	 * @param token A cancellation token.
+	 */
+	provideTextSearchResults(query: TextSearchQueryNew, options: TextSearchProviderOptions, progress: IProgress<TextSearchResultNew>, token: CancellationToken): ProviderResult<TextSearchCompleteNew>;
+}
+
 /**
  * Information collected when text search is complete.
  */
@@ -382,7 +417,7 @@ export interface FileSearchProviderNew {
 	 * @param progress A progress callback that must be invoked for all results.
 	 * @param token A cancellation token.
 	 */
-	provideFileSearchResults(pattern: string, options: FileSearchProviderOptions, token: CancellationToken): ProviderResult<SearchResultFromFolder<URI>[]>;
+	provideFileSearchResults(pattern: string, options: FileSearchProviderOptions, token: CancellationToken): ProviderResult<URI[]>;
 }
 
 /**
@@ -396,7 +431,7 @@ export interface TextSearchProviderNew {
 	 * @param progress A progress callback that must be invoked for all results.
 	 * @param token A cancellation token.
 	 */
-	provideTextSearchResults(query: TextSearchQueryNew, options: TextSearchProviderOptions, progress: IProgress<SearchResultFromFolder<TextSearchResultNew>>, token: CancellationToken): ProviderResult<TextSearchCompleteNew>;
+	provideTextSearchResults(query: TextSearchQueryNew, options: TextSearchProviderOptions, progress: IProgress<TextSearchResultNew>, token: CancellationToken): ProviderResult<TextSearchCompleteNew>;
 }
 
 /**
@@ -502,13 +537,5 @@ export interface AITextSearchProviderNew {
 	 * @param progress A progress callback that must be invoked for all results.
 	 * @param token A cancellation token.
 	 */
-	provideAITextSearchResults(query: string, options: TextSearchProviderOptions, progress: IProgress<SearchResultFromFolder<TextSearchResultNew>>, token: CancellationToken): ProviderResult<TextSearchCompleteNew>;
+	provideAITextSearchResults(query: string, options: TextSearchProviderOptions, progress: IProgress<TextSearchResultNew>, token: CancellationToken): ProviderResult<TextSearchCompleteNew>;
 }
-
-/**
- * A wrapper for a search result that indicates the original workspace folder that this result was found for.
- */
-export type SearchResultFromFolder<T> = {
-	result: T;
-	folder: URI;
-};

--- a/src/vs/workbench/services/search/test/node/textSearchManager.test.ts
+++ b/src/vs/workbench/services/search/test/node/textSearchManager.test.ts
@@ -9,14 +9,14 @@ import { URI } from '../../../../../base/common/uri.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { Progress } from '../../../../../platform/progress/common/progress.js';
 import { ITextQuery, QueryType } from '../../common/search.js';
-import { ProviderResult, TextSearchCompleteNew, TextSearchProviderOptions, TextSearchProviderNew, TextSearchQueryNew, TextSearchResultNew, SearchResultFromFolder } from '../../common/searchExtTypes.js';
+import { ProviderResult, TextSearchCompleteNew, TextSearchProviderOptions, TextSearchProviderNew, TextSearchQueryNew, TextSearchResultNew } from '../../common/searchExtTypes.js';
 import { NativeTextSearchManager } from '../../node/textSearchManager.js';
 
 suite('NativeTextSearchManager', () => {
 	test('fixes encoding', async () => {
 		let correctEncoding = false;
 		const provider: TextSearchProviderNew = {
-			provideTextSearchResults(query: TextSearchQueryNew, options: TextSearchProviderOptions, progress: Progress<SearchResultFromFolder<TextSearchResultNew>>, token: CancellationToken): ProviderResult<TextSearchCompleteNew> {
+			provideTextSearchResults(query: TextSearchQueryNew, options: TextSearchProviderOptions, progress: Progress<TextSearchResultNew>, token: CancellationToken): ProviderResult<TextSearchCompleteNew> {
 				correctEncoding = options.folderOptions[0].encoding === 'windows-1252';
 
 				return null;

--- a/src/vscode-dts/vscode.proposed.aiTextSearchProviderNew.d.ts
+++ b/src/vscode-dts/vscode.proposed.aiTextSearchProviderNew.d.ts
@@ -17,7 +17,7 @@ declare module 'vscode' {
 		 * @param progress A progress callback that must be invoked for all results.
 		 * @param token A cancellation token.
 		 */
-		provideAITextSearchResults(query: string, options: TextSearchProviderOptions, progress: Progress<SearchResultFromFolder<TextSearchResultNew>>, token: CancellationToken): ProviderResult<TextSearchCompleteNew>;
+		provideAITextSearchResults(query: string, options: TextSearchProviderOptions, progress: Progress<TextSearchResultNew>, token: CancellationToken): ProviderResult<TextSearchCompleteNew>;
 	}
 
 	export namespace workspace {

--- a/src/vscode-dts/vscode.proposed.fileSearchProviderNew.d.ts
+++ b/src/vscode-dts/vscode.proposed.fileSearchProviderNew.d.ts
@@ -81,9 +81,8 @@ declare module 'vscode' {
 		 * @param pattern The search pattern to match against file paths.
 		 * @param options A set of options to consider while searching files.
 		 * @param token A cancellation token.
-		 * @returns A list of matching URIs, where each URI is associated with a workspace folder.
 		 */
-		provideFileSearchResults(pattern: string, options: FileSearchProviderOptions, token: CancellationToken): ProviderResult<SearchResultFromFolder<Uri>[]>;
+		provideFileSearchResults(pattern: string, options: FileSearchProviderOptions, token: CancellationToken): ProviderResult<Uri[]>;
 	}
 
 	export namespace workspace {

--- a/src/vscode-dts/vscode.proposed.textSearchProviderNew.d.ts
+++ b/src/vscode-dts/vscode.proposed.textSearchProviderNew.d.ts
@@ -244,14 +244,6 @@ declare module 'vscode' {
 	export type TextSearchResultNew = TextSearchMatchNew | TextSearchContextNew;
 
 	/**
-	 * A wrapper for a search result that indicates the original workspace folder that this result was found for.
-	 */
-	export type SearchResultFromFolder<T> = {
-		result: T;
-		folder: Uri;
-	};
-
-	/**
 	 * A TextSearchProvider provides search results for text results inside files in the workspace.
 	 */
 	export interface TextSearchProviderNew {
@@ -265,7 +257,7 @@ declare module 'vscode' {
 		 * These results can be direct matches, or context that surrounds matches.
 		 * @param token A cancellation token.
 		 */
-		provideTextSearchResults(query: TextSearchQueryNew, options: TextSearchProviderOptions, progress: Progress<SearchResultFromFolder<TextSearchResultNew>>, token: CancellationToken): ProviderResult<TextSearchCompleteNew>;
+		provideTextSearchResults(query: TextSearchQueryNew, options: TextSearchProviderOptions, progress: Progress<TextSearchResultNew>, token: CancellationToken): ProviderResult<TextSearchCompleteNew>;
 	}
 
 	export namespace workspace {


### PR DESCRIPTION
Reverts microsoft/vscode#227256

I didn't notice that this was fixed on the adopter's side. https://github.com/microsoft/vscode/issues/227248