### PR TITLE
Fix shell integration for windows julia

### DIFF
--- a/src/vs/platform/terminal/node/windowsShellHelper.ts
+++ b/src/vs/platform/terminal/node/windowsShellHelper.ts
@@ -143,7 +143,7 @@ export class WindowsShellHelper extends Disposable implements IWindowsShellHelpe
 			case 'bash.exe':
 			case 'git-cmd.exe':
 				return WindowsShellType.GitBash;
-			case 'julia.exe:':
+			case 'julialauncher.exe':
 				return GeneralShellType.Julia;
 			case 'nu.exe':
 				return GeneralShellType.NuShell;


### PR DESCRIPTION
Related: https://github.com/microsoft/vscode/pull/225083 
https://github.com/microsoft/vscode/issues/224325 

Debugging on windows showed we should search for julialauncher.exe rather than julia.exe for windows julia users. 
<img width="1433" alt="Screenshot 2024-09-05 at 3 40 00 PM" src="https://github.com/user-attachments/assets/dca17f19-13a1-4544-8989-fd1112a21768">

Turns out we should use 'julialauncher.exe'  rather than 'julia.exe' - for the executable to fire event.