### PR TITLE
Fixed Zen Mode not exiting when leaving fullscreen - #231474

### DIFF
--- a/src/vs/workbench/browser/layout.ts
+++ b/src/vs/workbench/browser/layout.ts
@@ -465,8 +465,7 @@ export abstract class Layout extends Disposable implements IWorkbenchLayoutServi
 		} else {
 			this.mainContainer.classList.remove(LayoutClasses.FULLSCREEN);
 
-			const zenModeExitInfo = this.stateModel.getRuntimeValue(LayoutStateKeys.ZEN_MODE_EXIT_INFO);
-			if (zenModeExitInfo.transitionedToFullScreen && this.isZenModeActive()) {
+			if (this.isZenModeActive()) {
 				this.toggleZenMode();
 			}
 		}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
I propose to remove the unnecessary check so that Zen Mode toggles off when a user leaves Fullscreen Mode.

To test these changes:

1. Start Visual Studio Code
2. Enter Fullscreen Mode
3. Enable Zen Mode
4. Exit Fullscreen Mode

Zen mode should now be toggled off.