### PR TITLE
Git - cheery-pick now handles the case where the changes are already present on the current branch

### DIFF
--- a/extensions/git/src/api/git.d.ts
+++ b/extensions/git/src/api/git.d.ts
@@ -409,5 +409,6 @@ export const enum GitErrorCodes {
 	EmptyCommitMessage = 'EmptyCommitMessage',
 	BranchFastForwardRejected = 'BranchFastForwardRejected',
 	BranchNotYetBorn = 'BranchNotYetBorn',
-	TagConflict = 'TagConflict'
+	TagConflict = 'TagConflict',
+	CherryPickEmpty = 'CherryPickEmpty'
 }

--- a/extensions/git/src/commands.ts
+++ b/extensions/git/src/commands.ts
@@ -4403,6 +4403,12 @@ export class CommandCenter {
 						type = 'information';
 						options.modal = false;
 						break;
+					case GitErrorCodes.CherryPickEmpty:
+						message = l10n.t('The changes are already present in the current branch.');
+						choices.clear();
+						type = 'information';
+						options.modal = false;
+						break;
 					default: {
 						const hint = (err.stderr || err.message || String(err))
 							.replace(/^error: /mi, '')


### PR DESCRIPTION
Fixes #229507