### PR TITLE
Put `hasNode` check if refreshing particular elements

### DIFF
--- a/src/vs/workbench/contrib/search/browser/searchView.ts
+++ b/src/vs/workbench/contrib/search/browser/searchView.ts
@@ -2448,11 +2448,16 @@ class RefreshTreeController extends Disposable {
 
 				await this.searchView.getControl().updateChildren(undefined);
 			} else {
-				// IFileMatchInstance modified, refresh those elements
-				await Promise.all(event.elements.map(async element => {
-					await this.searchView.getControl().updateChildren(element);
-					this.searchView.getControl().rerender(element);
-				}));
+				const treeHasAllElements = event.elements.every(elem => this.searchView.getControl().hasNode(elem));
+				if (treeHasAllElements) {
+					// IFileMatchInstance modified, refresh those elements
+					await Promise.all(event.elements.map(async element => {
+						await this.searchView.getControl().updateChildren(element);
+						this.searchView.getControl().rerender(element);
+					}));
+				} else {
+					this.searchView.getControl().updateChildren(undefined);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Fixes #231399

This *should* fix the tree issues with the SearchView throwing an error from its tree.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
