### PR TITLE
Explicitly blurring the dom node so the edit context events are not fired anymore

### DIFF
--- a/src/vs/base/browser/ui/inputbox/inputBox.ts
+++ b/src/vs/base/browser/ui/inputbox/inputBox.ts
@@ -299,6 +299,7 @@ export class InputBox extends Widget {
 	}
 
 	public select(range: IRange | null = null): void {
+		console.log('select');
 		this.input.select();
 
 		if (range) {

--- a/src/vs/base/browser/ui/splitview/paneview.ts
+++ b/src/vs/base/browser/ui/splitview/paneview.ts
@@ -238,6 +238,8 @@ export abstract class Pane extends Disposable implements IView {
 	}
 
 	render(): void {
+		console.log('render of Pane');
+
 		this.element.classList.toggle('expanded', this.isExpanded());
 		this.element.classList.toggle('horizontal', this.orientation === Orientation.HORIZONTAL);
 		this.element.classList.toggle('vertical', this.orientation === Orientation.VERTICAL);

--- a/src/vs/editor/browser/controller/editContext/native/nativeEditContext.ts
+++ b/src/vs/editor/browser/controller/editContext/native/nativeEditContext.ts
@@ -56,7 +56,14 @@ export class NativeEditContext extends AbstractEditContext {
 		this.domNode.setClassName(`native-edit-context`);
 		this._updateDomAttributes();
 
-		this._focusTracker = this._register(new FocusTracker(this.domNode.domNode, (newFocusValue: boolean) => this._context.viewModel.setHasFocus(newFocusValue)));
+		this._focusTracker = this._register(new FocusTracker(this.domNode.domNode, (newFocusValue: boolean) => {
+			this._context.viewModel.setHasFocus(newFocusValue);
+			// Added in order to not have the edit context fire when not focused
+			if (!newFocusValue) {
+				this.domNode.domNode.focus();
+				this.domNode.domNode.blur();
+			}
+		}));
 
 		this._editContext = new EditContext();
 		this.domNode.domNode.editContext = this._editContext;
@@ -97,10 +104,6 @@ export class NativeEditContext extends AbstractEditContext {
 				this._compositionRangeWithinEditor = newCompositionRangeWithinEditor;
 			}
 			this._emitTypeEvent(viewController, e);
-
-			// TODO @aiday-mar calling write screen reader content so that the document selection is immediately set
-			// remove the following when electron will be upgraded
-			this._screenReaderSupport.writeScreenReaderContent();
 		}));
 		this._register(editContextAddDisposableListener(this._editContext, 'compositionstart', (e) => {
 			const position = this._context.viewModel.getPrimaryCursorState().modelState.position;

--- a/src/vs/editor/browser/controller/editContext/native/nativeEditContext.ts
+++ b/src/vs/editor/browser/controller/editContext/native/nativeEditContext.ts
@@ -57,16 +57,15 @@ export class NativeEditContext extends AbstractEditContext {
 		this._updateDomAttributes();
 
 		this._focusTracker = this._register(new FocusTracker(this.domNode.domNode, (newFocusValue: boolean) => {
-			console.log('inside of focus tracker handker');
+			console.log('inside of focus tracker handler');
 			console.log('document.activeElement : ', getActiveElement());
 			console.log('this._editContext : ', this._editContext);
-
 			console.log('newFocusValue : ', newFocusValue);
-			// how to explicitly blur instead of letting dom blur it
-			// find where the new dom node is created and explicitly blur it
+
 			this._context.viewModel.setHasFocus(newFocusValue);
 
-			// look at the code executed with and without this, there seems to be a differecne
+			console.log('this._editContext.attachedElements : ', this._editContext.attachedElements());
+			// look at the code executed with and without this, there seems to be a difference?
 			// if (!newFocusValue) {
 			// 	this.domNode.domNode.focus();
 			// 	this.domNode.domNode.blur();
@@ -107,6 +106,12 @@ export class NativeEditContext extends AbstractEditContext {
 		this._register(editContextAddDisposableListener(this._editContext, 'textupdate', (e) => {
 			console.log('text update event e : ', e);
 			console.log('document.activeElement : ', getActiveElement());
+			console.log('this.domNode.domNode : ', this.domNode.domNode);
+			const activeElement = getActiveElement();
+			if (activeElement !== this.domNode.domNode) {
+				this.domNode.domNode.blur();
+				return;
+			}
 			const compositionRangeWithinEditor = this._compositionRangeWithinEditor;
 			if (compositionRangeWithinEditor) {
 				const position = this._context.viewModel.getPrimaryCursorState().modelState.position;
@@ -138,6 +143,7 @@ export class NativeEditContext extends AbstractEditContext {
 	// --- Public methods ---
 
 	public override dispose(): void {
+		console.log('dispose of NativeEditContext');
 		this.domNode.domNode.blur();
 		this.domNode.domNode.remove();
 		super.dispose();

--- a/src/vs/editor/browser/controller/editContext/native/nativeEditContextUtils.ts
+++ b/src/vs/editor/browser/controller/editContext/native/nativeEditContextUtils.ts
@@ -43,6 +43,13 @@ export class FocusTracker extends Disposable {
 	get isFocused(): boolean {
 		return this._isFocused;
 	}
+
+	override dispose(): void {
+		// Need to explicitly blur the edit dom node, so that the edit context no longer relies on its events
+		this._domNode.blur();
+		this._handleFocusedChanged(false);
+		super.dispose();
+	}
 }
 
 export function editContextAddDisposableListener<K extends keyof EditContextEventHandlersEventMap>(target: EventTarget, type: K, listener: (this: GlobalEventHandlers, ev: EditContextEventHandlersEventMap[K]) => any, options?: boolean | AddEventListenerOptions): IDisposable {

--- a/src/vs/editor/browser/controller/editContext/native/nativeEditContextUtils.ts
+++ b/src/vs/editor/browser/controller/editContext/native/nativeEditContextUtils.ts
@@ -15,22 +15,29 @@ export interface ITypeData {
 
 export class FocusTracker extends Disposable {
 	private _isFocused: boolean = false;
-	private _shouldHandleFocus: boolean = true;
 
 	constructor(
 		private readonly _domNode: HTMLElement,
 		private readonly _onFocusChange: (newFocusValue: boolean) => void,
 	) {
 		super();
-		this._register(addDisposableListener(this._domNode, 'focus', () => this._handleFocusedChanged(true)));
-		this._register(addDisposableListener(this._domNode, 'blur', () => this._handleFocusedChanged(false)));
+		this._register(addDisposableListener(this._domNode, 'focus', () => {
+			console.log('on focus of FocusTracker');
+			this._handleFocusedChanged(true);
+		}));
+		this._register(addDisposableListener(this._domNode, 'blur', () => {
+			console.log('on blur of FocusTracker');
+			this._handleFocusedChanged(false);
+		}));
 	}
 
 	private _handleFocusedChanged(focused: boolean): void {
 		console.log('_handleFocusedChanges, focused : ', focused);
-		if (this._isFocused === focused || !this._shouldHandleFocus) {
+		console.log('document.activeElement : ', getActiveElement());
+		if (this._isFocused === focused) {
 			return;
 		}
+		console.log('after early return');
 		this._isFocused = focused;
 		this._onFocusChange(this._isFocused);
 	}
@@ -44,29 +51,14 @@ export class FocusTracker extends Disposable {
 	}
 
 	public refreshFocusState(): void {
-		console.log('refresh focus state of focus tracker');
+		console.log('refreshFocusState of FocusTracker');
 		const isFocused = getActiveElement() === this._domNode;
 		console.log('isFocused : ', isFocused);
-
-		if (!isFocused) {
-			console.log('before focus then blur 1');
-			this._domNode.focus();
-			this._domNode.blur();
-		}
 		this._handleFocusedChanged(isFocused);
-		if (!isFocused) {
-			console.log('before focus then blur 2');
-			this._domNode.focus();
-			this._domNode.blur();
-		}
 	}
 
 	get isFocused(): boolean {
 		return this._isFocused;
-	}
-
-	override dispose(): void {
-		super.dispose();
 	}
 }
 

--- a/src/vs/editor/browser/controller/editContext/native/screenReaderSupport.ts
+++ b/src/vs/editor/browser/controller/editContext/native/screenReaderSupport.ts
@@ -116,13 +116,9 @@ export class ScreenReaderSupport {
 	}
 
 	private _getScreenReaderContentState(): ScreenReaderContentState | undefined {
-		// Make the screen reader content always be visible because of the bug and also set the selection
-
-		// TODO @aiday-mar Ultimately uncomment this code when Electron will be upgraded
-		// if (this._accessibilitySupport === AccessibilitySupport.Disabled) {
-		// 	return;
-		// }
-		const accessibilityPageSize = this._accessibilitySupport === AccessibilitySupport.Disabled ? 1 : this._accessibilityPageSize;
+		if (this._accessibilitySupport === AccessibilitySupport.Disabled) {
+			return;
+		}
 		const simpleModel: ISimpleModel = {
 			getLineCount: (): number => {
 				return this._context.viewModel.getLineCount();
@@ -140,7 +136,7 @@ export class ScreenReaderSupport {
 				return this._context.viewModel.modifyPosition(position, offset);
 			}
 		};
-		return PagedScreenReaderStrategy.fromEditorSelection(simpleModel, this._primarySelection, accessibilityPageSize, this._accessibilitySupport === AccessibilitySupport.Unknown);
+		return PagedScreenReaderStrategy.fromEditorSelection(simpleModel, this._primarySelection, this._accessibilityPageSize, this._accessibilitySupport === AccessibilitySupport.Unknown);
 	}
 
 	private _setSelectionOfScreenReaderContent(selectionOffsetStart: number, selectionOffsetEnd: number): void {

--- a/src/vs/editor/browser/controller/editContext/textArea/textAreaEditContext.ts
+++ b/src/vs/editor/browser/controller/editContext/textArea/textAreaEditContext.ts
@@ -449,10 +449,12 @@ export class TextAreaEditContext extends AbstractEditContext {
 		}));
 
 		this._register(this._textAreaInput.onFocus(() => {
+			console.log('onFocus of TextAreaEditContext');
 			this._context.viewModel.setHasFocus(true);
 		}));
 
 		this._register(this._textAreaInput.onBlur(() => {
+			console.log('onBlur of TextAreaEditContext');
 			this._context.viewModel.setHasFocus(false);
 		}));
 

--- a/src/vs/editor/browser/controller/editContext/textArea/textAreaEditContextInput.ts
+++ b/src/vs/editor/browser/controller/editContext/textArea/textAreaEditContextInput.ts
@@ -388,6 +388,7 @@ export class TextAreaInput extends Disposable {
 		}));
 
 		this._register(this._textArea.onFocus(() => {
+			console.log('onFocus of TextAreaWrapper');
 			const hadFocus = this._hasFocus;
 
 			this._setHasFocus(true);
@@ -416,6 +417,7 @@ export class TextAreaInput extends Disposable {
 				// Fire artificial composition end
 				this._onCompositionEnd.fire();
 			}
+			console.log('onBlur of TextAreaWrapper');
 			this._setHasFocus(false);
 		}));
 		this._register(this._textArea.onSyntheticTap(() => {
@@ -534,6 +536,7 @@ export class TextAreaInput extends Disposable {
 	}
 
 	public focusTextArea(): void {
+		console.log('focusTextArea');
 		// Setting this._hasFocus and writing the screen reader content
 		// will result in a focus() and setSelectionRange() in the textarea
 		this._setHasFocus(true);
@@ -547,10 +550,12 @@ export class TextAreaInput extends Disposable {
 	}
 
 	public refreshFocusState(): void {
+		console.log('refreshFocusState');
 		this._setHasFocus(this._textArea.hasFocus());
 	}
 
 	private _setHasFocus(newHasFocus: boolean): void {
+		console.log('_setHasFocus, newHasFocus : ', newHasFocus);
 		if (this._hasFocus === newHasFocus) {
 			// no change
 			return;
@@ -566,6 +571,7 @@ export class TextAreaInput extends Disposable {
 		}
 
 		if (this._hasFocus) {
+			console.log('write this._hasFocus');
 			this.writeNativeTextAreaContent('focusgain');
 		}
 

--- a/src/vs/editor/browser/view.ts
+++ b/src/vs/editor/browser/view.ts
@@ -434,6 +434,7 @@ export class View extends ViewEventHandler {
 		this._context.removeEventHandler(this);
 		this._viewGpuContext?.dispose();
 
+		this._editContext.dispose();
 		this._viewLines.dispose();
 		this._viewLinesGpu?.dispose();
 

--- a/src/vs/editor/browser/view.ts
+++ b/src/vs/editor/browser/view.ts
@@ -120,6 +120,7 @@ export class View extends ViewEventHandler {
 		@IInstantiationService private readonly _instantiationService: IInstantiationService
 	) {
 		super();
+		console.log('view constructor');
 		this._selections = [new Selection(1, 1, 1, 1)];
 		this._renderAnimationFrame = null;
 

--- a/src/vs/editor/browser/widget/codeEditor/codeEditorWidget.ts
+++ b/src/vs/editor/browser/widget/codeEditor/codeEditorWidget.ts
@@ -472,6 +472,7 @@ export class CodeEditorWidget extends Disposable implements editorBrowser.ICodeE
 	}
 
 	public setModel(_model: ITextModel | editorCommon.IDiffEditorModel | editorCommon.IDiffEditorViewModel | null = null): void {
+		console.log('setModel');
 		try {
 			this._beginUpdate();
 			const model = <ITextModel | null>_model;
@@ -1019,6 +1020,7 @@ export class CodeEditorWidget extends Disposable implements editorBrowser.ICodeE
 	}
 
 	public onHide(): void {
+		console.log('on hide of code editor widget');
 		this._modelData?.view.refreshFocusState();
 		this._focusTracker.refreshState();
 	}
@@ -1419,6 +1421,7 @@ export class CodeEditorWidget extends Disposable implements editorBrowser.ICodeE
 	}
 
 	public focus(): void {
+		console.log('focus of code editor widget');
 		if (!this._modelData || !this._modelData.hasRealView) {
 			return;
 		}
@@ -1593,6 +1596,7 @@ export class CodeEditorWidget extends Disposable implements editorBrowser.ICodeE
 	}
 
 	public render(forceRedraw: boolean = false): void {
+		console.log('render');
 		if (!this._modelData || !this._modelData.hasRealView) {
 			return;
 		}
@@ -1757,6 +1761,7 @@ export class CodeEditorWidget extends Disposable implements editorBrowser.ICodeE
 		}));
 
 		const [view, hasRealView] = this._createView(viewModel);
+		console.log('inside of _createView');
 		if (hasRealView) {
 			this._domElement.appendChild(view.domNode.domNode);
 
@@ -1872,6 +1877,7 @@ export class CodeEditorWidget extends Disposable implements editorBrowser.ICodeE
 	}
 
 	private _detachModel(): ITextModel | null {
+		console.log('_detachModel');
 		this._contributionsDisposable?.dispose();
 		this._contributionsDisposable = undefined;
 		if (!this._modelData) {

--- a/src/vs/workbench/browser/parts/editor/editorPane.ts
+++ b/src/vs/workbench/browser/parts/editor/editorPane.ts
@@ -159,7 +159,6 @@ export abstract class EditorPane extends Composite implements IEditorPane {
 	 * @param visible the state of visibility of this editor
 	 */
 	protected setEditorVisible(visible: boolean): void {
-		// do
 		// Subclasses can implement
 	}
 

--- a/src/vs/workbench/browser/parts/editor/editorPane.ts
+++ b/src/vs/workbench/browser/parts/editor/editorPane.ts
@@ -159,6 +159,7 @@ export abstract class EditorPane extends Composite implements IEditorPane {
 	 * @param visible the state of visibility of this editor
 	 */
 	protected setEditorVisible(visible: boolean): void {
+		// do
 		// Subclasses can implement
 	}
 

--- a/src/vs/workbench/browser/parts/editor/editorPanes.ts
+++ b/src/vs/workbench/browser/parts/editor/editorPanes.ts
@@ -305,6 +305,7 @@ export class EditorPanes extends Disposable {
 	}
 
 	private getEditorPaneDescriptor(editor: EditorInput): IEditorPaneDescriptor {
+		console.log('getEditorPaneDescriptor');
 		if (editor.hasCapability(EditorInputCapabilities.RequiresTrust) && !this.workspaceTrustService.isWorkspaceTrusted()) {
 			// Workspace trust: if an editor signals it needs workspace trust
 			// but the current workspace is untrusted, we fallback to a generic
@@ -317,6 +318,7 @@ export class EditorPanes extends Disposable {
 	}
 
 	private doShowEditorPane(descriptor: IEditorPaneDescriptor): EditorPane {
+		console.log('doShowEditorPane');
 
 		// Return early if the currently active editor pane can handle the input
 		if (this._activeEditorPane && descriptor.describes(this._activeEditorPane)) {
@@ -487,6 +489,7 @@ export class EditorPanes extends Disposable {
 		// Remove editor pane from parent
 		const editorPaneContainer = this._activeEditorPane.getContainer();
 		if (editorPaneContainer) {
+			// before removing active editor pane
 			editorPaneContainer.remove();
 			hide(editorPaneContainer);
 		}

--- a/src/vs/workbench/contrib/preferences/browser/keybindingsEditor.ts
+++ b/src/vs/workbench/contrib/preferences/browser/keybindingsEditor.ts
@@ -163,7 +163,6 @@ export class KeybindingsEditor extends EditorPane implements IKeybindingsEditorP
 
 	protected createEditor(parent: HTMLElement): void {
 		console.log('inside of createEditor of KeybindingsEditor');
-
 		const keybindingsEditorElement = DOM.append(parent, $('div', { class: 'keybindings-editor' }));
 
 		this.createAriaLabelElement(keybindingsEditorElement);
@@ -198,10 +197,10 @@ export class KeybindingsEditor extends EditorPane implements IKeybindingsEditorP
 
 	override focus(): void {
 		console.log('focus of KeybindingEditor');
-
 		super.focus();
 
 		const activeKeybindingEntry = this.activeKeybindingEntry;
+		console.log('activeKeybindingEntry');
 		if (activeKeybindingEntry) {
 			this.selectEntry(activeKeybindingEntry);
 		} else if (!isIOS) {

--- a/src/vs/workbench/contrib/preferences/browser/keybindingsEditor.ts
+++ b/src/vs/workbench/contrib/preferences/browser/keybindingsEditor.ts
@@ -162,6 +162,8 @@ export class KeybindingsEditor extends EditorPane implements IKeybindingsEditorP
 	}
 
 	protected createEditor(parent: HTMLElement): void {
+		console.log('inside of createEditor of KeybindingsEditor');
+
 		const keybindingsEditorElement = DOM.append(parent, $('div', { class: 'keybindings-editor' }));
 
 		this.createAriaLabelElement(keybindingsEditorElement);
@@ -195,6 +197,8 @@ export class KeybindingsEditor extends EditorPane implements IKeybindingsEditorP
 	}
 
 	override focus(): void {
+		console.log('focus of KeybindingEditor');
+
 		super.focus();
 
 		const activeKeybindingEntry = this.activeKeybindingEntry;

--- a/src/vs/workbench/contrib/preferences/browser/preferencesWidgets.ts
+++ b/src/vs/workbench/contrib/preferences/browser/preferencesWidgets.ts
@@ -467,7 +467,11 @@ export class SearchWidget extends Widget {
 	}
 
 	focus() {
+		console.log('focus of search widget');
 		this.inputBox.focus();
+		const selection = DOM.getActiveDocument().getSelection();
+		console.log('selection : ', selection);
+
 		if (this.getValue()) {
 			this.inputBox.select();
 		}

--- a/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
@@ -249,6 +249,7 @@ export class SettingsEditor2 extends EditorPane {
 		@IEditorProgressService private readonly editorProgressService: IEditorProgressService,
 		@IUserDataProfileService userDataProfileService: IUserDataProfileService,
 	) {
+		console.log('settingseditor2 constructor');
 		super(SettingsEditor2.ID, group, telemetryService, themeService, storageService);
 		this.delayedFilterLogging = new Delayer<void>(1000);
 		this.searchDelayer = new Delayer(300);
@@ -509,6 +510,7 @@ export class SettingsEditor2 extends EditorPane {
 	}
 
 	override focus(): void {
+		console.log('focus of settings editor 2');
 		super.focus();
 
 		if (this._currentFocusContext === SettingsFocusContext.Search) {


### PR DESCRIPTION
fixes https://github.com/microsoft/vscode/issues/228104

Explicitly blurring the dom node so the edit context events are not fired anymore

⚠️ This is a temporary fix, as the bug is caused by Chromium, but this will be added in the meantime.