### PR TITLE
Include .js/.ts in module specifiers in the VS Code workspace

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -76,6 +76,7 @@
 	"npm.exclude": "**/extensions/**",
 	"emmet.excludeLanguages": [],
 	"typescript.preferences.importModuleSpecifier": "relative",
+	"typescript.preferences.importModuleSpecifierEnding": "js",
 	"typescript.preferences.quoteStyle": "single",
 	"json.schemas": [
 		{


### PR DESCRIPTION
Fixes https://github.com/microsoft/TypeScript/issues/60451