### PR TITLE
Click to copy/exec shell code in markdown preview

### DIFF
--- a/extensions/markdown-language-features/.gitignore
+++ b/extensions/markdown-language-features/.gitignore
@@ -1,2 +1,3 @@
 notebook-out
 media/*.js
+media/codicon.css

--- a/extensions/markdown-language-features/esbuild-preview.js
+++ b/extensions/markdown-language-features/esbuild-preview.js
@@ -9,10 +9,16 @@ const srcDir = path.join(__dirname, 'preview-src');
 const outDir = path.join(__dirname, 'media');
 
 require('../esbuild-webview-common').run({
-	entryPoints: [
-		path.join(srcDir, 'index.ts'),
-		path.join(srcDir, 'pre'),
-	],
+	entryPoints: {
+		'index': path.join(srcDir, 'index.ts'),
+		'pre': path.join(srcDir, 'pre'),
+		'codicon': path.join(__dirname, 'node_modules', '@vscode', 'codicons', 'dist', 'codicon.css'),
+	},
 	srcDir,
 	outdir: outDir,
+	additionalOptions: {
+		loader: {
+			'.ttf': 'dataurl',
+		}
+	}
 }, process.argv);

--- a/extensions/markdown-language-features/media/code.css
+++ b/extensions/markdown-language-features/media/code.css
@@ -1,0 +1,56 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+.code-block-wrapper {
+	position: relative;
+	display: block;
+}
+
+.code-block-buttons {
+	position: absolute;
+	top: 8px;
+	right: 8px;
+	display: flex;
+	gap: 4px;
+	z-index: 1;
+}
+
+.terminal-button {
+	position: static;
+	height: 24px;
+	width: 24px;
+	background: var(--vscode-editor-background);
+	border: 1px solid var(--vscode-widget-border);
+	border-color: var(--vscode-button-border);
+	border-radius: 4px;
+	color: var(--vscode-button-foreground);
+	cursor: pointer;
+	transition: opacity 0.2s;
+	padding: 4px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	opacity: 0.25;
+}
+
+.terminal-button i {
+	font-family: codicon;
+	font-style: normal;
+	font-size: 16px;
+	line-height: 16px;
+	color: var(--vscode-icon-foreground);
+}
+
+.code-block-wrapper:hover .terminal-button {
+	opacity: 0.5;
+}
+
+.terminal-button:hover {
+	background: var(--vscode-button-hoverBackground);
+}
+
+.code-block-wrapper:hover .terminal-button:hover {
+	opacity: 1;
+}

--- a/extensions/markdown-language-features/package-lock.json
+++ b/extensions/markdown-language-features/package-lock.json
@@ -29,6 +29,7 @@
         "@types/picomatch": "^2.3.0",
         "@types/vscode-notebook-renderer": "^1.60.0",
         "@types/vscode-webview": "^1.57.0",
+        "@vscode/codicons": "^0.0.36",
         "@vscode/markdown-it-katex": "^1.1.1",
         "lodash.throttle": "^4.1.1",
         "vscode-languageserver-types": "^3.17.2",
@@ -232,6 +233,13 @@
       "resolved": "https://registry.npmjs.org/@types/vscode-webview/-/vscode-webview-1.57.0.tgz",
       "integrity": "sha512-x3Cb/SMa1IwRHfSvKaZDZOTh4cNoG505c3NjTqGlMC082m++x/ETUmtYniDsw6SSmYzZXO8KBNhYxR0+VqymqA==",
       "dev": true
+    },
+    "node_modules/@vscode/codicons": {
+      "version": "0.0.36",
+      "resolved": "https://registry.npmjs.org/@vscode/codicons/-/codicons-0.0.36.tgz",
+      "integrity": "sha512-wsNOvNMMJ2BY8rC2N2MNBG7yOowV3ov8KlvUE/AiVUlHKTfWsw3OgAOQduX7h0Un6GssKD3aoTVH+TF3DSQwKQ==",
+      "dev": true,
+      "license": "CC-BY-4.0"
     },
     "node_modules/@vscode/extension-telemetry": {
       "version": "0.9.8",

--- a/extensions/markdown-language-features/package.json
+++ b/extensions/markdown-language-features/package.json
@@ -737,7 +737,9 @@
     ],
     "markdown.previewStyles": [
       "./media/markdown.css",
-      "./media/highlight.css"
+      "./media/codicon.css",
+      "./media/highlight.css",
+      "./media/code.css"
     ],
     "markdown.previewScripts": [
       "./media/index.js"
@@ -787,6 +789,7 @@
     "@types/vscode-notebook-renderer": "^1.60.0",
     "@types/vscode-webview": "^1.57.0",
     "@vscode/markdown-it-katex": "^1.1.1",
+    "@vscode/codicons": "^0.0.36",
     "lodash.throttle": "^4.1.1",
     "vscode-languageserver-types": "^3.17.2",
     "vscode-markdown-languageservice": "^0.3.0-alpha.3"

--- a/extensions/markdown-language-features/preview-src/code.ts
+++ b/extensions/markdown-language-features/preview-src/code.ts
@@ -1,0 +1,78 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { MessagePoster } from './messaging';
+import { PreviewSettings } from './settings';
+import { getStrings } from './strings';
+
+export class CodeBlockManager {
+	private _messaging?: MessagePoster;
+
+	constructor(private readonly _settings: PreviewSettings) { }
+
+	public setPoster(poster: MessagePoster) {
+		this._messaging = poster;
+	}
+
+	public initializeCodeBlocks() {
+		const shellBlocks = document.querySelectorAll('pre:has(.code-line)');
+		shellBlocks.forEach(pre => {
+			this._initializeCodeBlock(pre);
+		});
+	}
+
+	private _initializeCodeBlock(pre: Element) {
+		if (pre.parentElement?.classList.contains('code-block-wrapper')) {
+			return;
+		}
+		const wrapper = document.createElement('div');
+		wrapper.className = 'code-block-wrapper';
+		pre.parentElement?.replaceChild(wrapper, pre);
+		wrapper.appendChild(pre);
+
+		const buttonsContainer = document.createElement('div');
+		buttonsContainer.className = 'code-block-buttons';
+
+		const createClickHandler = (messageType: 'copyText' | 'runInTerminal', parameterName: string) => (e: MouseEvent) => {
+			e.preventDefault();
+			const currentText = pre.querySelector('.code-line')?.textContent ?? '';
+			this._messaging!.postMessage(messageType, {
+				[parameterName]: currentText
+			});
+		};
+
+		const strings = getStrings();
+
+		this._createButton(buttonsContainer, {
+			title: strings.codeBlockCopyAction,
+			icon: 'copy',
+			onClick: createClickHandler('copyText', 'text')
+		});
+
+		if (this._shouldAllowRunInTerminal(pre)) {
+			this._createButton(buttonsContainer, {
+				title: strings.codeBlockRunAction,
+				icon: 'terminal',
+				onClick: createClickHandler('runInTerminal', 'command')
+			});
+		}
+
+		wrapper.appendChild(buttonsContainer);
+	}
+
+	private _shouldAllowRunInTerminal(pre: Element) {
+		return pre.querySelector('.language-shell') !== null && this._settings.allowScriptExecution;
+	}
+
+	private _createButton(container: HTMLElement, options: { title: string; icon: string; onClick: (e: MouseEvent) => void }) {
+		const button = document.createElement('button');
+		button.className = 'terminal-button';
+		button.title = options.title;
+		button.innerHTML = `<i class="codicon codicon-${options.icon}"></i>`;
+		button.addEventListener('click', options.onClick);
+		container.appendChild(button);
+		return button;
+	}
+}

--- a/extensions/markdown-language-features/preview-src/index.ts
+++ b/extensions/markdown-language-features/preview-src/index.ts
@@ -40,7 +40,7 @@ const messaging = createPosterForVsCode(vscode, settings);
 
 window.cspAlerter.setPoster(messaging);
 window.styleLoadingMonitor.setPoster(messaging);
-
+window.codeBlockManager.setPoster(messaging);
 
 function doAfterImagesLoaded(cb: () => void) {
 	const imgElements = document.getElementsByTagName('img');
@@ -80,6 +80,7 @@ onceDocumentLoaded(() => {
 	// Restore
 	const scrollProgress = state.scrollProgress;
 	addImageContexts();
+	window.codeBlockManager.initializeCodeBlocks();
 	if (typeof scrollProgress === 'number' && !settings.settings.fragment) {
 		doAfterImagesLoaded(() => {
 			scrollDisabledCount += 1;
@@ -292,6 +293,7 @@ window.addEventListener('message', async event => {
 
 			window.dispatchEvent(new CustomEvent('vscode.markdown.updateContent'));
 			addImageContexts();
+			window.codeBlockManager.initializeCodeBlocks();
 			break;
 		}
 	}
@@ -372,6 +374,8 @@ function updateScrollProgress() {
 	state.scrollProgress = window.scrollY / document.body.clientHeight;
 	vscode.setState(state);
 }
+
+
 
 
 /**

--- a/extensions/markdown-language-features/preview-src/pre.ts
+++ b/extensions/markdown-language-features/preview-src/pre.ts
@@ -6,13 +6,17 @@
 import { CspAlerter } from './csp';
 import { StyleLoadingMonitor } from './loading';
 import { SettingsManager } from './settings';
+import { CodeBlockManager } from './code';
 
 declare global {
 	interface Window {
 		cspAlerter: CspAlerter;
 		styleLoadingMonitor: StyleLoadingMonitor;
+		codeBlockManager: CodeBlockManager;
 	}
 }
 
-window.cspAlerter = new CspAlerter(new SettingsManager());
+const settingsManager = new SettingsManager();
+window.cspAlerter = new CspAlerter(settingsManager);
 window.styleLoadingMonitor = new StyleLoadingMonitor();
+window.codeBlockManager = new CodeBlockManager(settingsManager.settings);

--- a/extensions/markdown-language-features/preview-src/settings.ts
+++ b/extensions/markdown-language-features/preview-src/settings.ts
@@ -14,6 +14,7 @@ export interface PreviewSettings {
 	readonly disableSecurityWarnings: boolean;
 	readonly doubleClickToSwitchToEditor: boolean;
 	readonly webviewResourceRoot: string;
+	readonly allowScriptExecution: boolean;
 }
 
 export function getRawData(key: string): string {

--- a/extensions/markdown-language-features/src/preview/documentRenderer.ts
+++ b/extensions/markdown-language-features/src/preview/documentRenderer.ts
@@ -25,7 +25,11 @@ const previewStrings = {
 
 	cspAlertMessageTitle: vscode.l10n.t("Potentially unsafe or insecure content has been disabled in the Markdown preview. Change the Markdown preview security setting to allow insecure content or enable scripts"),
 
-	cspAlertMessageLabel: vscode.l10n.t("Content Disabled Security Warning")
+	cspAlertMessageLabel: vscode.l10n.t("Content Disabled Security Warning"),
+
+	codeBlockCopyAction: vscode.l10n.t("Copy Code"),
+
+	codeBlockRunAction: vscode.l10n.t("Run in Terminal")
 };
 
 export interface MarkdownContentProviderOutput {
@@ -76,6 +80,7 @@ export class MdDocumentRenderer {
 			scrollEditorWithPreview: config.scrollEditorWithPreview,
 			doubleClickToSwitchToEditor: config.doubleClickToSwitchToEditor,
 			disableSecurityWarnings: this._cspArbiter.shouldDisableSecurityWarnings(),
+			allowScriptExecution: this._cspArbiter.shouldAllowScriptExecutionForResource(sourceUri),
 			webviewResourceRoot: resourceProvider.asWebviewUri(markdownDocument.uri).toString(),
 		};
 

--- a/extensions/markdown-language-features/src/preview/preview.ts
+++ b/extensions/markdown-language-features/src/preview/preview.ts
@@ -150,6 +150,14 @@ class MarkdownPreview extends Disposable implements WebviewResourceProvider {
 					vscode.window.showWarningMessage(
 						vscode.l10n.t("Could not load 'markdown.styles': {0}", e.unloadedStyles.join(', ')));
 					break;
+
+				case 'copyText':
+					vscode.env.clipboard.writeText(e.text);
+					break;
+
+				case 'runInTerminal':
+					this._onDidRunInTerminal(e.command);
+					break;
 			}
 		}));
 
@@ -299,6 +307,11 @@ class MarkdownPreview extends Disposable implements WebviewResourceProvider {
 			this._isScrolling = true;
 			scrollEditorToLine(line, editor);
 		}
+	}
+
+	private async _onDidRunInTerminal(command: string): Promise<void> {
+		const terminal = vscode.window.activeTerminal || vscode.window.createTerminal();
+		await terminal.sendText(command);
 	}
 
 	private async _onDidClickPreview(line: number): Promise<void> {

--- a/extensions/markdown-language-features/src/preview/security.ts
+++ b/extensions/markdown-language-features/src/preview/security.ts
@@ -24,6 +24,8 @@ export interface ContentSecurityPolicyArbiter {
 	shouldDisableSecurityWarnings(): boolean;
 
 	setShouldDisableSecurityWarning(shouldShow: boolean): Thenable<void>;
+
+	shouldAllowScriptExecutionForResource(resource: vscode.Uri): boolean;
 }
 
 export class ExtensionContentSecurityPolicyArbiter implements ContentSecurityPolicyArbiter {
@@ -65,6 +67,11 @@ export class ExtensionContentSecurityPolicyArbiter implements ContentSecurityPol
 
 	public setShouldDisableSecurityWarning(disabled: boolean): Thenable<void> {
 		return this._workspaceState.update(this._should_disable_security_warning_key, disabled);
+	}
+
+	public shouldAllowScriptExecutionForResource(resource: vscode.Uri): boolean {
+		const workspaceName = vscode.workspace.getWorkspaceFolder(resource)?.name;
+		return workspaceName !== undefined && workspaceName === vscode.workspace.name && vscode.workspace.isTrusted;
 	}
 
 	private _getRoot(resource: vscode.Uri): vscode.Uri {

--- a/extensions/markdown-language-features/types/previewMessaging.d.ts
+++ b/extensions/markdown-language-features/types/previewMessaging.d.ts
@@ -38,6 +38,16 @@ export namespace FromWebviewMessage {
 		readonly unloadedStyles: readonly string[];
 	}
 
+	export interface RunInTerminal extends BaseMessage {
+		readonly type: 'runInTerminal';
+		readonly command: string;
+	}
+
+	export interface CopyText extends BaseMessage {
+		readonly type: 'copyText';
+		readonly text: string;
+	}
+
 	export type Type =
 		| CacheImageSizes
 		| RevealLine
@@ -45,6 +55,8 @@ export namespace FromWebviewMessage {
 		| ClickLink
 		| ShowPreviewSecuritySelector
 		| PreviewStyleLoadError
+		| RunInTerminal
+		| CopyText
 		;
 }
 


### PR DESCRIPTION
Requested in #209876

Introduces a `CodeBlockManager` class that wraps every code block with a container and overlays either one or two buttons:

- A copy button that copies the code to the clipboard
- An execute button that executes the code in the active terminal, or creates a new terminal if none is active

The execute button is only shown if the markdown file is in the workspace that the preview is running in, and if `workspace.isTrusted`.

Minimal changes to dependencies and `esbuild-preview.js` were introduced to support Codicons in the preview web view.

Testing:

Made a markdown file with a few code blocks of various sizes and an image. Opened this markdown file from within both trusted and untrusted workspaces.  Ensured that all of the following worked as expected in both cases:

- Vertical scrolling synchronization
- Active line indicators
- Image rendering
- Presence or absence of the "Run in Terminal" button
- Running code in the terminal
- Copying text
- Horizontal scrolling of code blocks that overflow, ensuring that the copy/exec buttons stay visible
- Resizing the markdown window

30 Second Loom Demo:

[![Markdown Preview Run in Terminal Buttons - 2 December 2024](https://cdn.loom.com/sessions/thumbnails/575228bc47c444ae91fe8d3ca8053387-fc5126dd87ede550-full-play.gif)](https://www.loom.com/share/575228bc47c444ae91fe8d3ca8053387)
