### PR TITLE
fix: memory leak in settings indicators

### DIFF
--- a/src/vs/workbench/contrib/preferences/browser/settingsEditorSettingIndicators.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsEditorSettingIndicators.ts
@@ -362,6 +362,7 @@ export class SettingsTreeIndicatorsLabel implements IDisposable {
 	}
 
 	updateScopeOverrides(element: SettingsTreeSettingElement, onDidClickOverrideElement: Emitter<ISettingOverrideClickEvent>, onApplyFilter: Emitter<string>) {
+		this.scopeOverridesIndicator.disposables.clear();
 		this.scopeOverridesIndicator.element.innerText = '';
 		this.scopeOverridesIndicator.element.style.display = 'none';
 		this.scopeOverridesIndicator.focusElement = this.scopeOverridesIndicator.element;
@@ -409,7 +410,6 @@ export class SettingsTreeIndicatorsLabel implements IDisposable {
 				// just to click into the one override there is.
 				this.scopeOverridesIndicator.element.style.display = 'inline';
 				this.scopeOverridesIndicator.element.classList.remove('setting-indicator');
-				this.scopeOverridesIndicator.disposables.clear();
 
 				const prefaceText = element.isConfigured ?
 					localize('alsoConfiguredIn', "Also modified in") :

--- a/src/vs/workbench/contrib/preferences/browser/settingsEditorSettingIndicators.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsEditorSettingIndicators.ts
@@ -360,7 +360,6 @@ export class SettingsTreeIndicatorsLabel implements IDisposable {
 		for (const indicator of this.parenthesizedIndicators) {
 			indicator.disposables.dispose();
 		}
-		this.scopeOverridesIndicator.disposables.dispose();
 	}
 
 	updateScopeOverrides(element: SettingsTreeSettingElement, onDidClickOverrideElement: Emitter<ISettingOverrideClickEvent>, onApplyFilter: Emitter<string>) {

--- a/src/vs/workbench/contrib/preferences/browser/settingsEditorSettingIndicators.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsEditorSettingIndicators.ts
@@ -194,7 +194,6 @@ export class SettingsTreeIndicatorsLabel implements IDisposable {
 		};
 		this.addHoverDisposables(disposables, syncIgnoredElement, showHover);
 
-
 		return {
 			element: syncIgnoredElement,
 			label: syncIgnoredLabel,

--- a/src/vs/workbench/contrib/preferences/browser/settingsEditorSettingIndicators.ts
+++ b/src/vs/workbench/contrib/preferences/browser/settingsEditorSettingIndicators.ts
@@ -194,6 +194,7 @@ export class SettingsTreeIndicatorsLabel implements IDisposable {
 		};
 		this.addHoverDisposables(disposables, syncIgnoredElement, showHover);
 
+
 		return {
 			element: syncIgnoredElement,
 			label: syncIgnoredLabel,
@@ -359,6 +360,7 @@ export class SettingsTreeIndicatorsLabel implements IDisposable {
 		for (const indicator of this.parenthesizedIndicators) {
 			indicator.disposables.dispose();
 		}
+		this.scopeOverridesIndicator.disposables.dispose();
 	}
 
 	updateScopeOverrides(element: SettingsTreeSettingElement, onDidClickOverrideElement: Emitter<ISettingOverrideClickEvent>, onApplyFilter: Emitter<string>) {


### PR DESCRIPTION
This fixes a memory leak in the settings indicators. 

Currently the function only clears the scopeOverridesIndicator in one if condition but not in others:

```js
this.scopeOverridesIndicator.disposables.clear();
```

This means that the hover disposables added here

```js
this.addHoverDisposables(this.scopeOverridesIndicator.disposables, this.scopeOverridesIndicator.element, showHover);
```

are not being cleared when calling updateScopeOverrides.