### PR TITLE
workbench.action.focus*GroupWithoutWrap commands fail to focus *-most group when sibebar/panel is focused (fix #236648)

### DIFF
--- a/src/vs/workbench/browser/parts/editor/editorCommands.ts
+++ b/src/vs/workbench/browser/parts/editor/editorCommands.ts
@@ -312,6 +312,7 @@ function registerActiveEditorMoveCopyCommand(): void {
 			} else if (sourceGroup.id !== targetGroup.id) {
 				sourceGroup.copyEditors(editors.map(editor => ({ editor })), targetGroup);
 			}
+
 			targetGroup.focus();
 		}
 	}
@@ -972,8 +973,8 @@ function registerFocusEditorGroupWihoutWrapCommands(): void {
 		CommandsRegistry.registerCommand(command.id, async (accessor: ServicesAccessor) => {
 			const editorGroupsService = accessor.get(IEditorGroupsService);
 
-			const group = editorGroupsService.findGroup({ direction: command.direction }, editorGroupsService.activeGroup, false);
-			group?.focus();
+			const group = editorGroupsService.findGroup({ direction: command.direction }, editorGroupsService.activeGroup, false) ?? editorGroupsService.activeGroup;
+			group.focus();
 		});
 	}
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Read our Pull Request guidelines:
  https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->
