### PR TITLE
Add setting option to always enable default color decorators

### DIFF
--- a/src/vs/editor/browser/config/migrateOptions.ts
+++ b/src/vs/editor/browser/config/migrateOptions.ts
@@ -93,6 +93,7 @@ registerSimpleEditorSettingMigration('renderFinalNewline', [[true, 'on'], [false
 registerSimpleEditorSettingMigration('cursorSmoothCaretAnimation', [[true, 'on'], [false, 'off']]);
 registerSimpleEditorSettingMigration('occurrencesHighlight', [[true, 'singleFile'], [false, 'off']]);
 registerSimpleEditorSettingMigration('wordBasedSuggestions', [[true, 'matchingDocuments'], [false, 'off']]);
+registerSimpleEditorSettingMigration('defaultColorDecorators', [[true, 'auto'], [false, 'never']]);
 
 registerEditorSettingMigration('autoClosingBrackets', (value, read, write) => {
 	if (value === false) {

--- a/src/vs/editor/common/config/editorOptions.ts
+++ b/src/vs/editor/common/config/editorOptions.ts
@@ -268,7 +268,7 @@ export interface IEditorOptions {
 	/**
 	 * Controls whether to use default color decorations or not using the default document color provider
 	 */
-	defaultColorDecorators?: boolean;
+	defaultColorDecorators?: 'auto' | 'always' | 'never';
 	/**
 	 * Disable the use of `transform: translate3d(0px, 0px, 0px)` for the editor margin and lines layers.
 	 * The usage of `transform: translate3d(0px, 0px, 0px)` acts as a hint for browsers to create an extra layer.
@@ -6342,9 +6342,17 @@ export const EditorOptions = {
 	// Leave these at the end (because they have dependencies!)
 	effectiveCursorStyle: register(new EffectiveCursorStyle()),
 	editorClassName: register(new EditorClassName()),
-	defaultColorDecorators: register(new EditorBooleanOption(
-		EditorOption.defaultColorDecorators, 'defaultColorDecorators', true,
-		{ markdownDescription: nls.localize('defaultColorDecorators', "Controls whether inline color decorations should be shown using the default document color provider") }
+	defaultColorDecorators: register(new EditorStringEnumOption(
+		EditorOption.defaultColorDecorators, 'defaultColorDecorators', 'auto' as 'auto' | 'always' | 'never',
+		['auto', 'always', 'never'] as const,
+		{
+			enumDescriptions: [
+				nls.localize('editor.defaultColorDecorators.auto', "Show default color decorators only when no extension provides colors decorators."),
+				nls.localize('editor.defaultColorDecorators.always', "Always show default color decorators."),
+				nls.localize('editor.defaultColorDecorators.never', "Never show default color decorators."),
+			],
+			description: nls.localize('defaultColorDecorators', "Controls whether inline color decorations should be shown using the default document color provider.")
+		}
 	)),
 	pixelRatio: register(new EditorPixelRatio()),
 	tabFocusMode: register(new EditorBooleanOption(EditorOption.tabFocusMode, 'tabFocusMode', false,

--- a/src/vs/editor/contrib/colorPicker/browser/color.ts
+++ b/src/vs/editor/contrib/colorPicker/browser/color.ts
@@ -16,7 +16,7 @@ import { DefaultDocumentColorProvider } from './defaultDocumentColorProvider.js'
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { ServicesAccessor } from '../../../browser/editorExtensions.js';
 
-export async function getColors(colorProviderRegistry: LanguageFeatureRegistry<DocumentColorProvider>, model: ITextModel, token: CancellationToken, isDefaultColorDecoratorsEnabled: boolean = true): Promise<IColorData[]> {
+export async function getColors(colorProviderRegistry: LanguageFeatureRegistry<DocumentColorProvider>, model: ITextModel, token: CancellationToken, isDefaultColorDecoratorsEnabled: 'auto' | 'always' | 'never' = 'auto'): Promise<IColorData[]> {
 	return _findColorData<IColorData>(new ColorDataCollector(), colorProviderRegistry, model, token, isDefaultColorDecoratorsEnabled);
 }
 
@@ -73,14 +73,14 @@ export class ColorPresentationsCollector implements DataCollector<IColorPresenta
 	}
 }
 
-export async function _findColorData<T extends IColorPresentation | IExtColorData | IColorData>(collector: DataCollector<T>, colorProviderRegistry: LanguageFeatureRegistry<DocumentColorProvider>, model: ITextModel, token: CancellationToken, isDefaultColorDecoratorsEnabled: boolean): Promise<T[]> {
+export async function _findColorData<T extends IColorPresentation | IExtColorData | IColorData>(collector: DataCollector<T>, colorProviderRegistry: LanguageFeatureRegistry<DocumentColorProvider>, model: ITextModel, token: CancellationToken, colorDecoratorsEnablement: 'auto' | 'always' | 'never'): Promise<T[]> {
 	let validDocumentColorProviderFound = false;
 	let defaultProvider: DefaultDocumentColorProvider | undefined;
 	const colorData: T[] = [];
 	const documentColorProviders = colorProviderRegistry.ordered(model);
 	for (let i = documentColorProviders.length - 1; i >= 0; i--) {
 		const provider = documentColorProviders[i];
-		if (provider instanceof DefaultDocumentColorProvider) {
+		if (colorDecoratorsEnablement !== 'always' && provider instanceof DefaultDocumentColorProvider) {
 			defaultProvider = provider;
 		} else {
 			try {
@@ -95,20 +95,20 @@ export async function _findColorData<T extends IColorPresentation | IExtColorDat
 	if (validDocumentColorProviderFound) {
 		return colorData;
 	}
-	if (defaultProvider && isDefaultColorDecoratorsEnabled) {
+	if (defaultProvider && colorDecoratorsEnablement !== 'never') {
 		await collector.compute(defaultProvider, model, token, colorData);
 		return colorData;
 	}
 	return [];
 }
 
-export function _setupColorCommand(accessor: ServicesAccessor, resource: URI): { model: ITextModel; colorProviderRegistry: LanguageFeatureRegistry<DocumentColorProvider>; isDefaultColorDecoratorsEnabled: boolean } {
+export function _setupColorCommand(accessor: ServicesAccessor, resource: URI): { model: ITextModel; colorProviderRegistry: LanguageFeatureRegistry<DocumentColorProvider>; colorDecoratorsEnablement: 'auto' | 'always' | 'never' } {
 	const { colorProvider: colorProviderRegistry } = accessor.get(ILanguageFeaturesService);
 	const model = accessor.get(IModelService).getModel(resource);
 	if (!model) {
 		throw illegalArgument();
 	}
-	const isDefaultColorDecoratorsEnabled = accessor.get(IConfigurationService).getValue<boolean>('editor.defaultColorDecorators', { resource });
-	return { model, colorProviderRegistry, isDefaultColorDecoratorsEnabled };
+	const colorDecoratorsEnablement = accessor.get(IConfigurationService).getValue<'auto' | 'always' | 'never'>('editor.defaultColorDecorators', { resource });
+	return { model, colorProviderRegistry, colorDecoratorsEnablement };
 }
 

--- a/src/vs/editor/contrib/colorPicker/browser/color.ts
+++ b/src/vs/editor/contrib/colorPicker/browser/color.ts
@@ -16,8 +16,8 @@ import { DefaultDocumentColorProvider } from './defaultDocumentColorProvider.js'
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { ServicesAccessor } from '../../../browser/editorExtensions.js';
 
-export async function getColors(colorProviderRegistry: LanguageFeatureRegistry<DocumentColorProvider>, model: ITextModel, token: CancellationToken, isDefaultColorDecoratorsEnabled: 'auto' | 'always' | 'never' = 'auto'): Promise<IColorData[]> {
-	return _findColorData<IColorData>(new ColorDataCollector(), colorProviderRegistry, model, token, isDefaultColorDecoratorsEnabled);
+export async function getColors(colorProviderRegistry: LanguageFeatureRegistry<DocumentColorProvider>, model: ITextModel, token: CancellationToken, defaultColorDecoratorsEnablement: 'auto' | 'always' | 'never' = 'auto'): Promise<IColorData[]> {
+	return _findColorData<IColorData>(new ColorDataCollector(), colorProviderRegistry, model, token, defaultColorDecoratorsEnablement);
 }
 
 export function getColorPresentations(model: ITextModel, colorInfo: IColorInformation, provider: DocumentColorProvider, token: CancellationToken): Promise<IColorPresentation[] | null | undefined> {
@@ -73,14 +73,14 @@ export class ColorPresentationsCollector implements DataCollector<IColorPresenta
 	}
 }
 
-export async function _findColorData<T extends IColorPresentation | IExtColorData | IColorData>(collector: DataCollector<T>, colorProviderRegistry: LanguageFeatureRegistry<DocumentColorProvider>, model: ITextModel, token: CancellationToken, colorDecoratorsEnablement: 'auto' | 'always' | 'never'): Promise<T[]> {
+export async function _findColorData<T extends IColorPresentation | IExtColorData | IColorData>(collector: DataCollector<T>, colorProviderRegistry: LanguageFeatureRegistry<DocumentColorProvider>, model: ITextModel, token: CancellationToken, defaultColorDecoratorsEnablement: 'auto' | 'always' | 'never'): Promise<T[]> {
 	let validDocumentColorProviderFound = false;
 	let defaultProvider: DefaultDocumentColorProvider | undefined;
 	const colorData: T[] = [];
 	const documentColorProviders = colorProviderRegistry.ordered(model);
 	for (let i = documentColorProviders.length - 1; i >= 0; i--) {
 		const provider = documentColorProviders[i];
-		if (colorDecoratorsEnablement !== 'always' && provider instanceof DefaultDocumentColorProvider) {
+		if (defaultColorDecoratorsEnablement !== 'always' && provider instanceof DefaultDocumentColorProvider) {
 			defaultProvider = provider;
 		} else {
 			try {
@@ -95,20 +95,20 @@ export async function _findColorData<T extends IColorPresentation | IExtColorDat
 	if (validDocumentColorProviderFound) {
 		return colorData;
 	}
-	if (defaultProvider && colorDecoratorsEnablement !== 'never') {
+	if (defaultProvider && defaultColorDecoratorsEnablement !== 'never') {
 		await collector.compute(defaultProvider, model, token, colorData);
 		return colorData;
 	}
 	return [];
 }
 
-export function _setupColorCommand(accessor: ServicesAccessor, resource: URI): { model: ITextModel; colorProviderRegistry: LanguageFeatureRegistry<DocumentColorProvider>; colorDecoratorsEnablement: 'auto' | 'always' | 'never' } {
+export function _setupColorCommand(accessor: ServicesAccessor, resource: URI): { model: ITextModel; colorProviderRegistry: LanguageFeatureRegistry<DocumentColorProvider>; defaultColorDecoratorsEnablement: 'auto' | 'always' | 'never' } {
 	const { colorProvider: colorProviderRegistry } = accessor.get(ILanguageFeaturesService);
 	const model = accessor.get(IModelService).getModel(resource);
 	if (!model) {
 		throw illegalArgument();
 	}
-	const colorDecoratorsEnablement = accessor.get(IConfigurationService).getValue<'auto' | 'always' | 'never'>('editor.defaultColorDecorators', { resource });
-	return { model, colorProviderRegistry, colorDecoratorsEnablement };
+	const defaultColorDecoratorsEnablement = accessor.get(IConfigurationService).getValue<'auto' | 'always' | 'never'>('editor.defaultColorDecorators', { resource });
+	return { model, colorProviderRegistry, defaultColorDecoratorsEnablement };
 }
 

--- a/src/vs/editor/contrib/colorPicker/browser/colorDetector.ts
+++ b/src/vs/editor/contrib/colorPicker/browser/colorDetector.ts
@@ -43,7 +43,7 @@ export class ColorDetector extends Disposable implements IEditorContribution {
 	private readonly _colorDecoratorIds = this._editor.createDecorationsCollection();
 
 	private _isColorDecoratorsEnabled: boolean;
-	private _isDefaultColorDecoratorsEnabled: boolean;
+	private _isDefaultColorDecoratorsEnabled: 'auto' | 'always' | 'never';
 
 	private readonly _ruleFactory = new DynamicCssRules(this._editor);
 

--- a/src/vs/editor/contrib/colorPicker/browser/colorDetector.ts
+++ b/src/vs/editor/contrib/colorPicker/browser/colorDetector.ts
@@ -43,7 +43,7 @@ export class ColorDetector extends Disposable implements IEditorContribution {
 	private readonly _colorDecoratorIds = this._editor.createDecorationsCollection();
 
 	private _isColorDecoratorsEnabled: boolean;
-	private _isDefaultColorDecoratorsEnabled: 'auto' | 'always' | 'never';
+	private _defaultColorDecoratorsEnablement: 'auto' | 'always' | 'never';
 
 	private readonly _ruleFactory = new DynamicCssRules(this._editor);
 
@@ -66,7 +66,7 @@ export class ColorDetector extends Disposable implements IEditorContribution {
 		this._register(_editor.onDidChangeConfiguration((e) => {
 			const prevIsEnabled = this._isColorDecoratorsEnabled;
 			this._isColorDecoratorsEnabled = this.isEnabled();
-			this._isDefaultColorDecoratorsEnabled = this._editor.getOption(EditorOption.defaultColorDecorators);
+			this._defaultColorDecoratorsEnablement = this._editor.getOption(EditorOption.defaultColorDecorators);
 			const updatedColorDecoratorsSetting = prevIsEnabled !== this._isColorDecoratorsEnabled || e.hasChanged(EditorOption.colorDecoratorsLimit);
 			const updatedDefaultColorDecoratorsSetting = e.hasChanged(EditorOption.defaultColorDecorators);
 			if (updatedColorDecoratorsSetting || updatedDefaultColorDecoratorsSetting) {
@@ -82,7 +82,7 @@ export class ColorDetector extends Disposable implements IEditorContribution {
 		this._timeoutTimer = null;
 		this._computePromise = null;
 		this._isColorDecoratorsEnabled = this.isEnabled();
-		this._isDefaultColorDecoratorsEnabled = this._editor.getOption(EditorOption.defaultColorDecorators);
+		this._defaultColorDecoratorsEnablement = this._editor.getOption(EditorOption.defaultColorDecorators);
 		this.updateColors();
 	}
 
@@ -149,7 +149,7 @@ export class ColorDetector extends Disposable implements IEditorContribution {
 				return [];
 			}
 			const sw = new StopWatch(false);
-			const colors = await getColors(this._languageFeaturesService.colorProvider, model, token, this._isDefaultColorDecoratorsEnabled);
+			const colors = await getColors(this._languageFeaturesService.colorProvider, model, token, this._defaultColorDecoratorsEnablement);
 			this._debounceInformation.update(model, sw.elapsed());
 			return colors;
 		});

--- a/src/vs/editor/contrib/colorPicker/browser/colorPickerContribution.ts
+++ b/src/vs/editor/contrib/colorPicker/browser/colorPickerContribution.ts
@@ -37,8 +37,8 @@ CommandsRegistry.registerCommand('_executeDocumentColorProvider', function (acce
 	if (!(resource instanceof URI)) {
 		throw illegalArgument();
 	}
-	const { model, colorProviderRegistry, isDefaultColorDecoratorsEnabled } = _setupColorCommand(accessor, resource);
-	return _findColorData<IExtColorData>(new ExtColorDataCollector(), colorProviderRegistry, model, CancellationToken.None, isDefaultColorDecoratorsEnabled);
+	const { model, colorProviderRegistry, colorDecoratorsEnablement } = _setupColorCommand(accessor, resource);
+	return _findColorData<IExtColorData>(new ExtColorDataCollector(), colorProviderRegistry, model, CancellationToken.None, colorDecoratorsEnablement);
 });
 
 CommandsRegistry.registerCommand('_executeColorPresentationProvider', function (accessor, ...args) {
@@ -47,7 +47,7 @@ CommandsRegistry.registerCommand('_executeColorPresentationProvider', function (
 	if (!(uri instanceof URI) || !Array.isArray(color) || color.length !== 4 || !Range.isIRange(range)) {
 		throw illegalArgument();
 	}
-	const { model, colorProviderRegistry, isDefaultColorDecoratorsEnabled } = _setupColorCommand(accessor, uri);
+	const { model, colorProviderRegistry, colorDecoratorsEnablement } = _setupColorCommand(accessor, uri);
 	const [red, green, blue, alpha] = color;
-	return _findColorData<IColorPresentation>(new ColorPresentationsCollector({ range: range, color: { red, green, blue, alpha } }), colorProviderRegistry, model, CancellationToken.None, isDefaultColorDecoratorsEnabled);
+	return _findColorData<IColorPresentation>(new ColorPresentationsCollector({ range: range, color: { red, green, blue, alpha } }), colorProviderRegistry, model, CancellationToken.None, colorDecoratorsEnablement);
 });

--- a/src/vs/editor/contrib/colorPicker/browser/colorPickerContribution.ts
+++ b/src/vs/editor/contrib/colorPicker/browser/colorPickerContribution.ts
@@ -37,8 +37,8 @@ CommandsRegistry.registerCommand('_executeDocumentColorProvider', function (acce
 	if (!(resource instanceof URI)) {
 		throw illegalArgument();
 	}
-	const { model, colorProviderRegistry, colorDecoratorsEnablement } = _setupColorCommand(accessor, resource);
-	return _findColorData<IExtColorData>(new ExtColorDataCollector(), colorProviderRegistry, model, CancellationToken.None, colorDecoratorsEnablement);
+	const { model, colorProviderRegistry, defaultColorDecoratorsEnablement } = _setupColorCommand(accessor, resource);
+	return _findColorData<IExtColorData>(new ExtColorDataCollector(), colorProviderRegistry, model, CancellationToken.None, defaultColorDecoratorsEnablement);
 });
 
 CommandsRegistry.registerCommand('_executeColorPresentationProvider', function (accessor, ...args) {
@@ -47,7 +47,7 @@ CommandsRegistry.registerCommand('_executeColorPresentationProvider', function (
 	if (!(uri instanceof URI) || !Array.isArray(color) || color.length !== 4 || !Range.isIRange(range)) {
 		throw illegalArgument();
 	}
-	const { model, colorProviderRegistry, colorDecoratorsEnablement } = _setupColorCommand(accessor, uri);
+	const { model, colorProviderRegistry, defaultColorDecoratorsEnablement } = _setupColorCommand(accessor, uri);
 	const [red, green, blue, alpha] = color;
-	return _findColorData<IColorPresentation>(new ColorPresentationsCollector({ range: range, color: { red, green, blue, alpha } }), colorProviderRegistry, model, CancellationToken.None, colorDecoratorsEnablement);
+	return _findColorData<IColorPresentation>(new ColorPresentationsCollector({ range: range, color: { red, green, blue, alpha } }), colorProviderRegistry, model, CancellationToken.None, defaultColorDecoratorsEnablement);
 });

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -5051,14 +5051,14 @@ declare namespace monaco.editor {
 		ariaLabel: IEditorOption<EditorOption.ariaLabel, string>;
 		ariaRequired: IEditorOption<EditorOption.ariaRequired, boolean>;
 		screenReaderAnnounceInlineSuggestion: IEditorOption<EditorOption.screenReaderAnnounceInlineSuggestion, boolean>;
-		autoClosingBrackets: IEditorOption<EditorOption.autoClosingBrackets, 'always' | 'languageDefined' | 'beforeWhitespace' | 'never'>;
-		autoClosingComments: IEditorOption<EditorOption.autoClosingComments, 'always' | 'languageDefined' | 'beforeWhitespace' | 'never'>;
+		autoClosingBrackets: IEditorOption<EditorOption.autoClosingBrackets, 'always' | 'never' | 'languageDefined' | 'beforeWhitespace'>;
+		autoClosingComments: IEditorOption<EditorOption.autoClosingComments, 'always' | 'never' | 'languageDefined' | 'beforeWhitespace'>;
 		autoClosingDelete: IEditorOption<EditorOption.autoClosingDelete, 'auto' | 'always' | 'never'>;
 		autoClosingOvertype: IEditorOption<EditorOption.autoClosingOvertype, 'auto' | 'always' | 'never'>;
-		autoClosingQuotes: IEditorOption<EditorOption.autoClosingQuotes, 'always' | 'languageDefined' | 'beforeWhitespace' | 'never'>;
+		autoClosingQuotes: IEditorOption<EditorOption.autoClosingQuotes, 'always' | 'never' | 'languageDefined' | 'beforeWhitespace'>;
 		autoIndent: IEditorOption<EditorOption.autoIndent, EditorAutoIndentStrategy>;
 		automaticLayout: IEditorOption<EditorOption.automaticLayout, boolean>;
-		autoSurround: IEditorOption<EditorOption.autoSurround, 'languageDefined' | 'never' | 'quotes' | 'brackets'>;
+		autoSurround: IEditorOption<EditorOption.autoSurround, 'never' | 'languageDefined' | 'quotes' | 'brackets'>;
 		bracketPairColorization: IEditorOption<EditorOption.bracketPairColorization, Readonly<Required<IBracketPairColorizationOptions>>>;
 		bracketPairGuides: IEditorOption<EditorOption.guides, Readonly<Required<IGuidesOptions>>>;
 		stickyTabStops: IEditorOption<EditorOption.stickyTabStops, boolean>;

--- a/src/vs/monaco.d.ts
+++ b/src/vs/monaco.d.ts
@@ -3314,7 +3314,7 @@ declare namespace monaco.editor {
 		/**
 		 * Controls whether to use default color decorations or not using the default document color provider
 		 */
-		defaultColorDecorators?: boolean;
+		defaultColorDecorators?: 'auto' | 'always' | 'never';
 		/**
 		 * Disable the use of `transform: translate3d(0px, 0px, 0px)` for the editor margin and lines layers.
 		 * The usage of `transform: translate3d(0px, 0px, 0px)` acts as a hint for browsers to create an extra layer.
@@ -5193,7 +5193,7 @@ declare namespace monaco.editor {
 		wordWrapOverride2: IEditorOption<EditorOption.wordWrapOverride2, 'on' | 'off' | 'inherit'>;
 		effectiveCursorStyle: IEditorOption<EditorOption.effectiveCursorStyle, TextEditorCursorStyle>;
 		editorClassName: IEditorOption<EditorOption.editorClassName, string>;
-		defaultColorDecorators: IEditorOption<EditorOption.defaultColorDecorators, boolean>;
+		defaultColorDecorators: IEditorOption<EditorOption.defaultColorDecorators, 'auto' | 'always' | 'never'>;
 		pixelRatio: IEditorOption<EditorOption.pixelRatio, number>;
 		tabFocusMode: IEditorOption<EditorOption.tabFocusMode, boolean>;
 		layoutInfo: IEditorOption<EditorOption.layoutInfo, EditorLayoutInfo>;

--- a/src/vs/workbench/contrib/codeEditor/browser/simpleEditorOptions.ts
+++ b/src/vs/workbench/contrib/codeEditor/browser/simpleEditorOptions.ts
@@ -48,7 +48,7 @@ export function getSimpleEditorOptions(configurationService: IConfigurationServi
 		accessibilitySupport: configurationService.getValue<'auto' | 'off' | 'on'>('editor.accessibilitySupport'),
 		cursorBlinking: configurationService.getValue<'blink' | 'smooth' | 'phase' | 'expand' | 'solid'>('editor.cursorBlinking'),
 		experimentalEditContextEnabled: configurationService.getValue<boolean>('editor.experimentalEditContextEnabled'),
-		defaultColorDecorators: false,
+		defaultColorDecorators: 'never',
 	};
 }
 


### PR DESCRIPTION
Default value keeps previous behavior to show default color decorators only when extensions do not provide default color decorators

fixes https://github.com/microsoft/vscode/issues/182214