### PR TITLE
Ensure settings and keybindings views open at correct location

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/preferences.contribution.ts
+++ b/src/vs/workbench/contrib/preferences/browser/preferences.contribution.ts
@@ -47,6 +47,9 @@ import { IUserDataProfileService, CURRENT_PROFILE_CONTEXT } from '../../../servi
 import { IUserDataProfilesService } from '../../../../platform/userDataProfile/common/userDataProfile.js';
 import { isCodeEditor } from '../../../../editor/browser/editorBrowser.js';
 import { Categories } from '../../../../platform/action/common/actionCommonCategories.js';
+import { resolveCommandsContext } from '../../../browser/parts/editor/editorCommandsContext.js';
+import { IEditorGroup, IEditorGroupsService } from '../../../services/editor/common/editorGroupsService.js';
+import { IListService } from '../../../../platform/list/browser/listService.js';
 
 const SETTINGS_EDITOR_COMMAND_SEARCH = 'settings.action.search';
 
@@ -791,9 +794,10 @@ class PreferencesActionsContribution extends Disposable implements IWorkbenchCon
 					]
 				});
 			}
-			run(accessor: ServicesAccessor, args: string | undefined) {
-				const query = typeof args === 'string' ? args : undefined;
-				return accessor.get(IPreferencesService).openGlobalKeybindingSettings(false, { query });
+			run(accessor: ServicesAccessor, ...args: unknown[]) {
+				const query = typeof args[0] === 'string' ? args[0] : undefined;
+				const groupId = getEditorGroupFromArguments(accessor, args)?.id;
+				return accessor.get(IPreferencesService).openGlobalKeybindingSettings(false, { query, groupId });
 			}
 		}));
 		this._register(MenuRegistry.appendMenuItem(MenuId.MenubarPreferencesMenu, {
@@ -834,8 +838,9 @@ class PreferencesActionsContribution extends Disposable implements IWorkbenchCon
 					]
 				});
 			}
-			run(accessor: ServicesAccessor) {
-				return accessor.get(IPreferencesService).openGlobalKeybindingSettings(true);
+			run(accessor: ServicesAccessor, ...args: unknown[]) {
+				const groupId = getEditorGroupFromArguments(accessor, args)?.id;
+				return accessor.get(IPreferencesService).openGlobalKeybindingSettings(true, { groupId });
 			}
 		}));
 		this._register(registerAction2(class extends Action2 {
@@ -852,8 +857,9 @@ class PreferencesActionsContribution extends Disposable implements IWorkbenchCon
 					]
 				});
 			}
-			run(accessor: ServicesAccessor) {
-				const editorPane = accessor.get(IEditorService).activeEditorPane;
+			run(accessor: ServicesAccessor, ...args: unknown[]) {
+				const group = getEditorGroupFromArguments(accessor, args);
+				const editorPane = group?.activeEditorPane;
 				if (editorPane instanceof KeybindingsEditor) {
 					editorPane.search('@source:system');
 				}
@@ -873,8 +879,9 @@ class PreferencesActionsContribution extends Disposable implements IWorkbenchCon
 					]
 				});
 			}
-			run(accessor: ServicesAccessor) {
-				const editorPane = accessor.get(IEditorService).activeEditorPane;
+			run(accessor: ServicesAccessor, ...args: unknown[]) {
+				const group = getEditorGroupFromArguments(accessor, args);
+				const editorPane = group?.activeEditorPane;
 				if (editorPane instanceof KeybindingsEditor) {
 					editorPane.search('@source:extension');
 				}
@@ -894,8 +901,9 @@ class PreferencesActionsContribution extends Disposable implements IWorkbenchCon
 					]
 				});
 			}
