### PR TITLE
debug: adopt formalized DAP ANSI styling support

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/baseDebugView.ts
+++ b/src/vs/workbench/contrib/debug/browser/baseDebugView.ts
@@ -17,20 +17,15 @@ import { KeyCode } from '../../../../base/common/keyCodes.js';
 import { DisposableStore, IDisposable, dispose, toDisposable } from '../../../../base/common/lifecycle.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
 import { localize } from '../../../../nls.js';
-import { CommandsRegistry, ICommandService } from '../../../../platform/commands/common/commands.js';
+import { ICommandService } from '../../../../platform/commands/common/commands.js';
 import { IContextViewService } from '../../../../platform/contextview/browser/contextView.js';
 import { IHoverService } from '../../../../platform/hover/browser/hover.js';
 import { defaultInputBoxStyles } from '../../../../platform/theme/browser/defaultStyles.js';
-import { COPY_EVALUATE_PATH_ID, COPY_VALUE_ID } from './debugCommands.js';
-import { DebugLinkHoverBehavior, DebugLinkHoverBehaviorTypeData, LinkDetector } from './linkDetector.js';
-import { IDebugService, IExpression, IExpressionValue } from '../common/debug.js';
-import { Expression, ExpressionContainer, Variable } from '../common/debugModel.js';
+import { IDebugService, IExpression } from '../common/debug.js';
+import { Variable } from '../common/debugModel.js';
 import { IDebugVisualizerService } from '../common/debugVisualizers.js';
-import { ReplEvaluationResult } from '../common/replModel.js';
+import { LinkDetector } from './linkDetector.js';
 
