### PR TITLE
Fix outline pane text overflow when empty

### DIFF
--- a/src/vs/workbench/contrib/outline/browser/outlinePane.css
+++ b/src/vs/workbench/contrib/outline/browser/outlinePane.css
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 .monaco-workbench .outline-pane {
+	position: relative;
 	display: flex;
 	flex-direction: column;
 }


### PR DESCRIPTION
Set the outline pane's position to relative to prevent text from falling out of the container when it is empty and being collapsed

Fixes #209757