### PR TITLE
Resetting screen reader text to use LineFeed

### DIFF
--- a/src/vs/editor/browser/controller/editContext/native/nativeEditContext.ts
+++ b/src/vs/editor/browser/controller/editContext/native/nativeEditContext.ts
@@ -103,7 +103,7 @@ export class NativeEditContext extends AbstractEditContext {
 		}));
 		this._register(addDisposableListener(this.domNode.domNode, 'beforeinput', async (e) => {
 			if (e.inputType === 'insertParagraph' || e.inputType === 'insertLineBreak') {
-				this._onType(viewController, { text: '\n', replacePrevCharCnt: 0, replaceNextCharCnt: 0, positionDelta: 0 });
+				this._onType(viewController, { text: this._context.viewModel.model.getEOL(), replacePrevCharCnt: 0, replaceNextCharCnt: 0, positionDelta: 0 });
 			}
 		}));
 

--- a/src/vs/editor/browser/controller/editContext/native/nativeEditContext.ts
+++ b/src/vs/editor/browser/controller/editContext/native/nativeEditContext.ts
@@ -104,8 +104,7 @@ export class NativeEditContext extends AbstractEditContext {
 		}));
 		this._register(addDisposableListener(this.domNode.domNode, 'beforeinput', async (e) => {
 			if (e.inputType === 'insertParagraph' || e.inputType === 'insertLineBreak') {
-				// this._context.viewModel.model.getEOL()
-				this._onType(viewController, { text: '\n', replacePrevCharCnt: 0, replaceNextCharCnt: 0, positionDelta: 0 });
+				this._onType(viewController, { text: this._context.viewModel.model.getEOL(), replacePrevCharCnt: 0, replaceNextCharCnt: 0, positionDelta: 0 });
 			}
 		}));
 
