### PR TITLE
Revert keybindings changes and fix command labels in keybindings editor

### DIFF
--- a/src/vs/base/common/labels.ts
+++ b/src/vs/base/common/labels.ts
@@ -434,10 +434,6 @@ export function unmnemonicLabel(label: string): string {
 	return label.replace(/&/g, '&&');
 }
 
-export function stripMnemonicLabel(label: string): string {
-	return label.replace(/&&/g, '');
-}
-
 /**
  * Splits a recent label in name and parent path, supporting both '/' and '\' and workspace suffixes.
  * If the location is remote, the remote name is included in the name part.

--- a/src/vs/platform/actions/common/actions.ts
+++ b/src/vs/platform/actions/common/actions.ts
@@ -369,7 +369,7 @@ export interface IMenuRegistry {
 	 */
 	appendMenuItems(items: Iterable<{ id: MenuId; item: IMenuItem | ISubmenuItem }>): IDisposable;
 	appendMenuItem(menu: MenuId, item: IMenuItem | ISubmenuItem): IDisposable;
-	getMenuItems(loc: MenuId | undefined): Array<IMenuItem | ISubmenuItem>;
+	getMenuItems(loc: MenuId): Array<IMenuItem | ISubmenuItem>;
 }
 
 export const MenuRegistry: IMenuRegistry = new class implements IMenuRegistry {
@@ -425,14 +425,9 @@ export const MenuRegistry: IMenuRegistry = new class implements IMenuRegistry {
 		return result;
 	}
 
-	getMenuItems(id: MenuId | undefined): Array<IMenuItem | ISubmenuItem> {
+	getMenuItems(id: MenuId): Array<IMenuItem | ISubmenuItem> {
 		let result: Array<IMenuItem | ISubmenuItem>;
-		if (id === undefined) {
-			result = [];
-			for (const items of this._menuItems.values()) {
-				result.push(...items);
-			}
-		} else if (this._menuItems.has(id)) {
+		if (this._menuItems.has(id)) {
 			result = [...this._menuItems.get(id)!];
 		} else {
 			result = [];

--- a/src/vs/workbench/contrib/chat/electron-sandbox/actions/voiceChatActions.ts
+++ b/src/vs/workbench/contrib/chat/electron-sandbox/actions/voiceChatActions.ts
@@ -1299,7 +1299,7 @@ abstract class BaseInstallSpeechProviderAction extends Action2 {
 
 export class InstallSpeechProviderForVoiceChatAction extends BaseInstallSpeechProviderAction {
 
-	static readonly ID = '_workbench.action.chat.installProviderForVoiceChat';
+	static readonly ID = 'workbench.action.chat.installProviderForVoiceChat';
 
 	constructor() {
 		super({
@@ -1328,7 +1328,7 @@ export class InstallSpeechProviderForVoiceChatAction extends BaseInstallSpeechPr
 
 export class InstallSpeechProviderForSynthesizeChatAction extends BaseInstallSpeechProviderAction {
 
-	static readonly ID = '_workbench.action.chat.installProviderForSynthesis';
+	static readonly ID = 'workbench.action.chat.installProviderForSynthesis';
 
 	constructor() {
 		super({

--- a/src/vs/workbench/contrib/preferences/browser/keybindingsEditor.ts
+++ b/src/vs/workbench/contrib/preferences/browser/keybindingsEditor.ts
@@ -38,7 +38,7 @@ import { INotificationService } from '../../../../platform/notification/common/n
 import { CancellationToken } from '../../../../base/common/cancellation.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
 import { Emitter, Event } from '../../../../base/common/event.js';
-import { MenuRegistry, isIMenuItem } from '../../../../platform/actions/common/actions.js';
+import { MenuRegistry, MenuId, isIMenuItem } from '../../../../platform/actions/common/actions.js';
 import { IListAccessibilityProvider } from '../../../../base/browser/ui/list/listWidget.js';
 import { WORKBENCH_BACKGROUND } from '../../../common/theme.js';
 import { IKeybindingItemEntry, IKeybindingsEditorPane } from '../../../services/preferences/common/preferences.js';
@@ -563,7 +563,7 @@ export class KeybindingsEditor extends EditorPane implements IKeybindingsEditorP
 		for (const editorAction of EditorExtensionsRegistry.getEditorActions()) {
 			actionsLabels.set(editorAction.id, editorAction.label);
 		}
-		for (const menuItem of MenuRegistry.getMenuItems(undefined /* all menus */)) {
+		for (const menuItem of MenuRegistry.getMenuItems(MenuId.CommandPalette)) {
 			if (isIMenuItem(menuItem)) {
 				const title = typeof menuItem.command.title === 'string' ? menuItem.command.title : menuItem.command.title.value;
 				const category = menuItem.command.category ? typeof menuItem.command.category === 'string' ? menuItem.command.category : menuItem.command.category.value : undefined;

--- a/src/vs/workbench/contrib/preferences/browser/keybindingsEditor.ts
+++ b/src/vs/workbench/contrib/preferences/browser/keybindingsEditor.ts
@@ -63,7 +63,6 @@ import { IEditorGroup } from '../../../services/editor/common/editorGroupsServic
 import type { IManagedHover } from '../../../../base/browser/ui/hover/hover.js';
 import { IHoverService } from '../../../../platform/hover/browser/hover.js';
 import { IAccessibilityService } from '../../../../platform/accessibility/common/accessibility.js';
-import { stripMnemonicLabel } from '../../../../base/common/labels.js';
 
 const $ = DOM.$;
 
@@ -568,7 +567,7 @@ export class KeybindingsEditor extends EditorPane implements IKeybindingsEditorP
 			if (isIMenuItem(menuItem)) {
 				const title = typeof menuItem.command.title === 'string' ? menuItem.command.title : menuItem.command.title.value;
 				const category = menuItem.command.category ? typeof menuItem.command.category === 'string' ? menuItem.command.category : menuItem.command.category.value : undefined;
-				actionsLabels.set(menuItem.command.id, stripMnemonicLabel(category ? `${category}: ${title}` : title));
+				actionsLabels.set(menuItem.command.id, category ? `${category}: ${title}` : title);
 			}
 		}
 		return actionsLabels;


### PR DESCRIPTION
This pull request reverts two previous commits that caused issues with command labels in the keybindings editor. The first commit, "Revert 'Some command labels in the keybindings editor are showing & (fix #228911) (#228914)'" reverts a previous fix for issue #228911. The second commit, "Revert 'keybindings - gather command labels from all menus (#228372)'" reverts a change that caused incorrect command labels to be displayed. These changes fix the issue with command labels in the keybindings editor.++