### PR TITLE
build: add npmrc to remote/web folder

### DIFF
--- a/remote/web/.npmrc
+++ b/remote/web/.npmrc
@@ -1,0 +1,2 @@
+legacy-peer-deps="true"
+timeout=180000

--- a/remote/web/package-lock.json
+++ b/remote/web/package-lock.json
@@ -160,12 +160,6 @@
 			"resolved": "https://registry.npmjs.org/tas-client-umd/-/tas-client-umd-0.2.0.tgz",
 			"integrity": "sha512-oezN7mJVm5qZDVEby7OzxCLKUpUN5of0rY4dvOWaDF2JZBlGpd3BXceFN8B53qlTaIkVSzP65aAMT0Vc+/N25Q=="
 		},
-		"node_modules/tslib": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
-			"integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
-			"peer": true
-		},
 		"node_modules/vscode-oniguruma": {
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.7.0.tgz",


### PR DESCRIPTION
`remote/web` takes the configuration from root when run via postinstall step, but if a user were to `cd remote/web` and run `npm i` then system configuration will be applied.

Addressed accidental change via https://github.com/microsoft/vscode/commit/31e1cb3e716cf2b0579ebb6c6f723ba9b3717662

FYI @Tyriar 