### PR TITLE
Workaround MSAL behavior

### DIFF
--- a/extensions/microsoft-authentication/src/common/scopeData.ts
+++ b/extensions/microsoft-authentication/src/common/scopeData.ts
@@ -6,6 +6,9 @@
 const DEFAULT_CLIENT_ID = 'aebc6443-996d-45c2-90f0-388ff96faa56';
 const DEFAULT_TENANT = 'organizations';
 
+const OIDC_SCOPES = ['openid', 'email', 'profile', 'offline_access'];
+const GRAPH_TACK_ON_SCOPE = 'User.Read';
+
 export class ScopeData {
 
 	/**
@@ -38,22 +41,10 @@ export class ScopeData {
 
 	constructor(readonly originalScopes: readonly string[] = []) {
 		const modifiedScopes = [...originalScopes];
-		if (!modifiedScopes.includes('openid')) {
-			modifiedScopes.push('openid');
-		}
-		if (!modifiedScopes.includes('email')) {
-			modifiedScopes.push('email');
-		}
-		if (!modifiedScopes.includes('profile')) {
-			modifiedScopes.push('profile');
-		}
-		if (!modifiedScopes.includes('offline_access')) {
-			modifiedScopes.push('offline_access');
-		}
 		modifiedScopes.sort();
 		this.allScopes = modifiedScopes;
 		this.scopeStr = modifiedScopes.join(' ');
-		this.scopesToSend = this.originalScopes.filter(s => !s.startsWith('VSCODE_'));
+		this.scopesToSend = this.getScopesToSend(modifiedScopes);
 		this.clientId = this.getClientId(this.allScopes);
 		this.tenant = this.getTenantId(this.allScopes);
 	}
@@ -74,5 +65,20 @@ export class ScopeData {
 			}
 			return prev;
 		}, undefined) ?? DEFAULT_TENANT;
+	}
+
+	private getScopesToSend(scopes: string[]) {
+		const scopesToSend = scopes.filter(s => !s.startsWith('VSCODE_'));
+
+		const set = new Set(scopesToSend);
+		for (const scope of OIDC_SCOPES) {
+			set.delete(scope);
+		}
+
+		// If we only had OIDC scopes, we need to add a tack-on scope to make the request valid.
+		if (!set.size) {
+			scopesToSend.push(GRAPH_TACK_ON_SCOPE);
+		}
+		return scopesToSend;
 	}
 }

--- a/extensions/microsoft-authentication/src/common/scopeData.ts
+++ b/extensions/microsoft-authentication/src/common/scopeData.ts
@@ -75,7 +75,8 @@ export class ScopeData {
 			set.delete(scope);
 		}
 
-		// If we only had OIDC scopes, we need to add a tack-on scope to make the request valid.
+		// If we only had OIDC scopes, we need to add a tack-on scope to make the request valid
+		// by forcing Identity into treating this as a Graph token request.
 		if (!set.size) {
 			scopesToSend.push(GRAPH_TACK_ON_SCOPE);
 		}

--- a/extensions/microsoft-authentication/src/common/test/scopeData.test.ts
+++ b/extensions/microsoft-authentication/src/common/test/scopeData.test.ts
@@ -9,22 +9,27 @@ import { ScopeData } from '../scopeData';
 suite('ScopeData', () => {
 	test('should include default scopes if not present', () => {
 		const scopeData = new ScopeData(['custom_scope']);
-		assert.deepStrictEqual(scopeData.allScopes, ['custom_scope', 'email', 'offline_access', 'openid', 'profile']);
+		assert.deepStrictEqual(scopeData.allScopes, ['custom_scope']);
 	});
 
 	test('should not duplicate default scopes if already present', () => {
-		const scopeData = new ScopeData(['openid', 'email', 'profile', 'offline_access']);
-		assert.deepStrictEqual(scopeData.allScopes, ['email', 'offline_access', 'openid', 'profile']);
+		const scopeData = new ScopeData(['custom_scope', 'openid', 'email', 'profile', 'offline_access']);
+		assert.deepStrictEqual(scopeData.allScopes, ['custom_scope', 'email', 'offline_access', 'openid', 'profile']);
 	});
 
 	test('should sort the scopes alphabetically', () => {
-		const scopeData = new ScopeData(['profile', 'email', 'openid', 'offline_access']);
-		assert.deepStrictEqual(scopeData.allScopes, ['email', 'offline_access', 'openid', 'profile']);
+		const scopeData = new ScopeData(['custom_scope', 'profile', 'email', 'openid', 'offline_access']);
+		assert.deepStrictEqual(scopeData.allScopes, ['custom_scope', 'email', 'offline_access', 'openid', 'profile']);
 	});
 
 	test('should create a space-separated string of all scopes', () => {
-		const scopeData = new ScopeData(['custom_scope']);
+		const scopeData = new ScopeData(['custom_scope', 'openid', 'email', 'offline_access', 'profile']);
 		assert.strictEqual(scopeData.scopeStr, 'custom_scope email offline_access openid profile');
+	});
+
+	test('should add TACK ON scope if all scopes are OIDC scopes', () => {
+		const scopeData = new ScopeData(['openid', 'email', 'offline_access', 'profile']);
+		assert.deepStrictEqual(scopeData.scopesToSend, ['email', 'offline_access', 'openid', 'profile', 'User.Read']);
 	});
 
 	test('should filter out internal VS Code scopes for scopesToSend', () => {


### PR DESCRIPTION
The main change this makes is around what scopes are being requested.

Due to an MSAL or Identity issue, if you request a resource like `FOO/user_impersonation` and then `email`... the 2nd call does not use Graph and instead uses FOO and FOO may not have an `email` scope available. To work around this, if we detect that all scopes being requested are [OIDC scopes](https://learn.microsoft.com/en-us/entra/identity-platform/scopes-oidc#openid-connect-scopes) then we tack on `User.Read` to make sure that what gets returned is in fact from Graph. This prevents an infinite loop that was happening before. MSAL/Identity should fix this behavior, but this works for now.

Additionally, MSAL does already tack on OIDC scopes to all requests so I removed the logic that adds those.

Couple small things:
* Make sure MSAL logs get logged (trace)
* Use a Sequencer to make sure acquireToken calls are done sequentially just in case.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

ref https://github.com/microsoft/vscode/issues/229415