### PR TITLE
Render lines to the alphabetic baseline

### DIFF
--- a/src/vs/editor/browser/gpu/atlas/atlas.ts
+++ b/src/vs/editor/browser/gpu/atlas/atlas.ts
@@ -31,6 +31,9 @@ export interface ITextureAtlasPageGlyph {
 	originOffsetX: number;
 	/** The y offset from {@link y} of the glyph's origin. */
 	originOffsetY: number;
+	alphabeticBaseline: number;
+	fontBoundingBoxAscent: number;
+	fontBoundingBoxDescent: number;
 }
 
 /**

--- a/src/vs/editor/browser/gpu/atlas/atlas.ts
+++ b/src/vs/editor/browser/gpu/atlas/atlas.ts
@@ -31,8 +31,19 @@ export interface ITextureAtlasPageGlyph {
 	originOffsetX: number;
 	/** The y offset from {@link y} of the glyph's origin. */
 	originOffsetY: number;
-	alphabeticBaseline: number;
+	/**
+	 * The distance from the the glyph baseline to the top of the highest bounding rectangle of all
+	 * fonts used to render the text.
+	 *
+	 * @see {@link TextMetrics.fontBoundingBoxAscent}
+	 */
 	fontBoundingBoxAscent: number;
+	/**
+	 * The distance from the the glyph baseline to the bottom of the bounding rectangle of all fonts
+	 * used to render the text.
+	 *
+	 * @see {@link TextMetrics.fontBoundingBoxDescent}
+	 */
 	fontBoundingBoxDescent: number;
 }
 

--- a/src/vs/editor/browser/gpu/atlas/textureAtlasShelfAllocator.ts
+++ b/src/vs/editor/browser/gpu/atlas/textureAtlasShelfAllocator.ts
@@ -81,7 +81,6 @@ export class TextureAtlasShelfAllocator implements ITextureAtlasAllocator {
 			h: glyphHeight,
 			originOffsetX: rasterizedGlyph.originOffset.x,
 			originOffsetY: rasterizedGlyph.originOffset.y,
-			alphabeticBaseline: rasterizedGlyph.alphabeticBaseline,
 			fontBoundingBoxAscent: rasterizedGlyph.fontBoundingBoxAscent,
 			fontBoundingBoxDescent: rasterizedGlyph.fontBoundingBoxDescent,
 		};

--- a/src/vs/editor/browser/gpu/atlas/textureAtlasShelfAllocator.ts
+++ b/src/vs/editor/browser/gpu/atlas/textureAtlasShelfAllocator.ts
@@ -80,7 +80,10 @@ export class TextureAtlasShelfAllocator implements ITextureAtlasAllocator {
 			w: glyphWidth,
 			h: glyphHeight,
 			originOffsetX: rasterizedGlyph.originOffset.x,
-			originOffsetY: rasterizedGlyph.originOffset.y
+			originOffsetY: rasterizedGlyph.originOffset.y,
+			alphabeticBaseline: rasterizedGlyph.alphabeticBaseline,
+			fontBoundingBoxAscent: rasterizedGlyph.fontBoundingBoxAscent,
+			fontBoundingBoxDescent: rasterizedGlyph.fontBoundingBoxDescent,
 		};
 
 		// Shift current row

--- a/src/vs/editor/browser/gpu/atlas/textureAtlasSlabAllocator.ts
+++ b/src/vs/editor/browser/gpu/atlas/textureAtlasSlabAllocator.ts
@@ -278,7 +278,10 @@ export class TextureAtlasSlabAllocator implements ITextureAtlasAllocator {
 			w: glyphWidth,
 			h: glyphHeight,
 			originOffsetX: rasterizedGlyph.originOffset.x,
-			originOffsetY: rasterizedGlyph.originOffset.y
+			originOffsetY: rasterizedGlyph.originOffset.y,
+			alphabeticBaseline: rasterizedGlyph.alphabeticBaseline,
+			fontBoundingBoxAscent: rasterizedGlyph.fontBoundingBoxAscent,
+			fontBoundingBoxDescent: rasterizedGlyph.fontBoundingBoxDescent,
 		};
 
 		// Set the glyph

