### PR TITLE
Add shortcuts to compare incoming/current with common ancestor

### DIFF
--- a/extensions/merge-conflict/package.json
+++ b/extensions/merge-conflict/package.json
@@ -101,6 +101,20 @@
         "original": "Compare Current Conflict",
         "command": "merge-conflict.compare",
         "enablement": "!isMergeEditor"
+      },
+      {
+        "category": "%command.category%",
+        "title": "%command.compare-ancestor-current%",
+        "original": "Compare Current Conflict (common ancestor ↔ current)",
+        "command": "merge-conflict.compare-ancestor-current",
+        "enablement": "!isMergeEditor"
+      },
+      {
+        "category": "%command.category%",
+        "title": "%command.compare-ancestor-incoming%",
+        "original": "Compare Current Conflict (common ancestor ↔ incoming)",
+        "command": "merge-conflict.compare-ancestor-incoming",
+        "enablement": "!isMergeEditor"
       }
     ],
     "menus": {

--- a/extensions/merge-conflict/package.nls.json
+++ b/extensions/merge-conflict/package.nls.json
@@ -12,6 +12,8 @@
 	"command.next": "Next Conflict",
 	"command.previous": "Previous Conflict",
 	"command.compare": "Compare Current Conflict",
+	"command.compare-ancestor-current": "Compare Current Conflict (common ancestor ↔ current)",
+	"command.compare-ancestor-incoming": "Compare Current Conflict (common ancestor ↔ incoming)",
 	"config.title": "Merge Conflict",
 	"config.autoNavigateNextConflictEnabled": "Whether to automatically navigate to the next merge conflict after resolving a merge conflict.",
 	"config.codeLensEnabled": "Create a CodeLens for merge conflict blocks within editor.",

--- a/extensions/merge-conflict/src/codelensProvider.ts
+++ b/extensions/merge-conflict/src/codelensProvider.ts
@@ -63,25 +63,31 @@ export default class MergeConflictCodeLensProvider implements vscode.CodeLensPro
 		conflicts.forEach(conflict => {
 			const acceptCurrentCommand: vscode.Command = {
 				command: 'merge-conflict.accept.current',
-				title: vscode.l10n.t("Accept Current Change"),
+				title: vscode.l10n.t("Accept Current"),
 				arguments: ['known-conflict', conflict]
 			};
 
 			const acceptIncomingCommand: vscode.Command = {
 				command: 'merge-conflict.accept.incoming',
-				title: vscode.l10n.t("Accept Incoming Change"),
+				title: vscode.l10n.t("Accept Incoming"),
 				arguments: ['known-conflict', conflict]
 			};
 
 			const acceptBothCommand: vscode.Command = {
 				command: 'merge-conflict.accept.both',
-				title: vscode.l10n.t("Accept Both Changes"),
+				title: vscode.l10n.t("Accept Both"),
 				arguments: ['known-conflict', conflict]
 			};
 
+			// Only allow comparing with the common ancestor if there is a single
+			// one. This is the common case with diff3/zdiff3.
+			const hasSingleCommonAncestor = conflict.commonAncestors.length === 1;
+
 			const diffCommand: vscode.Command = {
 				command: 'merge-conflict.compare',
-				title: vscode.l10n.t("Compare Changes"),
+				title: hasSingleCommonAncestor
+					? vscode.l10n.t("Compare Current & Incoming")
+					: vscode.l10n.t("Compare Changes"),
 				arguments: [conflict]
 			};
 
@@ -92,6 +98,25 @@ export default class MergeConflictCodeLensProvider implements vscode.CodeLensPro
 				new vscode.CodeLens(range, acceptBothCommand),
 				new vscode.CodeLens(range, diffCommand)
 			);
+
+			if (hasSingleCommonAncestor) {
+				const diffBaseCurrentCommand: vscode.Command = {
+					command: 'merge-conflict.compare-ancestor-current',
+					title: vscode.l10n.t("Compare Ancestor & Current"),
+					arguments: [conflict]
+				};
+
+				const diffBaseIncomingCommand: vscode.Command = {
+					command: 'merge-conflict.compare-ancestor-incoming',
+					title: vscode.l10n.t("Compare Ancestor & Incoming"),
+					arguments: [conflict]
+				};
+
+				items.push(
+					new vscode.CodeLens(range, diffBaseCurrentCommand),
+					new vscode.CodeLens(range, diffBaseIncomingCommand),
+				);
+			}
 		});
 
 		return items;


### PR DESCRIPTION
Git has a diff style `diff3` or `zdiff3` that shows the common ancestor of two conflicting commits in the conflict. For example:

```
<<<<<<< HEAD
	int c = 2;
||||||| parent of ed293d1 (Capitalise)
	int c;
=======
	int C;
>>>>>>> ed293d1 (Capitalise)
```

This is enormously useful when resolving conflicts. However sometimes git is dumb and you end up with conflicts that are difficult to follow.

For example suppose you have some `really long old code`, and you write some `new code` to replace it. You rebase your change, and find that someone has made a tiny tiny change *somewhere* in the really long old code. It *might* be relevant - it could be some change that you also need to apply to your new code. But the conflict just looks like this:

```
<<<<<<< HEAD
	really
	long
	old
	code
||||||| parent of ed293d1 (Capitalise)
	really
	Long
	old
	code
=======
	new
	code
>>>>>>> ed293d1 (Capitalise)
```

Not too bad with 4 lines but sometimes it's hundreds, and then you end up visually diffing it, like a cave man.

There is an existing `Compare Changes` option, but it only compares `Current` with `Incoming`. This commit adds two more options to compare the common ancestor with `Current` or `Incoming` instead, thus solving the problem once and for all.

This was mostly straightforward. The two tricky bits are:

1. Apparently you can have more than one common ancestor. I've never seen that so I just don't show the buttons in that case (or pick the first common ancestor if you use the command palette).
2. What if you don't have `diff3` and still run the new compare commands from the command palette? In that case it falls back to not showing any changes.

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
