### PR TITLE
Change `window.experimentalControlOverlay`'s scope to application

### DIFF
--- a/src/vs/workbench/electron-sandbox/desktop.contribution.ts
+++ b/src/vs/workbench/electron-sandbox/desktop.contribution.ts
@@ -239,7 +239,8 @@ import { MAX_ZOOM_LEVEL, MIN_ZOOM_LEVEL } from '../../platform/window/electron-s
 				'type': 'boolean',
 				'included': isLinux,
 				'markdownDescription': localize('window.experimentalControlOverlay', "Show the native window controls when {0} is set to `custom` (Linux only).", '`#window.titleBarStyle#`'),
-				'default': true
+				'default': true,
+				'scope': ConfigurationScope.APPLICATION,
 			},
 			'window.customTitleBarVisibility': {
 				'type': 'string',


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
Fixes #230353 by changing the scope of `window.experimentalControlOverlay` to application/default profile scope to avoid the window controls being detached from the state of the window (fullscreen/windowed)
