### PR TITLE
make textSearchResult tree items bolded

### DIFF
--- a/src/vs/workbench/contrib/search/browser/media/searchview.css
+++ b/src/vs/workbench/contrib/search/browser/media/searchview.css
@@ -195,6 +195,15 @@
 	height: 100%;
 }
 
+.search-view .textsearchresult {
+	display: flex;
+	position: relative;
+	line-height: 22px;
+	padding: 0;
+	height: 100%;
+	font-weight: 500;
+}
+
 .pane-body:not(.wide) .search-view .foldermatch .monaco-icon-label,
 .pane-body:not(.wide) .search-view .filematch .monaco-icon-label {
 	flex: 1;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
Bold the `Text Results` and `GitHub Copilot Results` headers in the search tree

![image](https://github.com/user-attachments/assets/7bfb5a1e-9e61-428a-9195-360f6bff3c60)
