### PR TITLE
Fix accessible view regression

### DIFF
--- a/src/vs/editor/contrib/wordHighlighter/browser/wordHighlighter.ts
+++ b/src/vs/editor/contrib/wordHighlighter/browser/wordHighlighter.ts
@@ -214,6 +214,7 @@ class WordHighlighter {
 	private readonly textModelService: ITextModelService;
 	private readonly codeEditorService: ICodeEditorService;
 	private readonly configurationService: IConfigurationService;
+	private readonly contextKeyService: IContextKeyService;
 	private readonly logService: ILogService;
 
 	private occurrencesHighlightEnablement: string;
@@ -252,6 +253,7 @@ class WordHighlighter {
 		this.codeEditorService = codeEditorService;
 		this.textModelService = textModelService;
 		this.configurationService = configurationService;
+		this.contextKeyService = contextKeyService;
 		this.logService = logService;
 
 		this._hasWordHighlights = ctxHasWordHighlights.bindTo(contextKeyService);
@@ -633,8 +635,11 @@ class WordHighlighter {
 
 	private async _run(multiFileConfigChange?: boolean, noDelay?: boolean): Promise<void> {
 
-		const hasTextFocus = this.editor.hasTextFocus();
+		if (this.contextKeyService.getContextKeyValue('accessibleViewIsShown')) {
+			return;
+		}
 
+		const hasTextFocus = this.editor.hasTextFocus();
 		if (!hasTextFocus) { // new nb cell scrolled in, didChangeModel fires
 			if (!WordHighlighter.query) { // no previous query, nothing to highlight off of
 				this._stopAll();

--- a/src/vs/editor/contrib/wordHighlighter/browser/wordHighlighter.ts
+++ b/src/vs/editor/contrib/wordHighlighter/browser/wordHighlighter.ts
@@ -214,7 +214,6 @@ class WordHighlighter {
 	private readonly textModelService: ITextModelService;
 	private readonly codeEditorService: ICodeEditorService;
 	private readonly configurationService: IConfigurationService;
-	private readonly contextKeyService: IContextKeyService;
 	private readonly logService: ILogService;
 
 	private occurrencesHighlightEnablement: string;
@@ -253,7 +252,6 @@ class WordHighlighter {
 		this.codeEditorService = codeEditorService;
 		this.textModelService = textModelService;
 		this.configurationService = configurationService;
-		this.contextKeyService = contextKeyService;
 		this.logService = logService;
 
 		this._hasWordHighlights = ctxHasWordHighlights.bindTo(contextKeyService);
@@ -635,10 +633,6 @@ class WordHighlighter {
 
 	private async _run(multiFileConfigChange?: boolean, noDelay?: boolean): Promise<void> {
 
-		if (this.contextKeyService.getContextKeyValue('accessibleViewIsShown')) {
-			return;
-		}
-
 		const hasTextFocus = this.editor.hasTextFocus();
 		if (!hasTextFocus) { // new nb cell scrolled in, didChangeModel fires
 			if (!WordHighlighter.query) { // no previous query, nothing to highlight off of
@@ -853,7 +847,7 @@ export class WordHighlighterContribution extends Disposable implements IEditorCo
 		super();
 		this._wordHighlighter = null;
 		const createWordHighlighterIfPossible = () => {
-			if (editor.hasModel() && !editor.getModel().isTooLargeForTokenization()) {
+			if (editor.hasModel() && !editor.getModel().isTooLargeForTokenization() && editor.getModel().uri.scheme !== Schemas.accessibleView) {
 				this._wordHighlighter = new WordHighlighter(editor, languageFeaturesService.documentHighlightProvider, languageFeaturesService.multiDocumentHighlightProvider, contextKeyService, textModelService, codeEditorService, configurationService, logService);
 			}
 		};


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fixes: #231285

Talked with @meganrogge and user in the accessible view won't gain value from highlights in the accessible view, and due to blurring logic there would already be no highlights in other editors. 

Safe fix is to not create wordHighlighters for this view, easily by checking the model schema