### PR TITLE
Fix positioning of DND overlay in inline chat widget

### DIFF
--- a/src/vs/workbench/contrib/inlineChat/browser/media/inlineChat.css
+++ b/src/vs/workbench/contrib/inlineChat/browser/media/inlineChat.css
@@ -18,6 +18,7 @@
 	box-shadow: 0 2px 4px 0 var(--vscode-widget-shadow);
 	background: var(--vscode-inlineChat-background);
 	padding-top: 3px;
+	position: relative;
 }
 
 .monaco-workbench .inline-chat .chat-widget .interactive-session .interactive-input-part {


### PR DESCRIPTION
The DND overlay in the inline chat widget was previously positioned incorrectly. This pull request fixes the positioning by making it relative to the inline chat widget instead of the view zone.