### PR TITLE
Fixed UI issue with terminal icon picker

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalInstance.ts
@@ -2153,7 +2153,7 @@ export class TerminalInstance extends Disposable implements ITerminalInstance {
 			return icon;
 		}
 		const iconPicker = this._scopedInstantiationService.createInstance(TerminalIconPicker);
-		const pickedIcon = await iconPicker.pickIcons();
+		const pickedIcon = await iconPicker.pickIcons(this.instanceId); //add instanceId to specify UI for each terminal
 		iconPicker.dispose();
 		if (!pickedIcon) {
 			return undefined;

--- a/src/vs/workbench/contrib/terminal/browser/terminalTabsList.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalTabsList.ts
@@ -328,7 +328,7 @@ class TerminalTabsRenderer implements IListRenderer<ITerminalInstance, ITerminal
 
 		template.element.classList.toggle('has-text', hasText);
 		template.element.classList.toggle('is-active', this._terminalGroupService.activeInstance === instance);
-
+		template.element.setAttribute('id', `terminal-tab-instance-${instance.instanceId}`);	// ARIA
 		let prefix: string = '';
 		if (group.terminalInstances.length > 1) {
 			const terminalIndex = group.terminalInstances.indexOf(instance);


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/06894840-3eb4-48b8-86e2-f2412e0f8249)
![image](https://github.com/user-attachments/assets/894e84ca-d79d-4967-95af-0ee39c4498ad)
I did the issue by changing the position and adding parameters for the function. I just want to learn about OS contribution right now and I took my chance to try with this issue. It was made so that the icon bar appears either on top or the bottom of the terminal depends on where you put it. I also added comments about what each line of code does and explain what I am doing.