### PR TITLE
Adopt `preparePasteEdits` for js/ts update imports on paste

### DIFF
--- a/extensions/typescript-language-features/package.nls.json
+++ b/extensions/typescript-language-features/package.nls.json
@@ -236,7 +236,7 @@
 	"configuration.tsserver.web.projectWideIntellisense.suppressSemanticErrors": "Suppresses semantic errors on web even when project wide IntelliSense is enabled. This is always on when project wide IntelliSense is not enabled or available. See `#typescript.tsserver.web.projectWideIntellisense.enabled#`",
 	"configuration.tsserver.web.typeAcquisition.enabled": "Enable/disable package acquisition on the web. This enables IntelliSense for imported packages. Requires `#typescript.tsserver.web.projectWideIntellisense.enabled#`. Currently not supported for Safari.",
 	"configuration.tsserver.nodePath": "Run TS Server on a custom Node installation. This can be a path to a Node executable, or 'node' if you want VS Code to detect a Node installation.",
-	"configuration.updateImportsOnPaste": "Automatically update imports when pasting code. Requires TypeScript 5.6+.",
+	"configuration.updateImportsOnPaste": "Automatically update imports when pasting code. Requires TypeScript 5.7+.",
 	"configuration.expandableHover": "(Experimental) Enable/disable expanding on hover.",
 	"walkthroughs.nodejsWelcome.title": "Get started with JavaScript and Node.js",
 	"walkthroughs.nodejsWelcome.description": "Make the most of Visual Studio Code's first-class JavaScript experience.",

--- a/extensions/typescript-language-features/src/languageFeatures/copyPaste.ts
+++ b/extensions/typescript-language-features/src/languageFeatures/copyPaste.ts
@@ -50,7 +50,24 @@ class DocumentPasteProvider implements vscode.DocumentPasteEditProvider {
 		private readonly _client: ITypeScriptServiceClient,
 	) { }
 
-	prepareDocumentPaste(document: vscode.TextDocument, ranges: readonly vscode.Range[], dataTransfer: vscode.DataTransfer, _token: vscode.CancellationToken) {
+	async prepareDocumentPaste(document: vscode.TextDocument, ranges: readonly vscode.Range[], dataTransfer: vscode.DataTransfer, token: vscode.CancellationToken) {
+		if (!this.isEnabled(document)) {
+			return;
+		}
+
+		const file = this._client.toOpenTsFilePath(document);
+		if (!file) {
+			return;
+		}
+
+		const response = await this._client.execute('preparePasteEdits', {
+			file,
+			copiedTextSpan: ranges.map(typeConverters.Range.toTextSpan),
+		}, token);
+		if (token.isCancellationRequested || response.type !== 'response' || !response.body) {
+			return;
+		}
+
 		dataTransfer.set(DocumentPasteProvider.metadataMimeType,
 			new vscode.DataTransferItem(new CopyMetadata(document.uri, ranges).toJSON()));
 	}
@@ -62,8 +79,7 @@ class DocumentPasteProvider implements vscode.DocumentPasteEditProvider {
 		_context: vscode.DocumentPasteEditContext,
 		token: vscode.CancellationToken,
 	): Promise<vscode.DocumentPasteEdit[] | undefined> {
-		const config = vscode.workspace.getConfiguration(this._modeId, document.uri);
-		if (!config.get(settingId, false)) {
+		if (!this.isEnabled(document)) {
 			return;
 		}
 
@@ -127,12 +143,17 @@ class DocumentPasteProvider implements vscode.DocumentPasteEditProvider {
 
 		return metadata ? CopyMetadata.fromJSON(metadata) : undefined;
 	}
+
+	private isEnabled(document: vscode.TextDocument) {
+		const config = vscode.workspace.getConfiguration(this._modeId, document.uri);
+		return config.get(settingId, false);
+	}
 }
 
 export function register(selector: DocumentSelector, language: LanguageDescription, client: ITypeScriptServiceClient) {
 	return conditionalRegistration([
 		requireSomeCapability(client, ClientCapability.Semantic),
-		requireMinVersion(client, API.v560),
+		requireMinVersion(client, API.v570),
 		requireGlobalConfiguration(language.id, settingId),
 	], () => {
 		return vscode.languages.registerDocumentPasteEditProvider(selector.semantic, new DocumentPasteProvider(language.id, client), {

--- a/extensions/typescript-language-features/src/tsServer/api.ts
+++ b/extensions/typescript-language-features/src/tsServer/api.ts
@@ -28,7 +28,6 @@ export class API {
 	public static readonly v520 = API.fromSimpleString('5.2.0');
 	public static readonly v544 = API.fromSimpleString('5.4.4');
 	public static readonly v540 = API.fromSimpleString('5.4.0');
-	public static readonly v550 = API.fromSimpleString('5.5.0');
 	public static readonly v560 = API.fromSimpleString('5.6.0');
 	public static readonly v570 = API.fromSimpleString('5.7.0');
 

--- a/extensions/typescript-language-features/src/tsServer/protocol/protocol.d.ts
+++ b/extensions/typescript-language-features/src/tsServer/protocol/protocol.d.ts
@@ -19,5 +19,18 @@ declare module '../../../../node_modules/typescript/lib/typescript' {
 		interface Response {
 			readonly _serverType?: ServerType;
 		}
+
+		//#region PreparePasteEdits
+		interface PreparePasteEditsRequest extends FileRequest {
+			command: 'preparePasteEdits';
+			arguments: PreparePasteEditsRequestArgs;
+		}
+		interface PreparePasteEditsRequestArgs extends FileRequestArgs {
+			copiedTextSpan: TextSpan[];
+		}
+		interface PreparePasteEditsResponse extends Response {
+			body: boolean;
+		}
+		//#endregion
 	}
 }

--- a/extensions/typescript-language-features/src/typescriptService.ts
+++ b/extensions/typescript-language-features/src/typescriptService.ts
@@ -78,6 +78,7 @@ interface StandardTsServerRequests {
 	'linkedEditingRange': [Proto.FileLocationRequestArgs, Proto.LinkedEditingRangeResponse];
 	'mapCode': [Proto.MapCodeRequestArgs, Proto.MapCodeResponse];
 	'getPasteEdits': [Proto.GetPasteEditsRequestArgs, Proto.GetPasteEditsResponse];
+	'preparePasteEdits': [Proto.PreparePasteEditsRequestArgs, Proto.PreparePasteEditsResponse];
 }
 
 interface NoResponseTsServerRequests {


### PR DESCRIPTION
Client side of https://github.com/microsoft/TypeScript/pull/60053

cc @navya9singh