### PR TITLE
Add gdshader to Godot icon list for theme-seti

### DIFF
--- a/extensions/theme-seti/build/update-icon-theme.js
+++ b/extensions/theme-seti/build/update-icon-theme.js
@@ -21,7 +21,7 @@ const nonBuiltInLanguages = { // { fileNames, extensions  }
 	"erb": { extensions: ['erb', 'rhtml', 'html.erb'] },
 	"github-issues": { extensions: ['github-issues'] },
 	"gradle": { extensions: ['gradle'] },
-	"godot": { extensions: ['gd', 'godot', 'tres', 'tscn'] },
+	"godot": { extensions: ['gd', 'godot', 'tres', 'tscn', 'gdshader'] },
 	"haml": { extensions: ['haml'] },
 	"haskell": { extensions: ['hs'] },
 	"haxe": { extensions: ['hx'] },

--- a/extensions/theme-seti/icons/vs-seti-icon-theme.json
+++ b/extensions/theme-seti/icons/vs-seti-icon-theme.json
@@ -534,6 +534,14 @@
 			"fontCharacter": "\\E03B",
 			"fontColor": "#a074c4"
 		},
+		"_godot_4_light": {
+			"fontCharacter": "\\E03B",
+			"fontColor": "#cc6d2e"
+		},
+		"_godot_4": {
+			"fontCharacter": "\\E03B",
+			"fontColor": "#e37933"
+		},
 		"_gradle_light": {
 			"fontCharacter": "\\E03C",
 			"fontColor": "#498ba7"
@@ -1614,6 +1622,7 @@
 		"godot": "_godot_1",
 		"tres": "_godot_2",
 		"tscn": "_godot_3",
+		"gdshader": "_godot_4",
 		"gradle": "_gradle",
 		"gsp": "_grails",
 		"gql": "_graphql",


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

This adds support for the `.gdshader` file extension to `theme-seti`'s icons.

<img width="1026" alt="Screenshot 2024-12-15 at 9 44 58 AM" src="https://github.com/user-attachments/assets/57216291-82c6-42e8-83f4-f3b803d8b46a" />

<img width="1026" alt="Screenshot 2024-12-15 at 9 45 07 AM" src="https://github.com/user-attachments/assets/ec05b8d9-810d-4987-914a-69956afdaa9e" />


