### PR TITLE
missing `(next|previous)AuxilaryBarView` commands (fix #154724)

### DIFF
--- a/src/vs/workbench/browser/parts/activitybar/activitybarPart.ts
+++ b/src/vs/workbench/browser/parts/activitybar/activitybarPart.ts
@@ -29,15 +29,15 @@ import { IPaneCompositePart } from '../paneCompositePart.js';
 import { IPaneCompositeBarOptions, PaneCompositeBar } from '../paneCompositeBar.js';
 import { GlobalCompositeBar } from '../globalCompositeBar.js';
 import { IStorageService } from '../../../../platform/storage/common/storage.js';
-import { Action2, IAction2Options, IMenuService, MenuId, MenuRegistry, registerAction2 } from '../../../../platform/actions/common/actions.js';
+import { Action2, IMenuService, MenuId, MenuRegistry, registerAction2 } from '../../../../platform/actions/common/actions.js';
 import { ContextKeyExpr, IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
 import { Categories } from '../../../../platform/action/common/actionCommonCategories.js';
 import { getContextMenuActions } from '../../../../platform/actions/browser/menuEntryActionViewItem.js';
 import { IViewDescriptorService, ViewContainerLocation, ViewContainerLocationToString } from '../../../common/views.js';
-import { IPaneCompositePartService } from '../../../services/panecomposite/browser/panecomposite.js';
 import { IExtensionService } from '../../../services/extensions/common/extensions.js';
 import { IWorkbenchEnvironmentService } from '../../../services/environment/common/environmentService.js';
 import { IViewsService } from '../../../services/views/common/viewsService.js';
+import { SwitchCompositeViewAction } from '../compositeBarActions.js';
 
 export class ActivitybarPart extends Part {
 
@@ -506,61 +506,27 @@ MenuRegistry.appendMenuItem(MenuId.ViewTitleContext, {
 	order: 1
 });
 
-class SwitchSideBarViewAction extends Action2 {
-
-	constructor(
-		desc: Readonly<IAction2Options>,
-		private readonly offset: number
-	) {
-		super(desc);
+registerAction2(class extends SwitchCompositeViewAction {
+	constructor() {
+		super({
+			id: 'workbench.action.previousSideBarView',
+			title: localize2('previousSideBarView', 'Previous Primary Side Bar View'),
+			category: Categories.View,
+			f1: true
+		}, ViewContainerLocation.Sidebar, -1);
 	}
+});
 
-	async run(accessor: ServicesAccessor): Promise<void> {
-		const paneCompositeService = accessor.get(IPaneCompositePartService);
-
-		const visibleViewletIds = paneCompositeService.getVisiblePaneCompositeIds(ViewContainerLocation.Sidebar);
-
-		const activeViewlet = paneCompositeService.getActivePaneComposite(ViewContainerLocation.Sidebar);
-		if (!activeViewlet) {
-			return;
-		}
-		let targetViewletId: string | undefined;
-		for (let i = 0; i < visibleViewletIds.length; i++) {
-			if (visibleViewletIds[i] === activeViewlet.getId()) {
-				targetViewletId = visibleViewletIds[(i + visibleViewletIds.length + this.offset) % visibleViewletIds.length];
-				break;
-			}
-		}
-
-		await paneCompositeService.openPaneComposite(targetViewletId, ViewContainerLocation.Sidebar, true);
+registerAction2(class extends SwitchCompositeViewAction {
+	constructor() {
+		super({
+			id: 'workbench.action.nextSideBarView',
+			title: localize2('nextSideBarView', 'Next Primary Side Bar View'),
+			category: Categories.View,
+			f1: true
+		}, ViewContainerLocation.Sidebar, 1);
 	}
-}
-
-registerAction2(
-	class PreviousSideBarViewAction extends SwitchSideBarViewAction {
-		constructor() {
-			super({
-				id: 'workbench.action.previousSideBarView',
-				title: localize2('previousSideBarView', 'Previous Primary Side Bar View'),
-				category: Categories.View,
-				f1: true
-			}, -1);
-		}
-	}
-);
-
-registerAction2(
-	class NextSideBarViewAction extends SwitchSideBarViewAction {
-		constructor() {
-			super({
-				id: 'workbench.action.nextSideBarView',
-				title: localize2('nextSideBarView', 'Next Primary Side Bar View'),
-				category: Categories.View,
-				f1: true
-			}, 1);
-		}
-	}
-);
+});
 
 registerAction2(
 	class FocusActivityBarAction extends Action2 {

--- a/src/vs/workbench/browser/parts/auxiliarybar/auxiliaryBarActions.ts
+++ b/src/vs/workbench/browser/parts/auxiliarybar/auxiliaryBarActions.ts
@@ -141,7 +141,7 @@ registerAction2(class extends SwitchCompositeViewAction {
 	constructor() {
 		super({
 			id: 'workbench.action.previousAuxiliaryBarView',
-			title: localize2('previousAuxiliaryBarView', 'Previous Secondary Bar View'),
+			title: localize2('previousAuxiliaryBarView', 'Previous Secondary Side Bar View'),
 			category: Categories.View,
 			f1: true
 		}, ViewContainerLocation.AuxiliaryBar, -1);
@@ -152,7 +152,7 @@ registerAction2(class extends SwitchCompositeViewAction {
 	constructor() {
 		super({
 			id: 'workbench.action.nextAuxiliaryBarView',
-			title: localize2('nextAuxiliaryBarView', 'Next Secondary Bar View'),
+			title: localize2('nextAuxiliaryBarView', 'Next Secondary Side Bar View'),
 			category: Categories.View,
 			f1: true
 		}, ViewContainerLocation.AuxiliaryBar, 1);

--- a/src/vs/workbench/browser/parts/auxiliarybar/auxiliaryBarActions.ts
+++ b/src/vs/workbench/browser/parts/auxiliarybar/auxiliaryBarActions.ts
@@ -16,7 +16,7 @@ import { IPaneCompositePartService } from '../../../services/panecomposite/brows
 import { ServicesAccessor } from '../../../../platform/instantiation/common/instantiation.js';
 import { KeybindingWeight } from '../../../../platform/keybinding/common/keybindingsRegistry.js';
 import { KeyCode, KeyMod } from '../../../../base/common/keyCodes.js';
-
+import { SwitchCompositeViewAction } from '../compositeBarActions.js';
 
 const auxiliaryBarRightIcon = registerIcon('auxiliarybar-right-layout-icon', Codicon.layoutSidebarRight, localize('toggleAuxiliaryIconRight', 'Icon to toggle the auxiliary bar off in its right position.'));
 const auxiliaryBarRightOffIcon = registerIcon('auxiliarybar-right-off-layout-icon', Codicon.layoutSidebarRightOff, localize('toggleAuxiliaryIconRightOn', 'Icon to toggle the auxiliary bar on in its right position.'));
@@ -136,3 +136,25 @@ MenuRegistry.appendMenuItems([
 		}
 	}
 ]);
+
+registerAction2(class extends SwitchCompositeViewAction {
+	constructor() {
+		super({
+			id: 'workbench.action.previousAuxiliaryBarView',
+			title: localize2('previousAuxiliaryBarView', 'Previous Secondary Bar View'),
+			category: Categories.View,
+			f1: true
+		}, ViewContainerLocation.AuxiliaryBar, -1);
+	}
+});
+
+registerAction2(class extends SwitchCompositeViewAction {
+	constructor() {
+		super({
+			id: 'workbench.action.nextAuxiliaryBarView',
+			title: localize2('nextAuxiliaryBarView', 'Next Secondary Bar View'),
+			category: Categories.View,
+			f1: true
+		}, ViewContainerLocation.AuxiliaryBar, 1);
+	}
+});

--- a/src/vs/workbench/browser/parts/panel/panelActions.ts
+++ b/src/vs/workbench/browser/parts/panel/panelActions.ts
@@ -20,6 +20,7 @@ import { IPaneCompositePartService } from '../../../services/panecomposite/brows
 import { INotificationService } from '../../../../platform/notification/common/notification.js';
 import { ICommandActionTitle } from '../../../../platform/action/common/action.js';
 import { KeybindingWeight } from '../../../../platform/keybinding/common/keybindingsRegistry.js';
+import { SwitchCompositeViewAction } from '../compositeBarActions.js';
 
 const maximizeIcon = registerIcon('panel-maximize', Codicon.chevronUp, localize('maximizeIcon', 'Icon to maximize a panel.'));
 const restoreIcon = registerIcon('panel-restore', Codicon.chevronDown, localize('restoreIcon', 'Icon to restore a panel.'));
@@ -223,54 +224,25 @@ AlignPanelActionConfigs.forEach(alignPanelAction => {
 	});
 });
 
-class SwitchPanelViewAction extends Action2 {
-
-	constructor(id: string, title: ICommandActionTitle) {
-		super({
-			id,
-			title,
-			category: Categories.View,
-			f1: true,
-		});
-	}
-
-	override async run(accessor: ServicesAccessor, offset: number): Promise<void> {
-		const paneCompositeService = accessor.get(IPaneCompositePartService);
-		const pinnedPanels = paneCompositeService.getVisiblePaneCompositeIds(ViewContainerLocation.Panel);
-		const activePanel = paneCompositeService.getActivePaneComposite(ViewContainerLocation.Panel);
-		if (!activePanel) {
-			return;
-		}
-		let targetPanelId: string | undefined;
-		for (let i = 0; i < pinnedPanels.length; i++) {
-			if (pinnedPanels[i] === activePanel.getId()) {
-				targetPanelId = pinnedPanels[(i + pinnedPanels.length + offset) % pinnedPanels.length];
-				break;
-			}
-		}
-		if (typeof targetPanelId === 'string') {
-			await paneCompositeService.openPaneComposite(targetPanelId, ViewContainerLocation.Panel, true);
-		}
-	}
-}
-
-registerAction2(class extends SwitchPanelViewAction {
+registerAction2(class extends SwitchCompositeViewAction {
 	constructor() {
-		super('workbench.action.previousPanelView', localize2('previousPanelView', "Previous Panel View"));
-	}
-
-	override run(accessor: ServicesAccessor): Promise<void> {
-		return super.run(accessor, -1);
+		super({
+			id: 'workbench.action.previousPanelView',
+			title: localize2('previousPanelView', "Previous Panel View"),
+			category: Categories.View,
+			f1: true
+		}, ViewContainerLocation.Panel, -1);
 	}
 });
 
-registerAction2(class extends SwitchPanelViewAction {
+registerAction2(class extends SwitchCompositeViewAction {
 	constructor() {
-		super('workbench.action.nextPanelView', localize2('nextPanelView', "Next Panel View"));
-	}
-
-	override run(accessor: ServicesAccessor): Promise<void> {
-		return super.run(accessor, 1);
+		super({
+			id: 'workbench.action.nextPanelView',
+			title: localize2('nextPanelView', "Next Panel View"),
+			category: Categories.View,
+			f1: true
+		}, ViewContainerLocation.Panel, 1);
 	}
 });
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