@@ -205,10 +204,6 @@ export class NativeEditContext extends AbstractEditContext {
 		this._editContext.updateText(0, Number.MAX_SAFE_INTEGER, editContextState.text);
 		this._editContext.updateSelection(editContextState.selectionStartOffset, editContextState.selectionEndOffset);
 		this._textStartPositionWithinEditor = editContextState.textStartPositionWithinEditor;
-
-		console.log('this._editContext.text : ', this._editContext.text);
-		console.log('this._editContext.selectionStart : ', this._editContext.selectionStart);
-		console.log('this._editContext.selectionEnd : ', this._editContext.selectionEnd);
 	}
 
 	private _emitTypeEvent(viewController: ViewController, e: TextUpdateEvent): void {
@@ -412,7 +407,6 @@ export class NativeEditContext extends AbstractEditContext {
 		// system caret. This is reflected in Chrome as a `selectionchange` event and needs to be reflected within the editor.
 
 		return addDisposableListener(this.domNode.domNode.ownerDocument, 'selectionchange', () => {
-			console.log('selectionchange');
 			const options = this._context.configuration.options;
 			const accessibilitySupportEnabled = options.get(EditorOption.accessibilitySupport);
 			if (!this.isFocused() || accessibilitySupportEnabled !== AccessibilitySupport.Enabled) {
@@ -432,39 +426,22 @@ export class NativeEditContext extends AbstractEditContext {
 				return;
 			}
 			const range = activeDocumentSelection.getRangeAt(0);
-			const primaryState = this._context.viewModel.getPrimaryCursorState();
-			console.log('primaryState.modelState.selection : ', primaryState.modelState.selection);
-
 			const model = this._context.viewModel.model;
 			const offsetOfStartOfScreenReaderContent = model.getOffsetAt(screenReaderContentState.startPositionWithinEditor);
-			console.log('offsetOfStartOfScreenReaderContent : ', offsetOfStartOfScreenReaderContent);
-			console.log('range : ', range);
-			console.log('range.startOffset : ', range.startOffset);
-			console.log('range.endOffset : ', range.endOffset);
-
 			let offsetOfSelectionStart = range.startOffset + offsetOfStartOfScreenReaderContent;
 			let offsetOfSelectionEnd = range.endOffset + offsetOfStartOfScreenReaderContent;
-
 			const modelUsesCRLF = this._context.viewModel.model.getEndOfLineSequence() === EndOfLineSequence.CRLF;
 			if (modelUsesCRLF) {
 				const screenReaderContentText = screenReaderContentState.value;
 				const offsetTransformer = new PositionOffsetTransformer(screenReaderContentText);
 				const positionOfStartWithinText = offsetTransformer.getPosition(range.startOffset);
 				const positionOfEndWithinText = offsetTransformer.getPosition(range.endOffset);
-				console.log('positionOfStartWithinText.lineNumber : ', positionOfStartWithinText.lineNumber);
-				console.log('positionOfEndWithinText.lineNumber : ', positionOfEndWithinText.lineNumber);
-
 				offsetOfSelectionStart += positionOfStartWithinText.lineNumber - 1;
 				offsetOfSelectionEnd += positionOfEndWithinText.lineNumber - 1;
 			}
-
-			console.log('offsetOfSelectionStart : ', offsetOfSelectionStart);
-			console.log('offsetOfSelectionEnd : ', offsetOfSelectionEnd);
 			const positionOfSelectionStart = model.getPositionAt(offsetOfSelectionStart);
 			const positionOfSelectionEnd = model.getPositionAt(offsetOfSelectionEnd);
 			const newSelection = Selection.fromPositions(positionOfSelectionStart, positionOfSelectionEnd);
-			// If the model uses CRLF then need to update the selection so that it the selection positions are correct
-			console.log('newSelection : ', newSelection);
 			viewController.setSelection(newSelection);
 		});
 	}

--- a/src/vs/editor/browser/controller/editContext/native/screenReaderSupport.ts
+++ b/src/vs/editor/browser/controller/editContext/native/screenReaderSupport.ts
@@ -8,7 +8,7 @@ import { FastDomNode } from '../../../../../base/browser/fastDomNode.js';
 import { localize } from '../../../../../nls.js';
 import { AccessibilitySupport } from '../../../../../platform/accessibility/common/accessibility.js';
 import { IKeybindingService } from '../../../../../platform/keybinding/common/keybinding.js';
-import { EditorOption, EditorOptions } from '../../../../common/config/editorOptions.js';
+import { EditorOption } from '../../../../common/config/editorOptions.js';
 import { FontInfo } from '../../../../common/config/fontInfo.js';
 import { Position } from '../../../../common/core/position.js';
 import { Range } from '../../../../common/core/range.js';
@@ -58,13 +58,7 @@ export class ScreenReaderSupport {
 		this._fontInfo = options.get(EditorOption.fontInfo);
 		this._lineHeight = options.get(EditorOption.lineHeight);
 		this._accessibilitySupport = options.get(EditorOption.accessibilitySupport);
-		const accessibilityPageSize = options.get(EditorOption.accessibilityPageSize);
-		if (this._accessibilitySupport === AccessibilitySupport.Enabled && accessibilityPageSize === EditorOptions.accessibilityPageSize.defaultValue) {
-			// If a screen reader is attached and the default value is not set we should automatically increase the page size to 500 for a better experience
-			this._accessibilityPageSize = 500;
-		} else {
-			this._accessibilityPageSize = accessibilityPageSize;
-		}
+		this._accessibilityPageSize = options.get(EditorOption.accessibilityPageSize);
 	}
 
 	private _updateDomAttributes(): void {
@@ -118,13 +112,9 @@ export class ScreenReaderSupport {
 			return;
 		}
 		this._screenReaderContentState = this._getScreenReaderContentState();
-		console.log('this._screenReaderContentState : ', this._screenReaderContentState);
 		if (!this._screenReaderContentState) {
 			return;
 		}
-		console.log('this._screenReaderContentState.value : ', this._screenReaderContentState.value);
-		console.log('this._screenReaderContentState.selectionStart : ', this._screenReaderContentState.selectionStart);
-		console.log('this._screenReaderContentState.selectionEnd : ', this._screenReaderContentState.selectionEnd);
 		if (this._domNode.domNode.textContent !== this._screenReaderContentState.value) {
 			this._domNode.domNode.textContent = this._screenReaderContentState.value;
 		}
@@ -156,12 +146,10 @@ export class ScreenReaderSupport {
 				return this._context.viewModel.modifyPosition(position, offset);
 			}
 		};
-		console.log('this._accessibilityPageSize : ', this._accessibilityPageSize);
 		return PagedScreenReaderStrategy.fromEditorSelection(simpleModel, this._primarySelection, this._accessibilityPageSize, this._accessibilitySupport === AccessibilitySupport.Unknown);
 	}
 
 	private _setSelectionOfScreenReaderContent(selectionOffsetStart: number, selectionOffsetEnd: number): void {
-		console.log('_setSelectionOfScreenReaderContent');
 		const activeDocument = getActiveWindow().document;
 		const activeDocumentSelection = activeDocument.getSelection();
 		if (!activeDocumentSelection) {
@@ -174,7 +162,6 @@ export class ScreenReaderSupport {
 		const range = new globalThis.Range();
 		range.setStart(textContent, selectionOffsetStart);
 		range.setEnd(textContent, selectionOffsetEnd);
-		console.log('range : ', range);
 		activeDocumentSelection.removeAllRanges();
 		activeDocumentSelection.addRange(range);
 	}

--- a/src/vs/editor/browser/controller/editContext/native/screenReaderSupport.ts
+++ b/src/vs/editor/browser/controller/editContext/native/screenReaderSupport.ts
@@ -8,7 +8,7 @@ import { FastDomNode } from '../../../../../base/browser/fastDomNode.js';
 import { localize } from '../../../../../nls.js';
 import { AccessibilitySupport } from '../../../../../platform/accessibility/common/accessibility.js';
 import { IKeybindingService } from '../../../../../platform/keybinding/common/keybinding.js';
-import { EditorOption } from '../../../../common/config/editorOptions.js';
+import { EditorOption, EditorOptions } from '../../../../common/config/editorOptions.js';
 import { FontInfo } from '../../../../common/config/fontInfo.js';
 import { Position } from '../../../../common/core/position.js';
 import { Range } from '../../../../common/core/range.js';
@@ -58,7 +58,13 @@ export class ScreenReaderSupport {
 		this._fontInfo = options.get(EditorOption.fontInfo);
 		this._lineHeight = options.get(EditorOption.lineHeight);
 		this._accessibilitySupport = options.get(EditorOption.accessibilitySupport);
-		this._accessibilityPageSize = options.get(EditorOption.accessibilityPageSize);
+		const accessibilityPageSize = options.get(EditorOption.accessibilityPageSize);
+		if (this._accessibilitySupport === AccessibilitySupport.Enabled && accessibilityPageSize === EditorOptions.accessibilityPageSize.defaultValue) {
+			// If a screen reader is attached and the default value is not set we should automatically increase the page size to 500 for a better experience
+			this._accessibilityPageSize = 500;
+		} else {
+			this._accessibilityPageSize = accessibilityPageSize;
+		}
 	}
 
 	private _updateDomAttributes(): void {
@@ -112,17 +118,21 @@ export class ScreenReaderSupport {
 			return;
 		}
 		this._screenReaderContentState = this._getScreenReaderContentState();
+		console.log('this._screenReaderContentState : ', this._screenReaderContentState);
 		if (!this._screenReaderContentState) {
 			return;
 		}
+		console.log('this._screenReaderContentState.value : ', this._screenReaderContentState.value);
+		console.log('this._screenReaderContentState.selectionStart : ', this._screenReaderContentState.selectionStart);
+		console.log('this._screenReaderContentState.selectionEnd : ', this._screenReaderContentState.selectionEnd);
 		if (this._domNode.domNode.textContent !== this._screenReaderContentState.value) {
 			this._domNode.domNode.textContent = this._screenReaderContentState.value;
 		}
 		this._setSelectionOfScreenReaderContent(this._screenReaderContentState.selectionStart, this._screenReaderContentState.selectionEnd);
 	}
 
-	public startPositionOfScreenReaderContentWithinEditor(): Position | undefined {
-		return this._screenReaderContentState?.startPositionWithinEditor;
+	public get screenReaderContentState(): ScreenReaderContentState | undefined {
+		return this._screenReaderContentState;
 	}
 
 	private _getScreenReaderContentState(): ScreenReaderContentState | undefined {
@@ -146,10 +156,12 @@ export class ScreenReaderSupport {
 				return this._context.viewModel.modifyPosition(position, offset);
 			}
 		};
-		return PagedScreenReaderStrategy.fromEditorSelection(simpleModel, this._primarySelection, this._accessibilityPageSize, this._accessibilitySupport === AccessibilitySupport.Unknown, false);
+		console.log('this._accessibilityPageSize : ', this._accessibilityPageSize);
+		return PagedScreenReaderStrategy.fromEditorSelection(simpleModel, this._primarySelection, this._accessibilityPageSize, this._accessibilitySupport === AccessibilitySupport.Unknown);
 	}
 
 	private _setSelectionOfScreenReaderContent(selectionOffsetStart: number, selectionOffsetEnd: number): void {
+		console.log('_setSelectionOfScreenReaderContent');
 		const activeDocument = getActiveWindow().document;
 		const activeDocumentSelection = activeDocument.getSelection();
 		if (!activeDocumentSelection) {
@@ -162,6 +174,7 @@ export class ScreenReaderSupport {
 		const range = new globalThis.Range();
 		range.setStart(textContent, selectionOffsetStart);
 		range.setEnd(textContent, selectionOffsetEnd);
+		console.log('range : ', range);
 		activeDocumentSelection.removeAllRanges();
 		activeDocumentSelection.addRange(range);
 	}

--- a/src/vs/editor/browser/controller/editContext/screenReaderUtils.ts
+++ b/src/vs/editor/browser/controller/editContext/screenReaderUtils.ts
@@ -50,7 +50,7 @@ export class PagedScreenReaderStrategy {
 		return new Range(startLineNumber, 1, endLineNumber + 1, 1);
 	}
 
-	public static fromEditorSelection(model: ISimpleModel, selection: Range, linesPerPage: number, trimLongText: boolean, useLineFeed: boolean): ScreenReaderContentState {
+	public static fromEditorSelection(model: ISimpleModel, selection: Range, linesPerPage: number, trimLongText: boolean): ScreenReaderContentState {
 		// Chromium handles very poorly text even of a few thousand chars
 		// Cut text to avoid stalling the entire UI
 		const LIMIT_CHARS = 500;
@@ -62,34 +62,33 @@ export class PagedScreenReaderStrategy {
 		const selectionEndPageRange = PagedScreenReaderStrategy._getRangeForPage(selectionEndPage, linesPerPage);
 
 		let pretextRange = selectionStartPageRange.intersectRanges(new Range(1, 1, selection.startLineNumber, selection.startColumn))!;
-		const endOfLinePreference = useLineFeed ? EndOfLinePreference.LF : EndOfLinePreference.TextDefined;
-		if (trimLongText && model.getValueLengthInRange(pretextRange, endOfLinePreference) > LIMIT_CHARS) {
+		if (trimLongText && model.getValueLengthInRange(pretextRange, EndOfLinePreference.LF) > LIMIT_CHARS) {
 			const pretextStart = model.modifyPosition(pretextRange.getEndPosition(), -LIMIT_CHARS);
 			pretextRange = Range.fromPositions(pretextStart, pretextRange.getEndPosition());
 		}
-		const pretext = model.getValueInRange(pretextRange, endOfLinePreference);
+		const pretext = model.getValueInRange(pretextRange, EndOfLinePreference.LF);
 
 		const lastLine = model.getLineCount();
 		const lastLineMaxColumn = model.getLineMaxColumn(lastLine);
 		let posttextRange = selectionEndPageRange.intersectRanges(new Range(selection.endLineNumber, selection.endColumn, lastLine, lastLineMaxColumn))!;
-		if (trimLongText && model.getValueLengthInRange(posttextRange, endOfLinePreference) > LIMIT_CHARS) {
+		if (trimLongText && model.getValueLengthInRange(posttextRange, EndOfLinePreference.LF) > LIMIT_CHARS) {
 			const posttextEnd = model.modifyPosition(posttextRange.getStartPosition(), LIMIT_CHARS);
 			posttextRange = Range.fromPositions(posttextRange.getStartPosition(), posttextEnd);
 		}
-		const posttext = model.getValueInRange(posttextRange, endOfLinePreference);
+		const posttext = model.getValueInRange(posttextRange, EndOfLinePreference.LF);
 
 
 		let text: string;
 		if (selectionStartPage === selectionEndPage || selectionStartPage + 1 === selectionEndPage) {
 			// take full selection
-			text = model.getValueInRange(selection, endOfLinePreference);
+			text = model.getValueInRange(selection, EndOfLinePreference.LF);
 		} else {
 			const selectionRange1 = selectionStartPageRange.intersectRanges(selection)!;
 			const selectionRange2 = selectionEndPageRange.intersectRanges(selection)!;
 			text = (
-				model.getValueInRange(selectionRange1, endOfLinePreference)
+				model.getValueInRange(selectionRange1, EndOfLinePreference.LF)
 				+ String.fromCharCode(8230)
-				+ model.getValueInRange(selectionRange2, endOfLinePreference)
+				+ model.getValueInRange(selectionRange2, EndOfLinePreference.LF)
 			);
 		}
 		if (trimLongText && text.length > 2 * LIMIT_CHARS) {

--- a/src/vs/editor/browser/controller/editContext/textArea/textAreaEditContext.ts
+++ b/src/vs/editor/browser/controller/editContext/textArea/textAreaEditContext.ts
@@ -282,7 +282,8 @@ export class TextAreaEditContext extends AbstractEditContext {
 					return TextAreaState.EMPTY;
 				}
 
-				const screenReaderContentState = PagedScreenReaderStrategy.fromEditorSelection(simpleModel, this._selections[0], this._accessibilityPageSize, this._accessibilitySupport === AccessibilitySupport.Unknown, true);
+				const screenReaderContentState = PagedScreenReaderStrategy.fromEditorSelection(simpleModel, this._selections[0], this._accessibilityPageSize, this._accessibilitySupport === AccessibilitySupport.Unknown);
+				console.log('screenReaderContentState : ', screenReaderContentState);
 				return TextAreaState.fromScreenReaderContentState(screenReaderContentState);
 			},
 

--- a/src/vs/editor/browser/controller/editContext/textArea/textAreaEditContext.ts
+++ b/src/vs/editor/browser/controller/editContext/textArea/textAreaEditContext.ts
@@ -283,7 +283,6 @@ export class TextAreaEditContext extends AbstractEditContext {
 				}
 
 				const screenReaderContentState = PagedScreenReaderStrategy.fromEditorSelection(simpleModel, this._selections[0], this._accessibilityPageSize, this._accessibilitySupport === AccessibilitySupport.Unknown);
-				console.log('screenReaderContentState : ', screenReaderContentState);
 				return TextAreaState.fromScreenReaderContentState(screenReaderContentState);
 			},
 

--- a/src/vs/editor/browser/controller/editContext/textArea/textAreaEditContextState.ts
+++ b/src/vs/editor/browser/controller/editContext/textArea/textAreaEditContextState.ts
@@ -72,6 +72,10 @@ export class TextAreaState {
 		if (_debugComposition) {
 			console.log(`writeToTextArea ${reason}: ${this.toString()}`);
 		}
+		console.log('writeToTextArea');
+		console.log('this.value : ', this.value);
+		console.log('this.selectionStart : ', this.selectionStart);
+		console.log('this.selectionEnd : ', this.selectionEnd);
 		textArea.setValue(reason, this.value);
 		if (select) {
 			textArea.setSelectionRange(reason, this.selectionStart, this.selectionEnd);

--- a/src/vs/editor/browser/controller/editContext/textArea/textAreaEditContextState.ts
+++ b/src/vs/editor/browser/controller/editContext/textArea/textAreaEditContextState.ts
@@ -72,10 +72,6 @@ export class TextAreaState {
 		if (_debugComposition) {
 			console.log(`writeToTextArea ${reason}: ${this.toString()}`);
 		}
-		console.log('writeToTextArea');
-		console.log('this.value : ', this.value);
-		console.log('this.selectionStart : ', this.selectionStart);
-		console.log('this.selectionEnd : ', this.selectionEnd);
 		textArea.setValue(reason, this.value);
 		if (select) {
 			textArea.setSelectionRange(reason, this.selectionStart, this.selectionEnd);

--- a/src/vs/editor/test/browser/controller/imeTester.ts
+++ b/src/vs/editor/test/browser/controller/imeTester.ts
@@ -118,7 +118,7 @@ function doCreateTest(description: string, inputStr: string, expectedStr: string
 		getScreenReaderContent: (): TextAreaState => {
 			const selection = new Range(1, 1 + cursorOffset, 1, 1 + cursorOffset + cursorLength);
 
-			const screenReaderContentState = PagedScreenReaderStrategy.fromEditorSelection(model, selection, 10, true, true);
+			const screenReaderContentState = PagedScreenReaderStrategy.fromEditorSelection(model, selection, 10, true);
 			return TextAreaState.fromScreenReaderContentState(screenReaderContentState);
 		},
 		deduceModelPosition: (viewAnchorPosition: Position, deltaOffset: number, lineFeedCnt: number): Position => {

--- a/src/vs/editor/test/browser/controller/textAreaState.test.ts
+++ b/src/vs/editor/test/browser/controller/textAreaState.test.ts
@@ -365,7 +365,7 @@ suite('TextAreaState', () => {
 
 		function testPagedScreenReaderStrategy(lines: string[], selection: Selection, expected: TextAreaState): void {
 			const model = createTextModel(lines.join('\n'));
-			const screenReaderContentState = PagedScreenReaderStrategy.fromEditorSelection(model, selection, 10, true, true);
+			const screenReaderContentState = PagedScreenReaderStrategy.fromEditorSelection(model, selection, 10, true);
 			const textAreaState = TextAreaState.fromScreenReaderContentState(screenReaderContentState);
 			assert.ok(equalsTextAreaState(textAreaState, expected));
 			model.dispose();


### PR DESCRIPTION
Resetting screen reader text to use LineFeed

Calculate the offsets for `selectionchange` event differently

Fixes issue mentioned in https://github.com/microsoft/vscode/issues/229051