### PR TITLE
Revert 'Show Sidebar in new Window when Activity Bar not default'

### DIFF
--- a/src/vs/workbench/browser/layout.ts
+++ b/src/vs/workbench/browser/layout.ts
@@ -671,9 +671,6 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 			runtime: layoutRuntimeState,
 		};
 
-		const isNewWindow = lifecycleService.startupKind === StartupKind.NewWindow;
-		const activityBarNotDefault = this.configurationService.getValue<ActivityBarPosition>(LayoutSettings.ACTIVITY_BAR_LOCATION) !== ActivityBarPosition.DEFAULT;
-
 		// Sidebar View Container To Restore
 		if (this.isVisible(Parts.SIDEBAR_PART)) {
 
@@ -693,15 +690,6 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 				this.state.initialization.views.containerToRestore.sideBar = viewContainerToRestore;
 			} else {
 				this.stateModel.setRuntimeValue(LayoutStateKeys.SIDEBAR_HIDDEN, true);
-			}
-		}
-		// Side bar is hidden and a new window is opened with activity bar not visible (not default)
-		else if (isNewWindow && activityBarNotDefault) {
-			// Open side bar if there is a view container to restore
-			const viewContainerToRestore = this.storageService.get(SidebarPart.activeViewletSettingsKey, StorageScope.WORKSPACE, this.viewDescriptorService.getDefaultViewContainer(ViewContainerLocation.Sidebar)?.id);
-			if (viewContainerToRestore) {
-				this.state.initialization.views.containerToRestore.sideBar = viewContainerToRestore;
-				this.stateModel.setRuntimeValue(LayoutStateKeys.SIDEBAR_HIDDEN, false);
 			}
 		}
 


### PR DESCRIPTION
This pull request reverts a previous change that modified the behavior of the sidebar in new windows when the activity bar is not set to default. The reverted code included logic to show the sidebar under specific conditions, which has now been removed to restore the previous functionality.

closes #230575
closes #230489

related #226027