### PR TITLE
Suppress safe generic type assertions, ref #211878

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/settingsWidgets.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsWidgets.ts
@@ -463,6 +463,7 @@ export class ListSettingWidget<TListDataItem extends IListDataItem> extends Abst
 	}
 
 	protected getEmptyItem(): TListDataItem {
+		// eslint-disable-next-line local/code-no-dangerous-type-assertions
 		return {
 			value: {
 				type: 'string',
@@ -624,6 +625,7 @@ export class ListSettingWidget<TListDataItem extends IListDataItem> extends Abst
 
 		const updatedInputBoxItem = (): TListDataItem => {
 			const inputBox = valueInput as InputBox;
+			// eslint-disable-next-line local/code-no-dangerous-type-assertions
 			return {
 				value: {
 					type: 'string',
@@ -633,6 +635,7 @@ export class ListSettingWidget<TListDataItem extends IListDataItem> extends Abst
 			} as TListDataItem;
 		};
 		const updatedSelectBoxItem = (selectedValue: string): TListDataItem => {
+			// eslint-disable-next-line local/code-no-dangerous-type-assertions
 			return {
 				value: {
 					type: 'enum',


### PR DESCRIPTION
I confirmed that the objects satisfy type IListDataItem, which TListDataItem extends.
I also confirmed that `satisfies IListDataItem` does not work, because TypeScript is unable to automatically cast IListDataItem to TListDataItem.