### PR TITLE
fix: open diffs button in chat editing widget is not visible in light theme

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/media/chat.css
@@ -624,7 +624,8 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	background-color: var(--vscode-button-secondaryHoverBackground);
 }
 
-.interactive-session .chat-editing-session .chat-editing-session-actions .monaco-button.secondary.codicon:hover {
+.interactive-session .chat-editing-session .chat-editing-session-actions .monaco-button.secondary.codicon:hover,
+.interactive-session .chat-editing-session .chat-editing-session-toolbar-actions .monaco-button.secondary:hover {
 	background-color: var(--vscode-toolbar-hoverBackground);
 }
 

--- a/src/vs/workbench/contrib/chat/browser/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/media/chat.css
@@ -606,6 +606,7 @@ have to be updated for changes to the rules above, or to support more deeply nes
 .interactive-session .chat-editing-session .chat-editing-session-actions .monaco-button.secondary.codicon {
 	background-color: transparent;
 	border-color: transparent;
+	color: var(--vscode-foreground);
 	cursor: pointer;
 	height: 16px;
 	padding: 0px;
@@ -621,6 +622,10 @@ have to be updated for changes to the rules above, or to support more deeply nes
 .interactive-session .chat-editing-session .chat-editing-session-toolbar-actions .monaco-button.secondary:hover,
 .interactive-session .chat-editing-session .chat-editing-session-actions .monaco-button.secondary:hover {
 	background-color: var(--vscode-button-secondaryHoverBackground);
+}
+
+.interactive-session .chat-editing-session .chat-editing-session-actions .monaco-button.secondary.codicon:hover {
+	background-color: var(--vscode-toolbar-hoverBackground);
 }
 
 .interactive-session .chat-editing-session .chat-editing-session-toolbar-actions .monaco-button,


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
