### PR TITLE
Only add additional margin on hover children with bg

### DIFF
--- a/src/vs/base/browser/ui/hover/hoverWidget.css
+++ b/src/vs/base/browser/ui/hover/hoverWidget.css
@@ -176,12 +176,23 @@
 	color: var(--vscode-textLink-activeForeground);
 }
 
-/** Spans in markdown hovers need a margin-bottom to avoid looking cramped: https://github.com/microsoft/vscode/issues/101496 **/
-.monaco-hover .markdown-hover .hover-contents:not(.code-hover-contents):not(.html-hover-contents) span {
+/**
+ * Spans in markdown hovers need a margin-bottom to avoid looking cramped:
+ * https://github.com/microsoft/vscode/issues/101496
+
+ * This was later refined to only apply when the last child of a rendered markdown block (before the
+ * border or a `hr`) uses background color:
+ * https://github.com/microsoft/vscode/issues/228136
+ */
+.monaco-hover .markdown-hover .hover-contents:not(.code-hover-contents):not(.html-hover-contents) p:last-child [style*="background-color"] {
 	margin-bottom: 4px;
 	display: inline-block;
 }
 
+/**
+ * Add a slight margin to try vertically align codicons with any text
+ * https://github.com/microsoft/vscode/issues/221359
+ */
 .monaco-hover .markdown-hover .hover-contents:not(.code-hover-contents):not(.html-hover-contents) span.codicon {
 	margin-bottom: 2px;
 }


### PR DESCRIPTION
Fixes #228136

After:

More consistent margins in extensions (cc @sandy081):

![image](https://github.com/user-attachments/assets/c23bcb90-12c7-432e-a3a3-8951934cc198)

Gap remains at bottom of tags in GHPR hover (cc @alexr00):

![image](https://github.com/user-attachments/assets/ba3735a2-b59d-4442-8b74-341416dde7c4)
