### PR TITLE
GitHub - do not show the "Publish to GitHub" command in an empty workspace

### DIFF
--- a/extensions/github/package.json
+++ b/extensions/github/package.json
@@ -69,7 +69,7 @@
       "commandPalette": [
         {
           "command": "github.publish",
-          "when": "git-base.gitEnabled && remoteName != 'codespaces'"
+          "when": "git-base.gitEnabled && workspaceFolderCount != 0 && remoteName != 'codespaces'"
         },
         {
           "command": "github.copyVscodeDevLink",


### PR DESCRIPTION
Fixes #234534