### PR TITLE
Disable caching of dev device id + fallback to UUID

### DIFF
--- a/src/vs/base/node/id.ts
+++ b/src/vs/base/node/id.ts
@@ -122,6 +122,6 @@ export async function getdevDeviceId(errorLogger: (error: any) => void): Promise
 		return id;
 	} catch (err) {
 		errorLogger(err);
-		return '';
+		return uuid.generateUuid();
 	}
 }

--- a/src/vs/code/node/cliProcessMain.ts
+++ b/src/vs/code/node/cliProcessMain.ts
@@ -186,7 +186,7 @@ class CliMain extends Disposable {
 			}
 		}
 		const sqmId = await resolveSqmId(stateService, logService);
-		const devDeviceId = await resolvedevDeviceId(stateService, logService);
+		const devDeviceId = await resolvedevDeviceId(logService);
 
 		// Initialize user data profiles after initializing the state
 		userDataProfilesService.init();

--- a/src/vs/platform/telemetry/common/telemetry.ts
+++ b/src/vs/platform/telemetry/common/telemetry.ts
@@ -74,7 +74,6 @@ export const firstSessionDateStorageKey = 'telemetry.firstSessionDate';
 export const lastSessionDateStorageKey = 'telemetry.lastSessionDate';
 export const machineIdKey = 'telemetry.machineId';
 export const sqmIdKey = 'telemetry.sqmId';
-export const devDeviceIdKey = 'telemetry.devDeviceId';
 
 // Configuration Keys
 export const TELEMETRY_SECTION_ID = 'telemetry';

--- a/src/vs/platform/telemetry/electron-main/telemetryUtils.ts
+++ b/src/vs/platform/telemetry/electron-main/telemetryUtils.ts
@@ -5,7 +5,7 @@
 
 import { ILogService } from '../../log/common/log.js';
 import { IStateService } from '../../state/node/state.js';
-import { machineIdKey, sqmIdKey, devDeviceIdKey } from '../common/telemetry.js';
+import { machineIdKey, sqmIdKey } from '../common/telemetry.js';
 import { resolveMachineId as resolveNodeMachineId, resolveSqmId as resolveNodeSqmId, resolvedevDeviceId as resolveNodedevDeviceId } from '../node/telemetryUtils.js';
 
 export async function resolveMachineId(stateService: IStateService, logService: ILogService): Promise<string> {
@@ -22,7 +22,6 @@ export async function resolveSqmId(stateService: IStateService, logService: ILog
 }
 
 export async function resolvedevDeviceId(stateService: IStateService, logService: ILogService): Promise<string> {
-	const devDeviceId = await resolveNodedevDeviceId(stateService, logService);
-	stateService.setItem(devDeviceIdKey, devDeviceId);
+	const devDeviceId = await resolveNodedevDeviceId(logService);
 	return devDeviceId;
 }

--- a/src/vs/platform/telemetry/node/telemetryUtils.ts
+++ b/src/vs/platform/telemetry/node/telemetryUtils.ts
@@ -7,7 +7,7 @@ import { isMacintosh } from '../../../base/common/platform.js';
 import { getMachineId, getSqmMachineId, getdevDeviceId } from '../../../base/node/id.js';
 import { ILogService } from '../../log/common/log.js';
 import { IStateReadService } from '../../state/node/state.js';
-import { machineIdKey, sqmIdKey, devDeviceIdKey } from '../common/telemetry.js';
+import { machineIdKey, sqmIdKey } from '../common/telemetry.js';
 
 
 export async function resolveMachineId(stateService: IStateReadService, logService: ILogService): Promise<string> {
@@ -30,11 +30,7 @@ export async function resolveSqmId(stateService: IStateReadService, logService: 
 	return sqmId;
 }
 
-export async function resolvedevDeviceId(stateService: IStateReadService, logService: ILogService): Promise<string> {
-	let devDeviceId = stateService.getItem<string>(devDeviceIdKey);
-	if (typeof devDeviceId !== 'string') {
-		devDeviceId = await getdevDeviceId(logService.error.bind(logService));
-	}
-
+export async function resolvedevDeviceId(logService: ILogService): Promise<string> {
+	const devDeviceId = await getdevDeviceId(logService.error.bind(logService));
 	return devDeviceId;
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
This stops using the state service to cache device ids. This is because to get the most accurate info we should always read to disk as other applications can write to this file. Additionally we now fallback to a UUID so the id is never empty.