### PR TITLE
Use `disregardIgnoreFiles` in file search queries

### DIFF
--- a/src/vs/workbench/contrib/files/browser/views/explorerViewer.ts
+++ b/src/vs/workbench/contrib/files/browser/views/explorerViewer.ts
@@ -602,7 +602,10 @@ export class ExplorerFindProvider implements IAsyncFindProvider<ExplorerItem> {
 
 		const searchExcludePattern = getExcludes(this.configurationService.getValue<ISearchConfiguration>({ resource: root.resource })) || {};
 		const searchOptions: IFileQuery = {
-			folderQueries: [{ folder: root.resource }],
+			folderQueries: [{
+				folder: root.resource,
+				disregardIgnoreFiles: !this.configurationService.getValue<boolean>('explorer.excludeGitIgnore'),
+			}],
 			type: QueryType.File,
 			shouldGlobMatchFilePattern: true,
 			cacheKey: `explorerfindprovider:${root.name}:${rootIndex}:${this.sessionId}`,


### PR DESCRIPTION
Potential candidate fix for #234129 as it is very simple