### PR TITLE
workbench.externalBrowser opens the selected browser properly

### DIFF
--- a/src/vs/platform/native/electron-main/nativeHostMainService.ts
+++ b/src/vs/platform/native/electron-main/nativeHostMainService.ts
@@ -522,11 +522,16 @@ export class NativeHostMainService extends Disposable implements INativeHostMain
 			return shell.openExternal(url);
 		}
 
+		let browserName = configuredBrowser;
+		if (configuredBrowser.toLowerCase() === 'edge') {
+			browserName = isWindows ? 'msedge' : 'microsoft-edge';
+		}
+
 		if (configuredBrowser.includes(posix.sep) || configuredBrowser.includes(win32.sep)) {
 			const browserPathExists = await Promises.exists(configuredBrowser);
 			if (!browserPathExists) {
 				this.logService.error(`Configured external browser path does not exist: ${configuredBrowser}`);
-				return shell.openExternal(url);
+				return;
 			}
 		}
 
@@ -534,20 +539,33 @@ export class NativeHostMainService extends Disposable implements INativeHostMain
 			const { default: open } = await import('open');
 			const res = await open(url, {
 				app: {
-					// Use `open.apps` helper to allow cross-platform browser
-					// aliases to be looked up properly. Fallback to the
-					// configured value if not found.
-					name: Object.hasOwn(open.apps, configuredBrowser) ? open.apps[(configuredBrowser as keyof typeof open['apps'])] : configuredBrowser
-				}
+					name: browserName
+				},
+				wait: true
 			});
 
+			if (res.exitCode !== 0) {
+				throw new Error(`Failed to open browser. Exit code: ${res.exitCode}`);
+			}
+
 			res.stderr?.once('data', (data: Buffer) => {
-				this.logService.error(`Error openening external URL '${url}' using browser '${configuredBrowser}': ${data.toString()}`);
-				return shell.openExternal(url);
+				this.logService.error(`Error opening external URL '${url}' using browser '${browserName}': ${data.toString()}`);
 			});
 		} catch (error) {
-			this.logService.error(`Unable to open external URL '${url}' using browser '${configuredBrowser}' due to ${error}.`);
-			return shell.openExternal(url);
+			this.logService.error(`Unable to open external URL '${url}' using browser '${browserName}' due to ${error}.`);
+			try {
+				let command;
+				if (isWindows) {
+					command = `start ${browserName} "${url}"`;
+				} else if (isMacintosh) {
+					command = `open -a "${browserName}" "${url}"`;
+				} else {
+					command = `${browserName} "${url}"`;
+				}
+				await promisify(exec)(command);
+			} catch (fallbackError) {
+				this.logService.error(`Fallback method failed to open URL '${url}' using browser '${browserName}': ${fallbackError}`);
+			}
 		}
 	}
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
This fixes #230636.

Now, when the user tries to set the `workbench.externalBrowser` setting to a particular browser, it will not open 2 tabs (1 for the user's default browser, and the other tab for what the user put for the value of `workbench.externalBrowser`).

Below are some gifs that shows the effect of the changes:
![open-link-fix-1](https://github.com/user-attachments/assets/01beee5f-d120-4625-8255-e7e2f7a73c72)

![open-link-fix-2](https://github.com/user-attachments/assets/6aff0058-22d3-4be4-8802-38ca3a2cf16a)


