### PR TITLE
fix: allow wolfi in requirements check

### DIFF
--- a/resources/server/bin/helpers/check-requirements-linux.sh
+++ b/resources/server/bin/helpers/check-requirements-linux.sh
@@ -36,6 +36,10 @@ if [ -f /etc/os-release ]; then
         echo "Warning: NixOS detected, skipping GLIBC check"
         exit 0
     fi
+    if [ "$OS_ID" = "wolfi" ]; then
+        echo "Warning: Wolfi detected, skipping GLIBC check"
+        exit 0
+    fi
 fi
 
 # Based on https://github.com/bminor/glibc/blob/520b1df08de68a3de328b65a25b86300a7ddf512/elf/cache.c#L162-L245


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
This modifies the requirements check to allow the [wolfi](https://www.chainguard.dev/unchained/introducing-wolfi-the-first-linux-un-distro-designed-for-securing-the-software-supply-chain) distro which identifies itself as `ID=wolfi` in `/etc/os-release`.

I've been using this secure distro for my devcontainers for the past year and I've needed to rely on an empty `/tmp/vscode-skip-server-requirements-check` file to make it work. By adding this change (similar to the NixOS skip block above it), Wolfi will be directly usable as a devcontainer.