### PR TITLE
Clarify tests by using existing folders

### DIFF
--- a/extensions/terminal-suggest/src/test/terminalSuggestMain.test.ts
+++ b/extensions/terminal-suggest/src/test/terminalSuggestMain.test.ts
@@ -105,12 +105,11 @@ const testSpecs2: ISuiteSpec[] = [
 			{ input: 'cd ~|', expectedCompletions: ['~'], expectedResourceRequests: { type: 'folders', cwd: testCwd } },
 
 			// Relative paths
-			{ input: 'cd s|', expectedResourceRequests: { type: 'folders', cwd: testCwd } },
-			{ input: 'cd src|', expectedResourceRequests: { type: 'folders', cwd: testCwd } },
-			{ input: 'cd src/|', expectedResourceRequests: { type: 'folders', cwd: testCwd } },
+			{ input: 'cd c|', expectedResourceRequests: { type: 'folders', cwd: testCwd } },
+			{ input: 'cd child|', expectedResourceRequests: { type: 'folders', cwd: testCwd } },
 			{ input: 'cd .|', expectedResourceRequests: { type: 'folders', cwd: testCwd } },
 			{ input: 'cd ./|', expectedResourceRequests: { type: 'folders', cwd: testCwd } },
-			{ input: 'cd ./src|', expectedResourceRequests: { type: 'folders', cwd: testCwd } },
+			{ input: 'cd ./child|', expectedResourceRequests: { type: 'folders', cwd: testCwd } },
 			{ input: 'cd ..|', expectedResourceRequests: { type: 'folders', cwd: testCwd } },
 
 			// Relative directories (changes cwd due to /)


### PR DESCRIPTION
The old src/ case was removed as it was actually wrong when the folder exists, and that's covered below.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
