### PR TITLE
Only enable js/ts paste with imports for copy and pasted within VS Code

### DIFF
--- a/extensions/typescript-language-features/src/languageFeatures/copyPaste.ts
+++ b/extensions/typescript-language-features/src/languageFeatures/copyPaste.ts
@@ -159,7 +159,7 @@ export function register(selector: DocumentSelector, language: LanguageDescripti
 		return vscode.languages.registerDocumentPasteEditProvider(selector.semantic, new DocumentPasteProvider(language.id, client), {
 			providedPasteEditKinds: [DocumentPasteProvider.kind],
 			copyMimeTypes: [DocumentPasteProvider.metadataMimeType],
-			pasteMimeTypes: ['text/plain'],
+			pasteMimeTypes: [DocumentPasteProvider.metadataMimeType],
 		});
 	});
 }


### PR DESCRIPTION
May revisit this in the future