### PR TITLE
fix: reset request failed context key for chat editing when session is cleared

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingService.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingService.ts
@@ -136,6 +136,7 @@ export class ChatEditingService extends Disposable implements IChatEditingServic
 			return this._currentSessionObs.read(r)?.canRedo.read(r) || false;
 		}));
 		this._register(this._chatService.onDidDisposeSession((e) => {
+			this._applyingChatEditsFailedContextKey.set(false);
 			if (e.reason === 'cleared' && this._currentSessionObs.get()?.chatSessionId === e.sessionId) {
 				void this._currentSessionObs.get()?.stop();
 			}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
