### PR TITLE
Move timeline hovers to the side

### DIFF
--- a/src/vs/base/browser/ui/iconLabel/iconLabel.ts
+++ b/src/vs/base/browser/ui/iconLabel/iconLabel.ts
@@ -24,7 +24,7 @@ export interface IIconLabelCreationOptions {
 	readonly supportDescriptionHighlights?: boolean;
 	readonly supportIcons?: boolean;
 	readonly hoverDelegate?: IHoverDelegate;
-	readonly hoverTargetOverrride?: HTMLElement;
+	readonly hoverTargetOverride?: HTMLElement;
 }
 
 export interface IIconLabelValueOptions {
@@ -211,11 +211,11 @@ export class IconLabel extends Disposable {
 		}
 
 		let hoverTarget = htmlElement;
-		if (this.creationOptions?.hoverTargetOverrride) {
-			if (!dom.isAncestor(htmlElement, this.creationOptions.hoverTargetOverrride)) {
+		if (this.creationOptions?.hoverTargetOverride) {
+			if (!dom.isAncestor(htmlElement, this.creationOptions.hoverTargetOverride)) {
 				throw new Error('hoverTargetOverrride must be an ancestor of the htmlElement');
 			}
-			hoverTarget = this.creationOptions.hoverTargetOverrride;
+			hoverTarget = this.creationOptions.hoverTargetOverride;
 		}
 
 		if (this.hoverDelegate.showNativeHover) {

--- a/src/vs/workbench/browser/parts/editor/multiEditorTabsControl.ts
+++ b/src/vs/workbench/browser/parts/editor/multiEditorTabsControl.ts
@@ -817,7 +817,7 @@ export class MultiEditorTabsControl extends EditorTabsControl {
 		tabContainer.appendChild(tabBorderTopContainer);
 
 		// Tab Editor Label
-		const editorLabel = this.tabResourceLabels.create(tabContainer, { hoverTargetOverrride: tabContainer });
+		const editorLabel = this.tabResourceLabels.create(tabContainer, { hoverTargetOverride: tabContainer });
 
 		// Tab Actions
 		const tabActionsContainer = document.createElement('div');

--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/chatAttachmentsContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/chatAttachmentsContentPart.ts
@@ -55,7 +55,7 @@ export class ChatAttachmentsContentPart extends Disposable {
 			}
 
 			const widget = dom.append(container, dom.$('.chat-attached-context-attachment.show-file-icons'));
-			const label = this._contextResourceLabels.create(widget, { supportIcons: true, hoverDelegate, hoverTargetOverrride: widget });
+			const label = this._contextResourceLabels.create(widget, { supportIcons: true, hoverDelegate, hoverTargetOverride: widget });
 
 			const correspondingContentReference = this.contentReferences.find((ref) => typeof ref.reference === 'object' && 'variableName' in ref.reference && ref.reference.variableName === attachment.name);
 			const isAttachmentOmitted = correspondingContentReference?.options?.status?.kind === ChatResponseReferencePartStatusKind.Omitted;

--- a/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
@@ -735,7 +735,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 			}
 
 			const widget = dom.append(container, $('.chat-attached-context-attachment.show-file-icons'));
-			const label = this._contextResourceLabels.create(widget, { supportIcons: true, hoverDelegate, hoverTargetOverrride: widget });
+			const label = this._contextResourceLabels.create(widget, { supportIcons: true, hoverDelegate, hoverTargetOverride: widget });
 
 			let ariaLabel: string | undefined;
 

--- a/src/vs/workbench/contrib/timeline/browser/timelinePane.ts
+++ b/src/vs/workbench/contrib/timeline/browser/timelinePane.ts
@@ -56,8 +56,8 @@ import { IExtensionService } from '../../../services/extensions/common/extension
 import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
 import { AriaRole } from '../../../../base/browser/ui/aria/aria.js';
 import { ILocalizedString } from '../../../../platform/action/common/action.js';
-import { getDefaultHoverDelegate } from '../../../../base/browser/ui/hover/hoverDelegateFactory.js';
-import { IHoverService } from '../../../../platform/hover/browser/hover.js';
+import { IHoverService, WorkbenchHoverDelegate } from '../../../../platform/hover/browser/hover.js';
+import { HoverPosition } from '../../../../base/browser/ui/hover/hoverWidget.js';
 
 const ItemHeight = 22;
 
@@ -1159,7 +1159,14 @@ class TimelineTreeRenderer implements ITreeRenderer<TreeElement, FuzzyScore, Tim
 		@IThemeService private themeService: IThemeService,
 	) {
 		this.actionViewItemProvider = createActionViewItem.bind(undefined, this.instantiationService);
-		this._hoverDelegate = getDefaultHoverDelegate('mouse');
+		this._hoverDelegate = this.instantiationService.createInstance(WorkbenchHoverDelegate, 'element', false, {
+			appearance: {
+				showPointer: true
+			},
+			position: {
+				hoverPosition: HoverPosition.RIGHT // Will flip when there's no space
+			}
+		});
 	}
 
 	private uri: URI | undefined;

--- a/src/vs/workbench/contrib/timeline/browser/timelinePane.ts
+++ b/src/vs/workbench/contrib/timeline/browser/timelinePane.ts
@@ -1160,9 +1160,6 @@ class TimelineTreeRenderer implements ITreeRenderer<TreeElement, FuzzyScore, Tim
 	) {
 		this.actionViewItemProvider = createActionViewItem.bind(undefined, this.instantiationService);
 		this._hoverDelegate = this.instantiationService.createInstance(WorkbenchHoverDelegate, 'element', false, {
-			appearance: {
-				showPointer: true
-			},
 			position: {
 				hoverPosition: HoverPosition.RIGHT // Will flip when there's no space
 			}


### PR DESCRIPTION
Fixes #232487

Before:

<img width="547" alt="Screenshot 2024-10-29 at 7 00 47 am" src="https://github.com/user-attachments/assets/ac1c32ac-1c69-488f-a6ad-223279b4779e">

After - aligns with SCM view and makes hovers with links easier to hover:

<img width="564" alt="Screenshot 2024-10-29 at 7 00 26 am" src="https://github.com/user-attachments/assets/5ce9f642-1fff-4612-9c1f-6ad20e576c79">
