### PR TITLE
SCM Graph - better handling of graph refresh

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadSCM.ts
+++ b/src/vs/workbench/api/browser/mainThreadSCM.ts
@@ -190,7 +190,7 @@ class MainThreadSCMHistoryProvider implements ISCMHistoryProvider {
 	}, undefined);
 	get historyItemBaseRef(): IObservable<ISCMHistoryItemRef | undefined> { return this._historyItemBaseRef; }
 
-	private readonly _historyItemRefChanges = observableValue<ISCMHistoryItemRefsChangeEvent>(this, { added: [], modified: [], removed: [] });
+	private readonly _historyItemRefChanges = observableValue<ISCMHistoryItemRefsChangeEvent>(this, { added: [], modified: [], removed: [], silent: false });
 	get historyItemRefChanges(): IObservable<ISCMHistoryItemRefsChangeEvent> { return this._historyItemRefChanges; }
 
 	constructor(private readonly proxy: ExtHostSCMShape, private readonly handle: number) { }
@@ -232,7 +232,7 @@ class MainThreadSCMHistoryProvider implements ISCMHistoryProvider {
 		const modified = historyItemRefs.modified.map(ref => toISCMHistoryItemRef(ref)!);
 		const removed = historyItemRefs.removed.map(ref => toISCMHistoryItemRef(ref)!);
 
-		this._historyItemRefChanges.set({ added, modified, removed }, undefined);
+		this._historyItemRefChanges.set({ added, modified, removed, silent: historyItemRefs.silent }, undefined);
 	}
 }
 

--- a/src/vs/workbench/api/common/extHost.protocol.ts
+++ b/src/vs/workbench/api/common/extHost.protocol.ts
@@ -1555,6 +1555,7 @@ export interface SCMHistoryItemRefsChangeEventDto {
 	readonly added: readonly SCMHistoryItemRefDto[];
 	readonly modified: readonly SCMHistoryItemRefDto[];
 	readonly removed: readonly SCMHistoryItemRefDto[];
+	readonly silent: boolean;
 }
 
 export interface SCMHistoryItemDto {

--- a/src/vs/workbench/api/common/extHostSCM.ts
+++ b/src/vs/workbench/api/common/extHostSCM.ts
@@ -612,7 +612,7 @@ class ExtHostSourceControl implements vscode.SourceControl {
 				const modified = e.modified.map(ref => ({ ...ref, icon: getHistoryItemIconDto(ref.icon) }));
 				const removed = e.removed.map(ref => ({ ...ref, icon: getHistoryItemIconDto(ref.icon) }));
 
-				this.#proxy.$onDidChangeHistoryProviderHistoryItemRefs(this.handle, { added, modified, removed });
+				this.#proxy.$onDidChangeHistoryProviderHistoryItemRefs(this.handle, { added, modified, removed, silent: e.silent });
 			}));
 		}
 	}

--- a/src/vs/workbench/contrib/scm/browser/media/scm.css
+++ b/src/vs/workbench/contrib/scm/browser/media/scm.css
@@ -527,7 +527,7 @@
 	background-color: var(--vscode-badge-background);
 	color: var(--vscode-badge-foreground);
 	border: 1px solid var(--vscode-contrastBorder);
-	margin-left: 6px;
+	margin: 0 6px;
 	padding: 2px 4px;
 }
 

--- a/src/vs/workbench/contrib/scm/browser/scmHistoryViewPane.ts
+++ b/src/vs/workbench/contrib/scm/browser/scmHistoryViewPane.ts
@@ -1156,6 +1156,33 @@ export class SCMHistoryViewPane extends ViewPane {
 						return;
 					}
 
+					// If there are any removed history item references we need to check whether they are
+					// currently being used in the filter. If they are, we need to update the filter which
+					// will result in the graph being refreshed.
+					if (changes.removed.length !== 0) {
+						const historyItemsFilter = this._treeViewModel.historyItemsFilter.get();
+
+						if (historyItemsFilter !== 'all' && historyItemsFilter !== 'auto') {
+							let updateFilter = false;
+							const historyItemRefs = [...historyItemsFilter];
+
+							for (const ref of changes.removed) {
+								const index = historyItemRefs
+									.findIndex(item => item.id === ref.id);
+
+								if (index !== -1) {
+									historyItemRefs.splice(index, 1);
+									updateFilter = true;
+								}
+							}
+
+							if (updateFilter) {
+								this._treeViewModel.setHistoryItemsFilter(historyItemRefs);
+								return;
+							}
+						}
+					}
+
 					this.refresh();
 				}));
 

--- a/src/vs/workbench/contrib/scm/browser/scmHistoryViewPane.ts
+++ b/src/vs/workbench/contrib/scm/browser/scmHistoryViewPane.ts
@@ -16,7 +16,7 @@ import { fromNow } from '../../../../base/common/date.js';
 import { createMatches, FuzzyScore, IMatch } from '../../../../base/common/filters.js';
 import { MarkdownString } from '../../../../base/common/htmlContent.js';
 import { Disposable, DisposableStore, IDisposable } from '../../../../base/common/lifecycle.js';
