### PR TITLE
testing: implement getControllersWithTests command

### DIFF
--- a/src/vs/workbench/contrib/testing/browser/testing.contribution.ts
+++ b/src/vs/workbench/contrib/testing/browser/testing.contribution.ts
@@ -235,5 +235,15 @@ CommandsRegistry.registerCommand({
 	}
 });
 
+CommandsRegistry.registerCommand({
+	id: 'vscode.testing.getControllersWithTests',
+	handler: async (accessor: ServicesAccessor) => {
+		const testService = accessor.get(ITestService);
+		return [...testService.collection.rootItems]
+			.filter(r => r.children.size > 0)
+			.map(r => r.controllerId);
+	}
+});
+
 Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).registerConfiguration(testingConfiguration);
 


### PR DESCRIPTION
Saves having to use a full test observer when only checking for presence

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
