### PR TITLE
add z-index to paste widget

### DIFF
--- a/src/vs/editor/contrib/dropOrPasteInto/browser/postEditWidget.css
+++ b/src/vs/editor/contrib/dropOrPasteInto/browser/postEditWidget.css
@@ -10,6 +10,7 @@
 	color: var(--vscode-button-foreground);
 	background-color: var(--vscode-button-background);
 	overflow: hidden;
+	z-index: 10;
 }
 
 .post-edit-widget .monaco-button {


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
fix https://github.com/microsoft/vscode/issues/234902 and fix https://github.com/microsoft/vscode/issues/235197

cc. @mjbvz looks like the fix you did didn't quite work? i see that it's in the overflowing container, but the wrong thing has the higher z-index selector. I just manually added it, but lmk 🫡 

![Screenshot 2024-12-04 at 3 58 34 PM](https://github.com/user-attachments/assets/b1e34674-60a3-4782-857e-ea7c67372b78)