-import { autorun, autorunWithStore, autorunWithStoreHandleChanges, derived, IObservable, observableValue, waitForState, constObservable, latestChangedValue, observableFromEvent, runOnChange, signalFromObservable } from '../../../../base/common/observable.js';
+import { autorun, autorunWithStore, derived, IObservable, observableValue, waitForState, constObservable, latestChangedValue, observableFromEvent, runOnChange } from '../../../../base/common/observable.js';
 import { ThemeIcon } from '../../../../base/common/themables.js';
 import { localize } from '../../../../nls.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
@@ -1132,58 +1132,32 @@ export class SCMHistoryViewPane extends ViewPane {
 				// Update context
 				this._scmProviderCtx.set(repository.provider.contextValue);
 
-				// Publish
-				const historyItemRemoteRefIdSignal = signalFromObservable(this, derived(reader => {
-					return historyProvider.historyItemRemoteRef.read(reader)?.id;
+				// HistoryItemId changed (checkout)
+				const historyItemRefId = derived(reader => {
+					return historyProvider.historyItemRef.read(reader)?.id;
+				});
+				store.add(runOnChange(historyItemRefId, () => {
+					this.refresh();
 				}));
 
-				// Fetch, Push
-				const historyItemRemoteRefRevision = derived(reader => {
-					return historyProvider.historyItemRemoteRef.read(reader)?.revision;
-				});
-
 				// HistoryItemRefs changed
-				store.add(
-					autorunWithStoreHandleChanges<{ refresh: boolean | 'ifScrollTop' }>({
-						owner: this,
-						createEmptyChangeSummary: () => ({ refresh: false }),
-						handleChange(context, changeSummary) {
-							changeSummary.refresh = context.didChange(historyItemRemoteRefRevision) ? 'ifScrollTop' : true;
-							return true;
-						},
-					}, (reader, changeSummary) => {
-						historyItemRemoteRefIdSignal.read(reader);
-						const historyItemRefValue = historyProvider.historyItemRef.read(reader);
-						const historyItemRemoteRefRevisionValue = historyItemRemoteRefRevision.read(reader);
-
-						// Commit, Checkout, Publish, Pull
-						if (changeSummary.refresh === true) {
+				store.add(runOnChange(historyProvider.historyItemRefChanges, changes => {
+					if (changes.silent) {
+						// The history item reference changes occurred in the background (ex: Auto Fetch)
+						// If tree is scrolled to the top, we can safely refresh the tree, otherwise we
+						// will show a visual cue that the view is outdated.
+						if (this._tree.scrollTop === 0) {
 							this.refresh();
 							return;
 						}
 
-						if (changeSummary.refresh === 'ifScrollTop') {
-							// If the history item remote revision has changed, but it matches the history
-							// item revision, then it means that a Push operation was performed and it is
-							// safe to refresh the graph.
-							if (historyItemRefValue?.revision === historyItemRemoteRefRevisionValue) {
-								this.refresh();
-								return;
-							}
+						// Show the "Outdated" badge on the view
+						this._repositoryOutdated.set(true, undefined);
+						return;
+					}
 
-							// If the history item remote revision has changed, but it does not matches the
-							// history item revision, then a Fetch operation was performed. This can be the
-							// result of a user action (Fetch) or a background action (Auto Fetch). If the
-							// tree is scrolled to the top, we can safely refresh the tree.
-							if (this._tree.scrollTop === 0) {
-								this.refresh();
-								return;
-							}
-
-							// Show the "Outdated" badge on the view
-							this._repositoryOutdated.set(true, undefined);
-						}
-					}));
+					this.refresh();
+				}));
 
 				// HistoryItemRefs filter changed
 				store.add(runOnChange(this._treeViewModel.historyItemsFilter, () => {

--- a/src/vs/workbench/contrib/scm/common/history.ts
+++ b/src/vs/workbench/contrib/scm/common/history.ts
@@ -53,6 +53,7 @@ export interface ISCMHistoryItemRefsChangeEvent {
 	readonly added: readonly ISCMHistoryItemRef[];
 	readonly removed: readonly ISCMHistoryItemRef[];
 	readonly modified: readonly ISCMHistoryItemRef[];
+	readonly silent: boolean;
 }
 
 export interface ISCMHistoryItem {

--- a/src/vscode-dts/vscode.proposed.scmHistoryProvider.d.ts
+++ b/src/vscode-dts/vscode.proposed.scmHistoryProvider.d.ts
@@ -76,5 +76,13 @@ declare module 'vscode' {
 		readonly added: readonly SourceControlHistoryItemRef[];
 		readonly removed: readonly SourceControlHistoryItemRef[];
 		readonly modified: readonly SourceControlHistoryItemRef[];
+
+		/**
+		 * Flag to indicate if the operation that caused the event to trigger was due
+		 * to a user action or a background operation (ex: Auto Fetch). The flag is used
+		 * to determine whether to automatically refresh the user interface or present
+		 * the user with a visual cue that the user interface is outdated.
+		 */
+		readonly silent: boolean;
 	}
 }


### PR DESCRIPTION
* Add `silent` property so that API consumers can explicitly specify whether an action was performed in the background
* Graph refresh uses a new event to cover all change scenarios