### PR TITLE
fix #228076 - do not disable extension for missing dependencies

### DIFF
--- a/src/vs/workbench/services/extensionManagement/browser/extensionEnablementService.ts
+++ b/src/vs/workbench/services/extensionManagement/browser/extensionEnablementService.ts
@@ -474,7 +474,7 @@ export class ExtensionEnablementService extends Disposable implements IWorkbench
 			: [];
 
 		if (!dependencyExtensions.length) {
-			return !!extensions.length && !!extension.manifest.extensionDependencies?.length;
+			return false;
 		}
 
 		const hasEnablementState = computedEnablementStates.has(extension);

--- a/src/vs/workbench/services/extensionManagement/test/browser/extensionEnablementService.test.ts
+++ b/src/vs/workbench/services/extensionManagement/test/browser/extensionEnablementService.test.ts
@@ -979,13 +979,13 @@ suite('ExtensionEnablementService Test', () => {
 		assert.deepStrictEqual(testObject.getEnablementStates(installed), [EnablementState.DisabledGlobally, EnablementState.DisabledByExtensionDependency]);
 	});
 
-	test('test extension is disabled by dependency when it has a missing dependency', async () => {
+	test('test extension is not disabled when it has a missing dependency', async () => {
 		const target = aLocalExtension2('pub.b', { extensionDependencies: ['pub.a'] });
 		installed.push(target);
 		testObject = disposableStore.add(new TestExtensionEnablementService(instantiationService));
 		await (<TestExtensionEnablementService>testObject).waitUntilInitialized();
 
-		assert.strictEqual(testObject.getEnablementState(target), EnablementState.DisabledByExtensionDependency);
+		assert.strictEqual(testObject.getEnablementState(target), EnablementState.EnabledGlobally);
 	});
 
 	test('test extension is disabled by invalidity', async () => {


### PR DESCRIPTION
A remote extension can depend on built in descriptive extension that runs locally