### PR TITLE
fix: make `#file` variables part of the chat editing working set

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chat.ts
+++ b/src/vs/workbench/contrib/chat/browser/chat.ts
@@ -183,6 +183,7 @@ export interface IChatWidget {
 	getFocus(): ChatTreeItem | undefined;
 	setInput(query?: string): void;
 	getInput(): string;
+	refreshParsedInput(): void;
 	logInputHistory(): void;
 	acceptInput(query?: string, options?: IChatAcceptInputOptions): Promise<IChatResponseModel | undefined>;
 	acceptInputWithPrefix(prefix: string): void;

--- a/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
@@ -224,6 +224,15 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		}
 		return edits;
 	}
+
+	private _attemptedWorkingSetEntriesCount: number = 0;
+	/**
+	 * The number of working set entries that the user actually wanted to attach.
+	 * This is less than or equal to {@link ChatInputPart.chatEditWorkingSetFiles}.
+	 */
+	public get attemptedWorkingSetEntriesCount() {
+		return this._attemptedWorkingSetEntriesCount;
+	}
 	private _combinedChatEditWorkingSetEntries: URI[] = [];
 	public get chatEditWorkingSetFiles() {
 		return this._combinedChatEditWorkingSetEntries;
@@ -969,6 +978,9 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		const overviewRegion = innerContainer.querySelector('.chat-editing-session-overview') as HTMLElement ?? dom.append(innerContainer, $('.chat-editing-session-overview'));
 		const overviewText = overviewRegion.querySelector('span') ?? dom.append(overviewRegion, $('span'));
 		overviewText.textContent = localize('chatEditingSession.workingSet', 'Working Set');
+
+		// Record the number of entries that the user wanted to add to the working set
+		this._attemptedWorkingSetEntriesCount = entries.length;
 
 		if (entries.length === 1) {
 			overviewText.textContent += ' ' + localize('chatEditingSession.oneFile', '(1 file)');

--- a/src/vs/workbench/contrib/chat/browser/contrib/chatDynamicVariables.ts
+++ b/src/vs/workbench/contrib/chat/browser/contrib/chatDynamicVariables.ts
@@ -57,6 +57,7 @@ export class ChatDynamicVariableModel extends Disposable implements IChatWidgetC
 								range: rangeToDelete,
 								text: '',
 							}]);
+							this.widget.refreshParsedInput();
 						}
 						return null;
 					} else if (Range.compareRangesUsingStarts(ref.range, c.range) > 0) {
@@ -96,6 +97,7 @@ export class ChatDynamicVariableModel extends Disposable implements IChatWidgetC
 	addReference(ref: IDynamicVariable): void {
 		this._variables.push(ref);
 		this.updateDecorations();
+		this.widget.refreshParsedInput();
 	}
 
 	private updateDecorations(): void {

--- a/src/vs/workbench/contrib/chat/browser/contrib/chatInputEditorContrib.ts
+++ b/src/vs/workbench/contrib/chat/browser/contrib/chatInputEditorContrib.ts
@@ -321,6 +321,7 @@ class ChatTokenDeleter extends Disposable {
 							range: rangeToDelete,
 							text: '',
 						}]);
+						this.widget.refreshParsedInput();
 					}
 				});
 			}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

cc @roblourens @jrieken 

I want to avoid rerendering the editing widget too frequently (i.e. not re-parsing and rerendering on input editor content change), and I also don't want to start refcounting variable references in the input part, so I went with forcing a re-parse of the input request whenever we accept/remove a dynamic completion and when the input is cleared, which I think covers the majority of cases. LMK if you have questions or suggestions