### PR TITLE
Remove old reference of adding providers contributed by the environment

### DIFF
--- a/src/vs/workbench/contrib/authentication/browser/authentication.contribution.ts
+++ b/src/vs/workbench/contrib/authentication/browser/authentication.contribution.ts
@@ -117,10 +117,7 @@ class AuthenticationContribution extends Disposable implements IWorkbenchContrib
 		},
 	});
 
-	constructor(
-		@IAuthenticationService private readonly _authenticationService: IAuthenticationService,
-		@IBrowserWorkbenchEnvironmentService private readonly _environmentService: IBrowserWorkbenchEnvironmentService
-	) {
+	constructor(@IAuthenticationService private readonly _authenticationService: IAuthenticationService) {
 		super();
 		this._register(codeExchangeProxyCommand);
 		this._register(extensionFeature);
@@ -131,7 +128,6 @@ class AuthenticationContribution extends Disposable implements IWorkbenchContrib
 		}
 		this._registerHandlers();
 		this._registerAuthenticationExtentionPointHandler();
-		this._registerEnvContributedAuthenticationProviders();
 		this._registerActions();
 	}
 
@@ -165,15 +161,6 @@ class AuthenticationContribution extends Disposable implements IWorkbenchContrib
 				}
 			});
 		});
-	}
-
-	private _registerEnvContributedAuthenticationProviders(): void {
-		if (!this._environmentService.options?.authenticationProviders?.length) {
-			return;
-		}
-		for (const provider of this._environmentService.options.authenticationProviders) {
-			this._authenticationService.registerAuthenticationProvider(provider.id, provider);
-		}
 	}
 
 	private _registerHandlers(): void {


### PR DESCRIPTION
This code should have been removed when we moved this exact code into:

https://github.com/microsoft/vscode/blob/6486ae847d16c00fc9b50a360c24408aa150d8bb/src/vs/workbench/services/authentication/browser/authenticationService.ts#L93-L100

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This actually caused an issue in vscode.dev where the account menu wouldn't get updated because the auth providers were being registered twice. This should fix that.