### PR TITLE
fix accessible view bug

### DIFF
--- a/src/vs/base/browser/markdownRenderer.ts
+++ b/src/vs/base/browser/markdownRenderer.ts
@@ -545,9 +545,8 @@ export function renderMarkdownAsPlaintext(markdown: IMarkdownString, withCodeBlo
 		value = `${value.substr(0, 100_000)}…`;
 	}
 
-	const html = marked.parse(value, { async: false, renderer: withCodeBlocks ? plainTextWithCodeBlocksRenderer.value : plainTextRenderer.value }).replace(/&(#\d+|[a-zA-Z]+);/g, m => unescapeInfo.get(m) ?? m);
-
-	return sanitizeRenderedMarkdown({ isTrusted: false }, html).toString().replace(unescapeRegex, match => unescapeInfo.get(match) ?? match);
+	const html = marked.parse(value, { async: false, renderer: withCodeBlocks ? plainTextWithCodeBlocksRenderer.value : plainTextRenderer.value });
+	return sanitizeRenderedMarkdown({ isTrusted: false }, html).toString().replace(/&(#\d+|[a-zA-Z]+);/g, m => unescapeInfo.get(m) ?? m);
 }
 
 const unescapeInfo = new Map<string, string>([
@@ -558,7 +557,6 @@ const unescapeInfo = new Map<string, string>([
 	['&lt;', '<'],
 	['&gt;', '>'],
 ]);
-const unescapeRegex = new RegExp(Array.from(unescapeInfo.keys()).join('|'), 'g');
 
 function createRenderer(): marked.Renderer {
 	const renderer = new marked.Renderer();

--- a/src/vs/base/browser/markdownRenderer.ts
+++ b/src/vs/base/browser/markdownRenderer.ts
@@ -547,13 +547,7 @@ export function renderMarkdownAsPlaintext(markdown: IMarkdownString, withCodeBlo
 
 	const html = marked.parse(value, { async: false, renderer: withCodeBlocks ? plainTextWithCodeBlocksRenderer.value : plainTextRenderer.value }).replace(/&(#\d+|[a-zA-Z]+);/g, m => unescapeInfo.get(m) ?? m);
 
-	let sanitized = sanitizeRenderedMarkdown({ isTrusted: false }, html).toString();
-	if (sanitized.includes('&lt;-')) {
-		// Preserve the <- characters
-		sanitized = sanitized.replaceAll('&lt;-', '<-');
-	}
-	return sanitized;
-
+	return sanitizeRenderedMarkdown({ isTrusted: false }, html).toString().replace(unescapeRegex, match => unescapeInfo.get(match) ?? match);
 }
 
 const unescapeInfo = new Map<string, string>([
@@ -564,6 +558,7 @@ const unescapeInfo = new Map<string, string>([
 	['&lt;', '<'],
 	['&gt;', '>'],
 ]);
+const unescapeRegex = new RegExp(Array.from(unescapeInfo.keys()).join('|'), 'g');
 
 function createRenderer(): marked.Renderer {
 	const renderer = new marked.Renderer();

--- a/src/vs/base/browser/markdownRenderer.ts
+++ b/src/vs/base/browser/markdownRenderer.ts
@@ -547,7 +547,13 @@ export function renderMarkdownAsPlaintext(markdown: IMarkdownString, withCodeBlo
 
 	const html = marked.parse(value, { async: false, renderer: withCodeBlocks ? plainTextWithCodeBlocksRenderer.value : plainTextRenderer.value }).replace(/&(#\d+|[a-zA-Z]+);/g, m => unescapeInfo.get(m) ?? m);
 
-	return sanitizeRenderedMarkdown({ isTrusted: false }, html).toString();
+	let sanitized = sanitizeRenderedMarkdown({ isTrusted: false }, html).toString();
+	if (sanitized.includes('&lt;-')) {
+		// Preserve the <- characters
+		sanitized = sanitized.replaceAll('&lt;-', '<-');
+	}
+	return sanitized;
+
 }
 
 const unescapeInfo = new Map<string, string>([


### PR DESCRIPTION
Before:
<img width="712" alt="Screenshot 2024-09-09 at 10 24 23 AM" src="https://github.com/user-attachments/assets/49c9cd75-61bd-46df-9469-28972993280a">

After:
<img width="934" alt="Screenshot 2024-09-09 at 12 02 25 PM" src="https://github.com/user-attachments/assets/f1fdf6b5-242f-48e3-b932-d69103c36948">


I tried adding a `dompurify` hook, but for the particular events we currently support, the string is still correct at those times. One thing I could do is add an `afterSanitizeAttribute` hook which may work 🤔 , but wonder if there's a reason we don't do that for other cases?

I could also just do this in the two cases where this is happening - for the chat accessible views. Pls LMK your thoughts @mjbvz .

<img width="1685" alt="Screenshot 2024-09-09 at 11 58 51 AM" src="https://github.com/user-attachments/assets/03b67a6f-4883-4aa1-a3bc-cc577837c144">
