### PR TITLE
implement `IChatWidget`, `lastFocusedWidget` for terminal

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatWidget.ts
@@ -1098,7 +1098,7 @@ export class ChatWidgetService implements IChatWidgetService {
 	private _lastFocusedWidget: ChatWidget | undefined = undefined;
 
 	get lastFocusedWidget(): IChatWidget | undefined {
-		return TerminalChatController.activeChatWidget?.chatWidget?.inlineChatWidget.chatWidget ?? this._lastFocusedWidget;
+		return TerminalChatController.activeChatController?.chatWidget ?? this._lastFocusedWidget;
 	}
 
 	constructor() { }

--- a/src/vs/workbench/contrib/chat/browser/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatWidget.ts
@@ -1098,7 +1098,7 @@ export class ChatWidgetService implements IChatWidgetService {
 	private _lastFocusedWidget: ChatWidget | undefined = undefined;
 
 	get lastFocusedWidget(): IChatWidget | undefined {
-		return TerminalChatController.activeChatWidget?.chatWidget ?? this._lastFocusedWidget;
+		return TerminalChatController.activeChatWidget?.chatWidget?.inlineChatWidget.chatWidget ?? this._lastFocusedWidget;
 	}
 
 	constructor() { }

--- a/src/vs/workbench/contrib/chat/browser/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatWidget.ts
@@ -29,6 +29,7 @@ import { WorkbenchObjectTree } from '../../../../platform/list/browser/listServi
 import { ILogService } from '../../../../platform/log/common/log.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
 import { IThemeService } from '../../../../platform/theme/common/themeService.js';
+import { TerminalChatController } from '../../terminal/terminalContribExports.js';
 import { ChatAgentLocation, IChatAgentCommand, IChatAgentData, IChatAgentService, IChatWelcomeMessageContent, isChatWelcomeMessageContent } from '../common/chatAgents.js';
 import { CONTEXT_CHAT_INPUT_HAS_AGENT, CONTEXT_CHAT_LOCATION, CONTEXT_CHAT_REQUEST_IN_PROGRESS, CONTEXT_IN_CHAT_SESSION, CONTEXT_IN_QUICK_CHAT, CONTEXT_LAST_ITEM_ID, CONTEXT_PARTICIPANT_SUPPORTS_MODEL_PICKER, CONTEXT_RESPONSE_FILTERED } from '../common/chatContextKeys.js';
 import { IChatEditingService, IChatEditingSession } from '../common/chatEditingService.js';
@@ -1096,8 +1097,8 @@ export class ChatWidgetService implements IChatWidgetService {
 	private _widgets: ChatWidget[] = [];
 	private _lastFocusedWidget: ChatWidget | undefined = undefined;
 
-	get lastFocusedWidget(): ChatWidget | undefined {
-		return this._lastFocusedWidget;
+	get lastFocusedWidget(): IChatWidget | undefined {
+		return TerminalChatController.activeChatWidget?.chatWidget ?? this._lastFocusedWidget;
 	}
 
 	constructor() { }

--- a/src/vs/workbench/contrib/chat/electron-sandbox/actions/voiceChatActions.ts
+++ b/src/vs/workbench/contrib/chat/electron-sandbox/actions/voiceChatActions.ts
@@ -146,7 +146,7 @@ class VoiceChatSessionControllerFactory {
 		// 1.) probe terminal chat which is not part of chat widget service
 		const activeInstance = terminalService.activeInstance;
 		if (activeInstance) {
-			const terminalChat = TerminalChatController.activeChatWidget || TerminalChatController.get(activeInstance);
+			const terminalChat = TerminalChatController.activeChatController || TerminalChatController.get(activeInstance);
 			if (terminalChat?.hasFocus()) {
 				return VoiceChatSessionControllerFactory.doCreateForTerminalChat(terminalChat);
 			}
@@ -697,7 +697,7 @@ class ChatSynthesizerSessionController {
 		// 1.) probe terminal chat which is not part of chat widget service
 		const activeInstance = terminalService.activeInstance;
 		if (activeInstance) {
-			const terminalChat = TerminalChatController.activeChatWidget || TerminalChatController.get(activeInstance);
+			const terminalChat = TerminalChatController.activeChatController || TerminalChatController.get(activeInstance);
 			if (terminalChat?.hasFocus()) {
 				return {
 					onDidHideChat: terminalChat.onDidHide,

--- a/src/vs/workbench/contrib/terminalContrib/chat/browser/terminalChatActions.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chat/browser/terminalChatActions.ts
@@ -99,7 +99,7 @@ registerActiveXtermAction({
 			return;
 		}
 		const contr = TerminalChatController.activeChatController || TerminalChatController.get(activeInstance);
-		contr?.terminalChatWidget?.inlineChatWidget.chatWidget.focusLastMessage();
+		contr?.chatWidget?.focusLastMessage();
 	}
 });
 

--- a/src/vs/workbench/contrib/terminalContrib/chat/browser/terminalChatActions.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chat/browser/terminalChatActions.ts
@@ -36,7 +36,7 @@ registerActiveXtermAction({
 			return;
 		}
 
-		const contr = TerminalChatController.activeChatWidget || TerminalChatController.get(activeInstance);
+		const contr = TerminalChatController.activeChatController || TerminalChatController.get(activeInstance);
 
 		if (opts) {
 			opts = typeof opts === 'string' ? { query: opts } : opts;
@@ -76,7 +76,7 @@ registerActiveXtermAction({
 		if (isDetachedTerminalInstance(activeInstance)) {
 			return;
 		}
-		const contr = TerminalChatController.activeChatWidget || TerminalChatController.get(activeInstance);
+		const contr = TerminalChatController.activeChatController || TerminalChatController.get(activeInstance);
 		contr?.clear();
 	}
 });
@@ -98,8 +98,8 @@ registerActiveXtermAction({
 		if (isDetachedTerminalInstance(activeInstance)) {
 			return;
 		}
-		const contr = TerminalChatController.activeChatWidget || TerminalChatController.get(activeInstance);
-		contr?.chatWidget?.inlineChatWidget.chatWidget.focusLastMessage();
+		const contr = TerminalChatController.activeChatController || TerminalChatController.get(activeInstance);
+		contr?.terminalChatWidget?.inlineChatWidget.chatWidget.focusLastMessage();
 	}
 });
 
@@ -121,8 +121,8 @@ registerActiveXtermAction({
 		if (isDetachedTerminalInstance(activeInstance)) {
 			return;
 		}
-		const contr = TerminalChatController.activeChatWidget || TerminalChatController.get(activeInstance);
-		contr?.chatWidget?.focus();
+		const contr = TerminalChatController.activeChatController || TerminalChatController.get(activeInstance);
+		contr?.terminalChatWidget?.focus();
 	}
 });
 
@@ -150,7 +150,7 @@ registerActiveXtermAction({
 		if (isDetachedTerminalInstance(activeInstance)) {
 			return;
 		}
-		const contr = TerminalChatController.activeChatWidget || TerminalChatController.get(activeInstance);
+		const contr = TerminalChatController.activeChatController || TerminalChatController.get(activeInstance);
 		contr?.clear();
 	}
 });
@@ -182,7 +182,7 @@ registerActiveXtermAction({
 		if (isDetachedTerminalInstance(activeInstance)) {
 			return;
 		}
-		const contr = TerminalChatController.activeChatWidget || TerminalChatController.get(activeInstance);
+		const contr = TerminalChatController.activeChatController || TerminalChatController.get(activeInstance);
 		contr?.acceptCommand(true);
 	}
 });
@@ -212,7 +212,7 @@ registerActiveXtermAction({
 		if (isDetachedTerminalInstance(activeInstance)) {
 			return;
 		}
-		const contr = TerminalChatController.activeChatWidget || TerminalChatController.get(activeInstance);
+		const contr = TerminalChatController.activeChatController || TerminalChatController.get(activeInstance);
 		contr?.acceptCommand(true);
 	}
 });
@@ -243,7 +243,7 @@ registerActiveXtermAction({
 		if (isDetachedTerminalInstance(activeInstance)) {
 			return;
 		}
-		const contr = TerminalChatController.activeChatWidget || TerminalChatController.get(activeInstance);
+		const contr = TerminalChatController.activeChatController || TerminalChatController.get(activeInstance);
 		contr?.acceptCommand(false);
 	}
 });
@@ -273,7 +273,7 @@ registerActiveXtermAction({
 		if (isDetachedTerminalInstance(activeInstance)) {
 			return;
 		}
-		const contr = TerminalChatController.activeChatWidget || TerminalChatController.get(activeInstance);
+		const contr = TerminalChatController.activeChatController || TerminalChatController.get(activeInstance);
 		contr?.acceptCommand(false);
 	}
 });
@@ -302,7 +302,7 @@ registerActiveXtermAction({
 		if (isDetachedTerminalInstance(activeInstance)) {
 			return;
 		}
-		const contr = TerminalChatController.activeChatWidget || TerminalChatController.get(activeInstance);
+		const contr = TerminalChatController.activeChatController || TerminalChatController.get(activeInstance);
 		contr?.viewInChat();
 	}
 });
@@ -331,7 +331,7 @@ registerActiveXtermAction({
 		if (isDetachedTerminalInstance(activeInstance)) {
 			return;
 		}
-		const contr = TerminalChatController.activeChatWidget || TerminalChatController.get(activeInstance);
+		const contr = TerminalChatController.activeChatController || TerminalChatController.get(activeInstance);
 		contr?.acceptInput();
 	}
 });
