### PR TITLE
Restore close commands for keybinding support

### DIFF
--- a/src/vs/workbench/browser/actions/layoutActions.ts
+++ b/src/vs/workbench/browser/actions/layoutActions.ts
@@ -53,25 +53,6 @@ const fullscreenIcon = registerIcon('fullscreen', Codicon.screenFull, localize('
 const centerLayoutIcon = registerIcon('centerLayoutIcon', Codicon.layoutCentered, localize('centerLayoutIcon', "Represents centered layout mode"));
 const zenModeIcon = registerIcon('zenMode', Codicon.target, localize('zenModeIcon', "Represents zen mode"));
 
-
-// --- Close Side Bar
-
-registerAction2(class extends Action2 {
-
-	constructor() {
-		super({
-			id: 'workbench.action.closeSidebar',
-			title: localize2('closeSidebar', 'Close Primary Side Bar'),
-			category: Categories.View,
-			f1: true
-		});
-	}
-
-	run(accessor: ServicesAccessor): void {
-		accessor.get(IWorkbenchLayoutService).setPartHidden(true, Parts.SIDEBAR_PART);
-	}
-});
-
 export const ToggleActivityBarVisibilityActionId = 'workbench.action.toggleActivityBarVisibility';
 
 // --- Toggle Centered Layout

--- a/src/vs/workbench/browser/actions/layoutActions.ts
+++ b/src/vs/workbench/browser/actions/layoutActions.ts
@@ -304,6 +304,9 @@ class ToggleSidebarVisibilityAction extends Action2 {
 				title: localize('primary sidebar', "Primary Side Bar"),
 				mnemonicTitle: localize({ key: 'primary sidebar mnemonic', comment: ['&& denotes a mnemonic'] }, "&&Primary Side Bar"),
 			},
+			metadata: {
+				description: localize('openAndCloseSidebar', 'Open/Show and Close/Hide Sidebar'),
+			},
 			category: Categories.View,
 			f1: true,
 			keybinding: {

--- a/src/vs/workbench/browser/parts/auxiliarybar/auxiliaryBarActions.ts
+++ b/src/vs/workbench/browser/parts/auxiliarybar/auxiliaryBarActions.ts
@@ -41,6 +41,9 @@ export class ToggleAuxiliaryBarAction extends Action2 {
 			},
 			icon: closeIcon, // Ensures no flickering when using toggled.icon
 			category: Categories.View,
+			metadata: {
+				description: localize('openAndCloseAuxiliaryBar', 'Open/Show and Close/Hide Secondary Side Bar'),
+			},
 			f1: true,
 			keybinding: {
 				weight: KeybindingWeight.WorkbenchContrib,

--- a/src/vs/workbench/browser/parts/auxiliarybar/auxiliaryBarActions.ts
+++ b/src/vs/workbench/browser/parts/auxiliarybar/auxiliaryBarActions.ts
@@ -74,6 +74,21 @@ export class ToggleAuxiliaryBarAction extends Action2 {
 
 registerAction2(ToggleAuxiliaryBarAction);
 
+registerAction2(class extends Action2 {
+	constructor() {
+		super({
+			id: 'workbench.action.closeAuxiliaryBar',
+			title: localize2('closeSecondarySideBar', 'Hide Secondary Side Bar'),
+			category: Categories.View,
+			precondition: AuxiliaryBarVisibleContext,
+			f1: true,
+		});
+	}
+	run(accessor: ServicesAccessor) {
+		accessor.get(IWorkbenchLayoutService).setPartHidden(true, Parts.AUXILIARYBAR_PART);
+	}
+});
+
 registerAction2(class FocusAuxiliaryBarAction extends Action2 {
 
 	static readonly ID = 'workbench.action.focusAuxiliaryBar';

--- a/src/vs/workbench/browser/parts/panel/panelActions.ts
+++ b/src/vs/workbench/browser/parts/panel/panelActions.ts
@@ -46,6 +46,9 @@ export class TogglePanelAction extends Action2 {
 			icon: closeIcon, // Ensures no flickering when using toggled.icon
 			f1: true,
 			category: Categories.View,
+			metadata: {
+				description: localize('openAndClosePanel', 'Open/Show and Close/Hide Panel'),
+			},
 			keybinding: { primary: KeyMod.CtrlCmd | KeyCode.KeyJ, weight: KeybindingWeight.WorkbenchContrib },
 			menu: [
 				{

--- a/src/vs/workbench/browser/parts/panel/panelActions.ts
+++ b/src/vs/workbench/browser/parts/panel/panelActions.ts
@@ -74,6 +74,21 @@ export class TogglePanelAction extends Action2 {
 registerAction2(TogglePanelAction);
 
 registerAction2(class extends Action2 {
+	constructor() {
+		super({
+			id: 'workbench.action.closePanel',
+			title: localize2('closePanel', 'Hide Panel'),
+			category: Categories.View,
+			precondition: PanelVisibleContext,
+			f1: true,
+		});
+	}
+	run(accessor: ServicesAccessor) {
+		accessor.get(IWorkbenchLayoutService).setPartHidden(true, Parts.PANEL_PART);
+	}
+});
+
+registerAction2(class extends Action2 {
 
 	static readonly ID = 'workbench.action.focusPanel';
 	static readonly LABEL = localize('focusPanel', "Focus into Panel");

--- a/src/vs/workbench/browser/parts/sidebar/sidebarActions.ts
+++ b/src/vs/workbench/browser/parts/sidebar/sidebarActions.ts
@@ -13,6 +13,24 @@ import { KeybindingWeight } from '../../../../platform/keybinding/common/keybind
 import { Categories } from '../../../../platform/action/common/actionCommonCategories.js';
 import { IPaneCompositePartService } from '../../../services/panecomposite/browser/panecomposite.js';
 import { ViewContainerLocation } from '../../../common/views.js';
+import { SideBarVisibleContext } from '../../../common/contextkeys.js';
+
+registerAction2(class extends Action2 {
+
+	constructor() {
+		super({
+			id: 'workbench.action.closeSidebar',
+			title: localize2('closeSidebar', 'Close Primary Side Bar'),
+			category: Categories.View,
+			f1: true,
+			precondition: SideBarVisibleContext
+		});
+	}
+
+	run(accessor: ServicesAccessor): void {
+		accessor.get(IWorkbenchLayoutService).setPartHidden(true, Parts.SIDEBAR_PART);
+	}
+});
 
 export class FocusSideBarAction extends Action2 {
 


### PR DESCRIPTION
Reintroduce close commands for the sidebar, auxiliary bar, and panel, while improving their discoverability through updated metadata descriptions.

related https://github.com/microsoft/vscode/pull/236062