### PR TITLE
ci: add checks to verify mach-o objects architecture

### DIFF
--- a/build/azure-pipelines/darwin/product-build-darwin-universal.yml
+++ b/build/azure-pipelines/darwin/product-build-darwin-universal.yml
@@ -68,6 +68,13 @@ steps:
 
   - script: |
       set -e
+      APP_ROOT="$(Agent.BuildDirectory)/VSCode-darwin-$(VSCODE_ARCH)"
+      APP_NAME="`ls $APP_ROOT | head -n 1`"
+      APP_PATH="$APP_ROOT/$APP_NAME" node build/darwin/verify-macho.js universal
+    displayName: Verify arch of Mach-O objects
+
+  - script: |
+      set -e
       security create-keychain -p pwd $(agent.tempdirectory)/buildagent.keychain
       security default-keychain -s $(agent.tempdirectory)/buildagent.keychain
       security unlock-keychain -p pwd $(agent.tempdirectory)/buildagent.keychain

--- a/build/azure-pipelines/darwin/product-build-darwin.yml
+++ b/build/azure-pipelines/darwin/product-build-darwin.yml
@@ -188,6 +188,14 @@ steps:
         chmod +x "$APP_PATH/Contents/Resources/app/bin/$CLI_APP_NAME"
       displayName: Make CLI executable
 
+    - script: |
+        set -e
+        APP_ROOT="$(Agent.BuildDirectory)/VSCode-darwin-$(VSCODE_ARCH)"
+        APP_NAME="`ls $APP_ROOT | head -n 1`"
+        APP_PATH="$APP_ROOT/$APP_NAME" node build/darwin/verify-macho.js $(VSCODE_ARCH)
+        APP_PATH="$(Agent.BuildDirectory)/vscode-server-darwin-$(VSCODE_ARCH)" node build/darwin/verify-macho.js $(VSCODE_ARCH)
+      displayName: Verify arch of Mach-O objects
+
     # Setting hardened entitlements is a requirement for:
     # * Apple notarization
     # * Running tests on Big Sur (because Big Sur has additional security precautions)

--- a/build/darwin/create-universal-app.js
+++ b/build/darwin/create-universal-app.js
@@ -8,7 +8,6 @@ const path = require("path");
 const fs = require("fs");
 const minimatch = require("minimatch");
 const vscode_universal_bundler_1 = require("vscode-universal-bundler");
-const cross_spawn_promise_1 = require("@malept/cross-spawn-promise");
 const root = path.dirname(path.dirname(__dirname));
 async function main(buildDir) {
     const arch = process.env['VSCODE_ARCH'];
@@ -48,12 +47,6 @@ async function main(buildDir) {
         darwinUniversalAssetId: 'darwin-universal'
     });
     fs.writeFileSync(productJsonPath, JSON.stringify(productJson, null, '\t'));
