### PR TITLE
extensions: wrap table cell content in paragraph element

### DIFF
--- a/src/vs/workbench/contrib/extensions/browser/extensionFeaturesTab.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionFeaturesTab.ts
@@ -470,7 +470,7 @@ class ExtensionFeatureView extends Disposable {
 						return $('tr', undefined,
 							...row.map(rowData => {
 								if (typeof rowData === 'string') {
-									return $('td', undefined, rowData);
+									return $('td', undefined, $('p', undefined, rowData));
 								}
 								const data = Array.isArray(rowData) ? rowData : [rowData];
 								return $('td', undefined, ...data.map(item => {


### PR DESCRIPTION
Fixes: https://github.com/microsoft/vscode/issues/225466

Wraps the string content of table cells in a `<p>` element for consistent styling and layout in the extension features tab.