### PR TITLE
change condition for adding terminal completion executables

### DIFF
--- a/extensions/terminal-suggest/src/terminalSuggestMain.ts
+++ b/extensions/terminal-suggest/src/terminalSuggestMain.ts
@@ -187,7 +187,7 @@ async function getCommandsInPath(): Promise<Set<string> | undefined> {
 			const files = await vscode.workspace.fs.readDirectory(vscode.Uri.file(path));
 
 			for (const [file, fileType] of files) {
-				if (fileType === vscode.FileType.File || fileType === vscode.FileType.SymbolicLink) {
+				if (fileType !== vscode.FileType.Unknown && fileType !== vscode.FileType.Directory) {
 					executables.add(file);
 				}
 			}


### PR DESCRIPTION
fix #235082

see https://github.com/microsoft/vscode/issues/235082#issuecomment-2539870337

Before, I wasn't seeing `code-insiders` in the list

<img width="331" alt="Screenshot 2024-12-12 at 1 58 54 PM" src="https://github.com/user-attachments/assets/4897d8de-40da-4b2e-8731-87327d88024e" />
