### PR TITLE
chore: add TSAUpload step to Custom SDL stage

### DIFF
--- a/build/azure-pipelines/config/tsaoptions.json
+++ b/build/azure-pipelines/config/tsaoptions.json
@@ -1,5 +1,5 @@
 {
-	"codebaseName": "devdiv_$(Build.Repository.Name)",
+	"codebaseName": "devdiv_microsoft_vscode",
 	"serviceTreeID": "79c048b2-322f-4ed5-a1ea-252a1250e4b3",
 	"instanceUrl": "https://devdiv.visualstudio.com/defaultcollection",
 	"projectName": "DevDiv",

--- a/build/azure-pipelines/config/tsaoptions.json
+++ b/build/azure-pipelines/config/tsaoptions.json
@@ -1,0 +1,12 @@
+{
+	"codebaseName": "devdiv_$(Build.Repository.Name)",
+	"serviceTreeID": "79c048b2-322f-4ed5-a1ea-252a1250e4b3",
+	"instanceUrl": "https://devdiv.visualstudio.com/defaultcollection",
+	"projectName": "DevDiv",
+	"areaPath": "DevDiv\\VS Code (compliance tracking only)\\Visual Studio Code Client",
+	"notificationAliases": [
+		"monacotools@microsoft.com"
+	],
+	"validateToolOutput": "None",
+	"allTools": true
+}

--- a/build/azure-pipelines/product-build.yml
+++ b/build/azure-pipelines/product-build.yml
@@ -174,15 +174,7 @@ extends:
     sdl:
       tsa:
         enabled: true
-        config:
-          codebaseName: 'devdiv_$(Build.Repository.Name)'
-          serviceTreeID: '79c048b2-322f-4ed5-a1ea-252a1250e4b3'
-          instanceUrl: 'https://devdiv.visualstudio.com/defaultcollection'
-          projectName: 'DevDiv'
-          areaPath: "DevDiv\\VS Code (compliance tracking only)\\Visual Studio Code Client"
-          notificationAliases: ['monacotools@microsoft.com']
-          validateToolOutput: None
-          allTools: true
+        configFile: $(Build.SourcesDirectory)/build/azure-pipelines/config/tsaoptions.json
       codeql:
         runSourceLanguagesInSourceAnalysis: true
         compiled:

--- a/build/azure-pipelines/win32/sdl-scan-win32.yml
+++ b/build/azure-pipelines/win32/sdl-scan-win32.yml
@@ -160,3 +160,10 @@ steps:
       ArtifactType: Container
       PublishProcessedResults: false
       AllTools: true
+
+  # TSA Upload
+  - task: securedevelopmentteam.vss-secure-development-tools.build-task-uploadtotsa.TSAUpload@2
+    displayName: TSA Upload
+    continueOnError: true
+    inputs:
+      GdnPublishTsaConfigFile: '$(Build.SourcesDirectory)/build/azure-pipelines/config/tsaoptions.json'

--- a/build/azure-pipelines/win32/sdl-scan-win32.yml
+++ b/build/azure-pipelines/win32/sdl-scan-win32.yml
@@ -166,4 +166,5 @@ steps:
     displayName: TSA Upload
     continueOnError: true
     inputs:
+      GdnPublishTsaOnboard: true
       GdnPublishTsaConfigFile: '$(Build.SourcesDirectory)/build/azure-pipelines/config/tsaoptions.json'


### PR DESCRIPTION
Verification build: https://dev.azure.com/monacotools/Monaco/_build/results?buildId=298527&view=results

Currently, only the default SDL stage uploads scan results with TSA.
This PR also enables the custom SDL stage, which runs APIScan and BinSkim, to upload results with TSA.