### PR TITLE
`bun.lock` as package manager lockfile

### DIFF
--- a/extensions/npm/src/preferred-pm.ts
+++ b/extensions/npm/src/preferred-pm.ts
@@ -28,6 +28,10 @@ async function isBunPreferred(pkgPath: string): Promise<PreferredProperties> {
 		return { isPreferred: true, hasLockfile: true };
 	}
 
+	if (await pathExists(path.join(pkgPath, 'bun.lock'))) {
+		return { isPreferred: true, hasLockfile: true };
+	}
+
 	return { isPreferred: false, hasLockfile: false };
 }
 

--- a/src/vs/workbench/contrib/files/browser/files.contribution.ts
+++ b/src/vs/workbench/contrib/files/browser/files.contribution.ts
@@ -619,7 +619,7 @@ configurationRegistry.registerConfiguration({
 				'*.jsx': '${capture}.js',
 				'*.tsx': '${capture}.ts',
 				'tsconfig.json': 'tsconfig.*.json',
-				'package.json': 'package-lock.json, yarn.lock, pnpm-lock.yaml, bun.lockb',
+				'package.json': 'package-lock.json, yarn.lock, pnpm-lock.yaml, bun.lockb, bun.lock',
 			}
 		}
 	}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Extends #235917 by adding it to more places.

---

Also with `jsonc` it gives warnings about trailing comma, but we have made intentional decision to have them, so what is the best way to suppress them (ie not have whole file full of warnings) 
- I think I have worked it out with using the extension with `jsonValidation` and `allowTrailingCommas`, but just wondered the best official way was

example here: https://github.com/oven-sh/bun/pull/15705