### PR TITLE
fix: cannot open vscode when use vscode-win32-x64 in Windows

### DIFF
--- a/build/lib/optimize.js
+++ b/build/lib/optimize.js
@@ -71,7 +71,7 @@ function bundleESMTask(opts) {
                             newContents = contents;
                         }
                         // File Content Mapper
-                        const mapper = opts.fileContentMapper?.(path);
+                        const mapper = opts.fileContentMapper?.(path.replace(/\\/g, '/'));
                         if (mapper) {
                             newContents = await mapper(newContents);
                         }

--- a/build/lib/optimize.ts
+++ b/build/lib/optimize.ts
@@ -106,7 +106,7 @@ function bundleESMTask(opts: IBundleESMTaskOpts): NodeJS.ReadWriteStream {
 						}
 
 						// File Content Mapper
-						const mapper = opts.fileContentMapper?.(path);
+						const mapper = opts.fileContentMapper?.(path.replace(/\\/g, '/'));
 						if (mapper) {
 							newContents = await mapper(newContents);
 						}


### PR DESCRIPTION
When executing `npm run gulp vscode-win32-x64` on the Windows platform, the `bundle-vscode` task is triggered. However, this task does not handle the path issues well, resulting in the contents of the `bootstrap-window.js` file not being injected into `workbench.js` and `processExplorer.js`.

The reason why VSCode does not encounter this issue is that the code compilation (compile-build) is performed on a Linux machine, while the Windows machine only executes the application build (vscode-win32-x64-ci will not trigger `bundle-vscode`).

PTAL @deepak1556 
