### PR TITLE
Fix Wayland display error for xdg-open

### DIFF
--- a/resources/linux/snap/electron-launch
+++ b/resources/linux/snap/electron-launch
@@ -149,17 +149,19 @@ if [[ -n "$XDG_RUNTIME_DIR" && -z "$DISABLE_WAYLAND" ]]; then
     if [ -n "$WAYLAND_DISPLAY" ]; then
         wdisplay="$WAYLAND_DISPLAY"
     fi
-    wayland_sockpath="$XDG_RUNTIME_DIR/../$wdisplay"
-    wayland_snappath="$XDG_RUNTIME_DIR/$wdisplay"
+    wayland_sockpath="$XDG_RUNTIME_DIR/$wdisplay"
+    snap_paths=("$XDG_RUNTIME_DIR/snap."*/"$wdisplay") 
     if [ -S "$wayland_sockpath" ]; then
         # if running under wayland, use it
         #export WAYLAND_DEBUG=1
         # shellcheck disable=SC2034
         wayland_available=true
-        # create the compat symlink for now
-        if [ ! -e "$wayland_snappath" ]; then
-            ln -s "$wayland_sockpath" "$wayland_snappath"
-        fi
+        for wayland_snappath in "${snap_paths[@]}"; do
+          # create the compat symlink for now
+          if [ ! -e "$wayland_snappath" ]; then
+              ln -s "$wayland_sockpath" "$wayland_snappath"
+          fi
+        done
     fi
 fi
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
## Description
Refactor Wayland socket handling
- Update the wayland socket path to use the correct XDG_RUNTIME_DIR structure.
- Introduce support for multiple snap paths to accommodate Wayland display.


Closes #223591