### PR TITLE
Revert "Apply auto synthesize setting to textual input for chat reque…

### DIFF
--- a/src/vs/workbench/contrib/accessibility/browser/accessibilityConfiguration.ts
+++ b/src/vs/workbench/contrib/accessibility/browser/accessibilityConfiguration.ts
@@ -775,7 +775,7 @@ export class DynamicSpeechAccessibilityConfiguration extends Disposable implemen
 						localize('accessibility.voice.autoSynthesize.off', "Disable the feature."),
 						localize('accessibility.voice.autoSynthesize.auto', "When a screen reader is detected, disable the feature. Otherwise, enable the feature.")
 					],
-					'markdownDescription': localize('autoSynthesize', "Whether a textual response should automatically be read out aloud. For non screen reader users, this will happen when speech was used as input. For screen reader users, this will happen with any input type. For example, in a chat session, a response is automatically synthesized when voice is used as chat request."),
+					'markdownDescription': localize('autoSynthesize', "Whether a textual response should automatically be read out aloud when speech was used as input. For example in a chat session, a response is automatically synthesized when voice was used as chat request."),
 					'default': this.productService.quality !== 'stable' ? 'auto' : 'off', // TODO@bpasero decide on a default
 					'tags': ['accessibility']
 				}

--- a/src/vs/workbench/contrib/chat/browser/chatAccessibilityService.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatAccessibilityService.ts
@@ -14,7 +14,6 @@ import { renderStringAsPlaintext } from '../../../../base/browser/markdownRender
 import { MarkdownString } from '../../../../base/common/htmlContent.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { AccessibilityVoiceSettingId } from '../../accessibility/browser/accessibilityConfiguration.js';
-import { ICommandService } from '../../../../platform/commands/common/commands.js';
 
 const CHAT_RESPONSE_PENDING_ALLOWANCE_MS = 4000;
 export class ChatAccessibilityService extends Disposable implements IChatAccessibilityService {
@@ -28,8 +27,7 @@ export class ChatAccessibilityService extends Disposable implements IChatAccessi
 	constructor(
 		@IAccessibilitySignalService private readonly _accessibilitySignalService: IAccessibilitySignalService,
 		@IInstantiationService private readonly _instantiationService: IInstantiationService,
-		@IConfigurationService private readonly _configurationService: IConfigurationService,
-		@ICommandService private readonly _commandService: ICommandService,
+		@IConfigurationService private readonly _configurationService: IConfigurationService
 	) {
 		super();
 	}
@@ -49,9 +47,7 @@ export class ChatAccessibilityService extends Disposable implements IChatAccessi
 		}
 		const errorDetails = isPanelChat && response.errorDetails ? ` ${response.errorDetails.message}` : '';
 		const plainTextResponse = renderStringAsPlaintext(new MarkdownString(responseContent));
-		if (this._configurationService.getValue(AccessibilityVoiceSettingId.AutoSynthesize) === 'on' && !isVoiceInput) {
-			this._commandService.executeCommand('workbench.action.chat.readChatResponseAloud');
-		} else {
+		if (!isVoiceInput || this._configurationService.getValue(AccessibilityVoiceSettingId.AutoSynthesize) !== 'on') {
 			status(plainTextResponse + errorDetails);
 		}
 	}


### PR DESCRIPTION
Fixes [#229062](https://github.com/microsoft/vscode/issues/229062)

This reverts commit 9eeccd11af2ed0d35c9646d9da84e04458bb0a3a.

Some thorough testing by @jooyoungseo has proven that we don't want to use auto synthesize here when a textual chat response is made as screen reader announcement rate, pitch, etc. can be fine-tuned unlike the synthesizer. Users can add a keybinding should they want to use this feature for textual request responses.