### PR TITLE
Send normalized canonical path to debug adapter always

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/debugSession.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugSession.ts
@@ -481,10 +481,6 @@ export class DebugSession implements IDebugSession, IDisposable {
 		if (breakpointsToSend.length && !rawSource.adapterData) {
 			rawSource.adapterData = breakpointsToSend[0].adapterData;
 		}
-		// Normalize all drive letters going out from vscode to debug adapters so we are consistent with our resolving #43959
-		if (rawSource.path) {
-			rawSource.path = normalizeDriveLetter(rawSource.path);
-		}
 
 		const response = await this.raw.setBreakpoints({
 			source: rawSource,
@@ -1506,10 +1502,17 @@ export class DebugSession implements IDebugSession, IDisposable {
 
 	private getRawSource(uri: URI): DebugProtocol.Source {
 		const source = this.getSourceForUri(uri);
+		const data = Source.getEncodedDebugData(uri);
+
 		if (source) {
+			if (source.raw.path) {
+				// Always use normalized canonical path for consistency #232088
+				// Normalize all drive letters going out from vscode to debug adapters so we are consistent with our resolving #43959
+				source.raw.path = normalizeDriveLetter(data.path);
+			}
+
 			return source.raw;
 		} else {
-			const data = Source.getEncodedDebugData(uri);
 			return { name: data.name, path: data.path, sourceReference: data.sourceReference };
 		}
 	}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fix #232088.

VS Code sends inconsistent paths across different setBreakpoints requests in the same session, in case the debug adapter sends differently cased path in Source as part of stack resolution or other responses. This is common in case insensitive file systems and can create issues for underlying debug adapter or debuggers like lldb.

We already normalize drive letter on Windows before sending it to debug adapter to be consistent. Extend this to normalize and use the canonical path for the entire path, instead of just normalizing the drive letter. This makes different setBreakpoints requests have consistent path string for the same path in case-insensitive file systems.
