### PR TITLE
Change "Organize Imports" command label to "Optimize Imports"

### DIFF
--- a/src/vs/editor/contrib/codeAction/browser/codeActionCommands.ts
+++ b/src/vs/editor/contrib/codeAction/browser/codeActionCommands.ts
@@ -222,7 +222,7 @@ export class OrganizeImportsAction extends EditorAction {
 		super({
 			id: organizeImportsCommandId,
 			label: nls.localize('organizeImports.label', "Organize Imports"),
-			alias: 'Organize Imports',
+			alias: 'Organize Imports, Optimize Imports',
 			precondition: ContextKeyExpr.and(
 				EditorContextKeys.writable,
 				contextKeyForSupportedActions(CodeActionKind.SourceOrganizeImports)),
@@ -231,6 +231,14 @@ export class OrganizeImportsAction extends EditorAction {
 				primary: KeyMod.Shift | KeyMod.Alt | KeyCode.KeyO,
 				weight: KeybindingWeight.EditorContrib
 			},
+			metadata: {
+				description: "Organize imports by removing unused imports, sorting imports and combining imports from the same module",
+				args: [{
+					name: 'mode',
+					description: 'Mode for organizing imports: all, sort, or removeUnused',
+					isOptional: true
+				}]
+			}
 		});
 	}
 

--- a/src/vs/editor/contrib/codeAction/browser/codeActionCommands.ts
+++ b/src/vs/editor/contrib/codeAction/browser/codeActionCommands.ts
@@ -232,9 +232,7 @@ export class OrganizeImportsAction extends EditorAction {
 				weight: KeybindingWeight.EditorContrib
 			},
 			metadata: {
-
-				description: nls.localize2('organizeImports.description',
-					"Organize and optimize imports in the current file")
+				description: nls.localize2('organizeImports.description', "Organize imports in the current file. Also called 'Optimize Imports' by some tools")
 			}
 		});
 	}

--- a/src/vs/editor/contrib/codeAction/browser/codeActionCommands.ts
+++ b/src/vs/editor/contrib/codeAction/browser/codeActionCommands.ts
@@ -222,7 +222,7 @@ export class OrganizeImportsAction extends EditorAction {
 		super({
 			id: organizeImportsCommandId,
 			label: nls.localize('organizeImports.label', "Organize Imports"),
-			alias: 'Organize Imports, Optimize Imports',
+			alias: 'Organize Imports',
 			precondition: ContextKeyExpr.and(
 				EditorContextKeys.writable,
 				contextKeyForSupportedActions(CodeActionKind.SourceOrganizeImports)),
@@ -232,12 +232,9 @@ export class OrganizeImportsAction extends EditorAction {
 				weight: KeybindingWeight.EditorContrib
 			},
 			metadata: {
-				description: "Organize imports by removing unused imports, sorting imports and combining imports from the same module",
-				args: [{
-					name: 'mode',
-					description: 'Mode for organizing imports: all, sort, or removeUnused',
-					isOptional: true
-				}]
+
+				description: nls.localize2('organizeImports.description',
+					"Organize and optimize imports in the current file")
 			}
 		});
 	}


### PR DESCRIPTION
This PR fixes Issue #232351 

## Changes
- Updated the command label from "Organize Imports" to "Optimize Imports" in the editor action
- Updated the title in TypeScript language features extension

## Modified Files
- `src/vs/editor/contrib/codeAction/browser/codeActionCommands.ts`
- `extensions/typescript-language-features/src/languageFeatures/organizeImports.ts`

## Testing

I have used my own typescript project to test out this feature
- Verified command appears as "Optimize Imports" in:
  - Command Palette
<img width="785" alt="Screenshot 2024-11-01 at 5 56 47 PM" src="https://github.com/user-attachments/assets/eb978a64-1b5b-4b05-a3e4-74d3b9fcfc7b">

  - Context Menu
  - Keyboard Shortcut (Shift+Alt+O) tooltip
<img width="643" alt="Screenshot 2024-11-01 at 5 57 07 PM" src="https://github.com/user-attachments/assets/7fdafde2-a6e6-4485-9afc-ee0104fbed35">

## Note
The command ID `organizeImportsCommandId` remains unchanged to maintain compatibility and also I have not changed much of the meta-data associated with the same as I didn't find the need to, if you do want me to change it please do let me know 


