### PR TITLE
support showIcons setting in terminal completions, simple suggest widget

### DIFF
--- a/src/vs/workbench/services/suggest/browser/simpleSuggestWidget.ts
+++ b/src/vs/workbench/services/suggest/browser/simpleSuggestWidget.ts
@@ -19,6 +19,7 @@ import { localize } from '../../../../nls.js';
 import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
 import { SuggestWidgetStatus } from '../../../../editor/contrib/suggest/browser/suggestWidgetStatus.js';
 import { MenuId } from '../../../../platform/actions/common/actions.js';
+import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 
 const $ = dom.$;
 
@@ -86,7 +87,8 @@ export class SimpleSuggestWidget extends Disposable {
 		private readonly _persistedSize: IPersistedWidgetSizeDelegate,
 		private readonly _getFontInfo: () => ISimpleSuggestWidgetFontInfo,
 		options: IWorkbenchSuggestWidgetOptions,
-		@IInstantiationService instantiationService: IInstantiationService
+		@IInstantiationService instantiationService: IInstantiationService,
+		@IConfigurationService configurationService: IConfigurationService,
 	) {
 		super();
 
@@ -140,6 +142,9 @@ export class SimpleSuggestWidget extends Disposable {
 			// this._preferenceLocked = false;
 			state = undefined;
 		}));
+
+		const applyIconStyle = () => this.element.domNode.classList.toggle('no-icons', !configurationService.getValue('editor.suggest.showIcons'));
+		applyIconStyle();
 
 		const renderer = new SimpleSuggestWidgetItemRenderer(_getFontInfo);
 		this._register(renderer);
@@ -196,6 +201,11 @@ export class SimpleSuggestWidget extends Disposable {
 		this._register(this._list.onMouseDown(e => this._onListMouseDownOrTap(e)));
 		this._register(this._list.onTap(e => this._onListMouseDownOrTap(e)));
 		this._register(this._list.onDidChangeSelection(e => this._onListSelection(e)));
+		this._register(configurationService.onDidChangeConfiguration(e => {
+			if (e.affectsConfiguration('editor.suggest.showIcons')) {
+				applyIconStyle();
+			}
+		}));
 	}
 
 	private _cursorPosition?: { top: number; left: number; height: number };


### PR DESCRIPTION
fixes #235088

<img width="457" alt="Screenshot 2024-12-12 at 2 36 35 PM" src="https://github.com/user-attachments/assets/8c83dd66-c5b6-49bf-b407-f9fe7468a7ce" />

exactly what's done here https://github.com/microsoft/vscode/blob/f3c23c67bb1bb86c77a3c4fe641d2c89b2a08034/src/vs/editor/contrib/suggest/browser/suggestWidget.ts#L217-L218
