### PR TITLE
Custom reference rendering for kernel variable

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/chatReferencesContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/chatReferencesContentPart.ts
@@ -340,6 +340,11 @@ class CollapsibleListRenderer implements IListRenderer<IChatCollapsibleListItem,
 						description: `#${reference.variableName}`,
 						range: 'range' in reference.value ? reference.value.range : undefined,
 					}, { icon, title: data.options?.status?.description ?? data.title });
+			} else if (reference.variableName.startsWith('kernelVariable')) {
+				const variable = reference.variableName.split(':')[1];
+				const asVariableName = `${variable}`;
+				const label = `Kernel variable`;
+				templateData.label.setLabel(label, asVariableName, { title: data.options?.status?.description });
 			} else {
 				const variable = this.chatVariablesService.getVariable(reference.variableName);
 				// This is a hack to get chat attachment ThemeIcons to render for resource labels


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

<img width="574" alt="image" src="https://github.com/user-attachments/assets/2615edb1-62fa-49cf-bf46-a42610d5ef93">

This is my attempt to custom render the kernel variable in the references list. Since the kernel variables are not registered via the `ChatVariableService` (similar to how files are provided as suggestions), I don't see a way of contributing the `fullName`/`icon`/etc to allow more generic custom rendering. The variable is sent to Copilot and is sent back as reference with the name only `{ variableName: '#kernelVariable:df' }`, which loses all the rest of the information (e.g., icon).
