### PR TITLE
bash shellIntegration: Prevent error messages when running with `set -u`

### DIFF
--- a/src/vs/workbench/contrib/terminal/common/scripts/shellIntegration-bash.sh
+++ b/src/vs/workbench/contrib/terminal/common/scripts/shellIntegration-bash.sh
@@ -11,8 +11,8 @@ fi
 VSCODE_SHELL_INTEGRATION=1
 
 # Run relevant rc/profile only if shell integration has been injected, not when run manually
-if [ "$VSCODE_INJECTION" == "1" ]; then
-	if [ -z "$VSCODE_SHELL_LOGIN" ]; then
+if [ "${VSCODE_INJECTION-}" == "1" ]; then
+	if [ -z "${VSCODE_SHELL_LOGIN-}" ]; then
 		if [ -r ~/.bashrc ]; then
 			. ~/.bashrc
 		fi
@@ -41,7 +41,7 @@ if [ "$VSCODE_INJECTION" == "1" ]; then
 	builtin unset VSCODE_INJECTION
 fi
 
-if [ -z "$VSCODE_SHELL_INTEGRATION" ]; then
+if [ -z "${VSCODE_SHELL_INTEGRATION-}" ]; then
 	builtin return
 fi
 
@@ -172,11 +172,11 @@ __vsc_in_command_execution="1"
 __vsc_current_command=""
 
 # It's fine this is in the global scope as it getting at it requires access to the shell environment
-__vsc_nonce="$VSCODE_NONCE"
+__vsc_nonce="${VSCODE_NONCE-}"
 unset VSCODE_NONCE
 
 # Some features should only work in Insiders
-__vsc_stable="$VSCODE_STABLE"
+__vsc_stable="${VSCODE_STABLE-}"
 unset VSCODE_STABLE
 
 # Report continuation prompt


### PR DESCRIPTION
This change causes `bash` to substitute a null string for variables that are referenced, but unset. This prevents error messages when running bash with `set -u`.

e.g. "bash: VSCODE_INJECTION: unbound variable"

To test:
- place `set -u` in your `~/.bashrc`, to show an error message when unset variables are referenced
- open a new terminal in VS-Code, with shell-integration enabled

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
