### PR TITLE
testing: show item when coverage is filtered, standardize some tree classes

### DIFF
--- a/src/vs/platform/actions/common/actions.ts
+++ b/src/vs/platform/actions/common/actions.ts
@@ -139,6 +139,7 @@ export class MenuId {
 	static readonly TestPeekElement = new MenuId('TestPeekElement');
 	static readonly TestPeekTitle = new MenuId('TestPeekTitle');
 	static readonly TestCallStack = new MenuId('TestCallStack');
+	static readonly TestCoverageFilterItem = new MenuId('TestCoverageFilterItem');
 	static readonly TouchBarContext = new MenuId('TouchBarContext');
 	static readonly TitleBarContext = new MenuId('TitleBarContext');
 	static readonly TitleBarTitleContext = new MenuId('TitleBarTitleContext');

--- a/src/vs/workbench/contrib/testing/browser/media/testing.css
+++ b/src/vs/workbench/contrib/testing/browser/media/testing.css
@@ -43,34 +43,41 @@
 	position: relative;
 }
 
-.test-explorer .test-item .label,
-.test-output-peek-tree .test-peek-item .name,
-.test-coverage-list-item .name,
-.test-coverage-list-item-label {
-	flex-grow: 1;
-	width: 0;
-	overflow: hidden;
-	white-space: nowrap;
-	text-overflow: ellipsis;
-
-	.monaco-list.horizontal-scrolling & {
-		width: auto;
-		overflow: visible;
-	}
-}
-
-.test-output-peek-tree .test-peek-item .name .codicon,
-.test-explorer .test-item .label .codicon {
-	vertical-align: middle;
-	font-size: 1em;
-	transform: scale(1.25);
-	margin: 0 0.125em;
-}
-
-.test-explorer .test-item,
-.test-output-peek-tree .test-peek-item {
+.testing-stdtree-container {
 	display: flex;
 	align-items: center;
+
+	.label {
+		flex-grow: 1;
+		width: 0;
+		overflow: hidden;
+		white-space: nowrap;
+		text-overflow: ellipsis;
+
+		.codicon {
+			vertical-align: middle;
+			font-size: 1em;
+			transform: scale(1.25);
+			margin: 0 0.125em;
+		}
+
+		.monaco-list.horizontal-scrolling & {
+			width: auto;
+			overflow: visible;
+		}
+	}
+
+	.monaco-action-bar {
+		display: none;
+		flex-shrink: 0;
+		margin-right: 0.8em;
+	}
+
+	&:hover, &.focused {
+		.monaco-action-bar {
+			display: initial;
+		}
+	}
 }
 
 .test-output-peek-tree {
@@ -78,12 +85,14 @@
 	border-left: 1px solid var(--vscode-panelSection-border);
 }
 
-.test-output-peek-tree .monaco-list-row .monaco-action-bar,
-.test-explorer .monaco-list-row .monaco-action-bar,
 .test-explorer .monaco-list-row .codicon-testing-hidden {
 	display: none;
 	flex-shrink: 0;
 	margin-right: 0.8em;
+}
+
+.test-explorer .monaco-list-row .monaco-action-bar.testing-is-continuous-run {
+	display: initial;
 }
 
 .test-explorer .monaco-list-row .monaco-action-bar .codicon-testing-continuous-is-on {
@@ -100,14 +109,6 @@
 
 .test-explorer .monaco-list-row .monaco-action-bar.testing-is-continuous-run .action-item:last-child {
 	display: block !important;
-}
-
-.test-explorer .monaco-list-row:hover .monaco-action-bar,
-.test-explorer .monaco-list-row.focused .monaco-action-bar,
-.test-explorer .monaco-list-row .monaco-action-bar.testing-is-continuous-run,
-.test-output-peek-tree .monaco-list-row:hover .monaco-action-bar,
-.test-output-peek-tree .monaco-list-row.focused .monaco-action-bar {
-	display: initial;
 }
 
 .test-explorer .monaco-list-row .test-is-hidden .codicon-testing-hidden {
@@ -466,15 +467,6 @@
 }
 
 /** -- coverage  */
-
-.coverage-view-is-filtered > .pane-header > .actions {
-	display: block !important;
-}
-
-.test-coverage-list-item {
-	display: flex;
-	align-items: center;
-}
 
 .test-coverage-bars {
 	display: flex;

--- a/src/vs/workbench/contrib/testing/browser/testCoverageView.ts
+++ b/src/vs/workbench/contrib/testing/browser/testCoverageView.ts
@@ -4,6 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as dom from '../../../../base/browser/dom.js';
+import { ActionBar } from '../../../../base/browser/ui/actionbar/actionbar.js';
 import { IIdentityProvider, IListVirtualDelegate } from '../../../../base/browser/ui/list/list.js';
 import { ICompressedTreeElement, ICompressedTreeNode } from '../../../../base/browser/ui/tree/compressedObjectTreeModel.js';
 import { ICompressibleTreeRenderer } from '../../../../base/browser/ui/tree/objectTree.js';
@@ -24,7 +25,9 @@ import { Position } from '../../../../editor/common/core/position.js';
 import { Range } from '../../../../editor/common/core/range.js';
 import { localize, localize2 } from '../../../../nls.js';
 import { Categories } from '../../../../platform/action/common/actionCommonCategories.js';
-import { Action2, MenuId, registerAction2 } from '../../../../platform/actions/common/actions.js';
+import { getActionBarActions } from '../../../../platform/actions/browser/menuEntryActionViewItem.js';
+import { Action2, IMenuService, MenuId, registerAction2 } from '../../../../platform/actions/common/actions.js';
+import { ICommandService } from '../../../../platform/commands/common/commands.js';
 import { IConfigurationService } from '../../../../platform/configuration/common/configuration.js';
 import { ContextKeyExpr, IContextKeyService } from '../../../../platform/contextkey/common/contextkey.js';
 import { IContextMenuService } from '../../../../platform/contextview/browser/contextView.js';
@@ -42,17 +45,17 @@ import { IThemeService } from '../../../../platform/theme/common/themeService.js
 import { IResourceLabel, ResourceLabels } from '../../../browser/labels.js';
 import { IViewPaneOptions, ViewAction, ViewPane } from '../../../browser/parts/views/viewPane.js';
 import { IViewDescriptorService } from '../../../common/views.js';
-import * as coverUtils from './codeCoverageDisplayUtils.js';
-import { testingStatesToIcons, testingWasCovered } from './icons.js';
-import { CoverageBarSource, ManagedTestCoverageBars } from './testCoverageBars.js';
+import { ACTIVE_GROUP, IEditorService, SIDE_GROUP } from '../../../services/editor/common/editorService.js';
 import { TestCommandId, Testing } from '../common/constants.js';
 import { onObservableChange } from '../common/observableUtils.js';
 import { BypassedFileCoverage, ComputedFileCoverage, FileCoverage, TestCoverage, getTotalCoveragePercent } from '../common/testCoverage.js';
 import { ITestCoverageService } from '../common/testCoverageService.js';
 import { TestId } from '../common/testId.js';
 import { TestingContextKeys } from '../common/testingContextKeys.js';
-import { CoverageDetails, DetailType, ICoverageCount, IDeclarationCoverage, TestResultState } from '../common/testTypes.js';
-import { ACTIVE_GROUP, IEditorService, SIDE_GROUP } from '../../../services/editor/common/editorService.js';
+import { CoverageDetails, DetailType, ICoverageCount, IDeclarationCoverage, ITestItem, TestResultState } from '../common/testTypes.js';
+import * as coverUtils from './codeCoverageDisplayUtils.js';
+import { testingStatesToIcons, testingWasCovered } from './icons.js';
+import { CoverageBarSource, ManagedTestCoverageBars } from './testCoverageBars.js';
 
 const enum CoverageSortOrder {
 	Coverage,
@@ -94,13 +97,6 @@ export class TestCoverageView extends ViewPane {
 			} else {
 				this.tree.clear();
 			}
-		}));
-
-		this._register(autorun(reader => {
-			this.element.classList.toggle(
-				'coverage-view-is-filtered',
-				!!this.coverageService.filterToTest.read(reader),
-			);
 		}));
 	}
 
