### PR TITLE
Hex value should be prefixed with whitespace or should be at the start of the line

### DIFF
--- a/src/vs/editor/common/languages/defaultDocumentColorsComputer.ts
+++ b/src/vs/editor/common/languages/defaultDocumentColorsComputer.ts
@@ -49,15 +49,10 @@ function _findRange(model: IDocumentColorComputerTarget, match: RegExpMatchArray
 	return range;
 }
 
-function _findHexColorInformation(range: IRange | undefined, hexSchema: string, hexParameters: string) {
+function _findHexColorInformation(range: IRange | undefined, hexValue: string) {
 	if (!range) {
 		return;
 	}
-	// Even though length 3 and 4 hex values are valid, do not show default color decorators for these lengths
-	if (hexParameters.length !== 6 && hexParameters.length !== 8) {
-		return;
-	}
-	const hexValue = hexSchema + hexParameters;
 	const parsedHexColor = Color.Format.CSS.parseHex(hexValue);
 	if (!parsedHexColor) {
 		return;
@@ -106,7 +101,7 @@ function _findMatches(model: IDocumentColorComputerTarget | string, regex: RegEx
 function computeColors(model: IDocumentColorComputerTarget): IColorInformation[] {
 	const result: IColorInformation[] = [];
 	// Early validation for RGB and HSL
-	const initialValidationRegex = /\b(rgb|rgba|hsl|hsla)(\([0-9\s,.\%]*\))|(#)([A-Fa-f0-9]{3})\b|(#)([A-Fa-f0-9]{4})\b|(#)([A-Fa-f0-9]{6})\b|(#)([A-Fa-f0-9]{8})\b/gm;
+	const initialValidationRegex = /\b(rgb|rgba|hsl|hsla)(\([0-9\s,.\%]*\))|\s+(#)([A-Fa-f0-9]{6})\b|\s+(#)([A-Fa-f0-9]{8})\b|^(#)([A-Fa-f0-9]{6})\b|^(#)([A-Fa-f0-9]{8})\b/gm;
 	const initialValidationMatches = _findMatches(model, initialValidationRegex);
 
 	// Potential colors have been found, validate the parameters
@@ -132,7 +127,7 @@ function computeColors(model: IDocumentColorComputerTarget): IColorInformation[]
 				const regexParameters = /^\(\s*(36[0]|3[0-5][0-9]|[12][0-9][0-9]|[1-9]?[0-9])\s*,\s*(100|\d{1,2}[.]\d*|\d{1,2})%\s*,\s*(100|\d{1,2}[.]\d*|\d{1,2})%\s*,\s*(0[.][0-9]+|[.][0-9]+|[01][.]|[01])\s*\)$/gm;
 				colorInformation = _findHSLColorInformation(_findRange(model, initialMatch), _findMatches(colorParameters, regexParameters), true);
 			} else if (colorScheme === '#') {
-				colorInformation = _findHexColorInformation(_findRange(model, initialMatch), colorScheme, colorParameters);
+				colorInformation = _findHexColorInformation(_findRange(model, initialMatch), colorScheme + colorParameters);
 			}
 			if (colorInformation) {
 				result.push(colorInformation);


### PR DESCRIPTION
Also refactors the code so that searching for length 6 and 8 hex values are encoded in the regex, not filtered after the match is found

fixes https://github.com/microsoft/vscode/issues/233209