### PR TITLE
Make terminal inline chat look more like editor inline chat

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/chat/browser/media/terminalChatWidget.css
+++ b/src/vs/workbench/contrib/terminalContrib/chat/browser/media/terminalChatWidget.css
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-.terminal-inline-chat {
+.monaco-workbench .terminal-inline-chat {
 	position: absolute;
 	left: 0;
 	bottom: 0;
@@ -11,19 +11,63 @@
 	height: auto !important;
 }
 
-.terminal-inline-chat .inline-chat {
+.monaco-workbench .terminal-inline-chat .inline-chat {
 	margin-top: 0 !important;
+	color: inherit;
+	border-radius: unset;
+	border: unset;
+	box-shadow: unset;
+	background: var(--vscode-inlineChat-background);
+	position: relative;
+	outline: none;
+
+	border-top-style: solid;
+	border-bottom-style: solid;
+	border-top-color: rgb(0, 122, 204);
+	border-bottom-color: rgb(0, 122, 204);
+	border-top-width: 1px;
+	border-bottom-width: 1px;
 }
 
-.terminal-inline-chat.hide {
+.monaco-workbench .terminal-inline-chat .interactive-session {
+	margin: initial;
+}
+
+.monaco-workbench .terminal-inline-chat.hide {
 	visibility: hidden;
 }
 
-.terminal-inline-chat .chatMessageContent .value {
+.monaco-workbench .terminal-inline-chat .chatMessageContent .value {
 	padding-top: 10px;
 }
 
-.terminal-inline-chat .inline-chat-input .monaco-editor-background {
+.monaco-workbench .terminal-inline-chat .inline-chat-input .monaco-editor-background {
 	/* Override the global panel rule for monaco backgrounds */
 	background-color: var(--vscode-inlineChatInput-background) !important;
+}
+
+@property --inline-chat-frame-progress {
+	syntax: '<percentage>';
+	initial-value: 0%;
+	inherits: false;
+}
+
+@keyframes shift {
+	0% {
+		--inline-chat-frame-progress: 0%;
+	}
+
+	50% {
+		--inline-chat-frame-progress: 100%;
+	}
+
+	100% {
+		--inline-chat-frame-progress: 0%;
+	}
+}
+
+.monaco-workbench .terminal-inline-chat.busy .inline-chat {
+	--inline-chat-frame-progress: 0%;
+	border-image: linear-gradient(90deg, var(--vscode-editorGutter-addedBackground) var(--inline-chat-frame-progress), var(--vscode-button-background)) 1;
+	animation: 3s shift linear infinite;
 }

--- a/src/vs/workbench/contrib/terminalContrib/chat/browser/terminalChatActions.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chat/browser/terminalChatActions.ts
@@ -67,11 +67,6 @@ registerActiveXtermAction({
 		weight: KeybindingWeight.WorkbenchContrib,
 	},
 	icon: Codicon.close,
-	menu: {
-		id: MENU_TERMINAL_CHAT_WIDGET,
-		group: 'navigation',
-		order: 2
-	},
 	f1: true,
 	precondition: TerminalChatContextKeys.visible,
 	run: (_xterm, _accessor, activeInstance) => {

--- a/src/vs/workbench/contrib/terminalContrib/chat/browser/terminalChatWidget.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chat/browser/terminalChatWidget.ts
@@ -45,7 +45,6 @@ const enum Message {
 	ReturnInput = 1 << 6,
 }
 
-const terminalChatPlaceholder = localize('default.placeholder', "Ask Copilot");
 export class TerminalChatWidget extends Disposable {
 
 	private readonly _container: HTMLElement;
@@ -155,7 +154,7 @@ export class TerminalChatWidget extends Disposable {
 		observer.observe(this._terminalElement);
 		this._register(toDisposable(() => observer.disconnect()));
 
-		this._reset();
+		this._resetPlaceholder();
 		this._container.appendChild(this._inlineChatWidget.domNode);
 
 		this._focusTracker = this._register(trackFocus(this._container));
@@ -225,8 +224,8 @@ export class TerminalChatWidget extends Disposable {
 		this._updateVerticalPosition(adjustedHeight);
 	}
 
-	private _reset() {
-		this.inlineChatWidget.placeholder = terminalChatPlaceholder;
+	private _resetPlaceholder() {
+		this.inlineChatWidget.placeholder = this._model.value?.welcomeMessage?.title ?? localize('askAI', 'Ask AI');
 	}
 
 	async reveal(viewState?: IChatViewState): Promise<void> {
@@ -234,7 +233,7 @@ export class TerminalChatWidget extends Disposable {
 		this._doLayout(this._inlineChatWidget.contentHeight);
 		this._container.classList.remove('hide');
 		this._visibleContextKey.set(true);
-		this.inlineChatWidget.placeholder = terminalChatPlaceholder;
+		this._resetPlaceholder();
 		this._inlineChatWidget.focus();
 		this._instance.scrollToBottom();
 	}
@@ -278,7 +277,7 @@ export class TerminalChatWidget extends Disposable {
 	hide(): void {
 		this._container.classList.add('hide');
 		this._inlineChatWidget.reset();
-		this._reset();
+		this._resetPlaceholder();
 		this._inlineChatWidget.updateToolbar(false);
 		this._visibleContextKey.set(false);
 		this._inlineChatWidget.value = '';

--- a/src/vs/workbench/contrib/terminalContrib/chat/browser/terminalChatWidget.ts
+++ b/src/vs/workbench/contrib/terminalContrib/chat/browser/terminalChatWidget.ts
@@ -201,7 +201,8 @@ export class TerminalChatWidget extends Disposable {
 		}
 		const style = getActiveWindow().getComputedStyle(xtermElement);
 		const xtermLeftPadding = parseInt(style.paddingLeft);
-		const width = xtermElement.clientWidth - xtermLeftPadding - 12; //Math.min(640, xtermElement.clientWidth - 12/* padding */ - 2/* border */ - Constants.HorizontalMargin - xtermPadding);
+		// TODO: Remove magic number https://github.com/microsoft/vscode/issues/233206
+		const width = xtermElement.clientWidth - xtermLeftPadding - 12;
 		const terminalWrapperHeight = this._getTerminalWrapperHeight() ?? Number.MAX_SAFE_INTEGER;
 		let height = Math.min(480, heightInPixel, terminalWrapperHeight);
 		const top = this._getTop() ?? 0;


### PR DESCRIPTION
Big changes:

- No more border radius, it looks like a monaco zone widget now.
- Adjusted paddings to make it look right
- Added border animation like editor inline chat
- Removed close chat button

Fixes #233199

(gif also includes https://github.com/microsoft/vscode/pull/233210 to improve code block alignment)

![Recording 2024-11-06 at 07 22 15](https://github.com/user-attachments/assets/7fde253e-9458-4f31-86d2-58548e00dc06)
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
