### PR TITLE
When move chat to edit, group requests by timestamp

### DIFF
--- a/src/vs/workbench/contrib/chat/test/common/__snapshots__/ChatService_can_deserialize.0.snap
+++ b/src/vs/workbench/contrib/chat/test/common/__snapshots__/ChatService_can_deserialize.0.snap
@@ -94,7 +94,8 @@
         kind: "usedContext"
       },
       contentReferences: [  ],
-      codeCitations: [  ]
+      codeCitations: [  ],
+      timestamp: undefined
     }
   ]
 }

--- a/src/vs/workbench/contrib/chat/test/common/__snapshots__/ChatService_can_deserialize_with_response.0.snap
+++ b/src/vs/workbench/contrib/chat/test/common/__snapshots__/ChatService_can_deserialize_with_response.0.snap
@@ -78,7 +78,8 @@
       slashCommand: undefined,
       usedContext: undefined,
       contentReferences: [  ],
-      codeCitations: [  ]
+      codeCitations: [  ],
+      timestamp: undefined
     }
   ]
 }

--- a/src/vs/workbench/contrib/chat/test/common/__snapshots__/ChatService_can_serialize.1.snap
+++ b/src/vs/workbench/contrib/chat/test/common/__snapshots__/ChatService_can_serialize.1.snap
@@ -101,7 +101,8 @@
         kind: "usedContext"
       },
       contentReferences: [  ],
-      codeCitations: [  ]
+      codeCitations: [  ],
+      timestamp: undefined
     },
     {
       message: {
@@ -149,7 +150,8 @@
       slashCommand: undefined,
       usedContext: undefined,
       contentReferences: [  ],
-      codeCitations: [  ]
+      codeCitations: [  ],
+      timestamp: undefined
     }
   ]
 }

--- a/src/vs/workbench/contrib/chat/test/common/__snapshots__/ChatService_sendRequest_fails.0.snap
+++ b/src/vs/workbench/contrib/chat/test/common/__snapshots__/ChatService_sendRequest_fails.0.snap
@@ -78,7 +78,8 @@
       slashCommand: undefined,
       usedContext: undefined,
       contentReferences: [  ],
-      codeCitations: [  ]
+      codeCitations: [  ],
+      timestamp: undefined
     }
   ]
 }

--- a/src/vs/workbench/contrib/chat/test/common/chatService.test.ts
+++ b/src/vs/workbench/contrib/chat/test/common/chatService.test.ts
@@ -21,7 +21,7 @@ import { ITelemetryService } from '../../../../../platform/telemetry/common/tele
 import { NullTelemetryService } from '../../../../../platform/telemetry/common/telemetryUtils.js';
 import { IWorkspaceContextService } from '../../../../../platform/workspace/common/workspace.js';
 import { ChatAgentLocation, ChatAgentService, IChatAgent, IChatAgentImplementation, IChatAgentService } from '../../common/chatAgents.js';
-import { ISerializableChatData } from '../../common/chatModel.js';
+import { IChatModel, ISerializableChatData } from '../../common/chatModel.js';
 import { IChatFollowup, IChatService } from '../../common/chatService.js';
 import { ChatService } from '../../common/chatServiceImpl.js';
 import { ChatSlashCommandService, IChatSlashCommandService } from '../../common/chatSlashCommands.js';
@@ -183,7 +183,7 @@ suite('ChatService', () => {
 		assert(response);
 		await response.responseCompletePromise;
 
-		await assertSnapshot(model.toExport());
+		await assertSnapshot(toSnapshotExportData(model));
 	});
 
 	test('history', async () => {
@@ -233,7 +233,7 @@ suite('ChatService', () => {
 		const model = testDisposables.add(testService.startSession(ChatAgentLocation.Panel, CancellationToken.None));
 		assert.strictEqual(model.getRequests().length, 0);
 
-		await assertSnapshot(model.toExport());
+		await assertSnapshot(toSnapshotExportData(model));
 
 		const response = await testService.sendRequest(model.sessionId, `@${chatAgentWithUsedContextId} test request`);
 		assert(response);
@@ -245,7 +245,7 @@ suite('ChatService', () => {
 		await response2.responseCompletePromise;
 		assert.strictEqual(model.getRequests().length, 2);
 
-		await assertSnapshot(model.toExport());
+		await assertSnapshot(toSnapshotExportData(model));
 	});
 
 	test('can deserialize', async () => {
@@ -274,7 +274,7 @@ suite('ChatService', () => {
 		const chatModel2 = testService2.loadSessionFromContent(serializedChatData);
 		assert(chatModel2);
 
-		await assertSnapshot(chatModel2.toExport());
+		await assertSnapshot(toSnapshotExportData(chatModel2));
 	});
 
 	test('can deserialize with response', async () => {
@@ -302,6 +302,20 @@ suite('ChatService', () => {
 		const chatModel2 = testService2.loadSessionFromContent(serializedChatData);
 		assert(chatModel2);
 
-		await assertSnapshot(chatModel2.toExport());
+		await assertSnapshot(toSnapshotExportData(chatModel2));
 	});
 });
+
+
+function toSnapshotExportData(model: IChatModel) {
+	const exp = model.toExport();
+	return {
+		...exp,
+		requests: exp.requests.map(r => {
+			return {
+				...r,
+				timestamp: undefined
+			};
+		})
+	};
+}


### PR DESCRIPTION
* add timestamp to `IChatRequestModel` (fyi @roblourens)
* adopt test snapshot logic because of timestampe
* and use timestamp to group/select request when moving them to edits