### PR TITLE
Add EditContext support when on chrome, edge or on desktop

### DIFF
--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -5764,7 +5764,8 @@ export const EditorOptions = {
 	experimentalEditContextEnabled: register(new EditorBooleanOption(
 		EditorOption.experimentalEditContextEnabled, 'experimentalEditContextEnabled', false,
 		{
-			description: nls.localize('experimentalEditContextEnabled', "Sets whether the new experimental edit context should be used instead of the text area.")
+			description: nls.localize('experimentalEditContextEnabled', "Sets whether the new experimental edit context should be used instead of the text area."),
+			included: platform.isChrome || platform.isEdge || platform.isNative
 		}
 	)),
 	stickyScroll: register(new EditorStickyScroll()),


### PR DESCRIPTION
Add EditContext support when on chrome, edge or on desktop

In relation to https://github.com/microsoft/vscode/issues/230315