### PR TITLE
Make sure to preserve spaces in status bar prefix

### DIFF
--- a/src/vs/workbench/browser/parts/statusbar/statusbarItem.ts
+++ b/src/vs/workbench/browser/parts/statusbar/statusbarItem.ts
@@ -308,7 +308,7 @@ class StatusBarCodiconLabel extends SimpleIconLabel {
 			// If we have text to show, add a space to separate from progress
 			let textContent = text ?? '';
 			if (textContent) {
-				textContent = ` ${textContent}`;
+				textContent = `\u00A0${textContent}`; // prepend non-breaking space
 			}
 
 			// Append new elements


### PR DESCRIPTION
Regular old space gets stripped out

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
