### PR TITLE
Enable drag-and-drop support for multiple files in the terminal

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminal.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminal.ts
@@ -1107,13 +1107,20 @@ export interface ITerminalInstance extends IBaseTerminalInstance {
 	/**
 	 * Sends a path to the terminal instance, preparing it as needed based on the detected shell
 	 * running within the terminal. The text is written to the stdin of the underlying pty process
-	 * (shell) of the terminal instance.
+	 * (shell) of the terminal instance. The character(s) added are \n or \r\n, depending on the platform.
 	 *
 	 * @param originalPath The path to send.
-	 * @param shouldExecute Indicates that the text being sent should be executed rather than just inserted in the terminal.
-	 * The character(s) added are \n or \r\n, depending on the platform. This defaults to `true`.
 	 */
-	sendPath(originalPath: string | URI, shouldExecute: boolean): Promise<void>;
+	executePath(originalPath: string | URI): Promise<void>;
+
+	/**
+	 * Sends paths to the terminal instance, preparing it as needed based on the detected shell
+	 * running within the terminal. The text is written to the stdin of the underlying pty process
+	 * (shell) of the terminal instance. The URIs are separated by a single space.
+	 *
+	 * @param originalPaths The paths to send.
+	 */
+	sendPaths(originalPaths: (string | URI)[]): Promise<void>;
 
 	runCommand(command: string, shouldExecute?: boolean, commandId?: string): Promise<void>;
 

--- a/src/vs/workbench/contrib/terminal/browser/terminalActions.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalActions.ts
@@ -607,7 +607,7 @@ export function registerTerminalActions() {
 			}
 
 			// TODO: Convert this to ctrl+c, ctrl+v for pwsh?
-			await instance.sendPath(uri, true);
+			await instance.executePath(uri);
 			return c.groupService.showPanel();
 		}
 	});


### PR DESCRIPTION
Drag and dropping multiple files into the terminal has never worked; only one path was inserted. This pull request fixes the issue. This request is very important to me because I like to `git stash` selected files. I want to be able to write `git stash -- ` and drop selected files from the SCM view.

Please forgive me for not referencing an issue number here.