### PR TITLE
Fix bottom border of Manage menu

### DIFF
--- a/src/vs/base/browser/ui/menu/menu.ts
+++ b/src/vs/base/browser/ui/menu/menu.ts
@@ -324,7 +324,7 @@ export class Menu extends ActionBar {
 		const borderRadius = '5px';
 		const shadow = style.shadowColor ? `0 2px 8px ${style.shadowColor}` : '';
 
-		scrollElement.style.outline = border;
+		scrollElement.style.border = border;
 		scrollElement.style.borderRadius = borderRadius;
 		scrollElement.style.color = fgColor;
 		scrollElement.style.backgroundColor = bgColor;


### PR DESCRIPTION
Corrects the styling of the Manage menu by replacing the outline property with the border property, ensuring the bottom border is displayed correctly.

Fixes #228659