### PR TITLE
fix: extra indent in `Lua` when keywords are inside string or comment

### DIFF
--- a/extensions/lua/language-configuration.json
+++ b/extensions/lua/language-configuration.json
@@ -23,7 +23,8 @@
 		["'", "'"]
 	],
 	"indentationRules": {
-		"increaseIndentPattern": "^((?!(\\-\\-)).)*((\\b(else|function|then|do|repeat)\\b((?!\\b(end|until)\\b).)*)|(\\{\\s*))$",
+		"unIndentedLinePattern": "^\\s*\\-\\-",
+		"increaseIndentPattern": "((\\b(else|function|then|do|repeat)\\b((?!\\b(end|until)\\b).)*)|(\\{\\s*))$",
 		"decreaseIndentPattern": "^\\s*((\\b(elseif|else|end|until)\\b)|(\\})|(\\)))"
 	}
 }

--- a/extensions/lua/language-configuration.json
+++ b/extensions/lua/language-configuration.json
@@ -24,7 +24,7 @@
 	],
 	"indentationRules": {
 		"unIndentedLinePattern": "^\\s*\\-\\-",
-		"increaseIndentPattern": "((\\b(else|function|then|do|repeat)\\b((?!\\b(end|until)\\b).)*)|(\\{\\s*))$",
+		"increaseIndentPattern": "((\\b(else|function|then|do|repeat)\\b((?!\\b(end|until)\\b).)*)|([\\{\\(]\\s*(\\-\\-.*)?))$",
 		"decreaseIndentPattern": "^\\s*((\\b(elseif|else|end|until)\\b)|(\\})|(\\)))"
 	}
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

fixes #199223, fixes #223606

## Problem Description

Most languages use brackets to evaluate indentation; however, **Lua** uses keywords for this purpose. When keywords are inside a string or comment, the indentation becomes incorrect:
```lua
assert(type(v) == "function")
    |<-- Incorrect indent triggered by `function`, which is just inside a string
```

Another special case involves multiline strings, as mentioned here: https://github.com/LuaLS/lua-language-server/issues/2799#issuecomment-2293424794
```lua
local s = 'abc\z
function'
    |<-- Incorrect indentation
```

