### PR TITLE
Remove under-discussion from needing milestone

### DIFF
--- a/.vscode/notebooks/grooming.github-issues
+++ b/.vscode/notebooks/grooming.github-issues
@@ -37,7 +37,7 @@
   {
     "kind": 2,
     "language": "github-issues",
-    "value": "$repos assignee:@me is:open type:issue no:milestone -label:info-needed -label:triage-needed -label:confirmation-pending\r\n"
+    "value": "$repos assignee:@me is:open type:issue no:milestone -label:info-needed -label:triage-needed -label:confirmation-pending -label:under-discussion\r\n"
   },
   {
     "kind": 1,


### PR DESCRIPTION
I believe that if an issue is under discussion, that it does not have to be on a milestone such as the Backlog milestone as well.