### PR TITLE
NB multiselect undo/redo fix

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/contrib/multicursor/notebookMulticursor.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/multicursor/notebookMulticursor.ts
@@ -385,6 +385,20 @@ export class NotebookMultiCursorController extends Disposable implements INotebo
 		}
 	}
 
+	private updateViewModelSelections() {
+		for (const cell of this.trackedCells) {
+			const controller = this.cursorsControllers.get(cell.cellViewModel.uri);
+			if (!controller) {
+				// should not happen
+				return;
+			}
+
+			if (cell.cellViewModel.getSelections().length > 0) {
+				controller.setSelections(new ViewModelEventsCollector(), undefined, cell.cellViewModel.getSelections(), CursorChangeReason.Explicit);
+			}
+		}
+	}
+
 	private updateFinalUndoRedo() {
 		const anchorCellModel = this.anchorCell?.[1].getModel();
 		if (!anchorCellModel) {
@@ -775,16 +789,10 @@ export class NotebookMultiCursorController extends Disposable implements INotebo
 			if (model) {
 				models.push(model);
 			}
-
-			const controller = this.cursorsControllers.get(cell.cellViewModel.uri);
-			if (!controller) {
-				// should not happen
-				return;
-			}
-			controller.setSelections(new ViewModelEventsCollector(), undefined, cell.cellViewModel.getSelections(), CursorChangeReason.Explicit);
 		}
 
 		await Promise.all(models.map(model => model.undo()));
+		this.updateViewModelSelections();
 		this.updateLazyDecorations();
 	}
 
@@ -795,16 +803,10 @@ export class NotebookMultiCursorController extends Disposable implements INotebo
 			if (model) {
 				models.push(model);
 			}
-
-			const controller = this.cursorsControllers.get(cell.cellViewModel.uri);
-			if (!controller) {
-				// should not happen
-				return;
-			}
-			controller.setSelections(new ViewModelEventsCollector(), undefined, cell.cellViewModel.getSelections(), CursorChangeReason.Explicit);
 		}
 
 		await Promise.all(models.map(model => model.redo()));
+		this.updateViewModelSelections();
 		this.updateLazyDecorations();
 	}
 

--- a/src/vs/workbench/contrib/notebook/browser/contrib/multicursor/notebookMulticursor.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/multicursor/notebookMulticursor.ts
@@ -393,9 +393,7 @@ export class NotebookMultiCursorController extends Disposable implements INotebo
 				return;
 			}
 
-			if (cell.cellViewModel.getSelections().length > 0) {
-				controller.setSelections(new ViewModelEventsCollector(), undefined, cell.cellViewModel.getSelections(), CursorChangeReason.Explicit);
-			}
+			cell.cellViewModel.setSelections(controller.getSelections());
 		}
 	}
 


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Re: #235124

Initially had been setting controller selections based on the cell view model before undo/redo, to keep controllers in sync. This would cause issues outside of the viewport as there is no viewmodel to get selections from. 

Fix:
Collect models and perform undo/redo without any selection management before. Afterwards, use the cursor controller as the source of truth and update the viewmodel selections accordingly.