-const MAX_VALUE_RENDER_LENGTH_IN_VIEWLET = 1024;
-const booleanRegex = /^(true|false)$/i;
-const stringRegex = /^(['"]).*\1$/;
 const $ = dom.$;
 
 export interface IRenderValueOptions {
@@ -59,117 +54,6 @@ export function renderViewTree(container: HTMLElement): HTMLElement {
 	treeContainer.classList.add('debug-view-content');
 	container.appendChild(treeContainer);
 	return treeContainer;
-}
-
-export function renderExpressionValue(store: DisposableStore, expressionOrValue: IExpressionValue | string, container: HTMLElement, options: IRenderValueOptions, hoverService: IHoverService): void {
-	let value = typeof expressionOrValue === 'string' ? expressionOrValue : expressionOrValue.value;
-
-	// remove stale classes
-	container.className = 'value';
-	// when resolving expressions we represent errors from the server as a variable with name === null.
-	if (value === null || ((expressionOrValue instanceof Expression || expressionOrValue instanceof Variable || expressionOrValue instanceof ReplEvaluationResult) && !expressionOrValue.available)) {
-		container.classList.add('unavailable');
-		if (value !== Expression.DEFAULT_VALUE) {
-			container.classList.add('error');
-		}
-	} else {
-		if (typeof expressionOrValue !== 'string' && options.showChanged && expressionOrValue.valueChanged && value !== Expression.DEFAULT_VALUE) {
-			// value changed color has priority over other colors.
-			container.className = 'value changed';
-			expressionOrValue.valueChanged = false;
-		}
-
-		if (options.colorize && typeof expressionOrValue !== 'string') {
-			if (expressionOrValue.type === 'number' || expressionOrValue.type === 'boolean' || expressionOrValue.type === 'string') {
-				container.classList.add(expressionOrValue.type);
-			} else if (!isNaN(+value)) {
-				container.classList.add('number');
-			} else if (booleanRegex.test(value)) {
-				container.classList.add('boolean');
-			} else if (stringRegex.test(value)) {
-				container.classList.add('string');
-			}
-		}
-	}
-
-	if (options.maxValueLength && value && value.length > options.maxValueLength) {
-		value = value.substring(0, options.maxValueLength) + '...';
-	}
-	if (!value) {
-		value = '';
-	}
-
-	const session = (expressionOrValue instanceof ExpressionContainer) ? expressionOrValue.getSession() : undefined;
-	// Only use hovers for links if thre's not going to be a hover for the value.
-	const hoverBehavior: DebugLinkHoverBehaviorTypeData = options.hover === false ? { type: DebugLinkHoverBehavior.Rich, store } : { type: DebugLinkHoverBehavior.None };
-	if (expressionOrValue instanceof ExpressionContainer && expressionOrValue.valueLocationReference !== undefined && session && options.linkDetector) {
-		container.textContent = '';
-		container.appendChild(options.linkDetector.linkifyLocation(value, expressionOrValue.valueLocationReference, session, hoverBehavior));
-	} else if (options.linkDetector) {
-		container.textContent = '';
-		container.appendChild(options.linkDetector.linkify(value, false, session ? session.root : undefined, true, hoverBehavior));
-	} else {
-		container.textContent = value;
-	}
-
-	if (options.hover !== false) {
-		const { commands = [], commandService } = options.hover || {};
-		store.add(hoverService.setupManagedHover(getDefaultHoverDelegate('mouse'), container, () => {
-			const container = dom.$('div');
-			const markdownHoverElement = dom.$('div.hover-row');
-			const hoverContentsElement = dom.append(markdownHoverElement, dom.$('div.hover-contents'));
-			const hoverContentsPre = dom.append(hoverContentsElement, dom.$('pre.debug-var-hover-pre'));
-			hoverContentsPre.textContent = value;
-			container.appendChild(markdownHoverElement);
-			return container;
-		}, {
-			actions: commands.map(({ id, args }) => {
-				const description = CommandsRegistry.getCommand(id)?.metadata?.description;
-				return {
-					label: typeof description === 'string' ? description : description ? description.value : id,
-					commandId: id,
-					run: () => commandService!.executeCommand(id, ...args),
-				};
-			})
-		}));
-	}
-}
-
-export function renderVariable(store: DisposableStore, commandService: ICommandService, hoverService: IHoverService, variable: Variable, data: IVariableTemplateData, showChanged: boolean, highlights: IHighlight[], linkDetector?: LinkDetector, displayType?: boolean): void {
-	if (variable.available) {
-		data.type.textContent = '';
-		let text = variable.name;
-		if (variable.value && typeof variable.name === 'string') {
-			if (variable.type && displayType) {
-				text += ': ';
-				data.type.textContent = variable.type + ' =';
-			} else {
-				text += ' =';
-			}
-		}
-
-		data.label.set(text, highlights, variable.type && !displayType ? variable.type : variable.name);
-		data.name.classList.toggle('virtual', variable.presentationHint?.kind === 'virtual');
-		data.name.classList.toggle('internal', variable.presentationHint?.visibility === 'internal');
-	} else if (variable.value && typeof variable.name === 'string' && variable.name) {
-		data.label.set(':');
-	}
-
-	data.expression.classList.toggle('lazy', !!variable.presentationHint?.lazy);
-	const commands = [
-		{ id: COPY_VALUE_ID, args: [variable, [variable]] as unknown[] }
-	];
-	if (variable.evaluateName) {
-		commands.push({ id: COPY_EVALUATE_PATH_ID, args: [{ variable }] });
-	}
-
-	renderExpressionValue(store, variable, data.value, {
-		showChanged,
-		maxValueLength: MAX_VALUE_RENDER_LENGTH_IN_VIEWLET,
-		hover: { commands, commandService },
-		colorize: true,
-		linkDetector
-	}, hoverService);
 }
 
 export interface IInputBoxOptions {

--- a/src/vs/workbench/contrib/debug/browser/debugANSIHandling.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugANSIHandling.ts
@@ -378,7 +378,7 @@ export function handleANSIOutput(text: string, linkDetector: ILinkDetector, work
 
 		if (colorIndex !== undefined && colorType) {
 			const colorName = ansiColorIdentifiers[colorIndex];
-			changeColor(colorType, `--vscode-terminal-${colorName}`);
+			changeColor(colorType, `--vscode-${colorName.replaceAll('.', '-')}`);
 		}
 	}
 }

--- a/src/vs/workbench/contrib/debug/browser/debugANSIHandling.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugANSIHandling.ts
@@ -4,7 +4,6 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { Color, RGBA } from '../../../../base/common/color.js';
-import { IThemeService } from '../../../../platform/theme/common/themeService.js';
 import { IWorkspaceFolder } from '../../../../platform/workspace/common/workspace.js';
 import { ansiColorIdentifiers } from '../../terminal/common/terminalColorRegistry.js';
 import { ILinkDetector } from './linkDetector.js';
@@ -13,15 +12,15 @@ import { ILinkDetector } from './linkDetector.js';
  * @param text The content to stylize.
  * @returns An {@link HTMLSpanElement} that contains the potentially stylized text.
  */
-export function handleANSIOutput(text: string, linkDetector: ILinkDetector, themeService: IThemeService, workspaceFolder: IWorkspaceFolder | undefined): HTMLSpanElement {
+export function handleANSIOutput(text: string, linkDetector: ILinkDetector, workspaceFolder: IWorkspaceFolder | undefined): HTMLSpanElement {
 
 	const root: HTMLSpanElement = document.createElement('span');
 	const textLength: number = text.length;
 
 	let styleNames: string[] = [];
-	let customFgColor: RGBA | undefined;
-	let customBgColor: RGBA | undefined;
-	let customUnderlineColor: RGBA | undefined;
+	let customFgColor: RGBA | string | undefined;
+	let customBgColor: RGBA | string | undefined;
+	let customUnderlineColor: RGBA | string | undefined;
 	let colorsInverted: boolean = false;
 	let currentPos: number = 0;
 	let buffer: string = '';
@@ -116,7 +115,7 @@ export function handleANSIOutput(text: string, linkDetector: ILinkDetector, them
 	 * @param color Color to change to. If `undefined` or not provided,
 	 * will clear current color without adding a new one.
 	 */
-	function changeColor(colorType: 'foreground' | 'background' | 'underline', color?: RGBA | undefined): void {
+	function changeColor(colorType: 'foreground' | 'background' | 'underline', color?: RGBA | string): void {
 		if (colorType === 'foreground') {
 			customFgColor = color;
 		} else if (colorType === 'background') {
@@ -135,7 +134,7 @@ export function handleANSIOutput(text: string, linkDetector: ILinkDetector, them
 	 * [] flag to make sure it is appropriate to turn ON or OFF (if it is already inverted don't call
 	 */
 	function reverseForegroundAndBackgroundColors(): void {
-		const oldFgColor: RGBA | undefined = customFgColor;
+		const oldFgColor = customFgColor;
 		changeColor('foreground', customBgColor);
 		changeColor('background', oldFgColor);
 	}
@@ -334,12 +333,8 @@ export function handleANSIOutput(text: string, linkDetector: ILinkDetector, them
 		} else if (colorNumber >= 0 && colorNumber <= 15) {
 			if (colorType === 'underline') {
 				// for underline colors we just decode the 0-15 color number to theme color, set and return
-				const theme = themeService.getColorTheme();
 				const colorName = ansiColorIdentifiers[colorNumber];
-				const color = theme.getColor(colorName);
-				if (color) {
-					changeColor(colorType, color.rgba);
-				}
+				changeColor(colorType, `--vscode-treminal-${colorName}`);
 				return;
 			}
 			// Need to map to one of the four basic color ranges (30-37, 90-97, 40-47, 100-107)
@@ -364,7 +359,6 @@ export function handleANSIOutput(text: string, linkDetector: ILinkDetector, them
 	 * nothing.
 	 */
 	function setBasicColor(styleCode: number): void {
-		const theme = themeService.getColorTheme();
 		let colorType: 'foreground' | 'background' | undefined;
 		let colorIndex: number | undefined;
 
@@ -384,10 +378,7 @@ export function handleANSIOutput(text: string, linkDetector: ILinkDetector, them
 
 		if (colorIndex !== undefined && colorType) {
 			const colorName = ansiColorIdentifiers[colorIndex];
-			const color = theme.getColor(colorName);
-			if (color) {
-				changeColor(colorType, color.rgba);
-			}
+			changeColor(colorType, `--vscode-terminal-${colorName}`);
 		}
 	}
 }
@@ -407,9 +398,9 @@ export function appendStylizedStringToContainer(
 	cssClasses: string[],
 	linkDetector: ILinkDetector,
 	workspaceFolder: IWorkspaceFolder | undefined,
-	customTextColor?: RGBA,
-	customBackgroundColor?: RGBA,
-	customUnderlineColor?: RGBA
+	customTextColor?: RGBA | string,
+	customBackgroundColor?: RGBA | string,
+	customUnderlineColor?: RGBA | string,
 ): void {
 	if (!root || !stringContent) {
 		return;
@@ -420,16 +411,17 @@ export function appendStylizedStringToContainer(
 	container.className = cssClasses.join(' ');
 	if (customTextColor) {
 		container.style.color =
-			Color.Format.CSS.formatRGB(new Color(customTextColor));
+			typeof customTextColor === 'string' ? `var(${customTextColor})` : Color.Format.CSS.formatRGB(new Color(customTextColor));
 	}
 	if (customBackgroundColor) {
 		container.style.backgroundColor =
-			Color.Format.CSS.formatRGB(new Color(customBackgroundColor));
+			typeof customBackgroundColor === 'string' ? `var(${customBackgroundColor})` : Color.Format.CSS.formatRGB(new Color(customBackgroundColor));
 	}
 	if (customUnderlineColor) {
 		container.style.textDecorationColor =
-			Color.Format.CSS.formatRGB(new Color(customUnderlineColor));
+			typeof customUnderlineColor === 'string' ? `var(${customUnderlineColor})` : Color.Format.CSS.formatRGB(new Color(customUnderlineColor));
 	}
+
 	root.appendChild(container);
 }
 

--- a/src/vs/workbench/contrib/debug/browser/debugExpressionRenderer.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugExpressionRenderer.ts
@@ -1,0 +1,180 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as dom from '../../../../base/browser/dom.js';
+import { IHighlight } from '../../../../base/browser/ui/highlightedlabel/highlightedLabel.js';
+import { getDefaultHoverDelegate } from '../../../../base/browser/ui/hover/hoverDelegateFactory.js';
+import { DisposableStore, IDisposable } from '../../../../base/common/lifecycle.js';
+import { IObservable } from '../../../../base/common/observable.js';
+import { CommandsRegistry, ICommandService } from '../../../../platform/commands/common/commands.js';
+import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
+import { IHoverService } from '../../../../platform/hover/browser/hover.js';
+import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
+import { observableConfigValue } from '../../../../platform/observable/common/platformObservableUtils.js';
+import { IDebugSession, IExpressionValue } from '../common/debug.js';
+import { Expression, ExpressionContainer, Variable } from '../common/debugModel.js';
+import { ReplEvaluationResult } from '../common/replModel.js';
+import { IVariableTemplateData } from './baseDebugView.js';
+import { handleANSIOutput } from './debugANSIHandling.js';
+import { COPY_EVALUATE_PATH_ID, COPY_VALUE_ID } from './debugCommands.js';
+import { DebugLinkHoverBehavior, DebugLinkHoverBehaviorTypeData, LinkDetector } from './linkDetector.js';
+
+export interface IValueHoverOptions {
+	/** Commands to show in the hover footer. */
+	commands?: { id: string; args: unknown[] }[];
+}
+
+export interface IRenderValueOptions {
+	showChanged?: boolean;
+	maxValueLength?: number;
+	/** If not false, a rich hover will be shown on the element. */
+	hover?: false | IValueHoverOptions;
+	colorize?: boolean;
+
+	/** @deprecated */
+	wasANSI?: boolean;
+	session?: IDebugSession;
+	locationReference?: number;
+}
+
+export interface IRenderVariableOptions {
+	showChanged?: boolean;
+	highlights?: IHighlight[];
+}
+
+
+const MAX_VALUE_RENDER_LENGTH_IN_VIEWLET = 1024;
+const booleanRegex = /^(true|false)$/i;
+const stringRegex = /^(['"]).*\1$/;
+
+export class DebugExpressionRenderer {
+	private displayType: IObservable<boolean>;
+	private readonly linkDetector: LinkDetector;
+
+	constructor(
+		@ICommandService private readonly commandService: ICommandService,
+		@IConfigurationService configurationService: IConfigurationService,
+		@IInstantiationService instantiationService: IInstantiationService,
+		@IHoverService private readonly hoverService: IHoverService,
+	) {
+		this.linkDetector = instantiationService.createInstance(LinkDetector);
+		this.displayType = observableConfigValue('debug.showVariableTypes', false, configurationService);
+	}
+
+	renderVariable(data: IVariableTemplateData, variable: Variable, options: IRenderVariableOptions = {}): IDisposable {
+		const displayType = this.displayType.get();
+
+		if (variable.available) {
+			data.type.textContent = '';
+			let text = variable.name;
+			if (variable.value && typeof variable.name === 'string') {
+				if (variable.type && displayType) {
+					text += ': ';
+					data.type.textContent = variable.type + ' =';
+				} else {
+					text += ' =';
+				}
+			}
+
+			data.label.set(text, options.highlights, variable.type && !displayType ? variable.type : variable.name);
+			data.name.classList.toggle('virtual', variable.presentationHint?.kind === 'virtual');
+			data.name.classList.toggle('internal', variable.presentationHint?.visibility === 'internal');
+		} else if (variable.value && typeof variable.name === 'string' && variable.name) {
+			data.label.set(':');
+		}
+
+		data.expression.classList.toggle('lazy', !!variable.presentationHint?.lazy);
+		const commands = [
+			{ id: COPY_VALUE_ID, args: [variable, [variable]] as unknown[] }
+		];
+		if (variable.evaluateName) {
+			commands.push({ id: COPY_EVALUATE_PATH_ID, args: [{ variable }] });
+		}
+
+		return this.renderValue(data.value, variable, {
+			showChanged: options.showChanged,
+			maxValueLength: MAX_VALUE_RENDER_LENGTH_IN_VIEWLET,
+			hover: { commands },
+			colorize: true,
+			session: variable.getSession(),
+		});
+	}
+
+	renderValue(container: HTMLElement, expressionOrValue: IExpressionValue | string, options: IRenderValueOptions = {}): IDisposable {
+		const store = new DisposableStore();
+
+		let value = typeof expressionOrValue === 'string' ? expressionOrValue : expressionOrValue.value;
+
+		// remove stale classes
+		container.className = 'value';
+		// when resolving expressions we represent errors from the server as a variable with name === null.
+		if (value === null || ((expressionOrValue instanceof Expression || expressionOrValue instanceof Variable || expressionOrValue instanceof ReplEvaluationResult) && !expressionOrValue.available)) {
+			container.classList.add('unavailable');
+			if (value !== Expression.DEFAULT_VALUE) {
+				container.classList.add('error');
+			}
+		} else {
+			if (typeof expressionOrValue !== 'string' && options.showChanged && expressionOrValue.valueChanged && value !== Expression.DEFAULT_VALUE) {
+				// value changed color has priority over other colors.
+				container.className = 'value changed';
+				expressionOrValue.valueChanged = false;
+			}
+
+			if (options.colorize && typeof expressionOrValue !== 'string') {
+				if (expressionOrValue.type === 'number' || expressionOrValue.type === 'boolean' || expressionOrValue.type === 'string') {
+					container.classList.add(expressionOrValue.type);
+				} else if (!isNaN(+value)) {
+					container.classList.add('number');
+				} else if (booleanRegex.test(value)) {
+					container.classList.add('boolean');
+				} else if (stringRegex.test(value)) {
+					container.classList.add('string');
+				}
+			}
+		}
+
+		if (options.maxValueLength && value && value.length > options.maxValueLength) {
+			value = value.substring(0, options.maxValueLength) + '...';
+		}
+		if (!value) {
+			value = '';
+		}
+
+		const session = (expressionOrValue instanceof ExpressionContainer) ? expressionOrValue.getSession() : undefined;
+		// Only use hovers for links if thre's not going to be a hover for the value.
+		const hoverBehavior: DebugLinkHoverBehaviorTypeData = options.hover === false ? { type: DebugLinkHoverBehavior.Rich, store } : { type: DebugLinkHoverBehavior.None };
+		if (expressionOrValue instanceof ExpressionContainer && expressionOrValue.valueLocationReference !== undefined && session) {
+			container.textContent = '';
+			container.appendChild(this.linkDetector.linkifyLocation(value, expressionOrValue.valueLocationReference, session, hoverBehavior));
+		} else {
+			container.textContent = '';
+			container.appendChild(handleANSIOutput(value, this.linkDetector, session ? session.root : undefined));
+		}
+
+		if (options.hover !== false) {
+			const { commands = [] } = options.hover || {};
+			store.add(this.hoverService.setupManagedHover(getDefaultHoverDelegate('mouse'), container, () => {
+				const container = dom.$('div');
+				const markdownHoverElement = dom.$('div.hover-row');
+				const hoverContentsElement = dom.append(markdownHoverElement, dom.$('div.hover-contents'));
+				const hoverContentsPre = dom.append(hoverContentsElement, dom.$('pre.debug-var-hover-pre'));
+				hoverContentsPre.textContent = value;
+				container.appendChild(markdownHoverElement);
+				return container;
+			}, {
+				actions: commands.map(({ id, args }) => {
+					const description = CommandsRegistry.getCommand(id)?.metadata?.description;
+					return {
+						label: typeof description === 'string' ? description : description ? description.value : id,
+						commandId: id,
+						run: () => this.commandService.executeCommand(id, ...args),
+					};
+				})
+			}));
+		}
+
+		return store;
+	}
+}

--- a/src/vs/workbench/contrib/debug/browser/debugSession.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugSession.ts
@@ -363,7 +363,8 @@ export class DebugSession implements IDebugSession, IDisposable {
 				supportsMemoryReferences: true, //#129684
 				supportsArgsCanBeInterpretedByShell: true, // #149910
 				supportsMemoryEvent: true, // #133643
-				supportsStartDebuggingRequest: true
+				supportsStartDebuggingRequest: true,
+				supportsANSIStyling: true,
 			});
 
 			this.initialized = true;
@@ -1201,7 +1202,7 @@ export class DebugSession implements IDebugSession, IDisposable {
 
 				if (event.body.group === 'start' || event.body.group === 'startCollapsed') {
 					const expanded = event.body.group === 'start';
-					this.repl.startGroup(event.body.output || '', expanded, source);
+					this.repl.startGroup(this, event.body.output || '', expanded, source);
 					return;
 				}
 				if (event.body.group === 'end') {

--- a/src/vs/workbench/contrib/debug/browser/media/debug.contribution.css
+++ b/src/vs/workbench/contrib/debug/browser/media/debug.contribution.css
@@ -59,6 +59,10 @@
 	margin: 0;
 }
 
+.debug-var-hover-pre span {
+	display: inline !important;
+}
+
 /* Do not push text with inline decoration when decoration on start of line */
 .monaco-editor .debug-top-stack-frame-column.start-of-line {
 	position: absolute;

--- a/src/vs/workbench/contrib/debug/browser/replViewer.ts
+++ b/src/vs/workbench/contrib/debug/browser/replViewer.ts
@@ -300,6 +300,7 @@ export class ReplRawObjectsRenderer implements ITreeRenderer<RawObjectReplElemen
 		// value
 		templateData.elementStore.add(this.expressionRenderer.renderValue(templateData.value, element.value, {
 			hover: false,
+			session: node.element.getSession(),
 		}));
 	}
 

--- a/src/vs/workbench/contrib/debug/browser/replViewer.ts
+++ b/src/vs/workbench/contrib/debug/browser/replViewer.ts
@@ -17,22 +17,19 @@ import { basename } from '../../../../base/common/path.js';
 import severity from '../../../../base/common/severity.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
 import { localize } from '../../../../nls.js';
-import { ICommandService } from '../../../../platform/commands/common/commands.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { IContextViewService } from '../../../../platform/contextview/browser/contextView.js';
 import { IHoverService } from '../../../../platform/hover/browser/hover.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { ILabelService } from '../../../../platform/label/common/label.js';
 import { defaultCountBadgeStyles } from '../../../../platform/theme/browser/defaultStyles.js';
-import { IThemeService } from '../../../../platform/theme/common/themeService.js';
-import { AbstractExpressionsRenderer, IExpressionTemplateData, IInputBoxOptions, renderExpressionValue, renderVariable } from './baseDebugView.js';
-import { handleANSIOutput } from './debugANSIHandling.js';
-import { debugConsoleEvaluationInput } from './debugIcons.js';
-import { ILinkDetector, LinkDetector } from './linkDetector.js';
+import { IEditorService } from '../../../services/editor/common/editorService.js';
 import { IDebugConfiguration, IDebugService, IDebugSession, IExpression, IExpressionContainer, INestingReplElement, IReplElement, IReplElementSource, IReplOptions } from '../common/debug.js';
 import { Variable } from '../common/debugModel.js';
 import { RawObjectReplElement, ReplEvaluationInput, ReplEvaluationResult, ReplGroup, ReplOutputElement, ReplVariableElement } from '../common/replModel.js';
-import { IEditorService } from '../../../services/editor/common/editorService.js';
+import { AbstractExpressionsRenderer, IExpressionTemplateData, IInputBoxOptions } from './baseDebugView.js';
+import { DebugExpressionRenderer } from './debugExpressionRenderer.js';
+import { debugConsoleEvaluationInput } from './debugIcons.js';
 
 const $ = dom.$;
 
@@ -43,6 +40,7 @@ interface IReplEvaluationInputTemplateData {
 interface IReplGroupTemplateData {
 	label: HTMLElement;
 	source: SourceWidget;
+	elementDisposable?: IDisposable;
 }
 
 interface IReplEvaluationResultTemplateData {
@@ -57,7 +55,7 @@ interface IOutputReplElementTemplateData {
 	value: HTMLElement;
 	source: SourceWidget;
 	getReplElementSource(): IReplElementSource | undefined;
-	elementListener: IDisposable;
+	elementDisposable: DisposableStore;
 }
 
 interface IRawObjectReplTemplateData {
@@ -97,8 +95,7 @@ export class ReplGroupRenderer implements ITreeRenderer<ReplGroup, FuzzyScore, I
 	static readonly ID = 'replGroup';
 
 	constructor(
-		private readonly linkDetector: LinkDetector,
-		@IThemeService private readonly themeService: IThemeService,
+		private readonly expressionRenderer: DebugExpressionRenderer,
 		@IInstantiationService private readonly instaService: IInstantiationService,
 	) { }
 
@@ -115,14 +112,16 @@ export class ReplGroupRenderer implements ITreeRenderer<ReplGroup, FuzzyScore, I
 	}
 
 	renderElement(element: ITreeNode<ReplGroup, FuzzyScore>, _index: number, templateData: IReplGroupTemplateData): void {
+
+		templateData.elementDisposable?.dispose();
 		const replGroup = element.element;
 		dom.clearNode(templateData.label);
-		const result = handleANSIOutput(replGroup.name, this.linkDetector, this.themeService, undefined);
-		templateData.label.appendChild(result);
+		templateData.elementDisposable = this.expressionRenderer.renderValue(templateData.label, replGroup.name, { wasANSI: true, session: element.element.session });
 		templateData.source.setSource(replGroup.sourceData);
 	}
 
 	disposeTemplate(templateData: IReplGroupTemplateData): void {
+		templateData.elementDisposable?.dispose();
 		templateData.source.dispose();
 	}
 }
@@ -135,8 +134,7 @@ export class ReplEvaluationResultsRenderer implements ITreeRenderer<ReplEvaluati
 	}
 
 	constructor(
-		private readonly linkDetector: LinkDetector,
-		private readonly hoverService: IHoverService
+		private readonly expressionRenderer: DebugExpressionRenderer,
 	) { }
 
 	renderTemplate(container: HTMLElement): IReplEvaluationResultTemplateData {
@@ -149,11 +147,11 @@ export class ReplEvaluationResultsRenderer implements ITreeRenderer<ReplEvaluati
 	renderElement(element: ITreeNode<ReplEvaluationResult | Variable, FuzzyScore>, index: number, templateData: IReplEvaluationResultTemplateData): void {
 		templateData.elementStore.clear();
 		const expression = element.element;
-		renderExpressionValue(templateData.elementStore, expression, templateData.value, {
+		templateData.elementStore.add(this.expressionRenderer.renderValue(templateData.value, expression, {
 			colorize: true,
 			hover: false,
-			linkDetector: this.linkDetector,
-		}, this.hoverService);
+			session: element.element.getSession(),
+		}));
 	}
 
 	disposeTemplate(templateData: IReplEvaluationResultTemplateData): void {
@@ -165,8 +163,7 @@ export class ReplOutputElementRenderer implements ITreeRenderer<ReplOutputElemen
 	static readonly ID = 'outputReplElement';
 
 	constructor(
-		private readonly linkDetector: LinkDetector,
-		@IThemeService private readonly themeService: IThemeService,
+		private readonly expressionRenderer: DebugExpressionRenderer,
 		@IInstantiationService private readonly instaService: IInstantiationService,
 	) { }
 
@@ -184,21 +181,22 @@ export class ReplOutputElementRenderer implements ITreeRenderer<ReplOutputElemen
 		data.count = new CountBadge(data.countContainer, {}, defaultCountBadgeStyles);
 		data.value = dom.append(expression, $('span.value.label'));
 		data.source = this.instaService.createInstance(SourceWidget, expression);
+		data.elementDisposable = new DisposableStore();
 
 		return data;
 	}
 
 	renderElement({ element }: ITreeNode<ReplOutputElement, FuzzyScore>, index: number, templateData: IOutputReplElementTemplateData): void {
+		templateData.elementDisposable.clear();
 		this.setElementCount(element, templateData);
-		templateData.elementListener = element.onDidChangeCount(() => this.setElementCount(element, templateData));
+		templateData.elementDisposable.add(element.onDidChangeCount(() => this.setElementCount(element, templateData)));
 		// value
 		dom.clearNode(templateData.value);
 		// Reset classes to clear ansi decorations since templates are reused
 		templateData.value.className = 'value';
 
 		const locationReference = element.expression?.valueLocationReference;
-		const detector: ILinkDetector = locationReference !== undefined ? this.linkDetector.makeReferencedLinkDetector(locationReference, element.session) : this.linkDetector;
-		templateData.value.appendChild(handleANSIOutput(element.value, detector, this.themeService, element.session.root));
+		templateData.elementDisposable.add(this.expressionRenderer.renderValue(templateData.value, element.value, { wasANSI: true, session: element.session, locationReference }));
 
 		templateData.value.classList.add((element.severity === severity.Warning) ? 'warn' : (element.severity === severity.Error) ? 'error' : (element.severity === severity.Ignore) ? 'ignore' : 'info');
 		templateData.source.setSource(element.sourceData);
@@ -216,10 +214,11 @@ export class ReplOutputElementRenderer implements ITreeRenderer<ReplOutputElemen
 
 	disposeTemplate(templateData: IOutputReplElementTemplateData): void {
 		templateData.source.dispose();
+		templateData.elementDisposable.dispose();
 	}
 
 	disposeElement(_element: ITreeNode<ReplOutputElement, FuzzyScore>, _index: number, templateData: IOutputReplElementTemplateData): void {
-		templateData.elementListener.dispose();
+		templateData.elementDisposable.clear();
 	}
 }
 
@@ -232,11 +231,10 @@ export class ReplVariablesRenderer extends AbstractExpressionsRenderer<IExpressi
 	}
 
 	constructor(
-		private readonly linkDetector: LinkDetector,
+		private readonly expressionRenderer: DebugExpressionRenderer,
 		@IDebugService debugService: IDebugService,
 		@IContextViewService contextViewService: IContextViewService,
-		@ICommandService private readonly commandService: ICommandService,
-		@IHoverService hoverService: IHoverService
+		@IHoverService hoverService: IHoverService,
 	) {
 		super(debugService, contextViewService, hoverService);
 	}
@@ -251,10 +249,11 @@ export class ReplVariablesRenderer extends AbstractExpressionsRenderer<IExpressi
 		const isReplVariable = expression instanceof ReplVariableElement;
 		if (isReplVariable || !expression.name) {
 			data.label.set('');
-			renderExpressionValue(data.elementDisposable, isReplVariable ? expression.expression : expression, data.value, { colorize: true, linkDetector: this.linkDetector, hover: false }, this.hoverService);
+			const value = isReplVariable ? expression.expression : expression;
+			data.elementDisposable.add(this.expressionRenderer.renderValue(data.value, value, { colorize: true, hover: false, session: expression.getSession() }));
 			data.expression.classList.remove('nested-variable');
 		} else {
-			renderVariable(data.elementDisposable, this.commandService, this.hoverService, expression as Variable, data, true, highlights, this.linkDetector);
+			data.elementDisposable.add(this.expressionRenderer.renderVariable(data, expression as Variable, { showChanged: true, highlights }));
 			data.expression.classList.toggle('nested-variable', isNestedVariable(expression));
 		}
 	}
@@ -268,8 +267,7 @@ export class ReplRawObjectsRenderer implements ITreeRenderer<RawObjectReplElemen
 	static readonly ID = 'rawObject';
 
 	constructor(
-		private readonly linkDetector: LinkDetector,
-		private readonly hoverService: IHoverService
+		private readonly expressionRenderer: DebugExpressionRenderer,
 	) { }
 
 	get templateId(): string {
@@ -300,10 +298,9 @@ export class ReplRawObjectsRenderer implements ITreeRenderer<RawObjectReplElemen
 		}
 
 		// value
-		renderExpressionValue(templateData.elementStore, element.value, templateData.value, {
-			linkDetector: this.linkDetector,
+		templateData.elementStore.add(this.expressionRenderer.renderValue(templateData.value, element.value, {
 			hover: false,
-		}, this.hoverService);
+		}));
 	}
 
 	disposeTemplate(templateData: IRawObjectReplTemplateData): void {

--- a/src/vs/workbench/contrib/debug/browser/variablesView.ts
+++ b/src/vs/workbench/contrib/debug/browser/variablesView.ts
@@ -22,7 +22,7 @@ import { localize } from '../../../../nls.js';
 import { createAndFillInContextMenuActions } from '../../../../platform/actions/browser/menuEntryActionViewItem.js';
 import { IMenuService, MenuId, registerAction2 } from '../../../../platform/actions/common/actions.js';
 import { IClipboardService } from '../../../../platform/clipboard/common/clipboardService.js';
-import { CommandsRegistry, ICommandService } from '../../../../platform/commands/common/commands.js';
+import { CommandsRegistry } from '../../../../platform/commands/common/commands.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { ContextKeyExpr, IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
 import { IContextMenuService, IContextViewService } from '../../../../platform/contextview/browser/contextView.js';
@@ -38,16 +38,16 @@ import { IThemeService } from '../../../../platform/theme/common/themeService.js
 import { ViewAction, ViewPane } from '../../../browser/parts/views/viewPane.js';
 import { IViewletViewOptions } from '../../../browser/parts/views/viewsViewlet.js';
 import { IViewDescriptorService } from '../../../common/views.js';
-import { AbstractExpressionDataSource, AbstractExpressionsRenderer, IExpressionTemplateData, IInputBoxOptions, renderExpressionValue, renderVariable, renderViewTree } from './baseDebugView.js';
-import { ADD_TO_WATCH_ID, ADD_TO_WATCH_LABEL, COPY_EVALUATE_PATH_ID, COPY_EVALUATE_PATH_LABEL, COPY_VALUE_ID, COPY_VALUE_LABEL } from './debugCommands.js';
-import { LinkDetector } from './linkDetector.js';
-import { CONTEXT_BREAK_WHEN_VALUE_CHANGES_SUPPORTED, CONTEXT_BREAK_WHEN_VALUE_IS_ACCESSED_SUPPORTED, CONTEXT_BREAK_WHEN_VALUE_IS_READ_SUPPORTED, CONTEXT_VARIABLES_FOCUSED, DataBreakpointSetType, DebugVisualizationType, IDataBreakpointInfoResponse, IDebugConfiguration, IDebugService, IExpression, IScope, IStackFrame, IViewModel, VARIABLES_VIEW_ID } from '../common/debug.js';
+import { IEditorService, SIDE_GROUP } from '../../../services/editor/common/editorService.js';
+import { IExtensionService } from '../../../services/extensions/common/extensions.js';
+import { IExtensionsWorkbenchService } from '../../extensions/common/extensions.js';
+import { CONTEXT_BREAK_WHEN_VALUE_CHANGES_SUPPORTED, CONTEXT_BREAK_WHEN_VALUE_IS_ACCESSED_SUPPORTED, CONTEXT_BREAK_WHEN_VALUE_IS_READ_SUPPORTED, CONTEXT_VARIABLES_FOCUSED, DataBreakpointSetType, DebugVisualizationType, IDataBreakpointInfoResponse, IDebugService, IExpression, IScope, IStackFrame, IViewModel, VARIABLES_VIEW_ID } from '../common/debug.js';
 import { getContextForVariable } from '../common/debugContext.js';
 import { ErrorScope, Expression, Scope, StackFrame, Variable, VisualizedExpression, getUriForDebugMemory } from '../common/debugModel.js';
 import { DebugVisualizer, IDebugVisualizerService } from '../common/debugVisualizers.js';
-import { IExtensionsWorkbenchService } from '../../extensions/common/extensions.js';
-import { IEditorService, SIDE_GROUP } from '../../../services/editor/common/editorService.js';
-import { IExtensionService } from '../../../services/extensions/common/extensions.js';
+import { AbstractExpressionDataSource, AbstractExpressionsRenderer, IExpressionTemplateData, IInputBoxOptions, renderViewTree } from './baseDebugView.js';
+import { ADD_TO_WATCH_ID, ADD_TO_WATCH_LABEL, COPY_EVALUATE_PATH_ID, COPY_EVALUATE_PATH_LABEL, COPY_VALUE_ID, COPY_VALUE_LABEL } from './debugCommands.js';
+import { DebugExpressionRenderer } from './debugExpressionRenderer.js';
 
 const $ = dom.$;
 let forgetScopes = true;
@@ -122,11 +122,11 @@ export class VariablesView extends ViewPane {
 		this.element.classList.add('debug-pane');
 		container.classList.add('debug-variables');
 		const treeContainer = renderViewTree(container);
-		const linkDetector = this.instantiationService.createInstance(LinkDetector);
+		const expressionRenderer = this.instantiationService.createInstance(DebugExpressionRenderer);
 		this.tree = <WorkbenchAsyncDataTree<IStackFrame | null, IExpression | IScope, FuzzyScore>>this.instantiationService.createInstance(WorkbenchAsyncDataTree, 'VariablesView', treeContainer, new VariablesDelegate(),
 			[
-				this.instantiationService.createInstance(VariablesRenderer, linkDetector),
-				this.instantiationService.createInstance(VisualizedVariableRenderer, linkDetector),
+				this.instantiationService.createInstance(VariablesRenderer, expressionRenderer),
+				this.instantiationService.createInstance(VisualizedVariableRenderer, expressionRenderer),
 				new ScopesRenderer(),
 				new ScopeErrorRenderer(),
 			],
@@ -434,7 +434,7 @@ export class VisualizedVariableRenderer extends AbstractExpressionsRenderer {
 	}
 
 	constructor(
-		private readonly linkDetector: LinkDetector,
+		private readonly expressionRenderer: DebugExpressionRenderer,
 		@IDebugService debugService: IDebugService,
 		@IContextViewService contextViewService: IContextViewService,
 		@IHoverService hoverService: IHoverService,
@@ -461,12 +461,11 @@ export class VisualizedVariableRenderer extends AbstractExpressionsRenderer {
 			text += ':';
 		}
 		data.label.set(text, highlights, viz.name);
-		renderExpressionValue(data.elementDisposable, viz, data.value, {
+		data.elementDisposable.add(this.expressionRenderer.renderValue(data.value, viz, {
 			showChanged: false,
 			maxValueLength: 1024,
 			colorize: true,
-			linkDetector: this.linkDetector
-		}, this.hoverService);
+		}));
 	}
 
 	protected override getInputBoxOptions(expression: IExpression): IInputBoxOptions | undefined {
@@ -516,16 +515,14 @@ export class VariablesRenderer extends AbstractExpressionsRenderer {
 	static readonly ID = 'variable';
 
 	constructor(
-		private readonly linkDetector: LinkDetector,
+		private readonly expressionRenderer: DebugExpressionRenderer,
 		@IMenuService private readonly menuService: IMenuService,
 		@IContextKeyService private readonly contextKeyService: IContextKeyService,
 		@IDebugVisualizerService private readonly visualization: IDebugVisualizerService,
 		@IContextMenuService private readonly contextMenuService: IContextMenuService,
-		@ICommandService private readonly commandService: ICommandService,
 		@IDebugService debugService: IDebugService,
 		@IContextViewService contextViewService: IContextViewService,
 		@IHoverService hoverService: IHoverService,
-		@IConfigurationService private configurationService: IConfigurationService,
 	) {
 		super(debugService, contextViewService, hoverService);
 	}
@@ -535,17 +532,14 @@ export class VariablesRenderer extends AbstractExpressionsRenderer {
 	}
 
 	protected renderExpression(expression: IExpression, data: IExpressionTemplateData, highlights: IHighlight[]): void {
-		const showType = this.configurationService.getValue<IDebugConfiguration>('debug').showVariableTypes;
-		renderVariable(data.elementDisposable, this.commandService, this.hoverService, expression as Variable, data, true, highlights, this.linkDetector, showType);
+		data.elementDisposable.add(this.expressionRenderer.renderVariable(data, expression as Variable, {
+			highlights,
+			showChanged: true,
+		}));
 	}
 
 	public override renderElement(node: ITreeNode<IExpression, FuzzyScore>, index: number, data: IExpressionTemplateData): void {
 		data.elementDisposable.clear();
-		data.elementDisposable.add(this.configurationService.onDidChangeConfiguration(e => {
-			if (e.affectsConfiguration('debug.showVariableTypes')) {
-				super.renderExpressionElement(node.element, node, data);
-			}
-		}));
 		super.renderExpressionElement(node.element, node, data);
 	}
 

--- a/src/vs/workbench/contrib/debug/browser/variablesView.ts
+++ b/src/vs/workbench/contrib/debug/browser/variablesView.ts
@@ -465,6 +465,7 @@ export class VisualizedVariableRenderer extends AbstractExpressionsRenderer {
 			showChanged: false,
 			maxValueLength: 1024,
 			colorize: true,
+			session: expression.getSession(),
 		}));
 	}
 

--- a/src/vs/workbench/contrib/debug/browser/watchExpressionsView.ts
+++ b/src/vs/workbench/contrib/debug/browser/watchExpressionsView.ts
@@ -30,12 +30,12 @@ import { IThemeService } from '../../../../platform/theme/common/themeService.js
 import { ViewAction, ViewPane } from '../../../browser/parts/views/viewPane.js';
 import { IViewletViewOptions } from '../../../browser/parts/views/viewsViewlet.js';
 import { IViewDescriptorService } from '../../../common/views.js';
-import { AbstractExpressionDataSource, AbstractExpressionsRenderer, IExpressionTemplateData, IInputBoxOptions, renderExpressionValue, renderViewTree } from './baseDebugView.js';
-import { watchExpressionsAdd, watchExpressionsRemoveAll } from './debugIcons.js';
-import { LinkDetector } from './linkDetector.js';
-import { VariablesRenderer, VisualizedVariableRenderer } from './variablesView.js';
 import { CONTEXT_CAN_VIEW_MEMORY, CONTEXT_VARIABLE_IS_READONLY, CONTEXT_WATCH_EXPRESSIONS_EXIST, CONTEXT_WATCH_EXPRESSIONS_FOCUSED, CONTEXT_WATCH_ITEM_TYPE, IDebugConfiguration, IDebugService, IExpression, WATCH_VIEW_ID } from '../common/debug.js';
 import { Expression, Variable, VisualizedExpression } from '../common/debugModel.js';
+import { AbstractExpressionDataSource, AbstractExpressionsRenderer, IExpressionTemplateData, IInputBoxOptions, renderViewTree } from './baseDebugView.js';
+import { DebugExpressionRenderer } from './debugExpressionRenderer.js';
+import { watchExpressionsAdd, watchExpressionsRemoveAll } from './debugIcons.js';
+import { VariablesRenderer, VisualizedVariableRenderer } from './variablesView.js';
 
 const MAX_VALUE_RENDER_LENGTH_IN_VIEWLET = 1024;
 let ignoreViewUpdates = false;
@@ -50,6 +50,7 @@ export class WatchExpressionsView extends ViewPane {
 	private watchItemType: IContextKey<string | undefined>;
 	private variableReadonly: IContextKey<boolean>;
 	private menu: IMenu;
+	private expressionRenderer: DebugExpressionRenderer;
 
 	constructor(
 		options: IViewletViewOptions,
@@ -78,6 +79,7 @@ export class WatchExpressionsView extends ViewPane {
 		this.variableReadonly = CONTEXT_VARIABLE_IS_READONLY.bindTo(contextKeyService);
 		this.watchExpressionsExist.set(this.debugService.getModel().getWatchExpressions().length > 0);
 		this.watchItemType = CONTEXT_WATCH_ITEM_TYPE.bindTo(contextKeyService);
+		this.expressionRenderer = instantiationService.createInstance(DebugExpressionRenderer);
 	}
 
 	protected override renderBody(container: HTMLElement): void {
@@ -87,13 +89,12 @@ export class WatchExpressionsView extends ViewPane {
 		container.classList.add('debug-watch');
 		const treeContainer = renderViewTree(container);
 
-		const linkDetector = this.instantiationService.createInstance(LinkDetector);
-		const expressionsRenderer = this.instantiationService.createInstance(WatchExpressionsRenderer, linkDetector);
+		const expressionsRenderer = this.instantiationService.createInstance(WatchExpressionsRenderer, this.expressionRenderer);
 		this.tree = <WorkbenchAsyncDataTree<IDebugService | IExpression, IExpression, FuzzyScore>>this.instantiationService.createInstance(WorkbenchAsyncDataTree, 'WatchExpressions', treeContainer, new WatchExpressionsDelegate(),
 			[
 				expressionsRenderer,
-				this.instantiationService.createInstance(VariablesRenderer, linkDetector),
-				this.instantiationService.createInstance(VisualizedVariableRenderer, linkDetector),
+				this.instantiationService.createInstance(VariablesRenderer, this.expressionRenderer),
+				this.instantiationService.createInstance(VisualizedVariableRenderer, this.expressionRenderer),
 			],
 			this.instantiationService.createInstance(WatchExpressionsDataSource), {
 			accessibilityProvider: new WatchExpressionsAccessibilityProvider(),
@@ -279,7 +280,7 @@ export class WatchExpressionsRenderer extends AbstractExpressionsRenderer {
 	static readonly ID = 'watchexpression';
 
 	constructor(
-		private readonly linkDetector: LinkDetector,
+		private readonly expressionRenderer: DebugExpressionRenderer,
 		@IMenuService private readonly menuService: IMenuService,
 		@IContextKeyService private readonly contextKeyService: IContextKeyService,
 		@IDebugService debugService: IDebugService,
@@ -330,12 +331,11 @@ export class WatchExpressionsRenderer extends AbstractExpressionsRenderer {
 		}
 
 		data.label.set(text, highlights, title);
-		renderExpressionValue(data.elementDisposable, expression, data.value, {
+		data.elementDisposable.add(this.expressionRenderer.renderValue(data.value, expression, {
 			showChanged: true,
 			maxValueLength: MAX_VALUE_RENDER_LENGTH_IN_VIEWLET,
-			linkDetector: this.linkDetector,
 			colorize: true
-		}, this.hoverService);
+		}));
 	}
 
 	protected getInputBoxOptions(expression: IExpression, settingValue: boolean): IInputBoxOptions {

--- a/src/vs/workbench/contrib/debug/browser/watchExpressionsView.ts
+++ b/src/vs/workbench/contrib/debug/browser/watchExpressionsView.ts
@@ -334,7 +334,8 @@ export class WatchExpressionsRenderer extends AbstractExpressionsRenderer {
 		data.elementDisposable.add(this.expressionRenderer.renderValue(data.value, expression, {
 			showChanged: true,
 			maxValueLength: MAX_VALUE_RENDER_LENGTH_IN_VIEWLET,
-			colorize: true
+			colorize: true,
+			session: expression.getSession(),
 		}));
 	}
 

--- a/src/vs/workbench/contrib/debug/common/debug.ts
+++ b/src/vs/workbench/contrib/debug/common/debug.ts
@@ -164,6 +164,7 @@ export interface IExpressionValue {
 
 export interface IExpressionContainer extends ITreeElement, IExpressionValue {
 	readonly hasChildren: boolean;
+	getSession(): IDebugSession | undefined;
 	evaluateLazy(): Promise<void>;
 	getChildren(): Promise<IExpression[]>;
 	readonly reference?: number;

--- a/src/vs/workbench/contrib/debug/common/debugModel.ts
+++ b/src/vs/workbench/contrib/debug/common/debugModel.ts
@@ -258,7 +258,7 @@ export class VisualizedExpression implements IExpression {
 		return Promise.resolve();
 	}
 	getChildren(): Promise<IExpression[]> {
-		return this.visualizer.getVisualizedChildren(this.treeId, this.treeItem.id);
+		return this.visualizer.getVisualizedChildren(this.session, this.treeId, this.treeItem.id);
 	}
 
 	getId(): string {
@@ -278,11 +278,16 @@ export class VisualizedExpression implements IExpression {
 	}
 
 	constructor(
+		private readonly session: IDebugSession | undefined,
 		private readonly visualizer: IDebugVisualizerService,
 		public readonly treeId: string,
 		public readonly treeItem: IDebugVisualizationTreeItem,
 		public readonly original?: Variable,
 	) { }
+
+	public getSession(): IDebugSession | undefined {
+		return this.session;
+	}
 
 	/** Edits the value, sets the {@link errorMessage} and returns false if unsuccessful */
 	public async edit(newValue: string) {

--- a/src/vs/workbench/contrib/debug/common/debugProtocol.d.ts
+++ b/src/vs/workbench/contrib/debug/common/debugProtocol.d.ts
@@ -221,7 +221,12 @@ declare module DebugProtocol {
 				etc.
 			*/
 			category?: 'console' | 'important' | 'stdout' | 'stderr' | 'telemetry' | string;
-			/** The output to report. */
+			/** The output to report.
+
+				ANSI escape sequences may be used to inflience text color and styling if `supportsANSIStyling` is present in both the adapter's `Capabilities` and the client's `InitializeRequestArguments`. A client may strip any unrecognized ANSI sequences.
+
+				If the `supportsANSIStyling` capabilities are not both true, then the client should display the output literally.
+			*/
 			output: string;
 			/** Support for keeping an output log organized by grouping related messages.
 				'start': Start a new group in expanded mode. Subsequent output events are members of the group and should be shown indented.
@@ -530,6 +535,8 @@ declare module DebugProtocol {
 		supportsArgsCanBeInterpretedByShell?: boolean;
 		/** Client supports the `startDebugging` request. */
 		supportsStartDebuggingRequest?: boolean;
+		/** The client will interpret ANSI escape sequences in the display of `OutputEvent.output` and `Variable.value` fields when `Capabilities.supportsANSIStyling` is also enabled. */
+		supportsANSIStyling?: boolean;
 	}
 
 	/** Response to `initialize` request. */
@@ -1840,6 +1847,8 @@ declare module DebugProtocol {
 			Clients may present the first applicable mode in this array as the 'default' mode in gestures that set breakpoints.
 		*/
 		breakpointModes?: BreakpointMode[];
+		/** The debug adapter supports ANSI escape sequences in styling of `OutputEvent.output` and `Variable.value` fields. */
+		supportsANSIStyling?: boolean;
 	}
 
 	/** An `ExceptionBreakpointsFilter` is shown in the UI as an filter option for configuring how exceptions are dealt with. */

--- a/src/vs/workbench/contrib/debug/common/debugVisualizers.ts
+++ b/src/vs/workbench/contrib/debug/common/debugVisualizers.ts
@@ -10,7 +10,7 @@ import { ContextKeyExpr, ContextKeyExpression, IContextKeyService } from '../../
 import { ExtensionIdentifier, IExtensionDescription } from '../../../../platform/extensions/common/extensions.js';
 import { createDecorator } from '../../../../platform/instantiation/common/instantiation.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
-import { CONTEXT_VARIABLE_NAME, CONTEXT_VARIABLE_TYPE, CONTEXT_VARIABLE_VALUE, MainThreadDebugVisualization, IDebugVisualization, IDebugVisualizationContext, IExpression, IExpressionContainer, IDebugVisualizationTreeItem } from './debug.js';
+import { CONTEXT_VARIABLE_NAME, CONTEXT_VARIABLE_TYPE, CONTEXT_VARIABLE_VALUE, MainThreadDebugVisualization, IDebugVisualization, IDebugVisualizationContext, IExpression, IExpressionContainer, IDebugVisualizationTreeItem, IDebugSession } from './debug.js';
 import { getContextForVariable } from './debugContext.js';
 import { Scope, Variable, VisualizedExpression } from './debugModel.js';
 import { IExtensionService } from '../../../services/extensions/common/extensions.js';
@@ -84,7 +84,7 @@ export interface IDebugVisualizerService {
 	/**
 	 * Gets children for a visualized tree node.
 	 */
-	getVisualizedChildren(treeId: string, treeElementId: number): Promise<IExpression[]>;
+	getVisualizedChildren(session: IDebugSession | undefined, treeId: string, treeElementId: number): Promise<IExpression[]>;
 
 	/**
 	 * Gets children for a visualized tree node.
@@ -202,7 +202,7 @@ export class DebugVisualizerService implements IDebugVisualizerService {
 				return;
 			}
 
-			return new VisualizedExpression(this, treeId, treeItem, expr);
+			return new VisualizedExpression(expr.getSession(), this, treeId, treeItem, expr);
 		} catch (e) {
 			this.logService.warn('Failed to get visualized node', e);
 			return;
@@ -210,9 +210,10 @@ export class DebugVisualizerService implements IDebugVisualizerService {
 	}
 
 	/** @inheritdoc */
-	public async getVisualizedChildren(treeId: string, treeElementId: number): Promise<IExpression[]> {
-		const children = await this.trees.get(treeId)?.getChildren(treeElementId) || [];
-		return children.map(c => new VisualizedExpression(this, treeId, c, undefined));
+	public async getVisualizedChildren(session: IDebugSession | undefined, treeId: string, treeElementId: number): Promise<IExpression[]> {
+		const node = this.trees.get(treeId);
+		const children = await node?.getChildren(treeElementId) || [];
+		return children.map(c => new VisualizedExpression(session, this, treeId, c, undefined));
 	}
 
 	/** @inheritdoc */

--- a/src/vs/workbench/contrib/debug/common/replModel.ts
+++ b/src/vs/workbench/contrib/debug/common/replModel.ts
@@ -76,11 +76,16 @@ export class ReplVariableElement implements INestingReplElement {
 	private readonly id = generateUuid();
 
 	constructor(
+		private readonly session: IDebugSession,
 		public readonly expression: IExpression,
 		public readonly severity: severity,
 		public readonly sourceData?: IReplElementSource,
 	) {
 		this.hasChildren = expression.hasChildren;
+	}
+
+	getSession() {
+		return this.session;
 	}
 
 	getChildren(): IReplElement[] | Promise<IReplElement[]> {
@@ -104,6 +109,10 @@ export class RawObjectReplElement implements IExpression, INestingReplElement {
 
 	getId(): string {
 		return this.id;
+	}
+
+	getSession(): IDebugSession | undefined {
+		return undefined;
 	}
 
 	get value(): string {
@@ -292,7 +301,7 @@ export class ReplModel {
 			// have formatted it nicely e.g. with ANSI color codes.
 			this.addReplElement(output
 				? new ReplOutputElement(session, getUniqueId(), output, sev, source, expression)
-				: new ReplVariableElement(expression, sev, source));
+				: new ReplVariableElement(session, expression, sev, source));
 			return;
 		}
 

--- a/src/vs/workbench/contrib/debug/common/replModel.ts
+++ b/src/vs/workbench/contrib/debug/common/replModel.ts
@@ -193,6 +193,7 @@ export class ReplGroup implements INestingReplElement {
 	static COUNTER = 0;
 
 	constructor(
+		public readonly session: IDebugSession,
 		public name: string,
 		public autoExpand: boolean,
 		public sourceData?: IReplElementSource
@@ -315,8 +316,8 @@ export class ReplModel {
 		this.addReplElement(element);
 	}
 
-	startGroup(name: string, autoExpand: boolean, sourceData?: IReplElementSource): void {
-		const group = new ReplGroup(name, autoExpand, sourceData);
+	startGroup(session: IDebugSession, name: string, autoExpand: boolean, sourceData?: IReplElementSource): void {
+		const group = new ReplGroup(session, name, autoExpand, sourceData);
 		this.addReplElement(group);
 	}
 

--- a/src/vs/workbench/contrib/debug/test/browser/baseDebugView.test.ts
+++ b/src/vs/workbench/contrib/debug/test/browser/baseDebugView.test.ts
@@ -9,92 +9,97 @@ import { HighlightedLabel } from '../../../../../base/browser/ui/highlightedlabe
 import { DisposableStore } from '../../../../../base/common/lifecycle.js';
 import { isWindows } from '../../../../../base/common/platform.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
-import { NullCommandService } from '../../../../../platform/commands/test/common/nullCommandService.js';
 import { IHoverService } from '../../../../../platform/hover/browser/hover.js';
 import { NullHoverService } from '../../../../../platform/hover/test/browser/nullHoverService.js';
 import { TestInstantiationService } from '../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
-import { renderExpressionValue, renderVariable, renderViewTree } from '../../browser/baseDebugView.js';
-import { LinkDetector } from '../../browser/linkDetector.js';
+import { workbenchInstantiationService } from '../../../../test/browser/workbenchTestServices.js';
+import { renderViewTree } from '../../browser/baseDebugView.js';
+import { DebugExpressionRenderer } from '../../browser/debugExpressionRenderer.js';
 import { isStatusbarInDebugMode } from '../../browser/statusbarColorProvider.js';
 import { State } from '../../common/debug.js';
 import { Expression, Scope, StackFrame, Thread, Variable } from '../../common/debugModel.js';
+import { MockSession } from '../common/mockDebug.js';
 import { createTestSession } from './callStack.test.js';
 import { createMockDebugModel } from './mockDebugModel.js';
-import { MockSession } from '../common/mockDebug.js';
-import { workbenchInstantiationService } from '../../../../test/browser/workbenchTestServices.js';
+import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
+import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 const $ = dom.$;
 
-function assertVariable(session: MockSession, scope: Scope, disposables: Pick<DisposableStore, "add">, linkDetector: LinkDetector, displayType: boolean) {
-	let variable = new Variable(session, 1, scope, 2, 'foo', 'bar.foo', undefined, 0, 0, undefined, {}, 'string');
-	let expression = $('.');
-	let name = $('.');
-	let type = $('.');
-	let value = $('.');
-	const label = new HighlightedLabel(name);
-	const lazyButton = $('.');
-	const store = disposables.add(new DisposableStore());
-	renderVariable(store, NullCommandService, NullHoverService, variable, { expression, name, type, value, label, lazyButton }, false, [], undefined, displayType);
-
-	assert.strictEqual(label.element.textContent, 'foo');
-	assert.strictEqual(value.textContent, '');
-
-	variable.value = 'hey';
-	expression = $('.');
-	name = $('.');
-	type = $('.');
-	value = $('.');
-	renderVariable(store, NullCommandService, NullHoverService, variable, { expression, name, type, value, label, lazyButton }, false, [], linkDetector, displayType);
-	assert.strictEqual(value.textContent, 'hey');
-	assert.strictEqual(label.element.textContent, displayType ? 'foo: ' : 'foo =');
-	assert.strictEqual(type.textContent, displayType ? 'string =' : '');
-
-	variable.value = isWindows ? 'C:\\foo.js:5' : '/foo.js:5';
-	expression = $('.');
-	name = $('.');
-	type = $('.');
-	value = $('.');
-	renderVariable(store, NullCommandService, NullHoverService, variable, { expression, name, type, value, label, lazyButton }, false, [], linkDetector, displayType);
-	assert.ok(value.querySelector('a'));
-	assert.strictEqual(value.querySelector('a')!.textContent, variable.value);
-
-	variable = new Variable(session, 1, scope, 2, 'console', 'console', '5', 0, 0, undefined, { kind: 'virtual' });
-	expression = $('.');
-	name = $('.');
-	type = $('.');
-	value = $('.');
-	renderVariable(store, NullCommandService, NullHoverService, variable, { expression, name, type, value, label, lazyButton }, false, [], linkDetector, displayType);
-	assert.strictEqual(name.className, 'virtual');
-	assert.strictEqual(label.element.textContent, 'console =');
-	assert.strictEqual(value.className, 'value number');
-
-	variable = new Variable(session, 1, scope, 2, 'xpto', 'xpto.xpto', undefined, 0, 0, undefined, {}, 'custom-type');
-	renderVariable(store, NullCommandService, NullHoverService, variable, { expression, name, type, value, label, lazyButton }, false, [], linkDetector, displayType);
-	assert.strictEqual(label.element.textContent, 'xpto');
-	assert.strictEqual(value.textContent, '');
-	variable.value = '2';
-	expression = $('.');
-	name = $('.');
-	type = $('.');
-	value = $('.');
-	renderVariable(store, NullCommandService, NullHoverService, variable, { expression, name, type, value, label, lazyButton }, false, [], linkDetector, displayType);
-	assert.strictEqual(value.textContent, '2');
-	assert.strictEqual(label.element.textContent, displayType ? 'xpto: ' : 'xpto =');
-	assert.strictEqual(type.textContent, displayType ? 'custom-type =' : '');
-
-	label.dispose();
-}
 
 suite('Debug - Base Debug View', () => {
 	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
-	let linkDetector: LinkDetector;
+	let renderer: DebugExpressionRenderer;
+	let configurationService: TestConfigurationService;
+
+	function assertVariable(session: MockSession, scope: Scope, disposables: Pick<DisposableStore, "add">, displayType: boolean) {
+		let variable = new Variable(session, 1, scope, 2, 'foo', 'bar.foo', undefined, 0, 0, undefined, {}, 'string');
+		let expression = $('.');
+		let name = $('.');
+		let type = $('.');
+		let value = $('.');
+		const label = new HighlightedLabel(name);
+		const lazyButton = $('.');
+		const store = disposables.add(new DisposableStore());
+		store.add(renderer.renderVariable({ expression, name, type, value, label, lazyButton }, variable, { showChanged: false }));
+
+		assert.strictEqual(label.element.textContent, 'foo');
+		assert.strictEqual(value.textContent, '');
+
+		variable.value = 'hey';
+		expression = $('.');
+		name = $('.');
+		type = $('.');
+		value = $('.');
+		store.add(renderer.renderVariable({ expression, name, type, value, label, lazyButton }, variable, { showChanged: false }));
+		assert.strictEqual(value.textContent, 'hey');
+		assert.strictEqual(label.element.textContent, displayType ? 'foo: ' : 'foo =');
+		assert.strictEqual(type.textContent, displayType ? 'string =' : '');
+
+		variable.value = isWindows ? 'C:\\foo.js:5' : '/foo.js:5';
+		expression = $('.');
+		name = $('.');
+		type = $('.');
+		value = $('.');
+		store.add(renderer.renderVariable({ expression, name, type, value, label, lazyButton }, variable, { showChanged: false }));
+		assert.ok(value.querySelector('a'));
+		assert.strictEqual(value.querySelector('a')!.textContent, variable.value);
+
+		variable = new Variable(session, 1, scope, 2, 'console', 'console', '5', 0, 0, undefined, { kind: 'virtual' });
+		expression = $('.');
+		name = $('.');
+		type = $('.');
+		value = $('.');
+		store.add(renderer.renderVariable({ expression, name, type, value, label, lazyButton }, variable, { showChanged: false }));
+		assert.strictEqual(name.className, 'virtual');
+		assert.strictEqual(label.element.textContent, 'console =');
+		assert.strictEqual(value.className, 'value number');
+
+		variable = new Variable(session, 1, scope, 2, 'xpto', 'xpto.xpto', undefined, 0, 0, undefined, {}, 'custom-type');
+		store.add(renderer.renderVariable({ expression, name, type, value, label, lazyButton }, variable, { showChanged: false }));
+		assert.strictEqual(label.element.textContent, 'xpto');
+		assert.strictEqual(value.textContent, '');
+		variable.value = '2';
+		expression = $('.');
+		name = $('.');
+		type = $('.');
+		value = $('.');
+		store.add(renderer.renderVariable({ expression, name, type, value, label, lazyButton }, variable, { showChanged: false }));
+		assert.strictEqual(value.textContent, '2');
+		assert.strictEqual(label.element.textContent, displayType ? 'xpto: ' : 'xpto =');
+		assert.strictEqual(type.textContent, displayType ? 'custom-type =' : '');
+
+		label.dispose();
+	}
 
 	/**
 	 * Instantiate services for use by the functions being tested.
 	 */
 	setup(() => {
 		const instantiationService: TestInstantiationService = workbenchInstantiationService(undefined, disposables);
-		linkDetector = instantiationService.createInstance(LinkDetector);
+		configurationService = instantiationService.createInstance(TestConfigurationService);
+		instantiationService.stub(IConfigurationService, configurationService);
 		instantiationService.stub(IHoverService, NullHoverService);
+		renderer = instantiationService.createInstance(DebugExpressionRenderer);
 	});
 
 	test('render view tree', () => {
@@ -110,37 +115,37 @@ suite('Debug - Base Debug View', () => {
 	test('render expression value', () => {
 		let container = $('.container');
 		const store = disposables.add(new DisposableStore());
-		renderExpressionValue(store, 'render \n me', container, {}, NullHoverService);
+		store.add(renderer.renderValue(container, 'render \n me', {}));
 		assert.strictEqual(container.className, 'value');
 		assert.strictEqual(container.textContent, 'render \n me');
 
 		const expression = new Expression('console');
 		expression.value = 'Object';
 		container = $('.container');
-		renderExpressionValue(store, expression, container, { colorize: true }, NullHoverService);
+		store.add(renderer.renderValue(container, expression, { colorize: true }));
 		assert.strictEqual(container.className, 'value unavailable error');
 
 		expression.available = true;
 		expression.value = '"string value"';
 		container = $('.container');
-		renderExpressionValue(store, expression, container, { colorize: true, linkDetector }, NullHoverService);
+		store.add(renderer.renderValue(container, expression, { colorize: true }));
 		assert.strictEqual(container.className, 'value string');
 		assert.strictEqual(container.textContent, '"string value"');
 
 		expression.type = 'boolean';
 		container = $('.container');
-		renderExpressionValue(store, expression, container, { colorize: true }, NullHoverService);
+		store.add(renderer.renderValue(container, expression, { colorize: true }));
 		assert.strictEqual(container.className, 'value boolean');
 		assert.strictEqual(container.textContent, expression.value);
 
 		expression.value = 'this is a long string';
 		container = $('.container');
-		renderExpressionValue(store, expression, container, { colorize: true, maxValueLength: 4, linkDetector }, NullHoverService);
+		store.add(renderer.renderValue(container, expression, { colorize: true, maxValueLength: 4 }));
 		assert.strictEqual(container.textContent, 'this...');
 
 		expression.value = isWindows ? 'C:\\foo.js:5' : '/foo.js:5';
 		container = $('.container');
-		renderExpressionValue(store, expression, container, { colorize: true, linkDetector }, NullHoverService);
+		store.add(renderer.renderValue(container, expression, { colorize: true }));
 		assert.ok(container.querySelector('a'));
 		assert.strictEqual(container.querySelector('a')!.textContent, expression.value);
 	});
@@ -157,7 +162,8 @@ suite('Debug - Base Debug View', () => {
 		const stackFrame = new StackFrame(thread, 1, null!, 'app.js', 'normal', range, 0, true);
 		const scope = new Scope(stackFrame, 1, 'local', 1, false, 10, 10);
 
-		assertVariable(session, scope, disposables, linkDetector, false);
+		configurationService.setUserConfiguration('debug.showVariableTypes', false);
+		assertVariable(session, scope, disposables, false);
 
 	});
 
@@ -173,7 +179,8 @@ suite('Debug - Base Debug View', () => {
 		const stackFrame = new StackFrame(thread, 1, null!, 'app.js', 'normal', range, 0, true);
 		const scope = new Scope(stackFrame, 1, 'local', 1, false, 10, 10);
 
-		assertVariable(session, scope, disposables, linkDetector, true);
+		configurationService.setUserConfiguration('debug.showVariableTypes', true);
+		assertVariable(session, scope, disposables, true);
 	});
 
 	test('statusbar in debug mode', () => {

--- a/src/vs/workbench/contrib/debug/test/browser/debugANSIHandling.test.ts
+++ b/src/vs/workbench/contrib/debug/test/browser/debugANSIHandling.test.ts
@@ -10,16 +10,14 @@ import { DisposableStore } from '../../../../../base/common/lifecycle.js';
 import { generateUuid } from '../../../../../base/common/uuid.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
 import { TestInstantiationService } from '../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
-import { IThemeService } from '../../../../../platform/theme/common/themeService.js';
-import { TestColorTheme, TestThemeService } from '../../../../../platform/theme/test/common/testThemeService.js';
+import { workbenchInstantiationService } from '../../../../test/browser/workbenchTestServices.js';
+import { registerColors } from '../../../terminal/common/terminalColorRegistry.js';
 import { appendStylizedStringToContainer, calcANSI8bitColor, handleANSIOutput } from '../../browser/debugANSIHandling.js';
 import { DebugSession } from '../../browser/debugSession.js';
 import { LinkDetector } from '../../browser/linkDetector.js';
 import { DebugModel } from '../../common/debugModel.js';
 import { createTestSession } from './callStack.test.js';
 import { createMockDebugModel } from './mockDebugModel.js';
-import { ansiColorMap, registerColors } from '../../../terminal/common/terminalColorRegistry.js';
-import { workbenchInstantiationService } from '../../../../test/browser/workbenchTestServices.js';
 
 suite('Debug - ANSI Handling', () => {
 
@@ -27,7 +25,6 @@ suite('Debug - ANSI Handling', () => {
 	let model: DebugModel;
 	let session: DebugSession;
 	let linkDetector: LinkDetector;
-	let themeService: IThemeService;
 
 	/**
 	 * Instantiate services for use by the functions being tested.
@@ -39,13 +36,6 @@ suite('Debug - ANSI Handling', () => {
 
 		const instantiationService: TestInstantiationService = <TestInstantiationService>workbenchInstantiationService(undefined, disposables);
 		linkDetector = instantiationService.createInstance(LinkDetector);
-
-		const colors: { [id: string]: string } = {};
-		for (const color in ansiColorMap) {
-			colors[color] = <any>ansiColorMap[color].defaults.dark;
-		}
-		const testTheme = new TestColorTheme(colors);
-		themeService = new TestThemeService(testTheme);
 		registerColors();
 	});
 
@@ -92,7 +82,7 @@ suite('Debug - ANSI Handling', () => {
 	 * @returns An {@link HTMLSpanElement} that contains the stylized text.
 	 */
 	function getSequenceOutput(sequence: string): HTMLSpanElement {
-		const root: HTMLSpanElement = handleANSIOutput(sequence, linkDetector, themeService, session.root);
+		const root: HTMLSpanElement = handleANSIOutput(sequence, linkDetector, session.root);
 		assert.strictEqual(1, root.children.length);
 		const child: Node = root.lastChild!;
 		if (isHTMLSpanElement(child)) {
@@ -405,7 +395,7 @@ suite('Debug - ANSI Handling', () => {
 		if (elementsExpected === undefined) {
 			elementsExpected = assertions.length;
 		}
-		const root: HTMLSpanElement = handleANSIOutput(sequence, linkDetector, themeService, session.root);
+		const root: HTMLSpanElement = handleANSIOutput(sequence, linkDetector, session.root);
 		assert.strictEqual(elementsExpected, root.children.length);
 		for (let i = 0; i < elementsExpected; i++) {
 			const child: Node = root.children[i];

--- a/src/vs/workbench/contrib/debug/test/browser/repl.test.ts
+++ b/src/vs/workbench/contrib/debug/test/browser/repl.test.ts
@@ -201,7 +201,7 @@ suite('Debug - REPL', () => {
 		const repl = new ReplModel(configurationService);
 
 		repl.appendToRepl(session, { output: 'first global line', sev: severity.Info });
-		repl.startGroup('group_1', true);
+		repl.startGroup(session, 'group_1', true);
 		repl.appendToRepl(session, { output: 'first line in group', sev: severity.Info });
 		repl.appendToRepl(session, { output: 'second line in group', sev: severity.Info });
 		const elements = repl.getReplElements();
@@ -212,7 +212,7 @@ suite('Debug - REPL', () => {
 		assert.strictEqual(group.hasChildren, true);
 		assert.strictEqual(group.hasEnded, false);
 
-		repl.startGroup('group_2', false);
+		repl.startGroup(session, 'group_2', false);
 		repl.appendToRepl(session, { output: 'first line in subgroup', sev: severity.Info });
 		repl.appendToRepl(session, { output: 'second line in subgroup', sev: severity.Info });
 		const children = group.getChildren();

--- a/src/vs/workbench/contrib/debug/test/browser/watchExpressionView.test.ts
+++ b/src/vs/workbench/contrib/debug/test/browser/watchExpressionView.test.ts
@@ -18,6 +18,7 @@ import { NullHoverService } from '../../../../../platform/hover/test/browser/nul
 import { IDebugService, IViewModel } from '../../common/debug.js';
 import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { TestConfigurationService } from '../../../../../platform/configuration/test/common/testConfigurationService.js';
+import { DebugExpressionRenderer } from '../../browser/debugExpressionRenderer.js';
 const $ = dom.$;
 
 function assertWatchVariable(disposables: Pick<DisposableStore, "add">, watchExpressionsRenderer: WatchExpressionsRenderer, displayType: boolean) {
@@ -80,9 +81,13 @@ suite('Debug - Watch Debug View', () => {
 	let watchExpressionsRenderer: WatchExpressionsRenderer;
 	let instantiationService: TestInstantiationService;
 	let configurationService: TestConfigurationService;
+	let expressionRenderer: DebugExpressionRenderer;
 
 	setup(() => {
 		instantiationService = workbenchInstantiationService(undefined, disposables);
+		configurationService = instantiationService.createInstance(TestConfigurationService);
+		instantiationService.stub(IConfigurationService, configurationService);
+		expressionRenderer = instantiationService.createInstance(DebugExpressionRenderer);
 		const debugService = new MockDebugService();
 		instantiationService.stub(IHoverService, NullHoverService);
 		debugService.getViewModel = () => <IViewModel>{ focusedStackFrame: undefined, getSelectedExpression: () => undefined };
@@ -91,24 +96,16 @@ suite('Debug - Watch Debug View', () => {
 	});
 
 	test('watch expressions with display type', () => {
-		configurationService = new TestConfigurationService({
-			debug: {
-				showVariableTypes: true
-			}
-		});
+		configurationService.setUserConfiguration('debug', { showVariableTypes: true });
 		instantiationService.stub(IConfigurationService, configurationService);
-		watchExpressionsRenderer = instantiationService.createInstance(WatchExpressionsRenderer, null as any);
+		watchExpressionsRenderer = instantiationService.createInstance(WatchExpressionsRenderer, expressionRenderer);
 		assertWatchVariable(disposables, watchExpressionsRenderer, true);
 	});
 
 	test('watch expressions', () => {
-		configurationService = new TestConfigurationService({
-			debug: {
-				showVariableTypes: false
-			}
-		});
+		configurationService.setUserConfiguration('debug', { showVariableTypes: false });
 		instantiationService.stub(IConfigurationService, configurationService);
-		watchExpressionsRenderer = instantiationService.createInstance(WatchExpressionsRenderer, null as any);
+		watchExpressionsRenderer = instantiationService.createInstance(WatchExpressionsRenderer, expressionRenderer);
 		assertWatchVariable(disposables, watchExpressionsRenderer, false);
 	});
 });

--- a/src/vs/workbench/contrib/notebook/browser/contrib/notebookVariables/notebookVariablesTree.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/notebookVariables/notebookVariablesTree.ts
@@ -70,6 +70,7 @@ export class NotebookVariableRenderer implements ITreeRenderer<INotebookVariable
 		data.elementDisposables.add(this.expressionRenderer.renderValue(data.value, element.element, {
 			colorize: true,
 			maxValueLength: MAX_VALUE_RENDER_LENGTH_IN_VIEWLET,
+			session: undefined,
 		}));
 	}
 

--- a/src/vs/workbench/contrib/notebook/browser/contrib/notebookVariables/notebookVariablesTree.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/notebookVariables/notebookVariablesTree.ts
@@ -10,9 +10,9 @@ import { ITreeNode, ITreeRenderer } from '../../../../../../base/browser/ui/tree
 import { FuzzyScore } from '../../../../../../base/common/filters.js';
 import { DisposableStore } from '../../../../../../base/common/lifecycle.js';
 import { localize } from '../../../../../../nls.js';
-import { IHoverService } from '../../../../../../platform/hover/browser/hover.js';
+import { IInstantiationService } from '../../../../../../platform/instantiation/common/instantiation.js';
 import { WorkbenchObjectTree } from '../../../../../../platform/list/browser/listService.js';
-import { renderExpressionValue } from '../../../../debug/browser/baseDebugView.js';
+import { DebugExpressionRenderer } from '../../../../debug/browser/debugExpressionRenderer.js';
 import { INotebookVariableElement } from './notebookVariablesDataSource.js';
 
 const $ = dom.$;
@@ -40,15 +40,16 @@ export interface IVariableTemplateData {
 
 export class NotebookVariableRenderer implements ITreeRenderer<INotebookVariableElement, FuzzyScore, IVariableTemplateData> {
 
+	private expressionRenderer: DebugExpressionRenderer;
+
 	static readonly ID = 'variableElement';
 
 	get templateId(): string {
 		return NotebookVariableRenderer.ID;
 	}
 
-	constructor(
-		@IHoverService private readonly _hoverService: IHoverService
-	) {
+	constructor(@IInstantiationService instantiationService: IInstantiationService) {
+		this.expressionRenderer = instantiationService.createInstance(DebugExpressionRenderer);
 	}
 
 	renderTemplate(container: HTMLElement): IVariableTemplateData {
@@ -66,10 +67,10 @@ export class NotebookVariableRenderer implements ITreeRenderer<INotebookVariable
 		data.name.textContent = text;
 		data.name.title = element.element.type ?? '';
 
-		renderExpressionValue(data.elementDisposables, element.element, data.value, {
+		data.elementDisposables.add(this.expressionRenderer.renderValue(data.value, element.element, {
 			colorize: true,
 			maxValueLength: MAX_VALUE_RENDER_LENGTH_IN_VIEWLET,
-		}, this._hoverService);
+		}));
 	}
 
 	disposeElement(element: ITreeNode<INotebookVariableElement, FuzzyScore>, index: number, templateData: IVariableTemplateData, height: number | undefined): void {

--- a/src/vs/workbench/contrib/notebook/browser/contrib/notebookVariables/notebookVariablesView.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/notebookVariables/notebookVariablesView.ts
@@ -88,7 +88,7 @@ export class NotebookVariablesView extends ViewPane {
 			'notebookVariablesTree',
 			container,
 			new NotebookVariablesDelegate(),
-			[new NotebookVariableRenderer(this.hoverService)],
+			[this.instantiationService.createInstance(NotebookVariableRenderer)],
 			this.dataSource,
 			{
 				accessibilityProvider: new NotebookVariableAccessibilityProvider(),


### PR DESCRIPTION
Closes #227728

VS Code now advertises `supportsANSIStyling` and styles debug output
with ANSI code if and only if the debug adapter supports it. This
consolidates disparate output rendering logic into the
`DebugExpressionRenderer` where previously we had a bunch of
free-floating functions that needed different services injected.

As a minor change, we now linkify inside of debug hovers:

![image](https://github.com/user-attachments/assets/5d22011e-5546-4682-965f-e38818b731bb)

And of course the major change is ANSI support in all the places.
For example, with my provisional changes in js-debug to display DOM nodes more nicely:

![image](https://github.com/user-attachments/assets/27bdae6d-995d-4be3-bfd3-ce0ec8d54ee1)


<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
