### PR TITLE
Restore viewport context when no selection

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/attachments/implicitContextAttachment.ts
+++ b/src/vs/workbench/contrib/chat/browser/attachments/implicitContextAttachment.ts
@@ -41,7 +41,7 @@ export class ImplicitContextAttachmentWidget extends Disposable {
 		this.domNode.classList.toggle('disabled', !this.attachment.enabled);
 		const label = this.resourceLabels.create(this.domNode, { supportIcons: true });
 		const file = URI.isUri(this.attachment.value) ? this.attachment.value : this.attachment.value!.uri;
-		const range = URI.isUri(this.attachment.value) ? undefined : this.attachment.value!.range;
+		const range = URI.isUri(this.attachment.value) || !this.attachment.isSelection ? undefined : this.attachment.value!.range;
 
 		const fileBasename = basename(file);
 		const fileDirname = dirname(file);

--- a/src/vs/workbench/contrib/chat/common/chatModel.ts
+++ b/src/vs/workbench/contrib/chat/common/chatModel.ts
@@ -49,6 +49,7 @@ export interface IBaseChatRequestVariableEntry {
 export interface IChatRequestImplicitVariableEntry extends Omit<IBaseChatRequestVariableEntry, 'kind'> {
 	readonly kind: 'implicit';
 	readonly value: URI | Location | undefined;
+	readonly isSelection: boolean;
 	enabled: boolean;
 }
 


### PR DESCRIPTION
Was including the full file, after the implicit context widget was added. This sends a Location as the reference value for the current viewport.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
