### PR TITLE
prevent `null` from being used as language name

### DIFF
--- a/src/vs/workbench/contrib/snippets/browser/commands/configureSnippets.ts
+++ b/src/vs/workbench/contrib/snippets/browser/commands/configureSnippets.ts
@@ -101,7 +101,7 @@ async function computePicks(snippetService: ISnippetsService, userDataProfileSer
 			const mode = basename(file.location).replace(/\.json$/, '');
 			existing.push({
 				label: basename(file.location),
-				description: `(${languageService.getLanguageName(mode)})`,
+				description: `(${languageService.getLanguageName(mode) ?? mode})`,
 				filepath: file.location
 			});
 			seen.add(mode);


### PR DESCRIPTION
https://github.com/microsoft/vscode/issues/226053