### PR TITLE
Improve consistency across terminal/ and terminalContrib/

### DIFF
--- a/src/vs/workbench/contrib/terminal/.eslintrc.json
+++ b/src/vs/workbench/contrib/terminal/.eslintrc.json
@@ -14,6 +14,7 @@
 			// typeLike
 			{ "selector": "typeLike", "format": ["PascalCase"] },
 			{ "selector": "interface", "format": ["PascalCase"] }
-		]
+		],
+		"comma-dangle": ["warn", "only-multiline"]
 	}
 }

--- a/src/vs/workbench/contrib/terminal/browser/terminal.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminal.ts
@@ -1041,7 +1041,7 @@ export interface ITerminalInstance extends IBaseTerminalInstance {
 }
 
 export const enum XtermTerminalConstants {
-	SearchHighlightLimit = 1000
+	SearchHighlightLimit = 20000
 }
 
 export interface IXtermAttachToElementOptions {

--- a/src/vs/workbench/contrib/terminalContrib/.eslintrc.json
+++ b/src/vs/workbench/contrib/terminalContrib/.eslintrc.json
@@ -1,0 +1,19 @@
+{
+	"rules": {
+		"@typescript-eslint/naming-convention": [
+			"warn",
+			// variableLike
+			{ "selector": "variable", "format": ["camelCase", "UPPER_CASE", "PascalCase"] },
+			{ "selector": "variable", "filter": "^I.+Service$", "format": ["PascalCase"], "prefix": ["I"] },
+			// memberLike
+			{ "selector": "memberLike", "modifiers": ["private"], "format": ["camelCase"], "leadingUnderscore": "require" },
+			{ "selector": "memberLike", "modifiers": ["protected"], "format": ["camelCase"], "leadingUnderscore": "require" },
+			{ "selector": "enumMember", "format": ["PascalCase"] },
+			// memberLike - Allow enum-like objects to use UPPER_CASE
+			{ "selector": "method", "modifiers": ["public"], "format": ["camelCase", "UPPER_CASE"] },
+			// typeLike
+			{ "selector": "typeLike", "format": ["PascalCase"] },
+			{ "selector": "interface", "format": ["PascalCase"] }
+		]
+	}
+}

--- a/src/vs/workbench/contrib/terminalContrib/.eslintrc.json
+++ b/src/vs/workbench/contrib/terminalContrib/.eslintrc.json
@@ -14,6 +14,7 @@
 			// typeLike
 			{ "selector": "typeLike", "format": ["PascalCase"] },
 			{ "selector": "interface", "format": ["PascalCase"] }
-		]
+		],
+		"comma-dangle": ["warn", "only-multiline"]
 	}
 }

--- a/src/vs/workbench/contrib/terminalContrib/accessibility/browser/terminalAccessibleBufferProvider.ts
+++ b/src/vs/workbench/contrib/terminalContrib/accessibility/browser/terminalAccessibleBufferProvider.ts
@@ -29,7 +29,7 @@ export class TerminalAccessibleBufferProvider extends Disposable implements IAcc
 		private _bufferTracker: BufferContentTracker,
 		customHelp: () => string,
 		@IConfigurationService configurationService: IConfigurationService,
