### PR TITLE
Simplify Windows Start Menu folder to just be an entry #234217

### DIFF
--- a/build/win32/code.iss
+++ b/build/win32/code.iss
@@ -99,7 +99,7 @@ Source: "appx\*"; DestDir: "{app}\appx"; BeforeInstall: RemoveAppxPackage; After
 #endif
 
 [Icons]
-Name: "{group}\{#NameLong}"; Filename: "{app}\{#ExeBasename}.exe"; AppUserModelID: "{#AppUserId}"
+Name: "{autoprograms}\{#NameLong}"; Filename: "{app}\{#ExeBasename}.exe"; AppUserModelID: "{#AppUserId}"
 Name: "{autodesktop}\{#NameLong}"; Filename: "{app}\{#ExeBasename}.exe"; Tasks: desktopicon; AppUserModelID: "{#AppUserId}"
 Name: "{userappdata}\Microsoft\Internet Explorer\Quick Launch\{#NameLong}"; Filename: "{app}\{#ExeBasename}.exe"; Tasks: quicklaunchicon; AppUserModelID: "{#AppUserId}"
 

--- a/build/win32/code.iss
+++ b/build/win32/code.iss
@@ -99,7 +99,7 @@ Source: "appx\*"; DestDir: "{app}\appx"; BeforeInstall: RemoveAppxPackage; After
 #endif
 
 [Icons]
-Name: "{autoprograms}\{#NameLong}"; Filename: "{app}\{#ExeBasename}.exe"; AppUserModelID: "{#AppUserId}"
+Name: "{autostartmenu}\{#NameLong}"; Filename: "{app}\{#ExeBasename}.exe"; AppUserModelID: "{#AppUserId}"
 Name: "{autodesktop}\{#NameLong}"; Filename: "{app}\{#ExeBasename}.exe"; Tasks: desktopicon; AppUserModelID: "{#AppUserId}"
 Name: "{userappdata}\Microsoft\Internet Explorer\Quick Launch\{#NameLong}"; Filename: "{app}\{#ExeBasename}.exe"; Tasks: quicklaunchicon; AppUserModelID: "{#AppUserId}"
 


### PR DESCRIPTION
This simple change causes the Windows installer to just place an entry in the Start Menu, instead of creating an entire folder, which does not make much sense for a single entry. Solves issue #234217

The resulting change is as following:

From

%appdata%\Microsoft\Windows\Start Menu\Programs\Visual Studio Code\Visual Studio Code.lnk
![image](https://github.com/user-attachments/assets/38f87f19-92f8-4e8c-98d7-2e7be63f525d)

To

%appdata%\Microsoft\Windows\Start Menu\Programs\Visual Studio Code.lnk
![image](https://github.com/user-attachments/assets/ea6df203-ac52-41da-8064-f9e527717b67)

