### PR TITLE
Revert "fix: CLI is missing guard:cf flags"

### DIFF
--- a/build/azure-pipelines/win32/cli-build-win32.yml
+++ b/build/azure-pipelines/win32/cli-build-win32.yml
@@ -53,8 +53,7 @@ steps:
         VSCODE_CLI_ENV:
           OPENSSL_LIB_DIR: $(Build.ArtifactStagingDirectory)/openssl/x64-windows-static/lib
           OPENSSL_INCLUDE_DIR: $(Build.ArtifactStagingDirectory)/openssl/x64-windows-static/include
-          RUSTFLAGS: "-Ctarget-feature=+crt-static -Clink-args=/guard:cf -Clink-args=/CETCOMPAT"
-          CFLAGS: "/guard:cf /Qspectre"
+          RUSTFLAGS: "-C target-feature=+crt-static"
 
   - ${{ if eq(parameters.VSCODE_BUILD_WIN32_ARM64, true) }}:
     - template: ../cli/cli-compile.yml@self
@@ -66,8 +65,7 @@ steps:
         VSCODE_CLI_ENV:
           OPENSSL_LIB_DIR: $(Build.ArtifactStagingDirectory)/openssl/arm64-windows-static/lib
           OPENSSL_INCLUDE_DIR: $(Build.ArtifactStagingDirectory)/openssl/arm64-windows-static/include
-          RUSTFLAGS: "-C target-feature=+crt-static -Clink-args=/guard:cf -Clink-args=/CETCOMPAT"
-          CFLAGS: "/guard:cf /Qspectre"
+          RUSTFLAGS: "-C target-feature=+crt-static"
 
   - ${{ if not(parameters.VSCODE_CHECK_ONLY) }}:
     - ${{ if eq(parameters.VSCODE_BUILD_WIN32_ARM64, true) }}:

--- a/cli/.cargo/config.toml
+++ b/cli/.cargo/config.toml
@@ -1,2 +1,0 @@
-[target.'cfg(target_os = "windows")']
-rustflags = ["-Ctarget-feature=+crt-static", "-Clink-args=/guard:cf", "-Clink-args=/CETCOMPAT"]

--- a/cli/CONTRIBUTING.md
+++ b/cli/CONTRIBUTING.md
@@ -8,7 +8,7 @@
 
 For the moment, we require OpenSSL on Windows, where it is not usually installed by default. To install it:
 
-1. Follow steps 1 and 2 of [Set up vcpkg](https://learn.microsoft.com/en-us/vcpkg/get_started/get-started-msbuild?pivots=shell-powershell#1---set-up-vcpkg) to obtain the executable.
+1. Install (clone) vcpkg [using their instructions](https://github.com/Microsoft/vcpkg#quick-start-windows)
 1. Add the location of the `vcpkg` directory to your system or user PATH.
 1. Run`vcpkg install openssl:x64-windows-static-md` (after restarting your terminal for PATH changes to apply)
 1. You should be able to then `cargo build` successfully


### PR DESCRIPTION
Reverts microsoft/vscode#231863

The PR broke the CLI ARM build.