### PR TITLE
Improve quoting in executeCommand API

### DIFF
--- a/src/vs/workbench/api/common/extHostTerminalShellIntegration.ts
+++ b/src/vs/workbench/api/common/extHostTerminalShellIntegration.ts
@@ -174,9 +174,16 @@ class InternalTerminalShellIntegration extends Disposable {
 			// executeCommand(commandLine: string): vscode.TerminalShellExecution;
 			// executeCommand(executable: string, args: string[]): vscode.TerminalShellExecution;
 			executeCommand(commandLineOrExecutable: string, args?: string[]): vscode.TerminalShellExecution {
-				let commandLineValue: string = commandLineOrExecutable;
-				if (args && args.length > 0) {
-					commandLineValue += ` "${args.map(e => `${e.replaceAll('"', '\\"')}`).join('" "')}"`;
+				let commandLineValue = commandLineOrExecutable;
+				if (args) {
+					for (const arg of args) {
+						const wrapInQuotes = !arg.match(/["'`]/) && arg.match(/\s/);
+						if (wrapInQuotes) {
+							commandLineValue += ` "${arg}"`;
+						} else {
+							commandLineValue += ` ${arg}`;
+						}
+					}
 				}
 
 				that._onDidRequestShellExecution.fire(commandLineValue);

--- a/src/vscode-dts/vscode.d.ts
+++ b/src/vscode-dts/vscode.d.ts
@@ -7504,8 +7504,13 @@ declare module 'vscode' {
 		 * verify whether it was successful.
 		 *
 		 * @param executable A command to run.
-		 * @param args Arguments to launch the executable with which will be automatically escaped
-		 * based on the executable type.
+		 * @param args Arguments to launch the executable with. The arguments will be escaped such
+		 * that they are interpreted as single arguments when the argument both contains whitespace
+		 * and does not include any single quote, double quote or backtick characters.
+		 *
+		 * Note that this escaping is not intended to be a security measure, be careful when passing
+		 * untrusted data to this API as strings like `$(...)` can often be used in shells to
+		 * execute code within a string.
 		 *
 		 * @example
 		 * // Execute a command in a terminal immediately after being created


### PR DESCRIPTION
Fixes #232757

Testing this with `terminal.shellIntegration.executeCommand('cd', ["a b", "c", "\"d\"", "'e'"]);`

Before:

![image](https://github.com/user-attachments/assets/eb52cf4a-1d33-4a06-97bd-3315d4b91d2e)

After:

![image](https://github.com/user-attachments/assets/9872dcf8-26ee-485b-b4b5-7edb801802b7)
