### PR TITLE
esm - restore ability to `require.resolve` with `paths`

### DIFF
--- a/src/vs/workbench/api/node/extHostExtensionService.ts
+++ b/src/vs/workbench/api/node/extHostExtensionService.ts
@@ -49,7 +49,11 @@ class NodeModuleRequireInterceptor extends RequireInterceptor {
 		const originalResolveFilename = node_module._resolveFilename;
 		node_module._resolveFilename = function resolveFilename(request: string, parent: unknown, isMain: boolean, options?: { paths?: string[] }) {
 			if (request === 'vsda' && Array.isArray(options?.paths) && options.paths.length === 0) {
-				options.paths = undefined; // TODO what to fill in here?
+				// ESM: ever since we moved to ESM, `require.main` will be `undefined` for extensions
+				// Some extensions have been using `require.resolve('vsda', { paths: require.main.paths })`
+				// to find the `vsda` module in our app root. To be backwards compatible with this pattern,
+				// we help by filling in the `paths` array with the node modules paths of the current module.
+				options.paths = node_module._nodeModulePaths(import.meta.dirname);
 			}
 			return originalResolveFilename.call(this, request, parent, isMain, options);
 		};

--- a/src/vs/workbench/api/node/extHostExtensionService.ts
+++ b/src/vs/workbench/api/node/extHostExtensionService.ts
@@ -46,6 +46,14 @@ class NodeModuleRequireInterceptor extends RequireInterceptor {
 			return originalLookup.call(this, applyAlternatives(request), parent);
 		};
 
+		const originalResolveFilename = node_module._resolveFilename;
+		node_module._resolveFilename = function resolveFilename(request: string, parent: unknown, isMain: boolean, options?: { paths?: string[] }) {
+			if (request === 'vsda' && Array.isArray(options?.paths) && options.paths.length === 0) {
+				options.paths = undefined; // TODO what to fill in here?
+			}
+			return originalResolveFilename.call(this, request, parent, isMain, options);
+		};
+
 		const applyAlternatives = (request: string) => {
 			for (const alternativeModuleName of that._alternatives) {
 				const alternative = alternativeModuleName(request);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
