### PR TITLE
Focus on Webview View command is missing activity bar title in VS Code 1.96 Insiders (fix #235220)

### DIFF
--- a/src/vs/workbench/services/views/browser/viewsService.ts
+++ b/src/vs/workbench/services/views/browser/viewsService.ts
@@ -545,6 +545,7 @@ export class ViewsService extends Disposable implements IViewsService {
 				super({
 					id: viewDescriptor.focusCommand ? viewDescriptor.focusCommand.id : `${viewDescriptor.id}.focus`,
 					title,
+					category,
 					menu: [{
 						id: MenuId.CommandPalette,
 						when: viewDescriptor.when,


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
