### PR TITLE
Add shellType, Command and Prompt values for terminal title/desc

### DIFF
--- a/src/vs/platform/terminal/common/capabilities/commandDetection/promptInputModel.ts
+++ b/src/vs/platform/terminal/common/capabilities/commandDetection/promptInputModel.ts
@@ -33,8 +33,11 @@ export interface IPromptInputModel extends IPromptInputModelState {
 	/**
 	 * Gets the prompt input as a user-friendly string where `|` is the cursor position and `[` and
 	 * `]` wrap any ghost text.
+	 *
+	 * @param emptyStringWhenEmpty If true, an empty string is returned when the prompt input is
+	 * empty (as opposed to '|').
 	 */
-	getCombinedString(): string;
+	getCombinedString(emptyStringWhenEmpty?: boolean): string;
 }
 
 export interface IPromptInputModelState {
@@ -149,7 +152,7 @@ export class PromptInputModel extends Disposable implements IPromptInputModel {
 		}
 	}
 
-	getCombinedString(): string {
+	getCombinedString(emptyStringWhenEmpty?: boolean): string {
 		const value = this._value.replaceAll('\n', '\u23CE');
 		if (this._cursorIndex === -1) {
 			return value;
@@ -160,6 +163,9 @@ export class PromptInputModel extends Disposable implements IPromptInputModel {
 			result += `${value.substring(this.ghostTextIndex)}]`;
 		} else {
 			result += value.substring(this.cursorIndex);
+		}
+		if (result === '|' && emptyStringWhenEmpty) {
+			return '';
 		}
 		return result;
 	}

--- a/src/vs/workbench/contrib/terminal/common/terminalConfiguration.ts
+++ b/src/vs/workbench/contrib/terminal/common/terminalConfiguration.ts
@@ -24,6 +24,9 @@ const terminalDescriptors = '\n- ' + [
 	'`\${separator}`: ' + localize('separator', "a conditional separator {0} that only shows when surrounded by variables with values or static text.", '(` - `)'),
 	'`\${sequence}`: ' + localize('sequence', "the name provided to the terminal by the process"),
 	'`\${task}`: ' + localize('task', "indicates this terminal is associated with a task"),
+	'`\${shellType}`: ' + localize('shellType', "the detected shell type"),
+	'`\${shellCommand}`: ' + localize('shellCommand', "the command being executed according to shell integration"),
+	'`\${shellPrompt}`: ' + localize('shellPrompt', "the shell's full prompt according to shell integration"),
 ].join('\n- '); // intentionally concatenated to not produce a string that is too long for translations
 
 let terminalTitle = localize('terminalTitle', "Controls the terminal title. Variables are substituted based on the context:");

--- a/src/vs/workbench/contrib/terminal/test/browser/terminalInstance.test.ts
+++ b/src/vs/workbench/contrib/terminal/test/browser/terminalInstance.test.ts
@@ -15,7 +15,7 @@ import { TestConfigurationService } from '../../../../../platform/configuration/
 import { TestInstantiationService } from '../../../../../platform/instantiation/test/common/instantiationServiceMock.js';
 import { TerminalCapability } from '../../../../../platform/terminal/common/capabilities/capabilities.js';
 import { TerminalCapabilityStore } from '../../../../../platform/terminal/common/capabilities/terminalCapabilityStore.js';
-import { ITerminalChildProcess, ITerminalProfile } from '../../../../../platform/terminal/common/terminal.js';
+import { GeneralShellType, ITerminalChildProcess, ITerminalProfile } from '../../../../../platform/terminal/common/terminal.js';
 import { IWorkspaceFolder } from '../../../../../platform/workspace/common/workspace.js';
 import { IViewDescriptorService } from '../../../../common/views.js';
 import { ITerminalConfigurationService, ITerminalInstance, ITerminalInstanceService } from '../../browser/terminal.js';
@@ -260,13 +260,14 @@ suite('Workbench - TerminalInstance', () => {
 		let instantiationService: TestInstantiationService;
 		let capabilities: TerminalCapabilityStore;
 
-		function createInstance(partial?: Partial<ITerminalInstance>): Pick<ITerminalInstance, 'shellLaunchConfig' | 'userHome' | 'cwd' | 'initialCwd' | 'processName' | 'sequence' | 'workspaceFolder' | 'staticTitle' | 'capabilities' | 'title' | 'description'> {
+		function createInstance(partial?: Partial<ITerminalInstance>): Pick<ITerminalInstance, 'shellLaunchConfig' | 'shellType' | 'userHome' | 'cwd' | 'initialCwd' | 'processName' | 'sequence' | 'workspaceFolder' | 'staticTitle' | 'capabilities' | 'title' | 'description'> {
 			const capabilities = store.add(new TerminalCapabilityStore());
 			if (!isWindows) {
 				capabilities.add(TerminalCapability.NaiveCwdDetection, null!);
 			}
 			return {
 				shellLaunchConfig: {},
+				shellType: GeneralShellType.PowerShell,
 				cwd: 'cwd',
 				initialCwd: undefined,
 				processName: '',


### PR DESCRIPTION
Fixes #233091

With values:

```json
"terminal.integrated.tabs.title": "${shellType}",
"terminal.integrated.tabs.description": "${task}${separator}${local}${separator}${shellPrompt}${separator}${cwdFolder}",
```

![Recording 2024-11-05 at 07 10 57](https://github.com/user-attachments/assets/0c25acf0-7c9b-4ae3-88aa-a8eadd9bf62a)

`shellCommand` is similar, but only shows up when it's being executed.
