### PR TITLE
Add no verify option to git extension command center

### DIFF
--- a/extensions/git/src/postCommitCommands.ts
+++ b/extensions/git/src/postCommitCommands.ts
@@ -199,7 +199,7 @@ export class CommitCommandsCenter {
 		return [
 			{ command: 'git.commit', title: l10n.t('{0} Commit', icon ?? '$(check)'), tooltip, arguments: [this.repository.sourceControl, null] },
 			{ command: 'git.commitAmend', title: l10n.t('{0} Commit (Amend)', icon ?? '$(check)'), tooltip, arguments: [this.repository.sourceControl, null] },
-			{ command: 'git.commitNoVerify', title: l10n.t('{0} Commit (No verify)', icon ?? '$(check)'), tooltip, arguments: [this.repository.sourceControl, null] }
+			{ command: 'git.commitNoVerify', title: l10n.t('{0} Commit (No Verify)', icon ?? '$(check)'), tooltip, arguments: [this.repository.sourceControl, null] }
 		];
 	}
 

--- a/extensions/git/src/postCommitCommands.ts
+++ b/extensions/git/src/postCommitCommands.ts
@@ -199,6 +199,7 @@ export class CommitCommandsCenter {
 		return [
 			{ command: 'git.commit', title: l10n.t('{0} Commit', icon ?? '$(check)'), tooltip, arguments: [this.repository.sourceControl, null] },
 			{ command: 'git.commitAmend', title: l10n.t('{0} Commit (Amend)', icon ?? '$(check)'), tooltip, arguments: [this.repository.sourceControl, null] },
+			{ command: 'git.commitNoVerify', title: l10n.t('{0} Commit (No verify)', icon ?? '$(check)'), tooltip, arguments: [this.repository.sourceControl, null] }
 		];
 	}
 


### PR DESCRIPTION
This adds the option to Commit (No verify) in the Git extension command center (in addition to the 3 dots menu)

<img width="1210" alt="git extension no verify screenshot" src="https://github.com/user-attachments/assets/a2bd442d-e6c4-4bfc-9d3c-dce284d6eb19">

The changes are basically a dupe of [this PR](https://github.com/microsoft/vscode/pull/190143) because that was closed automatically and the user was deleted (@ghost)

Addresses https://github.com/microsoft/vscode/issues/190047