### PR TITLE
show the command center chat icon in the text

### DIFF
--- a/src/vs/workbench/browser/parts/views/media/views.css
+++ b/src/vs/workbench/browser/parts/views/media/views.css
@@ -124,6 +124,12 @@
 	margin-inline-end: 0px;
 }
 
+.monaco-workbench .pane > .pane-body .welcome-view-content > p .codicon[class*='codicon-'] {
+	font-size: 13px;
+	line-height: 1.4em;
+	vertical-align: bottom;
+}
+
 .customview-tree .monaco-list-row .monaco-tl-contents.align-icon-with-twisty::before {
 	display: none;
 }

--- a/src/vs/workbench/browser/parts/views/viewPane.ts
+++ b/src/vs/workbench/browser/parts/views/viewPane.ts
@@ -54,6 +54,7 @@ import { IHoverService } from '../../../../platform/hover/browser/hover.js';
 import { IListStyles } from '../../../../base/browser/ui/list/listWidget.js';
 import { PANEL_BACKGROUND, PANEL_SECTION_DRAG_AND_DROP_BACKGROUND, PANEL_STICKY_SCROLL_BACKGROUND, PANEL_STICKY_SCROLL_BORDER, PANEL_STICKY_SCROLL_SHADOW, SIDE_BAR_BACKGROUND, SIDE_BAR_DRAG_AND_DROP_BACKGROUND, SIDE_BAR_STICKY_SCROLL_BACKGROUND, SIDE_BAR_STICKY_SCROLL_BORDER, SIDE_BAR_STICKY_SCROLL_SHADOW } from '../../../common/theme.js';
 import { IAccessibleViewInformationService } from '../../../services/accessibility/common/accessibleViewInformationService.js';
+import { renderLabelWithIcons } from '../../../../base/browser/ui/iconLabel/iconLabels.js';
 
 export enum ViewPaneShowActions {
 	/** Show the actions when the view is hovered. This is the default behavior. */
@@ -274,7 +275,7 @@ class ViewWelcomeController {
 
 					for (const node of linkedText.nodes) {
 						if (typeof node === 'string') {
-							append(p, document.createTextNode(node));
+							append(p, ...renderLabelWithIcons(node));
 						} else {
 							const link = this.renderDisposables.add(this.instantiationService.createInstance(Link, p, node, {}));
 

--- a/src/vs/workbench/contrib/chat/browser/chatMovedView.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatMovedView.contribution.ts
@@ -208,11 +208,12 @@ export class MoveChatViewContribution implements IWorkbenchContribution {
 			localize('chatMovedMainMessage1Right', "Chat has been moved to the Secondary Side Bar on the right for a more integrated AI experience in your editor.");
 
 		const chatViewKeybinding = this.keybindingService.lookupKeybinding(CHAT_SIDEBAR_PANEL_ID)?.getLabel();
+		const copilotIcon = `$(${this.productService.defaultChatAgent?.icon ?? 'comment-discussion'})`;
 		let quicklyAccessMessage = undefined;
 		if (this.hasCommandCenterChat() && chatViewKeybinding) {
-			quicklyAccessMessage = localize('chatMovedCommandCenterAndKeybind', "You can quickly access Chat via the new Copilot icon in the editor title bar or with the keyboard shortcut {0}.", chatViewKeybinding);
+			quicklyAccessMessage = localize('chatMovedCommandCenterAndKeybind', "You can quickly access Chat via the new Copilot icon ({0}) in the editor title bar or with the keyboard shortcut {1}.", copilotIcon, chatViewKeybinding);
 		} else if (this.hasCommandCenterChat()) {
-			quicklyAccessMessage = localize('chatMovedCommandCenter', "You can quickly access Chat via the new Copilot icon in the editor title bar.");
+			quicklyAccessMessage = localize('chatMovedCommandCenter', "You can quickly access Chat via the new Copilot icon ({0}) in the editor title bar.", copilotIcon);
 		} else if (chatViewKeybinding) {
 			quicklyAccessMessage = localize('chatMovedKeybind', "You can quickly access Chat with the keyboard shortcut {0}.", chatViewKeybinding);
 		}


### PR DESCRIPTION
There was a recommendation to have the icon in the text so users know what to look for in standup. We don't currently support icons in welcome view content, so I had to add it.

![image](https://github.com/user-attachments/assets/b41f5f9b-3b8e-4d5d-b166-3287bda61889)
