### PR TITLE
Change Windows Start Menu folder to just be an entry

### DIFF
--- a/build/win32/code.iss
+++ b/build/win32/code.iss
@@ -99,7 +99,7 @@ Source: "appx\*"; DestDir: "{app}\appx"; BeforeInstall: RemoveAppxPackage; After
 #endif
 
 [Icons]
-Name: "{group}\{#NameLong}"; Filename: "{app}\{#ExeBasename}.exe"; AppUserModelID: "{#AppUserId}"
+Name: "{autoprograms}\{#NameLong}"; Filename: "{app}\{#ExeBasename}.exe"; AppUserModelID: "{#AppUserId}"
 Name: "{autodesktop}\{#NameLong}"; Filename: "{app}\{#ExeBasename}.exe"; Tasks: desktopicon; AppUserModelID: "{#AppUserId}"
 Name: "{userappdata}\Microsoft\Internet Explorer\Quick Launch\{#NameLong}"; Filename: "{app}\{#ExeBasename}.exe"; Tasks: quicklaunchicon; AppUserModelID: "{#AppUserId}"
 


### PR DESCRIPTION
This simple change causes the Windows Inno installer to just place one .lnk entry in the Start Menu, instead of creating an entire folder, as this does not make much sense for a single entry. This is essentially a Start Menu cleanup.

The resulting change is as following:

**From**
- %appdata%\Microsoft\Windows\Start Menu\Programs\Visual Studio Code\Visual Studio Code.lnk

**To**
- %appdata%\Microsoft\Windows\Start Menu\Programs\Visual Studio Code.lnk