### PR TITLE
Revert "chat command center polish (#229674)"

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -170,5 +170,5 @@
 	},
 	"css.format.spaceAroundSelectorSeparator": true,
 	"typescript.enablePromptUseWorkspaceTsdk": true,
-	"chat.commandCenter.enabled": true
+	"inlineChat.experimental.onlyZoneWidget": true
 }

--- a/src/vs/platform/actions/browser/dropdownWithPrimaryActionViewItem.ts
+++ b/src/vs/platform/actions/browser/dropdownWithPrimaryActionViewItem.ts
@@ -61,7 +61,7 @@ export class DropdownWithPrimaryActionViewItem extends BaseActionViewItem {
 			menuAsChild: _options?.menuAsChild ?? true,
 			classNames: className ? ['codicon', 'codicon-chevron-down', className] : ['codicon', 'codicon-chevron-down'],
 			actionRunner: this._options?.actionRunner,
-			keybindingProvider: this._options?.getKeyBinding ?? (action => _keybindingService.lookupKeybinding(action.id)),
+			keybindingProvider: this._options?.getKeyBinding,
 			hoverDelegate: _options?.hoverDelegate
 		});
 	}

--- a/src/vs/workbench/contrib/chat/browser/actions/chatQuickInputActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatQuickInputActions.ts
@@ -116,7 +116,7 @@ class QuickChatGlobalAction extends Action2 {
 			},
 			menu: {
 				id: MenuId.ChatCommandCenter,
-				group: 'c_quickChat',
+				group: 'open',
 				order: 5
 			},
 			metadata: {

--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -103,9 +103,8 @@ configurationRegistry.registerConfiguration({
 		},
 		'chat.commandCenter.enabled': {
 			type: 'boolean',
-			tags: ['experimental'],
 			markdownDescription: nls.localize('chat.commandCenter.enabled', "Controls whether the command center shows a menu for chat actions (requires {0}).", '`#window.commandCenter#`'),
-			default: false
+			default: true
 		},
 		'chat.experimental.implicitContext': {
 			type: 'boolean',

--- a/src/vs/workbench/contrib/inlineChat/browser/inlineChatActions.ts
+++ b/src/vs/workbench/contrib/inlineChat/browser/inlineChatActions.ts
@@ -13,7 +13,7 @@ import { EditorContextKeys } from '../../../../editor/common/editorContextKeys.j
 import { InlineChatController, InlineChatRunOptions } from './inlineChatController.js';
 import { ACTION_ACCEPT_CHANGES, CTX_INLINE_CHAT_HAS_AGENT, CTX_INLINE_CHAT_HAS_STASHED_SESSION, CTX_INLINE_CHAT_FOCUSED, CTX_INLINE_CHAT_INNER_CURSOR_FIRST, CTX_INLINE_CHAT_INNER_CURSOR_LAST, CTX_INLINE_CHAT_VISIBLE, CTX_INLINE_CHAT_OUTER_CURSOR_POSITION, CTX_INLINE_CHAT_USER_DID_EDIT, CTX_INLINE_CHAT_DOCUMENT_CHANGED, CTX_INLINE_CHAT_EDIT_MODE, EditMode, MENU_INLINE_CHAT_WIDGET_STATUS, CTX_INLINE_CHAT_REQUEST_IN_PROGRESS, CTX_INLINE_CHAT_RESPONSE_TYPE, InlineChatResponseType, ACTION_REGENERATE_RESPONSE, ACTION_VIEW_IN_CHAT, ACTION_TOGGLE_DIFF, CTX_INLINE_CHAT_CHANGE_HAS_DIFF, CTX_INLINE_CHAT_CHANGE_SHOWS_DIFF, MENU_INLINE_CHAT_ZONE, ACTION_DISCARD_CHANGES } from '../common/inlineChat.js';
 import { localize, localize2 } from '../../../../nls.js';
-import { Action2, IAction2Options, MenuId } from '../../../../platform/actions/common/actions.js';
+import { Action2, IAction2Options } from '../../../../platform/actions/common/actions.js';
 import { ContextKeyExpr } from '../../../../platform/contextkey/common/contextkey.js';
 import { IInstantiationService, ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
 import { KeybindingWeight } from '../../../../platform/keybinding/common/keybindingsRegistry.js';
@@ -27,7 +27,6 @@ import { ILogService } from '../../../../platform/log/common/log.js';
 import { IChatService } from '../../chat/common/chatService.js';
 import { CONTEXT_CHAT_INPUT_HAS_TEXT, CONTEXT_IN_CHAT_INPUT } from '../../chat/common/chatContextKeys.js';
 import { HunkInformation } from './inlineChatSession.js';
-import { ActiveEditorContext } from '../../../common/contextkeys.js';
 
 CommandsRegistry.registerCommandAlias('interactiveEditor.start', 'inlineChat.start');
 CommandsRegistry.registerCommandAlias('interactive.acceptChanges', ACTION_ACCEPT_CHANGES);
@@ -50,28 +49,17 @@ export class StartSessionAction extends EditorAction2 {
 	constructor() {
 		super({
 			id: 'inlineChat.start',
-			title: localize2('run', 'Editor Inline Chat'),
+			title: localize2('run', 'Editor Chat'),
 			category: AbstractInlineChatAction.category,
 			f1: true,
-			precondition: ContextKeyExpr.and(
-				CTX_INLINE_CHAT_HAS_AGENT,
-				ContextKeyExpr.or(
-					ActiveEditorContext.isEqualTo('workbench.editors.files.textFileEditor'),
-					ActiveEditorContext.isEqualTo('workbench.editor.notebook')
-				)
-			),
+			precondition: ContextKeyExpr.and(CTX_INLINE_CHAT_HAS_AGENT, EditorContextKeys.writable),
 			keybinding: {
-				when: ContextKeyExpr.and(EditorContextKeys.focus, EditorContextKeys.writable),
+				when: EditorContextKeys.focus,
 				weight: KeybindingWeight.WorkbenchContrib,
 				primary: KeyMod.CtrlCmd | KeyCode.KeyI,
 				secondary: [KeyChord(KeyMod.CtrlCmd | KeyCode.KeyK, KeyCode.KeyI)],
 			},
-			icon: START_INLINE_CHAT,
-			menu: {
-				id: MenuId.ChatCommandCenter,
-				group: 'b_inlineChat',
-				order: 10,
-			}
+			icon: START_INLINE_CHAT
 		});
 	}
 


### PR DESCRIPTION
This reverts commit b80272842e5135b1716a499947cdd71973f4e197.

This broke sanity tests for copilot-chat, probably in preconditions
for `inlineChat.start`. It's not clear to me what the right fix is,
so I am backing it out in order to unblock copilot-chat.

In copilot-chat's "E2E Production Inline Chat Test", we run

```
vscode.commands.executeCommand('vscode.editorChat.start', {
```

And that command no longer triggered inline chat.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
