### PR TITLE
Adding box around composition in light and dark high contrast themes

### DIFF
--- a/src/vs/editor/browser/controller/editContext/native/nativeEditContext.css
+++ b/src/vs/editor/browser/controller/editContext/native/nativeEditContext.css
@@ -18,10 +18,18 @@
 	border-bottom: none;
 }
 
-.monaco-editor .edit-context-composition-secondary {
+.monaco-editor :not(.hc-black, .hc-light) .edit-context-composition-secondary {
 	border-bottom: 1px solid var(--vscode-editor-compositionBorder);
 }
 
-.monaco-editor .edit-context-composition-primary {
+.monaco-editor :not(.hc-black, .hc-light) .edit-context-composition-primary {
 	border-bottom: 2px solid var(--vscode-editor-compositionBorder);
+}
+
+.monaco-editor :is(.hc-black, .hc-light) .edit-context-composition-secondary {
+	border: 1px solid var(--vscode-editor-compositionBorder);
+}
+
+.monaco-editor :is(.hc-black, .hc-light) .edit-context-composition-primary {
+	border: 2px solid var(--vscode-editor-compositionBorder);
 }


### PR DESCRIPTION
Adding box around composition in light and dark high contrast themes

<img width="192" alt="Screenshot 2024-09-30 at 10 57 02" src="https://github.com/user-attachments/assets/81550060-1a1e-40e8-8f35-28fcc1fc98b7">

fixes https://github.com/microsoft/vscode/issues/229853