### PR TITLE
Remove TODOs that aren't needed

### DIFF
--- a/src/vs/editor/browser/viewParts/viewLinesGpu/viewLinesGpu.ts
+++ b/src/vs/editor/browser/viewParts/viewLinesGpu/viewLinesGpu.ts
@@ -320,8 +320,6 @@ export class ViewLinesGpu extends ViewPart implements IViewLines {
 
 			this._logService.trace('Updating atlas page[', layerIndex, '] from version ', this._atlasGpuTextureVersions[layerIndex], ' to version ', page.version);
 
-			// TODO: Reuse buffer instead of reconstructing each time
-			// TODO: Dynamically set buffer size
 			const entryCount = GlyphStorageBufferInfo.FloatsPerEntry * TextureAtlasPage.maximumGlyphCount;
 			const values = new Float32Array(entryCount);
 			let entryOffset = 0;


### PR DESCRIPTION
This would be a micro-optimization at this point. Currently a page's values takes a bit over 100kb, and it's probably preferable to re-create it instead of sharing and potentially getting a reused buffer locks. We can consider using a buffer pool with memory reclamation if this impacts performance later.

Fixes #227103

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
