### PR TITLE
integration tests: colorization test are run 6 times

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
         run: npm run test-node
 
       - name: Run Unit Tests (Browser, Chromium)
-        run: npm run test-browser-no-install --browser chromium
+        run: npm run test-browser-no-install -- --browser chromium
 
       - name: Run Integration Tests (Electron)
         run: .\scripts\test-integration.bat
@@ -162,7 +162,7 @@ jobs:
 
       - name: Run Unit Tests (Browser, Chromium)
         id: browser-unit-tests
-        run: DISPLAY=:10 npm run test-browser-no-install --browser chromium
+        run: DISPLAY=:10 npm run test-browser-no-install -- --browser chromium
 
       - name: Run Integration Tests (Electron)
         id: electron-integration-tests
@@ -238,7 +238,7 @@ jobs:
         run: npm run test-node
 
       - name: Run Unit Tests (Browser, Chromium)
-        run: DISPLAY=:10 npm run test-browser-no-install --browser chromium
+        run: DISPLAY=:10 npm run test-browser-no-install -- --browser chromium
 
       - name: Run Integration Tests (Electron)
         run: DISPLAY=:10 ./scripts/test-integration.sh

--- a/scripts/test-integration.bat
+++ b/scripts/test-integration.bat
@@ -49,7 +49,7 @@ if %errorlevel% neq 0 exit /b %errorlevel%
 
 echo.
 echo ### Colorize tests
-call npm run test-extension -l vscode-colorize-tests
+call npm run test-extension -- -l vscode-colorize-tests
 if %errorlevel% neq 0 exit /b %errorlevel%
 
 echo.
@@ -59,7 +59,7 @@ if %errorlevel% neq 0 exit /b %errorlevel%
 
 echo.
 echo ### Markdown tests
-call npm run test-extension -l markdown-language-features
+call npm run test-extension -- -l markdown-language-features
 if %errorlevel% neq 0 exit /b %errorlevel%
 
 echo.
@@ -77,24 +77,24 @@ if %errorlevel% neq 0 exit /b %errorlevel%
 
 echo.
 echo ### Ipynb tests
-call npm run test-extension -l ipynb
+call npm run test-extension -- -l ipynb
 if %errorlevel% neq 0 exit /b %errorlevel%
 
 echo.
 echo ### Notebook Output tests
-call npm run test-extension -l notebook-renderers
+call npm run test-extension -- -l notebook-renderers
 if %errorlevel% neq 0 exit /b %errorlevel%
 
 echo.
 echo ### Configuration editing tests
 set CFWORKSPACE=%TEMPDIR%\cf-%RANDOM%
 mkdir %CFWORKSPACE%
-call npm run test-extension -l configuration-editing
+call npm run test-extension -- -l configuration-editing
 if %errorlevel% neq 0 exit /b %errorlevel%
 
 echo.
 echo ### GitHub Authentication tests
-call npm run test-extension -l github-authentication
+call npm run test-extension -- -l github-authentication
 if %errorlevel% neq 0 exit /b %errorlevel%
 
 :: Tests standalone (CommonJS)

--- a/scripts/test-integration.sh
+++ b/scripts/test-integration.sh
@@ -67,7 +67,7 @@ kill_app
 echo
 echo "### Colorize tests"
 echo
-npm run test-extension -l vscode-colorize-tests
+npm run test-extension -- -l vscode-colorize-tests
 kill_app
 
 echo
@@ -79,7 +79,7 @@ kill_app
 echo
 echo "### Markdown tests"
 echo
-npm run test-extension -l markdown-language-features
+npm run test-extension -- -l markdown-language-features
 kill_app
 
 echo
@@ -97,25 +97,25 @@ kill_app
 echo
 echo "### Ipynb tests"
 echo
-npm run test-extension -l ipynb
+npm run test-extension -- -l ipynb
 kill_app
 
 echo
 echo "### Notebook Output tests"
 echo
-npm run test-extension -l notebook-renderers
+npm run test-extension -- -l notebook-renderers
 kill_app
 
 echo
 echo "### Configuration editing tests"
 echo
-npm run test-extension -l configuration-editing
+npm run test-extension -- -l configuration-editing
 kill_app
 
 echo
 echo "### GitHub Authentication tests"
 echo
-npm run test-extension -l github-authentication
+npm run test-extension -- -l github-authentication
 kill_app
 
 # Tests standalone (CommonJS)


### PR DESCRIPTION
`npm run` needs `--` before script arguments that start with `-`

e.g. `npm run test-extension -- -l vscode-colorize-tests`


