### PR TITLE
use keyboard vs key icon for configure keybinding action icons

### DIFF
--- a/src/vs/workbench/contrib/accessibility/browser/accessibleViewActions.ts
+++ b/src/vs/workbench/contrib/accessibility/browser/accessibleViewActions.ts
@@ -233,7 +233,7 @@ class AccessibilityHelpConfigureKeybindingsAction extends Action2 {
 		super({
 			id: AccessibilityCommandId.AccessibilityHelpConfigureKeybindings,
 			precondition: ContextKeyExpr.and(accessibilityHelpIsShown, accessibleViewHasUnassignedKeybindings),
-			icon: Codicon.key,
+			icon: Codicon.recordKeys,
 			keybinding: {
 				primary: KeyMod.Alt | KeyCode.KeyK,
 				weight: KeybindingWeight.WorkbenchContrib
@@ -260,7 +260,7 @@ class AccessibilityHelpConfigureAssignedKeybindingsAction extends Action2 {
 		super({
 			id: AccessibilityCommandId.AccessibilityHelpConfigureAssignedKeybindings,
 			precondition: ContextKeyExpr.and(accessibilityHelpIsShown, accessibleViewHasAssignedKeybindings),
-			icon: Codicon.key,
+			icon: Codicon.recordKeys,
 			keybinding: {
 				primary: KeyMod.Alt | KeyCode.KeyA,
 				weight: KeybindingWeight.WorkbenchContrib


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
fix #229827