### PR TITLE
SCM Graph - maintain history item filter references state when view is collapsed/expanded

### DIFF
--- a/src/vs/workbench/contrib/scm/browser/scmHistoryViewPane.ts
+++ b/src/vs/workbench/contrib/scm/browser/scmHistoryViewPane.ts
@@ -1090,15 +1090,17 @@ export class SCMHistoryViewPane extends ViewPane {
 
 		this._createTree(this._treeContainer);
 
+		this._treeViewModel = this.instantiationService.createInstance(SCMHistoryViewModel);
+		this._register(this._treeViewModel);
+
 		this.onDidChangeBodyVisibility(async visible => {
 			if (!visible) {
 				this._visibilityDisposables.clear();
 				return;
 			}
 
-			// Create view model
-			this._treeViewModel = this.instantiationService.createInstance(SCMHistoryViewModel);
-			this._visibilityDisposables.add(this._treeViewModel);
+			// Clear repository state
+			this._treeViewModel.clearRepositoryState();
 
 			// Initial rendering
 			await this._progressService.withProgress({ location: this.id }, async () => {


### PR DESCRIPTION
Related #228440