### PR TITLE
Prevent find widget from being cropped in AUX window

### DIFF
--- a/src/vs/base/browser/ui/inputbox/inputBox.css
+++ b/src/vs/base/browser/ui/inputbox/inputBox.css
@@ -24,7 +24,6 @@
 .monaco-inputbox > .ibwrapper {
 	position: relative;
 	width: 100%;
-	height: 100%;
 }
 
 .monaco-inputbox > .ibwrapper > .input {


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/227546

Steps to Reproduce:

1. Open a text editor in the main window.
2. Open the find widget and focus on it. Notice how the blue outline fully outlines the input box.
3. Right-click the editor tab and select "Copy into New Window".
4. In the new window, open the find widget and focus on it again.

| Before | After |
| ------- | ------ |
|![image](https://github.com/user-attachments/assets/72bfffa3-0275-42a3-be51-ddffe27758db)|![image](https://github.com/user-attachments/assets/27401719-409e-4215-81de-2ba755fac213)|

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
