### PR TITLE
Invert gpuMark, add reasons why it cannot be rendered to title

### DIFF
--- a/src/vs/editor/browser/gpu/viewGpuContext.ts
+++ b/src/vs/editor/browser/gpu/viewGpuContext.ts
@@ -138,4 +138,28 @@ export class ViewGpuContext extends Disposable {
 		}
 		return true;
 	}
+
+	/**
+	 * Like {@link canRender} but returned detailed information about why the line cannot be rendered.
+	 */
+	public static canRenderDetailed(options: ViewLineOptions, viewportData: ViewportData, lineNumber: number): string[] {
+		const data = viewportData.getViewLineRenderingData(lineNumber);
+		const reasons: string[] = [];
+		if (data.containsRTL) {
+			reasons.push('containsRTL');
+		}
+		if (data.maxColumn > GpuRenderLimits.maxGpuCols) {
+			reasons.push('maxColumn > maxGpuCols');
+		}
+		if (data.continuesWithWrappedLine) {
+			reasons.push('continuesWithWrappedLine');
+		}
+		if (data.inlineDecorations.length > 0) {
+			reasons.push('inlineDecorations > 0');
+		}
+		if (lineNumber >= GpuRenderLimits.maxGpuLines) {
+			reasons.push('lineNumber >= maxGpuLines');
+		}
+		return reasons;
+	}
 }

--- a/src/vs/editor/browser/viewParts/gpuMark/gpuMark.css
+++ b/src/vs/editor/browser/viewParts/gpuMark/gpuMark.css
@@ -8,7 +8,13 @@
 	top: 0;
 	bottom: 0;
 	left: 0;
-	width: 2px;
+	width: 100%;
 	display: inline-block;
-	background: var(--vscode-editorLineNumber-foreground);
+	border-left: solid 2px var(--vscode-editorWarning-foreground);
+	opacity: 0.2;
+	transition: background-color 0.1s linear;
+}
+
+.monaco-editor .margin-view-overlays .gpu-mark:hover {
+	background-color: var(--vscode-editorWarning-foreground)
 }

--- a/src/vs/editor/browser/viewParts/gpuMark/gpuMark.ts
+++ b/src/vs/editor/browser/viewParts/gpuMark/gpuMark.ts
@@ -77,8 +77,8 @@ export class GpuMarkOverlay extends DynamicViewOverlay {
 		const output: string[] = [];
 		for (let lineNumber = visibleStartLineNumber; lineNumber <= visibleEndLineNumber; lineNumber++) {
 			const lineIndex = lineNumber - visibleStartLineNumber;
-			const canRender = ViewGpuContext.canRender(options, viewportData, lineNumber);
-			output[lineIndex] = canRender ? `<div class="${GpuMarkOverlay.CLASS_NAME}"></div>` : '';
+			const cannotRenderReasons = ViewGpuContext.canRenderDetailed(options, viewportData, lineNumber);
+			output[lineIndex] = cannotRenderReasons.length ? `<div class="${GpuMarkOverlay.CLASS_NAME}" title="Cannot render on GPU: ${cannotRenderReasons.join(', ')}"></div>` : '';
 		}
 
 		this._renderResult = output;


### PR DESCRIPTION
Fixes #233993

![image](https://github.com/user-attachments/assets/2f2e3071-fc8a-4715-aeda-6a3cfc6988f7)
