### PR TITLE
Support drag and drop for symbols in breadcrumbs, outline and chat

### DIFF
--- a/src/vs/platform/dnd/browser/dnd.ts
+++ b/src/vs/platform/dnd/browser/dnd.ts
@@ -30,7 +30,7 @@ import { Registry } from '../../registry/common/platform.js';
 export const CodeDataTransfers = {
 	EDITORS: 'CodeEditors',
 	FILES: 'CodeFiles',
-	SYMBOLS: 'CodeSymbols'
+	SYMBOLS: 'application/vnd.code.symbols'
 };
 
 export interface IDraggedResourceEditorInput extends IBaseTextResourceEditorInput {

--- a/src/vs/platform/dnd/browser/dnd.ts
+++ b/src/vs/platform/dnd/browser/dnd.ts
@@ -29,7 +29,8 @@ import { Registry } from '../../registry/common/platform.js';
 
 export const CodeDataTransfers = {
 	EDITORS: 'CodeEditors',
-	FILES: 'CodeFiles'
+	FILES: 'CodeFiles',
+	SYMBOLS: 'CodeSymbols'
 };
 
 export interface IDraggedResourceEditorInput extends IBaseTextResourceEditorInput {
@@ -398,6 +399,31 @@ export class LocalSelectionTransfer<T> {
 			this.proto = proto;
 		}
 	}
+}
+
+export interface DocumentSymbolTransferData {
+	name: string;
+	fsPath: string;
+	range: {
+		startLineNumber: number;
+		startColumn: number;
+		endLineNumber: number;
+		endColumn: number;
+	};
+	kind: number;
+}
+
+export function extractSymbolDropData(e: DragEvent): DocumentSymbolTransferData[] {
+	const rawSymbolsData = e.dataTransfer?.getData(CodeDataTransfers.SYMBOLS);
+	if (rawSymbolsData) {
+		try {
+			return JSON.parse(rawSymbolsData);
+		} catch (error) {
+			// Invalid transfer
+		}
+	}
+
+	return [];
 }
 
 /**

--- a/src/vs/workbench/browser/parts/editor/breadcrumbsControl.ts
+++ b/src/vs/workbench/browser/parts/editor/breadcrumbsControl.ts
@@ -8,8 +8,8 @@ import { StandardMouseEvent } from '../../../../base/browser/mouseEvent.js';
 import { BreadcrumbsItem, BreadcrumbsWidget, IBreadcrumbsItemEvent, IBreadcrumbsWidgetStyles } from '../../../../base/browser/ui/breadcrumbs/breadcrumbsWidget.js';
 import { timeout } from '../../../../base/common/async.js';
 import { KeyCode, KeyMod } from '../../../../base/common/keyCodes.js';
-import { combinedDisposable, DisposableStore, MutableDisposable, toDisposable } from '../../../../base/common/lifecycle.js';
-import { extUri } from '../../../../base/common/resources.js';
+import { combinedDisposable, DisposableStore, IDisposable, MutableDisposable, toDisposable } from '../../../../base/common/lifecycle.js';
+import { basename, extUri } from '../../../../base/common/resources.js';
 import { URI } from '../../../../base/common/uri.js';
 import './media/breadcrumbscontrol.css';
 import { localize, localize2 } from '../../../../nls.js';
@@ -40,6 +40,11 @@ import { defaultBreadcrumbsWidgetStyles } from '../../../../platform/theme/brows
 import { Emitter } from '../../../../base/common/event.js';
 import { IHoverDelegate } from '../../../../base/browser/ui/hover/hoverDelegate.js';
 import { getDefaultHoverDelegate } from '../../../../base/browser/ui/hover/hoverDelegateFactory.js';
+import { DataTransfers } from '../../../../base/browser/dnd.js';
+import { $ } from '../../../../base/browser/dom.js';
+import { OutlineElement } from '../../../../editor/contrib/documentSymbols/browser/outlineModel.js';
+import { CodeDataTransfers, DocumentSymbolTransferData } from '../../../../platform/dnd/browser/dnd.js';
+import { DocumentSymbol } from '../../../../editor/common/languages.js';
 
 class OutlineItem extends BreadcrumbsItem {
 
@@ -96,8 +101,27 @@ class OutlineItem extends BreadcrumbsItem {
 		}, 0, template, undefined);
 
 		this._disposables.add(toDisposable(() => { renderer.disposeTemplate(template); }));
-	}
 
+		if (element instanceof OutlineElement && outline.uri) {
+			const symbolUri = symbolRangeUri(element.symbol, outline.uri);
+			const symbolTransferData: DocumentSymbolTransferData = {
+				name: element.symbol.name,
+				fsPath: outline.uri.fsPath,
+				range: element.symbol.range,
+				kind: element.symbol.kind
+			};
+			const dataTransfers: DataTransfer[] = [
+				[CodeDataTransfers.SYMBOLS, [symbolTransferData]],
+				[DataTransfers.RESOURCES, [symbolUri]]
+			];
+			this._disposables.add(createBreadcrumbDndObserver(container, element.symbol.name, symbolUri, dataTransfers));
+		}
+	}
+}
+
+function symbolRangeUri(symbol: DocumentSymbol, uri: URI): string {
+	const range = symbol.range;
+	return uri.toString() + `#L${range.startLineNumber},${range.startColumn}-L${range.endLineNumber},${range.endColumn}`;
 }
 
 class FileItem extends BreadcrumbsItem {
@@ -139,7 +163,51 @@ class FileItem extends BreadcrumbsItem {
 		});
 		container.classList.add(FileKind[this.element.kind].toLowerCase());
 		this._disposables.add(label);
+
+		const dataTransfers: DataTransfer[] = [
+			[CodeDataTransfers.FILES, [this.element.uri.fsPath]],
+			[DataTransfers.RESOURCES, [this.element.uri.toString()]],
+		];
+		const dndObserver = createBreadcrumbDndObserver(container, basename(this.element.uri), this.element.uri.toString(), dataTransfers);
+		this._disposables.add(dndObserver);
 	}
+}
+
+type DataTransfer = [string, any[]];
+
+function createBreadcrumbDndObserver(container: HTMLElement, label: string, textData: string, dataTransfers: DataTransfer[]): IDisposable {
+	container.draggable = true;
+
+	return new dom.DragAndDropObserver(container, {
+		onDragStart: event => {
+			if (!event.dataTransfer) {
+				return;
+			}
+
+			// Set data transfer
+			event.dataTransfer.effectAllowed = 'copyMove';
+			event.dataTransfer.setData(DataTransfers.TEXT, textData);
+			for (const [type, data] of dataTransfers) {
+				event.dataTransfer.setData(type, JSON.stringify(data));
+			}
+
+			// Create drag image and remove when dropped
+			const dragImage = $('.monaco-drag-image');
+			dragImage.textContent = label;
+
+			const getDragImageContainer = (e: HTMLElement | null) => {
+				while (e && !e.classList.contains('monaco-workbench')) {
+					e = e.parentElement;
+				}
+				return e || container.ownerDocument;
+			};
+
+			const dragContainer = getDragImageContainer(container);
+			dragContainer.appendChild(dragImage);
+			event.dataTransfer.setDragImage(dragImage, -10, -10);
+			setTimeout(() => dragImage.remove(), 0);
+		}
+	});
 }
 
 export interface IBreadcrumbsControlOptions {

--- a/src/vs/workbench/browser/parts/editor/breadcrumbsControl.ts
+++ b/src/vs/workbench/browser/parts/editor/breadcrumbsControl.ts
@@ -44,7 +44,7 @@ import { DataTransfers } from '../../../../base/browser/dnd.js';
 import { $ } from '../../../../base/browser/dom.js';
 import { OutlineElement } from '../../../../editor/contrib/documentSymbols/browser/outlineModel.js';
 import { CodeDataTransfers, DocumentSymbolTransferData } from '../../../../platform/dnd/browser/dnd.js';
-import { DocumentSymbol } from '../../../../editor/common/languages.js';
+import { withSelection } from '../../../../platform/opener/common/opener.js';
 
 class OutlineItem extends BreadcrumbsItem {
 
@@ -103,7 +103,7 @@ class OutlineItem extends BreadcrumbsItem {
 		this._disposables.add(toDisposable(() => { renderer.disposeTemplate(template); }));
 
 		if (element instanceof OutlineElement && outline.uri) {
-			const symbolUri = symbolRangeUri(element.symbol, outline.uri);
+			const symbolUri = withSelection(outline.uri, element.symbol.range);
 			const symbolTransferData: DocumentSymbolTransferData = {
 				name: element.symbol.name,
 				fsPath: outline.uri.fsPath,
@@ -114,14 +114,9 @@ class OutlineItem extends BreadcrumbsItem {
 				[CodeDataTransfers.SYMBOLS, [symbolTransferData]],
 				[DataTransfers.RESOURCES, [symbolUri]]
 			];
-			this._disposables.add(createBreadcrumbDndObserver(container, element.symbol.name, symbolUri, dataTransfers));
+			this._disposables.add(createBreadcrumbDndObserver(container, element.symbol.name, symbolUri.toString(), dataTransfers));
 		}
 	}
-}
-
-function symbolRangeUri(symbol: DocumentSymbol, uri: URI): string {
-	const range = symbol.range;
-	return uri.toString() + `#L${range.startLineNumber},${range.startColumn}-L${range.endLineNumber},${range.endColumn}`;
 }
 
 class FileItem extends BreadcrumbsItem {

--- a/src/vs/workbench/contrib/codeEditor/browser/outline/documentSymbolsOutline.ts
+++ b/src/vs/workbench/contrib/codeEditor/browser/outline/documentSymbolsOutline.ts
@@ -170,7 +170,7 @@ class DocumentSymbolsOutline implements IOutline<DocumentSymbolItem> {
 				: target === OutlineTarget.Breadcrumbs
 					? instantiationService.createInstance(DocumentSymbolFilter, 'breadcrumbs')
 					: undefined,
-			dnd: new DocumentSymbolDragAndDrop(() => this._outlineModel),
+			dnd: new DocumentSymbolDragAndDrop(),
 		};
 
 		this.config = {

--- a/src/vs/workbench/contrib/codeEditor/browser/outline/documentSymbolsOutline.ts
+++ b/src/vs/workbench/contrib/codeEditor/browser/outline/documentSymbolsOutline.ts
@@ -10,7 +10,7 @@ import { IWorkbenchContributionsRegistry, Extensions as WorkbenchExtensions } fr
 import { Registry } from '../../../../../platform/registry/common/platform.js';
 import { LifecyclePhase } from '../../../../services/lifecycle/common/lifecycle.js';
 import { IEditorPane } from '../../../../common/editor.js';
-import { DocumentSymbolComparator, DocumentSymbolAccessibilityProvider, DocumentSymbolRenderer, DocumentSymbolFilter, DocumentSymbolGroupRenderer, DocumentSymbolIdentityProvider, DocumentSymbolNavigationLabelProvider, DocumentSymbolVirtualDelegate } from './documentSymbolsTree.js';
+import { DocumentSymbolComparator, DocumentSymbolAccessibilityProvider, DocumentSymbolRenderer, DocumentSymbolFilter, DocumentSymbolGroupRenderer, DocumentSymbolIdentityProvider, DocumentSymbolNavigationLabelProvider, DocumentSymbolVirtualDelegate, DocumentSymbolDragAndDrop } from './documentSymbolsTree.js';
 import { ICodeEditor, isCodeEditor, isDiffEditor } from '../../../../../editor/browser/editorBrowser.js';
 import { OutlineGroup, OutlineElement, OutlineModel, TreeElement, IOutlineMarker, IOutlineModelService } from '../../../../../editor/contrib/documentSymbols/browser/outlineModel.js';
 import { CancellationToken, CancellationTokenSource } from '../../../../../base/common/cancellation.js';
@@ -169,7 +169,8 @@ class DocumentSymbolsOutline implements IOutline<DocumentSymbolItem> {
 				? instantiationService.createInstance(DocumentSymbolFilter, 'outline')
 				: target === OutlineTarget.Breadcrumbs
 					? instantiationService.createInstance(DocumentSymbolFilter, 'breadcrumbs')
-					: undefined
+					: undefined,
+			dnd: new DocumentSymbolDragAndDrop(() => this._outlineModel),
 		};
 
 		this.config = {

--- a/src/vs/workbench/contrib/codeEditor/browser/outline/documentSymbolsTree.ts
+++ b/src/vs/workbench/contrib/codeEditor/browser/outline/documentSymbolsTree.ts
@@ -67,10 +67,10 @@ export class DocumentSymbolIdentityProvider implements IIdentityProvider<Documen
 
 export class DocumentSymbolDragAndDrop implements ITreeDragAndDrop<DocumentSymbolItem> {
 
-	constructor(private readonly _modelProvider: () => OutlineModel | undefined) { }
+	constructor() { }
 
 	getDragURI(element: DocumentSymbolItem): string | null {
-		const resource = this._modelProvider()?.uri;
+		const resource = OutlineModel.get(element)?.uri;
 		if (!resource) {
 			return null;
 		}
@@ -99,7 +99,7 @@ export class DocumentSymbolDragAndDrop implements ITreeDragAndDrop<DocumentSymbo
 			return;
 		}
 
-		const resource = this._modelProvider()?.uri;
+		const resource = OutlineModel.get(item)?.uri;
 		if (!resource) {
 			return;
 		}

--- a/src/vs/workbench/contrib/codeEditor/browser/outline/documentSymbolsTree.ts
+++ b/src/vs/workbench/contrib/codeEditor/browser/outline/documentSymbolsTree.ts
@@ -26,8 +26,9 @@ import { ThemeIcon } from '../../../../../base/common/themables.js';
 import { mainWindow } from '../../../../../base/browser/window.js';
 import { IDragAndDropData, DataTransfers } from '../../../../../base/browser/dnd.js';
 import { ElementsDragAndDropData } from '../../../../../base/browser/ui/list/listView.js';
-import { URI } from '../../../../../base/common/uri.js';
 import { CodeDataTransfers } from '../../../../../platform/dnd/browser/dnd.js';
+import { withSelection } from '../../../../../platform/opener/common/opener.js';
+import { URI } from '../../../../../base/common/uri.js';
 
 export type DocumentSymbolItem = OutlineGroup | OutlineElement;
 
@@ -75,7 +76,7 @@ export class DocumentSymbolDragAndDrop implements ITreeDragAndDrop<DocumentSymbo
 		}
 
 		if (element instanceof OutlineElement) {
-			return symbolRangeUri(element.symbol, resource);
+			return symbolRangeUri(resource, element.symbol).toString();
 		} else {
 			return resource.toString();
 		}
@@ -112,7 +113,7 @@ export class DocumentSymbolDragAndDrop implements ITreeDragAndDrop<DocumentSymbo
 		}));
 
 		originalEvent.dataTransfer.setData(CodeDataTransfers.SYMBOLS, JSON.stringify(symbolsData));
-		originalEvent.dataTransfer.setData(DataTransfers.RESOURCES, JSON.stringify(outlineElements.map(oe => symbolRangeUri(oe.symbol, resource))));
+		originalEvent.dataTransfer.setData(DataTransfers.RESOURCES, JSON.stringify(outlineElements.map(oe => symbolRangeUri(resource, oe.symbol))));
 	}
 
 	onDragOver(): boolean | ITreeDragOverReaction { return false; }
@@ -120,9 +121,8 @@ export class DocumentSymbolDragAndDrop implements ITreeDragAndDrop<DocumentSymbo
 	dispose(): void { }
 }
 
-export function symbolRangeUri(symbol: DocumentSymbol, uri: URI): string {
-	const range = symbol.range;
-	return uri.toString() + `#L${range.startLineNumber},${range.startColumn}-L${range.endLineNumber},${range.endColumn}`;
+function symbolRangeUri(resource: URI, symbol: DocumentSymbol): URI {
+	return withSelection(resource, symbol.range);
 }
 
 class DocumentSymbolGroupTemplate {


### PR DESCRIPTION
Implement drag and drop functionality for symbols, allowing users to interact with symbols in breadcrumbs and chat.