### PR TITLE
Turn on TypeScript's experimental expandable hover by default in the VS Code workspace

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -170,4 +170,5 @@
 	"typescript.enablePromptUseWorkspaceTsdk": true,
 	"eslint.useFlatConfig": true,
 	"editor.occurrencesHighlightDelay": 0,
+	"typescript.experimental.expandableHover": true,
 }


### PR DESCRIPTION
From feedback from standup