### PR TITLE
Dim disabled SVG icons in action bar

### DIFF
--- a/src/vs/base/browser/ui/actionbar/actionbar.css
+++ b/src/vs/base/browser/ui/actionbar/actionbar.css
@@ -52,10 +52,17 @@
 	border-radius: 5px;
 }
 
-.monaco-action-bar .action-item.disabled .action-label,
-.monaco-action-bar .action-item.disabled .action-label::before,
-.monaco-action-bar .action-item.disabled .action-label:hover {
+.monaco-action-bar .action-item.disabled .action-label:not(.icon) ,
+.monaco-action-bar .action-item.disabled .action-label:not(.icon)::before,
+.monaco-action-bar .action-item.disabled .action-label:not(.icon):hover {
 	color: var(--vscode-disabledForeground);
+}
+
+/* Unable to change color of SVGs, hence opacity is used */
+.monaco-action-bar .action-item.disabled .action-label.icon ,
+.monaco-action-bar .action-item.disabled .action-label.icon::before,
+.monaco-action-bar .action-item.disabled .action-label.icon:hover {
+	opacity: 0.6;
 }
 
 /* Vertical actions */


### PR DESCRIPTION
Update the CSS to apply a reduced opacity to SVG icons in the action bar when commands are disabled, ensuring they visually indicate their disabled state. This addresses the issue where SVG icons were not dimmed as expected. Fixes #209397