### PR TITLE
make sure names match

### DIFF
--- a/src/vs/workbench/contrib/issue/browser/issueFormService.ts
+++ b/src/vs/workbench/contrib/issue/browser/issueFormService.ts
@@ -111,8 +111,8 @@ export class IssueFormService implements IIssueFormService {
 		const actions = menu.getActions({ renderShortTitle: true }).flatMap(entry => entry[1]);
 		for (const action of actions) {
 			try {
-				if (action.item && 'source' in action.item && action.item.source?.id === extensionId) {
-					this.extensionIdentifierSet.add(extensionId);
+				if (action.item && 'source' in action.item && action.item.source?.id.toLowerCase() === extensionId.toLowerCase()) {
+					this.extensionIdentifierSet.add(extensionId.toLowerCase());
 					await action.run();
 				}
 			} catch (error) {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

the main reason we are doing this is because in copilot and copilot chat, github uses:
`GitHub` as the source (we create extension identifiers in core by doing source + `.` + extensionName), but in core the check is `github.copilot-chat` since that is what the extension contributes.

<img width="709" alt="Screenshot 2024-11-14 at 6 02 58 PM" src="https://github.com/user-attachments/assets/ebc42e5d-ca28-44f8-ba43-eaef6f37173d">

vs.

<img width="482" alt="Screenshot 2024-11-14 at 6 02 09 PM" src="https://github.com/user-attachments/assets/32c0bc1b-6ca3-4ebc-a180-cb7905be75a8">

in any case, capitalization shouldn't matter