### PR TITLE
typo: fix to misspellings of 'current'

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/breakpointsView.ts
+++ b/src/vs/workbench/contrib/debug/browser/breakpointsView.ts
@@ -1236,7 +1236,7 @@ class ExceptionBreakpointInputRenderer implements IListRenderer<IExceptionBreakp
 			}
 		}));
 		toDispose.add(dom.addDisposableListener(inputBox.inputElement, 'blur', () => {
-			// Need to react with a timeout on the blur event due to possible concurent splices #56443
+			// Need to react with a timeout on the blur event due to possible concurrent splices #56443
 			setTimeout(() => {
 				wrapUp(true);
 			});

--- a/src/vs/workbench/contrib/notebook/browser/diff/diffElementOutputs.ts
+++ b/src/vs/workbench/contrib/notebook/browser/diff/diffElementOutputs.ts
@@ -152,7 +152,7 @@ export class OutputElement extends Disposable {
 			index: index,
 			picked: index === currIndex,
 			detail: this.generateRendererInfo(mimeType.rendererId),
-			description: index === currIndex ? nls.localize('curruentActiveMimeType', "Currently Active") : undefined
+			description: index === currIndex ? nls.localize('currentActiveMimeType', "Currently Active") : undefined
 		}));
 
 		const disposables = new DisposableStore();

--- a/src/vs/workbench/contrib/notebook/browser/view/cellParts/cellOutput.ts
+++ b/src/vs/workbench/contrib/notebook/browser/view/cellParts/cellOutput.ts
@@ -366,7 +366,7 @@ class CellOutputElement extends Disposable {
 					index: index,
 					picked: index === currIndex,
 					detail: this._generateRendererInfo(mimeType.rendererId),
-					description: index === currIndex ? nls.localize('curruentActiveMimeType', "Currently Active") : undefined
+					description: index === currIndex ? nls.localize('currentActiveMimeType', "Currently Active") : undefined
 				});
 			}
 		});


### PR DESCRIPTION
simple typo fix
fixed 'curruentActiveMimeType' to 'currentActiveMimeType'
fixed 'concurent' to 'concurrent'
