### PR TITLE
a11y view is blank after running `focus comment on line`

### DIFF
--- a/src/vs/workbench/contrib/comments/browser/commentThreadZoneWidget.ts
+++ b/src/vs/workbench/contrib/comments/browser/commentThreadZoneWidget.ts
@@ -188,7 +188,7 @@ export class ReviewZoneWidget extends ZoneWidget implements ICommentThreadWidget
 
 	public reveal(commentUniqueId?: number, focus: CommentWidgetFocus = CommentWidgetFocus.None) {
 		this.makeVisible(commentUniqueId, focus);
-		const comment = this._commentThread.comments?.find(comment => comment.uniqueIdInThread === commentUniqueId);
+		const comment = this._commentThread.comments?.find(comment => comment.uniqueIdInThread === commentUniqueId) ?? this._commentThread.comments?.[0];
 		this.commentService.setActiveCommentAndThread(this.uniqueOwner, { thread: this._commentThread, comment });
 	}
 


### PR DESCRIPTION
Fixes #229857