### PR TITLE
ci: cleanup snap publishing step

### DIFF
--- a/build/azure-pipelines/linux/snap-build-linux.yml
+++ b/build/azure-pipelines/linux/snap-build-linux.yml
@@ -20,17 +20,10 @@ steps:
       # Make sure we get latest packages
       sudo apt-get update
       sudo apt-get upgrade -y
-      sudo apt-get install -y curl apt-transport-https ca-certificates make g++
-
-      curl --version
-      make --version
-      g++ --version
+      sudo apt-get install -y curl apt-transport-https ca-certificates
 
       # Define variables
       SNAP_ROOT="$(pwd)/.build/linux/snap/$(VSCODE_ARCH)"
-
-      # Install build dependencies
-      (cd build && npm ci)
 
       # Unpack snap tarball artifact, in order to preserve file perms
       (cd .build/linux && tar -xzf snap-tarball/snap-$(VSCODE_ARCH).tar.gz)


### PR DESCRIPTION
Removes unused build dependency setup in the snap pipeline.

Sanity build: https://monacotools.visualstudio.com/Monaco/_build/results?buildId=299860&view=results