### PR TITLE
get terminal editor's name to persist upon rename cancellation

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminalActions.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalActions.ts
@@ -1720,12 +1720,13 @@ async function renameWithQuickPick(c: ITerminalServicesCollection, accessor: Ser
 	}
 
 	if (instance) {
-		const originalTitle = instance.title;
 		const title = await accessor.get(IQuickInputService).input({
 			value: instance.title,
 			prompt: localize('workbench.action.terminal.rename.prompt', "Enter terminal name"),
 		});
-		instance.rename(title ?? originalTitle);
+		if (title) {
+			instance.rename(title);
+		}
 	}
 }
 

--- a/src/vs/workbench/contrib/terminal/browser/terminalActions.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalActions.ts
@@ -1720,11 +1720,12 @@ async function renameWithQuickPick(c: ITerminalServicesCollection, accessor: Ser
 	}
 
 	if (instance) {
+		const originalTitle = instance.title;
 		const title = await accessor.get(IQuickInputService).input({
 			value: instance.title,
 			prompt: localize('workbench.action.terminal.rename.prompt', "Enter terminal name"),
 		});
-		instance.rename(title);
+		instance.rename(title ?? originalTitle);
 	}
 }
 


### PR DESCRIPTION
fix #235931