### PR TITLE
debug: cleanup welcome view actions

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/debugConfigurationManager.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugConfigurationManager.ts
@@ -28,7 +28,7 @@ import { IUriIdentityService } from '../../../../platform/uriIdentity/common/uri
 import { IWorkspaceContextService, IWorkspaceFolder, IWorkspaceFoldersChangeEvent, WorkbenchState } from '../../../../platform/workspace/common/workspace.js';
 import { IEditorPane } from '../../../common/editor.js';
 import { debugConfigure } from './debugIcons.js';
-import { CONTEXT_DEBUG_CONFIGURATION_TYPE, DebugConfigurationProviderTriggerKind, IAdapterManager, ICompound, IConfig, IConfigPresentation, IConfigurationManager, IDebugConfigurationProvider, IGlobalConfig, ILaunch } from '../common/debug.js';
+import { CONTEXT_DEBUG_CONFIGURATION_TYPE, DebugConfigurationProviderTriggerKind, IAdapterManager, ICompound, IConfig, IConfigPresentation, IConfigurationManager, IDebugConfigurationProvider, IGlobalConfig, IGuessedDebugger, ILaunch } from '../common/debug.js';
 import { launchSchema } from '../common/debugSchemas.js';
 import { getVisibleAndSorted } from '../common/debugUtils.js';
 import { launchSchemaId } from '../../../services/configuration/common/configuration.js';
@@ -46,6 +46,7 @@ const DEBUG_SELECTED_ROOT = 'debug.selectedroot';
 // Debug type is only stored if a dynamic configuration is used for better restore
 const DEBUG_SELECTED_TYPE = 'debug.selectedtype';
 const DEBUG_RECENT_DYNAMIC_CONFIGURATIONS = 'debug.recentdynamicconfigurations';
+const ON_DEBUG_DYNAMIC_CONFIGURATIONS_NAME = 'onDebugDynamicConfigurations';
 
 interface IDynamicPickItem { label: string; launch: ILaunch; config: IConfig }
 
@@ -174,9 +175,8 @@ export class ConfigurationManager implements IConfigurationManager {
 		return results.reduce((first, second) => first.concat(second), []);
 	}
 
