### PR TITLE
Allow the .ndjson extension for the jsonl language

### DIFF
--- a/extensions/json/package.json
+++ b/extensions/json/package.json
@@ -74,7 +74,8 @@
           "JSON Lines"
         ],
         "extensions": [
-          ".jsonl"
+          ".jsonl",
+          ".ndjson"
         ],
         "filenames": [],
         "configuration": "./language-configuration.json"


### PR DESCRIPTION
NDJSON is a specification that is essentially the same thing as JSON lines. The spec can be found on https://github.com/ndjson/ndjson-spec.

The NDJSON website is down. The project seems pretty much dead. The status is best described by this comment:
https://github.com/ndjson/ndjson-spec/issues/35#issuecomment-1285673417

However, this doesn’t mean there aren’t any `.ndjson` files out there. This changes adds `.ndjson` to the list of `jsonl` file extensions.