### PR TITLE
Replace duplicate aliases in editoractions

### DIFF
--- a/src/vs/editor/contrib/anchorSelect/browser/anchorSelect.ts
+++ b/src/vs/editor/contrib/anchorSelect/browser/anchorSelect.ts
@@ -14,7 +14,7 @@ import { Selection } from '../../../common/core/selection.js';
 import { IEditorContribution } from '../../../common/editorCommon.js';
 import { EditorContextKeys } from '../../../common/editorContextKeys.js';
 import { TrackedRangeStickiness } from '../../../common/model.js';
-import { localize } from '../../../../nls.js';
+import { localize, localize2 } from '../../../../nls.js';
 import { IContextKey, IContextKeyService, RawContextKey } from '../../../../platform/contextkey/common/contextkey.js';
 import { KeybindingWeight } from '../../../../platform/keybinding/common/keybindingsRegistry.js';
 
@@ -103,8 +103,7 @@ class SetSelectionAnchor extends EditorAction {
 	constructor() {
 		super({
 			id: 'editor.action.setSelectionAnchor',
-			label: localize('setSelectionAnchor', "Set Selection Anchor"),
-			alias: 'Set Selection Anchor',
+			label: localize2('setSelectionAnchor', "Set Selection Anchor"),
 			precondition: undefined,
 			kbOpts: {
 				kbExpr: EditorContextKeys.editorTextFocus,
@@ -123,8 +122,7 @@ class GoToSelectionAnchor extends EditorAction {
 	constructor() {
 		super({
 			id: 'editor.action.goToSelectionAnchor',
-			label: localize('goToSelectionAnchor', "Go to Selection Anchor"),
-			alias: 'Go to Selection Anchor',
+			label: localize2('goToSelectionAnchor', "Go to Selection Anchor"),
 			precondition: SelectionAnchorSet,
 		});
 	}
@@ -138,8 +136,7 @@ class SelectFromAnchorToCursor extends EditorAction {
 	constructor() {
 		super({
 			id: 'editor.action.selectFromAnchorToCursor',
-			label: localize('selectFromAnchorToCursor', "Select from Anchor to Cursor"),
-			alias: 'Select from Anchor to Cursor',
+			label: localize2('selectFromAnchorToCursor', "Select from Anchor to Cursor"),
 			precondition: SelectionAnchorSet,
 			kbOpts: {
 				kbExpr: EditorContextKeys.editorTextFocus,
@@ -158,8 +155,7 @@ class CancelSelectionAnchor extends EditorAction {
 	constructor() {
 		super({
 			id: 'editor.action.cancelSelectionAnchor',
-			label: localize('cancelSelectionAnchor', "Cancel Selection Anchor"),
-			alias: 'Cancel Selection Anchor',
+			label: localize2('cancelSelectionAnchor', "Cancel Selection Anchor"),
 			precondition: SelectionAnchorSet,
 			kbOpts: {
 				kbExpr: EditorContextKeys.editorTextFocus,

--- a/src/vs/editor/contrib/bracketMatching/browser/bracketMatching.ts
+++ b/src/vs/editor/contrib/bracketMatching/browser/bracketMatching.ts
@@ -29,8 +29,7 @@ class JumpToBracketAction extends EditorAction {
 	constructor() {
 		super({
 			id: 'editor.action.jumpToBracket',
-			label: nls.localize('smartSelect.jumpBracket', "Go to Bracket"),
-			alias: 'Go to Bracket',
+			label: nls.localize2('smartSelect.jumpBracket', "Go to Bracket"),
 			precondition: undefined,
 			kbOpts: {
 				kbExpr: EditorContextKeys.editorTextFocus,
@@ -49,8 +48,7 @@ class SelectToBracketAction extends EditorAction {
 	constructor() {
 		super({
 			id: 'editor.action.selectToBracket',
-			label: nls.localize('smartSelect.selectToBracket', "Select to Bracket"),
-			alias: 'Select to Bracket',
+			label: nls.localize2('smartSelect.selectToBracket', "Select to Bracket"),
 			precondition: undefined,
 			metadata: {
 				description: nls.localize2('smartSelect.selectToBracketDescription', "Select the text inside and including the brackets or curly braces"),
@@ -82,8 +80,7 @@ class RemoveBracketsAction extends EditorAction {
 	constructor() {
 		super({
 			id: 'editor.action.removeBrackets',
-			label: nls.localize('smartSelect.removeBrackets', "Remove Brackets"),
-			alias: 'Remove Brackets',
+			label: nls.localize2('smartSelect.removeBrackets', "Remove Brackets"),
 			precondition: undefined,
 			kbOpts: {
 				kbExpr: EditorContextKeys.editorTextFocus,

--- a/src/vs/editor/contrib/caretOperations/browser/caretOperations.ts
+++ b/src/vs/editor/contrib/caretOperations/browser/caretOperations.ts
@@ -42,8 +42,7 @@ class MoveCaretLeftAction extends MoveCaretAction {
 	constructor() {
 		super(true, {
 			id: 'editor.action.moveCarretLeftAction',
-			label: nls.localize('caret.moveLeft', "Move Selected Text Left"),
-			alias: 'Move Selected Text Left',
+			label: nls.localize2('caret.moveLeft', "Move Selected Text Left"),
 			precondition: EditorContextKeys.writable
 		});
 	}
@@ -53,8 +52,7 @@ class MoveCaretRightAction extends MoveCaretAction {
 	constructor() {
 		super(false, {
 			id: 'editor.action.moveCarretRightAction',
-			label: nls.localize('caret.moveRight', "Move Selected Text Right"),
-			alias: 'Move Selected Text Right',
+			label: nls.localize2('caret.moveRight', "Move Selected Text Right"),
 			precondition: EditorContextKeys.writable
 		});
 	}

--- a/src/vs/editor/contrib/caretOperations/browser/transpose.ts
+++ b/src/vs/editor/contrib/caretOperations/browser/transpose.ts
@@ -19,8 +19,7 @@ class TransposeLettersAction extends EditorAction {
 	constructor() {
 		super({
 			id: 'editor.action.transposeLetters',
-			label: nls.localize('transposeLetters.label', "Transpose Letters"),
-			alias: 'Transpose Letters',
+			label: nls.localize2('transposeLetters.label', "Transpose Letters"),
 			precondition: EditorContextKeys.writable,
 			kbOpts: {
 				kbExpr: EditorContextKeys.textInputFocus,

--- a/src/vs/editor/contrib/clipboard/browser/clipboard.ts
+++ b/src/vs/editor/contrib/clipboard/browser/clipboard.ts
@@ -157,8 +157,7 @@ class ExecCommandCopyWithSyntaxHighlightingAction extends EditorAction {
 	constructor() {
 		super({
 			id: 'editor.action.clipboardCopyWithSyntaxHighlightingAction',
-			label: nls.localize('actions.clipboard.copyWithSyntaxHighlightingLabel', "Copy With Syntax Highlighting"),
-			alias: 'Copy With Syntax Highlighting',
+			label: nls.localize2('actions.clipboard.copyWithSyntaxHighlightingLabel', "Copy With Syntax Highlighting"),
 			precondition: undefined,
 			kbOpts: {
 				kbExpr: EditorContextKeys.textInputFocus,

--- a/src/vs/editor/contrib/codelens/browser/codelensController.ts
+++ b/src/vs/editor/contrib/codelens/browser/codelensController.ts
@@ -18,7 +18,7 @@ import { CodeLens, Command } from '../../../common/languages.js';
 import { CodeLensItem, CodeLensModel, getCodeLensModel } from './codelens.js';
 import { ICodeLensCache } from './codeLensCache.js';
 import { CodeLensHelper, CodeLensWidget } from './codelensWidget.js';
-import { localize } from '../../../../nls.js';
+import { localize, localize2 } from '../../../../nls.js';
 import { ICommandService } from '../../../../platform/commands/common/commands.js';
 import { INotificationService } from '../../../../platform/notification/common/notification.js';
 import { IQuickInputService } from '../../../../platform/quickinput/common/quickInput.js';
@@ -464,8 +464,7 @@ registerEditorAction(class ShowLensesInCurrentLine extends EditorAction {
 		super({
 			id: 'codelens.showLensesInCurrentLine',
 			precondition: EditorContextKeys.hasCodeLensProvider,
-			label: localize('showLensOnLine', "Show CodeLens Commands For Current Line"),
-			alias: 'Show CodeLens Commands For Current Line',
+			label: localize2('showLensOnLine', "Show CodeLens Commands For Current Line"),
 		});
 	}
 

--- a/src/vs/editor/contrib/colorPicker/browser/standaloneColorPicker/standaloneColorPickerActions.ts
+++ b/src/vs/editor/contrib/colorPicker/browser/standaloneColorPicker/standaloneColorPickerActions.ts
@@ -38,13 +38,12 @@ export class HideStandaloneColorPicker extends EditorAction {
 	constructor() {
 		super({
 			id: 'editor.action.hideColorPicker',
-			label: localize({
+			label: localize2({
 				key: 'hideColorPicker',
 				comment: [
 					'Action that hides the color picker'
 				]
 			}, "Hide the Color Picker"),
-			alias: 'Hide the Color Picker',
 			precondition: EditorContextKeys.standaloneColorPickerVisible.isEqualTo(true),
 			kbOpts: {
 				primary: KeyCode.Escape,
@@ -64,13 +63,12 @@ export class InsertColorWithStandaloneColorPicker extends EditorAction {
 	constructor() {
 		super({
 			id: 'editor.action.insertColorWithStandaloneColorPicker',
-			label: localize({
+			label: localize2({
 				key: 'insertColorWithStandaloneColorPicker',
 				comment: [
 					'Action that inserts color with standalone color picker'
 				]
 			}, "Insert Color with Standalone Color Picker"),
-			alias: 'Insert Color with Standalone Color Picker',
 			precondition: EditorContextKeys.standaloneColorPickerFocused.isEqualTo(true),
 			kbOpts: {
 				primary: KeyCode.Enter,

--- a/src/vs/editor/contrib/comment/browser/comment.ts
+++ b/src/vs/editor/contrib/comment/browser/comment.ts
@@ -82,8 +82,7 @@ class ToggleCommentLineAction extends CommentLineAction {
 	constructor() {
 		super(Type.Toggle, {
 			id: 'editor.action.commentLine',
-			label: nls.localize('comment.line', "Toggle Line Comment"),
-			alias: 'Toggle Line Comment',
+			label: nls.localize2('comment.line', "Toggle Line Comment"),
 			precondition: EditorContextKeys.writable,
 			kbOpts: {
 				kbExpr: EditorContextKeys.editorTextFocus,
@@ -104,8 +103,7 @@ class AddLineCommentAction extends CommentLineAction {
 	constructor() {
 		super(Type.ForceAdd, {
 			id: 'editor.action.addCommentLine',
-			label: nls.localize('comment.line.add', "Add Line Comment"),
-			alias: 'Add Line Comment',
+			label: nls.localize2('comment.line.add', "Add Line Comment"),
 			precondition: EditorContextKeys.writable,
 			kbOpts: {
 				kbExpr: EditorContextKeys.editorTextFocus,
@@ -120,8 +118,7 @@ class RemoveLineCommentAction extends CommentLineAction {
 	constructor() {
 		super(Type.ForceRemove, {
 			id: 'editor.action.removeCommentLine',
-			label: nls.localize('comment.line.remove', "Remove Line Comment"),
-			alias: 'Remove Line Comment',
+			label: nls.localize2('comment.line.remove', "Remove Line Comment"),
 			precondition: EditorContextKeys.writable,
 			kbOpts: {
 				kbExpr: EditorContextKeys.editorTextFocus,
@@ -137,8 +134,7 @@ class BlockCommentAction extends EditorAction {
 	constructor() {
 		super({
 			id: 'editor.action.blockComment',
-			label: nls.localize('comment.block', "Toggle Block Comment"),
-			alias: 'Toggle Block Comment',
+			label: nls.localize2('comment.block', "Toggle Block Comment"),
 			precondition: EditorContextKeys.writable,
 			kbOpts: {
 				kbExpr: EditorContextKeys.editorTextFocus,

--- a/src/vs/editor/contrib/contextmenu/browser/contextmenu.ts
+++ b/src/vs/editor/contrib/contextmenu/browser/contextmenu.ts
@@ -391,8 +391,7 @@ class ShowContextMenu extends EditorAction {
 	constructor() {
 		super({
 			id: 'editor.action.showContextMenu',
-			label: nls.localize('action.showContextMenu.label', "Show Editor Context Menu"),
-			alias: 'Show Editor Context Menu',
+			label: nls.localize2('action.showContextMenu.label', "Show Editor Context Menu"),
 			precondition: undefined,
 			kbOpts: {
 				kbExpr: EditorContextKeys.textInputFocus,

--- a/src/vs/editor/contrib/cursorUndo/browser/cursorUndo.ts
+++ b/src/vs/editor/contrib/cursorUndo/browser/cursorUndo.ts
@@ -129,8 +129,7 @@ export class CursorUndo extends EditorAction {
 	constructor() {
 		super({
 			id: 'cursorUndo',
-			label: nls.localize('cursor.undo', "Cursor Undo"),
-			alias: 'Cursor Undo',
+			label: nls.localize2('cursor.undo', "Cursor Undo"),
 			precondition: undefined,
 			kbOpts: {
 				kbExpr: EditorContextKeys.textInputFocus,
@@ -149,8 +148,7 @@ export class CursorRedo extends EditorAction {
 	constructor() {
 		super({
 			id: 'cursorRedo',
-			label: nls.localize('cursor.redo', "Cursor Redo"),
-			alias: 'Cursor Redo',
+			label: nls.localize2('cursor.redo', "Cursor Redo"),
 			precondition: undefined
 		});
 	}

--- a/src/vs/editor/contrib/dropOrPasteInto/browser/copyPasteContribution.ts
+++ b/src/vs/editor/contrib/dropOrPasteInto/browser/copyPasteContribution.ts
@@ -70,8 +70,7 @@ registerEditorAction(class PasteAsAction extends EditorAction {
 	constructor() {
 		super({
 			id: 'editor.action.pasteAs',
-			label: nls.localize('pasteAs', "Paste As..."),
-			alias: 'Paste As...',
+			label: nls.localize2('pasteAs', "Paste As..."),
 			precondition: EditorContextKeys.writable,
 			metadata: {
 				description: 'Paste as',
@@ -98,8 +97,7 @@ registerEditorAction(class extends EditorAction {
 	constructor() {
 		super({
 			id: 'editor.action.pasteAsText',
-			label: nls.localize('pasteAsText', "Paste as Text"),
-			alias: 'Paste as Text',
+			label: nls.localize2('pasteAsText', "Paste as Text"),
 			precondition: EditorContextKeys.writable,
 		});
 	}

--- a/src/vs/editor/contrib/find/browser/findController.ts
+++ b/src/vs/editor/contrib/find/browser/findController.ts
@@ -523,8 +523,7 @@ export class FindController extends CommonFindController implements IFindControl
 
 export const StartFindAction = registerMultiEditorAction(new MultiEditorAction({
 	id: FIND_IDS.StartFindAction,
-	label: nls.localize('startFindAction', "Find"),
-	alias: 'Find',
+	label: nls.localize2('startFindAction', "Find"),
 	precondition: ContextKeyExpr.or(EditorContextKeys.focus, ContextKeyExpr.has('editorIsOpen')),
 	kbOpts: {
 		kbExpr: null,
@@ -579,8 +578,7 @@ export class StartFindWithArgsAction extends EditorAction {
 	constructor() {
 		super({
 			id: FIND_IDS.StartFindWithArgs,
-			label: nls.localize('startFindWithArgsAction', "Find With Arguments"),
-			alias: 'Find With Arguments',
+			label: nls.localize2('startFindWithArgsAction', "Find With Arguments"),
 			precondition: undefined,
 			kbOpts: {
 				kbExpr: null,
@@ -629,8 +627,7 @@ export class StartFindWithSelectionAction extends EditorAction {
 	constructor() {
 		super({
 			id: FIND_IDS.StartFindWithSelection,
-			label: nls.localize('startFindWithSelectionAction', "Find With Selection"),
-			alias: 'Find With Selection',
+			label: nls.localize2('startFindWithSelectionAction', "Find With Selection"),
 			precondition: undefined,
 			kbOpts: {
 				kbExpr: null,
@@ -687,8 +684,7 @@ export class NextMatchFindAction extends MatchFindAction {
 	constructor() {
 		super({
 			id: FIND_IDS.NextMatchFindAction,
-			label: nls.localize('findNextMatchAction', "Find Next"),
-			alias: 'Find Next',
+			label: nls.localize2('findNextMatchAction', "Find Next"),
 			precondition: undefined,
 			kbOpts: [{
 				kbExpr: EditorContextKeys.focus,
@@ -720,8 +716,7 @@ export class PreviousMatchFindAction extends MatchFindAction {
 	constructor() {
 		super({
 			id: FIND_IDS.PreviousMatchFindAction,
-			label: nls.localize('findPreviousMatchAction', "Find Previous"),
-			alias: 'Find Previous',
+			label: nls.localize2('findPreviousMatchAction', "Find Previous"),
 			precondition: undefined,
 			kbOpts: [{
 				kbExpr: EditorContextKeys.focus,
@@ -748,8 +743,7 @@ export class MoveToMatchFindAction extends EditorAction {
 	constructor() {
 		super({
 			id: FIND_IDS.GoToMatchFindAction,
-			label: nls.localize('findMatchAction.goToMatch', "Go to Match..."),
-			alias: 'Go to Match...',
+			label: nls.localize2('findMatchAction.goToMatch', "Go to Match..."),
 			precondition: CONTEXT_FIND_WIDGET_VISIBLE
 		});
 	}
@@ -894,8 +888,7 @@ export class NextSelectionMatchFindAction extends SelectionMatchFindAction {
 	constructor() {
 		super({
 			id: FIND_IDS.NextSelectionMatchFindAction,
-			label: nls.localize('nextSelectionMatchFindAction', "Find Next Selection"),
-			alias: 'Find Next Selection',
+			label: nls.localize2('nextSelectionMatchFindAction', "Find Next Selection"),
 			precondition: undefined,
 			kbOpts: {
 				kbExpr: EditorContextKeys.focus,
@@ -915,8 +908,7 @@ export class PreviousSelectionMatchFindAction extends SelectionMatchFindAction {
 	constructor() {
 		super({
 			id: FIND_IDS.PreviousSelectionMatchFindAction,
-			label: nls.localize('previousSelectionMatchFindAction', "Find Previous Selection"),
-			alias: 'Find Previous Selection',
+			label: nls.localize2('previousSelectionMatchFindAction', "Find Previous Selection"),
 			precondition: undefined,
 			kbOpts: {
 				kbExpr: EditorContextKeys.focus,
@@ -933,8 +925,7 @@ export class PreviousSelectionMatchFindAction extends SelectionMatchFindAction {
 
 export const StartFindReplaceAction = registerMultiEditorAction(new MultiEditorAction({
 	id: FIND_IDS.StartFindReplaceAction,
-	label: nls.localize('startReplace', "Replace"),
-	alias: 'Replace',
+	label: nls.localize2('startReplace', "Replace"),
 	precondition: ContextKeyExpr.or(EditorContextKeys.focus, ContextKeyExpr.has('editorIsOpen')),
 	kbOpts: {
 		kbExpr: null,

--- a/src/vs/editor/contrib/folding/browser/folding.ts
+++ b/src/vs/editor/contrib/folding/browser/folding.ts
@@ -635,8 +635,7 @@ class UnfoldAction extends FoldingAction<FoldingArguments> {
 	constructor() {
 		super({
 			id: 'editor.unfold',
-			label: nls.localize('unfoldAction.label', "Unfold"),
-			alias: 'Unfold',
+			label: nls.localize2('unfoldAction.label', "Unfold"),
 			precondition: CONTEXT_FOLDING_ENABLED,
 			kbOpts: {
 				kbExpr: EditorContextKeys.editorTextFocus,
@@ -699,8 +698,7 @@ class UnFoldRecursivelyAction extends FoldingAction<void> {
 	constructor() {
 		super({
 			id: 'editor.unfoldRecursively',
-			label: nls.localize('unFoldRecursivelyAction.label', "Unfold Recursively"),
-			alias: 'Unfold Recursively',
+			label: nls.localize2('unFoldRecursivelyAction.label', "Unfold Recursively"),
 			precondition: CONTEXT_FOLDING_ENABLED,
 			kbOpts: {
 				kbExpr: EditorContextKeys.editorTextFocus,
@@ -720,8 +718,7 @@ class FoldAction extends FoldingAction<FoldingArguments> {
 	constructor() {
 		super({
 			id: 'editor.fold',
-			label: nls.localize('foldAction.label', "Fold"),
-			alias: 'Fold',
+			label: nls.localize2('foldAction.label', "Fold"),
 			precondition: CONTEXT_FOLDING_ENABLED,
 			kbOpts: {
 				kbExpr: EditorContextKeys.editorTextFocus,
@@ -792,8 +789,7 @@ class ToggleFoldAction extends FoldingAction<void> {
 	constructor() {
 		super({
 			id: 'editor.toggleFold',
-			label: nls.localize('toggleFoldAction.label', "Toggle Fold"),
-			alias: 'Toggle Fold',
+			label: nls.localize2('toggleFoldAction.label', "Toggle Fold"),
 			precondition: CONTEXT_FOLDING_ENABLED,
 			kbOpts: {
 				kbExpr: EditorContextKeys.editorTextFocus,
@@ -815,8 +811,7 @@ class FoldRecursivelyAction extends FoldingAction<void> {
 	constructor() {
 		super({
 			id: 'editor.foldRecursively',
-			label: nls.localize('foldRecursivelyAction.label', "Fold Recursively"),
-			alias: 'Fold Recursively',
+			label: nls.localize2('foldRecursivelyAction.label', "Fold Recursively"),
 			precondition: CONTEXT_FOLDING_ENABLED,
 			kbOpts: {
 				kbExpr: EditorContextKeys.editorTextFocus,
@@ -838,8 +833,7 @@ class ToggleFoldRecursivelyAction extends FoldingAction<void> {
 	constructor() {
 		super({
 			id: 'editor.toggleFoldRecursively',
-			label: nls.localize('toggleFoldRecursivelyAction.label', "Toggle Fold Recursively"),
-			alias: 'Toggle Fold Recursively',
+			label: nls.localize2('toggleFoldRecursivelyAction.label', "Toggle Fold Recursively"),
 			precondition: CONTEXT_FOLDING_ENABLED,
 			kbOpts: {
 				kbExpr: EditorContextKeys.editorTextFocus,
@@ -861,8 +855,7 @@ class FoldAllBlockCommentsAction extends FoldingAction<void> {
 	constructor() {
 		super({
 			id: 'editor.foldAllBlockComments',
-			label: nls.localize('foldAllBlockComments.label', "Fold All Block Comments"),
-			alias: 'Fold All Block Comments',
+			label: nls.localize2('foldAllBlockComments.label', "Fold All Block Comments"),
 			precondition: CONTEXT_FOLDING_ENABLED,
 			kbOpts: {
 				kbExpr: EditorContextKeys.editorTextFocus,
@@ -894,8 +887,7 @@ class FoldAllRegionsAction extends FoldingAction<void> {
 	constructor() {
 		super({
 			id: 'editor.foldAllMarkerRegions',
-			label: nls.localize('foldAllMarkerRegions.label', "Fold All Regions"),
-			alias: 'Fold All Regions',
+			label: nls.localize2('foldAllMarkerRegions.label', "Fold All Regions"),
 			precondition: CONTEXT_FOLDING_ENABLED,
 			kbOpts: {
 				kbExpr: EditorContextKeys.editorTextFocus,
@@ -927,8 +919,7 @@ class UnfoldAllRegionsAction extends FoldingAction<void> {
 	constructor() {
 		super({
 			id: 'editor.unfoldAllMarkerRegions',
-			label: nls.localize('unfoldAllMarkerRegions.label', "Unfold All Regions"),
-			alias: 'Unfold All Regions',
+			label: nls.localize2('unfoldAllMarkerRegions.label', "Unfold All Regions"),
 			precondition: CONTEXT_FOLDING_ENABLED,
 			kbOpts: {
 				kbExpr: EditorContextKeys.editorTextFocus,
@@ -960,8 +951,7 @@ class FoldAllExceptAction extends FoldingAction<void> {
 	constructor() {
 		super({
 			id: 'editor.foldAllExcept',
-			label: nls.localize('foldAllExcept.label', "Fold All Except Selected"),
-			alias: 'Fold All Except Selected',
+			label: nls.localize2('foldAllExcept.label', "Fold All Except Selected"),
 			precondition: CONTEXT_FOLDING_ENABLED,
 			kbOpts: {
 				kbExpr: EditorContextKeys.editorTextFocus,
@@ -983,8 +973,7 @@ class UnfoldAllExceptAction extends FoldingAction<void> {
 	constructor() {
 		super({
 			id: 'editor.unfoldAllExcept',
-			label: nls.localize('unfoldAllExcept.label', "Unfold All Except Selected"),
-			alias: 'Unfold All Except Selected',
+			label: nls.localize2('unfoldAllExcept.label', "Unfold All Except Selected"),
 			precondition: CONTEXT_FOLDING_ENABLED,
 			kbOpts: {
 				kbExpr: EditorContextKeys.editorTextFocus,
@@ -1005,8 +994,7 @@ class FoldAllAction extends FoldingAction<void> {
 	constructor() {
 		super({
 			id: 'editor.foldAll',
-			label: nls.localize('foldAllAction.label', "Fold All"),
-			alias: 'Fold All',
+			label: nls.localize2('foldAllAction.label', "Fold All"),
 			precondition: CONTEXT_FOLDING_ENABLED,
 			kbOpts: {
 				kbExpr: EditorContextKeys.editorTextFocus,
@@ -1026,8 +1014,7 @@ class UnfoldAllAction extends FoldingAction<void> {
 	constructor() {
 		super({
 			id: 'editor.unfoldAll',
-			label: nls.localize('unfoldAllAction.label', "Unfold All"),
-			alias: 'Unfold All',
+			label: nls.localize2('unfoldAllAction.label', "Unfold All"),
 			precondition: CONTEXT_FOLDING_ENABLED,
 			kbOpts: {
 				kbExpr: EditorContextKeys.editorTextFocus,
@@ -1060,8 +1047,7 @@ class GotoParentFoldAction extends FoldingAction<void> {
 	constructor() {
 		super({
 			id: 'editor.gotoParentFold',
-			label: nls.localize('gotoParentFold.label', "Go to Parent Fold"),
-			alias: 'Go to Parent Fold',
+			label: nls.localize2('gotoParentFold.label', "Go to Parent Fold"),
 			precondition: CONTEXT_FOLDING_ENABLED,
 			kbOpts: {
 				kbExpr: EditorContextKeys.editorTextFocus,
@@ -1091,8 +1077,7 @@ class GotoPreviousFoldAction extends FoldingAction<void> {
 	constructor() {
 		super({
 			id: 'editor.gotoPreviousFold',
-			label: nls.localize('gotoPreviousFold.label', "Go to Previous Folding Range"),
-			alias: 'Go to Previous Folding Range',
+			label: nls.localize2('gotoPreviousFold.label', "Go to Previous Folding Range"),
 			precondition: CONTEXT_FOLDING_ENABLED,
 			kbOpts: {
 				kbExpr: EditorContextKeys.editorTextFocus,
@@ -1122,8 +1107,7 @@ class GotoNextFoldAction extends FoldingAction<void> {
 	constructor() {
 		super({
 			id: 'editor.gotoNextFold',
-			label: nls.localize('gotoNextFold.label', "Go to Next Folding Range"),
-			alias: 'Go to Next Folding Range',
+			label: nls.localize2('gotoNextFold.label', "Go to Next Folding Range"),
 			precondition: CONTEXT_FOLDING_ENABLED,
 			kbOpts: {
 				kbExpr: EditorContextKeys.editorTextFocus,
@@ -1153,8 +1137,7 @@ class FoldRangeFromSelectionAction extends FoldingAction<void> {
 	constructor() {
 		super({
 			id: 'editor.createFoldingRangeFromSelection',
-			label: nls.localize('createManualFoldRange.label', "Create Folding Range from Selection"),
-			alias: 'Create Folding Range from Selection',
+			label: nls.localize2('createManualFoldRange.label', "Create Folding Range from Selection"),
 			precondition: CONTEXT_FOLDING_ENABLED,
 			kbOpts: {
 				kbExpr: EditorContextKeys.editorTextFocus,
@@ -1205,8 +1188,7 @@ class RemoveFoldRangeFromSelectionAction extends FoldingAction<void> {
 	constructor() {
 		super({
 			id: 'editor.removeManualFoldingRanges',
-			label: nls.localize('removeManualFoldingRanges.label', "Remove Manual Folding Ranges"),
-			alias: 'Remove Manual Folding Ranges',
+			label: nls.localize2('removeManualFoldingRanges.label', "Remove Manual Folding Ranges"),
 			precondition: CONTEXT_FOLDING_ENABLED,
 			kbOpts: {
 				kbExpr: EditorContextKeys.editorTextFocus,
@@ -1236,8 +1218,7 @@ class ToggleImportFoldAction extends FoldingAction<void> {
 	constructor() {
 		super({
 			id: 'editor.toggleImportFold',
-			label: nls.localize('toggleImportFold.label', "Toggle Import Fold"),
-			alias: 'Toggle Import Fold',
+			label: nls.localize2('toggleImportFold.label', "Toggle Import Fold"),
 			precondition: CONTEXT_FOLDING_ENABLED,
 			kbOpts: {
 				kbExpr: EditorContextKeys.editorTextFocus,
@@ -1285,8 +1266,7 @@ for (let i = 1; i <= 7; i++) {
 	registerInstantiatedEditorAction(
 		new FoldLevelAction({
 			id: FoldLevelAction.ID(i),
-			label: nls.localize('foldLevelAction.label', "Fold Level {0}", i),
-			alias: `Fold Level ${i}`,
+			label: nls.localize2('foldLevelAction.label', "Fold Level {0}", i),
 			precondition: CONTEXT_FOLDING_ENABLED,
 			kbOpts: {
 				kbExpr: EditorContextKeys.editorTextFocus,

--- a/src/vs/editor/contrib/fontZoom/browser/fontZoom.ts
+++ b/src/vs/editor/contrib/fontZoom/browser/fontZoom.ts
@@ -13,8 +13,7 @@ class EditorFontZoomIn extends EditorAction {
 	constructor() {
 		super({
 			id: 'editor.action.fontZoomIn',
-			label: nls.localize('EditorFontZoomIn.label', "Increase Editor Font Size"),
-			alias: 'Increase Editor Font Size',
+			label: nls.localize2('EditorFontZoomIn.label', "Increase Editor Font Size"),
 			precondition: undefined
 		});
 	}
@@ -29,8 +28,7 @@ class EditorFontZoomOut extends EditorAction {
 	constructor() {
 		super({
 			id: 'editor.action.fontZoomOut',
-			label: nls.localize('EditorFontZoomOut.label', "Decrease Editor Font Size"),
-			alias: 'Decrease Editor Font Size',
+			label: nls.localize2('EditorFontZoomOut.label', "Decrease Editor Font Size"),
 			precondition: undefined
 		});
 	}
@@ -45,8 +43,7 @@ class EditorFontZoomReset extends EditorAction {
 	constructor() {
 		super({
 			id: 'editor.action.fontZoomReset',
-			label: nls.localize('EditorFontZoomReset.label', "Reset Editor Font Size"),
-			alias: 'Reset Editor Font Size',
+			label: nls.localize2('EditorFontZoomReset.label', "Reset Editor Font Size"),
 			precondition: undefined
 		});
 	}

--- a/src/vs/editor/contrib/format/browser/formatActions.ts
+++ b/src/vs/editor/contrib/format/browser/formatActions.ts
@@ -214,8 +214,7 @@ class FormatDocumentAction extends EditorAction {
 	constructor() {
 		super({
 			id: 'editor.action.formatDocument',
-			label: nls.localize('formatDocument.label', "Format Document"),
-			alias: 'Format Document',
+			label: nls.localize2('formatDocument.label', "Format Document"),
 			precondition: ContextKeyExpr.and(EditorContextKeys.notInCompositeEditor, EditorContextKeys.writable, EditorContextKeys.hasDocumentFormattingProvider),
 			kbOpts: {
 				kbExpr: EditorContextKeys.editorTextFocus,
@@ -247,8 +246,7 @@ class FormatSelectionAction extends EditorAction {
 	constructor() {
 		super({
 			id: 'editor.action.formatSelection',
-			label: nls.localize('formatSelection.label', "Format Selection"),
-			alias: 'Format Selection',
+			label: nls.localize2('formatSelection.label', "Format Selection"),
 			precondition: ContextKeyExpr.and(EditorContextKeys.writable, EditorContextKeys.hasDocumentSelectionFormattingProvider),
 			kbOpts: {
 				kbExpr: EditorContextKeys.editorTextFocus,

--- a/src/vs/editor/contrib/gotoError/browser/gotoError.ts
+++ b/src/vs/editor/contrib/gotoError/browser/gotoError.ts
@@ -185,12 +185,11 @@ class MarkerNavigationAction extends EditorAction {
 
 export class NextMarkerAction extends MarkerNavigationAction {
 	static ID: string = 'editor.action.marker.next';
-	static LABEL: string = nls.localize('markerAction.next.label', "Go to Next Problem (Error, Warning, Info)");
+	static LABEL = nls.localize2('markerAction.next.label', "Go to Next Problem (Error, Warning, Info)");
 	constructor() {
 		super(true, false, {
 			id: NextMarkerAction.ID,
 			label: NextMarkerAction.LABEL,
-			alias: 'Go to Next Problem (Error, Warning, Info)',
 			precondition: undefined,
 			kbOpts: {
 				kbExpr: EditorContextKeys.focus,
@@ -199,7 +198,7 @@ export class NextMarkerAction extends MarkerNavigationAction {
 			},
 			menuOpts: {
 				menuId: MarkerNavigationWidget.TitleMenu,
-				title: NextMarkerAction.LABEL,
+				title: NextMarkerAction.LABEL.value,
 				icon: registerIcon('marker-navigation-next', Codicon.arrowDown, nls.localize('nextMarkerIcon', 'Icon for goto next marker.')),
 				group: 'navigation',
 				order: 1
@@ -210,12 +209,11 @@ export class NextMarkerAction extends MarkerNavigationAction {
 
 class PrevMarkerAction extends MarkerNavigationAction {
 	static ID: string = 'editor.action.marker.prev';
-	static LABEL: string = nls.localize('markerAction.previous.label', "Go to Previous Problem (Error, Warning, Info)");
+	static LABEL = nls.localize2('markerAction.previous.label', "Go to Previous Problem (Error, Warning, Info)");
 	constructor() {
 		super(false, false, {
 			id: PrevMarkerAction.ID,
 			label: PrevMarkerAction.LABEL,
-			alias: 'Go to Previous Problem (Error, Warning, Info)',
 			precondition: undefined,
 			kbOpts: {
 				kbExpr: EditorContextKeys.focus,
@@ -224,7 +222,7 @@ class PrevMarkerAction extends MarkerNavigationAction {
 			},
 			menuOpts: {
 				menuId: MarkerNavigationWidget.TitleMenu,
-				title: PrevMarkerAction.LABEL,
+				title: PrevMarkerAction.LABEL.value,
 				icon: registerIcon('marker-navigation-previous', Codicon.arrowUp, nls.localize('previousMarkerIcon', 'Icon for goto previous marker.')),
 				group: 'navigation',
 				order: 2
@@ -237,8 +235,7 @@ class NextMarkerInFilesAction extends MarkerNavigationAction {
 	constructor() {
 		super(true, true, {
 			id: 'editor.action.marker.nextInFiles',
-			label: nls.localize('markerAction.nextInFiles.label', "Go to Next Problem in Files (Error, Warning, Info)"),
-			alias: 'Go to Next Problem in Files (Error, Warning, Info)',
+			label: nls.localize2('markerAction.nextInFiles.label', "Go to Next Problem in Files (Error, Warning, Info)"),
 			precondition: undefined,
 			kbOpts: {
 				kbExpr: EditorContextKeys.focus,
@@ -259,8 +256,7 @@ class PrevMarkerInFilesAction extends MarkerNavigationAction {
 	constructor() {
 		super(false, true, {
 			id: 'editor.action.marker.prevInFiles',
-			label: nls.localize('markerAction.previousInFiles.label', "Go to Previous Problem in Files (Error, Warning, Info)"),
-			alias: 'Go to Previous Problem in Files (Error, Warning, Info)',
+			label: nls.localize2('markerAction.previousInFiles.label', "Go to Previous Problem in Files (Error, Warning, Info)"),
 			precondition: undefined,
 			kbOpts: {
 				kbExpr: EditorContextKeys.focus,

--- a/src/vs/editor/contrib/gpu/browser/gpuActions.ts
+++ b/src/vs/editor/contrib/gpu/browser/gpuActions.ts
@@ -5,7 +5,7 @@
 
 import { VSBuffer } from '../../../../base/common/buffer.js';
 import { URI } from '../../../../base/common/uri.js';
-import { localize } from '../../../../nls.js';
+import { localize, localize2 } from '../../../../nls.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { ContextKeyExpr } from '../../../../platform/contextkey/common/contextkey.js';
 import { IFileService } from '../../../../platform/files/common/files.js';
@@ -24,8 +24,7 @@ class DebugEditorGpuRendererAction extends EditorAction {
 	constructor() {
 		super({
 			id: 'editor.action.debugEditorGpuRenderer',
-			label: localize('gpuDebug.label', "Developer: Debug Editor GPU Renderer"),
-			alias: 'Developer: Debug Editor GPU Renderer',
+			label: localize2('gpuDebug.label', "Developer: Debug Editor GPU Renderer"),
 			// TODO: Why doesn't `ContextKeyExpr.equals('config:editor.experimentalGpuAcceleration', 'on')` work?
 			precondition: ContextKeyExpr.true(),
 		});

--- a/src/vs/editor/contrib/hover/browser/hoverActions.ts
+++ b/src/vs/editor/contrib/hover/browser/hoverActions.ts
@@ -30,7 +30,7 @@ export class ShowOrFocusHoverAction extends EditorAction {
 	constructor() {
 		super({
 			id: SHOW_OR_FOCUS_HOVER_ACTION_ID,
-			label: nls.localize({
+			label: nls.localize2({
 				key: 'showOrFocusHover',
 				comment: [
 					'Label for action that will trigger the showing/focusing of a hover in the editor.',
@@ -59,7 +59,6 @@ export class ShowOrFocusHoverAction extends EditorAction {
 					}
 				}]
 			},
-			alias: 'Show or Focus Hover',
 			precondition: undefined,
 			kbOpts: {
 				kbExpr: EditorContextKeys.editorTextFocus,
@@ -112,14 +111,13 @@ export class ShowDefinitionPreviewHoverAction extends EditorAction {
 	constructor() {
 		super({
 			id: SHOW_DEFINITION_PREVIEW_HOVER_ACTION_ID,
-			label: nls.localize({
+			label: nls.localize2({
 				key: 'showDefinitionPreviewHover',
 				comment: [
 					'Label for action that will trigger the showing of definition preview hover in the editor.',
 					'This allows for users to show the definition preview hover without using the mouse.'
 				]
 			}, "Show Definition Preview Hover"),
-			alias: 'Show Definition Preview Hover',
 			precondition: undefined,
 			metadata: {
 				description: nls.localize2('showDefinitionPreviewHoverDescription', 'Show the definition preview hover in the editor.'),
@@ -156,13 +154,12 @@ export class ScrollUpHoverAction extends EditorAction {
 	constructor() {
 		super({
 			id: SCROLL_UP_HOVER_ACTION_ID,
-			label: nls.localize({
+			label: nls.localize2({
 				key: 'scrollUpHover',
 				comment: [
 					'Action that allows to scroll up in the hover widget with the up arrow when the hover widget is focused.'
 				]
 			}, "Scroll Up Hover"),
-			alias: 'Scroll Up Hover',
 			precondition: EditorContextKeys.hoverFocused,
 			kbOpts: {
 				kbExpr: EditorContextKeys.hoverFocused,
@@ -189,13 +186,12 @@ export class ScrollDownHoverAction extends EditorAction {
 	constructor() {
 		super({
 			id: SCROLL_DOWN_HOVER_ACTION_ID,
-			label: nls.localize({
+			label: nls.localize2({
 				key: 'scrollDownHover',
 				comment: [
 					'Action that allows to scroll down in the hover widget with the up arrow when the hover widget is focused.'
 				]
 			}, "Scroll Down Hover"),
-			alias: 'Scroll Down Hover',
 			precondition: EditorContextKeys.hoverFocused,
 			kbOpts: {
 				kbExpr: EditorContextKeys.hoverFocused,
@@ -222,13 +218,12 @@ export class ScrollLeftHoverAction extends EditorAction {
 	constructor() {
 		super({
 			id: SCROLL_LEFT_HOVER_ACTION_ID,
-			label: nls.localize({
+			label: nls.localize2({
 				key: 'scrollLeftHover',
 				comment: [
 					'Action that allows to scroll left in the hover widget with the left arrow when the hover widget is focused.'
 				]
 			}, "Scroll Left Hover"),
-			alias: 'Scroll Left Hover',
 			precondition: EditorContextKeys.hoverFocused,
 			kbOpts: {
 				kbExpr: EditorContextKeys.hoverFocused,
@@ -255,13 +250,12 @@ export class ScrollRightHoverAction extends EditorAction {
 	constructor() {
 		super({
 			id: SCROLL_RIGHT_HOVER_ACTION_ID,
-			label: nls.localize({
+			label: nls.localize2({
 				key: 'scrollRightHover',
 				comment: [
 					'Action that allows to scroll right in the hover widget with the right arrow when the hover widget is focused.'
 				]
 			}, "Scroll Right Hover"),
-			alias: 'Scroll Right Hover',
 			precondition: EditorContextKeys.hoverFocused,
 			kbOpts: {
 				kbExpr: EditorContextKeys.hoverFocused,
@@ -288,13 +282,12 @@ export class PageUpHoverAction extends EditorAction {
 	constructor() {
 		super({
 			id: PAGE_UP_HOVER_ACTION_ID,
-			label: nls.localize({
+			label: nls.localize2({
 				key: 'pageUpHover',
 				comment: [
 					'Action that allows to page up in the hover widget with the page up command when the hover widget is focused.'
 				]
 			}, "Page Up Hover"),
-			alias: 'Page Up Hover',
 			precondition: EditorContextKeys.hoverFocused,
 			kbOpts: {
 				kbExpr: EditorContextKeys.hoverFocused,
@@ -322,13 +315,12 @@ export class PageDownHoverAction extends EditorAction {
 	constructor() {
 		super({
 			id: PAGE_DOWN_HOVER_ACTION_ID,
-			label: nls.localize({
+			label: nls.localize2({
 				key: 'pageDownHover',
 				comment: [
 					'Action that allows to page down in the hover widget with the page down command when the hover widget is focused.'
 				]
 			}, "Page Down Hover"),
-			alias: 'Page Down Hover',
 			precondition: EditorContextKeys.hoverFocused,
 			kbOpts: {
 				kbExpr: EditorContextKeys.hoverFocused,
@@ -356,13 +348,12 @@ export class GoToTopHoverAction extends EditorAction {
 	constructor() {
 		super({
 			id: GO_TO_TOP_HOVER_ACTION_ID,
-			label: nls.localize({
+			label: nls.localize2({
 				key: 'goToTopHover',
 				comment: [
 					'Action that allows to go to the top of the hover widget with the home command when the hover widget is focused.'
 				]
 			}, "Go To Top Hover"),
-			alias: 'Go To Bottom Hover',
 			precondition: EditorContextKeys.hoverFocused,
 			kbOpts: {
 				kbExpr: EditorContextKeys.hoverFocused,
@@ -391,13 +382,12 @@ export class GoToBottomHoverAction extends EditorAction {
 	constructor() {
 		super({
 			id: GO_TO_BOTTOM_HOVER_ACTION_ID,
-			label: nls.localize({
+			label: nls.localize2({
 				key: 'goToBottomHover',
 				comment: [
 					'Action that allows to go to the bottom in the hover widget with the end command when the hover widget is focused.'
 				]
 			}, "Go To Bottom Hover"),
-			alias: 'Go To Bottom Hover',
 			precondition: EditorContextKeys.hoverFocused,
 			kbOpts: {
 				kbExpr: EditorContextKeys.hoverFocused,

--- a/src/vs/editor/contrib/inPlaceReplace/browser/inPlaceReplace.ts
+++ b/src/vs/editor/contrib/inPlaceReplace/browser/inPlaceReplace.ts
@@ -131,8 +131,7 @@ class InPlaceReplaceUp extends EditorAction {
 	constructor() {
 		super({
 			id: 'editor.action.inPlaceReplace.up',
-			label: nls.localize('InPlaceReplaceAction.previous.label', "Replace with Previous Value"),
-			alias: 'Replace with Previous Value',
+			label: nls.localize2('InPlaceReplaceAction.previous.label', "Replace with Previous Value"),
 			precondition: EditorContextKeys.writable,
 			kbOpts: {
 				kbExpr: EditorContextKeys.editorTextFocus,
@@ -156,8 +155,7 @@ class InPlaceReplaceDown extends EditorAction {
 	constructor() {
 		super({
 			id: 'editor.action.inPlaceReplace.down',
-			label: nls.localize('InPlaceReplaceAction.next.label', "Replace with Next Value"),
-			alias: 'Replace with Next Value',
+			label: nls.localize2('InPlaceReplaceAction.next.label', "Replace with Next Value"),
 			precondition: EditorContextKeys.writable,
 			kbOpts: {
 				kbExpr: EditorContextKeys.editorTextFocus,

--- a/src/vs/editor/contrib/indentation/browser/indentation.ts
+++ b/src/vs/editor/contrib/indentation/browser/indentation.ts
@@ -34,8 +34,7 @@ export class IndentationToSpacesAction extends EditorAction {
 	constructor() {
 		super({
 			id: IndentationToSpacesAction.ID,
-			label: nls.localize('indentationToSpaces', "Convert Indentation to Spaces"),
-			alias: 'Convert Indentation to Spaces',
+			label: nls.localize2('indentationToSpaces', "Convert Indentation to Spaces"),
 			precondition: EditorContextKeys.writable,
 			metadata: {
 				description: nls.localize2('indentationToSpacesDescription', "Convert the tab indentation to spaces."),
@@ -71,8 +70,7 @@ export class IndentationToTabsAction extends EditorAction {
 	constructor() {
 		super({
 			id: IndentationToTabsAction.ID,
-			label: nls.localize('indentationToTabs', "Convert Indentation to Tabs"),
-			alias: 'Convert Indentation to Tabs',
+			label: nls.localize2('indentationToTabs', "Convert Indentation to Tabs"),
 			precondition: EditorContextKeys.writable,
 			metadata: {
 				description: nls.localize2('indentationToTabsDescription', "Convert the spaces indentation to tabs."),
@@ -167,8 +165,7 @@ export class IndentUsingTabs extends ChangeIndentationSizeAction {
 	constructor() {
 		super(false, false, {
 			id: IndentUsingTabs.ID,
-			label: nls.localize('indentUsingTabs', "Indent Using Tabs"),
-			alias: 'Indent Using Tabs',
+			label: nls.localize2('indentUsingTabs', "Indent Using Tabs"),
 			precondition: undefined,
 			metadata: {
 				description: nls.localize2('indentUsingTabsDescription', "Use indentation with tabs."),
@@ -184,8 +181,7 @@ export class IndentUsingSpaces extends ChangeIndentationSizeAction {
 	constructor() {
 		super(true, false, {
 			id: IndentUsingSpaces.ID,
-			label: nls.localize('indentUsingSpaces', "Indent Using Spaces"),
-			alias: 'Indent Using Spaces',
+			label: nls.localize2('indentUsingSpaces', "Indent Using Spaces"),
 			precondition: undefined,
 			metadata: {
 				description: nls.localize2('indentUsingSpacesDescription', "Use indentation with spaces."),
@@ -201,8 +197,7 @@ export class ChangeTabDisplaySize extends ChangeIndentationSizeAction {
 	constructor() {
 		super(true, true, {
 			id: ChangeTabDisplaySize.ID,
-			label: nls.localize('changeTabDisplaySize', "Change Tab Display Size"),
-			alias: 'Change Tab Display Size',
+			label: nls.localize2('changeTabDisplaySize', "Change Tab Display Size"),
 			precondition: undefined,
 			metadata: {
 				description: nls.localize2('changeTabDisplaySizeDescription', "Change the space size equivalent of the tab."),
@@ -218,8 +213,7 @@ export class DetectIndentation extends EditorAction {
 	constructor() {
 		super({
 			id: DetectIndentation.ID,
-			label: nls.localize('detectIndentation', "Detect Indentation from Content"),
-			alias: 'Detect Indentation from Content',
+			label: nls.localize2('detectIndentation', "Detect Indentation from Content"),
 			precondition: undefined,
 			metadata: {
 				description: nls.localize2('detectIndentationDescription', "Detect the indentation from content."),
@@ -244,8 +238,7 @@ export class ReindentLinesAction extends EditorAction {
 	constructor() {
 		super({
 			id: 'editor.action.reindentlines',
-			label: nls.localize('editor.reindentlines', "Reindent Lines"),
-			alias: 'Reindent Lines',
+			label: nls.localize2('editor.reindentlines', "Reindent Lines"),
 			precondition: EditorContextKeys.writable,
 			metadata: {
 				description: nls.localize2('editor.reindentlinesDescription', "Reindent the lines of the editor."),
@@ -273,8 +266,7 @@ export class ReindentSelectedLinesAction extends EditorAction {
 	constructor() {
 		super({
 			id: 'editor.action.reindentselectedlines',
-			label: nls.localize('editor.reindentselectedlines', "Reindent Selected Lines"),
-			alias: 'Reindent Selected Lines',
+			label: nls.localize2('editor.reindentselectedlines', "Reindent Selected Lines"),
 			precondition: EditorContextKeys.writable,
 			metadata: {
 				description: nls.localize2('editor.reindentselectedlinesDescription', "Reindent the selected lines of the editor."),

--- a/src/vs/editor/contrib/inlineCompletions/browser/controller/commands.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/controller/commands.ts
@@ -26,8 +26,7 @@ export class ShowNextInlineSuggestionAction extends EditorAction {
 	constructor() {
 		super({
 			id: ShowNextInlineSuggestionAction.ID,
-			label: nls.localize('action.inlineSuggest.showNext', "Show Next Inline Suggestion"),
-			alias: 'Show Next Inline Suggestion',
+			label: nls.localize2('action.inlineSuggest.showNext', "Show Next Inline Suggestion"),
 			precondition: ContextKeyExpr.and(EditorContextKeys.writable, InlineCompletionContextKeys.inlineSuggestionVisible),
 			kbOpts: {
 				weight: 100,
@@ -47,8 +46,7 @@ export class ShowPreviousInlineSuggestionAction extends EditorAction {
 	constructor() {
 		super({
 			id: ShowPreviousInlineSuggestionAction.ID,
-			label: nls.localize('action.inlineSuggest.showPrevious', "Show Previous Inline Suggestion"),
-			alias: 'Show Previous Inline Suggestion',
+			label: nls.localize2('action.inlineSuggest.showPrevious', "Show Previous Inline Suggestion"),
 			precondition: ContextKeyExpr.and(EditorContextKeys.writable, InlineCompletionContextKeys.inlineSuggestionVisible),
 			kbOpts: {
 				weight: 100,
@@ -67,8 +65,7 @@ export class TriggerInlineSuggestionAction extends EditorAction {
 	constructor() {
 		super({
 			id: 'editor.action.inlineSuggest.trigger',
-			label: nls.localize('action.inlineSuggest.trigger', "Trigger Inline Suggestion"),
-			alias: 'Trigger Inline Suggestion',
+			label: nls.localize2('action.inlineSuggest.trigger', "Trigger Inline Suggestion"),
 			precondition: EditorContextKeys.writable
 		});
 	}
@@ -87,8 +84,7 @@ export class TriggerInlineEditAction extends EditorAction {
 	constructor() {
 		super({
 			id: 'editor.action.inlineSuggest.trigger.inlineEdit',
-			label: nls.localize('action.inlineSuggest.trigger.inlineEdit', "Trigger Inline Edit"),
-			alias: 'Trigger Inline Edit',
+			label: nls.localize2('action.inlineSuggest.trigger.inlineEdit', "Trigger Inline Edit"),
 			precondition: EditorContextKeys.writable
 		});
 	}
@@ -111,8 +107,7 @@ export class AcceptNextWordOfInlineCompletion extends EditorAction {
 	constructor() {
 		super({
 			id: 'editor.action.inlineSuggest.acceptNextWord',
-			label: nls.localize('action.inlineSuggest.acceptNextWord', "Accept Next Word Of Inline Suggestion"),
-			alias: 'Accept Next Word Of Inline Suggestion',
+			label: nls.localize2('action.inlineSuggest.acceptNextWord', "Accept Next Word Of Inline Suggestion"),
 			precondition: ContextKeyExpr.and(EditorContextKeys.writable, InlineCompletionContextKeys.inlineSuggestionVisible),
 			kbOpts: {
 				weight: KeybindingWeight.EditorContrib + 1,
@@ -138,8 +133,7 @@ export class AcceptNextLineOfInlineCompletion extends EditorAction {
 	constructor() {
 		super({
 			id: 'editor.action.inlineSuggest.acceptNextLine',
-			label: nls.localize('action.inlineSuggest.acceptNextLine', "Accept Next Line Of Inline Suggestion"),
-			alias: 'Accept Next Line Of Inline Suggestion',
+			label: nls.localize2('action.inlineSuggest.acceptNextLine', "Accept Next Line Of Inline Suggestion"),
 			precondition: ContextKeyExpr.and(EditorContextKeys.writable, InlineCompletionContextKeys.inlineSuggestionVisible),
 			kbOpts: {
 				weight: KeybindingWeight.EditorContrib + 1,
@@ -163,8 +157,7 @@ export class AcceptInlineCompletion extends EditorAction {
 	constructor() {
 		super({
 			id: inlineSuggestCommitId,
-			label: nls.localize('action.inlineSuggest.accept', "Accept Inline Suggestion"),
-			alias: 'Accept Inline Suggestion',
+			label: nls.localize2('action.inlineSuggest.accept', "Accept Inline Suggestion"),
 			precondition: ContextKeyExpr.or(InlineCompletionContextKeys.inlineSuggestionVisible, InlineCompletionContextKeys.inlineEditVisible),
 			menuOpts: [{
 				menuId: MenuId.InlineSuggestionToolbar,
@@ -228,8 +221,7 @@ export class JumpToNextInlineEdit extends EditorAction {
 	constructor() {
 		super({
 			id: 'editor.action.inlineSuggest.jump',
-			label: nls.localize('action.inlineSuggest.jump', "Jump to next inline edit"),
-			alias: 'Jump to next inline edit',
+			label: nls.localize2('action.inlineSuggest.jump', "Jump to next inline edit"),
 			precondition: InlineCompletionContextKeys.inlineEditVisible,
 			menuOpts: [{
 				menuId: MenuId.InlineEditsActions,
@@ -266,8 +258,7 @@ export class HideInlineCompletion extends EditorAction {
 	constructor() {
 		super({
 			id: HideInlineCompletion.ID,
-			label: nls.localize('action.inlineSuggest.hide', "Hide Inline Suggestion"),
-			alias: 'Hide Inline Suggestion',
+			label: nls.localize2('action.inlineSuggest.hide', "Hide Inline Suggestion"),
 			precondition: ContextKeyExpr.or(InlineCompletionContextKeys.inlineSuggestionVisible, InlineCompletionContextKeys.inlineEditVisible),
 			kbOpts: {
 				weight: 100,

--- a/src/vs/editor/contrib/lineSelection/browser/lineSelection.ts
+++ b/src/vs/editor/contrib/lineSelection/browser/lineSelection.ts
@@ -16,8 +16,7 @@ export class ExpandLineSelectionAction extends EditorAction {
 	constructor() {
 		super({
 			id: 'expandLineSelection',
-			label: nls.localize('expandLineSelection', "Expand Line Selection"),
-			alias: 'Expand Line Selection',
+			label: nls.localize2('expandLineSelection', "Expand Line Selection"),
 			precondition: undefined,
 			kbOpts: {
 				weight: KeybindingWeight.EditorCore,

--- a/src/vs/editor/contrib/linesOperations/browser/linesOperations.ts
+++ b/src/vs/editor/contrib/linesOperations/browser/linesOperations.ts
@@ -79,8 +79,7 @@ class CopyLinesUpAction extends AbstractCopyLinesAction {
 	constructor() {
 		super(false, {
 			id: 'editor.action.copyLinesUpAction',
-			label: nls.localize('lines.copyUp', "Copy Line Up"),
-			alias: 'Copy Line Up',
+			label: nls.localize2('lines.copyUp', "Copy Line Up"),
 			precondition: EditorContextKeys.writable,
 			kbOpts: {
 				kbExpr: EditorContextKeys.editorTextFocus,
@@ -102,8 +101,7 @@ class CopyLinesDownAction extends AbstractCopyLinesAction {
 	constructor() {
 		super(true, {
 			id: 'editor.action.copyLinesDownAction',
-			label: nls.localize('lines.copyDown', "Copy Line Down"),
-			alias: 'Copy Line Down',
+			label: nls.localize2('lines.copyDown', "Copy Line Down"),
 			precondition: EditorContextKeys.writable,
 			kbOpts: {
 				kbExpr: EditorContextKeys.editorTextFocus,
@@ -126,8 +124,7 @@ export class DuplicateSelectionAction extends EditorAction {
 	constructor() {
 		super({
 			id: 'editor.action.duplicateSelection',
-			label: nls.localize('duplicateSelection', "Duplicate Selection"),
-			alias: 'Duplicate Selection',
+			label: nls.localize2('duplicateSelection', "Duplicate Selection"),
 			precondition: EditorContextKeys.writable,
 			menuOpts: {
 				menuId: MenuId.MenubarSelectionMenu,
@@ -194,8 +191,7 @@ class MoveLinesUpAction extends AbstractMoveLinesAction {
 	constructor() {
 		super(false, {
 			id: 'editor.action.moveLinesUpAction',
-			label: nls.localize('lines.moveUp', "Move Line Up"),
-			alias: 'Move Line Up',
+			label: nls.localize2('lines.moveUp', "Move Line Up"),
 			precondition: EditorContextKeys.writable,
 			kbOpts: {
 				kbExpr: EditorContextKeys.editorTextFocus,
@@ -217,8 +213,7 @@ class MoveLinesDownAction extends AbstractMoveLinesAction {
 	constructor() {
 		super(true, {
 			id: 'editor.action.moveLinesDownAction',
-			label: nls.localize('lines.moveDown', "Move Line Down"),
-			alias: 'Move Line Down',
+			label: nls.localize2('lines.moveDown', "Move Line Down"),
 			precondition: EditorContextKeys.writable,
 			kbOpts: {
 				kbExpr: EditorContextKeys.editorTextFocus,
@@ -277,8 +272,7 @@ export class SortLinesAscendingAction extends AbstractSortLinesAction {
 	constructor() {
 		super(false, {
 			id: 'editor.action.sortLinesAscending',
-			label: nls.localize('lines.sortAscending', "Sort Lines Ascending"),
-			alias: 'Sort Lines Ascending',
+			label: nls.localize2('lines.sortAscending', "Sort Lines Ascending"),
 			precondition: EditorContextKeys.writable
 		});
 	}
@@ -288,8 +282,7 @@ export class SortLinesDescendingAction extends AbstractSortLinesAction {
 	constructor() {
 		super(true, {
 			id: 'editor.action.sortLinesDescending',
-			label: nls.localize('lines.sortDescending', "Sort Lines Descending"),
-			alias: 'Sort Lines Descending',
+			label: nls.localize2('lines.sortDescending', "Sort Lines Descending"),
 			precondition: EditorContextKeys.writable
 		});
 	}
@@ -299,8 +292,7 @@ export class DeleteDuplicateLinesAction extends EditorAction {
 	constructor() {
 		super({
 			id: 'editor.action.removeDuplicateLines',
-			label: nls.localize('lines.deleteDuplicates', "Delete Duplicate Lines"),
-			alias: 'Delete Duplicate Lines',
+			label: nls.localize2('lines.deleteDuplicates', "Delete Duplicate Lines"),
 			precondition: EditorContextKeys.writable
 		});
 	}
@@ -378,8 +370,7 @@ export class TrimTrailingWhitespaceAction extends EditorAction {
 	constructor() {
 		super({
 			id: TrimTrailingWhitespaceAction.ID,
-			label: nls.localize('lines.trimTrailingWhitespace', "Trim Trailing Whitespace"),
-			alias: 'Trim Trailing Whitespace',
+			label: nls.localize2('lines.trimTrailingWhitespace', "Trim Trailing Whitespace"),
 			precondition: EditorContextKeys.writable,
 			kbOpts: {
 				kbExpr: EditorContextKeys.editorTextFocus,
@@ -430,8 +421,7 @@ export class DeleteLinesAction extends EditorAction {
 	constructor() {
 		super({
 			id: 'editor.action.deleteLines',
-			label: nls.localize('lines.delete', "Delete Line"),
-			alias: 'Delete Line',
+			label: nls.localize2('lines.delete', "Delete Line"),
 			precondition: EditorContextKeys.writable,
 			kbOpts: {
 				kbExpr: EditorContextKeys.textInputFocus,
@@ -532,8 +522,7 @@ export class IndentLinesAction extends EditorAction {
 	constructor() {
 		super({
 			id: 'editor.action.indentLines',
-			label: nls.localize('lines.indent', "Indent Line"),
-			alias: 'Indent Line',
+			label: nls.localize2('lines.indent', "Indent Line"),
 			precondition: EditorContextKeys.writable,
 			kbOpts: {
 				kbExpr: EditorContextKeys.editorTextFocus,
@@ -558,8 +547,7 @@ class OutdentLinesAction extends EditorAction {
 	constructor() {
 		super({
 			id: 'editor.action.outdentLines',
-			label: nls.localize('lines.outdent', "Outdent Line"),
-			alias: 'Outdent Line',
+			label: nls.localize2('lines.outdent', "Outdent Line"),
 			precondition: EditorContextKeys.writable,
 			kbOpts: {
 				kbExpr: EditorContextKeys.editorTextFocus,
@@ -578,8 +566,7 @@ export class InsertLineBeforeAction extends EditorAction {
 	constructor() {
 		super({
 			id: 'editor.action.insertLineBefore',
-			label: nls.localize('lines.insertBefore', "Insert Line Above"),
-			alias: 'Insert Line Above',
+			label: nls.localize2('lines.insertBefore', "Insert Line Above"),
 			precondition: EditorContextKeys.writable,
 			kbOpts: {
 				kbExpr: EditorContextKeys.editorTextFocus,
@@ -603,8 +590,7 @@ export class InsertLineAfterAction extends EditorAction {
 	constructor() {
 		super({
 			id: 'editor.action.insertLineAfter',
-			label: nls.localize('lines.insertAfter', "Insert Line Below"),
-			alias: 'Insert Line Below',
+			label: nls.localize2('lines.insertAfter', "Insert Line Below"),
 			precondition: EditorContextKeys.writable,
 			kbOpts: {
 				kbExpr: EditorContextKeys.editorTextFocus,
@@ -671,8 +657,7 @@ export class DeleteAllLeftAction extends AbstractDeleteAllToBoundaryAction {
 	constructor() {
 		super({
 			id: 'deleteAllLeft',
-			label: nls.localize('lines.deleteAllLeft', "Delete All Left"),
-			alias: 'Delete All Left',
+			label: nls.localize2('lines.deleteAllLeft', "Delete All Left"),
 			precondition: EditorContextKeys.writable,
 			kbOpts: {
 				kbExpr: EditorContextKeys.textInputFocus,
@@ -749,8 +734,7 @@ export class DeleteAllRightAction extends AbstractDeleteAllToBoundaryAction {
 	constructor() {
 		super({
 			id: 'deleteAllRight',
-			label: nls.localize('lines.deleteAllRight', "Delete All Right"),
-			alias: 'Delete All Right',
+			label: nls.localize2('lines.deleteAllRight', "Delete All Right"),
 			precondition: EditorContextKeys.writable,
 			kbOpts: {
 				kbExpr: EditorContextKeys.textInputFocus,
@@ -816,8 +800,7 @@ export class JoinLinesAction extends EditorAction {
 	constructor() {
 		super({
 			id: 'editor.action.joinLines',
-			label: nls.localize('lines.joinLines', "Join Lines"),
-			alias: 'Join Lines',
+			label: nls.localize2('lines.joinLines', "Join Lines"),
 			precondition: EditorContextKeys.writable,
 			kbOpts: {
 				kbExpr: EditorContextKeys.editorTextFocus,
@@ -976,8 +959,7 @@ export class TransposeAction extends EditorAction {
 	constructor() {
 		super({
 			id: 'editor.action.transpose',
-			label: nls.localize('editor.transpose', "Transpose Characters around the Cursor"),
-			alias: 'Transpose Characters around the Cursor',
+			label: nls.localize2('editor.transpose', "Transpose Characters around the Cursor"),
 			precondition: EditorContextKeys.writable
 		});
 	}
@@ -1075,8 +1057,7 @@ export class UpperCaseAction extends AbstractCaseAction {
 	constructor() {
 		super({
 			id: 'editor.action.transformToUppercase',
-			label: nls.localize('editor.transformToUppercase', "Transform to Uppercase"),
-			alias: 'Transform to Uppercase',
+			label: nls.localize2('editor.transformToUppercase', "Transform to Uppercase"),
 			precondition: EditorContextKeys.writable
 		});
 	}
@@ -1090,8 +1071,7 @@ export class LowerCaseAction extends AbstractCaseAction {
 	constructor() {
 		super({
 			id: 'editor.action.transformToLowercase',
-			label: nls.localize('editor.transformToLowercase', "Transform to Lowercase"),
-			alias: 'Transform to Lowercase',
+			label: nls.localize2('editor.transformToLowercase', "Transform to Lowercase"),
 			precondition: EditorContextKeys.writable
 		});
 	}
@@ -1138,8 +1118,7 @@ export class TitleCaseAction extends AbstractCaseAction {
 	constructor() {
 		super({
 			id: 'editor.action.transformToTitlecase',
-			label: nls.localize('editor.transformToTitlecase', "Transform to Title Case"),
-			alias: 'Transform to Title Case',
+			label: nls.localize2('editor.transformToTitlecase', "Transform to Title Case"),
 			precondition: EditorContextKeys.writable
 		});
 	}
@@ -1164,8 +1143,7 @@ export class SnakeCaseAction extends AbstractCaseAction {
 	constructor() {
 		super({
 			id: 'editor.action.transformToSnakecase',
-			label: nls.localize('editor.transformToSnakecase', "Transform to Snake Case"),
-			alias: 'Transform to Snake Case',
+			label: nls.localize2('editor.transformToSnakecase', "Transform to Snake Case"),
 			precondition: EditorContextKeys.writable
 		});
 	}
@@ -1191,8 +1169,7 @@ export class CamelCaseAction extends AbstractCaseAction {
 	constructor() {
 		super({
 			id: 'editor.action.transformToCamelcase',
-			label: nls.localize('editor.transformToCamelcase', "Transform to Camel Case"),
-			alias: 'Transform to Camel Case',
+			label: nls.localize2('editor.transformToCamelcase', "Transform to Camel Case"),
 			precondition: EditorContextKeys.writable
 		});
 	}
@@ -1217,8 +1194,7 @@ export class PascalCaseAction extends AbstractCaseAction {
 	constructor() {
 		super({
 			id: 'editor.action.transformToPascalcase',
-			label: nls.localize('editor.transformToPascalcase', "Transform to Pascal Case"),
-			alias: 'Transform to Pascal Case',
+			label: nls.localize2('editor.transformToPascalcase', "Transform to Pascal Case"),
 			precondition: EditorContextKeys.writable
 		});
 	}
@@ -1258,8 +1234,7 @@ export class KebabCaseAction extends AbstractCaseAction {
 	constructor() {
 		super({
 			id: 'editor.action.transformToKebabcase',
-			label: nls.localize('editor.transformToKebabcase', 'Transform to Kebab Case'),
-			alias: 'Transform to Kebab Case',
+			label: nls.localize2('editor.transformToKebabcase', 'Transform to Kebab Case'),
 			precondition: EditorContextKeys.writable
 		});
 	}

--- a/src/vs/editor/contrib/linkedEditing/browser/linkedEditing.ts
+++ b/src/vs/editor/contrib/linkedEditing/browser/linkedEditing.ts
@@ -392,8 +392,7 @@ export class LinkedEditingAction extends EditorAction {
 	constructor() {
 		super({
 			id: 'editor.action.linkedEditing',
-			label: nls.localize('linkedEditing.label', "Start Linked Editing"),
-			alias: 'Start Linked Editing',
+			label: nls.localize2('linkedEditing.label', "Start Linked Editing"),
 			precondition: ContextKeyExpr.and(EditorContextKeys.writable, EditorContextKeys.hasRenameProvider),
 			kbOpts: {
 				kbExpr: EditorContextKeys.editorTextFocus,

--- a/src/vs/editor/contrib/links/browser/links.ts
+++ b/src/vs/editor/contrib/links/browser/links.ts
@@ -400,8 +400,7 @@ class OpenLinkAction extends EditorAction {
 	constructor() {
 		super({
 			id: 'editor.action.openLink',
-			label: nls.localize('label', "Open Link"),
-			alias: 'Open Link',
+			label: nls.localize2('label', "Open Link"),
 			precondition: undefined
 		});
 	}

--- a/src/vs/editor/contrib/multicursor/browser/multicursor.ts
+++ b/src/vs/editor/contrib/multicursor/browser/multicursor.ts
@@ -43,8 +43,7 @@ export class InsertCursorAbove extends EditorAction {
 	constructor() {
 		super({
 			id: 'editor.action.insertCursorAbove',
-			label: nls.localize('mutlicursor.insertAbove', "Add Cursor Above"),
-			alias: 'Add Cursor Above',
+			label: nls.localize2('mutlicursor.insertAbove', "Add Cursor Above"),
 			precondition: undefined,
 			kbOpts: {
 				kbExpr: EditorContextKeys.editorTextFocus,
@@ -96,8 +95,7 @@ export class InsertCursorBelow extends EditorAction {
 	constructor() {
 		super({
 			id: 'editor.action.insertCursorBelow',
-			label: nls.localize('mutlicursor.insertBelow', "Add Cursor Below"),
-			alias: 'Add Cursor Below',
+			label: nls.localize2('mutlicursor.insertBelow', "Add Cursor Below"),
 			precondition: undefined,
 			kbOpts: {
 				kbExpr: EditorContextKeys.editorTextFocus,
@@ -149,8 +147,7 @@ class InsertCursorAtEndOfEachLineSelected extends EditorAction {
 	constructor() {
 		super({
 			id: 'editor.action.insertCursorAtEndOfEachLineSelected',
-			label: nls.localize('mutlicursor.insertAtEndOfEachLineSelected', "Add Cursors to Line Ends"),
-			alias: 'Add Cursors to Line Ends',
+			label: nls.localize2('mutlicursor.insertAtEndOfEachLineSelected', "Add Cursors to Line Ends"),
 			precondition: undefined,
 			kbOpts: {
 				kbExpr: EditorContextKeys.editorTextFocus,
@@ -204,8 +201,7 @@ class InsertCursorAtEndOfLineSelected extends EditorAction {
 	constructor() {
 		super({
 			id: 'editor.action.addCursorsToBottom',
-			label: nls.localize('mutlicursor.addCursorsToBottom', "Add Cursors To Bottom"),
-			alias: 'Add Cursors To Bottom',
+			label: nls.localize2('mutlicursor.addCursorsToBottom', "Add Cursors To Bottom"),
 			precondition: undefined
 		});
 	}
@@ -237,8 +233,7 @@ class InsertCursorAtTopOfLineSelected extends EditorAction {
 	constructor() {
 		super({
 			id: 'editor.action.addCursorsToTop',
-			label: nls.localize('mutlicursor.addCursorsToTop', "Add Cursors To Top"),
-			alias: 'Add Cursors To Top',
+			label: nls.localize2('mutlicursor.addCursorsToTop', "Add Cursors To Top"),
 			precondition: undefined
 		});
 	}
@@ -691,8 +686,7 @@ export class AddSelectionToNextFindMatchAction extends MultiCursorSelectionContr
 	constructor() {
 		super({
 			id: 'editor.action.addSelectionToNextFindMatch',
-			label: nls.localize('addSelectionToNextFindMatch', "Add Selection To Next Find Match"),
-			alias: 'Add Selection To Next Find Match',
+			label: nls.localize2('addSelectionToNextFindMatch', "Add Selection To Next Find Match"),
 			precondition: undefined,
 			kbOpts: {
 				kbExpr: EditorContextKeys.focus,
@@ -716,8 +710,7 @@ export class AddSelectionToPreviousFindMatchAction extends MultiCursorSelectionC
 	constructor() {
 		super({
 			id: 'editor.action.addSelectionToPreviousFindMatch',
-			label: nls.localize('addSelectionToPreviousFindMatch', "Add Selection To Previous Find Match"),
-			alias: 'Add Selection To Previous Find Match',
+			label: nls.localize2('addSelectionToPreviousFindMatch', "Add Selection To Previous Find Match"),
 			precondition: undefined,
 			menuOpts: {
 				menuId: MenuId.MenubarSelectionMenu,
@@ -736,8 +729,7 @@ export class MoveSelectionToNextFindMatchAction extends MultiCursorSelectionCont
 	constructor() {
 		super({
 			id: 'editor.action.moveSelectionToNextFindMatch',
-			label: nls.localize('moveSelectionToNextFindMatch', "Move Last Selection To Next Find Match"),
-			alias: 'Move Last Selection To Next Find Match',
+			label: nls.localize2('moveSelectionToNextFindMatch', "Move Last Selection To Next Find Match"),
 			precondition: undefined,
 			kbOpts: {
 				kbExpr: EditorContextKeys.focus,
@@ -755,8 +747,7 @@ export class MoveSelectionToPreviousFindMatchAction extends MultiCursorSelection
 	constructor() {
 		super({
 			id: 'editor.action.moveSelectionToPreviousFindMatch',
-			label: nls.localize('moveSelectionToPreviousFindMatch', "Move Last Selection To Previous Find Match"),
-			alias: 'Move Last Selection To Previous Find Match',
+			label: nls.localize2('moveSelectionToPreviousFindMatch', "Move Last Selection To Previous Find Match"),
 			precondition: undefined
 		});
 	}
@@ -769,8 +760,7 @@ export class SelectHighlightsAction extends MultiCursorSelectionControllerAction
 	constructor() {
 		super({
 			id: 'editor.action.selectHighlights',
-			label: nls.localize('selectAllOccurrencesOfFindMatch', "Select All Occurrences of Find Match"),
-			alias: 'Select All Occurrences of Find Match',
+			label: nls.localize2('selectAllOccurrencesOfFindMatch', "Select All Occurrences of Find Match"),
 			precondition: undefined,
 			kbOpts: {
 				kbExpr: EditorContextKeys.focus,
@@ -794,8 +784,7 @@ export class CompatChangeAll extends MultiCursorSelectionControllerAction {
 	constructor() {
 		super({
 			id: 'editor.action.changeAll',
-			label: nls.localize('changeAll.label', "Change All Occurrences"),
-			alias: 'Change All Occurrences',
+			label: nls.localize2('changeAll.label', "Change All Occurrences"),
 			precondition: ContextKeyExpr.and(EditorContextKeys.writable, EditorContextKeys.editorTextFocus),
 			kbOpts: {
 				kbExpr: EditorContextKeys.editorTextFocus,
@@ -1079,12 +1068,11 @@ export class FocusNextCursor extends EditorAction {
 	constructor() {
 		super({
 			id: 'editor.action.focusNextCursor',
-			label: nls.localize('mutlicursor.focusNextCursor', "Focus Next Cursor"),
+			label: nls.localize2('mutlicursor.focusNextCursor', "Focus Next Cursor"),
 			metadata: {
 				description: nls.localize('mutlicursor.focusNextCursor.description', "Focuses the next cursor"),
 				args: [],
 			},
-			alias: 'Focus Next Cursor',
 			precondition: undefined
 		});
 	}
@@ -1118,12 +1106,11 @@ export class FocusPreviousCursor extends EditorAction {
 	constructor() {
 		super({
 			id: 'editor.action.focusPreviousCursor',
-			label: nls.localize('mutlicursor.focusPreviousCursor', "Focus Previous Cursor"),
+			label: nls.localize2('mutlicursor.focusPreviousCursor', "Focus Previous Cursor"),
 			metadata: {
 				description: nls.localize('mutlicursor.focusPreviousCursor.description', "Focuses the previous cursor"),
 				args: [],
 			},
-			alias: 'Focus Previous Cursor',
 			precondition: undefined
 		});
 	}

--- a/src/vs/editor/contrib/parameterHints/browser/parameterHints.ts
+++ b/src/vs/editor/contrib/parameterHints/browser/parameterHints.ts
@@ -77,8 +77,7 @@ export class TriggerParameterHintsAction extends EditorAction {
 	constructor() {
 		super({
 			id: 'editor.action.triggerParameterHints',
-			label: nls.localize('parameterHints.trigger.label', "Trigger Parameter Hints"),
-			alias: 'Trigger Parameter Hints',
+			label: nls.localize2('parameterHints.trigger.label', "Trigger Parameter Hints"),
 			precondition: EditorContextKeys.hasSignatureHelpProvider,
 			kbOpts: {
 				kbExpr: EditorContextKeys.editorTextFocus,

--- a/src/vs/editor/contrib/rename/browser/rename.ts
+++ b/src/vs/editor/contrib/rename/browser/rename.ts
@@ -412,8 +412,7 @@ export class RenameAction extends EditorAction {
 	constructor() {
 		super({
 			id: 'editor.action.rename',
-			label: nls.localize('rename.label', "Rename Symbol"),
-			alias: 'Rename Symbol',
+			label: nls.localize2('rename.label', "Rename Symbol"),
 			precondition: ContextKeyExpr.and(EditorContextKeys.writable, EditorContextKeys.hasRenameProvider),
 			kbOpts: {
 				kbExpr: EditorContextKeys.editorTextFocus,

--- a/src/vs/editor/contrib/smartSelect/browser/smartSelect.ts
+++ b/src/vs/editor/contrib/smartSelect/browser/smartSelect.ts
@@ -151,8 +151,7 @@ class GrowSelectionAction extends AbstractSmartSelect {
 	constructor() {
 		super(true, {
 			id: 'editor.action.smartSelect.expand',
-			label: nls.localize('smartSelect.expand', "Expand Selection"),
-			alias: 'Expand Selection',
+			label: nls.localize2('smartSelect.expand', "Expand Selection"),
 			precondition: undefined,
 			kbOpts: {
 				kbExpr: EditorContextKeys.editorTextFocus,
@@ -180,8 +179,7 @@ class ShrinkSelectionAction extends AbstractSmartSelect {
 	constructor() {
 		super(false, {
 			id: 'editor.action.smartSelect.shrink',
-			label: nls.localize('smartSelect.shrink', "Shrink Selection"),
-			alias: 'Shrink Selection',
+			label: nls.localize2('smartSelect.shrink', "Shrink Selection"),
 			precondition: undefined,
 			kbOpts: {
 				kbExpr: EditorContextKeys.editorTextFocus,

--- a/src/vs/editor/contrib/suggest/browser/suggestController.ts
+++ b/src/vs/editor/contrib/suggest/browser/suggestController.ts
@@ -804,8 +804,7 @@ export class TriggerSuggestAction extends EditorAction {
 	constructor() {
 		super({
 			id: TriggerSuggestAction.id,
-			label: nls.localize('suggest.trigger.label', "Trigger Suggest"),
-			alias: 'Trigger Suggest',
+			label: nls.localize2('suggest.trigger.label', "Trigger Suggest"),
 			precondition: ContextKeyExpr.and(EditorContextKeys.writable, EditorContextKeys.hasCompletionItemProvider, SuggestContext.Visible.toNegated()),
 			kbOpts: {
 				kbExpr: EditorContextKeys.textInputFocus,
@@ -1119,8 +1118,7 @@ registerEditorAction(class extends EditorAction {
 	constructor() {
 		super({
 			id: 'editor.action.resetSuggestSize',
-			label: nls.localize('suggest.reset.label', "Reset Suggest Widget Size"),
-			alias: 'Reset Suggest Widget Size',
+			label: nls.localize2('suggest.reset.label', "Reset Suggest Widget Size"),
 			precondition: undefined
 		});
 	}

--- a/src/vs/editor/contrib/tokenization/browser/tokenization.ts
+++ b/src/vs/editor/contrib/tokenization/browser/tokenization.ts
@@ -12,8 +12,7 @@ class ForceRetokenizeAction extends EditorAction {
 	constructor() {
 		super({
 			id: 'editor.action.forceRetokenize',
-			label: nls.localize('forceRetokenize', "Developer: Force Retokenize"),
-			alias: 'Developer: Force Retokenize',
+			label: nls.localize2('forceRetokenize', "Developer: Force Retokenize"),
 			precondition: undefined
 		});
 	}

--- a/src/vs/editor/contrib/unicodeHighlighter/browser/unicodeHighlighter.ts
+++ b/src/vs/editor/contrib/unicodeHighlighter/browser/unicodeHighlighter.ts
@@ -578,8 +578,7 @@ export class DisableHighlightingInCommentsAction extends EditorAction implements
 	constructor() {
 		super({
 			id: DisableHighlightingOfAmbiguousCharactersAction.ID,
-			label: nls.localize('action.unicodeHighlight.disableHighlightingInComments', 'Disable highlighting of characters in comments'),
-			alias: 'Disable highlighting of characters in comments',
+			label: nls.localize2('action.unicodeHighlight.disableHighlightingInComments', "Disable highlighting of characters in comments"),
 			precondition: undefined
 		});
 	}
@@ -602,8 +601,7 @@ export class DisableHighlightingInStringsAction extends EditorAction implements 
 	constructor() {
 		super({
 			id: DisableHighlightingOfAmbiguousCharactersAction.ID,
-			label: nls.localize('action.unicodeHighlight.disableHighlightingInStrings', 'Disable highlighting of characters in strings'),
-			alias: 'Disable highlighting of characters in strings',
+			label: nls.localize2('action.unicodeHighlight.disableHighlightingInStrings', "Disable highlighting of characters in strings"),
 			precondition: undefined
 		});
 	}
@@ -626,8 +624,7 @@ export class DisableHighlightingOfAmbiguousCharactersAction extends EditorAction
 	constructor() {
 		super({
 			id: DisableHighlightingOfAmbiguousCharactersAction.ID,
-			label: nls.localize('action.unicodeHighlight.disableHighlightingOfAmbiguousCharacters', 'Disable highlighting of ambiguous characters'),
-			alias: 'Disable highlighting of ambiguous characters',
+			label: nls.localize2('action.unicodeHighlight.disableHighlightingOfAmbiguousCharacters', "Disable highlighting of ambiguous characters"),
 			precondition: undefined
 		});
 	}
@@ -650,8 +647,7 @@ export class DisableHighlightingOfInvisibleCharactersAction extends EditorAction
 	constructor() {
 		super({
 			id: DisableHighlightingOfInvisibleCharactersAction.ID,
-			label: nls.localize('action.unicodeHighlight.disableHighlightingOfInvisibleCharacters', 'Disable highlighting of invisible characters'),
-			alias: 'Disable highlighting of invisible characters',
+			label: nls.localize2('action.unicodeHighlight.disableHighlightingOfInvisibleCharacters', "Disable highlighting of invisible characters"),
 			precondition: undefined
 		});
 	}
@@ -674,8 +670,7 @@ export class DisableHighlightingOfNonBasicAsciiCharactersAction extends EditorAc
 	constructor() {
 		super({
 			id: DisableHighlightingOfNonBasicAsciiCharactersAction.ID,
-			label: nls.localize('action.unicodeHighlight.disableHighlightingOfNonBasicAsciiCharacters', 'Disable highlighting of non basic ASCII characters'),
-			alias: 'Disable highlighting of non basic ASCII characters',
+			label: nls.localize2('action.unicodeHighlight.disableHighlightingOfNonBasicAsciiCharacters', "Disable highlighting of non basic ASCII characters"),
 			precondition: undefined
 		});
 	}
@@ -704,8 +699,7 @@ export class ShowExcludeOptions extends EditorAction {
 	constructor() {
 		super({
 			id: ShowExcludeOptions.ID,
-			label: nls.localize('action.unicodeHighlight.showExcludeOptions', "Show Exclude Options"),
-			alias: 'Show Exclude Options',
+			label: nls.localize2('action.unicodeHighlight.showExcludeOptions', "Show Exclude Options"),
 			precondition: undefined
 		});
 	}

--- a/src/vs/editor/contrib/wordHighlighter/browser/wordHighlighter.ts
+++ b/src/vs/editor/contrib/wordHighlighter/browser/wordHighlighter.ts
@@ -931,8 +931,7 @@ class NextWordHighlightAction extends WordHighlightNavigationAction {
 	constructor() {
 		super(true, {
 			id: 'editor.action.wordHighlight.next',
-			label: nls.localize('wordHighlight.next.label', "Go to Next Symbol Highlight"),
-			alias: 'Go to Next Symbol Highlight',
+			label: nls.localize2('wordHighlight.next.label', "Go to Next Symbol Highlight"),
 			precondition: ctxHasWordHighlights,
 			kbOpts: {
 				kbExpr: EditorContextKeys.editorTextFocus,
@@ -947,8 +946,7 @@ class PrevWordHighlightAction extends WordHighlightNavigationAction {
 	constructor() {
 		super(false, {
 			id: 'editor.action.wordHighlight.prev',
-			label: nls.localize('wordHighlight.previous.label', "Go to Previous Symbol Highlight"),
-			alias: 'Go to Previous Symbol Highlight',
+			label: nls.localize2('wordHighlight.previous.label', "Go to Previous Symbol Highlight"),
 			precondition: ctxHasWordHighlights,
 			kbOpts: {
 				kbExpr: EditorContextKeys.editorTextFocus,
@@ -963,8 +961,7 @@ class TriggerWordHighlightAction extends EditorAction {
 	constructor() {
 		super({
 			id: 'editor.action.wordHighlight.trigger',
-			label: nls.localize('wordHighlight.trigger.label', "Trigger Symbol Highlight"),
-			alias: 'Trigger Symbol Highlight',
+			label: nls.localize2('wordHighlight.trigger.label', "Trigger Symbol Highlight"),
 			precondition: undefined,
 			kbOpts: {
 				kbExpr: EditorContextKeys.editorTextFocus,

--- a/src/vs/editor/contrib/wordOperations/browser/wordOperations.ts
+++ b/src/vs/editor/contrib/wordOperations/browser/wordOperations.ts
@@ -473,8 +473,7 @@ export class DeleteInsideWord extends EditorAction {
 		super({
 			id: 'deleteInsideWord',
 			precondition: EditorContextKeys.writable,
-			label: nls.localize('deleteInsideWord', "Delete Word"),
-			alias: 'Delete Word'
+			label: nls.localize2('deleteInsideWord', "Delete Word"),
 		});
 	}
 

--- a/src/vs/workbench/contrib/codeEditor/browser/inspectEditorTokens/inspectEditorTokens.ts
+++ b/src/vs/workbench/contrib/codeEditor/browser/inspectEditorTokens/inspectEditorTokens.ts
@@ -120,8 +120,7 @@ class InspectEditorTokens extends EditorAction {
 	constructor() {
 		super({
 			id: 'editor.action.inspectTMScopes',
-			label: nls.localize('inspectEditorTokens', "Developer: Inspect Editor Tokens and Scopes"),
-			alias: 'Developer: Inspect Editor Tokens and Scopes',
+			label: nls.localize2('inspectEditorTokens', "Developer: Inspect Editor Tokens and Scopes"),
 			precondition: undefined
 		});
 	}

--- a/src/vs/workbench/contrib/codeEditor/browser/toggleWordWrap.ts
+++ b/src/vs/workbench/contrib/codeEditor/browser/toggleWordWrap.ts
@@ -56,8 +56,7 @@ class ToggleWordWrapAction extends EditorAction {
 	constructor() {
 		super({
 			id: TOGGLE_WORD_WRAP_ID,
-			label: nls.localize('toggle.wordwrap', "View: Toggle Word Wrap"),
-			alias: 'View: Toggle Word Wrap',
+			label: nls.localize2('toggle.wordwrap', "View: Toggle Word Wrap"),
 			precondition: undefined,
 			kbOpts: {
 				kbExpr: null,

--- a/src/vs/workbench/contrib/codeEditor/electron-sandbox/selectionClipboard.ts
+++ b/src/vs/workbench/contrib/codeEditor/electron-sandbox/selectionClipboard.ts
@@ -120,8 +120,7 @@ class PasteSelectionClipboardAction extends EditorAction {
 	constructor() {
 		super({
 			id: 'editor.action.selectionClipboardPaste',
-			label: nls.localize('actions.pasteSelectionClipboard', "Paste Selection Clipboard"),
-			alias: 'Paste Selection Clipboard',
+			label: nls.localize2('actions.pasteSelectionClipboard', "Paste Selection Clipboard"),
 			precondition: EditorContextKeys.writable
 		});
 	}

--- a/src/vs/workbench/contrib/debug/browser/debugEditorActions.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugEditorActions.ts
@@ -100,8 +100,7 @@ class ConditionalBreakpointAction extends EditorAction {
 	constructor() {
 		super({
 			id: 'editor.debug.action.conditionalBreakpoint',
-			label: nls.localize('conditionalBreakpointEditorAction', "Debug: Add Conditional Breakpoint..."),
-			alias: 'Debug: Add Conditional Breakpoint...',
+			label: nls.localize2('conditionalBreakpointEditorAction', "Debug: Add Conditional Breakpoint..."),
 			precondition: CONTEXT_DEBUGGERS_AVAILABLE,
 			menuOpts: {
 				menuId: MenuId.MenubarNewBreakpointMenu,
@@ -128,9 +127,8 @@ class LogPointAction extends EditorAction {
 	constructor() {
 		super({
 			id: 'editor.debug.action.addLogPoint',
-			label: nls.localize('logPointEditorAction', "Debug: Add Logpoint..."),
+			label: nls.localize2('logPointEditorAction', "Debug: Add Logpoint..."),
 			precondition: CONTEXT_DEBUGGERS_AVAILABLE,
-			alias: 'Debug: Add Logpoint...',
 			menuOpts: [
 				{
 					menuId: MenuId.MenubarNewBreakpointMenu,
@@ -443,8 +441,7 @@ class ShowDebugHoverAction extends EditorAction {
 	constructor() {
 		super({
 			id: 'editor.debug.action.showDebugHover',
-			label: nls.localize('showDebugHover', "Debug: Show Hover"),
-			alias: 'Debug: Show Hover',
+			label: nls.localize2('showDebugHover', "Debug: Show Hover"),
 			precondition: CONTEXT_IN_DEBUG_MODE,
 			kbOpts: {
 				kbExpr: EditorContextKeys.editorTextFocus,
@@ -596,8 +593,7 @@ class GoToNextBreakpointAction extends GoToBreakpointAction {
 	constructor() {
 		super(true, {
 			id: 'editor.debug.action.goToNextBreakpoint',
-			label: nls.localize('goToNextBreakpoint', "Debug: Go to Next Breakpoint"),
-			alias: 'Debug: Go to Next Breakpoint',
+			label: nls.localize2('goToNextBreakpoint', "Debug: Go to Next Breakpoint"),
 			precondition: CONTEXT_DEBUGGERS_AVAILABLE
 		});
 	}
@@ -607,8 +603,7 @@ class GoToPreviousBreakpointAction extends GoToBreakpointAction {
 	constructor() {
 		super(false, {
 			id: 'editor.debug.action.goToPreviousBreakpoint',
-			label: nls.localize('goToPreviousBreakpoint', "Debug: Go to Previous Breakpoint"),
-			alias: 'Debug: Go to Previous Breakpoint',
+			label: nls.localize2('goToPreviousBreakpoint', "Debug: Go to Previous Breakpoint"),
 			precondition: CONTEXT_DEBUGGERS_AVAILABLE
 		});
 	}
@@ -619,8 +614,7 @@ class CloseExceptionWidgetAction extends EditorAction {
 	constructor() {
 		super({
 			id: 'editor.debug.action.closeExceptionWidget',
-			label: nls.localize('closeExceptionWidget', "Close Exception Widget"),
-			alias: 'Close Exception Widget',
+			label: nls.localize2('closeExceptionWidget', "Close Exception Widget"),
 			precondition: CONTEXT_EXCEPTION_WIDGET_VISIBLE,
 			kbOpts: {
 				primary: KeyCode.Escape,

--- a/src/vs/workbench/contrib/debug/browser/repl.ts
+++ b/src/vs/workbench/contrib/debug/browser/repl.ts
@@ -906,8 +906,7 @@ class AcceptReplInputAction extends EditorAction {
 	constructor() {
 		super({
 			id: 'repl.action.acceptInput',
-			label: localize({ key: 'actions.repl.acceptInput', comment: ['Apply input from the debug console input box'] }, "Debug Console: Accept Input"),
-			alias: 'Debug Console: Accept Input',
+			label: localize2({ key: 'actions.repl.acceptInput', comment: ['Apply input from the debug console input box'] }, "Debug Console: Accept Input"),
 			precondition: CONTEXT_IN_DEBUG_REPL,
 			kbOpts: {
 				kbExpr: EditorContextKeys.textInputFocus,

--- a/src/vs/workbench/contrib/emmet/browser/actions/expandAbbreviation.ts
+++ b/src/vs/workbench/contrib/emmet/browser/actions/expandAbbreviation.ts
@@ -16,8 +16,7 @@ class ExpandAbbreviationAction extends EmmetEditorAction {
 	constructor() {
 		super({
 			id: 'editor.emmet.action.expandAbbreviation',
-			label: nls.localize('expandAbbreviationAction', "Emmet: Expand Abbreviation"),
-			alias: 'Emmet: Expand Abbreviation',
+			label: nls.localize2('expandAbbreviationAction', "Emmet: Expand Abbreviation"),
 			precondition: EditorContextKeys.writable,
 			actionName: 'expand_abbreviation',
 			kbOpts: {

--- a/src/vs/workbench/contrib/format/browser/formatActionsNone.ts
+++ b/src/vs/workbench/contrib/format/browser/formatActionsNone.ts
@@ -21,8 +21,7 @@ registerEditorAction(class FormatDocumentMultipleAction extends EditorAction {
 	constructor() {
 		super({
 			id: 'editor.action.formatDocument.none',
-			label: nls.localize('formatDocument.label.multiple', "Format Document"),
-			alias: 'Format Document',
+			label: nls.localize2('formatDocument.label.multiple', "Format Document"),
 			precondition: ContextKeyExpr.and(EditorContextKeys.writable, EditorContextKeys.hasDocumentFormattingProvider.toNegated()),
 			kbOpts: {
 				kbExpr: EditorContextKeys.editorTextFocus,

--- a/src/vs/workbench/contrib/format/browser/formatModified.ts
+++ b/src/vs/workbench/contrib/format/browser/formatModified.ts
@@ -25,8 +25,7 @@ registerEditorAction(class FormatModifiedAction extends EditorAction {
 	constructor() {
 		super({
 			id: 'editor.action.formatChanges',
-			label: nls.localize('formatChanges', "Format Modified Lines"),
-			alias: 'Format Modified Lines',
+			label: nls.localize2('formatChanges', "Format Modified Lines"),
 			precondition: ContextKeyExpr.and(EditorContextKeys.writable, EditorContextKeys.hasDocumentSelectionFormattingProvider),
 		});
 	}

--- a/src/vs/workbench/contrib/notebook/browser/contrib/format/formatting.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/format/formatting.ts
@@ -118,8 +118,7 @@ registerEditorAction(class FormatCellAction extends EditorAction {
 	constructor() {
 		super({
 			id: 'notebook.formatCell',
-			label: localize('formatCell.label', "Format Cell"),
-			alias: 'Format Cell',
+			label: localize2('formatCell.label', "Format Cell"),
 			precondition: ContextKeyExpr.and(NOTEBOOK_IS_ACTIVE_EDITOR, NOTEBOOK_EDITOR_EDITABLE, EditorContextKeys.inCompositeEditor, EditorContextKeys.writable, EditorContextKeys.hasDocumentFormattingProvider),
 			kbOpts: {
 				kbExpr: ContextKeyExpr.and(EditorContextKeys.editorTextFocus),

--- a/src/vs/workbench/contrib/scm/browser/dirtydiffDecorator.ts
+++ b/src/vs/workbench/contrib/scm/browser/dirtydiffDecorator.ts
@@ -482,8 +482,7 @@ export class ShowPreviousChangeAction extends EditorAction {
 	constructor(private readonly outerEditor?: ICodeEditor) {
 		super({
 			id: 'editor.action.dirtydiff.previous',
-			label: nls.localize('show previous change', "Show Previous Change"),
-			alias: 'Show Previous Change',
+			label: nls.localize2('show previous change', "Show Previous Change"),
 			precondition: TextCompareEditorActiveContext.toNegated(),
 			kbOpts: { kbExpr: EditorContextKeys.editorTextFocus, primary: KeyMod.Shift | KeyMod.Alt | KeyCode.F3, weight: KeybindingWeight.EditorContrib }
 		});
@@ -516,8 +515,7 @@ export class ShowNextChangeAction extends EditorAction {
 	constructor(private readonly outerEditor?: ICodeEditor) {
 		super({
 			id: 'editor.action.dirtydiff.next',
-			label: nls.localize('show next change', "Show Next Change"),
-			alias: 'Show Next Change',
+			label: nls.localize2('show next change', "Show Next Change"),
 			precondition: TextCompareEditorActiveContext.toNegated(),
 			kbOpts: { kbExpr: EditorContextKeys.editorTextFocus, primary: KeyMod.Alt | KeyCode.F3, weight: KeybindingWeight.EditorContrib }
 		});
@@ -569,8 +567,7 @@ export class GotoPreviousChangeAction extends EditorAction {
 	constructor() {
 		super({
 			id: 'workbench.action.editor.previousChange',
-			label: nls.localize('move to previous change', "Go to Previous Change"),
-			alias: 'Go to Previous Change',
+			label: nls.localize2('move to previous change', "Go to Previous Change"),
 			precondition: TextCompareEditorActiveContext.toNegated(),
 			kbOpts: { kbExpr: EditorContextKeys.editorTextFocus, primary: KeyMod.Shift | KeyMod.Alt | KeyCode.F5, weight: KeybindingWeight.EditorContrib }
 		});
@@ -611,8 +608,7 @@ export class GotoNextChangeAction extends EditorAction {
 	constructor() {
 		super({
 			id: 'workbench.action.editor.nextChange',
-			label: nls.localize('move to next change', "Go to Next Change"),
-			alias: 'Go to Next Change',
+			label: nls.localize2('move to next change', "Go to Next Change"),
 			precondition: TextCompareEditorActiveContext.toNegated(),
 			kbOpts: { kbExpr: EditorContextKeys.editorTextFocus, primary: KeyMod.Alt | KeyCode.F5, weight: KeybindingWeight.EditorContrib }
 		});


### PR DESCRIPTION
Follow up on #233239

In most cases, the `.alias` duplicates the original English string. We can use `localize2` to avoid having to duplicate the string in code