### PR TITLE
cli: revert "code server-web when offline"

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -81,5 +81,4 @@ codegen-units = 1
 
 [features]
 default = []
-vsda = []
 vscode-encrypt = []

--- a/cli/src/auth.rs
+++ b/cli/src/auth.rs
@@ -723,7 +723,7 @@ impl Auth {
 
 			match &init_code_json.message {
 				Some(m) => self.log.result(m),
-				None => self.log.result(format!(
+				None => self.log.result(&format!(
 					"To grant access to the server, please log into {} and use code {}",
 					init_code_json.verification_uri, init_code_json.user_code
 				)),

--- a/cli/src/commands/serve_web.rs
+++ b/cli/src/commands/serve_web.rs
@@ -15,7 +15,7 @@ use std::time::{Duration, Instant};
 use hyper::service::{make_service_fn, service_fn};
 use hyper::{Body, Request, Response, Server};
 use tokio::io::{AsyncBufReadExt, BufReader};
-use tokio::{pin, time};
+use tokio::pin;
 
 use crate::async_pipe::{
 	get_socket_name, get_socket_rw_stream, listen_socket_rw_stream, AsyncPipe,
@@ -50,7 +50,7 @@ const SERVER_IDLE_TIMEOUT_SECS: u64 = 60 * 60;
 /// (should be large enough to basically never happen)
 const SERVER_ACTIVE_TIMEOUT_SECS: u64 = SERVER_IDLE_TIMEOUT_SECS * 24 * 30 * 12;
 /// How long to cache the "latest" version we get from the update service.
-const RELEASE_CHECK_INTERVAL: u64 = 60 * 60;
+const RELEASE_CACHE_SECS: u64 = 60 * 60;
 
 /// Number of bytes for the secret keys. See workbench.ts for their usage.
 const SECRET_KEY_BYTES: usize = 32;
@@ -86,11 +86,7 @@ pub async fn serve_web(ctx: CommandContext, mut args: ServeWebArgs) -> Result<i3
 		}
 	}
 
-	let cm: Arc<ConnectionManager> = ConnectionManager::new(&ctx, platform, args.clone());
-	let update_check_interval = 3600;
-	cm.clone()
-		.start_update_checker(Duration::from_secs(update_check_interval));
-
+	let cm = ConnectionManager::new(&ctx, platform, args.clone());
 	let key = get_server_key_half(&ctx.paths);
 	let make_svc = move || {
 		let ctx = HandleContext {
@@ -179,7 +175,7 @@ async fn handle_proxied(ctx: &HandleContext, req: Request<Body>) -> Response<Bod
 	let release = if let Some((r, _)) = get_release_from_path(req.uri().path(), ctx.cm.platform) {
 		r
 	} else {
-		match ctx.cm.get_release_from_cache().await {
+		match ctx.cm.get_latest_release().await {
 			Ok(r) => r,
 			Err(e) => {
 				error!(ctx.log, "error getting latest version: {}", e);
@@ -542,65 +538,19 @@ impl ConnectionManager {
 	pub fn new(ctx: &CommandContext, platform: Platform, args: ServeWebArgs) -> Arc<Self> {
 		let base_path = normalize_base_path(args.server_base_path.as_deref().unwrap_or_default());
 
-		let cache = DownloadCache::new(ctx.paths.web_server_storage());
-		let target_kind = TargetKind::Web;
-
-		let quality = VSCODE_CLI_QUALITY.map_or(Quality::Stable, |q| match Quality::try_from(q) {
-			Ok(q) => q,
-			Err(_) => Quality::Stable,
-		});
-
-		let latest_version = tokio::sync::Mutex::new(cache.get().first().map(|latest_commit| {
-			(
-				Instant::now() - Duration::from_secs(RELEASE_CHECK_INTERVAL),
-				Release {
-					name: String::from("0.0.0"), // Version information not stored on cache
-					commit: latest_commit.clone(),
-					platform,
-					target: target_kind,
-					quality,
-				},
-			)
-		}));
-
 		Arc::new(Self {
 			platform,
 			args,
 			base_path,
 			log: ctx.log.clone(),
-			cache,
+			cache: DownloadCache::new(ctx.paths.web_server_storage()),
 			update_service: UpdateService::new(
 				ctx.log.clone(),
 				Arc::new(ReqwestSimpleHttp::with_client(ctx.http.clone())),
 			),
 			state: ConnectionStateMap::default(),
-			latest_version,
+			latest_version: tokio::sync::Mutex::default(),
 		})
-	}
-
-	// spawns a task that checks for updates every n seconds duration
-	pub fn start_update_checker(self: Arc<Self>, duration: Duration) {
-		tokio::spawn(async move {
-			let mut interval = time::interval(duration);
-			loop {
-				interval.tick().await;
-
-				if let Err(e) = self.get_latest_release().await {
-					warning!(self.log, "error getting latest version: {}", e);
-				}
-			}
-		});
-	}
-
-	// Returns the latest release from the cache, if one exists.
-	pub async fn get_release_from_cache(&self) -> Result<Release, CodeError> {
-		let latest = self.latest_version.lock().await;
-		if let Some((_, release)) = &*latest {
-			return Ok(release.clone());
-		}
-
-		drop(latest);
-		self.get_latest_release().await
 	}
 
 	/// Gets a connection to a server version
@@ -621,7 +571,11 @@ impl ConnectionManager {
 	pub async fn get_latest_release(&self) -> Result<Release, CodeError> {
 		let mut latest = self.latest_version.lock().await;
 		let now = Instant::now();
-		let target_kind = TargetKind::Web;
+		if let Some((checked_at, release)) = &*latest {
+			if checked_at.elapsed() < Duration::from_secs(RELEASE_CACHE_SECS) {
+				return Ok(release.clone());
+			}
+		}
 
 		let quality = VSCODE_CLI_QUALITY
 			.ok_or_else(|| CodeError::UpdatesNotConfigured("no configured quality"))
@@ -631,14 +585,13 @@ impl ConnectionManager {
 
 		let release = self
 			.update_service
-			.get_latest_commit(self.platform, target_kind, quality)
+			.get_latest_commit(self.platform, TargetKind::Web, quality)
 			.await
 			.map_err(|e| CodeError::UpdateCheckFailed(e.to_string()));
 
 		// If the update service is unavailable and we have stale data, use that
-		if let (Err(e), Some((_, previous))) = (&release, latest.clone()) {
+		if let (Err(e), Some((_, previous))) = (&release, &*latest) {
 			warning!(self.log, "error getting latest release, using stale: {}", e);
-			*latest = Some((now, previous.clone()));
 			return Ok(previous.clone());
 		}
 

--- a/cli/src/download_cache.rs
+++ b/cli/src/download_cache.rs
@@ -20,7 +20,6 @@ const KEEP_LRU: usize = 5;
 const STAGING_SUFFIX: &str = ".staging";
 const RENAME_ATTEMPTS: u32 = 20;
 const RENAME_DELAY: std::time::Duration = std::time::Duration::from_millis(200);
-const PERSISTED_STATE_FILE_NAME: &str = "lru.json";
 
 #[derive(Clone)]
 pub struct DownloadCache {
@@ -31,14 +30,9 @@ pub struct DownloadCache {
 impl DownloadCache {
 	pub fn new(path: PathBuf) -> DownloadCache {
 		DownloadCache {
-			state: PersistedState::new(path.join(PERSISTED_STATE_FILE_NAME)),
+			state: PersistedState::new(path.join("lru.json")),
 			path,
 		}
-	}
-
-	/// Gets the value stored on the state
-	pub fn get(&self) -> Vec<String> {
-		self.state.load()
 	}
 
 	/// Gets the download cache path. Names of cache entries can be formed by

--- a/cli/src/tunnels/code_server.rs
+++ b/cli/src/tunnels/code_server.rs
@@ -674,7 +674,7 @@ where
 		let write_line = |line: &str| -> std::io::Result<()> {
 			if let Some(mut f) = log_file.as_ref() {
 				f.write_all(line.as_bytes())?;
-				f.write_all(b"\n")?;
+				f.write_all(&[b'\n'])?;
 			}
 			if write_directly {
 				println!("{}", line);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "code-oss-dev",
   "version": "1.94.0",
-  "distro": "fcaeb73de7ac6ff11a3e732c63987e01b88341e7",
+  "distro": "36c6d77f96e54b1ad2233cd24fed8e8f08d5a388",
   "author": {
     "name": "Microsoft Corporation"
   },


### PR DESCRIPTION
This PR reverts changes from https://github.com/microsoft/vscode/pull/227830 and pushes distro back to https://github.com/microsoft/vscode-distro/commit/1f99a7e25e381bc566d839c0259770ef5735d8ed for addressing the Cli build issues.

Check https://github.com/microsoft/vscode/issues/227959 for additional details.