### PR TITLE
bring back `TerminalChatExecute` menu so voice input is possible, fire `acceptInput` so recording stops appropriately

### DIFF
--- a/src/vs/workbench/contrib/chat/electron-sandbox/actions/voiceChatActions.ts
+++ b/src/vs/workbench/contrib/chat/electron-sandbox/actions/voiceChatActions.ts
@@ -1349,7 +1349,7 @@ export class InstallSpeechProviderForVoiceChatAction extends BaseInstallSpeechPr
 			precondition: InstallingSpeechProvider.negate(),
 			menu: [{
 				id: MenuId.ChatInput,
-				when: HasSpeechProvider.negate(),
+				when: ContextKeyExpr.and(HasSpeechProvider.negate(), CONTEXT_CHAT_LOCATION.isEqualTo(ChatAgentLocation.Terminal).negate()),
 				group: 'navigation',
 				order: 3
 			}, {

--- a/src/vs/workbench/contrib/chat/electron-sandbox/actions/voiceChatActions.ts
+++ b/src/vs/workbench/contrib/chat/electron-sandbox/actions/voiceChatActions.ts
@@ -62,6 +62,8 @@ import { renderStringAsPlaintext } from '../../../../../base/browser/markdownRen
 type VoiceChatSessionContext = 'view' | 'inline' | 'terminal' | 'quick' | 'editor';
 const VoiceChatSessionContexts: VoiceChatSessionContext[] = ['view', 'inline', 'terminal', 'quick', 'editor'];
 
+const TerminalChatExecute = MenuId.for('terminalChatInput'); // unfortunately, terminal decided to go with their own menu (https://github.com/microsoft/vscode/issues/208789)
+
 // Global Context Keys (set on global context key service)
 const CanVoiceChat = ContextKeyExpr.and(CONTEXT_CHAT_ENABLED, HasSpeechProvider);
 const FocusInChatInput = ContextKeyExpr.or(CTX_INLINE_CHAT_FOCUSED, CONTEXT_IN_CHAT_INPUT);
@@ -609,6 +611,16 @@ export class StartVoiceChatAction extends Action2 {
 					group: 'navigation',
 					order: 2
 				},
+				{
+					id: TerminalChatExecute,
+					when: ContextKeyExpr.and(
+						HasSpeechProvider,
+						ScopedChatSynthesisInProgress.negate(),	// hide when text to speech is in progress
+						AnyScopedVoiceChatInProgress?.negate(),	// hide when voice chat is in progress
+					),
+					group: 'navigation',
+					order: -1
+				},
 			]
 		});
 	}
@@ -656,6 +668,12 @@ export class StopListeningAction extends Action2 {
 					when: ContextKeyExpr.and(CONTEXT_CHAT_LOCATION.isEqualTo(ChatAgentLocation.Panel).negate(), AnyScopedVoiceChatInProgress),
 					group: 'navigation',
 					order: 2
+				}, {
+
+					id: TerminalChatExecute,
+					when: AnyScopedVoiceChatInProgress,
+					group: 'navigation',
+					order: -1
 				},
 			]
 		});
@@ -991,6 +1009,18 @@ export class StopReadAloud extends Action2 {
 					group: 'navigation',
 					order: 2
 				},
+				{
+					id: TerminalChatExecute,
+					when: ScopedChatSynthesisInProgress,
+					group: 'navigation',
+					order: -1
+				},
+				{
+					id: TerminalChatExecute,
+					when: ScopedChatSynthesisInProgress,
+					group: 'navigation',
+					order: -1
+				}
 			]
 		});
 	}
@@ -1328,6 +1358,11 @@ export class InstallSpeechProviderForVoiceChatAction extends BaseInstallSpeechPr
 				when: HasSpeechProvider.negate(),
 				group: 'navigation',
 				order: 3
+			}, {
+				id: TerminalChatExecute,
+				when: HasSpeechProvider.negate(),
+				group: 'navigation',
+				order: -1
 			}]
 		});
 	}

--- a/src/vs/workbench/contrib/chat/electron-sandbox/actions/voiceChatActions.ts
+++ b/src/vs/workbench/contrib/chat/electron-sandbox/actions/voiceChatActions.ts
@@ -1014,12 +1014,6 @@ export class StopReadAloud extends Action2 {
 					when: ScopedChatSynthesisInProgress,
 					group: 'navigation',
 					order: -1
-				},
-				{
-					id: TerminalChatExecute,
-					when: ScopedChatSynthesisInProgress,
-					group: 'navigation',
-					order: -1
 				}
 			]
 		});

--- a/src/vs/workbench/contrib/terminalContrib/chat/browser/terminalChatController.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chat/browser/terminalChatController.ts
@@ -208,11 +208,11 @@ export class TerminalChatController extends Disposable implements ITerminalContr
 
 	async acceptInput(isVoiceInput?: boolean): Promise<IChatResponseModel | undefined> {
 		assertType(this._terminalChatWidget);
-		this._messages.fire(Message.AcceptInput);
 		if (!this._model.value) {
 			await this.reveal();
 		}
 		assertType(this._model.value);
+		this._messages.fire(Message.AcceptInput);
 		const lastInput = this._terminalChatWidget.value.inlineChatWidget.value;
 		if (!lastInput) {
 			return;

--- a/src/vs/workbench/contrib/terminalContrib/chat/browser/terminalChatController.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chat/browser/terminalChatController.ts
@@ -208,6 +208,7 @@ export class TerminalChatController extends Disposable implements ITerminalContr
 
 	async acceptInput(isVoiceInput?: boolean): Promise<IChatResponseModel | undefined> {
 		assertType(this._terminalChatWidget);
+		this._messages.fire(Message.AcceptInput);
 		if (!this._model.value) {
 			await this.reveal();
 		}


### PR DESCRIPTION
addresses #230330 in main
fixes [#229025](https://github.com/microsoft/vscode/issues/229025)