@@ -352,7 +352,7 @@ registerActiveXtermAction({
 		if (isDetachedTerminalInstance(activeInstance)) {
 			return;
 		}
-		const contr = TerminalChatController.activeChatWidget || TerminalChatController.get(activeInstance);
+		const contr = TerminalChatController.activeChatController || TerminalChatController.get(activeInstance);
 		contr?.cancel();
 	}
 });
@@ -371,7 +371,7 @@ registerActiveXtermAction({
 		if (isDetachedTerminalInstance(activeInstance)) {
 			return;
 		}
-		const contr = TerminalChatController.activeChatWidget || TerminalChatController.get(activeInstance);
+		const contr = TerminalChatController.activeChatController || TerminalChatController.get(activeInstance);
 		contr?.populateHistory(true);
 	}
 });
@@ -390,7 +390,7 @@ registerActiveXtermAction({
 		if (isDetachedTerminalInstance(activeInstance)) {
 			return;
 		}
-		const contr = TerminalChatController.activeChatWidget || TerminalChatController.get(activeInstance);
+		const contr = TerminalChatController.activeChatController || TerminalChatController.get(activeInstance);
 		contr?.populateHistory(false);
 	}
 });

--- a/src/vs/workbench/contrib/terminalContrib/chat/browser/terminalChatController.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chat/browser/terminalChatController.ts
@@ -10,7 +10,7 @@ import { Lazy } from '../../../../../base/common/lazy.js';
 import { Disposable, DisposableStore, MutableDisposable, toDisposable } from '../../../../../base/common/lifecycle.js';
 import { IContextKey, IContextKeyService } from '../../../../../platform/contextkey/common/contextkey.js';
 import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
