### PR TITLE
Use correct context keys for share provider title context action

### DIFF
--- a/src/vs/workbench/browser/parts/titlebar/titlebarActions.ts
+++ b/src/vs/workbench/browser/parts/titlebar/titlebarActions.ts
@@ -64,15 +64,9 @@ registerAction2(class ToggleNavigationControl extends ToggleTitleBarConfigAction
 	}
 });
 
-registerAction2(class ToggleShareControl extends ToggleTitleBarConfigAction {
-	constructor() {
-		super('workbench.experimental.share.enabled', localize('toggle.share', 'Share'), localize('toggle.shareDescription', "Toggle visibility of the Share action in title bar"), 2, false, ContextKeyExpr.has('config.window.commandCenter'));
-	}
-});
-
 registerAction2(class ToggleLayoutControl extends ToggleTitleBarConfigAction {
 	constructor() {
-		super(LayoutSettings.LAYOUT_ACTIONS, localize('toggle.layout', 'Layout Controls'), localize('toggle.layoutDescription', "Toggle visibility of the Layout Controls in title bar"), 3, true);
+		super(LayoutSettings.LAYOUT_ACTIONS, localize('toggle.layout', 'Layout Controls'), localize('toggle.layoutDescription', "Toggle visibility of the Layout Controls in title bar"), 4, true);
 	}
 });
 

--- a/src/vs/workbench/contrib/chat/browser/actions/chatActions.ts
+++ b/src/vs/workbench/contrib/chat/browser/actions/chatActions.ts
@@ -543,7 +543,7 @@ registerAction2(class ToggleCopilotControl extends ToggleTitleBarConfigAction {
 		super(
 			'chat.commandCenter.enabled',
 			localize('toggle.chatControl', 'Copilot Controls'),
-			localize('toggle.chatControlsDescription', "Toggle visibility of the Copilot Controls in title bar"), 4, false,
+			localize('toggle.chatControlsDescription', "Toggle visibility of the Copilot Controls in title bar"), 5, false,
 			ContextKeyExpr.and(
 				ChatContextKeys.supported,
 				ContextKeyExpr.has('config.window.commandCenter')

--- a/src/vs/workbench/contrib/share/browser/shareService.ts
+++ b/src/vs/workbench/contrib/share/browser/shareService.ts
@@ -9,11 +9,13 @@ import { URI } from '../../../../base/common/uri.js';
 import { ICodeEditorService } from '../../../../editor/browser/services/codeEditorService.js';
 import { score } from '../../../../editor/common/languageSelector.js';
 import { localize } from '../../../../nls.js';
-import { ISubmenuItem } from '../../../../platform/actions/common/actions.js';
-import { IContextKey, IContextKeyService, RawContextKey } from '../../../../platform/contextkey/common/contextkey.js';
+import { ISubmenuItem, registerAction2 } from '../../../../platform/actions/common/actions.js';
+import { ContextKeyExpr, IContextKey, IContextKeyService, RawContextKey } from '../../../../platform/contextkey/common/contextkey.js';
 import { ILabelService } from '../../../../platform/label/common/label.js';
 import { IQuickInputService, IQuickPickItem } from '../../../../platform/quickinput/common/quickInput.js';
 import { ITelemetryService } from '../../../../platform/telemetry/common/telemetry.js';
+import { ToggleTitleBarConfigAction } from '../../../browser/parts/titlebar/titlebarActions.js';
+import { WorkspaceFolderCountContext } from '../../../common/contextkeys.js';
 import { IShareProvider, IShareService, IShareableItem } from '../common/share.js';
 
 export const ShareProviderCountContext = new RawContextKey<number>('shareProviderCount', 0, localize('shareProviderCount', "The number of available share providers"));
@@ -84,3 +86,9 @@ export class ShareService implements IShareService {
 		return;
 	}
 }
+
+registerAction2(class ToggleShareControl extends ToggleTitleBarConfigAction {
+	constructor() {
+		super('workbench.experimental.share.enabled', localize('toggle.share', 'Share'), localize('toggle.shareDescription', "Toggle visibility of the Share action in title bar"), 3, false, ContextKeyExpr.and(ContextKeyExpr.has('config.window.commandCenter'), ContextKeyExpr.and(ShareProviderCountContext.notEqualsTo(0), WorkspaceFolderCountContext.notEqualsTo(0))));
+	}
+});


### PR DESCRIPTION
Update the share control action to use the correct context keys, ensuring proper visibility in the title bar based on share provider availability.