### PR TITLE
Fix: logic to restore wordhighlighter debounce by default

### DIFF
--- a/src/vs/editor/contrib/wordHighlighter/browser/wordHighlighter.ts
+++ b/src/vs/editor/contrib/wordHighlighter/browser/wordHighlighter.ts
@@ -716,7 +716,7 @@ class WordHighlighter {
 				if (myRequestId === this.workerRequestTokenId) {
 					this.workerRequestCompleted = true;
 					this.workerRequestValue = data || [];
-					this._beginRenderDecorations(!noDelay);
+					this._beginRenderDecorations(noDelay);
 				}
 			}, onUnexpectedError);
 		}
@@ -730,9 +730,9 @@ class WordHighlighter {
 		}
 	}
 
-	private _beginRenderDecorations(delay?: boolean): void {
+	private _beginRenderDecorations(noDelay?: boolean): void {
 		const currentTime = (new Date()).getTime();
-		const minimumRenderTime = this.lastCursorPositionChangeTime + (delay ? 250 : 0);
+		const minimumRenderTime = this.lastCursorPositionChangeTime + (noDelay ? 0 : 250);
 
 		if (currentTime >= minimumRenderTime) {
 			// Synchronous


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fixes default debounce rates for occurrence highlighting