### PR TITLE
fix: don't check for deprecated setting when enabling variables for terminal chat

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/contrib/chatInputCompletions.ts
+++ b/src/vs/workbench/contrib/chat/browser/contrib/chatInputCompletions.ts
@@ -606,18 +606,8 @@ class VariableCompletions extends Disposable {
 			_debugDisplayName: 'chatVariables',
 			triggerCharacters: [chatVariableLeader],
 			provideCompletionItems: async (model: ITextModel, position: Position, _context: CompletionContext, _token: CancellationToken) => {
-				const locations = new Set<ChatAgentLocation>();
-				locations.add(ChatAgentLocation.Panel);
-				locations.add(ChatAgentLocation.EditingSession);
-
-				for (const value of Object.values(ChatAgentLocation)) {
-					if (typeof value === 'string' && configService.getValue<boolean>(`chat.experimental.variables.${value}`)) {
-						locations.add(value);
-					}
-				}
-
 				const widget = this.chatWidgetService.getWidgetByInputUri(model.uri);
-				if (!widget || !locations.has(widget.location)) {
+				if (!widget) {
 					return null;
 				}
 


### PR DESCRIPTION
Fix https://github.com/microsoft/vscode/issues/229855