### PR TITLE
add rm from context aria label, fallback to using title for aria label, set aria label when icon is set

### DIFF
--- a/src/vs/base/browser/ui/button/button.ts
+++ b/src/vs/base/browser/ui/button/button.ts
@@ -261,11 +261,7 @@ export class Button extends Disposable implements IButton {
 
 		this.setTitle(title);
 
-		if (typeof this.options.ariaLabel === 'string') {
-			this._element.setAttribute('aria-label', this.options.ariaLabel);
-		} else if (this.options.ariaLabel) {
-			this._element.setAttribute('aria-label', title);
-		}
+		this._setAriaLabel();
 
 		this._label = value;
 	}
@@ -286,7 +282,16 @@ export class Button extends Disposable implements IButton {
 		}
 	}
 
+	private _setAriaLabel(): void {
+		if (typeof this.options.ariaLabel === 'string') {
+			this._element.setAttribute('aria-label', this.options.ariaLabel);
+		} else if (typeof this.options.title === 'string') {
+			this._element.setAttribute('aria-label', this.options.title);
+		}
+	}
+
 	set icon(icon: ThemeIcon) {
+		this._setAriaLabel();
 		this._element.classList.add(...ThemeIcon.asClassNameArray(icon));
 	}
 

--- a/src/vs/base/browser/ui/button/button.ts
+++ b/src/vs/base/browser/ui/button/button.ts
@@ -28,6 +28,9 @@ import { IActionProvider } from '../dropdown/dropdown.js';
 
 export interface IButtonOptions extends Partial<IButtonStyles> {
 	readonly title?: boolean | string;
+	/**
+	 * Will fallback to `title` if not set.
+	 */
 	readonly ariaLabel?: string;
 	readonly supportIcons?: boolean;
 	readonly supportShortLabel?: boolean;

--- a/src/vs/base/browser/ui/button/button.ts
+++ b/src/vs/base/browser/ui/button/button.ts
@@ -28,7 +28,7 @@ import { IActionProvider } from '../dropdown/dropdown.js';
 
 export interface IButtonOptions extends Partial<IButtonStyles> {
 	readonly title?: boolean | string;
-	readonly ariaLabel?: boolean | string;
+	readonly ariaLabel?: string;
 	readonly supportIcons?: boolean;
 	readonly supportShortLabel?: boolean;
 	readonly secondary?: boolean;

--- a/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
@@ -977,11 +977,12 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 			return;
 		}
 
+		const title = localize('chat.attachment.clearButton', "Remove from context");
 		const clearButton = new Button(widget, {
 			supportIcons: true,
 			hoverDelegate,
-			title: localize('chat.attachment.clearButton', "Remove from context"),
-			ariaLabel: localize('chat.attachment.clearButtonAria', "Remove from context"),
+			title,
+			ariaLabel: title
 		});
 
 		// If this item is rendering in place of the last attached context item, focus the clear button so the user can continue deleting attached context items with the keyboard

--- a/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
@@ -977,11 +977,10 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 			return;
 		}
 
-		const title = localize('chat.attachment.clearButton', "Remove from context");
 		const clearButton = new Button(widget, {
 			supportIcons: true,
 			hoverDelegate,
-			title
+			title: localize('chat.attachment.clearButton', "Remove from context")
 		});
 
 		// If this item is rendering in place of the last attached context item, focus the clear button so the user can continue deleting attached context items with the keyboard

--- a/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
@@ -981,6 +981,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 			supportIcons: true,
 			hoverDelegate,
 			title: localize('chat.attachment.clearButton', "Remove from context"),
+			ariaLabel: localize('chat.attachment.clearButtonAria', "Remove from context"),
 		});
 
 		// If this item is rendering in place of the last attached context item, focus the clear button so the user can continue deleting attached context items with the keyboard

--- a/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
+++ b/src/vs/workbench/contrib/chat/browser/chatInputPart.ts
@@ -981,8 +981,7 @@ export class ChatInputPart extends Disposable implements IHistoryNavigationWidge
 		const clearButton = new Button(widget, {
 			supportIcons: true,
 			hoverDelegate,
-			title,
-			ariaLabel: title
+			title
 		});
 
 		// If this item is rendering in place of the last attached context item, focus the clear button so the user can continue deleting attached context items with the keyboard


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
fix #236094
fix #236247
fix #236248

<img width="988" alt="Screenshot 2024-12-13 at 2 09 14 PM" src="https://github.com/user-attachments/assets/29aa0505-4da0-48de-a547-0c2a76c6c378" />

Before, aria label would get set when `label` was set. `Label` is optional though. Now, we also set aria label when the icon is set. 

Before, we would fallback to the title when `ariaLabel:true`. Now, we will fallback to the `title`, if any, when no `ariaLabel` is provided.

cc @roblourens 