### PR TITLE
Resetting the EditContext on the dom node on rendering - workaround fix for EditContext not working in aux window

### DIFF
--- a/src/vs/editor/browser/controller/editContext/native/nativeEditContext.ts
+++ b/src/vs/editor/browser/controller/editContext/native/nativeEditContext.ts
@@ -76,7 +76,7 @@ export class NativeEditContext extends AbstractEditContext {
 		}));
 
 		this._editContext = new EditContext();
-		this.apply();
+		this.setEditContextOnDomNode();
 
 		this._screenReaderSupport = instantiationService.createInstance(ScreenReaderSupport, this.domNode, context);
 
@@ -176,7 +176,9 @@ export class NativeEditContext extends AbstractEditContext {
 
 	public refreshFocusState(): void { }
 
-	public apply(): void {
+	// TODO: added as a workaround fix for https://github.com/microsoft/vscode/issues/229825
+	// When this issue will be fixed the following should be removed.
+	public setEditContextOnDomNode(): void {
 		this.domNode.domNode.editContext = this._editContext;
 	}
 

--- a/src/vs/editor/browser/controller/editContext/native/nativeEditContext.ts
+++ b/src/vs/editor/browser/controller/editContext/native/nativeEditContext.ts
@@ -76,7 +76,7 @@ export class NativeEditContext extends AbstractEditContext {
 		}));
 
 		this._editContext = new EditContext();
-		this.domNode.domNode.editContext = this._editContext;
+		this.apply();
 
 		this._screenReaderSupport = instantiationService.createInstance(ScreenReaderSupport, this.domNode, context);
 
@@ -175,6 +175,10 @@ export class NativeEditContext extends AbstractEditContext {
 	public focus(): void { this._focusTracker.focus(); }
 
 	public refreshFocusState(): void { }
+
+	public apply(): void {
+		this.domNode.domNode.editContext = this._editContext;
+	}
 
 	// --- Private methods ---
 

--- a/src/vs/editor/browser/view.ts
+++ b/src/vs/editor/browser/view.ts
@@ -7,7 +7,7 @@ import * as dom from '../../base/browser/dom.js';
 import { FastDomNode, createFastDomNode } from '../../base/browser/fastDomNode.js';
 import { IMouseWheelEvent } from '../../base/browser/mouseEvent.js';
 import { inputLatency } from '../../base/browser/performance.js';
-import { CodeWindow, mainWindow } from '../../base/browser/window.js';
+import { CodeWindow } from '../../base/browser/window.js';
 import { BugIndicatingError, onUnexpectedError } from '../../base/common/errors.js';
 import { IDisposable } from '../../base/common/lifecycle.js';
 import { IPointerHandlerHelper } from './controller/mouseHandler.js';
@@ -110,6 +110,8 @@ export class View extends ViewEventHandler {
 	// Actual mutable state
 	private _shouldRecomputeGlyphMarginLanes: boolean = false;
 	private _renderAnimationFrame: IDisposable | null;
+
+	private _targetWindow: CodeWindow | undefined;
 
 	constructor(
 		commandDelegate: ICommandDelegate,
@@ -457,8 +459,9 @@ export class View extends ViewEventHandler {
 		}
 		if (this._renderAnimationFrame === null) {
 			const targetWindow = dom.getWindow(this.domNode?.domNode);
-			if (targetWindow !== mainWindow && this._editContext instanceof NativeEditContext) {
-				this._editContext.apply();
+			if (targetWindow !== this._targetWindow && this._editContext instanceof NativeEditContext) {
+				this._editContext.setEditContextOnDomNode();
+				this._targetWindow = targetWindow;
 			}
 			const rendering = this._createCoordinatedRendering();
 			this._renderAnimationFrame = EditorRenderingCoordinator.INSTANCE.scheduleCoordinatedRendering({

--- a/src/vs/editor/browser/view.ts
+++ b/src/vs/editor/browser/view.ts
@@ -7,7 +7,7 @@ import * as dom from '../../base/browser/dom.js';
 import { FastDomNode, createFastDomNode } from '../../base/browser/fastDomNode.js';
 import { IMouseWheelEvent } from '../../base/browser/mouseEvent.js';
 import { inputLatency } from '../../base/browser/performance.js';
-import { CodeWindow } from '../../base/browser/window.js';
+import { CodeWindow, mainWindow } from '../../base/browser/window.js';
 import { BugIndicatingError, onUnexpectedError } from '../../base/common/errors.js';
 import { IDisposable } from '../../base/common/lifecycle.js';
 import { IPointerHandlerHelper } from './controller/mouseHandler.js';
@@ -456,9 +456,13 @@ export class View extends ViewEventHandler {
 			throw new BugIndicatingError();
 		}
 		if (this._renderAnimationFrame === null) {
+			const targetWindow = dom.getWindow(this.domNode?.domNode);
+			if (targetWindow !== mainWindow && this._editContext instanceof NativeEditContext) {
+				this._editContext.apply();
+			}
 			const rendering = this._createCoordinatedRendering();
 			this._renderAnimationFrame = EditorRenderingCoordinator.INSTANCE.scheduleCoordinatedRendering({
-				window: dom.getWindow(this.domNode?.domNode),
+				window: targetWindow,
 				prepareRenderText: () => {
 					if (this._store.isDisposed) {
 						throw new BugIndicatingError();


### PR DESCRIPTION
Resetting the EditContext on the editable dom node on rendering

Workaround fix for EditContext not working in aux window

in relation to https://github.com/microsoft/vscode/issues/229825