### PR TITLE
Handle when an extension hasn't used an auth provider yet

### DIFF
--- a/src/vs/workbench/contrib/authentication/browser/actions/manageTrustedExtensionsForAccountAction.ts
+++ b/src/vs/workbench/contrib/authentication/browser/actions/manageTrustedExtensionsForAccountAction.ts
@@ -221,7 +221,7 @@ class ManageTrustedExtensionsForAccountActionImpl {
 			quickPick.hide();
 		}));
 		disposableStore.add(quickPick.onDidTriggerItemButton(e =>
-			this._commandService.executeCommand('_manageAccountPreferencesForExtension', e.item.extension.id)
+			this._commandService.executeCommand('_manageAccountPreferencesForExtension', e.item.extension.id, providerId)
 		));
 		return quickPick;
 	}


### PR DESCRIPTION
By allowing an optional providerId passed in.

Fixes https://github.com/microsoft/vscode/issues/229503

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
