### PR TITLE
fix: interactive postinst script breaks install for non-interactive environments

### DIFF
--- a/resources/linux/debian/postinst.template
+++ b/resources/linux/debian/postinst.template
@@ -70,17 +70,24 @@ if [ "@@NAME@@" != "code-oss" ]; then
 		WRITE_SOURCE='ask'
 	fi
 
-	if [ "$WRITE_SOURCE" = 'ask' ] && ! [ -t 1 ]; then
-		# By default, write sources in a non-interactive terminal
-		WRITE_SOURCE='yes'
-	elif [ "$WRITE_SOURCE" = 'ask' ] && [ -e '/usr/share/debconf/confmodule' ]; then
-		# Ask the user whether to actually write the source list
-		db_input high @@NAME@@/add-microsoft-repo || true
-		db_go || true
+	if [ "$WRITE_SOURCE" = 'ask' ]; then
+		if ! [ -t 1 ]; then
+			# By default, write sources in a non-interactive terminal
+			# to match old behavior.
+			WRITE_SOURCE='yes'
+		elif [ -e '/usr/share/debconf/confmodule' ]; then
+			# Ask the user whether to actually write the source list
+			db_input high @@NAME@@/add-microsoft-repo || true
+			db_go || true
 
-		db_get @@NAME@@/add-microsoft-repo
-		if [ "$RET" = false ]; then
-			WRITE_SOURCE='no'
+			db_get @@NAME@@/add-microsoft-repo
+			if [ "$RET" = false ]; then
+				WRITE_SOURCE='no'
+			fi
+		else
+			# The terminal is interactive but there is no debconf.
+			# Write sources to match old behavior.
+			WRITE_SOURCE='yes'
 		fi
 	fi
 

--- a/resources/linux/debian/postinst.template
+++ b/resources/linux/debian/postinst.template
@@ -42,7 +42,10 @@ if [ "@@NAME@@" != "code-oss" ]; then
 		db_get @@NAME@@/add-microsoft-repo || true
 	fi
 
-	# Determine whether to install the repository source list
+	# Determine whether to write the Microsoft repository source list
+	# 0 means do not write
+	# 1 means ask and then write if Yes
+	# 2 means write without asking
 	WRITE_SOURCE=0
 	if [ "$RET" = false ]; then
 		# The user does not want to add the Microsoft repository
@@ -59,6 +62,9 @@ if [ "@@NAME@@" != "code-oss" ]; then
 	elif apt-cache policy | grep -q "https://packages.microsoft.com/repos/code"; then
 		# The user is already on the new repository
 		WRITE_SOURCE=0
+	elif [ -n "$CODE_INSTALL_WITH_REPO" ]; then
+		# The user wants to install Code with the Microsoft repo
+		WRITE_SOURCE=2
 	elif [ ! -f $CODE_SOURCE_PART ] && [ ! -f /etc/rpi-issue ]; then
 		# Write source list if it does not exist and we're not running on Raspberry Pi OS
 		WRITE_SOURCE=1

--- a/resources/linux/debian/postinst.template
+++ b/resources/linux/debian/postinst.template
@@ -44,11 +44,8 @@ if [ "@@NAME@@" != "code-oss" ]; then
 
 	# Determine whether to write the Microsoft repository source list
 	WRITE_SOURCE='no'
-	if [ "$CODE_INSTALL_WITH_REPO" = false ]; then
-		# The user does not want to add the Microsoft repository
-		WRITE_SOURCE='no'
 	elif [ "$RET" = false ]; then
-		# The user does not want to add the Microsoft repository
+		# The user specified in debconf not to add the Microsoft repository
 		WRITE_SOURCE='no'
 	elif [ -f "$CODE_SOURCE_PART_DEB822" ]; then
 		# The user has migrated themselves to the DEB822 format
@@ -63,9 +60,6 @@ if [ "@@NAME@@" != "code-oss" ]; then
 		# The user is already on the new repository
 		WRITE_SOURCE='no'
 	elif [ "$RET" = true ]; then
-		# User explicitly wants to add the Microsoft repository
-		WRITE_SOURCE='yes'
-	elif [ "$CODE_INSTALL_WITH_REPO" = true ]; then
 		# User explicitly wants to add the Microsoft repository
 		WRITE_SOURCE='yes'
 	elif [ ! -f $CODE_SOURCE_PART ] && [ ! -f /etc/rpi-issue ]; then

--- a/resources/linux/debian/postinst.template
+++ b/resources/linux/debian/postinst.template
@@ -47,7 +47,10 @@ if [ "@@NAME@@" != "code-oss" ]; then
 	# 1 means ask and then write if Yes
 	# 2 means write without asking
 	WRITE_SOURCE=0
