### PR TITLE
Enable terminal chat variables by default

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/actions/chatContextActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatContextActions.ts
@@ -229,9 +229,9 @@ export class AttachContextAction extends Action2 {
 	// used to enable/disable the keybinding and defined menu containment
 	private static _cdt = ContextKeyExpr.or(
 		ContextKeyExpr.and(CONTEXT_CHAT_LOCATION.isEqualTo(ChatAgentLocation.Panel)),
-		ContextKeyExpr.and(CONTEXT_CHAT_LOCATION.isEqualTo(ChatAgentLocation.Editor), ContextKeyExpr.equals('config.chat.experimental.variables.editor', true)),
-		ContextKeyExpr.and(CONTEXT_CHAT_LOCATION.isEqualTo(ChatAgentLocation.Notebook), ContextKeyExpr.equals('config.chat.experimental.variables.notebook', true)),
-		ContextKeyExpr.and(CONTEXT_CHAT_LOCATION.isEqualTo(ChatAgentLocation.Terminal), ContextKeyExpr.equals('config.chat.experimental.variables.terminal', true)),
+		ContextKeyExpr.and(CONTEXT_CHAT_LOCATION.isEqualTo(ChatAgentLocation.Editor)),
+		ContextKeyExpr.and(CONTEXT_CHAT_LOCATION.isEqualTo(ChatAgentLocation.Notebook)),
+		ContextKeyExpr.and(CONTEXT_CHAT_LOCATION.isEqualTo(ChatAgentLocation.Terminal)),
 	);
 
 	constructor() {

--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -135,21 +135,6 @@ configurationRegistry.registerConfiguration({
 			markdownDescription: nls.localize('chat.editing.confirmEditRequestRetry', "Whether to show a confirmation before retrying a request and its associated edits."),
 			default: true,
 		},
-		'chat.experimental.variables.editor': {
-			type: 'boolean',
-			description: nls.localize('chat.experimental.variables.editor', "Enables variables for editor chat."),
-			default: true
-		},
-		'chat.experimental.variables.notebook': {
-			type: 'boolean',
-			description: nls.localize('chat.experimental.variables.notebook', "Enables variables for notebook chat."),
-			default: true
-		},
-		'chat.experimental.variables.terminal': {
-			type: 'boolean',
-			description: nls.localize('chat.experimental.variables.terminal', "Enables variables for terminal chat."),
-			default: true
-		},
 		'chat.experimental.detectParticipant.enabled': {
 			type: 'boolean',
 			description: nls.localize('chat.experimental.detectParticipant.enabled', "Enables chat participant autodetection for panel chat."),

--- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
@@ -148,7 +148,7 @@ configurationRegistry.registerConfiguration({
 		'chat.experimental.variables.terminal': {
 			type: 'boolean',
 			description: nls.localize('chat.experimental.variables.terminal', "Enables variables for terminal chat."),
-			default: false
+			default: true
 		},
 		'chat.experimental.detectParticipant.enabled': {
 			type: 'boolean',


### PR DESCRIPTION
Fixes #229855

After https://github.com/microsoft/vscode/pull/231479 I don't think there are any problems with terminal chat variables. We can also consider removing the settings completely?