### PR TITLE
perf - validate device ID after window open

### DIFF
--- a/src/vs/code/electron-main/app.ts
+++ b/src/vs/code/electron-main/app.ts
@@ -102,7 +102,7 @@ import { ExtensionsScannerService } from '../../platform/extensionManagement/nod
 import { UserDataProfilesHandler } from '../../platform/userDataProfile/electron-main/userDataProfilesHandler.js';
 import { ProfileStorageChangesListenerChannel } from '../../platform/userDataProfile/electron-main/userDataProfileStorageIpc.js';
 import { Promises, RunOnceScheduler, runWhenGlobalIdle } from '../../base/common/async.js';
-import { resolveMachineId, resolveSqmId, resolvedevDeviceId } from '../../platform/telemetry/electron-main/telemetryUtils.js';
+import { resolveMachineId, resolveSqmId, resolvedevDeviceId, validatedevDeviceId } from '../../platform/telemetry/electron-main/telemetryUtils.js';
 import { ExtensionsProfileScannerService } from '../../platform/extensionManagement/node/extensionsProfileScannerService.js';
 import { LoggerChannel } from '../../platform/log/electron-main/logIpc.js';
 import { ILoggerMainService } from '../../platform/log/electron-main/loggerService.js';
@@ -1374,6 +1374,9 @@ export class CodeApplication extends Disposable {
 		if (isMacintosh && app.runningUnderARM64Translation) {
 			this.windowsMainService?.sendToFocused('vscode:showTranslatedBuildWarning');
 		}
+
+		// Validate Device ID is up to date
+		validatedevDeviceId(this.stateService, this.logService);
 	}
 
 	private async installMutex(): Promise<void> {

--- a/src/vs/code/electron-main/app.ts
+++ b/src/vs/code/electron-main/app.ts
@@ -146,8 +146,7 @@ export class CodeApplication extends Disposable {
 		@IStateService private readonly stateService: IStateService,
 		@IFileService private readonly fileService: IFileService,
 		@IProductService private readonly productService: IProductService,
-		@IUserDataProfilesMainService private readonly userDataProfilesMainService: IUserDataProfilesMainService,
-		@ITelemetryService private readonly telemetryService: ITelemetryService
+		@IUserDataProfilesMainService private readonly userDataProfilesMainService: IUserDataProfilesMainService
 	) {
 		super();
 
@@ -1377,7 +1376,7 @@ export class CodeApplication extends Disposable {
 		}
 
 		// Validate Device ID is up to date
-		validatedevDeviceId(this.stateService, this.logService, this.telemetryService);
+		validatedevDeviceId(this.stateService, this.logService);
 	}
 
 	private async installMutex(): Promise<void> {

--- a/src/vs/code/electron-main/app.ts
+++ b/src/vs/code/electron-main/app.ts
@@ -146,7 +146,8 @@ export class CodeApplication extends Disposable {
 		@IStateService private readonly stateService: IStateService,
 		@IFileService private readonly fileService: IFileService,
 		@IProductService private readonly productService: IProductService,
-		@IUserDataProfilesMainService private readonly userDataProfilesMainService: IUserDataProfilesMainService
+		@IUserDataProfilesMainService private readonly userDataProfilesMainService: IUserDataProfilesMainService,
+		@ITelemetryService private readonly telemetryService: ITelemetryService
 	) {
 		super();
 
@@ -1376,7 +1377,7 @@ export class CodeApplication extends Disposable {
 		}
 
 		// Validate Device ID is up to date
-		validatedevDeviceId(this.stateService, this.logService);
+		validatedevDeviceId(this.stateService, this.logService, this.telemetryService);
 	}
 
 	private async installMutex(): Promise<void> {

--- a/src/vs/code/node/cliProcessMain.ts
+++ b/src/vs/code/node/cliProcessMain.ts
@@ -186,7 +186,7 @@ class CliMain extends Disposable {
 			}
 		}
 		const sqmId = await resolveSqmId(stateService, logService);
-		const devDeviceId = await resolvedevDeviceId(logService);
+		const devDeviceId = await resolvedevDeviceId(stateService, logService);
 
 		// Initialize user data profiles after initializing the state
 		userDataProfilesService.init();

--- a/src/vs/platform/telemetry/common/commonProperties.ts
+++ b/src/vs/platform/telemetry/common/commonProperties.ts
@@ -34,7 +34,7 @@ export function resolveCommonProperties(
 	result['common.machineId'] = machineId;
 	// __GDPR__COMMON__ "common.sqmId" : { "endPoint": "SqmMachineId", "classification": "EndUserPseudonymizedInformation", "purpose": "BusinessInsight" }
 	result['common.sqmId'] = sqmId;
-	// __GDPR__COMMON__ "common.devDeviceId" : { "endPoint": "SqmUserId", "classification": "EndUserPseudonymizedInformation", "purpose": "BusinessInsight" }
+	// __GDPR__COMMON__ "common.devDeviceId" : { "endPoint": "SqmMachineId", "classification": "EndUserPseudonymizedInformation", "purpose": "BusinessInsight" }
 	result['common.devDeviceId'] = devDeviceId;
 	// __GDPR__COMMON__ "sessionID" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" }
 	result['sessionID'] = generateUuid() + Date.now();

--- a/src/vs/platform/telemetry/common/commonProperties.ts
+++ b/src/vs/platform/telemetry/common/commonProperties.ts
@@ -34,7 +34,7 @@ export function resolveCommonProperties(
 	result['common.machineId'] = machineId;
 	// __GDPR__COMMON__ "common.sqmId" : { "endPoint": "SqmMachineId", "classification": "EndUserPseudonymizedInformation", "purpose": "BusinessInsight" }
 	result['common.sqmId'] = sqmId;
-	// __GDPR__COMMON__ "common.devDeviceId" : { "endPoint": "SqmMachineId", "classification": "EndUserPseudonymizedInformation", "purpose": "BusinessInsight" }
+	// __GDPR__COMMON__ "common.devDeviceId" : { "endPoint": "SqmUserId", "classification": "EndUserPseudonymizedInformation", "purpose": "BusinessInsight" }
 	result['common.devDeviceId'] = devDeviceId;
 	// __GDPR__COMMON__ "sessionID" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" }
 	result['sessionID'] = generateUuid() + Date.now();

--- a/src/vs/platform/telemetry/common/telemetry.ts
+++ b/src/vs/platform/telemetry/common/telemetry.ts
@@ -74,6 +74,7 @@ export const firstSessionDateStorageKey = 'telemetry.firstSessionDate';
 export const lastSessionDateStorageKey = 'telemetry.lastSessionDate';
 export const machineIdKey = 'telemetry.machineId';
 export const sqmIdKey = 'telemetry.sqmId';
+export const devDeviceIdKey = 'telemetry.devDeviceId';
 
 // Configuration Keys
 export const TELEMETRY_SECTION_ID = 'telemetry';

--- a/src/vs/platform/telemetry/electron-main/telemetryUtils.ts
+++ b/src/vs/platform/telemetry/electron-main/telemetryUtils.ts
@@ -3,9 +3,10 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { getdevDeviceId } from '../../../base/node/id.js';
 import { ILogService } from '../../log/common/log.js';
 import { IStateService } from '../../state/node/state.js';
-import { machineIdKey, sqmIdKey } from '../common/telemetry.js';
+import { machineIdKey, sqmIdKey, devDeviceIdKey } from '../common/telemetry.js';
 import { resolveMachineId as resolveNodeMachineId, resolveSqmId as resolveNodeSqmId, resolvedevDeviceId as resolveNodedevDeviceId } from '../node/telemetryUtils.js';
 
 export async function resolveMachineId(stateService: IStateService, logService: ILogService): Promise<string> {
@@ -22,6 +23,15 @@ export async function resolveSqmId(stateService: IStateService, logService: ILog
 }
 
 export async function resolvedevDeviceId(stateService: IStateService, logService: ILogService): Promise<string> {
-	const devDeviceId = await resolveNodedevDeviceId(logService);
+	const devDeviceId = await resolveNodedevDeviceId(stateService, logService);
+	stateService.setItem(devDeviceIdKey, devDeviceId);
 	return devDeviceId;
+}
+
+export async function validatedevDeviceId(stateService: IStateService, logService: ILogService): Promise<void> {
+	const actualDeviceId = await getdevDeviceId(logService.error.bind(logService));
+	const currentDeviceId = await resolveNodedevDeviceId(stateService, logService);
+	if (actualDeviceId !== currentDeviceId) {
+		stateService.setItem(devDeviceIdKey, actualDeviceId);
+	}
 }

--- a/src/vs/platform/telemetry/electron-main/telemetryUtils.ts
+++ b/src/vs/platform/telemetry/electron-main/telemetryUtils.ts
@@ -6,7 +6,7 @@
 import { getdevDeviceId } from '../../../base/node/id.js';
 import { ILogService } from '../../log/common/log.js';
 import { IStateService } from '../../state/node/state.js';
-import { machineIdKey, sqmIdKey, devDeviceIdKey, ITelemetryService } from '../common/telemetry.js';
+import { machineIdKey, sqmIdKey, devDeviceIdKey } from '../common/telemetry.js';
 import { resolveMachineId as resolveNodeMachineId, resolveSqmId as resolveNodeSqmId, resolvedevDeviceId as resolveNodedevDeviceId } from '../node/telemetryUtils.js';
 
 export async function resolveMachineId(stateService: IStateService, logService: ILogService): Promise<string> {
@@ -28,20 +28,10 @@ export async function resolvedevDeviceId(stateService: IStateService, logService
 	return devDeviceId;
 }
 
-export async function validatedevDeviceId(stateService: IStateService, logService: ILogService, telemetryService: ITelemetryService): Promise<void> {
+export async function validatedevDeviceId(stateService: IStateService, logService: ILogService): Promise<void> {
 	const actualDeviceId = await getdevDeviceId(logService.error.bind(logService));
 	const currentDeviceId = await resolveNodedevDeviceId(stateService, logService);
 	if (actualDeviceId !== currentDeviceId) {
 		stateService.setItem(devDeviceIdKey, actualDeviceId);
-		telemetryService.publicLog2<
-			{
-				oldDeviceId: string;
-			},
-			{
-				owner: 'lramos15';
-				comment: 'Whenever the dev device id changes we collect this event to understand how often this is happening';
-				oldDeviceId: { classification: 'EndUserPseudonymizedInformation'; purpose: 'BusinessInsight'; endpoint: 'SqmUserId'; comment: 'The previous dev device id' };
-			}
-		>('devDeviceIdMismatch', { oldDeviceId: currentDeviceId });
 	}
 }

--- a/src/vs/platform/telemetry/node/telemetryUtils.ts
+++ b/src/vs/platform/telemetry/node/telemetryUtils.ts
@@ -7,7 +7,7 @@ import { isMacintosh } from '../../../base/common/platform.js';
 import { getMachineId, getSqmMachineId, getdevDeviceId } from '../../../base/node/id.js';
 import { ILogService } from '../../log/common/log.js';
 import { IStateReadService } from '../../state/node/state.js';
-import { machineIdKey, sqmIdKey } from '../common/telemetry.js';
+import { machineIdKey, sqmIdKey, devDeviceIdKey } from '../common/telemetry.js';
 
 
 export async function resolveMachineId(stateService: IStateReadService, logService: ILogService): Promise<string> {
@@ -30,7 +30,11 @@ export async function resolveSqmId(stateService: IStateReadService, logService: 
 	return sqmId;
 }
 
-export async function resolvedevDeviceId(logService: ILogService): Promise<string> {
-	const devDeviceId = await getdevDeviceId(logService.error.bind(logService));
+export async function resolvedevDeviceId(stateService: IStateReadService, logService: ILogService): Promise<string> {
+	let devDeviceId = stateService.getItem<string>(devDeviceIdKey);
+	if (typeof devDeviceId !== 'string') {
+		devDeviceId = await getdevDeviceId(logService.error.bind(logService));
+	}
+
 	return devDeviceId;
 }


### PR DESCRIPTION
This partially reverts https://github.com/microsoft/vscode/commit/e64fb06b203b6442989a2e803399c1c636453028 and adds a new validation method that is run after windows open to ensure the resolution of device ID does not always block startup.