### PR TITLE
fix: don't truncate focused element border in chat editing widget

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/media/chat.css
@@ -557,6 +557,7 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	white-space: nowrap;
 	overflow: hidden;
 	text-overflow: ellipsis;
+	align-content: center;
 }
 
 .interactive-session .chat-editing-session .chat-editing-session-container .monaco-progress-container {
@@ -570,6 +571,10 @@ have to be updated for changes to the rules above, or to support more deeply nes
 	flex-wrap: nowrap;
 	gap: 6px;
 	align-items: center;
+}
+
+.interactive-session .chat-editing-session .chat-editing-session-toolbar-actions {
+	margin: 3px 0px;
 }
 
 .interactive-session .chat-editing-session .monaco-button {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
<img width="369" alt="Screenshot 2024-10-30 at 2 34 10 PM" src="https://github.com/user-attachments/assets/ff854ccd-a5e4-47d8-b445-92d3422a4278">
