### PR TITLE
Limit providerUsage event

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadAuthentication.ts
+++ b/src/vs/workbench/api/browser/mainThreadAuthentication.ts
@@ -71,6 +71,7 @@ export class MainThreadAuthentication extends Disposable implements MainThreadAu
 	private readonly _proxy: ExtHostAuthenticationShape;
 
 	private readonly _registrations = this._register(new DisposableMap<string>());
+	private _sentProviderUsageEvents = new Set<string>();
 
 	constructor(
 		extHostContext: IExtHostContext,
@@ -314,6 +315,11 @@ export class MainThreadAuthentication extends Disposable implements MainThreadAu
 	}
 
 	private sendProviderUsageTelemetry(extensionId: string, providerId: string): void {
+		const key = `${extensionId}|${providerId}`;
+		if (this._sentProviderUsageEvents.has(key)) {
+			return;
+		}
+		this._sentProviderUsageEvents.add(key);
 		type AuthProviderUsageClassification = {
 			owner: 'TylerLeonhardt';
 			comment: 'Used to see which extensions are using which providers';


### PR DESCRIPTION
The 'authentication.providerUsage' event fires wayyyy too often.

Before:

> 1 Event every time an extension asks for any provider and that provider returns an auth session.

After:

> 1 Event per provider per extension per session. In other words, we will only fire the telemetry event if we have never seen Extension, Foo, receive an auth session from Provider, Bar, in this window.

This will dramatically reduce the number of events, while still giving me insight on what extensions are using what providers.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
