### PR TITLE
Make sure auth provider listener is setup before extensions and move register warning into ext host code

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadAuthentication.ts
+++ b/src/vs/workbench/api/browser/mainThreadAuthentication.ts
@@ -20,6 +20,7 @@ import { getAuthenticationProviderActivationEvent } from '../../services/authent
 import { URI, UriComponents } from '../../../base/common/uri.js';
 import { IOpenerService } from '../../../platform/opener/common/opener.js';
 import { CancellationError } from '../../../base/common/errors.js';
+import { ILogService } from '../../../platform/log/common/log.js';
 
 interface AuthenticationForceNewSessionOptions {
 	detail?: string;
@@ -81,7 +82,8 @@ export class MainThreadAuthentication extends Disposable implements MainThreadAu
 		@INotificationService private readonly notificationService: INotificationService,
 		@IExtensionService private readonly extensionService: IExtensionService,
 		@ITelemetryService private readonly telemetryService: ITelemetryService,
-		@IOpenerService private readonly openerService: IOpenerService
+		@IOpenerService private readonly openerService: IOpenerService,
+		@ILogService private readonly logService: ILogService
 	) {
 		super();
 		this._proxy = extHostContext.getProxy(ExtHostContext.ExtHostAuthentication);
@@ -96,6 +98,16 @@ export class MainThreadAuthentication extends Disposable implements MainThreadAu
 	}
 
 	async $registerAuthenticationProvider(id: string, label: string, supportsMultipleAccounts: boolean): Promise<void> {
+		if (!this.authenticationService.declaredProviders.find(p => p.id === id)) {
+			// If telemetry shows that this is not happening much, we can instead throw an error here.
+			this.logService.warn(`Authentication provider ${id} was not declared in the Extension Manifest.`);
+			type AuthProviderNotDeclaredClassification = {
+				owner: 'TylerLeonhardt';
+				comment: 'An authentication provider was not declared in the Extension Manifest.';
+				id: { classification: 'SystemMetaData'; purpose: 'FeatureInsight'; comment: 'The provider id.' };
+			};
+			this.telemetryService.publicLog2<{ id: string }, AuthProviderNotDeclaredClassification>('authentication.providerNotDeclared', { id });
+		}
 		const emitter = new Emitter<AuthenticationSessionsChangeEvent>();
 		this._registrations.set(id, emitter);
 		const provider = new MainThreadAuthenticationProvider(this._proxy, id, label, supportsMultipleAccounts, this.notificationService, emitter);

--- a/src/vs/workbench/contrib/authentication/browser/authentication.contribution.ts
+++ b/src/vs/workbench/contrib/authentication/browser/authentication.contribution.ts
@@ -3,9 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { IJSONSchema } from '../../../../base/common/jsonSchema.js';
 import { Disposable, IDisposable } from '../../../../base/common/lifecycle.js';
-import { isFalsyOrWhitespace } from '../../../../base/common/strings.js';
 import { localize } from '../../../../nls.js';
 import { MenuId, MenuRegistry, registerAction2 } from '../../../../platform/actions/common/actions.js';
 import { CommandsRegistry } from '../../../../platform/commands/common/commands.js';
@@ -15,49 +13,16 @@ import { SyncDescriptor } from '../../../../platform/instantiation/common/descri
 import { Registry } from '../../../../platform/registry/common/platform.js';
 import { IWorkbenchContribution, WorkbenchPhase, registerWorkbenchContribution2 } from '../../../common/contributions.js';
 import { SignOutOfAccountAction } from './actions/signOutOfAccountAction.js';
-import { AuthenticationProviderInformation, IAuthenticationService } from '../../../services/authentication/common/authentication.js';
+import { IAuthenticationService } from '../../../services/authentication/common/authentication.js';
 import { IBrowserWorkbenchEnvironmentService } from '../../../services/environment/browser/environmentService.js';
 import { Extensions, IExtensionFeatureTableRenderer, IExtensionFeaturesRegistry, IRenderedData, IRowData, ITableData } from '../../../services/extensionManagement/common/extensionFeatures.js';
-import { ExtensionsRegistry } from '../../../services/extensions/common/extensionsRegistry.js';
 import { ManageTrustedExtensionsForAccountAction } from './actions/manageTrustedExtensionsForAccountAction.js';
 import { ManageAccountPreferencesForExtensionAction } from './actions/manageAccountPreferencesForExtensionAction.js';
 import { IAuthenticationUsageService } from '../../../services/authentication/browser/authenticationUsageService.js';
-import { ILogService } from '../../../../platform/log/common/log.js';
 
 const codeExchangeProxyCommand = CommandsRegistry.registerCommand('workbench.getCodeExchangeProxyEndpoints', function (accessor, _) {
 	const environmentService = accessor.get(IBrowserWorkbenchEnvironmentService);
 	return environmentService.options?.codeExchangeProxyEndpoints;
-});
-
-const authenticationDefinitionSchema: IJSONSchema = {
-	type: 'object',
-	additionalProperties: false,
-	properties: {
-		id: {
-			type: 'string',
-			description: localize('authentication.id', 'The id of the authentication provider.')
-		},
-		label: {
-			type: 'string',
-			description: localize('authentication.label', 'The human readable name of the authentication provider.'),
-		}
-	}
-};
-
-const authenticationExtPoint = ExtensionsRegistry.registerExtensionPoint<AuthenticationProviderInformation[]>({
-	extensionPoint: 'authentication',
-	jsonSchema: {
-		description: localize({ key: 'authenticationExtensionPoint', comment: [`'Contributes' means adds here`] }, 'Contributes authentication'),
-		type: 'array',
-		items: authenticationDefinitionSchema
-	},
-	activationEventsGenerator: (authenticationProviders, result) => {
-		for (const authenticationProvider of authenticationProviders) {
-			if (authenticationProvider.id) {
-				result.push(`onAuthenticationRequest:${authenticationProvider.id}`);
-			}
-		}
-	}
 });
 
 class AuthenticationDataRenderer extends Disposable implements IExtensionFeatureTableRenderer {
@@ -118,10 +83,7 @@ class AuthenticationContribution extends Disposable implements IWorkbenchContrib
 		},
 	});
 
