### PR TITLE
build: make sdl scan gulp tasks lazy

### DIFF
--- a/build/gulpfile.scan.js
+++ b/build/gulpfile.scan.js
@@ -71,12 +71,15 @@ BUILD_TARGETS.forEach(buildTarget => {
 	gulp.task(setupSymbolsTask);
 });
 
-function nodeModules(destinationExe, destinationPdb, platform) {
+function getProductionDependencySources() {
 	const productionDependencies = deps.getProductionDependencies(root);
-	const dependenciesSrc = productionDependencies.map(d => path.relative(root, d)).map(d => [`${d}/**`, `!${d}/**/{test,tests}/**`]).flat();
+	return productionDependencies.map(d => path.relative(root, d)).map(d => [`${d}/**`, `!${d}/**/{test,tests}/**`]).flat();
+}
+
+function nodeModules(destinationExe, destinationPdb, platform) {
 
 	const exe = () => {
-		return gulp.src(dependenciesSrc, { base: '.', dot: true })
+		return gulp.src(getProductionDependencySources(), { base: '.', dot: true })
 			.pipe(filter([
 				'**/*.node',
 				// Exclude these paths.
@@ -89,7 +92,7 @@ function nodeModules(destinationExe, destinationPdb, platform) {
 
 	if (platform === 'win32') {
 		const pdb = () => {
-			return gulp.src(dependenciesSrc, { base: '.', dot: true })
+			return gulp.src(getProductionDependencySources(), { base: '.', dot: true })
 				.pipe(filter(['**/*.pdb']))
 				.pipe(gulp.dest(destinationPdb));
 		};
@@ -99,7 +102,7 @@ function nodeModules(destinationExe, destinationPdb, platform) {
 
 	if (platform === 'linux') {
 		const pdb = () => {
-			return gulp.src(dependenciesSrc, { base: '.', dot: true })
+			return gulp.src(getProductionDependencySources(), { base: '.', dot: true })
 				.pipe(filter(['**/*.sym']))
 				.pipe(gulp.dest(destinationPdb));
 		};


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/230200

`gulpfile.scan.js` was eagerly evaluating the dependency extraction as a side effect of loading the gulpfile via https://github.com/microsoft/vscode/blob/516ecddae18c27b92ed9079052f4d892aad499fc/build/gulpfile.js#L51-L53. This interferes with build task when switching branches that could contain possibly different dependency trees. The task is only meant to run in SDL scan CI on demand, so make the relevant calls lazy as well.

/cc @rzhao271 