### PR TITLE
Clean up support for paste edits

### DIFF
--- a/extensions/css-language-features/client/src/dropOrPaste/dropOrPasteResource.ts
+++ b/extensions/css-language-features/client/src/dropOrPaste/dropOrPasteResource.ts
@@ -9,7 +9,8 @@ import { getDocumentDir, Mimes, Schemes } from './shared';
 import { UriList } from './uriList';
 
 class DropOrPasteResourceProvider implements vscode.DocumentDropEditProvider, vscode.DocumentPasteEditProvider {
-	readonly kind = vscode.DocumentDropOrPasteEditKind.Empty.append('css', 'url');
+
+	readonly kind = vscode.DocumentDropOrPasteEditKind.Empty.append('css', 'link', 'url');
 
 	async provideDocumentDropEdits(
 		document: vscode.TextDocument,

--- a/extensions/ipynb/src/notebookImagePaste.ts
+++ b/extensions/ipynb/src/notebookImagePaste.ts
@@ -48,7 +48,7 @@ function getImageMimeType(uri: vscode.Uri): string | undefined {
 
 class DropOrPasteEditProvider implements vscode.DocumentPasteEditProvider, vscode.DocumentDropEditProvider {
 
-	public static readonly kind = vscode.DocumentDropOrPasteEditKind.Empty.append('markdown', 'image', 'attachment');
+	public static readonly kind = vscode.DocumentDropOrPasteEditKind.Empty.append('markdown', 'link', 'image', 'attachment');
 
 	async provideDocumentPasteEdits(
 		document: vscode.TextDocument,
@@ -68,7 +68,7 @@ class DropOrPasteEditProvider implements vscode.DocumentPasteEditProvider, vscod
 		}
 
 		const pasteEdit = new vscode.DocumentPasteEdit(insert.insertText, vscode.l10n.t('Insert Image as Attachment'), DropOrPasteEditProvider.kind);
-		pasteEdit.yieldTo = [vscode.DocumentDropOrPasteEditKind.Empty.append('text')];
+		pasteEdit.yieldTo = [vscode.DocumentDropOrPasteEditKind.Text];
 		pasteEdit.additionalEdit = insert.additionalEdit;
 		return [pasteEdit];
 	}
@@ -85,7 +85,7 @@ class DropOrPasteEditProvider implements vscode.DocumentPasteEditProvider, vscod
 		}
 
 		const dropEdit = new vscode.DocumentDropEdit(insert.insertText);
-		dropEdit.yieldTo = [vscode.DocumentDropOrPasteEditKind.Empty.append('text')];
+		dropEdit.yieldTo = [vscode.DocumentDropOrPasteEditKind.Text];
 		dropEdit.additionalEdit = insert.additionalEdit;
 		dropEdit.title = vscode.l10n.t('Insert Image as Attachment');
 		return dropEdit;

--- a/extensions/markdown-language-features/src/languageFeatures/copyFiles/dropOrPasteResource.ts
+++ b/extensions/markdown-language-features/src/languageFeatures/copyFiles/dropOrPasteResource.ts
@@ -10,7 +10,7 @@ import { getParentDocumentUri } from '../../util/document';
 import { Mime, mediaMimes } from '../../util/mimes';
 import { Schemes } from '../../util/schemes';
 import { NewFilePathGenerator } from './newFilePathGenerator';
-import { DropOrPasteEdit, createInsertUriListEdit, createUriListSnippet, getSnippetLabel } from './shared';
+import { DropOrPasteEdit, createInsertUriListEdit, createUriListSnippet, getSnippetLabelAndKind, baseLinkEditKind, linkEditKind, audioEditKind, videoEditKind, imageEditKind } from './shared';
 import { InsertMarkdownLink, shouldInsertMarkdownLinkByDefault } from './smartDropOrPaste';
 import { UriList } from '../../util/uriList';
 
@@ -30,8 +30,6 @@ enum CopyFilesSettings {
  */
 class ResourcePasteOrDropProvider implements vscode.DocumentPasteEditProvider, vscode.DocumentDropEditProvider {
 
-	public static readonly kind = vscode.DocumentDropOrPasteEditKind.Empty.append('markdown', 'link');
-
 	public static readonly mimeTypes = [
 		Mime.textUriList,
 		'files',
@@ -39,8 +37,8 @@ class ResourcePasteOrDropProvider implements vscode.DocumentPasteEditProvider, v
 	];
 
 	private readonly _yieldTo = [
-		vscode.DocumentDropOrPasteEditKind.Empty.append('text'),
-		vscode.DocumentDropOrPasteEditKind.Empty.append('markdown', 'image', 'attachment'),
+		vscode.DocumentDropOrPasteEditKind.Text,
+		vscode.DocumentDropOrPasteEditKind.Empty.append('markdown', 'link', 'image', 'attachment'), // Prefer notebook attachments
 	];
 
 	constructor(
@@ -64,7 +62,7 @@ class ResourcePasteOrDropProvider implements vscode.DocumentPasteEditProvider, v
 
 		const dropEdit = new vscode.DocumentDropEdit(edit.snippet);
 		dropEdit.title = edit.label;
-		dropEdit.kind = ResourcePasteOrDropProvider.kind;
+		dropEdit.kind = edit.kind;
 		dropEdit.additionalEdit = edit.additionalEdits;
 		dropEdit.yieldTo = [...this._yieldTo, ...edit.yieldTo];
 		return dropEdit;
@@ -86,7 +84,7 @@ class ResourcePasteOrDropProvider implements vscode.DocumentPasteEditProvider, v
 			return;
 		}
 
-		const pasteEdit = new vscode.DocumentPasteEdit(edit.snippet, edit.label, ResourcePasteOrDropProvider.kind);
+		const pasteEdit = new vscode.DocumentPasteEdit(edit.snippet, edit.label, edit.kind);
 		pasteEdit.additionalEdit = edit.additionalEdits;
 		pasteEdit.yieldTo = [...this._yieldTo, ...edit.yieldTo];
 		return [pasteEdit];
@@ -162,7 +160,7 @@ class ResourcePasteOrDropProvider implements vscode.DocumentPasteEditProvider, v
 		if (
 			uriList.entries.length === 1
 			&& (uriList.entries[0].uri.scheme === Schemes.http || uriList.entries[0].uri.scheme === Schemes.https)
-			&& !context?.only?.contains(ResourcePasteOrDropProvider.kind)
+			&& !context?.only?.contains(baseLinkEditKind)
 		) {
 			const text = await dataTransfer.get(Mime.textPlain)?.asString();
 			if (token.isCancellationRequested) {
@@ -184,6 +182,7 @@ class ResourcePasteOrDropProvider implements vscode.DocumentPasteEditProvider, v
 
 		return {
 			label: edit.label,
+			kind: edit.kind,
 			snippet: new vscode.SnippetString(''),
 			additionalEdits,
 			yieldTo: []
@@ -254,9 +253,11 @@ class ResourcePasteOrDropProvider implements vscode.DocumentPasteEditProvider, v
 			}
 		}
 
+		const { label, kind } = getSnippetLabelAndKind(snippet);
 		return {
 			snippet: snippet.snippet,
-			label: getSnippetLabel(snippet),
+			label,
+			kind,
 			additionalEdits,
 			yieldTo: [],
 		};
@@ -277,13 +278,21 @@ function textMatchesUriList(text: string, uriList: UriList): boolean {
 }
 
 export function registerResourceDropOrPasteSupport(selector: vscode.DocumentSelector, parser: IMdParser): vscode.Disposable {
+	const providedEditKinds = [
+		baseLinkEditKind,
+		linkEditKind,
+		imageEditKind,
+		audioEditKind,
+		videoEditKind,
+	];
+
 	return vscode.Disposable.from(
 		vscode.languages.registerDocumentPasteEditProvider(selector, new ResourcePasteOrDropProvider(parser), {
-			providedPasteEditKinds: [ResourcePasteOrDropProvider.kind],
+			providedPasteEditKinds: providedEditKinds,
 			pasteMimeTypes: ResourcePasteOrDropProvider.mimeTypes,
 		}),
 		vscode.languages.registerDocumentDropEditProvider(selector, new ResourcePasteOrDropProvider(parser), {
-			providedDropEditKinds: [ResourcePasteOrDropProvider.kind],
+			providedDropEditKinds: providedEditKinds,
 			dropMimeTypes: ResourcePasteOrDropProvider.mimeTypes,
 		}),
 	);

--- a/extensions/markdown-language-features/src/languageFeatures/copyFiles/pasteUrlProvider.ts
+++ b/extensions/markdown-language-features/src/languageFeatures/copyFiles/pasteUrlProvider.ts
@@ -6,9 +6,9 @@
 import * as vscode from 'vscode';
 import { IMdParser } from '../../markdownEngine';
 import { Mime } from '../../util/mimes';
-import { createInsertUriListEdit } from './shared';
-import { InsertMarkdownLink, findValidUriInText, shouldInsertMarkdownLinkByDefault } from './smartDropOrPaste';
 import { UriList } from '../../util/uriList';
+import { createInsertUriListEdit, linkEditKind } from './shared';
+import { InsertMarkdownLink, findValidUriInText, shouldInsertMarkdownLinkByDefault } from './smartDropOrPaste';
 
 /**
  * Adds support for pasting text uris to create markdown links.
@@ -17,7 +17,7 @@ import { UriList } from '../../util/uriList';
  */
 class PasteUrlEditProvider implements vscode.DocumentPasteEditProvider {
 
-	public static readonly kind = vscode.DocumentDropOrPasteEditKind.Empty.append('markdown', 'link');
+	public static readonly kind = linkEditKind;
 
 	public static readonly pasteMimeTypes = [Mime.textPlain];
 
@@ -61,7 +61,7 @@ class PasteUrlEditProvider implements vscode.DocumentPasteEditProvider {
 
 		if (!(await shouldInsertMarkdownLinkByDefault(this._parser, document, pasteUrlSetting, ranges, token))) {
 			pasteEdit.yieldTo = [
-				vscode.DocumentDropOrPasteEditKind.Empty.append('text'),
+				vscode.DocumentDropOrPasteEditKind.Text,
 				vscode.DocumentDropOrPasteEditKind.Empty.append('uri')
 			];
 		}

--- a/extensions/markdown-language-features/src/languageFeatures/updateLinksOnPaste.ts
+++ b/extensions/markdown-language-features/src/languageFeatures/updateLinksOnPaste.ts
@@ -9,9 +9,9 @@ import { Mime } from '../util/mimes';
 
 class UpdatePastedLinksEditProvider implements vscode.DocumentPasteEditProvider {
 
-	public static readonly kind = vscode.DocumentDropOrPasteEditKind.Empty.append('markdown', 'updateLinks');
+	public static readonly kind = vscode.DocumentDropOrPasteEditKind.Text.append('updateLinks', 'markdown');
 
-	public static readonly metadataMime = 'vnd.vscode.markdown.updateLinksMetadata';
+	public static readonly metadataMime = 'application/vnd.vscode.markdown.updatelinks.metadata';
 
 	constructor(
 		private readonly _client: MdLanguageClient,
@@ -67,7 +67,7 @@ class UpdatePastedLinksEditProvider implements vscode.DocumentPasteEditProvider 
 		pasteEdit.additionalEdit = workspaceEdit;
 
 		if (!context.only || !UpdatePastedLinksEditProvider.kind.contains(context.only)) {
-			pasteEdit.yieldTo = [vscode.DocumentDropOrPasteEditKind.Empty.append('text')];
+			pasteEdit.yieldTo = [vscode.DocumentDropOrPasteEditKind.Text];
 		}
 
 		return [pasteEdit];

--- a/extensions/typescript-language-features/src/languageFeatures/copyPaste.ts
+++ b/extensions/typescript-language-features/src/languageFeatures/copyPaste.ts
@@ -42,7 +42,7 @@ const enabledSettingId = 'updateImportsOnPaste.enabled';
 
 class DocumentPasteProvider implements vscode.DocumentPasteEditProvider {
 
-	static readonly kind = vscode.DocumentDropOrPasteEditKind.Empty.append('text', 'updateImports', 'jsts');
+	static readonly kind = vscode.DocumentDropOrPasteEditKind.Text.append('updateImports', 'jsts');
 	static readonly metadataMimeType = 'application/vnd.code.jsts.metadata';
 
 	constructor(
@@ -127,7 +127,7 @@ class DocumentPasteProvider implements vscode.DocumentPasteEditProvider {
 		}
 
 		const edit = new vscode.DocumentPasteEdit('', vscode.l10n.t("Paste with imports"), DocumentPasteProvider.kind);
-		edit.yieldTo = [vscode.DocumentDropOrPasteEditKind.Empty.append('text', 'plain')];
+		edit.yieldTo = [vscode.DocumentDropOrPasteEditKind.Text.append('plain')];
 
 		const additionalEdit = new vscode.WorkspaceEdit();
 		for (const edit of response.body.edits) {

--- a/src/vs/editor/common/languages.ts
+++ b/src/vs/editor/common/languages.ts
@@ -937,9 +937,9 @@ export interface DocumentPasteEditsSession {
  */
 export interface DocumentPasteEditProvider {
 	readonly id?: string;
-	readonly copyMimeTypes?: readonly string[];
-	readonly pasteMimeTypes?: readonly string[];
-	readonly providedPasteEditKinds?: readonly HierarchicalKind[];
+	readonly copyMimeTypes: readonly string[];
+	readonly pasteMimeTypes: readonly string[];
+	readonly providedPasteEditKinds: readonly HierarchicalKind[];
 
 	prepareDocumentPaste?(model: model.ITextModel, ranges: readonly IRange[], dataTransfer: IReadonlyVSDataTransfer, token: CancellationToken): Promise<undefined | IReadonlyVSDataTransfer>;
 

--- a/src/vs/editor/contrib/dropOrPasteInto/browser/defaultProviders.ts
+++ b/src/vs/editor/contrib/dropOrPasteInto/browser/defaultProviders.ts
@@ -28,6 +28,7 @@ abstract class SimplePasteAndDropProvider implements DocumentDropEditProvider, D
 	readonly providedPasteEditKinds: HierarchicalKind[];
 
 	abstract readonly dropMimeTypes: readonly string[] | undefined;
+	readonly copyMimeTypes = [];
 	abstract readonly pasteMimeTypes: readonly string[];
 
 	constructor(kind: HierarchicalKind) {
@@ -102,7 +103,7 @@ class PathProvider extends SimplePasteAndDropProvider {
 	readonly pasteMimeTypes = [Mimes.uriList];
 
 	constructor() {
-		super(HierarchicalKind.Empty.append('uri', 'absolute'));
+		super(HierarchicalKind.Empty.append('uri', 'path', 'absolute'));
 	}
 
 	protected async getEdit(dataTransfer: IReadonlyVSDataTransfer, token: CancellationToken): Promise<DocumentPasteEdit | undefined> {
@@ -153,7 +154,7 @@ class RelativePathProvider extends SimplePasteAndDropProvider {
 	constructor(
 		@IWorkspaceContextService private readonly _workspaceContextService: IWorkspaceContextService
 	) {
-		super(HierarchicalKind.Empty.append('uri', 'relative'));
+		super(HierarchicalKind.Empty.append('uri', 'path', 'relative'));
 	}
 
 	protected async getEdit(dataTransfer: IReadonlyVSDataTransfer, token: CancellationToken): Promise<DocumentPasteEdit | undefined> {
@@ -185,9 +186,9 @@ class RelativePathProvider extends SimplePasteAndDropProvider {
 class PasteHtmlProvider implements DocumentPasteEditProvider {
 
 	public readonly kind = new HierarchicalKind('html');
-
 	public readonly providedPasteEditKinds = [this.kind];
 
+	public readonly copyMimeTypes = [];
 	public readonly pasteMimeTypes = ['text/html'];
 
 	private readonly _yieldTo = [{ mimeType: Mimes.text }];

--- a/src/vs/workbench/api/browser/mainThreadLanguageFeatures.ts
+++ b/src/vs/workbench/api/browser/mainThreadLanguageFeatures.ts
@@ -1018,9 +1018,9 @@ class MainThreadPasteEditProvider implements languages.DocumentPasteEditProvider
 
 	private readonly dataTransfers = new DataTransferFileCache();
 
-	public readonly copyMimeTypes?: readonly string[];
-	public readonly pasteMimeTypes?: readonly string[];
-	public readonly providedPasteEditKinds?: readonly HierarchicalKind[];
+	public readonly copyMimeTypes: readonly string[];
+	public readonly pasteMimeTypes: readonly string[];
+	public readonly providedPasteEditKinds: readonly HierarchicalKind[];
 
 	readonly prepareDocumentPaste?: languages.DocumentPasteEditProvider['prepareDocumentPaste'];
 	readonly provideDocumentPasteEdits?: languages.DocumentPasteEditProvider['provideDocumentPasteEdits'];
@@ -1032,9 +1032,9 @@ class MainThreadPasteEditProvider implements languages.DocumentPasteEditProvider
 		metadata: IPasteEditProviderMetadataDto,
 		@IUriIdentityService private readonly _uriIdentService: IUriIdentityService
 	) {
-		this.copyMimeTypes = metadata.copyMimeTypes;
-		this.pasteMimeTypes = metadata.pasteMimeTypes;
-		this.providedPasteEditKinds = metadata.providedPasteEditKinds?.map(kind => new HierarchicalKind(kind));
+		this.copyMimeTypes = metadata.copyMimeTypes ?? [];
+		this.pasteMimeTypes = metadata.pasteMimeTypes ?? [];
+		this.providedPasteEditKinds = metadata.providedPasteEditKinds?.map(kind => new HierarchicalKind(kind)) ?? [];
 
 		if (metadata.supportsCopy) {
 			this.prepareDocumentPaste = async (model: ITextModel, selections: readonly IRange[], dataTransfer: IReadonlyVSDataTransfer, token: CancellationToken): Promise<IReadonlyVSDataTransfer | undefined> => {

--- a/src/vs/workbench/api/common/extHostTypes.ts
+++ b/src/vs/workbench/api/common/extHostTypes.ts
@@ -2907,6 +2907,7 @@ export enum DocumentPasteTriggerKind {
 
 export class DocumentDropOrPasteEditKind {
 	static Empty: DocumentDropOrPasteEditKind;
+	static Text: DocumentDropOrPasteEditKind;
 
 	private static sep = '.';
 
@@ -2927,6 +2928,7 @@ export class DocumentDropOrPasteEditKind {
 	}
 }
 DocumentDropOrPasteEditKind.Empty = new DocumentDropOrPasteEditKind('');
+DocumentDropOrPasteEditKind.Text = new DocumentDropOrPasteEditKind('text');
 
 export class DocumentPasteEdit {
 

--- a/src/vs/workbench/contrib/chat/browser/chatPasteProviders.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatPasteProviders.ts
@@ -25,6 +25,9 @@ const COPY_MIME_TYPES = 'application/vnd.code.additional-editor-data';
 export class PasteImageProvider implements DocumentPasteEditProvider {
 
 	public readonly kind = new HierarchicalKind('chat.attach.image');
+	public readonly providedPasteEditKinds = [this.kind];
+
+	public readonly copyMimeTypes = [];
 	public readonly pasteMimeTypes = ['image/*'];
 
 	constructor(
@@ -91,7 +94,7 @@ export class PasteImageProvider implements DocumentPasteEditProvider {
 			return;
 		}
 
-		return getCustomPaste(model, imageContext, mimeType, new HierarchicalKind('chat.attach.image'), localize('pastedImageAttachment', 'Pasted Image Attachment'), this.chatWidgetService);
+		return getCustomPaste(model, imageContext, mimeType, this.kind, localize('pastedImageAttachment', 'Pasted Image Attachment'), this.chatWidgetService);
 	}
 }
 
@@ -138,9 +141,9 @@ export function isImage(array: Uint8Array): boolean {
 }
 
 export class CopyTextProvider implements DocumentPasteEditProvider {
-
-	public readonly kind = new HierarchicalKind('chat.attach.text');
+	public readonly providedPasteEditKinds = [];
 	public readonly copyMimeTypes = [COPY_MIME_TYPES];
+	public readonly pasteMimeTypes = [];
 
 	async prepareDocumentPaste(model: ITextModel, ranges: readonly IRange[], dataTransfer: IReadonlyVSDataTransfer, token: CancellationToken): Promise<undefined | IReadonlyVSDataTransfer> {
 		if (model.uri.scheme === ChatInputPart.INPUT_SCHEME) {
@@ -156,6 +159,9 @@ export class CopyTextProvider implements DocumentPasteEditProvider {
 export class PasteTextProvider implements DocumentPasteEditProvider {
 
 	public readonly kind = new HierarchicalKind('chat.attach.text');
+	public readonly providedPasteEditKinds = [this.kind];
+
+	public readonly copyMimeTypes = [];
 	public readonly pasteMimeTypes = [COPY_MIME_TYPES];
 
 	constructor(
@@ -194,7 +200,7 @@ export class PasteTextProvider implements DocumentPasteEditProvider {
 			return;
 		}
 
-		return getCustomPaste(model, copiedContext, Mimes.text, new HierarchicalKind('chat.attach.text'), localize('pastedCodeAttachment', 'Pasted Code Attachment'), this.chatWidgetService);
+		return getCustomPaste(model, copiedContext, Mimes.text, this.kind, localize('pastedCodeAttachment', 'Pasted Code Attachment'), this.chatWidgetService);
 	}
 }
 

--- a/src/vs/workbench/contrib/dropOrPasteInto/browser/configurationSchema.ts
+++ b/src/vs/workbench/contrib/dropOrPasteInto/browser/configurationSchema.ts
@@ -139,15 +139,33 @@ export class DropOrPasteSchemaContribution extends Disposable implements IWorkbe
 				then: {
 					properties: {
 						'args': {
-							required: ['kind'],
-							properties: {
-								'kind': {
-									anyOf: [
-										{ enum: Array.from(this._allProvidedPasteKinds.map(x => x.value)) },
-										{ type: 'string' },
-									]
+							oneOf: [
+								{
+									required: ['kind'],
+									properties: {
+										'kind': {
+											anyOf: [
+												{ enum: Array.from(this._allProvidedPasteKinds.map(x => x.value)) },
+												{ type: 'string' },
+											]
+										}
+									}
+								},
+								{
+									required: ['preferences'],
+									properties: {
+										'preferences': {
+											type: 'array',
+											items: {
+												anyOf: [
+													{ enum: Array.from(this._allProvidedPasteKinds.map(x => x.value)) },
+													{ type: 'string' },
+												]
+											}
+										}
+									}
 								}
-							}
+							]
 						}
 					}
 				}

--- a/src/vscode-dts/vscode.proposed.documentPaste.d.ts
+++ b/src/vscode-dts/vscode.proposed.documentPaste.d.ts
@@ -13,6 +13,20 @@ declare module 'vscode' {
 	class DocumentDropOrPasteEditKind {
 		static readonly Empty: DocumentDropOrPasteEditKind;
 
+		/**
+		 * The root kind for basic text edits.
+		 *
+		 * This kind should be used for edits that insert basic text into the document. A good example of this is
+		 * an edit that pastes the clipboard text while also updating imports in the file based on the pasted text.
+		 * For this we could use a kind such as `text.updateImports.someLanguageId`.
+		 *
+		 * Even though most drop/paste edits ultimately insert text, you should not use {@linkcode Text} as the base kind
+		 * for every edit as this is redundant. Instead a more specific kind that describes the type of content being
+		 * inserted should be used instead For example, if the edit adds a Markdown link, use `markdown.link` since even
+		 * though the content being inserted is text, it's more important to know that the edit inserts Markdown syntax.
+		 */
+		static readonly Text: DocumentDropOrPasteEditKind;
+
 		private constructor(value: string);
 
 		/**
@@ -66,12 +80,17 @@ declare module 'vscode' {
 	/**
 	 * Additional information about the paste operation.
 	 */
-
+	// TODO: Should we also have this for drop?
 	export interface DocumentPasteEditContext {
 		/**
 		 * Requested kind of paste edits to return.
+		 *
+		 * When a explicit kind if requested by {@linkcode DocumentPasteTriggerKind.PasteAs PasteAs}, providers are
+		 * encourage to be more flexible when generating an edit of the requested kind.
 		 */
 		readonly only: DocumentDropOrPasteEditKind | undefined;
+
+		// TODO: should we also expose preferences?
 
 		/**
 		 * The reason why paste edits were requested.


### PR DESCRIPTION
- Allow setting an array of preferences for paste as keybindings
- Clarifies kinds used for core and extensions
- Exports text kind as API

