### PR TITLE
Make `preparePasteEdits` interrupt diagnostics too

### DIFF
--- a/extensions/typescript-language-features/src/languageFeatures/copyPaste.ts
+++ b/extensions/typescript-language-features/src/languageFeatures/copyPaste.ts
@@ -60,10 +60,10 @@ class DocumentPasteProvider implements vscode.DocumentPasteEditProvider {
 			return;
 		}
 
-		const response = await this._client.execute('preparePasteEdits', {
+		const response = await this._client.interruptGetErr(() => this._client.execute('preparePasteEdits', {
 			file,
 			copiedTextSpan: ranges.map(typeConverters.Range.toTextSpan),
-		}, token);
+		}, token));
 		if (token.isCancellationRequested || response.type !== 'response' || !response.body) {
 			return;
 		}


### PR DESCRIPTION
For #235959

Already done for the main paste request but we should do it for `preparePasteEdits`  too

