### PR TITLE
Fix Jittery editor mouse wheel zoom when setting window.zoomLevel = 1

### DIFF
--- a/src/vs/base/browser/ui/scrollbar/scrollableElement.ts
+++ b/src/vs/base/browser/ui/scrollbar/scrollableElement.ts
@@ -165,8 +165,9 @@ export class MouseWheelClassifier {
 	}
 
 	private _isAlmostInt(value: number): boolean {
+		const epsilon = Number.EPSILON * 100; // Use a small tolerance factor for floating-point errors
 		const delta = Math.abs(Math.round(value) - value);
-		return (delta < 0.01);
+		return (delta < 0.01 + epsilon);
 	}
 }
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->


## Related Issue
Fixes #225759

## Changes
- Modified the `_isAlmostInt` method in the `MouseWheelClassifier` class to increase the margin of error.
- Changed the threshold from `0.01` to `0.01 + Number.EPSILON * 100` (approximately 0.010000000000022205).

## Reason for Change
To account for floating-point errors in certain zoom level calculations.

## Previous Behavior
- For most zoom levels `deltaY = 0.996 ~ 1` and `_isAlmostInt` correctly returned `true`.
- At zoom level 1, with `deltaY` of 0.9899999999999999, `_isAlmostInt` incorrectly returned `false`.

## New Behavior
- `_isAlmostInt` now correctly returns `true` for zoom level 1 cases, as intended.

## Testing
1. Set zoom level to 1.
2. Verify that `_isAlmostInt` returns `true` for `deltaY` values very close to 1.
3. Check that the method still behaves correctly for other zoom levels.

## Additional Notes
This change helps maintain consistent behavior across different zoom levels, addressing edge cases where floating-point precision was causing unexpected results.
