### PR TITLE
Editor GPU: Fix left boundary tab rendering

### DIFF
--- a/src/vs/editor/browser/viewParts/viewLinesGpu/viewLinesGpu.ts
+++ b/src/vs/editor/browser/viewParts/viewLinesGpu/viewLinesGpu.ts
@@ -437,10 +437,23 @@ export class ViewLinesGpu extends ViewPart implements IViewLines {
 			return null;
 		}
 
+		// Resolve tab widths for this line
+		const lineData = viewportData.getViewLineRenderingData(lineNumber);
+		const content = lineData.content;
+		let startColumnResolvedTabWidth = 0;
+		let endColumnResolvedTabWidth = 0;
+		for (let x = 0; x < startColumn - 1; x++) {
+			startColumnResolvedTabWidth += content[x] === '\t' ? lineData.tabSize : 1;
+		}
+		endColumnResolvedTabWidth = startColumnResolvedTabWidth;
+		for (let x = startColumn - 1; x < endColumn - 1; x++) {
+			endColumnResolvedTabWidth += content[x] === '\t' ? lineData.tabSize : 1;
+		}
+
 		// Visible horizontal range in _scaled_ pixels
 		const result = new VisibleRanges(false, [new FloatHorizontalRange(
-			(startColumn - 1) * viewLineOptions.spaceWidth,
-			(endColumn - startColumn - 1) * viewLineOptions.spaceWidth)
+			startColumnResolvedTabWidth * viewLineOptions.spaceWidth,
+			endColumnResolvedTabWidth * viewLineOptions.spaceWidth)
 		]);
 
 		return result;


### PR DESCRIPTION
Fixes #233661

Before:

![image](https://github.com/user-attachments/assets/c1c5821b-f3bd-4ce3-bb34-41a049df65b2)

After:

![image](https://github.com/user-attachments/assets/7155e55b-2745-4b60-a1d7-194ad55fc3eb)
