### PR TITLE
Polish references button

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/chatReferencesContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/chatReferencesContentPart.ts
@@ -66,7 +66,7 @@ export class ChatCollapsibleListContentPart extends Disposable implements IChatC
 			localize('usedReferencesPlural', "Used {0} references", data.length) :
 			localize('usedReferencesSingular', "Used {0} reference", 1));
 		const iconElement = $('.chat-used-context-icon');
-		const icon = (element: IChatResponseViewModel) => element.usedReferencesExpanded ? Codicon.chevronUp : Codicon.chevronDown;
+		const icon = (element: IChatResponseViewModel) => element.usedReferencesExpanded ? Codicon.chevronDown : Codicon.chevronRight;
 		iconElement.classList.add(...ThemeIcon.asClassNameArray(icon(element)));
 		const buttonElement = $('.chat-used-context-label', undefined);
 
@@ -82,7 +82,7 @@ export class ChatCollapsibleListContentPart extends Disposable implements IChatC
 		}));
 		this.domNode = $('.chat-used-context', undefined, buttonElement);
 		collapseButton.label = referencesLabel;
-		collapseButton.element.append(iconElement);
+		collapseButton.element.prepend(iconElement);
 		this.updateAriaLabel(collapseButton.element, referencesLabel, element.usedReferencesExpanded);
 		this.domNode.classList.toggle('chat-used-context-collapsed', !element.usedReferencesExpanded);
 		this._register(collapseButton.onDidClick(() => {

--- a/src/vs/workbench/contrib/chat/browser/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/media/chat.css
@@ -929,10 +929,10 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	width: fit-content;
 	border: none;
 	border-radius: 4px;
-	padding: 2px 6px 2px 6px;
+	gap: 2px;
+	padding: 2px 6px 2px 2px;
 	text-align: initial;
 	justify-content: initial;
-	margin-left: -6px;
 }
 
 .interactive-session .chat-used-context-label .monaco-button:hover {


### PR DESCRIPTION
Slightly reverting a previous change since we still want to render spinners where the chevron is instead of pushing the text around.