### PR TITLE
Allow up to 16 texture atlas pages and use fixed arrays in the shader

### DIFF
--- a/src/vs/editor/browser/gpu/atlas/textureAtlas.ts
+++ b/src/vs/editor/browser/gpu/atlas/textureAtlas.ts
@@ -29,6 +29,12 @@ export class TextureAtlas extends Disposable {
 	private readonly _allocatorType: AllocatorType;
 
 	/**
+	 * The maximum number of texture atlas pages. This is currently a hard static cap that must not
+	 * be reached.
+	 */
+	static readonly maximumPageCount = 16;
+
+	/**
 	 * The main texture atlas pages which are both larger textures and more efficiently packed
 	 * relative to the scratch page. The idea is the main pages are drawn to and uploaded to the GPU
 	 * much less frequently so as to not drop frames.
@@ -131,7 +137,9 @@ export class TextureAtlas extends Disposable {
 	}
 
 	private _getGlyphFromNewPage(rasterizer: IGlyphRasterizer, chars: string, tokenMetadata: number, charMetadata: number): Readonly<ITextureAtlasPageGlyph> {
-		// TODO: Support more than 2 pages and the GPU texture layer limit
+		if (this._pages.length >= TextureAtlas.maximumPageCount) {
+			throw new Error(`Attempt to create a texture atlas page past the limit ${TextureAtlas.maximumPageCount}`);
+		}
 		this._pages.push(this._instantiationService.createInstance(TextureAtlasPage, this._pages.length, this.pageSize, this._allocatorType));
 		this._glyphPageIndex.set(chars, tokenMetadata, charMetadata, rasterizer.cacheKey, this._pages.length - 1);
 		return this._pages[this._pages.length - 1].getGlyph(rasterizer, chars, tokenMetadata, charMetadata)!;

--- a/src/vs/editor/browser/gpu/fullFileRenderStrategy.wgsl.ts
+++ b/src/vs/editor/browser/gpu/fullFileRenderStrategy.wgsl.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { TextureAtlasPage } from './atlas/textureAtlasPage.js';
 import { BindingId } from './gpu.js';
 
 export const fullFileRenderStrategyWgsl = /*wgsl*/ `
@@ -45,8 +46,8 @@ struct VSOutput {
 @group(0) @binding(${BindingId.ScrollOffset})            var<uniform>       scrollOffset:    ScrollOffset;
 
 // Storage buffers
-@group(0) @binding(${BindingId.GlyphInfo0})              var<storage, read> glyphInfo0:      array<GlyphInfo>;
-@group(0) @binding(${BindingId.GlyphInfo1})              var<storage, read> glyphInfo1:      array<GlyphInfo>;
+@group(0) @binding(${BindingId.GlyphInfo0})              var<storage, read> glyphInfo0:      array<GlyphInfo, ${TextureAtlasPage.maximumGlyphCount}>;
+@group(0) @binding(${BindingId.GlyphInfo1})              var<storage, read> glyphInfo1:      array<GlyphInfo, ${TextureAtlasPage.maximumGlyphCount}>;
 @group(0) @binding(${BindingId.Cells})                   var<storage, read> cells:           array<Cell>;
 
 @vertex fn vs(

--- a/src/vs/editor/browser/gpu/fullFileRenderStrategy.wgsl.ts
+++ b/src/vs/editor/browser/gpu/fullFileRenderStrategy.wgsl.ts
@@ -46,8 +46,7 @@ struct VSOutput {
 @group(0) @binding(${BindingId.ScrollOffset})            var<uniform>       scrollOffset:    ScrollOffset;
 
 // Storage buffers
-@group(0) @binding(${BindingId.GlyphInfo0})              var<storage, read> glyphInfo0:      array<GlyphInfo, ${TextureAtlasPage.maximumGlyphCount}>;
-@group(0) @binding(${BindingId.GlyphInfo1})              var<storage, read> glyphInfo1:      array<GlyphInfo, ${TextureAtlasPage.maximumGlyphCount}>;
+@group(0) @binding(${BindingId.GlyphInfo})               var<storage, read> glyphInfo:       array<array<GlyphInfo, ${TextureAtlasPage.maximumGlyphCount}>, 2>;
 @group(0) @binding(${BindingId.Cells})                   var<storage, read> cells:           array<Cell>;
 
 @vertex fn vs(
@@ -56,14 +55,7 @@ struct VSOutput {
 	@builtin(vertex_index) vertexIndex : u32
 ) -> VSOutput {
 	let cell = cells[instanceIndex];
-	// TODO: Is there a nicer way to init this?
-	var glyph = glyphInfo0[0];
-	let glyphIndex = u32(cell.glyphIndex);
-	if (u32(cell.textureIndex) == 0) {
-		glyph = glyphInfo0[glyphIndex];
-	} else {
-		glyph = glyphInfo1[glyphIndex];
-	}
+	var glyph = glyphInfo[u32(cell.textureIndex)][u32(cell.glyphIndex)];
 
 	var vsOut: VSOutput;
 	// Multiple vert.position by 2,-2 to get it into clipspace which ranged from -1 to 1

--- a/src/vs/editor/browser/gpu/fullFileRenderStrategy.wgsl.ts
+++ b/src/vs/editor/browser/gpu/fullFileRenderStrategy.wgsl.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { TextureAtlas } from './atlas/textureAtlas.js';
 import { TextureAtlasPage } from './atlas/textureAtlasPage.js';
 import { BindingId } from './gpu.js';
 
@@ -46,7 +47,7 @@ struct VSOutput {
 @group(0) @binding(${BindingId.ScrollOffset})            var<uniform>       scrollOffset:    ScrollOffset;
 
 // Storage buffers
-@group(0) @binding(${BindingId.GlyphInfo})               var<storage, read> glyphInfo:       array<array<GlyphInfo, ${TextureAtlasPage.maximumGlyphCount}>, 2>;
+@group(0) @binding(${BindingId.GlyphInfo})               var<storage, read> glyphInfo:       array<array<GlyphInfo, ${TextureAtlasPage.maximumGlyphCount}>, ${TextureAtlas.maximumPageCount}>;
 @group(0) @binding(${BindingId.Cells})                   var<storage, read> cells:           array<Cell>;
 
 @vertex fn vs(

--- a/src/vs/editor/browser/gpu/gpu.ts
+++ b/src/vs/editor/browser/gpu/gpu.ts
@@ -8,8 +8,7 @@ import type { ViewportData } from '../../common/viewLayout/viewLinesViewportData
 import type { ViewLineOptions } from '../viewParts/viewLines/viewLineOptions.js';
 
 export const enum BindingId {
-	GlyphInfo0,
-	GlyphInfo1,
+	GlyphInfo,
 	Cells,
 	TextureSampler,
 	Texture,

--- a/src/vs/editor/browser/viewParts/viewLinesGpu/viewLinesGpu.ts
+++ b/src/vs/editor/browser/viewParts/viewLinesGpu/viewLinesGpu.ts
@@ -343,7 +343,7 @@ export class ViewLinesGpu extends ViewPart implements IViewLines {
 			if (entryOffset / GlyphStorageBufferInfo.FloatsPerEntry > TextureAtlasPage.maximumGlyphCount) {
 				throw new Error(`Attempting to write more glyphs (${entryOffset / GlyphStorageBufferInfo.FloatsPerEntry}) than the GPUBuffer can hold (${TextureAtlasPage.maximumGlyphCount})`);
 			}
-			this._device.queue.writeBuffer(this._glyphStorageBuffer[layerIndex], 0, values);
+			this._device.queue.writeBuffer(this._glyphStorageBuffer[layerIndex], 0, values, 0, GlyphStorageBufferInfo.FloatsPerEntry * TextureAtlasPage.maximumGlyphCount);
 			if (page.usedArea.right - page.usedArea.left > 0 && page.usedArea.bottom - page.usedArea.top > 0) {
 				this._device.queue.copyExternalImageToTexture(
 					{ source: page.source },


### PR DESCRIPTION
The limit on my machine is 256 (and the default [according to mdn](https://developer.mozilla.org/en-US/docs/Web/API/GPUSupportedLimits)) which is a little excessive. Setting to a fixed 16 should cover the majority of cases. This can be refined later when we run into problems.

Fixes https://github.com/microsoft/vscode/issues/227100

This will allow users to zoom in on most machines and not hit the limit.