### PR TITLE
fix: declare "original-fs" dependency referenced by "src/main.ts"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -137,6 +137,7 @@
         "mocha-junit-reporter": "^2.2.1",
         "mocha-multi-reporters": "^1.5.1",
         "npm-run-all": "^4.1.5",
+        "original-fs": "^1.2.0",
         "os-browserify": "^0.3.0",
         "p-all": "^1.0.0",
         "path-browserify": "^1.0.1",
@@ -13049,6 +13050,13 @@
         "string_decoder": "~1.1.1",
         "util-deprecate": "~1.0.1"
       }
+    },
+    "node_modules/original-fs": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmmirror.com/original-fs/-/original-fs-1.2.0.tgz",
+      "integrity": "sha512-IGo+qFumpIV65oDchJrqL0BOk9kr82fObnTesNJt8t3YgP6vfqcmRs0ofPzg3D9PKMeBHt7lrg1k/6L+oFdS8g==",
+      "dev": true,
+      "license": "Unlicense"
     },
     "node_modules/os-browserify": {
       "version": "0.3.0",

--- a/package.json
+++ b/package.json
@@ -195,6 +195,7 @@
     "mocha-junit-reporter": "^2.2.1",
     "mocha-multi-reporters": "^1.5.1",
     "npm-run-all": "^4.1.5",
+    "original-fs": "^1.2.0",
     "os-browserify": "^0.3.0",
     "p-all": "^1.0.0",
     "path-browserify": "^1.0.1",


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

It seems to introduce a dependency "oringinal-fs" which was not declared in `package.json`, after I executed script `compile`, ran a cli `node out/main.js`, I got a ERR_MODULE_NOT_FOUND Error in the integrated terminal, a screenshot below:

![image](https://github.com/user-attachments/assets/fe8a30c8-0ec2-4f97-ac2c-73d27335c6d4)


It seems to be a problem, this pr would like to fix this~
