### PR TITLE
feat: enable experimental setting indicators

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/preferencesRenderers.ts
+++ b/src/vs/workbench/contrib/preferences/browser/preferencesRenderers.ts
@@ -699,11 +699,9 @@ class UnsupportedSettingsRenderer extends Disposable implements languages.CodeAc
 	private handleUnstableSettingConfiguration(setting: ISetting, configuration: IConfigurationPropertySchema, markerData: IMarkerData[]): void {
 		if (configuration.tags?.includes('preview')) {
 			markerData.push(this.generatePreviewSettingMarker(setting));
+		} else if (configuration.tags?.includes('experimental')) {
+			markerData.push(this.generateExperimentalSettingMarker(setting));
 		}
-		// Enable after further review and experimental -> onExP migration
-		// if (configuration.tags?.includes('experimental')) {
-		// 	markerData.push(this.generateExperimentalSettingMarker(setting));
-		// }
 	}
 
 	private generateUnsupportedApplicationSettingMarker(setting: ISetting): IMarkerData {
@@ -761,7 +759,6 @@ class UnsupportedSettingsRenderer extends Disposable implements languages.CodeAc
 		};
 	}
 
-	// @ts-expect-error
 	private generateExperimentalSettingMarker(setting: ISetting): IMarkerData {
 		return {
 			severity: MarkerSeverity.Info,

--- a/src/vs/workbench/contrib/preferences/browser/settingsEditorSettingIndicators.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsEditorSettingIndicators.ts
@@ -321,8 +321,7 @@ export class SettingsTreeIndicatorsLabel implements IDisposable {
 
 	updatePreviewIndicator(element: SettingsTreeSettingElement) {
 		const isPreviewSetting = element.tags?.has('preview');
-		// Hide experimental indicators for now until further review and experimental -> onExP migration.
-		const isExperimentalSetting = false; // element.tags?.has('experimental');
+		const isExperimentalSetting = element.tags?.has('experimental');
 		this.previewIndicator.element.style.display = (isPreviewSetting || isExperimentalSetting) ? 'inline' : 'none';
 		this.previewIndicator.label.text = isPreviewSetting ?
 			localize('previewLabel', "Preview") :


### PR DESCRIPTION
Enables experimental setting indicators in both the Settings editor and in settings JSON files after checking core and some extension experimental settings.