### PR TITLE
Handle line mapping changed and don't update buffers after decoration change

### DIFF
--- a/src/vs/editor/browser/viewParts/viewLinesGpu/viewLinesGpu.ts
+++ b/src/vs/editor/browser/viewParts/viewLinesGpu/viewLinesGpu.ts
@@ -385,9 +385,11 @@ export class ViewLinesGpu extends ViewPart implements IViewLines {
 	override onCursorStateChanged(e: viewEvents.ViewCursorStateChangedEvent): boolean { return true; }
 	override onDecorationsChanged(e: viewEvents.ViewDecorationsChangedEvent): boolean { return true; }
 	override onFlushed(e: viewEvents.ViewFlushedEvent): boolean { return true; }
+
 	override onLinesChanged(e: viewEvents.ViewLinesChangedEvent): boolean { return true; }
 	override onLinesDeleted(e: viewEvents.ViewLinesDeletedEvent): boolean { return true; }
 	override onLinesInserted(e: viewEvents.ViewLinesInsertedEvent): boolean { return true; }
+	override onLineMappingChanged(e: viewEvents.ViewLineMappingChangedEvent): boolean { return true; }
 	override onRevealRangeRequest(e: viewEvents.ViewRevealRangeRequestEvent): boolean { return true; }
 	override onScrollChanged(e: viewEvents.ViewScrollChangedEvent): boolean { return true; }
 	override onThemeChanged(e: viewEvents.ViewThemeChangedEvent): boolean { return true; }


### PR DESCRIPTION
Line mapping is the cause of the problems with folding, for decorations
we only want to invalidate the up to date lines cache since it won't
affect other lines afaict.

Fixes https://github.com/microsoft/vscode/issues/234614
Part of https://github.com/microsoft/vscode/issues/234214

Merge after https://github.com/microsoft/vscode/pull/234613