### PR TITLE
ci: check for clean git state in npm validation

### DIFF
--- a/build/azure-pipelines/product-npm-package-validate.yml
+++ b/build/azure-pipelines/product-npm-package-validate.yml
@@ -68,19 +68,27 @@ jobs:
               fi
 
               echo "Attempt $attempt: Running npm ci"
-              if npm ci --ignore-scripts; then
-                echo "npm ci succeeded on attempt $attempt"
-                exit 0
+              if npm i --ignore-scripts; then
+                if node build/npm/postinstall.js; then
+                  echo "npm i succeeded on attempt $attempt"
+                  exit 0
+                else
+                  echo "node build/npm/postinstall.js failed on attempt $attempt"
+                fi
               else
-                echo "npm ci failed on attempt $attempt"
+                echo "npm i failed on attempt $attempt"
               fi
             done
 
-            echo "npm ci failed after 6 attempts"
+            echo "npm i failed after 6 attempts"
             exit 1
           env:
+            npm_command: 'install --ignore-scripts'
             ELECTRON_SKIP_BINARY_DOWNLOAD: 1
             PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
             GITHUB_TOKEN: "$(github-distro-mixin-password)"
           displayName: Install dependencies with retries
           timeoutInMinutes: 400
+
+        - script: .github/workflows/check-clean-git-state.sh
+          displayName: Check clean git state

--- a/build/npm/postinstall.js
+++ b/build/npm/postinstall.js
@@ -60,7 +60,7 @@ function npmInstall(dir, opts) {
 		run('sudo', ['chown', '-R', `${userinfo.uid}:${userinfo.gid}`, `${path.resolve(root, dir)}`], opts);
 	} else {
 		log(dir, 'Installing dependencies...');
-		run(npm, [command], opts);
+		run(npm, command.split(' '), opts);
 	}
 }
 

--- a/test/monaco/.npmrc
+++ b/test/monaco/.npmrc
@@ -1,0 +1,2 @@
+legacy-peer-deps="true"
+timeout=180000


### PR DESCRIPTION
After the npm transition we have encountered issues where if user were to run `npm i` under any of the project subfolders and that subfolder didn't have a `.npmrc` file that shared the same project settings as the root then we will conflicting lock file changes.

Refs https://github.com/microsoft/vscode/pull/230214
Refs https://github.com/microsoft/vscode/pull/229330

The idea to tackle this was to add a new CI check that would run `npm install` instead of `npm clean install` and eventually run `check-clean-git-state.sh` to validate we don't have unexpected package-lock changes.

Instead of introducing yet another check, any objections to repurpose this npm package validate to additionally perform this action ?


Additional changes:

- Script will now run postinstall with `--ignore-scripts` to ensure installation under subfolders are validated as well