### PR TITLE
Allow overriding how markdown links are inserted using the keybinding

### DIFF
--- a/extensions/markdown-language-features/src/commands/insertResource.ts
+++ b/extensions/markdown-language-features/src/commands/insertResource.ts
@@ -6,7 +6,7 @@
 import * as vscode from 'vscode';
 import { Utils } from 'vscode-uri';
 import { Command } from '../commandManager';
-import { createUriListSnippet, mediaFileExtensions } from '../languageFeatures/copyFiles/shared';
+import { createUriListSnippet, linkEditKind, mediaFileExtensions } from '../languageFeatures/copyFiles/shared';
 import { coalesce } from '../util/arrays';
 import { getParentDocumentUri } from '../util/document';
 import { Schemes } from '../util/schemes';
@@ -84,7 +84,7 @@ function createInsertLinkEdit(activeEditor: vscode.TextEditor, selectedFiles: re
 	const snippetEdits = coalesce(activeEditor.selections.map((selection, i): vscode.SnippetTextEdit | undefined => {
 		const selectionText = activeEditor.document.getText(selection);
 		const snippet = createUriListSnippet(activeEditor.document.uri, selectedFiles.map(uri => ({ uri })), {
-			insertAsMedia: insertAsMedia,
+			linkKindHint: insertAsMedia ? 'media' : linkEditKind,
 			placeholderText: selectionText,
 			placeholderStartIndex: (i + 1) * selectedFiles.length,
 			separator: insertAsMedia ? '\n' : ' ',

--- a/extensions/markdown-language-features/src/languageFeatures/copyFiles/dropOrPasteResource.ts
+++ b/extensions/markdown-language-features/src/languageFeatures/copyFiles/dropOrPasteResource.ts
@@ -106,10 +106,10 @@ class ResourcePasteOrDropProvider implements vscode.DocumentPasteEditProvider, v
 		document: vscode.TextDocument,
 		ranges: readonly vscode.Range[],
 		dataTransfer: vscode.DataTransfer,
-		settings: {
+		settings: Readonly<{
 			insert: InsertMarkdownLink;
 			copyIntoWorkspace: CopyFilesSettings;
-		},
+		}>,
 		context: vscode.DocumentPasteEditContext | undefined,
 		token: vscode.CancellationToken,
 	): Promise<DropOrPasteEdit | undefined> {
@@ -172,7 +172,7 @@ class ResourcePasteOrDropProvider implements vscode.DocumentPasteEditProvider, v
 			}
 		}
 
-		const edit = createInsertUriListEdit(document, ranges, uriList);
+		const edit = createInsertUriListEdit(document, ranges, uriList, { linkKindHint: context?.only });
 		if (!edit) {
 			return;
 		}

--- a/extensions/markdown-language-features/src/languageFeatures/copyFiles/pasteUrlProvider.ts
+++ b/extensions/markdown-language-features/src/languageFeatures/copyFiles/pasteUrlProvider.ts
@@ -29,7 +29,7 @@ class PasteUrlEditProvider implements vscode.DocumentPasteEditProvider {
 		document: vscode.TextDocument,
 		ranges: readonly vscode.Range[],
 		dataTransfer: vscode.DataTransfer,
-		_context: vscode.DocumentPasteEditContext,
+		context: vscode.DocumentPasteEditContext,
 		token: vscode.CancellationToken,
 	): Promise<vscode.DocumentPasteEdit[] | undefined> {
 		const pasteUrlSetting = vscode.workspace.getConfiguration('markdown', document)
@@ -44,12 +44,17 @@ class PasteUrlEditProvider implements vscode.DocumentPasteEditProvider {
 			return;
 		}
 
+		// TODO: If the user has explicitly requested to paste as a markdown link,
+		// try to paste even if we don't have a valid uri
 		const uriText = findValidUriInText(text);
 		if (!uriText) {
 			return;
 		}
 
-		const edit = createInsertUriListEdit(document, ranges, UriList.from(uriText), { preserveAbsoluteUris: true });
+		const edit = createInsertUriListEdit(document, ranges, UriList.from(uriText), {
+			linkKindHint: context.only,
+			preserveAbsoluteUris: true
+		});
 		if (!edit) {
 			return;
 		}


### PR DESCRIPTION
Allows using the `kind` field in the `pasteAs` keybinding to force links to be inserted a certain way, such as as images

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
