### PR TITLE
polish: disabling default color decorators in simple editors through editor construction options

### DIFF
--- a/src/vs/workbench/contrib/codeEditor/browser/simpleEditorOptions.ts
+++ b/src/vs/workbench/contrib/codeEditor/browser/simpleEditorOptions.ts
@@ -48,6 +48,7 @@ export function getSimpleEditorOptions(configurationService: IConfigurationServi
 		accessibilitySupport: configurationService.getValue<'auto' | 'off' | 'on'>('editor.accessibilitySupport'),
 		cursorBlinking: configurationService.getValue<'blink' | 'smooth' | 'phase' | 'expand' | 'solid'>('editor.cursorBlinking'),
 		experimentalEditContextEnabled: configurationService.getValue<boolean>('editor.experimentalEditContextEnabled'),
+		defaultColorDecorators: false,
 	};
 }
 

--- a/src/vs/workbench/contrib/scm/browser/scmViewPane.ts
+++ b/src/vs/workbench/contrib/scm/browser/scmViewPane.ts
@@ -1513,7 +1513,6 @@ class SCMInputWidgetEditorOptions {
 			},
 			wrappingIndent: 'none',
 			wrappingStrategy: 'advanced',
-			defaultColorDecorators: false
 		};
 	}
 


### PR DESCRIPTION
polish item