### PR TITLE
Try dismissing paste widget on any cursor change

### DIFF
--- a/src/vs/editor/contrib/dropOrPasteInto/browser/postEditWidget.ts
+++ b/src/vs/editor/contrib/dropOrPasteInto/browser/postEditWidget.ts
@@ -75,9 +75,7 @@ class PostEditWidget<T extends DocumentPasteEdit | DocumentDropEdit> extends Dis
 		this._register(toDisposable((() => this.editor.removeContentWidget(this))));
 
 		this._register(this.editor.onDidChangeCursorPosition(e => {
-			if (!range.containsPosition(e.position)) {
-				this.dispose();
-			}
+			this.dispose();
 		}));
 
 		this._register(Event.runAndSubscribe(_keybindingService.onDidUpdateKeybindings, () => {


### PR DESCRIPTION
Hopefully helps with cases where you try triggering code actions but the paste widget is still visible

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