@@ -197,6 +193,16 @@ class RevealUncoveredDeclarations {
 	constructor(public readonly n: number) { }
 }
 
+class CurrentlyFilteredTo {
+	public readonly id = String(fnNodeId++);
+
+	public get label() {
+		return localize('filteredToTest', "Showing coverage for \"{0}\"", this.testItem.label);
+	}
+
+	constructor(public readonly testItem: ITestItem) { }
+}
+
 class LoadingDetails {
 	public readonly id = String(fnNodeId++);
 	public readonly label = localize('loadingCoverageDetails', "Loading Coverage Details...");
@@ -204,7 +210,7 @@ class LoadingDetails {
 
 /** Type of nodes returned from {@link TestCoverage}. Note: value is *always* defined. */
 type TestCoverageFileNode = IPrefixTreeNode<ComputedFileCoverage | FileCoverage>;
-type CoverageTreeElement = TestCoverageFileNode | DeclarationCoverageNode | LoadingDetails | RevealUncoveredDeclarations;
+type CoverageTreeElement = TestCoverageFileNode | DeclarationCoverageNode | LoadingDetails | RevealUncoveredDeclarations | CurrentlyFilteredTo;
 
 const isFileCoverage = (c: CoverageTreeElement): c is TestCoverageFileNode => typeof c === 'object' && 'value' in c;
 const isDeclarationCoverage = (c: CoverageTreeElement): c is DeclarationCoverageNode => c instanceof DeclarationCoverageNode;
@@ -221,8 +227,11 @@ class TestCoverageTree extends Disposable {
 		sortOrder: IObservable<CoverageSortOrder>,
 		@IInstantiationService instantiationService: IInstantiationService,
 		@IEditorService editorService: IEditorService,
+		@ICommandService commandService: ICommandService,
 	) {
 		super();
+
+		container.classList.add('testing-stdtree');
 
 		this.tree = instantiationService.createInstance(
 			WorkbenchCompressibleObjectTree<CoverageTreeElement, void>,
@@ -233,6 +242,7 @@ class TestCoverageTree extends Disposable {
 				instantiationService.createInstance(FileCoverageRenderer, labels),
 				instantiationService.createInstance(DeclarationCoverageRenderer),
 				instantiationService.createInstance(BasicRenderer),
+				instantiationService.createInstance(CurrentlyFilteredToRenderer),
 			],
 			{
 				expandOnlyOnTwistieClick: true,
@@ -289,6 +299,9 @@ class TestCoverageTree extends Disposable {
 				} else if (isDeclarationCoverage(e.element)) {
 					resource = e.element.uri;
 					selection = e.element.location;
+				} else if (e.element instanceof CurrentlyFilteredTo) {
+					commandService.executeCommand(TestCommandId.CoverageFilterToTest);
+					return;
 				}
 			}
 			if (!resource) {
@@ -351,7 +364,19 @@ class TestCoverageTree extends Disposable {
 			}
 		}));
 
-		this.tree.setChildren(null, Iterable.map(files, toChild));
+		let children = Iterable.map(files, toChild);
+		const filteredTo = showOnlyTest && coverage.result.getTestById(showOnlyTest.toString());
+		if (filteredTo) {
+			children = Iterable.concat(
+				Iterable.single<ICompressedTreeElement<CoverageTreeElement>>({
+					element: new CurrentlyFilteredTo(filteredTo),
+					incompressible: true,
+				}),
+				children,
+			);
+		}
+
+		this.tree.setChildren(null, children);
 	}
 
 	public layout(height: number, width: number) {
@@ -409,6 +434,9 @@ class TestCoverageTreeListDelegate implements IListVirtualDelegate<CoverageTreeE
 		if (element instanceof LoadingDetails || element instanceof RevealUncoveredDeclarations) {
 			return BasicRenderer.ID;
 		}
+		if (element instanceof CurrentlyFilteredTo) {
+			return CurrentlyFilteredToRenderer.ID;
+		}
 		assertNever(element);
 	}
 }
