### PR TITLE
inline edits: add a new keybinding `cmd+enter` to accept suggestion (1) without jumping to the edit and (2) to accept when there's a selection (currently `tab` shortcut for accepting an inline suggestion doesn't allow accepting when there's user selection to not disable indenting the selected code)

### DIFF
--- a/src/vs/editor/contrib/inlineCompletions/browser/controller/commands.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/controller/commands.ts
@@ -150,30 +150,43 @@ export class AcceptInlineCompletion extends EditorAction {
 				group: 'primary',
 				order: 1,
 			}],
-			kbOpts: {
-				primary: KeyCode.Tab,
-				weight: 200,
-				kbExpr: ContextKeyExpr.or(
-					ContextKeyExpr.and(
-						InlineCompletionContextKeys.inlineSuggestionVisible,
-						EditorContextKeys.tabMovesFocus.toNegated(),
-						SuggestContext.Visible.toNegated(),
-						EditorContextKeys.hoverFocused.toNegated(),
+			kbOpts: [
+				{
+					primary: KeyCode.Tab,
+					weight: 200,
+					kbExpr: ContextKeyExpr.or(
+						ContextKeyExpr.and(
+							InlineCompletionContextKeys.inlineSuggestionVisible,
+							EditorContextKeys.tabMovesFocus.toNegated(),
+							SuggestContext.Visible.toNegated(),
+							EditorContextKeys.hoverFocused.toNegated(),
 
-						InlineCompletionContextKeys.inlineSuggestionHasIndentationLessThanTabSize,
+							InlineCompletionContextKeys.inlineSuggestionHasIndentationLessThanTabSize,
+						),
+						ContextKeyExpr.and(
+							InlineCompletionContextKeys.inlineEditVisible,
+							EditorContextKeys.tabMovesFocus.toNegated(),
+							SuggestContext.Visible.toNegated(),
+							EditorContextKeys.hoverFocused.toNegated(),
+
+							//InlineCompletionContextKeys.cursorInIndentation.toNegated(),
+							InlineCompletionContextKeys.hasSelection.toNegated(),
+							InlineCompletionContextKeys.cursorAtInlineEdit,
+						)
 					),
-					ContextKeyExpr.and(
+				},
+				{
+					primary: KeyMod.CtrlCmd | KeyCode.Enter,
+					weight: 200,
+					kbExpr: ContextKeyExpr.and(
+						EditorContextKeys.editorTextFocus,
 						InlineCompletionContextKeys.inlineEditVisible,
-						EditorContextKeys.tabMovesFocus.toNegated(),
 						SuggestContext.Visible.toNegated(),
 						EditorContextKeys.hoverFocused.toNegated(),
-
-						//InlineCompletionContextKeys.cursorInIndentation.toNegated(),
-						InlineCompletionContextKeys.hasSelection.toNegated(),
-						InlineCompletionContextKeys.cursorAtInlineEdit,
-					)
-				),
-			}
+						EditorContextKeys.tabMovesFocus.toNegated(),
+					),
+				}
+			],
 		});
 	}
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