-import { IChatCodeBlockContextProviderService, showChatView } from '../../../chat/browser/chat.js';
+import { IChatCodeBlockContextProviderService, IChatWidget, showChatView } from '../../../chat/browser/chat.js';
 import { IChatProgress, IChatService } from '../../../chat/common/chatService.js';
 import { ITerminalContribution, ITerminalInstance, ITerminalService, IXtermTerminal, isDetachedTerminalInstance } from '../../../terminal/browser/terminal.js';
 import { TerminalWidgetManager } from '../../../terminal/browser/widgets/widgetManager.js';
@@ -44,10 +44,10 @@ export class TerminalChatController extends Disposable implements ITerminalContr
 		return instance.getContribution<TerminalChatController>(TerminalChatController.ID);
 	}
 	/**
-	 * Currently focused chat widget. This is used to track action context since 'active terminals'
+	 * The controller for the currently focused chat widget. This is used to track action context since 'active terminals'
 	 * are only tracked for non-detached terminal instanecs.
 	 */
-	static activeChatWidget?: TerminalChatController;
+	static activeChatController?: TerminalChatController;
 
 	private static _storageKey = 'terminal-inline-chat-history';
 	private static _promptHistory: string[] = [];
@@ -56,13 +56,19 @@ export class TerminalChatController extends Disposable implements ITerminalContr
 	 * The chat widget for the controller, this is lazy as we don't want to instantiate it until
 	 * both it's required and xterm is ready.
 	 */
