### PR TITLE
Fix drag-and-drop text and resource data for symbols

### DIFF
--- a/src/vs/workbench/browser/parts/editor/breadcrumbsControl.ts
+++ b/src/vs/workbench/browser/parts/editor/breadcrumbsControl.ts
@@ -112,9 +112,10 @@ class OutlineItem extends BreadcrumbsItem {
 			};
 			const dataTransfers: DataTransfer[] = [
 				[CodeDataTransfers.SYMBOLS, [symbolTransferData]],
-				[DataTransfers.RESOURCES, [symbolUri]]
+				[DataTransfers.RESOURCES, [symbolUri.toString()]]
 			];
-			this._disposables.add(createBreadcrumbDndObserver(container, element.symbol.name, symbolUri.toString(), dataTransfers));
+			const textData = symbolUri.fsPath + (symbolUri.fragment ? '#' + symbolUri.fragment : '');
+			this._disposables.add(createBreadcrumbDndObserver(container, element.symbol.name, textData, dataTransfers));
 		}
 	}
 }
@@ -163,7 +164,7 @@ class FileItem extends BreadcrumbsItem {
 			[CodeDataTransfers.FILES, [this.element.uri.fsPath]],
 			[DataTransfers.RESOURCES, [this.element.uri.toString()]],
 		];
-		const dndObserver = createBreadcrumbDndObserver(container, basename(this.element.uri), this.element.uri.toString(), dataTransfers);
+		const dndObserver = createBreadcrumbDndObserver(container, basename(this.element.uri), this.element.uri.fsPath, dataTransfers);
 		this._disposables.add(dndObserver);
 	}
 }

--- a/src/vs/workbench/contrib/codeEditor/browser/outline/documentSymbolsTree.ts
+++ b/src/vs/workbench/contrib/codeEditor/browser/outline/documentSymbolsTree.ts
@@ -76,9 +76,10 @@ export class DocumentSymbolDragAndDrop implements ITreeDragAndDrop<DocumentSymbo
 		}
 
 		if (element instanceof OutlineElement) {
-			return symbolRangeUri(resource, element.symbol).toString();
+			const symbolUri = symbolRangeUri(resource, element.symbol);
+			return symbolUri.fsPath + (symbolUri.fragment ? '#' + symbolUri.fragment : '');
 		} else {
-			return resource.toString();
+			return resource.fsPath;
 		}
 	}
 
@@ -113,7 +114,7 @@ export class DocumentSymbolDragAndDrop implements ITreeDragAndDrop<DocumentSymbo
 		}));
 
 		originalEvent.dataTransfer.setData(CodeDataTransfers.SYMBOLS, JSON.stringify(symbolsData));
-		originalEvent.dataTransfer.setData(DataTransfers.RESOURCES, JSON.stringify(outlineElements.map(oe => symbolRangeUri(resource, oe.symbol))));
+		originalEvent.dataTransfer.setData(DataTransfers.RESOURCES, JSON.stringify(outlineElements.map(oe => symbolRangeUri(resource, oe.symbol).toString())));
 	}
 
 	onDragOver(): boolean | ITreeDragOverReaction { return false; }


### PR DESCRIPTION
Correct the handling of drag-and-drop data for symbols by ensuring the correct text and resource URIs are used. 