### PR TITLE
Try converting absolute icon font sizes to relative values

### DIFF
--- a/src/vs/workbench/services/themes/browser/fileIconThemeData.ts
+++ b/src/vs/workbench/services/themes/browser/fileIconThemeData.ts
@@ -395,12 +395,14 @@ export class FileIconThemeLoader {
 		const fonts = iconThemeDocument.fonts;
 		const fontSizes = new Map<string, string>();
 		if (Array.isArray(fonts)) {
-			const defaultFontSize = fonts[0].size || '150%';
+			const defaultFontSize = this.tryNormalizeFontSize(fonts[0].size) || '150%';
 			fonts.forEach(font => {
 				const src = font.src.map(l => `${asCSSUrl(resolvePath(l.path))} format('${l.format}')`).join(', ');
 				cssRules.push(`@font-face { src: ${src}; font-family: '${font.id}'; font-weight: ${font.weight}; font-style: ${font.style}; font-display: block; }`);
-				if (font.size !== undefined && font.size !== defaultFontSize) {
-					fontSizes.set(font.id, font.size);
+
+				const fontSize = this.tryNormalizeFontSize(font.size);
+				if (fontSize !== undefined && fontSize !== defaultFontSize) {
+					fontSizes.set(font.id, fontSize);
 				}
 			});
 			cssRules.push(`.show-file-icons .file-icon::before, .show-file-icons .folder-icon::before, .show-file-icons .rootfolder-icon::before { font-family: '${fonts[0].id}'; font-size: ${defaultFontSize}; }`);
@@ -455,6 +457,27 @@ export class FileIconThemeLoader {
 		return result;
 	}
 
+	/**
+	 * Try converting absolute font sizes to relative values.
+	 *
+	 * This allows them to be scaled nicely depending on where they are used.
+	 */
+	private tryNormalizeFontSize(size: string | undefined): string | undefined {
+		if (!size) {
+			return undefined;
+		}
+
+		const defaultFontSizeInPx = 13;
+
+		if (size.endsWith('px')) {
+			const value = parseInt(size, 10);
+			if (!isNaN(value)) {
+				return Math.round((value / defaultFontSizeInPx) * 100) + '%';
+			}
+		}
+
+		return size;
+	}
 }
 
 function handleParentFolder(key: string, selectors: string[]): string {

--- a/src/vs/workbench/services/themes/common/fileIconThemeSchema.ts
+++ b/src/vs/workbench/services/themes/common/fileIconThemeSchema.ts
@@ -185,7 +185,7 @@ const schema: IJSONSchema = {
 					},
 					size: {
 						type: 'string',
-						description: nls.localize('schema.font-size', 'The default size of the font. See https://developer.mozilla.org/en-US/docs/Web/CSS/font-size for valid values.'),
+						description: nls.localize('schema.font-size', 'The default size of the font. We strongly recommend using a percentage value, for example: 125%.'),
 						pattern: fontSizeRegex
 					}
 				},


### PR DESCRIPTION
Fixes #229128

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
