### PR TITLE
testing: allow enabling and disabling CR per-profile

### DIFF
--- a/src/vs/base/common/prefixTree.ts
+++ b/src/vs/base/common/prefixTree.ts
@@ -20,9 +20,10 @@ export interface IPrefixTreeNode<T> {
  * well-defined prefix segments.
  */
 export class WellDefinedPrefixTree<V> {
-	private readonly root = new Node<V>();
+	public readonly root = new Node<V>();
 	private _size = 0;
 
+	/** Tree size, not including the root. */
 	public get size() {
 		return this._size;
 	}
@@ -108,6 +109,12 @@ export class WellDefinedPrefixTree<V> {
 				this._size--;
 				yield node._value;
 			}
+		}
+
+		// special case for the root note
+		if (subtree === this.root) {
+			this.root._value = unset;
+			this.root.children = undefined;
 		}
 	}
 

--- a/src/vs/base/test/common/prefixTree.test.ts
+++ b/src/vs/base/test/common/prefixTree.test.ts
@@ -159,4 +159,31 @@ suite('WellDefinedPrefixTree', () => {
 		assert.deepStrictEqual([...tree.deleteRecursive(key4)], [45]);
 		assert.strictEqual(tree.size, 0);
 	});
+
+	test('insert and delete root', () => {
+		assert.strictEqual(tree.size, 0);
+		tree.insert([], 1234);
+		assert.strictEqual(tree.size, 1);
+		assert.strictEqual(tree.find([]), 1234);
+		assert.strictEqual(tree.delete([]), 1234);
+		assert.strictEqual(tree.size, 0);
+
+		assert.strictEqual(tree.find([]), undefined);
+		assert.strictEqual(tree.delete([]), undefined);
+		assert.strictEqual(tree.size, 0);
+	});
+
+	test('insert and deleteRecursive root', () => {
+		assert.strictEqual(tree.size, 0);
+		tree.insert([], 1234);
+		tree.insert(['a'], 4567);
+		assert.strictEqual(tree.size, 2);
+		assert.strictEqual(tree.find([]), 1234);
+		assert.deepStrictEqual([...tree.deleteRecursive([])], [1234, 4567]);
+		assert.strictEqual(tree.size, 0);
+
+		assert.strictEqual(tree.find([]), undefined);
+		assert.deepStrictEqual([...tree.deleteRecursive([])], []);
+		assert.strictEqual(tree.size, 0);
+	});
 });

--- a/src/vs/workbench/contrib/testing/browser/testExplorerActions.ts
+++ b/src/vs/workbench/contrib/testing/browser/testExplorerActions.ts
@@ -494,8 +494,15 @@ class StartContinuousRunAction extends Action2 {
 			menu: continuousMenus(false),
 		});
 	}
