### PR TITLE
Add Select All Matches to notebook editor

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/contrib/find/notebookFindReplaceWidget.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/find/notebookFindReplaceWidget.ts
@@ -678,6 +678,10 @@ export abstract class SimpleFindReplaceWidget extends Widget {
 		return this._focusTracker;
 	}
 
+	public get isVisible(): boolean {
+		return this._isVisible;
+	}
+
 	private _onStateChanged(e: FindReplaceStateChangedEvent): void {
 		this._updateButtons();
 		this._updateMatchesCount();

--- a/src/vs/workbench/contrib/notebook/browser/contrib/find/notebookFindWidget.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/find/notebookFindWidget.ts
@@ -77,6 +77,7 @@ export class NotebookFindContrib extends Disposable implements INotebookEditorCo
 
 class NotebookFindWidget extends SimpleFindReplaceWidget implements INotebookEditorContribution {
 	protected _findWidgetFocused: IContextKey<boolean>;
+	private _isFocused: boolean = false;
 	private _showTimeout: number | null = null;
 	private _hideTimeout: number | null = null;
 	private _previousFocusElement?: HTMLElement;
@@ -130,6 +131,10 @@ class NotebookFindWidget extends SimpleFindReplaceWidget implements INotebookEdi
 
 	get findModel(): FindModel {
 		return this._findModel;
+	}
+
+	get isFocused(): boolean {
+		return this._isFocused;
 	}
 
 	private _onFindInputKeyDown(e: IKeyboardEvent): void {
@@ -234,11 +239,13 @@ class NotebookFindWidget extends SimpleFindReplaceWidget implements INotebookEdi
 
 	protected onFocusTrackerFocus() {
 		this._findWidgetFocused.set(true);
+		this._isFocused = true;
 	}
 
 	protected onFocusTrackerBlur() {
 		this._previousFocusElement = undefined;
 		this._findWidgetFocused.reset();
+		this._isFocused = false;
 	}
 
 	protected onReplaceInputFocusTrackerFocus(): void {

--- a/src/vs/workbench/contrib/notebook/browser/contrib/find/notebookFindWidget.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/find/notebookFindWidget.ts
@@ -47,7 +47,7 @@ export class NotebookFindContrib extends Disposable implements INotebookEditorCo
 
 	static readonly id: string = 'workbench.notebook.find';
 
-	private readonly widget: Lazy<NotebookFindWidget>;
+	private readonly _widget: Lazy<NotebookFindWidget>;
 
 	constructor(
 		private readonly notebookEditor: INotebookEditor,
@@ -55,19 +55,23 @@ export class NotebookFindContrib extends Disposable implements INotebookEditorCo
 	) {
 		super();
 
-		this.widget = new Lazy(() => this._register(this.instantiationService.createInstance(NotebookFindWidget, this.notebookEditor)));
+		this._widget = new Lazy(() => this._register(this.instantiationService.createInstance(NotebookFindWidget, this.notebookEditor)));
+	}
+
+	get widget(): NotebookFindWidget {
+		return this._widget.value;
 	}
 
 	show(initialInput?: string, options?: IShowNotebookFindWidgetOptions): Promise<void> {
-		return this.widget.value.show(initialInput, options);
+		return this._widget.value.show(initialInput, options);
 	}
 
 	hide() {
-		this.widget.rawValue?.hide();
+		this._widget.rawValue?.hide();
 	}
 
 	replace(searchString: string | undefined) {
-		return this.widget.value.replace(searchString);
+		return this._widget.value.replace(searchString);
 	}
 }
 
@@ -124,6 +128,9 @@ class NotebookFindWidget extends SimpleFindReplaceWidget implements INotebookEdi
 		}, true));
 	}
 
