### PR TITLE
Clear texture atlas and render strat when zooming

### DIFF
--- a/src/vs/editor/browser/gpu/fullFileRenderStrategy.ts
+++ b/src/vs/editor/browser/gpu/fullFileRenderStrategy.ts
@@ -76,9 +76,8 @@ export class FullFileRenderStrategy extends Disposable implements IGpuRenderStra
 		super();
 
 		// TODO: Detect when lines have been tokenized and clear _upToDateLines
-		const activeWindow = getActiveWindow();
 		const fontFamily = this._context.configuration.options.get(EditorOption.fontFamily);
-		const fontSize = Math.ceil(this._context.configuration.options.get(EditorOption.fontSize) * activeWindow.devicePixelRatio);
+		const fontSize = this._context.configuration.options.get(EditorOption.fontSize);
 
 		this._glyphRasterizer = this._register(new GlyphRasterizer(fontSize, fontFamily));
 
@@ -103,6 +102,17 @@ export class FullFileRenderStrategy extends Disposable implements IGpuRenderStra
 			new Float32Array(scrollOffsetBufferSize),
 			new Float32Array(scrollOffsetBufferSize),
 		];
+	}
+
+	reset() {
+		for (const bufferIndex of [0, 1]) {
+			// Zero out buffer and upload to GPU to prevent stale rows from rendering
+			const buffer = new Float32Array(this._cellValueBuffers[bufferIndex]);
+			buffer.fill(0, 0, buffer.length);
+			this._device.queue.writeBuffer(this._cellBindBuffer, 0, buffer.buffer, 0, buffer.byteLength);
+			this._upToDateLines[bufferIndex].clear();
+		}
+		this._visibleObjectCount = 0;
 	}
 
 	update(viewportData: ViewportData, viewLineOptions: ViewLineOptions): number {

--- a/src/vs/editor/browser/gpu/gpu.ts
+++ b/src/vs/editor/browser/gpu/gpu.ts
@@ -21,6 +21,10 @@ export interface IGpuRenderStrategy {
 	readonly wgsl: string;
 	readonly bindGroupEntries: GPUBindGroupEntry[];
 
+	/**
+	 * Resets the render strategy, clearing all data and setting up for a new frame.
+	 */
+	reset(): void;
 	update(viewportData: ViewportData, viewLineOptions: ViewLineOptions): number;
 	draw?(pass: GPURenderPassEncoder, viewportData: ViewportData): void;
 }

--- a/src/vs/editor/browser/gpu/viewGpuContext.ts
+++ b/src/vs/editor/browser/gpu/viewGpuContext.ts
@@ -3,10 +3,14 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { getActiveWindow } from '../../../base/browser/dom.js';
+import { addDisposableListener, getActiveWindow } from '../../../base/browser/dom.js';
 import { createFastDomNode, type FastDomNode } from '../../../base/browser/fastDomNode.js';
 import { Emitter } from '../../../base/common/event.js';
 import { Disposable } from '../../../base/common/lifecycle.js';
+import { observableValue, runOnChange, type IObservable } from '../../../base/common/observable.js';
+import { IInstantiationService } from '../../../platform/instantiation/common/instantiation.js';
+import { ViewLinesGpu } from '../viewParts/viewLinesGpu/viewLinesGpu.js';
+import { TextureAtlas } from './atlas/textureAtlas.js';
 import { GPULifecycle } from './gpuDisposable.js';
 import { ensureNonNullable, observeDevicePixelDimensions } from './gpuUtils.js';
 
@@ -19,7 +23,11 @@ export class ViewGpuContext extends Disposable {
 	private readonly _onDidChangeCanvasDevicePixelDimensions = this._register(new Emitter<{ width: number; height: number }>());
 	readonly onDidChangeCanvasDevicePixelDimensions = this._onDidChangeCanvasDevicePixelDimensions.event;
 
-	constructor() {
+	readonly devicePixelRatio: IObservable<number>;
+
+	constructor(
+		@IInstantiationService private readonly _instantiationService: IInstantiationService
+	) {
 		super();
 
 		this.canvas = createFastDomNode(document.createElement('canvas'));
@@ -28,6 +36,18 @@ export class ViewGpuContext extends Disposable {
 		this.ctx = ensureNonNullable(this.canvas.domNode.getContext('webgpu'));
 
 		this.device = GPULifecycle.requestDevice().then(ref => this._register(ref).object);
+		this.device.then(device => {
+			if (!ViewLinesGpu.atlas) {
+				ViewLinesGpu.atlas = this._instantiationService.createInstance(TextureAtlas, device.limits.maxTextureDimension2D, undefined);
+				runOnChange(this.devicePixelRatio, () => ViewLinesGpu.atlas.clear());
+			}
+		});
+
+		const dprObs = observableValue(this, getActiveWindow().devicePixelRatio);
+		this._register(addDisposableListener(getActiveWindow(), 'resize', () => {
+			dprObs.set(getActiveWindow().devicePixelRatio, undefined);
+		}));
+		this.devicePixelRatio = dprObs;
 
 		this._register(observeDevicePixelDimensions(this.canvas.domNode, getActiveWindow(), (width, height) => {
 			this.canvas.domNode.width = width;

--- a/src/vs/editor/browser/view.ts
+++ b/src/vs/editor/browser/view.ts
@@ -150,7 +150,7 @@ export class View extends ViewEventHandler {
 		this.domNode.setAttribute('role', 'code');
 
 		if (this._context.configuration.options.get(EditorOption.experimentalGpuAcceleration) === 'on') {
-			this._viewGpuContext = new ViewGpuContext();
+			this._viewGpuContext = this._instantiationService.createInstance(ViewGpuContext);
 		}
 
 		this._overflowGuardContainer = createFastDomNode(document.createElement('div'));

--- a/src/vs/editor/browser/viewParts/viewLinesGpu/viewLinesGpu.ts
+++ b/src/vs/editor/browser/viewParts/viewLinesGpu/viewLinesGpu.ts
@@ -70,6 +70,14 @@ export class ViewLinesGpu extends ViewPart {
 			// TODO: Request render, should this just call renderText with the last viewportData
 		}));
 
+		// Rerender when the texture atlas deletes glyphs
+		this._register(ViewLinesGpu.atlas.onDidDeleteGlyphs(() => {
+			this._atlasGpuTextureVersions.length = 0;
+			this._atlasGpuTextureVersions[0] = 0;
+			this._atlasGpuTextureVersions[1] = 0;
+			this._renderStrategy.reset();
+		}));
+
 		this.initWebgpu();
 	}
 


### PR DESCRIPTION
Fixes #227112

This corrects glyphs after zooming but only after a new render triggered by scrolling for example. To do it immediately without scroll is tracked in https://github.com/microsoft/vscode/issues/227102