### PR TITLE
`handle: string` to `nativeHandle: UInt8Array` based on feedback

### DIFF
--- a/extensions/microsoft-authentication/src/node/authProvider.ts
+++ b/extensions/microsoft-authentication/src/node/authProvider.ts
@@ -190,7 +190,7 @@ export class MsalAuthProvider implements AuthenticationProvider {
 		let result: AuthenticationResult | undefined;
 
 		try {
-			const windowHandle = env.handle ? Buffer.from(env.handle, 'base64') : undefined;
+			const windowHandle = env.nativeHandle ? Buffer.from(env.nativeHandle) : undefined;
 			result = await cachedPca.acquireTokenInteractive({
 				openBrowser: async (url: string) => { await env.openExternal(Uri.parse(url)); },
 				scopes: scopeData.scopesToSend,
@@ -232,7 +232,7 @@ export class MsalAuthProvider implements AuthenticationProvider {
 			// The user wants to try the loopback client or we got an error likely due to spinning up the server
 			const loopbackClient = new UriHandlerLoopbackClient(this._uriHandler, redirectUri, this._logger);
 			try {
-				const windowHandle = env.handle ? Buffer.from(env.handle) : undefined;
+				const windowHandle = env.nativeHandle ? Buffer.from(env.nativeHandle) : undefined;
 				result = await cachedPca.acquireTokenInteractive({
 					openBrowser: (url: string) => loopbackClient.openBrowser(url),
 					scopes: scopeData.scopesToSend,

--- a/src/vs/platform/window/common/window.ts
+++ b/src/vs/platform/window/common/window.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { VSBuffer } from '../../../base/common/buffer.js';
 import { IStringDictionary } from '../../../base/common/collections.js';
 import { PerformanceMark } from '../../../base/common/performance.js';
 import { isLinux, isMacintosh, isNative, isWeb } from '../../../base/common/platform.js';
@@ -355,7 +356,7 @@ export interface IOSConfiguration {
 
 export interface INativeWindowConfiguration extends IWindowConfiguration, NativeParsedArgs, ISandboxConfiguration {
 	mainPid: number;
-	handle?: string;
+	handle?: VSBuffer;
 
 	machineId: string;
 	sqmId: string;

--- a/src/vs/platform/windows/electron-main/windowImpl.ts
+++ b/src/vs/platform/windows/electron-main/windowImpl.ts
@@ -43,6 +43,7 @@ import { IStateService } from '../../state/node/state.js';
 import { IUserDataProfilesMainService } from '../../userDataProfile/electron-main/userDataProfile.js';
 import { ILoggerMainService } from '../../log/electron-main/loggerService.js';
 import { IInstantiationService } from '../../instantiation/common/instantiation.js';
+import { VSBuffer } from '../../../base/common/buffer.js';
 
 export interface IWindowCreationOptions {
 	readonly state: IWindowState;
@@ -1093,7 +1094,7 @@ export class CodeWindow extends BaseWindow implements ICodeWindow {
 
 		// Update window related properties
 		try {
-			configuration.handle = this._win.getNativeWindowHandle().toString('base64');
+			configuration.handle = VSBuffer.wrap(this._win.getNativeWindowHandle());
 		} catch (error) {
 			this.logService.error(`Error getting native window handle: ${error}`);
 		}

--- a/src/vs/workbench/api/common/extHost.api.impl.ts
+++ b/src/vs/workbench/api/common/extHost.api.impl.ts
@@ -437,9 +437,9 @@ export function createApiFactoryAndRegisterActors(accessor: ServicesAccessor): I
 				checkProposedApiEnabled(extension, 'resolvers');
 				return initData.commit;
 			},
-			get handle(): string | undefined {
+			get nativeHandle(): Uint8Array | undefined {
 				checkProposedApiEnabled(extension, 'nativeWindowHandle');
-				return initData.handle;
+				return extHostWindow.nativeHandle;
 			}
 		};
 		if (!initData.environment.extensionTestsLocationURI) {

--- a/src/vs/workbench/api/common/extHostWindow.ts
+++ b/src/vs/workbench/api/common/extHostWindow.ts
@@ -11,6 +11,8 @@ import { createDecorator } from '../../../platform/instantiation/common/instanti
 import { IExtHostRpcService } from './extHostRpcService.js';
 import { WindowState } from 'vscode';
 import { ExtHostWindowShape, IOpenUriOptions, MainContext, MainThreadWindowShape } from './extHost.protocol.js';
+import { IExtHostInitDataService } from './extHostInitDataService.js';
+import { decodeBase64 } from '../../../base/common/buffer.js';
 
 export class ExtHostWindow implements ExtHostWindowShape {
 
@@ -24,6 +26,7 @@ export class ExtHostWindow implements ExtHostWindowShape {
 	private readonly _onDidChangeWindowState = new Emitter<WindowState>();
 	readonly onDidChangeWindowState: Event<WindowState> = this._onDidChangeWindowState.event;
 
+	private _nativeHandle: Uint8Array | undefined;
 	private _state = ExtHostWindow.InitialState;
 
 	getState(): WindowState {
@@ -40,12 +43,22 @@ export class ExtHostWindow implements ExtHostWindowShape {
 		};
 	}
 
-	constructor(@IExtHostRpcService extHostRpc: IExtHostRpcService) {
+	constructor(
+		@IExtHostInitDataService initData: IExtHostInitDataService,
+		@IExtHostRpcService extHostRpc: IExtHostRpcService
+	) {
+		if (initData.handle) {
+			this._nativeHandle = decodeBase64(initData.handle).buffer;
+		}
 		this._proxy = extHostRpc.getProxy(MainContext.MainThreadWindow);
 		this._proxy.$getInitialState().then(({ isFocused, isActive }) => {
 			this.onDidChangeWindowProperty('focused', isFocused);
 			this.onDidChangeWindowProperty('active', isActive);
 		});
+	}
+
+	get nativeHandle(): Uint8Array | undefined {
+		return this._nativeHandle;
 	}
 
 	$onDidChangeWindowFocus(value: boolean) {

--- a/src/vs/workbench/services/environment/electron-sandbox/environmentService.ts
+++ b/src/vs/workbench/services/environment/electron-sandbox/environmentService.ts
@@ -14,6 +14,7 @@ import { URI } from '../../../../base/common/uri.js';
 import { Schemas } from '../../../../base/common/network.js';
 import { IProductService } from '../../../../platform/product/common/productService.js';
 import { joinPath } from '../../../../base/common/resources.js';
+import { VSBuffer } from '../../../../base/common/buffer.js';
 
 export const INativeWorkbenchEnvironmentService = refineServiceDecorator<IEnvironmentService, INativeWorkbenchEnvironmentService>(IEnvironmentService);
 
@@ -26,7 +27,7 @@ export interface INativeWorkbenchEnvironmentService extends IBrowserWorkbenchEnv
 	// --- Window
 	readonly window: {
 		id: number;
-		handle?: string;
+		handle?: VSBuffer;
 		colorScheme: IColorScheme;
 		maximized?: boolean;
 		accessibilitySupport?: boolean;

--- a/src/vs/workbench/services/extensions/electron-sandbox/localProcessExtensionHost.ts
+++ b/src/vs/workbench/services/extensions/electron-sandbox/localProcessExtensionHost.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { timeout } from '../../../../base/common/async.js';
-import { VSBuffer } from '../../../../base/common/buffer.js';
+import { encodeBase64, VSBuffer } from '../../../../base/common/buffer.js';
 import { CancellationError } from '../../../../base/common/errors.js';
 import { Emitter, Event } from '../../../../base/common/event.js';
 import { DisposableStore, toDisposable } from '../../../../base/common/lifecycle.js';
@@ -512,7 +512,7 @@ export class NativeLocalProcessExtensionHost implements IExtensionHost {
 			logsLocation: this._environmentService.extHostLogsPath,
 			autoStart: (this.startup === ExtensionHostStartup.EagerAutoStart),
 			uiKind: UIKind.Desktop,
-			handle: this._environmentService.window.handle
+			handle: this._environmentService.window.handle ? encodeBase64(this._environmentService.window.handle) : undefined
 		};
 	}
 

--- a/src/vscode-dts/vscode.proposed.nativeWindowHandle.d.ts
+++ b/src/vscode-dts/vscode.proposed.nativeWindowHandle.d.ts
@@ -9,9 +9,9 @@ declare module 'vscode' {
 
 	export namespace env {
 		/**
-		 * Retrieves a base64 representation of a native window
-		 * handle of the current window.
+		 * Retrieves the native window handle of the current active window.
+		 * The current active window may not be associated with this extension host.
 		 */
-		export const handle: string | undefined;
+		export const nativeHandle: Uint8Array | undefined;
 	}
 }


### PR DESCRIPTION
Feedback in https://github.com/microsoft/vscode/issues/229431

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Extra tricky because UInt8Array's don't serialize nicely... and VSBuffers do, but only between Main and Window....

So we use VSBuffer between Main & Window and then a base64 encoded string between Window and the ExtHost.

Ultimately handing off a UInt8Array to the extension.