+	get findModel(): FindModel {
+		return this._findModel;
+	}
 
 	private _onFindInputKeyDown(e: IKeyboardEvent): void {
 		if (e.equals(KeyCode.Enter)) {

--- a/src/vs/workbench/contrib/notebook/browser/contrib/multicursor/notebookMulticursor.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/multicursor/notebookMulticursor.ts
@@ -645,7 +645,7 @@ export class NotebookMultiCursorController extends Disposable implements INotebo
 			}
 
 			// get all matches in the notebook
-			const findResults = notebookTextModel.findAllMatches(this.word, false, true, USUAL_WORD_SEPARATORS);
+			const findResults = notebookTextModel.findMatches(this.word, false, true, USUAL_WORD_SEPARATORS);
 
 			// create the tracked matches for every result, needed for cursor controllers
 			this.trackedCells = [];
@@ -666,7 +666,7 @@ export class NotebookMultiCursorController extends Disposable implements INotebo
 
 		} else if (this.state === NotebookMultiCursorState.Selecting) {
 			// we will already have a word + some number of tracked matches, need to update them with the rest given findAllMatches result
-			const findResults = notebookTextModel.findAllMatches(this.word, false, true, USUAL_WORD_SEPARATORS);
+			const findResults = notebookTextModel.findMatches(this.word, false, true, USUAL_WORD_SEPARATORS);
 
 			// update existing tracked matches with new selections and create new tracked matches for cells that aren't tracked yet
 			for (const res of findResults) {

--- a/src/vs/workbench/contrib/notebook/browser/contrib/multicursor/notebookMulticursor.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/multicursor/notebookMulticursor.ts
@@ -999,7 +999,7 @@ class NotebookSelectAllFindMatches extends NotebookAction {
 	constructor() {
 		super({
 			id: NOTEBOOK_SELECT_ALL_FIND_MATCHES_ID,
-			title: localize('selectAllFindMatches', "Select All Find Matches"),
+			title: localize('selectAllFindMatches', "Select All Occurrences of Find Match"),
 			precondition: ContextKeyExpr.and(
 				ContextKeyExpr.equals('config.notebook.multiCursor.enabled', true),
 			),
@@ -1050,7 +1050,7 @@ class NotebookAddMatchToMultiSelectionAction extends NotebookAction {
 	constructor() {
 		super({
 			id: NOTEBOOK_ADD_FIND_MATCH_TO_SELECTION_ID,
-			title: localize('addFindMatchToSelection', "Add Find Match to Selection"),
+			title: localize('addFindMatchToSelection', "Add Selection To Next Find Match"),
 			precondition: ContextKeyExpr.and(
 				ContextKeyExpr.equals('config.notebook.multiCursor.enabled', true),
 				NOTEBOOK_IS_ACTIVE_EDITOR,

--- a/src/vs/workbench/contrib/notebook/common/model/notebookTextModel.ts
+++ b/src/vs/workbench/contrib/notebook/common/model/notebookTextModel.ts
@@ -1242,6 +1242,27 @@ export class NotebookTextModel extends Disposable implements INotebookTextModel 
 
 		return null;
 	}
+
+	findAllMatches(searchString: string, isRegex: boolean, matchCase: boolean, wordSeparators: string | null): { cell: NotebookCellTextModel; matches: FindMatch[] }[] {
+		const searchParams = new SearchParams(searchString, isRegex, matchCase, wordSeparators);
+		const searchData = searchParams.parseSearchRequest();
+
+		if (!searchData) {
+			return [];
+		}
+
+		const results: { cell: NotebookCellTextModel; matches: FindMatch[] }[] = [];
+		for (const cell of this._cells) {
+			const searchRange = new Range(1, 1, cell.textBuffer.getLineCount(), cell.textBuffer.getLineMaxColumn(cell.textBuffer.getLineCount()));
+			const matches = cell.textBuffer.findMatchesLineByLine(searchRange, searchData, false, 1000);
+
+			if (matches.length > 0) {
+				results.push({ cell, matches: matches });
+			}
+		}
+
+		return results;
+	}
 	//#endregion
 }
 

--- a/src/vs/workbench/contrib/notebook/common/model/notebookTextModel.ts
+++ b/src/vs/workbench/contrib/notebook/common/model/notebookTextModel.ts
@@ -1243,7 +1243,7 @@ export class NotebookTextModel extends Disposable implements INotebookTextModel 
 		return null;
 	}
 
-	findAllMatches(searchString: string, isRegex: boolean, matchCase: boolean, wordSeparators: string | null): { cell: NotebookCellTextModel; matches: FindMatch[] }[] {
+	findMatches(searchString: string, isRegex: boolean, matchCase: boolean, wordSeparators: string | null): { cell: NotebookCellTextModel; matches: FindMatch[] }[] {
 		const searchParams = new SearchParams(searchString, isRegex, matchCase, wordSeparators);
 		const searchData = searchParams.parseSearchRequest();
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fixes: #232866

uses the multicursor controller + notebook find to enable use of select all matches with `ctrl+shift+L`. This can be done from a single cursor, or during the selecting state of a multicursor session