### PR TITLE
Fix decoration support edge case of className being a prefix

### DIFF
--- a/src/vs/editor/browser/gpu/decorationCssRuleExtractor.ts
+++ b/src/vs/editor/browser/gpu/decorationCssRuleExtractor.ts
@@ -63,8 +63,17 @@ export class DecorationCssRuleExtractor extends Disposable {
 					// Note that originally `.matches(rule.selectorText)` was used but this would
 					// not pick up pseudo-classes which are important to determine support of the
 					// returned styles.
-					if (rule.selectorText.includes(`.${className}`)) {
-						rules.push(rule);
+					//
+					// Since a selector could contain a class name lookup that is simple a prefix of
+					// the class name we are looking for, we need to also check the character after
+					// it.
+					const searchTerm = `.${className}`;
+					const index = rule.selectorText.indexOf(searchTerm);
+					if (index !== -1) {
+						const endOfResult = index + searchTerm.length;
+						if (rule.selectorText.length === endOfResult || rule.selectorText.substring(endOfResult, endOfResult + 1).match(/[ :]/)) {
+							rules.push(rule);
+						}
 					}
 				}
 			}

--- a/src/vs/editor/test/browser/gpu/decorationCssRulerExtractor.test.ts
+++ b/src/vs/editor/test/browser/gpu/decorationCssRulerExtractor.test.ts
@@ -80,4 +80,15 @@ suite('DecorationCssRulerExtractor', () => {
 			`.${testClassName}:hover { opacity: 1; }`,
 		]);
 	});
+
+	test('should not pick up styles from selectors where the prefix is the class', () => {
+		addStyleElement([
+			`.${testClassName} { color: red; }`,
+			`.${testClassName}-ignoreme { opacity: 1; }`,
+			`.${testClassName}fake { opacity: 1; }`,
+		].join('\n'));
+		assertStyles(testClassName, [
+			`.${testClassName} { color: red; }`,
+		]);
+	});
 });


### PR DESCRIPTION
Fixes #234577

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
