### PR TITLE
debug: don't show element hover in console

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/replViewer.ts
+++ b/src/vs/workbench/contrib/debug/browser/replViewer.ts
@@ -196,7 +196,12 @@ export class ReplOutputElementRenderer implements ITreeRenderer<ReplOutputElemen
 		templateData.value.className = 'value';
 
 		const locationReference = element.expression?.valueLocationReference;
-		templateData.elementDisposable.add(this.expressionRenderer.renderValue(templateData.value, element.value, { wasANSI: true, session: element.session, locationReference }));
+		templateData.elementDisposable.add(this.expressionRenderer.renderValue(templateData.value, element.value, {
+			wasANSI: true,
+			session: element.session,
+			locationReference,
+			hover: false,
+		}));
 
 		templateData.value.classList.add((element.severity === severity.Warning) ? 'warn' : (element.severity === severity.Error) ? 'error' : (element.severity === severity.Ignore) ? 'ignore' : 'info');
 		templateData.source.setSource(element.sourceData);


### PR DESCRIPTION
This was unintentionally enabled in some refactors last month.

Fixes #228317

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