-	async getDynamicProviders(): Promise<{ label: string; type: string; getProvider: () => Promise<IDebugConfigurationProvider | undefined>; pick: () => Promise<{ launch: ILaunch; config: IConfig } | undefined> }[]> {
+	async getDynamicProviders(): Promise<{ label: string; type: string; getProvider: () => Promise<IDebugConfigurationProvider | undefined>; pick: () => Promise<{ launch: ILaunch; config: IConfig; label: string } | undefined> }[]> {
 		await this.extensionService.whenInstalledExtensionsRegistered();
-		const onDebugDynamicConfigurationsName = 'onDebugDynamicConfigurations';
 		const debugDynamicExtensionsTypes = this.extensionService.extensions.reduce((acc, e) => {
 			if (!e.activationEvents) {
 				return acc;
@@ -185,10 +185,10 @@ export class ConfigurationManager implements IConfigurationManager {
 			const explicitTypes: string[] = [];
 			let hasGenericEvent = false;
 			for (const event of e.activationEvents) {
-				if (event === onDebugDynamicConfigurationsName) {
+				if (event === ON_DEBUG_DYNAMIC_CONFIGURATIONS_NAME) {
 					hasGenericEvent = true;
-				} else if (event.startsWith(`${onDebugDynamicConfigurationsName}:`)) {
-					explicitTypes.push(event.slice(onDebugDynamicConfigurationsName.length + 1));
+				} else if (event.startsWith(`${ON_DEBUG_DYNAMIC_CONFIGURATIONS_NAME}:`)) {
+					explicitTypes.push(event.slice(ON_DEBUG_DYNAMIC_CONFIGURATIONS_NAME.length + 1));
 				}
 			}
 
@@ -214,33 +214,17 @@ export class ConfigurationManager implements IConfigurationManager {
 			return {
 				label: this.adapterManager.getDebuggerLabel(type)!,
 				getProvider: async () => {
-					await this.adapterManager.activateDebuggers(onDebugDynamicConfigurationsName, type);
+					await this.adapterManager.activateDebuggers(ON_DEBUG_DYNAMIC_CONFIGURATIONS_NAME, type);
 					return this.configProviders.find(p => p.type === type && p.triggerKind === DebugConfigurationProviderTriggerKind.Dynamic && p.provideDebugConfigurations);
 				},
 				type,
 				pick: async () => {
 					// Do a late 'onDebugDynamicConfigurationsName' activation so extensions are not activated too early #108578
-					await this.adapterManager.activateDebuggers(onDebugDynamicConfigurationsName, type);
-
-					const token = new CancellationTokenSource();
-					const picks: Promise<IDynamicPickItem[]>[] = [];
-					const provider = this.configProviders.find(p => p.type === type && p.triggerKind === DebugConfigurationProviderTriggerKind.Dynamic && p.provideDebugConfigurations);
-					this.getLaunches().forEach(launch => {
-						if (provider) {
-							picks.push(provider.provideDebugConfigurations!(launch.workspace?.uri, token.token).then(configurations => configurations.map(config => ({
-								label: config.name,
-								description: launch.name,
-								config,
-								buttons: [{
-									iconClass: ThemeIcon.asClassName(debugConfigure),
-									tooltip: nls.localize('editLaunchConfig', "Edit Debug Configuration in launch.json")
-								}],
-								launch
-							}))));
-						}
-					});
+					await this.adapterManager.activateDebuggers(ON_DEBUG_DYNAMIC_CONFIGURATIONS_NAME, type);
 
 					const disposables = new DisposableStore();
+					const token = new CancellationTokenSource();
+					disposables.add(token);
 					const input = disposables.add(this.quickInputService.createQuickPick<IDynamicPickItem>());
 					input.busy = true;
 					input.placeholder = nls.localize('selectConfiguration', "Select Launch Configuration");
@@ -257,39 +241,54 @@ export class ConfigurationManager implements IConfigurationManager {
 							this.removeRecentDynamicConfigurations(config.name, config.type);
 						}));
 						disposables.add(input.onDidHide(() => resolve(undefined)));
-					});
+					}).finally(() => token.cancel());
 
-					let nestedPicks: IDynamicPickItem[][];
+					let items: IDynamicPickItem[];
 					try {
 						// This await invokes the extension providers, which might fail due to several reasons,
 						// therefore we gate this logic under a try/catch to prevent leaving the Debug Tab
 						// selector in a borked state.
-						nestedPicks = await Promise.all(picks);
+						items = await this.getDynamicConfigurationsByType(type, token.token);
 					} catch (err) {
 						this.logService.error(err);
 						disposables.dispose();
 						return;
 					}
 
-					const items = nestedPicks.flat();
-
 					input.items = items;
 					input.busy = false;
 					input.show();
 					const chosen = await chosenPromise;
-
 					disposables.dispose();
-
-					if (!chosen) {
-						// User canceled quick input we should notify the provider to cancel computing configurations
-						token.cancel();
-						return;
-					}
 
 					return chosen;
 				}
 			};
 		});
