### PR TITLE
fix: set uri label on chat editing codeblock widgets

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/chatMarkdownContentPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/chatMarkdownContentPart.ts
@@ -338,5 +338,6 @@ class CollapsedCodeBlock extends Disposable {
 		const iconEl = dom.$('span.icon');
 		iconEl.classList.add(...iconClasses);
 		this.element.replaceChildren(iconEl, dom.$('span.icon-label', {}, iconText));
+		this.element.title = this.labelService.getUriLabel(uri, { relative: false });
 	}
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
