### PR TITLE
Fix bugs with chat paste widget

### DIFF
--- a/src/vs/editor/common/languages.ts
+++ b/src/vs/editor/common/languages.ts
@@ -903,7 +903,7 @@ export interface DocumentPasteEdit {
 	readonly title: string;
 	readonly kind: HierarchicalKind;
 	readonly handledMimeType?: string;
-	readonly yieldTo?: readonly DropYieldTo[];
+	yieldTo?: readonly DropYieldTo[];
 	insertText: string | { readonly snippet: string };
 	additionalEdit?: WorkspaceEdit;
 }

--- a/src/vs/editor/contrib/dropOrPasteInto/browser/copyPasteController.ts
+++ b/src/vs/editor/contrib/dropOrPasteInto/browser/copyPasteController.ts
@@ -685,11 +685,6 @@ export class CopyPasteController extends Disposable implements IEditorContributi
 			}
 		}
 
-		// Specific case for pasting code blocks.
-		if (edits.filter(edit => edit.kind.contains(new HierarchicalKind('chat.attach.text')))) {
-			return edits.findIndex(edit => edit.kind.contains(new HierarchicalKind('text.plain')));
-		}
-
 		return 0;
 	}
 }

--- a/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
@@ -43,6 +43,7 @@ import { getIconClasses } from '../../../../editor/common/services/getIconClasse
 import { IModelService } from '../../../../editor/common/services/model.js';
 import { ITextModelService } from '../../../../editor/common/services/resolverService.js';
 import { CopyPasteController } from '../../../../editor/contrib/dropOrPasteInto/browser/copyPasteController.js';
+import { DropIntoEditorController } from '../../../../editor/contrib/dropOrPasteInto/browser/dropIntoEditorController.js';
 import { ContentHoverController } from '../../../../editor/contrib/hover/browser/contentHoverController.js';
 import { GlyphHoverController } from '../../../../editor/contrib/hover/browser/glyphHoverController.js';
 import { SuggestController } from '../../../../editor/contrib/suggest/browser/suggestController.js';
@@ -656,6 +657,10 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 			inputContainer.classList.toggle('focused', false);
 
 			this._onDidBlur.fire();
+		}));
+		this._register(this._inputEditor.onDidBlurEditorWidget(() => {
+			CopyPasteController.get(this._inputEditor)?.clearWidgets();
+			DropIntoEditorController.get(this._inputEditor)?.clearWidgets();
 		}));
 
 		const hoverDelegate = this._register(createInstantHoverDelegate());

--- a/src/vs/workbench/contrib/chat/browser/chatViewPane.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatViewPane.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { $ } from '../../../../base/browser/dom.js';
 import { CancellationToken } from '../../../../base/common/cancellation.js';
 import { DisposableStore } from '../../../../base/common/lifecycle.js';
 import { MarshalledId } from '../../../../base/common/marshallingIds.js';
@@ -154,6 +155,7 @@ export class ChatViewPane extends ViewPane implements IViewWelcomeDelegate {
 
 			const scopedInstantiationService = this._register(this.instantiationService.createChild(new ServiceCollection([IContextKeyService, this.scopedContextKeyService])));
 			const locationBasedColors = this.getLocationBasedColors();
+			const editorOverflowNode = $('.chat-editor-overflow-widgets');
 			this._widget = this._register(scopedInstantiationService.createInstance(
 				ChatWidget,
 				this.chatOptions.location,
@@ -169,7 +171,8 @@ export class ChatViewPane extends ViewPane implements IViewWelcomeDelegate {
 							return this.chatOptions.location === ChatAgentLocation.EditingSession;
 						},
 					},
-					enableImplicitContext: this.chatOptions.location === ChatAgentLocation.Panel
+					enableImplicitContext: this.chatOptions.location === ChatAgentLocation.Panel,
+					editorOverflowWidgetsDomNode: editorOverflowNode,
 				},
 				{
 					listForeground: SIDE_BAR_FOREGROUND,
@@ -184,6 +187,7 @@ export class ChatViewPane extends ViewPane implements IViewWelcomeDelegate {
 			}));
 			this._register(this._widget.onDidClear(() => this.clear()));
 			this._widget.render(parent);
+			parent.appendChild(editorOverflowNode);
 
 			const sessionId = this.getSessionId();
 			const disposeListener = this._register(this.chatService.onDidDisposeSession((e) => {


### PR DESCRIPTION
Fixes #234902

- Fix z-index #234902
- Use `yieldTo` for edit ordering  instead of hardcoding chat workaround. This makes sure the list of edits shows up in the correct order
- Clear widget on editor focus loss

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