I initially tried to solve this by writing a very complicated `increaseIndentPattern` (https://github.com/microsoft/vscode/issues/199223#issuecomment-2247951065), but I encountered another major problem due to the **optimization** introduced in #210641, which removes brackets in strings or comments. This is because **Lua** has block quote syntax `[[...]]`, and the brackets are removed before evaluation, making it impossible to distinguish them in `increaseIndentPattern`. 😇 More details can be found here: https://github.com/microsoft/vscode/issues/223606
```lua
local s = [[function]]
    |<-- Incorrect indentation, and I can do nothing about it in `increaseIndentPattern`
-- because `[[` and `]]` are stripped, and the line actually becomes `local s = function` when evaluating
```

## Proposed Solution

The idea in this solution is similar to #210641. I attempted to remove **keywords** inside strings or comments. I extracted the possible keywords from a language's `increaseIndentPattern` and then created a regex to remove them.

## Are There Side Effects?

I performed a full search in `extensions\*\language-configuration.json` and found `14` languages that have defined `increaseIndentPattern`. Most of them do not contain keywords, so they will not be affected. The following is a test script that shows the actual `keywordsRegExp` for each of these 14 languages:

<details>
<summary>Toggle to show test script and result</summary>

### test script

```js
const patterns = [
    ["css",         "(^.*\\{[^}]*$)"],
    ["docker",      "^\\s*.*(:|-) ?(&amp;\\w+)?(\\{[^}\"']*|\\([^)\"']*)?$"],
    ["go",          "^.*(\\bcase\\b.*:|\\bdefault\\b:|(\\b(func|if|else|switch|select|for|struct)\\b.*)?{[^}\"'`]*|\\([^)\"'`]*)$"],
    ["html",        "<(?!\\?|(?:area|base|br|col|frame|hr|html|img|input|keygen|link|menuitem|meta|param|source|track|wbr)\\b|[^>]*\\/>)([-_\\.A-Za-z0-9]+)(?=\\s|>)\\b[^>]*>(?!.*<\\/\\1>)|<!--(?!.*-->)|\\{[^}\"']*$"],
    ["json",        "({+(?=((\\\\.|[^\"\\\\])*\"(\\\\.|[^\"\\\\])*\")*[^\"}]*)$)|(\\[+(?=((\\\\.|[^\"\\\\])*\"(\\\\.|[^\"\\\\])*\")*[^\"\\]]*)$)"],
    ["julia",       "^(\\s*|.*=\\s*|.*@\\w*\\s*)[\\w\\s]*(?:[\"'`][^\"'`]*[\"'`])*[\\w\\s]*\\b(if|while|for|function|macro|(mutable\\s+)?struct|abstract\\s+type|primitive\\s+type|let|quote|try|begin|.*\\)\\s*do|else|elseif|catch|finally)\\b(?!(?:.*\\bend\\b[^\\]]*)|(?:[^\\[]*\\].*)$).*$"],
    ["less",        "(^.*\\{[^}]*$)"],
    ["lua",         "((\\b(else|function|then|do|repeat)\\b((?!\\b(end|until)\\b).)*)|(\\{\\s*))$"],
    ["php",         "({(?!.*}).*|\\(|\\[|((else(\\s)?)?if|else|for(each)?|while|switch|case).*:)\\s*((/[/*].*|)?$|\\?>)"],
    ["ruby",        "^\\s*((begin|class|(private|protected)\\s+def|def|else|elsif|ensure|for|if|module|rescue|unless|until|when|in|while|case)|([^#]*\\sdo\\b)|([^#]*=\\s*(case|if|unless)))\\b([^#\\{;]|(\"|'|\/).*\\4)*(#.*)?$"],
    ["rust",        "^.*\\{[^}\"']*$|^.*\\([^\\)\"']*$"],
    ["scss",        "(^.*\\{[^}]*$)"],
    ["typescript",  "^.*(\\{[^}]*|\\([^)]*|\\[[^\\]]*)$"],
    ["yaml",        "^\\s*.*(:|-) ?(&amp;\\w+)?(\\{[^}\"']*|\\([^)\"']*)?$"],
]

const getKeywordsRegExp = (increaseIndentPatternStr) => {
    const keywordRegExp = /(?<!\\)[a-z]{2,}/g;
    const keywordsMatches = [...increaseIndentPatternStr.matchAll(keywordRegExp)];
    if (keywordsMatches.length <= 0) {
        return null;
    }
    const uniqueKeywords = [...new Set(keywordsMatches.map(r => r[0]))]
    return new RegExp(`\\b(${uniqueKeywords.join('|')})\\b`);
}

patterns.forEach((p) => {
    console.log(p[0].padEnd(10), getKeywordsRegExp(p[1]));
});
```
### result

```
css        null
docker     /\b(amp)\b/
go         /\b(case|default|func|if|else|switch|select|for|struct)\b/
html       /\b(area|base|br|col|frame|hr|html|img|input|keygen|link|menuitem|meta|param|source|track|wbr)\b/
json       null
julia      /\b(if|while|for|function|macro|mutable|struct|abstract|type|primitive|let|quote|try|begin|do|else|elseif|catch|finally|end)\b/
less       null
lua        /\b(else|function|then|do|repeat|end|until)\b/
php        /\b(else|if|for|each|while|switch|case)\b/
ruby       /\b(begin|class|private|protected|def|else|elsif|ensure|for|if|module|rescue|unless|until|when|in|while|case|do)\b/
rust       null
scss       null
typescript null
yaml       /\b(amp)\b/
```

</details>

- Among these 14 languages, I believe the indentation of `ruby` and `julia` is also keyword-based, so they may benefit as well.
- For other languages where indentation is not based on keywords, since my extra logic is to remove keywords **inside a string/comment**, I believe there will not be any observable side effects. 🤔

## Expected Result

The indentation issues in **Lua** when keywords are inside a string/comment should be resolved once and for all. 💆‍♂️

---

P.S.:
The LSP extension **LuaLS** that I used recently introduced a `fix-indent` feature on its server side. However, the performance is quite poor when editing large files: https://github.com/LuaLS/lua-language-server/issues/2803#issuecomment-2295217166. Therefore, I believe fixing indentation issues on the frontend (VSCode) is the proper approach.