### PR TITLE
Add 200 debounce time for mouse to find hover before hiding it

### DIFF
--- a/src/vs/editor/browser/services/hoverService/hoverService.ts
+++ b/src/vs/editor/browser/services/hoverService/hoverService.ts
@@ -83,7 +83,7 @@ export class HoverService extends Disposable implements IHoverService {
 
 			// Only clear the current options if it's the current hover, the current options help
 			// reduce flickering when the same hover is shown multiple times
-			if (this._currentHoverOptions === options) {
+			if (getHoverOptionsIdentity(this._currentHoverOptions) === getHoverOptionsIdentity(options)) {
 				this._currentHoverOptions = undefined;
 			}
 			hoverDisposables.dispose();

--- a/src/vs/editor/browser/services/hoverService/hoverWidget.ts
+++ b/src/vs/editor/browser/services/hoverService/hoverWidget.ts
@@ -641,8 +641,15 @@ class CompositeMouseTracker extends Widget {
 
 	get isMouseIn(): boolean { return this._isMouseIn; }
 
+	/**
+	 * @param _elements The target elements to track mouse in/out events on.
+	 * @param _eventDebounceDelay The delay in ms to debounce the event firing. This is used to
+	 * allow a short period for the mouse to move into the hover or a nearby target element. For
+	 * example hovering a scroll bar will not hide the hover immediately.
+	 */
 	constructor(
-		private _elements: HTMLElement[]
+		private _elements: HTMLElement[],
+		private _eventDebounceDelay: number = 200
 	) {
 		super();
 		this._elements.forEach(n => this.onmouseover(n, () => this._onTargetMouseOver(n)));
@@ -663,7 +670,7 @@ class CompositeMouseTracker extends Widget {
 		this._clearEvaluateMouseStateTimeout(target);
 		// Evaluate whether the mouse is still outside asynchronously such that other mouse targets
 		// have the opportunity to first their mouse in event.
-		this._mouseTimeout = dom.getWindow(target).setTimeout(() => this._fireIfMouseOutside(), 0);
+		this._mouseTimeout = dom.getWindow(target).setTimeout(() => this._fireIfMouseOutside(), this._eventDebounceDelay);
 	}
 
 	private _clearEvaluateMouseStateTimeout(target: HTMLElement): void {

--- a/src/vs/editor/browser/services/hoverService/hoverWidget.ts
+++ b/src/vs/editor/browser/services/hoverService/hoverWidget.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import './hover.css';
-import { DisposableStore } from '../../../../base/common/lifecycle.js';
+import { DisposableStore, MutableDisposable } from '../../../../base/common/lifecycle.js';
 import { Event, Emitter } from '../../../../base/common/event.js';
 import * as dom from '../../../../base/browser/dom.js';
 import { IKeybindingService } from '../../../../platform/keybinding/common/keybinding.js';
@@ -23,6 +23,7 @@ import { isMacintosh } from '../../../../base/common/platform.js';
 import { IAccessibilityService } from '../../../../platform/accessibility/common/accessibility.js';
 import { status } from '../../../../base/browser/ui/aria/aria.js';
 import type { IHoverOptions, IHoverTarget, IHoverWidget } from '../../../../base/browser/ui/hover/hover.js';
+import { TimeoutTimer } from '../../../../base/common/async.js';
 
 const $ = dom.$;
 type TargetRect = {
@@ -634,7 +635,7 @@ export class HoverWidget extends Widget implements IHoverWidget {
 
 class CompositeMouseTracker extends Widget {
 	private _isMouseIn: boolean = true;
-	private _mouseTimeout: number | undefined;
+	private readonly _mouseTimer: MutableDisposable<TimeoutTimer> = this._register(new MutableDisposable());
 
 	private readonly _onMouseOut = this._register(new Emitter<void>());
 	get onMouseOut(): Event<void> { return this._onMouseOut.event; }
@@ -652,32 +653,23 @@ class CompositeMouseTracker extends Widget {
 		private _eventDebounceDelay: number = 200
 	) {
 		super();
-		this._elements.forEach(n => this.onmouseover(n, () => this._onTargetMouseOver(n)));
-		this._elements.forEach(n => this.onmouseleave(n, () => this._onTargetMouseLeave(n)));
+
+		for (const element of this._elements) {
+			this.onmouseover(element, () => this._onTargetMouseOver());
+			this.onmouseleave(element, () => this._onTargetMouseLeave());
+		}
 	}
 
-	private _onTargetMouseOver(target: HTMLElement): void {
+	private _onTargetMouseOver(): void {
 		this._isMouseIn = true;
-		this._clearEvaluateMouseStateTimeout(target);
+		this._mouseTimer.clear();
 	}
 
-	private _onTargetMouseLeave(target: HTMLElement): void {
+	private _onTargetMouseLeave(): void {
 		this._isMouseIn = false;
-		this._evaluateMouseState(target);
-	}
-
-	private _evaluateMouseState(target: HTMLElement): void {
-		this._clearEvaluateMouseStateTimeout(target);
 		// Evaluate whether the mouse is still outside asynchronously such that other mouse targets
 		// have the opportunity to first their mouse in event.
-		this._mouseTimeout = dom.getWindow(target).setTimeout(() => this._fireIfMouseOutside(), this._eventDebounceDelay);
-	}
-
-	private _clearEvaluateMouseStateTimeout(target: HTMLElement): void {
-		if (this._mouseTimeout) {
-			dom.getWindow(target).clearTimeout(this._mouseTimeout);
-			this._mouseTimeout = undefined;
-		}
+		this._mouseTimer.value = new TimeoutTimer(() => this._fireIfMouseOutside(), this._eventDebounceDelay);
 	}
 
 	private _fireIfMouseOutside(): void {

--- a/src/vs/platform/hover/browser/hover.ts
+++ b/src/vs/platform/hover/browser/hover.ts
@@ -63,7 +63,11 @@ export class WorkbenchHoverDelegate extends Disposable implements IHoverDelegate
 			}));
 		}
 
-		const id = isHTMLElement(options.content) ? undefined : options.content.toString();
+		const id = isHTMLElement(options.content)
+			? undefined
+			: typeof options.content === 'string'
+				? options.content.toString()
+				: options.content.value;
 
 		return this.hoverService.showHover({
 			...options,


### PR DESCRIPTION
Fixes #228121

Early impressions of this is that it works quite nicely

@benibenj could you test this out? I tested a few things on my mac but want to also look on my Windows machine before i merge. Also I found this part of managed hover to be kind of hard to understand:

https://github.com/microsoft/vscode/blob/b3e8a4c9ef60243cde456631b0cd9d998e538f3b/src/vs/editor/browser/services/hoverService/hoverService.ts#L209-L277

Especially when it feels like it conflicts quite a bit with the HoverWidget largely managing its own lifecycle here:

https://github.com/microsoft/vscode/blob/b3e8a4c9ef60243cde456631b0cd9d998e538f3b/src/vs/editor/browser/services/hoverService/hoverWidget.ts#L238-L242