### PR TITLE
Implement rectangle renderer and gpu rulers view part

### DIFF
--- a/src/vs/editor/browser/gpu/fullFileRenderStrategy.ts
+++ b/src/vs/editor/browser/gpu/fullFileRenderStrategy.ts
@@ -146,9 +146,11 @@ export class FullFileRenderStrategy extends Disposable implements IGpuRenderStra
 
 		const activeWindow = getActiveWindow();
 
+		// TODO: Only update on scroll change
 		// Update scroll offset
 		const scrollTop = this._context.viewLayout.getCurrentScrollTop() * activeWindow.devicePixelRatio;
 		const scrollOffsetBuffer = this._scrollOffsetValueBuffers[this._activeDoubleBufferIndex];
+		// TODO: Add scroll left
 		scrollOffsetBuffer[1] = scrollTop;
 		this._device.queue.writeBuffer(this._scrollOffsetBindBuffer, 0, scrollOffsetBuffer);
 

--- a/src/vs/editor/browser/gpu/fullFileRenderStrategy.ts
+++ b/src/vs/editor/browser/gpu/fullFileRenderStrategy.ts
@@ -144,14 +144,12 @@ export class FullFileRenderStrategy extends Disposable implements IGpuRenderStra
 
 		let tokens: IViewLineTokens;
 
-		const activeWindow = getActiveWindow();
+		const dpr = getActiveWindow().devicePixelRatio;
 
-		// TODO: Only update on scroll change
 		// Update scroll offset
-		const scrollTop = this._context.viewLayout.getCurrentScrollTop() * activeWindow.devicePixelRatio;
 		const scrollOffsetBuffer = this._scrollOffsetValueBuffers[this._activeDoubleBufferIndex];
-		// TODO: Add scroll left
-		scrollOffsetBuffer[1] = scrollTop;
+		scrollOffsetBuffer[0] = this._context.viewLayout.getCurrentScrollLeft() * dpr;
+		scrollOffsetBuffer[1] = this._context.viewLayout.getCurrentScrollTop() * dpr;
 		this._device.queue.writeBuffer(this._scrollOffsetBindBuffer, 0, scrollOffsetBuffer);
 
 		// Update cell data
@@ -237,14 +235,14 @@ export class FullFileRenderStrategy extends Disposable implements IGpuRenderStra
 					glyph = this._atlas.getGlyph(this._glyphRasterizer, chars, tokenMetadata);
 
 					// TODO: Support non-standard character widths
-					screenAbsoluteX = Math.round((x + xOffset) * viewLineOptions.spaceWidth * activeWindow.devicePixelRatio);
+					screenAbsoluteX = Math.round((x + xOffset) * viewLineOptions.spaceWidth * dpr);
 					screenAbsoluteY = (
 						Math.ceil((
 							// Top of line including line height
 							viewportData.relativeVerticalOffset[y - viewportData.startLineNumber] +
 							// Delta to top of line after line height
 							Math.floor((viewportData.lineHeight - this._context.configuration.options.get(EditorOption.fontSize)) / 2)
-						) * activeWindow.devicePixelRatio)
+						) * dpr)
 					);
 					zeroToOneX = screenAbsoluteX / this._canvas.width;
 					zeroToOneY = screenAbsoluteY / this._canvas.height;

--- a/src/vs/editor/browser/gpu/fullFileRenderStrategy.wgsl.ts
+++ b/src/vs/editor/browser/gpu/fullFileRenderStrategy.wgsl.ts
@@ -40,7 +40,7 @@ struct VSOutput {
 };
 
 // Uniforms
-@group(0) @binding(${BindingId.ViewportUniform})         var<uniform>       layoutInfo:      LayoutInfo;
+@group(0) @binding(${BindingId.LayoutInfoUniform})       var<uniform>       layoutInfo:      LayoutInfo;
 @group(0) @binding(${BindingId.AtlasDimensionsUniform})  var<uniform>       atlasDims:       vec2f;
 @group(0) @binding(${BindingId.ScrollOffset})            var<uniform>       scrollOffset:    ScrollOffset;
 

