### PR TITLE
preview image attachment from keyboard

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
@@ -767,29 +767,30 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 						fromUserGesture: true
 					};
 					if (range) {
-						// HACK: This uses text editor options but the opener service doesn't support that? It's not clear if this ever worked
-						// eslint-disable-next-line local/code-no-dangerous-type-assertions
-						options.editorOptions = {
+						const textEditorOptions: ITextEditorOptions = {
 							selection: range
-						} as ITextEditorOptions as any;
+						};
+						options.editorOptions = textEditorOptions;
 					}
 					this.openerService.open(file, options);
 				}));
 
 				store.add(dom.addDisposableListener(widget, dom.EventType.KEY_DOWN, (e: KeyboardEvent) => {
 					const event = new StandardKeyboardEvent(e);
-					if (event.equals(KeyCode.Enter)) {
+					if (event.equals(KeyCode.Enter) || event.equals(KeyCode.Space)) {
 						dom.EventHelper.stop(e, true);
 						const options: Mutable<OpenInternalOptions> = {
 							fromUserGesture: true
 						};
 						if (range) {
-							// eslint-disable-next-line local/code-no-dangerous-type-assertions
-							options.editorOptions = {
+							const textEditorOptions: ITextEditorOptions = {
 								selection: range
-							} as ITextEditorOptions as any;
+							};
+							options.editorOptions = textEditorOptions;
 						}
-						this.openerService.open(file, options);
+						this.openerService.open(file, options).then(() => {
+							this.focus();
+						});
 					}
 				}));
 			}

--- a/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
@@ -761,7 +761,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 
 			if (file) {
 				widget.style.cursor = 'pointer';
-				store.add(dom.addDisposableListener(widget, dom.EventType.CLICK, (e: MouseEvent) => {
+				store.add(dom.addDisposableListener(widget, dom.EventType.DBLCLICK, (e: MouseEvent) => {
 					dom.EventHelper.stop(e, true);
 					const options: Mutable<OpenInternalOptions> = {
 						fromUserGesture: true
@@ -774,6 +774,24 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 						} as ITextEditorOptions as any;
 					}
 					this.openerService.open(file, options);
+				}));
+
+				store.add(dom.addDisposableListener(widget, dom.EventType.KEY_DOWN, (e: KeyboardEvent) => {
+					const event =
+						new StandardKeyboardEvent(e);
+					if (event.equals(KeyCode.Enter)) {
+						dom.EventHelper.stop(e, true);
+						const options: Mutable<OpenInternalOptions> = {
+							fromUserGesture: true
+						};
+						if (range) {
+							// eslint-disable-next-line local/code-no-dangerous-type-assertions
+							options.editorOptions = {
+								selection: range
+							} as ITextEditorOptions as any;
+						}
+						this.openerService.open(file, options);
+					}
 				}));
 			}
 

--- a/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
@@ -761,7 +761,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 
 			if (file) {
 				widget.style.cursor = 'pointer';
-				store.add(dom.addDisposableListener(widget, dom.EventType.DBLCLICK, (e: MouseEvent) => {
+				store.add(dom.addDisposableListener(widget, dom.EventType.CLICK, (e: MouseEvent) => {
 					dom.EventHelper.stop(e, true);
 					const options: Mutable<OpenInternalOptions> = {
 						fromUserGesture: true
@@ -777,8 +777,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 				}));
 
 				store.add(dom.addDisposableListener(widget, dom.EventType.KEY_DOWN, (e: KeyboardEvent) => {
-					const event =
-						new StandardKeyboardEvent(e);
+					const event = new StandardKeyboardEvent(e);
 					if (event.equals(KeyCode.Enter)) {
 						dom.EventHelper.stop(e, true);
 						const options: Mutable<OpenInternalOptions> = {

--- a/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
@@ -788,9 +788,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 							};
 							options.editorOptions = textEditorOptions;
 						}
-						this.openerService.open(file, options).then(() => {
-							this.focus();
-						});
+						this.openerService.open(file, options);
 					}
 				}));
 			}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

ref: https://github.com/microsoft/vscode/issues/230951

- modifies preview in editor to double click
- press enter to preview in editor

considerations:
- previously we had `enter` immediately show the hover preview - was a bit wonky
- now we have it open in an editor. you can still preview via the hover from mousing over.