### PR TITLE
std-in files (/tmp/code-stdin-*) are not removed on remote and should have user only access rights

### DIFF
--- a/src/vs/platform/environment/node/stdin.ts
+++ b/src/vs/platform/environment/node/stdin.ts
@@ -38,12 +38,17 @@ export function getStdinFilePath(): string {
 	return randomPath(tmpdir(), 'code-stdin', 3);
 }
 
+async function createStdInFile(targetPath: string) {
+	await fs.promises.appendFile(targetPath, '');
+	await fs.promises.chmod(targetPath, 0o600); // Ensure the file is only read/writable by the user: https://github.com/microsoft/vscode-remote-release/issues/9048
+}
+
 export async function readFromStdin(targetPath: string, verbose: boolean, onEnd?: Function): Promise<void> {
 
 	let [encoding, iconv] = await Promise.all([
 		resolveTerminalEncoding(verbose),		// respect terminal encoding when piping into file
 		import('@vscode/iconv-lite-umd'),		// lazy load encoding module for usage
-		fs.promises.appendFile(targetPath, '') 	// make sure file exists right away (https://github.com/microsoft/vscode/issues/155341)
+		createStdInFile(targetPath) 			// make sure file exists right away (https://github.com/microsoft/vscode/issues/155341)
 	]);
 
 	if (!iconv.default.encodingExists(encoding)) {

--- a/src/vs/server/node/server.cli.ts
+++ b/src/vs/server/node/server.cli.ts
@@ -184,10 +184,11 @@ export async function main(desc: ProductDescription, args: string[]): Promise<vo
 	parsedArgs['_'] = [];
 
 	let readFromStdinPromise: Promise<void> | undefined;
+	let stdinFilePath: string | undefined;
 
 	if (hasReadStdinArg && hasStdinWithoutTty()) {
 		try {
-			let stdinFilePath = cliStdInFilePath;
+			stdinFilePath = cliStdInFilePath;
 			if (!stdinFilePath) {
 				stdinFilePath = getStdinFilePath();
 				const readFromStdinDone = new DeferredPromise<void>();
@@ -351,8 +352,18 @@ export async function main(desc: ProductDescription, args: string[]): Promise<vo
 
 		if (readFromStdinPromise) {
 			await readFromStdinPromise;
+
+		}
+
+		if (waitMarkerFilePath && stdinFilePath) {
+			try {
+				fs.unlinkSync(stdinFilePath);
+			} catch (e) {
+				//ignore
+			}
 		}
 	}
+
 }
 
 function runningInWSL2(): boolean {


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-remote-release/issues/9048