### PR TITLE
import Module Specifier prefer mode 'project-relative'

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -75,7 +75,7 @@
 	"typescript.tsdk": "node_modules/typescript/lib",
 	"npm.exclude": "**/extensions/**",
 	"emmet.excludeLanguages": [],
-	"typescript.preferences.importModuleSpecifier": "relative",
+	"typescript.preferences.importModuleSpecifier": "project-relative",
 	"typescript.preferences.quoteStyle": "single",
 	"json.schemas": [
 		{


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

![image](https://github.com/user-attachments/assets/5ba6b8ce-bcfb-4c2c-b802-a7f914146b2d)


as showed above, mode 'project-relative' means preferring a non-relative import out of project directory, which could be more appropriate for us to make a auto-import action, because our personal machine's directory is various between each other, we couldn't predict where the file outside locates, and then the relative path is not appropriate, but a non-relative specifier could be.

