### PR TITLE
keybindings - gather command labels from all menus

### DIFF
--- a/src/vs/platform/actions/common/actions.ts
+++ b/src/vs/platform/actions/common/actions.ts
@@ -367,7 +367,7 @@ export interface IMenuRegistry {
 	 */
 	appendMenuItems(items: Iterable<{ id: MenuId; item: IMenuItem | ISubmenuItem }>): IDisposable;
 	appendMenuItem(menu: MenuId, item: IMenuItem | ISubmenuItem): IDisposable;
-	getMenuItems(loc: MenuId): Array<IMenuItem | ISubmenuItem>;
+	getMenuItems(loc: MenuId | undefined): Array<IMenuItem | ISubmenuItem>;
 }
 
 export const MenuRegistry: IMenuRegistry = new class implements IMenuRegistry {
@@ -423,9 +423,14 @@ export const MenuRegistry: IMenuRegistry = new class implements IMenuRegistry {
 		return result;
 	}
 
-	getMenuItems(id: MenuId): Array<IMenuItem | ISubmenuItem> {
+	getMenuItems(id: MenuId | undefined): Array<IMenuItem | ISubmenuItem> {
 		let result: Array<IMenuItem | ISubmenuItem>;
-		if (this._menuItems.has(id)) {
+		if (id === undefined) {
+			result = [];
+			for (const items of this._menuItems.values()) {
+				result.push(...items);
+			}
+		} else if (this._menuItems.has(id)) {
 			result = [...this._menuItems.get(id)!];
 		} else {
 			result = [];

--- a/src/vs/workbench/contrib/chat/electron-sandbox/actions/voiceChatActions.ts
+++ b/src/vs/workbench/contrib/chat/electron-sandbox/actions/voiceChatActions.ts
@@ -1299,7 +1299,7 @@ abstract class BaseInstallSpeechProviderAction extends Action2 {
 
 export class InstallSpeechProviderForVoiceChatAction extends BaseInstallSpeechProviderAction {
 
-	static readonly ID = 'workbench.action.chat.installProviderForVoiceChat';
+	static readonly ID = '_workbench.action.chat.installProviderForVoiceChat';
 
 	constructor() {
 		super({
@@ -1328,7 +1328,7 @@ export class InstallSpeechProviderForVoiceChatAction extends BaseInstallSpeechPr
 
 export class InstallSpeechProviderForSynthesizeChatAction extends BaseInstallSpeechProviderAction {
 
-	static readonly ID = 'workbench.action.chat.installProviderForSynthesis';
+	static readonly ID = '_workbench.action.chat.installProviderForSynthesis';
 
 	constructor() {
 		super({

--- a/src/vs/workbench/contrib/preferences/browser/keybindingsEditor.ts
+++ b/src/vs/workbench/contrib/preferences/browser/keybindingsEditor.ts
@@ -38,7 +38,7 @@ import { INotificationService } from '../../../../platform/notification/common/n
 import { CancellationToken } from '../../../../base/common/cancellation.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
 import { Emitter, Event } from '../../../../base/common/event.js';
-import { MenuRegistry, MenuId, isIMenuItem } from '../../../../platform/actions/common/actions.js';
+import { MenuRegistry, isIMenuItem } from '../../../../platform/actions/common/actions.js';
 import { IListAccessibilityProvider } from '../../../../base/browser/ui/list/listWidget.js';
 import { WORKBENCH_BACKGROUND } from '../../../common/theme.js';
 import { IKeybindingItemEntry, IKeybindingsEditorPane } from '../../../services/preferences/common/preferences.js';
@@ -563,7 +563,7 @@ export class KeybindingsEditor extends EditorPane implements IKeybindingsEditorP
 		for (const editorAction of EditorExtensionsRegistry.getEditorActions()) {
 			actionsLabels.set(editorAction.id, editorAction.label);
 		}
-		for (const menuItem of MenuRegistry.getMenuItems(MenuId.CommandPalette)) {
+		for (const menuItem of MenuRegistry.getMenuItems(undefined /* all menus */)) {
 			if (isIMenuItem(menuItem)) {
 				const title = typeof menuItem.command.title === 'string' ? menuItem.command.title : menuItem.command.title.value;
 				const category = menuItem.command.category ? typeof menuItem.command.category === 'string' ? menuItem.command.category : menuItem.command.category.value : undefined;


### PR DESCRIPTION
Previously we would only have a human readable label if an action was contributed to the command palette, which was not the case for "Read Aloud":

![image](https://github.com/user-attachments/assets/ac454b21-a8eb-4f5e-9c72-ae586489ce27)

With this fix, we gather labels from all menus and it looks like that:

![image](https://github.com/user-attachments/assets/1fdc867b-4d1c-424c-82d2-9a46c82fd7bc)

One thing I did not fully understand is, that a fourth entry now appeared:

![image](https://github.com/user-attachments/assets/d3a85722-90cb-444e-986f-f2e7ebda8719)

Which maps to `workbench.action.chat.installProviderForSynthesis`. 

I think it makes sense that it shows up, as its an action that is contributed to a menu, but I am not sure why the raw command was not appearing previously 🤔 

What helped (and I think also makes sense) was to change the commands for installing to be prefixed with a leading `_`:

https://github.com/microsoft/vscode/pull/228372/files#diff-3fd6fda06fcf4ddc95190c5bd20dfff5058b91c68c8ab09ed5a97c2d90b60db8