### PR TITLE
Use proxy settings when fetching a token if applicable

### DIFF
--- a/extensions/microsoft-authentication/package.json
+++ b/extensions/microsoft-authentication/package.json
@@ -128,6 +128,7 @@
     "@azure/ms-rest-azure-env": "^2.0.0",
     "@azure/msal-node": "^2.13.0",
     "@vscode/extension-telemetry": "^0.9.0",
+    "undici": "^6.19.8",
     "vscode-tas-client": "^0.1.84"
   },
   "repository": {

--- a/extensions/microsoft-authentication/yarn.lock
+++ b/extensions/microsoft-authentication/yarn.lock
@@ -305,6 +305,11 @@ undici-types@~5.26.4:
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-5.26.5.tgz#bcd539893d00b56e964fd2657a4866b221a65617"
   integrity sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==
 
+undici@^6.19.8:
+  version "6.19.8"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-6.19.8.tgz#002d7c8a28f8cc3a44ff33c3d4be4d85e15d40e1"
+  integrity sha512-U8uCCl2x9TK3WANvmBavymRzxbfFYG+tAu+fgx3zxQy3qdagQqBLwJVrdyO1TBfUXvfKveMKJZhpvUYoOjM+4g==
+
 uuid@^8.3.0:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
Fixes #226662 

Conditionally adds a proxy agent dispatcher to the fetch call in fetchTokenResponse if the HTTPS_PROXY environment variable is defined. This can be tested by doing the following:

1. Use VS Code behind a proxy server
2. Ensure the `HTTPS_PROXY` environment variable is set to the proxy server's address
3. Try and make a call to the `getSession` function from the `authentication` package included with VS Code similar to the one below.

```typescript
const session: Session = await authentication.getSession(
      'microsoft',
      [
        'VSCODE_CLIENT_ID:[REMOVED]',
        'VSCODE_TENANT:[REMOVED]',
        'offline_access',
        'https://graph.microsoft.com/User.Read',
      ],
      { createIfNone: true }
    );
```
4. The call should succeed with a session being created.
