### PR TITLE
Make cursor blink when experimental edit context is enabled

### DIFF
--- a/src/vs/editor/browser/viewParts/viewCursors/viewCursors.ts
+++ b/src/vs/editor/browser/viewParts/viewCursors/viewCursors.ts
@@ -225,7 +225,7 @@ export class ViewCursors extends ViewPart {
 	// ---- blinking logic
 
 	private _getCursorBlinking(): TextEditorCursorBlinkingStyle {
-		// Remove the following if statement when experimental edit context is made default sole implementation
+		// TODO: Remove the following if statement when experimental edit context is made default sole implementation
 		if (this._isComposingInput && !this._experimentalEditContextEnabled) {
 			// avoid double cursors
 			return TextEditorCursorBlinkingStyle.Hidden;

--- a/src/vs/editor/browser/viewParts/viewCursors/viewCursors.ts
+++ b/src/vs/editor/browser/viewParts/viewCursors/viewCursors.ts
@@ -225,6 +225,7 @@ export class ViewCursors extends ViewPart {
 	// ---- blinking logic
 
 	private _getCursorBlinking(): TextEditorCursorBlinkingStyle {
+		// Remove the following if statement when experimental edit context is made default sole implementation
 		if (this._isComposingInput && !this._experimentalEditContextEnabled) {
 			// avoid double cursors
 			return TextEditorCursorBlinkingStyle.Hidden;

--- a/src/vs/editor/browser/viewParts/viewCursors/viewCursors.ts
+++ b/src/vs/editor/browser/viewParts/viewCursors/viewCursors.ts
@@ -35,6 +35,7 @@ export class ViewCursors extends ViewPart {
 	private _cursorBlinking: TextEditorCursorBlinkingStyle;
 	private _cursorStyle: TextEditorCursorStyle;
 	private _cursorSmoothCaretAnimation: 'off' | 'explicit' | 'on';
+	private _experimentalEditContextEnabled: boolean;
 	private _selectionIsEmpty: boolean;
 	private _isComposingInput: boolean;
 
@@ -60,6 +61,7 @@ export class ViewCursors extends ViewPart {
 		this._cursorBlinking = options.get(EditorOption.cursorBlinking);
 		this._cursorStyle = options.get(EditorOption.cursorStyle);
 		this._cursorSmoothCaretAnimation = options.get(EditorOption.cursorSmoothCaretAnimation);
+		this._experimentalEditContextEnabled = options.get(EditorOption.experimentalEditContextEnabled);
 		this._selectionIsEmpty = true;
 		this._isComposingInput = false;
 
@@ -114,6 +116,7 @@ export class ViewCursors extends ViewPart {
 		this._cursorBlinking = options.get(EditorOption.cursorBlinking);
 		this._cursorStyle = options.get(EditorOption.cursorStyle);
 		this._cursorSmoothCaretAnimation = options.get(EditorOption.cursorSmoothCaretAnimation);
+		this._experimentalEditContextEnabled = options.get(EditorOption.experimentalEditContextEnabled);
 
 		this._updateBlinking();
 		this._updateDomClassName();
@@ -222,7 +225,7 @@ export class ViewCursors extends ViewPart {
 	// ---- blinking logic
 
 	private _getCursorBlinking(): TextEditorCursorBlinkingStyle {
-		if (this._isComposingInput) {
+		if (this._isComposingInput && !this._experimentalEditContextEnabled) {
 			// avoid double cursors
 			return TextEditorCursorBlinkingStyle.Hidden;
 		}


### PR DESCRIPTION
Previously when we did not yet have the experimental edit context yet, we would make a cursor blink in the text area cover. Now we don't have a text area cover anymore with the edit context so blinking should be reactivated. 

fixes https://github.com/microsoft/vscode/issues/229247