### PR TITLE
Remove msal-node-extensions workaround

### DIFF
--- a/extensions/microsoft-authentication/extension.webpack.config.js
+++ b/extensions/microsoft-authentication/extension.webpack.config.js
@@ -10,7 +10,6 @@
 const withDefaults = require('../shared.webpack.config');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 const path = require('path');
-const { NormalModuleReplacementPlugin } = require('webpack');
 
 const isWindows = process.platform === 'win32';
 
@@ -42,13 +41,6 @@ module.exports = withDefaults({
 					noErrorOnMissing: !isWindows
 				}
 			]
-		}),
-		// We don't use the feature that uses Dpapi, so we can just replace it with a mock.
-		// This is a bit of a hack, but it's the easiest way to do it. Really, msal should
-		// handle when this native node module is not available.
-		new NormalModuleReplacementPlugin(
-			/\.\.\/Dpapi\.mjs/,
-			path.resolve(__dirname, 'packageMocks', 'dpapi', 'dpapi.js')
-		)
+		})
 	]
 });


### PR DESCRIPTION
We needed this workaround because MSAL was always trying to require a native module we never use.

I sent a PR to MSAL to rework their behavior and that has now been released and we pulled that in in https://github.com/microsoft/vscode/pull/234450

With the updated msal-node-extensions library, we no longer need to do this webpack logic.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
