### PR TITLE
EditContext: Immediately set isFocused field on focus call

### DIFF
--- a/src/vs/editor/browser/controller/editContext/native/nativeEditContextUtils.ts
+++ b/src/vs/editor/browser/controller/editContext/native/nativeEditContextUtils.ts
@@ -35,6 +35,9 @@ export class FocusTracker extends Disposable {
 
 	public focus(): void {
 		this._domNode.focus();
+		// fixes: https://github.com/microsoft/vscode/issues/228147
+		// Immediately call this method in order to directly set the field isFocused to true so the textInputFocus context key is evaluated correctly
+		this._handleFocusedChanged(true);
 	}
 
 	get isFocused(): boolean {


### PR DESCRIPTION
Immediately set the field isFocused on focus call

This is needed in order for the context keys to be correctly evaluated