-	private _chatWidget: Lazy<TerminalChatWidget> | undefined;
+	private _terminalChatWidget: Lazy<TerminalChatWidget> | undefined;
 
 	/**
-	 * The chat widget for the controller, this will be undefined if xterm is not ready yet (ie. the
+	 * The terminal chat widget for the controller, this will be undefined if xterm is not ready yet (ie. the
+	 * terminal is still initializing). This wraps the inline chat widget.
+	 */
+	get terminalChatWidget(): TerminalChatWidget | undefined { return this._terminalChatWidget?.value; }
+
+	/**
+	 * The base chat widget for the controller, this will be undefined if xterm is not ready yet (ie. the
 	 * terminal is still initializing).
 	 */
-	get chatWidget(): TerminalChatWidget | undefined { return this._chatWidget?.value; }
+	get chatWidget(): IChatWidget | undefined { return this._terminalChatWidget?.value.inlineChatWidget?.chatWidget; }
 
 	private readonly _requestActiveContextKey: IContextKey<boolean>;
 	private readonly _responseContainsCodeBlockContextKey: IContextKey<boolean>;
@@ -76,14 +82,14 @@ export class TerminalChatController extends Disposable implements ITerminalContr
 	}
 
 	readonly onDidAcceptInput = Event.filter(this._messages.event, m => m === Message.ACCEPT_INPUT, this._store);
-	get onDidHide() { return this.chatWidget?.onDidHide ?? Event.None; }
+	get onDidHide() { return this.terminalChatWidget?.onDidHide ?? Event.None; }
 
 	private _terminalAgentName = 'terminal';
 
 	private readonly _model: MutableDisposable<ChatModel> = this._register(new MutableDisposable());
 
 	get scopedContextKeyService(): IContextKeyService {
-		return this._chatWidget?.value.inlineChatWidget.scopedContextKeyService ?? this._contextKeyService;
+		return this._terminalChatWidget?.value.inlineChatWidget.scopedContextKeyService ?? this._contextKeyService;
 	}
 
 	private _sessionCtor: CancelablePromise<void> | undefined;
