### PR TITLE
Correct tooltip capitalization of debug panel in status bar (fix #228088)

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/debugStatus.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugStatus.ts
@@ -66,7 +66,7 @@ export class DebugStatusContribution implements IWorkbenchContribution {
 			name: nls.localize('status.debug', "Debug"),
 			text: '$(debug-alt-small) ' + text,
 			ariaLabel: nls.localize('debugTarget', "Debug: {0}", text),
-			tooltip: nls.localize('selectAndStartDebug', "Select and start debug configuration"),
+			tooltip: nls.localize('selectAndStartDebug', "Select and Start Debug Configuration"),
 			command: 'workbench.action.debug.selectandstart'
 		};
 	}


### PR DESCRIPTION
This PR fixes #228088

![image](https://github.com/user-attachments/assets/6019a25b-9f9a-4ecc-8c2a-d01cc51dc956)
