### PR TITLE
Use stack instead of Array.shift()

### DIFF
--- a/src/vs/base/browser/ui/tree/abstractTree.ts
+++ b/src/vs/base/browser/ui/tree/abstractTree.ts
@@ -3082,8 +3082,9 @@ export abstract class AbstractTree<T, TFilterData, TRef> implements IDisposable 
 		const root = this.model.getNode();
 		const queue = [root];
 
-		while (queue.length > 0) {
-			const node = queue.shift()!;
+		let index = 0;
+		while (index < queue.length) {
+			const node = queue[index++];
 
 			if (node !== root && node.collapsible) {
 				state.expanded[getId(node.element)] = node.collapsed ? 0 : 1;

--- a/src/vs/base/browser/ui/tree/abstractTree.ts
+++ b/src/vs/base/browser/ui/tree/abstractTree.ts
@@ -3080,17 +3080,16 @@ export abstract class AbstractTree<T, TFilterData, TRef> implements IDisposable 
 		}
 
 		const root = this.model.getNode();
-		const queue = [root];
+		const stack = [root];
 
-		let index = 0;
-		while (index < queue.length) {
-			const node = queue[index++];
+		while (stack.length > 0) {
+			const node = stack.pop()!;
 
 			if (node !== root && node.collapsible) {
 				state.expanded[getId(node.element)] = node.collapsed ? 0 : 1;
 			}
 
-			insertInto(queue, queue.length, node.children);
+			insertInto(stack, stack.length, node.children);
 		}
 
 		return state;

--- a/src/vs/base/browser/ui/tree/asyncDataTree.ts
+++ b/src/vs/base/browser/ui/tree/asyncDataTree.ts
@@ -24,7 +24,7 @@ import { isIterable } from '../../../common/types.js';
 import { CancellationToken, CancellationTokenSource } from '../../../common/cancellation.js';
 import { IContextViewProvider } from '../contextview/contextview.js';
 import { FuzzyScore } from '../../../common/filters.js';
-import { splice } from '../../../common/arrays.js';
+import { insertInto, splice } from '../../../common/arrays.js';
 import { localize } from '../../../../nls.js';
 
 interface IAsyncDataTreeNode<TInput, T> {
@@ -1350,7 +1350,7 @@ export class AsyncDataTree<TInput, T, TFilterData = void> implements IDisposable
 				expanded.push(getId(node.element!.element as T));
 			}
 
-			stack.push(...node.children);
+			insertInto(stack, stack.length, node.children);
 		}
 
 		return { focus, selection, expanded, scrollTop: this.scrollTop };


### PR DESCRIPTION
Replace the use of `Array.shift()` with index-based access for improved performance in queue processing.

#230119