### PR TITLE
Add comment on next line when not at the end of the line comment in onEnter rules

### DIFF
--- a/extensions/javascript/javascript-language-configuration.json
+++ b/extensions/javascript/javascript-language-configuration.json
@@ -228,5 +228,18 @@
 				"appendText": "\t",
 			}
 		},
+		// Add // when pressing enter from inside line comment
+		{
+			"beforeText": {
+				"pattern": "\/\/.*"
+			},
+			"afterText": {
+				"pattern": "^(?!\\s*$).+"
+			},
+			"action": {
+				"indent": "none",
+				"appendText": "// "
+			}
+		},
 	]
 }

--- a/extensions/typescript-basics/language-configuration.json
+++ b/extensions/typescript-basics/language-configuration.json
@@ -252,7 +252,7 @@
 				"pattern": "\/\/.*"
 			},
 			"afterText": {
-				"pattern": ".*"
+				"pattern": "^(?!\\s*$).+"
 			},
 			"action": {
 				"indent": "none",


### PR DESCRIPTION
fixes https://github.com/microsoft/vscode/issues/233186

We add a line comment on the next line only when we press Enter only when the cursor is not at the end of the line comment, but in the middle somewhere

This PR also adds the same rule to the JavaScript language configuration file. The TypeScript and JavaScript language configuration files are the same and should be kept in sync. 