### PR TITLE
[Edit Context]: Introduce text area into which code is pasted 

### DIFF
--- a/src/vs/editor/browser/controller/editContext/editContext.ts
+++ b/src/vs/editor/browser/controller/editContext/editContext.ts
@@ -16,4 +16,5 @@ export abstract class AbstractEditContext extends ViewPart {
 	abstract setAriaOptions(options: IEditorAriaOptions): void;
 	abstract getLastRenderData(): Position | null;
 	abstract writeScreenReaderContent(reason: string): void;
+	abstract getTextAreaDomNode(): HTMLTextAreaElement;
 }

--- a/src/vs/editor/browser/controller/editContext/native/nativeEditContext.css
+++ b/src/vs/editor/browser/controller/editContext/native/nativeEditContext.css
@@ -13,6 +13,21 @@
 	text-wrap: nowrap;
 }
 
+.monaco-editor .native-edit-context-textarea {
+	min-width: 0;
+	min-height: 0;
+	margin: 0;
+	padding: 0;
+	position: absolute;
+	outline: none !important;
+	resize: none;
+	border: none;
+	overflow: hidden;
+	color: transparent;
+	background-color: transparent;
+	z-index: -10;
+}
+
 .monaco-editor .edit-context-composition-none {
 	background-color: transparent;
 	border-bottom: none;

--- a/src/vs/editor/browser/controller/editContext/native/nativeEditContext.ts
+++ b/src/vs/editor/browser/controller/editContext/native/nativeEditContext.ts
@@ -39,6 +39,8 @@ enum CompositionClassName {
 
 export class NativeEditContext extends AbstractEditContext {
 
+	// Text area used to handle paste events
+	public readonly textArea: FastDomNode<HTMLTextAreaElement>;
 	public readonly domNode: FastDomNode<HTMLDivElement>;
 	private readonly _editContext: EditContext;
 	private readonly _screenReaderSupport: ScreenReaderSupport;
@@ -69,9 +71,12 @@ export class NativeEditContext extends AbstractEditContext {
 
 		this.domNode = new FastDomNode(document.createElement('div'));
 		this.domNode.setClassName(`native-edit-context`);
+		this.textArea = new FastDomNode(document.createElement('textarea'));
+		this.textArea.setClassName(`native-edit-context-textarea`);
 		this._updateDomAttributes();
 
 		overflowGuardContainer.appendChild(this.domNode);
+		overflowGuardContainer.appendChild(this.textArea);
 		this._parent = overflowGuardContainer.domNode;
 
 		this._selectionChangeListener = this._register(new MutableDisposable());
@@ -140,6 +145,10 @@ export class NativeEditContext extends AbstractEditContext {
 		super.dispose();
 	}
 
+	public getTextAreaDomNode(): HTMLTextAreaElement {
+		return this.textArea.domNode;
+	}
+
 	public setAriaOptions(): void {
 		this._screenReaderSupport.setAriaOptions();
 	}
@@ -176,7 +185,9 @@ export class NativeEditContext extends AbstractEditContext {
 		this._screenReaderSupport.writeScreenReaderContent();
 	}
 
-	public isFocused(): boolean { return this._focusTracker.isFocused; }
+	public isFocused(): boolean {
+		return this._focusTracker.isFocused || (getActiveWindow().document.activeElement === this.textArea.domNode);
+	}
 
 	public focus(): void {
 		this._focusTracker.focus();

--- a/src/vs/editor/browser/controller/editContext/textArea/textAreaEditContext.ts
+++ b/src/vs/editor/browser/controller/editContext/textArea/textAreaEditContext.ts
@@ -474,6 +474,10 @@ export class TextAreaEditContext extends AbstractEditContext {
 		this._textAreaInput.writeNativeTextAreaContent(reason);
 	}
 
+	public getTextAreaDomNode(): HTMLTextAreaElement {
+		return this.textArea.domNode;
+	}
+
 	public override dispose(): void {
 		super.dispose();
 		this.textArea.domNode.remove();

--- a/src/vs/editor/browser/editorBrowser.ts
+++ b/src/vs/editor/browser/editorBrowser.ts
@@ -1078,6 +1078,11 @@ export interface ICodeEditor extends editorCommon.IEditor {
 	getContainerDomNode(): HTMLElement;
 
 	/**
+	 * Return this editor's text area dom node
+	 */
+	getTextAreaDomNode(): HTMLTextAreaElement | undefined;
+
+	/**
 	 * Returns the editor's dom node
 	 */
 	getDomNode(): HTMLElement | null;

--- a/src/vs/editor/browser/view.ts
+++ b/src/vs/editor/browser/view.ts
@@ -674,6 +674,10 @@ export class View extends ViewEventHandler {
 		this._scheduleRender();
 	}
 
+	public getTextAreaDomNode(): HTMLTextAreaElement {
+		return this._editContext.getTextAreaDomNode();
+	}
+
 	public layoutContentWidget(widgetData: IContentWidgetData): void {
 		this._contentWidgets.setWidgetPosition(
 			widgetData.widget,

--- a/src/vs/editor/browser/widget/codeEditor/codeEditorWidget.ts
+++ b/src/vs/editor/browser/widget/codeEditor/codeEditorWidget.ts
@@ -1394,6 +1394,10 @@ export class CodeEditorWidget extends Disposable implements editorBrowser.ICodeE
 		return this._domElement;
 	}
 
+	public getTextAreaDomNode(): HTMLTextAreaElement | undefined {
+		return this._modelData?.view.getTextAreaDomNode();
+	}
+
 	public getDomNode(): HTMLElement | null {
 		if (!this._modelData || !this._modelData.hasRealView) {
 			return null;

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -6063,6 +6063,10 @@ declare namespace monaco.editor {
 		 */
 		getContainerDomNode(): HTMLElement;
 		/**
+		 * Return this editor's text area dom node
+		 */
+		getTextAreaDomNode(): HTMLTextAreaElement | undefined;
+		/**
 		 * Returns the editor's dom node
 		 */
 		getDomNode(): HTMLElement | null;


### PR DESCRIPTION
fixes https://github.com/microsoft/vscode/issues/231707

Since execCommand executes the command on the current focused element in the given document, that is why we need to focus the text area dom node, before calling exec command on it, and then restoring the focus to the previously focused HTML element.