### PR TITLE
Remove 'unknown' from LanguageModelToolResult#constructor

### DIFF
--- a/src/vs/workbench/api/common/extHostTypes.ts
+++ b/src/vs/workbench/api/common/extHostTypes.ts
@@ -4770,7 +4770,7 @@ export class LanguageModelError extends Error {
 }
 
 export class LanguageModelToolResult {
-	constructor(public content: (LanguageModelTextPart | LanguageModelPromptTsxPart | unknown)[]) { }
+	constructor(public content: (LanguageModelTextPart | LanguageModelPromptTsxPart)[]) { }
 
 	toJSON() {
 		return {

--- a/src/vscode-dts/vscode.d.ts
+++ b/src/vscode-dts/vscode.d.ts
@@ -19897,7 +19897,7 @@ declare module 'vscode' {
 		 * Create a LanguageModelToolResult
 		 * @param content A list of tool result content parts
 		 */
-		constructor(content: (LanguageModelTextPart | LanguageModelPromptTsxPart | unknown)[]);
+		constructor(content: (LanguageModelTextPart | LanguageModelPromptTsxPart)[]);
 	}
 
 	/**


### PR DESCRIPTION
Port candidate to main  (#232284)
It should be on the content property but no need to be in the constructor.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
