### PR TITLE
Try to avoid writing full inline refs blobs to markdown stream

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatInlineAnchorWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatInlineAnchorWidget.ts
@@ -39,13 +39,20 @@ import { fillEditorsDragData } from '../../../browser/dnd.js';
 import { ResourceContextKey } from '../../../common/contextkeys.js';
 import { OPEN_TO_SIDE_COMMAND_ID } from '../../files/browser/fileConstants.js';
 import { ExplorerFolderContext } from '../../files/common/files.js';
-import { ContentRefData } from '../common/annotations.js';
+import { IWorkspaceSymbol } from '../../search/common/search.js';
+import { IChatContentInlineReference } from '../common/chatService.js';
 import { IChatVariablesService } from '../common/chatVariables.js';
 import { IChatWidgetService } from './chat.js';
 import { IChatMarkdownAnchorService } from './chatContentParts/chatMarkdownAnchorService.js';
 
 const chatResourceContextKey = new RawContextKey<string>('chatAnchorResource', undefined, { type: 'URI', description: localize('resource', "The full value of the chat anchor resource, including scheme and path") });
-
+type ContentRefData =
+	| { readonly kind: 'symbol'; readonly symbol: IWorkspaceSymbol }
+	| {
+		readonly kind?: undefined;
+		readonly uri: URI;
+		readonly range?: IRange;
+	};
 
 export class InlineAnchorWidget extends Disposable {
 
@@ -53,9 +60,11 @@ export class InlineAnchorWidget extends Disposable {
 
 	private readonly _chatResourceContext: IContextKey<string>;
 
+	readonly data: ContentRefData;
+
 	constructor(
 		private readonly element: HTMLAnchorElement | HTMLElement,
-		public readonly data: ContentRefData,
+		public readonly inlineReference: IChatContentInlineReference,
 		@IContextKeyService originalContextKeyService: IContextKeyService,
 		@IContextMenuService contextMenuService: IContextMenuService,
 		@IFileService fileService: IFileService,
@@ -70,6 +79,12 @@ export class InlineAnchorWidget extends Disposable {
 	) {
 		super();
 
+		this.data = 'uri' in inlineReference.inlineReference
+			? inlineReference.inlineReference
+			: 'name' in inlineReference.inlineReference
+				? { kind: 'symbol', symbol: inlineReference.inlineReference }
+				: { uri: inlineReference.inlineReference };
+
 		const contextKeyService = this._register(originalContextKeyService.createScoped(element));
 		this._chatResourceContext = chatResourceContextKey.bindTo(contextKeyService);
 
@@ -83,13 +98,13 @@ export class InlineAnchorWidget extends Disposable {
 		let location: { readonly uri: URI; readonly range?: IRange };
 		let contextMenuId: MenuId;
 		let contextMenuArg: URI | { readonly uri: URI; readonly range?: IRange };
-		if (data.kind === 'symbol') {
-			location = data.symbol.location;
+		if (this.data.kind === 'symbol') {
+			location = this.data.symbol.location;
 			contextMenuId = MenuId.ChatInlineSymbolAnchorContext;
 			contextMenuArg = location;
 
-			iconText = data.symbol.name;
-			iconClasses = ['codicon', ...getIconClasses(modelService, languageService, undefined, undefined, SymbolKinds.toIcon(data.symbol.kind))];
+			iconText = this.data.symbol.name;
+			iconClasses = ['codicon', ...getIconClasses(modelService, languageService, undefined, undefined, SymbolKinds.toIcon(this.data.symbol.kind))];
 
 			const model = modelService.getModel(location.uri);
 			if (model) {
@@ -120,7 +135,7 @@ export class InlineAnchorWidget extends Disposable {
 				});
 			}));
 		} else {
-			location = data;
+			location = this.data;
 			contextMenuId = MenuId.ChatInlineResourceAnchorContext;
 			contextMenuArg = location.uri;
 
@@ -129,7 +144,7 @@ export class InlineAnchorWidget extends Disposable {
 			this._chatResourceContext.set(location.uri.toString());
 
 			const label = labelService.getUriBasenameLabel(location.uri);
-			iconText = location.range && data.kind !== 'symbol' ?
+			iconText = location.range && this.data.kind !== 'symbol' ?
 				`${label}#${location.range.startLineNumber}-${location.range.endLineNumber}` :
 				label;
 

--- a/src/vs/workbench/contrib/chat/browser/chatListRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatListRenderer.ts
@@ -16,7 +16,7 @@ import { coalesce, distinct } from '../../../../base/common/arrays.js';
 import { Codicon } from '../../../../base/common/codicons.js';
 import { Emitter, Event } from '../../../../base/common/event.js';
 import { FuzzyScore } from '../../../../base/common/filters.js';
-import { IMarkdownString, MarkdownString } from '../../../../base/common/htmlContent.js';
+import { MarkdownString } from '../../../../base/common/htmlContent.js';
 import { KeyCode } from '../../../../base/common/keyCodes.js';
 import { Disposable, DisposableStore, IDisposable, dispose, toDisposable } from '../../../../base/common/lifecycle.js';
 import { ResourceMap } from '../../../../base/common/map.js';
@@ -47,7 +47,7 @@ import { CONTEXT_CHAT_RESPONSE_SUPPORT_ISSUE_REPORTING, CONTEXT_ITEM_ID, CONTEXT
 import { isChatRequestCheckpointed } from '../common/chatEditingService.js';
 import { IChatRequestVariableEntry, IChatTextEditGroup } from '../common/chatModel.js';
 import { chatSubcommandLeader } from '../common/chatParserTypes.js';
-import { ChatAgentVoteDirection, ChatAgentVoteDownReason, IChatConfirmation, IChatContentReference, IChatFollowup, IChatTask, IChatToolInvocation, IChatToolInvocationSerialized, IChatTreeData } from '../common/chatService.js';
+import { ChatAgentVoteDirection, ChatAgentVoteDownReason, IChatConfirmation, IChatContentReference, IChatFollowup, IChatMarkdownContent, IChatTask, IChatToolInvocation, IChatToolInvocationSerialized, IChatTreeData } from '../common/chatService.js';
 import { IChatCodeCitations, IChatReferences, IChatRendererContent, IChatRequestViewModel, IChatResponseViewModel, isRequestVM, isResponseVM } from '../common/chatViewModel.js';
 import { getNWords } from '../common/chatWordCounter.js';
 import { CodeBlockModelCollection } from '../common/codeBlockModelCollection.js';
@@ -720,7 +720,7 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 				} else {
 					// Only taking part of this markdown part
 					moreContentAvailable = true;
-					partsToRender.push({ kind: 'markdownContent', content: new MarkdownString(wordCountResult.value, part.content) });
+					partsToRender.push({ ...part, content: new MarkdownString(wordCountResult.value, part.content) });
 				}
 
 				if (numNeededWords <= 0) {
@@ -796,7 +796,7 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 		} else if (content.kind === 'warning') {
 			return this.instantiationService.createInstance(ChatWarningContentPart, 'warning', content.content, this.renderer);
 		} else if (content.kind === 'markdownContent') {
-			return this.renderMarkdown(content.content, templateData, context);
+			return this.renderMarkdown(content, templateData, context);
 		} else if (content.kind === 'references') {
 			return this.renderContentReferencesListData(content, undefined, context, templateData);
 		} else if (content.kind === 'codeCitations') {
@@ -894,7 +894,7 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 		return textEditPart;
 	}
 
-	private renderMarkdown(markdown: IMarkdownString, templateData: IChatListItemTemplate, context: IChatContentPartRenderContext): IChatContentPart {
+	private renderMarkdown(markdown: IChatMarkdownContent, templateData: IChatListItemTemplate, context: IChatContentPartRenderContext): IChatContentPart {
 		const element = context.element;
 		const fillInIncompleteTokens = isResponseVM(element) && (!element.isComplete || element.isCanceled || element.errorDetails?.responseIsFiltered || element.errorDetails?.responseIsIncomplete || !!element.renderData);
 		const codeBlockStartIndex = context.preceedingContentParts.reduce((acc, part) => acc + (part instanceof ChatMarkdownContentPart ? part.codeblocks.length : 0), 0);

--- a/src/vs/workbench/contrib/chat/common/annotations.ts
+++ b/src/vs/workbench/contrib/chat/common/annotations.ts
@@ -5,20 +5,12 @@
 import { MarkdownString } from '../../../../base/common/htmlContent.js';
 import { basename } from '../../../../base/common/resources.js';
 import { URI } from '../../../../base/common/uri.js';
+import { generateUuid } from '../../../../base/common/uuid.js';
 import { IRange } from '../../../../editor/common/core/range.js';
-import { IWorkspaceSymbol } from '../../search/common/search.js';
 import { IChatProgressRenderableResponseContent, IChatProgressResponseContent, appendMarkdownString, canMergeMarkdownStrings } from './chatModel.js';
 import { IChatAgentVulnerabilityDetails, IChatMarkdownContent } from './chatService.js';
 
 export const contentRefUrl = 'http://_vscodecontentref_'; // must be lowercase for URI
-
-export type ContentRefData =
-	| { readonly kind: 'symbol'; readonly symbol: IWorkspaceSymbol }
-	| {
-		readonly kind?: undefined;
-		readonly uri: URI;
-		readonly range?: IRange;
-	};
 
 export function annotateSpecialMarkdownContent(response: ReadonlyArray<IChatProgressResponseContent>): IChatProgressRenderableResponseContent[] {
 	const result: IChatProgressRenderableResponseContent[] = [];
@@ -26,39 +18,39 @@ export function annotateSpecialMarkdownContent(response: ReadonlyArray<IChatProg
 		const previousItem = result.filter(p => p.kind !== 'textEditGroup').at(-1);
 		const previousItemIndex = result.findIndex(p => p === previousItem);
 		if (item.kind === 'inlineReference') {
-			const location: ContentRefData = 'uri' in item.inlineReference
-				? item.inlineReference
-				: 'name' in item.inlineReference
-					? { kind: 'symbol', symbol: item.inlineReference }
-					: { uri: item.inlineReference };
-
-			const printUri = URI.parse(contentRefUrl).with({ fragment: JSON.stringify(location) });
 			let label: string | undefined = item.name;
 			if (!label) {
-				if (location.kind === 'symbol') {
-					label = location.symbol.name;
+				if (URI.isUri(item.inlineReference)) {
+					label = basename(item.inlineReference);
+				} else if ('name' in item.inlineReference) {
+					label = item.inlineReference.name;
 				} else {
-					label = basename(location.uri);
+					label = basename(item.inlineReference.uri);
 				}
 			}
 
+			const refId = generateUuid();
+			const printUri = URI.parse(contentRefUrl).with({ path: refId });
 			const markdownText = `[${label}](${printUri.toString()})`;
+
+			const annotationMetadata = { [refId]: item };
+
 			if (previousItem?.kind === 'markdownContent') {
 				const merged = appendMarkdownString(previousItem.content, new MarkdownString(markdownText));
-				result[previousItemIndex] = { content: merged, kind: 'markdownContent' };
+				result[previousItemIndex] = { ...previousItem, content: merged, inlineReferences: { ...annotationMetadata, ...(previousItem.inlineReferences || {}) } };
 			} else {
-				result.push({ content: new MarkdownString(markdownText), kind: 'markdownContent' });
+				result.push({ content: new MarkdownString(markdownText), inlineReferences: annotationMetadata, kind: 'markdownContent' });
 			}
 		} else if (item.kind === 'markdownContent' && previousItem?.kind === 'markdownContent' && canMergeMarkdownStrings(previousItem.content, item.content)) {
 			const merged = appendMarkdownString(previousItem.content, item.content);
-			result[previousItemIndex] = { content: merged, kind: 'markdownContent' };
+			result[previousItemIndex] = { ...previousItem, content: merged };
 		} else if (item.kind === 'markdownVuln') {
 			const vulnText = encodeURIComponent(JSON.stringify(item.vulnerabilities));
 			const markdownText = `<vscode_annotation details='${vulnText}'>${item.content.value}</vscode_annotation>`;
 			if (previousItem?.kind === 'markdownContent') {
 				// Since this is inside a codeblock, it needs to be merged into the previous markdown content.
 				const merged = appendMarkdownString(previousItem.content, new MarkdownString(markdownText));
-				result[previousItemIndex] = { content: merged, kind: 'markdownContent' };
+				result[previousItemIndex] = { ...previousItem, content: merged };
 			} else {
 				result.push({ content: new MarkdownString(markdownText), kind: 'markdownContent' });
 			}
@@ -66,7 +58,7 @@ export function annotateSpecialMarkdownContent(response: ReadonlyArray<IChatProg
 			if (previousItem?.kind === 'markdownContent') {
 				const markdownText = `<vscode_codeblock_uri>${item.uri.toString()}</vscode_codeblock_uri>`;
 				const merged = appendMarkdownString(previousItem.content, new MarkdownString(markdownText));
-				result[previousItemIndex] = { content: merged, kind: 'markdownContent' };
+				result[previousItemIndex] = { ...previousItem, content: merged };
 			}
 		} else {
 			result.push(item);

--- a/src/vs/workbench/contrib/chat/common/chatService.ts
+++ b/src/vs/workbench/contrib/chat/common/chatService.ts
@@ -112,6 +112,7 @@ export interface IChatAgentDetection {
 
 export interface IChatMarkdownContent {
 	content: IMarkdownString;
+	inlineReferences?: Record<string, IChatContentInlineReference>;
 	kind: 'markdownContent';
 }
 

--- a/src/vs/workbench/contrib/chat/test/common/__snapshots__/Annotations_extractVulnerabilitiesFromText_multiline.0.snap
+++ b/src/vs/workbench/contrib/chat/test/common/__snapshots__/Annotations_extractVulnerabilitiesFromText_multiline.0.snap
@@ -1,12 +1,12 @@
 [
   {
+    kind: "markdownContent",
     content: {
       value: "some code\nover\nmultiple lines <vscode_annotation details='%5B%7B%22title%22%3A%22title%22%2C%22description%22%3A%22vuln%22%7D%5D'>content with vuln\nand\nnewlines</vscode_annotation>more code\nwith newline",
       isTrusted: false,
       supportThemeIcons: false,
       supportHtml: false,
       baseUri: undefined
-    },
-    kind: "markdownContent"
+    }
   }
 ]

--- a/src/vs/workbench/contrib/chat/test/common/__snapshots__/Annotations_extractVulnerabilitiesFromText_multiple_vulns.0.snap
+++ b/src/vs/workbench/contrib/chat/test/common/__snapshots__/Annotations_extractVulnerabilitiesFromText_multiple_vulns.0.snap
@@ -1,12 +1,12 @@
 [
   {
+    kind: "markdownContent",
     content: {
       value: "some code\nover\nmultiple lines <vscode_annotation details='%5B%7B%22title%22%3A%22title%22%2C%22description%22%3A%22vuln%22%7D%5D'>content with vuln\nand\nnewlines</vscode_annotation>more code\nwith newline<vscode_annotation details='%5B%7B%22title%22%3A%22title%22%2C%22description%22%3A%22vuln%22%7D%5D'>content with vuln\nand\nnewlines</vscode_annotation>",
       isTrusted: false,
       supportThemeIcons: false,
       supportHtml: false,
       baseUri: undefined
-    },
-    kind: "markdownContent"
+    }
   }
 ]

--- a/src/vs/workbench/contrib/chat/test/common/__snapshots__/Annotations_extractVulnerabilitiesFromText_single_line.0.snap
+++ b/src/vs/workbench/contrib/chat/test/common/__snapshots__/Annotations_extractVulnerabilitiesFromText_single_line.0.snap
@@ -1,12 +1,12 @@
 [
   {
+    kind: "markdownContent",
     content: {
       value: "some code <vscode_annotation details='%5B%7B%22title%22%3A%22title%22%2C%22description%22%3A%22vuln%22%7D%5D'>content with vuln</vscode_annotation> after",
       isTrusted: false,
       supportThemeIcons: false,
       supportHtml: false,
       baseUri: undefined
-    },
-    kind: "markdownContent"
+    }
   }
 ]


### PR DESCRIPTION
Instead of writing all the inline reference metadata as a fake markdown link which can be extremely long, this switches to write out a fake link with just a id path. We can then use this to look up the actual metadata

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
