### PR TITLE
fix typo in debugger

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/breakpointsView.ts
+++ b/src/vs/workbench/contrib/debug/browser/breakpointsView.ts
@@ -1664,7 +1664,7 @@ registerAction2(class extends Action2 {
 	constructor() {
 		super({
 			id: 'workbench.debug.viewlet.action.toggleBreakpointsActivatedAction',
-			title: localize2('activateBreakpoints', 'Toggle Activate Breakpoints'),
+			title: localize2('activateBreakpoints', 'Toggle Active Breakpoints'),
 			f1: true,
 			icon: icons.breakpointsActivate,
 			menu: {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Related issue: https://github.com/microsoft/vscode/issues/232671

Fixing suspected typo in the debugger part of VS Code. This specifically addresses toggling breakpoints.

Testing:
1. Open the debugger tab of VSCode
2. Hover over the second icon of the breakpoints tab (should look like 2 circles, one shaded and one not)
3. See the string "Toggle Active Breakpoints"