### PR TITLE
Encapsulate xterm addon importing into own class

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
@@ -756,6 +756,7 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 			Terminal,
 			this._cols,
 			this._rows,
+			undefined,
 			this._scopedInstantiationService.createInstance(TerminalInstanceColorProvider, this._targetRef),
 			this.capabilities,
 			this._processManager.shellIntegrationNonce,

--- a/src/vs/workbench/contrib/terminal/browser/terminalService.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalService.ts
@@ -1028,6 +1028,7 @@ export class TerminalService extends Disposable implements ITerminalService {
 			ctor,
 			options.cols,
 			options.rows,
+			undefined,
 			options.colorProvider,
 			options.capabilities || new TerminalCapabilityStore(),
 			'',

--- a/src/vs/workbench/contrib/terminal/browser/xterm/xtermAddonImporter.ts
+++ b/src/vs/workbench/contrib/terminal/browser/xterm/xtermAddonImporter.ts
@@ -1,0 +1,54 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import type { ClipboardAddon as ClipboardAddonType } from '@xterm/addon-clipboard';
+import type { ImageAddon as ImageAddonType } from '@xterm/addon-image';
+import type { SearchAddon as SearchAddonType } from '@xterm/addon-search';
+import type { SerializeAddon as SerializeAddonType } from '@xterm/addon-serialize';
+import type { Unicode11Addon as Unicode11AddonType } from '@xterm/addon-unicode11';
+import type { WebglAddon as WebglAddonType } from '@xterm/addon-webgl';
+import { importAMDNodeModule } from '../../../../../amdX.js';
+
+export interface IXtermAddonNameToCtor {
+	clipboard: typeof ClipboardAddonType;
+	image: typeof ImageAddonType;
+	search: typeof SearchAddonType;
+	serialize: typeof SerializeAddonType;
+	unicode11: typeof Unicode11AddonType;
+	webgl: typeof WebglAddonType;
+}
+
+// This interface lets a maps key and value be linked with generics
+interface IImportedXtermAddonMap extends Map<keyof IXtermAddonNameToCtor, IXtermAddonNameToCtor[keyof IXtermAddonNameToCtor]> {
+	get<K extends keyof IXtermAddonNameToCtor>(name: K): IXtermAddonNameToCtor[K] | undefined;
+	set<K extends keyof IXtermAddonNameToCtor>(name: K, value: IXtermAddonNameToCtor[K]): this;
+}
+
+const importedAddons: IImportedXtermAddonMap = new Map();
+
+/**
+ * Exposes a simple interface to consumers, encapsulating the messy import xterm
+ * addon import and caching logic.
+ */
+export class XtermAddonImporter {
+	async importAddon<T extends keyof IXtermAddonNameToCtor>(name: T): Promise<IXtermAddonNameToCtor[T]> {
+		let addon = importedAddons.get(name);
+		if (!addon) {
+			switch (name) {
+				case 'clipboard': addon = (await importAMDNodeModule<typeof import('@xterm/addon-clipboard')>('@xterm/addon-clipboard', 'lib/addon-clipboard.js')).ClipboardAddon as IXtermAddonNameToCtor[T]; break;
+				case 'image': addon = (await importAMDNodeModule<typeof import('@xterm/addon-image')>('@xterm/addon-image', 'lib/addon-image.js')).ImageAddon as IXtermAddonNameToCtor[T]; break;
+				case 'search': addon = (await importAMDNodeModule<typeof import('@xterm/addon-search')>('@xterm/addon-search', 'lib/addon-search.js')).SearchAddon as IXtermAddonNameToCtor[T]; break;
+				case 'serialize': addon = (await importAMDNodeModule<typeof import('@xterm/addon-serialize')>('@xterm/addon-serialize', 'lib/addon-serialize.js')).SerializeAddon as IXtermAddonNameToCtor[T]; break;
+				case 'unicode11': addon = (await importAMDNodeModule<typeof import('@xterm/addon-unicode11')>('@xterm/addon-unicode11', 'lib/addon-unicode11.js')).Unicode11Addon as IXtermAddonNameToCtor[T]; break;
+				case 'webgl': addon = (await importAMDNodeModule<typeof import('@xterm/addon-webgl')>('@xterm/addon-webgl', 'lib/addon-webgl.js')).WebglAddon as IXtermAddonNameToCtor[T]; break;
+			}
+			if (!addon) {
+				throw new Error(`Could not load addon ${name}`);
+			}
+			importedAddons.set(name, addon);
+		}
+		return addon as IXtermAddonNameToCtor[T];
+	}
+}

--- a/src/vs/workbench/contrib/terminal/test/browser/xterm/xtermTerminal.test.ts
+++ b/src/vs/workbench/contrib/terminal/test/browser/xterm/xtermTerminal.test.ts
@@ -7,7 +7,6 @@ import type { WebglAddon } from '@xterm/addon-webgl';
 import type { IEvent, Terminal } from '@xterm/xterm';
 import { deepStrictEqual, strictEqual } from 'assert';
 import { importAMDNodeModule } from '../../../../../../amdX.js';
-import { isSafari } from '../../../../../../base/browser/browser.js';
 import { Color, RGBA } from '../../../../../../base/common/color.js';
 import { Emitter } from '../../../../../../base/common/event.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../../base/test/common/utils.js';
@@ -23,6 +22,7 @@ import { XtermTerminal } from '../../../browser/xterm/xtermTerminal.js';
 import { ITerminalConfiguration, TERMINAL_VIEW_ID } from '../../../common/terminal.js';
 import { registerColors, TERMINAL_BACKGROUND_COLOR, TERMINAL_CURSOR_BACKGROUND_COLOR, TERMINAL_CURSOR_FOREGROUND_COLOR, TERMINAL_FOREGROUND_COLOR, TERMINAL_INACTIVE_SELECTION_BACKGROUND_COLOR, TERMINAL_SELECTION_BACKGROUND_COLOR, TERMINAL_SELECTION_FOREGROUND_COLOR } from '../../../common/terminalColorRegistry.js';
 import { workbenchInstantiationService } from '../../../../../test/browser/workbenchTestServices.js';
+import { IXtermAddonNameToCtor, XtermAddonImporter } from '../../../browser/xterm/xtermAddonImporter.js';
 
 registerColors();
 
@@ -45,11 +45,12 @@ class TestWebglAddon implements WebglAddon {
 	clearTextureAtlas() { }
 }
 
-class TestXtermTerminal extends XtermTerminal {
-	webglAddonPromise: Promise<typeof WebglAddon> = Promise.resolve(TestWebglAddon);
-	// Force synchronous to avoid async when activating the addon
-	protected override _getWebglAddonConstructor() {
-		return this.webglAddonPromise;
+class TestXtermAddonImporter extends XtermAddonImporter {
+	override async importAddon<T extends keyof IXtermAddonNameToCtor>(name: T): Promise<IXtermAddonNameToCtor[T]> {
+		if (name === 'webgl') {
+			return Promise.resolve(TestWebglAddon) as any;
+		}
+		return super.importAddon(name);
 	}
 }
 
@@ -90,7 +91,7 @@ suite('XtermTerminal', () => {
 	let instantiationService: TestInstantiationService;
 	let configurationService: TestConfigurationService;
 	let themeService: TestThemeService;
-	let xterm: TestXtermTerminal;
+	let xterm: XtermTerminal;
 	let XTermBaseCtor: typeof Terminal;
 
 	setup(async () => {
@@ -113,7 +114,7 @@ suite('XtermTerminal', () => {
 		XTermBaseCtor = (await importAMDNodeModule<typeof import('@xterm/xterm')>('@xterm/xterm', 'lib/xterm.js')).Terminal;
 
 		const capabilityStore = store.add(new TerminalCapabilityStore());
-		xterm = store.add(instantiationService.createInstance(TestXtermTerminal, XTermBaseCtor, 80, 30, { getBackgroundColor: () => undefined }, capabilityStore, '', true));
+		xterm = store.add(instantiationService.createInstance(XtermTerminal, XTermBaseCtor, 80, 30, new TestXtermAddonImporter(), { getBackgroundColor: () => undefined }, capabilityStore, '', true));
 
 		TestWebglAddon.shouldThrow = false;
 		TestWebglAddon.isEnabled = false;
@@ -130,7 +131,7 @@ suite('XtermTerminal', () => {
 				[PANEL_BACKGROUND]: '#ff0000',
 				[SIDE_BAR_BACKGROUND]: '#00ff00'
 			}));
-			xterm = store.add(instantiationService.createInstance(XtermTerminal, XTermBaseCtor, 80, 30, { getBackgroundColor: () => new Color(new RGBA(255, 0, 0)) }, store.add(new TerminalCapabilityStore()), '', true));
+			xterm = store.add(instantiationService.createInstance(XtermTerminal, XTermBaseCtor, 80, 30, new TestXtermAddonImporter(), { getBackgroundColor: () => new Color(new RGBA(255, 0, 0)) }, store.add(new TerminalCapabilityStore()), '', true));
 			strictEqual(xterm.raw.options.theme?.background, '#ff0000');
 		});
 		test('should react to and apply theme changes', () => {
@@ -159,7 +160,7 @@ suite('XtermTerminal', () => {
 				'terminal.ansiBrightCyan': '#150000',
 				'terminal.ansiBrightWhite': '#160000',
 			}));
-			xterm = store.add(instantiationService.createInstance(XtermTerminal, XTermBaseCtor, 80, 30, { getBackgroundColor: () => undefined }, store.add(new TerminalCapabilityStore()), '', true));
+			xterm = store.add(instantiationService.createInstance(XtermTerminal, XTermBaseCtor, 80, 30, new TestXtermAddonImporter(), { getBackgroundColor: () => undefined }, store.add(new TerminalCapabilityStore()), '', true));
 			deepStrictEqual(xterm.raw.options.theme, {
 				background: undefined,
 				foreground: '#000200',
@@ -243,42 +244,6 @@ suite('XtermTerminal', () => {
 				brightCyan: '#15000f',
 				brightWhite: '#16000f',
 			});
-		});
-	});
-
-	suite('renderers', () => {
-		// This is skipped until the webgl renderer bug is fixed in Chromium
-		// https://bugs.chromium.org/p/chromium/issues/detail?id=1476475
-		test.skip('should re-evaluate gpu acceleration auto when the setting is changed', async () => {
-			// Check initial state
-			strictEqual(TestWebglAddon.isEnabled, false);
-
-			// Open xterm as otherwise the webgl addon won't activate
-			const container = document.createElement('div');
-			xterm.attachToElement(container);
-
-			// Auto should activate the webgl addon
-			await configurationService.setUserConfiguration('terminal', { integrated: { ...defaultTerminalConfig, gpuAcceleration: 'auto' } });
-			configurationService.onDidChangeConfigurationEmitter.fire({ affectsConfiguration: () => true } as any);
-			await xterm.webglAddonPromise; // await addon activate
-			if (isSafari) {
-				strictEqual(TestWebglAddon.isEnabled, false, 'The webgl renderer is always disabled on Safari');
-			} else {
-				strictEqual(TestWebglAddon.isEnabled, true);
-			}
-
-			// Turn off to reset state
-			await configurationService.setUserConfiguration('terminal', { integrated: { ...defaultTerminalConfig, gpuAcceleration: 'off' } });
-			configurationService.onDidChangeConfigurationEmitter.fire({ affectsConfiguration: () => true } as any);
-			await xterm.webglAddonPromise; // await addon activate
-			strictEqual(TestWebglAddon.isEnabled, false);
-
-			// Set to auto again but throw when activating the webgl addon
-			TestWebglAddon.shouldThrow = true;
-			await configurationService.setUserConfiguration('terminal', { integrated: { ...defaultTerminalConfig, gpuAcceleration: 'auto' } });
-			configurationService.onDidChangeConfigurationEmitter.fire({ affectsConfiguration: () => true } as any);
-			await xterm.webglAddonPromise; // await addon activate
-			strictEqual(TestWebglAddon.isEnabled, false);
 		});
 	});
 });

--- a/src/vs/workbench/contrib/terminalContrib/accessibility/test/browser/bufferContentTracker.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/accessibility/test/browser/bufferContentTracker.test.ts
@@ -79,7 +79,7 @@ suite('Buffer Content Tracker', () => {
 			capabilities.add(TerminalCapability.NaiveCwdDetection, null!);
 		}
 		const TerminalCtor = (await importAMDNodeModule<typeof import('@xterm/xterm')>('@xterm/xterm', 'lib/xterm.js')).Terminal;
-		xterm = store.add(instantiationService.createInstance(XtermTerminal, TerminalCtor, 80, 30, { getBackgroundColor: () => undefined }, capabilities, '', true));
+		xterm = store.add(instantiationService.createInstance(XtermTerminal, TerminalCtor, 80, 30, undefined, { getBackgroundColor: () => undefined }, capabilities, '', true));
 		const container = document.createElement('div');
 		xterm.raw.open(container);
 		configurationService = new TestConfigurationService({ terminal: { integrated: { tabs: { separator: ' - ', title: '${cwd}', description: '${cwd}' } } } });


### PR DESCRIPTION
This simplifies xtermTerminal.ts and hides the messy details of importing addons, caching and new somewhat complex interfaces for managing them.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
