### PR TITLE
predictable keytar resolution

### DIFF
--- a/extensions/microsoft-authentication/extension.webpack.config.js
+++ b/extensions/microsoft-authentication/extension.webpack.config.js
@@ -25,6 +25,11 @@ module.exports = withDefaults({
 		// gracefully.
 		'./msal-node-runtime': 'commonjs ./msal-node-runtime'
 	},
+	resolve: {
+		alias: {
+			'keytar': path.resolve(__dirname, 'packageMocks', 'keytar', 'index.js')
+		}
+	},
 	plugins: [
 		...withDefaults.nodePlugins(__dirname),
 		new CopyWebpackPlugin({


### PR DESCRIPTION
In a couple of builds [like this one](https://dev.azure.com/monacotools/Monaco/_build/results?buildId=305323&view=results) we have seen bad comparisons of `extension.js` in the Microsoft Auth extension:

> 2024-11-15T19:16:07.080Z electron-universal SHA for file Contents/Resources/app/extensions/microsoft-authentication/dist/extension.js does not match across builds a4db653e84d42a8cb4681a2274dffd34e0d7729cf14c0c4228b668778aa81c18!=6ff1bd8b8b51db2bff1d5f000625f0efe490a92eb282d0559aa904325d6cad68

Which is odd, considering there is no native dependencies used on macOS. The suspicion is that this is because of `keytar` which we have in the package.json using an odd `file:./path...`syntax to prevent it from installing normally since we don't use it.

The solution: additionally alias keytar in the webpack config so that the resolution is predictable.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
