### PR TITLE
Fixes an issue where settings sync causes double chat view

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatMovedView.contribution.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatMovedView.contribution.ts
@@ -114,6 +114,18 @@ export class MoveChatViewContribution implements IWorkbenchContribution {
 
 	private registerListeners(): void {
 		this.storageService.onDidChangeValue(StorageScope.APPLICATION, MoveChatViewContribution.hideMovedChatWelcomeViewStorageKey, new DisposableStore())(() => this.updateContextKey());
+
+		// If the view container gets shown but it's supposed to be hidden, go hide it.
+		this.viewsService.onDidChangeViewContainerVisibility(e => {
+			const supposedToBeHidden = this.storageService.getBoolean(MoveChatViewContribution.hideMovedChatWelcomeViewStorageKey, StorageScope.APPLICATION, false);
+			if (supposedToBeHidden && e.visible && e.id === CHAT_SIDEBAR_OLD_VIEW_PANEL_ID) {
+				const viewContainer = this.viewDescriptorService.getViewContainerById(CHAT_SIDEBAR_OLD_VIEW_PANEL_ID);
+
+				if (viewContainer) {
+					Registry.as<IViewContainersRegistry>(ViewExtensions.ViewContainersRegistry).deregisterViewContainer(viewContainer);
+				}
+			}
+		});
 	}
 
 	private registerCommands(): void {


### PR DESCRIPTION
deregister the view container if context key isn't honored

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
