### PR TITLE
chore: add npmrc to extensions folder

### DIFF
--- a/extensions/.npmrc
+++ b/extensions/.npmrc
@@ -1,0 +1,2 @@
+legacy-peer-deps="true"
+timeout=180000

--- a/extensions/configuration-editing/.npmrc
+++ b/extensions/configuration-editing/.npmrc
@@ -1,0 +1,2 @@
+legacy-peer-deps="true"
+timeout=180000

--- a/extensions/css-language-features/.npmrc
+++ b/extensions/css-language-features/.npmrc
@@ -1,0 +1,2 @@
+legacy-peer-deps="true"
+timeout=180000

--- a/extensions/css-language-features/server/.npmrc
+++ b/extensions/css-language-features/server/.npmrc
@@ -1,0 +1,2 @@
+legacy-peer-deps="true"
+timeout=180000

--- a/extensions/debug-auto-launch/.npmrc
+++ b/extensions/debug-auto-launch/.npmrc
@@ -1,0 +1,2 @@
+legacy-peer-deps="true"
+timeout=180000

--- a/extensions/debug-server-ready/.npmrc
+++ b/extensions/debug-server-ready/.npmrc
@@ -1,0 +1,2 @@
+legacy-peer-deps="true"
+timeout=180000

--- a/extensions/emmet/.npmrc
+++ b/extensions/emmet/.npmrc
@@ -1,0 +1,2 @@
+legacy-peer-deps="true"
+timeout=180000

--- a/extensions/extension-editing/.npmrc
+++ b/extensions/extension-editing/.npmrc
@@ -1,0 +1,2 @@
+legacy-peer-deps="true"
+timeout=180000

--- a/extensions/git-base/.npmrc
+++ b/extensions/git-base/.npmrc
@@ -1,0 +1,2 @@
+legacy-peer-deps="true"
+timeout=180000

--- a/extensions/git/.npmrc
+++ b/extensions/git/.npmrc
@@ -1,0 +1,2 @@
+legacy-peer-deps="true"
+timeout=180000

--- a/extensions/git/package-lock.json
+++ b/extensions/git/package-lock.json
@@ -386,13 +386,6 @@
         "url": "https://github.com/sponsors/Borewit"
       }
     },
