### PR TITLE
chore: publish symbols to SymWeb

### DIFF
--- a/build/azure-pipelines/cli/cli-compile.yml
+++ b/build/azure-pipelines/cli/cli-compile.yml
@@ -115,6 +115,9 @@ steps:
           SearchPattern: 'code.pdb'
           SymbolServerType: TeamServices
           SymbolsProduct: 'code'
+          ArtifactServices.Symbol.AccountName: microsoft
+          ArtifactServices.Symbol.PAT: $(System.AccessToken)
+          ArtifactServices.Symbol.UseAAD: false
         displayName: Publish Symbols
 
       - task: CopyFiles@2

--- a/build/azure-pipelines/win32/sdl-scan-win32.yml
+++ b/build/azure-pipelines/win32/sdl-scan-win32.yml
@@ -146,6 +146,9 @@ steps:
       SearchPattern: '**\*.pdb'
       SymbolServerType: TeamServices
       SymbolsProduct: 'code'
+      ArtifactServices.Symbol.AccountName: microsoft
+      ArtifactServices.Symbol.PAT: $(System.AccessToken)
+      ArtifactServices.Symbol.UseAAD: false
     displayName: Publish Symbols
     condition: succeeded()
 


### PR DESCRIPTION
Adds more parameters so that the symbols can be uploaded to SymWeb.

Verification build: https://dev.azure.com/monacotools/Monaco/_build/results?buildId=303278&view=results