--- a/src/vs/editor/browser/gpu/atlas/textureAtlasSlabAllocator.ts
+++ b/src/vs/editor/browser/gpu/atlas/textureAtlasSlabAllocator.ts
@@ -279,7 +279,6 @@ export class TextureAtlasSlabAllocator implements ITextureAtlasAllocator {
 			h: glyphHeight,
 			originOffsetX: rasterizedGlyph.originOffset.x,
 			originOffsetY: rasterizedGlyph.originOffset.y,
-			alphabeticBaseline: rasterizedGlyph.alphabeticBaseline,
 			fontBoundingBoxAscent: rasterizedGlyph.fontBoundingBoxAscent,
 			fontBoundingBoxDescent: rasterizedGlyph.fontBoundingBoxDescent,
 		};

--- a/src/vs/editor/browser/gpu/fullFileRenderStrategy.ts
+++ b/src/vs/editor/browser/gpu/fullFileRenderStrategy.ts
@@ -409,13 +409,17 @@ export class FullFileRenderStrategy extends ViewEventHandler implements IGpuRend
 
 					// TODO: Support non-standard character widths
 					absoluteOffsetX = Math.round((x + xOffset) * viewLineOptions.spaceWidth * dpr);
-					absoluteOffsetY = (
-						Math.ceil((
-							// Top of line including line height
-							viewportData.relativeVerticalOffset[y - viewportData.startLineNumber] +
-							// Delta to top of line after line height
-							Math.floor((viewportData.lineHeight - this._context.configuration.options.get(EditorOption.fontSize)) / 2)
-						) * dpr)
+					absoluteOffsetY = Math.round(
+						// Top of layout box (includes line height)
+						viewportData.relativeVerticalOffset[y - viewportData.startLineNumber] * dpr +
+
+						// Delta from top of layout box (includes line height) to top of the inline box (no line height)
+						Math.floor((viewportData.lineHeight * dpr - (glyph.fontBoundingBoxAscent + glyph.fontBoundingBoxDescent)) / 2) +
+
+						// Delta from top of inline box (no line height) to top of glyph origin. If the glyph was drawn
+						// with a top baseline for example, this ends up drawing the glyph correctly using the alphabetical
+						// baseline.
+						glyph.fontBoundingBoxAscent
 					);
 
 					cellIndex = ((y - 1) * this._viewGpuContext.maxGpuCols + x) * Constants.IndicesPerCell;

--- a/src/vs/editor/browser/gpu/raster/glyphRasterizer.ts
+++ b/src/vs/editor/browser/gpu/raster/glyphRasterizer.ts
@@ -38,7 +38,6 @@ export class GlyphRasterizer extends Disposable implements IGlyphRasterizer {
 			x: 0,
 			y: 0,
 		},
-		alphabeticBaseline: 0,
 		fontBoundingBoxAscent: 0,
 		fontBoundingBoxDescent: 0,
 	};
@@ -77,7 +76,6 @@ export class GlyphRasterizer extends Disposable implements IGlyphRasterizer {
 				source: this._canvas,
 				boundingBox: { top: 0, left: 0, bottom: -1, right: -1 },
 				originOffset: { x: 0, y: 0 },
-				alphabeticBaseline: 0,
 				fontBoundingBoxAscent: 0,
 				fontBoundingBoxDescent: 0,
 			};
