### PR TITLE
Ensure element is not rendered to 0px when updating height async

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatListRenderer.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatListRenderer.ts
@@ -578,7 +578,7 @@ export class ChatListItemRenderer extends Disposable implements ITreeRenderer<Ch
 			return;
 		}
 
-		const newHeight = templateData.rowContainer.offsetHeight;
+		const newHeight = Math.max(templateData.rowContainer.offsetHeight, 1);
 		templateData.currentElement.currentRenderedHeight = newHeight;
 		this._onDidChangeItemHeight.fire({ element: templateData.currentElement, height: newHeight });
 	}


### PR DESCRIPTION
Port candidate to main (#232281)
This can happen because templateParts are now not disposed when an element is unregistered, but we have to keep their listeners around because they are reused on the next render. A more complete non-candidate fix might be to check whether the element is in the DOM before rendering it at all. But the safe fix here is to just make sure it doesn't go to 0, so that the list doesn't skip rendering it entirely.
microsoft/vscode-copilot#9260

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
