### PR TITLE
fix: make onexp tag recognition case-insensitive

### DIFF
--- a/src/vs/workbench/services/configuration/browser/configurationService.ts
+++ b/src/vs/workbench/services/configuration/browser/configurationService.ts
@@ -1364,7 +1364,7 @@ class UpdateExperimentalSettingsDefaults extends Disposable implements IWorkbenc
 			// Many experimental settings refer to in-development or unstable settings.
 			// onExP more clearly indicates that the setting could be
 			// part of an experiment.
-			if (!tags || (!tags.includes('experimental') && !tags.includes('onExP'))) {
+			if (!tags || !tags.some(tag => tag.toLowerCase() === 'onexp')) {
 				continue;
 			}
 			if (this.processedExperimentalSettings.has(property)) {


### PR DESCRIPTION
I'm unsure whether it is worth using some(), or whether we could just check the exact onExP string. ExP stands for Experimentation Platform.