### PR TITLE
chore: restore latest 1ES template

### DIFF
--- a/build/azure-pipelines/product-build.yml
+++ b/build/azure-pipelines/product-build.yml
@@ -166,7 +166,7 @@ resources:
     - repository: 1ESPipelines
       type: git
       name: 1ESPipelineTemplates/1ESPipelineTemplates
-      ref: refs/tags/release-2024-09-23-4
+      ref: refs/tags/release
 
 extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1esPipelines


### PR DESCRIPTION
Verification build: https://dev.azure.com/monacotools/Monaco/_build/results?buildId=298487&view=results (The fact that it started means it wasn't blocked by yesterday's issue)

CC @sbatten @joaomoreno 