### PR TITLE
chore: add unstable indicators for json settings

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/preferencesRenderers.ts
+++ b/src/vs/workbench/contrib/preferences/browser/preferencesRenderers.ts
@@ -45,6 +45,7 @@ import { IWorkbenchEnvironmentService } from '../../../services/environment/comm
 import { IPreferencesEditorModel, IPreferencesService, ISetting, ISettingsEditorModel, ISettingsGroup } from '../../../services/preferences/common/preferences.js';
 import { DefaultSettingsEditorModel, SettingsEditorModel, WorkspaceConfigurationEditorModel } from '../../../services/preferences/common/preferencesModels.js';
 import { IUserDataProfileService } from '../../../services/userDataProfile/common/userDataProfile.js';
+import { EXPERIMENTAL_INDICATOR_DESCRIPTION, PREVIEW_INDICATOR_DESCRIPTION } from '../common/preferences.js';
 
 export interface IPreferencesRenderer extends IDisposable {
 	render(): void;
@@ -547,6 +548,7 @@ class UnsupportedSettingsRenderer extends Disposable implements languages.CodeAc
 					}
 					const configuration = configurationRegistry[setting.key];
 					if (configuration) {
+						this.handleUnstableSettingConfiguration(setting, configuration, markerData);
 						if (this.handlePolicyConfiguration(setting, configuration, markerData)) {
 							continue;
 						}
@@ -565,7 +567,7 @@ class UnsupportedSettingsRenderer extends Disposable implements languages.CodeAc
 								break;
 						}
 					} else {
-						markerData.push(this.gemerateUnknownConfigurationMarker(setting));
+						markerData.push(this.generateUnknownConfigurationMarker(setting));
 					}
 				}
 			}
@@ -605,7 +607,7 @@ class UnsupportedSettingsRenderer extends Disposable implements languages.CodeAc
 					});
 				}
 			} else {
-				markerData.push(this.gemerateUnknownConfigurationMarker(setting));
+				markerData.push(this.generateUnknownConfigurationMarker(setting));
 			}
 		}
 	}
@@ -694,6 +696,16 @@ class UnsupportedSettingsRenderer extends Disposable implements languages.CodeAc
 		}
 	}
 
+	private handleUnstableSettingConfiguration(setting: ISetting, configuration: IConfigurationPropertySchema, markerData: IMarkerData[]): void {
+		if (configuration.tags?.includes('preview')) {
+			markerData.push(this.generatePreviewSettingMarker(setting));
+		}
+		// Enable after further review and experimental -> onExP migration
+		// if (configuration.tags?.includes('experimental')) {
+		// 	markerData.push(this.generateExperimentalSettingMarker(setting));
+		// }
+	}
+
 	private generateUnsupportedApplicationSettingMarker(setting: ISetting): IMarkerData {
 		return {
 			severity: MarkerSeverity.Hint,
@@ -720,7 +732,7 @@ class UnsupportedSettingsRenderer extends Disposable implements languages.CodeAc
 		};
 	}
 
-	private gemerateUnknownConfigurationMarker(setting: ISetting): IMarkerData {
+	private generateUnknownConfigurationMarker(setting: ISetting): IMarkerData {
 		return {
 			severity: MarkerSeverity.Hint,
 			tags: [MarkerTag.Unnecessary],
@@ -739,6 +751,23 @@ class UnsupportedSettingsRenderer extends Disposable implements languages.CodeAc
 			diagnostics,
 			kind: CodeActionKind.QuickFix.value
 		}];
+	}
+
+	private generatePreviewSettingMarker(setting: ISetting): IMarkerData {
+		return {
+			severity: MarkerSeverity.Info,
+			...setting.range,
+			message: PREVIEW_INDICATOR_DESCRIPTION
+		};
+	}
+
+	// @ts-expect-error
+	private generateExperimentalSettingMarker(setting: ISetting): IMarkerData {
+		return {
+			severity: MarkerSeverity.Info,
+			...setting.range,
+			message: EXPERIMENTAL_INDICATOR_DESCRIPTION
+		};
 	}
 
 	private addCodeActions(range: IRange, codeActions: languages.CodeAction[]): void {

--- a/src/vs/workbench/contrib/preferences/browser/settingsEditorSettingIndicators.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsEditorSettingIndicators.ts
@@ -19,7 +19,7 @@ import { ConfigurationTarget } from '../../../../platform/configuration/common/c
 import { IUserDataProfilesService } from '../../../../platform/userDataProfile/common/userDataProfile.js';
 import { IUserDataSyncEnablementService } from '../../../../platform/userDataSync/common/userDataSync.js';
 import { SettingsTreeSettingElement } from './settingsTreeModels.js';
-import { POLICY_SETTING_TAG } from '../common/preferences.js';
+import { EXPERIMENTAL_INDICATOR_DESCRIPTION, POLICY_SETTING_TAG, PREVIEW_INDICATOR_DESCRIPTION } from '../common/preferences.js';
 import { IWorkbenchConfigurationService } from '../../../services/configuration/common/configuration.js';
 import { IHoverService } from '../../../../platform/hover/browser/hover.js';
 import type { IHoverOptions, IHoverWidget } from '../../../../base/browser/ui/hover/hover.js';
@@ -328,9 +328,7 @@ export class SettingsTreeIndicatorsLabel implements IDisposable {
 			localize('previewLabel', "Preview") :
 			localize('experimentalLabel', "Experimental");
 
-		const content = isPreviewSetting ?
-			localize('previewSettingDescription', "The setting is in the process of becoming stable.") :
-			localize('experimentalSettingDescription', "The setting is experimental and may change names or be removed.");
+		const content = isPreviewSetting ? PREVIEW_INDICATOR_DESCRIPTION : EXPERIMENTAL_INDICATOR_DESCRIPTION;
 		const showHover = (focus: boolean) => {
 			return this.hoverService.showHover({
 				...this.defaultHoverOptions,

--- a/src/vs/workbench/contrib/preferences/common/preferences.ts
+++ b/src/vs/workbench/contrib/preferences/common/preferences.ts
@@ -7,6 +7,7 @@ import { raceTimeout } from '../../../../base/common/async.js';
 import { CancellationToken } from '../../../../base/common/cancellation.js';
 import { IStringDictionary } from '../../../../base/common/collections.js';
 import { IExtensionRecommendations } from '../../../../base/common/product.js';
+import { localize } from '../../../../nls.js';
 import { RawContextKey } from '../../../../platform/contextkey/common/contextkey.js';
 import { IExtensionGalleryService, IGalleryExtension } from '../../../../platform/extensionManagement/common/extensionManagement.js';
 import { createDecorator } from '../../../../platform/instantiation/common/instantiation.js';
@@ -174,3 +175,6 @@ export function compareTwoNullableNumbers(a: number | undefined, b: number | und
 		return 0;
 	}
 }
+
+export const PREVIEW_INDICATOR_DESCRIPTION = localize('previewIndicatorDescription', "This setting controls a feature that is in active development.");
+export const EXPERIMENTAL_INDICATOR_DESCRIPTION = localize('experimentalIndicatorDescription', "This setting controls a feature that may change or be removed in the future. Adjusting this setting may result in instability.");


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
This PR adds info markers to setting.json files for preview settings, and adds scaffolding to add info markers to setting.json files for experimental settings.

It also changes the descriptions of the preview and experimental indicators.

![Info markers in the form of blue squiggly underlines below a preview setting](https://github.com/user-attachments/assets/2039f1b8-7119-4ba5-ae0b-bd141e1e040e)

