### PR TITLE
rm `auto` as a type for voice synthesizer setting

### DIFF
--- a/src/vs/workbench/contrib/accessibility/browser/accessibilityConfiguration.ts
+++ b/src/vs/workbench/contrib/accessibility/browser/accessibilityConfiguration.ts
@@ -806,14 +806,13 @@ export class DynamicSpeechAccessibilityConfiguration extends Disposable implemen
 				},
 				[AccessibilityVoiceSettingId.AutoSynthesize]: {
 					'type': 'string',
-					'enum': ['on', 'off', 'auto'],
+					'enum': ['on', 'off'],
 					'enumDescriptions': [
 						localize('accessibility.voice.autoSynthesize.on', "Enable the feature. When a screen reader is enabled, note that this will disable aria updates."),
 						localize('accessibility.voice.autoSynthesize.off', "Disable the feature."),
-						localize('accessibility.voice.autoSynthesize.auto', "When a screen reader is detected, disable the feature. Otherwise, enable the feature.")
 					],
 					'markdownDescription': localize('autoSynthesize', "Whether a textual response should automatically be read out aloud when speech was used as input. For example in a chat session, a response is automatically synthesized when voice was used as chat request."),
-					'default': this.productService.quality !== 'stable' ? 'auto' : 'off',
+					'default': this.productService.quality !== 'stable' ? 'on' : 'off',
 					'tags': ['accessibility']
 				}
 			}

--- a/src/vs/workbench/contrib/chat/electron-sandbox/actions/voiceChatActions.ts
+++ b/src/vs/workbench/contrib/chat/electron-sandbox/actions/voiceChatActions.ts
@@ -369,8 +369,8 @@ class VoiceChatSessions {
 		if (!response) {
 			return;
 		}
-		const autoSynthesize = this.configurationService.getValue<'on' | 'off' | 'auto'>(AccessibilityVoiceSettingId.AutoSynthesize);
-		if (autoSynthesize === 'on' || autoSynthesize === 'auto' && !this.accessibilityService.isScreenReaderOptimized()) {
+		const autoSynthesize = this.configurationService.getValue<'on' | 'off'>(AccessibilityVoiceSettingId.AutoSynthesize);
+		if (autoSynthesize === 'on' || (autoSynthesize !== 'off' && !this.accessibilityService.isScreenReaderOptimized())) {
 			let context: IVoiceChatSessionController | 'focused';
 			if (controller.context === 'inline') {
 				// This is ugly, but the lightweight inline chat turns into


### PR DESCRIPTION
fix #229403

Keeps logic related to `auto` for soft deprecation