### PR TITLE
Add extra type check in `findFiles2`

### DIFF
--- a/src/vs/workbench/api/common/extHostWorkspace.ts
+++ b/src/vs/workbench/api/common/extHostWorkspace.ts
@@ -499,12 +499,12 @@ export class ExtHostWorkspace implements ExtHostWorkspaceShape, IExtHostWorkspac
 			return Promise.resolve([]);
 		}
 
-		const filePatternsToUse = include ? [include] : filePatterns;
+		const filePatternsToUse = include ? [include] : filePatterns ?? [];
 		if (!Array.isArray(filePatternsToUse)) {
 			throw new Error(`Invalid file pattern provided ${filePatternsToUse}`);
 		}
 
-		const queryOptions: QueryOptions<IFileQueryBuilderOptions>[] = filePatternsToUse?.map(filePattern => {
+		const queryOptions: QueryOptions<IFileQueryBuilderOptions>[] = filePatternsToUse.map(filePattern => {
 
 			const excludePatterns = globsToISearchPatternBuilder(options.exclude);
 
@@ -532,7 +532,7 @@ export class ExtHostWorkspace implements ExtHostWorkspaceShape, IExtHostWorkspac
 				folder: folderToUse,
 				options: fileQueries
 			};
-		}) ?? [];
+		});
 
 		return this._findFilesBase(queryOptions, token);
 	}

--- a/src/vs/workbench/api/common/extHostWorkspace.ts
+++ b/src/vs/workbench/api/common/extHostWorkspace.ts
@@ -468,7 +468,7 @@ export class ExtHostWorkspace implements ExtHostWorkspaceShape, IExtHostWorkspac
 		}
 
 		// todo: consider exclude baseURI if available
-		return this._findFilesImpl(include, undefined, {
+		return this._findFilesImpl({ type: 'include', value: include }, {
 			exclude: [excludeString],
 			maxResults,
 			useExcludeSettings: useFileExcludes ? ExcludeSettingOptions.FilesExclude : ExcludeSettingOptions.None,
@@ -484,14 +484,13 @@ export class ExtHostWorkspace implements ExtHostWorkspaceShape, IExtHostWorkspac
 		extensionId: ExtensionIdentifier,
 		token: vscode.CancellationToken = CancellationToken.None): Promise<vscode.Uri[]> {
 		this._logService.trace(`extHostWorkspace#findFiles2New: fileSearch, extension: ${extensionId.value}, entryPoint: findFiles2New`);
-		return this._findFilesImpl(undefined, filePatterns, options, token);
+		return this._findFilesImpl({ type: 'filePatterns', value: filePatterns }, options, token);
 	}
 
 	private async _findFilesImpl(
 		// the old `findFiles` used `include` to query, but the new `findFiles2` uses `filePattern` to query.
 		// `filePattern` is the proper way to handle this, since it takes less precedence than the ignore files.
-		include: vscode.GlobPattern | undefined,
-		filePatterns: vscode.GlobPattern[] | undefined,
+		query: { type: 'include'; value: vscode.GlobPattern | undefined } | { type: 'filePatterns'; value: vscode.GlobPattern[] },
 		options: vscode.FindFiles2Options,
 		token: vscode.CancellationToken
 	): Promise<vscode.Uri[]> {
@@ -499,7 +498,7 @@ export class ExtHostWorkspace implements ExtHostWorkspaceShape, IExtHostWorkspac
 			return Promise.resolve([]);
 		}
 
-		const filePatternsToUse = include ? [include] : filePatterns ?? [];
+		const filePatternsToUse = query.type === 'include' ? [query.value] : query.value ?? [];
 		if (!Array.isArray(filePatternsToUse)) {
 			throw new Error(`Invalid file pattern provided ${filePatternsToUse}`);
 		}
@@ -518,16 +517,17 @@ export class ExtHostWorkspace implements ExtHostWorkspaceShape, IExtHostWorkspac
 				maxResults: options.maxResults,
 				excludePattern: excludePatterns.length > 0 ? excludePatterns : undefined,
 				_reason: 'startFileSearch',
-				shouldGlobSearch: include ? undefined : true,
+				shouldGlobSearch: query.type === 'include' ? undefined : true,
 			};
 
 			const parseInclude = parseSearchExcludeInclude(GlobPattern.from(filePattern));
 			const folderToUse = parseInclude?.folder;
-			if (include) {
+			if (query.type === 'include') {
 				fileQueries.includePattern = parseInclude?.pattern;
 			} else {
 				fileQueries.filePattern = parseInclude?.pattern;
 			}
+
 			return {
 				folder: folderToUse,
 				options: fileQueries

--- a/src/vs/workbench/api/common/extHostWorkspace.ts
+++ b/src/vs/workbench/api/common/extHostWorkspace.ts
@@ -493,13 +493,17 @@ export class ExtHostWorkspace implements ExtHostWorkspaceShape, IExtHostWorkspac
 		include: vscode.GlobPattern | undefined,
 		filePatterns: vscode.GlobPattern[] | undefined,
 		options: vscode.FindFiles2Options,
-		token: vscode.CancellationToken = CancellationToken.None): Promise<vscode.Uri[]> {
-		if (token && token.isCancellationRequested) {
+		token: vscode.CancellationToken
+	): Promise<vscode.Uri[]> {
+		if (token.isCancellationRequested) {
 			return Promise.resolve([]);
 		}
 
+		const filePatternsToUse = include ? [include] : filePatterns;
+		if (!Array.isArray(filePatternsToUse)) {
+			throw new Error(`Invalid file pattern provided ${filePatternsToUse}`);
+		}
 
-		const filePatternsToUse = include !== undefined ? [include] : filePatterns;
 		const queryOptions: QueryOptions<IFileQueryBuilderOptions>[] = filePatternsToUse?.map(filePattern => {
 
 			const excludePatterns = globsToISearchPatternBuilder(options.exclude);


### PR DESCRIPTION
For https://github.com/microsoft/vscode-copilot-release/issues/2493

Looking at the code I'm still not sure how this can happen but it seems like we end up trying to call `.map` on a value that is not an array. Adding a more explicit exception here to hopefully track this down

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
