### PR TITLE
debug: fix dynamic configurations in empty workspace

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/debugConfigurationManager.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugConfigurationManager.ts
@@ -226,8 +226,8 @@ export class ConfigurationManager implements IConfigurationManager {
 					const picks: Promise<IDynamicPickItem[]>[] = [];
 					const provider = this.configProviders.find(p => p.type === type && p.triggerKind === DebugConfigurationProviderTriggerKind.Dynamic && p.provideDebugConfigurations);
 					this.getLaunches().forEach(launch => {
-						if (launch.workspace && provider) {
-							picks.push(provider.provideDebugConfigurations!(launch.workspace.uri, token.token).then(configurations => configurations.map(config => ({
+						if (provider) {
+							picks.push(provider.provideDebugConfigurations!(launch.workspace?.uri, token.token).then(configurations => configurations.map(config => ({
 								label: config.name,
 								description: launch.name,
 								config,


### PR DESCRIPTION
We would skip trying to find configurations instead of passing an undefined workspace folder (which is entirely legal)

Fixes #228949

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