-    // Verify if native module architecture is correct
-    const findOutput = await (0, cross_spawn_promise_1.spawn)('find', [outAppPath, '-name', 'kerberos.node']);
-    const lipoOutput = await (0, cross_spawn_promise_1.spawn)('lipo', ['-archs', findOutput.replace(/\n$/, '')]);
-    if (lipoOutput.replace(/\n$/, '') !== 'x86_64 arm64') {
-        throw new Error(`Invalid arch, got : ${lipoOutput}`);
-    }
 }
 if (require.main === module) {
     main(process.argv[2]).catch(err => {

--- a/build/darwin/create-universal-app.ts
+++ b/build/darwin/create-universal-app.ts
@@ -7,7 +7,6 @@ import * as path from 'path';
 import * as fs from 'fs';
 import * as minimatch from 'minimatch';
 import { makeUniversalApp } from 'vscode-universal-bundler';
-import { spawn } from '@malept/cross-spawn-promise';
 
 const root = path.dirname(path.dirname(__dirname));
 
@@ -54,13 +53,6 @@ async function main(buildDir?: string) {
 		darwinUniversalAssetId: 'darwin-universal'
 	});
 	fs.writeFileSync(productJsonPath, JSON.stringify(productJson, null, '\t'));
-
-	// Verify if native module architecture is correct
-	const findOutput = await spawn('find', [outAppPath, '-name', 'kerberos.node']);
-	const lipoOutput = await spawn('lipo', ['-archs', findOutput.replace(/\n$/, '')]);
-	if (lipoOutput.replace(/\n$/, '') !== 'x86_64 arm64') {
-		throw new Error(`Invalid arch, got : ${lipoOutput}`);
-	}
 }
 
 if (require.main === module) {

--- a/build/darwin/verify-macho.js
+++ b/build/darwin/verify-macho.js
@@ -1,0 +1,123 @@
+"use strict";
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+Object.defineProperty(exports, "__esModule", { value: true });
+const assert = require("assert");
+const path = require("path");
+const promises_1 = require("fs/promises");
+const cross_spawn_promise_1 = require("@malept/cross-spawn-promise");
+const MACHO_PREFIX = 'Mach-O ';
+const MACHO_64_MAGIC_LE = 0xfeedfacf;
+const MACHO_UNIVERSAL_MAGIC_LE = 0xbebafeca;
+const MACHO_ARM64_CPU_TYPE = new Set([
+    0x0c000001,
+    0x0100000c,
+]);
+const MACHO_X86_64_CPU_TYPE = new Set([
+    0x07000001,
+    0x01000007,
+]);
+async function read(file, buf, offset, length, position) {
+    let filehandle;
+    try {
+        filehandle = await (0, promises_1.open)(file);
+        await filehandle.read(buf, offset, length, position);
+    }
+    finally {
+        await filehandle?.close();
+    }
+}
+async function checkMachOFiles(appPath, arch) {
+    const visited = new Set();
+    const invalidFiles = [];
+    const header = Buffer.alloc(8);
+    const file_header_entry_size = 20;
+    const checkx86_64Arch = (arch === 'x64');
+    const checkArm64Arch = (arch === 'arm64');
+    const checkUniversalArch = (arch === 'universal');
+    const traverse = async (p) => {
+        p = await (0, promises_1.realpath)(p);
+        if (visited.has(p)) {
+            return;
+        }
+        visited.add(p);
+        const info = await (0, promises_1.stat)(p);
+        if (info.isSymbolicLink()) {
+            return;
+        }
+        if (info.isFile()) {
+            let fileOutput = '';
+            try {
+                fileOutput = await (0, cross_spawn_promise_1.spawn)('file', ['--brief', '--no-pad', p]);
+            }
+            catch (e) {
+                if (e instanceof cross_spawn_promise_1.ExitCodeError) {
+                    /* silently accept error codes from "file" */
+                }
+                else {
+                    throw e;
+                }
+            }
+            if (fileOutput.startsWith(MACHO_PREFIX)) {
+                console.log(`Verifying architecture of ${p}`);
+                read(p, header, 0, 8, 0).then(_ => {
+                    const header_magic = header.readUInt32LE();
+                    if (header_magic === MACHO_64_MAGIC_LE) {
+                        const cpu_type = header.readUInt32LE(4);
+                        if (checkUniversalArch) {
+                            invalidFiles.push(p);
+                        }
+                        else if (checkArm64Arch && !MACHO_ARM64_CPU_TYPE.has(cpu_type)) {
+                            invalidFiles.push(p);
+                        }
+                        else if (checkx86_64Arch && !MACHO_X86_64_CPU_TYPE.has(cpu_type)) {
+                            invalidFiles.push(p);
+                        }
+                    }
+                    else if (header_magic === MACHO_UNIVERSAL_MAGIC_LE) {
+                        const num_binaries = header.readUInt32BE(4);
+                        assert.equal(num_binaries, 2);
+                        const file_entries_size = file_header_entry_size * num_binaries;
+                        const file_entries = Buffer.alloc(file_entries_size);
+                        read(p, file_entries, 0, file_entries_size, 8).then(_ => {
+                            for (let i = 0; i < num_binaries; i++) {
+                                const cpu_type = file_entries.readUInt32LE(file_header_entry_size * i);
+                                if (!MACHO_ARM64_CPU_TYPE.has(cpu_type) && !MACHO_X86_64_CPU_TYPE.has(cpu_type)) {
+                                    invalidFiles.push(p);
+                                }
+                            }
+                        });
+                    }
+                });
+            }
+        }
+        if (info.isDirectory()) {
+            for (const child of await (0, promises_1.readdir)(p)) {
+                await traverse(path.resolve(p, child));
+            }
+        }
+    };
+    await traverse(appPath);
+    return invalidFiles;
+}
+const archToCheck = process.argv[2];
+assert(process.env['APP_PATH'], 'APP_PATH not set');
+assert(archToCheck === 'x64' || archToCheck === 'arm64' || archToCheck === 'universal', `Invalid architecture ${archToCheck} to check`);
+checkMachOFiles(process.env['APP_PATH'], archToCheck).then(invalidFiles => {
+    if (invalidFiles.length > 0) {
+        console.error('\x1b[31mThe following files are built for the wrong architecture:\x1b[0m');
+        for (const file of invalidFiles) {
+            console.error(`\x1b[31m${file}\x1b[0m`);
+        }
+        process.exit(1);
+    }
+    else {
+        console.log('\x1b[32mAll files are valid\x1b[0m');
+    }
+}).catch(err => {
+    console.error(err);
+    process.exit(1);
+});
+//# sourceMappingURL=verify-macho.js.map

--- a/build/darwin/verify-macho.ts
+++ b/build/darwin/verify-macho.ts
@@ -1,0 +1,120 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import * as path from 'path';
+import { open, stat, readdir, realpath } from 'fs/promises';
+import { spawn, ExitCodeError } from '@malept/cross-spawn-promise';
+
+const MACHO_PREFIX = 'Mach-O ';
+const MACHO_64_MAGIC_LE = 0xfeedfacf;
+const MACHO_UNIVERSAL_MAGIC_LE = 0xbebafeca;
+const MACHO_ARM64_CPU_TYPE = new Set([
+	0x0c000001,
+	0x0100000c,
+]);
+const MACHO_X86_64_CPU_TYPE = new Set([
+	0x07000001,
+	0x01000007,
+]);
+
+async function read(file: string, buf: Buffer, offset: number, length: number, position: number) {
+	let filehandle;
+	try {
+		filehandle = await open(file);
+		await filehandle.read(buf, offset, length, position);
+	} finally {
+		await filehandle?.close();
+	}
+}
+
+async function checkMachOFiles(appPath: string, arch: string) {
+	const visited = new Set();
+	const invalidFiles: string[] = [];
+	const header = Buffer.alloc(8);
+	const file_header_entry_size = 20;
+	const checkx86_64Arch = (arch === 'x64');
+	const checkArm64Arch = (arch === 'arm64');
+	const checkUniversalArch = (arch === 'universal');
+	const traverse = async (p: string) => {
+		p = await realpath(p);
+		if (visited.has(p)) {
+			return;
+		}
+		visited.add(p);
+
+		const info = await stat(p);
+		if (info.isSymbolicLink()) {
+			return;
+		}
+		if (info.isFile()) {
+			let fileOutput = '';
+			try {
+				fileOutput = await spawn('file', ['--brief', '--no-pad', p]);
+			} catch (e) {
+				if (e instanceof ExitCodeError) {
+					/* silently accept error codes from "file" */
+				} else {
+					throw e;
+				}
+			}
+			if (fileOutput.startsWith(MACHO_PREFIX)) {
+				console.log(`Verifying architecture of ${p}`);
+				read(p, header, 0, 8, 0).then(_ => {
+					const header_magic = header.readUInt32LE();
+					if (header_magic === MACHO_64_MAGIC_LE) {
+						const cpu_type = header.readUInt32LE(4);
+						if (checkUniversalArch) {
+							invalidFiles.push(p);
+						} else if (checkArm64Arch && !MACHO_ARM64_CPU_TYPE.has(cpu_type)) {
+							invalidFiles.push(p);
+						} else if (checkx86_64Arch && !MACHO_X86_64_CPU_TYPE.has(cpu_type)) {
+							invalidFiles.push(p);
+						}
+					} else if (header_magic === MACHO_UNIVERSAL_MAGIC_LE) {
+						const num_binaries = header.readUInt32BE(4);
+						assert.equal(num_binaries, 2);
+						const file_entries_size = file_header_entry_size * num_binaries;
+						const file_entries = Buffer.alloc(file_entries_size);
+						read(p, file_entries, 0, file_entries_size, 8).then(_ => {
+							for (let i = 0; i < num_binaries; i++) {
+								const cpu_type = file_entries.readUInt32LE(file_header_entry_size * i);
+								if (!MACHO_ARM64_CPU_TYPE.has(cpu_type) && !MACHO_X86_64_CPU_TYPE.has(cpu_type)) {
+									invalidFiles.push(p);
+								}
+							}
+						});
+					}
+				});
+			}
+		}
+
+		if (info.isDirectory()) {
+			for (const child of await readdir(p)) {
+				await traverse(path.resolve(p, child));
+			}
+		}
+	};
+	await traverse(appPath);
+	return invalidFiles;
+}
+
+const archToCheck = process.argv[2];
+assert(process.env['APP_PATH'], 'APP_PATH not set');
+assert(archToCheck === 'x64' || archToCheck === 'arm64' || archToCheck === 'universal', `Invalid architecture ${archToCheck} to check`);
+checkMachOFiles(process.env['APP_PATH'], archToCheck).then(invalidFiles => {
+	if (invalidFiles.length > 0) {
+		console.error('\x1b[31mThe following files are built for the wrong architecture:\x1b[0m');
+		for (const file of invalidFiles) {
+			console.error(`\x1b[31m${file}\x1b[0m`);
+		}
+		process.exit(1);
+	} else {
+		console.log('\x1b[32mAll files are valid\x1b[0m');
+	}
+}).catch(err => {
+	console.error(err);
+	process.exit(1);
+});


### PR DESCRIPTION
Expands the checks to all macOS pipelines and compliments sanity testing (unexercised native path can atleast be confirmed to have been built for the right architecture)