-	constructor(
-		@IAuthenticationService private readonly _authenticationService: IAuthenticationService,
-		@ILogService private readonly _logService: ILogService
-	) {
+	constructor(@IAuthenticationService private readonly _authenticationService: IAuthenticationService) {
 		super();
 		this._register(codeExchangeProxyCommand);
 		this._register(extensionFeature);
@@ -131,43 +93,7 @@ class AuthenticationContribution extends Disposable implements IWorkbenchContrib
 			this._clearPlaceholderMenuItem();
 		}
 		this._registerHandlers();
-		this._registerAuthenticationExtentionPointHandler();
 		this._registerActions();
-	}
-
-	private _registerAuthenticationExtentionPointHandler(): void {
-		authenticationExtPoint.setHandler((extensions, { added, removed }) => {
-			this._logService.info(`Found authentication providers. added: ${added.length}, removed: ${removed.length}`);
-			added.forEach(point => {
-				for (const provider of point.value) {
-					if (isFalsyOrWhitespace(provider.id)) {
-						point.collector.error(localize('authentication.missingId', 'An authentication contribution must specify an id.'));
-						continue;
-					}
-
-					if (isFalsyOrWhitespace(provider.label)) {
-						point.collector.error(localize('authentication.missingLabel', 'An authentication contribution must specify a label.'));
-						continue;
-					}
-
-					if (!this._authenticationService.declaredProviders.some(p => p.id === provider.id)) {
-						this._authenticationService.registerDeclaredAuthenticationProvider(provider);
-						this._logService.info(`Declared authentication provider: ${provider.id}`);
-					} else {
-						point.collector.error(localize('authentication.idConflict', "This authentication id '{0}' has already been registered", provider.id));
-					}
-				}
-			});
-
-			const removedExtPoints = removed.flatMap(r => r.value);
-			removedExtPoints.forEach(point => {
-				const provider = this._authenticationService.declaredProviders.find(provider => provider.id === point.id);
-				if (provider) {
-					this._authenticationService.unregisterDeclaredAuthenticationProvider(provider.id);
-					this._logService.info(`Undeclared authentication provider: ${provider.id}`);
-				}
-			});
-		});
 	}
 
 	private _registerHandlers(): void {

--- a/src/vs/workbench/services/authentication/browser/authenticationService.ts
+++ b/src/vs/workbench/services/authentication/browser/authenticationService.ts
@@ -16,6 +16,8 @@ import { AuthenticationProviderInformation, AuthenticationSession, Authenticatio
 import { IBrowserWorkbenchEnvironmentService } from '../../environment/browser/environmentService.js';
 import { ActivationKind, IExtensionService } from '../../extensions/common/extensions.js';
 import { ILogService } from '../../../../platform/log/common/log.js';
+import { IJSONSchema } from '../../../../base/common/jsonSchema.js';
+import { ExtensionsRegistry } from '../../extensions/common/extensionsRegistry.js';
 
 export function getAuthenticationProviderActivationEvent(id: string): string { return `onAuthenticationRequest:${id}`; }
 
@@ -43,6 +45,37 @@ export async function getCurrentAuthenticationSessionInfo(
 	}
 	return undefined;
 }
+
+const authenticationDefinitionSchema: IJSONSchema = {
+	type: 'object',
+	additionalProperties: false,
+	properties: {
+		id: {
+			type: 'string',
+			description: localize('authentication.id', 'The id of the authentication provider.')
+		},
+		label: {
+			type: 'string',
+			description: localize('authentication.label', 'The human readable name of the authentication provider.'),
+		}
+	}
+};
+
+const authenticationExtPoint = ExtensionsRegistry.registerExtensionPoint<AuthenticationProviderInformation[]>({
+	extensionPoint: 'authentication',
+	jsonSchema: {
+		description: localize({ key: 'authenticationExtensionPoint', comment: [`'Contributes' means adds here`] }, 'Contributes authentication'),
+		type: 'array',
+		items: authenticationDefinitionSchema
+	},
+	activationEventsGenerator: (authenticationProviders, result) => {
+		for (const authenticationProvider of authenticationProviders) {
+			if (authenticationProvider.id) {
+				result.push(`onAuthenticationRequest:${authenticationProvider.id}`);
+			}
+		}
+	}
+});
 
 export class AuthenticationService extends Disposable implements IAuthenticationService {
 	declare readonly _serviceBrand: undefined;
@@ -85,6 +118,7 @@ export class AuthenticationService extends Disposable implements IAuthentication
 		}));
 
 		this._registerEnvContributedAuthenticationProviders();
