### PR TITLE
Place edit context dom node always inside the viewport for correct focusing behavior

### DIFF
--- a/src/vs/editor/browser/controller/editContext/native/screenReaderSupport.ts
+++ b/src/vs/editor/browser/controller/editContext/native/screenReaderSupport.ts
@@ -28,7 +28,7 @@ export class ScreenReaderSupport {
 	private _contentWidth: number = 1;
 	private _contentHeight: number = 1;
 	private _lineHeight: number = 1;
-	private _fontInfo: FontInfo | undefined;
+	private _fontInfo!: FontInfo;
 	private _accessibilityPageSize: number = 1;
 	private _ignoreSelectionChangeTime: number = 0;
 
@@ -136,7 +136,7 @@ export class ScreenReaderSupport {
 
 	private _doRender(top: number, left: number, width: number, height: number): void {
 		// For correct alignment of the screen reader content, we need to apply the correct font
-		applyFontInfo(this._domNode, this._fontInfo!);
+		applyFontInfo(this._domNode, this._fontInfo);
 
 		this._domNode.setTop(top);
 		this._domNode.setLeft(left);

--- a/src/vs/editor/browser/controller/editContext/native/screenReaderSupport.ts
+++ b/src/vs/editor/browser/controller/editContext/native/screenReaderSupport.ts
@@ -18,7 +18,7 @@ import { ViewConfigurationChangedEvent, ViewCursorStateChangedEvent } from '../.
 import { ViewContext } from '../../../../common/viewModel/viewContext.js';
 import { applyFontInfo } from '../../../config/domFontInfo.js';
 import { IEditorAriaOptions } from '../../../editorBrowser.js';
-import { RestrictedRenderingContext, RenderingContext } from '../../../view/renderingContext.js';
+import { RestrictedRenderingContext, RenderingContext, HorizontalPosition } from '../../../view/renderingContext.js';
 import { ariaLabelForScreenReaderContent, ISimpleModel, newlinecount, PagedScreenReaderStrategy, ScreenReaderContentState } from '../screenReaderUtils.js';
 
 export class ScreenReaderSupport {
@@ -26,12 +26,14 @@ export class ScreenReaderSupport {
 	// Configuration values
 	private _contentLeft: number = 1;
 	private _contentWidth: number = 1;
+	private _contentHeight: number = 1;
 	private _lineHeight: number = 1;
 	private _fontInfo: FontInfo | undefined;
 	private _accessibilityPageSize: number = 1;
 	private _ignoreSelectionChangeTime: number = 0;
 
 	private _primarySelection: Selection = new Selection(1, 1, 1, 1);
+	private _primaryCursorVisibleRange: HorizontalPosition | null = null;
 	private _screenReaderContentState: ScreenReaderContentState | undefined;
 
 	constructor(
@@ -59,7 +61,7 @@ export class ScreenReaderSupport {
 	public onConfigurationChanged(e: ViewConfigurationChangedEvent): void {
 		this._updateConfigurationSettings();
 		this._updateDomAttributes();
-		if (this._accessibilityService.isScreenReaderOptimized()) {
+		if (this._accessibilityService.isScreenReaderOptimized() && e.hasChanged(EditorOption.accessibilitySupport)) {
 			this.writeScreenReaderContent();
 		}
 	}
@@ -69,6 +71,7 @@ export class ScreenReaderSupport {
 		const layoutInfo = options.get(EditorOption.layoutInfo);
 		this._contentLeft = layoutInfo.contentLeft;
 		this._contentWidth = layoutInfo.contentWidth;
+		this._contentHeight = layoutInfo.height;
 		this._fontInfo = options.get(EditorOption.fontInfo);
 		this._lineHeight = options.get(EditorOption.lineHeight);
 		this._accessibilityPageSize = options.get(EditorOption.accessibilityPageSize);
@@ -93,24 +96,58 @@ export class ScreenReaderSupport {
 
 	public prepareRender(ctx: RenderingContext): void {
 		this.writeScreenReaderContent();
+		this._primaryCursorVisibleRange = ctx.visibleRangeForPosition(this._primarySelection.getPosition());
 	}
 
 	public render(ctx: RestrictedRenderingContext): void {
 		if (!this._screenReaderContentState) {
 			return;
 		}
+
+		if (!this._primaryCursorVisibleRange) {
+			// The primary cursor is outside the viewport => place textarea to the top left
+			this._renderAtTopLeft();
+			return;
+		}
+
+		const editorScrollLeft = this._context.viewLayout.getCurrentScrollLeft();
+		const left = this._contentLeft + this._primaryCursorVisibleRange.left - editorScrollLeft;
+		if (left < this._contentLeft || left > this._contentLeft + this._contentWidth) {
+			// cursor is outside the viewport
+			this._renderAtTopLeft();
+			return;
+		}
+
+		const editorScrollTop = this._context.viewLayout.getCurrentScrollTop();
+		const top = this._context.viewLayout.getVerticalOffsetForLineNumber(this._primarySelection.positionLineNumber) - editorScrollTop;
+		if (top < 0 || top > this._contentHeight) {
+			// cursor is outside the viewport
+			this._renderAtTopLeft();
+			return;
+		}
+
+		this._doRender(top, this._contentLeft, this._contentWidth, this._lineHeight);
+		this._setScrollTop();
+	}
+
+	private _renderAtTopLeft(): void {
+		this._doRender(0, 0, this._contentWidth, 1);
+	}
+
+	private _doRender(top: number, left: number, width: number, height: number): void {
 		// For correct alignment of the screen reader content, we need to apply the correct font
 		applyFontInfo(this._domNode, this._fontInfo!);
 
-		const verticalOffsetForPrimaryLineNumber = this._context.viewLayout.getVerticalOffsetForLineNumber(this._primarySelection.positionLineNumber);
-		const editorScrollTop = this._context.viewLayout.getCurrentScrollTop();
-		const top = verticalOffsetForPrimaryLineNumber - editorScrollTop;
-
 		this._domNode.setTop(top);
-		this._domNode.setLeft(this._contentLeft);
-		this._domNode.setWidth(this._contentWidth);
-		this._domNode.setHeight(this._lineHeight);
+		this._domNode.setLeft(left);
+		this._domNode.setWidth(width);
+		this._domNode.setHeight(height);
+	}
 
+	private _setScrollTop(): void {
+		if (!this._screenReaderContentState) {
+			return;
+		}
 		// Setting position within the screen reader content by modifying scroll position
 		const textContentBeforeSelection = this._screenReaderContentState.value.substring(0, this._screenReaderContentState.selectionStart);
 		const numberOfLinesOfContentBeforeSelection = newlinecount(textContentBeforeSelection);


### PR DESCRIPTION
+ re-render the edit context dom node on different events (mirrors text area)

fixes https://github.com/microsoft/vscode/issues/235231