### PR TITLE
Add long-press E fix on MacOS for EditContext

### DIFF
--- a/src/vs/editor/browser/controller/editContext/native/nativeEditContext.ts
+++ b/src/vs/editor/browser/controller/editContext/native/nativeEditContext.ts
@@ -97,7 +97,10 @@ export class NativeEditContext extends AbstractEditContext {
 				this._editContext.updateCompositionRangeWithinEditor(newCompositionRangeWithinEditor);
 			}
 			this._emitTypeEvent(viewController, e);
-			// this._screenReaderSupport.writeScreenReaderContent();
+
+			// TODO @aiday-mar calling write screen reader content so that the document selection is immediately set
+			// remove the following when electron will be upgraded
+			this._screenReaderSupport.writeScreenReaderContent();
 		}));
 		this._register(this._editContext.onCompositionStart(e => {
 			const position = this._context.viewModel.getPrimaryCursorState().viewState.position;

--- a/src/vs/editor/browser/controller/editContext/native/screenReaderSupport.ts
+++ b/src/vs/editor/browser/controller/editContext/native/screenReaderSupport.ts
@@ -113,9 +113,12 @@ export class ScreenReaderSupport {
 
 	private _getScreenReaderContentState(): ScreenReaderContentState | undefined {
 		// Make the screen reader content always be visible because of the bug and also set the selection
-		if (this._accessibilitySupport === AccessibilitySupport.Disabled) {
-			return;
-		}
+
+		// TODO @aiday-mar Ultimately uncomment this code when Electron will be upgraded
+		// if (this._accessibilitySupport === AccessibilitySupport.Disabled) {
+		// 	return;
+		// }
+		const accessibilityPageSize = this._accessibilitySupport === AccessibilitySupport.Disabled ? 1 : this._accessibilityPageSize;
 		const simpleModel: ISimpleModel = {
 			getLineCount: (): number => {
 				return this._context.viewModel.getLineCount();
@@ -133,7 +136,7 @@ export class ScreenReaderSupport {
 				return this._context.viewModel.modifyPosition(position, offset);
 			}
 		};
-		return PagedScreenReaderStrategy.fromEditorSelection(simpleModel, this._primarySelection, this._accessibilityPageSize, this._accessibilitySupport === AccessibilitySupport.Unknown);
+		return PagedScreenReaderStrategy.fromEditorSelection(simpleModel, this._primarySelection, accessibilityPageSize, this._accessibilitySupport === AccessibilitySupport.Unknown);
 	}
 
 	private _setSelectionOfScreenReaderContent(selectionOffsetStart: number, selectionOffsetEnd: number): void {


### PR DESCRIPTION
This pull-request fixes the long-press E fix on MacOS for EditContext.

To fix the long-press E issue we set the document selection immediately after a text update event. This implies the hidden div element always contains text so that the selection can be set. 

The code in this PR must be reverted once we have upgraded to a higher Eletron and thus Chromium version. 

Before:

https://github.com/user-attachments/assets/f917f87f-88fa-4eaa-b84c-39f7d7fb84f2

After:

https://github.com/user-attachments/assets/ef71be87-325d-466d-8b27-bb89de2866ff