### PR TITLE
testing: fix double scrollbars on long output

### DIFF
--- a/src/vs/editor/browser/widget/diffEditor/diffEditorWidget.ts
+++ b/src/vs/editor/browser/widget/diffEditor/diffEditorWidget.ts
@@ -517,6 +517,7 @@ export class DiffEditorWidget extends DelegatingEditor implements IDiffEditor {
 		this._options.updateOptions(changedOptions);
 	}
 
+	getDomNode(): HTMLElement { return this.elements.root; }
 	getContainerDomNode(): HTMLElement { return this._domElement; }
 	getOriginalEditor(): ICodeEditor { return this._editors.original; }
 	getModifiedEditor(): ICodeEditor { return this._editors.modified; }

--- a/src/vs/workbench/contrib/debug/browser/callStackWidget.ts
+++ b/src/vs/workbench/contrib/debug/browser/callStackWidget.ts
@@ -17,7 +17,6 @@ import { ThemeIcon } from '../../../../base/common/themables.js';
 import { Constants } from '../../../../base/common/uint.js';
 import { URI } from '../../../../base/common/uri.js';
 import { generateUuid } from '../../../../base/common/uuid.js';
-import './media/callStackWidget.css';
 import { ICodeEditor } from '../../../../editor/browser/editorBrowser.js';
 import { EditorContributionCtor, EditorContributionInstantiation, IEditorContributionDescription } from '../../../../editor/browser/editorExtensions.js';
 import { CodeEditorWidget } from '../../../../editor/browser/widget/codeEditor/codeEditorWidget.js';
@@ -41,8 +40,9 @@ import { WorkbenchList } from '../../../../platform/list/browser/listService.js'
 import { INotificationService } from '../../../../platform/notification/common/notification.js';
 import { defaultButtonStyles } from '../../../../platform/theme/browser/defaultStyles.js';
 import { ResourceLabel } from '../../../browser/labels.js';
-import { makeStackFrameColumnDecoration, TOP_STACK_FRAME_DECORATION } from './callStackEditorContribution.js';
 import { IEditorService, SIDE_GROUP } from '../../../services/editor/common/editorService.js';
