### PR TITLE
Fix escaping of raw values that contain `&` in md preview

### DIFF
--- a/extensions/markdown-language-features/src/util/dom.ts
+++ b/extensions/markdown-language-features/src/util/dom.ts
@@ -5,7 +5,10 @@
 import * as vscode from 'vscode';
 
 export function escapeAttribute(value: string | vscode.Uri): string {
-	return value.toString().replace(/"/g, '&quot;');
+	return value.toString()
+		.replace(/&/g, '&amp;')
+		.replace(/"/g, '&quot;')
+		.replace(/'/g, '&#39;');
 }
 
 export function getNonce() {


### PR DESCRIPTION
Fixes #236660

