### PR TITLE
Windows: using `edge` as `workbench.externalBrowser` opens default browser too (workaround #230636)

### DIFF
--- a/src/vs/platform/native/electron-main/nativeHostMainService.ts
+++ b/src/vs/platform/native/electron-main/nativeHostMainService.ts
@@ -541,17 +541,17 @@ export class NativeHostMainService extends Disposable implements INativeHostMain
 				}
 			});
 
-			if (!isWindows) {
-				// On Linux/macOS, listen to stderr and treat that as failure
-				// for opening the browser to fallback to the default.
-				// On Windows, unfortunately PowerShell seems to always write
-				// to stderr so we cannot use it there
-				// (see also https://github.com/microsoft/vscode/issues/230636)
-				res.stderr?.once('data', (data: Buffer) => {
-					this.logService.error(`Error openening external URL '${url}' using browser '${configuredBrowser}': ${data.toString()}`);
-					return shell.openExternal(url);
-				});
-			}
+			res.stderr?.once('data', (data: Buffer) => {
+				this.logService.error(`Error openening external URL '${url}' using browser '${configuredBrowser}': ${data.toString()}`);
+				if (!isWindows) {
+					// On Linux/macOS, listen to stderr and treat that as failure
+					// for opening the browser to fallback to the default.
+					// On Windows, unfortunately PowerShell seems to always write
+					// to stderr so we cannot use it there
+					// (see also https://github.com/microsoft/vscode/issues/230636)
+					shell.openExternal(url);
+				}
+			});
 		} catch (error) {
 			this.logService.error(`Unable to open external URL '${url}' using browser '${configuredBrowser}' due to ${error}.`);
 			return shell.openExternal(url);

--- a/src/vs/platform/native/electron-main/nativeHostMainService.ts
+++ b/src/vs/platform/native/electron-main/nativeHostMainService.ts
@@ -541,17 +541,17 @@ export class NativeHostMainService extends Disposable implements INativeHostMain
 				}
 			});
 
-			res.stderr?.once('data', (data: Buffer) => {
-				this.logService.error(`Error openening external URL '${url}' using browser '${configuredBrowser}': ${data.toString()}`);
-				if (!isWindows) {
-					// On Linux/macOS, listen to stderr and treat that as failure
-					// for opening the browser to fallback to the default.
-					// On Windows, unfortunately PowerShell seems to always write
-					// to stderr so we cannot use it there
-					// (see also https://github.com/microsoft/vscode/issues/230636)
-					shell.openExternal(url);
-				}
-			});
+			if (!isWindows) {
+				// On Linux/macOS, listen to stderr and treat that as failure
+				// for opening the browser to fallback to the default.
+				// On Windows, unfortunately PowerShell seems to always write
+				// to stderr so we cannot use it there
+				// (see also https://github.com/microsoft/vscode/issues/230636)
+				res.stderr?.once('data', (data: Buffer) => {
+					this.logService.error(`Error openening external URL '${url}' using browser '${configuredBrowser}': ${data.toString()}`);
+					return shell.openExternal(url);
+				});
+			}
 		} catch (error) {
 			this.logService.error(`Unable to open external URL '${url}' using browser '${configuredBrowser}' due to ${error}.`);
 			return shell.openExternal(url);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
