### PR TITLE
focus debug console when it becomes visible 

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/repl.ts
+++ b/src/vs/workbench/contrib/debug/browser/repl.ts
@@ -214,6 +214,7 @@ export class Repl extends FilterViewPane implements IHistoryNavigationWidget {
 					this.tree?.updateChildren(undefined, true, false);
 					this.onDidStyleChange();
 				}
+				this.focus();
 			}
 		}));
 		this._register(this.configurationService.onDidChangeConfiguration(e => {


### PR DESCRIPTION
fix #236499

With this change https://github.com/microsoft/vscode/issues/235931#issuecomment-2550841316, we now have to call the view container's `focus` when it becomes visible 
