### PR TITLE
remove width and height attributes from multi-file-edits.svg

### DIFF
--- a/src/vs/workbench/contrib/welcomeGettingStarted/common/media/multi-file-edits.svg
+++ b/src/vs/workbench/contrib/welcomeGettingStarted/common/media/multi-file-edits.svg
@@ -1,4 +1,4 @@
-<svg width="631" height="531" viewBox="0 0 631 531" fill="none" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<svg viewBox="0 0 631 531" fill="none" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <g>
     <g>
       <g clip-path="url(#clip0_304_6548)">


### PR DESCRIPTION
For: https://github.com/microsoft/vscode/issues/236243
Verified on exploration build.