### PR TITLE
Implementing Terminal: Run Recent Commad when there are no open terminal

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminalActions.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalActions.ts
@@ -249,22 +249,11 @@ export function registerActiveInstanceAction(
 	const originalRun = options.run;
 	return registerTerminalAction({
 		...options,
-		run: async (c, accessor, args) => {
-			let activeInstance = c.service.activeInstance;
-			const id = options.id;
+		run: (c, accessor, args) => {
+			const activeInstance = c.service.activeInstance;
 			if (activeInstance) {
 				return originalRun(activeInstance, c, accessor, args);
 			}
-			if (id !== 'workbench.action.terminal.runRecentCommand') {
-				return;
-			}
-			const commandService = accessor.get(ICommandService);
-			await commandService.executeCommand('workbench.action.terminal.new');
-			activeInstance = c.service.activeInstance;
-			if (activeInstance) {
-				return originalRun(activeInstance, c, accessor, args);
-			}
-			return;
 		}
 	});
 }

--- a/src/vs/workbench/contrib/terminal/browser/terminalActions.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalActions.ts
@@ -249,11 +249,22 @@ export function registerActiveInstanceAction(
 	const originalRun = options.run;
 	return registerTerminalAction({
 		...options,
-		run: (c, accessor, args) => {
-			const activeInstance = c.service.activeInstance;
+		run: async (c, accessor, args) => {
+			let activeInstance = c.service.activeInstance;
+			const id = options.id;
 			if (activeInstance) {
 				return originalRun(activeInstance, c, accessor, args);
 			}
+			if (id !== 'workbench.action.terminal.runRecentCommand') {
+				return;
+			}
+			const commandService = accessor.get(ICommandService);
+			await commandService.executeCommand('workbench.action.terminal.new');
+			activeInstance = c.service.activeInstance;
+			if (activeInstance) {
+				return originalRun(activeInstance, c, accessor, args);
+			}
+			return;
 		}
 	});
 }

--- a/src/vs/workbench/contrib/terminalContrib/history/browser/terminal.history.contribution.ts
+++ b/src/vs/workbench/contrib/terminalContrib/history/browser/terminal.history.contribution.ts
@@ -21,6 +21,7 @@ import { TerminalContextKeys } from '../../../terminal/common/terminalContextKey
 import { clearShellFileHistory, getCommandHistory, getDirectoryHistory } from '../common/history.js';
 import { TerminalHistoryCommandId } from '../common/terminal.history.js';
 import { showRunRecentQuickPick } from './terminalRunRecentQuickPick.js';
+import { ICommandService } from '../../../../../platform/commands/common/commands.js';
 
 // #region Terminal Contributions
 
@@ -124,7 +125,8 @@ registerActiveInstanceAction({
 	}
 });
 
-registerActiveInstanceAction({
+
+registerTerminalAction({
 	id: TerminalHistoryCommandId.RunRecentCommand,
 	title: localize2('workbench.action.terminal.runRecentCommand', 'Run Recent Command...'),
 	precondition,
@@ -141,7 +143,13 @@ registerActiveInstanceAction({
 			weight: KeybindingWeight.WorkbenchContrib
 		}
 	],
-	run: async (activeInstance, c) => {
+	run: async (c, accessor) => {
+		let activeInstance = c.service.activeInstance;
+		if (!activeInstance) {
+			const commandService = accessor.get(ICommandService);
+			await commandService.executeCommand('workbench.action.terminal.new');
+			activeInstance = c.service.activeInstance!;
+		}
 		const history = TerminalHistoryContribution.get(activeInstance);
 		if (!history) {
 			return;

--- a/src/vs/workbench/contrib/terminalContrib/history/browser/terminalRunRecentQuickPick.ts
+++ b/src/vs/workbench/contrib/terminalContrib/history/browser/terminalRunRecentQuickPick.ts
@@ -36,7 +36,8 @@ export async function showRunRecentQuickPick(
 	type: 'command' | 'cwd',
 	filterMode?: 'fuzzy' | 'contiguous',
 	value?: string,
-): Promise<void> {
+	isFromRunRecentCommand?: boolean,
+): Promise<void | boolean> {
 	if (!instance.xterm) {
 		return;
 	}
@@ -228,6 +229,9 @@ export async function showRunRecentQuickPick(
 		}
 	}
 	if (items.length === 0) {
+		if (isFromRunRecentCommand) {
+			return true;
+		}
 		return;
 	}
 	const disposables = new DisposableStore();


### PR DESCRIPTION
Fix #233604 
The command 'Terminal: Run Recent Command' will now create a new terminal if no terminals are currently open.

Simply creating a new terminal is not sufficient for the recent command window to display correctly.
When a new terminal is created, it looks like it takes some more time to fully update its related variables, so I inserted a loop of quick sleep functions (up to 5 seconds in total) while continuosly trying to display the recent command window.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
