### PR TITLE
Improve error logging for missing tree nodes

### DIFF
--- a/src/vs/base/browser/ui/tree/asyncDataTree.ts
+++ b/src/vs/base/browser/ui/tree/asyncDataTree.ts
@@ -1219,7 +1219,8 @@ export class AsyncDataTree<TInput, T, TFilterData = void> implements IDisposable
 		const node: IAsyncDataTreeNode<TInput, T> | undefined = this.nodes.get((element === this.root.element ? null : element) as T);
 
 		if (!node) {
-			throw new TreeError(this.user, `Data tree node not found: ${element}`);
+			const nodeIdentity = this.identityProvider?.getId(element as T).toString();
+			throw new TreeError(this.user, `Data tree node not found${nodeIdentity ? `: ${nodeIdentity}` : ''}`);
 		}
 
 		return node;


### PR DESCRIPTION
Enhance the error message when a data tree node is not found by including the node's id, if available.