### PR TITLE
Add `paste as` default settings and enable js/ts paste with imports by default

### DIFF
--- a/extensions/typescript-language-features/package.json
+++ b/extensions/typescript-language-features/package.json
@@ -1506,23 +1506,17 @@
           "description": "%typescript.tsserver.enableRegionDiagnostics%",
           "scope": "window"
         },
-        "javascript.experimental.updateImportsOnPaste": {
+        "javascript.updateImportsOnPaste.enabled": {
           "scope": "window",
           "type": "boolean",
-          "default": false,
-          "description": "%configuration.updateImportsOnPaste%",
-          "tags": [
-            "experimental"
-          ]
+          "default": true,
+          "markdownDescription": "%configuration.updateImportsOnPaste%"
         },
-        "typescript.experimental.updateImportsOnPaste": {
+        "typescript.updateImportsOnPaste.enabled": {
           "scope": "window",
           "type": "boolean",
-          "default": false,
-          "description": "%configuration.updateImportsOnPaste%",
-          "tags": [
-            "experimental"
-          ]
+          "default": true,
+          "markdownDescription": "%configuration.updateImportsOnPaste%"
         },
         "typescript.experimental.expandableHover": {
           "type": "boolean",

--- a/extensions/typescript-language-features/package.nls.json
+++ b/extensions/typescript-language-features/package.nls.json
@@ -224,7 +224,7 @@
 	"configuration.tsserver.web.projectWideIntellisense.suppressSemanticErrors": "Suppresses semantic errors on web even when project wide IntelliSense is enabled. This is always on when project wide IntelliSense is not enabled or available. See `#typescript.tsserver.web.projectWideIntellisense.enabled#`",
 	"configuration.tsserver.web.typeAcquisition.enabled": "Enable/disable package acquisition on the web. This enables IntelliSense for imported packages. Requires `#typescript.tsserver.web.projectWideIntellisense.enabled#`. Currently not supported for Safari.",
 	"configuration.tsserver.nodePath": "Run TS Server on a custom Node installation. This can be a path to a Node executable, or 'node' if you want VS Code to detect a Node installation.",
-	"configuration.updateImportsOnPaste": "Automatically update imports when pasting code. Requires TypeScript 5.7+.",
+	"configuration.updateImportsOnPaste": "Enable updating imports when pasting code. Requires TypeScript 5.7+.\n\nBy default this shows a option to update imports after pasting. You can use the `#editor.pasteAs.preferences#` setting to update imports automatically when pasting: `\"editor.pasteAs.preferences\": [{ \"kind\": \"text.jsts.pasteWithImports\" }]`.",
 	"configuration.expandableHover": "Enable/disable expanding on hover.",
 	"walkthroughs.nodejsWelcome.title": "Get started with JavaScript and Node.js",
 	"walkthroughs.nodejsWelcome.description": "Make the most of Visual Studio Code's first-class JavaScript experience.",

--- a/extensions/typescript-language-features/src/languageFeatures/copyPaste.ts
+++ b/extensions/typescript-language-features/src/languageFeatures/copyPaste.ts
@@ -38,7 +38,7 @@ class CopyMetadata {
 	}
 }
 
-const settingId = 'experimental.updateImportsOnPaste';
+const enabledSettingId = 'updateImportsOnPaste.enabled';
 
 class DocumentPasteProvider implements vscode.DocumentPasteEditProvider {
 
@@ -127,6 +127,8 @@ class DocumentPasteProvider implements vscode.DocumentPasteEditProvider {
 		}
 
 		const edit = new vscode.DocumentPasteEdit('', vscode.l10n.t("Paste with imports"), DocumentPasteProvider.kind);
+		edit.yieldTo = [vscode.DocumentDropOrPasteEditKind.Empty.append('text', 'plain')];
+
 		const additionalEdit = new vscode.WorkspaceEdit();
 		for (const edit of response.body.edits) {
 			additionalEdit.set(this._client.toResource(edit.fileName), edit.textChanges.map(typeConverters.TextEdit.fromCodeEdit));
@@ -146,7 +148,7 @@ class DocumentPasteProvider implements vscode.DocumentPasteEditProvider {
 
 	private isEnabled(document: vscode.TextDocument) {
 		const config = vscode.workspace.getConfiguration(this._modeId, document.uri);
-		return config.get(settingId, false);
+		return config.get(enabledSettingId, false);
 	}
 }
 
@@ -154,7 +156,7 @@ export function register(selector: DocumentSelector, language: LanguageDescripti
 	return conditionalRegistration([
 		requireSomeCapability(client, ClientCapability.Semantic),
 		requireMinVersion(client, API.v570),
-		requireGlobalConfiguration(language.id, settingId),
+		requireGlobalConfiguration(language.id, enabledSettingId),
 	], () => {
 		return vscode.languages.registerDocumentPasteEditProvider(selector.semantic, new DocumentPasteProvider(language.id, client), {
 			providedPasteEditKinds: [DocumentPasteProvider.kind],

--- a/src/vs/editor/contrib/dropOrPasteInto/browser/copyPasteContribution.ts
+++ b/src/vs/editor/contrib/dropOrPasteInto/browser/copyPasteContribution.ts
@@ -6,14 +6,17 @@
 import { HierarchicalKind } from '../../../../base/common/hierarchicalKind.js';
 import { IJSONSchema, SchemaToType } from '../../../../base/common/jsonSchema.js';
 import { KeyCode, KeyMod } from '../../../../base/common/keyCodes.js';
+import * as nls from '../../../../nls.js';
+import { Extensions as ConfigurationExtensions, ConfigurationScope, IConfigurationRegistry } from '../../../../platform/configuration/common/configurationRegistry.js';
+import { KeybindingWeight } from '../../../../platform/keybinding/common/keybindingsRegistry.js';
+import { Registry } from '../../../../platform/registry/common/platform.js';
 import { ICodeEditor } from '../../../browser/editorBrowser.js';
 import { EditorAction, EditorCommand, EditorContributionInstantiation, ServicesAccessor, registerEditorAction, registerEditorCommand, registerEditorContribution } from '../../../browser/editorExtensions.js';
+import { editorConfigurationBaseNode } from '../../../common/config/editorConfigurationSchema.js';
 import { EditorContextKeys } from '../../../common/editorContextKeys.js';
 import { registerEditorFeature } from '../../../common/editorFeatures.js';
-import { CopyPasteController, changePasteTypeCommandId, pasteWidgetVisibleCtx } from './copyPasteController.js';
+import { CopyPasteController, changePasteTypeCommandId, pasteWidgetVisibleCtx, pasteAsPreferenceConfig } from './copyPasteController.js';
 import { DefaultPasteProvidersFeature, DefaultTextPasteOrDropEditProvider } from './defaultProviders.js';
-import * as nls from '../../../../nls.js';
-import { KeybindingWeight } from '../../../../platform/keybinding/common/keybindingsRegistry.js';
 
 registerEditorContribution(CopyPasteController.ID, CopyPasteController, EditorContributionInstantiation.Eager); // eager because it listens to events on the container dom node of the editor
 registerEditorFeature(DefaultPasteProvidersFeature);
@@ -103,5 +106,36 @@ registerEditorAction(class extends EditorAction {
 
 	public override run(_accessor: ServicesAccessor, editor: ICodeEditor) {
 		return CopyPasteController.get(editor)?.pasteAs({ providerId: DefaultTextPasteOrDropEditProvider.id });
+	}
+});
+
+export type PreferredPasteConfiguration = ReadonlyArray<{ readonly kind: string; readonly mimeType?: string }>;
+
+Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).registerConfiguration({
+	...editorConfigurationBaseNode,
+	properties: {
+		[pasteAsPreferenceConfig]: {
+			type: 'array',
+			scope: ConfigurationScope.LANGUAGE_OVERRIDABLE,
+			description: nls.localize('preferredDescription', "Configures the preferred type of edit to use when pasting content.\n\nThis is an ordered list of edit kinds with optional mime types for the content being pasted. The first available edit of a preferred kind will be used."),
+			default: [],
+			items: {
+				type: 'object',
+				required: ['kind'],
+				properties: {
+					mimeType: {
+						type: 'string',
+						description: nls.localize('mimeType', "The optional mime type that this preference applies to. If not provided, the preference will be used for all mime types."),
+					},
+					kind: {
+						type: 'string',
+						description: nls.localize('kind', "The kind identifier of the paste edit."),
+					}
+				},
+				defaultSnippets: [
+					{ body: { kind: '$1' } }
+				]
+			}
+		},
 	}
 });

--- a/src/vs/editor/contrib/dropOrPasteInto/browser/dropIntoEditorContribution.ts
+++ b/src/vs/editor/contrib/dropOrPasteInto/browser/dropIntoEditorContribution.ts
@@ -4,16 +4,16 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { KeyCode, KeyMod } from '../../../../base/common/keyCodes.js';
+import * as nls from '../../../../nls.js';
+import { Extensions as ConfigurationExtensions, ConfigurationScope, IConfigurationRegistry } from '../../../../platform/configuration/common/configurationRegistry.js';
+import { KeybindingWeight } from '../../../../platform/keybinding/common/keybindingsRegistry.js';
+import { Registry } from '../../../../platform/registry/common/platform.js';
 import { ICodeEditor } from '../../../browser/editorBrowser.js';
 import { EditorCommand, EditorContributionInstantiation, ServicesAccessor, registerEditorCommand, registerEditorContribution } from '../../../browser/editorExtensions.js';
 import { editorConfigurationBaseNode } from '../../../common/config/editorConfigurationSchema.js';
 import { registerEditorFeature } from '../../../common/editorFeatures.js';
 import { DefaultDropProvidersFeature } from './defaultProviders.js';
-import * as nls from '../../../../nls.js';
-import { Extensions as ConfigurationExtensions, ConfigurationScope, IConfigurationRegistry } from '../../../../platform/configuration/common/configurationRegistry.js';
-import { KeybindingWeight } from '../../../../platform/keybinding/common/keybindingsRegistry.js';
-import { Registry } from '../../../../platform/registry/common/platform.js';
-import { DropIntoEditorController, changeDropTypeCommandId, defaultProviderConfig, dropWidgetVisibleCtx } from './dropIntoEditorController.js';
+import { DropIntoEditorController, changeDropTypeCommandId, dropAsPreferenceConfig, dropWidgetVisibleCtx } from './dropIntoEditorController.js';
 
 registerEditorContribution(DropIntoEditorController.ID, DropIntoEditorController, EditorContributionInstantiation.BeforeFirstInteraction);
 registerEditorFeature(DefaultDropProvidersFeature);
@@ -52,17 +52,33 @@ registerEditorCommand(new class extends EditorCommand {
 	}
 });
 
+export type PreferredDropConfiguration = ReadonlyArray<{ readonly kind: string; readonly mimeType?: string }>;
+
 Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).registerConfiguration({
 	...editorConfigurationBaseNode,
 	properties: {
-		[defaultProviderConfig]: {
-			type: 'object',
+		[dropAsPreferenceConfig]: {
+			type: 'array',
 			scope: ConfigurationScope.LANGUAGE_OVERRIDABLE,
-			description: nls.localize('defaultProviderDescription', "Configures the default drop provider to use for content of a given mime type."),
-			default: {},
-			additionalProperties: {
-				type: 'string',
-			},
+			description: nls.localize('preferredDescription', "Configures the preferred type of edit to use when dropping content.\n\nThis is an ordered list of edit kinds with optional mime types for the content being dropped. The first available edit of a preferred kind will be used."),
+			default: [],
+			items: {
+				type: 'object',
+				required: ['kind'],
+				properties: {
+					mimeType: {
+						type: 'string',
+						description: nls.localize('mimeType', "The optional mime type that this preference applies to. If not provided, the preference will be used for all mime types."),
+					},
+					kind: {
+						type: 'string',
+						description: nls.localize('kind', "The kind identifier of the drop edit."),
+					}
+				},
+				defaultSnippets: [
+					{ body: { kind: '$1' } }
+				]
+			}
 		},
 	}
 });

--- a/src/vs/platform/actionWidget/browser/actionList.ts
+++ b/src/vs/platform/actionWidget/browser/actionList.ts
@@ -37,6 +37,7 @@ export interface IActionListItem<T> {
 	readonly label?: string;
 	readonly keybinding?: ResolvedKeybinding;
 	canPreview?: boolean | undefined;
+	readonly hideIcon?: boolean;
 }
 
 interface IActionMenuTemplateData {
@@ -118,6 +119,8 @@ class ActionItemRenderer<T> implements IListRenderer<IActionListItem<T>, IAction
 			return;
 		}
 
+		dom.setVisibility(!element.hideIcon, data.icon);
+
 		data.text.textContent = stripNewlines(element.label);
 
 		data.keybinding.set(element.keybinding);
@@ -139,8 +142,8 @@ class ActionItemRenderer<T> implements IListRenderer<IActionListItem<T>, IAction
 		}
 	}
 
-	disposeTemplate(_templateData: IActionMenuTemplateData): void {
-		_templateData.keybinding.dispose();
+	disposeTemplate(templateData: IActionMenuTemplateData): void {
+		templateData.keybinding.dispose();
 	}
 }
 

--- a/src/vs/workbench/contrib/dropOrPasteInto/browser/dropOrPasteInto.contribution.ts
+++ b/src/vs/workbench/contrib/dropOrPasteInto/browser/dropOrPasteInto.contribution.ts
@@ -1,0 +1,46 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import { toAction } from '../../../../base/common/actions.js';
+import { CopyPasteController, pasteAsPreferenceConfig } from '../../../../editor/contrib/dropOrPasteInto/browser/copyPasteController.js';
+import { dropAsPreferenceConfig, DropIntoEditorController } from '../../../../editor/contrib/dropOrPasteInto/browser/dropIntoEditorController.js';
+import { localize } from '../../../../nls.js';
+import { IWorkbenchContribution, registerWorkbenchContribution2, WorkbenchPhase } from '../../../common/contributions.js';
+import { IPreferencesService } from '../../../services/preferences/common/preferences.js';
+
+class DropOrPasteInto implements IWorkbenchContribution {
+	public static ID = 'workbench.contrib.dropOrPasteInto';
+
+	constructor(
+		@IPreferencesService private readonly _preferencesService: IPreferencesService
+	) {
+		CopyPasteController.setConfigureDefaultAction(toAction({
+			id: 'workbench.action.configurePreferredPasteAction',
+			label: localize('configureDefaultPaste.label', 'Configure preferred paste action...'),
+			run: () => this.configurePreferredPasteAction()
+		}));
+
+		DropIntoEditorController.setConfigureDefaultAction(toAction({
+			id: 'workbench.action.configurePreferredDropAction',
+			label: localize('configureDefaultDrop.label', 'Configure preferred drop action...'),
+			run: () => this.configurePreferredDropAction()
+		}));
+	}
+
+	private configurePreferredPasteAction() {
+		return this._preferencesService.openUserSettings({
+			jsonEditor: true,
+			revealSetting: { key: pasteAsPreferenceConfig, edit: true }
+		});
+	}
+
+	private configurePreferredDropAction() {
+		return this._preferencesService.openUserSettings({
+			jsonEditor: true,
+			revealSetting: { key: dropAsPreferenceConfig, edit: true }
+		});
+	}
+}
+
+registerWorkbenchContribution2(DropOrPasteInto.ID, DropOrPasteInto, WorkbenchPhase.Eventually);

--- a/src/vs/workbench/workbench.common.main.ts
+++ b/src/vs/workbench/workbench.common.main.ts
@@ -398,4 +398,8 @@ import './contrib/scrollLocking/browser/scrollLocking.contribution.js';
 // Inline Completions
 import './contrib/inlineCompletions/browser/inlineCompletions.contribution.js';
 
+// Drop or paste into
+import './contrib/dropOrPasteInto/browser/dropOrPasteInto.contribution.js';
+
+
 //#endregion


### PR DESCRIPTION
Fixes #184871
For #30066

Adds new settings that let you configure the default way to paste/drop.

Also enables js/ts paste with imports by default for 5.7+. However will not apply by default. Instead it will be shown as an option after pasting. You can then use the `editor.pasteAs.preferences` setting to make it apply automatically or use the `javascript.updateImportsOnPaste.enabled` settings to disable the feature entirely
