### PR TITLE
Git - file system provider should throw `FileNotFound` if the resource does not exist in git instead of returning an empty file

### DIFF
--- a/extensions/git/src/fileSystemProvider.ts
+++ b/extensions/git/src/fileSystemProvider.ts
@@ -192,7 +192,8 @@ export class GitFileSystemProvider implements FileSystemProvider {
 		try {
 			return await repository.buffer(sanitizeRef(ref, path, repository), path);
 		} catch (err) {
-			return new Uint8Array(0);
+			// File does not exist in git (ex: git ignored)
+			throw FileSystemError.FileNotFound();
 		}
 	}
 


### PR DESCRIPTION
Fixes #236647