### PR TITLE
re-add terminal voice action, stop it when appropriate

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/chat/browser/terminalChatController.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chat/browser/terminalChatController.ts
@@ -216,7 +216,7 @@ export class TerminalChatController extends Disposable implements ITerminalContr
 			await this.reveal();
 		}
 		assertType(this._model.value);
-		this._messages.fire(Message.AcceptInput);
+		this._messages.fire(Message.ACCEPT_INPUT);
 		const lastInput = this._terminalChatWidget.value.inlineChatWidget.value;
 		if (!lastInput) {
 			return;

--- a/src/vs/workbench/contrib/terminalContrib/chat/browser/terminalChatController.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chat/browser/terminalChatController.ts
@@ -216,6 +216,7 @@ export class TerminalChatController extends Disposable implements ITerminalContr
 			await this.reveal();
 		}
 		assertType(this._model.value);
+		this._messages.fire(Message.AcceptInput);
 		const lastInput = this._terminalChatWidget.value.inlineChatWidget.value;
 		if (!lastInput) {
 			return;


### PR DESCRIPTION
This was introduced by a refactoring from @roblourens, but really was caused by the terminal handling things differently from other chats. 
fixes https://github.com/microsoft/vscode/issues/230330 

The bug/regression fix was deemed `verification-found` right before I went on vacation. I wasn't reproducing the bug because had a setting that obscured it enabled.
fixes https://github.com/microsoft/vscode/issues/229025