### PR TITLE
Fix titlebar update for longer extension names

### DIFF
--- a/src/vs/workbench/browser/parts/titlebar/titlebarPart.ts
+++ b/src/vs/workbench/browser/parts/titlebar/titlebarPart.ts
@@ -536,6 +536,10 @@ export class BrowserTitlebarPart extends Part implements ITitlebarPart {
 			this.title.innerText = this.windowTitle.value;
 			this.titleDisposables.add(this.windowTitle.onDidChange(() => {
 				this.title.innerText = this.windowTitle.value;
+				// layout menubar and other renderings in the titlebar
+				if (this.lastLayoutDimensions) {
+					this.updateLayout(this.lastLayoutDimensions);
+				}
 			}));
 		}
 


### PR DESCRIPTION
Ensure the titlebar updates correctly when window title updates

Fixes #171742