-	if [ "$RET" = false ]; then
+	if [ "$CODE_INSTALL_WITH_REPO" = false ]; then
+		# The user does not want to add the Microsoft repository
+		WRITE_SOURCE=0
+	elif [ "$RET" = false ]; then
 		# The user does not want to add the Microsoft repository
 		WRITE_SOURCE=0
 	elif [ -f "$CODE_SOURCE_PART_DEB822" ]; then
@@ -62,14 +65,17 @@ if [ "@@NAME@@" != "code-oss" ]; then
 	elif apt-cache policy | grep -q "https://packages.microsoft.com/repos/code"; then
 		# The user is already on the new repository
 		WRITE_SOURCE=0
-	elif [ -n "$CODE_INSTALL_WITH_REPO" ]; then
-		# The user wants to install Code with the Microsoft repo
+	elif [ "$RET" = true ]; then
+		# User explicitly wants to add the Microsoft repository
+		WRITE_SOURCE=2
+	elif [ "$CODE_INSTALL_WITH_REPO" = true ]; then
+		# User explicitly wants to add the Microsoft repository
 		WRITE_SOURCE=2
 	elif [ ! -f $CODE_SOURCE_PART ] && [ ! -f /etc/rpi-issue ]; then
-		# Write source list if it does not exist and we're not running on Raspberry Pi OS
+		# Source list does not exist and we're not running on Raspberry Pi OS
 		WRITE_SOURCE=1
 	elif grep -q "# disabled on upgrade to" $CODE_SOURCE_PART; then
-		# Write source list if it was disabled by OS upgrade
+		# Source list was disabled by OS upgrade
 		WRITE_SOURCE=1
 	fi
 

--- a/resources/linux/debian/postinst.template
+++ b/resources/linux/debian/postinst.template
@@ -43,54 +43,54 @@ if [ "@@NAME@@" != "code-oss" ]; then
 	fi
 
 	# Determine whether to write the Microsoft repository source list
-	# 0 means do not write
-	# 1 means ask and then write if Yes
-	# 2 means write without asking
-	WRITE_SOURCE=0
+	WRITE_SOURCE='no'
 	if [ "$CODE_INSTALL_WITH_REPO" = false ]; then
 		# The user does not want to add the Microsoft repository
-		WRITE_SOURCE=0
+		WRITE_SOURCE='no'
 	elif [ "$RET" = false ]; then
 		# The user does not want to add the Microsoft repository
-		WRITE_SOURCE=0
+		WRITE_SOURCE='no'
 	elif [ -f "$CODE_SOURCE_PART_DEB822" ]; then
 		# The user has migrated themselves to the DEB822 format
-		WRITE_SOURCE=0
+		WRITE_SOURCE='no'
 	elif [ -f "$CODE_SOURCE_PART" ] && (grep -q "http://packages.microsoft.com/repos/vscode" $CODE_SOURCE_PART); then
 		# Migrate from old repository
-		WRITE_SOURCE=2
+		WRITE_SOURCE='yes'
 	elif [ -f "$CODE_SOURCE_PART" ] && (grep -q "http://packages.microsoft.com/repos/code" $CODE_SOURCE_PART); then
 		# Migrate from old repository
-		WRITE_SOURCE=2
+		WRITE_SOURCE='yes'
 	elif apt-cache policy | grep -q "https://packages.microsoft.com/repos/code"; then
 		# The user is already on the new repository
-		WRITE_SOURCE=0
+		WRITE_SOURCE='no'
 	elif [ "$RET" = true ]; then
 		# User explicitly wants to add the Microsoft repository
-		WRITE_SOURCE=2
+		WRITE_SOURCE='yes'
 	elif [ "$CODE_INSTALL_WITH_REPO" = true ]; then
 		# User explicitly wants to add the Microsoft repository
-		WRITE_SOURCE=2
+		WRITE_SOURCE='yes'
 	elif [ ! -f $CODE_SOURCE_PART ] && [ ! -f /etc/rpi-issue ]; then
 		# Source list does not exist and we're not running on Raspberry Pi OS
-		WRITE_SOURCE=1
+		WRITE_SOURCE='ask'
 	elif grep -q "# disabled on upgrade to" $CODE_SOURCE_PART; then
 		# Source list was disabled by OS upgrade
-		WRITE_SOURCE=1
+		WRITE_SOURCE='ask'
 	fi
 
-	if [ "$WRITE_SOURCE" -eq "1" ] && [ -e '/usr/share/debconf/confmodule' ]; then
+	if [ "$WRITE_SOURCE" = 'ask' ] && ! [ -t 1 ]; then
+		# By default, write sources in a non-interactive terminal
+		WRITE_SOURCE='yes'
+	elif [ "$WRITE_SOURCE" = 'ask' ] && [ -e '/usr/share/debconf/confmodule' ]; then
 		# Ask the user whether to actually write the source list
 		db_input high @@NAME@@/add-microsoft-repo || true
 		db_go || true
 
 		db_get @@NAME@@/add-microsoft-repo
 		if [ "$RET" = false ]; then
