### PR TITLE
Git - remove the usage of `cp.execSync` from git integration test. Add assertions.

### DIFF
--- a/extensions/git/src/test/smoke.test.ts
+++ b/extensions/git/src/test/smoke.test.ts
@@ -129,28 +129,26 @@ suite('git smoke test', function () {
 	});
 
 	test('rename/delete conflict', async function () {
-		cp.execSync('git checkout -b test', { cwd });
+		await commands.executeCommand('workbench.view.scm');
 
+		await repository.createBranch('test', true);
+
+		// Delete file (test branch)
 		fs.unlinkSync(file('app.js'));
-		cp.execSync('git add .', { cwd });
+		await repository.commit('commit on test', { all: true });
 
-		await repository.commit('commit on test');
-		cp.execSync('git checkout main', { cwd });
+		await repository.checkout('main');
 
+		// Rename file (main branch)
 		fs.renameSync(file('app.js'), file('rename.js'));
-		cp.execSync('git add .', { cwd });
-		await repository.commit('commit on main');
+		await repository.commit('commit on main', { all: true });
 
 		try {
-			cp.execSync('git merge test', { cwd });
+			await repository.merge('test');
 		} catch (e) { }
 
-		setTimeout(() => {
-			commands.executeCommand('workbench.scm.focus');
-		}, 2e3);
-
-		await new Promise(resolve => {
-			setTimeout(resolve, 5e3);
-		});
+		assert.strictEqual(repository.state.mergeChanges.length, 1);
+		assert.strictEqual(repository.state.workingTreeChanges.length, 0);
+		assert.strictEqual(repository.state.indexChanges.length, 0);
 	});
 });


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
