### PR TITLE
chore: enable Defender for Linux

### DIFF
--- a/build/azure-pipelines/product-build.yml
+++ b/build/azure-pipelines/product-build.yml
@@ -171,6 +171,8 @@ resources:
 extends:
   template: v1/1ES.Official.PipelineTemplate.yml@1esPipelines
   parameters:
+    featureFlags:
+      EnableDefenderForLinux: true
     sdl:
       tsa:
         enabled: true


### PR DESCRIPTION
Verification build to check the pipeline could start up even with all boxes checked: https://dev.azure.com/monacotools/Monaco/_build/results?buildId=300007&view=results
Verification build to check the pipeline runs as expected with a sample of builds: https://dev.azure.com/monacotools/Monaco/_build/results?buildId=300008&view=results