-			WRITE_SOURCE=0
+			WRITE_SOURCE='no'
 		fi
 	fi
 
-	if [ "$WRITE_SOURCE" -ne "0" ]; then
+	if [ "$WRITE_SOURCE" != 'no' ]; then
 		echo "### THIS FILE IS AUTOMATICALLY CONFIGURED ###
 # You may comment out this entry, but any other modifications may be lost.
 deb [arch=amd64,arm64,armhf] https://packages.microsoft.com/repos/code stable main" > $CODE_SOURCE_PART

--- a/resources/linux/debian/postinst.template
+++ b/resources/linux/debian/postinst.template
@@ -44,7 +44,7 @@ if [ "@@NAME@@" != "code-oss" ]; then
 
 	# Determine whether to write the Microsoft repository source list
 	WRITE_SOURCE='no'
-	elif [ "$RET" = false ]; then
+	if [ "$RET" = false ]; then
 		# The user specified in debconf not to add the Microsoft repository
 		WRITE_SOURCE='no'
 	elif [ -f "$CODE_SOURCE_PART_DEB822" ]; then

--- a/resources/linux/debian/postinst.template
+++ b/resources/linux/debian/postinst.template
@@ -36,7 +36,7 @@ if [ "@@NAME@@" != "code-oss" ]; then
 	eval $(apt-config shell APT_TRUSTED_PARTS Dir::Etc::trustedparts/d)
 	CODE_TRUSTED_PART=${APT_TRUSTED_PARTS}microsoft.gpg
 
-	RET=true
+	RET=''
 	if [ -e '/usr/share/debconf/confmodule' ]; then
 		. /usr/share/debconf/confmodule
 		db_get @@NAME@@/add-microsoft-repo || true
@@ -44,7 +44,7 @@ if [ "@@NAME@@" != "code-oss" ]; then
 
 	# Determine whether to write the Microsoft repository source list
 	WRITE_SOURCE='no'
-	if [ "$RET" = false ]; then
+	if [ "$RET" = 'false' ]; then
 		# The user specified in debconf not to add the Microsoft repository
 		WRITE_SOURCE='no'
 	elif [ -f "$CODE_SOURCE_PART_DEB822" ]; then
@@ -59,8 +59,8 @@ if [ "@@NAME@@" != "code-oss" ]; then
 	elif apt-cache policy | grep -q "https://packages.microsoft.com/repos/code"; then
 		# The user is already on the new repository
 		WRITE_SOURCE='no'
-	elif [ "$RET" = true ]; then
-		# User explicitly wants to add the Microsoft repository
+	elif [ "$RET" = 'true' ]; then
+		# The user specified in debconf to add the Microsoft repository
 		WRITE_SOURCE='yes'
 	elif [ ! -f $CODE_SOURCE_PART ] && [ ! -f /etc/rpi-issue ]; then
 		# Source list does not exist and we're not running on Raspberry Pi OS

--- a/resources/linux/debian/postinst.template
+++ b/resources/linux/debian/postinst.template
@@ -36,7 +36,8 @@ if [ "@@NAME@@" != "code-oss" ]; then
 	eval $(apt-config shell APT_TRUSTED_PARTS Dir::Etc::trustedparts/d)
 	CODE_TRUSTED_PART=${APT_TRUSTED_PARTS}microsoft.gpg
 
-	RET=''
+	# RET seems to be true by default even after db_get is called on a first install.
+	RET='true'
 	if [ -e '/usr/share/debconf/confmodule' ]; then
 		. /usr/share/debconf/confmodule
 		db_get @@NAME@@/add-microsoft-repo || true
@@ -59,9 +60,6 @@ if [ "@@NAME@@" != "code-oss" ]; then
 	elif apt-cache policy | grep -q "https://packages.microsoft.com/repos/code"; then
 		# The user is already on the new repository
 		WRITE_SOURCE='no'
-	elif [ "$RET" = 'true' ]; then
-		# The user specified in debconf to add the Microsoft repository
-		WRITE_SOURCE='yes'
 	elif [ ! -f $CODE_SOURCE_PART ] && [ ! -f /etc/rpi-issue ]; then
 		# Source list does not exist and we're not running on Raspberry Pi OS
 		WRITE_SOURCE='ask'


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

With the latest Stable release, first-time Debian package users have to confirm whether they want to add the Microsoft repository or not.

This PR adds more checks so that users in non-interactive or CI environments could opt in or opt out of installing the repository by explicitly setting the debconf value before starting the install. Machines without debconf are automatically opted in to installing the repository to match with the previous behaviour.

Closes https://github.com/microsoft/vscode/issues/22145