### PR TITLE
Fix chat row widths

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/media/chat.css
@@ -18,7 +18,6 @@
 	display: flex;
 	flex-direction: column;
 	color: var(--vscode-interactive-session-foreground);
-	width: 100%;
 
 	cursor: default;
 	user-select: text;


### PR DESCRIPTION
Fix #231077

cc @joyceerhl - I'm not sure what this was doing, but it's making the container too wide because of the padding. You could use `border-box` if you need something like this

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