@@ -152,8 +150,6 @@ export class GlyphRasterizer extends Disposable implements IGlyphRasterizer {
 		this._workGlyph.source = this._canvas;
 		this._workGlyph.originOffset.x = this._workGlyph.boundingBox.left - originX;
 		this._workGlyph.originOffset.y = this._workGlyph.boundingBox.top - originY;
-		// TODO: Clean this up, reduce duplication
-		this._workGlyph.alphabeticBaseline = this._textMetrics.alphabeticBaseline;
 		this._workGlyph.fontBoundingBoxAscent = this._textMetrics.fontBoundingBoxAscent;
 		this._workGlyph.fontBoundingBoxDescent = this._textMetrics.fontBoundingBoxDescent;
 

--- a/src/vs/editor/browser/gpu/raster/glyphRasterizer.ts
+++ b/src/vs/editor/browser/gpu/raster/glyphRasterizer.ts
@@ -24,6 +24,8 @@ export class GlyphRasterizer extends Disposable implements IGlyphRasterizer {
 	private _canvas: OffscreenCanvas;
 	private _ctx: OffscreenCanvasRenderingContext2D;
 
+	private readonly _textMetrics: TextMetrics;
+
 	private _workGlyph: IRasterizedGlyph = {
 		source: null!,
 		boundingBox: {
@@ -35,7 +37,10 @@ export class GlyphRasterizer extends Disposable implements IGlyphRasterizer {
 		originOffset: {
 			x: 0,
 			y: 0,
-		}
+		},
+		alphabeticBaseline: 0,
+		fontBoundingBoxAscent: 0,
+		fontBoundingBoxDescent: 0,
 	};
 	private _workGlyphConfig: { chars: string | undefined; tokenMetadata: number; charMetadata: number } = { chars: undefined, tokenMetadata: 0, charMetadata: 0 };
 
@@ -52,6 +57,8 @@ export class GlyphRasterizer extends Disposable implements IGlyphRasterizer {
 		}));
 		this._ctx.textBaseline = 'top';
 		this._ctx.fillStyle = '#FFFFFF';
+		this._ctx.font = `${devicePixelFontSize}px ${this.fontFamily}`;
+		this._textMetrics = this._ctx.measureText('A');
 	}
 
 	// TODO: Support drawing multiple fonts and sizes
@@ -69,7 +76,10 @@ export class GlyphRasterizer extends Disposable implements IGlyphRasterizer {
 			return {
 				source: this._canvas,
 				boundingBox: { top: 0, left: 0, bottom: -1, right: -1 },
-				originOffset: { x: 0, y: 0 }
+				originOffset: { x: 0, y: 0 },
+				alphabeticBaseline: 0,
+				fontBoundingBoxAscent: 0,
+				fontBoundingBoxDescent: 0,
 			};
 		}
 		// Check if the last glyph matches the config, reuse if so. This helps avoid unnecessary
@@ -122,9 +132,8 @@ export class GlyphRasterizer extends Disposable implements IGlyphRasterizer {
 		} else {
 			this._ctx.fillStyle = colorMap[TokenMetadata.getForeground(metadata)];
 		}
-		// TODO: This might actually be slower
-		// const textMetrics = this._ctx.measureText(chars);
 		this._ctx.textBaseline = 'top';
+
 		this._ctx.fillText(chars, originX, originY);
 
 		const imageData = this._ctx.getImageData(0, 0, this._canvas.width, this._canvas.height);
