### PR TITLE
Mark bun.lock as jsonc

### DIFF
--- a/extensions/json/package.json
+++ b/extensions/json/package.json
@@ -62,6 +62,7 @@
         ],
         "filenames": [
           "babel.config.json",
+          "bun.lock",
           ".babelrc.json",
           ".ember-cli",
           "typedoc.json"


### PR DESCRIPTION
Bun added support for a new lockfile format using the jsonc language. It uses an unconventional file extension, but it would be nice if VSCode understands it by default anyway.

See https://github.com/oven-sh/bun/pull/15705
