### PR TITLE
Experiment with allowing absolute paths for imports in core

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
   "main": "./out/main.js",
   "type": "module",
   "private": true,
+  "imports": {
+    "#vs/*.js": "./out/vs/*.js"
+  },
   "scripts": {
     "test": "echo Please run any of the test scripts from the scripts folder.",
     "test-browser": "npx playwright install && node test/unit/browser/index.js",

--- a/src/tsconfig.base.json
+++ b/src/tsconfig.base.json
@@ -13,7 +13,7 @@
 		"forceConsistentCasingInFileNames": true,
 		"baseUrl": ".",
 		"paths": {
-			"vs/*": [
+			"#vs/*": [
 				"./vs/*"
 			]
 		},

--- a/src/vs/editor/common/codecs/baseToken.ts
+++ b/src/vs/editor/common/codecs/baseToken.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { IRange, Range } from '../../../editor/common/core/range.js';
+import { IRange, Range } from '#vs/editor/common/core/range.js';
 
 /**
  * Base class for all tokens with a `range` that

--- a/src/vs/platform/log/common/log.ts
+++ b/src/vs/platform/log/common/log.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import * as nls from '../../../nls.js';
+import * as nls from '#vs/nls.js';
 import { toErrorMessage } from '../../../base/common/errorMessage.js';
 import { Emitter, Event } from '../../../base/common/event.js';
 import { hash } from '../../../base/common/hash.js';

--- a/src/vs/platform/policy/node/nativePolicyService.ts
+++ b/src/vs/platform/policy/node/nativePolicyService.ts
@@ -8,7 +8,7 @@ import { IStringDictionary } from '../../../base/common/collections.js';
 import { Throttler } from '../../../base/common/async.js';
 import type { PolicyUpdate, Watcher } from '@vscode/policy-watcher';
 import { MutableDisposable } from '../../../base/common/lifecycle.js';
-import { ILogService } from '../../log/common/log.js';
+import { ILogService } from '#vs/platform/log/common/log.js';
 
 export class NativePolicyService extends AbstractPolicyService implements IPolicyService {
 


### PR DESCRIPTION
For #236644

Quickly hacked this together to allow `#/vs/` absolute imports. This only works for dev right now

@bpasero @jrieken Let me know if this is something we would like to look into further