### PR TITLE
Fix chat attachment container resizing

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
@@ -699,13 +699,12 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		onDidChangeCursorPosition();
 	}
 
-	private async renderAttachedContext(isLayout = false) {
+	private async renderAttachedContext() {
 		const container = this.attachedContextContainer;
-		this.attachedContextDisposables.clear();
-		const store = new DisposableStore;
+		const oldHeight = container.offsetHeight;
+		const store = new DisposableStore();
 		this.attachedContextDisposables.value = store;
 
-		const oldHeight = container.offsetHeight;
 		dom.clearNode(container);
 		const hoverDelegate = store.add(createInstantHoverDelegate());
 		dom.setVisibility(Boolean(this.attachmentModel.size) || Boolean(this.implicitContext.value), this.attachedContextContainer);
@@ -831,7 +830,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 			widget.ariaLabel = ariaLabel;
 		}
 
-		if (oldHeight !== container.offsetHeight && !isLayout) {
+		if (oldHeight !== container.offsetHeight) {
 			this._onDidChangeHeight.fire();
 		}
 	}
@@ -870,7 +869,6 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 				this.focus();
 			}
 
-			this._onDidChangeHeight.fire();
 			this._onDidChangeContext.fire({ removed: [attachment] });
 		});
 		store.add(disp);
@@ -1061,8 +1059,6 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 
 	private previousInputEditorDimension: IDimension | undefined;
 	private _layout(height: number, width: number, allowRecurse = true): void {
-		this.renderAttachedContext(true);
-
 		const data = this.getLayoutData();
 		const inputEditorHeight = Math.min(data.inputPartEditorHeight, height - data.followupsHeight - data.attachmentsHeight - data.inputPartVerticalPadding - data.toolbarsHeight);
 


### PR DESCRIPTION
- Don't render attachments during layout. It's async and always gets sized to the height of one attachment because that's all that has rendered
- Measure oldHeight before disposing previously rendered things
- Don't fire onDidChangeHeight immediately when the button is clicked, this also starts a layout while a render is happening

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
