### PR TITLE
notebook variable view updates

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/contrib/notebookVariables/notebookVariables.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/notebookVariables/notebookVariables.ts
@@ -87,7 +87,7 @@ export class NotebookVariables extends Disposable implements IWorkbenchContribut
 			const viewDescriptor = {
 				id: 'NOTEBOOK_VARIABLES', name: nls.localize2('notebookVariables', "Notebook Variables"),
 				containerIcon: variablesViewIcon, ctorDescriptor: new SyncDescriptor(NotebookVariablesView),
-				order: 50, weight: 5, canToggleVisibility: true, canMoveView: true, collapsed: true, when: NOTEBOOK_VARIABLE_VIEW_ENABLED,
+				order: 50, weight: 5, canToggleVisibility: true, canMoveView: true, collapsed: false, when: NOTEBOOK_VARIABLE_VIEW_ENABLED,
 			};
 
 			viewsRegistry.registerViews([viewDescriptor], debugViewContainer);


### PR DESCRIPTION
https://github.com/microsoft/vscode/issues/203480

- update the variables view if the notebook is visible, not only when active - needed for REPL/IW when the focus is in the linked text document.
- update the title of the view - "REPL variables" when it applies to a REPL/IW