### PR TITLE
Small fix for notebook search

### DIFF
--- a/src/vs/workbench/contrib/search/browser/notebookSearch/notebookSearchModelBase.ts
+++ b/src/vs/workbench/contrib/search/browser/notebookSearch/notebookSearchModelBase.ts
@@ -44,7 +44,6 @@ export function isIMatchInNotebook(obj: any): obj is IMatchInNotebook {
 		typeof obj.parent === 'function' &&
 		typeof obj.cellParent === 'object' &&
 		typeof obj.isWebviewMatch === 'function' &&
-		typeof obj.isReadonly === 'function' &&
 		typeof obj.cellIndex === 'number' &&
 		(typeof obj.webviewIndex === 'number' || obj.webviewIndex === undefined) &&
 		(typeof obj.cell === 'object' || obj.cell === undefined);


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fix for notebook search where linking to a cell and replacing values was not working.
This was due to a change in `isReadOnly`, now instead of being a function is a getter which returns the type of the returned value.