### PR TITLE
clean up aria labels for different REPL editor parts

### DIFF
--- a/src/vs/workbench/contrib/accessibility/browser/accessibilityConfiguration.ts
+++ b/src/vs/workbench/contrib/accessibility/browser/accessibilityConfiguration.ts
@@ -58,8 +58,7 @@ export const enum AccessibilityVerbositySettingId {
 	Hover = 'accessibility.verbosity.hover',
 	Notification = 'accessibility.verbosity.notification',
 	EmptyEditorHint = 'accessibility.verbosity.emptyEditorHint',
-	ReplEditor = 'accessibility.verbosity.notebook',
-	ReplInputHint = 'accessibility.verbosity.replInputHint',
+	ReplEditor = 'accessibility.verbosity.replEditor',
 	Comments = 'accessibility.verbosity.comments',
 	DiffEditorActive = 'accessibility.verbosity.diffEditorActive',
 	Debug = 'accessibility.verbosity.debug',
@@ -164,8 +163,8 @@ const configuration: IConfigurationNode = {
 			description: localize('verbosity.emptyEditorHint', 'Provide information about relevant actions in an empty text editor.'),
 			...baseVerbosityProperty
 		},
-		[AccessibilityVerbositySettingId.ReplInputHint]: {
-			description: localize('verbosity.replInputHint', 'Provide information about relevant actions For the Repl input.'),
+		[AccessibilityVerbositySettingId.ReplEditor]: {
+			description: localize('verbosity.replEditor.description', 'Provide information about how to access the REPL editor accessibility help menu when the REPL editor is focused.'),
 			...baseVerbosityProperty
 		},
 		[AccessibilityVerbositySettingId.Comments]: {

--- a/src/vs/workbench/contrib/interactive/browser/replInputHintContentWidget.ts
+++ b/src/vs/workbench/contrib/interactive/browser/replInputHintContentWidget.ts
@@ -41,7 +41,7 @@ export class ReplInputHintContentWidget extends Disposable implements IContentWi
 		}));
 		const onDidFocusEditorText = Event.debounce(this.editor.onDidFocusEditorText, () => undefined, 500);
 		this._register(onDidFocusEditorText(() => {
-			if (this.editor.hasTextFocus() && this.ariaLabel && configurationService.getValue(AccessibilityVerbositySettingId.ReplInputHint)) {
+			if (this.editor.hasTextFocus() && this.ariaLabel && configurationService.getValue(AccessibilityVerbositySettingId.ReplEditor)) {
 				status(this.ariaLabel);
 			}
 		}));
@@ -121,7 +121,7 @@ export class ReplInputHintContentWidget extends Disposable implements IContentWi
 				? localize('ReplInputAriaLabelHelp', "Use {0} for accessibility help. ", helpKeybinding)
 				: localize('ReplInputAriaLabelHelpNoKb', "Run the Open Accessibility Help command for more information. ");
 
-			this.ariaLabel = helpInfo.concat(actionPart, localize('disableHint', ' Toggle {0} in settings to disable this hint.', AccessibilityVerbositySettingId.ReplInputHint));
+			this.ariaLabel = actionPart.concat(helpInfo, localize('disableHint', ' Toggle {0} in settings to disable this hint.', AccessibilityVerbositySettingId.ReplEditor));
 		}
 	}
 

--- a/src/vs/workbench/contrib/replNotebook/browser/replEditor.ts
+++ b/src/vs/workbench/contrib/replNotebook/browser/replEditor.ts
@@ -58,6 +58,7 @@ import { ReplEditorInput } from './replEditorInput.js';
 import { ReplInputHintContentWidget } from '../../interactive/browser/replInputHintContentWidget.js';
 import { ServiceCollection } from '../../../../platform/instantiation/common/serviceCollection.js';
 import { ICodeEditor } from '../../../../editor/browser/editorBrowser.js';
+import { localize } from '../../../../nls.js';
 
 const INTERACTIVE_EDITOR_VIEW_STATE_PREFERENCE_KEY = 'InteractiveEditorViewState';
 
@@ -276,6 +277,7 @@ export class ReplEditor extends EditorPane implements IEditorPaneWithScrolling {
 			...editorOptions,
 			...editorOptionsOverride,
 			...{
+				ariaLabel: localize('replEditorInput', "REPL Input"),
 				glyphMargin: true,
 				padding: {
 					top: INPUT_EDITOR_PADDING,


### PR DESCRIPTION
- Combine REPL verbosity settings into a single setting
- Use the REPL editor verbosity setting correctly
- Provide an Aria label for the REPL input editor, to clarify what that editor is for
