### PR TITLE
debug: bump js-debug to 1.95.3

### DIFF
--- a/product.json
+++ b/product.json
@@ -50,8 +50,8 @@
 		},
 		{
 			"name": "ms-vscode.js-debug",
-			"version": "1.95.2",
-			"sha256": "c7db7b77787dcefbda15e0bcf43a456a4e4ac669c4a097b663664d94a48adce5",
+			"version": "1.95.3",
+			"sha256": "77b61197558a46140534deb7d8dd3c9d5038b9cb7ea8195e272c6a3a882d8e73",
 			"repo": "https://github.com/microsoft/vscode-js-debug",
 			"metadata": {
 				"id": "25629058-ddac-4e17-abba-74678e126c5d",


### PR DESCRIPTION
Contains https://github.com/microsoft/vscode-js-debug/compare/v1.95.2...v1.95.3

I will have a nicer fix on js-debug's main branch, but this is simple and safe. In non-locked conditions the evaluation takes single-digit milliseconds.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
