### PR TITLE
Add `jsonl` and `snippets` suggestion settings

### DIFF
--- a/extensions/json-language-features/package.json
+++ b/extensions/json-language-features/package.json
@@ -139,6 +139,18 @@
           "strings": true
         },
         "editor.suggest.insertMode": "replace"
+      },
+      "[jsonl]": {
+        "editor.quickSuggestions": {
+          "strings": true
+        },
+        "editor.suggest.insertMode": "replace"
+      },
+      "[snippets]": {
+        "editor.quickSuggestions": {
+          "strings": true
+        },
+        "editor.suggest.insertMode": "replace"
       }
     },
     "jsonValidation": [


### PR DESCRIPTION
fix https://github.com/microsoft/vscode/issues/209534
still issues with https://github.com/microsoft/vscode/issues/231224 tho

1. make sure `"editor.suggest.insertMode"` is set to default `"insert"`
1. Create `.code-snippets` file with code
```json
{
	"test": {
		""
	}
}
```
2. assign language `snippets`
3. type `body` within the double quotes `""`
![image](https://github.com/user-attachments/assets/eb7f43c3-c353-4936-8a83-31bb797e42ab)
4. expect quick suggestions to pop up
5. select any suggestion
6. expect the correct number of valid double quotes
![image](https://github.com/user-attachments/assets/323e9838-6bd2-4029-9d79-f0b9609ada50)

