### PR TITLE
chore: rm unreached ignore items when build extensions.

### DIFF
--- a/extensions/configuration-editing/.vscodeignore
+++ b/extensions/configuration-editing/.vscodeignore
@@ -4,7 +4,6 @@ tsconfig.json
 out/**
 extension.webpack.config.js
 extension-browser.webpack.config.js
-yarn.lock
 package-lock.json
 build/**
 schemas/devContainer.codespaces.schema.json

--- a/extensions/css-language-features/.vscodeignore
+++ b/extensions/css-language-features/.vscodeignore
@@ -11,10 +11,8 @@ server/tsconfig.json
 server/test/**
 server/bin/**
 server/build/**
-server/yarn.lock
 server/package-lock.json
 server/.npmignore
-yarn.lock
 package-lock.json
 server/extension.webpack.config.js
 extension.webpack.config.js

--- a/extensions/debug-auto-launch/.vscodeignore
+++ b/extensions/debug-auto-launch/.vscodeignore
@@ -2,5 +2,4 @@ src/**
 tsconfig.json
 out/**
 extension.webpack.config.js
-yarn.lock
 package-lock.json

--- a/extensions/debug-server-ready/.vscodeignore
+++ b/extensions/debug-server-ready/.vscodeignore
@@ -2,6 +2,5 @@ src/**
 tsconfig.json
 out/**
 extension.webpack.config.js
-yarn.lock
 package-lock.json
 .vscode

--- a/extensions/emmet/.vscodeignore
+++ b/extensions/emmet/.vscodeignore
@@ -7,6 +7,5 @@ extension.webpack.config.js
 extension-browser.webpack.config.js
 CONTRIBUTING.md
 cgmanifest.json
-yarn.lock
 package-lock.json
 .vscode

--- a/extensions/extension-editing/.vscodeignore
+++ b/extensions/extension-editing/.vscodeignore
@@ -4,5 +4,4 @@ tsconfig.json
 out/**
 extension.webpack.config.js
 extension-browser.webpack.config.js
-yarn.lock
 package-lock.json

--- a/extensions/git/.vscodeignore
+++ b/extensions/git/.vscodeignore
@@ -4,5 +4,4 @@ out/**
 tsconfig.json
 build/**
 extension.webpack.config.js
-yarn.lock
 package-lock.json

--- a/extensions/github-authentication/.vscodeignore
+++ b/extensions/github-authentication/.vscodeignore
@@ -6,5 +6,4 @@ build/**
 extension.webpack.config.js
 extension-browser.webpack.config.js
 tsconfig.json
-yarn.lock
 package-lock.json

--- a/extensions/github/.vscodeignore
+++ b/extensions/github/.vscodeignore
@@ -4,5 +4,4 @@ out/**
 build/**
 extension.webpack.config.js
 tsconfig.json
-yarn.lock
 package-lock.json

--- a/extensions/grunt/.vscodeignore
+++ b/extensions/grunt/.vscodeignore
@@ -3,5 +3,4 @@ src/**
 tsconfig.json
 out/**
 extension.webpack.config.js
-yarn.lock
 package-lock.json

--- a/extensions/gulp/.vscodeignore
+++ b/extensions/gulp/.vscodeignore
@@ -2,5 +2,4 @@ src/**
 tsconfig.json
 out/**
 extension.webpack.config.js
-yarn.lock
 package-lock.json

--- a/extensions/html-language-features/.vscodeignore
+++ b/extensions/html-language-features/.vscodeignore
@@ -13,10 +13,8 @@ server/test/**
 server/bin/**
 server/build/**
 server/lib/cgmanifest.json
-server/yarn.lock
 server/package-lock.json
 server/.npmignore
-yarn.lock
 package-lock.json
 server/extension.webpack.config.js
 extension.webpack.config.js

--- a/extensions/ipynb/.vscodeignore
+++ b/extensions/ipynb/.vscodeignore
@@ -5,7 +5,6 @@ out/**
 tsconfig.json
 extension.webpack.config.js
 extension-browser.webpack.config.js
-yarn.lock
 package-lock.json
 .gitignore
 esbuild.js

--- a/extensions/jake/.vscodeignore
+++ b/extensions/jake/.vscodeignore
@@ -2,5 +2,4 @@ src/**
 tsconfig.json
 out/**
 extension.webpack.config.js
-yarn.lock
 package-lock.json

--- a/extensions/json-language-features/.vscodeignore
+++ b/extensions/json-language-features/.vscodeignore
@@ -10,11 +10,9 @@ server/tsconfig.json
 server/test/**
 server/bin/**
 server/build/**
-server/yarn.lock
 server/package-lock.json
 server/.npmignore
 server/README.md
-yarn.lock
 package-lock.json
 CONTRIBUTING.md
 server/extension.webpack.config.js

--- a/extensions/json-language-features/server/.npmignore
+++ b/extensions/json-language-features/server/.npmignore
@@ -5,7 +5,6 @@ src/
 test/
 tsconfig.json
 .gitignore
-yarn.lock
 package-lock.json
 extension.webpack.config.js
 vscode-json-languageserver-*.tgz

--- a/extensions/markdown-language-features/.vscodeignore
+++ b/extensions/markdown-language-features/.vscodeignore
@@ -9,7 +9,6 @@ out/**
 extension.webpack.config.js
 extension-browser.webpack.config.js
 cgmanifest.json
-yarn.lock
 package-lock.json
 preview-src/**
 webpack.config.js

--- a/extensions/markdown-math/.vscodeignore
+++ b/extensions/markdown-math/.vscodeignore
@@ -4,7 +4,6 @@ extension-browser.webpack.config.js
 extension.webpack.config.js
 esbuild.js
 cgmanifest.json
-yarn.lock
 package-lock.json
 webpack.config.js
 tsconfig.json

--- a/extensions/media-preview/.vscodeignore
+++ b/extensions/media-preview/.vscodeignore
@@ -6,7 +6,6 @@ out/**
 extension.webpack.config.js
 extension-browser.webpack.config.js
 cgmanifest.json
-yarn.lock
 package-lock.json
 preview-src/**
 webpack.config.js

--- a/extensions/merge-conflict/.vscodeignore
+++ b/extensions/merge-conflict/.vscodeignore
@@ -3,5 +3,4 @@ tsconfig.json
 out/**
 extension.webpack.config.js
 extension-browser.webpack.config.js
-yarn.lock
 package-lock.json

--- a/extensions/microsoft-authentication/.vscodeignore
+++ b/extensions/microsoft-authentication/.vscodeignore
@@ -4,7 +4,6 @@ out/test/**
 out/**
 extension.webpack.config.js
 extension-browser.webpack.config.js
-yarn.lock
 package-lock.json
 src/**
 .gitignore

--- a/extensions/npm/.vscodeignore
+++ b/extensions/npm/.vscodeignore
@@ -4,5 +4,4 @@ tsconfig.json
 .vscode/**
 extension.webpack.config.js
 extension-browser.webpack.config.js
-yarn.lock
 package-lock.json

--- a/extensions/php-language-features/.vscodeignore
+++ b/extensions/php-language-features/.vscodeignore
@@ -3,5 +3,4 @@ src/**
 out/**
 tsconfig.json
 extension.webpack.config.js
-yarn.lock
 package-lock.json

--- a/extensions/references-view/.vscodeignore
+++ b/extensions/references-view/.vscodeignore
@@ -3,5 +3,4 @@ src/**
 out/**
 tsconfig.json
 *.webpack.config.js
-yarn.lock
 package-lock.json

--- a/extensions/search-result/.vscodeignore
+++ b/extensions/search-result/.vscodeignore
@@ -3,6 +3,5 @@ out/**
 tsconfig.json
 extension.webpack.config.js
 extension-browser.webpack.config.js
-yarn.lock
 package-lock.json
 syntaxes/generateTMLanguage.js

--- a/extensions/simple-browser/.vscodeignore
+++ b/extensions/simple-browser/.vscodeignore
@@ -8,7 +8,6 @@ extension.webpack.config.js
 extension-browser.webpack.config.js
 cgmanifest.json
 .gitignore
-yarn.lock
 package-lock.json
 preview-src/**
 webpack.config.js

--- a/extensions/tunnel-forwarding/.vscodeignore
+++ b/extensions/tunnel-forwarding/.vscodeignore
@@ -2,5 +2,4 @@ src/**
 tsconfig.json
 out/**
 extension.webpack.config.js
-yarn.lock
 package-lock.json

--- a/extensions/typescript-language-features/.vscodeignore
+++ b/extensions/typescript-language-features/.vscodeignore
@@ -8,5 +8,4 @@ tsconfig.json
 extension.webpack.config.js
 extension-browser.webpack.config.js
 cgmanifest.json
-yarn.lock
 package-lock.json


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

`.vscodeignore` file used for declaring unused files to ignore when build built-in extensions.

The problem is that after we migrate `yarn` back to `npm`, `yarn.lock` or `server/yarn.lock` items declared in this file aren't reached actually while building extensions. This pr would like to fix it~