+		this._registerAuthenticationExtentionPointHandler();
 	}
 
 	private _declaredProviders: AuthenticationProviderInformation[] = [];
@@ -100,6 +134,41 @@ export class AuthenticationService extends Disposable implements IAuthentication
 			this.registerDeclaredAuthenticationProvider(provider);
 			this.registerAuthenticationProvider(provider.id, provider);
 		}
+	}
+
+	private _registerAuthenticationExtentionPointHandler(): void {
+		this._register(authenticationExtPoint.setHandler((_extensions, { added, removed }) => {
+			this._logService.debug(`Found authentication providers. added: ${added.length}, removed: ${removed.length}`);
+			added.forEach(point => {
+				for (const provider of point.value) {
+					if (isFalsyOrWhitespace(provider.id)) {
+						point.collector.error(localize('authentication.missingId', 'An authentication contribution must specify an id.'));
+						continue;
+					}
+
+					if (isFalsyOrWhitespace(provider.label)) {
+						point.collector.error(localize('authentication.missingLabel', 'An authentication contribution must specify a label.'));
+						continue;
+					}
+
+					if (!this.declaredProviders.some(p => p.id === provider.id)) {
+						this.registerDeclaredAuthenticationProvider(provider);
+						this._logService.debug(`Declared authentication provider: ${provider.id}`);
+					} else {
+						point.collector.error(localize('authentication.idConflict', "This authentication id '{0}' has already been registered", provider.id));
+					}
+				}
+			});
+
+			const removedExtPoints = removed.flatMap(r => r.value);
+			removedExtPoints.forEach(point => {
+				const provider = this.declaredProviders.find(provider => provider.id === point.id);
+				if (provider) {
+					this.unregisterDeclaredAuthenticationProvider(provider.id);
+					this._logService.debug(`Undeclared authentication provider: ${provider.id}`);
+				}
+			});
+		}));
 	}
 
 	registerDeclaredAuthenticationProvider(provider: AuthenticationProviderInformation): void {
@@ -129,9 +198,6 @@ export class AuthenticationService extends Disposable implements IAuthentication
 	}
 
 	registerAuthenticationProvider(id: string, authenticationProvider: IAuthenticationProvider): void {
-		if (!this._declaredProviders.find(p => p.id === id)) {
-			this._logService.warn(`Registering an authentication provider that is not declared in the Extension Manifest. This may cause unexpected behavior. id: ${id}, label: ${authenticationProvider.label}`);
-		}
 		this._authenticationProviders.set(id, authenticationProvider);
 		const disposableStore = new DisposableStore();
 		disposableStore.add(authenticationProvider.onDidChangeSessions(e => this._onDidChangeSessions.fire({


### PR DESCRIPTION
This just moves code out of a contribution into the service so that the ExtPoint handler gets set up before extensions start coming in.

Also, we'd like to throw when an extension doesn't include their auth provider in the package.json so move the warning into a place that makes sense and set up a telemetry event so we can understand usage of this behavior.

Fixes https://github.com/microsoft/vscode/issues/233324

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
