### PR TITLE
Restore tab newline fix in editor tabs

### DIFF
--- a/src/vs/workbench/browser/parts/editor/media/editortabscontrol.css
+++ b/src/vs/workbench/browser/parts/editor/media/editortabscontrol.css
@@ -15,6 +15,11 @@
 	flex: 1;
 }
 
+.monaco-workbench .part.editor > .content .editor-group-container > .title .title-label .label-name,
+.monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab .tab-label .label-name {
+	white-space: nowrap;
+}
+
 .monaco-workbench .part.editor > .content .editor-group-container > .title .title-label a,
 .monaco-workbench .part.editor > .content .editor-group-container > .title .tabs-container > .tab .tab-label a {
 	font-size: 13px;


### PR DESCRIPTION
Reintroduce CSS rules to prevent tab labels from wrapping in the editor tabs.

fixes #234336