### PR TITLE
Set input of relay of splice

### DIFF
--- a/src/vs/base/browser/ui/tree/abstractTree.ts
+++ b/src/vs/base/browser/ui/tree/abstractTree.ts
@@ -578,7 +578,14 @@ export class TreeRenderer<T, TFilterData, TRef, TTemplateData> implements IListR
 
 export type LabelFuzzyScore = { label: string; score: FuzzyScore };
 
-class FindFilter<T> implements ITreeFilter<T, FuzzyScore | LabelFuzzyScore>, IDisposable {
+export interface IFindFilter<T> extends ITreeFilter<T, FuzzyScore | LabelFuzzyScore> {
+	filter(element: T, parentVisibility: TreeVisibility): TreeFilterResult<FuzzyScore | LabelFuzzyScore>;
+	pattern: string;
+	totalCount: number;
+	matchCount: number;
+}
+
+class FindFilter<T> implements IFindFilter<T>, IDisposable {
 	private _totalCount = 0;
 	get totalCount(): number { return this._totalCount; }
 	private _matchCount = 0;
@@ -979,12 +986,16 @@ enum DefaultTreeToggles {
 	MatchType = 'matchType',
 }
 
-interface IFindControllerOptions extends IFindWidgetOptions {
+interface IAbstractFindControllerOptions extends IFindWidgetOptions {
+	placeholder?: string;
+}
+
+interface IFindControllerOptions extends IAbstractFindControllerOptions {
 	defaultFindMode?: TreeFindMode;
 	defaultFindMatchType?: TreeFindMatchType;
 }
 
-class FindController<T, TFilterData> implements IDisposable {
+export abstract class AbstractFindController<T, TFilterData> implements IDisposable {
 
 	private _history: string[] | undefined;
 
@@ -992,69 +1003,17 @@ class FindController<T, TFilterData> implements IDisposable {
 	get pattern(): string { return this._pattern; }
 	private previousPattern = '';
 
-	get toggles(): ITreeFindToggleContribution[] {
-		return [{
-			id: DefaultTreeToggles.Mode,
-			icon: Codicon.listFilter,
-			title: localize('filter', "Filter"),
-			isChecked: this.mode === TreeFindMode.Filter,
-		}, {
-			id: DefaultTreeToggles.MatchType,
-			icon: Codicon.searchFuzzy,
-			title: localize('fuzzySearch', "Fuzzy Match"),
-			isChecked: this.matchType === TreeFindMatchType.Fuzzy,
-		}];
-	}
+	protected abstract toggles: ITreeFindToggleContribution[];
 
-	get placeholder(): string {
-		return this.mode === TreeFindMode.Filter ? localize('type to filter', "Type to filter") : localize('type to search', "Type to search");
-	}
-
-	private _mode: TreeFindMode;
-	get mode(): TreeFindMode { return this._mode; }
-	set mode(mode: TreeFindMode) {
-		if (mode === this._mode) {
-			return;
-		}
-
-		this._mode = mode;
-
-		if (this.widget) {
-			this.widget.setToggleState(DefaultTreeToggles.Mode, mode === TreeFindMode.Filter);
-			this.widget.setPlaceHolder(this.placeholder);
-		}
-
-		this.tree.refilter();
-		this.render();
-		this._onDidChangeMode.fire(mode);
-	}
-
-	private _matchType: TreeFindMatchType;
-	get matchType(): TreeFindMatchType { return this._matchType; }
-	set matchType(matchType: TreeFindMatchType) {
-		if (matchType === this._matchType) {
-			return;
-		}
-
-		this._matchType = matchType;
-
-		if (this.widget) {
-			this.widget.setToggleState(DefaultTreeToggles.MatchType, matchType === TreeFindMatchType.Fuzzy);
-		}
-
-		this.tree.refilter();
-		this.render();
-		this._onDidChangeMatchType.fire(matchType);
+	private _placeholder: string;
+	protected get placeholder(): string { return this._placeholder; }
+	protected set placeholder(value: string) {
+		this._placeholder = value;
+		this.widget?.setPlaceHolder(value);
 	}
 
 	private widget: FindWidget<T, TFilterData> | undefined;
 	private width = 0;
-
-	private readonly _onDidChangeMode = new Emitter<TreeFindMode>();
-	readonly onDidChangeMode = this._onDidChangeMode.event;
-
-	private readonly _onDidChangeMatchType = new Emitter<TreeFindMatchType>();
-	readonly onDidChangeMatchType = this._onDidChangeMatchType.event;
 
 	private readonly _onDidChangePattern = new Emitter<string>();
 	readonly onDidChangePattern = this._onDidChangePattern.event;
@@ -1066,23 +1025,12 @@ class FindController<T, TFilterData> implements IDisposable {
 	private readonly disposables = new DisposableStore();
 
 	constructor(
-		private tree: AbstractTree<T, TFilterData, any>,
-		private filter: FindFilter<T>,
-		private readonly contextViewProvider: IContextViewProvider,
-		private readonly options: IFindControllerOptions = {}
+		protected tree: AbstractTree<T, TFilterData, any>,
+		protected filter: IFindFilter<T>,
+		protected readonly contextViewProvider: IContextViewProvider,
+		protected readonly options: IAbstractFindControllerOptions = {}
 	) {
-		this._mode = options.defaultFindMode ?? TreeFindMode.Highlight;
-		this._matchType = options.defaultFindMatchType ?? TreeFindMatchType.Fuzzy;
-	}
-
-	updateOptions(optionsUpdate: IAbstractTreeOptionsUpdate = {}): void {
-		if (optionsUpdate.defaultFindMode !== undefined) {
-			this.mode = optionsUpdate.defaultFindMode;
-		}
-
-		if (optionsUpdate.defaultFindMatchType !== undefined) {
-			this.matchType = optionsUpdate.defaultFindMatchType;
-		}
+		this._placeholder = options.placeholder ?? localize('type to search', "Type to search");
 	}
 
 	isOpened(): boolean {
@@ -1129,11 +1077,132 @@ class FindController<T, TFilterData> implements IDisposable {
 		this._onDidChangeOpenState.fire(false);
 	}
 
-	private onDidChangeValue(pattern: string): void {
+	protected onDidChangeValue(pattern: string): void {
 		this._pattern = pattern;
 		this._onDidChangePattern.fire(pattern);
 
 		this.filter.pattern = pattern;
+		this.applyPattern(pattern);
+	}
+
+	protected abstract applyPattern(pattern: string): void;
+
+	protected onDidToggleChange(e: ITreeFindToggleChangeEvent): void {
+		// Subclasses can override
+	}
+
+	protected setToggleState(id: string, checked: boolean): void {
+		this.widget?.setToggleState(id, checked);
+	}
+
+	render(): void {
+		const noMatches = this.filter.matchCount === 0 && this.filter.totalCount > 0;
+
+		if (this.pattern && noMatches) {
+			alert(localize('replFindNoResults', "No results"));
+			if (this.tree.options.showNotFoundMessage ?? true) {
+				this.widget?.showMessage({ type: MessageType.WARNING, content: localize('not found', "No elements found.") });
+			} else {
+				this.widget?.showMessage({ type: MessageType.WARNING });
+			}
+		} else {
+			this.widget?.clearMessage();
+			if (this.pattern) {
+				alert(localize('replFindResults', "{0} results", this.filter.matchCount));
+			}
+		}
+	}
+
+	layout(width: number): void {
+		this.width = width;
+		this.widget?.layout(width);
+	}
+
+	dispose() {
+		this._history = undefined;
+		this._onDidChangePattern.dispose();
+		this.enabledDisposables.dispose();
+		this.disposables.dispose();
+	}
+}
+
+class FindController<T, TFilterData> extends AbstractFindController<T, TFilterData> {
+
+	get toggles(): ITreeFindToggleContribution[] {
+		return [{
+			id: DefaultTreeToggles.Mode,
+			icon: Codicon.listFilter,
+			title: localize('filter', "Filter"),
+			isChecked: this.mode === TreeFindMode.Filter,
+		}, {
+			id: DefaultTreeToggles.MatchType,
+			icon: Codicon.searchFuzzy,
+			title: localize('fuzzySearch', "Fuzzy Match"),
+			isChecked: this.matchType === TreeFindMatchType.Fuzzy,
+		}];
+	}
+
+	private _mode: TreeFindMode;
+	get mode(): TreeFindMode { return this._mode; }
+	set mode(mode: TreeFindMode) {
+		if (mode === this._mode) {
+			return;
+		}
+
+		this._mode = mode;
+
+		this.setToggleState(DefaultTreeToggles.Mode, mode === TreeFindMode.Filter);
+		this.placeholder = this.mode === TreeFindMode.Filter ? localize('type to filter', "Type to filter") : localize('type to search', "Type to search");
+
+		this.tree.refilter();
+		this.render();
+		this._onDidChangeMode.fire(mode);
+	}
+
+	private _matchType: TreeFindMatchType;
+	get matchType(): TreeFindMatchType { return this._matchType; }
+	set matchType(matchType: TreeFindMatchType) {
+		if (matchType === this._matchType) {
+			return;
+		}
+
+		this._matchType = matchType;
+
+		this.setToggleState(DefaultTreeToggles.MatchType, matchType === TreeFindMatchType.Fuzzy);
+
+		this.tree.refilter();
+		this.render();
+		this._onDidChangeMatchType.fire(matchType);
+	}
+
+	private readonly _onDidChangeMode = new Emitter<TreeFindMode>();
+	readonly onDidChangeMode = this._onDidChangeMode.event;
+
+	private readonly _onDidChangeMatchType = new Emitter<TreeFindMatchType>();
+	readonly onDidChangeMatchType = this._onDidChangeMatchType.event;
+
+	constructor(
+		tree: AbstractTree<T, TFilterData, any>,
+		filter: IFindFilter<T>,
+		contextViewProvider: IContextViewProvider,
+		options: IFindControllerOptions = {}
+	) {
+		super(tree, filter, contextViewProvider, options);
+		this._mode = options.defaultFindMode ?? TreeFindMode.Highlight;
+		this._matchType = options.defaultFindMatchType ?? TreeFindMatchType.Fuzzy;
+	}
+
+	updateOptions(optionsUpdate: IAbstractTreeOptionsUpdate = {}): void {
+		if (optionsUpdate.defaultFindMode !== undefined) {
+			this.mode = optionsUpdate.defaultFindMode;
+		}
+
+		if (optionsUpdate.defaultFindMatchType !== undefined) {
+			this.matchType = optionsUpdate.defaultFindMatchType;
+		}
+	}
+
+	protected applyPattern(pattern: string): void {
 		this.tree.refilter();
 
 		if (pattern) {
@@ -1153,7 +1222,7 @@ class FindController<T, TFilterData> implements IDisposable {
 		this.render();
 	}
 
-	private onDidToggleChange(e: ITreeFindToggleChangeEvent): void {
+	protected override onDidToggleChange(e: ITreeFindToggleChangeEvent): void {
 		switch (e.id) {
 			case DefaultTreeToggles.Mode:
 				this.mode = e.isChecked ? TreeFindMode.Filter : TreeFindMode.Highlight;
@@ -1164,26 +1233,8 @@ class FindController<T, TFilterData> implements IDisposable {
 		}
 	}
 
-	render(): void {
-		const noMatches = this.filter.totalCount > 0 && this.filter.matchCount === 0;
-
-		if (this.pattern && noMatches) {
-			alert(localize('replFindNoResults', "No results"));
-			if (this.tree.options.showNotFoundMessage ?? true) {
-				this.widget?.showMessage({ type: MessageType.WARNING, content: localize('not found', "No elements found.") });
-			} else {
-				this.widget?.showMessage({ type: MessageType.WARNING });
-			}
-		} else {
-			this.widget?.clearMessage();
-			if (this.pattern) {
-				alert(localize('replFindResults', "{0} results", this.filter.matchCount));
-			}
-		}
-	}
-
 	shouldAllowFocus(node: ITreeNode<T, TFilterData>): boolean {
-		if (!this.widget || !this.pattern) {
+		if (!this.isOpened() || !this.pattern) {
 			return true;
 		}
 
@@ -1192,18 +1243,6 @@ class FindController<T, TFilterData> implements IDisposable {
 		}
 
 		return !FuzzyScore.isDefault(node.filterData as any as FuzzyScore);
-	}
-
-	layout(width: number): void {
-		this.width = width;
-		this.widget?.layout(width);
-	}
-
-	dispose() {
-		this._history = undefined;
-		this._onDidChangePattern.dispose();
-		this.enabledDisposables.dispose();
-		this.disposables.dispose();
 	}
 }
 

--- a/src/vs/base/browser/ui/tree/abstractTree.ts
+++ b/src/vs/base/browser/ui/tree/abstractTree.ts
@@ -3204,6 +3204,7 @@ export abstract class AbstractTree<T, TFilterData, TRef> implements IDisposable 
 		this.onDidChangeModelRelay.input = Event.signal(model.onDidSpliceModel);
 		this.onDidChangeCollapseStateRelay.input = model.onDidChangeCollapseState;
 		this.onDidChangeRenderNodeCountRelay.input = model.onDidChangeRenderNodeCount;
+		this.onDidSpliceModelRelay.input = model.onDidSpliceModel;
 	}
 
 	setModel(newModel: ITreeModel<T, TFilterData, TRef>) {


### PR DESCRIPTION
This pull request sets the input of the `onDidSpliceModelRelay` relay in the `AbstractTree` class to the `onDidSpliceModel` event of the model. This ensures that the relay is properly updated when the model is spliced.

Related [#212077](https://github.com/microsoft/vscode/issues/212077)