### PR TITLE
Show remote name for files in recently opened (fix #143096)

### DIFF
--- a/src/vs/platform/label/common/label.ts
+++ b/src/vs/platform/label/common/label.ts
@@ -20,8 +20,9 @@ export interface ILabelService {
 	 * If `relative` is passed returns a label relative to the workspace root that the uri belongs to.
 	 * If `noPrefix` is passed does not tildify the label and also does not prepand the root name for relative labels in a multi root scenario.
 	 * If `separator` is passed, will use that over the defined path separator of the formatter.
+	 * If `appendWorkspaceSuffix` is passed, will append the name of the workspace to the label.
 	 */
-	getUriLabel(resource: URI, options?: { relative?: boolean; noPrefix?: boolean; separator?: '/' | '\\' }): string;
+	getUriLabel(resource: URI, options?: { relative?: boolean; noPrefix?: boolean; separator?: '/' | '\\'; appendWorkspaceSuffix?: boolean }): string;
 	getUriBasenameLabel(resource: URI): string;
 	getWorkspaceLabel(workspace: (IWorkspaceIdentifier | ISingleFolderWorkspaceIdentifier | URI | IWorkspace), options?: { verbose: Verbosity }): string;
 	getHostLabel(scheme: string, authority?: string): string;

--- a/src/vs/workbench/browser/actions/windowActions.ts
+++ b/src/vs/workbench/browser/actions/windowActions.ts
@@ -211,7 +211,7 @@ abstract class BaseOpenRecentAction extends Action2 {
 			resource = recent.fileUri;
 			iconClasses = getIconClasses(modelService, languageService, resource, FileKind.FILE);
 			openable = { fileUri: resource };
-			fullLabel = recent.label || labelService.getUriLabel(resource);
+			fullLabel = recent.label || labelService.getUriLabel(resource, { appendWorkspaceSuffix: true });
 		}
 
 		const { name, parentPath } = splitRecentLabel(fullLabel);

--- a/src/vs/workbench/browser/parts/titlebar/menubarControl.ts
+++ b/src/vs/workbench/browser/parts/titlebar/menubarControl.ts
@@ -327,7 +327,7 @@ export abstract class MenubarControl extends Disposable {
 			openable = { workspaceUri: uri };
 		} else {
 			uri = recent.fileUri;
-			label = recent.label || this.labelService.getUriLabel(uri);
+			label = recent.label || this.labelService.getUriLabel(uri, { appendWorkspaceSuffix: true });
 			commandId = 'openRecentFile';
 			openable = { fileUri: uri };
 		}

--- a/src/vs/workbench/contrib/search/browser/anythingQuickAccess.ts
+++ b/src/vs/workbench/contrib/search/browser/anythingQuickAccess.ts
@@ -484,8 +484,6 @@ export class AnythingQuickAccessProvider extends PickerQuickAccessProvider<IAnyt
 		const editorHistoryPicks: Array<IAnythingQuickPickItem> = [];
 		for (const editor of this.historyService.getHistory()) {
 			const resource = editor.resource;
-			// allow untitled and terminal editors to go through
-			// allow github copilot chat to go through
 			if (!resource) {
 				continue;
 			}

--- a/src/vs/workbench/services/dialogs/browser/abstractFileDialogService.ts
+++ b/src/vs/workbench/services/dialogs/browser/abstractFileDialogService.ts
@@ -230,7 +230,7 @@ export abstract class AbstractFileDialogService implements IFileDialogService {
 	}
 
 	protected addFileToRecentlyOpened(uri: URI): void {
-		this.workspacesService.addRecentlyOpened([{ fileUri: uri, label: this.labelService.getUriLabel(uri) }]);
+		this.workspacesService.addRecentlyOpened([{ fileUri: uri, label: this.labelService.getUriLabel(uri, { appendWorkspaceSuffix: true }) }]);
 	}
 
 	protected async pickFolderAndOpenSimplified(schema: string, options: IPickAndOpenOptions): Promise<void> {

--- a/src/vs/workbench/services/host/browser/browserHostService.ts
+++ b/src/vs/workbench/services/host/browser/browserHostService.ts
@@ -428,7 +428,7 @@ export class BrowserHostService extends Disposable implements IHostService {
 			return this.labelService.getWorkspaceLabel(getWorkspaceIdentifier(openable.workspaceUri), { verbose: Verbosity.LONG });
 		}
 
-		return this.labelService.getUriLabel(openable.fileUri);
+		return this.labelService.getUriLabel(openable.fileUri, { appendWorkspaceSuffix: true });
 	}
 
 	private shouldReuse(options: IOpenWindowOptions = Object.create(null), isFile: boolean): boolean {

--- a/src/vs/workbench/services/host/electron-sandbox/nativeHostService.ts
+++ b/src/vs/workbench/services/host/electron-sandbox/nativeHostService.ts
@@ -130,7 +130,7 @@ class WorkbenchHostService extends Disposable implements IHostService {
 			return this.labelService.getWorkspaceLabel({ id: '', configPath: openable.workspaceUri }, { verbose: Verbosity.LONG });
 		}
 
-		return this.labelService.getUriLabel(openable.fileUri);
+		return this.labelService.getUriLabel(openable.fileUri, { appendWorkspaceSuffix: true });
 	}
 
 	private doOpenEmptyWindow(options?: IOpenEmptyWindowOptions): Promise<void> {

--- a/src/vs/workbench/services/label/common/labelService.ts
+++ b/src/vs/workbench/services/label/common/labelService.ts
@@ -208,19 +208,23 @@ export class LabelService extends Disposable implements ILabelService {
 		return bestResult ? bestResult.formatting : undefined;
 	}
 
-	getUriLabel(resource: URI, options: { relative?: boolean; noPrefix?: boolean; separator?: '/' | '\\' } = {}): string {
+	getUriLabel(resource: URI, options: { relative?: boolean; noPrefix?: boolean; separator?: '/' | '\\'; appendWorkspaceSuffix?: boolean } = {}): string {
 		let formatting = this.findFormatting(resource);
 		if (formatting && options.separator) {
 			// mixin separator if defined from the outside
 			formatting = { ...formatting, separator: options.separator };
 		}
 
-		const label = this.doGetUriLabel(resource, formatting, options);
+		let label = this.doGetUriLabel(resource, formatting, options);
 
 		// Without formatting we still need to support the separator
 		// as provided in options (https://github.com/microsoft/vscode/issues/130019)
 		if (!formatting && options.separator) {
-			return label.replace(sepRegexp, options.separator);
+			label = label.replace(sepRegexp, options.separator);
+		}
+
+		if (options.appendWorkspaceSuffix && formatting?.workspaceSuffix) {
+			label = this.appendWorkspaceSuffix(label, resource);
 		}
 
 		return label;


### PR DESCRIPTION
Adds the workspace label to file entries in recently opened:

![image](https://github.com/user-attachments/assets/3aa202c9-4a24-4bfa-9c80-324e0d02f823)
