### PR TITLE
re-organize Search Model for new AI results branch of workbench tree

### DIFF
--- a/src/vs/workbench/contrib/search/browser/media/searchview.css
+++ b/src/vs/workbench/contrib/search/browser/media/searchview.css
@@ -186,6 +186,7 @@
 	color: var(--vscode-textLink-activeForeground);
 }
 
+.search-view .textsearchresult,
 .search-view .foldermatch,
 .search-view .filematch {
 	display: flex;

--- a/src/vs/workbench/contrib/search/browser/media/searchview.css
+++ b/src/vs/workbench/contrib/search/browser/media/searchview.css
@@ -186,7 +186,6 @@
 	color: var(--vscode-textLink-activeForeground);
 }
 
-.search-view .textsearchresult,
 .search-view .foldermatch,
 .search-view .filematch {
 	display: flex;

--- a/src/vs/workbench/contrib/search/browser/searchModel.ts
+++ b/src/vs/workbench/contrib/search/browser/searchModel.ts
@@ -1914,6 +1914,12 @@ export class SearchResult extends Disposable {
 		@INotebookEditorService private readonly notebookEditorService: INotebookEditorService,
 	) {
 		super();
+		this._plainTextSearchResult = this._register(this.instantiationService.createInstance(ReplaceableTextSearchResult, true, this, PLAIN_TEXT_SEARCH__RESULT_ID));
+		this._aiTextSearchResult = this._register(this.instantiationService.createInstance(TextSearchResult, true, this, AI_TEXT_SEARCH_RESULT_ID));
+
+		this._register(this._plainTextSearchResult.onChange((e) => this._onChange.fire(e)));
+		this._register(this._aiTextSearchResult.onChange((e) => this._onChange.fire(e)));
+
 		this.modelService.getModels().forEach(model => this.onModelAdded(model));
 		this._register(this.modelService.onModelAdded(model => this.onModelAdded(model)));
 
@@ -1923,10 +1929,6 @@ export class SearchResult extends Disposable {
 			}
 		}));
 
-		this._plainTextSearchResult = this._register(this.instantiationService.createInstance(ReplaceableTextSearchResult, true, this, PLAIN_TEXT_SEARCH__RESULT_ID));
-		this._aiTextSearchResult = this._register(this.instantiationService.createInstance(TextSearchResult, true, this, AI_TEXT_SEARCH_RESULT_ID));
-		this._register(this._plainTextSearchResult.onChange((e) => this._onChange.fire(e)));
-		this._register(this._aiTextSearchResult.onChange((e) => this._onChange.fire(e)));
 	}
 
 	get plainTextSearchResult(): ReplaceableTextSearchResult {

--- a/src/vs/workbench/contrib/search/browser/searchModel.ts
+++ b/src/vs/workbench/contrib/search/browser/searchModel.ts
@@ -1919,7 +1919,7 @@ export class SearchResult extends Disposable {
 			}
 		}));
 
-		this._plainTextSearchResult = this._register(this.instantiationService.createInstance(TextSearchResult, true, this, PLAIN_TEXT_SEARCH__RESULT_ID));
+		this._plainTextSearchResult = this._register(this.instantiationService.createInstance(ReplaceableTextSearchResult, true, this, PLAIN_TEXT_SEARCH__RESULT_ID));
 		this._aiTextSearchResult = this._register(this.instantiationService.createInstance(TextSearchResult, true, this, AI_TEXT_SEARCH_RESULT_ID));
 		this._register(this._plainTextSearchResult.onChange((e) => this._onChange.fire(e)));
 		this._register(this._aiTextSearchResult.onChange((e) => this._onChange.fire(e)));
@@ -2123,6 +2123,8 @@ export class SearchResult extends Disposable {
 	}
 
 	override async dispose(): Promise<void> {
+		this._aiTextSearchResult?.dispose();
+		this._plainTextSearchResult?.dispose();
 		this._onWillChangeModelListener?.dispose();
 		this._onDidChangeModelListener?.dispose();
 		super.dispose();

--- a/src/vs/workbench/contrib/search/browser/searchModel.ts
+++ b/src/vs/workbench/contrib/search/browser/searchModel.ts
@@ -2010,9 +2010,13 @@ export class SearchResult extends Disposable {
 		);
 	}
 
-	folderMatches(): FolderMatch[] {
-		return [...this._plainTextSearchResult.folderMatches(), ...this._aiTextSearchResult.folderMatches()];
+	folderMatches(ai: boolean = false): FolderMatch[] {
+		if (ai) {
+			return this._aiTextSearchResult.folderMatches();
+		}
+		return this._plainTextSearchResult.folderMatches();
 	}
+
 	private onModelAdded(model: ITextModel): void {
 		const folderMatch = this._plainTextSearchResult.findFolderSubstr(model.uri);
 		folderMatch?.bindModel(model);

--- a/src/vs/workbench/contrib/search/browser/searchModel.ts
+++ b/src/vs/workbench/contrib/search/browser/searchModel.ts
@@ -1488,6 +1488,10 @@ export class TextSearchResult extends Disposable {
 			}
 		}));
 	}
+
+	get isAIContributed() {
+		return this.id() === AI_TEXT_SEARCH_RESULT_ID;
+	}
 	id() {
 		return this._id;
 	}
