### PR TITLE
remove safari paste workaround

### DIFF
--- a/src/vs/platform/clipboard/browser/clipboardService.ts
+++ b/src/vs/platform/clipboard/browser/clipboardService.ts
@@ -34,7 +34,6 @@ export class BrowserClipboardService extends Disposable implements IClipboardSer
 
 		if (isSafari || isWebkitWebView) {
 			this.installWebKitWriteTextWorkaround();
-			this.installWebKitReadWorkaround();
 		}
 
 		// Keep track of copy operations to reset our set of
@@ -70,7 +69,6 @@ export class BrowserClipboardService extends Disposable implements IClipboardSer
 	}
 
 	private webKitPendingClipboardWritePromise: DeferredPromise<string> | undefined;
-	private webKitPendingClipboardReadPromise: DeferredPromise<string> | undefined;
 
 	// In Safari, it has the following note:
 	//
@@ -107,29 +105,6 @@ export class BrowserClipboardService extends Disposable implements IClipboardSer
 			});
 		};
 
-
-		this._register(Event.runAndSubscribe(this.layoutService.onDidAddContainer, ({ container, disposables }) => {
-			disposables.add(addDisposableListener(container, 'click', handler));
-			disposables.add(addDisposableListener(container, 'keydown', handler));
-		}, { container: this.layoutService.mainContainer, disposables: this._store }));
-	}
-
-	// Experimental
-	private installWebKitReadWorkaround(): void {
-		const handler = () => {
-			const currentReadPromise = new DeferredPromise<string>();
-
-			// Cancel the previous promise since we just created a new one in response to this new event
-			if (this.webKitPendingClipboardReadPromise && !this.webKitPendingClipboardReadPromise.isSettled) {
-				this.webKitPendingClipboardReadPromise.cancel();
-			}
-			this.webKitPendingClipboardReadPromise = currentReadPromise;
-			getActiveWindow().navigator.clipboard.read().catch(async err => {
-				if (!(err instanceof Error) || err.name !== 'NotAllowedError' || !currentReadPromise.isRejected) {
-					this.logService.error(err);
-				}
-			});
-		};
 
 		this._register(Event.runAndSubscribe(this.layoutService.onDidAddContainer, ({ container, disposables }) => {
 			disposables.add(addDisposableListener(container, 'click', handler));


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

fixes issue where a `paste` context menu shows up everywhere in safari on web

fixes https://github.com/microsoft/vscode/issues/229400