### PR TITLE
Add `open to side` action for symbol anchors

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatInlineAnchorWidget.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatInlineAnchorWidget.ts
@@ -31,6 +31,7 @@ import { IClipboardService } from '../../../../platform/clipboard/common/clipboa
 import { ICommandService } from '../../../../platform/commands/common/commands.js';
 import { IContextKey, IContextKeyService, RawContextKey } from '../../../../platform/contextkey/common/contextkey.js';
 import { IContextMenuService } from '../../../../platform/contextview/browser/contextView.js';
+import { ITextResourceEditorInput } from '../../../../platform/editor/common/editor.js';
 import { FileKind, IFileService } from '../../../../platform/files/common/files.js';
 import { IHoverService } from '../../../../platform/hover/browser/hover.js';
 import { IInstantiationService, ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
@@ -39,7 +40,7 @@ import { ILabelService } from '../../../../platform/label/common/label.js';
 import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
 import { fillEditorsDragData } from '../../../browser/dnd.js';
 import { ResourceContextKey } from '../../../common/contextkeys.js';
-import { OPEN_TO_SIDE_COMMAND_ID } from '../../files/browser/fileConstants.js';
+import { IEditorService, SIDE_GROUP } from '../../../services/editor/common/editorService.js';
 import { ExplorerFolderContext } from '../../files/common/files.js';
 import { IWorkspaceSymbol } from '../../search/common/search.js';
 import { IChatContentInlineReference } from '../common/chatService.js';
@@ -152,10 +153,6 @@ export class InlineAnchorWidget extends Disposable {
 			contextMenuId = MenuId.ChatInlineResourceAnchorContext;
 			contextMenuArg = location.uri;
 
-			const resourceContextKey = this._register(new ResourceContextKey(contextKeyService, fileService, languageService, modelService));
-			resourceContextKey.set(location.uri);
-			this._chatResourceContext.set(location.uri.toString());
-
 			const label = labelService.getUriBasenameLabel(location.uri);
 			iconText = location.range && this.data.kind !== 'symbol' ?
 				`${label}#${location.range.startLineNumber}-${location.range.endLineNumber}` :
@@ -183,6 +180,10 @@ export class InlineAnchorWidget extends Disposable {
 				});
 			}));
 		}
+
+		const resourceContextKey = this._register(new ResourceContextKey(contextKeyService, fileService, languageService, modelService));
+		resourceContextKey.set(location.uri);
+		this._chatResourceContext.set(location.uri.toString());
 
 		const iconEl = dom.$('span.icon');
 		iconEl.classList.add(...iconClasses);
@@ -323,20 +324,36 @@ registerAction2(class OpenToSideResourceAction extends Action2 {
 				mac: {
 					primary: KeyMod.WinCtrl | KeyCode.Enter
 				},
-			}
+			},
+			menu: [{
+				id: MenuId.ChatInlineSymbolAnchorContext,
+				group: 'navigation',
+				order: 1
+			}]
 		});
 	}
 
 	override async run(accessor: ServicesAccessor): Promise<void> {
 		const chatWidgetService = accessor.get(IChatMarkdownAnchorService);
-		const commandService = accessor.get(ICommandService);
+		const editorService = accessor.get(IEditorService);
 
 		const anchor = chatWidgetService.lastFocusedAnchor;
-		if (!anchor || anchor.data.kind === 'symbol') {
+		if (!anchor) {
 			return;
 		}
 
-		commandService.executeCommand(OPEN_TO_SIDE_COMMAND_ID, anchor.data.uri);
+		const input: ITextResourceEditorInput = anchor.data.kind === 'symbol'
+			? {
+				resource: anchor.data.symbol.location.uri, options: {
+					selection: {
+						startColumn: anchor.data.symbol.location.range.startColumn,
+						startLineNumber: anchor.data.symbol.location.range.startLineNumber,
+					}
+				}
+			}
+			: { resource: anchor.data.uri };
+
+		await editorService.openEditors([input], SIDE_GROUP);
 	}
 });
 
@@ -357,10 +374,10 @@ registerAction2(class GoToDefinitionAction extends Action2 {
 			},
 			menu: [{
 				id: MenuId.ChatInlineSymbolAnchorContext,
-				group: 'navigation',
+				group: '4_symbol_nav',
 				order: 1.1,
 				when: EditorContextKeys.hasDefinitionProvider,
-			},]
+			}]
 		});
 	}
 
@@ -407,7 +424,7 @@ registerAction2(class GoToTypeDefinitionsAction extends Action2 {
 			},
 			menu: [{
 				id: MenuId.ChatInlineSymbolAnchorContext,
-				group: 'navigation',
+				group: '4_symbol_nav',
 				order: 1.1,
 				when: EditorContextKeys.hasTypeDefinitionProvider,
 			},]
@@ -432,7 +449,7 @@ registerAction2(class GoToImplementations extends Action2 {
 			},
 			menu: [{
 				id: MenuId.ChatInlineSymbolAnchorContext,
-				group: 'navigation',
+				group: '4_symbol_nav',
 				order: 1.2,
 				when: EditorContextKeys.hasImplementationProvider,
 			},]
@@ -457,7 +474,7 @@ registerAction2(class GoToReferencesAction extends Action2 {
 			},
 			menu: [{
 				id: MenuId.ChatInlineSymbolAnchorContext,
-				group: 'navigation',
+				group: '4_symbol_nav',
 				order: 1.3,
 				when: EditorContextKeys.hasReferenceProvider,
 			},]


### PR DESCRIPTION
Useful command and also prevents the symbol context menu from being empty if there are no active providers for the language

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
