### PR TITLE
request folders/files when appropriate

### DIFF
--- a/extensions/terminal-suggest/src/terminalSuggestMain.ts
+++ b/extensions/terminal-suggest/src/terminalSuggestMain.ts
@@ -328,16 +328,6 @@ export async function getCompletionItemsFromSpecs(specs: Fig.Spec[], terminalCon
 			}
 		}
 	}
-	const shouldShowCommands = !terminalContext.commandLine.substring(0, terminalContext.cursorPosition).trimStart().includes(' ');
-	if (shouldShowCommands && (filesRequested === foldersRequested)) {
-		// Include builitin/available commands in the results
-		const labels = new Set(items.map(i => i.label));
-		for (const command of availableCommands) {
-			if (!labels.has(command)) {
-				items.push(createCompletionItem(terminalContext.cursorPosition, prefix, command));
-			}
-		}
-	}
 
 	const shouldShowResourceCompletions =
 		(
@@ -350,6 +340,17 @@ export async function getCompletionItemsFromSpecs(specs: Fig.Spec[], terminalCon
 		)
 		// and neither files nor folders are going to be requested (for a specific spec's argument)
 		&& (!filesRequested && !foldersRequested);
+
+	const shouldShowCommands = !terminalContext.commandLine.substring(0, terminalContext.cursorPosition).trimStart().includes(' ');
+	if (shouldShowCommands && (filesRequested === foldersRequested)) {
+		// Include builitin/available commands in the results
+		const labels = new Set(items.map(i => i.label));
+		for (const command of availableCommands) {
+			if (!labels.has(command)) {
+				items.push(createCompletionItem(terminalContext.cursorPosition, prefix, command));
+			}
+		}
+	}
 
 	if (shouldShowResourceCompletions) {
 		filesRequested = true;


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
fix #236368

Moves the `shouldShowResourceCompletions` to before the commands are added to items because that checks `items.length` which was now always > 0 for this case since builtins/available commands get added now without being filtered in the extension. 

https://github.com/microsoft/vscode/pull/236370/files#diff-871475e273b07f70170c8a80935b21ef48e50211f5ecf48da0846719ccdacfb5R334-R340

<img width="592" alt="Screenshot 2024-12-17 at 10 38 46 AM" src="https://github.com/user-attachments/assets/0b8aa39a-ff2b-42bc-a84b-85cd5149c202" />
<img width="407" alt="Screenshot 2024-12-17 at 10 38 38 AM" src="https://github.com/user-attachments/assets/96ebd991-e161-4b16-9bbe-1d97b9d7e3e0" />

