### PR TITLE
Convert windows style path to unix style path

### DIFF
--- a/build/gulpfile.vscode.js
+++ b/build/gulpfile.vscode.js
@@ -139,6 +139,7 @@ const bundleVSCodeTask = task.define('bundle-vscode', task.series(
 				],
 				resources: vscodeResources,
 				fileContentMapper: filePath => {
+					filePath = path.posix.normalize(filePath.replace(/\\/g, '/'));
 					if (
 						filePath.endsWith('vs/code/electron-sandbox/workbench/workbench.js') ||
 						filePath.endsWith('vs/code/electron-sandbox/processExplorer/processExplorer.js')) {
@@ -149,9 +150,11 @@ const bundleVSCodeTask = task.define('bundle-vscode', task.series(
 					}
 					return undefined;
 				},
-				skipTSBoilerplateRemoval: entryPoint =>
-					entryPoint === 'vs/code/electron-sandbox/workbench/workbench' ||
-					entryPoint === 'vs/code/electron-sandbox/processExplorer/processExplorer',
+				skipTSBoilerplateRemoval: entryPoint => {
+					entryPoint = path.posix.normalize(entryPoint.replace(/\\/g, '/'));
+					return entryPoint === 'vs/code/electron-sandbox/workbench/workbench' ||
+						entryPoint === 'vs/code/electron-sandbox/processExplorer/processExplorer'
+				}
 			}
 		}
 	)


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Since the string comparison of file path is done in gulp task, the comparison is always returning false in windows, since the comparison is done with a hardcoded unix style path.

Closes #233477