### PR TITLE
repl command fixes

### DIFF
--- a/src/vs/workbench/contrib/interactive/browser/interactive.contribution.ts
+++ b/src/vs/workbench/contrib/interactive/browser/interactive.contribution.ts
@@ -618,7 +618,7 @@ registerAction2(class extends Action2 {
 					SuggestContext.Visible.toNegated()
 				),
 				primary: KeyCode.UpArrow,
-				weight: KeybindingWeight.WorkbenchContrib + 5
+				weight: KeybindingWeight.WorkbenchContrib
 			},
 			precondition: ContextKeyExpr.and(IS_COMPOSITE_NOTEBOOK, NOTEBOOK_EDITOR_FOCUSED.negate())
 		});
@@ -659,7 +659,7 @@ registerAction2(class extends Action2 {
 					SuggestContext.Visible.toNegated()
 				),
 				primary: KeyCode.DownArrow,
-				weight: KeybindingWeight.WorkbenchContrib + 5
+				weight: KeybindingWeight.WorkbenchContrib
 			},
 			precondition: ContextKeyExpr.and(IS_COMPOSITE_NOTEBOOK, NOTEBOOK_EDITOR_FOCUSED.negate())
 		});
@@ -756,7 +756,7 @@ registerAction2(class extends Action2 {
 			},
 			keybinding: {
 				when: ContextKeyExpr.and(IS_COMPOSITE_NOTEBOOK, NOTEBOOK_EDITOR_FOCUSED),
-				weight: KeybindingWeight.WorkbenchContrib,
+				weight: KeybindingWeight.WorkbenchContrib + 5,
 				primary: KeyMod.CtrlCmd | KeyCode.DownArrow
 			}
 		});
@@ -802,7 +802,7 @@ registerAction2(class extends Action2 {
 				when: ContextKeyExpr.and(
 					INTERACTIVE_INPUT_CURSOR_BOUNDARY.notEqualsTo('bottom'),
 					INTERACTIVE_INPUT_CURSOR_BOUNDARY.notEqualsTo('none')),
-				weight: KeybindingWeight.WorkbenchContrib,
+				weight: KeybindingWeight.WorkbenchContrib + 5,
 				primary: KeyMod.CtrlCmd | KeyCode.UpArrow
 			},
 			{

--- a/src/vs/workbench/contrib/interactive/browser/interactive.contribution.ts
+++ b/src/vs/workbench/contrib/interactive/browser/interactive.contribution.ts
@@ -618,9 +618,9 @@ registerAction2(class extends Action2 {
 					SuggestContext.Visible.toNegated()
 				),
 				primary: KeyCode.UpArrow,
-				weight: KeybindingWeight.WorkbenchContrib
+				weight: KeybindingWeight.WorkbenchContrib + 5
 			},
-			precondition: IS_COMPOSITE_NOTEBOOK
+			precondition: ContextKeyExpr.and(IS_COMPOSITE_NOTEBOOK, NOTEBOOK_EDITOR_FOCUSED.negate())
 		});
 	}
 
@@ -659,9 +659,9 @@ registerAction2(class extends Action2 {
 					SuggestContext.Visible.toNegated()
 				),
 				primary: KeyCode.DownArrow,
-				weight: KeybindingWeight.WorkbenchContrib
+				weight: KeybindingWeight.WorkbenchContrib + 5
 			},
-			precondition: IS_COMPOSITE_NOTEBOOK
+			precondition: ContextKeyExpr.and(IS_COMPOSITE_NOTEBOOK, NOTEBOOK_EDITOR_FOCUSED.negate())
 		});
 	}
 
@@ -758,8 +758,7 @@ registerAction2(class extends Action2 {
 				when: ContextKeyExpr.and(IS_COMPOSITE_NOTEBOOK, NOTEBOOK_EDITOR_FOCUSED),
 				weight: KeybindingWeight.WorkbenchContrib,
 				primary: KeyMod.CtrlCmd | KeyCode.DownArrow
-			},
-			precondition: InteractiveWindowOpen
+			}
 		});
 	}
 


### PR DESCRIPTION
only call history commands when focused on the input. Increase weight for focus input to override scrolling commands

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
