### PR TITLE
Avoid setting a negative padding on the chat welcome view container

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatWidget.ts
@@ -963,7 +963,7 @@ export class ChatWidget extends Disposable implements IChatWidget {
 		this.tree.getHTMLElement().style.height = `${listHeight}px`;
 
 		// Push the welcome message down so it doesn't change position when followups appear
-		const followupsOffset = 100 - this.inputPart.followupsHeight;
+		const followupsOffset = Math.max(100 - this.inputPart.followupsHeight, 0);
 		this.welcomeMessageContainer.style.height = `${listHeight - followupsOffset}px`;
 		this.welcomeMessageContainer.style.paddingBottom = `${followupsOffset}px`;
 		this.renderer.layout(width);


### PR DESCRIPTION
The layout here is a bit weird to avoid shifting when followups appear. If the followups wrap, then the layout is messed up because negative padding is not allowed. I might try to simplify this for next month.
Fix microsoft/vscode-copilot#8749

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
