### PR TITLE
Introduces IObservableWithChange so that typescript does not show the default type for TChange in hovers.

### DIFF
--- a/build/monaco/monaco.usage.recipe
+++ b/build/monaco/monaco.usage.recipe
@@ -35,6 +35,6 @@ import * as editorAPI from './vs/editor/editor.api';
 	a = editorAPI.editor;
 	a = editorAPI.languages;
 
-	const o: IObservable<number, number> = null!;
+	const o: IObservable<number> = null!;
 	o.TChange;
 })();

--- a/src/vs/base/common/event.ts
+++ b/src/vs/base/common/event.ts
@@ -9,7 +9,7 @@ import { onUnexpectedError } from './errors.js';
 import { createSingleCallFunction } from './functional.js';
 import { combinedDisposable, Disposable, DisposableMap, DisposableStore, IDisposable, toDisposable } from './lifecycle.js';
 import { LinkedList } from './linkedList.js';
-import { IObservable, IObserver } from './observable.js';
+import { IObservable, IObservableWithChange, IObserver } from './observable.js';
 import { StopWatch } from './stopwatch.js';
 import { MicrotaskDelay } from './symbols.js';
 
@@ -666,7 +666,7 @@ export namespace Event {
 		private _counter = 0;
 		private _hasChanged = false;
 
-		constructor(readonly _observable: IObservable<T, any>, store: DisposableStore | undefined) {
+		constructor(readonly _observable: IObservable<T>, store: DisposableStore | undefined) {
 			const options: EmitterOptions = {
 				onWillAddFirstListener: () => {
 					_observable.addObserver(this);
@@ -687,21 +687,21 @@ export namespace Event {
 			}
 		}
 
-		beginUpdate<T>(_observable: IObservable<T, void>): void {
+		beginUpdate<T>(_observable: IObservable<T>): void {
 			// assert(_observable === this.obs);
 			this._counter++;
 		}
 
-		handlePossibleChange<T>(_observable: IObservable<T, unknown>): void {
+		handlePossibleChange<T>(_observable: IObservable<T>): void {
 			// assert(_observable === this.obs);
 		}
 
-		handleChange<T, TChange>(_observable: IObservable<T, TChange>, _change: TChange): void {
+		handleChange<T, TChange>(_observable: IObservableWithChange<T, TChange>, _change: TChange): void {
 			// assert(_observable === this.obs);
 			this._hasChanged = true;
 		}
 
-		endUpdate<T>(_observable: IObservable<T, void>): void {
+		endUpdate<T>(_observable: IObservable<T>): void {
 			// assert(_observable === this.obs);
 			this._counter--;
 			if (this._counter === 0) {
@@ -718,7 +718,7 @@ export namespace Event {
 	 * Creates an event emitter that is fired when the observable changes.
 	 * Each listeners subscribes to the emitter.
 	 */
-	export function fromObservable<T>(obs: IObservable<T, any>, store?: DisposableStore): Event<T> {
+	export function fromObservable<T>(obs: IObservable<T>, store?: DisposableStore): Event<T> {
 		const observer = new EmitterObserver(obs, store);
 		return observer.emitter.event;
 	}
@@ -726,7 +726,7 @@ export namespace Event {
 	/**
 	 * Each listener is attached to the observable directly.
 	 */
-	export function fromObservableLight(observable: IObservable<any>): Event<void> {
+	export function fromObservableLight(observable: IObservable<unknown>): Event<void> {
 		return (listener, thisArgs, disposables) => {
 			let count = 0;
 			let didChange = false;

--- a/src/vs/base/common/observableInternal/autorun.ts
+++ b/src/vs/base/common/observableInternal/autorun.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { IChangeContext, IObservable, IObserver, IReader } from './base.js';
+import { IChangeContext, IObservable, IObservableWithChange, IObserver, IReader } from './base.js';
 import { DebugNameData, IDebugNameData } from './debugName.js';
 import { assertFn, BugIndicatingError, DisposableStore, IDisposable, markAsDisposed, onBugIndicatingError, toDisposable, trackDisposable } from './commonFacade/deps.js';
 import { getLogger } from './logging.js';
@@ -286,7 +286,7 @@ export class AutorunObserver<TChangeSummary = any> implements IObserver, IReader
 		}
 	}
 
-	public handleChange<T, TChange>(observable: IObservable<T, TChange>, change: TChange): void {
+	public handleChange<T, TChange>(observable: IObservableWithChange<T, TChange>, change: TChange): void {
 		if (this.dependencies.has(observable) && !this.dependenciesToBeRemoved.has(observable)) {
 			try {
 				const shouldReact = this._handleChange ? this._handleChange({

--- a/src/vs/base/common/observableInternal/base.ts
+++ b/src/vs/base/common/observableInternal/base.ts
@@ -13,12 +13,19 @@ import { keepObserved, recomputeInitiallyAndOnChange } from './utils.js';
  * Represents an observable value.
  *
  * @template T The type of the values the observable can hold.
+ */
+export interface IObservable<T> extends IObservableWithChange<T, unknown> { }
+
+/**
+ * Represents an observable value.
+ *
+ * @template T The type of the values the observable can hold.
  * @template TChange The type used to describe value changes
  * (usually `void` and only used in advanced scenarios).
  * While observers can miss temporary values of an observable,
  * they will receive all change values (as long as they are subscribed)!
  */
-export interface IObservable<T, TChange = unknown> {
+export interface IObservableWithChange<T, TChange = unknown> {
 	/**
 	 * Returns the current value.
 	 *
@@ -71,7 +78,7 @@ export interface IObservable<T, TChange = unknown> {
 	 * ONLY FOR DEBUGGING!
 	 * Logs computations of this derived.
 	*/
-	log(): IObservable<T, TChange>;
+	log(): IObservableWithChange<T, TChange>;
 
 	/**
 	 * Makes sure this value is computed eagerly.
@@ -98,7 +105,7 @@ export interface IReader {
 	/**
 	 * Reads the value of an observable and subscribes to it.
 	 */
-	readObservable<T>(observable: IObservable<T, any>): T;
+	readObservable<T>(observable: IObservableWithChange<T, any>): T;
 }
 
 /**
@@ -143,7 +150,7 @@ export interface IObserver {
 	 *
 	 * @param change Indicates how or why the value changed.
 	 */
-	handleChange<T, TChange>(observable: IObservable<T, TChange>, change: TChange): void;
+	handleChange<T, TChange>(observable: IObservableWithChange<T, TChange>, change: TChange): void;
 }
 
 export interface ISettable<T, TChange = void> {
@@ -162,7 +169,7 @@ export interface ITransaction {
 	 * Calls {@link Observer.beginUpdate} immediately
 	 * and {@link Observer.endUpdate} when the transaction ends.
 	 */
-	updateObserver(observer: IObserver, observable: IObservable<any, any>): void;
+	updateObserver(observer: IObserver, observable: IObservableWithChange<any, any>): void;
 }
 
 let _recomputeInitiallyAndOnChange: typeof recomputeInitiallyAndOnChange;
@@ -185,7 +192,7 @@ export function _setDerivedOpts(derived: typeof _derived) {
 	_derived = derived;
 }
 
-export abstract class ConvenientObservable<T, TChange> implements IObservable<T, TChange> {
+export abstract class ConvenientObservable<T, TChange> implements IObservableWithChange<T, TChange> {
 	get TChange(): TChange { return null!; }
 
 	public abstract get(): T;
@@ -239,7 +246,7 @@ export abstract class ConvenientObservable<T, TChange> implements IObservable<T,
 		);
 	}
 
-	public log(): IObservable<T, TChange> {
+	public log(): IObservableWithChange<T, TChange> {
 		logObservable(this);
 		return this;
 	}
@@ -248,7 +255,7 @@ export abstract class ConvenientObservable<T, TChange> implements IObservable<T,
 	 * @sealed
 	 * Converts an observable of an observable value into a direct observable of the value.
 	*/
-	public flatten<TNew>(this: IObservable<IObservable<TNew, any>>): IObservable<TNew, unknown> {
+	public flatten<TNew>(this: IObservable<IObservableWithChange<TNew, any>>): IObservable<TNew> {
 		return _derived(
 			{
 				owner: undefined,
@@ -390,7 +397,7 @@ export class TransactionImpl implements ITransaction {
 /**
  * A settable observable.
  */
-export interface ISettableObservable<T, TChange = void> extends IObservable<T, TChange>, ISettable<T, TChange> {
+export interface ISettableObservable<T, TChange = void> extends IObservableWithChange<T, TChange>, ISettable<T, TChange> {
 }
 
 /**
@@ -505,11 +512,11 @@ export interface IChangeTracker {
 }
 
 export interface IChangeContext {
-	readonly changedObservable: IObservable<any, any>;
+	readonly changedObservable: IObservableWithChange<any, any>;
 	readonly change: unknown;
 
 	/**
 	 * Returns if the given observable caused the change.
 	 */
-	didChange<T, TChange>(observable: IObservable<T, TChange>): this is { change: TChange };
+	didChange<T, TChange>(observable: IObservableWithChange<T, TChange>): this is { change: TChange };
 }

--- a/src/vs/base/common/observableInternal/derived.ts
+++ b/src/vs/base/common/observableInternal/derived.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { BaseObservable, IChangeContext, IObservable, IObserver, IReader, ISettableObservable, ITransaction, _setDerivedOpts, } from './base.js';
+import { BaseObservable, IChangeContext, IObservable, IObservableWithChange, IObserver, IReader, ISettableObservable, ITransaction, _setDerivedOpts, } from './base.js';
 import { DebugNameData, DebugOwner, IDebugNameData } from './debugName.js';
 import { BugIndicatingError, DisposableStore, EqualityComparer, IDisposable, assertFn, onBugIndicatingError, strictEquals } from './commonFacade/deps.js';
 import { getLogger } from './logging.js';
@@ -386,7 +386,7 @@ export class Derived<T, TChangeSummary = any> extends BaseObservable<T, void> im
 		assertFn(() => this.updateCount >= 0);
 	}
 
-	public handlePossibleChange<T>(observable: IObservable<T, unknown>): void {
+	public handlePossibleChange<T>(observable: IObservable<T>): void {
 		// In all other states, observers already know that we might have changed.
 		if (this.state === DerivedState.upToDate && this.dependencies.has(observable) && !this.dependenciesToBeRemoved.has(observable)) {
 			this.state = DerivedState.dependenciesMightHaveChanged;
@@ -396,7 +396,7 @@ export class Derived<T, TChangeSummary = any> extends BaseObservable<T, void> im
 		}
 	}
 
-	public handleChange<T, TChange>(observable: IObservable<T, TChange>, change: TChange): void {
+	public handleChange<T, TChange>(observable: IObservableWithChange<T, TChange>, change: TChange): void {
 		if (this.dependencies.has(observable) && !this.dependenciesToBeRemoved.has(observable)) {
 			let shouldReact = false;
 			try {
@@ -460,7 +460,7 @@ export class Derived<T, TChangeSummary = any> extends BaseObservable<T, void> im
 		super.removeObserver(observer);
 	}
 
-	public override log(): IObservable<T, void> {
+	public override log(): IObservableWithChange<T, void> {
 		if (!getLogger()) {
 			super.log();
 			getLogger()?.handleDerivedCreated(this);

--- a/src/vs/base/common/observableInternal/index.ts
+++ b/src/vs/base/common/observableInternal/index.ts
@@ -7,7 +7,7 @@
 
 export { observableValueOpts } from './api.js';
 export { autorun, autorunDelta, autorunHandleChanges, autorunOpts, autorunWithStore, autorunWithStoreHandleChanges } from './autorun.js';
-export { asyncTransaction, disposableObservableValue, globalTransaction, observableValue, subtransaction, transaction, TransactionImpl, type IChangeContext, type IChangeTracker, type IObservable, type IObserver, type IReader, type ISettable, type ISettableObservable, type ITransaction, } from './base.js';
+export { asyncTransaction, disposableObservableValue, globalTransaction, observableValue, subtransaction, transaction, TransactionImpl, type IChangeContext, type IChangeTracker, type IObservable, type IObservableWithChange, type IObserver, type IReader, type ISettable, type ISettableObservable, type ITransaction, } from './base.js';
 export { derived, derivedDisposable, derivedHandleChanges, derivedOpts, derivedWithSetter, derivedWithStore } from './derived.js';
 export { ObservableLazy, ObservableLazyPromise, ObservablePromise, PromiseResult, } from './promise.js';
 export { derivedWithCancellationToken, waitForState } from './utilsCancellation.js';

--- a/src/vs/base/common/observableInternal/logging.ts
+++ b/src/vs/base/common/observableInternal/logging.ts
@@ -39,7 +39,7 @@ interface IChangeInformation {
 }
 
 export interface IObservableLogger {
-	handleObservableChanged(observable: IObservable<any, any>, info: IChangeInformation): void;
+	handleObservableChanged(observable: IObservable<any>, info: IChangeInformation): void;
 	handleFromEventObservableTriggered(observable: FromEventObservable<any, any>, info: IChangeInformation): void;
 
 	handleAutorunCreated(autorun: AutorunObserver): void;
@@ -101,7 +101,7 @@ export class ConsoleObservableLogger implements IObservableLogger {
 			: [normalText(` (unchanged)`)];
 	}
 
-	handleObservableChanged(observable: IObservable<unknown, unknown>, info: IChangeInformation): void {
+	handleObservableChanged(observable: IObservable<unknown>, info: IChangeInformation): void {
 		if (!this._isIncluded(observable)) { return; }
 		console.log(...this.textToConsoleArgs([
 			formatKind('observable value changed'),
@@ -110,9 +110,9 @@ export class ConsoleObservableLogger implements IObservableLogger {
 		]));
 	}
 
-	private readonly changedObservablesSets = new WeakMap<object, Set<IObservable<any, any>>>();
+	private readonly changedObservablesSets = new WeakMap<object, Set<IObservable<any>>>();
 
-	formatChanges(changes: Set<IObservable<any, any>>): ConsoleText | undefined {
+	formatChanges(changes: Set<IObservable<any>>): ConsoleText | undefined {
 		if (changes.size === 0) {
 			return undefined;
 		}

--- a/src/vs/base/test/common/observable.test.ts
+++ b/src/vs/base/test/common/observable.test.ts
@@ -8,7 +8,7 @@ import { setUnexpectedErrorHandler } from '../../common/errors.js';
 import { Emitter, Event } from '../../common/event.js';
 import { DisposableStore } from '../../common/lifecycle.js';
 import { autorun, autorunHandleChanges, derived, derivedDisposable, IObservable, IObserver, ISettableObservable, ITransaction, keepObserved, observableFromEvent, observableSignal, observableValue, transaction, waitForState } from '../../common/observable.js';
-import { BaseObservable } from '../../common/observableInternal/base.js';
+import { BaseObservable, IObservableWithChange } from '../../common/observableInternal/base.js';
 import { ensureNoDisposablesAreLeakedInTestSuite } from './utils.js';
 
 suite('observables', () => {
@@ -1486,18 +1486,18 @@ export class LoggingObserver implements IObserver {
 	constructor(public readonly debugName: string, private readonly log: Log) {
 	}
 
-	beginUpdate<T>(observable: IObservable<T, void>): void {
+	beginUpdate<T>(observable: IObservable<T>): void {
 		this.count++;
 		this.log.log(`${this.debugName}.beginUpdate (count ${this.count})`);
 	}
-	endUpdate<T>(observable: IObservable<T, void>): void {
+	endUpdate<T>(observable: IObservable<T>): void {
 		this.log.log(`${this.debugName}.endUpdate (count ${this.count})`);
 		this.count--;
 	}
-	handleChange<T, TChange>(observable: IObservable<T, TChange>, change: TChange): void {
+	handleChange<T, TChange>(observable: IObservableWithChange<T, TChange>, change: TChange): void {
 		this.log.log(`${this.debugName}.handleChange (count ${this.count})`);
 	}
-	handlePossibleChange<T>(observable: IObservable<T, unknown>): void {
+	handlePossibleChange<T>(observable: IObservable<T>): void {
 		this.log.log(`${this.debugName}.handlePossibleChange`);
 	}
 }

--- a/src/vs/editor/browser/observableCodeEditor.ts
+++ b/src/vs/editor/browser/observableCodeEditor.ts
@@ -5,7 +5,7 @@
 
 import { equalsIfDefined, itemsEquals } from '../../base/common/equals.js';
 import { Disposable, DisposableStore, IDisposable, toDisposable } from '../../base/common/lifecycle.js';
-import { IObservable, ITransaction, TransactionImpl, autorun, autorunOpts, derived, derivedOpts, derivedWithSetter, observableFromEvent, observableSignal, observableValue, observableValueOpts } from '../../base/common/observable.js';
+import { IObservable, IObservableWithChange, ITransaction, TransactionImpl, autorun, autorunOpts, derived, derivedOpts, derivedWithSetter, observableFromEvent, observableSignal, observableValue, observableValueOpts } from '../../base/common/observable.js';
 import { EditorOption, FindComputedEditorOptionValueById } from '../common/config/editorOptions.js';
 import { LineRange } from '../common/core/lineRange.js';
 import { OffsetRange } from '../common/core/offsetRange.js';
@@ -155,13 +155,13 @@ export class ObservableCodeEditor extends Disposable {
 	public readonly isReadonly = observableFromEvent(this, this.editor.onDidChangeConfiguration, () => this.editor.getOption(EditorOption.readOnly));
 
 	private readonly _versionId = observableValueOpts<number | null, IModelContentChangedEvent | undefined>({ owner: this, lazy: true }, this.editor.getModel()?.getVersionId() ?? null);
-	public readonly versionId: IObservable<number | null, IModelContentChangedEvent | undefined> = this._versionId;
+	public readonly versionId: IObservableWithChange<number | null, IModelContentChangedEvent | undefined> = this._versionId;
 
 	private readonly _selections = observableValueOpts<Selection[] | null, ICursorSelectionChangedEvent | undefined>(
 		{ owner: this, equalsFn: equalsIfDefined(itemsEquals(Selection.selectionsEqual)), lazy: true },
 		this.editor.getSelections() ?? null
 	);
-	public readonly selections: IObservable<Selection[] | null, ICursorSelectionChangedEvent | undefined> = this._selections;
+	public readonly selections: IObservableWithChange<Selection[] | null, ICursorSelectionChangedEvent | undefined> = this._selections;
 
 
 	public readonly positions = derivedOpts<readonly Position[] | null>(

--- a/src/vs/editor/browser/widget/diffEditor/components/diffEditorSash.ts
+++ b/src/vs/editor/browser/widget/diffEditor/components/diffEditorSash.ts
@@ -62,7 +62,7 @@ export class DiffEditorSash extends Disposable {
 		private readonly _domNode: HTMLElement,
 		private readonly _dimensions: { height: IObservable<number>; width: IObservable<number> },
 		private readonly _enabled: IObservable<boolean>,
-		private readonly _boundarySashes: IObservable<IBoundarySashes | undefined, void>,
+		private readonly _boundarySashes: IObservable<IBoundarySashes | undefined>,
 		public readonly sashLeft: ISettableObservable<number>,
 		private readonly _resetSash: () => void,
 	) {

--- a/src/vs/editor/browser/widget/diffEditor/diffEditorOptions.ts
+++ b/src/vs/editor/browser/widget/diffEditor/diffEditorOptions.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { IObservable, ISettableObservable, derived, derivedConstOnceDefined, observableFromEvent, observableValue } from '../../../../base/common/observable.js';
+import { IObservable, IObservableWithChange, ISettableObservable, derived, derivedConstOnceDefined, observableFromEvent, observableValue } from '../../../../base/common/observable.js';
 import { Constants } from '../../../../base/common/uint.js';
 import { IAccessibilityService } from '../../../../platform/accessibility/common/accessibility.js';
 import { diffEditorDefaultOptions } from '../../../common/config/diffEditor.js';
@@ -15,7 +15,7 @@ import { DiffEditorViewModel, DiffState } from './diffEditorViewModel.js';
 export class DiffEditorOptions {
 	private readonly _options: ISettableObservable<IEditorOptions & Required<IDiffEditorBaseOptions>, { changedOptions: IDiffEditorOptions }>;
 
-	public get editorOptions(): IObservable<IEditorOptions, { changedOptions: IEditorOptions }> { return this._options; }
+	public get editorOptions(): IObservableWithChange<IEditorOptions, { changedOptions: IEditorOptions }> { return this._options; }
 
 	private readonly _diffEditorWidth = observableValue<number>(this, 0);
 

--- a/src/vs/editor/browser/widget/diffEditor/features/gutterFeature.ts
+++ b/src/vs/editor/browser/widget/diffEditor/features/gutterFeature.ts
@@ -50,7 +50,7 @@ export class DiffEditorGutter extends Disposable {
 		private readonly _editors: DiffEditorEditors,
 		private readonly _options: DiffEditorOptions,
 		private readonly _sashLayout: SashLayout,
-		private readonly _boundarySashes: IObservable<IBoundarySashes | undefined, void>,
+		private readonly _boundarySashes: IObservable<IBoundarySashes | undefined>,
 		@IInstantiationService private readonly _instantiationService: IInstantiationService,
 		@IContextKeyService private readonly _contextKeyService: IContextKeyService,
 		@IMenuService private readonly _menuService: IMenuService,

--- a/src/vs/editor/browser/widget/diffEditor/utils.ts
+++ b/src/vs/editor/browser/widget/diffEditor/utils.ts
@@ -7,7 +7,7 @@ import { IDimension } from '../../../../base/browser/dom.js';
 import { findLast } from '../../../../base/common/arraysFind.js';
 import { CancellationTokenSource } from '../../../../base/common/cancellation.js';
 import { Disposable, DisposableStore, IDisposable, IReference, toDisposable } from '../../../../base/common/lifecycle.js';
-import { IObservable, ISettableObservable, autorun, autorunHandleChanges, autorunOpts, autorunWithStore, observableValue, transaction } from '../../../../base/common/observable.js';
+import { IObservable, IObservableWithChange, ISettableObservable, autorun, autorunHandleChanges, autorunOpts, autorunWithStore, observableValue, transaction } from '../../../../base/common/observable.js';
 import { ElementSizeObserver } from '../../config/elementSizeObserver.js';
 import { ICodeEditor, IOverlayWidget, IViewZone } from '../../editorBrowser.js';
 import { Position } from '../../../common/core/position.js';
@@ -126,7 +126,7 @@ export class ObservableElementSizeObserver extends Disposable {
 	}
 }
 
-export function animatedObservable(targetWindow: Window, base: IObservable<number, boolean>, store: DisposableStore): IObservable<number> {
+export function animatedObservable(targetWindow: Window, base: IObservableWithChange<number, boolean>, store: DisposableStore): IObservable<number> {
 	let targetVal = base.get();
 	let startVal = targetVal;
 	let curVal = targetVal;

--- a/src/vs/editor/contrib/inlineCompletions/browser/model/inlineCompletionsModel.ts
+++ b/src/vs/editor/contrib/inlineCompletions/browser/model/inlineCompletionsModel.ts
@@ -7,7 +7,7 @@ import { mapFindFirst } from '../../../../../base/common/arraysFind.js';
 import { itemsEquals } from '../../../../../base/common/equals.js';
 import { BugIndicatingError, onUnexpectedError, onUnexpectedExternalError } from '../../../../../base/common/errors.js';
 import { Disposable } from '../../../../../base/common/lifecycle.js';
-import { IObservable, IReader, ITransaction, autorun, derived, derivedHandleChanges, derivedOpts, observableSignal, observableValue, recomputeInitiallyAndOnChange, subtransaction, transaction } from '../../../../../base/common/observable.js';
+import { IObservable, IObservableWithChange, IReader, ITransaction, autorun, derived, derivedHandleChanges, derivedOpts, observableSignal, observableValue, recomputeInitiallyAndOnChange, subtransaction, transaction } from '../../../../../base/common/observable.js';
 import { commonPrefixLength, firstNonWhitespaceIndex } from '../../../../../base/common/strings.js';
 import { isDefined } from '../../../../../base/common/types.js';
 import { ICommandService } from '../../../../../platform/commands/common/commands.js';
@@ -63,7 +63,7 @@ export class InlineCompletionsModel extends Disposable {
 	constructor(
 		public readonly textModel: ITextModel,
 		private readonly _selectedSuggestItem: IObservable<SuggestItemInfo | undefined>,
-		public readonly _textModelVersionId: IObservable<number | null, IModelContentChangedEvent | undefined>,
+		public readonly _textModelVersionId: IObservableWithChange<number | null, IModelContentChangedEvent | undefined>,
 		private readonly _positions: IObservable<readonly Position[]>,
 		private readonly _debounceValue: IFeatureDebounceInformation,
 		private readonly _enabled: IObservable<boolean>,

--- a/src/vs/editor/test/browser/widget/observableCodeEditor.test.ts
+++ b/src/vs/editor/test/browser/widget/observableCodeEditor.test.ts
@@ -112,7 +112,7 @@ suite("CodeEditorWidget", () => {
 		}));
 
 	test("listener interaction (unforced)", () => {
-		let derived: IObservable<string, unknown>;
+		let derived: IObservable<string>;
 		let log: Log;
 		withEditorSetupTestFixture(
 			(editor, disposables) => {
@@ -143,7 +143,7 @@ suite("CodeEditorWidget", () => {
 	});
 
 	test("listener interaction ()", () => {
-		let derived: IObservable<string, unknown>;
+		let derived: IObservable<string>;
 		let log: Log;
 		withEditorSetupTestFixture(
 			(editor, disposables) => {

--- a/src/vs/workbench/contrib/mergeEditor/browser/model/textModelDiffs.ts
+++ b/src/vs/workbench/contrib/mergeEditor/browser/model/textModelDiffs.ts
@@ -12,7 +12,7 @@ import { LineRangeEdit } from './editing.js';
 import { LineRange } from './lineRange.js';
 import { ReentrancyBarrier } from '../../../../../base/common/controlFlow.js';
 import { IMergeDiffComputer } from './diffComputer.js';
-import { autorun, IObservable, IReader, ITransaction, observableSignal, observableValue, transaction } from '../../../../../base/common/observable.js';
+import { autorun, IObservableWithChange, IReader, ITransaction, observableSignal, observableValue, transaction } from '../../../../../base/common/observable.js';
 import { UndoRedoGroup } from '../../../../../platform/undoRedo/common/undoRedo.js';
 
 export class TextModelDiffs extends Disposable {
@@ -61,14 +61,14 @@ export class TextModelDiffs extends Disposable {
 		}));
 	}
 
-	public get state(): IObservable<TextModelDiffState, TextModelDiffChangeReason> {
+	public get state(): IObservableWithChange<TextModelDiffState, TextModelDiffChangeReason> {
 		return this._state;
 	}
 
 	/**
 	 * Diffs from base to input.
 	*/
-	public get diffs(): IObservable<DetailedLineRangeMapping[], TextModelDiffChangeReason> {
+	public get diffs(): IObservableWithChange<DetailedLineRangeMapping[], TextModelDiffChangeReason> {
 		return this._diffs;
 	}
 

--- a/src/vs/workbench/contrib/notebook/browser/contrib/chatEdit/notebookChatActionsOverlay.ts
+++ b/src/vs/workbench/contrib/notebook/browser/contrib/chatEdit/notebookChatActionsOverlay.ts
@@ -24,7 +24,7 @@ import { navigationBearingFakeActionId } from '../../../../chat/browser/chatEdit
 export class NotebookChatActionsOverlayController extends Disposable {
 	constructor(
 		private readonly notebookEditor: INotebookEditor,
-		cellDiffInfo: IObservable<CellDiffInfo[] | undefined, unknown>,
+		cellDiffInfo: IObservable<CellDiffInfo[] | undefined>,
 		deletedCellDecorator: INotebookDeletedCellDecorator,
 		@IChatEditingService private readonly _chatEditingService: IChatEditingService,
 		@IInstantiationService instantiationService: IInstantiationService,
@@ -60,7 +60,7 @@ export class NotebookChatActionsOverlay extends Disposable {
 	constructor(
 		private readonly notebookEditor: INotebookEditor,
 		entry: IModifiedFileEntry,
-		cellDiffInfo: IObservable<CellDiffInfo[] | undefined, unknown>,
+		cellDiffInfo: IObservable<CellDiffInfo[] | undefined>,
 		nextEntry: IModifiedFileEntry,
 		previousEntry: IModifiedFileEntry,
 		deletedCellDecorator: INotebookDeletedCellDecorator,
@@ -196,7 +196,7 @@ export class NotebookChatActionsOverlay extends Disposable {
 class NextPreviousChangeActionRunner extends ActionRunner {
 	constructor(
 		private readonly notebookEditor: INotebookEditor,
-		private readonly cellDiffInfo: IObservable<CellDiffInfo[] | undefined, unknown>,
+		private readonly cellDiffInfo: IObservable<CellDiffInfo[] | undefined>,
 		private readonly entry: IModifiedFileEntry,
 		private readonly next: IModifiedFileEntry,
 		private readonly direction: 'next' | 'previous',

--- a/src/vs/workbench/contrib/testing/common/observableUtils.ts
+++ b/src/vs/workbench/contrib/testing/common/observableUtils.ts
@@ -4,16 +4,16 @@
  *--------------------------------------------------------------------------------------------*/
 
 import { IDisposable } from '../../../../base/common/lifecycle.js';
-import { IObservable, IObserver } from '../../../../base/common/observable.js';
+import { IObservableWithChange, IObserver } from '../../../../base/common/observable.js';
 
-export function onObservableChange<T>(observable: IObservable<unknown, T>, callback: (value: T) => void): IDisposable {
+export function onObservableChange<T>(observable: IObservableWithChange<unknown, T>, callback: (value: T) => void): IDisposable {
 	const o: IObserver = {
 		beginUpdate() { },
 		endUpdate() { },
 		handlePossibleChange(observable) {
 			observable.reportChanges();
 		},
-		handleChange<T2, TChange>(_observable: IObservable<T2, TChange>, change: TChange) {
+		handleChange<T2, TChange>(_observable: IObservableWithChange<T2, TChange>, change: TChange) {
 			callback(change as any as T);
 		}
 	};


### PR DESCRIPTION
This should make it easier to understand types when observables (potentially nested) are involved.