@@ -143,6 +152,11 @@ export class GlyphRasterizer extends Disposable implements IGlyphRasterizer {
 		this._workGlyph.source = this._canvas;
 		this._workGlyph.originOffset.x = this._workGlyph.boundingBox.left - originX;
 		this._workGlyph.originOffset.y = this._workGlyph.boundingBox.top - originY;
+		// TODO: Clean this up, reduce duplication
+		this._workGlyph.alphabeticBaseline = this._textMetrics.alphabeticBaseline;
+		this._workGlyph.fontBoundingBoxAscent = this._textMetrics.fontBoundingBoxAscent;
+		this._workGlyph.fontBoundingBoxDescent = this._textMetrics.fontBoundingBoxDescent;
+
 		// const result2: IRasterizedGlyph = {
 		// 	source: this._canvas,
 		// 	boundingBox: {

--- a/src/vs/editor/browser/gpu/raster/raster.ts
+++ b/src/vs/editor/browser/gpu/raster/raster.ts
@@ -64,4 +64,10 @@ export interface IRasterizedGlyph {
 	 * The offset to the glyph's origin (where it should be drawn to).
 	 */
 	originOffset: { x: number; y: number };
+	/**
+	 * The glyph's distance from the alphabetical baseline.
+	 */
+	alphabeticBaseline: number;
+	fontBoundingBoxAscent: number;
+	fontBoundingBoxDescent: number;
 }

--- a/src/vs/editor/browser/gpu/raster/raster.ts
+++ b/src/vs/editor/browser/gpu/raster/raster.ts
@@ -65,9 +65,17 @@ export interface IRasterizedGlyph {
 	 */
 	originOffset: { x: number; y: number };
 	/**
-	 * The glyph's distance from the alphabetical baseline.
+	 * The distance from the the glyph baseline to the top of the highest bounding rectangle of all
+	 * fonts used to render the text.
+	 *
+	 * @see {@link TextMetrics.fontBoundingBoxAscent}
 	 */
-	alphabeticBaseline: number;
 	fontBoundingBoxAscent: number;
+	/**
+	 * The distance from the the glyph baseline to the bottom of the bounding rectangle of all fonts
+	 * used to render the text.
+	 *
+	 * @see {@link TextMetrics.fontBoundingBoxDescent}
+	 */
 	fontBoundingBoxDescent: number;
 }

--- a/src/vs/editor/test/browser/gpu/atlas/textureAtlas.test.ts
+++ b/src/vs/editor/test/browser/gpu/atlas/textureAtlas.test.ts
@@ -56,7 +56,6 @@ class TestGlyphRasterizer implements IGlyphRasterizer {
 			source: canvas,
 			boundingBox: { top: 0, left: 0, bottom: h - 1, right: w - 1 },
 			originOffset: { x: 0, y: 0 },
-			alphabeticBaseline: 0,
 			fontBoundingBoxAscent: 0,
 			fontBoundingBoxDescent: 0,
 		};

--- a/src/vs/editor/test/browser/gpu/atlas/textureAtlas.test.ts
+++ b/src/vs/editor/test/browser/gpu/atlas/textureAtlas.test.ts
@@ -56,6 +56,9 @@ class TestGlyphRasterizer implements IGlyphRasterizer {
 			source: canvas,
 			boundingBox: { top: 0, left: 0, bottom: h - 1, right: w - 1 },
 			originOffset: { x: 0, y: 0 },
+			alphabeticBaseline: 0,
+			fontBoundingBoxAscent: 0,
+			fontBoundingBoxDescent: 0,
 		};
 	}
 }

--- a/src/vs/editor/test/browser/gpu/atlas/textureAtlasAllocator.test.ts
+++ b/src/vs/editor/test/browser/gpu/atlas/textureAtlasAllocator.test.ts
@@ -29,6 +29,9 @@ function createRasterizedGlyph(w: number, h: number, data: ArrayLike<number>): I
 		source,
 		boundingBox: { top: 0, left: 0, bottom: h - 1, right: w - 1 },
 		originOffset: { x: 0, y: 0 },
+		alphabeticBaseline: 0,
+		fontBoundingBoxAscent: 0,
+		fontBoundingBoxDescent: 0,
 	};
 }
 

--- a/src/vs/editor/test/browser/gpu/atlas/textureAtlasAllocator.test.ts
+++ b/src/vs/editor/test/browser/gpu/atlas/textureAtlasAllocator.test.ts
@@ -29,7 +29,6 @@ function createRasterizedGlyph(w: number, h: number, data: ArrayLike<number>): I
 		source,
 		boundingBox: { top: 0, left: 0, bottom: h - 1, right: w - 1 },
 		originOffset: { x: 0, y: 0 },
-		alphabeticBaseline: 0,
 		fontBoundingBoxAscent: 0,
 		fontBoundingBoxDescent: 0,
 	};


### PR DESCRIPTION
Fixes #234581

This makes lines render at the same y coordinate as DOM-based lines do. This was done by:

- Calculating the correct "inline box" (no line height) as opposed to "layout box" (includes line height). The size of the inline box is calculated using `FontMetrics.fontBoundingBoxAscent + FontMetrics.fontBoundingBoxDescent`.
- Drawing the glyph at the correct `y` position inside the inline box by using `FontMetrics.fontBoundingBoxAscent`. Glyphs are currently drawn using `textBaseline = top` and `fontBoundingBoxAscent` positions it such that characters should be aligned with the alphabetic baseline.

Tested on device pixel ratio `1` and `2`. There are some problems still with decimal dprs but this isn't tested thoroughly and could be related to other issues, so out of scope for this PR.

Notice that the gif shows no vertical flicker with the current line always using inline decorations (via `git.blame.editorDecoration.enabled`).

![Recording 2024-11-25 at 11 53 36](https://github.com/user-attachments/assets/c0d1ff99-16f2-498d-8207-ec9ca9afd134)

\* horizontal flickering is mostly due to https://github.com/microsoft/vscode/issues/227101