### PR TITLE
Workaround references list not updating

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/chatReferencesContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/chatReferencesContentPart.ts
@@ -60,8 +60,10 @@ export class ChatCollapsibleListContentPart extends Disposable implements IChatC
 	private readonly _onDidChangeHeight = this._register(new Emitter<void>());
 	public readonly onDidChangeHeight = this._onDidChangeHeight.event;
 
+	private readonly data: ReadonlyArray<IChatCollapsibleListItem>;
+
 	constructor(
-		private readonly data: ReadonlyArray<IChatCollapsibleListItem>,
+		data: ReadonlyArray<IChatCollapsibleListItem>,
 		labelOverride: string | undefined,
 		element: IChatResponseViewModel,
 		contentReferencesListPool: CollapsibleListPool,
@@ -71,6 +73,11 @@ export class ChatCollapsibleListContentPart extends Disposable implements IChatC
 		@IContextMenuService private readonly contextMenuService: IContextMenuService,
 	) {
 		super();
+
+		// Hold onto copy of array in case it is mutated externally
+		this.data = [...data];
+
+		console.log('ChatCollapsibleListContentPart', data.length);
 
 		const referencesLabel = labelOverride ?? (data.length > 1 ?
 			localize('usedReferencesPlural', "Used {0} references", data.length) :

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/chatReferencesContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/chatReferencesContentPart.ts
@@ -60,10 +60,8 @@ export class ChatCollapsibleListContentPart extends Disposable implements IChatC
 	private readonly _onDidChangeHeight = this._register(new Emitter<void>());
 	public readonly onDidChangeHeight = this._onDidChangeHeight.event;
 
-	private readonly data: ReadonlyArray<IChatCollapsibleListItem>;
-
 	constructor(
-		data: ReadonlyArray<IChatCollapsibleListItem>,
+		private readonly data: ReadonlyArray<IChatCollapsibleListItem>,
 		labelOverride: string | undefined,
 		element: IChatResponseViewModel,
 		contentReferencesListPool: CollapsibleListPool,
@@ -73,11 +71,6 @@ export class ChatCollapsibleListContentPart extends Disposable implements IChatC
 		@IContextMenuService private readonly contextMenuService: IContextMenuService,
 	) {
 		super();
-
-		// Hold onto copy of array in case it is mutated externally
-		this.data = [...data];
-
-		console.log('ChatCollapsibleListContentPart', data.length);
 
 		const referencesLabel = labelOverride ?? (data.length > 1 ?
 			localize('usedReferencesPlural', "Used {0} references", data.length) :

--- a/src/vs/workbench/contrib/chat/common/chatModel.ts
+++ b/src/vs/workbench/contrib/chat/common/chatModel.ts
@@ -492,7 +492,7 @@ export class ChatResponseModel extends Disposable implements IChatResponseModel 
 
 	private readonly _contentReferences: IChatContentReference[] = [];
 	public get contentReferences(): ReadonlyArray<IChatContentReference> {
-		return this._contentReferences;
+		return Array.from(this._contentReferences);
 	}
 
 	private readonly _codeCitations: IChatCodeCitation[] = [];


### PR DESCRIPTION
Not the ideal fix but this makes it so that `ChatCollapsibleListContentPart` does not have a live version of the references list passed to it. The current code results in the item never being re-rendered because `hasSameContent` would always return true, so the references list would not update

There are a bunch of layers above this that all say they are readonly arrays too. Being readonly is correct from the consumer side, but it looks like the array does get mutated behind the scenes which is often unexpected

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
