### PR TITLE
chore: bump distro

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "code-oss-dev",
   "version": "1.95.0",
-  "distro": "31869f6dce1a663115fbc3d8dcb832d6cdd407c0",
+  "distro": "fd8f1c3e49c4bea1e956ad61fe2b77ac40fa58aa",
   "author": {
     "name": "Microsoft Corporation"
   },


### PR DESCRIPTION
Follow-up to https://github.com/microsoft/vscode-distro/pull/990

Addresses https://dev.azure.com/monacotools/Monaco/_build/results?buildId=298405&view=results