### PR TITLE
fix: tweak when clause for showing Save All in chat editing widget

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatEditorSaving.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditorSaving.ts
@@ -209,7 +209,11 @@ export class ChatEditingSaveAllAction extends Action2 {
 					order: 1,
 					// Show the option to save without accepting if the user has autosave
 					// and also hasn't configured the setting to always save with generated changes
-					when: ContextKeyExpr.or(hasAppliedChatEditsContextKey.negate(), ContextKeyExpr.and(hasUndecidedChatEditingResourceContextKey, ContextKeyExpr.notEquals('config.files.autoSave', 'off'), ContextKeyExpr.equals(`config.${ChatEditorSaving._config}`, false), CONTEXT_CHAT_LOCATION.isEqualTo(ChatAgentLocation.EditingSession)))
+					when: ContextKeyExpr.and(
+						ContextKeyExpr.or(hasUndecidedChatEditingResourceContextKey, hasAppliedChatEditsContextKey.negate()),
+						ContextKeyExpr.notEquals('config.files.autoSave', 'off'), ContextKeyExpr.equals(`config.${ChatEditorSaving._config}`, false),
+						CONTEXT_CHAT_LOCATION.isEqualTo(ChatAgentLocation.EditingSession)
+					)
 				}
 			],
 		});


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