+	}
+
+	async getDynamicConfigurationsByType(type: string, token: CancellationToken = CancellationToken.None): Promise<IDynamicPickItem[]> {
+		// Do a late 'onDebugDynamicConfigurationsName' activation so extensions are not activated too early #108578
+		await this.adapterManager.activateDebuggers(ON_DEBUG_DYNAMIC_CONFIGURATIONS_NAME, type);
+
+		const picks: Promise<IDynamicPickItem[]>[] = [];
+		const provider = this.configProviders.find(p => p.type === type && p.triggerKind === DebugConfigurationProviderTriggerKind.Dynamic && p.provideDebugConfigurations);
+		this.getLaunches().forEach(launch => {
+			if (provider) {
+				picks.push(provider.provideDebugConfigurations!(launch.workspace?.uri, token).then(configurations => configurations.map(config => ({
+					label: config.name,
+					description: launch.name,
+					config,
+					buttons: [{
+						iconClass: ThemeIcon.asClassName(debugConfigure),
+						tooltip: nls.localize('editLaunchConfig', "Edit Debug Configuration in launch.json")
+					}],
+					launch
+				}))));
+			}
+		});
+
+		return (await Promise.all(picks)).flat();
 	}
 
 	getAllConfigurations(): { launch: ILaunch; name: string; presentation?: IConfigPresentation }[] {
@@ -560,13 +559,19 @@ abstract class AbstractLaunch implements ILaunch {
 
 	async getInitialConfigurationContent(folderUri?: uri, type?: string, useInitialConfigs?: boolean, token?: CancellationToken): Promise<string> {
 		let content = '';
-		const adapter = type ? this.adapterManager.getEnabledDebugger(type) : await this.adapterManager.guessDebugger(true);
-		if (adapter) {
+		const adapter: Partial<IGuessedDebugger> | undefined = type
+			? { debugger: this.adapterManager.getEnabledDebugger(type) }
+			: await this.adapterManager.guessDebugger(true);
+
+		if (adapter?.withConfig && adapter.debugger) {
+			content = await adapter.debugger.getInitialConfigurationContent([adapter.withConfig.config]);
+		} else if (adapter?.debugger) {
 			const initialConfigs = useInitialConfigs ?
-				await this.configurationManager.provideDebugConfigurations(folderUri, adapter.type, token || CancellationToken.None) :
+				await this.configurationManager.provideDebugConfigurations(folderUri, adapter.debugger.type, token || CancellationToken.None) :
 				[];
-			content = await adapter.getInitialConfigurationContent(initialConfigs);
+			content = await adapter.debugger.getInitialConfigurationContent(initialConfigs);
 		}
+
 		return content;
 	}
 

--- a/src/vs/workbench/contrib/debug/browser/debugViewlet.ts
+++ b/src/vs/workbench/contrib/debug/browser/debugViewlet.ts
@@ -30,10 +30,11 @@ import { DEBUG_CONFIGURE_COMMAND_ID, DEBUG_CONFIGURE_LABEL, DEBUG_START_COMMAND_
 import { debugConfigure } from './debugIcons.js';
 import { createDisconnectMenuItemAction } from './debugToolBar.js';
 import { WelcomeView } from './welcomeView.js';
-import { BREAKPOINTS_VIEW_ID, CONTEXT_DEBUGGERS_AVAILABLE, CONTEXT_DEBUG_STATE, CONTEXT_DEBUG_UX, CONTEXT_DEBUG_UX_KEY, getStateLabel, IDebugService, ILaunch, REPL_VIEW_ID, State, VIEWLET_ID } from '../common/debug.js';
+import { BREAKPOINTS_VIEW_ID, CONTEXT_DEBUGGERS_AVAILABLE, CONTEXT_DEBUG_STATE, CONTEXT_DEBUG_UX, CONTEXT_DEBUG_UX_KEY, getStateLabel, IDebugService, ILaunch, REPL_VIEW_ID, State, VIEWLET_ID, EDITOR_CONTRIBUTION_ID, IDebugEditorContribution } from '../common/debug.js';
 import { IExtensionService } from '../../../services/extensions/common/extensions.js';
 import { IWorkbenchLayoutService } from '../../../services/layout/browser/layoutService.js';
 import { IBaseActionViewItemOptions } from '../../../../base/browser/ui/actionbar/actionViewItems.js';
+import { ICodeEditor } from '../../../../editor/browser/editorBrowser.js';
 
 export class DebugViewPaneContainer extends ViewPaneContainer {
 
@@ -223,7 +224,7 @@ registerAction2(class extends Action2 {
 		});
 	}
 
-	async run(accessor: ServicesAccessor): Promise<void> {
+	async run(accessor: ServicesAccessor, opts?: { addNew?: boolean }): Promise<void> {
 		const debugService = accessor.get(IDebugService);
 		const quickInputService = accessor.get(IQuickInputService);
 		const configurationManager = debugService.getConfigurationManager();
@@ -247,7 +248,13 @@ registerAction2(class extends Action2 {
 		}
 
 		if (launch) {
-			await launch.openConfigFile({ preserveFocus: false });
+			const { editor } = await launch.openConfigFile({ preserveFocus: false });
+			if (editor && opts?.addNew) {
+				const codeEditor = <ICodeEditor>editor.getControl();
+				if (codeEditor) {
+					await codeEditor.getContribution<IDebugEditorContribution>(EDITOR_CONTRIBUTION_ID)?.addLaunchConfiguration();
+				}
+			}
 		}
 	}
 });

--- a/src/vs/workbench/contrib/debug/browser/welcomeView.ts
+++ b/src/vs/workbench/contrib/debug/browser/welcomeView.ts
@@ -3,30 +3,30 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { IViewletViewOptions } from '../../../browser/parts/views/viewsViewlet.js';
-import { IThemeService } from '../../../../platform/theme/common/themeService.js';
-import { IKeybindingService } from '../../../../platform/keybinding/common/keybinding.js';
-import { IContextMenuService } from '../../../../platform/contextview/browser/contextView.js';
-import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
-import { IContextKeyService, RawContextKey, IContextKey, ContextKeyExpr } from '../../../../platform/contextkey/common/contextkey.js';
-import { localize, localize2 } from '../../../../nls.js';
-import { IDebugService, CONTEXT_DEBUGGERS_AVAILABLE, CONTEXT_DEBUG_EXTENSION_AVAILABLE } from '../common/debug.js';
-import { IEditorService } from '../../../services/editor/common/editorService.js';
-import { ViewPane } from '../../../browser/parts/views/viewPane.js';
-import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
-import { IViewDescriptorService, IViewsRegistry, Extensions, ViewContentGroups } from '../../../common/views.js';
-import { Registry } from '../../../../platform/registry/common/platform.js';
-import { IOpenerService } from '../../../../platform/opener/common/opener.js';
-import { WorkbenchStateContext } from '../../../common/contextkeys.js';
-import { OpenFolderAction, OpenFileAction, OpenFileFolderAction } from '../../../browser/actions/workspaceActions.js';
+import { DisposableStore } from '../../../../base/common/lifecycle.js';
 import { isMacintosh, isWeb } from '../../../../base/common/platform.js';
 import { isCodeEditor, isDiffEditor } from '../../../../editor/browser/editorBrowser.js';
+import { localize, localize2 } from '../../../../nls.js';
+import { ILocalizedString } from '../../../../platform/action/common/action.js';
+import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
+import { ContextKeyExpr, IContextKey, IContextKeyService, RawContextKey } from '../../../../platform/contextkey/common/contextkey.js';
+import { IContextMenuService } from '../../../../platform/contextview/browser/contextView.js';
+import { IHoverService } from '../../../../platform/hover/browser/hover.js';
+import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
+import { IKeybindingService } from '../../../../platform/keybinding/common/keybinding.js';
+import { IOpenerService } from '../../../../platform/opener/common/opener.js';
+import { Registry } from '../../../../platform/registry/common/platform.js';
 import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
 import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
-import { DisposableStore } from '../../../../base/common/lifecycle.js';
-import { SELECT_AND_START_ID, DEBUG_CONFIGURE_COMMAND_ID, DEBUG_START_COMMAND_ID } from './debugCommands.js';
-import { ILocalizedString } from '../../../../platform/action/common/action.js';
-import { IHoverService } from '../../../../platform/hover/browser/hover.js';
+import { IThemeService } from '../../../../platform/theme/common/themeService.js';
+import { OpenFileAction, OpenFileFolderAction, OpenFolderAction } from '../../../browser/actions/workspaceActions.js';
+import { ViewPane } from '../../../browser/parts/views/viewPane.js';
+import { IViewletViewOptions } from '../../../browser/parts/views/viewsViewlet.js';
+import { WorkbenchStateContext } from '../../../common/contextkeys.js';
+import { Extensions, IViewDescriptorService, IViewsRegistry, ViewContentGroups } from '../../../common/views.js';
+import { IEditorService } from '../../../services/editor/common/editorService.js';
+import { CONTEXT_DEBUGGERS_AVAILABLE, CONTEXT_DEBUG_EXTENSION_AVAILABLE, IDebugService } from '../common/debug.js';
+import { DEBUG_CONFIGURE_COMMAND_ID, DEBUG_START_COMMAND_ID } from './debugCommands.js';
 
 const debugStartLanguageKey = 'debugStartLanguage';
 const CONTEXT_DEBUG_START_LANGUAGE = new RawContextKey<string>(debugStartLanguageKey, undefined);
@@ -142,13 +142,6 @@ viewsRegistry.registerViewWelcomeContent(WelcomeView.ID, {
 });
 
 viewsRegistry.registerViewWelcomeContent(WelcomeView.ID, {
-	content: `[${localize('detectThenRunAndDebug', "Show all automatic debug configurations")}](command:${SELECT_AND_START_ID}).`,
-	when: CONTEXT_DEBUGGERS_AVAILABLE,
-	group: ViewContentGroups.Debug,
-	order: 10
-});
-
-viewsRegistry.registerViewWelcomeContent(WelcomeView.ID, {
 	content: localize(
 		{
 			key: 'customizeRunAndDebug',
@@ -157,7 +150,7 @@ viewsRegistry.registerViewWelcomeContent(WelcomeView.ID, {
 				'{Locked="](command:{0})"}'
 			]
 		},
-		"To customize Run and Debug [create a launch.json file](command:{0}).", DEBUG_CONFIGURE_COMMAND_ID),
+		"To customize Run and Debug [create a launch.json file](command:{0}).", `${DEBUG_CONFIGURE_COMMAND_ID}?${encodeURIComponent(JSON.stringify([{ addNew: true }]))}`),
 	when: ContextKeyExpr.and(CONTEXT_DEBUGGERS_AVAILABLE, WorkbenchStateContext.notEqualsTo('empty')),
 	group: ViewContentGroups.Debug
 });

--- a/src/vs/workbench/contrib/debug/common/debug.ts
+++ b/src/vs/workbench/contrib/debug/common/debug.ts
@@ -1018,7 +1018,8 @@ export interface IConfigurationManager {
 	onDidChangeConfigurationProviders: Event<void>;
 
 	hasDebugConfigurationProvider(debugType: string, triggerKind?: DebugConfigurationProviderTriggerKind): boolean;
-	getDynamicProviders(): Promise<{ label: string; type: string; pick: () => Promise<{ launch: ILaunch; config: IConfig } | undefined> }[]>;
+	getDynamicProviders(): Promise<{ label: string; type: string; pick: () => Promise<{ launch: ILaunch; config: IConfig; label: string } | undefined> }[]>;
+	getDynamicConfigurationsByType(type: string, token?: CancellationToken): Promise<{ launch: ILaunch; config: IConfig; label: string }[]>;
 
 	registerDebugConfigurationProvider(debugConfigurationProvider: IDebugConfigurationProvider): IDisposable;
 	unregisterDebugConfigurationProvider(debugConfigurationProvider: IDebugConfigurationProvider): void;
@@ -1049,9 +1050,18 @@ export interface IAdapterManager {
 	substituteVariables(debugType: string, folder: IWorkspaceFolder | undefined, config: IConfig): Promise<IConfig>;
 	runInTerminal(debugType: string, args: DebugProtocol.RunInTerminalRequestArguments, sessionId: string): Promise<number | undefined>;
 	getEnabledDebugger(type: string): (IDebugger & IDebuggerMetadata) | undefined;
-	guessDebugger(gettingConfigurations: boolean): Promise<(IDebugger & IDebuggerMetadata) | undefined>;
+	guessDebugger(gettingConfigurations: boolean): Promise<IGuessedDebugger | undefined>;
 
 	get onDidDebuggersExtPointRead(): Event<void>;
+}
+
+export interface IGuessedDebugger {
+	debugger: IDebugger;
+	withConfig?: {
+		label: string;
+		launch: ILaunch;
+		config: IConfig;
+	};
 }
 
 export interface ILaunch {

--- a/src/vs/workbench/contrib/debug/common/debugStorage.ts
+++ b/src/vs/workbench/contrib/debug/common/debugStorage.ts
@@ -12,6 +12,7 @@ import { IUriIdentityService } from '../../../../platform/uriIdentity/common/uri
 import { IDebugModel, IEvaluate, IExpression } from './debug.js';
 import { Breakpoint, DataBreakpoint, ExceptionBreakpoint, Expression, FunctionBreakpoint } from './debugModel.js';
 import { ITextFileService } from '../../../services/textfile/common/textfiles.js';
+import { mapValues } from '../../../../base/common/objects.js';
 
 const DEBUG_BREAKPOINTS_KEY = 'debug.breakpoint';
 const DEBUG_FUNCTION_BREAKPOINTS_KEY = 'debug.functionbreakpoint';
@@ -20,6 +21,11 @@ const DEBUG_EXCEPTION_BREAKPOINTS_KEY = 'debug.exceptionbreakpoint';
 const DEBUG_WATCH_EXPRESSIONS_KEY = 'debug.watchexpressions';
 const DEBUG_CHOSEN_ENVIRONMENTS_KEY = 'debug.chosenenvironment';
 const DEBUG_UX_STATE_KEY = 'debug.uxstate';
+
+export interface IChosenEnvironment {
+	type: string;
+	dynamicLabel?: string;
+}
 
 export class DebugStorage extends Disposable {
 	public readonly breakpoints = observableValue(this, this.loadBreakpoints());
@@ -118,11 +124,13 @@ export class DebugStorage extends Disposable {
 		return result || [];
 	}
 
-	loadChosenEnvironments(): { [key: string]: string } {
-		return JSON.parse(this.storageService.get(DEBUG_CHOSEN_ENVIRONMENTS_KEY, StorageScope.WORKSPACE, '{}'));
+	loadChosenEnvironments(): Record<string, IChosenEnvironment> {
+		const obj = JSON.parse(this.storageService.get(DEBUG_CHOSEN_ENVIRONMENTS_KEY, StorageScope.WORKSPACE, '{}'));
+		// back compat from when this was a string map:
+		return mapValues(obj, (value): IChosenEnvironment => typeof value === 'string' ? { type: value } : value);
 	}
 
-	storeChosenEnvironments(environments: { [key: string]: string }): void {
+	storeChosenEnvironments(environments: Record<string, IChosenEnvironment>): void {
 		this.storageService.store(DEBUG_CHOSEN_ENVIRONMENTS_KEY, JSON.stringify(environments), StorageScope.WORKSPACE, StorageTarget.MACHINE);
 	}
 


### PR DESCRIPTION
Some consolidation especially now that copilot is also going to be
having a welcome view contribution:

- Show dynamic configurations in "Run and Debug" as "More X options..."
- Remove the separate action for "Show all automatic debug configurations"
- Make the "create a launch.json file" start adding a configuration as
  well (positioning the cursor and triggering completion)
- Make "Run and Debug"'s memoization be able to remember dynamic configs

![](https://memes.peet.io/img/24-11-6171dc57-fd60-4165-bcb6-d156bb0517cc.png)

fyi @roblourens

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
