### PR TITLE
fix(markdown-preview/copy-image): invalid error with blob when download image.

### DIFF
--- a/extensions/markdown-language-features/src/commands/copyImage.ts
+++ b/extensions/markdown-language-features/src/commands/copyImage.ts
@@ -16,6 +16,10 @@ export class CopyImageCommand implements Command {
 
 	public execute(args: { id: string; resource: string }) {
 		const source = vscode.Uri.parse(args.resource);
-		this._webviewManager.findPreview(source)?.copyImage(args.id);
+		const imagePreview = this._webviewManager.findPreview(source);
+
+		if (imagePreview) {
+			imagePreview.copyImage(args.id);
+		}
 	}
 }

--- a/extensions/markdown-language-features/src/util/is-url.ts
+++ b/extensions/markdown-language-features/src/util/is-url.ts
@@ -1,0 +1,15 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+export function isURL(value: string | null | undefined) {
+	if (!value) { return false; }
+
+	try {
+		new URL(value);
+		return true;
+	} catch {
+		return false;
+	}
+}


### PR DESCRIPTION
When you copied an image with an external link, it gave a CORS error.

![Screenshot 2024-11-09 at 15 32 21](https://github.com/user-attachments/assets/e9d82b34-8f98-40c7-b242-c18ceb624325)

Since it wasn't possible to fix the CORS issue directly to resolve this problem, instead of copying an image from an external source, it now copies the link to your clipboard so you can access the image. For local images, it still copies normally like before.

before:

https://github.com/user-attachments/assets/f624dcfb-ba92-468f-a088-9e10a5d887cf



after:

https://github.com/user-attachments/assets/72c840dd-5b5a-4337-b6b7-052f20151150

issue: https://github.com/microsoft/vscode/issues/205624

