### PR TITLE
Add 'open image' context in markdown preview

### DIFF
--- a/extensions/markdown-language-features/package.json
+++ b/extensions/markdown-language-features/package.json
@@ -126,6 +126,11 @@
         "category": "Markdown"
       },
       {
+        "command": "_markdown.openImage",
+        "title": "%markdown.openImage.title%",
+        "category": "Markdown"
+      },
+      {
         "command": "markdown.showPreview",
         "title": "%markdown.preview.title%",
         "category": "Markdown",
@@ -189,7 +194,11 @@
       "webview/context": [
         {
           "command": "_markdown.copyImage",
-          "when": "webviewId == 'markdown.preview' && webviewSection == 'image'"
+          "when": "webviewId == 'markdown.preview' && (webviewSection == 'image' || webviewSection == 'localImage')"
+        },
+        {
+          "command": "_markdown.openImage",
+          "when": "webviewId == 'markdown.preview' && webviewSection == 'localImage'"
         }
       ],
       "editor/title": [
@@ -244,6 +253,10 @@
         }
       ],
       "commandPalette": [
+        {
+          "command": "_markdown.openImage",
+          "when": "false"
+        },
         {
           "command": "_markdown.copyImage",
           "when": "false"

--- a/extensions/markdown-language-features/package.nls.json
+++ b/extensions/markdown-language-features/package.nls.json
@@ -2,6 +2,7 @@
 	"displayName": "Markdown Language Features",
 	"description": "Provides rich language support for Markdown.",
 	"markdown.copyImage.title": "Copy Image",
+	"markdown.openImage.title": "Open Image",
 	"markdown.preview.breaks.desc": "Sets how line-breaks are rendered in the Markdown preview. Setting it to `true` creates a `<br>` for newlines inside paragraphs.",
 	"markdown.preview.linkify": "Convert URL-like text to links in the Markdown preview.",
 	"markdown.preview.typographer": "Enable some language-neutral replacement and quotes beautification in the Markdown preview.",

--- a/extensions/markdown-language-features/preview-src/index.ts
+++ b/extensions/markdown-language-features/preview-src/index.ts
@@ -132,7 +132,11 @@ function addImageContexts() {
 	for (const img of images) {
 		img.id = 'image-' + idNumber;
 		idNumber += 1;
-		img.setAttribute('data-vscode-context', JSON.stringify({ webviewSection: 'image', id: img.id, 'preventDefaultContextMenuItems': true, resource: documentResource }));
+		const imageSource = img.src;
+		const imgSrcAttribute = img.getAttribute('src');
+		const isLocalFile = imageSource !== imgSrcAttribute;
+		const webviewSection = isLocalFile ? 'localImage' : 'image';
+		img.setAttribute('data-vscode-context', JSON.stringify({ webviewSection, id: img.id, 'preventDefaultContextMenuItems': true, resource: documentResource, imageSource }));
 	}
 }
 

--- a/extensions/markdown-language-features/preview-src/index.ts
+++ b/extensions/markdown-language-features/preview-src/index.ts
@@ -11,6 +11,7 @@ import { SettingsManager, getData } from './settings';
 import throttle = require('lodash.throttle');
 import morphdom from 'morphdom';
 import type { ToWebviewMessage } from '../types/previewMessaging';
+import { isOfScheme, Schemes } from '../src/util/schemes';
 
 let scrollDisabledCount = 0;
 
@@ -132,9 +133,8 @@ function addImageContexts() {
 	for (const img of images) {
 		img.id = 'image-' + idNumber;
 		idNumber += 1;
-		const imageSource = img.src;
-		const imgSrcAttribute = img.getAttribute('src');
-		const isLocalFile = imageSource !== imgSrcAttribute;
+		const imageSource = img.getAttribute('data-src');
+		const isLocalFile = imageSource && !(isOfScheme(Schemes.http, imageSource) || isOfScheme(Schemes.https, imageSource));
 		const webviewSection = isLocalFile ? 'localImage' : 'image';
 		img.setAttribute('data-vscode-context', JSON.stringify({ webviewSection, id: img.id, 'preventDefaultContextMenuItems': true, resource: documentResource, imageSource }));
 	}

--- a/extensions/markdown-language-features/src/commands/index.ts
+++ b/extensions/markdown-language-features/src/commands/index.ts
@@ -18,6 +18,7 @@ import { CopyImageCommand } from './copyImage';
 import { ShowPreviewSecuritySelectorCommand } from './showPreviewSecuritySelector';
 import { ShowSourceCommand } from './showSource';
 import { ToggleLockCommand } from './toggleLock';
+import { OpenImageCommand } from './openImage';
 
 export function registerMarkdownCommands(
 	commandManager: CommandManager,
@@ -28,6 +29,7 @@ export function registerMarkdownCommands(
 ): vscode.Disposable {
 	const previewSecuritySelector = new PreviewSecuritySelector(cspArbiter, previewManager);
 
+	commandManager.register(new OpenImageCommand(previewManager));
 	commandManager.register(new CopyImageCommand(previewManager));
 	commandManager.register(new ShowPreviewCommand(previewManager, telemetryReporter));
 	commandManager.register(new ShowPreviewToSideCommand(previewManager, telemetryReporter));

--- a/extensions/markdown-language-features/src/commands/openImage.ts
+++ b/extensions/markdown-language-features/src/commands/openImage.ts
@@ -16,7 +16,7 @@ export class OpenImageCommand implements Command {
 
 	public execute(args: { resource: string; imageSource: string }) {
 		const source = vscode.Uri.parse(args.resource);
-		const imageSource = vscode.Uri.file(vscode.Uri.parse(args.imageSource).path);
-		vscode.commands.executeCommand('vscode.open', imageSource, this._webviewManager.findPreview(source));
+		const imageSourceUri = vscode.Uri.file(vscode.Uri.parse(args.imageSource).path);
+		vscode.commands.executeCommand('vscode.open', imageSourceUri, this._webviewManager.findPreview(source));
 	}
 }

--- a/extensions/markdown-language-features/src/commands/openImage.ts
+++ b/extensions/markdown-language-features/src/commands/openImage.ts
@@ -1,0 +1,22 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+import { Command } from '../commandManager';
+import { MarkdownPreviewManager } from '../preview/previewManager';
+
+export class OpenImageCommand implements Command {
+	public readonly id = '_markdown.openImage';
+
+	public constructor(
+		private readonly _webviewManager: MarkdownPreviewManager,
+	) { }
+
+	public execute(args: { resource: string, imageSource: string }) {
+		const source = vscode.Uri.parse(args.resource);
+		const { fsPath } = vscode.Uri.parse(args.imageSource);
+		this._webviewManager.findPreview(source)?.openImage(fsPath);
+	}
+}

--- a/extensions/markdown-language-features/src/commands/openImage.ts
+++ b/extensions/markdown-language-features/src/commands/openImage.ts
@@ -14,9 +14,9 @@ export class OpenImageCommand implements Command {
 		private readonly _webviewManager: MarkdownPreviewManager,
 	) { }
 
-	public execute(args: { resource: string, imageSource: string }) {
+	public execute(args: { resource: string; imageSource: string }) {
 		const source = vscode.Uri.parse(args.resource);
-		const { fsPath } = vscode.Uri.parse(args.imageSource);
-		this._webviewManager.findPreview(source)?.openImage(fsPath);
+		const imageSource = vscode.Uri.file(vscode.Uri.parse(args.imageSource).path);
+		vscode.commands.executeCommand('vscode.open', imageSource, this._webviewManager.findPreview(source));
 	}
 }

--- a/extensions/markdown-language-features/src/commands/openImage.ts
+++ b/extensions/markdown-language-features/src/commands/openImage.ts
@@ -16,7 +16,6 @@ export class OpenImageCommand implements Command {
 
 	public execute(args: { resource: string; imageSource: string }) {
 		const source = vscode.Uri.parse(args.resource);
-		const imageSourceUri = vscode.Uri.file(vscode.Uri.parse(args.imageSource).path);
-		vscode.commands.executeCommand('vscode.open', imageSourceUri, this._webviewManager.findPreview(source));
+		this._webviewManager.openDocumentLink(args.imageSource, source);
 	}
 }

--- a/extensions/markdown-language-features/src/preview/preview.ts
+++ b/extensions/markdown-language-features/src/preview/preview.ts
@@ -443,7 +443,6 @@ export interface IManagedMarkdownPreview {
 	readonly onDidChangeViewState: vscode.Event<vscode.WebviewPanelOnDidChangeViewStateEvent>;
 
 	copyImage(id: string): void;
-	openImage(imagePath: string): void;
 	dispose(): void;
 	refresh(): void;
 	updateConfiguration(): void;
@@ -523,12 +522,6 @@ export class StaticMarkdownPreview extends Disposable implements IManagedMarkdow
 			source: this.resource.toString(),
 			id: id
 		});
-	}
-
-	openImage(imagePath: string): void {
-		const uri = vscode.Uri.file(imagePath);
-		this._webviewPanel.reveal();
-		vscode.commands.executeCommand('vscode.open', uri);
 	}
 
 	private readonly _onDispose = this._register(new vscode.EventEmitter<void>());
@@ -684,12 +677,6 @@ export class DynamicMarkdownPreview extends Disposable implements IManagedMarkdo
 			source: this.resource.toString(),
 			id: id
 		});
-	}
-
-	openImage(imagePath: string): void {
-		const uri = vscode.Uri.file(imagePath);
-		this._webviewPanel.reveal();
-		vscode.commands.executeCommand('vscode.open', uri);
 	}
 
 	private readonly _onDisposeEmitter = this._register(new vscode.EventEmitter<void>());

