### PR TITLE
Render secondary review actions using drop-downs

### DIFF
--- a/src/vs/workbench/contrib/comments/browser/commentNode.ts
+++ b/src/vs/workbench/contrib/comments/browser/commentNode.ts
@@ -633,7 +633,7 @@ export class CommentNode<T extends IRange | ICellRange> extends Disposable {
 			this._commentFormActions?.setActions(menu);
 		}));
 
-		this._commentFormActions = new CommentFormActions(this.keybindingService, this._contextKeyService, container, (action: IAction): void => {
+		this._commentFormActions = new CommentFormActions(this.keybindingService, this._contextKeyService, this.contextMenuService, container, (action: IAction): void => {
 			const text = this._commentEditor!.getValue();
 
 			action.run({
@@ -659,7 +659,7 @@ export class CommentNode<T extends IRange | ICellRange> extends Disposable {
 			this._commentEditorActions?.setActions(menu);
 		}));
 
-		this._commentEditorActions = new CommentFormActions(this.keybindingService, this._contextKeyService, container, (action: IAction): void => {
+		this._commentEditorActions = new CommentFormActions(this.keybindingService, this._contextKeyService, this.contextMenuService, container, (action: IAction): void => {
 			const text = this._commentEditor!.getValue();
 
 			action.run({

--- a/src/vs/workbench/contrib/comments/browser/commentReply.ts
+++ b/src/vs/workbench/contrib/comments/browser/commentReply.ts
@@ -30,6 +30,7 @@ import { ICommentThreadWidget } from '../common/commentThreadWidget.js';
 import { ICellRange } from '../../notebook/common/notebookRange.js';
 import { LayoutableEditor, MIN_EDITOR_HEIGHT, SimpleCommentEditor, calculateEditorHeight } from './simpleCommentEditor.js';
 import { IHoverService } from '../../../../platform/hover/browser/hover.js';
+import { IContextMenuService } from '../../../../platform/contextview/browser/contextView.js';
 
 let INMEM_MODEL_ID = 0;
 export const COMMENTEDITOR_DECORATION_KEY = 'commenteditordecoration';
@@ -63,6 +64,7 @@ export class CommentReply<T extends IRange | ICellRange> extends Disposable {
 		@ICommentService private commentService: ICommentService,
 		@IConfigurationService configurationService: IConfigurationService,
 		@IKeybindingService private keybindingService: IKeybindingService,
+		@IContextMenuService private contextMenuService: IContextMenuService,
 		@IHoverService private hoverService: IHoverService,
 		@ITextModelService private readonly textModelService: ITextModelService
 	) {
@@ -273,7 +275,7 @@ export class CommentReply<T extends IRange | ICellRange> extends Disposable {
 			this._commentFormActions.setActions(menu);
 		}));
 
-		this._commentFormActions = new CommentFormActions(this.keybindingService, this._contextKeyService, container, async (action: IAction) => {
+		this._commentFormActions = new CommentFormActions(this.keybindingService, this._contextKeyService, this.contextMenuService, container, async (action: IAction) => {
 			await this._actionRunDelegate?.();
 
 			await action.run({
@@ -296,7 +298,7 @@ export class CommentReply<T extends IRange | ICellRange> extends Disposable {
 			this._commentEditorActions.setActions(editorMenu);
 		}));
 
-		this._commentEditorActions = new CommentFormActions(this.keybindingService, this._contextKeyService, container, async (action: IAction) => {
+		this._commentEditorActions = new CommentFormActions(this.keybindingService, this._contextKeyService, this.contextMenuService, container, async (action: IAction) => {
 			this._actionRunDelegate?.();
 
 			action.run({

--- a/src/vs/workbench/contrib/comments/browser/commentThreadAdditionalActions.ts
+++ b/src/vs/workbench/contrib/comments/browser/commentThreadAdditionalActions.ts
@@ -16,6 +16,7 @@ import { CommentFormActions } from './commentFormActions.js';
 import { CommentMenus } from './commentMenus.js';
 import { ICellRange } from '../../notebook/common/notebookRange.js';
 import { IKeybindingService } from '../../../../platform/keybinding/common/keybinding.js';
+import { IContextMenuService } from '../../../../platform/contextview/browser/contextView.js';
 
 export class CommentThreadAdditionalActions<T extends IRange | ICellRange> extends Disposable {
 	private _container: HTMLElement | null;
@@ -29,6 +30,7 @@ export class CommentThreadAdditionalActions<T extends IRange | ICellRange> exten
 		private _commentMenus: CommentMenus,
 		private _actionRunDelegate: (() => void) | null,
 		@IKeybindingService private _keybindingService: IKeybindingService,
+		@IContextMenuService private _contextMenuService: IContextMenuService,
 	) {
 		super();
 
@@ -80,14 +82,14 @@ export class CommentThreadAdditionalActions<T extends IRange | ICellRange> exten
 			this._enableDisableMenu(menu);
 		}));
 
-		this._commentFormActions = new CommentFormActions(this._keybindingService, this._contextKeyService, container, async (action: IAction) => {
+		this._commentFormActions = new CommentFormActions(this._keybindingService, this._contextKeyService, this._contextMenuService, container, async (action: IAction) => {
 			this._actionRunDelegate?.();
 
 			action.run({
 				thread: this._commentThread,
 				$mid: MarshalledId.CommentThreadInstance
 			});
-		}, 4);
+		}, 4, true);
 
 		this._register(this._commentFormActions);
 		this._commentFormActions.setActions(menu, /*hasOnlySecondaryActions*/ true);


### PR DESCRIPTION
microsoft/vscode-copilot#8038

This is limited to the `"comments/commentThread/additionalActions"` contribution point (proposed API).

It uses the `"group"` of the contributions and shows groups ending in `_\d+_dropdown@\d+` as dropdowns. The first command in the group is used as the main action, and the rest are shown in the dropdown. (The main action is not shown in the dropdown.)

The number before the `@` in the group id are used to control order among several dropdown buttons, the number after the `@` is used to control order of actions within a dropdown. Buttons without dropdown can be added between dropdown buttons by omitting `_dropdown` in the group id.

Example usage:
```json
"comments/commentThread/additionalActions": [
	{
		"command": "github.copilot.interactiveEditor.review.applyShort",
		"group": "inline_1_dropdown@0",
		"when": "commentController == github-copilot-review"
	},
	{
		"command": "github.copilot.interactiveEditor.review.applyAndNext",
		"group": "inline_1_dropdown@1",
		"when": "commentController == github-copilot-review"
	},
	{
		"command": "github.copilot.interactiveEditor.review.apply",
		"group": "inline_1_dropdown@2",
		"when": "commentController == github-copilot-review"
	},
	{
		"command": "github.copilot.interactiveEditor.review.discardShort",
		"group": "inline_2_dropdown@0",
		"when": "commentController == github-copilot-review"
	},
	{
		"command": "github.copilot.interactiveEditor.review.discardAndNext",
		"group": "inline_2_dropdown@1",
		"when": "commentController == github-copilot-review"
	},
	{
		"command": "github.copilot.interactiveEditor.review.discard",
		"group": "inline_2_dropdown@2",
		"when": "commentController == github-copilot-review"
	},
	{
		"command": "github.copilot.interactiveEditor.review.continueInInlineChat",
		"group": "inline_2_dropdown@3",
		"when": "commentController == github-copilot-review"
	}
],
```
