### PR TITLE
Remove margin when a code block is the first part of an answer

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/media/chat.css
@@ -305,6 +305,10 @@
 	margin: 8px 0 16px 0;
 }
 
+.interactive-item-container .value .rendered-markdown > div[data-code]:first-child {
+	margin-top: 0;
+}
+
 .interactive-item-container .value .rendered-markdown .codicon {
 	position: relative;
 	top: 2px;

--- a/src/vs/workbench/contrib/chat/browser/media/chat.css
+++ b/src/vs/workbench/contrib/chat/browser/media/chat.css
@@ -306,7 +306,14 @@
 }
 
 .interactive-item-container .value .rendered-markdown > div[data-code]:first-child {
+	/* Code blocks at the beginning of an answer should not have a margin as it means it won't align
+	 * with the agent icon*/
 	margin-top: 0;
+}
+.interactive-item-container .value .rendered-markdown > div[data-code]:first-child .interactive-result-code-block .interactive-result-code-block-toolbar > .monaco-action-bar,
+.interactive-item-container .value .rendered-markdown > div[data-code]:first-child .interactive-result-code-block .interactive-result-code-block-toolbar > .monaco-toolbar {
+	/* Override the top to avoid the toolbar getting clipped by overflow:hidden */
+	top: 6px;
 }
 
 .interactive-item-container .value .rendered-markdown .codicon {


### PR DESCRIPTION
Fixes #233203

Before:

![image](https://github.com/user-attachments/assets/2f3a36b9-813c-4b9d-9010-3b90aece2c29)

After:

<img width="228" alt="Screenshot 2024-11-06 at 7 29 22 am" src="https://github.com/user-attachments/assets/6d992aad-dc72-4bc3-9372-7fa63626bf3f">
