### PR TITLE
allow relative paths for "typescript.tsserver.nodePath"

### DIFF
--- a/extensions/typescript-language-features/src/configuration/configuration.electron.ts
+++ b/extensions/typescript-language-features/src/configuration/configuration.electron.ts
@@ -52,7 +52,18 @@ export class ElectronServiceConfigurationProvider extends BaseServiceConfigurati
 			const fixedPath = this.fixPathPrefixes(inspect.workspaceValue);
 			if (!path.isAbsolute(fixedPath)) {
 				const workspacePath = RelativeWorkspacePathResolver.asAbsoluteWorkspacePath(fixedPath);
-				return workspacePath || null;
+
+				if (workspacePath) {
+					return workspacePath;
+				}
+
+				// if path is relative assume it is relative to the workspace folder
+				if (vscode.workspace.workspaceFolders?.length === 1) {
+					const root = vscode.workspace.workspaceFolders[0];
+					return path.join(root.uri.fsPath, fixedPath);
+				}
+
+				return null;
 			}
 			return fixedPath;
 		}


### PR DESCRIPTION
This change updates the `typescript.tsserver.nodePath` to allow relative paths to be used for single folder workspaces. The updated behaviour will now be similar to `typescript.tsdk`.

https://github.com/microsoft/vscode/issues/232113
