### PR TITLE
Don't require loading project for eslint rules

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -155,9 +155,6 @@ export default tseslint.config(
 		],
 		languageOptions: {
 			parser: tseslint.parser,
-			parserOptions: {
-				project: path.join(__dirname, 'src', 'tsconfig.json'),
-			}
 		},
 		plugins: {
 			'@typescript-eslint': tseslint.plugin,


### PR DESCRIPTION
Added during the migration  but this is no longer required

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
