### PR TITLE
Update paste/drop preference settings

### DIFF
--- a/extensions/typescript-language-features/package.nls.json
+++ b/extensions/typescript-language-features/package.nls.json
@@ -224,7 +224,7 @@
 	"configuration.tsserver.web.projectWideIntellisense.suppressSemanticErrors": "Suppresses semantic errors on web even when project wide IntelliSense is enabled. This is always on when project wide IntelliSense is not enabled or available. See `#typescript.tsserver.web.projectWideIntellisense.enabled#`",
 	"configuration.tsserver.web.typeAcquisition.enabled": "Enable/disable package acquisition on the web. This enables IntelliSense for imported packages. Requires `#typescript.tsserver.web.projectWideIntellisense.enabled#`. Currently not supported for Safari.",
 	"configuration.tsserver.nodePath": "Run TS Server on a custom Node installation. This can be a path to a Node executable, or 'node' if you want VS Code to detect a Node installation.",
-	"configuration.updateImportsOnPaste": "Enable updating imports when pasting code. Requires TypeScript 5.7+.\n\nBy default this shows a option to update imports after pasting. You can use the `#editor.pasteAs.preferences#` setting to update imports automatically when pasting: `\"editor.pasteAs.preferences\": [{ \"kind\": \"text.jsts.pasteWithImports\" }]`.",
+	"configuration.updateImportsOnPaste": "Enable updating imports when pasting code. Requires TypeScript 5.7+.\n\nBy default this shows a option to update imports after pasting. You can use the `#editor.pasteAs.preferences#` setting to update imports automatically when pasting: `\"editor.pasteAs.preferences\": [ \"text.updateImports.jsts\" ]`.",
 	"configuration.expandableHover": "Enable/disable expanding on hover.",
 	"walkthroughs.nodejsWelcome.title": "Get started with JavaScript and Node.js",
 	"walkthroughs.nodejsWelcome.description": "Make the most of Visual Studio Code's first-class JavaScript experience.",

--- a/extensions/typescript-language-features/src/languageFeatures/copyPaste.ts
+++ b/extensions/typescript-language-features/src/languageFeatures/copyPaste.ts
@@ -42,7 +42,7 @@ const enabledSettingId = 'updateImportsOnPaste.enabled';
 
 class DocumentPasteProvider implements vscode.DocumentPasteEditProvider {
 
-	static readonly kind = vscode.DocumentDropOrPasteEditKind.Empty.append('text', 'jsts', 'pasteWithImports');
+	static readonly kind = vscode.DocumentDropOrPasteEditKind.Empty.append('text', 'updateImports', 'jsts');
 	static readonly metadataMimeType = 'application/vnd.code.jsts.metadata';
 
 	constructor(

--- a/src/vs/editor/contrib/dropOrPasteInto/browser/copyPasteContribution.ts
+++ b/src/vs/editor/contrib/dropOrPasteInto/browser/copyPasteContribution.ts
@@ -109,7 +109,7 @@ registerEditorAction(class extends EditorAction {
 	}
 });
 
-export type PreferredPasteConfiguration = ReadonlyArray<{ readonly kind: string; readonly mimeType?: string }>;
+export type PreferredPasteConfiguration = string;
 
 Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).registerConfiguration({
 	...editorConfigurationBaseNode,
@@ -117,24 +117,11 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).regis
 		[pasteAsPreferenceConfig]: {
 			type: 'array',
 			scope: ConfigurationScope.LANGUAGE_OVERRIDABLE,
-			description: nls.localize('preferredDescription', "Configures the preferred type of edit to use when pasting content.\n\nThis is an ordered list of edit kinds with optional mime types for the content being pasted. The first available edit of a preferred kind will be used."),
+			description: nls.localize('preferredDescription', "Configures the preferred type of edit to use when pasting content.\n\nThis is an ordered list of edit kinds. The first available edit of a preferred kind will be used."),
 			default: [],
 			items: {
-				type: 'object',
-				required: ['kind'],
-				properties: {
-					mimeType: {
-						type: 'string',
-						description: nls.localize('mimeType', "The optional mime type that this preference applies to. If not provided, the preference will be used for all mime types."),
-					},
-					kind: {
-						type: 'string',
-						description: nls.localize('kind', "The kind identifier of the paste edit."),
-					}
-				},
-				defaultSnippets: [
-					{ body: { kind: '$1' } }
-				]
+				type: 'string',
+				description: nls.localize('kind', "The kind identifier of the paste edit."),
 			}
 		},
 	}

