### PR TITLE
fix: useMsal setting doesn't have tags

### DIFF
--- a/extensions/microsoft-authentication/package.json
+++ b/extensions/microsoft-authentication/package.json
@@ -101,7 +101,11 @@
         "properties": {
           "microsoft.useMsal": {
             "type": "boolean",
-            "description": "%useMsal.description%"
+            "description": "%useMsal.description%",
+            "tags": [
+              "onExP",
+              "preview"
+            ]
           }
         }
       }


### PR DESCRIPTION
It looks like the setting is still being rolled out on ExP.