### PR TITLE
fix 235221: Sanitizing the html content by closing the unclosed tags

### DIFF
--- a/extensions/markdown-language-features/preview-src/index.ts
+++ b/extensions/markdown-language-features/preview-src/index.ts
@@ -355,7 +355,10 @@ document.addEventListener('click', event => {
 
 window.addEventListener('load', () => {
 	const htmlParser = new DOMParser();
-	const markDownHtml = htmlParser.parseFromString(getData('data-md-content'), 'text/html');
+	const markDownHtml = htmlParser.parseFromString(
+		decodeURIComponent(getData('data-md-content')),
+		'text/html'
+	);
 	document.body.appendChild(markDownHtml.body);
 });
 

--- a/extensions/markdown-language-features/preview-src/index.ts
+++ b/extensions/markdown-language-features/preview-src/index.ts
@@ -353,6 +353,12 @@ document.addEventListener('click', event => {
 	}
 }, true);
 
+window.addEventListener('load', () => {
+	const htmlParser = new DOMParser();
+	const markDownHtml = htmlParser.parseFromString(getData('data-md-content'), 'text/html');
+	document.body.appendChild(markDownHtml.body);
+});
+
 window.addEventListener('scroll', throttle(() => {
 	updateScrollProgress();
 

--- a/extensions/markdown-language-features/src/preview/documentRenderer.ts
+++ b/extensions/markdown-language-features/src/preview/documentRenderer.ts
@@ -99,7 +99,7 @@ export class MdDocumentRenderer {
 					data-settings="${escapeAttribute(JSON.stringify(initialData))}"
 					data-strings="${escapeAttribute(JSON.stringify(previewStrings))}"
 					data-state="${escapeAttribute(JSON.stringify(state || {}))}"
-					data-md-content="${escapeAttribute(JSON.stringify(body.html))}">
+					data-md-content="${escapeAttribute(JSON.stringify(encodeURIComponent(body.html)))}">
 				<script src="${this._extensionResourcePath(resourceProvider, 'pre.js')}" nonce="${nonce}"></script>
 				${this._getStyles(resourceProvider, sourceUri, config, imageInfo)}
 				<base href="${resourceProvider.asWebviewUri(markdownDocument.uri)}">

--- a/extensions/markdown-language-features/src/preview/documentRenderer.ts
+++ b/extensions/markdown-language-features/src/preview/documentRenderer.ts
@@ -98,13 +98,13 @@ export class MdDocumentRenderer {
 				<meta id="vscode-markdown-preview-data"
 					data-settings="${escapeAttribute(JSON.stringify(initialData))}"
 					data-strings="${escapeAttribute(JSON.stringify(previewStrings))}"
-					data-state="${escapeAttribute(JSON.stringify(state || {}))}">
+					data-state="${escapeAttribute(JSON.stringify(state || {}))}"
+					data-md-content="${escapeAttribute(JSON.stringify(body.html))}">
 				<script src="${this._extensionResourcePath(resourceProvider, 'pre.js')}" nonce="${nonce}"></script>
 				${this._getStyles(resourceProvider, sourceUri, config, imageInfo)}
 				<base href="${resourceProvider.asWebviewUri(markdownDocument.uri)}">
 			</head>
 			<body class="vscode-body ${config.scrollBeyondLastLine ? 'scrollBeyondLastLine' : ''} ${config.wordWrap ? 'wordWrap' : ''} ${config.markEditorSelection ? 'showEditorSelection' : ''}">
-				${body.html}
 				${this._getScripts(resourceProvider, nonce)}
 			</body>
 			</html>`;


### PR DESCRIPTION
fix #235221: Sanitizing the html content and closing the unclosed tags

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
The unclosed comment tag in markdown causes a breakage in the final html thats generated by the markdown rendering engine.

The script tags for markdown preview which are dynamically inserted to the DOM are engulfed by the unclosed comment tag and are then treated as a part of the comment by the JS engine.