### PR TITLE
Fixes old extensionHost process is not killed immediately after reloading vscode web tab in the browser

### DIFF
--- a/src/vs/workbench/services/lifecycle/browser/lifecycleService.ts
+++ b/src/vs/workbench/services/lifecycle/browser/lifecycleService.ts
@@ -172,6 +172,9 @@ export class BrowserLifecycleService extends AbstractLifecycleService {
 			joiners: () => [], 				// Unsupported in web
 			token: CancellationToken.None, 	// Unsupported in web
 			join(promise, joiner) {
+				if (typeof promise === 'function') {
+					promise();
+				}
 				logService.error(`[lifecycle] Long running operations during shutdown are unsupported in the web (id: ${joiner.id})`);
 			},
 			force: () => { /* No-Op in web */ },


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
Fixes https://github.com/microsoft/vscode/issues/234943