### PR TITLE
fix "revert" icon in inline diff editor

### DIFF
--- a/src/vs/editor/browser/widget/diffEditor/diffEditor.contribution.ts
+++ b/src/vs/editor/browser/widget/diffEditor/diffEditor.contribution.ts
@@ -47,7 +47,7 @@ MenuRegistry.appendMenuItem(MenuId.EditorTitle, {
 registerAction2(RevertHunkOrSelection);
 
 for (const ctx of [
-	{ icon: Codicon.arrowRight, key: EditorContextKeys.diffEditorInlineMode.toNegated() },
+	{ icon: Codicon.arrowLeft, key: EditorContextKeys.diffEditorInlineMode.toNegated() },
 	{ icon: Codicon.discard, key: EditorContextKeys.diffEditorInlineMode }
 ]) {
 	MenuRegistry.appendMenuItem(MenuId.DiffEditorHunkToolbar, {


### PR DESCRIPTION
As the screenshot shows below, the "Revert Block" icon of diff editor (inline mode) is wrong. The arrow should point to left because the left editor is for original content and the right editor is for changed content. This PR fixes it.

Before:

![image](https://github.com/user-attachments/assets/688537ee-4e7f-47f1-9b92-11b0464f10a5)

After:

![image](https://github.com/user-attachments/assets/adf0d04e-18d0-4e16-8461-2f3059f77a61)

When clicking this button, it revert this block: (same as before)

https://github.com/user-attachments/assets/c0c77042-63d6-470a-93b8-75489e15f0d0
