### PR TITLE
Use claims to force an idToken in Broker flow

### DIFF
--- a/extensions/microsoft-authentication/src/node/cachedPublicClientApplication.ts
+++ b/extensions/microsoft-authentication/src/node/cachedPublicClientApplication.ts
@@ -102,8 +102,18 @@ export class CachedPublicClientApplication implements ICachedPublicClientApplica
 			);
 			if (fiveMinutesBefore < new Date()) {
 				this._logger.debug(`[acquireTokenSilent] [${this._clientId}] [${this._authority}] [${request.scopes.join(' ')}] [${request.account.username}] id token is expired or about to expire. Forcing refresh...`);
-				result = await this._sequencer.queue(() => this._pca.acquireTokenSilent({ ...request, forceRefresh: true }));
+				const newRequest = this._isBrokerAvailable
+					// HACK: Broker doesn't support forceRefresh so we need to pass in claims which will force a refresh
+					? { ...request, claims: '{ "id_token": {}}' }
+					: { ...request, forceRefresh: true };
+				result = await this._sequencer.queue(() => this._pca.acquireTokenSilent(newRequest));
 				this._logger.debug(`[acquireTokenSilent] [${this._clientId}] [${this._authority}] [${request.scopes.join(' ')}] [${request.account.username}] got refreshed result`);
+			}
+			const newIdTokenExpirationInSecs = (result.idTokenClaims as { exp?: number }).exp;
+			if (newIdTokenExpirationInSecs) {
+				if (new Date(newIdTokenExpirationInSecs * 1000) < new Date()) {
+					this._logger.error(`[acquireTokenSilent] [${this._clientId}] [${this._authority}] [${request.scopes.join(' ')}] [${request.account.username}] id token is still expired.`);
+				}
 			}
 		}
 


### PR DESCRIPTION
Looks like the Broker doesn't support `forceRefresh`... This is an alternative way of forcing a refresh.

Fixes https://github.com/microsoft/vscode/issues/229456

<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
