### PR TITLE
More tweaks to inline anchor rendering

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/media/chatInlineAnchorWidget.css
+++ b/src/vs/workbench/contrib/chat/browser/media/chatInlineAnchorWidget.css
@@ -20,22 +20,25 @@
 }
 
 .chat-inline-anchor-widget .icon {
-	display: inline-block;
 	vertical-align: middle;
+	line-height: 1em;
+	font-size: 90%;
+	overflow: hidden;
 }
 
-.chat-inline-anchor-widget .icon::before {
+.show-file-icons.chat-inline-anchor-widget .icon::before {
 	display: inline-block;
-	background-size: 100%;
-	background-position: left center;
-	background-repeat: no-repeat;
-	width: 0.8em !important;
-	height: 0.8em;
-	margin-right: 4px;
-}
+	line-height: 100%;
+	overflow: hidden;
 
-.chat-inline-anchor-widget .file-icon::before {
-	font-size: 120%;
+	background-size: contain;
+	background-position: center;
+	background-repeat: no-repeat;
+
+	margin-right: 3px;
+	margin-bottom: 1px;
+
+	flex-shrink: 0;
 }
 
 .chat-inline-anchor-widget .icon-label {

--- a/src/vs/workbench/services/themes/browser/fileIconThemeData.ts
+++ b/src/vs/workbench/services/themes/browser/fileIconThemeData.ts
@@ -406,12 +406,15 @@ export class FileIconThemeLoader {
 			cssRules.push(`.show-file-icons .file-icon::before, .show-file-icons .folder-icon::before, .show-file-icons .rootfolder-icon::before { font-family: '${fonts[0].id}'; font-size: ${defaultFontSize}; }`);
 		}
 
+		// Use emQuads to prevent the icon from collapsing to zero height for image icons
+		const emQuad = '\\2001';
+
 		for (const defId in selectorByDefinitionId) {
 			const selectors = selectorByDefinitionId[defId];
 			const definition = iconThemeDocument.iconDefinitions[defId];
 			if (definition) {
 				if (definition.iconPath) {
-					cssRules.push(`${selectors.join(', ')} { content: ' '; background-image: ${asCSSUrl(resolvePath(definition.iconPath))}; }`);
+					cssRules.push(`${selectors.join(', ')} { content: '${emQuad}'; background-image: ${asCSSUrl(resolvePath(definition.iconPath))}; }`);
 				} else if (definition.fontCharacter || definition.fontColor) {
 					const body = [];
 					if (definition.fontColor) {
@@ -441,8 +444,8 @@ export class FileIconThemeLoader {
 					const icon = this.languageService.getIcon(languageId);
 					if (icon) {
 						const selector = `.show-file-icons .${escapeCSS(languageId)}-lang-file-icon.file-icon::before`;
-						cssRules.push(`${selector} { content: ' '; background-image: ${asCSSUrl(icon.dark)}; }`);
-						cssRules.push(`.vs ${selector} { content: ' '; background-image: ${asCSSUrl(icon.light)}; }`);
+						cssRules.push(`${selector} { content: '${emQuad}'; background-image: ${asCSSUrl(icon.dark)}; }`);
+						cssRules.push(`.vs ${selector} { content: '${emQuad}'; background-image: ${asCSSUrl(icon.light)}; }`);
 					}
 				}
 			}


### PR DESCRIPTION
Better centers the file icon and also supports more file icon types

As part of this I think I need to tweak the default css rules for the file icons. The issue is that for image file icons, if they are rendered inline with `content: " "` they can end up collapsing down to zero height. I can override this in my css rules, but that causes other issues with non-image icons

Instead we can use an em quad to make the icon take up the right height by default. This size can still be overridden by css rules elsewhere in the workbench

Also just adding that I'm not using our normal IconLabel classes because I want normal inline text wrapping and that seemed impossible to get using it