@@ -1511,7 +1515,7 @@ export class TextSearchResult extends Disposable {
 	add(allRaw: IFileMatch[], searchInstanceID: string, ai: boolean, silent: boolean = false): void {
 		// Split up raw into a list per folder so we can do a batch add per folder.
 
-		const { byFolder, other } = this.groupFilesByFolder(allRaw, ai);
+		const { byFolder, other } = this.groupFilesByFolder(allRaw);
 		byFolder.forEach(raw => {
 			if (!raw.length) {
 				return;
@@ -1519,7 +1523,7 @@ export class TextSearchResult extends Disposable {
 
 			// ai results go into the respective folder
 			const folderMatch = this.getFolderMatch(raw[0].resource);
-			folderMatch?.addFileMatch(raw, silent, searchInstanceID, ai);
+			folderMatch?.addFileMatch(raw, silent, searchInstanceID, this.isAIContributed);
 		});
 
 		if (!ai) {
@@ -1541,7 +1545,7 @@ export class TextSearchResult extends Disposable {
 
 		const fileMatches: FileMatch[] = matches.filter(m => m instanceof FileMatch) as FileMatch[];
 
-		const { byFolder, other } = this.groupFilesByFolder(fileMatches, ai);
+		const { byFolder, other } = this.groupFilesByFolder(fileMatches);
 		byFolder.forEach(matches => {
 			if (!matches.length) {
 				return;
@@ -1555,7 +1559,7 @@ export class TextSearchResult extends Disposable {
 		}
 	}
 
-	groupFilesByFolder(fileMatches: IFileMatch[], ai: boolean): { byFolder: ResourceMap<IFileMatch[]>; other: IFileMatch[] } {
+	groupFilesByFolder(fileMatches: IFileMatch[]): { byFolder: ResourceMap<IFileMatch[]>; other: IFileMatch[] } {
 		const rawPerFolder = new ResourceMap<IFileMatch[]>();
 		const otherFileMatches: IFileMatch[] = [];
 		this._folderMatches.forEach(fm => rawPerFolder.set(fm.resource, []));

--- a/src/vs/workbench/contrib/search/browser/searchModel.ts
+++ b/src/vs/workbench/contrib/search/browser/searchModel.ts
@@ -950,7 +950,7 @@ export class FolderMatch extends Disposable {
 		private _id: string,
 		protected _index: number,
 		protected _query: ITextQuery,
-		private _parent: SearchResult | FolderMatch,
+		private _parent: TextSearchResult | FolderMatch,
 		private _searchResult: SearchResult,
 		private _closestRoot: FolderMatchWorkspaceRoot | null,
 		@IReplaceService private readonly replaceService: IReplaceService,
@@ -999,7 +999,7 @@ export class FolderMatch extends Disposable {
 		return this._name.value;
 	}
 
-	parent(): SearchResult | FolderMatch {
+	parent(): TextSearchResult | FolderMatch {
 		return this._parent;
 	}
 
@@ -1213,7 +1213,7 @@ export class FolderMatch extends Disposable {
 
 	private isInParentChain(folderMatch: FolderMatchWithResource) {
 
-		let matchItem: FolderMatch | SearchResult = this;
+		let matchItem: FolderMatch | TextSearchResult = this;
 		while (matchItem instanceof FolderMatch) {
 			if (matchItem.id() === folderMatch.id()) {
 				return true;
@@ -1329,7 +1329,7 @@ export class FolderMatchWithResource extends FolderMatch {
 
 	protected _normalizedResource: Lazy<URI>;
 
-	constructor(_resource: URI, _id: string, _index: number, _query: ITextQuery, _parent: SearchResult | FolderMatch, _searchResult: SearchResult, _closestRoot: FolderMatchWorkspaceRoot | null,
+	constructor(_resource: URI, _id: string, _index: number, _query: ITextQuery, _parent: TextSearchResult | FolderMatch, _searchResult: SearchResult, _closestRoot: FolderMatchWorkspaceRoot | null,
 		@IReplaceService replaceService: IReplaceService,
 		@IInstantiationService instantiationService: IInstantiationService,
 		@ILabelService labelService: ILabelService,
@@ -1353,13 +1353,13 @@ export class FolderMatchWithResource extends FolderMatch {
  * FolderMatchWorkspaceRoot => folder for workspace root
  */
 export class FolderMatchWorkspaceRoot extends FolderMatchWithResource {
-	constructor(_resource: URI, _id: string, _index: number, _query: ITextQuery, _parent: SearchResult, private readonly _ai: boolean,
+	constructor(_resource: URI, _id: string, _index: number, _query: ITextQuery, _parent: TextSearchResult, private readonly _ai: boolean,
 		@IReplaceService replaceService: IReplaceService,
 		@IInstantiationService instantiationService: IInstantiationService,
 		@ILabelService labelService: ILabelService,
 		@IUriIdentityService uriIdentityService: IUriIdentityService
 	) {
-		super(_resource, _id, _index, _query, _parent, _parent, null, replaceService, instantiationService, labelService, uriIdentityService);
+		super(_resource, _id, _index, _query, _parent, _parent.parent(), null, replaceService, instantiationService, labelService, uriIdentityService);
 	}
 
 	private normalizedUriParent(uri: URI): URI {
@@ -1426,14 +1426,14 @@ export class FolderMatchWorkspaceRoot extends FolderMatchWithResource {
  * FolderMatch => required resource (normal folder node)
  */
 export class FolderMatchNoRoot extends FolderMatch {
-	constructor(_id: string, _index: number, _query: ITextQuery, _parent: SearchResult,
+	constructor(_id: string, _index: number, _query: ITextQuery, _parent: TextSearchResult,
 		@IReplaceService replaceService: IReplaceService,
 		@IInstantiationService instantiationService: IInstantiationService,
 		@ILabelService labelService: ILabelService,
 		@IUriIdentityService uriIdentityService: IUriIdentityService,
 
 	) {
-		super(null, _id, _index, _query, _parent, _parent, null, replaceService, instantiationService, labelService, uriIdentityService);
+		super(null, _id, _index, _query, _parent, _parent.parent(), null, replaceService, instantiationService, labelService, uriIdentityService);
 	}
 
 	createAndConfigureFileMatch(rawFileMatch: IFileMatch, searchInstanceID: string): FileMatch {
@@ -1450,6 +1450,307 @@ export class FolderMatchNoRoot extends FolderMatch {
 		const disposable = fileMatch.onChange(({ didRemove }) => this.onFileChange(fileMatch, didRemove));
 		this._register(fileMatch.onDispose(() => disposable.dispose()));
 		return fileMatch;
+	}
+}
+
+export class TextSearchResult extends Disposable {
+	private _onChange = this._register(new Emitter<IChangeEvent>());
+	readonly onChange: Event<IChangeEvent> = this._onChange.event;
+	private _isDirty = false;
+	private _showHighlights: boolean = false;
+
+	private _query: ITextQuery | null = null;
+	private _rangeHighlightDecorations: RangeHighlightDecorations;
+	private disposePastResults: () => Promise<void> = () => Promise.resolve();
+
+	private _folderMatches: FolderMatchWorkspaceRoot[] = [];
+	private _otherFilesMatch: FolderMatch | null = null;
+	private _folderMatchesMap: TernarySearchTree<URI, FolderMatchWithResource> = TernarySearchTree.forUris<FolderMatchWorkspaceRoot>(key => this.uriIdentityService.extUri.ignorePathCasing(key));
+	public resource = null;
+
+
+	public cachedSearchComplete: ISearchComplete | undefined;
+
+	constructor(
+		private _allowOtherResults: boolean,
+		private _parent: SearchResult,
+		private _id: string,
+		@IInstantiationService private readonly instantiationService: IInstantiationService,
+		@IUriIdentityService private readonly uriIdentityService: IUriIdentityService
+	) {
+		super();
+		this._rangeHighlightDecorations = this.instantiationService.createInstance(RangeHighlightDecorations);
+
+
+		this._register(this.onChange(e => {
+			if (e.removed) {
+				this._isDirty = !this.isEmpty();
+			}
+		}));
+	}
+	id() {
+		return this._id;
+	}
+	parent() {
+		return this._parent;
+	}
+
+	get isDirty(): boolean {
+		return this._isDirty;
+	}
+
+	public getFolderMatch(resource: URI): FolderMatchWorkspaceRoot | FolderMatch | undefined {
+		const folderMatch = this._folderMatchesMap.findSubstr(resource);
+
+		if (!folderMatch && this._allowOtherResults && this._otherFilesMatch) {
+			return this._otherFilesMatch;
+		}
+		return folderMatch;
+	}
+
+	add(allRaw: IFileMatch[], searchInstanceID: string, ai: boolean, silent: boolean = false): void {
+		// Split up raw into a list per folder so we can do a batch add per folder.
+
+		const { byFolder, other } = this.groupFilesByFolder(allRaw, ai);
+		byFolder.forEach(raw => {
+			if (!raw.length) {
+				return;
+			}
+
+			// ai results go into the respective folder
+			const folderMatch = this.getFolderMatch(raw[0].resource);
+			folderMatch?.addFileMatch(raw, silent, searchInstanceID, ai);
+		});
+
+		if (!ai) {
+			this._otherFilesMatch?.addFileMatch(other, silent, searchInstanceID, false);
+		}
+		this.disposePastResults();
+	}
+
+	remove(matches: FileMatch | FolderMatch | (FileMatch | FolderMatch)[], ai = false): void {
+		if (!Array.isArray(matches)) {
+			matches = [matches];
+		}
+
+		matches.forEach(m => {
+			if (m instanceof FolderMatch) {
+				m.clear();
+			}
+		});
+
+		const fileMatches: FileMatch[] = matches.filter(m => m instanceof FileMatch) as FileMatch[];
+
+		const { byFolder, other } = this.groupFilesByFolder(fileMatches, ai);
+		byFolder.forEach(matches => {
+			if (!matches.length) {
+				return;
+			}
+
+			this.getFolderMatch(matches[0].resource)?.remove(<FileMatch[]>matches);
+		});
+
+		if (other.length) {
+			this.getFolderMatch(other[0].resource)?.remove(<FileMatch[]>other);
+		}
+	}
+
+	groupFilesByFolder(fileMatches: IFileMatch[], ai: boolean): { byFolder: ResourceMap<IFileMatch[]>; other: IFileMatch[] } {
+		const rawPerFolder = new ResourceMap<IFileMatch[]>();
+		const otherFileMatches: IFileMatch[] = [];
+		this._folderMatches.forEach(fm => rawPerFolder.set(fm.resource, []));
+
+		fileMatches.forEach(rawFileMatch => {
+			const folderMatch = this.getFolderMatch(rawFileMatch.resource);
+			if (!folderMatch) {
+				// foldermatch was previously removed by user or disposed for some reason
+				return;
+			}
+
+			const resource = folderMatch.resource;
+			if (resource) {
+				rawPerFolder.get(resource)!.push(rawFileMatch);
+			} else {
+				otherFileMatches.push(rawFileMatch);
+			}
+		});
+
+		return {
+			byFolder: rawPerFolder,
+			other: otherFileMatches
+		};
+	}
+	isEmpty(): boolean {
+		return this.folderMatches().every((folderMatch) => folderMatch.isEmpty());
+	}
+
+	findFolderSubstr(resource: URI) {
+		return this._folderMatchesMap.findSubstr(resource);
+	}
+
+	get query(): ITextQuery | null {
+		return this._query;
+	}
+
+	set query(query: ITextQuery | null) {
+		// When updating the query we could change the roots, so keep a reference to them to clean up when we trigger `disposePastResults`
+		const oldFolderMatches = this.folderMatches();
+		this.disposePastResults = async () => {
+			oldFolderMatches.forEach(match => match.clear());
+			oldFolderMatches.forEach(match => match.dispose());
+			this._isDirty = false;
+		};
+
+		this.cachedSearchComplete = undefined;
+
+		this._rangeHighlightDecorations.removeHighlightRange();
+		this._folderMatchesMap = TernarySearchTree.forUris<FolderMatchWithResource>(key => this.uriIdentityService.extUri.ignorePathCasing(key));
+		if (!query) {
+			return;
+		}
+
+		this._folderMatches = (query && query.folderQueries || [])
+			.map(fq => fq.folder)
+			.map((resource, index) => <FolderMatchWorkspaceRoot>this._createBaseFolderMatch(resource, resource.toString(), index, query, false));
+
+		this._folderMatches.forEach(fm => this._folderMatchesMap.set(fm.resource, fm));
+
+		if (this._allowOtherResults) {
+			this._otherFilesMatch = <FolderMatchNoRoot>this._createBaseFolderMatch(null, 'otherFiles', this._folderMatches.length + 1, query, false);
+		}
+
+		this._query = query;
+	}
+	private _createBaseFolderMatch(resource: URI | null, id: string, index: number, query: ITextQuery, ai: boolean): FolderMatch {
+		let folderMatch: FolderMatch;
+		if (resource) {
+			folderMatch = this._register(this.instantiationService.createInstance(FolderMatchWorkspaceRoot, resource, id, index, query, this, ai));
+		} else {
+			folderMatch = this._register(this.instantiationService.createInstance(FolderMatchNoRoot, id, index, query, this));
+		}
+		const disposable = folderMatch.onChange((event) => this._onChange.fire(event));
+		this._register(folderMatch.onDispose(() => disposable.dispose()));
+		return folderMatch;
+	}
+
+
+	folderMatches(): FolderMatch[] {
+		return this._otherFilesMatch && this._allowOtherResults ?
+			[
+				...this._folderMatches,
+				this._otherFilesMatch,
+			] :
+			this._folderMatches;
+	}
+
+	private disposeMatches(): void {
+		this.folderMatches().forEach(folderMatch => folderMatch.dispose());
+
+		this._folderMatches = [];
+
+		this._folderMatchesMap = TernarySearchTree.forUris<FolderMatchWithResource>(key => this.uriIdentityService.extUri.ignorePathCasing(key));
+
+		this._rangeHighlightDecorations.removeHighlightRange();
+	}
+
+	matches(): FileMatch[] {
+		const matches: FileMatch[][] = [];
+		this.folderMatches().forEach(folderMatch => {
+			matches.push(folderMatch.allDownstreamFileMatches());
+		});
+
+		return (<FileMatch[]>[]).concat(...matches);
+	}
+
+	get showHighlights(): boolean {
+		return this._showHighlights;
+	}
+
+	toggleHighlights(value: boolean): void {
+		if (this._showHighlights === value) {
+			return;
+		}
+		this._showHighlights = value;
+		let selectedMatch: Match | null = null;
+		this.matches().forEach((fileMatch: FileMatch) => {
+			fileMatch.updateHighlights();
+			fileMatch.updateNotebookHighlights();
+			if (!selectedMatch) {
+				selectedMatch = fileMatch.getSelectedMatch();
+			}
+		});
+		if (this._showHighlights && selectedMatch) {
+			// TS?
+			this._rangeHighlightDecorations.highlightRange(
+				(<Match>selectedMatch).parent().resource,
+				(<Match>selectedMatch).range()
+			);
+		} else {
+			this._rangeHighlightDecorations.removeHighlightRange();
+		}
+	}
+
+	get rangeHighlightDecorations(): RangeHighlightDecorations {
+		return this._rangeHighlightDecorations;
+	}
+
+	fileCount(): number {
+		return this.folderMatches().reduce<number>((prev, match) => prev + match.recursiveFileCount(), 0);
+	}
+
+	count(): number {
+		return this.matches().reduce<number>((prev, match) => prev + match.count(), 0);
+	}
+
+	clear(): void {
+		this.folderMatches().forEach((folderMatch) => folderMatch.clear(true));
+		this.disposeMatches();
+		this._folderMatches = [];
+		this._otherFilesMatch = null;
+	}
+
+	override async dispose(): Promise<void> {
+		this._rangeHighlightDecorations.dispose();
+		this.disposeMatches();
+		super.dispose();
+		await this.disposePastResults();
+	}
+}
+
+export class ReplaceableTextSearchResult extends TextSearchResult {
+	constructor(
+		_allowOtherResults: boolean,
+		parent: SearchResult,
+		id: string,
+		@IInstantiationService instantiationService: IInstantiationService,
+		@IUriIdentityService uriIdentityService: IUriIdentityService,
+		@IReplaceService private readonly replaceService: IReplaceService,
+	) {
+		super(_allowOtherResults, parent, id, instantiationService, uriIdentityService);
+
+	}
+
+	replace(match: FileMatch): Promise<any> {
+		return this.getFolderMatch(match.resource)?.replace(match) ?? Promise.resolve();
+	}
+
+	replaceAll(progress: IProgress<IProgressStep>): Promise<any> {
+		this.replacingAll = true;
+
+		const promise = this.replaceService.replace(this.matches(), progress);
+
+		return promise.then(() => {
+			this.replacingAll = false;
+			this.clear();
+		}, () => {
+			this.replacingAll = false;
+		});
+	}
+
+	private set replacingAll(running: boolean) {
+		this.folderMatches().forEach((folderMatch) => {
+			folderMatch.replacingAll = running;
+		});
 	}
 }
 
@@ -1576,9 +1877,9 @@ export function searchComparer(elementA: RenderableMatch, elementB: RenderableMa
 
 function createParentList(element: RenderableMatch): RenderableMatch[] {
 	const parentArray: RenderableMatch[] = [];
-	let currElement: RenderableMatch | SearchResult = element;
+	let currElement: RenderableMatch | TextSearchResult = element;
 
-	while (!(currElement instanceof SearchResult)) {
+	while (!(currElement instanceof TextSearchResult)) {
 		parentArray.push(currElement);
 		currElement = currElement.parent();
 	}
@@ -1586,38 +1887,29 @@ function createParentList(element: RenderableMatch): RenderableMatch[] {
 	return parentArray;
 }
 
+export const PLAIN_TEXT_SEARCH__RESULT_ID = 'plainTextSearch';
+export const AI_TEXT_SEARCH_RESULT_ID = 'aiTextSearch';
+
 export class SearchResult extends Disposable {
 
 	private _onChange = this._register(new PauseableEmitter<IChangeEvent>({
 		merge: mergeSearchResultEvents
 	}));
 	readonly onChange: Event<IChangeEvent> = this._onChange.event;
-	private _folderMatches: FolderMatchWorkspaceRoot[] = [];
-	private _aiFolderMatches: FolderMatchWorkspaceRoot[] = [];
-	private _otherFilesMatch: FolderMatch | null = null;
-	private _folderMatchesMap: TernarySearchTree<URI, FolderMatchWithResource> = TernarySearchTree.forUris<FolderMatchWorkspaceRoot>(key => this.uriIdentityService.extUri.ignorePathCasing(key));
-	private _aiFolderMatchesMap: TernarySearchTree<URI, FolderMatchWithResource> = TernarySearchTree.forUris<FolderMatchWorkspaceRoot>(key => this.uriIdentityService.extUri.ignorePathCasing(key));
-	private _showHighlights: boolean = false;
-	private _query: ITextQuery | null = null;
-	private _rangeHighlightDecorations: RangeHighlightDecorations;
-	private disposePastResults: () => Promise<void> = () => Promise.resolve();
-	private _isDirty = false;
 	private _onWillChangeModelListener: IDisposable | undefined;
 	private _onDidChangeModelListener: IDisposable | undefined;
+	private _plainTextSearchResult: ReplaceableTextSearchResult;
+	private _aiTextSearchResult: TextSearchResult;
 
-	private _cachedSearchComplete: ISearchComplete | undefined;
-	private _aiCachedSearchComplete: ISearchComplete | undefined;
+	public hasAISearched = false;
 
 	constructor(
 		public readonly searchModel: SearchModel,
-		@IReplaceService private readonly replaceService: IReplaceService,
 		@IInstantiationService private readonly instantiationService: IInstantiationService,
 		@IModelService private readonly modelService: IModelService,
-		@IUriIdentityService private readonly uriIdentityService: IUriIdentityService,
 		@INotebookEditorService private readonly notebookEditorService: INotebookEditorService,
 	) {
 		super();
-		this._rangeHighlightDecorations = this.instantiationService.createInstance(RangeHighlightDecorations);
 		this.modelService.getModels().forEach(model => this.onModelAdded(model));
 		this._register(this.modelService.onModelAdded(model => this.onModelAdded(model)));
 
@@ -1627,11 +1919,17 @@ export class SearchResult extends Disposable {
 			}
 		}));
 
-		this._register(this.onChange(e => {
-			if (e.removed) {
-				this._isDirty = !this.isEmpty() || !this.isEmpty(true);
-			}
-		}));
+		this._plainTextSearchResult = this._register(this.instantiationService.createInstance(TextSearchResult, true, this, PLAIN_TEXT_SEARCH__RESULT_ID));
+		this._aiTextSearchResult = this._register(this.instantiationService.createInstance(TextSearchResult, true, this, AI_TEXT_SEARCH_RESULT_ID));
+		this._register(this._plainTextSearchResult.onChange((e) => this._onChange.fire(e)));
+		this._register(this._aiTextSearchResult.onChange((e) => this._onChange.fire(e)));
+	}
+
+	get plainTextSearchResult(): ReplaceableTextSearchResult {
+		return this._plainTextSearchResult;
+	}
+	get textSearchResults(): TextSearchResult[] {
+		return [this._plainTextSearchResult, this._aiTextSearchResult];
 	}
 
 	async batchReplace(elementsToReplace: RenderableMatch[]) {
@@ -1677,60 +1975,17 @@ export class SearchResult extends Disposable {
 	}
 
 	get isDirty(): boolean {
-		return this._isDirty;
+		return this._aiTextSearchResult.isDirty || this._plainTextSearchResult.isDirty;
 	}
 
 	get query(): ITextQuery | null {
-		return this._query;
+		return this._plainTextSearchResult.query;
 	}
 
 	set query(query: ITextQuery | null) {
-		// When updating the query we could change the roots, so keep a reference to them to clean up when we trigger `disposePastResults`
-		const oldFolderMatches = this.folderMatches();
-		this.disposePastResults = async () => {
-			oldFolderMatches.forEach(match => match.clear());
-			oldFolderMatches.forEach(match => match.dispose());
-			this._isDirty = false;
-		};
-
-		this._cachedSearchComplete = undefined;
-		this._aiCachedSearchComplete = undefined;
-
-		this._rangeHighlightDecorations.removeHighlightRange();
-		this._folderMatchesMap = TernarySearchTree.forUris<FolderMatchWithResource>(key => this.uriIdentityService.extUri.ignorePathCasing(key));
-		this._aiFolderMatchesMap = TernarySearchTree.forUris<FolderMatchWithResource>(key => this.uriIdentityService.extUri.ignorePathCasing(key));
-
-		if (!query) {
-			return;
-		}
-
-		this._folderMatches = (query && query.folderQueries || [])
-			.map(fq => fq.folder)
-			.map((resource, index) => <FolderMatchWorkspaceRoot>this._createBaseFolderMatch(resource, resource.toString(), index, query, false));
-
-		this._folderMatches.forEach(fm => this._folderMatchesMap.set(fm.resource, fm));
-
-		this._aiFolderMatches = (query && query.folderQueries || [])
-			.map(fq => fq.folder)
-			.map((resource, index) => <FolderMatchWorkspaceRoot>this._createBaseFolderMatch(resource, resource.toString(), index, query, true));
-
-		this._aiFolderMatches.forEach(fm => this._aiFolderMatchesMap.set(fm.resource, fm));
-
-		this._otherFilesMatch = <FolderMatchNoRoot>this._createBaseFolderMatch(null, 'otherFiles', this._folderMatches.length + this._aiFolderMatches.length + 1, query, false);
-
-		this._query = query;
-	}
-
-	setCachedSearchComplete(cachedSearchComplete: ISearchComplete | undefined, ai: boolean) {
-		if (ai) {
-			this._aiCachedSearchComplete = cachedSearchComplete;
-		} else {
-			this._cachedSearchComplete = cachedSearchComplete;
-		}
-	}
-
-	getCachedSearchComplete(ai: boolean) {
-		return ai ? this._aiCachedSearchComplete : this._cachedSearchComplete;
+		this._plainTextSearchResult.query = query;
+		this._aiTextSearchResult.query = query;
+		this.hasAISearched = false;
 	}
 
 	private onDidAddNotebookEditorWidget(widget: NotebookEditorWidget): void {
@@ -1755,236 +2010,118 @@ export class SearchResult extends Disposable {
 		);
 	}
 
+	folderMatches(): FolderMatch[] {
+		return [...this._plainTextSearchResult.folderMatches(), ...this._aiTextSearchResult.folderMatches()];
+	}
 	private onModelAdded(model: ITextModel): void {
-		const folderMatch = this._folderMatchesMap.findSubstr(model.uri);
+		const folderMatch = this._plainTextSearchResult.findFolderSubstr(model.uri);
 		folderMatch?.bindModel(model);
 	}
 
 	private async onNotebookEditorWidgetAdded(editor: NotebookEditorWidget, resource: URI): Promise<void> {
-		const folderMatch = this._folderMatchesMap.findSubstr(resource);
+		const folderMatch = this._plainTextSearchResult.findFolderSubstr(resource);
 		await folderMatch?.bindNotebookEditorWidget(editor, resource);
 	}
 
 	private onNotebookEditorWidgetRemoved(editor: NotebookEditorWidget, resource: URI): void {
-		const folderMatch = this._folderMatchesMap.findSubstr(resource);
+		const folderMatch = this._plainTextSearchResult.findFolderSubstr(resource);
 		folderMatch?.unbindNotebookEditorWidget(editor, resource);
-	}
-
-	private _createBaseFolderMatch(resource: URI | null, id: string, index: number, query: ITextQuery, ai: boolean): FolderMatch {
-		let folderMatch: FolderMatch;
-		if (resource) {
-			folderMatch = this._register(this.instantiationService.createInstance(FolderMatchWorkspaceRoot, resource, id, index, query, this, ai));
-		} else {
-			folderMatch = this._register(this.instantiationService.createInstance(FolderMatchNoRoot, id, index, query, this));
-		}
-		const disposable = folderMatch.onChange((event) => this._onChange.fire(event));
-		this._register(folderMatch.onDispose(() => disposable.dispose()));
-		return folderMatch;
 	}
 
 
 	add(allRaw: IFileMatch[], searchInstanceID: string, ai: boolean, silent: boolean = false): void {
 		// Split up raw into a list per folder so we can do a batch add per folder.
 
-		const { byFolder, other } = this.groupFilesByFolder(allRaw, ai);
-		byFolder.forEach(raw => {
-			if (!raw.length) {
-				return;
-			}
-
-			// ai results go into the respective folder
-			const folderMatch = ai ? this.getAIFolderMatch(raw[0].resource) : this.getFolderMatch(raw[0].resource);
-			folderMatch?.addFileMatch(raw, silent, searchInstanceID, ai);
-		});
-
-		if (!ai) {
-			this._otherFilesMatch?.addFileMatch(other, silent, searchInstanceID, false);
+		if (ai) {
+			this._aiTextSearchResult.add(allRaw, searchInstanceID, ai, silent);
+		} else {
+			this._plainTextSearchResult.add(allRaw, searchInstanceID, ai, silent);
 		}
-		this.disposePastResults();
 	}
 
 	clear(): void {
-		this.folderMatches().forEach((folderMatch) => folderMatch.clear(true));
-		this.folderMatches(true);
-		this.disposeMatches();
-		this._folderMatches = [];
-		this._aiFolderMatches = [];
-		this._otherFilesMatch = null;
+		this._aiTextSearchResult.clear();
+		this._plainTextSearchResult.clear();
 	}
 
 	remove(matches: FileMatch | FolderMatch | (FileMatch | FolderMatch)[], ai = false): void {
-		if (!Array.isArray(matches)) {
-			matches = [matches];
+		if (ai) {
+			this._aiTextSearchResult.remove(matches, ai);
 		}
+		this._plainTextSearchResult.remove(matches, ai);
 
-		matches.forEach(m => {
-			if (m instanceof FolderMatch) {
-				m.clear();
-			}
-		});
-
-		const fileMatches: FileMatch[] = matches.filter(m => m instanceof FileMatch) as FileMatch[];
-
-		const { byFolder, other } = this.groupFilesByFolder(fileMatches, ai);
-		byFolder.forEach(matches => {
-			if (!matches.length) {
-				return;
-			}
-
-			this.getFolderMatch(matches[0].resource).remove(<FileMatch[]>matches);
-		});
-
-		if (other.length) {
-			this.getFolderMatch(other[0].resource).remove(<FileMatch[]>other);
-		}
 	}
 
 	replace(match: FileMatch): Promise<any> {
-		return this.getFolderMatch(match.resource).replace(match);
-	}
-
-	replaceAll(progress: IProgress<IProgressStep>): Promise<any> {
-		this.replacingAll = true;
-
-		const promise = this.replaceService.replace(this.matches(), progress);
-
-		return promise.then(() => {
-			this.replacingAll = false;
-			this.clear();
-		}, () => {
-			this.replacingAll = false;
-		});
-	}
-
-	folderMatches(ai = false): FolderMatch[] {
-		if (ai) {
-			return this._aiFolderMatches;
-		}
-		return this._otherFilesMatch ?
-			[
-				...this._folderMatches,
-				this._otherFilesMatch
-			] :
-			[
-				...this._folderMatches
-			];
+		return this._plainTextSearchResult.replace(match);
 	}
 
 	matches(ai = false): FileMatch[] {
-		const matches: FileMatch[][] = [];
-		this.folderMatches(ai).forEach(folderMatch => {
-			matches.push(folderMatch.allDownstreamFileMatches());
-		});
-
-		return (<FileMatch[]>[]).concat(...matches);
+		if (ai) {
+			return this._aiTextSearchResult.matches();
+		}
+		return this._plainTextSearchResult.matches();
 	}
 
 	isEmpty(ai = false): boolean {
-		return this.folderMatches(ai).every((folderMatch) => folderMatch.isEmpty());
+		if (ai) {
+			return this._aiTextSearchResult.isEmpty();
+		}
+		return this._plainTextSearchResult.isEmpty();
 	}
 
 	fileCount(ai = false): number {
-		return this.folderMatches(ai).reduce<number>((prev, match) => prev + match.recursiveFileCount(), 0);
+		if (ai) {
+			return this._aiTextSearchResult.fileCount();
+		}
+		return this._plainTextSearchResult.fileCount();
 	}
 
 	count(ai = false): number {
-		return this.matches(ai).reduce<number>((prev, match) => prev + match.count(), 0);
-	}
-
-	get showHighlights(): boolean {
-		return this._showHighlights;
-	}
-
-	toggleHighlights(value: boolean): void {
-		if (this._showHighlights === value) {
-			return;
+		if (ai) {
+			return this._aiTextSearchResult.count();
 		}
-		this._showHighlights = value;
-		let selectedMatch: Match | null = null;
-		this.matches().forEach((fileMatch: FileMatch) => {
-			fileMatch.updateHighlights();
-			fileMatch.updateNotebookHighlights();
-			if (!selectedMatch) {
-				selectedMatch = fileMatch.getSelectedMatch();
-			}
-		});
-		if (this._showHighlights && selectedMatch) {
-			// TS?
-			this._rangeHighlightDecorations.highlightRange(
-				(<Match>selectedMatch).parent().resource,
-				(<Match>selectedMatch).range()
-			);
+		return this._plainTextSearchResult.count();
+	}
+
+	setCachedSearchComplete(cachedSearchComplete: ISearchComplete | undefined, ai: boolean) {
+		if (ai) {
+			this._aiTextSearchResult.cachedSearchComplete = cachedSearchComplete;
 		} else {
-			this._rangeHighlightDecorations.removeHighlightRange();
+			this._plainTextSearchResult.cachedSearchComplete = cachedSearchComplete;
 		}
 	}
 
-	get rangeHighlightDecorations(): RangeHighlightDecorations {
-		return this._rangeHighlightDecorations;
+	getCachedSearchComplete(ai: boolean): ISearchComplete | undefined {
+		if (ai) {
+			return this._aiTextSearchResult.cachedSearchComplete;
+		}
+		return this._plainTextSearchResult.cachedSearchComplete;
 	}
 
-	private getFolderMatch(resource: URI): FolderMatchWorkspaceRoot | FolderMatch {
-		const folderMatch = this._folderMatchesMap.findSubstr(resource);
-		return folderMatch ? folderMatch : this._otherFilesMatch!;
+	toggleHighlights(value: boolean, ai: boolean = false): void {
+		if (ai) {
+			this._aiTextSearchResult.toggleHighlights(value);
+		} else {
+			this._plainTextSearchResult.toggleHighlights(value);
+		}
 	}
 
-	private getAIFolderMatch(resource: URI): FolderMatchWorkspaceRoot | FolderMatch | undefined {
-		const folderMatch = this._aiFolderMatchesMap.findSubstr(resource);
-		return folderMatch;
+	getRangeHighlightDecorations(ai: boolean = false): RangeHighlightDecorations {
+		if (ai) {
+			return this._aiTextSearchResult.rangeHighlightDecorations;
+		}
+		return this._plainTextSearchResult.rangeHighlightDecorations;
 	}
 
-	private set replacingAll(running: boolean) {
-		this.folderMatches().forEach((folderMatch) => {
-			folderMatch.replacingAll = running;
-		});
-	}
-
-	private groupFilesByFolder(fileMatches: IFileMatch[], ai: boolean): { byFolder: ResourceMap<IFileMatch[]>; other: IFileMatch[] } {
-		const rawPerFolder = new ResourceMap<IFileMatch[]>();
-		const otherFileMatches: IFileMatch[] = [];
-		(ai ? this._aiFolderMatches : this._folderMatches).forEach(fm => rawPerFolder.set(fm.resource, []));
-
-		fileMatches.forEach(rawFileMatch => {
-			const folderMatch = ai ? this.getAIFolderMatch(rawFileMatch.resource) : this.getFolderMatch(rawFileMatch.resource);
-			if (!folderMatch) {
-				// foldermatch was previously removed by user or disposed for some reason
-				return;
-			}
-
-			const resource = folderMatch.resource;
-			if (resource) {
-				rawPerFolder.get(resource)!.push(rawFileMatch);
-			} else {
-				otherFileMatches.push(rawFileMatch);
-			}
-		});
-
-		return {
-			byFolder: rawPerFolder,
-			other: otherFileMatches
-		};
-	}
-
-	private disposeMatches(): void {
-		this.folderMatches().forEach(folderMatch => folderMatch.dispose());
-		this.folderMatches(true).forEach(folderMatch => folderMatch.dispose());
-
-		this._folderMatches = [];
-		this._aiFolderMatches = [];
-
-		this._folderMatchesMap = TernarySearchTree.forUris<FolderMatchWithResource>(key => this.uriIdentityService.extUri.ignorePathCasing(key));
-		this._aiFolderMatchesMap = TernarySearchTree.forUris<FolderMatchWithResource>(key => this.uriIdentityService.extUri.ignorePathCasing(key));
-
-		this._rangeHighlightDecorations.removeHighlightRange();
+	replaceAll(progress: IProgress<IProgressStep>): Promise<any> {
+		return this._plainTextSearchResult.replaceAll(progress);
 	}
 
 	override async dispose(): Promise<void> {
 		this._onWillChangeModelListener?.dispose();
 		this._onDidChangeModelListener?.dispose();
-		this._rangeHighlightDecorations.dispose();
-		this.disposeMatches();
 		super.dispose();
-		await this.disposePastResults();
 	}
 }
 
@@ -2070,11 +2207,12 @@ export class SearchModel extends Disposable {
 	}
 
 	async addAIResults(onProgress?: (result: ISearchProgressItem) => void) {
-		if (this.searchResult.count(true)) {
+		if (this.searchResult.hasAISearched) {
 			// already has matches
 			return;
 		} else {
 			if (this._searchQuery) {
+				this.searchResult.hasAISearched = true;
 				await this.aiSearch(
 					{ ...this._searchQuery, contentPattern: this._searchQuery.contentPattern.pattern, type: QueryType.aiText },
 					onProgress,
@@ -2365,7 +2503,7 @@ export class SearchModel extends Disposable {
 
 export type FileMatchOrMatch = FileMatch | Match;
 
-export type RenderableMatch = FolderMatch | FolderMatchWithResource | FileMatch | Match;
+export type RenderableMatch = TextSearchResult | FolderMatch | FolderMatchWithResource | FileMatch | Match;
 
 export class SearchViewModelWorkbenchService implements ISearchViewModelWorkbenchService {
 

--- a/src/vs/workbench/contrib/search/browser/searchView.ts
+++ b/src/vs/workbench/contrib/search/browser/searchView.ts
@@ -64,13 +64,13 @@ import { appendKeyBindingLabel } from './searchActionsBase.js';
 import { IFindInFilesArgs } from './searchActionsFind.js';
 import { searchDetailsIcon } from './searchIcons.js';
 import { renderSearchMessage } from './searchMessage.js';
-import { FileMatchRenderer, FolderMatchRenderer, MatchRenderer, SearchAccessibilityProvider, SearchDelegate, TextSearchResultRenderer } from './searchResultsView.js';
+import { FileMatchRenderer, FolderMatchRenderer, MatchRenderer, SearchAccessibilityProvider, SearchDelegate } from './searchResultsView.js';
 import { SearchWidget } from './searchWidget.js';
 import * as Constants from '../common/constants.js';
 import { IReplaceService } from './replace.js';
 import { getOutOfWorkspaceEditorResources, SearchStateKey, SearchUIState } from '../common/search.js';
 import { ISearchHistoryService, ISearchHistoryValues, SearchHistoryService } from '../common/searchHistoryService.js';
-import { AI_TEXT_SEARCH_RESULT_ID, FileMatch, FileMatchOrMatch, FolderMatch, FolderMatchWithResource, IChangeEvent, ISearchViewModelWorkbenchService, Match, MatchInNotebook, RenderableMatch, searchMatchComparer, SearchModel, SearchModelLocation, SearchResult } from './searchModel.js';
+import { FileMatch, FileMatchOrMatch, FolderMatch, FolderMatchWithResource, IChangeEvent, ISearchViewModelWorkbenchService, Match, MatchInNotebook, RenderableMatch, searchMatchComparer, SearchModel, SearchModelLocation, SearchResult } from './searchModel.js';
 import { createEditorFromSearchResult } from '../../searchEditor/browser/searchEditorActions.js';
 import { ACTIVE_GROUP, IEditorService, SIDE_GROUP } from '../../../services/editor/common/editorService.js';
 import { IPreferencesService, ISettingsEditorOptions } from '../../../services/preferences/common/preferences.js';
@@ -970,7 +970,6 @@ export class SearchView extends ViewPane {
 			delegate,
 			[
 				this._register(this.instantiationService.createInstance(FolderMatchRenderer, this, this.treeLabels)),
-				this._register(this.instantiationService.createInstance(TextSearchResultRenderer, this.treeLabels)),
 				this._register(this.instantiationService.createInstance(FileMatchRenderer, this, this.treeLabels)),
 				this._register(this.instantiationService.createInstance(MatchRenderer, this)),
 			],
@@ -1005,8 +1004,6 @@ export class SearchView extends ViewPane {
 				this.currentSelectedFileMatch.setSelectedMatch(selectedMatch);
 
 				this.onFocus(selectedMatch, options.editorOptions.preserveFocus, options.sideBySide, options.editorOptions.pinned);
-			} else if (options.element?.id() === AI_TEXT_SEARCH_RESULT_ID) {
-				this.model.addAIResults().then(() => this.refreshTree());
 			}
 		}));
 

--- a/src/vs/workbench/contrib/search/test/browser/searchActions.test.ts
+++ b/src/vs/workbench/contrib/search/test/browser/searchActions.test.ts
@@ -120,7 +120,7 @@ suite('Search Actions', () => {
 			type: QueryType.Text, folderQueries: [{ folder: createFileUriFromPathFromRoot() }], contentPattern: {
 				pattern: ''
 			}
-		}, searchModel.searchResult, searchModel.searchResult, null);
+		}, searchModel.searchResult.plainTextSearchResult, searchModel.searchResult, null);
 		store.add(folderMatch);
 		const fileMatch = instantiationService.createInstance(FileMatch, {
 			pattern: ''

--- a/src/vs/workbench/contrib/search/test/browser/searchNotebookHelpers.test.ts
+++ b/src/vs/workbench/contrib/search/test/browser/searchNotebookHelpers.test.ts
@@ -213,7 +213,7 @@ suite('searchNotebookHelpers', () => {
 				type: QueryType.Text, folderQueries: [{ folder: createFileUriFromPathFromRoot() }], contentPattern: {
 					pattern: ''
 				}
-			}, searchModel.searchResult, searchModel.searchResult, null);
+			}, searchModel.searchResult.plainTextSearchResult, searchModel.searchResult, null);
 			const fileMatch = instantiationService.createInstance(FileMatch, {
 				pattern: ''
 			}, undefined, undefined, folderMatch, rawMatch, null, '');

--- a/src/vs/workbench/contrib/search/test/browser/searchViewlet.test.ts
+++ b/src/vs/workbench/contrib/search/test/browser/searchViewlet.test.ts
@@ -15,7 +15,7 @@ import { IUriIdentityService } from '../../../../../platform/uriIdentity/common/
 import { UriIdentityService } from '../../../../../platform/uriIdentity/common/uriIdentityService.js';
 import { IWorkspaceContextService } from '../../../../../platform/workspace/common/workspace.js';
 import { TestWorkspace } from '../../../../../platform/workspace/test/common/testWorkspace.js';
-import { FileMatch, FolderMatch, Match, searchComparer, searchMatchComparer, SearchModel, SearchResult } from '../../browser/searchModel.js';
+import { FileMatch, FolderMatch, Match, searchComparer, searchMatchComparer, SearchModel, SearchResult, TextSearchResult } from '../../browser/searchModel.js';
 import { MockLabelService } from '../../../../services/label/test/common/mockLabelService.js';
 import { IFileMatch, ITextSearchMatch, OneLineRange, QueryType, SearchSortOrder } from '../../../../services/search/common/search.js';
 import { TestContextService } from '../../../../test/common/workbenchTestServices.js';
@@ -123,8 +123,8 @@ suite('Search - Viewlet', () => {
 	test('Cross-type Comparer', () => {
 
 		const searchResult = aSearchResult();
-		const folderMatch1 = aFolderMatch('/voo', 0, searchResult);
-		const folderMatch2 = aFolderMatch('/with', 1, searchResult);
+		const folderMatch1 = aFolderMatch('/voo', 0, searchResult.plainTextSearchResult);
+		const folderMatch2 = aFolderMatch('/with', 1, searchResult.plainTextSearchResult);
 
 		const fileMatch1 = aFileMatch('/voo/foo.a', folderMatch1);
 		const fileMatch2 = aFileMatch('/with/path.c', folderMatch2);
@@ -188,7 +188,7 @@ suite('Search - Viewlet', () => {
 		return fileMatch;
 	}
 
-	function aFolderMatch(path: string, index: number, parent?: SearchResult): FolderMatch {
+	function aFolderMatch(path: string, index: number, parent?: TextSearchResult): FolderMatch {
 		const searchModel = instantiation.createInstance(SearchModel);
 		store.add(searchModel);
 		const folderMatch = instantiation.createInstance(FolderMatch, createFileUriFromPathFromRoot(path), path, index, {

--- a/src/vs/workbench/services/search/common/queryBuilder.ts
+++ b/src/vs/workbench/services/search/common/queryBuilder.ts
@@ -22,7 +22,7 @@ import { IUriIdentityService } from '../../../../platform/uriIdentity/common/uri
 import { IWorkspaceContextService, IWorkspaceFolderData, toWorkspaceFolder, WorkbenchState } from '../../../../platform/workspace/common/workspace.js';
 import { IEditorGroupsService } from '../../editor/common/editorGroupsService.js';
 import { IPathService } from '../../path/common/pathService.js';
-import { ExcludeGlobPattern, getExcludes, ICommonQueryProps, IFileQuery, IFolderQuery, IPatternInfo, ISearchConfiguration, ITextQuery, ITextSearchPreviewOptions, pathIncludedInQuery, QueryType } from './search.js';
+import { ExcludeGlobPattern, getExcludes, IAITextQuery, ICommonQueryProps, IFileQuery, IFolderQuery, IPatternInfo, ISearchConfiguration, ITextQuery, ITextSearchPreviewOptions, pathIncludedInQuery, QueryType } from './search.js';
 import { GlobPattern } from './searchExtTypes.js';
 
 /**
@@ -126,6 +126,15 @@ export class QueryBuilder {
 		@IPathService private readonly pathService: IPathService,
 		@IUriIdentityService private readonly uriIdentityService: IUriIdentityService
 	) {
+	}
+
+	aiText(contentPattern: string, folderResources?: uri[], options: ITextQueryBuilderOptions = {}): IAITextQuery {
+		const commonQuery = this.commonQuery(folderResources?.map(toWorkspaceFolder), options);
+		return {
+			...commonQuery,
+			type: QueryType.aiText,
+			contentPattern,
+		};
 	}
 
 	text(contentPattern: IPatternInfo, folderResources?: uri[], options: ITextQueryBuilderOptions = {}): ITextQuery {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
Some preliminary work in getting the search model ready for having AI results in the same view as ripgrep results (just in another node). Even if we don't keep that view long-term, this is generally a more organized way to storing these results.