### PR TITLE
fix: remove chat edits file suggestions when working set is emptied

### DIFF
--- a/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatEditing/chatEditingActions.ts
@@ -109,6 +109,13 @@ registerAction2(class RemoveFileFromWorkingSet extends WorkingSetAction {
 		for (const uri of uris) {
 			chatWidget.attachmentModel.delete(uri.toString());
 		}
+
+		// If there are now only suggested files in the working set, also clear those
+		const entries = [...currentEditingSession.workingSet.entries()];
+		const suggestedFiles = entries.filter(([_, state]) => state.state === WorkingSetEntryState.Suggested);
+		if (suggestedFiles.length === entries.length && !chatWidget.attachmentModel.attachments.find((v) => v.isFile && URI.isUri(v.value))) {
+			currentEditingSession.remove(WorkingSetEntryRemovalReason.Programmatic, ...entries.map(([uri,]) => uri));
+		}
 	}
 });
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
