### PR TITLE
include temp ~ files in default exclusions

### DIFF
--- a/src/vs/workbench/contrib/files/browser/files.contribution.ts
+++ b/src/vs/workbench/contrib/files/browser/files.contribution.ts
@@ -154,7 +154,7 @@ configurationRegistry.registerConfiguration({
 			'type': 'object',
 			'markdownDescription': nls.localize('exclude', "Configure [glob patterns](https://aka.ms/vscode-glob-patterns) for excluding files and folders. For example, the File Explorer decides which files and folders to show or hide based on this setting. Refer to the `#search.exclude#` setting to define search-specific excludes. Refer to the `#explorer.excludeGitIgnore#` setting for ignoring files based on your `.gitignore`."),
 			'default': {
-				...{ '**/.git': true, '**/.svn': true, '**/.hg': true, '**/CVS': true, '**/.DS_Store': true, '**/Thumbs.db': true },
+				...{ '**/.git': true, '**/.svn': true, '**/.hg': true, '**/CVS': true, '**/.DS_Store': true, '**/Thumbs.db': true, '**/**~': true },
 				...(isWeb ? { '**/*.crswap': true /* filter out swap files used for local file access */ } : undefined)
 			},
 			'scope': ConfigurationScope.RESOURCE,


### PR DESCRIPTION
I'm not aware of any environment that stores files ending with ~ that are not purely temporary, but several build and other software that uses those for temporary files,

I suggest to have this in the default exclusions, similar to Thumbs.db (which is Win32 specific) and .DS_Store (Macos specific) as a quite portable definition of temporary files.