### PR TITLE
Some command labels in the keybindings editor are showing & (fix #228911)

### DIFF
--- a/src/vs/base/common/labels.ts
+++ b/src/vs/base/common/labels.ts
@@ -434,6 +434,10 @@ export function unmnemonicLabel(label: string): string {
 	return label.replace(/&/g, '&&');
 }
 
+export function stripMnemonicLabel(label: string): string {
+	return label.replace(/&&/g, '');
+}
+
 /**
  * Splits a recent label in name and parent path, supporting both '/' and '\' and workspace suffixes.
  * If the location is remote, the remote name is included in the name part.

--- a/src/vs/workbench/contrib/preferences/browser/keybindingsEditor.ts
+++ b/src/vs/workbench/contrib/preferences/browser/keybindingsEditor.ts
@@ -63,6 +63,7 @@ import { IEditorGroup } from '../../../services/editor/common/editorGroupsServic
 import type { IManagedHover } from '../../../../base/browser/ui/hover/hover.js';
 import { IHoverService } from '../../../../platform/hover/browser/hover.js';
 import { IAccessibilityService } from '../../../../platform/accessibility/common/accessibility.js';
+import { stripMnemonicLabel } from '../../../../base/common/labels.js';
 
 const $ = DOM.$;
 
@@ -567,7 +568,7 @@ export class KeybindingsEditor extends EditorPane implements IKeybindingsEditorP
 			if (isIMenuItem(menuItem)) {
 				const title = typeof menuItem.command.title === 'string' ? menuItem.command.title : menuItem.command.title.value;
 				const category = menuItem.command.category ? typeof menuItem.command.category === 'string' ? menuItem.command.category : menuItem.command.category.value : undefined;
-				actionsLabels.set(menuItem.command.id, category ? `${category}: ${title}` : title);
+				actionsLabels.set(menuItem.command.id, stripMnemonicLabel(category ? `${category}: ${title}` : title));
 			}
 		}
 		return actionsLabels;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