-			run(accessor: ServicesAccessor) {
-				const editorPane = accessor.get(IEditorService).activeEditorPane;
+			run(accessor: ServicesAccessor, args: unknown[]) {
+				const group = getEditorGroupFromArguments(accessor, args);
+				const editorPane = group?.activeEditorPane;
 				if (editorPane instanceof KeybindingsEditor) {
 					editorPane.search('@source:user');
 				}
@@ -1207,11 +1215,12 @@ class PreferencesActionsContribution extends Disposable implements IWorkbenchCon
 		for (const folder of this.workspaceContextService.getWorkspace().folders) {
 			const commandId = `_workbench.openFolderSettings.${folder.uri.toString()}`;
 			if (!CommandsRegistry.getCommand(commandId)) {
-				CommandsRegistry.registerCommand(commandId, () => {
+				CommandsRegistry.registerCommand(commandId, (accessor: ServicesAccessor, ...args: any[]) => {
+					const groupId = getEditorGroupFromArguments(accessor, args)?.id;
 					if (this.workspaceContextService.getWorkbenchState() === WorkbenchState.FOLDER) {
-						return this.preferencesService.openWorkspaceSettings({ jsonEditor: false });
+						return this.preferencesService.openWorkspaceSettings({ jsonEditor: false, groupId });
 					} else {
-						return this.preferencesService.openFolderSettings({ folderUri: folder.uri, jsonEditor: false });
+						return this.preferencesService.openFolderSettings({ folderUri: folder.uri, jsonEditor: false, groupId });
 					}
 				});
 				MenuRegistry.appendMenuItem(MenuId.EditorTitle, {
@@ -1261,9 +1270,10 @@ class SettingsEditorTitleContribution extends Disposable implements IWorkbenchCo
 						}]
 					});
 				}
-				run(accessor: ServicesAccessor, args: IOpenSettingsActionOptions) {
-					args = sanitizeOpenSettingsArgs(args);
-					return accessor.get(IPreferencesService).openUserSettings({ jsonEditor: false, ...args });
+				run(accessor: ServicesAccessor, ...args: unknown[]) {
+					const sanatizedArgs = sanitizeOpenSettingsArgs(args[0]);
+					const groupId = getEditorGroupFromArguments(accessor, args)?.id;
+					return accessor.get(IPreferencesService).openUserSettings({ jsonEditor: false, ...sanatizedArgs, groupId });
 				}
 			});
 		};
@@ -1289,8 +1299,9 @@ class SettingsEditorTitleContribution extends Disposable implements IWorkbenchCo
 					}]
 				});
 			}
-			run(accessor: ServicesAccessor) {
-				const editorPane = accessor.get(IEditorService).activeEditorPane;
+			run(accessor: ServicesAccessor, ...args: unknown[]) {
+				const group = getEditorGroupFromArguments(accessor, args);
+				const editorPane = group?.activeEditorPane;
 				if (editorPane instanceof SettingsEditor2) {
 					return editorPane.switchToSettingsFile();
 				}
@@ -1298,6 +1309,11 @@ class SettingsEditorTitleContribution extends Disposable implements IWorkbenchCo
 			}
 		}));
 	}
+}
+
+function getEditorGroupFromArguments(accessor: ServicesAccessor, args: unknown[]): IEditorGroup | undefined {
+	const context = resolveCommandsContext(args, accessor.get(IEditorService), accessor.get(IEditorGroupsService), accessor.get(IListService));
+	return context.groupedEditors[0]?.group;
 }
 
 const workbenchContributionsRegistry = Registry.as<IWorkbenchContributionsRegistry>(WorkbenchExtensions.Workbench);

