### PR TITLE
Use `WorkbenchCompressibleAsyncDataTree` for lazy loading AI results

### DIFF
--- a/src/vs/base/browser/ui/tree/abstractTree.ts
+++ b/src/vs/base/browser/ui/tree/abstractTree.ts
@@ -3247,7 +3247,7 @@ interface ITreeNavigatorView<T extends NonNullable<any>, TFilterData> {
 	element(index: number): ITreeNode<T, TFilterData>;
 }
 
-class TreeNavigator<T extends NonNullable<any>, TFilterData, TRef> implements ITreeNavigator<T> {
+export class TreeNavigator<T extends NonNullable<any>, TFilterData, TRef> implements ITreeNavigator<T> {
 
 	private index: number;
 

--- a/src/vs/base/browser/ui/tree/abstractTree.ts
+++ b/src/vs/base/browser/ui/tree/abstractTree.ts
@@ -3247,7 +3247,7 @@ interface ITreeNavigatorView<T extends NonNullable<any>, TFilterData> {
 	element(index: number): ITreeNode<T, TFilterData>;
 }
 
-export class TreeNavigator<T extends NonNullable<any>, TFilterData, TRef> implements ITreeNavigator<T> {
+class TreeNavigator<T extends NonNullable<any>, TFilterData, TRef> implements ITreeNavigator<T> {
 
 	private index: number;
 

--- a/src/vs/base/browser/ui/tree/asyncDataTree.ts
+++ b/src/vs/base/browser/ui/tree/asyncDataTree.ts
@@ -504,6 +504,20 @@ export class AsyncDataTree<TInput, T, TFilterData = void> implements IDisposable
 		this.tree.domFocus();
 	}
 
+	isDOMFocused(): boolean {
+		return this.tree.isDOMFocused();
+	}
+
+	navigate(start?: T | TInput) {
+
+		if (start === undefined) {
+			return this.tree.navigate();
+		}
+		const node = this.getDataNode(start);
+
+		return this.tree.navigate(node);
+	}
+
 	layout(height?: number, width?: number): void {
 		this.tree.layout(height, width);
 	}
@@ -1397,3 +1411,32 @@ function getVisibility<TFilterData>(filterResult: TreeFilterResult<TFilterData>)
 		return getVisibleState(filterResult);
 	}
 }
+
+// export class AsyncDataTreeNavigator<TInput, T, TFilterData> implements ITreeNavigator<T> {
+// 	private navigator;
+
+// 	constructor(tree: ObjectTree<IAsyncDataTreeNode<TInput, T>, TFilterData>) {
+// 		this.navigator = tree.navigate();
+// 	}
+
+// 	current(): T | null {
+// 		const current = this.navigator.current();
+// 		if (current instanceof TInput) {
+// 			return null;
+// 		}
+// 		return current;
+// 	}
+// 	previous(): T | null {
+// 		throw new Error('Method not implemented.');
+// 	}
+// 	first(): T | null {
+// 		throw new Error('Method not implemented.');
+// 	}
+// 	last(): T | null {
+// 		throw new Error('Method not implemented.');
+// 	}
+// 	next(): T | null {
+// 		throw new Error('Method not implemented.');
+// 	}
+
+// }

--- a/src/vs/base/browser/ui/tree/asyncDataTree.ts
+++ b/src/vs/base/browser/ui/tree/asyncDataTree.ts
@@ -1415,7 +1415,7 @@ function getVisibility<TFilterData>(filterResult: TreeFilterResult<TFilterData>)
 	}
 }
 