@@ -114,7 +120,7 @@ export class TerminalChatController extends Disposable implements ITerminalContr
 
 		this._register(this._chatCodeBlockContextProviderService.registerProvider({
 			getCodeBlockContext: (editor) => {
-				if (!editor || !this._chatWidget?.hasValue || !this.hasFocus()) {
+				if (!editor || !this._terminalChatWidget?.hasValue || !this.hasFocus()) {
 					return;
 				}
 				return {
@@ -140,16 +146,16 @@ export class TerminalChatController extends Disposable implements ITerminalContr
 	}
 
 	xtermReady(xterm: IXtermTerminal & { raw: RawXtermTerminal }): void {
-		this._chatWidget = new Lazy(() => {
+		this._terminalChatWidget = new Lazy(() => {
 			const chatWidget = this._register(this._instantiationService.createInstance(TerminalChatWidget, this._instance.domElement!, this._instance, xterm));
 			this._register(chatWidget.focusTracker.onDidFocus(() => {
-				TerminalChatController.activeChatWidget = this;
+				TerminalChatController.activeChatController = this;
 				if (!isDetachedTerminalInstance(this._instance)) {
 					this._terminalService.setActiveInstance(this._instance);
 				}
 			}));
 			this._register(chatWidget.focusTracker.onDidBlur(() => {
-				TerminalChatController.activeChatWidget = undefined;
+				TerminalChatController.activeChatController = undefined;
 				this._instance.resetScrollbarVisibility();
 			}));
 			if (!this._instance.domElement) {
@@ -175,7 +181,7 @@ export class TerminalChatController extends Disposable implements ITerminalContr
 	private _forcedPlaceholder: string | undefined = undefined;
 
 	private _updatePlaceholder(): void {
-		const inlineChatWidget = this._chatWidget?.value.inlineChatWidget;
+		const inlineChatWidget = this._terminalChatWidget?.value.inlineChatWidget;
 		if (inlineChatWidget) {
 			inlineChatWidget.placeholder = this._getPlaceholderText();
 		}
@@ -200,29 +206,29 @@ export class TerminalChatController extends Disposable implements ITerminalContr
 		this._model.clear();
 		this._responseContainsCodeBlockContextKey.reset();
 		this._requestActiveContextKey.reset();
-		this._chatWidget?.value.hide();
-		this._chatWidget?.value.setValue(undefined);
+		this._terminalChatWidget?.value.hide();
+		this._terminalChatWidget?.value.setValue(undefined);
 	}
 
 	async acceptInput(isVoiceInput?: boolean): Promise<IChatResponseModel | undefined> {
-		assertType(this._chatWidget);
+		assertType(this._terminalChatWidget);
 		if (!this._model.value) {
 			await this.reveal();
 		}
 		assertType(this._model.value);
-		const lastInput = this._chatWidget.value.inlineChatWidget.value;
+		const lastInput = this._terminalChatWidget.value.inlineChatWidget.value;
 		if (!lastInput) {
 			return;
 		}
 		const model = this._model.value;
-		this._chatWidget.value.inlineChatWidget.setChatModel(model);
+		this._terminalChatWidget.value.inlineChatWidget.setChatModel(model);
 		this._historyUpdate(lastInput);
 		this._activeRequestCts?.cancel();
 		this._activeRequestCts = new CancellationTokenSource();
 		const store = new DisposableStore();
 		this._requestActiveContextKey.set(true);
 		let responseContent = '';
-		const response = await this._chatWidget.value.inlineChatWidget.chatWidget.acceptInput(lastInput, isVoiceInput);
+		const response = await this._terminalChatWidget.value.inlineChatWidget.chatWidget.acceptInput(lastInput, isVoiceInput);
 		this._currentRequestId = response?.requestId;
 		const responsePromise = new DeferredPromise<IChatResponseModel | undefined>();
 		try {
@@ -239,12 +245,12 @@ export class TerminalChatController extends Disposable implements ITerminalContr
 						this._requestActiveContextKey.set(false);
 						this._requestActiveContextKey.set(false);
 						const containsCode = responseContent.includes('```');
-						this._chatWidget!.value.inlineChatWidget.updateChatMessage({ message: new MarkdownString(responseContent), requestId: response!.requestId }, false, containsCode);
-						const firstCodeBlock = await this.chatWidget?.inlineChatWidget.getCodeBlockInfo(0);
-						const secondCodeBlock = await this.chatWidget?.inlineChatWidget.getCodeBlockInfo(1);
+						this._terminalChatWidget!.value.inlineChatWidget.updateChatMessage({ message: new MarkdownString(responseContent), requestId: response!.requestId }, false, containsCode);
+						const firstCodeBlock = await this.terminalChatWidget?.inlineChatWidget.getCodeBlockInfo(0);
+						const secondCodeBlock = await this.terminalChatWidget?.inlineChatWidget.getCodeBlockInfo(1);
 						this._responseContainsCodeBlockContextKey.set(!!firstCodeBlock);
 						this._responseContainsMulitpleCodeBlocksContextKey.set(!!secondCodeBlock);
-						this._chatWidget?.value.inlineChatWidget.updateToolbar(true);
+						this._terminalChatWidget?.value.inlineChatWidget.updateToolbar(true);
 						responsePromise.complete(response);
 					}
 				}));
@@ -259,7 +265,7 @@ export class TerminalChatController extends Disposable implements ITerminalContr
 	}
 
 	updateInput(text: string, selectAll = true): void {
-		const widget = this._chatWidget?.value.inlineChatWidget;
+		const widget = this._terminalChatWidget?.value.inlineChatWidget;
 		if (widget) {
 			widget.value = text;
 			if (selectAll) {
@@ -269,19 +275,19 @@ export class TerminalChatController extends Disposable implements ITerminalContr
 	}
 
 	getInput(): string {
-		return this._chatWidget?.value.input() ?? '';
+		return this._terminalChatWidget?.value.input() ?? '';
 	}
 
 	focus(): void {
-		this._chatWidget?.value.focus();
+		this._terminalChatWidget?.value.focus();
 	}
 
 	hasFocus(): boolean {
-		return this._chatWidget?.rawValue?.hasFocus() ?? false;
+		return this._terminalChatWidget?.rawValue?.hasFocus() ?? false;
 	}
 
 	populateHistory(up: boolean) {
-		if (!this._chatWidget?.value) {
+		if (!this._terminalChatWidget?.value) {
 			return;
 		}
 
@@ -292,7 +298,7 @@ export class TerminalChatController extends Disposable implements ITerminalContr
 
 		if (this._historyOffset === -1) {
 			// remember the current value
-			this._historyCandidate = this._chatWidget.value.inlineChatWidget.value;
+			this._historyCandidate = this._terminalChatWidget.value.inlineChatWidget.value;
 		}
 
 		const newIdx = this._historyOffset + (up ? 1 : -1);
@@ -310,8 +316,8 @@ export class TerminalChatController extends Disposable implements ITerminalContr
 			this._historyOffset = newIdx;
 		}
 
-		this._chatWidget.value.inlineChatWidget.value = entry;
-		this._chatWidget.value.inlineChatWidget.selectAll();
+		this._terminalChatWidget.value.inlineChatWidget.value = entry;
+		this._terminalChatWidget.value.inlineChatWidget.selectAll();
 	}
 
 	cancel(): void {
@@ -319,7 +325,7 @@ export class TerminalChatController extends Disposable implements ITerminalContr
 		this._sessionCtor = undefined;
 		this._activeRequestCts?.cancel();
 		this._requestActiveContextKey.set(false);
-		const model = this._chatWidget?.value.inlineChatWidget.getChatModel();
+		const model = this._terminalChatWidget?.value.inlineChatWidget.getChatModel();
 		if (!model?.sessionId) {
 			return;
 		}
@@ -327,23 +333,23 @@ export class TerminalChatController extends Disposable implements ITerminalContr
 	}
 
 	async acceptCommand(shouldExecute: boolean): Promise<void> {
-		const code = await this.chatWidget?.inlineChatWidget.getCodeBlockInfo(0);
+		const code = await this.terminalChatWidget?.inlineChatWidget.getCodeBlockInfo(0);
 		if (!code) {
 			return;
 		}
-		this._chatWidget?.value.acceptCommand(code.textEditorModel.getValue(), shouldExecute);
+		this._terminalChatWidget?.value.acceptCommand(code.textEditorModel.getValue(), shouldExecute);
 	}
 
 	async reveal(): Promise<void> {
 		await this._createSession();
-		this._chatWidget?.value.reveal();
-		this._chatWidget?.value.focus();
+		this._terminalChatWidget?.value.reveal();
+		this._terminalChatWidget?.value.focus();
 	}
 
 	async viewInChat(): Promise<void> {
 		//TODO: is this necessary? better way?
 		const widget = await showChatView(this._viewsService);
-		const currentRequest = this.chatWidget?.inlineChatWidget.chatWidget.viewModel?.model.getRequests().find(r => r.id === this._currentRequestId);
+		const currentRequest = this.terminalChatWidget?.inlineChatWidget.chatWidget.viewModel?.model.getRequests().find(r => r.id === this._currentRequestId);
 		if (!widget || !currentRequest?.response) {
 			return;
 		}
@@ -374,6 +380,6 @@ export class TerminalChatController extends Disposable implements ITerminalContr
 				followups: currentRequest.response!.followups
 			});
 		widget.focusLastMessage();
-		this._chatWidget?.rawValue?.hide();
+		this._terminalChatWidget?.rawValue?.hide();
 	}
 }

--- a/src/vs/workbench/contrib/terminalContrib/chat/browser/terminalChatWidget.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chat/browser/terminalChatWidget.ts
@@ -24,6 +24,7 @@ import { IChatRequestVariableEntry, IChatResponseModel } from '../../../chat/com
 import { IChatResponseViewModel, IChatViewModel } from '../../../chat/common/chatViewModel.js';
 import { ICodeEditor } from '../../../../../editor/browser/editorBrowser.js';
 import { IParsedChatRequest } from '../../../chat/common/chatParserTypes.js';
+import { MENU_INLINE_CHAT_WIDGET_SECONDARY } from '../../../inlineChat/common/inlineChat.js';
 
 const enum Constants {
 	HorizontalMargin = 10,
@@ -98,6 +99,7 @@ export class TerminalChatWidget extends Disposable implements IChatWidget {
 						}
 					}
 				},
+				secondaryMenuId: MENU_INLINE_CHAT_WIDGET_SECONDARY,
 				chatWidgetViewOptions: {
 					rendererOptions: { editableCodeBlock: true },
 					menus: {

--- a/src/vs/workbench/contrib/terminalContrib/chat/browser/terminalChatWidget.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chat/browser/terminalChatWidget.ts
@@ -12,18 +12,11 @@ import './media/terminalChatWidget.css';
 import { localize } from '../../../../../nls.js';
 import { IContextKey, IContextKeyService } from '../../../../../platform/contextkey/common/contextkey.js';
 import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';
-import { ChatAgentLocation, IChatAgentCommand, IChatAgentData } from '../../../chat/common/chatAgents.js';
+import { ChatAgentLocation } from '../../../chat/common/chatAgents.js';
 import { InlineChatWidget } from '../../../inlineChat/browser/inlineChatWidget.js';
 import { ITerminalInstance, type IXtermTerminal } from '../../../terminal/browser/terminal.js';
 import { MENU_TERMINAL_CHAT_INPUT, MENU_TERMINAL_CHAT_WIDGET, MENU_TERMINAL_CHAT_WIDGET_STATUS, TerminalChatCommandId, TerminalChatContextKeys } from './terminalChat.js';
 import { TerminalStickyScrollContribution } from '../../stickyScroll/browser/terminalStickyScrollContribution.js';
-import { ChatTreeItem, IChatCodeBlockInfo, IChatFileTreeInfo, IChatWidget, IChatWidgetViewContext } from '../../../chat/browser/chat.js';
-import { URI } from '../../../../../base/common/uri.js';
-import { IChatWidgetContrib, IChatViewState } from '../../../chat/browser/chatWidget.js';
-import { IChatRequestVariableEntry, IChatResponseModel } from '../../../chat/common/chatModel.js';
-import { IChatResponseViewModel, IChatViewModel } from '../../../chat/common/chatViewModel.js';
-import { ICodeEditor } from '../../../../../editor/browser/editorBrowser.js';
-import { IParsedChatRequest } from '../../../chat/common/chatParserTypes.js';
 import { MENU_INLINE_CHAT_WIDGET_SECONDARY } from '../../../inlineChat/common/inlineChat.js';
 
 const enum Constants {
@@ -31,7 +24,7 @@ const enum Constants {
 	VerticalMargin = 30
 }
 
-export class TerminalChatWidget extends Disposable implements IChatWidget {
+export class TerminalChatWidget extends Disposable {
 
 	private readonly _container: HTMLElement;
 
@@ -45,21 +38,6 @@ export class TerminalChatWidget extends Disposable implements IChatWidget {
 
 	private readonly _focusedContextKey: IContextKey<boolean>;
 	private readonly _visibleContextKey: IContextKey<boolean>;
-
-	onDidChangeViewModel!: Event<void>;
-	onDidAcceptInput!: Event<void>;
-	onDidSubmitAgent!: Event<{ agent: IChatAgentData; slashCommand?: IChatAgentCommand }>;
-	onDidChangeAgent!: Event<{ agent: IChatAgentData; slashCommand?: IChatAgentCommand }>;
-	onDidChangeParsedInput!: Event<void>;
-	onDidChangeContext!: Event<{ removed?: IChatRequestVariableEntry[]; added?: IChatRequestVariableEntry[] }>;
-	location!: ChatAgentLocation;
-	viewContext!: IChatWidgetViewContext;
-	viewModel: IChatViewModel | undefined;
-	inputEditor!: ICodeEditor;
-	supportsFileReferences!: boolean;
-	parsedInput!: IParsedChatRequest;
-	lastSelectedAgent: IChatAgentData | undefined;
-	scopedContextKeyService!: IContextKeyService;
 
 	constructor(
 		private readonly _terminalElement: HTMLElement,
@@ -134,80 +112,6 @@ export class TerminalChatWidget extends Disposable implements IChatWidget {
 		}));
 
 		this.hide();
-		this.onDidChangeViewModel = this.inlineChatWidget.chatWidget.onDidChangeViewModel;
-		this.onDidAcceptInput = this.inlineChatWidget.chatWidget.onDidAcceptInput;
-		this.onDidSubmitAgent = this.inlineChatWidget.chatWidget.onDidSubmitAgent;
-		this.onDidChangeAgent = this.inlineChatWidget.chatWidget.onDidChangeAgent;
-		this.onDidChangeParsedInput = this.inlineChatWidget.chatWidget.onDidChangeParsedInput;
-		this.onDidChangeContext = this.inlineChatWidget.chatWidget.onDidChangeContext;
-		this.location = this.inlineChatWidget.chatWidget.location;
-		this.viewContext = this.inlineChatWidget.chatWidget.viewContext;
-		this.viewModel = this.inlineChatWidget.chatWidget.viewModel;
-		this.inputEditor = this.inlineChatWidget.chatWidget.inputEditor;
-		this.supportsFileReferences = this.inlineChatWidget.chatWidget.supportsFileReferences;
-		this.parsedInput = this.inlineChatWidget.chatWidget.parsedInput;
-		this.scopedContextKeyService = this.inlineChatWidget.chatWidget.scopedContextKeyService;
-	}
-
-	getContrib<T extends IChatWidgetContrib>(id: string): T | undefined {
-		return this.inlineChatWidget.chatWidget.getContrib(id);
-	}
-	getSibling(item: ChatTreeItem, type: 'next' | 'previous'): ChatTreeItem | undefined {
-		return this.inlineChatWidget.chatWidget.getSibling(item, type);
-	}
-	getFocus(): ChatTreeItem | undefined {
-		return this.inlineChatWidget.chatWidget.getFocus();
-	}
-	setInput(query?: string): void {
-		this.inlineChatWidget.chatWidget.setInput(query);
-	}
-	getInput(): string {
-		return this.inlineChatWidget.chatWidget.getInput();
-	}
-	logInputHistory(): void {
-		this.inlineChatWidget.chatWidget.logInputHistory();
-	}
-	acceptInput(query?: string, isVoiceInput?: boolean): Promise<IChatResponseModel | undefined> {
-		return this.inlineChatWidget.chatWidget.acceptInput(query, isVoiceInput);
-	}
-	acceptInputWithPrefix(prefix: string): void {
-		this.inlineChatWidget.chatWidget.acceptInputWithPrefix(prefix);
-	}
-	setInputPlaceholder(placeholder: string): void {
-		this.inlineChatWidget.chatWidget.setInputPlaceholder(placeholder);
-	}
-	resetInputPlaceholder(): void {
-		this.inlineChatWidget.chatWidget.resetInputPlaceholder();
-	}
-	focusLastMessage(): void {
-		this.inlineChatWidget.chatWidget.focusLastMessage();
-	}
-	focusInput(): void {
-		this.inlineChatWidget.chatWidget.focusInput();
-	}
-	hasInputFocus(): boolean {
-		return this.inlineChatWidget.chatWidget.hasInputFocus();
-	}
-	getCodeBlockInfoForEditor(uri: URI): IChatCodeBlockInfo | undefined {
-		return this.inlineChatWidget.chatWidget.getCodeBlockInfoForEditor(uri);
-	}
-	getCodeBlockInfosForResponse(response: IChatResponseViewModel): IChatCodeBlockInfo[] {
-		return this.inlineChatWidget.chatWidget.getCodeBlockInfosForResponse(response);
-	}
-	getFileTreeInfosForResponse(response: IChatResponseViewModel): IChatFileTreeInfo[] {
-		return this.inlineChatWidget.chatWidget.getFileTreeInfosForResponse(response);
-	}
-	getLastFocusedFileTreeForResponse(response: IChatResponseViewModel): IChatFileTreeInfo | undefined {
-		return this.inlineChatWidget.chatWidget.getLastFocusedFileTreeForResponse(response);
-	}
-	setContext(overwrite: boolean, ...context: IChatRequestVariableEntry[]): void {
-		this.inlineChatWidget.chatWidget.setContext(overwrite, ...context);
-	}
-	clear(): void {
-		this.inlineChatWidget.chatWidget.clear();
-	}
-	getViewState(): IChatViewState {
-		return this.inlineChatWidget.chatWidget.getViewState();
 	}
 
 	private _dimension?: Dimension;


### PR DESCRIPTION
fixes [#229025](https://github.com/microsoft/vscode/issues/229025)
fixes https://github.com/microsoft/vscode/issues/229015

![Screenshot 2024-09-23 at 8 49 46 AM](https://github.com/user-attachments/assets/0038801a-8de0-424a-94ab-2391377037c7)

This also moves us closer to getting rid of the terminal specific handling in `VoiceChatActions`. In order to do that, we will need to move a lot of code from `TerminalChatController` to `TerminalChatWidget`. For example, `acceptInput` so that when `chatWidget.acceptInput` is called here, the terminal specific stuff happens. 

https://github.com/microsoft/vscode/blob/5855e0db2c1f0f8d65885b5d9f9823ce9e6e77be/src/vs/workbench/contrib/chat/electron-sandbox/actions/voiceChatActions.ts#L210

The `acceptInput` in `TerminalChatController` currently handles everything vs the `TerminalChatWidget`

https://github.com/microsoft/vscode/blob/5855e0db2c1f0f8d65885b5d9f9823ce9e6e77be/src/vs/workbench/contrib/terminalContrib/chat/browser/terminalChatController.ts#L207-L233


