### PR TITLE
Fix explorer find rerender error and related issue

### DIFF
--- a/src/vs/workbench/contrib/files/browser/views/explorerViewer.ts
+++ b/src/vs/workbench/contrib/files/browser/views/explorerViewer.ts
@@ -562,7 +562,9 @@ export class ExplorerFindProvider implements IAsyncFindProvider<ExplorerItem> {
 
 		const tree = this.treeProvider();
 		for (const directory of highlightedDirectories) {
-			tree.rerender(directory);
+			if (tree.hasNode(directory)) {
+				tree.rerender(directory);
+			}
 		}
 	}
 


### PR DESCRIPTION
Address an error in the explorer find functionality by ensuring that the rerender method is only called for existing nodes. This change also resolves issue #234129.