### PR TITLE
Small fix for the new account preference

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadAuthentication.ts
+++ b/src/vs/workbench/api/browser/mainThreadAuthentication.ts
@@ -262,7 +262,7 @@ export class MainThreadAuthentication extends Disposable implements MainThreadAu
 		}
 
 		// For the silent flows, if we have a session but we don't have a session preference, we'll return the first one that is valid.
-		if (!matchingAccountPreferenceSession) {
+		if (!matchingAccountPreferenceSession && !this.authenticationExtensionsService.getAccountPreference(extensionId, providerId)) {
 			const validSession = sessions.find(session => this.authenticationAccessService.isAccessAllowed(providerId, session.account.label, extensionId));
 			if (validSession) {
 				return validSession;


### PR DESCRIPTION
We need to check this directly so that we are sure we don't have an account preference... since `matchingAccountPreferenceSession` could be undefined because there is no valid session that matches the preference.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
ref https://github.com/microsoft/vscode/issues/225943