### PR TITLE
Send access token instead of id token

### DIFF
--- a/src/vs/workbench/contrib/editSessions/browser/editSessionsStorageService.ts
+++ b/src/vs/workbench/contrib/editSessions/browser/editSessionsStorageService.ts
@@ -269,7 +269,7 @@ export class EditSessionsWorkbenchService extends Disposable implements IEditSes
 			const existingSession = await this.getExistingSession();
 			if (existingSession) {
 				this.logService.info(`Found existing authentication session with ID ${existingSession.session.id}`);
-				return { sessionId: existingSession.session.id, token: existingSession.session.idToken ?? existingSession.session.accessToken, providerId: existingSession.session.providerId };
+				return { sessionId: existingSession.session.id, token: existingSession.session.accessToken, providerId: existingSession.session.providerId };
 			} else {
 				this._didSignOut.fire();
 			}
@@ -296,7 +296,7 @@ export class EditSessionsWorkbenchService extends Disposable implements IEditSes
 		const authenticationSession = await this.getAccountPreference(reason);
 		if (authenticationSession !== undefined) {
 			this.existingSessionId = authenticationSession.id;
-			return { sessionId: authenticationSession.id, token: authenticationSession.idToken ?? authenticationSession.accessToken, providerId: authenticationSession.providerId };
+			return { sessionId: authenticationSession.id, token: authenticationSession.accessToken, providerId: authenticationSession.providerId };
 		}
 
 		return undefined;

--- a/src/vs/workbench/services/userDataSync/browser/userDataSyncWorkbenchService.ts
+++ b/src/vs/workbench/services/userDataSync/browser/userDataSyncWorkbenchService.ts
@@ -52,7 +52,7 @@ class UserDataSyncAccount implements IUserDataSyncAccount {
 	get sessionId(): string { return this.session.id; }
 	get accountName(): string { return this.session.account.label; }
 	get accountId(): string { return this.session.account.id; }
-	get token(): string { return this.session.idToken || this.session.accessToken; }
+	get token(): string { return this.session.accessToken; }
 }
 
 type MergeEditorInput = { base: URI; input1: { uri: URI }; input2: { uri: URI }; result: URI };


### PR DESCRIPTION
Now that we ask for the SettingsSync scope, we can switch to using the access token with the explicit permission to ReadWrite Settings Sync.

Needs deployment of Settings Sync before we merge it in.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
