### PR TITLE
editor sticky scroll: only collapse outermost region with folding icon

### DIFF
--- a/src/vs/editor/contrib/stickyScroll/browser/stickyScrollController.ts
+++ b/src/vs/editor/contrib/stickyScroll/browser/stickyScrollController.ts
@@ -394,7 +394,7 @@ export class StickyScrollController extends Disposable implements IEditorContrib
 		if (!foldingIcon) {
 			return;
 		}
-		toggleCollapseState(this._foldingModel, Number.MAX_VALUE, [line]);
+		toggleCollapseState(this._foldingModel, 1, [line]);
 		foldingIcon.isCollapsed = !foldingIcon.isCollapsed;
 		const scrollTop = (foldingIcon.isCollapsed ?
 			this._editor.getTopForLineNumber(foldingIcon.foldingEndLine)


### PR DESCRIPTION
fixes https://github.com/microsoft/vscode/issues/235140