### PR TITLE
SCM - fix history item picker when view is in the auxiliary bar

### DIFF
--- a/src/vs/workbench/contrib/scm/browser/media/scm.css
+++ b/src/vs/workbench/contrib/scm/browser/media/scm.css
@@ -553,7 +553,8 @@
 	padding: 2px 4px;
 }
 
-.monaco-workbench .part.auxiliarybar > .title > .title-actions .action-label.scm-graph-repository-picker {
+.monaco-workbench .part.auxiliarybar > .title > .title-actions .action-label.scm-graph-repository-picker,
+.monaco-workbench .part.auxiliarybar > .title > .title-actions .action-label.scm-graph-history-item-picker {
 	display: flex;
 }
 


### PR DESCRIPTION
Fixes #229499