### PR TITLE
feat: add preview indicators

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/media/settingsEditor2.css
+++ b/src/vs/workbench/contrib/preferences/browser/media/settingsEditor2.css
@@ -405,9 +405,9 @@
 }
 
 .settings-editor > .settings-body .settings-tree-container .setting-item-contents .setting-item-title > .setting-indicators-container .setting-indicator.setting-item-preview {
-	background: rgb(214, 63, 38);
+	color: var(--vscode-badge-foreground);
+	background: var(--vscode-badge-background);
 	font-style: italic;
-	margin-left: 4px;
 	margin-right: 4px;
 	padding: 0px 4px 2px;
 	border-radius: 4px;

--- a/src/vs/workbench/contrib/preferences/browser/media/settingsEditor2.css
+++ b/src/vs/workbench/contrib/preferences/browser/media/settingsEditor2.css
@@ -404,6 +404,15 @@
 	padding-bottom: 2px;
 }
 
+.settings-editor > .settings-body .settings-tree-container .setting-item-contents .setting-item-title > .setting-indicators-container .setting-indicator.setting-item-preview {
+	background: rgb(214, 63, 38);
+	font-style: italic;
+	margin-left: 4px;
+	margin-right: 4px;
+	padding: 0px 4px 2px;
+	border-radius: 4px;
+}
+
 .settings-editor > .settings-body .settings-tree-container .setting-item-contents .setting-item-title .codicon {
 	vertical-align: middle;
 	padding-left: 1px;

--- a/src/vs/workbench/contrib/preferences/browser/settingsEditorSettingIndicators.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsEditorSettingIndicators.ts
@@ -321,7 +321,8 @@ export class SettingsTreeIndicatorsLabel implements IDisposable {
 
 	updatePreviewIndicator(element: SettingsTreeSettingElement) {
 		const isPreviewSetting = element.tags?.has('preview');
-		const isExperimentalSetting = element.tags?.has('experimental');
+		// Hide experimental indicators for now until further review and experimental -> onExP migration.
+		const isExperimentalSetting = false; // element.tags?.has('experimental');
 		this.previewIndicator.element.style.display = (isPreviewSetting || isExperimentalSetting) ? 'inline' : 'none';
 		this.previewIndicator.label.text = isPreviewSetting ?
 			localize('previewLabel', "Preview") :

--- a/src/vs/workbench/contrib/preferences/browser/settingsEditorSettingIndicators.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsEditorSettingIndicators.ts
@@ -64,15 +64,16 @@ let cachedSyncIgnoredSettings: string[] = [];
 export class SettingsTreeIndicatorsLabel implements IDisposable {
 	private readonly indicatorsContainerElement: HTMLElement;
 
+	private readonly previewIndicator: SettingIndicator;
 	private readonly workspaceTrustIndicator: SettingIndicator;
 	private readonly scopeOverridesIndicator: SettingIndicator;
 	private readonly syncIgnoredIndicator: SettingIndicator;
 	private readonly defaultOverrideIndicator: SettingIndicator;
-	private readonly previewIndicator: SettingIndicator;
-	/** Indicators that end up wrapped in a parenthesis at the top-right of the setting */
-	private readonly parenthesizedIndicators: SettingIndicator[];
+
 	/** Indicators that each have their own square container at the top-right of the setting */
 	private readonly isolatedIndicators: SettingIndicator[] = [];
+	/** Indicators that end up wrapped in a parenthesis at the top-right of the setting */
+	private readonly parenthesizedIndicators: SettingIndicator[];
 
 	private readonly keybindingListeners: DisposableStore = new DisposableStore();
 	private focusedIndex = 0;
@@ -87,13 +88,14 @@ export class SettingsTreeIndicatorsLabel implements IDisposable {
 		this.indicatorsContainerElement = DOM.append(container, $('.setting-indicators-container'));
 		this.indicatorsContainerElement.style.display = 'inline';
 
+		this.previewIndicator = this.createPreviewIndicator();
+		this.isolatedIndicators = [this.previewIndicator];
+
 		this.workspaceTrustIndicator = this.createWorkspaceTrustIndicator();
 		this.scopeOverridesIndicator = this.createScopeOverridesIndicator();
 		this.syncIgnoredIndicator = this.createSyncIgnoredIndicator();
 		this.defaultOverrideIndicator = this.createDefaultOverrideIndicator();
-		this.previewIndicator = this.createPreviewIndicator();
 		this.parenthesizedIndicators = [this.workspaceTrustIndicator, this.scopeOverridesIndicator, this.syncIgnoredIndicator, this.defaultOverrideIndicator];
-		this.isolatedIndicators = [this.previewIndicator];
 	}
 
 	private defaultHoverOptions: Partial<IHoverOptions> = {
@@ -353,6 +355,9 @@ export class SettingsTreeIndicatorsLabel implements IDisposable {
 
 	dispose() {
 		this.keybindingListeners.dispose();
+		for (const indicator of this.isolatedIndicators) {
+			indicator.disposables.dispose();
+		}
 		for (const indicator of this.parenthesizedIndicators) {
 			indicator.disposables.dispose();
 		}

--- a/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsTree.ts
@@ -994,6 +994,7 @@ export abstract class AbstractSettingRenderer extends Disposable implements ITre
 		template.indicatorsLabel.updateWorkspaceTrust(element);
 		template.indicatorsLabel.updateSyncIgnored(element, this.ignoredSettings);
 		template.indicatorsLabel.updateDefaultOverrideIndicator(element);
+		template.indicatorsLabel.updatePreviewIndicator(element);
 		template.elementDisposables.add(this.onDidChangeIgnoredSettings(() => {
 			template.indicatorsLabel.updateSyncIgnored(element, this.ignoredSettings);
 		}));


### PR DESCRIPTION
Adds Preview indicators for tag:preview settings in the Settings editor, and also adds scaffolding for Experimental indicators for tag:experimental settings in the Settings editor.

## Example

![Copilot setting modified in workspace displays both preview and modified indicators](https://github.com/user-attachments/assets/be4e8be7-ad46-4ac1-9d64-29e3b1c746b1)