@@ -448,6 +476,51 @@ class Sorter implements ITreeSorter<CoverageTreeElement> {
 	}
 }
 
+interface IFilteredToTemplate {
+	label: HTMLElement;
+	actions: ActionBar;
+}
+
+class CurrentlyFilteredToRenderer implements ICompressibleTreeRenderer<CoverageTreeElement, FuzzyScore, IFilteredToTemplate> {
+	public static readonly ID = 'C';
+	public readonly templateId = CurrentlyFilteredToRenderer.ID;
+
+	constructor(
+		@IMenuService private readonly menuService: IMenuService,
+		@IContextKeyService private readonly contextKeyService: IContextKeyService,
+	) { }
+
+	renderCompressedElements(node: ITreeNode<ICompressedTreeNode<CoverageTreeElement>, FuzzyScore>, index: number, templateData: IFilteredToTemplate, height: number | undefined): void {
+		this.renderInner(node.element.elements[node.element.elements.length - 1] as CurrentlyFilteredTo, templateData);
+	}
+
+	renderTemplate(container: HTMLElement): IFilteredToTemplate {
+		container.classList.add('testing-stdtree-container');
+		const label = dom.append(container, dom.$('.label'));
+		const menu = this.menuService.getMenuActions(MenuId.TestCoverageFilterItem, this.contextKeyService, {
+			shouldForwardArgs: true,
+		});
+
+		const actions = new ActionBar(container);
+		actions.push(getActionBarActions(menu, 'inline').primary, { icon: true, label: false });
+		actions.domNode.style.display = 'block';
+
+		return { label, actions };
+	}
+
+	renderElement(element: ITreeNode<CoverageTreeElement, FuzzyScore>, index: number, templateData: IFilteredToTemplate, height: number | undefined): void {
+		this.renderInner(element.element as CurrentlyFilteredTo, templateData);
+	}
+
+	disposeTemplate(templateData: IFilteredToTemplate): void {
+		templateData.actions.dispose();
+	}
+
+	private renderInner(element: CurrentlyFilteredTo, container: IFilteredToTemplate) {
+		container.label.innerText = element.label;
+	}
+}
+
 interface FileTemplateData {
 	container: HTMLElement;
 	bars: ManagedTestCoverageBars;
@@ -469,7 +542,7 @@ class FileCoverageRenderer implements ICompressibleTreeRenderer<CoverageTreeElem
 	/** @inheritdoc */
 	public renderTemplate(container: HTMLElement): FileTemplateData {
 		const templateDisposables = new DisposableStore();
-		container.classList.add('test-coverage-list-item');
+		container.classList.add('testing-stdtree-container', 'test-coverage-list-item');
 
 		return {
 			container,
@@ -518,7 +591,7 @@ class FileCoverageRenderer implements ICompressibleTreeRenderer<CoverageTreeElem
 			fileKind: stat.children?.size ? FileKind.FOLDER : FileKind.FILE,
 			matches: createMatches(filterData),
 			separator: this.labelService.getSeparator(file.uri.scheme, file.uri.authority),
-			extraClasses: ['test-coverage-list-item-label'],
+			extraClasses: ['label'],
 		});
 	}
 }
