### PR TITLE
Render JSDoc examples as typescript code

### DIFF
--- a/extensions/typescript-language-features/src/languageFeatures/util/textRendering.ts
+++ b/extensions/typescript-language-features/src/languageFeatures/util/textRendering.ts
@@ -28,7 +28,7 @@ function getTagBodyText(
 		if (/^\s*[~`]{3}/m.test(text)) {
 			return text;
 		}
-		return '```\n' + text + '\n```';
+		return '```tsx\n' + text + '\n```';
 	}
 
 	let text = convertLinkTags(tag.text, filePathConverter);

--- a/extensions/typescript-language-features/src/test/unit/textRendering.test.ts
+++ b/extensions/typescript-language-features/src/test/unit/textRendering.test.ts
@@ -89,7 +89,7 @@ suite('typescript.previewer', () => {
 					text: 'code();'
 				}
 			], noopToResource),
-			'*@example*  \n```\ncode();\n```'
+			'*@example*  \n```tsx\ncode();\n```'
 		);
 	});
 
@@ -113,7 +113,7 @@ suite('typescript.previewer', () => {
 					text: '<caption>Not code</caption>\ncode();'
 				}
 			], noopToResource),
-			'*@example*  \nNot code\n```\ncode();\n```'
+			'*@example*  \nNot code\n```tsx\ncode();\n```'
 		);
 	});
 
@@ -154,7 +154,7 @@ suite('typescript.previewer', () => {
 					]
 				}
 			], noopToResource),
-			'*@example*  \n```\n1 + 1 {@link foo}\n```');
+			'*@example*  \n```tsx\n1 + 1 {@link foo}\n```');
 	});
 
 	test('Should render @linkcode symbol name as code', () => {


### PR DESCRIPTION
Currently `@example` produces Markdown code blocks for code examples, but they are not annotated with a programming language. This commit annotates those code blocks as `typescript`, allowing for better highlighting for JS/TS when using Markdown renderers that recognize these languages.

See this related PR: https://github.com/typescript-language-server/typescript-language-server/pull/918

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fixes #234142