-		@ITerminalService terminalService: ITerminalService
+		@ITerminalService terminalService: ITerminalService,
 	) {
 		super();
 		this.options.customHelp = customHelp;

--- a/src/vs/workbench/contrib/terminalContrib/autoReplies/browser/terminal.autoReplies.contribution.ts
+++ b/src/vs/workbench/contrib/terminalContrib/autoReplies/browser/terminal.autoReplies.contribution.ts
@@ -18,7 +18,7 @@ export class TerminalAutoRepliesContribution extends Disposable implements IWork
 
 	constructor(
 		@IConfigurationService private readonly _configurationService: IConfigurationService,
-		@ITerminalInstanceService terminalInstanceService: ITerminalInstanceService
+		@ITerminalInstanceService terminalInstanceService: ITerminalInstanceService,
 	) {
 		super();
 

--- a/src/vs/workbench/contrib/terminalContrib/chat/browser/terminal.initialHint.contribution.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chat/browser/terminal.initialHint.contribution.ts
@@ -88,12 +88,12 @@ export class TerminalInitialHintContribution extends Disposable implements ITerm
 
 	constructor(
 		private readonly _ctx: ITerminalContributionContext | IDetachedCompatibleTerminalContributionContext,
-		@IInstantiationService private readonly _instantiationService: IInstantiationService,
-		@IConfigurationService private readonly _configurationService: IConfigurationService,
-		@ITerminalGroupService private readonly _terminalGroupService: ITerminalGroupService,
-		@ITerminalEditorService private readonly _terminalEditorService: ITerminalEditorService,
 		@IChatAgentService private readonly _chatAgentService: IChatAgentService,
+		@IConfigurationService private readonly _configurationService: IConfigurationService,
+		@IInstantiationService private readonly _instantiationService: IInstantiationService,
 		@IStorageService private readonly _storageService: IStorageService,
+		@ITerminalEditorService private readonly _terminalEditorService: ITerminalEditorService,
+		@ITerminalGroupService private readonly _terminalGroupService: ITerminalGroupService,
 	) {
 		super();
 
@@ -207,44 +207,43 @@ registerTerminalContribution(TerminalInitialHintContribution.ID, TerminalInitial
 
 class TerminalInitialHintWidget extends Disposable {
 
-
-	private domNode: HTMLElement | undefined;
-	private readonly toDispose: DisposableStore = this._register(new DisposableStore());
-	private isVisible = false;
-	private ariaLabel: string = '';
+	private _domNode: HTMLElement | undefined;
+	private readonly _toDispose: DisposableStore = this._register(new DisposableStore());
+	private _isVisible = false;
+	private _ariaLabel: string = '';
 
 	constructor(
 		private readonly _instance: ITerminalInstance,
 		@IChatAgentService private readonly _chatAgentService: IChatAgentService,
-		@ICommandService private readonly commandService: ICommandService,
-		@IConfigurationService private readonly configurationService: IConfigurationService,
-		@IKeybindingService private readonly keybindingService: IKeybindingService,
-		@ITelemetryService private readonly telemetryService: ITelemetryService,
-		@IProductService private readonly productService: IProductService,
-		@ITerminalService private readonly terminalService: ITerminalService,
+		@ICommandService private readonly _commandService: ICommandService,
+		@IConfigurationService private readonly _configurationService: IConfigurationService,
+		@IContextMenuService private readonly _contextMenuService: IContextMenuService,
+		@IKeybindingService private readonly _keybindingService: IKeybindingService,
+		@IProductService private readonly _productService: IProductService,
 		@IStorageService private readonly _storageService: IStorageService,
-		@IContextMenuService private readonly contextMenuService: IContextMenuService
+		@ITelemetryService private readonly _telemetryService: ITelemetryService,
+		@ITerminalService private readonly _terminalService: ITerminalService,
 	) {
 		super();
-		this.toDispose.add(_instance.onDidFocus(() => {
-			if (this._instance.hasFocus && this.isVisible && this.ariaLabel && this.configurationService.getValue(AccessibilityVerbositySettingId.TerminalChat)) {
-				status(this.ariaLabel);
+		this._toDispose.add(_instance.onDidFocus(() => {
+			if (this._instance.hasFocus && this._isVisible && this._ariaLabel && this._configurationService.getValue(AccessibilityVerbositySettingId.TerminalChat)) {
+				status(this._ariaLabel);
 			}
 		}));
-		this.toDispose.add(terminalService.onDidChangeInstances(() => {
-			if (this.terminalService.instances.length !== 1) {
+		this._toDispose.add(_terminalService.onDidChangeInstances(() => {
+			if (this._terminalService.instances.length !== 1) {
 				this.dispose();
 			}
 		}));
-		this.toDispose.add(this.configurationService.onDidChangeConfiguration(e => {
-			if (e.affectsConfiguration(TerminalInitialHintSettingId.Enabled) && !this.configurationService.getValue(TerminalInitialHintSettingId.Enabled)) {
+		this._toDispose.add(this._configurationService.onDidChangeConfiguration(e => {
+			if (e.affectsConfiguration(TerminalInitialHintSettingId.Enabled) && !this._configurationService.getValue(TerminalInitialHintSettingId.Enabled)) {
 				this.dispose();
 			}
 		}));
 	}
 
 	private _getHintInlineChat(agents: IChatAgent[]) {
-		let providerName = (agents.length === 1 ? agents[0].fullName : undefined) ?? this.productService.nameShort;
+		let providerName = (agents.length === 1 ? agents[0].fullName : undefined) ?? this._productService.nameShort;
 		const defaultAgent = this._chatAgentService.getDefaultAgent(ChatAgentLocation.Panel);
 		if (defaultAgent?.extensionId.value === agents[0].extensionId.value) {
 			providerName = defaultAgent.fullName ?? providerName;
@@ -254,13 +253,13 @@ class TerminalInitialHintWidget extends Disposable {
 
 		const handleClick = () => {
 			this._storageService.store(Constants.InitialHintHideStorageKey, true, StorageScope.APPLICATION, StorageTarget.USER);
-			this.telemetryService.publicLog2<WorkbenchActionExecutedEvent, WorkbenchActionExecutedClassification>('workbenchActionExecuted', {
+			this._telemetryService.publicLog2<WorkbenchActionExecutedEvent, WorkbenchActionExecutedClassification>('workbenchActionExecuted', {
 				id: 'terminalInlineChat.hintAction',
 				from: 'hint'
 			});
-			this.commandService.executeCommand(TerminalChatCommandId.Start, { from: 'hint' });
+			this._commandService.executeCommand(TerminalChatCommandId.Start, { from: 'hint' });
 		};
-		this.toDispose.add(this.commandService.onDidExecuteCommand(e => {
+		this._toDispose.add(this._commandService.onDidExecuteCommand(e => {
 			if (e.commandId === TerminalChatCommandId.Start) {
 				this._storageService.store(Constants.InitialHintHideStorageKey, true, StorageScope.APPLICATION, StorageTarget.USER);
 				this.dispose();
@@ -268,7 +267,7 @@ class TerminalInitialHintWidget extends Disposable {
 		}));
 
 		const hintHandler: IContentActionHandler = {
-			disposables: this.toDispose,
+			disposables: this._toDispose,
 			callback: (index, _event) => {
 				switch (index) {
 					case '0':
@@ -281,7 +280,7 @@ class TerminalInitialHintWidget extends Disposable {
 		const hintElement = $('div.terminal-initial-hint');
 		hintElement.style.display = 'block';
 
-		const keybindingHint = this.keybindingService.lookupKeybinding(TerminalChatCommandId.Start);
+		const keybindingHint = this._keybindingService.lookupKeybinding(TerminalChatCommandId.Start);
 		const keybindingHintLabel = keybindingHint?.getLabel();
 
 		if (keybindingHint && keybindingHintLabel) {
@@ -289,7 +288,7 @@ class TerminalInitialHintWidget extends Disposable {
 
 			const [before, after] = actionPart.split(keybindingHintLabel).map((fragment) => {
 				const hintPart = $('a', undefined, fragment);
-				this.toDispose.add(dom.addDisposableListener(hintPart, dom.EventType.CLICK, handleClick));
+				this._toDispose.add(dom.addDisposableListener(hintPart, dom.EventType.CLICK, handleClick));
 				return hintPart;
 			});
 
@@ -301,7 +300,7 @@ class TerminalInitialHintWidget extends Disposable {
 			label.element.style.display = 'inline';
 
 			label.element.style.cursor = 'pointer';
-			this.toDispose.add(dom.addDisposableListener(label.element, dom.EventType.CLICK, handleClick));
+			this._toDispose.add(dom.addDisposableListener(label.element, dom.EventType.CLICK, handleClick));
 
 			hintElement.appendChild(after);
 
@@ -325,21 +324,21 @@ class TerminalInitialHintWidget extends Disposable {
 	}
 
 	getDomNode(agents: IChatAgent[]): HTMLElement {
-		if (!this.domNode) {
-			this.domNode = $('.terminal-initial-hint');
-			this.domNode!.style.paddingLeft = '4px';
+		if (!this._domNode) {
+			this._domNode = $('.terminal-initial-hint');
+			this._domNode!.style.paddingLeft = '4px';
 
 			const { hintElement, ariaLabel } = this._getHintInlineChat(agents);
-			this.domNode.append(hintElement);
-			this.ariaLabel = ariaLabel.concat(localize('disableHint', ' Toggle {0} in settings to disable this hint.', AccessibilityVerbositySettingId.TerminalChat));
+			this._domNode.append(hintElement);
+			this._ariaLabel = ariaLabel.concat(localize('disableHint', ' Toggle {0} in settings to disable this hint.', AccessibilityVerbositySettingId.TerminalChat));
 
-			this.toDispose.add(dom.addDisposableListener(this.domNode, 'click', () => {
-				this.domNode?.remove();
-				this.domNode = undefined;
+			this._toDispose.add(dom.addDisposableListener(this._domNode, 'click', () => {
+				this._domNode?.remove();
+				this._domNode = undefined;
 			}));
 
-			this.toDispose.add(dom.addDisposableListener(this.domNode, dom.EventType.CONTEXT_MENU, (e) => {
-				this.contextMenuService.showContextMenu({
+			this._toDispose.add(dom.addDisposableListener(this._domNode, dom.EventType.CONTEXT_MENU, (e) => {
+				this._contextMenuService.showContextMenu({
 					getAnchor: () => { return new StandardMouseEvent(dom.getActiveWindow(), e); },
 					getActions: () => {
 						return [{
@@ -348,18 +347,18 @@ class TerminalInitialHintWidget extends Disposable {
 							tooltip: localize('disableInitialHint', "Disable Initial Hint"),
 							enabled: true,
 							class: undefined,
-							run: () => this.configurationService.updateValue(TerminalInitialHintSettingId.Enabled, false)
+							run: () => this._configurationService.updateValue(TerminalInitialHintSettingId.Enabled, false)
 						}
 						];
 					}
 				});
 			}));
 		}
-		return this.domNode;
+		return this._domNode;
 	}
 
 	override dispose(): void {
-		this.domNode?.remove();
+		this._domNode?.remove();
 		super.dispose();
 	}
 }

--- a/src/vs/workbench/contrib/terminalContrib/chat/browser/terminalChatController.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chat/browser/terminalChatController.ts
@@ -25,14 +25,14 @@ import type { ITerminalContributionContext } from '../../../terminal/browser/ter
 import { TerminalChatContextKeys } from './terminalChat.js';
 
 const enum Message {
-	NONE = 0,
-	ACCEPT_SESSION = 1 << 0,
-	CANCEL_SESSION = 1 << 1,
-	PAUSE_SESSION = 1 << 2,
-	CANCEL_REQUEST = 1 << 3,
-	CANCEL_INPUT = 1 << 4,
-	ACCEPT_INPUT = 1 << 5,
-	RERUN_INPUT = 1 << 6,
+	None = 0,
+	AcceptSession = 1 << 0,
+	CancelSession = 1 << 1,
+	PauseSession = 1 << 2,
+	CancelRequest = 1 << 3,
+	CancelInput = 1 << 4,
+	AcceptInput = 1 << 5,
+	ReturnInput = 1 << 6,
 }
 
 export class TerminalChatController extends Disposable implements ITerminalContribution {
@@ -79,7 +79,7 @@ export class TerminalChatController extends Disposable implements ITerminalContr
 		return this._lastResponseContent;
 	}
 
-	readonly onDidAcceptInput = Event.filter(this._messages.event, m => m === Message.ACCEPT_INPUT, this._store);
+	readonly onDidAcceptInput = Event.filter(this._messages.event, m => m === Message.AcceptInput, this._store);
 	get onDidHide() { return this.terminalChatWidget?.onDidHide ?? Event.None; }
 
 	private _terminalAgentName = 'terminal';
@@ -100,13 +100,13 @@ export class TerminalChatController extends Disposable implements ITerminalContr
 
 	constructor(
 		private readonly _ctx: ITerminalContributionContext,
-		@ITerminalService private readonly _terminalService: ITerminalService,
-		@IInstantiationService private readonly _instantiationService: IInstantiationService,
-		@IContextKeyService private readonly _contextKeyService: IContextKeyService,
+		@IChatCodeBlockContextProviderService chatCodeBlockContextProviderService: IChatCodeBlockContextProviderService,
 		@IChatService private readonly _chatService: IChatService,
-		@IChatCodeBlockContextProviderService private readonly _chatCodeBlockContextProviderService: IChatCodeBlockContextProviderService,
-		@IViewsService private readonly _viewsService: IViewsService,
+		@IContextKeyService private readonly _contextKeyService: IContextKeyService,
+		@IInstantiationService private readonly _instantiationService: IInstantiationService,
 		@IStorageService private readonly _storageService: IStorageService,
+		@ITerminalService private readonly _terminalService: ITerminalService,
+		@IViewsService private readonly _viewsService: IViewsService,
 	) {
 		super();
 
@@ -114,7 +114,7 @@ export class TerminalChatController extends Disposable implements ITerminalContr
 		this._responseContainsCodeBlockContextKey = TerminalChatContextKeys.responseContainsCodeBlock.bindTo(this._contextKeyService);
 		this._responseContainsMulitpleCodeBlocksContextKey = TerminalChatContextKeys.responseContainsMultipleCodeBlocks.bindTo(this._contextKeyService);
 
-		this._register(this._chatCodeBlockContextProviderService.registerProvider({
+		this._register(chatCodeBlockContextProviderService.registerProvider({
 			getCodeBlockContext: (editor) => {
 				if (!editor || !this._terminalChatWidget?.hasValue || !this.hasFocus()) {
 					return;

--- a/src/vs/workbench/contrib/terminalContrib/chat/browser/terminalChatEnabler.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chat/browser/terminalChatEnabler.ts
@@ -18,8 +18,8 @@ export class TerminalChatEnabler {
 	private readonly _store = new DisposableStore();
 
 	constructor(
+		@IChatAgentService chatAgentService: IChatAgentService,
 		@IContextKeyService contextKeyService: IContextKeyService,
-		@IChatAgentService chatAgentService: IChatAgentService
 	) {
 		this._ctxHasProvider = TerminalChatContextKeys.hasChatAgent.bindTo(contextKeyService);
 		this._store.add(chatAgentService.onDidChangeAgents(() => {

--- a/src/vs/workbench/contrib/terminalContrib/chat/browser/terminalChatWidget.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chat/browser/terminalChatWidget.ts
@@ -43,19 +43,19 @@ export class TerminalChatWidget extends Disposable {
 		private readonly _terminalElement: HTMLElement,
 		private readonly _instance: ITerminalInstance,
 		private readonly _xterm: IXtermTerminal & { raw: RawXtermTerminal },
-		@IInstantiationService private readonly _instantiationService: IInstantiationService,
-		@IContextKeyService private readonly _contextKeyService: IContextKeyService
+		@IContextKeyService contextKeyService: IContextKeyService,
+		@IInstantiationService instantiationService: IInstantiationService,
 	) {
 		super();
 
-		this._focusedContextKey = TerminalChatContextKeys.focused.bindTo(this._contextKeyService);
-		this._visibleContextKey = TerminalChatContextKeys.visible.bindTo(this._contextKeyService);
+		this._focusedContextKey = TerminalChatContextKeys.focused.bindTo(contextKeyService);
+		this._visibleContextKey = TerminalChatContextKeys.visible.bindTo(contextKeyService);
 
 		this._container = document.createElement('div');
 		this._container.classList.add('terminal-inline-chat');
 		_terminalElement.appendChild(this._container);
 
-		this._inlineChatWidget = this._instantiationService.createInstance(
+		this._inlineChatWidget = instantiationService.createInstance(
 			InlineChatWidget,
 			{
 				location: ChatAgentLocation.Terminal,

--- a/src/vs/workbench/contrib/terminalContrib/chat/browser/terminalChatWidget.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chat/browser/terminalChatWidget.ts
@@ -86,7 +86,7 @@ export class TerminalChatWidget extends Disposable {
 						inputSideToolbar: MENU_TERMINAL_CHAT_WIDGET,
 					}
 				}
-			}
+			},
 		);
 		this._register(Event.any(
 			this._inlineChatWidget.onDidChangeHeight,

--- a/src/vs/workbench/contrib/terminalContrib/chat/test/browser/terminalInitialHint.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chat/test/browser/terminalInitialHint.test.ts
@@ -16,15 +16,13 @@ import { ExtensionIdentifier } from '../../../../../../platform/extensions/commo
 import { ChatAgentLocation, IChatAgent } from '../../../../chat/common/chatAgents.js';
 import { importAMDNodeModule } from '../../../../../../amdX.js';
 
-// Test TerminalInitialHintAddon
-
 suite('Terminal Initial Hint Addon', () => {
 	const store = ensureNoDisposablesAreLeakedInTestSuite();
 	let eventCount = 0;
 	let xterm: Terminal;
 	let initialHintAddon: InitialHintAddon;
-	const _onDidChangeAgents: Emitter<IChatAgent | undefined> = new Emitter();
-	const onDidChangeAgents = _onDidChangeAgents.event;
+	const onDidChangeAgentsEmitter: Emitter<IChatAgent | undefined> = new Emitter();
+	const onDidChangeAgents = onDidChangeAgentsEmitter.event;
 	const agent: IChatAgent = {
 		id: 'termminal',
 		name: 'terminal',
@@ -72,30 +70,30 @@ suite('Terminal Initial Hint Addon', () => {
 		});
 		test('hint is not shown when there is just an editor agent', () => {
 			eventCount = 0;
-			_onDidChangeAgents.fire(editorAgent);
+			onDidChangeAgentsEmitter.fire(editorAgent);
 			xterm.focus();
 			strictEqual(eventCount, 0);
 		});
 		test('hint is shown when there is a terminal chat agent', () => {
 			eventCount = 0;
-			_onDidChangeAgents.fire(editorAgent);
+			onDidChangeAgentsEmitter.fire(editorAgent);
 			xterm.focus();
 			strictEqual(eventCount, 0);
-			_onDidChangeAgents.fire(agent);
+			onDidChangeAgentsEmitter.fire(agent);
 			strictEqual(eventCount, 1);
 		});
 		test('hint is not shown again when another terminal chat agent is added if it has already shown', () => {
 			eventCount = 0;
-			_onDidChangeAgents.fire(agent);
+			onDidChangeAgentsEmitter.fire(agent);
 			xterm.focus();
 			strictEqual(eventCount, 1);
-			_onDidChangeAgents.fire(agent);
+			onDidChangeAgentsEmitter.fire(agent);
 			strictEqual(eventCount, 1);
 		});
 	});
 	suite('Input', () => {
 		test('hint is not shown when there has been input', () => {
-			_onDidChangeAgents.fire(agent);
+			onDidChangeAgentsEmitter.fire(agent);
 			xterm.writeln('data');
 			setTimeout(() => {
 				xterm.focus();

--- a/src/vs/workbench/contrib/terminalContrib/clipboard/browser/terminal.clipboard.contribution.ts
+++ b/src/vs/workbench/contrib/terminalContrib/clipboard/browser/terminal.clipboard.contribution.ts
@@ -51,7 +51,7 @@ export class TerminalClipboardContribution extends Disposable implements ITermin
 		@IConfigurationService private readonly _configurationService: IConfigurationService,
 		@IInstantiationService private readonly _instantiationService: IInstantiationService,
 		@INotificationService private readonly _notificationService: INotificationService,
-		@ITerminalConfigurationService private readonly _terminalConfigurationService: ITerminalConfigurationService
+		@ITerminalConfigurationService private readonly _terminalConfigurationService: ITerminalConfigurationService,
 	) {
 		super();
 	}

--- a/src/vs/workbench/contrib/terminalContrib/find/browser/terminal.find.contribution.ts
+++ b/src/vs/workbench/contrib/terminalContrib/find/browser/terminal.find.contribution.ts
@@ -44,7 +44,7 @@ class TerminalFindContribution extends Disposable implements ITerminalContributi
 	constructor(
 		ctx: ITerminalContributionContext | IDetachedCompatibleTerminalContributionContext,
 		@IInstantiationService instantiationService: IInstantiationService,
-		@ITerminalService terminalService: ITerminalService
+		@ITerminalService terminalService: ITerminalService,
 	) {
 		super();
 

--- a/src/vs/workbench/contrib/terminalContrib/find/browser/terminalFindWidget.ts
+++ b/src/vs/workbench/contrib/terminalContrib/find/browser/terminalFindWidget.ts
@@ -32,14 +32,14 @@ export class TerminalFindWidget extends SimpleFindWidget {
 
 	constructor(
 		private _instance: ITerminalInstance | IDetachedTerminalInstance,
-		@IContextViewService _contextViewService: IContextViewService,
-		@IKeybindingService keybindingService: IKeybindingService,
-		@IContextKeyService private readonly _contextKeyService: IContextKeyService,
-		@IContextMenuService _contextMenuService: IContextMenuService,
-		@IClipboardService _clipboardService: IClipboardService,
+		@IClipboardService clipboardService: IClipboardService,
+		@IConfigurationService configurationService: IConfigurationService,
+		@IContextKeyService contextKeyService: IContextKeyService,
+		@IContextMenuService contextMenuService: IContextMenuService,
+		@IContextViewService contextViewService: IContextViewService,
 		@IHoverService hoverService: IHoverService,
-		@IThemeService private readonly _themeService: IThemeService,
-		@IConfigurationService private readonly _configurationService: IConfigurationService
+		@IKeybindingService keybindingService: IKeybindingService,
+		@IThemeService themeService: IThemeService,
 	) {
 		super({
 			showCommonFindToggles: true,
@@ -55,14 +55,14 @@ export class TerminalFindWidget extends SimpleFindWidget {
 			closeWidgetActionId: TerminalFindCommandId.FindHide,
 			type: 'Terminal',
 			matchesLimit: XtermTerminalConstants.SearchHighlightLimit
-		}, _contextViewService, _contextKeyService, hoverService, keybindingService);
+		}, contextViewService, contextKeyService, hoverService, keybindingService);
 
 		this._register(this.state.onFindReplaceStateChange(() => {
 			this.show();
 		}));
-		this._findInputFocused = TerminalContextKeys.findInputFocus.bindTo(this._contextKeyService);
-		this._findWidgetFocused = TerminalContextKeys.findFocus.bindTo(this._contextKeyService);
-		this._findWidgetVisible = TerminalContextKeys.findVisible.bindTo(this._contextKeyService);
+		this._findInputFocused = TerminalContextKeys.findInputFocus.bindTo(contextKeyService);
+		this._findWidgetFocused = TerminalContextKeys.findFocus.bindTo(contextKeyService);
+		this._findWidgetVisible = TerminalContextKeys.findVisible.bindTo(contextKeyService);
 		const innerDom = this.getDomNode().firstChild;
 		if (innerDom) {
 			this._register(dom.addDisposableListener(innerDom, 'mousedown', (event) => {
@@ -74,15 +74,15 @@ export class TerminalFindWidget extends SimpleFindWidget {
 		}
 		const findInputDomNode = this.getFindInputDomNode();
 		this._register(dom.addDisposableListener(findInputDomNode, 'contextmenu', (event) => {
-			openContextMenu(dom.getWindow(findInputDomNode), event, _clipboardService, _contextMenuService);
+			openContextMenu(dom.getWindow(findInputDomNode), event, clipboardService, contextMenuService);
 			event.stopPropagation();
 		}));
-		this._register(this._themeService.onDidColorThemeChange(() => {
+		this._register(themeService.onDidColorThemeChange(() => {
 			if (this.isVisible()) {
 				this.find(true, true);
 			}
 		}));
-		this._register(this._configurationService.onDidChangeConfiguration((e) => {
+		this._register(configurationService.onDidChangeConfiguration((e) => {
 			if (e.affectsConfiguration('workbench.colorCustomizations') && this.isVisible()) {
 				this.find(true, true);
 			}

--- a/src/vs/workbench/contrib/terminalContrib/history/browser/terminal.history.contribution.ts
+++ b/src/vs/workbench/contrib/terminalContrib/history/browser/terminal.history.contribution.ts
@@ -35,12 +35,12 @@ class TerminalHistoryContribution extends Disposable implements ITerminalContrib
 
 	constructor(
 		private readonly _ctx: ITerminalContributionContext,
-		@IContextKeyService private readonly _contextKeyService: IContextKeyService,
+		@IContextKeyService contextKeyService: IContextKeyService,
 		@IInstantiationService private readonly _instantiationService: IInstantiationService,
 	) {
 		super();
 
-		this._terminalInRunCommandPicker = TerminalContextKeys.inTerminalRunCommandPicker.bindTo(this._contextKeyService);
+		this._terminalInRunCommandPicker = TerminalContextKeys.inTerminalRunCommandPicker.bindTo(contextKeyService);
 
 		this._register(_ctx.instance.capabilities.onDidAddCapabilityType(e => {
 			switch (e) {

--- a/src/vs/workbench/contrib/terminalContrib/history/browser/terminal.history.contribution.ts
+++ b/src/vs/workbench/contrib/terminalContrib/history/browser/terminal.history.contribution.ts
@@ -72,7 +72,7 @@ class TerminalHistoryContribution extends Disposable implements ITerminalContrib
 			this._terminalInRunCommandPicker,
 			type,
 			filterMode,
-			value
+			value,
 		);
 	}
 }

--- a/src/vs/workbench/contrib/terminalContrib/history/browser/terminalRunRecentQuickPick.ts
+++ b/src/vs/workbench/contrib/terminalContrib/history/browser/terminalRunRecentQuickPick.ts
@@ -41,11 +41,11 @@ export async function showRunRecentQuickPick(
 		return;
 	}
 
+	const accessibleViewService = accessor.get(IAccessibleViewService);
 	const editorService = accessor.get(IEditorService);
 	const instantiationService = accessor.get(IInstantiationService);
 	const quickInputService = accessor.get(IQuickInputService);
 	const storageService = accessor.get(IStorageService);
-	const accessibleViewService = accessor.get(IAccessibleViewService);
 
 	const runRecentStorageKey = `${TerminalStorageKeys.PinnedRecentCommandsPrefix}.${instance.shellType}`;
 	let placeholder: string;

--- a/src/vs/workbench/contrib/terminalContrib/history/browser/terminalRunRecentQuickPick.ts
+++ b/src/vs/workbench/contrib/terminalContrib/history/browser/terminalRunRecentQuickPick.ts
@@ -35,7 +35,7 @@ export async function showRunRecentQuickPick(
 	terminalInRunCommandPicker: IContextKey<boolean>,
 	type: 'command' | 'cwd',
 	filterMode?: 'fuzzy' | 'contiguous',
-	value?: string
+	value?: string,
 ): Promise<void> {
 	if (!instance.xterm) {
 		return;
@@ -149,7 +149,7 @@ export async function showRunRecentQuickPick(
 		if (previousSessionItems.length > 0) {
 			items.push(
 				{ type: 'separator', label: terminalStrings.previousSessionCategory },
-				...previousSessionItems
+				...previousSessionItems,
 			);
 		}
 
@@ -167,7 +167,7 @@ export async function showRunRecentQuickPick(
 		if (dedupedShellFileItems.length > 0) {
 			items.push(
 				{ type: 'separator', label: localize('shellFileHistoryCategory', '{0} history', instance.shellType) },
-				...dedupedShellFileItems
+				...dedupedShellFileItems,
 			);
 		}
 	} else {
@@ -199,7 +199,7 @@ export async function showRunRecentQuickPick(
 		if (previousSessionItems.length > 0) {
 			items.push(
 				{ type: 'separator', label: terminalStrings.previousSessionCategory },
-				...previousSessionItems
+				...previousSessionItems,
 			);
 		}
 	}
@@ -330,7 +330,7 @@ class TerminalOutputProvider extends Disposable implements ITextModelContentProv
 
 	constructor(
 		@ITextModelService textModelResolverService: ITextModelService,
-		@IModelService private readonly _modelService: IModelService
+		@IModelService private readonly _modelService: IModelService,
 	) {
 		super();
 		this._register(textModelResolverService.registerTextModelContentProvider(TerminalOutputProvider.scheme, this));

--- a/src/vs/workbench/contrib/terminalContrib/history/common/history.ts
+++ b/src/vs/workbench/contrib/terminalContrib/history/common/history.ts
@@ -83,7 +83,7 @@ export class TerminalPersistedHistory<T> extends Disposable implements ITerminal
 	constructor(
 		private readonly _storageDataKey: string,
 		@IConfigurationService private readonly _configurationService: IConfigurationService,
-		@IStorageService private readonly _storageService: IStorageService
+		@IStorageService private readonly _storageService: IStorageService,
 	) {
 		super();
 

--- a/src/vs/workbench/contrib/terminalContrib/links/browser/terminal.links.contribution.ts
+++ b/src/vs/workbench/contrib/terminalContrib/links/browser/terminal.links.contribution.ts
@@ -49,7 +49,7 @@ class TerminalLinkContribution extends DisposableStore implements ITerminalContr
 	constructor(
 		private readonly _ctx: ITerminalContributionContext | IDetachedCompatibleTerminalContributionContext,
 		@IInstantiationService private readonly _instantiationService: IInstantiationService,
-		@ITerminalLinkProviderService private readonly _terminalLinkProviderService: ITerminalLinkProviderService
+		@ITerminalLinkProviderService private readonly _terminalLinkProviderService: ITerminalLinkProviderService,
 	) {
 		super();
 		this._linkResolver = this._instantiationService.createInstance(TerminalLinkResolver);

--- a/src/vs/workbench/contrib/terminalContrib/links/browser/terminalLinkManager.ts
+++ b/src/vs/workbench/contrib/terminalContrib/links/browser/terminalLinkManager.ts
@@ -54,11 +54,11 @@ export class TerminalLinkManager extends DisposableStore {
 		capabilities: ITerminalCapabilityStore,
 		private readonly _linkResolver: ITerminalLinkResolver,
 		@IConfigurationService private readonly _configurationService: IConfigurationService,
-		@ITerminalConfigurationService private readonly _terminalConfigurationService: ITerminalConfigurationService,
 		@IInstantiationService private readonly _instantiationService: IInstantiationService,
-		@INotificationService private readonly _notificationService: INotificationService,
+		@INotificationService notificationService: INotificationService,
+		@ITerminalConfigurationService terminalConfigurationService: ITerminalConfigurationService,
 		@ITerminalLogService private readonly _logService: ITerminalLogService,
-		@ITunnelService private readonly _tunnelService: ITunnelService
+		@ITunnelService private readonly _tunnelService: ITunnelService,
 	) {
 		super();
 
@@ -112,13 +112,13 @@ export class TerminalLinkManager extends DisposableStore {
 					throw new Error(`Could not find scheme in link "${text}"`);
 				}
 				const scheme = text.substring(0, colonIndex);
-				if (this._terminalConfigurationService.config.allowedLinkSchemes.indexOf(scheme) === -1) {
-					this._notificationService.prompt(Severity.Warning, nls.localize('scheme', 'Opening URIs can be insecure, do you want to allow opening links with the scheme {0}?', scheme), [
+				if (terminalConfigurationService.config.allowedLinkSchemes.indexOf(scheme) === -1) {
+					notificationService.prompt(Severity.Warning, nls.localize('scheme', 'Opening URIs can be insecure, do you want to allow opening links with the scheme {0}?', scheme), [
 						{
 							label: nls.localize('allow', 'Allow {0}', scheme),
 							run: () => {
 								const allowedLinkSchemes = [
-									...this._terminalConfigurationService.config.allowedLinkSchemes,
+									...terminalConfigurationService.config.allowedLinkSchemes,
 									scheme
 								];
 								this._configurationService.updateValue(`terminal.integrated.allowedLinkSchemes`, allowedLinkSchemes);

--- a/src/vs/workbench/contrib/terminalContrib/links/browser/terminalLinkOpeners.ts
+++ b/src/vs/workbench/contrib/terminalContrib/links/browser/terminalLinkOpeners.ts
@@ -77,7 +77,7 @@ export class TerminalLocalFolderOutsideWorkspaceLinkOpener implements ITerminalL
 }
 
 export class TerminalSearchLinkOpener implements ITerminalLinkOpener {
-	protected _fileQueryBuilder = this._instantiationService.createInstance(QueryBuilder);
+	protected _fileQueryBuilder: QueryBuilder;
 
 	constructor(
 		private readonly _capabilities: ITerminalCapabilityStore,
@@ -86,13 +86,14 @@ export class TerminalSearchLinkOpener implements ITerminalLinkOpener {
 		private readonly _localFolderInWorkspaceOpener: TerminalLocalFolderInWorkspaceLinkOpener,
 		private readonly _getOS: () => OperatingSystem,
 		@IFileService private readonly _fileService: IFileService,
-		@IInstantiationService private readonly _instantiationService: IInstantiationService,
-		@ITerminalLogService private readonly _logService: ITerminalLogService,
+		@IInstantiationService instantiationService: IInstantiationService,
 		@IQuickInputService private readonly _quickInputService: IQuickInputService,
 		@ISearchService private readonly _searchService: ISearchService,
-		@IWorkspaceContextService private readonly _workspaceContextService: IWorkspaceContextService,
+		@ITerminalLogService private readonly _logService: ITerminalLogService,
 		@IWorkbenchEnvironmentService private readonly _workbenchEnvironmentService: IWorkbenchEnvironmentService,
+		@IWorkspaceContextService private readonly _workspaceContextService: IWorkspaceContextService,
 	) {
+		this._fileQueryBuilder = instantiationService.createInstance(QueryBuilder);
 	}
 
 	async open(link: ITerminalSimpleLink): Promise<void> {

--- a/src/vs/workbench/contrib/terminalContrib/links/browser/terminalLinkQuickpick.ts
+++ b/src/vs/workbench/contrib/terminalContrib/links/browser/terminalLinkQuickpick.ts
@@ -266,7 +266,7 @@ export class TerminalLinkQuickpick extends DisposableStore {
 		this._editorSequencer.queue(async () => {
 			await this._editorViewState.openTransientEditor({
 				resource: link.uri,
-				options: { preserveFocus: true, revealIfOpened: true, ignoreError: true, selection, }
+				options: { preserveFocus: true, revealIfOpened: true, ignoreError: true, selection }
 			});
 		});
 	}

--- a/src/vs/workbench/contrib/terminalContrib/links/browser/terminalLinkQuickpick.ts
+++ b/src/vs/workbench/contrib/terminalContrib/links/browser/terminalLinkQuickpick.ts
@@ -32,10 +32,10 @@ export class TerminalLinkQuickpick extends DisposableStore {
 	readonly onDidRequestMoreLinks = this._onDidRequestMoreLinks.event;
 
 	constructor(
+		@IAccessibleViewService private readonly _accessibleViewService: IAccessibleViewService,
+		@IInstantiationService instantiationService: IInstantiationService,
 		@ILabelService private readonly _labelService: ILabelService,
 		@IQuickInputService private readonly _quickInputService: IQuickInputService,
-		@IAccessibleViewService private readonly _accessibleViewService: IAccessibleViewService,
-		@IInstantiationService instantiationService: IInstantiationService
 	) {
 		super();
 		this._editorViewState = this.add(instantiationService.createInstance(PickerEditorState));

--- a/src/vs/workbench/contrib/terminalContrib/links/test/browser/terminalLinkParsing.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/links/test/browser/terminalLinkParsing.test.ts
@@ -255,7 +255,7 @@ suite('TerminalLinkParsing', () => {
 			strictEqual(removeLinkQueryString('foo?a=b&c=d'), 'foo');
 		});
 		test('should respect ? in UNC paths', () => {
-			strictEqual(removeLinkQueryString('\\\\?\\foo?a=b'), '\\\\?\\foo',);
+			strictEqual(removeLinkQueryString('\\\\?\\foo?a=b'), '\\\\?\\foo');
 		});
 	});
 	suite('detectLinks', () => {

--- a/src/vs/workbench/contrib/terminalContrib/quickAccess/browser/terminalQuickAccess.ts
+++ b/src/vs/workbench/contrib/terminalContrib/quickAccess/browser/terminalQuickAccess.ts
@@ -25,16 +25,17 @@ export class TerminalQuickAccessProvider extends PickerQuickAccessProvider<IPick
 	static PREFIX = 'term ';
 
 	constructor(
+		@ICommandService private readonly _commandService: ICommandService,
 		@IEditorService private readonly _editorService: IEditorService,
-		@ITerminalService private readonly _terminalService: ITerminalService,
+		@IInstantiationService private readonly _instantiationService: IInstantiationService,
 		@ITerminalEditorService private readonly _terminalEditorService: ITerminalEditorService,
 		@ITerminalGroupService private readonly _terminalGroupService: ITerminalGroupService,
-		@ICommandService private readonly _commandService: ICommandService,
+		@ITerminalService private readonly _terminalService: ITerminalService,
 		@IThemeService private readonly _themeService: IThemeService,
-		@IInstantiationService private readonly _instantiationService: IInstantiationService
 	) {
 		super(TerminalQuickAccessProvider.PREFIX, { canAcceptInBackground: true });
 	}
+
 	protected _getPicks(filter: string): Array<IPickerQuickAccessItem | IQuickPickSeparator> {
 		terminalPicks = [];
 		terminalPicks.push({ type: 'separator', label: 'panel' });

--- a/src/vs/workbench/contrib/terminalContrib/quickFix/browser/quickFixAddon.ts
+++ b/src/vs/workbench/contrib/terminalContrib/quickFix/browser/quickFixAddon.ts
@@ -76,15 +76,15 @@ export class TerminalQuickFixAddon extends Disposable implements ITerminalAddon,
 	constructor(
 		private readonly _aliases: string[][] | undefined,
 		private readonly _capabilities: ITerminalCapabilityStore,
-		@ITerminalQuickFixService private readonly _quickFixService: ITerminalQuickFixService,
+		@IAccessibilitySignalService private readonly _accessibilitySignalService: IAccessibilitySignalService,
+		@IActionWidgetService private readonly _actionWidgetService: IActionWidgetService,
 		@ICommandService private readonly _commandService: ICommandService,
 		@IConfigurationService private readonly _configurationService: IConfigurationService,
-		@IAccessibilitySignalService private readonly _accessibilitySignalService: IAccessibilitySignalService,
+		@IExtensionService private readonly _extensionService: IExtensionService,
+		@ILabelService private readonly _labelService: ILabelService,
 		@IOpenerService private readonly _openerService: IOpenerService,
 		@ITelemetryService private readonly _telemetryService: ITelemetryService,
-		@IExtensionService private readonly _extensionService: IExtensionService,
-		@IActionWidgetService private readonly _actionWidgetService: IActionWidgetService,
-		@ILabelService private readonly _labelService: ILabelService
+		@ITerminalQuickFixService private readonly _quickFixService: ITerminalQuickFixService,
 	) {
 		super();
 		const commandDetectionCapability = this._capabilities.get(TerminalCapability.CommandDetection);

--- a/src/vs/workbench/contrib/terminalContrib/wslRecommendation/browser/terminal.wslRecommendation.contribution.ts
+++ b/src/vs/workbench/contrib/terminalContrib/wslRecommendation/browser/terminal.wslRecommendation.contribution.ts
@@ -19,10 +19,10 @@ export class TerminalWslRecommendationContribution extends Disposable implements
 	static ID = 'terminalWslRecommendation';
 
 	constructor(
-		@IInstantiationService instantiationService: IInstantiationService,
-		@IProductService productService: IProductService,
-		@INotificationService notificationService: INotificationService,
 		@IExtensionManagementService extensionManagementService: IExtensionManagementService,
+		@IInstantiationService instantiationService: IInstantiationService,
+		@INotificationService notificationService: INotificationService,
+		@IProductService productService: IProductService,
 		@ITerminalService terminalService: ITerminalService,
 	) {
 		super();


### PR DESCRIPTION
Merge/review after https://github.com/microsoft/vscode/pull/230387

- Adds `.eslintrc` to `terminalContrib/`
- Adds permissive `comma-dangle` to the terminal eslints
- Sort injected services and remove unneeded ones
