### PR TITLE
Let IActionOptions take a localized string

### DIFF
--- a/src/vs/editor/browser/editorExtensions.ts
+++ b/src/vs/editor/browser/editorExtensions.ts
@@ -334,11 +334,15 @@ export interface IEditorActionContextMenuOptions {
 	when?: ContextKeyExpression;
 	menuId?: MenuId;
 }
-export interface IActionOptions extends ICommandOptions {
+export type IActionOptions = ICommandOptions & {
+	contextMenuOpts?: IEditorActionContextMenuOptions | IEditorActionContextMenuOptions[];
+} & ({
+	label: nls.ILocalizedString;
+	alias?: string;
+} | {
 	label: string;
 	alias: string;
-	contextMenuOpts?: IEditorActionContextMenuOptions | IEditorActionContextMenuOptions[];
-}
+});
 
 export abstract class EditorAction extends EditorCommand {
 
@@ -358,7 +362,7 @@ export abstract class EditorAction extends EditorCommand {
 				item.menuId = MenuId.EditorContext;
 			}
 			if (!item.title) {
-				item.title = opts.label;
+				item.title = typeof opts.label === 'string' ? opts.label : opts.label.value;
 			}
 			item.when = ContextKeyExpr.and(opts.precondition, item.when);
 			return <ICommandMenuOptions>item;
@@ -379,8 +383,13 @@ export abstract class EditorAction extends EditorCommand {
 
 	constructor(opts: IActionOptions) {
 		super(EditorAction.convertOptions(opts));
-		this.label = opts.label;
-		this.alias = opts.alias;
+		if (typeof opts.label === 'string') {
+			this.label = opts.label;
+			this.alias = opts.alias ?? opts.label;
+		} else {
+			this.label = opts.label.value;
+			this.alias = opts.alias ?? opts.label.original;
+		}
 	}
 
 	public runEditorCommand(accessor: ServicesAccessor, editor: ICodeEditor, args: any): void | Promise<void> {

--- a/src/vs/editor/contrib/codeAction/browser/codeActionCommands.ts
+++ b/src/vs/editor/contrib/codeAction/browser/codeActionCommands.ts
@@ -69,8 +69,7 @@ export class QuickFixAction extends EditorAction {
 	constructor() {
 		super({
 			id: quickFixCommandId,
-			label: nls.localize('quickfix.trigger.label', "Quick Fix..."),
-			alias: 'Quick Fix...',
+			label: nls.localize2('quickfix.trigger.label', "Quick Fix..."),
 			precondition: ContextKeyExpr.and(EditorContextKeys.writable, EditorContextKeys.hasCodeActionsProvider),
 			kbOpts: {
 				kbExpr: EditorContextKeys.textInputFocus,
@@ -126,8 +125,7 @@ export class RefactorAction extends EditorAction {
 	constructor() {
 		super({
 			id: refactorCommandId,
-			label: nls.localize('refactor.label', "Refactor..."),
-			alias: 'Refactor...',
+			label: nls.localize2('refactor.label', "Refactor..."),
 			precondition: ContextKeyExpr.and(EditorContextKeys.writable, EditorContextKeys.hasCodeActionsProvider),
 			kbOpts: {
 				kbExpr: EditorContextKeys.textInputFocus,
@@ -177,8 +175,7 @@ export class SourceAction extends EditorAction {
 	constructor() {
 		super({
 			id: sourceActionCommandId,
-			label: nls.localize('source.label', "Source Action..."),
-			alias: 'Source Action...',
+			label: nls.localize2('source.label', "Source Action..."),
 			precondition: ContextKeyExpr.and(EditorContextKeys.writable, EditorContextKeys.hasCodeActionsProvider),
 			contextMenuOpts: {
 				group: '1_modification',
@@ -221,8 +218,7 @@ export class OrganizeImportsAction extends EditorAction {
 	constructor() {
 		super({
 			id: organizeImportsCommandId,
-			label: nls.localize('organizeImports.label', "Organize Imports"),
-			alias: 'Organize Imports',
+			label: nls.localize2('organizeImports.label', "Organize Imports"),
 			precondition: ContextKeyExpr.and(
 				EditorContextKeys.writable,
 				contextKeyForSupportedActions(CodeActionKind.SourceOrganizeImports)),
@@ -247,8 +243,7 @@ export class FixAllAction extends EditorAction {
 	constructor() {
 		super({
 			id: fixAllCommandId,
-			label: nls.localize('fixAll.label', "Fix All"),
-			alias: 'Fix All',
+			label: nls.localize2('fixAll.label', "Fix All"),
 			precondition: ContextKeyExpr.and(
 				EditorContextKeys.writable,
 				contextKeyForSupportedActions(CodeActionKind.SourceFixAll))
@@ -268,8 +263,7 @@ export class AutoFixAction extends EditorAction {
 	constructor() {
 		super({
 			id: autoFixCommandId,
-			label: nls.localize('autoFix.label', "Auto Fix..."),
-			alias: 'Auto Fix...',
+			label: nls.localize2('autoFix.label', "Auto Fix..."),
 			precondition: ContextKeyExpr.and(
 				EditorContextKeys.writable,
 				contextKeyForSupportedActions(CodeActionKind.QuickFix)),

--- a/src/vs/workbench/contrib/emmet/browser/emmetActions.ts
+++ b/src/vs/workbench/contrib/emmet/browser/emmetActions.ts
@@ -42,9 +42,9 @@ class GrammarContributions implements IGrammarContributions {
 	}
 }
 
-interface IEmmetActionOptions extends IActionOptions {
+type IEmmetActionOptions = IActionOptions & {
 	actionName: string;
-}
+};
 
 export abstract class EmmetEditorAction extends EditorAction {
 


### PR DESCRIPTION
The `IActionOptions.alias` property typically duplicates the unlocalized `label`. This PR makes lets us avoid this duplication by letting you pass an  `ILocalizedString` to `label`. The localized version of the string will be used for the label while the unlocalized version will be used for the alias

The typings is a little ugly to avoid having to change all the existing implementers of `ILocalizedString`

Tested by adopting for code action commands 