### PR TITLE
Move executeToolbar to below text input in panel chat

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/media/chat.css
@@ -427,7 +427,6 @@ have to be updated for changes to the rules above, or to support more deeply nes
 }
 
 .interactive-session .interactive-input-and-execute-toolbar {
-	display: flex;
 	box-sizing: border-box;
 	cursor: text;
 	background-color: var(--vscode-input-background);
@@ -436,11 +435,12 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	position: relative;
 	padding: 0 6px;
 	margin-bottom: 4px;
-	align-items: flex-end;
-	justify-content: space-between;
 }
 
 .interactive-session .interactive-input-part.compact .interactive-input-and-execute-toolbar {
+	display: flex;
+	align-items: flex-end;
+	justify-content: space-between;
 	margin-bottom: 0;
 	border-radius: 2px;
 }
@@ -473,6 +473,10 @@ have to be updated for changes to the rules above, or to support more deeply nes
 
 	/* It's bottom-aligned, make it appear centered within the container */
 	margin-bottom: 7px;
+}
+
+.interactive-session .interactive-input-part .interactive-execute-toolbar .monaco-action-bar {
+	float: right;
 }
 
 .interactive-session .interactive-input-part .interactive-execute-toolbar .monaco-action-bar .actions-container {


### PR DESCRIPTION
Not changing quick chat or inline chat, to start. Will also move chat attachments into this space, and possibly split the attachment/other buttons out of the execute toolbar

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
