### PR TITLE
fix regression with terminal tabs/panel

### DIFF
--- a/src/vs/workbench/contrib/terminal/browser/terminalView.ts
+++ b/src/vs/workbench/contrib/terminal/browser/terminalView.ts
@@ -217,6 +217,7 @@ export class TerminalViewPane extends ViewPane {
 				// defer focusing the panel to the focus() call
 				// to prevent overriding preserveFocus for extensions
 				this._terminalGroupService.showPanel(false);
+				this.focus();
 			} else {
 				for (const instance of this._terminalGroupService.instances) {
 					instance.resetFocusContextKey();


### PR DESCRIPTION
fix #235931

With this change https://github.com/microsoft/vscode/issues/235931#issuecomment-2550841316, we now have to call the view container's `focus` when it becomes visible 

https://github.com/user-attachments/assets/0e92cce7-c72e-4cc5-84b9-84c1b15412f0




