### PR TITLE
Make hover appearance optional (fix option type)

### DIFF
--- a/src/vs/base/browser/ui/hover/hover.ts
+++ b/src/vs/base/browser/ui/hover/hover.ts
@@ -227,7 +227,7 @@ export type IDelayedHoverOptions = Omit<IHoverOptions, 'target'>;
 
 // `position` is ignored for delayed at mouse hover methods as it's overwritten by the mouse event.
 // `showPointer` is always false when using mouse positioning
-export type IDelayedHoverAtMouseOptions = Omit<IDelayedHoverOptions, 'position' | 'appearance'> & { appearance: Omit<IHoverAppearanceOptions, 'showPointer'> };
+export type IDelayedHoverAtMouseOptions = Omit<IDelayedHoverOptions, 'position' | 'appearance'> & { appearance?: Omit<IHoverAppearanceOptions, 'showPointer'> };
 
 export interface IHoverLifecycleOptions {
 	/**


### PR DESCRIPTION
`IDelayedHoverAtMouseOptions` currently forces you to add the `appearance` property. This is wrong and should not be required

@Tyriar 