### PR TITLE
Splitting cells should maintain the current edit state

### DIFF
--- a/src/vs/workbench/contrib/notebook/browser/contrib/cellCommands/cellCommands.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/cellCommands/cellCommands.ts
@@ -15,7 +15,7 @@ import { KeybindingWeight } from '../../../../../../platform/keybinding/common/k
 import { ResourceNotebookCellEdit } from '../../../../bulkEdit/browser/bulkCellEdits.js';
 import { changeCellToKind, computeCellLinesContents, copyCellRange, joinCellsWithSurrounds, joinSelectedCells, moveCellRange } from '../../controller/cellOperations.js';
 import { cellExecutionArgs, CellOverflowToolbarGroups, CellToolbarOrder, CELL_TITLE_CELL_GROUP_ID, INotebookCellActionContext, INotebookCellToolbarActionContext, INotebookCommandContext, NotebookCellAction, NotebookMultiCellAction, parseMultiCellExecutionArgs } from '../../controller/coreActions.js';
-import { CellEditState, CellFocusMode, EXPAND_CELL_INPUT_COMMAND_ID, EXPAND_CELL_OUTPUT_COMMAND_ID, ICellOutputViewModel, ICellViewModel, INotebookEditor } from '../../notebookBrowser.js';
+import { CellFocusMode, EXPAND_CELL_INPUT_COMMAND_ID, EXPAND_CELL_OUTPUT_COMMAND_ID, ICellOutputViewModel, ICellViewModel, INotebookEditor } from '../../notebookBrowser.js';
 import { NOTEBOOK_CELL_EDITABLE, NOTEBOOK_CELL_HAS_OUTPUTS, NOTEBOOK_CELL_INPUT_COLLAPSED, NOTEBOOK_CELL_LIST_FOCUSED, NOTEBOOK_CELL_OUTPUT_COLLAPSED, NOTEBOOK_CELL_TYPE, NOTEBOOK_EDITOR_EDITABLE, NOTEBOOK_EDITOR_FOCUSED, NOTEBOOK_IS_ACTIVE_EDITOR, NOTEBOOK_OUTPUT_FOCUSED } from '../../../common/notebookContextKeys.js';
 import * as icons from '../../notebookIcons.js';
 import { CellEditType, CellKind, NotebookSetting } from '../../../common/notebookCommon.js';
@@ -206,9 +206,7 @@ registerAction2(class extends NotebookCellAction {
 					{ quotableLabel: 'Split Notebook Cell' }
 				);
 
-				if (cell.getEditState() !== CellEditState.Preview) {
-					context.notebookEditor.cellAt(index + 1)?.updateEditState(CellEditState.Editing, 'splitCell');
-				}
+				context.notebookEditor.cellAt(index + 1)?.updateEditState(cell.getEditState(), 'splitCell');
 			}
 		}
 	}

--- a/src/vs/workbench/contrib/notebook/browser/contrib/cellCommands/cellCommands.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/cellCommands/cellCommands.ts
@@ -15,7 +15,7 @@ import { KeybindingWeight } from '../../../../../../platform/keybinding/common/k
 import { ResourceNotebookCellEdit } from '../../../../bulkEdit/browser/bulkCellEdits.js';
 import { changeCellToKind, computeCellLinesContents, copyCellRange, joinCellsWithSurrounds, joinSelectedCells, moveCellRange } from '../../controller/cellOperations.js';
 import { cellExecutionArgs, CellOverflowToolbarGroups, CellToolbarOrder, CELL_TITLE_CELL_GROUP_ID, INotebookCellActionContext, INotebookCellToolbarActionContext, INotebookCommandContext, NotebookCellAction, NotebookMultiCellAction, parseMultiCellExecutionArgs } from '../../controller/coreActions.js';
-import { CellFocusMode, EXPAND_CELL_INPUT_COMMAND_ID, EXPAND_CELL_OUTPUT_COMMAND_ID, ICellOutputViewModel, ICellViewModel, INotebookEditor } from '../../notebookBrowser.js';
+import { CellEditState, CellFocusMode, EXPAND_CELL_INPUT_COMMAND_ID, EXPAND_CELL_OUTPUT_COMMAND_ID, ICellOutputViewModel, ICellViewModel, INotebookEditor } from '../../notebookBrowser.js';
 import { NOTEBOOK_CELL_EDITABLE, NOTEBOOK_CELL_HAS_OUTPUTS, NOTEBOOK_CELL_INPUT_COLLAPSED, NOTEBOOK_CELL_LIST_FOCUSED, NOTEBOOK_CELL_OUTPUT_COLLAPSED, NOTEBOOK_CELL_TYPE, NOTEBOOK_EDITOR_EDITABLE, NOTEBOOK_EDITOR_FOCUSED, NOTEBOOK_IS_ACTIVE_EDITOR, NOTEBOOK_OUTPUT_FOCUSED } from '../../../common/notebookContextKeys.js';
 import * as icons from '../../notebookIcons.js';
 import { CellEditType, CellKind, NotebookSetting } from '../../../common/notebookCommon.js';
@@ -205,6 +205,8 @@ registerAction2(class extends NotebookCellAction {
 					],
 					{ quotableLabel: 'Split Notebook Cell' }
 				);
+
+				context.notebookEditor.cellAt(index + 1)?.updateEditState(CellEditState.Editing, 'splitCell');
 			}
 		}
 	}

--- a/src/vs/workbench/contrib/notebook/browser/contrib/cellCommands/cellCommands.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/cellCommands/cellCommands.ts
@@ -206,7 +206,9 @@ registerAction2(class extends NotebookCellAction {
 					{ quotableLabel: 'Split Notebook Cell' }
 				);
 
-				context.notebookEditor.cellAt(index + 1)?.updateEditState(CellEditState.Editing, 'splitCell');
+				if (cell.getEditState() !== CellEditState.Preview) {
+					context.notebookEditor.cellAt(index + 1)?.updateEditState(CellEditState.Editing, 'splitCell');
+				}
 			}
 		}
 	}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

Fixes: #208673

This seems reasonable, as when you're splitting a cell, 99% of the time you would be in editing mode and likely would want to continue editing. We still split into preview mode if the cell being split was initially in preview mode. This effectively means that we are just splitting into the same mode as the cell was intially in.

cc/ @rebornix to check if there is a specific reason we have been always splitting md cells into preview mode.