-    "node_modules/tslib": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
-      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
-      "license": "0BSD",
-      "peer": true
-    },
     "node_modules/undici-types": {
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",

--- a/extensions/github-authentication/.npmrc
+++ b/extensions/github-authentication/.npmrc
@@ -1,0 +1,2 @@
+legacy-peer-deps="true"
+timeout=180000

--- a/extensions/github/.npmrc
+++ b/extensions/github/.npmrc
@@ -1,0 +1,2 @@
+legacy-peer-deps="true"
+timeout=180000

--- a/extensions/grunt/.npmrc
+++ b/extensions/grunt/.npmrc
@@ -1,0 +1,2 @@
+legacy-peer-deps="true"
+timeout=180000

--- a/extensions/gulp/.npmrc
+++ b/extensions/gulp/.npmrc
@@ -1,0 +1,2 @@
+legacy-peer-deps="true"
+timeout=180000

--- a/extensions/html-language-features/.npmrc
+++ b/extensions/html-language-features/.npmrc
@@ -1,0 +1,2 @@
+legacy-peer-deps="true"
+timeout=180000

--- a/extensions/html-language-features/server/.npmrc
+++ b/extensions/html-language-features/server/.npmrc
@@ -1,0 +1,2 @@
+legacy-peer-deps="true"
+timeout=180000

--- a/extensions/ipynb/.npmrc
+++ b/extensions/ipynb/.npmrc
@@ -1,0 +1,2 @@
+legacy-peer-deps="true"
+timeout=180000

--- a/extensions/jake/.npmrc
+++ b/extensions/jake/.npmrc
@@ -1,0 +1,2 @@
+legacy-peer-deps="true"
+timeout=180000

--- a/extensions/json-language-features/.npmrc
+++ b/extensions/json-language-features/.npmrc
@@ -1,0 +1,2 @@
+legacy-peer-deps="true"
+timeout=180000

--- a/extensions/json-language-features/server/.npmrc
+++ b/extensions/json-language-features/server/.npmrc
@@ -1,0 +1,2 @@
+legacy-peer-deps="true"
+timeout=180000

--- a/extensions/markdown-language-features/.npmrc
+++ b/extensions/markdown-language-features/.npmrc
@@ -1,0 +1,2 @@
+legacy-peer-deps="true"
+timeout=180000

--- a/extensions/markdown-math/.npmrc
+++ b/extensions/markdown-math/.npmrc
@@ -1,0 +1,2 @@
+legacy-peer-deps="true"
+timeout=180000

--- a/extensions/media-preview/.npmrc
+++ b/extensions/media-preview/.npmrc
@@ -1,0 +1,2 @@
+legacy-peer-deps="true"
+timeout=180000

--- a/extensions/merge-conflict/.npmrc
+++ b/extensions/merge-conflict/.npmrc
@@ -1,0 +1,2 @@
+legacy-peer-deps="true"
+timeout=180000

--- a/extensions/microsoft-authentication/.npmrc
+++ b/extensions/microsoft-authentication/.npmrc
@@ -1,0 +1,2 @@
+legacy-peer-deps="true"
+timeout=180000

--- a/extensions/notebook-renderers/.npmrc
+++ b/extensions/notebook-renderers/.npmrc
@@ -1,0 +1,2 @@
+legacy-peer-deps="true"
+timeout=180000

--- a/extensions/npm/.npmrc
+++ b/extensions/npm/.npmrc
@@ -1,0 +1,2 @@
+legacy-peer-deps="true"
+timeout=180000

--- a/extensions/php-language-features/.npmrc
+++ b/extensions/php-language-features/.npmrc
@@ -1,0 +1,2 @@
+legacy-peer-deps="true"
+timeout=180000

--- a/extensions/references-view/.npmrc
+++ b/extensions/references-view/.npmrc
@@ -1,0 +1,2 @@
+legacy-peer-deps="true"
+timeout=180000

--- a/extensions/simple-browser/.npmrc
+++ b/extensions/simple-browser/.npmrc
@@ -1,0 +1,2 @@
+legacy-peer-deps="true"
+timeout=180000

--- a/extensions/tunnel-forwarding/.npmrc
+++ b/extensions/tunnel-forwarding/.npmrc
@@ -1,0 +1,2 @@
+legacy-peer-deps="true"
+timeout=180000

--- a/extensions/typescript-language-features/.npmrc
+++ b/extensions/typescript-language-features/.npmrc
@@ -1,0 +1,2 @@
+legacy-peer-deps="true"
+timeout=180000

--- a/extensions/vscode-api-tests/.npmrc
+++ b/extensions/vscode-api-tests/.npmrc
@@ -1,0 +1,2 @@
+legacy-peer-deps="true"
+timeout=180000

--- a/extensions/vscode-colorize-tests/.npmrc
+++ b/extensions/vscode-colorize-tests/.npmrc
@@ -1,0 +1,2 @@
+legacy-peer-deps="true"
+timeout=180000

--- a/extensions/vscode-test-resolver/.npmrc
+++ b/extensions/vscode-test-resolver/.npmrc
@@ -1,0 +1,2 @@
+legacy-peer-deps="true"
+timeout=180000


### PR DESCRIPTION
https://github.com/microsoft/vscode/pull/230197 accidentally made changes to `extensions/git/package-lock.json` that is against the project setting https://github.com/microsoft/vscode/blob/4aeed99e330c914b94951f0dda87115f7c23020d/.npmrc#L6

This change adds `.npmrc` to all extension subfolders that need them to avoid such changes if a user were to run `npm i` under those directories.

I am also looking to catching this in CI, there is no check we have today that can capture this case since we run `npm clean install` which freezes the lock files.