### PR TITLE
Set dropdown container's `aria-disabled` property to announce its disabled state on keyboard focus to screen reader users

### DIFF
--- a/src/vs/platform/actions/browser/dropdownWithPrimaryActionViewItem.ts
+++ b/src/vs/platform/actions/browser/dropdownWithPrimaryActionViewItem.ts
@@ -87,6 +87,7 @@ export class DropdownWithPrimaryActionViewItem extends BaseActionViewItem {
 		this._container.classList.add('monaco-dropdown-with-primary');
 		const primaryContainer = DOM.$('.action-container');
 		primaryContainer.role = 'button';
+		primaryContainer.ariaDisabled = String(!this.action.enabled);
 		this._primaryAction.render(DOM.append(this._container, primaryContainer));
 		this._dropdownContainer = DOM.$('.dropdown-action-container');
 		this._dropdown.render(DOM.append(this._container, this._dropdownContainer));


### PR DESCRIPTION
fix #235203

<img width="1125" alt="Screenshot 2024-12-12 at 1 12 53 PM" src="https://github.com/user-attachments/assets/61139a34-6ff4-49da-a821-ea73be0a70c7" />