--- a/src/vs/editor/browser/gpu/fullFileRenderStrategy.wgsl.ts
+++ b/src/vs/editor/browser/gpu/fullFileRenderStrategy.wgsl.ts
@@ -67,7 +67,7 @@ struct VSOutput {
 	var vsOut: VSOutput;
 	// Multiple vert.position by 2,-2 to get it into clipspace which ranged from -1 to 1
 	vsOut.position = vec4f(
-		(((vert.position * vec2f(2, -2)) / layoutInfo.canvasDims)) * glyph.size + cell.position + ((glyph.origin * vec2f(2, -2)) / layoutInfo.canvasDims) + (((scrollOffset.offset + layoutInfo.viewportOffset) * 2) / layoutInfo.canvasDims),
+		(((vert.position * vec2f(2, -2)) / layoutInfo.canvasDims)) * glyph.size + cell.position + ((glyph.origin * vec2f(2, -2)) / layoutInfo.canvasDims) + (((layoutInfo.viewportOffset - scrollOffset.offset * vec2(1, -1)) * 2) / layoutInfo.canvasDims),
 		0.0,
 		1.0
 	);

--- a/src/vs/editor/browser/gpu/gpu.ts
+++ b/src/vs/editor/browser/gpu/gpu.ts
@@ -12,7 +12,7 @@ export const enum BindingId {
 	Cells,
 	TextureSampler,
 	Texture,
-	ViewportUniform,
+	LayoutInfoUniform,
 	AtlasDimensionsUniform,
 	ScrollOffset,
 }

--- a/src/vs/editor/browser/gpu/objectCollectionBuffer.ts
+++ b/src/vs/editor/browser/gpu/objectCollectionBuffer.ts
@@ -57,6 +57,7 @@ export interface IObjectCollectionBuffer<T extends ObjectCollectionBufferPropert
 export interface IObjectCollectionBufferEntry<T extends ObjectCollectionBufferPropertySpec[]> extends IDisposable {
 	set(propertyName: T[number]['name'], value: number): void;
 	get(propertyName: T[number]['name']): number;
+	setRaw(data: ArrayLike<number>): void;
 }
 
 export function createObjectCollectionBuffer<T extends ObjectCollectionBufferPropertySpec[]>(
@@ -165,5 +166,12 @@ class ObjectCollectionBufferEntry<T extends ObjectCollectionBufferPropertySpec[]
 
 	get(propertyName: T[number]['name']): number {
 		return this._view[this.i * this._propertySpecsMap.size + this._propertySpecsMap.get(propertyName)!.offset];
+	}
+
+	setRaw(data: ArrayLike<number>): void {
+		if (data.length !== this._propertySpecsMap.size) {
+			throw new Error(`Data length ${data.length} does not match the number of properties in the collection (${this._propertySpecsMap.size})`);
+		}
+		this._view.set(data, this.i * this._propertySpecsMap.size);
 	}
 }

--- a/src/vs/editor/browser/gpu/objectCollectionBuffer.ts
+++ b/src/vs/editor/browser/gpu/objectCollectionBuffer.ts
@@ -32,6 +32,10 @@ export interface IObjectCollectionBuffer<T extends ObjectCollectionBufferPropert
 	 * The size of the used portion of the view (in float32s).
 	 */
 	readonly viewUsedSize: number;
+	/**
+	 * The number of entries in the buffer.
+	 */
+	readonly entryCount: number;
 
 	/**
 	 * Fires when the buffer is modified.
@@ -71,6 +75,9 @@ class ObjectCollectionBuffer<T extends ObjectCollectionBufferPropertySpec[]> ext
 	}
 	get viewUsedSize() {
 		return this._entries.size * this._entrySize;
+	}
+	get entryCount() {
+		return this._entries.size;
 	}
 
 	private readonly _propertySpecsMap: Map<string, ObjectCollectionBufferPropertySpec & { offset: number }> = new Map();

--- a/src/vs/editor/browser/gpu/objectCollectionBuffer.ts
+++ b/src/vs/editor/browser/gpu/objectCollectionBuffer.ts
@@ -94,7 +94,7 @@ class ObjectCollectionBuffer<T extends ObjectCollectionBufferPropertySpec[]> ext
 	) {
 		super();
 
-		this.view = new Float32Array(capacity * 2);
+		this.view = new Float32Array(capacity * propertySpecs.length);
 		this.buffer = this.view.buffer;
 		this._entrySize = propertySpecs.length;
 		for (let i = 0; i < propertySpecs.length; i++) {

--- a/src/vs/editor/browser/gpu/rectangleRenderer.ts
+++ b/src/vs/editor/browser/gpu/rectangleRenderer.ts
@@ -167,9 +167,7 @@ export class RectangleRenderer extends Disposable {
 
 	private _update(): number {
 		this._device.queue.writeBuffer(this._shapeBindBuffer, 0, this._shapeCollection.buffer);
-
-		// TODO: Expose entry size on collection
-		return this._shapeCollection.viewUsedSize / 4;
+		return this._shapeCollection.entryCount;
 	}
 
 	draw(viewportData: ViewportData) {

--- a/src/vs/editor/browser/gpu/rectangleRenderer.ts
+++ b/src/vs/editor/browser/gpu/rectangleRenderer.ts
@@ -15,7 +15,11 @@ export type RectangleRendererEntrySpec = [
 	{ name: 'x' },
 	{ name: 'y' },
 	{ name: 'width' },
-	{ name: 'height' }
+	{ name: 'height' },
+	{ name: 'red' },
+	{ name: 'green' },
+	{ name: 'blue' },
+	{ name: 'alpha' }
 ];
 
 export class RectangleRenderer extends Disposable {
@@ -35,7 +39,11 @@ export class RectangleRenderer extends Disposable {
 		{ name: 'x' },
 		{ name: 'y' },
 		{ name: 'width' },
-		{ name: 'height' }
+		{ name: 'height' },
+		{ name: 'red' },
+		{ name: 'green' },
+		{ name: 'blue' },
+		{ name: 'alpha' }
 	], 32));
 
 	constructor(
@@ -46,7 +54,7 @@ export class RectangleRenderer extends Disposable {
 		super();
 
 		// TODO: Add color
-		this._shapeCollection.createEntry({ x: 200, y: 100, width: 100, height: 25 });
+		this._shapeCollection.createEntry({ x: 200, y: 100, width: 100, height: 25, red: 0, green: 1, blue: 0, alpha: 1 });
 
 		this._initWebgpu(device);
 	}
@@ -200,9 +208,9 @@ export class RectangleRenderer extends Disposable {
 		this._initialized = true;
 	}
 
-	register(x: number, y: number, width: number, height: number): IObjectCollectionBufferEntry<RectangleRendererEntrySpec> {
+	register(x: number, y: number, width: number, height: number, red: number, green: number, blue: number, alpha: number): IObjectCollectionBufferEntry<RectangleRendererEntrySpec> {
 		// TODO: Expand buffer if needed
-		return this._shapeCollection.createEntry({ x, y, width, height });
+		return this._shapeCollection.createEntry({ x, y, width, height, red, green, blue, alpha });
 	}
 
 	private _update(): number {

--- a/src/vs/editor/browser/gpu/rectangleRenderer.ts
+++ b/src/vs/editor/browser/gpu/rectangleRenderer.ts
@@ -53,9 +53,6 @@ export class RectangleRenderer extends Disposable {
 	) {
 		super();
 
-		// TODO: Add color
-		this._shapeCollection.createEntry({ x: 200, y: 100, width: 100, height: 25, red: 0, green: 1, blue: 0, alpha: 1 });
-
 		this._initWebgpu(device);
 	}
 

--- a/src/vs/editor/browser/gpu/rectangleRenderer.ts
+++ b/src/vs/editor/browser/gpu/rectangleRenderer.ts
@@ -214,6 +214,7 @@ export class RectangleRenderer extends Disposable {
 	}
 
 	private _update(): number {
+		// TODO: Only write dirty range
 		this._device.queue.writeBuffer(this._shapeBindBuffer, 0, this._shapeCollection.buffer);
 		return this._shapeCollection.entryCount;
 	}

--- a/src/vs/editor/browser/gpu/rectangleRenderer.ts
+++ b/src/vs/editor/browser/gpu/rectangleRenderer.ts
@@ -21,7 +21,7 @@ export type RectangleRendererEntrySpec = [
 	{ name: 'red' },
 	{ name: 'green' },
 	{ name: 'blue' },
-	{ name: 'alpha' }
+	{ name: 'alpha' },
 ];
 
 export class RectangleRenderer extends Disposable {
@@ -48,7 +48,7 @@ export class RectangleRenderer extends Disposable {
 		{ name: 'red' },
 		{ name: 'green' },
 		{ name: 'blue' },
-		{ name: 'alpha' }
+		{ name: 'alpha' },
 	], 32));
 
 	constructor(
@@ -127,7 +127,7 @@ export class RectangleRenderer extends Disposable {
 
 		const scrollOffsetBufferSize = 2;
 		this._scrollOffsetBindBuffer = this._register(GPULifecycle.createBuffer(this._device, {
-			label: 'Monaco scroll offset buffer',
+			label: 'Monaco rectangle renderer scroll offset buffer',
 			size: scrollOffsetBufferSize * Float32Array.BYTES_PER_ELEMENT,
 			usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
 		})).object;

--- a/src/vs/editor/browser/gpu/rectangleRenderer.ts
+++ b/src/vs/editor/browser/gpu/rectangleRenderer.ts
@@ -1,0 +1,197 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Disposable } from '../../../base/common/lifecycle.js';
+import type { ViewportData } from '../../common/viewLayout/viewLinesViewportData.js';
+import { GPULifecycle } from './gpuDisposable.js';
+import { quadVertices } from './gpuUtils.js';
+import { createObjectCollectionBuffer, type IObjectCollectionBuffer, type IObjectCollectionBufferEntry } from './objectCollectionBuffer.js';
+import { RectangleRendererBindingId, rectangleRendererWgsl } from './rectangleRenderer.wgsl.js';
+
+export type RectangleRendererEntrySpec = [
+	{ name: 'x' },
+	{ name: 'y' },
+	{ name: 'width' },
+	{ name: 'height' }
+];
+
+export class RectangleRenderer extends Disposable {
+
+	private _device!: GPUDevice;
+	private _renderPassDescriptor!: GPURenderPassDescriptor;
+	private _renderPassColorAttachment!: GPURenderPassColorAttachment;
+	private _bindGroup!: GPUBindGroup;
+	private _pipeline!: GPURenderPipeline;
+
+	private _vertexBuffer!: GPUBuffer;
+	private _shapeBindBuffer!: GPUBuffer;
+
+	private _initialized: boolean = false;
+
+	private readonly _shapeCollection: IObjectCollectionBuffer<RectangleRendererEntrySpec> = this._register(createObjectCollectionBuffer([
+		{ name: 'x' },
+		{ name: 'y' },
+		{ name: 'width' },
+		{ name: 'height' }
+	], 32));
+
+	constructor(
+		private readonly _ctx: GPUCanvasContext,
+		device: Promise<GPUDevice>,
+	) {
+		super();
+
+		// TODO: Add color
+		this._shapeCollection.createEntry({ x: -0.2, y: 0.1, width: 0.25, height: -0.5 });
+
+		this._initWebgpu(device);
+	}
+
+	private async _initWebgpu(device: Promise<GPUDevice>) {
+
+		// #region General
+
+		this._device = await device;
+
+		if (this._store.isDisposed) {
+			return;
+		}
+
+		const presentationFormat = navigator.gpu.getPreferredCanvasFormat();
+		this._ctx.configure({
+			device: this._device,
+			format: presentationFormat,
+			alphaMode: 'premultiplied',
+		});
+
+		this._renderPassColorAttachment = {
+			view: null!, // Will be filled at render time
+			loadOp: 'load',
+			storeOp: 'store',
+		};
+		this._renderPassDescriptor = {
+			label: 'Monaco rectangle renderer render pass',
+			colorAttachments: [this._renderPassColorAttachment],
+		};
+
+		// #endregion General
+
+		// #region Storage buffers
+
+		this._shapeBindBuffer = this._register(GPULifecycle.createBuffer(this._device, {
+			label: 'Monaco rectangle renderer shape buffer',
+			size: this._shapeCollection.buffer.byteLength,
+			usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
+		})).object;
+
+		// #endregion Storage buffers
+
+		// #region Vertex buffer
+
+		this._vertexBuffer = this._register(GPULifecycle.createBuffer(this._device, {
+			label: 'Monaco rectangle renderer vertex buffer',
+			size: quadVertices.byteLength,
+			usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST,
+		}, quadVertices)).object;
+
+		// #endregion Vertex buffer
+
+		// #region Shader module
+
+		const module = this._device.createShaderModule({
+			label: 'Monaco rectangle renderer shader module',
+			code: rectangleRendererWgsl,
+		});
+
+		// #endregion Shader module
+
+		// #region Pipeline
+
+		this._pipeline = this._device.createRenderPipeline({
+			label: 'Monaco rectangle renderer render pipeline',
+			layout: 'auto',
+			vertex: {
+				module,
+				buffers: [
+					{
+						arrayStride: 2 * Float32Array.BYTES_PER_ELEMENT, // 2 floats, 4 bytes each
+						attributes: [
+							{ shaderLocation: 0, offset: 0, format: 'float32x2' },  // position
+						],
+					}
+				]
+			},
+			fragment: {
+				module,
+				targets: [
+					{
+						format: presentationFormat,
+						blend: {
+							color: {
+								srcFactor: 'src-alpha',
+								dstFactor: 'one-minus-src-alpha'
+							},
+							alpha: {
+								srcFactor: 'src-alpha',
+								dstFactor: 'one-minus-src-alpha'
+							},
+						},
+					}
+				],
+			},
+		});
+
+		// #endregion Pipeline
+
+		// #region Bind group
+
+		this._bindGroup = this._device.createBindGroup({
+			label: 'Monaco rectangle renderer bind group',
+			layout: this._pipeline.getBindGroupLayout(0),
+			entries: [
+				{ binding: RectangleRendererBindingId.Shapes, resource: { buffer: this._shapeBindBuffer } },
+			],
+		});
+
+		// endregion Bind group
+
+		this._initialized = true;
+	}
+
+	register(x: number, y: number, width: number, height: number): IObjectCollectionBufferEntry<RectangleRendererEntrySpec> {
+		// TODO: Expand buffer if needed
+		return this._shapeCollection.createEntry({ x, y, width, height });
+	}
+
+	private _update(): number {
+		this._device.queue.writeBuffer(this._shapeBindBuffer, 0, this._shapeCollection.buffer);
+
+		// TODO: Expose entry size on collection
+		return this._shapeCollection.viewUsedSize / 4;
+	}
+
+	draw(viewportData: ViewportData) {
+		if (!this._initialized) {
+			return;
+		}
+
+		const visibleObjectCount = this._update();
+		console.log('draw rectangle count', visibleObjectCount);
+
+		const encoder = this._device.createCommandEncoder({ label: 'our encoder' });
+
+		this._renderPassColorAttachment.view = this._ctx.getCurrentTexture().createView();
+		const pass = encoder.beginRenderPass(this._renderPassDescriptor);
+		pass.setPipeline(this._pipeline);
+		pass.setVertexBuffer(0, this._vertexBuffer);
+		pass.setBindGroup(0, this._bindGroup);
+
+		pass.draw(quadVertices.length / 2, visibleObjectCount);
+		pass.end();
+
+		const commandBuffer = encoder.finish();
+		this._device.queue.submit([commandBuffer]);
+	}
+}

--- a/src/vs/editor/browser/gpu/rectangleRenderer.wgsl.ts
+++ b/src/vs/editor/browser/gpu/rectangleRenderer.wgsl.ts
@@ -22,7 +22,13 @@ struct LayoutInfo {
 
 struct Shape {
 	position: vec2f,
-	size: vec2f
+	size: vec2f,
+	color: vec4f,
+};
+
+struct VSOutput {
+	@builtin(position) position: vec4f,
+	@location(1)       color:    vec4f,
 };
 
 // Uniforms
@@ -35,10 +41,11 @@ struct Shape {
 	vert: Vertex,
 	@builtin(instance_index) instanceIndex: u32,
 	@builtin(vertex_index) vertexIndex : u32
-) -> @builtin(position) vec4f {
+) -> VSOutput {
 	let shape = shapes[instanceIndex];
 
-	return vec4f(
+	var vsOut: VSOutput;
+	vsOut.position = vec4f(
 		(
 			// Top left corner
 			vec2f(-1, 1) +
@@ -50,9 +57,11 @@ struct Shape {
 		0.0,
 		1.0
 	);
+	vsOut.color = shape.color;
+	return vsOut;
 }
 
-@fragment fn fs() -> @location(0) vec4f {
-	return vec4(1, 0, 0, 1);
+@fragment fn fs(vsOut: VSOutput) -> @location(0) vec4f {
+	return vsOut.color;
 }
 `;

--- a/src/vs/editor/browser/gpu/rectangleRenderer.wgsl.ts
+++ b/src/vs/editor/browser/gpu/rectangleRenderer.wgsl.ts
@@ -48,14 +48,11 @@ struct VSOutput {
 	vsOut.position = vec4f(
 		(
 			// Top left corner
-			vec2f(-1, 1) +
+			vec2f(-1,  1) +
 			// Convert pixel position to clipspace
-			vec2f(2, -2) * (
-				// Shape position
-				(shape.position) / layoutInfo.canvasDims +
-				// Shape size
-				((vert.position) / layoutInfo.canvasDims) * shape.size
-			)
+			vec2f( 2, -2) / layoutInfo.canvasDims *
+			// Shape position and size
+			(shape.position + vert.position * shape.size)
 		),
 		0.0,
 		1.0

--- a/src/vs/editor/browser/gpu/rectangleRenderer.wgsl.ts
+++ b/src/vs/editor/browser/gpu/rectangleRenderer.wgsl.ts
@@ -22,7 +22,7 @@ struct LayoutInfo {
 }
 
 struct ScrollOffset {
-	offset: vec2f
+	offset: vec2f,
 }
 
 struct Shape {

--- a/src/vs/editor/browser/gpu/rectangleRenderer.wgsl.ts
+++ b/src/vs/editor/browser/gpu/rectangleRenderer.wgsl.ts
@@ -1,0 +1,39 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+export const enum RectangleRendererBindingId {
+	Shapes
+}
+
+export const rectangleRendererWgsl = /*wgsl*/ `
+
+struct Vertex {
+	@location(0) position: vec2f,
+};
+
+struct Shape {
+	position: vec2f,
+	size: vec2f
+};
+
+@group(0) @binding(${RectangleRendererBindingId.Shapes}) var<storage, read> shapes: array<Shape>;
+
+@vertex fn vs(
+	vert: Vertex,
+	@builtin(instance_index) instanceIndex: u32,
+	@builtin(vertex_index) vertexIndex : u32
+) -> @builtin(position) vec4f {
+	let shape = shapes[instanceIndex];
+	return vec4f(
+		(vert.position + shape.position) * shape.size,
+		0.0,
+		1.0
+	);
+}
+
+@fragment fn fs() -> @location(0) vec4f {
+	return vec4(1, 0, 0, 1);
+}
+`;

--- a/src/vs/editor/browser/gpu/rectangleRenderer.wgsl.ts
+++ b/src/vs/editor/browser/gpu/rectangleRenderer.wgsl.ts
@@ -49,10 +49,13 @@ struct VSOutput {
 		(
 			// Top left corner
 			vec2f(-1, 1) +
-			// Shape position
-			(shape.position * vec2f(2, -2)) / layoutInfo.canvasDims +
-			// Shape size
-			((vert.position * vec2f(2, -2)) / layoutInfo.canvasDims) * shape.size
+			// Convert pixel position to clipspace
+			vec2f(2, -2) * (
+				// Shape position
+				(shape.position) / layoutInfo.canvasDims +
+				// Shape size
+				((vert.position) / layoutInfo.canvasDims) * shape.size
+			)
 		),
 		0.0,
 		1.0

--- a/src/vs/editor/browser/gpu/rectangleRenderer.wgsl.ts
+++ b/src/vs/editor/browser/gpu/rectangleRenderer.wgsl.ts
@@ -6,6 +6,7 @@
 export const enum RectangleRendererBindingId {
 	Shapes,
 	LayoutInfoUniform,
+	ScrollOffset,
 }
 
 export const rectangleRendererWgsl = /*wgsl*/ `
@@ -18,6 +19,10 @@ struct LayoutInfo {
 	canvasDims: vec2f,
 	viewportOffset: vec2f,
 	viewportDims: vec2f,
+}
+
+struct ScrollOffset {
+	offset: vec2f
 }
 
 struct Shape {
@@ -36,6 +41,7 @@ struct VSOutput {
 
 // Storage buffers
 @group(0) @binding(${RectangleRendererBindingId.Shapes})            var<storage, read> shapes:          array<Shape>;
+@group(0) @binding(${RectangleRendererBindingId.ScrollOffset})      var<uniform>       scrollOffset:    ScrollOffset;
 
 @vertex fn vs(
 	vert: Vertex,
@@ -52,7 +58,7 @@ struct VSOutput {
 			// Convert pixel position to clipspace
 			vec2f( 2, -2) / layoutInfo.canvasDims *
 			// Shape position and size
-			(layoutInfo.viewportOffset + shape.position + vert.position * shape.size)
+			(layoutInfo.viewportOffset - scrollOffset.offset + shape.position + vert.position * shape.size)
 		),
 		0.0,
 		1.0

--- a/src/vs/editor/browser/gpu/rectangleRenderer.wgsl.ts
+++ b/src/vs/editor/browser/gpu/rectangleRenderer.wgsl.ts
@@ -52,7 +52,7 @@ struct VSOutput {
 			// Convert pixel position to clipspace
 			vec2f( 2, -2) / layoutInfo.canvasDims *
 			// Shape position and size
-			(shape.position + vert.position * shape.size)
+			(layoutInfo.viewportOffset + shape.position + vert.position * shape.size)
 		),
 		0.0,
 		1.0

--- a/src/vs/editor/browser/gpu/viewGpuContext.ts
+++ b/src/vs/editor/browser/gpu/viewGpuContext.ts
@@ -18,6 +18,7 @@ import { INotificationService, IPromptChoice, Severity } from '../../../platform
 import { GPULifecycle } from './gpuDisposable.js';
 import { ensureNonNullable, observeDevicePixelDimensions } from './gpuUtils.js';
 import { RectangleRenderer } from './rectangleRenderer.js';
+import type { ViewContext } from '../../common/viewModel/viewContext.js';
 
 export class ViewGpuContext extends Disposable {
 	readonly canvas: FastDomNode<HTMLCanvasElement>;
@@ -55,6 +56,7 @@ export class ViewGpuContext extends Disposable {
 	readonly devicePixelRatio: IObservable<number>;
 
 	constructor(
+		context: ViewContext,
 		@IInstantiationService private readonly _instantiationService: IInstantiationService,
 		@INotificationService private readonly _notificationService: INotificationService,
 		@IConfigurationService private readonly configurationService: IConfigurationService,
@@ -80,7 +82,7 @@ export class ViewGpuContext extends Disposable {
 			}
 		});
 
-		this.rectangleRenderer = this._instantiationService.createInstance(RectangleRenderer, this.canvas.domNode, this.ctx, this.device);
+		this.rectangleRenderer = this._instantiationService.createInstance(RectangleRenderer, context, this.canvas.domNode, this.ctx, this.device);
 
 		const dprObs = observableValue(this, getActiveWindow().devicePixelRatio);
 		this._register(addDisposableListener(getActiveWindow(), 'resize', () => {

--- a/src/vs/editor/browser/gpu/viewGpuContext.ts
+++ b/src/vs/editor/browser/gpu/viewGpuContext.ts
@@ -80,7 +80,7 @@ export class ViewGpuContext extends Disposable {
 			}
 		});
 
-		this.rectangleRenderer = this._instantiationService.createInstance(RectangleRenderer, this.ctx, this.device);
+		this.rectangleRenderer = this._instantiationService.createInstance(RectangleRenderer, this.canvas.domNode, this.ctx, this.device);
 
 		const dprObs = observableValue(this, getActiveWindow().devicePixelRatio);
 		this._register(addDisposableListener(getActiveWindow(), 'resize', () => {

--- a/src/vs/editor/browser/gpu/viewGpuContext.ts
+++ b/src/vs/editor/browser/gpu/viewGpuContext.ts
@@ -17,6 +17,7 @@ import { IConfigurationService } from '../../../platform/configuration/common/co
 import { INotificationService, IPromptChoice, Severity } from '../../../platform/notification/common/notification.js';
 import { GPULifecycle } from './gpuDisposable.js';
 import { ensureNonNullable, observeDevicePixelDimensions } from './gpuUtils.js';
+import { RectangleRenderer } from './rectangleRenderer.js';
 
 export class ViewGpuContext extends Disposable {
 	readonly canvas: FastDomNode<HTMLCanvasElement>;
@@ -24,7 +25,10 @@ export class ViewGpuContext extends Disposable {
 
 	readonly device: Promise<GPUDevice>;
 
+	readonly rectangleRenderer: RectangleRenderer;
+
 	private static _atlas: TextureAtlas | undefined;
+
 
 	/**
 	 * The shared texture atlas to use across all views.
@@ -75,6 +79,8 @@ export class ViewGpuContext extends Disposable {
 				runOnChange(this.devicePixelRatio, () => ViewGpuContext.atlas.clear());
 			}
 		});
+
+		this.rectangleRenderer = this._instantiationService.createInstance(RectangleRenderer, this.ctx, this.device);
 
 		const dprObs = observableValue(this, getActiveWindow().devicePixelRatio);
 		this._register(addDisposableListener(getActiveWindow(), 'resize', () => {

--- a/src/vs/editor/browser/view.ts
+++ b/src/vs/editor/browser/view.ts
@@ -60,6 +60,7 @@ import { ViewLinesGpu } from './viewParts/viewLinesGpu/viewLinesGpu.js';
 import { AbstractEditContext } from './controller/editContext/editContextUtils.js';
 import { IVisibleRangeProvider, TextAreaEditContext } from './controller/editContext/textArea/textAreaEditContext.js';
 import { NativeEditContext } from './controller/editContext/native/nativeEditContext.js';
+import { RulersGpu } from './viewParts/rulersGpu/rulersGpu.js';
 
 
 export interface IContentWidgetData {
@@ -214,7 +215,9 @@ export class View extends ViewEventHandler {
 		this._overlayWidgets = new ViewOverlayWidgets(this._context, this.domNode);
 		this._viewParts.push(this._overlayWidgets);
 
-		const rulers = new Rulers(this._context);
+		const rulers = this._viewGpuContext
+			? new RulersGpu(this._context, this._viewGpuContext)
+			: new Rulers(this._context);
 		this._viewParts.push(rulers);
 
 		const blockOutline = new BlockDecorations(this._context);
@@ -231,7 +234,9 @@ export class View extends ViewEventHandler {
 		}
 
 		this._linesContent.appendChild(contentViewOverlays.getDomNode());
-		this._linesContent.appendChild(rulers.domNode);
+		if ('domNode' in rulers) {
+			this._linesContent.appendChild(rulers.domNode);
+		}
 		this._linesContent.appendChild(this._viewZones.domNode);
 		this._linesContent.appendChild(this._viewLines.getDomNode());
 		this._linesContent.appendChild(this._contentWidgets.domNode);

--- a/src/vs/editor/browser/view.ts
+++ b/src/vs/editor/browser/view.ts
@@ -151,7 +151,7 @@ export class View extends ViewEventHandler {
 		this.domNode.setAttribute('role', 'code');
 
 		if (this._context.configuration.options.get(EditorOption.experimentalGpuAcceleration) === 'on') {
-			this._viewGpuContext = this._instantiationService.createInstance(ViewGpuContext);
+			this._viewGpuContext = this._instantiationService.createInstance(ViewGpuContext, this._context);
 		}
 
 		this._overflowGuardContainer = createFastDomNode(document.createElement('div'));

--- a/src/vs/editor/browser/viewParts/rulersGpu/rulersGpu.ts
+++ b/src/vs/editor/browser/viewParts/rulersGpu/rulersGpu.ts
@@ -58,11 +58,10 @@ export class RulersGpu extends ViewPart {
 			const shape = this._gpuShapes[i];
 			const color = ruler.color ? Color.fromHex(ruler.color) : this._context.theme.getColor(editorRuler) ?? Color.white;
 			const rulerData = [
-				// TODO: The x should be relative to the left side of the viewport
 				ruler.column * typicalHalfwidthCharacterWidth * devicePixelRatio,
 				0,
 				Math.max(1, Math.ceil(devicePixelRatio)),
-				this._viewGpuContext.canvasDevicePixelDimensions.read(reader).height,
+				Number.MAX_SAFE_INTEGER,
 				color.rgba.r / 255,
 				color.rgba.g / 255,
 				color.rgba.b / 255,

--- a/src/vs/editor/browser/viewParts/rulersGpu/rulersGpu.ts
+++ b/src/vs/editor/browser/viewParts/rulersGpu/rulersGpu.ts
@@ -1,0 +1,90 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { ViewPart } from '../../view/viewPart.js';
+import { RenderingContext, RestrictedRenderingContext } from '../../view/renderingContext.js';
+import { ViewContext } from '../../../common/viewModel/viewContext.js';
+import * as viewEvents from '../../../common/viewEvents.js';
+import { EditorOption, IRulerOption } from '../../../common/config/editorOptions.js';
+import type { ViewGpuContext } from '../../gpu/viewGpuContext.js';
+import type { IObjectCollectionBufferEntry } from '../../gpu/objectCollectionBuffer.js';
+import type { RectangleRendererEntrySpec } from '../../gpu/rectangleRenderer.js';
+
+/**
+ * Rulers are vertical lines that appear at certain columns in the editor. There can be >= 0 rulers
+ * at a time.
+ */
+export class RulersGpu extends ViewPart {
+
+	private readonly _gpuShapes: IObjectCollectionBufferEntry<RectangleRendererEntrySpec>[] = [];
+	private _rulers: IRulerOption[];
+	private _typicalHalfwidthCharacterWidth: number;
+
+	constructor(
+		context: ViewContext,
+		private readonly _viewGpuContext: ViewGpuContext
+	) {
+		super(context);
+		const options = this._context.configuration.options;
+		this._rulers = options.get(EditorOption.rulers);
+		this._typicalHalfwidthCharacterWidth = options.get(EditorOption.fontInfo).typicalHalfwidthCharacterWidth;
+	}
+
+	// --- begin event handlers
+
+	public override onConfigurationChanged(e: viewEvents.ViewConfigurationChangedEvent): boolean {
+		const options = this._context.configuration.options;
+		this._rulers = options.get(EditorOption.rulers);
+		this._typicalHalfwidthCharacterWidth = options.get(EditorOption.fontInfo).typicalHalfwidthCharacterWidth;
+		return true;
+	}
+	public override onScrollChanged(e: viewEvents.ViewScrollChangedEvent): boolean {
+		return e.scrollHeightChanged;
+	}
+
+	// --- end event handlers
+
+	public prepareRender(ctx: RenderingContext): void {
+		// Nothing to read
+	}
+
+	public render(ctx: RestrictedRenderingContext): void {
+		for (let i = 0, len = this._rulers.length; i < len; i++) {
+			const ruler = this._rulers[i];
+			const shape = this._gpuShapes[i];
+			const rulerData = this._getRulerData(ruler);
+			if (!shape) {
+				this._gpuShapes[i] = this._viewGpuContext.rectangleRenderer.register(...rulerData);
+			} else {
+				// TODO: Setting ruler data directly would be nicer (eg. `shape.setData(rulerData)`)
+				shape.set('x', rulerData[0]);
+				shape.set('y', rulerData[1]);
+				shape.set('width', rulerData[2]);
+				shape.set('height', rulerData[3]);
+				shape.set('red', rulerData[4]);
+				shape.set('green', rulerData[5]);
+				shape.set('blue', rulerData[6]);
+				shape.set('alpha', rulerData[7]);
+			}
+		}
+		while (this._gpuShapes.length > this._rulers.length) {
+			this._gpuShapes.splice(-1, 1)[0].dispose();
+		}
+	}
+
+	private _getRulerData(ruler: IRulerOption): [number, number, number, number, number, number, number, number] {
+		return [
+			// TODO: The x should be relative to the left side of the viewport
+			ruler.column * this._typicalHalfwidthCharacterWidth * this._viewGpuContext.devicePixelRatio.get(),
+			0,
+			1,
+			this._viewGpuContext.canvasDevicePixelDimensions.get().height,
+			1,
+			0,
+			0,
+			1
+		];
+	}
+}

--- a/src/vs/editor/browser/viewParts/rulersGpu/rulersGpu.ts
+++ b/src/vs/editor/browser/viewParts/rulersGpu/rulersGpu.ts
@@ -11,6 +11,8 @@ import { EditorOption, IRulerOption } from '../../../common/config/editorOptions
 import type { ViewGpuContext } from '../../gpu/viewGpuContext.js';
 import type { IObjectCollectionBufferEntry } from '../../gpu/objectCollectionBuffer.js';
 import type { RectangleRendererEntrySpec } from '../../gpu/rectangleRenderer.js';
+import { Color } from '../../../../base/common/color.js';
+import { editorRuler } from '../../../common/core/editorColorRegistry.js';
 
 /**
  * Rulers are vertical lines that appear at certain columns in the editor. There can be >= 0 rulers
@@ -51,6 +53,7 @@ export class RulersGpu extends ViewPart {
 	}
 
 	public render(ctx: RestrictedRenderingContext): void {
+		// TODO: Shapes live across renders, we should only do this when the rulers have changed
 		for (let i = 0, len = this._rulers.length; i < len; i++) {
 			const ruler = this._rulers[i];
 			const shape = this._gpuShapes[i];
@@ -75,16 +78,17 @@ export class RulersGpu extends ViewPart {
 	}
 
 	private _getRulerData(ruler: IRulerOption): [number, number, number, number, number, number, number, number] {
+		const color = ruler.color ? Color.fromHex(ruler.color) : this._context.theme.getColor(editorRuler) ?? Color.white;
 		return [
 			// TODO: The x should be relative to the left side of the viewport
 			ruler.column * this._typicalHalfwidthCharacterWidth * this._viewGpuContext.devicePixelRatio.get(),
 			0,
-			1,
+			Math.max(1, Math.ceil(this._viewGpuContext.devicePixelRatio.get())),
 			this._viewGpuContext.canvasDevicePixelDimensions.get().height,
-			1,
-			0,
-			0,
-			1
+			color.rgba.r / 255,
+			color.rgba.g / 255,
+			color.rgba.b / 255,
+			color.rgba.a,
 		];
 	}
 }

--- a/src/vs/editor/browser/viewParts/viewLinesGpu/viewLinesGpu.ts
+++ b/src/vs/editor/browser/viewParts/viewLinesGpu/viewLinesGpu.ts
@@ -271,7 +271,7 @@ export class ViewLinesGpu extends ViewPart {
 					})
 				},
 				{ binding: BindingId.Texture, resource: this._atlasGpuTexture.createView() },
-				{ binding: BindingId.ViewportUniform, resource: { buffer: layoutInfoUniformBuffer } },
+				{ binding: BindingId.LayoutInfoUniform, resource: { buffer: layoutInfoUniformBuffer } },
 				{ binding: BindingId.AtlasDimensionsUniform, resource: { buffer: atlasInfoUniformBuffer } },
 				...this._renderStrategy.bindGroupEntries
 			],

--- a/src/vs/editor/browser/viewParts/viewLinesGpu/viewLinesGpu.ts
+++ b/src/vs/editor/browser/viewParts/viewLinesGpu/viewLinesGpu.ts
@@ -223,7 +223,6 @@ export class ViewLinesGpu extends ViewPart {
 			layout: 'auto',
 			vertex: {
 				module,
-				entryPoint: 'vs',
 				buffers: [
 					{
 						arrayStride: 2 * Float32Array.BYTES_PER_ELEMENT, // 2 floats, 4 bytes each
@@ -235,7 +234,6 @@ export class ViewLinesGpu extends ViewPart {
 			},
 			fragment: {
 				module,
-				entryPoint: 'fs',
 				targets: [
 					{
 						format: presentationFormat,
@@ -362,6 +360,8 @@ export class ViewLinesGpu extends ViewPart {
 	}
 
 	private _renderText(viewportData: ViewportData): void {
+		this._viewGpuContext.rectangleRenderer.draw(viewportData);
+
 		const options = new ViewLineOptions(this._context.configuration, this._context.theme.type);
 
 		const visibleObjectCount = this._renderStrategy.update(viewportData, options);

--- a/src/vs/editor/test/browser/view/gpu/objectCollectionBuffer.test.ts
+++ b/src/vs/editor/test/browser/view/gpu/objectCollectionBuffer.test.ts
@@ -54,6 +54,28 @@ suite('ObjectCollectionBuffer', () => {
 		assertUsedData(buffer, [1, 2, 5, 6, 9, 10]);
 	});
 
+	test('entryCount, viewUsedSize, bufferUsedSize', () => {
+		const buffer = store.add(createObjectCollectionBuffer([
+			{ name: 'foo' },
+			{ name: 'bar' },
+		] as const, 5));
+		strictEqual(buffer.entryCount, 0);
+		strictEqual(buffer.bufferUsedSize, 0);
+		strictEqual(buffer.viewUsedSize, 0);
+		buffer.createEntry({ foo: 1, bar: 2 });
+		strictEqual(buffer.entryCount, 1);
+		strictEqual(buffer.viewUsedSize, 2);
+		strictEqual(buffer.bufferUsedSize, 8);
+		const entry = buffer.createEntry({ foo: 3, bar: 4 });
+		strictEqual(buffer.entryCount, 2);
+		strictEqual(buffer.viewUsedSize, 4);
+		strictEqual(buffer.bufferUsedSize, 16);
+		entry.dispose();
+		strictEqual(buffer.entryCount, 1);
+		strictEqual(buffer.viewUsedSize, 2);
+		strictEqual(buffer.bufferUsedSize, 8);
+	});
+
 	test('entry.get', () => {
 		const buffer = store.add(createObjectCollectionBuffer([
 			{ name: 'foo' },


### PR DESCRIPTION
Fixes #221211

Also respects scroll left for character rendering.

```json
  "editor.rulers": [
    { "column": 80, "color": "#ff7777" },
    { "column": 81, "color": "#77ff77" },
    { "column": 82, "color": "#7777ff" },
    100,
    120
  ],
```
![image](https://github.com/user-attachments/assets/24698680-7e29-419a-8441-a6255c359727)
