### PR TITLE
Enable `Go to Current History Item` correctly after reference picker change (fix #235132)

### DIFF
--- a/src/vs/workbench/contrib/scm/browser/scmHistoryViewPane.ts
+++ b/src/vs/workbench/contrib/scm/browser/scmHistoryViewPane.ts
@@ -1348,10 +1348,10 @@ export class SCMHistoryViewPane extends ViewPane {
 				}));
 
 				// HistoryItemRefs filter changed
-				store.add(runOnChange(this._treeViewModel.onDidChangeHistoryItemsFilter, () => {
-					this.refresh();
+				store.add(runOnChange(this._treeViewModel.onDidChangeHistoryItemsFilter, async () => {
+					await this.refresh();
 
-					// Update context key (needs to be done after the refresh call)
+					// Update context key (needs to be done after the refresh call has finished)
 					this._scmCurrentHistoryItemRefInFilter.set(this._isCurrentHistoryItemInFilter(historyItemRefId.get()));
 				}));
 


### PR DESCRIPTION
This PR fixes #235132