--- a/extensions/markdown-language-features/src/preview/preview.ts
+++ b/extensions/markdown-language-features/src/preview/preview.ts
@@ -443,6 +443,7 @@ export interface IManagedMarkdownPreview {
 	readonly onDidChangeViewState: vscode.Event<vscode.WebviewPanelOnDidChangeViewStateEvent>;
 
 	copyImage(id: string): void;
+	openImage(imagePath: string): void;
 	dispose(): void;
 	refresh(): void;
 	updateConfiguration(): void;
@@ -522,6 +523,12 @@ export class StaticMarkdownPreview extends Disposable implements IManagedMarkdow
 			source: this.resource.toString(),
 			id: id
 		});
+	}
+
+	openImage(imagePath: string): void {
+		const uri = vscode.Uri.file(imagePath);
+		this._webviewPanel.reveal();
+		vscode.commands.executeCommand('vscode.open', uri);
 	}
 
 	private readonly _onDispose = this._register(new vscode.EventEmitter<void>());
@@ -677,6 +684,12 @@ export class DynamicMarkdownPreview extends Disposable implements IManagedMarkdo
 			source: this.resource.toString(),
 			id: id
 		});
+	}
+
+	openImage(imagePath: string): void {
+		const uri = vscode.Uri.file(imagePath);
+		this._webviewPanel.reveal();
+		vscode.commands.executeCommand('vscode.open', uri);
 	}
 
 	private readonly _onDisposeEmitter = this._register(new vscode.EventEmitter<void>());

