### PR TITLE
Don't strip out html like tags when rendering markdown code blocks as plain text

### DIFF
--- a/src/vs/base/test/browser/markdownRenderer.test.ts
+++ b/src/vs/base/test/browser/markdownRenderer.test.ts
@@ -260,15 +260,32 @@ suite('MarkdownRenderer', () => {
 
 		test('test code, blockquote, heading, list, listitem, paragraph, table, tablerow, tablecell, strong, em, br, del, text are rendered plaintext', () => {
 			const markdown = { value: '`code`\n>quote\n# heading\n- list\n\ntable | table2\n--- | --- \none | two\n\n\nbo**ld**\n_italic_\n~~del~~\nsome text' };
-			const expected = 'code\nquote\nheading\nlist\n\ntable table2\none two\nbold\nitalic\ndel\nsome text\n';
+			const expected = 'code\nquote\nheading\nlist\n\ntable table2\none two\nbold\nitalic\ndel\nsome text';
 			const result: string = renderMarkdownAsPlaintext(markdown);
 			assert.strictEqual(result, expected);
 		});
 
 		test('test html, hr, image, link are rendered plaintext', () => {
 			const markdown = { value: '<div>html</div>\n\n---\n![image](imageLink)\n[text](textLink)' };
-			const expected = '\ntext\n';
+			const expected = 'text';
 			const result: string = renderMarkdownAsPlaintext(markdown);
+			assert.strictEqual(result, expected);
+		});
+
+		test(`Should not remove html inside of code blocks`, () => {
+			const markdown = {
+				value: [
+					'```html',
+					'<form>html</form>',
+					'```',
+				].join('\n')
+			};
+			const expected = [
+				'```',
+				'<form>html</form>',
+				'```',
+			].join('\n');
+			const result: string = renderMarkdownAsPlaintext(markdown, true);
 			assert.strictEqual(result, expected);
 		});
 	});


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-copilot-release/issues/2489

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
