### PR TITLE
testing: some refinements to default settings and progress

### DIFF
--- a/src/vs/workbench/contrib/testing/browser/testExplorerActions.ts
+++ b/src/vs/workbench/contrib/testing/browser/testExplorerActions.ts
@@ -953,7 +953,12 @@ export class GoToTest extends Action2 {
 			id: TestCommandId.GoToTest,
 			title: localize2('testing.editFocusedTest', 'Go to Test'),
 			icon: Codicon.goToFile,
-			menu: testItemInlineAndInContext(ActionOrder.GoToTest, TestingContextKeys.testItemHasUri.isEqualTo(true)),
+			menu: {
+				id: MenuId.TestItem,
+				group: 'builtin@1',
+				order: ActionOrder.GoToTest,
+				when: TestingContextKeys.testItemHasUri.isEqualTo(true),
+			},
 			keybinding: {
 				weight: KeybindingWeight.EditorContrib - 10,
 				when: FocusedViewContext.isEqualTo(Testing.ExplorerViewId),

--- a/src/vs/workbench/contrib/testing/browser/testing.contribution.ts
+++ b/src/vs/workbench/contrib/testing/browser/testing.contribution.ts
@@ -180,7 +180,7 @@ CommandsRegistry.registerCommand({
 
 CommandsRegistry.registerCommand({
 	id: 'vscode.revealTest',
-	handler: async (accessor: ServicesAccessor, extId: string) => {
+	handler: async (accessor: ServicesAccessor, extId: string, opts?: { preserveFocus?: boolean; openToSide?: boolean }) => {
 		const test = accessor.get(ITestService).collection.getNodeById(extId);
 		if (!test) {
 			return;
@@ -217,7 +217,13 @@ CommandsRegistry.registerCommand({
 
 		await openerService.open(position
 			? uri.with({ fragment: `L${position.lineNumber}:${position.column}` })
-			: uri
+			: uri,
+			{
+				openToSide: opts?.openToSide,
+				editorOptions: {
+					preserveFocus: opts?.preserveFocus,
+				}
+			}
 		);
 	}
 });

--- a/src/vs/workbench/contrib/testing/browser/testingExplorerView.ts
+++ b/src/vs/workbench/contrib/testing/browser/testingExplorerView.ts
@@ -727,7 +727,6 @@ class TestingExplorerViewModel extends Disposable {
 				accessibilityProvider: instantiationService.createInstance(ListAccessibilityProvider),
 				filter: this.filter,
 				findWidgetEnabled: false,
-				openOnSingleClick: false,
 			}) as TestingObjectTree<FuzzyScore>;
 
 
@@ -786,8 +785,19 @@ class TestingExplorerViewModel extends Disposable {
 		}));
 
 		this._register(this.tree.onDidOpen(e => {
-			if (e.element instanceof TestItemTreeElement && !e.element.children.size && e.element.test.item.uri) {
-				commandService.executeCommand('vscode.revealTest', e.element.test.item.extId);
+			if (!(e.element instanceof TestItemTreeElement)) {
+				return;
+			}
+
+			filterState.didSelectTestInExplorer(e.element.test.item.extId);
+
+			if (!e.element.children.size && e.element.test.item.uri) {
+				if (!this.tryPeekError(e.element)) {
+					commandService.executeCommand('vscode.revealTest', e.element.test.item.extId, {
+						openToSide: e.sideBySide,
+						preserveFocus: true,
+					});
+				}
 			}
 		}));
 
@@ -813,20 +823,6 @@ class TestingExplorerViewModel extends Disposable {
 		this._register(onDidChangeVisibility(visible => {
 			if (visible) {
 				filterState.focusInput();
-			}
-		}));
-
-		this._register(this.tree.onDidChangeSelection(evt => {
-			if (dom.isMouseEvent(evt.browserEvent) && (evt.browserEvent.altKey || evt.browserEvent.shiftKey)) {
-				return; // don't focus when alt-clicking to multi select
-			}
-
-			const selected = evt.elements[0];
-			if (selected && evt.browserEvent && selected instanceof TestItemTreeElement) {
-				filterState.didSelectTestInExplorer(selected.test.item.extId);
-				if (selected.children.size === 0 && selected.test.expand === TestItemExpandState.NotExpandable) {
-					this.tryPeekError(selected);
-				}
 			}
 		}));
 

--- a/src/vs/workbench/contrib/testing/browser/testingProgressUiService.ts
+++ b/src/vs/workbench/contrib/testing/browser/testingProgressUiService.ts
@@ -51,7 +51,7 @@ export class TestingProgressTrigger extends Disposable {
 			return;
 		}
 
-		const cfg = getTestingConfiguration(this.configurationService, TestingConfigKeys.OpenTesting);
+		const cfg = getTestingConfiguration(this.configurationService, TestingConfigKeys.OpenResults);
 		if (cfg === AutoOpenTesting.NeverOpen) {
 			return;
 		}

--- a/src/vs/workbench/contrib/testing/common/configuration.ts
+++ b/src/vs/workbench/contrib/testing/common/configuration.ts
@@ -7,12 +7,13 @@ import { observableFromEvent } from '../../../../base/common/observable.js';
 import { localize } from '../../../../nls.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { IConfigurationNode } from '../../../../platform/configuration/common/configurationRegistry.js';
+import { Registry } from '../../../../platform/registry/common/platform.js';
+import { ConfigurationKeyValuePairs, Extensions, IConfigurationMigrationRegistry } from '../../../common/configuration.js';
 
 export const enum TestingConfigKeys {
-	AutoRunDelay = 'testing.autoRun.delay',
 	AutoOpenPeekView = 'testing.automaticallyOpenPeekView',
 	AutoOpenPeekViewDuringContinuousRun = 'testing.automaticallyOpenPeekViewDuringAutoRun',
-	OpenTesting = 'testing.openTesting',
+	OpenResults = 'testing.automaticallyOpenResults',
 	FollowRunningTest = 'testing.followRunningTest',
 	DefaultGutterClickAction = 'testing.defaultGutterClickAction',
 	GutterEnabled = 'testing.gutterEnabled',
@@ -65,12 +66,6 @@ export const testingConfiguration: IConfigurationNode = {
 	title: localize('testConfigurationTitle', "Testing"),
 	type: 'object',
 	properties: {
-		[TestingConfigKeys.AutoRunDelay]: {
-			type: 'integer',
-			minimum: 0,
-			description: localize('testing.autoRun.delay', "How long to wait, in milliseconds, after a test is marked as outdated and starting a new run."),
-			default: 1000,
-		},
 		[TestingConfigKeys.AutoOpenPeekView]: {
 			description: localize('testing.automaticallyOpenPeekView', "Configures when the error Peek view is automatically opened."),
 			enum: [
@@ -142,7 +137,7 @@ export const testingConfiguration: IConfigurationNode = {
 			type: 'boolean',
 			default: true,
 		},
-		[TestingConfigKeys.OpenTesting]: {
+		[TestingConfigKeys.OpenResults]: {
 			enum: [
 				AutoOpenTesting.NeverOpen,
 				AutoOpenTesting.OpenOnTestStart,
@@ -199,6 +194,14 @@ export const testingConfiguration: IConfigurationNode = {
 	}
 };
 
+Registry.as<IConfigurationMigrationRegistry>(Extensions.ConfigurationMigration)
+	.registerConfigurationMigrations([{
+		key: 'testing.openTesting',
+		migrateFn: (value: AutoOpenTesting): ConfigurationKeyValuePairs => {
+			return [[TestingConfigKeys.OpenResults, { value }]];
+		}
+	}]);
+
 export interface ITestingCoverageBarThresholds {
 	red: number;
 	green: number;
@@ -206,7 +209,6 @@ export interface ITestingCoverageBarThresholds {
 }
 
 export interface ITestingConfiguration {
-	[TestingConfigKeys.AutoRunDelay]: number;
 	[TestingConfigKeys.AutoOpenPeekView]: AutoOpenPeekViewWhen;
 	[TestingConfigKeys.AutoOpenPeekViewDuringContinuousRun]: boolean;
 	[TestingConfigKeys.CountBadge]: TestingCountBadge;
@@ -214,7 +216,7 @@ export interface ITestingConfiguration {
 	[TestingConfigKeys.DefaultGutterClickAction]: DefaultGutterClickAction;
 	[TestingConfigKeys.GutterEnabled]: boolean;
 	[TestingConfigKeys.SaveBeforeTest]: boolean;
-	[TestingConfigKeys.OpenTesting]: AutoOpenTesting;
+	[TestingConfigKeys.OpenResults]: AutoOpenTesting;
 	[TestingConfigKeys.AlwaysRevealTestOnStateChange]: boolean;
 	[TestingConfigKeys.ShowAllMessages]: boolean;
 	[TestingConfigKeys.CoveragePercent]: TestingDisplayedCoveragePercent;

--- a/src/vs/workbench/contrib/testing/common/configuration.ts
+++ b/src/vs/workbench/contrib/testing/common/configuration.ts
@@ -109,7 +109,7 @@ export const testingConfiguration: IConfigurationNode = {
 		[TestingConfigKeys.FollowRunningTest]: {
 			description: localize('testing.followRunningTest', 'Controls whether the running test should be followed in the Test Explorer view.'),
 			type: 'boolean',
-			default: true,
+			default: false,
 		},
 		[TestingConfigKeys.DefaultGutterClickAction]: {
 			description: localize('testing.defaultGutterClickAction', 'Controls the action to take when left-clicking on a test decoration in the gutter.'),


### PR DESCRIPTION
- migrate testing.openTesting -> testing.automaticallyOpenResults to be more accurate and discoverable
- use a single click action for 'opening' tests in the explorer. This aligns with the file explorer.
- with that, remove the inline "go to test" action (keep in the context menu for tests with children)
- turn off the `followRunningTest` setting by default, it's noisy and people have raised issues over this
- remove the unused "auto run delay" setting (not used since the testing API was finalized)