--- a/extensions/markdown-language-features/src/preview/previewManager.ts
+++ b/extensions/markdown-language-features/src/preview/previewManager.ts
@@ -170,6 +170,11 @@ export class MarkdownPreviewManager extends Disposable implements vscode.Webview
 		}
 	}
 
+	public openDocumentLink(linkText: string, fromResource: vscode.Uri) {
+		const viewColumn = this.findPreview(fromResource)?.resourceColumn;
+		return this._opener.openDocumentLink(linkText, fromResource, viewColumn);
+	}
+
 	public async deserializeWebviewPanel(
 		webview: vscode.WebviewPanel,
 		state: any

--- a/extensions/markdown-language-features/types/previewMessaging.d.ts
+++ b/extensions/markdown-language-features/types/previewMessaging.d.ts
@@ -71,10 +71,17 @@ export namespace ToWebviewMessage {
 		readonly id: string;
 	}
 
+	export interface OpenImageContent extends BaseMessage {
+		readonly type: 'openImage';
+		readonly source: string;
+		readonly imageSource: string;
+	}
+
 	export type Type =
 		| OnDidChangeTextEditorSelection
 		| UpdateView
 		| UpdateContent
 		| CopyImageContent
+		| OpenImageContent
 		;
 }


### PR DESCRIPTION
resolve #184553

This pull request aims to check whether an `img.src` is local or not, given that a local `src` attribute is automatically changed to a URI internally.
I've utilized the fact that any non-local `src` attribute will not be altered, providing a basis for differentiation.
I'm open to any suggestions for better ways to achieve this.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
