### PR TITLE
fix: update localization for walkthrough page title in GettingStartedInput

### DIFF
--- a/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStartedInput.ts
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/browser/gettingStartedInput.ts
@@ -75,7 +75,7 @@ export class GettingStartedInput extends EditorInput {
 	}
 
 	override getName() {
-		return this.walkthroughPageTitle ? localize('walkthroughPageTitle', 'Walkthrough: ') + this.walkthroughPageTitle : localize('getStarted', "Welcome");
+		return this.walkthroughPageTitle ? localize('walkthroughPageTitle', 'Walkthrough: {0}', this.walkthroughPageTitle) : localize('getStarted', "Welcome");
 	}
 
 	get selectedCategory() {


### PR DESCRIPTION
Fixes: https://github.com/microsoft/vscode/issues/234328