### PR TITLE
Migrate old accounts to MSAL

### DIFF
--- a/extensions/microsoft-authentication/src/extensionV1.ts
+++ b/extensions/microsoft-authentication/src/extensionV1.ts
@@ -105,6 +105,10 @@ async function initMicrosoftSovereignCloudAuthProvider(context: vscode.Extension
 }
 
 export async function activate(context: vscode.ExtensionContext, telemetryReporter: TelemetryReporter) {
+	// If we ever activate the old flow, then mark that we will need to migrate when the user upgrades to v2.
+	// TODO: MSAL Migration. Remove this when we remove the old flow.
+	context.globalState.update('msalMigration', false);
+
 	const uriHandler = new UriEventHandler();
 	context.subscriptions.push(uriHandler);
 	const betterSecretStorage = new BetterTokenStorage<IStoredSession>('microsoft.login.keylist', context);

--- a/extensions/microsoft-authentication/src/node/publicClientCache.ts
+++ b/extensions/microsoft-authentication/src/node/publicClientCache.ts
@@ -94,19 +94,37 @@ export class CachedPublicClientApplicationManager implements ICachedPublicClient
 		Disposable.from(...this._pcaDisposables.values()).dispose();
 	}
 
-	async getOrCreate(clientId: string, authority: string): Promise<ICachedPublicClientApplication> {
+	async getOrCreate(clientId: string, authority: string, refreshTokensToMigrate?: string[]): Promise<ICachedPublicClientApplication> {
 		// Use the clientId and authority as the key
 		const pcasKey = JSON.stringify({ clientId, authority });
 		let pca = this._pcas.get(pcasKey);
 		if (pca) {
 			this._logger.debug(`[getOrCreate] [${clientId}] [${authority}] PublicClientApplicationManager cache hit`);
-			return pca;
+		} else {
+			this._logger.debug(`[getOrCreate] [${clientId}] [${authority}] PublicClientApplicationManager cache miss, creating new PCA...`);
+			pca = await this._doCreatePublicClientApplication(clientId, authority, pcasKey);
+			await this._storePublicClientApplications();
+			this._logger.debug(`[getOrCreate] [${clientId}] [${authority}] PCA created.`);
 		}
 
-		this._logger.debug(`[getOrCreate] [${clientId}] [${authority}] PublicClientApplicationManager cache miss, creating new PCA...`);
-		pca = await this._doCreatePublicClientApplication(clientId, authority, pcasKey);
-		await this._storePublicClientApplications();
-		this._logger.debug(`[getOrCreate] [${clientId}] [${authority}] PCA created.`);
+		// TODO: MSAL Migration. Remove this when we remove the old flow.
+		if (refreshTokensToMigrate?.length) {
+			this._logger.debug(`[getOrCreate] [${clientId}] [${authority}] Migrating refresh tokens to PCA...`);
+			for (const refreshToken of refreshTokensToMigrate) {
+				try {
+					// Use the refresh token to acquire a result. This will cache the refresh token for future operations.
+					// The scopes don't matter here since we can create any token from the refresh token.
+					const result = await pca.acquireTokenByRefreshToken({ refreshToken, forceCache: true, scopes: [] });
+					if (result?.account) {
+						this._logger.debug(`[getOrCreate] [${clientId}] [${authority}] Refresh token migrated to PCA.`);
+					}
+				} catch (e) {
+					this._logger.error(`[getOrCreate] [${clientId}] [${authority}] Error migrating refresh token:`, e);
+				}
+			}
+			// reinitialize the PCA so the account is properly cached
+			await pca.initialize();
+		}
 		return pca;
 	}
 


### PR DESCRIPTION
Bascally, we reach into the old location in secret storage and if we find sessions (with a refresh token) we seed that in the MSAL world.

We do this one time... unless they switch back to the old world and then switch to the new world.

This has two different behaviors depending on if the Broker is used:
* If the broker is not used, this does what you might expect. It makes it seem totally transparent to the user that something has changed. All sessions get migrated over and the user is still logged in to what they were previously.
* If the broker is used... you don't get automatically logged in _unless_ you have already logged in to that account at the OS level. So this helps skip the "VS Code access layer" outlined in `accountAccess.ts`. Not as good as the previous bullet, but this is the best we can do in the broker world.

In time, we can remove this migration along with the old way of doing things.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
