### PR TITLE
Fix caching bug with multiple workspaces

### DIFF
--- a/src/vs/workbench/contrib/files/browser/views/explorerView.ts
+++ b/src/vs/workbench/contrib/files/browser/views/explorerView.ts
@@ -191,7 +191,7 @@ class ExplorerFindProvider implements IAsyncFindProvider<ExplorerItem> {
 				filePattern: isFuzzyMatch ? pattern : `**/*${pattern}*`,
 				maxResults: 512,
 				sortByScore: true,
-				cacheKey: `explorerfindprovider:${sessionId}`,
+				cacheKey: `explorerfindprovider:${folder.index}:${sessionId}`,
 				excludePattern: searchExcludePattern,
 			}, token);
 


### PR DESCRIPTION
This PR addresses a caching issue that arose when using multiple workspaces. The cache key for the `ExplorerFindProvider` has been updated to include the folder index, ensuring that searches are correctly scoped to the respective workspace. 

fixes: #231604