### PR TITLE
Adds single observable logging

### DIFF
--- a/src/vs/base/common/observableInternal/base.ts
+++ b/src/vs/base/common/observableInternal/base.ts
@@ -71,7 +71,7 @@ export interface IObservable<T, TChange = unknown> {
 	 * ONLY FOR DEBUGGING!
 	 * Logs computations of this derived.
 	*/
-	log(): IObservable<T>;
+	log(): IObservable<T, TChange>;
 
 	/**
 	 * Makes sure this value is computed eagerly.
@@ -239,7 +239,7 @@ export abstract class ConvenientObservable<T, TChange> implements IObservable<T,
 		);
 	}
 
-	public log(): IObservable<T> {
+	public log(): IObservable<T, TChange> {
 		logObservable(this);
 		return this;
 	}

--- a/src/vs/base/common/observableInternal/base.ts
+++ b/src/vs/base/common/observableInternal/base.ts
@@ -6,7 +6,7 @@
 import { DebugNameData, DebugOwner, getFunctionName } from './debugName.js';
 import { DisposableStore, EqualityComparer, IDisposable, strictEquals } from './commonFacade/deps.js';
 import type { derivedOpts } from './derived.js';
-import { getLogger } from './logging.js';
+import { getLogger, logObservable } from './logging.js';
 import { keepObserved, recomputeInitiallyAndOnChange } from './utils.js';
 
 /**
@@ -66,6 +66,12 @@ export interface IObservable<T, TChange = unknown> {
 	map<TNew>(owner: object, fn: (value: T, reader: IReader) => TNew): IObservable<TNew>;
 
 	flatten<TNew>(this: IObservable<IObservable<TNew>>): IObservable<TNew>;
+
+	/**
+	 * ONLY FOR DEBUGGING!
+	 * Logs computations of this derived.
+	*/
+	log(): IObservable<T>;
 
 	/**
 	 * Makes sure this value is computed eagerly.
@@ -231,6 +237,11 @@ export abstract class ConvenientObservable<T, TChange> implements IObservable<T,
 			},
 			(reader) => fn(this.read(reader), reader),
 		);
+	}
+
+	public log(): IObservable<T> {
+		logObservable(this);
+		return this;
 	}
 
 	/**

--- a/src/vs/base/common/observableInternal/derived.ts
+++ b/src/vs/base/common/observableInternal/derived.ts
@@ -459,6 +459,16 @@ export class Derived<T, TChangeSummary = any> extends BaseObservable<T, void> im
 		}
 		super.removeObserver(observer);
 	}
+
+	public override log(): IObservable<T> {
+		if (!getLogger()) {
+			super.log();
+			getLogger()?.handleDerivedCreated(this);
+		} else {
+			super.log();
+		}
+		return this;
+	}
 }
 
 

--- a/src/vs/base/common/observableInternal/derived.ts
+++ b/src/vs/base/common/observableInternal/derived.ts
@@ -460,7 +460,7 @@ export class Derived<T, TChangeSummary = any> extends BaseObservable<T, void> im
 		super.removeObserver(observer);
 	}
 
-	public override log(): IObservable<T> {
+	public override log(): IObservable<T, void> {
 		if (!getLogger()) {
 			super.log();
 			getLogger()?.handleDerivedCreated(this);

--- a/src/vs/base/common/observableInternal/lazyObservableValue.ts
+++ b/src/vs/base/common/observableInternal/lazyObservableValue.ts
@@ -6,6 +6,7 @@
 import { EqualityComparer } from './commonFacade/deps.js';
 import { BaseObservable, IObserver, ISettableObservable, ITransaction, TransactionImpl } from './base.js';
 import { DebugNameData } from './debugName.js';
+import { getLogger } from './logging.js';
 
 /**
  * Holds off updating observers until the value is actually read.
@@ -42,13 +43,15 @@ export class LazyObservableValue<T, TChange = void>
 		this._isUpToDate = true;
 
 		if (this._deltas.length > 0) {
-			for (const observer of this.observers) {
-				for (const change of this._deltas) {
+			for (const change of this._deltas) {
+				getLogger()?.handleObservableChanged(this, { change, didChange: true, oldValue: '(unknown)', newValue: this._value, hadValue: true });
+				for (const observer of this.observers) {
 					observer.handleChange(this, change);
 				}
 			}
 			this._deltas.length = 0;
 		} else {
+			getLogger()?.handleObservableChanged(this, { change: undefined, didChange: true, oldValue: '(unknown)', newValue: this._value, hadValue: true });
 			for (const observer of this.observers) {
 				observer.handleChange(this, undefined);
 			}

--- a/src/vs/base/common/observableInternal/logging.ts
+++ b/src/vs/base/common/observableInternal/logging.ts
@@ -18,6 +18,18 @@ export function getLogger(): IObservableLogger | undefined {
 	return globalObservableLogger;
 }
 
+export function logObservable(obs: IObservable<any>): void {
+	if (!globalObservableLogger) {
+		const l = new ConsoleObservableLogger();
+		l.addFilteredObj(obs);
+		setLogger(l);
+	} else {
+		if (globalObservableLogger instanceof ConsoleObservableLogger) {
+			(globalObservableLogger as ConsoleObservableLogger).addFilteredObj(obs);
+		}
+	}
+}
+
 interface IChangeInformation {
 	oldValue: unknown;
 	newValue: unknown;
@@ -43,6 +55,19 @@ export interface IObservableLogger {
 
 export class ConsoleObservableLogger implements IObservableLogger {
 	private indentation = 0;
+
+	private _filteredObjects: Set<unknown> | undefined;
+
+	public addFilteredObj(obj: unknown): void {
+		if (!this._filteredObjects) {
+			this._filteredObjects = new Set();
+		}
+		this._filteredObjects.add(obj);
+	}
+
+	private _isIncluded(obj: unknown): boolean {
+		return this._filteredObjects?.has(obj) ?? true;
+	}
 
 	private textToConsoleArgs(text: ConsoleText): unknown[] {
 		return consoleTextToArgs([
@@ -77,6 +102,7 @@ export class ConsoleObservableLogger implements IObservableLogger {
 	}
 
 	handleObservableChanged(observable: IObservable<unknown, unknown>, info: IChangeInformation): void {
+		if (!this._isIncluded(observable)) { return; }
 		console.log(...this.textToConsoleArgs([
 			formatKind('observable value changed'),
 			styled(observable.debugName, { color: 'BlueViolet' }),
@@ -130,7 +156,10 @@ export class ConsoleObservableLogger implements IObservableLogger {
 	}
 
 	handleDerivedRecomputed(derived: Derived<unknown>, info: IChangeInformation): void {
-		const changedObservables = this.changedObservablesSets.get(derived)!;
+		if (!this._isIncluded(derived)) { return; }
+
+		const changedObservables = this.changedObservablesSets.get(derived);
+		if (!changedObservables) { return; }
 		console.log(...this.textToConsoleArgs([
 			formatKind('derived recomputed'),
 			styled(derived.debugName, { color: 'BlueViolet' }),
@@ -142,6 +171,8 @@ export class ConsoleObservableLogger implements IObservableLogger {
 	}
 
 	handleFromEventObservableTriggered(observable: FromEventObservable<any, any>, info: IChangeInformation): void {
+		if (!this._isIncluded(observable)) { return; }
+
 		console.log(...this.textToConsoleArgs([
 			formatKind('observable from event triggered'),
 			styled(observable.debugName, { color: 'BlueViolet' }),
@@ -151,6 +182,8 @@ export class ConsoleObservableLogger implements IObservableLogger {
 	}
 
 	handleAutorunCreated(autorun: AutorunObserver): void {
+		if (!this._isIncluded(autorun)) { return; }
+
 		const existingHandleChange = autorun.handleChange;
 		this.changedObservablesSets.set(autorun, new Set());
 		autorun.handleChange = (observable, change) => {
@@ -160,13 +193,17 @@ export class ConsoleObservableLogger implements IObservableLogger {
 	}
 
 	handleAutorunTriggered(autorun: AutorunObserver): void {
-		const changedObservables = this.changedObservablesSets.get(autorun)!;
-		console.log(...this.textToConsoleArgs([
-			formatKind('autorun'),
-			styled(autorun.debugName, { color: 'BlueViolet' }),
-			this.formatChanges(changedObservables),
-			{ data: [{ fn: autorun._debugNameData.referenceFn ?? autorun._runFn }] }
-		]));
+		const changedObservables = this.changedObservablesSets.get(autorun);
+		if (!changedObservables) { return; }
+
+		if (this._isIncluded(autorun)) {
+			console.log(...this.textToConsoleArgs([
+				formatKind('autorun'),
+				styled(autorun.debugName, { color: 'BlueViolet' }),
+				this.formatChanges(changedObservables),
+				{ data: [{ fn: autorun._debugNameData.referenceFn ?? autorun._runFn }] }
+			]));
+		}
 		changedObservables.clear();
 		this.indentation++;
 	}
@@ -180,11 +217,13 @@ export class ConsoleObservableLogger implements IObservableLogger {
 		if (transactionName === undefined) {
 			transactionName = '';
 		}
-		console.log(...this.textToConsoleArgs([
-			formatKind('transaction'),
-			styled(transactionName, { color: 'BlueViolet' }),
-			{ data: [{ fn: transaction._fn }] }
-		]));
+		if (this._isIncluded(transaction)) {
+			console.log(...this.textToConsoleArgs([
+				formatKind('transaction'),
+				styled(transactionName, { color: 'BlueViolet' }),
+				{ data: [{ fn: transaction._fn }] }
+			]));
+		}
 		this.indentation++;
 	}
 

--- a/src/vs/base/common/observableInternal/logging.ts
+++ b/src/vs/base/common/observableInternal/logging.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { AutorunObserver } from './autorun.js';
-import { IObservable, ObservableValue, TransactionImpl } from './base.js';
+import { IObservable, TransactionImpl } from './base.js';
 import { Derived } from './derived.js';
 import { FromEventObservable } from './utils.js';
 
@@ -39,7 +39,7 @@ interface IChangeInformation {
 }
 
 export interface IObservableLogger {
-	handleObservableChanged(observable: ObservableValue<any, any>, info: IChangeInformation): void;
+	handleObservableChanged(observable: IObservable<any, any>, info: IChangeInformation): void;
 	handleFromEventObservableTriggered(observable: FromEventObservable<any, any>, info: IChangeInformation): void;
 
 	handleAutorunCreated(autorun: AutorunObserver): void;

--- a/src/vs/base/test/common/observable.test.ts
+++ b/src/vs/base/test/common/observable.test.ts
@@ -1507,21 +1507,21 @@ export class LoggingObservableValue<T, TChange = void>
 	implements ISettableObservable<T, TChange> {
 	private value: T;
 
-	constructor(public readonly debugName: string, initialValue: T, private readonly log: Log) {
+	constructor(public readonly debugName: string, initialValue: T, private readonly logger: Log) {
 		super();
 		this.value = initialValue;
 	}
 
 	protected override onFirstObserverAdded(): void {
-		this.log.log(`${this.debugName}.firstObserverAdded`);
+		this.logger.log(`${this.debugName}.firstObserverAdded`);
 	}
 
 	protected override onLastObserverRemoved(): void {
-		this.log.log(`${this.debugName}.lastObserverRemoved`);
+		this.logger.log(`${this.debugName}.lastObserverRemoved`);
 	}
 
 	public get(): T {
-		this.log.log(`${this.debugName}.get`);
+		this.logger.log(`${this.debugName}.get`);
 		return this.value;
 	}
 
@@ -1537,7 +1537,7 @@ export class LoggingObservableValue<T, TChange = void>
 			return;
 		}
 
-		this.log.log(`${this.debugName}.set (value ${value})`);
+		this.logger.log(`${this.debugName}.set (value ${value})`);
 
 		this.value = value;
 

--- a/src/vs/editor/browser/observableCodeEditor.ts
+++ b/src/vs/editor/browser/observableCodeEditor.ts
@@ -266,13 +266,13 @@ export class ObservableCodeEditor extends Disposable {
 	}
 
 	public observePosition(position: IObservable<Position | null>, store: DisposableStore): IObservable<Point | null> {
-		const result = observableValueOpts<Point | null>({ owner: this, equalsFn: equalsIfDefined(Point.equals) }, new Point(0, 0));
+		let pos = position.get();
+		const result = observableValueOpts<Point | null>({ owner: this, debugName: () => `topLeftOfPosition${pos?.toString()}`, equalsFn: equalsIfDefined(Point.equals) }, new Point(0, 0));
 		const contentWidgetId = `observablePositionWidget` + (this._widgetCounter++);
 		const domNode = document.createElement('div');
 		const w: IContentWidget = {
 			getDomNode: () => domNode,
 			getPosition: () => {
-				const pos = position.get();
 				return pos ? { preference: [ContentWidgetPositionPreference.EXACT], position: position.get() } : null;
 			},
 			getId: () => contentWidgetId,
@@ -283,7 +283,7 @@ export class ObservableCodeEditor extends Disposable {
 		};
 		this.editor.addContentWidget(w);
 		store.add(autorun(reader => {
-			position.read(reader);
+			pos = position.read(reader);
 			this.editor.layoutContentWidget(w);
 		}));
 		store.add(toDisposable(() => {


### PR DESCRIPTION
Do `const myDerived = derived(...).log()` to log whenever the derived is recomputed (and which dependencies changed).