### PR TITLE
rename search API names to old/current

### DIFF
--- a/extensions/vscode-api-tests/src/singlefolder-tests/workspace.test.ts
+++ b/extensions/vscode-api-tests/src/singlefolder-tests/workspace.test.ts
@@ -636,7 +636,7 @@ suite('vscode API - workspace', () => {
 	});
 
 	test('findTextInFiles', async () => {
-		const options: vscode.FindTextInFilesOptions = {
+		const options: vscode.FindTextInFilesOptionsOld = {
 			include: '*.ts',
 			previewOptions: {
 				matchLines: 1,
@@ -644,19 +644,19 @@ suite('vscode API - workspace', () => {
 			}
 		};
 
-		const results: vscode.TextSearchResult[] = [];
+		const results: vscode.TextSearchResultOld[] = [];
 		await vscode.workspace.findTextInFiles({ pattern: 'foo' }, options, result => {
 			results.push(result);
 		});
 
 		assert.strictEqual(results.length, 1);
-		const match = <vscode.TextSearchMatch>results[0];
+		const match = <vscode.TextSearchMatchOld>results[0];
 		assert(match.preview.text.indexOf('foo') >= 0);
 		assert.strictEqual(basename(vscode.workspace.asRelativePath(match.uri)), '10linefile.ts');
 	});
 
 	test('findTextInFiles, cancellation', async () => {
-		const results: vscode.TextSearchResult[] = [];
+		const results: vscode.TextSearchResultOld[] = [];
 		const cancellation = new vscode.CancellationTokenSource();
 		cancellation.cancel();
 

--- a/src/vs/workbench/api/common/extHost.api.impl.ts
+++ b/src/vs/workbench/api/common/extHost.api.impl.ts
@@ -985,7 +985,7 @@ export function createApiFactoryAndRegisterActors(accessor: ServicesAccessor): I
 
 				return extHostWorkspace.findTextInFiles(query, options || {}, callback, extension.identifier, token);
 			},
-			findTextInFilesNew: (query: vscode.TextSearchQuery, options?: vscode.FindTextInFilesOptions, token?: vscode.CancellationToken): vscode.FindTextInFilesResponse => {
+			findTextInFiles2: (query: vscode.TextSearchQuery, options?: vscode.FindTextInFilesOptions, token?: vscode.CancellationToken): vscode.FindTextInFilesResponse => {
 				checkProposedApiEnabled(extension, 'findTextInFilesNew');
 				checkProposedApiEnabled(extension, 'textSearchProviderNew');
 				return extHostWorkspace.findTextInFilesNew(query, options, extension.identifier, token);

--- a/src/vs/workbench/api/common/extHost.api.impl.ts
+++ b/src/vs/workbench/api/common/extHost.api.impl.ts
@@ -961,22 +961,22 @@ export function createApiFactoryAndRegisterActors(accessor: ServicesAccessor): I
 				// Note, undefined/null have different meanings on "exclude"
 				return extHostWorkspace.findFiles(include, exclude, maxResults, extension.identifier, token);
 			},
-			findFiles2: (filePattern: vscode.GlobPattern, options?: vscode.FindFiles2Options, token?: vscode.CancellationToken): Thenable<vscode.Uri[]> => {
-				checkProposedApiEnabled(extension, 'findFiles2');
-				return extHostWorkspace.findFiles2(filePattern, options, extension.identifier, token);
+			findFiles2: (filePattern: vscode.GlobPattern | vscode.GlobPattern[], options?: vscode.FindFiles2OptionsOld | vscode.FindFiles2Options, token?: vscode.CancellationToken): Thenable<vscode.Uri[]> => {
+				if (isProposedApiEnabled(extension, 'findFiles2New')) {
+					return extHostWorkspace.findFiles2New(<vscode.GlobPattern[]>filePattern, <vscode.FindFiles2Options>options, extension.identifier, token);
+				} else {
+					checkProposedApiEnabled(extension, 'findFiles2');
+					return extHostWorkspace.findFiles2(<vscode.GlobPattern>filePattern, <vscode.FindFiles2OptionsOld>options, extension.identifier, token);
+				}
 			},
-			findFiles2New: (filePattern: vscode.GlobPattern[], options?: vscode.FindFiles2OptionsNew, token?: vscode.CancellationToken): Thenable<vscode.Uri[]> => {
-				checkProposedApiEnabled(extension, 'findFiles2New');
-				return extHostWorkspace.findFiles2New(filePattern, options, extension.identifier, token);
-			},
-			findTextInFiles: (query: vscode.TextSearchQuery, optionsOrCallback: vscode.FindTextInFilesOptions | ((result: vscode.TextSearchResult) => void), callbackOrToken?: vscode.CancellationToken | ((result: vscode.TextSearchResult) => void), token?: vscode.CancellationToken) => {
+			findTextInFiles: (query: vscode.TextSearchQueryOld, optionsOrCallback: vscode.FindTextInFilesOptionsOld | ((result: vscode.TextSearchResultOld) => void), callbackOrToken?: vscode.CancellationToken | ((result: vscode.TextSearchResultOld) => void), token?: vscode.CancellationToken) => {
 				checkProposedApiEnabled(extension, 'findTextInFiles');
-				let options: vscode.FindTextInFilesOptions;
-				let callback: (result: vscode.TextSearchResult) => void;
+				let options: vscode.FindTextInFilesOptionsOld;
+				let callback: (result: vscode.TextSearchResultOld) => void;
 
 				if (typeof optionsOrCallback === 'object') {
 					options = optionsOrCallback;
-					callback = callbackOrToken as (result: vscode.TextSearchResult) => void;
+					callback = callbackOrToken as (result: vscode.TextSearchResultOld) => void;
 				} else {
 					options = {};
 					callback = optionsOrCallback;
@@ -985,7 +985,7 @@ export function createApiFactoryAndRegisterActors(accessor: ServicesAccessor): I
 
 				return extHostWorkspace.findTextInFiles(query, options || {}, callback, extension.identifier, token);
 			},
-			findTextInFilesNew: (query: vscode.TextSearchQueryNew, options?: vscode.FindTextInFilesOptionsNew, token?: vscode.CancellationToken): vscode.FindTextInFilesResponse => {
+			findTextInFilesNew: (query: vscode.TextSearchQuery, options?: vscode.FindTextInFilesOptions, token?: vscode.CancellationToken): vscode.FindTextInFilesResponse => {
 				checkProposedApiEnabled(extension, 'findTextInFilesNew');
 				checkProposedApiEnabled(extension, 'textSearchProviderNew');
 				return extHostWorkspace.findTextInFilesNew(query, options, extension.identifier, token);
@@ -1125,33 +1125,45 @@ export function createApiFactoryAndRegisterActors(accessor: ServicesAccessor): I
 			get fs() {
 				return extHostConsumerFileSystem.value;
 			},
-			registerFileSearchProvider: (scheme: string, provider: vscode.FileSearchProvider) => {
-				checkProposedApiEnabled(extension, 'fileSearchProvider');
-				return extHostSearch.registerFileSearchProviderOld(scheme, provider);
+			registerFileSearchProvider: (scheme: string, provider: vscode.FileSearchProvider | vscode.FileSearchProviderOld) => {
+				if (isProposedApiEnabled(extension, 'fileSearchProviderNew')) {
+					const providerNew = provider as vscode.FileSearchProvider;
+
+					return extHostSearch.registerFileSearchProvider(scheme, providerNew);
+
+				} else {
+					checkProposedApiEnabled(extension, 'fileSearchProvider');
+					const providerOld = provider as vscode.FileSearchProviderOld; // if they haven't opted in, we assume they are using the old API
+
+					return extHostSearch.registerFileSearchProviderOld(scheme, providerOld);
+				}
 			},
-			registerTextSearchProvider: (scheme: string, provider: vscode.TextSearchProvider) => {
-				checkProposedApiEnabled(extension, 'textSearchProvider');
-				return extHostSearch.registerTextSearchProviderOld(scheme, provider);
+			registerTextSearchProvider: (scheme: string, provider: vscode.TextSearchProvider | vscode.TextSearchProviderOld) => {
+
+				if (isProposedApiEnabled(extension, 'textSearchProviderNew')) {
+					const providerNew = provider as vscode.TextSearchProvider;
+
+					return extHostSearch.registerTextSearchProvider(scheme, providerNew);
+				} else {
+					checkProposedApiEnabled(extension, 'textSearchProvider');
+					const providerOld = provider as vscode.TextSearchProviderOld; // if they haven't opted in, we assume they are using the old API
+
+					return extHostSearch.registerTextSearchProviderOld(scheme, providerOld);
+				}
 			},
-			registerAITextSearchProvider: (scheme: string, provider: vscode.AITextSearchProvider) => {
+			registerAITextSearchProvider: (scheme: string, provider: vscode.AITextSearchProvider | vscode.AITextSearchProviderOld) => {
 				// there are some dependencies on textSearchProvider, so we need to check for both
-				checkProposedApiEnabled(extension, 'aiTextSearchProvider');
-				checkProposedApiEnabled(extension, 'textSearchProvider');
-				return extHostSearch.registerAITextSearchProviderOld(scheme, provider);
-			},
-			registerFileSearchProviderNew: (scheme: string, provider: vscode.FileSearchProviderNew) => {
-				checkProposedApiEnabled(extension, 'fileSearchProviderNew');
-				return extHostSearch.registerFileSearchProvider(scheme, provider);
-			},
-			registerTextSearchProviderNew: (scheme: string, provider: vscode.TextSearchProviderNew) => {
-				checkProposedApiEnabled(extension, 'textSearchProviderNew');
-				return extHostSearch.registerTextSearchProvider(scheme, provider);
-			},
-			registerAITextSearchProviderNew: (scheme: string, provider: vscode.AITextSearchProviderNew) => {
-				// there are some dependencies on textSearchProvider, so we need to check for both
-				checkProposedApiEnabled(extension, 'aiTextSearchProviderNew');
-				checkProposedApiEnabled(extension, 'textSearchProviderNew');
-				return extHostSearch.registerAITextSearchProvider(scheme, provider);
+				if (isProposedApiEnabled(extension, 'textSearchProviderNew') && isProposedApiEnabled(extension, 'aiTextSearchProviderNew')) {
+					const providerNew = provider as vscode.AITextSearchProvider;
+
+					return extHostSearch.registerAITextSearchProvider(scheme, providerNew);
+				} else {
+					checkProposedApiEnabled(extension, 'aiTextSearchProvider');
+					checkProposedApiEnabled(extension, 'textSearchProvider');
+					const providerOld = provider as vscode.AITextSearchProviderOld; // if they haven't opted in, we assume they are using the old API
+
+					return extHostSearch.registerAITextSearchProviderOld(scheme, providerOld);
+				}
 			},
 			registerRemoteAuthorityResolver: (authorityPrefix: string, resolver: vscode.RemoteAuthorityResolver) => {
 				checkProposedApiEnabled(extension, 'resolvers');
@@ -1784,8 +1796,8 @@ export function createApiFactoryAndRegisterActors(accessor: ServicesAccessor): I
 			InlineEdit: extHostTypes.InlineEdit,
 			InlineEditTriggerKind: extHostTypes.InlineEditTriggerKind,
 			ExcludeSettingOptions: ExcludeSettingOptions,
-			TextSearchContextNew: TextSearchContextNew,
-			TextSearchMatchNew: TextSearchMatchNew,
+			TextSearchContext: TextSearchContextNew,
+			TextSearchMatch: TextSearchMatchNew,
 			TextSearchCompleteMessageTypeNew: TextSearchCompleteMessageType,
 		};
 	};

--- a/src/vs/workbench/api/common/extHostSearch.ts
+++ b/src/vs/workbench/api/common/extHostSearch.ts
@@ -19,12 +19,12 @@ import { revive } from '../../../base/common/marshalling.js';
 import { OldAITextSearchProviderConverter, OldFileSearchProviderConverter, OldTextSearchProviderConverter } from '../../services/search/common/searchExtConversionTypes.js';
 
 export interface IExtHostSearch extends ExtHostSearchShape {
-	registerTextSearchProviderOld(scheme: string, provider: vscode.TextSearchProvider): IDisposable;
-	registerAITextSearchProviderOld(scheme: string, provider: vscode.AITextSearchProvider): IDisposable;
-	registerFileSearchProviderOld(scheme: string, provider: vscode.FileSearchProvider): IDisposable;
-	registerTextSearchProvider(scheme: string, provider: vscode.TextSearchProviderNew): IDisposable;
-	registerAITextSearchProvider(scheme: string, provider: vscode.AITextSearchProviderNew): IDisposable;
-	registerFileSearchProvider(scheme: string, provider: vscode.FileSearchProviderNew): IDisposable;
+	registerTextSearchProviderOld(scheme: string, provider: vscode.TextSearchProviderOld): IDisposable;
+	registerAITextSearchProviderOld(scheme: string, provider: vscode.AITextSearchProviderOld): IDisposable;
+	registerFileSearchProviderOld(scheme: string, provider: vscode.FileSearchProviderOld): IDisposable;
+	registerTextSearchProvider(scheme: string, provider: vscode.TextSearchProvider): IDisposable;
+	registerAITextSearchProvider(scheme: string, provider: vscode.AITextSearchProvider): IDisposable;
+	registerFileSearchProvider(scheme: string, provider: vscode.FileSearchProvider): IDisposable;
 	doInternalFileSearchWithCustomCallback(query: IFileQuery, token: CancellationToken, handleFileMatch: (data: URI[]) => void): Promise<ISearchCompleteStats>;
 }
 
@@ -35,13 +35,13 @@ export class ExtHostSearch implements IExtHostSearch {
 	protected readonly _proxy: MainThreadSearchShape = this.extHostRpc.getProxy(MainContext.MainThreadSearch);
 	protected _handlePool: number = 0;
 
-	private readonly _textSearchProvider = new Map<number, vscode.TextSearchProviderNew>();
+	private readonly _textSearchProvider = new Map<number, vscode.TextSearchProvider>();
 	private readonly _textSearchUsedSchemes = new Set<string>();
 
-	private readonly _aiTextSearchProvider = new Map<number, vscode.AITextSearchProviderNew>();
+	private readonly _aiTextSearchProvider = new Map<number, vscode.AITextSearchProvider>();
 	private readonly _aiTextSearchUsedSchemes = new Set<string>();
 
-	private readonly _fileSearchProvider = new Map<number, vscode.FileSearchProviderNew>();
+	private readonly _fileSearchProvider = new Map<number, vscode.FileSearchProvider>();
 	private readonly _fileSearchUsedSchemes = new Set<string>();
 
 	private readonly _fileSearchManager = new FileSearchManager();
@@ -56,7 +56,7 @@ export class ExtHostSearch implements IExtHostSearch {
 		return this._uriTransformer.transformOutgoingScheme(scheme);
 	}
 
-	registerTextSearchProviderOld(scheme: string, provider: vscode.TextSearchProvider): IDisposable {
+	registerTextSearchProviderOld(scheme: string, provider: vscode.TextSearchProviderOld): IDisposable {
 		if (this._textSearchUsedSchemes.has(scheme)) {
 			throw new Error(`a text search provider for the scheme '${scheme}' is already registered`);
 		}
@@ -72,7 +72,7 @@ export class ExtHostSearch implements IExtHostSearch {
 		});
 	}
 
-	registerTextSearchProvider(scheme: string, provider: vscode.TextSearchProviderNew): IDisposable {
+	registerTextSearchProvider(scheme: string, provider: vscode.TextSearchProvider): IDisposable {
 		if (this._textSearchUsedSchemes.has(scheme)) {
 			throw new Error(`a text search provider for the scheme '${scheme}' is already registered`);
 		}
@@ -88,7 +88,7 @@ export class ExtHostSearch implements IExtHostSearch {
 		});
 	}
 
-	registerAITextSearchProviderOld(scheme: string, provider: vscode.AITextSearchProvider): IDisposable {
+	registerAITextSearchProviderOld(scheme: string, provider: vscode.AITextSearchProviderOld): IDisposable {
 		if (this._aiTextSearchUsedSchemes.has(scheme)) {
 			throw new Error(`an AI text search provider for the scheme '${scheme}'is already registered`);
 		}
@@ -104,7 +104,7 @@ export class ExtHostSearch implements IExtHostSearch {
 		});
 	}
 
-	registerAITextSearchProvider(scheme: string, provider: vscode.AITextSearchProviderNew): IDisposable {
+	registerAITextSearchProvider(scheme: string, provider: vscode.AITextSearchProvider): IDisposable {
 		if (this._aiTextSearchUsedSchemes.has(scheme)) {
 			throw new Error(`an AI text search provider for the scheme '${scheme}'is already registered`);
 		}
@@ -120,7 +120,7 @@ export class ExtHostSearch implements IExtHostSearch {
 		});
 	}
 
-	registerFileSearchProviderOld(scheme: string, provider: vscode.FileSearchProvider): IDisposable {
+	registerFileSearchProviderOld(scheme: string, provider: vscode.FileSearchProviderOld): IDisposable {
 		if (this._fileSearchUsedSchemes.has(scheme)) {
 			throw new Error(`a file search provider for the scheme '${scheme}' is already registered`);
 		}
@@ -136,7 +136,7 @@ export class ExtHostSearch implements IExtHostSearch {
 		});
 	}
 
-	registerFileSearchProvider(scheme: string, provider: vscode.FileSearchProviderNew): IDisposable {
+	registerFileSearchProvider(scheme: string, provider: vscode.FileSearchProvider): IDisposable {
 		if (this._fileSearchUsedSchemes.has(scheme)) {
 			throw new Error(`a file search provider for the scheme '${scheme}' is already registered`);
 		}
@@ -208,14 +208,14 @@ export class ExtHostSearch implements IExtHostSearch {
 		return provider.name ?? 'AI';
 	}
 
-	protected createTextSearchManager(query: ITextQuery, provider: vscode.TextSearchProviderNew): TextSearchManager {
+	protected createTextSearchManager(query: ITextQuery, provider: vscode.TextSearchProvider): TextSearchManager {
 		return new TextSearchManager({ query, provider }, {
 			readdir: resource => Promise.resolve([]),
 			toCanonicalName: encoding => encoding
 		}, 'textSearchProvider');
 	}
 
-	protected createAITextSearchManager(query: IAITextQuery, provider: vscode.AITextSearchProviderNew): TextSearchManager {
+	protected createAITextSearchManager(query: IAITextQuery, provider: vscode.AITextSearchProvider): TextSearchManager {
 		return new TextSearchManager({ query, provider }, {
 			readdir: resource => Promise.resolve([]),
 			toCanonicalName: encoding => encoding

--- a/src/vs/workbench/api/node/extHostSearch.ts
+++ b/src/vs/workbench/api/node/extHostSearch.ts
@@ -161,7 +161,7 @@ export class NativeExtHostSearch extends ExtHostSearch implements IDisposable {
 		return super.$clearCache(cacheKey);
 	}
 
-	protected override createTextSearchManager(query: ITextQuery, provider: vscode.TextSearchProviderNew): TextSearchManager {
+	protected override createTextSearchManager(query: ITextQuery, provider: vscode.TextSearchProvider): TextSearchManager {
 		return new NativeTextSearchManager(query, provider, undefined, 'textSearchProvider');
 	}
 }

--- a/src/vs/workbench/api/test/node/extHostSearch.test.ts
+++ b/src/vs/workbench/api/test/node/extHostSearch.test.ts
@@ -75,12 +75,12 @@ function extensionResultIsMatch(data: vscode.TextSearchResultOld): data is vscod
 suite('ExtHostSearch', () => {
 	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
 
-	async function registerTestTextSearchProvider(provider: vscode.TextSearchProvider, scheme = 'file'): Promise<void> {
+	async function registerTestTextSearchProvider(provider: vscode.TextSearchProviderOld, scheme = 'file'): Promise<void> {
 		disposables.add(extHostSearch.registerTextSearchProviderOld(scheme, provider));
 		await rpcProtocol.sync();
 	}
 
-	async function registerTestFileSearchProvider(provider: vscode.FileSearchProvider, scheme = 'file'): Promise<void> {
+	async function registerTestFileSearchProvider(provider: vscode.FileSearchProviderOld, scheme = 'file'): Promise<void> {
 		disposables.add(extHostSearch.registerFileSearchProviderOld(scheme, provider));
 		await rpcProtocol.sync();
 	}

--- a/src/vs/workbench/api/test/node/extHostSearch.test.ts
+++ b/src/vs/workbench/api/test/node/extHostSearch.test.ts
@@ -68,8 +68,8 @@ class MockMainThreadSearch implements MainThreadSearchShape {
 
 let mockPFS: Partial<typeof pfs>;
 
-function extensionResultIsMatch(data: vscode.TextSearchResult): data is vscode.TextSearchMatch {
-	return !!(<vscode.TextSearchMatch>data).preview;
+function extensionResultIsMatch(data: vscode.TextSearchResultOld): data is vscode.TextSearchMatchOld {
+	return !!(<vscode.TextSearchMatchOld>data).preview;
 }
 
 suite('ExtHostSearch', () => {
@@ -170,7 +170,7 @@ suite('ExtHostSearch', () => {
 				this._pfs = mockPFS as any;
 			}
 
-			protected override createTextSearchManager(query: ITextQuery, provider: vscode.TextSearchProviderNew): TextSearchManager {
+			protected override createTextSearchManager(query: ITextQuery, provider: vscode.TextSearchProvider): TextSearchManager {
 				return new NativeTextSearchManager(query, provider, this._pfs);
 			}
 		});
@@ -746,14 +746,14 @@ suite('ExtHostSearch', () => {
 
 	suite('Text:', () => {
 
-		function makePreview(text: string): vscode.TextSearchMatch['preview'] {
+		function makePreview(text: string): vscode.TextSearchMatchOld['preview'] {
 			return {
 				matches: [new Range(0, 0, 0, text.length)],
 				text
 			};
 		}
 
-		function makeTextResult(baseFolder: URI, relativePath: string): vscode.TextSearchMatch {
+		function makeTextResult(baseFolder: URI, relativePath: string): vscode.TextSearchMatchOld {
 			return {
 				preview: makePreview('foo'),
 				ranges: [new Range(0, 0, 0, 3)],
@@ -778,8 +778,8 @@ suite('ExtHostSearch', () => {
 			};
 		}
 
-		function assertResults(actual: IFileMatch[], expected: vscode.TextSearchResult[]) {
-			const actualTextSearchResults: vscode.TextSearchResult[] = [];
+		function assertResults(actual: IFileMatch[], expected: vscode.TextSearchResultOld[]) {
+			const actualTextSearchResults: vscode.TextSearchResultOld[] = [];
 			for (const fileMatch of actual) {
 				// Make relative
 				for (const lineResult of fileMatch.results!) {
@@ -798,7 +798,7 @@ suite('ExtHostSearch', () => {
 							uri: fileMatch.resource
 						});
 					} else {
-						actualTextSearchResults.push(<vscode.TextSearchContext>{
+						actualTextSearchResults.push(<vscode.TextSearchContextOld>{
 							text: lineResult.text,
 							lineNumber: lineResult.lineNumber,
 							uri: fileMatch.resource
@@ -809,7 +809,7 @@ suite('ExtHostSearch', () => {
 
 			const rangeToString = (r: vscode.Range) => `(${r.start.line}, ${r.start.character}), (${r.end.line}, ${r.end.character})`;
 
-			const makeComparable = (results: vscode.TextSearchResult[]) => results
+			const makeComparable = (results: vscode.TextSearchResultOld[]) => results
 				.sort((a, b) => {
 					const compareKeyA = a.uri.toString() + ': ' + (extensionResultIsMatch(a) ? a.preview.text : a.text);
 					const compareKeyB = b.uri.toString() + ': ' + (extensionResultIsMatch(b) ? b.preview.text : b.text);
@@ -835,7 +835,7 @@ suite('ExtHostSearch', () => {
 
 		test('no results', async () => {
 			await registerTestTextSearchProvider({
-				provideTextSearchResults(query: vscode.TextSearchQuery, options: vscode.TextSearchOptions, progress: vscode.Progress<vscode.TextSearchResult>, token: vscode.CancellationToken): Promise<vscode.TextSearchComplete> {
+				provideTextSearchResults(query: vscode.TextSearchQuery, options: vscode.TextSearchOptions, progress: vscode.Progress<vscode.TextSearchResultOld>, token: vscode.CancellationToken): Promise<vscode.TextSearchComplete> {
 					return Promise.resolve(null!);
 				}
 			});
@@ -846,13 +846,13 @@ suite('ExtHostSearch', () => {
 		});
 
 		test('basic results', async () => {
-			const providedResults: vscode.TextSearchResult[] = [
+			const providedResults: vscode.TextSearchResultOld[] = [
 				makeTextResult(rootFolderA, 'file1.ts'),
 				makeTextResult(rootFolderA, 'file2.ts')
 			];
 
 			await registerTestTextSearchProvider({
-				provideTextSearchResults(query: vscode.TextSearchQuery, options: vscode.TextSearchOptions, progress: vscode.Progress<vscode.TextSearchResult>, token: vscode.CancellationToken): Promise<vscode.TextSearchComplete> {
+				provideTextSearchResults(query: vscode.TextSearchQuery, options: vscode.TextSearchOptions, progress: vscode.Progress<vscode.TextSearchResultOld>, token: vscode.CancellationToken): Promise<vscode.TextSearchComplete> {
 					providedResults.forEach(r => progress.report(r));
 					return Promise.resolve(null!);
 				}
@@ -865,7 +865,7 @@ suite('ExtHostSearch', () => {
 
 		test('all provider calls get global include/excludes', async () => {
 			await registerTestTextSearchProvider({
-				provideTextSearchResults(query: vscode.TextSearchQuery, options: vscode.TextSearchOptions, progress: vscode.Progress<vscode.TextSearchResult>, token: vscode.CancellationToken): Promise<vscode.TextSearchComplete> {
+				provideTextSearchResults(query: vscode.TextSearchQuery, options: vscode.TextSearchOptions, progress: vscode.Progress<vscode.TextSearchResultOld>, token: vscode.CancellationToken): Promise<vscode.TextSearchComplete> {
 					assert.strictEqual(options.includes.length, 1);
 					assert.strictEqual(options.excludes.length, 1);
 					return Promise.resolve(null!);
@@ -895,7 +895,7 @@ suite('ExtHostSearch', () => {
 
 		test('global/local include/excludes combined', async () => {
 			await registerTestTextSearchProvider({
-				provideTextSearchResults(query: vscode.TextSearchQuery, options: vscode.TextSearchOptions, progress: vscode.Progress<vscode.TextSearchResult>, token: vscode.CancellationToken): Promise<vscode.TextSearchComplete> {
+				provideTextSearchResults(query: vscode.TextSearchQuery, options: vscode.TextSearchOptions, progress: vscode.Progress<vscode.TextSearchResultOld>, token: vscode.CancellationToken): Promise<vscode.TextSearchComplete> {
 					if (options.folder.toString() === rootFolderA.toString()) {
 						assert.deepStrictEqual(options.includes.sort(), ['*.ts', 'foo']);
 						assert.deepStrictEqual(options.excludes.sort(), ['*.js', 'bar']);
@@ -939,7 +939,7 @@ suite('ExtHostSearch', () => {
 
 		test('include/excludes resolved correctly', async () => {
 			await registerTestTextSearchProvider({
-				provideTextSearchResults(query: vscode.TextSearchQuery, options: vscode.TextSearchOptions, progress: vscode.Progress<vscode.TextSearchResult>, token: vscode.CancellationToken): Promise<vscode.TextSearchComplete> {
+				provideTextSearchResults(query: vscode.TextSearchQuery, options: vscode.TextSearchOptions, progress: vscode.Progress<vscode.TextSearchResultOld>, token: vscode.CancellationToken): Promise<vscode.TextSearchComplete> {
 					assert.deepStrictEqual(options.includes.sort(), ['*.jsx', '*.ts']);
 					assert.deepStrictEqual(options.excludes.sort(), []);
 
@@ -979,7 +979,7 @@ suite('ExtHostSearch', () => {
 
 		test('provider fail', async () => {
 			await registerTestTextSearchProvider({
-				provideTextSearchResults(query: vscode.TextSearchQuery, options: vscode.TextSearchOptions, progress: vscode.Progress<vscode.TextSearchResult>, token: vscode.CancellationToken): Promise<vscode.TextSearchComplete> {
+				provideTextSearchResults(query: vscode.TextSearchQuery, options: vscode.TextSearchOptions, progress: vscode.Progress<vscode.TextSearchResultOld>, token: vscode.CancellationToken): Promise<vscode.TextSearchComplete> {
 					throw new Error('Provider fail');
 				}
 			});
@@ -1006,13 +1006,13 @@ suite('ExtHostSearch', () => {
 				}
 			};
 
-			const providedResults: vscode.TextSearchResult[] = [
+			const providedResults: vscode.TextSearchResultOld[] = [
 				makeTextResult(rootFolderA, 'file1.js'),
 				makeTextResult(rootFolderA, 'file1.ts')
 			];
 
 			await registerTestTextSearchProvider({
-				provideTextSearchResults(query: vscode.TextSearchQuery, options: vscode.TextSearchOptions, progress: vscode.Progress<vscode.TextSearchResult>, token: vscode.CancellationToken): Promise<vscode.TextSearchComplete> {
+				provideTextSearchResults(query: vscode.TextSearchQuery, options: vscode.TextSearchOptions, progress: vscode.Progress<vscode.TextSearchResultOld>, token: vscode.CancellationToken): Promise<vscode.TextSearchComplete> {
 					providedResults.forEach(r => progress.report(r));
 					return Promise.resolve(null!);
 				}
@@ -1059,7 +1059,7 @@ suite('ExtHostSearch', () => {
 			};
 
 			await registerTestTextSearchProvider({
-				provideTextSearchResults(query: vscode.TextSearchQuery, options: vscode.TextSearchOptions, progress: vscode.Progress<vscode.TextSearchResult>, token: vscode.CancellationToken): Promise<vscode.TextSearchComplete> {
+				provideTextSearchResults(query: vscode.TextSearchQuery, options: vscode.TextSearchOptions, progress: vscode.Progress<vscode.TextSearchResultOld>, token: vscode.CancellationToken): Promise<vscode.TextSearchComplete> {
 					let reportedResults;
 					if (options.folder.fsPath === rootFolderA.fsPath) {
 						reportedResults = [
@@ -1122,13 +1122,13 @@ suite('ExtHostSearch', () => {
 		});
 
 		test('include pattern applied', async () => {
-			const providedResults: vscode.TextSearchResult[] = [
+			const providedResults: vscode.TextSearchResultOld[] = [
 				makeTextResult(rootFolderA, 'file1.js'),
 				makeTextResult(rootFolderA, 'file1.ts')
 			];
 
 			await registerTestTextSearchProvider({
-				provideTextSearchResults(query: vscode.TextSearchQuery, options: vscode.TextSearchOptions, progress: vscode.Progress<vscode.TextSearchResult>, token: vscode.CancellationToken): Promise<vscode.TextSearchComplete> {
+				provideTextSearchResults(query: vscode.TextSearchQuery, options: vscode.TextSearchOptions, progress: vscode.Progress<vscode.TextSearchResultOld>, token: vscode.CancellationToken): Promise<vscode.TextSearchComplete> {
 					providedResults.forEach(r => progress.report(r));
 					return Promise.resolve(null!);
 				}
@@ -1152,14 +1152,14 @@ suite('ExtHostSearch', () => {
 		});
 
 		test('max results = 1', async () => {
-			const providedResults: vscode.TextSearchResult[] = [
+			const providedResults: vscode.TextSearchResultOld[] = [
 				makeTextResult(rootFolderA, 'file1.ts'),
 				makeTextResult(rootFolderA, 'file2.ts')
 			];
 
 			let wasCanceled = false;
 			await registerTestTextSearchProvider({
-				provideTextSearchResults(query: vscode.TextSearchQuery, options: vscode.TextSearchOptions, progress: vscode.Progress<vscode.TextSearchResult>, token: vscode.CancellationToken): Promise<vscode.TextSearchComplete> {
+				provideTextSearchResults(query: vscode.TextSearchQuery, options: vscode.TextSearchOptions, progress: vscode.Progress<vscode.TextSearchResultOld>, token: vscode.CancellationToken): Promise<vscode.TextSearchComplete> {
 					disposables.add(token.onCancellationRequested(() => wasCanceled = true));
 					providedResults.forEach(r => progress.report(r));
 					return Promise.resolve(null!);
@@ -1184,7 +1184,7 @@ suite('ExtHostSearch', () => {
 		});
 
 		test('max results = 2', async () => {
-			const providedResults: vscode.TextSearchResult[] = [
+			const providedResults: vscode.TextSearchResultOld[] = [
 				makeTextResult(rootFolderA, 'file1.ts'),
 				makeTextResult(rootFolderA, 'file2.ts'),
 				makeTextResult(rootFolderA, 'file3.ts')
@@ -1192,7 +1192,7 @@ suite('ExtHostSearch', () => {
 
 			let wasCanceled = false;
 			await registerTestTextSearchProvider({
-				provideTextSearchResults(query: vscode.TextSearchQuery, options: vscode.TextSearchOptions, progress: vscode.Progress<vscode.TextSearchResult>, token: vscode.CancellationToken): Promise<vscode.TextSearchComplete> {
+				provideTextSearchResults(query: vscode.TextSearchQuery, options: vscode.TextSearchOptions, progress: vscode.Progress<vscode.TextSearchResultOld>, token: vscode.CancellationToken): Promise<vscode.TextSearchComplete> {
 					disposables.add(token.onCancellationRequested(() => wasCanceled = true));
 					providedResults.forEach(r => progress.report(r));
 					return Promise.resolve(null!);
@@ -1217,14 +1217,14 @@ suite('ExtHostSearch', () => {
 		});
 
 		test('provider returns maxResults exactly', async () => {
-			const providedResults: vscode.TextSearchResult[] = [
+			const providedResults: vscode.TextSearchResultOld[] = [
 				makeTextResult(rootFolderA, 'file1.ts'),
 				makeTextResult(rootFolderA, 'file2.ts')
 			];
 
 			let wasCanceled = false;
 			await registerTestTextSearchProvider({
-				provideTextSearchResults(query: vscode.TextSearchQuery, options: vscode.TextSearchOptions, progress: vscode.Progress<vscode.TextSearchResult>, token: vscode.CancellationToken): Promise<vscode.TextSearchComplete> {
+				provideTextSearchResults(query: vscode.TextSearchQuery, options: vscode.TextSearchOptions, progress: vscode.Progress<vscode.TextSearchResultOld>, token: vscode.CancellationToken): Promise<vscode.TextSearchComplete> {
 					disposables.add(token.onCancellationRequested(() => wasCanceled = true));
 					providedResults.forEach(r => progress.report(r));
 					return Promise.resolve(null!);
@@ -1249,14 +1249,14 @@ suite('ExtHostSearch', () => {
 		});
 
 		test('provider returns early with limitHit', async () => {
-			const providedResults: vscode.TextSearchResult[] = [
+			const providedResults: vscode.TextSearchResultOld[] = [
 				makeTextResult(rootFolderA, 'file1.ts'),
 				makeTextResult(rootFolderA, 'file2.ts'),
 				makeTextResult(rootFolderA, 'file3.ts')
 			];
 
 			await registerTestTextSearchProvider({
-				provideTextSearchResults(query: vscode.TextSearchQuery, options: vscode.TextSearchOptions, progress: vscode.Progress<vscode.TextSearchResult>, token: vscode.CancellationToken): Promise<vscode.TextSearchComplete> {
+				provideTextSearchResults(query: vscode.TextSearchQuery, options: vscode.TextSearchOptions, progress: vscode.Progress<vscode.TextSearchResultOld>, token: vscode.CancellationToken): Promise<vscode.TextSearchComplete> {
 					providedResults.forEach(r => progress.report(r));
 					return Promise.resolve({ limitHit: true });
 				}
@@ -1281,7 +1281,7 @@ suite('ExtHostSearch', () => {
 		test('multiroot max results', async () => {
 			let cancels = 0;
 			await registerTestTextSearchProvider({
-				async provideTextSearchResults(query: vscode.TextSearchQuery, options: vscode.TextSearchOptions, progress: vscode.Progress<vscode.TextSearchResult>, token: vscode.CancellationToken): Promise<vscode.TextSearchComplete> {
+				async provideTextSearchResults(query: vscode.TextSearchQuery, options: vscode.TextSearchOptions, progress: vscode.Progress<vscode.TextSearchResultOld>, token: vscode.CancellationToken): Promise<vscode.TextSearchComplete> {
 					disposables.add(token.onCancellationRequested(() => cancels++));
 					await new Promise(r => process.nextTick(r));
 					[
@@ -1311,14 +1311,14 @@ suite('ExtHostSearch', () => {
 		});
 
 		test('works with non-file schemes', async () => {
-			const providedResults: vscode.TextSearchResult[] = [
+			const providedResults: vscode.TextSearchResultOld[] = [
 				makeTextResult(fancySchemeFolderA, 'file1.ts'),
 				makeTextResult(fancySchemeFolderA, 'file2.ts'),
 				makeTextResult(fancySchemeFolderA, 'file3.ts')
 			];
 
 			await registerTestTextSearchProvider({
-				provideTextSearchResults(query: vscode.TextSearchQuery, options: vscode.TextSearchOptions, progress: vscode.Progress<vscode.TextSearchResult>, token: vscode.CancellationToken): Promise<vscode.TextSearchComplete> {
+				provideTextSearchResults(query: vscode.TextSearchQuery, options: vscode.TextSearchOptions, progress: vscode.Progress<vscode.TextSearchResultOld>, token: vscode.CancellationToken): Promise<vscode.TextSearchComplete> {
 					providedResults.forEach(r => progress.report(r));
 					return Promise.resolve(null!);
 				}

--- a/src/vscode-dts/vscode.proposed.aiTextSearchProvider.d.ts
+++ b/src/vscode-dts/vscode.proposed.aiTextSearchProvider.d.ts
@@ -8,7 +8,7 @@ declare module 'vscode' {
 	/**
 	 * Options that apply to AI text search.
 	 */
-	export interface AITextSearchOptions extends SearchOptions {
+	export interface AITextSearchOptionsOld extends SearchOptions {
 		/**
 		 * The maximum number of results to be returned.
 		 */
@@ -39,7 +39,7 @@ declare module 'vscode' {
 	/**
 	 * An AITextSearchProvider provides additional AI text search results in the workspace.
 	 */
-	export interface AITextSearchProvider {
+	export interface AITextSearchProviderOld {
 		/**
 		 * The name of the AI searcher. Will be displayed as `{name} Results` in the Search View.
 		 */
@@ -52,7 +52,7 @@ declare module 'vscode' {
 		 * @param progress A progress callback that must be invoked for all results.
 		 * @param token A cancellation token.
 		 */
-		provideAITextSearchResults(query: string, options: AITextSearchOptions, progress: Progress<TextSearchResult>, token: CancellationToken): ProviderResult<TextSearchComplete>;
+		provideAITextSearchResults(query: string, options: AITextSearchOptionsOld, progress: Progress<TextSearchResultOld>, token: CancellationToken): ProviderResult<TextSearchComplete>;
 
 	}
 
@@ -66,6 +66,6 @@ declare module 'vscode' {
 		 * @param provider The provider.
 		 * @return A {@link Disposable} that unregisters this provider when being disposed.
 		 */
-		export function registerAITextSearchProvider(scheme: string, provider: AITextSearchProvider): Disposable;
+		export function registerAITextSearchProvider(scheme: string, provider: AITextSearchProviderOld): Disposable;
 	}
 }

--- a/src/vscode-dts/vscode.proposed.aiTextSearchProviderNew.d.ts
+++ b/src/vscode-dts/vscode.proposed.aiTextSearchProviderNew.d.ts
@@ -7,7 +7,7 @@ declare module 'vscode' {
 	/**
 	 * An AITextSearchProvider provides additional AI text search results in the workspace.
 	 */
-	export interface AITextSearchProviderNew {
+	export interface AITextSearchProvider {
 		/**
 		 * The name of the AI searcher. Will be displayed as `{name} Results` in the Search View.
 		 */
@@ -22,7 +22,7 @@ declare module 'vscode' {
 		 * @param progress A progress callback that must be invoked for all results.
 		 * @param token A cancellation token.
 		 */
-		provideAITextSearchResults(query: string, options: TextSearchProviderOptions, progress: Progress<TextSearchResultNew>, token: CancellationToken): ProviderResult<TextSearchCompleteNew>;
+		provideAITextSearchResults(query: string, options: TextSearchProviderOptions, progress: Progress<TextSearchResult>, token: CancellationToken): ProviderResult<TextSearchComplete>;
 	}
 
 	export namespace workspace {
@@ -35,6 +35,6 @@ declare module 'vscode' {
 		 * @param provider The provider.
 		 * @return A {@link Disposable} that unregisters this provider when being disposed.
 		 */
-		export function registerAITextSearchProviderNew(scheme: string, provider: AITextSearchProviderNew): Disposable;
+		export function registerAITextSearchProvider(scheme: string, provider: AITextSearchProvider): Disposable;
 	}
 }

--- a/src/vscode-dts/vscode.proposed.fileSearchProvider.d.ts
+++ b/src/vscode-dts/vscode.proposed.fileSearchProvider.d.ts
@@ -48,7 +48,7 @@ declare module 'vscode' {
 	 * The FileSearchProvider will be invoked on every keypress in quickopen. When `workspace.findFiles` is called, it will be invoked with an empty query string,
 	 * and in that case, every file in the folder should be returned.
 	 */
-	export interface FileSearchProvider {
+	export interface FileSearchProviderOld {
 		/**
 		 * Provide the set of files that match a certain file path pattern.
 		 * @param query The parameters for this query.
@@ -68,6 +68,6 @@ declare module 'vscode' {
 		 * @param provider The provider.
 		 * @return A {@link Disposable} that unregisters this provider when being disposed.
 		 */
-		export function registerFileSearchProvider(scheme: string, provider: FileSearchProvider): Disposable;
+		export function registerFileSearchProvider(scheme: string, provider: FileSearchProviderOld): Disposable;
 	}
 }

--- a/src/vscode-dts/vscode.proposed.fileSearchProviderNew.d.ts
+++ b/src/vscode-dts/vscode.proposed.fileSearchProviderNew.d.ts
@@ -73,7 +73,7 @@ declare module 'vscode' {
 	 *
 	 * The FileSearchProvider will be invoked on every keypress in quickopen.
 	 */
-	export interface FileSearchProviderNew {
+	export interface FileSearchProvider {
 		/**
 		 * WARNING: VERY EXPERIMENTAL.
 		 *
@@ -96,6 +96,6 @@ declare module 'vscode' {
 		 * @param provider The provider.
 		 * @return A {@link Disposable} that unregisters this provider when being disposed.
 		 */
-		export function registerFileSearchProviderNew(scheme: string, provider: FileSearchProviderNew): Disposable;
+		export function registerFileSearchProvider(scheme: string, provider: FileSearchProvider): Disposable;
 	}
 }

--- a/src/vscode-dts/vscode.proposed.findFiles2.d.ts
+++ b/src/vscode-dts/vscode.proposed.findFiles2.d.ts
@@ -5,7 +5,7 @@
 
 declare module 'vscode' {
 
-	export interface FindFiles2Options {
+	export interface FindFiles2OptionsOld {
 		// note: this is just FindTextInFilesOptions without select properties (include, previewOptions, beforeContext, afterContext)
 
 		/**
@@ -79,11 +79,11 @@ declare module 'vscode' {
 		 * @param filePattern A {@link GlobPattern glob pattern} that defines the files to search for. The glob pattern
 		 * will be matched against the file paths of resulting matches relative to their workspace. Use a {@link RelativePattern relative pattern}
 		 * to restrict the search results to a {@link WorkspaceFolder workspace folder}.
-		 * @param options A set of {@link FindFiles2Options FindFiles2Options} that defines where and how to search (e.g. exclude settings).
+		 * @param options A set of {@link FindFiles2OptionsOld FindFiles2Options} that defines where and how to search (e.g. exclude settings).
 		 * @param token A token that can be used to signal cancellation to the underlying search engine.
 		 * @returns A thenable that resolves to an array of resource identifiers. Will return no results if no
 		 * {@link workspace.workspaceFolders workspace folders} are opened.
 		 */
-		export function findFiles2(filePattern: GlobPattern, options?: FindFiles2Options, token?: CancellationToken): Thenable<Uri[]>;
+		export function findFiles2(filePattern: GlobPattern, options?: FindFiles2OptionsOld, token?: CancellationToken): Thenable<Uri[]>;
 	}
 }

--- a/src/vscode-dts/vscode.proposed.findFiles2New.d.ts
+++ b/src/vscode-dts/vscode.proposed.findFiles2New.d.ts
@@ -5,7 +5,7 @@
 
 declare module 'vscode' {
 
-	export interface FindFiles2OptionsNew {
+	export interface FindFiles2Options {
 		/**
 		 * An array of {@link GlobPattern GlobPattern} that defines files to exclude.
 		 * The glob patterns will be matched against the file paths of files relative to their workspace or {@link RelativePattern.baseUri} if applicable.
@@ -52,12 +52,12 @@ declare module 'vscode' {
 			 */
 			local?: boolean;
 			/**
-			 * Use ignore files at the parent directory. When set to `true`, {@link FindFiles2OptionsNew.useIgnoreFiles.local} must also be `true`.
+			 * Use ignore files at the parent directory. When set to `true`, {@link FindFiles2Options.useIgnoreFiles.local} must also be `true`.
 			 * May default to `search.useParentIgnoreFiles` setting if not set.
 			 */
 			parent?: boolean;
 			/**
-			 * Use global ignore files. When set to `true`, {@link FindFiles2OptionsNew.useIgnoreFiles.local} must also be `true`.
+			 * Use global ignore files. When set to `true`, {@link FindFiles2Options.useIgnoreFiles.local} must also be `true`.
 			 * May default to `search.useGlobalIgnoreFiles` setting if not set.
 			 */
 			global?: boolean;
@@ -100,6 +100,6 @@ declare module 'vscode' {
 		 * @returns A thenable that resolves to an array of resource identifiers. Will return no results if no
 		 * {@link workspace.workspaceFolders workspace folders} are opened.
 		 */
-		export function findFiles2New(filePattern: GlobPattern[], options?: FindFiles2OptionsNew, token?: CancellationToken): Thenable<Uri[]>;
+		export function findFiles2(filePattern: GlobPattern[], options?: FindFiles2Options, token?: CancellationToken): Thenable<Uri[]>;
 	}
 }

--- a/src/vscode-dts/vscode.proposed.findTextInFiles.d.ts
+++ b/src/vscode-dts/vscode.proposed.findTextInFiles.d.ts
@@ -10,7 +10,7 @@ declare module 'vscode' {
 	/**
 	 * Options that can be set on a findTextInFiles search.
 	 */
-	export interface FindTextInFilesOptions {
+	export interface FindTextInFilesOptionsOld {
 		/**
 		 * A {@link GlobPattern glob pattern} that defines the files to search for. The glob pattern
 		 * will be matched against the file paths of files relative to their workspace. Use a {@link RelativePattern relative pattern}
@@ -89,7 +89,7 @@ declare module 'vscode' {
 		 * @param token A token that can be used to signal cancellation to the underlying search engine.
 		 * @return A thenable that resolves when the search is complete.
 		 */
-		export function findTextInFiles(query: TextSearchQuery, callback: (result: TextSearchResult) => void, token?: CancellationToken): Thenable<TextSearchComplete>;
+		export function findTextInFiles(query: TextSearchQueryOld, callback: (result: TextSearchResultOld) => void, token?: CancellationToken): Thenable<TextSearchCompleteOld>;
 
 		/**
 		 * Search text in files across all {@link workspace.workspaceFolders workspace folders} in the workspace.
@@ -99,6 +99,6 @@ declare module 'vscode' {
 		 * @param token A token that can be used to signal cancellation to the underlying search engine.
 		 * @return A thenable that resolves when the search is complete.
 		 */
-		export function findTextInFiles(query: TextSearchQuery, options: FindTextInFilesOptions, callback: (result: TextSearchResult) => void, token?: CancellationToken): Thenable<TextSearchComplete>;
+		export function findTextInFiles(query: TextSearchQueryOld, options: FindTextInFilesOptionsOld, callback: (result: TextSearchResultOld) => void, token?: CancellationToken): Thenable<TextSearchCompleteOld>;
 	}
 }

--- a/src/vscode-dts/vscode.proposed.findTextInFilesNew.d.ts
+++ b/src/vscode-dts/vscode.proposed.findTextInFilesNew.d.ts
@@ -7,7 +7,7 @@ declare module 'vscode' {
 
 	// https://github.com/microsoft/vscode/issues/59924
 
-	export interface FindTextInFilesOptionsNew {
+	export interface FindTextInFilesOptions {
 		/**
 		 * An array of {@link GlobPattern GlobPattern} that defines the files to search for.
 		 * The glob patterns will be matched against the file paths of files relative to their workspace or {@link baseUri GlobPattern.baseUri} if applicable.
@@ -73,12 +73,12 @@ declare module 'vscode' {
 			 */
 			local?: boolean;
 			/**
-			 * Use ignore files at the parent directory. When set to `true`, {@link FindTextInFilesOptionsNew.useIgnoreFiles.local} must be `true`.
+			 * Use ignore files at the parent directory. When set to `true`, {@link FindTextInFilesOptions.useIgnoreFiles.local} must be `true`.
 			 * May default to `search.useParentIgnoreFiles` setting if not set.
 			 */
 			parent?: boolean;
 			/**
-			 * Use global ignore files. When set to `true`, {@link FindTextInFilesOptionsNew.useIgnoreFiles.local} must also be `true`.
+			 * Use global ignore files. When set to `true`, {@link FindTextInFilesOptions.useIgnoreFiles.local} must also be `true`.
 			 * May default to `search.useGlobalIgnoreFiles` setting if not set.
 			 */
 			global?: boolean;
@@ -123,11 +123,11 @@ declare module 'vscode' {
 		/**
 		 * The results of the text search, in batches. To get completion information, wait on the `complete` property.
 		 */
-		results: AsyncIterable<TextSearchResultNew>;
+		results: AsyncIterable<TextSearchResult>;
 		/**
 		 * The text search completion information. This resolves on completion.
 		 */
-		complete: Thenable<TextSearchCompleteNew>;
+		complete: Thenable<TextSearchComplete>;
 	}
 
 	/**
@@ -159,6 +159,6 @@ declare module 'vscode' {
 		 * @param token A token that can be used to signal cancellation to the underlying search engine.
 		 * @return A thenable that resolves when the search is complete.
 		 */
-		export function findTextInFilesNew(query: TextSearchQueryNew, options?: FindTextInFilesOptionsNew, token?: CancellationToken): FindTextInFilesResponse;
+		export function findTextInFilesNew(query: TextSearchQuery, options?: FindTextInFilesOptions, token?: CancellationToken): FindTextInFilesResponse;
 	}
 }

--- a/src/vscode-dts/vscode.proposed.findTextInFilesNew.d.ts
+++ b/src/vscode-dts/vscode.proposed.findTextInFilesNew.d.ts
@@ -159,6 +159,6 @@ declare module 'vscode' {
 		 * @param token A token that can be used to signal cancellation to the underlying search engine.
 		 * @return A thenable that resolves when the search is complete.
 		 */
-		export function findTextInFilesNew(query: TextSearchQuery, options?: FindTextInFilesOptions, token?: CancellationToken): FindTextInFilesResponse;
+		export function findTextInFiles2(query: TextSearchQuery, options?: FindTextInFilesOptions, token?: CancellationToken): FindTextInFilesResponse;
 	}
 }

--- a/src/vscode-dts/vscode.proposed.textSearchCompleteNew.d.ts
+++ b/src/vscode-dts/vscode.proposed.textSearchCompleteNew.d.ts
@@ -14,13 +14,13 @@ declare module 'vscode' {
 		 *
 		 * Commands may optionally return { triggerSearch: true } to signal to the editor that the original search should run be again.
 		 */
-		message?: TextSearchCompleteMessageNew[];
+		message?: TextSearchCompleteMessage[];
 	}
 
 	/**
 	 * A message regarding a completed search.
 	 */
-	export interface TextSearchCompleteMessageNew {
+	export interface TextSearchCompleteMessage {
 		/**
 		 * Markdown text of the message.
 		 */

--- a/src/vscode-dts/vscode.proposed.textSearchCompleteNew.d.ts
+++ b/src/vscode-dts/vscode.proposed.textSearchCompleteNew.d.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 declare module 'vscode' {
-	export interface TextSearchCompleteNew {
+	export interface TextSearchComplete {
 		/**
 		 * Additional information regarding the state of the completed search.
 		 *

--- a/src/vscode-dts/vscode.proposed.textSearchProvider.d.ts
+++ b/src/vscode-dts/vscode.proposed.textSearchProvider.d.ts
@@ -10,7 +10,7 @@ declare module 'vscode' {
 	/**
 	 * The parameters of a query for text search.
 	 */
-	export interface TextSearchQuery {
+	export interface TextSearchQueryOld {
 		/**
 		 * The text pattern to search for.
 		 */
@@ -171,7 +171,7 @@ declare module 'vscode' {
 	/**
 	 * Information collected when text search is complete.
 	 */
-	export interface TextSearchComplete {
+	export interface TextSearchCompleteOld {
 		/**
 		 * Whether the search hit the limit on the maximum number of search results.
 		 * `maxResults` on {@linkcode TextSearchOptions} specifies the max number of results.
@@ -212,7 +212,7 @@ declare module 'vscode' {
 	/**
 	 * A match from a text search
 	 */
-	export interface TextSearchMatch {
+	export interface TextSearchMatchOld {
 		/**
 		 * The uri for the matching document.
 		 */
@@ -232,7 +232,7 @@ declare module 'vscode' {
 	/**
 	 * A line of context surrounding a TextSearchMatch.
 	 */
-	export interface TextSearchContext {
+	export interface TextSearchContextOld {
 		/**
 		 * The uri for the matching document.
 		 */
@@ -250,12 +250,12 @@ declare module 'vscode' {
 		lineNumber: number;
 	}
 
-	export type TextSearchResult = TextSearchMatch | TextSearchContext;
+	export type TextSearchResultOld = TextSearchMatchOld | TextSearchContextOld;
 
 	/**
 	 * A TextSearchProvider provides search results for text results inside files in the workspace.
 	 */
-	export interface TextSearchProvider {
+	export interface TextSearchProviderOld {
 		/**
 		 * Provide results that match the given text pattern.
 		 * @param query The parameters for this query.
@@ -263,7 +263,7 @@ declare module 'vscode' {
 		 * @param progress A progress callback that must be invoked for all results.
 		 * @param token A cancellation token.
 		 */
-		provideTextSearchResults(query: TextSearchQuery, options: TextSearchOptions, progress: Progress<TextSearchResult>, token: CancellationToken): ProviderResult<TextSearchComplete>;
+		provideTextSearchResults(query: TextSearchQueryOld, options: TextSearchOptions, progress: Progress<TextSearchResultOld>, token: CancellationToken): ProviderResult<TextSearchComplete>;
 	}
 
 	export namespace workspace {
@@ -276,6 +276,6 @@ declare module 'vscode' {
 		 * @param provider The provider.
 		 * @return A {@link Disposable} that unregisters this provider when being disposed.
 		 */
-		export function registerTextSearchProvider(scheme: string, provider: TextSearchProvider): Disposable;
+		export function registerTextSearchProvider(scheme: string, provider: TextSearchProviderOld): Disposable;
 	}
 }

--- a/src/vscode-dts/vscode.proposed.textSearchProviderNew.d.ts
+++ b/src/vscode-dts/vscode.proposed.textSearchProviderNew.d.ts
@@ -10,7 +10,7 @@ declare module 'vscode' {
 	/**
 	 * The parameters of a query for text search. All optional booleans default to `false`.
 	 */
-	export interface TextSearchQueryNew {
+	export interface TextSearchQuery {
 		/**
 		 * The text pattern to search for.
 		 *
@@ -142,7 +142,7 @@ declare module 'vscode' {
 	/**
 	 * Information collected when text search is complete.
 	 */
-	export interface TextSearchCompleteNew {
+	export interface TextSearchComplete {
 		/**
 		 * Whether the search hit the limit on the maximum number of search results.
 		 * `maxResults` on {@linkcode TextSearchProviderOptions} specifies the max number of results.
@@ -164,9 +164,9 @@ declare module 'vscode' {
 	 * const foo = bar;
 	 * ```
 	 *
-	 * If the query is `log`, then the line `console.log(bar);` should be represented using a {@link TextSearchMatchNew}.
+	 * If the query is `log`, then the line `console.log(bar);` should be represented using a {@link TextSearchMatch}.
 	 */
-	export class TextSearchMatchNew {
+	export class TextSearchMatch {
 		/**
 		 * @param uri The uri for the matching document.
 		 * @param ranges The ranges associated with this match.
@@ -198,7 +198,7 @@ declare module 'vscode' {
 
 	/**
 	 * The context lines of text that are not a part of a match,
-	 * but that surround a match line of type {@link TextSearchMatchNew}.
+	 * but that surround a match line of type {@link TextSearchMatch}.
 	 *
 	 * For example, consider this excerpt:
 	 *
@@ -209,10 +209,10 @@ declare module 'vscode' {
 	 * ```
 	 *
 	 * If the query is `log`, then the lines `const bar = 1;` and `const foo = bar;`
-	 * should be represented using two separate {@link TextSearchContextNew} for the search instance.
+	 * should be represented using two separate {@link TextSearchContext} for the search instance.
 	 * This example assumes that the finder requests one line of surrounding context.
 	 */
-	export class TextSearchContextNew {
+	export class TextSearchContext {
 		/**
 		 * @param uri The uri for the matching document.
 		 * @param text The line of context text.
@@ -238,26 +238,26 @@ declare module 'vscode' {
 	}
 
 	/**
-	 * A result payload for a text search, pertaining to {@link TextSearchMatchNew matches}
-	 * and its associated {@link TextSearchContextNew context} within a single file.
+	 * A result payload for a text search, pertaining to {@link TextSearchMatch matches}
+	 * and its associated {@link TextSearchContext context} within a single file.
 	 */
-	export type TextSearchResultNew = TextSearchMatchNew | TextSearchContextNew;
+	export type TextSearchResult = TextSearchMatch | TextSearchContext;
 
 	/**
 	 * A TextSearchProvider provides search results for text results inside files in the workspace.
 	 */
-	export interface TextSearchProviderNew {
+	export interface TextSearchProvider {
 		/**
 		 * WARNING: VERY EXPERIMENTAL.
 		 *
 		 * Provide results that match the given text pattern.
 		 * @param query The parameters for this query.
 		 * @param options A set of options to consider while searching.
-		 * @param progress A progress callback that must be invoked for all {@link TextSearchResultNew results}.
+		 * @param progress A progress callback that must be invoked for all {@link TextSearchResult results}.
 		 * These results can be direct matches, or context that surrounds matches.
 		 * @param token A cancellation token.
 		 */
-		provideTextSearchResults(query: TextSearchQueryNew, options: TextSearchProviderOptions, progress: Progress<TextSearchResultNew>, token: CancellationToken): ProviderResult<TextSearchCompleteNew>;
+		provideTextSearchResults(query: TextSearchQuery, options: TextSearchProviderOptions, progress: Progress<TextSearchResult>, token: CancellationToken): ProviderResult<TextSearchComplete>;
 	}
 
 	export namespace workspace {
@@ -270,6 +270,6 @@ declare module 'vscode' {
 		 * @param provider The provider.
 		 * @return A {@link Disposable} that unregisters this provider when being disposed.
 		 */
-		export function registerTextSearchProviderNew(scheme: string, provider: TextSearchProviderNew): Disposable;
+		export function registerTextSearchProvider(scheme: string, provider: TextSearchProvider): Disposable;
 	}
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

ie:

`TextSearchProviderNew` -> `TextSearchProvider`
`TextSearchProvider` -> `TextSearchProviderOld`

exceptions:
`workspace.findTextInFilesNew` remains the same, as it has a different return type than the old version. Therefore, I don't think I can overload it (?)

Filenames remain with `New` because I want to keep the same proposal names.
