### PR TITLE
remote: broaden URI identification on openExternal

### DIFF
--- a/src/vs/server/node/server.cli.ts
+++ b/src/vs/server/node/server.cli.ts
@@ -375,7 +375,7 @@ function openInBrowser(args: string[], verbose: boolean) {
 	const uris: string[] = [];
 	for (const location of args) {
 		try {
-			if (/^(http|https|file):\/\//.test(location)) {
+			if (/^[a-z-]+:\/\/.+/.test(location)) {
 				uris.push(url.parse(location).href);
 			} else {
 				uris.push(pathToURI(location).href);


### PR DESCRIPTION
I want to protocol-activate copilot in a remote workspace using
openExternal, but I observed the URI was being treated as a path and
malformed. This change broadens the URI identification logic to accept
anything that looks like a protocol. I think this is okay since we
were already excluding file URIs from the rebase, so this really just
impacts any other esoteric URIs in addition to the product `urlProtocol`.

fyi @alexdima

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
