### PR TITLE
Ignore tsserver requests for `createDirectoryWatcher(~/Library)` on macOS

### DIFF
--- a/extensions/shared.webpack.config.js
+++ b/extensions/shared.webpack.config.js
@@ -117,6 +117,7 @@ function withBrowserDefaults(/**@type WebpackConfig & { context: string }*/extCo
 			extensions: ['.ts', '.js'], // support ts-files and js-files
 			fallback: {
 				'path': require.resolve('path-browserify'),
+				'os': require.resolve('os-browserify'),
 				'util': require.resolve('util')
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -201,6 +201,7 @@
     "opn": "^6.0.0",
     "p-all": "^1.0.0",
     "path-browserify": "^1.0.1",
+    "os-browserify": "^0.3.0",
     "postcss": "^8.4.33",
     "postcss-nesting": "^12.0.2",
     "pump": "^1.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7555,6 +7555,11 @@ ordered-read-streams@^1.0.0:
   dependencies:
     readable-stream "^2.0.1"
 
+os-browserify@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/os-browserify/-/os-browserify-0.3.0.tgz#854373c7f5c2315914fc9bfc6bd8238fdda1ec27"
+  integrity sha512-gjcpUc3clBf9+210TRaDWbf+rZZZEshZ+DlXMRCeAjp0xhTrnQsKHypIy1J3d5hKdUzj69t708EHtU8P6bUn0A==
+
 os-homedir@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-homedir/-/os-homedir-1.0.2.tgz#ffbc4988336e0e833de0c168c7ef152121aa7fb3"


### PR DESCRIPTION
Reland: https://github.com/microsoft/vscode/commit/eecc438ddab5e94d85c8cae75a618f1ffc523f5c