### PR TITLE
fix: Use a proper desktop name in package.json

### DIFF
--- a/build/gulpfile.vscode.js
+++ b/build/gulpfile.vscode.js
@@ -276,9 +276,8 @@ function packageTask(platform, arch, sourceFolderName, destinationFolderName, op
 		const name = product.nameShort;
 		const packageJsonUpdates = { name, version };
 
-		// for linux url handling
 		if (platform === 'linux') {
-			packageJsonUpdates.desktopName = `${product.applicationName}-url-handler.desktop`;
+			packageJsonUpdates.desktopName = `${product.applicationName}.desktop`;
 		}
 
 		let packageJsonContents;


### PR DESCRIPTION
Fixes #154693

Initally, this part is required due to how Electron handles the prorotol registeration as in https://github.com/microsoft/vscode/pull/56727#issuecomment-420701045 ( I also explained in https://github.com/microsoft/vscode/issues/154693#issuecomment-2409830275 )

However since https://github.com/microsoft/vscode/commit/986b5532b5df1b95517f1ab134c19e8490e6a825 that part is no longer used for protocol registeration on Linux, and since Electron 18, Electron uses the desktop file name to set the `app_id` in Wayland, and it was given the wrong one. This change fixes the problem where running VS Code on Wayland would have the `app_id` of `code-url-handler` which is unreasonable.

## Test steps

* Provision a new Linux machine / VM with a desktop environment with Wayland session
* Build the package
* Ensure the two .desktop files are installed properly
* Run VS Code with the environment variable `ELECTRON_OZONE_PLATFORM_HINT=wayland`
* Check if VS Code had the `app_id` of `code`

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
