### PR TITLE
fix: allow to bypass confirmation dialogs for undoing and retrying edit requests

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/chatTitleActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatTitleActions.ts
@@ -10,6 +10,7 @@ import { ServicesAccessor } from '../../../../../editor/browser/editorExtensions
 import { IBulkEditService } from '../../../../../editor/browser/services/bulkEditService.js';
 import { localize, localize2 } from '../../../../../nls.js';
 import { Action2, MenuId, registerAction2 } from '../../../../../platform/actions/common/actions.js';
+import { IConfigurationService } from '../../../../../platform/configuration/common/configuration.js';
 import { ContextKeyExpr } from '../../../../../platform/contextkey/common/contextkey.js';
 import { IDialogService } from '../../../../../platform/dialogs/common/dialogs.js';
 import { KeybindingWeight } from '../../../../../platform/keybinding/common/keybindingsRegistry.js';
@@ -205,16 +206,27 @@ export function registerChatTitleActions() {
 			}
 			const itemIndex = chatRequests?.findIndex(request => request.id === item.requestId);
 			if (chatModel?.initialLocation === ChatAgentLocation.EditingSession) {
+				const configurationService = accessor.get(IConfigurationService);
 				const dialogService = accessor.get(IDialogService);
-				const confirmation = await dialogService.confirm({
-					title: localize('chat.removeLast.confirmation.title', "Do you want to retry your last edit?"),
-					message: localize('chat.remove.confirmation.message', "This will also undo any edits made to your working set from this request."),
-					primaryButton: localize('chat.remove.confirmation.primaryButton', "Yes"),
-					type: 'info'
-				});
-				if (!confirmation) {
+				const shouldPrompt = configurationService.getValue('chat.editing.confirmEditRequestRetry') === true;
+				const confirmation = shouldPrompt
+					? await dialogService.confirm({
+						title: localize('chat.retryLast.confirmation.title', "Do you want to retry your last edit?"),
+						message: localize('chat.retry.confirmation.message', "This will also undo any edits made to your working set from this request."),
+						primaryButton: localize('chat.retry.confirmation.primaryButton', "Yes"),
+						checkbox: { label: localize('chat.retry.confirmation.checkbox', "Don't ask again"), checked: false },
+						type: 'info'
+					})
+					: { confirmed: true };
+
+				if (!confirmation.confirmed) {
 					return;
 				}
+
+				if (confirmation.checkboxChecked) {
+					await configurationService.updateValue('chat.editing.confirmEditRequestRetry', false);
+				}
+
 				// Reset the snapshot
 				const snapshotRequest = chatRequests[itemIndex];
 				if (snapshotRequest) {

--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -123,6 +123,18 @@ configurationRegistry.registerConfiguration({
 			markdownDescription: nls.localize('chat.editing.alwaysSaveWithGeneratedChanges', "Whether to always ask before saving files with changes made by chat."),
 			default: false,
 		},
+		'chat.editing.confirmEditRequestRemoval': {
+			type: 'boolean',
+			scope: ConfigurationScope.APPLICATION,
+			markdownDescription: nls.localize('chat.editing.confirmEditRequestRemoval', "Whether to show a confirmation before removing a request and its associated edits."),
+			default: true,
+		},
+		'chat.editing.confirmEditRequestRetry': {
+			type: 'boolean',
+			scope: ConfigurationScope.APPLICATION,
+			markdownDescription: nls.localize('chat.editing.confirmEditRequestRetry', "Whether to show a confirmation before retrying a request and its associated edits."),
+			default: true,
+		},
 		'chat.experimental.variables.editor': {
 			type: 'boolean',
 			description: nls.localize('chat.experimental.variables.editor', "Enables variables for editor chat."),


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
