### PR TITLE
Limit top level functions in notebook webview preloads

### DIFF
--- a/.eslintplugin/code-limited-top-functions.ts
+++ b/.eslintplugin/code-limited-top-functions.ts
@@ -1,0 +1,70 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as eslint from 'eslint';
+import { dirname, relative } from 'path';
+import minimatch from 'minimatch';
+
+export = new class implements eslint.Rule.RuleModule {
+
+	readonly meta: eslint.Rule.RuleMetaData = {
+		messages: {
+			layerbreaker: 'You are only allowed to define limited top level functions.'
+		},
+		schema: {
+			type: "array",
+			items: {
+				type: "object",
+				additionalProperties: {
+					type: "array",
+					items: {
+						type: "string"
+					}
+				}
+			}
+		}
+	};
+
+	create(context: eslint.Rule.RuleContext): eslint.Rule.RuleListener {
+		let fileRelativePath = relative(dirname(__dirname), context.getFilename());
+		if (!fileRelativePath.endsWith('/')) {
+			fileRelativePath += '/';
+		}
+		const ruleArgs = <Record<string, string[]>>context.options[0];
+
+		const matchingKey = Object.keys(ruleArgs).find(key => fileRelativePath.startsWith(key) || minimatch(fileRelativePath, key));
+		if (!matchingKey) {
+			// nothing
+			return {};
+		}
+
+		const restrictedFunctions = ruleArgs[matchingKey];
+
+		return {
+			FunctionDeclaration: (node: any) => {
+				const isTopLevel = node.parent.type === 'Program';
+				const functionName = node.id.name;
+				if (isTopLevel && !restrictedFunctions.includes(node.id.name)) {
+					context.report({
+						node,
+						message: `Top-level function '${functionName}' is restricted in this file. Allowed functions are: ${restrictedFunctions.join(', ')}.`
+					});
+				}
+			},
+			ExportNamedDeclaration(node: any) {
+				if (node.declaration && node.declaration.type === 'FunctionDeclaration') {
+					const functionName = node.declaration.id.name;
+					const isTopLevel = node.parent.type === 'Program';
+					if (isTopLevel && !restrictedFunctions.includes(node.declaration.id.name)) {
+						context.report({
+							node,
+							message: `Top-level function '${functionName}' is restricted in this file. Allowed functions are: ${restrictedFunctions.join(', ')}.`
+						});
+					}
+				}
+			}
+		}
+	}
+};

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1203,6 +1203,15 @@
 							"**/*"
 						]
 					}
+				],
+				"local/code-limited-top-functions": [
+					"error",
+					{
+						"src/vs/workbench/contrib/notebook/browser/view/renderers/webviewPreloads.ts": [
+							"webviewPreloads",
+							"preloadsScriptStr"
+						]
+					}
 				]
 			}
 		}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Add an eslint rule to enforce that.