-	async run(accessor: ServicesAccessor, ...args: any[]): Promise<void> {
+	async run(accessor: ServicesAccessor): Promise<void> {
 		const crs = accessor.get(ITestingContinuousRunService);
+		const profileService = accessor.get(ITestProfileService);
+
+		const lastRunProfiles = [...profileService.all()].flatMap(p => p.profiles.filter(p => crs.lastRunProfileIds.has(p.profileId)));
+		if (lastRunProfiles.length) {
+			return crs.start(lastRunProfiles);
+		}
+
 		const selected = await selectContinuousRunProfiles(crs, accessor.get(INotificationService), accessor.get(IQuickInputService), accessor.get(ITestProfileService).all());
 		if (selected.length) {
 			crs.start(selected);

--- a/src/vs/workbench/contrib/testing/common/testTypes.ts
+++ b/src/vs/workbench/contrib/testing/common/testTypes.ts
@@ -8,6 +8,7 @@ import { MarshalledId } from '../../../../base/common/marshallingIds.js';
 import { URI, UriComponents } from '../../../../base/common/uri.js';
 import { IPosition, Position } from '../../../../editor/common/core/position.js';
 import { IRange, Range } from '../../../../editor/common/core/range.js';
+import { localize } from '../../../../nls.js';
 import { TestId } from './testId.js';
 
 export const enum TestResultState {
@@ -51,6 +52,12 @@ export const enum TestRunProfileBitset {
 	HasConfigurable = 1 << 5,
 	SupportsContinuousRun = 1 << 6,
 }
+
+export const testProfileBitset = {
+	[TestRunProfileBitset.Run]: localize('testing.runProfileBitset.run', 'Run'),
+	[TestRunProfileBitset.Debug]: localize('testing.runProfileBitset.debug', 'Debug'),
+	[TestRunProfileBitset.Coverage]: localize('testing.runProfileBitset.coverage', 'Coverage'),
+};
 
 /**
  * List of all test run profile bitset values.

--- a/src/vs/workbench/contrib/testing/common/testingContextKeys.ts
+++ b/src/vs/workbench/contrib/testing/common/testingContextKeys.ts
@@ -12,7 +12,7 @@ export namespace TestingContextKeys {
 	export const providerCount = new RawContextKey('testing.providerCount', 0);
 	export const canRefreshTests = new RawContextKey('testing.canRefresh', false, { type: 'boolean', description: localize('testing.canRefresh', 'Indicates whether any test controller has an attached refresh handler.') });
 	export const isRefreshingTests = new RawContextKey('testing.isRefreshing', false, { type: 'boolean', description: localize('testing.isRefreshing', 'Indicates whether any test controller is currently refreshing tests.') });
-	export const isContinuousModeOn = new RawContextKey('testing.isContinuousModeOn', false, { type: 'boolean', description: localize('testing.isContinuousModeOn', 'Indicates whether continuous test mode is on.') });
+	export const isContinuousModeOn = new RawContextKey<boolean>('testing.isContinuousModeOn', false, { type: 'boolean', description: localize('testing.isContinuousModeOn', 'Indicates whether continuous test mode is on.') });
 	export const hasDebuggableTests = new RawContextKey('testing.hasDebuggableTests', false, { type: 'boolean', description: localize('testing.hasDebuggableTests', 'Indicates whether any test controller has registered a debug configuration') });
 	export const hasRunnableTests = new RawContextKey('testing.hasRunnableTests', false, { type: 'boolean', description: localize('testing.hasRunnableTests', 'Indicates whether any test controller has registered a run configuration') });
 	export const hasCoverableTests = new RawContextKey('testing.hasCoverableTests', false, { type: 'boolean', description: localize('testing.hasCoverableTests', 'Indicates whether any test controller has registered a coverage configuration') });

--- a/src/vs/workbench/contrib/testing/test/common/testingContinuousRunService.test.ts
+++ b/src/vs/workbench/contrib/testing/test/common/testingContinuousRunService.test.ts
@@ -1,0 +1,164 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { CancellationToken } from '../../../../../base/common/cancellation.js';
+import { Emitter } from '../../../../../base/common/event.js';
+import { ensureNoDisposablesAreLeakedInTestSuite } from '../../../../../base/test/common/utils.js';
+import { MockContextKeyService } from '../../../../../platform/keybinding/test/common/mockKeybindingService.js';
+import { mock, TestStorageService } from '../../../../test/common/workbenchTestServices.js';
+import { ITestingContinuousRunService, TestingContinuousRunService } from '../../common/testingContinuousRunService.js';
+import { ITestProfileService } from '../../common/testProfileService.js';
+import { ITestService } from '../../common/testService.js';
+import { ITestRunProfile, ResolvedTestRunRequest, TestRunProfileBitset } from '../../common/testTypes.js';
+
+suite('TestingContinuousRunService', () => {
+	const ds = ensureNoDisposablesAreLeakedInTestSuite();
+	let testService: MockTestService;
+	let cr: ITestingContinuousRunService;
+
+	const profile1: ITestRunProfile = { profileId: 1, controllerId: 'ctrl', group: TestRunProfileBitset.Run, label: 'label', supportsContinuousRun: true, isDefault: false, hasConfigurationHandler: true, tag: null };
+	const profile2: ITestRunProfile = { profileId: 2, controllerId: 'ctrl', group: TestRunProfileBitset.Run, label: 'label', supportsContinuousRun: true, isDefault: false, hasConfigurationHandler: true, tag: null };
+
+	class MockTestService extends mock<ITestService>() {
+		public requests = new Set<ResolvedTestRunRequest>();
+		public log: [kind: 'start' | 'stop', profileId: number, testIds: string[]][] = [];
+
+		override startContinuousRun(req: ResolvedTestRunRequest, token: CancellationToken): Promise<void> {
+			this.requests.add(req);
+			this.log.push(['start', req.targets[0].profileId, req.targets[0].testIds]);
+			ds.add(token.onCancellationRequested(() => {
+				this.log.push(['stop', req.targets[0].profileId, req.targets[0].testIds]);
+				this.requests.delete(req);
+			}));
+			return Promise.resolve();
+		}
+	}
+
+	class MockProfilesService extends mock<ITestProfileService>() {
+		public didChangeEmitter = ds.add(new Emitter<void>());
+		override onDidChange = this.didChangeEmitter.event;
+
+		override getGroupDefaultProfiles(group: TestRunProfileBitset, controllerId?: string): ITestRunProfile[] {
+			return [];
+		}
+	}
+
+	setup(() => {
+		testService = new MockTestService();
+		cr = ds.add(new TestingContinuousRunService(
+			testService,
+			ds.add(new TestStorageService()),
+			ds.add(new MockContextKeyService()),
+			new MockProfilesService(),
+		));
+	});
+
+	test('isSpecificallyEnabledFor', () => {
+		assert.strictEqual(cr.isEnabled(), false);
+		assert.strictEqual(cr.isSpecificallyEnabledFor('testId'), false);
+
+		cr.start([profile1], 'testId\0child');
+		assert.strictEqual(cr.isSpecificallyEnabledFor('testId'), false);
+		assert.strictEqual(cr.isSpecificallyEnabledFor('testId\0child'), true);
+
+		assert.deepStrictEqual(testService.log, [
+			['start', 1, ['testId\0child']],
+		]);
+	});
+
+	test('isEnabledForAParentOf', () => {
+		assert.strictEqual(cr.isEnabled(), false);
+		assert.strictEqual(cr.isEnabledForAParentOf('testId'), false);
+		cr.start([profile1], 'parentTestId\0testId');
+		assert.strictEqual(cr.isEnabledForAParentOf('parentTestId'), false);
+		assert.strictEqual(cr.isEnabledForAParentOf('parentTestId\0testId'), true);
+		assert.strictEqual(cr.isEnabledForAParentOf('parentTestId\0testId\0nestd'), true);
+		assert.strictEqual(cr.isEnabled(), true);
+
+		assert.deepStrictEqual(testService.log, [
+			['start', 1, ['parentTestId\0testId']],
+		]);
+	});
+
+	test('isEnabledForAChildOf', () => {
+		assert.strictEqual(cr.isEnabled(), false);
+		assert.strictEqual(cr.isEnabledForAChildOf('testId'), false);
+		cr.start([profile1], 'testId\0childTestId');
+		assert.strictEqual(cr.isEnabledForAChildOf('testId'), true);
+		assert.strictEqual(cr.isEnabledForAChildOf('testId\0childTestId'), true);
+		assert.strictEqual(cr.isEnabledForAChildOf('testId\0childTestId\0neested'), false);
+		assert.strictEqual(cr.isEnabled(), true);
+	});
+
+	suite('lifecycle', () => {
+		test('stops general in DFS order', () => {
+			cr.start([profile1], 'a\0b\0c\0d');
+			cr.start([profile1], 'a\0b');
+			cr.start([profile1], 'a\0b\0c');
+			cr.stop();
+			assert.deepStrictEqual(testService.log, [
+				['start', 1, ['a\0b\0c\0d']],
+				['start', 1, ['a\0b']],
+				['start', 1, ['a\0b\0c']],
+				['stop', 1, ['a\0b\0c\0d']],
+				['stop', 1, ['a\0b\0c']],
+				['stop', 1, ['a\0b']],
+			]);
+			assert.strictEqual(cr.isEnabled(), false);
+		});
+
+		test('stops profiles in DFS order', () => {
+			cr.start([profile1], 'a\0b\0c\0d');
+			cr.start([profile1], 'a\0b');
+			cr.start([profile1], 'a\0b\0c');
+			cr.stopProfile(profile1);
+			assert.deepStrictEqual(testService.log, [
+				['start', 1, ['a\0b\0c\0d']],
+				['start', 1, ['a\0b']],
+				['start', 1, ['a\0b\0c']],
+				['stop', 1, ['a\0b\0c\0d']],
+				['stop', 1, ['a\0b\0c']],
+				['stop', 1, ['a\0b']],
+			]);
+			assert.strictEqual(cr.isEnabled(), false);
+		});
+
+		test('updates profile for a test if profile is changed', () => {
+			cr.start([profile1], 'parent\0testId');
+			cr.start([profile2], 'parent\0testId');
+			assert.strictEqual(cr.isEnabled(), true);
+			cr.stop();
+			assert.strictEqual(cr.isEnabled(), false);
+			assert.deepStrictEqual(testService.log, [
+				['start', 1, ['parent\0testId']],
+				['start', 2, ['parent\0testId']],
+				['stop', 1, ['parent\0testId']],
+				['stop', 2, ['parent\0testId']],
+			]);
+			assert.strictEqual(cr.isEnabled(), false);
+		});
+
+		test('stops a single profile test', () => {
+			cr.start([profile1, profile2], 'parent\0testId');
+			cr.stopProfile(profile1);
+			assert.deepStrictEqual(testService.log, [
+				['start', 1, ['parent\0testId']],
+				['start', 2, ['parent\0testId']],
+				['stop', 1, ['parent\0testId']],
+			]);
+			assert.strictEqual(cr.isEnabled(), true);
+
+			cr.stopProfile(profile2);
+			assert.deepStrictEqual(testService.log, [
+				['start', 1, ['parent\0testId']],
+				['start', 2, ['parent\0testId']],
+				['stop', 1, ['parent\0testId']],
+				['stop', 2, ['parent\0testId']],
+			]);
+			assert.strictEqual(cr.isEnabled(), false);
+		});
+	});
+});


### PR DESCRIPTION
Adds a dropdown to the continous run button that allows enabling and
disabling profiles used in autorun individually. Pretty simple but
involved some refactoring of the CR service.

![](https://memes.peet.io/img/24-11-b6823379-2eb8-4fb1-bbeb-deb15670d441.png)

We can also technically do this on a per-test basis now too, although
this is not exposed in UI at the moment.

Closes #210848