### PR TITLE
fix: set _lastFocusedWidget as undefined on widget blur

### DIFF
--- a/src/vs/platform/list/browser/listService.ts
+++ b/src/vs/platform/list/browser/listService.ts
@@ -90,7 +90,11 @@ export class ListService implements IListService {
 
 		return combinedDisposable(
 			widget.onDidFocus(() => this.setLastFocusedList(widget)),
-			widget.onDidBlur(() => this.setLastFocusedList(undefined)),
+			widget.onDidBlur(() => {
+				if (this._lastFocusedWidget === widget) {
+					this.setLastFocusedList(undefined);
+				}
+			}),
 			toDisposable(() => this.lists.splice(this.lists.indexOf(registeredList), 1)),
 			widget.onDidDispose(() => {
 				this.lists = this.lists.filter(l => l !== registeredList);

--- a/src/vs/platform/list/browser/listService.ts
+++ b/src/vs/platform/list/browser/listService.ts
@@ -90,6 +90,7 @@ export class ListService implements IListService {
 
 		return combinedDisposable(
 			widget.onDidFocus(() => this.setLastFocusedList(widget)),
+			widget.onDidBlur(() => this.setLastFocusedList(undefined)),
 			toDisposable(() => this.lists.splice(this.lists.indexOf(registeredList), 1)),
 			widget.onDidDispose(() => {
 				this.lists = this.lists.filter(l => l !== registeredList);


### PR DESCRIPTION
Fixes #234791.

### How to reproduce

1. Have one open terminal (as default)
2. Click on the button with the terminal name
3. Click on "Change color..." and choose any color from the modal
4. Click on the button with the terminal name
5. Click on either "Rename...", "Split terminal", "Kill terminal"
6. Expect the buttons to not work

### Diagnosis

The problem happens when you pick a color in the modal mentioned above. As soon as you click a color, the modal briefly grabs focus before closing and applying your choice.

The issue boils down to this focus change. The `QuickInputTree` widget fires an `onDidFocus` event, which `listService` catches and uses to set `_lastFocusedWidget`.

But since the modal closes right away, `_lastFocusedWidget` ends up pointing to a list that’s no longer visible. Later, in `terminalActions.ts`, the `getSelectedInstances` function mistakenly thinks the colors from that list are selected terminals. So when `terminalService.getInstanceFromIndex(selection)` runs, it tries to use a color object as if it were a numeric index, causing the bug.

### Solution

To fix this, I added a listener for the `onDidBlur` event on the widget. This works as the opposite of `onDidFocus`—it resets `_lastFocusedWidget` to `undefined` when the widget loses focus, like when you pick a color and the modal closes.

This makes sure that lists that aren’t actually focused don’t get treated as such by `listService`. With this change, `getSelectedInstances` now works as expected, solving the issue.

### Before and after

https://github.com/user-attachments/assets/6ec88158-0b14-4b23-a06e-110f5ee9228e

https://github.com/user-attachments/assets/f9257a4b-12c2-4947-a3b5-5f9fae2e16ce

---

Let me know if additional testing or adjustments are needed!