--- a/src/vs/editor/contrib/dropOrPasteInto/browser/copyPasteController.ts
+++ b/src/vs/editor/contrib/dropOrPasteInto/browser/copyPasteController.ts
@@ -660,13 +660,11 @@ export class CopyPasteController extends Disposable implements IEditorContributi
 		}
 	}
 
-	private getInitialActiveEditIndex(model: ITextModel, edits: readonly DocumentPasteEdit[]) {
-		const preferredProviders = this._configService.getValue<PreferredPasteConfiguration>(pasteAsPreferenceConfig, { resource: model.uri });
+	private getInitialActiveEditIndex(model: ITextModel, edits: readonly DocumentPasteEdit[]): number {
+		const preferredProviders = this._configService.getValue<PreferredPasteConfiguration[]>(pasteAsPreferenceConfig, { resource: model.uri });
 		for (const config of Array.isArray(preferredProviders) ? preferredProviders : []) {
-			const desiredKind = new HierarchicalKind(config.kind);
-			const editIndex = edits.findIndex(edit =>
-				desiredKind.contains(edit.kind)
-				&& (!config.mimeType || (edit.handledMimeType && matchesMimeType(config.mimeType, [edit.handledMimeType]))));
+			const desiredKind = new HierarchicalKind(config);
+			const editIndex = edits.findIndex(edit => desiredKind.contains(edit.kind));
 			if (editIndex >= 0) {
 				return editIndex;
 			}

--- a/src/vs/editor/contrib/dropOrPasteInto/browser/dropIntoEditorContribution.ts
+++ b/src/vs/editor/contrib/dropOrPasteInto/browser/dropIntoEditorContribution.ts
@@ -52,7 +52,7 @@ registerEditorCommand(new class extends EditorCommand {
 	}
 });
 
-export type PreferredDropConfiguration = ReadonlyArray<{ readonly kind: string; readonly mimeType?: string }>;
+export type PreferredDropConfiguration = string;
 
 Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).registerConfiguration({
 	...editorConfigurationBaseNode,
@@ -60,24 +60,11 @@ Registry.as<IConfigurationRegistry>(ConfigurationExtensions.Configuration).regis
 		[dropAsPreferenceConfig]: {
 			type: 'array',
 			scope: ConfigurationScope.LANGUAGE_OVERRIDABLE,
-			description: nls.localize('preferredDescription', "Configures the preferred type of edit to use when dropping content.\n\nThis is an ordered list of edit kinds with optional mime types for the content being dropped. The first available edit of a preferred kind will be used."),
+			description: nls.localize('preferredDescription', "Configures the preferred type of edit to use when dropping content.\n\nThis is an ordered list of edit kinds. The first available edit of a preferred kind will be used."),
 			default: [],
 			items: {
-				type: 'object',
-				required: ['kind'],
-				properties: {
-					mimeType: {
-						type: 'string',
-						description: nls.localize('mimeType', "The optional mime type that this preference applies to. If not provided, the preference will be used for all mime types."),
-					},
-					kind: {
-						type: 'string',
-						description: nls.localize('kind', "The kind identifier of the drop edit."),
-					}
-				},
-				defaultSnippets: [
-					{ body: { kind: '$1' } }
-				]
+				type: 'string',
+				description: nls.localize('kind', "The kind identifier of the drop edit."),
 			}
 		},
 	}


### PR DESCRIPTION
Makes it a simple array of kinds for now. We can add the mime type variation later if needed

Also makes the paste with imports have a better hierarchy. This lets you setup a keybinding for `text.updateImports` that will work across all languages that support it

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
