### PR TITLE
Revert "focus debug console when it becomes visible "

### DIFF
--- a/src/vs/workbench/contrib/debug/browser/repl.ts
+++ b/src/vs/workbench/contrib/debug/browser/repl.ts
@@ -214,7 +214,6 @@ export class Repl extends FilterViewPane implements IHistoryNavigationWidget {
 					this.tree?.updateChildren(undefined, true, false);
 					this.onDidStyleChange();
 				}
-				this.focus();
 			}
 		}));
 		this._register(this.configurationService.onDidChangeConfiguration(e => {


### PR DESCRIPTION
Reverts microsoft/vscode#236502

The change https://github.com/microsoft/vscode/issues/232790 that caused this to break was reverted, so now reverting this. 