### PR TITLE
Try allowing custom commands to be sent to tsserver by extensions

### DIFF
--- a/extensions/typescript-language-features/src/commands/tsserverRequests.ts
+++ b/extensions/typescript-language-features/src/commands/tsserverRequests.ts
@@ -16,7 +16,7 @@ export class TSServerRequestCommand implements Command {
 		private readonly lazyClientHost: Lazy<TypeScriptServiceClientHost>
 	) { }
 
-	public execute(requestID: keyof TypeScriptRequests, args?: any, config?: any) {
+	public execute(command: keyof TypeScriptRequests, args?: any, config?: any) {
 		// A cancellation token cannot be passed through the command infrastructure
 		const token = nulToken;
 
@@ -36,8 +36,11 @@ export class TSServerRequestCommand implements Command {
 			'completionInfo'
 		];
 
-		if (!allowList.includes(requestID)) { return; }
-		return this.lazyClientHost.value.serviceClient.execute(requestID, args, token, config);
+		if (!allowList.includes(command) || command.startsWith('_')) {
+			return;
+		}
+
+		return this.lazyClientHost.value.serviceClient.execute(command, args, token, config);
 	}
 }
 


### PR DESCRIPTION
For #218275

Limit this to commands that start with `_` which should indicate that it's a private command and prevent clashes with normal TS commands

cc @dbaeumer 