### PR TITLE
Expose Account Preference in Extension context menu

### DIFF
--- a/src/vs/workbench/api/test/browser/extHostAuthentication.integrationTest.ts
+++ b/src/vs/workbench/api/test/browser/extHostAuthentication.integrationTest.ts
@@ -117,10 +117,10 @@ suite('ExtHostAuthentication', () => {
 		instantiationService.stub(IBrowserWorkbenchEnvironmentService, TestEnvironmentService);
 		instantiationService.stub(IProductService, TestProductService);
 		instantiationService.stub(IAuthenticationAccessService, instantiationService.createInstance(AuthenticationAccessService));
+		instantiationService.stub(IAuthenticationService, instantiationService.createInstance(AuthenticationService));
 		instantiationService.stub(IAuthenticationUsageService, instantiationService.createInstance(AuthenticationUsageService));
 		const rpcProtocol = new TestRPCProtocol();
 
-		instantiationService.stub(IAuthenticationService, instantiationService.createInstance(AuthenticationService));
 		instantiationService.stub(IAuthenticationExtensionsService, instantiationService.createInstance(AuthenticationExtensionsService));
 		rpcProtocol.set(MainContext.MainThreadAuthentication, instantiationService.createInstance(MainThreadAuthentication, rpcProtocol));
 		extHostAuthentication = new ExtHostAuthentication(rpcProtocol);

--- a/src/vs/workbench/contrib/authentication/browser/authentication.contribution.ts
+++ b/src/vs/workbench/contrib/authentication/browser/authentication.contribution.ts
@@ -21,6 +21,7 @@ import { Extensions, IExtensionFeatureTableRenderer, IExtensionFeaturesRegistry,
 import { ExtensionsRegistry } from '../../../services/extensions/common/extensionsRegistry.js';
 import { ManageTrustedExtensionsForAccountAction } from './actions/manageTrustedExtensionsForAccountAction.js';
 import { ManageAccountPreferencesForExtensionAction } from './actions/manageAccountPreferencesForExtensionAction.js';
+import { IAuthenticationUsageService } from '../../../services/authentication/browser/authenticationUsageService.js';
 
 const codeExchangeProxyCommand = CommandsRegistry.registerCommand('workbench.getCodeExchangeProxyEndpoints', function (accessor, _) {
 	const environmentService = accessor.get(IBrowserWorkbenchEnvironmentService);
@@ -105,7 +106,7 @@ const extensionFeature = Registry.as<IExtensionFeaturesRegistry>(Extensions.Exte
 	renderer: new SyncDescriptor(AuthenticationDataRenderer),
 });
 
-export class AuthenticationContribution extends Disposable implements IWorkbenchContribution {
+class AuthenticationContribution extends Disposable implements IWorkbenchContribution {
 	static ID = 'workbench.contrib.authentication';
 
 	private _placeholderMenuItem: IDisposable | undefined = MenuRegistry.appendMenuItem(MenuId.AccountsContext, {
@@ -204,4 +205,19 @@ export class AuthenticationContribution extends Disposable implements IWorkbench
 	}
 }
 
+class AuthenticationUsageContribution implements IWorkbenchContribution {
+	static ID = 'workbench.contrib.authenticationUsage';
+
+	constructor(
+		@IAuthenticationUsageService private readonly _authenticationUsageService: IAuthenticationUsageService,
+	) {
+		this._initializeExtensionUsageCache();
+	}
+
+	private async _initializeExtensionUsageCache() {
+		await this._authenticationUsageService.initializeExtensionUsageCache();
+	}
+}
+
 registerWorkbenchContribution2(AuthenticationContribution.ID, AuthenticationContribution, WorkbenchPhase.AfterRestored);
+registerWorkbenchContribution2(AuthenticationUsageContribution.ID, AuthenticationUsageContribution, WorkbenchPhase.Eventually);

--- a/src/vs/workbench/contrib/extensions/browser/extensions.contribution.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensions.contribution.ts
@@ -1566,7 +1566,7 @@ class ExtensionsContributions extends Disposable implements IWorkbenchContributi
 
 		this.registerExtensionAction({
 			id: 'workbench.extensions.action.configure',
-			title: localize2('workbench.extensions.action.configure', 'Extension Settings'),
+			title: localize2('workbench.extensions.action.configure', 'Settings'),
 			menu: {
 				id: MenuId.ExtensionContext,
 				group: '2_configure',
@@ -1577,8 +1577,20 @@ class ExtensionsContributions extends Disposable implements IWorkbenchContributi
 		});
 
 		this.registerExtensionAction({
+			id: 'workbench.extensions.action.manageAccountPreferences',
+			title: localize2('workbench.extensions.action.changeAccountPreference', "Account Preferences"),
+			menu: {
+				id: MenuId.ExtensionContext,
+				group: '2_configure',
+				when: ContextKeyExpr.and(ContextKeyExpr.equals('extensionStatus', 'installed'), ContextKeyExpr.has('extensionHasAccountPreferences')),
+				order: 2,
+			},
+			run: (accessor: ServicesAccessor, id: string) => accessor.get(ICommandService).executeCommand('_manageAccountPreferencesForExtension', id)
+		});
+
+		this.registerExtensionAction({
 			id: 'workbench.extensions.action.configureKeybindings',
-			title: localize2('workbench.extensions.action.configureKeybindings', 'Extension Keyboard Shortcuts'),
+			title: localize2('workbench.extensions.action.configureKeybindings', 'Keyboard Shortcuts'),
 			menu: {
 				id: MenuId.ExtensionContext,
 				group: '2_configure',

--- a/src/vs/workbench/contrib/extensions/browser/extensionsActions.ts
+++ b/src/vs/workbench/contrib/extensions/browser/extensionsActions.ts
@@ -71,6 +71,7 @@ import { Extensions, IExtensionFeaturesManagementService, IExtensionFeaturesRegi
 import { Registry } from '../../../../platform/registry/common/platform.js';
 import { IUpdateService } from '../../../../platform/update/common/update.js';
 import { ActionWithDropdownActionViewItem, IActionWithDropdownActionViewItemOptions } from '../../../../base/browser/ui/dropdown/dropdownActionViewItem.js';
+import { IAuthenticationUsageService } from '../../../services/authentication/browser/authenticationUsageService.js';
 
 export class PromptExtensionInstallFailureAction extends Action {
 
@@ -1198,6 +1199,7 @@ async function getContextMenuActionsGroups(extension: IExtension | undefined | n
 		const extensionRecommendationsService = accessor.get(IExtensionRecommendationsService);
 		const extensionIgnoredRecommendationsService = accessor.get(IExtensionIgnoredRecommendationsService);
 		const workbenchThemeService = accessor.get(IWorkbenchThemeService);
+		const authenticationUsageService = accessor.get(IAuthenticationUsageService);
 		const cksOverlay: [string, any][] = [];
 
 		if (extension) {
@@ -1241,10 +1243,11 @@ async function getContextMenuActionsGroups(extension: IExtension | undefined | n
 			cksOverlay.push(['extensionDisallowInstall', !!extension.deprecationInfo?.disallowInstall]);
 			cksOverlay.push(['extensionIsUnsigned', extension.gallery && !extension.gallery.isSigned]);
 
-			const [colorThemes, fileIconThemes, productIconThemes] = await Promise.all([workbenchThemeService.getColorThemes(), workbenchThemeService.getFileIconThemes(), workbenchThemeService.getProductIconThemes()]);
+			const [colorThemes, fileIconThemes, productIconThemes, extensionUsesAuth] = await Promise.all([workbenchThemeService.getColorThemes(), workbenchThemeService.getFileIconThemes(), workbenchThemeService.getProductIconThemes(), authenticationUsageService.extensionUsesAuth(extension.identifier.id.toLowerCase())]);
 			cksOverlay.push(['extensionHasColorThemes', colorThemes.some(theme => isThemeFromExtension(theme, extension))]);
 			cksOverlay.push(['extensionHasFileIconThemes', fileIconThemes.some(theme => isThemeFromExtension(theme, extension))]);
 			cksOverlay.push(['extensionHasProductIconThemes', productIconThemes.some(theme => isThemeFromExtension(theme, extension))]);
+			cksOverlay.push(['extensionHasAccountPreferences', extensionUsesAuth]);
 
 			cksOverlay.push(['canSetLanguage', extensionsWorkbenchService.canSetLanguage(extension)]);
 			cksOverlay.push(['isActiveLanguagePackExtension', extension.gallery && language === getLocale(extension.gallery)]);

--- a/src/vs/workbench/services/authentication/browser/authenticationUsageService.ts
+++ b/src/vs/workbench/services/authentication/browser/authenticationUsageService.ts
@@ -5,7 +5,9 @@
 
 import { InstantiationType, registerSingleton } from '../../../../platform/instantiation/common/extensions.js';
 import { createDecorator } from '../../../../platform/instantiation/common/instantiation.js';
+import { IProductService } from '../../../../platform/product/common/productService.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
+import { IAuthenticationService } from '../common/authentication.js';
 
 export interface IAccountUsage {
 	extensionId: string;
@@ -16,15 +18,57 @@ export interface IAccountUsage {
 export const IAuthenticationUsageService = createDecorator<IAuthenticationUsageService>('IAuthenticationUsageService');
 export interface IAuthenticationUsageService {
 	readonly _serviceBrand: undefined;
+	/**
+	 * Initializes the cache of extensions that use authentication. Ideally used in a contribution that can be run eventually after the workspace is loaded.
+	 */
+	initializeExtensionUsageCache(): Promise<void>;
+	/**
+	 * Checks if an extension uses authentication
+	 * @param extensionId The id of the extension to check
+	 */
+	extensionUsesAuth(extensionId: string): Promise<boolean>;
+	/**
+	 * Reads the usages for an account
+	 * @param providerId The id of the authentication provider to get usages for
+	 * @param accountName The name of the account to get usages for
+	 */
 	readAccountUsages(providerId: string, accountName: string,): IAccountUsage[];
+	/**
+	 *
+	 * @param providerId The id of the authentication provider to get usages for
+	 * @param accountName The name of the account to get usages for
+	 */
 	removeAccountUsage(providerId: string, accountName: string): void;
+	/**
+	 * Adds a usage for an account
+	 * @param providerId The id of the authentication provider to get usages for
+	 * @param accountName The name of the account to get usages for
+	 * @param extensionId The id of the extension to add a usage for
+	 * @param extensionName The name of the extension to add a usage for
+	 */
 	addAccountUsage(providerId: string, accountName: string, extensionId: string, extensionName: string): void;
 }
 
 export class AuthenticationUsageService implements IAuthenticationUsageService {
 	_serviceBrand: undefined;
 
-	constructor(@IStorageService private readonly _storageService: IStorageService) { }
+	private _initializedPromise: Promise<void> | undefined;
+	private _extensionsUsingAuth = new Set<string>();
+
+	constructor(
+		@IStorageService private readonly _storageService: IStorageService,
+		@IAuthenticationService private readonly _authenticationService: IAuthenticationService,
+		@IProductService private readonly _productService: IProductService,
+	) { }
+
+	initializeExtensionUsageCache(): Promise<void> {
+		return this._initExtensionsUsingAuth();
+	}
+
+	async extensionUsesAuth(extensionId: string): Promise<boolean> {
+		await this._initExtensionsUsingAuth();
+		return this._extensionsUsingAuth.has(extensionId);
+	}
 
 	readAccountUsages(providerId: string, accountName: string): IAccountUsage[] {
 		const accountKey = `${providerId}-${accountName}-usages`;
@@ -64,6 +108,44 @@ export class AuthenticationUsageService implements IAuthenticationUsageService {
 		}
 
 		this._storageService.store(accountKey, JSON.stringify(usages), StorageScope.APPLICATION, StorageTarget.MACHINE);
+		this._extensionsUsingAuth.add(extensionId);
+	}
+
+	private _initExtensionsUsingAuth() {
+		if (this._initializedPromise) {
+			return this._initializedPromise;
+		}
+
+		// If an extension is listed in `trustedExtensionAuthAccess` we should consider it as using auth
+		const trustedExtensionAuthAccess = this._productService.trustedExtensionAuthAccess;
+		if (Array.isArray(trustedExtensionAuthAccess)) {
+			for (const extensionId of trustedExtensionAuthAccess) {
+				this._extensionsUsingAuth.add(extensionId);
+			}
+		} else if (trustedExtensionAuthAccess) {
+			for (const extensions of Object.values(trustedExtensionAuthAccess)) {
+				for (const extensionId of extensions) {
+					this._extensionsUsingAuth.add(extensionId);
+				}
+			}
+		}
+
+		this._initializedPromise = (async () => {
+			for (const providerId of this._authenticationService.getProviderIds()) {
+				try {
+					const accounts = await this._authenticationService.getAccounts(providerId);
+					for (const account of accounts) {
+						const usage = this.readAccountUsages(providerId, account.label);
+						for (const u of usage) {
+							this._extensionsUsingAuth.add(u.extensionId);
+						}
+					}
+				} catch (e) {
+					// ignore
+				}
+			}
+		})();
+		return this._initializedPromise;
 	}
 }
 


### PR DESCRIPTION
So we have more entry points to account preference.

To do this, I added to the `AuthenticationUsageService` the ability to query if an extension "uses auth". I'm not totally sold on that being where this is... but it works for now.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

![image](https://github.com/user-attachments/assets/5c1a4f37-d86e-4516-a264-f91e871d292c)
![image](https://github.com/user-attachments/assets/546587a2-c43f-40f7-a238-3dd1b4e76fd8)

ref https://github.com/microsoft/vscode/issues/225943