@@ -542,9 +615,10 @@ class DeclarationCoverageRenderer implements ICompressibleTreeRenderer<CoverageT
 	/** @inheritdoc */
 	public renderTemplate(container: HTMLElement): DeclarationTemplateData {
 		const templateDisposables = new DisposableStore();
-		container.classList.add('test-coverage-list-item');
+		container.classList.add('test-coverage-list-item', 'testing-stdtree-container');
+
 		const icon = dom.append(container, dom.$('.state'));
-		const label = dom.append(container, dom.$('.name'));
+		const label = dom.append(container, dom.$('.label'));
 
 		return {
 			container,
@@ -626,6 +700,7 @@ registerAction2(class TestCoverageChangePerTestFilterAction extends Action2 {
 			},
 			menu: [
 				{ id: MenuId.CommandPalette, when: TestingContextKeys.hasPerTestCoverage },
+				{ id: MenuId.TestCoverageFilterItem, group: 'inline' },
 				{
 					id: MenuId.ViewTitle,
 					when: ContextKeyExpr.and(TestingContextKeys.hasPerTestCoverage, ContextKeyExpr.equals('view', Testing.CoverageViewId)),

--- a/src/vs/workbench/contrib/testing/browser/testResultsView/testResultsTree.ts
+++ b/src/vs/workbench/contrib/testing/browser/testResultsView/testResultsTree.ts
@@ -669,11 +669,11 @@ class TestRunElementRenderer implements ICompressibleTreeRenderer<ITreeElement, 
 	/** @inheritdoc */
 	public renderTemplate(container: HTMLElement): TemplateData {
 		const templateDisposable = new DisposableStore();
-		const wrapper = dom.append(container, dom.$('.test-peek-item'));
-		const icon = dom.append(wrapper, dom.$('.state'));
-		const label = dom.append(wrapper, dom.$('.name'));
+		container.classList.add('testing-stdtree-container');
+		const icon = dom.append(container, dom.$('.state'));
+		const label = dom.append(container, dom.$('.label'));
 
-		const actionBar = new ActionBar(wrapper, {
+		const actionBar = new ActionBar(container, {
 			actionViewItemProvider: (action, options) =>
 				action instanceof MenuItemAction
 					? this.instantiationService.createInstance(MenuEntryActionViewItem, action, { hoverDelegate: options.hoverDelegate })

--- a/src/vs/workbench/contrib/testing/browser/testResultsView/testResultsViewContent.ts
+++ b/src/vs/workbench/contrib/testing/browser/testResultsView/testResultsViewContent.ts
@@ -248,7 +248,7 @@ export class TestResultsViewContent extends Disposable {
 		this.contextKeyTestMessage = TestingContextKeys.testMessageContext.bindTo(this.messageContextKeyService);
 		this.contextKeyResultOutdated = TestingContextKeys.testResultOutdated.bindTo(this.messageContextKeyService);
 
-		const treeContainer = dom.append(containerElement, dom.$('.test-output-peek-tree'));
+		const treeContainer = dom.append(containerElement, dom.$('.test-output-peek-tree.testing-stdtree'));
 		const tree = this._register(this.instantiationService.createInstance(
 			OutputPeekTree,
 			treeContainer,

--- a/src/vs/workbench/contrib/testing/browser/testingExplorerView.ts
+++ b/src/vs/workbench/contrib/testing/browser/testingExplorerView.ts
@@ -1526,8 +1526,8 @@ class TestItemRenderer extends Disposable
 	/**
 	 * @inheritdoc
 	 */
-	public renderTemplate(container: HTMLElement): ITestElementTemplateData {
-		const wrapper = dom.append(container, dom.$('.test-item'));
+	public renderTemplate(wrapper: HTMLElement): ITestElementTemplateData {
+		wrapper.classList.add('testing-stdtree-container');
 
 		const icon = dom.append(wrapper, dom.$('.computed-state'));
 		const label = dom.append(wrapper, dom.$('.label'));


### PR DESCRIPTION
Fixes #235147

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
