### PR TITLE
Edit Context: reverting the long-press E fix to fix copy-paste

### DIFF
--- a/src/vs/editor/browser/controller/editContext/native/nativeEditContext.ts
+++ b/src/vs/editor/browser/controller/editContext/native/nativeEditContext.ts
@@ -97,10 +97,6 @@ export class NativeEditContext extends AbstractEditContext {
 				this._compositionRangeWithinEditor = newCompositionRangeWithinEditor;
 			}
 			this._emitTypeEvent(viewController, e);
-
-			// TODO @aiday-mar calling write screen reader content so that the document selection is immediately set
-			// remove the following when electron will be upgraded
-			this._screenReaderSupport.writeScreenReaderContent();
 		}));
 		this._register(editContextAddDisposableListener(this._editContext, 'compositionstart', (e) => {
 			const position = this._context.viewModel.getPrimaryCursorState().modelState.position;

--- a/src/vs/editor/browser/controller/editContext/native/screenReaderSupport.ts
+++ b/src/vs/editor/browser/controller/editContext/native/screenReaderSupport.ts
@@ -116,13 +116,9 @@ export class ScreenReaderSupport {
 	}
 
 	private _getScreenReaderContentState(): ScreenReaderContentState | undefined {
-		// Make the screen reader content always be visible because of the bug and also set the selection
-
-		// TODO @aiday-mar Ultimately uncomment this code when Electron will be upgraded
-		// if (this._accessibilitySupport === AccessibilitySupport.Disabled) {
-		// 	return;
-		// }
-		const accessibilityPageSize = this._accessibilitySupport === AccessibilitySupport.Disabled ? 1 : this._accessibilityPageSize;
+		if (this._accessibilitySupport === AccessibilitySupport.Disabled) {
+			return;
+		}
 		const simpleModel: ISimpleModel = {
 			getLineCount: (): number => {
 				return this._context.viewModel.getLineCount();
@@ -140,7 +136,7 @@ export class ScreenReaderSupport {
 				return this._context.viewModel.modifyPosition(position, offset);
 			}
 		};
-		return PagedScreenReaderStrategy.fromEditorSelection(simpleModel, this._primarySelection, accessibilityPageSize, this._accessibilitySupport === AccessibilitySupport.Unknown);
+		return PagedScreenReaderStrategy.fromEditorSelection(simpleModel, this._primarySelection, this._accessibilityPageSize, this._accessibilitySupport === AccessibilitySupport.Unknown);
 	}
 
 	private _setSelectionOfScreenReaderContent(selectionOffsetStart: number, selectionOffsetEnd: number): void {


### PR DESCRIPTION
Edit Context: reverting the long-press E fix to fix copy-paste

Please see https://github.com/microsoft/vscode/issues/227791 for more details

fixes https://github.com/microsoft/vscode/issues/227791