### PR TITLE
Allow wrapping chat confirm buttons

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatContentParts/media/chatConfirmationWidget.css
+++ b/src/vs/workbench/contrib/chat/browser/chatContentParts/media/chatConfirmationWidget.css
@@ -33,6 +33,7 @@
 	display: flex;
 	gap: 8px;
 	margin-top: 13px;
+	flex-wrap: wrap;
 }
 
 .chat-confirmation-widget.hideButtons .chat-confirmation-buttons-container {


### PR DESCRIPTION
They are ugly when their text wraps in place