### PR TITLE
Handle notebook cell editors getting their models swapped resulting in weird Editor viewzone issues

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/contrib/chatEdit/notebookCellDecorators.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/chatEdit/notebookCellDecorators.ts
@@ -5,7 +5,7 @@
 
 import { isEqual } from '../../../../../../base/common/resources.js';
 import { Disposable, DisposableStore, dispose, toDisposable } from '../../../../../../base/common/lifecycle.js';
-import { autorun, derived } from '../../../../../../base/common/observable.js';
+import { autorun, autorunWithStore, derived, observableFromEvent } from '../../../../../../base/common/observable.js';
 import { IChatEditingService, ChatEditingSessionState } from '../../../../chat/common/chatEditingService.js';
 import { NotebookTextModel } from '../../../common/model/notebookTextModel.js';
 import { INotebookEditor } from '../../notebookBrowser.js';
@@ -35,13 +35,13 @@ import { DetailedLineRangeMapping } from '../../../../../../editor/common/diff/r
 
 
 export class NotebookCellDiffDecorator extends DisposableStore {
-	private readonly _decorations = this.editor.createDecorationsCollection();
 	private _viewZones: string[] = [];
-	private readonly throttledDecorator = new ThrottledDelayer(100);
+	private readonly throttledDecorator = new ThrottledDelayer(50);
 	private diffForPreviouslyAppliedDecorators?: IDocumentDiff;
 
+	private readonly perEditorDisposables = this.add(new DisposableStore());
 	constructor(
-		public readonly editor: ICodeEditor,
+		notebookEditor: INotebookEditor,
 		public readonly modifiedCell: NotebookCellTextModel,
 		public readonly originalCell: NotebookCellTextModel,
 		@IChatEditingService private readonly _chatEditingService: IChatEditingService,
@@ -50,42 +50,74 @@ export class NotebookCellDiffDecorator extends DisposableStore {
 
 	) {
 		super();
-		this.add(this.editor.onDidChangeModel(() => {
-			this._clearRendering();
-			this.update();
-		}));
-		this.add(this.editor.onDidChangeModelContent(() => this.update()));
-		this.add(this.editor.onDidChangeConfiguration((e) => {
-			if (e.hasChanged(EditorOption.fontInfo) || e.hasChanged(EditorOption.lineHeight)) {
-				this.update();
+
+		const onDidChangeVisibleRanges = observableFromEvent(notebookEditor.onDidChangeVisibleRanges, () => notebookEditor.visibleRanges);
+		const editorObs = derived((r) => {
+			const visibleRanges = onDidChangeVisibleRanges.read(r);
+			const visibleCellHandles = visibleRanges.map(range => notebookEditor.getCellsInRange(range)).flat().map(c => c.handle);
+			if (!visibleCellHandles.includes(modifiedCell.handle)) {
+				return;
+			}
+			const editor = notebookEditor.codeEditors.find(item => item[0].handle === modifiedCell.handle)?.[1];
+			if (editor?.getModel() !== this.modifiedCell.textModel) {
+				return;
+			}
+			return editor;
+		});
+
+		this.add(autorunWithStore((r, store) => {
+			const editor = editorObs.read(r);
+			this.perEditorDisposables.clear();
+
+			if (editor) {
+				store.add(editor.onDidChangeModel(() => {
+					this.perEditorDisposables.clear();
+				}));
+				store.add(editor.onDidChangeModelContent(() => {
+					this.update(editor);
+				}));
+				store.add(editor.onDidChangeConfiguration((e) => {
+					if (e.hasChanged(EditorOption.fontInfo) || e.hasChanged(EditorOption.lineHeight)) {
+						this.update(editor);
+					}
+				}));
+				this.update(editor);
 			}
 		}));
 
 		const shouldBeReadOnly = derived(this, r => {
+			const editor = editorObs.read(r);
+			if (!editor) {
+				return false;
+			}
 			const value = this._chatEditingService.currentEditingSessionObs.read(r);
 			if (!value || value.state.read(r) !== ChatEditingSessionState.StreamingEdits) {
 				return false;
 			}
-			return value.entries.read(r).some(e => isEqual(e.modifiedURI, this.editor.getModel()?.uri));
+			return value.entries.read(r).some(e => isEqual(e.modifiedURI, editor.getModel()?.uri));
 		});
 
 
 		let actualReadonly: boolean | undefined;
 		let actualDeco: 'off' | 'editable' | 'on' | undefined;
 
-		this.add(autorun(r => {
+		this.add(autorun((r) => {
+			const editor = editorObs.read(r);
+			if (!editor) {
+				return;
+			}
 			const value = shouldBeReadOnly.read(r);
 			if (value) {
-				actualReadonly ??= this.editor.getOption(EditorOption.readOnly);
-				actualDeco ??= this.editor.getOption(EditorOption.renderValidationDecorations);
+				actualReadonly ??= editor.getOption(EditorOption.readOnly);
+				actualDeco ??= editor.getOption(EditorOption.renderValidationDecorations);
 
-				this.editor.updateOptions({
+				editor.updateOptions({
 					readOnly: true,
 					renderValidationDecorations: 'off'
 				});
 			} else {
 				if (actualReadonly !== undefined && actualDeco !== undefined) {
-					this.editor.updateOptions({
+					editor.updateOptions({
 						readOnly: actualReadonly,
 						renderValidationDecorations: actualDeco
 					});
@@ -94,35 +126,29 @@ export class NotebookCellDiffDecorator extends DisposableStore {
 				}
 			}
 		}));
-		this.update();
 	}
 
-	override dispose(): void {
-		this._clearRendering();
-		super.dispose();
+	public update(editor: ICodeEditor): void {
+		this.throttledDecorator.trigger(() => this._updateImpl(editor));
 	}
 
-	public update(): void {
-		this.throttledDecorator.trigger(() => this._updateImpl());
-	}
-
-	private async _updateImpl() {
+	private async _updateImpl(editor: ICodeEditor) {
 		if (this.isDisposed) {
 			return;
 		}
-		if (this.editor.getOption(EditorOption.inDiffEditor)) {
-			this._clearRendering();
+		if (editor.getOption(EditorOption.inDiffEditor)) {
+			this.perEditorDisposables.clear();
 			return;
 		}
-		const model = this.editor.getModel();
+		const model = editor.getModel();
 		if (!model || model !== this.modifiedCell.textModel) {
-			this._clearRendering();
+			this.perEditorDisposables.clear();
 			return;
 		}
 
-		const originalModel = this.getOrCreateOriginalModel();
+		const originalModel = this.getOrCreateOriginalModel(editor);
 		if (!originalModel) {
-			this._clearRendering();
+			this.perEditorDisposables.clear();
 			return;
 		}
 		const version = model.getVersionId();
@@ -139,27 +165,17 @@ export class NotebookCellDiffDecorator extends DisposableStore {
 		}
 
 
-		if (diff && !diff.identical && originalModel && model === this.editor.getModel() && this.editor.getModel()?.getVersionId() === version) {
-			this._updateWithDiff(originalModel, diff);
+		if (diff && !diff.identical && originalModel && model === editor.getModel() && editor.getModel()?.getVersionId() === version) {
+			this._updateWithDiff(editor, originalModel, diff);
 		} else {
-			this._clearRendering();
+			this.perEditorDisposables.clear();
 		}
 	}
 
-	private _clearRendering() {
-		this.editor.changeViewZones((viewZoneChangeAccessor) => {
-			for (const id of this._viewZones) {
-				viewZoneChangeAccessor.removeZone(id);
-			}
-		});
-		this._viewZones = [];
-		this._decorations.clear();
-	}
-
 	private _originalModel?: ITextModel;
-	private getOrCreateOriginalModel() {
+	private getOrCreateOriginalModel(editor: ICodeEditor) {
 		if (!this._originalModel) {
-			const model = this.editor.getModel();
+			const model = editor.getModel();
 			if (!model) {
 				return;
 			}
@@ -168,10 +184,22 @@ export class NotebookCellDiffDecorator extends DisposableStore {
 		return this._originalModel;
 	}
 
-	private _updateWithDiff(originalModel: ITextModel | undefined, diff: IDocumentDiff): void {
+	private _updateWithDiff(editor: ICodeEditor, originalModel: ITextModel | undefined, diff: IDocumentDiff): void {
 		if (areDiffsEqual(diff, this.diffForPreviouslyAppliedDecorators)) {
 			return;
 		}
+		const decorations = editor.createDecorationsCollection();
+		this.perEditorDisposables.add(toDisposable(() => {
+			editor.changeViewZones((viewZoneChangeAccessor) => {
+				for (const id of this._viewZones) {
+					viewZoneChangeAccessor.removeZone(id);
+				}
+			});
+			this._viewZones = [];
+			decorations.clear();
+			this.diffForPreviouslyAppliedDecorators = undefined;
+		}));
+
 		this.diffForPreviouslyAppliedDecorators = diff;
 
 		const chatDiffAddDecoration = ModelDecorationOptions.createDynamic({
@@ -193,7 +221,7 @@ export class NotebookCellDiffDecorator extends DisposableStore {
 		const addedDecoration = createOverviewDecoration(overviewRulerAddedForeground, minimapGutterAddedBackground);
 		const deletedDecoration = createOverviewDecoration(overviewRulerDeletedForeground, minimapGutterDeletedBackground);
 
-		this.editor.changeViewZones((viewZoneChangeAccessor) => {
+		editor.changeViewZones((viewZoneChangeAccessor) => {
 			for (const id of this._viewZones) {
 				viewZoneChangeAccessor.removeZone(id);
 			}
@@ -201,7 +229,7 @@ export class NotebookCellDiffDecorator extends DisposableStore {
 			const modifiedDecorations: IModelDeltaDecoration[] = [];
 			const mightContainNonBasicASCII = originalModel?.mightContainNonBasicASCII();
 			const mightContainRTL = originalModel?.mightContainRTL();
-			const renderOptions = RenderOptions.fromEditor(this.editor);
+			const renderOptions = RenderOptions.fromEditor(editor);
 
 			for (const diffEntry of diff.changes) {
 				const originalRange = diffEntry.original;
@@ -267,7 +295,7 @@ export class NotebookCellDiffDecorator extends DisposableStore {
 				}
 			}
 
-			this._decorations.set(modifiedDecorations);
+			decorations.set(modifiedDecorations);
 		});
 	}
 }
@@ -379,12 +407,12 @@ export class NotebookDeletedCellDecorator extends Disposable implements INoteboo
 			return height;
 		}));
 
-		Array.from(this.deletedCellInfos.keys()).sort().forEach((originalIndex) => {
+		Array.from(this.deletedCellInfos.keys()).sort((a, b) => a - b).forEach((originalIndex) => {
 			const previousDeletedCell = this.deletedCellInfos.get(originalIndex - 1);
 			if (previousDeletedCell) {
 				const deletedCell = this.deletedCellInfos.get(originalIndex);
 				if (deletedCell) {
-					deletedCell.offset = previousDeletedCell.height;
+					deletedCell.offset = previousDeletedCell.height + previousDeletedCell.offset;
 				}
 			}
 		});
@@ -553,4 +581,5 @@ function areLineRangeMappinsEqual(a: readonly DetailedLineRangeMapping[], b: rea
 	})) {
 		return false;
 	}
+	return true;
 }

--- a/src/vs/workbench/contrib/notebook/browser/contrib/chatEdit/notebookChatActionsOverlay.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/chatEdit/notebookChatActionsOverlay.ts
@@ -178,7 +178,7 @@ class NextPreviousChangeActionRunner extends ActionRunner {
 		const viewModel = this.notebookEditor.getViewModel();
 		const activeCell = this.notebookEditor.activeCellAndCodeEditor;
 		const cellDiff = this.cellDiffInfo.read(undefined);
-		if (!viewModel || !activeCell || !cellDiff || !cellDiff.length) {
+		if (!viewModel || !cellDiff?.length || (!activeCell && this.focusedDiff.read(undefined))) {
 			return this.goToNextEntry();
 		}
 


### PR DESCRIPTION
When we create viewzones for say 1st cell and 20th cell.
What can happen is that viewzones from editor of 20th cell gets reapplied to the second cell.

Some how viewzones are not destroyed when the model is updated.
Refactored to ensure we try not to keep editor and cells in sync in two places but do that in just one place.
Also modified navigation issues