-export class AsyncDataTreeNavigator<TInput, T> implements ITreeNavigator<T> {
+class AsyncDataTreeNavigator<TInput, T> implements ITreeNavigator<T> {
 
 	constructor(private navigator: ITreeNavigator<IAsyncDataTreeNode<TInput, T> | null>, private root: TInput) { }
 
@@ -1430,19 +1430,21 @@ export class AsyncDataTreeNavigator<TInput, T> implements ITreeNavigator<T> {
 	previous(): T | null {
 		const current = this.navigator.previous();
 		if (current?.element === this.root) {
-			return null;
+			return this.previous();
 		}
 		return <T | null>current;
 	}
 	first(): T | null {
-		this.navigator.first();
-		// the first should be the root
-		return this.next();
+		const current = this.navigator.first();
+		if (current?.element === this.root) {
+			return this.next();
+		}
+		return <T | null>current;
 	}
 	last(): T | null {
 		const current = this.navigator.last();
 		if (current?.element === this.root) {
-			return null;
+			return this.previous();
 		}
 		return <T | null>current;
 	}

--- a/src/vs/base/browser/ui/tree/asyncDataTree.ts
+++ b/src/vs/base/browser/ui/tree/asyncDataTree.ts
@@ -799,7 +799,8 @@ export class AsyncDataTree<TInput, T, TFilterData = void> implements IDisposable
 	// Implementation
 
 	protected getDataNode(element: TInput | T): IAsyncDataTreeNode<TInput, T> {
-		const node: IAsyncDataTreeNode<TInput, T> | undefined = this.nodes.get((element === this.root.element ? null : element) as T);
+		const elementToUse = (element === this.root.element ? null : element) as T;
+		const node: IAsyncDataTreeNode<TInput, T> | undefined = this.nodes.get(elementToUse);
 
 		if (!node) {
 			throw new TreeError(this.user, `Data tree node not found: ${element}`);
@@ -1425,35 +1426,35 @@ class AsyncDataTreeNavigator<TInput, T> implements ITreeNavigator<T> {
 			return null;
 		}
 		// if it is not the root, it should not be of `TInput` type
-		return <T | null>current;
+		return (current?.element ?? null) as T | null;
 	}
 	previous(): T | null {
 		const current = this.navigator.previous();
 		if (current?.element === this.root) {
 			return this.previous();
 		}
-		return <T | null>current;
+		return (current?.element ?? null) as T | null;
 	}
 	first(): T | null {
 		const current = this.navigator.first();
 		if (current?.element === this.root) {
 			return this.next();
 		}
-		return <T | null>current;
+		return (current?.element ?? null) as T | null;
 	}
 	last(): T | null {
 		const current = this.navigator.last();
 		if (current?.element === this.root) {
 			return this.previous();
 		}
-		return <T | null>current;
+		return (current?.element ?? null) as T | null;
 	}
 	next(): T | null {
 		const current = this.navigator.next();
 		if (current?.element === this.root) {
 			return this.next();
 		}
-		return <T | null>current;
+		return (current?.element ?? null) as T | null;
 	}
 
 }

--- a/src/vs/workbench/contrib/search/browser/quickTextSearch/textSearchQuickAccess.ts
+++ b/src/vs/workbench/contrib/search/browser/quickTextSearch/textSearchQuickAccess.ts
@@ -14,14 +14,14 @@ import { IConfigurationService } from '../../../../../platform/configuration/com
 import { ITextEditorSelection } from '../../../../../platform/editor/common/editor.js';
 import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
 import { ILabelService } from '../../../../../platform/label/common/label.js';
-import { WorkbenchCompressibleObjectTree, getSelectionKeyboardEvent } from '../../../../../platform/list/browser/listService.js';
+import { WorkbenchCompressibleAsyncDataTree, getSelectionKeyboardEvent } from '../../../../../platform/list/browser/listService.js';
 import { FastAndSlowPicks, IPickerQuickAccessItem, IPickerQuickAccessSeparator, PickerQuickAccessProvider, Picks, TriggerAction } from '../../../../../platform/quickinput/browser/pickerQuickAccess.js';
 import { DefaultQuickAccessFilterValue, IQuickAccessProviderRunOptions } from '../../../../../platform/quickinput/common/quickAccess.js';
 import { IKeyMods, IQuickPick, IQuickPickItem, QuickInputButtonLocation, QuickInputHideReason } from '../../../../../platform/quickinput/common/quickInput.js';
 import { IWorkspaceContextService, IWorkspaceFolder } from '../../../../../platform/workspace/common/workspace.js';
 import { IWorkbenchEditorConfiguration } from '../../../../common/editor.js';
 import { searchDetailsIcon, searchOpenInFileIcon, searchActivityBarIcon } from '../searchIcons.js';
-import { FileMatch, Match, RenderableMatch, SearchModel, SearchModelLocation, searchComparer } from '../searchModel.js';
+import { FileMatch, Match, RenderableMatch, SearchModel, SearchModelLocation, SearchResult, searchComparer } from '../searchModel.js';
 import { SearchView, getEditorSelectionFromMatch } from '../searchView.js';
 import { IWorkbenchSearchConfiguration, getOutOfWorkspaceEditorResources } from '../../common/search.js';
 import { ACTIVE_GROUP, IEditorService, SIDE_GROUP } from '../../../../services/editor/common/editorService.js';
@@ -218,7 +218,7 @@ export class TextSearchQuickAccess extends PickerQuickAccessProvider<ITextSearch
 		this.searchModel = this._instantiationService.createInstance(SearchModel);
 		this.searchModel.location = SearchModelLocation.QUICK_ACCESS;
 
-		const viewer: WorkbenchCompressibleObjectTree<RenderableMatch> | undefined = viewlet?.getControl();
+		const viewer: WorkbenchCompressibleAsyncDataTree<SearchResult, RenderableMatch> | undefined = viewlet?.getControl();
 		if (currentElem) {
 			viewer.setFocus([currentElem], getSelectionKeyboardEvent());
 			viewer.setSelection([currentElem], getSelectionKeyboardEvent());

--- a/src/vs/workbench/contrib/search/browser/searchActionsBase.ts
+++ b/src/vs/workbench/contrib/search/browser/searchActionsBase.ts
@@ -6,10 +6,10 @@
 import * as DOM from '../../../../base/browser/dom.js';
 import { ResolvedKeybinding } from '../../../../base/common/keybindings.js';
 import * as nls from '../../../../nls.js';
-import { WorkbenchCompressibleObjectTree } from '../../../../platform/list/browser/listService.js';
+import { WorkbenchCompressibleAsyncDataTree } from '../../../../platform/list/browser/listService.js';
 import { IViewsService } from '../../../services/views/common/viewsService.js';
 import { SearchView } from './searchView.js';
-import { FileMatch, FolderMatch, Match, RenderableMatch, searchComparer } from './searchModel.js';
+import { FileMatch, FolderMatch, Match, RenderableMatch, searchComparer, SearchResult } from './searchModel.js';
 import { ISearchConfigurationProperties, VIEW_ID } from '../../../services/search/common/search.js';
 
 export const category = nls.localize2('search', "Search");
@@ -27,7 +27,7 @@ export function getSearchView(viewsService: IViewsService): SearchView | undefin
 	return viewsService.getActiveViewWithId(VIEW_ID) as SearchView;
 }
 
-export function getElementsToOperateOn(viewer: WorkbenchCompressibleObjectTree<RenderableMatch, void>, currElement: RenderableMatch | undefined, sortConfig: ISearchConfigurationProperties): RenderableMatch[] {
+export function getElementsToOperateOn(viewer: WorkbenchCompressibleAsyncDataTree<SearchResult, RenderableMatch, void>, currElement: RenderableMatch | undefined, sortConfig: ISearchConfigurationProperties): RenderableMatch[] {
 	let elements: RenderableMatch[] = viewer.getSelection().filter((x): x is RenderableMatch => x !== null).sort((a, b) => searchComparer(a, b, sortConfig.sortOrder));
 
 	// if selection doesn't include multiple elements, just return current focus element.

--- a/src/vs/workbench/contrib/search/browser/searchActionsFind.ts
+++ b/src/vs/workbench/contrib/search/browser/searchActionsFind.ts
@@ -7,12 +7,12 @@ import * as nls from '../../../../nls.js';
 import { ICommandService } from '../../../../platform/commands/common/commands.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
-import { IListService, WorkbenchCompressibleObjectTree } from '../../../../platform/list/browser/listService.js';
+import { IListService, WorkbenchCompressibleAsyncDataTree } from '../../../../platform/list/browser/listService.js';
 import { ViewContainerLocation } from '../../../common/views.js';
 import { IViewsService } from '../../../services/views/common/viewsService.js';
 import * as Constants from '../common/constants.js';
 import * as SearchEditorConstants from '../../searchEditor/browser/constants.js';
-import { FileMatch, FolderMatchWithResource, Match, RenderableMatch } from './searchModel.js';
+import { FileMatch, FolderMatchWithResource, Match, RenderableMatch, SearchResult } from './searchModel.js';
 import { OpenSearchEditorArgs } from '../../searchEditor/browser/searchEditor.contribution.js';
 import { ISearchConfiguration, ISearchConfigurationProperties } from '../../../services/search/common/search.js';
 import { URI } from '../../../../base/common/uri.js';
@@ -366,7 +366,7 @@ async function searchWithFolderCommand(accessor: ServicesAccessor, isFromExplore
 	}
 }
 
-function getMultiSelectedSearchResources(viewer: WorkbenchCompressibleObjectTree<RenderableMatch, void>, currElement: RenderableMatch | undefined, sortConfig: ISearchConfigurationProperties): URI[] {
+function getMultiSelectedSearchResources(viewer: WorkbenchCompressibleAsyncDataTree<SearchResult, RenderableMatch, void>, currElement: RenderableMatch | undefined, sortConfig: ISearchConfigurationProperties): URI[] {
 	return getElementsToOperateOn(viewer, currElement, sortConfig)
 		.map((renderableMatch) => ((renderableMatch instanceof Match) ? null : renderableMatch.resource))
 		.filter((renderableMatch): renderableMatch is URI => (renderableMatch !== null));

--- a/src/vs/workbench/contrib/search/browser/searchActionsNav.ts
+++ b/src/vs/workbench/contrib/search/browser/searchActionsNav.ts
@@ -8,11 +8,11 @@ import * as nls from '../../../../nls.js';
 import { ICommandHandler } from '../../../../platform/commands/common/commands.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
-import { WorkbenchCompressibleObjectTree } from '../../../../platform/list/browser/listService.js';
+import { WorkbenchCompressibleAsyncDataTree } from '../../../../platform/list/browser/listService.js';
 import { IViewsService } from '../../../services/views/common/viewsService.js';
 import * as Constants from '../common/constants.js';
 import * as SearchEditorConstants from '../../searchEditor/browser/constants.js';
-import { FileMatchOrMatch, FolderMatch, RenderableMatch } from './searchModel.js';
+import { FileMatchOrMatch, FolderMatch, RenderableMatch, SearchResult } from './searchModel.js';
 import { SearchEditor } from '../../searchEditor/browser/searchEditor.js';
 import { SearchEditorInput } from '../../searchEditor/browser/searchEditorInput.js';
 import { IEditorService } from '../../../services/editor/common/editorService.js';
@@ -174,7 +174,7 @@ registerAction2(class OpenMatchAction extends Action2 {
 	run(accessor: ServicesAccessor) {
 		const searchView = getSearchView(accessor.get(IViewsService));
 		if (searchView) {
-			const tree: WorkbenchCompressibleObjectTree<RenderableMatch> = searchView.getControl();
+			const tree: WorkbenchCompressibleAsyncDataTree<SearchResult, RenderableMatch> = searchView.getControl();
 			const viewer = searchView.getControl();
 			const focus = tree.getFocus()[0];
 
@@ -206,7 +206,7 @@ registerAction2(class OpenMatchToSideAction extends Action2 {
 	run(accessor: ServicesAccessor) {
 		const searchView = getSearchView(accessor.get(IViewsService));
 		if (searchView) {
-			const tree: WorkbenchCompressibleObjectTree<RenderableMatch> = searchView.getControl();
+			const tree: WorkbenchCompressibleAsyncDataTree<SearchResult, RenderableMatch> = searchView.getControl();
 			searchView.open(<FileMatchOrMatch>tree.getFocus()[0], false, true, true);
 		}
 	}
@@ -229,7 +229,7 @@ registerAction2(class AddCursorsAtSearchResultsAction extends Action2 {
 	override async run(accessor: ServicesAccessor): Promise<any> {
 		const searchView = getSearchView(accessor.get(IViewsService));
 		if (searchView) {
-			const tree: WorkbenchCompressibleObjectTree<RenderableMatch> = searchView.getControl();
+			const tree: WorkbenchCompressibleAsyncDataTree<SearchResult, RenderableMatch> = searchView.getControl();
 			searchView.openEditorWithMultiCursor(<FileMatchOrMatch>tree.getFocus()[0]);
 		}
 	}

--- a/src/vs/workbench/contrib/search/browser/searchActionsRemoveReplace.ts
+++ b/src/vs/workbench/contrib/search/browser/searchActionsRemoveReplace.ts
@@ -287,7 +287,7 @@ async function performReplace(accessor: ServicesAccessor,
 	const searchResult = viewlet?.searchResult;
 
 	if (searchResult) {
-		searchResult.batchReplace(elementsToReplace);
+		await searchResult.batchReplace(elementsToReplace);
 	}
 
 	await viewlet?.refreshTreePromiseSerializer; // wait for refreshTree to finish

--- a/src/vs/workbench/contrib/search/browser/searchActionsRemoveReplace.ts
+++ b/src/vs/workbench/contrib/search/browser/searchActionsRemoveReplace.ts
@@ -359,6 +359,8 @@ function compareLevels(elem1: RenderableMatch, elem2: RenderableMatch) {
  */
 export function getElementToFocusAfterRemoved(viewer: WorkbenchCompressibleAsyncDataTree<SearchResult, RenderableMatch>, element: RenderableMatch, elementsToRemove: RenderableMatch[]): RenderableMatch | undefined {
 	const navigator: ITreeNavigator<any> = viewer.navigate(element);
+
+
 	if (element instanceof FolderMatch) {
 		while (!!navigator.next() && (!(navigator.current() instanceof FolderMatch) || arrayContainsElementOrParent(navigator.current(), elementsToRemove))) { }
 	} else if (element instanceof FileMatch) {

--- a/src/vs/workbench/contrib/search/browser/searchActionsTopBar.ts
+++ b/src/vs/workbench/contrib/search/browser/searchActionsTopBar.ts
@@ -220,10 +220,14 @@ function expandAll(accessor: ServicesAccessor) {
 	if (searchView) {
 		const viewer = searchView.getControl();
 
-		if (searchView.model.hasAIResults) {
-			viewer.expandAll();
+		if (searchView.shouldShowAIResults()) {
+			if (searchView.model.hasAIResults) {
+				viewer.expandAll();
+			} else {
+				viewer.expand(searchView.model.searchResult.plainTextSearchResult, true);
+			}
 		} else {
-			viewer.expand(searchView.model.searchResult.plainTextSearchResult, true);
+			viewer.expandAll();
 		}
 	}
 }

--- a/src/vs/workbench/contrib/search/browser/searchActionsTopBar.ts
+++ b/src/vs/workbench/contrib/search/browser/searchActionsTopBar.ts
@@ -219,7 +219,12 @@ function expandAll(accessor: ServicesAccessor) {
 	const searchView = getSearchView(viewsService);
 	if (searchView) {
 		const viewer = searchView.getControl();
-		viewer.expandAll();
+
+		if (searchView.model.hasAIResults) {
+			viewer.expandAll();
+		} else {
+			viewer.expand(searchView.model.searchResult.plainTextSearchResult, true);
+		}
 	}
 }
 

--- a/src/vs/workbench/contrib/search/browser/searchActionsTopBar.ts
+++ b/src/vs/workbench/contrib/search/browser/searchActionsTopBar.ts
@@ -172,10 +172,10 @@ registerAction2(class ViewAsTreeAction extends Action2 {
 			}]
 		});
 	}
-	run(accessor: ServicesAccessor, ...args: any[]) {
+	async run(accessor: ServicesAccessor, ...args: any[]) {
 		const searchView = getSearchView(accessor.get(IViewsService));
 		if (searchView) {
-			searchView.setTreeView(true);
+			await searchView.setTreeView(true);
 		}
 	}
 });
@@ -197,10 +197,10 @@ registerAction2(class ViewAsListAction extends Action2 {
 			}]
 		});
 	}
-	run(accessor: ServicesAccessor, ...args: any[]) {
+	async run(accessor: ServicesAccessor, ...args: any[]) {
 		const searchView = getSearchView(accessor.get(IViewsService));
 		if (searchView) {
-			searchView.setTreeView(false);
+			await searchView.setTreeView(false);
 		}
 	}
 });

--- a/src/vs/workbench/contrib/search/browser/searchActionsTopBar.ts
+++ b/src/vs/workbench/contrib/search/browser/searchActionsTopBar.ts
@@ -11,7 +11,6 @@ import { IViewsService } from '../../../services/views/common/viewsService.js';
 import { searchClearIcon, searchCollapseAllIcon, searchExpandAllIcon, searchRefreshIcon, searchShowAsList, searchShowAsTree, searchStopIcon } from './searchIcons.js';
 import * as Constants from '../common/constants.js';
 import { ISearchHistoryService } from '../common/searchHistoryService.js';
-import { FileMatch, FolderMatch, FolderMatchNoRoot, FolderMatchWorkspaceRoot, Match, SearchResult } from './searchModel.js';
 import { VIEW_ID } from '../../../services/search/common/search.js';
 import { ContextKeyExpr } from '../../../../platform/contextkey/common/contextkey.js';
 import { Action2, MenuId, registerAction2 } from '../../../../platform/actions/common/actions.js';
@@ -243,87 +242,87 @@ function refreshSearch(accessor: ServicesAccessor) {
 
 function collapseDeepestExpandedLevel(accessor: ServicesAccessor) {
 
-	const viewsService = accessor.get(IViewsService);
-	const searchView = getSearchView(viewsService);
-	if (searchView) {
-		const viewer = searchView.getControl();
+	// const viewsService = accessor.get(IViewsService);
+	// const searchView = getSearchView(viewsService);
+	// if (searchView) {
+	// 	const viewer = searchView.getControl();
 
-		/**
-		 * one level to collapse so collapse everything. If FolderMatch, check if there are visible grandchildren,
-		 * i.e. if Matches are returned by the navigator, and if so, collapse to them, otherwise collapse all levels.
-		 */
-		const navigator = viewer.navigate();
-		let node = navigator.first();
-		let canCollapseFileMatchLevel = false;
-		let canCollapseFirstLevel = false;
+	// 	/**
+	// 	 * one level to collapse so collapse everything. If FolderMatch, check if there are visible grandchildren,
+	// 	 * i.e. if Matches are returned by the navigator, and if so, collapse to them, otherwise collapse all levels.
+	// 	 */
+	// 	const navigator = viewer.navigate();
+	// 	let node = navigator.first();
+	// 	let canCollapseFileMatchLevel = false;
+	// 	let canCollapseFirstLevel = false;
 
-		if (node instanceof FolderMatchWorkspaceRoot || searchView.isTreeLayoutViewVisible) {
-			while (node = navigator.next()) {
-				if (node instanceof Match) {
-					canCollapseFileMatchLevel = true;
-					break;
-				}
-				if (searchView.isTreeLayoutViewVisible && !canCollapseFirstLevel) {
-					let nodeToTest = node;
+	// 	if (node instanceof FolderMatchWorkspaceRoot || searchView.isTreeLayoutViewVisible) {
+	// 		while (node = navigator.next()) {
+	// 			if (node instanceof Match) {
+	// 				canCollapseFileMatchLevel = true;
+	// 				break;
+	// 			}
+	// 			if (searchView.isTreeLayoutViewVisible && !canCollapseFirstLevel) {
+	// 				let nodeToTest = node;
 
-					if (node instanceof FolderMatch) {
-						const compressionStartNode = viewer.getCompressedTreeNode(node).element?.elements[0];
-						// Match elements should never be compressed, so !(compressionStartNode instanceof Match) should always be true here
-						nodeToTest = (compressionStartNode && !(compressionStartNode instanceof Match)) ? compressionStartNode : node;
-					}
+	// 				if (node instanceof FolderMatch) {
+	// 					const compressionStartNode = viewer.getCompressedTreeNode(node).element?.elements[0];
+	// 					// Match elements should never be compressed, so !(compressionStartNode instanceof Match) should always be true here
+	// 					nodeToTest = (compressionStartNode && !(compressionStartNode instanceof Match)) ? compressionStartNode : node;
+	// 				}
 
-					const immediateParent = nodeToTest.parent();
+	// 				const immediateParent = nodeToTest.parent();
 
-					if (!(immediateParent instanceof FolderMatchWorkspaceRoot || immediateParent instanceof FolderMatchNoRoot || immediateParent instanceof SearchResult)) {
-						canCollapseFirstLevel = true;
-					}
-				}
-			}
-		}
+	// 				if (!(immediateParent instanceof FolderMatchWorkspaceRoot || immediateParent instanceof FolderMatchNoRoot || immediateParent instanceof SearchResult)) {
+	// 					canCollapseFirstLevel = true;
+	// 				}
+	// 			}
+	// 		}
+	// 	}
 
-		if (canCollapseFileMatchLevel) {
-			node = navigator.first();
-			do {
-				if (node instanceof FileMatch) {
-					viewer.collapse(node);
-				}
-			} while (node = navigator.next());
-		} else if (canCollapseFirstLevel) {
-			node = navigator.first();
-			if (node) {
-				do {
+	// 	if (canCollapseFileMatchLevel) {
+	// 		node = navigator.first();
+	// 		do {
+	// 			if (node instanceof FileMatch) {
+	// 				viewer.collapse(node);
+	// 			}
+	// 		} while (node = navigator.next());
+	// 	} else if (canCollapseFirstLevel) {
+	// 		node = navigator.first();
+	// 		if (node) {
+	// 			do {
 
-					let nodeToTest = node;
+	// 				let nodeToTest = node;
 
-					if (node instanceof FolderMatch) {
-						const compressionStartNode = viewer.getCompressedTreeNode(node).element?.elements[0];
-						// Match elements should never be compressed, so !(compressionStartNode instanceof Match) should always be true here
-						nodeToTest = (compressionStartNode && !(compressionStartNode instanceof Match)) ? compressionStartNode : node;
-					}
-					const immediateParent = nodeToTest.parent();
+	// 				if (node instanceof FolderMatch) {
+	// 					const compressionStartNode = viewer.getCompressedTreeNode(node).element?.elements[0];
+	// 					// Match elements should never be compressed, so !(compressionStartNode instanceof Match) should always be true here
+	// 					nodeToTest = (compressionStartNode && !(compressionStartNode instanceof Match)) ? compressionStartNode : node;
+	// 				}
+	// 				const immediateParent = nodeToTest.parent();
 
-					if (immediateParent instanceof FolderMatchWorkspaceRoot || immediateParent instanceof FolderMatchNoRoot) {
-						if (viewer.hasElement(node)) {
-							viewer.collapse(node, true);
-						} else {
-							viewer.collapseAll();
-						}
-					}
-				} while (node = navigator.next());
-			}
-		} else {
-			viewer.collapseAll();
-		}
+	// 				if (immediateParent instanceof FolderMatchWorkspaceRoot || immediateParent instanceof FolderMatchNoRoot) {
+	// 					if (viewer.hasNode(node)) {
+	// 						viewer.collapse(node, true);
+	// 					} else {
+	// 						viewer.collapseAll();
+	// 					}
+	// 				}
+	// 			} while (node = navigator.next());
+	// 		}
+	// 	} else {
+	// 		viewer.collapseAll();
+	// 	}
 
-		const firstFocusParent = viewer.getFocus()[0]?.parent();
+	// 	const firstFocusParent = viewer.getFocus()[0]?.parent();
 
-		if (firstFocusParent && (firstFocusParent instanceof FolderMatch || firstFocusParent instanceof FileMatch) &&
-			viewer.hasElement(firstFocusParent) && viewer.isCollapsed(firstFocusParent)) {
-			viewer.domFocus();
-			viewer.focusFirst();
-			viewer.setSelection(viewer.getFocus());
-		}
-	}
+	// 	if (firstFocusParent && (firstFocusParent instanceof FolderMatch || firstFocusParent instanceof FileMatch) &&
+	// 		viewer.hasNode(firstFocusParent) && viewer.isCollapsed(firstFocusParent)) {
+	// 		viewer.domFocus();
+	// 		viewer.focusFirst();
+	// 		viewer.setSelection(viewer.getFocus());
+	// 	}
+	// }
 }
 
 //#endregion

--- a/src/vs/workbench/contrib/search/browser/searchFindInput.ts
+++ b/src/vs/workbench/contrib/search/browser/searchFindInput.ts
@@ -64,7 +64,7 @@ export class SearchFindInput extends ContextScopedFindInput {
 		this._findFilter.container.classList.add('monaco-custom-toggle');
 		this.filterVisible = filterStartVisiblitity;
 		// ensure that ai button is visible if it should be
-		this.sparkleVisible = shouldShowAIButton;
+		this.sparkleVisible = false;
 
 		this._register(this._aiButton.onChange(() => {
 			if (this.regex) {
@@ -96,7 +96,7 @@ export class SearchFindInput extends ContextScopedFindInput {
 	}
 
 	set sparkleVisible(visible: boolean) {
-		this._aiButton.visible = visible;
+		this._aiButton.visible = false;
 		this._updatePadding();
 	}
 

--- a/src/vs/workbench/contrib/search/browser/searchModel.ts
+++ b/src/vs/workbench/contrib/search/browser/searchModel.ts
@@ -603,6 +603,10 @@ export class FileMatch extends Disposable implements IFileMatch {
 		return this._parent;
 	}
 
+	get hasChildren(): boolean {
+		return this._textMatches.size > 0 || this._cellMatches.size > 0;
+	}
+
 	matches(): Match[] {
 		const cellMatches: MatchInNotebook[] = Array.from(this._cellMatches.values()).flatMap((e) => e.matches());
 		return [...this._textMatches.values(), ...cellMatches];
@@ -1001,6 +1005,10 @@ export class FolderMatch extends Disposable {
 
 	parent(): TextSearchResult | FolderMatch {
 		return this._parent;
+	}
+
+	get hasChildren(): boolean {
+		return this._fileMatches.size > 0 || this._folderMatches.size > 0;
 	}
 
 	bindModel(model: ITextModel): void {
@@ -1499,6 +1507,14 @@ export class TextSearchResult extends Disposable {
 		return this._parent;
 	}
 
+	get hasChildren(): boolean {
+		return this._folderMatches.length > 0;
+	}
+
+	name(): string {
+		return this._id === AI_TEXT_SEARCH_RESULT_ID ? 'AI' : 'Text';
+	}
+
 	get isDirty(): boolean {
 		return this._isDirty;
 	}
@@ -1934,6 +1950,18 @@ export class SearchResult extends Disposable {
 	get plainTextSearchResult(): ReplaceableTextSearchResult {
 		return this._plainTextSearchResult;
 	}
+
+	get aiTextSearchResult(): TextSearchResult {
+		return this._aiTextSearchResult;
+	}
+
+	get children() {
+		return this.textSearchResults;
+	}
+
+	get hasChildren(): boolean {
+		return true; // should always have a Text Search Result for plain results.
+	}
 	get textSearchResults(): TextSearchResult[] {
 		return [this._plainTextSearchResult, this._aiTextSearchResult];
 	}
@@ -2080,18 +2108,12 @@ export class SearchResult extends Disposable {
 		return this._plainTextSearchResult.isEmpty();
 	}
 
-	fileCount(ai = false): number {
-		if (ai) {
-			return this._aiTextSearchResult.fileCount();
-		}
-		return this._plainTextSearchResult.fileCount();
+	fileCount(): number {
+		return this._plainTextSearchResult.fileCount() + this._aiTextSearchResult.fileCount();
 	}
 
-	count(ai = false): number {
-		if (ai) {
-			return this._aiTextSearchResult.count();
-		}
-		return this._plainTextSearchResult.count();
+	count(): number {
+		return this._plainTextSearchResult.count() + this._aiTextSearchResult.count();
 	}
 
 	setCachedSearchComplete(cachedSearchComplete: ISearchComplete | undefined, ai: boolean) {
@@ -2515,7 +2537,7 @@ export class SearchModel extends Disposable {
 
 export type FileMatchOrMatch = FileMatch | Match;
 
-export type RenderableMatch = TextSearchResult | FolderMatch | FolderMatchWithResource | FileMatch | Match;
+export type RenderableMatch = TextSearchResult | FolderMatch | FileMatch | Match;
 
 export class SearchViewModelWorkbenchService implements ISearchViewModelWorkbenchService {
 

--- a/src/vs/workbench/contrib/search/browser/searchModel.ts
+++ b/src/vs/workbench/contrib/search/browser/searchModel.ts
@@ -2238,7 +2238,7 @@ export class SearchModel extends Disposable {
 	}
 
 	async addAIResults(onProgress?: (result: ISearchProgressItem) => void) {
-		if (this.hasAIResults || this.currentAICancelTokenSource !== undefined) {
+		if (this.hasAIResults || this.currentAICancelTokenSource !== null) {
 			// already has matches or pending matches
 			return;
 		} else {

--- a/src/vs/workbench/contrib/search/browser/searchResultsView.ts
+++ b/src/vs/workbench/contrib/search/browser/searchResultsView.ts
@@ -117,7 +117,7 @@ export class TextSearchResultRenderer extends Disposable implements ICompressibl
 
 	renderElement(element: ITreeNode<TextSearchResult, any>, index: number, templateData: IFolderMatchTemplate, height: number | undefined): void {
 		if (element.element.id() === AI_TEXT_SEARCH_RESULT_ID) {
-			templateData.label.setLabel(nls.localize('searchFolderMatch.aiText.label', "Load AI Results"));
+			templateData.label.setLabel(nls.localize('searchFolderMatch.aiText.label', "AI Results"));
 		} else {
 			templateData.label.setLabel(nls.localize('searchFolderMatch.plainText.label', "Text Results"));
 		}

--- a/src/vs/workbench/contrib/search/browser/searchView.ts
+++ b/src/vs/workbench/contrib/search/browser/searchView.ts
@@ -778,7 +778,7 @@ export class SearchView extends ViewPane {
 		}
 	}
 
-	private originalShouldCollapse(match: RenderableMatch): ObjectTreeElementCollapseState {
+	private originalShouldCollapse(match: RenderableMatch) {
 		const collapseResults = this.searchConfig.collapseResults;
 		return (collapseResults === 'alwaysCollapse' ||
 			(!(match instanceof Match) && match.count() > 10 && collapseResults !== 'alwaysExpand')) ?
@@ -787,7 +787,7 @@ export class SearchView extends ViewPane {
 
 	private shouldCollapse(match: RenderableMatch): boolean {
 		const collapseResults = this.originalShouldCollapse(match);
-		if (collapseResults === ObjectTreeElementCollapseState.Collapsed || collapseResults === ObjectTreeElementCollapseState.PreserveOrCollapsed) {
+		if (collapseResults === ObjectTreeElementCollapseState.PreserveOrCollapsed) {
 			return true;
 		}
 		return false;
@@ -967,6 +967,7 @@ export class SearchView extends ViewPane {
 				paddingBottom: SearchDelegate.ITEM_HEIGHT,
 				collapseByDefault: (e: RenderableMatch) => {
 					if (e.id() === AI_TEXT_SEARCH_RESULT_ID) {
+						// always collapse the ai text search result
 						return true;
 					}
 					return this.shouldCollapse(e);

--- a/src/vs/workbench/contrib/search/browser/searchView.ts
+++ b/src/vs/workbench/contrib/search/browser/searchView.ts
@@ -1059,7 +1059,8 @@ export class SearchView extends ViewPane {
 		const navigator = viewer.navigate();
 		let node = navigator.first();
 		do {
-			if (node && !viewer.isCollapsed(node)) {
+			if (node && !viewer.isCollapsed(node) && (this.viewModel.hasAIResults || node.id() !== AI_TEXT_SEARCH_RESULT_ID)) {
+				// ignore the ai text search result id
 				return true;
 			}
 		} while (node = navigator.next());

--- a/src/vs/workbench/contrib/search/browser/searchView.ts
+++ b/src/vs/workbench/contrib/search/browser/searchView.ts
@@ -2385,9 +2385,6 @@ class SearchViewDataSource implements IAsyncDataSource<SearchResult, RenderableM
 		}
 
 		const textSearchResults = searchResult.children;
-		// if (textSearchResults.length === 1) {
-		// 	return this.createTextSearchResultIterator(textSearchResults[0]);
-		// }
 		return textSearchResults;
 	}
 

--- a/src/vs/workbench/contrib/search/common/constants.ts
+++ b/src/vs/workbench/contrib/search/common/constants.ts
@@ -77,6 +77,5 @@ export const SearchContext = {
 	ViewHasFilePatternKey: new RawContextKey<boolean>('viewHasFilePattern', false),
 	ViewHasSomeCollapsibleKey: new RawContextKey<boolean>('viewHasSomeCollapsibleResult', false),
 	InTreeViewKey: new RawContextKey<boolean>('inTreeView', false),
-	AIResultsVisibleKey: new RawContextKey<boolean>('AIResultsVisibleKey', false),
 	hasAIResultProvider: new RawContextKey<boolean>('hasAIResultProviderKey', false),
 };


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

- Use the `WorkbenchCompressibleAsyncDataTree` instead of the `WorkbenchCompressibleObjectTree` in search. This is because we want to be able to dynamically load AI results in another tree node.
- Remove the sparkle icon for AI results and add it to another tree node instead. 

Notes:
- I added an `AsyncDataTreeNavigator` because I needed a navigator. It's just a wrapper on the internal `ObjectTree`'s navigator. I can refactor this later if this is not the best way to do this. cc @benibenj @joaomoreno 
- Since the `updateChildren` call is async (whereas I used `setChildren` before), I had to change a lot of the tree-building functions to be async. I tried to manually test the scenarios that I thought would be affected, but this might cause other bugs.