+import { makeStackFrameColumnDecoration, TOP_STACK_FRAME_DECORATION } from './callStackEditorContribution.js';
+import './media/callStackWidget.css';
 
 
 export class CallStackFrame {
@@ -82,7 +82,7 @@ class WrappedCallStackFrame extends CallStackFrame implements IFrameLikeItem {
 	public readonly collapsed = observableValue('WrappedCallStackFrame.collapsed', false);
 
 	public readonly height = derived(reader => {
-		return this.collapsed.read(reader) ? HEADER_HEIGHT : HEADER_HEIGHT + this.editorHeight.read(reader);
+		return this.collapsed.read(reader) ? CALL_STACK_WIDGET_HEADER_HEIGHT : CALL_STACK_WIDGET_HEADER_HEIGHT + this.editorHeight.read(reader);
 	});
 
 	constructor(original: CallStackFrame) {
@@ -94,7 +94,7 @@ class WrappedCustomStackFrame implements IFrameLikeItem {
 	public readonly collapsed = observableValue('WrappedCallStackFrame.collapsed', false);
 
 	public readonly height = derived(reader => {
-		const headerHeight = this.original.showHeader.read(reader) ? HEADER_HEIGHT : 0;
+		const headerHeight = this.original.showHeader.read(reader) ? CALL_STACK_WIDGET_HEADER_HEIGHT : 0;
 		return this.collapsed.read(reader) ? headerHeight : headerHeight + this.original.height.read(reader);
 	});
 
@@ -118,6 +118,10 @@ export class CallStackWidget extends Disposable {
 	private readonly layoutEmitter = this._register(new Emitter<void>());
 	private readonly currentFramesDs = this._register(new DisposableStore());
 	private cts?: CancellationTokenSource;
+
+	public get onDidScroll() {
+		return this.list.onDidScroll;
+	}
 
 	constructor(
 		container: HTMLElement,
@@ -251,7 +255,7 @@ class StackDelegate implements IListVirtualDelegate<ListItem> {
 			return element.height.get();
 		}
 		if (element instanceof SkippedCallFrames) {
-			return HEADER_HEIGHT;
+			return CALL_STACK_WIDGET_HEADER_HEIGHT;
 		}
 
 		assertNever(element);
@@ -306,7 +310,7 @@ const makeFrameElements = () => dom.h('div.multiCallStackFrame', [
 	])
 ]);
 
-const HEADER_HEIGHT = 24;
+export const CALL_STACK_WIDGET_HEADER_HEIGHT = 24;
 
 interface IAbstractFrameRendererTemplateData {
 	container: HTMLElement;

--- a/src/vs/workbench/contrib/testing/browser/testResultsView/testMessageStack.ts
+++ b/src/vs/workbench/contrib/testing/browser/testResultsView/testMessageStack.ts
@@ -3,7 +3,6 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Emitter } from '../../../../../base/common/event.js';
 import { Disposable } from '../../../../../base/common/lifecycle.js';
 import { ICodeEditor } from '../../../../../editor/browser/editorBrowser.js';
 import { IInstantiationService } from '../../../../../platform/instantiation/common/instantiation.js';

--- a/src/vs/workbench/contrib/testing/browser/testResultsView/testMessageStack.ts
+++ b/src/vs/workbench/contrib/testing/browser/testResultsView/testMessageStack.ts
@@ -12,9 +12,10 @@ import { ITestMessageStackFrame } from '../../common/testTypes.js';
 
 export class TestResultStackWidget extends Disposable {
 	private readonly widget: CallStackWidget;
-	private readonly changeStackFrameEmitter = this._register(new Emitter<ITestMessageStackFrame>());
 
-	public readonly onDidChangeStackFrame = this.changeStackFrameEmitter.event;
+	public get onDidScroll() {
+		return this.widget.onDidScroll;
+	}
 
 	constructor(
 		private readonly container: HTMLElement,

--- a/src/vs/workbench/contrib/testing/browser/testResultsView/testResultsOutput.ts
+++ b/src/vs/workbench/contrib/testing/browser/testResultsView/testResultsOutput.ts
@@ -39,6 +39,8 @@ import { Testing } from '../../common/constants.js';
 import { MutableObservableValue } from '../../common/observableValue.js';
 import { ITaskRawOutput, ITestResult, ITestRunTaskResults, LiveTestResult, TestResultItemChangeReason } from '../../common/testResult.js';
 import { ITestMessage, TestMessageType, getMarkId } from '../../common/testTypes.js';
+import { ScrollEvent } from '../../../../../base/common/scrollable.js';
+import { CALL_STACK_WIDGET_HEADER_HEIGHT } from '../../../debug/browser/callStackWidget.js';
 
 
 class SimpleDiffEditorModel extends EditorModel {
@@ -62,6 +64,7 @@ class SimpleDiffEditorModel extends EditorModel {
 
 export interface IPeekOutputRenderer extends IDisposable {
 	onDidContentSizeChange?: Event<void>;
+	onScrolled?(evt: ScrollEvent): void;
 	/** Updates the displayed test. Should clear if it cannot display the test. */
 	update(subject: InspectSubject): Promise<boolean>;
 	/** Recalculate content layout. Returns the height it should be rendered at. */
@@ -76,12 +79,12 @@ const commonEditorOptions: IEditorOptions = {
 	lineNumbers: 'off',
 	glyphMargin: false,
 	scrollbar: {
-		verticalScrollbarSize: 14,
+		vertical: 'hidden',
 		horizontal: 'auto',
 		useShadows: false,
 		verticalHasArrows: false,
 		horizontalHasArrows: false,
-		alwaysConsumeMouseWheel: false
+		handleMouseWheel: false,
 	},
 	overviewRulerLanes: 0,
 	fixedOverflowWidgets: true,
@@ -109,6 +112,7 @@ export class DiffContentProvider extends Disposable implements IPeekOutputRender
 	private readonly widget = this._register(new MutableDisposable<DiffEditorWidget>());
 	private readonly model = this._register(new MutableDisposable());
 	private dimension?: dom.IDimension;
+	private helper?: ScrollHelper;
 
 	public get onDidContentSizeChange() {
 		return this.widget.value?.onDidContentSizeChange || Event.None;
@@ -180,13 +184,16 @@ export class DiffContentProvider extends Disposable implements IPeekOutputRender
 		}
 
 		editor.layout(dimensions);
-		if (!hasMultipleFrames) {
-			return dimensions.height;
-		}
-
-		const height = Math.min(10000, Math.max(editor.getOriginalEditor().getContentHeight(), editor.getModifiedEditor().getContentHeight()));
-		editor.layout({ height, width: dimensions.width });
+		const height = Math.max(
+			editor.getOriginalEditor().getContentHeight(),
+			editor.getModifiedEditor().getContentHeight()
+		);
+		this.helper = new ScrollHelper(hasMultipleFrames, height, dimensions.height);
 		return height;
+	}
+
+	public onScrolled(evt: ScrollEvent): void {
+		this.helper?.onScrolled(evt, this.widget.value?.getDomNode(), this.widget.value?.getOriginalEditor());
 	}
 
 	protected getOptions(isMultiline: boolean): IDiffEditorOptions {
@@ -247,11 +254,32 @@ export class MarkdownTestMessagePeek extends Disposable implements IPeekOutputRe
 	}
 }
 
+class ScrollHelper {
+	constructor(
+		private readonly hasMultipleFrames: boolean,
+		private readonly contentHeight: number,
+		private readonly viewHeight: number,
+	) { }
+
+	public onScrolled(evt: ScrollEvent, container: HTMLElement | undefined | null, editor: ICodeEditor | undefined) {
+		if (!editor || !container) {
+			return;
+		}
+
+		let delta = Math.max(0, evt.scrollTop - (this.hasMultipleFrames ? CALL_STACK_WIDGET_HEADER_HEIGHT : 0));
+		delta = Math.min(Math.max(0, this.contentHeight - this.viewHeight), delta);
+
+		editor.setScrollTop(delta);
+		container.style.transform = `translateY(${delta}px)`;
+	}
+}
+
 export class PlainTextMessagePeek extends Disposable implements IPeekOutputRenderer {
 	private readonly widgetDecorations = this._register(new MutableDisposable());
 	private readonly widget = this._register(new MutableDisposable<CodeEditorWidget>());
 	private readonly model = this._register(new MutableDisposable());
 	private dimension?: dom.IDimension;
+	private helper?: ScrollHelper;
 
 	public get onDidContentSizeChange() {
 		return this.widget.value?.onDidContentSizeChange || Event.None;
@@ -310,6 +338,10 @@ export class PlainTextMessagePeek extends Disposable implements IPeekOutputRende
 		this.model.clear();
 	}
 
+	onScrolled(evt: ScrollEvent): void {
+		this.helper?.onScrolled(evt, this.widget.value?.getDomNode(), this.widget.value);
+	}
+
 	public layout(dimensions: dom.IDimension, hasMultipleFrames: boolean) {
 		this.dimension = dimensions;
 		const editor = this.widget.value;
@@ -318,12 +350,8 @@ export class PlainTextMessagePeek extends Disposable implements IPeekOutputRende
 		}
 
 		editor.layout(dimensions);
-		if (!hasMultipleFrames) {
-			return dimensions.height;
-		}
-
 		const height = editor.getContentHeight();
-		editor.layout({ height, width: dimensions.width });
+		this.helper = new ScrollHelper(hasMultipleFrames, height, dimensions.height);
 		return height;
 	}
 }

--- a/src/vs/workbench/contrib/testing/browser/testResultsView/testResultsViewContent.ts
+++ b/src/vs/workbench/contrib/testing/browser/testResultsView/testResultsViewContent.ts
@@ -366,9 +366,16 @@ export class TestResultsViewContent extends Disposable {
 		if (provider) {
 			const width = this.splitView.getViewSize(SubView.Diff);
 			if (width !== -1 && this.dimension) {
-
 				topFrame.height.set(provider.layout({ width, height: this.dimension?.height }, hasMultipleFrames)!, undefined);
 			}
+
+			if (provider.onScrolled) {
+				this.currentSubjectStore.add(this.callStackWidget.onDidScroll(evt => {
+					provider.onScrolled!(evt);
+				}));
+			}
+
+
 			if (provider.onDidContentSizeChange) {
 				this.currentSubjectStore.add(provider.onDidContentSizeChange(() => {
 					if (this.dimension && !this.isDoingLayoutUpdate) {


### PR DESCRIPTION
Previously we limited the editor height to 10,000 pixels for performance, but this could show a double scrollbar on long output. In this change, we instead maintain the editor size to be the size of the output peek / view and move the editor as scroll in the list moves to take advantage of the editor's virtualization capabilities.

Fixes #228991

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