--- a/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsEditor2.ts
@@ -789,7 +789,7 @@ export class SettingsEditor2 extends EditorPane {
 	private async openSettingsFile(options?: ISettingsEditorOptions): Promise<IEditorPane | undefined> {
 		const currentSettingsTarget = this.settingsTargetsWidget.settingsTarget;
 
-		const openOptions: IOpenSettingsOptions = { jsonEditor: true, ...options };
+		const openOptions: IOpenSettingsOptions = { jsonEditor: true, groupId: this.group.id, ...options };
 		if (currentSettingsTarget === ConfigurationTarget.USER_LOCAL) {
 			if (options?.revealSetting) {
 				const configurationProperties = Registry.as<IConfigurationRegistry>(Extensions.Configuration).getConfigurationProperties();

--- a/src/vs/workbench/services/preferences/common/preferences.ts
+++ b/src/vs/workbench/services/preferences/common/preferences.ts
@@ -211,6 +211,7 @@ export interface ISettingsEditorOptions extends IEditorOptions {
 export interface IOpenSettingsOptions extends ISettingsEditorOptions {
 	jsonEditor?: boolean;
 	openToSide?: boolean;
+	groupId?: number;
 }
 
 export function validateSettingsEditorOptions(options: ISettingsEditorOptions): ISettingsEditorOptions {
@@ -229,6 +230,10 @@ export interface IKeybindingsEditorModel<T> extends IPreferencesEditorModel<T> {
 
 export interface IKeybindingsEditorOptions extends IEditorOptions {
 	query?: string;
+}
+
+export interface IOpenKeybindingsEditorOptions extends IKeybindingsEditorOptions {
+	groupId?: number;
 }
 
 export const IPreferencesService = createDecorator<IPreferencesService>('preferencesService');
@@ -254,7 +259,7 @@ export interface IPreferencesService {
 	openRemoteSettings(options?: IOpenSettingsOptions): Promise<IEditorPane | undefined>;
 	openWorkspaceSettings(options?: IOpenSettingsOptions): Promise<IEditorPane | undefined>;
 	openFolderSettings(options: IOpenSettingsOptions & { folderUri: IOpenSettingsOptions['folderUri'] }): Promise<IEditorPane | undefined>;
-	openGlobalKeybindingSettings(textual: boolean, options?: IKeybindingsEditorOptions): Promise<void>;
+	openGlobalKeybindingSettings(textual: boolean, options?: IOpenKeybindingsEditorOptions): Promise<void>;
 	openDefaultKeybindingsFile(): Promise<IEditorPane | undefined>;
 	openLanguageSpecificSettings(languageId: string, options?: IOpenSettingsOptions): Promise<IEditorPane | undefined>;
 	getEditableSettingsURI(configurationTarget: ConfigurationTarget, resource?: URI): Promise<URI | null>;

--- a/src/vs/workbench/services/preferences/test/browser/preferencesService.test.ts
+++ b/src/vs/workbench/services/preferences/test/browser/preferencesService.test.ts
@@ -10,26 +10,37 @@ import { ICommandService } from '../../../../../platform/commands/common/command
 import { SyncDescriptor } from '../../../../../platform/instantiation/common/descriptors.js';
 import { ServiceCollection } from '../../../../../platform/instantiation/common/serviceCollection.js';
 import { IURLService } from '../../../../../platform/url/common/url.js';
-import { DEFAULT_EDITOR_ASSOCIATION } from '../../../../common/editor.js';
+import { DEFAULT_EDITOR_ASSOCIATION, IEditorPane } from '../../../../common/editor.js';
 import { IJSONEditingService } from '../../../configuration/common/jsonEditing.js';
 import { TestJSONEditingService } from '../../../configuration/test/common/testServices.js';
 import { PreferencesService } from '../../browser/preferencesService.js';
 import { IPreferencesService, ISettingsEditorOptions } from '../../common/preferences.js';
 import { IRemoteAgentService } from '../../../remote/common/remoteAgentService.js';
-import { TestRemoteAgentService, ITestInstantiationService, TestEditorService, workbenchInstantiationService } from '../../../../test/browser/workbenchTestServices.js';
+import { TestRemoteAgentService, ITestInstantiationService, workbenchInstantiationService, TestEditorGroupView, TestEditorGroupsService } from '../../../../test/browser/workbenchTestServices.js';
+import { IEditorGroupsService } from '../../../editor/common/editorGroupsService.js';
+import { IEditorOptions } from '../../../../../platform/editor/common/editor.js';
+import { SettingsEditor2Input } from '../../common/preferencesEditorInput.js';
 
 suite('PreferencesService', () => {
 	let testInstantiationService: ITestInstantiationService;
 	let testObject: PreferencesService;
-	let editorService: TestEditorService2;
+	let lastOpenEditorOptions: IEditorOptions | undefined;
 	const disposables = ensureNoDisposablesAreLeakedInTestSuite();
 
 	setup(() => {
-		editorService = disposables.add(new TestEditorService2());
-		testInstantiationService = workbenchInstantiationService({
-			editorService: () => editorService
-		}, disposables);
+		testInstantiationService = workbenchInstantiationService({}, disposables);
 
+		class TestOpenEditorGroupView extends TestEditorGroupView {
+			lastOpenEditorOptions: any;
+			override openEditor(_editor: SettingsEditor2Input, options?: IEditorOptions): Promise<IEditorPane> {
+				lastOpenEditorOptions = options;
+				_editor.dispose();
+				return Promise.resolve(undefined!);
+			}
+		}
+
+		const testEditorGroupService = new TestEditorGroupsService([new TestOpenEditorGroupView(0)]);
+		testInstantiationService.stub(IEditorGroupsService, testEditorGroupService);
 		testInstantiationService.stub(IJSONEditingService, TestJSONEditingService);
 		testInstantiationService.stub(IRemoteAgentService, TestRemoteAgentService);
 		testInstantiationService.stub(ICommandService, TestCommandService);
@@ -42,19 +53,10 @@ suite('PreferencesService', () => {
 		testObject = disposables.add(instantiationService.createInstance(PreferencesService));
 	});
 	test('options are preserved when calling openEditor', async () => {
-		testObject.openSettings({ jsonEditor: false, query: 'test query' });
-		const options = editorService.lastOpenEditorOptions as ISettingsEditorOptions;
+		await testObject.openSettings({ jsonEditor: false, query: 'test query' });
+		const options = lastOpenEditorOptions as ISettingsEditorOptions;
 		assert.strictEqual(options.focusSearch, true);
 		assert.strictEqual(options.override, DEFAULT_EDITOR_ASSOCIATION.id);
 		assert.strictEqual(options.query, 'test query');
 	});
 });
-
-class TestEditorService2 extends TestEditorService {
-	lastOpenEditorOptions: any;
-
-	override async openEditor(editorInput: any, options?: any): Promise<any | undefined> {
-		this.lastOpenEditorOptions = options;
-		return super.openEditor(editorInput, options);
-	}
-}


### PR DESCRIPTION
Adjust the settings and keybindings editor options to include a group ID, ensuring they open in the correct context.

fixes #213548

Can be tested by setting `workbench.editor.alwaysShowEditorActions` and clicking, having two groups, the settings editor in the inactive group and pressing on the open Settings (JSON) action