### PR TITLE
fix replacement index,length for terminal completions

### DIFF
--- a/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalCompletionService.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/browser/terminalCompletionService.ts
@@ -249,8 +249,8 @@ export class TerminalCompletionService extends Disposable implements ITerminalCo
 				kind,
 				isDirectory,
 				isFile: kind === TerminalCompletionItemKind.File,
-				replacementIndex: cursorPosition - lastWord.length > 0 ? cursorPosition - lastWord.length : cursorPosition,
-				replacementLength: lastWord.length > 0 ? lastWord.length : label.length
+				replacementIndex: cursorPosition - lastWord.length,
+				replacementLength: lastWord.length > 0 ? lastWord.length : cursorPosition
 			});
 		}
 

--- a/src/vs/workbench/contrib/terminalContrib/suggest/test/browser/terminalCompletionService.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/test/browser/terminalCompletionService.test.ts
@@ -69,6 +69,72 @@ suite('TerminalCompletionService', () => {
 	});
 
 	suite('resolveResources should return folder completions', () => {
+		test('', async () => {
+			const resourceRequestConfig: TerminalResourceRequestConfig = {
+				cwd: URI.parse('file:///test'),
+				foldersRequested: true,
+				pathSeparator
+			};
+			validResources = [URI.parse('file:///test')];
+			const childFolder = { resource: URI.parse('file:///test/folder1/'), name: 'folder1', isDirectory: true, isFile: false };
+			const childFile = { resource: URI.parse('file:///test/file1.txt'), name: 'file1.txt', isDirectory: false, isFile: true };
+			childResources = [childFolder, childFile];
+			const result = await terminalCompletionService.resolveResources(resourceRequestConfig, '', 1);
+			assert(!!result);
+			assert(result.length === 1);
+			assert.deepEqual(result![0], {
+				label: `.${pathSeparator}folder1${pathSeparator}`,
+				kind: TerminalCompletionItemKind.Folder,
+				isDirectory: true,
+				isFile: false,
+				replacementIndex: 1,
+				replacementLength: 1
+			});
+		});
+		test('.', async () => {
+			const resourceRequestConfig: TerminalResourceRequestConfig = {
+				cwd: URI.parse('file:///test'),
+				foldersRequested: true,
+				pathSeparator
+			};
+			validResources = [URI.parse('file:///test')];
+			const childFolder = { resource: URI.parse('file:///test/folder1/'), name: 'folder1', isDirectory: true, isFile: false };
+			const childFile = { resource: URI.parse('file:///test/file1.txt'), name: 'file1.txt', isDirectory: false, isFile: true };
+			childResources = [childFolder, childFile];
+			const result = await terminalCompletionService.resolveResources(resourceRequestConfig, '.', 2);
+			assert(!!result);
+			assert(result.length === 1);
+			assert.deepEqual(result![0], {
+				label: `.${pathSeparator}folder1${pathSeparator}`,
+				kind: TerminalCompletionItemKind.Folder,
+				isDirectory: true,
+				isFile: false,
+				replacementIndex: 1,
+				replacementLength: 1
+			});
+		});
+		test('./', async () => {
+			const resourceRequestConfig: TerminalResourceRequestConfig = {
+				cwd: URI.parse('file:///test'),
+				foldersRequested: true,
+				pathSeparator
+			};
+			validResources = [URI.parse('file:///test')];
+			const childFolder = { resource: URI.parse('file:///test/folder1/'), name: 'folder1', isDirectory: true, isFile: false };
+			const childFile = { resource: URI.parse('file:///test/file1.txt'), name: 'file1.txt', isDirectory: false, isFile: true };
+			childResources = [childFolder, childFile];
+			const result = await terminalCompletionService.resolveResources(resourceRequestConfig, './', 3);
+			assert(!!result);
+			assert(result.length === 1);
+			assert.deepEqual(result![0], {
+				label: `.${pathSeparator}folder1${pathSeparator}`,
+				kind: TerminalCompletionItemKind.Folder,
+				isDirectory: true,
+				isFile: false,
+				replacementIndex: 1,
+				replacementLength: 2
+			});
+		});
 		test('cd ', async () => {
 			const resourceRequestConfig: TerminalResourceRequestConfig = {
 				cwd: URI.parse('file:///test'),

--- a/src/vs/workbench/contrib/terminalContrib/suggest/test/browser/terminalCompletionService.test.ts
+++ b/src/vs/workbench/contrib/terminalContrib/suggest/test/browser/terminalCompletionService.test.ts
@@ -88,7 +88,7 @@ suite('TerminalCompletionService', () => {
 				isDirectory: true,
 				isFile: false,
 				replacementIndex: 3,
-				replacementLength: 10
+				replacementLength: 3
 			});
 		});
 		test('cd .', async () => {


### PR DESCRIPTION
adds more tests cases and:

fixes #236256
<img width="503" alt="Screenshot 2024-12-16 at 12 04 55 PM" src="https://github.com/user-attachments/assets/84c454a0-1de8-42fb-b975-78e3a6f60a0c" />

fixes https://github.com/microsoft/vscode/issues/236257
<img width="717" alt="Screenshot 2024-12-16 at 12 04 29 PM" src="https://github.com/user-attachments/assets/6fb8f467-901d-4a9b-94d7-4aba4b781b43" />

fixes https://github.com/microsoft/vscode/issues/236254
<img width="528" alt="Screenshot 2024-12-16 at 12 10 11 PM" src="https://github.com/user-attachments/assets/0aec49f6-ad04-405e-aa8e-b94500e0f5d0" />

