### PR TITLE
testing: sort completed tests by start sequence, not completion time

### DIFF
--- a/src/vs/workbench/contrib/testing/common/testResult.ts
+++ b/src/vs/workbench/contrib/testing/common/testResult.ts
@@ -340,6 +340,7 @@ export class LiveTestResult extends Disposable implements ITestResult {
 		public readonly id: string,
 		public readonly persist: boolean,
 		public readonly request: ResolvedTestRunRequest,
+		public readonly insertOrder: number,
 		@ITelemetryService private readonly telemetry: ITelemetryService,
 	) {
 		super();

--- a/src/vs/workbench/contrib/testing/test/common/testResultService.test.ts
+++ b/src/vs/workbench/contrib/testing/test/common/testResultService.test.ts
@@ -40,13 +40,15 @@ suite('Workbench - Test Results Service', () => {
 		}]
 	});
 
+	let insertCounter = 0;
+
 	class TestLiveTestResult extends LiveTestResult {
 		constructor(
 			id: string,
 			persist: boolean,
 			request: ResolvedTestRunRequest,
 		) {
-			super(id, persist, request, NullTelemetryService);
+			super(id, persist, request, insertCounter++, NullTelemetryService);
 			ds.add(this);
 		}
 
@@ -263,6 +265,7 @@ suite('Workbench - Test Results Service', () => {
 				'',
 				false,
 				defaultOpts([]),
+				insertCounter++,
 				NullTelemetryService,
 			));
 			results.clear();
@@ -270,12 +273,13 @@ suite('Workbench - Test Results Service', () => {
 			assert.deepStrictEqual(results.results, [r2]);
 		});
 
-		test('keeps ongoing tests on top', async () => {
+		test('keeps ongoing tests on top, restored order when done', async () => {
 			results.push(r);
 			const r2 = results.push(new LiveTestResult(
 				'',
 				false,
 				defaultOpts([]),
+				insertCounter++,
 				NullTelemetryService,
 			));
 
@@ -283,7 +287,7 @@ suite('Workbench - Test Results Service', () => {
 			r2.markComplete();
 			assert.deepStrictEqual(results.results, [r, r2]);
 			r.markComplete();
-			assert.deepStrictEqual(results.results, [r, r2]);
+			assert.deepStrictEqual(results.results, [r2, r]);
 		});
 
 		const makeHydrated = async (completedAt = 42, state = TestResultState.Passed) => new HydratedTestResult({

--- a/src/vs/workbench/contrib/testing/test/common/testResultStorage.test.ts
+++ b/src/vs/workbench/contrib/testing/test/common/testResultStorage.test.ts
@@ -25,6 +25,7 @@ suite('Workbench - Test Result Storage', () => {
 			'',
 			true,
 			{ targets: [], group: TestRunProfileBitset.Run },
+			1,
 			NullTelemetryService,
 		));
 


### PR DESCRIPTION
Fixes #235667

The root cause of the issue is the separate test run that playwright does:

https://github.com/microsoft/playwright-vscode/blob/4fba0d0873ee9bf5de17219fa2f48201fd16162f/src/extension.ts#L403-L422.

VS Code by default only shows failure messages from the last-ended test
run, which was the original (unused) test run VS Code created, because
it ends automatically after the runHandler's promise resolves. A good
change to make, which happens to fix this bug, is ensuring results are
retained in the order the user started the test runs versus the order
in which they ended.

Note that playwright is able to avoid the duplicate run since #213182,
but I think this is still a sensible change to make.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
