### PR TITLE
No need for memento hack

### DIFF
--- a/extensions/microsoft-authentication/package-lock.json
+++ b/extensions/microsoft-authentication/package-lock.json
@@ -10,8 +10,8 @@
       "license": "MIT",
       "dependencies": {
         "@azure/ms-rest-azure-env": "^2.0.0",
-        "@azure/msal-node": "^2.13.1",
-        "@azure/msal-node-extensions": "^1.3.0",
+        "@azure/msal-node": "^2.16.2",
+        "@azure/msal-node-extensions": "^1.5.0",
         "@vscode/extension-telemetry": "^0.9.0",
         "keytar": "file:./packageMocks/keytar",
         "vscode-tas-client": "^0.1.84"
@@ -33,19 +33,21 @@
       "integrity": "sha512-dG76W7ElfLi+fbTjnZVGj+M9e0BIEJmRxU6fHaUQ12bZBe8EJKYb2GV50YWNaP2uJiVQ5+7nXEVj1VN1UQtaEw=="
     },
     "node_modules/@azure/msal-common": {
-      "version": "14.14.2",
-      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-14.14.2.tgz",
-      "integrity": "sha512-XV0P5kSNwDwCA/SjIxTe9mEAsKB0NqGNSuaVrkCCE2lAyBr/D6YtD80Vkdp4tjWnPFwjzkwldjr1xU/facOJog==",
+      "version": "14.16.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-14.16.0.tgz",
+      "integrity": "sha512-1KOZj9IpcDSwpNiQNjt0jDYZpQvNZay7QAEi/5DLubay40iGYtLzya/jbjRPLyOTZhEKyL1MzPuw2HqBCjceYA==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
       }
     },
     "node_modules/@azure/msal-node": {
-      "version": "2.13.1",
-      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-2.13.1.tgz",
-      "integrity": "sha512-sijfzPNorKt6+9g1/miHwhj6Iapff4mPQx1azmmZExgzUROqWTM1o3ACyxDja0g47VpowFy/sxTM/WsuCyXTiw==",
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-2.16.2.tgz",
+      "integrity": "sha512-An7l1hEr0w1HMMh1LU+rtDtqL7/jw74ORlc9Wnh06v7TU/xpG39/Zdr1ZJu3QpjUfKJ+E0/OXMW8DRSWTlh7qQ==",
+      "license": "MIT",
       "dependencies": {
-        "@azure/msal-common": "14.14.2",
+        "@azure/msal-common": "14.16.0",
         "jsonwebtoken": "^9.0.0",
         "uuid": "^8.3.0"
       },
@@ -54,31 +56,19 @@
       }
     },
     "node_modules/@azure/msal-node-extensions": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-node-extensions/-/msal-node-extensions-1.3.0.tgz",
-      "integrity": "sha512-7rXN+9hDm3NncIfNnMyoFtsnz2AlUtmK5rsY3P+fhhbH+GOk0W5Y1BASvAB6RCcKdO+qSIK3ZA6VHQYy4iS/1w==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-node-extensions/-/msal-node-extensions-1.5.0.tgz",
+      "integrity": "sha512-UfEyh2xmJHKH64zPS/SbN1bd9adV4ZWGp1j2OSwIuhVraqpUXyXZ1LpDpiUqg/peTgLLtx20qrHOzYT0kKzmxQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@azure/msal-common": "14.15.0",
+        "@azure/msal-common": "14.16.0",
         "@azure/msal-node-runtime": "^0.17.1",
         "keytar": "^7.8.0"
       },
       "engines": {
         "node": ">=16"
       }
-    },
-    "node_modules/@azure/msal-node-extensions/node_modules/@azure/msal-common": {
-      "version": "14.15.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-14.15.0.tgz",
-      "integrity": "sha512-ImAQHxmpMneJ/4S8BRFhjt1MZ3bppmpRPYYNyzeQPeFN288YKbb8TmmISQEbtfkQ1BPASvYZU5doIZOPBAqENQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/@azure/msal-node-extensions/packageMocks/keytar": {
-      "extraneous": true
     },
     "node_modules/@azure/msal-node-runtime": {
       "version": "0.17.1",

--- a/extensions/microsoft-authentication/package.json
+++ b/extensions/microsoft-authentication/package.json
@@ -140,8 +140,8 @@
   },
   "dependencies": {
     "@azure/ms-rest-azure-env": "^2.0.0",
-    "@azure/msal-node": "^2.13.1",
-    "@azure/msal-node-extensions": "^1.3.0",
+    "@azure/msal-node": "^2.16.2",
+    "@azure/msal-node-extensions": "^1.5.0",
     "@vscode/extension-telemetry": "^0.9.0",
     "keytar": "file:./packageMocks/keytar",
     "vscode-tas-client": "^0.1.84"


### PR DESCRIPTION
MSAL node made `clearCache` synchronous :tada: so we can safely depend on it for clearing the cache.

> Context: The default behavior of MSAL's internal cache is that it is a union with what's in the persistant cache (secret storage) but what _we_ want is that secret storage is the source of truth, so every time we receive an update to secret storage, we clear the in-memory cache to get the data from the persistant cache.

Also bumps msal-node-extensions while we're at it.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
