### PR TITLE
Fix json not format pasted content

### DIFF
--- a/extensions/json-language-features/client/src/jsonClient.ts
+++ b/extensions/json-language-features/client/src/jsonClient.ts
@@ -533,9 +533,15 @@ async function startClientWithParticipants(context: ExtensionContext, languagePa
 						trimFinalNewlines: filesConfig.get<boolean>('trimFinalNewlines'),
 						insertFinalNewline: filesConfig.get<boolean>('insertFinalNewline'),
 					};
+
+					const formattingRange = new Range(
+						new Position(Math.max(0, range.start.line - 1), range.start.character),
+						new Position(range.end.line, range.end.character)
+					);
+
 					const params: DocumentRangeFormattingParams = {
 						textDocument: client.code2ProtocolConverter.asTextDocumentIdentifier(document),
-						range: client.code2ProtocolConverter.asRange(range),
+						range: client.code2ProtocolConverter.asRange(formattingRange),
 						options: client.code2ProtocolConverter.asFormattingOptions(options, fileFormattingOptions)
 					};
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
Close #228528 

Slightly increase the range when the range is not full content to let `jsonc-parser` work properly.

![demo](https://github.com/user-attachments/assets/6e8d0c64-3f3c-4b67-a0f7-41e505a73611)
