### PR TITLE
create-comment: monaco editor should disable line-number manipulating API for extensions?

### DIFF
--- a/src/vs/workbench/contrib/comments/browser/simpleCommentEditor.ts
+++ b/src/vs/workbench/contrib/comments/browser/simpleCommentEditor.ts
@@ -110,6 +110,11 @@ export class SimpleCommentEditor extends CodeEditorWidget {
 		return EditorExtensionsRegistry.getEditorActions();
 	}
 
+	public override updateOptions(newOptions: Readonly<IEditorOptions> | undefined): void {
+		const withLineNumberRemoved: Readonly<IEditorOptions> = { ...newOptions, lineNumbers: 'off' };
+		super.updateOptions(withLineNumberRemoved);
+	}
+
 	public static getEditorOptions(configurationService: IConfigurationService): IEditorOptions {
 		return {
 			wordWrap: 'on',


### PR DESCRIPTION
Fixes #229521