### PR TITLE
debug: ignore error when stopping a process

### DIFF
--- a/src/vs/workbench/api/browser/mainThreadDebugService.ts
+++ b/src/vs/workbench/api/browser/mainThreadDebugService.ts
@@ -397,7 +397,8 @@ export class MainThreadDebugService implements MainThreadDebugServiceShape, IDeb
 	}
 
 	public $acceptDAExit(handle: number, code: number, signal: string) {
-		this.getDebugAdapter(handle).fireExit(handle, code, signal);
+		// don't use getDebugAdapter since an error can be expected on a post-close
+		this._debugAdapters.get(handle)?.fireExit(handle, code, signal);
 	}
 
 	private getDebugAdapter(handle: number): ExtensionHostDebugAdapter {


### PR DESCRIPTION
This is a fix for the error

```
2024-12-13 00:42:43.208 [error] Error: Invalid debug adapter
    at mVt.p (vscode-file://vscode-app/c:/Users/Oleg/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/workbench/workbench.desktop.main.js:748:95)
    at mVt.$acceptDAExit (vscode-file://vscode-app/c:/Users/Oleg/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/workbench/workbench.desktop.main.js:748:35)
    at Fdt.S (vscode-file://vscode-app/c:/Users/Oleg/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/workbench/workbench.desktop.main.js:3145:41680)
    at Fdt.Q (vscode-file://vscode-app/c:/Users/Oleg/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/workbench/workbench.desktop.main.js:3145:41458)
    at Fdt.M (vscode-file://vscode-app/c:/Users/Oleg/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/workbench/workbench.desktop.main.js:3145:40546)
    at Fdt.L (vscode-file://vscode-app/c:/Users/Oleg/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/workbench/workbench.desktop.main.js:3145:39783)
    at aee.value (vscode-file://vscode-app/c:/Users/Oleg/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/workbench/workbench.desktop.main.js:3145:38444)
    at x.B (vscode-file://vscode-app/c:/Users/Oleg/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/workbench/workbench.desktop.main.js:30:748)
    at x.fire (vscode-file://vscode-app/c:/Users/Oleg/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/workbench/workbench.desktop.main.js:30:967)
    at K6.fire (vscode-file://vscode-app/c:/Users/Oleg/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/workbench/workbench.desktop.main.js:762:10348)
2024-12-13 00:42:43.882 [error] [llvm-vs-code-extensions.vscode-clangd] provider FAILED
2024-12-13 00:42:43.882 [error] {"a":true,"b":null}
```

It happens when you stop the debugged process from within VSCode.

Fixes #228724. Fixes #196948.

Reproducible 100% of the time with https://github.com/llvm/vscode-lldb and lldb-dap on Windows.