### PR TITLE
Re #229883. Event emitter and version increment should be sync'ed

### DIFF
--- a/src/vs/workbench/contrib/notebook/common/model/notebookCellTextModel.ts
+++ b/src/vs/workbench/contrib/notebook/common/model/notebookCellTextModel.ts
@@ -160,6 +160,7 @@ export class NotebookCellTextModel extends Disposable implements ICell {
 					this._alternativeId = this._textModel.getAlternativeVersionId();
 				}
 				this._textBufferHash = null;
+				this._onDidChangeContent.fire('content');
 				this._onDidChangeContent.fire({ type: 'model', event: e });
 			}));
 

--- a/src/vs/workbench/contrib/notebook/common/model/notebookCellTextModel.ts
+++ b/src/vs/workbench/contrib/notebook/common/model/notebookCellTextModel.ts
@@ -160,7 +160,6 @@ export class NotebookCellTextModel extends Disposable implements ICell {
 					this._alternativeId = this._textModel.getAlternativeVersionId();
 				}
 				this._textBufferHash = null;
-				this._onDidChangeContent.fire('content');
 				this._onDidChangeContent.fire({ type: 'model', event: e });
 			}));
 

--- a/src/vs/workbench/contrib/notebook/common/model/notebookTextModel.ts
+++ b/src/vs/workbench/contrib/notebook/common/model/notebookTextModel.ts
@@ -330,7 +330,7 @@ export class NotebookTextModel extends Disposable implements INotebookTextModel 
 	}
 
 	private _bindCellContentHandler(cell: NotebookCellTextModel, e: 'content' | 'language' | 'mime' | { type: 'model'; event: IModelContentChangedEvent }) {
-		this._increaseVersionId(e === 'content');
+		this._increaseVersionId(e === 'content' || (typeof e === 'object' && e.type === 'model'));
 		switch (e) {
 			case 'content':
 				this._pauseableEmitter.fire({
@@ -357,6 +357,17 @@ export class NotebookTextModel extends Disposable implements INotebookTextModel 
 					synchronous: true,
 					endSelectionState: undefined
 				});
+				break;
+
+			default:
+				if (typeof e === 'object' && e.type === 'model') {
+					this._pauseableEmitter.fire({
+						rawEvents: [{ kind: NotebookCellsChangeType.ChangeCellContent, index: this._getCellIndexByHandle(cell.handle), transient: false }],
+						versionId: this.versionId,
+						synchronous: true,
+						endSelectionState: undefined
+					});
+				}
 				break;
 		}
 	}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->


This is the right fix, the version increment and the events need to be sync'ed. https://github.com/microsoft/vscode/pull/229896 doubles the event which lead to the same bug. Didn't reproduce this issue locally as it requires `notebook.experimental.remoteSave` to be `true`, which is true in Insiders right now, but not OSS or Stable.