### PR TITLE
ensure shell integration is set when cwd is changed

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadTerminalShellIntegration.ts
+++ b/src/vs/workbench/api/browser/mainThreadTerminalShellIntegration.ts
@@ -37,7 +37,7 @@ export class MainThreadTerminalShellIntegration extends Disposable implements Ma
 		const onDidAddCommandDetection = this._store.add(this._terminalService.createOnInstanceEvent(instance => {
 			return Event.map(
 				Event.filter(instance.capabilities.onDidAddCapabilityType, e => {
-					return e === TerminalCapability.CommandDetection;
+					return e === TerminalCapability.CommandDetection || e === TerminalCapability.CwdDetection;
 				}), () => instance
 			);
 		})).event;

--- a/src/vs/workbench/api/common/extHostTerminalShellIntegration.ts
+++ b/src/vs/workbench/api/common/extHostTerminalShellIntegration.ts
@@ -29,6 +29,8 @@ export class ExtHostTerminalShellIntegration extends Disposable implements IExtH
 
 	protected _proxy: MainThreadTerminalShellIntegrationShape;
 
+	private _initialCwd: URI | undefined;
+
 	private _activeShellIntegrations: Map</*instanceId*/number, InternalTerminalShellIntegration> = new Map();
 
 	protected readonly _onDidChangeTerminalShellIntegration = new Emitter<vscode.TerminalShellIntegrationChangeEvent>();
@@ -92,6 +94,9 @@ export class ExtHostTerminalShellIntegration extends Disposable implements IExtH
 		if (!shellIntegration) {
 			shellIntegration = new InternalTerminalShellIntegration(terminal.value, this._onDidStartTerminalShellExecution);
 			this._activeShellIntegrations.set(instanceId, shellIntegration);
+			if (this._initialCwd) {
+				this._activeShellIntegrations.get(instanceId)?.setCwd(this._initialCwd);
+			}
 			shellIntegration.store.add(terminal.onWillDispose(() => this._activeShellIntegrations.get(instanceId)?.dispose()));
 			shellIntegration.store.add(shellIntegration.onDidRequestShellExecution(commandLine => this._proxy.$executeCommand(instanceId, commandLine)));
 			shellIntegration.store.add(shellIntegration.onDidRequestEndExecution(e => this._onDidEndTerminalShellExecution.fire(e)));
@@ -132,7 +137,13 @@ export class ExtHostTerminalShellIntegration extends Disposable implements IExtH
 	}
 
 	public $cwdChange(instanceId: number, cwd: UriComponents | undefined): void {
-		this._activeShellIntegrations.get(instanceId)?.setCwd(URI.revive(cwd));
+		const activeShellIntegration = this._activeShellIntegrations.get(instanceId);
+		const revivedCwd = URI.revive(cwd);
+		if (!activeShellIntegration) {
+			this._initialCwd = revivedCwd;
+		} else {
+			this._activeShellIntegrations.get(instanceId)?.setCwd(revivedCwd);
+		}
 	}
 
 	public $closeTerminal(instanceId: number): void {


### PR DESCRIPTION
fix #234670
fix #234671

without this change, `
 this._activeShellIntegrations.get(instanceId)`  would be `undefined` so cwd wouldn't get set (or stored). each commit on this PR fixes it, but differently.

https://github.com/microsoft/vscode/blob/d7e34a7c8dab66edb16ed25b2a3b3b3876f1df38/src/vs/workbench/api/common/extHostTerminalShellIntegration.ts#L135
