### PR TITLE
feat: support `preferredDarkFileIconTheme` & `preferredLightFileIconTheme`

### DIFF
--- a/src/vs/workbench/contrib/themes/browser/themes.contribution.ts
+++ b/src/vs/workbench/contrib/themes/browser/themes.contribution.ts
@@ -754,6 +754,26 @@ registerAction2(class extends Action2 {
 				themeService.setColorTheme(theme.id, 'auto');
 			}
 		}
+
+		let newIconThemeSettingId: string = ThemeSettings.PREFERRED_DARK_FILE_ICON_THEME;
+		switch (currentTheme.type) {
+			case ColorScheme.LIGHT:
+			case ColorScheme.HIGH_CONTRAST_LIGHT:
+				newIconThemeSettingId = ThemeSettings.PREFERRED_DARK_FILE_ICON_THEME;
+				break;
+			case ColorScheme.DARK:
+			case ColorScheme.HIGH_CONTRAST_DARK:
+				newIconThemeSettingId = ThemeSettings.PREFERRED_LIGHT_FILE_ICON_THEME;
+				break;
+		}
+
+		const fileIconThemeSettingId: string = configurationService.getValue(newIconThemeSettingId);
+		if (fileIconThemeSettingId && typeof fileIconThemeSettingId === 'string') {
+			const theme = (await themeService.getFileIconThemes()).find(t => t.settingsId === fileIconThemeSettingId);
+			if (theme) {
+				themeService.setFileIconTheme(theme.id, 'auto');
+			}
+		}
 	}
 });
 

--- a/src/vs/workbench/services/themes/browser/workbenchThemeService.ts
+++ b/src/vs/workbench/services/themes/browser/workbenchThemeService.ts
@@ -260,7 +260,13 @@ export class WorkbenchThemeService extends Disposable implements IWorkbenchTheme
 			) {
 				this.restoreColorTheme();
 			}
-			if (e.affectsConfiguration(ThemeSettings.FILE_ICON_THEME)) {
+			if (e.affectsConfiguration(ThemeSettings.FILE_ICON_THEME)
+				|| e.affectsConfiguration(ThemeSettings.DETECT_COLOR_SCHEME)
+				|| e.affectsConfiguration(ThemeSettings.DETECT_HC)
+				|| e.affectsConfiguration(ThemeSettings.SYSTEM_COLOR_THEME)
+				|| e.affectsConfiguration(ThemeSettings.PREFERRED_DARK_FILE_ICON_THEME)
+				|| e.affectsConfiguration(ThemeSettings.PREFERRED_LIGHT_FILE_ICON_THEME)
+			) {
 				this.restoreFileIconTheme();
 			}
 			if (e.affectsConfiguration(ThemeSettings.PRODUCT_ICON_THEME)) {
@@ -363,6 +369,7 @@ export class WorkbenchThemeService extends Disposable implements IWorkbenchTheme
 		this._register(this.hostColorService.onDidChangeColorScheme(() => {
 			if (this.settings.isDetectingColorScheme()) {
 				this.restoreColorTheme();
+				this.restoreFileIconTheme();
 			}
 		}));
 	}

--- a/src/vs/workbench/services/themes/common/workbenchThemeService.ts
+++ b/src/vs/workbench/services/themes/common/workbenchThemeService.ts
@@ -40,6 +40,9 @@ export enum ThemeSettings {
 	DETECT_COLOR_SCHEME = 'window.autoDetectColorScheme',
 	DETECT_HC = 'window.autoDetectHighContrast',
 
+	PREFERRED_DARK_FILE_ICON_THEME = 'workbench.preferredDarkFileIconTheme',
+	PREFERRED_LIGHT_FILE_ICON_THEME = 'workbench.preferredLightFileIconTheme',
+
 	SYSTEM_COLOR_THEME = 'window.systemColorTheme'
 }
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

close #185727

This PR adds two configuration `workbench.preferredDarkFileIconTheme` and `workbench.preferredLightFileIconTheme` that are similar to `workbench.preferredLightTheme` and `workbench.preferredDarkTheme`. 
