### PR TITLE
provide conversation as context to the map edit provider

### DIFF
--- a/src/vs/editor/common/languages.ts
+++ b/src/vs/editor/common/languages.ts
@@ -1206,6 +1206,16 @@ export function isLocationLink(thing: any): thing is LocationLink {
 		&& (Range.isIRange((thing as LocationLink).originSelectionRange) || Range.isIRange((thing as LocationLink).targetSelectionRange));
 }
 
+/**
+ * @internal
+ */
+export function isLocation(thing: any): thing is Location {
+	return thing
+		&& URI.isUri((thing as Location).uri)
+		&& Range.isIRange((thing as Location).range);
+}
+
+
 export type Definition = Location | Location[] | LocationLink[];
 
 /**
@@ -2264,7 +2274,28 @@ export interface DocumentContextItem {
 
 export interface MappedEditsContext {
 	/** The outer array is sorted by priority - from highest to lowest. The inner arrays contain elements of the same priority. */
-	documents: DocumentContextItem[][];
+	readonly documents: DocumentContextItem[][];
+	/**
+	 * @internal
+	 */
+	readonly conversation?: (ConversationRequest | ConversationResponse)[];
+}
+
+/**
+ * @internal
+ */
+export interface ConversationRequest {
+	readonly type: 'request';
+	readonly message: string;
+}
+
+/**
+ * @internal
+ */
+export interface ConversationResponse {
+	readonly type: 'response';
+	readonly message: string;
+	readonly references?: DocumentContextItem[];
 }
 
 export interface MappedEditsProvider {

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -8081,7 +8081,7 @@ declare namespace monaco.languages {
 
 	export interface MappedEditsContext {
 		/** The outer array is sorted by priority - from highest to lowest. The inner arrays contain elements of the same priority. */
-		documents: DocumentContextItem[][];
+		readonly documents: DocumentContextItem[][];
 	}
 
 	export interface MappedEditsProvider {

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -381,8 +381,15 @@ export interface IDocumentContextItemDto {
 	readonly ranges: IRange[];
 }
 
+export interface IConversationItemDto {
+	readonly type: 'request' | 'response';
+	readonly message: string;
+	readonly references?: IDocumentContextItemDto[];
+}
+
 export interface IMappedEditsContextDto {
 	documents: IDocumentContextItemDto[][];
+	conversation?: IConversationItemDto[];
 }
 
 export interface ISignatureHelpProviderMetadataDto {

--- a/src/vs/workbench/api/common/extHostTypeConverters.ts
+++ b/src/vs/workbench/api/common/extHostTypeConverters.ts
@@ -1623,27 +1623,51 @@ export namespace MappedEditsContext {
 			!!v && typeof v === 'object' &&
 			'documents' in v &&
 			Array.isArray(v.documents) &&
-			v.documents.every(subArr =>
-				Array.isArray(subArr) &&
-				subArr.every(docRef =>
-					docRef && typeof docRef === 'object' &&
-					'uri' in docRef && URI.isUri(docRef.uri) &&
-					'version' in docRef && typeof docRef.version === 'number' &&
-					'ranges' in docRef && Array.isArray(docRef.ranges) && docRef.ranges.every((r: unknown) => r instanceof types.Range)
-				)
-			)
+			v.documents.every(
+				subArr => Array.isArray(subArr) &&
+					subArr.every(DocumentContextItem.is))
 		);
 	}
 
 	export function from(extContext: vscode.MappedEditsContext): languages.MappedEditsContext {
 		return {
 			documents: extContext.documents.map((subArray) =>
-				subArray.map((r) => ({
-					uri: URI.from(r.uri),
-					version: r.version,
-					ranges: r.ranges.map((r) => Range.from(r)),
-				}))
+				subArray.map(DocumentContextItem.from)
 			),
+			conversation: extContext.conversation?.map(item => (
+				(item.type === 'request') ?
+					{
+						type: 'request',
+						message: item.message,
+					} :
+					{
+						type: 'response',
+						message: item.message,
+						references: item.references?.map(DocumentContextItem.from)
+					}
+			))
+		};
+
+	}
+}
+
+export namespace DocumentContextItem {
+
+	export function is(item: unknown): item is vscode.DocumentContextItem {
+		return (
+			typeof item === 'object' &&
+			item !== null &&
+			'uri' in item && URI.isUri(item.uri) &&
+			'version' in item && typeof item.version === 'number' &&
+			'ranges' in item && Array.isArray(item.ranges) && item.ranges.every((r: unknown) => r instanceof types.Range)
+		);
+	}
+
+	export function from(item: vscode.DocumentContextItem): languages.DocumentContextItem {
+		return {
+			uri: URI.from(item.uri),
+			version: item.version,
+			ranges: item.ranges.map(r => Range.from(r)),
 		};
 	}
 }

--- a/src/vscode-dts/vscode.proposed.mappedEditsProvider.d.ts
+++ b/src/vscode-dts/vscode.proposed.mappedEditsProvider.d.ts
@@ -11,8 +11,24 @@ declare module 'vscode' {
 		readonly ranges: Range[];
 	}
 
+	export interface ConversationRequest {
+		readonly type: 'request';
+		readonly message: string;
+	}
+
+	export interface ConversationResponse {
+		readonly type: 'response';
+		readonly message: string;
+		readonly references?: DocumentContextItem[];
+	}
+
 	export interface MappedEditsContext {
-		documents: DocumentContextItem[][];
+		readonly documents: DocumentContextItem[][];
+		/**
+		 * The conversation that led to the current code block(s).
+		 * The last conversation part contains the code block(s) for which the code mapper should provide edits.
+		 */
+		readonly conversation?: (ConversationRequest | ConversationResponse)[];
 	}
 
 	/**


### PR DESCRIPTION
Just as a start, didn't try to reuse the types that the chat/lm API has.

Also for now, the conversation is just an array of 1 (the response/reply that has the code block). Will look into the rest of the conversation later.

The references are represented with the `DocumentContextItem` type. Should probably be the `URI | Location | varReference` ...
but it feels to me that type is still in flux