### PR TITLE
fix: show Save All in chat editing widget for non-autosave users too

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatEditorSaving.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditorSaving.ts
@@ -267,12 +267,11 @@ export class ChatEditingSaveAllAction extends Action2 {
 					id: MenuId.ChatEditingWidgetToolbar,
 					group: 'navigation',
 					order: 2,
-					// Show the option to save without accepting if the user has autosave
-					// and also hasn't configured the setting to always save with generated changes
+					// Show the option to save without accepting if the user hasn't configured the setting to always save with generated changes
 					when: ContextKeyExpr.and(
 						applyingChatEditsFailedContextKey.negate(),
 						ContextKeyExpr.or(hasUndecidedChatEditingResourceContextKey, hasAppliedChatEditsContextKey.negate()),
-						ContextKeyExpr.notEquals('config.files.autoSave', 'off'), ContextKeyExpr.equals(`config.${ChatEditorSaving._config}`, false),
+						ContextKeyExpr.equals(`config.${ChatEditorSaving._config}`, false),
 						ChatContextKeys.location.isEqualTo(ChatAgentLocation.EditingSession)
 					)
 				}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
